### PR TITLE
feat(divmod): v5 MOD n2 preloop chain over modCode_noNop_v5

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -55,12 +55,18 @@ import EvmAsm.Evm64.DivMod.LoopBody.StoreLoopV5ExactX1
 import EvmAsm.Evm64.DivMod.LoopBody.TrialMaxV5
 import EvmAsm.Evm64.DivMod.LoopIterN1.MaxSkipV5
 import EvmAsm.Evm64.DivMod.Compose.LoopSetupV5
+import EvmAsm.Evm64.DivMod.Compose.LoopSetupV5Mod
 import EvmAsm.Evm64.DivMod.Compose.NormBV5
+import EvmAsm.Evm64.DivMod.Compose.NormBV5Mod
 import EvmAsm.Evm64.DivMod.Compose.NormAV5
+import EvmAsm.Evm64.DivMod.Compose.NormAV5Mod
 import EvmAsm.Evm64.DivMod.Compose.PhaseC2V5
+import EvmAsm.Evm64.DivMod.Compose.PhaseC2V5Mod
 import EvmAsm.Evm64.DivMod.Compose.CopyAUV5
 import EvmAsm.Evm64.DivMod.Compose.PhaseAV5
+import EvmAsm.Evm64.DivMod.Compose.PhaseAV5Mod
 import EvmAsm.Evm64.DivMod.Compose.CLZV5
+import EvmAsm.Evm64.DivMod.Compose.CLZV5Mod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5Preloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.SharedLoopPost
@@ -400,6 +406,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopUnifiedPost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopSelected
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopPreloop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopPreloopMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
@@ -456,6 +463,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN4MaxV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4CallAddbackV4NoNop
 
 import EvmAsm.Evm64.DivMod.Compose.PhaseBV5
+import EvmAsm.Evm64.DivMod.Compose.PhaseBV5Mod
 import EvmAsm.Evm64.DivMod.Compose.DenormEpilogueV5
 import EvmAsm.Evm64.DivMod.Compose.DenormEpilogueShift0ClzV5
 

