### PR TITLE
feat(stateless): account_is_empty_at_header_state_root — EIP-161 emptiness predicate

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -416,6 +416,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_extcodehash_at_header_state_root" => some ziskExtcodehashAtHeaderStateRootProbeUnit
   | "zisk_sload_at_header_state_root" => some ziskSloadAtHeaderStateRootProbeUnit
   | "zisk_account_exists_at_header_state_root" => some ziskAccountExistsAtHeaderStateRootProbeUnit
+  | "zisk_account_is_empty_at_header_state_root" => some ziskAccountIsEmptyAtHeaderStateRootProbeUnit
   | "zisk_validate_storage_root_in_witness_storage" => some ziskValidateStorageRootInWitnessStorageProbeUnit
   | "zisk_has_code_or_nonce_at_header_state_root" => some ziskHasCodeOrNonceAtHeaderStateRootProbeUnit
   | "zisk_rlp_field_to_u64"     => some ziskRlpFieldToU64ProbeUnit
@@ -573,6 +574,7 @@ def knownProgramNames : List String :=
    "zisk_extcodehash_at_header_state_root",
    "zisk_sload_at_header_state_root",
    "zisk_account_exists_at_header_state_root",
+   "zisk_account_is_empty_at_header_state_root",
    "zisk_validate_storage_root_in_witness_storage",
    "zisk_has_code_or_nonce_at_header_state_root",
    "zisk_rlp_field_to_u64",

--- a/EvmAsm/Codegen/Programs/StatePredicates.lean
+++ b/EvmAsm/Codegen/Programs/StatePredicates.lean
@@ -260,4 +260,272 @@ def ziskAccountExistsAtHeaderStateRootProbeUnit : BuildUnit := {
   dataAsm     := ziskAccountExistsAtHeaderStateRootDataSection
 }
 
