### PR TITLE
docs: document pure-to-emp bridge proof workaround

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,25 @@ When adding or modifying proofs:
   3. Breaking up large `have`s into separate lemmas so the core composition step has fewer atoms to permute.
 - **When DivMod postconditions explode under `xperm` or kernel `whnf`:** fold the postcondition before trying harder tactics. Put the final register/memory assertion spine behind a small `@[irreducible]` helper such as `...PostCore`, parameterized by the final values that the branch proof should expose. If the public post has a deep body let-chain, add a second folded helper such as `...PostFromBody` that takes already-computed intermediates; the public `...Post` should compute the lets and delegate to the helper. In branch bridge proofs, use `change` to refold the expanded target to the helper with local names, simplify only the relevant `if_pos`/`if_neg`, then unfold only the small core immediately before `xperm_hyp`. Split repeated bridge obligations into named lemmas for fresh heartbeat budgets. Use `lean_goal` at the failing line to confirm the target is folded; if it prints a huge `BitVec.toNat 32` or nested-let/nested-if term, fold first instead of running `xperm` on the expanded goal.
 - **When extracting framed pure facts in bridge posts:** inspect the shape with `lean_goal` before repeatedly applying `drop_pure` or `extract_pure`. Framed pures may remain behind an extra `sepConj` layer, so remove one layer at a time with small local rewrites (`rw [sepConj_assoc']`, `simp only [sepConj_pure_mid_left]`) and `obtain` the pure fact you need. Broad `simp` or blind repeated extraction can expand the folded post again or destruct useful `sepConj` structure.
+- **When `extract_pure`, `drop_pure`, or `xperm_pure` struggle on a folded framed post:** avoid broad pure-extraction tactics on the whole post if they expand the folded helper, trigger kernel `whnf`, leave `xperm` atom-count mismatches, or report an expected-type/free-variable error. First extract only the outer pure fact you need, then rewrite the specific remaining pure assertion to `empAssertion` with a local extensional proof and simplify the emp frame before calling `xperm_hyp`. Shape:
+
+  ```lean
+  extract_pure hp
+  obtain ⟨hp, h_pure⟩ := hp
+  rw [show (⌜P⌝ : Assertion) = empAssertion by
+    funext h
+    unfold EvmAsm.Rv64.pure EvmAsm.Rv64.empAssertion
+    apply propext
+    constructor
+    · intro h_p
+      exact h_p.1
+    · intro h_empty
+      exact ⟨h_empty, h_pure⟩] at hp
+  simp only [the relevant sepConj_emp lemma] at hp
+  xperm_hyp hp
+  ```
+
+  Keep `EvmAsm.Rv64.pure` qualified in the unfold so Lean does not choose an unrelated `pure`, and keep the target folded until the final local rewrite. Tracking issue: https://github.com/Verified-zkEVM/evm-asm/issues/7174.
 - **Exception for Shift composition files**: `set_option maxHeartbeats` up to 6400000 is acceptable for body/path composition proofs (Section 4+) which are bottlenecked by `xperm_hyp` permutation on large atom chains. Subsumption lemmas (Section 2) should NOT need heartbeat overrides — they use structural `unionAll` reasoning.
 
 - **All memory accesses must be aligned.** The verified RV64 operational semantics in `EvmAsm/Rv64/Basic.lean` defines `isValidDwordAccess = isValidMemAddr && isAligned8` and `isValidMemAccess = isValidMemAddr && isAligned4` — i.e. an `LD`/`SD` has no semantics unless its address is a multiple of 8, and `LW`/`LWU`/`SW` likewise need a multiple of 4. Per-width requirements:


### PR DESCRIPTION
## Summary
- document the pure-to-emp workaround for folded framed bridge posts
- call out the failure modes seen with extract_pure, drop_pure, and xperm_pure
- link the tracking issue for tactic improvements

## Verification
- docs-only change; no Lean build run for this branch

Refs https://github.com/Verified-zkEVM/evm-asm/issues/7174

Authored by @pirapira; implemented by Codex.