### PR TITLE
feat(div): add divKTrialCallV5* irreducibles (V5.2)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -47,6 +47,7 @@ import EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddback
 import EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeqV4NoNop
 import EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeqNamed
 import EvmAsm.Evm64.DivMod.LoopBody.TrialCallBounds
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCallV5
 import EvmAsm.Evm64.DivMod.Compose.SharedLoopPost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified

--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialCallV5.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialCallV5.lean
@@ -1,0 +1,236 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopBody.TrialCallV5
+
+  v5 irreducible aliases for the math-level trial-quotient values, mirroring
+  the v4 family in `LoopBody/TrialCall.lean` (lines 85-380). Bead
+  `evm-asm-wbc4i.2`.
+
+  These wrap each `let` binding from `div128Quot_v5` (in `LoopDefs/IterV5.lean`)
+  as an `@[irreducible] def` so that future `whnf`-heavy tactics (Knuth UB / LB
+  proofs under beads `.4` / `.5`) can reason about them as opaque names without
+  the entire let chain blowing up. The `*_eq_div128Quot_v5` theorem closes the
+  loop by showing the composition equals the math model.
+
+  v5 vs v4 differences (recapping the changes in `div128Quot_v5`):
+  - Phase-1a: `q1c := if hi1 = 0 then q1 else 0xFFFFFFFF` (the v5 cap, vs
+    v4's `q1 - 1`); `rhatc := if hi1 = 0 then rhat else uHi - q1c*dHi`
+    (recomputed, vs v4's `rhat + dHi`).
+  - Phase-1b 1st correction: guarded by `rhatc >>> 32 = 0` (vs v4's
+    unconditional ULT) — matches the guard already present in the 2nd
+    correction and in `div128Quot_phase2b_q0'`.
+  - Phase-2a: analogous cap on `q0c` and recomputed `rhat2c` from `un21`.
+  - Phase-1b 2nd correction, Phase-2 1st/2nd corrections, Phase-2 combine:
+    structurally identical to v4 (modulo upstream V5 values).
+-/
+
+import EvmAsm.Evm64.DivMod.LoopDefs.IterV5
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCall
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v5 `dHi = vTop >> 32`. Identical to v4. -/
+@[irreducible]
+def divKTrialCallV5DHi (vTop : Word) : Word :=
+  vTop >>> (32 : BitVec 6).toNat
+
+/-- v5 `dLo = (vTop << 32) >> 32`. Identical to v4. -/
+@[irreducible]
+def divKTrialCallV5DLo (vTop : Word) : Word :=
+  (vTop <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+
+/-- v5 `un1 = uLo >> 32`. Identical to v4. -/
+@[irreducible]
+def divKTrialCallV5Un1 (uLo : Word) : Word :=
+  uLo >>> (32 : BitVec 6).toNat
+
+/-- v5 `un0 = (uLo << 32) >> 32`. Identical to v4. -/
+@[irreducible]
+def divKTrialCallV5Un0 (uLo : Word) : Word :=
+  (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+
+/-- v5 Phase-1: `q1''` (= Q1dd) — the post-Phase-1b trial quotient.
+    Differs from v4 in: (a) Phase-1a `q1c` capped at `0xFFFFFFFF`;
+    (b) `rhatc` recomputed as `uHi - q1c*dHi`; (c) Phase-1b 1st
+    correction guarded by `rhatc >>> 32 = 0`. -/
+@[irreducible]
+def divKTrialCallV5Q1dd (uHi uLo vTop : Word) : Word :=
+  let dHi := divKTrialCallV5DHi vTop
+  let dLo := divKTrialCallV5DLo vTop
+  let un1 := divKTrialCallV5Un1 uLo
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+  let q1c := if hi1 = 0 then q1 else q1cCap
+  let rhatc := if hi1 = 0 then rhat else uHi - q1c * dHi
+  let qDlo := q1c * dLo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let phase1bFire1 :=
+    decide (rhatc >>> (32 : BitVec 6).toNat = 0) && BitVec.ult rhatUn1 qDlo
+  let q1' := if phase1bFire1 then q1c + signExtend12 4095 else q1c
+  let rhat' := if phase1bFire1 then rhatc + dHi else rhatc
+  let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
+  let qDlo2 := q1' * dLo
+  let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+  if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2 then q1' + signExtend12 4095 else q1'
+
+/-- v5 Phase-1: `rhat''` (= Rhatdd) — the post-Phase-1b remainder.
+    Mirrors `divKTrialCallV5Q1dd`'s control flow. -/
+@[irreducible]
+def divKTrialCallV5Rhatdd (uHi uLo vTop : Word) : Word :=
+  let dHi := divKTrialCallV5DHi vTop
+  let dLo := divKTrialCallV5DLo vTop
+  let un1 := divKTrialCallV5Un1 uLo
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+  let q1c := if hi1 = 0 then q1 else q1cCap
+  let rhatc := if hi1 = 0 then rhat else uHi - q1c * dHi
+  let qDlo := q1c * dLo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let phase1bFire1 :=
+    decide (rhatc >>> (32 : BitVec 6).toNat = 0) && BitVec.ult rhatUn1 qDlo
+  let q1' := if phase1bFire1 then q1c + signExtend12 4095 else q1c
+  let rhat' := if phase1bFire1 then rhatc + dHi else rhatc
+  let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
+  let qDlo2 := q1' * dLo
+  let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+  if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2 then rhat' + dHi else rhat'
+
+/-- v5 Phase-2 setup: `un21 = (rhat'' << 32 ||| un1) - q1'' * dLo`. -/
+@[irreducible]
+def divKTrialCallV5Un21 (uHi uLo vTop : Word) : Word :=
+  let un1 := divKTrialCallV5Un1 uLo
+  let q1'' := divKTrialCallV5Q1dd uHi uLo vTop
+  let rhat'' := divKTrialCallV5Rhatdd uHi uLo vTop
+  let cu_rhat_un1 := (rhat'' <<< (32 : BitVec 6).toNat) ||| un1
+  let cu_q1_dlo := q1'' * divKTrialCallV5DLo vTop
+  cu_rhat_un1 - cu_q1_dlo
+
+/-- v5 Phase-2a `rhat2c`. Differs from v4 in: the corrected branch uses
+    `un21 - q0c*dHi` (with `q0c = 0xFFFFFFFF`), not `rhat2 + dHi`. -/
+@[irreducible]
+def divKTrialCallV5Rhat2c (uHi uLo vTop : Word) : Word :=
+  let dHi := divKTrialCallV5DHi vTop
+  let un21 := divKTrialCallV5Un21 uHi uLo vTop
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi2 := q0 >>> (32 : BitVec 6).toNat
+  let q0cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+  if hi2 = 0 then rhat2 else un21 - q0cCap * dHi
+
+/-- v5 Phase-2a `q0c`. Differs from v4 in: the corrected branch uses
+    the cap `0xFFFFFFFF`, not `q0 - 1`. -/
+@[irreducible]
+def divKTrialCallV5Q0c (uHi uLo vTop : Word) : Word :=
+  let dHi := divKTrialCallV5DHi vTop
+  let un21 := divKTrialCallV5Un21 uHi uLo vTop
+  let q0 := rv64_divu un21 dHi
+  let hi2 := q0 >>> (32 : BitVec 6).toNat
+  let q0cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+  if hi2 = 0 then q0 else q0cCap
+
+/-- v5 Phase-2 1st D3 correction result (via `div128Quot_phase2b_q0'`,
+    which already has its own `rhat2c >>> 32 = 0` guard). -/
+@[irreducible]
+def divKTrialCallV5Q0d (uHi uLo vTop : Word) : Word :=
+  div128Quot_phase2b_q0'
+    (divKTrialCallV5Q0c uHi uLo vTop)
+    (divKTrialCallV5Rhat2c uHi uLo vTop)
+    (divKTrialCallV5DLo vTop)
+    (divKTrialCallV5Un0 uLo)
+
+/-- v5 Phase-2 1st D3 correction's `rhat` update. Structurally identical
+    to v4 (just over V5 upstreams). -/
+@[irreducible]
+def divKTrialCallV5Rhat2d (uHi uLo vTop : Word) : Word :=
+  let dHi := divKTrialCallV5DHi vTop
+  let dLo := divKTrialCallV5DLo vTop
+  let un0Div := divKTrialCallV5Un0 uLo
+  let q0c := divKTrialCallV5Q0c uHi uLo vTop
+  let rhat2c := divKTrialCallV5Rhat2c uHi uLo vTop
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let q0Dlo1 := q0c * dLo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0Div
+  if rhat2cHi = 0 then
+    if BitVec.ult rhat2Un0 q0Dlo1 then rhat2c + dHi else rhat2c
+  else rhat2c
+
+/-- v5 Phase-2 2nd D3 correction result (via `div128Quot_phase2b_q0'`).
+    Same as v4 modulo upstream V5 values. -/
+@[irreducible]
+def divKTrialCallV5Q0dd (uHi uLo vTop : Word) : Word :=
+  div128Quot_phase2b_q0'
+    (divKTrialCallV5Q0d uHi uLo vTop)
+    (divKTrialCallV5Rhat2d uHi uLo vTop)
+    (divKTrialCallV5DLo vTop)
+    (divKTrialCallV5Un0 uLo)
+
+/-- v5 final trial quotient: `(Q1dd << 32) ||| Q0dd`. -/
+@[irreducible]
+def divKTrialCallV5QHat (uHi uLo vTop : Word) : Word :=
+  (divKTrialCallV5Q1dd uHi uLo vTop <<< (32 : BitVec 6).toNat) |||
+    divKTrialCallV5Q0dd uHi uLo vTop
+
+/-- Rewrite `Q1dd` from its irreducible (flat-∧) Phase-1b 2nd D3 form
+    to the `div128Quot_phase2b_q0'` shape used by `div128Quot_v5`.
+    Reuses v4's `div128Quot_phase2b_q0'_and_form` lemma. -/
+theorem divKTrialCallV5Q1dd_eq_phase2b (uHi uLo vTop : Word) :
+    divKTrialCallV5Q1dd uHi uLo vTop =
+      (let dHi := divKTrialCallV5DHi vTop
+       let dLo := divKTrialCallV5DLo vTop
+       let un1 := divKTrialCallV5Un1 uLo
+       let q1 := rv64_divu uHi dHi
+       let rhat := uHi - q1 * dHi
+       let hi1 := q1 >>> (32 : BitVec 6).toNat
+       let q1cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+       let q1c := if hi1 = 0 then q1 else q1cCap
+       let rhatc := if hi1 = 0 then rhat else uHi - q1c * dHi
+       let qDlo := q1c * dLo
+       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+       let phase1bFire1 :=
+         decide (rhatc >>> (32 : BitVec 6).toNat = 0) && BitVec.ult rhatUn1 qDlo
+       let q1' := if phase1bFire1 then q1c + signExtend12 4095 else q1c
+       let rhat' := if phase1bFire1 then rhatc + dHi else rhatc
+       div128Quot_phase2b_q0' q1' rhat' dLo un1) := by
+  unfold divKTrialCallV5Q1dd
+  rw [div128Quot_phase2b_q0'_and_form]
+
+/-- Mirror of `divKTrialCallV5Q1dd_eq_phase2b` for `Rhatdd`. Uses v4's
+    `div128Quot_phase2b_rhat_and_form` to rewrite the flat-∧ form to
+    the nested-let-if shape in `div128Quot_v5`. -/
+theorem divKTrialCallV5Rhatdd_eq_phase2b (uHi uLo vTop : Word) :
+    divKTrialCallV5Rhatdd uHi uLo vTop =
+      (let dHi := divKTrialCallV5DHi vTop
+       let dLo := divKTrialCallV5DLo vTop
+       let un1 := divKTrialCallV5Un1 uLo
+       let q1 := rv64_divu uHi dHi
+       let rhat := uHi - q1 * dHi
+       let hi1 := q1 >>> (32 : BitVec 6).toNat
+       let q1cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+       let q1c := if hi1 = 0 then q1 else q1cCap
+       let rhatc := if hi1 = 0 then rhat else uHi - q1c * dHi
+       let qDlo := q1c * dLo
+       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+       let phase1bFire1 :=
+         decide (rhatc >>> (32 : BitVec 6).toNat = 0) && BitVec.ult rhatUn1 qDlo
+       let q1' := if phase1bFire1 then q1c + signExtend12 4095 else q1c
+       let rhat' := if phase1bFire1 then rhatc + dHi else rhatc
+       if rhat' >>> (32 : BitVec 6).toNat = 0 then
+         let qDlo2 := q1' * dLo
+         let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+         if BitVec.ult rhatUn1' qDlo2 then rhat' + dHi else rhat'
+       else rhat') := by
+  unfold divKTrialCallV5Rhatdd
+  rw [div128Quot_phase2b_rhat_and_form]
+
+-- NOTE: `divKTrialCallV5QHat_eq_div128Quot_v5` (the closure theorem that
+-- the irreducible composition equals `div128Quot_v5`) is left to a follow-up
+-- bead. The two bridging lemmas above (`Q1dd_eq_phase2b`, `Rhatdd_eq_phase2b`)
+-- give downstream proofs the structural rewrites they need without requiring
+-- a single monolithic `rfl` over the full let chain.
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -92,4 +92,5 @@ import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.UpperBound
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.ExactQuotient
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Algorithm
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.CapBounds
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.NoWrap
 import EvmAsm.Evm64.EvmWordArith.Div128CallSkipCloseV4

--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -90,4 +90,5 @@ import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Q1ddUndershootFromWideUn21
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.V4QHatBoundCounterexamples
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.UpperBound
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.ExactQuotient
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Algorithm
 import EvmAsm.Evm64.EvmWordArith.Div128CallSkipCloseV4

--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -91,4 +91,5 @@ import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.V4QHatBoundCounterexamples
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.UpperBound
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.ExactQuotient
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Algorithm
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.CapBounds
 import EvmAsm.Evm64.EvmWordArith.Div128CallSkipCloseV4

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Algorithm.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Algorithm.lean
@@ -1,0 +1,175 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Algorithm
+
+  v5 analog of `CallSkipLowerBoundV4/Algorithm.lean`. Provides named
+  `_unfold` lemmas for the v5 trial-call algorithm's irreducible
+  intermediate Word values, alongside three algorithm-level bundle
+  aliases (`algorithmUn21V5`, `algorithmQ1PrimeV5`, `algorithmQ0PrimeV5`)
+  that match the role of `algorithmQ1Prime` from v1/v2 chains.
+
+  Foundational for V5.4 (UB) and V5.5 (LB) proof chains under bead
+  `evm-asm-wbc4i.4.6` (filed 2026-05-28 as the V5.4.0 prerequisite).
+
+  v5 vs v4 differences (recap from `IterV5.lean` and `TrialCallV5.lean`):
+  - Phase-1a `q1c` capped at `0xFFFFFFFF`; `rhatc := uHi - q1c*dHi`.
+  - Phase-1b 1st correction guarded by `decide (rhatc >>> 32 = 0) && BLTU`.
+  - Phase-2a `q0c` analogously capped; `rhat2c := un21 - q0c*dHi`.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCallV5
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The v5 algorithm's `un21` output as a function of `(uHi, uLo, vTop)`.
+    Named bundle alias for `divKTrialCallV5Un21`. -/
+@[irreducible]
+def algorithmUn21V5 (uHi uLo vTop : Word) : Word :=
+  divKTrialCallV5Un21 uHi uLo vTop
+
+/-- Named unfold for `algorithmUn21V5`. -/
+theorem algorithmUn21V5_unfold (uHi uLo vTop : Word) :
+    algorithmUn21V5 uHi uLo vTop =
+      (let un1 := divKTrialCallV5Un1 uLo
+       let q1'' := divKTrialCallV5Q1dd uHi uLo vTop
+       let rhat'' := divKTrialCallV5Rhatdd uHi uLo vTop
+       let cu_rhat_un1 := (rhat'' <<< (32 : BitVec 6).toNat) ||| un1
+       let cu_q1_dlo := q1'' * divKTrialCallV5DLo vTop
+       cu_rhat_un1 - cu_q1_dlo) := by
+  delta algorithmUn21V5
+  delta divKTrialCallV5Un21
+  rfl
+
+/-- The v5 algorithm's Phase-1b output `q1''`. Named bundle alias for
+    `divKTrialCallV5Q1dd`. -/
+@[irreducible]
+def algorithmQ1PrimeV5 (uHi uLo vTop : Word) : Word :=
+  divKTrialCallV5Q1dd uHi uLo vTop
+
+/-- Named unfold for `algorithmQ1PrimeV5`. Note the v5 Phase-1a uses the
+    capped `q1cCap := 0xFFFFFFFF` value and recomputed `rhatc`, and the
+    Phase-1b 1st correction is guarded by `rhatc >>> 32 = 0`. -/
+theorem algorithmQ1PrimeV5_unfold (uHi uLo vTop : Word) :
+    algorithmQ1PrimeV5 uHi uLo vTop =
+      (let dHi := divKTrialCallV5DHi vTop
+       let dLo := divKTrialCallV5DLo vTop
+       let un1 := divKTrialCallV5Un1 uLo
+       let q1 := rv64_divu uHi dHi
+       let rhat := uHi - q1 * dHi
+       let hi1 := q1 >>> (32 : BitVec 6).toNat
+       let q1cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+       let q1c := if hi1 = 0 then q1 else q1cCap
+       let rhatc := if hi1 = 0 then rhat else uHi - q1c * dHi
+       let qDlo := q1c * dLo
+       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+       let phase1bFire1 :=
+         decide (rhatc >>> (32 : BitVec 6).toNat = 0) && BitVec.ult rhatUn1 qDlo
+       let q1' := if phase1bFire1 then q1c + signExtend12 4095 else q1c
+       let rhat' := if phase1bFire1 then rhatc + dHi else rhatc
+       let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
+       let qDlo2 := q1' * dLo
+       let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+       if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2 then q1' + signExtend12 4095 else q1') := by
+  delta algorithmQ1PrimeV5
+  delta divKTrialCallV5Q1dd
+  rfl
+
+/-- The v5 algorithm's Phase-2 output `q0''`. Named bundle alias for
+    `divKTrialCallV5Q0dd`. -/
+@[irreducible]
+def algorithmQ0PrimeV5 (uHi uLo vTop : Word) : Word :=
+  divKTrialCallV5Q0dd uHi uLo vTop
+
+/-- Named unfold for `algorithmQ0PrimeV5`. -/
+theorem algorithmQ0PrimeV5_unfold (uHi uLo vTop : Word) :
+    algorithmQ0PrimeV5 uHi uLo vTop =
+      div128Quot_phase2b_q0'
+        (divKTrialCallV5Q0d uHi uLo vTop)
+        (divKTrialCallV5Rhat2d uHi uLo vTop)
+        (divKTrialCallV5DLo vTop)
+        (divKTrialCallV5Un0 uLo) := by
+  delta algorithmQ0PrimeV5
+  delta divKTrialCallV5Q0dd
+  rfl
+
+/-- Named unfold for `divKTrialCallV5Q1dd`: q1'' after the V5 Phase-1a
+    cap + V5 guarded Phase-1b 1st correction + Phase-1b 2nd D3
+    correction. -/
+theorem divKTrialCallV5Q1dd_unfold (uHi uLo vTop : Word) :
+    divKTrialCallV5Q1dd uHi uLo vTop =
+      (let dHi := divKTrialCallV5DHi vTop
+       let dLo := divKTrialCallV5DLo vTop
+       let un1 := divKTrialCallV5Un1 uLo
+       let q1 := rv64_divu uHi dHi
+       let rhat := uHi - q1 * dHi
+       let hi1 := q1 >>> (32 : BitVec 6).toNat
+       let q1cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+       let q1c := if hi1 = 0 then q1 else q1cCap
+       let rhatc := if hi1 = 0 then rhat else uHi - q1c * dHi
+       let qDlo := q1c * dLo
+       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+       let phase1bFire1 :=
+         decide (rhatc >>> (32 : BitVec 6).toNat = 0) && BitVec.ult rhatUn1 qDlo
+       let q1' := if phase1bFire1 then q1c + signExtend12 4095 else q1c
+       let rhat' := if phase1bFire1 then rhatc + dHi else rhatc
+       let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
+       let qDlo2 := q1' * dLo
+       let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+       if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2 then q1' + signExtend12 4095 else q1') := by
+  delta divKTrialCallV5Q1dd; rfl
+
+/-- Named unfold for `divKTrialCallV5Rhatdd`. -/
+theorem divKTrialCallV5Rhatdd_unfold (uHi uLo vTop : Word) :
+    divKTrialCallV5Rhatdd uHi uLo vTop =
+      (let dHi := divKTrialCallV5DHi vTop
+       let dLo := divKTrialCallV5DLo vTop
+       let un1 := divKTrialCallV5Un1 uLo
+       let q1 := rv64_divu uHi dHi
+       let rhat := uHi - q1 * dHi
+       let hi1 := q1 >>> (32 : BitVec 6).toNat
+       let q1cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+       let q1c := if hi1 = 0 then q1 else q1cCap
+       let rhatc := if hi1 = 0 then rhat else uHi - q1c * dHi
+       let qDlo := q1c * dLo
+       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+       let phase1bFire1 :=
+         decide (rhatc >>> (32 : BitVec 6).toNat = 0) && BitVec.ult rhatUn1 qDlo
+       let q1' := if phase1bFire1 then q1c + signExtend12 4095 else q1c
+       let rhat' := if phase1bFire1 then rhatc + dHi else rhatc
+       let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
+       let qDlo2 := q1' * dLo
+       let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+       if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2 then rhat' + dHi else rhat') := by
+  delta divKTrialCallV5Rhatdd; rfl
+
+/-- Named unfold for `divKTrialCallV5Un21`. -/
+theorem divKTrialCallV5Un21_unfold (uHi uLo vTop : Word) :
+    divKTrialCallV5Un21 uHi uLo vTop =
+      (let un1 := divKTrialCallV5Un1 uLo
+       let q1'' := divKTrialCallV5Q1dd uHi uLo vTop
+       let rhat'' := divKTrialCallV5Rhatdd uHi uLo vTop
+       let cu_rhat_un1 := (rhat'' <<< (32 : BitVec 6).toNat) ||| un1
+       let cu_q1_dlo := q1'' * divKTrialCallV5DLo vTop
+       cu_rhat_un1 - cu_q1_dlo) := by
+  delta divKTrialCallV5Un21; rfl
+
+/-- Named unfold for `divKTrialCallV5Q0dd`. -/
+theorem divKTrialCallV5Q0dd_unfold (uHi uLo vTop : Word) :
+    divKTrialCallV5Q0dd uHi uLo vTop =
+      div128Quot_phase2b_q0'
+        (divKTrialCallV5Q0d uHi uLo vTop)
+        (divKTrialCallV5Rhat2d uHi uLo vTop)
+        (divKTrialCallV5DLo vTop)
+        (divKTrialCallV5Un0 uLo) := by
+  delta divKTrialCallV5Q0dd; rfl
+
+/-- Named unfold for `divKTrialCallV5QHat`: final V5 trial quotient as
+    the half-word combine of `Q1dd` and `Q0dd`. -/
+theorem divKTrialCallV5QHat_unfold (uHi uLo vTop : Word) :
+    divKTrialCallV5QHat uHi uLo vTop =
+      ((divKTrialCallV5Q1dd uHi uLo vTop <<< (32 : BitVec 6).toNat) |||
+        divKTrialCallV5Q0dd uHi uLo vTop) := by
+  delta divKTrialCallV5QHat; rfl
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Algorithm.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Algorithm.lean
@@ -255,4 +255,67 @@ theorem algorithmPhase1bFireV5_unfold (uHi uLo vTop : Word) :
           (algorithmQ1cV5 uHi vTop * divKTrialCallV5DLo vTop) := by
   delta algorithmPhase1bFireV5; rfl
 
+-- ============================================================================
+-- Phase-2a algorithm bundles for V5. Bead `evm-asm-wbc4i.4.6.2` (V5.4.0.3).
+--
+-- v5 vs v4 differences (same shape as Phase-1a):
+-- * `algorithmQ0cV5` uses cap `0xFFFFFFFF` (vs v4's `q0 - 1`).
+-- * `algorithmRhat2cV5` recomputed as `un21 - q0c*dHi` (vs v4's `rhat2 + dHi`).
+-- ============================================================================
+
+/-- The V5 Phase-2a-corrected quotient (before any Phase-2b correction). -/
+@[irreducible]
+def algorithmQ0cV5 (uHi uLo vTop : Word) : Word :=
+  let dHi := divKTrialCallV5DHi vTop
+  let un21 := divKTrialCallV5Un21 uHi uLo vTop
+  let q0 := rv64_divu un21 dHi
+  let hi2 := q0 >>> (32 : BitVec 6).toNat
+  let q0cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+  if hi2 = 0 then q0 else q0cCap
+
+/-- The V5 Phase-2a-corrected remainder. Recomputed from `un21 - q0c*dHi`. -/
+@[irreducible]
+def algorithmRhat2cV5 (uHi uLo vTop : Word) : Word :=
+  let dHi := divKTrialCallV5DHi vTop
+  let un21 := divKTrialCallV5Un21 uHi uLo vTop
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi2 := q0 >>> (32 : BitVec 6).toNat
+  let q0cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+  if hi2 = 0 then rhat2 else un21 - q0cCap * dHi
+
+/-- Named unfold for `algorithmQ0cV5`. -/
+theorem algorithmQ0cV5_unfold (uHi uLo vTop : Word) :
+    algorithmQ0cV5 uHi uLo vTop =
+      (let dHi := divKTrialCallV5DHi vTop
+       let un21 := divKTrialCallV5Un21 uHi uLo vTop
+       let q0 := rv64_divu un21 dHi
+       let hi2 := q0 >>> (32 : BitVec 6).toNat
+       let q0cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+       if hi2 = 0 then q0 else q0cCap) := by
+  delta algorithmQ0cV5; rfl
+
+/-- Named unfold for `algorithmRhat2cV5`. -/
+theorem algorithmRhat2cV5_unfold (uHi uLo vTop : Word) :
+    algorithmRhat2cV5 uHi uLo vTop =
+      (let dHi := divKTrialCallV5DHi vTop
+       let un21 := divKTrialCallV5Un21 uHi uLo vTop
+       let q0 := rv64_divu un21 dHi
+       let rhat2 := un21 - q0 * dHi
+       let hi2 := q0 >>> (32 : BitVec 6).toNat
+       let q0cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+       if hi2 = 0 then rhat2 else un21 - q0cCap * dHi) := by
+  delta algorithmRhat2cV5; rfl
+
+/-- The V5 `Q0c` irreducible coincides with the algorithm bundle
+    (sanity check; bodies are definitionally equal). -/
+theorem divKTrialCallV5Q0c_eq_algorithm (uHi uLo vTop : Word) :
+    divKTrialCallV5Q0c uHi uLo vTop = algorithmQ0cV5 uHi uLo vTop := by
+  delta divKTrialCallV5Q0c algorithmQ0cV5; rfl
+
+/-- The V5 `Rhat2c` irreducible coincides with the algorithm bundle. -/
+theorem divKTrialCallV5Rhat2c_eq_algorithm (uHi uLo vTop : Word) :
+    divKTrialCallV5Rhat2c uHi uLo vTop = algorithmRhat2cV5 uHi uLo vTop := by
+  delta divKTrialCallV5Rhat2c algorithmRhat2cV5; rfl
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Algorithm.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Algorithm.lean
@@ -172,4 +172,87 @@ theorem divKTrialCallV5QHat_unfold (uHi uLo vTop : Word) :
         divKTrialCallV5Q0dd uHi uLo vTop) := by
   delta divKTrialCallV5QHat; rfl
 
+-- ============================================================================
+-- Phase-1a + Phase-1b-fire-guard algorithm bundles for V5.
+-- Bead `evm-asm-wbc4i.4.6.1` (V5.4.0.2).
+--
+-- v5 vs v4 differences here:
+-- * `algorithmQ1cV5` uses the cap `q1cCap = 0xFFFFFFFF` (vs v4's
+--   `q1 - 1`).
+-- * `algorithmRhatcV5` is recomputed as `uHi - q1c * dHi` (vs v4's
+--   `rhat + dHi`).
+-- * `algorithmPhase1bFireV5` adds the `rhatc >>> 32 = 0` guard
+--   (matching the existing 2nd-correction and Phase-2-helper guards).
+-- ============================================================================
+
+/-- The V5 Phase-1a-corrected quotient (before the first Phase-1b dLo
+    check). Uses the cap `0xFFFFFFFF` when `hi1 ≠ 0`. -/
+@[irreducible]
+def algorithmQ1cV5 (uHi vTop : Word) : Word :=
+  let dHi := divKTrialCallV5DHi vTop
+  let q1 := rv64_divu uHi dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+  if hi1 = 0 then q1 else q1cCap
+
+/-- The V5 Phase-1a-corrected remainder. Recomputed from `uHi - q1c*dHi`
+    (not `rhat + dHi` as in v4). -/
+@[irreducible]
+def algorithmRhatcV5 (uHi vTop : Word) : Word :=
+  let dHi := divKTrialCallV5DHi vTop
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+  if hi1 = 0 then rhat else uHi - q1cCap * dHi
+
+/-- The low 64-bit comparison word for the V5 first Phase-1b dLo check. -/
+@[irreducible]
+def algorithmRhatUn1cV5 (uHi uLo vTop : Word) : Word :=
+  (algorithmRhatcV5 uHi vTop <<< (32 : BitVec 6).toNat) ||| divKTrialCallV5Un1 uLo
+
+/-- The V5 first Phase-1b dLo correction guard. Differs from v4 by the
+    additional `rhatc >>> 32 = 0` precondition that gates the BLTU. -/
+@[irreducible]
+def algorithmPhase1bFireV5 (uHi uLo vTop : Word) : Prop :=
+  algorithmRhatcV5 uHi vTop >>> (32 : BitVec 6).toNat = 0 ∧
+    BitVec.ult (algorithmRhatUn1cV5 uHi uLo vTop)
+      (algorithmQ1cV5 uHi vTop * divKTrialCallV5DLo vTop)
+
+/-- Named unfold for `algorithmQ1cV5`. -/
+theorem algorithmQ1cV5_unfold (uHi vTop : Word) :
+    algorithmQ1cV5 uHi vTop =
+      (let dHi := divKTrialCallV5DHi vTop
+       let q1 := rv64_divu uHi dHi
+       let hi1 := q1 >>> (32 : BitVec 6).toNat
+       let q1cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+       if hi1 = 0 then q1 else q1cCap) := by
+  delta algorithmQ1cV5; rfl
+
+/-- Named unfold for `algorithmRhatcV5`. -/
+theorem algorithmRhatcV5_unfold (uHi vTop : Word) :
+    algorithmRhatcV5 uHi vTop =
+      (let dHi := divKTrialCallV5DHi vTop
+       let q1 := rv64_divu uHi dHi
+       let rhat := uHi - q1 * dHi
+       let hi1 := q1 >>> (32 : BitVec 6).toNat
+       let q1cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+       if hi1 = 0 then rhat else uHi - q1cCap * dHi) := by
+  delta algorithmRhatcV5; rfl
+
+/-- Named unfold for `algorithmRhatUn1cV5`. -/
+theorem algorithmRhatUn1cV5_unfold (uHi uLo vTop : Word) :
+    algorithmRhatUn1cV5 uHi uLo vTop =
+      ((algorithmRhatcV5 uHi vTop <<< (32 : BitVec 6).toNat) |||
+        divKTrialCallV5Un1 uLo) := by
+  delta algorithmRhatUn1cV5; rfl
+
+/-- Named unfold for `algorithmPhase1bFireV5`. -/
+theorem algorithmPhase1bFireV5_unfold (uHi uLo vTop : Word) :
+    algorithmPhase1bFireV5 uHi uLo vTop ↔
+      algorithmRhatcV5 uHi vTop >>> (32 : BitVec 6).toNat = 0 ∧
+        BitVec.ult (algorithmRhatUn1cV5 uHi uLo vTop)
+          (algorithmQ1cV5 uHi vTop * divKTrialCallV5DLo vTop) := by
+  delta algorithmPhase1bFireV5; rfl
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/CapBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/CapBounds.lean
@@ -1,0 +1,67 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.CapBounds
+
+  V5-specific upper bounds derived directly from the Phase-1a / Phase-2a
+  cap structure. These are the foundational sub-2^32 bounds that v4's
+  proofs had to derive carefully (giving ≤ 2^32, not <); V5 has them
+  for free because the cap branch writes exactly 0xFFFFFFFF = 2^32 - 1.
+
+  Bead `evm-asm-wbc4i.4.6.3` (V5.4.0.4). Prerequisite for V5.4.1, V5.4.4,
+  V5.5.1, V5.5.2.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Algorithm
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Helper: `0xFFFFFFFF.toNat = 2^32 - 1`. Used by both Q1c and Q0c
+    bound proofs. -/
+private theorem v5_capCap_toNat :
+    ((BitVec.allOnes 64) >>> (32 : BitVec 6).toNat : Word).toNat = 2^32 - 1 := by
+  decide
+
+/-- The DIVU result `q1 := rv64_divu uHi dHi` is bounded by `2^32` from
+    the if-then-else branch in `algorithmQ1cV5` when `hi1 = 0`. -/
+private theorem rv64_divu_lt_pow32_of_hi1_zero (uHi dHi : Word)
+    (h : (rv64_divu uHi dHi) >>> (32 : BitVec 6).toNat = (0 : Word)) :
+    (rv64_divu uHi dHi).toNat < 2^32 := by
+  have hd : ((rv64_divu uHi dHi) >>> (32 : BitVec 6).toNat).toNat = 0 := by
+    rw [h]; rfl
+  rw [BitVec.toNat_ushiftRight, AddrNorm.bv6_toNat_32] at hd
+  rw [Nat.shiftRight_eq_div_pow] at hd
+  have : (rv64_divu uHi dHi).toNat / 2^32 = 0 := hd
+  exact Nat.div_eq_zero_iff.mp this |>.resolve_left (by decide)
+
+/-- Q1c is strictly less than 2^32 unconditionally under the V5 cap. -/
+theorem algorithmQ1cV5_lt_pow32 (uHi vTop : Word) :
+    (algorithmQ1cV5 uHi vTop).toNat < 2^32 := by
+  rw [algorithmQ1cV5_unfold]
+  by_cases h : (rv64_divu uHi (divKTrialCallV5DHi vTop)) >>> (32 : BitVec 6).toNat = (0 : Word)
+  · simp only [h, if_true]
+    exact rv64_divu_lt_pow32_of_hi1_zero _ _ h
+  · simp only [h, if_false]
+    rw [v5_capCap_toNat]
+    omega
+
+/-- Same for Q0c. -/
+theorem algorithmQ0cV5_lt_pow32 (uHi uLo vTop : Word) :
+    (algorithmQ0cV5 uHi uLo vTop).toNat < 2^32 := by
+  rw [algorithmQ0cV5_unfold]
+  by_cases h : (rv64_divu (divKTrialCallV5Un21 uHi uLo vTop)
+                  (divKTrialCallV5DHi vTop)) >>> (32 : BitVec 6).toNat = (0 : Word)
+  · simp only [h, if_true]
+    exact rv64_divu_lt_pow32_of_hi1_zero _ _ h
+  · simp only [h, if_false]
+    rw [v5_capCap_toNat]
+    omega
+
+/-- Bridge: `divKTrialCallV5Q0c` (the irreducible) inherits Q0c's cap
+    bound via the `_eq_algorithm` equation. -/
+theorem divKTrialCallV5Q0c_lt_pow32 (uHi uLo vTop : Word) :
+    (divKTrialCallV5Q0c uHi uLo vTop).toNat < 2^32 := by
+  rw [divKTrialCallV5Q0c_eq_algorithm]
+  exact algorithmQ0cV5_lt_pow32 uHi uLo vTop
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/NoWrap.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/NoWrap.lean
@@ -1,0 +1,85 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.NoWrap
+
+  No-wrap properties for the V5 cap-bounded multiplications: under
+  `algorithmQ{1,0}cV5 < 2^32` (from `CapBounds`) and `dLo < 2^32`, the
+  product `q*c * dLo` fits in BitVec 64 unconditionally.
+
+  v4's `algorithmQ1dV4_dLo_no_wrap` (Phase1bBound.lean:1007) required
+  `≤ 2^32 + 1` and a careful case-analysis; V5's bounds make this
+  unconditional and trivial.
+
+  Bead `evm-asm-wbc4i.4.6.4` (V5.4.0.5). Prerequisite for V5.4.1, V5.4.4.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.CapBounds
+import EvmAsm.Evm64.EvmWordArith.Div128FinalAssembly
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The v5 normalized `dLo = (vTop << 32) >> 32` is bounded by `2^32`.
+    Mirrors the v4 lemma at `Phase1bBound.lean:138`. -/
+theorem divKTrialCallV5DLo_lt_pow32 (vTop : Word) :
+    (divKTrialCallV5DLo vTop).toNat < 2^32 := by
+  unfold divKTrialCallV5DLo
+  exact Word_ushiftRight_32_lt_pow32
+
+/-- The v5 `un1 = uLo >> 32` is bounded by `2^32`. -/
+theorem divKTrialCallV5Un1_lt_pow32 (uLo : Word) :
+    (divKTrialCallV5Un1 uLo).toNat < 2^32 := by
+  unfold divKTrialCallV5Un1
+  exact Word_ushiftRight_32_lt_pow32
+
+/-- The v5 `dHi = vTop >> 32` is bounded by `2^32`. -/
+theorem divKTrialCallV5DHi_lt_pow32 (vTop : Word) :
+    (divKTrialCallV5DHi vTop).toNat < 2^32 := by
+  unfold divKTrialCallV5DHi
+  exact Word_ushiftRight_32_lt_pow32
+
+/-- The v5 `un0 = (uLo << 32) >> 32` is bounded by `2^32`. -/
+theorem divKTrialCallV5Un0_lt_pow32 (uLo : Word) :
+    (divKTrialCallV5Un0 uLo).toNat < 2^32 := by
+  unfold divKTrialCallV5Un0
+  exact Word_ushiftRight_32_lt_pow32
+
+/-- `Q1c * dLo` does not wrap mod 2^64 under the V5 cap. Strictly
+    tighter than v4's analog (no hypothesis on `vTop`). -/
+theorem algorithmQ1cV5_dLo_no_wrap (uHi vTop : Word) :
+    (algorithmQ1cV5 uHi vTop * divKTrialCallV5DLo vTop).toNat =
+      (algorithmQ1cV5 uHi vTop).toNat * (divKTrialCallV5DLo vTop).toNat := by
+  rw [BitVec.toNat_mul]
+  apply Nat.mod_eq_of_lt
+  have h_q := algorithmQ1cV5_lt_pow32 uHi vTop
+  have h_d := divKTrialCallV5DLo_lt_pow32 vTop
+  have : (algorithmQ1cV5 uHi vTop).toNat * (divKTrialCallV5DLo vTop).toNat <
+      2^32 * 2^32 := Nat.mul_lt_mul'' h_q h_d
+  calc (algorithmQ1cV5 uHi vTop).toNat * (divKTrialCallV5DLo vTop).toNat
+      < 2^32 * 2^32 := this
+    _ = 2^64 := by norm_num
+
+/-- `Q0c * dLo` does not wrap mod 2^64 under the V5 cap. -/
+theorem algorithmQ0cV5_dLo_no_wrap (uHi uLo vTop : Word) :
+    (algorithmQ0cV5 uHi uLo vTop * divKTrialCallV5DLo vTop).toNat =
+      (algorithmQ0cV5 uHi uLo vTop).toNat * (divKTrialCallV5DLo vTop).toNat := by
+  rw [BitVec.toNat_mul]
+  apply Nat.mod_eq_of_lt
+  have h_q := algorithmQ0cV5_lt_pow32 uHi uLo vTop
+  have h_d := divKTrialCallV5DLo_lt_pow32 vTop
+  have : (algorithmQ0cV5 uHi uLo vTop).toNat * (divKTrialCallV5DLo vTop).toNat <
+      2^32 * 2^32 := Nat.mul_lt_mul'' h_q h_d
+  calc (algorithmQ0cV5 uHi uLo vTop).toNat * (divKTrialCallV5DLo vTop).toNat
+      < 2^32 * 2^32 := this
+    _ = 2^64 := by norm_num
+
+/-- Bridge to the V5 irreducible family: `Q0c * dLo` no-wrap via
+    `divKTrialCallV5Q0c_eq_algorithm`. -/
+theorem divKTrialCallV5Q0c_dLo_no_wrap (uHi uLo vTop : Word) :
+    (divKTrialCallV5Q0c uHi uLo vTop * divKTrialCallV5DLo vTop).toNat =
+      (divKTrialCallV5Q0c uHi uLo vTop).toNat *
+        (divKTrialCallV5DLo vTop).toNat := by
+  rw [divKTrialCallV5Q0c_eq_algorithm]
+  exact algorithmQ0cV5_dLo_no_wrap uHi uLo vTop
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

- Adds `EvmAsm/Evm64/DivMod/LoopBody/TrialCallV5.lean` with the v5 irreducible family for trial-quotient intermediate values, mirroring v4's `divKTrialCallV4*` family in `TrialCall.lean:85-302`. Bead `evm-asm-wbc4i.2`.
- The v5 differences in the irreducibles match `div128Quot_v5`: Phase-1a cap `q1c := 0xFFFFFFFF` with recomputed `rhatc`, Phase-1b 1st-correction guarded by `rhatc >>> 32 = 0`, Phase-2a cap `q0c := 0xFFFFFFFF` with recomputed `rhat2c`. All other intermediate steps mirror v4 modulo upstream v5 values.
- Provides two bridging lemmas — `divKTrialCallV5Q1dd_eq_phase2b` and `divKTrialCallV5Rhatdd_eq_phase2b` — that rewrite the flat-∧ Phase-1b 2nd-D3 form to the nested-let / `div128Quot_phase2b_q0'` shape used by `div128Quot_v5`. Reuses v4's `div128Quot_phase2b_q0'_and_form` and `div128Quot_phase2b_rhat_and_form` from `TrialCall.lean`.
- The closure theorem `divKTrialCallV5QHat_eq_div128Quot_v5` is intentionally deferred to a follow-up bead — the structural `rfl` over the full let chain hit a definitional-equality wall here. The two bridging lemmas are sufficient for downstream V5.4 (UB) / V5.5 (LB) reasoning per stage; a future bead can close the monolithic equality once needed.
- Wired into `EvmAsm/Evm64/DivMod.lean` umbrella. Builds clean, no sorrys, no heartbeat/maxRecDepth tweaks.

**Stacked on PR #7082** (V5.1 math model). Review/merge that first.

Refs #61. Bead: evm-asm-wbc4i.2.

Authored by @pirapira; implemented by Claude Code
