### PR TITLE
feat(stateless): witness_headers_chain_validate — verify chain continuity over witness.headers

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -208,6 +208,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_block_validate_block_hash_pair" => some ziskBlockValidateBlockHashPairProbeUnit
   | "zisk_block_hash_and_extract_number" => some ziskBlockHashAndExtractNumberProbeUnit
   | "zisk_blockhash_from_witness_headers" => some ziskBlockhashFromWitnessHeadersProbeUnit
+  | "zisk_witness_headers_chain_validate" => some ziskWitnessHeadersChainValidateProbeUnit
   | "zisk_header_compute_summary_struct" => some ziskHeaderComputeSummaryStructProbeUnit
   | "zisk_header_extract_difficulty" => some ziskHeaderExtractDifficultyProbeUnit
   | "zisk_header_extract_extra_data" => some ziskHeaderExtractExtraDataProbeUnit
@@ -686,6 +687,7 @@ def knownProgramNames : List String :=
    "zisk_block_validate_block_hash_pair",
    "zisk_block_hash_and_extract_number",
    "zisk_blockhash_from_witness_headers",
+   "zisk_witness_headers_chain_validate",
    "zisk_header_compute_summary_struct",
    "zisk_header_extract_difficulty",
    "zisk_header_extract_extra_data",

--- a/EvmAsm/Codegen/Programs/BlockHashPredicates.lean
+++ b/EvmAsm/Codegen/Programs/BlockHashPredicates.lean
@@ -699,4 +699,182 @@ def ziskBlockhashFromWitnessHeadersProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockhashFromWitnessHeadersDataSection
 }
 
