### PR TITLE
feat(divmod): n4 v5 max+addback-beq j=0 loop body

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -134,6 +134,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN3CallAddbackV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4MaxV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4CallV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4AddbackV4NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN4V5.MaxAddbackBeqV5NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModPreloopN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3V4NoNop

--- a/EvmAsm/Evm64/DivMod/LoopIterN4V5/MaxAddbackBeqV5NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4V5/MaxAddbackBeqV5NoNop.lean
@@ -1,0 +1,99 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopIterN4V5.MaxAddbackBeqV5NoNop
+
+  v5 n=4 max+addback-beq loop body (j=0) over `sharedDivModCodeNoNop_v5`, with the
+  `loopBodyN4MaxSkipJ0Pre` precondition shared with the max-skip body.  Mirror of
+  the v5 n=3 max-addback-beq body (`LoopIterN3V5/MaxAddbackBeqV5NoNop`) with the
+  n=4 trial window (uHi=uTop, uLo=u3, vTop=v3), the n=4 addresses
+  (`u_addr_eq_n4`/`vtop_eq_v3_n4`), and the n=4 pre/post defs
+  (`loopBodyN4MaxSkipJ0Pre`/`loopBodyN4AddbackBeqPost`).  The max path skips the
+  div128 trial (`qHat = signExtend12 4095`, a constant), then does the single/double
+  addback correction (BEQ variant, handling both carry=0 and carry≠0 internally).
+  Branch 4/4 of the n=4 v5 loop.  Bead `evm-asm-wbc4i.8`.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionAddbackV5NoNop
+import EvmAsm.Evm64.DivMod.LoopBody.TrialMaxV5
+import EvmAsm.Evm64.DivMod.LoopBody.StoreLoopV5
+import EvmAsm.Evm64.DivMod.LoopIterN4MaxV4NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v5 n=4 max+addback-beq j=0 loop body (loopBodyOff → denormOff). -/
+theorem divK_loop_body_n4_max_addback_j0_beq_v5_spec_within_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (base : Word)
+    (hbltu : ¬BitVec.ult uTop v3)
+    (hcarry2_nz : isAddbackCarry2NzN4Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (sharedDivModCodeNoNop_v5 base)
+      (loopBodyN4MaxSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old
+        v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN4AddbackBeqPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qHat : Word := signExtend12 4095
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
+  let carryOut := if carry = 0 then
+      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
+    else carry
+  let vtopBase := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  have TF := divK_trial_max_full_v5_spec_within_noNop sp (0 : Word) (4 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old uTop u3 v3 base hbltu
+  dsimp only [] at TF
+  rw [u_addr_eq_n4] at TF
+  rw [u_addr8_eq_n4] at TF
+  rw [vtop_eq_v3_n4] at TF
+  have MCA := divK_mulsub_correction_addback_beq_v5_spec_within_noNop sp qHat (0 : Word)
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    (0 : Word) u3 vtopBase uTop v3 v2Old base
+  unfold isAddbackCarry2NzN4Max isAddbackCarry2Nz at hcarry2_nz
+  have MCA0 := MCA hcarry2_nz hborrow
+  have SL := divK_store_loop_j0_v5_spec_within_noNop sp q_out u4_out carryOut qOld base
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ v2Old) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCA0
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
+     (sp + signExtend12 3984 ↦ₘ (4 : Word)))
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by rw [loopBodyN4MaxSkipJ0Pre_unfold] at hp; xperm_hyp hp)
+    (fun h hp => by
+      delta loopBodyN4AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN4 loopExitPost
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    full
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Adds `divK_loop_body_n4_max_addback_j0_beq_v5_spec_within_noNop` in `EvmAsm/Evm64/DivMod/LoopIterN4V5/MaxAddbackBeqV5NoNop.lean` — **branch 4 of 4** of the n=4 v5 loop (bead `evm-asm-wbc4i.8`). The max path skips the div128 trial (`qHat = signExtend12 4095`), then runs the single/double addback correction (BEQ variant — handles both `carry=0` and `carry≠0` internally). 152 steps over `sharedDivModCodeNoNop_v5`, `loopBodyOff → denormOff`.

Follows #7583 (call+skip) and #7585 (max+skip). **This completes 3 of the 4 n=4 v5 loop-body branches** (call+addback-beq, the double-addback branch, remains).

## How

Mirror of the v5 n=3 max-addback-beq body (`divK_loop_body_n3_max_addback_j0_beq_v5_spec_within_noNop`, `LoopIterN3V5/MaxAddbackBeqV5NoNop`) with the n=4 substitutions:

- trial window `uHi=uTop, uLo=u3, vTop=v3` (vs n=3's `u3 u2 v2`);
- n=4 addresses `u_addr_eq_n4`/`u_addr8_eq_n4`/`vtop_eq_v3_n4`;
- n=4 pre/post defs `loopBodyN4MaxSkipJ0Pre` / `loopBodyN4AddbackBeqPost` (the max pre is shared with the max-skip body);
- hypothesis `isAddbackCarry2NzN4Max`;
- bricks `divK_trial_max_full_v5` + `divK_mulsub_correction_addback_beq_v5` + `divK_store_loop_j0_v5`.

The addback let-chain (`ms`/`carry`/`ab`/`ab'`/`q_out`/`un*Out`/`u4_out`/`carryOut`) is shape-independent (operates on all 4 limbs), so it is identical to the n=3 body.

## Gates

- `lake build EvmAsm.Evm64.DivMod.LoopIterN4V5.MaxAddbackBeqV5NoNop` ✓ (and the `EvmAsm.Evm64.DivMod` aggregator ✓)
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` only (no `native_decide`/`bv_decide`, no sorries)
- `scripts/check-unimported.sh` → 0 orphans
- banned-tactic scan → clean

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)