### PR TITLE
feat(stateless): extcodesize_at_block_number_address (EXTCODESIZE)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -100,6 +100,7 @@ import EvmAsm.Codegen.Programs.BlockNumberAtBlockHash
 import EvmAsm.Codegen.Programs.StateSlotAtBlockNumber
 import EvmAsm.Codegen.Programs.StateAccountAtBlockNumber
 import EvmAsm.Codegen.Programs.BalanceAtBlockNumber
+import EvmAsm.Codegen.Programs.ExtcodesizeAtBlockNumber
 import EvmAsm.Codegen.Programs.BlockHashAtBlockNumber
 import EvmAsm.Codegen.Programs.CodeAtBlockNumber
 import EvmAsm.Codegen.Programs.BlockHashAtStateRoot
@@ -490,6 +491,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_state_slot_at_block_number_address" => some ziskStateSlotAtBlockNumberAddressProbeUnit
   | "zisk_state_account_at_block_number_address" => some ziskStateAccountAtBlockNumberAddressProbeUnit
   | "zisk_balance_at_block_number_address" => some ziskBalanceAtBlockNumberAddressProbeUnit
+  | "zisk_extcodesize_at_block_number_address" => some ziskExtcodesizeAtBlockNumberAddressProbeUnit
   | "zisk_block_hash_at_block_number" => some ziskBlockHashAtBlockNumberProbeUnit
   | "zisk_code_at_block_number_address" => some ziskCodeAtBlockNumberAddressProbeUnit
   | "zisk_block_hash_at_state_root" => some ziskBlockHashAtStateRootProbeUnit
@@ -718,6 +720,7 @@ def knownProgramNames : List String :=
    "zisk_state_slot_at_block_number_address",
    "zisk_state_account_at_block_number_address",
    "zisk_balance_at_block_number_address",
+   "zisk_extcodesize_at_block_number_address",
    "zisk_block_hash_at_block_number",
    "zisk_code_at_block_number_address",
    "zisk_block_hash_at_state_root",

