### PR TITLE
feat(stateless): code_hash_at_block_number_address primitive

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -99,6 +99,7 @@ import EvmAsm.Codegen.Programs.StateRootChainWalkBack
 import EvmAsm.Codegen.Programs.BlockNumberAtBlockHash
 import EvmAsm.Codegen.Programs.StateSlotAtBlockNumber
 import EvmAsm.Codegen.Programs.StateAccountAtBlockNumber
+import EvmAsm.Codegen.Programs.CodeHashAtBlockNumber
 import EvmAsm.Codegen.Programs.BlockHashAtBlockNumber
 import EvmAsm.Codegen.Programs.CodeAtBlockNumber
 import EvmAsm.Codegen.Programs.BlockHashAtStateRoot
@@ -485,6 +486,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_extcodehash_at_block_hash_address" => some ziskExtcodehashAtBlockHashAddressProbeUnit
   | "zisk_state_slot_at_block_number_address" => some ziskStateSlotAtBlockNumberAddressProbeUnit
   | "zisk_state_account_at_block_number_address" => some ziskStateAccountAtBlockNumberAddressProbeUnit
+  | "zisk_code_hash_at_block_number_address" => some ziskCodeHashAtBlockNumberAddressProbeUnit
   | "zisk_block_hash_at_block_number" => some ziskBlockHashAtBlockNumberProbeUnit
   | "zisk_code_at_block_number_address" => some ziskCodeAtBlockNumberAddressProbeUnit
   | "zisk_block_hash_at_state_root" => some ziskBlockHashAtStateRootProbeUnit
@@ -710,6 +712,7 @@ def knownProgramNames : List String :=
    "zisk_extcodehash_at_block_hash_address",
    "zisk_state_slot_at_block_number_address",
    "zisk_state_account_at_block_number_address",
+   "zisk_code_hash_at_block_number_address",
    "zisk_block_hash_at_block_number",
    "zisk_code_at_block_number_address",
    "zisk_block_hash_at_state_root",

