### PR TITLE
feat(divmod): v5 n=2 phaseB preloop block

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -200,6 +200,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopDefs
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopDispatch
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopUnifiedPost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopUnified
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePostSelected
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopPreloop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopPreloop.lean
@@ -1,126 +1,54 @@
 /-
-  EvmAsm.Evm64.DivMod.Compose.PhaseBV5
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopPreloop
 
-  v5 phase-B brick (21 steps, phaseBOff → clzOff, n=1 detection path) over
-  `divCode_noNop_v5`.  Mirror of `evm_div_phaseB_n1_spec_within_v4_noNop`
-  (PhaseABV4NoNop.lean): phase-B doesn't touch div128, so the same version-agnostic
-  instruction bodies (init1/init2/tail + addi/bne singletons) extend to the v5 code
-  via the v5 block subsumption `sharedNoNop_v5_b1_div`.  Last leaf of the v5 n=1
-  preloop.  Bead `evm-asm-wbc4i.9.1`.
+  Preloop setup wrappers for the n=2 v5/no-NOP full DIV path.  Mirror of
+  FullPathN2V4NoNopPreloop, lifted to `divCode_noNop_v5` (the preloop runs the
+  shared clz/normalize/copyAU instructions, not the differing div128 subroutine).
+  Reuses the generic v5 preloop blocks (PhaseAV5/CLZV5/PhaseC2V5/NormBV5/NormAV5/
+  LoopSetupV5) + the v5 phaseB code-subsumption lemmas (PhaseBV5); only the
+  n=2-specific phaseB / compositions are built here.
 -/
 
+import EvmAsm.Evm64.DivMod.Compose.PhaseBV5
 import EvmAsm.Evm64.DivMod.Compose.PhaseABV4NoNop
