### PR TITLE
feat(divmod): v5 n=2 call carry from overestimate + unreach (compose #7424+#7426)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -160,6 +160,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N2V5ConcretePostBridge
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallableExact
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallAddbackOverestimate
+import EvmAsm.Evm64.DivMod.Spec.N2V5TrialOverestimate
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -163,6 +163,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5CallAddbackOverestimate
 import EvmAsm.Evm64.DivMod.Spec.N2V5TrialOverestimate
 import EvmAsm.Evm64.DivMod.Spec.N2V5C3Invariant
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromUnreach
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromBorrow
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -161,6 +161,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5ConcretePostBridge
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallableExact
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallAddbackOverestimate
 import EvmAsm.Evm64.DivMod.Spec.N2V5TrialOverestimate
+import EvmAsm.Evm64.DivMod.Spec.N2V5C3Invariant
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -162,6 +162,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5CallableExact
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallAddbackOverestimate
 import EvmAsm.Evm64.DivMod.Spec.N2V5TrialOverestimate
 import EvmAsm.Evm64.DivMod.Spec.N2V5C3Invariant
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromUnreach
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5C3Invariant.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5C3Invariant.lean
@@ -1,0 +1,70 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5C3Invariant
+
+  Abstract (qHat-as-value) `c3 = 1` invariant from the `+2` overestimate and the
+  unreachability of the `c3 ∈ {0, 2}` frontier under `carry = 0`.  This is the
+  raw `hc3` form that `callAddbackCarry2NzV5_of_overestimate_c3` (#7424)
+  consumes, with `q := divKTrialCallV5QHat u2 u1 v1`.
+
+  It is the qHat-abstract generalization of
+  `MulsubBltC3OneOfCarryZero_of_plus_two_and_unreach`
+  (DivBltC3InvariantPlusTwoCase, which is hardcoded to `divKTrialCallV4QHat`):
+  the proof is purely structural over `mulsubN4 q …` (only `mulsubN4_c3_le_two`
+  uses `hq_over`), so it applies verbatim to the v5 trial.  Feed `hq_over` from
+  `divKTrialCallV5QHat_le_window_div_plus_two_of_call` (#7425).
+-/
+
+import EvmAsm.Evm64.EvmWordArith.DivMulsubC3LeTwo
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- `c3 = 1` (in raw `carry = 0 → c3 = 1` form) for an arbitrary trial value `q`,
+    from the `+2` overestimate of `q` and the unreachability of the
+    `c3 = 0` / `c3 = 2` cases under `carry = 0`. -/
+theorem mulsubN4_c3_one_of_carry_zero_of_plus_two_and_unreach
+    (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hq_over : q.toNat ≤ val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2)
+    (h_unreach0 :
+      ¬ (addbackN4_carry
+            (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+            (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+            (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+            (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+            v0 v1 v2 v3 = 0 ∧
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 0))
+    (h_unreach2 :
+      ¬ (addbackN4_carry
+            (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+            (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+            (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+            (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+            v0 v1 v2 v3 = 0 ∧
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat = 2)) :
+    addbackN4_carry
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+        v0 v1 v2 v3 = 0 →
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 1 := by
+  intro h_carry_zero
+  have h_c3_le_two := mulsubN4_c3_le_two hbnz hq_over
+  apply BitVec.eq_of_toNat_eq
+  rcases Nat.lt_or_ge (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat 1 with h_lt1 | h_ge1
+  · exfalso
+    have h_c3_zero : (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 0 := by
+      apply BitVec.eq_of_toNat_eq
+      have h_zero : (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat = 0 := by omega
+      rw [h_zero]; rfl
+    exact h_unreach0 ⟨h_carry_zero, h_c3_zero⟩
+  · rcases Nat.lt_or_ge (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat 2 with h_lt2 | h_ge2
+    · have h_eq : (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat = 1 := by omega
+      rw [h_eq]; rfl
+    · exfalso
+      have h_c3_two : (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat = 2 := by omega
+      exact h_unreach2 ⟨h_carry_zero, h_c3_two⟩
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5CallCarryFromBorrow.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5CallCarryFromBorrow.lean
@@ -1,0 +1,34 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromBorrow
+
+  `callAddbackCarry2NzV5` from `c3 = 1` (the borrow-case fact) plus the `+2`
+  overestimate.  This is the correct discharge of the call-digit carry: it is
+  needed only on the ADDBACK branch of the loop's per-digit borrow dispatch,
+  where `c3 = 1` holds (borrow ⟹ c3 ≠ 0, and the n2 normalized divisor
+  `val256 v < 2^128` forces `c3 ≤ 1`, so `c3 = 1`).  In the no-borrow branch the
+  loop takes the SKIP body (`mulsubN4NoBorrow`) and no carry2nz is required.
+
+  This replaces the over-strong `loopN2SelectedCarryV5` hypothesis (which asserts
+  carry2nz unconditionally — false when a call digit's trial is exact, `c3 = 0`).
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallAddbackOverestimate
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- `callAddbackCarry2NzV5` from the `+2` overestimate and `c3 = 1`.  Since
+    `c3 = 1`, the `carry = 0 → c3 = 1` invariant is immediate, so the call carry
+    follows from `callAddbackCarry2NzV5_of_overestimate_c3` (#7424). -/
+theorem callAddbackCarry2NzV5_of_c3_eq_one
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hq_over : (divKTrialCallV5QHat u2 u1 v1).toNat ≤
+      val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2)
+    (hc3 : (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 1) :
+    callAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop :=
+  callAddbackCarry2NzV5_of_overestimate_c3 v0 v1 v2 v3 u0 u1 u2 u3 uTop hbnz hq_over
+    (fun _ => hc3)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5CallCarryFromUnreach.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5CallCarryFromUnreach.lean
@@ -1,0 +1,49 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromUnreach
+
+  Compose the call-digit carry helper (#7424,
+  `callAddbackCarry2NzV5_of_overestimate_c3`) with the abstract `c3 = 1`
+  invariant (#7426, `mulsubN4_c3_one_of_carry_zero_of_plus_two_and_unreach`):
+  `callAddbackCarry2NzV5` from the `+2` overestimate plus the unreachability of
+  the `c3 ∈ {0, 2}` frontier under `carry = 0`.  This reduces the call-digit
+  carry to exactly the two unreach conditions (the last remaining shape-discharge
+  for the call branch); the `+2` overestimate itself comes from
+  `divKTrialCallV5QHat_le_window_div_plus_two_of_call` (#7425) in the call regime.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallAddbackOverestimate
+import EvmAsm.Evm64.DivMod.Spec.N2V5C3Invariant
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- `callAddbackCarry2NzV5` from the `+2` overestimate and the unreachability of
+    the `c3 = 0` / `c3 = 2` cases under `carry = 0`. -/
+theorem callAddbackCarry2NzV5_of_overestimate_and_unreach
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hq_over : (divKTrialCallV5QHat u2 u1 v1).toNat ≤
+      val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2)
+    (h_unreach0 :
+      ¬ (addbackN4_carry
+            (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).1
+            (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.1
+            (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+            (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+            v0 v1 v2 v3 = 0 ∧
+          (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 0))
+    (h_unreach2 :
+      ¬ (addbackN4_carry
+            (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).1
+            (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.1
+            (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+            (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+            v0 v1 v2 v3 = 0 ∧
+          (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat = 2)) :
+    callAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop :=
+  callAddbackCarry2NzV5_of_overestimate_c3 v0 v1 v2 v3 u0 u1 u2 u3 uTop hbnz hq_over
+    (mulsubN4_c3_one_of_carry_zero_of_plus_two_and_unreach
+      (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3 hbnz hq_over h_unreach0 h_unreach2)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5TrialOverestimate.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5TrialOverestimate.lean
@@ -1,0 +1,49 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5TrialOverestimate
+
+  The v5 n=2 trial +2 overestimate (call regime), abstract over the per-digit
+  `u`-window: `divKTrialCallV5QHat u2 u1 v1 ≤ val256 u0 u1 u2 0 / val256 v0 v1 0 0 + 2`.
+
+  This is the call-digit hypothesis (`hq_over`) that
+  `callAddbackCarry2NzV5_of_overestimate_c3` (#7424) consumes.  Built by
+  composing `div128Quot_v5_le_q_true` (the EXACT single-limb floor bound, valid
+  in the CALL regime `u2 < v1` — NOT `_le_q_true_plus_one`, which would give +3)
+  with `knuth_theorem_b_abstract`, applying the latter to the `2^128`-scaled
+  window so its `2^256/2^192` split matches the n=2 2-limb divisor and
+  `Nat.mul_div_mul_left` collapses the scale.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.LowerBound
+import EvmAsm.Evm64.EvmWordArith.KnuthTheoremB
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmWord (val256)
+
+/-- v5 n=2 call-digit +2 overestimate, abstract over the digit's `u`-window
+    `(u0, u1, u2)` and the (already normalized) 2-limb divisor `(v0, v1)`. -/
+theorem divKTrialCallV5QHat_le_window_div_plus_two_of_call
+    (u0 u1 u2 v0 v1 : Word)
+    (hv1_norm : v1.toNat ≥ 2 ^ 63)
+    (hcall : u2.toNat < v1.toNat) :
+    (divKTrialCallV5QHat u2 u1 v1).toNat ≤
+      val256 u0 u1 u2 0 / val256 v0 v1 0 0 + 2 := by
+  rw [divKTrialCallV5QHat_eq_div128Quot_v5]
+  have h1 := div128Quot_v5_le_q_true u2 u1 v1 hv1_norm hcall
+  have hvrest : v0.toNat * 2 ^ 128 < 2 ^ 192 := by
+    have h := v0.isLt
+    have he : (2 : Nat) ^ 192 = 2 ^ 64 * 2 ^ 128 := by norm_num
+    rw [he]
+    exact Nat.mul_lt_mul_of_pos_right h (by positivity)
+  have h2 := knuth_theorem_b_abstract
+    (2 ^ 128 * val256 u0 u1 u2 0) (2 ^ 128 * val256 v0 v1 0 0)
+    u2.toNat u1.toNat (u0.toNat * 2 ^ 128)
+    v1.toNat (v0.toNat * 2 ^ 128)
+    (by simp only [val256]; rw [show BitVec.toNat (0 : BitVec 64) = 0 from rfl]; ring)
+    (by simp only [val256]; rw [show BitVec.toNat (0 : BitVec 64) = 0 from rfl]; ring)
+    hvrest hv1_norm hcall u1.isLt
+  rw [Nat.mul_div_mul_left _ _ (by positivity : 0 < 2 ^ 128)] at h2
+  omega
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds `callAddbackCarry2NzV5_of_overestimate_and_unreach` — composes the call-digit carry helper (#7424) with the abstract c3=1 invariant (#7426) to give `callAddbackCarry2NzV5` from the +2 overestimate plus the unreachability of the `c3 ∈ {0,2}` frontier under `carry=0`. **This reduces the call-digit carry to exactly the two unreach conditions** (the last remaining shape-discharge for the call branch); the +2 overestimate comes from #7425 in the call regime.

Stacked on #7426.

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)