### PR TITLE
feat(div): add v5 shared DIV/MOD code surfaces for div128_v5_spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose.lean
+++ b/EvmAsm/Evm64/DivMod/Compose.lean
@@ -21,6 +21,7 @@
 import EvmAsm.Evm64.DivMod.Compose.Div128
 import EvmAsm.Evm64.DivMod.Compose.Div128V4
 import EvmAsm.Evm64.DivMod.Compose.V4Code
+import EvmAsm.Evm64.DivMod.Compose.V5Code
 import EvmAsm.Evm64.DivMod.Compose.FullPath
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2

--- a/EvmAsm/Evm64/DivMod/Compose/V5Code.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/V5Code.lean
@@ -1,0 +1,84 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.V5Code
+
+  Shared DIV/MOD code surfaces for the v5 div128 migration.
+
+  Mirror of the v5-relevant shared surfaces from
+  `EvmAsm.Evm64.DivMod.Compose.Base` (`sharedDivModCode_v4`) and
+  `EvmAsm.Evm64.DivMod.Compose.V4NoNop` (`sharedDivModCodeNoNop_v4`),
+  swapping in `divK_div128_v5` — the capped Knuth Algorithm D variant that
+  repairs v4's two buggy ULTs by clamping `q1c`/`q0c` at `2^32 - 1`.
+
+  These surfaces are the code requirements for the shared variants of
+  `div128_v5_spec` (`div128_v5_spec_shared` / `div128_v5_spec_shared_noNop`).
+  Kept in a dedicated file rather than appended to `Base.lean`, which is at
+  its size cap. See bead evm-asm-wbc4i.6 (V5.6 val256 lift).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.Base
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v5 mirror of `sharedDivModCode_v4` — uses `divK_div128_v5` at block 12.
+    Blocks 0-11 are identical to `sharedDivModCode_v4`; only block 12 swaps
+    in the longer `divK_div128_v5` program. -/
+abbrev sharedDivModCode_v5 (base : Word) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg  base                  (divK_phaseA 1020),     -- block 0
+    CodeReq.ofProg (base + phaseBOff)     divK_phaseB,            -- block 1
+    CodeReq.ofProg (base + clzOff)        divK_clz,               -- block 2
+    CodeReq.ofProg (base + phaseC2Off)    (divK_phaseC2 172),     -- block 3
+    CodeReq.ofProg (base + normBOff)      divK_normB,             -- block 4
+    CodeReq.ofProg (base + normAOff)      (divK_normA 40),        -- block 5
+    CodeReq.ofProg (base + copyAUOff)     divK_copyAU,            -- block 6
+    CodeReq.ofProg (base + loopSetupOff)  (divK_loopSetup 464),   -- block 7
+    CodeReq.ofProg (base + loopBodyOff)   (divK_loopBody 560 7736),-- block 8
+    CodeReq.ofProg (base + denormOff)     divK_denorm,            -- block 9
+    CodeReq.ofProg (base + zeroPathOff)   divK_zeroPath,          -- block 10
+    CodeReq.ofProg (base + nopOff)        (ADDI .x0 .x0 0),       -- block 11
+    CodeReq.ofProg (base + div128Off)     divK_div128_v5          -- block 12 (v5)
+  ]
+
+/-- v5 mirror of `shared_b12_div128_v4_sub`: block 12 (`divK_div128_v5`)
+    is included in `sharedDivModCode_v5 base`. Used by `div128_v5_spec_shared`
+    to lift `div128_v5_spec` from singleton-`ofProg` cr to shared cr. -/
+theorem shared_b12_div128_v5_sub {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + div128Off) divK_div128_v5) a = some i →
+           (sharedDivModCode_v5 b) a = some i := by
+  unfold sharedDivModCode_v5; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+
+/-- v5 mirror of `sharedDivModCodeNoNop_v4`: shared DIV/MOD blocks with the
+    NOP return slot omitted and the final block using `divK_div128_v5`. -/
+abbrev sharedDivModCodeNoNop_v5 (base : Word) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg  base                  (divK_phaseA 1020),
+    CodeReq.ofProg (base + phaseBOff)     divK_phaseB,
+    CodeReq.ofProg (base + clzOff)        divK_clz,
+    CodeReq.ofProg (base + phaseC2Off)    (divK_phaseC2 172),
+    CodeReq.ofProg (base + normBOff)      divK_normB,
+    CodeReq.ofProg (base + normAOff)      (divK_normA 40),
+    CodeReq.ofProg (base + copyAUOff)     divK_copyAU,
+    CodeReq.ofProg (base + loopSetupOff)  (divK_loopSetup 464),
+    CodeReq.ofProg (base + loopBodyOff)   (divK_loopBody 560 7736),
+    CodeReq.ofProg (base + denormOff)     divK_denorm,
+    CodeReq.ofProg (base + zeroPathOff)   divK_zeroPath,
+    CodeReq.ofProg (base + div128Off)     divK_div128_v5
+  ]
+
+/-- v5 div128 block is included in `sharedDivModCodeNoNop_v5 base`. -/
+theorem sharedNoNop_b11_div128_v5_sub {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + div128Off) divK_div128_v5) a = some i →
+           (sharedDivModCodeNoNop_v5 b) a = some i := by
+  unfold sharedDivModCodeNoNop_v5; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `sharedDivModCode_v5` and `sharedDivModCodeNoNop_v5` — mirrors of the v4 shared DIV/MOD code surfaces, swapping in `divK_div128_v5` (the capped Knuth Algorithm D variant) at block 12.
- Add their div128 block-subsumption lemmas `shared_b12_div128_v5_sub` and `sharedNoNop_b11_div128_v5_sub`.
- New file `Compose/V5Code.lean` (Base.lean is at its 1200-line cap); registered in the `Compose` umbrella.

These are the code requirements for the upcoming shared variants of `div128_v5_spec` (`div128_v5_spec_shared` / `_shared_noNop`), the first mergeable slice toward the V5.6 val256 lift. Mechanical mirrors; depends only on `divK_div128_v5` (already on main).

Verification: `lake build EvmAsm.Evm64.DivMod.Compose.V5Code`; `scripts/check-file-size.sh`; `scripts/check-unimported.sh`; full `lake build` (2466 jobs) — all green. No sorry/admit/native_decide/maxHeartbeats.

Refs #61. Bead: evm-asm-wbc4i.6.13.

Authored by @pirapira; implemented by Claude Code