### PR TITLE
feat(divmod): v5 MOD n2d lane (shiftNz + combiner) over modCode_noNop_v5

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -221,6 +221,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N2V5ConcretePostBridge
 import EvmAsm.Evm64.DivMod.Spec.N2V5ConcretePostBridgeMod
 import EvmAsm.Evm64.DivMod.Spec.N2V5PostToDispatchPostV5
+import EvmAsm.Evm64.DivMod.Spec.N2V5PostToDispatchPostV5Mod
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallableExact
 import EvmAsm.Evm64.DivMod.Spec.N2V5CallAddbackOverestimate
 import EvmAsm.Evm64.DivMod.Spec.N2V5TrialOverestimate
@@ -289,7 +290,9 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopCallablePostSelectedBorrowCa
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFromShape
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFromShapeMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LaneShiftNz
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LaneShiftNzMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5Lane
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LaneMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5FullShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5ParamShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LaneShift0
@@ -320,6 +323,7 @@ import EvmAsm.Evm64.DivMod.Spec.N3V5QuotientLaneShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormScaled
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLaneShape
+import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLaneShapeMod
 import EvmAsm.Evm64.DivMod.Spec.N2V5ModRemainder
 import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0Quotient
 import EvmAsm.Evm64.DivMod.Spec.N2V5Shift0QuotientLane

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5LaneMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5LaneMod.lean
@@ -1,0 +1,51 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LaneMod
+
+  The v5 n=2 DIV lane combiner: case-splits on the normalization shift
+  (`(clzResult (b.getLimbN 1)).1 = 0`), delegating to the proven shift≠0 lane
+  (`evm_mod_n2_lane_shiftNz_v5`, #7465) and to the shift=0 lane (supplied as a
+  hypothesis, to be discharged once the shift=0 path is assembled).  Produces the
+  full `N2`-shape lane in the form the unconditional scaffold
+  (`evm_div_stack_spec_unconditional_of_lanes_v5_div`) consumes.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LaneShiftNzMod
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- n=2 lane = shift=0 lane ⊕ shift≠0 lane (#7465), combined by `by_cases` on the
+    normalization shift. -/
+theorem evm_mod_n2_lane_v5 (sp base : Word) (a b : EvmWord)
+    (raVal v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0) (hb1nz : b.getLimbN 1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (shift0lane : (clzResult (b.getLimbN 1)).1 = 0 →
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v5 base)
+        (divModStackDispatchPreNoX1 sp a b
+          (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+          ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat)) v5 v6 v7 v10 v11Old
+          q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+         ((sp + signExtend12 3936) ↦ₘ scratchMem))
+        (modStackDispatchPostV5 sp a b)) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat)) v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostV5 sp a b) := by
+  by_cases hsh : (clzResult (b.getLimbN 1)).1 = 0
+  · exact shift0lane hsh
+  · exact evm_mod_n2_lane_shiftNz_v5 sp base a b raVal v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+      retMem dMem dloMem scratch_un0 scratchMem hbnz hb3z hb2z hb1nz hsh halign
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5LaneShiftNzMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V5LaneShiftNzMod.lean
@@ -1,0 +1,107 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V5LaneShiftNzMod
+
+  The v5 n=2 DIV lane, shift≠0 case: from the stack-dispatch precondition to
+  `modStackDispatchPostV5`, over `modCode_noNop_v5`.  Composes the entry→nopOff
+  path with the carry discharged from shape
+  (`evm_mod_n2_stack_pre_to_unified_post_v5_noNop_fromShape`, #7463), the post
+  bridge (`fullModN2UnifiedPostNoX1V5_to_modStackDispatchPostV5`, #7464) with the
+  shape-derived quotient correctness
+  (`fullModN2RemainderWordV5_eq_mod_lane_of_shape`), and the step-count widening to
+  `unifiedDivBound`.  This is the shift≠0 half of `lane_n2` matching
+  `evm_mod_stack_spec_unconditional_of_lanes_v5_div`, mirroring
+  `evm_mod_n1_lane_shiftNz_v5`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopFromShapeMod
+import EvmAsm.Evm64.DivMod.Spec.N2V5PostToDispatchPostV5Mod
+import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLaneShapeMod
+import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Mod
+import EvmAsm.Evm64.DivMod.Spec.UnifiedBzero
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem evm_mod_n2_lane_shiftNz_v5 (sp base : Word) (a b : EvmWord)
+    (raVal v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0) (hb1nz : b.getLimbN 1 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 1)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat)) v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostV5 sp a b) := by
+  -- The three runtime borrow flags, in clean `ult (fullDivN2R{2,1}V5 …)` form.
+  obtain ⟨bltu_2, hbltu_2⟩ :
+      ∃ x, x = BitVec.ult (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1 := ⟨_, rfl⟩
+  obtain ⟨bltu_1, hbltu_1⟩ :
+      ∃ x, x = BitVec.ult (fullDivN2R2V5 bltu_2 (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1 := ⟨_, rfl⟩
+  obtain ⟨bltu_0, hbltu_0⟩ :
+      ∃ x, x = BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1 := ⟨_, rfl⟩
+  -- The per-digit `bltu` path matches, from the clean flag definitions.
+  have hc2 : bltu_2 = true →
+      BitVec.ult (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.1 = true := fun h => by rw [← hbltu_2]; exact h
+  have hm2 : bltu_2 = false →
+      ¬ BitVec.ult (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.1 := fun h => by rw [← hbltu_2, h]; decide
+  have hc1 : bltu_1 = true →
+      BitVec.ult (fullDivN2R2V5 bltu_2 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.1 = true := fun h => by rw [← hbltu_1]; exact h
+  have hm1 : bltu_1 = false →
+      ¬ BitVec.ult (fullDivN2R2V5 bltu_2 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.1 := fun h => by rw [← hbltu_1, h]; decide
+  have hc0 : bltu_0 = true →
+      BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.1 = true := fun h => by rw [← hbltu_0]; exact h
+  have hm0 : bltu_0 = false →
+      ¬ BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.1 := fun h => by rw [← hbltu_0, h]; decide
+  -- Quotient correctness from shape (lane form).
+  have hdivWord := fullModN2RemainderWordV5_eq_mod_lane_of_shape bltu_2 bltu_1 bltu_0
+    (a := a) (b := b) rfl rfl rfl rfl rfl rfl rfl rfl
+    hb2z hb3z hshift_nz hb1nz hc2 hm2 hc1 hm1 hc0 hm0
+  -- The entry→nopOff path with carry discharged from shape.
+  have hpath := evm_mod_n2_stack_pre_to_unified_post_v5_noNop_fromShape sp base a b
+    v5 v6 v7 v10 v11Old q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0 scratchMem raVal
+    bltu_2 bltu_1 bltu_0 hbnz hb3z hb2z hb1nz hshift_nz halign hbltu_2 hbltu_1 hbltu_0
+  refine cpsTripleWithin_mono_nSteps (by have h : unifiedDivBound = 946 := rfl; omega) <|
+    cpsTripleWithin_weaken (fun _ hp => hp) ?_ hpath
+  intro h hq
+  exact fullModN2UnifiedPostNoX1V5_to_modStackDispatchPostV5 bltu_2 bltu_1 bltu_0 sp base a b
+    retMem dMem dloMem scratch_un0 scratchMem raVal hdivWord h hq
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5PostToDispatchPostV5Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5PostToDispatchPostV5Mod.lean
@@ -1,0 +1,51 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5PostToDispatchPostV5Mod
+
+  N=2 V5 post bridge to the SCAFFOLD post `modStackDispatchPostV5`
+  (= `divStackDispatchPost ** memOwn (sp+3936)`).  Composes the existing
+  callable-frame bridge (`fullModN2UnifiedPostNoX1V5_frame_to_modStackDispatchPostCallableExactFrame_scratch_word`,
+  #7463-adjacent) with the public weakening `modStackDispatchPostCallableExactFrame_weaken`
+  and `memIs_implies_memOwn`.  This is the post half of the n=2 lane (the form the
+  unconditional scaffold `evm_div_stack_spec_unconditional_of_lanes_v5_div`
+  consumes), mirroring n1's `n1_denormPost_to_divStackDispatchPost_v5`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5ConcretePostBridgeMod
+import EvmAsm.Evm64.DivMod.Spec.N2V5ModRemainder
+import EvmAsm.Evm64.DivMod.Spec.StackPostBridgeMod
+import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Mod
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- From the n=2 v5 unified post (with exact caller `x1`) and quotient
+    correctness, conclude the scaffold post `modStackDispatchPostV5`. -/
+theorem fullModN2UnifiedPostNoX1V5_to_modStackDispatchPostV5
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base : Word) (a b : EvmWord)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hdivWord : fullModN2RemainderWordV5 bltu_2 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.mod a b) :
+    ∀ h,
+      (fullModN2UnifiedPostNoX1V5 bltu_2 bltu_1 bltu_0 sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) h →
+      modStackDispatchPostV5 sp a b h := by
+  intro h hp
+  have h1 := fullModN2UnifiedPostNoX1V5_frame_to_modStackDispatchPostCallableExactFrame_scratch_word
+    bltu_2 bltu_1 bltu_0 sp base a b
+    retMem dMem dloMem scratchUn0 scratchMem raVal hdivWord h hp
+  simp only [modStackDispatchPostV5]
+  revert h1
+  apply sepConj_mono
+  · exact fun h hp =>
+      modStackDispatchPostCallableExactFrame_weaken sp a b raVal (signExtend12 4095) h hp
+  · exact fun h hp => memIs_implies_memOwn h hp
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V5QuotientLaneShapeMod.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5QuotientLaneShapeMod.lean
@@ -1,0 +1,45 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLaneShapeMod
+
+  Lane-ready (`a b : EvmWord`) form of the n=2 v5 quotient-word correctness
+  FROM SHAPE: `fullModN2RemainderWordV5 … = EvmWord.mod a b`, from the n=2 divisor
+  shape (`b2=b3=0`, `b1≠0`, shift≠0) and the per-digit `bltu` path matches.
+  Bridges the `fromLimbs`-form `fullModN2RemainderWordV5_eq_mod_of_shape` to the
+  `a b` form via `EvmWord.fromLimbs_match_getLimbN_id`.  This is the shape-derived
+  `hdivWord` the n=2 lane feeds to
+  `fullDivN2UnifiedPostNoX1V5_to_divStackDispatchPostV5` (#7464) — the
+  shape-counterpart of the `hmulsub`/`hge`-form `fullModN2RemainderWordV5_eq_mod_lane`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V5ModRemainder
+import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLane
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Lane form from shape: the assembled v5 n=2 quotient word equals `EvmWord.mod a b`. -/
+theorem fullModN2RemainderWordV5_eq_mod_lane_of_shape
+    (bltu_2 bltu_1 bltu_0 : Bool) {a b : EvmWord}
+    {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hb2z : b2 = 0) (hb3z : b3 = 0) (hshift_nz : (clzResult b1).1 ≠ 0) (hb1nz : b1 ≠ 0)
+    (hc2 : bltu_2 = true → BitVec.ult (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm2 : bltu_2 = false → ¬ BitVec.ult (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2 (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hc1 : bltu_1 = true → BitVec.ult (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm1 : bltu_1 = false → ¬ BitVec.ult (fullDivN2R2V5 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hc0 : bltu_0 = true → BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1 = true)
+    (hm0 : bltu_0 = false → ¬ BitVec.ult (fullDivN2R1V5 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 (fullDivN2NormV b0 b1 b2 b3).2.1) :
+    fullModN2RemainderWordV5 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.mod a b := by
+  have hraw := fullModN2RemainderWordV5_eq_mod_of_shape a0 a1 a2 a3 b0 b1 b2 b3 bltu_2 bltu_1 bltu_0
+    hb2z hb3z hshift_nz hb1nz hc2 hm2 hc1 hm1 hc0 hm0
+  subst a0; subst a1; subst a2; subst a3; subst b0; subst b1; subst b2; subst b3
+  refine hraw.trans ?_
+  congr 1
+  · exact EvmWord.fromLimbs_match_getLimbN_id a
+  · exact EvmWord.fromLimbs_match_getLimbN_id b
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/StackPostBridgeMod.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/StackPostBridgeMod.lean
@@ -1,0 +1,59 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.StackPostBridgeMod
+
+  MOD mirror of `StackPostBridge.divStackDispatchPostCallableExactFrame_weaken`:
+  weaken `modStackDispatchPostCallableExactFrame` to the public
+  `modStackDispatchPost` (drop exact `x1`/`x9` to ownership, merge the no-`x1`
+  scratch with `regOwn .x1`).  Reuses the shared
+  `divScratchOwnCallNoX1_with_regOwn_x1` (scratch ownership is div/mod-agnostic);
+  only the post bundle names + the `sp+32` result word differ.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.StackPostBridge
+import EvmAsm.Evm64.DivMod.Spec.CallablePost
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem modStackDispatchPostCallableExactFrame_weaken
+    (sp : Word) (a b : EvmWord) (raVal x9Val : Word) :
+    ∀ h, modStackDispatchPostCallableExactFrame sp a b raVal x9Val h →
+      modStackDispatchPost sp a b h := by
+  intro h hp
+  rw [modStackDispatchPostCallableExactFrame_unfold,
+      modStackDispatchPostCallable_unfold,
+      modStackDispatchPost_unfold] at *
+  have step1 : ((((.x12 ↦ᵣ (sp + 32)) ** regOwn .x2 **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
+        evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.mod a b) **
+        divScratchOwnCallNoX1 sp) ** regOwn .x1) ** regOwn .x9) h := by
+    revert hp
+    apply sepConj_mono
+    · apply sepConj_mono
+      · exact fun _ hp => hp
+      · exact regIs_implies_regOwn _
+    · exact regIs_implies_regOwn _
+  have step2 : ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x9 ** regOwn .x2 **
+      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
+      evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.mod a b) **
+      (divScratchOwnCallNoX1 sp ** regOwn .x1)) h := by
+    xperm_hyp step1
+  revert step2
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  exact divScratchOwnCallNoX1_with_regOwn_x1 sp
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
Assemble the v5 MOD n=2 lane (mod mirror of the DIV n2 lane), 5 files:
- **`StackPostBridgeMod`** — `modStackDispatchPostCallableExactFrame_weaken` (reuses the shared `divScratchOwnCallNoX1_with_regOwn_x1`; only post bundle names + `EvmWord.mod` differ).
- **`N2V5QuotientLaneShapeMod`** — `fullModN2RemainderWordV5_eq_mod_lane_of_shape` (lane-ready `a,b` form via `fromLimbs_match_getLimbN_id`).
- **`N2V5PostToDispatchPostV5Mod`** — `fullModN2UnifiedPostNoX1V5_to_modStackDispatchPostV5` (n2c bridge + mod weaken + `memIs_implies_memOwn`).
- **`FullPathN2V5LaneShiftNzMod`** — `evm_mod_n2_lane_shiftNz_v5` (dispatch-pre → `modStackDispatchPostV5` over `modCode_noNop_v5`, shift≠0).
- **`FullPathN2V5LaneMod`** — `evm_mod_n2_lane_v5` (`by_cases` shift; shift=0 lane as a hypothesis, same shape as DIV).

Produces the N2-shape lane in the exact form `evm_mod_stack_spec_unconditional_of_lanes_v5_mod` consumes (modulo the shift=0 sub-lane). Bricks 32–36. Builds green; axiom-clean.

Stacked on #7719. Next: n2 shift=0 sub-lane → discharge `evm_mod_n2_lane_v5`'s `shift0lane`; then n1/n3/n4 lanes → capstone.

Refs #61. Bead: evm-asm-wbc4i.10.3.2.4.4.

Authored by @pirapira; implemented by Claude Code