### PR TITLE
feat(divmod): v5 call-addback loop-body post defs

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -168,6 +168,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5ModRemainder
 import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0Quotient
 import EvmAsm.Evm64.DivMod.LoopIterN2V5.IterPostV5
 import EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionAddbackV5NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN1.CallAddbackV5NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePostSelected
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallAddbackV5NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallAddbackV5NoNop.lean
@@ -20,10 +20,15 @@
 
 import EvmAsm.Evm64.DivMod.LoopIterN1.CallV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN1.CallAddbackV4NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN1.CallSkipJ0V5
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCallFullV5Named
+import EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionAddbackV5NoNop
+import EvmAsm.Evm64.DivMod.LoopBody.StoreLoopV5
 
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.Tactics
 
 /-- v5 call+addback j=0 loop-body post (with `regOwn .x1`).  Mirror of
     `loopBodyN1CallAddbackBeqJ0PostV4` with the v5 trial scratch defs. -/
@@ -57,5 +62,123 @@ def loopBodyN1CallAddbackBeqJ0PostV5NoX1
   (sp + signExtend12 3952 ↦ₘ dLo) **
   (sp + signExtend12 3944 ↦ₘ div_un0) **
   (sp + signExtend12 3936 ↦ₘ scratchOut)
+
+/-- v5 n=1 call+ADDBACK j=0 loop body over `sharedDivModCodeNoNop_v5`:
+    trial-call-full + mulsub + correction-addback + BEQ + store-loop, with the v5
+    trial `divKTrialCallV5QHat`.  Mirror of
+    `divK_loop_body_n1_call_addback_j0_beq_v4_spec_within_noNop`, using the v5
+    named trial-call (term-size) + the v5 addback bricks.  The
+    mulsub/addback/store bricks are generic over the divisor/window, so this same
+    composition (with the `n` window param) gives the n≥2 call-addback body. -/
+theorem divK_loop_body_n1_call_addback_j0_beq_v5_spec_within_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u1 v0)
+    (hborrow : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV5QHat u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word))
+    (hcarry2_nz :
+      let qHat := divKTrialCallV5QHat u1 u0 v0
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + denormOff) (sharedDivModCodeNoNop_v5 base)
+      (loopBodyN1CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem)
+      (loopBodyN1CallAddbackBeqJ0PostV5 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  unfold loopBodyN1CallSkipJ0PreV4
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let dHi := divKTrialCallV5DHi v0
+  let dLo := divKTrialCallV5DLo v0
+  let div_un0 := divKTrialCallV5Un0 u0
+  let q1'' := divKTrialCallV5Q1dd u1 u0 v0
+  let q0'' := divKTrialCallV5Q0dd u1 u0 v0
+  let x7Exit := divKTrialCallV5X7Exit u1 u0 v0
+  let x9Exit := divKTrialCallV5X9Exit u1 u0 v0
+  let qHat := divKTrialCallV5QHat u1 u0 v0
+  let scratchOut := divKTrialCallV5ScratchOut u1 u0 v0 scratchMem
+  have TF := divK_trial_call_full_v5_named_spec_within_noNop sp (0 : Word) (1 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    u1 u0 v0 retMem dMem dloMem scratch_un0 scratchMem base
+    halign hbltu
+  unfold divKTrialCallFullPostV5Named at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
+  let carryOut := if carry = 0 then
+      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
+    else carry
+  have MCA := divK_mulsub_correction_addback_beq_v5_spec_within_noNop
+    sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x9Exit q0'' dHi x7Exit q1'' (base + div128CallRetOff) base
+  intro_lets at MCA
+  have hcarry2_nz' :
+      carry = 0 →
+        addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0 := by
+    dsimp only [] at hcarry2_nz
+    exact hcarry2_nz
+  have MCA0 := MCA hcarry2_nz' hborrow
+  have MCA0f := cpsTripleWithin_frameR ((sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) MCA0
+  have SL := divK_store_loop_j0_v5_spec_within_noNop sp q_out u4_out carryOut qOld base
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCA0f
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
+     (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v0) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ div_un0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      unfold loopBodyN1CallAddbackBeqJ0PostV5
+      change (loopBodyN1AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+        (sp + signExtend12 3960 ↦ₘ v0) **
+        (sp + signExtend12 3952 ↦ₘ dLo) **
+        (sp + signExtend12 3944 ↦ₘ div_un0) **
+        (sp + signExtend12 3936 ↦ₘ scratchOut) **
+        regOwn .x1) h
+      unfold loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost
+      rw [loopExitPost_unfold]
+      rw [sepConj_assoc'] at hp; xperm_hyp hp)
+    full
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallAddbackV5NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallAddbackV5NoNop.lean
@@ -1,0 +1,61 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopIterN1.CallAddbackV5NoNop
+
+  v5 call+ADDBACK loop-body postconditions over `sharedDivModCodeNoNop_v5`.
+
+  The n=1 v5 loop uses the no-borrow SKIP path (`CallSkipJ0V5`), but the n≥2 loops
+  take the ADDBACK path when the multi-limb trial overshoots.  These are the
+  postcondition defs the (forthcoming) v5 call-addback loop body produces —
+  mirrors of `loopBodyN1CallAddbackBeqJ0PostV4` (CallAddbackV4NoNop) with the v5
+  trial scratch defs (`divKTrialCallV5DLo`/`Un0`/`QHat`/`ScratchOut`).  The body
+  PRE (`loopBodyN1CallSkipJ0PreV4`) and the shared addback-state post
+  (`loopBodyN1AddbackBeqPost`) are version-agnostic and reused directly.
+
+  The body proof composes `divK_trial_call_full_v5_named` (TrialCallFullV5Named) +
+  `divK_mulsub_correction_addback_beq_v5` (MulsubCorrectionAddbackV5NoNop) +
+  `divK_store_loop_j0_v5` (StoreLoopV5) — exactly mirroring the v5 skip body
+  `CallSkipJ0V5` with the addback brick in place of the skip brick.  Bead
+  `evm-asm-wbc4i.9.2`.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopIterN1.CallV5NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN1.CallAddbackV4NoNop
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v5 call+addback j=0 loop-body post (with `regOwn .x1`).  Mirror of
+    `loopBodyN1CallAddbackBeqJ0PostV4` with the v5 trial scratch defs. -/
+@[irreducible]
+def loopBodyN1CallAddbackBeqJ0PostV5
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV5DLo v0
+  let div_un0 := divKTrialCallV5Un0 u0
+  let qHat := divKTrialCallV5QHat u1 u0 v0
+  let scratchOut := divKTrialCallV5ScratchOut u1 u0 v0 scratchMem
+  loopBodyN1AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v0) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut) **
+  regOwn .x1
+
+/-- v5 call+addback j=0 loop-body post without `regOwn .x1` (for the
+    exact-`x1`-preserving variant). -/
+@[irreducible]
+def loopBodyN1CallAddbackBeqJ0PostV5NoX1
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV5DLo v0
+  let div_un0 := divKTrialCallV5Un0 u0
+  let qHat := divKTrialCallV5QHat u1 u0 v0
+  let scratchOut := divKTrialCallV5ScratchOut u1 u0 v0 scratchMem
+  loopBodyN1AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v0) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

`loopBodyN1CallAddbackBeqJ0PostV5` (+ `NoX1` variant) — the postcondition defs the v5 call-addback loop body produces.

Mirrors `loopBodyN1CallAddbackBeqJ0PostV4` with the v5 trial scratch defs (`divKTrialCallV5DLo/Un0/QHat/ScratchOut`); the shared addback-state post (`loopBodyN1AddbackBeqPost`) and the body PRE (`loopBodyN1CallSkipJ0PreV4`) are version-agnostic and reused.

The forthcoming body proof composes `divK_trial_call_full_v5_named` + `divK_mulsub_correction_addback_beq_v5` (#7374) + `divK_store_loop_j0_v5` — exactly mirroring the v5 skip body `CallSkipJ0V5` with the addback brick in place of the skip brick.

Bead `evm-asm-wbc4i.9.2`.

## Testing

- `lake build EvmAsm.Evm64.DivMod.LoopIterN1.CallAddbackV5NoNop` ✅
- `scripts/check-unimported.sh` ✅ (0 orphans)
- No `sorry` / `native_decide` / `bv_decide` / heartbeat bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
