### PR TITLE
feat(stateless): extra_data_at_block_hash primitive (+ lakefile fbracket fix)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -208,6 +208,7 @@ import EvmAsm.Codegen.Programs.TransactionsRootAtBlockHash
 import EvmAsm.Codegen.Programs.ReceiptsRootAtBlockHash
 import EvmAsm.Codegen.Programs.WithdrawalsRootAtBlockHash
 import EvmAsm.Codegen.Programs.PrevRandaoAtBlockHash
+import EvmAsm.Codegen.Programs.ExtraDataAtBlockHash
 
 namespace EvmAsm.Codegen
 
@@ -444,6 +445,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_ssz_hash_tree_root_bytes" => some ziskSszHashTreeRootBytesProbeUnit
   | "zisk_ssz_hash_tree_root_list_bytelist" => some ziskSszHashTreeRootListByteListProbeUnit
   | "zisk_ssz_hash_tree_root_execution_witness" => some ziskSszHashTreeRootExecutionWitnessProbeUnit
+  | "zisk_extra_data_at_block_hash" => some ziskExtraDataAtBlockHashProbeUnit
   | _                           => none
 
 /-- Look up a program by name. Returns `none` for unknown names so the CLI
@@ -881,6 +883,7 @@ def knownProgramNames : List String :=
    "zisk_receipts_root_at_block_hash",
    "zisk_withdrawals_root_at_block_hash",
    "zisk_prev_randao_at_block_hash",
+   "zisk_extra_data_at_block_hash",
    "zisk_slot_at_index",
    "zisk_rlp_encode_uint_be",
    "zisk_rlp_encode_bytes",

--- a/EvmAsm/Codegen/Programs/ExtraDataAtBlockHash.lean
+++ b/EvmAsm/Codegen/Programs/ExtraDataAtBlockHash.lean
@@ -1,0 +1,150 @@
+/-
+  EvmAsm.Codegen.Programs.ExtraDataAtBlockHash
+
+  Hash-keyed `header.extra_data` extractor (RLP field 12,
+  variable length up to 32 bytes per EIP-3675). Mirror of
+  the number-keyed `extra_data_at_block_number` probe but
+  takes a 32-byte block_hash key.
+
+  No proofs yet -- codegen `String` defs only.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.Mpt
+import EvmAsm.Codegen.Programs.HashBridge
+import EvmAsm.Codegen.Programs.HeaderU64
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Program
+
+/-! ## extra_data_at_block_hash
+
+    Hash-keyed extractor for `header.block.extra_data`
+    (RLP field 12, ≤ 32 B per EIP-3675).
+
+    Pipeline (composes K19 + existing
+    header_extract_extra_data; no new helpers):
+      witness.headers ∋ ?h with keccak(h) == block_hash  [K19]
+      h -> header_extract_extra_data -> (length, ≤32 bytes)
+
+    Use cases unique to the hash-keyed variant:
+      * Proposer-tag attestation -- block_hash is known
+        (e.g. from a finality proof) and the off-chain
+        observer wants the validator-signed proposer
+        identification bytes.
+      * EIP-3675 size invariant audit at a specific
+        block_hash without first translating to a number.
+      * Cross-witness extra_data consistency.
+
+    Calling convention (5 args):
+      a0 (input)  : block_hash ptr (32 bytes)
+      a1 (input)  : witness.headers ptr
+      a2 (input)  : witness.headers len
+      a3 (input)  : extra_data bytes out ptr (≥ 32 B)
+      a4 (input)  : u64 out (extra_data length)
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success (length written; bytes copied)
+        1 = block_hash not in witness.headers
+        2 = matched header extra_data extraction failed
+            (RLP malformed / field 12 length > 32)
+-/
+def extraDataAtBlockHashFunction : String :=
+  "extra_data_at_block_hash:\n" ++
+  "  addi sp, sp, -80\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  mv s0, a0                  # block_hash ptr\n" ++
+  "  mv s1, a1                  # witness.headers ptr\n" ++
+  "  mv s2, a2                  # witness.headers len\n" ++
+  "  mv s3, a3                  # extra_data bytes out\n" ++
+  "  mv s7, a4                  # u64 length out\n" ++
+  "  sd zero, 0(s7)\n" ++
+  "  sd zero,  0(s3); sd zero,  8(s3); sd zero, 16(s3); sd zero, 24(s3)\n" ++
+  "  mv a0, s1\n" ++
+  "  mv a1, s2\n" ++
+  "  mv a2, s0\n" ++
+  "  la a3, edbh_match_offset\n" ++
+  "  la a4, edbh_match_length\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  bnez a0, .Ledbh_no_match\n" ++
+  "  la t0, edbh_match_offset\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  add s4, s1, t1\n" ++
+  "  la t0, edbh_match_length\n" ++
+  "  ld s5, 0(t0)\n" ++
+  "  mv a0, s4\n" ++
+  "  mv a1, s5\n" ++
+  "  mv a2, s3\n" ++
+  "  mv a3, s7\n" ++
+  "  jal ra, header_extract_extra_data\n" ++
+  "  beqz a0, .Ledbh_ret\n" ++
+  "  sd zero, 0(s7)\n" ++
+  "  sd zero,  0(s3); sd zero,  8(s3); sd zero, 16(s3); sd zero, 24(s3)\n" ++
+  "  li a0, 2\n" ++
+  "  j .Ledbh_ret\n" ++
+  ".Ledbh_no_match:\n" ++
+  "  li a0, 1\n" ++
+  ".Ledbh_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  addi sp, sp, 80\n" ++
+  "  ret"
+
+/-- `zisk_extra_data_at_block_hash`: probe BuildUnit.
+    Output layout (48 bytes):
+      bytes  0.. 8 : status (0..2)
+      bytes  8..16 : extra_data length (u64 LE)
+      bytes 16..48 : extra_data bytes (≤ 32, zero-padded) -/
+def ziskExtraDataAtBlockHashPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t4, 0x40000000\n" ++
+  "  ld a2, 8(t4)                # witness_headers_len\n" ++
+  "  addi a0, t4, 16             # block_hash ptr\n" ++
+  "  addi a1, t4, 48             # witness.headers ptr\n" ++
+  "  li a3, 0xa0010010           # 32 B extra_data bytes out\n" ++
+  "  li a4, 0xa0010008           # u64 length out\n" ++
+  "  jal ra, extra_data_at_block_hash\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Ledbh_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  headerExtractExtraDataFunction ++ "\n" ++
+  extraDataAtBlockHashFunction ++ "\n" ++
+  ".Ledbh_pdone:"
+
+def ziskExtraDataAtBlockHashDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "heed_offset:\n" ++
+  "  .zero 8\n" ++
+  "heed_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "edbh_match_offset:\n" ++
+  "  .zero 8\n" ++
+  "edbh_match_length:\n" ++
+  "  .zero 8"
+
+def ziskExtraDataAtBlockHashProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskExtraDataAtBlockHashPrologue
+  dataAsm     := ziskExtraDataAtBlockHashDataSection
+}
+
+end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **449**
-- ziskemu round-trip scripts: **441** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **450**
+- ziskemu round-trip scripts: **442** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -15,6 +15,11 @@ rev = "main"
 
 [[lean_lib]]
 name = "EvmAsm"
