### PR TITLE
feat(divmod): v5 n=2 call×max×max full 3-digit combo (TMM)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -190,6 +190,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0Exit
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFinalPostCCC
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCCC
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCCM
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboTMM
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePostSelected
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboTMM.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboTMM.lean
@@ -1,0 +1,278 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboTMM
+
+  Three-iteration call×max×max composition for the n=2 v5/no-NOP source path.
+  j=2 takes the call path; j=1 and j=0 take the max-trial branch.  Reuses
+  r2CCCN2V5 (j=2 call) + the call×max prefix (#7395); defines r1TMMN2V5 (j=1 max
+  result).  Mirror of FullPathN2V4NoNopTMM.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFinalPostCCC
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCombo2
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopSource
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Opaque alias for the j=1 `iterN2Max` result (call×max×max, v5),
+    parameterized on `r2 := r2CCCN2V5 ...`. -/
+@[irreducible]
+def r1TMMN2V5 (v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let r2 := r2CCCN2V5 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  iterN2Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+
+theorem r1TMMN2V5_eq (v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop : Word) :
+    r1TMMN2V5 v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop =
+      (let r2 := r2CCCN2V5 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+       iterN2Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1) := by
+  delta r1TMMN2V5; rfl
+
+/-- Compact final postcondition for the n=2 v5 call×max×max source path. -/
+@[irreducible]
+def loopN2CallMaxMaxSourceFinalPostNoX1V5 (sp base : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem : Word) :
+    Assertion :=
+  let r2 := r2CCCN2V5 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let r1 := r1TMMN2V5 v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop
+  let scratch2 := divKTrialCallV5ScratchOut u2 u1 v1 scratchMem
+  let uBase2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+  let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+  ((loopIterPostN2Max sp (0 : Word) v0 v1 v2 v3
+    u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+    (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+    (sp + signExtend12 3960 ↦ₘ v1) **
+    (sp + signExtend12 3952 ↦ₘ (divKTrialCallV5DLo v1)) **
+    (sp + signExtend12 3944 ↦ₘ (divKTrialCallV5Un0 u1)) **
+    (sp + signExtend12 3936 ↦ₘ scratch2) **
+    (.x1 ↦ᵣ raVal)) **
+    (((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+      (qAddr1 ↦ₘ r1.1)) **
+     ((uBase2 + signExtend12 4064 ↦ₘ r2.2.2.2.2.2) **
+      (qAddr2 ↦ₘ r2.1))))
+
+theorem loopN2CallMaxMaxSourceFinalPostNoX1V5_unfold (sp base : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem : Word) :
+    loopN2CallMaxMaxSourceFinalPostNoX1V5 sp base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem =
+    (let r2 := r2CCCN2V5 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+     let r1 := r1TMMN2V5 v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop
+     let scratch2 := divKTrialCallV5ScratchOut u2 u1 v1 scratchMem
+     let uBase2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+     let qAddr2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+     let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+     let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+     ((loopIterPostN2Max sp (0 : Word) v0 v1 v2 v3
+       u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+       (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+       (sp + signExtend12 3960 ↦ₘ v1) **
+       (sp + signExtend12 3952 ↦ₘ (divKTrialCallV5DLo v1)) **
+       (sp + signExtend12 3944 ↦ₘ (divKTrialCallV5Un0 u1)) **
+       (sp + signExtend12 3936 ↦ₘ scratch2) **
+       (.x1 ↦ᵣ raVal)) **
+       (((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1)) **
+        ((uBase2 + signExtend12 4064 ↦ₘ r2.2.2.2.2.2) **
+         (qAddr2 ↦ₘ r2.1))))) := by
+  delta loopN2CallMaxMaxSourceFinalPostNoX1V5
+  rfl
+
+/-- Bundled runtime conditions for the n=2 v5 call×max×max source path. -/
+@[irreducible]
+def loopN2CallMaxMaxSourceCondsV5
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 : Word) : Prop :=
+  let r2 := r2CCCN2V5 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let r1 := r1TMMN2V5 v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop
+  BitVec.ult u2 v1 ∧
+  callAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop ∧
+  ¬BitVec.ult r2.2.2.1 v1 ∧
+  isAddbackCarry2NzN2Max v0 v1 v2 v3
+    u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 ∧
+  ¬BitVec.ult r1.2.2.1 v1 ∧
+  isAddbackCarry2NzN2Max v0 v1 v2 v3
+    u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+
+theorem loopN2CallMaxMaxSourceCondsV5_unfold
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 : Word) :
+    loopN2CallMaxMaxSourceCondsV5
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 =
+    (let r2 := r2CCCN2V5 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+     let r1 := r1TMMN2V5 v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop
+     BitVec.ult u2 v1 ∧
+     callAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop ∧
+     ¬BitVec.ult r2.2.2.1 v1 ∧
+     isAddbackCarry2NzN2Max v0 v1 v2 v3
+       u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 ∧
+     ¬BitVec.ult r1.2.2.1 v1 ∧
+     isAddbackCarry2NzN2Max v0 v1 v2 v3
+       u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) := by
+  delta loopN2CallMaxMaxSourceCondsV5
+  rfl
+
+/-- The n=2 v5/no-NOP source path whose j=2 takes call and j=1/j=0 take max. -/
+theorem divK_loop_n2_call_max_max_from_source_exact_loopIterScratch_v5_noNop
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hconds :
+      loopN2CallMaxMaxSourceCondsV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0Orig1 u0Orig0) :
+    cpsTripleWithin (234 + 152 + 152) (base + loopBodyOff) (base + denormOff)
+      (divCode_noNop_v5 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN2CallMaxMaxSourceFinalPostNoX1V5 sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem) := by
+  rw [loopN2CallMaxMaxSourceCondsV5_unfold] at hconds
+  simp only [r2CCCN2V5_eq, r1TMMN2V5_eq, callAddbackCarry2NzV5_unfold] at hconds
+  obtain ⟨hbltu_2, hcarry2_nz_2, hbltu_1, hcarry2_nz_1, hbltu_0, hcarry2_nz_0⟩ := hconds
+  have JCM := divK_loop_n2_call_max_from_source_exact_loopIterScratch_v5_noNop
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    halign hbltu_2 hcarry2_nz_2 hbltu_1 hcarry2_nz_1
+  have J0 := divK_loop_body_n2_max_j0_exact_loopIterScratch_v5_noNop sp base
+    (1 : Word) ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3
+      (signExtend12 4095 : Word)
+      v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1)
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig0
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    q0Old raVal
+    (base + div128CallRetOff) v1
+    (divKTrialCallV5DLo v1)
+    (divKTrialCallV5Un0 u1)
+    (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem)
+    hbltu_0 hcarry2_nz_0
+  have J0f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterN2Max v0 v1 v2 v3 u0Orig1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+      (iterN2Max v0 v1 v2 v3 u0Orig1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1)) **
+     (((sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)))
+    (by pcFree) J0
+  have hcomp := cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN2MaxScratchX1_j1_to_max_j0_pre_with_j2_frame
+      sp (base + div128CallRetOff) v1 (divKTrialCallV5DLo v1)
+      (divKTrialCallV5Un0 u1)
+      (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem)
+      v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+      u0Orig0 q0Old raVal
+      (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+    JCM J0f
+  have hsteps : (234 + 152) + 152 = 234 + 152 + 152 := by decide
+  rw [hsteps] at hcomp
+  refine cpsTripleWithin_weaken (fun _ hp => hp) ?_ hcomp
+  intro h hp
+  rw [loopN2CallMaxMaxSourceFinalPostNoX1V5_unfold]
+  simp only [r2CCCN2V5_eq, r1TMMN2V5_eq] at hp ⊢
+  xperm_hyp hp
+
+end EvmAsm.Evm64


### PR DESCRIPTION
The 3rd of the 8 full 3-digit n=2 v5 combos (j=2 call, j=1/j=0 max). Mirror of `divK_loop_n2_call_max_max_from_source_exact_loopIterScratch_v4_noNop`:

- defines `r1TMMN2V5` (j=1 `iterN2Max` over `r2CCCN2V5`) + the ccm-style `FinalPost`/`Conds`
- composes the v5 call×max prefix (#7395) with the v5 j=0 max exit body (#7396) via `loopIterPostN2MaxScratchX1_j1_to_max_j0_pre_with_j2_frame`. 234+152+152.

Raw nested form spelled out for J0 args (no irreducible aliases, per the #7400 whnf lesson). 3 of 8 full combos done (ccc, ccm, cmm).

Stacked on #7400 (v5 call×call×max combo).

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)