### PR TITLE
feat(divmod): v5 n=2 preloop with loop x1+scratch frame

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopPreloop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopPreloop.lean
@@ -394,4 +394,65 @@ theorem evm_div_n2_to_loopSetup_spec_within_v5_noNop (sp base : Word)
     (fun h hq => by delta loopSetupPost; xperm_hyp hq)
     hFull
 
+/-- n=2 v5/no-NOP entry→loopSetup with the loop's x1+scratch frame already in
+    place.  Mirror of `evm_div_n2_to_loopSetup_spec_within_v4_noNop_exact_x1_scratch_frame`
+    (frameR + weaken around `evm_div_n2_to_loopSetup_spec_within_v5_noNop`). -/
+theorem evm_div_n2_to_loopSetup_spec_within_v5_noNop_exact_x1_scratch_frame
+    (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
+    (hshift_nz : (clzResult b1).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff)
+      (divCode_noNop_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      (loopSetupPost sp (2 : Word) (clzResult b1).1 a0 a1 a2 a3 b0 b1 b2 b3 **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal))) := by
+  have hPre :=
+    evm_div_n2_to_loopSetup_spec_within_v5_noNop sp base a0 a1 a2 a3 b0 b1 b2 b3
+      v5 v6 v7 v10 q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+      hbnz hb3z hb2z hb1nz hshift_nz
+  have hFramed := cpsTripleWithin_frameR
+    (((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+      (sp + signExtend12 3968 ↦ₘ retMem) **
+      (sp + signExtend12 3960 ↦ₘ dMem) **
+      (sp + signExtend12 3952 ↦ₘ dloMem) **
+      (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+      (sp + signExtend12 3936 ↦ₘ scratchMem) **
+      (.x1 ↦ᵣ raVal)))
+    (by pcFree) hPre
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hFramed
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopPreloop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopPreloop.lean
@@ -245,4 +245,153 @@ theorem evm_div_phaseAB_n2_clz_spec_within_v5_noNop (sp base : Word)
     (fun h hq => by xperm_hyp hq)
     hABCLZ
 
+/-- PhaseAB(n=2) + CLZ + PhaseC2(shift≠0) + NormB over `divCode_noNop_v5`. -/
+theorem evm_div_n2_to_normB_spec_within_v5_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
+    (hshift_nz : (clzResult b1).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21) base (base + normAOff) (divCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (normBPost sp (2 : Word) (clzResult b1).1 b0 b1 b2 b3) := by
+  let shift := (clzResult b1).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  have hABCLZ := evm_div_phaseAB_n2_clz_spec_within_v5_noNop sp base b0 b1 b2 b3
+    v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2z hb1nz
+  have hABCLZf := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
+    (by pcFree) hABCLZ
+  have hC2 := divK_phaseC2_ntaken_spec_within_v5_noNop sp shift ((clzResult b1).2 >>> (63 : Nat))
+    shiftMem base hshift_nz
+  have hC2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ (clzResult b1).2) ** (.x10 ↦ᵣ b3) **
+     (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)))
+    (by pcFree) hC2
+  have hABC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABCLZf hC2f
+  have hNB := divK_normB_full_spec_within_v5_noNop sp b0 b1 b2 b3
+    (clzResult b1).2 ((clzResult b1).2 >>> (63 : Nat))
+    shift antiShift base
+  simp only [normBFullPost_unfold] at hNB
+  have hNBf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNB
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABC2 hNBf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta normBPost; xperm_hyp hq)
+    hFull
+
+/-- n=2 preloop entry-to-loopSetup over `divCode_noNop_v5`. base → base+loopBodyOff. -/
+theorem evm_div_n2_to_loopSetup_spec_within_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
+    (hshift_nz : (clzResult b1).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (divCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (loopSetupPost sp (2 : Word) (clzResult b1).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := (clzResult b1).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  have hNB := evm_div_n2_to_normB_spec_within_v5_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u5 u6 u7 nMem shiftMem hbnz hb3z hb2z hb1nz hshift_nz
+  have hNBf := cpsTripleWithin_frameR
+    ((.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+     ((sp + signExtend12 4024) ↦ₘ u4Old))
+    (by pcFree) hNB
+  have hNormA := divK_normA_full_spec_within_v5_noNop sp a0 a1 a2 a3
+    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
+    u0Old u1Old u2Old u3Old u4Old base
+  rw [divKNormAFullPreNoNop_unfold] at hNormA
+  simp only [normAFullPost_unfold] at hNormA
+  have hNormAf := cpsTripleWithin_frameR
+    ((.x0 ↦ᵣ (0 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ ((b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)))) **
+     ((sp + 56) ↦ₘ ((b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)))) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNormA
+  have hNA := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by delta normBPost at hp; xperm_hyp hp) hNBf hNormAf
+  have hLS := divK_loopSetup_ntaken_spec_within_v5_noNop sp (2 : Word)
+    (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
+    (by decide)
+  simp only [divKLoopSetupNtakenPreNoNop_unfold,
+      divKLoopSetupNtakenPostNoNop_unfold] at hLS
+  have hLSf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ ((b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)))) **
+     ((sp + 56) ↦ₘ ((b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)))) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+     ((sp + signExtend12 4040) ↦ₘ u2) **
+     ((sp + signExtend12 4032) ↦ₘ (a3 <<< (shift.toNat % 64) ||| a2 >>> (antiShift.toNat % 64))) **
+     ((sp + signExtend12 4024) ↦ₘ (a3 >>> (antiShift.toNat % 64))) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hLS
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hNA hLSf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta loopSetupPost; xperm_hyp hq)
+    hFull
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Adds `evm_div_n2_to_loopSetup_spec_within_v5_noNop_exact_x1_scratch_frame` — frameR (x11, jMem, ret/d/dlo/scratchUn0/scratchMem, .x1↦raVal) + weaken around the to_loopSetup block, putting the preloop post in the exact shape the unified v5 loop (#7410) consumes. The v4 bridge `loopSetupPost_to_loopN2PreWithScratchV4NoX1_framed` reuses directly since the v5 loop's pre is the code-agnostic `loopN2PreWithScratchV4NoX1`.

Stacked on #7413.

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)