--- a/EvmAsm/Evm64/DivMod/Compose/CLZV5Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/CLZV5Mod.lean
@@ -1,0 +1,134 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.CLZV5Mod
+
+  v5 count-leading-zeros brick (24 steps, clzOff → phaseC2Off) over
+  `modCode_noNop_v5`.  Mirror of `divK_clz_spec_within_v4_noNop` (CLZ.lean): the
+  clz binary-search stages don't touch div128, so the same version-agnostic stage
+  bodies extend to the v5 code via the v5 block subsumption `sharedNoNop_v5_b2_mod`.
+  Fifth brick of the v5 n=1 preloop.  Bead `evm-asm-wbc4i.9.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.CLZ
+import EvmAsm.Evm64.DivMod.Compose.V5NoNop
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- CLZ block instructions are subsumed by `modCode_noNop_v5`. -/
+private theorem divK_clz_code_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (CodeReq.ofProg (base + clzOff) divK_clz) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  exact sharedNoNop_v5_b2_mod a i h
+
+private theorem clz_stage_sub_noNop_v5 {base : Word}
+    (K M_s : BitVec 6) (M_a : BitVec 12) (k : Nat)
+    (hk : k + (divK_clz_stage_prog K M_s M_a).length ≤ divK_clz.length)
+    (hslice : (divK_clz.drop k).take (divK_clz_stage_prog K M_s M_a).length =
+      divK_clz_stage_prog K M_s M_a)
+    (hbound : 4 * divK_clz.length < 2 ^ 64) :
+    ∀ a i, (divK_clz_stage_code K M_s M_a ((base + clzOff) + BitVec.ofNat 64 (4 * k))) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  exact divK_clz_code_sub_modCode_noNop_v5 a i
+    (CodeReq.ofProg_mono_sub (base + clzOff) _ divK_clz _ k
+      rfl hslice hk hbound a i h)
+
+private theorem clz_last_sub_noNop_v5 {base : Word} (k : Nat)
+    (hk : k + divK_clz_last_prog.length ≤ divK_clz.length)
+    (hslice : (divK_clz.drop k).take divK_clz_last_prog.length = divK_clz_last_prog)
+    (hbound : 4 * divK_clz.length < 2 ^ 64) :
+    ∀ a i, (divK_clz_last_code ((base + clzOff) + BitVec.ofNat 64 (4 * k))) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  exact divK_clz_code_sub_modCode_noNop_v5 a i
+    (CodeReq.ofProg_mono_sub (base + clzOff) _ divK_clz _ k
+      rfl hslice hk hbound a i h)
+
+private theorem clz_init_sub_noNop_v5 {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + clzOff) (.ADDI .x6 .x0 0)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  exact divK_clz_code_sub_modCode_noNop_v5 a i
+    (CodeReq.singleton_mono (CodeReq.ofProg_lookup (base + clzOff) divK_clz 0
+      (by decide) (by decide)) a i (by rwa [show (base + clzOff : Word) =
+        base + clzOff + BitVec.ofNat 64 (4 * 0) from by bv_addr] at h))
+
+/-- v5 count-leading-zeros full brick, over `modCode_noNop_v5`.  Mirror of the v4
+    analog. -/
+theorem divK_clz_spec_within_v5_noNop_mod (val v6Old v7Old : Word) (base : Word) :
+    cpsTripleWithin 24 (base + clzOff) (base + phaseC2Off) (modCode_noNop_v5 base)
+      ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ v6Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x5 ↦ᵣ (clzResult val).2) ** (.x6 ↦ᵣ (clzResult val).1) **
+       (.x7 ↦ᵣ (clzResult val).2 >>> (63 : Nat)) ** (.x0 ↦ᵣ (0 : Word))) := by
+  unfold clzResult
+  have I := divK_clz_init_spec_within v6Old (base + clzOff)
+  have Ie := cpsTripleWithin_extend_code (hmono := clz_init_sub_noNop_v5) I
+  have Ief := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ val) ** (.x7 ↦ᵣ v7Old)) (by pcFree) Ie
+  have S0 := divK_clz_stage_combined_within 32 32 32 val (signExtend12 0) v7Old
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 1))
+  dsimp only [] at S0
+  have S0e := cpsTripleWithin_extend_code (hmono := clz_stage_sub_noNop_v5 32 32 32 1
+    (by decide) (by decide) (by decide)) S0
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 1) = base + clzOff + 4 from by bv_addr] at S0e
+  rw [clz_addr1] at S0e
+  seqFrame Ief S0e
+  let v0 := if val >>> (32 : BitVec 6).toNat ≠ 0 then val else val <<< (32 : BitVec 6).toNat
+  let c0 := if val >>> (32 : BitVec 6).toNat ≠ 0 then signExtend12 (0 : BitVec 12)
+    else signExtend12 (0 : BitVec 12) + signExtend12 (32 : BitVec 12)
+  have S1 := divK_clz_stage_combined_within 48 16 16 v0 c0 (val >>> (32 : BitVec 6).toNat)
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 5))
+  dsimp only [] at S1
+  have S1e := cpsTripleWithin_extend_code (hmono := clz_stage_sub_noNop_v5 48 16 16 5
+    (by decide) (by decide) (by decide)) S1
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 5) = base + clzOff + 20 from by bv_addr] at S1e
+  rw [clz_addr2] at S1e
+  seqFrame IefS0e S1e
+  let v1 := if v0 >>> (48 : BitVec 6).toNat ≠ 0 then v0 else v0 <<< (16 : BitVec 6).toNat
+  let c1 := if v0 >>> (48 : BitVec 6).toNat ≠ 0 then c0 else c0 + signExtend12 (16 : BitVec 12)
+  have S2 := divK_clz_stage_combined_within 56 8 8 v1 c1 (v0 >>> (48 : BitVec 6).toNat)
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 9))
+  dsimp only [] at S2
+  have S2e := cpsTripleWithin_extend_code (hmono := clz_stage_sub_noNop_v5 56 8 8 9
+    (by decide) (by decide) (by decide)) S2
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 9) = base + clzOff + 36 from by bv_addr] at S2e
+  rw [clz_addr3] at S2e
+  seqFrame IefS0eS1e S2e
+  let v2 := if v1 >>> (56 : BitVec 6).toNat ≠ 0 then v1 else v1 <<< (8 : BitVec 6).toNat
+  let c2 := if v1 >>> (56 : BitVec 6).toNat ≠ 0 then c1 else c1 + signExtend12 (8 : BitVec 12)
+  have S3 := divK_clz_stage_combined_within 60 4 4 v2 c2 (v1 >>> (56 : BitVec 6).toNat)
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 13))
+  dsimp only [] at S3
+  have S3e := cpsTripleWithin_extend_code (hmono := clz_stage_sub_noNop_v5 60 4 4 13
+    (by decide) (by decide) (by decide)) S3
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 13) = base + clzOff + 52 from by bv_addr] at S3e
+  rw [clz_addr4] at S3e
+  seqFrame IefS0eS1eS2e S3e
+  let v3 := if v2 >>> (60 : BitVec 6).toNat ≠ 0 then v2 else v2 <<< (4 : BitVec 6).toNat
+  let c3 := if v2 >>> (60 : BitVec 6).toNat ≠ 0 then c2 else c2 + signExtend12 (4 : BitVec 12)
+  have S4 := divK_clz_stage_combined_within 62 2 2 v3 c3 (v2 >>> (60 : BitVec 6).toNat)
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 17))
+  dsimp only [] at S4
+  have S4e := cpsTripleWithin_extend_code (hmono := clz_stage_sub_noNop_v5 62 2 2 17
+    (by decide) (by decide) (by decide)) S4
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 17) = base + clzOff + 68 from by bv_addr] at S4e
+  rw [clz_addr5] at S4e
+  seqFrame IefS0eS1eS2eS3e S4e
+  let v4 := if v3 >>> (62 : BitVec 6).toNat ≠ 0 then v3 else v3 <<< (2 : BitVec 6).toNat
+  let c4 := if v3 >>> (62 : BitVec 6).toNat ≠ 0 then c3 else c3 + signExtend12 (2 : BitVec 12)
+  have S5 := divK_clz_last_combined_within v4 c4 (v3 >>> (62 : BitVec 6).toNat)
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 21))
+  dsimp only [] at S5
+  have S5e := cpsTripleWithin_extend_code (hmono := clz_last_sub_noNop_v5 21
+    (by decide) (by decide) (by decide)) S5
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 21) = base + clzOff + 84 from by bv_addr] at S5e
+  rw [clz_addr6] at S5e
+  seqFrame IefS0eS1eS2eS3eS4e S5e
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    IefS0eS1eS2eS3eS4eS5e
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopPreloopMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5NoNopPreloopMod.lean
@@ -1,0 +1,458 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopPreloopMod
+
+  Preloop setup wrappers for the n=2 v5/no-NOP full DIV path.  Mirror of
+  FullPathN2V4NoNopPreloop, lifted to `modCode_noNop_v5` (the preloop runs the
+  shared clz/normalize/copyAU instructions, not the differing div128 subroutine).
+  Reuses the generic v5 preloop blocks (PhaseAV5/CLZV5/PhaseC2V5/NormBV5/NormAV5/
+  LoopSetupV5) + the v5 phaseB code-subsumption lemmas (PhaseBV5); only the
+  n=2-specific phaseB / compositions are built here.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.PhaseBV5Mod
+import EvmAsm.Evm64.DivMod.Compose.PhaseAV5Mod
+import EvmAsm.Evm64.DivMod.Compose.CLZV5Mod
+import EvmAsm.Evm64.DivMod.Compose.PhaseC2V5Mod
+import EvmAsm.Evm64.DivMod.Compose.NormBV5Mod
+import EvmAsm.Evm64.DivMod.Compose.NormAV5Mod
+import EvmAsm.Evm64.DivMod.Compose.LoopSetupV5Mod
+import EvmAsm.Evm64.DivMod.Compose.PhaseABV4NoNop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopLoopUnified
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- v5 phase-B (n=2 detection: b3=b2=0, b1≠0), over `modCode_noNop_v5`.
+    Mirror of `evm_mod_phaseB_n2_spec_within_v4_noNop` with v5 code subsumption. -/
+theorem evm_mod_phaseB_n2_spec_within_v5_noNop (sp base : Word)
+    (b1 b2 b3 : Word) (v5 v6 v7 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0) :
+    cpsTripleWithin 21 (base + phaseBOff) (base + clzOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) **
+       ((sp + signExtend12 3984) ↦ₘ nMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b1) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+       ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 3984) ↦ₘ (2 : Word))) := by
+  have hinit1_raw := divK_phaseB_init1_spec_within sp (base + phaseBOff) q0 q1 q2 q3 u5 u6 u7
+  simp only [phB_off_28] at hinit1_raw
+  have hinit1 := cpsTripleWithin_extend_code divK_phaseB_init1_code_sub_modCode_noNop_v5 hinit1_raw
+  have hinit1f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hinit1
+  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + phaseBInit2Off) b1 b2 v6 v7
+  simp only [phB_i2_8_v4] at hinit2_raw
+  have hinit2 := cpsTripleWithin_extend_code divK_phaseB_init2_code_sub_modCode_noNop_v5 hinit2_raw
+  have hinit2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+     ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hinit2
+  have h12 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hinit1f hinit2f
+  have haddi0_raw := addi_x0_spec_gen_within .x5 v5 4 (base + phaseBStep0Off) (by nofun)
+  simp only [phB_addi_4_v4, signExtend12_4] at haddi0_raw
+  have haddi0 := cpsTripleWithin_extend_code addi_x5_singleton_sub_modCode_noNop_v5 haddi0_raw
+  have haddi0f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) haddi0
+  have h123 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h12 haddi0f
+  have hbne0_raw := bne_spec_gen_within .x10 .x0 24 b3 (0 : Word) (base + phaseBBneOff)
+  rw [show (base + phaseBBneOff : Word) + signExtend13 24 = base + phaseBTailOff from by
+        rv64_addr, phB_bne_4_v4] at hbne0_raw
+  have hbne0_clean := cpsBranchWithin_ntakenStripPure2 hbne0_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd hb3z ((sepConj_pure_right _).mp h_rest).2)
+  have hbne0 := cpsTripleWithin_extend_code bne_x10_singleton_sub_modCode_noNop_v5 hbne0_clean
+  have hbne0f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hbne0
+  have h1234 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h123 hbne0f
+  have haddi1_raw := addi_x0_spec_gen_within .x5 (4 : Word) 3 (base + phaseBStep1Off) (by nofun)
+  simp only [phB_step1_4_v4, signExtend12_3] at haddi1_raw
+  have haddi1 := cpsTripleWithin_extend_code addi_x5_3_sub_modCode_noNop_v5 haddi1_raw
+  have haddi1f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) haddi1
+  have h12345 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h1234 haddi1f
+  have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + phaseBBne2Off)
+  rw [show (base + phaseBBne2Off : Word) + signExtend13 16 = base + phaseBTailOff from by
+        rv64_addr, phB_step1_8_v4] at hbne1_raw
+  have hbne1_clean := cpsBranchWithin_ntakenStripPure2 hbne1_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd hb2z ((sepConj_pure_right _).mp h_rest).2)
+  have hbne1 := cpsTripleWithin_extend_code bne_x7_16_sub_modCode_noNop_v5 hbne1_clean
+  have hbne1f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hbne1
+  have h123456 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h12345 hbne1f
+  have haddi2_raw := addi_x0_spec_gen_within .x5 (3 : Word) 2 (base + phaseBStep2Off) (by nofun)
+  simp only [phB_step2_4_v4, signExtend12_2] at haddi2_raw
+  have haddi2 := cpsTripleWithin_extend_code addi_x5_2_sub_modCode_noNop_v5 haddi2_raw
+  have haddi2f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x7 ↦ᵣ b2) ** (.x6 ↦ᵣ b1) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) haddi2
+  have h1234567 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_chunked hp) h123456 haddi2f
+  have hbne2_raw := bne_spec_gen_within .x6 .x0 8 b1 (0 : Word) (base + phaseBBne3Off)
+  rw [show (base + phaseBBne3Off : Word) + signExtend13 8 = base + phaseBTailOff from by
+        rv64_addr, phB_step2_8_v4] at hbne2_raw
+  have hbne2_clean := cpsBranchWithin_takenStripPure2 hbne2_raw
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hb1nz)
+  have hbne2 := cpsTripleWithin_extend_code bne_x6_8_sub_modCode_noNop_v5 hbne2_clean
+  have hbne2f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (2 : Word)) ** (.x10 ↦ᵣ b3) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hbne2
+  have h12345678 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_chunked hp) h1234567 hbne2f
+  have htail_raw := divK_phaseB_tail_spec_within sp (2 : Word) b1 nMem (base + phaseBTailOff)
+  simp only [divK_phaseB_tail_pre_unfold, divK_phaseB_tail_post_unfold,
+             phB_t_20_v4, divK_phaseB_n2_nm1_x8_v4, signExtend12_32, phB_sp8_32_v4] at htail_raw
+  have htail := cpsTripleWithin_extend_code divK_phaseB_tail_code_sub_modCode_noNop_v5 htail_raw
+  have htailf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)))
+    (by pcFree) htail
+  have hphaseB := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h12345678 htailf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hphaseB
+
+/-- PhaseAB(n=2) + CLZ over `modCode_noNop_v5`. base → base+phaseC2Off. -/
+theorem evm_mod_phaseAB_n2_clz_spec_within_v5_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24) base (base + phaseC2Off) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b1).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ (clzResult b1).1) ** (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word))) := by
+  have hA := evm_mod_phaseA_ntaken_spec_within_v5_noNop sp base b0 b1 b2 b3 v5 v10 hbnz
+  have hAf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+     ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+     ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hA
+  have hB := evm_mod_phaseB_n2_spec_within_v5_noNop sp base b1 b2 b3
+    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 nMem
+    hb3z hb2z hb1nz
+  have hBf := cpsTripleWithin_frameR
+    (((sp + 32) ↦ₘ b0))
+    (by pcFree) hB
+  have hAB := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hAf hBf
+  have hCLZ := divK_clz_spec_within_v5_noNop_mod b1 b1 b2 base
+  have hCLZf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)))
+    (by pcFree) hCLZ
+  have hABCLZ := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hAB hCLZf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hABCLZ
+
+/-- PhaseAB(n=2) + CLZ + PhaseC2(shift≠0) + NormB over `modCode_noNop_v5`. -/
+theorem evm_mod_n2_to_normB_spec_within_v5_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
+    (hshift_nz : (clzResult b1).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21) base (base + normAOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (normBPost sp (2 : Word) (clzResult b1).1 b0 b1 b2 b3) := by
+  let shift := (clzResult b1).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  have hABCLZ := evm_mod_phaseAB_n2_clz_spec_within_v5_noNop sp base b0 b1 b2 b3
+    v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2z hb1nz
+  have hABCLZf := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
+    (by pcFree) hABCLZ
+  have hC2 := divK_phaseC2_ntaken_spec_within_v5_noNop_mod sp shift ((clzResult b1).2 >>> (63 : Nat))
+    shiftMem base hshift_nz
+  have hC2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ (clzResult b1).2) ** (.x10 ↦ᵣ b3) **
+     (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)))
+    (by pcFree) hC2
+  have hABC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABCLZf hC2f
+  have hNB := divK_normB_full_spec_within_v5_noNop_mod sp b0 b1 b2 b3
+    (clzResult b1).2 ((clzResult b1).2 >>> (63 : Nat))
+    shift antiShift base
+  simp only [normBFullPost_unfold] at hNB
+  have hNBf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNB
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABC2 hNBf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta normBPost; xperm_hyp hq)
+    hFull
+
+/-- n=2 preloop entry-to-loopSetup over `modCode_noNop_v5`. base → base+loopBodyOff. -/
+theorem evm_mod_n2_to_loopSetup_spec_within_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
+    (hshift_nz : (clzResult b1).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (loopSetupPost sp (2 : Word) (clzResult b1).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := (clzResult b1).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  have hNB := evm_mod_n2_to_normB_spec_within_v5_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u5 u6 u7 nMem shiftMem hbnz hb3z hb2z hb1nz hshift_nz
+  have hNBf := cpsTripleWithin_frameR
+    ((.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+     ((sp + signExtend12 4024) ↦ₘ u4Old))
+    (by pcFree) hNB
+  have hNormA := divK_normA_full_spec_within_v5_noNop_mod sp a0 a1 a2 a3
+    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
+    u0Old u1Old u2Old u3Old u4Old base
+  rw [divKNormAFullPreNoNop_unfold] at hNormA
+  simp only [normAFullPost_unfold] at hNormA
+  have hNormAf := cpsTripleWithin_frameR
+    ((.x0 ↦ᵣ (0 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ ((b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)))) **
+     ((sp + 56) ↦ₘ ((b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)))) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNormA
+  have hNA := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by delta normBPost at hp; xperm_hyp hp) hNBf hNormAf
+  have hLS := divK_loopSetup_ntaken_spec_within_v5_noNop_mod sp (2 : Word)
+    (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
+    (by decide)
+  simp only [divKLoopSetupNtakenPreNoNop_unfold,
+      divKLoopSetupNtakenPostNoNop_unfold] at hLS
+  have hLSf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ ((b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)))) **
+     ((sp + 56) ↦ₘ ((b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)))) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+     ((sp + signExtend12 4040) ↦ₘ u2) **
+     ((sp + signExtend12 4032) ↦ₘ (a3 <<< (shift.toNat % 64) ||| a2 >>> (antiShift.toNat % 64))) **
+     ((sp + signExtend12 4024) ↦ₘ (a3 >>> (antiShift.toNat % 64))) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hLS
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hNA hLSf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta loopSetupPost; xperm_hyp hq)
+    hFull
+
+/-- n=2 v5/no-NOP entry→loopSetup with the loop's x1+scratch frame already in
+    place.  Mirror of `evm_mod_n2_to_loopSetup_spec_within_v4_noNop_exact_x1_scratch_frame`
+    (frameR + weaken around `evm_mod_n2_to_loopSetup_spec_within_v5_noNop`). -/
+theorem evm_mod_n2_to_loopSetup_spec_within_v5_noNop_exact_x1_scratch_frame
+    (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
+    (hshift_nz : (clzResult b1).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff)
+      (modCode_noNop_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      (loopSetupPost sp (2 : Word) (clzResult b1).1 a0 a1 a2 a3 b0 b1 b2 b3 **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal))) := by
+  have hPre :=
+    evm_mod_n2_to_loopSetup_spec_within_v5_noNop sp base a0 a1 a2 a3 b0 b1 b2 b3
+      v5 v6 v7 v10 q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+      hbnz hb3z hb2z hb1nz hshift_nz
+  have hFramed := cpsTripleWithin_frameR
+    (((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+      (sp + signExtend12 3968 ↦ₘ retMem) **
+      (sp + signExtend12 3960 ↦ₘ dMem) **
+      (sp + signExtend12 3952 ↦ₘ dloMem) **
+      (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+      (sp + signExtend12 3936 ↦ₘ scratchMem) **
+      (.x1 ↦ᵣ raVal)))
+    (by pcFree) hPre
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hFramed
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/LoopSetupV5Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/LoopSetupV5Mod.lean
@@ -1,0 +1,67 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.LoopSetupV5Mod
+
+  v5 loop-setup brick: the BLT-not-taken fall-through into the loop body, over
+  `modCode_noNop_v5`.  Mirror of `divK_loopSetup_ntaken_spec_within_v4_noNop`
+  (NormA.lean) — the loop-setup instructions do not touch div128, so the same
+  version-agnostic instruction bodies are extended to the v5 code via the v5 block
+  subsumption `sharedNoNop_v5_b7_mod`.  First brick of the v5 n=1 preloop
+  (toward the n=1 lane wrapper).  Bead `evm-asm-wbc4i.9.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.NormA
+import EvmAsm.Evm64.DivMod.Compose.V5NoNop
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The loop-setup block instructions are subsumed by `modCode_noNop_v5`. -/
+private theorem divK_loopSetup_code_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (divK_loopSetup_code 464 (base + loopSetupOff)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  exact sharedNoNop_v5_b7_mod a i h
+
+/-- BLT singleton at base+loopSetupOff+12 is subsumed by `modCode_noNop_v5`. -/
+private theorem blt_loopSetup_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + loopSetupOff + 12) (.BLT .x9 .x0 464)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + loopSetupOff) (divK_loopSetup 464) 3
+    (by decide) (by decide)
+  rw [show (BitVec.ofNat 64 (4 * 3) : Word) = (12 : Word) from by decide] at hlookup
+  exact divK_loopSetup_code_sub_modCode_noNop_v5 a i
+    (CodeReq.singleton_mono hlookup a i h)
+
+/-- LoopSetup (m ≥ 0, n ≤ 4): falls through to the loop body, over
+    `modCode_noNop_v5`.  Mirror of the v4 analog. -/
+theorem divK_loopSetup_ntaken_spec_within_v5_noNop_mod (sp n v1 v5 : Word) (base : Word)
+    (hm_ge : ¬BitVec.slt (signExtend12 (4 : BitVec 12) - n) (0 : Word)) :
+    let m := signExtend12 (4 : BitVec 12) - n
+    cpsTripleWithin 4 (base + loopSetupOff) (base + loopBodyOff) (modCode_noNop_v5 base)
+      (divKLoopSetupNtakenPreNoNop sp v5 v1 n)
+      (divKLoopSetupNtakenPostNoNop sp n m) := by
+  intro m
+  rw [divKLoopSetupNtakenPreNoNop_unfold, divKLoopSetupNtakenPostNoNop_unfold]
+  have hbody := divK_loopSetup_body_spec_within sp n v1 v5 464 (base + loopSetupOff)
+  have hbodye := cpsTripleWithin_extend_code divK_loopSetup_code_sub_modCode_noNop_v5 hbody
+  have hblt_raw := blt_spec_gen_within .x9 .x0 464 m (0 : Word) (base + loopSetupOff + 12)
+  rw [show (base + loopSetupOff + 12 : Word) + signExtend13 464 = base + denormOff from by rv64_addr,
+      show (base + loopSetupOff + 12 : Word) + 4 = base + loopBodyOff from by bv_addr] at hblt_raw
+  have hblt_clean := cpsBranchWithin_ntakenStripPure2 hblt_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hm_ge)
+  have hblte := cpsTripleWithin_extend_code blt_loopSetup_sub_modCode_noNop_v5 hblt_clean
+  have hbltef := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** ((sp + signExtend12 3984) ↦ₘ n))
+    (by pcFree) hblte
+  have h12 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hbodye hbltef
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    h12
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/NormAV5Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormAV5Mod.lean
@@ -1,0 +1,148 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.NormAV5Mod
+
+  v5 normalize-A brick (21 steps, normAOff → loopSetupOff) over `modCode_noNop_v5`.
+  Mirror of `divK_normA_full_spec_within_v4_noNop` (NormA.lean): the normA
+  instructions don't touch div128, so the same version-agnostic instruction bodies
+  are extended to the v5 code via the v5 block subsumption `sharedNoNop_v5_b5_mod`.
+  Second brick of the v5 n=1 preloop.  Bead `evm-asm-wbc4i.9.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.NormA
+import EvmAsm.Evm64.DivMod.Compose.V5NoNop
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Evm64.DivMod.AddrNorm (se12_0 se12_8 se12_16 se12_24)
+
+/-- The normA block instructions are subsumed by `modCode_noNop_v5`. -/
+private theorem divK_normA_code_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (CodeReq.ofProg (base + normAOff) (divK_normA 40)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  exact sharedNoNop_v5_b5_mod a i h
+
+/-- v5 normalize-A full brick, over `modCode_noNop_v5`.  Mirror of the v4 analog. -/
+theorem divK_normA_full_spec_within_v5_noNop_mod (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : Word)
+    (u0Old u1Old u2Old u3Old u4Old : Word) (base : Word) :
+    cpsTripleWithin 21 (base + normAOff) (base + loopSetupOff) (modCode_noNop_v5 base)
+      (divKNormAFullPreNoNop sp v5 v7 v10 shift antiShift
+        a0 a1 a2 a3 u0Old u1Old u2Old u3Old u4Old)
+      (normAFullPost sp a0 a1 a2 a3 shift antiShift) := by
+  rw [divKNormAFullPreNoNop_unfold, normAFullPost_unfold]
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  have htop := divK_normA_top_spec_within 24 4024 sp a3 v5 v7 antiShift u4Old (base + normAOff)
+  simp only [se12_24] at htop
+  have htope := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normA_code_sub_modCode_noNop_v5 a i
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + normAOff) (divK_normA 40)
+        (divK_normA_top_prog 24 4024) 0
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) htop
+  have htopef := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ v10) ** (.x6 ↦ᵣ shift) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) **
+     ((sp + signExtend12 4032) ↦ₘ u3Old) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old))
+    (by pcFree) htope
+  have hma1 := divK_normA_mergeA_spec_within 16 4032 sp a3 a2 u4 v10 shift antiShift u3Old (base + normAOff + 12)
+  simp only [se12_16] at hma1
+  rw [show (base + normAOff + 12 : Word) + 20 = base + normAOff + 32 from by bv_addr] at hma1
+  have hma1e := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normA_code_sub_modCode_noNop_v5 a i
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + normAOff + 12) (divK_normA 40)
+        (divK_normA_mergeA_prog 16 4032) 3
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hma1
+  have hma1ef := cpsTripleWithin_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old))
+    (by pcFree) hma1e
+  have h12 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) htopef hma1ef
+  have hmb := divK_normA_mergeB_spec_within 8 4040 sp a2 a1 u3 (a2 >>> (antiShift.toNat % 64))
+    shift antiShift u2Old (base + normAOff + 32)
+  simp only [se12_8] at hmb
+  rw [show (base + normAOff + 32 : Word) + 20 = base + normAOff + 52 from by bv_addr] at hmb
+  have hmbe := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normA_code_sub_modCode_noNop_v5 a i
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + normAOff + 32) (divK_normA 40)
+        (divK_normA_mergeB_prog 8 4040) 8
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hmb
+  have hmbef := cpsTripleWithin_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + signExtend12 4048) ↦ₘ u1Old) ** ((sp + signExtend12 4056) ↦ₘ u0Old))
+    (by pcFree) hmbe
+  have h123 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h12 hmbef
+  have hma2 := divK_normA_mergeA_spec_within 0 4048 sp a1 a0 u2 (a1 >>> (antiShift.toNat % 64))
+    shift antiShift u1Old (base + normAOff + 52)
+  simp only [se12_0] at hma2
+  rw [show (base + normAOff + 52 : Word) + 20 = base + normAOff + 72 from by bv_addr] at hma2
+  have hma2e := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normA_code_sub_modCode_noNop_v5 a i
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + normAOff + 52) (divK_normA 40)
+        (divK_normA_mergeA_prog 0 4048) 13
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hma2
+  have hma2ef := cpsTripleWithin_frameR
+    (((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4056) ↦ₘ u0Old))
+    (by pcFree) hma2e
+  have h1234 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h123 hma2ef
+  have hlast := divK_normA_last_spec_within 4056 sp a0 shift u0Old (base + normAOff + 72)
+  rw [show (base + normAOff + 72 : Word) + 8 = base + normAOff + 80 from by bv_addr] at hlast
+  have hlaste := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normA_code_sub_modCode_noNop_v5 a i
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + normAOff + 72) (divK_normA 40)
+        (divK_normA_last_prog 4056) 18
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hlast
+  have hlastef := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ u1) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) ** (.x2 ↦ᵣ antiShift) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1))
+    (by pcFree) hlaste
+  have h12345 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h1234 hlastef
+  have hjal := jal_x0_spec_gen_within 40 (base + normAOff + 80)
+  rw [show (base + normAOff + 80 : Word) + signExtend21 40 = base + loopSetupOff from by rv64_addr] at hjal
+  have hjale := cpsTripleWithin_extend_code (hmono := by
+    intro a i h
+    exact divK_normA_code_sub_modCode_noNop_v5 a i
+      (CodeReq.singleton_mono (by
+        have hlookup := CodeReq.ofProg_lookup (base + normAOff) (divK_normA 40) 20
+          (by decide) (by decide)
+        rw [show (base + normAOff : Word) + BitVec.ofNat 64 (4 * 20) = base + normAOff + 80 from by bv_addr]
+          at hlookup
+        exact hlookup) a i h)) hjal
+  let postAll := (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u1) ** (.x7 ↦ᵣ u0) **
+    (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+    (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+    ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+    ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+    ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+    ((sp + signExtend12 4056) ↦ₘ u0)
+  have hjalef := cpsTripleWithin_frameR postAll (by pcFree) hjale
+  have hjal_clean : cpsTripleWithin 1 (base + normAOff + 80) (base + loopSetupOff) (modCode_noNop_v5 base) postAll postAll :=
+    cpsTripleWithin_weaken
+      (fun h hp => by show (empAssertion ** postAll) h; rw [sepConj_emp_left']; exact hp)
+      (fun h hp => by rw [sepConj_emp_left'] at hp; exact hp)
+      hjalef
+  have h123456 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h12345 hjal_clean
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    h123456
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/NormBV5Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormBV5Mod.lean
@@ -1,0 +1,136 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.NormBV5Mod
+
+  v5 normalize-B brick (21 steps, normBOff → normAOff) over `modCode_noNop_v5`.
+  Mirror of `divK_normB_full_spec_within_v4_noNop` (Norm.lean): the normB
+  instructions don't touch div128, so the same version-agnostic merge/last bodies
+  are extended to the v5 code via the v5 block subsumption `sharedNoNop_v5_b4_mod`.
+  Third brick of the v5 n=1 preloop.  Bead `evm-asm-wbc4i.9.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.Norm
+import EvmAsm.Evm64.DivMod.Compose.V5NoNop
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Evm64.DivMod.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- The normB block instructions are subsumed by `modCode_noNop_v5`. -/
+private theorem divK_normB_code_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (CodeReq.ofProg (base + normBOff) divK_normB) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  exact sharedNoNop_v5_b4_mod a i h
+
+private theorem divK_normB_half1_within_v5_noNop
+    (sp b0 b1 b2 b3 v5 v7 shift antiShift : Word) (base : Word) :
+    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+    cpsTripleWithin 12 (base + normBOff) (base + normBOff + 48) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2') ** (.x7 ↦ᵣ (b1 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3')) := by
+  intro b3' b2'
+  have hm1 := divK_normB_merge_spec_within 56 48 sp b3 b2 v5 v7 shift antiShift (base + normBOff)
+  simp only [se12_56, se12_48] at hm1
+  have hm1e := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normB_code_sub_modCode_noNop_v5 a i
+      (CodeReq.ofProg_mono_sub (base + normBOff) (base + normBOff) divK_normB
+        (divK_normB_merge_prog 56 48) 0
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm1
+  have hm1ef := cpsTripleWithin_frameR
+    (((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1))
+    (by pcFree) hm1e
+  have hm2 := divK_normB_merge_spec_within 48 40 sp b2 b1 b3' (b2 >>> (antiShift.toNat % 64))
+    shift antiShift (base + normBOff + 24)
+  simp only [se12_48, se12_40] at hm2
+  rw [show (base + normBOff + 24 : Word) + 24 = base + normBOff + 48 from by bv_addr] at hm2
+  have hm2e := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normB_code_sub_modCode_noNop_v5 a i
+      (CodeReq.ofProg_mono_sub (base + normBOff) (base + normBOff + 24) divK_normB
+        (divK_normB_merge_prog 48 40) 6
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm2
+  have hm2ef := cpsTripleWithin_frameR
+    (((sp + 32) ↦ₘ b0) ** ((sp + 56) ↦ₘ b3'))
+    (by pcFree) hm2e
+  have h12 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hm1ef hm2ef
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    h12
+
+private theorem divK_normB_half2_within_v5_noNop
+    (sp b0 b1 b2' b3' shift antiShift : Word) (base : Word) :
+    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+    let b0' := b0 <<< (shift.toNat % 64)
+    cpsTripleWithin 9 (base + normBOff + 48) (base + normAOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2') ** (.x7 ↦ᵣ (b1 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3'))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x7 ↦ᵣ (b0 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+       ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3')) := by
+  intro b1' b0'
+  have hm3 := divK_normB_merge_spec_within 40 32 sp b1 b0
+    b2' (b1 >>> (antiShift.toNat % 64)) shift antiShift (base + normBOff + 48)
+  simp only [se12_40, se12_32] at hm3
+  rw [show (base + normBOff + 48 : Word) + 24 = base + normBOff + 72 from by bv_addr] at hm3
+  have hm3e := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normB_code_sub_modCode_noNop_v5 a i
+      (CodeReq.ofProg_mono_sub (base + normBOff) (base + normBOff + 48) divK_normB
+        (divK_normB_merge_prog 40 32) 12
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm3
+  have hm3ef := cpsTripleWithin_frameR
+    (((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3'))
+    (by pcFree) hm3e
+  have hl := divK_normB_last_spec_within 32 sp b0 b1' shift (base + normBOff + 72)
+  simp only [se12_32] at hl
+  rw [show (base + normBOff + 72 : Word) + 12 = base + normAOff from by bv_addr] at hl
+  have hle := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normB_code_sub_modCode_noNop_v5 a i
+      (CodeReq.ofProg_mono_sub (base + normBOff) (base + normBOff + 72) divK_normB
+        (divK_normB_last_prog 32) 18
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hl
+  have hlef := cpsTripleWithin_frameR
+    ((.x7 ↦ᵣ (b0 >>> (antiShift.toNat % 64))) ** (.x2 ↦ᵣ antiShift) **
+     ((sp + 40) ↦ₘ b1') ** ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3'))
+    (by pcFree) hle
+  have h34 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hm3ef hlef
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    h34
+
+/-- v5 normalize-B full brick, over `modCode_noNop_v5`.  Mirror of the v4 analog. -/
+theorem divK_normB_full_spec_within_v5_noNop_mod
+    (sp b0 b1 b2 b3 v5 v7 shift antiShift : Word) (base : Word) :
+    cpsTripleWithin 21 (base + normBOff) (base + normAOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
+      (normBFullPost sp b0 b1 b2 b3 shift antiShift) := by
+  rw [normBFullPost_unfold]
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  have h1 := divK_normB_half1_within_v5_noNop sp b0 b1 b2 b3 v5 v7 shift antiShift base
+  have h2 := divK_normB_half2_within_v5_noNop sp b0 b1 b2' b3' shift antiShift base
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    (cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by xperm_hyp hp) h1 h2)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAV5Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAV5Mod.lean
@@ -1,0 +1,66 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.PhaseAV5Mod
+
+  v5 phase-A brick (8 steps, base → phaseBOff, BEQ-not-taken for b ≠ 0) over
+  `modCode_noNop_v5`.  Mirror of `evm_mod_phaseA_ntaken_spec_within_v4_noNop`
+  (PhaseABV4NoNop.lean): phase-A doesn't touch div128, so its body extends to the
+  v5 code via the v5 block subsumption `sharedNoNop_v5_b0_mod`.  Sixth brick of the
+  v5 n=1 preloop.  Bead `evm-asm-wbc4i.9.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.PhaseABV4NoNop
+import EvmAsm.Evm64.DivMod.Compose.V5NoNop
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+private theorem divK_phaseA_code_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (divK_phaseA_code base) a = some i → (modCode_noNop_v5 base) a = some i := by
+  unfold divK_phaseA_code
+  intro a i h
+  exact sharedNoNop_v5_b0_mod a i h
+
+private theorem beq_singleton_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseABeqOff) (.BEQ .x5 .x0 1020)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  exact sharedNoNop_v5_b0_mod a i
+    (CodeReq.singleton_mono (CodeReq.ofProg_lookup base (divK_phaseA 1020) 7
+      (by decide) (by decide)) a i h)
+
+/-- v5 phase-A (b ≠ 0): OR-reduce b limbs, BEQ not taken → phase-B.  Mirror of the
+    v4 analog. -/
+theorem evm_mod_phaseA_ntaken_spec_within_v5_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v10 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0) :
+    cpsTripleWithin 8 base (base + phaseBOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (b0 ||| b1 ||| b2 ||| b3)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3)) := by
+  have hbody := cpsTripleWithin_extend_code divK_phaseA_code_sub_modCode_noNop_v5
+    (divK_phaseA_body_spec_within sp base b0 b1 b2 b3 v5 v10)
+  have hbeq_raw := beq_spec_gen_within .x5 .x0 1020 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + phaseABeqOff)
+  rw [show (base + phaseABeqOff : Word) + signExtend13 1020 = base + zeroPathOff from by rv64_addr,
+      show (base + phaseABeqOff : Word) + 4 = base + phaseBOff from by bv_addr] at hbeq_raw
+  have hbeq_clean := cpsBranchWithin_ntakenStripPure2 hbeq_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hbnz)
+  have hbeq := cpsTripleWithin_extend_code beq_singleton_sub_modCode_noNop_v5 hbeq_clean
+  have hbeq_framed := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
+    (by pcFree) hbeq
+  have hAB := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hbody hbeq_framed
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hAB
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseBV5Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseBV5Mod.lean
@@ -1,0 +1,96 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.PhaseBV5Mod
+
+  v5 phase-B brick (21 steps, phaseBOff → clzOff, n=1 detection path) over
+  `modCode_noNop_v5`.  Mirror of `evm_div_phaseB_n1_spec_within_v4_noNop`
+  (PhaseABV4NoNop.lean): phase-B doesn't touch div128, so the same version-agnostic
+  instruction bodies (init1/init2/tail + addi/bne singletons) extend to the v5 code
+  via the v5 block subsumption `sharedNoNop_v5_b1_mod`.  Last leaf of the v5 n=1
+  preloop.  Bead `evm-asm-wbc4i.9.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.PhaseABV4NoNop
+import EvmAsm.Evm64.DivMod.Compose.V5NoNop
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem divK_phaseB_init1_code_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (divK_phaseB_init1_code (base + phaseBOff)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  exact sharedNoNop_v5_b1_mod a i (CodeReq.ofProg_mono_sub (base + phaseBOff) (base + phaseBOff) divK_phaseB
+    (divK_phaseB.take 7) 0 (by bv_addr) (by decide) (by decide) (by decide) a i h)
+
+theorem divK_phaseB_init2_code_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (divK_phaseB_init2_code (base + phaseBInit2Off)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  exact sharedNoNop_v5_b1_mod a i (CodeReq.ofProg_mono_sub (base + phaseBOff) (base + phaseBInit2Off) divK_phaseB
+    (divK_phaseB.drop 7 |>.take 2) 7 (by bv_addr) (by decide) (by decide) (by decide) a i h)
+
+theorem divK_phaseB_tail_code_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (divK_phaseB_tail_code (base + phaseBTailOff)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  exact sharedNoNop_v5_b1_mod a i (CodeReq.ofProg_mono_sub (base + phaseBOff) (base + phaseBTailOff) divK_phaseB
+    (divK_phaseB.drop 16) 16 (by bv_addr) (by decide) (by decide) (by decide) a i h)
+
+theorem addi_x5_singleton_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseBStep0Off) (.ADDI .x5 .x0 4)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 9 (by decide) (by decide)
+  rw [show (base + phaseBOff : Word) + BitVec.ofNat 64 (4 * 9) = base + phaseBStep0Off from by bv_addr] at hlookup
+  exact sharedNoNop_v5_b1_mod a i (CodeReq.singleton_mono hlookup a i h)
+
+theorem bne_x10_singleton_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseBBneOff) (.BNE .x10 .x0 24)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 10 (by decide) (by decide)
+  rw [show (base + phaseBOff : Word) + BitVec.ofNat 64 (4 * 10) = base + phaseBBneOff from by bv_addr] at hlookup
+  exact sharedNoNop_v5_b1_mod a i (CodeReq.singleton_mono hlookup a i h)
+
+theorem addi_x5_3_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseBStep1Off) (.ADDI .x5 .x0 3)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 11 (by decide) (by decide)
+  rw [show (base + phaseBOff : Word) + BitVec.ofNat 64 (4 * 11) = base + phaseBStep1Off from by bv_addr] at hlookup
+  exact sharedNoNop_v5_b1_mod a i (CodeReq.singleton_mono hlookup a i h)
+
+theorem bne_x7_16_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseBBne2Off) (.BNE .x7 .x0 16)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 12 (by decide) (by decide)
+  rw [show (base + phaseBOff : Word) + BitVec.ofNat 64 (4 * 12) = base + phaseBBne2Off from by bv_addr] at hlookup
+  exact sharedNoNop_v5_b1_mod a i (CodeReq.singleton_mono hlookup a i h)
+
+theorem addi_x5_2_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseBStep2Off) (.ADDI .x5 .x0 2)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 13 (by decide) (by decide)
+  rw [show (base + phaseBOff : Word) + BitVec.ofNat 64 (4 * 13) = base + phaseBStep2Off from by bv_addr] at hlookup
+  exact sharedNoNop_v5_b1_mod a i (CodeReq.singleton_mono hlookup a i h)
+
+theorem bne_x6_8_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseBBne3Off) (.BNE .x6 .x0 8)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 14 (by decide) (by decide)
+  rw [show (base + phaseBOff : Word) + BitVec.ofNat 64 (4 * 14) = base + phaseBBne3Off from by bv_addr] at hlookup
+  exact sharedNoNop_v5_b1_mod a i (CodeReq.singleton_mono hlookup a i h)
+
+theorem addi_x5_1_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseBStep3Off) (.ADDI .x5 .x0 1)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 15 (by decide) (by decide)
+  rw [show (base + phaseBOff : Word) + BitVec.ofNat 64 (4 * 15) = base + phaseBStep3Off from by bv_addr] at hlookup
+  exact sharedNoNop_v5_b1_mod a i (CodeReq.singleton_mono hlookup a i h)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseC2V5Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseC2V5Mod.lean
@@ -1,0 +1,106 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.PhaseC2V5Mod
+
+  v5 phase-C2 brick (4 steps, phaseC2Off → normBOff, shift ≠ 0 / BEQ-not-taken)
+  over `modCode_noNop_v5`.  Mirror of `divK_phaseC2_ntaken_spec_within_v4_noNop`
+  (Norm.lean): phase-C2 doesn't touch div128, so its body extends to the v5 code
+  via the v5 block subsumption `sharedNoNop_v5_b3_mod`.  Fourth brick of the v5
+  n=1 preloop.  Bead `evm-asm-wbc4i.9.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.Norm
+import EvmAsm.Evm64.DivMod.Compose.V5NoNop
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Phase-C2 block instructions are subsumed by `modCode_noNop_v5`. -/
+private theorem divK_phaseC2_code_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (divK_phaseC2_code 172 (base + phaseC2Off)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  unfold divK_phaseC2_code
+  intro a i h
+  exact sharedNoNop_v5_b3_mod a i h
+
+/-- BEQ x6 x0 172 singleton subsumed by `modCode_noNop_v5`. -/
+private theorem beq_shift_sub_modCode_noNop_v5 {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseC2Off + 12) (.BEQ .x6 .x0 172)) a = some i →
+      (modCode_noNop_v5 base) a = some i := by
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + phaseC2Off) (divK_phaseC2 172) 3
+    (by decide) (by decide)
+  rw [show (BitVec.ofNat 64 (4 * 3) : Word) = (12 : Word) from by decide] at hlookup
+  exact divK_phaseC2_code_sub_modCode_noNop_v5 a i
+    (CodeReq.singleton_mono hlookup a i h)
+
+private theorem divK_phaseC2_body_modCode_noNop_v5_within
+    (sp shift v2 shiftMem : Word) (base : Word) :
+    cpsTripleWithin 3 (base + phaseC2Off) (base + phaseC2Off + 12) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+       (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
+  have hbody := divK_phaseC2_body_spec_within sp shift v2 shiftMem 172 (base + phaseC2Off)
+  exact cpsTripleWithin_extend_code divK_phaseC2_code_sub_modCode_noNop_v5 hbody
+
+/-- v5 phase-C2 (shift ≠ 0): store shift, compute antiShift, BEQ not taken → normB. -/
+theorem divK_phaseC2_ntaken_spec_within_v5_noNop_mod (sp shift v2 shiftMem : Word) (base : Word)
+    (hshift_nz : shift ≠ 0) :
+    cpsTripleWithin 4 (base + phaseC2Off) (base + normBOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+       (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
+  have hbody := divK_phaseC2_body_modCode_noNop_v5_within sp shift v2 shiftMem base
+  have hbeq_raw := beq_spec_gen_within .x6 .x0 172 shift (0 : Word) (base + phaseC2Off + 12)
+  rw [show (base + phaseC2Off + 12 : Word) + signExtend13 172 = base + copyAUOff from by rv64_addr,
+      show (base + phaseC2Off + 12 : Word) + 4 = base + normBOff from by bv_addr] at hbeq_raw
+  have hbeq_clean := cpsBranchWithin_ntakenStripPure2 hbeq_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 (show shift ≠ (0 : Word) from hshift_nz))
+  have hbeq := cpsTripleWithin_extend_code beq_shift_sub_modCode_noNop_v5 hbeq_clean
+  have hbeqf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hbeq
+  have hC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hbody hbeqf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hC2
+
+/-- v5 phase-C2 (shift = 0): store shift, compute antiShift, BEQ taken → copyAU
+    (skips the normB/normA normalization shifts since no normalization is needed).
+    Mirror of `divK_phaseC2_ntaken_spec_within_v5_noNop_mod` with the taken branch;
+    first brick of the v5 n=1 shift=0 preloop.  Bead `evm-asm-wbc4i.9.1`. -/
+theorem divK_phaseC2_taken_spec_within_v5_noNop_mod (sp shift v2 shiftMem : Word) (base : Word)
+    (hshift_z : shift = 0) :
+    cpsTripleWithin 4 (base + phaseC2Off) (base + copyAUOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+       (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
+  have hbody := divK_phaseC2_body_modCode_noNop_v5_within sp shift v2 shiftMem base
+  have hbeq_raw := beq_spec_gen_within .x6 .x0 172 shift (0 : Word) (base + phaseC2Off + 12)
+  rw [show (base + phaseC2Off + 12 : Word) + signExtend13 172 = base + copyAUOff from by rv64_addr,
+      show (base + phaseC2Off + 12 : Word) + 4 = base + normBOff from by bv_addr] at hbeq_raw
+  have hbeq_clean := cpsBranchWithin_takenStripPure2 hbeq_raw
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
+      exact absurd hshift_z ((sepConj_pure_right _).mp h_rest).2)
+  have hbeq := cpsTripleWithin_extend_code beq_shift_sub_modCode_noNop_v5 hbeq_clean
+  have hbeqf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hbeq
+  have hC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hbody hbeqf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hC2
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Mirror the entire v5 n=2 **preloop** to `modCode_noNop_v5`. Every preloop brick proves its spec from code-agnostic raw block specs extended via the v5 block-subsumption lemmas, so the mod port is `divCode_noNop_v5`→`modCode_noNop_v5` + `sharedNoNop_v5_bN_div`→`_mod` (cp + surgical swaps).
- **7 brick mirrors**: `PhaseBV5Mod` (10 code-subsumption lemmas), `PhaseAV5Mod`, `CLZV5Mod`, `PhaseC2V5Mod`, `NormBV5Mod`, `NormAV5Mod`, `LoopSetupV5Mod`. Public specs renamed (`_mod` / `evm_mod_`) to avoid clashing with the div bricks in the shared `EvmAsm.Evm64` namespace.
- **`FullPathN2V5NoNopPreloopMod`**: the 5 chained n2 preloop theorems, culminating in `evm_mod_n2_to_loopSetup_spec_within_v5_noNop_exact_x1_scratch_frame`.

Brick 27. Builds green; axiom-clean. Prereq for `FullBorrowCarry`-mod (preloop + loop compose).

Stacked on #7714. Refs #61. Bead: evm-asm-wbc4i.10.3.2.4.5.

Authored by @pirapira; implemented by Claude Code