### PR TITLE
feat(divmod): V5 trial-call-path specs over v5 div128 code

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/V5Code.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/V5Code.lean
@@ -81,4 +81,50 @@ theorem sharedNoNop_b11_div128_v5_sub {b : Word} :
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left
 
+/-- v5 mirror of `divK_loopBody_ofProg_sub_sharedCode_v4`: the loopBody ofProg
+    (block 8) is subsumed by `sharedDivModCode_v5`. -/
+private theorem divK_loopBody_ofProg_sub_sharedCode_v5 {base : Word} :
+    ∀ a i, (CodeReq.ofProg (base + loopBodyOff) (divK_loopBody 560 7736)) a = some i →
+      (sharedDivModCode_v5 base) a = some i := by
+  unfold sharedDivModCode_v5; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+
+/-- v5 mirror of `lb_sub_v4`: singleton at index k of `divK_loopBody` is
+    subsumed by `sharedDivModCode_v5 base`. -/
+theorem lb_sub_v5 {base : Word} (k : Nat) (addr : Word) (instr : Instr)
+    (hk : k < (divK_loopBody 560 7736).length)
+    (h_addr : addr = (base + loopBodyOff) + BitVec.ofNat 64 (4 * k))
+    (h_instr : (divK_loopBody 560 7736).get ⟨k, hk⟩ = instr) :
+    ∀ a i, CodeReq.singleton addr instr a = some i →
+      (sharedDivModCode_v5 base) a = some i := by
+  subst h_addr; subst h_instr
+  exact fun a i h => divK_loopBody_ofProg_sub_sharedCode_v5 a i
+    (CodeReq.singleton_mono
+      (CodeReq.ofProg_lookup (base + loopBodyOff) (divK_loopBody 560 7736) k hk (by decide)) a i h)
+
+/-- v5 mirror of `divK_loopBody_ofProg_sub_sharedCodeNoNop_v4`: the loopBody
+    ofProg (block 8) is subsumed by `sharedDivModCodeNoNop_v5`. -/
+private theorem divK_loopBody_ofProg_sub_sharedCodeNoNop_v5 {base : Word} :
+    ∀ a i, (CodeReq.ofProg (base + loopBodyOff) (divK_loopBody 560 7736)) a = some i →
+      (sharedDivModCodeNoNop_v5 base) a = some i := by
+  unfold sharedDivModCodeNoNop_v5; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+
+/-- v5 mirror of `lb_sub_noNop_v4`: singleton at index k of `divK_loopBody` is
+    subsumed by `sharedDivModCodeNoNop_v5 base`. -/
+theorem lb_sub_noNop_v5 {base : Word} (k : Nat) (addr : Word) (instr : Instr)
+    (hk : k < (divK_loopBody 560 7736).length)
+    (h_addr : addr = (base + loopBodyOff) + BitVec.ofNat 64 (4 * k))
+    (h_instr : (divK_loopBody 560 7736).get ⟨k, hk⟩ = instr) :
+    ∀ a i, CodeReq.singleton addr instr a = some i →
+      (sharedDivModCodeNoNop_v5 base) a = some i := by
+  subst h_addr; subst h_instr
+  exact fun a i h => divK_loopBody_ofProg_sub_sharedCodeNoNop_v5 a i
+    (CodeReq.singleton_mono
+      (CodeReq.ofProg_lookup (base + loopBodyOff) (divK_loopBody 560 7736) k hk (by decide)) a i h)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialCallPath.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialCallPath.lean
@@ -18,6 +18,7 @@
 import EvmAsm.Evm64.DivMod.LoopBody
 import EvmAsm.Evm64.DivMod.Compose.Div128
 import EvmAsm.Evm64.DivMod.Compose.Div128V4
+import EvmAsm.Evm64.DivMod.Compose.Div128V5
 
 open EvmAsm.Rv64.Tactics
 
@@ -405,6 +406,179 @@ theorem divK_trial_call_path_v4_spec_within_noNop
   apply cpsTripleWithin_of_forall_regIs_to_regOwn
   intro v1Old
   exact divK_trial_call_path_v4_spec_within_noNop_exact_x1
