### PR TITLE
feat(stateless): extcodehash_at_block_number_address (EIP-1052)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -101,6 +101,7 @@ import EvmAsm.Codegen.Programs.StateSlotAtBlockNumber
 import EvmAsm.Codegen.Programs.StateAccountAtBlockNumber
 import EvmAsm.Codegen.Programs.BalanceAtBlockNumber
 import EvmAsm.Codegen.Programs.NonceAtBlockNumber
+import EvmAsm.Codegen.Programs.ExtcodehashAtBlockNumber
 import EvmAsm.Codegen.Programs.BlockHashAtBlockNumber
 import EvmAsm.Codegen.Programs.CodeAtBlockNumber
 import EvmAsm.Codegen.Programs.BlockHashAtStateRoot
@@ -492,6 +493,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_state_account_at_block_number_address" => some ziskStateAccountAtBlockNumberAddressProbeUnit
   | "zisk_balance_at_block_number_address" => some ziskBalanceAtBlockNumberAddressProbeUnit
   | "zisk_nonce_at_block_number_address" => some ziskNonceAtBlockNumberAddressProbeUnit
+  | "zisk_extcodehash_at_block_number_address" => some ziskExtcodehashAtBlockNumberAddressProbeUnit
   | "zisk_block_hash_at_block_number" => some ziskBlockHashAtBlockNumberProbeUnit
   | "zisk_code_at_block_number_address" => some ziskCodeAtBlockNumberAddressProbeUnit
   | "zisk_block_hash_at_state_root" => some ziskBlockHashAtStateRootProbeUnit
@@ -721,6 +723,7 @@ def knownProgramNames : List String :=
    "zisk_state_account_at_block_number_address",
    "zisk_balance_at_block_number_address",
    "zisk_nonce_at_block_number_address",
+   "zisk_extcodehash_at_block_number_address",
    "zisk_block_hash_at_block_number",
    "zisk_code_at_block_number_address",
    "zisk_block_hash_at_state_root",

