### PR TITLE
feat(stateless): balance_at_block_hash_address primitive

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -92,6 +92,7 @@ import EvmAsm.Codegen.Programs.Receipt
 import EvmAsm.Codegen.Programs.State
 import EvmAsm.Codegen.Programs.StateCompose
 import EvmAsm.Codegen.Programs.StatePredicates
+import EvmAsm.Codegen.Programs.BalanceAtBlockHash
 import EvmAsm.Codegen.Programs.StateProof
 import EvmAsm.Codegen.Programs.StateStorageProof
 import EvmAsm.Codegen.Programs.StateCodeHashProof
@@ -422,6 +423,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_state_account_inclusion_proof_verify" => some ziskStateAccountInclusionProofVerifyProbeUnit
   | "zisk_state_slot_inclusion_proof_verify" => some ziskStateSlotInclusionProofVerifyProbeUnit
   | "zisk_state_code_hash_inclusion_proof_verify" => some ziskStateCodeHashInclusionProofVerifyProbeUnit
+  | "zisk_balance_at_block_hash_address" => some ziskBalanceAtBlockHashAddressProbeUnit
   | "zisk_slot_at_index"        => some ziskSlotAtIndexProbeUnit
   | "zisk_rlp_encode_uint_be"   => some ziskRlpEncodeUintBeProbeUnit
   | "zisk_rlp_encode_bytes"     => some ziskRlpEncodeBytesProbeUnit
@@ -596,6 +598,7 @@ def knownProgramNames : List String :=
    "zisk_state_account_inclusion_proof_verify",
    "zisk_state_slot_inclusion_proof_verify",
    "zisk_state_code_hash_inclusion_proof_verify",
+   "zisk_balance_at_block_hash_address",
    "zisk_slot_at_index",
    "zisk_rlp_encode_uint_be",
    "zisk_rlp_encode_bytes",

