### PR TITLE
feat(divmod): +2-overestimate remainder bounds for iterWithDoubleAddback

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivN4RemainderLt.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4RemainderLt.lean
@@ -73,4 +73,92 @@ theorem iterWithDoubleAddback_remainder_lt
   · exact iterWithDoubleAddback_no_borrow_remainder_lt
       q v0 v1 v2 v3 u0 u1 u2 u3 uTop hb hq_ge
 
+/-- **Borrow branch remainder bound with a `+2` overestimate.** The double
+    addback corrects an overestimate of up to `2`, so the borrow branch
+    tolerates `q ≤ ⌊window/v⌋ + 2` — which is exactly what the v5 multi-limb
+    trial provides (`divKTrialCallV5QHat ≤ val256 u / val256 v + 2`, #7219).
+    Same proof as the `…_plus_one` variant: the `+1` there is only used to derive
+    `+2` internally, so the `+2` hypothesis is consumed directly. -/
+theorem iterWithDoubleAddback_borrow_remainder_lt_of_qhat_le_div_plus_two
+    (q v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hb : BitVec.ult uTop (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2)
+    (hc3_one : (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 1)
+    (hq_over :
+      q.toNat ≤ EvmWord.val256 u0 u1 u2 u3 / EvmWord.val256 v0 v1 v2 v3 + 2) :
+    let out := iterWithDoubleAddback q v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    EvmWord.val256 out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1 +
+        out.2.2.2.2.2.toNat * 2^256 < EvmWord.val256 v0 v1 v2 v3 := by
+  intro out
+  subst out
+  have hout := iterWithDoubleAddback_borrow (qHat := q) (v0 := v0) (v1 := v1)
+    (v2 := v2) (v3 := v3) (u0 := u0) (u1 := u1) (u2 := u2) (u3 := u3)
+    (uTop := uTop) hb
+  simp only [] at hout
+  rw [hout]
+  let ms := mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+  by_cases hcarry_zero : carry = 0
+  · rw [if_pos hcarry_zero]
+    have hq_ge_2 :=
+      q_ge_two_of_mulsub_borrow_and_addback_carry_zero
+        q v0 v1 v2 v3 u0 u1 u2 u3 hc3_one (by
+          subst ms
+          subst carry
+          exact hcarry_zero)
+    have hbranch : iterDoubleAddbackBranch q v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      subst ms
+      subst carry
+      exact iterDoubleAddbackBranch_of q v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        hb hc3_one hcarry_zero hbnz hq_over hq_ge_2
+    have h := iterDoubleAddbackBranch_remainder_lt
+      q v0 v1 v2 v3 u0 u1 u2 u3 uTop hbranch
+    simp only [] at h
+    exact h
+  · rw [if_neg hcarry_zero]
+    have hcarry_one : carry = 1 := by
+      subst ms
+      subst carry
+      exact addbackN4_carry_eq_one_of_ne_zero
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+        v0 v1 v2 v3 hcarry_zero
+    have hq_pos := q_pos_of_mulsub_borrow q v0 v1 v2 v3 u0 u1 u2 u3 hc3_one
+    have hbranch : iterSingleAddbackBranch q v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      subst ms
+      subst carry
+      exact iterSingleAddbackBranch_of q v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        hb hc3_one hcarry_one hq_pos
+    have h := iterSingleAddbackBranch_remainder_lt
+      q v0 v1 v2 v3 u0 u1 u2 u3 uTop hbranch
+    simp only [] at h
+    exact h
+
+/-- **Unified per-iteration remainder bound with a `+2` overestimate.** As
+    `iterWithDoubleAddback_remainder_lt`, but with the `+2` overestimate the v5
+    multi-limb trial actually provides (the v5 n=2/n=3/n=4 specializations
+    consume this form). -/
+theorem iterWithDoubleAddback_remainder_lt_of_plus_two
+    (q v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hc3_one_of_borrow :
+      BitVec.ult uTop (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 →
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 1)
+    (hq_over :
+      q.toNat ≤ EvmWord.val256 u0 u1 u2 u3 / EvmWord.val256 v0 v1 v2 v3 + 2)
+    (hq_ge : EvmWord.val256 u0 u1 u2 u3 + uTop.toNat * 2^256 <
+              (q.toNat + 1) * EvmWord.val256 v0 v1 v2 v3) :
+    let out := iterWithDoubleAddback q v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    EvmWord.val256 out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1 +
+        out.2.2.2.2.2.toNat * 2^256 < EvmWord.val256 v0 v1 v2 v3 := by
+  intro out
+  subst out
+  by_cases hb : BitVec.ult uTop (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+  · exact iterWithDoubleAddback_borrow_remainder_lt_of_qhat_le_div_plus_two
+      q v0 v1 v2 v3 u0 u1 u2 u3 uTop hbnz hb (hc3_one_of_borrow hb) hq_over
+  · exact iterWithDoubleAddback_no_borrow_remainder_lt
+      q v0 v1 v2 v3 u0 u1 u2 u3 uTop hb hq_ge
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Adds the `+2`-overestimate forms of the per-iteration remainder bound, stacked on the `+1` versions (#7345):

- `iterWithDoubleAddback_borrow_remainder_lt_of_qhat_le_div_plus_two`
- `iterWithDoubleAddback_remainder_lt_of_plus_two` (unified, both branches)

The double addback corrects an overestimate of up to `2`, so the borrow branch tolerates `q ≤ ⌊window/v⌋ + 2` — which is exactly what the v5 **multi-limb** trial provides (`divKTrialCallV5QHat ≤ val256 u / val256 v + 2`, #7219). The existing `…_plus_one` lemma only used its `+1` hypothesis to derive `+2` internally, so the `+2` hypothesis is consumed directly with the same proof.

This is the form the v5 n=2/n=3/n=4 per-digit remainder bounds need (the single-limb n=1 path uses the exact-floor `+0` shortcut; the multi-limb paths get `+2` from Knuth Theorem A).

Bead `evm-asm-wbc4i.9.2`.

## Testing

- `lake build EvmAsm.Evm64.EvmWordArith.DivN4RemainderLt` ✅
- No `sorry` / `native_decide` / `bv_decide` / heartbeat bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