--- a/EvmAsm/Codegen/Programs/ExtcodehashAtBlockNumber.lean
+++ b/EvmAsm/Codegen/Programs/ExtcodehashAtBlockNumber.lean
@@ -1,0 +1,347 @@
+/-
+  EvmAsm.Codegen.Programs.ExtcodehashAtBlockNumber
+
+  Number-keyed EIP-1052 EXTCODEHASH primitive. Sibling of
+  ExtcodesizeAtBlockNumber (#7500 -- first EVM opcode at the
+  block_number key level).
+
+  Distinct from the plain `code_hash_at_block_number_address`
+  extractor (#7486) in the EIP-1052 emptiness collapse:
+  fully-empty accounts here yield 0, not EMPTY_CODE_HASH.
+
+  No proofs yet -- codegen `String` defs only.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.Mpt
+import EvmAsm.Codegen.Programs.HashBridge
+import EvmAsm.Codegen.Programs.Tx
+import EvmAsm.Codegen.Programs.HeaderU64
+import EvmAsm.Codegen.Programs.HeaderFields
+import EvmAsm.Codegen.Programs.State
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Program
+
+/-! ## extcodehash_at_block_number_address  (EIP-1052 at block_number)
+
+    Returns the 32-byte EIP-1052 EXTCODEHASH value:
+    `account.code_hash` when the account exists and is NOT
+    EIP-161 empty, otherwise 0.
+
+    EIP-1052 emptiness collapse distinguishes this from the
+    plain code_hash extractor:
+
+      | account contents       | code_hash extract | EXTCODEHASH |
+      |------------------------|-------------------|-------------|
+      | fully empty (in trie)  | EMPTY_CODE_HASH   | 0           |
+      | nonce only             | EMPTY_CODE_HASH   | EMPTY_CODE_HASH |
+      | balance only           | EMPTY_CODE_HASH   | EMPTY_CODE_HASH |
+      | contract               | k256(code)        | k256(code)  |
+      | (not in trie)          | 0                 | 0           |
+
+    Block_number EVM opcode family progress:
+      * extcodesize -- PR 7500
+      * extcodehash -- THIS
+      * extcodecopy -- (TODO)
+      * sload       -- (TODO)
+
+    Pipeline (composes K233 + K201 + K28 + EIP-161 check):
+      witness.headers ∋ ?h with h.block.number == target  [K233]
+      h -> header_extract_state_root                      [K201]
+      state_root + address -> account_at_address          [K28]
+      if absent OR EIP-161 empty: return 0
+      else: return account.code_hash
+
+    Calling convention (7 args):
+      a0 (input)  : target_block_number (u64, by value)
+      a1 (input)  : witness.headers ptr
+      a2 (input)  : witness.headers len
+      a3 (input)  : address ptr (20 bytes)
+      a4 (input)  : witness.state ptr
+      a5 (input)  : witness.state len
+      a6 (input)  : 32-byte EXTCODEHASH out ptr
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success (out buffer holds EIP-1052 result; may be 0)
+        1 = no header with target block_number
+        2 = K233 parse failure during scan
+        3 = matched header state_root extraction failure
+        4 = state-trie mpt parse error
+        5 = account RLP decode failure
+-/
+def extcodehashAtBlockNumberAddressFunction : String :=
+  "extcodehash_at_block_number_address:\n" ++
+  "  addi sp, sp, -96\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp); sd s10, 88(sp)\n" ++
+  "  mv s0, a0                  # target block_number\n" ++
+  "  mv s1, a1                  # headers ptr\n" ++
+  "  mv s2, a2                  # headers len\n" ++
+  "  mv s3, a3                  # address ptr\n" ++
+  "  mv s4, a4                  # witness.state ptr\n" ++
+  "  mv s5, a5                  # witness.state len\n" ++
+  "  mv s6, a6                  # 32 B output ptr\n" ++
+  "  sd zero,  0(s6); sd zero,  8(s6); sd zero, 16(s6); sd zero, 24(s6)\n" ++
+  "  li s9, 0                   # saw_parse_fail\n" ++
+  "  beqz s2, .Leabn_miss\n" ++
+  "  lwu t0, 0(s1)\n" ++
+  "  srli s7, t0, 2             # N\n" ++
+  "  li s8, 0                   # i\n" ++
+  ".Leabn_loop:\n" ++
+  "  beq s8, s7, .Leabn_finish\n" ++
+  "  slli t0, s8, 2\n" ++
+  "  add t1, s1, t0\n" ++
+  "  lwu t2, 0(t1)\n" ++
+  "  add s10, s1, t2            # header start\n" ++
+  "  addi t3, s8, 1\n" ++
+  "  beq t3, s7, .Leabn_use_end\n" ++
+  "  slli t3, t3, 2\n" ++
+  "  add t3, s1, t3\n" ++
+  "  lwu t4, 0(t3)\n" ++
+  "  add t4, s1, t4\n" ++
+  "  j .Leabn_have_end\n" ++
+  ".Leabn_use_end:\n" ++
+  "  add t4, s1, s2\n" ++
+  ".Leabn_have_end:\n" ++
+  "  sub t5, t4, s10\n" ++
+  "  mv a0, s10\n" ++
+  "  mv a1, t5\n" ++
+  "  la a2, eabn_number_scratch\n" ++
+  "  jal ra, header_extract_number\n" ++
+  "  bnez a0, .Leabn_parse_fail\n" ++
+  "  la t0, eabn_number_scratch\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  beq t1, s0, .Leabn_hit\n" ++
+  "  j .Leabn_step\n" ++
+  ".Leabn_parse_fail:\n" ++
+  "  li s9, 1\n" ++
+  ".Leabn_step:\n" ++
+  "  addi s8, s8, 1\n" ++
+  "  j .Leabn_loop\n" ++
+  ".Leabn_hit:\n" ++
+  "  slli t0, s8, 2\n" ++
+  "  add t1, s1, t0\n" ++
+  "  lwu t2, 0(t1)\n" ++
+  "  addi t3, s8, 1\n" ++
+  "  beq t3, s7, .Leabn_re_use_end\n" ++
+  "  slli t3, t3, 2\n" ++
+  "  add t3, s1, t3\n" ++
+  "  lwu t4, 0(t3)\n" ++
+  "  j .Leabn_re_have_end\n" ++
+  ".Leabn_re_use_end:\n" ++
+  "  mv t4, s2\n" ++
+  ".Leabn_re_have_end:\n" ++
+  "  sub t5, t4, t2\n" ++
+  "  mv a0, s10\n" ++
+  "  mv a1, t5\n" ++
+  "  la a2, eabn_state_root\n" ++
+  "  jal ra, header_extract_state_root\n" ++
+  "  beqz a0, .Leabn_walk\n" ++
+  "  li a0, 3\n" ++
+  "  j .Leabn_ret\n" ++
+  ".Leabn_walk:\n" ++
+  "  mv a0, s3\n" ++
+  "  li a1, 20\n" ++
+  "  la a2, eabn_state_root\n" ++
+  "  mv a3, s4\n" ++
+  "  mv a4, s5\n" ++
+  "  la a5, eabn_walked_struct\n" ++
+  "  jal ra, account_at_address\n" ++
+  "  beqz a0, .Leabn_check_empty\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Leabn_success_zero\n" ++
+  "  addi a0, a0, 2             # 2->4, 3->5\n" ++
+  "  j .Leabn_ret\n" ++
+  ".Leabn_success_zero:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Leabn_ret\n" ++
+  ".Leabn_check_empty:\n" ++
+  "  la t3, eabn_walked_struct\n" ++
+  "  ld t1, 0(t3)\n" ++
+  "  bnez t1, .Leabn_write_code_hash\n" ++
+  "  ld t1,  8(t3); bnez t1, .Leabn_write_code_hash\n" ++
+  "  ld t1, 16(t3); bnez t1, .Leabn_write_code_hash\n" ++
+  "  ld t1, 24(t3); bnez t1, .Leabn_write_code_hash\n" ++
+  "  ld t1, 32(t3); bnez t1, .Leabn_write_code_hash\n" ++
+  "  la t0, eabn_empty_code_hash\n" ++
+  "  ld t1,  0(t0); ld t2, 72(t3); bne t1, t2, .Leabn_write_code_hash\n" ++
+  "  ld t1,  8(t0); ld t2, 80(t3); bne t1, t2, .Leabn_write_code_hash\n" ++
+  "  ld t1, 16(t0); ld t2, 88(t3); bne t1, t2, .Leabn_write_code_hash\n" ++
+  "  ld t1, 24(t0); ld t2, 96(t3); bne t1, t2, .Leabn_write_code_hash\n" ++
+  "  # EIP-161 empty -> output stays zero (EIP-1052 collapse).\n" ++
+  "  li a0, 0\n" ++
+  "  j .Leabn_ret\n" ++
+  ".Leabn_write_code_hash:\n" ++
+  "  ld t1, 72(t3); sd t1,  0(s6)\n" ++
+  "  ld t1, 80(t3); sd t1,  8(s6)\n" ++
+  "  ld t1, 88(t3); sd t1, 16(s6)\n" ++
+  "  ld t1, 96(t3); sd t1, 24(s6)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Leabn_ret\n" ++
+  ".Leabn_finish:\n" ++
+  "  bnez s9, .Leabn_parse_status\n" ++
+  ".Leabn_miss:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Leabn_ret\n" ++
+  ".Leabn_parse_status:\n" ++
+  "  li a0, 2\n" ++
+  ".Leabn_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp)\n" ++
+  "  addi sp, sp, 96\n" ++
+  "  ret"
+
+/-- `zisk_extcodehash_at_block_number_address`: probe BuildUnit.
+    Input layout (at INPUT_ADDR):
+      bytes  0.. 8 : (ziskemu metadata)
+      bytes  8..16 : witness_headers_len (u64 LE)
+      bytes 16..24 : witness_state_len (u64 LE)
+      bytes 24..32 : target_block_number (u64 LE)
+      bytes 32..52 : address (20 bytes)
+      bytes 52..   : witness.headers ++ witness.state
+    Output layout (40 bytes):
+      bytes  0.. 8 : status (0..5)
+      bytes  8..40 : EXTCODEHASH (32 B; 0 on missing/empty) -/
+def ziskExtcodehashAtBlockNumberAddressPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t4, 0x40000000\n" ++
+  "  ld a2, 8(t4)                # witness_headers_len\n" ++
+  "  ld a5, 16(t4)               # witness_state_len\n" ++
+  "  ld a0, 24(t4)               # target_block_number\n" ++
+  "  addi a3, t4, 32             # address ptr\n" ++
+  "  addi a1, t4, 52             # witness.headers ptr\n" ++
+  "  add  a4, a1, a2             # witness.state ptr\n" ++
+  "  li a6, 0xa0010008           # 32 B output ptr\n" ++
+  "  jal ra, extcodehash_at_block_number_address\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Leabn_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  mptLookupByKeyFunction ++ "\n" ++
+  accountDecodeFunction ++ "\n" ++
+  accountAtAddressFunction ++ "\n" ++
+  headerExtractNumberFunction ++ "\n" ++
+  headerExtractStateRootFunction ++ "\n" ++
+  extcodehashAtBlockNumberAddressFunction ++ "\n" ++
+  ".Leabn_pdone:"
+
+def ziskExtcodehashAtBlockNumberAddressDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mnk_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_dummy_length:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mbc_offset:\n" ++
+  "  .zero 8\n" ++
+  "mbc_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_lookup_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_lookup_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_lookup_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_child_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_nibble_count:\n" ++
+  "  .zero 8\n" ++
+  "mw_is_leaf:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_nibble_buf:\n" ++
+  "  .zero 128\n" ++
+  ".balign 32\n" ++
+  "mlk_keccak_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "mlk_nibble_buf:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "ad_offset:\n" ++
+  "  .zero 8\n" ++
+  "ad_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aa_value_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aa_value_scratch:\n" ++
+  "  .zero 256\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "hesr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hesr_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "eabn_number_scratch:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "eabn_state_root:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "eabn_walked_struct:\n" ++
+  "  .zero 104\n" ++
+  ".balign 32\n" ++
+  "eabn_empty_code_hash:\n" ++
+  "  .byte 0xc5, 0xd2, 0x46, 0x01, 0x86, 0xf7, 0x23, 0x3c\n" ++
+  "  .byte 0x92, 0x7e, 0x7d, 0xb2, 0xdc, 0xc7, 0x03, 0xc0\n" ++
+  "  .byte 0xe5, 0x00, 0xb6, 0x53, 0xca, 0x82, 0x27, 0x3b\n" ++
+  "  .byte 0x7b, 0xfa, 0xd8, 0x04, 0x5d, 0x85, 0xa4, 0x70"
+
+def ziskExtcodehashAtBlockNumberAddressProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskExtcodehashAtBlockNumberAddressPrologue
+  dataAsm     := ziskExtcodehashAtBlockNumberAddressDataSection
+}
+
+end EvmAsm.Codegen

