### PR TITLE
test(stateless): variety -- _is_activation_active ts-only success branch

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -330,6 +330,26 @@ run_fixture "chain1_blob"           1                  0    ""           ""     
 # byte-for-byte against the spec.
 run_fixture "chain1_blob_realistic" 1                  0    ""           ""                  ""    ""           ""           "14:21:11684671" || fail=1
 
+# _is_activation_active TIMESTAMP-only success branch.
+# Sister to the bn-only success-branch fixture: same outer
+# configuration (fork=4 Amsterdam, expected blob_schedule)
+# but activation has timestamp=[0] instead of bn=[0].
+# Spec flow:
+#   _is_activation_active:
+#     activation.block_number is None  (no bn entry)
+#     activation.timestamp is Uint(0)  (not None)
+#     execution_payload.timestamp = 0
+#     0 < 0 is False -> falls through -> returns True
+#   active_fork.fork == Amsterdam   -> True
+#   blob_schedule == expected       -> True
+#   validate_chain_config returns successfully
+#   validate_headers([]) -> IndexError -> caught -> False.
+# Variety dimension: distinct branch of _is_activation_active.
+# Previously the bn-set branch was exercised (active_fork bn=[0]
+# passes; active_fork bn=[1] fails via InactiveForkConfigError);
+# the ts-only branch is the third path through that helper.
+run_fixture "chain1_fork4_ts_active"   1               4    ""           ""                  ""    ""           "0"          "14:21:11684671" || fail=1
+
 # Valid post-merge header with REALISTIC non-zero values for
 # every K-PR-IGNORED field (parent_hash, coinbase, state_root,
 # transactions_root, receipt_root, bloom, prev_randao,


### PR DESCRIPTION
## Summary

Add fixture \`chain1_fork4_ts_active\`: drives the spec's \`_is_activation_active\` through its **timestamp-only** success branch. Sister to PR #7067 (which used \`bn=[0]\`) but exercises a distinct path through the helper.

| field | PR #7067 (\`amsterdam_active\`) | **this PR** (\`ts_active\`) |
| ----- | ------------------------------ | -------------------------- |
| \`activation.block_number\` | \`[0]\` | empty |
| \`activation.timestamp\` | empty | \`[0]\` |

All other inputs identical (\`chain_id=1\`, \`fork=4\`, \`blob_schedule=(14, 21, 11684671)\`, empty headers).

## Spec flow through `_is_activation_active`

1. \`activation.block_number is None\` → skip first \`if\`
2. \`activation.timestamp is Uint(0)\` → not None
3. \`execution_payload.timestamp = 0\` → \`0 < 0\` is False → falls through
4. returns True

Then \`validate_chain_config\` succeeds (Amsterdam fork + matching blob_schedule), \`validate_headers([])\` raises \`IndexError\`, caught → \`successful_validation = False\`.

## Branches of `_is_activation_active` now covered

| Branch | Fixture |
| ------ | ------- |
| both None → \`InvalidForkActivationError\` | every empty-activation fixture |
| bn set, bn check passes | \`chain1_fork4_amsterdam_active\` (PR #7067) |
| bn set, bn check fails | \`chain1_fork4_inactive_bn\` (PR #7069) |
| ts-only set, ts check passes | **this PR** |
| ts-only set, ts check fails | (still missing) |

## Variety dimension

Distinct branch of the activation-active helper — ts-only success path. Mirror of PR #7067 across the block_number / timestamp axis.

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass, including the new \`chain1_fork4_ts_active\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)