### PR TITLE
feat(stateless): compute node_10_11 dynamically (support base_fee_per_gas)

### DIFF
--- a/EvmAsm/Codegen/Programs/StatelessGuestData.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuestData.lean
@@ -351,6 +351,17 @@ def statelessGuestDataSection : String :=
   -- values.
   ".balign 8\n" ++
   "npr_node_2_3_scratch:\n" ++
+  "  .zero 32\n" ++
+  -- `npr_node_10_11_scratch` holds dynamic
+  -- sha256(leaf_10=extra_data_default_root || leaf_11=base_fee_per_gas).
+  -- Replaces the previously-static `npr_node_10_11` constant when
+  -- combined with node_8_9 to form node_8_11. Opens up leaf_11
+  -- (base_fee_per_gas) for non-default values; leaf_10
+  -- (extra_data) still uses its empty-list default root
+  -- (= ssz_zero_hash[1]) loaded from the existing
+  -- ssz_zero_hashes table.
+  ".balign 8\n" ++
+  "npr_node_10_11_scratch:\n" ++
   "  .zero 32"
 
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/StatelessGuestEpilogue.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuestEpilogue.lean
@@ -206,6 +206,27 @@ def statelessGuestEpilogue : String :=
   "  la a0, npr_sha_input; li a1, 64; la a2, npr_node_4_5_scratch\n" ++
   "  jal ra, zkvm_sha256         # node_4_5 -> npr_node_4_5_scratch\n" ++
   "  # \n" ++
+  "  # Dynamic node_10_11 = sha256(leaf_10=extra_data_default ||\n" ++
+  "  #                            leaf_11=base_fee_per_gas):\n" ++
+  "  #   leaf_10 = SSZ default empty ByteList root = ssz_zero_hash[1]\n" ++
+  "  #             (= sha256(0||0) -- empty merkleized ByteList with\n" ++
+  "  #             length mix-in for the empty case).\n" ++
+  "  #   leaf_11 = base_fee_per_gas (uint256, 32 bytes LE @\n" ++
+  "  #             SSZ_BASE + 16 + 44 + 440 = +500)\n" ++
+  "  la t1, npr_sha_input\n" ++
+  "  la t3, ssz_zero_hashes\n" ++
+  "  addi t3, t3, 32             # ssz_zero_hash[1]\n" ++
+  "  ld t2,  0(t3); sd t2,  0(t1)\n" ++
+  "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
+  "  ld t2, 16(t3); sd t2, 16(t1)\n" ++
+  "  ld t2, 24(t3); sd t2, 24(t1)\n" ++
+  "  ld t2, 500(s6); sd t2, 32(t1)\n" ++
+  "  ld t2, 508(s6); sd t2, 40(t1)\n" ++
+  "  ld t2, 516(s6); sd t2, 48(t1)\n" ++
+  "  ld t2, 524(s6); sd t2, 56(t1)\n" ++
+  "  la a0, npr_sha_input; li a1, 64; la a2, npr_node_10_11_scratch\n" ++
+  "  jal ra, zkvm_sha256         # node_10_11 -> npr_node_10_11_scratch\n" ++
+  "  # \n" ++
   "  # Dynamic node_8_15 path (supports leaf_8 = gas_used and\n" ++
   "  # leaf_9 = timestamp):\n" ++
   "  #   leaf_8 = gas_used  (u64 LE @ SSZ_BASE + 16 + 44 + 420 = +480)\n" ++
@@ -221,14 +242,14 @@ def statelessGuestEpilogue : String :=
   "  sd zero, 40(t1); sd zero, 48(t1); sd zero, 56(t1)\n" ++
   "  la a0, npr_sha_input; li a1, 64; la a2, npr_sha_subtree\n" ++
   "  jal ra, zkvm_sha256         # node_8_9 -> npr_sha_subtree\n" ++
-  "  # node_8_11 = sha256(node_8_9 || npr_node_10_11)\n" ++
+  "  # node_8_11 = sha256(node_8_9 || npr_node_10_11_scratch)\n" ++
   "  la t1, npr_sha_input\n" ++
   "  la t3, npr_sha_subtree\n" ++
   "  ld t2,  0(t3); sd t2,  0(t1)\n" ++
   "  ld t2,  8(t3); sd t2,  8(t1)\n" ++
   "  ld t2, 16(t3); sd t2, 16(t1)\n" ++
   "  ld t2, 24(t3); sd t2, 24(t1)\n" ++
