### PR TITLE
feat(stateless): read fee_recipient (leaf 1) alongside parent_hash

### DIFF
--- a/EvmAsm/Codegen/Programs/StatelessGuestEpilogue.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuestEpilogue.lean
@@ -276,13 +276,13 @@ def statelessGuestEpilogue : String :=
   "  ld t2, 24(t3); sd t2, 56(t1)\n" ++
   "  la a0, npr_sha_input; li a1, 64; la a2, npr_sha_subtree\n" ++
   "  jal ra, zkvm_sha256         # node_4_7 -> npr_sha_subtree\n" ++
-  "  # Dynamic node_0_3 path (supports leaf_0 = parent_hash):\n" ++
-  "  #   leaf_0 = parent_hash (Bytes32 @ SSZ_BASE + 16 + 44 + 0 = +60)\n" ++
-  "  #   leaf_1 = ssz_zero_hash[0] (fee_recipient default = 20 zero bytes,\n" ++
-  "  #            padded to 32 zero bytes)\n" ++
+  "  # Dynamic node_0_3 path (supports leaf_0 = parent_hash and\n" ++
+  "  # leaf_1 = fee_recipient):\n" ++
+  "  #   leaf_0 = parent_hash    (Bytes32 @ SSZ_BASE + 16 + 44 + 0 = +60)\n" ++
+  "  #   leaf_1 = fee_recipient  (ByteVector[20] @ SSZ_BASE + 16 + 44 + 32\n" ++
+  "  #            = +92), packed into 32 bytes via 20 bytes from input\n" ++
+  "  #            + 12 zero padding (SSZ ByteVector[20].hash_tree_root).\n" ++
   "  # node_0_1 = sha256(leaf_0 || leaf_1) -> npr_node_0_3_scratch (temp)\n" ++
-  "  # Save node_4_7 first since the dynamic node_0_3 path uses\n" ++
-  "  # npr_sha_subtree for its first sha256, which would clobber it.\n" ++
   "  # We use npr_node_0_3_scratch as both temp (for node_0_1) and final\n" ++
   "  # (for node_0_3) since sha256 reads input then writes output.\n" ++
   "  la t1, npr_sha_input\n" ++
@@ -290,7 +290,10 @@ def statelessGuestEpilogue : String :=
   "  ld t2,  68(s6); sd t2,  8(t1)\n" ++
   "  ld t2,  76(s6); sd t2, 16(t1)\n" ++
   "  ld t2,  84(s6); sd t2, 24(t1)\n" ++
-  "  sd zero, 32(t1); sd zero, 40(t1); sd zero, 48(t1); sd zero, 56(t1)\n" ++
+  "  ld t2,  92(s6); sd t2, 32(t1)\n" ++
+  "  ld t2, 100(s6); sd t2, 40(t1)\n" ++
+  "  lwu t2, 108(s6); sd t2, 48(t1)\n" ++
+  "  sd zero, 56(t1)\n" ++
   "  la a0, npr_sha_input; li a1, 64; la a2, npr_node_0_3_scratch\n" ++
   "  jal ra, zkvm_sha256         # node_0_1 -> npr_node_0_3_scratch\n" ++
   "  # node_0_3 = sha256(node_0_1 || ssz_zero_hash[1])\n" ++

--- a/scripts/codegen-stateless-gen-fixture.py
+++ b/scripts/codegen-stateless-gen-fixture.py
@@ -72,6 +72,7 @@ npr_prev_randao_hex = sys.argv[17] if len(sys.argv) > 17 else ''
 npr_gas_used_str = sys.argv[18] if len(sys.argv) > 18 else ''
 npr_timestamp_str = sys.argv[19] if len(sys.argv) > 19 else ''
 npr_parent_hash_hex = sys.argv[20] if len(sys.argv) > 20 else ''
+npr_fee_recipient_hex = sys.argv[21] if len(sys.argv) > 21 else ''
 
 # Build the new-schema StatelessInput: empty new_payload_request,
 # witness whose 'state'/'codes' lists each hold zero or more
@@ -744,7 +745,7 @@ if npr_pbr_hex:
     npr_kwargs['parent_beacon_block_root'] = Bytes32SSZ(bytes.fromhex(npr_pbr_hex))
 if (npr_slot_str or npr_excess_blob_str or npr_block_number_str or
     npr_gas_limit_str or npr_prev_randao_hex or npr_gas_used_str or
-    npr_timestamp_str or npr_parent_hash_hex):
+    npr_timestamp_str or npr_parent_hash_hex or npr_fee_recipient_hex):
     from ethereum.forks.amsterdam.stateless_ssz import SszExecutionPayload
     from remerkleable.basic import uint64 as Uint64SSZ
     from remerkleable.byte_arrays import Bytes32 as Bytes32SSZ
