### PR TITLE
feat(divmod): v5 n1 dispatch-post bridge (hdivs_of_word_eq)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1V5Quotient.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1V5Quotient.lean
@@ -136,4 +136,26 @@ theorem fullDivN1QuotientWordV5_eq_div_of_shape
   unfold fullDivN1QuotientWordV5
   exact hdiv
 
+/-- **v5 dispatch-post bridge.** Decompose the v5 n=1 quotient-word equality
+    `fullDivN1QuotientWordV5 = EvmWord.div a b` into the four per-limb
+    `getLimbN`/digit equalities that the n=1 lane wrapper feeds to
+    `divStackDispatchPost`.  Pure `fromLimbs` projection — the v5 analog of
+    `fullDivN1_hdivs_of_word_eq`.  Bead `evm-asm-wbc4i.9.1.4`. -/
+theorem fullDivN1V5_hdivs_of_word_eq
+    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hdiv : fullDivN1QuotientWordV5 a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b) :
+    (EvmWord.div a b).getLimbN 0 =
+      (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 1 =
+      (fullDivN1R1V5 true true true a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 2 =
+      (fullDivN1R2V5 true true a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 3 =
+      (fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3).1 := by
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [← hdiv]; delta fullDivN1QuotientWordV5; exact EvmWord.getLimbN_fromLimbs_0
+  · rw [← hdiv]; delta fullDivN1QuotientWordV5; exact EvmWord.getLimbN_fromLimbs_1
+  · rw [← hdiv]; delta fullDivN1QuotientWordV5; exact EvmWord.getLimbN_fromLimbs_2
+  · rw [← hdiv]; delta fullDivN1QuotientWordV5; exact EvmWord.getLimbN_fromLimbs_3
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Adds `fullDivN1V5_hdivs_of_word_eq` — the v5 analog of `fullDivN1_hdivs_of_word_eq` (Dispatcher.lean). It decomposes the v5 n=1 quotient-word equality

```
fullDivN1QuotientWordV5 a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b   (#7232)
```

into the four per-limb `getLimbN`/digit equalities that the n=1 lane wrapper feeds to `divStackDispatchPost`:

```
(EvmWord.div a b).getLimbN k = (fullDivN1R{k}V5 ...).1   for k = 0,1,2,3
```

Pure `fromLimbs` projection (via `EvmWord.getLimbN_fromLimbs_{0..3}`).

## Context

Per the 2026-05-29 decision to use **v5 code for every lane** (the #7223 counterexample shows `div128Quot_v4 ≠ floor` even for normalized call-regime inputs, so V4 is unsound for n1 too), the n=1 lane wrapper is built over `sharedDivModCodeNoNop_v5`. This bridge is the step that turns the proven v5 quotient correctness (#7232) into the four limb facts the dispatch post consumes — the v5 counterpart of how the V4 path uses `fullDivN1_hdivs_of_word_eq`. Bead `evm-asm-wbc4i.9.1.4`.

## Gates

- `lake build EvmAsm.Evm64.DivMod.Spec.N1V5Quotient` ✓
- Full `lake build` (2483 jobs) ✓
- No `sorry`/`native_decide`/`bv_decide`; file-size + unimported checks pass (0 orphans)

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)