-  "  la t3, npr_node_10_11\n" ++
+  "  la t3, npr_node_10_11_scratch\n" ++
   "  ld t2,  0(t3); sd t2, 32(t1)\n" ++
   "  ld t2,  8(t3); sd t2, 40(t1)\n" ++
   "  ld t2, 16(t3); sd t2, 48(t1)\n" ++

--- a/scripts/codegen-stateless-gen-fixture.py
+++ b/scripts/codegen-stateless-gen-fixture.py
@@ -74,6 +74,7 @@ npr_timestamp_str = sys.argv[19] if len(sys.argv) > 19 else ''
 npr_parent_hash_hex = sys.argv[20] if len(sys.argv) > 20 else ''
 npr_fee_recipient_hex = sys.argv[21] if len(sys.argv) > 21 else ''
 npr_state_root_hex = sys.argv[22] if len(sys.argv) > 22 else ''
+npr_base_fee_str = sys.argv[23] if len(sys.argv) > 23 else ''
 
 # Build the new-schema StatelessInput: empty new_payload_request,
 # witness whose 'state'/'codes' lists each hold zero or more
@@ -747,7 +748,7 @@ if npr_pbr_hex:
 if (npr_slot_str or npr_excess_blob_str or npr_block_number_str or
     npr_gas_limit_str or npr_prev_randao_hex or npr_gas_used_str or
     npr_timestamp_str or npr_parent_hash_hex or npr_fee_recipient_hex or
-    npr_state_root_hex):
+    npr_state_root_hex or npr_base_fee_str):
     from ethereum.forks.amsterdam.stateless_ssz import SszExecutionPayload
     from remerkleable.basic import uint64 as Uint64SSZ
     from remerkleable.byte_arrays import Bytes32 as Bytes32SSZ
@@ -773,6 +774,9 @@ if (npr_slot_str or npr_excess_blob_str or npr_block_number_str or
         ep_kwargs['fee_recipient'] = ByteVecSSZ[20](bytes.fromhex(npr_fee_recipient_hex))
     if npr_state_root_hex:
         ep_kwargs['state_root'] = Bytes32SSZ(bytes.fromhex(npr_state_root_hex))
+    if npr_base_fee_str:
+        from remerkleable.basic import uint256 as Uint256SSZ
+        ep_kwargs['base_fee_per_gas'] = Uint256SSZ(int(npr_base_fee_str, 0))
     npr_kwargs['execution_payload'] = SszExecutionPayload(**ep_kwargs)
 npr = SszNewPayloadRequest(**npr_kwargs)
 

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -91,6 +91,7 @@ run_fixture() {
   local npr_parent_hash_hex="${19:-}"
   local npr_fee_recipient_hex="${20:-}"
   local npr_state_root_hex="${21:-}"
+  local npr_base_fee_str="${22:-}"
 
   local safe="${label//[^0-9A-Za-z_]/_}"
   local input_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.input"
@@ -98,8 +99,8 @@ run_fixture() {
   local spec_exp_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.spec-expected"
   local log_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.emu.log"
 
-  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty}, npr_pbr=${npr_pbr_hex:-empty}, npr_slot=${npr_slot_str:-empty}, npr_excess_blob=${npr_excess_blob_str:-empty}, npr_block_number=${npr_block_number_str:-empty}, npr_gas_limit=${npr_gas_limit_str:-empty}, npr_prev_randao=${npr_prev_randao_hex:-empty}, npr_gas_used=${npr_gas_used_str:-empty}, npr_timestamp=${npr_timestamp_str:-empty}, npr_parent_hash=${npr_parent_hash_hex:-empty}, npr_fee_recipient=${npr_fee_recipient_hex:-empty}, npr_state_root=${npr_state_root_hex:-empty})"
-  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex" "$npr_pbr_hex" "$npr_slot_str" "$npr_excess_blob_str" "$npr_block_number_str" "$npr_gas_limit_str" "$npr_prev_randao_hex" "$npr_gas_used_str" "$npr_timestamp_str" "$npr_parent_hash_hex" "$npr_fee_recipient_hex" "$npr_state_root_hex"
+  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty}, npr_pbr=${npr_pbr_hex:-empty}, npr_slot=${npr_slot_str:-empty}, npr_excess_blob=${npr_excess_blob_str:-empty}, npr_block_number=${npr_block_number_str:-empty}, npr_gas_limit=${npr_gas_limit_str:-empty}, npr_prev_randao=${npr_prev_randao_hex:-empty}, npr_gas_used=${npr_gas_used_str:-empty}, npr_timestamp=${npr_timestamp_str:-empty}, npr_parent_hash=${npr_parent_hash_hex:-empty}, npr_fee_recipient=${npr_fee_recipient_hex:-empty}, npr_state_root=${npr_state_root_hex:-empty}, npr_base_fee=${npr_base_fee_str:-empty})"
+  uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/codegen-stateless-gen-fixture.py" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex" "$npr_pbr_hex" "$npr_slot_str" "$npr_excess_blob_str" "$npr_block_number_str" "$npr_gas_limit_str" "$npr_prev_randao_hex" "$npr_gas_used_str" "$npr_timestamp_str" "$npr_parent_hash_hex" "$npr_fee_recipient_hex" "$npr_state_root_hex" "$npr_base_fee_str"
 
   # Guard against silent fail: if the spec generator crashed
   # (Python syntax error in the heredoc, missing import, etc.)
