### PR TITLE
feat(div): discharge v5 trial-quotient frontier + val256 +2 composition

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -64,6 +64,7 @@ import EvmAsm.Evm64.EvmWordArith.DivN2NormVStructure
 import EvmAsm.Evm64.EvmWordArith.DivBltBridge
 import EvmAsm.Evm64.EvmWordArith.DivBltBridgeSpecializations
 import EvmAsm.Evm64.EvmWordArith.DivV4TrialOverestimate
+import EvmAsm.Evm64.EvmWordArith.DivV5TrialOverestimate
 import EvmAsm.Evm64.EvmWordArith.DivV4TrialFromExactQuotient
 import EvmAsm.Evm64.EvmWordArith.DivV4TrialVal256Composition
 import EvmAsm.Evm64.EvmWordArith.DivKnuthAEqualWindow

--- a/EvmAsm/Evm64/EvmWordArith/DivV5TrialOverestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivV5TrialOverestimate.lean
@@ -23,6 +23,7 @@
 
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.UpperBound
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.LowerBound
+import EvmAsm.Evm64.EvmWordArith.DivV4TrialVal256Composition
 
 namespace EvmAsm.Evm64
 
@@ -74,5 +75,39 @@ theorem divKTrialCallV5QHat_ge_floor
       (divKTrialCallV5QHat uHi uLo vTop).toNat := by
   rw [divKTrialCallV5QHat_eq_div128Quot_v5]
   exact div128Quot_v5_ge_q_true uHi uLo vTop hvTop_ge huHi_lt_vTop
+
+/-- **v5 val256 composition** (mirror of `divKTrialCallV4QHat_le_val256_div_plus_two`):
+    from the v5 frontier `+1` bound and the version-agnostic Knuth Theorem A
+    top-window bridge `Knuth128_64TopWindowLeVal256DivPlusOne`, derive the
+    val256-level `+2` overestimate consumed by the BLT-path bridges
+    (`loopBodyN{2,3}CallAddbackCarry2Nz*_of_overestimate_c3`).
+
+    The `Knuth128_64TopWindowLeVal256DivPlusOne` bridge is version-agnostic
+    (a pure floor-division fact), so it is reused directly from the v4 file. -/
+theorem divKTrialCallV5QHat_le_val256_div_plus_two
+    (uHi uLo vTop : Word) (v0 v1 v2 v3 u0 u1 u2 u3 : Word)
+    (h_v5 : DivKTrialCallV5QHatLeFloorPlusOne uHi uLo vTop)
+    (h_knuth : Knuth128_64TopWindowLeVal256DivPlusOne uHi uLo vTop
+      v0 v1 v2 v3 u0 u1 u2 u3) :
+    (divKTrialCallV5QHat uHi uLo vTop).toNat ≤
+      val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2 := by
+  unfold DivKTrialCallV5QHatLeFloorPlusOne at h_v5
+  unfold Knuth128_64TopWindowLeVal256DivPlusOne at h_knuth
+  omega
+
+/-- The val256 `+2` overestimate discharged under the call regime +
+    normalisation (the v5 frontier is unconditional), leaving only the
+    version-agnostic Knuth top-window bridge as a hypothesis. -/
+theorem divKTrialCallV5QHat_le_val256_div_plus_two_of_norm
+    (uHi uLo vTop : Word) (v0 v1 v2 v3 u0 u1 u2 u3 : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat)
+    (h_knuth : Knuth128_64TopWindowLeVal256DivPlusOne uHi uLo vTop
+      v0 v1 v2 v3 u0 u1 u2 u3) :
+    (divKTrialCallV5QHat uHi uLo vTop).toNat ≤
+      val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2 :=
+  divKTrialCallV5QHat_le_val256_div_plus_two uHi uLo vTop v0 v1 v2 v3 u0 u1 u2 u3
+    (DivKTrialCallV5QHatLeFloorPlusOne_of_norm uHi uLo vTop hvTop_ge huHi_lt_vTop)
+    h_knuth
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/DivV5TrialOverestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivV5TrialOverestimate.lean
@@ -24,6 +24,7 @@
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.UpperBound
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.LowerBound
 import EvmAsm.Evm64.EvmWordArith.DivV4TrialVal256Composition
