### PR TITLE
feat(mpt): rlp_item_span — full byte-span of an RLP list item

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -635,6 +635,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_slot_at_index"        => some ziskSlotAtIndexProbeUnit
   | "zisk_rlp_encode_uint_be"   => some ziskRlpEncodeUintBeProbeUnit
   | "zisk_rlp_encode_bytes"     => some ziskRlpEncodeBytesProbeUnit
+  | "zisk_rlp_item_span"        => some ziskRlpItemSpanProbeUnit
   | "zisk_rlp_encode_list_prefix" => some ziskRlpEncodeListPrefixProbeUnit
   | "zisk_withdrawal_rlp_encode" => some ziskWithdrawalRlpEncodeProbeUnit
   | "zisk_withdrawal_compute_hash" => some ziskWithdrawalComputeHashProbeUnit
@@ -914,6 +915,7 @@ def knownProgramNames : List String :=
    "zisk_slot_at_index",
    "zisk_rlp_encode_uint_be",
    "zisk_rlp_encode_bytes",
+   "zisk_rlp_item_span",
    "zisk_rlp_encode_list_prefix",
    "zisk_withdrawal_rlp_encode",
    "zisk_withdrawal_compute_hash",

--- a/EvmAsm/Codegen/Programs/RlpRead.lean
+++ b/EvmAsm/Codegen/Programs/RlpRead.lean
@@ -662,5 +662,128 @@ def ziskRlpEncodeBytesProbeUnit : BuildUnit := {
   dataAsm     := ziskRlpEncodeBytesDataSection
 }
 