--- a/EvmAsm/Codegen/Programs/BalanceAtBlockHash.lean
+++ b/EvmAsm/Codegen/Programs/BalanceAtBlockHash.lean
@@ -1,0 +1,266 @@
+/-
+  EvmAsm.Codegen.Programs.BalanceAtBlockHash
+
+  Hash-keyed historical balance extractor. Sibling of
+  #7314 (storage_root, +40) and #7320 (code_hash, +72).
+  Field +8 (32 BE balance), spec default 0 on absent.
+
+  No proofs yet -- codegen `String` defs only.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.Mpt
+import EvmAsm.Codegen.Programs.HashBridge
+import EvmAsm.Codegen.Programs.HeaderFields
+import EvmAsm.Codegen.Programs.State
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Program
+
+/-! ## balance_at_block_hash_address
+
+    Hash-keyed historical balance extractor. Same template
+    as #7314 / #7320, different field (+8, 32 BE) and default
+    (0, i.e. 32 zero bytes).
+
+    Pipeline:
+      witness.headers ∋ ?h with keccak(h) == block_hash  [K19]
+      h -> header_extract_state_root                     [K201]
+      state_root + address -> account                    [K28]
+      struct.balance (offset +8, 32 BE) -> 32-byte out
+
+    Use cases:
+      * BALANCE-opcode-style queries against a historical
+        block (keyed by hash).
+      * Audit account-balance evolution: chain N calls with
+        different block_hashes to extract a balance time
+        series.
+      * Bridge snapshot validation: caller has a (block_hash,
+        address) record and wants the balance to compare
+        against an off-chain claim.
+
+    Calling convention (7 args):
+      a0 (input)  : block_hash ptr (32 bytes)
+      a1 (input)  : witness.headers ptr
+      a2 (input)  : witness.headers len
+      a3 (input)  : address ptr (20 bytes)
+      a4 (input)  : witness.state ptr
+      a5 (input)  : witness.state len
+      a6 (input)  : 32-byte balance_be out ptr
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success (walked balance written, BE u256)
+        1 = block_hash not in witness.headers
+        2 = matched header parse failure
+        3 = state_root size unexpected
+        4 = account absent (32 zero bytes written -- spec)
+        5 = state-trie mpt parse error
+        6 = account RLP decode failure
+-/
+def balanceAtBlockHashAddressFunction : String :=
+  "balance_at_block_hash_address:\n" ++
+  "  addi sp, sp, -80\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp)\n" ++
+  "  mv s0, a0                  # block_hash ptr\n" ++
+  "  mv s1, a1                  # witness.headers ptr\n" ++
+  "  mv s2, a2                  # witness.headers len\n" ++
+  "  mv s3, a3                  # address ptr\n" ++
+  "  mv s4, a4                  # witness.state ptr\n" ++
+  "  mv s5, a5                  # witness.state len\n" ++
+  "  mv s6, a6                  # balance out (32 B)\n" ++
+  "  sd zero,  0(s6); sd zero,  8(s6); sd zero, 16(s6); sd zero, 24(s6)\n" ++
+  "  mv a0, s1\n" ++
+  "  mv a1, s2\n" ++
+  "  mv a2, s0\n" ++
+  "  la a3, bbh_match_offset\n" ++
+  "  la a4, bbh_match_length\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  bnez a0, .Lbbh_no_match\n" ++
+  "  la t0, bbh_match_offset\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  add s7, s1, t1\n" ++
+  "  la t0, bbh_match_length\n" ++
+  "  ld s8, 0(t0)\n" ++
+  "  mv a0, s7\n" ++
+  "  mv a1, s8\n" ++
+  "  la a2, bbh_state_root\n" ++
+  "  jal ra, header_extract_state_root\n" ++
+  "  beqz a0, .Lbbh_walk\n" ++
+  "  addi a0, a0, 1\n" ++
+  "  j .Lbbh_ret\n" ++
+  ".Lbbh_walk:\n" ++
+  "  mv a0, s3\n" ++
+  "  li a1, 20\n" ++
+  "  la a2, bbh_state_root\n" ++
+  "  mv a3, s4\n" ++
+  "  mv a4, s5\n" ++
+  "  la a5, bbh_walked_struct\n" ++
+  "  jal ra, account_at_address\n" ++
+  "  beqz a0, .Lbbh_present\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Lbbh_absent\n" ++
+  "  addi a0, a0, 3\n" ++
+  "  j .Lbbh_ret\n" ++
+  ".Lbbh_present:\n" ++
+  "  la t0, bbh_walked_struct\n" ++
+  "  ld t2,  8(t0); sd t2,  0(s6)\n" ++
+  "  ld t2, 16(t0); sd t2,  8(s6)\n" ++
+  "  ld t2, 24(t0); sd t2, 16(s6)\n" ++
+  "  ld t2, 32(t0); sd t2, 24(s6)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbbh_ret\n" ++
+  ".Lbbh_absent:\n" ++
+  "  # Buffer already zero -- spec default for balance.\n" ++
+  "  li a0, 4\n" ++
+  "  j .Lbbh_ret\n" ++
+  ".Lbbh_no_match:\n" ++
+  "  li a0, 1\n" ++
+  ".Lbbh_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp)\n" ++
+  "  addi sp, sp, 80\n" ++
+  "  ret"
+
+/-- `zisk_balance_at_block_hash_address`: probe BuildUnit.
+    Input layout (at INPUT_ADDR):
+      bytes  0.. 8 : (ziskemu metadata)
+      bytes  8..16 : witness_headers_len (u64 LE)
+      bytes 16..24 : witness_state_len (u64 LE)
+      bytes 24..56 : block_hash (32 bytes)
+      bytes 56..76 : address (20 bytes)
+      bytes 76..   : witness.headers ++ witness.state
+    Output layout (40 bytes):
+      bytes  0.. 8 : status (0..6)
+      bytes  8..40 : balance (32 BE) -/
+def ziskBalanceAtBlockHashAddressPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t4, 0x40000000\n" ++
+  "  ld a2, 8(t4)                # witness_headers_len\n" ++
+  "  ld a5, 16(t4)               # witness_state_len\n" ++
+  "  addi a0, t4, 24             # block_hash ptr\n" ++
+  "  addi a3, t4, 56             # address ptr\n" ++
+  "  addi a1, t4, 76             # witness.headers ptr\n" ++
+  "  add  a4, a1, a2             # witness.state ptr\n" ++
+  "  li a6, 0xa0010008           # balance out (32 B)\n" ++
+  "  jal ra, balance_at_block_hash_address\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbbh_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  mptLookupByKeyFunction ++ "\n" ++
+  accountDecodeFunction ++ "\n" ++
+  accountAtAddressFunction ++ "\n" ++
+  headerExtractStateRootFunction ++ "\n" ++
+  balanceAtBlockHashAddressFunction ++ "\n" ++
+  ".Lbbh_pdone:"
+
+def ziskBalanceAtBlockHashAddressDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mnk_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_dummy_length:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mbc_offset:\n" ++
+  "  .zero 8\n" ++
+  "mbc_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_lookup_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_lookup_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_lookup_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_child_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_nibble_count:\n" ++
+  "  .zero 8\n" ++
+  "mw_is_leaf:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_nibble_buf:\n" ++
+  "  .zero 128\n" ++
+  ".balign 32\n" ++
+  "mlk_keccak_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "mlk_nibble_buf:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "ad_offset:\n" ++
+  "  .zero 8\n" ++
+  "ad_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aa_value_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aa_value_scratch:\n" ++
+  "  .zero 256\n" ++
+  ".balign 8\n" ++
+  "hesr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hesr_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "bbh_match_offset:\n" ++
+  "  .zero 8\n" ++
+  "bbh_match_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "bbh_state_root:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "bbh_walked_struct:\n" ++
+  "  .zero 104"
+
+def ziskBalanceAtBlockHashAddressProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBalanceAtBlockHashAddressPrologue
+  dataAsm     := ziskBalanceAtBlockHashAddressDataSection
+}
+
+end EvmAsm.Codegen

