### PR TITLE
feat(divmod): n4 v5 call+skip denorm/epilogue (denormOff → nopOff)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -328,6 +328,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallSkip
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDenormCallSkip
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFull

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopDenormCallSkip.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopDenormCallSkip.lean
@@ -1,0 +1,119 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDenormCallSkip
+
+  n=4 v5 call+skip denorm/epilogue + full path: denormOff → nopOff and the full
+  base → nopOff call+skip path over `divCode_noNop_v5`.  Mirror of the v4
+  `evm_div_n4_call_skip_denorm_epilogue_spec_noNop` / `evm_div_n4_full_call_skip_spec`
+  (FullPathN4) with the shared v5 denorm/epilogue
+  (`evm_div_preamble_denorm_epilogue_spec_v5_noNop`, DenormEpilogueV5) and the v5
+  trial quotient `divKTrialCallV5QHat`, plus the extra `sp+3936` div128 scratch
+  cell.  Bead `evm-asm-wbc4i.8`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallSkip
+import EvmAsm.Evm64.DivMod.Compose.DenormEpilogueV5
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- Final post for the n=4 v5 call+skip full path: the denormalized DIV output
+    plus the residual scratch cells (mirror of `fullDivN4CallSkipPost` with the v5
+    trial quotient and the extra `sp+3936` div128 scratch cell). -/
+def fullDivN4CallSkipPostV5 (sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem : Word) : Assertion :=
+  let shift := (clzResult b3).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  let qHat := divKTrialCallV5QHat u4 u3 b3'
+  let dLo := divKTrialCallV5DLo b3'
+  let div_un0 := divKTrialCallV5Un0 u3
+  let scratchOut := divKTrialCallV5ScratchOut u4 u3 b3' scratchMem
+  let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
+  denormDivPost sp shift ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 qHat 0 0 0 **
+  ((sp + signExtend12 3992) ↦ₘ shift) **
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4024) ↦ₘ u4 - ms.2.2.2.2) **
+  ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+  (.x9 ↦ᵣ (0 : Word) + signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ b3') **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1
+
+/-- n=4 v5 call+skip denorm/epilogue: denormOff → nopOff over `divCode_noNop_v5`. -/
+theorem evm_div_n4_call_skip_denorm_epilogue_spec_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 scratchMem : Word)
+    (hshift_nz : (clzResult b3).1 ≠ 0) :
+    cpsTripleWithin (2 + 23 + 10) (base + denormOff) (base + nopOff) (divCode_noNop_v5 base)
+      (preloopCallSkipPostN4V5 sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)
+      (fullDivN4CallSkipPostV5 sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) := by
+  let shift := (clzResult b3).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  let qHat := divKTrialCallV5QHat u4 u3 b3'
+  let dLo := divKTrialCallV5DLo b3'
+  let div_un0 := divKTrialCallV5Un0 u3
+  let scratchOut := divKTrialCallV5ScratchOut u4 u3 b3' scratchMem
+  let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
+  have hB := evm_div_preamble_denorm_epilogue_spec_v5_noNop sp base
+    ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 shift
+    ms.2.2.2.1 ((0 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088) ms.2.2.2.2
+    qHat 0 0 0
+    b0' b1' b2' b3'
+    hshift_nz
+  have hBF := cpsTripleWithin_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ u4 - ms.2.2.2.2) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     (.x9 ↦ᵣ (0 : Word) + signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ b3') **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ div_un0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) hB
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      simp only [preloopCallSkipPostN4V5, loopBodyN4CallSkipJ0PostV5,
+        loopBodyN4SkipPost, loopBodySkipPost, loopExitPost,
+        se12_32, se12_40, se12_48, se12_56,
+        u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+        u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at hp
+      xperm_hyp hp)
+    (fun h hq => by
+      delta fullDivN4CallSkipPostV5
+      rw [sepConj_assoc'] at hq
+      xperm_hyp hq)
+    hBF
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Adds `evm_div_n4_call_skip_denorm_epilogue_spec_v5_noNop` in `EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopDenormCallSkip.lean` — applies the shared v5 denorm/epilogue (`evm_div_preamble_denorm_epilogue_spec_v5_noNop`, `DenormEpilogueV5`) to the call-skip loop-exit state, taking `preloopCallSkipPostN4V5` (the #7593 post) to the final denormalized DIV output `fullDivN4CallSkipPostV5`. 35 steps, `denormOff → nopOff` over `divCode_noNop_v5`.

Composing this with #7593 gives the **full `base → nopOff` call-skip path** — the n4 lane is now one denorm-bridge + one dispatch away.

## How

Mirror of the v4 `evm_div_n4_call_skip_denorm_epilogue_spec_noNop` (`FullPathN4`) with the v5 denorm code, the v5 trial quotient `divKTrialCallV5QHat`, and the extra `sp+3936` div128 scratch cell. The pre bridge unfolds the loop-exit post (`loopBodyN4CallSkipJ0PostV5 → loopBodyN4SkipPost → loopExitPost`) and normalizes the j=0 addresses (`u_base_off*_j0`/`q_addr_j0`/`se12_*`) to the denorm pre's sp-relative form; the raw j=0 register forms (`(0:Word)<<<3`, `(0:Word) + signExtend12 4095`) are threaded through verbatim since normalizing them would conflict with the `u_base_off*` rewrites.

## Stacking

Based on `feat/v5-n4-preloop-callskip-compose` (PR #7593). Merge that first.

## Gates

- `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDenormCallSkip` ✓ (and the `EvmAsm.Evm64.DivMod` aggregator ✓)
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` only (no `native_decide`/`bv_decide`, no sorries)
- `scripts/check-unimported.sh` → 0 orphans
- banned-tactic scan → clean

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)