### PR TITLE
feat(stateless): witness_headers_find_index_by_block_hash primitive

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -92,6 +92,7 @@ import EvmAsm.Codegen.Programs.Receipt
 import EvmAsm.Codegen.Programs.State
 import EvmAsm.Codegen.Programs.StateCompose
 import EvmAsm.Codegen.Programs.StatePredicates
+import EvmAsm.Codegen.Programs.WitnessHeadersFindIndexByBlockHash
 import EvmAsm.Codegen.Programs.StateProof
 import EvmAsm.Codegen.Programs.StateStorageProof
 import EvmAsm.Codegen.Programs.StateCodeHashProof
@@ -422,6 +423,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_state_account_inclusion_proof_verify" => some ziskStateAccountInclusionProofVerifyProbeUnit
   | "zisk_state_slot_inclusion_proof_verify" => some ziskStateSlotInclusionProofVerifyProbeUnit
   | "zisk_state_code_hash_inclusion_proof_verify" => some ziskStateCodeHashInclusionProofVerifyProbeUnit
+  | "zisk_witness_headers_find_index_by_block_hash" => some ziskWitnessHeadersFindIndexByBlockHashProbeUnit
   | "zisk_slot_at_index"        => some ziskSlotAtIndexProbeUnit
   | "zisk_rlp_encode_uint_be"   => some ziskRlpEncodeUintBeProbeUnit
   | "zisk_rlp_encode_bytes"     => some ziskRlpEncodeBytesProbeUnit
@@ -596,6 +598,7 @@ def knownProgramNames : List String :=
    "zisk_state_account_inclusion_proof_verify",
    "zisk_state_slot_inclusion_proof_verify",
    "zisk_state_code_hash_inclusion_proof_verify",
+   "zisk_witness_headers_find_index_by_block_hash",
    "zisk_slot_at_index",
    "zisk_rlp_encode_uint_be",
    "zisk_rlp_encode_bytes",

