### PR TITLE
feat(divmod): v5 un21 = divKTrialCallV5Un21 bridge

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128V5FinalEqNamed.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128V5FinalEqNamed.lean
@@ -65,4 +65,48 @@ theorem div128V5_rhatFinal_eq_Rhatdd (u1 u0 v0 : Word) :
     (divKTrialCallV5Un1 u0)]
   exact (divKTrialCallV5Rhatdd_eq_phase2b u1 u0 v0).symm
 
+/-- The div128 code's Phase-2 setup value `un21` equals the named
+    `divKTrialCallV5Un21` — a `congr` consequence of the Phase-1 digit bridges
+    `div128V5_rhatFinal_eq_Rhatdd` and `div128V5_q1Final_eq_Q1dd`. -/
+theorem div128V5_un21_eq (u1 u0 v0 : Word) :
+    (((let cap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+       let q1 := rv64_divu u1 (divKTrialCallV5DHi v0)
+       let rhat := u1 - q1 * divKTrialCallV5DHi v0
+       let hi1 := q1 >>> (32 : BitVec 6).toNat
+       let q1c := if hi1 = 0 then q1 else cap
+       let rhatc := if hi1 = 0 then rhat else rhat + (q1 - cap) * divKTrialCallV5DHi v0
+       let rhatcHi := rhatc >>> (32 : BitVec 6).toNat
+       let qDlo1 := q1c * divKTrialCallV5DLo v0
+       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| divKTrialCallV5Un1 u0
+       let bq1' := if BitVec.ult rhatUn1 qDlo1 then q1c + signExtend12 4095 else q1c
+       let brhat' := if BitVec.ult rhatUn1 qDlo1 then rhatc + divKTrialCallV5DHi v0 else rhatc
+       let brhat'Hi := brhat' >>> (32 : BitVec 6).toNat
+       let qDlo2 := bq1' * divKTrialCallV5DLo v0
+       let rhatUn1' := (brhat' <<< (32 : BitVec 6).toNat) ||| divKTrialCallV5Un1 u0
+       let rhat'' := if BitVec.ult rhatUn1' qDlo2 then brhat' + divKTrialCallV5DHi v0 else brhat'
+       if rhatcHi ≠ 0 then rhatc else (if brhat'Hi = 0 then rhat'' else brhat'))
+        <<< (32 : BitVec 6).toNat) ||| divKTrialCallV5Un1 u0)
+    -
+    ((let cap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+      let q1 := rv64_divu u1 (divKTrialCallV5DHi v0)
+      let rhat := u1 - q1 * divKTrialCallV5DHi v0
+      let hi1 := q1 >>> (32 : BitVec 6).toNat
+      let q1c := if hi1 = 0 then q1 else cap
+      let rhatc := if hi1 = 0 then rhat else rhat + (q1 - cap) * divKTrialCallV5DHi v0
+      let rhatcHi := rhatc >>> (32 : BitVec 6).toNat
+      let qDlo1 := q1c * divKTrialCallV5DLo v0
+      let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| divKTrialCallV5Un1 u0
+      let bq1' := if BitVec.ult rhatUn1 qDlo1 then q1c + signExtend12 4095 else q1c
+      let brhat' := if BitVec.ult rhatUn1 qDlo1 then rhatc + divKTrialCallV5DHi v0 else rhatc
+      let brhat'Hi := brhat' >>> (32 : BitVec 6).toNat
+      let qDlo2 := bq1' * divKTrialCallV5DLo v0
+      let rhatUn1' := (brhat' <<< (32 : BitVec 6).toNat) ||| divKTrialCallV5Un1 u0
+      let q1'' := if BitVec.ult rhatUn1' qDlo2 then bq1' + signExtend12 4095 else bq1'
+      if rhatcHi ≠ 0 then q1c else (if brhat'Hi = 0 then q1'' else bq1'))
+      * divKTrialCallV5DLo v0)
+    = divKTrialCallV5Un21 u1 u0 v0 := by
+  rw [div128V5_rhatFinal_eq_Rhatdd u1 u0 v0, div128V5_q1Final_eq_Q1dd u1 u0 v0]
+  unfold divKTrialCallV5Un21
+  rfl
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

`div128V5_un21_eq`: the div128 code's Phase-2 setup value `un21 = (rhatFinal << 32 ||| un1) - q1Final * dLo` equals the named `divKTrialCallV5Un21`.

A `congr` consequence of the Phase-1 digit bridges `div128V5_rhatFinal_eq_Rhatdd` and `div128V5_q1Final_eq_Q1dd` (#7256): rewrite the two code shapes to the named `Rhatdd`/`Q1dd`, `unfold divKTrialCallV5Un21`, `rfl`.

## Why

`un21` is the Phase-2 dividend; this bridge is the foundation for the Phase-2 `rhat2c`/`q0c` and `x7Exit`/`x9Exit` raw=named bridges that give `divK_trial_call_full_v5` a compact NAMED post — the resolution of the brick-6 term-size wall. Bead `evm-asm-wbc4i.9.1`.

## Stacking

Based on **#7256** (the `q1Final=Q1dd` / `rhatFinal=Rhatdd` connectors).

## Gates

- `lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128V5FinalEqNamed` ✓
- Full `lake build` (2504 jobs) ✓
- No `sorry`/`native_decide`/`bv_decide`; file-size + unimported checks pass (0 orphans)

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)