-import EvmAsm.Evm64.DivMod.Compose.V5NoNop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopUnified
+
+open EvmAsm.Rv64.Tactics
 
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 
-theorem divK_phaseB_init1_code_sub_divCode_noNop_v5 {base : Word} :
-    ∀ a i, (divK_phaseB_init1_code (base + phaseBOff)) a = some i →
-      (divCode_noNop_v5 base) a = some i := by
-  intro a i h
-  exact sharedNoNop_v5_b1_div a i (CodeReq.ofProg_mono_sub (base + phaseBOff) (base + phaseBOff) divK_phaseB
-    (divK_phaseB.take 7) 0 (by bv_addr) (by decide) (by decide) (by decide) a i h)
-
-theorem divK_phaseB_init2_code_sub_divCode_noNop_v5 {base : Word} :
-    ∀ a i, (divK_phaseB_init2_code (base + phaseBInit2Off)) a = some i →
-      (divCode_noNop_v5 base) a = some i := by
-  intro a i h
-  exact sharedNoNop_v5_b1_div a i (CodeReq.ofProg_mono_sub (base + phaseBOff) (base + phaseBInit2Off) divK_phaseB
-    (divK_phaseB.drop 7 |>.take 2) 7 (by bv_addr) (by decide) (by decide) (by decide) a i h)
-
-theorem divK_phaseB_tail_code_sub_divCode_noNop_v5 {base : Word} :
-    ∀ a i, (divK_phaseB_tail_code (base + phaseBTailOff)) a = some i →
-      (divCode_noNop_v5 base) a = some i := by
-  intro a i h
-  exact sharedNoNop_v5_b1_div a i (CodeReq.ofProg_mono_sub (base + phaseBOff) (base + phaseBTailOff) divK_phaseB
-    (divK_phaseB.drop 16) 16 (by bv_addr) (by decide) (by decide) (by decide) a i h)
-
-theorem addi_x5_singleton_sub_divCode_noNop_v5 {base : Word} :
-    ∀ a i, (CodeReq.singleton (base + phaseBStep0Off) (.ADDI .x5 .x0 4)) a = some i →
-      (divCode_noNop_v5 base) a = some i := by
-  intro a i h
-  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 9 (by decide) (by decide)
-  rw [show (base + phaseBOff : Word) + BitVec.ofNat 64 (4 * 9) = base + phaseBStep0Off from by bv_addr] at hlookup
-  exact sharedNoNop_v5_b1_div a i (CodeReq.singleton_mono hlookup a i h)
-
-theorem bne_x10_singleton_sub_divCode_noNop_v5 {base : Word} :
-    ∀ a i, (CodeReq.singleton (base + phaseBBneOff) (.BNE .x10 .x0 24)) a = some i →
-      (divCode_noNop_v5 base) a = some i := by
-  intro a i h
-  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 10 (by decide) (by decide)
-  rw [show (base + phaseBOff : Word) + BitVec.ofNat 64 (4 * 10) = base + phaseBBneOff from by bv_addr] at hlookup
-  exact sharedNoNop_v5_b1_div a i (CodeReq.singleton_mono hlookup a i h)
-
-theorem addi_x5_3_sub_divCode_noNop_v5 {base : Word} :
-    ∀ a i, (CodeReq.singleton (base + phaseBStep1Off) (.ADDI .x5 .x0 3)) a = some i →
-      (divCode_noNop_v5 base) a = some i := by
-  intro a i h
-  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 11 (by decide) (by decide)
-  rw [show (base + phaseBOff : Word) + BitVec.ofNat 64 (4 * 11) = base + phaseBStep1Off from by bv_addr] at hlookup
-  exact sharedNoNop_v5_b1_div a i (CodeReq.singleton_mono hlookup a i h)
-
-theorem bne_x7_16_sub_divCode_noNop_v5 {base : Word} :
-    ∀ a i, (CodeReq.singleton (base + phaseBBne2Off) (.BNE .x7 .x0 16)) a = some i →
-      (divCode_noNop_v5 base) a = some i := by
-  intro a i h
-  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 12 (by decide) (by decide)
-  rw [show (base + phaseBOff : Word) + BitVec.ofNat 64 (4 * 12) = base + phaseBBne2Off from by bv_addr] at hlookup
-  exact sharedNoNop_v5_b1_div a i (CodeReq.singleton_mono hlookup a i h)
-
-theorem addi_x5_2_sub_divCode_noNop_v5 {base : Word} :
-    ∀ a i, (CodeReq.singleton (base + phaseBStep2Off) (.ADDI .x5 .x0 2)) a = some i →
-      (divCode_noNop_v5 base) a = some i := by
-  intro a i h
-  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 13 (by decide) (by decide)
-  rw [show (base + phaseBOff : Word) + BitVec.ofNat 64 (4 * 13) = base + phaseBStep2Off from by bv_addr] at hlookup
-  exact sharedNoNop_v5_b1_div a i (CodeReq.singleton_mono hlookup a i h)
-
-theorem bne_x6_8_sub_divCode_noNop_v5 {base : Word} :
-    ∀ a i, (CodeReq.singleton (base + phaseBBne3Off) (.BNE .x6 .x0 8)) a = some i →
-      (divCode_noNop_v5 base) a = some i := by
-  intro a i h
-  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 14 (by decide) (by decide)
-  rw [show (base + phaseBOff : Word) + BitVec.ofNat 64 (4 * 14) = base + phaseBBne3Off from by bv_addr] at hlookup
-  exact sharedNoNop_v5_b1_div a i (CodeReq.singleton_mono hlookup a i h)
-
-theorem addi_x5_1_sub_divCode_noNop_v5 {base : Word} :
-    ∀ a i, (CodeReq.singleton (base + phaseBStep3Off) (.ADDI .x5 .x0 1)) a = some i →
-      (divCode_noNop_v5 base) a = some i := by
-  intro a i h
-  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 15 (by decide) (by decide)
-  rw [show (base + phaseBOff : Word) + BitVec.ofNat 64 (4 * 15) = base + phaseBStep3Off from by bv_addr] at hlookup
-  exact sharedNoNop_v5_b1_div a i (CodeReq.singleton_mono hlookup a i h)
-
-/-- v5 phase-B (n=1 detection), over `divCode_noNop_v5`.  Mirror of the v4 analog. -/
-theorem evm_div_phaseB_n1_spec_within_v5_noNop (sp base : Word)
-    (b0 b1 b2 b3 : Word) (v5 v6 v7 : Word)
+/-- v5 phase-B (n=2 detection: b3=b2=0, b1≠0), over `divCode_noNop_v5`.
+    Mirror of `evm_div_phaseB_n2_spec_within_v4_noNop` with v5 code subsumption. -/
+theorem evm_div_phaseB_n2_spec_within_v5_noNop (sp base : Word)
+    (b1 b2 b3 : Word) (v5 v6 v7 : Word)
     (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
-    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0) :
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0) :
     cpsTripleWithin 21 (base + phaseBOff) (base + clzOff) (divCode_noNop_v5 base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
-       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) **
        ((sp + signExtend12 3984) ↦ₘ nMem))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b1) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