+# clang's default -fbracket-depth=256 trips on the deeply-nested
+# C ternary chain that Lean emits for the `lookupProgram` /
+# `lookupProgramTail` `match` cascade.  Each new probe arm adds
+# one bracket layer; we already brush the limit at ~240 arms.
+moreLeancArgs = ["-fbracket-depth=4096"]
 
 [[lean_exe]]
 name = "codegen"

--- a/scripts/codegen-zisk-extra-data-at-block-hash-check.sh
+++ b/scripts/codegen-zisk-extra-data-at-block-hash-check.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# codegen-zisk-extra-data-at-block-hash-check.sh
+#
+# Hash-keyed historical header.extra_data extractor (RLP
+# field 12, ≤ 32 B). Mirror of the number-keyed
+# `extra_data_at_block_number` but takes a 32-byte
+# block_hash key.
+#
+# Output (48 bytes):
+#   bytes  0.. 8 : status (0 ok, 1 hash miss, 2 RLP fail / oversized)
+#   bytes  8..16 : extra_data length (u64 LE; 0 on failure)
+#   bytes 16..48 : extra_data bytes (zero-padded; 0 on failure)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_extra_data_at_block_hash ELF"
+lake exe codegen --program zisk_extra_data_at_block_hash \
+  --halt linux93 \
+  -o gen-out/zisk_extra_data_at_block_hash
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_edbh_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_edbh_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_edbh_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0: return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset); offset += len(e)
+    for e in elements: section += e
+    return section
+
+def encode_header(state_root, extra_data_bytes):
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x44'*32,
+        b'\\x55'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', extra_data_bytes, b'\\x77'*32,
+        b'\\x00'*8,
+        b'', b'\\x66'*32, b'', b'', b'\\x99'*32,
+    ]
+    return rlp.encode(fields)
+
+mode = '$mode'
+
+if mode == 'empty_extra_data':
+    ed = b''
+    h0 = encode_header(b'\\xaa'*32, ed)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = (struct.pack('<Q', 0) + struct.pack('<Q', len(ed))
+                + ed + b'\\x00'*(32-len(ed)))
+elif mode == 'typical_geth_proposer_tag':
+    ed = b'geth-amsterdam-v1.0'
+    h0 = encode_header(b'\\xaa'*32, ed)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = (struct.pack('<Q', 0) + struct.pack('<Q', len(ed))
+                + ed + b'\\x00'*(32-len(ed)))
+elif mode == 'max_32_byte_extra_data':
+    ed = bytes(range(32))
+    h0 = encode_header(b'\\xaa'*32, ed)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', 32) + ed
+elif mode == 'oversized_33_byte_extra_data':
+    # Spec violation: EIP-3675 caps extra_data at 32 bytes; helper
+    # returns status=2.
+    ed = b'\\x77'*33
+    h0 = encode_header(b'\\xaa'*32, ed)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = struct.pack('<Q', 2) + struct.pack('<Q', 0) + b'\\x00'*32
+elif mode == 'two_headers_pick_second':
+    ed0 = b'first'
+    ed1 = b'second-proposer-tag'
+    h0 = encode_header(b'\\xaa'*32, ed0)
+    h1 = encode_header(b'\\xbb'*32, ed1)
+    witness_headers = build_ssz_section([h0, h1])
+    block_hash = k256(h1)
+    expected = (struct.pack('<Q', 0) + struct.pack('<Q', len(ed1))
+                + ed1 + b'\\x00'*(32-len(ed1)))
+elif mode == 'block_hash_miss':
+    h0 = encode_header(b'\\xaa'*32, b'tag')
+    witness_headers = build_ssz_section([h0])
+    block_hash = b'\\xee'*32
+    expected = struct.pack('<Q', 1) + struct.pack('<Q', 0) + b'\\x00'*32
+else:
+    raise SystemExit('bad mode: ' + mode)
+
+with open(sys.argv[1], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(witness_headers))
+        + block_hash
+        + witness_headers
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_extra_data_at_block_hash.elf \
+    -i "$in_file" -o "$out_file" -n 6000000 \
+    >"$REPO_ROOT/gen-out/zisk_edbh_${name}.emu.log" 2>&1 || true
+
+  local exp_size
+  exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-40s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-40s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "empty_extra_data"                  empty_extra_data || FAILED=1
+run_case "typical_geth_proposer_tag"         typical_geth_proposer_tag || FAILED=1
+run_case "max_32_byte_extra_data"            max_32_byte_extra_data || FAILED=1
+run_case "oversized_33_byte_extra_data_status_2" oversized_33_byte_extra_data || FAILED=1
+run_case "two_headers_pick_second"           two_headers_pick_second || FAILED=1
+run_case "block_hash_miss_status_1"          block_hash_miss || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: extra_data_at_block_hash end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Hash-keyed `header.extra_data` extractor (RLP field 12, ≤ 32 B per EIP-3675). Mirror of `extra_data_at_block_number` but takes a 32-byte `block_hash` key.
- Pipeline composes K19 `witness_lookup_by_hash` + existing K216 `header_extract_extra_data` — **no new asm helpers**.
- Unlocks proposer-tag attestation directly from a block_hash (e.g. consumed alongside a finality proof) without first scanning witness.headers for the block_number.
- **Build fix bundled in**: `lakefile.toml` gains `moreLeancArgs = ["-fbracket-depth=4096"]` — identical to PRs #7676 / #7679; carried so this branch builds on its own.

## Output layout (48 bytes)
- `0..8`: status (0 ok / 1 hash miss / 2 RLP fail or oversized)
- `8..16`: extra_data length (u64 LE; 0 on failure)
- `16..48`: extra_data bytes (zero-padded to 32; zero on failure)

## Test plan
- [x] `scripts/codegen-zisk-extra-data-at-block-hash-check.sh` — 6 fixtures pass:
  - `empty_extra_data` (legal empty proposer tag → length=0)
  - `typical_geth_proposer_tag` (ASCII `geth-amsterdam-v1.0`)
  - `max_32_byte_extra_data` (length=32, exactly at the EIP-3675 cap)
  - `oversized_33_byte_extra_data_status_2` (deliberate 33-byte field → size-fail)
  - `two_headers_pick_second`
  - `block_hash_miss_status_1`
- [x] `lake build codegen` clean (with the `-fbracket-depth=4096` flag)
- [x] All existing fixtures still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)