### PR TITLE
test(stateless): variety -- fork=4 + VALID_REALISTIC header

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -330,6 +330,23 @@ run_fixture "chain1_blob"           1                  0    ""           ""     
 # byte-for-byte against the spec.
 run_fixture "chain1_blob_realistic" 1                  0    ""           ""                  ""    ""           ""           "14:21:11684671" || fail=1
 
+# fork=4 Amsterdam + activation.bn=[0] + Amsterdam blob +
+# VALID_REALISTIC header (N=1, every K-PR-ignored field
+# populated with realistic non-zero bytes). Cross-product of
+# variety dimensions:
+#   * spec walks past validate_chain_config success (#7067)
+#   * spec walks past validate_headers success at N=1 (new)
+#   * spec uses _decode_header's PRIMARY amsterdam branch
+#     (distinct from PR #7075's PreviousForkHeader fallback)
+#   * ASM K-PR pipeline parses a REALISTIC-shape RLP header
+#     (with 32-byte non-zero parent_hash, coinbase, state_root,
+#      etc.) and all K-PRs accept -> .Lsg_all_pass
+# Previous fork=4 chained fixtures (PR #7068) used VALID_THREE
+# headers with minimal-field cohorts; this is the first
+# realistic-field-cohort fixture that the spec actually
+# walks past validate_headers.
+run_fixture "chain1_fork4_realistic_header" 1          4    ""           ""                  ""    "0"          ""           "14:21:11684671" "VALID_REALISTIC" || fail=1
+
 # Valid post-merge header with REALISTIC non-zero values for
 # every K-PR-IGNORED field (parent_hash, coinbase, state_root,
 # transactions_root, receipt_root, bloom, prev_randao,


### PR DESCRIPTION
## Summary

Add fixture \`chain1_fork4_realistic_header\`: \`fork=4\` Amsterdam + \`activation.bn=[0]\` + Amsterdam blob_schedule + \`VALID_REALISTIC\` header (N=1, every K-PR-ignored field populated with realistic non-zero bytes).

## Cross-product of variety dimensions

- Spec walks past \`validate_chain_config\` success (sister to PR #7067 which used empty headers).
- Spec walks past \`validate_headers\` success **at N=1 with a real RLP-decodable Amsterdam Header**.
- Spec uses \`_decode_header\`'s **primary** Amsterdam branch (distinct from PR #7075's \`PreviousForkHeader\` fallback).
- ASM K-PR pipeline parses a realistic-shape RLP header (32-byte non-zero \`parent_hash\`, \`coinbase\`, \`state_root\`, \`txs/receipt_root\`, \`bloom\`, \`prev_randao\`, \`base_fee_per_gas\`, \`withdrawals_root\`, \`excess_blob_gas\`, \`parent_beacon_block_root\`, \`requests_hash\`, \`block_access_list_hash\`, \`slot_number\`) and all K-PRs accept → \`.Lsg_all_pass\`.

## Why this matters

Previous \`fork=4\` fixtures with non-empty headers (PR #7068 \`VALID_THREE\`) used the **minimal-field-cohort** header builder; this is the first realistic-field-cohort fixture where the spec actually walks past \`validate_headers\`.

## Variety dimension

Combines "realistic field cohort" + "fork=4 spec-walks-past-validate_headers" — a cross-product previously uncovered.

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass, including the new \`chain1_fork4_realistic_header\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)