### PR TITLE
feat(stateless): code_at_block_hash_address primitive (historical EXTCODECOPY)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -93,6 +93,7 @@ import EvmAsm.Codegen.Programs.State
 import EvmAsm.Codegen.Programs.StateCompose
 import EvmAsm.Codegen.Programs.StatePredicates
 import EvmAsm.Codegen.Programs.CodeHashAtBlockHash
+import EvmAsm.Codegen.Programs.CodeAtBlockHash
 import EvmAsm.Codegen.Programs.StateProof
 import EvmAsm.Codegen.Programs.StateStorageProof
 import EvmAsm.Codegen.Programs.StateCodeHashProof
@@ -440,6 +441,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_state_slot_inclusion_proof_verify" => some ziskStateSlotInclusionProofVerifyProbeUnit
   | "zisk_state_code_hash_inclusion_proof_verify" => some ziskStateCodeHashInclusionProofVerifyProbeUnit
   | "zisk_code_hash_at_block_hash_address" => some ziskCodeHashAtBlockHashAddressProbeUnit
+  | "zisk_code_at_block_hash_address" => some ziskCodeAtBlockHashAddressProbeUnit
   | "zisk_storage_root_present_in_witness_storage" => some ziskStorageRootPresentInWitnessStorageProbeUnit
   | "zisk_witness_storage_keccak_at_index" => some ziskWitnessStorageKeccakAtIndexProbeUnit
   | "zisk_state_account_with_spec_default" => some ziskStateAccountWithSpecDefaultProbeUnit
@@ -631,6 +633,7 @@ def knownProgramNames : List String :=
    "zisk_state_slot_inclusion_proof_verify",
    "zisk_state_code_hash_inclusion_proof_verify",
    "zisk_code_hash_at_block_hash_address",
+   "zisk_code_at_block_hash_address",
    "zisk_storage_root_present_in_witness_storage",
    "zisk_witness_storage_keccak_at_index",
    "zisk_state_account_with_spec_default",

