### PR TITLE
feat(divmod): n3 v5 max-addback-beq norm wrappers

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -261,6 +261,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallSkipV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackBeqV5NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMax
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxAddbackNorm
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMax
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallJ0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallExactX1

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopMaxAddbackNorm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopMaxAddbackNorm.lean
@@ -1,0 +1,81 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxAddbackNorm
+
+  v5/no-NOP norm-pre wrappers for the n=3 DIV max+addback-beq loop bodies.
+  Mirror of the v4 n=3 max-addback-beq norm wrappers (`FullPathN3V4NoNop`
+  :274/:151), lifting the raw v5 max-addback-beq bodies (#7508, over
+  `sharedDivModCodeNoNop_v5`) to `divCode_noNop_v5` via
+  `sharedDivModCodeNoNop_v5_sub_divCode_noNop_v5`, hiding the sp-relative
+  addresses behind the (code-agnostic) NormPre defs reused from the v4 wrappers.
+  Bead `evm-asm-wbc4i.9.3.3.2.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNop
+import EvmAsm.Evm64.DivMod.Compose.V5NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN3V5.MaxAddbackBeqV5NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- Loop body n=3, max+addback-beq, j=0 over `divCode_noNop_v5`, with
+    sp-relative addresses hidden behind a named precondition. -/
+theorem divK_loop_body_n3_max_addback_j0_beq_norm_v5_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult u3 v2)
+    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v5 base)
+      (loopBodyN3MaxSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN3AddbackBeqPost sp (0 : Word) (signExtend12 4095 : Word)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n3_max_addback_j0_beq_v5_spec_within_noNop
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hcarry2_nz hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v5_sub_divCode_noNop_v5) raw
+  rw [loopBodyN3MaxSkipPre_unfold] at raw'
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw'
+  delta loopBodyN3MaxSkipJ0NormPreV4
+  exact raw'
+
+/-- Loop body n=3, max+addback-beq, j>0 over `divCode_noNop_v5`, with the
+    precondition hidden behind an irreducible definition. -/
+theorem divK_loop_body_n3_max_addback_jgt0_beq_norm_v5_noNop (j sp base : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult u3 v2)
+    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v5 base)
+      (loopBodyN3MaxAddbackJgt0NormPreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN3AddbackBeqPost sp j (signExtend12 4095 : Word)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n3_max_addback_jgt0_beq_v5_spec_within_noNop j hpos
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hcarry2_nz hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v5_sub_divCode_noNop_v5) raw
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopBodyN3MaxAddbackJgt0NormPreV4 at hp
+      xperm_hyp hp)
+    (fun h hp => hp)
+    raw'
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

- `divK_loop_body_n3_max_addback_{j0,jgt0}_beq_norm_v5_noNop` (new `FullPathN3V5NoNopMaxAddbackNorm`) — lift the raw v5 max-addback-beq bodies (#7508) to `divCode_noNop_v5`, hiding sp-relative addresses behind the v4 NormPre defs (`loopBodyN3MaxSkipJ0NormPreV4` for j0, `loopBodyN3MaxAddbackJgt0NormPreV4` for jgt0). Mirror of `FullPathN3V4NoNop` :274/:151.
- The max-path norm wrappers (skip #7505 + addback) are now complete. Trivial v4→v5 lift, built first try. Axiom-clean.

Refs #61. Bead: evm-asm-wbc4i.9.3.3.2.1.

Authored by @pirapira; implemented by Claude Code