### PR TITLE
feat(stateless): compute node_0_15 dynamically (support block_number)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -308,6 +308,61 @@ def statelessGuestEpilogue : String :=
   "  li s6, 0x40000000\n" ++
   "  addi s6, s6, 18             # s6 = SSZ_BASE\n" ++
   "  # \n" ++
+  "  # ===== exec_payload merkle path (leaves 0-15) =====\n" ++
+  "  # Path leaf_6 -> node_6_7 -> node_4_7 -> node_0_7 -> node_0_15\n" ++
+  "  # leaf_6 = block_number (u64 LE @ SSZ_BASE + 16 + 44 + 404 = +464)\n" ++
+  "  #          || 24 bytes of zero padding; sibling leaf_7 = ssz_zero_hash[0]\n" ++
+  "  la t1, npr_sha_input\n" ++
+  "  ld t2, 464(s6)              # block_number\n" ++
+  "  sd t2,  0(t1)\n" ++
+  "  sd zero,  8(t1); sd zero, 16(t1); sd zero, 24(t1)\n" ++
+  "  sd zero, 32(t1); sd zero, 40(t1); sd zero, 48(t1); sd zero, 56(t1)\n" ++
+  "  la a0, npr_sha_input; li a1, 64; la a2, npr_sha_subtree\n" ++
+  "  jal ra, zkvm_sha256         # node_6_7 -> npr_sha_subtree\n" ++
+  "  # node_4_7 = sha256(npr_node_4_5 || node_6_7)\n" ++
+  "  la t1, npr_sha_input\n" ++
+  "  la t3, npr_node_4_5\n" ++
+  "  ld t2,  0(t3); sd t2,  0(t1)\n" ++
+  "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 16(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 24(t1)\n" ++
+  "  la t3, npr_sha_subtree\n" ++
+  "  ld t2,  0(t3); sd t2, 32(t1)\n" ++
+  "  ld t2,  8(t3); sd t2, 40(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 48(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 56(t1)\n" ++
+  "  la a0, npr_sha_input; li a1, 64; la a2, npr_sha_subtree\n" ++
+  "  jal ra, zkvm_sha256         # node_4_7 -> npr_sha_subtree\n" ++
+  "  # node_0_7 = sha256(ssz_zero_hash[2] || node_4_7)\n" ++
+  "  la t1, npr_sha_input\n" ++
+  "  la t3, ssz_zero_hashes\n" ++
+  "  addi t3, t3, 64             # ssz_zero_hash[2]\n" ++
+  "  ld t2,  0(t3); sd t2,  0(t1)\n" ++
+  "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 16(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 24(t1)\n" ++
+  "  la t3, npr_sha_subtree\n" ++
+  "  ld t2,  0(t3); sd t2, 32(t1)\n" ++
+  "  ld t2,  8(t3); sd t2, 40(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 48(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 56(t1)\n" ++
+  "  la a0, npr_sha_input; li a1, 64; la a2, npr_sha_subtree\n" ++
+  "  jal ra, zkvm_sha256         # node_0_7 -> npr_sha_subtree\n" ++
+  "  # node_0_15 = sha256(node_0_7 || npr_node_8_15) -> npr_node_0_15_scratch\n" ++
+  "  la t1, npr_sha_input\n" ++
+  "  la t3, npr_sha_subtree\n" ++
+  "  ld t2,  0(t3); sd t2,  0(t1)\n" ++
+  "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 16(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 24(t1)\n" ++
+  "  la t3, npr_node_8_15\n" ++
+  "  ld t2,  0(t3); sd t2, 32(t1)\n" ++
+  "  ld t2,  8(t3); sd t2, 40(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 48(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 56(t1)\n" ++
+  "  la a0, npr_sha_input; li a1, 64; la a2, npr_node_0_15_scratch\n" ++
+  "  jal ra, zkvm_sha256         # node_0_15 -> npr_node_0_15_scratch\n" ++
+  "  # \n" ++
   "  # ===== exec_payload merkle path (leaves 16-31) =====\n" ++
   "  # node_16_17 = sha256(leaf_16 || leaf_17) where\n" ++
   "  #   leaf_16 = excess_blob_gas (u64 LE @ SSZ_BASE + 16 + 44 + 520\n" ++
