### PR TITLE
test(stateless): variety -- _is_activation_active ts-only FAIL branch

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -330,6 +330,21 @@ run_fixture "chain1_blob"           1                  0    ""           ""     
 # byte-for-byte against the spec.
 run_fixture "chain1_blob_realistic" 1                  0    ""           ""                  ""    ""           ""           "14:21:11684671" || fail=1
 
+# _is_activation_active TIMESTAMP-only FAIL branch. Sister to
+# the bn-only fail-branch fixture: same outer config (fork=4
+# Amsterdam, expected blob) but activation has timestamp=[1]
+# (no bn). _is_activation_active gets:
+#   activation.block_number is None              -> skip first if
+#   activation.timestamp = Uint(1) (not None)
+#   execution_payload.timestamp = 0
+#   0 < 1 is True -> returns False -> spec raises
+#   InactiveForkConfigError. Caught -> False.
+# Variety dimension: completes the _is_activation_active 2x2
+# coverage matrix (bn/ts X pass/fail). All four branches now
+# have a fixture. Mirror of chain1_fork4_inactive_bn across
+# the block_number/timestamp axis.
+run_fixture "chain1_fork4_inactive_ts" 1               4    ""           ""                  ""    ""           "1"          "14:21:11684671" || fail=1
+
 # Valid post-merge header with REALISTIC non-zero values for
 # every K-PR-IGNORED field (parent_hash, coinbase, state_root,
 # transactions_root, receipt_root, bloom, prev_randao,


### PR DESCRIPTION
## Summary

Add fixture \`chain1_fork4_inactive_ts\`: drives the spec's \`_is_activation_active\` through the **timestamp-only fail** branch. Closes the 2×2 coverage matrix for the activation helper.

| field | PR #7069 (\`inactive_bn\`) | **this PR** (\`inactive_ts\`) |
| ----- | ------------------------- | ----------------------------- |
| \`activation.block_number\` | \`[1]\` | empty |
| \`activation.timestamp\` | empty | \`[1]\` |

All other inputs identical (chain_id=1, fork=4, blob_schedule=Amsterdam, headers empty).

## Spec flow

1. \`activation.block_number is None\` → skip first \`if\`
2. \`activation.timestamp = Uint(1)\` → not None
3. \`execution_payload.timestamp = 0\` → \`0 < 1\` is True → \`_is_activation_active\` returns **False**
4. \`validate_chain_config\` raises \`InactiveForkConfigError\` → caught → \`successful_validation = False\`

## Branches of `_is_activation_active` — full coverage

| Branch | Fixture |
| ------ | ------- |
| both None → \`InvalidForkActivationError\` | every empty-activation fixture |
| bn set, bn-check passes (\`0 ≤ 0\`) | \`chain1_fork4_amsterdam_active\` (#7067) |
| bn set, bn-check fails (\`0 < 1\`) | \`chain1_fork4_inactive_bn\` (#7069) |
| ts set, ts-check passes (\`0 ≤ 0\`) | \`chain1_fork4_ts_active\` (#7073) |
| ts set, ts-check fails (\`0 < 1\`) | **this PR** |

## Variety dimension

Completes the 2×2 coverage matrix (field=bn/ts × verdict=pass/fail). Mirror of PR #7069 across the bn/ts axis.

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass, including the new \`chain1_fork4_inactive_ts\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)