### PR TITLE
feat(divmod): n3 v5 from-source borrowCarry dispatch (unblocked via named iterN3Max rewrite)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -274,6 +274,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallCombosBorrowCarryNamed
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopRestCombosBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopRestCombosBorrowCarryNamed
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnifiedBorrowCarryCases
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnifiedBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallCombos
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxCombos
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnified

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopUnifiedBorrowCarry.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopUnifiedBorrowCarry.lean
@@ -1,0 +1,116 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnifiedBorrowCarry
+
+  Borrow-dispatched unified n=3 v5 loop: takes `loopN3SelectedBorrowCarryV5` (the
+  satisfiable-from-shape carry bundle, #7526) instead of the unsatisfiable
+  unconditional `loopN3SelectedCarryV5`, and dispatches the 4 `bltu²` cases to the
+  per-case unified-post `_borrowCarry` wrappers (#7536), extracting the two
+  per-digit borrow-conditional carries from the bundle in each arm.
+
+  The bundle's j=0 window is `iterN3V5 bltu_1 …` (`@[irreducible]`); the dispatch
+  rewrites it with `iterN3V5_true_eq` (→ `iterWithDoubleAddback (divKTrialCallV5QHat …)`)
+  and the NAMED `iterN3V5_false_eq_max` (→ `iterN3Max`, *not* the over-unfolded
+  `iterWithDoubleAddback (signExtend12 4095)`).  Matching the wrappers' named
+  `iterN3Max` window keeps the isDefEq syntactic — the over-unfold to the saturated
+  `iterWithDoubleAddback` is exactly what forced the explosive defeq through the
+  irreducible `iterN3Max` in earlier attempts.  n3 mirror of
+  `divK_loop_n2_unified_from_source_..._borrowCarry`.  Bead `evm-asm-wbc4i.9.3.3.3.4`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopLoopDefsBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnifiedBorrowCarryCases
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Borrow-dispatched n=3 v5 unified loop: the carries come from the
+    satisfiable-from-shape `loopN3SelectedBorrowCarryV5` bundle (borrow-conditional
+    per digit), dispatched to the per-case unified-post `_borrowCarry` wrappers. -/
+theorem divK_loop_n3_unified_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 = BitVec.ult u3 v2)
+    (hbltu_0 : bltu_0 =
+      match bltu_1 with
+      | false => BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2
+      | true =>
+        BitVec.ult
+          (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
+    (hcarry : loopN3SelectedBorrowCarryV5 bltu_1 bltu_0
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig) :
+    cpsTripleWithin 468 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN3UnifiedPostV5NoX1 bltu_1 bltu_0 sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  cases bltu_1 <;> cases bltu_0
+  · -- max × max
+    have hb1 : ¬BitVec.ult u3 v2 := by rw [← hbltu_1]; decide
+    have hb0 :
+        let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        ¬BitVec.ult r1.2.2.2.1 v2 := by
+      simp only at hbltu_0 ⊢; rw [← hbltu_0]; decide
+    unfold loopN3SelectedBorrowCarryV5 at hcarry
+    simp only [iterN3V5_false_eq_max] at hcarry
+    rw [if_neg (by decide), if_neg (by decide)] at hcarry
+    obtain ⟨hc1, hc0⟩ := hcarry
+    exact divK_loop_n3_unified_maxmax_borrowCarry sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+      retMem dMem dloMem scratchUn0 scratchMem hb1 hc1 hb0 hc0
+  · -- max × call
+    have hb1 : ¬BitVec.ult u3 v2 := by rw [← hbltu_1]; decide
+    have hb0 :
+        let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        BitVec.ult r1.2.2.2.1 v2 := by
+      simp only at hbltu_0 ⊢; exact hbltu_0.symm
+    unfold loopN3SelectedBorrowCarryV5 at hcarry
+    simp only [iterN3V5_false_eq_max] at hcarry
+    rw [if_neg (by decide), if_pos (by decide)] at hcarry
+    obtain ⟨hc1, hc0⟩ := hcarry
+    exact divK_loop_n3_unified_maxcall_borrowCarry sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+      retMem dMem dloMem scratchUn0 scratchMem halign hb1 hc1 hb0 hc0
+  · -- call × max
+    have hb1 : BitVec.ult u3 v2 := hbltu_1.symm
+    have hb0 :
+        let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        ¬BitVec.ult r1.2.2.2.1 v2 := by
+      simp only at hbltu_0 ⊢; rw [← hbltu_0]; decide
+    unfold loopN3SelectedBorrowCarryV5 at hcarry
+    simp only [iterN3V5_true_eq] at hcarry
+    rw [if_pos (by decide), if_neg (by decide)] at hcarry
+    obtain ⟨hc1, hc0⟩ := hcarry
+    exact divK_loop_n3_unified_callmax_borrowCarry sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+      retMem dMem dloMem scratchUn0 scratchMem halign hb1 hc1 hb0 hc0
+  · -- call × call
+    have hb1 : BitVec.ult u3 v2 := hbltu_1.symm
+    have hb0 :
+        BitVec.ult
+          (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 := by
+      simp only at hbltu_0; exact hbltu_0.symm
+    unfold loopN3SelectedBorrowCarryV5 at hcarry
+    simp only [iterN3V5_true_eq] at hcarry
+    rw [if_pos (by decide), if_pos (by decide)] at hcarry
+    obtain ⟨hc1, hc0⟩ := hcarry
+    exact divK_loop_n3_unified_callcall_borrowCarry sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+      retMem dMem dloMem scratchUn0 scratchMem halign hb1 hc1 hb0 hc0
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3V5DigitStepIter.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V5DigitStepIter.lean
@@ -104,6 +104,18 @@ theorem iterN3V5_false_eq (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
       iterWithDoubleAddback (signExtend12 (4095 : BitVec 12)) v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   unfold iterN3V5 iterN3Max; simp only [Bool.false_eq_true, if_false]
 
+/-- `iterN3V5 false …` collapsed to the NAMED `iterN3Max` (stops *before* unfolding
+    the irreducible `iterN3Max`).  Unlike `iterN3V5_false_eq` — which over-unfolds
+    to `iterWithDoubleAddback (signExtend12 4095) …` — this keeps the result in the
+    same named form the loop combos / unified wrappers expect for the max branch,
+    so `simp only [iterN3V5_false_eq_max]` rewrites a bundle window to `iterN3Max`
+    without forcing the explosive defeq through the irreducible def.  Mirror of
+    n2's `loopN2IterSelectedV5_false`. -/
+theorem iterN3V5_false_eq_max (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    iterN3V5 false v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  unfold iterN3V5; simp only [Bool.false_eq_true, if_false]
+
 /-- Per-digit conservation, wrapped onto `iterN3V5 false` (clean, `uTop = 0`). -/
 theorem iterN3V5_max_conservation (v0 v1 v2 u0 u1 u2 u3 : Word)
     (hv2 : v2.toNat ≥ 2^63) (hmax : ¬ BitVec.ult u3 v2) :


### PR DESCRIPTION
## Summary

Resolves the **n=3 v5 borrowCarry dispatch** — the from-shape lane glue that was blocked for several iterations on an isDefEq/whnf explosion (the per-case wrappers built, but feeding the bundle obligations to them timed out at >1.6M heartbeats).

**Root cause.** The bundle's j=0 window is `iterN3V5 bltu_1 …` (`@[irreducible]`). The only rewrite available, `iterN3V5_false_eq`, **over-unfolds** the max branch all the way to `iterWithDoubleAddback (signExtend12 4095) …`, whereas the loop combos / unified wrappers expect the **named** `iterN3Max …`. Matching the over-unfolded saturated form against the irreducible `iterN3Max` forced the explosive defeq.

**Fix** (mirrors the working n2 dispatch, which uses a `loopN2IterSelectedV5` selector that rewrites to the named `iterN2Max`):
- Add `iterN3V5_false_eq_max : iterN3V5 false … = iterN3Max …` — stops *before* unfolding the irreducible `iterN3Max`.
- `divK_loop_n3_unified_from_source_exact_loopIterScratch_v5_noNop_borrowCarry`: dispatch the 4 `bltu²` cases, `simp only [iterN3V5_true_eq, iterN3V5_false_eq_max]` to put each bundle window in the wrappers' named form, extract the two borrow-conditional carries, feed the per-case `_borrowCarry` wrappers (#7536).

Builds first try; **axiom-clean** (`[propext, Classical.choice, Quot.sound]`). Full `DivMod` build green (1670 jobs); `check-unimported` clean.

n3 mirror of `divK_loop_n2_unified_from_source_…_borrowCarry`.

Refs #61. Bead: evm-asm-wbc4i.9.3.3.3.4. Stacked on #7536.

Authored by @pirapira; implemented by Claude Code