### PR TITLE
feat(divmod): single-addback top resolves to 0 for any U4 (c3=uTop+1)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -48,6 +48,7 @@ import EvmAsm.Evm64.EvmWordArith.ModBridgeAssemble
 import EvmAsm.Evm64.EvmWordArith.DivN4Lemmas
 import EvmAsm.Evm64.EvmWordArith.SkipBorrowExtract
 import EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback
+import EvmAsm.Evm64.EvmWordArith.DivN4SingleAddbackGen
 import EvmAsm.Evm64.EvmWordArith.DivN4RemainderLt
 import EvmAsm.Evm64.EvmWordArith.DivMulsubC3LeTwo
 import EvmAsm.Evm64.EvmWordArith.DivN3MaxOverestimate

--- a/EvmAsm/Evm64/EvmWordArith/DivN4SingleAddbackGen.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4SingleAddbackGen.lean
@@ -1,0 +1,45 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.DivN4SingleAddbackGen
+
+  U4-general "single addback resolves the borrow" fact.
+
+  In the n=4 single-digit Knuth division, the inner `mulsubN4` is a four-limb
+  mul-sub; the overflow limb `uTop` (= U4) is reconciled against the four-limb
+  borrow `c3` afterwards.  On the single-overshoot addback branch the borrow is
+  `c3 = uTop + 1`, and the first addback (with top input `uTop - c3`) produces a
+  carry that cancels it: the resulting top limb is `(uTop - c3) + carry = -1 + 1 =
+  0`, REGARDLESS of `uTop`.
+
+  The existing `iterSingleAddbackBranch_ab_top_toNat_eq_zero` (DivN4Overestimate)
+  proves this only for `uTop = 0` (it bakes in `c3 = 1`, derives `uTop = 0`).
+  `addbackN4_single_top_zero_of_c3_uTop_plus_one` proves it for ANY `uTop` (under
+  `c3 = uTop + 1` and `carry = 1`).  This removes the `U4 = 0` restriction at the
+  addback-top level — a step toward a U4-general `iterWithDoubleAddback`
+  conservation and hence a U4-general n=4 addback semantic.
+  Bead `evm-asm-wbc4i.8.2.2`.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- The single-addback top limb resolves to `0` for ANY `uTop`, given the
+    single-overshoot borrow `c3 = uTop + 1` (no wrap) and a nonzero addback carry
+    (`= 1`).  The addback top is `(uTop - c3) + carry = (uTop - (uTop+1)) + 1 = 0`. -/
+theorem addbackN4_single_top_zero_of_c3_uTop_plus_one
+    (un0 un1 un2 un3 v0 v1 v2 v3 uTop c3 : Word)
+    (hc3 : c3 = uTop + 1)
+    (hcarry_one : addbackN4_carry un0 un1 un2 un3 v0 v1 v2 v3 = 1) :
+    (addbackN4 un0 un1 un2 un3 (uTop - c3) v0 v1 v2 v3).2.2.2.2 = 0 := by
+  have htop := addbackN4_top_eq un0 un1 un2 un3 (uTop - c3) v0 v1 v2 v3
+  simp only [] at htop
+  rw [htop, hcarry_one, hc3]
+  apply BitVec.eq_of_toNat_eq
+  have h1 : (1 : BitVec 64).toNat = 1 := by decide
+  have h0 : (0 : BitVec 64).toNat = 0 := by decide
+  simp only [BitVec.toNat_add, BitVec.toNat_sub, h1, h0]
+  omega
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Adds `addbackN4_single_top_zero_of_c3_uTop_plus_one` in `EvmAsm/Evm64/EvmWordArith/DivN4SingleAddbackGen.lean`: the single-overshoot addback's outgoing top limb is `0` for **any** `uTop`, given `c3 = uTop + 1` and a nonzero addback carry (`= 1`):

```
(addbackN4 un0..un3 (uTop - c3) v).2.2.2.2 = 0
```

## How

The addback top is `(uTop - c3) + carry = (uTop - (uTop+1)) + 1 = 0` — a BitVec group identity (no wrap condition needed). Proof: `addbackN4_top_eq` to expose `(uTop-c3)+carry`, then `BitVec.eq_of_toNat_eq` + `toNat_add`/`toNat_sub` + `omega`.

## Why this matters

The existing `iterSingleAddbackBranch_ab_top_toNat_eq_zero` (DivN4Overestimate) proves this only for `uTop = 0` (it bakes in `c3 = 1`, derives `uTop = 0`). This version holds for **any** `uTop`, removing the `U4 = 0` restriction at the addback-top level.

This is a building block toward a U4-general `iterWithDoubleAddback` conservation — the precise remaining blocker for a U4-general n=4 addback semantic (the current `iterWithDoubleAddback_val256_conservation_of_carry2` requires `hc3_one_of_borrow`, i.e. `c3 = 1`, which only holds for `U4 = 0`). Bead `evm-asm-wbc4i.8.2.2`.

## Gates

- `lake build EvmAsm.Evm64.EvmWordArith.DivN4SingleAddbackGen` ✓ (and `EvmAsm.Evm64.EvmWordArith` aggregator ✓)
- `#print axioms` → `propext` + `Quot.sound` only; no banned tactics; no `sorry`
- `scripts/check-unimported.sh` → 0 orphans

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)