### PR TITLE
feat(divmod): n4 v5 carry2 predicate = generic isAddbackCarry2Nz at the call trial

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -86,6 +86,7 @@ import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0LaneFirstDigit
 import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0LaneRest
 import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5
 import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Div
+import EvmAsm.Evm64.DivMod.Spec.N4Carry2PredicateBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5CodeModelBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5Phase1bBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5DigitBridge

--- a/EvmAsm/Evm64/DivMod/Spec/N4Carry2PredicateBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4Carry2PredicateBridge.lean
@@ -1,0 +1,36 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4Carry2PredicateBridge
+
+  The n=4 v5 call-addback carry-2 predicate equals the generic double-addback
+  progress predicate at the v5 call trial:
+    `loopBodyN4CallAddbackCarry2NzV5 v u uTop
+       = isAddbackCarry2Nz (divKTrialCallV5QHat uTop u3 v3) v u uTop`.
+
+  Both unfold to the identical `mulsubN4`/`addbackN4` carry structure with the v5
+  call-trial quotient `divKTrialCallV5QHat uTop u3 v3` in the `qHat` slot, so this
+  is definitional (`rfl`).  Kept over plain `Word` variables (not the huge
+  normalized n=4 limb terms) so it stays kernel-cheap; the n=4 `h_carry2` discharge
+  rewrites with it and then applies the generic
+  `isAddbackCarry2Nz_of_overestimate_c3_one_of_carry_zero`
+  (the `+2` from #7574, the divisor `≠ 0`, and the `c3 = 1`-of-carry-zero invariant).
+  Bead `evm-asm-wbc4i.8.2.2`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.CallAddbackV5
+import EvmAsm.Evm64.DivMod.LoopDefs.Iter
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- The v5 call-addback carry-2 predicate is the generic `isAddbackCarry2Nz` at the
+    v5 call trial. -/
+theorem loopBodyN4CallAddbackCarry2NzV5_eq_isAddbackCarry2Nz
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    loopBodyN4CallAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      isAddbackCarry2Nz (divKTrialCallV5QHat uTop u3 v3)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  unfold loopBodyN4CallAddbackCarry2NzV5 isAddbackCarry2Nz
+  rfl
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

`loopBodyN4CallAddbackCarry2NzV5_eq_isAddbackCarry2Nz`:
```
loopBodyN4CallAddbackCarry2NzV5 v u uTop = isAddbackCarry2Nz (divKTrialCallV5QHat uTop u3 v3) v u uTop
```

Both defs unfold to the identical `mulsubN4`/`addbackN4` carry structure with the v5 call trial in the `qHat` slot, so this is **definitional** (`unfold` + `rfl`). Kept over plain `Word` variables (not the huge normalized n4 limb terms) to stay kernel-cheap.

The n4 `h_carry2` discharge rewrites with this to turn `isAddbackCarry2NzN4CallV5Ab` (= `loopBodyN4CallAddbackCarry2NzV5` over the normalized window) into the generic `isAddbackCarry2Nz` form, then applies `isAddbackCarry2Nz_of_overestimate_c3_one_of_carry_zero` (the `+2` from #7574, the divisor `≠ 0`, and the `c3=1`-of-carry-zero invariant).

Built, axioms = `[propext, Quot.sound]`. Depends only on merged code.

Refs #61. Bead: evm-asm-wbc4i.8.2.2.

Authored by @pirapira; implemented by Claude Code