### PR TITLE
feat(eest): stateless-guest conformance harness vs execution-spec-tests zkevm@v0.4.0 (Glamsterdam)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,7 @@
 [submodule "EvmAsm/Evm64/zkvm-standards"]
 	path = EvmAsm/Evm64/zkvm-standards
 	url = https://github.com/eth-act/zkvm-standards
+[submodule "execution-spec-tests"]
+	path = execution-spec-tests
+	url = https://github.com/ethereum/execution-spec-tests
+	shallow = true

--- a/CODEGEN.md
+++ b/CODEGEN.md
@@ -2007,7 +2007,13 @@ carries over):
 - M26 — `addrHash` dimension (multi-contract storage keying)
 - M27 — Nested call frames + multi-frame journal push/pop
 - M28 — Witness MPT integration (cold reads + commit sweep)
-- M29 — EEST fixture harness + CI
+- M29 — EEST fixture harness + CI — 🟡 stateless harness **landed**:
+  `scripts/eest-fetch-fixtures.sh` (download `fixtures_zkevm.tar.gz`),
+  `scripts/eest-stateless-to-input.py` (fixture → ziskemu `-i` input +
+  manifest), `scripts/codegen-eest-stateless-check.sh` (build ELF, run on
+  ziskemu, compare vs `statelessOutputBytes`). Targets EEST
+  `zkevm@v0.4.0` (Amsterdam/Glamsterdam); baseline in PROGRESS.md Axis F.
+  CI job (smoke subset on PRs) still TODO.
 
 **Storage-orthogonal candidates** (any order, interleave anywhere):
 - Real EXP body wiring (verified body exists complete; M10-

--- a/PLAN.md
+++ b/PLAN.md
@@ -1092,6 +1092,24 @@ through ECALL bridges (extending `EvmAsm/EL/Keccak*EcallBridge.lean`).
   `_at_header_state_root`. Plus `zisk_blockhash_from_witness_headers`
   (BLOCKHASH) and `zisk_witness_headers_chain_validate` (chain continuity).
   Same fixture/round-trip discipline against `execution-specs` Python.
+- ✅ **EEST conformance harness (2026-05-31)**: the `stateless_guest` ELF
+  now runs against the real Ethereum Execution Spec Tests instead of only
+  synthetic inputs. Target = `ethereum/execution-spec-tests` @ `zkevm@v0.4.0`
+  (the dedicated stateless "zkevm" fixture line for the **Amsterdam /
+  Glamsterdam** fork; adds the 2-byte schema-id prefix + filled `public_keys`
+  the guest reads), vendored as the `execution-spec-tests` submodule
+  (`shallow=true`). Pipeline: `scripts/eest-fetch-fixtures.sh` downloads the
+  `fixtures_zkevm.tar.gz` release artifact;
+  `scripts/eest-stateless-to-input.py` turns each block's
+  `statelessInputBytes` into a ziskemu `-i` input (+ manifest);
+  `scripts/codegen-eest-stateless-check.sh` builds the ELF, runs each input
+  on ziskemu, and compares the output against the block's recorded
+  `statelessOutputBytes`. Baseline (zkevm@v0.4.0): 23,219 stateless blocks
+  (22,325 valid / 894 invalid); the still-partial guest matches the
+  `successful_validation` bit on the 894 invalid-expecting blocks (it rejects
+  every non-empty-header witness) and 0 full-output matches (it emits the
+  pre-v0.4.0 empty-`active_fork` encoding). PR7+ guest completeness moves
+  this baseline up; see PROGRESS.md Axis F.
 
 ### Cross-references
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -109,9 +109,7 @@ when the underlying state changes.
 | Reference fork | Frontier/Shanghai (most opcodes); Amsterdam draft fork referenced for SDIV/SMOD |
 | Pin | `ethereum/execution-specs@ec23140` (gitlink in `.gitmodules`) |
 | Per-opcode reference-link audit | manual; `EvmWord.<op>` defs cite Python files in their docstrings (not yet machine-checked) |
-| EEST fixtures pin | `ethereum/execution-spec-tests` @ `zkevm@v0.4.0` (Amsterdam/Glamsterdam; gitlink, `shallow=true`); fixtures from the `fixtures_zkevm.tar.gz` release artifact, fetched by `scripts/eest-fetch-fixtures.sh` |
-| EEST stateless harness | ✅ wired — `scripts/codegen-eest-stateless-check.sh` runs the `stateless_guest` ELF on the zkevm fixtures via ziskemu and compares against each block's `statelessOutputBytes` |
-| EEST fixture pass rate | baseline (zkevm@v0.4.0): 23,219 stateless blocks (22,325 valid / 894 invalid). Partial guest matches the validation bit on the 894 invalid-expecting blocks (it rejects every non-empty-header witness); full 105-byte match = 0 (guest still emits the pre-v0.4.0 empty-`active_fork` encoding). Full run: `scripts/codegen-eest-stateless-check.sh --all` |
+| EEST fixture pass rate | ✗ harness not yet wired (parking-lot dependency on D obligations 3 + 4) |
 | RPC block replay | ✗ not started |
 
 ## G — Trust base
@@ -254,7 +252,7 @@ This is the verified gas-cost surrogate.
 ## D — Codegen reach
 
 - Programs in `EvmAsm/Codegen/Programs.lean` registry: **449**
-- ziskemu round-trip scripts: **440** under `scripts/codegen-*.sh`
+- ziskemu round-trip scripts: **441** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -109,7 +109,9 @@ when the underlying state changes.
 | Reference fork | Frontier/Shanghai (most opcodes); Amsterdam draft fork referenced for SDIV/SMOD |
 | Pin | `ethereum/execution-specs@ec23140` (gitlink in `.gitmodules`) |
 | Per-opcode reference-link audit | manual; `EvmWord.<op>` defs cite Python files in their docstrings (not yet machine-checked) |
-| EEST fixture pass rate | ✗ harness not yet wired (parking-lot dependency on D obligations 3 + 4) |
+| EEST fixtures pin | `ethereum/execution-spec-tests` @ `zkevm@v0.4.0` (Amsterdam/Glamsterdam; gitlink, `shallow=true`); fixtures from the `fixtures_zkevm.tar.gz` release artifact, fetched by `scripts/eest-fetch-fixtures.sh` |
+| EEST stateless harness | ✅ wired — `scripts/codegen-eest-stateless-check.sh` runs the `stateless_guest` ELF on the zkevm fixtures via ziskemu and compares against each block's `statelessOutputBytes` |
+| EEST fixture pass rate | baseline (zkevm@v0.4.0): 23,219 stateless blocks (22,325 valid / 894 invalid). Partial guest matches the validation bit on the 894 invalid-expecting blocks (it rejects every non-empty-header witness); full 105-byte match = 0 (guest still emits the pre-v0.4.0 empty-`active_fork` encoding). Full run: `scripts/codegen-eest-stateless-check.sh --all` |
 | RPC block replay | ✗ not started |
 
 ## G — Trust base

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# codegen-eest-stateless-check.sh -- Run the RISC-V stateless guest against
+# the EEST "zkevm" conformance fixtures and report a pass/fail baseline.
+#
+# Pipeline (end to end):
+#   1. build the `stateless_guest` ELF via codegen -> as -> ld;
+#   2. convert EEST zkevm fixtures (Amsterdam / Glamsterdam) into ziskemu
+#      `-i` inputs + a manifest via scripts/eest-stateless-to-input.py;
+#   3. run each guest input on ziskemu and compare its output against the
+#      fixture's recorded `statelessOutputBytes`.
+#
+# Fixtures come from the release tarball fetched by
+# scripts/eest-fetch-fixtures.sh (NOT re-filled locally); the EEST repo is
+# vendored as the `execution-spec-tests` submodule for provenance.
+#
+# Conformance metrics reported per run:
+#   * full   -- guest output == the full 105-byte expected result
+#               (root + validation bit + chain_config).  Structurally
+#               requires a *complete* guest; expect ~0 while the guest is
+#               partial (its encoder emits the empty-active_fork variant
+#               and computes a placeholder root / validation bit).
+#   * succ   -- guest output byte[32] == expected byte[32], i.e. the
+#               `successful_validation` decision matches.  This is the
+#               primary near-term signal; byte 32 is the validation bit in
+#               both layouts (a 32-byte root always precedes it).
+#   * ERROR  -- ziskemu nonzero exit / step-budget exhaustion / truncated
+#               output (e.g. the guest hit an Unimplemented exit).
+#
+# Usage:
+#   scripts/codegen-eest-stateless-check.sh [options]
+#     --all              run every stateless block (slow); default: smoke subset
+#     --limit N          cap to N guest invocations (default 50)
+#     --filter SUBSTR    only fixtures whose relpath contains SUBSTR
+#     --steps N          ziskemu max steps (default $EEST_STEPS or 5000000)
+#     --min-succ N       exit 1 if fewer than N succ-bit matches (regression gate)
+#     --tag TAG          EEST fixture tag (default $EEST_FIXTURE_TAG or zkevm@v0.4.0)
+#
+# Exit:
+#   0 -- ran to completion (baseline mode), or succ >= --min-succ
+#   1 -- build/convert failure, no fixtures, or succ < --min-succ
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+ALL=0
+LIMIT=50
+FILTER=""
+STEPS="${EEST_STEPS:-5000000}"
+MIN_SUCC=""
+TAG="${EEST_FIXTURE_TAG:-zkevm@v0.4.0}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all) ALL=1; shift ;;
+    --limit) LIMIT="$2"; shift 2 ;;
+    --filter) FILTER="$2"; shift 2 ;;
+    --steps) STEPS="$2"; shift 2 ;;
+    --min-succ) MIN_SUCC="$2"; shift 2 ;;
+    --tag) TAG="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+# --- locate ziskemu ---------------------------------------------------------
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+# --- locate fixtures --------------------------------------------------------
+FX="${EEST_FIXTURES_DIR:-$REPO_ROOT/gen-out/eest-fixtures/$TAG/fixtures/fixtures}"
+if [[ ! -d "$FX" ]]; then
+  echo "EEST fixtures not found at: $FX" >&2
+  echo "  run: scripts/eest-fetch-fixtures.sh '$TAG'" >&2
+  exit 1
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit stateless_guest ELF"
+lake exe codegen --program stateless_guest --halt linux93 -o gen-out/stateless_guest
+
+# --- convert fixtures -> ziskemu inputs + manifest --------------------------
+RUN_DIR="$REPO_ROOT/gen-out/eest-run"
+rm -rf "$RUN_DIR"
+mkdir -p "$RUN_DIR"
+conv_args=(--fixtures-dir "$FX" --out-dir "$RUN_DIR")
+[[ "$ALL" -eq 0 ]] && conv_args+=(--limit "$LIMIT")
+[[ -n "$FILTER" ]] && conv_args+=(--filter "$FILTER")
+echo "==> convert fixtures (tag=$TAG, $([[ $ALL -eq 1 ]] && echo all || echo "limit=$LIMIT")${FILTER:+, filter=$FILTER})"
+python3 scripts/eest-stateless-to-input.py "${conv_args[@]}"
+
+MANIFEST="$RUN_DIR/manifest.tsv"
+[[ -s "$MANIFEST" ]] || { echo "no stateless blocks selected" >&2; exit 1; }
+
+# --- run + classify ---------------------------------------------------------
+total=0 err=0 full=0 succ=0 fail=0
+while IFS=$'\t' read -r label input expected_hex succ_bit input_len relpath; do
+  total=$((total + 1))
+  out="$RUN_DIR/$label.output"
+  log="$RUN_DIR/$label.emu.log"
+  if ! "$ZISKEMU" -e gen-out/stateless_guest.elf -i "$input" -o "$out" \
+        -n "$STEPS" >"$log" 2>&1 </dev/null; then
+    err=$((err + 1)); echo "  ERROR(exit)   $relpath"; continue
+  fi
+  actual_hex="$(xxd -p -l 105 "$out" 2>/dev/null | tr -d '\n' || true)"
+  if [[ "${#actual_hex}" -lt 66 ]]; then
+    err=$((err + 1)); echo "  ERROR(short)  $relpath"; continue
+  fi
+  exp="${expected_hex:0:210}"
+  if [[ "$actual_hex" == "$exp" ]]; then
+    full=$((full + 1)); succ=$((succ + 1)); echo "  PASS(full)    $relpath"; continue
+  fi
+  a_succ="${actual_hex:64:2}"; e_succ="${expected_hex:64:2}"
+  if [[ "$a_succ" == "$e_succ" ]]; then
+    succ=$((succ + 1)); echo "  pass(succ)    $relpath"
+  else
+    fail=$((fail + 1)); echo "  FAIL          $relpath (succ guest=$a_succ exp=$e_succ)"
+  fi
+done < "$MANIFEST"
+
+ran=$((total - err))
+# --- summary + baseline file ------------------------------------------------
+BASELINE="$REPO_ROOT/gen-out/eest-baseline.txt"
+{
+  echo "EEST stateless-guest baseline"
+  echo "  generated:   $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  echo "  fixture tag: $TAG"
+  echo "  selection:   $([[ $ALL -eq 1 ]] && echo all || echo "limit=$LIMIT")${FILTER:+ filter=$FILTER}"
+  echo "  ziskemu:     $ZISKEMU (steps=$STEPS)"
+  echo "  total:       $total"
+  echo "  errored:     $err"
+  echo "  ran:         $ran"
+  echo "  full match:  $full"
+  echo "  succ match:  $succ"
+  echo "  fail:        $fail"
+} | tee "$BASELINE"
+
+echo "==> wrote baseline: $BASELINE"
+
+if [[ -n "$MIN_SUCC" && "$succ" -lt "$MIN_SUCC" ]]; then
+  echo "==> REGRESSION: succ match $succ < --min-succ $MIN_SUCC" >&2
+  exit 1
+fi
+exit 0

