### PR TITLE
feat(divmod): v5 n2 shift=0 loop body (loopBodyOff→denormOff) from shape

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -184,6 +184,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMTMBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMTTBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboTMMBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboTMTBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopDefsBorrowCarry
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -173,6 +173,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5IterSelectedEq
 import EvmAsm.Evm64.DivMod.Spec.N2V5IterR2R1Bridge
 import EvmAsm.Evm64.DivMod.Spec.N2V5BundleDigit2
 import EvmAsm.Evm64.DivMod.Spec.N2V5BundleOfShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5R2R1Dispatch
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -169,6 +169,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryBorrowN2
 import EvmAsm.Evm64.DivMod.Spec.N2V5HvSmall
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryOfCallShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5MaxCarryOfMaxShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5IterSelectedEq
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopSourceBorrowCarry

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -166,6 +166,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromUnreach
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromBorrow
 import EvmAsm.Evm64.DivMod.Spec.N2V5C3LeOne
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryBorrowN2
+import EvmAsm.Evm64.DivMod.Spec.N2V5HvSmall
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopSourceBorrowCarry

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -170,6 +170,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5HvSmall
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryOfCallShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5MaxCarryOfMaxShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5IterSelectedEq
+import EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopSourceBorrowCarry

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -170,6 +170,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5HvSmall
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryOfCallShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5MaxCarryOfMaxShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5IterSelectedEq
+import EvmAsm.Evm64.DivMod.Spec.N2V5IterR2R1Bridge
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -185,6 +185,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMTTBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboTMMBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboTMTBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopDefsBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopUnifiedBorrowCarry
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -179,6 +179,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCMBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMCBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMMBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCCMBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMTBorrowCarry
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -167,6 +167,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryFromBorrow
 import EvmAsm.Evm64.DivMod.Spec.N2V5C3LeOne
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryBorrowN2
 import EvmAsm.Evm64.DivMod.Spec.N2V5HvSmall
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryOfCallShape
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopSourceBorrowCarry

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -180,6 +180,10 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMCBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMMBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCCMBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMTBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMTMBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMTTBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboTMMBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboTMTBorrowCarry
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -199,6 +199,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopUnifiedBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopSelectedBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFullBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFromShape
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LaneShiftNz
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions
@@ -210,6 +211,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5ThreeStep
 import EvmAsm.Evm64.DivMod.Spec.N2V5RemainderLt
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormScaled
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLaneShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5ModRemainder
 import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0Quotient
 import EvmAsm.Evm64.DivMod.LoopIterN2V5.IterPostV5

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -176,6 +176,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5BundleDigit2
 import EvmAsm.Evm64.DivMod.Spec.N2V5BundleOfShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0BundleOfShape
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LoopShift0
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5PathShift0
 import EvmAsm.Evm64.DivMod.Spec.N2V5R2R1Dispatch
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -171,6 +171,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryOfCallShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5MaxCarryOfMaxShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5IterSelectedEq
 import EvmAsm.Evm64.DivMod.Spec.N2V5IterR2R1Bridge
+import EvmAsm.Evm64.DivMod.Spec.N2V5BundleDigit2
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -187,6 +187,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboTMTBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopDefsBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopUnifiedBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopSelectedBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFullBorrowCarry
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -214,6 +214,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLaneShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5ModRemainder
 import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0Quotient
+import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0QuotientLane
 import EvmAsm.Evm64.DivMod.LoopIterN2V5.IterPostV5
 import EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionAddbackV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN1.CallAddbackV5NoNop

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -203,6 +203,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopSelectedBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFullBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFromShape
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LaneShiftNz
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5Lane
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -174,6 +174,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5IterSelectedEq
 import EvmAsm.Evm64.DivMod.Spec.N2V5IterR2R1Bridge
 import EvmAsm.Evm64.DivMod.Spec.N2V5BundleDigit2
 import EvmAsm.Evm64.DivMod.Spec.N2V5BundleOfShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0BundleOfShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5R2R1Dispatch
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -168,6 +168,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5C3LeOne
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryBorrowN2
 import EvmAsm.Evm64.DivMod.Spec.N2V5HvSmall
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryOfCallShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5MaxCarryOfMaxShape
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopSourceBorrowCarry

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -197,6 +197,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopDefsBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopUnifiedBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopSelectedBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFullBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFromShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -249,6 +249,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopUnifiedPost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopSelected
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopPreloop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFull
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePostSelected

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -175,6 +175,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5IterR2R1Bridge
 import EvmAsm.Evm64.DivMod.Spec.N2V5BundleDigit2
 import EvmAsm.Evm64.DivMod.Spec.N2V5BundleOfShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0BundleOfShape
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LoopShift0
 import EvmAsm.Evm64.DivMod.Spec.N2V5R2R1Dispatch
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -158,6 +158,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallablePost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallablePostSelected
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N2V5ConcretePostBridge
+import EvmAsm.Evm64.DivMod.Spec.N2V5PostToDispatchPostV5
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallableExact
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallAddbackOverestimate
 import EvmAsm.Evm64.DivMod.Spec.N2V5TrialOverestimate

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -186,6 +186,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboTMMBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboTMTBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopDefsBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopUnifiedBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopSelectedBorrowCarry
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -172,6 +172,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5MaxCarryOfMaxShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5IterSelectedEq
 import EvmAsm.Evm64.DivMod.Spec.N2V5IterR2R1Bridge
 import EvmAsm.Evm64.DivMod.Spec.N2V5BundleDigit2
