### PR TITLE
feat(divmod): n4 v5 max+skip loop-body norm wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -135,6 +135,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN4MaxV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4CallV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4AddbackV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4V5.MaxSkipV5NoNop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopMax
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModPreloopN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3V4NoNop

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopMax.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopMax.lean
@@ -1,0 +1,59 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopMax
+
+  v5/no-NOP norm-pre wrapper for the n=4 DIV max+skip loop body (j=0).  Direct
+  mirror of the v4 n=4 max-skip norm wrapper
+  (`divK_loop_body_n4_max_skip_j0_norm_v4_noNop`, FullPathN4V4NoNop), lifting the
+  raw v5 max-skip body (over `sharedDivModCodeNoNop_v5`) to `divCode_noNop_v5` via
+  `sharedDivModCodeNoNop_v5_sub_divCode_noNop_v5` and exposing the sp-relative
+  addresses (the concrete-address pre the preloop composition consumes).
+  Bead `evm-asm-wbc4i.8`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V4NoNop
+import EvmAsm.Evm64.DivMod.Compose.V5NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN4V5.MaxSkipV5NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- Loop body n=4, max+skip, j=0 over `divCode_noNop_v5`, with sp-relative
+    addresses in the precondition (the form the preloop composition consumes). -/
+theorem divK_loop_body_n4_max_skip_j0_norm_v5_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult uTop v3) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) = (0 : Word) →
+    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+       ((sp + 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ u0) **
+       ((sp + 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ u2) **
+       ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + signExtend12 4024) ↦ₘ uTop) **
+       ((sp + signExtend12 4088) ↦ₘ qOld))
+      (loopBodyN4SkipPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n4_max_skip_j0_v5_spec_within_noNop
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v5_sub_divCode_noNop_v5) raw
+  rw [loopBodyN4MaxSkipJ0Pre_unfold] at raw'
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw'
+  rw [loopBodyN4MaxSkipJ0Post_unfold] at raw'
+  exact raw'
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Adds `divK_loop_body_n4_max_skip_j0_norm_v5_noNop` in `EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopMax.lean` — lifts the raw v5 max+skip loop body (#7585, over `sharedDivModCodeNoNop_v5`) to `divCode_noNop_v5` and exposes the sp-relative addresses (the concrete-address precondition the preloop composition consumes).

This is the first step of wiring the four n=4 v5 loop bodies into the n=4 lane (preloop → loop body → denorm → epilogue).

## How

Direct mirror of the v4 n=4 max-skip norm wrapper (`divK_loop_body_n4_max_skip_j0_norm_v4_noNop`, `FullPathN4V4NoNop`) with the v4 → v5 code-surface swap:

- lift via `cpsTripleWithin_extend_code (hmono := sharedDivModCodeNoNop_v5_sub_divCode_noNop_v5)`;
- normalize the pre with `loopBodyN4MaxSkipJ0Pre_unfold` + the `se12_*` / `u_base_off*_j0` / `q_addr_j0` simp lemmas;
- rewrite the post to `loopBodyN4SkipPost` via `loopBodyN4MaxSkipJ0Post_unfold`.

## Stacking

Based on `feat/v5-n4-loop-max-skip` (PR #7585, the raw max+skip body). Merge that first.

## Gates

- `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopMax` ✓ (and the `EvmAsm.Evm64.DivMod` aggregator ✓)
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` only (no `native_decide`/`bv_decide`, no sorries)
- `scripts/check-unimported.sh` → 0 orphans
- banned-tactic scan → clean

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)