### PR TITLE
feat(divmod): v5 trial X7Exit/X9Exit compact exit defs

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallV5NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallV5NoNop.lean
@@ -25,6 +25,45 @@ def divKTrialCallV5ScratchOut (uHi uLo vTop scratchMem : Word) : Word :=
   let rhat2c := divKTrialCallV5Rhat2c uHi uLo vTop
   if rhat2c >>> (32 : BitVec 6).toNat ≠ 0 then scratchMem else rhat2c
 
+/-- v5 trial `x7` exit value, in **compact** form over the irreducible v5
+    sub-defs (`divKTrialCallV5Un21`/`Rhat2c`/`Q0c`).  Mirror of
+    `divKTrialCallV4X7Exit`; needed for the compact NAMED trial-call-full post
+    that resolves the brick-6 term-size wall (memory: v5-execlayer-termsize-wall). -/
+def divKTrialCallV5X7Exit (uHi uLo vTop : Word) : Word :=
+  let dHi := divKTrialCallV5DHi vTop
+  let dLo := divKTrialCallV5DLo vTop
+  let un0 := divKTrialCallV5Un0 uLo
+  let un21 := divKTrialCallV5Un21 uHi uLo vTop
+  let cap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+  let q0 := rv64_divu un21 dHi
+  let hi2 := q0 >>> (32 : BitVec 6).toNat
+  let x7o := if hi2 = 0 then un21 else (q0 - cap) * dHi
+  let rhat2c := divKTrialCallV5Rhat2c uHi uLo vTop
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let q0c := divKTrialCallV5Q0c uHi uLo vTop
+  let q0Dlo1 := q0c * dLo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+  let bq0' := if BitVec.ult rhat2Un0 q0Dlo1 then q0c + signExtend12 4095 else q0c
+  let brhat2' := if BitVec.ult rhat2Un0 q0Dlo1 then rhat2c + dHi else rhat2c
+  let brhat2'Hi := brhat2' >>> (32 : BitVec 6).toNat
+  let q0Dlo2 := bq0' * dLo
+  if rhat2cHi ≠ 0 then x7o else (if brhat2'Hi = 0 then q0Dlo2 else q0Dlo1)
+
+/-- v5 trial `x9` exit value, compact form.  Mirror of `divKTrialCallV4X9Exit`. -/
+def divKTrialCallV5X9Exit (uHi uLo vTop : Word) : Word :=
+  let dHi := divKTrialCallV5DHi vTop
+  let dLo := divKTrialCallV5DLo vTop
+  let un0 := divKTrialCallV5Un0 uLo
+  let rhat2c := divKTrialCallV5Rhat2c uHi uLo vTop
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let q0c := divKTrialCallV5Q0c uHi uLo vTop
+  let q0Dlo1 := q0c * dLo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+  let brhat2' := if BitVec.ult rhat2Un0 q0Dlo1 then rhat2c + dHi else rhat2c
+  let brhat2'Hi := brhat2' >>> (32 : BitVec 6).toNat
+  let rhat2'Un0 := (brhat2' <<< (32 : BitVec 6).toNat) ||| un0
+  if rhat2cHi ≠ 0 then rhat2cHi else (if brhat2'Hi = 0 then rhat2'Un0 else brhat2'Hi)
+
 /-- v5 n=1 call+skip j=0 loop-body post: the digit `divKTrialCallV5QHat`
     (= exact `div128Quot_v5`) is stored, the dividend window updated by the
     no-borrow single-limb mulsub, and the div128 scratch cells settled. -/


### PR DESCRIPTION
## Summary

`divKTrialCallV5X7Exit` and `divKTrialCallV5X9Exit` — the v5 trial's `x7`/`x9` register exit values, in **compact** form over the irreducible v5 sub-defs (`divKTrialCallV5Un21`/`Rhat2c`/`Q0c`). Mirrors of `divKTrialCallV4X7Exit`/`X9Exit`.

## Why

These complete the named-register set (with `divKTrialCallV5QHat`/`Q1dd`/`Q0dd`/`DHi`/`DLo`/`Un0`/`ScratchOut`) needed for a **compact NAMED trial-call-full post** — the resolution to the brick-6 term-size wall found this session: composing the v5 loop body directly over the raw `div128V5SpecPost` `x11` quotient blows up (`dsimp` → heartbeat; `simp`-named → 83K-char goal), because v5's irreducible defs can't fold compactly the way v4's reducible defs do. A compact named post keeps the composition terms small (like v4). See memory `project-v5-execlayer-termsize-wall`. Bead `evm-asm-wbc4i.9.1`.

## Stacking

Based on **#7253** (which has `divKTrialCallV5ScratchOut` + `loopBodyN1CallSkipJ0PostV5`).

## Gates

- `lake build EvmAsm.Evm64.DivMod.LoopIterN1.CallV5NoNop` ✓
- Full `lake build` (2503 jobs) ✓
- No `sorry`/`native_decide`/`bv_decide`; file-size + unimported checks pass (0 orphans)

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)