@@ -765,6 +766,9 @@ if (npr_slot_str or npr_excess_blob_str or npr_block_number_str or
         ep_kwargs['timestamp'] = Uint64SSZ(int(npr_timestamp_str, 0))
     if npr_parent_hash_hex:
         ep_kwargs['parent_hash'] = Bytes32SSZ(bytes.fromhex(npr_parent_hash_hex))
+    if npr_fee_recipient_hex:
+        from remerkleable.byte_arrays import ByteVector as ByteVecSSZ
+        ep_kwargs['fee_recipient'] = ByteVecSSZ[20](bytes.fromhex(npr_fee_recipient_hex))
     npr_kwargs['execution_payload'] = SszExecutionPayload(**ep_kwargs)
 npr = SszNewPayloadRequest(**npr_kwargs)
 

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -89,6 +89,7 @@ run_fixture() {
   local npr_gas_used_str="${17:-}"
   local npr_timestamp_str="${18:-}"
   local npr_parent_hash_hex="${19:-}"
+  local npr_fee_recipient_hex="${20:-}"
 
   local safe="${label//[^0-9A-Za-z_]/_}"
   local input_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.input"
@@ -96,8 +97,8 @@ run_fixture() {
   local spec_exp_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.spec-expected"
   local log_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.emu.log"
 
-  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty}, npr_pbr=${npr_pbr_hex:-empty}, npr_slot=${npr_slot_str:-empty}, npr_excess_blob=${npr_excess_blob_str:-empty}, npr_block_number=${npr_block_number_str:-empty}, npr_gas_limit=${npr_gas_limit_str:-empty}, npr_prev_randao=${npr_prev_randao_hex:-empty}, npr_gas_used=${npr_gas_used_str:-empty}, npr_timestamp=${npr_timestamp_str:-empty}, npr_parent_hash=${npr_parent_hash_hex:-empty})"
-  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex" "$npr_pbr_hex" "$npr_slot_str" "$npr_excess_blob_str" "$npr_block_number_str" "$npr_gas_limit_str" "$npr_prev_randao_hex" "$npr_gas_used_str" "$npr_timestamp_str" "$npr_parent_hash_hex"
+  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty}, npr_pbr=${npr_pbr_hex:-empty}, npr_slot=${npr_slot_str:-empty}, npr_excess_blob=${npr_excess_blob_str:-empty}, npr_block_number=${npr_block_number_str:-empty}, npr_gas_limit=${npr_gas_limit_str:-empty}, npr_prev_randao=${npr_prev_randao_hex:-empty}, npr_gas_used=${npr_gas_used_str:-empty}, npr_timestamp=${npr_timestamp_str:-empty}, npr_parent_hash=${npr_parent_hash_hex:-empty}, npr_fee_recipient=${npr_fee_recipient_hex:-empty})"
+  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex" "$npr_pbr_hex" "$npr_slot_str" "$npr_excess_blob_str" "$npr_block_number_str" "$npr_gas_limit_str" "$npr_prev_randao_hex" "$npr_gas_used_str" "$npr_timestamp_str" "$npr_parent_hash_hex" "$npr_fee_recipient_hex"
 
   # Guard against silent fail: if the spec generator crashed
   # (Python syntax error in the heredoc, missing import, etc.)
@@ -289,6 +290,19 @@ run_fixture "chain1_npr_exec_payload_timestamp_dead" 1   0   ""           ""    
 # ssz_zero_hash[0]; default leaves 2, 3 = zero -> node_2_3 =
 # ssz_zero_hash[1]). Zero new sibling constants needed.
 run_fixture "chain1_npr_exec_payload_parent_hash_aa" 1   0   ""           ""                  ""    ""           ""           ""    ""                       ""                                ""    ""    ""    ""    ""                                ""    ""    "$(printf 'aa%.0s' {1..32})" || fail=1
+
+# Non-empty execution_payload: fee_recipient = 0x11*20
+# (leaf 1, ByteVector[20] inline; its hash_tree_root is the
+# 20 bytes padded to 32 with 12 zero bytes). Sibling of
+# parent_hash in the dynamic node_0_1 computation. The
+# current implementation hardcodes leaf_1 = ssz_zero_hash[0]
+# (4 sd zero). This PR replaces those with reads from input:
+#   ld + sd (bytes 0..8)
+#   ld + sd (bytes 8..16)
+#   lwu + sd (bytes 16..20, upper 4 bytes auto-zero via lwu)
+#   sd zero (bytes 24..32 padding)
+# Pure read-side extension -- no new sha256 calls.
+run_fixture "chain1_npr_exec_payload_fee_recipient_11" 1 0   ""           ""                  ""    ""           ""           ""    ""                       ""                                ""    ""    ""    ""    ""                                ""    ""    ""    "$(printf '11%.0s' {1..20})" || fail=1
 
 # Edge: chain_id = 2^32 = 0x100000000. LE bytes
 # 00 00 00 00 01 00 00 00. The encoder's chain_id split


### PR DESCRIPTION
Stacks on the npr_parent_hash series (#7123 already merged). Opens up \`execution_payload.fee_recipient\` (leaf 1) — its pair sibling in the dynamic \`node_0_1\` computation.

**Initially-failing fixture:** \`chain1_npr_exec_payload_fee_recipient_11\` (fee_recipient = 0x11 × 20).

**Smallest implementation step:** the previous PR's \`node_0_1\` computation hardcoded \`leaf_1 = ssz_zero_hash[0]\` via 4 \`sd zero\` instructions. This PR replaces them with:

\`\`\`
ld + sd  (bytes  0..8)
ld + sd  (bytes  8..16)
lwu + sd (bytes 16..20, upper 4 bytes auto-zero via lwu zero-extension)
sd zero  (bytes 24..32 padding)
\`\`\`

**No new sha256 calls** — pure read-side extension paralleling the leaf_7/gas_limit and leaf_9/timestamp patterns.

\`fee_recipient\` is read from input at \`SSZ_BASE + 92\` (NPR+44 + exec_payload offset 32 for fee_recipient inline ByteVector[20]).

For all pre-existing fixtures (\`fee_recipient = 20 zero bytes\`), the reads produce zeros, matching the prior \`sd zero\` byte pattern. The existing 80+ fixtures pass byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)