### PR TITLE
feat(divmod): v5 MOD n2 call×call×max 3-combo over modCode_noNop_v5

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -257,6 +257,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMCBorrowCarryMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMMBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMMBorrowCarryMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCCMBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCCMBorrowCarryMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMTBorrowCarry
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMMTBorrowCarryMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboMTMBorrowCarry

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboCCMBorrowCarryMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopComboCCMBorrowCarryMod.lean
@@ -1,0 +1,277 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCCMBorrowCarryMod
+
+  MOD mirror of `FullPathN2V5NoNopComboCCMBorrowCarry`: n2 call×call×max source path
+  over `modCode_noNop_v5` (cp + surgical swaps) — composes the MOD call×call 2-combo
+  (#7698) + the MOD j=0 max exit iter borrowCarry (#7702); final-post def + simp
+  lemmas code-agnostic (reused from DIV `FullPathN2V5NoNopComboCCM`).  Brick 23 of
+  the n=2 MOD loop body.  Bead `evm-asm-wbc4i.10.3.2.4.5`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCCBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopMaxJ0BorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopComboCCM
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem divK_loop_n2_call_call_max_from_source_exact_loopIterScratch_v5_noNop_borrowCarry_modCode
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 : BitVec.ult u2 v1)
+    (hcarry2_borrow_2 :
+      BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_1 :
+      BitVec.ult
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1)
+    (hcarry2_borrow_1 :
+      let r2 := iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r2.2.2.2.2.1
+        (mulsubN4_c3 (divKTrialCallV5QHat r2.2.2.1 r2.2.1 v1)
+          v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1) →
+      callAddbackCarry2NzV5 v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1)
+    (hbltu_0 :
+      let r2 := iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      let r1 := iterWithDoubleAddback (divKTrialCallV5QHat r2.2.2.1 r2.2.1 v1)
+        v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+      ¬BitVec.ult r1.2.2.1 v1)
+    (hcarry2_borrow_0 :
+      let r2 := iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      let r1 := iterWithDoubleAddback (divKTrialCallV5QHat r2.2.2.1 r2.2.1 v1)
+        v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+      BitVec.ult r1.2.2.2.2.1
+        (mulsubN4_c3 (signExtend12 4095 : Word)
+          v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      isAddbackCarry2NzN2Max v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    cpsTripleWithin (234 + 234 + 152) (base + loopBodyOff) (base + denormOff)
+      (modCode_noNop_v5 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN2CallCallMaxSourceFinalPostNoX1V5 sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem) := by
+  have JCC := divK_loop_n2_call_call_from_source_exact_loopIterScratch_v5_noNop_borrowCarry_modCode
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    halign hbltu_2 hcarry2_borrow_2 hbltu_1 hcarry2_borrow_1
+  have J0 := divK_loop_body_n2_max_j0_exact_loopIterScratch_v5_noNop_borrowCarry_modCode sp base
+    (1 : Word) ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3
+      (divKTrialCallV5QHat
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+      v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1)
+    (iterWithDoubleAddback
+        (divKTrialCallV5QHat
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+        v0 v1 v2 v3 u0Orig1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1
+    (iterWithDoubleAddback
+        (divKTrialCallV5QHat
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+        v0 v1 v2 v3 u0Orig1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig0
+    (iterWithDoubleAddback
+        (divKTrialCallV5QHat
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+        v0 v1 v2 v3 u0Orig1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+    (iterWithDoubleAddback
+        (divKTrialCallV5QHat
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+        v0 v1 v2 v3 u0Orig1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+    (iterWithDoubleAddback
+        (divKTrialCallV5QHat
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+        v0 v1 v2 v3 u0Orig1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+    (iterWithDoubleAddback
+        (divKTrialCallV5QHat
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+        v0 v1 v2 v3 u0Orig1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    q0Old raVal
+    (base + div128CallRetOff) v1
+    (divKTrialCallV5DLo v1)
+    (divKTrialCallV5Un0
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1)
+    (divKTrialCallV5ScratchOut
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1
+      (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem))
+    hbltu_0 hcarry2_borrow_0
+  have J0f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterWithDoubleAddback
+          (divKTrialCallV5QHat
+            (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+              v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+            (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+              v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+          v0 v1 v2 v3 u0Orig1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+      (iterWithDoubleAddback
+          (divKTrialCallV5QHat
+            (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+              v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+            (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+              v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+          v0 v1 v2 v3 u0Orig1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1)) **
+     (((sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)))
+    (by pcFree) J0
+  have hcomp := cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN2CallScratchNoX1_j1_to_max_j0_pre_with_j2_frame
+      sp base
+      (divKTrialCallV5QHat
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
+      (divKTrialCallV5DLo v1)
+      (divKTrialCallV5Un0
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1)
+      (divKTrialCallV5ScratchOut
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1
+        (divKTrialCallV5ScratchOut u2 u1 v1 scratchMem))
+      v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+      u0Orig0 q0Old raVal
+      (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2
+      (iterWithDoubleAddback (divKTrialCallV5QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+    JCC J0f
+  have hsteps : (234 + 234) + 152 = 234 + 234 + 152 := by decide
+  rw [hsteps] at hcomp
+  refine cpsTripleWithin_weaken (fun _ hp => hp) ?_ hcomp
+  intro h hp
+  rw [loopN2CallCallMaxSourceFinalPostNoX1V5_unfold]
+  simp only [r2CCCN2V5_eq, r1CCCN2V5_eq] at hp ⊢
+  xperm_hyp hp
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `Compose/FullPathN2V5NoNopComboCCMBorrowCarryMod.lean` — n2 call×call×max source path over `modCode_noNop_v5`, composing the MOD call×call 2-combo (#7698) + the MOD j=0 max exit iter borrowCarry (#7702). cp + surgical swaps.
- Brick 23 — 7th of 8 three-digit combos. Builds green; axiom-clean.

Stacked on #7710. Next: CCC (last 3-combo), then from_source.

Refs #61. Bead: evm-asm-wbc4i.10.3.2.4.5.

Authored by @pirapira; implemented by Claude Code