### PR TITLE
feat(divmod): v5 div128 Phase-1 quotient digit bridge

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128V5DigitBridge.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128V5DigitBridge.lean
@@ -34,4 +34,89 @@ theorem div128V5_rhatc_eq (uHi q1 cap dHi : Word) :
   · rfl
   · exact div128V5_rhatc_correction_eq uHi q1 cap dHi
 
+/-- The div128 **code** quotient: a standalone copy of `div128V5SpecPost`'s
+    `q` register (the corrected 128/64 quotient as the RISC-V code computes it,
+    with the incremental capped remainders).  `div128V5SpecPost`'s `x11` is this
+    by construction (`rfl`). -/
+def div128V5CodeQuot (uHi uLo vTop : Word) : Word :=
+  let dHi := vTop >>> (32 : BitVec 6).toNat
+  let dLo := (vTop <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let un1 := uLo >>> (32 : BitVec 6).toNat
+  let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let cap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi1 = 0 then q1 else cap
+  let rhatc := if hi1 = 0 then rhat else rhat + (q1 - cap) * dHi
+  let rhatcHi := rhatc >>> (32 : BitVec 6).toNat
+  let qDlo1 := q1c * dLo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let bq1' := if BitVec.ult rhatUn1 qDlo1 then q1c + signExtend12 4095 else q1c
+  let brhat' := if BitVec.ult rhatUn1 qDlo1 then rhatc + dHi else rhatc
+  let brhat'Hi := brhat' >>> (32 : BitVec 6).toNat
+  let qDlo2 := bq1' * dLo
+  let rhatUn1' := (brhat' <<< (32 : BitVec 6).toNat) ||| un1
+  let q1'' := if BitVec.ult rhatUn1' qDlo2 then bq1' + signExtend12 4095 else bq1'
+  let rhat'' := if BitVec.ult rhatUn1' qDlo2 then brhat' + dHi else brhat'
+  let q1Final := if rhatcHi ≠ 0 then q1c else (if brhat'Hi = 0 then q1'' else bq1')
+  let rhatFinal := if rhatcHi ≠ 0 then rhatc else (if brhat'Hi = 0 then rhat'' else brhat')
+  let un21 := ((rhatFinal <<< (32 : BitVec 6).toNat) ||| un1) - q1Final * dLo
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi2 := q0 >>> (32 : BitVec 6).toNat
+  let q0c := if hi2 = 0 then q0 else cap
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + (q0 - cap) * dHi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let q0Dlo1 := q0c * dLo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+  let bq0' := if BitVec.ult rhat2Un0 q0Dlo1 then q0c + signExtend12 4095 else q0c
+  let brhat2' := if BitVec.ult rhat2Un0 q0Dlo1 then rhat2c + dHi else rhat2c
+  let brhat2'Hi := brhat2' >>> (32 : BitVec 6).toNat
+  let q0Dlo2 := bq0' * dLo
+  let rhat2'Un0 := (brhat2' <<< (32 : BitVec 6).toNat) ||| un0
+  let q0'' := if BitVec.ult rhat2'Un0 q0Dlo2 then bq0' + signExtend12 4095 else bq0'
+  let q0Final := if rhat2cHi ≠ 0 then q0c else (if brhat2'Hi = 0 then q0'' else bq0')
+  (q1Final <<< (32 : BitVec 6).toNat) ||| q0Final
+
+/-- Phase-1 of the q-bridge: the code's corrected Phase-1 trial quotient digit
+    `q1Final` equals the model's `q1''`.  Combines the capped-remainder bridge
+    `div128V5_rhatc_eq` (rewriting the incremental `rhatc` to the model's closed
+    form) with the selection reconciliation `div128V5_phase1b_select_eq`. -/
+theorem div128V5_q1Final_eq_model (uHi dHi dLo un1 : Word) :
+    (let cap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+     let q1 := rv64_divu uHi dHi
+     let rhat := uHi - q1 * dHi
+     let hi1 := q1 >>> (32 : BitVec 6).toNat
+     let q1c := if hi1 = 0 then q1 else cap
+     let rhatc := if hi1 = 0 then rhat else rhat + (q1 - cap) * dHi
+     let rhatcHi := rhatc >>> (32 : BitVec 6).toNat
+     let qDlo1 := q1c * dLo
+     let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+     let bq1' := if BitVec.ult rhatUn1 qDlo1 then q1c + signExtend12 4095 else q1c
+     let brhat' := if BitVec.ult rhatUn1 qDlo1 then rhatc + dHi else rhatc
+     let brhat'Hi := brhat' >>> (32 : BitVec 6).toNat
+     let qDlo2 := bq1' * dLo
+     let rhatUn1' := (brhat' <<< (32 : BitVec 6).toNat) ||| un1
+     let q1'' := if BitVec.ult rhatUn1' qDlo2 then bq1' + signExtend12 4095 else bq1'
+     if rhatcHi ≠ 0 then q1c else (if brhat'Hi = 0 then q1'' else bq1'))
+    =
+    (let cap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+     let q1 := rv64_divu uHi dHi
+     let rhat := uHi - q1 * dHi
+     let hi1 := q1 >>> (32 : BitVec 6).toNat
+     let q1c := if hi1 = 0 then q1 else cap
+     let rhatc := if hi1 = 0 then rhat else uHi - q1c * dHi
+     let qDlo := q1c * dLo
+     let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+     let phase1bFire1 :=
+       decide (rhatc >>> (32 : BitVec 6).toNat = 0) && BitVec.ult rhatUn1 qDlo
+     let q1' := if phase1bFire1 then q1c + signExtend12 4095 else q1c
+     let rhat' := if phase1bFire1 then rhatc + dHi else rhatc
+     div128Quot_phase2b_q0' q1' rhat' dLo un1) := by
+  dsimp only
+  rw [div128V5_rhatc_eq uHi (rv64_divu uHi dHi)
+    ((BitVec.allOnes 64) >>> (32 : BitVec 6).toNat) dHi]
+  exact div128V5_phase1b_select_eq _ _ dHi dLo un1
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

`div128V5CodeQuot` (a standalone copy of `div128V5SpecPost`'s `q` register — the corrected 128/64 quotient as the RISC-V code computes it) and `div128V5_q1Final_eq_model`, which proves the **code's corrected Phase-1 trial quotient digit `q1Final` equals the model's `q1''`** — the first of the two digit bridges composing the full q-bridge `div128V5SpecPost.q = div128Quot_v5`.

## Proof

Composes two of the now-proven cores:
- `div128V5_rhatc_eq` (#7247 base) — rewrites the code's incremental `rhatc = rhat + (q1-cap)·dHi` to the model's closed `uHi - q1c·dHi`;
- `div128V5_phase1b_select_eq` (#7244) — the quotient selection reconciliation.

After `rw [div128V5_rhatc_eq]`, the code form is exactly `div128V5_phase1b_select_eq`'s LHS, so the proof closes with `exact`. This is the template for the Phase-2 q0 digit bridge (which additionally needs `div128Quot_phase2b_q0'_and_form` for the asymmetric first correction) and the final `q = (q1''<<32)|q0''` combine. Bead `evm-asm-wbc4i.9.1`.

## Stacking

Based on **#7247** (which carries #7243/#7244/#7245).

## Gates

- `lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128V5DigitBridge` ✓
- Full `lake build` (2501 jobs) ✓
- No `sorry`/`native_decide`/`bv_decide`; file-size + unimported checks pass (0 orphans)

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)