### PR TITLE
feat(stateless): extcodecopy_at_block_hash_address (EXTCODECOPY)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -120,6 +120,7 @@ import EvmAsm.Codegen.Programs.AccountExistsAtBlockHash
 import EvmAsm.Codegen.Programs.ExtcodesizeAtBlockHash
 import EvmAsm.Codegen.Programs.AccountIsEmptyAtBlockHash
 import EvmAsm.Codegen.Programs.ExtcodehashAtBlockHash
+import EvmAsm.Codegen.Programs.ExtcodecopyAtBlockHash
 import EvmAsm.Codegen.Programs.StateProof
 import EvmAsm.Codegen.Programs.StateStorageProof
 import EvmAsm.Codegen.Programs.StateCodeHashProof
@@ -483,6 +484,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_number_at_block_hash" => some ziskBlockNumberAtBlockHashProbeUnit
   | "zisk_has_code_or_nonce_at_block_hash_address" => some ziskHasCodeOrNonceAtBlockHashAddressProbeUnit
   | "zisk_extcodehash_at_block_hash_address" => some ziskExtcodehashAtBlockHashAddressProbeUnit
+  | "zisk_extcodecopy_at_block_hash_address" => some ziskExtcodecopyAtBlockHashAddressProbeUnit
   | "zisk_state_slot_at_block_number_address" => some ziskStateSlotAtBlockNumberAddressProbeUnit
   | "zisk_state_account_at_block_number_address" => some ziskStateAccountAtBlockNumberAddressProbeUnit
   | "zisk_block_hash_at_block_number" => some ziskBlockHashAtBlockNumberProbeUnit
@@ -708,6 +710,7 @@ def knownProgramNames : List String :=
    "zisk_block_number_at_block_hash",
    "zisk_has_code_or_nonce_at_block_hash_address",
    "zisk_extcodehash_at_block_hash_address",
+   "zisk_extcodecopy_at_block_hash_address",
    "zisk_state_slot_at_block_number_address",
    "zisk_state_account_at_block_number_address",
    "zisk_block_hash_at_block_number",

