### PR TITLE
feat(stateless): extcodesize_at_header_state_root — EVM EXTCODESIZE semantics

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -406,6 +406,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_account_at_header_state_root" => some ziskAccountAtHeaderStateRootProbeUnit
   | "zisk_slot_at_header_state_root" => some ziskSlotAtHeaderStateRootProbeUnit
   | "zisk_code_at_header_state_root" => some ziskCodeAtHeaderStateRootProbeUnit
+  | "zisk_extcodesize_at_header_state_root" => some ziskExtcodesizeAtHeaderStateRootProbeUnit
   | "zisk_rlp_field_to_u64"     => some ziskRlpFieldToU64ProbeUnit
   | "zisk_rlp_field_to_u256_be" => some ziskRlpFieldToU256BeProbeUnit
   | "zisk_tx_legacy_decode"     => some ziskTxLegacyDecodeProbeUnit
@@ -557,6 +558,7 @@ def knownProgramNames : List String :=
    "zisk_account_at_header_state_root",
    "zisk_slot_at_header_state_root",
    "zisk_code_at_header_state_root",
+   "zisk_extcodesize_at_header_state_root",
    "zisk_rlp_field_to_u64",
    "zisk_rlp_field_to_u256_be",
    "zisk_tx_legacy_decode",

--- a/EvmAsm/Codegen/Programs/StateCompose.lean
+++ b/EvmAsm/Codegen/Programs/StateCompose.lean
@@ -960,5 +960,270 @@ def ziskCodeAtHeaderStateRootProbeUnit : BuildUnit := {
   dataAsm     := ziskCodeAtHeaderStateRootDataSection
 }
 
