### PR TITLE
feat(stateless): nonce_at_block_number_address primitive

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -99,6 +99,7 @@ import EvmAsm.Codegen.Programs.StateRootChainWalkBack
 import EvmAsm.Codegen.Programs.BlockNumberAtBlockHash
 import EvmAsm.Codegen.Programs.StateSlotAtBlockNumber
 import EvmAsm.Codegen.Programs.StateAccountAtBlockNumber
+import EvmAsm.Codegen.Programs.NonceAtBlockNumber
 import EvmAsm.Codegen.Programs.BlockHashAtBlockNumber
 import EvmAsm.Codegen.Programs.CodeAtBlockNumber
 import EvmAsm.Codegen.Programs.BlockHashAtStateRoot
@@ -485,6 +486,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_extcodehash_at_block_hash_address" => some ziskExtcodehashAtBlockHashAddressProbeUnit
   | "zisk_state_slot_at_block_number_address" => some ziskStateSlotAtBlockNumberAddressProbeUnit
   | "zisk_state_account_at_block_number_address" => some ziskStateAccountAtBlockNumberAddressProbeUnit
+  | "zisk_nonce_at_block_number_address" => some ziskNonceAtBlockNumberAddressProbeUnit
   | "zisk_block_hash_at_block_number" => some ziskBlockHashAtBlockNumberProbeUnit
   | "zisk_code_at_block_number_address" => some ziskCodeAtBlockNumberAddressProbeUnit
   | "zisk_block_hash_at_state_root" => some ziskBlockHashAtStateRootProbeUnit
@@ -710,6 +712,7 @@ def knownProgramNames : List String :=
    "zisk_extcodehash_at_block_hash_address",
    "zisk_state_slot_at_block_number_address",
    "zisk_state_account_at_block_number_address",
+   "zisk_nonce_at_block_number_address",
    "zisk_block_hash_at_block_number",
    "zisk_code_at_block_number_address",
    "zisk_block_hash_at_state_root",

