### PR TITLE
feat(stateless): read timestamp (leaf 9) alongside gas_used

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -327,15 +327,19 @@ def statelessGuestEpilogue : String :=
   "  la a0, npr_sha_input; li a1, 64; la a2, npr_node_4_5_scratch\n" ++
   "  jal ra, zkvm_sha256         # node_4_5 -> npr_node_4_5_scratch\n" ++
   "  # \n" ++
-  "  # Dynamic node_8_15 path (supports leaf_8 = gas_used):\n" ++
-  "  #   leaf_8 = gas_used (u64 LE @ SSZ_BASE + 16 + 44 + 420 = +480)\n" ++
+  "  # Dynamic node_8_15 path (supports leaf_8 = gas_used and\n" ++
+  "  # leaf_9 = timestamp):\n" ++
+  "  #   leaf_8 = gas_used  (u64 LE @ SSZ_BASE + 16 + 44 + 420 = +480)\n" ++
   "  #            || 24 bytes of zero padding\n" ++
-  "  #   leaf_9 = ssz_zero_hash[0] (timestamp default = u64 zero)\n" ++
+  "  #   leaf_9 = timestamp (u64 LE @ SSZ_BASE + 16 + 44 + 428 = +488)\n" ++
+  "  #            || 24 bytes of zero padding\n" ++
   "  la t1, npr_sha_input\n" ++
   "  ld t2, 480(s6)              # gas_used\n" ++
   "  sd t2,  0(t1)\n" ++
   "  sd zero,  8(t1); sd zero, 16(t1); sd zero, 24(t1)\n" ++
-  "  sd zero, 32(t1); sd zero, 40(t1); sd zero, 48(t1); sd zero, 56(t1)\n" ++
+  "  ld t2, 488(s6)              # timestamp\n" ++
+  "  sd t2, 32(t1)\n" ++
+  "  sd zero, 40(t1); sd zero, 48(t1); sd zero, 56(t1)\n" ++
   "  la a0, npr_sha_input; li a1, 64; la a2, npr_sha_subtree\n" ++
   "  jal ra, zkvm_sha256         # node_8_9 -> npr_sha_subtree\n" ++
   "  # node_8_11 = sha256(node_8_9 || npr_node_10_11)\n" ++

--- a/scripts/codegen-stateless-gen-fixture.py
+++ b/scripts/codegen-stateless-gen-fixture.py
@@ -70,6 +70,7 @@ npr_block_number_str = sys.argv[15] if len(sys.argv) > 15 else ''
 npr_gas_limit_str = sys.argv[16] if len(sys.argv) > 16 else ''
 npr_prev_randao_hex = sys.argv[17] if len(sys.argv) > 17 else ''
 npr_gas_used_str = sys.argv[18] if len(sys.argv) > 18 else ''
+npr_timestamp_str = sys.argv[19] if len(sys.argv) > 19 else ''
 
 # Build the new-schema StatelessInput: empty new_payload_request,
 # witness whose 'state'/'codes' lists each hold zero or more
@@ -741,7 +742,8 @@ if npr_pbr_hex:
     from remerkleable.byte_arrays import Bytes32 as Bytes32SSZ
     npr_kwargs['parent_beacon_block_root'] = Bytes32SSZ(bytes.fromhex(npr_pbr_hex))
 if (npr_slot_str or npr_excess_blob_str or npr_block_number_str or
-    npr_gas_limit_str or npr_prev_randao_hex or npr_gas_used_str):
+    npr_gas_limit_str or npr_prev_randao_hex or npr_gas_used_str or
+    npr_timestamp_str):
     from ethereum.forks.amsterdam.stateless_ssz import SszExecutionPayload
     from remerkleable.basic import uint64 as Uint64SSZ
     from remerkleable.byte_arrays import Bytes32 as Bytes32SSZ
