### PR TITLE
feat(div): V5 Phase-1b no-fire overshoot bound for Q1d (V5.4.0.10)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Q1dNoFire.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Q1dNoFire.lean
@@ -63,4 +63,26 @@ theorem algorithmRhatdV5_eq_rhatc_of_phase1b_no_fire
     exact ⟨h_hi, h_ult⟩
   simp only [h_fire_false, Bool.false_eq_true, if_false]
 
+/-- When Phase-1b 1st correction doesn't fire, the Q1d/Rhatd pair
+    satisfies the "overshoot ≤ vTop" bound — the algorithm-level
+    precondition required by the generic
+    `div128Quot_phase2b_q0'_dLo_bound_fire_case`.
+
+    Combines V5.4.0.8 (Q1c bound) with V5.4.0.9 (Q1d = Q1c when no-fire)
+    and trivially weakens to the overshoot form. Mirror of v4's
+    `algorithmQ1dV4_dLo_overshoot_le_vTop_of_phase1b_no_fire`
+    (`Phase1bBound.lean:838`). -/
+theorem algorithmQ1dV5_dLo_overshoot_le_vTop_of_phase1b_no_fire
+    (uHi uLo vTop : Word)
+    (h_no_fire : ¬ algorithmPhase1bFireV5 uHi uLo vTop) :
+    (algorithmQ1dV5 uHi uLo vTop).toNat * (divKTrialCallV5DLo vTop).toNat ≤
+      (algorithmRhatdV5 uHi uLo vTop).toNat * 2^32 +
+        (divKTrialCallV5Un1 uLo).toNat +
+        (divKTrialCallV5DHi vTop).toNat * 2^32 +
+        (divKTrialCallV5DLo vTop).toNat := by
+  have h_bound := algorithmQ1cV5_dLo_bound_of_phase1b_no_fire uHi uLo vTop h_no_fire
+  rw [algorithmQ1dV5_eq_q1c_of_phase1b_no_fire uHi uLo vTop h_no_fire,
+      algorithmRhatdV5_eq_rhatc_of_phase1b_no_fire uHi uLo vTop h_no_fire]
+  exact le_trans h_bound (Nat.le_add_right _ _ |>.trans (Nat.le_add_right _ _))
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

- Adds `algorithmQ1dV5_dLo_overshoot_le_vTop_of_phase1b_no_fire` to `Q1dNoFire.lean`. Bead `evm-asm-wbc4i.4.6.9` (V5.4.0.10).
- Combines V5.4.0.8 (`algorithmQ1cV5_dLo_bound_of_phase1b_no_fire`) + V5.4.0.9 (Q1d = Q1c when no-fire) to derive the overshoot bound at Q1d level: `Q1d*dLo ≤ Rhatd*2^32 + un1 + dHi*2^32 + dLo`.
- Used omega-free `le_trans` chain to dodge `maxRecDepth` on the heavily-unfolded goal (the omega-based approach hit recursion-depth limit on the let-chain).
- This bound is the algorithm-level precondition for the generic `div128Quot_phase2b_q0'_dLo_bound_fire_case` helper that V5.4.1 will invoke when composing the Phase-1b 2nd correction. Mirror of v4's `algorithmQ1dV4_dLo_overshoot_le_vTop_of_phase1b_no_fire` (`Phase1bBound.lean:838`).

**Stacked on PR #7100** (V5.4.0.9 Q1d/Rhatd no-fire equations).

Refs #61. Bead: evm-asm-wbc4i.4.6.9.

Authored by @pirapira; implemented by Claude Code
