### PR TITLE
feat(divmod): v5 q0Final = Q0dd bridge (register set complete)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128V5FinalEqNamed.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128V5FinalEqNamed.lean
@@ -142,4 +142,46 @@ theorem div128V5_q0c_eq (u1 u0 v0 : Word) :
   unfold divKTrialCallV5Q0c
   rfl
 
+/-- The Phase-2a capped remainder in **closed** form (`un21 - q0c·dHi`, as the
+    model `div128V5_q0Final_eq_model` writes it) equals `divKTrialCallV5Rhat2c`.
+    (Distinct from `div128V5_rhat2c_eq`, the incremental code form.) -/
+theorem div128V5_rhat2c_closed_eq (u1 u0 v0 : Word) :
+    (let dHi := divKTrialCallV5DHi v0
+     let un21 := divKTrialCallV5Un21 u1 u0 v0
+     let q0 := rv64_divu un21 dHi
+     let rhat2 := un21 - q0 * dHi
+     let hi2 := q0 >>> (32 : BitVec 6).toNat
+     let cap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+     let q0c := if hi2 = 0 then q0 else cap
+     if hi2 = 0 then rhat2 else un21 - q0c * dHi)
+    = divKTrialCallV5Rhat2c u1 u0 v0 := by
+  unfold divKTrialCallV5Rhat2c
+  dsimp only
+  split <;> rfl
+
+/-- The div128 code's Phase-2 corrected quotient digit `q0Final` equals the named
+    `divKTrialCallV5Q0dd` — the last register-name bridge for `div128V5SpecPost`. -/
+theorem div128V5_q0Final_eq_Q0dd (u1 u0 v0 : Word) :
+    (let cap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
+     let q0 := rv64_divu (divKTrialCallV5Un21 u1 u0 v0) (divKTrialCallV5DHi v0)
+     let rhat2 := divKTrialCallV5Un21 u1 u0 v0 - q0 * divKTrialCallV5DHi v0
+     let hi2 := q0 >>> (32 : BitVec 6).toNat
+     let q0c := if hi2 = 0 then q0 else cap
+     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + (q0 - cap) * divKTrialCallV5DHi v0
+     let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+     let qDlo1 := q0c * divKTrialCallV5DLo v0
+     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| divKTrialCallV5Un0 u0
+     let bq0' := if BitVec.ult rhat2Un0 qDlo1 then q0c + signExtend12 4095 else q0c
+     let brhat2' := if BitVec.ult rhat2Un0 qDlo1 then rhat2c + divKTrialCallV5DHi v0 else rhat2c
+     let brhat2'Hi := brhat2' >>> (32 : BitVec 6).toNat
+     let qDlo2 := bq0' * divKTrialCallV5DLo v0
+     let rhat2'Un0 := (brhat2' <<< (32 : BitVec 6).toNat) ||| divKTrialCallV5Un0 u0
+     let q0'' := if BitVec.ult rhat2'Un0 qDlo2 then bq0' + signExtend12 4095 else bq0'
+     if rhat2cHi ≠ 0 then q0c else (if brhat2'Hi = 0 then q0'' else bq0'))
+    = divKTrialCallV5Q0dd u1 u0 v0 := by
+  rw [div128V5_q0Final_eq_model (divKTrialCallV5Un21 u1 u0 v0) (divKTrialCallV5DHi v0)
+    (divKTrialCallV5DLo v0) (divKTrialCallV5Un0 u0)]
+  unfold divKTrialCallV5Q0dd divKTrialCallV5Q0d divKTrialCallV5Rhat2d
+  simp only [← div128V5_q0c_eq u1 u0 v0, ← div128V5_rhat2c_closed_eq u1 u0 v0]
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

`div128V5_rhat2c_closed_eq` (Phase-2a remainder closed model form `un21 - q0c·dHi` = `divKTrialCallV5Rhat2c`, via `split`) and `div128V5_q0Final_eq_Q0dd` (code Phase-2 quotient digit `q0Final` = `divKTrialCallV5Q0dd`): rewrite via `div128V5_q0Final_eq_model` then fold the model `q0''` into `Q0dd` using the q0c/rhat2c-closed bridges.

## Significance — the register-name set for `div128V5SpecPost` is complete

| register | named def | PR |
|---|---|---|
| x11 (`q`) | `divKTrialCallV5QHat` | #7252 |
| x10 (`q1Final`) | `Q1dd` | #7256 |
| **x5 (`q0Final`)** | **`Q0dd`** | **this PR** |
| `un21` | `divKTrialCallV5Un21` | #7257 |
| `rhat2c`/`q0c` | `Rhat2c`/`Q0c` | #7258 |
| x7/x9 (`x7Exit`/`x9Exit`) | `X7Exit`/`X9Exit` | #7259 |
| x6 (`dHi`) | `DHi` | defeq |

With these, `divK_trial_call_full_v5` can be given a fully-compact NAMED post — the brick-6 unblock (the term-size wall came from the un-named raw quotient). Bead `evm-asm-wbc4i.9.1`.

## Gates

- `lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128V5FinalEqNamed` ✓
- Full `lake build` (2504 jobs) ✓
- No `sorry`/`native_decide`/`bv_decide`; file-size + unimported checks pass (0 orphans)

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)