### PR TITLE
feat(divmod): n4 v5 max+skip j=0 loop body

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -134,6 +134,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN3CallAddbackV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4MaxV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4CallV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4AddbackV4NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN4V5.MaxSkipV5NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModPreloopN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3V4NoNop

--- a/EvmAsm/Evm64/DivMod/LoopIterN4V5/MaxSkipV5NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4V5/MaxSkipV5NoNop.lean
@@ -1,0 +1,112 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopIterN4V5.MaxSkipV5NoNop
+
+  v5 n=4 max+skip loop body (j=0) over `sharedDivModCodeNoNop_v5`.  Direct mirror
+  of the v4 n=4 max+skip body (`LoopIterN4MaxV4NoNop`,
+  `divK_loop_body_n4_max_skip_j0_v4_spec_within_noNop`) with the three loop-body
+  bricks (and the code surface) swapped v4 → v5: `divK_trial_max_full_v5`,
+  `divK_mulsub_correction_skip_v5`, `divK_store_loop_j0_v5`.  The max path skips
+  the div128 trial (`qHat = signExtend12 4095`, a constant), so the n=4 pre/post
+  defs (`loopBodyN4MaxSkipJ0Pre`/`Post`) are version-agnostic and reused as-is;
+  the n=4 addresses (`u_addr_eq_n4`/`vtop_eq_v3_n4`) are unchanged.
+  Branch 3/4 of the n=4 v5 loop.  Bead `evm-asm-wbc4i.8`.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopBody.MulsubSkipV5
+import EvmAsm.Evm64.DivMod.LoopBody.TrialMaxV5
+import EvmAsm.Evm64.DivMod.LoopBody.StoreLoopV5
+import EvmAsm.Evm64.DivMod.LoopIterN4MaxV4NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- No-NOP/v5 loop body cpsTripleWithin for n=4, max+skip, j=0 (ends at denormOff). -/
+theorem divK_loop_body_n4_max_skip_j0_v5_spec_within_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (base : Word)
+    (hbltu : ¬BitVec.ult uTop v3) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (sharedDivModCodeNoNop_v5 base)
+      (loopBodyN4MaxSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old
+        v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN4MaxSkipJ0Post sp v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  rw [loopBodyN4MaxSkipJ0Pre_unfold, loopBodyN4MaxSkipJ0Post_unfold]
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qHat : Word := signExtend12 4095
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
+  let fs0 := p0_lo + (signExtend12 0 : Word)
+  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
+  let pc0 := ba0 + p0_hi
+  let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
+  let un0 := u0 - fs0; let c0 := pc0 + bs0
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
+  let fs1 := p1_lo + c0
+  let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
+  let pc1 := ba1 + p1_hi
+  let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
+  let un1 := u1 - fs1; let c1 := pc1 + bs1
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
+  let fs2 := p2_lo + c1
+  let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
+  let pc2 := ba2 + p2_hi
+  let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
+  let un2 := u2 - fs2; let c2 := pc2 + bs2
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
+  let fs3 := p3_lo + c2
+  let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
+  let pc3 := ba3 + p3_hi
+  let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
+  let un3 := u3 - fs3; let c3 := pc3 + bs3
+  let u4_new := uTop - c3
+  let vtopBase := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  have TF := divK_trial_max_full_v5_spec_within_noNop sp (0 : Word) (4 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old uTop u3 v3 base hbltu
+  dsimp only [] at TF
+  rw [u_addr_eq_n4] at TF
+  rw [u_addr8_eq_n4] at TF
+  rw [vtop_eq_v3_n4] at TF
+  have MCS := divK_mulsub_correction_skip_v5_spec_within_noNop sp qHat (0 : Word)
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    (0 : Word) u3 vtopBase uTop v3 v2Old base
+  intro_lets at MCS
+  have MCS0 := MCS hborrow
+  unfold divKMulsubCorrectionSkipPre at MCS0
+  unfold n4McaNamedSkipPost at MCS0
+  unfold mulsubN4 at MCS0
+  dsimp only [] at MCS0
+  have SL := divK_store_loop_j0_v5_spec_within_noNop sp qHat u4_new (0 : Word) qOld base
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ v2Old) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCS0
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
+     (sp + signExtend12 3984 ↦ₘ (4 : Word)))
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      delta loopBodyN4SkipPost loopBodySkipPost mulsubN4 loopExitPostN4 loopExitPost
+      rw [sepConj_assoc'] at hp; xperm_hyp hp)
+    full
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Adds `divK_loop_body_n4_max_skip_j0_v5_spec_within_noNop` in `EvmAsm/Evm64/DivMod/LoopIterN4V5/MaxSkipV5NoNop.lean` — **branch 3 of 4** of the n=4 v5 loop (bead `evm-asm-wbc4i.8`). The max path skips the div128 trial (`qHat = signExtend12 4095`, a constant); 76 steps over `sharedDivModCodeNoNop_v5`, `loopBodyOff → denormOff`.

Follows #7583 (branch 1, call+skip).

## How

Direct mirror of the v4 n=4 max+skip body (`divK_loop_body_n4_max_skip_j0_v4_spec_within_noNop`, `LoopIterN4MaxV4NoNop`) with the three loop-body bricks (and the code surface) swapped v4 → v5:

- `divK_trial_max_full_v5`
- `divK_mulsub_correction_skip_v5`
- `divK_store_loop_j0_v5`

Because the max quotient guess is a constant (`signExtend12 4095`), the n=4 pre/post defs (`loopBodyN4MaxSkipJ0Pre`/`Post`) carry no version-specific quotient terms and are reused as-is. n=4 window: `uHi=uTop, uLo=u3, vTop=v3`.

## Gates

- `lake build EvmAsm.Evm64.DivMod.LoopIterN4V5.MaxSkipV5NoNop` ✓ (and the `EvmAsm.Evm64.DivMod` aggregator ✓)
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` only (no `native_decide`/`bv_decide`, no sorries)
- `scripts/check-unimported.sh` → 0 orphans
- banned-tactic scan → clean

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)