### PR TITLE
feat(divmod): n4 v5 trial quotient = exact window floor

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -86,6 +86,7 @@ import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0LaneFirstDigit
 import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0LaneRest
 import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5
 import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Div
+import EvmAsm.Evm64.DivMod.Spec.N4V5TrialQuotientExact
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5CodeModelBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5Phase1bBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5DigitBridge

--- a/EvmAsm/Evm64/DivMod/Spec/N4V5TrialQuotientExact.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V5TrialQuotientExact.lean
@@ -1,0 +1,33 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4V5TrialQuotientExact
+
+  The v5 trial quotient is the exact window floor: under the call regime
+  (normalised divisor `vTop ≥ 2^63`) and the trial precondition `uHi < vTop`,
+  `divKTrialCallV5QHat uHi uLo vTop = floor((uHi·2^64 + uLo) / vTop)`.  Composes
+  the proven `divKTrialCallV5QHat_eq_div128Quot_v5` (the v5 trial folds to the v5
+  capped Knuth-D 128/64 quotient) with `div128Quot_v5_eq_q_true` (that capped
+  quotient is exact in this regime).  This is the trial→arithmetic step of the
+  n=4 v5 quotient-word equality (`fullDivN4QuotientWordV5 … = EvmWord.div a b`):
+  it pins the code's trial quotient to the normalised-window division, leaving
+  only the shift-normalisation invariance (window quotient = a / b) to the lane.
+  Bead `evm-asm-wbc4i.8`.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.LowerBound
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.UpperBound
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The v5 trial quotient equals the exact floor of the 128/64 window division,
+    in the call regime (`vTop ≥ 2^63`, `uHi < vTop`). -/
+theorem divKTrialCallV5QHat_eq_qTrue (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2 ^ 63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat) :
+    (divKTrialCallV5QHat uHi uLo vTop).toNat =
+      (uHi.toNat * 2 ^ 64 + uLo.toNat) / vTop.toNat := by
+  rw [divKTrialCallV5QHat_eq_div128Quot_v5]
+  exact div128Quot_v5_eq_q_true uHi uLo vTop hvTop_ge huHi_lt_vTop
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Adds `divKTrialCallV5QHat_eq_qTrue` in `EvmAsm/Evm64/DivMod/Spec/N4V5TrialQuotientExact.lean` — in the call regime (normalised divisor `vTop ≥ 2⁶³`, trial precondition `uHi < vTop`), the v5 trial quotient equals the exact floor of the 128/64 window division:

```
(divKTrialCallV5QHat uHi uLo vTop).toNat = (uHi.toNat * 2⁶⁴ + uLo.toNat) / vTop.toNat
```

This is the **trial→arithmetic step** of the n=4 v5 quotient-word equality (`fullDivN4QuotientWordV5 … = EvmWord.div a b`, #7605): it pins the code's trial quotient to the normalised-window division, leaving only the shift-normalisation invariance (window quotient = a/b) to the lane.

**Establishes that the word equality is achievable from `main`** (not blocked on the unmerged n4 semantic #7572–#7580).

## How

Composes two proven lemmas: `divKTrialCallV5QHat_eq_div128Quot_v5` (the v5 trial folds to the v5 capped Knuth-D 128/64 quotient) + `div128Quot_v5_eq_q_true` (that capped quotient is exact in this regime).

## Independence

Both lemmas are on `main` (`EvmWordArith/CallSkipLowerBoundV5/`), so this is an independent PR (base = main).

## Gates

- `lake build EvmAsm.Evm64.DivMod.Spec.N4V5TrialQuotientExact` ✓ (and the `EvmAsm.Evm64.DivMod` aggregator ✓)
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` only (no `native_decide`/`bv_decide`, no sorries)
- `scripts/check-unimported.sh` → 0 orphans
- banned-tactic scan → clean

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)