--- a/EvmAsm/Codegen/Programs/CodeHashAtBlockNumber.lean
+++ b/EvmAsm/Codegen/Programs/CodeHashAtBlockNumber.lean
@@ -1,0 +1,338 @@
+/-
+  EvmAsm.Codegen.Programs.CodeHashAtBlockNumber
+
+  Number-keyed historical code_hash extractor. Per-field
+  sibling of BalanceAtBlockNumber (offset +8, 32 B BE) and
+  NonceAtBlockNumber (offset +0, 8 B u64 LE); extracts the
+  raw stored `account.code_hash` (offset +72, 32 B) field.
+
+  Returns the **raw stored** code_hash, NOT the EIP-1052
+  EXTCODEHASH-collapsed value. Distinct from any future
+  `extcodehash_at_block_number_address`: fully-empty
+  accounts here yield `EMPTY_CODE_HASH`, not 0.
+
+  No proofs yet -- codegen `String` defs only.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.Mpt
+import EvmAsm.Codegen.Programs.HashBridge
+import EvmAsm.Codegen.Programs.Tx
+import EvmAsm.Codegen.Programs.HeaderU64
+import EvmAsm.Codegen.Programs.HeaderFields
+import EvmAsm.Codegen.Programs.State
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Program
+
+/-! ## code_hash_at_block_number_address
+
+    Number-keyed historical code_hash extractor.
+
+    Pipeline:
+      witness.headers ∋ ?h with h.block.number == target  [K233 scan]
+      h -> header_extract_state_root                      [K201]
+      state_root + address -> account                     [K28]
+      struct.code_hash (offset +72, 32 B) -> 32-byte out
+
+    Spec default on absent: zero (32 zero bytes). This is
+    *not* EMPTY_CODE_HASH; absence-by-status-1 (account not
+    in trie) is signalled distinctly via status=4, with the
+    output buffer zero-filled. Callers wanting the EIP-1052
+    EXTCODEHASH-collapsed value should use a separate
+    primitive (forthcoming).
+
+    Per-field × per-key matrix progress:
+
+      | field         | by_hash | by_number | by_state_root |
+      |---------------|---------|-----------|---------------|
+      | balance       | #7326   | (PR 7479) | (existing)    |
+      | nonce         | (mer.)  | (PR 7481) | (existing)    |
+      | code_hash     | #7320   | THIS      | (existing)    |
+      | storage_root  | #7314   | (TODO)    | (existing)    |
+
+    Use cases:
+      * Code-equality audits across historical blocks: chain
+        N calls with different block_numbers, compare returned
+        code_hashes byte-for-byte to detect contract
+        redeployment or proxy-upgrade events.
+      * Light-client semantic membership ("did Alice deploy
+        a contract by block 12345?": code_hash != EMPTY).
+      * Bridge consistency: counter-party records code_hash
+        at a specific height; verify it directly.
+
+    Calling convention (7 args):
+      a0 (input)  : target_block_number (u64, by value)
+      a1 (input)  : witness.headers ptr
+      a2 (input)  : witness.headers len
+      a3 (input)  : address ptr (20 bytes)
+      a4 (input)  : witness.state ptr
+      a5 (input)  : witness.state len
+      a6 (input)  : 32-byte code_hash out ptr
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success (code_hash written; 32 zero bytes if absent
+            via status 4)
+        1 = no header with target block_number
+        2 = K233 parse failure during scan
+        3 = matched header state_root extraction failure
+        4 = account absent in state trie (buffer zero)
+        5 = state-trie mpt parse error
+        6 = account RLP decode failure
+-/
+def codeHashAtBlockNumberAddressFunction : String :=
+  "code_hash_at_block_number_address:\n" ++
+  "  addi sp, sp, -96\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp); sd s10, 88(sp)\n" ++
+  "  mv s0, a0                  # target block_number\n" ++
+  "  mv s1, a1                  # headers ptr\n" ++
+  "  mv s2, a2                  # headers len\n" ++
+  "  mv s3, a3                  # address ptr\n" ++
+  "  mv s4, a4                  # witness.state ptr\n" ++
+  "  mv s5, a5                  # witness.state len\n" ++
+  "  mv s6, a6                  # code_hash out (32 B)\n" ++
+  "  sd zero,  0(s6); sd zero,  8(s6); sd zero, 16(s6); sd zero, 24(s6)\n" ++
+  "  li s9, 0                   # saw_parse_fail\n" ++
+  "  beqz s2, .Lchbn_miss\n" ++
+  "  lwu t0, 0(s1)\n" ++
+  "  srli s7, t0, 2             # N\n" ++
+  "  li s8, 0                   # i\n" ++
+  ".Lchbn_loop:\n" ++
+  "  beq s8, s7, .Lchbn_finish\n" ++
+  "  slli t0, s8, 2\n" ++
+  "  add t1, s1, t0\n" ++
+  "  lwu t2, 0(t1)\n" ++
+  "  add s10, s1, t2            # header start\n" ++
+  "  addi t3, s8, 1\n" ++
+  "  beq t3, s7, .Lchbn_use_end\n" ++
+  "  slli t3, t3, 2\n" ++
+  "  add t3, s1, t3\n" ++
+  "  lwu t4, 0(t3)\n" ++
+  "  add t4, s1, t4\n" ++
+  "  j .Lchbn_have_end\n" ++
+  ".Lchbn_use_end:\n" ++
+  "  add t4, s1, s2\n" ++
+  ".Lchbn_have_end:\n" ++
+  "  sub t5, t4, s10\n" ++
+  "  mv a0, s10\n" ++
+  "  mv a1, t5\n" ++
+  "  la a2, chbn_number_scratch\n" ++
+  "  jal ra, header_extract_number\n" ++
+  "  bnez a0, .Lchbn_parse_fail\n" ++
+  "  la t0, chbn_number_scratch\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  beq t1, s0, .Lchbn_hit\n" ++
+  "  j .Lchbn_step\n" ++
+  ".Lchbn_parse_fail:\n" ++
+  "  li s9, 1\n" ++
+  ".Lchbn_step:\n" ++
+  "  addi s8, s8, 1\n" ++
+  "  j .Lchbn_loop\n" ++
+  ".Lchbn_hit:\n" ++
+  "  slli t0, s8, 2\n" ++
+  "  add t1, s1, t0\n" ++
+  "  lwu t2, 0(t1)\n" ++
+  "  addi t3, s8, 1\n" ++
+  "  beq t3, s7, .Lchbn_re_use_end\n" ++
+  "  slli t3, t3, 2\n" ++
+  "  add t3, s1, t3\n" ++
+  "  lwu t4, 0(t3)\n" ++
+  "  j .Lchbn_re_have_end\n" ++
+  ".Lchbn_re_use_end:\n" ++
+  "  mv t4, s2\n" ++
+  ".Lchbn_re_have_end:\n" ++
+  "  sub t5, t4, t2\n" ++
+  "  mv a0, s10\n" ++
+  "  mv a1, t5\n" ++
+  "  la a2, chbn_state_root\n" ++
+  "  jal ra, header_extract_state_root\n" ++
+  "  beqz a0, .Lchbn_walk\n" ++
+  "  li a0, 3\n" ++
+  "  j .Lchbn_ret\n" ++
+  ".Lchbn_walk:\n" ++
+  "  mv a0, s3\n" ++
+  "  li a1, 20\n" ++
+  "  la a2, chbn_state_root\n" ++
+  "  mv a3, s4\n" ++
+  "  mv a4, s5\n" ++
+  "  la a5, chbn_walked_struct\n" ++
+  "  jal ra, account_at_address\n" ++
+  "  beqz a0, .Lchbn_present\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Lchbn_absent\n" ++
+  "  addi a0, a0, 3\n" ++
+  "  j .Lchbn_ret\n" ++
+  ".Lchbn_present:\n" ++
+  "  # Copy code_hash (offset +72, 32 B) to output.\n" ++
+  "  la t0, chbn_walked_struct\n" ++
+  "  ld t2, 72(t0); sd t2,  0(s6)\n" ++
+  "  ld t2, 80(t0); sd t2,  8(s6)\n" ++
+  "  ld t2, 88(t0); sd t2, 16(s6)\n" ++
+  "  ld t2, 96(t0); sd t2, 24(s6)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lchbn_ret\n" ++
+  ".Lchbn_absent:\n" ++
+  "  # buffer already zero (spec default).\n" ++
+  "  li a0, 4\n" ++
+  "  j .Lchbn_ret\n" ++
+  ".Lchbn_finish:\n" ++
+  "  bnez s9, .Lchbn_parse_status\n" ++
+  ".Lchbn_miss:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lchbn_ret\n" ++
+  ".Lchbn_parse_status:\n" ++
+  "  li a0, 2\n" ++
+  ".Lchbn_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp)\n" ++
+  "  addi sp, sp, 96\n" ++
+  "  ret"
+
+/-- `zisk_code_hash_at_block_number_address`: probe BuildUnit.
+    Input layout (at INPUT_ADDR):
+      bytes  0.. 8 : (ziskemu metadata)
+      bytes  8..16 : witness_headers_len (u64 LE)
+      bytes 16..24 : witness_state_len (u64 LE)
+      bytes 24..32 : target_block_number (u64 LE)
+      bytes 32..52 : address (20 bytes)
+      bytes 52..   : witness.headers ++ witness.state
+    Output layout (40 bytes):
+      bytes  0.. 8 : status (0..6)
+      bytes  8..40 : code_hash (32 B; 0 on absent) -/
+def ziskCodeHashAtBlockNumberAddressPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t4, 0x40000000\n" ++
+  "  ld a2, 8(t4)                # witness_headers_len\n" ++
+  "  ld a5, 16(t4)               # witness_state_len\n" ++
+  "  ld a0, 24(t4)               # target_block_number\n" ++
+  "  addi a3, t4, 32             # address ptr\n" ++
+  "  addi a1, t4, 52             # witness.headers ptr\n" ++
+  "  add  a4, a1, a2             # witness.state ptr\n" ++
+  "  li a6, 0xa0010008           # code_hash out\n" ++
+  "  jal ra, code_hash_at_block_number_address\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lchbn_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  mptLookupByKeyFunction ++ "\n" ++
+  accountDecodeFunction ++ "\n" ++
+  accountAtAddressFunction ++ "\n" ++
+  headerExtractNumberFunction ++ "\n" ++
+  headerExtractStateRootFunction ++ "\n" ++
+  codeHashAtBlockNumberAddressFunction ++ "\n" ++
+  ".Lchbn_pdone:"
+
+def ziskCodeHashAtBlockNumberAddressDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mnk_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_dummy_length:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mbc_offset:\n" ++
+  "  .zero 8\n" ++
+  "mbc_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_lookup_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_lookup_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_lookup_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_child_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_nibble_count:\n" ++
+  "  .zero 8\n" ++
+  "mw_is_leaf:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_nibble_buf:\n" ++
+  "  .zero 128\n" ++
+  ".balign 32\n" ++
+  "mlk_keccak_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "mlk_nibble_buf:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "ad_offset:\n" ++
+  "  .zero 8\n" ++
+  "ad_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aa_value_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aa_value_scratch:\n" ++
+  "  .zero 256\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "hesr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hesr_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "chbn_number_scratch:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "chbn_state_root:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "chbn_walked_struct:\n" ++
+  "  .zero 104"
+
+def ziskCodeHashAtBlockNumberAddressProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskCodeHashAtBlockNumberAddressPrologue
+  dataAsm     := ziskCodeHashAtBlockNumberAddressDataSection
+}
+
+end EvmAsm.Codegen

