### PR TITLE
feat(stateless): nonce_at_header_state_root — account.nonce u64 getter

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -415,6 +415,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_extcodesize_at_header_state_root" => some ziskExtcodesizeAtHeaderStateRootProbeUnit
   | "zisk_extcodehash_at_header_state_root" => some ziskExtcodehashAtHeaderStateRootProbeUnit
   | "zisk_balance_at_header_state_root" => some ziskBalanceAtHeaderStateRootProbeUnit
+  | "zisk_nonce_at_header_state_root" => some ziskNonceAtHeaderStateRootProbeUnit
   | "zisk_sload_at_header_state_root" => some ziskSloadAtHeaderStateRootProbeUnit
   | "zisk_account_exists_at_header_state_root" => some ziskAccountExistsAtHeaderStateRootProbeUnit
   | "zisk_account_is_empty_at_header_state_root" => some ziskAccountIsEmptyAtHeaderStateRootProbeUnit
@@ -574,6 +575,7 @@ def knownProgramNames : List String :=
    "zisk_extcodesize_at_header_state_root",
    "zisk_extcodehash_at_header_state_root",
    "zisk_balance_at_header_state_root",
+   "zisk_nonce_at_header_state_root",
    "zisk_sload_at_header_state_root",
    "zisk_account_exists_at_header_state_root",
    "zisk_account_is_empty_at_header_state_root",

--- a/EvmAsm/Codegen/Programs/EvmOpcodes.lean
+++ b/EvmAsm/Codegen/Programs/EvmOpcodes.lean
@@ -773,4 +773,215 @@ def ziskSloadAtHeaderStateRootProbeUnit : BuildUnit := {
   dataAsm     := ziskSloadAtHeaderStateRootDataSection
 }
 
