### PR TITLE
feat(stateless): blob_gas_used_at_block_hash primitive

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -210,6 +210,7 @@ import EvmAsm.Codegen.Programs.WithdrawalsRootAtBlockHash
 import EvmAsm.Codegen.Programs.PrevRandaoAtBlockHash
 import EvmAsm.Codegen.Programs.DifficultyAtBlockHash
 import EvmAsm.Codegen.Programs.HeaderNonceAtBlockHash
+import EvmAsm.Codegen.Programs.BlobGasUsedAtBlockHash
 
 namespace EvmAsm.Codegen
 
@@ -447,6 +448,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_ssz_hash_tree_root_list_bytelist" => some ziskSszHashTreeRootListByteListProbeUnit
   | "zisk_ssz_hash_tree_root_execution_witness" => some ziskSszHashTreeRootExecutionWitnessProbeUnit
   | "zisk_header_nonce_at_block_hash" => some ziskHeaderNonceAtBlockHashProbeUnit
+  | "zisk_blob_gas_used_at_block_hash" => some ziskBlobGasUsedAtBlockHashProbeUnit
   | _                           => none
 
 /-- Look up a program by name. Returns `none` for unknown names so the CLI
@@ -887,6 +889,7 @@ def knownProgramNames : List String :=
    "zisk_prev_randao_at_block_hash",
    "zisk_difficulty_at_block_hash",
    "zisk_header_nonce_at_block_hash",
+   "zisk_blob_gas_used_at_block_hash",
    "zisk_slot_at_index",
    "zisk_rlp_encode_uint_be",
    "zisk_rlp_encode_bytes",

