### PR TITLE
feat(divmod): v5 exact-x1 store-loop loop-body bricks

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -51,6 +51,7 @@ import EvmAsm.Evm64.DivMod.LoopBody.TrialCallV5
 import EvmAsm.Evm64.DivMod.LoopBody.TrialCallFullV5
 import EvmAsm.Evm64.DivMod.LoopBody.MulsubSkipV5
 import EvmAsm.Evm64.DivMod.LoopBody.StoreLoopV5
+import EvmAsm.Evm64.DivMod.LoopBody.StoreLoopV5ExactX1
 import EvmAsm.Evm64.DivMod.LoopBody.TrialMaxV5
 import EvmAsm.Evm64.DivMod.LoopIterN1.MaxSkipV5
 import EvmAsm.Evm64.DivMod.Compose.LoopSetupV5

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -175,6 +175,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN1.MaxAddbackV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN2V5.MaxAddbackV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN2V5.MaxSkipV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN2V5.CallSkipV5NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN2V5.CallSkipV5ExactX1NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN2V5.CallAddbackV5NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMax
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallJ0

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -85,6 +85,7 @@ import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5FinalEqNamed
 import EvmAsm.Evm64.DivMod.Spec.N1V5CodeQuotNoBorrow
 import EvmAsm.Evm64.DivMod.LoopIterN1.CallV5NoNop
 import EvmAsm.Evm64.DivMod.LoopBody.TrialCallFullV5Named
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCallFullV5NamedExactX1
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5X7X9Eq
 import EvmAsm.Evm64.DivMod.LoopIterN1.CallSkipJ0V5
 import EvmAsm.Evm64.DivMod.LoopIterN1.CallSkipJgt0V5

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -175,6 +175,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN2V5.MaxSkipV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN2V5.CallSkipV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN2V5.CallAddbackV5NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMax
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallJ0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePostSelected
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopCallJ0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopCallJ0.lean
@@ -1,0 +1,101 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallJ0
+
+  v5/no-NOP norm-pre wrappers for the n=2 DIV call-path j=0 loop bodies (the
+  loop EXIT to denorm).  Mirror of `divK_loop_body_n2_call_skip_j0_norm_v4_noNop`
+  and `divK_loop_body_n2_call_addback_j0_beq_norm_v4_noNop` (FullPathN2V4NoNop),
+  lifting the raw v5 j=0 call bodies (over `sharedDivModCodeNoNop_v5`) to
+  `divCode_noNop_v5` and hiding the sp-relative addresses behind the
+  (code-agnostic) NormPre def `loopBodyN2CallSkipJ0NormPreV4` reused from the v4
+  wrappers.  Takes the v5 borrow / carry2 hypotheses directly (the v4 wrapper
+  predicates are v4-trial-specific and not reused).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNop
+import EvmAsm.Evm64.DivMod.Compose.V5NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN2V5.CallSkipV5NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN2V5.CallAddbackV5NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- Loop body n=2, call+skip, j=0 over `divCode_noNop_v5` (loop exit), with
+    sp-relative addresses hidden behind a named precondition. -/
+theorem divK_loop_body_n2_call_skip_j0_norm_v5_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 158 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v5 base)
+      (loopBodyN2CallSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN2CallSkipJ0PostV5 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  have raw :=
+    cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v5_sub_divCode_noNop_v5)
+      (divK_loop_body_n2_call_skip_j0_v5_spec_within_noNop
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+        retMem dMem dloMem scratchUn0 scratchMem base
+        halign hbltu hborrow)
+  rw [loopBodyN2CallSkipJ0PreV4_unfold] at raw
+  rw [loopBodyN2CallSkipJ0Pre_unfold] at raw
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopBodyN2CallSkipJ0NormPreV4 loopBodyN2MaxSkipJ0NormPreV4 at hp
+      xperm_hyp hp)
+    (fun h hp => hp)
+    raw
+
+/-- Loop body n=2, call+addback (BEQ double-addback), j=0 over `divCode_noNop_v5`
+    (loop exit), with sp-relative addresses hidden behind a named precondition. -/
+theorem divK_loop_body_n2_call_addback_j0_beq_norm_v5_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word))
+    (hcarry2_nz :
+      let qHat := divKTrialCallV5QHat u2 u1 v1
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v5 base)
+      (loopBodyN2CallSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN2CallAddbackBeqJ0PostV5 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  have raw :=
+    cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v5_sub_divCode_noNop_v5)
+      (divK_loop_body_n2_call_addback_j0_beq_v5_spec_within_noNop
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+        retMem dMem dloMem scratchUn0 scratchMem base
+        halign hbltu hborrow hcarry2_nz)
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopBodyN2CallSkipJ0NormPreV4 loopBodyN2MaxSkipJ0NormPreV4 at hp
+      xperm_hyp hp)
+    (fun h hp => hp)
+    raw
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopBody/StoreLoopV5ExactX1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/StoreLoopV5ExactX1.lean
@@ -1,0 +1,57 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopBody.StoreLoopV5ExactX1
+
+  Exact-x1 variants of the v5 store-loop loop-body bricks: frame `.x1 ↦ᵣ raVal`
+  onto `divK_store_loop_{j0,jgt0}_v5_spec_within_noNop` (StoreLoopV5).  Mirror of
+  `divK_store_loop_{j0,jgt0}_v4_spec_within_noNop_exact_x1` (StoreLoop).  Needed
+  by the v5 n=2 call-path loop bodies that thread the concrete caller return
+  address through the store-loop exit / loop-back.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopBody.StoreLoopV5
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Store q[0] + loop exit at j=0 over `sharedDivModCodeNoNop_v5`, with exact
+    caller-framed `x1` carried through. -/
+theorem divK_store_loop_j0_v5_spec_within_noNop_exact_x1
+    (sp qHat v5Old v7Old qOld raVal : Word)
+    (base : Word) :
+    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let j' := (0 : Word) + signExtend12 4095
+    cpsTripleWithin 6 (base + storeLoopOff) (base + denormOff) (sharedDivModCodeNoNop_v5 base)
+      (((.x9 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+        (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) **
+        (qAddr ↦ₘ qOld)) ** (.x1 ↦ᵣ raVal))
+      (((.x9 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+        (.x5 ↦ᵣ (0 : Word) <<< (3 : BitVec 6).toNat) ** (.x7 ↦ᵣ qAddr) **
+        (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qHat)) ** (.x1 ↦ᵣ raVal)) := by
+  intro qAddr j'
+  have hStore := divK_store_loop_j0_v5_spec_within_noNop sp qHat v5Old v7Old qOld base
+  dsimp only [] at hStore
+  exact cpsTripleWithin_frameR (.x1 ↦ᵣ raVal) (by pcFree) hStore
+
+/-- Store q[j] + loop back at j>0 over `sharedDivModCodeNoNop_v5`, with exact
+    caller-framed `x1` carried through. -/
+theorem divK_store_loop_jgt0_v5_spec_within_noNop_exact_x1
+    (sp j qHat v5Old v7Old qOld raVal : Word)
+    (base : Word)
+    (hj_pos : BitVec.slt (j + signExtend12 4095) 0 = false) :
+    let jX8 := j <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - jX8
+    let j' := j + signExtend12 4095
+    cpsTripleWithin 6 (base + storeLoopOff) (base + loopBodyOff) (sharedDivModCodeNoNop_v5 base)
+      (((.x9 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+        (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) **
+        (qAddr ↦ₘ qOld)) ** (.x1 ↦ᵣ raVal))
+      (((.x9 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+        (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) **
+        (qAddr ↦ₘ qHat)) ** (.x1 ↦ᵣ raVal)) := by
+  intro jX8 qAddr j'
+  have hStore := divK_store_loop_jgt0_v5_spec_within_noNop sp j qHat v5Old v7Old qOld base hj_pos
+  dsimp only [] at hStore
+  exact cpsTripleWithin_frameR (.x1 ↦ᵣ raVal) (by pcFree) hStore
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialCallFullV5NamedExactX1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialCallFullV5NamedExactX1.lean
@@ -1,0 +1,194 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopBody.TrialCallFullV5NamedExactX1
+
+  Exact-x1 ("preserving the concrete caller return address") variant of the v5
+  trial-call-full brick, with the compact NAMED post.  Mirror of
+  `divK_trial_call_full_v5_spec_within_noNop` / `..._named_spec_within_noNop`
+  (TrialCallFullV5 / TrialCallFullV5Named) but keeping `.x1 ↦ᵣ raVal` instead of
+  collapsing it to `regOwn .x1` — needed by the n=2 (and n≥2) call-path loop
+  bodies that thread the concrete return address through the loop-back.  The
+  v5 trial-call-path already has the preserving-x1 form
+  (`divK_trial_call_path_v5_spec_within_noNop_exact_x1`, #7210), so the only
+  change from the regOwn version is dropping the
+  `cpsTripleWithin_of_forall_regIs_to_regOwn` step and threading `raVal`.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCallFullV5Named
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Raw exact-x1 v5 trial-call-full post (mirror of `divKTrialCallFullPostV5`
+    with `.x1 ↦ᵣ raVal` in place of `regOwn .x1`). -/
+def divKTrialCallFullPostV5ExactX1 (sp j n uHi uLo vTop base scratchMem raVal : Word) : Assertion :=
+  let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  div128V5SpecPost sp (base + div128CallRetOff) vTop uLo uHi scratchMem **
+  (.x1 ↦ᵣ raVal) **
+  (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ n) **
+  (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+  (vtopBase + signExtend12 32 ↦ₘ vTop)
+
+/-- Compact NAMED exact-x1 v5 trial-call-full post (mirror of
+    `divKTrialCallFullPostV5Named` with `.x1 ↦ᵣ raVal`). -/
+def divKTrialCallFullPostV5NamedExactX1
+    (sp j n uHi uLo vTop base scratchMem raVal : Word) : Assertion :=
+  let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let dHi := divKTrialCallV5DHi vTop
+  let dLo := divKTrialCallV5DLo vTop
+  let un0Div := divKTrialCallV5Un0 uLo
+  let q1'' := divKTrialCallV5Q1dd uHi uLo vTop
+  let q0'' := divKTrialCallV5Q0dd uHi uLo vTop
+  let x7Exit := divKTrialCallV5X7Exit uHi uLo vTop
+  let x9Exit := divKTrialCallV5X9Exit uHi uLo vTop
+  let q := divKTrialCallV5QHat uHi uLo vTop
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ x9Exit) ** (.x1 ↦ᵣ raVal) **
+  (.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) **
+  (.x7 ↦ᵣ x7Exit) ** (.x10 ↦ᵣ q1'') ** (.x11 ↦ᵣ q) **
+  (.x2 ↦ᵣ (base + div128CallRetOff)) ** (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ n) **
+  (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+  (vtopBase + signExtend12 32 ↦ₘ vTop) **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ vTop) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ un0Div) **
+  (sp + signExtend12 3936 ↦ₘ divKTrialCallV5ScratchOut uHi uLo vTop scratchMem)
+
+/-- Weaken the raw exact-x1 post to the compact NAMED exact-x1 post (same
+    register-name bridge as `divKTrialCallFullPostV5_imp_named`, with the
+    `.x1 ↦ᵣ raVal` atom riding along). -/
+theorem divKTrialCallFullPostV5ExactX1_imp_named
+    (sp j n uHi uLo vTop base scratchMem raVal : Word) :
+    ∀ h, divKTrialCallFullPostV5ExactX1 sp j n uHi uLo vTop base scratchMem raVal h →
+      divKTrialCallFullPostV5NamedExactX1 sp j n uHi uLo vTop base scratchMem raVal h := by
+  intro h hq
+  unfold divKTrialCallFullPostV5ExactX1 div128V5SpecPost at hq
+  unfold divKTrialCallFullPostV5NamedExactX1
+  rw [← div128V5_q1Final_eq_Q1dd uHi uLo vTop,
+      ← div128V5_q0Final_eq_Q0dd uHi uLo vTop,
+      div128V5_x7Exit_eq uHi uLo vTop,
+      div128V5_x9Exit_eq uHi uLo vTop,
+      ← div128V5CodeQuot_eq_divKTrialCallV5QHat uHi uLo vTop]
+  unfold divKTrialCallV5ScratchOut
+  rw [← div128V5_rhat2c_eq uHi uLo vTop, ← div128V5_un21_eq uHi uLo vTop]
+  unfold div128V5CodeQuot divKTrialCallV5DHi divKTrialCallV5DLo
+    divKTrialCallV5Un0 divKTrialCallV5Un1
+  xperm_hyp hq
+
+/-- Exact-x1 raw v5 trial-call-full path: mirror of
+    `divK_trial_call_full_v5_spec_within_noNop` keeping `.x1 ↦ᵣ raVal`. -/
+theorem divK_trial_call_full_v5_spec_within_noNop_exact_x1
+    (sp j n jOld v5Old v6Old v7Old v10Old v11Old v2Old uHi uLo vTop : Word)
+    (retMem dMem dloMem un0Mem scratchMem raVal : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult uHi vTop) :
+    let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
+    let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin 98 (base + loopBodyOff) (base + div128CallRetOff) (sharedDivModCodeNoNop_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ n) **
+       (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+       (vtopBase + signExtend12 32 ↦ₘ vTop) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem)) ** (.x1 ↦ᵣ raVal))
+      (divKTrialCallFullPostV5ExactX1 sp j n uHi uLo vTop base scratchMem raVal) := by
+  intro uAddr vtopBase
+  have STL := divK_save_trial_load_v5_spec_within_noNop
+    sp j n jOld v5Old v6Old v7Old v10Old uHi uLo vTop base
+  dsimp only [] at STL
+  have hbltu_raw := bltu_spec_gen_within .x7 .x10 (12 : BitVec 13) uHi vTop (base + trialCallOff)
+  rw [lb_bltu_taken, lb_bltu_ntaken] at hbltu_raw
+  have hbltu_ext := cpsBranchWithin_extend_code (hmono :=
+    lb_sub_noNop_v5 13 _ _ (by decide) (by bv_addr) (by decide)) hbltu_raw
+  have taken := cpsBranchWithin_takenPath hbltu_ext (fun hp hQf => by
+    obtain ⟨_, _, _, _, _, ⟨_, _, _, _, _, ⟨_, hpure⟩⟩⟩ := hQf
+    exact hpure hbltu)
+  have taken_clean := cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => sepConj_mono_right
+      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp) taken
+  have TCP := divK_trial_call_path_v5_spec_within_noNop_preserving_x1
+    sp j uLo uHi vTop vtopBase base raVal v2Old v11Old
+    retMem dMem dloMem un0Mem scratchMem halign
+  have STLf := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raVal) ** (.x11 ↦ᵣ v11Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ retMem) **
+     (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) **
+     (sp + signExtend12 3944 ↦ₘ un0Mem))
+    (by pcFree) STL
+  have taken_framed := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) ** (.x1 ↦ᵣ raVal) **
+     (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+     (.x11 ↦ᵣ v11Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ j) **
+     (sp + signExtend12 3984 ↦ₘ n) **
+     (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+     (vtopBase + signExtend12 32 ↦ₘ vTop) **
+     (sp + signExtend12 3968 ↦ₘ retMem) **
+     (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) **
+     (sp + signExtend12 3944 ↦ₘ un0Mem))
+    (by pcFree) taken_clean
+  have TCPf := cpsTripleWithin_frameR
+    ((sp + signExtend12 3976 ↦ₘ j) **
+     (sp + signExtend12 3984 ↦ₘ n) **
+     (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+     (vtopBase + signExtend12 32 ↦ₘ vTop))
+    (by pcFree) TCP
+  have STLf_taken_clean := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) STLf taken_framed
+  have STLf_taken_scratch := cpsTripleWithin_frameR
+    (sp + signExtend12 3936 ↦ₘ scratchMem)
+    (by pcFree) STLf_taken_clean
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) STLf_taken_scratch TCPf
+  unfold divKTrialCallFullPostV5ExactX1
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    full
+
+/-- Exact-x1 v5 trial-call-full path with the **compact NAMED post**
+    (`divKTrialCallFullPostV5NamedExactX1`).  The exact-x1 analog of
+    `divK_trial_call_full_v5_named_spec_within_noNop`. -/
+theorem divK_trial_call_full_v5_named_spec_within_noNop_exact_x1
+    (sp j n jOld v5Old v6Old v7Old v10Old v11Old v2Old uHi uLo vTop : Word)
+    (retMem dMem dloMem un0Mem scratchMem raVal : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult uHi vTop) :
+    let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
+    let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin 98 (base + loopBodyOff) (base + div128CallRetOff) (sharedDivModCodeNoNop_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ n) **
+       (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+       (vtopBase + signExtend12 32 ↦ₘ vTop) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem)) ** (.x1 ↦ᵣ raVal))
+      (divKTrialCallFullPostV5NamedExactX1 sp j n uHi uLo vTop base scratchMem raVal) := by
+  intro uAddr vtopBase
+  exact cpsTripleWithin_weaken (fun _ hp => hp)
+    (divKTrialCallFullPostV5ExactX1_imp_named sp j n uHi uLo vTop base scratchMem raVal)
+    (divK_trial_call_full_v5_spec_within_noNop_exact_x1
+      sp j n jOld v5Old v6Old v7Old v10Old v11Old v2Old uHi uLo vTop
+      retMem dMem dloMem un0Mem scratchMem raVal base halign hbltu)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopIterN2V5/CallSkipV5ExactX1NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2V5/CallSkipV5ExactX1NoNop.lean
@@ -1,0 +1,261 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopIterN2V5.CallSkipV5ExactX1NoNop
+
+  Exact-x1 ("preserving the concrete caller return address") variants of the v5
+  n=2 call+skip loop bodies (j=0 + j>0) over `sharedDivModCodeNoNop_v5`.  Mirror
+  of `divK_loop_body_n2_call_skip_{j0,jgt0}_v4_spec_within_noNop_exact_x1`
+  (LoopIterN2CallV4NoNop) with the v5 NAMED exact-x1 trial (#7385) + the v5
+  mulsub correction-skip + the v5 exact-x1 store-loop (#7386).  Needed by the
+  iter-ready loop-back bodies that thread `.x1 ↦ᵣ raVal` through the loop.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCallFullV5NamedExactX1
+import EvmAsm.Evm64.DivMod.LoopBody.MulsubSkipV5
+import EvmAsm.Evm64.DivMod.LoopBody.StoreLoopV5ExactX1
+import EvmAsm.Evm64.DivMod.LoopIterN2CallV4NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v5 n=2 call+skip j=0 NoX1 post (mirror of `loopBodyN2CallSkipJ0PostV4NoX1`
+    with v5 trial defs). -/
+@[irreducible]
+def loopBodyN2CallSkipJ0PostV5NoX1
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV5DLo v1
+  let divUn0 := divKTrialCallV5Un0 u1
+  let qHat := divKTrialCallV5QHat u2 u1 v1
+  let scratchOut := divKTrialCallV5ScratchOut u2 u1 v1 scratchMem
+  loopBodyN2SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v1) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ divUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut)
+
+/-- v5 n=2 call+skip j>0 NoX1 post (mirror of `loopBodyN2CallSkipJgt0PostV4NoX1`
+    with v5 trial defs). -/
+@[irreducible]
+def loopBodyN2CallSkipJgt0PostV5NoX1
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV5DLo v1
+  let divUn0 := divKTrialCallV5Un0 u1
+  let qHat := divKTrialCallV5QHat u2 u1 v1
+  let scratchOut := divKTrialCallV5ScratchOut u2 u1 v1 scratchMem
+  loopBodyN2SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v1) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ divUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut)
+
+/-- v5 n=2 call+skip j=0 loop body preserving the concrete caller `x1`
+    (158 steps, loopBodyOff → denormOff). -/
+theorem divK_loop_body_n2_call_skip_j0_v5_spec_within_noNop_exact_x1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 158 (base + loopBodyOff) (base + denormOff) (sharedDivModCodeNoNop_v5 base)
+      (loopBodyN2CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopBodyN2CallSkipJ0PostV5NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  unfold loopBodyN2CallSkipJ0PreV4NoX1
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let dHi := divKTrialCallV5DHi v1
+  let dLo := divKTrialCallV5DLo v1
+  let divUn0 := divKTrialCallV5Un0 u1
+  let q1'' := divKTrialCallV5Q1dd u2 u1 v1
+  let q0'' := divKTrialCallV5Q0dd u2 u1 v1
+  let x7Exit := divKTrialCallV5X7Exit u2 u1 v1
+  let x9Exit := divKTrialCallV5X9Exit u2 u1 v1
+  let qHat := divKTrialCallV5QHat u2 u1 v1
+  let scratchOut := divKTrialCallV5ScratchOut u2 u1 v1 scratchMem
+  have TF := divK_trial_call_full_v5_named_spec_within_noNop_exact_x1 sp (0 : Word) (2 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    u2 u1 v1 retMem dMem dloMem scratchUn0 scratchMem raVal base
+    halign hbltu
+  unfold divKTrialCallFullPostV5NamedExactX1 at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
+  have MCS0 := divK_mulsub_correction_skip_v5_spec_within_noNop sp qHat (0 : Word)
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x9Exit q0'' dHi x7Exit q1'' (base + div128CallRetOff) base
+    hborrow
+  unfold divKMulsubCorrectionSkipPre at MCS0
+  unfold n4McaNamedSkipPost at MCS0
+  unfold mulsubN4 at MCS0
+  dsimp only [] at MCS0
+  have MCS0f := cpsTripleWithin_frameR ((sp + signExtend12 3936 ↦ₘ scratchOut) ** (.x1 ↦ᵣ raVal))
+    (by pcFree) MCS0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
+  let fs0 := p0_lo + (signExtend12 0 : Word)
+  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
+  let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
+  let un0 := u0 - fs0; let c0 := pc0 + bs0
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
+  let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
+  let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
+  let un1 := u1 - fs1; let c1 := pc1 + bs1
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
+  let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
+  let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
+  let un2 := u2 - fs2; let c2 := pc2 + bs2
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
+  let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
+  let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
+  let un3 := u3 - fs3; let c3 := pc3 + bs3
+  let u4_new := uTop - c3
+  have SL := divK_store_loop_j0_v5_spec_within_noNop_exact_x1 sp qHat u4_new (0 : Word) qOld raVal base
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCS0f
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
+     (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v1) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ divUn0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut))
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      unfold loopBodyN2CallSkipJ0PostV5NoX1
+      unfold loopBodyN2SkipPost loopBodySkipPost loopExitPost
+      unfold mulsubN4
+      dsimp only []
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    full
+
+/-- v5 n=2 call+skip j>0 loop body preserving the concrete caller `x1`
+    (158 steps, loopBodyOff → loopBodyOff loop-back). -/
+theorem divK_loop_body_n2_call_skip_jgt0_v5_spec_within_noNop_exact_x1 (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 158 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCodeNoNop_v5 base)
+      (loopBodyN2CallSkipJgt0PreV4NoX1 sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopBodyN2CallSkipJgt0PostV5NoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  unfold loopBodyN2CallSkipJgt0PreV4NoX1
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  let dHi := divKTrialCallV5DHi v1
+  let dLo := divKTrialCallV5DLo v1
+  let divUn0 := divKTrialCallV5Un0 u1
+  let q1'' := divKTrialCallV5Q1dd u2 u1 v1
+  let q0'' := divKTrialCallV5Q0dd u2 u1 v1
+  let x7Exit := divKTrialCallV5X7Exit u2 u1 v1
+  let x9Exit := divKTrialCallV5X9Exit u2 u1 v1
+  let qHat := divKTrialCallV5QHat u2 u1 v1
+  let scratchOut := divKTrialCallV5ScratchOut u2 u1 v1 scratchMem
+  have TF := divK_trial_call_full_v5_named_spec_within_noNop_exact_x1 sp j (2 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    u2 u1 v1 retMem dMem dloMem scratchUn0 scratchMem raVal base
+    halign hbltu
+  unfold divKTrialCallFullPostV5NamedExactX1 at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
+  have MCS0 := divK_mulsub_correction_skip_v5_spec_within_noNop sp qHat j
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x9Exit q0'' dHi x7Exit q1'' (base + div128CallRetOff) base
+    hborrow
+  unfold divKMulsubCorrectionSkipPre at MCS0
+  unfold n4McaNamedSkipPost at MCS0
+  unfold mulsubN4 at MCS0
+  dsimp only [] at MCS0
+  have MCS0f := cpsTripleWithin_frameR ((sp + signExtend12 3936 ↦ₘ scratchOut) ** (.x1 ↦ᵣ raVal))
+    (by pcFree) MCS0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
+  let fs0 := p0_lo + (signExtend12 0 : Word)
+  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
+  let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
+  let un0 := u0 - fs0; let c0 := pc0 + bs0
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
+  let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
+  let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
+  let un1 := u1 - fs1; let c1 := pc1 + bs1
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
+  let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
+  let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
+  let un2 := u2 - fs2; let c2 := pc2 + bs2
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
+  let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
+  let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
+  let un3 := u3 - fs3; let c3 := pc3 + bs3
+  let u4_new := uTop - c3
+  have SL := divK_store_loop_jgt0_v5_spec_within_noNop_exact_x1 sp j qHat u4_new
+    (0 : Word) qOld raVal base hpos
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCS0f
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+     (sp + signExtend12 3976 ↦ₘ j) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
+     (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v1) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ divUn0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut))
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      unfold loopBodyN2CallSkipJgt0PostV5NoX1
+      unfold loopBodyN2SkipPost loopBodySkipPost loopExitPost
+      unfold mulsubN4
+      dsimp only []
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    full
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds `divK_store_loop_{j0,jgt0}_v5_spec_within_noNop_exact_x1`: frame the concrete caller return address `.x1 ↦ᵣ raVal` onto the plain v5 store-loop bricks (`StoreLoopV5`). Trivial mirror of the v4 exact-x1 store-loop bricks (`cpsTripleWithin_frameR (.x1 ↦ᵣ raVal)`).

Together with #7385 (exact-x1 named trial brick), these are the two leaf bricks the v5 n=2 call-path loop-back bodies (which thread x1 through the loop) compose with the mulsub correction blocks.

Stacked on #7385 (v5 exact-x1 named trial brick).

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)