### PR TITLE
feat(stateless): blockhash_from_witness_headers — BLOCKHASH opcode over witness.headers

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -205,6 +205,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_header_extract_gas_limit" => some ziskHeaderExtractGasLimitProbeUnit
   | "zisk_block_validate_block_hash_pair" => some ziskBlockValidateBlockHashPairProbeUnit
   | "zisk_block_hash_and_extract_number" => some ziskBlockHashAndExtractNumberProbeUnit
+  | "zisk_blockhash_from_witness_headers" => some ziskBlockhashFromWitnessHeadersProbeUnit
   | "zisk_header_compute_summary_struct" => some ziskHeaderComputeSummaryStructProbeUnit
   | "zisk_header_extract_difficulty" => some ziskHeaderExtractDifficultyProbeUnit
   | "zisk_header_extract_extra_data" => some ziskHeaderExtractExtraDataProbeUnit
@@ -673,6 +674,7 @@ def knownProgramNames : List String :=
    "zisk_header_extract_gas_limit",
    "zisk_block_validate_block_hash_pair",
    "zisk_block_hash_and_extract_number",
+   "zisk_blockhash_from_witness_headers",
    "zisk_header_compute_summary_struct",
    "zisk_header_extract_difficulty",
    "zisk_header_extract_extra_data",

--- a/EvmAsm/Codegen/Programs/BlockHashPredicates.lean
+++ b/EvmAsm/Codegen/Programs/BlockHashPredicates.lean
@@ -26,6 +26,7 @@ import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.Tx
 import EvmAsm.Codegen.Programs.Header
 import EvmAsm.Codegen.Programs.HeaderFields
+import EvmAsm.Codegen.Programs.HeaderU64
 
 namespace EvmAsm.Codegen
 
@@ -541,5 +542,161 @@ def ziskHeaderComputeSummaryStructProbeUnit : BuildUnit := {
   dataAsm     := ziskHeaderComputeSummaryStructDataSection
 }
 
