### PR TITLE
feat(divmod): n4 v5 trial quotient = v4 quotient (no-wrap bridge)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -87,6 +87,7 @@ import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0LaneRest
 import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5
 import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Div
 import EvmAsm.Evm64.DivMod.Spec.N4V5TrialQuotientExact
+import EvmAsm.Evm64.DivMod.Spec.N4V5TrialQuotientV4Bridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5CodeModelBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5Phase1bBridge
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128V5DigitBridge

--- a/EvmAsm/Evm64/DivMod/Spec/N4V5TrialQuotientV4Bridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V5TrialQuotientV4Bridge.lean
@@ -1,0 +1,42 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4V5TrialQuotientV4Bridge
+
+  Bridge `divKTrialCallV5QHat = div128Quot_v4` in the call-skip no-wrap regime:
+  both compute the exact 128/64 window floor there, so they coincide.  This lets
+  the n=4 v5 call-skip word equality reuse the v4 EvmWord-level quotient
+  correctness (`n4_call_skip_div_mod_getLimbN_v4`) by rewriting its `div128Quot_v4`
+  result to `divKTrialCallV5QHat`.  Composes `divKTrialCallV5QHat_eq_qTrue` (#7606,
+  v5 trial = floor) with `div128Quot_v4_eq_q_true_of_no_wrap_of_le` (v4 = floor
+  under no-wrap).  Bead `evm-asm-wbc4i.8`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N4V5TrialQuotientExact
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.QuotientBounds
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- In the call-skip no-wrap regime (both equal the exact window floor), the v5
+    trial quotient equals the v4 128/64 quotient. -/
+theorem divKTrialCallV5QHat_eq_div128Quot_v4_of_no_wrap_of_le
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2 ^ 63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat)
+    (huHi_lt_pow63 : uHi.toNat < 2 ^ 63)
+    (hUn21_lt_vTop : (divKTrialCallV4Un21 uHi uLo vTop).toNat < vTop.toNat)
+    (h_no_wrap :
+      (divKTrialCallV4Q1dd uHi uLo vTop).toNat *
+          (divKTrialCallV4DLo vTop).toNat ≤
+        ((divKTrialCallV4Rhatdd uHi uLo vTop).toNat % 2 ^ 32) * 2 ^ 32 +
+          (divKTrialCallV4Un1 uLo).toNat)
+    (h_le :
+      (div128Quot_v4 uHi uLo vTop).toNat ≤
+        (uHi.toNat * 2 ^ 64 + uLo.toNat) / vTop.toNat) :
+    divKTrialCallV5QHat uHi uLo vTop = div128Quot_v4 uHi uLo vTop := by
+  apply BitVec.eq_of_toNat_eq
+  rw [divKTrialCallV5QHat_eq_qTrue uHi uLo vTop hvTop_ge huHi_lt_vTop,
+      div128Quot_v4_eq_q_true_of_no_wrap_of_le uHi uLo vTop
+        hvTop_ge huHi_lt_vTop huHi_lt_pow63 hUn21_lt_vTop h_no_wrap h_le]
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Adds `divKTrialCallV5QHat_eq_div128Quot_v4_of_no_wrap_of_le` in `EvmAsm/Evm64/DivMod/Spec/N4V5TrialQuotientV4Bridge.lean` — in the call-skip no-wrap regime, the v5 trial quotient equals the v4 128/64 quotient (both compute the exact window floor).

This is the **key bridge** that lets the n=4 v5 call-skip word equality (`fullDivN4QuotientWordV5 (divKTrialCallV5QHat …) = EvmWord.div a b`) **reuse the v4 EvmWord-level quotient correctness** `n4_call_skip_div_mod_getLimbN_v4` (which gives `(a/b).getLimbN 0 = div128Quot_v4`): rewrite `div128Quot_v4 → divKTrialCallV5QHat` via this bridge.

## How

Composes `divKTrialCallV5QHat_eq_qTrue` (#7606, v5 trial = floor) with `div128Quot_v4_eq_q_true_of_no_wrap_of_le` (v4 = floor under no-wrap) via `BitVec.eq_of_toNat_eq` — both `toNat`s equal the same window floor.

## Stacking

Based on `feat/v5-n4-trial-quotient-exact` (PR #7606). Merge that first.

## Gates

- `lake build EvmAsm.Evm64.DivMod.Spec.N4V5TrialQuotientV4Bridge` ✓ (and the `EvmAsm.Evm64.DivMod` aggregator ✓)
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` only (no `native_decide`/`bv_decide`, no sorries)
- `scripts/check-unimported.sh` → 0 orphans
- banned-tactic scan → clean

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)