+import EvmAsm.Evm64.EvmWordArith.DivKnuthATopWindowFits
 
 namespace EvmAsm.Evm64
 
@@ -109,5 +110,31 @@ theorem divKTrialCallV5QHat_le_val256_div_plus_two_of_norm
   divKTrialCallV5QHat_le_val256_div_plus_two uHi uLo vTop v0 v1 v2 v3 u0 u1 u2 u3
     (DivKTrialCallV5QHatLeFloorPlusOne_of_norm uHi uLo vTop hvTop_ge huHi_lt_vTop)
     h_knuth
+
+/-- **End-to-end v5 `+2` val256 overestimate** under purely structural
+    conditions — the v5 analog of
+    `divKTrialCallV4QHat_le_val256_div_plus_two_of_exact_and_top_window_fits_v_eq_vTop`,
+    but STRICTLY WEAKER PREMISES: the v4 version needs `h_exact`
+    (`divKTrialCallV4QHat = exact floor`, hard to establish); the v5 version
+    needs only normalisation (`vTop ≥ 2^63`, `uHi < vTop`) because the v5
+    frontier is unconditional. The remaining conditions
+    (`val256(v) = vTop`, top-window-fits-`val256(u)`) are the version-agnostic
+    Knuth-A structural conditions, discharged by
+    `Knuth128_64TopWindowLeVal256DivPlusOne_of_top_window_fits_val256_and_v_eq_vTop`.
+
+    This is the val256 overestimate consumed by the BLT-path
+    `loopBodyN{2,3}CallAddbackCarry2Nz*_of_overestimate_c3` bridges. -/
+theorem divKTrialCallV5QHat_le_val256_div_plus_two_of_norm_and_top_window_fits_v_eq_vTop
+    (uHi uLo vTop : Word) (v0 v1 v2 v3 u0 u1 u2 u3 : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat)
+    (h_v_eq : val256 v0 v1 v2 v3 = vTop.toNat)
+    (h_u_fits : (uHi.toNat * 2^64 + uLo.toNat) * 2^128 ≤ val256 u0 u1 u2 u3) :
+    (divKTrialCallV5QHat uHi uLo vTop).toNat ≤
+      val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2 :=
+  divKTrialCallV5QHat_le_val256_div_plus_two_of_norm uHi uLo vTop
+    v0 v1 v2 v3 u0 u1 u2 u3 hvTop_ge huHi_lt_vTop
+    (Knuth128_64TopWindowLeVal256DivPlusOne_of_top_window_fits_val256_and_v_eq_vTop
+      uHi uLo vTop v0 v1 v2 v3 u0 u1 u2 u3 h_v_eq h_u_fits)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/DivV5TrialOverestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivV5TrialOverestimate.lean
@@ -1,0 +1,78 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.DivV5TrialOverestimate
+
+  v5 analog of `DivV4TrialOverestimate` — but DISCHARGED, not just named.
+
+  The v4 frontier `DivKTrialCallV4QHatLeFloorPlusOne` (bead `9iqmw.7.1.4.1`)
+  was the open obstruction gating `evm_div_stack_spec_unconditional`:
+    `divKTrialCallV4QHat uHi uLo vTop ≤ (uHi·2^64 + uLo)/vTop + 1`
+  under the call regime + normalisation. Under v4 it is FALSE in general
+  (PR #7080's `+2` counterexample), which is precisely why bead `7.1.4.1`
+  was impossible.
+
+  Under v5 the capped Knuth-D quotient `div128Quot_v5` satisfies this bound
+  unconditionally (V5.4.5, `div128Quot_v5_le_q_true_plus_one`), and
+  `divKTrialCallV5QHat = div128Quot_v5`
+  (`divKTrialCallV5QHat_eq_div128Quot_v5`). So the v5 frontier discharges
+  directly. This is the core payoff of the V5 repair: the obstruction that
+  was impossible under v4 holds under v5. The companion lower bound
+  (`≥ floor`, from V5.5.3) is included for the BLT-path bridges.
+
+  Bead `evm-asm-wbc4i.4.7`.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.UpperBound
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.LowerBound
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- The v5 call-trial Knuth-A `+1` upper bound at `(uHi, uLo, vTop)`, the v5
+    analog of `DivKTrialCallV4QHatLeFloorPlusOne`. Mirror predicate so
+    downstream beads/PRs have a single attackable (now discharged) target. -/
+def DivKTrialCallV5QHatLeFloorPlusOne (uHi uLo vTop : Word) : Prop :=
+  (divKTrialCallV5QHat uHi uLo vTop).toNat ≤
+    (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat + 1
+
+theorem DivKTrialCallV5QHatLeFloorPlusOne_unfold (uHi uLo vTop : Word) :
+    DivKTrialCallV5QHatLeFloorPlusOne uHi uLo vTop ↔
+      (divKTrialCallV5QHat uHi uLo vTop).toNat ≤
+        (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat + 1 :=
+  Iff.rfl
+
+/-- **The V5 payoff** (v5 analog of the impossible v4 bead `7.1.4.1`):
+    `divKTrialCallV5QHat ≤ (uHi·2^64 + uLo)/vTop + 1` discharged
+    unconditionally from V5.4.5, under just the call regime
+    (`uHi < vTop`) + normalisation (`vTop ≥ 2^63`). -/
+theorem divKTrialCallV5QHat_le_floor_plus_one
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat) :
+    (divKTrialCallV5QHat uHi uLo vTop).toNat ≤
+      (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat + 1 := by
+  rw [divKTrialCallV5QHat_eq_div128Quot_v5]
+  exact div128Quot_v5_le_q_true_plus_one uHi uLo vTop hvTop_ge huHi_lt_vTop
+
+/-- Named-predicate form of `divKTrialCallV5QHat_le_floor_plus_one`. -/
+theorem DivKTrialCallV5QHatLeFloorPlusOne_of_norm
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat) :
+    DivKTrialCallV5QHatLeFloorPlusOne uHi uLo vTop :=
+  divKTrialCallV5QHat_le_floor_plus_one uHi uLo vTop hvTop_ge huHi_lt_vTop
+
+/-- Companion lower bound (from V5.5.3): `(uHi·2^64+uLo)/vTop ≤
+    divKTrialCallV5QHat`. Together with the `+1` upper bound this pins the
+    v5 trial quotient to within 1 of the floor — the input to the BLT-path
+    `Carry2Nz` bridges. -/
+theorem divKTrialCallV5QHat_ge_floor
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat) :
+    (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat ≤
+      (divKTrialCallV5QHat uHi uLo vTop).toNat := by
+  rw [divKTrialCallV5QHat_eq_div128Quot_v5]
+  exact div128Quot_v5_ge_q_true uHi uLo vTop hvTop_ge huHi_lt_vTop
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Prove **`divKTrialCallV5QHat_le_floor_plus_one`**: the v5 analog of the open v4 frontier `DivKTrialCallV4QHatLeFloorPlusOne` (bead `9iqmw.7.1.4.1`) that gated `evm_div_stack_spec_unconditional` and was **FALSE under v4** (PR #7080's `+2` counterexample).
- Under v5 it discharges directly: `divKTrialCallV5QHat = div128Quot_v5` + V5.4.5 (`div128Quot_v5_le_q_true_plus_one`), under just the call regime (`uHi < vTop`) + normalisation (`vTop ≥ 2⁶³`).
- Companion lower bound `divKTrialCallV5QHat_ge_floor` (V5.5.3). Named-predicate form `DivKTrialCallV5QHatLeFloorPlusOne(_of_norm)`. New file `DivV5TrialOverestimate.lean` (mirrors the v4 frontier file, but **discharged** not just named).

This is the **core payoff of the V5 repair**: the trial-overestimate obstruction that was impossible under v4 holds unconditionally under v5. It is the frontier whose val256 composition yields the n4 dispatcher's `hq_over` premise.

No sorry; `lean_verify` = standard axioms only. Full build green (2470 jobs); gates pass. Depends only on V5.4.5/V5.5.3 (already on main).

Refs #61. Bead: evm-asm-wbc4i.4.7.

Authored by @pirapira; implemented by Claude Code