@@ -381,7 +436,7 @@ def statelessGuestEpilogue : String :=
   "  jal ra, zkvm_sha256         # node_16_31 -> npr_sha_subtree\n" ++
   "  # exec_payload_root = sha256(node_0_15 || node_16_31)\n" ++
   "  la t1, npr_sha_input\n" ++
-  "  la t3, npr_node_0_15\n" ++
+  "  la t3, npr_node_0_15_scratch\n" ++
   "  ld t2,  0(t3); sd t2,  0(t1)\n" ++
   "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
   "  ld t2, 16(t3); sd t2, 16(t1)\n" ++

--- a/EvmAsm/Codegen/Programs/StatelessGuestData.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuestData.lean
@@ -258,6 +258,34 @@ def statelessGuestDataSection : String :=
   "  .byte 0x50, 0x16, 0xe1, 0x2a, 0x8c, 0x78, 0x1a, 0x0b\n" ++
   ".balign 8\n" ++
   "npr_node_16_17_scratch:\n" ++
+  "  .zero 32\n" ++
+  -- Two new sibling constants for the leaf_6 (block_number)
+  -- merkle path through node_0_15:
+  --   npr_node_4_5 = sha256(leaf_4=logs_bloom_default ||
+  --                         leaf_5=prev_randao_default)
+  --   npr_node_8_15 = the subtree root of default leaves 8..15
+  --     (sha256 over leaves 8..15 for the default exec_payload).
+  -- The remaining two siblings on the path are
+  -- `ssz_zero_hash[0]` (leaf_7 default = u64 zero) and
+  -- `ssz_zero_hash[2]` (node_0_3 = sha256(zero || zero) at
+  -- depth 2). The prior `npr_node_0_15` constant is now
+  -- unreferenced (dynamic recompute via these siblings).
+  -- `npr_node_0_15_scratch` is the 32-byte buffer that holds
+  -- the dynamic computation result.
+  ".balign 8\n" ++
+  "npr_node_4_5:\n" ++
+  "  .byte 0xe8, 0xe5, 0x27, 0xe8, 0x4f, 0x66, 0x61, 0x63\n" ++
+  "  .byte 0xa9, 0x0e, 0xf9, 0x00, 0xe0, 0x13, 0xf5, 0x6b\n" ++
+  "  .byte 0x0a, 0x4d, 0x02, 0x01, 0x48, 0xb2, 0x22, 0x40\n" ++
+  "  .byte 0x57, 0xb7, 0x19, 0xf3, 0x51, 0xb0, 0x03, 0xa6\n" ++
+  ".balign 8\n" ++
+  "npr_node_8_15:\n" ++
+  "  .byte 0x9c, 0xd6, 0x13, 0x23, 0x26, 0x94, 0x9e, 0x18\n" ++
+  "  .byte 0x79, 0x4d, 0xb8, 0x5d, 0x0b, 0xed, 0x67, 0xe6\n" ++
+  "  .byte 0xff, 0x8d, 0x84, 0x02, 0x0c, 0x0b, 0x18, 0x89\n" ++
+  "  .byte 0xb6, 0x76, 0xd2, 0x91, 0x3b, 0xac, 0x8d, 0x4e\n" ++
+  ".balign 8\n" ++
+  "npr_node_0_15_scratch:\n" ++
   "  .zero 32"
 
 end EvmAsm.Codegen

--- a/scripts/codegen-stateless-gen-fixture.py
+++ b/scripts/codegen-stateless-gen-fixture.py
@@ -66,6 +66,7 @@ hdr_hex = sys.argv[11]
 npr_pbr_hex = sys.argv[12] if len(sys.argv) > 12 else ''
 npr_slot_str = sys.argv[13] if len(sys.argv) > 13 else ''
 npr_excess_blob_str = sys.argv[14] if len(sys.argv) > 14 else ''
