### PR TITLE
feat(div): add divK_div128_v5_len = 83 length lemma + skipBlock entry

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -38,6 +38,7 @@ theorem divK_nop_len : (ADDI .x0 .x0 0 : Program).length = 1 := by decide
 theorem divK_div128_len : divK_div128.length = 51 := by decide
 theorem divK_div128_v2_len : divK_div128_v2.length = 61 := by decide
 theorem divK_div128_v4_len : divK_div128_v4.length = 75 := by decide
+theorem divK_div128_v5_len : divK_div128_v5.length = 83 := by decide
 theorem divK_modEpilogue_len : (divK_mod_epilogue 24).length = 10 := by decide
 
 /-- Skip one ofProg block in a right-nested union via range disjointness.
@@ -49,7 +50,7 @@ macro "skipBlock" : tactic =>
           divK_normB_len, divK_normA_len, divK_copyAU_len, divK_loopSetup_len,
           divK_loopBody_len, divK_denorm_len, divK_divEpilogue_len,
           divK_zeroPath_len, divK_nop_len, divK_div128_len, divK_div128_v2_len,
-          divK_div128_v4_len, divK_modEpilogue_len] at hk1 hk2
+          divK_div128_v4_len, divK_div128_v5_len, divK_modEpilogue_len] at hk1 hk2
         bv_omega)))
 
 -- ============================================================================


### PR DESCRIPTION
## Summary

- Adds `theorem divK_div128_v5_len : divK_div128_v5.length = 83 := by decide` to `EvmAsm/Evm64/DivMod/Compose/Base.lean`, alongside the existing `divK_div128_v4_len = 75`. Bead `evm-asm-wbc4i.3.3`.
- Wires `divK_div128_v5_len` into the `skipBlock` macro's simp set so downstream `Compose`-style proofs that walk the program code via `CodeReq.ofProg` pick up the v5 program's length when computing block ranges.

**Stacked on PR #7084 (V5.3.1) → PR #7085 (V5.3.2)**.

Refs #61. Bead: evm-asm-wbc4i.3.3.

Authored by @pirapira; implemented by Claude Code
