### PR TITLE
feat(divmod): v5 n2 dispatch-eq + entry→nopOff path with carry from shape

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -173,6 +173,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5IterSelectedEq
 import EvmAsm.Evm64.DivMod.Spec.N2V5IterR2R1Bridge
 import EvmAsm.Evm64.DivMod.Spec.N2V5BundleDigit2
 import EvmAsm.Evm64.DivMod.Spec.N2V5BundleOfShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5R2R1Dispatch
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -197,6 +197,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopDefsBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopUnifiedBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopSelectedBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFullBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFromShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopFromShape.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopFromShape.lean
@@ -1,0 +1,89 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFromShape
+
+  Borrow-dispatched n=2 v5 entry→nopOff full path, with the carry hypothesis
+  DISCHARGED FROM SHAPE.  Wraps `evm_div_n2_stack_pre_to_unified_post_v5_noNop_borrowCarry`
+  (#7452): instead of taking `loopN2SelectedBorrowCarryV5` as a hypothesis, it
+  discharges it via `loopN2SelectedBorrowCarryV5_of_shape` (#7461), and accepts
+  the borrow flags in the CLEAN `ult (fullDivN2R{2,1}V5 …).2.2.1 vTop` form
+  (rather than #7452's `iterN2Max`/`iterWithDoubleAddback` `match` form), bridged
+  via the dispatch-form equalities (#7463).  This removes the last shape-derived
+  obligation from the n=2 execution path — the direct input to the n=2 lane.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallablePostSelectedBorrowCarry
+import EvmAsm.Evm64.DivMod.Spec.N2V5BundleOfShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5R2R1Dispatch
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem evm_div_n2_stack_pre_to_unified_post_v5_noNop_fromShape (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0) (hb1nz : b.getLimbN 1 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 1)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 : bltu_2 =
+      BitVec.ult (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN2R2V5 bltu_2 (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1)
+    (hbltu_0 : bltu_0 =
+      BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1) :
+    cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 702) + (2 + 23 + 10))
+      base (base + nopOff) (divCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (fullDivN2UnifiedPostNoX1V5 bltu_2 bltu_1 bltu_0 sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        retMem dMem dloMem scratchUn0 scratchMem **
+       (.x1 ↦ᵣ raVal)) := by
+  apply evm_div_n2_stack_pre_to_unified_post_v5_noNop_borrowCarry sp base a b
+    v5 v6 v7 v10 v11Old q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2z hb1nz hshift_nz halign hbltu_2
+  case hbltu_1 =>
+    -- match form, from clean form via dispatch-eq (full simp reduces the
+    -- proof-discriminated match)
+    cases bltu_2 <;> simpa [fullDivN2R2V5_eq_dispatch] using hbltu_1
+  case hbltu_0 =>
+    cases bltu_2 <;> cases bltu_1 <;>
+      simpa [fullDivN2R1V5_eq_dispatch, fullDivN2R2V5_eq_dispatch] using hbltu_0
+  case hcarry =>
+    -- discharge from shape (#7461); flags trivial from clean form
+    apply loopN2SelectedBorrowCarryV5_of_shape
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      bltu_2 bltu_1 bltu_0 hb2z hb3z hshift_nz hb1nz
+    · intro h; rw [← hbltu_2]; exact h
+    · intro h; rw [← hbltu_2, h]; decide
+    · intro h; rw [← hbltu_1]; exact h
+    · intro h; rw [← hbltu_1, h]; decide
+    · intro h; rw [← hbltu_0]; exact h
+    · intro h; rw [← hbltu_0, h]; decide
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5R2R1Dispatch.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5R2R1Dispatch.lean
@@ -1,0 +1,67 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5R2R1Dispatch
+
+  Dispatch-form equalities for the n=2 v5 per-digit results `fullDivN2R2V5` /
+  `fullDivN2R1V5`: each (irreducible) family result equals the `if`-on-flag
+  selection between `iterWithDoubleAddback (divKTrialCallV5QHat …)` (call regime)
+  and `iterN2Max …` (max regime).  These are the glue that connects the runtime
+  borrow-flag definitions used by the borrow-dispatched full path
+  (`evm_div_n2_stack_pre_to_unified_post_v5_noNop_borrowCarry`, stated with
+  `iterN2Max` / `iterWithDoubleAddback` `match` forms) to the `fullDivN2R2V5` /
+  `fullDivN2R1V5` forms over which the carry bundle
+  (`loopN2SelectedBorrowCarryV5_of_shape`) is stated — needed for the n=2 lane.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5Families
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- `fullDivN2R2V5` as an `if`-on-`bltu_2` dispatch between the call-regime
+    (`iterWithDoubleAddback`) and max-regime (`iterN2Max`) iterations. -/
+theorem fullDivN2R2V5_eq_dispatch (bltu_2 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3 =
+      (if bltu_2 then
+        iterWithDoubleAddback
+          (divKTrialCallV5QHat (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1)
+          (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0 0
+      else
+        iterN2Max
+          (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0 0) := by
+  simp only [fullDivN2R2V5, iterN2V5]
+
+/-- `fullDivN2R1V5` as an `if`-on-`bltu_1` dispatch, threaded on the `R2V5`
+    remainder. -/
+theorem fullDivN2R1V5_eq_dispatch (bltu_2 bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3 =
+      (if bltu_1 then
+        iterWithDoubleAddback
+          (divKTrialCallV5QHat (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+            (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.1 (fullDivN2NormV b0 b1 b2 b3).2.1)
+          (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1
+      else
+        iterN2Max
+          (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1) := by
+  simp only [fullDivN2R1V5, iterN2V5]
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Two stacked commits completing the n=2 v5 execution path with the carry hypothesis discharged from shape:

1. **`fullDivN2R2V5_eq_dispatch` / `fullDivN2R1V5_eq_dispatch`** (`Spec/N2V5R2R1Dispatch.lean`) — each (irreducible) n=2 v5 per-digit family result equals the `if`-on-flag selection between `iterWithDoubleAddback (divKTrialCallV5QHat …)` (call regime) and `iterN2Max …` (max regime). One-line `simp only [family def, iterN2V5]` proofs.

2. **`evm_div_n2_stack_pre_to_unified_post_v5_noNop_fromShape`** (`Compose/FullPathN2V5NoNopFromShape.lean`) — the borrow-dispatched n=2 v5 entry→nopOff full path with the carry hypothesis **discharged from shape**. Wraps #7452: instead of taking `loopN2SelectedBorrowCarryV5` as a hypothesis, it discharges it via `loopN2SelectedBorrowCarryV5_of_shape` (#7461), accepting the borrow flags in the clean `ult (fullDivN2R{2,1}V5 …).2.2.1 vTop` form (bridged via the dispatch-eq lemmas).

## Key proof points (helper)

- #7452's `hbltu_1`/`hbltu_0` are **proof-discriminated dependent matches** (`match bltu_2, hbltu_2 with …`). Route the apply-generated goals by `case hbltu_1`/`hbltu_0`/`hcarry` tag (the goals are misordered by `apply`).
- Discharge each match-form goal via `cases … <;> simpa [dispatch-eq] using hbltu_*` — full `simp` reduces the proof-discriminated match; `simp only` does **not**.
- The per-digit carry `hc/hm` are trivial from the clean-form flags (`rw [← hbltu_*]`).

This removes the last shape-derived obligation from the n=2 execution path — the direct input to the n=2 lane.

## Verification

Both theorems: axioms `propext`, `Classical.choice`, `Quot.sound` (no `sorry`/`native_decide`). Full `EvmAsm.Evm64.DivMod` builds green (1604 jobs).

Stacked on `feat/v5-n2-bundle-of-shape` (#7461).

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)