+/-! ## rlp_item_size / rlp_item_span (PR: full byte-span of an RLP item)
+
+    `rlp_list_nth_item` returns the item's CONTENT offset/length for string
+    items (e.g. a `0xa0||hash` ref -> offset after `0xa0`, length 32) but the
+    FULL span for embedded-list items -- inconsistent, so it can't be used to
+    copy a branch slot verbatim. `rlp_item_span` returns the FULL encoded span
+    (start offset incl. prefix, total size) of list item `i` for EVERY item
+    type, which is what mpt_set's branch-slot reconstruction needs. -/
+
+/-- `rlp_item_size`: a0 = ptr to one RLP item -> a0 = its full encoded size.
+    Leaf; clobbers t0..t6 only (preserves all s-registers and ra). -/
+def rlpItemSizeFunction : String :=
+  "rlp_item_size:\n" ++
+  "  lbu t0, 0(a0)\n" ++
+  "  li t1, 0x80\n" ++
+  "  bgeu t0, t1, .Lris2_a\n" ++
+  "  li a0, 1\n" ++                          -- single byte < 0x80
+  "  ret\n" ++
+  ".Lris2_a:\n" ++
+  "  li t1, 0xb8\n" ++
+  "  bgeu t0, t1, .Lris2_b\n" ++
+  "  addi a0, t0, -128\n" ++                  -- short string: len = t0 - 0x80
+  "  addi a0, a0, 1\n" ++                     -- + 1 prefix byte
+  "  ret\n" ++
+  ".Lris2_b:\n" ++
+  "  li t1, 0xc0\n" ++
+  "  bgeu t0, t1, .Lris2_c\n" ++
+  "  li t1, 0xb7\n" ++
+  "  sub t2, t0, t1\n" ++                     -- long string: lol = t0 - 0xb7
+  "  j .Lris2_long\n" ++
+  ".Lris2_c:\n" ++
+  "  li t1, 0xf8\n" ++
+  "  bgeu t0, t1, .Lris2_d\n" ++
+  "  addi a0, t0, -192\n" ++                  -- short list: len = t0 - 0xc0
+  "  addi a0, a0, 1\n" ++
+  "  ret\n" ++
+  ".Lris2_d:\n" ++
+  "  li t1, 0xf7\n" ++
+  "  sub t2, t0, t1\n" ++                     -- long list: lol = t0 - 0xf7
+  ".Lris2_long:\n" ++
+  "  li t3, 0\n" ++                           -- decoded length accumulator
+  "  addi t4, a0, 1\n" ++                     -- BE length bytes start at item+1
+  "  mv t5, t2\n" ++                          -- remaining lol bytes
+  ".Lris2_be:\n" ++
+  "  beqz t5, .Lris2_done\n" ++
+  "  slli t3, t3, 8\n" ++
+  "  lbu t6, 0(t4)\n" ++
+  "  or t3, t3, t6\n" ++
+  "  addi t4, t4, 1\n" ++
+  "  addi t5, t5, -1\n" ++
+  "  j .Lris2_be\n" ++
+  ".Lris2_done:\n" ++
+  "  addi a0, t2, 1\n" ++                     -- 1 (tag) + lol
+  "  add a0, a0, t3\n" ++                     -- + decoded payload length
+  "  ret"
+
+/-- `rlp_item_span`: a0 = list ptr, a1 = list len, a2 = item index i,
+    a3 = out_start_ptr (u64, item start offset incl. its prefix, relative to
+    list ptr), a4 = out_size_ptr (u64, full encoded size). Returns a0 = 0 on
+    success, 1 on parse failure / i out of range. The cursor is kept in a
+    callee-saved register because `rlp_item_size` clobbers the temporaries. -/
+def rlpItemSpanFunction : String :=
+  "rlp_item_span:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra, 0(sp); sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  sd s3, 32(sp); sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0; add s1, a0, a1; mv s2, a2; mv s3, a3; mv s4, a4\n" ++
+  "  bgeu s0, s1, .Lrisp_fail\n" ++
+  "  lbu t0, 0(s0)\n" ++
+  "  li t1, 0xc0; bltu t0, t1, .Lrisp_fail\n" ++   -- outer must be a list
+  "  li t1, 0xf8; bltu t0, t1, .Lrisp_short_outer\n" ++
+  "  li t1, 0xf7; sub t2, t0, t1; addi t2, t2, 1\n" ++
+  "  add s5, s0, t2; j .Lrisp_walk\n" ++
+  ".Lrisp_short_outer:\n" ++
+  "  addi s5, s0, 1\n" ++                          -- cursor at first item
+  ".Lrisp_walk:\n" ++
+  "  li s6, 0\n" ++                                -- index
+  ".Lrisp_loop:\n" ++
+  "  beq s6, s2, .Lrisp_target\n" ++
+  "  bgeu s5, s1, .Lrisp_fail\n" ++
+  "  mv a0, s5; jal ra, rlp_item_size\n" ++
+  "  add s5, s5, a0; addi s6, s6, 1; j .Lrisp_loop\n" ++
+  ".Lrisp_target:\n" ++
+  "  bgeu s5, s1, .Lrisp_fail\n" ++
+  "  mv a0, s5; jal ra, rlp_item_size\n" ++
+  "  sub t1, s5, s0; sd t1, 0(s3); sd a0, 0(s4)\n" ++
+  "  li a0, 0; j .Lrisp_ret\n" ++
+  ".Lrisp_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lrisp_ret:\n" ++
+  "  ld ra, 0(sp); ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  ld s3, 32(sp); ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64; ret"
+
+/-- `zisk_rlp_item_span`: probe. Input: bytes 0..8 list_len, 8..16 index i,
+    16.. list bytes. Output: 0..8 status, 8..16 item start offset, 16..24
+    item full size. -/
+def ziskRlpItemSpanPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a5, 0x40000000\n" ++
+  "  ld a1, 8(a5)                # list_len\n" ++
+  "  ld a2, 16(a5)               # index i\n" ++
+  "  addi a0, a5, 24             # list ptr\n" ++
+  "  li a3, 0xa0010008           # out_start\n" ++
+  "  li a4, 0xa0010010           # out_size\n" ++
+  "  jal ra, rlp_item_span\n" ++
+  "  li t0, 0xa0010000; sd a0, 0(t0)\n" ++
+  "  j .Lrisp_pdone\n" ++
+  rlpItemSizeFunction ++ "\n" ++
+  rlpItemSpanFunction ++ "\n" ++
+  ".Lrisp_pdone:"
+
+def ziskRlpItemSpanDataSection : String :=
+  ".section .data\n" ++
+  "ris_scratch:\n" ++
+  "  .zero 8"
+
+def ziskRlpItemSpanProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskRlpItemSpanPrologue
+  dataAsm     := ziskRlpItemSpanDataSection
+}
+
 
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **457**
-- ziskemu round-trip scripts: **450** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **458**
+- ziskemu round-trip scripts: **451** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-rlp-item-span-check.sh
+++ b/scripts/codegen-zisk-rlp-item-span-check.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# codegen-zisk-rlp-item-span-check.sh -- verify rlp_item_span returns the FULL
+# encoded byte-span (start offset incl. prefix, total size) of list item i for
+# every RLP item type (empty string, 32-byte hash-ref string, nested list,
+# long string). This is the new primitive mpt_set needs for branch-slot
+# reconstruction (bead evm-asm-fhsxz.4.1).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else echo "ziskemu not found" >&2; exit 1; fi
+fi
+
+echo "==> lake build codegen"
+lake build codegen >/dev/null
+echo "==> emit zisk_rlp_item_span"
+lake exe codegen --program zisk_rlp_item_span --halt linux93 -o "$REPO_ROOT/gen-out/zisk_rlp_item_span" >/dev/null
+
+ZISKEMU="$ZISKEMU" uv run --directory execution-specs --quiet python3 - <<'PY'
+import os, sys, struct, subprocess
+sys.path.insert(0, "/home/zksecurity/evm-asm/scripts")
+import mpt_ref as M  # rlp_bytes / rlp_list / rlp_len_prefix
+ZISK = os.environ["ZISKEMU"]; ELF = "/home/zksecurity/evm-asm/gen-out/zisk_rlp_item_span.elf"
+
+# A list whose 17 items span every shape a branch node can hold:
+items_raw = [
+    b"",                       # 0: empty  -> 0x80
+    b"\x11" * 32,              # 1: 32-byte hash ref -> 0xa0 || hash
+    None,                      # 2: nested list (inline node) -> 0xc.. list
+    b"Z" * 60,                 # 3: long string (>=56) -> 0xb8 + len + bytes
+    b"\x7f",                   # 4: single byte < 0x80 (raw)
+    b"abc",                    # 5: short string
+]
+def enc(i):
+    if i == 2:
+        return M.rlp_list([M.rlp_bytes(b"x"), M.rlp_bytes(b"y")])  # inline node
+    return M.rlp_bytes(items_raw[i])
+encoded_items = [enc(i) for i in range(len(items_raw))]
+payload = b"".join(encoded_items)
+lst = M.rlp_len_prefix(len(payload), 0xC0) + payload
+prefix_len = len(lst) - len(payload)
+
+# expected (start, size) per index
+starts, sizes = [], []
+off = prefix_len
+for e in encoded_items:
+    starts.append(off); sizes.append(len(e)); off += len(e)
+
+def run(i):
+    body = struct.pack("<Q", len(lst)) + struct.pack("<Q", i) + lst
+    body += b"\x00" * ((-len(body)) % 8)
+    open("/home/zksecurity/evm-asm/gen-out/ris.in", "wb").write(body)
+    subprocess.run([ZISK, "-e", ELF, "-i", "/home/zksecurity/evm-asm/gen-out/ris.in",
+                    "-o", "/home/zksecurity/evm-asm/gen-out/ris.out", "-n", "2000000"],
+                   check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    o = open("/home/zksecurity/evm-asm/gen-out/ris.out", "rb").read()
+    return struct.unpack_from("<q", o, 0)[0], struct.unpack_from("<Q", o, 8)[0], struct.unpack_from("<Q", o, 16)[0]
+
+fail = 0
+for i in range(len(encoded_items)):
+    status, start, size = run(i)
+    ok = (status == 0 and start == starts[i] and size == sizes[i])
+    print(f"  item {i}: status={status} start={start}(exp {starts[i]}) size={size}(exp {sizes[i]})  {'OK' if ok else 'FAIL'}")
+    if not ok: fail = 1
+# out-of-range index -> status 1
+status, _, _ = run(len(encoded_items))
+print(f"  oob index: status={status} (exp 1)  {'OK' if status==1 else 'FAIL'}")
+if status != 1: fail = 1
+sys.exit(fail)
+PY
+rc=$?
+[[ $rc -eq 0 ]] && echo "==> PASS: rlp_item_span matches reference for all item types" || echo "==> FAIL"
+exit $rc


### PR DESCRIPTION
## Summary
- Add `rlp_item_size` + `rlp_item_span` (`EvmAsm/Codegen/Programs/RlpRead.lean`): return the FULL encoded span (start offset incl. prefix, total size) of RLP list item `i` for every item type. `rlp_list_nth_item` is inconsistent (content-only for strings, full-span for inline lists); this uniform primitive is what `mpt_set` needs to copy/replace a branch slot verbatim during post-state-root recompute.
- Register `zisk_rlp_item_span` probe + `scripts/codegen-zisk-rlp-item-span-check.sh`; verified vs the Python RLP reference for empty / 32-byte hash-ref / inline-list / long-string / single / short-string items + out-of-range.
- Builds green; no `sorry`/`maxHeartbeats`/`maxRecDepth`.

Foundation for the EEST full-match blocker (`mpt_set` post-state-root recompute). Bead: evm-asm-fhsxz.4.1 (parent .4).

Authored by @pirapira; implemented by Claude Code