### PR TITLE
feat(div): add v5 Phase-2a cap block to divK_div128_v5

### DIFF
--- a/EvmAsm/Evm64/DivMod/Program.lean
+++ b/EvmAsm/Evm64/DivMod/Program.lean
@@ -344,28 +344,33 @@ def divK_div128_v4 : Program :=
   -- Total: 75 instructions (61 v2 + 14 for Phase 2b 2nd D3 + save/restore)
 
 /-- **v5** 128/64-bit unsigned division subroutine — repairs the two
-    buggy ULTs in `divK_div128_v4` (PR #7077, PR #7080). This bead
-    `evm-asm-wbc4i.3.1` introduces the def with the **Phase-1a cap**
-    only; Phase-2a is still the v4-style `q0 - 1` and will be replaced
-    in bead `evm-asm-wbc4i.3.2`. Matches the math model `div128Quot_v5`
-    in `LoopDefs/IterV5.lean` once Phase-2a lands.
+    buggy ULTs in `divK_div128_v4` (PR #7077, PR #7080). Matches the
+    math model `div128Quot_v5` in `LoopDefs/IterV5.lean`. Beads
+    `evm-asm-wbc4i.3.1` (Phase-1a) and `evm-asm-wbc4i.3.2` (Phase-2a).
 
-    **Phase-1a cap (this bead, v5 change)**: when `hi1 = q1 >> 32 ≠ 0`,
-    cap `q1c := 0xFFFFFFFF` (instead of `q1 - 1`) and recompute
-    `rhatc := rhat + (q1 - q1c) * dHi` (algebraically equal to
-    `uHi - q1c * dHi` since `rhat = uHi - q1 * dHi`). This guarantees
-    `q1c < 2^32` unconditionally so the downstream `q1c * dLo` cannot
-    wrap mod 2^64.
+    **Phase-1a cap**: when `hi1 = q1 >> 32 ≠ 0`, cap `q1c := 0xFFFFFFFF`
+    (instead of `q1 - 1`) and recompute `rhatc := rhat + (q1 - q1c)*dHi`
+    (algebraically `uHi - q1c*dHi` since `rhat = uHi - q1*dHi`).
 
-    **Layout** (79 instructions = 75 v4 + 4 for Phase-1a cap expansion):
+    **Phase-2a cap** (this bead): analogous — when `hi2 = q0 >> 32 ≠ 0`,
+    cap `q0c := 0xFFFFFFFF` and recompute `rhat2c := rhat2 + (q0 - q0c)*dHi`.
+
+    The two caps together guarantee `q1c, q0c < 2^32` unconditionally so
+    that `q1c * dLo` and `q0c * dLo` cannot wrap mod 2^64. PR #7080's
+    `cePlus2_*` and `ceUnd_*` inputs no longer violate the Knuth-A `+1`
+    bound under this program (to be proven in beads `.4` and `.5`).
+
+    **Layout** (83 instructions = 75 v4 + 4 Phase-1a + 4 Phase-2a):
     - [0..12]: identical to v4 (setup + DIVU + rhat).
     - [13..20]: v5 Phase-1a cap block (8 inst, vs v4's 4 at [13..16]).
-    - [21..78]: v4 instructions [17..74] shifted by +4 indices.
+    - [21..46]: v4 instructions [17..42] shifted by +4 indices.
+    - [47..54]: v5 Phase-2a cap block (8 inst, vs v4's 4 at [43..46]).
+    - [55..82]: v4 instructions [47..74] shifted by +8 indices.
 
-    All forward branches in v4 either target instructions in the same
-    segment (relative offset preserved when both endpoints shift) or
-    are the [14] Phase-1a BEQ which is re-targeted from `12` to `28`
-    bytes to skip the 6-instruction taken branch. -/
+    Forward branches in the original v4 either jump within a single
+    shifted segment (relative offset preserved) or are the [14] / [48]
+    cap BEQs which are re-targeted from `12` to `28` bytes to skip
+    each 6-instruction taken branch. -/
 def divK_div128_v5 : Program :=
   -- Save return addr and d
   SD .x12 .x2 3968 ;;                         -- [0]  save return addr
@@ -421,56 +426,58 @@ def divK_div128_v5 : Program :=
   single (.DIVU .x5 .x7 .x6) ;;              -- [44] x5 = q0
   single (.MUL .x9 .x5 .x6) ;;               -- [45]
   single (.SUB .x11 .x7 .x9) ;;              -- [46] x11 = rhat2
-  -- [47] Phase-2a v4-style refine (q0 := q0 - 1 when hi2 ≠ 0).
-  -- TODO(bead evm-asm-wbc4i.3.2): replace with v5 cap (analogous to
-  -- Phase-1a [13..20] above). Until that bead lands, `divK_div128_v5`
-  -- still has the Phase-2 wrap bug from PR #7080.
-  SRLI .x9 .x5 32 ;;                          -- [47]
-  single (.BEQ .x9 .x0 12) ;;                -- [48] skip if q0 < 2^32 → [51]
-  ADDI .x5 .x5 4095 ;;                        -- [49] q0--
-  single (.ADD .x11 .x11 .x6) ;;             -- [50] rhat2 += dHi
-  -- [51] Phase 2b guard (= v4 [47])
-  SRLI .x9 .x11 32 ;;                         -- [51] x9 = rhat2c >> 32
-  single (.BNE .x9 .x0 92) ;;                -- [52] if nonzero → skip to [75] (combine)
-  -- [53] Phase 2b 1st D3 mul-check (= v4 [49])
-  LD .x9 .x12 3952 ;;                         -- [53] dLo
-  single (.MUL .x7 .x5 .x9) ;;               -- [54] x7 = q0c * dLo
-  SLLI .x9 .x11 32 ;;                         -- [55] rhat2c << 32
-  SD .x12 .x11 3936 ;;                        -- [56] save rhat2c (NEW in v4)
-  LD .x11 .x12 3944 ;;                        -- [57] x11 = un0 (clobbers rhat2c)
-  single (.OR .x9 .x9 .x11) ;;               -- [58] x9 = rhat2c*2^32 + un0
-  single (.BLTU .x9 .x7 12) ;;               -- [59] if BLTU fires → correction [62]
-  -- [60] No-correction path
-  LD .x11 .x12 3936 ;;                        -- [60] restore rhat2c
-  JAL .x0 16 ;;                                -- [61] skip correction → [65] (2nd D3 entry)
-  -- [62] Correction path
-  ADDI .x5 .x5 4095 ;;                        -- [62] q0c--
-  LD .x11 .x12 3936 ;;                        -- [63] restore rhat2c
-  single (.ADD .x11 .x11 .x6) ;;             -- [64] rhat2c += dHi
-  -- [65] Phase 2b 2nd D3 guarded mul-check (= v4 [61])
-  SRLI .x9 .x11 32 ;;                         -- [65] x9 = rhat2c >> 32 (post-1st-correction)
-  single (.BNE .x9 .x0 36) ;;                -- [66] if nonzero → skip to [75] (combine)
-  LD .x9 .x12 3952 ;;                         -- [67] dLo
-  single (.MUL .x7 .x5 .x9) ;;               -- [68] x7 = q0c * dLo
-  SLLI .x9 .x11 32 ;;                         -- [69] rhat2c << 32
-  LD .x11 .x12 3944 ;;                        -- [70] x11 = un0
-  single (.OR .x9 .x9 .x11) ;;               -- [71] x9 = rhat2c*2^32 + un0
-  single (.BLTU .x9 .x7 8) ;;                -- [72] if BLTU fires → 2nd correction [74]
-  JAL .x0 8 ;;                                 -- [73] skip → [75]
-  ADDI .x5 .x5 4095 ;;                        -- [74] 2nd correction: q0c--
-  -- [75] Combine: q = q1c*2^32 + q0c (= v4 [71])
-  SLLI .x11 .x10 32 ;;                        -- [75] q1c << 32
-  single (.OR .x11 .x11 .x5) ;;              -- [76] x11 = q
+  -- [47] v5 Phase-2a cap: clamp q0c at 2^32 - 1, recompute rhat2c.
+  -- Mirror of Phase-1a above. Reuses x7 (= un21, dead from here on
+  -- until [54] writes it) as the diff scratch.
+  SRLI .x9 .x5 32 ;;                          -- [47] x9 = hi2 = q0 >> 32
+  single (.BEQ .x9 .x0 28) ;;                -- [48] skip if hi2 == 0 → [55]
+  ADDI .x9 .x0 4095 ;;                        -- [49] x9 = -1 = 0xFFFFFFFFFFFFFFFF
+  SRLI .x9 .x9 32 ;;                          -- [50] x9 = 0xFFFFFFFF (q0cCap)
+  single (.SUB .x7 .x5 .x9) ;;               -- [51] x7 = q0 - q0cCap
+  single (.MUL .x7 .x7 .x6) ;;               -- [52] x7 = (q0 - q0cCap) * dHi
+  single (.ADD .x11 .x11 .x7) ;;             -- [53] x11 = rhat2 + diff*dHi = rhat2c
+  ADDI .x5 .x9 0 ;;                           -- [54] x5 = q0c = q0cCap (MV via ADDI 0)
+  -- [55] Phase 2b guard (= v4 [47])
+  SRLI .x9 .x11 32 ;;                         -- [55] x9 = rhat2c >> 32
+  single (.BNE .x9 .x0 92) ;;                -- [56] if nonzero → skip to [79] (combine)
+  -- [57] Phase 2b 1st D3 mul-check (= v4 [49])
+  LD .x9 .x12 3952 ;;                         -- [57] dLo
+  single (.MUL .x7 .x5 .x9) ;;               -- [58] x7 = q0c * dLo
+  SLLI .x9 .x11 32 ;;                         -- [59] rhat2c << 32
+  SD .x12 .x11 3936 ;;                        -- [60] save rhat2c
+  LD .x11 .x12 3944 ;;                        -- [61] x11 = un0 (clobbers rhat2c)
+  single (.OR .x9 .x9 .x11) ;;               -- [62] x9 = rhat2c*2^32 + un0
+  single (.BLTU .x9 .x7 12) ;;               -- [63] if BLTU fires → correction [66]
+  -- [64] No-correction path
+  LD .x11 .x12 3936 ;;                        -- [64] restore rhat2c
+  JAL .x0 16 ;;                                -- [65] skip correction → [69] (2nd D3 entry)
+  -- [66] Correction path
+  ADDI .x5 .x5 4095 ;;                        -- [66] q0c--
+  LD .x11 .x12 3936 ;;                        -- [67] restore rhat2c
+  single (.ADD .x11 .x11 .x6) ;;             -- [68] rhat2c += dHi
+  -- [69] Phase 2b 2nd D3 guarded mul-check (= v4 [61])
+  SRLI .x9 .x11 32 ;;                         -- [69] x9 = rhat2c >> 32 (post-1st-correction)
+  single (.BNE .x9 .x0 36) ;;                -- [70] if nonzero → skip to [79] (combine)
+  LD .x9 .x12 3952 ;;                         -- [71] dLo
+  single (.MUL .x7 .x5 .x9) ;;               -- [72] x7 = q0c * dLo
+  SLLI .x9 .x11 32 ;;                         -- [73] rhat2c << 32
+  LD .x11 .x12 3944 ;;                        -- [74] x11 = un0
+  single (.OR .x9 .x9 .x11) ;;               -- [75] x9 = rhat2c*2^32 + un0
+  single (.BLTU .x9 .x7 8) ;;                -- [76] if BLTU fires → 2nd correction [78]
+  JAL .x0 8 ;;                                 -- [77] skip → [79]
+  ADDI .x5 .x5 4095 ;;                        -- [78] 2nd correction: q0c--
+  -- [79] Combine: q = q1c*2^32 + q0c (= v4 [71])
+  SLLI .x11 .x10 32 ;;                        -- [79] q1c << 32
+  single (.OR .x11 .x11 .x5) ;;              -- [80] x11 = q
   -- Restore and return
-  LD .x2 .x12 3968 ;;                         -- [77] restore return addr
-  JALR .x0 .x2 0                              -- [78] return
-  -- Total: 79 instructions (v4's 75 + 4 for Phase-1a cap expansion).
-  -- Phase-2a still v4-style — bead evm-asm-wbc4i.3.2 will add +4 more.
+  LD .x2 .x12 3968 ;;                         -- [81] restore return addr
+  JALR .x0 .x2 0                              -- [82] return
+  -- Total: 83 instructions (v4's 75 + 4 Phase-1a + 4 Phase-2a).
 
-/-- Phase-1a v5 cap sanity check: at the structural level, the cap
-    immediate is `0xFFFFFFFF`. Constructed as `(0xFF...FF) >>> 32`
-    via `ADDI .x5 .x0 4095 ;; SRLI .x5 .x5 32`. -/
-theorem divK_div128_v5_phase_1a_cap_eq :
+/-- Cap sanity check (Phase-1a and Phase-2a both): at the structural
+    level, the cap immediate is `0xFFFFFFFF`. Constructed in-program
+    as `(0xFF...FF) >>> 32` via `ADDI .x_ .x0 4095 ;; SRLI .x_ .x_ 32`. -/
+theorem divK_div128_v5_cap_eq :
     ((BitVec.allOnes 64) >>> (32 : BitVec 6).toNat : BitVec 64) =
       (0xFFFFFFFF : BitVec 64) := by
   decide


### PR DESCRIPTION
## Summary

- Adds the v5 Phase-2a cap block to `divK_div128_v5` (bead `evm-asm-wbc4i.3.2`). Mirror of the Phase-1a cap from PR #7084: when `hi2 = q0 >> 32 ≠ 0`, cap `q0c := 0xFFFFFFFF` and recompute `rhat2c := rhat2 + (q0 - q0cCap)*dHi` (= `un21 - q0c*dHi`). Reuses `x7` (= un21, dead from [47]) as the diff scratch.
- With both caps in place `q1c, q0c < 2^32` unconditionally so `q1c*dLo` and `q0c*dLo` cannot wrap mod 2^64 — the Phase-2 overshoot bug from PR #7080 is eliminated at the program level.
- Net program length 79 → 83 (+4 for Phase-2a expansion). All forward branches from old [51..78] keep their relative offsets; only the new Phase-2a BEQ is targeted at 28 bytes (mirroring Phase-1a).
- Renames the structural cap-sanity theorem from `divK_div128_v5_phase_1a_cap_eq` to `divK_div128_v5_cap_eq` since the same constant gates both phases.

**Stacked on PR #7084** (V5.3.1 Phase-1a). Review/merge that first.

Refs #61. Bead: evm-asm-wbc4i.3.2.

Authored by @pirapira; implemented by Claude Code
