### PR TITLE
feat(divmod): n4 v5 quotient-word projector (hdivs of word eq)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -86,6 +86,7 @@ import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0LaneFirstDigit
 import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0LaneRest
 import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5
 import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Div
+import EvmAsm.Evm64.DivMod.Spec.N4V5QuotientWord
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5CodeModelBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5Phase1bBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5DigitBridge

--- a/EvmAsm/Evm64/DivMod/Spec/N4V5QuotientWord.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V5QuotientWord.lean
@@ -1,0 +1,47 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4V5QuotientWord
+
+  N4 v5 quotient word: the n=4 DIV quotient is single-limb (the divisor is full,
+  `b3 ≠ 0 ⟹ b ≥ 2^192`, and `a < 2^256`, so `a / b < 2^64`), packed into an
+  `EvmWord` with limb 0 = `qVal` and limbs 1,2,3 = 0.  The `_hdivs_of_word_eq`
+  projector derives the four per-limb `EvmWord.div a b` facts (the `hdiv0..hdiv3`
+  hypotheses of the n=4 lane skeletons) from the single word equality
+  `fullDivN4QuotientWordV5 qVal = EvmWord.div a b`.  N=4 analog of
+  `fullDivN3V5_hdivs_of_word_eq` (N3V5QuotientWord).  The word equality itself
+  (Knuth-D quotient correctness, `qVal = a / b`) is the remaining deep obligation,
+  supplied by the lane.  Bead `evm-asm-wbc4i.8`.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.DivLimbBridge
+import EvmAsm.Evm64.EvmWordArith.Div
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The v5 n=4 quotient (single-limb), packed into an `EvmWord`: limb 0 = `qVal`,
+    limbs 1,2,3 = 0. -/
+def fullDivN4QuotientWordV5 (qVal : Word) : EvmWord :=
+  EvmWord.fromLimbs (fun i : Fin 4 =>
+    match i with
+    | 0 => qVal
+    | 1 => (0 : Word)
+    | 2 => (0 : Word)
+    | 3 => (0 : Word))
+
+/-- If `fullDivN4QuotientWordV5 qVal = EvmWord.div a b`, then limb 0 of
+    `EvmWord.div a b` is `qVal` and limbs 1,2,3 are zero — i.e. the four `hdiv`
+    facts the n=4 lane skeletons consume. -/
+theorem fullDivN4V5_hdivs_of_word_eq (a b : EvmWord) (qVal : Word)
+    (hdiv : fullDivN4QuotientWordV5 qVal = EvmWord.div a b) :
+    (EvmWord.div a b).getLimbN 0 = qVal ∧
+    (EvmWord.div a b).getLimbN 1 = (0 : Word) ∧
+    (EvmWord.div a b).getLimbN 2 = (0 : Word) ∧
+    (EvmWord.div a b).getLimbN 3 = (0 : Word) := by
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [← hdiv]; delta fullDivN4QuotientWordV5; exact EvmWord.getLimbN_fromLimbs_0
+  · rw [← hdiv]; delta fullDivN4QuotientWordV5; exact EvmWord.getLimbN_fromLimbs_1
+  · rw [← hdiv]; delta fullDivN4QuotientWordV5; exact EvmWord.getLimbN_fromLimbs_2
+  · rw [← hdiv]; delta fullDivN4QuotientWordV5; exact EvmWord.getLimbN_fromLimbs_3
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Adds `fullDivN4QuotientWordV5` + `fullDivN4V5_hdivs_of_word_eq` in `EvmAsm/Evm64/DivMod/Spec/N4V5QuotientWord.lean`.

The n=4 DIV quotient is **single-limb** (the divisor is full: `b3 ≠ 0 ⟹ b ≥ 2¹⁹²`, and `a < 2²⁵⁶`, so `a/b < 2⁶⁴`), packed into an `EvmWord` with limb 0 = `qVal` and limbs 1,2,3 = 0. The projector derives the four per-limb `EvmWord.div a b` facts — exactly the `hdiv0..hdiv3` hypotheses of the n=4 lane skeletons (#7602/#7603) — from the **single word equality** `fullDivN4QuotientWordV5 qVal = EvmWord.div a b`.

This **isolates the remaining deep obligation** to that one word equality (Knuth-D quotient correctness, `qVal = a/b`), which the lane will supply.

## How

N=4 analog of `fullDivN3V5_hdivs_of_word_eq` (`N3V5QuotientWord`): `delta` the word + the trivial `EvmWord.getLimbN_fromLimbs_{0,1,2,3}` projectors. Generic over `qVal` so both call branches (`qVal = qHat` / `q_out`) reuse it.

## Independence

Only needs `EvmWord.div` + the `DivLimbBridge` `getLimbN_fromLimbs` lemmas (all on `main`), so this is an independent PR (base = main).

## Gates

- `lake build EvmAsm.Evm64.DivMod.Spec.N4V5QuotientWord` ✓ (and the `EvmAsm.Evm64.DivMod` aggregator ✓)
- `#print axioms` → standard three + the inherited EvmWord-library `getLimb_fromLimbs` axioms (the same baseline the n3 analog depends on); no banned tactics in this proof
- `scripts/check-unimported.sh` → 0 orphans
- banned-tactic scan → clean

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)