### PR TITLE
feat(div): V5.4.1 irreducible-form Phase-1b dLo bound (V5.4.1.1)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Phase1bBound.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Phase1bBound.lean
@@ -88,4 +88,79 @@ theorem algorithmQ1dV5_phase1b_dLo_bound
     rw [h_qeq, if_neg h_guard]
     exact h_bound
 
+/-- Bridge: `divKTrialCallV5Q1dd` = `phase2b_q0'` on `(algorithmQ1d, algorithmRhatd)`.
+
+    Sidesteps the let-factoring mismatch via case-split on `hi1`: in each
+    branch, V5.2's symbolic `q1c` reference inside `rhatc` reduces to the
+    same concrete value as `algorithmRhatcV5_unfold`'s direct `q1cCap`
+    substitution. Bead `evm-asm-wbc4i.4.1.1` (V5.4.1.1). -/
+private theorem divKTrialCallV5Q1dd_eq_alg (uHi uLo vTop : Word) :
+    divKTrialCallV5Q1dd uHi uLo vTop =
+      div128Quot_phase2b_q0'
+        (algorithmQ1dV5 uHi uLo vTop)
+        (algorithmRhatdV5 uHi uLo vTop)
+        (divKTrialCallV5DLo vTop)
+        (divKTrialCallV5Un1 uLo) := by
+  rw [divKTrialCallV5Q1dd_eq_phase2b]
+  rw [algorithmQ1dV5_unfold, algorithmRhatdV5_unfold]
+  rw [algorithmQ1cV5_unfold, algorithmRhatcV5_unfold]
+  by_cases h : rv64_divu uHi (divKTrialCallV5DHi vTop) >>>
+      (32 : BitVec 6).toNat = (0 : Word)
+  · simp only [h, ↓reduceIte]
+  · simp only [h, ↓reduceIte]
+
+/-- Bridge for `divKTrialCallV5Rhatdd` — NESTED form to match V5.2's
+    eq_phase2b RHS exactly. -/
+private theorem divKTrialCallV5Rhatdd_eq_alg (uHi uLo vTop : Word) :
+    divKTrialCallV5Rhatdd uHi uLo vTop =
+      (if algorithmRhatdV5 uHi uLo vTop >>> (32 : BitVec 6).toNat = (0 : Word) then
+        let qDlo2 := algorithmQ1dV5 uHi uLo vTop * divKTrialCallV5DLo vTop
+        let rhatUn1' :=
+          (algorithmRhatdV5 uHi uLo vTop <<< (32 : BitVec 6).toNat) |||
+            divKTrialCallV5Un1 uLo
+        if BitVec.ult rhatUn1' qDlo2 then
+          algorithmRhatdV5 uHi uLo vTop + divKTrialCallV5DHi vTop
+        else algorithmRhatdV5 uHi uLo vTop
+      else algorithmRhatdV5 uHi uLo vTop) := by
+  rw [divKTrialCallV5Rhatdd_eq_phase2b]
+  rw [algorithmQ1dV5_unfold, algorithmRhatdV5_unfold]
+  rw [algorithmQ1cV5_unfold, algorithmRhatcV5_unfold]
+  by_cases h : rv64_divu uHi (divKTrialCallV5DHi vTop) >>>
+      (32 : BitVec 6).toNat = (0 : Word)
+  · simp only [h, ↓reduceIte]
+  · simp only [h, ↓reduceIte]
+
+/-- **V5.4.1 irreducible-form**: Phase-1b 2nd-correction dLo bound for V5
+    on the literal `divKTrialCallV5Q1dd` / `divKTrialCallV5Rhatdd`
+    irreducibles. Wraps the algorithm-level version via the two
+    case-split bridges. Closes the V5.4.1 bead's literal statement. -/
+theorem divKTrialCallV5_phase1b_dLo_bound
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat) :
+    (divKTrialCallV5Q1dd uHi uLo vTop).toNat *
+        (divKTrialCallV5DLo vTop).toNat ≤
+      (divKTrialCallV5Rhatdd uHi uLo vTop).toNat * 2^32 +
+        (divKTrialCallV5Un1 uLo).toNat := by
+  rw [divKTrialCallV5Q1dd_eq_alg, divKTrialCallV5Rhatdd_eq_alg]
+  -- Convert nested if (from Rhatdd bridge) to flat-AND if (algorithm-level statement).
+  have h_alg := algorithmQ1dV5_phase1b_dLo_bound uHi uLo vTop hvTop_ge huHi_lt_vTop
+  dsimp only at h_alg ⊢
+  by_cases h_outer : algorithmRhatdV5 uHi uLo vTop >>> (32 : BitVec 6).toNat = (0 : Word)
+  · rw [if_pos h_outer]
+    by_cases h_inner :
+        BitVec.ult
+          ((algorithmRhatdV5 uHi uLo vTop <<< (32 : BitVec 6).toNat) |||
+            divKTrialCallV5Un1 uLo)
+          (algorithmQ1dV5 uHi uLo vTop * divKTrialCallV5DLo vTop)
+    · rw [if_pos h_inner]
+      rw [if_pos ⟨h_outer, h_inner⟩] at h_alg
+      exact h_alg
+    · rw [if_neg h_inner]
+      rw [if_neg (fun h => h_inner h.2)] at h_alg
+      exact h_alg
+  · rw [if_neg h_outer]
+    rw [if_neg (fun h => h_outer h.1)] at h_alg
+    exact h_alg
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

- Closes bead `evm-asm-wbc4i.4.1.1` (V5.4.1.1) — and completes V5.4.1's literal statement.
- Adds `divKTrialCallV5_phase1b_dLo_bound` on the irreducible `Q1dd` / `Rhatdd` forms, wrapping the algorithm-level `algorithmQ1dV5_phase1b_dLo_bound` via two case-split bridges.
- **The bridges** sidestep the V5.2 ↔ algorithm let-factoring mismatch by case-splitting on `hi1 = q1 >>> 32 = 0`: in each branch, V5.2's symbolic `q1c` reference inside `rhatc` reduces to the same concrete expression as `algorithmRhatcV5_unfold`'s direct `q1cCap` substitution. The `simp only [h, ↓reduceIte]` chain closes both branches.
- **The main proof** uses the nested-if form (matching V5.2's `eq_phase2b`); the conversion to flat-AND form (in `algorithmQ1dV5_phase1b_dLo_bound`'s statement) is done via explicit `if_pos`/`if_neg` case-splits on the inner BLTU condition.
- Mirror of v4's `divKTrialCallV4_phase1b_dLo_bound` + `eq_phase2b_algorithm` chain (`Phase1bBound.lean:988` + `:630/:646`).

**Stacked on PR #7110** (V5.4.1 algorithm-level).

Refs #61. Bead: evm-asm-wbc4i.4.1.1.

Authored by @pirapira; implemented by Claude Code
