### PR TITLE
feat(divmod): v5 n2 loopN2IterSelectedV5 = iterN2V5 bridge

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -169,6 +169,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryBorrowN2
 import EvmAsm.Evm64.DivMod.Spec.N2V5HvSmall
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryOfCallShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5MaxCarryOfMaxShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5IterSelectedEq
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopSourceBorrowCarry

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5IterSelectedEq.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5IterSelectedEq.lean
@@ -1,0 +1,27 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5IterSelectedEq
+
+  `loopN2IterSelectedV5 = iterN2V5`: the branch-selected loop iteration
+  (FullPathN2V5NoNopLoopDefs) and the families iteration (FullPathN2V5Families)
+  share the same definition body, so they are equal.  This bridge lets the
+  per-digit remainder-collapse / step / validity lemmas (stated for `iterN2V5` in
+  N2V5RemainderLt) apply to the `loopN2IterSelectedV5` intermediates that appear
+  in `loopN2SelectedBorrowCarryV5` — needed to assemble
+  `loopN2SelectedBorrowCarryV5_of_shape`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopDefs
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5Families
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The unified loop iteration equals the families iteration. -/
+theorem loopN2IterSelectedV5_eq_iterN2V5 (bltu : Bool)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    loopN2IterSelectedV5 bltu v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      iterN2V5 bltu v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  simp only [loopN2IterSelectedV5, iterN2V5]
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds loopN2IterSelectedV5_eq_iterN2V5 -- the unified-loop iteration and the families iteration share the same def body. Lets the per-digit remainder-collapse/step/validity lemmas (for iterN2V5) apply to the loopN2IterSelectedV5 intermediates in loopN2SelectedBorrowCarryV5. Building block for loopN2SelectedBorrowCarryV5_of_shape.

Stacked on #7455.

Authored by @pirapira; implemented by Claude Code.