### PR TITLE
feat(divmod): v5 n3 per-digit remainder bound + collapse (max path)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -231,6 +231,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5R10Conservation
 import EvmAsm.Evm64.DivMod.Spec.N2V5ThreeStep
 import EvmAsm.Evm64.DivMod.Spec.N2V5RemainderLt
 import EvmAsm.Evm64.DivMod.Spec.N3V5RemainderLt
+import EvmAsm.Evm64.DivMod.Spec.N3V5DigitStepIter
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormScaled
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLaneShape

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5Families.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5Families.lean
@@ -1,0 +1,121 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5Families
+
+  N3 V5 iteration families: `iterN3V5` (the capped-trial per-iteration dispatch)
+  and the two-digit `fullDivN3R1V5` / `fullDivN3R0V5` / `fullDivN3C3V5`.  These are
+  the n=3 analogs of `FullPathN2V5Families` (`iterN2V5`, `fullDivN2R{2,1,0}V5`,
+  `fullDivN2C3V5`) and of the v4 n=3 families (`fullDivN3R{1,0}V4`,
+  `fullDivN3C3V4`), with the trial quotient supplied by the **capped** v5 callable
+  `divKTrialCallV5QHat` (over the 3-limb normalized divisor's top limb `v2`)
+  instead of the v4 `div128Quot`.  The n=3 loop runs two outer iterations
+  (digits `r1`, `r0`).  Foundational layer for the v5 n=3 DIV lane.  Bead
+  `evm-asm-wbc4i.9.3` (children 9.3.1/9.3.2/9.3.3).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCallV5
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- ============================================================================
+-- V5 per-iteration computation (capped trial)
+-- ============================================================================
+
+/-- Unified per-iteration computation with double addback for n=3, **v5**: the
+    trial quotient is the capped callable `divKTrialCallV5QHat u3 u2 v2` (the
+    n=3 analog of `iterN2V5`, and the capped counterpart of `iterN3`/`iterN3Call`). -/
+@[irreducible]
+def iterN3V5 (bltu : Bool) (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  if bltu then
+    iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  else
+    iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+
+theorem iterN3V5_unfold {bltu : Bool} {v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word} :
+    iterN3V5 bltu v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      (if bltu then
+        iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      else
+        iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  delta iterN3V5; rfl
+
+-- ============================================================================
+-- V5 two-digit iteration results
+-- ============================================================================
+
+/-- Digit-1 (first outer iteration) v5 result, over the normalized
+    divisor/window. -/
+@[irreducible]
+def fullDivN3R1V5 (bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let u := fullDivN3NormU a0 a1 a2 a3 b2
+  iterN3V5 bltu_1 v.1 v.2.1 v.2.2.1 v.2.2.2
+    u.2.1 u.2.2.1 u.2.2.2.1 u.2.2.2.2 (0 : Word)
+
+/-- Digit-0 (second outer iteration) v5 result, threaded on `fullDivN3R1V5`. -/
+@[irreducible]
+def fullDivN3R0V5 (bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let u := fullDivN3NormU a0 a1 a2 a3 b2
+  let r1 := fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  iterN3V5 bltu_0 v.1 v.2.1 v.2.2.1 v.2.2.2 u.1
+    r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+
+/-- Digit-0 mulsub borrow `c3` (the loop-exit `x10`), v5. -/
+@[irreducible]
+def fullDivN3C3V5 (bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word :=
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let u := fullDivN3NormU a0 a1 a2 a3 b2
+  let r1 := fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  if bltu_0 then
+    (mulsubN4 (divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v.2.2.1)
+      v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+  else
+    (mulsubN4 (signExtend12 4095 : Word)
+      v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+
+-- ============================================================================
+-- Dispatch (`_eq`) lemmas
+-- ============================================================================
+
+theorem fullDivN3R1V5_eq (bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3 =
+      (let v := fullDivN3NormV b0 b1 b2 b3
+       let u := fullDivN3NormU a0 a1 a2 a3 b2
+       iterN3V5 bltu_1 v.1 v.2.1 v.2.2.1 v.2.2.2
+         u.2.1 u.2.2.1 u.2.2.2.1 u.2.2.2.2 (0 : Word)) := by
+  delta fullDivN3R1V5; rfl
+
+theorem fullDivN3R0V5_eq (bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 =
+      (let v := fullDivN3NormV b0 b1 b2 b3
+       let u := fullDivN3NormU a0 a1 a2 a3 b2
+       let r1 := fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+       iterN3V5 bltu_0 v.1 v.2.1 v.2.2.1 v.2.2.2 u.1
+         r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) := by
+  delta fullDivN3R0V5; rfl
+
+theorem fullDivN3R1V5_true (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN3R1V5 true a0 a1 a2 a3 b0 b1 b2 b3 =
+      (let v := fullDivN3NormV b0 b1 b2 b3
+       let u := fullDivN3NormU a0 a1 a2 a3 b2
+       iterWithDoubleAddback (divKTrialCallV5QHat u.2.2.2.2 u.2.2.2.1 v.2.2.1)
+         v.1 v.2.1 v.2.2.1 v.2.2.2 u.2.1 u.2.2.1 u.2.2.2.1 u.2.2.2.2 (0 : Word)) := by
+  rw [fullDivN3R1V5_eq, iterN3V5_unfold]; simp
+
+theorem fullDivN3R1V5_false (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN3R1V5 false a0 a1 a2 a3 b0 b1 b2 b3 =
+      (let v := fullDivN3NormV b0 b1 b2 b3
+       let u := fullDivN3NormU a0 a1 a2 a3 b2
+       iterN3Max v.1 v.2.1 v.2.2.1 v.2.2.2 u.2.1 u.2.2.1 u.2.2.2.1 u.2.2.2.2 (0 : Word)) := by
+  rw [fullDivN3R1V5_eq, iterN3V5_unfold]; simp
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3V5DigitStepIter.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V5DigitStepIter.lean
@@ -1,0 +1,171 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3V5DigitStepIter
+
+  The v5 n=3 per-digit Euclidean step, stated on the **irreducible** `iterN3V5`
+  (call path).  `iterN3V5 true …` computes the v5 trial INTERNALLY (its args are
+  plain `Word`s), so `set out := iterN3V5 true …` is kernel-cheap — unlike
+  `iterWithDoubleAddback (divKTrialCallV5QHat …)`, whose exposed deep trial
+  ARGUMENT triggers the kernel term-size wall.  The per-digit conservation /
+  remainder-lt / collapse (proved on `iterWithDoubleAddback` in `N3V5RemainderLt`)
+  are first wrapped onto `iterN3V5` (via the trivial `iterN3V5_true_eq` bridge),
+  then combined by `set` + `rw` + `ring` with `iterN3V5` projections as atoms.
+  Per-digit input to the v5 n=3 quotient telescope.  Bead `evm-asm-wbc4i.9.3`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N3V5RemainderLt
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5Families
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- `iterN3V5 true …` is the call-path double-addback over the v5 trial. -/
+theorem iterN3V5_true_eq (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    iterN3V5 true v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  rw [iterN3V5_unfold]; simp
+
+/-- Per-digit conservation, wrapped onto `iterN3V5 true` (`uTop = 0`, clean —
+    matches n2's `iterN2V5_true_conservation_from_shape` pattern: simplify the
+    `uTop` term away on the deep form so the per-digit step needs no `simp at`). -/
+theorem iterN3V5_call_conservation (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63) (hcall : u3.toNat < v2.toNat) :
+    val256 u0 u1 u2 u3 =
+      (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).1.toNat * val256 v0 v1 v2 0 +
+        val256
+          (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.1
+          (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1
+          (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1
+          (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.1 +
+        (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.2.toNat * 2 ^ 256 := by
+  rw [iterN3V5_true_eq]
+  have h := n3_trial_call_val256_conservation v0 v1 v2 u0 u1 u2 u3 0 hv2 hcall
+  have h0 : (0 : Word).toNat = 0 := rfl
+  simpa [h0] using h
+
+/-- Per-digit remainder bound, wrapped onto `iterN3V5 true` (`uTop = 0`). -/
+theorem iterN3V5_call_remainder_lt (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63) (hcall : u3.toNat < v2.toNat) :
+    val256
+        (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.1
+        (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1
+        (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1
+        (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.1 +
+      (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.2.toNat * 2 ^ 256 <
+    val256 v0 v1 v2 0 := by
+  rw [iterN3V5_true_eq]
+  exact n3_trial_call_remainder_lt v0 v1 v2 u0 u1 u2 u3 hv2 hcall
+
+/-- Per-digit remainder collapse, wrapped onto `iterN3V5 true` (`uTop = 0`). -/
+theorem iterN3V5_call_collapse (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63) (hcall : u3.toNat < v2.toNat) :
+    (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.1 = 0 ∧
+    (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.2 = 0 := by
+  rw [iterN3V5_true_eq]
+  exact n3_trial_call_collapse v0 v1 v2 u0 u1 u2 u3 hv2 hcall
+
+/-- **v5 n=3 per-digit Euclidean step (call path), on `iterN3V5`.**  Combines the
+    wrapped conservation / collapse / remainder-lt with `iterN3V5` projections as
+    `ring` atoms — kernel-cheap (no deep trial argument). -/
+theorem iterN3V5_call_step (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63) (hcall : u3.toNat < v2.toNat) :
+    val256 u0 u1 u2 u3 =
+        (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).1.toNat * val256 v0 v1 v2 0 +
+        ((iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.1.toNat +
+          2 ^ 64 * (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1.toNat +
+          2 ^ 128 * (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1.toNat) ∧
+      (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.1.toNat +
+          2 ^ 64 * (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1.toNat +
+          2 ^ 128 * (iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1.toNat <
+        val256 v0 v1 v2 0 := by
+  obtain ⟨hc3z, hcz⟩ := iterN3V5_call_collapse v0 v1 v2 u0 u1 u2 u3 hv2 hcall
+  have hconv := iterN3V5_call_conservation v0 v1 v2 u0 u1 u2 u3 hv2 hcall
+  have hlt := iterN3V5_call_remainder_lt v0 v1 v2 u0 u1 u2 u3 hv2 hcall
+  set out := iterN3V5 true v0 v1 v2 0 u0 u1 u2 u3 0 with hout
+  have h0 : (0 : Word).toNat = 0 := rfl
+  have hcollapse : val256 out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1 =
+      out.2.1.toNat + 2 ^ 64 * out.2.2.1.toNat + 2 ^ 128 * out.2.2.2.1.toNat := by
+    rw [hc3z]; simp only [EvmWord.val256, h0]; ring
+  refine ⟨?_, ?_⟩
+  · rw [hconv, hcollapse, hcz, h0]; ring
+  · rw [hcollapse] at hlt; rw [hcz, h0] at hlt; simpa using hlt
+
+/-! ### Max branch (`bltu = false`, trial `= signExtend12 4095 = 2^64-1`)
+
+Mirrors the call path.  `iterN3V5 false …` unfolds (via `iterN3Max`) to the
+double-addback over the capped trial; the per-digit conservation / remainder-lt /
+collapse (max path) carry an extra window-validity hypothesis
+`val256 window < 2^64 · val256 v` (the running-remainder invariant in the
+telescope). -/
+
+/-- `iterN3V5 false …` is the max-path double-addback over the capped trial. -/
+theorem iterN3V5_false_eq (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    iterN3V5 false v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  unfold iterN3V5 iterN3Max; simp only [Bool.false_eq_true, if_false]
+
+/-- Per-digit conservation, wrapped onto `iterN3V5 false` (clean, `uTop = 0`). -/
+theorem iterN3V5_max_conservation (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63) (hmax : ¬ BitVec.ult u3 v2) :
+    val256 u0 u1 u2 u3 =
+      (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).1.toNat * val256 v0 v1 v2 0 +
+        val256
+          (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.1
+          (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1
+          (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1
+          (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.1 +
+        (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.2.toNat * 2 ^ 256 := by
+  rw [iterN3V5_false_eq]
+  have h := n3_trial_max_val256_conservation v0 v1 v2 u0 u1 u2 u3 0 hv2 hmax
+  have h0 : (0 : Word).toNat = 0 := rfl
+  simpa [h0] using h
+
+/-- Per-digit remainder bound, wrapped onto `iterN3V5 false` (`uTop = 0`). -/
+theorem iterN3V5_max_remainder_lt (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63) (hmax : ¬ BitVec.ult u3 v2)
+    (hvalid : val256 u0 u1 u2 u3 < 2 ^ 64 * val256 v0 v1 v2 0) :
+    val256
+        (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.1
+        (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1
+        (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1
+        (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.1 +
+      (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.2.toNat * 2 ^ 256 <
+    val256 v0 v1 v2 0 := by
+  rw [iterN3V5_false_eq]
+  exact n3_trial_max_remainder_lt v0 v1 v2 u0 u1 u2 u3 hv2 hmax hvalid
+
+/-- Per-digit remainder collapse, wrapped onto `iterN3V5 false` (`uTop = 0`). -/
+theorem iterN3V5_max_collapse (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63) (hmax : ¬ BitVec.ult u3 v2)
+    (hvalid : val256 u0 u1 u2 u3 < 2 ^ 64 * val256 v0 v1 v2 0) :
+    (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.1 = 0 ∧
+    (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.2 = 0 := by
+  rw [iterN3V5_false_eq]
+  exact n3_trial_max_collapse v0 v1 v2 u0 u1 u2 u3 hv2 hmax hvalid
+
+/-- **v5 n=3 per-digit Euclidean step (max path), on `iterN3V5`.** -/
+theorem iterN3V5_max_step (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63) (hmax : ¬ BitVec.ult u3 v2)
+    (hvalid : val256 u0 u1 u2 u3 < 2 ^ 64 * val256 v0 v1 v2 0) :
+    val256 u0 u1 u2 u3 =
+        (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).1.toNat * val256 v0 v1 v2 0 +
+        ((iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.1.toNat +
+          2 ^ 64 * (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1.toNat +
+          2 ^ 128 * (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1.toNat) ∧
+      (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.1.toNat +
+          2 ^ 64 * (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1.toNat +
+          2 ^ 128 * (iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1.toNat <
+        val256 v0 v1 v2 0 := by
+  obtain ⟨hc3z, hcz⟩ := iterN3V5_max_collapse v0 v1 v2 u0 u1 u2 u3 hv2 hmax hvalid
+  have hconv := iterN3V5_max_conservation v0 v1 v2 u0 u1 u2 u3 hv2 hmax
+  have hlt := iterN3V5_max_remainder_lt v0 v1 v2 u0 u1 u2 u3 hv2 hmax hvalid
+  set out := iterN3V5 false v0 v1 v2 0 u0 u1 u2 u3 0 with hout
+  have h0 : (0 : Word).toNat = 0 := rfl
+  have hcollapse : val256 out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1 =
+      out.2.1.toNat + 2 ^ 64 * out.2.2.1.toNat + 2 ^ 128 * out.2.2.2.1.toNat := by
+    rw [hc3z]; simp only [EvmWord.val256, h0]; ring
+  refine ⟨?_, ?_⟩
+  · rw [hconv, hcollapse, hcz, h0]; ring
+  · rw [hcollapse] at hlt; rw [hcz, h0] at hlt; simpa using hlt
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3V5RemainderLt.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V5RemainderLt.lean
@@ -166,4 +166,59 @@ theorem n3_trial_max_val256_conservation
     (fun hb hcz => q_ge_two_of_mulsub_borrow_and_addback_carry_zero
       q v0 v1 v2 0 u0 u1 u2 u3 (hc3 hb) hcz)
 
+/-- **v5 n=3 per-digit remainder bound (max path, `uTop = 0`).**  The cap-trial
+    double-addback remainder is below the 3-limb divisor, given the window-validity
+    invariant `val256 u < 2^64 · val256 v`. -/
+theorem n3_trial_max_remainder_lt
+    (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63)
+    (hmax : ¬ BitVec.ult u3 v2)
+    (hvalid : val256 u0 u1 u2 u3 < 2 ^ 64 * val256 v0 v1 v2 0) :
+    val256
+        (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 0).2.1
+        (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1
+        (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1
+        (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.1 +
+      (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.2.toNat
+        * 2 ^ 256 <
+    val256 v0 v1 v2 0 := by
+  have hbnz : v0 ||| v1 ||| v2 ||| 0 ≠ 0 := by
+    intro h
+    have hv2z : v2 = 0 := (BitVec.or_eq_zero_iff.mp (BitVec.or_eq_zero_iff.mp h).1).2
+    rw [hv2z] at hv2; simp at hv2
+  set q : Word := signExtend12 (4095 : BitVec 12) with hq
+  have hq_over := max_trial_local_overestimate_n3_of_not_ult v0 v1 v2 u0 u1 u2 u3 hv2 hmax
+  have hqsucc : q.toNat + 1 = 2 ^ 64 := by rw [hq, signExtend12_4095_toNat]; omega
+  have hq_ge : val256 u0 u1 u2 u3 + (0 : Word).toNat * 2 ^ 256 <
+      (q.toNat + 1) * val256 v0 v1 v2 0 := by
+    have h0 : (0 : Word).toNat = 0 := rfl
+    rw [h0, hqsucc, Nat.zero_mul, Nat.add_zero]; exact hvalid
+  have hc3 : BitVec.ult (0 : Word) (mulsubN4 q v0 v1 v2 0 u0 u1 u2 u3).2.2.2.2 →
+      (mulsubN4 q v0 v1 v2 0 u0 u1 u2 u3).2.2.2.2 = 1 := by
+    intro hb
+    apply mulsubN4_c3_eq_one_v3_zero
+    intro hz; rw [hz] at hb; exact absurd hb (by decide)
+  exact iterWithDoubleAddback_remainder_lt_of_plus_two
+    q v0 v1 v2 0 u0 u1 u2 u3 0 hbnz hc3 hq_over hq_ge
+
+/-- **v5 n=3 per-digit remainder collapse (max path).**  Top limb (`rem3`) and
+    overflow carry are zero. -/
+theorem n3_trial_max_collapse
+    (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63)
+    (hmax : ¬ BitVec.ult u3 v2)
+    (hvalid : val256 u0 u1 u2 u3 < 2 ^ 64 * val256 v0 v1 v2 0) :
+    (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.1 = 0 ∧
+    (iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.2 = 0 := by
+  have hlt := n3_trial_max_remainder_lt v0 v1 v2 u0 u1 u2 u3 hv2 hmax hvalid
+  have hv192 := n3_val256_v_lt_pow192 v0 v1 v2
+  set out := iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 0 u0 u1 u2 u3 0 with hout
+  have key : val256 out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1 +
+      out.2.2.2.2.2.toNat * 2 ^ 256 < 2 ^ 192 := by omega
+  refine ⟨?_, ?_⟩
+  · have h : out.2.2.2.2.1.toNat = 0 := by simp only [EvmWord.val256] at key; omega
+    exact BitVec.eq_of_toNat_eq (by rw [h]; rfl)
+  · have h : out.2.2.2.2.2.toNat = 0 := by simp only [EvmWord.val256] at key; omega
+    exact BitVec.eq_of_toNat_eq (by rw [h]; rfl)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
Stacked on the call-path remainder bound PR. Completes **both paths'** per-digit data for the v5 n=3 lane:

- `n3_trial_max_remainder_lt` — the cap-trial (`signExtend12 4095`) double-addback remainder is below `val256 v0 v1 v2 0`, given the window-validity invariant `val256 u < 2^64 · val256 v` (a hypothesis, supplied by the loop invariant at the lane). Via the generic `iterWithDoubleAddback_remainder_lt_of_plus_two` with `max_trial_local_overestimate_n3_of_not_ult` (`hq_over`) and the `q+1 = 2^64` cap.
- `n3_trial_max_collapse` — `rem3 = 0` and the overflow carry `= 0`.

Clean mirror of the n2 `iterN2V5_false_remainder_lt` / the call-path n3 lemmas, `uTop = 0`. Axiom-clean. Full build green; gates pass.

With #7487/#7488 (conservations) and #7489 (call-path remainder/collapse), the full per-digit data for **both branches** is now in place — the inputs to the forthcoming `iterN3V5_step` and the 2-digit quotient telescope.

Refs #61. Bead: evm-asm-wbc4i.9.3.

Authored by @pirapira; implemented by Claude Code