### PR TITLE
feat(divmod): v5 n2 full borrow-carry bundle from shape

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -173,6 +173,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5IterSelectedEq
 import EvmAsm.Evm64.DivMod.Spec.N2V5IterR2R1Bridge
 import EvmAsm.Evm64.DivMod.Spec.N2V5BundleDigit2
 import EvmAsm.Evm64.DivMod.Spec.N2V5BundleOfShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5R2R1Dispatch
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -197,6 +197,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopDefsBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopUnifiedBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopSelectedBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFullBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFromShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -172,6 +172,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5MaxCarryOfMaxShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5IterSelectedEq
 import EvmAsm.Evm64.DivMod.Spec.N2V5IterR2R1Bridge
 import EvmAsm.Evm64.DivMod.Spec.N2V5BundleDigit2
+import EvmAsm.Evm64.DivMod.Spec.N2V5BundleOfShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopFromShape.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopFromShape.lean
@@ -1,0 +1,89 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFromShape
+
+  Borrow-dispatched n=2 v5 entry→nopOff full path, with the carry hypothesis
+  DISCHARGED FROM SHAPE.  Wraps `evm_div_n2_stack_pre_to_unified_post_v5_noNop_borrowCarry`
+  (#7452): instead of taking `loopN2SelectedBorrowCarryV5` as a hypothesis, it
+  discharges it via `loopN2SelectedBorrowCarryV5_of_shape` (#7461), and accepts
+  the borrow flags in the CLEAN `ult (fullDivN2R{2,1}V5 …).2.2.1 vTop` form
+  (rather than #7452's `iterN2Max`/`iterWithDoubleAddback` `match` form), bridged
+  via the dispatch-form equalities (#7463).  This removes the last shape-derived
+  obligation from the n=2 execution path — the direct input to the n=2 lane.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallablePostSelectedBorrowCarry
+import EvmAsm.Evm64.DivMod.Spec.N2V5BundleOfShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5R2R1Dispatch
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem evm_div_n2_stack_pre_to_unified_post_v5_noNop_fromShape (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0) (hb1nz : b.getLimbN 1 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 1)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 : bltu_2 =
+      BitVec.ult (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN2R2V5 bltu_2 (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1)
+    (hbltu_0 : bltu_0 =
+      BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1) :
+    cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 702) + (2 + 23 + 10))
+      base (base + nopOff) (divCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (fullDivN2UnifiedPostNoX1V5 bltu_2 bltu_1 bltu_0 sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        retMem dMem dloMem scratchUn0 scratchMem **
+       (.x1 ↦ᵣ raVal)) := by
+  apply evm_div_n2_stack_pre_to_unified_post_v5_noNop_borrowCarry sp base a b
+    v5 v6 v7 v10 v11Old q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2z hb1nz hshift_nz halign hbltu_2
+  case hbltu_1 =>
+    -- match form, from clean form via dispatch-eq (full simp reduces the
+    -- proof-discriminated match)
+    cases bltu_2 <;> simpa [fullDivN2R2V5_eq_dispatch] using hbltu_1
+  case hbltu_0 =>
+    cases bltu_2 <;> cases bltu_1 <;>
+      simpa [fullDivN2R1V5_eq_dispatch, fullDivN2R2V5_eq_dispatch] using hbltu_0
+  case hcarry =>
+    -- discharge from shape (#7461); flags trivial from clean form
+    apply loopN2SelectedBorrowCarryV5_of_shape
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      bltu_2 bltu_1 bltu_0 hb2z hb3z hshift_nz hb1nz
+    · intro h; rw [← hbltu_2]; exact h
+    · intro h; rw [← hbltu_2, h]; decide
+    · intro h; rw [← hbltu_1]; exact h
+    · intro h; rw [← hbltu_1, h]; decide
+    · intro h; rw [← hbltu_0]; exact h
+    · intro h; rw [← hbltu_0, h]; decide
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5BundleOfShape.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5BundleOfShape.lean
@@ -1,0 +1,88 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5BundleOfShape
+
+  `loopN2SelectedBorrowCarryV5_of_shape`: the borrow-conditional carry bundle for
+  the n=2 v5 loop, discharged from shape at the lane level (over the
+  `fullDivN2NormV/U` accessors).  Telescopes the per-digit validity / collapse
+  (mirroring `fullDivN2_acc_quot_eq_div_of_shape`) and applies the per-digit
+  call/max carry discharges (#7454/#7455) via the iter→R2V5/R1V5 bridges (#7459).
+  This is the satisfiable-from-shape hypothesis the borrow-dispatched loop
+  (#7449/#7452) consumes — completing the n=2 carry-from-shape.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryOfCallShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5MaxCarryOfMaxShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
+import EvmAsm.Evm64.DivMod.Spec.N2V5IterR2R1Bridge
+import EvmAsm.Evm64.DivMod.Spec.N2V5NormScaled
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopDefsBorrowCarry
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- The borrow-conditional carry bundle, discharged from shape (lane level). -/
+theorem loopN2SelectedBorrowCarryV5_of_shape
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (bltu_2 bltu_1 bltu_0 : Bool)
+    (hb2z : b2 = 0) (hb3z : b3 = 0) (hshift_nz : (clzResult b1).1 ≠ 0) (hb1nz : b1 ≠ 0)
+    (hc2 : bltu_2 = true → BitVec.ult (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm2 : bltu_2 = false → ¬ BitVec.ult (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hc1 : bltu_1 = true → BitVec.ult (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm1 : bltu_1 = false → ¬ BitVec.ult (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hc0 : bltu_0 = true → BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm0 : bltu_0 = false → ¬ BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1) :
+    loopN2SelectedBorrowCarryV5 bltu_2 bltu_1 bltu_0
+      (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+      (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0 0
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.1 (fullDivN2NormU a0 a1 a2 a3 b1).1 := by
+  unfold loopN2SelectedBorrowCarryV5
+  simp only [loopN2IterSelectedV5_normUV_eq_R2V5, loopN2IterSelectedV5_normUV_eq_R1V5]
+  obtain ⟨hv1n, hv2z', hv3z'⟩ := fullDivN2NormV_shape_facts b0 b1 b2 b3 hb2z hb3z hb1nz hshift_nz
+  have hfwv := fullDivN2_first_window_valid a0 a1 a2 a3 b0 b1 b2 b3 hb2z hb3z hshift_nz hb1nz
+  obtain ⟨hR2c1, hR2c2⟩ := fullDivN2R2V5_collapse_of_shape a0 a1 a2 a3 b0 b1 b2 b3 bltu_2
+    hb2z hb3z hshift_nz hb1nz hfwv hc2 hm2
+  have hR2 := fullDivN2R2V5_step_of_shape a0 a1 a2 a3 b0 b1 b2 b3 bltu_2
+    hb2z hb3z hshift_nz hb1nz hfwv hc2 hm2
+  have hR1valid := n2_next_window_lt (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+    (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+    (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 _ hR2.2
+  obtain ⟨hR1c1, hR1c2⟩ := fullDivN2R1V5_collapse_of_shape a0 a1 a2 a3 b0 b1 b2 b3 bltu_2 bltu_1
+    hb2z hb3z hshift_nz hb1nz hR2c1 hR2c2 hR1valid hc1 hm1
+  refine ⟨?_, ?_, ?_⟩
+  · rw [hv2z', hv3z']
+    cases hb : bltu_2 with
+    | true =>
+      intro hborrow
+      have hcall : (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2.toNat <
+          (fullDivN2NormV b0 b1 b2 b3).2.1.toNat := by
+        have := hc2 hb; rw [BitVec.ult] at this; exact of_decide_eq_true this
+      exact callAddbackCarry2NzV5_of_borrow_of_call_shape _ _ _ _ _ 0 hv1n hcall hborrow
+    | false =>
+      intro hborrow
+      exact isAddbackCarry2NzN2Max_of_borrow_of_max_shape _ _ _ _ _ 0 hv1n (hm2 hb) hborrow
+  · rw [hv2z', hv3z', hR2c1, hR2c2]
+    cases hb : bltu_1 with
+    | true =>
+      intro hborrow
+      have hcall : (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1.toNat <
+          (fullDivN2NormV b0 b1 b2 b3).2.1.toNat := by
+        have := hc1 hb; rw [BitVec.ult] at this; exact of_decide_eq_true this
+      exact callAddbackCarry2NzV5_of_borrow_of_call_shape _ _ _ _ _ 0 hv1n hcall hborrow
+    | false =>
+      intro hborrow
+      exact isAddbackCarry2NzN2Max_of_borrow_of_max_shape _ _ _ _ _ 0 hv1n (hm1 hb) hborrow
+  · rw [hv2z', hv3z', hR1c1, hR1c2]
+    cases hb : bltu_0 with
+    | true =>
+      intro hborrow
+      have hcall : (fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1.toNat <
+          (fullDivN2NormV b0 b1 b2 b3).2.1.toNat := by
+        have := hc0 hb; rw [BitVec.ult] at this; exact of_decide_eq_true this
+      exact callAddbackCarry2NzV5_of_borrow_of_call_shape _ _ _ _ _ 0 hv1n hcall hborrow
+    | false =>
+      intro hborrow
+      exact isAddbackCarry2NzN2Max_of_borrow_of_max_shape _ _ _ _ _ 0 hv1n (hm0 hb) hborrow
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5R2R1Dispatch.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5R2R1Dispatch.lean
@@ -1,0 +1,67 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5R2R1Dispatch
+
+  Dispatch-form equalities for the n=2 v5 per-digit results `fullDivN2R2V5` /
+  `fullDivN2R1V5`: each (irreducible) family result equals the `if`-on-flag
+  selection between `iterWithDoubleAddback (divKTrialCallV5QHat …)` (call regime)
+  and `iterN2Max …` (max regime).  These are the glue that connects the runtime
+  borrow-flag definitions used by the borrow-dispatched full path
+  (`evm_div_n2_stack_pre_to_unified_post_v5_noNop_borrowCarry`, stated with
+  `iterN2Max` / `iterWithDoubleAddback` `match` forms) to the `fullDivN2R2V5` /
+  `fullDivN2R1V5` forms over which the carry bundle
+  (`loopN2SelectedBorrowCarryV5_of_shape`) is stated — needed for the n=2 lane.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5Families
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- `fullDivN2R2V5` as an `if`-on-`bltu_2` dispatch between the call-regime
+    (`iterWithDoubleAddback`) and max-regime (`iterN2Max`) iterations. -/
+theorem fullDivN2R2V5_eq_dispatch (bltu_2 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3 =
+      (if bltu_2 then
+        iterWithDoubleAddback
+          (divKTrialCallV5QHat (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1)
+          (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0 0
+      else
+        iterN2Max
+          (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0 0) := by
+  simp only [fullDivN2R2V5, iterN2V5]
+
+/-- `fullDivN2R1V5` as an `if`-on-`bltu_1` dispatch, threaded on the `R2V5`
+    remainder. -/
+theorem fullDivN2R1V5_eq_dispatch (bltu_2 bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3 =
+      (if bltu_1 then
+        iterWithDoubleAddback
+          (divKTrialCallV5QHat (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+            (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.1 (fullDivN2NormV b0 b1 b2 b3).2.1)
+          (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1
+      else
+        iterN2Max
+          (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1) := by
+  simp only [fullDivN2R1V5, iterN2V5]
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Proves `loopN2SelectedBorrowCarryV5_of_shape` — the **complete** borrow-conditional carry bundle for the n=2 v5 DIV loop, discharged from the n=2 divisor shape at the lane level (over the `fullDivN2NormV/U` accessors).

This is the satisfiable-from-shape hypothesis the borrow-dispatched loop (#7449/#7452) consumes, **completing the n=2 carry-from-shape** — the months-long carry-wall blocker for the n2/n3/n4 lanes.

## How

- `simp only [iter→R2V5/R1V5 bridges]` zeta-inlines the `let r2`/`let r1` bindings and rewrites the loop iterations to the families' `fullDivN2R2V5`/`fullDivN2R1V5`.
- Telescopes the per-digit validity/collapse chain exactly as `fullDivN2_acc_quot_eq_div_of_shape` (`first_window_valid` → R2 `step`+`collapse` → `n2_next_window_lt` → R1 `collapse`).
- Applies the per-digit call/max carry discharges (`callAddbackCarry2NzV5_of_borrow_of_call_shape` / `isAddbackCarry2NzN2Max_of_borrow_of_max_shape`) to each of the three digits, rewriting the high divisor limbs and collapsed remainder limbs to zero first.

## Verification

Axioms: `propext`, `Classical.choice`, `Quot.sound` (no `sorry`/`native_decide`). Build green.

Stacked on `feat/v5-n2-bundle-digit2`.

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)