### PR TITLE
feat(stateless): difficulty_at_block_hash primitive (+ lakefile fbracket fix)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -192,6 +192,7 @@ import EvmAsm.Codegen.Programs.TxSigningHash
 import EvmAsm.Codegen.Programs.Withdrawal
 import EvmAsm.Codegen.Programs.Address
 import EvmAsm.Codegen.Programs.ParentBeaconBlockRootAtBlockHash
+import EvmAsm.Codegen.Programs.DifficultyAtBlockHash
 
 namespace EvmAsm.Codegen
 
@@ -580,6 +581,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_parent_keccak_matches_child_parent_hash" => some ziskParentKeccakMatchesChildParentHashProbeUnit
   | "zisk_balance_at_block_hash_address" => some ziskBalanceAtBlockHashAddressProbeUnit
   | "zisk_parent_beacon_block_root_at_block_hash" => some ziskParentBeaconBlockRootAtBlockHashProbeUnit
+  | "zisk_difficulty_at_block_hash" => some ziskDifficultyAtBlockHashProbeUnit
   | "zisk_slot_at_index"        => some ziskSlotAtIndexProbeUnit
   | "zisk_rlp_encode_uint_be"   => some ziskRlpEncodeUintBeProbeUnit
   | "zisk_rlp_encode_bytes"     => some ziskRlpEncodeBytesProbeUnit
@@ -833,6 +835,7 @@ def knownProgramNames : List String :=
    "zisk_parent_keccak_matches_child_parent_hash",
    "zisk_balance_at_block_hash_address",
    "zisk_parent_beacon_block_root_at_block_hash",
+   "zisk_difficulty_at_block_hash",
    "zisk_slot_at_index",
    "zisk_rlp_encode_uint_be",
    "zisk_rlp_encode_bytes",

--- a/EvmAsm/Codegen/Programs/DifficultyAtBlockHash.lean
+++ b/EvmAsm/Codegen/Programs/DifficultyAtBlockHash.lean
@@ -1,0 +1,147 @@
+/-
+  EvmAsm.Codegen.Programs.DifficultyAtBlockHash
+
+  Hash-keyed `header.difficulty` extractor (RLP field 7,
+  u64). Mirror of the number-keyed
+  `difficulty_at_block_number` probe but takes a block_hash
+  key.
+
+  Per EIP-3675, post-merge canonical headers have
+  `difficulty = 0`; pre-merge headers may have a full
+  uint256 -- this thin wrapper only handles values that
+  fit in u64.
+
+  No proofs yet -- codegen `String` defs only.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.Mpt
+import EvmAsm.Codegen.Programs.HashBridge
+import EvmAsm.Codegen.Programs.HeaderU64
+import EvmAsm.Codegen.Programs.Tx
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Program
+
+/-! ## difficulty_at_block_hash
+
+    Hash-keyed extractor for `header.block.difficulty`
+    (RLP field 7, u64).
+
+    Pipeline (composes K19 + existing
+    header_extract_difficulty; no new helpers):
+      witness.headers ∋ ?h with keccak(h) == block_hash  [K19]
+      h -> header_extract_difficulty -> u64
+
+    Spec-defining check: per EIP-3675 (the Merge),
+    every post-merge canonical header satisfies
+    `difficulty == 0`. Reading difficulty hash-keyed lets a
+    bridge / light-client verify that invariant
+    without first translating block_hash to a block_number.
+
+    Calling convention (4 args):
+      a0 (input)  : block_hash ptr (32 bytes)
+      a1 (input)  : witness.headers ptr
+      a2 (input)  : witness.headers len
+      a3 (input)  : u64 difficulty out ptr
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success (difficulty u64 written)
+        1 = block_hash not in witness.headers
+        2 = matched header difficulty extraction failed
+            (RLP malformed / field 7 > 8 bytes BE)
+-/
+def difficultyAtBlockHashFunction : String :=
+  "difficulty_at_block_hash:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0                  # block_hash ptr\n" ++
+  "  mv s1, a1                  # witness.headers ptr\n" ++
+  "  mv s2, a2                  # witness.headers len\n" ++
+  "  mv s3, a3                  # difficulty u64 out\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  mv a0, s1\n" ++
+  "  mv a1, s2\n" ++
+  "  mv a2, s0\n" ++
+  "  la a3, dfbh_match_offset\n" ++
+  "  la a4, dfbh_match_length\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  bnez a0, .Ldfbh_no_match\n" ++
+  "  la t0, dfbh_match_offset\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  add s4, s1, t1\n" ++
+  "  la t0, dfbh_match_length\n" ++
+  "  ld s5, 0(t0)\n" ++
+  "  mv a0, s4\n" ++
+  "  mv a1, s5\n" ++
+  "  mv a2, s3\n" ++
+  "  jal ra, header_extract_difficulty\n" ++
+  "  beqz a0, .Ldfbh_ret\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  li a0, 2\n" ++
+  "  j .Ldfbh_ret\n" ++
+  ".Ldfbh_no_match:\n" ++
+  "  li a0, 1\n" ++
+  ".Ldfbh_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_difficulty_at_block_hash`: probe BuildUnit.
+    Output layout (16 bytes):
+      bytes  0.. 8 : status (0..2)
+      bytes  8..16 : difficulty u64 LE (0 on failure) -/
+def ziskDifficultyAtBlockHashPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t4, 0x40000000\n" ++
+  "  ld a2, 8(t4)                # witness_headers_len\n" ++
+  "  addi a0, t4, 16             # block_hash ptr\n" ++
+  "  addi a1, t4, 48             # witness.headers ptr\n" ++
+  "  li a3, 0xa0010008           # u64 difficulty out\n" ++
+  "  jal ra, difficulty_at_block_hash\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Ldfbh_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  headerExtractDifficultyFunction ++ "\n" ++
+  difficultyAtBlockHashFunction ++ "\n" ++
+  ".Ldfbh_pdone:"
+
+def ziskDifficultyAtBlockHashDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "dfbh_match_offset:\n" ++
+  "  .zero 8\n" ++
+  "dfbh_match_length:\n" ++
+  "  .zero 8"
+
+def ziskDifficultyAtBlockHashProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskDifficultyAtBlockHashPrologue
+  dataAsm     := ziskDifficultyAtBlockHashDataSection
+}
+
+end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **442**
-- ziskemu round-trip scripts: **433** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **443**
+- ziskemu round-trip scripts: **434** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **439**
-- ziskemu round-trip scripts: **430** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **440**
+- ziskemu round-trip scripts: **431** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **444**
-- ziskemu round-trip scripts: **435** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **445**
+- ziskemu round-trip scripts: **436** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **443**
-- ziskemu round-trip scripts: **434** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **444**
+- ziskemu round-trip scripts: **435** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **441**
-- ziskemu round-trip scripts: **432** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **442**
+- ziskemu round-trip scripts: **433** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **446**
-- ziskemu round-trip scripts: **437** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **447**
+- ziskemu round-trip scripts: **438** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **447**
-- ziskemu round-trip scripts: **438** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **448**
+- ziskemu round-trip scripts: **439** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **445**
-- ziskemu round-trip scripts: **436** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **446**
+- ziskemu round-trip scripts: **437** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **440**
-- ziskemu round-trip scripts: **431** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **441**
+- ziskemu round-trip scripts: **432** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -15,6 +15,11 @@ rev = "main"
 
 [[lean_lib]]
 name = "EvmAsm"
