### PR TITLE
feat(stateless): header_nonce_at_block_hash primitive (+ lakefile fbracket fix)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -202,6 +202,7 @@ import EvmAsm.Codegen.Programs.TxSigningHash
 import EvmAsm.Codegen.Programs.Withdrawal
 import EvmAsm.Codegen.Programs.Address
 import EvmAsm.Codegen.Programs.ParentBeaconBlockRootAtBlockHash
+import EvmAsm.Codegen.Programs.HeaderNonceAtBlockHash
 
 namespace EvmAsm.Codegen
 
@@ -438,6 +439,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_ssz_hash_tree_root_bytes" => some ziskSszHashTreeRootBytesProbeUnit
   | "zisk_ssz_hash_tree_root_list_bytelist" => some ziskSszHashTreeRootListByteListProbeUnit
   | "zisk_ssz_hash_tree_root_execution_witness" => some ziskSszHashTreeRootExecutionWitnessProbeUnit
+  | "zisk_header_nonce_at_block_hash" => some ziskHeaderNonceAtBlockHashProbeUnit
   | _                           => none
 
 /-- Look up a program by name. Returns `none` for unknown names so the CLI
@@ -863,6 +865,7 @@ def knownProgramNames : List String :=
    "zisk_parent_keccak_matches_child_parent_hash",
    "zisk_balance_at_block_hash_address",
    "zisk_parent_beacon_block_root_at_block_hash",
+   "zisk_header_nonce_at_block_hash",
    "zisk_slot_at_index",
    "zisk_rlp_encode_uint_be",
    "zisk_rlp_encode_bytes",

--- a/EvmAsm/Codegen/Programs/HeaderNonceAtBlockHash.lean
+++ b/EvmAsm/Codegen/Programs/HeaderNonceAtBlockHash.lean
@@ -1,0 +1,144 @@
+/-
+  EvmAsm.Codegen.Programs.HeaderNonceAtBlockHash
+
+  Hash-keyed `header.nonce` extractor (RLP field 14, exactly
+  8 bytes BE). Mirror of the number-keyed
+  `header_nonce_at_block_number` probe but takes a
+  block_hash key.
+
+  Per EIP-3675, post-merge canonical headers MUST have
+  `header.nonce = 0` (8-byte zero); this lets a bridge
+  verify the post-merge invariant directly from block_hash.
+
+  No proofs yet -- codegen `String` defs only.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.Mpt
+import EvmAsm.Codegen.Programs.HashBridge
+import EvmAsm.Codegen.Programs.HeaderU64
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Program
+
+/-! ## header_nonce_at_block_hash
+
+    Hash-keyed extractor for `header.block.nonce`
+    (RLP field 14, 8 bytes BE).
+
+    Pipeline (composes K19 + existing
+    header_extract_nonce; no new helpers):
+      witness.headers ∋ ?h with keccak(h) == block_hash  [K19]
+      h -> header_extract_nonce -> u64 (8 BE bytes -> u64 LE)
+
+    Spec-defining check: per EIP-3675 (the Merge),
+    every post-merge canonical header satisfies
+    `header.nonce == 0` (eight zero bytes BE). Reading
+    header.nonce hash-keyed lets a bridge / light-client
+    verify that invariant directly from a block_hash.
+
+    Calling convention (4 args):
+      a0 (input)  : block_hash ptr (32 bytes)
+      a1 (input)  : witness.headers ptr
+      a2 (input)  : witness.headers len
+      a3 (input)  : u64 nonce out ptr
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success (header.nonce u64 written)
+        1 = block_hash not in witness.headers
+        2 = matched header nonce extraction failed
+            (RLP malformed / field 14 size != 8)
+-/
+def headerNonceAtBlockHashFunction : String :=
+  "header_nonce_at_block_hash:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0                  # block_hash ptr\n" ++
+  "  mv s1, a1                  # witness.headers ptr\n" ++
+  "  mv s2, a2                  # witness.headers len\n" ++
+  "  mv s3, a3                  # nonce u64 out\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  mv a0, s1\n" ++
+  "  mv a1, s2\n" ++
+  "  mv a2, s0\n" ++
+  "  la a3, hnbh_match_offset\n" ++
+  "  la a4, hnbh_match_length\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  bnez a0, .Lhnbh_no_match\n" ++
+  "  la t0, hnbh_match_offset\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  add s4, s1, t1\n" ++
+  "  la t0, hnbh_match_length\n" ++
+  "  ld s5, 0(t0)\n" ++
+  "  mv a0, s4\n" ++
+  "  mv a1, s5\n" ++
+  "  mv a2, s3\n" ++
+  "  jal ra, header_extract_nonce\n" ++
+  "  beqz a0, .Lhnbh_ret\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lhnbh_ret\n" ++
+  ".Lhnbh_no_match:\n" ++
+  "  li a0, 1\n" ++
+  ".Lhnbh_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_header_nonce_at_block_hash`: probe BuildUnit.
+    Output layout (16 bytes):
+      bytes  0.. 8 : status (0..2)
+      bytes  8..16 : header.nonce u64 (BE-decoded; 0 on failure) -/
+def ziskHeaderNonceAtBlockHashPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t4, 0x40000000\n" ++
+  "  ld a2, 8(t4)                # witness_headers_len\n" ++
+  "  addi a0, t4, 16             # block_hash ptr\n" ++
+  "  addi a1, t4, 48             # witness.headers ptr\n" ++
+  "  li a3, 0xa0010008           # u64 nonce out\n" ++
+  "  jal ra, header_nonce_at_block_hash\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lhnbh_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  headerExtractNonceFunction ++ "\n" ++
+  headerNonceAtBlockHashFunction ++ "\n" ++
+  ".Lhnbh_pdone:"
+
+def ziskHeaderNonceAtBlockHashDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "hen_offset:\n" ++
+  "  .zero 8\n" ++
+  "hen_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "hnbh_match_offset:\n" ++
+  "  .zero 8\n" ++
+  "hnbh_match_length:\n" ++
+  "  .zero 8"
+
+def ziskHeaderNonceAtBlockHashProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskHeaderNonceAtBlockHashPrologue
+  dataAsm     := ziskHeaderNonceAtBlockHashDataSection
+}
+
+end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **444**
-- ziskemu round-trip scripts: **435** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **445**
+- ziskemu round-trip scripts: **436** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **443**
-- ziskemu round-trip scripts: **434** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **444**
+- ziskemu round-trip scripts: **435** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **448**
-- ziskemu round-trip scripts: **439** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **449**
+- ziskemu round-trip scripts: **440** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **446**
-- ziskemu round-trip scripts: **437** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **447**
+- ziskemu round-trip scripts: **438** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **447**
-- ziskemu round-trip scripts: **438** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **448**
+- ziskemu round-trip scripts: **439** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **445**
-- ziskemu round-trip scripts: **436** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **446**
+- ziskemu round-trip scripts: **437** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -15,6 +15,11 @@ rev = "main"
 
 [[lean_lib]]
 name = "EvmAsm"
