### PR TITLE
feat(stateless): storage_root_at_block_number_address primitive

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -99,6 +99,7 @@ import EvmAsm.Codegen.Programs.StateRootChainWalkBack
 import EvmAsm.Codegen.Programs.BlockNumberAtBlockHash
 import EvmAsm.Codegen.Programs.StateSlotAtBlockNumber
 import EvmAsm.Codegen.Programs.StateAccountAtBlockNumber
+import EvmAsm.Codegen.Programs.StorageRootAtBlockNumber
 import EvmAsm.Codegen.Programs.BlockHashAtBlockNumber
 import EvmAsm.Codegen.Programs.CodeAtBlockNumber
 import EvmAsm.Codegen.Programs.BlockHashAtStateRoot
@@ -485,6 +486,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_extcodehash_at_block_hash_address" => some ziskExtcodehashAtBlockHashAddressProbeUnit
   | "zisk_state_slot_at_block_number_address" => some ziskStateSlotAtBlockNumberAddressProbeUnit
   | "zisk_state_account_at_block_number_address" => some ziskStateAccountAtBlockNumberAddressProbeUnit
+  | "zisk_storage_root_at_block_number_address" => some ziskStorageRootAtBlockNumberAddressProbeUnit
   | "zisk_block_hash_at_block_number" => some ziskBlockHashAtBlockNumberProbeUnit
   | "zisk_code_at_block_number_address" => some ziskCodeAtBlockNumberAddressProbeUnit
   | "zisk_block_hash_at_state_root" => some ziskBlockHashAtStateRootProbeUnit
@@ -710,6 +712,7 @@ def knownProgramNames : List String :=
    "zisk_extcodehash_at_block_hash_address",
    "zisk_state_slot_at_block_number_address",
    "zisk_state_account_at_block_number_address",
+   "zisk_storage_root_at_block_number_address",
    "zisk_block_hash_at_block_number",
    "zisk_code_at_block_number_address",
    "zisk_block_hash_at_state_root",

