### PR TITLE
feat(stateless): compute NPR merkle root for non-zero parent_beacon_block_root

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -271,30 +271,80 @@ def statelessGuestValidatorPipeline : String :=
 def statelessGuestEpilogue : String :=
   statelessGuestValidatorPipeline ++ "\n" ++
   ".Lsg_hash:\n" ++
-  "  # Stamp `compute_new_payload_request_root(empty)` at OUTPUT[0..32).\n" ++
+  "  # Compute `compute_new_payload_request_root(stateless_input)`\n" ++
+  "  # at OUTPUT[0..32) -- the SSZ merkle root over the four NPR\n" ++
+  "  # field roots:\n" ++
+  "  #   field_root[0] = hash_tree_root(execution_payload)\n" ++
+  "  #   field_root[1] = hash_tree_root(versioned_hashes)\n" ++
+  "  #   field_root[2] = parent_beacon_block_root      (Bytes32 inline)\n" ++
+  "  #   field_root[3] = hash_tree_root(execution_requests)\n" ++
+  "  # For all current fixtures every NPR field except\n" ++
+  "  # parent_beacon_block_root is the SSZ default, so field_root[0],\n" ++
+  "  # field_root[1], and field_root[3] are static constants\n" ++
+  "  # (`npr_left_subtree` packages sha256(field_root[0] ||\n" ++
+  "  # field_root[1]); `npr_exec_requests_root` is field_root[3]).\n" ++
+  "  # field_root[2] is read from input at NPR_addr + 8 (NPR_addr\n" ++
+  "  # = SSZ_BASE + outer.offsets[0]; for this schema outer.offsets[0]\n" ++
+  "  # is always 16).\n" ++
   "  # \n" ++
-  "  # The spec's `verify_stateless_new_payload` always sets the\n" ++
-  "  # output's `new_payload_request_root` field to\n" ++
-  "  # `compute_new_payload_request_root(stateless_input)`. For an\n" ++
-  "  # *empty* SszNewPayloadRequest -- what the new-schema decoder\n" ++
-  "  # currently produces because no SSZ decode of\n" ++
-  "  # new_payload_request is wired -- this hash is the fixed\n" ++
-  "  # constant `empty_npr_root` below.\n" ++
+  "  # Computation:\n" ++
+  "  #   right_subtree = sha256(parent_beacon_block_root ||\n" ++
+  "  #                          npr_exec_requests_root)\n" ++
+  "  #   npr_root      = sha256(npr_left_subtree || right_subtree)\n" ++
   "  # \n" ++
