### PR TITLE
feat(divmod): v5 div128 Phase-1 remainder digit bridge

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128V5DigitBridge.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128V5DigitBridge.lean
@@ -119,4 +119,48 @@ theorem div128V5_q1Final_eq_model (uHi dHi dLo un1 : Word) :
     ((BitVec.allOnes 64) >>> (32 : BitVec 6).toNat) dHi]
   exact div128V5_phase1b_select_eq _ _ dHi dLo un1
 
+/-- Phase-1 of the q-bridge, remainder side: the code's corrected Phase-1
+    remainder `rhatFinal` equals the model's `rhat''` (needed for `un21`).
+    Same template as `div128V5_q1Final_eq_model`, via `div128V5_rhatc_eq` +
+    `div128V5_phase1b_rhat_select_eq`. -/
+theorem div128V5_rhatFinal_eq_model (uHi dHi dLo un1 : Word) :
+    (let cap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+     let q1 := rv64_divu uHi dHi
+     let rhat := uHi - q1 * dHi
+     let hi1 := q1 >>> (32 : BitVec 6).toNat
+     let q1c := if hi1 = 0 then q1 else cap
+     let rhatc := if hi1 = 0 then rhat else rhat + (q1 - cap) * dHi
+     let rhatcHi := rhatc >>> (32 : BitVec 6).toNat
+     let qDlo1 := q1c * dLo
+     let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+     let bq1' := if BitVec.ult rhatUn1 qDlo1 then q1c + signExtend12 4095 else q1c
+     let brhat' := if BitVec.ult rhatUn1 qDlo1 then rhatc + dHi else rhatc
+     let brhat'Hi := brhat' >>> (32 : BitVec 6).toNat
+     let qDlo2 := bq1' * dLo
+     let rhatUn1' := (brhat' <<< (32 : BitVec 6).toNat) ||| un1
+     let rhat'' := if BitVec.ult rhatUn1' qDlo2 then brhat' + dHi else brhat'
+     if rhatcHi ≠ 0 then rhatc else (if brhat'Hi = 0 then rhat'' else brhat'))
+    =
+    (let cap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+     let q1 := rv64_divu uHi dHi
+     let rhat := uHi - q1 * dHi
+     let hi1 := q1 >>> (32 : BitVec 6).toNat
+     let q1c := if hi1 = 0 then q1 else cap
+     let rhatc := if hi1 = 0 then rhat else uHi - q1c * dHi
+     let qDlo := q1c * dLo
+     let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+     let phase1bFire1 :=
+       decide (rhatc >>> (32 : BitVec 6).toNat = 0) && BitVec.ult rhatUn1 qDlo
+     let q1' := if phase1bFire1 then q1c + signExtend12 4095 else q1c
+     let rhat' := if phase1bFire1 then rhatc + dHi else rhatc
+     if rhat' >>> (32 : BitVec 6).toNat = 0 then
+       let qDlo2 := q1' * dLo
+       let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+       if BitVec.ult rhatUn1' qDlo2 then rhat' + dHi else rhat'
+     else rhat') := by
+  dsimp only
+  rw [div128V5_rhatc_eq uHi (rv64_divu uHi dHi)
+    ((BitVec.allOnes 64) >>> (32 : BitVec 6).toNat) dHi]
+  exact div128V5_phase1b_rhat_select_eq _ _ dHi dLo un1
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

`div128V5_rhatFinal_eq_model` — the code's corrected Phase-1 remainder `rhatFinal` equals the model's `rhat''`, completing the **Phase-1 half** of the per-digit q-bridge (the quotient side `q1Final` was #7248).

Same template as #7248: `rw [div128V5_rhatc_eq]` (incremental rhatc → model closed form), then `exact div128V5_phase1b_rhat_select_eq _ _ dHi dLo un1` (#7245).

## Why

With both Phase-1 digit equalities (`q1Final = q1''`, `rhatFinal = rhat''`) proven, the Phase-2 input `un21 = (rhatFinal << 32 ||| un1) - q1Final * dLo` agrees between code and model. The remaining q-bridge work is the Phase-2 `q0Final = q0''` digit (same template, but its model 1st-correction uses the `div128Quot_phase2b_q0'` primitive — needs `…_and_form`) and the `q = (q1''<<32)|q0''` combine, after which `div128V5CodeQuot = div128Quot_v5 = divKTrialCallV5QHat` (last `=` already proven). Bead `evm-asm-wbc4i.9.1`.

## Stacking

Based on **#7248** (which carries #7243/#7244/#7245/#7247 + the q1Final digit).

## Gates

- `lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128V5DigitBridge` ✓
- Full `lake build` (2501 jobs) ✓
- No `sorry`/`native_decide`/`bv_decide`; file-size + unimported checks pass (0 orphans)

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)