### PR TITLE
feat(divmod): v5 n=2 3-digit telescoping lemma

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -160,6 +160,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5TrialBranch
 import EvmAsm.Evm64.DivMod.Spec.N2V5DigitConservation
 import EvmAsm.Evm64.DivMod.Spec.N2V5R2Conservation
 import EvmAsm.Evm64.DivMod.Spec.N2V5R10Conservation
+import EvmAsm.Evm64.DivMod.Spec.N2V5ThreeStep
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePostSelected
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5ThreeStep.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5ThreeStep.lean
@@ -1,0 +1,41 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5ThreeStep
+
+  The generic 3-digit telescoping lemma for the v5 n=2 schoolbook — the n=2
+  analog of `fullDivN1V5_four_step_nat` (N1V5Quotient.lean).  It accumulates the
+  three per-digit conservation equations (top window `W2`, then each lower digit
+  bringing in the next dividend limb at the bottom with the previous remainder
+  shifted up by `2^64`) into the single Knuth mulsub equation
+
+      a = (q2·2^128 + q1·2^64 + q0)·V + R0r.
+
+  The per-digit conservations of `iterN2V5_true_conservation`
+  (`fullDivN2R{2,1,0}V5_conservation`, #7342/#7343) supply the three step
+  equations once each remainder is collapsed to its low two limbs (rem < V ≤
+  2^128 ⇒ high limbs and the overflow cell are zero); feeding them here gives
+  `fullDivN2MulSubEqV5`.  Bead `evm-asm-wbc4i.9.2`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5R10Conservation
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmWord
+
+/-- The v5 n=2 3-digit accumulation (pure `Nat`).  `W2` is the top 3-limb window
+    value `nu2 + 2^64·nu3 + 2^128·nu4`; `R2r`/`R1r` are the collapsed 2-limb
+    intermediate remainders; `R0r` is the final remainder value.  Mirror of
+    `fullDivN1V5_four_step_nat`, one digit shorter (the top digit consumes a
+    whole window at once). -/
+theorem fullDivN2V5_three_step_nat
+    {a V q2 q1 q0 nu0 nu1 W2 R2r R1r R0r : Nat}
+    (hfirst : a = nu0 + 2 ^ 64 * nu1 + 2 ^ 128 * W2)
+    (hstep2 : W2 = q2 * V + R2r)
+    (hstep1 : nu1 + 2 ^ 64 * R2r = q1 * V + R1r)
+    (hstep0 : nu0 + 2 ^ 64 * R1r = q0 * V + R0r) :
+    a = (q2 * 2 ^ 128 + q1 * 2 ^ 64 + q0) * V + R0r := by
+  subst hfirst hstep2
+  nlinarith [hstep1, hstep0]
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Adds `fullDivN2V5_three_step_nat` — the pure-`Nat` 3-digit telescoping lemma for the v5 n=2 schoolbook, the n=2 analog of `fullDivN1V5_four_step_nat`.

It accumulates the three per-digit conservation equations into the single Knuth mulsub equation:

```
a = (q2·2^128 + q1·2^64 + q0)·V + R0r
```

The top digit consumes the whole 3-limb top window `W2 = nu2 + 2^64·nu3 + 2^128·nu4` in one step; each lower digit brings in the next dividend limb at the bottom with the previous remainder shifted up by `2^64`.

The conservations `fullDivN2R{2,1,0}V5_conservation` (#7342/#7343) supply the three step equations once each intermediate remainder is collapsed to its low two limbs (rem < V ≤ 2^128 ⇒ high limbs and overflow zero). Feeding them here gives `fullDivN2MulSubEqV5` — the next link.

Bead `evm-asm-wbc4i.9.2`.

## Testing

- `lake build EvmAsm.Evm64.DivMod.Spec.N2V5ThreeStep` ✅
- `scripts/check-unimported.sh` ✅ (0 orphans)
- No `sorry` / `native_decide` / `bv_decide` / heartbeat bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
