### PR TITLE
feat(divmod): n3 v5 call-addback-beq j0 raw (correct norm-path variant)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -259,6 +259,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN3V5.MaxAddbackV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3V5.MaxAddbackBeqV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallSkipV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackV5NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackBeqV5NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMax
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMax
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallJ0

--- a/EvmAsm/Evm64/DivMod/LoopIterN3V5/CallAddbackBeqV5NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3V5/CallAddbackBeqV5NoNop.lean
@@ -1,0 +1,129 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackBeqV5NoNop
+
+  v5 n=3 call+addback-beq j=0 loop body over `sharedDivModCodeNoNop_v5`, with the
+  `loopBodyN3CallSkipJ0PreV4` precondition shared with the call-skip body — the
+  variant consumed by the norm/exact path.  Mirror of the v4 n=3
+  call-addback-beq body (`LoopIterN3AddbackV4NoNop` :250) with the v5 NAMED trial
+  + `divKTrialCallV5*` outputs + the v5 mulsub-correction-addback-beq / store
+  bricks.  The post is `loopBodyN3CallAddbackBeqJ0PostV5` (LoopIterN3V5.
+  CallAddbackV5NoNop), the V5 analog of `loopBodyN3CallAddbackJ0PostV4`.
+  Bead `evm-asm-wbc4i.9.3.3.2.2.2`.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionAddbackV5NoNop
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCallFullV5Named
+import EvmAsm.Evm64.DivMod.LoopBody.StoreLoopV5
+import EvmAsm.Evm64.DivMod.LoopIterN3CallV4NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackV5NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v5 n=3 call+addback-beq j=0 loop body (loopBodyOff → denormOff), with the
+    call-skip-j0 NormPre-style precondition. -/
+theorem divK_loop_body_n3_call_addback_j0_beq_v5_spec_within_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word))
+    (hcarry2_nz :
+      let qHat := divKTrialCallV5QHat u3 u2 v2
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + denormOff) (sharedDivModCodeNoNop_v5 base)
+      (loopBodyN3CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN3CallAddbackBeqJ0PostV5 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  unfold loopBodyN3CallSkipJ0PreV4
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let dHi := divKTrialCallV5DHi v2
+  let dLo := divKTrialCallV5DLo v2
+  let divUn0 := divKTrialCallV5Un0 u2
+  let q1'' := divKTrialCallV5Q1dd u3 u2 v2
+  let q0'' := divKTrialCallV5Q0dd u3 u2 v2
+  let x7Exit := divKTrialCallV5X7Exit u3 u2 v2
+  let x9Exit := divKTrialCallV5X9Exit u3 u2 v2
+  let qHat := divKTrialCallV5QHat u3 u2 v2
+  let scratchOut := divKTrialCallV5ScratchOut u3 u2 v2 scratchMem
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
+  let carryOut := if carry = 0 then
+      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
+    else carry
+  have TF := divK_trial_call_full_v5_named_spec_within_noNop sp (0 : Word) (3 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    u3 u2 v2 retMem dMem dloMem scratchUn0 scratchMem base
+    halign hbltu
+  unfold divKTrialCallFullPostV5Named at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n3] at TF
+  rw [u_addr8_eq_n3] at TF
+  rw [vtop_eq_v2_n3] at TF
+  have MCA := divK_mulsub_correction_addback_beq_v5_spec_within_noNop sp qHat (0 : Word)
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x9Exit q0'' dHi x7Exit q1'' (base + div128CallRetOff) base
+  intro_lets at MCA
+  have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR ((sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) MCA0
+  have SL := divK_store_loop_j0_v5_spec_within_noNop sp q_out u4_out carryOut qOld base
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCA0f
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
+     (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v2) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ divUn0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      rw [loopBodyN3CallSkipPre_unfold] at hp
+      xperm_hyp hp)
+    (fun h hp => by
+      unfold loopBodyN3CallAddbackBeqJ0PostV5
+      unfold loopBodyN3AddbackBeqPost loopBodyAddbackBeqPost loopExitPost
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    full
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopIterN3V5/CallAddbackBeqV5NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3V5/CallAddbackBeqV5NoNop.lean
@@ -15,6 +15,7 @@ import EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionAddbackV5NoNop
 import EvmAsm.Evm64.DivMod.LoopBody.TrialCallFullV5Named
 import EvmAsm.Evm64.DivMod.LoopBody.StoreLoopV5
 import EvmAsm.Evm64.DivMod.LoopIterN3CallV4NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN3AddbackV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackV5NoNop
 
 open EvmAsm.Rv64.Tactics
@@ -121,6 +122,127 @@ theorem divK_loop_body_n3_call_addback_j0_beq_v5_spec_within_noNop
       xperm_hyp hp)
     (fun h hp => by
       unfold loopBodyN3CallAddbackBeqJ0PostV5
+      unfold loopBodyN3AddbackBeqPost loopBodyAddbackBeqPost loopExitPost
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    full
+
+/-- v5 n=3 call+addback-beq j>0 loop-body post (j-parameterized; mirror of
+    `loopBodyN3CallAddbackJgt0PostV4` with v5 trial defs). -/
+@[irreducible]
+def loopBodyN3CallAddbackBeqJgt0PostV5
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV5DLo v2
+  let divUn0 := divKTrialCallV5Un0 u2
+  let qHat := divKTrialCallV5QHat u3 u2 v2
+  let scratchOut := divKTrialCallV5ScratchOut u3 u2 v2 scratchMem
+  loopBodyN3AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v2) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ divUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut) **
+  regOwn .x1
+
+/-- v5 n=3 call+addback-beq j>0 loop body (loopBodyOff → loopBodyOff loop-back),
+    with the `loopBodyN3CallAddbackJgt0PreV4` precondition. -/
+theorem divK_loop_body_n3_call_addback_jgt0_beq_v5_spec_within_noNop (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word))
+    (hcarry2_nz :
+      let qHat := divKTrialCallV5QHat u3 u2 v2
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCodeNoNop_v5 base)
+      (loopBodyN3CallAddbackJgt0PreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN3CallAddbackBeqJgt0PostV5 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  unfold loopBodyN3CallAddbackJgt0PreV4
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  let dHi := divKTrialCallV5DHi v2
+  let dLo := divKTrialCallV5DLo v2
+  let divUn0 := divKTrialCallV5Un0 u2
+  let q1'' := divKTrialCallV5Q1dd u3 u2 v2
+  let q0'' := divKTrialCallV5Q0dd u3 u2 v2
+  let x7Exit := divKTrialCallV5X7Exit u3 u2 v2
+  let x9Exit := divKTrialCallV5X9Exit u3 u2 v2
+  let qHat := divKTrialCallV5QHat u3 u2 v2
+  let scratchOut := divKTrialCallV5ScratchOut u3 u2 v2 scratchMem
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
+  let carryOut := if carry = 0 then
+      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
+    else carry
+  have TF := divK_trial_call_full_v5_named_spec_within_noNop sp j (3 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    u3 u2 v2 retMem dMem dloMem scratchUn0 scratchMem base
+    halign hbltu
+  unfold divKTrialCallFullPostV5Named at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n3] at TF
+  rw [u_addr8_eq_n3] at TF
+  rw [vtop_eq_v2_n3] at TF
+  have MCA := divK_mulsub_correction_addback_beq_v5_spec_within_noNop sp qHat j
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x9Exit q0'' dHi x7Exit q1'' (base + div128CallRetOff) base
+  intro_lets at MCA
+  have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR ((sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) MCA0
+  have SL := divK_store_loop_jgt0_v5_spec_within_noNop sp j q_out u4_out carryOut qOld base hpos
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCA0f
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
+     (sp + signExtend12 3976 ↦ₘ j) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
+     (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v2) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ divUn0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      rw [loopBodyN3CallSkipPre_unfold] at hp
+      xperm_hyp hp)
+    (fun h hp => by
+      unfold loopBodyN3CallAddbackBeqJgt0PostV5
       unfold loopBodyN3AddbackBeqPost loopBodyAddbackBeqPost loopExitPost
       rw [sepConj_assoc'] at hp
       xperm_hyp hp)


### PR DESCRIPTION
## Summary

- `divK_loop_body_n3_call_addback_j0_beq_v5_spec_within_noNop` (new `LoopIterN3V5/CallAddbackBeqV5NoNop`) — call-addback raw with the `loopBodyN3CallSkipJ0PreV4` precondition (the norm-path variant). Mirror of `LoopIterN3AddbackV4NoNop` :250: v5 NAMED trial + `divKTrialCallV5*` outputs + v5 mulsub-correction-addback-beq/store bricks (234 steps); post `loopBodyN3CallAddbackBeqJ0PostV5`.
- With #7508 (max-addback-beq), the correct addback-beq raws for j=0 are in place. Axiom-clean, built first try. Follow-on: jgt0 (j=1) variants.

Refs #61. Bead: evm-asm-wbc4i.9.3.3.2.2.2.

Authored by @pirapira; implemented by Claude Code