### PR TITLE
feat(stateless): account_is_empty_at_block_number_address (EIP-161)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -99,6 +99,7 @@ import EvmAsm.Codegen.Programs.StateRootChainWalkBack
 import EvmAsm.Codegen.Programs.BlockNumberAtBlockHash
 import EvmAsm.Codegen.Programs.StateSlotAtBlockNumber
 import EvmAsm.Codegen.Programs.StateAccountAtBlockNumber
+import EvmAsm.Codegen.Programs.AccountIsEmptyAtBlockNumber
 import EvmAsm.Codegen.Programs.BlockHashAtBlockNumber
 import EvmAsm.Codegen.Programs.CodeAtBlockNumber
 import EvmAsm.Codegen.Programs.BlockHashAtStateRoot
@@ -488,6 +489,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_extcodecopy_at_block_hash_address" => some ziskExtcodecopyAtBlockHashAddressProbeUnit
   | "zisk_state_slot_at_block_number_address" => some ziskStateSlotAtBlockNumberAddressProbeUnit
   | "zisk_state_account_at_block_number_address" => some ziskStateAccountAtBlockNumberAddressProbeUnit
+  | "zisk_account_is_empty_at_block_number_address" => some ziskAccountIsEmptyAtBlockNumberAddressProbeUnit
   | "zisk_block_hash_at_block_number" => some ziskBlockHashAtBlockNumberProbeUnit
   | "zisk_code_at_block_number_address" => some ziskCodeAtBlockNumberAddressProbeUnit
   | "zisk_block_hash_at_state_root" => some ziskBlockHashAtStateRootProbeUnit
@@ -715,6 +717,7 @@ def knownProgramNames : List String :=
    "zisk_extcodecopy_at_block_hash_address",
    "zisk_state_slot_at_block_number_address",
    "zisk_state_account_at_block_number_address",
+   "zisk_account_is_empty_at_block_number_address",
    "zisk_block_hash_at_block_number",
    "zisk_code_at_block_number_address",
    "zisk_block_hash_at_state_root",

