### PR TITLE
feat(stateless): compute node_8_15 dynamically (support gas_used)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -326,6 +326,46 @@ def statelessGuestEpilogue : String :=
   "  ld t2, 456(s6); sd t2, 56(t1)\n" ++
   "  la a0, npr_sha_input; li a1, 64; la a2, npr_node_4_5_scratch\n" ++
   "  jal ra, zkvm_sha256         # node_4_5 -> npr_node_4_5_scratch\n" ++
+  "  # \n" ++
+  "  # Dynamic node_8_15 path (supports leaf_8 = gas_used):\n" ++
+  "  #   leaf_8 = gas_used (u64 LE @ SSZ_BASE + 16 + 44 + 420 = +480)\n" ++
+  "  #            || 24 bytes of zero padding\n" ++
+  "  #   leaf_9 = ssz_zero_hash[0] (timestamp default = u64 zero)\n" ++
+  "  la t1, npr_sha_input\n" ++
+  "  ld t2, 480(s6)              # gas_used\n" ++
+  "  sd t2,  0(t1)\n" ++
+  "  sd zero,  8(t1); sd zero, 16(t1); sd zero, 24(t1)\n" ++
+  "  sd zero, 32(t1); sd zero, 40(t1); sd zero, 48(t1); sd zero, 56(t1)\n" ++
+  "  la a0, npr_sha_input; li a1, 64; la a2, npr_sha_subtree\n" ++
+  "  jal ra, zkvm_sha256         # node_8_9 -> npr_sha_subtree\n" ++
+  "  # node_8_11 = sha256(node_8_9 || npr_node_10_11)\n" ++
+  "  la t1, npr_sha_input\n" ++
+  "  la t3, npr_sha_subtree\n" ++
+  "  ld t2,  0(t3); sd t2,  0(t1)\n" ++
+  "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 16(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 24(t1)\n" ++
+  "  la t3, npr_node_10_11\n" ++
+  "  ld t2,  0(t3); sd t2, 32(t1)\n" ++
+  "  ld t2,  8(t3); sd t2, 40(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 48(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 56(t1)\n" ++
+  "  la a0, npr_sha_input; li a1, 64; la a2, npr_sha_subtree\n" ++
+  "  jal ra, zkvm_sha256         # node_8_11 -> npr_sha_subtree\n" ++
+  "  # node_8_15 = sha256(node_8_11 || npr_node_12_15) -> npr_node_8_15_scratch\n" ++
+  "  la t1, npr_sha_input\n" ++
+  "  la t3, npr_sha_subtree\n" ++
+  "  ld t2,  0(t3); sd t2,  0(t1)\n" ++
+  "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 16(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 24(t1)\n" ++
+  "  la t3, npr_node_12_15\n" ++
+  "  ld t2,  0(t3); sd t2, 32(t1)\n" ++
+  "  ld t2,  8(t3); sd t2, 40(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 48(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 56(t1)\n" ++
+  "  la a0, npr_sha_input; li a1, 64; la a2, npr_node_8_15_scratch\n" ++
+  "  jal ra, zkvm_sha256         # node_8_15 -> npr_node_8_15_scratch\n" ++
   "  # leaf_6 = block_number (u64 LE @ SSZ_BASE + 16 + 44 + 404 = +464)\n" ++
   "  #          || 24 bytes of zero padding\n" ++
   "  # leaf_7 = gas_limit    (u64 LE @ SSZ_BASE + 16 + 44 + 412 = +472)\n" ++
@@ -375,7 +415,7 @@ def statelessGuestEpilogue : String :=
   "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
   "  ld t2, 16(t3); sd t2, 16(t1)\n" ++
   "  ld t2, 24(t3); sd t2, 24(t1)\n" ++
-  "  la t3, npr_node_8_15\n" ++
+  "  la t3, npr_node_8_15_scratch\n" ++
   "  ld t2,  0(t3); sd t2, 32(t1)\n" ++
   "  ld t2,  8(t3); sd t2, 40(t1)\n" ++
   "  ld t2, 16(t3); sd t2, 48(t1)\n" ++

--- a/EvmAsm/Codegen/Programs/StatelessGuestData.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuestData.lean
@@ -303,6 +303,32 @@ def statelessGuestDataSection : String :=
   "  .byte 0xc1, 0x5f, 0xf4, 0xcd, 0x10, 0x5a, 0xb3, 0x3c\n" ++
   ".balign 8\n" ++
   "npr_node_4_5_scratch:\n" ++
