### PR TITLE
feat(divmod): v5 n1 first-digit carry-zero from shape (no Carry2NzAll)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -51,6 +51,7 @@ import EvmAsm.Evm64.DivMod.LoopBody.TrialCallV5
 import EvmAsm.Evm64.DivMod.Compose.SharedLoopPost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5Defs
+import EvmAsm.Evm64.DivMod.Spec.N1V5CarryZero
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.LoopUnifiedN1.CallIter210NoNop
 import EvmAsm.Evm64.DivMod.LoopUnifiedN1.UnifiedNoNop

--- a/EvmAsm/Evm64/DivMod/Spec/N1V5CarryZero.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1V5CarryZero.lean
@@ -1,0 +1,66 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N1V5CarryZero
+
+  n=1 carry-zero discharged from shape over the **v5** schoolbook
+  (`fullDivN1R3V5` / `iterN1V5` / `div128Quot_v5`).
+
+  This is the v5 analog of `fullDivN1R3CarryZero_true_of_shape_*`
+  (`N1CarryZeroReducers.lean`), but — crucially — it needs NO `Carry2NzAll`
+  reachability hypothesis and NO `Div128AllPhasesNoWrapInv`. Because the v5
+  trial is the exact 128/64 floor (`div128Quot_v5 = floor`, V5.4.5/V5.5.3), the
+  single-limb mulsub leaves no borrow, so the iteration carry is zero — purely
+  from the divisor shape. This sidesteps the false-universal `Carry2NzAll` that
+  blocked the v4 n=1 lane. Bead evm-asm-wbc4i.9.1.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N1CarryZeroReducers
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5Defs
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- **Abstract v5 single-limb carry-zero.** For a normalized one-limb divisor
+    (`v0 ≥ 2^63`) in the call regime (`u1 < v0`), the v5 call-path iteration has
+    zero carry: the v5 trial `div128Quot_v5 u1 u0 v0 ≤ floor` (V5.4.5), so
+    `qHat·v0 ≤ u1·2^64 + u0` and the mulsub does not borrow. Mirrors
+    `iterN1_true_carry_zero_of_v0_all_phases_no_wrap` but with NO
+    `Div128AllPhasesNoWrapInv` hypothesis — the v5 floor bound is
+    unconditional. -/
+theorem iterN1V5_true_carry_zero_of_v0_norm_call
+    (v0 u0 u1 : Word)
+    (hv0_norm : v0.toNat ≥ 2^63)
+    (hcall : u1.toNat < v0.toNat) :
+    (iterN1V5 true v0 0 0 0 u0 u1 0 0 0).2.2.2.2.2 = 0 := by
+  apply iterN1V5_true_carry_zero_of_mulsub_c3_zero
+  · apply c3_un_zero_of_qHat_mul_le
+    have hq_le := div128Quot_v5_le_q_true u1 u0 v0 hv0_norm hcall
+    have h_product : (div128Quot_v5 u1 u0 v0).toNat * v0.toNat ≤
+        u1.toNat * 2^64 + u0.toNat :=
+      le_trans (Nat.mul_le_mul_right v0.toNat hq_le) (Nat.div_mul_le_self _ _)
+    simp [EvmWord.val256]
+    omega
+  · rfl
+
+/-- **v5 n=1 first-digit carry-zero, from shape (no `Carry2NzAll`).**
+    `(fullDivN1R3V5 true …).carry = 0`, discharged unconditionally from the
+    one-limb divisor shape: `normV.1 ≥ 2^63`
+    (`fullDivN1NormV_limb0_ge_pow63_of_shape`) and the call regime
+    `U_top < V0'` (`fullDivN1NormU_top_lt_normV_limb0_of_shape_shift_nz`). -/
+theorem fullDivN1R3V5_carry_zero_of_shape
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0) :
+    (fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.2 = 0 := by
+  unfold fullDivN1R3V5
+  simp only [
+    fullDivN1NormV_limb1_eq_zero_of_shape_shift_nz b0 b1 b2 b3 hb1z hshift_nz,
+    fullDivN1NormV_limb2_eq_zero_of_shape b0 b1 b2 b3 hb1z hb2z,
+    fullDivN1NormV_limb3_eq_zero_of_shape b0 b1 b2 b3 hb2z hb3z]
+  exact iterN1V5_true_carry_zero_of_v0_norm_call _ _ _
+    (fullDivN1NormV_limb0_ge_pow63_of_shape b0 b1 b2 b3 hbnz hb1z hb2z hb3z)
+    (fullDivN1NormU_top_lt_normV_limb0_of_shape_shift_nz
+      a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb1z hb2z hb3z hshift_nz)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N1V5CarryZero.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1V5CarryZero.lean
@@ -1,16 +1,17 @@
 /-
   EvmAsm.Evm64.DivMod.Spec.N1V5CarryZero
 
-  n=1 carry-zero discharged from shape over the **v5** schoolbook
-  (`fullDivN1R3V5` / `iterN1V5` / `div128Quot_v5`).
+  n=1 carry-zero and per-step remainder bound, discharged from shape over the
+  **v5** schoolbook (`fullDivN1R3V5` / `iterN1V5` / `div128Quot_v5`).
 
-  This is the v5 analog of `fullDivN1R3CarryZero_true_of_shape_*`
-  (`N1CarryZeroReducers.lean`), but — crucially — it needs NO `Carry2NzAll`
-  reachability hypothesis and NO `Div128AllPhasesNoWrapInv`. Because the v5
-  trial is the exact 128/64 floor (`div128Quot_v5 = floor`, V5.4.5/V5.5.3), the
-  single-limb mulsub leaves no borrow, so the iteration carry is zero — purely
-  from the divisor shape. This sidesteps the false-universal `Carry2NzAll` that
-  blocked the v4 n=1 lane. Bead evm-asm-wbc4i.9.1.
+  These are the v5 analogs of `fullDivN1R3CarryZero_true_of_shape_*` and the
+  remainder-lt hypotheses (`N1CarryZeroReducers.lean` / `N1QuotientStackBridge`),
+  but — crucially — they need NO `Carry2NzAll` reachability hypothesis and NO
+  `Div128AllPhasesNoWrapInv`. Because the v5 trial is the exact 128/64 floor
+  (`div128Quot_v5 = floor`, V5.4.5/V5.5.3), the single-limb mulsub leaves no
+  borrow, so both the iteration carry is zero and the remainder is `< v0` —
+  purely from the divisor shape. This sidesteps the false-universal
+  `Carry2NzAll` that blocked the v4 n=1 lane. Bead evm-asm-wbc4i.9.1.
 -/
 
 import EvmAsm.Evm64.DivMod.Spec.N1CarryZeroReducers
@@ -22,11 +23,8 @@ open EvmAsm.Rv64
 
 /-- **Abstract v5 single-limb carry-zero.** For a normalized one-limb divisor
     (`v0 ≥ 2^63`) in the call regime (`u1 < v0`), the v5 call-path iteration has
-    zero carry: the v5 trial `div128Quot_v5 u1 u0 v0 ≤ floor` (V5.4.5), so
-    `qHat·v0 ≤ u1·2^64 + u0` and the mulsub does not borrow. Mirrors
-    `iterN1_true_carry_zero_of_v0_all_phases_no_wrap` but with NO
-    `Div128AllPhasesNoWrapInv` hypothesis — the v5 floor bound is
-    unconditional. -/
+    zero carry. Mirrors `iterN1_true_carry_zero_of_v0_all_phases_no_wrap` but
+    with NO `Div128AllPhasesNoWrapInv` — the v5 floor bound is unconditional. -/
 theorem iterN1V5_true_carry_zero_of_v0_norm_call
     (v0 u0 u1 : Word)
     (hv0_norm : v0.toNat ≥ 2^63)
@@ -42,11 +40,45 @@ theorem iterN1V5_true_carry_zero_of_v0_norm_call
     omega
   · rfl
 
-/-- **v5 n=1 first-digit carry-zero, from shape (no `Carry2NzAll`).**
-    `(fullDivN1R3V5 true …).carry = 0`, discharged unconditionally from the
-    one-limb divisor shape: `normV.1 ≥ 2^63`
-    (`fullDivN1NormV_limb0_ge_pow63_of_shape`) and the call regime
-    `U_top < V0'` (`fullDivN1NormU_top_lt_normV_limb0_of_shape_shift_nz`). -/
+/-- **Abstract v5 single-limb remainder bound.** For a normalized one-limb
+    divisor (`v0 ≥ 2^63`) in the call regime (`u1 < v0`), the v5 iteration's
+    remainder is `< v0`: the v5 trial is the exact floor, so the no-borrow
+    mulsub leaves `remainder = (u1·2^64 + u0) mod v0 < v0`. The per-step
+    invariant that propagates the call regime to the next n=1 digit, with NO
+    `Div128AllPhasesNoWrapInv`. -/
+theorem iterN1V5_true_remainder_lt_of_v0_norm_call
+    (v0 u0 u1 : Word)
+    (hv0_norm : v0.toNat ≥ 2^63)
+    (hcall : u1.toNat < v0.toNat) :
+    EvmWord.val256
+      (iterN1V5 true v0 0 0 0 u0 u1 0 0 0).2.1
+      (iterN1V5 true v0 0 0 0 u0 u1 0 0 0).2.2.1
+      (iterN1V5 true v0 0 0 0 u0 u1 0 0 0).2.2.2.1
+      (iterN1V5 true v0 0 0 0 u0 u1 0 0 0).2.2.2.2.1 < v0.toNat := by
+  have hv0_pos : 0 < v0.toNat := by omega
+  have hq_eq := div128Quot_v5_eq_q_true u1 u0 v0 hv0_norm hcall
+  have hc3 : (mulsubN4 (div128Quot_v5 u1 u0 v0) v0 0 0 0 u0 u1 0 0).2.2.2.2 = 0 := by
+    apply c3_un_zero_of_qHat_mul_le
+    have h_prod : (div128Quot_v5 u1 u0 v0).toNat * v0.toNat ≤ u1.toNat * 2^64 + u0.toNat :=
+      le_trans (Nat.mul_le_mul_right v0.toNat
+        (div128Quot_v5_le_q_true u1 u0 v0 hv0_norm hcall)) (Nat.div_mul_le_self _ _)
+    simp [EvmWord.val256]
+    omega
+  rw [iterN1V5_true]
+  unfold iterN1Call_v5
+  rw [iterWithDoubleAddback_no_borrow (by rw [hc3]; simp [BitVec.ult])]
+  dsimp only
+  have hval := mulsubN4_val256_eq (div128Quot_v5 u1 u0 v0) v0 0 0 0 u0 u1 0 0
+  simp only [hc3] at hval
+  rw [hq_eq] at hval
+  simp [EvmWord.val256] at hval ⊢
+  -- `simp` evaluated `2^64` to its literal; state the Euclidean facts in the
+  -- same literal form so omega sees one `floor * v0` atom.
+  have hdm := Nat.div_add_mod' (u1.toNat * 18446744073709551616 + u0.toNat) v0.toNat
+  have hlt := Nat.mod_lt (u1.toNat * 18446744073709551616 + u0.toNat) hv0_pos
+  omega
+
+/-- **v5 n=1 first-digit carry-zero, from shape (no `Carry2NzAll`).** -/
 theorem fullDivN1R3V5_carry_zero_of_shape
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
@@ -59,6 +91,30 @@ theorem fullDivN1R3V5_carry_zero_of_shape
     fullDivN1NormV_limb2_eq_zero_of_shape b0 b1 b2 b3 hb1z hb2z,
     fullDivN1NormV_limb3_eq_zero_of_shape b0 b1 b2 b3 hb2z hb3z]
   exact iterN1V5_true_carry_zero_of_v0_norm_call _ _ _
