### PR TITLE
feat(stateless): compute NPR merkle for non-default execution_payload.slot_number

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -47,6 +47,7 @@ import EvmAsm.Stateless.SSZ.HashTreeRoot.Program
 import EvmAsm.Codegen.Programs.Evm
 import EvmAsm.Codegen.Programs.HashBridge
 import EvmAsm.Codegen.Programs.HashProbes
+import EvmAsm.Codegen.Programs.StatelessGuestData
 import EvmAsm.Codegen.Programs.IntrinsicGas
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.Mpt
@@ -301,48 +302,124 @@ def statelessGuestEpilogue : String :=
   "  # versioned_hashes / execution_requests requires recomputing\n" ++
   "  # those field roots dynamically -- deferred to subsequent PRs.\n" ++
   "  # \n" ++
-  "  # Re-derive SSZ_BASE; the K-PR pipeline may have clobbered\n" ++
-  "  # the decoder's x17 via the validator a-register churn.\n" ++
-  "  li t0, 0x40000000\n" ++
-  "  addi t0, t0, 18             # t0 = SSZ_BASE\n" ++
-  "  # Build sha256 input for right_subtree at npr_sha_input[0..64).\n" ++
-  "  # bytes [0..32) = parent_beacon_block_root from input (SSZ_BASE +\n" ++
-  "  # 16 + 8 = SSZ_BASE + 24).\n" ++
+  "  # Re-derive SSZ_BASE in s6 (callee-saved -- survives zkvm_sha256\n" ++
+  "  # calls). K-PR pipeline only saves s0-s5 in its validators, so\n" ++
+  "  # s6 is free.\n" ++
+  "  li s6, 0x40000000\n" ++
+  "  addi s6, s6, 18             # s6 = SSZ_BASE\n" ++
+  "  # \n" ++
+  "  # ===== exec_payload merkle path (leaves 16-31, leaf 18=slot_number) =====\n" ++
+  "  # leaf_18 = slot_number (u64 LE at SSZ_BASE + 16 + 44 + 532 = +592)\n" ++
+  "  #          || 24 bytes of zero padding\n" ++
   "  la t1, npr_sha_input\n" ++
-  "  ld t2, 24(t0); sd t2,  0(t1)\n" ++
-  "  ld t2, 32(t0); sd t2,  8(t1)\n" ++
-  "  ld t2, 40(t0); sd t2, 16(t1)\n" ++
-  "  ld t2, 48(t0); sd t2, 24(t1)\n" ++
-  "  # bytes [32..64) = npr_exec_requests_root.\n" ++
-  "  la t3, npr_exec_requests_root\n" ++
-  "  ld t2,  0(t3); sd t2, 32(t1)\n" ++
-  "  ld t2,  8(t3); sd t2, 40(t1)\n" ++
-  "  ld t2, 16(t3); sd t2, 48(t1)\n" ++
-  "  ld t2, 24(t3); sd t2, 56(t1)\n" ++
-  "  # right_subtree = sha256(input[0..64)) -> npr_sha_subtree.\n" ++
-  "  la a0, npr_sha_input\n" ++
-  "  li a1, 64\n" ++
-  "  la a2, npr_sha_subtree\n" ++
-  "  jal ra, zkvm_sha256\n" ++
-  "  # Build sha256 input for the root at npr_sha_input[0..64).\n" ++
-  "  # bytes [0..32) = npr_left_subtree.\n" ++
+  "  ld t2, 592(s6)              # slot_number\n" ++
+  "  sd t2,  0(t1)\n" ++
+  "  sd zero,  8(t1); sd zero, 16(t1); sd zero, 24(t1)\n" ++
+  "  # bytes [32..64) = ssz_zero_hash[0] = leaf_19\n" ++
+  "  sd zero, 32(t1); sd zero, 40(t1); sd zero, 48(t1); sd zero, 56(t1)\n" ++
+  "  la a0, npr_sha_input; li a1, 64; la a2, npr_sha_subtree\n" ++
+  "  jal ra, zkvm_sha256         # node_18_19 -> npr_sha_subtree\n" ++
+  "  # node_16_19 = sha256(node_16_17 || node_18_19)\n" ++
   "  la t1, npr_sha_input\n" ++
-  "  la t3, npr_left_subtree\n" ++
+  "  la t3, npr_node_16_17\n" ++
   "  ld t2,  0(t3); sd t2,  0(t1)\n" ++
   "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
   "  ld t2, 16(t3); sd t2, 16(t1)\n" ++
   "  ld t2, 24(t3); sd t2, 24(t1)\n" ++
-  "  # bytes [32..64) = npr_sha_subtree (right_subtree from prior call).\n" ++
   "  la t3, npr_sha_subtree\n" ++
   "  ld t2,  0(t3); sd t2, 32(t1)\n" ++
   "  ld t2,  8(t3); sd t2, 40(t1)\n" ++
   "  ld t2, 16(t3); sd t2, 48(t1)\n" ++
   "  ld t2, 24(t3); sd t2, 56(t1)\n" ++
