### PR TITLE
feat(div): prove V5 Phase-1b no-fire dLo bound for Q1c (V5.4.0.8)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -95,6 +95,11 @@ import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.CapBounds
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.NoWrap
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1d
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1cEuclidean
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Phase1bNoFireBound
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.CapBounds
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.NoWrap
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1d
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1cEuclidean
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.CapBounds
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.NoWrap
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1d

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Phase1bNoFireBound.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Phase1bNoFireBound.lean
@@ -1,0 +1,59 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Phase1bNoFireBound
+
+  The no-fire dLo bound at the V5 cap level:
+  `¬ algorithmPhase1bFireV5 ⇒ Q1c * dLo ≤ Rhatc * 2^32 + un1`.
+
+  V5's Phase-1b 1st-correction guard is `rhatc >>> 32 = 0 ∧ BLTU`, so
+  `¬ fire` decomposes into either:
+  - `rhatc >>> 32 ≠ 0`: bound holds by sheer magnitude (rhatc*2^32 ≥ 2^64).
+  - `rhatc >>> 32 = 0 ∧ ¬ BLTU`: bound holds by the failed unsigned
+    comparison directly.
+
+  Reuses v4's `phase1b_no_fire_dLo_bound_of_rhat_hi_{zero,nonzero}`
+  (generic over `q1c, rhatc, dLo, un1`) — no V5-specific lemmas needed.
+
+  Bead `evm-asm-wbc4i.4.6.7` (V5.4.0.8). Prerequisite for V5.4.1.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1cEuclidean
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Phase1bBound
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem algorithmQ1cV5_dLo_bound_of_phase1b_no_fire
+    (uHi uLo vTop : Word)
+    (h_no_fire : ¬ algorithmPhase1bFireV5 uHi uLo vTop) :
+    (algorithmQ1cV5 uHi vTop).toNat * (divKTrialCallV5DLo vTop).toNat ≤
+      (algorithmRhatcV5 uHi vTop).toNat * 2^32 +
+        (divKTrialCallV5Un1 uLo).toNat := by
+  set q1c := algorithmQ1cV5 uHi vTop with hq1c
+  set rhatc := algorithmRhatcV5 uHi vTop with hrhatc
+  set dLo := divKTrialCallV5DLo vTop with hdLo
+  set un1 := divKTrialCallV5Un1 uLo with hun1
+  have h_q1c_le : q1c.toNat ≤ 2^32 := by
+    rw [hq1c]; have := algorithmQ1cV5_lt_pow32 uHi vTop; omega
+  have h_dLo_lt : dLo.toNat < 2^32 := by
+    rw [hdLo]; exact divKTrialCallV5DLo_lt_pow32 vTop
+  have h_un_lt : un1.toNat < 2^32 := by
+    rw [hun1]; exact divKTrialCallV5Un1_lt_pow32 uLo
+  by_cases h_rhat_hi : rhatc >>> (32 : BitVec 6).toNat = (0 : Word)
+  · -- rhatc small: no-fire ⇒ ¬ BLTU (since the high-half precondition holds).
+    have h_ult_false :
+        ¬ BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un1) (q1c * dLo) := by
+      intro h_ult
+      apply h_no_fire
+      delta algorithmPhase1bFireV5 algorithmRhatUn1cV5
+      refine ⟨h_rhat_hi, ?_⟩
+      simpa [hq1c, hrhatc, hdLo, hun1] using h_ult
+    have h_q1c_dLo_no_wrap : (q1c * dLo).toNat = q1c.toNat * dLo.toNat := by
+      rw [hq1c, hdLo]; exact algorithmQ1cV5_dLo_no_wrap uHi vTop
+    exact phase1b_no_fire_dLo_bound_of_rhat_hi_zero q1c rhatc dLo un1
+      h_rhat_hi h_un_lt h_q1c_dLo_no_wrap h_ult_false
+  · -- rhatc large: bound trivially holds.
+    exact phase1b_no_fire_dLo_bound_of_rhat_hi_nonzero q1c rhatc dLo un1
+      h_q1c_le h_dLo_lt h_rhat_hi
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

- Adds `EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Phase1bNoFireBound.lean` with the V5 no-fire Phase-1b dLo bound at the Q1c level. Bead `evm-asm-wbc4i.4.6.7` (V5.4.0.8).
- `algorithmQ1cV5_dLo_bound_of_phase1b_no_fire` : `¬ algorithmPhase1bFireV5 ⇒ Q1c * dLo ≤ Rhatc * 2^32 + un1`.
- Case-splits on `rhatc >>> 32`:
  - **nonzero**: bound trivially holds since `rhatc * 2^32 ≥ 2^64`.
  - **zero**: V5's no-fire forces `¬ BLTU` (the high-half precondition for fire is satisfied, so non-fire must come from the BLTU side). Apply v4's generic `phase1b_no_fire_dLo_bound_of_rhat_hi_zero`.
- Reuses v4's two `phase1b_no_fire_dLo_bound_*` helpers (generic over `q1c, rhatc, dLo, un1`) without duplicating their arithmetic. This is the FIRST V5 file that consumes v4 infrastructure structurally — the generic helpers in `Phase1bBound.lean` work as-is.

**Stacked on PR #7098** (V5.4.0.7 Q0c half).

Refs #61. Bead: evm-asm-wbc4i.4.6.7.

Authored by @pirapira; implemented by Claude Code