--- a/EvmAsm/Codegen/Programs/AccountIsEmptyAtBlockNumber.lean
+++ b/EvmAsm/Codegen/Programs/AccountIsEmptyAtBlockNumber.lean
@@ -1,0 +1,351 @@
+/-
+  EvmAsm.Codegen.Programs.AccountIsEmptyAtBlockNumber
+
+  Number-keyed EIP-161 emptiness predicate. COMPLETES the
+  block_number boolean-predicate trio:
+    * account_exists       -- PR 7492
+    * has_code_or_nonce    -- PR 7494
+    * account_is_empty     -- THIS
+
+  Returns 1 iff the account at `address` is present in the
+  state trie of the block at `target_block_number` AND is
+  fully empty (nonce==0 AND balance==0 AND
+  code_hash==EMPTY_CODE_HASH).
+
+  No proofs yet -- codegen `String` defs only.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.Mpt
+import EvmAsm.Codegen.Programs.HashBridge
+import EvmAsm.Codegen.Programs.Tx
+import EvmAsm.Codegen.Programs.HeaderU64
+import EvmAsm.Codegen.Programs.HeaderFields
+import EvmAsm.Codegen.Programs.State
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Program
+
+/-! ## account_is_empty_at_block_number_address  (EIP-161)
+
+    Number-keyed EIP-161 emptiness predicate.
+
+    Pipeline:
+      witness.headers ∋ ?h with h.block.number == target  [K233 scan]
+      h -> header_extract_state_root                      [K201]
+      state_root + address -> account_at_address          [K28]
+      pres ∧ nonce==0 ∧ balance==0 ∧ ch==EMPTY -> predicate=1
+
+    Spec-distinguishing row matrix (vs predicate siblings;
+    EIP-161 row is the distinguishing column):
+
+      | account contents       | exists | EIP-684 | EIP-161 |
+      |------------------------|--------|---------|---------|
+      | fully empty (in trie)  |   1    |    0    |    1    |
+      | balance only           |   1    |    0    |    0    |
+      | nonce only             |   1    |    1    |    0    |
+      | contract (code only)   |   1    |    1    |    0    |
+      | (not in trie)          |   0    |    0    |    0    |
+
+    Use cases:
+      * EIP-161 clearing logic: detect accounts that should
+        be pruned after being touched at a historical block.
+      * Witness-trimming audits: an EIP-161-empty account at
+        height N can be omitted from the storage witness
+        without affecting consensus.
+      * Light-client semantic membership at height: "is this
+        address observably active at block 12345?"
+
+    Composes K233 + K201 + K28 + nonce/balance zero checks +
+    code_hash vs EMPTY_CODE_HASH compare. No new helpers.
+
+    Calling convention (7 args):
+      a0 (input)  : target_block_number (u64, by value)
+      a1 (input)  : witness.headers ptr
+      a2 (input)  : witness.headers len
+      a3 (input)  : address ptr (20 bytes)
+      a4 (input)  : witness.state ptr
+      a5 (input)  : witness.state len
+      a6 (input)  : u64 predicate out ptr
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success (predicate written; 0=not-empty, 1=empty)
+        1 = no header with target block_number
+        2 = K233 parse failure during scan
+        3 = matched header state_root extraction failure
+        4 = state-trie mpt parse error
+        5 = account RLP decode failure
+-/
+def accountIsEmptyAtBlockNumberAddressFunction : String :=
+  "account_is_empty_at_block_number_address:\n" ++
+  "  addi sp, sp, -96\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp); sd s10, 88(sp)\n" ++
+  "  mv s0, a0                  # target block_number\n" ++
+  "  mv s1, a1                  # headers ptr\n" ++
+  "  mv s2, a2                  # headers len\n" ++
+  "  mv s3, a3                  # address ptr\n" ++
+  "  mv s4, a4                  # witness.state ptr\n" ++
+  "  mv s5, a5                  # witness.state len\n" ++
+  "  mv s6, a6                  # predicate out (u64)\n" ++
+  "  sd zero, 0(s6)\n" ++
+  "  li s9, 0                   # saw_parse_fail\n" ++
+  "  beqz s2, .Laiebn_miss\n" ++
+  "  lwu t0, 0(s1)\n" ++
+  "  srli s7, t0, 2             # N\n" ++
+  "  li s8, 0                   # i\n" ++
+  ".Laiebn_loop:\n" ++
+  "  beq s8, s7, .Laiebn_finish\n" ++
+  "  slli t0, s8, 2\n" ++
+  "  add t1, s1, t0\n" ++
+  "  lwu t2, 0(t1)\n" ++
+  "  add s10, s1, t2            # header start\n" ++
+  "  addi t3, s8, 1\n" ++
+  "  beq t3, s7, .Laiebn_use_end\n" ++
+  "  slli t3, t3, 2\n" ++
+  "  add t3, s1, t3\n" ++
+  "  lwu t4, 0(t3)\n" ++
+  "  add t4, s1, t4\n" ++
+  "  j .Laiebn_have_end\n" ++
+  ".Laiebn_use_end:\n" ++
+  "  add t4, s1, s2\n" ++
+  ".Laiebn_have_end:\n" ++
+  "  sub t5, t4, s10\n" ++
+  "  mv a0, s10\n" ++
+  "  mv a1, t5\n" ++
+  "  la a2, aiebn_number_scratch\n" ++
+  "  jal ra, header_extract_number\n" ++
+  "  bnez a0, .Laiebn_parse_fail\n" ++
+  "  la t0, aiebn_number_scratch\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  beq t1, s0, .Laiebn_hit\n" ++
+  "  j .Laiebn_step\n" ++
+  ".Laiebn_parse_fail:\n" ++
+  "  li s9, 1\n" ++
+  ".Laiebn_step:\n" ++
+  "  addi s8, s8, 1\n" ++
+  "  j .Laiebn_loop\n" ++
+  ".Laiebn_hit:\n" ++
+  "  slli t0, s8, 2\n" ++
+  "  add t1, s1, t0\n" ++
+  "  lwu t2, 0(t1)\n" ++
+  "  addi t3, s8, 1\n" ++
+  "  beq t3, s7, .Laiebn_re_use_end\n" ++
+  "  slli t3, t3, 2\n" ++
+  "  add t3, s1, t3\n" ++
+  "  lwu t4, 0(t3)\n" ++
+  "  j .Laiebn_re_have_end\n" ++
+  ".Laiebn_re_use_end:\n" ++
+  "  mv t4, s2\n" ++
+  ".Laiebn_re_have_end:\n" ++
+  "  sub t5, t4, t2\n" ++
+  "  mv a0, s10\n" ++
+  "  mv a1, t5\n" ++
+  "  la a2, aiebn_state_root\n" ++
+  "  jal ra, header_extract_state_root\n" ++
+  "  beqz a0, .Laiebn_walk\n" ++
+  "  li a0, 3\n" ++
+  "  j .Laiebn_ret\n" ++
+  ".Laiebn_walk:\n" ++
+  "  mv a0, s3\n" ++
+  "  li a1, 20\n" ++
+  "  la a2, aiebn_state_root\n" ++
+  "  mv a3, s4\n" ++
+  "  mv a4, s5\n" ++
+  "  la a5, aiebn_walked_struct\n" ++
+  "  jal ra, account_at_address\n" ++
+  "  beqz a0, .Laiebn_check\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Laiebn_absent\n" ++
+  "  addi a0, a0, 2             # 2->4, 3->5\n" ++
+  "  j .Laiebn_ret\n" ++
+  ".Laiebn_absent:\n" ++
+  "  # account absent -> NOT empty (predicate stays 0).\n" ++
+  "  li a0, 0\n" ++
+  "  j .Laiebn_ret\n" ++
+  ".Laiebn_check:\n" ++
+  "  la t3, aiebn_walked_struct\n" ++
+  "  ld t1, 0(t3)\n" ++
+  "  bnez t1, .Laiebn_not_empty\n" ++
+  "  ld t1,  8(t3); bnez t1, .Laiebn_not_empty\n" ++
+  "  ld t1, 16(t3); bnez t1, .Laiebn_not_empty\n" ++
+  "  ld t1, 24(t3); bnez t1, .Laiebn_not_empty\n" ++
+  "  ld t1, 32(t3); bnez t1, .Laiebn_not_empty\n" ++
+  "  la t0, aiebn_empty_code_hash\n" ++
+  "  ld t1,  0(t0); ld t2, 72(t3); bne t1, t2, .Laiebn_not_empty\n" ++
+  "  ld t1,  8(t0); ld t2, 80(t3); bne t1, t2, .Laiebn_not_empty\n" ++
+  "  ld t1, 16(t0); ld t2, 88(t3); bne t1, t2, .Laiebn_not_empty\n" ++
+  "  ld t1, 24(t0); ld t2, 96(t3); bne t1, t2, .Laiebn_not_empty\n" ++
+  "  li t1, 1\n" ++
+  "  sd t1, 0(s6)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Laiebn_ret\n" ++
+  ".Laiebn_not_empty:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Laiebn_ret\n" ++
+  ".Laiebn_finish:\n" ++
+  "  bnez s9, .Laiebn_parse_status\n" ++
+  ".Laiebn_miss:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Laiebn_ret\n" ++
+  ".Laiebn_parse_status:\n" ++
+  "  li a0, 2\n" ++
+  ".Laiebn_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp)\n" ++
+  "  addi sp, sp, 96\n" ++
+  "  ret"
+
+/-- `zisk_account_is_empty_at_block_number_address`: probe BuildUnit.
+    Input layout (at INPUT_ADDR):
+      bytes  0.. 8 : (ziskemu metadata)
+      bytes  8..16 : witness_headers_len (u64 LE)
+      bytes 16..24 : witness_state_len (u64 LE)
+      bytes 24..32 : target_block_number (u64 LE)
+      bytes 32..52 : address (20 bytes)
+      bytes 52..   : witness.headers ++ witness.state
+    Output layout (16 bytes):
+      bytes  0.. 8 : status (0..5)
+      bytes  8..16 : predicate (u64; 0 = not-empty, 1 = empty) -/
+def ziskAccountIsEmptyAtBlockNumberAddressPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t4, 0x40000000\n" ++
+  "  ld a2, 8(t4)                # witness_headers_len\n" ++
+  "  ld a5, 16(t4)               # witness_state_len\n" ++
+  "  ld a0, 24(t4)               # target_block_number\n" ++
+  "  addi a3, t4, 32             # address ptr\n" ++
+  "  addi a1, t4, 52             # witness.headers ptr\n" ++
+  "  add  a4, a1, a2             # witness.state ptr\n" ++
+  "  li a6, 0xa0010008           # predicate out\n" ++
+  "  jal ra, account_is_empty_at_block_number_address\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Laiebn_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  mptLookupByKeyFunction ++ "\n" ++
+  accountDecodeFunction ++ "\n" ++
+  accountAtAddressFunction ++ "\n" ++
+  headerExtractNumberFunction ++ "\n" ++
+  headerExtractStateRootFunction ++ "\n" ++
+  accountIsEmptyAtBlockNumberAddressFunction ++ "\n" ++
+  ".Laiebn_pdone:"
+
+def ziskAccountIsEmptyAtBlockNumberAddressDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mnk_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_dummy_length:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mbc_offset:\n" ++
+  "  .zero 8\n" ++
+  "mbc_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_lookup_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_lookup_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_lookup_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_child_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_nibble_count:\n" ++
+  "  .zero 8\n" ++
+  "mw_is_leaf:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_nibble_buf:\n" ++
+  "  .zero 128\n" ++
+  ".balign 32\n" ++
+  "mlk_keccak_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "mlk_nibble_buf:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "ad_offset:\n" ++
+  "  .zero 8\n" ++
+  "ad_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aa_value_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aa_value_scratch:\n" ++
+  "  .zero 256\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "hesr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hesr_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aiebn_number_scratch:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aiebn_state_root:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "aiebn_walked_struct:\n" ++
+  "  .zero 104\n" ++
+  ".balign 32\n" ++
+  "aiebn_empty_code_hash:\n" ++
+  "  .byte 0xc5, 0xd2, 0x46, 0x01, 0x86, 0xf7, 0x23, 0x3c\n" ++
+  "  .byte 0x92, 0x7e, 0x7d, 0xb2, 0xdc, 0xc7, 0x03, 0xc0\n" ++
+  "  .byte 0xe5, 0x00, 0xb6, 0x53, 0xca, 0x82, 0x27, 0x3b\n" ++
+  "  .byte 0x7b, 0xfa, 0xd8, 0x04, 0x5d, 0x85, 0xa4, 0x70"
+
+def ziskAccountIsEmptyAtBlockNumberAddressProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskAccountIsEmptyAtBlockNumberAddressPrologue
+  dataAsm     := ziskAccountIsEmptyAtBlockNumberAddressDataSection
+}
+
+end EvmAsm.Codegen

