### PR TITLE
feat(divmod): v5 addback BEQ passthrough loop-body brick

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -167,6 +167,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5ModRemainder
 import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0Quotient
 import EvmAsm.Evm64.DivMod.LoopIterN2V5.IterPostV5
+import EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionAddbackV5NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePostSelected
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4

--- a/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionAddbackV5NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionAddbackV5NoNop.lean
@@ -1,0 +1,47 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionAddbackV5NoNop
+
+  v5 mulsub + correction-ADDBACK loop-body bricks over `sharedDivModCodeNoNop_v5`.
+
+  The mulsub + addback instructions run AFTER the `div128` subroutine (the only
+  block that differs between v4 and v5), so these are mechanical mirrors of the v4
+  specs (`MulsubCorrectionAddback`), swapping the code surface
+  `sharedDivModCodeNoNop_v4 → _v5` and the code-subsumption lemma
+  `lb_sub_noNop_v4 → lb_sub_noNop_v5` (same pattern as `MulsubSkipV5`).
+
+  Unlike the n=1 loop (single-limb divisor ⇒ exact floor ⇒ no borrow ⇒ skip
+  path), the n=2/n=3/n=4 loops have a multi-limb divisor where the trial can
+  overshoot and the addback FIRES — so these addback bricks are needed for the
+  v5 n≥2 loop bodies.  First brick: the `BEQ` passthrough taken on the
+  single-addback path (`carry ≠ 0`).  Bead `evm-asm-wbc4i.9.2`.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionAddback
+import EvmAsm.Evm64.DivMod.Compose.V5Code
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v5 no-NOP variant of `divK_beq_passthrough_v4_spec_within_noNop`: on the
+    single-addback path (`carry ≠ 0`) the addback `BEQ` is not taken, so control
+    falls through to the store-loop.  Mechanical mirror of the v4 proof with the
+    v5 code subsumption. -/
+theorem divK_beq_passthrough_v5_spec_within_noNop {carry : Word} (base : Word) (hne : carry ≠ 0) :
+    cpsTripleWithin 1 (base + addbackBeqOff) (base + storeLoopOff) (sharedDivModCodeNoNop_v5 base)
+      ((.x7 ↦ᵣ carry) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x7 ↦ᵣ carry) ** (.x0 ↦ᵣ (0 : Word))) := by
+  have hbeq := beq_spec_gen_within .x7 .x0 (8044 : BitVec 13) carry 0 (base + addbackBeqOff)
+  rw [lb_beq_back_ntaken_local] at hbeq
+  have hbeq_ext := cpsBranchWithin_extend_code (hmono :=
+    lb_sub_noNop_v5 108 _ _ (by decide) (by bv_addr) (by decide)) hbeq
+  have ntaken := cpsBranchWithin_ntakenPath hbeq_ext (fun hp hQt => by
+    obtain ⟨_, _, _, _, _, ⟨_, _, _, _, _, ⟨_, hpure⟩⟩⟩ := hQt
+    exact hne hpure)
+  exact cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => sepConj_mono_right
+      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
+    ntaken
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

`divK_beq_passthrough_v5_spec_within_noNop` — the first brick of the v5 mulsub+**addback** loop-body chain (over `sharedDivModCodeNoNop_v5`).

The mulsub + addback instructions run *after* the `div128` subroutine (the only block that differs between v4 and v5), so this is a mechanical mirror of the v4 `divK_beq_passthrough_v4` proof, swapping `lb_sub_noNop_v4 → lb_sub_noNop_v5` (same pattern that built the v5 *skip* bricks in `MulsubSkipV5`).

This addback path is needed for the n≥2 loop bodies: unlike n=1 (single-limb divisor ⇒ exact floor ⇒ no borrow ⇒ skip path), the multi-limb trial can overshoot and the addback fires.

Next bricks (recorded): `divK_double_addback_beq_v5`, `divK_mulsub_correction_addback_named_880_v5`, `divK_mulsub_correction_addback_beq_v5` → the v5 n2 call-addback body.

Bead `evm-asm-wbc4i.9.2`.

## Testing

- `lake build EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionAddbackV5NoNop` ✅
- `scripts/check-unimported.sh` ✅ (0 orphans)
- No `sorry` / `native_decide` / `bv_decide` / heartbeat bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