@@ -314,6 +315,16 @@ run_fixture "chain1_npr_exec_payload_fee_recipient_11" 1 0   ""           ""    
 # One extra sha256 call. Opens up BOTH state_root (leaf 2)
 # and receipts_root (leaf 3) -- this fixture exercises leaf 2.
 run_fixture "chain1_npr_exec_payload_state_root_22" 1    0   ""           ""                  ""    ""           ""           ""    ""                       ""                                ""    ""    ""    ""    ""                                ""    ""    ""    ""    "$(printf '22%.0s' {1..32})" || fail=1
+
+# Non-empty execution_payload: base_fee_per_gas = 0x12345
+# (leaf 11, uint256 inline = 32 bytes LE). Replaces the
+# static `npr_node_10_11` constant in the node_8_15 path
+# with a dynamic
+#   sha256(leaf_10=extra_data_default_root || leaf_11=base_fee)
+# computation. The leaf_10 sibling stays static via existing
+# `ssz_zero_hashes[1]` (extra_data default empty ByteList
+# root happens to equal ssz_zero_hash[1]). +1 sha256 call.
+run_fixture "chain1_npr_exec_payload_base_fee_12345" 1   0   ""           ""                  ""    ""           ""           ""    ""                       ""                                ""    ""    ""    ""    ""                                ""    ""    ""    ""    ""                                  "0x12345" || fail=1
 
 # Edge: chain_id = 2^32 = 0x100000000. LE bytes
 # 00 00 00 00 01 00 00 00. The encoder's chain_id split


### PR DESCRIPTION
Stacks on the npr_state_root series. Opens up \`execution_payload.base_fee_per_gas\` (leaf 11, uint256 inline).

**Initially-failing fixture:** \`chain1_npr_exec_payload_base_fee_12345\` (base_fee_per_gas = 0x12345).

**Smallest implementation step:** replace the static \`npr_node_10_11\` constant with a dynamic:

\`\`\`
node_10_11 = sha256(leaf_10=extra_data_default_root || leaf_11=base_fee_per_gas)
\`\`\`

Where \`leaf_10\` (extra_data SSZ root for empty ByteList) happens to equal \`ssz_zero_hash[1]\` — the existing \`ssz_zero_hashes\` table covers it **without a new constant**.

\`sha256\` calls in \`.Lsg_hash\`: 20 → 21.

\`base_fee_per_gas\` is read from input at \`SSZ_BASE + 500\` (NPR+44 + exec_payload offset 440 for uint256 inline).

For all pre-existing fixtures (\`base_fee_per_gas=0\`), the dynamic computation reproduces the old \`npr_node_10_11\` constant byte-for-byte: \`sha256(ssz_zero_hash[1] || 0) = old constant\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)