### PR TITLE
feat(divmod): v5 phase-C2 taken brick (shift=0 → copyAU)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/PhaseC2V5.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseC2V5.lean
@@ -72,4 +72,35 @@ theorem divK_phaseC2_ntaken_spec_within_v5_noNop (sp shift v2 shiftMem : Word) (
     (fun h hq => by xperm_hyp hq)
     hC2
 
+/-- v5 phase-C2 (shift = 0): store shift, compute antiShift, BEQ taken → copyAU
+    (skips the normB/normA normalization shifts since no normalization is needed).
+    Mirror of `divK_phaseC2_ntaken_spec_within_v5_noNop` with the taken branch;
+    first brick of the v5 n=1 shift=0 preloop.  Bead `evm-asm-wbc4i.9.1`. -/
+theorem divK_phaseC2_taken_spec_within_v5_noNop (sp shift v2 shiftMem : Word) (base : Word)
+    (hshift_z : shift = 0) :
+    cpsTripleWithin 4 (base + phaseC2Off) (base + copyAUOff) (divCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+       (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
+  have hbody := divK_phaseC2_body_divCode_noNop_v5_within sp shift v2 shiftMem base
+  have hbeq_raw := beq_spec_gen_within .x6 .x0 172 shift (0 : Word) (base + phaseC2Off + 12)
+  rw [show (base + phaseC2Off + 12 : Word) + signExtend13 172 = base + copyAUOff from by rv64_addr,
+      show (base + phaseC2Off + 12 : Word) + 4 = base + normBOff from by bv_addr] at hbeq_raw
+  have hbeq_clean := cpsBranchWithin_takenStripPure2 hbeq_raw
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
+      exact absurd hshift_z ((sepConj_pure_right _).mp h_rest).2)
+  have hbeq := cpsTripleWithin_extend_code beq_shift_sub_divCode_noNop_v5 hbeq_clean
+  have hbeqf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hbeq
+  have hC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hbody hbeqf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hC2
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `divK_phaseC2_taken_spec_within_v5_noNop`, the **shift=0** sibling of the existing `divK_phaseC2_ntaken_spec_within_v5_noNop`, over `divCode_noNop_v5`.
- When `shift = 0`, the BEQ at `phaseC2Off+12` is taken, jumping to `copyAUOff` and skipping the normB/normA normalization shifts (no normalization needed when the divisor is already top-bit-aligned).
- Same 4-step phase-C2 body as the ntaken brick, with the taken-branch strip (`cpsBranchWithin_takenStripPure2`) and exit at `base + copyAUOff`.

First brick of the v5 n=1 **shift=0 preloop**, needed to complete the n=1 DIV lane shift=0 sub-case toward `evm_div_stack_spec_unconditional`. The shift≠0 lane (#7308) and the bzero lane (#7315) are already done.

## Verification
- `lake build` (full) succeeds; `scripts/check-file-size.sh` clean; no `sorry`/`native_decide`/heartbeat bumps.

Refs #61. Bead: evm-asm-wbc4i.9.1.

Authored by @pirapira; implemented by Claude Code
