### PR TITLE
feat(stateless): extcodecopy_at_header_state_root — EVM EXTCODECOPY opcode

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -416,6 +416,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_extcodehash_at_header_state_root" => some ziskExtcodehashAtHeaderStateRootProbeUnit
   | "zisk_balance_at_header_state_root" => some ziskBalanceAtHeaderStateRootProbeUnit
   | "zisk_sload_at_header_state_root" => some ziskSloadAtHeaderStateRootProbeUnit
+  | "zisk_extcodecopy_at_header_state_root" => some ziskExtcodecopyAtHeaderStateRootProbeUnit
   | "zisk_account_exists_at_header_state_root" => some ziskAccountExistsAtHeaderStateRootProbeUnit
   | "zisk_account_is_empty_at_header_state_root" => some ziskAccountIsEmptyAtHeaderStateRootProbeUnit
   | "zisk_validate_storage_root_in_witness_storage" => some ziskValidateStorageRootInWitnessStorageProbeUnit
@@ -575,6 +576,7 @@ def knownProgramNames : List String :=
    "zisk_extcodehash_at_header_state_root",
    "zisk_balance_at_header_state_root",
    "zisk_sload_at_header_state_root",
+   "zisk_extcodecopy_at_header_state_root",
    "zisk_account_exists_at_header_state_root",
    "zisk_account_is_empty_at_header_state_root",
    "zisk_validate_storage_root_in_witness_storage",

--- a/EvmAsm/Codegen/Programs/EvmOpcodes.lean
+++ b/EvmAsm/Codegen/Programs/EvmOpcodes.lean
@@ -857,166 +857,6 @@ def nonceAtHeaderStateRootFunction : String :=
 
 /-- `zisk_nonce_at_header_state_root`: probe BuildUnit.
 
-/-! ## extcodecopy_at_header_state_root  (EVM EXTCODECOPY opcode)
-
-    Witness-side implementation of the EVM EXTCODECOPY opcode.
-    Given a parent header RLP, an address, a code offset, a
-    length, an SSZ `witness.state` list, and an SSZ
-    `witness.codes` list, write `length` bytes into a
-    caller-supplied output buffer:
-
-        for i in 0..length:
-          output[i] = code[code_offset + i] if code_offset + i < len(code) else 0
-
-    i.e., reads past the end of the code are zero-padded
-    (NOT truncated, NOT errored). This zero-pad rule is the
-    EXTCODECOPY-specific spec divergence from a naive byte-copy.
-
-    Distinct from PR `code_at_header_state_root` (which returns
-    the full code's offset/length in witness.codes without
-    range-extraction) and from PR `extcodesize_at_header_state_root`
-    (which returns just the length). EXTCODECOPY is the only
-    opcode that actually emits code bytes into EVM memory.
-
-    Composes K201 `header_extract_state_root` + K28
-    `account_at_address` + K19 `witness_lookup_by_hash` + an
-    inline byte-by-byte zero-padded copy loop.
-
-    Calling convention (8 args, fits in a0..a7):
-      a0 (input)  : header_rlp ptr
-      a1 (input)  : header_rlp_len
-      a2 (input)  : address ptr (20 bytes)
-      a3 (input)  : code_offset (u64)
-      a4 (input)  : length (u64; must be <= 256)
-      a5 (input)  : output buffer ptr (`length` bytes)
-      a6 (input)  : witness.state ptr
-      a7 (input)  : witness.state len
-      (precondition: caller pre-set `eccp_codes_ptr` and
-       `eccp_codes_len` in .data scratch.)
-      ra (input)  : return
-
-      a0 (output) :
-        0 = success (output filled, zero-padded as needed)
-        2 = state-trie mpt parse error
-        3 = account_decode failure
-        4 = header parse / state_root size fail
-        5 = code_hash != EMPTY but not in witness.codes
-            (witness integrity violation)
-        6 = length > 256 (probe cap; not a spec issue)
-
-      (Code 1 "account not in trie" is intentionally absent:
-      missing accounts map to `status=0, output=all zeros` per
-      the EXTCODECOPY spec.)
--/
-def extcodecopyAtHeaderStateRootFunction : String :=
-  "extcodecopy_at_header_state_root:\n" ++
-  "  addi sp, sp, -96\n" ++
-  "  sd ra,  0(sp)\n" ++
-  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
-  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
-  "  sd s8, 72(sp); sd s9, 80(sp)\n" ++
-  "  mv s0, a0                  # header_rlp ptr\n" ++
-  "  mv s1, a1                  # header_rlp_len\n" ++
-  "  mv s2, a2                  # address ptr\n" ++
-  "  mv s3, a3                  # code_offset\n" ++
-  "  mv s4, a4                  # length\n" ++
-  "  mv s5, a5                  # output buffer ptr\n" ++
-  "  mv s6, a6                  # witness.state ptr\n" ++
-  "  mv s7, a7                  # witness.state len\n" ++
-  "  # Reject length > 256.\n" ++
-  "  li t0, 256\n" ++
-  "  bgtu s4, t0, .Lecc_too_long\n" ++
-  "  # Pre-zero output[0..length] byte-by-byte (length <= 256).\n" ++
-  "  mv t0, s5\n" ++
-  "  mv t1, s4\n" ++
-  ".Lecc_zero_loop:\n" ++
-  "  beqz t1, .Lecc_zero_done\n" ++
-  "  sb zero, 0(t0)\n" ++
-  "  addi t0, t0, 1\n" ++
-  "  addi t1, t1, -1\n" ++
-  "  j .Lecc_zero_loop\n" ++
-  ".Lecc_zero_done:\n" ++
-  "  # Step 1: header.state_root -> ecc_state_root.\n" ++
-  "  mv a0, s0\n" ++
-  "  mv a1, s1\n" ++
-  "  la a2, ecc_state_root\n" ++
-  "  jal ra, header_extract_state_root\n" ++
-  "  beqz a0, .Lecc_step2\n" ++
-  "  li a0, 4\n" ++
-  "  j .Lecc_ret\n" ++
-  ".Lecc_step2:\n" ++
-  "  # Step 2: account_at_address -> ecc_acct_struct.\n" ++
-  "  mv a0, s2\n" ++
-  "  li a1, 20\n" ++
-  "  la a2, ecc_state_root\n" ++
-  "  mv a3, s6\n" ++
-  "  mv a4, s7\n" ++
-  "  la s8, ecc_acct_struct\n" ++
-  "  mv a5, s8\n" ++
-  "  jal ra, account_at_address\n" ++
-  "  beqz a0, .Lecc_step3\n" ++
-  "  li t0, 1\n" ++
-  "  beq a0, t0, .Lecc_success_zero  # 1 -> output is zeros\n" ++
-  "  j .Lecc_ret                     # 2/3 propagate\n" ++
-  ".Lecc_success_zero:\n" ++
-  "  li a0, 0\n" ++
-  "  j .Lecc_ret\n" ++
-  ".Lecc_step3:\n" ++
-  "  # Check code_hash == EMPTY_CODE_HASH.\n" ++
-  "  la t0, ecc_empty_code_hash\n" ++
-  "  ld t1,  0(t0); ld t2, 72(s8); bne t1, t2, .Lecc_step4\n" ++
-  "  ld t1,  8(t0); ld t2, 80(s8); bne t1, t2, .Lecc_step4\n" ++
-  "  ld t1, 16(t0); ld t2, 88(s8); bne t1, t2, .Lecc_step4\n" ++
-  "  ld t1, 24(t0); ld t2, 96(s8); bne t1, t2, .Lecc_step4\n" ++
-  "  # Empty code; output stays zero, return 0.\n" ++
-  "  li a0, 0\n" ++
-  "  j .Lecc_ret\n" ++
-  ".Lecc_step4:\n" ++
-  "  # Step 4: lookup code in witness.codes.\n" ++
-  "  la t0, eccp_codes_ptr; ld a0, 0(t0)\n" ++
-  "  la t0, eccp_codes_len; ld a1, 0(t0)\n" ++
-  "  addi a2, s8, 72            # &acct.code_hash\n" ++
-  "  la a3, ecc_match_offset\n" ++
-  "  la a4, ecc_match_len\n" ++
-  "  jal ra, witness_lookup_by_hash\n" ++
-  "  beqz a0, .Lecc_step5\n" ++
-  "  li a0, 5                   # integrity violation\n" ++
-  "  j .Lecc_ret\n" ++
-  ".Lecc_step5:\n" ++
-  "  # s9 = code_ptr = codes_ptr + match_offset\n" ++
-  "  la t0, eccp_codes_ptr; ld t1, 0(t0)\n" ++
-  "  la t0, ecc_match_offset; ld t2, 0(t0)\n" ++
-  "  add s9, t1, t2\n" ++
-  "  # code_len in t3\n" ++
-  "  la t0, ecc_match_len; ld t3, 0(t0)\n" ++
-  "  # Byte-by-byte zero-padded copy.\n" ++
-  "  # for i in 0..length: output[i] = code[code_offset+i] if code_offset+i < code_len else 0\n" ++
-  "  li t0, 0                   # i\n" ++
-  ".Lecc_copy_loop:\n" ++
-  "  beq t0, s4, .Lecc_copy_done\n" ++
-  "  add t1, s3, t0             # src_idx = code_offset + i\n" ++
-  "  bgeu t1, t3, .Lecc_pad     # past code end -> already zero\n" ++
-  "  add t2, s9, t1             # code_ptr + src_idx\n" ++
-  "  lbu t4, 0(t2)\n" ++
-  "  add t5, s5, t0\n" ++
-  "  sb t4, 0(t5)\n" ++
-  ".Lecc_pad:\n" ++
-  "  addi t0, t0, 1\n" ++
-  "  j .Lecc_copy_loop\n" ++
-  ".Lecc_copy_done:\n" ++
-  "  li a0, 0\n" ++
-  "  j .Lecc_ret\n" ++
-  ".Lecc_too_long:\n" ++
-  "  li a0, 6\n" ++
-  ".Lecc_ret:\n" ++
-  "  ld ra,  0(sp)\n" ++
-  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
-  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
-  "  ld s8, 72(sp); ld s9, 80(sp)\n" ++
-  "  addi sp, sp, 96\n" ++
-  "  ret"
-
-/-- `zisk_extcodecopy_at_header_state_root`: probe BuildUnit.
     Input layout (at INPUT_ADDR):
       bytes  0.. 8 : (ziskemu metadata)
       bytes  8..16 : header_rlp_len    (u64 LE)