--- a/EvmAsm/Codegen/Programs/StorageRootAtBlockNumber.lean
+++ b/EvmAsm/Codegen/Programs/StorageRootAtBlockNumber.lean
@@ -1,0 +1,339 @@
+/-
+  EvmAsm.Codegen.Programs.StorageRootAtBlockNumber
+
+  Number-keyed historical storage_root extractor.
+  **Completes the 4-field block_number row** alongside:
+    * balance     -- PR 7479
+    * nonce       -- PR 7481
+    * code_hash   -- PR 7486
+
+  Extracts the raw stored `account.storage_root` field at
+  offset +40 (32 B). Spec default: zero (32 zero bytes) on
+  absent.
+
+  No proofs yet -- codegen `String` defs only.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.Mpt
+import EvmAsm.Codegen.Programs.HashBridge
+import EvmAsm.Codegen.Programs.Tx
+import EvmAsm.Codegen.Programs.HeaderU64
+import EvmAsm.Codegen.Programs.HeaderFields
+import EvmAsm.Codegen.Programs.State
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Program
+
+/-! ## storage_root_at_block_number_address
+
+    Number-keyed historical storage_root extractor.
+
+    Pipeline:
+      witness.headers ∋ ?h with h.block.number == target  [K233 scan]
+      h -> header_extract_state_root                      [K201]
+      state_root + address -> account                     [K28]
+      struct.storage_root (offset +40, 32 B) -> 32-byte out
+
+    Spec default on absent: zero (32 zero bytes). Note that
+    a present-but-with-empty-storage account returns
+    `EMPTY_TRIE_ROOT` (0x56e8...) -- distinct from the
+    32-zero-bytes absent case. Callers branching on storage
+    emptiness should compare against EMPTY_TRIE_ROOT, not
+    against zero.
+
+    Completes the per-field × per-key matrix's block_number
+    column:
+
+      | field         | by_hash | by_number | by_state_root |
+      |---------------|---------|-----------|---------------|
+      | balance       | #7326   | (PR 7479) | (existing)    |
+      | nonce         | (mer.)  | (PR 7481) | (existing)    |
+      | code_hash     | #7320   | (PR 7486) | (existing)    |
+      | storage_root  | #7314   | THIS      | (existing)    |
+
+    Use cases:
+      * Storage-trie freshness audit: compare
+        storage_root at successive block_numbers to detect
+        storage writes without enumerating slots.
+      * Light-client cold-call gate: storage_root ==
+        EMPTY_TRIE_ROOT  -> SLOAD always returns 0; skip
+        the storage-trie walk.
+      * Bridge consistency: counter-party records
+        storage_root at height N; verify directly.
+
+    Calling convention (7 args):
+      a0 (input)  : target_block_number (u64, by value)
+      a1 (input)  : witness.headers ptr
+      a2 (input)  : witness.headers len
+      a3 (input)  : address ptr (20 bytes)
+      a4 (input)  : witness.state ptr
+      a5 (input)  : witness.state len
+      a6 (input)  : 32-byte storage_root out ptr
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success (storage_root written; 32 zero bytes if
+            absent via status 4)
+        1 = no header with target block_number
+        2 = K233 parse failure during scan
+        3 = matched header state_root extraction failure
+        4 = account absent in state trie (buffer zero)
+        5 = state-trie mpt parse error
+        6 = account RLP decode failure
+-/
+def storageRootAtBlockNumberAddressFunction : String :=
+  "storage_root_at_block_number_address:\n" ++
+  "  addi sp, sp, -96\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp); sd s10, 88(sp)\n" ++
+  "  mv s0, a0                  # target block_number\n" ++
+  "  mv s1, a1                  # headers ptr\n" ++
+  "  mv s2, a2                  # headers len\n" ++
+  "  mv s3, a3                  # address ptr\n" ++
+  "  mv s4, a4                  # witness.state ptr\n" ++
+  "  mv s5, a5                  # witness.state len\n" ++
+  "  mv s6, a6                  # storage_root out (32 B)\n" ++
+  "  sd zero,  0(s6); sd zero,  8(s6); sd zero, 16(s6); sd zero, 24(s6)\n" ++
+  "  li s9, 0                   # saw_parse_fail\n" ++
+  "  beqz s2, .Lsrbn_miss\n" ++
+  "  lwu t0, 0(s1)\n" ++
+  "  srli s7, t0, 2             # N\n" ++
+  "  li s8, 0                   # i\n" ++
+  ".Lsrbn_loop:\n" ++
+  "  beq s8, s7, .Lsrbn_finish\n" ++
+  "  slli t0, s8, 2\n" ++
+  "  add t1, s1, t0\n" ++
+  "  lwu t2, 0(t1)\n" ++
+  "  add s10, s1, t2            # header start\n" ++
+  "  addi t3, s8, 1\n" ++
+  "  beq t3, s7, .Lsrbn_use_end\n" ++
+  "  slli t3, t3, 2\n" ++
+  "  add t3, s1, t3\n" ++
+  "  lwu t4, 0(t3)\n" ++
+  "  add t4, s1, t4\n" ++
+  "  j .Lsrbn_have_end\n" ++
+  ".Lsrbn_use_end:\n" ++
+  "  add t4, s1, s2\n" ++
+  ".Lsrbn_have_end:\n" ++
+  "  sub t5, t4, s10\n" ++
+  "  mv a0, s10\n" ++
+  "  mv a1, t5\n" ++
+  "  la a2, srbn_number_scratch\n" ++
+  "  jal ra, header_extract_number\n" ++
+  "  bnez a0, .Lsrbn_parse_fail\n" ++
+  "  la t0, srbn_number_scratch\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  beq t1, s0, .Lsrbn_hit\n" ++
+  "  j .Lsrbn_step\n" ++
+  ".Lsrbn_parse_fail:\n" ++
+  "  li s9, 1\n" ++
+  ".Lsrbn_step:\n" ++
+  "  addi s8, s8, 1\n" ++
+  "  j .Lsrbn_loop\n" ++
+  ".Lsrbn_hit:\n" ++
+  "  slli t0, s8, 2\n" ++
+  "  add t1, s1, t0\n" ++
+  "  lwu t2, 0(t1)\n" ++
+  "  addi t3, s8, 1\n" ++
+  "  beq t3, s7, .Lsrbn_re_use_end\n" ++
+  "  slli t3, t3, 2\n" ++
+  "  add t3, s1, t3\n" ++
+  "  lwu t4, 0(t3)\n" ++
+  "  j .Lsrbn_re_have_end\n" ++
+  ".Lsrbn_re_use_end:\n" ++
+  "  mv t4, s2\n" ++
+  ".Lsrbn_re_have_end:\n" ++
+  "  sub t5, t4, t2\n" ++
+  "  mv a0, s10\n" ++
+  "  mv a1, t5\n" ++
+  "  la a2, srbn_state_root\n" ++
+  "  jal ra, header_extract_state_root\n" ++
+  "  beqz a0, .Lsrbn_walk\n" ++
+  "  li a0, 3\n" ++
+  "  j .Lsrbn_ret\n" ++
+  ".Lsrbn_walk:\n" ++
+  "  mv a0, s3\n" ++
+  "  li a1, 20\n" ++
+  "  la a2, srbn_state_root\n" ++
+  "  mv a3, s4\n" ++
+  "  mv a4, s5\n" ++
+  "  la a5, srbn_walked_struct\n" ++
+  "  jal ra, account_at_address\n" ++
+  "  beqz a0, .Lsrbn_present\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Lsrbn_absent\n" ++
+  "  addi a0, a0, 3\n" ++
+  "  j .Lsrbn_ret\n" ++
+  ".Lsrbn_present:\n" ++
+  "  # Copy storage_root (offset +40, 32 B) to output.\n" ++
+  "  la t0, srbn_walked_struct\n" ++
+  "  ld t2, 40(t0); sd t2,  0(s6)\n" ++
+  "  ld t2, 48(t0); sd t2,  8(s6)\n" ++
+  "  ld t2, 56(t0); sd t2, 16(s6)\n" ++
+  "  ld t2, 64(t0); sd t2, 24(s6)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lsrbn_ret\n" ++
+  ".Lsrbn_absent:\n" ++
+  "  # buffer already zero (spec default).\n" ++
+  "  li a0, 4\n" ++
+  "  j .Lsrbn_ret\n" ++
+  ".Lsrbn_finish:\n" ++
+  "  bnez s9, .Lsrbn_parse_status\n" ++
+  ".Lsrbn_miss:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lsrbn_ret\n" ++
+  ".Lsrbn_parse_status:\n" ++
+  "  li a0, 2\n" ++
+  ".Lsrbn_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp)\n" ++
+  "  addi sp, sp, 96\n" ++
+  "  ret"
+
+/-- `zisk_storage_root_at_block_number_address`: probe BuildUnit.
+    Input layout (at INPUT_ADDR):
+      bytes  0.. 8 : (ziskemu metadata)
+      bytes  8..16 : witness_headers_len (u64 LE)
+      bytes 16..24 : witness_state_len (u64 LE)
+      bytes 24..32 : target_block_number (u64 LE)
+      bytes 32..52 : address (20 bytes)
+      bytes 52..   : witness.headers ++ witness.state
+    Output layout (40 bytes):
+      bytes  0.. 8 : status (0..6)
+      bytes  8..40 : storage_root (32 B; 0 on absent) -/
+def ziskStorageRootAtBlockNumberAddressPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t4, 0x40000000\n" ++
+  "  ld a2, 8(t4)                # witness_headers_len\n" ++
+  "  ld a5, 16(t4)               # witness_state_len\n" ++
+  "  ld a0, 24(t4)               # target_block_number\n" ++
+  "  addi a3, t4, 32             # address ptr\n" ++
+  "  addi a1, t4, 52             # witness.headers ptr\n" ++
+  "  add  a4, a1, a2             # witness.state ptr\n" ++
+  "  li a6, 0xa0010008           # storage_root out\n" ++
+  "  jal ra, storage_root_at_block_number_address\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lsrbn_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  mptLookupByKeyFunction ++ "\n" ++
+  accountDecodeFunction ++ "\n" ++
+  accountAtAddressFunction ++ "\n" ++
+  headerExtractNumberFunction ++ "\n" ++
+  headerExtractStateRootFunction ++ "\n" ++
+  storageRootAtBlockNumberAddressFunction ++ "\n" ++
+  ".Lsrbn_pdone:"
+
+def ziskStorageRootAtBlockNumberAddressDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mnk_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_dummy_length:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mbc_offset:\n" ++
+  "  .zero 8\n" ++
+  "mbc_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_lookup_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_lookup_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_lookup_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_child_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_nibble_count:\n" ++
+  "  .zero 8\n" ++
+  "mw_is_leaf:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_nibble_buf:\n" ++
+  "  .zero 128\n" ++
+  ".balign 32\n" ++
+  "mlk_keccak_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "mlk_nibble_buf:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "ad_offset:\n" ++
+  "  .zero 8\n" ++
+  "ad_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aa_value_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aa_value_scratch:\n" ++
+  "  .zero 256\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "hesr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hesr_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "srbn_number_scratch:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "srbn_state_root:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "srbn_walked_struct:\n" ++
+  "  .zero 104"
+
+def ziskStorageRootAtBlockNumberAddressProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskStorageRootAtBlockNumberAddressPrologue
+  dataAsm     := ziskStorageRootAtBlockNumberAddressDataSection
+}
+
+end EvmAsm.Codegen