--- a/EvmAsm/Codegen/Programs/ExtcodesizeAtBlockNumber.lean
+++ b/EvmAsm/Codegen/Programs/ExtcodesizeAtBlockNumber.lean
@@ -1,0 +1,359 @@
+/-
+  EvmAsm.Codegen.Programs.ExtcodesizeAtBlockNumber
+
+  Number-keyed EXTCODESIZE primitive. **First EVM opcode**
+  at the block_number key level -- the equivalent block_hash
+  family already has extcodesize / extcodehash / extcodecopy /
+  sload.
+
+  Mirrors `extcodesize_at_block_hash_address` (#7470) but
+  keyed by block_number. The block_number key requires an
+  additional inner loop (K233 scan) vs the block_hash key's
+  K19 lookup, since witness.headers is not hash-indexed by
+  number.
+
+  No proofs yet -- codegen `String` defs only.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.Mpt
+import EvmAsm.Codegen.Programs.HashBridge
+import EvmAsm.Codegen.Programs.Tx
+import EvmAsm.Codegen.Programs.HeaderU64
+import EvmAsm.Codegen.Programs.HeaderFields
+import EvmAsm.Codegen.Programs.State
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Program
+
+/-! ## extcodesize_at_block_number_address  (EXTCODESIZE at block_number)
+
+    Returns the byte length of the deployed code at `address`
+    in the state trie of the block at `target_block_number`.
+
+    Spec-defining edge cases:
+      * Account not in state trie -> 0 (no code at all).
+      * Account present but code_hash == EMPTY_CODE_HASH -> 0.
+      * Account present with non-empty code_hash but code body
+        missing from witness.codes -> structural error
+        (witness integrity violation; status 6).
+
+    Use cases:
+      * EXTCODESIZE opcode replay against a historical block.
+      * Light-client contract-presence audit by height.
+      * Bridge / oracle "size of deployed code at block N"
+        query without committing to fetching the code body.
+
+    Composes K233 (header scan) + K201 + K28 + K19 (witness.codes
+    by code_hash) + EMPTY_CODE_HASH inline compare. No new
+    helpers.
+
+    Calling convention (8 args; full a0..a7):
+      a0 (input)  : target_block_number (u64, by value)
+      a1 (input)  : witness.headers ptr
+      a2 (input)  : witness.headers len
+      a3 (input)  : address ptr (20 bytes)
+      a4 (input)  : witness.state ptr
+      a5 (input)  : witness.state len
+      a6 (input)  : witness.codes ptr
+      a7 (input)  : witness.codes len
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success (`ecsbn_code_len` holds length; may be 0)
+        1 = no header with target block_number
+        2 = K233 parse failure during scan
+        3 = matched header state_root extraction failure
+        4 = state-trie mpt parse error
+        5 = account_decode failure
+        6 = code_hash != EMPTY but not found in witness.codes
+            (witness integrity violation)
+
+    The probe BuildUnit copies `ecsbn_code_len` to OUTPUT + 8.
+-/
+def extcodesizeAtBlockNumberAddressFunction : String :=
+  "extcodesize_at_block_number_address:\n" ++
+  "  addi sp, sp, -112\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp); sd s10, 88(sp); sd s11, 96(sp)\n" ++
+  "  mv s0, a0                  # target block_number\n" ++
+  "  mv s1, a1                  # headers ptr\n" ++
+  "  mv s2, a2                  # headers len\n" ++
+  "  mv s3, a3                  # address ptr\n" ++
+  "  mv s4, a4                  # witness.state ptr\n" ++
+  "  mv s5, a5                  # witness.state len\n" ++
+  "  mv s6, a6                  # witness.codes ptr\n" ++
+  "  mv s11, a7                 # witness.codes len\n" ++
+  "  la t0, ecsbn_code_len\n" ++
+  "  sd zero, 0(t0)\n" ++
+  "  li s9, 0                   # saw_parse_fail\n" ++
+  "  beqz s2, .Lecsbn_miss\n" ++
+  "  lwu t0, 0(s1)\n" ++
+  "  srli s7, t0, 2             # N\n" ++
+  "  li s8, 0                   # i\n" ++
+  ".Lecsbn_loop:\n" ++
+  "  beq s8, s7, .Lecsbn_finish\n" ++
+  "  slli t0, s8, 2\n" ++
+  "  add t1, s1, t0\n" ++
+  "  lwu t2, 0(t1)\n" ++
+  "  add s10, s1, t2            # header start\n" ++
+  "  addi t3, s8, 1\n" ++
+  "  beq t3, s7, .Lecsbn_use_end\n" ++
+  "  slli t3, t3, 2\n" ++
+  "  add t3, s1, t3\n" ++
+  "  lwu t4, 0(t3)\n" ++
+  "  add t4, s1, t4\n" ++
+  "  j .Lecsbn_have_end\n" ++
+  ".Lecsbn_use_end:\n" ++
+  "  add t4, s1, s2\n" ++
+  ".Lecsbn_have_end:\n" ++
+  "  sub t5, t4, s10\n" ++
+  "  mv a0, s10\n" ++
+  "  mv a1, t5\n" ++
+  "  la a2, ecsbn_number_scratch\n" ++
+  "  jal ra, header_extract_number\n" ++
+  "  bnez a0, .Lecsbn_parse_fail\n" ++
+  "  la t0, ecsbn_number_scratch\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  beq t1, s0, .Lecsbn_hit\n" ++
+  "  j .Lecsbn_step\n" ++
+  ".Lecsbn_parse_fail:\n" ++
+  "  li s9, 1\n" ++
+  ".Lecsbn_step:\n" ++
+  "  addi s8, s8, 1\n" ++
+  "  j .Lecsbn_loop\n" ++
+  ".Lecsbn_hit:\n" ++
+  "  slli t0, s8, 2\n" ++
+  "  add t1, s1, t0\n" ++
+  "  lwu t2, 0(t1)\n" ++
+  "  addi t3, s8, 1\n" ++
+  "  beq t3, s7, .Lecsbn_re_use_end\n" ++
+  "  slli t3, t3, 2\n" ++
+  "  add t3, s1, t3\n" ++
+  "  lwu t4, 0(t3)\n" ++
+  "  j .Lecsbn_re_have_end\n" ++
+  ".Lecsbn_re_use_end:\n" ++
+  "  mv t4, s2\n" ++
+  ".Lecsbn_re_have_end:\n" ++
+  "  sub t5, t4, t2\n" ++
+  "  mv a0, s10\n" ++
+  "  mv a1, t5\n" ++
+  "  la a2, ecsbn_state_root\n" ++
+  "  jal ra, header_extract_state_root\n" ++
+  "  beqz a0, .Lecsbn_walk\n" ++
+  "  li a0, 3\n" ++
+  "  j .Lecsbn_ret\n" ++
+  ".Lecsbn_walk:\n" ++
+  "  mv a0, s3\n" ++
+  "  li a1, 20\n" ++
+  "  la a2, ecsbn_state_root\n" ++
+  "  mv a3, s4\n" ++
+  "  mv a4, s5\n" ++
+  "  la a5, ecsbn_acct_struct\n" ++
+  "  jal ra, account_at_address\n" ++
+  "  beqz a0, .Lecsbn_check_empty\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Lecsbn_success_zero\n" ++
+  "  addi a0, a0, 2             # 2->4, 3->5\n" ++
+  "  j .Lecsbn_ret\n" ++
+  ".Lecsbn_success_zero:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lecsbn_ret\n" ++
+  ".Lecsbn_check_empty:\n" ++
+  "  la t3, ecsbn_acct_struct\n" ++
+  "  la t0, ecsbn_empty_code_hash\n" ++
+  "  ld t1,  0(t0); ld t2, 72(t3); bne t1, t2, .Lecsbn_lookup\n" ++
+  "  ld t1,  8(t0); ld t2, 80(t3); bne t1, t2, .Lecsbn_lookup\n" ++
+  "  ld t1, 16(t0); ld t2, 88(t3); bne t1, t2, .Lecsbn_lookup\n" ++
+  "  ld t1, 24(t0); ld t2, 96(t3); bne t1, t2, .Lecsbn_lookup\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lecsbn_ret\n" ++
+  ".Lecsbn_lookup:\n" ++
+  "  mv a0, s6\n" ++
+  "  mv a1, s11\n" ++
+  "  la t0, ecsbn_acct_struct\n" ++
+  "  addi a2, t0, 72            # &acct.code_hash\n" ++
+  "  la a3, ecsbn_dummy_offset\n" ++
+  "  la a4, ecsbn_code_len\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  beqz a0, .Lecsbn_ret\n" ++
+  "  la t0, ecsbn_code_len\n" ++
+  "  sd zero, 0(t0)\n" ++
+  "  li a0, 6\n" ++
+  "  j .Lecsbn_ret\n" ++
+  ".Lecsbn_finish:\n" ++
+  "  bnez s9, .Lecsbn_parse_status\n" ++
+  ".Lecsbn_miss:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lecsbn_ret\n" ++
+  ".Lecsbn_parse_status:\n" ++
+  "  li a0, 2\n" ++
+  ".Lecsbn_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp); ld s11, 96(sp)\n" ++
+  "  addi sp, sp, 112\n" ++
+  "  ret"
+
+/-- `zisk_extcodesize_at_block_number_address`: probe BuildUnit.
+    Input layout (at INPUT_ADDR):
+      bytes  0.. 8 : (ziskemu metadata)
+      bytes  8..16 : witness_headers_len (u64 LE)
+      bytes 16..24 : witness_state_len (u64 LE)
+      bytes 24..32 : witness_codes_len (u64 LE)
+      bytes 32..40 : target_block_number (u64 LE)
+      bytes 40..60 : address (20 bytes)
+      bytes 60..   : witness.headers ++ witness.state ++ witness.codes
+    Output layout (16 bytes):
+      bytes  0.. 8 : status (0..6)
+      bytes  8..16 : code length (u64; 0 for missing/empty) -/
+def ziskExtcodesizeAtBlockNumberAddressPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t4, 0x40000000\n" ++
+  "  ld t5,  8(t4)               # witness_headers_len\n" ++
+  "  ld t6, 16(t4)               # witness_state_len\n" ++
+  "  ld a7, 24(t4)               # witness_codes_len\n" ++
+  "  ld a0, 32(t4)               # target_block_number\n" ++
+  "  addi a3, t4, 40             # address ptr\n" ++
+  "  addi a1, t4, 60             # witness.headers ptr\n" ++
+  "  mv a2, t5\n" ++
+  "  add a4, a1, t5              # witness.state ptr\n" ++
+  "  mv a5, t6\n" ++
+  "  add a6, a4, t6              # witness.codes ptr\n" ++
+  "  jal ra, extcodesize_at_block_number_address\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  la t1, ecsbn_code_len; ld t2, 0(t1); sd t2, 8(t0)\n" ++
+  "  j .Lecsbn_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  mptLookupByKeyFunction ++ "\n" ++
+  accountDecodeFunction ++ "\n" ++
+  accountAtAddressFunction ++ "\n" ++
+  headerExtractNumberFunction ++ "\n" ++
+  headerExtractStateRootFunction ++ "\n" ++
+  extcodesizeAtBlockNumberAddressFunction ++ "\n" ++
+  ".Lecsbn_pdone:"
+
+def ziskExtcodesizeAtBlockNumberAddressDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mnk_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_dummy_length:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mbc_offset:\n" ++
+  "  .zero 8\n" ++
+  "mbc_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_lookup_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_lookup_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_lookup_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_child_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_nibble_count:\n" ++
+  "  .zero 8\n" ++
+  "mw_is_leaf:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_nibble_buf:\n" ++
+  "  .zero 128\n" ++
+  ".balign 32\n" ++
+  "mlk_keccak_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "mlk_nibble_buf:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "ad_offset:\n" ++
+  "  .zero 8\n" ++
+  "ad_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aa_value_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aa_value_scratch:\n" ++
+  "  .zero 256\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "hesr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hesr_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "ecsbn_number_scratch:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "ecsbn_state_root:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "ecsbn_acct_struct:\n" ++
+  "  .zero 104\n" ++
+  ".balign 8\n" ++
+  "ecsbn_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "ecsbn_code_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "ecsbn_empty_code_hash:\n" ++
+  "  .byte 0xc5, 0xd2, 0x46, 0x01, 0x86, 0xf7, 0x23, 0x3c\n" ++
+  "  .byte 0x92, 0x7e, 0x7d, 0xb2, 0xdc, 0xc7, 0x03, 0xc0\n" ++
+  "  .byte 0xe5, 0x00, 0xb6, 0x53, 0xca, 0x82, 0x27, 0x3b\n" ++
+  "  .byte 0x7b, 0xfa, 0xd8, 0x04, 0x5d, 0x85, 0xa4, 0x70"
+
+def ziskExtcodesizeAtBlockNumberAddressProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskExtcodesizeAtBlockNumberAddressPrologue
+  dataAsm     := ziskExtcodesizeAtBlockNumberAddressDataSection
+}
+
+end EvmAsm.Codegen