@@ -1042,45 +882,6 @@ def ziskNonceAtHeaderStateRootPrologue : String :=
   "  li t0, 0xa0010000\n" ++
   "  sd a0, 0(t0)\n" ++
   "  j .Lnonce_pdone\n" ++
-      bytes 24..32 : witness_codes_len (u64 LE)
-      bytes 32..40 : code_offset (u64 LE)
-      bytes 40..48 : length (u64 LE; must be <= 256)
-      bytes 48..68 : address (20 bytes)
-      bytes 68..68+H              : header_rlp
-      bytes 68+H..68+H+WS         : witness.state
-      bytes 68+H+WS..             : witness.codes
-    Output layout:
-      bytes  0.. 8 : status (0 / 2 / 3 / 4 / 5 / 6)
-      bytes  8..16 : effective length (= length on success; 0 otherwise)
-      bytes 16..(16+length) : copied code bytes, zero-padded -/
-def ziskExtcodecopyAtHeaderStateRootPrologue : String :=
-  "  li sp, 0xa0050000\n" ++
-  "  li t1, 0x40000000\n" ++
-  "  ld t2,  8(t1)               # header_rlp_len\n" ++
-  "  ld t3, 16(t1)               # witness_state_len\n" ++
-  "  ld t4, 24(t1)               # witness_codes_len\n" ++
-  "  ld a3, 32(t1)               # code_offset\n" ++
-  "  ld a4, 40(t1)               # length\n" ++
-  "  mv s1, a4                   # save length in callee-saved reg\n" ++
-  "  addi a2, t1, 48             # address ptr\n" ++
-  "  addi a0, t1, 68             # header_rlp ptr\n" ++
-  "  mv a1, t2                   # header_rlp_len\n" ++
-  "  add a6, a0, t2              # witness.state ptr\n" ++
-  "  mv a7, t3                   # witness.state len\n" ++
-  "  add t5, a6, t3              # witness.codes ptr\n" ++
-  "  la t0, eccp_codes_ptr; sd t5, 0(t0)\n" ++
-  "  la t0, eccp_codes_len; sd t4, 0(t0)\n" ++
-  "  li a5, 0xa0010010           # output buffer at OUTPUT + 16\n" ++
-  "  jal ra, extcodecopy_at_header_state_root\n" ++
-  "  li t0, 0xa0010000\n" ++
-  "  sd a0, 0(t0)                # status\n" ++
-  "  # Write effective length = length on success, else 0.\n" ++
-  "  bnez a0, .Lecc_no_len\n" ++
-  "  sd s1, 8(t0)                # success: use saved length\n" ++
-  "  j .Lecc_pdone\n" ++
-  ".Lecc_no_len:\n" ++
-  "  sd zero, 8(t0)\n" ++
-  "  j .Lecc_pdone\n" ++
   zkvmKeccak256Function ++ "\n" ++
   witnessLookupByHashFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