-       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
        ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
        ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
        ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-       ((sp + signExtend12 3984) ↦ₘ (1 : Word))) := by
+       ((sp + signExtend12 3984) ↦ₘ (2 : Word))) := by
   have hinit1_raw := divK_phaseB_init1_spec_within sp (base + phaseBOff) q0 q1 q2 q3 u5 u6 u7
   simp only [phB_off_28] at hinit1_raw
   have hinit1 := cpsTripleWithin_extend_code divK_phaseB_init1_code_sub_divCode_noNop_v5 hinit1_raw
   have hinit1f := cpsTripleWithin_frameR
     ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
-     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
      ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit1
   have hinit2_raw := divK_phaseB_init2_spec_within sp (base + phaseBInit2Off) b1 b2 v6 v7
@@ -128,7 +56,7 @@ theorem evm_div_phaseB_n1_spec_within_v5_noNop (sp base : Word)
   have hinit2 := cpsTripleWithin_extend_code divK_phaseB_init2_code_sub_divCode_noNop_v5 hinit2_raw
   have hinit2f := cpsTripleWithin_frameR
     ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
-     ((sp + 32) ↦ₘ b0) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + 56) ↦ₘ b3) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
@@ -142,7 +70,7 @@ theorem evm_div_phaseB_n1_spec_within_v5_noNop (sp base : Word)
   have haddi0 := cpsTripleWithin_extend_code addi_x5_singleton_sub_divCode_noNop_v5 haddi0_raw
   have haddi0f := cpsTripleWithin_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
-     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
@@ -161,7 +89,7 @@ theorem evm_div_phaseB_n1_spec_within_v5_noNop (sp base : Word)
   have hbne0 := cpsTripleWithin_extend_code bne_x10_singleton_sub_divCode_noNop_v5 hbne0_clean
   have hbne0f := cpsTripleWithin_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
-     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
@@ -175,7 +103,7 @@ theorem evm_div_phaseB_n1_spec_within_v5_noNop (sp base : Word)
   have haddi1 := cpsTripleWithin_extend_code addi_x5_3_sub_divCode_noNop_v5 haddi1_raw
   have haddi1f := cpsTripleWithin_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
-     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
@@ -194,7 +122,7 @@ theorem evm_div_phaseB_n1_spec_within_v5_noNop (sp base : Word)
   have hbne1 := cpsTripleWithin_extend_code bne_x7_16_sub_divCode_noNop_v5 hbne1_clean
   have hbne1f := cpsTripleWithin_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) **
-     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
@@ -208,7 +136,7 @@ theorem evm_div_phaseB_n1_spec_within_v5_noNop (sp base : Word)
   have haddi2 := cpsTripleWithin_extend_code addi_x5_2_sub_divCode_noNop_v5 haddi2_raw
   have haddi2f := cpsTripleWithin_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x7 ↦ᵣ b2) ** (.x6 ↦ᵣ b1) **
-     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
@@ -216,18 +144,18 @@ theorem evm_div_phaseB_n1_spec_within_v5_noNop (sp base : Word)
      ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) haddi2
   have h1234567 := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by xperm_hyp hp) h123456 haddi2f
+    (fun h hp => by xperm_chunked hp) h123456 haddi2f
   have hbne2_raw := bne_spec_gen_within .x6 .x0 8 b1 (0 : Word) (base + phaseBBne3Off)
   rw [show (base + phaseBBne3Off : Word) + signExtend13 8 = base + phaseBTailOff from by
         rv64_addr, phB_step2_8_v4] at hbne2_raw
