### PR TITLE
feat(stateless): compute node_4_5 dynamically (support prev_randao)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -310,6 +310,22 @@ def statelessGuestEpilogue : String :=
   "  # \n" ++
   "  # ===== exec_payload merkle path (leaves 0-15) =====\n" ++
   "  # Path leaf_6 -> node_6_7 -> node_4_7 -> node_0_7 -> node_0_15\n" ++
+  "  # First: dynamically compute node_4_5 = sha256(leaf_4 || leaf_5)\n" ++
+  "  # where leaf_4 = npr_leaf_4_logs_bloom_root (constant, default\n" ++
+  "  # logs_bloom merkle root) and leaf_5 = prev_randao (Bytes32 @\n" ++
+  "  # SSZ_BASE + 16 + 44 + 372 = +432).\n" ++
+  "  la t1, npr_sha_input\n" ++
+  "  la t3, npr_leaf_4_logs_bloom_root\n" ++
+  "  ld t2,  0(t3); sd t2,  0(t1)\n" ++
+  "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 16(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 24(t1)\n" ++
+  "  ld t2, 432(s6); sd t2, 32(t1)\n" ++
+  "  ld t2, 440(s6); sd t2, 40(t1)\n" ++
+  "  ld t2, 448(s6); sd t2, 48(t1)\n" ++
+  "  ld t2, 456(s6); sd t2, 56(t1)\n" ++
+  "  la a0, npr_sha_input; li a1, 64; la a2, npr_node_4_5_scratch\n" ++
+  "  jal ra, zkvm_sha256         # node_4_5 -> npr_node_4_5_scratch\n" ++
   "  # leaf_6 = block_number (u64 LE @ SSZ_BASE + 16 + 44 + 404 = +464)\n" ++
   "  #          || 24 bytes of zero padding\n" ++
   "  # leaf_7 = gas_limit    (u64 LE @ SSZ_BASE + 16 + 44 + 412 = +472)\n" ++
@@ -323,9 +339,9 @@ def statelessGuestEpilogue : String :=
   "  sd zero, 40(t1); sd zero, 48(t1); sd zero, 56(t1)\n" ++
   "  la a0, npr_sha_input; li a1, 64; la a2, npr_sha_subtree\n" ++
   "  jal ra, zkvm_sha256         # node_6_7 -> npr_sha_subtree\n" ++
-  "  # node_4_7 = sha256(npr_node_4_5 || node_6_7)\n" ++
+  "  # node_4_7 = sha256(npr_node_4_5_scratch || node_6_7)\n" ++
   "  la t1, npr_sha_input\n" ++
-  "  la t3, npr_node_4_5\n" ++
+  "  la t3, npr_node_4_5_scratch\n" ++
   "  ld t2,  0(t3); sd t2,  0(t1)\n" ++
   "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
   "  ld t2, 16(t3); sd t2, 16(t1)\n" ++

--- a/EvmAsm/Codegen/Programs/StatelessGuestData.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuestData.lean
@@ -286,6 +286,23 @@ def statelessGuestDataSection : String :=
   "  .byte 0xb6, 0x76, 0xd2, 0x91, 0x3b, 0xac, 0x8d, 0x4e\n" ++
   ".balign 8\n" ++
   "npr_node_0_15_scratch:\n" ++
+  "  .zero 32\n" ++
+  -- `npr_leaf_4_logs_bloom_root` is the SSZ hash_tree_root of
+  -- an empty `logs_bloom` (ByteVector[256], all zeros), = leaf 4
+  -- of the default exec_payload merkle. Now that the
+  -- `.Lsg_hash` epilogue computes `node_4_5` dynamically to
+  -- support non-default `prev_randao` (= leaf 5), only the
+  -- logs_bloom-side leaf needs to be precomputed as a constant.
+  -- `npr_node_4_5_scratch` holds the dynamic
+  -- sha256(npr_leaf_4_logs_bloom_root || prev_randao).
+  ".balign 8\n" ++
+  "npr_leaf_4_logs_bloom_root:\n" ++
+  "  .byte 0xc7, 0x80, 0x09, 0xfd, 0xf0, 0x7f, 0xc5, 0x6a\n" ++
+  "  .byte 0x11, 0xf1, 0x22, 0x37, 0x06, 0x58, 0xa3, 0x53\n" ++
+  "  .byte 0xaa, 0xa5, 0x42, 0xed, 0x63, 0xe4, 0x4c, 0x4b\n" ++
+  "  .byte 0xc1, 0x5f, 0xf4, 0xcd, 0x10, 0x5a, 0xb3, 0x3c\n" ++
+  ".balign 8\n" ++
+  "npr_node_4_5_scratch:\n" ++
   "  .zero 32"
 
 end EvmAsm.Codegen

