### PR TITLE
feat(divmod): n4 v5 preloop + call+skip composition (base → denormOff)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -327,6 +327,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopSelected
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallSkip
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFull

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopPreloopCallSkip.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopPreloopCallSkip.lean
@@ -1,0 +1,149 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallSkip
+
+  n=4 v5 preloop + call+skip loop body composition: base → denormOff over
+  `divCode_noNop_v5` (shift ≠ 0, call+skip path).  Mirror of the v4
+  `evm_div_n4_preloop_call_skip_spec_noNop` (FullPathN4NoNop), composing the v5
+  preloop (#7582, `evm_div_n4_to_loopSetup_spec_within_v5_noNop`, base→loopBodyOff)
+  with the v5 call-skip norm wrapper (#7589,
+  `divK_loop_body_n4_call_skip_j0_norm_v5_noNop`, loopBodyOff→denormOff) via
+  `cpsTripleWithin_seq_perm_same_cr`.  The v5 loop additionally owns the
+  `sp+3936` div128 scratch cell (threaded as `scratchMem`).  Bead
+  `evm-asm-wbc4i.8`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopCall
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v5 skip-addback borrow condition at n=4 (call path): the v5 trial quotient
+    `divKTrialCallV5QHat` produces no addback borrow. -/
+def isSkipBorrowN4CallV5 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
+  let shift := (clzResult b3).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  mulsubN4NoBorrow (divKTrialCallV5QHat u4 u3 b3') b0' b1' b2' b3' u0 u1 u2 u3 u4
+
+/-- v5 preloop + call-skip post bundle (the v5 loop body post
+    `loopBodyN4CallSkipJ0PostV5` plus the cells framed past the loop body). -/
+def preloopCallSkipPostN4V5 (sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem : Word) : Assertion :=
+  let shift := (clzResult b3).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  loopBodyN4CallSkipJ0PostV5 sp base b0' b1' b2' b3' u0 u1 u2 u3 u4 scratchMem **
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 3992) ↦ₘ shift)
+
+/-- n=4 pre-loop + call+skip loop body over `divCode_noNop_v5`: base → denormOff
+    (shift ≠ 0). -/
+theorem evm_div_n4_preloop_call_skip_spec_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : isCallTrialN4 a3 b2 b3)
+    (hborrow : isSkipBorrowN4CallV5 a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 158) base (base + denormOff) (divCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1)
+      (preloopCallSkipPostN4V5 sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) := by
+  unfold isCallTrialN4 at hbltu
+  unfold isSkipBorrowN4CallV5 at hborrow
+  let shift := (clzResult b3).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  have hPre := evm_div_n4_to_loopSetup_spec_within_v5_noNop sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    hbnz hb3nz hshift_nz
+  have hPreF := cpsTripleWithin_frameR
+    ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+     (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+     (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1)
+    (by pcFree) hPre
+  have hLoop := divK_loop_body_n4_call_skip_j0_norm_v5_noNop sp base
+    jMem (4 : Word) shift u0 (a0 >>> (antiShift.toNat % 64)) v11Old antiShift
+    b0' b1' b2' b3' u0 u1 u2 u3 u4 (0 : Word)
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow
+  have hLoopF := cpsTripleWithin_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hLoop
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      delta loopSetupPost at hp
+      simp only [x1_val_n4] at hp
+      rw [loopBodyN4CallJ0NormPre_unfold]
+      xperm_hyp hp) hPreF hLoopF
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta preloopCallSkipPostN4V5; xperm_hyp hq)
+    hFull
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Adds `evm_div_n4_preloop_call_skip_spec_v5_noNop` in `EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopPreloopCallSkip.lean` — composes the **v5 preloop** (#7582, `base → loopBodyOff`) with the **v5 call-skip norm wrapper** (#7589, `loopBodyOff → denormOff`) into a single `base → denormOff` triple over `divCode_noNop_v5`, for the shift≠0 call-skip path.

This is the **first preloop+body composition** of the n=4 v5 lane — and the call path is the one the lane takes (b3≠0 + U4=0 ⟹ uTop=0 < v3 ⟹ BLTU trial taken).

Also adds two supporting defs:
- `isSkipBorrowN4CallV5` — the v5 shape-level skip-borrow condition (v4's `isSkipBorrowN4Call` uses `div128Quot`; this uses the v5 trial quotient `divKTrialCallV5QHat`);
- `preloopCallSkipPostN4V5` — the composed post bundle (the v5 loop body post + the cells framed past the loop body).

## How

Mirror of the v4 `evm_div_n4_preloop_call_skip_spec_noNop` (`FullPathN4NoNop`), with the v5 preloop/loop-body and the extra `sp+3936` div128 scratch cell threaded through: framed past the preloop, owned by the loop body. Composed via `cpsTripleWithin_seq_perm_same_cr` (unfold `loopSetupPost` + `x1_val_n4` simp + `loopBodyN4CallJ0NormPre_unfold` + `xperm_hyp`).

## Stacking

This composition depends on **two** independent stacks:
- `feat/v5-n4-norm-call-skip` (#7589 → #7583), the PR base, and
- `feat/v5-n4-preloop-phaseb` (#7582), merged into this branch.

The preloop file (`FullPathN4V5NoNopPreloop.lean`) appears in this diff because of that merge; it is #7582's content and the duplicate resolves once both #7589 and #7582 land on main.

## Gates

- `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallSkip` ✓ (and the `EvmAsm.Evm64.DivMod` aggregator ✓)
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` only (no `native_decide`/`bv_decide`, no sorries)
- `scripts/check-unimported.sh` → 0 orphans
- banned-tactic scan → clean

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)