### PR TITLE
feat(divmod): v5 n=2 j2 loop source with borrow-conditional carry2nz

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -168,6 +168,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5C3LeOne
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryBorrowN2
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopSourceBorrowCarry
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -164,6 +164,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5TrialOverestimate
 import EvmAsm.Evm64.DivMod.Spec.N2V5C3Invariant
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromUnreach
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromBorrow
+import EvmAsm.Evm64.DivMod.Spec.N2V5C3LeOne
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -166,6 +166,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromUnreach
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromBorrow
 import EvmAsm.Evm64.DivMod.Spec.N2V5C3LeOne
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryBorrowN2
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -169,6 +169,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryBorrowN2
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopSourceBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCCBorrowCarry
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -167,6 +167,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromBorrow
 import EvmAsm.Evm64.DivMod.Spec.N2V5C3LeOne
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryBorrowN2
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -165,6 +165,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5C3Invariant
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromUnreach
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromBorrow
 import EvmAsm.Evm64.DivMod.Spec.N2V5C3LeOne
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryBorrowN2
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopCallIterBorrowCarry.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopCallIterBorrowCarry.lean
@@ -1,0 +1,121 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry
+
+  Borrow-dispatched variants of the j=2 / j=1 N2 call iteration bodies
+  (FullPathN2V5NoNopCallIter), requiring carry2nz ONLY conditionally on the
+  runtime borrow (mirror of the j=0 variant #7432).  In the borrow branch we
+  delegate to the original body; in the no-borrow branch we inline the SKIP path
+  (no carry2nz).  The conditional hypothesis is dischargeable from shape via
+  `callAddbackCarry2NzV5_of_borrow_n2` (#7431).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIter
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryBorrowN2
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- j=2 N2 call iteration, carry2nz required only on the runtime-borrow branch. -/
+theorem divK_loop_body_n2_call_j2_exact_loopIterScratch_v5_noNop_borrowCarry (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hcarry2_borrow :
+      BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v5 base)
+      (loopBodyN2CallSkipJgt0NormPreV4NoX1 (2 : Word) sp
+        jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+        retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal))
+      (loopIterPostN2CallScratchNoX1 sp base (2 : Word)
+        (divKTrialCallV5QHat u2 u1 v1)
+        (divKTrialCallV5DLo v1)
+        (divKTrialCallV5Un0 u1)
+        (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop ** (.x1 ↦ᵣ raVal)) := by
+  by_cases hborrow :
+      BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
+  · exact divK_loop_body_n2_call_j2_exact_loopIterScratch_v5_noNop
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem
+      halign hbltu (hcarry2_borrow hborrow)
+  · have hborrow_zero :
+        mulsubN4NoBorrow (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold mulsubN4NoBorrow
+      dsimp only
+      unfold mulsubN4_c3 at hborrow
+      rw [if_neg hborrow]
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => hp)
+        (fun h hp => by
+          rw [loopBodyN2CallSkipJgt0PostV5NoX1_eq_scratch] at hp
+          rw [loopIterPostN2CallScratchNoX1_skip hborrow] at hp
+          xperm_hyp hp)
+        (divK_loop_body_n2_call_skip_jgt0_norm_v5_noNop_exact_x1
+          (2 : Word) sp base EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
+          jOld v5Old v6Old v7Old v10Old v11Old v2Old
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+          retMem dMem dloMem scratchUn0 scratchMem raVal
+          halign hbltu hborrow_zero)
+
+/-- j=1 N2 call iteration, carry2nz required only on the runtime-borrow branch. -/
+theorem divK_loop_body_n2_call_j1_exact_loopIterScratch_v5_noNop_borrowCarry (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hcarry2_borrow :
+      BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v5 base)
+      (loopBodyN2CallSkipJgt0NormPreV4NoX1 (1 : Word) sp
+        jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+        retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal))
+      (loopIterPostN2CallScratchNoX1 sp base (1 : Word)
+        (divKTrialCallV5QHat u2 u1 v1)
+        (divKTrialCallV5DLo v1)
+        (divKTrialCallV5Un0 u1)
+        (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop ** (.x1 ↦ᵣ raVal)) := by
+  by_cases hborrow :
+      BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
+  · exact divK_loop_body_n2_call_j1_exact_loopIterScratch_v5_noNop
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem
+      halign hbltu (hcarry2_borrow hborrow)
+  · have hborrow_zero :
+        mulsubN4NoBorrow (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold mulsubN4NoBorrow
+      dsimp only
+      unfold mulsubN4_c3 at hborrow
+      rw [if_neg hborrow]
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => hp)
+        (fun h hp => by
+          rw [loopBodyN2CallSkipJgt0PostV5NoX1_eq_scratch] at hp
+          rw [loopIterPostN2CallScratchNoX1_skip hborrow] at hp
+          xperm_hyp hp)
+        (divK_loop_body_n2_call_skip_jgt0_norm_v5_noNop_exact_x1
+          (1 : Word) sp base EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+          jOld v5Old v6Old v7Old v10Old v11Old v2Old
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+          retMem dMem dloMem scratchUn0 scratchMem raVal
+          halign hbltu hborrow_zero)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboCCBorrowCarry.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboCCBorrowCarry.lean
@@ -1,0 +1,127 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCCBorrowCarry
+
+  Borrow-dispatched variant of the n=2 call×call two-digit prefix
+  (FullPathN2V5NoNopComboCC): each call digit's carry2nz is required only
+  conditionally on that digit's runtime borrow.  Chains the j=2 source
+  borrowCarry (#7434) with the j=1 body borrowCarry (#7433) via the same
+  cross-digit pre-bridge.  The conditional hypotheses are dischargeable from
+  shape via `callAddbackCarry2NzV5_of_borrow_n2` (#7431).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopSourceBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Full n=2 call×call prefix, carry2nz required only on each digit's
+    runtime-borrow branch. -/
+theorem divK_loop_n2_call_call_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 : BitVec.ult u2 v1)
+    (hcarry2_borrow_2 :
+      BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_1 :
+      BitVec.ult
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1)
+    (hcarry2_borrow_1 :
+      let r2 := iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r2.2.2.2.2.1
+        (mulsubN4_c3 (divKTrialCallV5QHat r2.2.2.1 r2.2.1 v1)
+          v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1) :
+    let r2 := iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let qHat1 := divKTrialCallV5QHat r2.2.2.1 r2.2.1 v1
+    let dLo1 := divKTrialCallV5DLo v1
+    let divUn01 := divKTrialCallV5Un0 r2.2.1
+    let scratch2 := divKTrialCallV5ScratchOut u2 u1 v1 scratchMem
+    let scratch1 := divKTrialCallV5ScratchOut r2.2.2.1 r2.2.1 v1 scratch2
+    let uBase2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let uBase0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (234 + 234) (base + loopBodyOff) (base + loopBodyOff)
+      (divCode_noNop_v5 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN2CallScratchNoX1 sp base (1 : Word)
+        qHat1 dLo1 divUn01 scratch1
+        v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 **
+        (.x1 ↦ᵣ raVal)) **
+        (((uBase2 + signExtend12 4064 ↦ₘ r2.2.2.2.2.2) **
+          (qAddr2 ↦ₘ r2.1)) **
+         (((uBase0 + signExtend12 0) ↦ₘ u0Orig0) **
+          (qAddr0 ↦ₘ q0Old)))) := by
+  intro r2 qHat1 dLo1 divUn01 scratch2 scratch1 uBase2 qAddr2 uBase0 qAddr0
+  have J2 := divK_loop_n2_call_j2_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu_2 hcarry2_borrow_2
+  subst r2
+  subst qHat1
+  subst dLo1
+  subst divUn01
+  subst scratch2
+  subst scratch1
+  subst uBase2
+  subst qAddr2
+  subst uBase0
+  subst qAddr0
+  have J1 := divK_loop_body_n2_call_j1_exact_loopIterScratch_v5_noNop_borrowCarry sp base
+    (2 : Word)
+    ((2 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q1Old raVal
+    (base + div128CallRetOff) v1 (divKTrialCallV5DLo v1)
+    (divKTrialCallV5Un0 u1) (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem)
+    halign hbltu_1 hcarry2_borrow_1
+  have J1f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)) **
+     (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig0) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J1
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN2CallScratchNoX1_j2_to_call_j1_pre
+      sp base (divKTrialCallV5QHat u2 u1 v1) (divKTrialCallV5DLo v1)
+      (divKTrialCallV5Un0 u1) (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q1Old q0Old raVal)
+    J2 J1f
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopJ0ExitBorrowCarry.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopJ0ExitBorrowCarry.lean
@@ -1,0 +1,75 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
+
+  Borrow-dispatched variant of `divK_loop_body_n2_call_j0_exact_loopIterScratch_v5_noNop`
+  (FullPathN2V5NoNopJ0Exit) that requires carry2nz ONLY conditionally on the
+  runtime borrow, instead of the over-strong unconditional `hcarry2_nz` (which is
+  false when the call digit's trial is exact, c3 = 0).
+
+  In the borrow branch we delegate to the original body (supplying carry2nz from
+  the conditional hypothesis); in the no-borrow branch we inline the SKIP path
+  (mirror of the original body's no-borrow branch), which needs no carry2nz.  The
+  conditional hypothesis is dischargeable from shape via
+  `callAddbackCarry2NzV5_of_borrow_n2` (#7431).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0Exit
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryBorrowN2
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- j=0 N2 call iteration over v5/no-NOP code, with carry2nz required only on the
+    runtime-borrow branch. -/
+theorem divK_loop_body_n2_call_j0_exact_loopIterScratch_v5_noNop_borrowCarry
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hcarry2_borrow :
+      BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v5 base)
+      (loopBodyN2CallSkipJ0NormPreV4NoX1 sp
+        jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+        retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal))
+      (loopIterPostN2CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV5QHat u2 u1 v1)
+        (divKTrialCallV5DLo v1)
+        (divKTrialCallV5Un0 u1)
+        (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop ** (.x1 ↦ᵣ raVal)) := by
+  by_cases hborrow :
+      BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
+  · exact divK_loop_body_n2_call_j0_exact_loopIterScratch_v5_noNop
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem
+      halign hbltu (hcarry2_borrow hborrow)
+  · have hborrow_zero :
+        mulsubN4NoBorrow (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold mulsubN4NoBorrow
+      dsimp only
+      unfold mulsubN4_c3 at hborrow
+      rw [if_neg hborrow]
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => hp)
+        (fun h hp => by
+          rw [loopBodyN2CallSkipJ0PostV5NoX1_eq_scratch] at hp
+          rw [loopIterPostN2CallScratchNoX1_skip hborrow] at hp
+          xperm_hyp hp)
+        (divK_loop_body_n2_call_skip_j0_norm_v5_noNop_exact_x1
+          sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+          retMem dMem dloMem scratchUn0 scratchMem raVal
+          halign hbltu hborrow_zero)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopSourceBorrowCarry.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopSourceBorrowCarry.lean
@@ -1,0 +1,70 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopSourceBorrowCarry
+
+  Borrow-dispatched variant of the j=2 single-call loop source theorem
+  (FullPathN2V5NoNopSource), requiring carry2nz only conditionally on the runtime
+  borrow.  Identical to the original except it uses the `_borrowCarry` j=2 body
+  (#7433) and threads the conditional `hcarry2_borrow` hypothesis.  Base of the
+  borrow-dispatched combo recursion.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopSource
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- First n=2 call iteration from the loop source, with carry2nz required only on
+    the runtime-borrow branch. -/
+theorem divK_loop_n2_call_j2_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hcarry2_borrow :
+      BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v5 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN2CallScratchNoX1 sp base (2 : Word)
+        (divKTrialCallV5QHat u2 u1 v1)
+        (divKTrialCallV5DLo v1)
+        (divKTrialCallV5Un0 u1)
+        (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop ** (.x1 ↦ᵣ raVal)) **
+        ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig1) **
+         ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q1Old)) **
+         (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig0) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))) := by
+  have J2 := divK_loop_body_n2_call_j2_exact_loopIterScratch_v5_noNop_borrowCarry sp base
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q2Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu hcarry2_borrow
+  have J2f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig1) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q1Old)) **
+     (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig0) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J2
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      have hp' := loopN2PreWithScratchV4NoX1_to_call_j2_pre
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem h hp
+      xperm_hyp hp')
+    (fun h hp => hp)
+    J2f
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5C3LeOne.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5C3LeOne.lean
@@ -1,0 +1,56 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5C3LeOne
+
+  `mulsubN4_c3_le_one_of_plus_two_of_v_lt`: under a `+2` trial overestimate AND a
+  small divisor (`2 * val256 v < 2^256`, e.g. the n=2 normalized divisor where
+  `v2 = v3 = 0` so `val256 v < 2^128`), the mulsub borrow `c3 ≤ 1`.
+
+  Mirror of `mulsubN4_c3_le_two` (DivMulsubC3LeTwo) tightened by the small-divisor
+  bound: `c3 * 2^256 ≤ val256(ms) + 2*val256 v < 2^256 + 2^256 = 2*2^256`.
+
+  Combined with the borrow fact (`c3 ≠ 0`) this gives `c3 = 1` for the n=2
+  addback branch, which discharges `callAddbackCarry2NzV5` via
+  `callAddbackCarry2NzV5_of_c3_eq_one` (#7428) — letting the loop's call body drop
+  the over-strong unconditional carry2nz hypothesis.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.DivMulsubC3LeTwo
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- Under a `+2` overestimate and a small divisor (`2 * val256 v < 2^256`), the
+    mulsub borrow `c3` is at most `1`. -/
+theorem mulsubN4_c3_le_one_of_plus_two_of_v_lt {q v0 v1 v2 v3 u0 u1 u2 u3 : Word}
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hq_over : q.toNat ≤ val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2)
+    (hv_small : 2 * val256 v0 v1 v2 v3 < 2 ^ 256) :
+    (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat ≤ 1 := by
+  let ms := mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  have hmulsub := mulsubN4_val256_eq q v0 v1 v2 v3 u0 u1 u2 u3
+  simp only [] at hmulsub
+  have := val256_bound u0 u1 u2 u3
+  have := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+  have := val256_bound v0 v1 v2 v3
+  have := val256_pos_of_or_ne_zero hbnz
+  have hdiv_mul_le : val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 *
+      val256 v0 v1 v2 v3 ≤ val256 u0 u1 u2 u3 :=
+    Nat.div_mul_le_self _ _
+  have hqv_le : q.toNat * val256 v0 v1 v2 v3 ≤
+      val256 u0 u1 u2 u3 + 2 * val256 v0 v1 v2 v3 := by
+    calc q.toNat * val256 v0 v1 v2 v3
+        ≤ (val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2) * val256 v0 v1 v2 v3 :=
+          Nat.mul_le_mul_right _ hq_over
+      _ = val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 * val256 v0 v1 v2 v3 +
+          2 * val256 v0 v1 v2 v3 := by ring
+      _ ≤ val256 u0 u1 u2 u3 + 2 * val256 v0 v1 v2 v3 :=
+          Nat.add_le_add_right hdiv_mul_le _
+  have hc3_bound : c3.toNat * 2 ^ 256 < 2 * 2 ^ 256 := by nlinarith
+  show c3.toNat ≤ 1
+  have h256_pos : (0 : Nat) < 2 ^ 256 := by positivity
+  have : c3.toNat < 2 := (Nat.mul_lt_mul_right h256_pos).mp hc3_bound
+  omega
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5CallCarryBorrowN2.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5CallCarryBorrowN2.lean
@@ -1,0 +1,50 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryBorrowN2
+
+  `callAddbackCarry2NzV5_of_borrow_n2`: the call-digit carry discharged purely
+  from the runtime borrow + n2 shape facts, with NO unconditional carry2nz
+  hypothesis.  On the addback (borrow) branch of the loop's per-digit dispatch,
+  the borrow check `BitVec.ult uTop (mulsubN4_c3 …)` gives `c3 ≠ 0`; the n2
+  small-divisor `c3 ≤ 1` bound (#7430) then forces `c3 = 1`, which discharges
+  `callAddbackCarry2NzV5` via `callAddbackCarry2NzV5_of_c3_eq_one` (#7428).
+
+  This is what lets the loop's call body drop the over-strong `hcarry2_nz`
+  hypothesis (false in the no-borrow / exact case): carry2nz is needed only in
+  the borrow branch, where it is now derived from shape.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromBorrow
+import EvmAsm.Evm64.DivMod.Spec.N2V5C3LeOne
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- `callAddbackCarry2NzV5` from the `+2` overestimate, the n2 small-divisor
+    bound, and the runtime borrow check `BitVec.ult uTop (mulsubN4_c3 …) = true`. -/
+theorem callAddbackCarry2NzV5_of_borrow_n2
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hq_over : (divKTrialCallV5QHat u2 u1 v1).toNat ≤
+      val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2)
+    (hv_small : 2 * val256 v0 v1 v2 v3 < 2 ^ 256)
+    (hborrow : BitVec.ult uTop
+      (mulsubN4_c3 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3) = true) :
+    callAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  apply callAddbackCarry2NzV5_of_c3_eq_one v0 v1 v2 v3 u0 u1 u2 u3 uTop hbnz hq_over
+  have hle1 := mulsubN4_c3_le_one_of_plus_two_of_v_lt hbnz hq_over hv_small
+  have hne0 : (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 ≠ 0 := by
+    intro h0
+    unfold mulsubN4_c3 at hborrow
+    rw [h0] at hborrow
+    have : ¬ BitVec.ult uTop (0 : Word) := by rw [BitVec.ult_eq_decide]; simp
+    exact this hborrow
+  have hne0' :
+      (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat ≠ 0 := by
+    intro hz
+    exact hne0 (BitVec.eq_of_toNat_eq (by rw [hz]; rfl))
+  apply BitVec.eq_of_toNat_eq
+  show (mulsubN4 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat = 1
+  omega
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds `divK_loop_n2_call_j2_from_source_exact_loopIterScratch_v5_noNop_borrowCarry` — the j2 single-call loop source requiring carry2nz only conditionally on the runtime borrow. Uses the `_borrowCarry` j2 body (#7433) + threads the conditional hypothesis. Base of the borrow-dispatched combo recursion replacing the unsatisfiable unconditional `loopN2SelectedCarryV5`.

Stacked on #7433.

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)