### PR TITLE
feat(divmod): v5 DIV unconditional stack spec — n4 lane discharged

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -449,6 +449,7 @@ import EvmAsm.Evm64.DivMod.Spec.N4Carry2ComposeBridge
 import EvmAsm.Evm64.DivMod.Spec.N4V5AddbackBorrowComplement
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopShiftNzCertOfShape
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLaneOfShapeNative
+import EvmAsm.Evm64.DivMod.Compose.FullPathV5DivUnconditional
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLane
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5LaneShiftNz

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathV5DivUnconditional.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathV5DivUnconditional.lean
@@ -1,0 +1,55 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathV5DivUnconditional
+
+  The v5 DIV unconditional stack spec, with NO remaining lane hypothesis.
+
+  `evm_div_stack_spec_unconditional_v5_div_of_n4lane` (#7570, bead `.10.2`) had
+  reduced the v5 DIV spec to a single open obligation — the n=4 lane.  That lane
+  is now proven from the n=4 shape alone by `evm_div_n4_lane_of_shape_native`
+  (#7668), so feeding it in (reconciling `N4ShapeIs b` to `b.getLimbN 3 ≠ 0` via
+  `N4ShapeIs.b3_ne_zero`) discharges the last hypothesis and yields the fully
+  unconditional v5 DIV dispatch triple over `divCode_noNop_v5` with the uniform
+  dispatch shift `divDispatchShiftX2 b` in `x2`.
+
+  Bead `evm-asm-wbc4i.10.2`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathV5DivAssembly
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLaneOfShapeNative
+import EvmAsm.Evm64.DivMod.Spec.DivisorShapeLimbProjections
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The v5 DIV unconditional spec: with the uniform shift `divDispatchShiftX2 b`
+    in `x2`, the full dispatch triple holds for every divisor shape, with no
+    remaining lane hypothesis (the n=4 lane is discharged from shape via
+    `evm_div_n4_lane_of_shape_native`). -/
+theorem evm_div_stack_spec_unconditional_v5_div
+    (sp base : Word) (a b : EvmWord)
+    (raVal v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        (divDispatchShiftX2 b) v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostV5 sp a b) := by
+  refine evm_div_stack_spec_unconditional_v5_div_of_n4lane sp base a b
+    raVal v5 v6 v7 v10 v11
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0 scratchMem halign ?lane_n4
+  intro hshape
+  exact evm_div_n4_lane_of_shape_native sp base a b
+    raVal v5 v6 v7 v10 v11
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0 scratchMem
+    (N4ShapeIs.b3_ne_zero hshape) halign
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Prove **`evm_div_stack_spec_unconditional_v5_div`**: the v5 DIV dispatch triple over `divCode_noNop_v5` holds for **every divisor shape**, with **no remaining lane hypothesis**.

`evm_div_stack_spec_unconditional_v5_div_of_n4lane` (#7570) had already reduced the v5 DIV spec to a single open obligation — the n=4 lane. That lane is now proven from the n=4 shape alone by `evm_div_n4_lane_of_shape_native` (#7668), so feeding it in — reconciling `N4ShapeIs b` to `b.getLimbN 3 ≠ 0` via `N4ShapeIs.b3_ne_zero` — discharges the last hypothesis.

This completes the v5 DIV stack spec **at the v5 dispatch surface** (uniform dispatch shift `divDispatchShiftX2 b` in x2). The remaining work toward the public-surface `evm_div_stack_spec_unconditional` is the v5→`divCode`/`divStackDispatchPost` surface bridge.

## Verification
- `lake build EvmAsm.Evm64.DivMod.Compose.FullPathV5DivUnconditional` ✔ + aggregator `EvmAsm.Evm64.DivMod` ✔
- `scripts/check-unimported.sh` ✔ (0 orphans)
- `#print axioms` → baseline EvmWord `getLimb_fromLimbs`/`fromLimbs_getLimb` footprint (n1/n2/n3 parity) + propext/Classical.choice/Quot.sound; no new banned axioms
- no `sorry` / `native_decide` / `bv_decide`

Bead evm-asm-wbc4i.10.2.

Stacked on #7668 (which is stacked on #7666).

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)