-  have hbne2_clean := cpsBranchWithin_ntakenStripPure2 hbne2_raw
-    (fun hp hQt => by
-      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact absurd hb1z ((sepConj_pure_right _).mp h_rest).2)
+  have hbne2_clean := cpsBranchWithin_takenStripPure2 hbne2_raw
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hb1nz)
   have hbne2 := cpsTripleWithin_extend_code bne_x6_8_sub_divCode_noNop_v5 hbne2_clean
   have hbne2f := cpsTripleWithin_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (2 : Word)) ** (.x10 ↦ᵣ b3) ** (.x7 ↦ᵣ b2) **
-     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
@@ -235,38 +163,24 @@ theorem evm_div_phaseB_n1_spec_within_v5_noNop (sp base : Word)
      ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hbne2
   have h12345678 := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by xperm_hyp hp) h1234567 hbne2f
-  have haddi3_raw := addi_x0_spec_gen_within .x5 (2 : Word) 1 (base + phaseBStep3Off) (by nofun)
-  simp only [phB_fall_4_v4, signExtend12_1] at haddi3_raw
-  have haddi3 := cpsTripleWithin_extend_code addi_x5_1_sub_divCode_noNop_v5 haddi3_raw
-  have haddi3f := cpsTripleWithin_frameR
-    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
-     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
-     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ nMem))
-    (by pcFree) haddi3
-  have h123456789 := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by xperm_chunked hp) h12345678 haddi3f
-  have htail_raw := divK_phaseB_tail_spec_within sp (1 : Word) b0 nMem (base + phaseBTailOff)
+    (fun h hp => by xperm_chunked hp) h1234567 hbne2f
+  have htail_raw := divK_phaseB_tail_spec_within sp (2 : Word) b1 nMem (base + phaseBTailOff)
   simp only [divK_phaseB_tail_pre_unfold, divK_phaseB_tail_post_unfold,
-             phB_t_20_v4, divK_phaseB_n1_nm1_x8_v4, signExtend12_32, phB_sp0_32_v4] at htail_raw
+             phB_t_20_v4, divK_phaseB_n2_nm1_x8_v4, signExtend12_32, phB_sp8_32_v4] at htail_raw
   have htail := cpsTripleWithin_extend_code divK_phaseB_tail_code_sub_divCode_noNop_v5 htail_raw
   have htailf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
-     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)))
     (by pcFree) htail
   have hphaseB := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by xperm_chunked hp) h123456789 htailf
+    (fun h hp => by xperm_hyp hp) h12345678 htailf
   exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-    (fun h hp => by xperm_chunked hp)
-    (fun h hq => by xperm_chunked hq)
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
     hphaseB
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseABV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseABV4NoNop.lean
@@ -37,7 +37,7 @@ theorem phB_t_20_v4 {base : Word} :
 theorem divK_phaseB_n1_nm1_x8_v4 :
     ((1 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat = (0 : Word) := by
   decide
-private theorem divK_phaseB_n2_nm1_x8_v4 :
+theorem divK_phaseB_n2_nm1_x8_v4 :
     ((2 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat = (8 : Word) := by
   decide
 private theorem divK_phaseB_n3_nm1_x8_v4 :
@@ -49,7 +49,7 @@ private theorem divK_phaseB_n4_nm1_x8_v4 :
 theorem phB_sp0_32_v4 {sp : Word} :
     (sp + (0 : Word) + (32 : Word)) = sp + 32 := by
   bv_addr
-private theorem phB_sp8_32_v4 {sp : Word} :
+theorem phB_sp8_32_v4 {sp : Word} :
     (sp + (8 : Word) + (32 : Word)) = sp + 40 := by
   bv_addr
 private theorem phB_sp16_32_v4 {sp : Word} :


### PR DESCRIPTION
Adds `evm_div_phaseB_n2_spec_within_v5_noNop` (n=2 divisor detection) over `divCode_noNop_v5` — the only n2-specific preloop block lacking a v5 version. Mirror of the v4 phaseB_n2 swapping the phaseB code-sub lemmas v4→v5. Un-privates the PhaseBV5 code-sub lemmas + two n2 tail address lemmas so the preloop file can reuse them. First block of the n2 preloop chain.

Stacked on #7410 (unified loop).

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)