### PR TITLE
feat(divmod): n3 v5 call-addback-beq exact-x1 loop bodies (j0 + jgt0)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -260,6 +260,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN3V5.MaxAddbackBeqV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallSkipV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackBeqV5NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackBeqExactX1V5NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMax
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCall
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxAddbackNorm

--- a/EvmAsm/Evm64/DivMod/LoopIterN3V5/CallAddbackBeqExactX1V5NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3V5/CallAddbackBeqExactX1V5NoNop.lean
@@ -1,0 +1,265 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackBeqExactX1V5NoNop
+
+  Exact-x1 variants of the v5 n=3 call+addback-beq loop bodies (j=0 and j>0) over
+  `sharedDivModCodeNoNop_v5`, preserving the concrete caller `x1` (= `raVal`)
+  through the v5 div128 trial call — the addback companions to the call-skip
+  exact-x1 raws (`CallSkipExactX1V5NoNop`).  Mirror of the v4 analogs
+  (`LoopIterN3AddbackV4NoNop` :346/:538) with the v5 NAMED exact-x1 trial
+  (`divK_trial_call_full_v5_named_spec_within_noNop_exact_x1`) + the v5
+  mulsub-correction-addback-beq / exact-x1 store bricks.  Carries the NoX1 addback
+  posts (`loopBodyN3CallAddbackJ{0,gt0}PostV5NoX1`) consumed by the n=3 call
+  exact-jN / combo path.  Bead `evm-asm-wbc4i.9.3.3.2.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionAddbackV5NoNop
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCallFullV5NamedExactX1
+import EvmAsm.Evm64.DivMod.LoopBody.StoreLoopV5ExactX1
+import EvmAsm.Evm64.DivMod.LoopIterN3CallV4NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN3AddbackV4NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v5 n=3 call+addback-beq j=0 loop-body post (no x1; mirror of
+    `loopBodyN3CallAddbackJ0PostV4NoX1` with v5 trial defs). -/
+@[irreducible]
+def loopBodyN3CallAddbackJ0PostV5NoX1
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV5DLo v2
+  let divUn0 := divKTrialCallV5Un0 u2
+  let qHat := divKTrialCallV5QHat u3 u2 v2
+  let scratchOut := divKTrialCallV5ScratchOut u3 u2 v2 scratchMem
+  loopBodyN3AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v2) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ divUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut)
+
+/-- v5 n=3 call+addback-beq j>0 loop-body post (j-parameterized, no x1; mirror of
+    `loopBodyN3CallAddbackJgt0PostV4NoX1` with v5 trial defs). -/
+@[irreducible]
+def loopBodyN3CallAddbackJgt0PostV5NoX1
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV5DLo v2
+  let divUn0 := divKTrialCallV5Un0 u2
+  let qHat := divKTrialCallV5QHat u3 u2 v2
+  let scratchOut := divKTrialCallV5ScratchOut u3 u2 v2 scratchMem
+  loopBodyN3AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v2) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ divUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut)
+
+/-- v5 n=3 call+addback-beq j=0 loop body preserving concrete `x1 = raVal`. -/
+theorem divK_loop_body_n3_call_addback_j0_beq_v5_spec_within_noNop_exact_x1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word))
+    (hcarry2_nz :
+      let qHat := divKTrialCallV5QHat u3 u2 v2
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + denormOff) (sharedDivModCodeNoNop_v5 base)
+      (loopBodyN3CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopBodyN3CallAddbackJ0PostV5NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  unfold loopBodyN3CallSkipJ0PreV4NoX1
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let dHi := divKTrialCallV5DHi v2
+  let dLo := divKTrialCallV5DLo v2
+  let divUn0 := divKTrialCallV5Un0 u2
+  let q1'' := divKTrialCallV5Q1dd u3 u2 v2
+  let q0'' := divKTrialCallV5Q0dd u3 u2 v2
+  let x7Exit := divKTrialCallV5X7Exit u3 u2 v2
+  let x9Exit := divKTrialCallV5X9Exit u3 u2 v2
+  let qHat := divKTrialCallV5QHat u3 u2 v2
+  let scratchOut := divKTrialCallV5ScratchOut u3 u2 v2 scratchMem
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
+  let carryOut := if carry = 0 then
+      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
+    else carry
+  have TF := divK_trial_call_full_v5_named_spec_within_noNop_exact_x1 sp (0 : Word) (3 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    u3 u2 v2 retMem dMem dloMem scratchUn0 scratchMem raVal base
+    halign hbltu
+  unfold divKTrialCallFullPostV5NamedExactX1 at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n3] at TF
+  rw [u_addr8_eq_n3] at TF
+  rw [vtop_eq_v2_n3] at TF
+  have MCA := divK_mulsub_correction_addback_beq_v5_spec_within_noNop sp qHat (0 : Word)
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x9Exit q0'' dHi x7Exit q1'' (base + div128CallRetOff) base
+  intro_lets at MCA
+  have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR ((sp + signExtend12 3936 ↦ₘ scratchOut) ** (.x1 ↦ᵣ raVal))
+    (by pcFree) MCA0
+  have SL := divK_store_loop_j0_v5_spec_within_noNop_exact_x1 sp q_out u4_out carryOut qOld raVal base
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCA0f
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
+     (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v2) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ divUn0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut))
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      unfold loopBodyN3CallAddbackJ0PostV5NoX1
+      unfold loopBodyN3AddbackBeqPost loopBodyAddbackBeqPost loopExitPost
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    full
+
+/-- v5 n=3 call+addback-beq j>0 loop body preserving concrete `x1 = raVal`. -/
+theorem divK_loop_body_n3_call_addback_jgt0_beq_v5_spec_within_noNop_exact_x1 (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word))
+    (hcarry2_nz :
+      let qHat := divKTrialCallV5QHat u3 u2 v2
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCodeNoNop_v5 base)
+      (loopBodyN3CallSkipJgt0PreV4NoX1 sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopBodyN3CallAddbackJgt0PostV5NoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  unfold loopBodyN3CallSkipJgt0PreV4NoX1
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  let dHi := divKTrialCallV5DHi v2
+  let dLo := divKTrialCallV5DLo v2
+  let divUn0 := divKTrialCallV5Un0 u2
+  let q1'' := divKTrialCallV5Q1dd u3 u2 v2
+  let q0'' := divKTrialCallV5Q0dd u3 u2 v2
+  let x7Exit := divKTrialCallV5X7Exit u3 u2 v2
+  let x9Exit := divKTrialCallV5X9Exit u3 u2 v2
+  let qHat := divKTrialCallV5QHat u3 u2 v2
+  let scratchOut := divKTrialCallV5ScratchOut u3 u2 v2 scratchMem
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
+  let carryOut := if carry = 0 then
+      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
+    else carry
+  have TF := divK_trial_call_full_v5_named_spec_within_noNop_exact_x1 sp j (3 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    u3 u2 v2 retMem dMem dloMem scratchUn0 scratchMem raVal base
+    halign hbltu
+  unfold divKTrialCallFullPostV5NamedExactX1 at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n3] at TF
+  rw [u_addr8_eq_n3] at TF
+  rw [vtop_eq_v2_n3] at TF
+  have MCA := divK_mulsub_correction_addback_beq_v5_spec_within_noNop sp qHat j
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x9Exit q0'' dHi x7Exit q1'' (base + div128CallRetOff) base
+  intro_lets at MCA
+  have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR ((sp + signExtend12 3936 ↦ₘ scratchOut) ** (.x1 ↦ᵣ raVal))
+    (by pcFree) MCA0
+  have SL := divK_store_loop_jgt0_v5_spec_within_noNop_exact_x1 sp j q_out u4_out carryOut qOld
+    raVal base hpos
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCA0f
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
+     (sp + signExtend12 3976 ↦ₘ j) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
+     (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v2) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ divUn0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut))
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      unfold loopBodyN3CallAddbackJgt0PostV5NoX1
+      unfold loopBodyN3AddbackBeqPost loopBodyAddbackBeqPost loopExitPost
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    full
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

The addback companions to the call-skip exact-x1 raws — the call body preserving concrete `x1` (=raVal) through the v5 div128 trial on the addback (borrow) branch.

- `divK_loop_body_n3_call_addback_j0_beq_v5_spec_within_noNop_exact_x1` + `loopBodyN3CallAddbackJ0PostV5NoX1` (j=0 → denorm). Mirror of `LoopIterN3AddbackV4NoNop` :346.
- `divK_loop_body_n3_call_addback_jgt0_beq_v5_spec_within_noNop_exact_x1` + `loopBodyN3CallAddbackJgt0PostV5NoX1` (j>0 → loop-back). Mirror of :538.

Both over `sharedDivModCodeNoNop_v5` with the v5 NAMED exact-x1 trial + v5 mulsub-correction-addback-beq / exact-x1 store bricks. The exact-x1 store already carries x1 in its own pre/post, so x1 is not re-framed onto SLf (the bug I hit and fixed). Axiom-clean (`propext`/`Classical.choice`/`Quot.sound`), independent of the call-skip exact-x1 PR (branches from main).

Completes the four n=3 v5 call exact-x1 raws (skip j0/j1 in #7513 + addback j0/jgt0 here); next is the exact-loopIterScratch wrappers.

Refs #61. Bead: evm-asm-wbc4i.9.3.3.2.1.

Authored by @pirapira; implemented by Claude Code