@@ -1097,10 +898,6 @@ def ziskExtcodecopyAtHeaderStateRootPrologue : String :=
   ".Lnonce_pdone:"
 
 def ziskNonceAtHeaderStateRootDataSection : String :=
-  extcodecopyAtHeaderStateRootFunction ++ "\n" ++
-  ".Lecc_pdone:"
-
-def ziskExtcodecopyAtHeaderStateRootDataSection : String :=
   ".section .data\n" ++
   ".balign 32\n" ++
   "zk3_state:\n" ++
@@ -1185,6 +982,128 @@ def ziskNonceAtHeaderStateRootProbeUnit : BuildUnit := {
   body        := NOP
   prologueAsm := ziskNonceAtHeaderStateRootPrologue
   dataAsm     := ziskNonceAtHeaderStateRootDataSection
+}
+
+end EvmAsm.Codegen
+
+def ziskExtcodecopyAtHeaderStateRootPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t1, 0x40000000\n" ++
+  "  ld t2,  8(t1)               # header_rlp_len\n" ++
+  "  ld t3, 16(t1)               # witness_state_len\n" ++
+  "  ld t4, 24(t1)               # witness_codes_len\n" ++
+  "  ld a3, 32(t1)               # code_offset\n" ++
+  "  ld a4, 40(t1)               # length\n" ++
+  "  mv s1, a4                   # save length in callee-saved reg\n" ++
+  "  addi a2, t1, 48             # address ptr\n" ++
+  "  addi a0, t1, 68             # header_rlp ptr\n" ++
+  "  mv a1, t2                   # header_rlp_len\n" ++
+  "  add a6, a0, t2              # witness.state ptr\n" ++
+  "  mv a7, t3                   # witness.state len\n" ++
+  "  add t5, a6, t3              # witness.codes ptr\n" ++
+  "  la t0, eccp_codes_ptr; sd t5, 0(t0)\n" ++
+  "  la t0, eccp_codes_len; sd t4, 0(t0)\n" ++
+  "  li a5, 0xa0010010           # output buffer at OUTPUT + 16\n" ++
+  "  jal ra, extcodecopy_at_header_state_root\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  # Write effective length = length on success, else 0.\n" ++
+  "  bnez a0, .Lecc_no_len\n" ++
+  "  sd s1, 8(t0)                # success: use saved length\n" ++
+  "  j .Lecc_pdone\n" ++
+  ".Lecc_no_len:\n" ++
+  "  sd zero, 8(t0)\n" ++
+  "  j .Lecc_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  mptLookupByKeyFunction ++ "\n" ++
+  accountDecodeFunction ++ "\n" ++
+  accountAtAddressFunction ++ "\n" ++
+  headerExtractStateRootFunction ++ "\n" ++
+  extcodecopyAtHeaderStateRootFunction ++ "\n" ++
+  ".Lecc_pdone:"
+
+def ziskExtcodecopyAtHeaderStateRootDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mnk_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_dummy_length:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mbc_offset:\n" ++
+  "  .zero 8\n" ++
+  "mbc_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_lookup_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_lookup_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_lookup_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_child_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_nibble_count:\n" ++
+  "  .zero 8\n" ++
+  "mw_is_leaf:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_nibble_buf:\n" ++
+  "  .zero 128\n" ++
+  ".balign 32\n" ++
+  "mlk_keccak_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "mlk_nibble_buf:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "ad_offset:\n" ++
+  "  .zero 8\n" ++
+  "ad_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aa_value_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aa_value_scratch:\n" ++
+  "  .zero 256\n" ++
+  ".balign 8\n" ++
+  "hesr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hesr_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
   "ecc_state_root:\n" ++
   "  .zero 32\n" ++
   ".balign 8\n" ++

--- a/EvmAsm/Codegen/Programs/EvmOpcodes.lean
+++ b/EvmAsm/Codegen/Programs/EvmOpcodes.lean
@@ -984,8 +984,6 @@ def ziskNonceAtHeaderStateRootProbeUnit : BuildUnit := {
   dataAsm     := ziskNonceAtHeaderStateRootDataSection
 }
 
-end EvmAsm.Codegen
-
 def ziskExtcodecopyAtHeaderStateRootPrologue : String :=
   "  li sp, 0xa0050000\n" ++
   "  li t1, 0x40000000\n" ++

--- a/EvmAsm/Codegen/Programs/EvmOpcodes.lean
+++ b/EvmAsm/Codegen/Programs/EvmOpcodes.lean
@@ -984,6 +984,181 @@ def ziskNonceAtHeaderStateRootProbeUnit : BuildUnit := {
   dataAsm     := ziskNonceAtHeaderStateRootDataSection
 }
 
