### PR TITLE
feat(divmod): n4 call-path +2 over normalized window under U4=0

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -86,6 +86,7 @@ import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0LaneFirstDigit
 import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0LaneRest
 import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5
 import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Div
+import EvmAsm.Evm64.DivMod.Spec.N4QHatBound
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5CodeModelBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5Phase1bBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5DigitBridge

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -86,6 +86,7 @@ import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0LaneFirstDigit
 import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0LaneRest
 import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5
 import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Div
+import EvmAsm.Evm64.DivMod.Spec.N4WindowDivBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5CodeModelBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5Phase1bBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5DigitBridge

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -88,6 +88,7 @@ import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5
 import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Div
 import EvmAsm.Evm64.DivMod.Spec.N4QHatBound
 import EvmAsm.Evm64.DivMod.Spec.N4WindowDivBridge
+import EvmAsm.Evm64.DivMod.Spec.N4QHatWindowBound
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5CodeModelBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5Phase1bBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5DigitBridge

--- a/EvmAsm/Evm64/DivMod/Spec/N4QHatBound.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4QHatBound.lean
@@ -1,0 +1,38 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4QHatBound
+
+  The n=4 call-path trial-quotient `+2` overestimate in the `n4CallAddbackBeq*`
+  names: `(n4CallAddbackBeqQHatV5 a b).toNat ≤ n4CallAddbackBeqQTrue a b + 2`
+  (`qTrue = val256 a / val256 b`).  Just the generic
+  `divKTrialCallV5QHat_le_val256_div_plus_two_of_call` (#7219) transported through
+  `n4CallAddbackBeqQHatV5 = div128Quot_v5 (…) = divKTrialCallV5QHat (…)` (the
+  normalized window of `n4CallAddbackBeqQHatV5` is, definitionally, exactly the
+  trial window of #7219).
+
+  Feeds the n=4 unconditional-semantic routing (bead `.8.2.2`): with the window
+  bridge `n4CallAddbackBeq_window_div_eq_qTrue_of_u4_zero` (#7572), under `U4 = 0`
+  this `+2` over `qTrue` becomes a `+2` over the normalized window
+  `val256(U0..U3)/BNormVal`, which `mulsubN4_c3_le_two` /
+  `isAddbackCarry2Nz_of_overestimate_…` consume.  Bead `evm-asm-wbc4i.8.2.2`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntimeV5
+import EvmAsm.Evm64.EvmWordArith.DivV5TrialOverestimate
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- The n=4 call-path trial quotient overestimates `qTrue` by at most 2. -/
+theorem n4CallAddbackBeqQHatV5_le_qTrue_plus_two_of_call {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3)) :
+    (n4CallAddbackBeqQHatV5 a b).toNat ≤ n4CallAddbackBeqQTrue a b + 2 := by
+  have h := divKTrialCallV5QHat_le_val256_div_plus_two_of_call
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) hb3nz hshift_nz hcall
+  rw [divKTrialCallV5QHat_eq_div128Quot_v5] at h
+  exact h
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4QHatWindowBound.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4QHatWindowBound.lean
@@ -1,0 +1,39 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4QHatWindowBound
+
+  The n=4 call-path trial quotient `+2` overestimate against the NORMALIZED WINDOW,
+  under `U4 = 0`:
+    `(n4CallAddbackBeqQHatV5 a b).toNat ≤ val256(U0..U3) / BNormVal + 2`.
+  This is exactly the `hq_over` hypothesis (in `+2` form) that the generic
+  double-addback bridges `mulsubN4_c3_le_two` (`c3 ≤ 2`) and
+  `isAddbackCarry2Nz_of_overestimate_c3_one_of_carry_zero` (the `h_carry2` runtime
+  condition `isAddbackCarry2NzN4CallV5Ab`) consume.
+
+  Composes the original-domain `+2` (`n4CallAddbackBeqQHatV5_le_qTrue_plus_two_of_call`,
+  #7573) with the window↔original bridge under `U4 = 0`
+  (`n4CallAddbackBeq_window_div_eq_qTrue_of_u4_zero`, #7572).  Bead
+  `evm-asm-wbc4i.8.2.2`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N4QHatBound
+import EvmAsm.Evm64.DivMod.Spec.N4WindowDivBridge
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- Under `U4 = 0`, the n=4 call trial quotient overestimates the normalized-window
+    quotient by at most 2 — the `+2`-form `hq_over` for the double-addback bridges. -/
+theorem n4CallAddbackBeqQHatV5_le_window_div_plus_two_of_u4_zero {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3))
+    (hu4 : (n4CallAddbackBeqU4 a b).toNat = 0) :
+    (n4CallAddbackBeqQHatV5 a b).toNat ≤
+      EvmWord.val256 (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+        (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b) /
+      n4CallAddbackBeqBNormVal b + 2 := by
+  rw [n4CallAddbackBeq_window_div_eq_qTrue_of_u4_zero hshift_nz hu4]
+  exact n4CallAddbackBeqQHatV5_le_qTrue_plus_two_of_call hb3nz hshift_nz hcall
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4WindowDivBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4WindowDivBridge.lean
@@ -1,0 +1,54 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4WindowDivBridge
+
+  The n=4 window-vs-original quotient bridge under `U4 = 0`: when the normalized
+  five-limb dividend has zero overflow limb (`n4CallAddbackBeqU4 a b = 0`), the
+  normalized-window Euclidean quotient `val256(U0..U3) / val256(B0..B3Prime)`
+  collapses to the original unnormalized quotient `n4CallAddbackBeqQTrue a b`
+  (`= val256 a / val256 b`).
+
+  This is the clean math link the n=4 unconditional-semantic routing (bead
+  `.8.2.2`) needs: the `hq_over` hypothesis of
+  `n4CallAddbackBeqSemanticHoldsV5_of_runtime_conditions` is stated over the
+  normalized WINDOW `val256(U0..U3)/val256(B0..B3Prime)`, while the proven trial
+  bounds (`#7201` top-limb `+1`, `#7219` val256 `+2`) are over the ORIGINAL
+  `val256 a / val256 b = qTrue`.  Under `U4 = 0` (which the dispatcher routing
+  establishes on the call/addback path) the two domains coincide, so this lemma
+  lets those original-domain bounds be transported to the window `hq_over`.
+
+  Follows immediately from the proven `n4CallAddbackBeqNormalized_div_eq_qTrueV5`
+  (`UNormVal / BNormVal = qTrue`) by collapsing the `U4·2^256` overflow term of
+  `UNormVal`.  Bead `evm-asm-wbc4i.8.2.2`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntimeV5
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- Abstract collapse: a five-limb dividend value `W + u4·2^256` with zero overflow
+    limb (`u4 = 0`) has the same Euclidean quotient as its low four limbs `W`.  Kept
+    fully abstract (the window value `W` is an opaque `Nat` variable) so the kernel
+    never evaluates the huge `val256`-of-normalized-limbs term it is instantiated to. -/
+private theorem div_collapse_of_zero_overflow {W u4 BN q : Nat}
+    (h : (W + u4 * 2 ^ 256) / BN = q) (hu4 : u4 = 0) : W / BN = q := by
+  subst hu4; simpa using h
+
+/-- Under `U4 = 0`, the normalized-window quotient equals the original `qTrue`.
+    Phrased with the opaque `n4CallAddbackBeqBNormVal b` denominator (which is by
+    definition `val256 (B0Prime b) .. (B3Prime b)`, the `hq_over` denominator).
+    The abstract `div_collapse_of_zero_overflow` keeps the huge `val256(U0..U3)`
+    window value opaque, sidestepping the kernel deep-recursion the n=4 normalized
+    limb terms otherwise trigger. -/
+theorem n4CallAddbackBeq_window_div_eq_qTrue_of_u4_zero {a b : EvmWord}
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hu4 : (n4CallAddbackBeqU4 a b).toNat = 0) :
+    EvmWord.val256 (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+        (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b) /
+      n4CallAddbackBeqBNormVal b
+      = n4CallAddbackBeqQTrue a b :=
+  div_collapse_of_zero_overflow
+    (n4CallAddbackBeqNormalized_div_eq_qTrueV5 (a := a) (b := b) hshift_nz) hu4
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

`n4CallAddbackBeqQHatV5_le_window_div_plus_two_of_u4_zero`:
```
(n4CallAddbackBeqQHatV5 a b).toNat ≤ val256(U0..U3) / BNormVal + 2     -- under U4=0
```

This is **exactly the +2-form `hq_over`** the generic double-addback bridges consume: `mulsubN4_c3_le_two` (→ `c3 ≤ 2`) and `isAddbackCarry2Nz_of_overestimate_c3_one_of_carry_zero` (→ the `h_carry2` runtime condition `isAddbackCarry2NzN4CallV5Ab`, whose mulsub is exactly `mulsubN4 qHat B0Prime.. U0..U3`).

Composes the original-domain +2 (#7573, `qHat ≤ qTrue + 2`) with the window↔original bridge under `U4=0` (#7572, `val256(U0..U3)/BNormVal = qTrue`).

**Built first try.** Axioms = `[propext, Classical.choice, Quot.sound]`. Integrates #7572 + #7573.

Refs #61. Bead: evm-asm-wbc4i.8.2.2.

Authored by @pirapira; implemented by Claude Code