+import EvmAsm.Evm64.DivMod.Spec.N2V5BundleOfShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallIterBorrowCarry

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5Lane.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5Lane.lean
@@ -1,0 +1,51 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5Lane
+
+  The v5 n=2 DIV lane combiner: case-splits on the normalization shift
+  (`(clzResult (b.getLimbN 1)).1 = 0`), delegating to the proven shift≠0 lane
+  (`evm_div_n2_lane_shiftNz_v5`, #7465) and to the shift=0 lane (supplied as a
+  hypothesis, to be discharged once the shift=0 path is assembled).  Produces the
+  full `N2`-shape lane in the form the unconditional scaffold
+  (`evm_div_stack_spec_unconditional_of_lanes_v5_div`) consumes.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LaneShiftNz
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- n=2 lane = shift=0 lane ⊕ shift≠0 lane (#7465), combined by `by_cases` on the
+    normalization shift. -/
+theorem evm_div_n2_lane_v5 (sp base : Word) (a b : EvmWord)
+    (raVal v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0) (hb1nz : b.getLimbN 1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (shift0lane : (clzResult (b.getLimbN 1)).1 = 0 →
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v5 base)
+        (divModStackDispatchPreNoX1 sp a b
+          (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+          ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat)) v5 v6 v7 v10 v11Old
+          q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+         ((sp + signExtend12 3936) ↦ₘ scratchMem))
+        (divStackDispatchPostV5 sp a b)) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat)) v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostV5 sp a b) := by
+  by_cases hsh : (clzResult (b.getLimbN 1)).1 = 0
+  · exact shift0lane hsh
+  · exact evm_div_n2_lane_shiftNz_v5 sp base a b raVal v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+      retMem dMem dloMem scratch_un0 scratchMem hbnz hb3z hb2z hb1nz hsh halign
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5LaneShiftNz.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5LaneShiftNz.lean
@@ -1,0 +1,107 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LaneShiftNz
+
+  The v5 n=2 DIV lane, shift≠0 case: from the stack-dispatch precondition to
+  `divStackDispatchPostV5`, over `divCode_noNop_v5`.  Composes the entry→nopOff
+  path with the carry discharged from shape
+  (`evm_div_n2_stack_pre_to_unified_post_v5_noNop_fromShape`, #7463), the post
+  bridge (`fullDivN2UnifiedPostNoX1V5_to_divStackDispatchPostV5`, #7464) with the
+  shape-derived quotient correctness
+  (`fullDivN2QuotientWordV5_eq_div_lane_of_shape`), and the step-count widening to
+  `unifiedDivBound`.  This is the shift≠0 half of `lane_n2` matching
+  `evm_div_stack_spec_unconditional_of_lanes_v5_div`, mirroring
+  `evm_div_n1_lane_shiftNz_v5`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFromShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5PostToDispatchPostV5
+import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLaneShape
+import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Div
+import EvmAsm.Evm64.DivMod.Spec.UnifiedBzero
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem evm_div_n2_lane_shiftNz_v5 (sp base : Word) (a b : EvmWord)
+    (raVal v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0) (hb1nz : b.getLimbN 1 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 1)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat)) v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostV5 sp a b) := by
+  -- The three runtime borrow flags, in clean `ult (fullDivN2R{2,1}V5 …)` form.
+  obtain ⟨bltu_2, hbltu_2⟩ :
+      ∃ x, x = BitVec.ult (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1 := ⟨_, rfl⟩
+  obtain ⟨bltu_1, hbltu_1⟩ :
+      ∃ x, x = BitVec.ult (fullDivN2R2V5 bltu_2 (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1 := ⟨_, rfl⟩
+  obtain ⟨bltu_0, hbltu_0⟩ :
+      ∃ x, x = BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1 := ⟨_, rfl⟩
+  -- The per-digit `bltu` path matches, from the clean flag definitions.
+  have hc2 : bltu_2 = true →
+      BitVec.ult (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.1 = true := fun h => by rw [← hbltu_2]; exact h
+  have hm2 : bltu_2 = false →
+      ¬ BitVec.ult (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.1 := fun h => by rw [← hbltu_2, h]; decide
+  have hc1 : bltu_1 = true →
+      BitVec.ult (fullDivN2R2V5 bltu_2 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.1 = true := fun h => by rw [← hbltu_1]; exact h
+  have hm1 : bltu_1 = false →
+      ¬ BitVec.ult (fullDivN2R2V5 bltu_2 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.1 := fun h => by rw [← hbltu_1, h]; decide
+  have hc0 : bltu_0 = true →
+      BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.1 = true := fun h => by rw [← hbltu_0]; exact h
+  have hm0 : bltu_0 = false →
+      ¬ BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.1 := fun h => by rw [← hbltu_0, h]; decide
+  -- Quotient correctness from shape (lane form).
+  have hdivWord := fullDivN2QuotientWordV5_eq_div_lane_of_shape bltu_2 bltu_1 bltu_0
+    (a := a) (b := b) rfl rfl rfl rfl rfl rfl rfl rfl
+    hb2z hb3z hshift_nz hb1nz hc2 hm2 hc1 hm1 hc0 hm0
+  -- The entry→nopOff path with carry discharged from shape.
+  have hpath := evm_div_n2_stack_pre_to_unified_post_v5_noNop_fromShape sp base a b
+    v5 v6 v7 v10 v11Old q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0 scratchMem raVal
+    bltu_2 bltu_1 bltu_0 hbnz hb3z hb2z hb1nz hshift_nz halign hbltu_2 hbltu_1 hbltu_0
+  refine cpsTripleWithin_mono_nSteps (by have h : unifiedDivBound = 946 := rfl; omega) <|
+    cpsTripleWithin_weaken (fun _ hp => hp) ?_ hpath
+  intro h hq
+  exact fullDivN2UnifiedPostNoX1V5_to_divStackDispatchPostV5 bltu_2 bltu_1 bltu_0 sp base a b
+    retMem dMem dloMem scratch_un0 scratchMem raVal hdivWord h hq
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5LoopShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5LoopShift0.lean
@@ -1,0 +1,91 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LoopShift0
+
+  v5 n=2 shift=0 LOOP body (loopBodyOff → denormOff) over `divCode_noNop_v5`,
+  with the carry hypothesis DISCHARGED FROM SHAPE.  The unified loop
+  (`divK_loop_n2_unified_from_source_exact_loopIterScratch_v5_noNop_borrowCarry`,
+  #7449) is GENERIC in the divisor/window values, so the shift=0 loop is that
+  loop instantiated with the RAW divisor `(b0, b1, 0, 0)` and the shift=0
+  u-window `(a2, a3, 0, 0, 0)` / `a1` / `a0`.  The carry is discharged via
+  `loopN2SelectedBorrowCarryV5_shift0_of_shape` (#7469); the borrow flags are
+  introduced in clean `ult (iterN2V5 …).2.2.1 b1` form.  The `hbltu_0` goal
+  (#7449's `iterN2Max`/`iterWithDoubleAddback` THREADED form) is bridged to the
+  clean PADDED form by rewriting the digit-2 `u3 = uTop = 0` collapse
+  (`iterN2V5_collapse`, converted to `iterN2Max` form by `simp [iterN2V5]`).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopUnifiedBorrowCarry
+import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0BundleOfShape
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+theorem divK_loop_n2_shift0_from_shape_v5_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (a0 a1 a2 a3 b0 b1 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hb1ge : b1.toNat ≥ 2^63) :
+    ∃ bltu_2 bltu_1 bltu_0 : Bool,
+    cpsTripleWithin 702 (base + loopBodyOff) (base + denormOff)
+      (divCode_noNop_v5 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        b0 b1 0 0 a2 a3 0 0 0 a1 a0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN2UnifiedPostV5NoX1 bltu_2 bltu_1 bltu_0 sp base
+        b0 b1 0 0 a2 a3 0 0 0 a1 a0
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  have h0 : (0:Word).toNat = 0 := rfl
+  have hbnz : b0 ||| b1 ||| (0:Word) ||| 0 ≠ 0 := by
+    intro h
+    have h2 := (BitVec.or_eq_zero_iff.mp h).1
+    have h3 := (BitVec.or_eq_zero_iff.mp h2).1
+    have hz : b1 = 0 := (BitVec.or_eq_zero_iff.mp h3).2
+    rw [hz] at hb1ge; simp at hb1ge
+  have hvpos : 2^127 ≤ val256 b0 b1 0 0 := by simp only [EvmWord.val256, h0]; omega
+  have hfwv : val256 a2 a3 0 0 < 2^64 * val256 b0 b1 0 0 := by
+    have ha : val256 a2 a3 0 0 < 2^128 := by
+      have := a2.isLt; have := a3.isLt; simp only [EvmWord.val256, h0]; omega
+    calc val256 a2 a3 0 0 < 2^128 := ha
+      _ ≤ 2^64 * 2^127 := by norm_num
+      _ ≤ 2^64 * val256 b0 b1 0 0 := Nat.mul_le_mul_left _ hvpos
+  -- The three runtime borrow flags, in clean `ult (iterN2V5 …).2.2.1 b1` form.
+  obtain ⟨bltu_2, hbltu_2⟩ : ∃ x, x = BitVec.ult (0 : Word) b1 := ⟨_, rfl⟩
+  obtain ⟨bltu_1, hbltu_1⟩ :
+      ∃ x, x = BitVec.ult (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 b1 := ⟨_, rfl⟩
+  obtain ⟨bltu_0, hbltu_0⟩ :
+      ∃ x, x = BitVec.ult (iterN2V5 bltu_1 b0 b1 0 0 a1
+        (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1
+        (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 0).2.2.1 b1 := ⟨_, rfl⟩
+  -- Per-digit `bltu` path matches (shared by the collapse + carry bundle).
+  have hc2 : bltu_2 = true → BitVec.ult (0:Word) b1 = true := fun h => by rw [← hbltu_2]; exact h
+  have hm2 : bltu_2 = false → ¬ BitVec.ult (0:Word) b1 := fun h => by rw [← hbltu_2, h]; decide
+  -- digit-2 remainder collapse (u3 = uTop = 0).
+  obtain ⟨hR2u3, hR2uTop, _⟩ := iterN2V5_collapse bltu_2 b0 b1 a2 a3 0 hbnz hb1ge hfwv hc2 hm2
+  refine ⟨bltu_2, bltu_1, bltu_0, ?_⟩
+  apply divK_loop_n2_unified_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+    bltu_2 bltu_1 bltu_0 sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    b0 b1 0 0 a2 a3 0 0 0 a1 a0 q2Old q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign
+  case hbltu_2 =>
+    exact hbltu_2
+  case hbltu_1 =>
+    cases bltu_2 <;>
+      simp only [iterN2V5, reduceIte, Bool.false_eq_true] at hbltu_1 ⊢ <;> exact hbltu_1
+  case hbltu_0 =>
+    cases bltu_2 <;> cases bltu_1 <;>
+      simp only [iterN2V5, reduceIte, Bool.false_eq_true] at hR2u3 hR2uTop hbltu_0 ⊢ <;>
+      rw [hR2u3, hR2uTop] <;> exact hbltu_0
+  case hcarry =>
+    exact loopN2SelectedBorrowCarryV5_shift0_of_shape a0 a1 a2 a3 b0 b1
+      bltu_2 bltu_1 bltu_0 hb1ge hc2 hm2
+      (fun h => by rw [← hbltu_1]; exact h)
+      (fun h => by rw [← hbltu_1, h]; decide)
+      (fun h => by rw [← hbltu_0]; exact h)
+      (fun h => by rw [← hbltu_0, h]; decide)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopCallablePostSelectedBorrowCarry.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopCallablePostSelectedBorrowCarry.lean
@@ -1,0 +1,647 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallablePostSelectedBorrowCarry
+
+  Borrow-dispatched n=2 v5 entry→nopOff full path: mirror of #7420
+  (`evm_div_n2_stack_pre_to_unified_post_v5_noNop_selectedCarry`) using the
+  borrow-dispatched full path (#7451) and taking `loopN2SelectedBorrowCarryV5`
+  (satisfiable from shape).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallablePost
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFullBorrowCarry
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_add_zero)
+
+theorem evm_div_n2_stack_pre_to_unified_post_v5_noNop_borrowCarry (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0) (hb1nz : b.getLimbN 1 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 1)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 : bltu_2 =
+      BitVec.ult (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1)
+    (hbltu_1 : bltu_1 =
+      match bltu_2 with
+      | false =>
+        BitVec.ult (iterN2Max
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+          (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+          (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+          (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+          (0 : Word) (0 : Word)).2.2.1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.1
+      | true =>
+        BitVec.ult (iterWithDoubleAddback
+          (divKTrialCallV5QHat
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1)
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+          (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+          (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+          (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+          (0 : Word) (0 : Word)).2.2.1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_2, bltu_1 with
+      | false, false =>
+        BitVec.ult (iterN2Max
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+          (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.1
+          (iterN2Max (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+            (0 : Word) (0 : Word)).2.1
+          (iterN2Max (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.1
+          (iterN2Max (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.1
+          (iterN2Max (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.1
+      | false, true =>
+        BitVec.ult (iterWithDoubleAddback
+          (divKTrialCallV5QHat
+            (iterN2Max (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+              (0 : Word) (0 : Word)).2.2.1
+            (iterN2Max (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+              (0 : Word) (0 : Word)).2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1)
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+          (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.1
+          (iterN2Max (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+            (0 : Word) (0 : Word)).2.1
+          (iterN2Max (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.1
+          (iterN2Max (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.1
+          (iterN2Max (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.1
+      | true, false =>
+        BitVec.ult (iterN2Max
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+          (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.1)
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+            (0 : Word) (0 : Word)).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.1)
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.1)
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.1)
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.1
+      | true, true =>
+        BitVec.ult (iterWithDoubleAddback
+          (divKTrialCallV5QHat
+            (iterWithDoubleAddback (divKTrialCallV5QHat
+                (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                  (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+                (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                  (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+                (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                  (b.getLimbN 2) (b.getLimbN 3)).2.1)
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+              (0 : Word) (0 : Word)).2.2.1
+            (iterWithDoubleAddback (divKTrialCallV5QHat
+                (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                  (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+                (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                  (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+                (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                  (b.getLimbN 2) (b.getLimbN 3)).2.1)
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+              (0 : Word) (0 : Word)).2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1)
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+          (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.1)
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+            (0 : Word) (0 : Word)).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.1)
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.1)
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+              (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+              (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.1)
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+            (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
+          (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.1)
+    (hcarry : loopN2SelectedBorrowCarryV5 bltu_2 bltu_1 bltu_0
+      (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+      (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+      (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 1)).2.2.1
+      (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 1)).2.2.2.1
+      (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 1)).2.2.2.2
+      (0 : Word) (0 : Word)
+      (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 1)).2.1
+      (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 1)).1) :
+    cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 702) + (2 + 23 + 10))
+      base (base + nopOff) (divCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (fullDivN2UnifiedPostNoX1V5 bltu_2 bltu_1 bltu_0 sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        retMem dMem dloMem scratchUn0 scratchMem **
+       (.x1 ↦ᵣ raVal)) := by
+  have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
+  have hA0 := fullDivN2_preloop_loop_unified_exact_x1_scratch_v5_noNop_borrowCarry
+    bltu_2 bltu_1 bltu_0 sp base
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz' hb3z hb2z hb1nz hshift_nz halign hbltu_2
+    (by cases bltu_2 <;> simpa using hbltu_1)
+    (by cases bltu_2 <;> cases bltu_1 <;> simpa using hbltu_0) hcarry
+  have hA : cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 702)
+      base (base + denormOff) (divCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      ((loopN2UnifiedPostV5NoX1 bltu_2 bltu_1 bltu_0 sp base
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+        (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 1)).2.2.1
+        (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 1)).2.2.2.1
+        (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 1)).2.2.2.2
+        (0 : Word) (0 : Word)
+        (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 1)).2.1
+        (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 1)).1
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
+        ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult (b.getLimbN 1)).1))) := by
+    refine cpsTripleWithin_weaken ?_ (fun _ hq => hq) hA0
+    intro _ hp
+    rw [divModStackDispatchPreNoX1_unfold, divScratchValuesCallNoX1_unfold] at hp
+    rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ rfl rfl rfl rfl,
+        evmWordIs_sp32_limbs_eq sp b _ _ _ _ rfl rfl rfl rfl,
+        divScratchValues_unfold] at hp
+    rw [word_add_zero]
+    xperm_hyp hp
+  have hshift_nz' : fullDivN2Shift (b.getLimbN 1) ≠ 0 := by
+    delta fullDivN2Shift
+    exact hshift_nz
+  have hBNoNop := evm_div_n2_denorm_epilogue_bundled_spec_noNop_v5Final_exact_x1_frame
+    bltu_2 bltu_1 bltu_0 sp base
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    retMem dMem dloMem scratchUn0 scratchMem raVal hshift_nz'
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      cases bltu_2 <;> cases bltu_1 <;> cases bltu_0
+      · exact loopN2UnifiedPostV5NoX1_to_fullDivN2DenormPreV5_frame_FFF
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      · exact loopN2UnifiedPostV5NoX1_to_fullDivN2DenormPreV5_frame_FFT
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      · exact loopN2UnifiedPostV5NoX1_to_fullDivN2DenormPreV5_frame_FTF
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      · exact loopN2UnifiedPostV5NoX1_to_fullDivN2DenormPreV5_frame_FTT
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      · exact loopN2UnifiedPostV5NoX1_to_fullDivN2DenormPreV5_frame_TFF
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      · exact loopN2UnifiedPostV5NoX1_to_fullDivN2DenormPreV5_frame_TFT
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      · exact loopN2UnifiedPostV5NoX1_to_fullDivN2DenormPreV5_frame_TTF
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      · exact loopN2UnifiedPostV5NoX1_to_fullDivN2DenormPreV5_frame_TTT
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp)
+    hA hBNoNop
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hq => hq)
+    hFull
+
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboMMTBorrowCarry.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboMMTBorrowCarry.lean
@@ -1,0 +1,149 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMTBorrowCarry
+
+  Borrow-dispatched variant of the n=2 max×max×call source path (ComboMMT):
+  each digit's carry required only conditionally on its runtime borrow.
+  Composes the max×max prefix borrowCarry (#7440) + j=0 call exit body
+  borrowCarry (#7432).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMT
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem divK_loop_n2_max_max_call_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 : ¬BitVec.ult u2 v1)
+    (hcarry2_borrow_2 :
+      BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) →
+      isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_1 :
+      let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      ¬BitVec.ult r2.2.2.1 v1)
+    (hcarry2_borrow_1 :
+      let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r2.2.2.2.2.1
+        (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1) →
+      isAddbackCarry2NzN2Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1)
+    (hbltu_0 :
+      let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      let r1 := iterN2Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+      BitVec.ult r1.2.2.1 v1)
+    (hcarry2_borrow_0 :
+      let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      let r1 := iterN2Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+      BitVec.ult r1.2.2.2.2.1
+        (mulsubN4_c3 (divKTrialCallV5QHat r1.2.2.1 r1.2.1 v1)
+          v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    cpsTripleWithin (152 + 152 + 234) (base + loopBodyOff) (base + denormOff)
+      (divCode_noNop_v5 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN2MaxMaxCallSourceFinalPostNoX1V5 sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem) := by
+  have JMM := divK_loop_n2_max_max_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    hbltu_2 hcarry2_borrow_2 hbltu_1 hcarry2_borrow_1
+  have J0 := divK_loop_body_n2_call_j0_exact_loopIterScratch_v5_noNop_borrowCarry sp base
+    (1 : Word) ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3
+      (signExtend12 4095 : Word)
+      v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1)
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig0
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    halign hbltu_0 hcarry2_borrow_0
+  have J0f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterN2Max v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+      (iterN2Max v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1)) **
+     (((sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)))
+    (by pcFree) J0
+  have hcomp := cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN2MaxScratchX1_j1_to_call_j0_pre_with_j2_frame
+      sp retMem dMem dloMem scratchUn0 scratchMem
+      v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+      u0Orig0 q0Old raVal
+      (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+    JMM J0f
+  have hsteps : (152 + 152) + 234 = 152 + 152 + 234 := by decide
+  rw [hsteps] at hcomp
+  refine cpsTripleWithin_weaken (fun _ hp => hp) ?_ hcomp
+  intro h hp
+  rw [loopN2MaxMaxCallSourceFinalPostNoX1V5_unfold]
+  simp only [r2MMTN2V5_eq, r1MMTN2V5_eq] at hp ⊢
+  xperm_hyp hp
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboMTMBorrowCarry.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboMTMBorrowCarry.lean
@@ -1,0 +1,201 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMTMBorrowCarry
+
+  Borrow-dispatched variant of the n=2 max_call_max source path (ComboMTM): each digit's
+  carry required only conditionally on its runtime borrow.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMCBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMaxJ0BorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMTM
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem divK_loop_n2_max_call_max_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 :
+      ¬BitVec.ult u2 v1)
+    (hcarry2_borrow_2 :
+      BitVec.ult uTop
+        (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) →
+      isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_1 :
+      let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r2.2.2.1 v1)
+    (hcarry2_borrow_1 :
+      let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r2.2.2.2.2.1
+        (mulsubN4_c3 (divKTrialCallV5QHat r2.2.2.1 r2.2.1 v1) v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1)
+    (hbltu_0 :
+      let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      let r1 := iterWithDoubleAddback (divKTrialCallV5QHat r2.2.2.1 r2.2.1 v1)
+        v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+      ¬BitVec.ult r1.2.2.1 v1)
+    (hcarry2_borrow_0 :
+      let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      let r1 := iterWithDoubleAddback (divKTrialCallV5QHat r2.2.2.1 r2.2.1 v1)
+        v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+      BitVec.ult r1.2.2.2.2.1
+        (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      isAddbackCarry2NzN2Max v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    cpsTripleWithin (152 + 234 + 152) (base + loopBodyOff) (base + denormOff)
+      (divCode_noNop_v5 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN2MaxCallMaxSourceFinalPostNoX1V5 sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem) := by
+  have JMC := divK_loop_n2_max_call_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    halign hbltu_2 hcarry2_borrow_2 hbltu_1 hcarry2_borrow_1
+  have J0 := divK_loop_body_n2_max_j0_exact_loopIterScratch_v5_noNop_borrowCarry sp base
+    (1 : Word) ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3
+      (divKTrialCallV5QHat
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+      v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1)
+    (iterWithDoubleAddback
+        (divKTrialCallV5QHat
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+        v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1
+    (iterWithDoubleAddback
+        (divKTrialCallV5QHat
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+        v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig0
+    (iterWithDoubleAddback
+        (divKTrialCallV5QHat
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+        v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+    (iterWithDoubleAddback
+        (divKTrialCallV5QHat
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+        v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+    (iterWithDoubleAddback
+        (divKTrialCallV5QHat
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+        v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+    (iterWithDoubleAddback
+        (divKTrialCallV5QHat
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+        v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    q0Old raVal
+    (base + div128CallRetOff) v1
+    (divKTrialCallV5DLo v1)
+    (divKTrialCallV5Un0
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1)
+    (divKTrialCallV5ScratchOut
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1
+      scratchMem)
+    hbltu_0 hcarry2_borrow_0
+  have J0f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterWithDoubleAddback
+          (divKTrialCallV5QHat
+            (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+            (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+          v0 v1 v2 v3 u0Orig1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+      (iterWithDoubleAddback
+          (divKTrialCallV5QHat
+            (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+            (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+          v0 v1 v2 v3 u0Orig1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1)) **
+     (((sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)))
+    (by pcFree) J0
+  have hcomp := cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN2CallScratchNoX1_j1_to_max_j0_pre_with_j2_frame
+      sp base
+      (divKTrialCallV5QHat
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+      (divKTrialCallV5DLo v1)
+      (divKTrialCallV5Un0
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1)
+      (divKTrialCallV5ScratchOut
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1
+        scratchMem)
+      v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+      u0Orig0 q0Old raVal
+      (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+    JMC J0f
+  have hsteps : (152 + 234) + 152 = 152 + 234 + 152 := by decide
+  rw [hsteps] at hcomp
+  refine cpsTripleWithin_weaken (fun _ hp => hp) ?_ hcomp
+  intro h hp
+  rw [loopN2MaxCallMaxSourceFinalPostNoX1V5_unfold]
+  simp only [r2MTTN2V5_eq, r1MTTN2V5_eq] at hp ⊢
+  xperm_hyp hp
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboMTTBorrowCarry.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboMTTBorrowCarry.lean
@@ -1,0 +1,201 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMTTBorrowCarry
+
+  Borrow-dispatched variant of the n=2 max_call_call source path (ComboMTT): each digit's
+  carry required only conditionally on its runtime borrow.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMCBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMTT
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem divK_loop_n2_max_call_call_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 :
+      ¬BitVec.ult u2 v1)
+    (hcarry2_borrow_2 :
+      BitVec.ult uTop
+        (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) →
+      isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_1 :
+      let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r2.2.2.1 v1)
+    (hcarry2_borrow_1 :
+      let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r2.2.2.2.2.1
+        (mulsubN4_c3 (divKTrialCallV5QHat r2.2.2.1 r2.2.1 v1) v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1)
+    (hbltu_0 :
+      let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      let r1 := iterWithDoubleAddback (divKTrialCallV5QHat r2.2.2.1 r2.2.1 v1)
+        v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+      BitVec.ult r1.2.2.1 v1)
+    (hcarry2_borrow_0 :
+      let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      let r1 := iterWithDoubleAddback (divKTrialCallV5QHat r2.2.2.1 r2.2.1 v1)
+        v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+      BitVec.ult r1.2.2.2.2.1
+        (mulsubN4_c3 (divKTrialCallV5QHat r1.2.2.1 r1.2.1 v1) v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    cpsTripleWithin (152 + 234 + 234) (base + loopBodyOff) (base + denormOff)
+      (divCode_noNop_v5 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN2MaxCallCallSourceFinalPostNoX1V5 sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem) := by
+  have JMC := divK_loop_n2_max_call_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    halign hbltu_2 hcarry2_borrow_2 hbltu_1 hcarry2_borrow_1
+  have J0 := divK_loop_body_n2_call_j0_exact_loopIterScratch_v5_noNop_borrowCarry sp base
+    (1 : Word) ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3
+      (divKTrialCallV5QHat
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+      v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1)
+    (iterWithDoubleAddback
+        (divKTrialCallV5QHat
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+        v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1
+    (iterWithDoubleAddback
+        (divKTrialCallV5QHat
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+        v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig0
+    (iterWithDoubleAddback
+        (divKTrialCallV5QHat
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+        v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+    (iterWithDoubleAddback
+        (divKTrialCallV5QHat
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+        v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+    (iterWithDoubleAddback
+        (divKTrialCallV5QHat
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+        v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+    (iterWithDoubleAddback
+        (divKTrialCallV5QHat
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+        v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    q0Old raVal
+    (base + div128CallRetOff) v1
+    (divKTrialCallV5DLo v1)
+    (divKTrialCallV5Un0
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1)
+    (divKTrialCallV5ScratchOut
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1
+      scratchMem)
+    halign hbltu_0 hcarry2_borrow_0
+  have J0f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterWithDoubleAddback
+          (divKTrialCallV5QHat
+            (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+            (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+          v0 v1 v2 v3 u0Orig1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+      (iterWithDoubleAddback
+          (divKTrialCallV5QHat
+            (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+            (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+          v0 v1 v2 v3 u0Orig1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1)) **
+     (((sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)))
+    (by pcFree) J0
+  have hcomp := cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN2CallScratchNoX1_j1_to_call_j0_pre_with_j2_frame
+      sp base
+      (divKTrialCallV5QHat
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+      (divKTrialCallV5DLo v1)
+      (divKTrialCallV5Un0
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1)
+      (divKTrialCallV5ScratchOut
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1
+        scratchMem)
+      v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+      u0Orig0 q0Old raVal
+      (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+    JMC J0f
+  have hsteps : (152 + 234) + 234 = 152 + 234 + 234 := by decide
+  rw [hsteps] at hcomp
+  refine cpsTripleWithin_weaken (fun _ hp => hp) ?_ hcomp
+  intro h hp
+  rw [loopN2MaxCallCallSourceFinalPostNoX1V5_unfold]
+  simp only [r2MTTN2V5_eq, r1MTTN2V5_eq] at hp ⊢
+  xperm_hyp hp
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboTMMBorrowCarry.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboTMMBorrowCarry.lean
@@ -1,0 +1,200 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboTMMBorrowCarry
+
+  Borrow-dispatched variant of the n=2 call_max_max source path (ComboTMM): each digit's
+  carry required only conditionally on its runtime borrow.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCMBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMaxJ0BorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboTMM
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem divK_loop_n2_call_max_max_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 :
+      BitVec.ult u2 v1)
+    (hcarry2_borrow_2 :
+      BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_1 :
+      let r2 := iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      ¬BitVec.ult r2.2.2.1 v1)
+    (hcarry2_borrow_1 :
+      let r2 := iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r2.2.2.2.2.1
+        (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1) →
+      isAddbackCarry2NzN2Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1)
+    (hbltu_0 :
+      let r2 := iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      let r1 := iterN2Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+      ¬BitVec.ult r1.2.2.1 v1)
+    (hcarry2_borrow_0 :
+      let r2 := iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      let r1 := iterN2Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+      BitVec.ult r1.2.2.2.2.1
+        (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      isAddbackCarry2NzN2Max v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    cpsTripleWithin (234 + 152 + 152) (base + loopBodyOff) (base + denormOff)
+      (divCode_noNop_v5 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN2CallMaxMaxSourceFinalPostNoX1V5 sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem) := by
+  have JCM := divK_loop_n2_call_max_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    halign hbltu_2 hcarry2_borrow_2 hbltu_1 hcarry2_borrow_1
+  have J0 := divK_loop_body_n2_max_j0_exact_loopIterScratch_v5_noNop_borrowCarry sp base
+    (1 : Word) ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3
+      (signExtend12 4095 : Word)
+      v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1)
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig0
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    q0Old raVal
+    (base + div128CallRetOff) v1
+    (divKTrialCallV5DLo v1)
+    (divKTrialCallV5Un0 u1)
+    (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem)
+    hbltu_0 hcarry2_borrow_0
+  have J0f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterN2Max v0 v1 v2 v3 u0Orig1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+      (iterN2Max v0 v1 v2 v3 u0Orig1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1)) **
+     (((sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)))
+    (by pcFree) J0
+  have hcomp := cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN2MaxScratchX1_j1_to_max_j0_pre_with_j2_frame
+      sp (base + div128CallRetOff) v1 (divKTrialCallV5DLo v1)
+      (divKTrialCallV5Un0 u1)
+      (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem)
+      v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+      u0Orig0 q0Old raVal
+      (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+    JCM J0f
+  have hsteps : (234 + 152) + 152 = 234 + 152 + 152 := by decide
+  rw [hsteps] at hcomp
+  refine cpsTripleWithin_weaken (fun _ hp => hp) ?_ hcomp
+  intro h hp
+  rw [loopN2CallMaxMaxSourceFinalPostNoX1V5_unfold]
+  simp only [r2CCCN2V5_eq, r1TMMN2V5_eq] at hp ⊢
+  xperm_hyp hp
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboTMTBorrowCarry.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboTMTBorrowCarry.lean
@@ -1,0 +1,200 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboTMTBorrowCarry
+
+  Borrow-dispatched variant of the n=2 call_max_call source path (ComboTMT): each digit's
+  carry required only conditionally on its runtime borrow.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCMBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboTMT
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem divK_loop_n2_call_max_call_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 :
+      BitVec.ult u2 v1)
+    (hcarry2_borrow_2 :
+      BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_1 :
+      let r2 := iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      ¬BitVec.ult r2.2.2.1 v1)
+    (hcarry2_borrow_1 :
+      let r2 := iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r2.2.2.2.2.1
+        (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1) →
+      isAddbackCarry2NzN2Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1)
+    (hbltu_0 :
+      let r2 := iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      let r1 := iterN2Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+      BitVec.ult r1.2.2.1 v1)
+    (hcarry2_borrow_0 :
+      let r2 := iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      let r1 := iterN2Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+      BitVec.ult r1.2.2.2.2.1
+        (mulsubN4_c3 (divKTrialCallV5QHat r1.2.2.1 r1.2.1 v1) v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    cpsTripleWithin (234 + 152 + 234) (base + loopBodyOff) (base + denormOff)
+      (divCode_noNop_v5 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN2CallMaxCallSourceFinalPostNoX1V5 sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem) := by
+  have JCM := divK_loop_n2_call_max_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    halign hbltu_2 hcarry2_borrow_2 hbltu_1 hcarry2_borrow_1
+  have J0 := divK_loop_body_n2_call_j0_exact_loopIterScratch_v5_noNop_borrowCarry sp base
+    (1 : Word) ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3
+      (signExtend12 4095 : Word)
+      v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1)
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig0
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    q0Old raVal
+    (base + div128CallRetOff) v1
+    (divKTrialCallV5DLo v1)
+    (divKTrialCallV5Un0 u1)
+    (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem)
+    halign hbltu_0 hcarry2_borrow_0
+  have J0f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterN2Max v0 v1 v2 v3 u0Orig1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+      (iterN2Max v0 v1 v2 v3 u0Orig1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1)) **
+     (((sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)))
+    (by pcFree) J0
+  have hcomp := cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN2MaxScratchX1_j1_to_call_j0_pre_with_j2_frame
+      sp (base + div128CallRetOff) v1 (divKTrialCallV5DLo v1)
+      (divKTrialCallV5Un0 u1)
+      (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem)
+      v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+      u0Orig0 q0Old raVal
+      (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+    JCM J0f
+  have hsteps : (234 + 152) + 234 = 234 + 152 + 234 := by decide
+  rw [hsteps] at hcomp
+  refine cpsTripleWithin_weaken (fun _ hp => hp) ?_ hcomp
+  intro h hp
+  rw [loopN2CallMaxCallSourceFinalPostNoX1V5_unfold]
+  simp only [r2CCCN2V5_eq, r1TMMN2V5_eq] at hp ⊢
+  xperm_hyp hp
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopFromShape.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopFromShape.lean
@@ -1,0 +1,89 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFromShape
+
+  Borrow-dispatched n=2 v5 entry→nopOff full path, with the carry hypothesis
+  DISCHARGED FROM SHAPE.  Wraps `evm_div_n2_stack_pre_to_unified_post_v5_noNop_borrowCarry`
+  (#7452): instead of taking `loopN2SelectedBorrowCarryV5` as a hypothesis, it
+  discharges it via `loopN2SelectedBorrowCarryV5_of_shape` (#7461), and accepts
+  the borrow flags in the CLEAN `ult (fullDivN2R{2,1}V5 …).2.2.1 vTop` form
+  (rather than #7452's `iterN2Max`/`iterWithDoubleAddback` `match` form), bridged
+  via the dispatch-form equalities (#7463).  This removes the last shape-derived
+  obligation from the n=2 execution path — the direct input to the n=2 lane.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallablePostSelectedBorrowCarry
+import EvmAsm.Evm64.DivMod.Spec.N2V5BundleOfShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5R2R1Dispatch
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem evm_div_n2_stack_pre_to_unified_post_v5_noNop_fromShape (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0) (hb1nz : b.getLimbN 1 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 1)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 : bltu_2 =
+      BitVec.ult (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN2R2V5 bltu_2 (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1)
+    (hbltu_0 : bltu_0 =
+      BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1) :
+    cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 702) + (2 + 23 + 10))
+      base (base + nopOff) (divCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (fullDivN2UnifiedPostNoX1V5 bltu_2 bltu_1 bltu_0 sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        retMem dMem dloMem scratchUn0 scratchMem **
+       (.x1 ↦ᵣ raVal)) := by
+  apply evm_div_n2_stack_pre_to_unified_post_v5_noNop_borrowCarry sp base a b
+    v5 v6 v7 v10 v11Old q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2z hb1nz hshift_nz halign hbltu_2
+  case hbltu_1 =>
+    -- match form, from clean form via dispatch-eq (full simp reduces the
+    -- proof-discriminated match)
+    cases bltu_2 <;> simpa [fullDivN2R2V5_eq_dispatch] using hbltu_1
+  case hbltu_0 =>
+    cases bltu_2 <;> cases bltu_1 <;>
+      simpa [fullDivN2R1V5_eq_dispatch, fullDivN2R2V5_eq_dispatch] using hbltu_0
+  case hcarry =>
+    -- discharge from shape (#7461); flags trivial from clean form
+    apply loopN2SelectedBorrowCarryV5_of_shape
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      bltu_2 bltu_1 bltu_0 hb2z hb3z hshift_nz hb1nz
+    · intro h; rw [← hbltu_2]; exact h
+    · intro h; rw [← hbltu_2, h]; decide
+    · intro h; rw [← hbltu_1]; exact h
+    · intro h; rw [← hbltu_1, h]; decide
+    · intro h; rw [← hbltu_0]; exact h
+    · intro h; rw [← hbltu_0, h]; decide
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopFullBorrowCarry.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopFullBorrowCarry.lean
@@ -1,0 +1,392 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFullBorrowCarry
+
+  Borrow-dispatched full n=2 v5 preloop+loop composition (entry → denormOff):
+  mirror of #7416 (`fullDivN2_preloop_loop_unified_..._selectedCarry`) using the
+  borrow-dispatched inst loop wrapper (#7450) and taking
+  `loopN2SelectedBorrowCarryV5` (satisfiable from shape).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopPreloop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopSelectedBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopLoopUnified
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Base
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem fullDivN2_preloop_loop_unified_exact_x1_scratch_v5_noNop_borrowCarry
+    (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
+    (hshift_nz : (clzResult b1).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 : bltu_2 =
+      BitVec.ult (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+        (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hbltu_1 : bltu_1 =
+      match bltu_2 with
+      | false =>
+        BitVec.ult (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+          (0 : Word) (0 : Word)).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+      | true =>
+        BitVec.ult (iterWithDoubleAddback
+          (divKTrialCallV5QHat
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.1)
+          (fullDivN2NormV b0 b1 b2 b3).1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+          (0 : Word) (0 : Word)).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_2, bltu_1 with
+      | false, false =>
+        BitVec.ult (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+      | false, true =>
+        BitVec.ult (iterWithDoubleAddback
+          (divKTrialCallV5QHat
+            (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+              (fullDivN2NormV b0 b1 b2 b3).2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (0 : Word) (0 : Word)).2.2.1
+            (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+              (fullDivN2NormV b0 b1 b2 b3).2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (0 : Word) (0 : Word)).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.1)
+          (fullDivN2NormV b0 b1 b2 b3).1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+      | true, false =>
+        BitVec.ult (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+      | true, true =>
+        BitVec.ult (iterWithDoubleAddback
+          (divKTrialCallV5QHat
+            (iterWithDoubleAddback (divKTrialCallV5QHat
+                (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+                (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+                (fullDivN2NormV b0 b1 b2 b3).2.1)
+              (fullDivN2NormV b0 b1 b2 b3).1
+              (fullDivN2NormV b0 b1 b2 b3).2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (0 : Word) (0 : Word)).2.2.1
+            (iterWithDoubleAddback (divKTrialCallV5QHat
+                (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+                (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+                (fullDivN2NormV b0 b1 b2 b3).2.1)
+              (fullDivN2NormV b0 b1 b2 b3).1
+              (fullDivN2NormV b0 b1 b2 b3).2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (0 : Word) (0 : Word)).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.1)
+          (fullDivN2NormV b0 b1 b2 b3).1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hcarry : loopN2SelectedBorrowCarryV5 bltu_2 bltu_1 bltu_0
+      (fullDivN2NormV b0 b1 b2 b3).1
+      (fullDivN2NormV b0 b1 b2 b3).2.1
+      (fullDivN2NormV b0 b1 b2 b3).2.2.1
+      (fullDivN2NormV b0 b1 b2 b3).2.2.2
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+      (0 : Word) (0 : Word)
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+      (fullDivN2NormU a0 a1 a2 a3 b1).1) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 702) base (base + denormOff)
+      (divCode_noNop_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      ((loopN2UnifiedPostV5NoX1 bltu_2 bltu_1 bltu_0 sp base
+        (fullDivN2NormV b0 b1 b2 b3).1
+        (fullDivN2NormV b0 b1 b2 b3).2.1
+        (fullDivN2NormV b0 b1 b2 b3).2.2.1
+        (fullDivN2NormV b0 b1 b2 b3).2.2.2
+        (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+        (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+        (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+        (0 : Word) (0 : Word)
+        (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+        (fullDivN2NormU a0 a1 a2 a3 b1).1
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1))) := by
+  have hPre := evm_div_n2_to_loopSetup_spec_within_v5_noNop_exact_x1_scratch_frame
+    sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2z hb1nz hshift_nz
+  have hLoop := evm_div_n2_loop_unified_inst_noNop_exact_x1_v5_borrowCarry
+    bltu_2 bltu_1 bltu_0 sp base
+    (fullDivN2Shift b1) (fullDivN2AntiShift b1)
+    (fullDivN2NormV b0 b1 b2 b3).1
+    (fullDivN2NormV b0 b1 b2 b3).2.1
+    (fullDivN2NormV b0 b1 b2 b3).2.2.1
+    (fullDivN2NormV b0 b1 b2 b3).2.2.2
+    (fullDivN2NormU a0 a1 a2 a3 b1).1
+    (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+    (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+    (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+    (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+    (a0 >>> ((fullDivN2AntiShift b1).toNat % 64)) v11Old jMem
+    retMem dMem dloMem scratchUn0 scratchMem raVal
+    halign hbltu_2 (by cases bltu_2 <;> simpa using hbltu_1)
+    (by cases bltu_2 <;> cases bltu_1 <;> simpa using hbltu_0) hcarry
+  have hLoopf := cpsTripleWithin_frameR
+    ((((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+      ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1)))
+    (by pcFree) hLoop
+  have hBridge := loopSetupPost_to_loopN2PreWithScratchV4NoX1_framed
+    sp a0 a1 a2 a3 b0 b1 b2 b3 v11Old
+    jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+  have hPre' := cpsTripleWithin_weaken
+    (fun h hp => hp)
+    hBridge
+    hPre
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hPre' hLoopf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hq => hq)
+    hFull
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopLoopDefsBorrowCarry.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopLoopDefsBorrowCarry.lean
@@ -1,0 +1,53 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopDefsBorrowCarry
+
+  `loopN2SelectedBorrowCarryV5`: the borrow-conditional analog of
+  `loopN2SelectedCarryV5` (FullPathN2V5NoNopLoopDefs).  Each per-digit carry fact
+  is required ONLY conditionally on that digit's runtime borrow — so unlike the
+  unconditional `loopN2SelectedCarryV5` (which is false when a call digit's trial
+  is exact, c3 = 0), this predicate IS satisfiable from shape (call digits via
+  `callAddbackCarry2NzV5_of_borrow_n2` (#7431), max digits vacuously since the
+  saturated trial never borrows).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopDefs
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Borrow-conditional selected-carry bundle for the n=2 v5 loop: per digit,
+    `borrow → carry`, with the trial and carry predicate picked by the branch. -/
+def loopN2SelectedBorrowCarryV5 (bltu_2 bltu_1 bltu_0 : Bool)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 : Word) : Prop :=
+  let r2 := loopN2IterSelectedV5 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let r1 := loopN2IterSelectedV5 bltu_1 v0 v1 v2 v3
+    u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  (if bltu_2 then
+    (BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+   else
+    (BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) →
+      isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)) ∧
+  (if bltu_1 then
+    (BitVec.ult r2.2.2.2.2.1
+      (mulsubN4_c3 (divKTrialCallV5QHat r2.2.2.1 r2.2.1 v1)
+        v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1)
+   else
+    (BitVec.ult r2.2.2.2.2.1
+      (mulsubN4_c3 (signExtend12 4095 : Word)
+        v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1) →
+      isAddbackCarry2NzN2Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1)) ∧
+  (if bltu_0 then
+    (BitVec.ult r1.2.2.2.2.1
+      (mulsubN4_c3 (divKTrialCallV5QHat r1.2.2.1 r1.2.1 v1)
+        v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1)
+   else
+    (BitVec.ult r1.2.2.2.2.1
+      (mulsubN4_c3 (signExtend12 4095 : Word)
+        v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      isAddbackCarry2NzN2Max v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1))
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopLoopSelectedBorrowCarry.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopLoopSelectedBorrowCarry.lean
@@ -1,0 +1,95 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopSelectedBorrowCarry
+
+  Instantiated borrow-dispatched n=2 v5 loop (register-slot form): re-exposes the
+  borrow-dispatched unified loop (#7449) with the loop-setup register slots named,
+  taking `loopN2SelectedBorrowCarryV5` (satisfiable from shape).  Mirror of the
+  selectedCarry inst wrapper (#7415).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopUnifiedBorrowCarry
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem evm_div_n2_loop_unified_inst_noNop_exact_x1_v5_borrowCarry
+    (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
+    (shift antiShift v0' v1' v2' v3' u0S u1S u2S u3S u4_s : Word)
+    (v10_val v11Old jMem : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem raVal : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 : bltu_2 = BitVec.ult u4_s v1')
+    (hbltu_1 : bltu_1 =
+      match bltu_2 with
+      | false => BitVec.ult (iterN2Max v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.1 v1'
+      | true =>
+        BitVec.ult (iterWithDoubleAddback (divKTrialCallV5QHat u4_s u3S v1')
+          v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.1 v1')
+    (hbltu_0 : bltu_0 =
+      match bltu_2, bltu_1 with
+      | false, false =>
+        BitVec.ult (iterN2Max v0' v1' v2' v3' u1S
+          (iterN2Max v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.1
+          (iterN2Max v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.1
+          (iterN2Max v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.2.1
+          (iterN2Max v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1 v1'
+      | false, true =>
+        BitVec.ult (iterWithDoubleAddback
+          (divKTrialCallV5QHat (iterN2Max v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.1
+            (iterN2Max v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.1 v1')
+          v0' v1' v2' v3' u1S
+          (iterN2Max v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.1
+          (iterN2Max v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.1
+          (iterN2Max v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.2.1
+          (iterN2Max v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1 v1'
+      | true, false =>
+        BitVec.ult (iterN2Max v0' v1' v2' v3' u1S
+          (iterWithDoubleAddback (divKTrialCallV5QHat u4_s u3S v1')
+            v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u4_s u3S v1')
+            v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u4_s u3S v1')
+            v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u4_s u3S v1')
+            v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1 v1'
+      | true, true =>
+        BitVec.ult (iterWithDoubleAddback
+          (divKTrialCallV5QHat
+            (iterWithDoubleAddback (divKTrialCallV5QHat u4_s u3S v1')
+              v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.1
+            (iterWithDoubleAddback (divKTrialCallV5QHat u4_s u3S v1')
+              v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.1 v1')
+          v0' v1' v2' v3' u1S
+          (iterWithDoubleAddback (divKTrialCallV5QHat u4_s u3S v1')
+            v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u4_s u3S v1')
+            v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u4_s u3S v1')
+            v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u4_s u3S v1')
+            v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1 v1')
+    (hcarry : loopN2SelectedBorrowCarryV5 bltu_2 bltu_1 bltu_0
+      v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word) u1S u0S) :
+    cpsTripleWithin 702 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v5 base)
+      (loopN2PreWithScratchV4NoX1 sp jMem (2 : Word) shift u0S v10_val v11Old antiShift
+        v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+        u1S u0S (0 : Word) (0 : Word) (0 : Word)
+        retMem dMem dloMem scratch_un0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN2UnifiedPostV5NoX1 bltu_2 bltu_1 bltu_0 sp base
+        v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word) u1S u0S
+        retMem dMem dloMem scratch_un0 scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  cases bltu_2 <;> cases bltu_1 <;> cases bltu_0 <;>
+  (simp only at hbltu_0 hbltu_1 hbltu_2;
+   exact divK_loop_n2_unified_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+     _ _ _ sp base
+     jMem (2 : Word) shift u0S v10_val v11Old antiShift
+     v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word) u1S u0S
+     (0 : Word) (0 : Word) (0 : Word) raVal
+     retMem dMem dloMem scratch_un0 scratchMem
+     halign hbltu_2 hbltu_1 hbltu_0 hcarry)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopLoopUnifiedBorrowCarry.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopLoopUnifiedBorrowCarry.lean
@@ -104,7 +104,7 @@ theorem divK_loop_n2_unified_from_source_exact_loopIterScratch_v5_noNop_borrowCa
         (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1 := by
       simp only at hbltu_0; rw [show BitVec.ult _ v1 = false from hbltu_0.symm]; decide
     unfold loopN2SelectedBorrowCarryV5 at hcarry
-    simp only [loopN2IterSelectedV5_true, loopN2IterSelectedV5_false] at hcarry
+    simp only [loopN2IterSelectedV5_false] at hcarry
     obtain ⟨hc2, hc1, hc0⟩ := hcarry
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun _ hp => hp)
@@ -128,7 +128,7 @@ theorem divK_loop_n2_unified_from_source_exact_loopIterScratch_v5_noNop_borrowCa
         (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1 := by
       simp only at hbltu_0; exact hbltu_0.symm
     unfold loopN2SelectedBorrowCarryV5 at hcarry
-    simp only [loopN2IterSelectedV5_true, loopN2IterSelectedV5_false] at hcarry
+    simp only [loopN2IterSelectedV5_false] at hcarry
     obtain ⟨hc2, hc1, hc0⟩ := hcarry
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun _ hp => hp)
@@ -280,7 +280,7 @@ theorem divK_loop_n2_unified_from_source_exact_loopIterScratch_v5_noNop_borrowCa
             v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1 := by
       simp only at hbltu_0; rw [show BitVec.ult _ v1 = false from hbltu_0.symm]; decide
     unfold loopN2SelectedBorrowCarryV5 at hcarry
-    simp only [loopN2IterSelectedV5_true, loopN2IterSelectedV5_false] at hcarry
+    simp only [loopN2IterSelectedV5_true] at hcarry
     obtain ⟨hc2, hc1, hc0⟩ := hcarry
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun _ hp => hp)
@@ -316,7 +316,7 @@ theorem divK_loop_n2_unified_from_source_exact_loopIterScratch_v5_noNop_borrowCa
             v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1 := by
       simp only at hbltu_0; exact hbltu_0.symm
     unfold loopN2SelectedBorrowCarryV5 at hcarry
-    simp only [loopN2IterSelectedV5_true, loopN2IterSelectedV5_false] at hcarry
+    simp only [loopN2IterSelectedV5_true] at hcarry
     obtain ⟨hc2, hc1, hc0⟩ := hcarry
     exact cpsTripleWithin_weaken
       (fun _ hp => hp)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopLoopUnifiedBorrowCarry.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopLoopUnifiedBorrowCarry.lean
@@ -1,0 +1,333 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopUnifiedBorrowCarry
+
+  Borrow-dispatched unified n=2 v5 loop: takes `loopN2SelectedBorrowCarryV5` (the
+  satisfiable-from-shape carry bundle, #7448) instead of the unsatisfiable
+  `loopN2SelectedCarryV5`, and dispatches the 8 `bltu³` cases to the from_source
+  `_borrowCarry` combos (#7436/44/45/46/47), extracting the three per-digit
+  borrow-conditional carries from the bundle in each arm.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopDefsBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopUnifiedPost
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCCCBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMMBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCCMBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMTBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMTMBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMTTBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboTMMBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboTMTBorrowCarry
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem divK_loop_n2_unified_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+    (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 : bltu_2 = BitVec.ult u2 v1)
+    (hbltu_1 : bltu_1 =
+      match bltu_2 with
+      | false => BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1
+      | true =>
+        BitVec.ult (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1)
+    (hbltu_0 : bltu_0 =
+      match bltu_2, bltu_1 with
+      | false, false =>
+        BitVec.ult (iterN2Max v0 v1 v2 v3 u0Orig1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1
+      | false, true =>
+        BitVec.ult (iterWithDoubleAddback
+          (divKTrialCallV5QHat (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+            (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+          v0 v1 v2 v3 u0Orig1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1
+      | true, false =>
+        BitVec.ult (iterN2Max v0 v1 v2 v3 u0Orig1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1
+      | true, true =>
+        BitVec.ult (iterWithDoubleAddback
+          (divKTrialCallV5QHat
+            (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+              v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+            (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+              v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+          v0 v1 v2 v3 u0Orig1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1)
+    (hcarry : loopN2SelectedBorrowCarryV5 bltu_2 bltu_1 bltu_0
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0) :
+    cpsTripleWithin 702 (base + loopBodyOff) (base + denormOff)
+      (divCode_noNop_v5 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN2UnifiedPostV5NoX1 bltu_2 bltu_1 bltu_0 sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  cases bltu_2 <;> cases bltu_1 <;> cases bltu_0
+  · -- FFF = MMM
+    have hb2 : ¬BitVec.ult u2 v1 := by rw [show BitVec.ult u2 v1 = false from hbltu_2.symm]; decide
+    have hb1 : ¬BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 := by
+      simp only at hbltu_1; rw [show BitVec.ult _ v1 = false from hbltu_1.symm]; decide
+    have hb0 : ¬BitVec.ult (iterN2Max v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1 := by
+      simp only at hbltu_0; rw [show BitVec.ult _ v1 = false from hbltu_0.symm]; decide
+    unfold loopN2SelectedBorrowCarryV5 at hcarry
+    simp only [loopN2IterSelectedV5_true, loopN2IterSelectedV5_false] at hcarry
+    obtain ⟨hc2, hc1, hc0⟩ := hcarry
+    exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+      (fun _ hp => hp)
+      (fun _ hp => by
+        simp only [loopN2MaxMaxMaxSourceFinalPostNoX1V5_unfold, r2MMTN2V5_eq, r1MMTN2V5_eq] at hp
+        unfold loopN2UnifiedPostV5NoX1
+        simp only [r2MMTN2V5_eq, r1MMTN2V5_eq]
+        xperm_hyp hp)
+      (divK_loop_n2_max_max_max_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem hb2 hc2 hb1 hc1 hb0 hc0)
+  · -- FFT = MMC
+    have hb2 : ¬BitVec.ult u2 v1 := by rw [show BitVec.ult u2 v1 = false from hbltu_2.symm]; decide
+    have hb1 : ¬BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 := by
+      simp only at hbltu_1; rw [show BitVec.ult _ v1 = false from hbltu_1.symm]; decide
+    have hb0 : BitVec.ult (iterN2Max v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1 := by
+      simp only at hbltu_0; exact hbltu_0.symm
+    unfold loopN2SelectedBorrowCarryV5 at hcarry
+    simp only [loopN2IterSelectedV5_true, loopN2IterSelectedV5_false] at hcarry
+    obtain ⟨hc2, hc1, hc0⟩ := hcarry
+    exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+      (fun _ hp => hp)
+      (fun _ hp => by
+        simp only [loopN2MaxMaxCallSourceFinalPostNoX1V5_unfold, r2MMTN2V5_eq, r1MMTN2V5_eq] at hp
+        unfold loopN2UnifiedPostV5NoX1
+        simp only [r2MMTN2V5_eq, r1MMTN2V5_eq]
+        xperm_hyp hp)
+      (divK_loop_n2_max_max_call_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hb2 hc2 hb1 hc1 hb0 hc0)
+  · -- FTF = MCM
+    have hb2 : ¬BitVec.ult u2 v1 := by rw [show BitVec.ult u2 v1 = false from hbltu_2.symm]; decide
+    have hb1 : BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 := by
+      simp only at hbltu_1; exact hbltu_1.symm
+    have hb0 : ¬BitVec.ult
+        (iterWithDoubleAddback
+          (divKTrialCallV5QHat (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+            (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+          v0 v1 v2 v3 u0Orig1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1 := by
+      simp only at hbltu_0; rw [show BitVec.ult _ v1 = false from hbltu_0.symm]; decide
+    unfold loopN2SelectedBorrowCarryV5 at hcarry
+    simp only [loopN2IterSelectedV5_true, loopN2IterSelectedV5_false] at hcarry
+    obtain ⟨hc2, hc1, hc0⟩ := hcarry
+    exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+      (fun _ hp => hp)
+      (fun _ hp => by
+        simp only [loopN2MaxCallMaxSourceFinalPostNoX1V5_unfold, r2MTTN2V5_eq, r1MTTN2V5_eq] at hp
+        unfold loopN2UnifiedPostV5NoX1
+        simp only [r2MTTN2V5_eq, r1MTTN2V5_eq]
+        xperm_hyp hp)
+      (divK_loop_n2_max_call_max_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hb2 hc2 hb1 hc1 hb0 hc0)
+  · -- FTT = MCC
+    have hb2 : ¬BitVec.ult u2 v1 := by rw [show BitVec.ult u2 v1 = false from hbltu_2.symm]; decide
+    have hb1 : BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 := by
+      simp only at hbltu_1; exact hbltu_1.symm
+    have hb0 : BitVec.ult
+        (iterWithDoubleAddback
+          (divKTrialCallV5QHat (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+            (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+          v0 v1 v2 v3 u0Orig1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1 := by
+      simp only at hbltu_0; exact hbltu_0.symm
+    unfold loopN2SelectedBorrowCarryV5 at hcarry
+    simp only [loopN2IterSelectedV5_true, loopN2IterSelectedV5_false] at hcarry
+    obtain ⟨hc2, hc1, hc0⟩ := hcarry
+    exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+      (fun _ hp => hp)
+      (fun _ hp => by
+        simp only [loopN2MaxCallCallSourceFinalPostNoX1V5_unfold, r2MTTN2V5_eq, r1MTTN2V5_eq] at hp
+        unfold loopN2UnifiedPostV5NoX1
+        simp only [r2MTTN2V5_eq, r1MTTN2V5_eq]
+        xperm_hyp hp)
+      (divK_loop_n2_max_call_call_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hb2 hc2 hb1 hc1 hb0 hc0)
+  · -- TFF = TMM (call-max-max)
+    have hb2 : BitVec.ult u2 v1 := hbltu_2.symm
+    have hb1 : ¬BitVec.ult (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 := by
+      simp only at hbltu_1; rw [show BitVec.ult _ v1 = false from hbltu_1.symm]; decide
+    have hb0 : ¬BitVec.ult
+        (iterN2Max v0 v1 v2 v3 u0Orig1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1 := by
+      simp only at hbltu_0; rw [show BitVec.ult _ v1 = false from hbltu_0.symm]; decide
+    unfold loopN2SelectedBorrowCarryV5 at hcarry
+    simp only [loopN2IterSelectedV5_true, loopN2IterSelectedV5_false] at hcarry
+    obtain ⟨hc2, hc1, hc0⟩ := hcarry
+    exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+      (fun _ hp => hp)
+      (fun _ hp => by
+        simp only [loopN2CallMaxMaxSourceFinalPostNoX1V5_unfold, r2CCCN2V5_eq, r1TMMN2V5_eq] at hp
+        unfold loopN2UnifiedPostV5NoX1
+        simp only [r2CCCN2V5_eq, r1TMMN2V5_eq]
+        xperm_hyp hp)
+      (divK_loop_n2_call_max_max_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hb2 hc2 hb1 hc1 hb0 hc0)
+  · -- TFT = TMT (call-max-call)
+    have hb2 : BitVec.ult u2 v1 := hbltu_2.symm
+    have hb1 : ¬BitVec.ult (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 := by
+      simp only at hbltu_1; rw [show BitVec.ult _ v1 = false from hbltu_1.symm]; decide
+    have hb0 : BitVec.ult
+        (iterN2Max v0 v1 v2 v3 u0Orig1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1 := by
+      simp only at hbltu_0; exact hbltu_0.symm
+    unfold loopN2SelectedBorrowCarryV5 at hcarry
+    simp only [loopN2IterSelectedV5_true, loopN2IterSelectedV5_false] at hcarry
+    obtain ⟨hc2, hc1, hc0⟩ := hcarry
+    exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+      (fun _ hp => hp)
+      (fun _ hp => by
+        simp only [loopN2CallMaxCallSourceFinalPostNoX1V5_unfold, r2CCCN2V5_eq, r1TMMN2V5_eq] at hp
+        unfold loopN2UnifiedPostV5NoX1
+        simp only [r2CCCN2V5_eq, r1TMMN2V5_eq]
+        xperm_hyp hp)
+      (divK_loop_n2_call_max_call_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hb2 hc2 hb1 hc1 hb0 hc0)
+  · -- TTF = CCM (call-call-max)
+    have hb2 : BitVec.ult u2 v1 := hbltu_2.symm
+    have hb1 : BitVec.ult (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 := by
+      simp only at hbltu_1; exact hbltu_1.symm
+    have hb0 : ¬BitVec.ult
+        (iterWithDoubleAddback
+          (divKTrialCallV5QHat
+            (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+              v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+            (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+              v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+          v0 v1 v2 v3 u0Orig1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1 := by
+      simp only at hbltu_0; rw [show BitVec.ult _ v1 = false from hbltu_0.symm]; decide
+    unfold loopN2SelectedBorrowCarryV5 at hcarry
+    simp only [loopN2IterSelectedV5_true, loopN2IterSelectedV5_false] at hcarry
+    obtain ⟨hc2, hc1, hc0⟩ := hcarry
+    exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+      (fun _ hp => hp)
+      (fun _ hp => by
+        simp only [loopN2CallCallMaxSourceFinalPostNoX1V5_unfold, r2CCCN2V5_eq, r1CCCN2V5_eq] at hp
+        unfold loopN2UnifiedPostV5NoX1
+        simp only [r2CCCN2V5_eq, r1CCCN2V5_eq]
+        xperm_hyp hp)
+      (divK_loop_n2_call_call_max_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hb2 hc2 hb1 hc1 hb0 hc0)
+  · -- TTT = CCC (all call)
+    have hb2 : BitVec.ult u2 v1 := hbltu_2.symm
+    have hb1 : BitVec.ult (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 := by
+      simp only at hbltu_1; exact hbltu_1.symm
+    have hb0 : BitVec.ult
+        (iterWithDoubleAddback
+          (divKTrialCallV5QHat
+            (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+              v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+            (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+              v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+          v0 v1 v2 v3 u0Orig1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1 := by
+      simp only at hbltu_0; exact hbltu_0.symm
+    unfold loopN2SelectedBorrowCarryV5 at hcarry
+    simp only [loopN2IterSelectedV5_true, loopN2IterSelectedV5_false] at hcarry
+    obtain ⟨hc2, hc1, hc0⟩ := hcarry
+    exact cpsTripleWithin_weaken
+      (fun _ hp => hp)
+      (fun _ hp => by
+        simp only [loopN2CallCallCallSourceFinalPostNoX1V5_unfold, r2CCCN2V5_eq, r1CCCN2V5_eq] at hp
+        unfold loopN2UnifiedPostV5NoX1
+        simp only [r2CCCN2V5_eq, r1CCCN2V5_eq]
+        xperm_hyp hp)
+      (divK_loop_n2_call_call_call_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hb2 hc2 hb1 hc1 hb0 hc0)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5PathShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5PathShift0.lean
@@ -1,0 +1,67 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5PathShift0
+
+  Bridge from the n=2 v5 shift=0 preloop exit (at `loopBodyOff`, the layout
+  produced by `evm_div_n2_to_loopSetup_shift0_spec_v5_noNop`, #7468) to the
+  loop's entry bundle `loopN2PreWithScratchV4NoX1` over the RAW divisor
+  `(b0, b1, 0, 0)` and shift=0 window — the shift=0 analog of
+  `loopSetupPost_to_loopN2PreWithScratchV4NoX1_framed`.  Closes the gap between
+  the preloop (#7468) and the loop body (#7471) so they compose into the shift=0
+  path `base → denormOff`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5PreloopShift0
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LoopShift0
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Loop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3Loop
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- Bridge: shift=0 preloop exit (b2 = b3 = 0) plus the framed scratch/return
+    cells implies the loop entry bundle over the raw divisor. -/
+theorem n2_shift0_loopExit_to_loopN2PreWithScratch (sp : Word)
+    (a0 a1 a2 a3 b0 b1 v11Old jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word) :
+    ∀ h,
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (2 : Word)) **
+        (.x9 ↦ᵣ (signExtend12 (4 : BitVec 12) - (2 : Word))) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x10 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ (clzResult b1).1) **
+        (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+        (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - (clzResult b1).1)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
+        ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
+        ((sp + signExtend12 4024) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        ((sp + signExtend12 3968) ↦ₘ retMem) ** ((sp + signExtend12 3960) ↦ₘ dMem) **
+        ((sp + signExtend12 3952) ↦ₘ dloMem) ** ((sp + signExtend12 3944) ↦ₘ scratchUn0) **
+        ((sp + signExtend12 3936) ↦ₘ scratchMem) ** (.x1 ↦ᵣ raVal))) h →
+      ((loopN2PreWithScratchV4NoX1 sp jMem (2 : Word) (clzResult b1).1
+        ((clzResult b1).2 >>> (63 : Nat)) (0 : Word) v11Old
+        (signExtend12 (0 : BitVec 12) - (clzResult b1).1)
+        b0 b1 0 0 a2 a3 0 0 0 a1 a0 0 0 0
+        retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1))) h := by
+  intro h hp
+  rw [show signExtend12 (4 : BitVec 12) - (2 : Word) = (2 : Word) from by decide] at hp
+  delta loopN2PreWithScratchV4NoX1 loopN2PreWithScratchNoX1 loopN2Pre
+  simp only [n2_ub2_off0, n2_ub2_off4088, n2_ub2_off4080, n2_ub2_off4072, n2_ub2_off4064,
+    n3_ub1_off0, n3_ub0_off0, n2_qa2, n3_qa1, n3_qa0,
+    se12_32, se12_40, se12_48, se12_56] at hp ⊢
+  xperm_hyp hp
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5PathShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5PathShift0.lean
@@ -64,4 +64,77 @@ theorem n2_shift0_loopExit_to_loopN2PreWithScratch (sp : Word)
     se12_32, se12_40, se12_48, se12_56] at hp ⊢
   xperm_hyp hp
 
+/-- n=2 v5 shift=0 path `base → denormOff`: preloop (#7468) ∘ bridge ∘ loop
+    (#7471), the carry discharged from shape.  Shift=0 analog of
+    `fullDivN2_preloop_loop_unified_exact_x1_scratch_v5_noNop_borrowCarry`. -/
+theorem evm_div_n2_to_denorm_shift0_from_shape_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 v2 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| (0 : Word) ||| 0 ≠ 0) (hb1nz : b1 ≠ 0)
+    (hshift_z : (clzResult b1).1 = 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff) :
+    ∃ bltu_2 bltu_1 bltu_0 : Bool,
+    cpsTripleWithin (((8 + 21 + 24 + 4) + 13) + 702) base (base + denormOff)
+      (divCode_noNop_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        ((sp + signExtend12 3968) ↦ₘ retMem) ** ((sp + signExtend12 3960) ↦ₘ dMem) **
+        ((sp + signExtend12 3952) ↦ₘ dloMem) ** ((sp + signExtend12 3944) ↦ₘ scratchUn0) **
+        ((sp + signExtend12 3936) ↦ₘ scratchMem) ** (.x1 ↦ᵣ raVal)))
+      ((loopN2UnifiedPostV5NoX1 bltu_2 bltu_1 bltu_0 sp base
+        b0 b1 0 0 a2 a3 0 0 0 a1 a0
+        retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1))) := by
+  have hb1ge : b1.toNat ≥ 2^63 := clz_zero_imp_msb hshift_z
+  have hPre := evm_div_n2_to_loopSetup_shift0_spec_v5_noNop sp base a0 a1 a2 a3 b0 b1 0 0
+    v2 v5 v6 v7 v10 q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    hbnz rfl rfl hb1nz hshift_z
+  have hPref := cpsTripleWithin_frameR
+    ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+     ((sp + signExtend12 3968) ↦ₘ retMem) ** ((sp + signExtend12 3960) ↦ₘ dMem) **
+     ((sp + signExtend12 3952) ↦ₘ dloMem) ** ((sp + signExtend12 3944) ↦ₘ scratchUn0) **
+     ((sp + signExtend12 3936) ↦ₘ scratchMem) ** (.x1 ↦ᵣ raVal))
+    (by pcFree) hPre
+  obtain ⟨bltu_2, bltu_1, bltu_0, hLoop⟩ := divK_loop_n2_shift0_from_shape_v5_noNop
+    sp base jMem (2 : Word) (clzResult b1).1 ((clzResult b1).2 >>> (63 : Nat)) (0 : Word)
+    v11Old (signExtend12 (0 : BitVec 12) - (clzResult b1).1)
+    a0 a1 a2 a3 b0 b1 0 0 0 raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hb1ge
+  have hLoopf := cpsTripleWithin_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1))
+    (by pcFree) hLoop
+  refine ⟨bltu_2, bltu_1, bltu_0, ?_⟩
+  have hPre' := cpsTripleWithin_weaken (fun h hp => hp)
+    (n2_shift0_loopExit_to_loopN2PreWithScratch sp a0 a1 a2 a3 b0 b1 v11Old
+      jMem retMem dMem dloMem scratchUn0 scratchMem raVal)
+    hPref
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hPre' hLoopf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => hp) (fun h hq => hq) hFull
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5PreloopShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5PreloopShift0.lean
@@ -1,0 +1,150 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5PreloopShift0
+
+  v5 n=2 shift=0 preloop pieces over `divCode_noNop_v5`.  On the shift=0 branch
+  the divisor is already top-bit-aligned, so normalization is skipped: phase-C2
+  takes the BEQ to copyAU.  This file builds the n=2 phaseAB-clz + phaseC2-taken
+  segment (`base → copyAUOff`), the n=2 analog of
+  `evm_div_phaseAB_n1_clz_c2taken_spec_v5_noNop`.  Composes the n=2 phaseAB clz
+  (`evm_div_phaseAB_n2_clz_spec_within_v5_noNop`) with the shared shift=0 phase-C2
+  branch (`divK_phaseC2_taken_spec_within_v5_noNop`).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopPreloop
+import EvmAsm.Evm64.DivMod.Compose.PhaseC2V5
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5PreloopShift0
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v5 n=2 phaseAB-clz + phaseC2(shift=0 taken), `base → copyAUOff`, over
+    `divCode_noNop_v5`.  Shift=0 branch (`(clzResult b1).1 = 0`): the divisor is
+    already aligned, so phase-C2 takes the BEQ to copyAU. -/
+theorem evm_div_phaseAB_n2_clz_c2taken_spec_v5_noNop (sp base : Word)
+    (b0 b1 b2 b3 v2 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
+    (hshift_z : (clzResult b1).1 = 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4) base (base + copyAUOff) (divCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b1).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ (clzResult b1).1) ** (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+       (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - (clzResult b1).1)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1)) := by
+  have hABCLZ := evm_div_phaseAB_n2_clz_spec_within_v5_noNop sp base b0 b1 b2 b3
+    v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2z hb1nz
+  have hABCLZf := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ v2) ** ((sp + signExtend12 3992) ↦ₘ shiftMem))
+    (by pcFree) hABCLZ
+  have hC2 := divK_phaseC2_taken_spec_within_v5_noNop sp (clzResult b1).1
+    v2 shiftMem base hshift_z
+  have hC2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ (clzResult b1).2) ** (.x10 ↦ᵣ b3) **
+     (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)))
+    (by pcFree) hC2
+  have hABC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABCLZf hC2f
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hABC2
+
+/-- Full n=2 shift=0 preloop, `base → loopBodyOff`, over `divCode_noNop_v5`.
+    Shift=0 analog of the n=2 preloop: on the shift=0 branch
+    (`(clzResult b1).1 = 0`) the dividend is copied verbatim (u-cells ← a-cells,
+    u[4] = 0) instead of normalized.  Loop counter `x5 ← 2`, `x9 ← 4 − 2`. -/
+theorem evm_div_n2_to_loopSetup_shift0_spec_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v2 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
+    (hshift_z : (clzResult b1).1 = 0) :
+    cpsTripleWithin ((8 + 21 + 24 + 4) + 13) base (base + loopBodyOff)
+      (divCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (2 : Word)) **
+       (.x9 ↦ᵣ (signExtend12 (4 : BitVec 12) - (2 : Word))) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ (clzResult b1).1) **
+       (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+       (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - (clzResult b1).1)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
+       ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1)) := by
+  have hC2 := evm_div_phaseAB_n2_clz_c2taken_spec_v5_noNop sp base b0 b1 b2 b3
+    v2 v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem shiftMem hbnz hb3z hb2z hb1nz hshift_z
+  have hC2f := cpsTripleWithin_frameR
+    ((.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+     ((sp + signExtend12 4024) ↦ₘ u4Old))
+    (by pcFree) hC2
+  have hSeg := divK_copyAU_loopSetup_shift0_spec_v5_noNop sp base
+    a0 a1 a2 a3 u0Old u1Old u2Old u3Old u4Old (clzResult b1).2
+    (signExtend12 (4 : BitVec 12) - (4 : Word)) (2 : Word) (by decide)
+  have hSegf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ (clzResult b1).1) **
+     (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+     (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - (clzResult b1).1)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1))
+    (by pcFree) hSeg
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by simp only [signExtend12_0] at hp ⊢; xperm_hyp hp) hC2f hSegf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by simp only [signExtend12_0] at hq ⊢; xperm_hyp hq)
+    hFull
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5BundleDigit2.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5BundleDigit2.lean
@@ -1,0 +1,70 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5BundleDigit2
+
+  The j=2 (first) conjunct of `loopN2SelectedBorrowCarryV5` at the lane level
+  (over the `fullDivN2NormV/U` accessors), discharged from shape.  The first
+  digit's window has `u3 = uTop = 0` (no collapse needed), so it applies the
+  per-digit call/max carry discharges (#7454/#7455) directly after rewriting the
+  normalized divisor's high limbs to zero (#7458).  Demonstrates the per-digit
+  pattern of the full `loopN2SelectedBorrowCarryV5_of_shape` telescope.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryOfCallShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5MaxCarryOfMaxShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- The j=2 conjunct of the borrow-carry bundle, from shape. -/
+theorem loopN2SelectedBorrowCarryV5_digit2_of_shape
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (bltu_2 : Bool)
+    (hb2z : b2 = 0) (hb3z : b3 = 0) (hshift_nz : (clzResult b1).1 ≠ 0) (hb1nz : b1 ≠ 0)
+    (hc2 : bltu_2 = true →
+      BitVec.ult (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm2 : bltu_2 = false →
+      ¬ BitVec.ult (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (fullDivN2NormV b0 b1 b2 b3).2.1) :
+    (if bltu_2 then
+      (BitVec.ult 0
+        (mulsubN4_c3 (divKTrialCallV5QHat (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1)
+          (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0) →
+        callAddbackCarry2NzV5 (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0 0)
+     else
+      (BitVec.ult 0
+        (mulsubN4_c3 (signExtend12 4095 : Word)
+          (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0) →
+        isAddbackCarry2NzN2Max (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0 0)) := by
+  obtain ⟨hv1n, hv2z', hv3z'⟩ := fullDivN2NormV_shape_facts b0 b1 b2 b3 hb2z hb3z hb1nz hshift_nz
+  rw [hv2z', hv3z']
+  cases hbl : bltu_2 with
+  | true =>
+    intro hborrow
+    have hcall : (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2.toNat <
+        (fullDivN2NormV b0 b1 b2 b3).2.1.toNat := by
+      have := hc2 hbl; rw [BitVec.ult] at this; exact of_decide_eq_true this
+    exact callAddbackCarry2NzV5_of_borrow_of_call_shape
+      (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0 hv1n hcall hborrow
+  | false =>
+    intro hborrow
+    exact isAddbackCarry2NzN2Max_of_borrow_of_max_shape
+      (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0 hv1n (hm2 hbl) hborrow
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5BundleOfShape.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5BundleOfShape.lean
@@ -1,0 +1,88 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5BundleOfShape
+
+  `loopN2SelectedBorrowCarryV5_of_shape`: the borrow-conditional carry bundle for
+  the n=2 v5 loop, discharged from shape at the lane level (over the
+  `fullDivN2NormV/U` accessors).  Telescopes the per-digit validity / collapse
+  (mirroring `fullDivN2_acc_quot_eq_div_of_shape`) and applies the per-digit
+  call/max carry discharges (#7454/#7455) via the iter→R2V5/R1V5 bridges (#7459).
+  This is the satisfiable-from-shape hypothesis the borrow-dispatched loop
+  (#7449/#7452) consumes — completing the n=2 carry-from-shape.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryOfCallShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5MaxCarryOfMaxShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
+import EvmAsm.Evm64.DivMod.Spec.N2V5IterR2R1Bridge
+import EvmAsm.Evm64.DivMod.Spec.N2V5NormScaled
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopDefsBorrowCarry
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- The borrow-conditional carry bundle, discharged from shape (lane level). -/
+theorem loopN2SelectedBorrowCarryV5_of_shape
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (bltu_2 bltu_1 bltu_0 : Bool)
+    (hb2z : b2 = 0) (hb3z : b3 = 0) (hshift_nz : (clzResult b1).1 ≠ 0) (hb1nz : b1 ≠ 0)
+    (hc2 : bltu_2 = true → BitVec.ult (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm2 : bltu_2 = false → ¬ BitVec.ult (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hc1 : bltu_1 = true → BitVec.ult (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm1 : bltu_1 = false → ¬ BitVec.ult (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hc0 : bltu_0 = true → BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm0 : bltu_0 = false → ¬ BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1) :
+    loopN2SelectedBorrowCarryV5 bltu_2 bltu_1 bltu_0
+      (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+      (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0 0
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.1 (fullDivN2NormU a0 a1 a2 a3 b1).1 := by
+  unfold loopN2SelectedBorrowCarryV5
+  simp only [loopN2IterSelectedV5_normUV_eq_R2V5, loopN2IterSelectedV5_normUV_eq_R1V5]
+  obtain ⟨hv1n, hv2z', hv3z'⟩ := fullDivN2NormV_shape_facts b0 b1 b2 b3 hb2z hb3z hb1nz hshift_nz
+  have hfwv := fullDivN2_first_window_valid a0 a1 a2 a3 b0 b1 b2 b3 hb2z hb3z hshift_nz hb1nz
+  obtain ⟨hR2c1, hR2c2⟩ := fullDivN2R2V5_collapse_of_shape a0 a1 a2 a3 b0 b1 b2 b3 bltu_2
+    hb2z hb3z hshift_nz hb1nz hfwv hc2 hm2
+  have hR2 := fullDivN2R2V5_step_of_shape a0 a1 a2 a3 b0 b1 b2 b3 bltu_2
+    hb2z hb3z hshift_nz hb1nz hfwv hc2 hm2
+  have hR1valid := n2_next_window_lt (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+    (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+    (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 _ hR2.2
+  obtain ⟨hR1c1, hR1c2⟩ := fullDivN2R1V5_collapse_of_shape a0 a1 a2 a3 b0 b1 b2 b3 bltu_2 bltu_1
+    hb2z hb3z hshift_nz hb1nz hR2c1 hR2c2 hR1valid hc1 hm1
+  refine ⟨?_, ?_, ?_⟩
+  · rw [hv2z', hv3z']
+    cases hb : bltu_2 with
+    | true =>
+      intro hborrow
+      have hcall : (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2.toNat <
+          (fullDivN2NormV b0 b1 b2 b3).2.1.toNat := by
+        have := hc2 hb; rw [BitVec.ult] at this; exact of_decide_eq_true this
+      exact callAddbackCarry2NzV5_of_borrow_of_call_shape _ _ _ _ _ 0 hv1n hcall hborrow
+    | false =>
+      intro hborrow
+      exact isAddbackCarry2NzN2Max_of_borrow_of_max_shape _ _ _ _ _ 0 hv1n (hm2 hb) hborrow
+  · rw [hv2z', hv3z', hR2c1, hR2c2]
+    cases hb : bltu_1 with
+    | true =>
+      intro hborrow
+      have hcall : (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1.toNat <
+          (fullDivN2NormV b0 b1 b2 b3).2.1.toNat := by
+        have := hc1 hb; rw [BitVec.ult] at this; exact of_decide_eq_true this
+      exact callAddbackCarry2NzV5_of_borrow_of_call_shape _ _ _ _ _ 0 hv1n hcall hborrow
+    | false =>
+      intro hborrow
+      exact isAddbackCarry2NzN2Max_of_borrow_of_max_shape _ _ _ _ _ 0 hv1n (hm1 hb) hborrow
+  · rw [hv2z', hv3z', hR1c1, hR1c2]
+    cases hb : bltu_0 with
+    | true =>
+      intro hborrow
+      have hcall : (fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1.toNat <
+          (fullDivN2NormV b0 b1 b2 b3).2.1.toNat := by
+        have := hc0 hb; rw [BitVec.ult] at this; exact of_decide_eq_true this
+      exact callAddbackCarry2NzV5_of_borrow_of_call_shape _ _ _ _ _ 0 hv1n hcall hborrow
+    | false =>
+      intro hborrow
+      exact isAddbackCarry2NzN2Max_of_borrow_of_max_shape _ _ _ _ _ 0 hv1n (hm0 hb) hborrow
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5CallCarryOfCallShape.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5CallCarryOfCallShape.lean
@@ -1,0 +1,42 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryOfCallShape
+
+  The per-digit call-carry discharge for the n=2 lane: from the call regime
+  (`u2 < v1`, i.e. `bltu = true`) + the normalized divisor (`v1 ≥ 2^63`,
+  `v2 = v3 = 0`) + the runtime borrow, derive `callAddbackCarry2NzV5` on a
+  `v2 = v3 = 0`, `u3 = 0` window.  Composes the +2 overestimate (#7425, valid in
+  the call regime), the small-divisor bound (#7453), and the borrow-case carry
+  discharge (#7431).  Applied per call digit by the lane (the call regime comes
+  from that digit's `bltu` being true; `u3 = 0` from the per-digit remainder
+  collapse).
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5TrialOverestimate
+import EvmAsm.Evm64.DivMod.Spec.N2V5HvSmall
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryBorrowN2
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- `callAddbackCarry2NzV5` on a `v2=v3=0`, `u3=0` window, from the call regime,
+    the normalized top divisor limb, and the runtime borrow. -/
+theorem callAddbackCarry2NzV5_of_borrow_of_call_shape
+    (v0 v1 u0 u1 u2 uTop : Word)
+    (hv1_norm : v1.toNat ≥ 2 ^ 63)
+    (hcall : u2.toNat < v1.toNat)
+    (hborrow : BitVec.ult uTop
+      (mulsubN4_c3 (divKTrialCallV5QHat u2 u1 v1) v0 v1 0 0 u0 u1 u2 0) = true) :
+    callAddbackCarry2NzV5 v0 v1 0 0 u0 u1 u2 0 uTop := by
+  have hbnz : v0 ||| v1 ||| 0 ||| 0 ≠ 0 := by
+    intro h
+    have h2 := (BitVec.or_eq_zero_iff.mp h).1
+    have h3 := (BitVec.or_eq_zero_iff.mp h2).1
+    have hv1z : v1 = 0 := (BitVec.or_eq_zero_iff.mp h3).2
+    rw [hv1z] at hv1_norm
+    simp at hv1_norm
+  exact callAddbackCarry2NzV5_of_borrow_n2 v0 v1 0 0 u0 u1 u2 0 uTop hbnz
+    (divKTrialCallV5QHat_le_window_div_plus_two_of_call u0 u1 u2 v0 v1 hv1_norm hcall)
+    (n2_two_val256_v_lt_pow256 v0 v1) hborrow
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5HvSmall.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5HvSmall.lean
@@ -1,0 +1,28 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5HvSmall
+
+  The n=2 small-divisor fact `2 * val256 v0 v1 0 0 < 2^256` (the `hv_small`
+  hypothesis of `mulsubN4_c3_le_one_of_plus_two_of_v_lt` (#7430) /
+  `callAddbackCarry2NzV5_of_borrow_n2` (#7431)), from the normalized n=2 divisor
+  bound `val256 v0 v1 0 0 < 2^128` (`n2_val256_v_lt_pow128`).
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5RemainderLt
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- For the n=2 (two-limb) divisor, `2 * val256 v0 v1 0 0 < 2^256`. -/
+theorem n2_two_val256_v_lt_pow256 (v0 v1 : Word) :
+    2 * val256 v0 v1 0 0 < 2 ^ 256 := by
+  have h := n2_val256_v_lt_pow128 v0 v1
+  have he : (2 : Nat) ^ 256 = 2 * (2 ^ 128 * 2 ^ 127) := by norm_num
+  rw [he]
+  have hp : 0 < (2 : Nat) ^ 127 := by positivity
+  calc 2 * val256 v0 v1 0 0 < 2 * 2 ^ 128 := by omega
+    _ ≤ 2 * (2 ^ 128 * 2 ^ 127) := by
+        have : (2 : Nat) ^ 128 ≤ 2 ^ 128 * 2 ^ 127 := Nat.le_mul_of_pos_right _ hp
+        omega
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5IterR2R1Bridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5IterR2R1Bridge.lean
@@ -1,0 +1,45 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5IterR2R1Bridge
+
+  Bridges the bundle's loop iterations (`loopN2IterSelectedV5` over the
+  `fullDivN2NormV/U` accessors) to the families' per-digit results
+  `fullDivN2R2V5` / `fullDivN2R1V5`.  These let the per-digit `_collapse_of_shape`
+  / `_step_of_shape` lemmas (stated for `fullDivN2R2V5`/`R1V5`) apply to the
+  `r2`/`r1` intermediates that appear inside `loopN2SelectedBorrowCarryV5` at the
+  lane level — the glue for the telescope discharge of
+  `loopN2SelectedBorrowCarryV5_of_shape`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5IterSelectedEq
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The bundle's j=2 iteration (over NormV/U) equals the families' `fullDivN2R2V5`. -/
+theorem loopN2IterSelectedV5_normUV_eq_R2V5
+    (bltu_2 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    loopN2IterSelectedV5 bltu_2
+      (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+      (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0 0
+      = fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3 := by
+  simp only [loopN2IterSelectedV5_eq_iterN2V5, fullDivN2R2V5]
+
+/-- The bundle's j=1 iteration (over NormV/U and the R2 outputs) equals the
+    families' `fullDivN2R1V5`. -/
+theorem loopN2IterSelectedV5_normUV_eq_R1V5
+    (bltu_2 bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    loopN2IterSelectedV5 bltu_1
+      (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+      (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+      (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+      (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+      (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+      (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+      (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1
+      = fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3 := by
+  simp only [loopN2IterSelectedV5_eq_iterN2V5, fullDivN2R1V5]
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5IterSelectedEq.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5IterSelectedEq.lean
@@ -1,0 +1,27 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5IterSelectedEq
+
+  `loopN2IterSelectedV5 = iterN2V5`: the branch-selected loop iteration
+  (FullPathN2V5NoNopLoopDefs) and the families iteration (FullPathN2V5Families)
+  share the same definition body, so they are equal.  This bridge lets the
+  per-digit remainder-collapse / step / validity lemmas (stated for `iterN2V5` in
+  N2V5RemainderLt) apply to the `loopN2IterSelectedV5` intermediates that appear
+  in `loopN2SelectedBorrowCarryV5` — needed to assemble
+  `loopN2SelectedBorrowCarryV5_of_shape`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopDefs
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5Families
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The unified loop iteration equals the families iteration. -/
+theorem loopN2IterSelectedV5_eq_iterN2V5 (bltu : Bool)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    loopN2IterSelectedV5 bltu v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      iterN2V5 bltu v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  simp only [loopN2IterSelectedV5, iterN2V5]
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5MaxCarryOfMaxShape.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5MaxCarryOfMaxShape.lean
@@ -1,0 +1,63 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5MaxCarryOfMaxShape
+
+  The per-digit MAX-carry discharge for the n=2 lane: from the max regime
+  (`¬ u2 < v1`, i.e. `bltu = false`) + the normalized top divisor limb
+  (`v1 ≥ 2^63`) + the runtime borrow, derive `isAddbackCarry2NzN2Max` on a
+  `v2=v3=0`, `u3=0` window.  Max analog of the call discharge (#7454): the
+  saturated trial `2^64-1` can overestimate the capped digit by 1, so the max
+  digit genuinely can borrow; in the borrow case the n=2 small-divisor `c3 ≤ 1`
+  bound (#7430) forces `c3 = 1` and the generic
+  `isAddbackCarry2Nz_of_overestimate_c3_one_of_carry_zero` (q = `signExtend12
+  4095`) closes it, using the max `+2` overestimate
+  `max_trial_local_overestimate_n2_of_not_ult`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5C3LeOne
+import EvmAsm.Evm64.DivMod.Spec.N2V5HvSmall
+import EvmAsm.Evm64.EvmWordArith.DivN2MaxOverestimate
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- `isAddbackCarry2NzN2Max` on a `v2=v3=0`, `u3=0` window, from the max regime,
+    the normalized top divisor limb, and the runtime borrow. -/
+theorem isAddbackCarry2NzN2Max_of_borrow_of_max_shape
+    (v0 v1 u0 u1 u2 uTop : Word)
+    (hv1_norm : v1.toNat ≥ 2 ^ 63)
+    (hbltu : ¬ BitVec.ult u2 v1)
+    (hborrow : BitVec.ult uTop
+      (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 0 0 u0 u1 u2 0) = true) :
+    isAddbackCarry2NzN2Max v0 v1 0 0 u0 u1 u2 0 uTop := by
+  unfold isAddbackCarry2NzN2Max
+  have hbnz : v0 ||| v1 ||| 0 ||| 0 ≠ 0 := by
+    intro h
+    have h2 := (BitVec.or_eq_zero_iff.mp h).1
+    have h3 := (BitVec.or_eq_zero_iff.mp h2).1
+    have hv1z : v1 = 0 := (BitVec.or_eq_zero_iff.mp h3).2
+    rw [hv1z] at hv1_norm
+    simp at hv1_norm
+  have hq_over : (signExtend12 (4095 : BitVec 12) : Word).toNat ≤
+      val256 u0 u1 u2 0 / val256 v0 v1 0 0 + 2 :=
+    max_trial_local_overestimate_n2_of_not_ult v0 v1 u0 u1 u2 hv1_norm hbltu
+  have hle1 := mulsubN4_c3_le_one_of_plus_two_of_v_lt hbnz hq_over
+    (n2_two_val256_v_lt_pow256 v0 v1)
+  have hne0 : (mulsubN4 (signExtend12 4095 : Word) v0 v1 0 0 u0 u1 u2 0).2.2.2.2 ≠ 0 := by
+    intro h0
+    unfold mulsubN4_c3 at hborrow
+    rw [h0] at hborrow
+    have : ¬ BitVec.ult uTop (0 : Word) := by rw [BitVec.ult_eq_decide]; simp
+    exact this hborrow
+  have hne0' :
+      (mulsubN4 (signExtend12 4095 : Word) v0 v1 0 0 u0 u1 u2 0).2.2.2.2.toNat ≠ 0 := by
+    intro hz
+    exact hne0 (BitVec.eq_of_toNat_eq (by rw [hz]; rfl))
+  have hc3eq : (mulsubN4 (signExtend12 4095 : Word) v0 v1 0 0 u0 u1 u2 0).2.2.2.2 = 1 := by
+    apply BitVec.eq_of_toNat_eq
+    show (mulsubN4 (signExtend12 4095 : Word) v0 v1 0 0 u0 u1 u2 0).2.2.2.2.toNat = 1
+    omega
+  exact isAddbackCarry2Nz_of_overestimate_c3_one_of_carry_zero
+    (signExtend12 4095 : Word) v0 v1 0 0 u0 u1 u2 0 uTop hbnz hq_over (fun _ => hc3eq)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5NormVShapeFacts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5NormVShapeFacts.lean
@@ -1,0 +1,28 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5NormVShapeFacts
+
+  Bundled n=2 normalized-divisor shape facts: from the n=2 shape (`b2 = 0`,
+  `b3 = 0`, `b1 ≠ 0`, `shift ≠ 0`), the normalized divisor `fullDivN2NormV` has
+  its top limb MSB set (`≥ 2^63`) and its two high limbs zero (`v2 = v3 = 0`).
+  These are the `hv1_norm`/`v2=0`/`v3=0` facts the per-digit carry discharges
+  (#7454/#7455) and the validity telescope repeatedly consume when discharging
+  `loopN2SelectedBorrowCarryV5` from shape at the lane level.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.DivN2NormVStructure
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The three normalized-divisor facts for the n=2 lane, bundled. -/
+theorem fullDivN2NormV_shape_facts (b0 b1 b2 b3 : Word)
+    (hb2z : b2 = 0) (hb3z : b3 = 0) (hb1nz : b1 ≠ 0) (hshift_nz : (clzResult b1).1 ≠ 0) :
+    2 ^ 63 ≤ (fullDivN2NormV b0 b1 b2 b3).2.1.toNat ∧
+    (fullDivN2NormV b0 b1 b2 b3).2.2.1 = 0 ∧
+    (fullDivN2NormV b0 b1 b2 b3).2.2.2 = 0 :=
+  ⟨fullDivN2NormV_msb_of_b1_ne_zero b0 b1 b2 b3 hb1nz,
+   fullDivN2NormV_v2_zero_of_shape_shift_nz b0 b1 b2 b3 hb2z hshift_nz,
+   fullDivN2NormV_top_zero_of_shape b0 b1 b2 b3 hb3z hb2z⟩
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5PostToDispatchPostV5.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5PostToDispatchPostV5.lean
@@ -1,0 +1,50 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5PostToDispatchPostV5
+
+  N=2 V5 post bridge to the SCAFFOLD post `divStackDispatchPostV5`
+  (= `divStackDispatchPost ** memOwn (sp+3936)`).  Composes the existing
+  callable-frame bridge (`fullDivN2UnifiedPostNoX1V5_frame_to_divStackDispatchPostCallableExactFrame_scratch_word`,
+  #7463-adjacent) with the public weakening `divStackDispatchPostCallableExactFrame_weaken`
+  and `memIs_implies_memOwn`.  This is the post half of the n=2 lane (the form the
+  unconditional scaffold `evm_div_stack_spec_unconditional_of_lanes_v5_div`
+  consumes), mirroring n1's `n1_denormPost_to_divStackDispatchPost_v5`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5ConcretePostBridge
+import EvmAsm.Evm64.DivMod.Spec.StackPostBridge
+import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Div
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- From the n=2 v5 unified post (with exact caller `x1`) and quotient
+    correctness, conclude the scaffold post `divStackDispatchPostV5`. -/
+theorem fullDivN2UnifiedPostNoX1V5_to_divStackDispatchPostV5
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base : Word) (a b : EvmWord)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hdivWord : fullDivN2QuotientWordV5 bltu_2 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.div a b) :
+    ∀ h,
+      (fullDivN2UnifiedPostNoX1V5 bltu_2 bltu_1 bltu_0 sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) h →
+      divStackDispatchPostV5 sp a b h := by
+  intro h hp
+  have h1 := fullDivN2UnifiedPostNoX1V5_frame_to_divStackDispatchPostCallableExactFrame_scratch_word
+    bltu_2 bltu_1 bltu_0 sp base a b
+    retMem dMem dloMem scratchUn0 scratchMem raVal hdivWord h hp
+  simp only [divStackDispatchPostV5]
+  revert h1
+  apply sepConj_mono
+  · exact fun h hp =>
+      divStackDispatchPostCallableExactFrame_weaken sp a b raVal (signExtend12 4095) h hp
+  · exact fun h hp => memIs_implies_memOwn h hp
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5QuotientLaneShape.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5QuotientLaneShape.lean
@@ -1,0 +1,45 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLaneShape
+
+  Lane-ready (`a b : EvmWord`) form of the n=2 v5 quotient-word correctness
+  FROM SHAPE: `fullDivN2QuotientWordV5 … = EvmWord.div a b`, from the n=2 divisor
+  shape (`b2=b3=0`, `b1≠0`, shift≠0) and the per-digit `bltu` path matches.
+  Bridges the `fromLimbs`-form `fullDivN2QuotientWordV5_eq_div_of_shape` to the
+  `a b` form via `EvmWord.fromLimbs_match_getLimbN_id`.  This is the shape-derived
+  `hdivWord` the n=2 lane feeds to
+  `fullDivN2UnifiedPostNoX1V5_to_divStackDispatchPostV5` (#7464) — the
+  shape-counterpart of the `hmulsub`/`hge`-form `fullDivN2QuotientWordV5_eq_div_lane`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Lane form from shape: the assembled v5 n=2 quotient word equals `EvmWord.div a b`. -/
+theorem fullDivN2QuotientWordV5_eq_div_lane_of_shape
+    (bltu_2 bltu_1 bltu_0 : Bool) {a b : EvmWord}
+    {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hb2z : b2 = 0) (hb3z : b3 = 0) (hshift_nz : (clzResult b1).1 ≠ 0) (hb1nz : b1 ≠ 0)
+    (hc2 : bltu_2 = true → BitVec.ult (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm2 : bltu_2 = false → ¬ BitVec.ult (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hc1 : bltu_1 = true → BitVec.ult (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm1 : bltu_1 = false → ¬ BitVec.ult (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hc0 : bltu_0 = true → BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm0 : bltu_0 = false → ¬ BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1) :
+    fullDivN2QuotientWordV5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b := by
+  have hraw := fullDivN2QuotientWordV5_eq_div_of_shape a0 a1 a2 a3 b0 b1 b2 b3 bltu_2 bltu_1 bltu_0
+    hb2z hb3z hshift_nz hb1nz hc2 hm2 hc1 hm1 hc0 hm0
+  subst a0; subst a1; subst a2; subst a3; subst b0; subst b1; subst b2; subst b3
+  refine hraw.trans ?_
+  congr 1
+  · exact EvmWord.fromLimbs_match_getLimbN_id a
+  · exact EvmWord.fromLimbs_match_getLimbN_id b
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5R2R1Dispatch.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5R2R1Dispatch.lean
@@ -1,0 +1,67 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5R2R1Dispatch
+
+  Dispatch-form equalities for the n=2 v5 per-digit results `fullDivN2R2V5` /
+  `fullDivN2R1V5`: each (irreducible) family result equals the `if`-on-flag
+  selection between `iterWithDoubleAddback (divKTrialCallV5QHat …)` (call regime)
+  and `iterN2Max …` (max regime).  These are the glue that connects the runtime
+  borrow-flag definitions used by the borrow-dispatched full path
+  (`evm_div_n2_stack_pre_to_unified_post_v5_noNop_borrowCarry`, stated with
+  `iterN2Max` / `iterWithDoubleAddback` `match` forms) to the `fullDivN2R2V5` /
+  `fullDivN2R1V5` forms over which the carry bundle
+  (`loopN2SelectedBorrowCarryV5_of_shape`) is stated — needed for the n=2 lane.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5Families
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- `fullDivN2R2V5` as an `if`-on-`bltu_2` dispatch between the call-regime
+    (`iterWithDoubleAddback`) and max-regime (`iterN2Max`) iterations. -/
+theorem fullDivN2R2V5_eq_dispatch (bltu_2 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3 =
+      (if bltu_2 then
+        iterWithDoubleAddback
+          (divKTrialCallV5QHat (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1)
+          (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0 0
+      else
+        iterN2Max
+          (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 0 0) := by
+  simp only [fullDivN2R2V5, iterN2V5]
+
+/-- `fullDivN2R1V5` as an `if`-on-`bltu_1` dispatch, threaded on the `R2V5`
+    remainder. -/
+theorem fullDivN2R1V5_eq_dispatch (bltu_2 bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3 =
+      (if bltu_1 then
+        iterWithDoubleAddback
+          (divKTrialCallV5QHat (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+            (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.1 (fullDivN2NormV b0 b1 b2 b3).2.1)
+          (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1
+      else
+        iterN2Max
+          (fullDivN2NormV b0 b1 b2 b3).1 (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+          (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1) := by
+  simp only [fullDivN2R1V5, iterN2V5]
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5Shift0BundleOfShape.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5Shift0BundleOfShape.lean
@@ -1,0 +1,99 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5Shift0BundleOfShape
+
+  `loopN2SelectedBorrowCarryV5_shift0_of_shape`: the borrow-conditional carry
+  bundle for the n=2 v5 SHIFT=0 loop, discharged from shape.  Shift=0 counterpart
+  of `loopN2SelectedBorrowCarryV5_of_shape` (#7461): the divisor is the RAW
+  `(b0, b1, 0, 0)` (already top-bit-aligned, `b1 ≥ 2^63`), so the loop runs the
+  raw `iterN2V5 … b0 b1 0 0 …` family directly (no normalization).  `v2 = v3 = 0`
+  are literal (no shape facts needed); the per-digit `u3 = uTop = 0` collapse is
+  via `iterN2V5_collapse` and the per-digit carry discharges
+  (`callAddbackCarry2NzV5_of_borrow_of_call_shape` / `…N2Max…`).  This is the
+  satisfiable-from-shape carry hypothesis the shift=0 loop consumes.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5CallCarryOfCallShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5MaxCarryOfMaxShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5IterSelectedEq
+import EvmAsm.Evm64.DivMod.Spec.N2V5NormScaled
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopDefsBorrowCarry
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- The shift=0 borrow-conditional carry bundle, discharged from shape. -/
+theorem loopN2SelectedBorrowCarryV5_shift0_of_shape
+    (a0 a1 a2 a3 b0 b1 : Word) (bltu_2 bltu_1 bltu_0 : Bool)
+    (hb1ge : b1.toNat ≥ 2^63)
+    (hc2 : bltu_2 = true → BitVec.ult (0:Word) b1 = true)
+    (hm2 : bltu_2 = false → ¬ BitVec.ult (0:Word) b1)
+    (hc1 : bltu_1 = true → BitVec.ult (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 b1 = true)
+    (hm1 : bltu_1 = false → ¬ BitVec.ult (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 b1)
+    (hc0 : bltu_0 = true → BitVec.ult (iterN2V5 bltu_1 b0 b1 0 0 a1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 0).2.2.1 b1 = true)
+    (hm0 : bltu_0 = false → ¬ BitVec.ult (iterN2V5 bltu_1 b0 b1 0 0 a1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 0).2.2.1 b1) :
+    loopN2SelectedBorrowCarryV5 bltu_2 bltu_1 bltu_0 b0 b1 0 0 a2 a3 0 0 0 a1 a0 := by
+  have h0 : (0:Word).toNat = 0 := rfl
+  have hbnz : b0 ||| b1 ||| (0:Word) ||| 0 ≠ 0 := by
+    intro h
+    have h2 := (BitVec.or_eq_zero_iff.mp h).1
+    have h3 := (BitVec.or_eq_zero_iff.mp h2).1
+    have hz : b1 = 0 := (BitVec.or_eq_zero_iff.mp h3).2
+    rw [hz] at hb1ge; simp at hb1ge
+  have hvpos : 2^127 ≤ val256 b0 b1 0 0 := by simp only [EvmWord.val256, h0]; omega
+  have hfwv : val256 a2 a3 0 0 < 2^64 * val256 b0 b1 0 0 := by
+    have ha : val256 a2 a3 0 0 < 2^128 := by
+      have := a2.isLt; have := a3.isLt; simp only [EvmWord.val256, h0]; omega
+    calc val256 a2 a3 0 0 < 2^128 := ha
+      _ ≤ 2^64 * 2^127 := by norm_num
+      _ ≤ 2^64 * val256 b0 b1 0 0 := Nat.mul_le_mul_left _ hvpos
+  have hR2 := iterN2V5_step bltu_2 b0 b1 a2 a3 0 hbnz hb1ge hfwv hc2 hm2
+  obtain ⟨hR2u3, hR2uTop, _⟩ := iterN2V5_collapse bltu_2 b0 b1 a2 a3 0 hbnz hb1ge hfwv hc2 hm2
+  have hR1valid := n2_next_window_lt a1
+    (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1
+    (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 _ hR2.2
+  obtain ⟨hR1u3, hR1uTop, _⟩ := iterN2V5_collapse bltu_1 b0 b1 a1
+    (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1
+    (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 hbnz hb1ge hR1valid hc1 hm1
+  unfold loopN2SelectedBorrowCarryV5
+  simp only [loopN2IterSelectedV5_eq_iterN2V5]
+  refine ⟨?_, ?_, ?_⟩
+  · cases hb : bltu_2 with
+    | true =>
+      intro hborrow
+      have hcall : (0:Word).toNat < b1.toNat := by
+        have := hc2 hb; rw [BitVec.ult] at this; exact of_decide_eq_true this
+      exact callAddbackCarry2NzV5_of_borrow_of_call_shape b0 b1 a2 a3 0 0 hb1ge hcall hborrow
+    | false =>
+      intro hborrow
+      exact isAddbackCarry2NzN2Max_of_borrow_of_max_shape b0 b1 a2 a3 0 0 hb1ge (hm2 hb) hborrow
+  · rw [hR2u3, hR2uTop]
+    cases hb : bltu_1 with
+    | true =>
+      intro hborrow
+      have hcall : (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1.toNat < b1.toNat := by
+        have := hc1 hb; rw [BitVec.ult] at this; exact of_decide_eq_true this
+      exact callAddbackCarry2NzV5_of_borrow_of_call_shape b0 b1 a1
+        (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1
+        (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 hb1ge hcall hborrow
+    | false =>
+      intro hborrow
+      exact isAddbackCarry2NzN2Max_of_borrow_of_max_shape b0 b1 a1
+        (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1
+        (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 hb1ge (hm1 hb) hborrow
+  · rw [hR2u3, hR2uTop, hR1u3, hR1uTop]
+    cases hb : bltu_0 with
+    | true =>
+      intro hborrow
+      have hcall : (iterN2V5 bltu_1 b0 b1 0 0 a1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 0).2.2.1.toNat < b1.toNat := by
+        have := hc0 hb; rw [BitVec.ult] at this; exact of_decide_eq_true this
+      exact callAddbackCarry2NzV5_of_borrow_of_call_shape b0 b1 a0
+        (iterN2V5 bltu_1 b0 b1 0 0 a1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 0).2.1
+        (iterN2V5 bltu_1 b0 b1 0 0 a1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 0).2.2.1 0 hb1ge hcall hborrow
+    | false =>
+      intro hborrow
+      exact isAddbackCarry2NzN2Max_of_borrow_of_max_shape b0 b1 a0
+        (iterN2V5 bltu_1 b0 b1 0 0 a1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 0).2.1
+        (iterN2V5 bltu_1 b0 b1 0 0 a1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 0).2.2.1 0 hb1ge (hm0 hb) hborrow
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5Shift0QuotientLane.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5Shift0QuotientLane.lean
@@ -1,0 +1,53 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5Shift0QuotientLane
+
+  Lane-ready (`a b : EvmWord`) form of the n=2 v5 SHIFT=0 quotient-word
+  correctness: the shift=0 schoolbook quotient word equals `EvmWord.div a b`,
+  given the n=2 shape (`b2=b3=0`, top divisor limb `b1 ≥ 2^63` i.e. shift=0) and
+  the per-digit `bltu` path matches.  Bridges the `fromLimbs`-form
+  `n2_shift0_quotient_word_eq_div` to the `a b` form via
+  `EvmWord.fromLimbs_match_getLimbN_id` (with the `b2=b3=0` padding discharged by
+  the shape).  Counterpart of the shift≠0 `fullDivN2QuotientWordV5_eq_div_lane_of_shape`;
+  the `hdivWord` the eventual n=2 shift=0 lane will feed to its post bridge.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0Quotient
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- Lane form of the shift=0 n=2 quotient word: equals `EvmWord.div a b`. -/
+theorem n2_shift0_quotient_word_eq_div_lane (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 : Word) (bltu_2 bltu_1 bltu_0 : Bool)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2z : b.getLimbN 2 = 0) (hb3z : b.getLimbN 3 = 0)
+    (hb1ge : b1.toNat ≥ 2^63)
+    (hc2 : bltu_2 = true → BitVec.ult (0:Word) b1 = true)
+    (hm2 : bltu_2 = false → ¬ BitVec.ult (0:Word) b1)
+    (hc1 : bltu_1 = true → BitVec.ult (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 b1 = true)
+    (hm1 : bltu_1 = false → ¬ BitVec.ult (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 b1)
+    (hc0 : bltu_0 = true → BitVec.ult (iterN2V5 bltu_1 b0 b1 0 0 a1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 0).2.2.1 b1 = true)
+    (hm0 : bltu_0 = false → ¬ BitVec.ult (iterN2V5 bltu_1 b0 b1 0 0 a1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 0).2.2.1 b1) :
+    EvmWord.fromLimbs (fun i : Fin 4 => match i with
+        | 0 => (iterN2V5 bltu_0 b0 b1 0 0 a0 (iterN2V5 bltu_1 b0 b1 0 0 a1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 0).2.1 (iterN2V5 bltu_1 b0 b1 0 0 a1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 0).2.2.1 0 0).1
+        | 1 => (iterN2V5 bltu_1 b0 b1 0 0 a1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 0).1
+        | 2 => (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).1
+        | 3 => 0)
+      = EvmWord.div a b := by
+  have hbase := n2_shift0_quotient_word_eq_div a0 a1 a2 a3 b0 b1 hb1ge bltu_2 bltu_1 bltu_0
+    hc2 hm2 hc1 hm1 hc0 hm0
+  refine hbase.trans ?_
+  congr 1
+  · conv_rhs => rw [← EvmWord.fromLimbs_match_getLimbN_id a]
+    congr 1
+    funext i
+    fin_cases i <;> simp only [ha0, ha1, ha2, ha3]
+  · conv_rhs => rw [← EvmWord.fromLimbs_match_getLimbN_id b]
+    congr 1
+    funext i
+    fin_cases i <;> simp only [hb0, hb1, hb2z, hb3z]
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Proves `divK_loop_n2_shift0_from_shape_v5_noNop` — the v5 n=2 **shift=0 loop body** (`loopBodyOff → denormOff`) over `divCode_noNop_v5`, with the carry hypothesis discharged from shape.

The unified loop `divK_loop_n2_unified_from_source_exact_loopIterScratch_v5_noNop_borrowCarry` (#7449) is **generic** in the divisor/window values, so the shift=0 loop is that loop instantiated with the raw divisor `(b0, b1, 0, 0)` and shift=0 u-window `(a2, a3, 0, 0, 0)` / `a1` / `a0`. The carry is discharged via `loopN2SelectedBorrowCarryV5_shift0_of_shape` (the shift=0 carry bundle).

## Key proof points

- borrow flags introduced in clean `ult (iterN2V5 …).2.2.1 b1` form;
- `hbltu_1` via `cases bltu_2 <;> simp only [iterN2V5, reduceIte, Bool.false_eq_true] <;> exact` (`Bool.false_eq_true` needed — `reduceIte` reduces `if true = true` but not `if false = true`);
- `hbltu_0` bridges #7449's `iterN2Max`/`iterWithDoubleAddback` **threaded** form to the clean **padded** form by rewriting the digit-2 `u3 = uTop = 0` collapse (`iterN2V5_collapse`, converted to `iterN2Max` form by the same `simp`);
- `hcarry` = the shift=0 carry bundle exactly.

## Verification

Axioms: `propext`, `Classical.choice`, `Quot.sound` (no `sorry`/`native_decide`). Full `EvmAsm.Evm64.DivMod` builds green (1611 jobs).

Stacked on `feat/v5-n2-phaseab-c2taken` (which holds the merged shift=0 carry bundle / preloop / quotient lane after the automerge stack collapse).

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)