### PR TITLE
feat(divmod): n4 v5 call+addback-beq j=0 loop body (final loop-body branch)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -134,6 +134,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN3CallAddbackV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4MaxV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4CallV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4AddbackV4NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN4V5.CallAddbackBeqV5NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModPreloopN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3V4NoNop

--- a/EvmAsm/Evm64/DivMod/LoopIterN4V5/CallAddbackBeqV5NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4V5/CallAddbackBeqV5NoNop.lean
@@ -1,0 +1,148 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopIterN4V5.CallAddbackBeqV5NoNop
+
+  v5 n=4 call+addback-beq j=0 loop body over `sharedDivModCodeNoNop_v5`, with the
+  `loopBodyN4CallSkipJ0PreV4` precondition shared with the call-skip body.  Mirror
+  of the v5 n=3 call-addback-beq body
+  (`divK_loop_body_n3_call_addback_j0_beq_v5_spec_within_noNop`,
+  LoopIterN3V5/CallAddbackBeqV5NoNop) with the n=4 trial window
+  (uHi=uTop, uLo=u3, vTop=v3), the n=4 addresses (`u_addr_eq_n4`/`vtop_eq_v3_n4`),
+  and the n=4 pre/post defs.  This is the call path (div128 trial via the v5
+  NAMED trial-call-full, qHat = `divKTrialCallV5QHat uTop u3 v3`) followed by the
+  single/double addback correction (BEQ variant).  Branch 2/4 of the n=4 v5 loop
+  — the last loop-body branch.  Bead `evm-asm-wbc4i.8`.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionAddbackV5NoNop
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCallFullV5Named
+import EvmAsm.Evm64.DivMod.LoopBody.StoreLoopV5
+import EvmAsm.Evm64.DivMod.LoopIterN4CallV4NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN4AddbackV4NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v5 n=4 call+addback-beq j=0 loop-body post (mirror of
+    `loopBodyN3CallAddbackBeqJ0PostV5` with the n=4 trial window). -/
+@[irreducible]
+def loopBodyN4CallAddbackBeqJ0PostV5
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV5DLo v3
+  let div_un0 := divKTrialCallV5Un0 u3
+  let qHat := divKTrialCallV5QHat uTop u3 v3
+  let scratchOut := divKTrialCallV5ScratchOut uTop u3 v3 scratchMem
+  loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v3) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut) **
+  regOwn .x1
+
+/-- v5 n=4 call+addback-beq j=0 loop body (loopBodyOff → denormOff), with the
+    call-skip-j0 precondition. -/
+theorem divK_loop_body_n4_call_addback_j0_beq_v5_spec_within_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult uTop v3)
+    (hborrow : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV5QHat uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word))
+    (hcarry2_nz :
+      let qHat := divKTrialCallV5QHat uTop u3 v3
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + denormOff) (sharedDivModCodeNoNop_v5 base)
+      (loopBodyN4CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN4CallAddbackBeqJ0PostV5 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  unfold loopBodyN4CallSkipJ0PreV4
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let dHi := divKTrialCallV5DHi v3
+  let dLo := divKTrialCallV5DLo v3
+  let divUn0 := divKTrialCallV5Un0 u3
+  let q1'' := divKTrialCallV5Q1dd uTop u3 v3
+  let q0'' := divKTrialCallV5Q0dd uTop u3 v3
+  let x7Exit := divKTrialCallV5X7Exit uTop u3 v3
+  let x9Exit := divKTrialCallV5X9Exit uTop u3 v3
+  let qHat := divKTrialCallV5QHat uTop u3 v3
+  let scratchOut := divKTrialCallV5ScratchOut uTop u3 v3 scratchMem
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
+  let carryOut := if carry = 0 then
+      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
+    else carry
+  have TF := divK_trial_call_full_v5_named_spec_within_noNop sp (0 : Word) (4 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    uTop u3 v3 retMem dMem dloMem scratchUn0 scratchMem base
+    halign hbltu
+  unfold divKTrialCallFullPostV5Named at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n4] at TF
+  rw [u_addr8_eq_n4] at TF
+  rw [vtop_eq_v3_n4] at TF
+  have MCA := divK_mulsub_correction_addback_beq_v5_spec_within_noNop sp qHat (0 : Word)
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x9Exit q0'' dHi x7Exit q1'' (base + div128CallRetOff) base
+  intro_lets at MCA
+  have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR ((sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) MCA0
+  have SL := divK_store_loop_j0_v5_spec_within_noNop sp q_out u4_out carryOut qOld base
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCA0f
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
+     (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v3) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ divUn0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      rw [loopBodyN4CallSkipJ0Pre_unfold] at hp
+      xperm_hyp hp)
+    (fun h hp => by
+      unfold loopBodyN4CallAddbackBeqJ0PostV5
+      delta loopBodyN4AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN4 loopExitPost
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    full
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Adds `divK_loop_body_n4_call_addback_j0_beq_v5_spec_within_noNop` in `EvmAsm/Evm64/DivMod/LoopIterN4V5/CallAddbackBeqV5NoNop.lean` — **branch 2 of 4** of the n=4 v5 loop, the **last loop-body branch**. Call path (div128 trial via the v5 NAMED trial-call-full, `qHat = divKTrialCallV5QHat uTop u3 v3`) followed by the single/double addback correction (BEQ variant). 234 steps over `sharedDivModCodeNoNop_v5`, `loopBodyOff → denormOff`.

With this, **all four n=4 v5 loop-body branches are proven**: call+skip (#7583), max+skip (#7585), max+addback-beq (#7586), and call+addback-beq (this PR).

## How

Mirror of the v5 n=3 call-addback-beq body (`divK_loop_body_n3_call_addback_j0_beq_v5_spec_within_noNop`, `LoopIterN3V5/CallAddbackBeqV5NoNop`) with the n=4 substitutions:

- trial window `uHi=uTop, uLo=u3, vTop=v3`;
- n=4 addresses `u_addr_eq_n4`/`u_addr8_eq_n4`/`vtop_eq_v3_n4`;
- pre `loopBodyN4CallSkipJ0PreV4` (shared with the call-skip body), new post `loopBodyN4CallAddbackBeqJ0PostV5`;
- bricks `divK_trial_call_full_v5_named` + `divK_mulsub_correction_addback_beq_v5` + `divK_store_loop_j0_v5`.

Effectively combines branch 1's trial setup (the `divKTrialCallV5*` lets + named trial) with branch 4's addback let-chain (`ms`/`carry`/`ab`/`ab'`/`q_out`/`un*Out`).

## Gates

- `lake build EvmAsm.Evm64.DivMod.LoopIterN4V5.CallAddbackBeqV5NoNop` ✓ (and the `EvmAsm.Evm64.DivMod` aggregator ✓)
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` only (no `native_decide`/`bv_decide`, no sorries)
- `scripts/check-unimported.sh` → 0 orphans
- banned-tactic scan → clean

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)