### PR TITLE
feat(divmod): v5 MOD n2 max j=2 from-source body over modCode_noNop_v5

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -242,6 +242,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMaxJ0BorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMaxIterBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMaxIterBorrowCarryMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMaxSourceBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMaxSourceBorrowCarryMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCMBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMCBorrowCarry

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopMaxSourceBorrowCarryMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopMaxSourceBorrowCarryMod.lean
@@ -1,0 +1,71 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMaxSourceBorrowCarryMod
+
+  MOD mirror of `FullPathN2V5NoNopMaxSourceBorrowCarry`: the borrow-dispatched
+  j=2 single-MAX loop source theorem over `modCode_noNop_v5`, requiring
+  `isAddbackCarry2NzN2Max` only conditionally on the runtime borrow.  Byte-for-byte
+  the DIV proof — compose the MOD j=2 max iter borrowCarry body (#7691) with the
+  (code-agnostic) source-pre bridge `loopN2PreWithScratchV4NoX1_to_max_j2_pre`.
+  Brick 6 of the n=2 MOD loop body (max source layer).
+  Bead `evm-asm-wbc4i.10.3.2.4.5`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopSource
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMaxIterBorrowCarryMod
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- First n=2 MAX iteration from the loop source over `modCode_noNop_v5`, carry
+    required only on the runtime-borrow branch. -/
+theorem divK_loop_n2_max_j2_from_source_exact_loopIterScratch_v5_noNop_borrowCarry_modCode
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_borrow :
+      BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) →
+      isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v5 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN2Max sp (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)) **
+        ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig1) **
+         ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q1Old)) **
+         (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig0) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))) := by
+  have J2 := divK_loop_body_n2_max_j2_exact_loopIterScratch_v5_noNop_borrowCarry_modCode sp base
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q2Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem hbltu hcarry2_borrow
+  have J2f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig1) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q1Old)) **
+     (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig0) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J2
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      have hp' := loopN2PreWithScratchV4NoX1_to_max_j2_pre
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem h hp
+      xperm_hyp hp')
+    (fun h hp => hp)
+    J2f
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `Compose/FullPathN2V5NoNopMaxSourceBorrowCarryMod.lean` — the borrow-dispatched j=2 single-MAX loop source theorem over `modCode_noNop_v5`, composing the MOD j=2 max iter borrowCarry body (#7691) with the code-agnostic source-pre bridge `loopN2PreWithScratchV4NoX1_to_max_j2_pre` (MOD mirror of `FullPathN2V5NoNopMaxSourceBorrowCarry`).
- Brick 6 of the n=2 MOD loop body (max source layer).
- Builds green; axiom-clean.

Stacked on #7691. Next: the call iter/source layers, then the combos.

Refs #61. Bead: evm-asm-wbc4i.10.3.2.4.5.

Authored by @pirapira; implemented by Claude Code