### PR TITLE
feat(divmod): U4-general n4 h_carry2 from h_borrow (no U4=0)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -101,6 +101,7 @@ import EvmAsm.Evm64.DivMod.Spec.N4Carry2PredicateBridge
 import EvmAsm.Evm64.DivMod.Spec.N4QHatLeOne
 import EvmAsm.Evm64.DivMod.Spec.N4QHatTopWindowBound
 import EvmAsm.Evm64.DivMod.Spec.N4Carry2OfBorrow
+import EvmAsm.Evm64.DivMod.Spec.N4Carry2OfBorrowGen
 import EvmAsm.Evm64.DivMod.Spec.N4SemanticOfBorrow
 import EvmAsm.Evm64.DivMod.Spec.DivDispatchShift
 import EvmAsm.Evm64.DivMod.Spec.N4V5TrialQuotientV4Bridge

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -90,6 +90,7 @@ import EvmAsm.Evm64.DivMod.Spec.N4Carry2OfNamed
 import EvmAsm.Evm64.DivMod.Spec.N4V5QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N4QHatBound
 import EvmAsm.Evm64.DivMod.Spec.N4QHatOvershoot
+import EvmAsm.Evm64.DivMod.Spec.N4C3EqUTopPlusOne
 import EvmAsm.Evm64.DivMod.Spec.N4WindowDivBridge
 import EvmAsm.Evm64.DivMod.Spec.N4QHatWindowBound
 import EvmAsm.Evm64.DivMod.Spec.N4V5TrialQuotientExact