--- a/scripts/codegen-zisk-account-is-empty-at-block-number-address-check.sh
+++ b/scripts/codegen-zisk-account-is-empty-at-block-number-address-check.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# codegen-zisk-account-is-empty-at-block-number-address-check.sh
+#
+# Number-keyed EIP-161 emptiness predicate. Completes the
+# block_number boolean-predicate trio:
+#   * account_exists (PR 7492)
+#   * has_code_or_nonce (PR 7494)
+#   * account_is_empty (THIS)
+#
+# Output (16 bytes):
+#   bytes  0.. 8 : status (0..5)
+#   bytes  8..16 : predicate (u64; 0 = not-empty, 1 = empty)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_account_is_empty_at_block_number_address ELF"
+lake exe codegen --program zisk_account_is_empty_at_block_number_address \
+  --halt linux93 \
+  -o gen-out/zisk_account_is_empty_at_block_number_address
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+  local target="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_aiebn_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_aiebn_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_aiebn_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def hp_encode(nibbles, is_leaf):
+    flag = 2 if is_leaf else 0
+    if len(nibbles) % 2 == 1:
+        flag |= 1
+        result = bytes([flag * 0x10 + nibbles[0]])
+        nibbles = nibbles[1:]
+    else:
+        result = bytes([flag * 0x10])
+    for i in range(0, len(nibbles), 2):
+        result += bytes([nibbles[i] * 0x10 + nibbles[i+1]])
+    return result
+
+def leaf_node(path_nibbles, value):
+    return rlp.encode([hp_encode(path_nibbles, True), value])
+
+def bytes_to_nibbles(b):
+    out = []
+    for byte in b:
+        out.append(byte >> 4); out.append(byte & 0xf)
+    return out
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0: return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset); offset += len(e)
+    for e in elements: section += e
+    return section
+
+def encode_account(nonce, balance, storage_root, code_hash):
+    return rlp.encode([nonce, balance, storage_root, code_hash])
+
+def encode_header(number_val, state_root):
+    if number_val == 0:
+        number_field = b''
+    else:
+        nbytes = (number_val.bit_length() + 7) // 8
+        number_field = number_val.to_bytes(nbytes, 'big')
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x55'*32,
+        b'\\x66'*32, b'\\x00'*256, b'', number_field, b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    return rlp.encode(fields)
+
+EMPTY_TRIE = bytes.fromhex('56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421')
+EMPTY_CODE_HASH = bytes.fromhex('c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')
+
+def state_trie_one(addr, acct_rlp):
+    path = bytes_to_nibbles(k256(addr))
+    leaf = leaf_node(path, acct_rlp)
+    return k256(leaf), build_ssz_section([leaf])
+
+def resolve_code_hash(mode_str):
+    if mode_str == 'empty':
+        return EMPTY_CODE_HASH
+    if mode_str.startswith('contract:'):
+        return k256(bytes.fromhex(mode_str.split(':', 1)[1]))
+    raise SystemExit('bad code_mode: ' + mode_str)
+
+mode = '$mode'
+target = int('$target')
+parts = '$parts'.split('|')
+ALICE = b'\\xaa' * 20
+BOB = b'\\xbb' * 20
+
+if mode == 'account':
+    nonce = int(parts[0]); balance = int(parts[1])
+    code_hash = resolve_code_hash(parts[2])
+    acct = encode_account(nonce, balance, EMPTY_TRIE, code_hash)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(100, b'\\xee'*32)
+    h1 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0, h1])
+    addr = ALICE
+    pred = 1 if (nonce == 0 and balance == 0 and code_hash == EMPTY_CODE_HASH) else 0
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', pred)
+elif mode == 'missing':
+    acct = encode_account(0, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(BOB, acct)
+    h0 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0])
+    addr = ALICE
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', 0)
+elif mode == 'number_miss':
+    acct = encode_account(0, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(100, sr)
+    witness_headers = build_ssz_section([h0])
+    addr = ALICE
+    expected = struct.pack('<Q', 1) + struct.pack('<Q', 0)
+else:
+    raise SystemExit('bad mode: ' + mode)
+
+with open(sys.argv[1], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(witness_headers))
+        + struct.pack('<Q', len(witness_state))
+        + struct.pack('<Q', target)
+        + addr
+        + witness_headers
+        + witness_state
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_account_is_empty_at_block_number_address.elf \
+    -i "$in_file" -o "$out_file" -n 6000000 \
+    >"$REPO_ROOT/gen-out/zisk_aiebn_${name}.emu.log" 2>&1 || true
+
+  local exp_size
+  exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-40s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-40s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+parts="0|0|empty"                 run_case "fully_empty_in_trie"     account 101 || FAILED=1
+parts="0|1000|empty"              run_case "balance_only"            account 101 || FAILED=1
+parts="1|0|empty"                 run_case "nonce_only"              account 101 || FAILED=1
+parts="0|0|contract:6000"         run_case "contract_only"           account 101 || FAILED=1
+parts="42|1000|contract:6000"     run_case "fully_active"            account 101 || FAILED=1
+parts=""                          run_case "missing_account_zero"    missing 101 || FAILED=1
+parts=""                          run_case "number_not_in_section"   number_miss 999 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: account_is_empty_at_block_number_address (EIP-161) end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Number-keyed EIP-161 emptiness predicate. **Completes the
block_number boolean-predicate trio** that mirrors the
established block_hash trio:

| predicate                  | block_hash | block_number |
|----------------------------|------------|--------------|
| account_exists             | #7456      | #7492        |
| has_code_or_nonce (EIP-684)| #7462      | #7494        |
| account_is_empty (EIP-161) | #7466      | **this**     |

Returns 1 iff the account at \`address\` is present in the
state trie of the block at \`target_block_number\` AND is
fully empty (\`nonce==0\` AND \`balance==0\` AND
\`code_hash==EMPTY_CODE_HASH\`).

Spec-distinguishing row matrix (the EIP-161 column is the
distinguishing axis for "fully empty in trie" vs every
other row):

| account contents       | exists | EIP-684 | EIP-161 |
|------------------------|--------|---------|---------|
| fully empty (in trie)  |   1    |    0    |    1    |
| balance only           |   1    |    0    |    0    |
| nonce only             |   1    |    1    |    0    |
| contract (code only)   |   1    |    1    |    0    |
| (not in trie)          |   0    |    0    |    0    |

Use cases:
- EIP-161 clearing logic: detect accounts that should be
  pruned after being touched at a historical block.
- Witness-trimming audits: an EIP-161-empty account at
  height N can be omitted from the storage witness without
  affecting consensus.
- Light-client semantic membership at height: "is this
  address observably active at block 12345?"

Composes K233 + K201 + K28 + nonce/balance zero checks +
code_hash vs EMPTY_CODE_HASH compare. No new helpers.

## Test plan

- [x] \`lake build codegen\` succeeds.
- [x] \`bash scripts/codegen-zisk-account-is-empty-at-block-number-address-check.sh\` — 7/7 fixtures pass covering all 5 spec-distinguishing rows.
- [x] No \`native_decide\` / \`bv_decide\`; aligned LD/SD only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)