### PR TITLE
feat(stateless): sload_at_block_hash_address (SLOAD)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -117,6 +117,7 @@ import EvmAsm.Codegen.Programs.NonceAtBlockHash
 import EvmAsm.Codegen.Programs.CodeAtBlockHash
 import EvmAsm.Codegen.Programs.HasCodeOrNonceAtBlockHash
 import EvmAsm.Codegen.Programs.AccountExistsAtBlockHash
+import EvmAsm.Codegen.Programs.SloadAtBlockHash
 import EvmAsm.Codegen.Programs.StateProof
 import EvmAsm.Codegen.Programs.StateStorageProof
 import EvmAsm.Codegen.Programs.StateCodeHashProof
@@ -488,6 +489,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_number_at_state_root" => some ziskBlockNumberAtStateRootProbeUnit
   | "zisk_state_root_at_block_number" => some ziskStateRootAtBlockNumberProbeUnit
   | "zisk_account_exists_at_block_hash_address" => some ziskAccountExistsAtBlockHashAddressProbeUnit
+  | "zisk_sload_at_block_hash_address" => some ziskSloadAtBlockHashAddressProbeUnit
   | "zisk_storage_root_present_in_witness_storage" => some ziskStorageRootPresentInWitnessStorageProbeUnit
   | "zisk_witness_storage_keccak_at_index" => some ziskWitnessStorageKeccakAtIndexProbeUnit
   | "zisk_witness_codes_keccak_at_index" => some ziskWitnessCodesKeccakAtIndexProbeUnit
@@ -710,6 +712,7 @@ def knownProgramNames : List String :=
    "zisk_block_number_at_state_root",
    "zisk_state_root_at_block_number",
    "zisk_account_exists_at_block_hash_address",
+   "zisk_sload_at_block_hash_address",
    "zisk_storage_root_present_in_witness_storage",
    "zisk_witness_storage_keccak_at_index",
    "zisk_witness_codes_keccak_at_index",

