### PR TITLE
feat(divmod): v5 n=1 shift=0 full preloop (base → loopBodyOff)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V5PreloopShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V5PreloopShift0.lean
@@ -12,10 +12,13 @@
 
 import EvmAsm.Evm64.DivMod.Compose.CopyAUV5
 import EvmAsm.Evm64.DivMod.Compose.LoopSetupV5
+import EvmAsm.Evm64.DivMod.Compose.PhaseC2V5
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5Preloop
 
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 
 /-- v5 shift=0 middle segment: copy-AU then loop-setup (BLT-not-taken), from
     `copyAUOff` to `loopBodyOff`, over `divCode_noNop_v5`.  The dividend `a[0..3]`
@@ -59,6 +62,136 @@ theorem divK_copyAU_loopSetup_shift0_spec_v5_noNop (sp base : Word)
   exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
+    hFull
+
+/-- DIV PhaseAB(n=1) + CLZ + PhaseC2(taken, shift=0) over `divCode_noNop_v5`,
+    `base → copyAUOff`.  Shift=0 analog of `evm_div_phaseAB_n1_clz_c2_spec_v5_noNop`
+    (which goes to normBOff on the not-taken branch). -/
+theorem evm_div_phaseAB_n1_clz_c2taken_spec_v5_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_z : (clzResult b0).1 = 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4) base (base + copyAUOff) (divCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b0).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ (clzResult b0).1) **
+       (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+       (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - (clzResult b0).1)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1)) := by
+  have hABCLZ := evm_div_phaseAB_n1_clz_spec_v5_noNop sp base b0 b1 b2 b3
+    v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2z hb1z
+  have hABCLZf := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) ** ((sp + signExtend12 3992) ↦ₘ shiftMem))
+    (by pcFree) hABCLZ
+  have hC2 := divK_phaseC2_taken_spec_within_v5_noNop sp (clzResult b0).1
+    ((clzResult b0).2 >>> (63 : Nat)) shiftMem base hshift_z
+  have hC2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ (clzResult b0).2) ** (.x10 ↦ᵣ b3) **
+     (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)))
+    (by pcFree) hC2
+  have hABC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABCLZf hC2f
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hABC2
+
+/-- Full n=1 shift=0 preloop, `base → loopBodyOff`, over `divCode_noNop_v5`.
+    Shift=0 analog of `evm_div_n1_to_loopSetup_spec_v5_noNop`: same entry shape,
+    but on the shift=0 branch (`(clzResult b0).1 = 0`) the dividend is copied
+    verbatim (u-cells ← a-cells, u[4] = 0) instead of normalized.  Loop counter
+    `x5 ← 1`, `x9 ← 4 − 1`. -/
+theorem evm_div_n1_to_loopSetup_shift0_spec_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_z : (clzResult b0).1 = 0) :
+    cpsTripleWithin ((8 + 21 + 24 + 4) + 13) base (base + loopBodyOff)
+      (divCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (1 : Word)) **
+       (.x9 ↦ᵣ (signExtend12 (4 : BitVec 12) - (1 : Word))) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ (clzResult b0).1) **
+       (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+       (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - (clzResult b0).1)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
+       ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1)) := by
+  have hC2 := evm_div_phaseAB_n1_clz_c2taken_spec_v5_noNop sp base b0 b1 b2 b3
+    v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem shiftMem hbnz hb3z hb2z hb1z hshift_z
+  have hC2f := cpsTripleWithin_frameR
+    ((.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+     ((sp + signExtend12 4024) ↦ₘ u4Old))
+    (by pcFree) hC2
+  have hSeg := divK_copyAU_loopSetup_shift0_spec_v5_noNop sp base
+    a0 a1 a2 a3 u0Old u1Old u2Old u3Old u4Old (clzResult b0).2
+    (signExtend12 (4 : BitVec 12) - (4 : Word)) (1 : Word) (by decide)
+  have hSegf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ (clzResult b0).1) **
+     (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+     (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - (clzResult b0).1)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1))
+    (by pcFree) hSeg
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by simp only [signExtend12_0] at hp ⊢; xperm_hyp hp) hC2f hSegf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by simp only [signExtend12_0] at hq ⊢; xperm_hyp hq)
     hFull
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseC2V5.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseC2V5.lean
@@ -72,4 +72,35 @@ theorem divK_phaseC2_ntaken_spec_within_v5_noNop (sp shift v2 shiftMem : Word) (
     (fun h hq => by xperm_hyp hq)
     hC2
 
+/-- v5 phase-C2 (shift = 0): store shift, compute antiShift, BEQ taken → copyAU
+    (skips the normB/normA normalization shifts since no normalization is needed).
+    Mirror of `divK_phaseC2_ntaken_spec_within_v5_noNop` with the taken branch;
+    first brick of the v5 n=1 shift=0 preloop.  Bead `evm-asm-wbc4i.9.1`. -/
+theorem divK_phaseC2_taken_spec_within_v5_noNop (sp shift v2 shiftMem : Word) (base : Word)
+    (hshift_z : shift = 0) :
+    cpsTripleWithin 4 (base + phaseC2Off) (base + copyAUOff) (divCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+       (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
+  have hbody := divK_phaseC2_body_divCode_noNop_v5_within sp shift v2 shiftMem base
+  have hbeq_raw := beq_spec_gen_within .x6 .x0 172 shift (0 : Word) (base + phaseC2Off + 12)
+  rw [show (base + phaseC2Off + 12 : Word) + signExtend13 172 = base + copyAUOff from by rv64_addr,
+      show (base + phaseC2Off + 12 : Word) + 4 = base + normBOff from by bv_addr] at hbeq_raw
+  have hbeq_clean := cpsBranchWithin_takenStripPure2 hbeq_raw
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
+      exact absurd hshift_z ((sepConj_pure_right _).mp h_rest).2)
+  have hbeq := cpsTripleWithin_extend_code beq_shift_sub_divCode_noNop_v5 hbeq_clean
+  have hbeqf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hbeq
+  have hC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hbody hbeqf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hC2
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
Front-composes the v5 n=1 **shift=0 preloop** chain over `divCode_noNop_v5`:

- `evm_div_phaseAB_n1_clz_c2taken_spec_v5_noNop` (`base → copyAUOff`): AB+clz+phase-C2-taken — the shift=0 analog of `evm_div_phaseAB_n1_clz_c2_spec_v5_noNop` (which falls through to `normBOff` on not-taken); same body, taken branch to copyAU.
- `evm_div_n1_to_loopSetup_shift0_spec_v5_noNop` (`base → loopBodyOff`): composes the above with the copyAU+loopSetup segment. **Same entry shape** as the shift≠0 `evm_div_n1_to_loopSetup_spec_v5_noNop` (drop-in), but on the shift=0 branch (`(clzResult b0).1 = 0`) the dividend is copied verbatim (u-cells ← a-cells, `u[4]=0`) rather than normalized; loop counter `x5 ← 1`, `x9 ← 4−1`.

The seq bridges normalize `signExtend12 0 → 0` (copyAU uses `signExtend12 0` for the a0 cell; the preloop frame uses `0`) via `signExtend12_0`.

This **completes the v5 n=1 shift=0 preloop**. Remaining for the shift=0 sub-lane: the loop at shift=0 shape (`loopBodyOff → denormOff`) + the shift=0 epilogue (already done) → full shift=0 path → `by_cases` to assemble `lane_n1` toward `evm_div_stack_spec_unconditional`.

## Stacking
Depends on #7316 (phase-C2 taken brick — cherry-picked onto this branch) and #7318 (copyAU+loopSetup segment, base). Based on `feat/v5-copyAU` (#7318's chain); the phase-C2-taken commit appears here too until #7316 merges.

## Verification
- `lake build` (full) succeeds; `scripts/check-file-size.sh` clean; no `sorry`/`native_decide`/heartbeat bumps.

Refs #61. Bead: evm-asm-wbc4i.9.1.

Authored by @pirapira; implemented by Claude Code
