### PR TITLE
feat(div): V5.5.0.3 — Phase-1b 1st-fire ⇒ q_true_1 < Q1c (strict)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -105,4 +105,5 @@ import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Phase1bBound
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1ddBound
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1cLB
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1cLBUncond
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1cStrictLT
 import EvmAsm.Evm64.EvmWordArith.Div128CallSkipCloseV4

--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -106,4 +106,5 @@ import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1ddBound
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1cLB
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1cLBUncond
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1cStrictLT
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1dLB
 import EvmAsm.Evm64.EvmWordArith.Div128CallSkipCloseV4

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Q1cStrictLT.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Q1cStrictLT.lean
@@ -1,0 +1,83 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1cStrictLT
+
+  V5.5.0.3: when V5's Phase-1b 1st correction fires, the abstract first
+  quotient digit is STRICTLY less than the Phase-1a-corrected quotient:
+
+    algorithmPhase1bFireV5 ⇒ q_true_1 < Q1c.toNat
+
+  Uses the generic `phase1b_fire_q_true_1_lt_q_nat` helper from
+  `CallSkipLowerBoundV4/Phase1bBound.lean` + Q1c Euclidean (V5.4.0.7)
+  + bit-level no-wrap facts.
+
+  Bead `evm-asm-wbc4i.5.6` (V5.5.0.3). Prerequisite for V5.5.1 to show
+  Q1d = Q1c - 1 ≥ q_true_1 in the fire case.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1cLBUncond
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Phase1bBound
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64 EvmWord
+
+theorem algorithmQ1cV5_q_true_1_lt_of_phase1b_fire
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (h_fire : algorithmPhase1bFireV5 uHi uLo vTop) :
+    (uHi.toNat * 2^32 + (divKTrialCallV5Un1 uLo).toNat) / vTop.toNat <
+      (algorithmQ1cV5 uHi vTop).toNat := by
+  -- Extract fire's two conditions.
+  rw [algorithmPhase1bFireV5_unfold] at h_fire
+  rw [algorithmRhatUn1cV5_unfold] at h_fire
+  obtain ⟨h_rhat_hi_zero, h_ult⟩ := h_fire
+  -- Setup names.
+  set q := algorithmQ1cV5 uHi vTop with hq
+  set rhat := algorithmRhatcV5 uHi vTop with hrhat
+  set dHi := divKTrialCallV5DHi vTop with hdHi
+  set dLo := divKTrialCallV5DLo vTop with hdLo
+  set un := divKTrialCallV5Un1 uLo with hun
+  -- Get vTop decomposition.
+  have h_vTop_decomp : vTop.toNat = dHi.toNat * 2^32 + dLo.toNat := by
+    rw [hdHi, hdLo]; unfold divKTrialCallV5DHi divKTrialCallV5DLo
+    exact div128Quot_vTop_decomp vTop
+  -- Get Q1c Euclidean (V5.4.0.7): q * dHi + rhat = uHi.
+  have h_post : q.toNat * dHi.toNat + rhat.toNat = uHi.toNat := by
+    rw [hq, hrhat, hdHi]
+    exact algorithmQ1cV5_rhatc_post uHi vTop hvTop_ge
+  -- rhat < 2^32 from h_rhat_hi_zero.
+  have h_rhat_lt : rhat.toNat < 2^32 := by
+    have h_nat : (rhat >>> (32 : BitVec 6).toNat).toNat = 0 := by
+      rw [h_rhat_hi_zero]; rfl
+    rw [BitVec.toNat_ushiftRight, AddrNorm.bv6_toNat_32,
+        Nat.shiftRight_eq_div_pow] at h_nat
+    have : rhat.toNat < 2^64 := rhat.isLt
+    omega
+  have h_un_lt : un.toNat < 2^32 := by
+    rw [hun]; exact divKTrialCallV5Un1_lt_pow32 uLo
+  -- (rhat <<< 32 ||| un).toNat = rhat * 2^32 + un.
+  have h_lhs_toNat :
+      (((rhat <<< (32 : BitVec 6).toNat) ||| un).toNat) =
+        rhat.toNat * 2^32 + un.toNat := by
+    rw [show ((32 : BitVec 6).toNat : Nat) = 32 from by rfl]
+    exact halfword_combine rhat un h_rhat_lt h_un_lt
+  -- (q * dLo).toNat = q * dLo (no-wrap, V5.4.0.5).
+  have h_rhs_toNat : (q * dLo).toNat = q.toNat * dLo.toNat := by
+    rw [hq, hdLo]; exact algorithmQ1cV5_dLo_no_wrap uHi vTop
+  -- Convert BLTU to Nat-level <.
+  have h_ult_nat :
+      rhat.toNat * 2^32 + un.toNat < q.toNat * dLo.toNat := by
+    have h_word : ((rhat <<< (32 : BitVec 6).toNat) ||| un).toNat <
+        (q * dLo).toNat := by
+      simpa [BitVec.ult, hq, hrhat, hdLo, hun] using h_ult
+    rw [h_lhs_toNat, h_rhs_toNat] at h_word
+    exact h_word
+  -- Apply generic phase1b_fire_q_true_1_lt_q_nat.
+  have h_core := phase1b_fire_q_true_1_lt_q_nat
+    uHi.toNat un.toNat dHi.toNat dLo.toNat q.toNat rhat.toNat
+    (by rw [← h_vTop_decomp]; omega)
+    h_post h_ult_nat
+  rw [← h_vTop_decomp] at h_core
+  exact h_core
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Q1dLB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Q1dLB.lean
@@ -1,0 +1,71 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1dLB
+
+  V5.5.0.4: unconditional Knuth-A LB on V5's post-Phase-1b-1st-correction
+  quotient: `Q1d ≥ q_true_1`.
+
+  Composes V5.5.0.2 (Q1c ≥ q_true_1) + V5.5.0.3 (1st-fire ⇒ strict)
+  via case-split on the Phase-1b 1st correction firing:
+  - No-fire: Q1d = Q1c ≥ q_true_1.
+  - Fire: Q1d = Q1c - 1; strict gives q_true_1 < Q1c, so q_true_1 ≤ Q1c - 1 = Q1d.
+
+  Bead `evm-asm-wbc4i.5.7` (V5.5.0.4). Prerequisite for V5.5.1.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q1cStrictLT
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem algorithmQ1dV5_ge_q_true_1
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat) :
+    (uHi.toNat * 2^32 + (divKTrialCallV5Un1 uLo).toNat) / vTop.toNat ≤
+      (algorithmQ1dV5 uHi uLo vTop).toNat := by
+  -- Knuth-A LB on Q1c (V5.5.0.2).
+  have h_q1c_ge : (uHi.toNat * 2^32 + (divKTrialCallV5Un1 uLo).toNat) /
+      vTop.toNat ≤ (algorithmQ1cV5 uHi vTop).toNat :=
+    algorithmQ1cV5_ge_q_true_1 uHi uLo vTop hvTop_ge huHi_lt_vTop
+  -- Case-split on Phase-1b 1st correction.
+  by_cases h_fire : algorithmPhase1bFireV5 uHi uLo vTop
+  · -- Fire: Q1d = Q1c + signExtend12 4095 (= Q1c - 1 mod 2^64).
+    rw [algorithmQ1dV5_unfold]
+    dsimp only
+    have h_fire_cond :
+        (decide (algorithmRhatcV5 uHi vTop >>> (32 : BitVec 6).toNat = 0) &&
+          BitVec.ult
+            ((algorithmRhatcV5 uHi vTop <<< (32 : BitVec 6).toNat) |||
+              divKTrialCallV5Un1 uLo)
+            (algorithmQ1cV5 uHi vTop * divKTrialCallV5DLo vTop)) = true := by
+      rw [algorithmPhase1bFireV5_unfold] at h_fire
+      rw [algorithmRhatUn1cV5_unfold] at h_fire
+      obtain ⟨h_hi, h_ult⟩ := h_fire
+      simp only [Bool.and_eq_true, decide_eq_true_eq]
+      exact ⟨h_hi, h_ult⟩
+    rw [if_pos h_fire_cond]
+    -- Strict overshoot (V5.5.0.3): q_true_1 < Q1c.
+    have h_strict :=
+      algorithmQ1cV5_q_true_1_lt_of_phase1b_fire uHi uLo vTop hvTop_ge h_fire
+    -- (Q1c + signExtend12 4095).toNat = Q1c.toNat - 1 (no-wrap since Q1c ≥ 1).
+    have h_q1c_lt : (algorithmQ1cV5 uHi vTop).toNat < 2^32 :=
+      algorithmQ1cV5_lt_pow32 uHi vTop
+    have h_q1c_pos : (algorithmQ1cV5 uHi vTop).toNat ≥ 1 :=
+      Nat.one_le_iff_ne_zero.mpr (fun h => by
+        rw [h] at h_strict; exact Nat.not_lt_zero _ h_strict)
+    have h_se : (signExtend12 4095 : Word).toNat = 2^64 - 1 := by decide
+    rw [BitVec.toNat_add, h_se]
+    have h_sum : (algorithmQ1cV5 uHi vTop).toNat + (2^64 - 1) =
+        ((algorithmQ1cV5 uHi vTop).toNat - 1) + 2^64 := by omega
+    have h_lt_pow64 : (algorithmQ1cV5 uHi vTop).toNat - 1 < 2^64 := by
+      have : (algorithmQ1cV5 uHi vTop).toNat < 2^32 := h_q1c_lt
+      have : (2 : Nat)^32 < 2^64 := by decide
+      omega
+    rw [h_sum, Nat.add_mod_right, Nat.mod_eq_of_lt h_lt_pow64]
+    exact Nat.le_sub_one_of_lt h_strict
+  · -- No-fire: Q1d = Q1c, LB is direct.
+    rw [algorithmQ1dV5_eq_q1c_of_phase1b_no_fire uHi uLo vTop h_fire]
+    exact h_q1c_ge
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

- Closes bead `evm-asm-wbc4i.5.6` (V5.5.0.3). Adds `Q1cStrictLT.lean` with `algorithmQ1cV5_q_true_1_lt_of_phase1b_fire`:
  > `algorithmPhase1bFireV5 ⇒ q_true_1 < Q1c.toNat`
- When V5 Phase-1b 1st correction fires (`decide guard && BLTU`), the abstract first quotient digit is **strictly** less than the Phase-1a-corrected quotient.
- Reuses the generic `phase1b_fire_q_true_1_lt_q_nat` helper from v4 (`Phase1bBound.lean:1141`) + Q1c Euclidean (V5.4.0.7) + `halfword_combine` + V5.4.0.5's no-wrap.
- Used by V5.5.1 to show `Q1d = Q1c - 1 ≥ q_true_1` in the fire case (preserves the LB through Phase-1b 1st correction).

**Stacked on PR #7115** (V5.5.0.2 unconditional Q1c LB).

Refs #61. Bead: evm-asm-wbc4i.5.6.

Authored by @pirapira; implemented by Claude Code