--- a/scripts/codegen-zisk-extcodesize-at-block-number-address-check.sh
+++ b/scripts/codegen-zisk-extcodesize-at-block-number-address-check.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# codegen-zisk-extcodesize-at-block-number-address-check.sh
+#
+# Number-keyed EXTCODESIZE primitive. First EVM opcode at
+# the block_number key level.
+#
+# Output (16 bytes):
+#   bytes  0.. 8 : status (0..6)
+#   bytes  8..16 : code length (u64; 0 for missing/empty)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_extcodesize_at_block_number_address ELF"
+lake exe codegen --program zisk_extcodesize_at_block_number_address \
+  --halt linux93 \
+  -o gen-out/zisk_extcodesize_at_block_number_address
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <mode> <target> [args...]
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+  local target="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_ecsbn_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_ecsbn_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_ecsbn_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def hp_encode(nibbles, is_leaf):
+    flag = 2 if is_leaf else 0
+    if len(nibbles) % 2 == 1:
+        flag |= 1
+        result = bytes([flag * 0x10 + nibbles[0]])
+        nibbles = nibbles[1:]
+    else:
+        result = bytes([flag * 0x10])
+    for i in range(0, len(nibbles), 2):
+        result += bytes([nibbles[i] * 0x10 + nibbles[i+1]])
+    return result
+
+def leaf_node(path_nibbles, value):
+    return rlp.encode([hp_encode(path_nibbles, True), value])
+
+def bytes_to_nibbles(b):
+    out = []
+    for byte in b:
+        out.append(byte >> 4); out.append(byte & 0xf)
+    return out
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0: return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset); offset += len(e)
+    for e in elements: section += e
+    return section
+
+def encode_account(nonce, balance, storage_root, code_hash):
+    return rlp.encode([nonce, balance, storage_root, code_hash])
+
+def encode_header(number_val, state_root):
+    if number_val == 0:
+        number_field = b''
+    else:
+        nbytes = (number_val.bit_length() + 7) // 8
+        number_field = number_val.to_bytes(nbytes, 'big')
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x55'*32,
+        b'\\x66'*32, b'\\x00'*256, b'', number_field, b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    return rlp.encode(fields)
+
+EMPTY_TRIE = bytes.fromhex('56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421')
+EMPTY_CODE_HASH = bytes.fromhex('c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')
+
+def state_trie_one(addr, acct_rlp):
+    path = bytes_to_nibbles(k256(addr))
+    leaf = leaf_node(path, acct_rlp)
+    return k256(leaf), build_ssz_section([leaf])
+
+mode = '$mode'
+target = int('$target')
+parts = '$parts'.split('|')
+ALICE = b'\\xaa' * 20
+BOB = b'\\xbb' * 20
+
+if mode == 'contract':
+    code = bytes.fromhex(parts[0])
+    code_hash = k256(code)
+    acct = encode_account(0, 0, EMPTY_TRIE, code_hash)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(100, b'\\xee'*32)
+    h1 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0, h1])
+    witness_codes = build_ssz_section([code])
+    addr = ALICE
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', len(code))
+elif mode == 'empty_code_present':
+    acct = encode_account(7, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0])
+    witness_codes = b''
+    addr = ALICE
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', 0)
+elif mode == 'missing_account':
+    code = bytes.fromhex(parts[0])
+    code_hash = k256(code)
+    acct = encode_account(0, 0, EMPTY_TRIE, code_hash)
+    sr, witness_state = state_trie_one(BOB, acct)
+    h0 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0])
+    witness_codes = build_ssz_section([code])
+    addr = ALICE
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', 0)
+elif mode == 'integrity_violation':
+    code = bytes.fromhex(parts[0])
+    code_hash = k256(code)
+    acct = encode_account(0, 0, EMPTY_TRIE, code_hash)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0])
+    witness_codes = b''  # incomplete
+    addr = ALICE
+    expected = struct.pack('<Q', 6) + struct.pack('<Q', 0)
+elif mode == 'number_miss':
+    code = bytes.fromhex(parts[0])
+    code_hash = k256(code)
+    acct = encode_account(0, 0, EMPTY_TRIE, code_hash)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(100, sr)
+    witness_headers = build_ssz_section([h0])
+    witness_codes = build_ssz_section([code])
+    addr = ALICE
+    expected = struct.pack('<Q', 1) + struct.pack('<Q', 0)
+else:
+    raise SystemExit('bad mode: ' + mode)
+
+with open(sys.argv[1], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(witness_headers))
+        + struct.pack('<Q', len(witness_state))
+        + struct.pack('<Q', len(witness_codes))
+        + struct.pack('<Q', target)
+        + addr
+        + witness_headers
+        + witness_state
+        + witness_codes
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_extcodesize_at_block_number_address.elf \
+    -i "$in_file" -o "$out_file" -n 6000000 \
+    >"$REPO_ROOT/gen-out/zisk_ecsbn_${name}.emu.log" 2>&1 || true
+
+  local exp_size; exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-36s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-36s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+parts="6000"                                     run_case "contract_tiny_code"        contract 101 || FAILED=1
+parts="60006000016000526000601a526001601aF3"     run_case "contract_18b_code"         contract 101 || FAILED=1
+parts=""                                         run_case "empty_code_eoa"            empty_code_present 101 || FAILED=1
+parts="6000"                                     run_case "missing_account_zero"      missing_account 101 || FAILED=1
+parts="6000"                                     run_case "integrity_violation"       integrity_violation 101 || FAILED=1
+parts="6000"                                     run_case "number_not_in_section"     number_miss 999 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: extcodesize_at_block_number_address end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Number-keyed EXTCODESIZE primitive. **First EVM opcode** at
the block_number key level — the equivalent block_hash
family already has extcodesize / extcodehash / extcodecopy /
sload.