--- a/EvmAsm/Codegen/Programs/NonceAtBlockNumber.lean
+++ b/EvmAsm/Codegen/Programs/NonceAtBlockNumber.lean
@@ -1,0 +1,327 @@
+/-
+  EvmAsm.Codegen.Programs.NonceAtBlockNumber
+
+  Number-keyed historical nonce extractor. Per-field
+  sibling of BalanceAtBlockNumber (offset +8, 32 B BE),
+  extracting offset +0 (8 B u64 LE) instead.
+
+  No proofs yet -- codegen `String` defs only.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.Mpt
+import EvmAsm.Codegen.Programs.HashBridge
+import EvmAsm.Codegen.Programs.Tx
+import EvmAsm.Codegen.Programs.HeaderU64
+import EvmAsm.Codegen.Programs.HeaderFields
+import EvmAsm.Codegen.Programs.State
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Program
+
+/-! ## nonce_at_block_number_address
+
+    Number-keyed historical nonce extractor.
+
+    Pipeline:
+      witness.headers ∋ ?h with h.block.number == target  [K233 scan]
+      h -> header_extract_state_root                      [K201]
+      state_root + address -> account                     [K28]
+      struct.nonce (offset +0, 8 B u64 LE) -> u64 out
+
+    Distinct from the BalanceAtBlockNumber sibling only in:
+      * output field offset (+0 vs +8)
+      * output width (8 B vs 32 B)
+      * no BE conversion needed (nonce is stored as u64 LE
+        in the canonical struct)
+
+    Per-field × per-key matrix progress:
+
+      | field         | by_hash | by_number | by_state_root |
+      |---------------|---------|-----------|---------------|
+      | balance       | #7326   | (PR 7479) | (existing)    |
+      | nonce         | (mer.)  | THIS      | (existing)    |
+      | code_hash     | #7320   | (TODO)    | (existing)    |
+      | storage_root  | #7314   | (TODO)    | (existing)    |
+
+    Use cases:
+      * Replay protection: caller has a signed tx with a
+        claimed nonce N at block B; verify directly against
+        the chain's actual nonce at that height.
+      * Account-activity audit: derive (block_number, nonce)
+        time series for forensic analysis.
+      * Light-client semantic membership ("had Alice
+        transacted by block 12345?": nonce > 0).
+
+    Calling convention (7 args):
+      a0 (input)  : target_block_number (u64, by value)
+      a1 (input)  : witness.headers ptr
+      a2 (input)  : witness.headers len
+      a3 (input)  : address ptr (20 bytes)
+      a4 (input)  : witness.state ptr
+      a5 (input)  : witness.state len
+      a6 (input)  : u64 nonce out ptr
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success (nonce written; may be 0)
+        1 = no header with target block_number
+        2 = K233 parse failure during scan
+        3 = matched header state_root extraction failure
+        4 = account absent in state trie (0 written -- spec)
+        5 = state-trie mpt parse error
+        6 = account RLP decode failure
+-/
+def nonceAtBlockNumberAddressFunction : String :=
+  "nonce_at_block_number_address:\n" ++
+  "  addi sp, sp, -96\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp); sd s10, 88(sp)\n" ++
+  "  mv s0, a0                  # target block_number\n" ++
+  "  mv s1, a1                  # headers ptr\n" ++
+  "  mv s2, a2                  # headers len\n" ++
+  "  mv s3, a3                  # address ptr\n" ++
+  "  mv s4, a4                  # witness.state ptr\n" ++
+  "  mv s5, a5                  # witness.state len\n" ++
+  "  mv s6, a6                  # nonce out (u64)\n" ++
+  "  sd zero, 0(s6)\n" ++
+  "  li s9, 0                   # saw_parse_fail\n" ++
+  "  beqz s2, .Lnbn_miss\n" ++
+  "  lwu t0, 0(s1)\n" ++
+  "  srli s7, t0, 2             # N\n" ++
+  "  li s8, 0                   # i\n" ++
+  ".Lnbn_loop:\n" ++
+  "  beq s8, s7, .Lnbn_finish\n" ++
+  "  slli t0, s8, 2\n" ++
+  "  add t1, s1, t0\n" ++
+  "  lwu t2, 0(t1)\n" ++
+  "  add s10, s1, t2            # header start\n" ++
+  "  addi t3, s8, 1\n" ++
+  "  beq t3, s7, .Lnbn_use_end\n" ++
+  "  slli t3, t3, 2\n" ++
+  "  add t3, s1, t3\n" ++
+  "  lwu t4, 0(t3)\n" ++
+  "  add t4, s1, t4\n" ++
+  "  j .Lnbn_have_end\n" ++
+  ".Lnbn_use_end:\n" ++
+  "  add t4, s1, s2\n" ++
+  ".Lnbn_have_end:\n" ++
+  "  sub t5, t4, s10\n" ++
+  "  mv a0, s10\n" ++
+  "  mv a1, t5\n" ++
+  "  la a2, nbn_number_scratch\n" ++
+  "  jal ra, header_extract_number\n" ++
+  "  bnez a0, .Lnbn_parse_fail\n" ++
+  "  la t0, nbn_number_scratch\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  beq t1, s0, .Lnbn_hit\n" ++
+  "  j .Lnbn_step\n" ++
+  ".Lnbn_parse_fail:\n" ++
+  "  li s9, 1\n" ++
+  ".Lnbn_step:\n" ++
+  "  addi s8, s8, 1\n" ++
+  "  j .Lnbn_loop\n" ++
+  ".Lnbn_hit:\n" ++
+  "  slli t0, s8, 2\n" ++
+  "  add t1, s1, t0\n" ++
+  "  lwu t2, 0(t1)\n" ++
+  "  addi t3, s8, 1\n" ++
+  "  beq t3, s7, .Lnbn_re_use_end\n" ++
+  "  slli t3, t3, 2\n" ++
+  "  add t3, s1, t3\n" ++
+  "  lwu t4, 0(t3)\n" ++
+  "  j .Lnbn_re_have_end\n" ++
+  ".Lnbn_re_use_end:\n" ++
+  "  mv t4, s2\n" ++
+  ".Lnbn_re_have_end:\n" ++
+  "  sub t5, t4, t2\n" ++
+  "  mv a0, s10\n" ++
+  "  mv a1, t5\n" ++
+  "  la a2, nbn_state_root\n" ++
+  "  jal ra, header_extract_state_root\n" ++
+  "  beqz a0, .Lnbn_walk\n" ++
+  "  li a0, 3\n" ++
+  "  j .Lnbn_ret\n" ++
+  ".Lnbn_walk:\n" ++
+  "  mv a0, s3\n" ++
+  "  li a1, 20\n" ++
+  "  la a2, nbn_state_root\n" ++
+  "  mv a3, s4\n" ++
+  "  mv a4, s5\n" ++
+  "  la a5, nbn_walked_struct\n" ++
+  "  jal ra, account_at_address\n" ++
+  "  beqz a0, .Lnbn_present\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Lnbn_absent\n" ++
+  "  addi a0, a0, 3             # 2 -> 5, 3 -> 6\n" ++
+  "  j .Lnbn_ret\n" ++
+  ".Lnbn_present:\n" ++
+  "  # Copy nonce field (offset +0, 8 B u64 LE) to output.\n" ++
+  "  la t0, nbn_walked_struct\n" ++
+  "  ld t2, 0(t0)\n" ++
+  "  sd t2, 0(s6)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lnbn_ret\n" ++
+  ".Lnbn_absent:\n" ++
+  "  # buffer already zero (spec default for nonce).\n" ++
+  "  li a0, 4\n" ++
+  "  j .Lnbn_ret\n" ++
+  ".Lnbn_finish:\n" ++
+  "  bnez s9, .Lnbn_parse_status\n" ++
+  ".Lnbn_miss:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lnbn_ret\n" ++
+  ".Lnbn_parse_status:\n" ++
+  "  li a0, 2\n" ++
+  ".Lnbn_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp)\n" ++
+  "  addi sp, sp, 96\n" ++
+  "  ret"
+
+/-- `zisk_nonce_at_block_number_address`: probe BuildUnit.
+    Input layout (at INPUT_ADDR):
+      bytes  0.. 8 : (ziskemu metadata)
+      bytes  8..16 : witness_headers_len (u64 LE)
+      bytes 16..24 : witness_state_len (u64 LE)
+      bytes 24..32 : target_block_number (u64 LE)
+      bytes 32..52 : address (20 bytes)
+      bytes 52..   : witness.headers ++ witness.state
+    Output layout (16 bytes):
+      bytes  0.. 8 : status (0..6)
+      bytes  8..16 : nonce (u64 LE; 0 on absent) -/
+def ziskNonceAtBlockNumberAddressPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t4, 0x40000000\n" ++
+  "  ld a2, 8(t4)                # witness_headers_len\n" ++
+  "  ld a5, 16(t4)               # witness_state_len\n" ++
+  "  ld a0, 24(t4)               # target_block_number\n" ++
+  "  addi a3, t4, 32             # address ptr\n" ++
+  "  addi a1, t4, 52             # witness.headers ptr\n" ++
+  "  add  a4, a1, a2             # witness.state ptr\n" ++
+  "  li a6, 0xa0010008           # nonce out\n" ++
+  "  jal ra, nonce_at_block_number_address\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lnbn_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  mptLookupByKeyFunction ++ "\n" ++
+  accountDecodeFunction ++ "\n" ++
+  accountAtAddressFunction ++ "\n" ++
+  headerExtractNumberFunction ++ "\n" ++
+  headerExtractStateRootFunction ++ "\n" ++
+  nonceAtBlockNumberAddressFunction ++ "\n" ++
+  ".Lnbn_pdone:"
+
+def ziskNonceAtBlockNumberAddressDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mnk_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_dummy_length:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mbc_offset:\n" ++
+  "  .zero 8\n" ++
+  "mbc_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_lookup_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_lookup_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_lookup_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_child_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_nibble_count:\n" ++
+  "  .zero 8\n" ++
+  "mw_is_leaf:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_nibble_buf:\n" ++
+  "  .zero 128\n" ++
+  ".balign 32\n" ++
+  "mlk_keccak_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "mlk_nibble_buf:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "ad_offset:\n" ++
+  "  .zero 8\n" ++
+  "ad_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aa_value_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aa_value_scratch:\n" ++
+  "  .zero 256\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "hesr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hesr_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "nbn_number_scratch:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "nbn_state_root:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "nbn_walked_struct:\n" ++
+  "  .zero 104"
+
+def ziskNonceAtBlockNumberAddressProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskNonceAtBlockNumberAddressPrologue
+  dataAsm     := ziskNonceAtBlockNumberAddressDataSection
+}
+
+end EvmAsm.Codegen

