### PR TITLE
feat(divmod): v5 n2 shift=0 post bridge to divStackDispatchPostV5

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -204,6 +204,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFullBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFromShape
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LaneShiftNz
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5Lane
+import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0PostBridge
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -206,6 +206,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LaneShiftNz
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5Lane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0PostBridge
 import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0DivLimb
+import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0PreLift
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -205,6 +205,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFromShape
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LaneShiftNz
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5Lane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0PostBridge
+import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0DivLimb
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientCorrect
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
 import EvmAsm.Evm64.DivMod.Spec.N2V5Conditions

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5Shift0DivLimb.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5Shift0DivLimb.lean
@@ -1,0 +1,48 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5Shift0DivLimb
+
+  Per-limb form of the n=2 v5 SHIFT=0 quotient correctness: each limb of
+  `EvmWord.div a b` equals the corresponding shift=0 schoolbook digit
+  (the raw `iterN2V5 …`-based quotient digit).  Decomposes the quotient-word
+  equality `n2_shift0_quotient_word_eq_div_lane` (#7467) into the four
+  `(EvmWord.div a b).getLimbN i = digit_i` equalities via `getLimbN_fromLimbs_*`.
+  These are the `hdiv0..hdiv3` facts the n=2 shift=0 lane feeds to the post
+  bridge `n2_shift0_epiloguePost_to_divStackDispatchPostV5` (#7475).
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0QuotientLane
+import EvmAsm.Evm64.EvmWordArith.DivLimbBridge
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The four `(EvmWord.div a b).getLimbN i` shift=0 digit equalities. -/
+theorem n2_shift0_div_getLimbN_lane (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 : Word) (bltu_2 bltu_1 bltu_0 : Bool)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2z : b.getLimbN 2 = 0) (hb3z : b.getLimbN 3 = 0)
+    (hb1ge : b1.toNat ≥ 2^63)
+    (hc2 : bltu_2 = true → BitVec.ult (0:Word) b1 = true)
+    (hm2 : bltu_2 = false → ¬ BitVec.ult (0:Word) b1)
+    (hc1 : bltu_1 = true → BitVec.ult (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 b1 = true)
+    (hm1 : bltu_1 = false → ¬ BitVec.ult (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 b1)
+    (hc0 : bltu_0 = true → BitVec.ult (iterN2V5 bltu_1 b0 b1 0 0 a1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 0).2.2.1 b1 = true)
+    (hm0 : bltu_0 = false → ¬ BitVec.ult (iterN2V5 bltu_1 b0 b1 0 0 a1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 0).2.2.1 b1) :
+    (EvmWord.div a b).getLimbN 0 =
+        (iterN2V5 bltu_0 b0 b1 0 0 a0 (iterN2V5 bltu_1 b0 b1 0 0 a1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 0).2.1 (iterN2V5 bltu_1 b0 b1 0 0 a1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 0).2.2.1 0 0).1 ∧
+    (EvmWord.div a b).getLimbN 1 =
+        (iterN2V5 bltu_1 b0 b1 0 0 a1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.1 (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).2.2.1 0 0).1 ∧
+    (EvmWord.div a b).getLimbN 2 = (iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0).1 ∧
+    (EvmWord.div a b).getLimbN 3 = (0 : Word) := by
+  have hword := n2_shift0_quotient_word_eq_div_lane a b a0 a1 a2 a3 b0 b1 bltu_2 bltu_1 bltu_0
+    ha0 ha1 ha2 ha3 hb0 hb1 hb2z hb3z hb1ge hc2 hm2 hc1 hm1 hc0 hm0
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> rw [← hword]
+  · exact EvmWord.getLimbN_fromLimbs_0
+  · exact EvmWord.getLimbN_fromLimbs_1
+  · exact EvmWord.getLimbN_fromLimbs_2
+  · exact EvmWord.getLimbN_fromLimbs_3
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5Shift0PostBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5Shift0PostBridge.lean
@@ -1,0 +1,60 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5Shift0PostBridge
+
+  N=2 v5 SHIFT=0 post bridge: from the shift=0 epilogue post (at nopOff — the
+  quotient digits `q0..q3` in the output m-cells sp+32..56 and registers, plus
+  the scratch cells) to the scaffold post `divStackDispatchPostV5`.  Mirrors n1's
+  `n1_denormPost_to_divStackDispatchPost_v5` via `divStackDispatchPost_weaken` +
+  `evmWordIs_sp{,32}_limbs_eq` + `memIs_implies_memOwn`.  Given the quotient
+  digits equal `(EvmWord.div a b).getLimbN i` (from the shift=0 quotient
+  correctness, #7467), this is the post half of the n=2 shift=0 lane.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Div
+import EvmAsm.Evm64.DivMod.Compose.Base
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_add_zero)
+
+/-- Shift=0 epilogue post (+ dividend & scratch frame) ⊢ `divStackDispatchPostV5`. -/
+theorem n2_shift0_epiloguePost_to_divStackDispatchPostV5
+    (sp : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 q0 q1 q2 q3 v1 v2 v11 shift : Word)
+    (u0 u1 u2 u3 u4 u5 u6 u7 nMem jMem retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hdiv0 : (EvmWord.div a b).getLimbN 0 = q0) (hdiv1 : (EvmWord.div a b).getLimbN 1 = q1)
+    (hdiv2 : (EvmWord.div a b).getLimbN 2 = q2) (hdiv3 : (EvmWord.div a b).getLimbN 3 = q3) :
+    ∀ h,
+      (((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ q0) ** (.x6 ↦ᵣ q1) ** (.x7 ↦ᵣ q2) **
+        (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ q3) **
+        ((sp + signExtend12 3992) ↦ₘ shift) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + 32) ↦ₘ q0) ** ((sp + 40) ↦ₘ q1) **
+        ((sp + 48) ↦ₘ q2) ** ((sp + 56) ↦ₘ q3)) **
+       ((.x9 ↦ᵣ v1) ** (.x11 ↦ᵣ v11) ** regOwn .x1 **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+        ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+        ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
+        ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
+        ((sp + signExtend12 3984) ↦ₘ nMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        ((sp + signExtend12 3968) ↦ₘ retMem) ** ((sp + signExtend12 3960) ↦ₘ dMem) **
+        ((sp + signExtend12 3952) ↦ₘ dloMem) ** ((sp + signExtend12 3944) ↦ₘ scratch_un0) **
+        ((sp + signExtend12 3936) ↦ₘ scratchMem))) h →
+      divStackDispatchPostV5 sp a b h := by
+  intro h hp
+  rw [divStackDispatchPostV5]
+  apply sepConj_mono_right (P := divStackDispatchPost sp a b) memIs_implies_memOwn h
+  apply sepConj_mono_left (divStackDispatchPost_weaken sp a b) h
+  rw [evmWordIs_sp_limbs_eq sp a a0 a1 a2 a3 ha0 ha1 ha2 ha3,
+      evmWordIs_sp32_limbs_eq sp (EvmWord.div a b) q0 q1 q2 q3 hdiv0 hdiv1 hdiv2 hdiv3,
+      divScratchValuesCall_unfold, divScratchValues_unfold]
+  rw [word_add_zero] at hp
+  xperm_hyp hp
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5Shift0PreLift.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5Shift0PreLift.lean
@@ -1,0 +1,61 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5Shift0PreLift
+
+  N=2 v5 SHIFT=0 pre lift: the stack-dispatch DIV precondition
+  `divModStackDispatchPreNoX1` (with the n=2 register instantiation
+  `x9 = 4-4`, `x2 = (clzResult b1).2>>>63`) plus the v5 extra scratch cell
+  `sp+3936` implies the shift=0 path entry shape consumed by
+  `evm_div_n2_to_denorm_shift0_from_shape_v5_noNop` (#7472).  Mirrors the
+  shift≠0 pre lift inside #7452.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5PathShift0
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_add_zero)
+
+theorem n2_shift0_dispatchPre_to_pathEntry (sp : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 raVal v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2z : b.getLimbN 2 = 0) (hb3z : b.getLimbN 3 = 0) :
+    ∀ h,
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult b1).2 >>> (63 : Nat)) v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem)) h →
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ ((clzResult b1).2 >>> (63 : Nat))) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        ((sp + signExtend12 3968) ↦ₘ retMem) ** ((sp + signExtend12 3960) ↦ₘ dMem) **
+        ((sp + signExtend12 3952) ↦ₘ dloMem) ** ((sp + signExtend12 3944) ↦ₘ scratchUn0) **
+        ((sp + signExtend12 3936) ↦ₘ scratchMem) ** (.x1 ↦ᵣ raVal))) h := by
+  intro h hp
+  rw [divModStackDispatchPreNoX1_unfold, divScratchValuesCallNoX1_unfold] at hp
+  rw [evmWordIs_sp_limbs_eq sp a a0 a1 a2 a3 ha0 ha1 ha2 ha3,
+      evmWordIs_sp32_limbs_eq sp b b0 b1 0 0 hb0 hb1 hb2z hb3z,
+      divScratchValues_unfold] at hp
+  rw [word_add_zero]
+  xperm_hyp hp
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Proves `n2_shift0_epiloguePost_to_divStackDispatchPostV5` — from the shift=0 epilogue post (at nopOff: quotient digits `q0..q3` in output m-cells `sp+32..56` and regs `x5/x6/x7/x10`, plus scratch cells) to the scaffold post `divStackDispatchPostV5`, given the quotient digits equal `(EvmWord.div a b).getLimbN i` (from the shift=0 quotient correctness, #7467).

## How

Mirrors n1's `n1_denormPost_to_divStackDispatchPost_v5`: `divStackDispatchPost_weaken` + `evmWordIs_sp_limbs_eq` (a-cells = a) + `evmWordIs_sp32_limbs_eq` (m-cells = div limbs) + `memIs_implies_memOwn` (sp+3936) + `word_add_zero` (sp+0 normalization) + `xperm`. Source supplies `regOwn .x1` (the lane weakens the epilogue's `regIs` x1 first).

This is the **post half of the n=2 shift=0 lane**.

## Verification

Axioms: `propext`, `Quot.sound` (no `sorry`/`native_decide`). Full `EvmAsm.Evm64.DivMod` builds green (1614 jobs).

Stacked on `feat/v5-n2-lane-combiner` (#7473).

Authored by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)