+/-! ## extcodecopy_at_header_state_root  (EVM EXTCODECOPY opcode)
+
+    Witness-side implementation of the EVM EXTCODECOPY opcode.
+    Given a parent header RLP, an address, a code offset, a
+    length, an SSZ `witness.state` list, and an SSZ
+    `witness.codes` list, write `length` bytes into a
+    caller-supplied output buffer:
+
+        for i in 0..length:
+          output[i] = code[code_offset + i] if code_offset + i < len(code) else 0
+
+    i.e., reads past the end of the code are zero-padded
+    (NOT truncated, NOT errored). This zero-pad rule is the
+    EXTCODECOPY-specific spec divergence from a naive byte-copy.
+
+    Distinct from PR `code_at_header_state_root` (which returns
+    the full code's offset/length in witness.codes without
+    range-extraction) and from PR `extcodesize_at_header_state_root`
+    (which returns just the length). EXTCODECOPY is the only
+    opcode that actually emits code bytes into EVM memory.
+
+    Composes K201 `header_extract_state_root` + K28
+    `account_at_address` + K19 `witness_lookup_by_hash` + an
+    inline byte-by-byte zero-padded copy loop.
+
+    Calling convention (8 args, fits in a0..a7):
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp_len
+      a2 (input)  : address ptr (20 bytes)
+      a3 (input)  : code_offset (u64)
+      a4 (input)  : length (u64; must be <= 256)
+      a5 (input)  : output buffer ptr (`length` bytes)
+      a6 (input)  : witness.state ptr
+      a7 (input)  : witness.state len
+      (precondition: caller pre-set `eccp_codes_ptr` and
+       `eccp_codes_len` in .data scratch.)
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success (output filled, zero-padded as needed)
+        2 = state-trie mpt parse error
+        3 = account_decode failure
+        4 = header parse / state_root size fail
+        5 = code_hash != EMPTY but not in witness.codes
+            (witness integrity violation)
+        6 = length > 256 (probe cap; not a spec issue)
+
+      (Code 1 "account not in trie" is intentionally absent:
+      missing accounts map to `status=0, output=all zeros` per
+      the EXTCODECOPY spec.)
+-/
+def extcodecopyAtHeaderStateRootFunction : String :=
+  "extcodecopy_at_header_state_root:\n" ++
+  "  addi sp, sp, -96\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp)\n" ++
+  "  mv s0, a0                  # header_rlp ptr\n" ++
+  "  mv s1, a1                  # header_rlp_len\n" ++
+  "  mv s2, a2                  # address ptr\n" ++
+  "  mv s3, a3                  # code_offset\n" ++
+  "  mv s4, a4                  # length\n" ++
+  "  mv s5, a5                  # output buffer ptr\n" ++
+  "  mv s6, a6                  # witness.state ptr\n" ++
+  "  mv s7, a7                  # witness.state len\n" ++
+  "  # Reject length > 256.\n" ++
+  "  li t0, 256\n" ++
+  "  bgtu s4, t0, .Lecc_too_long\n" ++
+  "  # Pre-zero output[0..length] byte-by-byte (length <= 256).\n" ++
+  "  mv t0, s5\n" ++
+  "  mv t1, s4\n" ++
+  ".Lecc_zero_loop:\n" ++
+  "  beqz t1, .Lecc_zero_done\n" ++
+  "  sb zero, 0(t0)\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lecc_zero_loop\n" ++
+  ".Lecc_zero_done:\n" ++
+  "  # Step 1: header.state_root -> ecc_state_root.\n" ++
+  "  mv a0, s0\n" ++
+  "  mv a1, s1\n" ++
+  "  la a2, ecc_state_root\n" ++
+  "  jal ra, header_extract_state_root\n" ++
+  "  beqz a0, .Lecc_step2\n" ++
+  "  li a0, 4\n" ++
+  "  j .Lecc_ret\n" ++
+  ".Lecc_step2:\n" ++
+  "  # Step 2: account_at_address -> ecc_acct_struct.\n" ++
+  "  mv a0, s2\n" ++
+  "  li a1, 20\n" ++
+  "  la a2, ecc_state_root\n" ++
+  "  mv a3, s6\n" ++
+  "  mv a4, s7\n" ++
+  "  la s8, ecc_acct_struct\n" ++
+  "  mv a5, s8\n" ++
+  "  jal ra, account_at_address\n" ++
+  "  beqz a0, .Lecc_step3\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Lecc_success_zero  # 1 -> output is zeros\n" ++
+  "  j .Lecc_ret                     # 2/3 propagate\n" ++
+  ".Lecc_success_zero:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lecc_ret\n" ++
+  ".Lecc_step3:\n" ++
+  "  # Check code_hash == EMPTY_CODE_HASH.\n" ++
+  "  la t0, ecc_empty_code_hash\n" ++
+  "  ld t1,  0(t0); ld t2, 72(s8); bne t1, t2, .Lecc_step4\n" ++
+  "  ld t1,  8(t0); ld t2, 80(s8); bne t1, t2, .Lecc_step4\n" ++
+  "  ld t1, 16(t0); ld t2, 88(s8); bne t1, t2, .Lecc_step4\n" ++
+  "  ld t1, 24(t0); ld t2, 96(s8); bne t1, t2, .Lecc_step4\n" ++
+  "  # Empty code; output stays zero, return 0.\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lecc_ret\n" ++
+  ".Lecc_step4:\n" ++
+  "  # Step 4: lookup code in witness.codes.\n" ++
+  "  la t0, eccp_codes_ptr; ld a0, 0(t0)\n" ++
+  "  la t0, eccp_codes_len; ld a1, 0(t0)\n" ++
+  "  addi a2, s8, 72            # &acct.code_hash\n" ++
+  "  la a3, ecc_match_offset\n" ++
+  "  la a4, ecc_match_len\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  beqz a0, .Lecc_step5\n" ++
+  "  li a0, 5                   # integrity violation\n" ++
+  "  j .Lecc_ret\n" ++
+  ".Lecc_step5:\n" ++
+  "  # s9 = code_ptr = codes_ptr + match_offset\n" ++
+  "  la t0, eccp_codes_ptr; ld t1, 0(t0)\n" ++
+  "  la t0, ecc_match_offset; ld t2, 0(t0)\n" ++
+  "  add s9, t1, t2\n" ++
+  "  # code_len in t3\n" ++
+  "  la t0, ecc_match_len; ld t3, 0(t0)\n" ++
+  "  # Byte-by-byte zero-padded copy.\n" ++
+  "  # for i in 0..length: output[i] = code[code_offset+i] if code_offset+i < code_len else 0\n" ++
+  "  li t0, 0                   # i\n" ++
+  ".Lecc_copy_loop:\n" ++
+  "  beq t0, s4, .Lecc_copy_done\n" ++
+  "  add t1, s3, t0             # src_idx = code_offset + i\n" ++
+  "  bgeu t1, t3, .Lecc_pad     # past code end -> already zero\n" ++
+  "  add t2, s9, t1             # code_ptr + src_idx\n" ++
+  "  lbu t4, 0(t2)\n" ++
+  "  add t5, s5, t0\n" ++
+  "  sb t4, 0(t5)\n" ++
+  ".Lecc_pad:\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  j .Lecc_copy_loop\n" ++
+  ".Lecc_copy_done:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lecc_ret\n" ++
+  ".Lecc_too_long:\n" ++
+  "  li a0, 6\n" ++
+  ".Lecc_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp)\n" ++
+  "  addi sp, sp, 96\n" ++
+  "  ret"
+
+/-- `zisk_extcodecopy_at_header_state_root`: probe BuildUnit.
+    Input layout (at INPUT_ADDR):
+      bytes  0.. 8 : (ziskemu metadata)
+      bytes  8..16 : header_rlp_len    (u64 LE)
+      bytes 16..24 : witness_state_len (u64 LE)
+      bytes 24..32 : witness_codes_len (u64 LE)
+      bytes 32..40 : code_offset (u64 LE)
+      bytes 40..48 : length (u64 LE; must be <= 256)
+      bytes 48..68 : address (20 bytes)
+      bytes 68..68+H              : header_rlp
+      bytes 68+H..68+H+WS         : witness.state
+      bytes 68+H+WS..             : witness.codes
+    Output layout:
+      bytes  0.. 8 : status (0 / 2 / 3 / 4 / 5 / 6)
+      bytes  8..16 : effective length (= length on success; 0 otherwise)
+      bytes 16..(16+length) : copied code bytes, zero-padded -/
 def ziskExtcodecopyAtHeaderStateRootPrologue : String :=
   "  li sp, 0xa0050000\n" ++
   "  li t1, 0x40000000\n" ++

