### PR TITLE
feat(stateless): parent_beacon_block_root_at_block_hash primitive

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -178,6 +178,7 @@ import EvmAsm.Codegen.Programs.TxSignature
 import EvmAsm.Codegen.Programs.TxSigningHash
 import EvmAsm.Codegen.Programs.Withdrawal
 import EvmAsm.Codegen.Programs.Address
+import EvmAsm.Codegen.Programs.ParentBeaconBlockRootAtBlockHash
 
 namespace EvmAsm.Codegen
 
@@ -552,6 +553,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_witness_state_keccak_at_index" => some ziskWitnessStateKeccakAtIndexProbeUnit
   | "zisk_parent_keccak_matches_child_parent_hash" => some ziskParentKeccakMatchesChildParentHashProbeUnit
   | "zisk_balance_at_block_hash_address" => some ziskBalanceAtBlockHashAddressProbeUnit
+  | "zisk_parent_beacon_block_root_at_block_hash" => some ziskParentBeaconBlockRootAtBlockHashProbeUnit
   | "zisk_slot_at_index"        => some ziskSlotAtIndexProbeUnit
   | "zisk_rlp_encode_uint_be"   => some ziskRlpEncodeUintBeProbeUnit
   | "zisk_rlp_encode_bytes"     => some ziskRlpEncodeBytesProbeUnit
@@ -791,6 +793,7 @@ def knownProgramNames : List String :=
    "zisk_witness_state_keccak_at_index",
    "zisk_parent_keccak_matches_child_parent_hash",
    "zisk_balance_at_block_hash_address",
+   "zisk_parent_beacon_block_root_at_block_hash",
    "zisk_slot_at_index",
    "zisk_rlp_encode_uint_be",
    "zisk_rlp_encode_bytes",

