### PR TITLE
feat(divmod): v5 Phase-2 x7Exit/x9Exit = named bridges

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -64,6 +64,7 @@ import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5DigitBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5FinalEqNamed
 import EvmAsm.Evm64.DivMod.Spec.N1V5CodeQuotNoBorrow
 import EvmAsm.Evm64.DivMod.LoopIterN1.CallV5NoNop
+import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5X7X9Eq
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.LoopUnifiedN1.CallIter210NoNop
 import EvmAsm.Evm64.DivMod.LoopUnifiedN1.UnifiedNoNop

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128V5X7X9Eq.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128V5X7X9Eq.lean
@@ -1,0 +1,73 @@
+/-
+  EvmAsm.Evm64.DivMod.LimbSpec.Div128V5X7X9Eq
+
+  The div128 code's Phase-2 exit registers `x7Exit` / `x9Exit` (incremental
+  forms, as in `div128V5SpecPost`, over the named `un21`) equal the compact
+  named `divKTrialCallV5X7Exit` / `divKTrialCallV5X9Exit`.  Obtained by unfolding
+  the named exit defs and rewriting their `divKTrialCallV5Rhat2c` / `Q0c` back to
+  the incremental code forms via `div128V5_rhat2c_eq` / `div128V5_q0c_eq`
+  (#7258).  With the Phase-1 / un21 / rhat2c / q0c bridges, these name the last
+  div128V5SpecPost registers, completing the inputs to a compact NAMED
+  trial-call-full post (brick 6).  Bead `evm-asm-wbc4i.9.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5FinalEqNamed
+import EvmAsm.Evm64.DivMod.LoopIterN1.CallV5NoNop
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- `divKTrialCallV5X9Exit` in the incremental code form (matching
+    `div128V5SpecPost`'s `x9Exit` over the named `un21`). -/
+theorem div128V5_x9Exit_eq (u1 u0 v0 : Word) :
+    divKTrialCallV5X9Exit u1 u0 v0 =
+    (let dHi := divKTrialCallV5DHi v0
+     let dLo := divKTrialCallV5DLo v0
+     let un0 := divKTrialCallV5Un0 u0
+     let un21 := divKTrialCallV5Un21 u1 u0 v0
+     let q0 := rv64_divu un21 dHi
+     let rhat2 := un21 - q0 * dHi
+     let hi2 := q0 >>> (32 : BitVec 6).toNat
+     let cap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + (q0 - cap) * dHi
+     let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+     let q0c := if hi2 = 0 then q0 else cap
+     let q0Dlo1 := q0c * dLo
+     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+     let brhat2' := if BitVec.ult rhat2Un0 q0Dlo1 then rhat2c + dHi else rhat2c
+     let brhat2'Hi := brhat2' >>> (32 : BitVec 6).toNat
+     let rhat2'Un0 := (brhat2' <<< (32 : BitVec 6).toNat) ||| un0
+     if rhat2cHi ≠ 0 then rhat2cHi else (if brhat2'Hi = 0 then rhat2'Un0 else brhat2'Hi)) := by
+  unfold divKTrialCallV5X9Exit
+  dsimp only
+  rw [← div128V5_rhat2c_eq u1 u0 v0, ← div128V5_q0c_eq u1 u0 v0]
+
+/-- `divKTrialCallV5X7Exit` in the incremental code form (matching
+    `div128V5SpecPost`'s `x7Exit` over the named `un21`). -/
+theorem div128V5_x7Exit_eq (u1 u0 v0 : Word) :
+    divKTrialCallV5X7Exit u1 u0 v0 =
+    (let dHi := divKTrialCallV5DHi v0
+     let dLo := divKTrialCallV5DLo v0
+     let un0 := divKTrialCallV5Un0 u0
+     let un21 := divKTrialCallV5Un21 u1 u0 v0
+     let q0 := rv64_divu un21 dHi
+     let rhat2 := un21 - q0 * dHi
+     let hi2 := q0 >>> (32 : BitVec 6).toNat
+     let cap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+     let x7o := if hi2 = 0 then un21 else (q0 - cap) * dHi
+     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + (q0 - cap) * dHi
+     let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+     let q0c := if hi2 = 0 then q0 else cap
+     let q0Dlo1 := q0c * dLo
+     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+     let bq0' := if BitVec.ult rhat2Un0 q0Dlo1 then q0c + signExtend12 4095 else q0c
+     let brhat2' := if BitVec.ult rhat2Un0 q0Dlo1 then rhat2c + dHi else rhat2c
+     let brhat2'Hi := brhat2' >>> (32 : BitVec 6).toNat
+     let q0Dlo2 := bq0' * dLo
+     if rhat2cHi ≠ 0 then x7o else (if brhat2'Hi = 0 then q0Dlo2 else q0Dlo1)) := by
+  unfold divKTrialCallV5X7Exit
+  dsimp only
+  rw [← div128V5_rhat2c_eq u1 u0 v0, ← div128V5_q0c_eq u1 u0 v0]
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

`div128V5_x7Exit_eq` and `div128V5_x9Exit_eq`: the named compact exit defs `divKTrialCallV5X7Exit`/`X9Exit` (#7254) equal the div128 code's incremental Phase-2 x7/x9 exit forms (as in `div128V5SpecPost`, over the named `un21`). Proved by unfolding the named exit defs and rewriting their `divKTrialCallV5Rhat2c`/`Q0c` to the incremental code forms via `div128V5_rhat2c_eq`/`q0c_eq` (#7258).

## Significance — the register-bridge set is complete

For naming `div128V5SpecPost`'s registers (to give `divK_trial_call_full_v5` a compact NAMED post, resolving the brick-6 term-size wall):
- x10 `q1Final = Q1dd`, x7-rem `rhatFinal = Rhatdd` (#7256)
- `un21 = divKTrialCallV5Un21` (#7257)
- x?-Phase2a `rhat2c = Rhat2c`, `q0c = Q0c` (#7258)
- **x7 `x7Exit`, x9 `x9Exit` (this PR)**
- x11 `q = divKTrialCallV5QHat` (#7252, merged); x6 `dHi = DHi` (defeq); x5 `q0Final` via the model form (`div128V5_q0Final_eq_model`).

Next: define `divKTrialCallFullPostV5Named`, prove `divK_trial_call_full_v5` produces it (weaken via these bridges), then the brick-6 composition. Bead `evm-asm-wbc4i.9.1`.

## Stacking

Based on **#7258** (`rhat2c`/`q0c` bridges). Uses `divKTrialCallV5X7Exit`/`X9Exit` from the merged #7254.

## Gates

- `lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128V5X7X9Eq` ✓
- Full `lake build` (2505 jobs) ✓
- No `sorry`/`native_decide`/`bv_decide`; file-size + unimported checks pass (0 orphans)

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)