### PR TITLE
feat(divmod): v5 div128 Phase-1b/2b code=model selection bridge

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -58,6 +58,7 @@ import EvmAsm.Evm64.DivMod.Spec.N1V5CarryZero
 import EvmAsm.Evm64.DivMod.Spec.N1V5DigitSteps
 import EvmAsm.Evm64.DivMod.Spec.N1V5Quotient
 import EvmAsm.Evm64.DivMod.Spec.N1V5NoBorrow
+import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5Phase1bBridge
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.LoopUnifiedN1.CallIter210NoNop
 import EvmAsm.Evm64.DivMod.LoopUnifiedN1.UnifiedNoNop

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128V5Phase1bBridge.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128V5Phase1bBridge.lean
@@ -1,0 +1,87 @@
+/-
+  EvmAsm.Evm64.DivMod.LimbSpec.Div128V5Phase1bBridge
+
+  The generic Phase-1b/2b **code-vs-model selection reconciliation** for the v5
+  div128 q-bridge.
+
+  The div128 code post (`div128V5SpecPost`) selects the corrected quotient digit
+  with an *outer* `rhatcHi ≠ 0` guard wrapping two unguarded D3 corrections:
+
+      bq'    = if ult rhatUn  (q*dLo)  then q+1 else q          -- 1st correction
+      q''    = if ult rhatUn' (bq'*dLo) then bq'+1 else bq'     -- 2nd correction
+      qFinal = if rhatcHi ≠ 0 then q else (if brhat'Hi = 0 then q'' else bq')
+
+  while the model `div128Quot_v5` folds the `rhatcHi = 0` guard into the *first*
+  correction's fire condition and delegates the second to
+  `div128Quot_phase2b_q0'`:
+
+      fire1  = decide (rhatcHi = 0) && ult rhatUn (q*dLo)
+      q'     = if fire1 then q+1 else q
+      qModel = div128Quot_phase2b_q0' q' rhat' dLo un
+
+  Both compute the same digit; this lemma proves it for arbitrary
+  `q rhatc dHi dLo un`, by case analysis on `rhatcHi` and the two ULTs plus the
+  `div128Quot_phase2b_q0'_and_form` rewrite.  It is the reusable heart of the
+  q-bridge `div128V5SpecPost.q = div128Quot_v5` (both the Phase-1 `q1` digit and
+  the Phase-2 `q0` digit have this exact shape).  Bead `evm-asm-wbc4i.9.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCall
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- `ite` over a conjunction unfolds to nested `ite` (common else branch). -/
+private theorem ite_and_nest {α : Sort _} (C D : Prop) [Decidable C] [Decidable D]
+    (x y : α) :
+    (if C ∧ D then x else y) = if C then (if D then x else y) else y := by
+  by_cases hC : C <;> by_cases hD : D <;> simp [hC, hD]
+
+/-- **Phase-1b/2b code = model selection.**  The code's outer-`rhatcHi`-guarded
+    two-correction selection equals the model's `phase1bFire`/`phase2b_q0'`
+    form, for arbitrary capped quotient `q`, remainder `rhatc`, and the divisor
+    halves `dHi`/`dLo` and dividend half `un`. -/
+theorem div128V5_phase1b_select_eq
+    (q rhatc dHi dLo un : Word) :
+    (if rhatc >>> (32 : BitVec 6).toNat ≠ 0 then q
+     else
+      (if ((if BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+              then rhatc + dHi else rhatc) >>> (32 : BitVec 6).toNat = 0)
+       then
+        (if BitVec.ult
+              (((if BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+                  then rhatc + dHi else rhatc) <<< (32 : BitVec 6).toNat) ||| un)
+              ((if BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+                  then q + signExtend12 4095 else q) * dLo)
+          then (if BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+                  then q + signExtend12 4095 else q) + signExtend12 4095
+          else (if BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+                  then q + signExtend12 4095 else q))
+       else (if BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+               then q + signExtend12 4095 else q)))
+    =
+    div128Quot_phase2b_q0'
+      (if decide (rhatc >>> (32 : BitVec 6).toNat = 0) &&
+            BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+       then q + signExtend12 4095 else q)
+      (if decide (rhatc >>> (32 : BitVec 6).toNat = 0) &&
+            BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+       then rhatc + dHi else rhatc)
+      dLo un := by
+  rw [← div128Quot_phase2b_q0'_and_form]
+  by_cases hHi : rhatc >>> (32 : BitVec 6).toNat = (0 : Word)
+  · -- rhatcHi = 0: outer code guard false; model fire1 = ult.
+    by_cases hUlt : BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+    · simp only [hHi, hUlt, ne_eq, not_true_eq_false, if_false, if_true,
+        decide_true, Bool.true_and]
+      rw [ite_and_nest]
+    · simp only [hHi, hUlt, ne_eq, not_true_eq_false, if_false,
+        decide_true, Bool.and_false, Bool.false_eq_true]
+      simp
+  · -- rhatcHi ≠ 0: code picks q; model fire1 = false, phase2b guard false → q.
+    simp only [hHi, ne_eq, not_false_eq_true, if_true, decide_false,
+      Bool.false_and, Bool.false_eq_true, if_false]
+    simp
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

`div128V5_phase1b_select_eq` — the **generic reconciliation at the heart of the v5 div128 q-bridge**. The div128 code post (`div128V5SpecPost`) selects the corrected quotient digit with an *outer* `rhatcHi ≠ 0` guard wrapping two unguarded D3 corrections:

```
bq'    = if ult rhatUn  (q*dLo)  then q+1 else q
q''    = if ult rhatUn' (bq'*dLo) then bq'+1 else bq'
qFinal = if rhatcHi ≠ 0 then q else (if brhat'Hi = 0 then q'' else bq')
```

while the model `div128Quot_v5` folds the `rhatcHi = 0` guard into the first correction's fire condition and delegates the second to `div128Quot_phase2b_q0'`:

```
fire1  = decide (rhatcHi = 0) && ult rhatUn (q*dLo)
q'     = if fire1 then q+1 else q
qModel = div128Quot_phase2b_q0' q' rhat' dLo un
```

Both compute the same digit; proved for arbitrary `q rhatc dHi dLo un` by case analysis on `rhatcHi` and the two ULTs plus the `div128Quot_phase2b_q0'_and_form` rewrite (and a small `ite_and_nest` helper).

## Why

This is the reusable core of the bridge `div128V5SpecPost.q = div128Quot_v5` — **both** the Phase-1 `q1` digit and the Phase-2 `q0` digit share this exact selection shape. Together with the rhatc arithmetic bridge (#7243), it reduces the full q-bridge to plugging in the concrete Phase-1/Phase-2 intermediates. The q-bridge connects the v5 loop-body execution result to the proven v5 quotient correctness (`fullDivN1QuotientWordV5 = EvmWord.div`, #7232), unblocking the n=1 lane wrapper. Bead `evm-asm-wbc4i.9.1`.

## Gates

- `lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128V5Phase1bBridge` ✓
- Full `lake build` (2488 jobs) ✓
- No `sorry`/`native_decide`/`bv_decide`; file-size + unimported checks pass (0 orphans)

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)