### PR TITLE
feat(divmod): n4 v5 DIV lane call+skip branch (of hdiv)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -360,6 +360,7 @@ import EvmAsm.Evm64.DivMod.Compose.DenormEpilogueShift0ClzV5
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5Full
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDispatchPre
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDispatchPostBridge
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLaneCallSkip
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5LaneShiftNz
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5LaneShift0

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopLaneCallSkip.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopLaneCallSkip.lean
@@ -1,0 +1,74 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLaneCallSkip
+
+  The n=4 v5 DIV lane, call+skip branch, assembled from the dispatch
+  precondition to `divStackDispatchPostV5` over `divCode_noNop_v5`, taking the
+  quotient-correctness facts `hdiv0..hdiv3` as HYPOTHESES (their derivation —
+  Knuth-D correctness via the U4=0 semantic — is supplied later by the full
+  lane).  Composes the pre-bridge (`n4_dispatchPre_to_pathEntry_v5`), the full
+  call+skip path (`evm_div_n4_full_call_skip_spec_v5_noNop`), and the post-bridge
+  (`n4_denormDivPost_frame_to_divStackDispatchPost_v5`).  Structural mirror of
+  `evm_div_n1_lane_shiftNz_v5` (FullPathN1V5LaneShiftNz).  Bead `evm-asm-wbc4i.8`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopFullCallSkip
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDispatchPre
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDispatchPostBridge
+import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Div
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- n=4 v5 DIV lane (call+skip branch), from the dispatch pre to
+    `divStackDispatchPostV5`, given the quotient-correctness facts. -/
+theorem evm_div_n4_lane_callSkip_of_hdiv (sp base : Word) (a b : EvmWord)
+    (x1Val v5 v6 v7 v10 v11Old : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : isCallTrialN4 a3 b2 b3)
+    (hborrow : isSkipBorrowN4CallV5 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hdiv0 : (EvmWord.div a b).getLimbN 0 =
+      divKTrialCallV5QHat
+        (a3 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64))
+        ((a3 <<< ((clzResult b3).1.toNat % 64)) ||| (a2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+        ((b3 <<< ((clzResult b3).1.toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64))))
+    (hdiv1 : (EvmWord.div a b).getLimbN 1 = 0)
+    (hdiv2 : (EvmWord.div a b).getLimbN 2 = 0)
+    (hdiv3 : (EvmWord.div a b).getLimbN 3 = 0) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) x1Val
+        ((clzResult b3).2 >>> (63 : Nat)) v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostV5 sp a b) := by
+  have hpath := evm_div_n4_full_call_skip_spec_v5_noNop sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratchUn0 scratchMem
+    hbnz hb3nz hshift_nz halign hbltu hborrow
+  refine cpsTripleWithin_mono_nSteps (by have h : unifiedDivBound = 946 := rfl; omega) <|
+    cpsTripleWithin_weaken ?_ ?_ hpath
+  · intro h hp
+    exact n4_dispatchPre_to_pathEntry_v5 sp a b x1Val ((clzResult b3).2 >>> (63 : Nat))
+      v5 v6 v7 v10 v11Old a0 a1 a2 a3 b0 b1 b2 b3
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem retMem dMem dloMem
+      scratchUn0 scratchMem ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 h hp
+  · intro h hq
+    delta divStackDispatchPostV5
+    unfold fullDivN4CallSkipPostV5 at hq
+    exact n4_denormDivPost_frame_to_divStackDispatchPost_v5 sp base a b a0 a1 a2 a3
+      _ _ _ _ _ _ _ _ _ _ _ _ ha0 ha1 ha2 ha3 hdiv0 hdiv1 hdiv2 hdiv3 h hq
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Adds `evm_div_n4_lane_callSkip_of_hdiv` in `EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopLaneCallSkip.lean` — the **n=4 v5 DIV lane, call+skip branch**, from the dispatch precondition `divModStackDispatchPreNoX1` to `divStackDispatchPostV5` (the scaffold-feeding shape), over `divCode_noNop_v5`, taking the quotient-correctness facts `hdiv0..hdiv3` as **hypotheses**.

This **validates the lane plumbing end-to-end** and reduces the call+skip lane to *just* the `hdiv` math (Knuth-D quotient correctness via the U4=0 semantic) + the shape-derived `isCallTrialN4` / `isSkipBorrowN4CallV5`.

## How

Composes the three lane pieces into the scaffold shape, a structural mirror of `evm_div_n1_lane_shiftNz_v5` (`FullPathN1V5LaneShiftNz`):
- pre-bridge `n4_dispatchPre_to_pathEntry_v5` (#7600)
- full call+skip path `evm_div_n4_full_call_skip_spec_v5_noNop` (#7597)
- post-bridge `n4_denormDivPost_frame_to_divStackDispatchPost_v5` (#7601)

## Stacking

This is a **merge branch** combining `feat/v5-n4-full-callskip` (PR #7597 stack, the PR base) + `feat/v5-n4-dispatch-pre` (#7600) + `feat/v5-n4-dispatch-post` (#7601). The bridge files appear in this diff from those merges; they resolve once #7600/#7601 land on main.

## Gates

- `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLaneCallSkip` ✓ (and the `EvmAsm.Evm64.DivMod` aggregator ✓)
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` only (no `native_decide`/`bv_decide`, no sorries)
- `scripts/check-unimported.sh` → 0 orphans
- banned-tactic scan → clean

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)