### PR TITLE
feat(divmod): v5 MOD n2 max×max×call 3-combo over modCode_noNop_v5

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -258,6 +258,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMMBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMMBorrowCarryMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCCMBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMTBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMTBorrowCarryMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMTMBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMTTBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboTMMBorrowCarry

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboMMTBorrowCarryMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboMMTBorrowCarryMod.lean
@@ -1,0 +1,151 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMTBorrowCarryMod
+
+  MOD mirror of `FullPathN2V5NoNopComboMMTBorrowCarry`: the n=2 max×max×call source
+  path over `modCode_noNop_v5`.  File-copied DIV proof with 4 surgical swaps —
+  composes the MOD max×max 2-combo (#7697) + the MOD j=0 call exit iter borrowCarry
+  (#7703); the final-post def + simp lemmas are code-agnostic (reused from the DIV
+  `FullPathN2V5NoNopComboMMT`).  Brick 18 of the n=2 MOD loop body.
+  Bead `evm-asm-wbc4i.10.3.2.4.5`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopJ0ExitBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMT
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem divK_loop_n2_max_max_call_from_source_exact_loopIterScratch_v5_noNop_borrowCarry_modCode
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 : ¬BitVec.ult u2 v1)
+    (hcarry2_borrow_2 :
+      BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) →
+      isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_1 :
+      let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      ¬BitVec.ult r2.2.2.1 v1)
+    (hcarry2_borrow_1 :
+      let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r2.2.2.2.2.1
+        (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1) →
+      isAddbackCarry2NzN2Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1)
+    (hbltu_0 :
+      let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      let r1 := iterN2Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+      BitVec.ult r1.2.2.1 v1)
+    (hcarry2_borrow_0 :
+      let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      let r1 := iterN2Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+      BitVec.ult r1.2.2.2.2.1
+        (mulsubN4_c3 (divKTrialCallV5QHat r1.2.2.1 r1.2.1 v1)
+          v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    cpsTripleWithin (152 + 152 + 234) (base + loopBodyOff) (base + denormOff)
+      (modCode_noNop_v5 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN2MaxMaxCallSourceFinalPostNoX1V5 sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem) := by
+  have JMM := divK_loop_n2_max_max_from_source_exact_loopIterScratch_v5_noNop_borrowCarry_modCode
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    hbltu_2 hcarry2_borrow_2 hbltu_1 hcarry2_borrow_1
+  have J0 := divK_loop_body_n2_call_j0_exact_loopIterScratch_v5_noNop_borrowCarry_modCode sp base
+    (1 : Word) ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3
+      (signExtend12 4095 : Word)
+      v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1)
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig0
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    halign hbltu_0 hcarry2_borrow_0
+  have J0f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterN2Max v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+      (iterN2Max v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1)) **
+     (((sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)))
+    (by pcFree) J0
+  have hcomp := cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN2MaxScratchX1_j1_to_call_j0_pre_with_j2_frame
+      sp retMem dMem dloMem scratchUn0 scratchMem
+      v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+      u0Orig0 q0Old raVal
+      (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+    JMM J0f
+  have hsteps : (152 + 152) + 234 = 152 + 152 + 234 := by decide
+  rw [hsteps] at hcomp
+  refine cpsTripleWithin_weaken (fun _ hp => hp) ?_ hcomp
+  intro h hp
+  rw [loopN2MaxMaxCallSourceFinalPostNoX1V5_unfold]
+  simp only [r2MMTN2V5_eq, r1MMTN2V5_eq] at hp ⊢
+  xperm_hyp hp
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `Compose/FullPathN2V5NoNopComboMMTBorrowCarryMod.lean` — the n=2 max×max×call source path over `modCode_noNop_v5`, composing the MOD max×max 2-combo (#7697) + the MOD j=0 call exit iter borrowCarry (#7703).
- MOD mirror of `FullPathN2V5NoNopComboMMTBorrowCarry` (cp + 4 surgical swaps); final-post def + simp lemmas code-agnostic (reused from DIV).
- Brick 18 — 2nd of the 8 three-digit combos.
- Builds green; axiom-clean.

Stacked on #7705. Next: MTM/MTT/TMM/TMT/CCM/CCC, then from_source + wrapper.

Refs #61. Bead: evm-asm-wbc4i.10.3.2.4.5.

Authored by @pirapira; implemented by Claude Code