### PR TITLE
feat(stateless): compute node_16_17 dynamically (support excess_blob_gas)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -308,7 +308,23 @@ def statelessGuestEpilogue : String :=
   "  li s6, 0x40000000\n" ++
   "  addi s6, s6, 18             # s6 = SSZ_BASE\n" ++
   "  # \n" ++
-  "  # ===== exec_payload merkle path (leaves 16-31, leaf 18=slot_number) =====\n" ++
+  "  # ===== exec_payload merkle path (leaves 16-31) =====\n" ++
+  "  # node_16_17 = sha256(leaf_16 || leaf_17) where\n" ++
+  "  #   leaf_16 = excess_blob_gas (u64 LE @ SSZ_BASE + 16 + 44 + 520\n" ++
+  "  #             = +580) || 24 bytes zero padding\n" ++
+  "  #   leaf_17 = npr_leaf_17_bal_root (block_access_list_root for\n" ++
+  "  #             the empty/default ByteList -- constant)\n" ++
+  "  la t1, npr_sha_input\n" ++
+  "  ld t2, 580(s6)              # excess_blob_gas\n" ++
+  "  sd t2,  0(t1)\n" ++
+  "  sd zero,  8(t1); sd zero, 16(t1); sd zero, 24(t1)\n" ++
+  "  la t3, npr_leaf_17_bal_root\n" ++
+  "  ld t2,  0(t3); sd t2, 32(t1)\n" ++
+  "  ld t2,  8(t3); sd t2, 40(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 48(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 56(t1)\n" ++
+  "  la a0, npr_sha_input; li a1, 64; la a2, npr_node_16_17_scratch\n" ++
+  "  jal ra, zkvm_sha256         # node_16_17 -> npr_node_16_17_scratch\n" ++
   "  # leaf_18 = slot_number (u64 LE at SSZ_BASE + 16 + 44 + 532 = +592)\n" ++
   "  #          || 24 bytes of zero padding\n" ++
   "  la t1, npr_sha_input\n" ++
@@ -319,9 +335,9 @@ def statelessGuestEpilogue : String :=
   "  sd zero, 32(t1); sd zero, 40(t1); sd zero, 48(t1); sd zero, 56(t1)\n" ++
   "  la a0, npr_sha_input; li a1, 64; la a2, npr_sha_subtree\n" ++
   "  jal ra, zkvm_sha256         # node_18_19 -> npr_sha_subtree\n" ++
-  "  # node_16_19 = sha256(node_16_17 || node_18_19)\n" ++
+  "  # node_16_19 = sha256(node_16_17_scratch || node_18_19)\n" ++
   "  la t1, npr_sha_input\n" ++
-  "  la t3, npr_node_16_17\n" ++
+  "  la t3, npr_node_16_17_scratch\n" ++
   "  ld t2,  0(t3); sd t2,  0(t1)\n" ++
   "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
   "  ld t2, 16(t3); sd t2, 16(t1)\n" ++

--- a/EvmAsm/Codegen/Programs/StatelessGuestData.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuestData.lean
@@ -239,6 +239,25 @@ def statelessGuestDataSection : String :=
   "  .zero 32\n" ++
   ".balign 8\n" ++
   "npr_left_subtree_scratch:\n" ++