--- a/EvmAsm/Evm64/DivMod/Spec/N4C3EqUTopPlusOne.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4C3EqUTopPlusOne.lean
@@ -1,0 +1,85 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4C3EqUTopPlusOne
+
+  Discharges the `hc3_of_borrow` obligation of the U4-general
+  `iterWithDoubleAddback_val256_conservation_gen` (#7653) for the n=4 v5 call path:
+  on the borrow branch (`U4 < c3`), the four-limb mulsub borrow is exactly
+  `c3 = U4 + 1`.
+
+  Two steps:
+  * `n4CallAddbackBeqQHatV5_mul_B3Prime_le_topwindow`: `qHat·B3' ≤ U4·2^64 + U3`,
+    because the v5 trial `qHat` is the FLOOR of the top window
+    (`divKTrialCallV5QHat_eq_floor` + `Nat.div_mul_le_self`).
+  * feeding that to the tight borrow bound `mulsubN4_c3_le_uTop_plus_one` (#7654)
+    gives `c3 ≤ U4 + 1`; with the borrow `U4 < c3` and `U4 < 2^63` (so no wrap),
+    `c3 = U4 + 1`.
+
+  This is the last deferred premise of the U4-general n=4 conservation.
+  Bead `evm-asm-wbc4i.8.2.2`.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.DivN4C3LeUTopPlusOne
+import EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntime
+import EvmAsm.Evm64.DivMod.Spec.CallAddbackV5
+import EvmAsm.Evm64.EvmWordArith.DivV5TrialOverestimate
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- The v5 trial quotient is the floor of the top window, so `qHat·B3' ≤ U4·2^64 + U3`. -/
+theorem n4CallAddbackBeqQHatV5_mul_B3Prime_le_topwindow {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hcall : isCallTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3)) :
+    (n4CallAddbackBeqQHatV5 a b).toNat * (n4CallAddbackBeqB3Prime b).toNat ≤
+      (n4CallAddbackBeqU4 a b).toNat * 2 ^ 64 + (n4CallAddbackBeqU3 a b).toNat := by
+  have hB3 : (n4CallAddbackBeqB3Prime b).toNat ≥ 2 ^ 63 :=
+    n4CallAddbackBeqB3Prime_ge_pow63 hb3nz
+  have hu4_lt : (n4CallAddbackBeqU4 a b).toNat < (n4CallAddbackBeqB3Prime b).toNat := by
+    have h_decomp := n4CallAddbackBeqU4_lt_vTop_of_call hcall
+    rw [div128Quot_vTop_decomp (n4CallAddbackBeqB3Prime b)]
+    simpa [divKTrialCallV4DHi, divKTrialCallV4DLo] using h_decomp
+  rw [n4CallAddbackBeqQHatV5_eq_normalized, ← divKTrialCallV5QHat_eq_div128Quot_v5,
+    divKTrialCallV5QHat_eq_floor _ _ _ hB3 hu4_lt]
+  exact Nat.div_mul_le_self _ _
+
+/-- On the borrow branch (`U4 < c3`), the n=4 v5 mulsub borrow is exactly `U4 + 1`.
+    This is the `hc3_of_borrow` premise of `iterWithDoubleAddback_val256_conservation_gen`. -/
+theorem n4CallAddbackBeq_c3_eq_uTop_plus_one_of_borrow {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3)) :
+    BitVec.ult (n4CallAddbackBeqU4 a b)
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b)
+          (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+          (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.2 →
+      (mulsubN4 (n4CallAddbackBeqQHatV5 a b)
+          (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+          (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.2 =
+        n4CallAddbackBeqU4 a b + 1 := by
+  intro hborrow
+  have hc3_le := mulsubN4_c3_le_uTop_plus_one (n4CallAddbackBeqQHatV5 a b)
+    (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+    (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+    (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+    (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)
+    (n4CallAddbackBeqU4 a b)
+    (n4CallAddbackBeqQHatV5_mul_B3Prime_le_topwindow hb3nz hcall)
+  have hbt : (n4CallAddbackBeqU4 a b).toNat <
+      (mulsubN4 (n4CallAddbackBeqQHatV5 a b)
+        (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+        (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+        (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+        (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.2.toNat := by
+    rw [EvmWord.ult_iff] at hborrow; exact hborrow
+  have hu4_small : (n4CallAddbackBeqU4 a b).toNat < 2 ^ 63 :=
+    n4CallAddbackBeqU4_lt_pow63_of_shift_nz hshift_nz
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_add, show (1 : Word).toNat = 1 from by decide]
+  omega
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4Carry2OfBorrowGen.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4Carry2OfBorrowGen.lean
@@ -1,0 +1,56 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4Carry2OfBorrowGen
+
+  U4-general n=4 v5 `h_carry2` (`isAddbackCarry2NzN4CallV5Evm`) from `h_borrow` +
+  the n=4 shape — with NO `U4 = 0` restriction.
+
+  U4-general counterpart of `n4CallAddbackBeqCarry2_of_borrow_and_u4_zero`
+  (N4Carry2OfBorrow).  Routes the generic
+  `isAddbackCarry2Nz_of_overestimate_c3_uTop_plus_one_of_carry_zero` (#7663) with:
+  * the full-dividend `+2` overestimate `qHat ≤ qTrue + 2`
+    (`n4CallAddbackBeqQHatV5_le_qTrue_plus_two_of_call`, #7573), rewritten to
+    `qHat ≤ (U4·2^256 + val256 U)/BNormVal + 2` via
+    `n4CallAddbackBeqNormalized_div_eq_qTrueV5`;
+  * `c3 = U4 + 1` on borrow (`n4CallAddbackBeq_c3_eq_uTop_plus_one_of_borrow`, #7656).
+
+  With this, all three semantic runtime conditions (`hq_over`, `h_carry2`,
+  `h_rem_lt`) are discharged from `h_borrow` for ANY `U4`.  Bead `evm-asm-wbc4i.8.2.2`.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.DivN4Carry2C3UTopPlusOne
+import EvmAsm.Evm64.DivMod.Spec.N4C3EqUTopPlusOne
+import EvmAsm.Evm64.DivMod.Spec.N4QHatBound
+import EvmAsm.Evm64.DivMod.Spec.N4Carry2OfNamed
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- The n=4 v5 `h_carry2` condition follows from `h_borrow` for ANY `U4`. -/
+theorem n4CallAddbackBeqCarry2_of_borrow_gen {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3))
+    (h_borrow : isAddbackBorrowN4CallV5Evm a b) :
+    isAddbackCarry2NzN4CallV5Evm a b := by
+  apply isAddbackCarry2NzN4CallV5Evm_of_named
+  apply isAddbackCarry2Nz_of_overestimate_c3_uTop_plus_one_of_carry_zero
+  · exact n4CallAddbackBeqNormalizedDivisor_ne_zero hb3nz
+  · have h := n4CallAddbackBeqQHatV5_le_qTrue_plus_two_of_call hb3nz hshift_nz hcall
+    rw [← n4CallAddbackBeqNormalized_div_eq_qTrueV5 hshift_nz] at h
+    unfold n4CallAddbackBeqUNormValV5 n4CallAddbackBeqBNormVal at h
+    rw [show val256 (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b) +
+          (n4CallAddbackBeqU4 a b).toNat * 2 ^ 256 =
+        (n4CallAddbackBeqU4 a b).toNat * 2 ^ 256 +
+          val256 (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b) from by ring] at h
+    exact h
+  · intro _
+    have hb_raw := n4CallAddbackBeqBorrow_raw_of_runtimeV5 h_borrow
+    have hc3 := n4CallAddbackBeq_c3_eq_uTop_plus_one_of_borrow hb3nz hshift_nz hcall hb_raw
+    rw [hc3, BitVec.toNat_add, show (1 : Word).toNat = 1 from by decide]
+    have := n4CallAddbackBeqU4_lt_pow63_of_shift_nz (a := a) hshift_nz
+    omega
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -52,6 +52,7 @@ import EvmAsm.Evm64.EvmWordArith.DivN4SingleAddbackGen
 import EvmAsm.Evm64.EvmWordArith.DivN4SingleAddbackVal256
 import EvmAsm.Evm64.EvmWordArith.DivN4RemainderLt
 import EvmAsm.Evm64.EvmWordArith.DivMulsubC3LeTwo
+import EvmAsm.Evm64.EvmWordArith.DivN4C3LeUTopPlusOne
 import EvmAsm.Evm64.EvmWordArith.DivN3MaxOverestimate
 import EvmAsm.Evm64.EvmWordArith.DivN2MaxOverestimate
 import EvmAsm.Evm64.EvmWordArith.DivBltC3Invariant

--- a/EvmAsm/Evm64/EvmWordArith/DivN4C3LeUTopPlusOne.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4C3LeUTopPlusOne.lean
@@ -1,0 +1,80 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.DivN4C3LeUTopPlusOne
+
+  The U4-general TIGHT mulsub borrow bound `c3 ≤ uTop + 1`.
+
+  For the n=4 single-digit Knuth division, the inner four-limb `mulsubN4` borrow
+  `c3` is at most `uTop + 1` whenever the trial quotient satisfies the top-window
+  floor bound `q · v3 ≤ uTop·2^64 + u3` (which the v5 trial does, since it IS the
+  floor of the top window).  This is TIGHTER than `mulsubN4_c3_le_u4_plus_two`
+  (c3 ≤ uTop + 2) and is exactly what the U4-general `iterWithDoubleAddback`
+  conservation needs to discharge `c3 = uTop + 1` on the borrow branch (`uTop < c3`
+  rules out smaller, this bound rules out larger).
+
+  Key cancellation: `q·val256 v = q·(val256 v0 v1 v2 0) + q·v3·2^192`, with
+  `q·v3·2^192 ≤ uTop·2^256 + u3·2^192` (top-window floor) and `val256 u ≥ u3·2^192`;
+  the `u3·2^192` terms cancel, leaving `c3·2^256 < (uTop+2)·2^256`.
+
+  All powers are kept symbolic (related via `pow_add`) so no 256-bit literal is
+  ever evaluated; the combines use `nlinarith` / `linarith` (powers as atoms).
+  Bead `evm-asm-wbc4i.8.2.2`.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- The four-limb `mulsubN4` borrow is at most `uTop + 1` under the top-window
+    floor bound `q·v3 ≤ uTop·2^64 + u3`. -/
+theorem mulsubN4_c3_le_uTop_plus_one
+    (q v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hqB3 : q.toNat * v3.toNat ≤ uTop.toNat * 2 ^ 64 + u3.toNat) :
+    (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat ≤ uTop.toNat + 1 := by
+  have hms := mulsubN4_val256_eq q v0 v1 v2 v3 u0 u1 u2 u3
+  simp only [] at hms
+  set c3 := (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 with hc3_def
+  set MR := val256 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+    (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+    (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+    (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1 with hMR_def
+  -- scale relations (symbolic; no literal evaluated).
+  have e6419 : (2 : Nat) ^ 64 * 2 ^ 192 = 2 ^ 256 := by rw [← pow_add]
+  -- top-window floor: q·v3·2^192 ≤ uTop·2^256 + u3·2^192.
+  have hqv3 : q.toNat * v3.toNat * 2 ^ 192 ≤ uTop.toNat * 2 ^ 256 + u3.toNat * 2 ^ 192 := by
+    calc q.toNat * v3.toNat * 2 ^ 192
+        ≤ (uTop.toNat * 2 ^ 64 + u3.toNat) * 2 ^ 192 := Nat.mul_le_mul_right _ hqB3
+      _ = uTop.toNat * (2 ^ 64 * 2 ^ 192) + u3.toNat * 2 ^ 192 := by ring
+      _ = uTop.toNat * 2 ^ 256 + u3.toNat * 2 ^ 192 := by rw [e6419]
+  -- low three limbs: q·(val256 v0 v1 v2 0) < 2^256.
+  have hvlow_lt : val256 v0 v1 v2 0 < 2 ^ 192 := val256_lt_pow192 v0 v1 v2
+  have hqvlow : q.toNat * val256 v0 v1 v2 0 < 2 ^ 256 := by
+    have h1 : q.toNat + 1 ≤ 2 ^ 64 := q.isLt
+    have h2 : val256 v0 v1 v2 0 + 1 ≤ 2 ^ 192 := hvlow_lt
+    have hkey : q.toNat * val256 v0 v1 v2 0 < 2 ^ 64 * 2 ^ 192 := by
+      nlinarith [h1, h2, Nat.zero_le q.toNat, Nat.zero_le (val256 v0 v1 v2 0)]
+    rwa [e6419] at hkey
+  -- q·val256 v split.
+  have hqsplit : q.toNat * val256 v0 v1 v2 v3 =
+      q.toNat * val256 v0 v1 v2 0 + q.toNat * v3.toNat * 2 ^ 192 := by
+    have hvsplit : val256 v0 v1 v2 v3 = val256 v0 v1 v2 0 + v3.toNat * 2 ^ 192 := by
+      unfold val256
+      rw [show (0 : Word).toNat = 0 from by decide]
+      ring
+    rw [hvsplit, Nat.mul_add, Nat.mul_assoc]
+  -- val256 u ≥ u3·2^192 ; MR < 2^256.
+  have hVU : u3.toNat * 2 ^ 192 ≤ val256 u0 u1 u2 u3 := by
+    show u3.toNat * 2 ^ 192 ≤ u0.toNat + u1.toNat * 2 ^ 64 + u2.toNat * 2 ^ 128 + u3.toNat * 2 ^ 192
+    exact Nat.le_add_left _ _
+  have hMR_lt : MR < 2 ^ 256 := val256_bound _ _ _ _
+  -- c3·2^256 < (uTop+2)·2^256, then divide.
+  have hC3lt : c3.toNat * 2 ^ 256 < (uTop.toNat + 2) * 2 ^ 256 := by
+    have hexp : (uTop.toNat + 2) * 2 ^ 256 = uTop.toNat * 2 ^ 256 + 2 * 2 ^ 256 := by ring
+    rw [hexp]
+    linarith [hms, hqsplit, hqv3, hqvlow, hVU, hMR_lt]
+  have hpow : (0 : Nat) < 2 ^ 256 := by positivity
+  have hlt := Nat.lt_of_mul_lt_mul_right hC3lt
+  omega
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Adds `n4CallAddbackBeqCarry2_of_borrow_gen` in `EvmAsm/Evm64/DivMod/Spec/N4Carry2OfBorrowGen.lean`: the n=4 v5 `h_carry2` condition (`isAddbackCarry2NzN4CallV5Evm`) follows from `h_borrow` + the n=4 shape for **any** `U4`.

U4-general counterpart of `n4CallAddbackBeqCarry2_of_borrow_and_u4_zero`. Routes the generic `isAddbackCarry2Nz_of_overestimate_c3_uTop_plus_one_of_carry_zero` (#7663) with:
- the full-dividend `+2` overestimate `qHat ≤ qTrue + 2` (#7573), rewritten to `qHat ≤ (U4·2^256 + val256 U)/BNormVal + 2` via `n4CallAddbackBeqNormalized_div_eq_qTrueV5`;
- `c3 = U4 + 1` on borrow (#7656).

## Why this matters

With this, **all three** semantic runtime conditions (`hq_over`, `h_carry2`, `h_rem_lt`) are discharged from `h_borrow` for **any** `U4` — so the n=4 shift≠0 cert's addback disjunct (`isAddbackBorrow` via #7643, `carry2` via this, `semantic` via #7661) is fully dischargeable from shape. Bead `evm-asm-wbc4i.8.2.2`.

## Stacking

Cut from `feat/v5-carry2-c3-utop-plus-one` (#7663) and merges `feat/v5-n4-c3-eq-utop-plus-one` (#7656).

## Gates

- `lake build EvmAsm.Evm64.DivMod.Spec.N4Carry2OfBorrowGen` ✓ (and `EvmAsm.Evm64.DivMod` aggregator ✓)
- `#print axioms` → standard three; no banned tactics; no `sorry`
- `scripts/check-unimported.sh` → 0 orphans

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)