+# clang's default -fbracket-depth=256 trips on the deeply-nested
+# C ternary chain that Lean emits for the `lookupProgram` /
+# `lookupProgramTail` `match` cascade.  Each new probe arm adds
+# one bracket layer; we already brush the limit at ~240 arms.
+moreLeancArgs = ["-fbracket-depth=4096"]
 
 [[lean_exe]]
 name = "codegen"

--- a/scripts/codegen-zisk-difficulty-at-block-hash-check.sh
+++ b/scripts/codegen-zisk-difficulty-at-block-hash-check.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# codegen-zisk-difficulty-at-block-hash-check.sh
+#
+# Hash-keyed historical header.difficulty extractor (RLP
+# field 7, u64). Mirror of the number-keyed
+# `difficulty_at_block_number` but takes a 32-byte
+# block_hash key.
+#
+# Spec-defining check: per EIP-3675 (the Merge), every
+# post-merge canonical header MUST have difficulty == 0.
+# A non-zero difficulty at the block_hash flags either a
+# pre-merge ancestor or a malformed witness.
+#
+# Output (16 bytes):
+#   bytes  0.. 8 : status (0 ok, 1 hash miss, 2 RLP fail / overflow)
+#   bytes  8..16 : difficulty u64 LE (0 on failure)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_difficulty_at_block_hash ELF"
+lake exe codegen --program zisk_difficulty_at_block_hash \
+  --halt linux93 \
+  -o gen-out/zisk_difficulty_at_block_hash
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_dfbh_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_dfbh_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_dfbh_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0: return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset); offset += len(e)
+    for e in elements: section += e
+    return section
+
+def be_min(val):
+    if val == 0: return b''
+    nbytes = (val.bit_length() + 7) // 8
+    return val.to_bytes(nbytes, 'big')
+
+def encode_header(state_root, difficulty_val):
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x44'*32,
+        b'\\x55'*32, b'\\x00'*256, be_min(difficulty_val), b'\\x01',
+        b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+        b'', b'\\x66'*32, b'', b'', b'\\x99'*32,
+    ]
+    return rlp.encode(fields)
+
+def encode_header_raw_diff(state_root, diff_bytes):
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x44'*32,
+        b'\\x55'*32, b'\\x00'*256, diff_bytes, b'\\x01',
+        b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+        b'', b'\\x66'*32, b'', b'', b'\\x99'*32,
+    ]
+    return rlp.encode(fields)
+
+mode = '$mode'
+
+if mode == 'post_merge_zero':
+    h0 = encode_header(b'\\xaa'*32, 0)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', 0)
+elif mode == 'pre_merge_small_difficulty':
+    diff = 0x1A2B3C4D5E6F
+    h0 = encode_header(b'\\xaa'*32, diff)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', diff)
+elif mode == 'pre_merge_u64_max':
+    diff = (1 << 64) - 1
+    h0 = encode_header(b'\\xaa'*32, diff)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', diff)
+elif mode == 'pre_merge_u256_overflow':
+    # 9-byte difficulty exceeds u64; helper must return status=2.
+    h0 = encode_header_raw_diff(b'\\xaa'*32, b'\\x01' + b'\\x00'*8)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = struct.pack('<Q', 2) + struct.pack('<Q', 0)
+elif mode == 'two_headers_pick_second':
+    h0 = encode_header(b'\\xaa'*32, 0xDEAD)
+    h1 = encode_header(b'\\xbb'*32, 0)
+    witness_headers = build_ssz_section([h0, h1])
+    block_hash = k256(h1)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', 0)
+elif mode == 'block_hash_miss':
+    h0 = encode_header(b'\\xaa'*32, 0)
+    witness_headers = build_ssz_section([h0])
+    block_hash = b'\\xee'*32
+    expected = struct.pack('<Q', 1) + struct.pack('<Q', 0)
+else:
+    raise SystemExit('bad mode: ' + mode)
+
+with open(sys.argv[1], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(witness_headers))
+        + block_hash
+        + witness_headers
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_difficulty_at_block_hash.elf \
+    -i "$in_file" -o "$out_file" -n 6000000 \
+    >"$REPO_ROOT/gen-out/zisk_dfbh_${name}.emu.log" 2>&1 || true
+
+  local exp_size
+  exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-40s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-40s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "post_merge_zero"                  post_merge_zero || FAILED=1
+run_case "pre_merge_small_difficulty"       pre_merge_small_difficulty || FAILED=1
+run_case "pre_merge_u64_max"                pre_merge_u64_max || FAILED=1
+run_case "pre_merge_u256_overflow_status_2" pre_merge_u256_overflow || FAILED=1
+run_case "two_headers_pick_second"          two_headers_pick_second || FAILED=1
+run_case "block_hash_miss_status_1"         block_hash_miss || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: difficulty_at_block_hash end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Hash-keyed `header.difficulty` extractor (RLP field 7, u64). Mirror of `difficulty_at_block_number` but takes a 32-byte `block_hash` key.
- Pipeline composes K19 `witness_lookup_by_hash` + existing K215 `header_extract_difficulty` — **no new asm helpers**.
- **Build fix bundled in**: `lakefile.toml` gains `moreLeancArgs = ["-fbracket-depth=4096"]` on the EvmAsm library. The `lookupProgram` / `lookupProgramTail` match cascade now brushes clang's default 256-deep ternary nesting limit; without this flag a fresh build of `EvmAsm.Codegen.Programs` was failing with `bracket nesting level exceeded maximum of 256`.

## Spec-defining check
Per EIP-3675 (the Merge), every post-merge canonical header has `difficulty == 0`. A non-zero value at the block_hash flags a pre-merge ancestor or a malformed witness. The `post_merge_zero` fixture asserts this invariant directly from block_hash.

## Status codes
- `0` success
- `1` block_hash not in `witness.headers`
- `2` matched header difficulty extraction failed (RLP malformed / field 7 > 8 bytes BE — pre-merge u256 difficulty too wide)

## Test plan
- [x] `scripts/codegen-zisk-difficulty-at-block-hash-check.sh` — 6 fixtures pass:
  - `post_merge_zero` (EIP-3675 invariant)
  - `pre_merge_small_difficulty` (0x1A2B3C4D5E6F)
  - `pre_merge_u64_max` (u64::MAX still surfaces as status=0)
  - `pre_merge_u256_overflow_status_2` (9-byte difficulty → status=2)
  - `two_headers_pick_second`
  - `block_hash_miss_status_1`
- [x] `lake build codegen` clean with the new `-fbracket-depth=4096` flag (was broken on plain `main` for the same nesting-limit reason)
- [x] All existing fixtures still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)