--- a/scripts/eest-fetch-fixtures.sh
+++ b/scripts/eest-fetch-fixtures.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# eest-fetch-fixtures.sh -- Download the EEST stateless ("zkevm") fixtures.
+#
+# The stateless guest is validated against the Ethereum Execution Spec
+# Tests (EEST) "zkevm" fixture line, which targets the Amsterdam fork
+# (the working name for Glamsterdam) and ships the SSZ-encoded
+# `StatelessInput` guest program inputs the Lean `run_stateless_guest`
+# consumes (2-byte schema-id prefix + `public_keys` filled as of
+# `zkevm@v0.4.0`).
+#
+# This script downloads the `fixtures_zkevm.tar.gz` asset attached to
+# the EEST release tag into a gitignored cache and extracts it.  The
+# EEST repo itself is vendored as the `execution-spec-tests` submodule
+# (pinned to the same tag) for provenance / source; the *fixtures* are
+# consumed from the release tarball rather than re-filled locally.
+#
+# Usage:
+#   scripts/eest-fetch-fixtures.sh [TAG]
+#   TAG defaults to the EEST_FIXTURE_TAG env var, else "zkevm@v0.4.0".
+#
+# Output:
+#   gen-out/eest-fixtures/<TAG>/fixtures_zkevm.tar.gz   (downloaded)
+#   gen-out/eest-fixtures/<TAG>/fixtures/               (extracted tree)
+#   gen-out/eest-fixtures/<TAG>/.asset-meta             (size for re-run checks)
+#
+# Idempotent: re-running with an already-downloaded asset of the
+# expected size skips the download (pass --force to re-download).
+#
+# Exit:
+#   0 -- fixtures present and extracted
+#   1 -- download / extraction failed
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+REPO="${EEST_REPO:-ethereum/execution-spec-tests}"
+TAG="${1:-${EEST_FIXTURE_TAG:-zkevm@v0.4.0}}"
+ASSET="fixtures_zkevm.tar.gz"
+FORCE=0
+[[ "${2:-}" == "--force" || "${1:-}" == "--force" ]] && FORCE=1
+
+CACHE_DIR="$REPO_ROOT/gen-out/eest-fixtures/$TAG"
+TARBALL="$CACHE_DIR/$ASSET"
+EXTRACT_DIR="$CACHE_DIR/fixtures"
+META_FILE="$CACHE_DIR/.asset-meta"
+
+mkdir -p "$CACHE_DIR"
+
+echo "==> EEST stateless fixtures: $REPO @ $TAG ($ASSET)"
+
+# Expected asset size (bytes) from the release metadata, if gh is available.
+expected_size=""
+if command -v gh >/dev/null 2>&1; then
+  expected_size="$(gh release view "$TAG" --repo "$REPO" \
+    --json assets \
+    --jq ".assets[] | select(.name==\"$ASSET\") | .size" 2>/dev/null || true)"
+fi
+
+need_download=1
+if [[ "$FORCE" -eq 0 && -f "$TARBALL" ]]; then
+  actual_size="$(stat -c '%s' "$TARBALL" 2>/dev/null || echo 0)"
+  if [[ -n "$expected_size" && "$actual_size" == "$expected_size" ]]; then
+    echo "    cached tarball matches release size ($actual_size bytes) -- skipping download"
+    need_download=0
+  elif [[ -z "$expected_size" && "$actual_size" -gt 0 ]]; then
+    echo "    cached tarball present ($actual_size bytes); gh unavailable to verify -- reusing"
+    need_download=0
+  fi
+fi
+
+if [[ "$need_download" -eq 1 ]]; then
+  echo "==> downloading $ASSET"
+  if command -v gh >/dev/null 2>&1; then
+    gh release download "$TAG" --repo "$REPO" --pattern "$ASSET" \
+      --output "$TARBALL" --clobber
+  else
+    # curl fallback -- URL-encode the '@' in the tag as %40.
+    enc_tag="${TAG/@/%40}"
+    url="https://github.com/$REPO/releases/download/$enc_tag/$ASSET"
+    echo "    gh not found; curl $url"
+    curl -fL --retry 3 -o "$TARBALL" "$url"
+  fi
+fi
+
+dl_size="$(stat -c '%s' "$TARBALL" 2>/dev/null || echo 0)"
+printf 'tag=%s\nasset=%s\nsize=%s\nexpected_size=%s\n' \
+  "$TAG" "$ASSET" "$dl_size" "${expected_size:-unknown}" >"$META_FILE"
+echo "    tarball: $TARBALL ($dl_size bytes)"
+
+echo "==> extracting into $EXTRACT_DIR"
+rm -rf "$EXTRACT_DIR"
+mkdir -p "$EXTRACT_DIR"
+tar -xzf "$TARBALL" -C "$EXTRACT_DIR"
+
+n_json="$(find "$EXTRACT_DIR" -name '*.json' | wc -l | tr -d ' ')"
+echo "==> done: $n_json json file(s) under $EXTRACT_DIR"
+echo "    (set EEST_FIXTURES_DIR=$EXTRACT_DIR for the harness)"

