### PR TITLE
feat(divmod): v5 n=2 base callable-exact-frame lane (unifiedDivBound)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -158,6 +158,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallablePost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallablePostSelected
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N2V5ConcretePostBridge
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallableExact
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -160,6 +160,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N2V5ConcretePostBridge
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallableExact
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallAddbackOverestimate
+import EvmAsm.Evm64.DivMod.Spec.N2V5TrialOverestimate
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -163,6 +163,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5CallAddbackOverestimate
 import EvmAsm.Evm64.DivMod.Spec.N2V5TrialOverestimate
 import EvmAsm.Evm64.DivMod.Spec.N2V5C3Invariant
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromUnreach
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromBorrow
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -161,6 +161,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5ConcretePostBridge
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallableExact
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallAddbackOverestimate
 import EvmAsm.Evm64.DivMod.Spec.N2V5TrialOverestimate
+import EvmAsm.Evm64.DivMod.Spec.N2V5C3Invariant
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -162,6 +162,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5CallableExact
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallAddbackOverestimate
 import EvmAsm.Evm64.DivMod.Spec.N2V5TrialOverestimate
 import EvmAsm.Evm64.DivMod.Spec.N2V5C3Invariant
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromUnreach
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -159,6 +159,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallablePostSelected
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N2V5ConcretePostBridge
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallableExact
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallAddbackOverestimate
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5C3Invariant.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5C3Invariant.lean
@@ -1,0 +1,70 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5C3Invariant
+
+  Abstract (qHat-as-value) `c3 = 1` invariant from the `+2` overestimate and the
+  unreachability of the `c3 ∈ {0, 2}` frontier under `carry = 0`.  This is the
+  raw `hc3` form that `callAddbackCarry2NzV5_of_overestimate_c3` (#7424)
+  consumes, with `q := divKTrialCallV5QHat u2 u1 v1`.
+
+  It is the qHat-abstract generalization of
+  `MulsubBltC3OneOfCarryZero_of_plus_two_and_unreach`
+  (DivBltC3InvariantPlusTwoCase, which is hardcoded to `divKTrialCallV4QHat`):
+  the proof is purely structural over `mulsubN4 q …` (only `mulsubN4_c3_le_two`
+  uses `hq_over`), so it applies verbatim to the v5 trial.  Feed `hq_over` from
+  `divKTrialCallV5QHat_le_window_div_plus_two_of_call` (#7425).
+-/
+
+import EvmAsm.Evm64.EvmWordArith.DivMulsubC3LeTwo
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- `c3 = 1` (in raw `carry = 0 → c3 = 1` form) for an arbitrary trial value `q`,
+    from the `+2` overestimate of `q` and the unreachability of the
+    `c3 = 0` / `c3 = 2` cases under `carry = 0`. -/
+theorem mulsubN4_c3_one_of_carry_zero_of_plus_two_and_unreach
+    (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hq_over : q.toNat ≤ val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2)
+    (h_unreach0 :
+      ¬ (addbackN4_carry
+            (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+            (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+            (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+            (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+            v0 v1 v2 v3 = 0 ∧
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 0))
+    (h_unreach2 :
+      ¬ (addbackN4_carry
+            (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+            (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+            (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+            (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+            v0 v1 v2 v3 = 0 ∧
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat = 2)) :
+    addbackN4_carry
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+        v0 v1 v2 v3 = 0 →
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 1 := by
+  intro h_carry_zero
+  have h_c3_le_two := mulsubN4_c3_le_two hbnz hq_over
+  apply BitVec.eq_of_toNat_eq
+  rcases Nat.lt_or_ge (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat 1 with h_lt1 | h_ge1
+  · exfalso
+    have h_c3_zero : (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 0 := by
+      apply BitVec.eq_of_toNat_eq
+      have h_zero : (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat = 0 := by omega
+      rw [h_zero]; rfl
+    exact h_unreach0 ⟨h_carry_zero, h_c3_zero⟩
+  · rcases Nat.lt_or_ge (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat 2 with h_lt2 | h_ge2
+    · have h_eq : (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat = 1 := by omega
+      rw [h_eq]; rfl
+    · exfalso
+      have h_c3_two : (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat = 2 := by omega
+      exact h_unreach2 ⟨h_carry_zero, h_c3_two⟩
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5CallAddbackOverestimate.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5CallAddbackOverestimate.lean
@@ -1,0 +1,45 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5CallAddbackOverestimate
+
+  v5 n=2 call-digit carry: `callAddbackCarry2NzV5` from the +2 Knuth overestimate
+  + the BLT c3 invariant.  v5 counterpart of
+  `loopBodyN2CallAddbackCarry2NzV4_of_overestimate_c3`
+  (DivBltBridgeSpecializations) — `callAddbackCarry2NzV5` is definitionally
+  `isAddbackCarry2Nz (divKTrialCallV5QHat u2 u1 v1) …`, so the qHat-abstract
+  generic lemma `isAddbackCarry2Nz_of_overestimate_c3_one_of_carry_zero` applies
+  directly with the v5 trial.  (The v4 abbrev `MulsubBltC3OneOfCarryZero` is
+  hardcoded to `divKTrialCallV4QHat`, so the c3 invariant is stated here in raw
+  form over `divKTrialCallV5QHat` to avoid a v4-vs-v5 trial reconciliation.)
+  This is the call-digit half of the n=2 carry-from-shape discharge (the
+  max-digit half is `isAddbackCarry2NzN2Max_of_not_ult_c3_one_of_carry_zero`).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFinalPostCCC
+import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmWord (val256)
+
+/-- v5 call-digit carry-2-nonzero from the +2 overestimate and the BLT c3
+    invariant (raw form over the v5 trial `divKTrialCallV5QHat u2 u1 v1`). -/
+theorem callAddbackCarry2NzV5_of_overestimate_c3
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hq_over : (divKTrialCallV5QHat u2 u1 v1).toNat ≤
+      val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2)
+    (hc3 :
+      addbackN4_carry
+          (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).1
+          (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.1
+          (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+          (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+          v0 v1 v2 v3 = 0 →
+        (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 1) :
+    callAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  rw [callAddbackCarry2NzV5_unfold]
+  exact isAddbackCarry2Nz_of_overestimate_c3_one_of_carry_zero
+    (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3 uTop hbnz hq_over hc3
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5CallCarryFromBorrow.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5CallCarryFromBorrow.lean
@@ -1,0 +1,34 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromBorrow
+
+  `callAddbackCarry2NzV5` from `c3 = 1` (the borrow-case fact) plus the `+2`
+  overestimate.  This is the correct discharge of the call-digit carry: it is
+  needed only on the ADDBACK branch of the loop's per-digit borrow dispatch,
+  where `c3 = 1` holds (borrow ⟹ c3 ≠ 0, and the n2 normalized divisor
+  `val256 v < 2^128` forces `c3 ≤ 1`, so `c3 = 1`).  In the no-borrow branch the
+  loop takes the SKIP body (`mulsubN4NoBorrow`) and no carry2nz is required.
+
+  This replaces the over-strong `loopN2SelectedCarryV5` hypothesis (which asserts
+  carry2nz unconditionally — false when a call digit's trial is exact, `c3 = 0`).
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallAddbackOverestimate
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- `callAddbackCarry2NzV5` from the `+2` overestimate and `c3 = 1`.  Since
+    `c3 = 1`, the `carry = 0 → c3 = 1` invariant is immediate, so the call carry
+    follows from `callAddbackCarry2NzV5_of_overestimate_c3` (#7424). -/
+theorem callAddbackCarry2NzV5_of_c3_eq_one
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hq_over : (divKTrialCallV5QHat u2 u1 v1).toNat ≤
+      val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2)
+    (hc3 : (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 1) :
+    callAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop :=
+  callAddbackCarry2NzV5_of_overestimate_c3 v0 v1 v2 v3 u0 u1 u2 u3 uTop hbnz hq_over
+    (fun _ => hc3)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5CallCarryFromUnreach.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5CallCarryFromUnreach.lean
@@ -1,0 +1,49 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromUnreach
+
+  Compose the call-digit carry helper (#7424,
+  `callAddbackCarry2NzV5_of_overestimate_c3`) with the abstract `c3 = 1`
+  invariant (#7426, `mulsubN4_c3_one_of_carry_zero_of_plus_two_and_unreach`):
+  `callAddbackCarry2NzV5` from the `+2` overestimate plus the unreachability of
+  the `c3 ∈ {0, 2}` frontier under `carry = 0`.  This reduces the call-digit
+  carry to exactly the two unreach conditions (the last remaining shape-discharge
+  for the call branch); the `+2` overestimate itself comes from
+  `divKTrialCallV5QHat_le_window_div_plus_two_of_call` (#7425) in the call regime.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallAddbackOverestimate
+import EvmAsm.Evm64.DivMod.Spec.N2V5C3Invariant
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- `callAddbackCarry2NzV5` from the `+2` overestimate and the unreachability of
+    the `c3 = 0` / `c3 = 2` cases under `carry = 0`. -/
+theorem callAddbackCarry2NzV5_of_overestimate_and_unreach
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hq_over : (divKTrialCallV5QHat u2 u1 v1).toNat ≤
+      val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2)
+    (h_unreach0 :
+      ¬ (addbackN4_carry
+            (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).1
+            (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.1
+            (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+            (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+            v0 v1 v2 v3 = 0 ∧
+          (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 0))
+    (h_unreach2 :
+      ¬ (addbackN4_carry
+            (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).1
+            (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.1
+            (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+            (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+            v0 v1 v2 v3 = 0 ∧
+          (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat = 2)) :
+    callAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop :=
+  callAddbackCarry2NzV5_of_overestimate_c3 v0 v1 v2 v3 u0 u1 u2 u3 uTop hbnz hq_over
+    (mulsubN4_c3_one_of_carry_zero_of_plus_two_and_unreach
+      (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3 hbnz hq_over h_unreach0 h_unreach2)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5CallableExact.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5CallableExact.lean
@@ -1,0 +1,76 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5CallableExact
+
+  Base unified-bound n=2 v5 DIV callable exact-frame lane (mirror of the v4
+  `evm_div_n2_stack_spec_noNop_v4_preNoX1_callableExactFrame_uni`): applies the
+  v5 post bridge (#7421) to weaken #7420's unified loop post to the callable
+  exact-frame dispatch post, weakens the scratch cell to memOwn, and lifts the
+  840-step body count to `unifiedDivBound`.  Takes the quotient-correctness fact
+  and the body triple as hypotheses; the shape-level dischargers come later.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5ConcretePostBridge
+import EvmAsm.Evm64.DivMod.Spec.UnifiedBzero
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Unified-bound n=2 DIV v4 body spec over `divCode_noNop_v5` with exact
+    caller-framed `x1` and `x9` in the postcondition.  The v4 trial-call
+    scratch cell at `sp + signExtend12 3936` is existentially closed (`memOwn`).
+
+    `hbody` should be produced by `evm_div_n2_stack_pre_to_unified_post_v5_noNop`.
+    This wrapper applies the bridge to convert the unified post to the callable
+    exact frame, weakens the scratch cell, and lifts to `unifiedDivBound`. -/
+theorem evm_div_n2_stack_spec_noNop_v5_preNoX1_callableExactFrame_uni
+    (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hdivWord : fullDivN2QuotientWordV5 bltu_2 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.div a b)
+    (hbody : cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 702) + (2 + 23 + 10))
+      base (base + nopOff) (divCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (fullDivN2UnifiedPostNoX1V5 bltu_2 bltu_1 bltu_0 sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        retMem dMem dloMem scratchUn0 scratchMem **
+       (.x1 ↦ᵣ raVal))) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) :=
+  cpsTripleWithin_mono_nSteps (by unfold unifiedDivBound; decide) <|
+    cpsTripleWithin_weaken
+      (fun _ hp => hp)
+      (fun _ hq => by
+        obtain ⟨h1, h2, hd, hu, hframe, hscratch⟩ := hq
+        exact ⟨h1, h2, hd, hu, hframe, memIs_implies_memOwn h2 hscratch⟩)
+      (cpsTripleWithin_weaken
+        (fun _ hp => hp)
+        (fun h hq =>
+          fullDivN2UnifiedPostNoX1V5_frame_to_divStackDispatchPostCallableExactFrame_scratch_word
+            bltu_2 bltu_1 bltu_0 sp base a b
+            retMem dMem dloMem scratchUn0 scratchMem raVal hdivWord h hq)
+        hbody)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5TrialOverestimate.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5TrialOverestimate.lean
@@ -1,0 +1,49 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5TrialOverestimate
+
+  The v5 n=2 trial +2 overestimate (call regime), abstract over the per-digit
+  `u`-window: `divKTrialCallV5QHat u2 u1 v1 ≤ val256 u0 u1 u2 0 / val256 v0 v1 0 0 + 2`.
+
+  This is the call-digit hypothesis (`hq_over`) that
+  `callAddbackCarry2NzV5_of_overestimate_c3` (#7424) consumes.  Built by
+  composing `div128Quot_v5_le_q_true` (the EXACT single-limb floor bound, valid
+  in the CALL regime `u2 < v1` — NOT `_le_q_true_plus_one`, which would give +3)
+  with `knuth_theorem_b_abstract`, applying the latter to the `2^128`-scaled
+  window so its `2^256/2^192` split matches the n=2 2-limb divisor and
+  `Nat.mul_div_mul_left` collapses the scale.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.LowerBound
+import EvmAsm.Evm64.EvmWordArith.KnuthTheoremB
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmWord (val256)
+
+/-- v5 n=2 call-digit +2 overestimate, abstract over the digit's `u`-window
+    `(u0, u1, u2)` and the (already normalized) 2-limb divisor `(v0, v1)`. -/
+theorem divKTrialCallV5QHat_le_window_div_plus_two_of_call
+    (u0 u1 u2 v0 v1 : Word)
+    (hv1_norm : v1.toNat ≥ 2 ^ 63)
+    (hcall : u2.toNat < v1.toNat) :
+    (divKTrialCallV5QHat u2 u1 v1).toNat ≤
+      val256 u0 u1 u2 0 / val256 v0 v1 0 0 + 2 := by
+  rw [divKTrialCallV5QHat_eq_div128Quot_v5]
+  have h1 := div128Quot_v5_le_q_true u2 u1 v1 hv1_norm hcall
+  have hvrest : v0.toNat * 2 ^ 128 < 2 ^ 192 := by
+    have h := v0.isLt
+    have he : (2 : Nat) ^ 192 = 2 ^ 64 * 2 ^ 128 := by norm_num
+    rw [he]
+    exact Nat.mul_lt_mul_of_pos_right h (by positivity)
+  have h2 := knuth_theorem_b_abstract
+    (2 ^ 128 * val256 u0 u1 u2 0) (2 ^ 128 * val256 v0 v1 0 0)
+    u2.toNat u1.toNat (u0.toNat * 2 ^ 128)
+    v1.toNat (v0.toNat * 2 ^ 128)
+    (by simp only [val256]; rw [show BitVec.toNat (0 : BitVec 64) = 0 from rfl]; ring)
+    (by simp only [val256]; rw [show BitVec.toNat (0 : BitVec 64) = 0 from rfl]; ring)
+    hvrest hv1_norm hcall u1.isLt
+  rw [Nat.mul_div_mul_left _ _ (by positivity : 0 < 2 ^ 128)] at h2
+  omega
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds `evm_div_n2_stack_spec_noNop_v5_preNoX1_callableExactFrame_uni` — takes `hdivWord` (`fullDivN2QuotientWordV5 = EvmWord.div a b`) + `hbody` (#7420's 840-step path) and produces the `unifiedDivBound` lane with `divStackDispatchPostCallableExactFrame ** memOwn 3936`. Applies the post bridge (#7421), weakens scratch→memOwn, lifts 840≤946 via mono_nSteps. Built.

The shape-level dischargers (bltu/carry from `N2ShapeIs`) feeding hbody/hdivWord come next.

Stacked on #7421.

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)