+  "  .zero 32\n" ++
+  -- Sibling constants for the dynamic node_8_15 path supporting
+  -- leaf_8 = gas_used. Both are subtree roots over default
+  -- exec_payload fields and remain static until those leaves
+  -- are opened up in follow-up PRs:
+  --   npr_node_10_11 = sha256(leaf_10=extra_data_root_default ||
+  --                           leaf_11=base_fee_per_gas_default)
+  --   npr_node_12_15 = subtree over default leaves 12..15
+  --                    (block_hash, transactions, withdrawals,
+  --                    blob_gas_used).
+  -- `npr_node_8_15_scratch` is the 32-byte buffer that holds
+  -- the dynamic node_8_15.
+  ".balign 8\n" ++
+  "npr_node_10_11:\n" ++
+  "  .byte 0x7a, 0x05, 0x01, 0xf5, 0x95, 0x7b, 0xdf, 0x9c\n" ++
+  "  .byte 0xb3, 0xa8, 0xff, 0x49, 0x66, 0xf0, 0x22, 0x65\n" ++
+  "  .byte 0xf9, 0x68, 0x65, 0x8b, 0x7a, 0x9c, 0x62, 0x64\n" ++
+  "  .byte 0x2c, 0xba, 0x11, 0x65, 0xe8, 0x66, 0x42, 0xf5\n" ++
+  ".balign 8\n" ++
+  "npr_node_12_15:\n" ++
+  "  .byte 0x88, 0x4f, 0x54, 0x7a, 0xad, 0x3a, 0x48, 0x73\n" ++
+  "  .byte 0xe7, 0x79, 0xe0, 0x4f, 0x8d, 0xdd, 0xb8, 0x8f\n" ++
+  "  .byte 0xd4, 0xe8, 0x22, 0x22, 0xa4, 0x4a, 0xb8, 0xa0\n" ++
+  "  .byte 0x37, 0xf2, 0x21, 0xdb, 0x97, 0xe9, 0x7b, 0xaa\n" ++
+  ".balign 8\n" ++
+  "npr_node_8_15_scratch:\n" ++
   "  .zero 32"
 
 end EvmAsm.Codegen

--- a/scripts/codegen-stateless-gen-fixture.py
+++ b/scripts/codegen-stateless-gen-fixture.py
@@ -69,6 +69,7 @@ npr_excess_blob_str = sys.argv[14] if len(sys.argv) > 14 else ''
 npr_block_number_str = sys.argv[15] if len(sys.argv) > 15 else ''
 npr_gas_limit_str = sys.argv[16] if len(sys.argv) > 16 else ''
 npr_prev_randao_hex = sys.argv[17] if len(sys.argv) > 17 else ''
+npr_gas_used_str = sys.argv[18] if len(sys.argv) > 18 else ''
 
 # Build the new-schema StatelessInput: empty new_payload_request,
 # witness whose 'state'/'codes' lists each hold zero or more
@@ -740,7 +741,7 @@ if npr_pbr_hex:
     from remerkleable.byte_arrays import Bytes32 as Bytes32SSZ
     npr_kwargs['parent_beacon_block_root'] = Bytes32SSZ(bytes.fromhex(npr_pbr_hex))
 if (npr_slot_str or npr_excess_blob_str or npr_block_number_str or
-    npr_gas_limit_str or npr_prev_randao_hex):
+    npr_gas_limit_str or npr_prev_randao_hex or npr_gas_used_str):
     from ethereum.forks.amsterdam.stateless_ssz import SszExecutionPayload
     from remerkleable.basic import uint64 as Uint64SSZ
     from remerkleable.byte_arrays import Bytes32 as Bytes32SSZ
