### PR TITLE
feat(divmod): v5 n1 quotient correctness (= EvmWord.div a b) from shape

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1V5Quotient.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1V5Quotient.lean
@@ -49,4 +49,91 @@ def fullDivN1QuotientWordV5 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : EvmWord :=
     | 2 => (fullDivN1R2V5 true true a0 a1 a2 a3 b0 b1 b2 b3).1
     | 3 => (fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3).1)
 
+open EvmWord in
+/-- A per-step remainder bounded by the divisor occupies only its low limb,
+    so its `val256` collapses to `limb0.toNat`. -/
+private theorem rem_val_eq_limb0 {x0 x1 x2 x3 v0 : Word}
+    (hrem : val256 x0 x1 x2 x3 < v0.toNat) : val256 x0 x1 x2 x3 = x0.toNat := by
+  obtain ⟨h1, h2, h3⟩ := val256_high_limbs_zero_of_lt_word x0 x1 x2 x3 v0 hrem
+  rw [h1, h2, h3]; simp [val256]
+
+open EvmWord in
+/-- The n=1 normalized single-limb divisor value is `val256(b)·2^shift`. -/
+private theorem normV1_eq_scaled_of_shape
+    (b0 b1 b2 b3 : Word) (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0) :
+    (fullDivN1NormV b0 b1 b2 b3).1.toNat =
+      val256 b0 b1 b2 b3 * 2 ^ (fullDivN1Shift b0).toNat := by
+  have h := fullDivN1NormV_val256_eq_scaled_of_shape b0 b1 b2 b3 hb1z hb2z hb3z hshift_nz
+  rw [← h, fullDivN1NormV_limb1_eq_zero_of_shape_shift_nz b0 b1 b2 b3 hb1z hshift_nz,
+      fullDivN1NormV_limb2_eq_zero_of_shape b0 b1 b2 b3 hb1z hb2z,
+      fullDivN1NormV_limb3_eq_zero_of_shape b0 b1 b2 b3 hb2z hb3z]
+  simp [val256]
+
+open EvmWord in
+/-- **v5 n=1 quotient correctness, from shape.** The four-digit v5 n=1
+    schoolbook computes the exact quotient `EvmWord.div a b` — discharged from
+    the divisor shape alone, with NO `Carry2NzAll` and NO
+    `Div128AllPhasesNoWrapInv`. Assembles the four per-digit conservations (via
+    `fullDivN1V5_four_step_nat`, carries zero) into the normalized Euclidean
+    equation, then applies `div_quotient_of_normalized` + `div_of_val256_eq_div`
+    with the final remainder bound (`fullDivN1R0V5_remainder_lt_of_shape`) and
+    the scaled-limb identities. Bead `evm-asm-wbc4i.9.1`. -/
+theorem fullDivN1QuotientWordV5_eq_div_of_shape
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0) :
+    fullDivN1QuotientWordV5 a0 a1 a2 a3 b0 b1 b2 b3 =
+      EvmWord.div
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3)
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3) := by
+  set s := (fullDivN1Shift b0).toNat with hs
+  have hu := fullDivN1NormU_val256_eq_scaled a0 a1 a2 a3 b0 hshift_nz
+  have hc3 := fullDivN1R3V5_conservation_of_shape a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb1z hb2z hb3z hshift_nz
+  have hc2 := fullDivN1R2V5_conservation_of_shape a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb1z hb2z hb3z hshift_nz
+  have hc1 := fullDivN1R1V5_conservation_of_shape a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb1z hb2z hb3z hshift_nz
+  have hc0 := fullDivN1R0V5_conservation_of_shape a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb1z hb2z hb3z hshift_nz
+  have hr3 := rem_val_eq_limb0 (fullDivN1R3V5_remainder_lt_of_shape a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb1z hb2z hb3z hshift_nz)
+  have hr2 := rem_val_eq_limb0 (fullDivN1R2V5_remainder_lt_of_shape a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb1z hb2z hb3z hshift_nz)
+  have hr1 := rem_val_eq_limb0 (fullDivN1R1V5_remainder_lt_of_shape a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb1z hb2z hb3z hshift_nz)
+  have hr0lt := fullDivN1R0V5_remainder_lt_of_shape a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb1z hb2z hb3z hshift_nz
+  have hr0 := rem_val_eq_limb0 hr0lt
+  have hvb : (fullDivN1NormV b0 b1 b2 b3).1.toNat = val256 b0 b1 b2 b3 * 2 ^ s := by
+    rw [hs]; exact normV1_eq_scaled_of_shape b0 b1 b2 b3 hb1z hb2z hb3z hshift_nz
+  have hacc := fullDivN1V5_four_step_nat
+    (a := val256 a0 a1 a2 a3 * 2 ^ s) (b := (fullDivN1NormV b0 b1 b2 b3).1.toNat)
+    (q3 := (fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3).1.toNat)
+    (q2 := (fullDivN1R2V5 true true a0 a1 a2 a3 b0 b1 b2 b3).1.toNat)
+    (q1 := (fullDivN1R1V5 true true true a0 a1 a2 a3 b0 b1 b2 b3).1.toNat)
+    (q0 := (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).1.toNat)
+    (u0 := (fullDivN1NormU a0 a1 a2 a3 b0).1.toNat)
+    (u1 := (fullDivN1NormU a0 a1 a2 a3 b0).2.1.toNat)
+    (u2 := (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1.toNat)
+    (u3 := (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1.toNat)
+    (u4 := (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2.toNat)
+    (r3 := (fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3).2.1.toNat)
+    (r2 := (fullDivN1R2V5 true true a0 a1 a2 a3 b0 b1 b2 b3).2.1.toNat)
+    (r1 := (fullDivN1R1V5 true true true a0 a1 a2 a3 b0 b1 b2 b3).2.1.toNat)
+    (r0 := (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.1.toNat)
+    (by rw [← hu]; simp [val256]; ring)
+    (by have h := hc3; rw [hr3] at h; simp [val256] at h; omega)
+    (by have h := hc2; rw [hr2] at h; simp [val256] at h; omega)
+    (by have h := hc1; rw [hr1] at h; simp [val256] at h; omega)
+    (by have h := hc0; rw [hr0] at h; simp [val256] at h; omega)
+  rw [hvb] at hacc
+  have hlt : (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.1.toNat <
+      val256 b0 b1 b2 b3 * 2 ^ s := by rw [← hr0, ← hvb]; exact hr0lt
+  have hq := div_quotient_of_normalized (s := s) hacc hlt
+  have hqval : val256
+      (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).1
+      (fullDivN1R1V5 true true true a0 a1 a2 a3 b0 b1 b2 b3).1
+      (fullDivN1R2V5 true true a0 a1 a2 a3 b0 b1 b2 b3).1
+      (fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3).1 =
+      val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 := by rw [← hq]; simp [val256]; ring
+  have hdiv := div_of_val256_eq_div (a0 := a0) (a1 := a1) (a2 := a2) (a3 := a3)
+    (b0 := b0) (b1 := b1) (b2 := b2) (b3 := b3) hbnz hqval
+  unfold fullDivN1QuotientWordV5
+  exact hdiv
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- **`fullDivN1QuotientWordV5_eq_div_of_shape`**: the v5 n=1 schoolbook computes the exact quotient — `fullDivN1QuotientWordV5 a b = EvmWord.div a b`, discharged from the divisor shape alone, with **NO `Carry2NzAll` and NO `Div128AllPhasesNoWrapInv`**. This is the n=1 quotient-correctness milestone.
- Assembles the four per-digit conservations (via `fullDivN1V5_four_step_nat`, carries zero) into the normalized Euclidean equation, then `div_quotient_of_normalized` + `div_of_val256_eq_div` with the final remainder bound + scaled-limb identities.
- Helpers `rem_val_eq_limb0` (remainder `< v0` ⇒ `val256 = limb0`) and `normV1_eq_scaled_of_shape` (`normV.1 = val256(b)·2^s`).

The entire mathematical content of the n=1 lane (the trial is exact ⇒ the schoolbook is correct, from shape) is now proven. Remaining for the n=1 lane: the stack-spec wrapper (`N1ShapeIs → dispatchPost` over `sharedDivModCodeNoNop_v5`) and the scaffold re-point.

Stacked on #7231. No sorry/admit/heartbeat (only the pre-existing `getLimb_fromLimbs` `bv_decide` axioms from the shared `fromLimbs` infrastructure, same as all other lanes); full `lake build` green.

Refs #61. Bead: wbc4i.9.1.

Authored by @pirapira; implemented by Claude Code