--- a/scripts/codegen-stateless-gen-fixture.py
+++ b/scripts/codegen-stateless-gen-fixture.py
@@ -68,6 +68,7 @@ npr_slot_str = sys.argv[13] if len(sys.argv) > 13 else ''
 npr_excess_blob_str = sys.argv[14] if len(sys.argv) > 14 else ''
 npr_block_number_str = sys.argv[15] if len(sys.argv) > 15 else ''
 npr_gas_limit_str = sys.argv[16] if len(sys.argv) > 16 else ''
+npr_prev_randao_hex = sys.argv[17] if len(sys.argv) > 17 else ''
 
 # Build the new-schema StatelessInput: empty new_payload_request,
 # witness whose 'state'/'codes' lists each hold zero or more
@@ -738,9 +739,11 @@ npr_kwargs = {}
 if npr_pbr_hex:
     from remerkleable.byte_arrays import Bytes32 as Bytes32SSZ
     npr_kwargs['parent_beacon_block_root'] = Bytes32SSZ(bytes.fromhex(npr_pbr_hex))
-if npr_slot_str or npr_excess_blob_str or npr_block_number_str or npr_gas_limit_str:
+if (npr_slot_str or npr_excess_blob_str or npr_block_number_str or
+    npr_gas_limit_str or npr_prev_randao_hex):
     from ethereum.forks.amsterdam.stateless_ssz import SszExecutionPayload
     from remerkleable.basic import uint64 as Uint64SSZ
+    from remerkleable.byte_arrays import Bytes32 as Bytes32SSZ
     ep_kwargs = {}
     if npr_slot_str:
         ep_kwargs['slot_number'] = Uint64SSZ(int(npr_slot_str, 0))
@@ -750,6 +753,8 @@ if npr_slot_str or npr_excess_blob_str or npr_block_number_str or npr_gas_limit_
         ep_kwargs['block_number'] = Uint64SSZ(int(npr_block_number_str, 0))
     if npr_gas_limit_str:
         ep_kwargs['gas_limit'] = Uint64SSZ(int(npr_gas_limit_str, 0))
+    if npr_prev_randao_hex:
+        ep_kwargs['prev_randao'] = Bytes32SSZ(bytes.fromhex(npr_prev_randao_hex))
     npr_kwargs['execution_payload'] = SszExecutionPayload(**ep_kwargs)
 npr = SszNewPayloadRequest(**npr_kwargs)
 

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -85,6 +85,7 @@ run_fixture() {
   local npr_excess_blob_str="${13:-}"
   local npr_block_number_str="${14:-}"
   local npr_gas_limit_str="${15:-}"
+  local npr_prev_randao_hex="${16:-}"
 
   local safe="${label//[^0-9A-Za-z_]/_}"
   local input_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.input"
@@ -92,8 +93,8 @@ run_fixture() {
   local spec_exp_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.spec-expected"
   local log_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.emu.log"
 
-  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty}, npr_pbr=${npr_pbr_hex:-empty}, npr_slot=${npr_slot_str:-empty}, npr_excess_blob=${npr_excess_blob_str:-empty}, npr_block_number=${npr_block_number_str:-empty}, npr_gas_limit=${npr_gas_limit_str:-empty})"
-  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex" "$npr_pbr_hex" "$npr_slot_str" "$npr_excess_blob_str" "$npr_block_number_str" "$npr_gas_limit_str"
+  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty}, npr_pbr=${npr_pbr_hex:-empty}, npr_slot=${npr_slot_str:-empty}, npr_excess_blob=${npr_excess_blob_str:-empty}, npr_block_number=${npr_block_number_str:-empty}, npr_gas_limit=${npr_gas_limit_str:-empty}, npr_prev_randao=${npr_prev_randao_hex:-empty})"
+  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex" "$npr_pbr_hex" "$npr_slot_str" "$npr_excess_blob_str" "$npr_block_number_str" "$npr_gas_limit_str" "$npr_prev_randao_hex"
 
   # Guard against silent fail: if the spec generator crashed
   # (Python syntax error in the heredoc, missing import, etc.)
