### PR TITLE
feat(divmod): v5 MOD unconditional scaffold + modStackDispatchPostV5

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -86,6 +86,7 @@ import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0LaneFirstDigit
 import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0LaneRest
 import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5
 import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Div
+import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Mod
 import EvmAsm.Evm64.DivMod.Spec.N4Carry2OfNamed
 import EvmAsm.Evm64.DivMod.Spec.N4V5QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N4QHatBound

--- a/EvmAsm/Evm64/DivMod/Spec/UnconditionalScaffoldV5Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/UnconditionalScaffoldV5Mod.lean
@@ -1,0 +1,88 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Mod
+
+  The v5 MOD unconditional scaffold — the MOD mirror of
+  `UnconditionalScaffoldV5Div`.  Over `modCode_noNop_v5` (the v5 MOD code
+  surface, which contains the MOD epilogue block the MOD path executes), with
+  the dispatch post carrying the extra `memOwn (sp+3936)` the v5 div128 loop
+  owns (`modStackDispatchPostV5`) and the pre carrying the matching `sp+3936`
+  scratch cell.  Same `DivisorLimbCase.elim_named` case-split as the DIV
+  scaffold; the dispatch pre `divModStackDispatchPreNoX1` is shared between
+  DIV and MOD.  Bead `evm-asm-wbc4i.10.3`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5
+import EvmAsm.Evm64.DivMod.Spec.UnifiedBzero
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v5 MOD stack-dispatch post: the standard MOD post plus the extra `sp+3936`
+    div128-scratch cell the v5 loop owns. -/
+def modStackDispatchPostV5 (sp : Word) (a b : EvmWord) : Assertion :=
+  modStackDispatchPost sp a b ** memOwn (sp + signExtend12 3936)
+
+/-- v5 MOD unconditional spec from the five divisor-shape lanes, over the actual
+    MOD code surface `modCode_noNop_v5` with the v5 dispatch post. -/
+theorem evm_mod_stack_spec_unconditional_of_lanes_v5_mod
+    (sp base : Word) (a b : EvmWord)
+    (x9Val raVal v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (lane_bzero : b = 0 →
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v5 base)
+        (divModStackDispatchPreNoX1 sp a b x9Val raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+         ((sp + signExtend12 3936) ↦ₘ scratchMem))
+        (modStackDispatchPostV5 sp a b))
+    (lane_n1 : N1ShapeIs b →
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v5 base)
+        (divModStackDispatchPreNoX1 sp a b x9Val raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+         ((sp + signExtend12 3936) ↦ₘ scratchMem))
+        (modStackDispatchPostV5 sp a b))
+    (lane_n2 : N2ShapeIs b →
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v5 base)
+        (divModStackDispatchPreNoX1 sp a b x9Val raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+         ((sp + signExtend12 3936) ↦ₘ scratchMem))
+        (modStackDispatchPostV5 sp a b))
+    (lane_n3 : N3ShapeIs b →
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v5 base)
+        (divModStackDispatchPreNoX1 sp a b x9Val raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+         ((sp + signExtend12 3936) ↦ₘ scratchMem))
+        (modStackDispatchPostV5 sp a b))
+    (lane_n4 : N4ShapeIs b →
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v5 base)
+        (divModStackDispatchPreNoX1 sp a b x9Val raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+         ((sp + signExtend12 3936) ↦ₘ scratchMem))
+        (modStackDispatchPostV5 sp a b)) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b x9Val raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostV5 sp a b) := by
+  refine DivisorLimbCase.elim_named
+    (P := fun b' => cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b' x9Val raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostV5 sp a b'))
+    b ?bzero ?n1 ?n2 ?n3 ?n4
+  case bzero => exact lane_bzero
+  case n1 => exact lane_n1
+  case n2 => exact lane_n2
+  case n3 => exact lane_n3
+  case n4 => exact lane_n4
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

The MOD mirror of the DIV unconditional scaffold (`UnconditionalScaffoldV5Div`), kicking off the MOD v5 closure (`evm-asm-wbc4i.10.3`). In `Spec/UnconditionalScaffoldV5Mod.lean`:

- `modStackDispatchPostV5 sp a b := modStackDispatchPost sp a b ** memOwn (sp + signExtend12 3936)` — mirror of `divStackDispatchPostV5`.
- `evm_mod_stack_spec_unconditional_of_lanes_v5_mod` — the v5 MOD dispatch triple over `modCode_noNop_v5` from the five divisor-shape lanes (bzero/n1/n2/n3/n4), routed by the same `DivisorLimbCase.elim_named` case-split as the DIV scaffold.

DIV and MOD **share** the dispatch pre `divModStackDispatchPreNoX1` and the entire loop; only the code surface (`modCode_noNop_v5`) and the post (`modStackDispatchPostV5`, remainder) differ.

## Verification
- `lake build EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Mod` ✔ + aggregator `EvmAsm.Evm64.DivMod` ✔
- `scripts/check-unimported.sh` ✔ (0 orphans)
- `#print axioms evm_mod_stack_spec_unconditional_of_lanes_v5_mod` → `propext, Classical.choice, Quot.sound` only (pure routing)
- no `sorry` / `native_decide` / `bv_decide`

Scaffold piece (.10.3.1) of the MOD closure; the per-shape MOD lanes (.10.3.2) and assembly/capstone (.10.3.3) plug into it.

Bead evm-asm-wbc4i.10.3.

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)