--- a/EvmAsm/Codegen/Programs/EvmOpcodes.lean
+++ b/EvmAsm/Codegen/Programs/EvmOpcodes.lean
@@ -773,4 +773,324 @@ def ziskSloadAtHeaderStateRootProbeUnit : BuildUnit := {
   dataAsm     := ziskSloadAtHeaderStateRootDataSection
 }
 
+/-! ## extcodecopy_at_header_state_root  (EVM EXTCODECOPY opcode)
+
+    Witness-side implementation of the EVM EXTCODECOPY opcode.
+    Given a parent header RLP, an address, a code offset, a
+    length, an SSZ `witness.state` list, and an SSZ
+    `witness.codes` list, write `length` bytes into a
+    caller-supplied output buffer:
+
+        for i in 0..length:
+          output[i] = code[code_offset + i] if code_offset + i < len(code) else 0
+
+    i.e., reads past the end of the code are zero-padded
+    (NOT truncated, NOT errored). This zero-pad rule is the
+    EXTCODECOPY-specific spec divergence from a naive byte-copy.
+
+    Distinct from PR `code_at_header_state_root` (which returns
+    the full code's offset/length in witness.codes without
+    range-extraction) and from PR `extcodesize_at_header_state_root`
+    (which returns just the length). EXTCODECOPY is the only
+    opcode that actually emits code bytes into EVM memory.
+
+    Composes K201 `header_extract_state_root` + K28
+    `account_at_address` + K19 `witness_lookup_by_hash` + an
+    inline byte-by-byte zero-padded copy loop.
+
+    Calling convention (8 args, fits in a0..a7):
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp_len
+      a2 (input)  : address ptr (20 bytes)
+      a3 (input)  : code_offset (u64)
+      a4 (input)  : length (u64; must be <= 256)
+      a5 (input)  : output buffer ptr (`length` bytes)
+      a6 (input)  : witness.state ptr
+      a7 (input)  : witness.state len
+      (precondition: caller pre-set `eccp_codes_ptr` and
+       `eccp_codes_len` in .data scratch.)
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success (output filled, zero-padded as needed)
+        2 = state-trie mpt parse error
+        3 = account_decode failure
+        4 = header parse / state_root size fail
+        5 = code_hash != EMPTY but not in witness.codes
+            (witness integrity violation)
+        6 = length > 256 (probe cap; not a spec issue)
+
+      (Code 1 "account not in trie" is intentionally absent:
+      missing accounts map to `status=0, output=all zeros` per
+      the EXTCODECOPY spec.)
+-/
+def extcodecopyAtHeaderStateRootFunction : String :=
+  "extcodecopy_at_header_state_root:\n" ++
+  "  addi sp, sp, -96\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp)\n" ++
+  "  mv s0, a0                  # header_rlp ptr\n" ++
+  "  mv s1, a1                  # header_rlp_len\n" ++
+  "  mv s2, a2                  # address ptr\n" ++
+  "  mv s3, a3                  # code_offset\n" ++
+  "  mv s4, a4                  # length\n" ++
+  "  mv s5, a5                  # output buffer ptr\n" ++
+  "  mv s6, a6                  # witness.state ptr\n" ++
+  "  mv s7, a7                  # witness.state len\n" ++
+  "  # Reject length > 256.\n" ++
+  "  li t0, 256\n" ++
+  "  bgtu s4, t0, .Lecc_too_long\n" ++
+  "  # Pre-zero output[0..length] byte-by-byte (length <= 256).\n" ++
+  "  mv t0, s5\n" ++
+  "  mv t1, s4\n" ++
+  ".Lecc_zero_loop:\n" ++
+  "  beqz t1, .Lecc_zero_done\n" ++
+  "  sb zero, 0(t0)\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lecc_zero_loop\n" ++
+  ".Lecc_zero_done:\n" ++
+  "  # Step 1: header.state_root -> ecc_state_root.\n" ++
+  "  mv a0, s0\n" ++
+  "  mv a1, s1\n" ++
+  "  la a2, ecc_state_root\n" ++
+  "  jal ra, header_extract_state_root\n" ++
+  "  beqz a0, .Lecc_step2\n" ++
+  "  li a0, 4\n" ++
+  "  j .Lecc_ret\n" ++
+  ".Lecc_step2:\n" ++
+  "  # Step 2: account_at_address -> ecc_acct_struct.\n" ++
+  "  mv a0, s2\n" ++
+  "  li a1, 20\n" ++
+  "  la a2, ecc_state_root\n" ++
+  "  mv a3, s6\n" ++
+  "  mv a4, s7\n" ++
+  "  la s8, ecc_acct_struct\n" ++
+  "  mv a5, s8\n" ++
+  "  jal ra, account_at_address\n" ++
+  "  beqz a0, .Lecc_step3\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Lecc_success_zero  # 1 -> output is zeros\n" ++
+  "  j .Lecc_ret                     # 2/3 propagate\n" ++
+  ".Lecc_success_zero:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lecc_ret\n" ++
+  ".Lecc_step3:\n" ++
+  "  # Check code_hash == EMPTY_CODE_HASH.\n" ++
+  "  la t0, ecc_empty_code_hash\n" ++
+  "  ld t1,  0(t0); ld t2, 72(s8); bne t1, t2, .Lecc_step4\n" ++
+  "  ld t1,  8(t0); ld t2, 80(s8); bne t1, t2, .Lecc_step4\n" ++
+  "  ld t1, 16(t0); ld t2, 88(s8); bne t1, t2, .Lecc_step4\n" ++
+  "  ld t1, 24(t0); ld t2, 96(s8); bne t1, t2, .Lecc_step4\n" ++
+  "  # Empty code; output stays zero, return 0.\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lecc_ret\n" ++
+  ".Lecc_step4:\n" ++
+  "  # Step 4: lookup code in witness.codes.\n" ++
+  "  la t0, eccp_codes_ptr; ld a0, 0(t0)\n" ++
+  "  la t0, eccp_codes_len; ld a1, 0(t0)\n" ++
+  "  addi a2, s8, 72            # &acct.code_hash\n" ++
+  "  la a3, ecc_match_offset\n" ++
+  "  la a4, ecc_match_len\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  beqz a0, .Lecc_step5\n" ++
+  "  li a0, 5                   # integrity violation\n" ++
+  "  j .Lecc_ret\n" ++
+  ".Lecc_step5:\n" ++
+  "  # s9 = code_ptr = codes_ptr + match_offset\n" ++
+  "  la t0, eccp_codes_ptr; ld t1, 0(t0)\n" ++
+  "  la t0, ecc_match_offset; ld t2, 0(t0)\n" ++
+  "  add s9, t1, t2\n" ++
+  "  # code_len in t3\n" ++
+  "  la t0, ecc_match_len; ld t3, 0(t0)\n" ++
+  "  # Byte-by-byte zero-padded copy.\n" ++
+  "  # for i in 0..length: output[i] = code[code_offset+i] if code_offset+i < code_len else 0\n" ++
+  "  li t0, 0                   # i\n" ++
+  ".Lecc_copy_loop:\n" ++
+  "  beq t0, s4, .Lecc_copy_done\n" ++
+  "  add t1, s3, t0             # src_idx = code_offset + i\n" ++
+  "  bgeu t1, t3, .Lecc_pad     # past code end -> already zero\n" ++
+  "  add t2, s9, t1             # code_ptr + src_idx\n" ++
+  "  lbu t4, 0(t2)\n" ++
+  "  add t5, s5, t0\n" ++
+  "  sb t4, 0(t5)\n" ++
+  ".Lecc_pad:\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  j .Lecc_copy_loop\n" ++
+  ".Lecc_copy_done:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lecc_ret\n" ++
+  ".Lecc_too_long:\n" ++
+  "  li a0, 6\n" ++
+  ".Lecc_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp)\n" ++
+  "  addi sp, sp, 96\n" ++
+  "  ret"
+
+/-- `zisk_extcodecopy_at_header_state_root`: probe BuildUnit.
+    Input layout (at INPUT_ADDR):
+      bytes  0.. 8 : (ziskemu metadata)
+      bytes  8..16 : header_rlp_len    (u64 LE)
+      bytes 16..24 : witness_state_len (u64 LE)
+      bytes 24..32 : witness_codes_len (u64 LE)
+      bytes 32..40 : code_offset (u64 LE)
+      bytes 40..48 : length (u64 LE; must be <= 256)
+      bytes 48..68 : address (20 bytes)
+      bytes 68..68+H              : header_rlp
+      bytes 68+H..68+H+WS         : witness.state
+      bytes 68+H+WS..             : witness.codes
+    Output layout:
+      bytes  0.. 8 : status (0 / 2 / 3 / 4 / 5 / 6)
+      bytes  8..16 : effective length (= length on success; 0 otherwise)
+      bytes 16..(16+length) : copied code bytes, zero-padded -/
+def ziskExtcodecopyAtHeaderStateRootPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t1, 0x40000000\n" ++
+  "  ld t2,  8(t1)               # header_rlp_len\n" ++
+  "  ld t3, 16(t1)               # witness_state_len\n" ++
+  "  ld t4, 24(t1)               # witness_codes_len\n" ++
+  "  ld a3, 32(t1)               # code_offset\n" ++
+  "  ld a4, 40(t1)               # length\n" ++
+  "  mv s1, a4                   # save length in callee-saved reg\n" ++
+  "  addi a2, t1, 48             # address ptr\n" ++
+  "  addi a0, t1, 68             # header_rlp ptr\n" ++
+  "  mv a1, t2                   # header_rlp_len\n" ++
+  "  add a6, a0, t2              # witness.state ptr\n" ++
+  "  mv a7, t3                   # witness.state len\n" ++
+  "  add t5, a6, t3              # witness.codes ptr\n" ++
+  "  la t0, eccp_codes_ptr; sd t5, 0(t0)\n" ++
+  "  la t0, eccp_codes_len; sd t4, 0(t0)\n" ++
+  "  li a5, 0xa0010010           # output buffer at OUTPUT + 16\n" ++
+  "  jal ra, extcodecopy_at_header_state_root\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  # Write effective length = length on success, else 0.\n" ++
+  "  bnez a0, .Lecc_no_len\n" ++
+  "  sd s1, 8(t0)                # success: use saved length\n" ++
+  "  j .Lecc_pdone\n" ++
+  ".Lecc_no_len:\n" ++
+  "  sd zero, 8(t0)\n" ++
+  "  j .Lecc_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  mptLookupByKeyFunction ++ "\n" ++
+  accountDecodeFunction ++ "\n" ++
+  accountAtAddressFunction ++ "\n" ++
+  headerExtractStateRootFunction ++ "\n" ++
+  extcodecopyAtHeaderStateRootFunction ++ "\n" ++
+  ".Lecc_pdone:"
+
+def ziskExtcodecopyAtHeaderStateRootDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mnk_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_dummy_length:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mbc_offset:\n" ++
+  "  .zero 8\n" ++
+  "mbc_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_lookup_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_lookup_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_lookup_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_child_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_nibble_count:\n" ++
+  "  .zero 8\n" ++
+  "mw_is_leaf:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_nibble_buf:\n" ++
+  "  .zero 128\n" ++
+  ".balign 32\n" ++
+  "mlk_keccak_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "mlk_nibble_buf:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "ad_offset:\n" ++
+  "  .zero 8\n" ++
+  "ad_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aa_value_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aa_value_scratch:\n" ++
+  "  .zero 256\n" ++
+  ".balign 8\n" ++
+  "hesr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hesr_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "ecc_state_root:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "ecc_acct_struct:\n" ++
+  "  .zero 104\n" ++
+  ".balign 8\n" ++
+  "eccp_codes_ptr:\n" ++
+  "  .zero 8\n" ++
+  "eccp_codes_len:\n" ++
+  "  .zero 8\n" ++
+  "ecc_match_offset:\n" ++
+  "  .zero 8\n" ++
+  "ecc_match_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "ecc_empty_code_hash:\n" ++
+  "  .byte 0xc5, 0xd2, 0x46, 0x01, 0x86, 0xf7, 0x23, 0x3c\n" ++
+  "  .byte 0x92, 0x7e, 0x7d, 0xb2, 0xdc, 0xc7, 0x03, 0xc0\n" ++
+  "  .byte 0xe5, 0x00, 0xb6, 0x53, 0xca, 0x82, 0x27, 0x3b\n" ++
+  "  .byte 0x7b, 0xfa, 0xd8, 0x04, 0x5d, 0x85, 0xa4, 0x70"
+
+def ziskExtcodecopyAtHeaderStateRootProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskExtcodecopyAtHeaderStateRootPrologue
+  dataAsm     := ziskExtcodecopyAtHeaderStateRootDataSection
+}
+
 end EvmAsm.Codegen

