### PR TITLE
feat(divmod): v5 n=1 loop-at-shape bridge equations

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -80,6 +80,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN1.Iter10CallV5
 import EvmAsm.Evm64.DivMod.LoopIterN1.Iter210CallV5
 import EvmAsm.Evm64.DivMod.LoopIterN1.UnifiedDefsV5
 import EvmAsm.Evm64.DivMod.LoopIterN1.UnifiedCallV5
+import EvmAsm.Evm64.DivMod.LoopIterN1.LoopAtShapeBridgeV5
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.LoopUnifiedN1.CallIter210NoNop
 import EvmAsm.Evm64.DivMod.LoopUnifiedN1.UnifiedNoNop

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/LoopAtShapeBridgeV5.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/LoopAtShapeBridgeV5.lean
@@ -1,0 +1,52 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopIterN1.LoopAtShapeBridgeV5
+
+  Bridge equations connecting the v5 full-loop's per-digit helper states
+  (`fullN1S2`/`fullN1S1`, raw `iterN1Call_v5` nestings) to the schoolbook model
+  digits (`fullDivN1R2V5`/`fullDivN1R1V5 true`, irreducible) at the normalized
+  inputs.  These let the loop-at-shape instantiation discharge the full loop's
+  `hbltu_1`/`hbltu_0`/`hborrow_1`/`hborrow_0` hypotheses (over `fullN1S*`) using
+  the shape lemmas (over `fullDivN1R*V5`).  Bead `evm-asm-wbc4i.9.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopIterN1.UnifiedCallV5
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- `fullN1S2` at the normalized inputs equals the schoolbook j=1-entry digit
+    `fullDivN1R2V5 true true`. -/
+theorem fullN1S2_eq_fullDivN1R2V5 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullN1S2 (fullDivN1NormV b0 b1 b2 b3).1 (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1 (fullDivN1NormV b0 b1 b2 b3).2.2.2
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1 (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2 0 0 0
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+    = fullDivN1R2V5 true true a0 a1 a2 a3 b0 b1 b2 b3 := by
+  unfold fullN1S2 fullDivN1R2V5 fullDivN1R3V5
+  simp only [iterN1V5_true]
+
+/-- `fullN1S1` at the normalized inputs equals the schoolbook j=0-entry digit
+    `fullDivN1R1V5 true true true`. -/
+theorem fullN1S1_eq_fullDivN1R1V5 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullN1S1 (fullDivN1NormV b0 b1 b2 b3).1 (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1 (fullDivN1NormV b0 b1 b2 b3).2.2.2
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1 (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2 0 0 0
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1 (fullDivN1NormU a0 a1 a2 a3 b0).2.1
+    = fullDivN1R1V5 true true true a0 a1 a2 a3 b0 b1 b2 b3 := by
+  unfold fullN1S1 fullN1S2 fullDivN1R1V5 fullDivN1R2V5 fullDivN1R3V5
+  simp only [iterN1V5_true]
+
+/-- The first schoolbook digit `fullDivN1R3V5 true` equals the raw `iterN1Call_v5`
+    over the normalized top window — the form the full loop's `hbltu_2`/`hborrow_3`
+    hypotheses use. -/
+theorem fullDivN1R3V5_eq_iterN1Call_v5 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3
+    = iterN1Call_v5 (fullDivN1NormV b0 b1 b2 b3).1 (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1 (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1 (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0 := by
+  unfold fullDivN1R3V5
+  simp only [iterN1V5_true]
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/UnifiedCallV5.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/UnifiedCallV5.lean
@@ -22,12 +22,12 @@ private theorem iterN1Call_v5_unfoldU (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
   rfl
 
 /-- j=2-entry iteration state (after the j=3 digit). -/
-private def fullN1S2 (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_2 : Word) :=
+def fullN1S2 (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_2 : Word) :=
   let s3 := iterN1Call_v5 v0 v1 v2 v3 u0 u1 u2 u3 uTop
   iterN1Call_v5 v0 v1 v2 v3 u0_orig_2 s3.2.1 s3.2.2.1 s3.2.2.2.1 s3.2.2.2.2.1
 
 /-- j=1-entry iteration state (after the j=3, j=2 digits). -/
-private def fullN1S1 (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_2 u0_orig_1 : Word) :=
+def fullN1S1 (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_2 u0_orig_1 : Word) :=
   let s2 := fullN1S2 v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_2
   iterN1Call_v5 v0 v1 v2 v3 u0_orig_1 s2.2.1 s2.2.2.1 s2.2.2.2.1 s2.2.2.2.2.1
 


### PR DESCRIPTION
## Summary

Off `main` (the #7274–#7279 loop stack and #7280 lane-bltu have merged). Makes the full-loop per-digit helper states `fullN1S2`/`fullN1S1` public and adds the bridge equations connecting them (and the first digit) to the schoolbook model at the normalized inputs:

- `fullN1S2_eq_fullDivN1R2V5`: `fullN1S2 (norm) = fullDivN1R2V5 true true`
- `fullN1S1_eq_fullDivN1R1V5`: `fullN1S1 (norm) = fullDivN1R1V5 true true true`
- `fullDivN1R3V5_eq_iterN1Call_v5`: `fullDivN1R3V5 true = iterN1Call_v5 (norm top window)`

Each is `unfold … ; simp only [iterN1V5_true]`. These resolve the impedance between the full loop's hypotheses (over `fullN1S*`/`iterN1Call_v5`) and the shape lemmas (over the **irreducible** `fullDivN1R*V5`), enabling the loop-at-shape instantiation to discharge all 8 per-digit hyps via the lane lemmas (#7280 bltu, #7281 no-borrow).

## Verification

Builds clean, no `sorry`, standard axioms.

Bead `evm-asm-wbc4i.9.1`. Next: the loop-at-shape theorem (instantiate the full loop at normalized inputs, rewrite via these bridges, supply the lane discharge lemmas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)