+/-! ## witness_headers_chain_validate
+
+    Verify that an SSZ `witness.headers` list forms a coherent
+    chain: for each consecutive pair `(headers[i], headers[i+1])`,
+    confirm that
+      keccak256(headers[i]) == headers[i+1].parent_hash.
+
+    This is a per-pair generalization of K212
+    `block_validate_block_hash_pair` (which handles one pair) to
+    the whole witness section. Spec-side, this is the invariant
+    that lets `apply_body` trust the witness chain as the
+    canonical link from `parent_header` back to an ancestor: a
+    chain whose any pair fails this predicate is structurally
+    invalid and cannot be used to resolve `BLOCKHASH(n)` for
+    older heights without first detecting the break.
+
+    Walks the SSZ list with the same iteration pattern as K19
+    `witness_lookup_by_hash` / `blockhash_from_witness_headers`.
+
+    Calling convention:
+      a0 (input)  : witness.headers section ptr
+      a1 (input)  : section_len (0 ⇒ vacuous-valid)
+      a2 (input)  : u64 out ptr (n_pairs_checked; pairs == N-1
+                    on full success, or i (the first failing
+                    parent index) on mismatch / parse fail)
+      a3 (input)  : u64 out ptr (first_mismatch_index;
+                    written as 0xFFFFFFFFFFFFFFFF when no
+                    mismatch was found, else the parent index i
+                    of the failing pair)
+      ra (input)  : return
+      a0 (output) :
+        0 = all consecutive pairs link (or N ≤ 1, vacuous)
+        1 = some pair's parent_hash mismatch detected
+        2 = RLP parse failure when reading some header's
+            `parent_hash` field
+-/
+def witnessHeadersChainValidateFunction : String :=
+  "witness_headers_chain_validate:\n" ++
+  "  addi sp, sp, -80\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  mv s0, a0                  # section ptr\n" ++
+  "  mv s1, a1                  # section_len\n" ++
+  "  mv s2, a2                  # n_pairs_out ptr\n" ++
+  "  mv s3, a3                  # mismatch_idx_out ptr\n" ++
+  "  # Pre-fill outputs assuming vacuous-success: n=0, mismatch=-1.\n" ++
+  "  sd zero, 0(s2)\n" ++
+  "  li t0, -1\n" ++
+  "  sd t0, 0(s3)\n" ++
+  "  beqz s1, .Lwchv_ok           # empty section ⇒ vacuous\n" ++
+  "  lwu t0, 0(s0)                # first inner offset = 4 * N\n" ++
+  "  srli s4, t0, 2               # s4 = N\n" ++
+  "  li t1, 1\n" ++
+  "  bleu s4, t1, .Lwchv_ok       # N ≤ 1 ⇒ vacuous\n" ++
+  "  li s5, 0                     # s5 = i (parent index)\n" ++
+  ".Lwchv_loop:\n" ++
+  "  addi t3, s5, 1\n" ++
+  "  beq t3, s4, .Lwchv_ok        # i+1 == N: all pairs checked\n" ++
+  "  # Parent (element s5) bounds.\n" ++
+  "  slli t0, s5, 2\n" ++
+  "  add t1, s0, t0\n" ++
+  "  lwu t2, 0(t1)                # parent inner_off\n" ++
+  "  add a0, s0, t2               # parent_ptr\n" ++
+  "  slli t4, t3, 2               # 4*(i+1)\n" ++
+  "  add t4, s0, t4\n" ++
+  "  lwu t5, 0(t4)                # next inner_off = parent_end_off\n" ++
+  "  sub a1, t5, t2               # parent_len\n" ++
+  "  # keccak256(parent_rlp) -> wchv_parent_keccak\n" ++
+  "  la a2, wchv_parent_keccak\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  # Child (element s5+1) bounds.\n" ++
+  "  addi t3, s5, 1\n" ++
+  "  slli t4, t3, 2\n" ++
+  "  add t4, s0, t4\n" ++
+  "  lwu t5, 0(t4)                # child inner_off\n" ++
+  "  add a0, s0, t5               # child_ptr\n" ++
+  "  addi t6, t3, 1\n" ++
+  "  beq t6, s4, .Lwchv_use_end\n" ++
+  "  slli t6, t6, 2\n" ++
+  "  add t6, s0, t6\n" ++
+  "  lwu s6, 0(t6)\n" ++
+  "  j .Lwchv_have_end\n" ++
+  ".Lwchv_use_end:\n" ++
+  "  mv s6, s1\n" ++
+  ".Lwchv_have_end:\n" ++
+  "  sub a1, s6, t5               # child_len\n" ++
+  "  la a2, wchv_child_parent_hash\n" ++
+  "  jal ra, header_extract_parent_hash\n" ++
+  "  beqz a0, .Lwchv_compare\n" ++
+  "  # parent_hash extract failed -> status 2.\n" ++
+  "  sd s5, 0(s2)\n" ++
+  "  sd s5, 0(s3)\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lwchv_ret\n" ++
+  ".Lwchv_compare:\n" ++
+  "  la t0, wchv_parent_keccak\n" ++
+  "  la t1, wchv_child_parent_hash\n" ++
+  "  ld t2,  0(t0); ld t3,  0(t1); bne t2, t3, .Lwchv_mismatch\n" ++
+  "  ld t2,  8(t0); ld t3,  8(t1); bne t2, t3, .Lwchv_mismatch\n" ++
+  "  ld t2, 16(t0); ld t3, 16(t1); bne t2, t3, .Lwchv_mismatch\n" ++
+  "  ld t2, 24(t0); ld t3, 24(t1); bne t2, t3, .Lwchv_mismatch\n" ++
+  "  addi s5, s5, 1\n" ++
+  "  j .Lwchv_loop\n" ++
+  ".Lwchv_mismatch:\n" ++
+  "  sd s5, 0(s2)                 # n_pairs_out = i\n" ++
+  "  sd s5, 0(s3)                 # mismatch_idx_out = i\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lwchv_ret\n" ++
+  ".Lwchv_ok:\n" ++
+  "  # Write n_pairs = N-1 (or 0 if N<=1; we'll handle below).\n" ++
+  "  li t0, 1\n" ++
+  "  bleu s4, t0, .Lwchv_n_is_zero\n" ++
+  "  addi t0, s4, -1\n" ++
+  "  sd t0, 0(s2)\n" ++
+  "  j .Lwchv_ok_pred\n" ++
+  ".Lwchv_n_is_zero:\n" ++
+  "  sd zero, 0(s2)\n" ++
+  ".Lwchv_ok_pred:\n" ++
+  "  li t0, -1\n" ++
+  "  sd t0, 0(s3)\n" ++
+  "  li a0, 0\n" ++
+  ".Lwchv_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  addi sp, sp, 80\n" ++
+  "  ret"
+
+/-- `zisk_witness_headers_chain_validate`: probe BuildUnit.
+    Input layout (at INPUT_ADDR):
+      bytes  0.. 8 : (ziskemu metadata)
+      bytes  8..16 : section_len (u64 LE)
+      bytes 16..   : witness.headers section
+    Output layout:
+      bytes  0.. 8 : status (0 / 1 / 2)
+      bytes  8..16 : n_pairs_checked / first failing parent index
+      bytes 16..24 : mismatch_index (0xFF..FF on success) -/
+def ziskWitnessHeadersChainValidatePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a6, 0x40000000\n" ++
+  "  ld a1, 8(a6)                # section_len\n" ++
+  "  addi a0, a6, 16             # section ptr\n" ++
+  "  li a2, 0xa0010008           # n_pairs out\n" ++
+  "  li a3, 0xa0010010           # mismatch_idx out\n" ++
+  "  jal ra, witness_headers_chain_validate\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lwchv_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  headerExtractParentHashFunction ++ "\n" ++
+  witnessHeadersChainValidateFunction ++ "\n" ++
+  ".Lwchv_pdone:"
+
+def ziskWitnessHeadersChainValidateDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 8\n" ++
+  "heph_offset:\n" ++
+  "  .zero 8\n" ++
+  "heph_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "wchv_parent_keccak:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "wchv_child_parent_hash:\n" ++
+  "  .zero 32"
+
+def ziskWitnessHeadersChainValidateProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskWitnessHeadersChainValidatePrologue
+  dataAsm     := ziskWitnessHeadersChainValidateDataSection
+}
+
 end EvmAsm.Codegen

