### PR TITLE
feat(divmod): v5 n3 per-digit trial bounds (hq_ge + hq_over)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -231,6 +231,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5R10Conservation
 import EvmAsm.Evm64.DivMod.Spec.N2V5ThreeStep
 import EvmAsm.Evm64.DivMod.Spec.N2V5RemainderLt
 import EvmAsm.Evm64.DivMod.Spec.N3V5RemainderLt
+import EvmAsm.Evm64.DivMod.Spec.N3V5DigitStepIter
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormScaled
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLaneShape

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -230,6 +230,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5R2Conservation
 import EvmAsm.Evm64.DivMod.Spec.N2V5R10Conservation
 import EvmAsm.Evm64.DivMod.Spec.N2V5ThreeStep
 import EvmAsm.Evm64.DivMod.Spec.N2V5RemainderLt
+import EvmAsm.Evm64.DivMod.Spec.N3V5RemainderLt
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormScaled
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLaneShape

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5Families.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5Families.lean
@@ -1,0 +1,121 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5Families
+
+  N3 V5 iteration families: `iterN3V5` (the capped-trial per-iteration dispatch)
+  and the two-digit `fullDivN3R1V5` / `fullDivN3R0V5` / `fullDivN3C3V5`.  These are
+  the n=3 analogs of `FullPathN2V5Families` (`iterN2V5`, `fullDivN2R{2,1,0}V5`,
+  `fullDivN2C3V5`) and of the v4 n=3 families (`fullDivN3R{1,0}V4`,
+  `fullDivN3C3V4`), with the trial quotient supplied by the **capped** v5 callable
+  `divKTrialCallV5QHat` (over the 3-limb normalized divisor's top limb `v2`)
+  instead of the v4 `div128Quot`.  The n=3 loop runs two outer iterations
+  (digits `r1`, `r0`).  Foundational layer for the v5 n=3 DIV lane.  Bead
+  `evm-asm-wbc4i.9.3` (children 9.3.1/9.3.2/9.3.3).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCallV5
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- ============================================================================
+-- V5 per-iteration computation (capped trial)
+-- ============================================================================
+
+/-- Unified per-iteration computation with double addback for n=3, **v5**: the
+    trial quotient is the capped callable `divKTrialCallV5QHat u3 u2 v2` (the
+    n=3 analog of `iterN2V5`, and the capped counterpart of `iterN3`/`iterN3Call`). -/
+@[irreducible]
+def iterN3V5 (bltu : Bool) (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  if bltu then
+    iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  else
+    iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+
+theorem iterN3V5_unfold {bltu : Bool} {v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word} :
+    iterN3V5 bltu v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      (if bltu then
+        iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      else
+        iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  delta iterN3V5; rfl
+
+-- ============================================================================
+-- V5 two-digit iteration results
+-- ============================================================================
+
+/-- Digit-1 (first outer iteration) v5 result, over the normalized
+    divisor/window. -/
+@[irreducible]
+def fullDivN3R1V5 (bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let u := fullDivN3NormU a0 a1 a2 a3 b2
+  iterN3V5 bltu_1 v.1 v.2.1 v.2.2.1 v.2.2.2
+    u.2.1 u.2.2.1 u.2.2.2.1 u.2.2.2.2 (0 : Word)
+
+/-- Digit-0 (second outer iteration) v5 result, threaded on `fullDivN3R1V5`. -/
+@[irreducible]
+def fullDivN3R0V5 (bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let u := fullDivN3NormU a0 a1 a2 a3 b2
+  let r1 := fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  iterN3V5 bltu_0 v.1 v.2.1 v.2.2.1 v.2.2.2 u.1
+    r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+
+/-- Digit-0 mulsub borrow `c3` (the loop-exit `x10`), v5. -/
+@[irreducible]
+def fullDivN3C3V5 (bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word :=
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let u := fullDivN3NormU a0 a1 a2 a3 b2
+  let r1 := fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  if bltu_0 then
+    (mulsubN4 (divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v.2.2.1)
+      v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+  else
+    (mulsubN4 (signExtend12 4095 : Word)
+      v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+
+-- ============================================================================
+-- Dispatch (`_eq`) lemmas
+-- ============================================================================
+
+theorem fullDivN3R1V5_eq (bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3 =
+      (let v := fullDivN3NormV b0 b1 b2 b3
+       let u := fullDivN3NormU a0 a1 a2 a3 b2
+       iterN3V5 bltu_1 v.1 v.2.1 v.2.2.1 v.2.2.2
+         u.2.1 u.2.2.1 u.2.2.2.1 u.2.2.2.2 (0 : Word)) := by
+  delta fullDivN3R1V5; rfl
+
+theorem fullDivN3R0V5_eq (bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 =
+      (let v := fullDivN3NormV b0 b1 b2 b3
+       let u := fullDivN3NormU a0 a1 a2 a3 b2
+       let r1 := fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+       iterN3V5 bltu_0 v.1 v.2.1 v.2.2.1 v.2.2.2 u.1
+         r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) := by
+  delta fullDivN3R0V5; rfl
+
+theorem fullDivN3R1V5_true (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN3R1V5 true a0 a1 a2 a3 b0 b1 b2 b3 =
+      (let v := fullDivN3NormV b0 b1 b2 b3
+       let u := fullDivN3NormU a0 a1 a2 a3 b2
+       iterWithDoubleAddback (divKTrialCallV5QHat u.2.2.2.2 u.2.2.2.1 v.2.2.1)
+         v.1 v.2.1 v.2.2.1 v.2.2.2 u.2.1 u.2.2.1 u.2.2.2.1 u.2.2.2.2 (0 : Word)) := by
+  rw [fullDivN3R1V5_eq, iterN3V5_unfold]; simp
+
+theorem fullDivN3R1V5_false (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN3R1V5 false a0 a1 a2 a3 b0 b1 b2 b3 =
+      (let v := fullDivN3NormV b0 b1 b2 b3
+       let u := fullDivN3NormU a0 a1 a2 a3 b2
+       iterN3Max v.1 v.2.1 v.2.2.1 v.2.2.2 u.2.1 u.2.2.1 u.2.2.2.1 u.2.2.2.2 (0 : Word)) := by
+  rw [fullDivN3R1V5_eq, iterN3V5_unfold]; simp
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3V5DigitStepIter.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V5DigitStepIter.lean
@@ -1,0 +1,171 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3V5DigitStepIter
+
+  The v5 n=3 per-digit Euclidean step, stated on the **irreducible** `iterN3V5`
+  (call path).  `iterN3V5 true …` computes the v5 trial INTERNALLY (its args are
+  plain `Word`s), so `set out := iterN3V5 true …` is kernel-cheap — unlike
+  `iterWithDoubleAddback (divKTrialCallV5QHat …)`, whose exposed deep trial
+  ARGUMENT triggers the kernel term-size wall.  The per-digit conservation /
+  remainder-lt / collapse (proved on `iterWithDoubleAddback` in `N3V5RemainderLt`)
+  are first wrapped onto `iterN3V5` (via the trivial `iterN3V5_true_eq` bridge),
+  then combined by `set` + `rw` + `ring` with `iterN3V5` projections as atoms.
+  Per-digit input to the v5 n=3 quotient telescope.  Bead `evm-asm-wbc4i.9.3`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N3V5RemainderLt
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5Families
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- `iterN3V5 true …` is the call-path double-addback over the v5 trial. -/
+theorem iterN3V5_true_eq (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    iterN3V5 true v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  rw [iterN3V5_unfold]; simp
+
+/-- Per-digit conservation, wrapped onto `iterN3V5 true` (`uTop = 0`, clean —
+    matches n2's `iterN2V5_true_conservation_from_shape` pattern: simplify the
+    `uTop` term away on the deep form so the per-digit step needs no `simp at`). -/
+theorem iterN3V5_call_conservation (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63) (hcall : u3.toNat < v2.toNat) :
+    val256 u0 u1 u2 u3 =
+      (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).1.toNat * val256 v0 v1 v2 0 +
+        val256
+          (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.1
+          (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1
+          (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1
+          (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.1 +
+        (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.2.toNat * 2 ^ 256 := by
+  rw [iterN3V5_true_eq]
+  have h := n3_trial_call_val256_conservation v0 v1 v2 u0 u1 u2 u3 0 hv2 hcall
+  have h0 : (0 : Word).toNat = 0 := rfl
+  simpa [h0] using h
+
+/-- Per-digit remainder bound, wrapped onto `iterN3V5 true` (`uTop = 0`). -/
+theorem iterN3V5_call_remainder_lt (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63) (hcall : u3.toNat < v2.toNat) :
+    val256
+        (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.1
+        (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1
+        (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1
+        (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.1 +
+      (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.2.toNat * 2 ^ 256 <
+    val256 v0 v1 v2 0 := by
+  rw [iterN3V5_true_eq]
+  exact n3_trial_call_remainder_lt v0 v1 v2 u0 u1 u2 u3 hv2 hcall
+
+/-- Per-digit remainder collapse, wrapped onto `iterN3V5 true` (`uTop = 0`). -/
+theorem iterN3V5_call_collapse (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63) (hcall : u3.toNat < v2.toNat) :
+    (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.1 = 0 ∧
+    (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.2 = 0 := by
+  rw [iterN3V5_true_eq]
+  exact n3_trial_call_collapse v0 v1 v2 u0 u1 u2 u3 hv2 hcall
+
+/-- **v5 n=3 per-digit Euclidean step (call path), on `iterN3V5`.**  Combines the
+    wrapped conservation / collapse / remainder-lt with `iterN3V5` projections as
+    `ring` atoms — kernel-cheap (no deep trial argument). -/
+theorem iterN3V5_call_step (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63) (hcall : u3.toNat < v2.toNat) :
+    val256 u0 u1 u2 u3 =
+        (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).1.toNat * val256 v0 v1 v2 0 +
+        ((iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.1.toNat +
+          2 ^ 64 * (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1.toNat +
+          2 ^ 128 * (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1.toNat) ∧
+      (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.1.toNat +
+          2 ^ 64 * (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1.toNat +
+          2 ^ 128 * (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1.toNat <
+        val256 v0 v1 v2 0 := by
+  obtain ⟨hc3z, hcz⟩ := iterN3V5_call_collapse v0 v1 v2 u0 u1 u2 u3 hv2 hcall
+  have hconv := iterN3V5_call_conservation v0 v1 v2 u0 u1 u2 u3 hv2 hcall
+  have hlt := iterN3V5_call_remainder_lt v0 v1 v2 u0 u1 u2 u3 hv2 hcall
+  set out := iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0 with hout
+  have h0 : (0 : Word).toNat = 0 := rfl
+  have hcollapse : val256 out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1 =
+      out.2.1.toNat + 2 ^ 64 * out.2.2.1.toNat + 2 ^ 128 * out.2.2.2.1.toNat := by
+    rw [hc3z]; simp only [EvmWord.val256, h0]; ring
+  refine ⟨?_, ?_⟩
+  · rw [hconv, hcollapse, hcz, h0]; ring
+  · rw [hcollapse] at hlt; rw [hcz, h0] at hlt; simpa using hlt
+
+/-! ### Max branch (`bltu = false`, trial `= signExtend12 4095 = 2^64-1`)
+
+Mirrors the call path.  `iterN3V5 false …` unfolds (via `iterN3Max`) to the
+double-addback over the capped trial; the per-digit conservation / remainder-lt /
+collapse (max path) carry an extra window-validity hypothesis
+`val256 window < 2^64 · val256 v` (the running-remainder invariant in the
+telescope). -/
+
+/-- `iterN3V5 false …` is the max-path double-addback over the capped trial. -/
+theorem iterN3V5_false_eq (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    iterN3V5 false v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  unfold iterN3V5 iterN3Max; simp only [Bool.false_eq_true, if_false]
+
+/-- Per-digit conservation, wrapped onto `iterN3V5 false` (clean, `uTop = 0`). -/
+theorem iterN3V5_max_conservation (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63) (hmax : ¬ BitVec.ult u3 v2) :
+    val256 u0 u1 u2 u3 =
+      (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).1.toNat * val256 v0 v1 v2 0 +
+        val256
+          (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.1
+          (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1
+          (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1
+          (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.1 +
+        (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.2.toNat * 2 ^ 256 := by
+  rw [iterN3V5_false_eq]
+  have h := n3_trial_max_val256_conservation v0 v1 v2 u0 u1 u2 u3 0 hv2 hmax
+  have h0 : (0 : Word).toNat = 0 := rfl
+  simpa [h0] using h
+
+/-- Per-digit remainder bound, wrapped onto `iterN3V5 false` (`uTop = 0`). -/
+theorem iterN3V5_max_remainder_lt (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63) (hmax : ¬ BitVec.ult u3 v2)
+    (hvalid : val256 u0 u1 u2 u3 < 2 ^ 64 * val256 v0 v1 v2 0) :
+    val256
+        (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.1
+        (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1
+        (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1
+        (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.1 +
+      (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.2.toNat * 2 ^ 256 <
+    val256 v0 v1 v2 0 := by
+  rw [iterN3V5_false_eq]
+  exact n3_trial_max_remainder_lt v0 v1 v2 u0 u1 u2 u3 hv2 hmax hvalid
+
+/-- Per-digit remainder collapse, wrapped onto `iterN3V5 false` (`uTop = 0`). -/
+theorem iterN3V5_max_collapse (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63) (hmax : ¬ BitVec.ult u3 v2)
+    (hvalid : val256 u0 u1 u2 u3 < 2 ^ 64 * val256 v0 v1 v2 0) :
+    (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.1 = 0 ∧
+    (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.2 = 0 := by
+  rw [iterN3V5_false_eq]
+  exact n3_trial_max_collapse v0 v1 v2 u0 u1 u2 u3 hv2 hmax hvalid
+
+/-- **v5 n=3 per-digit Euclidean step (max path), on `iterN3V5`.** -/
+theorem iterN3V5_max_step (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63) (hmax : ¬ BitVec.ult u3 v2)
+    (hvalid : val256 u0 u1 u2 u3 < 2 ^ 64 * val256 v0 v1 v2 0) :
+    val256 u0 u1 u2 u3 =
+        (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).1.toNat * val256 v0 v1 v2 0 +
+        ((iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.1.toNat +
+          2 ^ 64 * (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1.toNat +
+          2 ^ 128 * (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1.toNat) ∧
+      (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.1.toNat +
+          2 ^ 64 * (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1.toNat +
+          2 ^ 128 * (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1.toNat <
+        val256 v0 v1 v2 0 := by
+  obtain ⟨hc3z, hcz⟩ := iterN3V5_max_collapse v0 v1 v2 u0 u1 u2 u3 hv2 hmax hvalid
+  have hconv := iterN3V5_max_conservation v0 v1 v2 u0 u1 u2 u3 hv2 hmax
+  have hlt := iterN3V5_max_remainder_lt v0 v1 v2 u0 u1 u2 u3 hv2 hmax hvalid
+  set out := iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0 with hout
+  have h0 : (0 : Word).toNat = 0 := rfl
+  have hcollapse : val256 out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1 =
+      out.2.1.toNat + 2 ^ 64 * out.2.2.1.toNat + 2 ^ 128 * out.2.2.2.1.toNat := by
+    rw [hc3z]; simp only [EvmWord.val256, h0]; ring
+  refine ⟨?_, ?_⟩
+  · rw [hconv, hcollapse, hcz, h0]; ring
+  · rw [hcollapse] at hlt; rw [hcz, h0] at hlt; simpa using hlt
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3V5RemainderLt.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V5RemainderLt.lean
@@ -1,0 +1,65 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3V5RemainderLt
+
+  The v5 n=3 per-digit val256 conservation (call path).  For a 3-limb divisor
+  `(v0,v1,v2,0)` (top limb `v2`, normalized `v2 ≥ 2^63`) in the call regime
+  (`u3 < v2`), the digit's `iterWithDoubleAddback` over the v5 trial
+  `divKTrialCallV5QHat u3 u2 v2` satisfies the Euclidean conservation
+
+    `val256 u0 u1 u2 u3 + uTop·2^256
+       = q·val256 v0 v1 v2 0 + val256(rem) + carry·2^256`.
+
+  The n=3 analog of `iterN2V5_true_conservation_from_shape`, stated directly on
+  `iterWithDoubleAddback` (the form `iterN3V5 true` unfolds to via
+  `iterN3V5_unfold` + `if_pos`).  Reuses the position-independent
+  `iterWithDoubleAddback_val256_conservation_of_branch_bounds` with the n=3 trial
+  overestimate `n3_window_div_le_val256_div_plus_two_v5` (KnuthAFloorWindowN3) and
+  `mulsubN4_c3_eq_one_v3_zero` (the `v3 = 0` borrow fact).  Per-digit step input
+  for the v5 n=3 quotient telescope.  Bead `evm-asm-wbc4i.9.3`.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.KnuthAFloorWindowN3
+import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- **v5 n=3 per-digit val256 conservation (call path).**  `q = divKTrialCallV5QHat
+    u3 u2 v2` is the v5 trial; the digit's double-addback iterate conserves value
+    against the 3-limb divisor `(v0,v1,v2,0)`. -/
+theorem n3_trial_call_val256_conservation
+    (v0 v1 v2 u0 u1 u2 u3 uTop : Word)
+    (hv2 : v2.toNat ≥ 2^63)
+    (hcall : u3.toNat < v2.toNat) :
+    val256 u0 u1 u2 u3 + uTop.toNat * 2 ^ 256 =
+      (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 0 u0 u1 u2 u3 uTop).1.toNat * val256 v0 v1 v2 0 +
+        val256
+          (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 0 u0 u1 u2 u3 uTop).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 0 u0 u1 u2 u3 uTop).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 0 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 0 u0 u1 u2 u3 uTop).2.2.2.2.1 +
+        (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 0 u0 u1 u2 u3 uTop).2.2.2.2.2.toNat * 2 ^ 256 := by
+  have hbnz : v0 ||| v1 ||| v2 ||| 0 ≠ 0 := by
+    intro h
+    have hv2z : v2 = 0 := (BitVec.or_eq_zero_iff.mp (BitVec.or_eq_zero_iff.mp h).1).2
+    rw [hv2z] at hv2; simp at hv2
+  set q := divKTrialCallV5QHat u3 u2 v2 with hq
+  have hq_over : q.toNat ≤ val256 u0 u1 u2 u3 / val256 v0 v1 v2 0 + 2 := by
+    rw [hq]; exact n3_window_div_le_val256_div_plus_two_v5 v0 v1 v2 u0 u1 u2 u3 hv2 hcall
+  have hc3 : BitVec.ult uTop (mulsubN4 q v0 v1 v2 0 u0 u1 u2 u3).2.2.2.2 →
+      (mulsubN4 q v0 v1 v2 0 u0 u1 u2 u3).2.2.2.2 = 1 := by
+    intro hb
+    apply mulsubN4_c3_eq_one_v3_zero
+    intro hc3z
+    rw [hc3z] at hb
+    exact absurd hb (by simp [BitVec.ult])
+  exact iterWithDoubleAddback_val256_conservation_of_branch_bounds
+    q v0 v1 v2 0 u0 u1 u2 u3 uTop hbnz hq_over hc3
+    (fun hb _ => q_pos_of_mulsub_borrow q v0 v1 v2 0 u0 u1 u2 u3 (hc3 hb))
+    (fun hb hcz => q_ge_two_of_mulsub_borrow_and_addback_carry_zero
+      q v0 v1 v2 0 u0 u1 u2 u3 (hc3 hb) hcz)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3V5RemainderLt.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V5RemainderLt.lean
@@ -20,6 +20,7 @@
 
 import EvmAsm.Evm64.EvmWordArith.KnuthAFloorWindowN3
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
+import EvmAsm.Evm64.EvmWordArith.DivN3MaxOverestimate
 
 namespace EvmAsm.Evm64
 
@@ -49,6 +50,44 @@ theorem n3_trial_call_val256_conservation
   set q := divKTrialCallV5QHat u3 u2 v2 with hq
   have hq_over : q.toNat ≤ val256 u0 u1 u2 u3 / val256 v0 v1 v2 0 + 2 := by
     rw [hq]; exact n3_window_div_le_val256_div_plus_two_v5 v0 v1 v2 u0 u1 u2 u3 hv2 hcall
+  have hc3 : BitVec.ult uTop (mulsubN4 q v0 v1 v2 0 u0 u1 u2 u3).2.2.2.2 →
+      (mulsubN4 q v0 v1 v2 0 u0 u1 u2 u3).2.2.2.2 = 1 := by
+    intro hb
+    apply mulsubN4_c3_eq_one_v3_zero
+    intro hc3z
+    rw [hc3z] at hb
+    exact absurd hb (by simp [BitVec.ult])
+  exact iterWithDoubleAddback_val256_conservation_of_branch_bounds
+    q v0 v1 v2 0 u0 u1 u2 u3 uTop hbnz hq_over hc3
+    (fun hb _ => q_pos_of_mulsub_borrow q v0 v1 v2 0 u0 u1 u2 u3 (hc3 hb))
+    (fun hb hcz => q_ge_two_of_mulsub_borrow_and_addback_carry_zero
+      q v0 v1 v2 0 u0 u1 u2 u3 (hc3 hb) hcz)
+
+/-- **v5 n=3 per-digit val256 conservation (max path).**  When the trial would
+    overflow (`¬ u3 < v2`), the digit uses the cap trial `signExtend12 4095`; the
+    double-addback iterate still conserves value against `(v0,v1,v2,0)`.  This is
+    the form `iterN3Max` / `iterN3V5 false` unfold to. -/
+theorem n3_trial_max_val256_conservation
+    (v0 v1 v2 u0 u1 u2 u3 uTop : Word)
+    (hv2 : v2.toNat ≥ 2^63)
+    (hmax : ¬ BitVec.ult u3 v2) :
+    val256 u0 u1 u2 u3 + uTop.toNat * 2 ^ 256 =
+      (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12))
+          v0 v1 v2 0 u0 u1 u2 u3 uTop).1.toNat * val256 v0 v1 v2 0 +
+        val256
+          (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 uTop).2.1
+          (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 uTop).2.2.1
+          (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 uTop).2.2.2.2.1 +
+        (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12))
+          v0 v1 v2 0 u0 u1 u2 u3 uTop).2.2.2.2.2.toNat * 2 ^ 256 := by
+  have hbnz : v0 ||| v1 ||| v2 ||| 0 ≠ 0 := by
+    intro h
+    have hv2z : v2 = 0 := (BitVec.or_eq_zero_iff.mp (BitVec.or_eq_zero_iff.mp h).1).2
+    rw [hv2z] at hv2; simp at hv2
+  set q := (signExtend12 (4095 : BitVec 12) : Word) with hq
+  have hq_over : q.toNat ≤ val256 u0 u1 u2 u3 / val256 v0 v1 v2 0 + 2 := by
+    rw [hq]; exact max_trial_local_overestimate_n3_of_not_ult v0 v1 v2 u0 u1 u2 u3 hv2 hmax
   have hc3 : BitVec.ult uTop (mulsubN4 q v0 v1 v2 0 u0 u1 u2 u3).2.2.2.2 →
       (mulsubN4 q v0 v1 v2 0 u0 u1 u2 u3).2.2.2.2 = 1 := by
     intro hb

--- a/EvmAsm/Evm64/DivMod/Spec/N3V5RemainderLt.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V5RemainderLt.lean
@@ -20,6 +20,7 @@
 
 import EvmAsm.Evm64.EvmWordArith.KnuthAFloorWindowN3
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
+import EvmAsm.Evm64.EvmWordArith.DivN4RemainderLt
 import EvmAsm.Evm64.EvmWordArith.DivN3MaxOverestimate
 
 namespace EvmAsm.Evm64
@@ -62,6 +63,70 @@ theorem n3_trial_call_val256_conservation
     (fun hb _ => q_pos_of_mulsub_borrow q v0 v1 v2 0 u0 u1 u2 u3 (hc3 hb))
     (fun hb hcz => q_ge_two_of_mulsub_borrow_and_addback_carry_zero
       q v0 v1 v2 0 u0 u1 u2 u3 (hc3 hb) hcz)
+
+/-- The n=3 divisor value `(v0,v1,v2,0)` is a 3-limb number, hence `< 2^192`. -/
+theorem n3_val256_v_lt_pow192 (v0 v1 v2 : Word) : val256 v0 v1 v2 0 < 2 ^ 192 := by
+  have h0 : (0 : Word).toNat = 0 := rfl
+  have := v0.isLt; have := v1.isLt; have := v2.isLt
+  simp only [EvmWord.val256, h0]; omega
+
+/-- **v5 n=3 per-digit remainder bound (call path, `uTop = 0`).**  The
+    double-addback remainder is below the 3-limb divisor. -/
+theorem n3_trial_call_remainder_lt
+    (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63)
+    (hcall : u3.toNat < v2.toNat) :
+    val256
+        (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 0 u0 u1 u2 u3 0).2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.1 +
+      (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.2.toNat
+        * 2 ^ 256 <
+    val256 v0 v1 v2 0 := by
+  have hbnz : v0 ||| v1 ||| v2 ||| 0 ≠ 0 := by
+    intro h
+    have hv2z : v2 = 0 := (BitVec.or_eq_zero_iff.mp (BitVec.or_eq_zero_iff.mp h).1).2
+    rw [hv2z] at hv2; simp at hv2
+  have hv_pos : 0 < val256 v0 v1 v2 0 := by
+    have h0 : (0 : Word).toNat = 0 := rfl
+    simp only [EvmWord.val256, h0]; omega
+  have hq_over := n3_window_div_le_val256_div_plus_two_v5 v0 v1 v2 u0 u1 u2 u3 hv2 hcall
+  have hge := n3_window_val256_div_le_trial_v5 v0 v1 v2 u0 u1 u2 u3 hv2 hcall
+  have hq_ge : val256 u0 u1 u2 u3 + (0 : Word).toNat * 2 ^ 256 <
+      ((divKTrialCallV5QHat u3 u2 v2).toNat + 1) * val256 v0 v1 v2 0 := by
+    have h0 : (0 : Word).toNat = 0 := rfl
+    rw [h0, Nat.zero_mul, Nat.add_zero]
+    exact (Nat.div_lt_iff_lt_mul hv_pos).mp (by omega)
+  have hc3 : BitVec.ult (0 : Word)
+        (mulsubN4 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 0 u0 u1 u2 u3).2.2.2.2 →
+      (mulsubN4 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 0 u0 u1 u2 u3).2.2.2.2 = 1 := by
+    intro hb
+    apply mulsubN4_c3_eq_one_v3_zero
+    intro hc3z
+    rw [hc3z] at hb
+    exact absurd hb (by decide)
+  exact iterWithDoubleAddback_remainder_lt_of_plus_two
+    (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 0 u0 u1 u2 u3 0 hbnz hc3 hq_over hq_ge
+
+/-- **v5 n=3 per-digit remainder collapse (call path).**  The remainder fits in
+    three limbs: the top limb (`rem3`) and the overflow carry are zero. -/
+theorem n3_trial_call_collapse
+    (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63)
+    (hcall : u3.toNat < v2.toNat) :
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.1 = 0 ∧
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.2 = 0 := by
+  have hlt := n3_trial_call_remainder_lt v0 v1 v2 u0 u1 u2 u3 hv2 hcall
+  have hv192 := n3_val256_v_lt_pow192 v0 v1 v2
+  set out := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 0 u0 u1 u2 u3 0 with hout
+  have key : val256 out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1 +
+      out.2.2.2.2.2.toNat * 2 ^ 256 < 2 ^ 192 := by omega
+  refine ⟨?_, ?_⟩
+  · have h : out.2.2.2.2.1.toNat = 0 := by simp only [EvmWord.val256] at key; omega
+    exact BitVec.eq_of_toNat_eq (by rw [h]; rfl)
+  · have h : out.2.2.2.2.2.toNat = 0 := by simp only [EvmWord.val256] at key; omega
+    exact BitVec.eq_of_toNat_eq (by rw [h]; rfl)
 
 /-- **v5 n=3 per-digit val256 conservation (max path).**  When the trial would
     overflow (`¬ u3 < v2`), the digit uses the cap trial `signExtend12 4095`; the

--- a/EvmAsm/Evm64/DivMod/Spec/N3V5RemainderLt.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V5RemainderLt.lean
@@ -166,4 +166,59 @@ theorem n3_trial_max_val256_conservation
     (fun hb hcz => q_ge_two_of_mulsub_borrow_and_addback_carry_zero
       q v0 v1 v2 0 u0 u1 u2 u3 (hc3 hb) hcz)
 
+/-- **v5 n=3 per-digit remainder bound (max path, `uTop = 0`).**  The cap-trial
+    double-addback remainder is below the 3-limb divisor, given the window-validity
+    invariant `val256 u < 2^64 · val256 v`. -/
+theorem n3_trial_max_remainder_lt
+    (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63)
+    (hmax : ¬ BitVec.ult u3 v2)
+    (hvalid : val256 u0 u1 u2 u3 < 2 ^ 64 * val256 v0 v1 v2 0) :
+    val256
+        (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 0).2.1
+        (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1
+        (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1
+        (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.1 +
+      (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.2.toNat
+        * 2 ^ 256 <
+    val256 v0 v1 v2 0 := by
+  have hbnz : v0 ||| v1 ||| v2 ||| 0 ≠ 0 := by
+    intro h
+    have hv2z : v2 = 0 := (BitVec.or_eq_zero_iff.mp (BitVec.or_eq_zero_iff.mp h).1).2
+    rw [hv2z] at hv2; simp at hv2
+  set q : Word := signExtend12 (4095 : BitVec 12) with hq
+  have hq_over := max_trial_local_overestimate_n3_of_not_ult v0 v1 v2 u0 u1 u2 u3 hv2 hmax
+  have hqsucc : q.toNat + 1 = 2 ^ 64 := by rw [hq, signExtend12_4095_toNat]; omega
+  have hq_ge : val256 u0 u1 u2 u3 + (0 : Word).toNat * 2 ^ 256 <
+      (q.toNat + 1) * val256 v0 v1 v2 0 := by
+    have h0 : (0 : Word).toNat = 0 := rfl
+    rw [h0, hqsucc, Nat.zero_mul, Nat.add_zero]; exact hvalid
+  have hc3 : BitVec.ult (0 : Word) (mulsubN4 q v0 v1 v2 0 u0 u1 u2 u3).2.2.2.2 →
+      (mulsubN4 q v0 v1 v2 0 u0 u1 u2 u3).2.2.2.2 = 1 := by
+    intro hb
+    apply mulsubN4_c3_eq_one_v3_zero
+    intro hz; rw [hz] at hb; exact absurd hb (by decide)
+  exact iterWithDoubleAddback_remainder_lt_of_plus_two
+    q v0 v1 v2 0 u0 u1 u2 u3 0 hbnz hc3 hq_over hq_ge
+
+/-- **v5 n=3 per-digit remainder collapse (max path).**  Top limb (`rem3`) and
+    overflow carry are zero. -/
+theorem n3_trial_max_collapse
+    (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63)
+    (hmax : ¬ BitVec.ult u3 v2)
+    (hvalid : val256 u0 u1 u2 u3 < 2 ^ 64 * val256 v0 v1 v2 0) :
+    (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.1 = 0 ∧
+    (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.2 = 0 := by
+  have hlt := n3_trial_max_remainder_lt v0 v1 v2 u0 u1 u2 u3 hv2 hmax hvalid
+  have hv192 := n3_val256_v_lt_pow192 v0 v1 v2
+  set out := iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 0 with hout
+  have key : val256 out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1 +
+      out.2.2.2.2.2.toNat * 2 ^ 256 < 2 ^ 192 := by omega
+  refine ⟨?_, ?_⟩
+  · have h : out.2.2.2.2.1.toNat = 0 := by simp only [EvmWord.val256] at key; omega
+    exact BitVec.eq_of_toNat_eq (by rw [h]; rfl)
+  · have h : out.2.2.2.2.2.toNat = 0 := by simp only [EvmWord.val256] at key; omega
+    exact BitVec.eq_of_toNat_eq (by rw [h]; rfl)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -117,4 +117,5 @@ import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Q0ddBound
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.UpperBound
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.LowerBound
 import EvmAsm.Evm64.EvmWordArith.KnuthAFloorWindow
+import EvmAsm.Evm64.EvmWordArith.KnuthAFloorWindowN3
 import EvmAsm.Evm64.EvmWordArith.Div128CallSkipCloseV4

--- a/EvmAsm/Evm64/EvmWordArith/KnuthAFloorWindowN3.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthAFloorWindowN3.lean
@@ -1,0 +1,85 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.KnuthAFloorWindowN3
+
+  The v5 n=3 per-digit trial bounds — the n=3 analogs of the n=2 lemmas in
+  `KnuthAFloorWindow`.  For a 3-limb divisor `(v0,v1,v2,0)` (top limb `v2`,
+  normalized `v2 ≥ 2^63`) and a 4-limb window `(u0,u1,u2,u3)` in the call regime
+  (`u3 < v2`):
+
+  - `n3_window_val256_div_le_trial_v5` (no-underestimate, `hq_ge`):
+    `val256 u / val256 v ≤ divKTrialCallV5QHat u3 u2 v2`.
+  - `n3_window_div_le_val256_div_plus_two_v5` (overestimate, `hq_over`):
+    `divKTrialCallV5QHat u3 u2 v2 ≤ val256 u / val256 v + 2`.
+
+  Both reuse the position-independent cores `knuth_a_floor_window_le` /
+  `knuth_theorem_b_abstract`, instantiated at the n=3 place values
+  (`K = 2^128`, divisor scaled by `2^64` to embed the 3-limb divisor into the
+  4-limb top-digit frame), and the v5 trial floor lemmas
+  (`div128Quot_v5_ge_q_true`, `divKTrialCallV5QHat_eq_floor`).  These are the
+  `hq_ge`/`hq_over` inputs to `iterWithDoubleAddback`'s conservation/remainder
+  bounds for the v5 n=3 lane.  Bead `evm-asm-wbc4i.9.3`.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.KnuthAFloorWindow
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- **v5 n=3 per-digit no-underestimate.** The full 4-limb window quotient is at
+    most the v5 trial quotient (top two window limbs `u3,u2` over the divisor's
+    top limb `v2`).  `hq_ge` ingredient for the n=3 per-digit remainder bound. -/
+theorem n3_window_val256_div_le_trial_v5
+    (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63)
+    (hcall : u3.toNat < v2.toNat) :
+    val256 u0 u1 u2 u3 / val256 v0 v1 v2 0 ≤
+      (divKTrialCallV5QHat u3 u2 v2).toNat := by
+  rw [divKTrialCallV5QHat_eq_div128Quot_v5]
+  have h0 : (0 : Word).toNat = 0 := rfl
+  have hVtop : 0 < v2.toNat := by omega
+  have hV : v2.toNat * 2 ^ 128 ≤ val256 v0 v1 v2 0 := by
+    simp only [EvmWord.val256, h0]; omega
+  have hU : val256 u0 u1 u2 u3 =
+      (u3.toNat * 2 ^ 64 + u2.toNat) * 2 ^ 128 + (u0.toNat + u1.toNat * 2 ^ 64) := by
+    simp only [EvmWord.val256]; ring
+  have hUlow : u0.toNat + u1.toNat * 2 ^ 64 < 2 ^ 128 := by
+    have := u0.isLt; have := u1.isLt; omega
+  have hknuth := knuth_a_floor_window_le hV hVtop (by positivity) hU hUlow
+  have hge := div128Quot_v5_ge_q_true u3 u2 v2 hv2 hcall
+  omega
+
+/-- **v5 n=3 per-digit Knuth-A upper bound (`+2`).** The top-window quotient
+    `(u3·2^64+u2)/v2` overshoots the full 4-limb window quotient by at most 2.
+    Reuses `knuth_theorem_b_abstract` after scaling both window and divisor by
+    `2^64` (embedding the 3-limb divisor into the 4-limb top-digit frame). -/
+theorem n3_window_top_div_le_val256_div_plus_two
+    (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63)
+    (hcall : u3.toNat < v2.toNat) :
+    (u3.toNat * 2 ^ 64 + u2.toNat) / v2.toNat ≤
+      val256 u0 u1 u2 u3 / val256 v0 v1 v2 0 + 2 := by
+  have h0 : (0 : Word).toNat = 0 := rfl
+  have hvr : val256 v0 v1 0 0 * 2 ^ 64 < 2 ^ 192 := by
+    have := v0.isLt; have := v1.isLt; simp only [EvmWord.val256, h0]; omega
+  have hb := knuth_theorem_b_abstract
+    (val256 u0 u1 u2 u3 * 2 ^ 64) (val256 v0 v1 v2 0 * 2 ^ 64)
+    u3.toNat u2.toNat (val256 u0 u1 0 0 * 2 ^ 64) v2.toNat (val256 v0 v1 0 0 * 2 ^ 64)
+    (by simp only [EvmWord.val256, h0]; ring)
+    (by simp only [EvmWord.val256, h0]; ring)
+    hvr hv2 hcall u2.isLt
+  rwa [Nat.mul_div_mul_right _ _ (by positivity)] at hb
+
+/-- **v5 n=3 per-digit overestimate (`hq_over`).** The v5 trial quotient is at
+    most `val256 u / val256 v + 2`.  Combines `divKTrialCallV5QHat_eq_floor`
+    (the v5 trial is the exact top-window floor) with the Knuth-A upper bound. -/
+theorem n3_window_div_le_val256_div_plus_two_v5
+    (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63)
+    (hcall : u3.toNat < v2.toNat) :
+    (divKTrialCallV5QHat u3 u2 v2).toNat ≤
+      val256 u0 u1 u2 u3 / val256 v0 v1 v2 0 + 2 := by
+  rw [divKTrialCallV5QHat_eq_floor u3 u2 v2 hv2 hcall]
+  exact n3_window_top_div_le_val256_div_plus_two v0 v1 v2 u0 u1 u2 u3 hv2 hcall
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
The v5 n=3 per-digit trial-quotient bounds — the n=3 analogs of the n=2 `KnuthAFloorWindow` lemmas, for a 3-limb divisor `(v0,v1,v2,0)` (top limb `v2`, normalized `v2 ≥ 2^63`) and 4-limb window `(u0,u1,u2,u3)` in the call regime (`u3 < v2`):

- `n3_window_val256_div_le_trial_v5` (`hq_ge` / no-underestimate): `val256 u / val256 v ≤ divKTrialCallV5QHat u3 u2 v2`.
- `n3_window_top_div_le_val256_div_plus_two` (Knuth-A `+2`) and `n3_window_div_le_val256_div_plus_two_v5` (`hq_over`): `divKTrialCallV5QHat u3 u2 v2 ≤ val256 u / val256 v + 2`.

Both reuse the position-independent cores `knuth_a_floor_window_le` / `knuth_theorem_b_abstract`, instantiated at the n=3 place values (`K = 2^128`, divisor scaled by `2^64` to embed the 3-limb divisor into the 4-limb top-digit frame), plus the v5 trial floor lemmas (`div128Quot_v5_ge_q_true`, `divKTrialCallV5QHat_eq_floor`).

These are the `hq_ge`/`hq_over` inputs to `iterWithDoubleAddback`'s conservation/remainder bounds for the v5 n=3 lane — the key math prerequisite for the n=3 per-digit conservation/step.

Pure Nat/bitvector reasoning, axiom-clean (`propext`/`Classical.choice`/`Quot.sound` only). Full build green; gates pass.

Refs #61. Bead: evm-asm-wbc4i.9.3.

Authored by @pirapira; implemented by Claude Code