-  "  # Generalising to non-empty new_payload_request requires\n" ++
-  "  # implementing `hash_tree_root(SszNewPayloadRequest)` (a\n" ++
-  "  # deeply-nested Container with 19-field execution_payload +\n" ++
-  "  # versioned_hashes List + execution_requests Container). That's\n" ++
-  "  # tracked as a follow-up to this PR. For now we stamp the\n" ++
-  "  # empty-input constant so the spec-diff section of the test\n" ++
-  "  # shrinks to zero for our current fixture set.\n" ++
-  "  li t0, 0xa0010000           # t0 = OUTPUT_ADDR (root field)\n" ++
-  "  la t1, empty_npr_root\n" ++
-  "  ld t2,  0(t1); sd t2,  0(t0)\n" ++
-  "  ld t2,  8(t1); sd t2,  8(t0)\n" ++
-  "  ld t2, 16(t1); sd t2, 16(t0)\n" ++
-  "  ld t2, 24(t1); sd t2, 24(t0)\n" ++
+  "  # For pbr=zero (every previously-shipped fixture) the\n" ++
+  "  # computation reproduces the precomputed `empty_npr_root`\n" ++
+  "  # constant. For non-empty pbr it produces the spec-matching\n" ++
+  "  # root.\n" ++
+  "  # \n" ++
+  "  # Generalising to non-default execution_payload /\n" ++
+  "  # versioned_hashes / execution_requests requires recomputing\n" ++
+  "  # those field roots dynamically -- deferred to subsequent PRs.\n" ++
+  "  # \n" ++
+  "  # Re-derive SSZ_BASE; the K-PR pipeline may have clobbered\n" ++
+  "  # the decoder's x17 via the validator a-register churn.\n" ++
+  "  li t0, 0x40000000\n" ++
+  "  addi t0, t0, 18             # t0 = SSZ_BASE\n" ++
+  "  # Build sha256 input for right_subtree at npr_sha_input[0..64).\n" ++
+  "  # bytes [0..32) = parent_beacon_block_root from input (SSZ_BASE +\n" ++
+  "  # 16 + 8 = SSZ_BASE + 24).\n" ++
+  "  la t1, npr_sha_input\n" ++
+  "  ld t2, 24(t0); sd t2,  0(t1)\n" ++
+  "  ld t2, 32(t0); sd t2,  8(t1)\n" ++
+  "  ld t2, 40(t0); sd t2, 16(t1)\n" ++
+  "  ld t2, 48(t0); sd t2, 24(t1)\n" ++
+  "  # bytes [32..64) = npr_exec_requests_root.\n" ++
+  "  la t3, npr_exec_requests_root\n" ++
+  "  ld t2,  0(t3); sd t2, 32(t1)\n" ++
+  "  ld t2,  8(t3); sd t2, 40(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 48(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 56(t1)\n" ++
+  "  # right_subtree = sha256(input[0..64)) -> npr_sha_subtree.\n" ++
+  "  la a0, npr_sha_input\n" ++
+  "  li a1, 64\n" ++
+  "  la a2, npr_sha_subtree\n" ++
+  "  jal ra, zkvm_sha256\n" ++
+  "  # Build sha256 input for the root at npr_sha_input[0..64).\n" ++
+  "  # bytes [0..32) = npr_left_subtree.\n" ++
+  "  la t1, npr_sha_input\n" ++
+  "  la t3, npr_left_subtree\n" ++
+  "  ld t2,  0(t3); sd t2,  0(t1)\n" ++
+  "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 16(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 24(t1)\n" ++
+  "  # bytes [32..64) = npr_sha_subtree (right_subtree from prior call).\n" ++
+  "  la t3, npr_sha_subtree\n" ++
+  "  ld t2,  0(t3); sd t2, 32(t1)\n" ++
+  "  ld t2,  8(t3); sd t2, 40(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 48(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 56(t1)\n" ++
+  "  # root = sha256(input[0..64)) -> OUTPUT_ADDR.\n" ++
+  "  la a0, npr_sha_input\n" ++
+  "  li a1, 64\n" ++
+  "  li a2, 0xa0010000\n" ++
+  "  jal ra, zkvm_sha256\n" ++
   "  j .Lsg_done\n" ++
+  zkvmSha256Function ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
   rlpFieldToU64Function ++ "\n" ++
   chainValidatePostMergeFullFunction ++ "\n" ++
@@ -449,7 +499,35 @@ def statelessGuestDataSection : String :=
   "  .byte 0xf7, 0x83, 0x79, 0x28, 0xaf, 0x2f, 0xf9, 0x7a\n" ++
   "  .byte 0xdd, 0x39, 0x49, 0x6e, 0x3c, 0x72, 0xbc, 0xdf\n" ++
   "  .byte 0xba, 0xdf, 0xfc, 0x45, 0x3d, 0xee, 0x6a, 0x58\n" ++