-  "  # root = sha256(input[0..64)) -> OUTPUT_ADDR.\n" ++
-  "  la a0, npr_sha_input\n" ++
-  "  li a1, 64\n" ++
-  "  li a2, 0xa0010000\n" ++
-  "  jal ra, zkvm_sha256\n" ++
+  "  la a0, npr_sha_input; li a1, 64; la a2, npr_sha_subtree\n" ++
+  "  jal ra, zkvm_sha256         # node_16_19 -> npr_sha_subtree\n" ++
+  "  # node_16_23 = sha256(node_16_19 || ssz_zero_hash[2])\n" ++
+  "  la t1, npr_sha_input\n" ++
+  "  la t3, npr_sha_subtree\n" ++
+  "  ld t2,  0(t3); sd t2,  0(t1)\n" ++
+  "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 16(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 24(t1)\n" ++
+  "  la t3, ssz_zero_hashes\n" ++
+  "  addi t3, t3, 64             # ssz_zero_hash[2]\n" ++
+  "  ld t2,  0(t3); sd t2, 32(t1)\n" ++
+  "  ld t2,  8(t3); sd t2, 40(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 48(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 56(t1)\n" ++
+  "  la a0, npr_sha_input; li a1, 64; la a2, npr_sha_subtree\n" ++
+  "  jal ra, zkvm_sha256         # node_16_23 -> npr_sha_subtree\n" ++
+  "  # node_16_31 = sha256(node_16_23 || ssz_zero_hash[3])\n" ++
+  "  la t1, npr_sha_input\n" ++
+  "  la t3, npr_sha_subtree\n" ++
+  "  ld t2,  0(t3); sd t2,  0(t1)\n" ++
+  "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 16(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 24(t1)\n" ++
+  "  la t3, ssz_zero_hashes\n" ++
+  "  addi t3, t3, 96             # ssz_zero_hash[3]\n" ++
+  "  ld t2,  0(t3); sd t2, 32(t1)\n" ++
+  "  ld t2,  8(t3); sd t2, 40(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 48(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 56(t1)\n" ++
+  "  la a0, npr_sha_input; li a1, 64; la a2, npr_sha_subtree\n" ++
+  "  jal ra, zkvm_sha256         # node_16_31 -> npr_sha_subtree\n" ++
+  "  # exec_payload_root = sha256(node_0_15 || node_16_31)\n" ++
+  "  la t1, npr_sha_input\n" ++
+  "  la t3, npr_node_0_15\n" ++
+  "  ld t2,  0(t3); sd t2,  0(t1)\n" ++
+  "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 16(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 24(t1)\n" ++
+  "  la t3, npr_sha_subtree\n" ++
+  "  ld t2,  0(t3); sd t2, 32(t1)\n" ++
+  "  ld t2,  8(t3); sd t2, 40(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 48(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 56(t1)\n" ++
+  "  la a0, npr_sha_input; li a1, 64; la a2, npr_exec_payload_root\n" ++
+  "  jal ra, zkvm_sha256         # exec_payload_root -> npr_exec_payload_root\n" ++
+  "  # \n" ++
+  "  # ===== NPR top-level merkle =====\n" ++
+  "  # left_subtree = sha256(exec_payload_root || versioned_hashes_root)\n" ++
+  "  la t1, npr_sha_input\n" ++
+  "  la t3, npr_exec_payload_root\n" ++
+  "  ld t2,  0(t3); sd t2,  0(t1)\n" ++
+  "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 16(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 24(t1)\n" ++
+  "  la t3, npr_versioned_hashes_root\n" ++
+  "  ld t2,  0(t3); sd t2, 32(t1)\n" ++
+  "  ld t2,  8(t3); sd t2, 40(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 48(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 56(t1)\n" ++
+  "  la a0, npr_sha_input; li a1, 64; la a2, npr_left_subtree_scratch\n" ++
+  "  jal ra, zkvm_sha256         # left_subtree -> npr_left_subtree_scratch\n" ++
+  "  # right_subtree = sha256(parent_beacon_block_root || npr_exec_requests_root)\n" ++
+  "  la t1, npr_sha_input\n" ++
+  "  ld t2, 24(s6); sd t2,  0(t1)\n" ++
+  "  ld t2, 32(s6); sd t2,  8(t1)\n" ++
+  "  ld t2, 40(s6); sd t2, 16(t1)\n" ++
+  "  ld t2, 48(s6); sd t2, 24(t1)\n" ++
+  "  la t3, npr_exec_requests_root\n" ++
+  "  ld t2,  0(t3); sd t2, 32(t1)\n" ++
+  "  ld t2,  8(t3); sd t2, 40(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 48(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 56(t1)\n" ++
+  "  la a0, npr_sha_input; li a1, 64; la a2, npr_sha_subtree\n" ++
+  "  jal ra, zkvm_sha256         # right_subtree -> npr_sha_subtree\n" ++
+  "  # root = sha256(left_subtree || right_subtree) -> OUTPUT_ADDR\n" ++
+  "  la t1, npr_sha_input\n" ++
+  "  la t3, npr_left_subtree_scratch\n" ++
+  "  ld t2,  0(t3); sd t2,  0(t1)\n" ++
+  "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 16(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 24(t1)\n" ++
+  "  la t3, npr_sha_subtree\n" ++
+  "  ld t2,  0(t3); sd t2, 32(t1)\n" ++
+  "  ld t2,  8(t3); sd t2, 40(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 48(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 56(t1)\n" ++
+  "  la a0, npr_sha_input; li a1, 64; li a2, 0xa0010000\n" ++
+  "  jal ra, zkvm_sha256         # root -> OUTPUT_ADDR\n" ++
   "  j .Lsg_done\n" ++
   zkvmSha256Function ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
