### PR TITLE
feat(divmod): n4 v5 carry2/borrow Compose ↔ Evm bridges

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -438,6 +438,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLaneCallSkipOfConds
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLaneCallSkipOfCondsNative
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLaneShiftNz
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLaneShiftNzNative
+import EvmAsm.Evm64.DivMod.Spec.N4Carry2ComposeBridge
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLane
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5LaneShiftNz

--- a/EvmAsm/Evm64/DivMod/Spec/N4Carry2ComposeBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4Carry2ComposeBridge.lean
@@ -1,0 +1,45 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4Carry2ComposeBridge
+
+  Bridge the two surface forms of the n=4 v5 call-addback carry2 predicate:
+  the `Evm` form `isAddbackCarry2NzN4CallV5Evm` (= the `@[irreducible]`
+  `isAddbackCarry2NzN4CallV5Ab` over `getLimbN`, used by the semantic chain
+  #7661/#7664) implies the Compose form `isAddbackCarry2NzN4CallV5`
+  (FullPathN4V5NoNopPreloopCallAddback, used by the runtime certificate
+  `n4ShiftNzLaneRuntimeCertV5Native`).
+
+  Both unfold to the same `loopBodyN4CallAddbackCarry2NzV5` if-implication over the
+  windowed limbs; the Evm side just hides it behind the irreducible `Ab` wrapper.
+  (The borrow predicates are already definitionally equal, so only carry2 needs a
+  bridge.)  This is the last plumbing piece for the n=4 shift≠0 cert-of-shape.
+  Bead `evm-asm-wbc4i.8.2.2`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallAddback
+import EvmAsm.Evm64.DivMod.Spec.CallAddbackV5
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The `Evm` carry2 predicate implies the Compose carry2 predicate. -/
+theorem isAddbackCarry2NzN4CallV5_of_Evm {a b : EvmWord}
+    (h : isAddbackCarry2NzN4CallV5Evm a b) :
+    isAddbackCarry2NzN4CallV5 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := by
+  rw [isAddbackCarry2NzN4CallV5Evm_def] at h
+  unfold isAddbackCarry2NzN4CallV5Ab loopBodyN4CallAddbackCarry2NzV5 at h
+  unfold isAddbackCarry2NzN4CallV5
+  exact h
+
+/-- The Compose borrow predicate implies the `Evm` borrow predicate. -/
+theorem isAddbackBorrowN4CallV5Evm_of_compose {a b : EvmWord}
+    (h : isAddbackBorrowN4CallV5 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    isAddbackBorrowN4CallV5Evm a b := by
+  rw [isAddbackBorrowN4CallV5Evm_def]
+  unfold isAddbackBorrowN4CallV5Ab loopBodyN4CallAddbackBorrowV5
+  unfold isAddbackBorrowN4CallV5 at h
+  exact h
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Adds `isAddbackCarry2NzN4CallV5_of_Evm` (Evm → Compose carry2) and `isAddbackBorrowN4CallV5Evm_of_compose` (Compose → Evm borrow) in `EvmAsm/Evm64/DivMod/Spec/N4Carry2ComposeBridge.lean`.

## Why

The runtime certificate `n4ShiftNzLaneRuntimeCertV5Native` uses the **Compose-form** predicates (`isAddbackBorrowN4CallV5` / `isAddbackCarry2NzN4CallV5`), while the U4-general semantic/carry2 chain (#7661/#7664) uses the **Evm form** (= the `@[irreducible]` `*Ab` over `getLimbN`). Both unfold to the same `loopBody…` if-implication over the windowed limbs; the bridges unfold the irreducible `Ab` wrapper to align them.

These are the plumbing pieces for the n=4 shift≠0 **cert-of-shape**: discharge the addback disjunct from shape via #7643 (Compose borrow from ¬skip) → `isAddbackBorrowN4CallV5Evm_of_compose` → #7664 (carry2 Evm) → `isAddbackCarry2NzN4CallV5_of_Evm` (Compose carry2) + #7661 (semantic). Bead `evm-asm-wbc4i.8.2.2`.

## Gates

- `lake build EvmAsm.Evm64.DivMod.Spec.N4Carry2ComposeBridge` ✓ (and `EvmAsm.Evm64.DivMod` aggregator ✓)
- `#print axioms` → `propext` + `Quot.sound` only; no banned tactics; no `sorry`
- `scripts/check-unimported.sh` → 0 orphans

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)