### PR TITLE
feat(stateless): compute node_2_3 dynamically (support state_root)

### DIFF
--- a/EvmAsm/Codegen/Programs/StatelessGuestData.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuestData.lean
@@ -341,6 +341,16 @@ def statelessGuestDataSection : String :=
   -- mirroring the leaf_7/gas_limit pattern).
   ".balign 8\n" ++
   "npr_node_0_3_scratch:\n" ++
+  "  .zero 32\n" ++
+  -- `npr_node_2_3_scratch` holds dynamic
+  -- sha256(leaf_2=state_root || leaf_3=receipts_root). Replaces
+  -- the previously-static `ssz_zero_hash[1]` (= default
+  -- node_2_3) as the right input to
+  -- node_0_3 = sha256(node_0_1 || node_2_3). Opens up leaf_2
+  -- (state_root) and leaf_3 (receipts_root) for non-default
+  -- values.
+  ".balign 8\n" ++
+  "npr_node_2_3_scratch:\n" ++
   "  .zero 32"
 
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/StatelessGuestEpilogue.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuestEpilogue.lean
@@ -296,15 +296,28 @@ def statelessGuestEpilogue : String :=
   "  sd zero, 56(t1)\n" ++
   "  la a0, npr_sha_input; li a1, 64; la a2, npr_node_0_3_scratch\n" ++
   "  jal ra, zkvm_sha256         # node_0_1 -> npr_node_0_3_scratch\n" ++
-  "  # node_0_3 = sha256(node_0_1 || ssz_zero_hash[1])\n" ++
+  "  # node_2_3 = sha256(leaf_2=state_root || leaf_3=receipts_root):\n" ++
+  "  #   state_root    (Bytes32 @ SSZ_BASE + 16 + 44 + 52  = +112)\n" ++
+  "  #   receipts_root (Bytes32 @ SSZ_BASE + 16 + 44 + 84  = +144)\n" ++
+  "  la t1, npr_sha_input\n" ++
+  "  ld t2, 112(s6); sd t2,  0(t1)\n" ++
+  "  ld t2, 120(s6); sd t2,  8(t1)\n" ++
+  "  ld t2, 128(s6); sd t2, 16(t1)\n" ++
+  "  ld t2, 136(s6); sd t2, 24(t1)\n" ++
+  "  ld t2, 144(s6); sd t2, 32(t1)\n" ++
+  "  ld t2, 152(s6); sd t2, 40(t1)\n" ++
+  "  ld t2, 160(s6); sd t2, 48(t1)\n" ++
+  "  ld t2, 168(s6); sd t2, 56(t1)\n" ++
+  "  la a0, npr_sha_input; li a1, 64; la a2, npr_node_2_3_scratch\n" ++
+  "  jal ra, zkvm_sha256         # node_2_3 -> npr_node_2_3_scratch\n" ++
+  "  # node_0_3 = sha256(node_0_1 || node_2_3)\n" ++
   "  la t1, npr_sha_input\n" ++
   "  la t3, npr_node_0_3_scratch\n" ++
   "  ld t2,  0(t3); sd t2,  0(t1)\n" ++
   "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
   "  ld t2, 16(t3); sd t2, 16(t1)\n" ++
   "  ld t2, 24(t3); sd t2, 24(t1)\n" ++
-  "  la t3, ssz_zero_hashes\n" ++
-  "  addi t3, t3, 32             # ssz_zero_hash[1]\n" ++
+  "  la t3, npr_node_2_3_scratch\n" ++
   "  ld t2,  0(t3); sd t2, 32(t1)\n" ++
   "  ld t2,  8(t3); sd t2, 40(t1)\n" ++
   "  ld t2, 16(t3); sd t2, 48(t1)\n" ++

--- a/scripts/codegen-stateless-gen-fixture.py
+++ b/scripts/codegen-stateless-gen-fixture.py
@@ -73,6 +73,7 @@ npr_gas_used_str = sys.argv[18] if len(sys.argv) > 18 else ''
 npr_timestamp_str = sys.argv[19] if len(sys.argv) > 19 else ''
 npr_parent_hash_hex = sys.argv[20] if len(sys.argv) > 20 else ''
 npr_fee_recipient_hex = sys.argv[21] if len(sys.argv) > 21 else ''
+npr_state_root_hex = sys.argv[22] if len(sys.argv) > 22 else ''
 
 # Build the new-schema StatelessInput: empty new_payload_request,
 # witness whose 'state'/'codes' lists each hold zero or more
@@ -745,7 +746,8 @@ if npr_pbr_hex:
     npr_kwargs['parent_beacon_block_root'] = Bytes32SSZ(bytes.fromhex(npr_pbr_hex))
 if (npr_slot_str or npr_excess_blob_str or npr_block_number_str or
     npr_gas_limit_str or npr_prev_randao_hex or npr_gas_used_str or
-    npr_timestamp_str or npr_parent_hash_hex or npr_fee_recipient_hex):
+    npr_timestamp_str or npr_parent_hash_hex or npr_fee_recipient_hex or
+    npr_state_root_hex):
     from ethereum.forks.amsterdam.stateless_ssz import SszExecutionPayload
     from remerkleable.basic import uint64 as Uint64SSZ
     from remerkleable.byte_arrays import Bytes32 as Bytes32SSZ
