### PR TITLE
feat(divmod): n3 v5 shift=0 loop + loopExit bridge + path (base→denormOff)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -300,6 +300,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopLoopDefsBorrowCarry
 import EvmAsm.Evm64.DivMod.Spec.N3V5BundleOfShape
 import EvmAsm.Evm64.DivMod.Spec.N3V5Shift0BundleOfShape
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5LoopShift0
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5PathShift0
 import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallSkipExactX1V5NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMax
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallJ0

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -299,6 +299,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopLoopSelected
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopLoopDefsBorrowCarry
 import EvmAsm.Evm64.DivMod.Spec.N3V5BundleOfShape
 import EvmAsm.Evm64.DivMod.Spec.N3V5Shift0BundleOfShape
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5LoopShift0
 import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallSkipExactX1V5NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMax
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallJ0

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5LoopShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5LoopShift0.lean
@@ -1,0 +1,65 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5LoopShift0
+
+  v5 n=3 shift=0 LOOP body (loopBodyOff → denormOff) over `divCode_noNop_v5`, with
+  the carry hypothesis DISCHARGED FROM SHAPE.  The unified loop
+  (`divK_loop_n3_unified_from_source_exact_loopIterScratch_v5_noNop_borrowCarry`,
+  #7538) is GENERIC in the divisor/window values, so the shift=0 loop is that loop
+  instantiated with the RAW divisor `(b0, b1, b2, 0)` (`b2 ≥ 2^63`) and the shift=0
+  verbatim-dividend window `u0=a1, u1=a2, u2=a3, u3=0, uTop=0, u0Orig=a0` (read off
+  the shift=0 preloop, FullPathN3V5PreloopShift0).  The carry is discharged via
+  `loopN3SelectedBorrowCarryV5_shift0_of_shape` (#7553); the `hbltu_0` match form
+  is bridged to the clean `iterN3V5` form via `iterN3V5_false_eq_max` /
+  `iterN3V5_true_eq`.  n=3 analog of `divK_loop_n2_shift0_param_v5_noNop`.
+  Bead `evm-asm-wbc4i.9.3.3.8`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnifiedBorrowCarry
+import EvmAsm.Evm64.DivMod.Spec.N3V5Shift0BundleOfShape
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- Flag-parameterized shift=0 LOOP body (`loopBodyOff → denormOff`): the unified
+    n=3 loop (#7538) instantiated with the raw divisor + verbatim-dividend window,
+    the carry discharged from shape. -/
+theorem divK_loop_n3_shift0_param_v5_noNop (bltu_1 bltu_0 : Bool)
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (a0 a1 a2 a3 b0 b1 b2 q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hb2ge : b2.toNat ≥ 2 ^ 63)
+    (hbltu_1 : bltu_1 = BitVec.ult (0 : Word) b2)
+    (hbltu_0 : bltu_0 =
+      BitVec.ult (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 b2) :
+    cpsTripleWithin 468 (base + loopBodyOff) (base + denormOff)
+      (divCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        b0 b1 b2 0 a1 a2 a3 0 0 a0 q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN3UnifiedPostV5NoX1 bltu_1 bltu_0 sp base
+        b0 b1 b2 0 a1 a2 a3 0 0 a0
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  apply divK_loop_n3_unified_from_source_exact_loopIterScratch_v5_noNop_borrowCarry
+    bltu_1 bltu_0 sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    b0 b1 b2 0 a1 a2 a3 0 0 a0 q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign
+  case hbltu_1 =>
+    exact hbltu_1
+  case hbltu_0 =>
+    cases bltu_1 <;>
+      simp only [iterN3V5_false_eq_max, iterN3V5_true_eq] at hbltu_0 ⊢ <;> exact hbltu_0
+  case hcarry =>
+    exact loopN3SelectedBorrowCarryV5_shift0_of_shape a0 a1 a2 a3 b0 b1 b2
+      bltu_1 bltu_0 hb2ge
+      (fun h => by rw [← hbltu_1]; exact h)
+      (fun h => by rw [← hbltu_1, h]; decide)
+      (fun h => by rw [← hbltu_0]; exact h)
+      (fun h => by rw [← hbltu_0, h]; decide)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5PathShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5PathShift0.lean
@@ -1,0 +1,149 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5PathShift0
+
+  Bridge from the n=3 v5 shift=0 preloop exit (at `loopBodyOff`, the layout
+  produced by `evm_div_n3_to_loopSetup_shift0_spec_v5_noNop`, #7552) to the loop's
+  entry bundle `loopN3PreWithScratchV4NoX1` over the RAW divisor `(b0, b1, b2, 0)`
+  and shift=0 verbatim window — the shift=0 analog of
+  `loopSetupPost_to_loopN3PreWithScratchV4NoX1_framed`.  Then the shift=0 path
+  `base → denormOff`: preloop (#7552) ∘ bridge ∘ loop (#7554), carry from shape.
+  n=3 analog of `FullPathN2V5PathShift0`.  Bead `evm-asm-wbc4i.9.3.3.8`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5PreloopShift0
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5LoopShift0
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3Loop
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- Bridge: shift=0 preloop exit (`b3 = 0`) plus the framed scratch/return cells
+    implies the loop entry bundle over the raw divisor + verbatim window. -/
+theorem n3_shift0_loopExit_to_loopN3PreWithScratch (sp : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v11Old jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hb3z : b3 = 0) :
+    ∀ h,
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) **
+        (.x9 ↦ᵣ (signExtend12 (4 : BitVec 12) - (3 : Word))) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ (clzResult b2).1) **
+        (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+        (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - (clzResult b2).1)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+        ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
+        ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
+        ((sp + signExtend12 4024) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        ((sp + signExtend12 3968) ↦ₘ retMem) ** ((sp + signExtend12 3960) ↦ₘ dMem) **
+        ((sp + signExtend12 3952) ↦ₘ dloMem) ** ((sp + signExtend12 3944) ↦ₘ scratchUn0) **
+        ((sp + signExtend12 3936) ↦ₘ scratchMem) ** (.x1 ↦ᵣ raVal))) h →
+      ((loopN3PreWithScratchV4NoX1 sp jMem (3 : Word) (clzResult b2).1
+        ((clzResult b2).2 >>> (63 : Nat)) (0 : Word) v11Old
+        (signExtend12 (0 : BitVec 12) - (clzResult b2).1)
+        b0 b1 b2 0 a1 a2 a3 0 0 a0 0 0
+        retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))) h := by
+  intro h hp
+  subst hb3z
+  rw [show signExtend12 (4 : BitVec 12) - (3 : Word) = (1 : Word) from by decide] at hp
+  delta loopN3PreWithScratchV4NoX1 loopN3PreWithScratchNoX1 loopN3Pre
+  simp only [n3_ub1_off0, n3_ub1_off4088, n3_ub1_off4080, n3_ub1_off4072, n3_ub1_off4064,
+    n3_ub0_off0, n3_qa1, n3_qa0,
+    se12_32, se12_40, se12_48, se12_56] at hp ⊢
+  xperm_hyp hp
+
+/-- Flag-parameterized n=3 v5 shift=0 path `base → denormOff`: preloop (#7552) ∘
+    bridge ∘ loop (#7554), the carry discharged from shape. -/
+theorem evm_div_n3_to_denorm_shift0_param_v5_noNop (bltu_1 bltu_0 : Bool)
+    (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v2 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_z : (clzResult b2).1 = 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 = BitVec.ult (0 : Word) b2)
+    (hbltu_0 : bltu_0 =
+      BitVec.ult (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 b2) :
+    cpsTripleWithin (((8 + 21 + 24 + 4) + 13) + 468) base (base + denormOff)
+      (divCode_noNop_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        ((sp + signExtend12 3968) ↦ₘ retMem) ** ((sp + signExtend12 3960) ↦ₘ dMem) **
+        ((sp + signExtend12 3952) ↦ₘ dloMem) ** ((sp + signExtend12 3944) ↦ₘ scratchUn0) **
+        ((sp + signExtend12 3936) ↦ₘ scratchMem) ** (.x1 ↦ᵣ raVal)))
+      ((loopN3UnifiedPostV5NoX1 bltu_1 bltu_0 sp base
+        b0 b1 b2 0 a1 a2 a3 0 0 a0
+        retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))) := by
+  have hb2ge : b2.toNat ≥ 2 ^ 63 := clz_zero_imp_msb hshift_z
+  have hPre := evm_div_n3_to_loopSetup_shift0_spec_v5_noNop sp base a0 a1 a2 a3 b0 b1 b2 b3
+    v2 v5 v6 v7 v10 q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    hbnz hb3z hb2nz hshift_z
+  have hPref := cpsTripleWithin_frameR
+    ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+     ((sp + signExtend12 3968) ↦ₘ retMem) ** ((sp + signExtend12 3960) ↦ₘ dMem) **
+     ((sp + signExtend12 3952) ↦ₘ dloMem) ** ((sp + signExtend12 3944) ↦ₘ scratchUn0) **
+     ((sp + signExtend12 3936) ↦ₘ scratchMem) ** (.x1 ↦ᵣ raVal))
+    (by pcFree) hPre
+  have hLoop := divK_loop_n3_shift0_param_v5_noNop bltu_1 bltu_0 sp base jMem (3 : Word)
+    (clzResult b2).1 ((clzResult b2).2 >>> (63 : Nat)) (0 : Word) v11Old
+    (signExtend12 (0 : BitVec 12) - (clzResult b2).1)
+    a0 a1 a2 a3 b0 b1 b2 (0 : Word) (0 : Word) raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hb2ge hbltu_1 hbltu_0
+  have hLoopf := cpsTripleWithin_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))
+    (by pcFree) hLoop
+  have hPre' := cpsTripleWithin_weaken (fun h hp => hp)
+    (n3_shift0_loopExit_to_loopN3PreWithScratch sp a0 a1 a2 a3 b0 b1 b2 b3 v11Old
+      jMem retMem dMem dloMem scratchUn0 scratchMem raVal hb3z)
+    hPref
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hPre' hLoopf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => hp) (fun h hq => hq) hFull
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

`divK_loop_n3_shift0_param_v5_noNop` — the v5 n=3 shift=0 **loop body** (`loopBodyOff → denormOff`).

The unified loop (#7538, generic in the divisor/window) instantiated with the **raw** divisor `(b0,b1,b2,0)` (`b2 ≥ 2^63`) and the shift=0 verbatim-dividend window `u0=a1, u1=a2, u2=a3, u3=0, uTop=0, u0Orig=a0` (from the shift=0 preloop #7552). Carry discharged from shape via the shift=0 bundle (#7553); the `hbltu_0` match form bridged to the clean `iterN3V5` form via `iterN3V5_false_eq_max` / `iterN3V5_true_eq`.

n=3 analog of `divK_loop_n2_shift0_param_v5_noNop`. **Built first try**, axiom-clean (`[propext, Classical.choice, Quot.sound]`).

Third piece of the n3 shift0 sub-phase (bead 9.3.3.8): preloop #7552 + bundle #7553 + loop (this). Stacked on #7553.

Refs #61. Bead: evm-asm-wbc4i.9.3.3.8.

Authored by @pirapira; implemented by Claude Code