### PR TITLE
feat(divmod): n4 v5 call-addback q_out reconciliation

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -361,6 +361,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5Full
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDispatchPre
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDispatchPostBridge
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLaneCallAddback
+import EvmAsm.Evm64.DivMod.Spec.N4V5CallAddbackQOutReconcile
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5LaneShiftNz
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5LaneShift0

--- a/EvmAsm/Evm64/DivMod/Spec/N4V5CallAddbackQOutReconcile.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V5CallAddbackQOutReconcile.lean
@@ -1,0 +1,30 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4V5CallAddbackQOutReconcile
+
+  Reconciles the two n=4 v5 call-addback corrected-quotient defs: the lane
+  skeleton's `fullDivN4CallAddbackQuotientV5` (built on `divKTrialCallV5QHat`) and
+  the runtime/word-equality's `n4CallAddbackBeqQOutV5` (built on `div128Quot_v5`).
+  They differ only in the trial-quotient name, and `divKTrialCallV5QHat =
+  div128Quot_v5`, so they are equal.  This lets the call-addback word equality
+  (#7609, `… = n4CallAddbackBeqQOutV5`) feed the call-addback lane skeleton
+  (#7603, `hdiv0 : … = fullDivN4CallAddbackQuotientV5 …`).  Bead `evm-asm-wbc4i.8`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLaneCallAddback
+import EvmAsm.Evm64.DivMod.Spec.CallAddbackV5
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The lane-skeleton corrected quotient equals the runtime corrected quotient. -/
+theorem fullDivN4CallAddbackQuotientV5_eq_QOutV5 (a b : EvmWord) :
+    fullDivN4CallAddbackQuotientV5
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+      n4CallAddbackBeqQOutV5 a b := by
+  rw [n4CallAddbackBeqQOutV5_raw_unfold]
+  unfold fullDivN4CallAddbackQuotientV5
+  simp only [divKTrialCallV5QHat_eq_div128Quot_v5]
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Adds `fullDivN4CallAddbackQuotientV5_eq_QOutV5` in `EvmAsm/Evm64/DivMod/Spec/N4V5CallAddbackQOutReconcile.lean` — the lane-skeleton corrected quotient `fullDivN4CallAddbackQuotientV5` (#7603, built on `divKTrialCallV5QHat`) equals the runtime corrected quotient `n4CallAddbackBeqQOutV5` (built on `div128Quot_v5`).

This **connects the call-addback word equality (#7609, `… = n4CallAddbackBeqQOutV5`) to the call-addback lane skeleton (#7603, whose `hdiv0` uses `fullDivN4CallAddbackQuotientV5`)** — removing the def mismatch flagged between them.

## How

The two defs differ only in the trial-quotient name; `divKTrialCallV5QHat = div128Quot_v5` (proven), so they coincide: `rw [n4CallAddbackBeqQOutV5_raw_unfold]; unfold fullDivN4CallAddbackQuotientV5; simp only [divKTrialCallV5QHat_eq_div128Quot_v5]`.

## Stacking

Based on `feat/v5-n4-lane-calladdback` (PR #7603, which defines `fullDivN4CallAddbackQuotientV5`).

## Gates

- `lake build EvmAsm.Evm64.DivMod.Spec.N4V5CallAddbackQOutReconcile` ✓ (and the `EvmAsm.Evm64.DivMod` aggregator ✓)
- `#print axioms` → `[propext, Quot.sound]` only (no `native_decide`/`bv_decide`, no sorries)
- `scripts/check-unimported.sh` → 0 orphans
- banned-tactic scan → clean

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)