--- a/EvmAsm/Codegen/Programs/SloadAtBlockHash.lean
+++ b/EvmAsm/Codegen/Programs/SloadAtBlockHash.lean
@@ -1,0 +1,340 @@
+/-
+  EvmAsm.Codegen.Programs.SloadAtBlockHash
+
+  Hash-keyed SLOAD primitive. Mirrors the existing
+  `sload_at_header_state_root` (under EvmOpcodes) but takes
+  a `block_hash` as the key instead of raw header bytes.
+
+  Pipeline:
+    witness.headers ∋ ?h with keccak(h) == block_hash  [K19]
+    h -> header_extract_state_root                     [K201]
+    state_root + address -> account_at_address         [K28]
+    slot_idx -> slot_at_index                          [K29]
+    returns 0 for missing account / missing slot per SLOAD spec.
+
+  Notably the function needs 9 inputs but RISC-V passes
+  only 8 in a0..a7. We solve this by:
+    * Using a side-effect global `sloadbh_u256` for the
+      output (saves 1 arg).
+    * Stashing `witness.storage_len` into a global scratch
+      `sloadbh_witness_storage_len` before the call (saves
+      another arg, so the actual call uses 7 args).
+
+  No proofs yet -- codegen `String` defs only.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.Mpt
+import EvmAsm.Codegen.Programs.HashBridge
+import EvmAsm.Codegen.Programs.HeaderFields
+import EvmAsm.Codegen.Programs.State
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Program
+
+/-! ## sload_at_block_hash_address  (SLOAD at block_hash)
+
+    Returns the u256 value an `SLOAD(slot)` frame would push
+    when executed against the storage trie of `address` in
+    the block named by `block_hash`.
+
+    Per the spec, SLOAD returns 0 if:
+      * `block_hash` is in witness.headers BUT the account
+        is not present in the state trie, OR
+      * `account.storage_root == EMPTY_TRIE_ROOT`, OR
+      * the storage slot is simply not present in the
+        storage trie (any uninitialised slot is implicitly
+        zero).
+
+    Distinct from `state_slot_at_block_hash_address`
+    (#7307 family) in that absence-cases here are collapsed
+    to (status=0, value=0); that primitive surfaces them as
+    distinct statuses.
+
+    Use cases:
+      * SLOAD opcode replay against a historical block keyed
+        by hash.
+      * Light-client storage oracle, e.g. querying a known
+        ERC-20 balance slot at a specific block_hash.
+      * Cross-chain bridge: a counter-party claims slot
+        value V at block_hash B; verify directly.
+
+    Composes K19 (witness.headers) + K201 + K28 + K29
+    (slot_at_index). No new helpers.
+
+    Calling convention (7 args + 1 global scratch):
+      a0 (input)  : block_hash ptr (32 bytes)
+      a1 (input)  : witness.headers ptr
+      a2 (input)  : witness.headers len
+      a3 (input)  : address ptr (20 bytes)
+      a4 (input)  : slot_idx ptr (32-byte BE u256)
+      a5 (input)  : witness.state ptr
+      a6 (input)  : witness.state len
+      a7 (input)  : witness.storage ptr
+      [scratch]   : sloadbh_witness_storage_len -- must be
+                    written by the caller before the call.
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success (`sloadbh_u256` holds the u256 BE value;
+            may be 0)
+        1 = block_hash not in witness.headers
+        2 = matched header parse / state_root size fail
+        3 = state-trie mpt parse error
+        4 = account_decode failure
+        6 = storage-trie mpt parse error
+        7 = slot RLP decode failure
+
+      (Statuses 5 and "account/slot absent" are intentionally
+      mapped to status=0, value=0 per SLOAD semantics.)
+-/
+def sloadAtBlockHashAddressFunction : String :=
+  "sload_at_block_hash_address:\n" ++
+  "  addi sp, sp, -112\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp); sd s10, 88(sp); sd s11, 96(sp)\n" ++
+  "  mv s0, a0                  # block_hash ptr\n" ++
+  "  mv s1, a1                  # witness.headers ptr\n" ++
+  "  mv s2, a2                  # witness.headers len\n" ++
+  "  mv s3, a3                  # address ptr\n" ++
+  "  mv s4, a4                  # slot_idx ptr\n" ++
+  "  mv s5, a5                  # witness.state ptr\n" ++
+  "  mv s6, a6                  # witness.state len\n" ++
+  "  mv s7, a7                  # witness.storage ptr\n" ++
+  "  la t0, sloadbh_witness_storage_len\n" ++
+  "  ld s11, 0(t0)              # witness.storage len (from scratch)\n" ++
+  "  # Pre-zero the u256 output.\n" ++
+  "  la t0, sloadbh_u256\n" ++
+  "  sd zero,  0(t0); sd zero,  8(t0); sd zero, 16(t0); sd zero, 24(t0)\n" ++
+  "  mv a0, s1\n" ++
+  "  mv a1, s2\n" ++
+  "  mv a2, s0\n" ++
+  "  la a3, sloadbh_match_offset\n" ++
+  "  la a4, sloadbh_match_length\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  bnez a0, .Lsloadbh_no_match\n" ++
+  "  la t0, sloadbh_match_offset\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  add s8, s1, t1\n" ++
+  "  la t0, sloadbh_match_length\n" ++
+  "  ld s9, 0(t0)\n" ++
+  "  mv a0, s8\n" ++
+  "  mv a1, s9\n" ++
+  "  la a2, sloadbh_state_root\n" ++
+  "  jal ra, header_extract_state_root\n" ++
+  "  beqz a0, .Lsloadbh_step2\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lsloadbh_ret\n" ++
+  ".Lsloadbh_step2:\n" ++
+  "  # account_at_address.\n" ++
+  "  mv a0, s3\n" ++
+  "  li a1, 20\n" ++
+  "  la a2, sloadbh_state_root\n" ++
+  "  mv a3, s5\n" ++
+  "  mv a4, s6\n" ++
+  "  la s10, sloadbh_acct_struct\n" ++
+  "  mv a5, s10\n" ++
+  "  jal ra, account_at_address\n" ++
+  "  beqz a0, .Lsloadbh_step3\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Lsloadbh_missing_acct\n" ++
+  "  addi a0, a0, 1\n" ++
+  "  j .Lsloadbh_ret\n" ++
+  ".Lsloadbh_missing_acct:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lsloadbh_ret\n" ++
+  ".Lsloadbh_step3:\n" ++
+  "  # slot_at_index over witness.storage with acct.storage_root.\n" ++
+  "  mv a0, s4                  # slot_idx ptr\n" ++
+  "  li a1, 32\n" ++
+  "  addi a2, s10, 40           # &acct.storage_root\n" ++
+  "  mv a3, s7                  # witness.storage ptr\n" ++
+  "  mv a4, s11                 # witness.storage len\n" ++
+  "  la a5, sloadbh_u256\n" ++
+  "  jal ra, slot_at_index\n" ++
+  "  beqz a0, .Lsloadbh_ret\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Lsloadbh_missing_slot\n" ++
+  "  # slot_at_index status 2 -> 6, 3 -> 7.\n" ++
+  "  addi a0, a0, 4\n" ++
+  "  j .Lsloadbh_ret\n" ++
+  ".Lsloadbh_missing_slot:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lsloadbh_ret\n" ++
+  ".Lsloadbh_no_match:\n" ++
+  "  li a0, 1\n" ++
+  ".Lsloadbh_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp); ld s11, 96(sp)\n" ++
+  "  addi sp, sp, 112\n" ++
+  "  ret"
+
+/-- `zisk_sload_at_block_hash_address`: probe BuildUnit.
+    Input layout (at INPUT_ADDR):
+      bytes  0.. 8 : (ziskemu metadata)
+      bytes  8..16 : witness_headers_len (u64 LE)
+      bytes 16..24 : witness_state_len   (u64 LE)
+      bytes 24..32 : witness_storage_len (u64 LE)
+      bytes 32..64 : block_hash (32 bytes)
+      bytes 64..96 : slot_idx   (32-byte BE u256)
+      bytes 96..116: address    (20 bytes)
+      bytes 116..  : witness.headers ++ witness.state ++ witness.storage
+    Output layout:
+      bytes  0.. 8 : status (0 / 1 / 2 / 3 / 4 / 6 / 7)
+      bytes  8..40 : slot value (u256 BE; 0 on missing/absent) -/
+def ziskSloadAtBlockHashAddressPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t4, 0x40000000\n" ++
+  "  ld t5, 8(t4)                # witness_headers_len\n" ++
+  "  ld t6, 16(t4)               # witness_state_len\n" ++
+  "  ld t3, 24(t4)               # witness_storage_len\n" ++
+  "  # Stash witness_storage_len into scratch.\n" ++
+  "  la t0, sloadbh_witness_storage_len\n" ++
+  "  sd t3, 0(t0)\n" ++
+  "  addi a0, t4, 32             # block_hash ptr\n" ++
+  "  addi a4, t4, 64             # slot_idx ptr\n" ++
+  "  addi a3, t4, 96             # address ptr\n" ++
+  "  addi a1, t4, 116            # witness.headers ptr\n" ++
+  "  mv a2, t5                   # witness.headers len\n" ++
+  "  add a5, a1, t5              # witness.state ptr\n" ++
+  "  mv a6, t6                   # witness.state len\n" ++
+  "  add a7, a5, t6              # witness.storage ptr\n" ++
+  "  jal ra, sload_at_block_hash_address\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  la t1, sloadbh_u256\n" ++
+  "  ld t2,  0(t1); sd t2,  8(t0)\n" ++
+  "  ld t2,  8(t1); sd t2, 16(t0)\n" ++
+  "  ld t2, 16(t1); sd t2, 24(t0)\n" ++
+  "  ld t2, 24(t1); sd t2, 32(t0)\n" ++
+  "  j .Lsloadbh_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  mptLookupByKeyFunction ++ "\n" ++
+  accountDecodeFunction ++ "\n" ++
+  accountAtAddressFunction ++ "\n" ++
+  slotDecodeU256Function ++ "\n" ++
+  slotAtIndexFunction ++ "\n" ++
+  headerExtractStateRootFunction ++ "\n" ++
+  sloadAtBlockHashAddressFunction ++ "\n" ++
+  ".Lsloadbh_pdone:"
+
+def ziskSloadAtBlockHashAddressDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mnk_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_dummy_length:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mbc_offset:\n" ++
+  "  .zero 8\n" ++
+  "mbc_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_lookup_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_lookup_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_lookup_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_child_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_nibble_count:\n" ++
+  "  .zero 8\n" ++
+  "mw_is_leaf:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_nibble_buf:\n" ++
+  "  .zero 128\n" ++
+  ".balign 32\n" ++
+  "mlk_keccak_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "mlk_nibble_buf:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "ad_offset:\n" ++
+  "  .zero 8\n" ++
+  "ad_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aa_value_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aa_value_scratch:\n" ++
+  "  .zero 256\n" ++
+  ".balign 8\n" ++
+  "si_value_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "si_value_scratch:\n" ++
+  "  .zero 256\n" ++
+  ".balign 8\n" ++
+  "hesr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hesr_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "sloadbh_match_offset:\n" ++
+  "  .zero 8\n" ++
+  "sloadbh_match_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "sloadbh_witness_storage_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "sloadbh_state_root:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "sloadbh_acct_struct:\n" ++
+  "  .zero 104\n" ++
+  ".balign 32\n" ++
+  "sloadbh_u256:\n" ++
+  "  .zero 32"
+
+def ziskSloadAtBlockHashAddressProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskSloadAtBlockHashAddressPrologue
+  dataAsm     := ziskSloadAtBlockHashAddressDataSection
+}
+
+end EvmAsm.Codegen

