### PR TITLE
feat(divmod): n3 v5 named-carry call borrowCarry combos (dispatch-feeding fix)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -269,6 +269,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxExact
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallExact
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallExactBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallCombosBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallCombosBorrowCarryNamed
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallCombos
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxCombos
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnified

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopCallCombosBorrowCarryNamed.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopCallCombosBorrowCarryNamed.lean
@@ -1,0 +1,101 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallCombosBorrowCarryNamed
+
+  Named-carry restatements of the call-first n=3 borrowCarry combos: identical to
+  the inline-carry combos (FullPathN3V5NoNopCallCombosBorrowCarry, #7531) but with
+  the second-addback carry obligation written as the NAMED
+  `loopBodyN3CallAddbackCarry2NzV5` (defeq to the inline form, unfolded here where
+  `mulsubN4`/`addbackN4` are transparent).  These let the from-source borrowCarry
+  dispatch feed the bundle's named obligations to combos NAMED-to-NAMED, avoiding
+  the isDefEq explosion that arises when matching inline carry hypotheses with the
+  iteration windows held opaque.  Bead `evm-asm-wbc4i.9.3.3.3.4`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallCombosBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnified
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Named-carry restatement of `divK_loop_n3_call_j1_from_source_..._borrowCarry`. -/
+theorem divK_loop_n3_call_j1_from_source_exact_loopIterScratch_v5_noNop_borrowCarry_named
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hcarry2_borrow :
+      BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) →
+      loopBodyN3CallAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3CallScratchNoX1 sp base (1 : Word)
+        (divKTrialCallV5QHat u3 u2 v2)
+        (divKTrialCallV5DLo v2)
+        (divKTrialCallV5Un0 u2)
+        (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) **
+        (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old))) :=
+  divK_loop_n3_call_j1_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu hcarry2_borrow
+
+/-- Named-carry restatement of `divK_loop_n3_call_call_from_source_..._borrowCarry`. -/
+theorem divK_loop_n3_call_call_from_source_exact_loopIterScratch_v5_noNop_borrowCarry_named
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : BitVec.ult u3 v2)
+    (hcarry2_borrow_1 :
+      BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) →
+      loopBodyN3CallAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_0 :
+      BitVec.ult
+        (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
+    (hcarry2_borrow_0 :
+      let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r1.2.2.2.2.1
+        (mulsubN4_c3 (divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v2)
+          v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      loopBodyN3CallAddbackCarry2NzV5 v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (234 + 234) (base + loopBodyOff) (base + denormOff) (divCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v2)
+        (divKTrialCallV5DLo v2)
+        (divKTrialCallV5Un0 r1.2.2.1)
+        (divKTrialCallV5ScratchOut r1.2.2.2.1 r1.2.2.1 v2
+          (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem))
+        v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) :=
+  divK_loop_n3_call_call_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu_1 hcarry2_borrow_1 hbltu_0 hcarry2_borrow_0
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

`divK_loop_n3_call_{j1_from_source,call}_..._borrowCarry_named` — named-carry restatements of the inline-carry call borrowCarry combos (#7531), with the second-addback carry written as the **named** `loopBodyN3CallAddbackCarry2NzV5` (defeq to inline; unfolded here where `mulsubN4`/`addbackN4` are transparent, so the named→inline feeding is a single cheap defeq with no explosion).

**This is the structural fix for the from-source borrowCarry dispatch blocker** (diagnosed last tick): the dispatch was hitting an isDefEq explosion (>2M heartbeats) matching *inline* carry hypotheses against the `mulsubN4`/`addbackN4`-nested combo statements. With these named-carry combos, the dispatch feeds the bundle's named obligations **named-to-named** (holding the iteration windows opaque) — no explosion.

Built first try, axiom-clean. Next: `call_max` + `max_call` named wrappers, then the dispatch itself. Stacked on #7531.

Refs #61. Bead: evm-asm-wbc4i.9.3.3.3.4.

Authored by @pirapira; implemented by Claude Code