### PR TITLE
feat(divmod): v5 MOD n2 call×max 2-combo over modCode_noNop_v5

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -249,6 +249,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMaxSourceBorrowCarryMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMBorrowCarryMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCMBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCMBorrowCarryMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMCBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMCBorrowCarryMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMMBorrowCarry

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboCMBorrowCarryMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboCMBorrowCarryMod.lean
@@ -1,0 +1,125 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCMBorrowCarryMod
+
+  MOD mirror of `FullPathN2V5NoNopComboCMBorrowCarry`: the borrow-dispatched n=2
+  call×max two-digit prefix over `modCode_noNop_v5`.  Byte-for-byte the DIV proof
+  — chain the MOD j=2 call source borrowCarry (#7696) with the MOD j=1 max iter
+  borrowCarry body (#7691) via the code-agnostic call→max source-pre bridge
+  `loopIterPostN2CallScratchNoX1_j2_to_max_j1_pre`.  Brick 13 of the n=2 MOD loop
+  body (combo layer — call×max 2-combo; last of the four 2-digit prefixes).
+  Bead `evm-asm-wbc4i.10.3.2.4.5`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopSourceBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMaxIterBorrowCarryMod
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Full n=2 call×max prefix over `modCode_noNop_v5`, carry required only on each
+    digit's runtime-borrow branch. -/
+theorem divK_loop_n2_call_max_from_source_exact_loopIterScratch_v5_noNop_borrowCarry_modCode
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 : BitVec.ult u2 v1)
+    (hcarry2_borrow_2 :
+      BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_1 :
+      let r2 := iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      ¬BitVec.ult r2.2.2.1 v1)
+    (hcarry2_borrow_1 :
+      let r2 := iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r2.2.2.2.2.1
+        (mulsubN4_c3 (signExtend12 4095 : Word)
+          v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1) →
+      isAddbackCarry2NzN2Max v0 v1 v2 v3
+        u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1) :
+    let r2 := iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let scratch2 := divKTrialCallV5ScratchOut u2 u1 v1 scratchMem
+    let uBase2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let uBase0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (234 + 152) (base + loopBodyOff) (base + loopBodyOff)
+      (modCode_noNop_v5 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN2Max sp (1 : Word) v0 v1 v2 v3
+        u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 **
+        (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+        (sp + signExtend12 3960 ↦ₘ v1) **
+        (sp + signExtend12 3952 ↦ₘ (divKTrialCallV5DLo v1)) **
+        (sp + signExtend12 3944 ↦ₘ (divKTrialCallV5Un0 u1)) **
+        (sp + signExtend12 3936 ↦ₘ scratch2) **
+        (.x1 ↦ᵣ raVal)) **
+        (((uBase2 + signExtend12 4064 ↦ₘ r2.2.2.2.2.2) **
+          (qAddr2 ↦ₘ r2.1)) **
+         (((uBase0 + signExtend12 0) ↦ₘ u0Orig0) **
+          (qAddr0 ↦ₘ q0Old)))) := by
+  intro r2 scratch2 uBase2 qAddr2 uBase0 qAddr0
+  have J2 := divK_loop_n2_call_j2_from_source_exact_loopIterScratch_v5_noNop_borrowCarry_modCode
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu_2 hcarry2_borrow_2
+  subst r2
+  subst scratch2
+  subst uBase2
+  subst qAddr2
+  subst uBase0
+  subst qAddr0
+  have J1 := divK_loop_body_n2_max_j1_exact_loopIterScratch_v5_noNop_borrowCarry_modCode sp base
+    (2 : Word)
+    ((2 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q1Old raVal
+    (base + div128CallRetOff) v1 (divKTrialCallV5DLo v1)
+    (divKTrialCallV5Un0 u1) (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem)
+    hbltu_1 hcarry2_borrow_1
+  have J1f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)) **
+     (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig0) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J1
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN2CallScratchNoX1_j2_to_max_j1_pre
+      sp base (divKTrialCallV5QHat u2 u1 v1) (divKTrialCallV5DLo v1)
+      (divKTrialCallV5Un0 u1) (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q1Old q0Old raVal)
+    J2 J1f
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `Compose/FullPathN2V5NoNopComboCMBorrowCarryMod.lean` — the borrow-dispatched n=2 call×max two-digit prefix over `modCode_noNop_v5`, chaining the MOD j=2 call source borrowCarry (#7696) with the MOD j=1 max iter borrowCarry body (#7691) via the code-agnostic call→max source-pre bridge `loopIterPostN2CallScratchNoX1_j2_to_max_j1_pre`.
- Brick 13 — **completes all four n=2 2-combos** (MM/CC/MC/CM).
- Builds green; axiom-clean.

Stacked on #7699 (the merged max+call branch). Next: the 8 three-digit combos (MMM…CCC), then from_source + wrapper.

Refs #61. Bead: evm-asm-wbc4i.10.3.2.4.5.

Authored by @pirapira; implemented by Claude Code