### PR TITLE
feat(divmod): v5 n=2 getLimbN bridge + lane-ready digit equalities

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N2V5QuotientShape.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5QuotientShape.lean
@@ -55,4 +55,53 @@ theorem fullDivN2QuotientWordV5_eq_div_of_shape
   unfold fullDivN2QuotientWordV5
   exact hdiv
 
+/-- **getLimbN bridge.** Decompose the quotient-word equality into the four
+    per-limb `getLimbN`/digit equalities the n=2 lane wrapper feeds to
+    `divStackDispatchPost`.  Pure `fromLimbs` projection — n=2 analog of
+    `fullDivN1V5_hdivs_of_word_eq`. -/
+theorem fullDivN2V5_hdivs_of_word_eq
+    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (bltu_2 bltu_1 bltu_0 : Bool)
+    (hdiv : fullDivN2QuotientWordV5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b) :
+    (EvmWord.div a b).getLimbN 0 = (fullDivN2R0V5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 1 = (fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 2 = (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 3 = (0 : Word) := by
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [← hdiv]; delta fullDivN2QuotientWordV5; exact EvmWord.getLimbN_fromLimbs_0
+  · rw [← hdiv]; delta fullDivN2QuotientWordV5; exact EvmWord.getLimbN_fromLimbs_1
+  · rw [← hdiv]; delta fullDivN2QuotientWordV5; exact EvmWord.getLimbN_fromLimbs_2
+  · rw [← hdiv]; delta fullDivN2QuotientWordV5; exact EvmWord.getLimbN_fromLimbs_3
+
+/-- **Lane-ready form: the four `(div a b).getLimbN` digit equalities from shape**
+    (shift≠0) + the `bltu` path matches.  Composes
+    `fullDivN2QuotientWordV5_eq_div_of_shape` with the `getLimbN` bridge. -/
+theorem div_getLimbN_eq_digit_n2_v5_of_shape
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (bltu_2 bltu_1 bltu_0 : Bool)
+    (hb2z : b2 = 0) (hb3z : b3 = 0) (hshift_nz : (clzResult b1).1 ≠ 0) (hb1nz : b1 ≠ 0)
+    (hc2 : bltu_2 = true → BitVec.ult (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm2 : bltu_2 = false → ¬ BitVec.ult (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hc1 : bltu_1 = true → BitVec.ult (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm1 : bltu_1 = false → ¬ BitVec.ult (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hc0 : bltu_0 = true → BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm0 : bltu_0 = false → ¬ BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1) :
+    (EvmWord.div
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3)
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3)).getLimbN 0
+      = (fullDivN2R0V5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3)
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3)).getLimbN 1
+      = (fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3)
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3)).getLimbN 2
+      = (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3)
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3)).getLimbN 3
+      = (0 : Word) :=
+  fullDivN2V5_hdivs_of_word_eq _ _ a0 a1 a2 a3 b0 b1 b2 b3 bltu_2 bltu_1 bltu_0
+    (fullDivN2QuotientWordV5_eq_div_of_shape a0 a1 a2 a3 b0 b1 b2 b3 bltu_2 bltu_1 bltu_0
+      hb2z hb3z hshift_nz hb1nz hc2 hm2 hc1 hm1 hc0 hm0)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Adds the getLimbN bridges that turn the n=2 quotient-word correctness into the per-limb digit equalities the lane wrapper consumes (stacked on #7362):

- `fullDivN2V5_hdivs_of_word_eq` — decompose `fullDivN2QuotientWordV5 = div a b` into the four `(div a b).getLimbN k = digit_k` facts (pure `fromLimbs` projection; n=2 analog of `fullDivN1V5_hdivs_of_word_eq`).
- `div_getLimbN_eq_digit_n2_v5_of_shape` — the lane-ready form straight from the divisor shape + `bltu` path matches, composing the quotient correctness (#7362) with the getLimbN bridge.

These are the digit equalities the n=2 lane wrapper feeds to `divStackDispatchPost` (mirroring how the n1 lane consumed `fullDivN1V5_hdivs_of_word_eq`).

Bead `evm-asm-wbc4i.9.2`.

## Testing

- `lake build EvmAsm.Evm64.DivMod.Spec.N2V5QuotientShape` ✅
- No `sorry` / `native_decide` / `bv_decide` / heartbeat bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
