### PR TITLE
feat(divmod): v5 n=2 source j=2 loop bodies (call + max)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -183,6 +183,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallJ0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallExactX1
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMaxIter
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIter
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopSource
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePostSelected
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopSource.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopSource.lean
@@ -1,0 +1,126 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopSource
+
+  Source-level v5/no-NOP wrappers for the n=2 DIV loop: the first-iteration
+  (j=2) call and max bodies from the callable-ready loop source, preserving
+  concrete `x1` and carrying the j=1/j=0 source atoms as a frame.  Mirror of the
+  j=2 source theorems in `FullPathN2V4NoNopSource`, swapping the iter bodies
+  (v4→v5, #7391/#7392), the code surface, and the v5 trial accessors in the
+  call post; the loop pre (`loopN2PreWithScratchV4NoX1`) and the pre-bridge
+  lemmas are code-agnostic and reused from the v4 wrappers.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIter
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMaxIter
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- First n=2 call iteration from the callable-ready v5 loop source, preserving
+    concrete `x1` and carrying the j=1/j=0 source atoms as a frame. -/
+theorem divK_loop_n2_call_j2_from_source_exact_loopIterScratch_v5_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hcarry2_nz :
+      let qHat := divKTrialCallV5QHat u2 u1 v1
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v5 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN2CallScratchNoX1 sp base (2 : Word)
+        (divKTrialCallV5QHat u2 u1 v1)
+        (divKTrialCallV5DLo v1)
+        (divKTrialCallV5Un0 u1)
+        (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop ** (.x1 ↦ᵣ raVal)) **
+        ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig1) **
+         ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q1Old)) **
+         (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig0) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))) := by
+  have J2 := divK_loop_body_n2_call_j2_exact_loopIterScratch_v5_noNop sp base
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q2Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu hcarry2_nz
+  have J2f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig1) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q1Old)) **
+     (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig0) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J2
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      have hp' := loopN2PreWithScratchV4NoX1_to_call_j2_pre
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem h hp
+      xperm_hyp hp')
+    (fun h hp => hp)
+    J2f
+
+/-- First n=2 max iteration from the callable-ready v5 loop source, preserving
+    concrete `x1`, scratch, and the j=1/j=0 source atoms as a frame. -/
+theorem divK_loop_n2_max_j2_from_source_exact_loopIterScratch_v5_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v5 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN2Max sp (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)) **
+        ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig1) **
+         ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q1Old)) **
+         (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig0) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))) := by
+  have J2 := divK_loop_body_n2_max_j2_exact_loopIterScratch_v5_noNop sp base
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q2Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem hbltu hcarry2_nz
+  have J2f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig1) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q1Old)) **
+     (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig0) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J2
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      have hp' := loopN2PreWithScratchV4NoX1_to_max_j2_pre
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem h hp
+      xperm_hyp hp')
+    (fun h hp => hp)
+    J2f
+
+end EvmAsm.Evm64


### PR DESCRIPTION
First slice of the n=2 v5 source/combo layer. Mirror of the j=2 source theorems in `FullPathN2V4NoNopSource`:

- `divK_loop_n2_{call,max}_j2_from_source_exact_loopIterScratch_v5_noNop` — wrap the v5 j=2 iter bodies (#7391/#7392) + frameR the j1/j0 source atoms + weaken the pre via the code-agnostic `loopN2PreWithScratchV4NoX1_to_{call,max}_j2_pre` bridges.

The loop pre (`loopN2PreWithScratchV4NoX1`) and pre-bridge lemmas are code-agnostic and reused from v4; only the iter bodies, code surface, and v5 trial accessors in the call post differ.

Stacked on #7392 (v5 n=2 iter-ready call bodies).

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)