@@ -356,178 +433,10 @@ def statelessGuestEpilogue : String :=
   chainValidateConsecutiveNumbersFunction ++ "\n" ++
   ".Lsg_done:"
 
-def statelessGuestDataSection : String :=
-  ".section .data\n" ++
-  ".balign 8\n" ++
-  "sha256_w_iv:\n" ++
-  "  .quad 0xbb67ae856a09e667\n" ++
-  "  .quad 0xa54ff53a3c6ef372\n" ++
-  "  .quad 0x9b05688c510e527f\n" ++
-  "  .quad 0x5be0cd191f83d9ab\n" ++
-  ".balign 8\n" ++
-  "sha256_w_state:\n" ++
-  "  .zero 32\n" ++
-  ".balign 8\n" ++
-  "sha256_w_input:\n" ++
-  "  .zero 64\n" ++
-  ".balign 8\n" ++
-  "sha256_w_params:\n" ++
-  "  .quad sha256_w_state\n" ++
-  "  .quad sha256_w_input\n" ++
-  ".balign 32\n" ++
-  "ssz_merkleize_scratch:\n" ++
-  "  .zero 1024\n" ++
-  ".balign 32\n" ++
-  "ssz_merkleize_padded:\n" ++
-  "  .zero 1024\n" ++
-  ".balign 32\n" ++
-  "ssz_merkleize_partial:\n" ++
-  "  .zero 64\n" ++
-  ".balign 32\n" ++
-  "ssz_hb_chunks:\n" ++
-  "  .zero 1024\n" ++
-  ".balign 32\n" ++
-  "ssz_hb_partial:\n" ++
-  "  .zero 32\n" ++
-  ".balign 32\n" ++
-  "ssz_hb_mix:\n" ++
-  "  .zero 64\n" ++
-  ".balign 32\n" ++
-  "ssz_ltb_child_roots:\n" ++
-  "  .zero 1024\n" ++
-  ".balign 32\n" ++
-  "ssz_ltb_partial:\n" ++
-  "  .zero 32\n" ++
-  ".balign 32\n" ++
-  "ssz_ltb_mix:\n" ++
-  "  .zero 64\n" ++
-  ".balign 32\n" ++
-  "ssz_ew_field_roots:\n" ++
-  "  .zero 96\n" ++
-  sszZeroHashesDataSection ++ "\n" ++
-  -- Header-validator pipeline scratch:
-  ".balign 8\n" ++
-  "sg_header_lengths:\n" ++
-  "  .zero 2048\n" ++          -- MAX_WITNESS_HEADERS (256) × 8 bytes
-  "sg_kpr_valid:\n" ++
-  "  .zero 8\n" ++
-  "sg_kpr_bad_index:\n" ++
-  "  .zero 8\n" ++
-  -- Shared K-PR scratch (zk3_state / rfu_offset / rfu_length: used by
-  -- rlp_list_nth_item + rlp_field_to_u64; same labels each K-PR
-  -- declares, declared once here):
-  "zk3_state:\n" ++
-  "  .zero 200\n" ++
-  "rfu_offset:\n" ++
-  "  .zero 8\n" ++
-  "rfu_length:\n" ++
-  "  .zero 8\n" ++
-  -- K290 chain_validate_post_merge_full scratch:
-  "cvpmf_field:\n" ++
-  "  .zero 8\n" ++
-  "cvpmf_offset:\n" ++
-  "  .zero 8\n" ++
-  "cvpmf_length:\n" ++
-  "  .zero 8\n" ++
-  "cvpmf_iter_ptr:\n" ++
-  "  .zero 8\n" ++
-  "cvpmf_iter_i:\n" ++
-  "  .zero 8\n" ++
-  "cvpmf_empty_hash:\n" ++
-  "  .byte 0x1d, 0xcc, 0x4d, 0xe8, 0xde, 0xc7, 0x5d, 0x7a\n" ++
-  "  .byte 0xab, 0x85, 0xb5, 0x67, 0xb6, 0xcc, 0xd4, 0x1a\n" ++
-  "  .byte 0xd3, 0x12, 0x45, 0x1b, 0x94, 0x8a, 0x74, 0x13\n" ++
-  "  .byte 0xf0, 0xa1, 0x42, 0xfd, 0x40, 0xd4, 0x93, 0x47\n" ++
-  -- K291 chain_validate_extra_data_length scratch:
-  "cvedl_offset:\n" ++
-  "  .zero 8\n" ++
-  "cvedl_length:\n" ++
-  "  .zero 8\n" ++
-  "cvedl_iter_ptr:\n" ++
-  "  .zero 8\n" ++
-  "cvedl_iter_i:\n" ++
-  "  .zero 8\n" ++
-  -- K240 chain_validate_gas_used_under_limit scratch:
-  "cvgul_gas_used:\n" ++
-  "  .zero 8\n" ++
-  "cvgul_gas_limit:\n" ++
-  "  .zero 8\n" ++
-  "cvgul_iter_ptr:\n" ++
-  "  .zero 8\n" ++
-  "cvgul_iter_i:\n" ++
-  "  .zero 8\n" ++
-  -- K278 chain_validate_blob_gas_used_multiple scratch:
-  "cvbgm_field:\n" ++
-  "  .zero 8\n" ++
-  "cvbgm_iter_ptr:\n" ++
-  "  .zero 8\n" ++
-  "cvbgm_iter_i:\n" ++
-  "  .zero 8\n" ++
-  -- K277 chain_validate_blob_gas_used_under_max scratch:
-  "cvbgum_field:\n" ++
-  "  .zero 8\n" ++
-  "cvbgum_iter_ptr:\n" ++
-  "  .zero 8\n" ++
-  "cvbgum_iter_i:\n" ++
-  "  .zero 8\n" ++
-  -- K229 chain_validate_increasing_timestamps scratch:
-  "cvit_ts:\n" ++
-  "  .zero 8\n" ++
-  "cvit_iter_child:\n" ++
-  "  .zero 8\n" ++
-  "cvit_iter_i:\n" ++
-  "  .zero 8\n" ++
-  "cvit_iter_prev:\n" ++
-  "  .zero 8\n" ++
-  -- K230 chain_validate_consecutive_numbers scratch:
-  "cvcn_num:\n" ++
-  "  .zero 8\n" ++
-  "cvcn_iter_child:\n" ++
-  "  .zero 8\n" ++
-  "cvcn_iter_i:\n" ++
-  "  .zero 8\n" ++
-  "cvcn_iter_prev:\n" ++
-  "  .zero 8\n" ++
-  -- compute_new_payload_request_root(empty_input) -- the spec
-  -- hash for an empty `SszNewPayloadRequest`, independent of
-  -- chain_id. Stamped at OUTPUT[0..32) by the epilogue.
-  -- (Verified against
-  --  `execution-specs/.../stateless.compute_new_payload_request_root`
-  --  on d7fe16ab8.)
-  ".balign 8\n" ++
-  "empty_npr_root:\n" ++
-  "  .byte 0xf7, 0x83, 0x79, 0x28, 0xaf, 0x2f, 0xf9, 0x7a\n" ++
-  "  .byte 0xdd, 0x39, 0x49, 0x6e, 0x3c, 0x72, 0xbc, 0xdf\n" ++
-  "  .byte 0xba, 0xdf, 0xfc, 0x45, 0x3d, 0xee, 0x6a, 0x58\n" ++
-  "  .byte 0x2c, 0xa2, 0xa5, 0xc7, 0xcc, 0x51, 0x2f, 0x71\n" ++
-  -- SSZ field roots for the NPR sub-tree, used by the
-  -- epilogue's `compute_new_payload_request_root` computation.
-  -- `npr_left_subtree` is sha256(field_root[execution_payload] ||
-  -- field_root[versioned_hashes]) for the default (empty)
-  -- execution_payload + versioned_hashes lists. These three
-  -- sub-trees are constant for the input class currently
-  -- supported (NPR with default execution_payload /
-  -- versioned_hashes / execution_requests; only
-  -- parent_beacon_block_root may be non-zero); they collapse to
-  -- `empty_npr_root` when parent_beacon_block_root is zero.
-  ".balign 8\n" ++
-  "npr_left_subtree:\n" ++
-  "  .byte 0x50, 0x57, 0xc2, 0x29, 0xce, 0xf7, 0x0b, 0x3d\n" ++
-  "  .byte 0x2f, 0xe3, 0x46, 0xe2, 0xd6, 0x19, 0x8f, 0x3d\n" ++
-  "  .byte 0xd5, 0x36, 0x5b, 0xd9, 0x65, 0x13, 0x22, 0xe8\n" ++
-  "  .byte 0x81, 0xa0, 0x99, 0x4c, 0xbd, 0x34, 0x30, 0x57\n" ++
-  ".balign 8\n" ++
-  "npr_exec_requests_root:\n" ++
-  "  .byte 0x85, 0xe2, 0x53, 0xb4, 0x05, 0x99, 0xd0, 0xdf\n" ++
-  "  .byte 0x75, 0x6b, 0xe0, 0x43, 0xea, 0x69, 0x49, 0xe4\n" ++
-  "  .byte 0x9a, 0x07, 0xe7, 0x56, 0xde, 0xef, 0x72, 0xb3\n" ++
-  "  .byte 0x58, 0x8a, 0x4b, 0x05, 0x36, 0x22, 0x06, 0xb5\n" ++
-  ".balign 8\n" ++
-  "npr_sha_input:\n" ++
-  "  .zero 64\n" ++
-  ".balign 8\n" ++
-  "npr_sha_subtree:\n" ++
-  "  .zero 32"
+-- `statelessGuestDataSection` lives in
+-- `EvmAsm/Codegen/Programs/StatelessGuestData.lean` (carved
+-- out here to satisfy the file-size hard cap; see PR #5870
+-- and PR #5900 for the established submodule pattern).
 
 def statelessGuestUnit : BuildUnit := {
   body        := EvmAsm.Stateless.run_stateless_guest
@@ -1240,6 +1149,7 @@ end EvmAsm.Codegen
     "EvmAsm/Codegen/Programs/State.lean",
     "EvmAsm/Codegen/Programs/RlpRead.lean",
     "EvmAsm/Codegen/Programs/Ssz.lean",
+    "EvmAsm/Codegen/Programs/StatelessGuestData.lean",
     "EvmAsm/Codegen/Programs/Tx.lean",
     "EvmAsm/Codegen/Programs/TxDecode.lean",
     "EvmAsm/Codegen/Programs/TxExtract.lean",

--- a/EvmAsm/Codegen/Programs/StatelessGuestData.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuestData.lean
@@ -1,0 +1,244 @@
+/-
+  EvmAsm.Codegen.Programs.StatelessGuestData
+
+  `.data` section for the `stateless_guest` ELF.  Carved out of
+  `Programs.lean` for the file-size hard cap; consumed by the
+  registry hub via `statelessGuestDataSection`.
+
+  Contains:
+    * sha256 + keccak permutation scratch buffers (zkvm_sha256
+      and zkvm_keccak256 require these by label).
+    * SSZ merkleization scratch buffers (`ssz_merkleize_*`,
+      `ssz_hb_*`, `ssz_ltb_*`, `ssz_ew_field_roots`).
+    * `ssz_zero_hashes` lookup table (32 × 32 bytes).
+    * Header-validator pipeline scratch (`sg_header_lengths`,
+      `sg_kpr_valid`, `sg_kpr_bad_index`).
+    * Shared K-PR scratch (`zk3_state`, `rfu_offset`,
+      `rfu_length`) plus per-K-PR locals.
+    * SSZ sub-tree constants used by the
+      `compute_new_payload_request_root` computation at
+      `.Lsg_hash`: `npr_node_0_15`, `npr_node_16_17`,
+      `npr_versioned_hashes_root`, `npr_exec_requests_root`, and
+      legacy `npr_left_subtree` / `empty_npr_root` (currently
+      unreferenced but kept for context).
+    * Two scratch buffers `npr_sha_input` (64 bytes) and
+      `npr_sha_subtree` (32 bytes) plus `npr_exec_payload_root`
+      / `npr_left_subtree_scratch` (32 bytes each) for the
+      multi-step merkle computation.
+-/
+import EvmAsm.Codegen.Programs.Ssz
+
+namespace EvmAsm.Codegen
+
+def statelessGuestDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "sha256_w_iv:\n" ++
+  "  .quad 0xbb67ae856a09e667\n" ++
+  "  .quad 0xa54ff53a3c6ef372\n" ++
+  "  .quad 0x9b05688c510e527f\n" ++
+  "  .quad 0x5be0cd191f83d9ab\n" ++
+  ".balign 8\n" ++
+  "sha256_w_state:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "sha256_w_input:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "sha256_w_params:\n" ++
+  "  .quad sha256_w_state\n" ++
+  "  .quad sha256_w_input\n" ++
+  ".balign 32\n" ++
+  "ssz_merkleize_scratch:\n" ++
+  "  .zero 1024\n" ++
+  ".balign 32\n" ++
+  "ssz_merkleize_padded:\n" ++
+  "  .zero 1024\n" ++
+  ".balign 32\n" ++
+  "ssz_merkleize_partial:\n" ++
+  "  .zero 64\n" ++
+  ".balign 32\n" ++
+  "ssz_hb_chunks:\n" ++
+  "  .zero 1024\n" ++
+  ".balign 32\n" ++
+  "ssz_hb_partial:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "ssz_hb_mix:\n" ++
+  "  .zero 64\n" ++
+  ".balign 32\n" ++
+  "ssz_ltb_child_roots:\n" ++
+  "  .zero 1024\n" ++
+  ".balign 32\n" ++
+  "ssz_ltb_partial:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "ssz_ltb_mix:\n" ++
+  "  .zero 64\n" ++
+  ".balign 32\n" ++
+  "ssz_ew_field_roots:\n" ++
+  "  .zero 96\n" ++
+  sszZeroHashesDataSection ++ "\n" ++
+  -- Header-validator pipeline scratch:
+  ".balign 8\n" ++
+  "sg_header_lengths:\n" ++
+  "  .zero 2048\n" ++          -- MAX_WITNESS_HEADERS (256) × 8 bytes
+  "sg_kpr_valid:\n" ++
+  "  .zero 8\n" ++
+  "sg_kpr_bad_index:\n" ++
+  "  .zero 8\n" ++
+  -- Shared K-PR scratch (zk3_state / rfu_offset / rfu_length: used by
+  -- rlp_list_nth_item + rlp_field_to_u64; same labels each K-PR
+  -- declares, declared once here):
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  -- K290 chain_validate_post_merge_full scratch:
+  "cvpmf_field:\n" ++
+  "  .zero 8\n" ++
+  "cvpmf_offset:\n" ++
+  "  .zero 8\n" ++
+  "cvpmf_length:\n" ++
+  "  .zero 8\n" ++
+  "cvpmf_iter_ptr:\n" ++
+  "  .zero 8\n" ++
+  "cvpmf_iter_i:\n" ++
+  "  .zero 8\n" ++
+  "cvpmf_empty_hash:\n" ++
+  "  .byte 0x1d, 0xcc, 0x4d, 0xe8, 0xde, 0xc7, 0x5d, 0x7a\n" ++
+  "  .byte 0xab, 0x85, 0xb5, 0x67, 0xb6, 0xcc, 0xd4, 0x1a\n" ++
+  "  .byte 0xd3, 0x12, 0x45, 0x1b, 0x94, 0x8a, 0x74, 0x13\n" ++
+  "  .byte 0xf0, 0xa1, 0x42, 0xfd, 0x40, 0xd4, 0x93, 0x47\n" ++
+  -- K291 chain_validate_extra_data_length scratch:
+  "cvedl_offset:\n" ++
+  "  .zero 8\n" ++
+  "cvedl_length:\n" ++
+  "  .zero 8\n" ++
+  "cvedl_iter_ptr:\n" ++
+  "  .zero 8\n" ++
+  "cvedl_iter_i:\n" ++
+  "  .zero 8\n" ++
+  -- K240 chain_validate_gas_used_under_limit scratch:
+  "cvgul_gas_used:\n" ++
+  "  .zero 8\n" ++
+  "cvgul_gas_limit:\n" ++
+  "  .zero 8\n" ++
+  "cvgul_iter_ptr:\n" ++
+  "  .zero 8\n" ++
+  "cvgul_iter_i:\n" ++
+  "  .zero 8\n" ++
+  -- K278 chain_validate_blob_gas_used_multiple scratch:
+  "cvbgm_field:\n" ++
+  "  .zero 8\n" ++
+  "cvbgm_iter_ptr:\n" ++
+  "  .zero 8\n" ++
+  "cvbgm_iter_i:\n" ++
+  "  .zero 8\n" ++
+  -- K277 chain_validate_blob_gas_used_under_max scratch:
+  "cvbgum_field:\n" ++
+  "  .zero 8\n" ++
+  "cvbgum_iter_ptr:\n" ++
+  "  .zero 8\n" ++
+  "cvbgum_iter_i:\n" ++
+  "  .zero 8\n" ++
+  -- K229 chain_validate_increasing_timestamps scratch:
+  "cvit_ts:\n" ++
+  "  .zero 8\n" ++
+  "cvit_iter_child:\n" ++
+  "  .zero 8\n" ++
+  "cvit_iter_i:\n" ++
+  "  .zero 8\n" ++
+  "cvit_iter_prev:\n" ++
+  "  .zero 8\n" ++
+  -- K230 chain_validate_consecutive_numbers scratch:
+  "cvcn_num:\n" ++
+  "  .zero 8\n" ++
+  "cvcn_iter_child:\n" ++
+  "  .zero 8\n" ++
+  "cvcn_iter_i:\n" ++
+  "  .zero 8\n" ++
+  "cvcn_iter_prev:\n" ++
+  "  .zero 8\n" ++
+  -- compute_new_payload_request_root(empty_input) -- the spec
+  -- hash for an empty `SszNewPayloadRequest`, independent of
+  -- chain_id. Was previously stamped at OUTPUT[0..32) by the
+  -- epilogue; now derived dynamically via the
+  -- exec_payload + NPR merkle computation in `.Lsg_hash`. Kept
+  -- here as a reference value for diff context.
+  -- (Verified against
+  --  `execution-specs/.../stateless.compute_new_payload_request_root`
+  --  on d7fe16ab8.)
+  ".balign 8\n" ++
+  "empty_npr_root:\n" ++
+  "  .byte 0xf7, 0x83, 0x79, 0x28, 0xaf, 0x2f, 0xf9, 0x7a\n" ++
+  "  .byte 0xdd, 0x39, 0x49, 0x6e, 0x3c, 0x72, 0xbc, 0xdf\n" ++
+  "  .byte 0xba, 0xdf, 0xfc, 0x45, 0x3d, 0xee, 0x6a, 0x58\n" ++
+  "  .byte 0x2c, 0xa2, 0xa5, 0xc7, 0xcc, 0x51, 0x2f, 0x71\n" ++
+  -- SSZ field roots / merkle sub-trees for the NPR computation
+  -- at `.Lsg_hash`. Under the currently-supported NPR class
+  -- (default execution_payload modulo slot_number; default
+  -- versioned_hashes; default execution_requests):
+  --
+  --   `npr_left_subtree` is sha256(field_root[execution_payload]
+  --     || field_root[versioned_hashes]) for the empty case --
+  --     LEGACY (was the precomputed left half before the
+  --     dynamic exec_payload merkle path landed). Kept as
+  --     unreferenced constant for context.
+  --   `npr_versioned_hashes_root` is field_root[versioned_hashes]
+  --     for the empty list; used as the right input to
+  --     `left_subtree = sha256(exec_payload_root || vh_root)`.
+  --   `npr_exec_requests_root` is field_root[execution_requests]
+  --     for the empty case; used as the right input to
+  --     `right_subtree = sha256(pbr || exec_requests_root)`.
+  --   `npr_node_0_15` is the merkle root over the 16 left
+  --     leaves of the default exec_payload Container (padded
+  --     to 32 leaves).
+  --   `npr_node_16_17` is sha256(leaf_16=ssz_zero_hash[0] ||
+  --     leaf_17=block_access_list_root_for_empty).
+  ".balign 8\n" ++
+  "npr_left_subtree:\n" ++
+  "  .byte 0x50, 0x57, 0xc2, 0x29, 0xce, 0xf7, 0x0b, 0x3d\n" ++
+  "  .byte 0x2f, 0xe3, 0x46, 0xe2, 0xd6, 0x19, 0x8f, 0x3d\n" ++
+  "  .byte 0xd5, 0x36, 0x5b, 0xd9, 0x65, 0x13, 0x22, 0xe8\n" ++
+  "  .byte 0x81, 0xa0, 0x99, 0x4c, 0xbd, 0x34, 0x30, 0x57\n" ++
+  ".balign 8\n" ++
+  "npr_exec_requests_root:\n" ++
+  "  .byte 0x85, 0xe2, 0x53, 0xb4, 0x05, 0x99, 0xd0, 0xdf\n" ++
+  "  .byte 0x75, 0x6b, 0xe0, 0x43, 0xea, 0x69, 0x49, 0xe4\n" ++
+  "  .byte 0x9a, 0x07, 0xe7, 0x56, 0xde, 0xef, 0x72, 0xb3\n" ++
+  "  .byte 0x58, 0x8a, 0x4b, 0x05, 0x36, 0x22, 0x06, 0xb5\n" ++
+  ".balign 8\n" ++
+  "npr_sha_input:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "npr_sha_subtree:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "npr_node_0_15:\n" ++
+  "  .byte 0x71, 0xfc, 0x71, 0x15, 0x80, 0xd1, 0x9a, 0x35\n" ++
+  "  .byte 0x16, 0x98, 0xda, 0xb1, 0x39, 0x16, 0x66, 0xd8\n" ++
+  "  .byte 0x49, 0xe0, 0x60, 0x9a, 0xea, 0x02, 0x09, 0x65\n" ++
+  "  .byte 0x15, 0x6b, 0x5e, 0x8d, 0x8c, 0x83, 0xa2, 0xe7\n" ++
+  ".balign 8\n" ++
+  "npr_node_16_17:\n" ++
+  "  .byte 0x95, 0xcc, 0x8c, 0xa6, 0xc4, 0xc1, 0x05, 0x66\n" ++
+  "  .byte 0x41, 0xe5, 0xad, 0x8d, 0xc6, 0xe5, 0x66, 0xae\n" ++
+  "  .byte 0x5e, 0x6f, 0xeb, 0x2c, 0x03, 0xde, 0x7a, 0xf8\n" ++
+  "  .byte 0xfc, 0x95, 0x84, 0x0f, 0x55, 0xdf, 0x8b, 0x8c\n" ++
+  ".balign 8\n" ++
+  "npr_versioned_hashes_root:\n" ++
+  "  .byte 0xdb, 0xa9, 0x67, 0x1b, 0xac, 0x95, 0x13, 0xc9\n" ++
+  "  .byte 0x48, 0x2f, 0x14, 0x16, 0xa5, 0x3a, 0xab, 0xd2\n" ++
+  "  .byte 0xc6, 0xce, 0x90, 0xd5, 0xa5, 0xf8, 0x65, 0xce\n" ++
+  "  .byte 0x5a, 0x55, 0xc7, 0x75, 0x32, 0x5c, 0x91, 0x36\n" ++
+  ".balign 8\n" ++
+  "npr_exec_payload_root:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "npr_left_subtree_scratch:\n" ++
+  "  .zero 32"
+
+end EvmAsm.Codegen

--- a/scripts/codegen-stateless-gen-fixture.py
+++ b/scripts/codegen-stateless-gen-fixture.py
@@ -64,6 +64,7 @@ ts_str = sys.argv[9]
 blob_str = sys.argv[10]
 hdr_hex = sys.argv[11]
 npr_pbr_hex = sys.argv[12] if len(sys.argv) > 12 else ''
+npr_slot_str = sys.argv[13] if len(sys.argv) > 13 else ''
 
 # Build the new-schema StatelessInput: empty new_payload_request,
 # witness whose 'state'/'codes' lists each hold zero or more
@@ -686,13 +687,17 @@ if pk_hex:
     pk_entries = pk_hex.split(':')
     pk_args = tuple(PkBV(bytes.fromhex(p)) for p in pk_entries)
 
+npr_kwargs = {}
 if npr_pbr_hex:
     from remerkleable.byte_arrays import Bytes32 as Bytes32SSZ
-    npr = SszNewPayloadRequest(
-        parent_beacon_block_root=Bytes32SSZ(bytes.fromhex(npr_pbr_hex)),
+    npr_kwargs['parent_beacon_block_root'] = Bytes32SSZ(bytes.fromhex(npr_pbr_hex))
+if npr_slot_str:
+    from ethereum.forks.amsterdam.stateless_ssz import SszExecutionPayload
+    from remerkleable.basic import uint64 as Uint64SSZ
+    npr_kwargs['execution_payload'] = SszExecutionPayload(
+        slot_number=Uint64SSZ(int(npr_slot_str, 0)),
     )
-else:
-    npr = SszNewPayloadRequest()
+npr = SszNewPayloadRequest(**npr_kwargs)
 
 ssz_input = SszStatelessInput(
     new_payload_request=npr,

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -81,6 +81,7 @@ run_fixture() {
   local blob_schedule="${9:-}"
   local witness_headers_hex="${10:-}"
   local npr_pbr_hex="${11:-}"
+  local npr_slot_str="${12:-}"
 
   local safe="${label//[^0-9A-Za-z_]/_}"
   local input_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.input"
@@ -88,8 +89,8 @@ run_fixture() {
   local spec_exp_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.spec-expected"
   local log_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.emu.log"
 
-  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty}, npr_pbr=${npr_pbr_hex:-empty})"
-  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex" "$npr_pbr_hex"
+  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty}, npr_pbr=${npr_pbr_hex:-empty}, npr_slot=${npr_slot_str:-empty})"
+  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex" "$npr_pbr_hex" "$npr_slot_str"
 
   # Guard against silent fail: if the spec generator crashed
   # (Python syntax error in the heredoc, missing import, etc.)
@@ -197,6 +198,17 @@ run_fixture "chain_sepolia_amsterdam" 11155111         4    ""           ""     
 # previously-shipped fixtures (pbr=zero), the computation
 # reproduces the empty_npr_root constant exactly.
 run_fixture "chain1_npr_pbr_ff" 1                      0    ""           ""                  ""    ""           ""           ""    ""                       "$(printf 'ff%.0s' {1..32})" || fail=1
+
+# Non-empty execution_payload: slot_number = 0x1234, all other
+# execution_payload fields default. The 19-field SSZ Container
+# merkleization tree changes at leaf 18 (slot_number's field
+# index), which propagates up 5 levels to a new
+# exec_payload_root, then through the NPR merkle to a new
+# top-level root. Drives the encoder past its current
+# pbr-only computation by adding the exec_payload merkle path
+# (5 extra sha256 calls + 2 new sibling constants `node_0_15`
+# and `node_16_17`).
+run_fixture "chain1_npr_exec_payload_slot_1234" 1      0    ""           ""                  ""    ""           ""           ""    ""                       ""                                "4660" || fail=1
 
 # Edge: chain_id = 2^32 = 0x100000000. LE bytes
 # 00 00 00 00 01 00 00 00. The encoder's chain_id split


### PR DESCRIPTION
## Summary

Builds on #7081. The previous PR generalised NPR root to non-zero \`parent_beacon_block_root\`; this PR pushes the implementation one merkle subtree deeper.

**Initially-failing fixture:** \`chain1_npr_exec_payload_slot_1234\` sets \`NPR.execution_payload.slot_number = 0x1234\` (all other exec_payload fields default). The spec walks the 32-leaf SSZ merkle tree of \`SszExecutionPayload\` (19 fields padded), where \`slot_number\` sits at leaf 18; changing it propagates up 5 levels to a new \`exec_payload_root\`, then through the NPR's 4-leaf merkle to a new top-level root.

**Smallest implementation step:** extend the \`.Lsg_hash\` computation from 2 \`sha256\` calls (pbr-only NPR merkle) to 8 (5 exec_payload merkle path + 3 NPR top-level).

## New constants

The exec_payload path uses two new \`.data\` constants for the non-zero default leaves on the path:

| constant | meaning |
| -------- | ------- |
| \`npr_node_0_15\` | merkle root of leaves 0..15 (default exec_payload field roots) |
| \`npr_node_16_17\` | \`sha256(leaf_16=zero \|\| leaf_17=block_access_list_root_for_empty)\` |

The remaining siblings on the path (\`leaf_19\`, \`node_20_23\`, \`node_24_31\`) are existing \`ssz_zero_hashes[i]\` entries.

The previous PR's \`npr_left_subtree\` constant is now unreferenced; replaced by dynamic \`sha256(exec_payload_root || vh_root)\` so exec_payload changes propagate correctly. \`vh_root\` and \`exec_requests_root\` are still \`.data\` constants (their input classes haven't been opened up yet).

## File-size carve-out

The new asm pushed \`Programs.lean\` over the hard cap. \`statelessGuestDataSection\` is lifted into the new \`EvmAsm/Codegen/Programs/StatelessGuestData.lean\` submodule.

| file | before | after |
| ---- | ------ | ----- |
| \`Programs.lean\` | 1373 | 1172 |
| \`StatelessGuestData.lean\` | — | 244 (new) |
| \`hardCap\` | 1328 | 1328 (unchanged — \`Mpt.lean\` still sits at 1327, so the cap can't drop further without secondary carves) |

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass: the 80+ existing (pbr=zero + slot=0 paths reproduce \`empty_npr_root\`) plus the new \`chain1_npr_pbr_ff\` and \`chain1_npr_exec_payload_slot_1234\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)