Mirrors \`extcodesize_at_block_hash_address\` (#7470) but
keyed by block_number. The block_number key requires an
inner K233 scan (\`header_extract_number\`) instead of the
block_hash key's K19 lookup, since witness.headers is not
hash-indexed by number.

Returns the u64 byte length that \`EXTCODESIZE(address)\`
would push when executed against the state of the block at
\`target_block_number\`:
- 0 if the account doesn't exist
- 0 if \`account.code_hash == EMPTY_CODE_HASH\`
- \`len(witness.codes[i])\` where \`keccak(codes[i]) == acct.code_hash\`

Pipeline (composes K233 scan + K201 + K28 + K19 by code_hash
+ EMPTY_CODE_HASH inline compare; no new helpers):

\`\`\`
witness.headers ∋ ?h with h.block.number == target  [K233]
h -> header_extract_state_root                      [K201]
state_root + address -> account_at_address          [K28]
if code_hash == EMPTY_CODE_HASH: return 0
else: witness.codes ∋ ?c with keccak(c) == code_hash [K19]
      return len(c)
\`\`\`

Uses all 8 a-registers (\`a0..a7\`) for inputs + an extra
\`s11\` to stash \`witness.codes_len\` past the first call
that clobbers a-regs (same pattern as
\`extcodesize_at_block_hash_address\`).

Status codes:

| status | meaning |
|--------|---------|
| 0 | success (ecsbn_code_len holds length; 0 if empty) |
| 1 | no header with target block_number |
| 2 | K233 parse failure during scan |
| 3 | matched header state_root extraction failure |
| 4 | state-trie mpt parse error |
| 5 | account_decode failure |
| 6 | code_hash != EMPTY but not found in witness.codes (witness integrity violation) |

## Test plan

- [x] \`lake build codegen\` succeeds.
- [x] \`bash scripts/codegen-zisk-extcodesize-at-block-number-address-check.sh\` — 6/6 fixtures pass:
  - \`contract_tiny_code\` (2 B) → (0, 2)
  - \`contract_18b_code\` → (0, 18)
  - \`empty_code_eoa\` (in-trie EMPTY_CODE_HASH) → (0, 0)
  - \`missing_account_zero\` → (0, 0)
  - \`integrity_violation\` → (6, 0)
  - \`number_not_in_section\` → (1, 0)
- [x] No \`native_decide\` / \`bv_decide\`; aligned LD/SD only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)