@@ -758,6 +760,8 @@ if (npr_slot_str or npr_excess_blob_str or npr_block_number_str or
         ep_kwargs['prev_randao'] = Bytes32SSZ(bytes.fromhex(npr_prev_randao_hex))
     if npr_gas_used_str:
         ep_kwargs['gas_used'] = Uint64SSZ(int(npr_gas_used_str, 0))
+    if npr_timestamp_str:
+        ep_kwargs['timestamp'] = Uint64SSZ(int(npr_timestamp_str, 0))
     npr_kwargs['execution_payload'] = SszExecutionPayload(**ep_kwargs)
 npr = SszNewPayloadRequest(**npr_kwargs)
 

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -87,6 +87,7 @@ run_fixture() {
   local npr_gas_limit_str="${15:-}"
   local npr_prev_randao_hex="${16:-}"
   local npr_gas_used_str="${17:-}"
+  local npr_timestamp_str="${18:-}"
 
   local safe="${label//[^0-9A-Za-z_]/_}"
   local input_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.input"
@@ -94,8 +95,8 @@ run_fixture() {
   local spec_exp_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.spec-expected"
   local log_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.emu.log"
 
-  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty}, npr_pbr=${npr_pbr_hex:-empty}, npr_slot=${npr_slot_str:-empty}, npr_excess_blob=${npr_excess_blob_str:-empty}, npr_block_number=${npr_block_number_str:-empty}, npr_gas_limit=${npr_gas_limit_str:-empty}, npr_prev_randao=${npr_prev_randao_hex:-empty}, npr_gas_used=${npr_gas_used_str:-empty})"
-  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex" "$npr_pbr_hex" "$npr_slot_str" "$npr_excess_blob_str" "$npr_block_number_str" "$npr_gas_limit_str" "$npr_prev_randao_hex" "$npr_gas_used_str"
+  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty}, npr_pbr=${npr_pbr_hex:-empty}, npr_slot=${npr_slot_str:-empty}, npr_excess_blob=${npr_excess_blob_str:-empty}, npr_block_number=${npr_block_number_str:-empty}, npr_gas_limit=${npr_gas_limit_str:-empty}, npr_prev_randao=${npr_prev_randao_hex:-empty}, npr_gas_used=${npr_gas_used_str:-empty}, npr_timestamp=${npr_timestamp_str:-empty})"
+  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex" "$npr_pbr_hex" "$npr_slot_str" "$npr_excess_blob_str" "$npr_block_number_str" "$npr_gas_limit_str" "$npr_prev_randao_hex" "$npr_gas_used_str" "$npr_timestamp_str"
 
   # Guard against silent fail: if the spec generator crashed
   # (Python syntax error in the heredoc, missing import, etc.)
@@ -266,6 +267,14 @@ run_fixture "chain1_npr_exec_payload_prev_randao_aa" 1   0   ""           ""    
 # subtrees that branch off the path; the leaf_9 (timestamp)
 # sibling stays hardcoded zero for now.
 run_fixture "chain1_npr_exec_payload_gas_used_1234" 1    0   ""           ""                  ""    ""           ""           ""    ""                       ""                                ""    ""    ""    ""    ""                                "4660" || fail=1
+
+# Non-empty execution_payload: timestamp = 0xDEAD (leaf 9,
+# sibling of gas_used in the dynamic node_8_9 pair). The
+# current node_8_9 computation hardcodes leaf_9 = ssz_zero_hash[0];
+# this fixture forces the asm to read timestamp from input and
+# use it as the right input to sha256(leaf_8 || leaf_9).
+# Pure read-side extension -- no new sha256 calls.
+run_fixture "chain1_npr_exec_payload_timestamp_dead" 1   0   ""           ""                  ""    ""           ""           ""    ""                       ""                                ""    ""    ""    ""    ""                                ""    "57005" || fail=1
 
 # Edge: chain_id = 2^32 = 0x100000000. LE bytes
 # 00 00 00 00 01 00 00 00. The encoder's chain_id split


### PR DESCRIPTION
Stacks on the gas_used PR (#7111, already merged). Opens up \`execution_payload.timestamp\` (leaf 9) — its pair sibling in the dynamic \`node_8_9\` computation.

**Initially-failing fixture:** \`chain1_npr_exec_payload_timestamp_dead\` (timestamp = 0xDEAD).

**Smallest implementation step:** the previous PR's \`node_8_9\` computation hardcoded \`leaf_9 = ssz_zero_hash[0]\` via 4 \`sd zero\` instructions. This PR replaces the first \`sd zero, 32(t1)\` with \`ld t2, 488(s6); sd t2, 32(t1)\`. **No new sha256 calls** — pure read-side extension paralleling the leaf_7/gas_limit extension in #7102.

\`timestamp\` is read from input at \`SSZ_BASE + 16 + 44 + 428 = SSZ_BASE + 488\` (8 bytes after \`gas_used\`).

For all pre-existing fixtures (\`timestamp=0\`), the LD reads zero, producing the same leaf_9 byte pattern as the prior hardcoded zero stores. The existing 80+ fixtures pass byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)