+/-! ## extcodesize_at_header_state_root  (EVM EXTCODESIZE opcode)
+
+    Witness-side implementation of the EVM `EXTCODESIZE` opcode.
+    Given a parent header RLP, an address, and the SSZ
+    `witness.state` and `witness.codes` sections, return the
+    u64 byte length an `EXTCODESIZE(addr)` frame would push.
+
+    EXTCODESIZE semantics (per the execution spec):
+      * 0 if the account doesn't exist
+      * 0 if the account has `code_hash == EMPTY_CODE_HASH`
+        (no code; no codes-section lookup needed)
+      * `len(witness.codes[i])` where node `i` is the entry whose
+        `keccak256` matches `account.code_hash`
+
+    Distinct from PR-K? `code_at_header_state_root` (which
+    returns the code's offset/length without applying the
+    empty-code rule) and PR-K? `extcodehash_at_header_state_root`
+    (which returns the hash, with EIP-1052's empty-account zero
+    rule).
+
+    Composes K201 `header_extract_state_root`, K28
+    `account_at_address`, K19 `witness_lookup_by_hash`, and an
+    inline 4 x u64 compare against the pre-baked
+    `EMPTY_CODE_HASH` constant.
+
+    Calling convention (7 args, fits in a0..a6):
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp_len
+      a2 (input)  : address ptr (20 bytes)
+      a3 (input)  : witness.state ptr
+      a4 (input)  : witness.state len
+      a5 (input)  : witness.codes ptr
+      a6 (input)  : witness.codes len
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success (`ecsahsr_code_len` holds the code length;
+            may be 0 for missing/empty)
+        2 = state-trie mpt parse error
+        3 = account_decode failure
+        4 = header parse / state_root size fail
+        5 = code_hash != EMPTY but not found in witness.codes
+            (witness integrity violation)
+
+    The probe BuildUnit copies `ecsahsr_code_len` to OUTPUT + 8.
+-/
+def extcodesizeAtHeaderStateRootFunction : String :=
+  "extcodesize_at_header_state_root:\n" ++
+  "  addi sp, sp, -80\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  mv s0, a0                  # header_rlp ptr\n" ++
+  "  mv s1, a1                  # header_rlp_len\n" ++
+  "  mv s2, a2                  # address ptr\n" ++
+  "  mv s3, a3                  # witness.state ptr\n" ++
+  "  mv s4, a4                  # witness.state len\n" ++
+  "  mv s5, a5                  # witness.codes ptr\n" ++
+  "  mv s6, a6                  # witness.codes len\n" ++
+  "  # Pre-zero output (covers the missing/empty cases).\n" ++
+  "  la t0, ecsahsr_code_len\n" ++
+  "  sd zero, 0(t0)\n" ++
+  "  # Step 1: header.state_root -> ecsahsr_state_root.\n" ++
+  "  mv a0, s0\n" ++
+  "  mv a1, s1\n" ++
+  "  la a2, ecsahsr_state_root\n" ++
+  "  jal ra, header_extract_state_root\n" ++
+  "  beqz a0, .Lecsahsr_step2\n" ++
+  "  li a0, 4\n" ++
+  "  j .Lecsahsr_ret\n" ++
+  ".Lecsahsr_step2:\n" ++
+  "  # Step 2: account_at_address -> ecsahsr_acct_struct.\n" ++
+  "  mv a0, s2\n" ++
+  "  li a1, 20\n" ++
+  "  la a2, ecsahsr_state_root\n" ++
+  "  mv a3, s3\n" ++
+  "  mv a4, s4\n" ++
+  "  la s7, ecsahsr_acct_struct\n" ++
+  "  mv a5, s7\n" ++
+  "  jal ra, account_at_address\n" ++
+  "  beqz a0, .Lecsahsr_check_empty\n" ++
+  "  # status 1 (not in trie) -> spec returns 0 (output already zero).\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Lecsahsr_success_zero\n" ++
+  "  # status 2/3 -> propagate.\n" ++
+  "  j .Lecsahsr_ret\n" ++
+  ".Lecsahsr_success_zero:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lecsahsr_ret\n" ++
+  ".Lecsahsr_check_empty:\n" ++
+  "  # code_hash == EMPTY_CODE_HASH ?\n" ++
+  "  la t0, ecsahsr_empty_code_hash\n" ++
+  "  ld t1,  0(t0); ld t2, 72(s7); bne t1, t2, .Lecsahsr_lookup\n" ++
+  "  ld t1,  8(t0); ld t2, 80(s7); bne t1, t2, .Lecsahsr_lookup\n" ++
+  "  ld t1, 16(t0); ld t2, 88(s7); bne t1, t2, .Lecsahsr_lookup\n" ++
+  "  ld t1, 24(t0); ld t2, 96(s7); bne t1, t2, .Lecsahsr_lookup\n" ++
+  "  # code is empty; output stays 0, return 0.\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lecsahsr_ret\n" ++
+  ".Lecsahsr_lookup:\n" ++
+  "  # Step 3: witness_lookup_by_hash(codes, &acct.code_hash).\n" ++
+  "  mv a0, s5\n" ++
+  "  mv a1, s6\n" ++
+  "  addi a2, s7, 72            # &acct.code_hash\n" ++
+  "  la a3, ecsahsr_dummy_offset\n" ++
+  "  la a4, ecsahsr_code_len\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  beqz a0, .Lecsahsr_ret\n" ++
+  "  # miss -> witness integrity violation (5); zero output.\n" ++
+  "  la t0, ecsahsr_code_len\n" ++
+  "  sd zero, 0(t0)\n" ++
+  "  li a0, 5\n" ++
+  ".Lecsahsr_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  addi sp, sp, 80\n" ++
+  "  ret"
+
+/-- `zisk_extcodesize_at_header_state_root`: probe BuildUnit.
+    Input layout (at INPUT_ADDR):
+      bytes  0.. 8 : (ziskemu metadata)
+      bytes  8..16 : header_rlp_len    (u64 LE)
+      bytes 16..24 : witness_state_len (u64 LE)
+      bytes 24..32 : witness_codes_len (u64 LE)
+      bytes 32..52 : address (20 bytes)
+      bytes 52..52+H              : header_rlp
+      bytes 52+H..52+H+WS         : witness.state
+      bytes 52+H+WS..             : witness.codes
+    Output layout:
+      bytes  0.. 8 : status (0 / 2 / 3 / 4 / 5)
+      bytes  8..16 : code length (u64; 0 for missing/empty) -/
+def ziskExtcodesizeAtHeaderStateRootPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t1, 0x40000000\n" ++
+  "  ld t2, 8(t1)                # header_rlp_len\n" ++
+  "  ld t3, 16(t1)               # witness_state_len\n" ++
+  "  ld t4, 24(t1)               # witness_codes_len\n" ++
+  "  addi a2, t1, 32             # address ptr\n" ++
+  "  addi a0, t1, 52             # header_rlp ptr\n" ++
+  "  mv a1, t2                   # header_rlp_len\n" ++
+  "  add a3, a0, t2              # witness.state ptr\n" ++
+  "  mv a4, t3                   # witness_state_len\n" ++
+  "  add a5, a3, t3              # witness.codes ptr\n" ++
+  "  mv a6, t4                   # witness_codes_len\n" ++
+  "  jal ra, extcodesize_at_header_state_root\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status at OUTPUT + 0\n" ++
+  "  # Copy ecsahsr_code_len to OUTPUT + 8.\n" ++
+  "  la t1, ecsahsr_code_len; ld t2, 0(t1); sd t2, 8(t0)\n" ++
+  "  j .Lecsahsr_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  mptLookupByKeyFunction ++ "\n" ++
+  accountDecodeFunction ++ "\n" ++
+  accountAtAddressFunction ++ "\n" ++
+  headerExtractStateRootFunction ++ "\n" ++
+  extcodesizeAtHeaderStateRootFunction ++ "\n" ++
+  ".Lecsahsr_pdone:"
+
+def ziskExtcodesizeAtHeaderStateRootDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mnk_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_dummy_length:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mbc_offset:\n" ++
+  "  .zero 8\n" ++
+  "mbc_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_lookup_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_lookup_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_lookup_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_child_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_nibble_count:\n" ++
+  "  .zero 8\n" ++
+  "mw_is_leaf:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_nibble_buf:\n" ++
+  "  .zero 128\n" ++
+  ".balign 32\n" ++
+  "mlk_keccak_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "mlk_nibble_buf:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "ad_offset:\n" ++
+  "  .zero 8\n" ++
+  "ad_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aa_value_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aa_value_scratch:\n" ++
+  "  .zero 256\n" ++
+  ".balign 8\n" ++
+  "hesr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hesr_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "ecsahsr_state_root:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "ecsahsr_acct_struct:\n" ++
+  "  .zero 104\n" ++
+  ".balign 8\n" ++
+  "ecsahsr_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "ecsahsr_code_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "ecsahsr_empty_code_hash:\n" ++
+  "  .byte 0xc5, 0xd2, 0x46, 0x01, 0x86, 0xf7, 0x23, 0x3c\n" ++
+  "  .byte 0x92, 0x7e, 0x7d, 0xb2, 0xdc, 0xc7, 0x03, 0xc0\n" ++
+  "  .byte 0xe5, 0x00, 0xb6, 0x53, 0xca, 0x82, 0x27, 0x3b\n" ++
+  "  .byte 0x7b, 0xfa, 0xd8, 0x04, 0x5d, 0x85, 0xa4, 0x70"
+
+def ziskExtcodesizeAtHeaderStateRootProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskExtcodesizeAtHeaderStateRootPrologue
+  dataAsm     := ziskExtcodesizeAtHeaderStateRootDataSection
+}
+
 
 end EvmAsm.Codegen