--- a/EvmAsm/Codegen/Programs/ParentBeaconBlockRootAtBlockHash.lean
+++ b/EvmAsm/Codegen/Programs/ParentBeaconBlockRootAtBlockHash.lean
@@ -1,0 +1,139 @@
+/-
+  EvmAsm.Codegen.Programs.ParentBeaconBlockRootAtBlockHash
+
+  Hash-keyed EIP-4788 `header.parent_beacon_block_root`
+  extractor (RLP field 19, 32 bytes; Cancun+). Mirror of
+  the number-keyed `parent_beacon_block_root_at_block_number`
+  probe but takes a 32-byte block_hash key.
+
+  No proofs yet -- codegen `String` defs only.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.Mpt
+import EvmAsm.Codegen.Programs.HashBridge
+import EvmAsm.Codegen.Programs.HeaderFields
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Program
+
+/-! ## parent_beacon_block_root_at_block_hash
+
+    Hash-keyed extractor for
+    `header.block.parent_beacon_block_root` (RLP field 19,
+    32 B; Cancun+ per EIP-4788).
+
+    Pipeline (composes K19 + existing K281; no new helpers):
+      witness.headers ∋ ?h with keccak(h) == block_hash  [K19]
+      h -> header_extract_parent_beacon_block_root -> 32 B
+
+    Use cases unique to the hash-keyed variant:
+      * Beacon-root bridge attestation -- a CL client posts a
+        `(block_hash, beacon_root)` claim; verify it without
+        first translating block_hash to a block_number.
+      * Cross-witness consistency for parent_beacon_block_root.
+      * Reorg detection across CL-driven splits.
+
+    Calling convention (4 args):
+      a0 (input)  : block_hash ptr (32 bytes)
+      a1 (input)  : witness.headers ptr
+      a2 (input)  : witness.headers len
+      a3 (input)  : 32-byte parent_beacon_block_root out ptr
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success
+        1 = block_hash not in witness.headers
+        2 = matched header parent_beacon_block_root extraction
+            failed (RLP malformed / field 19 absent (pre-Cancun)
+            / size != 32)
+-/
+def parentBeaconBlockRootAtBlockHashFunction : String :=
+  "parent_beacon_block_root_at_block_hash:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0                  # block_hash ptr\n" ++
+  "  mv s1, a1                  # witness.headers ptr\n" ++
+  "  mv s2, a2                  # witness.headers len\n" ++
+  "  mv s3, a3                  # parent_beacon_block_root out (32 B)\n" ++
+  "  sd zero,  0(s3); sd zero,  8(s3); sd zero, 16(s3); sd zero, 24(s3)\n" ++
+  "  mv a0, s1\n" ++
+  "  mv a1, s2\n" ++
+  "  mv a2, s0\n" ++
+  "  la a3, pbrbh_match_offset\n" ++
+  "  la a4, pbrbh_match_length\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  bnez a0, .Lpbrbh_no_match\n" ++
+  "  la t0, pbrbh_match_offset\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  add s4, s1, t1\n" ++
+  "  la t0, pbrbh_match_length\n" ++
+  "  ld s5, 0(t0)\n" ++
+  "  mv a0, s4\n" ++
+  "  mv a1, s5\n" ++
+  "  mv a2, s3\n" ++
+  "  jal ra, header_extract_parent_beacon_block_root\n" ++
+  "  beqz a0, .Lpbrbh_ret\n" ++
+  "  sd zero,  0(s3); sd zero,  8(s3); sd zero, 16(s3); sd zero, 24(s3)\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lpbrbh_ret\n" ++
+  ".Lpbrbh_no_match:\n" ++
+  "  li a0, 1\n" ++
+  ".Lpbrbh_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_parent_beacon_block_root_at_block_hash`: probe BuildUnit. -/
+def ziskParentBeaconBlockRootAtBlockHashPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t4, 0x40000000\n" ++
+  "  ld a2, 8(t4)                # witness_headers_len\n" ++
+  "  addi a0, t4, 16             # block_hash ptr\n" ++
+  "  addi a1, t4, 48             # witness.headers ptr\n" ++
+  "  li a3, 0xa0010008           # 32 B parent_beacon_block_root out\n" ++
+  "  jal ra, parent_beacon_block_root_at_block_hash\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lpbrbh_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  headerExtractParentBeaconBlockRootFunction ++ "\n" ++
+  parentBeaconBlockRootAtBlockHashFunction ++ "\n" ++
+  ".Lpbrbh_pdone:"
+
+def ziskParentBeaconBlockRootAtBlockHashDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "hepbbr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hepbbr_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "pbrbh_match_offset:\n" ++
+  "  .zero 8\n" ++
+  "pbrbh_match_length:\n" ++
+  "  .zero 8"
+
+def ziskParentBeaconBlockRootAtBlockHashProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskParentBeaconBlockRootAtBlockHashPrologue
+  dataAsm     := ziskParentBeaconBlockRootAtBlockHashDataSection
+}
+
+end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **417**
-- ziskemu round-trip scripts: **408** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **418**
+- ziskemu round-trip scripts: **409** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-parent-beacon-block-root-at-block-hash-check.sh
+++ b/scripts/codegen-zisk-parent-beacon-block-root-at-block-hash-check.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# codegen-zisk-parent-beacon-block-root-at-block-hash-check.sh
+#
+# Hash-keyed EIP-4788 historical header.parent_beacon_block_root
+# extractor (RLP field 19, Cancun+). Mirror of the number-keyed
+# `parent_beacon_block_root_at_block_number` but takes a 32-byte
+# block_hash key.
+#
+# Output (40 bytes):
+#   bytes  0.. 8 : status (0 ok, 1 hash miss, 2 RLP fail)
+#   bytes  8..40 : parent_beacon_block_root (32 B; zero on failure)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_parent_beacon_block_root_at_block_hash ELF"
+lake exe codegen --program zisk_parent_beacon_block_root_at_block_hash \
+  --halt linux93 \
+  -o gen-out/zisk_parent_beacon_block_root_at_block_hash
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_pbrbh_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_pbrbh_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_pbrbh_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0: return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset); offset += len(e)
+    for e in elements: section += e
+    return section
+
+# 20-field Amsterdam header with field 19 = parent_beacon_block_root.
+def encode_header(state_root, parent_beacon_block_root, n_fields=20):
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x44'*32,
+        b'\\x55'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+        b'',                       # base_fee_per_gas
+        b'\\x66'*32,               # withdrawals_root
+        b'',                       # blob_gas_used
+        b'',                       # excess_blob_gas
+        parent_beacon_block_root,  # field 19
+    ]
+    return rlp.encode(fields[:n_fields])
+
+mode = '$mode'
+
+if mode == 'distinct_pbbr':
+    pbbr = bytes(range(32))
+    h0 = encode_header(b'\\xaa'*32, pbbr)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = struct.pack('<Q', 0) + pbbr
+elif mode == 'two_headers_pick_second':
+    pbbr0 = b'\\x77'*32
+    pbbr1 = bytes(range(31, -1, -1))
+    h0 = encode_header(b'\\xaa'*32, pbbr0)
+    h1 = encode_header(b'\\xbb'*32, pbbr1)
+    witness_headers = build_ssz_section([h0, h1])
+    block_hash = k256(h1)
+    expected = struct.pack('<Q', 0) + pbbr1
+elif mode == 'block_hash_miss':
+    h0 = encode_header(b'\\xaa'*32, b'\\xbe'*32)
+    witness_headers = build_ssz_section([h0])
+    block_hash = b'\\xee'*32
+    expected = struct.pack('<Q', 1) + b'\\x00'*32
+elif mode == 'rlp_field_size_mismatch':
+    # 33-byte field 19 forces size != 32 path
+    h0 = encode_header(b'\\xaa'*32, b'\\xbb'*33)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = struct.pack('<Q', 2) + b'\\x00'*32
+elif mode == 'pre_cancun_field_absent':
+    # 19-field (pre-Cancun-ish) header; field 19 absent entirely.
+    h0 = encode_header(b'\\xaa'*32, b'\\xbb'*32, n_fields=19)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = struct.pack('<Q', 2) + b'\\x00'*32
+else:
+    raise SystemExit('bad mode: ' + mode)
+
+with open(sys.argv[1], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(witness_headers))
+        + block_hash
+        + witness_headers
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_parent_beacon_block_root_at_block_hash.elf \
+    -i "$in_file" -o "$out_file" -n 6000000 \
+    >"$REPO_ROOT/gen-out/zisk_pbrbh_${name}.emu.log" 2>&1 || true
+
+  local exp_size
+  exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-40s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-40s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "distinct_pbbr"                    distinct_pbbr || FAILED=1
+run_case "two_headers_pick_second"          two_headers_pick_second || FAILED=1
+run_case "block_hash_miss_status_1"         block_hash_miss || FAILED=1
+run_case "rlp_field_size_mismatch_status_2" rlp_field_size_mismatch || FAILED=1
+run_case "pre_cancun_field_absent_status_2" pre_cancun_field_absent || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: parent_beacon_block_root_at_block_hash end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Hash-keyed EIP-4788 `header.parent_beacon_block_root` extractor (RLP field 19, 32 B; Cancun+). Mirror of `parent_beacon_block_root_at_block_number` but takes a 32-byte `block_hash` key.
- Pipeline composes K19 `witness_lookup_by_hash` + existing K281 `header_extract_parent_beacon_block_root` — **no new asm helpers**.
- Unlocks beacon-root bridge attestation directly from `(block_hash, beacon_root)` claims without first translating block_hash to a block_number.

## Status codes
- `0` success
- `1` block_hash not in `witness.headers`
- `2` matched header parent_beacon_block_root extraction failed (RLP malformed / field 19 absent (pre-Cancun) / size ≠ 32)

## Test plan
- [x] `scripts/codegen-zisk-parent-beacon-block-root-at-block-hash-check.sh` — 5 fixtures pass:
  - `distinct_pbbr` (status=0)
  - `two_headers_pick_second` (proves hash-keyed lookup walks past head)
  - `block_hash_miss_status_1`
  - `rlp_field_size_mismatch_status_2` (33-byte field 19 → size-check branch)
  - `pre_cancun_field_absent_status_2` (19-field header → field 19 missing → parse_fail surfaced as status=2)
- [x] `lake build codegen` clean (no new sorries / no new axioms)
- [x] All existing fixtures still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)