--- a/scripts/codegen-zisk-balance-at-block-hash-address-check.sh
+++ b/scripts/codegen-zisk-balance-at-block-hash-address-check.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# codegen-zisk-balance-at-block-hash-address-check.sh
+#
+# Hash-keyed historical balance extractor.
+#
+# Output (40 bytes):
+#   bytes  0.. 8 : status (0..6)
+#   bytes  8..40 : balance (32 BE; 0 on absent)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_balance_at_block_hash_address ELF"
+lake exe codegen --program zisk_balance_at_block_hash_address \
+  --halt linux93 \
+  -o gen-out/zisk_balance_at_block_hash_address
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_bbh_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_bbh_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_bbh_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def hp_encode(nibbles, is_leaf):
+    flag = 2 if is_leaf else 0
+    if len(nibbles) % 2 == 1:
+        flag |= 1
+        result = bytes([flag * 0x10 + nibbles[0]])
+        nibbles = nibbles[1:]
+    else:
+        result = bytes([flag * 0x10])
+    for i in range(0, len(nibbles), 2):
+        result += bytes([nibbles[i] * 0x10 + nibbles[i+1]])
+    return result
+
+def leaf_node(path_nibbles, value):
+    return rlp.encode([hp_encode(path_nibbles, True), value])
+
+def bytes_to_nibbles(b):
+    out = []
+    for byte in b:
+        out.append(byte >> 4); out.append(byte & 0xf)
+    return out
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0: return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset); offset += len(e)
+    for e in elements: section += e
+    return section
+
+def encode_account(nonce, balance, storage_root, code_hash):
+    return rlp.encode([nonce, balance, storage_root, code_hash])
+
+def encode_header(state_root):
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x55'*32,
+        b'\\x66'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    return rlp.encode(fields)
+
+EMPTY_TRIE = bytes.fromhex('56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421')
+EMPTY_CODE_HASH = bytes.fromhex('c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')
+
+def state_trie_one(addr, acct_rlp):
+    path = bytes_to_nibbles(k256(addr))
+    leaf = leaf_node(path, acct_rlp)
+    return k256(leaf), build_ssz_section([leaf])
+
+mode = '$mode'
+ALICE = b'\\xaa' * 20
+BOB = b'\\xbb' * 20
+
+if mode == 'small_balance':
+    bal = 1000000000000000000
+    acct = encode_account(0, bal, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(sr)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0); addr = ALICE
+    expected = struct.pack('<Q', 0) + bal.to_bytes(32, 'big')
+elif mode == 'big_balance':
+    bal = 2**200
+    acct = encode_account(0, bal, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(sr)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0); addr = ALICE
+    expected = struct.pack('<Q', 0) + bal.to_bytes(32, 'big')
+elif mode == 'zero_balance':
+    acct = encode_account(0, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(sr)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0); addr = ALICE
+    expected = struct.pack('<Q', 0) + b'\\x00' * 32
+elif mode == 'absent':
+    acct = encode_account(0, 999, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(BOB, acct)
+    h0 = encode_header(sr)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0); addr = ALICE
+    expected = struct.pack('<Q', 4) + b'\\x00' * 32
+elif mode == 'block_hash_miss':
+    acct = encode_account(0, 999, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(sr)
+    witness_headers = build_ssz_section([h0])
+    block_hash = b'\\xee' * 32; addr = ALICE
+    expected = struct.pack('<Q', 1) + b'\\x00' * 32
+else:
+    raise SystemExit('bad mode')
+
+with open(sys.argv[1], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(witness_headers))
+        + struct.pack('<Q', len(witness_state))
+        + block_hash
+        + addr
+        + witness_headers
+        + witness_state
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_balance_at_block_hash_address.elf \
+    -i "$in_file" -o "$out_file" -n 6000000 \
+    >"$REPO_ROOT/gen-out/zisk_bbh_${name}.emu.log" 2>&1 || true
+
+  local exp_size
+  exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-40s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-40s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "small_balance_1eth"            small_balance || FAILED=1
+run_case "big_balance_2_to_200"          big_balance || FAILED=1
+run_case "zero_balance_present"          zero_balance || FAILED=1
+run_case "absent_account_default_zero"   absent || FAILED=1
+run_case "block_hash_miss"               block_hash_miss || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: balance_at_block_hash_address end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds `balance_at_block_hash_address`: hash-keyed historical balance extractor. Third sibling in the family after #7314 (storage_root, `+40`) and #7320 (code_hash, `+72`). This: field `+8` (32 BE u256), default `0` on absent.

## Use cases

* **BALANCE-opcode-style queries** against a historical block (keyed by hash, not index).
* **Account-balance time series** — chain N calls with different block_hashes to track balance evolution.
* **Bridge snapshot validation** — caller has a `(block_hash, address, balance)` record from off-chain; this primitive returns the chain-anchored balance to compare against the claim.

## Status codes

```
0 = success
1 = block_hash not in witness.headers
2 = matched header parse failure
3 = state_root size unexpected
4 = account absent (32 zero bytes — spec default)
5 = state-trie mpt parse error
6 = account RLP decode failure
```

## Test plan

5 fixtures covering small/big/zero/absent/miss:

* [x] `small_balance_1eth` — 1 ETH → walked BE bytes
* [x] `big_balance_2_to_200` — `2^200` (exercises high u256 limbs)
* [x] `zero_balance_present` — present with 0 (distinct from absent; status 0 vs 4)
* [x] `absent_account_default_zero` — address missing → status 4, zero bytes
* [x] `block_hash_miss` — hash not in witness → status 1

Composes K3 + K19 + K201 + K28. The pre-existing roundtrip integration test fails on `main` too with `Header.__init__()` missing `slot_number` — unrelated python-spec drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)