### PR TITLE
feat(divmod): n4 v5 semantic from h_borrow alone under U4=0 (h_carry2 + consolidation)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -86,6 +86,7 @@ import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0LaneFirstDigit
 import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0LaneRest
 import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5
 import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Div
+import EvmAsm.Evm64.DivMod.Spec.N4QHatLeOne
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5CodeModelBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5Phase1bBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5DigitBridge

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -89,6 +89,7 @@ import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Div
 import EvmAsm.Evm64.DivMod.Spec.N4Carry2OfNamed
 import EvmAsm.Evm64.DivMod.Spec.N4QHatLeOne
 import EvmAsm.Evm64.DivMod.Spec.N4Carry2OfBorrow
+import EvmAsm.Evm64.DivMod.Spec.N4SemanticOfBorrow
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5CodeModelBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5Phase1bBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5DigitBridge

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -88,6 +88,7 @@ import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5
 import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Div
 import EvmAsm.Evm64.DivMod.Spec.N4Carry2OfNamed
 import EvmAsm.Evm64.DivMod.Spec.N4QHatLeOne
+import EvmAsm.Evm64.DivMod.Spec.N4Carry2OfBorrow
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5CodeModelBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5Phase1bBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5DigitBridge

--- a/EvmAsm/Evm64/DivMod/Spec/N4Carry2OfBorrow.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4Carry2OfBorrow.lean
@@ -1,0 +1,57 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4Carry2OfBorrow
+
+  The n=4 v5 `h_carry2` runtime condition (`isAddbackCarry2NzN4CallV5Evm`) from the
+  `h_borrow` runtime condition, under `U4 = 0`.
+
+  Chain (all proven): the borrow `isAddbackBorrowN4CallV5Evm` gives `U4 < c3`
+  (`n4CallAddbackBeqBorrow_raw_of_runtimeV5`), hence `c3 ≠ 0`; with the `+1`
+  trial bound under `U4 = 0` (`n4CallAddbackBeqQHatV5_le_window_div_plus_one_of_u4_zero`,
+  #7579), `mulsubN4_c3_ne_zero_imp_one` pins `c3 = 1`; the generic
+  `isAddbackCarry2Nz_of_overestimate_c3_one_of_carry_zero` (with the `+2` weakened
+  from the `+1`) then gives the named `isAddbackCarry2Nz`, and the reverse bridge
+  `isAddbackCarry2NzN4CallV5Evm_of_named` (#7578) packages it as the runtime
+  predicate.
+
+  This collapses the n=4 v5 semantic's `h_carry2` (and `hq_over`, `h_rem_lt`) so that,
+  under `U4 = 0`, the only remaining runtime input is `h_borrow` itself (plus the
+  dispatcher routing that establishes `U4 = 0` / `h_borrow`).  Bead `evm-asm-wbc4i.8.2.2`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N4Carry2OfNamed
+import EvmAsm.Evm64.DivMod.Spec.N4QHatLeOne
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- Under `U4 = 0`, the n=4 v5 `h_carry2` condition follows from `h_borrow`. -/
+theorem n4CallAddbackBeqCarry2_of_borrow_and_u4_zero {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hu4 : (n4CallAddbackBeqU4 a b).toNat = 0)
+    (h_borrow : isAddbackBorrowN4CallV5Evm a b) :
+    isAddbackCarry2NzN4CallV5Evm a b := by
+  apply isAddbackCarry2NzN4CallV5Evm_of_named
+  apply isAddbackCarry2Nz_of_overestimate_c3_one_of_carry_zero
+  · exact n4CallAddbackBeqNormalizedDivisor_ne_zero hb3nz
+  · exact le_trans (n4CallAddbackBeqQHatV5_le_window_div_plus_one_of_u4_zero hb3nz hu4)
+      (by omega)
+  · intro _
+    have hborrow_raw := n4CallAddbackBeqBorrow_raw_of_runtimeV5 h_borrow
+    have hc3_nz :
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b)
+          (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+          (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.2 ≠ 0 := by
+      intro h0
+      rw [h0] at hborrow_raw
+      have : ¬ BitVec.ult (n4CallAddbackBeqU4 a b) (0 : Word) := by
+        rw [BitVec.ult_eq_decide]; simp
+      exact this hborrow_raw
+    exact mulsubN4_c3_ne_zero_imp_one
+      (n4CallAddbackBeqNormalizedDivisor_ne_zero hb3nz)
+      (n4CallAddbackBeqQHatV5_le_window_div_plus_one_of_u4_zero hb3nz hu4)
+      hc3_nz
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4QHatLeOne.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4QHatLeOne.lean
@@ -1,0 +1,50 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4QHatLeOne
+
+  Under `U4 = 0`, the n=4 call trial quotient is at most 1, hence overestimates the
+  normalized-window quotient by at most 1 (the `+1` `hq_over` the n=4 v5 semantic
+  `n4CallAddbackBeqSemanticHoldsV5_of_runtime_conditions` actually takes — tighter
+  than the `+2` of #7574).
+
+  `qHat = div128Quot_v5 U4 U3 B3' = (U4·2^64 + U3) / B3'` exactly (`#7218`,
+  `divKTrialCallV5QHat_eq_floor`); with `U4 = 0` this is `U3 / B3'`, and since
+  `U3 < 2^64 ≤ 2·B3'` (B3' ≥ 2^63 normalized), the floor is ≤ 1.  No div128 phase
+  internals are needed — just the proven floor characterization + arithmetic.
+  Bead `evm-asm-wbc4i.8.2.2`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntimeV5
+import EvmAsm.Evm64.EvmWordArith.DivV5TrialOverestimate
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- Under `U4 = 0`, the n=4 call trial quotient is at most 1. -/
+theorem n4CallAddbackBeqQHatV5_le_one_of_u4_zero {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hu4 : (n4CallAddbackBeqU4 a b).toNat = 0) :
+    (n4CallAddbackBeqQHatV5 a b).toNat ≤ 1 := by
+  have hB3 : (n4CallAddbackBeqB3Prime b).toNat ≥ 2 ^ 63 :=
+    n4CallAddbackBeqB3Prime_ge_pow63 hb3nz
+  have hU3 : (n4CallAddbackBeqU3 a b).toNat < 2 ^ 64 := (n4CallAddbackBeqU3 a b).isLt
+  rw [n4CallAddbackBeqQHatV5_eq_normalized, ← divKTrialCallV5QHat_eq_div128Quot_v5,
+    divKTrialCallV5QHat_eq_floor _ _ _ hB3 (by omega), hu4, Nat.zero_mul, Nat.zero_add]
+  apply Nat.lt_succ_iff.mp
+  rw [Nat.div_lt_iff_lt_mul (by omega : 0 < (n4CallAddbackBeqB3Prime b).toNat)]
+  omega
+
+/-- Under `U4 = 0`, the n=4 call trial quotient overestimates the normalized-window
+    quotient by at most 1 — the `+1` `hq_over` of the n=4 v5 semantic. -/
+theorem n4CallAddbackBeqQHatV5_le_window_div_plus_one_of_u4_zero {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hu4 : (n4CallAddbackBeqU4 a b).toNat = 0) :
+    (n4CallAddbackBeqQHatV5 a b).toNat ≤
+      EvmWord.val256 (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+        (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b) /
+      EvmWord.val256 (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+        (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b) + 1 := by
+  have h := n4CallAddbackBeqQHatV5_le_one_of_u4_zero hb3nz hu4
+  exact Nat.le_trans h (Nat.le_add_left 1 _)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4SemanticOfBorrow.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4SemanticOfBorrow.lean
@@ -1,0 +1,41 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4SemanticOfBorrow
+
+  The n=4 v5 call+addback-BEQ semantic from a SINGLE runtime input, under `U4 = 0`:
+    `n4CallAddbackBeqSemanticHoldsV5 a b`  (i.e. `qOut = qTrue = val256 a / val256 b`)
+  follows from just the borrow condition `isAddbackBorrowN4CallV5Evm a b` (plus the
+  n=4 shape `b3 ≠ 0` / `clz b3 ≠ 0` and `U4 = 0`).
+
+  Consolidates the semantic-discharge chain: the `+1` `hq_over` (#7579, via
+  `qHat ≤ 1` under `U4 = 0`), `h_carry2` from `h_borrow` (#7580), and `h_rem_lt`
+  from the runtime conditions (#7199) all fed into
+  `n4CallAddbackBeqSemanticHoldsV5_of_runtime_conditions`.  All three previously-
+  hypothesised runtime conditions (`hq_over`, `h_carry2`, `h_rem_lt`) are now
+  discharged; the only remaining runtime input on the U4=0 single-addback branch is
+  `h_borrow`, which the n=4 v5 code path establishes by execution.  Bead
+  `evm-asm-wbc4i.8.2.2`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N4Carry2OfBorrow
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- The n=4 v5 semantic from the borrow condition alone, under `U4 = 0`. -/
+theorem n4CallAddbackBeqSemanticHoldsV5_of_borrow_u4_zero {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hu4 : (n4CallAddbackBeqU4 a b).toNat = 0)
+    (h_borrow : isAddbackBorrowN4CallV5Evm a b) :
+    n4CallAddbackBeqSemanticHoldsV5 a b :=
+  n4CallAddbackBeqSemanticHoldsV5_of_runtime_conditions hb3nz hshift_nz
+    (n4CallAddbackBeqQHatV5_le_window_div_plus_one_of_u4_zero hb3nz hu4)
+    h_borrow
+    (n4CallAddbackBeqCarry2_of_borrow_and_u4_zero hb3nz hu4 h_borrow)
+    (n4CallAddbackBeqIterRNormVal_lt_BNormVal_of_runtimeV5
+      (n4CallAddbackBeqNormalizedDivisor_ne_zero hb3nz)
+      (n4CallAddbackBeqQHatV5_le_window_div_plus_one_of_u4_zero hb3nz hu4)
+      h_borrow)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

`n4CallAddbackBeqCarry2_of_borrow_and_u4_zero` — under `U4=0`, the n4 v5 `h_carry2` condition (`isAddbackCarry2NzN4CallV5Evm`) **follows from `h_borrow`**.

Chain (all proven):
- `h_borrow` gives `U4 < c3` (`n4CallAddbackBeqBorrow_raw_of_runtimeV5`), hence `c3 ≠ 0`;
- with the `+1` trial bound under `U4=0` (#7579), `mulsubN4_c3_ne_zero_imp_one` pins `c3 = 1`;
- `isAddbackCarry2Nz_of_overestimate_c3_one_of_carry_zero` (the `+2` weakened from the `+1`) gives the named `isAddbackCarry2Nz`;
- the reverse bridge (#7578) packages it as the runtime predicate.

**This collapses the n4 v5 semantic's `h_carry2`** (joining the already-discharged `hq_over` #7579 and `h_rem_lt`): under `U4=0`, the only remaining runtime input is `h_borrow` itself (plus the dispatcher routing establishing `U4=0` / `h_borrow`).

Built first try, axioms = `[propext, Classical.choice, Quot.sound]`. Integrates #7578 + #7579.

Refs #61. Bead: evm-asm-wbc4i.8.2.2.

Authored by @pirapira; implemented by Claude Code