### PR TITLE
feat(divmod): v5 MOD preloop copyAU + loopSetup bricks (preloop complete)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/PreloopV5Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PreloopV5Mod.lean
@@ -22,6 +22,7 @@ import EvmAsm.Evm64.DivMod.Compose.PhaseABV4NoNop
 import EvmAsm.Evm64.DivMod.Compose.CLZ
 import EvmAsm.Evm64.DivMod.Compose.Norm
 import EvmAsm.Evm64.DivMod.Compose.NormA
+import EvmAsm.Evm64.DivMod.LimbSpec.CopyAU
 import EvmAsm.Evm64.DivMod.Compose.V5NoNop
 
 namespace EvmAsm.Evm64
@@ -547,5 +548,87 @@ theorem divK_normA_full_spec_within_v5_noNop_modCode (sp a0 a1 a2 a3 v5 v7 v10 s
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
     h123456
+
+-- ============================================================================
+-- Brick 6: copy-AU (copyAUOff → loopSetupOff, shift = 0 path) over modCode_noNop_v5.
+-- MOD mirror of `divK_copyAU_spec_within_v5_noNop` (CopyAUV5.lean), `_b6_mod`.
+-- ============================================================================
+
+/-- v5 copy-AU (shift = 0) over `modCode_noNop_v5`: copy `a[0..3]` into `u[0..3]`,
+    zero `u[4]`.  MOD mirror of `divK_copyAU_spec_within_v5_noNop`. -/
+theorem divK_copyAU_spec_within_v5_noNop_modCode (sp base : Word)
+    (a0 a1 a2 a3 u0 u1 u2 u3 u4 v5 : Word) :
+    cpsTripleWithin 9 (base + copyAUOff) (base + loopSetupOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) **
+       ((sp + signExtend12 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + signExtend12 4024) ↦ₘ u4))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ a3) **
+       ((sp + signExtend12 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
+       ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ (0 : Word))) := by
+  have hbody := divK_copyAU_spec_within sp (base + copyAUOff)
+    a0 a1 a2 a3 u0 u1 u2 u3 u4 v5
+  simp only [divK_copyAU_code] at hbody
+  rw [show (base + copyAUOff) + 36 = base + loopSetupOff from by
+    simp only [copyAUOff, loopSetupOff]; bv_addr] at hbody
+  exact cpsTripleWithin_extend_code sharedNoNop_v5_b6_mod hbody
+
+-- ============================================================================
+-- Brick 7: loop-setup (loopSetupOff → loopBodyOff) over modCode_noNop_v5.
+-- MOD mirror of `divK_loopSetup_ntaken_spec_within_v5_noNop` (LoopSetupV5.lean), `_b7_mod`.
+-- ============================================================================
+
+/-- The loop-setup block instructions are subsumed by `modCode_noNop_v5`. -/
+private theorem divK_loopSetup_code_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (divK_loopSetup_code 464 (base + loopSetupOff)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  exact sharedNoNop_v5_b7_mod a i h
+
+/-- BLT singleton at base+loopSetupOff+12 is subsumed by `modCode_noNop_v5`. -/
+private theorem blt_loopSetup_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + loopSetupOff + 12) (.BLT .x9 .x0 464)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + loopSetupOff) (divK_loopSetup 464) 3
+    (by decide) (by decide)
+  rw [show (BitVec.ofNat 64 (4 * 3) : Word) = (12 : Word) from by decide] at hlookup
+  exact divK_loopSetup_code_sub_modCode_noNop_v5 a i
+    (CodeReq.singleton_mono hlookup a i h)
+
+/-- LoopSetup (m ≥ 0, n ≤ 4) over `modCode_noNop_v5`: falls through to the loop
+    body.  MOD mirror of `divK_loopSetup_ntaken_spec_within_v5_noNop`. -/
+theorem divK_loopSetup_ntaken_spec_within_v5_noNop_modCode (sp n v1 v5 : Word) (base : Word)
+    (hm_ge : ¬BitVec.slt (signExtend12 (4 : BitVec 12) - n) (0 : Word)) :
+    let m := signExtend12 (4 : BitVec 12) - n
+    cpsTripleWithin 4 (base + loopSetupOff) (base + loopBodyOff) (modCode_noNop_v5 base)
+      (divKLoopSetupNtakenPreNoNop sp v5 v1 n)
+      (divKLoopSetupNtakenPostNoNop sp n m) := by
+  intro m
+  rw [divKLoopSetupNtakenPreNoNop_unfold, divKLoopSetupNtakenPostNoNop_unfold]
+  have hbody := divK_loopSetup_body_spec_within sp n v1 v5 464 (base + loopSetupOff)
+  have hbodye := cpsTripleWithin_extend_code divK_loopSetup_code_sub_modCode_noNop_v5 hbody
+  have hblt_raw := blt_spec_gen_within .x9 .x0 464 m (0 : Word) (base + loopSetupOff + 12)
+  rw [show (base + loopSetupOff + 12 : Word) + signExtend13 464 = base + denormOff from by rv64_addr,
+      show (base + loopSetupOff + 12 : Word) + 4 = base + loopBodyOff from by bv_addr] at hblt_raw
+  have hblt_clean := cpsBranchWithin_ntakenStripPure2 hblt_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hm_ge)
+  have hblte := cpsTripleWithin_extend_code blt_loopSetup_sub_modCode_noNop_v5 hblt_clean
+  have hbltef := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** ((sp + signExtend12 3984) ↦ₘ n))
+    (by pcFree) hblte
+  have h12 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hbodye hbltef
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    h12
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Append `divK_copyAU_spec_within_v5_noNop_modCode` and `divK_loopSetup_ntaken_spec_within_v5_noNop_modCode` to `Compose/PreloopV5Mod.lean` — the copy-AU (shift=0) and loop-setup preloop bricks re-pointed to `modCode_noNop_v5` via `sharedNoNop_v5_b6_mod` / `b7_mod` (MOD mirrors of `CopyAUV5.lean` / `LoopSetupV5.lean`).
- Bricks 6 + 7 — **the MOD preloop is now complete over `modCode_noNop_v5`** (all of phaseA / CLZ / phaseC2 / normB / normA / copyAU / loopSetup).
- Builds green; axiom-clean.

Stacked on #7684. Next: the loop body over `modCode_noNop_v5`, then compose preloop+loop, then n2b.

Refs #61. Bead: evm-asm-wbc4i.10.3.2.4.5.

Authored by @pirapira; implemented by Claude Code