--- a/scripts/codegen-zisk-storage-root-at-block-number-address-check.sh
+++ b/scripts/codegen-zisk-storage-root-at-block-number-address-check.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# codegen-zisk-storage-root-at-block-number-address-check.sh
+#
+# Number-keyed historical storage_root extractor. Completes
+# the 4-field block_number row alongside balance / nonce /
+# code_hash (PRs #7479 / #7481 / #7486).
+#
+# Spec defaults:
+#   account absent           -> 32 zero bytes (status 4)
+#   account present, empty   -> EMPTY_TRIE_ROOT (status 0)
+#   account present, nonempty-> actual storage_root
+#
+# Output (40 bytes):
+#   bytes  0.. 8 : status (0..6)
+#   bytes  8..40 : storage_root (32 B)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_storage_root_at_block_number_address ELF"
+lake exe codegen --program zisk_storage_root_at_block_number_address \
+  --halt linux93 \
+  -o gen-out/zisk_storage_root_at_block_number_address
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+  local target="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_srbn_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_srbn_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_srbn_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def hp_encode(nibbles, is_leaf):
+    flag = 2 if is_leaf else 0
+    if len(nibbles) % 2 == 1:
+        flag |= 1
+        result = bytes([flag * 0x10 + nibbles[0]])
+        nibbles = nibbles[1:]
+    else:
+        result = bytes([flag * 0x10])
+    for i in range(0, len(nibbles), 2):
+        result += bytes([nibbles[i] * 0x10 + nibbles[i+1]])
+    return result
+
+def leaf_node(path_nibbles, value):
+    return rlp.encode([hp_encode(path_nibbles, True), value])
+
+def bytes_to_nibbles(b):
+    out = []
+    for byte in b:
+        out.append(byte >> 4); out.append(byte & 0xf)
+    return out
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0: return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset); offset += len(e)
+    for e in elements: section += e
+    return section
+
+def encode_account(nonce, balance, storage_root, code_hash):
+    return rlp.encode([nonce, balance, storage_root, code_hash])
+
+def encode_header(number_val, state_root):
+    if number_val == 0:
+        number_field = b''
+    else:
+        nbytes = (number_val.bit_length() + 7) // 8
+        number_field = number_val.to_bytes(nbytes, 'big')
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x55'*32,
+        b'\\x66'*32, b'\\x00'*256, b'', number_field, b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    return rlp.encode(fields)
+
+EMPTY_TRIE = bytes.fromhex('56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421')
+EMPTY_CODE_HASH = bytes.fromhex('c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')
+
+def state_trie_one(addr, acct_rlp):
+    path = bytes_to_nibbles(k256(addr))
+    leaf = leaf_node(path, acct_rlp)
+    return k256(leaf), build_ssz_section([leaf])
+
+def storage_trie_one(slot_key_be, value_int):
+    if value_int == 0:
+        v_short = b''
+    else:
+        nbytes = (value_int.bit_length() + 7) // 8
+        v_short = value_int.to_bytes(nbytes, 'big')
+    path = bytes_to_nibbles(k256(slot_key_be))
+    leaf = leaf_node(path, rlp.encode(v_short))
+    return k256(leaf)
+
+mode = '$mode'
+target = int('$target')
+ALICE = b'\\xaa' * 20
+BOB = b'\\xbb' * 20
+
+if mode == 'empty_storage':
+    # Account with EMPTY_TRIE storage_root -- distinct from
+    # 32 zero bytes (the absent-account default).
+    acct = encode_account(0, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(100, b'\\xee'*32)
+    h1 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0, h1])
+    addr = ALICE
+    expected = struct.pack('<Q', 0) + EMPTY_TRIE
+elif mode == 'nonempty_storage':
+    # Pick a known slot/value to derive a deterministic
+    # non-EMPTY_TRIE root.
+    slot_key = (1).to_bytes(32, 'big')
+    sroot = storage_trie_one(slot_key, 42)
+    acct = encode_account(0, 0, sroot, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0])
+    addr = ALICE
+    expected = struct.pack('<Q', 0) + sroot
+elif mode == 'absent_account':
+    # ALICE not in trie -> spec default 32 zero bytes (NOT
+    # EMPTY_TRIE; this row distinguishes from empty-storage).
+    acct = encode_account(0, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(BOB, acct)
+    h0 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0])
+    addr = ALICE
+    expected = struct.pack('<Q', 4) + b'\\x00' * 32
+elif mode == 'number_miss':
+    acct = encode_account(0, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(100, sr)
+    witness_headers = build_ssz_section([h0])
+    addr = ALICE
+    expected = struct.pack('<Q', 1) + b'\\x00' * 32
+else:
+    raise SystemExit('bad mode')
+
+with open(sys.argv[1], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(witness_headers))
+        + struct.pack('<Q', len(witness_state))
+        + struct.pack('<Q', target)
+        + addr
+        + witness_headers
+        + witness_state
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_storage_root_at_block_number_address.elf \
+    -i "$in_file" -o "$out_file" -n 6000000 \
+    >"$REPO_ROOT/gen-out/zisk_srbn_${name}.emu.log" 2>&1 || true
+
+  local exp_size
+  exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-40s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-40s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "empty_storage_returns_emptytrie"     empty_storage 101 || FAILED=1
+run_case "nonempty_storage_returns_root"       nonempty_storage 101 || FAILED=1
+run_case "absent_account_returns_zero"         absent_account 101 || FAILED=1
+run_case "number_not_in_section"               number_miss 999 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: storage_root_at_block_number_address end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Number-keyed historical storage_root extractor. **Completes
the 4-field block_number row** alongside the just-opened
siblings:

| field         | by_hash | by_number | by_state_root |
|---------------|---------|-----------|---------------|
| balance       | #7326   | (#7479)   | (existing)    |
| nonce         | (mer.)  | (#7481)   | (existing)    |
| code_hash     | #7320   | (#7486)   | (existing)    |
| storage_root  | #7314   | **this**  | (existing)    |

The block_number row now has **full per-field coverage**,
mirroring the established block_hash row.

Pipeline (composes K233 scan + K201 + K28; no new helpers):

\`\`\`
witness.headers ∋ ?h with h.block.number == target  [K233]
h -> header_extract_state_root                      [K201]
state_root + address -> account                     [K28]
struct.storage_root (offset +40, 32 B) -> 32-byte out
\`\`\`

A present-but-with-empty-storage account returns
\`EMPTY_TRIE_ROOT\` (\`0x56e8...\`) — **distinct from the
32-zero-bytes absent case**. Callers branching on storage
emptiness should compare against \`EMPTY_TRIE_ROOT\`, not
against zero.

Use cases:
- Storage-trie freshness audit: compare storage_root at
  successive block_numbers to detect storage writes without
  enumerating slots.
- Light-client cold-call gate: \`storage_root == EMPTY_TRIE\`
  → SLOAD always returns 0; skip the storage-trie walk.
- Bridge consistency: counter-party records storage_root at
  height N; verify directly.

Status codes:

| status | meaning |
|--------|---------|
| 0 | success (storage_root written; EMPTY_TRIE if empty storage; 32 zero bytes if absent via status 4) |
| 1 | no header with target block_number |
| 2 | K233 parse failure during scan |
| 3 | matched header state_root extraction failure |
| 4 | account absent in state trie (buffer zero) |
| 5 | state-trie mpt parse error |
| 6 | account RLP decode failure |

## Test plan

- [x] \`lake build codegen\` succeeds.
- [x] \`bash scripts/codegen-zisk-storage-root-at-block-number-address-check.sh\` — 4/4 fixtures pass:
  - \`empty_storage_returns_emptytrie\` (in-trie EOA with empty storage → EMPTY_TRIE_ROOT)
  - \`nonempty_storage_returns_root\` (real storage_root from a 1-slot trie)
  - \`absent_account_returns_zero\` (status=4; **distinct** from empty_storage)
  - \`number_not_in_section\` (status=1)
- [x] No \`native_decide\` / \`bv_decide\`; aligned LD/SD only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)