### PR TITLE
feat(divmod): v5 n=3 accumulated-quotient telescope (acc_quot_eq_div)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -236,6 +236,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5ThreeStep
 import EvmAsm.Evm64.DivMod.Spec.N2V5RemainderLt
 import EvmAsm.Evm64.DivMod.Spec.N3V5RemainderLt
 import EvmAsm.Evm64.DivMod.Spec.N3V5DigitStepIter
+import EvmAsm.Evm64.DivMod.Spec.N3V5AccQuot
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormScaled
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLaneShape

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -237,6 +237,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5RemainderLt
 import EvmAsm.Evm64.DivMod.Spec.N3V5RemainderLt
 import EvmAsm.Evm64.DivMod.Spec.N3V5DigitStepIter
 import EvmAsm.Evm64.DivMod.Spec.N3V5AccQuot
+import EvmAsm.Evm64.DivMod.Spec.N3V5QuotientShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormScaled
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLaneShape

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -278,6 +278,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopUnifiedPost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopSelected
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopPreloop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFull
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePost

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopPreloop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopPreloop.lean
@@ -17,6 +17,10 @@
 import EvmAsm.Evm64.DivMod.Compose.PhaseBV5
 import EvmAsm.Evm64.DivMod.Compose.PhaseAV5
 import EvmAsm.Evm64.DivMod.Compose.CLZV5
+import EvmAsm.Evm64.DivMod.Compose.PhaseC2V5
+import EvmAsm.Evm64.DivMod.Compose.NormBV5
+import EvmAsm.Evm64.DivMod.Compose.NormAV5
+import EvmAsm.Evm64.DivMod.Compose.LoopSetupV5
 import EvmAsm.Evm64.DivMod.Compose.PhaseABV4NoNop
 
 open EvmAsm.Rv64.Tactics
@@ -213,5 +217,214 @@ theorem evm_div_phaseAB_n3_clz_spec_within_v5_noNop (sp base : Word)
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
     hABCLZ
