### PR TITLE
feat(divmod): v5 n=2 j=0 exit iter bodies (call + max) + prerequisites

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -186,6 +186,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIter
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopSource
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCC
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCombo2
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0Exit
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePostSelected
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopJ0Exit.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopJ0Exit.lean
@@ -1,0 +1,220 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0Exit
+
+  v5/no-NOP n=2 j=0 EXIT iter bodies (call + max), over `divCode_noNop_v5`
+  (loopBodyOff → denormOff).  Mirror of `divK_loop_body_n2_{call,max}_j0_exact_loopIterScratch_v4_noNop`
+  (FullPathN2V4NoNopSource): case on the c3 borrow guard, dispatch to the v5 j=0
+  norm bodies, and weaken the post to `loopIterPostN2{CallScratchNoX1,Max}` via
+  the post-eq lemmas + code-agnostic producer bridges.  Also supplies the two
+  missing prerequisites: the v5 max+addback j=0 norm body and the J0 call post-eq
+  lemmas.  These are the j=0 exit digits the 8 full n=2 combos chain after a
+  2-digit prefix.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCombo2
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- v5 n=2 max+addback j=0 norm body (mirror of the v4 analog; #7383 supplied
+    only the j>0 case). -/
+theorem divK_loop_body_n2_max_addback_j0_beq_norm_v5_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v5 base)
+      (loopBodyN2MaxSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN2AddbackBeqPost sp (0 : Word) (signExtend12 4095 : Word)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n2_max_addback_j0_beq_v5_spec_within_noNop
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hcarry2_nz hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v5_sub_divCode_noNop_v5) raw
+  rw [loopBodyN2MaxSkipJ0Pre_unfold] at raw'
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw'
+  delta loopBodyN2MaxSkipJ0NormPreV4
+  exact raw'
+
+/-- The v5 call+skip j=0 NoX1 post equals the generic scratch-form post with the
+    v5 trial values (mirror of `loopBodyN2CallSkipJ0PostV4NoX1_eq_scratch`). -/
+theorem loopBodyN2CallSkipJ0PostV5NoX1_eq_scratch
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    loopBodyN2CallSkipJ0PostV5NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem =
+      loopBodyN2CallSkipPostJScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV5QHat u2 u1 v1)
+        (divKTrialCallV5DLo v1)
+        (divKTrialCallV5Un0 u1)
+        (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  delta loopBodyN2CallSkipJ0PostV5NoX1 loopBodyN2CallSkipPostJScratchNoX1
+  rfl
+
+/-- The v5 call+addback j=0 NoX1 post equals the generic scratch-form post with
+    the v5 trial values (mirror of `loopBodyN2CallAddbackBeqJ0PostV4NoX1_eq_scratch`). -/
+theorem loopBodyN2CallAddbackBeqJ0PostV5NoX1_eq_scratch
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    loopBodyN2CallAddbackBeqJ0PostV5NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem =
+      loopBodyN2CallAddbackBeqPostJScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV5QHat u2 u1 v1)
+        (divKTrialCallV5DLo v1)
+        (divKTrialCallV5Un0 u1)
+        (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  delta loopBodyN2CallAddbackBeqJ0PostV5NoX1 loopBodyN2CallAddbackBeqPostJScratchNoX1
+  rfl
+
+/-- Unified j=0 N2 call iteration over v5/no-NOP code (loop exit), preserving
+    concrete `x1` and exposing the v5 scratch cell in the final post. -/
+theorem divK_loop_body_n2_call_j0_exact_loopIterScratch_v5_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hcarry2_nz :
+      let qHat := divKTrialCallV5QHat u2 u1 v1
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v5 base)
+      (loopBodyN2CallSkipJ0NormPreV4NoX1 sp
+        jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+        retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal))
+      (loopIterPostN2CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV5QHat u2 u1 v1)
+        (divKTrialCallV5DLo v1)
+        (divKTrialCallV5Un0 u1)
+        (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop ** (.x1 ↦ᵣ raVal)) := by
+  by_cases hborrow :
+      BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word) := by
+      unfold mulsubN4_c3 at hborrow
+      rw [if_pos hborrow]; decide
+    exact cpsTripleWithin_weaken
+      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN2CallAddbackBeqJ0PostV5NoX1_eq_scratch] at hp
+        rw [loopIterPostN2CallScratchNoX1_addback hborrow] at hp
+        xperm_hyp hp)
+      (divK_loop_body_n2_call_addback_j0_beq_norm_v5_noNop_exact_x1
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+        retMem dMem dloMem scratchUn0 scratchMem raVal
+        halign hbltu hborrow_nz hcarry2_nz)
+  · have hborrow_zero :
+        mulsubN4NoBorrow (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold mulsubN4NoBorrow
+      dsimp only
+      unfold mulsubN4_c3 at hborrow
+      rw [if_neg hborrow]
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => hp)
+        (fun h hp => by
+          rw [loopBodyN2CallSkipJ0PostV5NoX1_eq_scratch] at hp
+          rw [loopIterPostN2CallScratchNoX1_skip hborrow] at hp
+          xperm_hyp hp)
+        (divK_loop_body_n2_call_skip_j0_norm_v5_noNop_exact_x1
+          sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+          retMem dMem dloMem scratchUn0 scratchMem raVal
+          halign hbltu hborrow_zero)
+
+/-- Unified j=0 N2 max iteration over v5/no-NOP code (loop exit), preserving
+    concrete `x1` and carrying the v5 scratch cells as frame. -/
+theorem divK_loop_body_n2_max_j0_exact_loopIterScratch_v5_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v5 base)
+      ((loopBodyN2MaxSkipJ0NormPreV4 sp
+        jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      ((loopIterPostN2Max sp (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal))) := by
+  by_cases hborrow :
+      BitVec.ult uTop
+        (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) ≠ (0 : Word) := by
+      rw [if_pos hborrow]
+      decide
+    have J := divK_loop_body_n2_max_addback_j0_beq_norm_v5_noNop
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hcarry2_nz hborrow_nz
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by
+        rw [loopIterPostN2Max_addback hborrow] at hp
+        xperm_hyp hp)
+      Jf
+  · have hborrow_zero :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) = (0 : Word) := by
+      rw [if_neg hborrow]
+    have J := divK_loop_body_n2_max_skip_j0_norm_v5_noNop
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hborrow_zero
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => by xperm_hyp hp)
+        (fun h hp => by
+          rw [loopIterPostN2Max_skip hborrow] at hp
+          xperm_hyp hp)
+        Jf
+
+end EvmAsm.Evm64


### PR DESCRIPTION
The j=0 exit digits the 8 full n=2 combos chain after a 2-digit prefix. Mirror of `divK_loop_body_n2_{call,max}_j0_exact_loopIterScratch_v4_noNop` (loopBodyOff → denormOff):

- supplies two missing prerequisites: `divK_loop_body_n2_max_addback_j0_beq_norm_v5_noNop` (the j=0 max addback norm; #7383 did only j>0) and the J0 call post-eq lemmas (`loopBodyN2Call{Skip,AddbackBeq}J0PostV5NoX1_eq_scratch`)
- `divK_loop_body_n2_{call,max}_j0_exact_loopIterScratch_v5_noNop` — case on the c3 borrow guard, dispatch to the v5 j=0 norm bodies (#7383/#7390), weaken via the post-eq lemmas + code-agnostic producer bridges. Call exit 234 steps (skip mono 158→234); max exit 152 (skip mono 76→152).

Stacked on #7395 (v5 n=2 2-digit prefix combos).

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)