### PR TITLE
feat(divmod): v5 trial-call-full post weaken to compact named (brick-6 wall resolved)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialCallFullV5Named.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialCallFullV5Named.lean
@@ -12,6 +12,10 @@
 -/
 
 import EvmAsm.Evm64.DivMod.LoopIterN1.CallV5NoNop
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCallFullV5
+import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5FinalEqNamed
+import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5X7X9Eq
+import EvmAsm.Evm64.DivMod.Spec.N1V5CodeQuotNoBorrow
 
 namespace EvmAsm.Evm64
 
@@ -42,5 +46,25 @@ def divKTrialCallFullPostV5Named (sp j n uHi uLo vTop base scratchMem : Word) : 
   (sp + signExtend12 3952 ↦ₘ dLo) **
   (sp + signExtend12 3944 ↦ₘ un0Div) **
   (sp + signExtend12 3936 ↦ₘ divKTrialCallV5ScratchOut uHi uLo vTop scratchMem)
+
+/-- Weaken the raw v5 trial-call-full post (`div128V5SpecPost ** trial-frame`,
+    huge Knuth-D quotient terms) to the compact NAMED post. -/
+theorem divKTrialCallFullPostV5_imp_named
+    (sp j n uHi uLo vTop base scratchMem : Word) :
+    ∀ h, divKTrialCallFullPostV5 sp j n uHi uLo vTop base scratchMem h →
+      divKTrialCallFullPostV5Named sp j n uHi uLo vTop base scratchMem h := by
+  intro h hq
+  unfold divKTrialCallFullPostV5 div128V5SpecPost at hq
+  unfold divKTrialCallFullPostV5Named
+  rw [← div128V5_q1Final_eq_Q1dd uHi uLo vTop,
+      ← div128V5_q0Final_eq_Q0dd uHi uLo vTop,
+      div128V5_x7Exit_eq uHi uLo vTop,
+      div128V5_x9Exit_eq uHi uLo vTop,
+      ← div128V5CodeQuot_eq_divKTrialCallV5QHat uHi uLo vTop]
+  unfold divKTrialCallV5ScratchOut
+  rw [← div128V5_rhat2c_eq uHi uLo vTop, ← div128V5_un21_eq uHi uLo vTop]
+  unfold div128V5CodeQuot divKTrialCallV5DHi divKTrialCallV5DLo
+    divKTrialCallV5Un0 divKTrialCallV5Un1
+  xperm_hyp hq
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Resolves the **brick-6 term-size wall** (memory: `v5-execlayer-termsize-wall`).

Proves `divKTrialCallFullPostV5_imp_named`: the raw v5 trial-call-full post `div128V5SpecPost ** trial-frame` (whose registers are the huge raw Knuth-D quotient terms that blow up `dsimp`/`simp`) implies the compact NAMED post `divKTrialCallFullPostV5Named` (over `divKTrialCallV5QHat`/`Q1dd`/`Q0dd`/`DHi`/`X7Exit`/`X9Exit`/`ScratchOut`).

## Proof strategy (dodges the wall)

Rather than expand the raw hypothesis, rewrite the **named goal** back to the raw code forms and let `xperm` match defeq:

- `← div128V5_q1Final_eq_Q1dd`, `← div128V5_q0Final_eq_Q0dd` (Phase-1/2 digits)
- `div128V5_x7Exit_eq`, `div128V5_x9Exit_eq` (forward — exit registers)
- `← div128V5CodeQuot_eq_divKTrialCallV5QHat` (the quotient, via the q-bridge)
- `← div128V5_rhat2c_eq`, `← div128V5_un21_eq` (after unfolding `ScratchOut`)
- `unfold` only the **leaf** irreducible sub-defs (`DHi`/`DLo`/`Un0`/`Un1`/`div128V5CodeQuot`)
- `xperm_hyp`

Crucially `divKTrialCallV5Un21` must **not** be unfolded — its body is stated over the model `Q1dd`/`Rhatdd` (not the raw `q1Final`/`rhatFinal`), so `← div128V5_un21_eq` reverts it to the raw-code form instead.

## Verification

`#print axioms` → `propext, Classical.choice, Quot.sound` only. No `sorry`, no `native_decide`. Builds clean.

Unblocks brick 6 (`divK_loop_body_n1_call_skip_j0_v5`) → the v5 n=1 loop body. Bead `evm-asm-wbc4i.9.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)