+/-! ## nonce_at_header_state_root
+
+    Witness-side getter for `account.nonce` as a u64. Same
+    "absent → 0" flattening as BALANCE and SLOAD. Useful for:
+      * CREATE/CREATE2 address derivation
+        (`keccak(rlp([sender, sender.nonce]))[12:]`)
+      * EIP-684 collision checks (`nonce > 0` arm)
+      * Nonce monotonicity checks on EOAs
+
+    Distinct from `account_at_header_state_root` (which surfaces
+    missing accounts as status 1): NONCE flattens absence to
+    `(status=0, nonce=0)` per the spec's "uninitialised accounts
+    have nonce 0" rule.
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp_len
+      a2 (input)  : address ptr (20 bytes)
+      a3 (input)  : witness.state ptr
+      a4 (input)  : witness.state len
+      a5 (input)  : u64 out ptr
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success (nonce written to output; 0 for absent)
+        2 = state-trie mpt parse error
+        3 = account_decode failure
+        4 = header parse / state_root size fail
+
+      (Code 1 is intentionally absent: missing accounts map to
+      `status=0, nonce=0` per the spec.)
+-/
+def nonceAtHeaderStateRootFunction : String :=
+  "nonce_at_header_state_root:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0                  # header_rlp ptr\n" ++
+  "  mv s1, a1                  # header_rlp_len\n" ++
+  "  mv s2, a2                  # address ptr\n" ++
+  "  mv s3, a3                  # witness.state ptr\n" ++
+  "  mv s4, a4                  # witness.state len\n" ++
+  "  mv s5, a5                  # u64 out ptr\n" ++
+  "  # Pre-zero output -- NONCE default value.\n" ++
+  "  sd zero, 0(s5)\n" ++
+  "  # Step 1: header.state_root -> nonce_state_root.\n" ++
+  "  mv a0, s0\n" ++
+  "  mv a1, s1\n" ++
+  "  la a2, nonce_state_root\n" ++
+  "  jal ra, header_extract_state_root\n" ++
+  "  beqz a0, .Lnonce_step2\n" ++
+  "  li a0, 4\n" ++
+  "  j .Lnonce_ret\n" ++
+  ".Lnonce_step2:\n" ++
+  "  # Step 2: account_at_address -> nonce_acct_struct.\n" ++
+  "  mv a0, s2\n" ++
+  "  li a1, 20\n" ++
+  "  la a2, nonce_state_root\n" ++
+  "  mv a3, s3\n" ++
+  "  mv a4, s4\n" ++
+  "  la s6, nonce_acct_struct\n" ++
+  "  mv a5, s6\n" ++
+  "  jal ra, account_at_address\n" ++
+  "  beqz a0, .Lnonce_copy\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Lnonce_absent\n" ++
+  "  j .Lnonce_ret\n" ++
+  ".Lnonce_absent:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lnonce_ret\n" ++
+  ".Lnonce_copy:\n" ++
+  "  # Copy nonce (struct + 0 .. + 8) to output.\n" ++
+  "  ld t1, 0(s6); sd t1, 0(s5)\n" ++
+  "  li a0, 0\n" ++
+  ".Lnonce_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_nonce_at_header_state_root`: probe BuildUnit.
+
+    Input layout (at INPUT_ADDR):
+      bytes  0.. 8 : (ziskemu metadata)
+      bytes  8..16 : header_rlp_len    (u64 LE)
+      bytes 16..24 : witness_state_len (u64 LE)
+      bytes 24..44 : address (20 bytes)
+      bytes 44..44+H              : header_rlp
+      bytes 44+H..44+H+WS         : witness.state
+    Output layout:
+      bytes  0.. 8 : status (0 / 2 / 3 / 4)
+      bytes  8..16 : nonce (u64 LE; 0 on absent) -/
+def ziskNonceAtHeaderStateRootPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t1, 0x40000000\n" ++
+  "  ld t2, 8(t1)                # header_rlp_len\n" ++
+  "  ld t3, 16(t1)               # witness_state_len\n" ++
+  "  addi a2, t1, 24             # address ptr\n" ++
+  "  addi a0, t1, 44             # header_rlp ptr\n" ++
+  "  mv a1, t2                   # header_rlp_len\n" ++
+  "  add a3, a0, t2              # witness.state ptr\n" ++
+  "  mv a4, t3                   # witness_state_len\n" ++
+  "  li a5, 0xa0010008           # u64 output\n" ++
+  "  jal ra, nonce_at_header_state_root\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lnonce_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  mptLookupByKeyFunction ++ "\n" ++
+  accountDecodeFunction ++ "\n" ++
+  accountAtAddressFunction ++ "\n" ++
+  headerExtractStateRootFunction ++ "\n" ++
+  nonceAtHeaderStateRootFunction ++ "\n" ++
+  ".Lnonce_pdone:"
+
+def ziskNonceAtHeaderStateRootDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mnk_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_dummy_length:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mbc_offset:\n" ++
+  "  .zero 8\n" ++
+  "mbc_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_lookup_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_lookup_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_lookup_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_child_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_nibble_count:\n" ++
+  "  .zero 8\n" ++
+  "mw_is_leaf:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_nibble_buf:\n" ++
+  "  .zero 128\n" ++
+  ".balign 32\n" ++
+  "mlk_keccak_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "mlk_nibble_buf:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "ad_offset:\n" ++
+  "  .zero 8\n" ++
+  "ad_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aa_value_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aa_value_scratch:\n" ++
+  "  .zero 256\n" ++
+  ".balign 8\n" ++
+  "hesr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hesr_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "nonce_state_root:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "nonce_acct_struct:\n" ++
+  "  .zero 104"
+
+def ziskNonceAtHeaderStateRootProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskNonceAtHeaderStateRootPrologue
+  dataAsm     := ziskNonceAtHeaderStateRootDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **331**
-- ziskemu round-trip scripts: **322** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **332**
+- ziskemu round-trip scripts: **323** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-nonce-at-header-state-root-check.sh
+++ b/scripts/codegen-zisk-nonce-at-header-state-root-check.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# codegen-zisk-nonce-at-header-state-root-check.sh
+#
+# Witness-side getter for account.nonce as a u64. Returns 0 for
+# absent accounts (same "absent → 0" flattening as BALANCE / SLOAD).
+#
+# Output (16 bytes):
+#   bytes  0.. 8 : status (0 / 2 / 3 / 4)
+#   bytes  8..16 : nonce (u64 LE; 0 on absent)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_nonce_at_header_state_root ELF"
+lake exe codegen --program zisk_nonce_at_header_state_root \
+  --halt linux93 \
+  -o gen-out/zisk_nonce_at_header_state_root
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_nonce_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_nonce_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_nonce_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def hp_encode(nibbles, is_leaf):
+    flag = 2 if is_leaf else 0
+    if len(nibbles) % 2 == 1:
+        flag |= 1
+        result = bytes([flag * 0x10 + nibbles[0]])
+        nibbles = nibbles[1:]
+    else:
+        result = bytes([flag * 0x10])
+    for i in range(0, len(nibbles), 2):
+        result += bytes([nibbles[i] * 0x10 + nibbles[i+1]])
+    return result
+
+def leaf_node(path_nibbles, value):
+    return rlp.encode([hp_encode(path_nibbles, True), value])
+
+def bytes_to_nibbles(b):
+    out = []
+    for byte in b:
+        out.append(byte >> 4)
+        out.append(byte & 0xf)
+    return out
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0:
+        return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset)
+        offset += len(e)
+    for e in elements:
+        section += e
+    return section
+
+def encode_account(nonce, balance, storage_root, code_hash):
+    return rlp.encode([nonce, balance, storage_root, code_hash])
+
+def encode_header(state_root):
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x55'*32,
+        b'\\x66'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    return rlp.encode(fields)
+
+EMPTY_TRIE = bytes.fromhex('56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421')
+EMPTY_CODE = bytes.fromhex('c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')
+
+argv = sys.argv[1:]
+mode = '$mode'
+parts = [
+$(for arg in "$@"; do printf '  %s,\n' "\"$arg\""; done)
+]
+
+def build_state_trie(addr, account_rlp):
+    path = bytes_to_nibbles(k256(addr))
+    leaf = leaf_node(path, account_rlp)
+    return k256(leaf), build_ssz_section([leaf])
+
+if mode == 'account':
+    addr = bytes.fromhex(parts[0])
+    nonce = int(parts[1])
+    balance = int(parts[2])
+    account = encode_account(nonce, balance, EMPTY_TRIE, EMPTY_CODE)
+    state_root, witness_state = build_state_trie(addr, account)
+    header = encode_header(state_root)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', nonce)
+elif mode == 'missing':
+    lookup_addr = bytes.fromhex(parts[0])
+    stored_addr = bytes.fromhex(parts[1])
+    account = encode_account(42, 0, EMPTY_TRIE, EMPTY_CODE)
+    state_root, witness_state = build_state_trie(stored_addr, account)
+    header = encode_header(state_root)
+    addr = lookup_addr
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', 0)
+elif mode == 'garbage_header':
+    addr = bytes.fromhex(parts[0])
+    witness_state = b''
+    header = b'\\x00'
+    expected = struct.pack('<Q', 4) + struct.pack('<Q', 0)
+else:
+    raise SystemExit('bad mode: ' + mode)
+
+with open(argv[0], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(header))
+        + struct.pack('<Q', len(witness_state))
+        + addr
+        + header
+        + witness_state
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(argv[1], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_nonce_at_header_state_root.elf \
+    -i "$in_file" -o "$out_file" -n 4000000 \
+    >"$REPO_ROOT/gen-out/zisk_nonce_${name}.emu.log" 2>&1 || true
+
+  local exp_size; exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-26s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-26s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+ALICE="$(printf 'aa%.0s' $(seq 1 20))"
+BOB="$(printf 'bb%.0s' $(seq 1 20))"
+
+FAILED=0
+run_case "nonce_zero"           account "$ALICE" 0 0 || FAILED=1
+run_case "nonce_one"            account "$ALICE" 1 0 || FAILED=1
+run_case "nonce_typical"        account "$ALICE" 42 1000000000000000000 || FAILED=1
+run_case "nonce_u64_max"        account "$ALICE" 18446744073709551615 0 || FAILED=1
+# Spec-defining flatten: missing account returns 0 (NOT an error).
+run_case "missing_account"      missing "$BOB" "$ALICE" || FAILED=1
+run_case "garbage_header"       garbage_header "$ALICE" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: nonce_at_header_state_root end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `zisk_nonce_at_header_state_root`, the u64 sibling of PR #7165 BALANCE. Returns `account.nonce` for an address, with "absent → 0" flattening per the spec invariant that uninitialised accounts have nonce 0.
- Composes K201 + K28, then copies the u64 nonce field (struct + 0 .. + 8) to the caller's output.
- Spec uses of `account.nonce`:
  - CREATE / CREATE2 address derivation (`keccak(rlp([sender, sender.nonce]))[12:]`)
  - EIP-684 collision checks (nonce > 0 arm)
  - Nonce monotonicity checks on EOAs
- The "absent → 0" flattening is the spec divergence point: a naive NONCE that errored on missing accounts would diverge from the Python spec.
- Appended to `Programs/EvmOpcodes.lean` alongside BALANCE.
- No changes to any existing program or fixture — `scripts/codegen-stateless-spec-output-check.sh` still passes byte-for-byte.

## Probe interface

Input layout at `INPUT_ADDR = 0x40000000`:

```
[0..8)   ziskemu metadata (zero)
[8..16)  header_rlp_len    (u64 LE)
[16..24) witness_state_len (u64 LE)
[24..44) address (20 bytes)
[44..44+H)            header_rlp
[44+H..44+H+WS)       witness.state SSZ list
```

Output at `OUTPUT_ADDR = 0xa0010000`:

| range     | meaning |
|-----------|---------|
| `[0..8)`  | status (0 / 2 / 3 / 4) |
| `[8..16)` | nonce (u64 LE; 0 on absent) |

Status codes:

| code | meaning |
|------|---------|
| 0 | success (nonce obeys "absent → 0" semantic) |
| 2 | state-trie mpt parse error |
| 3 | account_decode failure |
| 4 | header parse / state_root size fail |

Code 1 is intentionally absent.

## Test plan
- [x] `lake build codegen` clean
- [x] `scripts/codegen-zisk-nonce-at-header-state-root-check.sh` — 6 fixtures pass:
  - `nonce_zero` — nonce = 0 → (0, 0)
  - `nonce_one` — nonce = 1 → (0, 1)
  - `nonce_typical` — nonce = 42 → (0, 42)
  - `nonce_u64_max` — nonce = 2^64 - 1 → (0, max u64)
  - **`missing_account`** — address not in state trie → **(0, 0)** (spec-defining flatten)
  - `garbage_header` → (4, 0)
- [x] `scripts/codegen-stateless-spec-output-check.sh` — integration fixtures still match `run_stateless_guest` byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)