### PR TITLE
feat(divmod): n4 v5 call+skip loop-body norm wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -267,6 +267,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackBeqV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackBeqExactX1V5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4V5.CallSkipV5NoNop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopCall
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMax
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCall
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxAddbackNorm

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopCall.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopCall.lean
@@ -1,0 +1,58 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopCall
+
+  v5/no-NOP norm-pre wrapper for the n=4 DIV call+skip loop body (j=0).  Mirror
+  of the v4 n=4 call-skip norm wrapper (`divK_loop_body_n4_call_skip_j0_norm_noNop`,
+  FullPathN4NoNop), lifting the raw v5 call+skip body (#7583, over
+  `sharedDivModCodeNoNop_v5`) to `divCode_noNop_v5` via
+  `sharedDivModCodeNoNop_v5_sub_divCode_noNop_v5` and exposing the sp-relative
+  addresses behind `loopBodyN4CallJ0NormPre` (plus the extra `sp+3936` div128
+  scratch cell the v5 loop owns).  Keeps the v5 post `loopBodyN4CallSkipJ0PostV5`
+  (identity post map).  Bead `evm-asm-wbc4i.8`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4NoNop
+import EvmAsm.Evm64.DivMod.Compose.V5NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN4V5.CallSkipV5NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- Loop body n=4, call+skip, j=0 over `divCode_noNop_v5`, with sp-relative
+    addresses behind `loopBodyN4CallJ0NormPre` + the v5 `sp+3936` scratch cell. -/
+theorem divK_loop_body_n4_call_skip_j0_norm_v5_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult uTop v3)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV5QHat uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 158 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v5 base)
+      (loopBodyN4CallJ0NormPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 **
+       (sp + signExtend12 3936 ↦ₘ scratchMem))
+      (loopBodyN4CallSkipJ0PostV5 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  have raw := divK_loop_body_n4_call_skip_j0_v5_spec_within_noNop
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+    retMem dMem dloMem scratchUn0 scratchMem base
+    halign hbltu hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v5_sub_divCode_noNop_v5) raw
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      rw [loopBodyN4CallJ0NormPre_unfold] at hp
+      rw [loopBodyN4CallSkipJ0PreV4_unfold]
+      rw [loopBodyN4CallSkipJ0Pre_unfold]
+      simp only [se12_32, se12_40, se12_48, se12_56,
+                 u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+                 u_base_off4072_j0, u_base_off4064_j0, q_addr_j0]
+      xperm_hyp hp)
+    (fun _ hp => hp)
+    raw'
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Adds `divK_loop_body_n4_call_skip_j0_norm_v5_noNop` in `EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopCall.lean` — lifts the raw v5 call+skip loop body (#7583, over `sharedDivModCodeNoNop_v5`) to `divCode_noNop_v5` and exposes the sp-relative addresses behind `loopBodyN4CallJ0NormPre` plus the extra `sp+3936` div128 scratch cell the v5 loop owns. Keeps the v5 post `loopBodyN4CallSkipJ0PostV5` (identity post map).

Second of the four n=4 v5 loop-body norm wrappers (after max-skip #7588); this is the **call path** — the branch the n=4 lane actually takes (b3≠0 + U4=0 ⟹ uTop=0 < v3 ⟹ BLTU trial taken).

## How

Mirror of the v4 n=4 call-skip norm wrapper (`divK_loop_body_n4_call_skip_j0_norm_noNop`, `FullPathN4NoNop`) with the v4 → v5 code-surface swap, plus the `+3936` scratch-cell handling: the pre is `loopBodyN4CallJ0NormPre ... ** (sp+3936 ↦ scratchMem)`, normalized from the raw body's `loopBodyN4CallSkipJ0PreV4` via the unfold lemmas + `se12_*`/`u_base_off*_j0`/`q_addr_j0` simp + `xperm_hyp`.

## Stacking

Based on `feat/v5-n4-loop-call-skip` (PR #7583, the raw call+skip body). Merge that first.

## Gates

- `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopCall` ✓ (and the `EvmAsm.Evm64.DivMod` aggregator ✓)
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` only (no `native_decide`/`bv_decide`, no sorries)
- `scripts/check-unimported.sh` → 0 orphans
- banned-tactic scan → clean

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)