### PR TITLE
feat(stateless): witness_codes_keccak_at_index primitive (completes index→keccak set)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -92,6 +92,7 @@ import EvmAsm.Codegen.Programs.Receipt
 import EvmAsm.Codegen.Programs.State
 import EvmAsm.Codegen.Programs.StateCompose
 import EvmAsm.Codegen.Programs.StatePredicates
+import EvmAsm.Codegen.Programs.WitnessCodesKeccakAtIndex
 import EvmAsm.Codegen.Programs.CodeHashAtBlockHash
 import EvmAsm.Codegen.Programs.WitnessHeadersFindIndexByBlockHash
 import EvmAsm.Codegen.Programs.StorageRootAtBlockHash
@@ -448,6 +449,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_code_hash_at_block_hash_address" => some ziskCodeHashAtBlockHashAddressProbeUnit
   | "zisk_storage_root_present_in_witness_storage" => some ziskStorageRootPresentInWitnessStorageProbeUnit
   | "zisk_witness_storage_keccak_at_index" => some ziskWitnessStorageKeccakAtIndexProbeUnit
+  | "zisk_witness_codes_keccak_at_index" => some ziskWitnessCodesKeccakAtIndexProbeUnit
   | "zisk_state_account_with_spec_default" => some ziskStateAccountWithSpecDefaultProbeUnit
   | "zisk_state_extract_storage_root_for_address" => some ziskStateExtractStorageRootForAddressProbeUnit
   | "zisk_chain_link_verify_and_extract_parent_state_root" => some ziskChainLinkVerifyAndExtractParentStateRootProbeUnit
@@ -645,6 +647,7 @@ def knownProgramNames : List String :=
    "zisk_code_hash_at_block_hash_address",
    "zisk_storage_root_present_in_witness_storage",
    "zisk_witness_storage_keccak_at_index",
+   "zisk_witness_codes_keccak_at_index",
    "zisk_state_account_with_spec_default",
    "zisk_state_extract_storage_root_for_address",
    "zisk_chain_link_verify_and_extract_parent_state_root",

