### PR TITLE
feat(div): Q1d/Rhatd = Q1c/Rhatc when V5 Phase-1b doesn't fire (V5.4.0.9)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -96,6 +96,7 @@ import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.NoWrap
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1d
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1cEuclidean
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Phase1bNoFireBound
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1dNoFire
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.CapBounds
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.NoWrap
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1d

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Q1dNoFire.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Q1dNoFire.lean
@@ -1,0 +1,66 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1dNoFire
+
+  When the V5 Phase-1b 1st correction does NOT fire, the post-1st-correction
+  values `algorithmQ1dV5` / `algorithmRhatdV5` coincide with the
+  Phase-1a-corrected values `algorithmQ1cV5` / `algorithmRhatcV5`.
+
+  Mirror of v4's `algorithmQ1dV4_eq_q1c_of_phase1b_no_fire`
+  (`Phase1bBound.lean:89`), but adapted to V5's stricter guard
+  (`rhatc >>> 32 = 0 ∧ BLTU` vs v4's bare BLTU).
+
+  Bead `evm-asm-wbc4i.4.6.8` (V5.4.0.9). Prerequisite for V5.4.1.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Phase1bNoFireBound
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- When Phase-1b 1st correction doesn't fire, `Q1d = Q1c`. -/
+theorem algorithmQ1dV5_eq_q1c_of_phase1b_no_fire
+    (uHi uLo vTop : Word)
+    (h_no_fire : ¬ algorithmPhase1bFireV5 uHi uLo vTop) :
+    algorithmQ1dV5 uHi uLo vTop = algorithmQ1cV5 uHi vTop := by
+  rw [algorithmQ1dV5_unfold]
+  dsimp only
+  -- The let-bindings flatten; just need to show the if-condition is false.
+  -- Direct case-split: show the fire condition is false.
+  have h_fire_false :
+      (decide (algorithmRhatcV5 uHi vTop >>> (32 : BitVec 6).toNat = 0) &&
+        BitVec.ult
+          ((algorithmRhatcV5 uHi vTop <<< (32 : BitVec 6).toNat) |||
+            divKTrialCallV5Un1 uLo)
+          (algorithmQ1cV5 uHi vTop * divKTrialCallV5DLo vTop)) ≠ true := by
+    intro h_true
+    rw [Bool.and_eq_true, decide_eq_true_eq] at h_true
+    obtain ⟨h_hi, h_ult⟩ := h_true
+    apply h_no_fire
+    delta algorithmPhase1bFireV5 algorithmRhatUn1cV5
+    exact ⟨h_hi, h_ult⟩
+  simp only [h_fire_false, Bool.false_eq_true, if_false]
+
+/-- When Phase-1b 1st correction doesn't fire, `Rhatd = Rhatc`. -/
+theorem algorithmRhatdV5_eq_rhatc_of_phase1b_no_fire
+    (uHi uLo vTop : Word)
+    (h_no_fire : ¬ algorithmPhase1bFireV5 uHi uLo vTop) :
+    algorithmRhatdV5 uHi uLo vTop = algorithmRhatcV5 uHi vTop := by
+  rw [algorithmRhatdV5_unfold]
+  dsimp only
+  -- Direct case-split: show the fire condition is false.
+  have h_fire_false :
+      (decide (algorithmRhatcV5 uHi vTop >>> (32 : BitVec 6).toNat = 0) &&
+        BitVec.ult
+          ((algorithmRhatcV5 uHi vTop <<< (32 : BitVec 6).toNat) |||
+            divKTrialCallV5Un1 uLo)
+          (algorithmQ1cV5 uHi vTop * divKTrialCallV5DLo vTop)) ≠ true := by
+    intro h_true
+    rw [Bool.and_eq_true, decide_eq_true_eq] at h_true
+    obtain ⟨h_hi, h_ult⟩ := h_true
+    apply h_no_fire
+    delta algorithmPhase1bFireV5 algorithmRhatUn1cV5
+    exact ⟨h_hi, h_ult⟩
+  simp only [h_fire_false, Bool.false_eq_true, if_false]
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

- Adds `EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Q1dNoFire.lean` with two equational lemmas. Bead `evm-asm-wbc4i.4.6.8` (V5.4.0.9).
- `algorithmQ1dV5_eq_q1c_of_phase1b_no_fire` and `algorithmRhatdV5_eq_rhatc_of_phase1b_no_fire`: when `¬ algorithmPhase1bFireV5`, the post-Phase-1b-1st-correction values coincide with the Phase-1a-corrected values.
- Proof unfolds the irreducible if-then-else: the fire condition is `(decide ... && BLTU)`, and we show that if it were `true` the algorithmPhase1bFireV5 `∧`-form would also be true, contradicting the no-fire hypothesis.
- Mirror of v4's `algorithmQ1dV4_eq_q1c_of_phase1b_no_fire` (`Phase1bBound.lean:89`), adapted to V5's stricter `(decide && BLTU)` guard form.

**Stacked on PR #7099** (V5.4.0.8 Phase-1b no-fire bound for Q1c).

Refs #61. Bead: evm-asm-wbc4i.4.6.8.

Authored by @pirapira; implemented by Claude Code