+npr_block_number_str = sys.argv[15] if len(sys.argv) > 15 else ''
 
 # Build the new-schema StatelessInput: empty new_payload_request,
 # witness whose 'state'/'codes' lists each hold zero or more
@@ -736,7 +737,7 @@ npr_kwargs = {}
 if npr_pbr_hex:
     from remerkleable.byte_arrays import Bytes32 as Bytes32SSZ
     npr_kwargs['parent_beacon_block_root'] = Bytes32SSZ(bytes.fromhex(npr_pbr_hex))
-if npr_slot_str or npr_excess_blob_str:
+if npr_slot_str or npr_excess_blob_str or npr_block_number_str:
     from ethereum.forks.amsterdam.stateless_ssz import SszExecutionPayload
     from remerkleable.basic import uint64 as Uint64SSZ
     ep_kwargs = {}
@@ -744,6 +745,8 @@ if npr_slot_str or npr_excess_blob_str:
         ep_kwargs['slot_number'] = Uint64SSZ(int(npr_slot_str, 0))
     if npr_excess_blob_str:
         ep_kwargs['excess_blob_gas'] = Uint64SSZ(int(npr_excess_blob_str, 0))
+    if npr_block_number_str:
+        ep_kwargs['block_number'] = Uint64SSZ(int(npr_block_number_str, 0))
     npr_kwargs['execution_payload'] = SszExecutionPayload(**ep_kwargs)
 npr = SszNewPayloadRequest(**npr_kwargs)
 

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -83,6 +83,7 @@ run_fixture() {
   local npr_pbr_hex="${11:-}"
   local npr_slot_str="${12:-}"
   local npr_excess_blob_str="${13:-}"
+  local npr_block_number_str="${14:-}"
 
   local safe="${label//[^0-9A-Za-z_]/_}"
   local input_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.input"
@@ -90,8 +91,8 @@ run_fixture() {
   local spec_exp_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.spec-expected"
   local log_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.emu.log"
 
-  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty}, npr_pbr=${npr_pbr_hex:-empty}, npr_slot=${npr_slot_str:-empty}, npr_excess_blob=${npr_excess_blob_str:-empty})"
-  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex" "$npr_pbr_hex" "$npr_slot_str" "$npr_excess_blob_str"
+  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty}, npr_pbr=${npr_pbr_hex:-empty}, npr_slot=${npr_slot_str:-empty}, npr_excess_blob=${npr_excess_blob_str:-empty}, npr_block_number=${npr_block_number_str:-empty})"
+  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex" "$npr_pbr_hex" "$npr_slot_str" "$npr_excess_blob_str" "$npr_block_number_str"
 
   # Guard against silent fail: if the spec generator crashed
   # (Python syntax error in the heredoc, missing import, etc.)
@@ -221,6 +222,20 @@ run_fixture "chain1_npr_exec_payload_slot_1234" 1      0    ""           ""     
 # computation reproduces the old constant byte-for-byte
 # because leaf_16 = ssz_zero_hash[0].
 run_fixture "chain1_npr_exec_payload_excess_blob_42" 1 0    ""           ""                  ""    ""           ""           ""    ""                       ""                                ""    "42" || fail=1
+
+# Non-empty execution_payload: block_number = 0xABCDEF (leaf
+# 6 in the exec_payload Container's 32-leaf merkle tree).
+# Drives the implementation past the existing
+# `npr_node_0_15` constant: previously this constant was
+# used directly as the LEFT input to `exec_payload_root`;
+# now leaf 6's merkle path is computed dynamically:
+#   node_6_7  = sha256(leaf_6 || ssz_zero_hash[0])
+#   node_4_7  = sha256(npr_node_4_5_constant || node_6_7)
+#   node_0_7  = sha256(ssz_zero_hash[2] || node_4_7)
+#   node_0_15 = sha256(node_0_7 || npr_node_8_15_constant)
+# Two new sibling constants (`npr_node_4_5`,
+# `npr_node_8_15`) replace one (`npr_node_0_15`).
+run_fixture "chain1_npr_exec_payload_block_number_abcdef" 1 0 ""        ""                  ""    ""           ""           ""    ""                       ""                                ""    ""    "11259375" || fail=1
 
 # Edge: chain_id = 2^32 = 0x100000000. LE bytes
 # 00 00 00 00 01 00 00 00. The encoder's chain_id split