--- a/EvmAsm/Codegen/Programs/WitnessHeadersFindIndexByBlockHash.lean
+++ b/EvmAsm/Codegen/Programs/WitnessHeadersFindIndexByBlockHash.lean
@@ -1,0 +1,156 @@
+/-
+  EvmAsm.Codegen.Programs.WitnessHeadersFindIndexByBlockHash
+
+  Pure search primitive: given a block_hash and
+  witness.headers, return the index i such that
+  keccak256(witness.headers[i]) == block_hash, or signal
+  not-found.
+
+  Hash -> index inverse of #7304 (which is index -> hash).
+  Useful building block for hash-keyed flows that need to
+  know the position (e.g. for downstream chain-link checks
+  against neighbouring indices).
+
+  No proofs yet -- codegen `String` defs only.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.HashBridge
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Program
+
+/-! ## witness_headers_find_index_by_block_hash
+
+    Iterate the witness.headers SSZ list section, keccak
+    each entry, and return the first index i where
+    keccak(headers[i]) == block_hash.
+
+    On miss, sets index to 0 and returns status 1; caller
+    distinguishes via status, not via the written index
+    (so the output buffer's contents on miss aren't
+    semantically meaningful).
+
+    Inverse of #7304: that returns hash for a given index;
+    this returns index for a given hash.
+
+    Use cases:
+      * Translate a hash-keyed query into an index-keyed
+        downstream call (e.g. caller has block_hash, wants
+        to chain into #7283 / #7296 which take indices).
+      * Detect whether a claimed block_hash is in the
+        witness chain without doing the full account walk
+        of #7307.
+      * Audit: find which position in the chain the trusted
+        anchor block sits at.
+
+    Calling convention (4 args):
+      a0 (input)  : block_hash ptr (32 bytes)
+      a1 (input)  : witness.headers ptr
+      a2 (input)  : witness.headers len
+      a3 (input)  : u64 index out ptr
+      ra (input)  : return
+
+      a0 (output) :
+        0 = found (index written)
+        1 = block_hash not in witness.headers
+-/
+def witnessHeadersFindIndexByBlockHashFunction : String :=
+  "witness_headers_find_index_by_block_hash:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0                  # block_hash ptr\n" ++
+  "  mv s1, a1                  # section ptr\n" ++
+  "  mv s2, a2                  # section_len\n" ++
+  "  mv s3, a3                  # index out\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  beqz s2, .Lwhfi_miss\n" ++
+  "  lwu t0, 0(s1)\n" ++
+  "  srli s4, t0, 2             # s4 = N\n" ++
+  "  li s5, 0                   # s5 = i\n" ++
+  ".Lwhfi_loop:\n" ++
+  "  beq s5, s4, .Lwhfi_miss\n" ++
+  "  slli t0, s5, 2\n" ++
+  "  add t1, s1, t0\n" ++
+  "  lwu t2, 0(t1)\n" ++
+  "  add a0, s1, t2             # el_i_start\n" ++
+  "  addi t3, s5, 1\n" ++
+  "  beq t3, s4, .Lwhfi_use_end\n" ++
+  "  slli t3, t3, 2\n" ++
+  "  add t3, s1, t3\n" ++
+  "  lwu t4, 0(t3)\n" ++
+  "  add t4, s1, t4             # el_i_end\n" ++
+  "  j .Lwhfi_have_end\n" ++
+  ".Lwhfi_use_end:\n" ++
+  "  add t4, s1, s2\n" ++
+  ".Lwhfi_have_end:\n" ++
+  "  sub a1, t4, a0             # el_i_len\n" ++
+  "  la a2, whfi_scratch_hash\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  la t0, whfi_scratch_hash\n" ++
+  "  mv t1, s0\n" ++
+  "  ld t2,  0(t0); ld t3,  0(t1); bne t2, t3, .Lwhfi_step\n" ++
+  "  ld t2,  8(t0); ld t3,  8(t1); bne t2, t3, .Lwhfi_step\n" ++
+  "  ld t2, 16(t0); ld t3, 16(t1); bne t2, t3, .Lwhfi_step\n" ++
+  "  ld t2, 24(t0); ld t3, 24(t1); bne t2, t3, .Lwhfi_step\n" ++
+  "  # Match.\n" ++
+  "  sd s5, 0(s3)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lwhfi_ret\n" ++
+  ".Lwhfi_step:\n" ++
+  "  addi s5, s5, 1\n" ++
+  "  j .Lwhfi_loop\n" ++
+  ".Lwhfi_miss:\n" ++
+  "  li a0, 1\n" ++
+  ".Lwhfi_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_witness_headers_find_index_by_block_hash`: probe BuildUnit.
+    Input layout (at INPUT_ADDR):
+      bytes  0.. 8 : (ziskemu metadata)
+      bytes  8..16 : witness_headers_len (u64 LE)
+      bytes 16..48 : block_hash (32 bytes)
+      bytes 48..   : witness.headers section bytes
+    Output layout (16 bytes):
+      bytes  0.. 8 : status (0 = found, 1 = miss)
+      bytes  8..16 : index (u64; 0 on miss) -/
+def ziskWitnessHeadersFindIndexByBlockHashPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a6, 0x40000000\n" ++
+  "  ld a2, 8(a6)                # witness_headers_len\n" ++
+  "  addi a0, a6, 16             # block_hash ptr\n" ++
+  "  addi a1, a6, 48             # witness.headers ptr\n" ++
+  "  li a3, 0xa0010008           # index out\n" ++
+  "  jal ra, witness_headers_find_index_by_block_hash\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lwhfi_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessHeadersFindIndexByBlockHashFunction ++ "\n" ++
+  ".Lwhfi_pdone:"
+
+def ziskWitnessHeadersFindIndexByBlockHashDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "whfi_scratch_hash:\n" ++
+  "  .zero 32"
+
+def ziskWitnessHeadersFindIndexByBlockHashProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskWitnessHeadersFindIndexByBlockHashPrologue
+  dataAsm     := ziskWitnessHeadersFindIndexByBlockHashDataSection
+}
+
+end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **352**
-- ziskemu round-trip scripts: **343** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **353**
+- ziskemu round-trip scripts: **344** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-witness-headers-find-index-by-block-hash-check.sh
+++ b/scripts/codegen-zisk-witness-headers-find-index-by-block-hash-check.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# codegen-zisk-witness-headers-find-index-by-block-hash-check.sh
+#
+# Pure hash -> index search: locate the position i where
+# keccak(witness.headers[i]) == block_hash.
+#
+# Output (16 bytes):
+#   bytes  0.. 8 : status (0 = found, 1 = miss)
+#   bytes  8..16 : index (u64; 0 on miss)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_witness_headers_find_index_by_block_hash ELF"
+lake exe codegen --program zisk_witness_headers_find_index_by_block_hash \
+  --halt linux93 \
+  -o gen-out/zisk_witness_headers_find_index_by_block_hash
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_whfi_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_whfi_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_whfi_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def encode_header(fill):
+    sr = bytes([fill]) * 32
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, sr, b'\\x55'*32,
+        b'\\x66'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    return rlp.encode(fields)
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0: return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset); offset += len(e)
+    for e in elements: section += e
+    return section
+
+mode = '$mode'
+
+if mode == 'three_idx0':
+    headers = [encode_header(0x44), encode_header(0x55), encode_header(0x66)]
+    witness_headers = build_ssz_section(headers)
+    block_hash = k256(headers[0])
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', 0)
+elif mode == 'three_idx1':
+    headers = [encode_header(0x44), encode_header(0x55), encode_header(0x66)]
+    witness_headers = build_ssz_section(headers)
+    block_hash = k256(headers[1])
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', 1)
+elif mode == 'three_idx2_last':
+    headers = [encode_header(0x44), encode_header(0x55), encode_header(0x66)]
+    witness_headers = build_ssz_section(headers)
+    block_hash = k256(headers[2])
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', 2)
+elif mode == 'miss':
+    headers = [encode_header(0x44), encode_header(0x55)]
+    witness_headers = build_ssz_section(headers)
+    block_hash = b'\\xee' * 32
+    expected = struct.pack('<Q', 1) + struct.pack('<Q', 0)
+elif mode == 'empty_section':
+    witness_headers = b''
+    block_hash = b'\\xee' * 32
+    expected = struct.pack('<Q', 1) + struct.pack('<Q', 0)
+else:
+    raise SystemExit('bad mode')
+
+with open(sys.argv[1], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(witness_headers))
+        + block_hash
+        + witness_headers
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_witness_headers_find_index_by_block_hash.elf \
+    -i "$in_file" -o "$out_file" -n 4000000 \
+    >"$REPO_ROOT/gen-out/zisk_whfi_${name}.emu.log" 2>&1 || true
+
+  local exp_size
+  exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-40s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-40s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "first_index_match"           three_idx0 || FAILED=1
+run_case "middle_index_match"          three_idx1 || FAILED=1
+run_case "last_index_match"            three_idx2_last || FAILED=1
+run_case "unrelated_hash_miss"         miss || FAILED=1
+run_case "empty_section_miss"          empty_section || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: witness_headers_find_index_by_block_hash end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds `witness_headers_find_index_by_block_hash`: pure hash → index search. Given a `block_hash` and the `witness.headers` SSZ section, returns the first index `i` where `keccak256(witness.headers[i]) == block_hash`. On miss, sets index to 0 and returns status 1.

## Inverse of #7304

| PR | Direction |
|----|-----------|
| #7304 | index → hash |
| **this** | hash → index |

## Use cases

* **Hash-keyed → index-keyed flow translation** — caller holds a block_hash but downstream primitives like #7283 (`witness_headers_account_at_index_address`) or #7296 (`witness_headers_slot_at_index_address`) require an index. This primitive bridges the two without rescanning.
* **Cheap presence check** — determine whether a claimed block_hash is in the witness chain at zero MPT cost (just hash + compare, no state walk).
* **Anchor positioning** — find which position the trusted-root block occupies in a multi-block witness chain.

## Test plan

5 fixtures:

* [x] `first_index_match` — block_hash matches headers[0] → status 0, index 0
* [x] `middle_index_match` — matches headers[1] → status 0, index 1
* [x] `last_index_match` — matches headers[2] (exercises section_end branch) → status 0, index 2
* [x] `unrelated_hash_miss` — hash matches no header → status 1, index 0
* [x] `empty_section_miss` — empty witness.headers → status 1

Composes K3 `zkvm_keccak256` + SSZ inner-offset traversal. The pre-existing roundtrip integration test fails on `main` too with `Header.__init__()` missing `slot_number` — unrelated python-spec drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)