+/-! ## blockhash_from_witness_headers
+
+    BLOCKHASH-opcode semantics over a stateless witness: given a
+    target block number and the `witness.headers` SSZ list
+    section, find the header whose `block.number` field matches
+    the target, then return `keccak256(header_rlp)`.
+
+    The witness layout is the same as `witness.state` /
+    `witness.codes` -- `[N x u32 inner offsets][concat header
+    bytes]` -- so the iteration pattern mirrors K19
+    `witness_lookup_by_hash`, but with the match criterion
+    swapped from a hash compare to a `header_extract_number`
+    call.
+
+    Calling convention:
+      a0 (input)  : target block number (u64)
+      a1 (input)  : witness.headers section ptr
+      a2 (input)  : section_len (0 ⇒ guaranteed miss)
+      a3 (input)  : 32-byte output buffer (block hash; written on hit only)
+      a4 (input)  : u64 out ptr (matched element offset within section; on hit only)
+      a5 (input)  : u64 out ptr (matched element length; on hit only)
+      ra (input)  : return
+      a0 (output) :
+        0 hit (output buffer filled, offset/length written)
+        1 miss
+        2 RLP parse failure on some header along the way
+-/
+def blockhashFromWitnessHeadersFunction : String :=
+  "blockhash_from_witness_headers:\n" ++
+  "  addi sp, sp, -80\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  mv s7, a0                  # target block number\n" ++
+  "  mv s0, a1                  # section ptr\n" ++
+  "  mv s1, a2                  # section_len\n" ++
+  "  mv s2, a3                  # block hash output ptr\n" ++
+  "  mv s3, a4                  # offset out ptr\n" ++
+  "  mv s4, a5                  # length out ptr\n" ++
+  "  beqz s1, .Lbhfwh_miss      # empty section ⇒ miss\n" ++
+  "  lwu t0, 0(s0)              # first inner offset = 4 * N\n" ++
+  "  srli s5, t0, 2             # s5 = N\n" ++
+  "  li s6, 0                   # s6 = i\n" ++
+  ".Lbhfwh_loop:\n" ++
+  "  beq s6, s5, .Lbhfwh_miss\n" ++
+  "  # Compute element i bounds.\n" ++
+  "  slli t0, s6, 2             # 4*i\n" ++
+  "  add t1, s0, t0\n" ++
+  "  lwu t2, 0(t1)              # inner_off_i\n" ++
+  "  add a0, s0, t2             # el_i_start\n" ++
+  "  addi t3, s6, 1\n" ++
+  "  beq t3, s5, .Lbhfwh_use_end\n" ++
+  "  slli t3, t3, 2             # 4*(i+1)\n" ++
+  "  add t3, s0, t3\n" ++
+  "  lwu t4, 0(t3)\n" ++
+  "  add t4, s0, t4             # el_i_end\n" ++
+  "  j .Lbhfwh_have_end\n" ++
+  ".Lbhfwh_use_end:\n" ++
+  "  add t4, s0, s1             # el_i_end = section_end\n" ++
+  ".Lbhfwh_have_end:\n" ++
+  "  sub a1, t4, a0             # el_i_len\n" ++
+  "  la a2, bhfwh_number_buf\n" ++
+  "  jal ra, header_extract_number\n" ++
+  "  beqz a0, .Lbhfwh_compare\n" ++
+  "  li a0, 2                   # any header that fails to parse number ⇒ status 2\n" ++
+  "  j .Lbhfwh_ret\n" ++
+  ".Lbhfwh_compare:\n" ++
+  "  la t0, bhfwh_number_buf; ld t1, 0(t0)\n" ++
+  "  beq t1, s7, .Lbhfwh_match\n" ++
+  "  addi s6, s6, 1\n" ++
+  "  j .Lbhfwh_loop\n" ++
+  ".Lbhfwh_match:\n" ++
+  "  # Recompute (offset, length) since they were clobbered.\n" ++
+  "  slli t0, s6, 2\n" ++
+  "  add t1, s0, t0\n" ++
+  "  lwu t2, 0(t1)\n" ++
+  "  add a0, s0, t2             # el_start\n" ++
+  "  sd t2, 0(s3)               # *out_offset\n" ++
+  "  addi t3, s6, 1\n" ++
+  "  beq t3, s5, .Lbhfwh_last\n" ++
+  "  slli t3, t3, 2\n" ++
+  "  add t3, s0, t3\n" ++
+  "  lwu t4, 0(t3)\n" ++
+  "  sub t4, t4, t2             # length\n" ++
+  "  j .Lbhfwh_store_len\n" ++
+  ".Lbhfwh_last:\n" ++
+  "  sub t4, s1, t2\n" ++
+  ".Lbhfwh_store_len:\n" ++
+  "  sd t4, 0(s4)               # *out_length\n" ++
+  "  mv a1, t4                  # length argument for keccak\n" ++
+  "  mv a2, s2                  # block hash out ptr\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbhfwh_ret\n" ++
+  ".Lbhfwh_miss:\n" ++
+  "  li a0, 1\n" ++
+  ".Lbhfwh_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  addi sp, sp, 80\n" ++
+  "  ret"
+
+/-- `zisk_blockhash_from_witness_headers`: probe BuildUnit.
+    Input layout (at INPUT_ADDR):
+      bytes  0.. 8 : (ziskemu metadata)
+      bytes  8..16 : target_block_number (u64 LE)
+      bytes 16..24 : section_len (u64 LE)
+      bytes 24..   : witness.headers section
+    Output layout:
+      bytes  0.. 8 : status (0 hit / 1 miss / 2 parse_fail)
+      bytes  8..16 : matched offset within section (on hit)
+      bytes 16..24 : matched length within section (on hit)
+      bytes 24..56 : block hash (on hit; zeros otherwise) -/
+def ziskBlockhashFromWitnessHeadersPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a6, 0x40000000\n" ++
+  "  ld a0, 8(a6)                # target block number\n" ++
+  "  ld a2, 16(a6)               # section_len\n" ++
+  "  addi a1, a6, 24             # section ptr\n" ++
+  "  li a3, 0xa0010018           # block hash out (OUTPUT + 24)\n" ++
+  "  li a4, 0xa0010008           # offset out  (OUTPUT + 8)\n" ++
+  "  li a5, 0xa0010010           # length out  (OUTPUT + 16)\n" ++
+  "  # Pre-zero outputs so non-hit cases surface as zeros.\n" ++
+  "  sd zero, 0(a4); sd zero, 0(a5)\n" ++
+  "  sd zero, 0(a3); sd zero, 8(a3); sd zero, 16(a3); sd zero, 24(a3)\n" ++
+  "  jal ra, blockhash_from_witness_headers\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status at OUTPUT + 0\n" ++
+  "  j .Lbhfwh_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  headerExtractNumberFunction ++ "\n" ++
+  blockhashFromWitnessHeadersFunction ++ "\n" ++
+  ".Lbhfwh_pdone:"
+
+def ziskBlockhashFromWitnessHeadersDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "bhfwh_number_buf:\n" ++
+  "  .zero 8"
+
+def ziskBlockhashFromWitnessHeadersProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockhashFromWitnessHeadersPrologue
+  dataAsm     := ziskBlockhashFromWitnessHeadersDataSection
+}
 
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **321**
-- ziskemu round-trip scripts: **312** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **322**
+- ziskemu round-trip scripts: **313** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-blockhash-from-witness-headers-check.sh
+++ b/scripts/codegen-zisk-blockhash-from-witness-headers-check.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# codegen-zisk-blockhash-from-witness-headers-check.sh
+#
+# BLOCKHASH-opcode semantics over a stateless witness: given a
+# target block number, find the matching header in
+# witness.headers and return keccak256(header_rlp).
+#
+# Composes K233 header_extract_number + zkvm_keccak256 over the
+# witness.headers SSZ list layout.
+#
+# Output (40 bytes):
+#   bytes  0.. 8 : status (0 hit / 1 miss / 2 parse_fail)
+#   bytes  8..16 : matched offset within section (on hit)
+#   bytes 16..24 : matched length within section (on hit)
+#   bytes 24..56 : block hash (on hit; zeros otherwise)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_blockhash_from_witness_headers ELF"
+lake exe codegen --program zisk_blockhash_from_witness_headers \
+  --halt linux93 \
+  -o gen-out/zisk_blockhash_from_witness_headers
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <mode> [args...]
+#
+#   hit <target_n> <numbers_csv>
+#     witness.headers = N synthetic headers with numbers from
+#     numbers_csv; lookup target_n which must be in numbers_csv.
+#     Expected: status 0, matched offset/length, keccak.
+#
+#   miss <target_n> <numbers_csv>
+#     Same but target_n is NOT in numbers_csv.
+#     Expected: status 1, zeros.
+#
+#   parse_fail <target_n>
+#     witness.headers contains one 1-byte garbage entry; should
+#     surface as status 2.
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_bhfwh_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_bhfwh_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_bhfwh_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0:
+        return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset)
+        offset += len(e)
+    for e in elements:
+        section += e
+    return section
+
+def header_with_number(n):
+    number_bytes = n.to_bytes((n.bit_length() + 7) // 8, 'big') if n > 0 else b''
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, b'\\x44'*32, b'\\x55'*32,
+        b'\\x66'*32, b'\\x00'*256, b'',
+        number_bytes,
+        b'\\x83\\xff\\xff\\xff', b'',
+        b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    return rlp.encode(fields)
+
+argv = sys.argv[1:]
+mode = '$mode'
+parts = [
+$(for arg in "$@"; do printf '  %s,\n' "\"$arg\""; done)
+]
+
+if mode == 'hit':
+    target = int(parts[0])
+    numbers = [int(p) for p in parts[1].split(',') if p]
+    headers = [header_with_number(n) for n in numbers]
+    section = build_ssz_section(headers)
+    # Find matched index
+    idx = numbers.index(target)
+    # Compute offset/length within the section.
+    N = len(headers)
+    offset = 4 * N
+    for i in range(idx):
+        offset += len(headers[i])
+    length = len(headers[idx])
+    block_hash = k256(headers[idx])
+    expected = (
+        struct.pack('<Q', 0)
+        + struct.pack('<Q', offset)
+        + struct.pack('<Q', length)
+        + block_hash
+    )
+elif mode == 'miss':
+    target = int(parts[0])
+    numbers = [int(p) for p in parts[1].split(',') if p]
+    headers = [header_with_number(n) for n in numbers]
+    section = build_ssz_section(headers)
+    expected = struct.pack('<Q', 1) + b'\\x00' * 48
+elif mode == 'parse_fail':
+    target = int(parts[0])
+    headers = [b'\\xc0']  # RLP empty list -- has no field-8 number
+    section = build_ssz_section(headers)
+    expected = struct.pack('<Q', 2) + b'\\x00' * 48
+else:
+    raise SystemExit('bad mode: ' + mode)
+
+with open(argv[0], 'wb') as f:
+    record = (
+        struct.pack('<Q', target)
+        + struct.pack('<Q', len(section))
+        + section
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(argv[1], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_blockhash_from_witness_headers.elf \
+    -i "$in_file" -o "$out_file" -n 4000000 \
+    >"$REPO_ROOT/gen-out/zisk_bhfwh_${name}.emu.log" 2>&1 || true
+
+  local exp_size; exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-30s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-30s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "hit_single"              hit 100 "100" || FAILED=1
+run_case "hit_first_of_three"      hit 100 "100,200,300" || FAILED=1
+run_case "hit_middle_of_three"     hit 200 "100,200,300" || FAILED=1
+run_case "hit_last_of_three"       hit 300 "100,200,300" || FAILED=1
+run_case "miss_smaller"            miss 50 "100,200,300" || FAILED=1
+run_case "miss_larger"             miss 999 "100,200,300" || FAILED=1
+run_case "miss_empty_section"      miss 100 "" || FAILED=1
+run_case "parse_fail"              parse_fail 100 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: blockhash_from_witness_headers end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `zisk_blockhash_from_witness_headers`, the witness-side implementation of the EVM `BLOCKHASH` opcode. Composes K233 `header_extract_number` and `zkvm_keccak256` to walk the `witness.headers` SSZ list, find the header whose `block.number` matches a target, and return `keccak256(header_rlp)`.
- Pivots from the trie-walk angle of PRs #7142–#7146 to the opcode-semantic angle: where those resolve account/storage/code via `witness.state`, this one resolves `BLOCKHASH(n)` via `witness.headers` — one of the rare EVM opcodes that reads outside the current block's trie roots.
- Reuses the same SSZ list iteration pattern as K19 `witness_lookup_by_hash`; only the match criterion swaps from hash-compare to a `header_extract_number` call.
- No changes to any existing program or fixture — `scripts/codegen-stateless-spec-output-check.sh` still passes byte-for-byte.

## Probe interface

Input layout at `INPUT_ADDR = 0x40000000`:

```
[0..8)   ziskemu metadata (zero)
[8..16)  target_block_number (u64 LE)
[16..24) section_len         (u64 LE)
[24..)   witness.headers section bytes
```

Output at `OUTPUT_ADDR = 0xa0010000`:

| range      | meaning |
|------------|---------|
| `[0..8)`   | status (0 hit / 1 miss / 2 parse fail) |
| `[8..16)`  | matched element offset within section (on hit) |
| `[16..24)` | matched element length (on hit) |
| `[24..56)` | block hash = `keccak256(matched_header)` (on hit; zeros otherwise) |

## Test plan
- [x] `lake build codegen` clean
- [x] `scripts/codegen-zisk-blockhash-from-witness-headers-check.sh` — 8 fixtures pass:
  - `hit_single`, `hit_first_of_three`, `hit_middle_of_three`, `hit_last_of_three` (target found at varying positions; offset/length/keccak verified)
  - `miss_smaller`, `miss_larger`, `miss_empty_section` (target not present → status 1)
  - `parse_fail` (a malformed header in the section → status 2)
- [x] `scripts/codegen-stateless-spec-output-check.sh` — integration fixtures still match `run_stateless_guest` byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)