--- a/scripts/codegen-zisk-nonce-at-block-number-address-check.sh
+++ b/scripts/codegen-zisk-nonce-at-block-number-address-check.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# codegen-zisk-nonce-at-block-number-address-check.sh
+#
+# Number-keyed historical nonce extractor.
+#
+# Output (16 bytes):
+#   bytes  0.. 8 : status (0..6)
+#   bytes  8..16 : nonce (u64 LE; 0 on absent)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_nonce_at_block_number_address ELF"
+lake exe codegen --program zisk_nonce_at_block_number_address \
+  --halt linux93 \
+  -o gen-out/zisk_nonce_at_block_number_address
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+  local target="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_nbn_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_nbn_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_nbn_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def hp_encode(nibbles, is_leaf):
+    flag = 2 if is_leaf else 0
+    if len(nibbles) % 2 == 1:
+        flag |= 1
+        result = bytes([flag * 0x10 + nibbles[0]])
+        nibbles = nibbles[1:]
+    else:
+        result = bytes([flag * 0x10])
+    for i in range(0, len(nibbles), 2):
+        result += bytes([nibbles[i] * 0x10 + nibbles[i+1]])
+    return result
+
+def leaf_node(path_nibbles, value):
+    return rlp.encode([hp_encode(path_nibbles, True), value])
+
+def bytes_to_nibbles(b):
+    out = []
+    for byte in b:
+        out.append(byte >> 4); out.append(byte & 0xf)
+    return out
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0: return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset); offset += len(e)
+    for e in elements: section += e
+    return section
+
+def encode_account(nonce, balance, storage_root, code_hash):
+    return rlp.encode([nonce, balance, storage_root, code_hash])
+
+def encode_header(number_val, state_root):
+    if number_val == 0:
+        number_field = b''
+    else:
+        nbytes = (number_val.bit_length() + 7) // 8
+        number_field = number_val.to_bytes(nbytes, 'big')
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x55'*32,
+        b'\\x66'*32, b'\\x00'*256, b'', number_field, b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    return rlp.encode(fields)
+
+EMPTY_TRIE = bytes.fromhex('56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421')
+EMPTY_CODE_HASH = bytes.fromhex('c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')
+
+def state_trie_one(addr, acct_rlp):
+    path = bytes_to_nibbles(k256(addr))
+    leaf = leaf_node(path, acct_rlp)
+    return k256(leaf), build_ssz_section([leaf])
+
+mode = '$mode'
+target = int('$target')
+ALICE = b'\\xaa' * 20
+BOB = b'\\xbb' * 20
+
+if mode == 'nonce_zero_present':
+    acct = encode_account(0, 999, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(100, b'\\xee'*32)
+    h1 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0, h1])
+    addr = ALICE
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', 0)
+elif mode == 'nonce_seven':
+    acct = encode_account(7, 999, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0])
+    addr = ALICE
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', 7)
+elif mode == 'nonce_two_bytes':
+    n = 0x1234
+    acct = encode_account(n, 999, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0])
+    addr = ALICE
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', n)
+elif mode == 'nonce_max_u64':
+    n = (1 << 64) - 1
+    acct = encode_account(n, 999, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0])
+    addr = ALICE
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', n)
+elif mode == 'absent_account':
+    acct = encode_account(42, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(BOB, acct)
+    h0 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0])
+    addr = ALICE
+    expected = struct.pack('<Q', 4) + struct.pack('<Q', 0)
+elif mode == 'number_miss':
+    acct = encode_account(42, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(100, sr)
+    witness_headers = build_ssz_section([h0])
+    addr = ALICE
+    expected = struct.pack('<Q', 1) + struct.pack('<Q', 0)
+else:
+    raise SystemExit('bad mode')
+
+with open(sys.argv[1], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(witness_headers))
+        + struct.pack('<Q', len(witness_state))
+        + struct.pack('<Q', target)
+        + addr
+        + witness_headers
+        + witness_state
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_nonce_at_block_number_address.elf \
+    -i "$in_file" -o "$out_file" -n 6000000 \
+    >"$REPO_ROOT/gen-out/zisk_nbn_${name}.emu.log" 2>&1 || true
+
+  local exp_size
+  exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-40s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-40s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "nonce_zero_present_at_101"      nonce_zero_present 101 || FAILED=1
+run_case "nonce_seven"                    nonce_seven 101 || FAILED=1
+run_case "nonce_two_bytes_0x1234"         nonce_two_bytes 101 || FAILED=1
+run_case "nonce_max_u64"                  nonce_max_u64 101 || FAILED=1
+run_case "absent_account_default_zero"    absent_account 101 || FAILED=1
+run_case "number_not_in_section"          number_miss 999 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: nonce_at_block_number_address end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Number-keyed historical nonce extractor. Per-field sibling
of \`balance_at_block_number_address\` (PR #7479); extracts
the struct.nonce field at offset +0 (8 B u64 LE) instead
of balance at +8 (32 B BE).

Pipeline (composes K233 scan + K201 + K28; no new helpers):

\`\`\`
witness.headers ∋ ?h with h.block.number == target  [K233]
h -> header_extract_state_root                      [K201]
state_root + address -> account                     [K28]
struct.nonce (offset +0, 8 B u64 LE) -> u64 out
\`\`\`

Continues filling the per-field × per-key matrix:

| field         | by_hash | by_number | by_state_root |
|---------------|---------|-----------|---------------|
| balance       | #7326   | (#7479)   | (existing)    |
| nonce         | (mer.)  | **this**  | (existing)    |
| code_hash     | #7320   | (TODO)    | (existing)    |
| storage_root  | #7314   | (TODO)    | (existing)    |

Use cases:
- Replay protection oracle: caller has a signed tx with
  claimed nonce N at block B; verify the chain's actual
  historical nonce.
- Account-activity audit: \`(block_number, nonce)\` timeline
  for forensic analysis.
- Light-client semantic membership ("had Alice transacted
  by block 12345?" — nonce > 0).

Status codes:

| status | meaning |
|--------|---------|
| 0 | success (nonce u64 LE written; may be 0) |
| 1 | no header with target block_number |
| 2 | K233 parse failure during scan |
| 3 | matched header state_root extraction failure |
| 4 | account absent in state trie (0 written — spec) |
| 5 | state-trie mpt parse error |
| 6 | account RLP decode failure |

## Test plan

- [x] \`lake build codegen\` succeeds.
- [x] \`bash scripts/codegen-zisk-nonce-at-block-number-address-check.sh\` — 6/6 fixtures pass:
  - \`nonce_zero_present_at_101\` (positional routing, second-of-two headers)
  - \`nonce_seven\`, \`nonce_two_bytes_0x1234\`, \`nonce_max_u64\` (covers varint width spectrum — ensures RLP leading-byte handling and u64 LE conversion work across byte widths)
  - \`absent_account_default_zero\`
  - \`number_not_in_section\`
- [x] No \`native_decide\` / \`bv_decide\`; aligned LD/SD only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)