+
+/-- PhaseAB(n=3) + CLZ + PhaseC2(ntaken) + NormB over `divCode_noNop_v5`. -/
+theorem evm_div_n3_to_normB_spec_within_v5_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21) base (base + normAOff) (divCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (normBPost sp (3 : Word) (clzResult b2).1 b0 b1 b2 b3) := by
+  let shift := (clzResult b2).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  have hABCLZ := evm_div_phaseAB_n3_clz_spec_within_v5_noNop sp base b0 b1 b2 b3
+    v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2nz
+  have hABCLZf := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
+    (by pcFree) hABCLZ
+  have hC2 := divK_phaseC2_ntaken_spec_within_v5_noNop sp shift ((clzResult b2).2 >>> (63 : Nat))
+    shiftMem base hshift_nz
+  have hC2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ (clzResult b2).2) ** (.x10 ↦ᵣ b3) **
+     (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)))
+    (by pcFree) hC2
+  have hABC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABCLZf hC2f
+  have hNB := divK_normB_full_spec_within_v5_noNop sp b0 b1 b2 b3
+    (clzResult b2).2 ((clzResult b2).2 >>> (63 : Nat))
+    shift antiShift base
+  simp only [normBFullPost_unfold] at hNB
+  have hNBf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNB
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABC2 hNBf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta normBPost; xperm_hyp hq)
+    hFull
+
+/-- n=3 preloop entry-to-loopSetup over `divCode_noNop_v5`. base → base+loopBodyOff. -/
+theorem evm_div_n3_to_loopSetup_spec_within_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (divCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (loopSetupPost sp (3 : Word) (clzResult b2).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := (clzResult b2).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  have hNB := evm_div_n3_to_normB_spec_within_v5_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u5 u6 u7 nMem shiftMem hbnz hb3z hb2nz hshift_nz
+  have hNBf := cpsTripleWithin_frameR
+    ((.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+     ((sp + signExtend12 4024) ↦ₘ u4Old))
+    (by pcFree) hNB
+  have hNormA := divK_normA_full_spec_within_v5_noNop sp a0 a1 a2 a3
+    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
+    u0Old u1Old u2Old u3Old u4Old base
+  rw [divKNormAFullPreNoNop_unfold] at hNormA
+  simp only [normAFullPost_unfold] at hNormA
+  have hNormAf := cpsTripleWithin_frameR
+    ((.x0 ↦ᵣ (0 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ ((b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)))) **
+     ((sp + 56) ↦ₘ ((b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)))) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNormA
+  have hNA := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by delta normBPost at hp; xperm_hyp hp) hNBf hNormAf
+  have hLS := divK_loopSetup_ntaken_spec_within_v5_noNop sp (3 : Word)
+    (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
+    (by decide)
+  simp only [divKLoopSetupNtakenPreNoNop_unfold,
+      divKLoopSetupNtakenPostNoNop_unfold] at hLS
+  have hLSf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ ((b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)))) **
+     ((sp + 56) ↦ₘ ((b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)))) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+     ((sp + signExtend12 4040) ↦ₘ u2) **
+     ((sp + signExtend12 4032) ↦ₘ (a3 <<< (shift.toNat % 64) ||| a2 >>> (antiShift.toNat % 64))) **
+     ((sp + signExtend12 4024) ↦ₘ (a3 >>> (antiShift.toNat % 64))) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hLS
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hNA hLSf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta loopSetupPost; xperm_hyp hq)
+    hFull
+
+/-- n=3 v5/no-NOP entry→loopSetup with the loop's x1+scratch frame already in
+    place.  frameR + weaken around `evm_div_n3_to_loopSetup_spec_within_v5_noNop`. -/
+theorem evm_div_n3_to_loopSetup_spec_within_v5_noNop_exact_x1_scratch_frame
+    (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff)
+      (divCode_noNop_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      (loopSetupPost sp (3 : Word) (clzResult b2).1 a0 a1 a2 a3 b0 b1 b2 b3 **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal))) := by
+  have hPre :=
+    evm_div_n3_to_loopSetup_spec_within_v5_noNop sp base a0 a1 a2 a3 b0 b1 b2 b3
+      v5 v6 v7 v10 q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+      hbnz hb3z hb2nz hshift_nz
+  have hFramed := cpsTripleWithin_frameR
+    (((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+      (sp + signExtend12 3968 ↦ₘ retMem) **
+      (sp + signExtend12 3960 ↦ₘ dMem) **
+      (sp + signExtend12 3952 ↦ₘ dloMem) **
+      (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+      (sp + signExtend12 3936 ↦ₘ scratchMem) **
+      (.x1 ↦ᵣ raVal)))
+    (by pcFree) hPre
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hFramed
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopPreloop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopPreloop.lean
@@ -1,0 +1,157 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloop
+
+  The v5 n=3 preloop execution-spec chain (entry → loop setup) over
+  `divCode_noNop_v5`.  The n=3 analog of `FullPathN2V5NoNopPreloop`, and the
+  V4→V5 lift of the n=3 preloop pieces in `FullPathN3V4NoNopPreloop` /
+  `PhaseABV4NoNop`: the preloop instructions are identical between v4 and v5
+  (they precede the div128 block), so each piece re-proves over `divCode_noNop_v5`
+  by swapping the per-instruction code-subsumption lemmas `*_sub_divCode_noNop_v4`
+  → `*_sub_divCode_noNop_v5` (PhaseBV5).  Bead `evm-asm-wbc4i.9.3.3.1`.
+
+  This file currently provides phase B (n=3 divisor-width detection: b3=0, b2≠0,
+  writing nMem=3).  The branch structure differs from n=2: the `bne x7` (b2)
+  check is TAKEN (b2≠0), jumping straight to the tail with x5=3.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.PhaseBV5
+import EvmAsm.Evm64.DivMod.Compose.PhaseABV4NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v5 phase-B (n=3 detection: b3=0, b2≠0), over `divCode_noNop_v5`.
+    V4→V5 lift of `evm_div_phaseB_n3_spec_within_v4_noNop` (swapping the
+    per-instruction code-subsumption lemmas to their v5 forms). -/
+theorem evm_div_phaseB_n3_spec_within_v5_noNop (sp base : Word)
+    (b1 b2 b3 : Word) (v5 v6 v7 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0) :
+    cpsTripleWithin 21 (base + phaseBOff) (base + clzOff) (divCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) **
+       ((sp + signExtend12 3984) ↦ₘ nMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+       ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 3984) ↦ₘ (3 : Word))) := by
+  have hinit1_raw := divK_phaseB_init1_spec_within sp (base + phaseBOff) q0 q1 q2 q3 u5 u6 u7
+  simp only [phB_off_28] at hinit1_raw
+  have hinit1 := cpsTripleWithin_extend_code divK_phaseB_init1_code_sub_divCode_noNop_v5 hinit1_raw
+  have hinit1f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hinit1
+  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + phaseBInit2Off) b1 b2 v6 v7
+  simp only [phB_i2_8_v4] at hinit2_raw
+  have hinit2 := cpsTripleWithin_extend_code divK_phaseB_init2_code_sub_divCode_noNop_v5 hinit2_raw
+  have hinit2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+     ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hinit2
+  have h12 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_chunked hp) hinit1f hinit2f
+  have haddi0_raw := addi_x0_spec_gen_within .x5 v5 4 (base + phaseBStep0Off) (by nofun)
+  simp only [phB_addi_4_v4, signExtend12_4] at haddi0_raw
+  have haddi0 := cpsTripleWithin_extend_code addi_x5_singleton_sub_divCode_noNop_v5 haddi0_raw
+  have haddi0f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) haddi0
+  have h123 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_chunked hp) h12 haddi0f
+  have hbne0_raw := bne_spec_gen_within .x10 .x0 24 b3 (0 : Word) (base + phaseBBneOff)
+  rw [show (base + phaseBBneOff : Word) + signExtend13 24 = base + phaseBTailOff from by
+        rv64_addr, phB_bne_4_v4] at hbne0_raw
+  have hbne0_clean := cpsBranchWithin_ntakenStripPure2 hbne0_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd hb3z ((sepConj_pure_right _).mp h_rest).2)
+  have hbne0 := cpsTripleWithin_extend_code bne_x10_singleton_sub_divCode_noNop_v5 hbne0_clean
+  have hbne0f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hbne0
+  have h1234 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_chunked hp) h123 hbne0f
+  have haddi1_raw := addi_x0_spec_gen_within .x5 (4 : Word) 3 (base + phaseBStep1Off) (by nofun)
+  simp only [phB_step1_4_v4, signExtend12_3] at haddi1_raw
+  have haddi1 := cpsTripleWithin_extend_code addi_x5_3_sub_divCode_noNop_v5 haddi1_raw
+  have haddi1f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) haddi1
+  have h12345 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_chunked hp) h1234 haddi1f
+  have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + phaseBBne2Off)
+  rw [show (base + phaseBBne2Off : Word) + signExtend13 16 = base + phaseBTailOff from by
+        rv64_addr, phB_step1_8_v4] at hbne1_raw
+  have hbne1_clean := cpsBranchWithin_takenStripPure2 hbne1_raw
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hb2nz)
+  have hbne1 := cpsTripleWithin_extend_code bne_x7_16_sub_divCode_noNop_v5 hbne1_clean
+  have hbne1f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hbne1
+  have h123456 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_chunked hp) h12345 hbne1f
+  have htail_raw := divK_phaseB_tail_spec_within sp (3 : Word) b2 nMem (base + phaseBTailOff)
+  simp only [divK_phaseB_tail_pre_unfold, divK_phaseB_tail_post_unfold,
+             phB_t_20_v4, divK_phaseB_n3_nm1_x8_v4, signExtend12_32, phB_sp16_32_v4] at htail_raw
+  have htail := cpsTripleWithin_extend_code divK_phaseB_tail_code_sub_divCode_noNop_v5 htail_raw
+  have htailf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)))
+    (by pcFree) htail
+  have hphaseB := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h123456 htailf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hphaseB
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopPreloop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopPreloop.lean
@@ -15,6 +15,8 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.PhaseBV5
+import EvmAsm.Evm64.DivMod.Compose.PhaseAV5
+import EvmAsm.Evm64.DivMod.Compose.CLZV5
 import EvmAsm.Evm64.DivMod.Compose.PhaseABV4NoNop
 
 open EvmAsm.Rv64.Tactics
