### PR TITLE
feat(divmod): v5 n2 DIV lane (shift≠0) to divStackDispatchPostV5

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -199,6 +199,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopUnifiedBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopSelectedBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFullBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFromShape
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LaneShiftNz
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions
@@ -210,6 +211,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5ThreeStep
 import EvmAsm.Evm64.DivMod.Spec.N2V5RemainderLt
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormScaled
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLaneShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5ModRemainder
 import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0Quotient
 import EvmAsm.Evm64.DivMod.LoopIterN2V5.IterPostV5

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -158,6 +158,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallablePost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallablePostSelected
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N2V5ConcretePostBridge
+import EvmAsm.Evm64.DivMod.Spec.N2V5PostToDispatchPostV5
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallableExact
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallAddbackOverestimate
 import EvmAsm.Evm64.DivMod.Spec.N2V5TrialOverestimate

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5LaneShiftNz.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5LaneShiftNz.lean
@@ -1,0 +1,107 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LaneShiftNz
+
+  The v5 n=2 DIV lane, shift≠0 case: from the stack-dispatch precondition to
+  `divStackDispatchPostV5`, over `divCode_noNop_v5`.  Composes the entry→nopOff
+  path with the carry discharged from shape
+  (`evm_div_n2_stack_pre_to_unified_post_v5_noNop_fromShape`, #7463), the post
+  bridge (`fullDivN2UnifiedPostNoX1V5_to_divStackDispatchPostV5`, #7464) with the
+  shape-derived quotient correctness
+  (`fullDivN2QuotientWordV5_eq_div_lane_of_shape`), and the step-count widening to
+  `unifiedDivBound`.  This is the shift≠0 half of `lane_n2` matching
+  `evm_div_stack_spec_unconditional_of_lanes_v5_div`, mirroring
+  `evm_div_n1_lane_shiftNz_v5`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFromShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5PostToDispatchPostV5
+import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLaneShape
+import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Div
+import EvmAsm.Evm64.DivMod.Spec.UnifiedBzero
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem evm_div_n2_lane_shiftNz_v5 (sp base : Word) (a b : EvmWord)
+    (raVal v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0) (hb1nz : b.getLimbN 1 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 1)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat)) v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostV5 sp a b) := by
+  -- The three runtime borrow flags, in clean `ult (fullDivN2R{2,1}V5 …)` form.
+  obtain ⟨bltu_2, hbltu_2⟩ :
+      ∃ x, x = BitVec.ult (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1 := ⟨_, rfl⟩
+  obtain ⟨bltu_1, hbltu_1⟩ :
+      ∃ x, x = BitVec.ult (fullDivN2R2V5 bltu_2 (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1 := ⟨_, rfl⟩
+  obtain ⟨bltu_0, hbltu_0⟩ :
+      ∃ x, x = BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1 := ⟨_, rfl⟩
+  -- The per-digit `bltu` path matches, from the clean flag definitions.
+  have hc2 : bltu_2 = true →
+      BitVec.ult (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.1 = true := fun h => by rw [← hbltu_2]; exact h
+  have hm2 : bltu_2 = false →
+      ¬ BitVec.ult (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.1 := fun h => by rw [← hbltu_2, h]; decide
+  have hc1 : bltu_1 = true →
+      BitVec.ult (fullDivN2R2V5 bltu_2 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.1 = true := fun h => by rw [← hbltu_1]; exact h
+  have hm1 : bltu_1 = false →
+      ¬ BitVec.ult (fullDivN2R2V5 bltu_2 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.1 := fun h => by rw [← hbltu_1, h]; decide
+  have hc0 : bltu_0 = true →
+      BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.1 = true := fun h => by rw [← hbltu_0]; exact h
+  have hm0 : bltu_0 = false →
+      ¬ BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.1 := fun h => by rw [← hbltu_0, h]; decide
+  -- Quotient correctness from shape (lane form).
+  have hdivWord := fullDivN2QuotientWordV5_eq_div_lane_of_shape bltu_2 bltu_1 bltu_0
+    (a := a) (b := b) rfl rfl rfl rfl rfl rfl rfl rfl
+    hb2z hb3z hshift_nz hb1nz hc2 hm2 hc1 hm1 hc0 hm0
+  -- The entry→nopOff path with carry discharged from shape.
+  have hpath := evm_div_n2_stack_pre_to_unified_post_v5_noNop_fromShape sp base a b
+    v5 v6 v7 v10 v11Old q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0 scratchMem raVal
+    bltu_2 bltu_1 bltu_0 hbnz hb3z hb2z hb1nz hshift_nz halign hbltu_2 hbltu_1 hbltu_0
+  refine cpsTripleWithin_mono_nSteps (by have h : unifiedDivBound = 946 := rfl; omega) <|
+    cpsTripleWithin_weaken (fun _ hp => hp) ?_ hpath
+  intro h hq
+  exact fullDivN2UnifiedPostNoX1V5_to_divStackDispatchPostV5 bltu_2 bltu_1 bltu_0 sp base a b
+    retMem dMem dloMem scratch_un0 scratchMem raVal hdivWord h hq
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5PostToDispatchPostV5.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5PostToDispatchPostV5.lean
@@ -1,0 +1,50 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5PostToDispatchPostV5
+
+  N=2 V5 post bridge to the SCAFFOLD post `divStackDispatchPostV5`
+  (= `divStackDispatchPost ** memOwn (sp+3936)`).  Composes the existing
+  callable-frame bridge (`fullDivN2UnifiedPostNoX1V5_frame_to_divStackDispatchPostCallableExactFrame_scratch_word`,
+  #7463-adjacent) with the public weakening `divStackDispatchPostCallableExactFrame_weaken`
+  and `memIs_implies_memOwn`.  This is the post half of the n=2 lane (the form the
+  unconditional scaffold `evm_div_stack_spec_unconditional_of_lanes_v5_div`
+  consumes), mirroring n1's `n1_denormPost_to_divStackDispatchPost_v5`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5ConcretePostBridge
+import EvmAsm.Evm64.DivMod.Spec.StackPostBridge
+import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Div
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- From the n=2 v5 unified post (with exact caller `x1`) and quotient
+    correctness, conclude the scaffold post `divStackDispatchPostV5`. -/
+theorem fullDivN2UnifiedPostNoX1V5_to_divStackDispatchPostV5
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base : Word) (a b : EvmWord)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hdivWord : fullDivN2QuotientWordV5 bltu_2 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.div a b) :
+    ∀ h,
+      (fullDivN2UnifiedPostNoX1V5 bltu_2 bltu_1 bltu_0 sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) h →
+      divStackDispatchPostV5 sp a b h := by
+  intro h hp
+  have h1 := fullDivN2UnifiedPostNoX1V5_frame_to_divStackDispatchPostCallableExactFrame_scratch_word
+    bltu_2 bltu_1 bltu_0 sp base a b
+    retMem dMem dloMem scratchUn0 scratchMem raVal hdivWord h hp
+  simp only [divStackDispatchPostV5]
+  revert h1
+  apply sepConj_mono
+  · exact fun h hp =>
+      divStackDispatchPostCallableExactFrame_weaken sp a b raVal (signExtend12 4095) h hp
+  · exact fun h hp => memIs_implies_memOwn h hp
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5QuotientLaneShape.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5QuotientLaneShape.lean
@@ -1,0 +1,45 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLaneShape
+
+  Lane-ready (`a b : EvmWord`) form of the n=2 v5 quotient-word correctness
+  FROM SHAPE: `fullDivN2QuotientWordV5 … = EvmWord.div a b`, from the n=2 divisor
+  shape (`b2=b3=0`, `b1≠0`, shift≠0) and the per-digit `bltu` path matches.
+  Bridges the `fromLimbs`-form `fullDivN2QuotientWordV5_eq_div_of_shape` to the
+  `a b` form via `EvmWord.fromLimbs_match_getLimbN_id`.  This is the shape-derived
+  `hdivWord` the n=2 lane feeds to
+  `fullDivN2UnifiedPostNoX1V5_to_divStackDispatchPostV5` (#7464) — the
+  shape-counterpart of the `hmulsub`/`hge`-form `fullDivN2QuotientWordV5_eq_div_lane`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Lane form from shape: the assembled v5 n=2 quotient word equals `EvmWord.div a b`. -/
+theorem fullDivN2QuotientWordV5_eq_div_lane_of_shape
+    (bltu_2 bltu_1 bltu_0 : Bool) {a b : EvmWord}
+    {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hb2z : b2 = 0) (hb3z : b3 = 0) (hshift_nz : (clzResult b1).1 ≠ 0) (hb1nz : b1 ≠ 0)
+    (hc2 : bltu_2 = true → BitVec.ult (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm2 : bltu_2 = false → ¬ BitVec.ult (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hc1 : bltu_1 = true → BitVec.ult (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm1 : bltu_1 = false → ¬ BitVec.ult (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hc0 : bltu_0 = true → BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm0 : bltu_0 = false → ¬ BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1) :
+    fullDivN2QuotientWordV5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b := by
+  have hraw := fullDivN2QuotientWordV5_eq_div_of_shape a0 a1 a2 a3 b0 b1 b2 b3 bltu_2 bltu_1 bltu_0
+    hb2z hb3z hshift_nz hb1nz hc2 hm2 hc1 hm1 hc0 hm0
+  subst a0; subst a1; subst a2; subst a3; subst b0; subst b1; subst b2; subst b3
+  refine hraw.trans ?_
+  congr 1
+  · exact EvmWord.fromLimbs_match_getLimbN_id a
+  · exact EvmWord.fromLimbs_match_getLimbN_id b
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Proves **`evm_div_n2_lane_shiftNz_v5`** — the v5 n=2 DIV lane (shift≠0 case), from the stack-dispatch precondition to `divStackDispatchPostV5` over `divCode_noNop_v5`. This is the **shift≠0 half of the scaffold's `lane_n2`**, mirroring the merged `evm_div_n1_lane_shiftNz_v5`.

## Composition

- **Path**: entry→nopOff with carry discharged from shape (#7463, `evm_div_n2_stack_pre_to_unified_post_v5_noNop_fromShape`). The three runtime borrow flags are introduced in clean `ult (fullDivN2R{2,1}V5 …)` form via `obtain ⟨_, rfl⟩`, so the per-digit `bltu` path matches (`hc2…hm0`) are immediate (`rw [← hbltu_*]`).
- **Post**: `fullDivN2UnifiedPostNoX1V5_to_divStackDispatchPostV5` (#7464) + shape-derived quotient correctness.
- **Step count**: widen 840 → `unifiedDivBound` (946).

Also adds **`fullDivN2QuotientWordV5_eq_div_lane_of_shape`** (`N2V5QuotientLaneShape`): the lane (`a b : EvmWord`) form of n=2 quotient correctness from shape, bridging the `fromLimbs`-form `_eq_div_of_shape` to the `a b` form via `EvmWord.fromLimbs_match_getLimbN_id`.

## Verification

Axioms **match the merged n1 lane exactly** (`propext`/`Classical.choice`/`Quot.sound` plus the core `EvmWord.fromLimbs_getLimb`/`getLimb_fromLimbs_*` baseline axioms) — no new `native_decide`/`bv_decide` introduced. Full `EvmAsm.Evm64.DivMod` builds green (1607 jobs).

Stacked on `feat/v5-n2-post-to-dispatchpostv5` (#7464).

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)