### PR TITLE
feat(div): complete V5.4.0.7 with Q0c Euclidean identity

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Q1cEuclidean.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Q1cEuclidean.lean
@@ -114,4 +114,80 @@ theorem algorithmQ1cV5_rhatc_post
     rw [h_rhatc_no_wrap, h_cap_dHi_no_wrap]
     omega
 
+/-- Phase-2a Euclidean identity at the V5 cap level. Analog of
+    `algorithmQ1cV5_rhatc_post` with `un21` in place of `uHi`.
+    Holds for both branches by the same case-analysis pattern. -/
+theorem algorithmQ0cV5_rhat2c_post
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63) :
+    (algorithmQ0cV5 uHi uLo vTop).toNat * (divKTrialCallV5DHi vTop).toNat +
+      (algorithmRhat2cV5 uHi uLo vTop).toNat =
+      (divKTrialCallV5Un21 uHi uLo vTop).toNat := by
+  rw [algorithmQ0cV5_unfold, algorithmRhat2cV5_unfold]
+  dsimp only
+  set dHi := divKTrialCallV5DHi vTop with hdHi
+  set un21 := divKTrialCallV5Un21 uHi uLo vTop with hun21
+  set q0 : Word := rv64_divu un21 dHi with hq0
+  have h_dHi_ge : dHi.toNat ≥ 2^31 := by
+    rw [hdHi]; unfold divKTrialCallV5DHi
+    rw [BitVec.toNat_ushiftRight, AddrNorm.bv6_toNat_32, Nat.shiftRight_eq_div_pow]
+    omega
+  have h_dHi_lt : dHi.toNat < 2^32 := by
+    rw [hdHi]; exact divKTrialCallV5DHi_lt_pow32 vTop
+  have h_dHi_ne : dHi ≠ 0 := by
+    intro h
+    have : dHi.toNat = 0 := by rw [h]; rfl
+    omega
+  have h_q0_eq : q0.toNat = un21.toNat / dHi.toNat := by
+    rw [hq0]; unfold rv64_divu
+    have : ¬ (dHi == 0#64) := by simpa using h_dHi_ne
+    rw [if_neg this, BitVec.toNat_udiv]
+  have h_q0_dHi_le_un21 : q0.toNat * dHi.toNat ≤ un21.toNat := by
+    rw [h_q0_eq]; exact Nat.div_mul_le_self _ _
+  have h_q0_dHi_no_wrap : (q0 * dHi).toNat = q0.toNat * dHi.toNat := by
+    rw [BitVec.toNat_mul]
+    apply Nat.mod_eq_of_lt
+    have : un21.toNat < 2^64 := un21.isLt
+    omega
+  have h_rhat2_no_wrap : (un21 - q0 * dHi).toNat = un21.toNat - (q0 * dHi).toNat := by
+    rw [BitVec.toNat_sub, h_q0_dHi_no_wrap]
+    have hlt : un21.toNat < 2^64 := un21.isLt
+    omega
+  by_cases h_hi2 : q0 >>> (32 : BitVec 6).toNat = (0 : Word)
+  · rw [if_pos h_hi2, if_pos h_hi2]
+    rw [h_rhat2_no_wrap, h_q0_dHi_no_wrap]
+    omega
+  · rw [if_neg h_hi2, if_neg h_hi2]
+    set q0cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat with hcap
+    have h_cap_nat : q0cCap.toNat = 2^32 - 1 := by rw [hcap]; decide
+    have h_cap_lt : q0cCap.toNat < 2^32 := by omega
+    have h_hi2_nat : (q0 >>> (32 : BitVec 6).toNat).toNat ≠ 0 := by
+      intro h
+      apply h_hi2
+      apply BitVec.eq_of_toNat_eq
+      rw [h]; rfl
+    have h_q0_hi_pos : (q0 >>> (32 : BitVec 6).toNat).toNat ≥ 1 := by omega
+    have h_q0_ge : q0.toNat ≥ 2^32 := by
+      have h_shift : (q0 >>> (32 : BitVec 6).toNat).toNat = q0.toNat / 2^32 := by
+        rw [BitVec.toNat_ushiftRight, AddrNorm.bv6_toNat_32, Nat.shiftRight_eq_div_pow]
+      rw [h_shift] at h_q0_hi_pos
+      omega
+    have h_cap_lt_q0 : q0cCap.toNat < q0.toNat := by omega
+    have h_cap_dHi_no_wrap : (q0cCap * dHi).toNat = q0cCap.toNat * dHi.toNat := by
+      rw [BitVec.toNat_mul]
+      apply Nat.mod_eq_of_lt
+      have : q0cCap.toNat * dHi.toNat < 2^32 * 2^32 := Nat.mul_lt_mul'' h_cap_lt h_dHi_lt
+      calc q0cCap.toNat * dHi.toNat < 2^32 * 2^32 := this
+        _ = 2^64 := by norm_num
+    have h_cap_dHi_le_un21 : q0cCap.toNat * dHi.toNat ≤ un21.toNat := by
+      have step1 : q0cCap.toNat * dHi.toNat ≤ q0.toNat * dHi.toNat :=
+        Nat.mul_le_mul_right _ (Nat.le_of_lt h_cap_lt_q0)
+      exact le_trans step1 h_q0_dHi_le_un21
+    have h_rhat2c_no_wrap : (un21 - q0cCap * dHi).toNat = un21.toNat - (q0cCap * dHi).toNat := by
+      rw [BitVec.toNat_sub, h_cap_dHi_no_wrap]
+      have hlt : un21.toNat < 2^64 := un21.isLt
+      omega
+    rw [h_rhat2c_no_wrap, h_cap_dHi_no_wrap]
+    omega
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

- Completes bead `evm-asm-wbc4i.4.6.6` (V5.4.0.7) by adding the Phase-2a half: `algorithmQ0cV5_rhat2c_post`.
- Same proof structure as PR #7097's `algorithmQ1cV5_rhatc_post` with `un21` substituted for `uHi`. Both branches (no-fire / fire) by the same case-analysis pattern.
- The Phase-2 setup `un21 = divKTrialCallV5Un21 uHi uLo vTop` is used directly without requiring `un21 < vTop` — the Euclidean identity holds purely from the DIVU semantics and the V5 cap.

**Stacked on PR #7097** (V5.4.0.7 Q1c half).

Refs #61. Bead: evm-asm-wbc4i.4.6.6.

Authored by @pirapira; implemented by Claude Code