@@ -153,5 +155,63 @@ theorem evm_div_phaseB_n3_spec_within_v5_noNop (sp base : Word)
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
     hphaseB
+
+/-- PhaseA(ntaken) + PhaseB(n=3) + CLZ(b2) over `divCode_noNop_v5`.
+    Mirror of `evm_div_phaseAB_n2_clz_spec_within_v5_noNop`, with phase-B n=3 and
+    the CLZ taken on `b2` (the n=3 top divisor limb). -/
+theorem evm_div_phaseAB_n3_clz_spec_within_v5_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24) base (base + phaseC2Off) (divCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b2).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ (clzResult b2).1) ** (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word))) := by
+  have hA := evm_div_phaseA_ntaken_spec_within_v5_noNop sp base b0 b1 b2 b3 v5 v10 hbnz
+  have hAf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+     ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+     ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hA
+  have hB := evm_div_phaseB_n3_spec_within_v5_noNop sp base b1 b2 b3
+    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 nMem
+    hb3z hb2nz
+  have hBf := cpsTripleWithin_frameR
+    (((sp + 32) ↦ₘ b0))
+    (by pcFree) hB
+  have hAB := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hAf hBf
+  have hCLZ := divK_clz_spec_within_v5_noNop b2 b1 b2 base
+  have hCLZf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)))
+    (by pcFree) hCLZ
+  have hABCLZ := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hAB hCLZf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hABCLZ
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseABV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseABV4NoNop.lean
@@ -40,7 +40,7 @@ theorem divK_phaseB_n1_nm1_x8_v4 :
 theorem divK_phaseB_n2_nm1_x8_v4 :
     ((2 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat = (8 : Word) := by
   decide
-private theorem divK_phaseB_n3_nm1_x8_v4 :
+theorem divK_phaseB_n3_nm1_x8_v4 :
     ((3 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat = (16 : Word) := by
   decide
 private theorem divK_phaseB_n4_nm1_x8_v4 :
@@ -52,7 +52,7 @@ theorem phB_sp0_32_v4 {sp : Word} :
 theorem phB_sp8_32_v4 {sp : Word} :
     (sp + (8 : Word) + (32 : Word)) = sp + 40 := by
   bv_addr
-private theorem phB_sp16_32_v4 {sp : Word} :
+theorem phB_sp16_32_v4 {sp : Word} :
     (sp + (16 : Word) + (32 : Word)) = sp + 48 := by
   bv_addr
 private theorem phB_sp24_32_v4 {sp : Word} :

--- a/EvmAsm/Evm64/DivMod/Spec/N3V5AccQuot.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V5AccQuot.lean
@@ -1,0 +1,316 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3V5AccQuot
+
+  The v5 n=3 accumulated-quotient telescope (foundation).  n=3 has a 3-limb
+  divisor and a 4-limb dividend → 2 outer iterations (digits r1, r0), the
+  per-digit windows being 4 limbs wide (one wider than n=2).
+
+  This file currently provides the FIRST-WINDOW validity seed for the telescope:
+  the top-4-limb normalized window is `< 2^64 · val256 normV`, the `hvalid`
+  hypothesis of the digit-1 step.  Mirrors n2's `fullDivN2_first_window_valid`
+  (`N2V5NormScaled.lean`), using the (version-independent) normalization scaling
+  bridges from `N3RemainderWordV4`/`DivN3NormVStructure`.  Bead `evm-asm-wbc4i.9.3.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N3RemainderWordV4
+import EvmAsm.Evm64.DivMod.Spec.N2V5NormScaled
+import EvmAsm.Evm64.DivMod.Spec.N3V5DigitStepIter
+import EvmAsm.Evm64.EvmWordArith.DivN3NormVStructure
+import EvmAsm.Evm64.EvmWordArith.DivLimbBridge
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- **Top-4-limb first-window core (n=3).**  Generic Nat lemma: if the 5 limbs of
+    the normalized dividend sum (with weights) to `A·S` (`A < 2^256`, `S > 0`) and
+    the divisor value `B ≥ 2^128`, then the top-4-limb window is `< 2^64·(B·S)`.
+    The n=3 analog of `first_window_core` (which extracts the top 3 limbs). -/
+theorem first_window_core_n3 (n0 n1 n2 n3 n4 A B S : Nat)
+    (hU : n0 + 2 ^ 64 * n1 + 2 ^ 128 * n2 + 2 ^ 192 * n3 + 2 ^ 256 * n4 = A * S)
+    (hA : A < 2 ^ 256) (hB : 2 ^ 128 ≤ B) (hSpos : 0 < S) :
+    n1 + 2 ^ 64 * n2 + 2 ^ 128 * n3 + 2 ^ 192 * n4 < 2 ^ 64 * (B * S) := by
+  have hW1le : 2 ^ 64 * (n1 + 2 ^ 64 * n2 + 2 ^ 128 * n3 + 2 ^ 192 * n4) ≤ A * S := by
+    nlinarith [hU]
+  have hAB : A * S < 2 ^ 128 * (B * S) := by nlinarith [hA, hB, hSpos]
+  have hchain : 2 ^ 64 * (n1 + 2 ^ 64 * n2 + 2 ^ 128 * n3 + 2 ^ 192 * n4)
+      < 2 ^ 64 * (2 ^ 64 * (B * S)) := by nlinarith [hW1le, hAB]
+  exact Nat.lt_of_mul_lt_mul_left hchain
+
+/-- **v5 n=3 first-window validity (digit r1).**  The top-4-limb normalized
+    window `(u₁,u₂,u₃,u₄)` is `< 2^64 · val256 normV`, the `hvalid` hypothesis of
+    the digit-1 per-digit step.  Follows from the normalization scaling bridge
+    (`val256 normU + nu₄·2^256 = val256 a·2^s`), the dividend bound
+    `val256 a < 2^256`, and the divisor bound `val256 b ≥ 2^128` (3-limb, `b₂≠0`). -/
+theorem fullDivN3_first_window_valid (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb3z : b3 = 0) (hshift_nz : (clzResult b2).1 ≠ 0) (hb2nz : b2 ≠ 0) :
+    val256 (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+      < 2 ^ 64 * val256 (fullDivN3NormV b0 b1 b2 b3).1
+          (fullDivN3NormV b0 b1 b2 b3).2.1 (fullDivN3NormV b0 b1 b2 b3).2.2.1 0 := by
+  have hsnz : fullDivN3Shift b2 ≠ 0 := by unfold fullDivN3Shift; exact hshift_nz
+  have hscaleU := fullDivN3NormU_val256_eq_scaled_with_overflow a0 a1 a2 a3 b2 hsnz
+  have hscaleV := fullDivN3NormV_val256_eq_scaled_of_b3_zero b0 b1 b2 b3 hsnz hb3z
+  have hvtop := fullDivN3NormV_top_zero_of_shape_shift_nz b0 b1 b2 b3 hb3z hshift_nz
+  rw [hvtop] at hscaleV
+  have hA := val256_bound a0 a1 a2 a3
+  have hB : 2 ^ 128 ≤ val256 b0 b1 b2 b3 := val256_ge_pow128_of_limb2 b0 b1 b2 b3 hb2nz
+  have hSpos : 0 < 2 ^ (fullDivN3Shift b2).toNat := by positivity
+  have hU : (fullDivN3NormU a0 a1 a2 a3 b2).1.toNat
+      + 2 ^ 64 * (fullDivN3NormU a0 a1 a2 a3 b2).2.1.toNat
+      + 2 ^ 128 * (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1.toNat
+      + 2 ^ 192 * (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1.toNat
+      + 2 ^ 256 * (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2.toNat
+      = val256 a0 a1 a2 a3 * 2 ^ (fullDivN3Shift b2).toNat := by
+    rw [← hscaleU]; simp only [EvmWord.val256]; ring
+  have hWexp : val256 (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+      (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+      (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+      (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+      = (fullDivN3NormU a0 a1 a2 a3 b2).2.1.toNat
+        + 2 ^ 64 * (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1.toNat
+        + 2 ^ 128 * (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1.toNat
+        + 2 ^ 192 * (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2.toNat := by
+    simp only [EvmWord.val256]; ring
+  rw [hWexp, hscaleV]
+  exact first_window_core_n3 _ _ _ _ _ _ _ _ hU hA hB hSpos
+
+/-- **v5 n=3 unified per-digit step** (dispatch on the runtime flag `bltu`).
+    Combines the call/max per-digit steps (`N3V5DigitStepIter`) into the single
+    `bltu`-parameterized form consumed by the `_step_of_shape` telescope lemmas,
+    mirroring n2's `iterN2V5_step`.  `hcall`/`hmax` are the dispatched `u₃ < v₂`
+    comparisons. -/
+theorem iterN3V5_step (bltu : Bool) (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63)
+    (hvalid : val256 u0 u1 u2 u3 < 2 ^ 64 * val256 v0 v1 v2 0)
+    (hcall : bltu = true → BitVec.ult u3 v2 = true)
+    (hmax : bltu = false → ¬ BitVec.ult u3 v2) :
+    val256 u0 u1 u2 u3 =
+        (iterN3V5 bltu v0 v1 v2 0 u0 u1 u2 u3 0).1.toNat * val256 v0 v1 v2 0 +
+        ((iterN3V5 bltu v0 v1 v2 0 u0 u1 u2 u3 0).2.1.toNat +
+          2 ^ 64 * (iterN3V5 bltu v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1.toNat +
+          2 ^ 128 * (iterN3V5 bltu v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1.toNat) ∧
+      (iterN3V5 bltu v0 v1 v2 0 u0 u1 u2 u3 0).2.1.toNat +
+          2 ^ 64 * (iterN3V5 bltu v0 v1 v2 0 u0 u1 u2 u3 0).2.2.1.toNat +
+          2 ^ 128 * (iterN3V5 bltu v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.1.toNat <
+        val256 v0 v1 v2 0 := by
+  cases bltu with
+  | true =>
+    have hu : u3.toNat < v2.toNat := by
+      have := hcall rfl; rw [BitVec.ult] at this; exact of_decide_eq_true this
+    exact iterN3V5_call_step v0 v1 v2 u0 u1 u2 u3 hv2 hu
+  | false =>
+    exact iterN3V5_max_step v0 v1 v2 u0 u1 u2 u3 hv2 (hmax rfl) hvalid
+
+/-- **v5 n=3 unified per-digit remainder collapse** (dispatch on `bltu`).  The
+    3-limb-divisor remainder fits in three limbs: `rem₃` and the overflow carry
+    are both zero.  Mirrors n2's `iterN2V5_collapse`. -/
+theorem iterN3V5_collapse (bltu : Bool) (v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hv2 : v2.toNat ≥ 2^63)
+    (hvalid : val256 u0 u1 u2 u3 < 2 ^ 64 * val256 v0 v1 v2 0)
+    (hcall : bltu = true → BitVec.ult u3 v2 = true)
+    (hmax : bltu = false → ¬ BitVec.ult u3 v2) :
+    (iterN3V5 bltu v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.1 = 0 ∧
+    (iterN3V5 bltu v0 v1 v2 0 u0 u1 u2 u3 0).2.2.2.2.2 = 0 := by
+  cases bltu with
+  | true =>
+    have hu : u3.toNat < v2.toNat := by
+      have := hcall rfl; rw [BitVec.ult] at this; exact of_decide_eq_true this
+    exact iterN3V5_call_collapse v0 v1 v2 u0 u1 u2 u3 hv2 hu
+  | false =>
+    exact iterN3V5_max_collapse v0 v1 v2 u0 u1 u2 u3 hv2 (hmax rfl) hvalid
+
+/-- **Next-window validity (n=3).**  If the previous 3-limb remainder is `< V`,
+    the next digit's 4-limb window `val256(nu, r₀, r₁, r₂)` is `< 2^64·V`.
+    Propagates the window-validity invariant across the two n=3 digits.  The
+    n=3 analog of `n2_next_window_lt` (one limb wider). -/
+theorem n3_next_window_lt (nu r0 r1 r2 : Word) (V : Nat)
+    (h : r0.toNat + 2 ^ 64 * r1.toNat + 2 ^ 128 * r2.toNat < V) :
+    val256 nu r0 r1 r2 < 2 ^ 64 * V := by
+  have hnu := nu.isLt
+  have hexp : val256 nu r0 r1 r2 =
+      nu.toNat + 2 ^ 64 * (r0.toNat + 2 ^ 64 * r1.toNat + 2 ^ 128 * r2.toNat) := by
+    simp only [EvmWord.val256]; ring
+  rw [hexp]
+  calc nu.toNat + 2 ^ 64 * (r0.toNat + 2 ^ 64 * r1.toNat + 2 ^ 128 * r2.toNat)
+      < 2 ^ 64 + 2 ^ 64 * (r0.toNat + 2 ^ 64 * r1.toNat + 2 ^ 128 * r2.toNat) := by omega
+    _ = 2 ^ 64 * ((r0.toNat + 2 ^ 64 * r1.toNat + 2 ^ 128 * r2.toNat) + 1) := by ring
+    _ ≤ 2 ^ 64 * V := Nat.mul_le_mul_left _ h
+
+/-- **fullDivN3R1V5 step over the normalized window** (digit 1, the first
+    window).  `hvalid` is derived internally from `fullDivN3_first_window_valid`. -/
+theorem fullDivN3R1V5_step_of_shape (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (bltu_1 : Bool)
+    (hb3z : b3 = 0) (hshift_nz : (clzResult b2).1 ≠ 0) (hb2nz : b2 ≠ 0)
+    (hcall : bltu_1 = true →
+      BitVec.ult (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2 (fullDivN3NormV b0 b1 b2 b3).2.2.1 = true)
+    (hmax : bltu_1 = false →
+      ¬ BitVec.ult (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2 (fullDivN3NormV b0 b1 b2 b3).2.2.1) :
+    val256 (fullDivN3NormU a0 a1 a2 a3 b2).2.1 (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1 (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2 =
+      (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat *
+        val256 (fullDivN3NormV b0 b1 b2 b3).1 (fullDivN3NormV b0 b1 b2 b3).2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.1 0 +
+        ((fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.1.toNat +
+          2 ^ 64 * (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1.toNat +
+          2 ^ 128 * (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1.toNat) ∧
+      (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.1.toNat +
+          2 ^ 64 * (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1.toNat +
+          2 ^ 128 * (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1.toNat <
+        val256 (fullDivN3NormV b0 b1 b2 b3).1 (fullDivN3NormV b0 b1 b2 b3).2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.1 0 := by
+  have hvtop := fullDivN3NormV_top_zero_of_shape_shift_nz b0 b1 b2 b3 hb3z hshift_nz
+  have hmsb := fullDivN3NormV_msb_of_b2_ne_zero b0 b1 b2 b3 hb2nz
+  have hvalid := fullDivN3_first_window_valid a0 a1 a2 a3 b0 b1 b2 b3 hb3z hshift_nz hb2nz
+  have hrw : fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3 =
+      iterN3V5 bltu_1 (fullDivN3NormV b0 b1 b2 b3).1 (fullDivN3NormV b0 b1 b2 b3).2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1 0
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.1 (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1 (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2 0 := by
+    unfold fullDivN3R1V5; dsimp only; rw [hvtop]
+  rw [hrw]
+  exact iterN3V5_step bltu_1 _ _ _ _ _ _ _ hmsb hvalid hcall hmax
+
+/-- **fullDivN3R1V5 remainder collapse** (digit 1): `rem₃` and carry are zero. -/
+theorem fullDivN3R1V5_collapse_of_shape (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (bltu_1 : Bool)
+    (hb3z : b3 = 0) (hshift_nz : (clzResult b2).1 ≠ 0) (hb2nz : b2 ≠ 0)
+    (hcall : bltu_1 = true →
+      BitVec.ult (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2 (fullDivN3NormV b0 b1 b2 b3).2.2.1 = true)
+    (hmax : bltu_1 = false →
+      ¬ BitVec.ult (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2 (fullDivN3NormV b0 b1 b2 b3).2.2.1) :
+    (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 = 0 ∧
+    (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.2 = 0 := by
+  have hvtop := fullDivN3NormV_top_zero_of_shape_shift_nz b0 b1 b2 b3 hb3z hshift_nz
+  have hmsb := fullDivN3NormV_msb_of_b2_ne_zero b0 b1 b2 b3 hb2nz
+  have hvalid := fullDivN3_first_window_valid a0 a1 a2 a3 b0 b1 b2 b3 hb3z hshift_nz hb2nz
+  have hrw : fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3 =
+      iterN3V5 bltu_1 (fullDivN3NormV b0 b1 b2 b3).1 (fullDivN3NormV b0 b1 b2 b3).2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1 0
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.1 (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1 (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2 0 := by
+    unfold fullDivN3R1V5; dsimp only; rw [hvtop]
+  rw [hrw]
+  exact iterN3V5_collapse bltu_1 _ _ _ _ _ _ _ hmsb hvalid hcall hmax
+
+/-- **fullDivN3R0V5 step over the normalized window** (digit 0, chained on the
+    digit-1 remainder via `hpc : r₁.rem₃ = 0` and the propagated `hvalid`). -/
+theorem fullDivN3R0V5_step_of_shape (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (bltu_1 bltu_0 : Bool)
+    (hb3z : b3 = 0) (hshift_nz : (clzResult b2).1 ≠ 0) (hb2nz : b2 ≠ 0)
+    (hpc : (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 = 0)
+    (hvalid : val256 (fullDivN3NormU a0 a1 a2 a3 b2).1
+        (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+        (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+        (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        < 2 ^ 64 * val256 (fullDivN3NormV b0 b1 b2 b3).1 (fullDivN3NormV b0 b1 b2 b3).2.1
+            (fullDivN3NormV b0 b1 b2 b3).2.2.1 0)
+    (hcall : bltu_0 = true →
+      BitVec.ult (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1 = true)
+    (hmax : bltu_0 = false →
+      ¬ BitVec.ult (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1) :
+    val256 (fullDivN3NormU a0 a1 a2 a3 b2).1
+        (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+        (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+        (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 =
+      (fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat *
+        val256 (fullDivN3NormV b0 b1 b2 b3).1 (fullDivN3NormV b0 b1 b2 b3).2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.1 0 +
+        ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1.toNat +
+          2 ^ 64 * (fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1.toNat +
+          2 ^ 128 * (fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1.toNat) ∧
+      (fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1.toNat +
+          2 ^ 64 * (fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1.toNat +
+          2 ^ 128 * (fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1.toNat <
+        val256 (fullDivN3NormV b0 b1 b2 b3).1 (fullDivN3NormV b0 b1 b2 b3).2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.1 0 := by
+  have hvtop := fullDivN3NormV_top_zero_of_shape_shift_nz b0 b1 b2 b3 hb3z hshift_nz
+  have hmsb := fullDivN3NormV_msb_of_b2_ne_zero b0 b1 b2 b3 hb2nz
+  have hrw : fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 =
+      iterN3V5 bltu_0 (fullDivN3NormV b0 b1 b2 b3).1 (fullDivN3NormV b0 b1 b2 b3).2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1 0
+        (fullDivN3NormU a0 a1 a2 a3 b2).1
+        (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+        (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+        (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 0 := by
+    unfold fullDivN3R0V5; dsimp only; rw [hvtop, hpc]
+  rw [hrw]
+  exact iterN3V5_step bltu_0 _ _ _ _ _ _ _ hmsb hvalid hcall hmax
+
+/-- The v5 n=3 2-digit accumulation (pure `Nat`).  `W1` is the top 4-limb window
+    value; `R1r` is the collapsed 3-limb intermediate remainder, `R0r` the final
+    remainder.  The n=3 analog of `fullDivN2V5_three_step_nat`, one digit shorter
+    (4-limb dividend / 3-limb divisor → 2 digits). -/
+theorem fullDivN3V5_two_step_nat
+    {a V q1 q0 nu0 W1 R1r R0r : Nat}
+    (hfirst : a = nu0 + 2 ^ 64 * W1)
+    (hstep1 : W1 = q1 * V + R1r)
+    (hstep0 : nu0 + 2 ^ 64 * R1r = q0 * V + R0r) :
+    a = (q1 * 2 ^ 64 + q0) * V + R0r := by
+  subst hfirst hstep1
+  nlinarith [hstep0]
+
+/-- **v5 n=3 accumulated quotient correctness (shift≠0).**  The two v5 n=3
+    quotient digits combine to exactly `val256 a / val256 b`.  Telescopes the two
+    per-digit steps (R1/R0) — chained via the window-validity invariant and the
+    digit-1 collapse — through `fullDivN3V5_two_step_nat` into the normalized
+    Euclidean equation, then `div_quotient_of_normalized` recovers the quotient.
+    The `bltu` arguments match the per-digit `u₃ < v₂` comparisons. -/
+theorem fullDivN3_acc_quot_eq_div_of_shape
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (bltu_1 bltu_0 : Bool)
+    (hb3z : b3 = 0) (hshift_nz : (clzResult b2).1 ≠ 0) (hb2nz : b2 ≠ 0)
+    (hc1 : bltu_1 = true →
+      BitVec.ult (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2 (fullDivN3NormV b0 b1 b2 b3).2.2.1 = true)
+    (hm1 : bltu_1 = false →
+      ¬ BitVec.ult (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2 (fullDivN3NormV b0 b1 b2 b3).2.2.1)
+    (hc0 : bltu_0 = true →
+      BitVec.ult (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1 = true)
+    (hm0 : bltu_0 = false →
+      ¬ BitVec.ult (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1) :
+    (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat * 2 ^ 64
+        + (fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat
+      = val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 := by
+  have hsnz : fullDivN3Shift b2 ≠ 0 := by unfold fullDivN3Shift; exact hshift_nz
+  have hR1 := fullDivN3R1V5_step_of_shape a0 a1 a2 a3 b0 b1 b2 b3 bltu_1 hb3z hshift_nz hb2nz hc1 hm1
+  have hR1c := fullDivN3R1V5_collapse_of_shape a0 a1 a2 a3 b0 b1 b2 b3 bltu_1 hb3z hshift_nz hb2nz hc1 hm1
+  have hR0valid := n3_next_window_lt (fullDivN3NormU a0 a1 a2 a3 b2).1
+      (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+      (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+      (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 _ hR1.2
+  have hR0 := fullDivN3R0V5_step_of_shape a0 a1 a2 a3 b0 b1 b2 b3 bltu_1 bltu_0
+      hb3z hshift_nz hb2nz hR1c.1 hR0valid hc0 hm0
+  have hscaleU := fullDivN3NormU_val256_eq_scaled_with_overflow a0 a1 a2 a3 b2 hsnz
+  have hscaleV := fullDivN3NormV_val256_eq_scaled_of_b3_zero b0 b1 b2 b3 hsnz hb3z
+  have hvtop := fullDivN3NormV_top_zero_of_shape_shift_nz b0 b1 b2 b3 hb3z hshift_nz
+  rw [hvtop] at hscaleV
+  have hfirst : val256 a0 a1 a2 a3 * 2 ^ (fullDivN3Shift b2).toNat =
+      (fullDivN3NormU a0 a1 a2 a3 b2).1.toNat
+        + 2 ^ 64 * val256 (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2 := by
+    rw [← hscaleU]; simp only [EvmWord.val256]; ring
+  have hw0 : val256 (fullDivN3NormU a0 a1 a2 a3 b2).1
+      (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+      (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+      (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+      = (fullDivN3NormU a0 a1 a2 a3 b2).1.toNat
+        + 2 ^ 64 * ((fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.1.toNat
+          + 2 ^ 64 * (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1.toNat
+          + 2 ^ 128 * (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1.toNat) := by
+    simp only [EvmWord.val256]; ring
+  rw [hw0] at hR0
+  have htele := fullDivN3V5_two_step_nat hfirst hR1.1 hR0.1
+  rw [hscaleV] at htele
+  have hlt : (fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1.toNat
+      + 2 ^ 64 * (fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1.toNat
+      + 2 ^ 128 * (fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1.toNat
+      < val256 b0 b1 b2 b3 * 2 ^ (fullDivN3Shift b2).toNat := by
+    rw [← hscaleV]; exact hR0.2
+  have hfin := div_quotient_of_normalized htele hlt
+  linarith [hfin]
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3V5QuotientShape.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V5QuotientShape.lean
@@ -1,0 +1,96 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3V5QuotientShape
+
+  **v5 n=3 quotient correctness from shape (shift≠0):**
+  `fullDivN3QuotientWordV5 = EvmWord.div a b`.
+
+  Combines the accumulated-quotient telescope `fullDivN3_acc_quot_eq_div_of_shape`
+  (N3V5AccQuot) with the `EvmWord` lift `div_of_val256_eq_div`: the assembled
+  quotient word's `val256` equals `val256 a / val256 b`, hence the word equals
+  `EvmWord.div a b`.  Then `fullDivN3V5_hdivs_of_word_eq` (N3V5QuotientWord)
+  projects out the four per-limb `(div a b).getLimbN` digit equalities the n=3
+  lane wrapper feeds to `divStackDispatchPost`.
+
+  n=3 analog of `fullDivN2QuotientWordV5_eq_div_of_shape` (N2V5QuotientShape).
+  Bead `evm-asm-wbc4i.9.3.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N3V5AccQuot
+import EvmAsm.Evm64.DivMod.Spec.N3V5QuotientWord
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- **v5 n=3 quotient correctness (shift≠0), from shape + `bltu` path matches.**
+    The assembled v5 n=3 quotient word equals `EvmWord.div a b`. -/
+theorem fullDivN3QuotientWordV5_eq_div_of_shape
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (bltu_1 bltu_0 : Bool)
+    (hb3z : b3 = 0) (hshift_nz : (clzResult b2).1 ≠ 0) (hb2nz : b2 ≠ 0)
+    (hc1 : bltu_1 = true →
+      BitVec.ult (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2 (fullDivN3NormV b0 b1 b2 b3).2.2.1 = true)
+    (hm1 : bltu_1 = false →
+      ¬ BitVec.ult (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2 (fullDivN3NormV b0 b1 b2 b3).2.2.1)
+    (hc0 : bltu_0 = true →
+      BitVec.ult (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1 = true)
+    (hm0 : bltu_0 = false →
+      ¬ BitVec.ult (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1) :
+    fullDivN3QuotientWordV5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 =
+      EvmWord.div
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3)
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3) := by
+  have h0 : (0 : Word).toNat = 0 := rfl
+  have hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0 := by
+    intro h
+    have h2 := (BitVec.or_eq_zero_iff.mp h).1
+    exact hb2nz (BitVec.or_eq_zero_iff.mp h2).2
+  have hacc := fullDivN3_acc_quot_eq_div_of_shape a0 a1 a2 a3 b0 b1 b2 b3
+    bltu_1 bltu_0 hb3z hshift_nz hb2nz hc1 hm1 hc0 hm0
+  have hqval : val256 (fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+      (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1 0 0
+      = val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 := by
+    rw [← hacc]; simp only [EvmWord.val256, h0]; ring
+  have hdiv := div_of_val256_eq_div hbnz hqval
+  unfold fullDivN3QuotientWordV5
+  exact hdiv
+
+/-- **Lane-ready form: the four `(div a b).getLimbN` digit equalities from shape**
+    (shift≠0) + the `bltu` path matches.  Composes
+    `fullDivN3QuotientWordV5_eq_div_of_shape` with the `getLimbN` projector
+    `fullDivN3V5_hdivs_of_word_eq`. -/
+theorem div_getLimbN_eq_digit_n3_v5_of_shape
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (bltu_1 bltu_0 : Bool)
+    (hb3z : b3 = 0) (hshift_nz : (clzResult b2).1 ≠ 0) (hb2nz : b2 ≠ 0)
+    (hc1 : bltu_1 = true →
+      BitVec.ult (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2 (fullDivN3NormV b0 b1 b2 b3).2.2.1 = true)
+    (hm1 : bltu_1 = false →
+      ¬ BitVec.ult (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2 (fullDivN3NormV b0 b1 b2 b3).2.2.1)
+    (hc0 : bltu_0 = true →
+      BitVec.ult (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1 = true)
+    (hm0 : bltu_0 = false →
+      ¬ BitVec.ult (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1) :
+    (EvmWord.div
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3)
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3)).getLimbN 0
+      = (fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3)
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3)).getLimbN 1
+      = (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3)
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3)).getLimbN 2
+      = (0 : Word) ∧
+    (EvmWord.div
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3)
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3)).getLimbN 3
+      = (0 : Word) := by
+  have hword := fullDivN3QuotientWordV5_eq_div_of_shape a0 a1 a2 a3 b0 b1 b2 b3
+    bltu_1 bltu_0 hb3z hshift_nz hb2nz hc1 hm1 hc0 hm0
+  exact fullDivN3V5_hdivs_of_word_eq bltu_1 bltu_0 _ _ a0 a1 a2 a3 b0 b1 b2 b3 hword
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Prove **`fullDivN3_acc_quot_eq_div_of_shape`**: the two v5 n=3 quotient digits combine to exactly `val256 a / val256 b` (4-limb dividend / 3-limb divisor → 2 outer iterations). The n=3 analog of `fullDivN2_acc_quot_eq_div_of_shape`, in a new `Spec/N3V5AccQuot.lean`. All theorems axiom-clean (`propext`/`Classical.choice`/`Quot.sound`).

## Contents (foundation → telescope)

- **`first_window_core_n3`** / **`fullDivN3_first_window_valid`** — the top-4-limb normalized window is `< 2^64·val256 normV` (the digit-1 `hvalid` seed; one limb wider than n=2, divisor `≥ 2^128`). Reuses the version-independent normalization scaling bridges (`fullDivN3NormU/V_val256_eq_scaled*`, `…_top_zero_of_shape_shift_nz`, `val256_ge_pow128_of_limb2`).
- **`iterN3V5_step`** / **`iterN3V5_collapse`** — unified per-digit step/collapse dispatching the call/max forms (#7493) on the runtime `bltu` flag.
- **`n3_next_window_lt`** — propagates the 3-limb-remainder window-validity invariant across digits (n=3 analog of `n2_next_window_lt`).
- **`fullDivN3R1V5_step_of_shape`** / **`_collapse_of_shape`** / **`fullDivN3R0V5_step_of_shape`** — wire the unified step/collapse onto the `fullDivN3R{1,0}V5` family forms from shape (`unfold; dsimp; rw [top_zero, prev-collapse]`).
- **`fullDivN3V5_two_step_nat`** — the 2-digit Nat accumulation.
- **`fullDivN3_acc_quot_eq_div_of_shape`** — telescopes R1→R0 through `two_step_nat` into the normalized Euclidean equation, then `div_quotient_of_normalized` recovers the quotient.

This builds on the n3 per-digit math + step that landed via the n3 stack (#7483/#7484/#7485 + #7487–#7490 + #7493), now on `main`.

## Gates

- `lake build` ✅ (exit 0, no linter warnings) · file-size ✅ · unimported ✅ (0 orphans) · no sorry/native_decide/bv_decide/heartbeat-scaling

Bead `evm-asm-wbc4i.9.3.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)