@@ -755,6 +756,8 @@ if (npr_slot_str or npr_excess_blob_str or npr_block_number_str or
         ep_kwargs['gas_limit'] = Uint64SSZ(int(npr_gas_limit_str, 0))
     if npr_prev_randao_hex:
         ep_kwargs['prev_randao'] = Bytes32SSZ(bytes.fromhex(npr_prev_randao_hex))
+    if npr_gas_used_str:
+        ep_kwargs['gas_used'] = Uint64SSZ(int(npr_gas_used_str, 0))
     npr_kwargs['execution_payload'] = SszExecutionPayload(**ep_kwargs)
 npr = SszNewPayloadRequest(**npr_kwargs)
 

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -86,6 +86,7 @@ run_fixture() {
   local npr_block_number_str="${14:-}"
   local npr_gas_limit_str="${15:-}"
   local npr_prev_randao_hex="${16:-}"
+  local npr_gas_used_str="${17:-}"
 
   local safe="${label//[^0-9A-Za-z_]/_}"
   local input_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.input"
@@ -93,8 +94,8 @@ run_fixture() {
   local spec_exp_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.spec-expected"
   local log_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.emu.log"
 
-  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty}, npr_pbr=${npr_pbr_hex:-empty}, npr_slot=${npr_slot_str:-empty}, npr_excess_blob=${npr_excess_blob_str:-empty}, npr_block_number=${npr_block_number_str:-empty}, npr_gas_limit=${npr_gas_limit_str:-empty}, npr_prev_randao=${npr_prev_randao_hex:-empty})"
-  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex" "$npr_pbr_hex" "$npr_slot_str" "$npr_excess_blob_str" "$npr_block_number_str" "$npr_gas_limit_str" "$npr_prev_randao_hex"
+  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty}, npr_pbr=${npr_pbr_hex:-empty}, npr_slot=${npr_slot_str:-empty}, npr_excess_blob=${npr_excess_blob_str:-empty}, npr_block_number=${npr_block_number_str:-empty}, npr_gas_limit=${npr_gas_limit_str:-empty}, npr_prev_randao=${npr_prev_randao_hex:-empty}, npr_gas_used=${npr_gas_used_str:-empty})"
+  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex" "$npr_pbr_hex" "$npr_slot_str" "$npr_excess_blob_str" "$npr_block_number_str" "$npr_gas_limit_str" "$npr_prev_randao_hex" "$npr_gas_used_str"
 
   # Guard against silent fail: if the spec generator crashed
   # (Python syntax error in the heredoc, missing import, etc.)
@@ -255,6 +256,16 @@ run_fixture "chain1_npr_exec_payload_gas_limit_coffee" 1 0  ""           ""     
 # 32-byte constant `npr_leaf_4_logs_bloom_root` (the default
 # logs_bloom merkle root).
 run_fixture "chain1_npr_exec_payload_prev_randao_aa" 1   0   ""           ""                  ""    ""           ""           ""    ""                       ""                                ""    ""    ""    ""    "$(printf 'aa%.0s' {1..32})" || fail=1
+
+# Non-empty execution_payload: gas_used = 0x1234 (leaf 8 in
+# the exec_payload Container's 32-leaf merkle). Drives the
+# implementation past the existing `npr_node_8_15` constant
+# by computing the leaf_8 -> node_8_15 path dynamically (3
+# extra sha256 calls). Two new sibling constants
+# (`npr_node_10_11`, `npr_node_12_15`) cover the default
+# subtrees that branch off the path; the leaf_9 (timestamp)
+# sibling stays hardcoded zero for now.
+run_fixture "chain1_npr_exec_payload_gas_used_1234" 1    0   ""           ""                  ""    ""           ""           ""    ""                       ""                                ""    ""    ""    ""    ""                                "4660" || fail=1
 
 # Edge: chain_id = 2^32 = 0x100000000. LE bytes
 # 00 00 00 00 01 00 00 00. The encoder's chain_id split


### PR DESCRIPTION
Stacks on the npr_prev_randao series (#7106 already merged). Opens up \`execution_payload.gas_used\` (leaf 8).

**Initially-failing fixture:** \`chain1_npr_exec_payload_gas_used_1234\`.

**Smallest implementation step:** replace the precomputed \`npr_node_8_15\` \`.data\` constant with a dynamic 3-call sha256 merkle path:

\`\`\`
node_8_9  = sha256(leaf_8 || leaf_9=ssz_zero_hash[0])
node_8_11 = sha256(node_8_9 || npr_node_10_11_constant)
node_8_15 = sha256(node_8_11 || npr_node_12_15_constant)
\`\`\`

| new constant | meaning |
| ------------ | ------- |
| \`npr_node_10_11\` | \`sha256(extra_data_root || base_fee_per_gas_default)\` |
| \`npr_node_12_15\` | subtree root over default leaves 12..15 |

\`gas_used\` is read from input at \`SSZ_BASE + 16 + 44 + 420 = SSZ_BASE + 480\`.

leaf_9 (timestamp) stays hardcoded as \`ssz_zero_hash[0]\` — a future PR can extend \`node_8_9\` to read timestamp from input as well, mirroring the leaf_6/leaf_7 sibling extension pattern.

For all pre-existing fixtures (\`gas_used=0\`), the dynamic computation reproduces the old \`npr_node_8_15\` constant byte-for-byte.

\`sha256\` calls in \`.Lsg_hash\`: 14 → 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)