### PR DESCRIPTION
## Summary

Builds on #7087. The previous PR made \`node_16_17\` dynamic; this PR makes \`node_0_15\` dynamic so the implementation can support a leaf in the **left** half of the exec_payload merkle tree.

**Initially-failing fixture:** \`chain1_npr_exec_payload_block_number_abcdef\` sets \`NPR.execution_payload.block_number = 0xABCDEF\` (leaf 6 in the exec_payload Container's 32-leaf merkle tree).

**Smallest implementation step:** replace the precomputed \`npr_node_0_15\` \`.data\` constant with a dynamic 4-call sha256 merkle path computation from leaf 6 up to \`node_0_15\`:

\`\`\`
node_6_7  = sha256(leaf_6 || ssz_zero_hash[0])
node_4_7  = sha256(npr_node_4_5_constant || node_6_7)
node_0_7  = sha256(ssz_zero_hash[2] || node_4_7)
node_0_15 = sha256(node_0_7 || npr_node_8_15_constant)
\`\`\`

The path picks leaf 6 specifically because **two of the four siblings collapse to existing \`ssz_zero_hashes\` entries** (\`leaf_7=0\` → \`ssz_zero_hash[0]\`; \`node_0_3 = sha256(0||0) = ssz_zero_hash[1]\` then combined with \`ssz_zero_hash[1]\` gives \`ssz_zero_hash[2]\`). Only two new sibling constants are needed:

| constant | meaning |
| -------- | ------- |
| \`npr_node_4_5\` | \`sha256(logs_bloom_default || prev_randao_default)\` |
| \`npr_node_8_15\` | subtree root of default leaves 8..15 |

\`block_number\` is read from input at \`SSZ_BASE + 16 + 44 + 404 = SSZ_BASE + 464\` (NPR_addr = SSZ_BASE+16; exec_payload_addr = NPR+44; \`block_number\` inline at \`exec_payload + 404\`).

For all pre-existing fixtures (\`block_number=0\`), the dynamic computation reproduces the old \`npr_node_0_15\` constant byte-for-byte: \`leaf_6 = ssz_zero_hash[0]\`, so each subsequent merkle step matches the prior baked-in chain.

\`sha256\` calls in \`.Lsg_hash\`: 9 → 13.

The legacy \`npr_node_0_15\` constant remains in \`StatelessGuestData.lean\` but is now unreferenced (kept for diff-context).

## Surface

| file | change |
| ---- | ------ |
| \`scripts/codegen-stateless-spec-output-check.sh\` | 14th optional positional arg \`npr_block_number_str\`; new fixture \`chain1_npr_exec_payload_block_number_abcdef\`. |
| \`scripts/codegen-stateless-gen-fixture.py\` | read \`sys.argv[15]\` as \`npr_block_number_str\`; when set, populate \`SszExecutionPayload(block_number=...)\`. |
| \`EvmAsm/Codegen/Programs.lean\` | new 4-call merkle path inserted before the existing 16-31 path. The \`exec_payload_root\` computation now reads \`node_0_15\` from \`npr_node_0_15_scratch\`. |
| \`EvmAsm/Codegen/Programs/StatelessGuestData.lean\` | new \`npr_node_4_5\` / \`npr_node_8_15\` constants and \`npr_node_0_15_scratch\` buffer. |

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass, including the new \`chain1_npr_exec_payload_block_number_abcdef\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)