--- a/EvmAsm/Codegen/Programs/BlobGasUsedAtBlockHash.lean
+++ b/EvmAsm/Codegen/Programs/BlobGasUsedAtBlockHash.lean
@@ -1,0 +1,147 @@
+/-
+  EvmAsm.Codegen.Programs.BlobGasUsedAtBlockHash
+
+  Hash-keyed `header.blob_gas_used` extractor (RLP field
+  17, u64; Cancun+). Mirror of the number-keyed
+  `blob_gas_used_at_block_number` probe but takes a
+  block_hash key.
+
+  Per EIP-4844, blob_gas_used is recorded per block and
+  must be a non-negative multiple of GAS_PER_BLOB (131072).
+
+  No proofs yet -- codegen `String` defs only.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.Mpt
+import EvmAsm.Codegen.Programs.HashBridge
+import EvmAsm.Codegen.Programs.HeaderU64
+import EvmAsm.Codegen.Programs.Tx
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Program
+
+/-! ## blob_gas_used_at_block_hash
+
+    Hash-keyed extractor for
+    `header.block.blob_gas_used` (RLP field 17, u64).
+
+    Pipeline (composes K19 + existing
+    header_extract_blob_gas_used; no new helpers):
+      witness.headers ∋ ?h with keccak(h) == block_hash  [K19]
+      h -> header_extract_blob_gas_used -> u64
+
+    Use cases unique to the hash-keyed variant:
+      * Blob-fee bridge attestation -- compute the blob-gas
+        component of an off-chain receipt-equivalent given
+        only `(block_hash, blob_count)`.
+      * Cross-witness blob_gas_used consistency.
+      * Detecting that a block_hash refers to a pre-Cancun
+        header (parse_fail surfaces as status=2).
+
+    Calling convention (4 args):
+      a0 (input)  : block_hash ptr (32 bytes)
+      a1 (input)  : witness.headers ptr
+      a2 (input)  : witness.headers len
+      a3 (input)  : u64 blob_gas_used out ptr
+      ra (input)  : return
+
+      a0 (output) :
+        0 = success (blob_gas_used u64 written)
+        1 = block_hash not in witness.headers
+        2 = matched header blob_gas_used extraction failed
+            (RLP malformed / pre-Cancun / field 17 > 8 bytes BE)
+-/
+def blobGasUsedAtBlockHashFunction : String :=
+  "blob_gas_used_at_block_hash:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0                  # block_hash ptr\n" ++
+  "  mv s1, a1                  # witness.headers ptr\n" ++
+  "  mv s2, a2                  # witness.headers len\n" ++
+  "  mv s3, a3                  # blob_gas_used u64 out\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  mv a0, s1\n" ++
+  "  mv a1, s2\n" ++
+  "  mv a2, s0\n" ++
+  "  la a3, bgubh_match_offset\n" ++
+  "  la a4, bgubh_match_length\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  bnez a0, .Lbgubh_no_match\n" ++
+  "  la t0, bgubh_match_offset\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  add s4, s1, t1\n" ++
+  "  la t0, bgubh_match_length\n" ++
+  "  ld s5, 0(t0)\n" ++
+  "  mv a0, s4\n" ++
+  "  mv a1, s5\n" ++
+  "  mv a2, s3\n" ++
+  "  jal ra, header_extract_blob_gas_used\n" ++
+  "  beqz a0, .Lbgubh_ret\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lbgubh_ret\n" ++
+  ".Lbgubh_no_match:\n" ++
+  "  li a0, 1\n" ++
+  ".Lbgubh_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_blob_gas_used_at_block_hash`: probe BuildUnit.
+    Output layout (16 bytes):
+      bytes  0.. 8 : status (0..2)
+      bytes  8..16 : blob_gas_used u64 LE (0 on failure) -/
+def ziskBlobGasUsedAtBlockHashPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t4, 0x40000000\n" ++
+  "  ld a2, 8(t4)                # witness_headers_len\n" ++
+  "  addi a0, t4, 16             # block_hash ptr\n" ++
+  "  addi a1, t4, 48             # witness.headers ptr\n" ++
+  "  li a3, 0xa0010008           # u64 blob_gas_used out\n" ++
+  "  jal ra, blob_gas_used_at_block_hash\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbgubh_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  headerExtractBlobGasUsedFunction ++ "\n" ++
+  blobGasUsedAtBlockHashFunction ++ "\n" ++
+  ".Lbgubh_pdone:"
+
+def ziskBlobGasUsedAtBlockHashDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "bgubh_match_offset:\n" ++
+  "  .zero 8\n" ++
+  "bgubh_match_length:\n" ++
+  "  .zero 8"
+
+def ziskBlobGasUsedAtBlockHashProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlobGasUsedAtBlockHashPrologue
+  dataAsm     := ziskBlobGasUsedAtBlockHashDataSection
+}
+
+end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **450**
-- ziskemu round-trip scripts: **442** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **451**
+- ziskemu round-trip scripts: **443** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **451**
-- ziskemu round-trip scripts: **443** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **452**
+- ziskemu round-trip scripts: **444** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **449**
-- ziskemu round-trip scripts: **441** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **450**
+- ziskemu round-trip scripts: **442** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-blob-gas-used-at-block-hash-check.sh
+++ b/scripts/codegen-zisk-blob-gas-used-at-block-hash-check.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# codegen-zisk-blob-gas-used-at-block-hash-check.sh
+#
+# Hash-keyed historical header.blob_gas_used extractor
+# (RLP field 17, u64; Cancun+). Mirror of the number-keyed
+# `blob_gas_used_at_block_number` but takes a 32-byte
+# block_hash key.
+#
+# Output (16 bytes):
+#   bytes  0.. 8 : status (0 ok, 1 hash miss, 2 RLP fail)
+#   bytes  8..16 : blob_gas_used u64 LE (0 on failure)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_blob_gas_used_at_block_hash ELF"
+lake exe codegen --program zisk_blob_gas_used_at_block_hash \
+  --halt linux93 \
+  -o gen-out/zisk_blob_gas_used_at_block_hash
+
+REPO_ROOT="$(pwd)"
+
+GAS_PER_BLOB=131072
+
+run_case() {
+  local name="$1"; shift
+  local mode="$1"; shift
+
+  local in_file="$REPO_ROOT/gen-out/zisk_bgubh_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_bgubh_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_bgubh_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+from Crypto.Hash import keccak
+
+def k256(b):
+    h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+
+def build_ssz_section(elements):
+    n = len(elements)
+    if n == 0: return b''
+    section = b''
+    offset = 4 * n
+    for e in elements:
+        section += struct.pack('<I', offset); offset += len(e)
+    for e in elements: section += e
+    return section
+
+def be_min(val):
+    if val == 0: return b''
+    nbytes = (val.bit_length() + 7) // 8
+    return val.to_bytes(nbytes, 'big')
+
+# 20-field Amsterdam-shape header w/ field 17 = blob_gas_used
+def encode_header(state_root, blob_gas_used_val, n_fields=20):
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x44'*32,
+        b'\\x55'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+        b'',                       # base_fee_per_gas (field 15)
+        b'\\x66'*32,               # withdrawals_root (16)
+        be_min(blob_gas_used_val), # blob_gas_used (17)
+        b'',                       # excess_blob_gas (18)
+        b'\\x99'*32,               # parent_beacon_block_root (19)
+    ]
+    return rlp.encode(fields[:n_fields])
+
+def encode_header_raw17(state_root, raw17_bytes):
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x44'*32,
+        b'\\x55'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+        b'', b'\\x66'*32, raw17_bytes, b'', b'\\x99'*32,
+    ]
+    return rlp.encode(fields)
+
+mode = '$mode'
+GAS_PER_BLOB = 131072
+
+if mode == 'zero_blobs':
+    h0 = encode_header(b'\\xaa'*32, 0)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', 0)
+elif mode == 'one_blob':
+    bgu = GAS_PER_BLOB
+    h0 = encode_header(b'\\xaa'*32, bgu)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', bgu)
+elif mode == 'six_blobs_eip4844_max':
+    bgu = 6 * GAS_PER_BLOB
+    h0 = encode_header(b'\\xaa'*32, bgu)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', bgu)
+elif mode == 'two_headers_pick_second':
+    h0 = encode_header(b'\\xaa'*32, 0)
+    h1 = encode_header(b'\\xbb'*32, 3 * GAS_PER_BLOB)
+    witness_headers = build_ssz_section([h0, h1])
+    block_hash = k256(h1)
+    expected = struct.pack('<Q', 0) + struct.pack('<Q', 3 * GAS_PER_BLOB)
+elif mode == 'block_hash_miss':
+    h0 = encode_header(b'\\xaa'*32, GAS_PER_BLOB)
+    witness_headers = build_ssz_section([h0])
+    block_hash = b'\\xee'*32
+    expected = struct.pack('<Q', 1) + struct.pack('<Q', 0)
+elif mode == 'rlp_overflow_9_bytes':
+    # 9-byte field 17 exceeds u64; helper returns status=2.
+    h0 = encode_header_raw17(b'\\xaa'*32, b'\\x01' + b'\\x00'*8)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = struct.pack('<Q', 2) + struct.pack('<Q', 0)
+elif mode == 'pre_cancun_field_absent':
+    # 17-field header (pre-Cancun) -- field 17 absent.
+    h0 = encode_header(b'\\xaa'*32, 0, n_fields=17)
+    witness_headers = build_ssz_section([h0])
+    block_hash = k256(h0)
+    expected = struct.pack('<Q', 2) + struct.pack('<Q', 0)
+else:
+    raise SystemExit('bad mode: ' + mode)
+
+with open(sys.argv[1], 'wb') as f:
+    record = (
+        struct.pack('<Q', len(witness_headers))
+        + block_hash
+        + witness_headers
+    )
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_blob_gas_used_at_block_hash.elf \
+    -i "$in_file" -o "$out_file" -n 6000000 \
+    >"$REPO_ROOT/gen-out/zisk_bgubh_${name}.emu.log" 2>&1 || true
+
+  local exp_size
+  exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-40s OK   %d bytes match\n" "$name" "$exp_size"
+    return 0
+  else
+    printf "  %-40s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "zero_blobs"                        zero_blobs || FAILED=1
+run_case "one_blob_gas_per_blob"             one_blob || FAILED=1
+run_case "six_blobs_eip4844_max"             six_blobs_eip4844_max || FAILED=1
+run_case "two_headers_pick_second"           two_headers_pick_second || FAILED=1
+run_case "block_hash_miss_status_1"          block_hash_miss || FAILED=1
+run_case "rlp_overflow_9_bytes_status_2"     rlp_overflow_9_bytes || FAILED=1
+run_case "pre_cancun_field_absent_status_2"  pre_cancun_field_absent || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: blob_gas_used_at_block_hash end-to-end"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Hash-keyed `header.blob_gas_used` extractor (RLP field 17, u64; Cancun+ per EIP-4844). Mirror of `blob_gas_used_at_block_number` but takes a 32-byte `block_hash` key.
- Pipeline composes K19 `witness_lookup_by_hash` + existing K241 `header_extract_blob_gas_used` — **no new asm helpers**.
- Unlocks blob-fee bridge attestation given only `(block_hash, blob_count)`, cross-witness consistency, and pre-Cancun detection (parse_fail surfaces as status=2).

## Status codes
- `0` success (blob_gas_used u64 written)
- `1` block_hash not in `witness.headers`
- `2` matched header blob_gas_used extraction failed (RLP malformed / pre-Cancun / field 17 > 8 bytes BE)

## Test plan
- [x] `scripts/codegen-zisk-blob-gas-used-at-block-hash-check.sh` — 7 fixtures pass:
  - `zero_blobs` (empty RLP integer → u64 0)
  - `one_blob_gas_per_blob` (131072 = `GAS_PER_BLOB`)
  - `six_blobs_eip4844_max` (`6 * GAS_PER_BLOB`, at the per-block cap)
  - `two_headers_pick_second`
  - `block_hash_miss_status_1`
  - `rlp_overflow_9_bytes_status_2` (9-byte field 17 → status=2)
  - `pre_cancun_field_absent_status_2` (17-field header → field 17 absent → parse_fail → status=2)
- [x] `lake build codegen` clean
- [x] All existing fixtures still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)