### PR TITLE
feat(divmod): v5 n2 loop-iter to fullDivN2R2V5/R1V5 bridges

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -170,6 +170,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5HvSmall
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryOfCallShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5MaxCarryOfMaxShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5IterSelectedEq
+import EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopSourceBorrowCarry

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -170,6 +170,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5HvSmall
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryOfCallShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5MaxCarryOfMaxShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5IterSelectedEq
+import EvmAsm.Evm64.DivMod.Spec.N2V5IterR2R1Bridge
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -171,6 +171,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryOfCallShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5MaxCarryOfMaxShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5IterSelectedEq
 import EvmAsm.Evm64.DivMod.Spec.N2V5IterR2R1Bridge
+import EvmAsm.Evm64.DivMod.Spec.N2V5BundleDigit2
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5BundleDigit2.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5BundleDigit2.lean
@@ -1,0 +1,70 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5BundleDigit2
+
+  The j=2 (first) conjunct of `loopN2SelectedBorrowCarryV5` at the lane level
+  (over the `fullDivN2NormV/U` accessors), discharged from shape.  The first
+  digit's window has `u3 = uTop = 0` (no collapse needed), so it applies the
+  per-digit call/max carry discharges (#7454/#7455) directly after rewriting the
+  normalized divisor's high limbs to zero (#7458).  Demonstrates the per-digit
+  pattern of the full `loopN2SelectedBorrowCarryV5_of_shape` telescope.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryOfCallShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5MaxCarryOfMaxShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- The j=2 conjunct of the borrow-carry bundle, from shape. -/
+theorem loopN2SelectedBorrowCarryV5_digit2_of_shape
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (bltu_2 : Bool)
+    (hb2z : b2 = 0) (hb3z : b3 = 0) (hshift_nz : (clzResult b1).1 ≠ 0) (hb1nz : b1 ≠ 0)
+    (hc2 : bltu_2 = true →
+      BitVec.ult (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm2 : bltu_2 = false →
+      ¬ BitVec.ult (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (fullDivN2NormV b0 b1 b2 b3).2.1) :
+    (if bltu_2 then
+      (BitVec.ult 0
+        (mulsubN4_c3 (divKTrialCallV5QHat (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1)
+          (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0) →
+        callAddbackCarry2NzV5 (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0 0)
+     else
+      (BitVec.ult 0
+        (mulsubN4_c3 (signExtend12 4095 : Word)
+          (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0) →
+        isAddbackCarry2NzN2Max (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0 0)) := by
+  obtain ⟨hv1n, hv2z', hv3z'⟩ := fullDivN2NormV_shape_facts b0 b1 b2 b3 hb2z hb3z hb1nz hshift_nz
+  rw [hv2z', hv3z']
+  cases hbl : bltu_2 with
+  | true =>
+    intro hborrow
+    have hcall : (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2.toNat <
+        (fullDivN2NormV b0 b1 b2 b3).2.1.toNat := by
+      have := hc2 hbl; rw [BitVec.ult] at this; exact of_decide_eq_true this
+    exact callAddbackCarry2NzV5_of_borrow_of_call_shape
+      (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0 hv1n hcall hborrow
+  | false =>
+    intro hborrow
+    exact isAddbackCarry2NzN2Max_of_borrow_of_max_shape
+      (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0 hv1n (hm2 hbl) hborrow
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5IterR2R1Bridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5IterR2R1Bridge.lean
@@ -1,0 +1,45 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5IterR2R1Bridge
+
+  Bridges the bundle's loop iterations (`loopN2IterSelectedV5` over the
+  `fullDivN2NormV/U` accessors) to the families' per-digit results
+  `fullDivN2R2V5` / `fullDivN2R1V5`.  These let the per-digit `_collapse_of_shape`
+  / `_step_of_shape` lemmas (stated for `fullDivN2R2V5`/`R1V5`) apply to the
+  `r2`/`r1` intermediates that appear inside `loopN2SelectedBorrowCarryV5` at the
+  lane level — the glue for the telescope discharge of
+  `loopN2SelectedBorrowCarryV5_of_shape`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5IterSelectedEq
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The bundle's j=2 iteration (over NormV/U) equals the families' `fullDivN2R2V5`. -/
+theorem loopN2IterSelectedV5_normUV_eq_R2V5
+    (bltu_2 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    loopN2IterSelectedV5 bltu_2
+      (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+      (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0 0
+      = fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3 := by
+  simp only [loopN2IterSelectedV5_eq_iterN2V5, fullDivN2R2V5]
+
+/-- The bundle's j=1 iteration (over NormV/U and the R2 outputs) equals the
+    families' `fullDivN2R1V5`. -/
+theorem loopN2IterSelectedV5_normUV_eq_R1V5
+    (bltu_2 bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    loopN2IterSelectedV5 bltu_1
+      (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+      (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+      (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+      (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+      (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+      (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1
+      = fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3 := by
+  simp only [loopN2IterSelectedV5_eq_iterN2V5, fullDivN2R1V5]
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5NormVShapeFacts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5NormVShapeFacts.lean
@@ -1,0 +1,28 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
+
+  Bundled n=2 normalized-divisor shape facts: from the n=2 shape (`b2 = 0`,
+  `b3 = 0`, `b1 ≠ 0`, `shift ≠ 0`), the normalized divisor `fullDivN2NormV` has
+  its top limb MSB set (`≥ 2^63`) and its two high limbs zero (`v2 = v3 = 0`).
+  These are the `hv1_norm`/`v2=0`/`v3=0` facts the per-digit carry discharges
+  (#7454/#7455) and the validity telescope repeatedly consume when discharging
+  `loopN2SelectedBorrowCarryV5` from shape at the lane level.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.DivN2NormVStructure
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The three normalized-divisor facts for the n=2 lane, bundled. -/
+theorem fullDivN2NormV_shape_facts (b0 b1 b2 b3 : Word)
+    (hb2z : b2 = 0) (hb3z : b3 = 0) (hb1nz : b1 ≠ 0) (hshift_nz : (clzResult b1).1 ≠ 0) :
+    2 ^ 63 ≤ (fullDivN2NormV b0 b1 b2 b3).2.1.toNat ∧
+    (fullDivN2NormV b0 b1 b2 b3).2.2.1 = 0 ∧
+    (fullDivN2NormV b0 b1 b2 b3).2.2.2 = 0 :=
+  ⟨fullDivN2NormV_msb_of_b1_ne_zero b0 b1 b2 b3 hb1nz,
+   fullDivN2NormV_v2_zero_of_shape_shift_nz b0 b1 b2 b3 hb2z hshift_nz,
+   fullDivN2NormV_top_zero_of_shape b0 b1 b2 b3 hb3z hb2z⟩
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds loopN2IterSelectedV5_normUV_eq_R2V5 / _R1V5 -- the bundle's loop iterations equal the families' fullDivN2R2V5/R1V5. Let the per-digit _collapse_of_shape/_step_of_shape lemmas apply to the r2/r1 intermediates in loopN2SelectedBorrowCarryV5. The glue for the telescope discharge.

Stacked on #7458.

Authored by @pirapira; implemented by Claude Code.