### PR TITLE
feat(divmod): n4 v5 shift=0 preloop + call-skip loop body (base → denormOff)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -266,6 +266,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallSkipV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackBeqV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackBeqExactX1V5NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN4V5.CallSkipV5NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMax
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCall
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxAddbackNorm

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -267,6 +267,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackBeqV5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackBeqExactX1V5NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4V5.CallSkipV5NoNop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopCall
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMax
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCall
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxAddbackNorm

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -328,6 +328,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallSkip
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFull

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopCall.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopCall.lean
@@ -1,0 +1,58 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopCall
+
+  v5/no-NOP norm-pre wrapper for the n=4 DIV call+skip loop body (j=0).  Mirror
+  of the v4 n=4 call-skip norm wrapper (`divK_loop_body_n4_call_skip_j0_norm_noNop`,
+  FullPathN4NoNop), lifting the raw v5 call+skip body (#7583, over
+  `sharedDivModCodeNoNop_v5`) to `divCode_noNop_v5` via
+  `sharedDivModCodeNoNop_v5_sub_divCode_noNop_v5` and exposing the sp-relative
+  addresses behind `loopBodyN4CallJ0NormPre` (plus the extra `sp+3936` div128
+  scratch cell the v5 loop owns).  Keeps the v5 post `loopBodyN4CallSkipJ0PostV5`
+  (identity post map).  Bead `evm-asm-wbc4i.8`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4NoNop
+import EvmAsm.Evm64.DivMod.Compose.V5NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN4V5.CallSkipV5NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- Loop body n=4, call+skip, j=0 over `divCode_noNop_v5`, with sp-relative
+    addresses behind `loopBodyN4CallJ0NormPre` + the v5 `sp+3936` scratch cell. -/
+theorem divK_loop_body_n4_call_skip_j0_norm_v5_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult uTop v3)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV5QHat uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 158 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v5 base)
+      (loopBodyN4CallJ0NormPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 **
+       (sp + signExtend12 3936 ↦ₘ scratchMem))
+      (loopBodyN4CallSkipJ0PostV5 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  have raw := divK_loop_body_n4_call_skip_j0_v5_spec_within_noNop
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+    retMem dMem dloMem scratchUn0 scratchMem base
+    halign hbltu hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v5_sub_divCode_noNop_v5) raw
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      rw [loopBodyN4CallJ0NormPre_unfold] at hp
+      rw [loopBodyN4CallSkipJ0PreV4_unfold]
+      rw [loopBodyN4CallSkipJ0Pre_unfold]
+      simp only [se12_32, se12_40, se12_48, se12_56,
+                 u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+                 u_base_off4072_j0, u_base_off4064_j0, q_addr_j0]
+      xperm_hyp hp)
+    (fun _ hp => hp)
+    raw'
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5ToDenormShift0CallSkip.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5ToDenormShift0CallSkip.lean
@@ -1,0 +1,111 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallSkip
+
+  n=4 v5 shift=0 preloop + call+skip loop body, `base → denormOff` over
+  `divCode_noNop_v5`.  Shift=0 analog of `evm_div_n4_preloop_call_skip_spec_v5_noNop`
+  (#7593): composes the n=4 shift=0 preloop (#7617,
+  `evm_div_n4_to_loopSetup_shift0_spec_v5_noNop`, base→loopBodyOff) with the
+  GENERIC call+skip loop body (#7589, `divK_loop_body_n4_call_skip_j0_norm_v5_noNop`,
+  loopBodyOff→denormOff) instantiated with the RAW divisor `(b0,b1,b2,b3)` and the
+  shift=0 u-window `(a0,a1,a2,a3, uTop=0)` — no normalization, since on the shift=0
+  branch `b3 ≥ 2^63` already.  The trial condition is `ult 0 b3` (true from
+  `b3 ≠ 0`); the skip-borrow over the raw window is taken as a hypothesis.
+  Bead `evm-asm-wbc4i.8`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopCall
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- n=4 v5 shift=0 preloop + call+skip loop body post: the generic loop-body
+    call-skip post over the RAW window plus the cells framed past the loop body.
+    Shift=0 analog of `preloopCallSkipPostN4V5`. -/
+def preloopCallSkipShift0PostN4V5 (sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem : Word) : Assertion :=
+  loopBodyN4CallSkipJ0PostV5 sp base b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word) scratchMem **
+  (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+   ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+   ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+   ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+   ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+   ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+   ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+   ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1))
+
+/-- n=4 v5 shift=0 pre-loop + call+skip loop body over `divCode_noNop_v5`:
+    base → denormOff.  Shift=0 analog of `evm_div_n4_preloop_call_skip_spec_v5_noNop`. -/
+theorem evm_div_n4_preloop_call_skip_shift0_spec_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v2 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_z : (clzResult b3).1 = 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV5QHat (0 : Word) a3 b3) b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word)) :
+    cpsTripleWithin (((8 + 21 + 24 + 4) + 13) + 158) base (base + denormOff) (divCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1)
+      (preloopCallSkipShift0PostN4V5 sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) := by
+  have hbltu : BitVec.ult (0 : Word) b3 = true := by
+    have hb3pos : 0 < b3.toNat := Nat.pos_of_ne_zero (fun h => hb3nz (by
+      apply BitVec.eq_of_toNat_eq; simpa using h))
+    simpa [BitVec.ult, BitVec.toNat_ofNat] using hb3pos
+  have hPre := evm_div_n4_to_loopSetup_shift0_spec_v5_noNop sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v2 v5 v6 v7 v10
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    hbnz hb3nz hshift_z
+  have hPreF := cpsTripleWithin_frameR
+    ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+     (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+     (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1)
+    (by pcFree) hPre
+  have hLoop := divK_loop_body_n4_call_skip_j0_norm_v5_noNop sp base
+    jMem (4 : Word) (clzResult b3).1 ((clzResult b3).2 >>> (63 : Nat)) b3 v11Old
+    (signExtend12 (0 : BitVec 12) - (clzResult b3).1)
+    b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word) (0 : Word)
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow
+  have hLoopF := cpsTripleWithin_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1))
+    (by pcFree) hLoop
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      rw [show signExtend12 (4 : BitVec 12) - (4 : Word) = (0 : Word) from by decide] at hp
+      rw [loopBodyN4CallJ0NormPre_unfold]
+      xperm_hyp hp) hPreF hLoopF
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta preloopCallSkipShift0PostN4V5; xperm_hyp hq)
+    hFull
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopIterN4V5/CallSkipV5NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4V5/CallSkipV5NoNop.lean
@@ -1,0 +1,145 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopIterN4V5.CallSkipV5NoNop
+
+  v5 n=4 call+skip loop body (j=0) over `sharedDivModCodeNoNop_v5`.  Mirror of
+  the v4 n=4 call+skip body (`LoopIterN4CallV4NoNop`,
+  `divK_loop_body_n4_call_skip_j0_v4_spec_within_noNop`), but using the v5 NAMED
+  trial-call-full post (`divKTrialCallFullPostV5Named`) — the compact named post
+  that keeps the v5 Knuth-D quotient terms from blowing up `dsimp`/`xperm` — plus
+  the v5 bricks (mulsub correction-skip, store-loop).  Same shape as the n=3 v5
+  call+skip body (`LoopIterN3V5/CallSkipV5NoNop`) with the trial window at digit 4
+  (uHi=uTop, uLo=u3, vTop=v3) and the n=4 glue lemmas / pre defs.
+  Bead `evm-asm-wbc4i.8`.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopIterN4CallV4NoNop
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCallFullV5Named
+import EvmAsm.Evm64.DivMod.LoopBody.MulsubSkipV5
+import EvmAsm.Evm64.DivMod.LoopBody.StoreLoopV5
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v5 n=4 call+skip j=0 loop-body post (mirror of `loopBodyN4CallSkipJ0PostV4`
+    with v5 trial defs; n=4 trial window uHi=uTop uLo=u3 vTop=v3). -/
+@[irreducible]
+def loopBodyN4CallSkipJ0PostV5
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV5DLo v3
+  let divUn0 := divKTrialCallV5Un0 u3
+  let qHat := divKTrialCallV5QHat uTop u3 v3
+  let scratchOut := divKTrialCallV5ScratchOut uTop u3 v3 scratchMem
+  loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v3) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ divUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut) **
+  regOwn .x1
+
+/-- v5 n=4 call+skip j=0 loop body over `sharedDivModCodeNoNop_v5` (158 steps,
+    loopBodyOff → denormOff).  Mirror of the v4 analog with the v5 NAMED trial. -/
+theorem divK_loop_body_n4_call_skip_j0_v5_spec_within_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult uTop v3)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV5QHat uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 158 (base + loopBodyOff) (base + denormOff) (sharedDivModCodeNoNop_v5 base)
+      (loopBodyN4CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN4CallSkipJ0PostV5 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  unfold loopBodyN4CallSkipJ0PreV4
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let dHi := divKTrialCallV5DHi v3
+  let dLo := divKTrialCallV5DLo v3
+  let divUn0 := divKTrialCallV5Un0 u3
+  let q1'' := divKTrialCallV5Q1dd uTop u3 v3
+  let q0'' := divKTrialCallV5Q0dd uTop u3 v3
+  let x7Exit := divKTrialCallV5X7Exit uTop u3 v3
+  let x9Exit := divKTrialCallV5X9Exit uTop u3 v3
+  let qHat := divKTrialCallV5QHat uTop u3 v3
+  let scratchOut := divKTrialCallV5ScratchOut uTop u3 v3 scratchMem
+  have TF := divK_trial_call_full_v5_named_spec_within_noNop sp (0 : Word) (4 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    uTop u3 v3 retMem dMem dloMem scratchUn0 scratchMem base
+    halign hbltu
+  unfold divKTrialCallFullPostV5Named at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n4] at TF
+  rw [u_addr8_eq_n4] at TF
+  rw [vtop_eq_v3_n4] at TF
+  have MCS0 := divK_mulsub_correction_skip_v5_spec_within_noNop sp qHat (0 : Word)
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x9Exit q0'' dHi x7Exit q1'' (base + div128CallRetOff) base
+    hborrow
+  unfold divKMulsubCorrectionSkipPre at MCS0
+  unfold n4McaNamedSkipPost at MCS0
+  unfold mulsubN4 at MCS0
+  dsimp only [] at MCS0
+  have MCS0f := cpsTripleWithin_frameR ((sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) MCS0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
+  let fs0 := p0_lo + (signExtend12 0 : Word)
+  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
+  let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
+  let un0 := u0 - fs0; let c0 := pc0 + bs0
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
+  let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
+  let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
+  let un1 := u1 - fs1; let c1 := pc1 + bs1
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
+  let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
+  let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
+  let un2 := u2 - fs2; let c2 := pc2 + bs2
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
+  let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
+  let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
+  let un3 := u3 - fs3; let c3 := pc3 + bs3
+  let u4_new := uTop - c3
+  have SL := divK_store_loop_j0_v5_spec_within_noNop sp qHat u4_new (0 : Word) qOld base
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCS0f
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
+     (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v3) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ divUn0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      rw [loopBodyN4CallSkipJ0Pre_unfold] at hp
+      xperm_hyp hp)
+    (fun h hp => by
+      unfold loopBodyN4CallSkipJ0PostV5
+      unfold loopBodyN4SkipPost loopBodySkipPost loopExitPost
+      unfold mulsubN4
+      dsimp only []
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    full
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Adds `evm_div_n4_preloop_call_skip_shift0_spec_v5_noNop` in `EvmAsm/Evm64/DivMod/Compose/FullPathN4V5ToDenormShift0CallSkip.lean` — the n=4 v5 **shift=0 preloop + call+skip loop body**, `base → denormOff` over `divCode_noNop_v5`. Shift=0 analog of `evm_div_n4_preloop_call_skip_spec_v5_noNop` (#7593).

## How

Composes:
- the n=4 shift=0 preloop (#7617, `evm_div_n4_to_loopSetup_shift0_spec_v5_noNop`, base→loopBodyOff);
- the **generic** call+skip loop body (#7589, `divK_loop_body_n4_call_skip_j0_norm_v5_noNop`, loopBodyOff→denormOff), instantiated with the **raw** divisor `(b0,b1,b2,b3)` and the shift=0 u-window `(a0,a1,a2,a3, uTop=0)`.

**Key insight**: the loop body is generic in its window, so the shift=0 loop needs *no separate loop math* — just a thin instantiation. On the shift=0 branch `b3 ≥ 2⁶³` already, so no normalization is applied. The trial condition `ult 0 b3` is derived from `b3 ≠ 0`; the skip-borrow over the raw window is taken as a hypothesis. The bridge matches the explicit shift=0 preloop exit to `loopBodyN4CallJ0NormPre` after rewriting `x9 = signExtend12 4 − 4 = 0`.

## Toward the capstone

Second piece of the n=4 shift=0 path (toward discharging the `shift0lane` obligation of `evm_div_n4_lane_v5_of_cert` #7615). Next: the call-addback shift=0 variant, the shared shift=0 epilogue compose (denormOff→nopOff), and the shift=0 lane wrapper.

## Stacking

**Merge branch** combining `feat/v5-n4-preloop-shift0` (#7617, the PR base) + `feat/v5-n4-norm-call-skip` (#7589, the generic loop body). Both sets of files appear in the diff; they resolve once the stacks land on main.

## Gates

- `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallSkip` ✓ (and the `EvmAsm.Evm64.DivMod` aggregator ✓)
- `#print axioms` → standard three; no banned tactics
- `scripts/check-unimported.sh` → 0 orphans

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)