### PR TITLE
feat(divmod): n4 v5 shiftNz cert-of-shape (cert from shape, no runtime inputs)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -101,6 +101,7 @@ import EvmAsm.Evm64.DivMod.Spec.N4Carry2PredicateBridge
 import EvmAsm.Evm64.DivMod.Spec.N4QHatLeOne
 import EvmAsm.Evm64.DivMod.Spec.N4QHatTopWindowBound
 import EvmAsm.Evm64.DivMod.Spec.N4Carry2OfBorrow
+import EvmAsm.Evm64.DivMod.Spec.N4Carry2OfBorrowGen
 import EvmAsm.Evm64.DivMod.Spec.N4SemanticOfBorrow
 import EvmAsm.Evm64.DivMod.Spec.DivDispatchShift
 import EvmAsm.Evm64.DivMod.Spec.N4V5TrialQuotientV4Bridge

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -447,6 +447,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLaneShiftNz
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLaneShiftNzNative
 import EvmAsm.Evm64.DivMod.Spec.N4Carry2ComposeBridge
 import EvmAsm.Evm64.DivMod.Spec.N4V5AddbackBorrowComplement
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopShiftNzCertOfShape
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLane
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5LaneShiftNz

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopShiftNzCertOfShape.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopShiftNzCertOfShape.lean
@@ -1,0 +1,52 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopShiftNzCertOfShape
+
+  Discharge the n=4 v5 shift≠0 native runtime certificate
+  `n4ShiftNzLaneRuntimeCertV5Native` (#7642) from the SHAPE alone (`b3 ≠ 0` +
+  `clz b3 ≠ 0`), with no runtime inputs.  The v5-native analogue of the shift0
+  cert-of-shape `evm_div_n4_shift0_cert_of_shape` (#7635).
+
+  Case split on the v5 skip-borrow:
+  * `isSkipBorrowN4CallV5`  → the skip disjunct (trivially);
+  * `¬ isSkipBorrowN4CallV5` → the addback disjunct, fully discharged from shape:
+    - `isAddbackBorrowN4CallV5` from the borrow complement (#7643);
+    - `isAddbackCarry2NzN4CallV5` from `n4CallAddbackBeqCarry2_of_borrow_gen`
+      (#7664) via the Compose↔Evm bridges (#7665);
+    - `n4CallAddbackBeqSemanticHoldsV5` (qOut = qTrue) from the U4-general semantic
+      `n4CallAddbackBeqSemanticHoldsV5_gen` (#7661).
+
+  With this, the n=4 shift≠0 lane's runtime certificate holds unconditionally on
+  the n=4 shape — the last math/plumbing piece before the unconditional lane.
+  Bead `evm-asm-wbc4i.8.2.2`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLaneShiftNzNative
+import EvmAsm.Evm64.DivMod.Spec.N4V5AddbackBorrowComplement
+import EvmAsm.Evm64.DivMod.Spec.N4SemanticGen
+import EvmAsm.Evm64.DivMod.Spec.N4Carry2OfBorrowGen
+import EvmAsm.Evm64.DivMod.Spec.N4Carry2ComposeBridge
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The n=4 v5 shift≠0 native runtime certificate holds for any `a b` of the n=4
+    shape (`b3 ≠ 0`, `clz b3 ≠ 0`) — no runtime inputs. -/
+theorem evm_div_n4_shiftNz_cert_of_shape_native (a b : EvmWord)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0) :
+    n4ShiftNzLaneRuntimeCertV5Native a b := by
+  have hcall := isCallTrialN4_of_shift_nz (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3)
+    hb3nz hshift_nz
+  by_cases hskip : isSkipBorrowN4CallV5
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+  · exact Or.inl hskip
+  · have hborrow_c := isAddbackBorrowN4CallV5_of_not_skipBorrow hskip
+    have hborrow_e := isAddbackBorrowN4CallV5Evm_of_compose hborrow_c
+    have hcarry2_e := n4CallAddbackBeqCarry2_of_borrow_gen hb3nz hshift_nz hcall hborrow_e
+    have hsem := n4CallAddbackBeqSemanticHoldsV5_gen hb3nz hshift_nz hcall hborrow_e hcarry2_e
+    have hcarry2_c := isAddbackCarry2NzN4CallV5_of_Evm hcarry2_e
+    exact Or.inr ⟨hborrow_c, hcarry2_c, hsem⟩
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4Carry2OfBorrowGen.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4Carry2OfBorrowGen.lean
@@ -1,0 +1,56 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4Carry2OfBorrowGen
+
+  U4-general n=4 v5 `h_carry2` (`isAddbackCarry2NzN4CallV5Evm`) from `h_borrow` +
+  the n=4 shape — with NO `U4 = 0` restriction.
+
+  U4-general counterpart of `n4CallAddbackBeqCarry2_of_borrow_and_u4_zero`
+  (N4Carry2OfBorrow).  Routes the generic
+  `isAddbackCarry2Nz_of_overestimate_c3_uTop_plus_one_of_carry_zero` (#7663) with:
+  * the full-dividend `+2` overestimate `qHat ≤ qTrue + 2`
+    (`n4CallAddbackBeqQHatV5_le_qTrue_plus_two_of_call`, #7573), rewritten to
+    `qHat ≤ (U4·2^256 + val256 U)/BNormVal + 2` via
+    `n4CallAddbackBeqNormalized_div_eq_qTrueV5`;
+  * `c3 = U4 + 1` on borrow (`n4CallAddbackBeq_c3_eq_uTop_plus_one_of_borrow`, #7656).
+
+  With this, all three semantic runtime conditions (`hq_over`, `h_carry2`,
+  `h_rem_lt`) are discharged from `h_borrow` for ANY `U4`.  Bead `evm-asm-wbc4i.8.2.2`.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.DivN4Carry2C3UTopPlusOne
+import EvmAsm.Evm64.DivMod.Spec.N4C3EqUTopPlusOne
+import EvmAsm.Evm64.DivMod.Spec.N4QHatBound
+import EvmAsm.Evm64.DivMod.Spec.N4Carry2OfNamed
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- The n=4 v5 `h_carry2` condition follows from `h_borrow` for ANY `U4`. -/
+theorem n4CallAddbackBeqCarry2_of_borrow_gen {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3))
+    (h_borrow : isAddbackBorrowN4CallV5Evm a b) :
+    isAddbackCarry2NzN4CallV5Evm a b := by
+  apply isAddbackCarry2NzN4CallV5Evm_of_named
+  apply isAddbackCarry2Nz_of_overestimate_c3_uTop_plus_one_of_carry_zero
+  · exact n4CallAddbackBeqNormalizedDivisor_ne_zero hb3nz
+  · have h := n4CallAddbackBeqQHatV5_le_qTrue_plus_two_of_call hb3nz hshift_nz hcall
+    rw [← n4CallAddbackBeqNormalized_div_eq_qTrueV5 hshift_nz] at h
+    unfold n4CallAddbackBeqUNormValV5 n4CallAddbackBeqBNormVal at h
+    rw [show val256 (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b) +
+          (n4CallAddbackBeqU4 a b).toNat * 2 ^ 256 =
+        (n4CallAddbackBeqU4 a b).toNat * 2 ^ 256 +
+          val256 (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b) from by ring] at h
+    exact h
+  · intro _
+    have hb_raw := n4CallAddbackBeqBorrow_raw_of_runtimeV5 h_borrow
+    have hc3 := n4CallAddbackBeq_c3_eq_uTop_plus_one_of_borrow hb3nz hshift_nz hcall hb_raw
+    rw [hc3, BitVec.toNat_add, show (1 : Word).toNat = 1 from by decide]
+    have := n4CallAddbackBeqU4_lt_pow63_of_shift_nz (a := a) hshift_nz
+    omega
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -49,6 +49,7 @@ import EvmAsm.Evm64.EvmWordArith.DivN4Lemmas
 import EvmAsm.Evm64.EvmWordArith.SkipBorrowExtract
 import EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback
 import EvmAsm.Evm64.EvmWordArith.DivN4SecondCarryGen
+import EvmAsm.Evm64.EvmWordArith.DivN4Carry2C3UTopPlusOne
 import EvmAsm.Evm64.EvmWordArith.DivN4SingleAddbackGen
 import EvmAsm.Evm64.EvmWordArith.DivN4SingleAddbackVal256
 import EvmAsm.Evm64.EvmWordArith.DivN4RemainderLt

--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -48,6 +48,7 @@ import EvmAsm.Evm64.EvmWordArith.ModBridgeAssemble
 import EvmAsm.Evm64.EvmWordArith.DivN4Lemmas
 import EvmAsm.Evm64.EvmWordArith.SkipBorrowExtract
 import EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback
+import EvmAsm.Evm64.EvmWordArith.DivN4SecondCarryGen
 import EvmAsm.Evm64.EvmWordArith.DivN4SingleAddbackGen
 import EvmAsm.Evm64.EvmWordArith.DivN4SingleAddbackVal256
 import EvmAsm.Evm64.EvmWordArith.DivN4RemainderLt

--- a/EvmAsm/Evm64/EvmWordArith/DivN4Carry2C3UTopPlusOne.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Carry2C3UTopPlusOne.lean
@@ -1,0 +1,62 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.DivN4Carry2C3UTopPlusOne
+
+  U4-general double-addback progress bridge: under the val256 `+2` overestimate
+  against the FULL five-limb dividend and the first-addback-zero branch forcing
+  `c3 = uTop + 1`, the `isAddbackCarry2Nz` predicate holds.
+
+  U4-general counterpart of `isAddbackCarry2Nz_of_overestimate_c3_one_of_carry_zero`
+  (DivN4Overestimate), which is `c3 = 1` / `U4 = 0`-specific.  Same structure, but
+  routed through the generalised second-carry lemma `addbackN4_second_carry_one_gen`
+  (#7662).  Bead `evm-asm-wbc4i.8.2.2`.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.DivN4SecondCarryGen
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- U4-general: `isAddbackCarry2Nz` from the full-dividend `+2` overestimate and
+    `c3 = uTop + 1` on the first-addback-zero branch. -/
+theorem isAddbackCarry2Nz_of_overestimate_c3_uTop_plus_one_of_carry_zero
+    (q v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hq_over : q.toNat ≤
+      (uTop.toNat * 2 ^ 256 + val256 u0 u1 u2 u3) / val256 v0 v1 v2 v3 + 2)
+    (hc3_of_carry_zero :
+      addbackN4_carry
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+        v0 v1 v2 v3 = 0 →
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat = uTop.toNat + 1) :
+    isAddbackCarry2Nz q v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  dsimp [isAddbackCarry2Nz]
+  intro hcarry_zero
+  let ms := mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3
+  let abTop := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+    (uTop - ms.2.2.2.2) v0 v1 v2 v3
+  let abZero := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+    0 v0 v1 v2 v3
+  have hc3 : ms.2.2.2.2.toNat = uTop.toNat + 1 := by
+    subst ms
+    exact hc3_of_carry_zero hcarry_zero
+  have hsecond := addbackN4_second_carry_one_gen q v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    hbnz hq_over hc3 hcarry_zero
+  simp only [] at hsecond
+  have h_indep := addbackN4_fst4_u4_indep
+    ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+    (uTop - ms.2.2.2.2) 0 v0 v1 v2 v3
+  rcases h_indep with ⟨h0, h1, h2, h3⟩
+  have hsecond_top :
+      (addbackN4_carry abTop.1 abTop.2.1 abTop.2.2.1 abTop.2.2.2.1
+        v0 v1 v2 v3).toNat = 1 := by
+    rw [h0, h1, h2, h3]
+    exact hsecond
+  intro hzero
+  rw [hzero] at hsecond_top
+  norm_num at hsecond_top
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/DivN4SecondCarryGen.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4SecondCarryGen.lean
@@ -1,0 +1,88 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.DivN4SecondCarryGen
+
+  U4-general second-addback carry: under the val256 `+2` overestimate against the
+  FULL five-limb dividend `uTop·2^256 + val256 u`, the borrow `c3 = uTop + 1`, and a
+  zero first-addback carry, the SECOND addback carry is `1`.
+
+  U4-general counterpart of `addbackN4_second_carry_one` (DivN4Overestimate),
+  which is `c3 = 1` / `U4 = 0`-specific.  Same clean val256 bookkeeping:
+  from `mulsubN4_val256_eq` (with `c3 = uTop + 1`) and `q·v ≤ (uTop·2^256 +
+  val256 u) + 2·v`, one gets `val256(ms.result) + 2·v ≥ 2^256`, hence the first
+  addback (carry = 0) leaves `val256(ab.result) + v ≥ 2^256`, so the second
+  addback overflows (`carry2 = 1`).
+
+  Bead `evm-asm-wbc4i.8.2.2`.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- U4-general: second-addback carry is `1`, under the full-dividend `+2`
+    overestimate, `c3 = uTop + 1`, and a zero first-addback carry. -/
+theorem addbackN4_second_carry_one_gen (q v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hq_over : q.toNat ≤
+      (uTop.toNat * 2 ^ 256 + val256 u0 u1 u2 u3) / val256 v0 v1 v2 v3 + 2)
+    (hc3 : (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat = uTop.toNat + 1)
+    (hcarry_zero : (addbackN4_carry
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+      v0 v1 v2 v3) = 0) :
+    let ms := mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 v0 v1 v2 v3
+    (addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3).toNat = 1 := by
+  intro ms ab
+  have hmulsub := mulsubN4_val256_eq q v0 v1 v2 v3 u0 u1 u2 u3
+  simp only [] at hmulsub
+  rw [hc3] at hmulsub
+  have hab1 := addbackN4_val256_eq ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 v0 v1 v2 v3
+  simp only [] at hab1
+  have hc1_val : (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3).toNat = 0 := by
+    rw [hcarry_zero]; decide
+  rw [hc1_val] at hab1
+  have hab' := addbackN4_val256_eq ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 0 v0 v1 v2 v3
+  simp only [] at hab'
+  have hvpos := val256_pos_of_or_ne_zero hbnz
+  have hmsb := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+  have habb := val256_bound ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1
+  have habrb := val256_bound
+    (addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 0 v0 v1 v2 v3).1
+    (addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 0 v0 v1 v2 v3).2.1
+    (addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 0 v0 v1 v2 v3).2.2.1
+    (addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 0 v0 v1 v2 v3).2.2.2.1
+  have hdiv_mul_le :
+      (uTop.toNat * 2 ^ 256 + val256 u0 u1 u2 u3) / val256 v0 v1 v2 v3 * val256 v0 v1 v2 v3 ≤
+        uTop.toNat * 2 ^ 256 + val256 u0 u1 u2 u3 := Nat.div_mul_le_self _ _
+  have hqv_le : q.toNat * val256 v0 v1 v2 v3 ≤
+      (uTop.toNat * 2 ^ 256 + val256 u0 u1 u2 u3) + 2 * val256 v0 v1 v2 v3 := by
+    calc q.toNat * val256 v0 v1 v2 v3
+        ≤ ((uTop.toNat * 2 ^ 256 + val256 u0 u1 u2 u3) / val256 v0 v1 v2 v3 + 2) *
+            val256 v0 v1 v2 v3 := Nat.mul_le_mul_right _ hq_over
+      _ = (uTop.toNat * 2 ^ 256 + val256 u0 u1 u2 u3) / val256 v0 v1 v2 v3 * val256 v0 v1 v2 v3 +
+            2 * val256 v0 v1 v2 v3 := by ring
+      _ ≤ (uTop.toNat * 2 ^ 256 + val256 u0 u1 u2 u3) + 2 * val256 v0 v1 v2 v3 :=
+          Nat.add_le_add_right hdiv_mul_le _
+  -- val256(ms.result) + 2v ≥ 2^256.
+  have h_ge : val256 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 + 2 * val256 v0 v1 v2 v3 ≥ 2 ^ 256 := by
+    nlinarith [hmulsub, hqv_le]
+  -- val256(ab.result) + v ≥ 2^256.
+  have h_ab1_v_ge : val256 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 + val256 v0 v1 v2 v3 ≥ 2 ^ 256 := by
+    nlinarith [hab1, h_ge]
+  set carry2 := (addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3).toNat with hc2def
+  have hc2_lt : carry2 * 2 ^ 256 < 2 * 2 ^ 256 := by nlinarith [hab', habb, hvpos]
+  have hc2_ge : carry2 ≥ 1 := by
+    by_contra h
+    have hc2_zero : carry2 = 0 := by omega
+    rw [hc2_zero] at hab'
+    nlinarith [hab', h_ab1_v_ge, habrb]
+  have h256_pos : (0 : Nat) < 2 ^ 256 := by positivity
+  have hlt2 : carry2 < 2 := (Nat.mul_lt_mul_right h256_pos).mp hc2_lt
+  omega
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Adds `evm_div_n4_shiftNz_cert_of_shape_native` in `EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopShiftNzCertOfShape.lean`: the n=4 v5 shift≠0 native runtime certificate `n4ShiftNzLaneRuntimeCertV5Native` (#7642) holds for any `a, b` of the n=4 shape (`b3 ≠ 0`, `clz b3 ≠ 0`) — **no runtime inputs**. The v5-native analogue of the shift0 cert-of-shape `evm_div_n4_shift0_cert_of_shape` (#7635).

## How

Case split on the v5 skip-borrow:
- `isSkipBorrowN4CallV5` → the skip disjunct (trivially);
- `¬ isSkipBorrowN4CallV5` → the addback disjunct, fully discharged from shape:
  - `isAddbackBorrowN4CallV5` from the borrow complement (#7643);
  - `isAddbackCarry2NzN4CallV5` from `n4CallAddbackBeqCarry2_of_borrow_gen` (#7664) via the Compose↔Evm bridges (#7665);
  - `n4CallAddbackBeqSemanticHoldsV5` (`qOut = qTrue`) from the U4-general semantic `n4CallAddbackBeqSemanticHoldsV5_gen` (#7661).

## Why this matters

This is the **assembly of the entire U4-general addback proof chain** — the n=4 shift≠0 lane's runtime certificate now holds **unconditionally on the n=4 shape**, with no runtime inputs. Both branches (skip + addback) are discharged. Next: feed this to the dispatcher (#7642) for the unconditional `lane_n4`. Bead `evm-asm-wbc4i.8.2.2`.

## Stacking

Cut from `feat/v5-n4-semantic-gen` (#7661) and merges `feat/v5-n4-carry2-of-borrow-gen` (#7664) + `feat/v5-n4-carry2-compose-bridge` (#7665) + main (for #7643/#7642).

## Gates

- `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopShiftNzCertOfShape` ✓ (and `EvmAsm.Evm64.DivMod` aggregator ✓)
- `#print axioms` → standard three; no banned tactics; no `sorry`
- `scripts/check-unimported.sh` → 0 orphans

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)