### PR TITLE
feat(divmod): v5 n=1 call+skip j>0 (steady-state) loop body

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -67,6 +67,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN1.CallV5NoNop
 import EvmAsm.Evm64.DivMod.LoopBody.TrialCallFullV5Named
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5X7X9Eq
 import EvmAsm.Evm64.DivMod.LoopIterN1.CallSkipJ0V5
+import EvmAsm.Evm64.DivMod.LoopIterN1.CallSkipJgt0V5
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.LoopUnifiedN1.CallIter210NoNop
 import EvmAsm.Evm64.DivMod.LoopUnifiedN1.UnifiedNoNop

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallSkipJgt0V5.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallSkipJgt0V5.lean
@@ -1,0 +1,151 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopIterN1.CallSkipJgt0V5
+
+  The v5 n=1 call+skip j>0 (steady-state) loop body over
+  `sharedDivModCodeNoNop_v5`: trial-call-full + mulsub + correction-skip +
+  store-loop loop-back (storeLoopOff → loopBodyOff).  Mirror of
+  `divK_loop_body_n1_call_skip_jgt0_v4_spec_within_noNop` (LoopIterN1/CallV4NoNop),
+  with the v5 NAMED trial-call-full post (#7264) and v5 bricks (#7238/#7239).
+
+  Together with the j=0 brick (CallSkipJ0V5), this gives both loop-body cases for
+  the v5 n=1 loop iteration.  Bead `evm-asm-wbc4i.9.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopIterN1.CallSkipJ0V5
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v5 n=1 call+skip j>0 loop-body post (mirror of `loopBodyN1CallSkipJgt0PostV4`
+    with v5 trial defs): the exact v5 trial quotient `divKTrialCallV5QHat` is
+    stored, the loop counter stays `j`, and the div128 scratch cells settle. -/
+def loopBodyN1CallSkipJgt0PostV5
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV5DLo v0
+  let div_un0 := divKTrialCallV5Un0 u0
+  let qHat := divKTrialCallV5QHat u1 u0 v0
+  let scratchOut := divKTrialCallV5ScratchOut u1 u0 v0 scratchMem
+  loopBodyN1SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v0) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut) **
+  regOwn .x1
+
+/-- v5 n=1 call+skip j>0 loop body over `sharedDivModCodeNoNop_v5` (158 steps,
+    loopBodyOff → loopBodyOff loop-back).  Mirror of the v4 analog. -/
+theorem divK_loop_body_n1_call_skip_jgt0_v5_spec_within_noNop (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u1 v0)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV5QHat u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+    cpsTripleWithin 158 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCodeNoNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ qOld) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1)
+      (loopBodyN1CallSkipJgt0PostV5 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  intro uBase qAddr
+  let dHi := divKTrialCallV5DHi v0
+  let dLo := divKTrialCallV5DLo v0
+  let div_un0 := divKTrialCallV5Un0 u0
+  let q1'' := divKTrialCallV5Q1dd u1 u0 v0
+  let q0'' := divKTrialCallV5Q0dd u1 u0 v0
+  let x7Exit := divKTrialCallV5X7Exit u1 u0 v0
+  let x9Exit := divKTrialCallV5X9Exit u1 u0 v0
+  let qHat := divKTrialCallV5QHat u1 u0 v0
+  let scratchOut := divKTrialCallV5ScratchOut u1 u0 v0 scratchMem
+  have TF := divK_trial_call_full_v5_named_spec_within_noNop sp j (1 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    u1 u0 v0 retMem dMem dloMem scratch_un0 scratchMem base
+    halign hbltu
+  unfold divKTrialCallFullPostV5Named at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
+  have MCS0 := divK_mulsub_correction_skip_v5_spec_within_noNop sp qHat j
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x9Exit q0'' dHi x7Exit q1'' (base + div128CallRetOff) base
+    hborrow
+  unfold divKMulsubCorrectionSkipPre at MCS0
+  unfold n4McaNamedSkipPost at MCS0
+  unfold mulsubN4 at MCS0
+  dsimp only [] at MCS0
+  have MCS0f := cpsTripleWithin_frameR ((sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) MCS0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
+  let fs0 := p0_lo + (signExtend12 0 : Word)
+  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
+  let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
+  let un0 := u0 - fs0; let c0 := pc0 + bs0
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
+  let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
+  let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
+  let un1 := u1 - fs1; let c1 := pc1 + bs1
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
+  let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
+  let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
+  let un2 := u2 - fs2; let c2 := pc2 + bs2
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
+  let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
+  let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
+  let un3 := u3 - fs3; let c3 := pc3 + bs3
+  let u4_new := uTop - c3
+  have SL := divK_store_loop_jgt0_v5_spec_within_noNop sp j qHat u4_new (0 : Word) qOld base hpos
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCS0f
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+     (sp + signExtend12 3976 ↦ₘ j) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
+     (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v0) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ div_un0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      unfold loopBodyN1CallSkipJgt0PostV5
+      unfold loopBodyN1SkipPost loopBodySkipPost loopExitPost
+      unfold mulsubN4
+      dsimp only []
+      rw [sepConj_assoc'] at hp; xperm_hyp hp)
+    full
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Stacked on #7266. Adds `divK_loop_body_n1_call_skip_jgt0_v5_spec_within_noNop` + post `loopBodyN1CallSkipJgt0PostV5` — **the v5 n=1 steady-state (j>0) loop body** over `sharedDivModCodeNoNop_v5` (158 steps, `loopBodyOff → loopBodyOff` loop-back).

Composes v5 trial-call-full (NAMED post, #7264) + mulsub/correction-skip (#7238) + store-loop-jgt0 loop-back (#7239), parameterized by the loop counter `j` with `hpos : BitVec.slt (j + signExtend12 4095) 0 = false`.

Mirror of `divK_loop_body_n1_call_skip_jgt0_v4_spec_within_noNop`. Together with the j=0 brick (#7266), **both loop-body cases for the v5 n=1 loop iteration are now proven**.

## Verification

`#print axioms` → `propext, Classical.choice, Quot.sound` only. No `sorry`. Aggregator builds clean.

Bead `evm-asm-wbc4i.9.1`. Next: the n=1 loop iteration (compose j=0 + j>0 over the 4 digits) → unified n=1 spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)