+# clang's default -fbracket-depth=256 trips on the deeply-nested
+# C ternary chain that Lean emits for the `lookupProgram` /
+# `lookupProgramTail` `match` cascade.  Each new probe arm adds
+# one bracket layer; we already brush the limit at ~240 arms.
+moreLeancArgs = ["-fbracket-depth=4096"]
 
 [[lean_exe]]
 name = "codegen"

--- a/scripts/codegen-zisk-header-nonce-at-block-hash-check.sh
+++ b/scripts/codegen-zisk-header-nonce-at-block-hash-check.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# codegen-zisk-header-nonce-at-block-hash-check.sh
+#
+# Hash-keyed historical header.nonce extractor (RLP field
+# 14, exactly 8 bytes BE). Mirror of the number-keyed
+# `header_nonce_at_block_number` but takes a 32-byte
+# block_hash key.
+#
+# Spec-defining check: per EIP-3675 (the Merge), every
+# post-merge canonical header MUST have header.nonce
+# == 0 (8 BE zero bytes). A non-zero nonce at the
+# block_hash flags either a pre-merge ancestor or a
+# malformed witness.
+#
+# Output (16 bytes):
+#   bytes  0.. 8 : status (0 ok, 1 hash miss, 2 RLP fail)
+#   bytes  8..16 : header.nonce u64 LE (0 on failure)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_header_nonce_at_block_hash ELF"
+lake exe codegen --program zisk_header_nonce_at_block_hash \
+  --halt linux93 \
+  -o gen-out/zisk_header_nonce_at_block_hash
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_hnbh_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_hnbh_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_hnbh_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0: return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset); offset += len(e)
+    for e in elements: section += e
+    return section
+
+def encode_header(state_root, nonce_bytes):
+    # nonce_bytes: exactly 8 raw bytes; legal callers must pass 8 B.
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x44'*32,
+        b'\\x55'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, nonce_bytes,
+        b'', b'\\x66'*32, b'', b'', b'\\x99'*32,
+    ]
+    return rlp.encode(fields)
+
+mode = '$mode'
+
+if mode == 'post_merge_zero_nonce':
+    h0 = encode_header(b'\\xaa'*32, b'\\x00'*8)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', 0)
+elif mode == 'pre_merge_pow_nonce':
+    nonce_be = b'\\xCA\\xFE\\xBA\\xBE\\xDE\\xAD\\xBE\\xEF'
+    nonce_u64 = int.from_bytes(nonce_be, 'big')
+    h0 = encode_header(b'\\xaa'*32, nonce_be)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', nonce_u64)
+elif mode == 'max_u64_nonce':
+    nonce_be = b'\\xff'*8
+    h0 = encode_header(b'\\xaa'*32, nonce_be)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', (1<<64)-1)
+elif mode == 'two_headers_pick_second':
+    h0 = encode_header(b'\\xaa'*32, b'\\xDE\\xAD\\xBE\\xEF\\xDE\\xAD\\xBE\\xEF')
+    h1 = encode_header(b'\\xbb'*32, b'\\x00'*8)
+    witness_headers = build_ssz_section([h0, h1])
+    block_hash = k256(h1)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', 0)
+elif mode == 'block_hash_miss':
+    h0 = encode_header(b'\\xaa'*32, b'\\x00'*8)
+    witness_headers = build_ssz_section([h0])
+    block_hash = b'\\xee'*32
+    expected = struct.pack('<Q', 1) + struct.pack('<Q', 0)
+elif mode == 'rlp_field_size_mismatch':
+    # 7-byte nonce forces field 14 size != 8.
+    h0 = encode_header(b'\\xaa'*32, b'\\x99'*7)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = struct.pack('<Q', 2) + struct.pack('<Q', 0)
+else:
+    raise SystemExit('bad mode: ' + mode)
+
+with open(sys.argv[1], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(witness_headers))
+        + block_hash
+        + witness_headers
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_header_nonce_at_block_hash.elf \
+    -i "$in_file" -o "$out_file" -n 6000000 \
+    >"$REPO_ROOT/gen-out/zisk_hnbh_${name}.emu.log" 2>&1 || true
+
+  local exp_size
+  exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-40s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-40s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "post_merge_zero_nonce"            post_merge_zero_nonce || FAILED=1
+run_case "pre_merge_pow_nonce"              pre_merge_pow_nonce || FAILED=1
+run_case "max_u64_nonce"                    max_u64_nonce || FAILED=1
+run_case "two_headers_pick_second"          two_headers_pick_second || FAILED=1
+run_case "block_hash_miss_status_1"         block_hash_miss || FAILED=1
+run_case "rlp_field_size_mismatch_status_2" rlp_field_size_mismatch || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: header_nonce_at_block_hash end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Hash-keyed `header.nonce` extractor (RLP field 14, exactly 8 bytes BE → u64). Mirror of `header_nonce_at_block_number` but takes a 32-byte `block_hash` key.
- Pipeline composes K19 `witness_lookup_by_hash` + existing `header_extract_nonce` — **no new asm helpers**.
- **Spec-defining check**: per EIP-3675 (the Merge), every post-merge canonical header satisfies `header.nonce == 0` (8 BE zero bytes). The `post_merge_zero_nonce` fixture asserts this invariant directly from block_hash.
- **Build fix bundled in**: `lakefile.toml` gains `moreLeancArgs = ["-fbracket-depth=4096"]` on the EvmAsm library — identical to the change in still-open PR #7676; carried here so this branch builds on its own.

## Status codes
- `0` success
- `1` block_hash not in `witness.headers`
- `2` matched header nonce extraction failed (RLP malformed / field 14 size ≠ 8)

## Test plan
- [x] `scripts/codegen-zisk-header-nonce-at-block-hash-check.sh` — 6 fixtures pass:
  - `post_merge_zero_nonce` (EIP-3675 invariant)
  - `pre_merge_pow_nonce` (0xCAFEBABEDEADBEEF → matching u64 LE)
  - `max_u64_nonce` (8 BE 0xff bytes decode to (1<<64)-1)
  - `two_headers_pick_second`
  - `block_hash_miss_status_1`
  - `rlp_field_size_mismatch_status_2` (7-byte field 14)
- [x] `lake build codegen` clean with the new `-fbracket-depth=4096` flag
- [x] All existing fixtures still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)