@@ -769,6 +771,8 @@ if (npr_slot_str or npr_excess_blob_str or npr_block_number_str or
     if npr_fee_recipient_hex:
         from remerkleable.byte_arrays import ByteVector as ByteVecSSZ
         ep_kwargs['fee_recipient'] = ByteVecSSZ[20](bytes.fromhex(npr_fee_recipient_hex))
+    if npr_state_root_hex:
+        ep_kwargs['state_root'] = Bytes32SSZ(bytes.fromhex(npr_state_root_hex))
     npr_kwargs['execution_payload'] = SszExecutionPayload(**ep_kwargs)
 npr = SszNewPayloadRequest(**npr_kwargs)
 

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -90,6 +90,7 @@ run_fixture() {
   local npr_timestamp_str="${18:-}"
   local npr_parent_hash_hex="${19:-}"
   local npr_fee_recipient_hex="${20:-}"
+  local npr_state_root_hex="${21:-}"
 
   local safe="${label//[^0-9A-Za-z_]/_}"
   local input_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.input"
@@ -97,8 +98,8 @@ run_fixture() {
   local spec_exp_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.spec-expected"
   local log_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.emu.log"
 
-  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty}, npr_pbr=${npr_pbr_hex:-empty}, npr_slot=${npr_slot_str:-empty}, npr_excess_blob=${npr_excess_blob_str:-empty}, npr_block_number=${npr_block_number_str:-empty}, npr_gas_limit=${npr_gas_limit_str:-empty}, npr_prev_randao=${npr_prev_randao_hex:-empty}, npr_gas_used=${npr_gas_used_str:-empty}, npr_timestamp=${npr_timestamp_str:-empty}, npr_parent_hash=${npr_parent_hash_hex:-empty}, npr_fee_recipient=${npr_fee_recipient_hex:-empty})"
-  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex" "$npr_pbr_hex" "$npr_slot_str" "$npr_excess_blob_str" "$npr_block_number_str" "$npr_gas_limit_str" "$npr_prev_randao_hex" "$npr_gas_used_str" "$npr_timestamp_str" "$npr_parent_hash_hex" "$npr_fee_recipient_hex"
+  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty}, npr_pbr=${npr_pbr_hex:-empty}, npr_slot=${npr_slot_str:-empty}, npr_excess_blob=${npr_excess_blob_str:-empty}, npr_block_number=${npr_block_number_str:-empty}, npr_gas_limit=${npr_gas_limit_str:-empty}, npr_prev_randao=${npr_prev_randao_hex:-empty}, npr_gas_used=${npr_gas_used_str:-empty}, npr_timestamp=${npr_timestamp_str:-empty}, npr_parent_hash=${npr_parent_hash_hex:-empty}, npr_fee_recipient=${npr_fee_recipient_hex:-empty}, npr_state_root=${npr_state_root_hex:-empty})"
+  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex" "$npr_pbr_hex" "$npr_slot_str" "$npr_excess_blob_str" "$npr_block_number_str" "$npr_gas_limit_str" "$npr_prev_randao_hex" "$npr_gas_used_str" "$npr_timestamp_str" "$npr_parent_hash_hex" "$npr_fee_recipient_hex" "$npr_state_root_hex"
 
   # Guard against silent fail: if the spec generator crashed
   # (Python syntax error in the heredoc, missing import, etc.)
@@ -303,6 +304,16 @@ run_fixture "chain1_npr_exec_payload_parent_hash_aa" 1   0   ""           ""    
 #   sd zero (bytes 24..32 padding)
 # Pure read-side extension -- no new sha256 calls.
 run_fixture "chain1_npr_exec_payload_fee_recipient_11" 1 0   ""           ""                  ""    ""           ""           ""    ""                       ""                                ""    ""    ""    ""    ""                                ""    ""    ""    "$(printf '11%.0s' {1..20})" || fail=1
+
+# Non-empty execution_payload: state_root = 0x22*32 (leaf 2,
+# Bytes32 inline). The current implementation hardcodes
+# `node_2_3 = ssz_zero_hash[1]` as the right input to the
+# dynamic `node_0_3 = sha256(node_0_1 || ssz_zero_hash[1])`.
+# This PR replaces that lookup with a dynamic
+#   node_2_3 = sha256(leaf_2=state_root || leaf_3=receipts_root)
+# One extra sha256 call. Opens up BOTH state_root (leaf 2)
+# and receipts_root (leaf 3) -- this fixture exercises leaf 2.
+run_fixture "chain1_npr_exec_payload_state_root_22" 1    0   ""           ""                  ""    ""           ""           ""    ""                       ""                                ""    ""    ""    ""    ""                                ""    ""    ""    ""    "$(printf '22%.0s' {1..32})" || fail=1
 
 # Edge: chain_id = 2^32 = 0x100000000. LE bytes
 # 00 00 00 00 01 00 00 00. The encoder's chain_id split


### PR DESCRIPTION
Stacks on the npr_fee_recipient series. Opens up \`execution_payload.state_root\` (leaf 2) — and incidentally \`receipts_root\` (leaf 3), since the dynamic \`node_2_3\` computation reads both.

**Initially-failing fixture:** \`chain1_npr_exec_payload_state_root_22\` (state_root = 0x22 × 32).

**Smallest implementation step:** replace the static \`ssz_zero_hash[1]\` (= default \`node_2_3\`) as the right input to \`node_0_3 = sha256(node_0_1 || node_2_3)\` with a dynamic sha256:

\`\`\`
node_2_3 = sha256(leaf_2=state_root || leaf_3=receipts_root)
\`\`\`

**One extra sha256 call** (19 → 20). Opens up both leaves; the fixture exercises leaf 2.

\`state_root\` is read from input at \`SSZ_BASE + 112\` (NPR+44 + exec_payload offset 52); \`receipts_root\` at \`SSZ_BASE + 144\` (offset 84).

For all pre-existing fixtures (\`state_root = receipts_root = 0\`), the dynamic computation reproduces the old \`ssz_zero_hash[1]\` constant byte-for-byte: \`node_2_3 = sha256(0 || 0) = ssz_zero_hash[1]\`. The existing 80+ fixtures pass byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)