-  "  .byte 0x2c, 0xa2, 0xa5, 0xc7, 0xcc, 0x51, 0x2f, 0x71"
+  "  .byte 0x2c, 0xa2, 0xa5, 0xc7, 0xcc, 0x51, 0x2f, 0x71\n" ++
+  -- SSZ field roots for the NPR sub-tree, used by the
+  -- epilogue's `compute_new_payload_request_root` computation.
+  -- `npr_left_subtree` is sha256(field_root[execution_payload] ||
+  -- field_root[versioned_hashes]) for the default (empty)
+  -- execution_payload + versioned_hashes lists. These three
+  -- sub-trees are constant for the input class currently
+  -- supported (NPR with default execution_payload /
+  -- versioned_hashes / execution_requests; only
+  -- parent_beacon_block_root may be non-zero); they collapse to
+  -- `empty_npr_root` when parent_beacon_block_root is zero.
+  ".balign 8\n" ++
+  "npr_left_subtree:\n" ++
+  "  .byte 0x50, 0x57, 0xc2, 0x29, 0xce, 0xf7, 0x0b, 0x3d\n" ++
+  "  .byte 0x2f, 0xe3, 0x46, 0xe2, 0xd6, 0x19, 0x8f, 0x3d\n" ++
+  "  .byte 0xd5, 0x36, 0x5b, 0xd9, 0x65, 0x13, 0x22, 0xe8\n" ++
+  "  .byte 0x81, 0xa0, 0x99, 0x4c, 0xbd, 0x34, 0x30, 0x57\n" ++
+  ".balign 8\n" ++
+  "npr_exec_requests_root:\n" ++
+  "  .byte 0x85, 0xe2, 0x53, 0xb4, 0x05, 0x99, 0xd0, 0xdf\n" ++
+  "  .byte 0x75, 0x6b, 0xe0, 0x43, 0xea, 0x69, 0x49, 0xe4\n" ++
+  "  .byte 0x9a, 0x07, 0xe7, 0x56, 0xde, 0xef, 0x72, 0xb3\n" ++
+  "  .byte 0x58, 0x8a, 0x4b, 0x05, 0x36, 0x22, 0x06, 0xb5\n" ++
+  ".balign 8\n" ++
+  "npr_sha_input:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "npr_sha_subtree:\n" ++
+  "  .zero 32"
 
 def statelessGuestUnit : BuildUnit := {
   body        := EvmAsm.Stateless.run_stateless_guest

--- a/scripts/codegen-stateless-gen-fixture.py
+++ b/scripts/codegen-stateless-gen-fixture.py
@@ -63,6 +63,7 @@ bn_str = sys.argv[8]
 ts_str = sys.argv[9]
 blob_str = sys.argv[10]
 hdr_hex = sys.argv[11]
+npr_pbr_hex = sys.argv[12] if len(sys.argv) > 12 else ''
 
 # Build the new-schema StatelessInput: empty new_payload_request,
 # witness whose 'state'/'codes' lists each hold zero or more
@@ -685,8 +686,16 @@ if pk_hex:
     pk_entries = pk_hex.split(':')
     pk_args = tuple(PkBV(bytes.fromhex(p)) for p in pk_entries)
 
+if npr_pbr_hex:
+    from remerkleable.byte_arrays import Bytes32 as Bytes32SSZ
+    npr = SszNewPayloadRequest(
+        parent_beacon_block_root=Bytes32SSZ(bytes.fromhex(npr_pbr_hex)),
+    )
+else:
+    npr = SszNewPayloadRequest()
+
 ssz_input = SszStatelessInput(
-    new_payload_request=SszNewPayloadRequest(),
+    new_payload_request=npr,
     witness=witness,
     chain_config=cc,
     public_keys=PkList(*pk_args),

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -80,6 +80,7 @@ run_fixture() {
   local timestamp="${8:-}"
   local blob_schedule="${9:-}"
   local witness_headers_hex="${10:-}"
+  local npr_pbr_hex="${11:-}"
 
   local safe="${label//[^0-9A-Za-z_]/_}"
   local input_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.input"
@@ -87,8 +88,8 @@ run_fixture() {
   local spec_exp_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.spec-expected"
   local log_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.emu.log"
 
-  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty})"
-  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex"
+  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty}, npr_pbr=${npr_pbr_hex:-empty})"
+  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex" "$npr_pbr_hex"
 
   # Guard against silent fail: if the spec generator crashed
   # (Python syntax error in the heredoc, missing import, etc.)
@@ -176,6 +177,26 @@ run_fixture "chain_sepolia"         11155111                || fail=1
 # isn't checked against any specific value), then
 # validate_headers([]) -> IndexError -> False.
 run_fixture "chain_sepolia_amsterdam" 11155111         4    ""           ""                  ""    "0"          ""           "14:21:11684671" || fail=1
