### PR TITLE
feat(divmod): v5 n=2 full preloop+loop composition (entry -> denormOff)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -202,6 +202,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopUnifiedPost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopSelected
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopPreloop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFull
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePostSelected
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5Families.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5Families.lean
@@ -249,19 +249,8 @@ theorem fullDivN2UnifiedPostNoX1V5_unfold {bltu_2 bltu_1 bltu_0 : Bool}
        fullDivN2ScratchMemV5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)) := by
   delta fullDivN2UnifiedPostNoX1V5; rfl
 
--- ============================================================================
--- Quotient word
--- ============================================================================
-
-@[irreducible]
-def fullDivN2QuotientWordV5 (bltu_2 bltu_1 bltu_0 : Bool)
-    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : EvmWord :=
-  EvmWord.fromLimbs (fun i : Fin 4 =>
-    match i with
-    | 0 => (fullDivN2R0V5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
-    | 1 => (fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
-    | 2 => (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1
-    | 3 => (0 : Word))
+-- (`fullDivN2QuotientWordV5` lives in `Spec/N2V5QuotientWord.lean`, which imports
+-- this file for the `fullDivN2R{0,1,2}V5` digit results.)
 
 -- ============================================================================
 -- V5 denorm epilogue

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5Families.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5Families.lean
@@ -1,24 +1,25 @@
 /-
   EvmAsm.Evm64.DivMod.Compose.FullPathN2V5Families
 
-  N2 v5 iteration family: `iterN2V5` + `fullDivN2R{0,1,2}V5` + `fullDivN2C3V5`.
-  Mirror of the v4 family (`FullPathN2V4Families`), with the per-digit trial
-  quotient swapped from `divKTrialCallV4QHat` to `divKTrialCallV5QHat` (the only
-  version-dependent component — the normalization, `iterWithDoubleAddback`,
-  `iterN2Max`, and `mulsubN4` are version-agnostic).  Foundational schoolbook
-  defs for the v5 n=2 DIV lane.  Bead `evm-asm-wbc4i.9.2`.
+  N2 V5 iteration family: R0V5/R1V5/R2V5/C3V5/DenormPreV5/etc.
+  Mirrors FullPathN3V4.lean (lines 141-275) for n=2.
 -/
 
-import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4Families
-import EvmAsm.Evm64.DivMod.LoopBody.TrialCallV5
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFull
+import EvmAsm.Evm64.DivMod.Compose.DenormEpilogueV5
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Base
 
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 
-/-- v5 n=2 per-digit iteration: the call path uses the v5 trial quotient
-    `divKTrialCallV5QHat u2 u1 v1` (top two dividend limbs over the divisor's
-    top limb `v1`); the max path is version-agnostic. -/
+open EvmAsm.Rv64.Tactics
+
+-- ============================================================================
+-- V5 iteration intermediates
+-- ============================================================================
+
 @[irreducible]
 def iterN2V5 (bltu : Bool) (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
     Word × Word × Word × Word × Word × Word :=
@@ -66,5 +67,267 @@ def fullDivN2C3V5 (bltu_2 bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
   else
     (mulsubN4 (signExtend12 4095 : Word)
       v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+
+-- ============================================================================
+-- V5 denorm pre/post
+-- ============================================================================
+
+@[irreducible]
+def fullDivN2DenormPreV5 (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let shift := fullDivN2Shift b1
+  let v := fullDivN2NormV b0 b1 b2 b3
+  let r2 := fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN2R0V5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ sp + signExtend12 4056) ** (.x0 ↦ᵣ (0 : Word)) **
+   (.x5 ↦ᵣ (0 : Word)) ** (.x7 ↦ᵣ sp + signExtend12 4088) **
+   (.x2 ↦ᵣ r0.2.2.2.2.1) **
+   (.x10 ↦ᵣ fullDivN2C3V5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) **
+   ((sp + signExtend12 3992) ↦ₘ shift) **
+   ((sp + signExtend12 4056) ↦ₘ r0.2.1) **
+   ((sp + signExtend12 4048) ↦ₘ r0.2.2.1) **
+   ((sp + signExtend12 4040) ↦ₘ r0.2.2.2.1) **
+   ((sp + signExtend12 4032) ↦ₘ r0.2.2.2.2.1) **
+   ((sp + signExtend12 4088) ↦ₘ r0.1) **
+   ((sp + signExtend12 4080) ↦ₘ r1.1) **
+   ((sp + signExtend12 4072) ↦ₘ r2.1) **
+   ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+   ((sp + signExtend12 32) ↦ₘ v.1) **
+   ((sp + signExtend12 40) ↦ₘ v.2.1) **
+   ((sp + signExtend12 48) ↦ₘ v.2.2.1) **
+   ((sp + signExtend12 56) ↦ₘ v.2.2.2))
+
+@[irreducible]
+def fullDivN2DenormPostV5 (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let shift := fullDivN2Shift b1
+  let r2 := fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN2R0V5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1
+    r0.1 r1.1 r2.1 (0 : Word) **
+  ((sp + signExtend12 3992) ↦ₘ shift)
+
+-- ============================================================================
+-- V5 scratch, frame, unified post
+-- ============================================================================
+
+@[irreducible]
+def fullDivN2ScratchMemV5 (bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 scratchMem : Word) : Word :=
+  let v := fullDivN2NormV b0 b1 b2 b3
+  let u := fullDivN2NormU a0 a1 a2 a3 b1
+  let scratch2 := if bltu_2 then
+      divKTrialCallV5ScratchOut u.2.2.2.2 u.2.2.2.1 v.2.1 scratchMem
+    else scratchMem
+  let r2 := fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let scratch1 := if bltu_1 then
+      divKTrialCallV5ScratchOut r2.2.2.1 r2.2.1 v.2.1 scratch2
+    else scratch2
+  let r1 := fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  if bltu_0 then
+    divKTrialCallV5ScratchOut r1.2.2.1 r1.2.1 v.2.1 scratch1
+  else scratch1
+
+@[irreducible]
+def fullDivN2ScratchNoX1V5 (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 : Word) :
+    Assertion :=
+  let v := fullDivN2NormV b0 b1 b2 b3
+  let u := fullDivN2NormU a0 a1 a2 a3 b1
+  let r2 := fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let scratchRet2 := if bltu_2 then (base + div128CallRetOff) else retMem
+  let scratchD2 := if bltu_2 then v.2.1 else dMem
+  let scratchDLo2 := if bltu_2 then divKTrialCallV5DLo v.2.1 else dloMem
+  let scratchUn02 := if bltu_2 then divKTrialCallV5Un0 u.2.2.2.1 else scratchUn0
+  let scratchRet1 := if bltu_1 then (base + div128CallRetOff) else scratchRet2
+  let scratchD1 := if bltu_1 then v.2.1 else scratchD2
+  let scratchDLo1 := if bltu_1 then divKTrialCallV5DLo v.2.1 else scratchDLo2
+  let scratchUn01 := if bltu_1 then divKTrialCallV5Un0 r2.2.1 else scratchUn02
+  let r1 := fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  (sp + signExtend12 3968 ↦ₘ (if bltu_0 then (base + div128CallRetOff) else scratchRet1)) **
+  (sp + signExtend12 3960 ↦ₘ (if bltu_0 then v.2.1 else scratchD1)) **
+  (sp + signExtend12 3952 ↦ₘ (if bltu_0 then divKTrialCallV5DLo v.2.1 else scratchDLo1)) **
+  (sp + signExtend12 3944 ↦ₘ (if bltu_0 then divKTrialCallV5Un0 r1.2.1 else scratchUn01))
+
+@[irreducible]
+def fullDivN2FrameNoX1V5 (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 : Word) :
+    Assertion :=
+  let r2 := fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN2R0V5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) **
+  ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+  ((sp + signExtend12 4008) ↦ₘ r2.2.2.2.2.2) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+  fullDivN2ScratchNoX1V5 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+    retMem dMem dloMem scratchUn0
+
+@[irreducible]
+def fullDivN2UnifiedPostNoX1V5 (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem : Word) :
+    Assertion :=
+  fullDivN2DenormPostV5 bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 **
+  fullDivN2FrameNoX1V5 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+    retMem dMem dloMem scratchUn0 **
+  ((sp + signExtend12 3936) ↦ₘ
+    fullDivN2ScratchMemV5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)
+
+-- ============================================================================
+-- _unfold lemmas for the @[irreducible] V5 assertion bundles
+-- ============================================================================
+
+theorem fullDivN2DenormPostV5_unfold {bltu_2 bltu_1 bltu_0 : Bool}
+    {sp a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
+    fullDivN2DenormPostV5 bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 =
+    (let shift := fullDivN2Shift b1
+     let r2 := fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+     let r1 := fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+     let r0 := fullDivN2R0V5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+     denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1
+       r0.1 r1.1 r2.1 (0 : Word) **
+     ((sp + signExtend12 3992) ↦ₘ shift)) := by
+  delta fullDivN2DenormPostV5; rfl
+
+theorem fullDivN2ScratchNoX1V5_unfold {bltu_2 bltu_1 bltu_0 : Bool}
+    {sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 : Word} :
+    fullDivN2ScratchNoX1V5 bltu_2 bltu_1 bltu_0 sp base
+      a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 =
+    (let v := fullDivN2NormV b0 b1 b2 b3
+     let u := fullDivN2NormU a0 a1 a2 a3 b1
+     let r2 := fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+     let scratchRet2 := if bltu_2 then (base + div128CallRetOff) else retMem
+     let scratchD2 := if bltu_2 then v.2.1 else dMem
+     let scratchDLo2 := if bltu_2 then divKTrialCallV5DLo v.2.1 else dloMem
+     let scratchUn02 := if bltu_2 then divKTrialCallV5Un0 u.2.2.2.1 else scratchUn0
+     let scratchRet1 := if bltu_1 then (base + div128CallRetOff) else scratchRet2
+     let scratchD1 := if bltu_1 then v.2.1 else scratchD2
+     let scratchDLo1 := if bltu_1 then divKTrialCallV5DLo v.2.1 else scratchDLo2
+     let scratchUn01 := if bltu_1 then divKTrialCallV5Un0 r2.2.1 else scratchUn02
+     let r1 := fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+     (sp + signExtend12 3968 ↦ₘ (if bltu_0 then (base + div128CallRetOff) else scratchRet1)) **
+     (sp + signExtend12 3960 ↦ₘ (if bltu_0 then v.2.1 else scratchD1)) **
+     (sp + signExtend12 3952 ↦ₘ (if bltu_0 then divKTrialCallV5DLo v.2.1 else scratchDLo1)) **
+     (sp + signExtend12 3944 ↦ₘ (if bltu_0 then divKTrialCallV5Un0 r1.2.1 else scratchUn01))) := by
+  delta fullDivN2ScratchNoX1V5; rfl
+
+theorem fullDivN2FrameNoX1V5_unfold {bltu_2 bltu_1 bltu_0 : Bool}
+    {sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 : Word} :
+    fullDivN2FrameNoX1V5 bltu_2 bltu_1 bltu_0 sp base
+      a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 =
+    (let r2 := fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+     let r1 := fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+     let r0 := fullDivN2R0V5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) **
+     ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+     ((sp + signExtend12 4008) ↦ₘ r2.2.2.2.2.2) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+     fullDivN2ScratchNoX1V5 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratchUn0) := by
+  delta fullDivN2FrameNoX1V5; rfl
+
+theorem fullDivN2UnifiedPostNoX1V5_unfold {bltu_2 bltu_1 bltu_0 : Bool}
+    {sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem : Word} :
+    fullDivN2UnifiedPostNoX1V5 bltu_2 bltu_1 bltu_0 sp base
+      a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem =
+    (fullDivN2DenormPostV5 bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 **
+     fullDivN2FrameNoX1V5 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratchUn0 **
+     ((sp + signExtend12 3936) ↦ₘ
+       fullDivN2ScratchMemV5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)) := by
+  delta fullDivN2UnifiedPostNoX1V5; rfl
+
+-- ============================================================================
+-- Quotient word
+-- ============================================================================
+
+@[irreducible]
+def fullDivN2QuotientWordV5 (bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : EvmWord :=
+  EvmWord.fromLimbs (fun i : Fin 4 =>
+    match i with
+    | 0 => (fullDivN2R0V5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+    | 1 => (fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+    | 2 => (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1
+    | 3 => (0 : Word))
+
+-- ============================================================================
+-- V5 denorm epilogue
+-- ============================================================================
+
+theorem evm_div_n2_denorm_epilogue_bundled_spec_noNop_v5Final
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hshift_nz : fullDivN2Shift b1 ≠ 0) :
+    cpsTripleWithin (2 + 23 + 10) (base + denormOff) (base + nopOff) (divCode_noNop_v5 base)
+      (fullDivN2DenormPreV5 bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3)
+      (fullDivN2DenormPostV5 bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := fullDivN2Shift b1
+  let v := fullDivN2NormV b0 b1 b2 b3
+  let r2 := fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN2R0V5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  let c3 := fullDivN2C3V5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  have h := evm_div_preamble_denorm_epilogue_spec_v5_noNop sp base
+    r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 shift
+    r0.2.2.2.2.1 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    c3 r0.1 r1.1 r2.1 (0 : Word)
+    v.1 v.2.1 v.2.2.1 v.2.2.2 hshift_nz
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      subst shift; subst v; subst r2; subst r1; subst r0; subst c3
+      delta fullDivN2DenormPreV5 at hp
+      simp only [se12_32, se12_40, se12_48, se12_56] at hp
+      xperm_hyp hp)
+    (fun h hq => by
+      subst shift; subst r2; subst r1; subst r0
+      delta fullDivN2DenormPostV5
+      xperm_hyp hq)
+    h
+
+theorem evm_div_n2_denorm_epilogue_bundled_spec_noNop_v5Final_exact_x1_frame
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hshift_nz : fullDivN2Shift b1 ≠ 0) :
+    cpsTripleWithin (2 + 23 + 10) (base + denormOff) (base + nopOff)
+      (divCode_noNop_v5 base)
+      (fullDivN2DenormPreV5 bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 **
+       fullDivN2FrameNoX1V5 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+         retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ
+         fullDivN2ScratchMemV5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (fullDivN2UnifiedPostNoX1V5 bltu_2 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem **
+       (.x1 ↦ᵣ raVal)) := by
+  have hDenorm := evm_div_n2_denorm_epilogue_bundled_spec_noNop_v5Final
+    bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3 hshift_nz
+  have hFramed := cpsTripleWithin_frameR
+    (fullDivN2FrameNoX1V5 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratchUn0 **
+     ((sp + signExtend12 3936) ↦ₘ
+       fullDivN2ScratchMemV5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) **
+     (.x1 ↦ᵣ raVal))
+    (by
+      delta fullDivN2FrameNoX1V5 fullDivN2ScratchNoX1V5
+      pcFree) hDenorm
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by
+      delta fullDivN2UnifiedPostNoX1V5
+      xperm_hyp hq)
+    hFramed
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopFull.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopFull.lean
@@ -1,0 +1,394 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFull
+
+  n=2 v5/no-NOP path from dispatch entry through the loop (entry → denormOff),
+  composing the framed preloop (#7414), the v4 loopSetupPost→pre bridge (reused
+  verbatim — the v5 loop's pre is the code-agnostic loopN2PreWithScratchV4NoX1),
+  and the instantiated selected-carry v5 loop (#7415). Mirror of
+  `fullDivN2_preloop_loop_unified_exact_x1_scratch_v4_noNop_selectedCarry`
+  (FullPathN2V4NoNopPreloop:662) with the v5 trial accessors + 702-step loop.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopPreloop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopSelected
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopLoopUnified
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Base
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem fullDivN2_preloop_loop_unified_exact_x1_scratch_v5_noNop_selectedCarry
+    (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
+    (hshift_nz : (clzResult b1).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 : bltu_2 =
+      BitVec.ult (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+        (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hbltu_1 : bltu_1 =
+      match bltu_2 with
+      | false =>
+        BitVec.ult (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+          (0 : Word) (0 : Word)).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+      | true =>
+        BitVec.ult (iterWithDoubleAddback
+          (divKTrialCallV5QHat
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.1)
+          (fullDivN2NormV b0 b1 b2 b3).1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+          (0 : Word) (0 : Word)).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_2, bltu_1 with
+      | false, false =>
+        BitVec.ult (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+      | false, true =>
+        BitVec.ult (iterWithDoubleAddback
+          (divKTrialCallV5QHat
+            (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+              (fullDivN2NormV b0 b1 b2 b3).2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (0 : Word) (0 : Word)).2.2.1
+            (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+              (fullDivN2NormV b0 b1 b2 b3).2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (0 : Word) (0 : Word)).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.1)
+          (fullDivN2NormV b0 b1 b2 b3).1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+      | true, false =>
+        BitVec.ult (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+      | true, true =>
+        BitVec.ult (iterWithDoubleAddback
+          (divKTrialCallV5QHat
+            (iterWithDoubleAddback (divKTrialCallV5QHat
+                (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+                (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+                (fullDivN2NormV b0 b1 b2 b3).2.1)
+              (fullDivN2NormV b0 b1 b2 b3).1
+              (fullDivN2NormV b0 b1 b2 b3).2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (0 : Word) (0 : Word)).2.2.1
+            (iterWithDoubleAddback (divKTrialCallV5QHat
+                (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+                (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+                (fullDivN2NormV b0 b1 b2 b3).2.1)
+              (fullDivN2NormV b0 b1 b2 b3).1
+              (fullDivN2NormV b0 b1 b2 b3).2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (0 : Word) (0 : Word)).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.1)
+          (fullDivN2NormV b0 b1 b2 b3).1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hcarry : loopN2SelectedCarryV5 bltu_2 bltu_1 bltu_0
+      (fullDivN2NormV b0 b1 b2 b3).1
+      (fullDivN2NormV b0 b1 b2 b3).2.1
+      (fullDivN2NormV b0 b1 b2 b3).2.2.1
+      (fullDivN2NormV b0 b1 b2 b3).2.2.2
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+      (0 : Word) (0 : Word)
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+      (fullDivN2NormU a0 a1 a2 a3 b1).1) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 702) base (base + denormOff)
+      (divCode_noNop_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      ((loopN2UnifiedPostV5NoX1 bltu_2 bltu_1 bltu_0 sp base
+        (fullDivN2NormV b0 b1 b2 b3).1
+        (fullDivN2NormV b0 b1 b2 b3).2.1
+        (fullDivN2NormV b0 b1 b2 b3).2.2.1
+        (fullDivN2NormV b0 b1 b2 b3).2.2.2
+        (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+        (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+        (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+        (0 : Word) (0 : Word)
+        (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+        (fullDivN2NormU a0 a1 a2 a3 b1).1
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1))) := by
+  have hPre := evm_div_n2_to_loopSetup_spec_within_v5_noNop_exact_x1_scratch_frame
+    sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2z hb1nz hshift_nz
+  have hLoop := evm_div_n2_loop_unified_inst_noNop_exact_x1_v5_selectedCarry
+    bltu_2 bltu_1 bltu_0 sp base
+    (fullDivN2Shift b1) (fullDivN2AntiShift b1)
+    (fullDivN2NormV b0 b1 b2 b3).1
+    (fullDivN2NormV b0 b1 b2 b3).2.1
+    (fullDivN2NormV b0 b1 b2 b3).2.2.1
+    (fullDivN2NormV b0 b1 b2 b3).2.2.2
+    (fullDivN2NormU a0 a1 a2 a3 b1).1
+    (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+    (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+    (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+    (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+    (a0 >>> ((fullDivN2AntiShift b1).toNat % 64)) v11Old jMem
+    retMem dMem dloMem scratchUn0 scratchMem raVal
+    halign hbltu_2 (by cases bltu_2 <;> simpa using hbltu_1)
+    (by cases bltu_2 <;> cases bltu_1 <;> simpa using hbltu_0) hcarry
+  have hLoopf := cpsTripleWithin_frameR
+    ((((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+      ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1)))
+    (by pcFree) hLoop
+  have hBridge := loopSetupPost_to_loopN2PreWithScratchV4NoX1_framed
+    sp a0 a1 a2 a3 b0 b1 b2 b3 v11Old
+    jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+  have hPre' := cpsTripleWithin_weaken
+    (fun h hp => hp)
+    hBridge
+    hPre
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hPre' hLoopf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hq => hq)
+    hFull
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds `fullDivN2_preloop_loop_unified_exact_x1_scratch_v5_noNop_selectedCarry` — composes framed preloop (#7414) + v4 bridge (reused verbatim) + instantiated v5 loop (#7415). `cpsTripleWithin (8+21+24+4+21+21+4+702) base (base+denormOff)` over `divCode_noNop_v5`, post `loopN2UnifiedPostV5NoX1 ** .x1`. **The full n=2 v5 execution path from dispatch entry through the loop is now proven.** Built first try.

Stacked on #7415.

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)