### PR TITLE
feat(divmod): v5 n3 iteration families (iterN3V5 + fullDivN3R{1,0}V5 + C3V5)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -150,6 +150,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopMaxCall
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5Families
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopSource
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopFinalPost

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -151,6 +151,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopMaxCall
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5Families
+import EvmAsm.Evm64.DivMod.Spec.N3V5QuotientWord
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopSource
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopFinalPost

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5Families.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5Families.lean
@@ -1,0 +1,121 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5Families
+
+  N3 V5 iteration families: `iterN3V5` (the capped-trial per-iteration dispatch)
+  and the two-digit `fullDivN3R1V5` / `fullDivN3R0V5` / `fullDivN3C3V5`.  These are
+  the n=3 analogs of `FullPathN2V5Families` (`iterN2V5`, `fullDivN2R{2,1,0}V5`,
+  `fullDivN2C3V5`) and of the v4 n=3 families (`fullDivN3R{1,0}V4`,
+  `fullDivN3C3V4`), with the trial quotient supplied by the **capped** v5 callable
+  `divKTrialCallV5QHat` (over the 3-limb normalized divisor's top limb `v2`)
+  instead of the v4 `div128Quot`.  The n=3 loop runs two outer iterations
+  (digits `r1`, `r0`).  Foundational layer for the v5 n=3 DIV lane.  Bead
+  `evm-asm-wbc4i.9.3` (children 9.3.1/9.3.2/9.3.3).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCallV5
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- ============================================================================
+-- V5 per-iteration computation (capped trial)
+-- ============================================================================
+
+/-- Unified per-iteration computation with double addback for n=3, **v5**: the
+    trial quotient is the capped callable `divKTrialCallV5QHat u3 u2 v2` (the
+    n=3 analog of `iterN2V5`, and the capped counterpart of `iterN3`/`iterN3Call`). -/
+@[irreducible]
+def iterN3V5 (bltu : Bool) (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  if bltu then
+    iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  else
+    iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+
+theorem iterN3V5_unfold {bltu : Bool} {v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word} :
+    iterN3V5 bltu v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      (if bltu then
+        iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      else
+        iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  delta iterN3V5; rfl
+
+-- ============================================================================
+-- V5 two-digit iteration results
+-- ============================================================================
+
+/-- Digit-1 (first outer iteration) v5 result, over the normalized
+    divisor/window. -/
+@[irreducible]
+def fullDivN3R1V5 (bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let u := fullDivN3NormU a0 a1 a2 a3 b2
+  iterN3V5 bltu_1 v.1 v.2.1 v.2.2.1 v.2.2.2
+    u.2.1 u.2.2.1 u.2.2.2.1 u.2.2.2.2 (0 : Word)
+
+/-- Digit-0 (second outer iteration) v5 result, threaded on `fullDivN3R1V5`. -/
+@[irreducible]
+def fullDivN3R0V5 (bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let u := fullDivN3NormU a0 a1 a2 a3 b2
+  let r1 := fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  iterN3V5 bltu_0 v.1 v.2.1 v.2.2.1 v.2.2.2 u.1
+    r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+
+/-- Digit-0 mulsub borrow `c3` (the loop-exit `x10`), v5. -/
+@[irreducible]
+def fullDivN3C3V5 (bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word :=
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let u := fullDivN3NormU a0 a1 a2 a3 b2
+  let r1 := fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  if bltu_0 then
+    (mulsubN4 (divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v.2.2.1)
+      v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+  else
+    (mulsubN4 (signExtend12 4095 : Word)
+      v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+
+-- ============================================================================
+-- Dispatch (`_eq`) lemmas
+-- ============================================================================
+
+theorem fullDivN3R1V5_eq (bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3 =
+      (let v := fullDivN3NormV b0 b1 b2 b3
+       let u := fullDivN3NormU a0 a1 a2 a3 b2
+       iterN3V5 bltu_1 v.1 v.2.1 v.2.2.1 v.2.2.2
+         u.2.1 u.2.2.1 u.2.2.2.1 u.2.2.2.2 (0 : Word)) := by
+  delta fullDivN3R1V5; rfl
+
+theorem fullDivN3R0V5_eq (bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 =
+      (let v := fullDivN3NormV b0 b1 b2 b3
+       let u := fullDivN3NormU a0 a1 a2 a3 b2
+       let r1 := fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+       iterN3V5 bltu_0 v.1 v.2.1 v.2.2.1 v.2.2.2 u.1
+         r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) := by
+  delta fullDivN3R0V5; rfl
+
+theorem fullDivN3R1V5_true (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN3R1V5 true a0 a1 a2 a3 b0 b1 b2 b3 =
+      (let v := fullDivN3NormV b0 b1 b2 b3
+       let u := fullDivN3NormU a0 a1 a2 a3 b2
+       iterWithDoubleAddback (divKTrialCallV5QHat u.2.2.2.2 u.2.2.2.1 v.2.2.1)
+         v.1 v.2.1 v.2.2.1 v.2.2.2 u.2.1 u.2.2.1 u.2.2.2.1 u.2.2.2.2 (0 : Word)) := by
+  rw [fullDivN3R1V5_eq, iterN3V5_unfold]; simp
+
+theorem fullDivN3R1V5_false (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN3R1V5 false a0 a1 a2 a3 b0 b1 b2 b3 =
+      (let v := fullDivN3NormV b0 b1 b2 b3
+       let u := fullDivN3NormU a0 a1 a2 a3 b2
+       iterN3Max v.1 v.2.1 v.2.2.1 v.2.2.2 u.2.1 u.2.2.1 u.2.2.2.1 u.2.2.2.2 (0 : Word)) := by
+  rw [fullDivN3R1V5_eq, iterN3V5_unfold]; simp
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3V5QuotientWord.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V5QuotientWord.lean
@@ -1,0 +1,50 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3V5QuotientWord
+
+  N3 V5 quotient word: packs the two v5 n=3 digit results
+  (`fullDivN3R0V5`, `fullDivN3R1V5`) into an `EvmWord` (limbs 2,3 zero), plus the
+  `_hdivs_of_word_eq` projector deriving the per-limb `EvmWord.div a b` facts from
+  the word equality.  N=3 analog of `fullDivN3QuotientWordV4` /
+  `fullDivN2QuotientWordV5`.  Foundational for the v5 n=3 DIV lane's post bridge.
+  Bead `evm-asm-wbc4i.9.3`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5Families
+import EvmAsm.Evm64.EvmWordArith.DivLimbBridge
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The v5 n=3 quotient, packed into an `EvmWord`: limb 0 = digit-0 result,
+    limb 1 = digit-1 result, limbs 2,3 = 0. -/
+def fullDivN3QuotientWordV5 (bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : EvmWord :=
+  EvmWord.fromLimbs (fun i : Fin 4 =>
+    match i with
+    | 0 => (fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+    | 1 => (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+    | 2 => (0 : Word)
+    | 3 => (0 : Word))
+
+/-- If `fullDivN3QuotientWordV5 ... = EvmWord.div a b`, then each limb of
+    `EvmWord.div a b` matches the corresponding v5 `fullDivN3R{0,1}V5` result
+    (and limbs 2, 3 are zero). -/
+theorem fullDivN3V5_hdivs_of_word_eq
+    (bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hdiv : fullDivN3QuotientWordV5 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b) :
+    (EvmWord.div a b).getLimbN 0 =
+      (fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 1 =
+      (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 2 = (0 : Word) ∧
+    (EvmWord.div a b).getLimbN 3 = (0 : Word) := by
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [← hdiv]; delta fullDivN3QuotientWordV5; exact EvmWord.getLimbN_fromLimbs_0
+  · rw [← hdiv]; delta fullDivN3QuotientWordV5; exact EvmWord.getLimbN_fromLimbs_1
+  · rw [← hdiv]; delta fullDivN3QuotientWordV5; exact EvmWord.getLimbN_fromLimbs_2
+  · rw [← hdiv]; delta fullDivN3QuotientWordV5; exact EvmWord.getLimbN_fromLimbs_3
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
Foundational layer for the v5 n=3 DIV lane (bead `evm-asm-wbc4i.9.3`) — the first of the ~8-PR v5 n=3 chain (mirroring the v5 n=2 chain that the now-complete n=1/n=2 lanes were built on).

The n=3 analogs of `FullPathN2V5Families`, with the trial quotient supplied by the **capped** v5 callable `divKTrialCallV5QHat` (over the 3-limb normalized divisor's top limb `v2`) instead of the v4 `div128Quot`. The n=3 loop runs two outer iterations, so there are two digits:

- `iterN3V5` — capped per-iteration dispatch (`if bltu then iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2) … else iterN3Max …`); + `iterN3V5_unfold`.
- `fullDivN3R1V5` / `fullDivN3R0V5` — the two threaded digit results over `fullDivN3NormV` / `fullDivN3NormU`; + `_eq` / `_true` / `_false` dispatch lemmas.
- `fullDivN3C3V5` — the digit-0 mulsub borrow.

Pure defs + `delta;rfl`/`simp` lemmas (axioms: `propext`, `Quot.sound`). Full build green; file-size, unimported, sorry/heartbeat gates pass. Wired into `DivMod.lean`.

Refs #61. Bead: evm-asm-wbc4i.9.3.

Authored by @pirapira; implemented by Claude Code