### PR TITLE
feat(divmod): v5 div128 Phase-1b/2b remainder selection bridge

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128V5Phase1bBridge.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128V5Phase1bBridge.lean
@@ -84,4 +84,58 @@ theorem div128V5_phase1b_select_eq
       Bool.false_and, Bool.false_eq_true, if_false]
     simp
 
+/-- **Phase-1b/2b code = model remainder selection.**  Companion to
+    `div128V5_phase1b_select_eq` for the *remainder* `rhatFinal`/`rhat''` (needed
+    for `un21 = (rhatFinal << 32 ||| un) - q1Final * dLo`).  Same case analysis,
+    via `div128Quot_phase2b_rhat_and_form`. -/
+theorem div128V5_phase1b_rhat_select_eq
+    (q rhatc dHi dLo un : Word) :
+    (if rhatc >>> (32 : BitVec 6).toNat ≠ 0 then rhatc
+     else
+      (if ((if BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+              then rhatc + dHi else rhatc) >>> (32 : BitVec 6).toNat = 0)
+       then
+        (if BitVec.ult
+              (((if BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+                  then rhatc + dHi else rhatc) <<< (32 : BitVec 6).toNat) ||| un)
+              ((if BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+                  then q + signExtend12 4095 else q) * dLo)
+          then (if BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+                  then rhatc + dHi else rhatc) + dHi
+          else (if BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+                  then rhatc + dHi else rhatc))
+       else (if BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+               then rhatc + dHi else rhatc)))
+    =
+    (if (if decide (rhatc >>> (32 : BitVec 6).toNat = 0) &&
+            BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+         then rhatc + dHi else rhatc) >>> (32 : BitVec 6).toNat = 0 then
+      let qDlo2 := (if decide (rhatc >>> (32 : BitVec 6).toNat = 0) &&
+                       BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+                    then q + signExtend12 4095 else q) * dLo
+      let rhatUn := ((if decide (rhatc >>> (32 : BitVec 6).toNat = 0) &&
+                         BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+                      then rhatc + dHi else rhatc) <<< (32 : BitVec 6).toNat) ||| un
+      if BitVec.ult rhatUn qDlo2 then
+        (if decide (rhatc >>> (32 : BitVec 6).toNat = 0) &&
+            BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+         then rhatc + dHi else rhatc) + dHi
+      else (if decide (rhatc >>> (32 : BitVec 6).toNat = 0) &&
+              BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+            then rhatc + dHi else rhatc)
+     else (if decide (rhatc >>> (32 : BitVec 6).toNat = 0) &&
+              BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+            then rhatc + dHi else rhatc)) := by
+  rw [← div128Quot_phase2b_rhat_and_form]
+  by_cases hHi : rhatc >>> (32 : BitVec 6).toNat = (0 : Word)
+  · by_cases hUlt : BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+    · simp only [hHi, hUlt, ne_eq, not_true_eq_false, if_false, if_true,
+        decide_true, Bool.true_and]
+      rw [ite_and_nest]
+    · simp only [hHi, hUlt, ne_eq, not_true_eq_false, if_false,
+        decide_true, Bool.and_false, Bool.false_eq_true]
+      simp
+  · simp only [hHi, ne_eq, not_false_eq_true, if_true, decide_false,
+      Bool.false_and, Bool.false_eq_true, if_false]
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

`div128V5_phase1b_rhat_select_eq` — the **remainder** companion to `div128V5_phase1b_select_eq` (#7244). The q-bridge's `un21 = (rhatFinal << 32 ||| un) - q1Final * dLo` step needs `rhatFinal(code) = rhat''(model)`, not just the quotient. This lemma proves the code's outer-`rhatcHi`-guarded two-correction remainder selection equals the model's `div128Quot_v5` nested-`if` remainder form, by the same case analysis as the quotient version via `div128Quot_phase2b_rhat_and_form` + the `ite_and_nest` helper.

## Context

With this, both halves of each Knuth digit step are bridged:
- **quotient** selection: `div128V5_phase1b_select_eq` (#7244)
- **remainder** selection: this PR
- **rhatc arithmetic**: `div128V5_rhatc_correction_eq` (#7243, merged)

The full q-bridge `div128V5SpecPost.q = div128Quot_v5` now reduces to instantiating these at the Phase-1 (`q1c`/`rhatc` from `uHi`/`dHi`) and Phase-2 (`q0c`/`rhat2c` from `un21`/`dHi`) intermediates and combining `q = (q1 << 32) ||| q0`. That bridge connects the v5 loop-body execution to the proven v5 quotient correctness (#7232). Bead `evm-asm-wbc4i.9.1`.

## Stacking

Based on **#7244** (quotient selection + the shared `ite_and_nest` helper).

## Gates

- `lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128V5Phase1bBridge` ✓
- Full `lake build` (2488 jobs) ✓
- No `sorry`/`native_decide`/`bv_decide`; file-size + unimported checks pass (0 orphans)

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)