--- a/EvmAsm/Codegen/Programs/ExtcodecopyAtBlockHash.lean
+++ b/EvmAsm/Codegen/Programs/ExtcodecopyAtBlockHash.lean
@@ -1,0 +1,389 @@
+/-
+  EvmAsm.Codegen.Programs.ExtcodecopyAtBlockHash
+
+  Hash-keyed EXTCODECOPY primitive. Mirrors the existing
+  `extcodecopy_at_header_state_root` (under
+  EvmOpcodesExtcodecopy) but takes a `block_hash` as the
+  key instead of raw header bytes.
+
+  EXTCODECOPY is the only EVM opcode that actually emits
+  code bytes into EVM memory. Its spec divergence from a
+  naive byte-copy is the zero-pad rule:
+
+      for i in 0..length:
+        output[i] = code[code_offset + i] if code_offset + i < len(code) else 0
+
+  Reads past the end of the code are zero-padded, NOT
+  truncated, NOT errored.
+
+  This primitive has too many inputs to fit RISC-V's 8
+  a-registers, so several get stashed via global scratch
+  labels before the call -- the same pattern established
+  by sload_at_block_hash_address.
+
+  No proofs yet -- codegen `String` defs only.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.Mpt
+import EvmAsm.Codegen.Programs.HashBridge
+import EvmAsm.Codegen.Programs.HeaderFields
+import EvmAsm.Codegen.Programs.State
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Program
+
+/-! ## extcodecopy_at_block_hash_address  (EXTCODECOPY at block_hash)
+
+    Writes `length` bytes of `address`'s deployed code
+    starting at `code_offset` into a caller-supplied output
+    buffer, evaluated against the state of the block named
+    by `block_hash`. Reads past the end of the code are
+    zero-padded; missing accounts and empty-code accounts
+    map to all-zeros output (status 0).
+
+    Completes the EXT* trio at block_hash:
+      * extcodesize (#7470) -- u64 length
+      * extcodehash (#7474) -- 32 B EIP-1052 hash
+      * extcodecopy (THIS)  -- bytes with zero-pad-past-end
+
+    Use cases:
+      * EXTCODECOPY opcode replay against a historical
+        block keyed by hash.
+      * Off-chain code-inspection oracles when the caller
+        identifies blocks by hash, not number / state_root.
+      * Code-equality checks across forks: copy a fixed
+        window at two block_hashes, diff in caller.
+
+    Pipeline (composes K19 + K201 + K28 + K19' + inline
+    zero-padded byte copy; no new helpers):
+
+      witness.headers ∋ ?h with keccak(h) == block_hash  [K19]
+      h -> header_extract_state_root                     [K201]
+      state_root + address -> account_at_address         [K28]
+      if account absent OR code_hash == EMPTY_CODE_HASH:
+        output := all zeros, return 0 (spec)
+      else:
+        witness.codes ∋ ?c with keccak(c) == code_hash    [K19']
+        for i in 0..length:
+          output[i] = c[code_offset+i] if code_offset+i < len(c) else 0
+
+    Calling convention (8 a-regs + 3 global scratches):
+      a0 (input)  : block_hash ptr (32 bytes)
+      a1 (input)  : witness.headers ptr
+      a2 (input)  : witness.headers len
+      a3 (input)  : address ptr (20 bytes)
+      a4 (input)  : code_offset (u64)
+      a5 (input)  : length (u64; must be <= 256)
+      a6 (input)  : output buffer ptr (`length` bytes)
+      a7 (input)  : witness.state ptr
+      [scratch ecccbh_witness_state_len] : witness.state len
+      [scratch ecccbh_codes_ptr]         : witness.codes ptr
+      [scratch ecccbh_codes_len]         : witness.codes len
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success (output filled, zero-padded as needed)
+        1 = block_hash not in witness.headers
+        2 = matched header parse / state_root size fail
+        3 = state-trie mpt parse error
+        4 = account_decode failure
+        5 = code_hash != EMPTY but not found in witness.codes
+            (witness integrity violation)
+        6 = length > 256 (probe cap; not a spec issue)
+-/
+def extcodecopyAtBlockHashAddressFunction : String :=
+  "extcodecopy_at_block_hash_address:\n" ++
+  "  addi sp, sp, -112\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp); sd s10, 88(sp); sd s11, 96(sp)\n" ++
+  "  mv s0, a0                  # block_hash ptr\n" ++
+  "  mv s1, a1                  # witness.headers ptr\n" ++
+  "  mv s2, a2                  # witness.headers len\n" ++
+  "  mv s3, a3                  # address ptr\n" ++
+  "  mv s4, a4                  # code_offset\n" ++
+  "  mv s5, a5                  # length\n" ++
+  "  mv s6, a6                  # output buffer ptr\n" ++
+  "  mv s7, a7                  # witness.state ptr\n" ++
+  "  la t0, ecccbh_witness_state_len\n" ++
+  "  ld s11, 0(t0)              # witness.state len\n" ++
+  "  li t0, 256\n" ++
+  "  bgtu s5, t0, .Lecccbh_too_long\n" ++
+  "  # Pre-zero output[0..length] byte-by-byte.\n" ++
+  "  mv t0, s6\n" ++
+  "  mv t1, s5\n" ++
+  ".Lecccbh_zero_loop:\n" ++
+  "  beqz t1, .Lecccbh_zero_done\n" ++
+  "  sb zero, 0(t0)\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lecccbh_zero_loop\n" ++
+  ".Lecccbh_zero_done:\n" ++
+  "  # Step 0: K19 on witness.headers by block_hash.\n" ++
+  "  mv a0, s1\n" ++
+  "  mv a1, s2\n" ++
+  "  mv a2, s0\n" ++
+  "  la a3, ecccbh_match_offset\n" ++
+  "  la a4, ecccbh_match_length\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  bnez a0, .Lecccbh_no_match\n" ++
+  "  la t0, ecccbh_match_offset\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  add s8, s1, t1\n" ++
+  "  la t0, ecccbh_match_length\n" ++
+  "  ld s9, 0(t0)\n" ++
+  "  # Step 1: header.state_root.\n" ++
+  "  mv a0, s8\n" ++
+  "  mv a1, s9\n" ++
+  "  la a2, ecccbh_state_root\n" ++
+  "  jal ra, header_extract_state_root\n" ++
+  "  beqz a0, .Lecccbh_step2\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lecccbh_ret\n" ++
+  ".Lecccbh_step2:\n" ++
+  "  # Step 2: account_at_address.\n" ++
+  "  mv a0, s3\n" ++
+  "  li a1, 20\n" ++
+  "  la a2, ecccbh_state_root\n" ++
+  "  mv a3, s7\n" ++
+  "  mv a4, s11\n" ++
+  "  la s10, ecccbh_acct_struct\n" ++
+  "  mv a5, s10\n" ++
+  "  jal ra, account_at_address\n" ++
+  "  beqz a0, .Lecccbh_step3\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Lecccbh_success_zero\n" ++
+  "  addi a0, a0, 1\n" ++
+  "  j .Lecccbh_ret\n" ++
+  ".Lecccbh_success_zero:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lecccbh_ret\n" ++
+  ".Lecccbh_step3:\n" ++
+  "  # Check code_hash == EMPTY_CODE_HASH.\n" ++
+  "  la t0, ecccbh_empty_code_hash\n" ++
+  "  ld t1,  0(t0); ld t2, 72(s10); bne t1, t2, .Lecccbh_step4\n" ++
+  "  ld t1,  8(t0); ld t2, 80(s10); bne t1, t2, .Lecccbh_step4\n" ++
+  "  ld t1, 16(t0); ld t2, 88(s10); bne t1, t2, .Lecccbh_step4\n" ++
+  "  ld t1, 24(t0); ld t2, 96(s10); bne t1, t2, .Lecccbh_step4\n" ++
+  "  # Empty code; output stays zero.\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lecccbh_ret\n" ++
+  ".Lecccbh_step4:\n" ++
+  "  # Step 4: K19 on witness.codes by code_hash.\n" ++
+  "  la t0, ecccbh_codes_ptr; ld a0, 0(t0)\n" ++
+  "  la t0, ecccbh_codes_len; ld a1, 0(t0)\n" ++
+  "  addi a2, s10, 72           # &acct.code_hash\n" ++
+  "  la a3, ecccbh_code_match_offset\n" ++
+  "  la a4, ecccbh_code_match_len\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  beqz a0, .Lecccbh_step5\n" ++
+  "  li a0, 5\n" ++
+  "  j .Lecccbh_ret\n" ++
+  ".Lecccbh_step5:\n" ++
+  "  # code_ptr = codes_ptr + match_offset; code_len = match_len.\n" ++
+  "  la t0, ecccbh_codes_ptr; ld t1, 0(t0)\n" ++
+  "  la t0, ecccbh_code_match_offset; ld t2, 0(t0)\n" ++
+  "  add s11, t1, t2            # reusing s11 for code_ptr\n" ++
+  "  la t0, ecccbh_code_match_len; ld t3, 0(t0)\n" ++
+  "  # Byte-by-byte zero-padded copy.\n" ++
+  "  li t0, 0                   # i\n" ++
+  ".Lecccbh_copy_loop:\n" ++
+  "  beq t0, s5, .Lecccbh_copy_done\n" ++
+  "  add t1, s4, t0             # src_idx = code_offset + i\n" ++
+  "  bgeu t1, t3, .Lecccbh_pad  # past code end -> already zero\n" ++
+  "  add t2, s11, t1\n" ++
+  "  lbu t4, 0(t2)\n" ++
+  "  add t5, s6, t0\n" ++
+  "  sb t4, 0(t5)\n" ++
+  ".Lecccbh_pad:\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  j .Lecccbh_copy_loop\n" ++
+  ".Lecccbh_copy_done:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lecccbh_ret\n" ++
+  ".Lecccbh_too_long:\n" ++
+  "  li a0, 6\n" ++
+  "  j .Lecccbh_ret\n" ++
+  ".Lecccbh_no_match:\n" ++
+  "  li a0, 1\n" ++
+  ".Lecccbh_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp); ld s11, 96(sp)\n" ++
+  "  addi sp, sp, 112\n" ++
+  "  ret"
+
+/-- `zisk_extcodecopy_at_block_hash_address`: probe BuildUnit.
+    Input layout (at INPUT_ADDR):
+      bytes  0.. 8 : (ziskemu metadata)
+      bytes  8..16 : witness_headers_len (u64 LE)
+      bytes 16..24 : witness_state_len   (u64 LE)
+      bytes 24..32 : witness_codes_len   (u64 LE)
+      bytes 32..40 : code_offset (u64 LE)
+      bytes 40..48 : length (u64 LE; must be <= 256)
+      bytes 48..80 : block_hash (32 bytes)
+      bytes 80..100: address (20 bytes)
+      bytes 100..  : witness.headers ++ witness.state ++ witness.codes
+    Output layout:
+      bytes  0.. 8 : status (0..6)
+      bytes  8..16 : effective length (= length on success; 0 otherwise)
+      bytes 16..(16+length) : copied code bytes, zero-padded -/
+def ziskExtcodecopyAtBlockHashAddressPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t4, 0x40000000\n" ++
+  "  ld t5,  8(t4)               # witness_headers_len\n" ++
+  "  ld t6, 16(t4)               # witness_state_len\n" ++
+  "  ld t3, 24(t4)               # witness_codes_len\n" ++
+  "  ld a4, 32(t4)               # code_offset\n" ++
+  "  ld a5, 40(t4)               # length\n" ++
+  "  mv s1, a5                   # stash length for output effective-length write\n" ++
+  "  addi a0, t4, 48             # block_hash ptr\n" ++
+  "  addi a3, t4, 80             # address ptr\n" ++
+  "  addi a1, t4, 100            # witness.headers ptr\n" ++
+  "  mv a2, t5                   # witness.headers len\n" ++
+  "  add a7, a1, t5              # witness.state ptr\n" ++
+  "  la t0, ecccbh_witness_state_len; sd t6, 0(t0)\n" ++
+  "  add t1, a7, t6              # witness.codes ptr\n" ++
+  "  la t0, ecccbh_codes_ptr; sd t1, 0(t0)\n" ++
+  "  la t0, ecccbh_codes_len; sd t3, 0(t0)\n" ++
+  "  li a6, 0xa0010010           # output buffer at OUTPUT + 16\n" ++
+  "  jal ra, extcodecopy_at_block_hash_address\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  bnez a0, .Lecccbh_no_len\n" ++
+  "  sd s1, 8(t0)\n" ++
+  "  j .Lecccbh_pdone\n" ++
+  ".Lecccbh_no_len:\n" ++
+  "  sd zero, 8(t0)\n" ++
+  "  j .Lecccbh_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  mptLookupByKeyFunction ++ "\n" ++
+  accountDecodeFunction ++ "\n" ++
+  accountAtAddressFunction ++ "\n" ++
+  headerExtractStateRootFunction ++ "\n" ++
+  extcodecopyAtBlockHashAddressFunction ++ "\n" ++
+  ".Lecccbh_pdone:"
+
+def ziskExtcodecopyAtBlockHashAddressDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mnk_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_dummy_length:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mbc_offset:\n" ++
+  "  .zero 8\n" ++
+  "mbc_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_lookup_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_lookup_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_lookup_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_child_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_nibble_count:\n" ++
+  "  .zero 8\n" ++
+  "mw_is_leaf:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_nibble_buf:\n" ++
+  "  .zero 128\n" ++
+  ".balign 32\n" ++
+  "mlk_keccak_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "mlk_nibble_buf:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "ad_offset:\n" ++
+  "  .zero 8\n" ++
+  "ad_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aa_value_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aa_value_scratch:\n" ++
+  "  .zero 256\n" ++
+  ".balign 8\n" ++
+  "hesr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hesr_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "ecccbh_witness_state_len:\n" ++
+  "  .zero 8\n" ++
+  "ecccbh_codes_ptr:\n" ++
+  "  .zero 8\n" ++
+  "ecccbh_codes_len:\n" ++
+  "  .zero 8\n" ++
+  "ecccbh_match_offset:\n" ++
+  "  .zero 8\n" ++
+  "ecccbh_match_length:\n" ++
+  "  .zero 8\n" ++
+  "ecccbh_code_match_offset:\n" ++
+  "  .zero 8\n" ++
+  "ecccbh_code_match_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "ecccbh_state_root:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "ecccbh_acct_struct:\n" ++
+  "  .zero 104\n" ++
+  ".balign 32\n" ++
+  "ecccbh_empty_code_hash:\n" ++
+  "  .byte 0xc5, 0xd2, 0x46, 0x01, 0x86, 0xf7, 0x23, 0x3c\n" ++
+  "  .byte 0x92, 0x7e, 0x7d, 0xb2, 0xdc, 0xc7, 0x03, 0xc0\n" ++
+  "  .byte 0xe5, 0x00, 0xb6, 0x53, 0xca, 0x82, 0x27, 0x3b\n" ++
+  "  .byte 0x7b, 0xfa, 0xd8, 0x04, 0x5d, 0x85, 0xa4, 0x70"
+
+def ziskExtcodecopyAtBlockHashAddressProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskExtcodecopyAtBlockHashAddressPrologue
+  dataAsm     := ziskExtcodecopyAtBlockHashAddressDataSection
+}
+
+end EvmAsm.Codegen

--- a/scripts/codegen-zisk-extcodecopy-at-block-hash-address-check.sh
+++ b/scripts/codegen-zisk-extcodecopy-at-block-hash-address-check.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# codegen-zisk-extcodecopy-at-block-hash-address-check.sh
+#
+# Hash-keyed EXTCODECOPY. From (block_hash, address,
+# code_offset, length, witness.headers, witness.state,
+# witness.codes) write `length` bytes of `address`'s deployed
+# code (starting at `code_offset`) into a caller-supplied
+# output buffer, zero-padding past the code's end.
+#
+# Output layout:
+#   bytes  0.. 8 : status (0..6)
+#   bytes  8..16 : effective length (length on success; 0 else)
+#   bytes 16..(16+length) : copied bytes, zero-padded
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_extcodecopy_at_block_hash_address ELF"
+lake exe codegen --program zisk_extcodecopy_at_block_hash_address \
+  --halt linux93 \
+  -o gen-out/zisk_extcodecopy_at_block_hash_address
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <mode> [args...]
+#   contract <code_hex> <code_offset> <length>
+#     Real contract code at ALICE; expected window per spec.
+#   missing <code_offset> <length>
+#     ALICE not in trie; expect (0, length, all-zero).
+#   empty_code <code_offset> <length>
+#     EMPTY_CODE_HASH account; expect (0, length, all-zero).
+#   integrity_violation <code_hex> <code_offset> <length>
+#     code_hash !=EMPTY but witness.codes empty; expect (5, 0).
+#   block_hash_miss <code_hex> <code_offset> <length>
+#     Wrong block_hash; expect (1, 0).
+#   too_long <code_hex> <code_offset>
+#     length = 257 > 256; expect (6, 0).
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_ecccbh_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_ecccbh_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_ecccbh_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def hp_encode(nibbles, is_leaf):
+    flag = 2 if is_leaf else 0
+    if len(nibbles) % 2 == 1:
+        flag |= 1
+        result = bytes([flag * 0x10 + nibbles[0]])
+        nibbles = nibbles[1:]
+    else:
+        result = bytes([flag * 0x10])
+    for i in range(0, len(nibbles), 2):
+        result += bytes([nibbles[i] * 0x10 + nibbles[i+1]])
+    return result
+
+def leaf_node(path_nibbles, value):
+    return rlp.encode([hp_encode(path_nibbles, True), value])
+
+def bytes_to_nibbles(b):
+    out = []
+    for byte in b:
+        out.append(byte >> 4); out.append(byte & 0xf)
+    return out
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0: return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset); offset += len(e)
+    for e in elements: section += e
+    return section
+
+def encode_account(nonce, balance, storage_root, code_hash):
+    return rlp.encode([nonce, balance, storage_root, code_hash])
+
+def encode_header(state_root):
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x55'*32,
+        b'\\x66'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    return rlp.encode(fields)
+
+EMPTY_TRIE = bytes.fromhex('56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421')
+EMPTY_CODE_HASH = bytes.fromhex('c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')
+
+def state_trie_one(addr, acct_rlp):
+    path = bytes_to_nibbles(k256(addr))
+    leaf = leaf_node(path, acct_rlp)
+    return k256(leaf), build_ssz_section([leaf])
+
+def expected_window(code, code_offset, length):
+    out = bytearray(length)
+    for i in range(length):
+        idx = code_offset + i
+        if idx < len(code):
+            out[i] = code[idx]
+    return bytes(out)
+
+mode = '$mode'
+parts = [
+$(for arg in "$@"; do printf '  %s,\n' "\"$arg\""; done)
+]
+ALICE = b'\\xaa' * 20
+BOB = b'\\xbb' * 20
+
+if mode == 'contract':
+    code = bytes.fromhex(parts[0])
+    code_offset = int(parts[1]); length = int(parts[2])
+    acct = encode_account(0, 0, EMPTY_TRIE, k256(code))
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(sr); witness_headers = build_ssz_section([h0])
+    witness_codes = build_ssz_section([code])
+    block_hash = k256(h0); addr = ALICE
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', length) + expected_window(code, code_offset, length)
+elif mode == 'missing':
+    code_offset = int(parts[0]); length = int(parts[1])
+    acct = encode_account(0, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(BOB, acct)
+    h0 = encode_header(sr); witness_headers = build_ssz_section([h0])
+    witness_codes = b''
+    block_hash = k256(h0); addr = ALICE
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', length) + bytes(length)
+elif mode == 'empty_code':
+    code_offset = int(parts[0]); length = int(parts[1])
+    acct = encode_account(0, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(sr); witness_headers = build_ssz_section([h0])
+    witness_codes = b''
+    block_hash = k256(h0); addr = ALICE
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', length) + bytes(length)
+elif mode == 'integrity_violation':
+    code = bytes.fromhex(parts[0])
+    code_offset = int(parts[1]); length = int(parts[2])
+    acct = encode_account(0, 0, EMPTY_TRIE, k256(code))
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(sr); witness_headers = build_ssz_section([h0])
+    witness_codes = b''      # incomplete
+    block_hash = k256(h0); addr = ALICE
+    expected = struct.pack('<Q', 5) + struct.pack('<Q', 0) + bytes(length)
+elif mode == 'block_hash_miss':
+    code = bytes.fromhex(parts[0])
+    code_offset = int(parts[1]); length = int(parts[2])
+    acct = encode_account(0, 0, EMPTY_TRIE, k256(code))
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(sr); witness_headers = build_ssz_section([h0])
+    witness_codes = build_ssz_section([code])
+    block_hash = b'\\xee' * 32; addr = ALICE
+    expected = struct.pack('<Q', 1) + struct.pack('<Q', 0) + bytes(length)
+elif mode == 'too_long':
+    code = bytes.fromhex(parts[0])
+    code_offset = int(parts[1])
+    length = 257
+    acct = encode_account(0, 0, EMPTY_TRIE, k256(code))
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(sr); witness_headers = build_ssz_section([h0])
+    witness_codes = build_ssz_section([code])
+    block_hash = k256(h0); addr = ALICE
+    expected = struct.pack('<Q', 6) + struct.pack('<Q', 0)  # don't compare bytes section past header
+else:
+    raise SystemExit('bad mode: ' + mode)
+
+with open(sys.argv[1], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(witness_headers))
+        + struct.pack('<Q', len(witness_state))
+        + struct.pack('<Q', len(witness_codes))
+        + struct.pack('<Q', code_offset)
+        + struct.pack('<Q', length)
+        + block_hash
+        + addr
+        + witness_headers
+        + witness_state
+        + witness_codes
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_extcodecopy_at_block_hash_address.elf \
+    -i "$in_file" -o "$out_file" -n 6000000 \
+    >"$REPO_ROOT/gen-out/zisk_ecccbh_${name}.emu.log" 2>&1 || true
+
+  local exp_size; exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-36s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-36s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "small_code_full"            contract "60006000016000526000601a526001601aF3" 0 18 || FAILED=1
+run_case "small_code_mid_window"      contract "60006000016000526000601a526001601aF3" 4 8 || FAILED=1
+run_case "zero_pad_past_end"          contract "60006000016000526000601a526001601aF3" 14 16 || FAILED=1
+run_case "offset_far_past_end"        contract "6000" 100 8 || FAILED=1
+run_case "missing_account_zeros"      missing 0 16 || FAILED=1
+run_case "empty_code_zeros"           empty_code 5 32 || FAILED=1
+run_case "integrity_violation"        integrity_violation "6000" 0 4 || FAILED=1
+run_case "block_hash_miss"            block_hash_miss "6000" 0 8 || FAILED=1
+run_case "too_long_257"               too_long "6000" 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: extcodecopy_at_block_hash_address end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Hash-keyed EXTCODECOPY primitive. Mirrors the existing
\`extcodecopy_at_header_state_root\` (under
\`EvmOpcodesExtcodecopy\`) but takes a \`block_hash\` as the
key instead of raw header bytes.

**Completes the EXT* trio at block_hash**:

| opcode | PR | output |
|--------|-----|---------|
| EXTCODESIZE | #7470 | u64 length |
| EXTCODEHASH | #7474 | 32 B EIP-1052 hash |
| EXTCODECOPY | **this** | bytes with zero-pad-past-end |

Writes \`length\` bytes of \`address\`'s deployed code starting
at \`code_offset\` into a caller-supplied output buffer.
Per EXTCODECOPY spec:

\`\`\`
for i in 0..length:
  output[i] = code[code_offset + i] if code_offset + i < len(code) else 0
\`\`\`

Reads past the end of the code are **zero-padded** (NOT
truncated, NOT errored). Missing accounts and empty-code
accounts map to all-zeros output with status 0.

Pipeline (composes K19 + K201 + K28 + K19' + inline byte
copy; no new helpers):

\`\`\`
witness.headers ∋ ?h with keccak(h) == block_hash  [K19]
h -> header_extract_state_root                     [K201]
state_root + address -> account_at_address         [K28]
if absent OR code_hash == EMPTY: output zeros, return 0
else: witness.codes ∋ ?c with keccak(c) == code_hash [K19']
      zero-padded byte copy
\`\`\`

**11 effective inputs vs RISC-V's 8 a-regs**; resolved by
stashing 3 values into global scratch labels in the prologue
(\`ecccbh_witness_state_len\`, \`ecccbh_codes_ptr\`,
\`ecccbh_codes_len\`) — same pattern established by
\`sload_at_block_hash_address\` (#7476).

Status codes:

| status | meaning |
|--------|---------|
| 0 | success (output filled, zero-padded as needed) |
| 1 | block_hash not in witness.headers |
| 2 | matched header parse / state_root size fail |
| 3 | state-trie mpt parse error |
| 4 | account_decode failure |
| 5 | code_hash != EMPTY but not in witness.codes |
| 6 | length > 256 (probe cap) |

## Test plan

- [x] \`lake build codegen\` succeeds.
- [x] \`bash scripts/codegen-zisk-extcodecopy-at-block-hash-address-check.sh\` — 9/9 fixtures pass covering the full spec surface:
  - \`small_code_full\` — whole 18 B code at offset 0
  - \`small_code_mid_window\` — 8 B at offset 4
  - \`zero_pad_past_end\` — 16 B starting near end → tail zeros
  - \`offset_far_past_end\` — offset 100 of 2 B code → all zeros
  - \`missing_account_zeros\` — lookup ALICE, only BOB in trie
  - \`empty_code_zeros\` — EMPTY_CODE_HASH account
  - \`integrity_violation\` (status 5)
  - \`block_hash_miss\` (status 1)
  - \`too_long_257\` (status 6 — probe cap)
- [x] No \`native_decide\` / \`bv_decide\`; aligned LD/SD/LBU/SB only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)