### PR TITLE
feat(divmod): n4 v5 shift=0 preloop + call-addback loop body (base → denormOff)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -328,6 +328,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallAddback
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFull

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5ToDenormShift0CallAddback.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5ToDenormShift0CallAddback.lean
@@ -1,0 +1,122 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallAddback
+
+  n=4 v5 shift=0 preloop + call+addback-beq loop body, `base → denormOff` over
+  `divCode_noNop_v5`.  Shift=0 analog of `evm_div_n4_preloop_call_addback_spec_v5_noNop`
+  (#7594), and the call+addback counterpart of the shift=0 call+skip path (#7618).
+  Composes the n=4 shift=0 preloop (#7617,
+  `evm_div_n4_to_loopSetup_shift0_spec_v5_noNop`, base→loopBodyOff) with the
+  GENERIC call+addback loop body (#7590,
+  `divK_loop_body_n4_call_addback_j0_beq_norm_v5_noNop`, loopBodyOff→denormOff)
+  instantiated with the RAW divisor `(b0,b1,b2,b3)` and the shift=0 u-window
+  `(a0,a1,a2,a3, uTop=0)` — no normalization, since on the shift=0 branch
+  `b3 ≥ 2^63` already.  The trial condition is `ult 0 b3` (from `b3 ≠ 0`); the
+  addback borrow and carry2 conditions over the raw window are taken as hypotheses.
+  Bead `evm-asm-wbc4i.8`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopCallAddback
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- n=4 v5 shift=0 preloop + call+addback-beq loop body post: the generic
+    loop-body addback post over the RAW window plus the cells framed past the
+    loop body.  Shift=0 analog of `preloopCallAddbackPostN4V5`. -/
+def preloopCallAddbackShift0PostN4V5 (sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem : Word) : Assertion :=
+  loopBodyN4CallAddbackBeqJ0PostV5 sp base b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word) scratchMem **
+  (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+   ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+   ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+   ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+   ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+   ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+   ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+   ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1))
+
+/-- n=4 v5 shift=0 pre-loop + call+addback-beq loop body over `divCode_noNop_v5`:
+    base → denormOff.  Shift=0 analog of `evm_div_n4_preloop_call_addback_spec_v5_noNop`. -/
+theorem evm_div_n4_preloop_call_addback_shift0_spec_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v2 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_z : (clzResult b3).1 = 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hborrow : (if BitVec.ult (0 : Word)
+        (mulsubN4 (divKTrialCallV5QHat (0 : Word) a3 b3) b0 b1 b2 b3 a0 a1 a2 a3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word))
+    (hcarry2_nz :
+      let qHat := divKTrialCallV5QHat (0 : Word) a3 b3
+      let ms := mulsubN4 qHat b0 b1 b2 b3 a0 a1 a2 a3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 b0 b1 b2 b3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 ((0 : Word) - c3) b0 b1 b2 b3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 b0 b1 b2 b3 ≠ 0) :
+    cpsTripleWithin (((8 + 21 + 24 + 4) + 13) + 234) base (base + denormOff) (divCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1)
+      (preloopCallAddbackShift0PostN4V5 sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) := by
+  have hbltu : BitVec.ult (0 : Word) b3 = true := by
+    have hb3pos : 0 < b3.toNat := Nat.pos_of_ne_zero (fun h => hb3nz (by
+      apply BitVec.eq_of_toNat_eq; simpa using h))
+    simpa [BitVec.ult, BitVec.toNat_ofNat] using hb3pos
+  have hPre := evm_div_n4_to_loopSetup_shift0_spec_v5_noNop sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v2 v5 v6 v7 v10
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    hbnz hb3nz hshift_z
+  have hPreF := cpsTripleWithin_frameR
+    ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+     (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+     (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1)
+    (by pcFree) hPre
+  have hLoop := divK_loop_body_n4_call_addback_j0_beq_norm_v5_noNop sp base
+    jMem (4 : Word) (clzResult b3).1 ((clzResult b3).2 >>> (63 : Nat)) b3 v11Old
+    (signExtend12 (0 : BitVec 12) - (clzResult b3).1)
+    b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word) (0 : Word)
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow hcarry2_nz
+  have hLoopF := cpsTripleWithin_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1))
+    (by pcFree) hLoop
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      rw [show signExtend12 (4 : BitVec 12) - (4 : Word) = (0 : Word) from by decide] at hp
+      rw [loopBodyN4CallJ0NormPre_unfold]
+      xperm_hyp hp) hPreF hLoopF
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta preloopCallAddbackShift0PostN4V5; xperm_hyp hq)
+    hFull
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Adds `evm_div_n4_preloop_call_addback_shift0_spec_v5_noNop` in `EvmAsm/Evm64/DivMod/Compose/FullPathN4V5ToDenormShift0CallAddback.lean` — the n=4 v5 **shift=0 preloop + call+addback-beq loop body**, `base → denormOff` over `divCode_noNop_v5`. Shift=0 analog of `evm_div_n4_preloop_call_addback_spec_v5_noNop` (#7594); the call+addback counterpart of the shift=0 call+skip path (#7618).

## How

Composes the n=4 shift=0 preloop (#7617) with the **generic** call+addback loop body (#7590, `divK_loop_body_n4_call_addback_j0_beq_norm_v5_noNop`) instantiated with the **raw** divisor `(b0,b1,b2,b3)` and shift=0 u-window `(a0,a1,a2,a3, uTop=0)` — a thin instantiation, no separate shift0 loop math. The trial condition `ult 0 b3` derives from `b3 ≠ 0`; the addback borrow + carry2 conditions over the raw window are taken as hypotheses. Same bridge as the skip variant (rewrite `x9 = signExtend12 4 − 4 = 0`, then `loopBodyN4CallJ0NormPre_unfold` + `xperm_hyp`).

## Toward the capstone

Both shift=0 to-denorm branches (skip #7618, addback this) are now complete. Next: the shared shift=0 epilogue compose (denormOff→nopOff via the n-agnostic `evm_div_shift0_epilogue_spec_v5_noNop`), the shift=0 quotient-correctness, and the shift=0 lane wrapper (→ `shift0lane` of #7615).

## Stacking

**Merge branch** combining `feat/v5-n4-preloop-shift0` (#7617, the PR base) + `feat/v5-n4-norm-call-addback` (#7590, the generic addback loop body). Both file sets appear in the diff; they resolve once the stacks land.

## Gates

- `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallAddback` ✓ (and the `EvmAsm.Evm64.DivMod` aggregator ✓)
- `#print axioms` → standard three; no banned tactics
- `scripts/check-unimported.sh` → 0 orphans

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)