--- a/scripts/eest-stateless-to-input.py
+++ b/scripts/eest-stateless-to-input.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Convert EEST "zkevm" stateless fixtures into ziskemu guest inputs.
+
+The EEST zkevm fixtures (release line ``zkevm@vX.Y.Z``, targeting the
+Amsterdam / Glamsterdam fork) are ``blockchain_tests`` whose blocks each
+carry two extra hex fields:
+
+  * ``statelessInputBytes``  -- the schema-prefixed (``0x0001...``) SSZ
+    ``StatelessInput`` that ``run_stateless_guest`` consumes.
+  * ``statelessOutputBytes`` -- the canonical 105-byte SSZ
+    ``StatelessValidationResult`` the guest is expected to produce.
+
+This tool walks a directory of such fixtures and, for every block that
+has ``statelessInputBytes``, writes a ziskemu ``-i`` input file in the
+exact layout ``scripts/stateless-gen-input.py`` uses
+(``<u64 LE length><blob><zero pad to 8>``), and emits a TSV manifest
+that the harness (``codegen-eest-stateless-check.sh``) iterates.
+
+Manifest columns (tab-separated, one row per guest invocation):
+  label  input_file  expected_hex  succ_bit  input_len  fixture_relpath
+
+Usage:
+  eest-stateless-to-input.py --fixtures-dir DIR --out-dir DIR
+                             [--manifest FILE] [--limit N] [--filter SUB]
+
+``--limit`` caps the number of guest invocations emitted (the default is
+a small smoke subset; pass a large value or ``--all`` via the harness for
+the full suite).  ``--filter`` keeps only fixtures whose relative path
+contains the given substring.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import struct
+import sys
+from pathlib import Path
+
+
+def pack_ziskemu_input(blob: bytes) -> bytes:
+    """Mirror scripts/stateless-gen-input.py: 8-byte LE length, blob, pad to 8."""
+    total = 8 + len(blob)
+    pad = (-total) % 8
+    return struct.pack("<Q", len(blob)) + blob + (b"\x00" * pad)
+
+
+def sanitize(s: str) -> str:
+    return "".join(c if c.isalnum() or c in "._-" else "_" for c in s)
+
+
+def iter_blocks(fixture_path: Path):
+    """Yield (label, input_bytes, expected_bytes) for each stateless block."""
+    try:
+        doc = json.loads(fixture_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:  # corrupt / unreadable
+        print(f"  warn: cannot parse {fixture_path}: {exc}", file=sys.stderr)
+        return
+    for test_name, tc in doc.items():
+        blocks = tc.get("blocks") if isinstance(tc, dict) else None
+        if not isinstance(blocks, list):
+            continue
+        # Short, stable per-test tag (the part after the last "::").
+        short = test_name.split("::")[-1] if "::" in test_name else test_name
+        for bi, blk in enumerate(blocks):
+            if not isinstance(blk, dict):
+                continue
+            sib = blk.get("statelessInputBytes")
+            sob = blk.get("statelessOutputBytes")
+            if not sib or not sob:
+                continue  # block opted out of stateless validation
+            try:
+                ib = bytes.fromhex(sib[2:] if sib.startswith("0x") else sib)
+                ob = bytes.fromhex(sob[2:] if sob.startswith("0x") else sob)
+            except ValueError as exc:
+                print(f"  warn: bad hex in {fixture_path}: {exc}", file=sys.stderr)
+                continue
+            label = sanitize(f"{short}#b{bi}")
+            yield label, ib, ob
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--fixtures-dir", required=True, type=Path)
+    ap.add_argument("--out-dir", required=True, type=Path)
+    ap.add_argument("--manifest", type=Path, default=None)
+    ap.add_argument("--limit", type=int, default=0, help="cap invocations (0 = no cap)")
+    ap.add_argument("--filter", default="", help="keep fixtures whose relpath contains this")
+    args = ap.parse_args()
+
+    fixtures_dir: Path = args.fixtures_dir
+    out_dir: Path = args.out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = args.manifest or (out_dir / "manifest.tsv")
+
+    json_files = sorted(
+        p for p in fixtures_dir.rglob("*.json")
+        if ".meta" not in p.parts
+    )
+
+    n = 0
+    used_labels: set[str] = set()
+    with manifest_path.open("w") as mf:
+        for fp in json_files:
+            relpath = str(fp.relative_to(fixtures_dir))
+            if args.filter and args.filter not in relpath:
+                continue
+            for label, ib, ob in iter_blocks(fp):
+                if args.limit and n >= args.limit:
+                    print(
+                        f"==> limit {args.limit} reached; stopping "
+                        f"(more fixtures available -- truncated)",
+                        file=sys.stderr,
+                    )
+                    mf.flush()
+                    print(f"wrote {n} input(s) + manifest {manifest_path}")
+                    return 0
+                # Make the label unique across fixtures by prefixing a counter.
+                uniq = f"{n:05d}_{label}"
+                if uniq in used_labels:
+                    uniq = f"{uniq}_{len(used_labels)}"
+                used_labels.add(uniq)
+
+                input_file = out_dir / f"{uniq}.input"
+                input_file.write_bytes(pack_ziskemu_input(ib))
+                succ_bit = ob[32] if len(ob) > 32 else -1
+                mf.write(
+                    "\t".join(
+                        [
+                            uniq,
+                            str(input_file),
+                            ob.hex(),
+                            str(succ_bit),
+                            str(len(ib)),
+                            relpath,
+                        ]
+                    )
+                    + "\n"
+                )
+                n += 1
+
+    print(f"wrote {n} input(s) + manifest {manifest_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Context

Stakeholders want `run_stateless_guest` (the RISC-V stateless block
validator) to be exercised against the real Ethereum conformance suite,
targeting the coming **Glamsterdam** fork. Until now the guest was only
validated against synthetic, hand-built SSZ inputs; PROGRESS.md Axis F
recorded the EEST fixture pass rate as *"✗ harness not yet wired"* and
CODEGEN.md M29 listed it as future work.

## Most reasonable EEST target

`ethereum/execution-spec-tests` @ **`zkevm@v0.4.0`** (published 2026-05-13):

- **Glamsterdam = the `Amsterdam` fork** in Ethereum spec working names;
  EEST added Amsterdam support specifically to begin testing Glamsterdam.
- EEST publishes a dedicated **`zkevm@vX.Y.Z`** fixture line for stateless
  guest programs. `zkevm@v0.4.0` is the latest, targets `--fork Amsterdam`,
  and ships a prebuilt `fixtures_zkevm.tar.gz` artifact.
- It is **format-aligned with our guest**: `zkevm@v0.4.0` adds the 2-byte
  `schema-id` prefix (= `STATELESS_INPUT_SCHEMA_ID = 0x0001`) and fills the
  `public_keys` field of `StatelessInput`.
- The existing `execution-specs` submodule already tracks the matching
  `projects/zkevm` spec line that hosts `forks/amsterdam/stateless_guest.py`.

## What this PR does (harness + baseline; no guest feature work)

- **Submodule**: `ethereum/execution-spec-tests` added at
  `execution-spec-tests/`, pinned to `zkevm@v0.4.0` (commit `88e9fb8`),
  `shallow=true` (tag tree ~48MB vs ~9.2GB full history). Note: the commit
  is also tagged `bal@v1.7.0`, so `git submodule status` shows that label —
  the GitHub API confirms `88e9fb8` is `zkevm@v0.4.0`.
- **`scripts/eest-fetch-fixtures.sh`** — download `fixtures_zkevm.tar.gz`
  into a gitignored `gen-out/eest-fixtures` cache (idempotent).
- **`scripts/eest-stateless-to-input.py`** — turn each block's
  `statelessInputBytes` into a ziskemu `-i` input (+ TSV manifest with the
  expected `statelessOutputBytes`).
- **`scripts/codegen-eest-stateless-check.sh`** — build the `stateless_guest`
  ELF, run each input on ziskemu, and classify full-match / validation-bit
  match / FAIL / ERROR; writes a baseline summary.

## Baseline (zkevm@v0.4.0)

Full suite: **23,219** stateless blocks across 2,857 fixtures —
**22,325 expect valid**, **894 expect invalid**. The still-partial guest
(header validation + SSZ only; VM/MPT/tx/state-root stubbed) matches the
`successful_validation` bit on the **894 invalid-expecting** blocks (it
rejects any non-empty-header witness) and produces **0 full-output matches**
(it still emits the pre-v0.4.0 empty-`active_fork` encoding). Validated on
representative slices (e.g. eip7702_set_code_tx: 11/120 validation-bit
matches; 0 ziskemu errors incl. the 302KB-witness deposit fixture). PR7+
guest completeness moves this baseline up.

## Verification

```
git submodule update --init --recommend-shallow execution-spec-tests
scripts/eest-fetch-fixtures.sh                      # download + extract
scripts/codegen-eest-stateless-check.sh --limit 20  # smoke
scripts/codegen-eest-stateless-check.sh --all       # full suite (~6h)
```

## Out of scope

Guest feature work (EVM interpreter, MPT walk, tx processing, state-root),
filling fixtures from source, and a CI job (smoke subset on PRs) — noted as
follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)