--- a/scripts/codegen-zisk-code-hash-at-block-number-address-check.sh
+++ b/scripts/codegen-zisk-code-hash-at-block-number-address-check.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# codegen-zisk-code-hash-at-block-number-address-check.sh
+#
+# Number-keyed historical code_hash extractor (raw stored
+# value; NOT EIP-1052-collapsed).
+#
+# Output (40 bytes):
+#   bytes  0.. 8 : status (0..6)
+#   bytes  8..40 : code_hash (32 B; 0 on absent)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_code_hash_at_block_number_address ELF"
+lake exe codegen --program zisk_code_hash_at_block_number_address \
+  --halt linux93 \
+  -o gen-out/zisk_code_hash_at_block_number_address
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+  local target="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_chbn_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_chbn_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_chbn_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def hp_encode(nibbles, is_leaf):
+    flag = 2 if is_leaf else 0
+    if len(nibbles) % 2 == 1:
+        flag |= 1
+        result = bytes([flag * 0x10 + nibbles[0]])
+        nibbles = nibbles[1:]
+    else:
+        result = bytes([flag * 0x10])
+    for i in range(0, len(nibbles), 2):
+        result += bytes([nibbles[i] * 0x10 + nibbles[i+1]])
+    return result
+
+def leaf_node(path_nibbles, value):
+    return rlp.encode([hp_encode(path_nibbles, True), value])
+
+def bytes_to_nibbles(b):
+    out = []
+    for byte in b:
+        out.append(byte >> 4); out.append(byte & 0xf)
+    return out
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0: return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset); offset += len(e)
+    for e in elements: section += e
+    return section
+
+def encode_account(nonce, balance, storage_root, code_hash):
+    return rlp.encode([nonce, balance, storage_root, code_hash])
+
+def encode_header(number_val, state_root):
+    if number_val == 0:
+        number_field = b''
+    else:
+        nbytes = (number_val.bit_length() + 7) // 8
+        number_field = number_val.to_bytes(nbytes, 'big')
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x55'*32,
+        b'\\x66'*32, b'\\x00'*256, b'', number_field, b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    return rlp.encode(fields)
+
+EMPTY_TRIE = bytes.fromhex('56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421')
+EMPTY_CODE_HASH = bytes.fromhex('c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')
+
+def state_trie_one(addr, acct_rlp):
+    path = bytes_to_nibbles(k256(addr))
+    leaf = leaf_node(path, acct_rlp)
+    return k256(leaf), build_ssz_section([leaf])
+
+mode = '$mode'
+target = int('$target')
+ALICE = b'\\xaa' * 20
+BOB = b'\\xbb' * 20
+
+if mode == 'contract':
+    code_hash = k256(bytes.fromhex('6000'))
+    acct = encode_account(0, 0, EMPTY_TRIE, code_hash)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(100, b'\\xee'*32)
+    h1 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0, h1])
+    addr = ALICE
+    expected = struct.pack('<Q', 0) + code_hash
+elif mode == 'eoa_emits_empty_code_hash':
+    # EOA with EMPTY_CODE_HASH in trie -- distinct from EIP-1052
+    # (which would collapse to 0 for fully empty accounts).
+    acct = encode_account(7, 1000, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0])
+    addr = ALICE
+    expected = struct.pack('<Q', 0) + EMPTY_CODE_HASH
+elif mode == 'fully_empty_account_still_returns_empty_code_hash':
+    # CRITICAL EIP-1052 vs raw-extract distinction: a fully-
+    # empty in-trie account returns EMPTY_CODE_HASH here
+    # (NOT 0 as EIP-1052 would dictate).
+    acct = encode_account(0, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0])
+    addr = ALICE
+    expected = struct.pack('<Q', 0) + EMPTY_CODE_HASH
+elif mode == 'absent_account':
+    acct = encode_account(0, 999, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(BOB, acct)
+    h0 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0])
+    addr = ALICE
+    expected = struct.pack('<Q', 4) + b'\\x00' * 32
+elif mode == 'number_miss':
+    acct = encode_account(0, 999, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(100, sr)
+    witness_headers = build_ssz_section([h0])
+    addr = ALICE
+    expected = struct.pack('<Q', 1) + b'\\x00' * 32
+else:
+    raise SystemExit('bad mode')
+
+with open(sys.argv[1], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(witness_headers))
+        + struct.pack('<Q', len(witness_state))
+        + struct.pack('<Q', target)
+        + addr
+        + witness_headers
+        + witness_state
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_code_hash_at_block_number_address.elf \
+    -i "$in_file" -o "$out_file" -n 6000000 \
+    >"$REPO_ROOT/gen-out/zisk_chbn_${name}.emu.log" 2>&1 || true
+
+  local exp_size
+  exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-44s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-44s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "contract_keccak6000"                        contract 101 || FAILED=1
+run_case "eoa_with_value_still_empty_code_hash"       eoa_emits_empty_code_hash 101 || FAILED=1
+run_case "fully_empty_returns_empty_not_zero"         fully_empty_account_still_returns_empty_code_hash 101 || FAILED=1
+run_case "absent_account_zero_buffer"                 absent_account 101 || FAILED=1
+run_case "number_not_in_section"                      number_miss 999 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: code_hash_at_block_number_address end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Number-keyed historical code_hash extractor. Per-field
sibling of \`balance_at_block_number_address\` (PR #7479) and
\`nonce_at_block_number_address\` (PR #7481); extracts the
raw stored \`account.code_hash\` field (offset +72, 32 B).

**Returns the raw stored code_hash, NOT the EIP-1052
EXTCODEHASH-collapsed value.** Distinct from any future
\`extcodehash_at_block_number_address\`: fully-empty accounts
here yield \`EMPTY_CODE_HASH\` (the canonical empty-code
sentinel), NOT 0 (which is what EIP-1052 would collapse to).

Pipeline (composes K233 scan + K201 + K28; no new helpers):

\`\`\`
witness.headers ∋ ?h with h.block.number == target  [K233]
h -> header_extract_state_root                      [K201]
state_root + address -> account                     [K28]
struct.code_hash (offset +72, 32 B) -> 32-byte out
\`\`\`

Per-field × per-key matrix progress:

| field         | by_hash | by_number | by_state_root |
|---------------|---------|-----------|---------------|
| balance       | #7326   | (#7479)   | (existing)    |
| nonce         | (mer.)  | (#7481)   | (existing)    |
| code_hash     | #7320   | **this**  | (existing)    |
| storage_root  | #7314   | (TODO)    | (existing)    |

Use cases:
- Code-equality audits: chain N calls with different
  block_numbers, byte-compare returned code_hashes to
  detect contract redeployment / proxy upgrades.
- Light-client semantic membership ("did Alice deploy a
  contract by block 12345?" — code_hash != EMPTY).
- Bridge consistency: counter-party records code_hash at
  height N; verify directly.

Status codes:

| status | meaning |
|--------|---------|
| 0 | success (code_hash written; 32 zero bytes if absent via status 4) |
| 1 | no header with target block_number |
| 2 | K233 parse failure during scan |
| 3 | matched header state_root extraction failure |
| 4 | account absent in state trie (buffer zero) |
| 5 | state-trie mpt parse error |
| 6 | account RLP decode failure |

## Test plan

- [x] \`lake build codegen\` succeeds.
- [x] \`bash scripts/codegen-zisk-code-hash-at-block-number-address-check.sh\` — 5/5 fixtures pass:
  - \`contract_keccak6000\` (positional routing, real code)
  - \`eoa_with_value_still_empty_code_hash\` (in-trie EOA → EMPTY)
  - \`fully_empty_returns_empty_not_zero\` (**critical row** distinguishing raw extract from EIP-1052: in-trie fully empty → EMPTY_CODE_HASH, NOT 0)
  - \`absent_account_zero_buffer\` (status=4)
  - \`number_not_in_section\` (status=1)
- [x] No \`native_decide\` / \`bv_decide\`; aligned LD/SD only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)