### PR TITLE
feat(divmod): v5 n=1 call-path iteration post + skip bridges

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -70,6 +70,7 @@ import EvmAsm.Evm64.DivMod.LoopBody.TrialCallFullV5Named
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5X7X9Eq
 import EvmAsm.Evm64.DivMod.LoopIterN1.CallSkipJ0V5
 import EvmAsm.Evm64.DivMod.LoopIterN1.CallSkipJgt0V5
+import EvmAsm.Evm64.DivMod.LoopIterN1.IterPostV5
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.LoopUnifiedN1.CallIter210NoNop
 import EvmAsm.Evm64.DivMod.LoopUnifiedN1.UnifiedNoNop

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/IterPostV5.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/IterPostV5.lean
@@ -1,0 +1,69 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopIterN1.IterPostV5
+
+  v5 n=1 call-path per-digit iteration postcondition `loopIterPostN1CallV5`
+  (mirror of `loopIterPostN1CallV4NoX1`, LoopDefs/Post.lean, but over the EXACT
+  v5 trial `div128Quot_v5` and the clean named scratch defs).  Plus the skip
+  bridges connecting the v5 loop-body posts (#7266/#7267) to this iteration post.
+
+  Because `div128Quot_v5` is the exact floor, the single-limb mulsub never
+  borrows, so the loop body always takes the SKIP path — the `iterWithDoubleAddback`
+  model reduces to the skip mulsub (the addback is a no-op).  These bridges feed
+  the v5 n=1 loop iteration (no `Carry2NzAll`).  Bead `evm-asm-wbc4i.9.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopIterN1.CallSkipJgt0V5
+import EvmAsm.Evm64.DivMod.Spec.N1V5CodeQuotNoBorrow
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v5 n=1 call-path per-digit iteration post: the schoolbook digit result
+    (`iterWithDoubleAddback` over `div128Quot_v5`) with the div128 scratch cells
+    settled (via the named v5 scratch defs).  Mirror of `loopIterPostN1CallV4NoX1`
+    plus `regOwn .x1`. -/
+@[irreducible] def loopIterPostN1CallV5
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let qHat := div128Quot_v5 u1 u0 v0
+  let r := iterWithDoubleAddback qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let c3 := (mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+  loopExitPostN1 sp j r.1 c3 r.2.1 r.2.2.1 r.2.2.2.1 r.2.2.2.2.1 r.2.2.2.2.2 v0 v1 v2 v3 **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v0) **
+  (sp + signExtend12 3952 ↦ₘ divKTrialCallV5DLo v0) **
+  (sp + signExtend12 3944 ↦ₘ divKTrialCallV5Un0 u0) **
+  (sp + signExtend12 3936 ↦ₘ divKTrialCallV5ScratchOut u1 u0 v0 scratchMem) **
+  regOwn .x1
+
+/-- Skip bridge (j=0): the v5 j=0 loop-body post equals the iteration post when
+    the mulsub does not borrow (which, for the exact v5 trial, always holds). -/
+theorem loopIterPostN1CallV5_j0_skip
+    {sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word}
+    (hb : ¬BitVec.ult uTop
+      (mulsubN4_c3 (div128Quot_v5 u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)) :
+    loopBodyN1CallSkipJ0PostV5 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem =
+    loopIterPostN1CallV5 sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem := by
+  unfold loopBodyN1CallSkipJ0PostV5 loopIterPostN1CallV5
+  rw [divKTrialCallV5QHat_eq_div128Quot_v5]
+  delta loopBodyN1SkipPost loopBodySkipPost loopExitPostN1 loopExitPost
+    iterWithDoubleAddback
+  unfold mulsubN4_c3 at hb
+  simp only [if_neg hb]
+
+/-- Skip bridge (j>0): the v5 steady-state loop-body post equals the iteration
+    post when the mulsub does not borrow. -/
+theorem loopIterPostN1CallV5_jgt0_skip
+    {sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word}
+    (hb : ¬BitVec.ult uTop
+      (mulsubN4_c3 (div128Quot_v5 u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)) :
+    loopBodyN1CallSkipJgt0PostV5 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem =
+    loopIterPostN1CallV5 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem := by
+  unfold loopBodyN1CallSkipJgt0PostV5 loopIterPostN1CallV5
+  rw [divKTrialCallV5QHat_eq_div128Quot_v5]
+  delta loopBodyN1SkipPost loopBodySkipPost loopExitPostN1 loopExitPost
+    iterWithDoubleAddback
+  unfold mulsubN4_c3 at hb
+  simp only [if_neg hb]
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

First model-plumbing step of the v5 n=1 loop iteration. Off `main` (all loop-body bricks now merged).

Adds `loopIterPostN1CallV5` — the v5 call-path per-digit iteration post (mirror of `loopIterPostN1CallV4NoX1`) over the **exact** v5 trial `div128Quot_v5` and the named v5 scratch defs — plus the two skip bridges:

- `loopIterPostN1CallV5_j0_skip`: `loopBodyN1CallSkipJ0PostV5 = loopIterPostN1CallV5`
- `loopIterPostN1CallV5_jgt0_skip`: `loopBodyN1CallSkipJgt0PostV5 = loopIterPostN1CallV5`

both under the no-borrow guard `¬ult uTop (mulsubN4_c3 (div128Quot_v5 ...) ...)`.

Because `div128Quot_v5` is the exact floor, the mulsub never borrows, so the `iterWithDoubleAddback` model reduces to the skip mulsub (`simp [if_neg hb]`) — exactly the v4 pattern, **without `Carry2NzAll`**. These connect the v5 loop-body posts (merged) to the iteration model.

## Verification

`#print axioms` → `propext, Quot.sound` only. No `sorry`. Aggregator builds clean.

Bead `evm-asm-wbc4i.9.1`. Next: thin v5 unified per-digit bodies (dispatch to skip via no-borrow) → iter210 + unified composition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)