+
+# Non-empty new_payload_request: parent_beacon_block_root set
+# to 0xff*32, all other NPR fields default (empty execution
+# payload, no versioned hashes, no execution requests).
+# Spec's compute_new_payload_request_root(...) computes a
+# different 32-byte hash than the empty-NPR constant -- the
+# OUTPUT[0..32) bytes are determined by the SSZ merkle tree
+# over the NPR's four field roots.
+#
+# Drives the smallest possible RISC-V implementation step:
+# previously the encoder STAMPED `empty_npr_root` (a static
+# 32-byte .data constant); after this PR the encoder reads
+# parent_beacon_block_root from input and computes
+#   right_subtree = sha256(pbr || exec_requests_root)
+#   root          = sha256(left_subtree || right_subtree)
+# with `left_subtree` and `exec_requests_root` as new .data
+# constants (precomputed from empty subtrees). For all
+# previously-shipped fixtures (pbr=zero), the computation
+# reproduces the empty_npr_root constant exactly.
+run_fixture "chain1_npr_pbr_ff" 1                      0    ""           ""                  ""    ""           ""           ""    ""                       "$(printf 'ff%.0s' {1..32})" || fail=1
 
 # Edge: chain_id = 2^32 = 0x100000000. LE bytes
 # 00 00 00 00 01 00 00 00. The encoder's chain_id split


### PR DESCRIPTION
## Summary

First PR that drives a **small targeted implementation change** to the RISC-V \`run_stateless_guest\` via a test that initially fails.

**Initially-failing fixture:** \`chain1_npr_pbr_ff\` — \`SszNewPayloadRequest\` with \`parent_beacon_block_root = 0xff × 32\` (all other NPR fields default). Spec's \`compute_new_payload_request_root(...)\` returns a 32-byte hash that differs from the empty-NPR constant. The current encoder stamped \`empty_npr_root\` unconditionally → mismatch on OUTPUT[0..32).

**Smallest implementation step:** replace the static-constant stamp at \`.Lsg_hash\` with a 2-call \`sha256\` merkle computation over the 4 NPR field roots:

\`\`\`
right_subtree = sha256(parent_beacon_block_root  ||  npr_exec_requests_root)
root          = sha256(npr_left_subtree          ||  right_subtree)
\`\`\`

\`npr_left_subtree\` and \`npr_exec_requests_root\` are precomputed \`.data\` constants:
- \`npr_left_subtree = sha256(field_root[execution_payload] || field_root[versioned_hashes])\` for the empty defaults.
- \`npr_exec_requests_root = field_root[execution_requests]\` for the empty default.

\`parent_beacon_block_root\` is read from input at \`SSZ_BASE + 16 + 8\` (NPR_addr = \`SSZ_BASE + outer.offsets[0]\` = \`SSZ_BASE + 16\` for our schema; the \`Bytes32\` pbr lives inline at \`NPR+8\`). The K-PR pipeline may clobber x17, so \`SSZ_BASE\` is re-derived from \`INPUT_BASE + 18\` directly.

## Why this is the smallest possible step

- The NPR class supported here (default \`execution_payload\` + default \`versioned_hashes\` + default \`execution_requests\`; only \`parent_beacon_block_root\` may vary) collapses **three** of the four SSZ subtrees to static constants. Only the \`(pbr, exec_requests_root)\` subtree and the final root need dynamic \`sha256\` calls.
- For pbr = zeros (every previously-shipped fixture), the new computation reproduces the \`empty_npr_root\` constant byte-for-byte. Verified by SSZ merkle expansion: \`sha256(left || sha256(0 || exec_req_root)) = existing empty_npr_root\`.
- Future PRs can generalise to non-default \`execution_payload\` / \`versioned_hashes\` / \`execution_requests\` by replacing each constant with a real SSZ hash_tree_root computation.

## Surface

| file | change |
| ---- | ------ |
| \`scripts/codegen-stateless-spec-output-check.sh\` | 11th optional positional arg \`npr_pbr_hex\`; new fixture \`chain1_npr_pbr_ff\`. |
| \`scripts/codegen-stateless-gen-fixture.py\` | read \`sys.argv[12]\` as \`npr_pbr_hex\`; build \`SszNewPayloadRequest(parent_beacon_block_root=...)\` when set. |
| \`EvmAsm/Codegen/Programs.lean\` | new \`.Lsg_hash\` block calls \`zkvm_sha256\` twice over \`npr_sha_input\` (64-byte scratch). Two new \`.data\` constants and two new scratch buffers. \`zkvmSha256Function\` appended to the epilogue text so the symbol is linked. |

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all 80+ existing fixtures pass (their pbr=zero output now flows through the new computation path and reproduces \`empty_npr_root\` byte-for-byte).
- [x] New fixture \`chain1_npr_pbr_ff\` passes (initially failed before the \`.Lsg_hash\` rewrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)