+  "  .zero 32\n" ++
+  -- `npr_leaf_17_bal_root` is the SSZ hash_tree_root of an
+  -- empty `block_access_list` (ByteList[MAX_BLOCK_ACCESS_LIST_BYTES]),
+  -- = leaf 17 of the default exec_payload merkle tree. Now that
+  -- the `.Lsg_hash` epilogue computes `node_16_17` dynamically
+  -- (to support non-default `excess_blob_gas` = leaf 16), only
+  -- leaf 17 needs to be precomputed as a constant; the prior
+  -- `npr_node_16_17` is no longer referenced but kept for
+  -- diff-context.
+  -- `npr_node_16_17_scratch` is the 32-byte buffer that holds
+  -- the dynamic sha256(leaf_16 || npr_leaf_17_bal_root).
+  ".balign 8\n" ++
+  "npr_leaf_17_bal_root:\n" ++
+  "  .byte 0x0e, 0x61, 0x79, 0x77, 0x4d, 0x9c, 0x1f, 0x78\n" ++
+  "  .byte 0x0c, 0x91, 0xa6, 0x89, 0x68, 0xa1, 0x43, 0xb5\n" ++
+  "  .byte 0xff, 0xd2, 0xf1, 0x8c, 0x2c, 0x01, 0xa2, 0xe8\n" ++
+  "  .byte 0x50, 0x16, 0xe1, 0x2a, 0x8c, 0x78, 0x1a, 0x0b\n" ++
+  ".balign 8\n" ++
+  "npr_node_16_17_scratch:\n" ++
   "  .zero 32"
 
 end EvmAsm.Codegen

--- a/scripts/codegen-stateless-gen-fixture.py
+++ b/scripts/codegen-stateless-gen-fixture.py
@@ -65,6 +65,7 @@ blob_str = sys.argv[10]
 hdr_hex = sys.argv[11]
 npr_pbr_hex = sys.argv[12] if len(sys.argv) > 12 else ''
 npr_slot_str = sys.argv[13] if len(sys.argv) > 13 else ''
+npr_excess_blob_str = sys.argv[14] if len(sys.argv) > 14 else ''
 
 # Build the new-schema StatelessInput: empty new_payload_request,
 # witness whose 'state'/'codes' lists each hold zero or more
@@ -735,12 +736,15 @@ npr_kwargs = {}
 if npr_pbr_hex:
     from remerkleable.byte_arrays import Bytes32 as Bytes32SSZ
     npr_kwargs['parent_beacon_block_root'] = Bytes32SSZ(bytes.fromhex(npr_pbr_hex))
-if npr_slot_str:
+if npr_slot_str or npr_excess_blob_str:
     from ethereum.forks.amsterdam.stateless_ssz import SszExecutionPayload
     from remerkleable.basic import uint64 as Uint64SSZ
-    npr_kwargs['execution_payload'] = SszExecutionPayload(
-        slot_number=Uint64SSZ(int(npr_slot_str, 0)),
-    )
+    ep_kwargs = {}
+    if npr_slot_str:
+        ep_kwargs['slot_number'] = Uint64SSZ(int(npr_slot_str, 0))
+    if npr_excess_blob_str:
+        ep_kwargs['excess_blob_gas'] = Uint64SSZ(int(npr_excess_blob_str, 0))
+    npr_kwargs['execution_payload'] = SszExecutionPayload(**ep_kwargs)
 npr = SszNewPayloadRequest(**npr_kwargs)
 
 ssz_input = SszStatelessInput(

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -82,6 +82,7 @@ run_fixture() {
   local witness_headers_hex="${10:-}"
   local npr_pbr_hex="${11:-}"
   local npr_slot_str="${12:-}"
+  local npr_excess_blob_str="${13:-}"
 
   local safe="${label//[^0-9A-Za-z_]/_}"
   local input_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.input"
@@ -89,8 +90,8 @@ run_fixture() {
   local spec_exp_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.spec-expected"
   local log_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.emu.log"
 
-  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty}, npr_pbr=${npr_pbr_hex:-empty}, npr_slot=${npr_slot_str:-empty})"
-  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex" "$npr_pbr_hex" "$npr_slot_str"
+  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty}, npr_pbr=${npr_pbr_hex:-empty}, npr_slot=${npr_slot_str:-empty}, npr_excess_blob=${npr_excess_blob_str:-empty})"
+  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex" "$npr_pbr_hex" "$npr_slot_str" "$npr_excess_blob_str"
 
   # Guard against silent fail: if the spec generator crashed
   # (Python syntax error in the heredoc, missing import, etc.)
