### PR TITLE
feat(divmod): v5 n1 loop-body skip post (brick 6 scaffold)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -62,6 +62,7 @@ import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5CodeModelBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5Phase1bBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5DigitBridge
 import EvmAsm.Evm64.DivMod.Spec.N1V5CodeQuotNoBorrow
+import EvmAsm.Evm64.DivMod.LoopIterN1.CallV5NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.LoopUnifiedN1.CallIter210NoNop
 import EvmAsm.Evm64.DivMod.LoopUnifiedN1.UnifiedNoNop

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallV5NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallV5NoNop.lean
@@ -1,0 +1,45 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopIterN1.CallV5NoNop
+
+  v5 n=1 call+skip loop-body postcondition (j = 0), the target of brick 6
+  (`divK_loop_body_n1_call_skip_j0_v5_spec_within_noNop`).
+
+  Mirror of `loopBodyN1CallSkipJ0PostV4` (LoopIterN1/Call.lean), with the trial
+  quotient digit being the v5 trial `divKTrialCallV5QHat` (= `div128Quot_v5`,
+  the exact floor) instead of the v4 trial.  The loop-body PRE
+  (`loopBodyN1CallSkipJ0PreV4`) is version-agnostic (no `divKTrialCallV4*`
+  references) and is reused directly for v5.  Bead `evm-asm-wbc4i.9.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopIterN1.Call
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCallV5
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v5 trial scratch-cell exit value (mirror of `divKTrialCallV4ScratchOut`):
+    the Phase-2a capped remainder `rhat2c`, or the prior scratch when the
+    high-correction guard fired. -/
+def divKTrialCallV5ScratchOut (uHi uLo vTop scratchMem : Word) : Word :=
+  let rhat2c := divKTrialCallV5Rhat2c uHi uLo vTop
+  if rhat2c >>> (32 : BitVec 6).toNat ≠ 0 then scratchMem else rhat2c
+
+/-- v5 n=1 call+skip j=0 loop-body post: the digit `divKTrialCallV5QHat`
+    (= exact `div128Quot_v5`) is stored, the dividend window updated by the
+    no-borrow single-limb mulsub, and the div128 scratch cells settled. -/
+@[irreducible]
+def loopBodyN1CallSkipJ0PostV5
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV5DLo v0
+  let div_un0 := divKTrialCallV5Un0 u0
+  let qHat := divKTrialCallV5QHat u1 u0 v0
+  loopBodyN1SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v0) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3936 ↦ₘ divKTrialCallV5ScratchOut u1 u0 v0 scratchMem) **
+  regOwn .x1
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

`divKTrialCallV5ScratchOut` and `loopBodyN1CallSkipJ0PostV5` — the **target post** for brick 6 (`divK_loop_body_n1_call_skip_j0_v5`). Mirror of `loopBodyN1CallSkipJ0PostV4`, with the trial digit being the v5 exact trial `divKTrialCallV5QHat` (= `div128Quot_v5`).

## Why this is all brick 6 needs (besides the composition)

- The loop-body **PRE** (`loopBodyN1CallSkipJ0PreV4`) references no `divKTrialCallV4*` defs — it's version-agnostic — so it's reused directly for v5.
- The v5 **MCS** (`divK_mulsub_correction_skip_v5`, #7238) and **SL** (`divK_store_loop_j0_v5`, #7239) share the exact v4 interface.
- So brick 6 = compose TF (#7237) + MCS + SL, `PreV4 → loopBodyN1CallSkipJ0PostV5`.

## Next (brick 6 composition)

Mirror `divK_loop_body_n1_call_skip_j0_v4_spec_within_noNop` (CallV4NoNop.lean:182). The one new wrinkle vs v4: the v5 TF post is `div128V5SpecPost` (raw registers) rather than named `divKTrialCallV4*` defs, so the composition needs a `div128V5SpecPost`→named-register view (`x11 = divKTrialCallV5QHat` via #7252, etc.) to feed the MCS pre by `xperm`. `hborrow` comes from `mulsubN4NoBorrow_div128V5CodeQuot_of_norm_call` (#7252). Bead `evm-asm-wbc4i.9.1`.

## Stacking

Based on **#7252**.

## Gates

- `lake build EvmAsm.Evm64.DivMod.LoopIterN1.CallV5NoNop` ✓
- Full `lake build` (2503 jobs) ✓
- No `sorry`/`native_decide`/`bv_decide`; file-size + unimported checks pass (0 orphans)

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)