### PR TITLE
feat(divmod): n1 normalized divisor top limb >= 2^63 from shape

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1CarryZeroReducers.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1CarryZeroReducers.lean
@@ -671,6 +671,21 @@ theorem fullDivN1NormV_limb0_dHi_ge_pow31_of_shape
   exact fullDivN1NormV_limb0_dHi_ge_pow31_of_b0_ne_zero b0 b1 b2 b3
     (fullDivN1_b0_ne_zero_of_shape b0 b1 b2 b3 hbnz hb1z hb2z hb3z)
 
+/-- The n=1 normalized divisor top limb is at least `2^63` — the full-strength
+    normalization invariant (the `…_dHi_ge_pow31` lemma above is its high-half
+    corollary). This is the `vTop ≥ 2^63` precondition of `div128Quot_v5_eq_q_true`
+    when specialized to the n=1 first trial call, so the v5 n=1 trial computes the
+    exact floor — discharging the n=1 carry-zero (via the
+    `…_of_shape_div128Quot_floor` pattern) from shape alone. -/
+theorem fullDivN1NormV_limb0_ge_pow63_of_shape
+    (b0 b1 b2 b3 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0) :
+    (fullDivN1NormV b0 b1 b2 b3).1.toNat ≥ 2^63 := by
+  have hb0nz := fullDivN1_b0_ne_zero_of_shape b0 b1 b2 b3 hbnz hb1z hb2z hb3z
+  have h := b3_shifted_ge_pow63 hb0nz
+  simpa [fullDivN1NormV, fullDivN1Shift] using h
+
 /-- The high half of any normalized n=1 divisor limb is a 32-bit quantity. -/
 theorem fullDivN1NormV_limb0_dHi_lt_pow32 (b0 b1 b2 b3 : Word) :
     ((fullDivN1NormV b0 b1 b2 b3).1 >>> (32 : BitVec 6).toNat).toNat <


### PR DESCRIPTION
## Summary
- Add `fullDivN1NormV_limb0_ge_pow63_of_shape`: the n=1 normalized divisor top limb is `≥ 2^63` — the full-strength normalization invariant (the existing `…_dHi_ge_pow31_of_shape` is its high-half corollary). Proof: `b3_shifted_ge_pow63` on `b0` + `simpa`.
- This is the `vTop ≥ 2^63` precondition of `div128Quot_v5_eq_q_true` (#7218) specialized to the n=1 first trial call. With the already-proven call regime `U_top < V0'` (`fullDivN1NormU_top_lt_normV_limb0_of_shape_shift_nz`), it gives `div128Quot_v5 = floor` for n=1, discharging the n=1 carry-zero (via the `fullDivN1R3CarryZero_true_of_shape_div128Quot_floor` pattern) from shape alone — the path to the v5 n=1 lane.

No sorry/admit/heartbeat; full `lake build` green.

Refs #61. Bead: wbc4i.9.1.2.

Authored by @pirapira; implemented by Claude Code