--- a/EvmAsm/Codegen/Programs/CodeAtBlockHash.lean
+++ b/EvmAsm/Codegen/Programs/CodeAtBlockHash.lean
@@ -1,0 +1,342 @@
+/-
+  EvmAsm.Codegen.Programs.CodeAtBlockHash
+
+  Historical bytecode extractor keyed by block_hash.
+  Pipeline: find header by block_hash, walk to account,
+  extract code_hash, then look up the code in witness.codes
+  by that hash. Returns (offset, length) of the bytecode
+  within witness.codes.
+
+  Composes the hash-keyed walk family (#7314/#7320/#7326/#7331)
+  with a final K19 over witness.codes.
+
+  No proofs yet -- codegen `String` defs only.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.Mpt
+import EvmAsm.Codegen.Programs.HashBridge
+import EvmAsm.Codegen.Programs.HeaderFields
+import EvmAsm.Codegen.Programs.State
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Program
+
+/-! ## code_at_block_hash_address
+
+    Historical bytecode lookup keyed by block_hash:
+      block_hash + witness.headers -- K19 -> header
+      header + witness.state + addr -- K201 + K28 -> account
+      account.code_hash + witness.codes -- K19 -> (offset, length)
+
+    Returns the location of the bytecode within
+    witness.codes so the caller can slice it without
+    materialising the bytes here.
+
+    For EOAs / absent accounts: code_hash = EMPTY_CODE_HASH;
+    K19 over witness.codes will miss (witness.codes
+    typically doesn't contain the empty string), so the
+    primitive returns (offset=0, length=0) with a distinct
+    status (5) indicating "empty code -- expected miss".
+
+    Use cases:
+      * EXTCODECOPY-style queries at a trusted historical
+        block: caller wants the bytecode bytes; this
+        primitive returns where in witness.codes they sit.
+      * EXTCODESIZE-style queries: the length component
+        gives the deployed code size at that historical
+        block.
+      * Bytecode-fingerprint audit: chain N calls across
+        block hashes to track contract deployment /
+        replacement.
+
+    Argument squeeze: 8 register args + 2 scratch labels
+    set by the prologue
+      (cabh_codes_len, cabh_code_offset_out_ptr).
+    The (offset, length) output is two u64s written to
+    consecutive 8-byte locations (caller-provided ptr).
+
+    Calling convention (8 register args + 2 scratch):
+      a0 (input)  : block_hash ptr (32 bytes)
+      a1 (input)  : witness.headers ptr
+      a2 (input)  : witness.headers len
+      a3 (input)  : address ptr (20 bytes)
+      a4 (input)  : witness.state ptr
+      a5 (input)  : witness.state len
+      a6 (input)  : witness.codes ptr
+      a7 (input)  : (u64 length out ptr)
+      cabh_codes_len           : u64 (caller-set scratch)
+      cabh_code_offset_out_ptr : u64* (caller-set scratch
+                                 pointing to the u64 offset
+                                 output)
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success (offset, length valid)
+        1 = block_hash not in witness.headers
+        2 = matched header parse failure
+        3 = state_root size unexpected
+        4 = account absent (caller can interpret as empty code)
+        5 = code_hash = EMPTY_CODE_HASH (EOA / no code);
+            (offset, length) = (0, 0)
+        6 = state-trie mpt parse error
+        7 = account RLP decode failure
+        8 = code_hash NOT found in witness.codes (witness
+            structurally invalid -- chain-claimed code_hash
+            should be discoverable here)
+
+    Output is written via the two caller-supplied ptrs:
+      cabh_code_offset_out_ptr (u64): offset into witness.codes
+      a7 (u64):                       length of the bytecode
+-/
+def codeAtBlockHashAddressFunction : String :=
+  "code_at_block_hash_address:\n" ++
+  "  addi sp, sp, -112\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp); sd s10, 88(sp); sd s11, 96(sp)\n" ++
+  "  mv s0, a0                  # block_hash ptr\n" ++
+  "  mv s1, a1                  # witness.headers ptr\n" ++
+  "  mv s2, a2                  # witness.headers len\n" ++
+  "  mv s3, a3                  # address ptr\n" ++
+  "  mv s4, a4                  # witness.state ptr\n" ++
+  "  mv s5, a5                  # witness.state len\n" ++
+  "  mv s6, a6                  # witness.codes ptr\n" ++
+  "  mv s7, a7                  # length out ptr\n" ++
+  "  la t6, cabh_codes_len\n" ++
+  "  ld s8, 0(t6)               # witness.codes len\n" ++
+  "  la t6, cabh_code_offset_out_ptr\n" ++
+  "  ld s9, 0(t6)               # offset out ptr\n" ++
+  "  sd zero, 0(s7)\n" ++
+  "  sd zero, 0(s9)\n" ++
+  "  # Step 1: find header.\n" ++
+  "  mv a0, s1; mv a1, s2; mv a2, s0\n" ++
+  "  la a3, cabh_match_offset; la a4, cabh_match_length\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  bnez a0, .Lcabh_no_match\n" ++
+  "  la t0, cabh_match_offset\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  add s10, s1, t1            # header start\n" ++
+  "  la t0, cabh_match_length\n" ++
+  "  ld s11, 0(t0)              # header len\n" ++
+  "  # Step 2: extract state_root.\n" ++
+  "  mv a0, s10\n" ++
+  "  mv a1, s11\n" ++
+  "  la a2, cabh_state_root\n" ++
+  "  jal ra, header_extract_state_root\n" ++
+  "  beqz a0, .Lcabh_walk\n" ++
+  "  addi a0, a0, 1             # K201 1->2, 2->3\n" ++
+  "  j .Lcabh_ret\n" ++
+  ".Lcabh_walk:\n" ++
+  "  # Step 3: account_at_address into scratch struct.\n" ++
+  "  mv a0, s3                  # address ptr\n" ++
+  "  li a1, 20\n" ++
+  "  la a2, cabh_state_root\n" ++
+  "  mv a3, s4                  # witness.state ptr\n" ++
+  "  mv a4, s5                  # witness.state len\n" ++
+  "  la a5, cabh_walked_struct\n" ++
+  "  jal ra, account_at_address\n" ++
+  "  beqz a0, .Lcabh_check_empty\n" ++
+  "  li t0, 1\n" ++
+  "  bne a0, t0, .Lcabh_decode_err\n" ++
+  "  # absent -> status 4\n" ++
+  "  li a0, 4\n" ++
+  "  j .Lcabh_ret\n" ++
+  ".Lcabh_decode_err:\n" ++
+  "  # K28: 2 -> 6, 3 -> 7.\n" ++
+  "  addi a0, a0, 4\n" ++
+  "  j .Lcabh_ret\n" ++
+  ".Lcabh_check_empty:\n" ++
+  "  # If code_hash field is EMPTY_CODE_HASH, status 5.\n" ++
+  "  la t0, cabh_walked_struct\n" ++
+  "  addi t0, t0, 72            # code_hash field\n" ++
+  "  la t1, cabh_empty_code_hash\n" ++
+  "  ld t2,  0(t0); ld t3,  0(t1); bne t2, t3, .Lcabh_lookup_code\n" ++
+  "  ld t2,  8(t0); ld t3,  8(t1); bne t2, t3, .Lcabh_lookup_code\n" ++
+  "  ld t2, 16(t0); ld t3, 16(t1); bne t2, t3, .Lcabh_lookup_code\n" ++
+  "  ld t2, 24(t0); ld t3, 24(t1); bne t2, t3, .Lcabh_lookup_code\n" ++
+  "  li a0, 5\n" ++
+  "  j .Lcabh_ret\n" ++
+  ".Lcabh_lookup_code:\n" ++
+  "  # Step 4: K19 over witness.codes with code_hash.\n" ++
+  "  mv a0, s6                  # witness.codes ptr\n" ++
+  "  mv a1, s8                  # witness.codes len\n" ++
+  "  la t0, cabh_walked_struct\n" ++
+  "  addi a2, t0, 72            # target_hash = code_hash\n" ++
+  "  mv a3, s9                  # offset out\n" ++
+  "  mv a4, s7                  # length out\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  beqz a0, .Lcabh_done\n" ++
+  "  li a0, 8                   # code_hash not in witness.codes\n" ++
+  "  j .Lcabh_ret\n" ++
+  ".Lcabh_done:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lcabh_ret\n" ++
+  ".Lcabh_no_match:\n" ++
+  "  li a0, 1\n" ++
+  ".Lcabh_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp); ld s11, 96(sp)\n" ++
+  "  addi sp, sp, 112\n" ++
+  "  ret"
+
+/-- `zisk_code_at_block_hash_address`: probe BuildUnit.
+    Input layout (at INPUT_ADDR):
+      bytes  0.. 8 : (ziskemu metadata)
+      bytes  8..16 : witness_headers_len (u64 LE)
+      bytes 16..24 : witness_state_len (u64 LE)
+      bytes 24..32 : witness_codes_len (u64 LE)
+      bytes 32..64 : block_hash (32 bytes)
+      bytes 64..84 : address (20 bytes)
+      bytes 84..   : witness.headers ++ witness.state ++ witness.codes
+    Output layout (24 bytes):
+      bytes  0.. 8 : status (0..8)
+      bytes  8..16 : code_offset (u64; offset into witness.codes)
+      bytes 16..24 : code_length (u64) -/
+def ziskCodeAtBlockHashAddressPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t4, 0x40000000\n" ++
+  "  ld a2, 8(t4)                # witness_headers_len\n" ++
+  "  ld a5, 16(t4)               # witness_state_len\n" ++
+  "  ld t5, 24(t4)               # witness_codes_len\n" ++
+  "  addi a0, t4, 32             # block_hash ptr\n" ++
+  "  addi a3, t4, 64             # address ptr\n" ++
+  "  addi a1, t4, 84             # witness.headers ptr\n" ++
+  "  add  a4, a1, a2             # witness.state ptr\n" ++
+  "  add  a6, a4, a5             # witness.codes ptr\n" ++
+  "  li a7, 0xa0010010           # length out (OUTPUT + 16)\n" ++
+  "  la t0, cabh_codes_len\n" ++
+  "  sd t5, 0(t0)\n" ++
+  "  la t0, cabh_code_offset_out_ptr\n" ++
+  "  li t1, 0xa0010008\n" ++
+  "  sd t1, 0(t0)\n" ++
+  "  jal ra, code_at_block_hash_address\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lcabh_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  mptLookupByKeyFunction ++ "\n" ++
+  accountDecodeFunction ++ "\n" ++
+  accountAtAddressFunction ++ "\n" ++
+  headerExtractStateRootFunction ++ "\n" ++
+  codeAtBlockHashAddressFunction ++ "\n" ++
+  ".Lcabh_pdone:"
+
+def ziskCodeAtBlockHashAddressDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mnk_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_dummy_length:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mbc_offset:\n" ++
+  "  .zero 8\n" ++
+  "mbc_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_lookup_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_lookup_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_lookup_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_child_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_nibble_count:\n" ++
+  "  .zero 8\n" ++
+  "mw_is_leaf:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_nibble_buf:\n" ++
+  "  .zero 128\n" ++
+  ".balign 32\n" ++
+  "mlk_keccak_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "mlk_nibble_buf:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "ad_offset:\n" ++
+  "  .zero 8\n" ++
+  "ad_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aa_value_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aa_value_scratch:\n" ++
+  "  .zero 256\n" ++
+  ".balign 8\n" ++
+  "hesr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hesr_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "cabh_match_offset:\n" ++
+  "  .zero 8\n" ++
+  "cabh_match_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "cabh_state_root:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "cabh_walked_struct:\n" ++
+  "  .zero 104\n" ++
+  ".balign 32\n" ++
+  "cabh_empty_code_hash:\n" ++
+  "  .byte 0xc5, 0xd2, 0x46, 0x01, 0x86, 0xf7, 0x23, 0x3c\n" ++
+  "  .byte 0x92, 0x7e, 0x7d, 0xb2, 0xdc, 0xc7, 0x03, 0xc0\n" ++
+  "  .byte 0xe5, 0x00, 0xb6, 0x53, 0xca, 0x82, 0x27, 0x3b\n" ++
+  "  .byte 0x7b, 0xfa, 0xd8, 0x04, 0x5d, 0x85, 0xa4, 0x70\n" ++
+  ".balign 8\n" ++
+  "cabh_codes_len:\n" ++
+  "  .zero 8\n" ++
+  "cabh_code_offset_out_ptr:\n" ++
+  "  .zero 8"
+
+def ziskCodeAtBlockHashAddressProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskCodeAtBlockHashAddressPrologue
+  dataAsm     := ziskCodeAtBlockHashAddressDataSection
+}
+
+end EvmAsm.Codegen

--- a/scripts/codegen-zisk-code-at-block-hash-address-check.sh
+++ b/scripts/codegen-zisk-code-at-block-hash-address-check.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# codegen-zisk-code-at-block-hash-address-check.sh
+#
+# Hash-keyed historical bytecode lookup. Chains code_hash
+# extract + witness.codes lookup. Returns (offset, length)
+# of bytecode within witness.codes.
+#
+# Output (24 bytes):
+#   bytes  0.. 8 : status (0..8)
+#   bytes  8..16 : code_offset (u64; into witness.codes)
+#   bytes 16..24 : code_length (u64)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_code_at_block_hash_address ELF"
+lake exe codegen --program zisk_code_at_block_hash_address \
+  --halt linux93 \
+  -o gen-out/zisk_code_at_block_hash_address
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_cabh_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_cabh_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_cabh_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def hp_encode(nibbles, is_leaf):
+    flag = 2 if is_leaf else 0
+    if len(nibbles) % 2 == 1:
+        flag |= 1
+        result = bytes([flag * 0x10 + nibbles[0]])
+        nibbles = nibbles[1:]
+    else:
+        result = bytes([flag * 0x10])
+    for i in range(0, len(nibbles), 2):
+        result += bytes([nibbles[i] * 0x10 + nibbles[i+1]])
+    return result
+
+def leaf_node(path_nibbles, value):
+    return rlp.encode([hp_encode(path_nibbles, True), value])
+
+def bytes_to_nibbles(b):
+    out = []
+    for byte in b:
+        out.append(byte >> 4); out.append(byte & 0xf)
+    return out
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0: return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset); offset += len(e)
+    for e in elements: section += e
+    return section
+
+def section_offset_of(elements, idx):
+    return 4 * len(elements) + sum(len(e) for e in elements[:idx])
+
+def encode_account(nonce, balance, storage_root, code_hash):
+    return rlp.encode([nonce, balance, storage_root, code_hash])
+
+def encode_header(state_root):
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x55'*32,
+        b'\\x66'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    return rlp.encode(fields)
+
+EMPTY_TRIE = bytes.fromhex('56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421')
+EMPTY_CODE_HASH = bytes.fromhex('c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')
+
+def state_trie_one(addr, acct_rlp):
+    path = bytes_to_nibbles(k256(addr))
+    leaf = leaf_node(path, acct_rlp)
+    return k256(leaf), build_ssz_section([leaf])
+
+mode = '$mode'
+ALICE = b'\\xaa' * 20
+BOB = b'\\xbb' * 20
+
+if mode == 'contract_present':
+    code = bytes.fromhex('600160005500')  # 6 bytes
+    ch = k256(code)
+    # Build witness.codes with code at index 1 to exercise non-zero offset.
+    decoy = bytes.fromhex('6000')
+    codes = [decoy, code]
+    witness_codes = build_ssz_section(codes)
+    expected_offset = section_offset_of(codes, 1)
+    expected_length = len(code)
+    acct = encode_account(1, 0, EMPTY_TRIE, ch)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(sr)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0); addr = ALICE
+    expected = (
+        struct.pack('<Q', 0)
+        + struct.pack('<Q', expected_offset)
+        + struct.pack('<Q', expected_length)
+    )
+elif mode == 'eoa_empty_code':
+    acct = encode_account(0, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(sr)
+    witness_headers = build_ssz_section([h0])
+    witness_codes = build_ssz_section([])
+    block_hash = k256(h0); addr = ALICE
+    expected = (
+        struct.pack('<Q', 5)
+        + struct.pack('<Q', 0)
+        + struct.pack('<Q', 0)
+    )
+elif mode == 'account_absent':
+    acct = encode_account(0, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(BOB, acct)
+    h0 = encode_header(sr)
+    witness_headers = build_ssz_section([h0])
+    witness_codes = build_ssz_section([])
+    block_hash = k256(h0); addr = ALICE  # not in trie
+    expected = (
+        struct.pack('<Q', 4)
+        + struct.pack('<Q', 0)
+        + struct.pack('<Q', 0)
+    )
+elif mode == 'code_hash_not_in_codes':
+    code_claimed = bytes.fromhex('6042')
+    ch = k256(code_claimed)
+    acct = encode_account(1, 0, EMPTY_TRIE, ch)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(sr)
+    witness_headers = build_ssz_section([h0])
+    # Witness.codes contains UNRELATED bytecode, NOT code_claimed.
+    decoy = bytes.fromhex('1234567890')
+    witness_codes = build_ssz_section([decoy])
+    block_hash = k256(h0); addr = ALICE
+    expected = (
+        struct.pack('<Q', 8)
+        + struct.pack('<Q', 0)
+        + struct.pack('<Q', 0)
+    )
+elif mode == 'block_hash_miss':
+    acct = encode_account(0, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(sr)
+    witness_headers = build_ssz_section([h0])
+    witness_codes = build_ssz_section([])
+    block_hash = b'\\xee' * 32; addr = ALICE
+    expected = (
+        struct.pack('<Q', 1)
+        + struct.pack('<Q', 0)
+        + struct.pack('<Q', 0)
+    )
+else:
+    raise SystemExit('bad mode')
+
+with open(sys.argv[1], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(witness_headers))
+        + struct.pack('<Q', len(witness_state))
+        + struct.pack('<Q', len(witness_codes))
+        + block_hash
+        + addr
+        + witness_headers
+        + witness_state
+        + witness_codes
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_code_at_block_hash_address.elf \
+    -i "$in_file" -o "$out_file" -n 6000000 \
+    >"$REPO_ROOT/gen-out/zisk_cabh_${name}.emu.log" 2>&1 || true
+
+  local exp_size
+  exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-40s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-40s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "contract_present"             contract_present || FAILED=1
+run_case "eoa_empty_code"               eoa_empty_code || FAILED=1
+run_case "account_absent"               account_absent || FAILED=1
+run_case "code_hash_not_in_codes"       code_hash_not_in_codes || FAILED=1
+run_case "block_hash_miss"              block_hash_miss || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: code_at_block_hash_address end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds `code_at_block_hash_address`: historical bytecode lookup keyed by block_hash. Chains the hash-keyed account walk with a second K19 over `witness.codes` to return `(offset, length)` of the deployed bytecode.

## Pipeline

```
block_hash + witness.headers       -- K19  -> header
header + witness.state + address   -- K201 + K28 -> account
account.code_hash + witness.codes  -- K19  -> (offset, length)
```

Returns the location within `witness.codes` so the caller can slice the bytes without materialising them here. Enables EXTCODESIZE (`= length`) and EXTCODECOPY (`= bytes at offset`) queries against a historical block.

## 9-way status codes

```
0 = success
1 = block_hash not in witness.headers
2 = header parse failure
3 = state_root size unexpected
4 = account absent
5 = EMPTY_CODE_HASH (EOA / no code)
6 = state-trie mpt parse error
7 = account RLP decode failure
8 = code_hash NOT in witness.codes (witness invalid)
```

Status 5 is the meaningful EOA path — the witness correctly doesn't include the empty string, so the K19 miss is expected. Status 8 indicates a broken witness where a chain-claimed code_hash should be discoverable but isn't.

## Test plan

5 fixtures across the failure spectrum:

* [x] `contract_present` — contract bytecode at index 1 of witness.codes (validates non-zero offset routing)
* [x] `eoa_empty_code` — EOA → status 5
* [x] `account_absent` → status 4
* [x] `code_hash_not_in_codes` — broken witness scenario → status 8
* [x] `block_hash_miss` → status 1

Composes K3 + K19 (x2) + K201 + K28. Argument squeeze: 8 register args + 2 scratch labels. The pre-existing roundtrip integration test fails on `main` too with `Header.__init__()` missing `slot_number` — unrelated python-spec drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)