### PR TITLE
feat(divmod): rescue v5 n1 conservation + quotient word (orphaned post-#7229)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -53,6 +53,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5Defs
 import EvmAsm.Evm64.DivMod.Spec.N1V5CarryZero
 import EvmAsm.Evm64.DivMod.Spec.N1V5DigitSteps
+import EvmAsm.Evm64.DivMod.Spec.N1V5Quotient
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.LoopUnifiedN1.CallIter210NoNop
 import EvmAsm.Evm64.DivMod.LoopUnifiedN1.UnifiedNoNop

--- a/EvmAsm/Evm64/DivMod/Spec/N1V5DigitSteps.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1V5DigitSteps.lean
@@ -160,4 +160,41 @@ theorem fullDivN1R0V5_remainder_lt_of_shape
   exact iterN1V5_true_remainder_lt_of_v0_norm_call _ _ _
     (fullDivN1NormV_limb0_ge_pow63_of_shape b0 b1 b2 b3 hbnz hb1z hb2z hb3z) hr1lt
 
+-- ============================================================================
+-- Per-step Euclidean conservation (building block for the 4-digit accumulation)
+-- ============================================================================
+
+/-- **Abstract per-step v5 Euclidean conservation.** For a normalized one-limb
+    divisor in the call regime, `val256(window) = qHat·v0 + val256(remainder)`,
+    where `qHat = R.1` is the iteration's quotient digit. From carry=0
+    (no-borrow) + `mulsubN4_val256_eq` — NO `Carry2NzAll`. The per-step input to
+    the version-agnostic 4-digit accumulation
+    (`fullDivN1_four_step_conservation_nat`) yielding the full normalized
+    Euclidean equation `fullDivN1NormalizedConservation`. -/
+theorem iterN1V5_true_conservation_of_v0_norm_call
+    (v0 u0 u1 : Word)
+    (hv0_norm : v0.toNat ≥ 2^63)
+    (hcall : u1.toNat < v0.toNat) :
+    EvmWord.val256 u0 u1 0 0 =
+      (iterN1V5 true v0 0 0 0 u0 u1 0 0 0).1.toNat * v0.toNat +
+      EvmWord.val256
+        (iterN1V5 true v0 0 0 0 u0 u1 0 0 0).2.1
+        (iterN1V5 true v0 0 0 0 u0 u1 0 0 0).2.2.1
+        (iterN1V5 true v0 0 0 0 u0 u1 0 0 0).2.2.2.1
+        (iterN1V5 true v0 0 0 0 u0 u1 0 0 0).2.2.2.2.1 := by
+  have hc3 : (mulsubN4 (div128Quot_v5 u1 u0 v0) v0 0 0 0 u0 u1 0 0).2.2.2.2 = 0 := by
+    apply c3_un_zero_of_qHat_mul_le
+    have h_prod : (div128Quot_v5 u1 u0 v0).toNat * v0.toNat ≤ u1.toNat * 2^64 + u0.toNat :=
+      le_trans (Nat.mul_le_mul_right v0.toNat
+        (div128Quot_v5_le_q_true u1 u0 v0 hv0_norm hcall)) (Nat.div_mul_le_self _ _)
+    simp [EvmWord.val256]; omega
+  rw [iterN1V5_true]
+  unfold iterN1Call_v5
+  rw [iterWithDoubleAddback_no_borrow (by rw [hc3]; simp [BitVec.ult])]
+  dsimp only
+  have hval := mulsubN4_val256_eq (div128Quot_v5 u1 u0 v0) v0 0 0 0 u0 u1 0 0
+  simp only [hc3] at hval
+  simp [EvmWord.val256] at hval ⊢
+  omega
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N1V5DigitSteps.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1V5DigitSteps.lean
@@ -197,4 +197,112 @@ theorem iterN1V5_true_conservation_of_v0_norm_call
   simp [EvmWord.val256] at hval ⊢
   omega
 
+-- ============================================================================
+-- Per-digit conservation instantiations (the 4 `hiter` inputs to the
+-- version-agnostic `fullDivN1_four_step_conservation_nat` accumulation)
+-- ============================================================================
+
+theorem fullDivN1R3V5_conservation_of_shape
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0) :
+    EvmWord.val256
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2 0 0 =
+      (fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3).1.toNat *
+        (fullDivN1NormV b0 b1 b2 b3).1.toNat +
+      EvmWord.val256
+        (fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3).2.1
+        (fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+        (fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        (fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 := by
+  unfold fullDivN1R3V5
+  simp only [
+    fullDivN1NormV_limb1_eq_zero_of_shape_shift_nz b0 b1 b2 b3 hb1z hshift_nz,
+    fullDivN1NormV_limb2_eq_zero_of_shape b0 b1 b2 b3 hb1z hb2z,
+    fullDivN1NormV_limb3_eq_zero_of_shape b0 b1 b2 b3 hb2z hb3z]
+  exact iterN1V5_true_conservation_of_v0_norm_call _ _ _
+    (fullDivN1NormV_limb0_ge_pow63_of_shape b0 b1 b2 b3 hbnz hb1z hb2z hb3z)
+    (fullDivN1NormU_top_lt_normV_limb0_of_shape_shift_nz
+      a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb1z hb2z hb3z hshift_nz)
+
+theorem fullDivN1R2V5_conservation_of_shape
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0) :
+    EvmWord.val256
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+      (fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3).2.1 0 0 =
+      (fullDivN1R2V5 true true a0 a1 a2 a3 b0 b1 b2 b3).1.toNat *
+        (fullDivN1NormV b0 b1 b2 b3).1.toNat +
+      EvmWord.val256
+        (fullDivN1R2V5 true true a0 a1 a2 a3 b0 b1 b2 b3).2.1
+        (fullDivN1R2V5 true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+        (fullDivN1R2V5 true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        (fullDivN1R2V5 true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 := by
+  obtain ⟨h1, h2, h3, hr3lt⟩ := n1v5_step_facts
+    (fullDivN1R3V5_remainder_lt_of_shape a0 a1 a2 a3 b0 b1 b2 b3
+      hbnz hb1z hb2z hb3z hshift_nz)
+  unfold fullDivN1R2V5
+  simp only [
+    fullDivN1NormV_limb1_eq_zero_of_shape_shift_nz b0 b1 b2 b3 hb1z hshift_nz,
+    fullDivN1NormV_limb2_eq_zero_of_shape b0 b1 b2 b3 hb1z hb2z,
+    fullDivN1NormV_limb3_eq_zero_of_shape b0 b1 b2 b3 hb2z hb3z, h1, h2, h3]
+  exact iterN1V5_true_conservation_of_v0_norm_call _ _ _
+    (fullDivN1NormV_limb0_ge_pow63_of_shape b0 b1 b2 b3 hbnz hb1z hb2z hb3z) hr3lt
+
+theorem fullDivN1R1V5_conservation_of_shape
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0) :
+    EvmWord.val256
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.1
+      (fullDivN1R2V5 true true a0 a1 a2 a3 b0 b1 b2 b3).2.1 0 0 =
+      (fullDivN1R1V5 true true true a0 a1 a2 a3 b0 b1 b2 b3).1.toNat *
+        (fullDivN1NormV b0 b1 b2 b3).1.toNat +
+      EvmWord.val256
+        (fullDivN1R1V5 true true true a0 a1 a2 a3 b0 b1 b2 b3).2.1
+        (fullDivN1R1V5 true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+        (fullDivN1R1V5 true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        (fullDivN1R1V5 true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 := by
+  obtain ⟨h1, h2, h3, hr2lt⟩ := n1v5_step_facts
+    (fullDivN1R2V5_remainder_lt_of_shape a0 a1 a2 a3 b0 b1 b2 b3
+      hbnz hb1z hb2z hb3z hshift_nz)
+  unfold fullDivN1R1V5
+  simp only [
+    fullDivN1NormV_limb1_eq_zero_of_shape_shift_nz b0 b1 b2 b3 hb1z hshift_nz,
+    fullDivN1NormV_limb2_eq_zero_of_shape b0 b1 b2 b3 hb1z hb2z,
+    fullDivN1NormV_limb3_eq_zero_of_shape b0 b1 b2 b3 hb2z hb3z, h1, h2, h3]
+  exact iterN1V5_true_conservation_of_v0_norm_call _ _ _
+    (fullDivN1NormV_limb0_ge_pow63_of_shape b0 b1 b2 b3 hbnz hb1z hb2z hb3z) hr2lt
+
+theorem fullDivN1R0V5_conservation_of_shape
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0) :
+    EvmWord.val256
+      (fullDivN1NormU a0 a1 a2 a3 b0).1
+      (fullDivN1R1V5 true true true a0 a1 a2 a3 b0 b1 b2 b3).2.1 0 0 =
+      (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).1.toNat *
+        (fullDivN1NormV b0 b1 b2 b3).1.toNat +
+      EvmWord.val256
+        (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.1
+        (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+        (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 := by
+  obtain ⟨h1, h2, h3, hr1lt⟩ := n1v5_step_facts
+    (fullDivN1R1V5_remainder_lt_of_shape a0 a1 a2 a3 b0 b1 b2 b3
+      hbnz hb1z hb2z hb3z hshift_nz)
+  unfold fullDivN1R0V5
+  simp only [
+    fullDivN1NormV_limb1_eq_zero_of_shape_shift_nz b0 b1 b2 b3 hb1z hshift_nz,
+    fullDivN1NormV_limb2_eq_zero_of_shape b0 b1 b2 b3 hb1z hb2z,
+    fullDivN1NormV_limb3_eq_zero_of_shape b0 b1 b2 b3 hb2z hb3z, h1, h2, h3]
+  exact iterN1V5_true_conservation_of_v0_norm_call _ _ _
+    (fullDivN1NormV_limb0_ge_pow63_of_shape b0 b1 b2 b3 hbnz hb1z hb2z hb3z) hr1lt
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N1V5Quotient.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1V5Quotient.lean
@@ -1,0 +1,52 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N1V5Quotient
+
+  v5 n=1 quotient word and the carry-zero 4-digit accumulation, en route to
+  `fullDivN1QuotientWordV5 = EvmWord.div a b`.
+
+  The per-digit toolkit (`N1V5DigitSteps.lean`) provides, from shape and with NO
+  `Carry2NzAll`:
+  - the 4 conservations `fullDivN1R{3,2,1,0}V5_conservation_of_shape`
+    (`val256(window) = q_k·v0 + val256(remainder)`), and
+  - the 4 remainder-lts `fullDivN1R{3,2,1,0}V5_remainder_lt_of_shape`.
+
+  `fullDivN1V5_four_step_nat` below accumulates the four conservation equations
+  into `val256(a)·2^s = quotient·(val256(b)·2^s) + r0` (the carries are already
+  zero in the v5 per-step conservations, unlike v4's raw form). With the final
+  remainder-lt + the scaled-divisor identity `normV.1 = val256(b)·2^s`, this
+  feeds `EvmWord.div_correct_normalized` to give
+  `fullDivN1QuotientWordV5 = EvmWord.div a b` (next step).
+
+  Bead evm-asm-wbc4i.9.1.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N1V5DigitSteps
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The carry-zero 4-digit accumulation — public re-proof of the private
+    `fullDivN1_four_step_conservation_nat`, specialized to all carries zero
+    (which is exactly what the v5 per-step conservations directly provide). -/
+theorem fullDivN1V5_four_step_nat
+    {a b q3 q2 q1 q0 u0 u1 u2 u3 u4 r3 r2 r1 r0 : Nat}
+    (hfirst : a = u0 + 2 ^ 64 * (u1 + 2 ^ 64 * (u2 + 2 ^ 64 * (u3 + 2 ^ 64 * u4))))
+    (hiter3 : u3 + 2 ^ 64 * u4 = q3 * b + r3)
+    (hiter2 : u2 + 2 ^ 64 * r3 = q2 * b + r2)
+    (hiter1 : u1 + 2 ^ 64 * r2 = q1 * b + r1)
+    (hiter0 : u0 + 2 ^ 64 * r1 = q0 * b + r0) :
+    a = (q3 * 2 ^ 192 + q2 * 2 ^ 128 + q1 * 2 ^ 64 + q0) * b + r0 := by
+  nlinarith
+
+/-- v5 n=1 quotient word: the four digit quotients `fullDivN1R{0,1,2,3}V5.1`
+    assembled into a 256-bit word (mirror of `fullDivN1QuotientWord`). -/
+def fullDivN1QuotientWordV5 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : EvmWord :=
+  EvmWord.fromLimbs (fun i : Fin 4 =>
+    match i with
+    | 0 => (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).1
+    | 1 => (fullDivN1R1V5 true true true a0 a1 a2 a3 b0 b1 b2 b3).1
+    | 2 => (fullDivN1R2V5 true true a0 a1 a2 a3 b0 b1 b2 b3).1
+    | 3 => (fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3).1)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
Rescues three n=1 v5 commits that landed on `feat/v5-n1-r2` *after* PR #7229 merged (so they were left out of main):
- per-step v5 Euclidean conservation `iterN1V5_true_conservation_of_v0_norm_call`;
- the four per-digit conservation instantiations `fullDivN1R{3,2,1,0}V5_conservation_of_shape`;
- `fullDivN1QuotientWordV5` (the 4 digit quotients assembled) + the public carry-zero 4-digit accumulation `fullDivN1V5_four_step_nat`.

Together with the merged per-digit carry-zeros + remainder-lts, these are the inputs for `fullDivN1QuotientWordV5 = EvmWord.div a b` via `div_correct_normalized` (next step). All from shape, NO `Carry2NzAll`.

Cherry-picked clean onto current main. No sorry/admit/heartbeat; full `lake build` green.

Refs #61. Bead: wbc4i.9.1.

Authored by @pirapira; implemented by Claude Code