--- a/EvmAsm/Codegen/Programs/WitnessCodesKeccakAtIndex.lean
+++ b/EvmAsm/Codegen/Programs/WitnessCodesKeccakAtIndex.lean
@@ -1,0 +1,139 @@
+/-
+  EvmAsm.Codegen.Programs.WitnessCodesKeccakAtIndex
+
+  Fourth index -> keccak primitive, completing the
+  symmetric set:
+    #7215  witness_state_keccak_at_index
+    #7260  witness_storage_keccak_at_index
+    #7304  witness_headers_block_hash_at_index
+    this   witness_codes_keccak_at_index
+
+  Body identical to siblings; distinct named primitive for
+  call-site clarity and separate ELF.
+
+  No proofs yet -- codegen `String` defs only.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.HashBridge
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Program
+
+/-! ## witness_codes_keccak_at_index
+
+    Read the i-th entry of a witness.codes SSZ list section
+    and return its keccak256 -- the canonical
+    EIP-spec code_hash of that bytecode.
+
+    Distinct semantic from siblings:
+      * #7215 / #7260: MPT node hashes
+      * #7304: canonical block hash
+      * THIS: canonical code_hash (== keccak of deployed
+        bytecode, the same value stored in an account
+        struct's code_hash field)
+
+    Use cases:
+      * Witness audit: "what's the code_hash of the i-th
+        contract in witness.codes?"
+      * Producer-claim verification: caller has an off-chain
+        list of expected code_hashes; this primitive
+        materialises the actual hashes from witness in
+        order.
+      * Reverse-direction lookup: caller has just retrieved
+        (offset, length) via #7333 and wants to confirm the
+        keccak self-consistency by index.
+
+    Calling convention (4 args):
+      a0 (input)  : witness.codes ptr
+      a1 (input)  : witness.codes len
+      a2 (input)  : index (u64)
+      a3 (input)  : 32-byte out buffer ptr
+      ra (input)  : return
+
+      a0 (output) : 0 = ok / 1 = index OOB
+-/
+def witnessCodesKeccakAtIndexFunction : String :=
+  "witness_codes_keccak_at_index:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp)\n" ++
+  "  mv s0, a0                  # section ptr\n" ++
+  "  mv s1, a1                  # section_len\n" ++
+  "  mv s2, a2                  # index\n" ++
+  "  mv s3, a3                  # out buf (32 B)\n" ++
+  "  sd zero,  0(s3); sd zero,  8(s3)\n" ++
+  "  sd zero, 16(s3); sd zero, 24(s3)\n" ++
+  "  beqz s1, .Lwcki_oob\n" ++
+  "  lwu t0, 0(s0)\n" ++
+  "  srli s4, t0, 2             # s4 = N\n" ++
+  "  bgeu s2, s4, .Lwcki_oob\n" ++
+  "  slli t0, s2, 2\n" ++
+  "  add t1, s0, t0\n" ++
+  "  lwu t2, 0(t1)\n" ++
+  "  add a0, s0, t2             # el_i_start\n" ++
+  "  addi t3, s2, 1\n" ++
+  "  beq t3, s4, .Lwcki_use_end\n" ++
+  "  slli t3, t3, 2\n" ++
+  "  add t3, s0, t3\n" ++
+  "  lwu t4, 0(t3)\n" ++
+  "  add t4, s0, t4             # el_i_end\n" ++
+  "  j .Lwcki_have_end\n" ++
+  ".Lwcki_use_end:\n" ++
+  "  add t4, s0, s1\n" ++
+  ".Lwcki_have_end:\n" ++
+  "  sub a1, t4, a0\n" ++
+  "  mv a2, s3\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lwcki_ret\n" ++
+  ".Lwcki_oob:\n" ++
+  "  li a0, 1\n" ++
+  ".Lwcki_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_witness_codes_keccak_at_index`: probe BuildUnit.
+    Input layout (at INPUT_ADDR):
+      bytes  0.. 8 : (ziskemu metadata)
+      bytes  8..16 : witness_codes_len (u64 LE)
+      bytes 16..24 : index (u64 LE)
+      bytes 24..   : witness.codes section bytes
+    Output layout (40 bytes):
+      bytes  0.. 8 : status (0=ok, 1=OOB)
+      bytes  8..40 : keccak256 / code_hash (32 B; zero on OOB) -/
+def ziskWitnessCodesKeccakAtIndexPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a6, 0x40000000\n" ++
+  "  ld a1, 8(a6)                # witness_codes_len\n" ++
+  "  ld a2, 16(a6)               # index\n" ++
+  "  addi a0, a6, 24             # witness.codes ptr\n" ++
+  "  li a3, 0xa0010008           # out buf (32 B)\n" ++
+  "  jal ra, witness_codes_keccak_at_index\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lwcki_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessCodesKeccakAtIndexFunction ++ "\n" ++
+  ".Lwcki_pdone:"
+
+def ziskWitnessCodesKeccakAtIndexDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200"
+
+def ziskWitnessCodesKeccakAtIndexProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskWitnessCodesKeccakAtIndexPrologue
+  dataAsm     := ziskWitnessCodesKeccakAtIndexDataSection
+}
+
+end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **384**
-- ziskemu round-trip scripts: **375** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **385**
+- ziskemu round-trip scripts: **376** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-witness-codes-keccak-at-index-check.sh
+++ b/scripts/codegen-zisk-witness-codes-keccak-at-index-check.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# codegen-zisk-witness-codes-keccak-at-index-check.sh
+#
+# Index -> keccak over witness.codes. Returns the
+# canonical code_hash of the i-th deployed bytecode.
+#
+# Output (40 bytes):
+#   bytes  0.. 8 : status (0=ok, 1=OOB)
+#   bytes  8..40 : keccak256 / code_hash (32 B; zero on OOB)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_witness_codes_keccak_at_index ELF"
+lake exe codegen --program zisk_witness_codes_keccak_at_index \
+  --halt linux93 \
+  -o gen-out/zisk_witness_codes_keccak_at_index
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+  local idx="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_wcki_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_wcki_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_wcki_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0: return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset); offset += len(e)
+    for e in elements: section += e
+    return section
+
+mode = '$mode'
+idx = int('$idx')
+
+if mode == 'single':
+    bytecodes = [bytes.fromhex('600160005500')]
+elif mode == 'three_contracts':
+    bytecodes = [
+        bytes.fromhex('6000'),
+        bytes.fromhex('600160005500'),
+        bytes.fromhex('60ff60005260206000f3'),
+    ]
+elif mode == 'empty':
+    bytecodes = []
+else:
+    raise SystemExit('bad mode')
+
+witness_codes = build_ssz_section(bytecodes)
+
+if idx < len(bytecodes):
+    expected = struct.pack('<Q', 0) + k256(bytecodes[idx])
+else:
+    expected = struct.pack('<Q', 1) + b'\\x00' * 32
+
+with open(sys.argv[1], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(witness_codes))
+        + struct.pack('<Q', idx)
+        + witness_codes
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_witness_codes_keccak_at_index.elf \
+    -i "$in_file" -o "$out_file" -n 4000000 \
+    >"$REPO_ROOT/gen-out/zisk_wcki_${name}.emu.log" 2>&1 || true
+
+  local exp_size
+  exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-40s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-40s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "single_idx0"                   single 0 || FAILED=1
+run_case "three_idx0_first"              three_contracts 0 || FAILED=1
+run_case "three_idx1_middle"             three_contracts 1 || FAILED=1
+run_case "three_idx2_last"               three_contracts 2 || FAILED=1
+run_case "three_idx3_oob"                three_contracts 3 || FAILED=1
+run_case "empty_section_oob"             empty 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: witness_codes_keccak_at_index end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds `witness_codes_keccak_at_index`: index-based code_hash extractor over `witness.codes`. **Completes the symmetric set of index → keccak primitives** across all 4 SSZ witness sections:

| PR | Section | Semantic |
|----|---------|----------|
| #7215 | state | MPT node hash |
| #7260 | storage | MPT node hash |
| #7304 | headers | block hash |
| **this** | codes | code_hash |

Each section's "keccak at index" has a different EIP-spec meaning. This primitive's meaning is the canonical `code_hash` — the same value stored in an account struct's code_hash field and used as the key in K19 over witness.codes.

## Use cases

* **Witness audit** — "what's the code_hash of the i-th contract in witness.codes?"
* **Producer-claim verification** — caller has an off-chain list of expected code_hashes; this materialises the actual hashes from witness in section order for batch comparison.
* **Reverse-direction check** — caller has retrieved `(offset, length)` via #7333 and wants to confirm the keccak self-consistency by index.

## Test plan

6 fixtures parallel to #7215/#7260/#7304:

* [x] `single_idx0` — single contract, idx 0
* [x] `three_idx0_first` — first of 3
* [x] `three_idx1_middle` — middle
* [x] `three_idx2_last` — exercises section_end branch
* [x] `three_idx3_oob` — past end → status 1, zero hash
* [x] `empty_section_oob` — empty section → status 1

Composes K3 `zkvm_keccak256` + SSZ inner-offset traversal. The pre-existing roundtrip integration test fails on `main` too with `Header.__init__()` missing `slot_number` — unrelated python-spec drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)