### PR TITLE
feat(divmod): n4 v5 full call+skip DIV path (base → nopOff)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -329,6 +329,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallSkip
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDenormCallSkip
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopFullCallSkip
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFull

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopFullCallSkip.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopFullCallSkip.lean
@@ -1,0 +1,63 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopFullCallSkip
+
+  Full n=4 v5 call+skip DIV path: base → nopOff over `divCode_noNop_v5`
+  (shift ≠ 0, call+skip).  Composes the preloop+body (#7593,
+  `evm_div_n4_preloop_call_skip_spec_v5_noNop`, base→denormOff) with the
+  denorm/epilogue (#7595, `evm_div_n4_call_skip_denorm_epilogue_spec_v5_noNop`,
+  denormOff→nopOff) via `cpsTripleWithin_seq_perm_same_cr`.  Mirror of the v4
+  `evm_div_n4_full_call_skip_spec_noNop` (FullPathN4NoNop).  Bead `evm-asm-wbc4i.8`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDenormCallSkip
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Full n=4 v5 DIV call+skip path: base → nopOff (shift ≠ 0). -/
+theorem evm_div_n4_full_call_skip_spec_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : isCallTrialN4 a3 b2 b3)
+    (hborrow : isSkipBorrowN4CallV5 a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 158 + (2 + 23 + 10))
+      base (base + nopOff) (divCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1)
+      (fullDivN4CallSkipPostV5 sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) := by
+  have hA := evm_div_n4_preloop_call_skip_spec_v5_noNop sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratchUn0 scratchMem
+    hbnz hb3nz hshift_nz halign hbltu hborrow
+  have hB := evm_div_n4_call_skip_denorm_epilogue_spec_v5_noNop sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 scratchMem hshift_nz
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hA hB
+  exact cpsTripleWithin_mono_nSteps (by decide) hFull
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Adds `evm_div_n4_full_call_skip_spec_v5_noNop` in `EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopFullCallSkip.lean` — the **complete n=4 v5 call+skip DIV path** over `divCode_noNop_v5`, `base → nopOff` (shift ≠ 0). Composes the preloop+body (#7593, `base → denormOff`) with the denorm/epilogue (#7595, `denormOff → nopOff`) via `cpsTripleWithin_seq_perm_same_cr` + `mono_nSteps`.

Pre = the base dispatch state (N4ShapeIs call path); post = `fullDivN4CallSkipPostV5` (the denormalized DIV output). This is the full call-skip lane branch, ready for the n=4 lane borrow-dispatch.

## How

Mirror of the v4 `evm_div_n4_full_call_skip_spec_noNop` (`FullPathN4NoNop`): the two halves share the intermediate `preloopCallSkipPostN4V5` (the #7593 post = the #7595 pre), so the `seq_perm` callback is a trivial `xperm_hyp`.

## Stacking

Based on `feat/v5-n4-denorm-callskip` (PR #7595), which already stacks on #7593 (preloop+body). Merge those first.

## Gates

- `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopFullCallSkip` ✓ (and the `EvmAsm.Evm64.DivMod` aggregator ✓)
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` only (no `native_decide`/`bv_decide`, no sorries)
- `scripts/check-unimported.sh` → 0 orphans
- banned-tactic scan → clean

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)