@@ -209,6 +210,17 @@ run_fixture "chain1_npr_pbr_ff" 1                      0    ""           ""     
 # (5 extra sha256 calls + 2 new sibling constants `node_0_15`
 # and `node_16_17`).
 run_fixture "chain1_npr_exec_payload_slot_1234" 1      0    ""           ""                  ""    ""           ""           ""    ""                       ""                                "4660" || fail=1
+
+# Non-empty execution_payload: excess_blob_gas = 0x2A
+# (leaf 16 in the exec_payload Container's 32-leaf merkle).
+# Until now `npr_node_16_17` was a precomputed constant in
+# `.data`; this PR replaces it with a dynamic
+#   sha256(leaf_16 || npr_leaf_17_block_access_list_root)
+# computation -- one extra sha256 call in `.Lsg_hash`.
+# For pre-existing fixtures (excess_blob_gas=0), the dynamic
+# computation reproduces the old constant byte-for-byte
+# because leaf_16 = ssz_zero_hash[0].
+run_fixture "chain1_npr_exec_payload_excess_blob_42" 1 0    ""           ""                  ""    ""           ""           ""    ""                       ""                                ""    "42" || fail=1
 
 # Edge: chain_id = 2^32 = 0x100000000. LE bytes
 # 00 00 00 00 01 00 00 00. The encoder's chain_id split


### PR DESCRIPTION
## Summary

Builds on #7083. The previous PR generalised NPR root to non-zero \`execution_payload.slot_number\`; this PR pushes the implementation one merkle leaf further into the same subtree.

**Initially-failing fixture:** \`chain1_npr_exec_payload_excess_blob_42\` sets \`NPR.execution_payload.excess_blob_gas = 0x2A\` (leaf 16 in the exec_payload Container's 32-leaf merkle tree; all other exec_payload fields default).

**Smallest implementation step:** replace the precomputed \`npr_node_16_17\` \`.data\` constant with a dynamic \`sha256(leaf_16 || npr_leaf_17_bal_root)\` computation at \`.Lsg_hash\`. One extra sha256 call (8 → 9 total).

| new symbol | meaning |
| ---------- | ------- |
| \`npr_leaf_17_bal_root\` | SSZ \`hash_tree_root\` of empty \`block_access_list\` (= leaf 17 of the default exec_payload merkle). |
| \`npr_node_16_17_scratch\` | 32-byte scratch holding dynamic \`node_16_17\`. |

\`excess_blob_gas\` is read from the input at \`SSZ_BASE + 16 + 44 + 520 = SSZ_BASE + 580\` (NPR_addr = SSZ_BASE+16; exec_payload_addr = NPR+44; \`excess_blob_gas\` inline at \`exec_payload + 520\`).

For all pre-existing fixtures (\`excess_blob_gas=0\`), the dynamic computation reproduces the old \`npr_node_16_17\` constant byte-for-byte because \`leaf_16 = ssz_zero_hash[0]\` and the static constant was exactly \`sha256(0 || leaf_17)\`. So the existing 80+ fixtures continue to pass.

The legacy \`npr_node_16_17\` constant remains in \`StatelessGuestData.lean\` but is now unreferenced (kept for diff-context).

## Surface

| file | change |
| ---- | ------ |
| \`scripts/codegen-stateless-spec-output-check.sh\` | 13th optional positional arg \`npr_excess_blob_str\`; new fixture \`chain1_npr_exec_payload_excess_blob_42\`. |
| \`scripts/codegen-stateless-gen-fixture.py\` | read \`sys.argv[14]\` as \`npr_excess_blob_str\`; when set, populate \`SszExecutionPayload(excess_blob_gas=...)\`. |
| \`EvmAsm/Codegen/Programs.lean\` | new sha256 step at top of exec_payload merkle path computes \`node_16_17\` dynamically; subsequent uses now reference \`npr_node_16_17_scratch\` instead of the static constant. |
| \`EvmAsm/Codegen/Programs/StatelessGuestData.lean\` | new \`npr_leaf_17_bal_root\` constant and \`npr_node_16_17_scratch\` buffer. |

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass, including the new \`chain1_npr_exec_payload_excess_blob_42\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)