--- a/scripts/codegen-zisk-extcodecopy-at-header-state-root-check.sh
+++ b/scripts/codegen-zisk-extcodecopy-at-header-state-root-check.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# codegen-zisk-extcodecopy-at-header-state-root-check.sh
+#
+# Witness-side EVM EXTCODECOPY opcode. Copies `length` bytes of
+# contract code into an output buffer, with the spec-mandated
+# zero-padding behavior when reads extend past the end of code.
+#
+# Composes K201 + K28 + K19 + a byte-by-byte zero-padded copy.
+#
+# Output (16 + length bytes; length capped at 256):
+#   bytes  0.. 8 : status
+#       0 success (output filled, zero-padded if needed)
+#       2 state-trie mpt parse error
+#       3 account_decode failure
+#       4 header parse fail
+#       5 code_hash != EMPTY but not in witness.codes
+#       6 length > 256 (probe cap)
+#   bytes  8..16 : effective length
+#   bytes 16..(16+length) : code bytes
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_extcodecopy_at_header_state_root ELF"
+lake exe codegen --program zisk_extcodecopy_at_header_state_root \
+  --halt linux93 \
+  -o gen-out/zisk_extcodecopy_at_header_state_root
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <mode> [args...]
+#
+#   contract <addr> <code_hex> <code_offset> <length>
+#     Account with non-trivial code; expect (0, length, expected_bytes).
+#
+#   empty_code <addr> <length>
+#     code_hash == EMPTY_CODE_HASH; expect (0, length, all zeros).
+#
+#   missing_account <lookup_addr> <stored_addr> <code_hex> <length>
+#     Account not at lookup_addr; expect (0, length, all zeros).
+#
+#   integrity_violation <addr> <code_hex> <length>
+#     account.code_hash claims code, but witness.codes is empty.
+#     Expect (5, 0, all zeros).
+#
+#   garbage_header <addr> <length>  -> (4, 0, all zeros)
+#
+#   over_cap <addr> <code_hex>  -> (6, 0, ...) [length=257]
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_ecc_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_ecc_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_ecc_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def hp_encode(nibbles, is_leaf):
+    flag = 2 if is_leaf else 0
+    if len(nibbles) % 2 == 1:
+        flag |= 1
+        result = bytes([flag * 0x10 + nibbles[0]])
+        nibbles = nibbles[1:]
+    else:
+        result = bytes([flag * 0x10])
+    for i in range(0, len(nibbles), 2):
+        result += bytes([nibbles[i] * 0x10 + nibbles[i+1]])
+    return result
+
+def leaf_node(path_nibbles, value):
+    return rlp.encode([hp_encode(path_nibbles, True), value])
+
+def bytes_to_nibbles(b):
+    out = []
+    for byte in b:
+        out.append(byte >> 4)
+        out.append(byte & 0xf)
+    return out
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0:
+        return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset)
+        offset += len(e)
+    for e in elements:
+        section += e
+    return section
+
+def encode_account(nonce, balance, storage_root, code_hash):
+    return rlp.encode([nonce, balance, storage_root, code_hash])
+
+def encode_header(state_root):
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x55'*32,
+        b'\\x66'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    return rlp.encode(fields)
+
+EMPTY_TRIE = bytes.fromhex('56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421')
+EMPTY_CODE_HASH = bytes.fromhex('c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')
+
+argv = sys.argv[1:]
+mode = '$mode'
+parts = [
+$(for arg in "$@"; do printf '  %s,\n' "\"$arg\""; done)
+]
+
+def build_state_with_account(addr, account_rlp):
+    path = bytes_to_nibbles(k256(addr))
+    leaf = leaf_node(path, account_rlp)
+    return k256(leaf), build_ssz_section([leaf])
+
+def extcodecopy_spec(code, offset, length):
+    out = bytearray(length)
+    for i in range(length):
+        src = offset + i
+        if src < len(code):
+            out[i] = code[src]
+    return bytes(out)
+
+if mode == 'contract':
+    addr = bytes.fromhex(parts[0])
+    code = bytes.fromhex(parts[1])
+    code_offset = int(parts[2])
+    length = int(parts[3])
+    code_hash = k256(code)
+    account = encode_account(0, 0, EMPTY_TRIE, code_hash)
+    state_root, witness_state = build_state_with_account(addr, account)
+    witness_codes = build_ssz_section([code])
+    header = encode_header(state_root)
+    spec_bytes = extcodecopy_spec(code, code_offset, length)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', length) + spec_bytes
+elif mode == 'empty_code':
+    addr = bytes.fromhex(parts[0])
+    length = int(parts[1])
+    code_offset = 0
+    account = encode_account(0, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    state_root, witness_state = build_state_with_account(addr, account)
+    witness_codes = b''
+    header = encode_header(state_root)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', length) + b'\\x00' * length
+elif mode == 'missing_account':
+    lookup_addr = bytes.fromhex(parts[0])
+    stored_addr = bytes.fromhex(parts[1])
+    code = bytes.fromhex(parts[2])
+    length = int(parts[3])
+    code_offset = 0
+    code_hash = k256(code)
+    account = encode_account(0, 0, EMPTY_TRIE, code_hash)
+    state_root, witness_state = build_state_with_account(stored_addr, account)
+    witness_codes = build_ssz_section([code])
+    addr = lookup_addr
+    header = encode_header(state_root)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', length) + b'\\x00' * length
+elif mode == 'integrity_violation':
+    addr = bytes.fromhex(parts[0])
+    code = bytes.fromhex(parts[1])
+    length = int(parts[2])
+    code_offset = 0
+    code_hash = k256(code)
+    account = encode_account(0, 0, EMPTY_TRIE, code_hash)
+    state_root, witness_state = build_state_with_account(addr, account)
+    witness_codes = b''
+    header = encode_header(state_root)
+    expected = struct.pack('<Q', 5) + struct.pack('<Q', 0) + b'\\x00' * length
+elif mode == 'garbage_header':
+    addr = bytes.fromhex(parts[0])
+    length = int(parts[1])
+    code_offset = 0
+    witness_state = b''
+    witness_codes = b''
+    header = b'\\x00'
+    expected = struct.pack('<Q', 4) + struct.pack('<Q', 0) + b'\\x00' * length
+elif mode == 'over_cap':
+    addr = bytes.fromhex(parts[0])
+    code = bytes.fromhex(parts[1])
+    code_offset = 0
+    length = 257
+    code_hash = k256(code)
+    account = encode_account(0, 0, EMPTY_TRIE, code_hash)
+    state_root, witness_state = build_state_with_account(addr, account)
+    witness_codes = build_ssz_section([code])
+    header = encode_header(state_root)
+    # status 6 + zero length; bytes section reads up to 0 effective length
+    expected = struct.pack('<Q', 6) + struct.pack('<Q', 0)
+else:
+    raise SystemExit('bad mode: ' + mode)
+
+with open(argv[0], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(header))
+        + struct.pack('<Q', len(witness_state))
+        + struct.pack('<Q', len(witness_codes))
+        + struct.pack('<Q', code_offset)
+        + struct.pack('<Q', length)
+        + addr
+        + header
+        + witness_state
+        + witness_codes
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(argv[1], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_extcodecopy_at_header_state_root.elf \
+    -i "$in_file" -o "$out_file" -n 4000000 \
+    >"$REPO_ROOT/gen-out/zisk_ecc_${name}.emu.log" 2>&1 || true
+
+  local exp_size; exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-30s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-30s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+ALICE="$(printf 'aa%.0s' $(seq 1 20))"
+BOB="$(printf 'bb%.0s' $(seq 1 20))"
+
+FAILED=0
+# Full code (10 bytes), copy all 10 with offset 0.
+run_case "full_code_offset_0"    contract "$ALICE" "60006000016000526000" 0 10 || FAILED=1
+# Tail of the code (offset 6, length 4).
+run_case "tail_of_code"          contract "$ALICE" "60006000016000526000" 6 4 || FAILED=1
+# THE spec-defining case: read past the end with zero padding.
+# code is 4 bytes long; offset=0, length=8 -> 4 bytes of code + 4 bytes of zero.
+run_case "zero_pad_past_end"     contract "$ALICE" "deadbeef" 0 8 || FAILED=1
+# Offset beyond code length -> all zeros.
+run_case "offset_past_end"       contract "$ALICE" "deadbeef" 10 4 || FAILED=1
+# Offset at end -> all zeros.
+run_case "offset_exactly_at_end" contract "$ALICE" "deadbeef" 4 3 || FAILED=1
+# Zero length -> empty output, status 0.
+run_case "zero_length"           contract "$ALICE" "deadbeef" 0 0 || FAILED=1
+# Empty code (EMPTY_CODE_HASH).
+run_case "empty_code_hash"       empty_code "$ALICE" 8 || FAILED=1
+# Missing account.
+run_case "missing_account"       missing_account "$BOB" "$ALICE" "6000" 4 || FAILED=1
+# Integrity violation.
+run_case "integrity_violation"   integrity_violation "$ALICE" "6000" 4 || FAILED=1
+# Garbage header.
+run_case "garbage_header"        garbage_header "$ALICE" 4 || FAILED=1
+# Length > 256 cap.
+run_case "over_cap"              over_cap "$ALICE" "6000" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: extcodecopy_at_header_state_root end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `zisk_extcodecopy_at_header_state_root`, the witness-side implementation of the EVM `EXTCODECOPY` opcode. Composes K201 + K28 + K19 + an inline byte-by-byte zero-padded copy.
- Spec semantic that drives this PR:

  ```
  for i in 0..length:
    output[i] = code[code_offset + i] if code_offset + i < len(code) else 0
  ```

  Reads past the end of the code are **zero-padded**, not truncated, not errored. This is the EXTCODECOPY-specific spec divergence from a naive byte-copy — the test `zero_pad_past_end` (offset=0, length=8 over a 4-byte code) initially fails for any naive implementation.

- Distinct from:
  - PR #7146 `code_at_header_state_root` — returns full code's offset/length without range-extraction.
  - PR #7153 `extcodesize_at_header_state_root` — returns just the length.
  
  EXTCODECOPY is the only opcode that actually emits code bytes into the EVM frame.

- Length capped at 256 (probe-side; not a spec limit) via new status code 6.
- No changes to any existing program or fixture — `scripts/codegen-stateless-spec-output-check.sh` still passes byte-for-byte.

## Probe interface

Input layout at `INPUT_ADDR = 0x40000000`:

```
[0..8)   ziskemu metadata (zero)
[8..16)  header_rlp_len    (u64 LE)
[16..24) witness_state_len (u64 LE)
[24..32) witness_codes_len (u64 LE)
[32..40) code_offset       (u64 LE)
[40..48) length            (u64 LE; <= 256)
[48..68) address (20 bytes)
[68..68+H)          header_rlp
[68+H..68+H+WS)     witness.state SSZ list
[68+H+WS..)         witness.codes SSZ list
```

Output at `OUTPUT_ADDR = 0xa0010000`:

| range            | meaning |
|------------------|---------|
| `[0..8)`         | status (0 / 2 / 3 / 4 / 5 / 6) |
| `[8..16)`        | effective length (= length on success; 0 otherwise) |
| `[16..16+length)`| copied code bytes, zero-padded |

Status codes:

| code | meaning |
|------|---------|
| 0 | success (output filled, zero-padded as needed) |
| 2 | state-trie mpt parse error |
| 3 | account_decode failure |
| 4 | header parse / state_root size fail |
| 5 | code_hash != EMPTY but not in witness.codes (integrity violation) |
| 6 | length > 256 (probe cap; not a spec issue) |

Code 1 is intentionally absent — missing accounts map to `status=0, output=all zeros`.

## Test plan
- [x] `lake build codegen` clean
- [x] `scripts/codegen-zisk-extcodecopy-at-header-state-root-check.sh` — 11 fixtures pass:
  - `full_code_offset_0` — offset=0, length=full → exact code
  - `tail_of_code` — partial offset+length → tail slice
  - **`zero_pad_past_end`** — offset=0, length=8 over 4-byte code → **4 code bytes + 4 zero padding** (the spec-defining case)
  - `offset_past_end` — offset beyond code → all zeros
  - `offset_exactly_at_end` — offset == code_len → all zeros
  - `zero_length` — length=0 → empty output (status 0)
  - `empty_code_hash` → all zeros (status 0)
  - `missing_account` → all zeros (status 0)
  - `integrity_violation` → status 5
  - `garbage_header` → status 4
  - `over_cap` (length=257) → status 6
- [x] `scripts/codegen-stateless-spec-output-check.sh` — integration fixtures still match `run_stateless_guest` byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)