### PR TITLE
feat(divmod): v5 n=2 top-digit (j=2) conservation instantiation

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -158,6 +158,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions
 import EvmAsm.Evm64.DivMod.Spec.N2V5TrialBranch
 import EvmAsm.Evm64.DivMod.Spec.N2V5DigitConservation
+import EvmAsm.Evm64.DivMod.Spec.N2V5R2Conservation
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePostSelected
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5R2Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5R2Conservation.lean
@@ -1,0 +1,65 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5R2Conservation
+
+  Top-digit (j=2) conservation for the v5 n=2 schoolbook, call path: connects the
+  generic per-digit conservation `iterN2V5_true_conservation` to the concrete
+  `fullDivN2R2V5 true` digit (whose call inputs are the normalized-divisor top
+  window `u.2.2.1 / u.2.2.2.1 / u.2.2.2.2` over `v`).  First link of the chained
+  `fullDivN2MulSubEqV5`.  Bead `evm-asm-wbc4i.9.2`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5DigitConservation
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmWord
+
+theorem fullDivN2R2V5_conservation (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hbnz : (fullDivN2NormV b0 b1 b2 b3).1 ||| (fullDivN2NormV b0 b1 b2 b3).2.1 |||
+        (fullDivN2NormV b0 b1 b2 b3).2.2.1 ||| (fullDivN2NormV b0 b1 b2 b3).2.2.2 ≠ 0)
+    (hc3_one_of_borrow :
+      BitVec.ult (0 : Word)
+          (mulsubN4
+            (divKTrialCallV5QHat (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (0 : Word)).2.2.2.2 →
+        (mulsubN4
+            (divKTrialCallV5QHat (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (0 : Word)).2.2.2.2 = 1)
+    (hcarry2 :
+      isAddbackCarry2Nz
+        (divKTrialCallV5QHat (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1)
+        (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+        (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+        (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+        (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (0 : Word) (0 : Word)) :
+    val256 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+        (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0
+      + (0 : Word).toNat * 2^256 =
+      (fullDivN2R2V5 true a0 a1 a2 a3 b0 b1 b2 b3).1.toNat *
+        val256 (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2 +
+      val256
+        (fullDivN2R2V5 true a0 a1 a2 a3 b0 b1 b2 b3).2.1
+        (fullDivN2R2V5 true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+        (fullDivN2R2V5 true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        (fullDivN2R2V5 true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 +
+      (fullDivN2R2V5 true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.2.toNat * 2^256 := by
+  unfold fullDivN2R2V5
+  exact iterN2V5_true_conservation
+    (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+    (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+    (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+    (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (0 : Word) (0 : Word)
+    hbnz hc3_one_of_borrow hcarry2
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
Add `fullDivN2R2V5_conservation`: the top-digit (j=2) conservation for the v5 n=2 schoolbook call path, connecting the generic `iterN2V5_true_conservation` (#7340) to the concrete `fullDivN2R2V5 true` digit (whose call inputs are the normalized top window `u.2.2.1/u.2.2.2.1/u.2.2.2.2` over `v`). Proof: `unfold fullDivN2R2V5` + the generic per-digit conservation at those args.

First link of the chained `fullDivN2MulSubEqV5` (the assembled n=2 conservation): the j=2/j=1/j=0 digit conservations chain (each via this instantiation pattern) into the mulsub equation the quotient correctness (#7336) consumes.

Stacked on #7340.

## Verification
- `lake build` (full) succeeds; `scripts/check-unimported.sh` clean; no `sorry`/`native_decide`/heartbeat bumps.

Refs #61. Bead: evm-asm-wbc4i.9.2.

Authored by @pirapira; implemented by Claude Code