--- a/scripts/codegen-zisk-extcodesize-at-header-state-root-check.sh
+++ b/scripts/codegen-zisk-extcodesize-at-header-state-root-check.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# codegen-zisk-extcodesize-at-header-state-root-check.sh
+#
+# Witness-side EXTCODESIZE: from a parent header RLP + witness.state +
+# witness.codes, return the u64 code length an EXTCODESIZE(addr)
+# frame would push:
+#   * 0 if the account doesn't exist
+#   * 0 if account.code_hash == EMPTY_CODE_HASH (no code)
+#   * len(witness.codes[i]) where keccak(codes[i]) == account.code_hash
+#
+# Composes K201 + K28 + K19 + an inline empty-code check.
+#
+# Output (16 bytes):
+#   bytes  0.. 8 : status
+#       0 success
+#       2 state-trie mpt parse
+#       3 account_decode failure
+#       4 header parse fail
+#       5 code_hash != EMPTY but not in witness.codes
+#   bytes  8..16 : code length (u64)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_extcodesize_at_header_state_root ELF"
+lake exe codegen --program zisk_extcodesize_at_header_state_root \
+  --halt linux93 \
+  -o gen-out/zisk_extcodesize_at_header_state_root
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <mode> [args...]
+#
+#   contract <addr> <nonce> <balance> <code_hex>
+#     Real contract; expect (0, len(code_bytes)).
+#
+#   contract_with_padding_codes <addr> <nonce> <balance> <code_hex> <extras_csv>
+#     Non-trivial codes section with extras before our target.
+#
+#   empty_code_present <addr> <nonce> <balance>
+#     Account in trie but code_hash == EMPTY_CODE_HASH; expect (0, 0).
+#
+#   missing_account <lookup_addr> <stored_addr> <nonce> <balance> <code_hex>
+#     Account not at lookup address; expect (0, 0).
+#
+#   integrity_violation <addr> <nonce> <balance> <code_hex>
+#     account.code_hash != EMPTY but witness.codes is empty
+#     (witness is incomplete); expect (5, 0).
+#
+#   garbage_header <addr>
+#     1-byte invalid header; expect (4, 0).
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_ecsahsr_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_ecsahsr_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_ecsahsr_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def hp_encode(nibbles, is_leaf):
+    flag = 2 if is_leaf else 0
+    if len(nibbles) % 2 == 1:
+        flag |= 1
+        result = bytes([flag * 0x10 + nibbles[0]])
+        nibbles = nibbles[1:]
+    else:
+        result = bytes([flag * 0x10])
+    for i in range(0, len(nibbles), 2):
+        result += bytes([nibbles[i] * 0x10 + nibbles[i+1]])
+    return result
+
+def leaf_node(path_nibbles, value):
+    return rlp.encode([hp_encode(path_nibbles, True), value])
+
+def bytes_to_nibbles(b):
+    out = []
+    for byte in b:
+        out.append(byte >> 4)
+        out.append(byte & 0xf)
+    return out
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0:
+        return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset)
+        offset += len(e)
+    for e in elements:
+        section += e
+    return section
+
+def encode_account(nonce, balance, storage_root, code_hash):
+    return rlp.encode([nonce, balance, storage_root, code_hash])
+
+def encode_header(state_root):
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x55'*32,
+        b'\\x66'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    return rlp.encode(fields)
+
+EMPTY_TRIE = bytes.fromhex('56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421')
+EMPTY_CODE_HASH = bytes.fromhex('c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')
+
+argv = sys.argv[1:]
+mode = '$mode'
+parts = [
+$(for arg in "$@"; do printf '  %s,\n' "\"$arg\""; done)
+]
+
+def build_state_with_account(addr, account_rlp):
+    path = bytes_to_nibbles(k256(addr))
+    leaf = leaf_node(path, account_rlp)
+    return k256(leaf), build_ssz_section([leaf])
+
+if mode == 'contract':
+    addr = bytes.fromhex(parts[0])
+    nonce = int(parts[1])
+    balance = int(parts[2])
+    code = bytes.fromhex(parts[3])
+    code_hash = k256(code)
+    account = encode_account(nonce, balance, EMPTY_TRIE, code_hash)
+    state_root, witness_state = build_state_with_account(addr, account)
+    witness_codes = build_ssz_section([code])
+    header = encode_header(state_root)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', len(code))
+elif mode == 'contract_with_padding_codes':
+    addr = bytes.fromhex(parts[0])
+    nonce = int(parts[1])
+    balance = int(parts[2])
+    code = bytes.fromhex(parts[3])
+    extras = [bytes.fromhex(p) for p in parts[4].split(',') if p]
+    code_hash = k256(code)
+    account = encode_account(nonce, balance, EMPTY_TRIE, code_hash)
+    state_root, witness_state = build_state_with_account(addr, account)
+    witness_codes = build_ssz_section(extras + [code])
+    header = encode_header(state_root)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', len(code))
+elif mode == 'empty_code_present':
+    addr = bytes.fromhex(parts[0])
+    nonce = int(parts[1])
+    balance = int(parts[2])
+    account = encode_account(nonce, balance, EMPTY_TRIE, EMPTY_CODE_HASH)
+    state_root, witness_state = build_state_with_account(addr, account)
+    witness_codes = b''
+    header = encode_header(state_root)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', 0)
+elif mode == 'missing_account':
+    lookup_addr = bytes.fromhex(parts[0])
+    stored_addr = bytes.fromhex(parts[1])
+    nonce = int(parts[2])
+    balance = int(parts[3])
+    code = bytes.fromhex(parts[4])
+    code_hash = k256(code)
+    account = encode_account(nonce, balance, EMPTY_TRIE, code_hash)
+    state_root, witness_state = build_state_with_account(stored_addr, account)
+    witness_codes = build_ssz_section([code])
+    addr = lookup_addr
+    header = encode_header(state_root)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', 0)
+elif mode == 'integrity_violation':
+    addr = bytes.fromhex(parts[0])
+    nonce = int(parts[1])
+    balance = int(parts[2])
+    code = bytes.fromhex(parts[3])
+    code_hash = k256(code)
+    account = encode_account(nonce, balance, EMPTY_TRIE, code_hash)
+    state_root, witness_state = build_state_with_account(addr, account)
+    witness_codes = b''                # incomplete witness
+    header = encode_header(state_root)
+    expected = struct.pack('<Q', 5) + struct.pack('<Q', 0)
+elif mode == 'garbage_header':
+    addr = bytes.fromhex(parts[0])
+    witness_state = b''
+    witness_codes = b''
+    header = b'\\x00'
+    expected = struct.pack('<Q', 4) + struct.pack('<Q', 0)
+else:
+    raise SystemExit('bad mode: ' + mode)
+
+with open(argv[0], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(header))
+        + struct.pack('<Q', len(witness_state))
+        + struct.pack('<Q', len(witness_codes))
+        + addr
+        + header
+        + witness_state
+        + witness_codes
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(argv[1], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_extcodesize_at_header_state_root.elf \
+    -i "$in_file" -o "$out_file" -n 4000000 \
+    >"$REPO_ROOT/gen-out/zisk_ecsahsr_${name}.emu.log" 2>&1 || true
+
+  local exp_size; exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-34s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-34s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+ALICE="$(printf 'aa%.0s' $(seq 1 20))"
+BOB="$(printf 'bb%.0s' $(seq 1 20))"
+
+FAILED=0
+run_case "contract_tiny_code"              contract "$ALICE" 0 0 "6000" || FAILED=1
+run_case "contract_18b_code"               contract "$ALICE" 42 1000000000000000000 "60006000016000526000601a526001601aF3" || FAILED=1
+run_case "contract_with_padding_codes"     contract_with_padding_codes "$ALICE" 0 0 "deadbeef" "aa55,1122334455" || FAILED=1
+run_case "empty_code_with_eoa_value"       empty_code_present "$ALICE" 1 1000000000000000000 || FAILED=1
+run_case "fully_empty_account"             empty_code_present "$ALICE" 0 0 || FAILED=1
+run_case "missing_account"                 missing_account "$BOB" "$ALICE" 0 0 "6000" || FAILED=1
+run_case "integrity_violation_no_codes"    integrity_violation "$ALICE" 0 0 "6000" || FAILED=1
+run_case "garbage_header"                  garbage_header "$ALICE" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: extcodesize_at_header_state_root end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `zisk_extcodesize_at_header_state_root`, the witness-side implementation of the EVM `EXTCODESIZE` opcode. Composes K201 `header_extract_state_root` + K28 `account_at_address` + K19 `witness_lookup_by_hash` with an inline `EMPTY_CODE_HASH` short-circuit.
- Per the spec, EXTCODESIZE returns the byte length of the contract code, or 0 if the account is missing or has no code. The non-trivial part is the empty-code short-circuit: if `account.code_hash == EMPTY_CODE_HASH` (= `keccak("")`), we must return 0 *without* doing a `witness.codes` lookup. Otherwise we look up the code by hash and return `len(code)`.
- Distinct from:
  - PR #7146 `code_at_header_state_root` — returns offset/length but doesn't apply the empty-code rule
  - PR #7150 `extcodehash_at_header_state_root` — returns the hash with EIP-1052's empty-account zero rule
- Introduces a new status code `5` for "code_hash != EMPTY but not found in witness.codes" — a witness integrity violation that's distinct from the EVM-semantics-defined zero returns. Fully-empty accounts surface as `(status=0, code_len=0)`.
- No changes to any existing program or fixture — `scripts/codegen-stateless-spec-output-check.sh` still passes byte-for-byte.

## Probe interface

Input layout at `INPUT_ADDR = 0x40000000`:

```
[0..8)   ziskemu metadata (zero)
[8..16)  header_rlp_len    (u64 LE)
[16..24) witness_state_len (u64 LE)
[24..32) witness_codes_len (u64 LE)
[32..52) address (20 bytes)
[52..52+H)            header_rlp
[52+H..52+H+WS)       witness.state SSZ list
[52+H+WS..)           witness.codes SSZ list
```

Output at `OUTPUT_ADDR = 0xa0010000`:

| range     | meaning |
|-----------|---------|
| `[0..8)`  | status (0/2/3/4/5) |
| `[8..16)` | code length (u64; 0 for missing/empty) |

Status codes:

| code | meaning |
|------|---------|
| 0 | success (`code_len` obeys EVM semantics) |
| 2 | state-trie mpt parse error |
| 3 | account_decode failure |
| 4 | header parse / state_root size fail |
| 5 | code_hash != EMPTY but not in witness.codes (witness integrity violation) |

## Test plan
- [x] `lake build codegen` clean
- [x] `scripts/codegen-zisk-extcodesize-at-header-state-root-check.sh` — 8 fixtures pass:
  - `contract_tiny_code` — `PUSH1 0; STOP` → (0, 2)
  - `contract_18b_code` — 18-byte code → (0, 18)
  - `contract_with_padding_codes` — code preceded by 2 extras in codes section → (0, real_len)
  - `empty_code_with_eoa_value` — EOA with nonce/balance but `EMPTY_CODE_HASH` → (0, 0)
  - `fully_empty_account` — present in trie but fully empty → (0, 0)
  - `missing_account` — not in trie → (0, 0)
  - `integrity_violation_no_codes` — account claims code but `witness.codes` is empty → (5, 0)
  - `garbage_header` → (4, 0)
- [x] `scripts/codegen-stateless-spec-output-check.sh` — integration fixtures still match `run_stateless_guest` byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)