--- a/scripts/codegen-zisk-witness-headers-chain-validate-check.sh
+++ b/scripts/codegen-zisk-witness-headers-chain-validate-check.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# codegen-zisk-witness-headers-chain-validate-check.sh
+#
+# Verify that an SSZ witness.headers list is a coherent chain:
+# for each consecutive pair (headers[i], headers[i+1]),
+#   keccak256(headers[i]) == headers[i+1].parent_hash.
+#
+# Walks the SSZ list with the same per-element iteration pattern
+# as PR #7147 blockhash_from_witness_headers.
+#
+# Output (24 bytes):
+#   bytes  0.. 8 : status (0 ok / 1 mismatch / 2 RLP parse fail)
+#   bytes  8..16 : n_pairs_checked (or first failing parent index)
+#   bytes 16..24 : first_mismatch_index (0xFF..FF on success)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_witness_headers_chain_validate ELF"
+lake exe codegen --program zisk_witness_headers_chain_validate \
+  --halt linux93 \
+  -o gen-out/zisk_witness_headers_chain_validate
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <mode> [args...]
+#
+#   coherent <N>
+#     Build N headers chained correctly: header[i+1].parent_hash = keccak(header[i]).
+#     Expect (status=0, n_pairs=N-1, mismatch_idx=0xFF..FF).
+#
+#   break_at <N> <break_idx>
+#     Build N headers, but break header[break_idx+1].parent_hash to garbage.
+#     Expect (status=1, n_pairs=break_idx, mismatch_idx=break_idx).
+#
+#   parse_fail <N>
+#     Replace one header in the section with 1-byte garbage that fails
+#     parent_hash extraction. Expect status=2.
+#
+#   empty
+#     Empty witness.headers; expect (0, 0, 0xFF..FF).
+#
+#   singleton
+#     One header; expect (0, 0, 0xFF..FF) - vacuously valid.
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_wchv_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_wchv_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_wchv_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0:
+        return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset)
+        offset += len(e)
+    for e in elements:
+        section += e
+    return section
+
+def header_with_parent_and_number(parent_hash, n):
+    nb = n.to_bytes((n.bit_length() + 7) // 8, 'big') if n > 0 else b''
+    fields = [
+        parent_hash, b'\\x22'*32, b'\\x33'*20, b'\\x44'*32, b'\\x55'*32,
+        b'\\x66'*32, b'\\x00'*256, b'',
+        nb,
+        b'\\x83\\xff\\xff\\xff', b'', b'\\x83\\x01\\x02\\x03', b'',
+        b'\\x77'*32, b'\\x00'*8,
+    ]
+    return rlp.encode(fields)
+
+def build_coherent_chain(N, start_parent=b'\\x00'*32, start_n=100):
+    headers = []
+    prev_hash = start_parent
+    for i in range(N):
+        h = header_with_parent_and_number(prev_hash, start_n + i)
+        headers.append(h)
+        prev_hash = k256(h)
+    return headers
+
+argv = sys.argv[1:]
+mode = '$mode'
+parts = [
+$(for arg in "$@"; do printf '  %s,\n' "\"$arg\""; done)
+]
+
+MAX64 = (1 << 64) - 1
+
+if mode == 'coherent':
+    N = int(parts[0])
+    headers = build_coherent_chain(N)
+    section = build_ssz_section(headers)
+    expected = (
+        struct.pack('<Q', 0)
+        + struct.pack('<Q', max(N - 1, 0))
+        + struct.pack('<Q', MAX64)
+    )
+elif mode == 'break_at':
+    N = int(parts[0])
+    break_idx = int(parts[1])
+    headers = build_coherent_chain(N)
+    # Replace headers[break_idx + 1] with one that has a wrong parent_hash.
+    wrong_parent = b'\\xff' * 32
+    headers[break_idx + 1] = header_with_parent_and_number(wrong_parent, 200 + break_idx)
+    # Adjust subsequent headers to chain off the rebuilt one so only
+    # the (break_idx, break_idx+1) pair is broken.
+    prev = k256(headers[break_idx + 1])
+    for j in range(break_idx + 2, N):
+        headers[j] = header_with_parent_and_number(prev, 200 + j)
+        prev = k256(headers[j])
+    section = build_ssz_section(headers)
+    expected = (
+        struct.pack('<Q', 1)
+        + struct.pack('<Q', break_idx)
+        + struct.pack('<Q', break_idx)
+    )
+elif mode == 'parse_fail':
+    N = int(parts[0])
+    headers = build_coherent_chain(N)
+    # Replace one header (index 1, the child of the first pair) with garbage.
+    headers[1] = b'\\x00'
+    section = build_ssz_section(headers)
+    # The first pair will fail to extract parent_hash from the garbage child.
+    expected = (
+        struct.pack('<Q', 2)
+        + struct.pack('<Q', 0)
+        + struct.pack('<Q', 0)
+    )
+elif mode == 'empty':
+    section = b''
+    expected = (
+        struct.pack('<Q', 0)
+        + struct.pack('<Q', 0)
+        + struct.pack('<Q', MAX64)
+    )
+elif mode == 'singleton':
+    headers = build_coherent_chain(1)
+    section = build_ssz_section(headers)
+    expected = (
+        struct.pack('<Q', 0)
+        + struct.pack('<Q', 0)
+        + struct.pack('<Q', MAX64)
+    )
+else:
+    raise SystemExit('bad mode: ' + mode)
+
+with open(argv[0], 'wb') as f:
+    record = struct.pack('<Q', len(section)) + section
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(argv[1], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_witness_headers_chain_validate.elf \
+    -i "$in_file" -o "$out_file" -n 8000000 \
+    >"$REPO_ROOT/gen-out/zisk_wchv_${name}.emu.log" 2>&1 || true
+
+  local exp_size; exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-30s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-30s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "empty"                empty || FAILED=1
+run_case "singleton"            singleton || FAILED=1
+run_case "coherent_2"           coherent 2 || FAILED=1
+run_case "coherent_5"           coherent 5 || FAILED=1
+run_case "break_first_pair"     break_at 4 0 || FAILED=1
+run_case "break_middle_pair"    break_at 5 2 || FAILED=1
+run_case "break_last_pair"      break_at 5 3 || FAILED=1
+run_case "parse_fail_garbage"   parse_fail 3 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: witness_headers_chain_validate end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `zisk_witness_headers_chain_validate`, the per-pair generalization of K212 `block_validate_block_hash_pair` (which handles one parent/child pair) to a whole SSZ `witness.headers` section.
- For each consecutive pair `(headers[i], headers[i+1])`, verifies `keccak256(headers[i]) == headers[i+1].parent_hash`. This is the structural invariant that lets `apply_body` trust `witness.headers` as the canonical chain linking the current block back to ancestors. A chain whose any pair fails this predicate cannot be used to resolve `BLOCKHASH(n)` for older heights without first detecting the break.
- Composes `zkvm_keccak256` + K202 `header_extract_parent_hash` with the same SSZ list iteration pattern as PR #7147 `blockhash_from_witness_headers`.
- Returns the first failing parent index on mismatch/parse-fail (not just a boolean) — lets the caller know exactly where the break is.
- No changes to any existing program or fixture — `scripts/codegen-stateless-spec-output-check.sh` still passes byte-for-byte.

## Probe interface

Input layout at `INPUT_ADDR = 0x40000000`:

```
[0..8)   ziskemu metadata (zero)
[8..16)  section_len (u64 LE)
[16..)   witness.headers section bytes
```

Output at `OUTPUT_ADDR = 0xa0010000`:

| range      | meaning |
|------------|---------|
| `[0..8)`   | status (0 ok / 1 mismatch / 2 RLP parse fail) |
| `[8..16)`  | n_pairs_checked on success; first failing parent index on mismatch/parse-fail |
| `[16..24)` | first_mismatch_index (`0xFFFFFFFFFFFFFFFF` on success) |

## Test plan
- [x] `lake build codegen` clean
- [x] `scripts/codegen-zisk-witness-headers-chain-validate-check.sh` — 8 fixtures pass:
  - `empty` and `singleton` — vacuously valid (no pairs to check)
  - `coherent_2`, `coherent_5` — properly-linked chains of length 2 and 5
  - `break_first_pair`, `break_middle_pair`, `break_last_pair` — each breaks one pair at a different position; checks the function reports the correct failing parent index
  - `parse_fail_garbage` — a 1-byte garbage header in the chain → status 2
- [x] `scripts/codegen-stateless-spec-output-check.sh` — integration fixtures still match `run_stateless_guest` byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)