### PR TITLE
test(stateless): variety -- Sepolia chain_id + Amsterdam fork config

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -161,6 +161,22 @@ run_fixture "chain_max_u64"         0xFFFFFFFFFFFFFFFF      || fail=1
 # topmost non-zero chain_id byte.
 run_fixture "chain_sepolia"         11155111                || fail=1
 
+# Sepolia (11155111) running Amsterdam fork. Combines the
+# real-world chain_id seam-byte pattern from chain_sepolia
+# (low 3 bytes a7 36 aa straddling the chain_id SD seam)
+# with the real-world fork config from
+# chain1_fork4_amsterdam_active (fork=4 + activation.bn=[0]
+# + Amsterdam blob_schedule). Variety dimension: realistic
+# chain_id + realistic fork config simultaneously. The
+# encoder echoes a max-shape SszForkConfig under a non-trivial
+# chain_id, exercising both the two-SD chain_id pack
+# (OUTPUT[37..45)) and the bounded byte-copy of
+# active_fork[16..L) on the same fixture for the first time.
+# Spec: validate_chain_config succeeds (Sepolia chain_id
+# isn't checked against any specific value), then
+# validate_headers([]) -> IndexError -> False.
+run_fixture "chain_sepolia_amsterdam" 11155111         4    ""           ""                  ""    "0"          ""           "14:21:11684671" || fail=1
+
 # Edge: chain_id = 2^32 = 0x100000000. LE bytes
 # 00 00 00 00 01 00 00 00. The encoder's chain_id split
 # places the LOW 3 bytes at OUTPUT[37..40) and the HIGH 5 at


### PR DESCRIPTION
## Summary

Add fixture \`chain_sepolia_amsterdam\`: Sepolia testnet \`chain_id = 11155111\` running the Amsterdam fork with the Amsterdam-expected blob_schedule. Combines two real-world variety axes that were previously orthogonal.

| axis | this PR | source variety |
| ---- | ------- | -------------- |
| chain_id | \`11155111\` (Sepolia) | \`chain_sepolia\` (#7026) |
| fork | 4 (Amsterdam) | \`chain1_fork4_amsterdam_active\` (#7067) |
| activation | \`bn=[0]\` | " |
| blob_schedule | \`(14, 21, 11684671)\` | " |
| headers | empty |  |

## Encoder paths exercised simultaneously

- Two-SD chain_id pack at \`OUTPUT[37..45)\` with the Sepolia seam-straddling byte pattern (low 3 = \`a7 36 aa\`; high 5 = \`00 00 00 00 00\`)
- Bounded byte-copy of \`active_fork[16..L)\` producing the full max-shape echo

This pairing was previously uncovered — the Sepolia chain_id had only been shipped with the minimal active_fork (\`fork=0\`, empty activation, empty blob), and the Amsterdam fork config had only been shipped with \`chain_id=1\`.

## Spec flow

1. \`validate_chain_config(...)\` → **success** (Sepolia chain_id isn't checked against any specific value)
2. \`validate_headers([])\` → \`IndexError\` → caught → \`successful_validation = False\`

## Variety dimension

Realistic chain_id + realistic fork config simultaneously — a production-shape fixture mirroring a real Sepolia-Amsterdam testnet client.

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass, including the new \`chain_sepolia_amsterdam\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)