+    (fullDivN1NormV_limb0_ge_pow63_of_shape b0 b1 b2 b3 hbnz hb1z hb2z hb3z)
+    (fullDivN1NormU_top_lt_normV_limb0_of_shape_shift_nz
+      a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb1z hb2z hb3z hshift_nz)
+
+/-- **v5 n=1 first-digit remainder bound, from shape.** `val256` of the
+    `fullDivN1R3V5` remainder is `< normV.1` — the per-step invariant that feeds
+    the call regime of the R2 digit. From shape (no `Carry2NzAll`). -/
+theorem fullDivN1R3V5_remainder_lt_of_shape
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0) :
+    EvmWord.val256
+      (fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3).2.1
+      (fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+      (fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+      (fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <
+      (fullDivN1NormV b0 b1 b2 b3).1.toNat := by
+  unfold fullDivN1R3V5
+  simp only [
+    fullDivN1NormV_limb1_eq_zero_of_shape_shift_nz b0 b1 b2 b3 hb1z hshift_nz,
+    fullDivN1NormV_limb2_eq_zero_of_shape b0 b1 b2 b3 hb1z hb2z,
+    fullDivN1NormV_limb3_eq_zero_of_shape b0 b1 b2 b3 hb2z hb3z]
+  exact iterN1V5_true_remainder_lt_of_v0_norm_call _ _ _
     (fullDivN1NormV_limb0_ge_pow63_of_shape b0 b1 b2 b3 hbnz hb1z hb2z hb3z)
     (fullDivN1NormU_top_lt_normV_limb0_of_shape_shift_nz
       a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb1z hb2z hb3z hshift_nz)


### PR DESCRIPTION
## Summary
- `Spec/N1V5CarryZero.lean`: the n=1 first-digit **carry-zero** AND **remainder `< v0`**, both discharged from the divisor shape alone — NO `Carry2NzAll`, NO `Div128AllPhasesNoWrapInv`.
  - `fullDivN1R3V5_carry_zero_of_shape` — carry = 0 from shape.
  - `fullDivN1R3V5_remainder_lt_of_shape` — the R3 remainder `val256 < normV.1`, the per-step invariant that feeds the call regime of the R2 digit.
  - Abstract helpers `iterN1V5_true_{carry_zero,remainder_lt}_of_v0_norm_call` (small-term, mirror the v4 `…_of_v0_all_phases_no_wrap` but drop the no-wrap invariant).
- Mechanism: the v5 trial is the exact 128/64 floor (`div128Quot_v5 = floor`, #7218), so for a normalized one-limb divisor the no-borrow mulsub gives carry = 0 and `remainder = (u1·2^64+u0) mod v0 < v0`. **Dissolves the `Carry2NzAll` blocker** for the n1 lane.

Combines the v5 n=1 building blocks (`iterN1V5` #7224, `fullDivN1*V5` #7225, `div128Quot_v5=floor`-for-n1 #7226). No sorry/admit/heartbeat; full `lake build` green.

Refs #61. Bead: wbc4i.9.1.

Authored by @pirapira; implemented by Claude Code