--- a/scripts/codegen-zisk-sload-at-block-hash-address-check.sh
+++ b/scripts/codegen-zisk-sload-at-block-hash-address-check.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# codegen-zisk-sload-at-block-hash-address-check.sh
+#
+# Hash-keyed SLOAD. From (block_hash, address, slot_idx,
+# witness.headers, witness.state, witness.storage), return
+# the u256 value SLOAD(slot) would push when executed
+# against the storage trie of `address` at the block named
+# by block_hash.
+#
+# Per spec, returns 0 for: missing account, EMPTY_TRIE storage_root,
+# missing slot.
+#
+# Output (40 bytes):
+#   bytes  0.. 8 : status (0 / 1 / 2 / 3 / 4 / 6 / 7)
+#   bytes  8..40 : slot value (u256 BE; 0 on missing/absent)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_sload_at_block_hash_address ELF"
+lake exe codegen --program zisk_sload_at_block_hash_address \
+  --halt linux93 \
+  -o gen-out/zisk_sload_at_block_hash_address
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_sloadbh_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_sloadbh_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_sloadbh_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def hp_encode(nibbles, is_leaf):
+    flag = 2 if is_leaf else 0
+    if len(nibbles) % 2 == 1:
+        flag |= 1
+        result = bytes([flag * 0x10 + nibbles[0]])
+        nibbles = nibbles[1:]
+    else:
+        result = bytes([flag * 0x10])
+    for i in range(0, len(nibbles), 2):
+        result += bytes([nibbles[i] * 0x10 + nibbles[i+1]])
+    return result
+
+def leaf_node(path_nibbles, value):
+    return rlp.encode([hp_encode(path_nibbles, True), value])
+
+def bytes_to_nibbles(b):
+    out = []
+    for byte in b:
+        out.append(byte >> 4); out.append(byte & 0xf)
+    return out
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0: return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset); offset += len(e)
+    for e in elements: section += e
+    return section
+
+def encode_account(nonce, balance, storage_root, code_hash):
+    return rlp.encode([nonce, balance, storage_root, code_hash])
+
+def encode_header(state_root):
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x55'*32,
+        b'\\x66'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    return rlp.encode(fields)
+
+EMPTY_TRIE = bytes.fromhex('56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421')
+EMPTY_CODE_HASH = bytes.fromhex('c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')
+
+def state_trie_one(addr, acct_rlp):
+    path = bytes_to_nibbles(k256(addr))
+    leaf = leaf_node(path, acct_rlp)
+    return k256(leaf), build_ssz_section([leaf])
+
+def storage_trie_one(slot_key_be, value_int):
+    # MPT key is keccak(slot_key_be). Value is rlp-encoded big-endian-shortest u256.
+    if value_int == 0:
+        v_short = b''
+    else:
+        nbytes = (value_int.bit_length() + 7) // 8
+        v_short = value_int.to_bytes(nbytes, 'big')
+    path = bytes_to_nibbles(k256(slot_key_be))
+    leaf = leaf_node(path, rlp.encode(v_short))
+    return k256(leaf), build_ssz_section([leaf])
+
+mode = '$mode'
+parts = [
+$(for arg in "$@"; do printf '  %s,\n' "\"$arg\""; done)
+]
+ALICE = b'\\xaa' * 20
+BOB = b'\\xbb' * 20
+
+def be32(n):
+    return n.to_bytes(32, 'big')
+
+if mode == 'value_one':
+    slot_idx = be32(0)
+    value = 1
+    sr_storage, witness_storage = storage_trie_one(slot_idx, value)
+    acct = encode_account(0, 0, sr_storage, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(sr); witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0); addr = ALICE
+    expected = struct.pack('<Q', 0) + be32(value)
+elif mode == 'value_big_u256':
+    slot_idx = be32(7)
+    value = (2**200) - 1
+    sr_storage, witness_storage = storage_trie_one(slot_idx, value)
+    acct = encode_account(0, 0, sr_storage, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(sr); witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0); addr = ALICE
+    expected = struct.pack('<Q', 0) + be32(value)
+elif mode == 'slot_zero_explicit':
+    slot_idx = be32(1)
+    value = 0
+    sr_storage, witness_storage = storage_trie_one(slot_idx, value)
+    acct = encode_account(0, 0, sr_storage, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(sr); witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0); addr = ALICE
+    expected = struct.pack('<Q', 0) + be32(0)
+elif mode == 'slot_absent':
+    # Slot we look up is not in trie -> SLOAD = 0.
+    slot_idx = be32(99)
+    sr_storage, witness_storage = storage_trie_one(be32(7), 42)
+    acct = encode_account(0, 0, sr_storage, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(sr); witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0); addr = ALICE
+    expected = struct.pack('<Q', 0) + be32(0)
+elif mode == 'empty_storage_root':
+    # Account exists but storage_root == EMPTY_TRIE -> SLOAD = 0.
+    slot_idx = be32(0)
+    acct = encode_account(0, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(sr); witness_headers = build_ssz_section([h0])
+    witness_storage = b''
+    block_hash = k256(h0); addr = ALICE
+    expected = struct.pack('<Q', 0) + be32(0)
+elif mode == 'account_absent':
+    # Lookup ALICE, only BOB in trie -> SLOAD = 0.
+    slot_idx = be32(0)
+    acct = encode_account(0, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(BOB, acct)
+    h0 = encode_header(sr); witness_headers = build_ssz_section([h0])
+    witness_storage = b''
+    block_hash = k256(h0); addr = ALICE
+    expected = struct.pack('<Q', 0) + be32(0)
+elif mode == 'block_hash_miss':
+    slot_idx = be32(0)
+    sr_storage, witness_storage = storage_trie_one(slot_idx, 5)
+    acct = encode_account(0, 0, sr_storage, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(sr); witness_headers = build_ssz_section([h0])
+    block_hash = b'\\xee' * 32; addr = ALICE
+    expected = struct.pack('<Q', 1) + be32(0)
+else:
+    raise SystemExit('bad mode: ' + mode)
+
+with open(sys.argv[1], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(witness_headers))
+        + struct.pack('<Q', len(witness_state))
+        + struct.pack('<Q', len(witness_storage))
+        + block_hash
+        + slot_idx
+        + addr
+        + witness_headers
+        + witness_state
+        + witness_storage
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_sload_at_block_hash_address.elf \
+    -i "$in_file" -o "$out_file" -n 6000000 \
+    >"$REPO_ROOT/gen-out/zisk_sloadbh_${name}.emu.log" 2>&1 || true
+
+  local exp_size; exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-36s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-36s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "value_one"                  value_one || FAILED=1
+run_case "value_big_u256"             value_big_u256 || FAILED=1
+run_case "slot_zero_explicit"         slot_zero_explicit || FAILED=1
+run_case "slot_absent_returns_zero"   slot_absent || FAILED=1
+run_case "empty_storage_root"         empty_storage_root || FAILED=1
+run_case "account_absent_returns_zero" account_absent || FAILED=1
+run_case "block_hash_miss"            block_hash_miss || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: sload_at_block_hash_address end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Hash-keyed SLOAD primitive. Mirrors the existing
\`sload_at_header_state_root\` (under \`EvmOpcodes\`) but
takes a \`block_hash\` as the key instead of raw header bytes.

Returns the u256 value \`SLOAD(slot)\` would push when
executed against the storage trie of \`address\` at the block
named by \`block_hash\`. Per spec, returns 0 for any of:

- \`block_hash\` present in witness.headers but account absent
- \`account.storage_root == EMPTY_TRIE_ROOT\`
- storage slot simply not present in storage trie

Distinct from \`state_slot_at_block_hash_address\` (which
surfaces absence cases as distinct statuses): this collapses
all of them to \`(status=0, value=0)\` per SLOAD spec, so
callers don't have to special-case absence.

**Notably needs 9 inputs but RISC-V passes only 8 in a0..a7.**
Solved by:

- Using a side-effect global \`sloadbh_u256\` for the output
  (saves 1 arg).
- Stashing \`witness.storage_len\` into a global scratch
  \`sloadbh_witness_storage_len\` before the call (saves
  another arg, so the actual call uses 7 args + the scratch).

This is a reusable pattern for any future block_hash-keyed
primitive that exceeds 8 inputs.

Pipeline (composes K19 + K201 + K28 + K29; no new helpers):

\`\`\`
witness.headers ∋ ?h with keccak(h) == block_hash  [K19]
h -> header_extract_state_root                     [K201]
state_root + address -> account_at_address         [K28]
slot_idx + acct.storage_root -> slot_at_index      [K29]
\`\`\`

Use cases:
- SLOAD opcode replay against a historical block keyed by hash.
- Light-client storage oracle (e.g. querying a known ERC-20
  balance slot at a specific block_hash).
- Cross-chain bridge: counter-party claims slot value V at
  block_hash B; verify directly.

Status codes:

| status | meaning |
|--------|---------|
| 0 | success (sloadbh_u256 holds u256 BE; may be 0) |
| 1 | block_hash not in witness.headers |
| 2 | matched header parse / state_root size fail |
| 3 | state-trie mpt parse error |
| 4 | account_decode failure |
| 6 | storage-trie mpt parse error |
| 7 | slot RLP decode failure |

## Test plan

- [x] \`lake build codegen\` succeeds.
- [x] \`bash scripts/codegen-zisk-sload-at-block-hash-address-check.sh\` — 7/7 fixtures pass covering positive values, big-u256, explicit zero, and the three SLOAD absence-cases:
  - \`value_one\` (slot 0 → 1)
  - \`value_big_u256\` (slot 7 → 2^200-1)
  - \`slot_zero_explicit\` (RLP-empty value → 0)
  - \`slot_absent_returns_zero\` (slot not in trie)
  - \`empty_storage_root\` (storage_root == EMPTY_TRIE)
  - \`account_absent_returns_zero\`
  - \`block_hash_miss\` (status=1)
- [x] Merge with \`origin/main\` clean after resolving one trivial parallel-add conflict (\`ExtcodesizeAtBlockHash\` landed concurrently; both kept).
- [x] No \`native_decide\` / \`bv_decide\`; aligned LD/SD only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)