### PR TITLE
feat(divmod): v5 MOD preloop phase-C2 bricks over modCode_noNop_v5

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/PreloopV5Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PreloopV5Mod.lean
@@ -20,6 +20,7 @@
 
 import EvmAsm.Evm64.DivMod.Compose.PhaseABV4NoNop
 import EvmAsm.Evm64.DivMod.Compose.CLZ
+import EvmAsm.Evm64.DivMod.Compose.Norm
 import EvmAsm.Evm64.DivMod.Compose.V5NoNop
 
 namespace EvmAsm.Evm64
@@ -196,5 +197,95 @@ theorem divK_clz_spec_within_v5_noNop_modCode (val v6Old v7Old : Word) (base : W
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
     IefS0eS1eS2eS3eS4eS5e
+
+-- ============================================================================
+-- Brick 3: phase-C2 (phaseC2Off → normBOff / copyAUOff) over modCode_noNop_v5.
+-- MOD mirror of `divK_phaseC2_{ntaken,taken}_spec_within_v5_noNop` (PhaseC2V5.lean).
+-- ============================================================================
+
+/-- Phase-C2 block instructions are subsumed by `modCode_noNop_v5`. -/
+private theorem divK_phaseC2_code_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (divK_phaseC2_code 172 (base + phaseC2Off)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  unfold divK_phaseC2_code
+  intro a i h
+  exact sharedNoNop_v5_b3_mod a i h
+
+/-- BEQ x6 x0 172 singleton subsumed by `modCode_noNop_v5`. -/
+private theorem beq_shift_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseC2Off + 12) (.BEQ .x6 .x0 172)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + phaseC2Off) (divK_phaseC2 172) 3
+    (by decide) (by decide)
+  rw [show (BitVec.ofNat 64 (4 * 3) : Word) = (12 : Word) from by decide] at hlookup
+  exact divK_phaseC2_code_sub_modCode_noNop_v5 a i
+    (CodeReq.singleton_mono hlookup a i h)
+
+private theorem divK_phaseC2_body_modCode_noNop_v5_within
+    (sp shift v2 shiftMem : Word) (base : Word) :
+    cpsTripleWithin 3 (base + phaseC2Off) (base + phaseC2Off + 12) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+       (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
+  have hbody := divK_phaseC2_body_spec_within sp shift v2 shiftMem 172 (base + phaseC2Off)
+  exact cpsTripleWithin_extend_code divK_phaseC2_code_sub_modCode_noNop_v5 hbody
+
+/-- v5 phase-C2 (shift ≠ 0) over `modCode_noNop_v5`: BEQ not taken → normB. -/
+theorem divK_phaseC2_ntaken_spec_within_v5_noNop_modCode (sp shift v2 shiftMem : Word) (base : Word)
+    (hshift_nz : shift ≠ 0) :
+    cpsTripleWithin 4 (base + phaseC2Off) (base + normBOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+       (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
+  have hbody := divK_phaseC2_body_modCode_noNop_v5_within sp shift v2 shiftMem base
+  have hbeq_raw := beq_spec_gen_within .x6 .x0 172 shift (0 : Word) (base + phaseC2Off + 12)
+  rw [show (base + phaseC2Off + 12 : Word) + signExtend13 172 = base + copyAUOff from by rv64_addr,
+      show (base + phaseC2Off + 12 : Word) + 4 = base + normBOff from by bv_addr] at hbeq_raw
+  have hbeq_clean := cpsBranchWithin_ntakenStripPure2 hbeq_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 (show shift ≠ (0 : Word) from hshift_nz))
+  have hbeq := cpsTripleWithin_extend_code beq_shift_sub_modCode_noNop_v5 hbeq_clean
+  have hbeqf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hbeq
+  have hC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hbody hbeqf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hC2
+
+/-- v5 phase-C2 (shift = 0) over `modCode_noNop_v5`: BEQ taken → copyAU. -/
+theorem divK_phaseC2_taken_spec_within_v5_noNop_modCode (sp shift v2 shiftMem : Word) (base : Word)
+    (hshift_z : shift = 0) :
+    cpsTripleWithin 4 (base + phaseC2Off) (base + copyAUOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+       (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
+  have hbody := divK_phaseC2_body_modCode_noNop_v5_within sp shift v2 shiftMem base
+  have hbeq_raw := beq_spec_gen_within .x6 .x0 172 shift (0 : Word) (base + phaseC2Off + 12)
+  rw [show (base + phaseC2Off + 12 : Word) + signExtend13 172 = base + copyAUOff from by rv64_addr,
+      show (base + phaseC2Off + 12 : Word) + 4 = base + normBOff from by bv_addr] at hbeq_raw
+  have hbeq_clean := cpsBranchWithin_takenStripPure2 hbeq_raw
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
+      exact absurd hshift_z ((sepConj_pure_right _).mp h_rest).2)
+  have hbeq := cpsTripleWithin_extend_code beq_shift_sub_modCode_noNop_v5 hbeq_clean
+  have hbeqf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hbeq
+  have hC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hbody hbeqf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hC2
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Append `divK_phaseC2_{ntaken,taken}_spec_within_v5_noNop_modCode` to `Compose/PreloopV5Mod.lean` — the phase-C2 preloop brick (both `shift≠0 → normB` and `shift=0 → copyAU` paths) re-pointed from `divCode_noNop_v5` to `modCode_noNop_v5` via `sharedNoNop_v5_b3_mod` (MOD mirror of `PhaseC2V5.lean`).
- Brick 3 of the MOD preloop re-point (bead `.10.3.2.4.5`); same mechanical `_div → _mod` pattern.
- Builds green; axiom-clean.

Stacked on #7681. Remaining preloop bricks: normB, normA, copyAU, loopSetup.

Refs #61. Bead: evm-asm-wbc4i.10.3.2.4.5.

Authored by @pirapira; implemented by Claude Code