@@ -245,6 +246,15 @@ run_fixture "chain1_npr_exec_payload_block_number_abcdef" 1 0 ""        ""      
 # the asm to read gas_limit from input and use it as the
 # right input to node_6_7 = sha256(leaf_6 || leaf_7).
 run_fixture "chain1_npr_exec_payload_gas_limit_coffee" 1 0  ""           ""                  ""    ""           ""           ""    ""                       ""                                ""    ""    ""    "12648430" || fail=1
+
+# Non-empty execution_payload: prev_randao = 0xAA*32 (leaf
+# 5, Bytes32 inline). The current implementation uses
+# `npr_node_4_5` as a precomputed constant; this PR replaces
+# it with a dynamic sha256(npr_leaf_4_logs_bloom_root ||
+# prev_randao_from_input). One extra sha256 call; one new
+# 32-byte constant `npr_leaf_4_logs_bloom_root` (the default
+# logs_bloom merkle root).
+run_fixture "chain1_npr_exec_payload_prev_randao_aa" 1   0   ""           ""                  ""    ""           ""           ""    ""                       ""                                ""    ""    ""    ""    "$(printf 'aa%.0s' {1..32})" || fail=1
 
 # Edge: chain_id = 2^32 = 0x100000000. LE bytes
 # 00 00 00 00 01 00 00 00. The encoder's chain_id split


### PR DESCRIPTION
## Summary

Stacks on the npr_block_number / npr_gas_limit sequence. This PR opens up \`execution_payload.prev_randao\` (leaf 5).

**Initially-failing fixture:** \`chain1_npr_exec_payload_prev_randao_aa\` sets \`NPR.execution_payload.prev_randao = 0xAA × 32\` (Bytes32 inline at leaf 5).

**Smallest implementation step:** replace the precomputed \`npr_node_4_5\` \`.data\` constant with a dynamic \`sha256(npr_leaf_4_logs_bloom_root || prev_randao_from_input)\` computation. **One extra sha256 call** (13 → 14 total).

| new symbol | meaning |
| ---------- | ------- |
| \`npr_leaf_4_logs_bloom_root\` | SSZ \`hash_tree_root\` of the default empty \`logs_bloom\` (= leaf 4; stays static for now since varying logs_bloom would require its own 8-chunk merkle subtree) |
| \`npr_node_4_5_scratch\` | 32-byte buffer holding dynamic \`node_4_5\` |

\`prev_randao\` is read from input at \`SSZ_BASE + 16 + 44 + 372 = SSZ_BASE + 432\` (NPR_addr = SSZ_BASE+16; exec_payload_addr = NPR+44; \`prev_randao\` Bytes32 inline at \`exec_payload + 372\`).

For all pre-existing fixtures (\`prev_randao=zero\`), the dynamic computation reproduces the old \`npr_node_4_5\` constant byte-for-byte because the static constant was exactly \`sha256(logs_bloom_default || 0)\`. The existing 80+ fixtures continue to pass.

## Surface

| file | change |
| ---- | ------ |
| \`scripts/codegen-stateless-spec-output-check.sh\` | 16th optional positional arg \`npr_prev_randao_hex\`; new fixture \`chain1_npr_exec_payload_prev_randao_aa\`. |
| \`scripts/codegen-stateless-gen-fixture.py\` | read \`sys.argv[17]\` as \`npr_prev_randao_hex\`; when set, populate \`SszExecutionPayload(prev_randao=Bytes32SSZ(...))\`. |
| \`EvmAsm/Codegen/Programs.lean\` | new sha256 step inserted before \`node_6_7\` computes \`node_4_5\` dynamically. \`node_4_7\` now references \`npr_node_4_5_scratch\`. |
| \`EvmAsm/Codegen/Programs/StatelessGuestData.lean\` | new \`npr_leaf_4_logs_bloom_root\` constant and \`npr_node_4_5_scratch\` buffer. |

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)