### PR TITLE
test(stateless): variety -- BPO5_HEADER (PreviousForkHeader fallback)

### DIFF
--- a/scripts/codegen-stateless-gen-fixture.py
+++ b/scripts/codegen-stateless-gen-fixture.py
@@ -546,6 +546,50 @@ elif hdr_hex in (
         slot_number=slot_v,
     )
     hdr_arg = (HeaderBL(rlp.encode(h)),)
+elif hdr_hex == 'BPO5_HEADER':
+    # bpo5-fork-shape RLP header. Drives the spec's
+    # _decode_header through its PreviousForkHeader fallback
+    # branch: rlp.decode_to(amsterdam Header, ...) raises
+    # because the list has 21 elements instead of 23 (amsterdam
+    # added block_access_list_hash + slot_number); then
+    # rlp.decode_to(PreviousForkHeader = bpo5 Header, ...)
+    # succeeds. All K-PR-checked fields are at the same
+    # positions in bpo5 as in amsterdam (the K-PR pipeline
+    # reads via field index, not name), so the ASM K-PR
+    # pipeline reads valid values and accepts -- ends up at
+    # .Lsg_all_pass falling through to .Lsg_hash.
+    from ethereum.forks.bpo5.blocks import Header as Bpo5Header
+    from ethereum.forks.bpo5.fork import EMPTY_OMMER_HASH as BPO5_EMPTY_OMMER_HASH
+    from ethereum_types.bytes import Bytes32, Bytes8, Bytes
+    from ethereum_types.numeric import Uint
+    from ethereum_types.numeric import U64 as U64t
+    from ethereum_types.numeric import U256
+    from ethereum.crypto.hash import Hash32
+    from ethereum_rlp import rlp
+    h = Bpo5Header(
+        parent_hash=Hash32(b'\x00' * 32),
+        ommers_hash=BPO5_EMPTY_OMMER_HASH,
+        coinbase=b'\x00' * 20,
+        state_root=Hash32(b'\x00' * 32),
+        transactions_root=Hash32(b'\x00' * 32),
+        receipt_root=Hash32(b'\x00' * 32),
+        bloom=b'\x00' * 256,
+        difficulty=Uint(0),
+        number=Uint(1),
+        gas_limit=Uint(1000000),
+        gas_used=Uint(0),
+        timestamp=U256(1234),
+        extra_data=Bytes(b''),
+        prev_randao=Bytes32(b'\x00' * 32),
+        nonce=Bytes8(b'\x00' * 8),
+        base_fee_per_gas=Uint(0),
+        withdrawals_root=Hash32(b'\x00' * 32),
+        blob_gas_used=U64t(0),
+        excess_blob_gas=U64t(0),
+        parent_beacon_block_root=Hash32(b'\x00' * 32),
+        requests_hash=Hash32(b'\x00' * 32),
+    )
+    hdr_arg = (HeaderBL(rlp.encode(h)),)
 elif hdr_hex:
     hdr_entries = hdr_hex.split(':')
     hdr_arg = tuple(HeaderBL(bytes.fromhex(h)) for h in hdr_entries)

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -330,6 +330,27 @@ run_fixture "chain1_blob"           1                  0    ""           ""     
 # byte-for-byte against the spec.
 run_fixture "chain1_blob_realistic" 1                  0    ""           ""                  ""    ""           ""           "14:21:11684671" || fail=1
 
+# bpo5-fork-shape RLP header. Drives the spec's
+# _decode_header through its PreviousForkHeader fallback:
+#   rlp.decode_to(amsterdam Header, ...) raises -- list has
+#     21 elements but amsterdam Header expects 23
+#     (amsterdam added block_access_list_hash + slot_number).
+#   rlp.decode_to(bpo5 Header, ...) succeeds.
+# Spec configuration: fork=4 + Amsterdam blob_schedule +
+# activation.bn=[0] so validate_chain_config succeeds, then
+# validate_headers reaches _decode_header which exercises
+# the fallback branch.
+#
+# Variety dimension: spec _decode_header's
+# PreviousForkHeader fallback path -- previously unexercised.
+# All K-PR-relevant fields (parent_hash, ommers_hash,
+# difficulty, nonce, gas, blob_gas_used, ...) sit at the
+# same field indices in both Header types because amsterdam
+# is a strict extension of bpo5, so the ASM K-PR pipeline
+# parses successfully and accepts. Output byte-identical to
+# spec.
+run_fixture "chain1_fork4_bpo5_header" 1               4    ""           ""                  ""    "0"          ""           "14:21:11684671" "BPO5_HEADER" || fail=1
+
 # Valid post-merge header with REALISTIC non-zero values for
 # every K-PR-IGNORED field (parent_hash, coinbase, state_root,
 # transactions_root, receipt_root, bloom, prev_randao,


### PR DESCRIPTION
## Summary

Add fixture \`chain1_fork4_bpo5_header\`: drives the spec's \`_decode_header\` through its **\`PreviousForkHeader\` fallback** branch — previously unexercised by any fixture that reached \`validate_headers\`.

\`bpo5\` Header has 21 fields; Amsterdam Header has 23 (Amsterdam added \`block_access_list_hash\` + \`slot_number\`). When the spec sees a \`bpo5\`-shape RLP list, \`rlp.decode_to(amsterdam Header, ...)\` raises \`rlp.DecodingError\` (wrong field count), and the \`except\` branch falls through to \`rlp.decode_to(bpo5 Header, ...)\` which succeeds.

## Spec flow

1. \`validate_chain_config\` (Amsterdam fork + matching blob) → OK
2. \`validate_headers([bpo5_rlp])\`:
   - \`_decode_header\` tries amsterdam Header → raises
   - falls back to bpo5 Header → **succeeds**
   - \`block_hashes = [keccak(bpo5_rlp)]\`; N=1 so no contiguity check
3. \`parent_header = bpo5_header\`
4. \`execute_new_payload_request(empty NPR, ...)\` → raises \`InvalidBlock("Invalid block hash")\`
5. caught → \`successful_validation = False\`

## ASM-side note

The K-PR pipeline reads header fields by position. All K-PR-relevant fields (difficulty, nonce, ommers_hash, extra_data, gas_limit, gas_used, blob_gas_used, timestamp, number) sit at the **same field indices** in both Header types because Amsterdam is a strict suffix-extension of bpo5. The K-PR pipeline parses successfully, every K-PR accepts, pipeline reaches \`.Lsg_all_pass\`, falls through to \`.Lsg_hash\`. Output byte-identical to spec.

## Variety dimension

Distinct branch of \`_decode_header\` — the \`PreviousForkHeader\` fallback for cross-fork-transition headers. Locks in the byte-output before the RISC-V implementation needs to grow real \`PreviousForkHeader\` support.

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass, including the new \`chain1_fork4_bpo5_header\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)