### PR TITLE
feat(divmod): v5 n2 shift=0 epilogue bridge + full shift=0 path

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -217,6 +217,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallablePostSelectedBorrowCa
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFromShape
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LaneShiftNz
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5Lane
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5FullShift0
 import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0PostBridge
 import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0DivLimb
 import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0PreLift

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5BridgeShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5BridgeShift0.lean
@@ -1,0 +1,79 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5BridgeShift0
+
+  The v5 n=2 shift=0 epilogue bridge: the loop result at `denormOff`
+  (`loopN2UnifiedPostV5NoX1` at the raw shift=0 inputs `(b0,b1,0,0)` /
+  `(a2,a3,0,0,0)`, plus `x1`, the a-cells, and the shift cell) reduces to the
+  shift=0 DIV-epilogue precondition (the 16-atom pre of
+  `evm_div_shift0_epilogue_spec_v5_noNop`) plus the untouched loop-state frame
+  `fullDivN2FrameShift0V5`.  Shift=0 / 3-digit / Bool-parameterized counterpart
+  of n1's `loopN1UnifiedPostV5_shift0_to_epiloguePre` and of the shift≠0 bridges
+  `loopN2UnifiedPostV5NoX1_to_fullDivN2DenormPreV5_frame_*`.  Bead
+  `evm-asm-wbc4i.9.2`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5FrameShift0
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopUnifiedPost
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Loop
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+attribute [local irreducible] EvmWord.val256 div128Quot_v5 iterWithDoubleAddback
+  mulsubN4 clzResult
+
+/-- Per-case shift=0 bridge tactic: `delta`-unfold the loop post arm + goal
+    helpers (syntactic — keeps the deep call terms opaque), resolve the branch
+    `ite`s, normalize the j=0 loop-exit addresses, then permute. -/
+local macro "n2s0_bridge_case " hp:ident " | " lip:ident ", " r2:ident ", " r1:ident : tactic =>
+  `(tactic|
+    (delta loopN2UnifiedPostV5NoX1 $lip $r2 $r1 at $hp:ident
+     delta n2Shift0R0 n2Shift0R1 n2Shift0R2 n2Shift0C3 fullDivN2FrameShift0V5 iterN2V5
+     simp (config := { decide := true }) only [ite_true, ite_false] at $hp:ident ⊢
+     rw [loopExitPostN2_j0_eq] at $hp:ident
+     simp (config := { decide := true }) only
+       [n2_ub2_off4064, n2_qa2, n3_ub1_off4064, n3_qa1,
+        se12_32, se12_40, se12_48, se12_56] at $hp:ident ⊢
+     sep_perm $hp))
+
+set_option linter.unusedSimpArgs false in
+/-- Shift=0 epilogue bridge: loop post (raw inputs) + a-cells + shift cell ⊢
+    shift=0 DIV-epilogue pre + `fullDivN2FrameShift0V5`. -/
+theorem loopN2UnifiedPostV5NoX1_shift0_to_epiloguePre
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (h : PartialState)
+    (hp : ((loopN2UnifiedPostV5NoX1 bltu_2 bltu_1 bltu_0 sp base
+              b0 b1 0 0 a2 a3 0 0 0 a1 a0
+              retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal)) **
+            (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+             ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+             ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+             ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+             ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1))) h) :
+    (((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ (sp + signExtend12 4056)) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ (0 : Word)) ** (.x7 ↦ᵣ (sp + signExtend12 4088)) **
+       (.x2 ↦ᵣ (n2Shift0R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1).2.2.2.2.1) **
+       (.x10 ↦ᵣ n2Shift0C3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1) **
+       ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1) **
+       ((sp + signExtend12 4088) ↦ₘ (n2Shift0R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1).1) **
+       ((sp + signExtend12 4080) ↦ₘ (n2Shift0R1 bltu_2 bltu_1 a1 a2 a3 b0 b1).1) **
+       ((sp + signExtend12 4072) ↦ₘ (n2Shift0R2 bltu_2 a2 a3 b0 b1).1) **
+       ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word))) **
+     fullDivN2FrameShift0V5 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1
+       retMem dMem dloMem scratchUn0 scratchMem raVal) h := by
+  cases bltu_2 <;> cases bltu_1 <;> cases bltu_0
+  · n2s0_bridge_case hp | loopIterPostN2Max, r2MMTN2V5, r1MMTN2V5                  -- f f f
+  · n2s0_bridge_case hp | loopIterPostN2CallScratchNoX1, r2MMTN2V5, r1MMTN2V5      -- f f t
+  · n2s0_bridge_case hp | loopIterPostN2Max, r2MTTN2V5, r1MTTN2V5                  -- f t f
+  · n2s0_bridge_case hp | loopIterPostN2CallScratchNoX1, r2MTTN2V5, r1MTTN2V5      -- f t t
+  · n2s0_bridge_case hp | loopIterPostN2Max, r2CCCN2V5, r1TMMN2V5                  -- t f f
+  · n2s0_bridge_case hp | loopIterPostN2CallScratchNoX1, r2CCCN2V5, r1TMMN2V5      -- t f t
+  · n2s0_bridge_case hp | loopIterPostN2Max, r2CCCN2V5, r1CCCN2V5                  -- t t f
+  · n2s0_bridge_case hp | loopIterPostN2CallScratchNoX1, r2CCCN2V5, r1CCCN2V5      -- t t t
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5FrameShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5FrameShift0.lean
@@ -1,0 +1,129 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5FrameShift0
+
+  The shift=0 loop-state frame for the v5 n=2 shift=0 epilogue composition: the
+  cells/registers the shift=0 DIV epilogue does NOT touch, carried around it.
+  Shift=0 counterpart of `fullDivN2FrameNoX1V5` (FullPathN2V5Families), with the
+  three digit iterates at the RAW shift=0 inputs
+    `r2 = iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0`,
+    `r1 = iterN2V5 bltu_1 b0 b1 0 0 a1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1`,
+    `r0 = iterN2V5 bltu_0 b0 b1 0 0 a0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1`,
+  and the dividend window `(a0,a1,a2,a3)` copied verbatim (no normalization).
+
+  The scratch dispatch (cells `sp+3968 … sp+3936`) mirrors
+  `fullDivN2ScratchNoX1V5`/`fullDivN2ScratchMemV5`, but over `(b0,b1,0,0)` and the
+  raw `(a2,a3,0,0,0)` digit-2 window.
+
+  Provides the def + `_unfold` + `pcFree` the forthcoming
+  `loopN2UnifiedPostV5NoX1 → shift0-epilogue-pre` bridge frames around the
+  epilogue.  Bead `evm-asm-wbc4i.9.2`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5Families
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Shift=0 raw digit-2 iterate (`iterN2V5` over the raw divisor `(b0,b1,0,0)`
+    and the digit-2 window `(a2,a3,0,0,0)`). -/
+def n2Shift0R2 (bltu_2 : Bool) (a2 a3 b0 b1 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  iterN2V5 bltu_2 b0 b1 0 0 a2 a3 0 0 0
+
+/-- Shift=0 raw digit-1 iterate, threaded on `n2Shift0R2`. -/
+def n2Shift0R1 (bltu_2 bltu_1 : Bool) (a1 a2 a3 b0 b1 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let r2 := n2Shift0R2 bltu_2 a2 a3 b0 b1
+  iterN2V5 bltu_1 b0 b1 0 0 a1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+
+/-- Shift=0 raw digit-0 iterate, threaded on `n2Shift0R1`. -/
+def n2Shift0R0 (bltu_2 bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let r1 := n2Shift0R1 bltu_2 bltu_1 a1 a2 a3 b0 b1
+  iterN2V5 bltu_0 b0 b1 0 0 a0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+
+/-- Shift=0 digit-0 mulsub borrow `c3` (the loop-exit `x10`). -/
+def n2Shift0C3 (bltu_2 bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 : Word) : Word :=
+  let r1 := n2Shift0R1 bltu_2 bltu_1 a1 a2 a3 b0 b1
+  (mulsubN4
+      (if bltu_0 then divKTrialCallV5QHat r1.2.2.1 r1.2.1 b1 else (signExtend12 4095 : Word))
+      b0 b1 0 0 a0 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+
+/-- Shift=0 loop-state frame (analog of `fullDivN2FrameNoX1V5`), parameterized on
+    the three loop-branch bits.  The cells/regs the shift=0 DIV epilogue does not
+    touch. -/
+@[irreducible] def fullDivN2FrameShift0V5 (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 retMem dMem dloMem scratchUn0 scratchMem raVal : Word) :
+    Assertion :=
+  let r2 := n2Shift0R2 bltu_2 a2 a3 b0 b1
+  let r1 := n2Shift0R1 bltu_2 bltu_1 a1 a2 a3 b0 b1
+  let r0 := n2Shift0R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1
+  -- scratch dispatch (mirror of fullDivN2ScratchMemV5 / fullDivN2ScratchNoX1V5)
+  let scratch2 := if bltu_2 then divKTrialCallV5ScratchOut 0 a3 b1 scratchMem else scratchMem
+  let scratch1 := if bltu_1 then divKTrialCallV5ScratchOut r2.2.2.1 r2.2.1 b1 scratch2 else scratch2
+  let scratchMemF := if bltu_0 then divKTrialCallV5ScratchOut r1.2.2.1 r1.2.1 b1 scratch1 else scratch1
+  let scratchRet2 := if bltu_2 then (base + div128CallRetOff) else retMem
+  let scratchD2 := if bltu_2 then b1 else dMem
+  let scratchDLo2 := if bltu_2 then divKTrialCallV5DLo b1 else dloMem
+  let scratchUn02 := if bltu_2 then divKTrialCallV5Un0 a3 else scratchUn0
+  let scratchRet1 := if bltu_1 then (base + div128CallRetOff) else scratchRet2
+  let scratchD1 := if bltu_1 then b1 else scratchD2
+  let scratchDLo1 := if bltu_1 then divKTrialCallV5DLo b1 else scratchDLo2
+  let scratchUn01 := if bltu_1 then divKTrialCallV5Un0 r2.2.1 else scratchUn02
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 3976) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)) **
+  ((sp + signExtend12 4056) ↦ₘ r0.2.1) ** ((sp + signExtend12 4048) ↦ₘ r0.2.2.1) **
+  ((sp + signExtend12 4040) ↦ₘ r0.2.2.2.1) ** ((sp + signExtend12 4032) ↦ₘ r0.2.2.2.2.1) **
+  ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) ** ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+  ((sp + signExtend12 4008) ↦ₘ r2.2.2.2.2.2) ** ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  (sp + signExtend12 3968 ↦ₘ (if bltu_0 then (base + div128CallRetOff) else scratchRet1)) **
+  (sp + signExtend12 3960 ↦ₘ (if bltu_0 then b1 else scratchD1)) **
+  (sp + signExtend12 3952 ↦ₘ (if bltu_0 then divKTrialCallV5DLo b1 else scratchDLo1)) **
+  (sp + signExtend12 3944 ↦ₘ (if bltu_0 then divKTrialCallV5Un0 r1.2.1 else scratchUn01)) **
+  (sp + signExtend12 3936 ↦ₘ scratchMemF) **
+  (.x1 ↦ᵣ raVal)
+
+theorem fullDivN2FrameShift0V5_unfold {bltu_2 bltu_1 bltu_0 : Bool}
+    {sp base a0 a1 a2 a3 b0 b1 retMem dMem dloMem scratchUn0 scratchMem raVal : Word} :
+    fullDivN2FrameShift0V5 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1
+      retMem dMem dloMem scratchUn0 scratchMem raVal =
+    (let r2 := n2Shift0R2 bltu_2 a2 a3 b0 b1
+     let r1 := n2Shift0R1 bltu_2 bltu_1 a1 a2 a3 b0 b1
+     let r0 := n2Shift0R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1
+     let scratch2 := if bltu_2 then divKTrialCallV5ScratchOut 0 a3 b1 scratchMem else scratchMem
+     let scratch1 := if bltu_1 then divKTrialCallV5ScratchOut r2.2.2.1 r2.2.1 b1 scratch2 else scratch2
+     let scratchMemF := if bltu_0 then divKTrialCallV5ScratchOut r1.2.2.1 r1.2.1 b1 scratch1 else scratch1
+     let scratchRet2 := if bltu_2 then (base + div128CallRetOff) else retMem
+     let scratchD2 := if bltu_2 then b1 else dMem
+     let scratchDLo2 := if bltu_2 then divKTrialCallV5DLo b1 else dloMem
+     let scratchUn02 := if bltu_2 then divKTrialCallV5Un0 a3 else scratchUn0
+     let scratchRet1 := if bltu_1 then (base + div128CallRetOff) else scratchRet2
+     let scratchD1 := if bltu_1 then b1 else scratchD2
+     let scratchDLo1 := if bltu_1 then divKTrialCallV5DLo b1 else scratchDLo2
+     let scratchUn01 := if bltu_1 then divKTrialCallV5Un0 r2.2.1 else scratchUn02
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 3976) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)) **
+     ((sp + signExtend12 4056) ↦ₘ r0.2.1) ** ((sp + signExtend12 4048) ↦ₘ r0.2.2.1) **
+     ((sp + signExtend12 4040) ↦ₘ r0.2.2.2.1) ** ((sp + signExtend12 4032) ↦ₘ r0.2.2.2.2.1) **
+     ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) ** ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+     ((sp + signExtend12 4008) ↦ₘ r2.2.2.2.2.2) ** ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (if bltu_0 then (base + div128CallRetOff) else scratchRet1)) **
+     (sp + signExtend12 3960 ↦ₘ (if bltu_0 then b1 else scratchD1)) **
+     (sp + signExtend12 3952 ↦ₘ (if bltu_0 then divKTrialCallV5DLo b1 else scratchDLo1)) **
+     (sp + signExtend12 3944 ↦ₘ (if bltu_0 then divKTrialCallV5Un0 r1.2.1 else scratchUn01)) **
+     (sp + signExtend12 3936 ↦ₘ scratchMemF) **
+     (.x1 ↦ᵣ raVal)) := by
+  delta fullDivN2FrameShift0V5; rfl
+
+theorem fullDivN2FrameShift0V5_pcFree {bltu_2 bltu_1 bltu_0 : Bool}
+    {sp base a0 a1 a2 a3 b0 b1 retMem dMem dloMem scratchUn0 scratchMem raVal : Word} :
+    (fullDivN2FrameShift0V5 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1
+      retMem dMem dloMem scratchUn0 scratchMem raVal).pcFree := by
+  rw [fullDivN2FrameShift0V5_unfold]
+  cases bltu_2 <;> cases bltu_1 <;> cases bltu_0 <;>
+    simp only [Bool.false_eq_true, if_true, if_false] <;> pcFree
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5FullShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5FullShift0.lean
@@ -1,0 +1,97 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5FullShift0
+
+  Full v5 n=2 DIV code path, shift=0 case (base → nopOff), over `divCode_noNop_v5`:
+  the shift=0 preloop+loop (`evm_div_n2_to_denorm_shift0_from_shape_v5_noNop`,
+  #7472) composed with the shift=0 DIV epilogue
+  (`evm_div_shift0_epilogue_spec_v5_noNop`) via the epilogue bridge
+  (`loopN2UnifiedPostV5NoX1_shift0_to_epiloguePre`).  Shift=0 analog of the n1
+  `evm_div_n1_full_shift0_spec_v5_noNop`.  The quotient digits land in the output
+  slots (`(n2Shift0R0 …).1, (n2Shift0R1 …).1, (n2Shift0R2 …).1, 0`).  Bead
+  `evm-asm-wbc4i.9.2`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5BridgeShift0
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5PathShift0
+import EvmAsm.Evm64.DivMod.Compose.DenormEpilogueV5
+
+namespace EvmAsm.Evm64
+open EvmAsm.Rv64
+
+theorem evm_div_n2_full_shift0_spec_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 v2 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| (0 : Word) ||| 0 ≠ 0) (hb1nz : b1 ≠ 0)
+    (hshift_z : (clzResult b1).1 = 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff) :
+    ∃ bltu_2 bltu_1 bltu_0 : Bool,
+    cpsTripleWithin (((((8 + 21 + 24 + 4) + 13) + 702)) + 12) base (base + nopOff)
+      (divCode_noNop_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        ((sp + signExtend12 3968) ↦ₘ retMem) ** ((sp + signExtend12 3960) ↦ₘ dMem) **
+        ((sp + signExtend12 3952) ↦ₘ dloMem) ** ((sp + signExtend12 3944) ↦ₘ scratchUn0) **
+        ((sp + signExtend12 3936) ↦ₘ scratchMem) ** (.x1 ↦ᵣ raVal)))
+      (((.x12 ↦ᵣ (sp + 32)) **
+         (.x5 ↦ᵣ (n2Shift0R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1).1) **
+         (.x6 ↦ᵣ (n2Shift0R1 bltu_2 bltu_1 a1 a2 a3 b0 b1).1) **
+         (.x7 ↦ᵣ (n2Shift0R2 bltu_2 a2 a3 b0 b1).1) **
+         (.x2 ↦ᵣ (n2Shift0R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1).2.2.2.2.1) **
+         (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ (0 : Word)) **
+         ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1) **
+         ((sp + signExtend12 4088) ↦ₘ (n2Shift0R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1).1) **
+         ((sp + signExtend12 4080) ↦ₘ (n2Shift0R1 bltu_2 bltu_1 a1 a2 a3 b0 b1).1) **
+         ((sp + signExtend12 4072) ↦ₘ (n2Shift0R2 bltu_2 a2 a3 b0 b1).1) **
+         ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+         ((sp + 32) ↦ₘ (n2Shift0R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1).1) **
+         ((sp + 40) ↦ₘ (n2Shift0R1 bltu_2 bltu_1 a1 a2 a3 b0 b1).1) **
+         ((sp + 48) ↦ₘ (n2Shift0R2 bltu_2 a2 a3 b0 b1).1) **
+         ((sp + 56) ↦ₘ (0 : Word))) **
+        fullDivN2FrameShift0V5 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1
+          retMem dMem dloMem scratchUn0 scratchMem raVal) := by
+  obtain ⟨bltu_2, bltu_1, bltu_0, hA⟩ := evm_div_n2_to_denorm_shift0_from_shape_v5_noNop
+    sp base a0 a1 a2 a3 b0 b1 v2 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratchUn0 scratchMem raVal hbnz hb1nz hshift_z halign
+  refine ⟨bltu_2, bltu_1, bltu_0, ?_⟩
+  have hB := evm_div_shift0_epilogue_spec_v5_noNop sp base
+    (0 : Word) (0 : Word) (0 : Word) (0 : Word) (clzResult b1).1
+    (n2Shift0R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1).2.2.2.2.1
+    (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    (n2Shift0C3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1)
+    (n2Shift0R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1).1
+    (n2Shift0R1 bltu_2 bltu_1 a1 a2 a3 b0 b1).1
+    (n2Shift0R2 bltu_2 a2 a3 b0 b1).1
+    (0 : Word)
+    b0 b1 0 0 hshift_z
+  have hBf := cpsTripleWithin_frameR
+    (fullDivN2FrameShift0V5 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1
+      retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (by exact fullDivN2FrameShift0V5_pcFree) hB
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      have hbr := loopN2UnifiedPostV5NoX1_shift0_to_epiloguePre bltu_2 bltu_1 bltu_0
+        sp base a0 a1 a2 a3 b0 b1 retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      xperm_hyp hbr) hA hBf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hFull
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- `fullDivN2FrameShift0V5` (+ `n2Shift0R0/R1/R2/C3` threaded-digit helpers): the loop-state frame the shift=0 DIV epilogue does not touch, over the raw divisor `(b0,b1,0,0)` and the raw digit-2 window `(a2,a3,0,0,0)`; scratch dispatch mirrors `fullDivN2ScratchNoX1V5`/`fullDivN2ScratchMemV5`.
- `loopN2UnifiedPostV5NoX1_shift0_to_epiloguePre`: the 8-case epilogue bridge from the n=2 loop result at `denormOff` to the 16-atom shift=0 DIV-epilogue precondition (`evm_div_shift0_epilogue_spec_v5_noNop`) plus the `fullDivN2FrameShift0V5` frame. `delta`-based (keeps the deep `div128Quot_v5`/`val256`/`iterWithDoubleAddback` terms opaque so `sep_perm` does not blow up).
- `evm_div_n2_full_shift0_spec_v5_noNop`: the full shift=0 code path `base → nopOff` over `divCode_noNop_v5`, composing the shift=0 preloop+loop (`evm_div_n2_to_denorm_shift0_from_shape_v5_noNop`) with the shift=0 epilogue via the bridge.

Mirrors the n1 shift=0 assembly (`FullPathN1V5{FrameShift0,BridgeShift0,FullShift0}`). All three theorems are kernel-clean (axioms: `propext`/`Classical.choice`/`Quot.sound` only — no `native_decide`). Full build green; file-size, unimported, and sorry/heartbeat gates all pass.

Remaining n2 shift=0 lane work (next): the `hdiv` connection (threaded `n2Shift0R*` digits → `(EvmWord.div a b).getLimbN` via `iterN2V5_collapse` + from-shape window-valid facts) and the lane combiner discharging `shift0lane` in `evm_div_n2_lane_v5`.

Refs #61. Bead: evm-asm-wbc4i.9.2.3.

Authored by @pirapira; implemented by Claude Code