+    sp j uLo uHi vTop vtopBase base v1Old v2Old v11Old
+    retMem dMem dloMem un0Mem scratchMem halign
+
+/-- Trial call path over `sharedDivModCode_v5`: JAL x2 560 (instr [16]) +
+    the v5 div128 subroutine, with exact x1 framing and the additional v5
+    scratch cell threaded explicitly. -/
+theorem divK_trial_call_path_v5_spec_within_exact_x1
+    (sp j uLo uHi vTop vtopBase : Word) (base : Word)
+    (v1Old v2Old v11Old : Word)
+    (retMem dMem dloMem un0Mem scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
+    cpsTripleWithin 84 (base + trialJalOff) (base + div128CallRetOff) (sharedDivModCode_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+       (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+       (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
+       (.x2 ↦ᵣ v2Old) ** (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem)) ** (.x1 ↦ᵣ v1Old))
+      (div128V5SpecPost sp (base + div128CallRetOff) vTop uLo uHi scratchMem **
+        regOwn .x1) := by
+  have J := jal_spec_within .x2 v2Old (560 : BitVec 21) (base + trialJalOff) (by nofun)
+  rw [lb_jal_target, lb_jal_ret] at J
+  have Je := cpsTripleWithin_extend_code (hmono :=
+    lb_sub_v5 16 _ _ (by decide) (by bv_addr) (by decide)) J
+  have D := div128_v5_spec_shared sp (base + div128CallRetOff) vTop uLo uHi base
+    j vtopBase v11Old retMem dMem dloMem un0Mem scratchMem
+    halign
+  have Df := cpsTripleWithin_frameR (.x1 ↦ᵣ v1Old) (by pcFree) D
+  have Jf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) ** (.x1 ↦ᵣ v1Old) **
+     (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+     (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
+     (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ retMem) **
+     (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) **
+     (sp + signExtend12 3944 ↦ₘ un0Mem) **
+     (sp + signExtend12 3936 ↦ₘ scratchMem))
+    (by pcFree) Je
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) Jf Df
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by
+      apply sepConj_mono_right (regIs_implies_regOwn .x1) h
+      xperm_hyp hq)
+    full
+
+/-- Trial call path over `sharedDivModCode_v5`, with `x1` existentially
+    owned. -/
+theorem divK_trial_call_path_v5_spec_within
+    (sp j uLo uHi vTop vtopBase : Word) (base : Word)
+    (v2Old v11Old : Word)
+    (retMem dMem dloMem un0Mem scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
+    cpsTripleWithin 84 (base + trialJalOff) (base + div128CallRetOff) (sharedDivModCode_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+       (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+       (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
+       (.x2 ↦ᵣ v2Old) ** (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem)) ** regOwn .x1)
+      (div128V5SpecPost sp (base + div128CallRetOff) vTop uLo uHi scratchMem **
+        regOwn .x1) := by
+  apply cpsTripleWithin_of_forall_regIs_to_regOwn
+  intro v1Old
+  exact divK_trial_call_path_v5_spec_within_exact_x1
+    sp j uLo uHi vTop vtopBase base v1Old v2Old v11Old
+    retMem dMem dloMem un0Mem scratchMem halign
+
+/-- Trial call path over `sharedDivModCodeNoNop_v5`: JAL x2 560 (instr [16])
+    plus the v5 div128 subroutine, preserving the framed concrete x1 value
+    and threading the additional v5 scratch cell explicitly. -/
+theorem divK_trial_call_path_v5_spec_within_noNop_preserving_x1
+    (sp j uLo uHi vTop vtopBase : Word) (base : Word)
+    (v1Old v2Old v11Old : Word)
+    (retMem dMem dloMem un0Mem scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
+    cpsTripleWithin 84 (base + trialJalOff) (base + div128CallRetOff) (sharedDivModCodeNoNop_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+       (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+       (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
+       (.x2 ↦ᵣ v2Old) ** (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem)) ** (.x1 ↦ᵣ v1Old))
+      (div128V5SpecPost sp (base + div128CallRetOff) vTop uLo uHi scratchMem **
+        (.x1 ↦ᵣ v1Old)) := by
+  have J := jal_spec_within .x2 v2Old (560 : BitVec 21) (base + trialJalOff) (by nofun)
+  rw [lb_jal_target, lb_jal_ret] at J
+  have Je := cpsTripleWithin_extend_code (hmono :=
+    lb_sub_noNop_v5 16 _ _ (by decide) (by bv_addr) (by decide)) J
+  have D := div128_v5_spec_shared_noNop sp (base + div128CallRetOff) vTop uLo uHi base
+    j vtopBase v11Old retMem dMem dloMem un0Mem scratchMem
+    halign
+  have Df := cpsTripleWithin_frameR (.x1 ↦ᵣ v1Old) (by pcFree) D
+  have Jf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) ** (.x1 ↦ᵣ v1Old) **
+     (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+     (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
+     (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ retMem) **
+     (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) **
+     (sp + signExtend12 3944 ↦ₘ un0Mem) **
+     (sp + signExtend12 3936 ↦ₘ scratchMem))
+    (by pcFree) Je
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) Jf Df
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    full
+
+/-- Trial call path over `sharedDivModCodeNoNop_v5`: JAL x2 560 (instr [16])
+    plus the v5 div128 subroutine, with exact x1 framing and the additional
+    v5 scratch cell threaded explicitly. -/
+theorem divK_trial_call_path_v5_spec_within_noNop_exact_x1
+    (sp j uLo uHi vTop vtopBase : Word) (base : Word)
+    (v1Old v2Old v11Old : Word)
+    (retMem dMem dloMem un0Mem scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
+    cpsTripleWithin 84 (base + trialJalOff) (base + div128CallRetOff) (sharedDivModCodeNoNop_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+       (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+       (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
+       (.x2 ↦ᵣ v2Old) ** (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem)) ** (.x1 ↦ᵣ v1Old))
+      (div128V5SpecPost sp (base + div128CallRetOff) vTop uLo uHi scratchMem **
+        regOwn .x1) := by
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by
+      apply sepConj_mono_right (regIs_implies_regOwn .x1) h
+      xperm_hyp hq)
+    (divK_trial_call_path_v5_spec_within_noNop_preserving_x1
+      sp j uLo uHi vTop vtopBase base v1Old v2Old v11Old
+      retMem dMem dloMem un0Mem scratchMem halign)
+
+/-- Trial call path over `sharedDivModCodeNoNop_v5`, with `x1`
+    existentially owned. -/
+theorem divK_trial_call_path_v5_spec_within_noNop
+    (sp j uLo uHi vTop vtopBase : Word) (base : Word)
+    (v2Old v11Old : Word)
+    (retMem dMem dloMem un0Mem scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
+    cpsTripleWithin 84 (base + trialJalOff) (base + div128CallRetOff) (sharedDivModCodeNoNop_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+       (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+       (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
+       (.x2 ↦ᵣ v2Old) ** (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem)) ** regOwn .x1)
+      (div128V5SpecPost sp (base + div128CallRetOff) vTop uLo uHi scratchMem **
+        regOwn .x1) := by
+  apply cpsTripleWithin_of_forall_regIs_to_regOwn
+  intro v1Old
+  exact divK_trial_call_path_v5_spec_within_noNop_exact_x1
     sp j uLo uHi vTop vtopBase base v1Old v2Old v11Old
     retMem dMem dloMem un0Mem scratchMem halign
 


### PR DESCRIPTION
## Summary
- Mirror the V4 trial-call-path chain (`divK_trial_call_path_v4_spec_within*`) to V5: five theorems `divK_trial_call_path_v5_spec_within{,_exact_x1,_noNop,_noNop_exact_x1,_noNop_preserving_x1}` composing `JAL x2 560` with `div128_v5_spec_shared` / `div128_v5_spec_shared_noNop` over `sharedDivModCode_v5` / `sharedDivModCodeNoNop_v5`.
- Step count `84` (= 1 JAL + 83-step v5 div128, vs 74 = 1 + 73 for v4).
- Adds `lb_sub_v5` / `lb_sub_noNop_v5` loopBody-block (block 8) subsumption helpers in `Compose/V5Code.lean`, mirroring `lb_sub_v4` / `lb_sub_noNop_v4`.
- No sorry/admit/heartbeat bumps; full `lake build` green; file-size + unimported checks pass.

Lifts the already-proven `div128_v5_spec` into the loop-body trial-call-path surface — the V5 mirror of the FullPathV4 chain entry point. Unblocks `wbc4i.10.1` (v5 lane wrappers).

Refs #61. Bead: wbc4i.7.2.

Authored by @pirapira; implemented by Claude Code