+/-! ## account_is_empty_at_header_state_root  (EIP-161)
+
+    Witness-side implementation of the EIP-161 `account_is_empty`
+    predicate: returns 1 iff the account is present in the state
+    trie AND has `nonce == 0` AND `balance == 0` AND
+    `code_hash == EMPTY_CODE_HASH`.
+
+    This is the predicate used by spec primitives that need
+    EIP-161's notion of emptiness:
+      * SELFDESTRUCT touched-account refund accounting.
+      * SSTORE refund rules (EIP-2200 / Berlin).
+      * CALL value-transfer "touch" semantics.
+
+    Completes the boolean-predicate trio with:
+      * `account_exists_at_header_state_root` (presence only;
+        ignores contents).
+      * `has_code_or_nonce_at_header_state_root` (EIP-684
+        CREATE collision; nonce OR code, no balance).
+
+    Spec-distinguishing rows (account_in_trie = present):
+
+        | account contents             | exists | EIP-684 | EIP-161 |
+        |------------------------------|--------|---------|---------|
+        | fully empty                  |   1    |    0    |    1    |
+        | balance only (n=0, c=EMPTY)  |   1    |    0    |    0    |
+        | nonce only  (b=0, c=EMPTY)   |   1    |    1    |    0    |
+        | contract    (c != EMPTY)     |   1    |    1    |    0    |
+        | (not in trie)                |   0    |    0    |    0    |
+
+    The `fully empty` row is where EIP-161 and EIP-684 give
+    OPPOSITE results: EIP-161 says empty (1), EIP-684 says no
+    collision (0). The `balance only` row is where EIP-161 and
+    `account_exists` give opposite results (0 vs 1).
+
+    Composes K201 `header_extract_state_root` + K28
+    `account_at_address` + an inline 9 x u64 check (1 nonce + 4
+    balance + 4 code_hash) against the baked-in EMPTY_CODE_HASH
+    constant.
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp_len
+      a2 (input)  : address ptr (20 bytes)
+      a3 (input)  : witness.state ptr
+      a4 (input)  : witness.state len
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success (`aie_predicate` holds 0 or 1)
+        2 = state-trie mpt parse error
+        3 = account_decode failure
+        4 = header parse / state_root size fail
+
+    Account-not-in-trie maps to predicate 0 (EIP-161 says empty
+    only when account is PRESENT but trivially zero; an absent
+    account is NOT empty per the strict spec read, because
+    `state[addr]` is undefined rather than equal to the empty
+    record). The probe BuildUnit copies `aie_predicate` to
+    OUTPUT + 8.
+-/
+def accountIsEmptyAtHeaderStateRootFunction : String :=
+  "account_is_empty_at_header_state_root:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp)\n" ++
+  "  mv s0, a0                  # header_rlp ptr\n" ++
+  "  mv s1, a1                  # header_rlp_len\n" ++
+  "  mv s2, a2                  # address ptr\n" ++
+  "  mv s3, a3                  # witness.state ptr\n" ++
+  "  mv s4, a4                  # witness.state len\n" ++
+  "  # Pre-zero predicate.\n" ++
+  "  la t0, aie_predicate\n" ++
+  "  sd zero, 0(t0)\n" ++
+  "  # Step 1: header.state_root -> aie_state_root.\n" ++
+  "  mv a0, s0\n" ++
+  "  mv a1, s1\n" ++
+  "  la a2, aie_state_root\n" ++
+  "  jal ra, header_extract_state_root\n" ++
+  "  beqz a0, .Laie_step2\n" ++
+  "  li a0, 4\n" ++
+  "  j .Laie_ret\n" ++
+  ".Laie_step2:\n" ++
+  "  # Step 2: account_at_address.\n" ++
+  "  mv a0, s2\n" ++
+  "  li a1, 20\n" ++
+  "  la a2, aie_state_root\n" ++
+  "  mv a3, s3\n" ++
+  "  mv a4, s4\n" ++
+  "  la s5, aie_acct_struct\n" ++
+  "  mv a5, s5\n" ++
+  "  jal ra, account_at_address\n" ++
+  "  beqz a0, .Laie_check\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Laie_absent\n" ++
+  "  j .Laie_ret\n" ++
+  ".Laie_absent:\n" ++
+  "  # absent -> predicate 0 (already zero).\n" ++
+  "  li a0, 0\n" ++
+  "  j .Laie_ret\n" ++
+  ".Laie_check:\n" ++
+  "  # nonce == 0 ?\n" ++
+  "  ld t1, 0(s5)\n" ++
+  "  bnez t1, .Laie_non_empty\n" ++
+  "  # balance == 0 ?\n" ++
+  "  ld t1,  8(s5); bnez t1, .Laie_non_empty\n" ++
+  "  ld t1, 16(s5); bnez t1, .Laie_non_empty\n" ++
+  "  ld t1, 24(s5); bnez t1, .Laie_non_empty\n" ++
+  "  ld t1, 32(s5); bnez t1, .Laie_non_empty\n" ++
+  "  # code_hash == EMPTY_CODE_HASH ?\n" ++
+  "  la t0, aie_empty_code_hash\n" ++
+  "  ld t1,  0(t0); ld t2, 72(s5); bne t1, t2, .Laie_non_empty\n" ++
+  "  ld t1,  8(t0); ld t2, 80(s5); bne t1, t2, .Laie_non_empty\n" ++
+  "  ld t1, 16(t0); ld t2, 88(s5); bne t1, t2, .Laie_non_empty\n" ++
+  "  ld t1, 24(t0); ld t2, 96(s5); bne t1, t2, .Laie_non_empty\n" ++
+  "  # All three empty-conditions hold; predicate := 1.\n" ++
+  "  la t0, aie_predicate\n" ++
+  "  li t1, 1\n" ++
+  "  sd t1, 0(t0)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Laie_ret\n" ++
+  ".Laie_non_empty:\n" ++
+  "  # Predicate stays 0.\n" ++
+  "  li a0, 0\n" ++
+  ".Laie_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_account_is_empty_at_header_state_root`: probe BuildUnit.
+    Input layout (at INPUT_ADDR):
+      bytes  0.. 8 : (ziskemu metadata)
+      bytes  8..16 : header_rlp_len    (u64 LE)
+      bytes 16..24 : witness_state_len (u64 LE)
+      bytes 24..44 : address (20 bytes)
+      bytes 44..44+H              : header_rlp
+      bytes 44+H..44+H+WS         : witness.state
+    Output layout:
+      bytes  0.. 8 : status (0 / 2 / 3 / 4)
+      bytes  8..16 : predicate (u64; 0 or 1) -/
+def ziskAccountIsEmptyAtHeaderStateRootPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t1, 0x40000000\n" ++
+  "  ld t2, 8(t1)                # header_rlp_len\n" ++
+  "  ld t3, 16(t1)               # witness_state_len\n" ++
+  "  addi a2, t1, 24             # address ptr\n" ++
+  "  addi a0, t1, 44             # header_rlp ptr\n" ++
+  "  mv a1, t2                   # header_rlp_len\n" ++
+  "  add a3, a0, t2              # witness.state ptr\n" ++
+  "  mv a4, t3                   # witness_state_len\n" ++
+  "  jal ra, account_is_empty_at_header_state_root\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  la t1, aie_predicate; ld t2, 0(t1); sd t2, 8(t0)\n" ++
+  "  j .Laie_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  mptLookupByKeyFunction ++ "\n" ++
+  accountDecodeFunction ++ "\n" ++
+  accountAtAddressFunction ++ "\n" ++
+  headerExtractStateRootFunction ++ "\n" ++
+  accountIsEmptyAtHeaderStateRootFunction ++ "\n" ++
+  ".Laie_pdone:"
+
+def ziskAccountIsEmptyAtHeaderStateRootDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mnk_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_dummy_length:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mbc_offset:\n" ++
+  "  .zero 8\n" ++
+  "mbc_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_lookup_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_lookup_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_lookup_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_child_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_nibble_count:\n" ++
+  "  .zero 8\n" ++
+  "mw_is_leaf:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_nibble_buf:\n" ++
+  "  .zero 128\n" ++
+  ".balign 32\n" ++
+  "mlk_keccak_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "mlk_nibble_buf:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "ad_offset:\n" ++
+  "  .zero 8\n" ++
+  "ad_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aa_value_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aa_value_scratch:\n" ++
+  "  .zero 256\n" ++
+  ".balign 8\n" ++
+  "hesr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hesr_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aie_state_root:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "aie_acct_struct:\n" ++
+  "  .zero 104\n" ++
+  ".balign 8\n" ++
+  "aie_predicate:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aie_empty_code_hash:\n" ++
+  "  .byte 0xc5, 0xd2, 0x46, 0x01, 0x86, 0xf7, 0x23, 0x3c\n" ++
+  "  .byte 0x92, 0x7e, 0x7d, 0xb2, 0xdc, 0xc7, 0x03, 0xc0\n" ++
+  "  .byte 0xe5, 0x00, 0xb6, 0x53, 0xca, 0x82, 0x27, 0x3b\n" ++
+  "  .byte 0x7b, 0xfa, 0xd8, 0x04, 0x5d, 0x85, 0xa4, 0x70"
+
+def ziskAccountIsEmptyAtHeaderStateRootProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskAccountIsEmptyAtHeaderStateRootPrologue
+  dataAsm     := ziskAccountIsEmptyAtHeaderStateRootDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **330**
-- ziskemu round-trip scripts: **321** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **331**
+- ziskemu round-trip scripts: **322** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-account-is-empty-at-header-state-root-check.sh
+++ b/scripts/codegen-zisk-account-is-empty-at-header-state-root-check.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# codegen-zisk-account-is-empty-at-header-state-root-check.sh
+#
+# Witness-side EIP-161 account_is_empty predicate. Returns 1 iff
+# the account is present in the state trie AND fully empty
+# (nonce=0, balance=0, code_hash=EMPTY_CODE_HASH).
+#
+# Completes the boolean-predicate trio with:
+#   * account_exists  (presence only; ignores contents)
+#   * has_code_or_nonce  (EIP-684; nonce OR code, no balance)
+#   * account_is_empty   (EIP-161; nonce AND balance AND code all
+#                         zero, present in trie)
+#
+# Spec-distinguishing rows:
+#
+#   | account contents             | exists | EIP-684 | EIP-161 |
+#   |------------------------------|--------|---------|---------|
+#   | fully empty (in trie)        |   1    |    0    |    1    |
+#   | balance only                 |   1    |    0    |    0    |
+#   | nonce only                   |   1    |    1    |    0    |
+#   | contract                     |   1    |    1    |    0    |
+#   | (not in trie)                |   0    |    0    |    0    |
+#
+# Output (16 bytes):
+#   bytes  0.. 8 : status (0 / 2 / 3 / 4)
+#   bytes  8..16 : predicate (u64; 0 or 1)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_account_is_empty_at_header_state_root ELF"
+lake exe codegen --program zisk_account_is_empty_at_header_state_root \
+  --halt linux93 \
+  -o gen-out/zisk_account_is_empty_at_header_state_root
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <mode> [args...]
+#
+#   account <addr> <nonce> <balance> <code_mode>  -- code_mode: empty | contract:<hex>
+#   missing <lookup_addr> <stored_addr>
+#   garbage_header <addr>
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_aie_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_aie_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_aie_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def hp_encode(nibbles, is_leaf):
+    flag = 2 if is_leaf else 0
+    if len(nibbles) % 2 == 1:
+        flag |= 1
+        result = bytes([flag * 0x10 + nibbles[0]])
+        nibbles = nibbles[1:]
+    else:
+        result = bytes([flag * 0x10])
+    for i in range(0, len(nibbles), 2):
+        result += bytes([nibbles[i] * 0x10 + nibbles[i+1]])
+    return result
+
+def leaf_node(path_nibbles, value):
+    return rlp.encode([hp_encode(path_nibbles, True), value])
+
+def bytes_to_nibbles(b):
+    out = []
+    for byte in b:
+        out.append(byte >> 4)
+        out.append(byte & 0xf)
+    return out
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0:
+        return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset)
+        offset += len(e)
+    for e in elements:
+        section += e
+    return section
+
+def encode_account(nonce, balance, storage_root, code_hash):
+    return rlp.encode([nonce, balance, storage_root, code_hash])
+
+def encode_header(state_root):
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x55'*32,
+        b'\\x66'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    return rlp.encode(fields)
+
+EMPTY_TRIE = bytes.fromhex('56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421')
+EMPTY_CODE_HASH = bytes.fromhex('c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')
+
+argv = sys.argv[1:]
+mode = '$mode'
+parts = [
+$(for arg in "$@"; do printf '  %s,\n' "\"$arg\""; done)
+]
+
+def build_state_trie(addr, account_rlp):
+    path = bytes_to_nibbles(k256(addr))
+    leaf = leaf_node(path, account_rlp)
+    return k256(leaf), build_ssz_section([leaf])
+
+def resolve_code_hash(mode):
+    if mode == 'empty':
+        return EMPTY_CODE_HASH
+    if mode.startswith('contract:'):
+        return k256(bytes.fromhex(mode.split(':', 1)[1]))
+    raise SystemExit('bad code_mode: ' + mode)
+
+if mode == 'account':
+    addr = bytes.fromhex(parts[0])
+    nonce = int(parts[1])
+    balance = int(parts[2])
+    code_hash = resolve_code_hash(parts[3])
+    account = encode_account(nonce, balance, EMPTY_TRIE, code_hash)
+    state_root, witness_state = build_state_trie(addr, account)
+    header = encode_header(state_root)
+    # EIP-161 emptiness: nonce==0 AND balance==0 AND code_hash==EMPTY_CODE_HASH.
+    pred = 1 if (nonce == 0 and balance == 0 and code_hash == EMPTY_CODE_HASH) else 0
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', pred)
+elif mode == 'missing':
+    lookup_addr = bytes.fromhex(parts[0])
+    stored_addr = bytes.fromhex(parts[1])
+    account = encode_account(0, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    state_root, witness_state = build_state_trie(stored_addr, account)
+    header = encode_header(state_root)
+    addr = lookup_addr
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', 0)
+elif mode == 'garbage_header':
+    addr = bytes.fromhex(parts[0])
+    witness_state = b''
+    header = b'\\x00'
+    expected = struct.pack('<Q', 4) + struct.pack('<Q', 0)
+else:
+    raise SystemExit('bad mode: ' + mode)
+
+with open(argv[0], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(header))
+        + struct.pack('<Q', len(witness_state))
+        + addr
+        + header
+        + witness_state
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(argv[1], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_account_is_empty_at_header_state_root.elf \
+    -i "$in_file" -o "$out_file" -n 4000000 \
+    >"$REPO_ROOT/gen-out/zisk_aie_${name}.emu.log" 2>&1 || true
+
+  local exp_size; exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-32s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-32s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+ALICE="$(printf 'aa%.0s' $(seq 1 20))"
+BOB="$(printf 'bb%.0s' $(seq 1 20))"
+
+FAILED=0
+# All five distinguishing rows from the table in the function comment:
+# 1) fully empty in trie -> predicate 1 (this row distinguishes from EIP-684).
+run_case "fully_empty_in_trie"            account "$ALICE" 0 0 "empty" || FAILED=1
+# 2) balance only -> predicate 0 (this row distinguishes from account_exists).
+run_case "balance_only"                   account "$ALICE" 0 1000000000000000000 "empty" || FAILED=1
+# 3) nonce only -> predicate 0.
+run_case "nonce_only"                     account "$ALICE" 1 0 "empty" || FAILED=1
+# 4) contract -> predicate 0.
+run_case "contract_nonzero_state"         account "$ALICE" 7 1000 "contract:6000" || FAILED=1
+# Hybrid: nonzero everything -> predicate 0.
+run_case "fully_active"                   account "$ALICE" 42 1000 "contract:6000" || FAILED=1
+# 5) account not in trie -> predicate 0.
+run_case "missing_account"                missing "$BOB" "$ALICE" || FAILED=1
+# Structural failure.
+run_case "garbage_header"                 garbage_header "$ALICE" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: account_is_empty_at_header_state_root (EIP-161) end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `zisk_account_is_empty_at_header_state_root`, the witness-side implementation of the EIP-161 `account_is_empty` predicate. Returns 1 iff the account is **present** in the state trie AND has `nonce == 0` AND `balance == 0` AND `code_hash == EMPTY_CODE_HASH`.
- Completes the boolean-predicate trio with PR #7160 `account_exists` (presence only, contents-ignorant) and PR #7156 `has_code_or_nonce` (EIP-684; nonce OR code, no balance):

| account contents             | exists | EIP-684 | EIP-161 |
|------------------------------|--------|---------|---------|
| fully empty (in trie)        |   1    |    0    |   **1** |
| balance only                 |   1    |    0    |     0   |
| nonce only                   |   1    |    1    |     0   |
| contract                     |   1    |    1    |     0   |
| (not in trie)                |   0    |    0    |     0   |

  The `fully empty` row is the spec-divergence test driving this PR: EIP-161 says empty (1), EIP-684 says no collision (0) — they give **opposite** answers on the same account.

- EIP-161 emptiness is used by SELFDESTRUCT refund accounting, SSTORE refund rules (EIP-2200 / Berlin), and CALL value-transfer "touch" semantics.
- Composes K201 + K28 with an inline 9×u64 check (1 nonce + 4 balance + 4 code_hash) against the baked-in `EMPTY_CODE_HASH`.
- Account-not-in-trie maps to predicate 0 (strict spec read: `state[addr]` is undefined rather than equal to the empty record).
- Appended to `Programs/StatePredicates.lean` alongside `account_exists`.
- No changes to any existing program or fixture — `scripts/codegen-stateless-spec-output-check.sh` still passes byte-for-byte.

## Probe interface

Input layout at `INPUT_ADDR = 0x40000000`:

```
[0..8)   ziskemu metadata (zero)
[8..16)  header_rlp_len    (u64 LE)
[16..24) witness_state_len (u64 LE)
[24..44) address (20 bytes)
[44..44+H)            header_rlp
[44+H..44+H+WS)       witness.state SSZ list
```

Output at `OUTPUT_ADDR = 0xa0010000`:

| range     | meaning |
|-----------|---------|
| `[0..8)`  | status (0 / 2 / 3 / 4) |
| `[8..16)` | predicate (u64; 0 or 1) |

## Test plan
- [x] `lake build codegen` clean
- [x] `scripts/codegen-zisk-account-is-empty-at-header-state-root-check.sh` — 7 fixtures pass, exercising every row of the distinguishing table:
  - **`fully_empty_in_trie` → 1** (EIP-161 distinguishing case vs EIP-684's 0)
  - `balance_only` → 0
  - `nonce_only` → 0
  - `contract_nonzero_state` → 0
  - `fully_active` → 0
  - `missing_account` → 0
  - `garbage_header` → status 4
- [x] `scripts/codegen-stateless-spec-output-check.sh` — integration fixtures still match `run_stateless_guest` byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)