--- a/scripts/codegen-zisk-extcodehash-at-block-number-address-check.sh
+++ b/scripts/codegen-zisk-extcodehash-at-block-number-address-check.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# codegen-zisk-extcodehash-at-block-number-address-check.sh
+#
+# Number-keyed EIP-1052 EXTCODEHASH.
+#
+# Output (40 bytes):
+#   bytes  0.. 8 : status (0..5)
+#   bytes  8..40 : EXTCODEHASH (32 B; 0 on missing/empty)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_extcodehash_at_block_number_address ELF"
+lake exe codegen --program zisk_extcodehash_at_block_number_address \
+  --halt linux93 \
+  -o gen-out/zisk_extcodehash_at_block_number_address
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+  local target="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_eabn_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_eabn_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_eabn_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def hp_encode(nibbles, is_leaf):
+    flag = 2 if is_leaf else 0
+    if len(nibbles) % 2 == 1:
+        flag |= 1
+        result = bytes([flag * 0x10 + nibbles[0]])
+        nibbles = nibbles[1:]
+    else:
+        result = bytes([flag * 0x10])
+    for i in range(0, len(nibbles), 2):
+        result += bytes([nibbles[i] * 0x10 + nibbles[i+1]])
+    return result
+
+def leaf_node(path_nibbles, value):
+    return rlp.encode([hp_encode(path_nibbles, True), value])
+
+def bytes_to_nibbles(b):
+    out = []
+    for byte in b:
+        out.append(byte >> 4); out.append(byte & 0xf)
+    return out
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0: return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset); offset += len(e)
+    for e in elements: section += e
+    return section
+
+def encode_account(nonce, balance, storage_root, code_hash):
+    return rlp.encode([nonce, balance, storage_root, code_hash])
+
+def encode_header(number_val, state_root):
+    if number_val == 0:
+        number_field = b''
+    else:
+        nbytes = (number_val.bit_length() + 7) // 8
+        number_field = number_val.to_bytes(nbytes, 'big')
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x55'*32,
+        b'\\x66'*32, b'\\x00'*256, b'', number_field, b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    return rlp.encode(fields)
+
+EMPTY_TRIE = bytes.fromhex('56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421')
+EMPTY_CODE_HASH = bytes.fromhex('c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')
+
+def state_trie_one(addr, acct_rlp):
+    path = bytes_to_nibbles(k256(addr))
+    leaf = leaf_node(path, acct_rlp)
+    return k256(leaf), build_ssz_section([leaf])
+
+def resolve_code_hash(mode_str):
+    if mode_str == 'empty':
+        return EMPTY_CODE_HASH
+    if mode_str.startswith('contract:'):
+        return k256(bytes.fromhex(mode_str.split(':', 1)[1]))
+    raise SystemExit('bad code_mode: ' + mode_str)
+
+mode = '$mode'
+target = int('$target')
+parts = '$parts'.split('|')
+ALICE = b'\\xaa' * 20
+BOB = b'\\xbb' * 20
+
+if mode == 'account':
+    nonce = int(parts[0]); balance = int(parts[1])
+    code_hash = resolve_code_hash(parts[2])
+    acct = encode_account(nonce, balance, EMPTY_TRIE, code_hash)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(100, b'\\xee'*32)
+    h1 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0, h1])
+    addr = ALICE
+    is_empty = (nonce == 0 and balance == 0 and code_hash == EMPTY_CODE_HASH)
+    extcodehash = b'\\x00' * 32 if is_empty else code_hash
+    expected = struct.pack('<Q', 0) + extcodehash
+elif mode == 'missing':
+    acct = encode_account(7, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(BOB, acct)
+    h0 = encode_header(101, sr)
+    witness_headers = build_ssz_section([h0])
+    addr = ALICE
+    expected = struct.pack('<Q', 0) + b'\\x00' * 32
+elif mode == 'number_miss':
+    acct = encode_account(0, 0, EMPTY_TRIE, EMPTY_CODE_HASH)
+    sr, witness_state = state_trie_one(ALICE, acct)
+    h0 = encode_header(100, sr)
+    witness_headers = build_ssz_section([h0])
+    addr = ALICE
+    expected = struct.pack('<Q', 1) + b'\\x00' * 32
+else:
+    raise SystemExit('bad mode: ' + mode)
+
+with open(sys.argv[1], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(witness_headers))
+        + struct.pack('<Q', len(witness_state))
+        + struct.pack('<Q', target)
+        + addr
+        + witness_headers
+        + witness_state
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_extcodehash_at_block_number_address.elf \
+    -i "$in_file" -o "$out_file" -n 6000000 \
+    >"$REPO_ROOT/gen-out/zisk_eabn_${name}.emu.log" 2>&1 || true
+
+  local exp_size; exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-36s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-36s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+parts="0|0|empty"                 run_case "fully_empty_in_trie"     account 101 || FAILED=1
+parts="0|1000|empty"              run_case "balance_only"            account 101 || FAILED=1
+parts="1|0|empty"                 run_case "nonce_only"              account 101 || FAILED=1
+parts="0|0|contract:6000"         run_case "contract_only"           account 101 || FAILED=1
+parts="42|1000|contract:6000"     run_case "fully_active"            account 101 || FAILED=1
+parts=""                          run_case "missing_account"         missing 101 || FAILED=1
+parts=""                          run_case "number_not_in_section"   number_miss 999 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: extcodehash_at_block_number_address (EIP-1052) end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Number-keyed EIP-1052 EXTCODEHASH primitive. Sibling of
\`extcodesize_at_block_number_address\` (#7500 — first EVM
opcode at the block_number key level).

Returns the 32-byte EIP-1052 result: \`account.code_hash\`
when the account exists and is NOT EIP-161 empty, otherwise 0.

**Distinct from the plain \`code_hash_at_block_number_address\`
extractor (#7486) in the EIP-1052 emptiness collapse:**

| account contents       | code_hash extract | EXTCODEHASH |
|------------------------|-------------------|-------------|
| fully empty (in trie)  | EMPTY_CODE_HASH   | 0           |
| nonce only             | EMPTY_CODE_HASH   | EMPTY_CODE_HASH |
| balance only           | EMPTY_CODE_HASH   | EMPTY_CODE_HASH |
| contract               | k256(code)        | k256(code)  |
| (not in trie)          | 0                 | 0           |

The \`balance_only\` row is the canonical distinguishing
case: present-but-non-EIP-161-empty returns
EMPTY_CODE_HASH (NOT 0), whereas a fully-empty account
collapses to 0.

Block_number EVM opcode family progress:

| opcode | block_hash | block_number |
|--------|------------|--------------|
| extcodesize | #7470 | #7500 |
| extcodehash (EIP-1052) | #7474 | **this** |
| extcodecopy | #7477 | (TODO) |
| sload | #7476 | (TODO) |

Pipeline (composes K233 + K201 + K28 + EIP-161 check; no
new helpers).

Status codes:

| status | meaning |
|--------|---------|
| 0 | success (32 B EIP-1052 result written) |
| 1 | no header with target block_number |
| 2 | K233 parse failure during scan |
| 3 | matched header state_root extraction failure |
| 4 | state-trie mpt parse error |
| 5 | account RLP decode failure |

## Test plan

- [x] \`lake build codegen\` succeeds.
- [x] \`bash scripts/codegen-zisk-extcodehash-at-block-number-address-check.sh\` — 7/7 fixtures pass covering the EIP-1052 row matrix.
- [x] Merge with \`origin/main\` clean after resolving 3 trivial parallel-add conflicts (\`CodeHashAtBlockNumber\` landed in parallel; both kept).
- [x] No \`native_decide\` / \`bv_decide\`; aligned LD/SD only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)