### PR TITLE
feat(divmod): v5 n=2 max+addback loop bodies (j0 + jgt0)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -170,6 +170,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN2V5.IterPostV5
 import EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionAddbackV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN1.CallAddbackV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN1.MaxAddbackV5NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN2V5.MaxAddbackV5NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePostSelected
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4

--- a/EvmAsm/Evm64/DivMod/LoopIterN2V5/MaxAddbackV5NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2V5/MaxAddbackV5NoNop.lean
@@ -1,0 +1,159 @@
+import EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionAddbackV5NoNop
+import EvmAsm.Evm64.DivMod.LoopBody.TrialMaxV5
+import EvmAsm.Evm64.DivMod.LoopBody.StoreLoopV5
+import EvmAsm.Evm64.DivMod.LoopIterN2MaxV4NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- No-NOP/v5 loop body cpsTripleWithin for n=2, max+addback, j=0. -/
+theorem divK_loop_body_n2_max_addback_j0_beq_v5_spec_within_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (base : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (sharedDivModCodeNoNop_v5 base)
+      (loopBodyN2MaxSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN2AddbackBeqPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qHat : Word := signExtend12 4095
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
+  let carryOut := if carry = 0 then
+      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
+    else carry
+  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  have TF := divK_trial_max_full_v5_spec_within_noNop sp (0 : Word) (2 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old u2 u1 v1 base hbltu
+  dsimp only [] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
+  have MCA := divK_mulsub_correction_addback_beq_v5_spec_within_noNop
+    sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    (0 : Word) u1 vtopBase u2 v1 v2Old base
+  intro_lets at MCA
+  unfold isAddbackCarry2NzN2Max isAddbackCarry2Nz at hcarry2_nz
+  have MCA0 := MCA hcarry2_nz hborrow
+  have SL := divK_store_loop_j0_v5_spec_within_noNop sp q_out u4_out carryOut qOld base
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ v2Old) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCA0
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
+     (sp + signExtend12 3984 ↦ₘ (2 : Word)))
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by rw [loopBodyN2MaxSkipJ0Pre_unfold] at hp; xperm_hyp hp)
+    (fun h hp => by
+      delta loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost
+      rw [sepConj_assoc'] at hp; xperm_hyp hp)
+    full
+
+/-- No-NOP/v5 loop body cpsTripleWithin for n=2, max+addback, j>0. -/
+theorem divK_loop_body_n2_max_addback_jgt0_beq_v5_spec_within_noNop (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (base : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCodeNoNop_v5 base)
+      (loopBodyN2MaxJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN2AddbackBeqPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  let qHat : Word := signExtend12 4095
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
+  let carryOut := if carry = 0 then
+      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
+    else carry
+  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  have TF := divK_trial_max_full_v5_spec_within_noNop sp j (2 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old u2 u1 v1 base hbltu
+  dsimp only [] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
+  have MCA := divK_mulsub_correction_addback_beq_v5_spec_within_noNop
+    sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    j u1 vtopBase u2 v1 v2Old base
+  intro_lets at MCA
+  unfold isAddbackCarry2NzN2Max isAddbackCarry2Nz at hcarry2_nz
+  have MCA0 := MCA hcarry2_nz hborrow
+  have SL := divK_store_loop_jgt0_v5_spec_within_noNop sp j q_out u4_out carryOut qOld base hpos
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ v2Old) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCA0
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
+     (sp + signExtend12 3976 ↦ₘ j) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
+     (sp + signExtend12 3984 ↦ₘ (2 : Word)))
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by rw [loopBodyN2MaxJgt0Pre_unfold] at hp; xperm_hyp hp)
+    (fun h hp => by
+      delta loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost
+      rw [sepConj_assoc'] at hp; xperm_hyp hp)
+    full
+
+end EvmAsm.Evm64


### PR DESCRIPTION
First of the v5 n=2 per-digit loop bodies. Mirrors the v4 n=2 max+addback bodies (`LoopIterN2MaxAddbackV4NoNop`) onto the v5 code path:

- `divK_loop_body_n2_max_addback_{j0,jgt0}_beq_v5_spec_within_noNop` — 152 steps each, composing `divK_trial_max_full_v5` (window param 2, trial window `u2 u1 v1`) + the v5 mulsub/correction/addback brick chain + `divK_store_loop_{j0,jgt0}_v5`.

The n=2 pre/post defs (`loopBodyN2MaxSkipJ0Pre` / `loopBodyN2MaxJgt0Pre` / `loopBodyN2AddbackBeqPost`) and the n=2 glue lemmas (`u_addr_eq_n2`, `vtop_eq_v1_n2`, `isAddbackCarry2NzN2Max`) are code-agnostic and reused from the v4 n=2 infrastructure.

Unlike the n=1 lane (where `div128Quot_v5` is the exact floor, so the addback branch is unreachable), the n=2 schoolbook addback can genuinely fire — so these addback bodies are required to assemble the unified n=2 v5 loop.

Stacked on #7377 (v5 n=1 call-addback + max-addback bodies).

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)