### PR TITLE
feat(stateless): block_verdict — full state recompute, first real EEST verdicts (2/30, 0 false-pos)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -217,6 +217,7 @@ import EvmAsm.Codegen.Programs.SszWitnessState
 import EvmAsm.Codegen.Programs.SszPayloadWithdrawals
 import EvmAsm.Codegen.Programs.SszParentHeader
 import EvmAsm.Codegen.Programs.StatelessVerdict
+import EvmAsm.Codegen.Programs.BlockVerdict
 import EvmAsm.Codegen.Programs.Address
 import EvmAsm.Codegen.Programs.OmmersHashAtBlockHash
 import EvmAsm.Codegen.Programs.ParentBeaconBlockRootAtBlockHash
@@ -738,6 +739,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_header_ssz_to_rlp" => some ziskBlockHeaderSszToRlpProbeUnit
   | "zisk_step2_verdict"         => some ziskStep2VerdictProbeUnit
   | "zisk_stateless_verdict"    => some ziskStatelessVerdictProbeUnit
+  | "zisk_stateless_verdict_v2" => some ziskStatelessVerdictV2ProbeUnit
   | "zisk_u256_from_u64_be"     => some ziskU256FromU64BeProbeUnit
   | "zisk_u256_to_u64_be"       => some ziskU256ToU64BeProbeUnit
   | "zisk_u256_is_zero"         => some ziskU256IsZeroProbeUnit
@@ -1032,6 +1034,7 @@ def knownProgramNames : List String :=
    "zisk_block_header_ssz_to_rlp",
    "zisk_step2_verdict",
    "zisk_stateless_verdict",
+   "zisk_stateless_verdict_v2",
    "zisk_u256_from_u64_be",
    "zisk_u256_to_u64_be",
    "zisk_u256_is_zero",
@@ -1348,7 +1351,8 @@ end EvmAsm.Codegen
     "EvmAsm/Codegen/Programs/SszWitnessState.lean",
     "EvmAsm/Codegen/Programs/SszPayloadWithdrawals.lean",
     "EvmAsm/Codegen/Programs/SszParentHeader.lean",
-    "EvmAsm/Codegen/Programs/StatelessVerdict.lean"
+    "EvmAsm/Codegen/Programs/StatelessVerdict.lean",
+    "EvmAsm/Codegen/Programs/BlockVerdict.lean"
   ]
   for path in paths do
     let contents ← IO.FS.readFile path

--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -56,6 +56,7 @@ import EvmAsm.Codegen.Programs.Mpt
 import EvmAsm.Codegen.Programs.MptSet
 import EvmAsm.Codegen.Programs.MptEncode
 import EvmAsm.Codegen.Programs.StorageWrite
+import EvmAsm.Codegen.Programs.AccountApplyStorage
 import EvmAsm.Codegen.Programs.StorageRoot
 import EvmAsm.Codegen.Programs.MptInternal
 import EvmAsm.Codegen.Programs.MptNibbles
@@ -293,6 +294,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_single_leaf_trie_root" => some ziskSingleLeafTrieRootProbeUnit
   | "zisk_storage_root_single_slot" => some ziskStorageRootSingleSlotProbeUnit
   | "zisk_account_set_storage_root" => some ziskAccountSetStorageRootProbeUnit
+  | "zisk_account_apply_storage_slot" => some ziskAccountApplyStorageSlotProbeUnit
   | "zisk_mpt_leaf_node_encode" => some ziskMptLeafNodeEncodeProbeUnit
   | "zisk_mpt_node_slot_encode" => some ziskMptNodeSlotEncodeProbeUnit
   | "zisk_mpt_extension_node_encode" => some ziskMptExtensionNodeEncodeProbeUnit
@@ -1041,6 +1043,7 @@ def knownProgramNames : List String :=
    "zisk_single_leaf_trie_root",
    "zisk_storage_root_single_slot",
    "zisk_account_set_storage_root",
+   "zisk_account_apply_storage_slot",
    "zisk_mpt_leaf_node_encode",
    "zisk_mpt_node_slot_encode",
    "zisk_mpt_extension_node_encode",
@@ -1267,6 +1270,7 @@ end EvmAsm.Codegen
     "EvmAsm/Codegen/Programs/MptSet.lean",
     "EvmAsm/Codegen/Programs/MptEncode.lean",
     "EvmAsm/Codegen/Programs/StorageWrite.lean",
+    "EvmAsm/Codegen/Programs/AccountApplyStorage.lean",
     "EvmAsm/Codegen/Programs/Noop.lean",
     "EvmAsm/Codegen/Programs/Storage.lean",
     "EvmAsm/Codegen/Programs/MptInternal.lean",

--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -294,7 +294,9 @@ open EvmAsm.Rv64
 def statelessGuestUnit : BuildUnit := {
   body        := EvmAsm.Stateless.run_stateless_guest
   epilogueAsm := statelessGuestEpilogue
-  dataAsm     := statelessGuestDataSection
+  -- guest scratch + the Step-2 verdict's data (zk3_state / rfu_* are dedup'd out
+  -- of the guest section since the appended verdict section provides them).
+  dataAsm     := statelessGuestDataSection ++ "\n" ++ statelessVerdictV2GuestData
 }
 
 /-! ## registry -/

--- a/EvmAsm/Codegen/Programs/AccountApplyStorage.lean
+++ b/EvmAsm/Codegen/Programs/AccountApplyStorage.lean
@@ -1,0 +1,174 @@
+/-
+  EvmAsm.Codegen.Programs.AccountApplyStorage
+
+  account_apply_storage_slot (bead evm-asm-fhsxz.2.4.2.5, step c): apply a single
+  storage write to an account, producing the new account RLP. This is the per-
+  system-contract update the EIP-2935 (history) and EIP-4788 (beacon-roots) block-
+  start system calls perform, and the brick that composes the StorageWrite
+  primitives into the Step-2 state recompute.
+
+  Given an account [nonce, balance, storageRoot, codeHash] and a (slot_key, value):
+    1. read field 2 (storageRoot) via rlp_list_nth_item;
+    2. if it is NOT the EMPTY_TRIE_ROOT, return status 1 (conservative miss —
+       a non-empty storage trie needs the general storage-trie update, out of the
+       single-leaf engine's scope; the verdict then leaves x11 = 0, never a false
+       positive). The genesis case both system contracts hit on the first blocks
+       (empty prior storage) IS handled;
+    3. else new_storage_root = storage_root_single_slot(slot_key, value);
+    4. account_set_storage_root(account, new_storage_root) -> new account RLP.
+
+  Composes storage_root_single_slot + account_set_storage_root (StorageWrite) +
+  rlp_list_nth_item; all byte work byte-wise (no-misaligned invariant).
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.HashBridge
+import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.MptEncode
+import EvmAsm.Codegen.Programs.MptSet
+import EvmAsm.Codegen.Programs.StorageWrite
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+/-! ## account_apply_storage_slot
+    a0 = account RLP ptr   a1 = account RLP length
+    a2 = slot_key ptr (32 B)   a3 = value ptr (minimal-BE word)   a4 = value len
+    a5 = out account RLP ptr   a6 = u64 out length ptr
+    a0 (output) = 0 (ok) / 1 (non-empty prior storage: conservative) /
+                  2 (parse fail). -/
+def accountApplyStorageSlotFunction : String :=
+  "account_apply_storage_slot:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0                   # account\n" ++
+  "  mv s1, a1                   # account len\n" ++
+  "  mv s2, a2                   # slot_key\n" ++
+  "  mv s3, a3                   # value\n" ++
+  "  mv s4, a4                   # value len\n" ++
+  "  mv s5, a5                   # out\n" ++
+  "  mv s6, a6                   # out len\n" ++
+  "  # field 2 = storageRoot -> aps_off / aps_len\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 2; la a3, aps_off; la a4, aps_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Laps_parsefail\n" ++
+  "  la t0, aps_len; ld t1, 0(t0); li t2, 32; bne t1, t2, .Laps_conservative\n" ++
+  "  # compare the 32 storageRoot bytes (account + aps_off) to EMPTY_TRIE_ROOT\n" ++
+  "  la t0, aps_off; ld t1, 0(t0); add t1, s0, t1   # storageRoot ptr\n" ++
+  "  la t2, aps_empty_root; li t3, 32\n" ++
+  ".Laps_cmp:\n" ++
+  "  beqz t3, .Laps_empty\n" ++
+  "  lbu t4, 0(t1); lbu t5, 0(t2); bne t4, t5, .Laps_conservative\n" ++
+  "  addi t1, t1, 1; addi t2, t2, 1; addi t3, t3, -1; j .Laps_cmp\n" ++
+  ".Laps_empty:\n" ++
+  "  # new_storage_root = storage_root_single_slot(slot_key, value, value_len)\n" ++
+  "  mv a0, s2; mv a1, s3; mv a2, s4; la a3, aps_newsroot\n" ++
+  "  jal ra, storage_root_single_slot\n" ++
+  "  # new account = account_set_storage_root(account, len, new_storage_root, out, out_len)\n" ++
+  "  mv a0, s0; mv a1, s1; la a2, aps_newsroot; mv a3, s5; mv a4, s6\n" ++
+  "  jal ra, account_set_storage_root\n" ++
+  "  bnez a0, .Laps_parsefail\n" ++
+  "  li a0, 0\n" ++
+  "  j .Laps_ret\n" ++
+  ".Laps_conservative:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Laps_ret\n" ++
+  ".Laps_parsefail:\n" ++
+  "  li a0, 2\n" ++
+  ".Laps_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-! ### zisk_account_apply_storage_slot probe.
+    Input (file -> INPUT+8): file[0:8]=account_len, file[8:16]=value_len,
+      file[16:48]=slot_key(32B), file[48:80]=value(<=32B), file[128:]=account RLP.
+    Output: OUTPUT+0=status, OUTPUT+8=out_len, OUTPUT+16=new account RLP. -/
+def ziskAccountApplyStorageSlotPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t0, 0x40000000\n" ++
+  "  ld a1, 8(t0)                # account_len\n" ++
+  "  ld a4, 16(t0)               # value_len\n" ++
+  "  addi a2, t0, 24             # slot_key\n" ++
+  "  addi a3, t0, 56             # value\n" ++
+  "  addi a0, t0, 136            # account RLP\n" ++
+  "  la a5, aps_out; la a6, aps_out_len\n" ++
+  "  jal ra, account_apply_storage_slot\n" ++
+  "  li t0, 0xa0010000; sd a0, 0(t0)\n" ++
+  "  la t1, aps_out_len; ld t2, 0(t1); sd t2, 8(t0)\n" ++
+  "  la t1, aps_out; addi t0, t0, 16; li t3, 0\n" ++
+  ".Lapsp_cp:\n" ++
+  "  beq t3, t2, .Lapsp_done\n" ++
+  "  add t4, t1, t3; lbu t5, 0(t4); add t6, t0, t3; sb t5, 0(t6)\n" ++
+  "  addi t3, t3, 1; j .Lapsp_cp\n" ++
+  ".Lapsp_done:\n" ++
+  "  j .Laps_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  hpEncodeNibblesFunction ++ "\n" ++
+  rlpEncodeBytesFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  singleLeafTrieRootFunction ++ "\n" ++
+  storageRootSingleSlotFunction ++ "\n" ++
+  msetMemcpyFunction ++ "\n" ++
+  rlpItemSizeFunction ++ "\n" ++
+  rlpItemSpanFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  mptSpliceSlotFunction ++ "\n" ++
+  accountSetStorageRootFunction ++ "\n" ++
+  accountApplyStorageSlotFunction ++ "\n" ++
+  ".Laps_pdone:"
+
+def ziskAccountApplyStorageSlotDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n  .zero 200\n" ++
+  "sltr_field_len:\n  .zero 8\n" ++
+  "sltr_nibble_count:\n  .zero 8\n" ++
+  "sltr_hp_len:\n  .zero 8\n" ++
+  "sltr_cursor:\n  .zero 8\n" ++
+  "sltr_total_payload:\n  .zero 8\n" ++
+  "sltr_nibbles:\n  .zero 2048\n" ++
+  "sltr_hp_buf:\n  .zero 1024\n" ++
+  "sltr_payload_buf:\n  .zero 16384\n" ++
+  "sltr_node_buf:\n  .zero 16384\n" ++
+  ".balign 32\n" ++
+  "srss_key:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "asr_ref:\n  .zero 40\n" ++
+  "mset_span_start:\n  .zero 8\n" ++
+  "mset_span_size:\n  .zero 8\n" ++
+  "mset_payload_start:\n  .zero 8\n" ++
+  "mset_head_len:\n  .zero 8\n" ++
+  "mset_tail_start:\n  .zero 8\n" ++
+  "mset_tail_len:\n  .zero 8\n" ++
+  "mset_new_payload_len:\n  .zero 8\n" ++
+  "mset_prefix_len:\n  .zero 8\n" ++
+  "mset_cursor:\n  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aps_off:\n  .zero 8\n" ++
+  "aps_len:\n  .zero 8\n" ++
+  "aps_out_len:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aps_newsroot:\n  .zero 32\n" ++
+  "aps_empty_root:\n" ++
+  "  .byte 0x56, 0xe8, 0x1f, 0x17, 0x1b, 0xcc, 0x55, 0xa6\n" ++
+  "  .byte 0xff, 0x83, 0x45, 0xe6, 0x92, 0xc0, 0xf8, 0x6e\n" ++
+  "  .byte 0x5b, 0x48, 0xe0, 0x1b, 0x99, 0x6c, 0xad, 0xc0\n" ++
+  "  .byte 0x01, 0x62, 0x2f, 0xb5, 0xe3, 0x63, 0xb4, 0x21\n" ++
+  ".balign 8\n" ++
+  "aps_out:\n  .zero 256"
+
+def ziskAccountApplyStorageSlotProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskAccountApplyStorageSlotPrologue
+  dataAsm     := ziskAccountApplyStorageSlotDataSection
+}
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/AccountApplyStorage.lean
+++ b/EvmAsm/Codegen/Programs/AccountApplyStorage.lean
@@ -141,6 +141,9 @@ def ziskAccountApplyStorageSlotDataSection : String :=
   ".balign 32\n" ++
   "srss_key:\n  .zero 32\n" ++
   ".balign 8\n" ++
+  "srss_rlpval:\n  .zero 40\n" ++
+  "srss_rlpval_len:\n  .zero 8\n" ++
+  ".balign 8\n" ++
   "asr_ref:\n  .zero 40\n" ++
   "mset_span_start:\n  .zero 8\n" ++
   "mset_span_size:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -159,6 +159,17 @@ def blockVerdictFunction : String :=
   ".Lbv_cmpok:\n" ++
   "  bnez s1, .Lbv_zero\n" ++
   "  bnez s2, .Lbv_zero\n" ++
+  "  # NO-TRANSACTION gate: this verdict does NOT validate transactions, so it can\n" ++
+  "  # only soundly judge no-tx blocks. A tx-bearing INVALID block whose invalid tx\n" ++
+  "  # is rejected (no state change) would otherwise match the recompute -> false\n" ++
+  "  # positive. tx list is empty iff transactions_offset == withdrawals_offset.\n" ++
+  "  addi t4, s3, 60             # exec_payload = SSZ_BASE+60\n" ++
+  "  la t5, bv_exec_p; sd t4, 0(t5)\n" ++
+  "  addi a0, t4, 504; jal ra, bgv_u32le        # transactions_offset\n" ++
+  "  la t5, bv_tx_off; sd a0, 0(t5)\n" ++
+  "  la t5, bv_exec_p; ld t4, 0(t5); addi a0, t4, 508; jal ra, bgv_u32le   # withdrawals_offset\n" ++
+  "  la t5, bv_tx_off; ld t3, 0(t5)\n" ++
+  "  bgtu a0, t3, .Lbv_zero      # wd_off > tx_off => transactions present => conservative 0\n" ++
   "  # EIP-7928 BAL gas-limit rule: reject if the block_access_list exceeds the\n" ++
   "  # gas limit (a semantic invalidity not caught by header/state checks).\n" ++
   "  addi t0, s3, 16             # NPR = SSZ_BASE+16\n" ++
@@ -405,7 +416,8 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bv_exec_p:\n  .zero 8\n" ++
   "bv_npr_p:\n  .zero 8\n" ++
   "bv_bal_start:\n  .zero 8\n" ++
-  "bv_bal_len:\n  .zero 8"
+  "bv_bal_len:\n  .zero 8\n" ++
+  "bv_tx_off:\n  .zero 8"
 
 def ziskStatelessVerdictV2ProbeUnit : BuildUnit := {
   body        := NOP

--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -413,4 +413,92 @@ def ziskStatelessVerdictV2ProbeUnit : BuildUnit := {
   dataAsm     := ziskStatelessVerdictV2DataSection
 }
 
+/-- The full stateless_verdict_v2 asm closure for embedding in the GUEST epilogue,
+    OMITTING rlp_list_nth_item + rlp_field_to_u64 (the guest already defines those,
+    so they would be duplicate labels). The guest jal's `stateless_verdict_v2` and
+    writes its bit to OUTPUT[32]. -/
+def statelessVerdictV2GuestClosure : String :=
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpFieldToU256BeFunction ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  hpEncodeNibblesFunction ++ "\n" ++
+  rlpEncodeBytesFunction ++ "\n" ++
+  rlpEncodeUintBeFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  rlpItemSizeFunction ++ "\n" ++
+  rlpItemSpanFunction ++ "\n" ++
+  mptLeafNodeEncodeFromNibblesFunction ++ "\n" ++
+  mptNodeSlotEncodeFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  u256FromU64BeFunction ++ "\n" ++
+  u256MulU64BeFunction ++ "\n" ++
+  u256DivU64BeFunction ++ "\n" ++
+  u256IsZeroFunction ++ "\n" ++
+  u256AddBeFunction ++ "\n" ++
+  u256SubBeFunction ++ "\n" ++
+  u256EqFunction ++ "\n" ++
+  withdrawalDecodeFunction ++ "\n" ++
+  withdrawalToPathDeltaFunction ++ "\n" ++
+  msetMemcpyFunction ++ "\n" ++
+  mptSpliceSlotFunction ++ "\n" ++
+  accountAddBalanceFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  nodeDbAppendFunction ++ "\n" ++
+  nodeDbLookupFunction ++ "\n" ++
+  mptNodeResolveFunction ++ "\n" ++
+  mptSetRecordWalkDbFunction ++ "\n" ++
+  mptSetAccFunction ++ "\n" ++
+  mptStateRootFunction ++ "\n" ++
+  withdrawalsStateRootFunction ++ "\n" ++
+  validateHeaderBasicFunction ++ "\n" ++
+  checkGasLimitFunction ++ "\n" ++
+  headerValidatePostMergeFunction ++ "\n" ++
+  headerValidateExtraDataLengthFunction ++ "\n" ++
+  eip1559CalcBaseFeePerGasFunction ++ "\n" ++
+  headerValidateBaseFeeFunction ++ "\n" ++
+  validateHeaderFullFunction ++ "\n" ++
+  headerExtendedDecodeFunction ++ "\n" ++
+  headersParentHashFunction ++ "\n" ++
+  headerValidateParentHashFunction ++ "\n" ++
+  validateHeaderRlpPairFunction ++ "\n" ++
+  bhrRevLeBeFunction ++ "\n" ++
+  blockHeaderSszToRlpFunction ++ "\n" ++
+  step2VerdictFunction ++ "\n" ++
+  headerExtractStateRootFunction ++ "\n" ++
+  ephU32leFunction ++ "\n" ++
+  extractParentHeaderAndStateRootFunction ++ "\n" ++
+  spwU32leFunction ++ "\n" ++
+  extractPayloadAndWithdrawalsFunction ++ "\n" ++
+  swsU32leFunction ++ "\n" ++
+  extractWitnessStateSectionFunction ++ "\n" ++
+  swrRevLeBeFunction ++ "\n" ++
+  sszWithdrawalToRlpFunction ++ "\n" ++
+  statelessVerdictFromSszFunction ++ "\n" ++
+  singleLeafTrieRootFunction ++ "\n" ++
+  storageRootSingleSlotFunction ++ "\n" ++
+  accountSetStorageRootFunction ++ "\n" ++
+  accountApplyStorageSlotFunction ++ "\n" ++
+  swdReadU64leFunction ++ "\n" ++
+  swdWriteBe32U64Function ++ "\n" ++
+  swdWriteBe8Function ++ "\n" ++
+  swdMinimalCopyFunction ++ "\n" ++
+  systemWriteDescriptorsFunction ++ "\n" ++
+  bsrSysChangeFunction ++ "\n" ++
+  blockStateRootFunction ++ "\n" ++
+  blockVerdictFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  bgvU32leFunction ++ "\n" ++
+  bgvU64leFunction ++ "\n" ++
+  balGasValidFunction ++ "\n" ++
+  statelessVerdictV2Function
+
+/-- The data section the guest needs for the embedded verdict closure (same as the
+    probe's, MINUS zk3_state / rfu_offset / rfu_length which the guest data already
+    defines — those are removed from the guest data section to avoid dup labels). -/
+def statelessVerdictV2GuestData : String :=
+  ziskStatelessVerdictV2DataSection
+
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -1,0 +1,382 @@
+/-
+  EvmAsm.Codegen.Programs.BlockVerdict
+
+  Step (d) of bead evm-asm-fhsxz.2.4.2.5 — the FULL state-transition verdict that
+  composes the EIP-2935 + EIP-4788 system-contract storage writes with the
+  withdrawal balance credits into ONE post-state-root recompute. This is what
+  turns the verified bricks into actual EEST withdrawal full-matches.
+
+    block_state_root: system_write_descriptors -> for each of the 2 system
+      contracts: walk the pre-state account, account_apply_storage_slot, record a
+      state-trie change; then the withdrawal changes (walk + account_add_balance);
+      then mpt_state_root over ALL changes -> post-state root.
+    block_verdict: block_header_ssz_to_rlp + validate_header_rlp_pair +
+      block_state_root + memcmp(recomputed, payload.state_root).
+    stateless_verdict_v2: the real-SSZ glue (= stateless_verdict_from_ssz) but
+      calling block_verdict (system writes included) instead of step2_verdict.
+
+  Conservative throughout: any walk miss / non-empty-storage system contract /
+  insert-needed withdrawal -> status != 0 -> verdict 0 (a MISS, never a false
+  positive). Reuses the stateless_verdict asm closure + data verbatim and adds the
+  StorageWrite / SystemWrites / single_leaf functions.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.MptEncode
+import EvmAsm.Codegen.Programs.StorageWrite
+import EvmAsm.Codegen.Programs.SystemWrites
+import EvmAsm.Codegen.Programs.AccountApplyStorage
+import EvmAsm.Codegen.Programs.StatelessVerdict
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+/-! ## bsr_sys_change -- record one system-contract storage-write change.
+    a0 = contract addr ptr (20 B)   a1 = slot_key ptr (32 B)
+    a2 = value ptr   a3 = value len   a4 = change index
+    Reads shared state from bsr_root_p / bsr_wit_p / bsr_wl_v; writes the change
+    entry at bsr_changes[index]. a0 (output) = 0 ok / 1 conservative. -/
+def bsrSysChangeFunction : String :=
+  "bsr_sys_change:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0; mv s1, a1; mv s2, a2; mv s3, a3; mv s4, a4\n" ++
+  "  # keccak(addr, 20) -> bsr_kbuf\n" ++
+  "  mv a0, s0; li a1, 20; la a2, bsr_kbuf; jal ra, zkvm_keccak256\n" ++
+  "  # path = bsr_paths + 64*index; bytes_to_nibbles(bsr_kbuf, 32, path)\n" ++
+  "  slli t0, s4, 6; la t1, bsr_paths; add t2, t1, t0\n" ++
+  "  la t3, bsr_pathp; sd t2, 0(t3)              # stash path ptr\n" ++
+  "  la a0, bsr_kbuf; li a1, 32; mv a2, t2; jal ra, bytes_to_nibbles\n" ++
+  "  # mpt_walk(root, witness, wlen, path, 64, bsr_acct, bsr_acct_len)\n" ++
+  "  la t0, bsr_root_p; ld a0, 0(t0); la t0, bsr_wit_p; ld a1, 0(t0); la t0, bsr_wl_v; ld a2, 0(t0)\n" ++
+  "  la t0, bsr_pathp; ld a3, 0(t0); li a4, 64; la a5, bsr_acct; la a6, bsr_acct_len\n" ++
+  "  jal ra, mpt_walk\n" ++
+  "  bnez a0, .Lbsc_fail\n" ++
+  "  # account_apply_storage_slot(acct, len, slot, val, vlen, newacct, bsr_tmplen)\n" ++
+  "  la a0, bsr_acct; la t0, bsr_acct_len; ld a1, 0(t0); mv a2, s1; mv a3, s2; mv a4, s3\n" ++
+  "  slli t0, s4, 7; la t1, bsr_newaccts; add a5, t1, t0; la a6, bsr_tmplen\n" ++
+  "  jal ra, account_apply_storage_slot\n" ++
+  "  bnez a0, .Lbsc_fail\n" ++
+  "  # record change[index] = (path, 64, newacct, tmplen)\n" ++
+  "  slli t0, s4, 5; la t1, bsr_changes; add t1, t1, t0\n" ++
+  "  la t2, bsr_pathp; ld t2, 0(t2); sd t2, 0(t1); li t3, 64; sd t3, 8(t1)\n" ++
+  "  slli t0, s4, 7; la t2, bsr_newaccts; add t2, t2, t0; sd t2, 16(t1)\n" ++
+  "  la t2, bsr_tmplen; ld t2, 0(t2); sd t2, 24(t1)\n" ++
+  "  li a0, 0; j .Lbsc_ret\n" ++
+  ".Lbsc_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lbsc_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-! ## block_state_root -- post-state root after system writes + withdrawals.
+    a0 = pre-state root ptr   a1 = witness   a2 = witness_len
+    a3 = wds descriptors   a4 = n_wds   a5 = out_root   a6 = SSZ_BASE
+    a0 (output) = 0 ok / 1 conservative (any miss / unsupported case). -/
+def blockStateRootFunction : String :=
+  "block_state_root:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s3, 24(sp); sd s4, 32(sp); sd s5, 40(sp)\n" ++
+  "  la t0, bsr_root_p; sd a0, 0(t0)\n" ++
+  "  la t0, bsr_wit_p;  sd a1, 0(t0)\n" ++
+  "  la t0, bsr_wl_v;   sd a2, 0(t0)\n" ++
+  "  mv s3, a3                   # wds descriptors\n" ++
+  "  mv s4, a4                   # n_wds\n" ++
+  "  mv s5, a5                   # out_root\n" ++
+  "  # derive the system writes (SSZ_BASE in a6)\n" ++
+  "  mv a0, a6; jal ra, system_write_descriptors\n" ++
+  "  # system change 0 = EIP-2935\n" ++
+  "  la a0, bsr_addr_2935; la a1, swd_2935_slot; la a2, swd_2935_val\n" ++
+  "  la t0, swd_2935_vlen; ld a3, 0(t0); li a4, 0\n" ++
+  "  jal ra, bsr_sys_change; bnez a0, .Lbsr_cons\n" ++
+  "  # system change 1 = EIP-4788\n" ++
+  "  la a0, bsr_addr_4788; la a1, swd_4788_slot; la a2, swd_4788_val\n" ++
+  "  la t0, swd_4788_vlen; ld a3, 0(t0); li a4, 1\n" ++
+  "  jal ra, bsr_sys_change; bnez a0, .Lbsr_cons\n" ++
+  "  # withdrawal changes at index 2..2+n_wds\n" ++
+  "  li s0, 0\n" ++
+  ".Lbsr_wl:\n" ++
+  "  beq s0, s4, .Lbsr_apply\n" ++
+  "  addi s1, s0, 2               # change index\n" ++
+  "  slli t0, s0, 4; add t0, s3, t0; ld a0, 0(t0); ld a1, 8(t0)   # wd[i] rlp ptr/len\n" ++
+  "  slli t1, s1, 6; la t2, bsr_paths; add a2, t2, t1; la a3, bsr_delta\n" ++
+  "  jal ra, withdrawal_to_path_delta; bnez a0, .Lbsr_cons\n" ++
+  "  la t0, bsr_root_p; ld a0, 0(t0); la t0, bsr_wit_p; ld a1, 0(t0); la t0, bsr_wl_v; ld a2, 0(t0)\n" ++
+  "  slli t1, s1, 6; la t2, bsr_paths; add a3, t2, t1; li a4, 64; la a5, bsr_acct; la a6, bsr_acct_len\n" ++
+  "  jal ra, mpt_walk; bnez a0, .Lbsr_cons\n" ++
+  "  la a0, bsr_acct; la t0, bsr_acct_len; ld a1, 0(t0); la a2, bsr_delta\n" ++
+  "  slli t1, s1, 7; la t2, bsr_newaccts; add a3, t2, t1; la a4, bsr_tmplen\n" ++
+  "  jal ra, account_add_balance; bnez a0, .Lbsr_cons\n" ++
+  "  slli t0, s1, 5; la t1, bsr_changes; add t1, t1, t0\n" ++
+  "  slli t2, s1, 6; la t3, bsr_paths; add t3, t3, t2; sd t3, 0(t1); li t3, 64; sd t3, 8(t1)\n" ++
+  "  slli t2, s1, 7; la t3, bsr_newaccts; add t3, t3, t2; sd t3, 16(t1)\n" ++
+  "  la t3, bsr_tmplen; ld t3, 0(t3); sd t3, 24(t1)\n" ++
+  "  addi s0, s0, 1; j .Lbsr_wl\n" ++
+  ".Lbsr_apply:\n" ++
+  "  la t0, bsr_root_p; ld a0, 0(t0); la t0, bsr_wit_p; ld a1, 0(t0); la t0, bsr_wl_v; ld a2, 0(t0)\n" ++
+  "  la a3, bsr_changes; addi a4, s4, 2; mv a5, s5\n" ++
+  "  jal ra, mpt_state_root\n" ++
+  "  j .Lbsr_ret\n" ++
+  ".Lbsr_cons:\n" ++
+  "  li a0, 1\n" ++
+  ".Lbsr_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s3, 24(sp); ld s4, 32(sp); ld s5, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-! ## block_verdict -- step2_verdict with the FULL (system + withdrawal) recompute.
+    a0 = params ptr (the step2_verdict struct)   a1 = SSZ_BASE
+    a0 (output) = verdict bit. -/
+def blockVerdictFunction : String :=
+  "block_verdict:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra, 0(sp); sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  mv s0, a0                   # params\n" ++
+  "  mv s3, a1                   # SSZ_BASE\n" ++
+  "  ld a0, 0(s0); ld a1, 32(s0); ld a2, 40(s0); ld a3, 48(s0); ld a4, 56(s0)\n" ++
+  "  la a5, sv_this_rlp; la a6, sv_this_rlp_len\n" ++
+  "  jal ra, block_header_ssz_to_rlp\n" ++
+  "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0); ld a2, 8(s0); ld a3, 16(s0)\n" ++
+  "  jal ra, validate_header_rlp_pair\n" ++
+  "  mv s1, a0\n" ++
+  "  ld a0, 24(s0); ld a1, 80(s0); ld a2, 88(s0); ld a3, 64(s0); ld a4, 72(s0)\n" ++
+  "  la a5, sv_recomputed; mv a6, s3\n" ++
+  "  jal ra, block_state_root\n" ++
+  "  mv s2, a0\n" ++
+  "  la t0, sv_recomputed; ld t1, 0(s0); addi t1, t1, 52; li t2, 32\n" ++
+  ".Lbv_cmp:\n" ++
+  "  beqz t2, .Lbv_cmpok\n" ++
+  "  lbu t3, 0(t0); lbu t4, 0(t1); bne t3, t4, .Lbv_zero\n" ++
+  "  addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1; j .Lbv_cmp\n" ++
+  ".Lbv_cmpok:\n" ++
+  "  bnez s1, .Lbv_zero\n" ++
+  "  bnez s2, .Lbv_zero\n" ++
+  "  li a0, 1; j .Lbv_ret\n" ++
+  ".Lbv_zero:\n" ++
+  "  li a0, 0\n" ++
+  ".Lbv_ret:\n" ++
+  "  ld ra, 0(sp); ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-! ## stateless_verdict_v2 -- real-SSZ glue calling block_verdict (system writes). -/
+def statelessVerdictV2Function : String :=
+  "stateless_verdict_v2:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp)\n" ++
+  "  li s0, 0x40000000\n" ++
+  "  addi s0, s0, 18\n" ++
+  "  mv a0, s0; la a1, svf_payload; la a2, svf_wds_ptr; la a3, svf_wds_count\n" ++
+  "  jal ra, extract_payload_and_withdrawals\n" ++
+  "  mv a0, s0; la a1, svf_witness; la a2, svf_witness_len\n" ++
+  "  jal ra, extract_witness_state_section\n" ++
+  "  mv a0, s0; la t0, svf_payload; ld a1, 0(t0)\n" ++
+  "  la a2, svf_parent_rlp; la a3, svf_parent_rlp_len; la a4, svf_parent_sr\n" ++
+  "  jal ra, extract_parent_header_and_state_root\n" ++
+  "  bnez a0, .Lv2_zero\n" ++
+  "  la t0, svf_wds_count; ld s1, 0(t0)\n" ++
+  "  la t0, svf_wds_ptr;   ld s2, 0(t0)\n" ++
+  "  la s3, svf_descriptors\n" ++
+  "  la s4, svf_rlp_arena\n" ++
+  "  li s5, 0\n" ++
+  ".Lv2_wl:\n" ++
+  "  bge s5, s1, .Lv2_wd\n" ++
+  "  mv a0, s2; mv a1, s4; la a2, svf_wd_len\n" ++
+  "  jal ra, ssz_withdrawal_to_rlp\n" ++
+  "  sd s4, 0(s3); la t0, svf_wd_len; ld t1, 0(t0); sd t1, 8(s3)\n" ++
+  "  addi s2, s2, 44; addi s4, s4, 72; addi s3, s3, 16; addi s5, s5, 1; j .Lv2_wl\n" ++
+  ".Lv2_wd:\n" ++
+  "  la t1, sv_params\n" ++
+  "  la t0, svf_payload;        ld t0, 0(t0); sd t0, 0(t1)\n" ++
+  "  la t0, svf_parent_rlp;     ld t0, 0(t0); sd t0, 8(t1)\n" ++
+  "  la t0, svf_parent_rlp_len; ld t0, 0(t0); sd t0, 16(t1)\n" ++
+  "  la t0, svf_parent_sr;      sd t0, 24(t1)\n" ++
+  "  la t0, svf_zero32;         sd t0, 32(t1)\n" ++
+  "  la t0, svf_zero32;         sd t0, 40(t1)\n" ++
+  "  addi t0, s0, 24;           sd t0, 48(t1)\n" ++
+  "  la t0, svf_zero32;         sd t0, 56(t1)\n" ++
+  "  la t0, svf_descriptors;    sd t0, 64(t1)\n" ++
+  "  la t0, svf_wds_count;      ld t0, 0(t0); sd t0, 72(t1)\n" ++
+  "  la t0, svf_witness;        ld t0, 0(t0); sd t0, 80(t1)\n" ++
+  "  la t0, svf_witness_len;    ld t0, 0(t0); sd t0, 88(t1)\n" ++
+  "  la a0, sv_params; mv a1, s0\n" ++
+  "  jal ra, block_verdict\n" ++
+  "  j .Lv2_ret\n" ++
+  ".Lv2_zero:\n" ++
+  "  li a0, 0\n" ++
+  ".Lv2_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_stateless_verdict_v2`: probe. Fed the SAME `-i` input as the guest.
+    Output OUTPUT+0 = verdict bit (system writes + withdrawals modeled). -/
+def ziskStatelessVerdictV2Prologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  jal ra, stateless_verdict_v2\n" ++
+  "  li t0, 0xa0010000; sd a0, 0(t0)            # OUTPUT+0 = verdict bit\n" ++
+  "  j .Lv2_pdone\n" ++
+  -- the full stateless_verdict closure (verbatim):
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  rlpFieldToU256BeFunction ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  hpEncodeNibblesFunction ++ "\n" ++
+  rlpEncodeBytesFunction ++ "\n" ++
+  rlpEncodeUintBeFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  rlpItemSizeFunction ++ "\n" ++
+  rlpItemSpanFunction ++ "\n" ++
+  mptLeafNodeEncodeFromNibblesFunction ++ "\n" ++
+  mptNodeSlotEncodeFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  u256FromU64BeFunction ++ "\n" ++
+  u256MulU64BeFunction ++ "\n" ++
+  u256DivU64BeFunction ++ "\n" ++
+  u256IsZeroFunction ++ "\n" ++
+  u256AddBeFunction ++ "\n" ++
+  u256SubBeFunction ++ "\n" ++
+  u256EqFunction ++ "\n" ++
+  withdrawalDecodeFunction ++ "\n" ++
+  withdrawalToPathDeltaFunction ++ "\n" ++
+  msetMemcpyFunction ++ "\n" ++
+  mptSpliceSlotFunction ++ "\n" ++
+  accountAddBalanceFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  nodeDbAppendFunction ++ "\n" ++
+  nodeDbLookupFunction ++ "\n" ++
+  mptNodeResolveFunction ++ "\n" ++
+  mptSetRecordWalkDbFunction ++ "\n" ++
+  mptSetAccFunction ++ "\n" ++
+  mptStateRootFunction ++ "\n" ++
+  withdrawalsStateRootFunction ++ "\n" ++
+  validateHeaderBasicFunction ++ "\n" ++
+  checkGasLimitFunction ++ "\n" ++
+  headerValidatePostMergeFunction ++ "\n" ++
+  headerValidateExtraDataLengthFunction ++ "\n" ++
+  eip1559CalcBaseFeePerGasFunction ++ "\n" ++
+  headerValidateBaseFeeFunction ++ "\n" ++
+  validateHeaderFullFunction ++ "\n" ++
+  headerExtendedDecodeFunction ++ "\n" ++
+  headersParentHashFunction ++ "\n" ++
+  headerValidateParentHashFunction ++ "\n" ++
+  validateHeaderRlpPairFunction ++ "\n" ++
+  bhrRevLeBeFunction ++ "\n" ++
+  blockHeaderSszToRlpFunction ++ "\n" ++
+  step2VerdictFunction ++ "\n" ++
+  headerExtractStateRootFunction ++ "\n" ++
+  ephU32leFunction ++ "\n" ++
+  extractParentHeaderAndStateRootFunction ++ "\n" ++
+  spwU32leFunction ++ "\n" ++
+  extractPayloadAndWithdrawalsFunction ++ "\n" ++
+  swsU32leFunction ++ "\n" ++
+  extractWitnessStateSectionFunction ++ "\n" ++
+  swrRevLeBeFunction ++ "\n" ++
+  sszWithdrawalToRlpFunction ++ "\n" ++
+  statelessVerdictFromSszFunction ++ "\n" ++
+  -- NEW: single_leaf + storage + system + block verdict:
+  singleLeafTrieRootFunction ++ "\n" ++
+  storageRootSingleSlotFunction ++ "\n" ++
+  accountSetStorageRootFunction ++ "\n" ++
+  accountApplyStorageSlotFunction ++ "\n" ++
+  swdReadU64leFunction ++ "\n" ++
+  swdWriteBe32U64Function ++ "\n" ++
+  swdWriteBe8Function ++ "\n" ++
+  swdMinimalCopyFunction ++ "\n" ++
+  systemWriteDescriptorsFunction ++ "\n" ++
+  bsrSysChangeFunction ++ "\n" ++
+  blockStateRootFunction ++ "\n" ++
+  blockVerdictFunction ++ "\n" ++
+  statelessVerdictV2Function ++ "\n" ++
+  ".Lv2_pdone:"
+
+def ziskStatelessVerdictV2DataSection : String :=
+  ziskStatelessVerdictDataSection ++ "\n" ++
+  -- single_leaf scratch:
+  ".balign 8\n" ++
+  "sltr_field_len:\n  .zero 8\n" ++
+  "sltr_nibble_count:\n  .zero 8\n" ++
+  "sltr_hp_len:\n  .zero 8\n" ++
+  "sltr_cursor:\n  .zero 8\n" ++
+  "sltr_total_payload:\n  .zero 8\n" ++
+  "sltr_nibbles:\n  .zero 2048\n" ++
+  "sltr_hp_buf:\n  .zero 1024\n" ++
+  "sltr_payload_buf:\n  .zero 16384\n" ++
+  "sltr_node_buf:\n  .zero 16384\n" ++
+  ".balign 32\n" ++
+  "srss_key:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "srss_rlpval:\n  .zero 40\n" ++
+  "srss_rlpval_len:\n  .zero 8\n" ++
+  "asr_ref:\n  .zero 40\n" ++
+  "aps_off:\n  .zero 8\n" ++
+  "aps_len:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aps_newsroot:\n  .zero 32\n" ++
+  "aps_empty_root:\n" ++
+  "  .byte 0x56, 0xe8, 0x1f, 0x17, 0x1b, 0xcc, 0x55, 0xa6\n" ++
+  "  .byte 0xff, 0x83, 0x45, 0xe6, 0x92, 0xc0, 0xf8, 0x6e\n" ++
+  "  .byte 0x5b, 0x48, 0xe0, 0x1b, 0x99, 0x6c, 0xad, 0xc0\n" ++
+  "  .byte 0x01, 0x62, 0x2f, 0xb5, 0xe3, 0x63, 0xb4, 0x21\n" ++
+  -- system_write_descriptors output:
+  ".balign 32\n" ++
+  "swd_2935_slot:\n  .zero 32\n" ++
+  ".balign 32\n" ++
+  "swd_2935_val:\n  .zero 32\n" ++
+  ".balign 32\n" ++
+  "swd_4788_slot:\n  .zero 32\n" ++
+  ".balign 32\n" ++
+  "swd_4788_val:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "swd_2935_vlen:\n  .zero 8\n" ++
+  "swd_4788_vlen:\n  .zero 8\n" ++
+  "swd_ts_be8:\n  .zero 8\n" ++
+  -- block_state_root scratch:
+  ".balign 8\n" ++
+  "bsr_root_p:\n  .zero 8\n" ++
+  "bsr_wit_p:\n  .zero 8\n" ++
+  "bsr_wl_v:\n  .zero 8\n" ++
+  "bsr_pathp:\n  .zero 8\n" ++
+  "bsr_acct_len:\n  .zero 8\n" ++
+  "bsr_tmplen:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "bsr_kbuf:\n  .zero 32\n" ++
+  "bsr_delta:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "bsr_acct:\n  .zero 256\n" ++
+  "bsr_paths:\n  .zero 1152\n" ++
+  "bsr_newaccts:\n  .zero 2304\n" ++
+  "bsr_changes:\n  .zero 576\n" ++
+  ".balign 32\n" ++
+  "bsr_addr_2935:\n" ++
+  "  .byte 0x00, 0x00, 0xF9, 0x08, 0x27, 0xF1, 0xC5, 0x3a\n" ++
+  "  .byte 0x10, 0xcb, 0x7A, 0x02, 0x33, 0x5B, 0x17, 0x53\n" ++
+  "  .byte 0x20, 0x00, 0x29, 0x35\n" ++
+  ".balign 32\n" ++
+  "bsr_addr_4788:\n" ++
+  "  .byte 0x00, 0x0F, 0x3d, 0xf6, 0xD7, 0x32, 0x80, 0x7E\n" ++
+  "  .byte 0xf1, 0x31, 0x9f, 0xB7, 0xB8, 0xbB, 0x85, 0x22\n" ++
+  "  .byte 0xd0, 0xBe, 0xac, 0x02"
+
+def ziskStatelessVerdictV2ProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskStatelessVerdictV2Prologue
+  dataAsm     := ziskStatelessVerdictV2DataSection
+}
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -28,6 +28,7 @@ import EvmAsm.Codegen.Programs.StorageWrite
 import EvmAsm.Codegen.Programs.SystemWrites
 import EvmAsm.Codegen.Programs.AccountApplyStorage
 import EvmAsm.Codegen.Programs.StatelessVerdict
+import EvmAsm.Codegen.Programs.BalGasValid
 
 namespace EvmAsm.Codegen
 
@@ -158,6 +159,25 @@ def blockVerdictFunction : String :=
   ".Lbv_cmpok:\n" ++
   "  bnez s1, .Lbv_zero\n" ++
   "  bnez s2, .Lbv_zero\n" ++
+  "  # EIP-7928 BAL gas-limit rule: reject if the block_access_list exceeds the\n" ++
+  "  # gas limit (a semantic invalidity not caught by header/state checks).\n" ++
+  "  addi t0, s3, 16             # NPR = SSZ_BASE+16\n" ++
+  "  addi t1, t0, 44             # exec_payload = NPR+44\n" ++
+  "  la t2, bv_exec_p; sd t1, 0(t2)\n" ++
+  "  la t2, bv_npr_p;  sd t0, 0(t2)\n" ++
+  "  addi a0, t1, 528; jal ra, bgv_u32le        # bal_off\n" ++
+  "  la t2, bv_exec_p; ld t1, 0(t2); add a0, t1, a0   # bal_start\n" ++
+  "  la t2, bv_bal_start; sd a0, 0(t2)\n" ++
+  "  la t2, bv_npr_p; ld t0, 0(t2); addi a0, t0, 4; jal ra, bgv_u32le   # vh_off\n" ++
+  "  la t2, bv_npr_p; ld t0, 0(t2); add a1, t0, a0   # bal_end\n" ++
+  "  la t2, bv_bal_start; ld t3, 0(t2); sub a1, a1, t3   # bal_len (a1 survives bgv_u64le)\n" ++
+  "  la t2, bv_bal_len; sd a1, 0(t2)\n" ++
+  "  la t2, bv_exec_p; ld t1, 0(t2); addi a0, t1, 412; jal ra, bgv_u64le   # a0 = gas_limit\n" ++
+  "  mv a2, a0                                  # gas_limit\n" ++
+  "  la t2, bv_bal_start; ld a0, 0(t2)          # bal_start\n" ++
+  "  la t2, bv_bal_len; ld a1, 0(t2)            # bal_len\n" ++
+  "  jal ra, bal_gas_valid\n" ++
+  "  bnez a0, .Lbv_zero          # BAL gas exceeded (or parse fail) -> invalid\n" ++
   "  li a0, 1; j .Lbv_ret\n" ++
   ".Lbv_zero:\n" ++
   "  li a0, 0\n" ++
@@ -302,6 +322,10 @@ def ziskStatelessVerdictV2Prologue : String :=
   bsrSysChangeFunction ++ "\n" ++
   blockStateRootFunction ++ "\n" ++
   blockVerdictFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  bgvU32leFunction ++ "\n" ++
+  bgvU64leFunction ++ "\n" ++
+  balGasValidFunction ++ "\n" ++
   statelessVerdictV2Function ++ "\n" ++
   ".Lv2_pdone:"
 
@@ -371,7 +395,17 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bsr_addr_4788:\n" ++
   "  .byte 0x00, 0x0F, 0x3d, 0xf6, 0xD7, 0x32, 0x80, 0x7E\n" ++
   "  .byte 0xf1, 0x31, 0x9f, 0xB7, 0xB8, 0xbB, 0x85, 0x22\n" ++
-  "  .byte 0xd0, 0xBe, 0xac, 0x02"
+  "  .byte 0xd0, 0xBe, 0xac, 0x02\n" ++
+  -- bal_gas_valid scratch (bal_gas_valid + block_verdict's BAL navigation):
+  ".balign 8\n" ++
+  "bgv_count:\n  .zero 8\n" ++
+  "bgv_off:\n  .zero 8\n" ++
+  "bgv_size:\n  .zero 8\n" ++
+  "bgv_acctlen:\n  .zero 8\n" ++
+  "bv_exec_p:\n  .zero 8\n" ++
+  "bv_npr_p:\n  .zero 8\n" ++
+  "bv_bal_start:\n  .zero 8\n" ++
+  "bv_bal_len:\n  .zero 8"
 
 def ziskStatelessVerdictV2ProbeUnit : BuildUnit := {
   body        := NOP

--- a/EvmAsm/Codegen/Programs/StatelessGuestData.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuestData.lean
@@ -148,14 +148,9 @@ def statelessGuestDataSection : String :=
   "sg_kpr_bad_index:\n" ++
   "  .zero 8\n" ++
   -- Shared K-PR scratch (zk3_state / rfu_offset / rfu_length: used by
-  -- rlp_list_nth_item + rlp_field_to_u64; same labels each K-PR
-  -- declares, declared once here):
-  "zk3_state:\n" ++
-  "  .zero 200\n" ++
-  "rfu_offset:\n" ++
-  "  .zero 8\n" ++
-  "rfu_length:\n" ++
-  "  .zero 8\n" ++
+  -- rlp_list_nth_item + rlp_field_to_u64). Now provided by the appended Step-2
+  -- verdict data section (statelessGuestUnit.dataAsm), so NOT declared here to
+  -- avoid duplicate-symbol errors.
   -- K290 chain_validate_post_merge_full scratch:
   "cvpmf_field:\n" ++
   "  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/StatelessGuestEpilogue.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuestEpilogue.lean
@@ -14,6 +14,7 @@ import EvmAsm.Codegen.Programs.HashBridge
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.Ssz
 import EvmAsm.Codegen.Programs.Tx
+import EvmAsm.Codegen.Programs.BlockVerdict
 
 namespace EvmAsm.Codegen
 
@@ -756,6 +757,13 @@ def statelessGuestEpilogue : String :=
   "  ld t2, 24(t3); sd t2, 56(t1)\n" ++
   "  la a0, npr_sha_input; li a1, 64; li a2, 0xa0010000\n" ++
   "  jal ra, zkvm_sha256         # root -> OUTPUT_ADDR\n" ++
+  "  # ===== Step-2 successful_validation: sound full state-transition verdict =====\n" ++
+  "  # (header-validate + withdrawals/EIP-2935/EIP-4788 state recompute ==\n" ++
+  "  #  payload.state_root + EIP-7928 BAL gas-limit rule). NPR root is already at\n" ++
+  "  #  OUTPUT[0..32); stamp the verdict bit at OUTPUT[32]. Conservative: any\n" ++
+  "  #  unhandled case -> 0 (never a false positive).\n" ++
+  "  jal ra, stateless_verdict_v2\n" ++
+  "  li t0, 0xa0010000; sb a0, 32(t0)\n" ++
   "  j .Lsg_done\n" ++
   zkvmSha256Function ++ "\n" ++
   -- SSZ merkleization helpers for the dynamic transactions_root /
@@ -962,6 +970,9 @@ def statelessGuestEpilogue : String :=
   chainValidateBlobGasUsedUnderMaxFunction ++ "\n" ++
   chainValidateIncreasingTimestampsFunction ++ "\n" ++
   chainValidateConsecutiveNumbersFunction ++ "\n" ++
+  -- Step-2 verdict closure (omits rlp_list_nth_item / rlp_field_to_u64 — already
+  -- defined above in this epilogue — to avoid duplicate labels):
+  statelessVerdictV2GuestClosure ++ "\n" ++
   ".Lsg_done:"
 
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/StorageWrite.lean
+++ b/EvmAsm/Codegen/Programs/StorageWrite.lean
@@ -46,11 +46,16 @@ def storageRootSingleSlotFunction : String :=
   "  mv s1, a1                   # value ptr\n" ++
   "  mv s2, a2                   # value len\n" ++
   "  mv s3, a3                   # out root\n" ++
+  "  # The storage-trie leaf value is RLP(stored word), which the leaf node\n" ++
+  "  # then wraps again -- so RLP-encode the value FIRST (for a >=0x80 / multi-\n" ++
+  "  # byte word this adds the 0x80+len prefix; small words are unchanged).\n" ++
+  "  mv a0, s1; mv a1, s2; la a2, srss_rlpval; la a3, srss_rlpval_len\n" ++
+  "  jal ra, rlp_encode_bytes\n" ++
   "  # trie key = keccak256(slot_key, 32) -> srss_key\n" ++
   "  mv a0, s0; li a1, 32; la a2, srss_key\n" ++
   "  jal ra, zkvm_keccak256\n" ++
-  "  # root = single_leaf_trie_root(srss_key, 32, value, value_len, out)\n" ++
-  "  la a0, srss_key; li a1, 32; mv a2, s1; mv a3, s2; mv a4, s3\n" ++
+  "  # root = single_leaf_trie_root(srss_key, 32, RLP(value), len, out)\n" ++
+  "  la a0, srss_key; li a1, 32; la a2, srss_rlpval; la t0, srss_rlpval_len; ld a3, 0(t0); mv a4, s3\n" ++
   "  jal ra, single_leaf_trie_root\n" ++
   "  li a0, 0\n" ++
   "  ld ra, 0(sp)\n" ++
@@ -126,7 +131,10 @@ def ziskStorageRootSingleSlotDataSection : String :=
   "sltr_payload_buf:\n  .zero 16384\n" ++
   "sltr_node_buf:\n  .zero 16384\n" ++
   ".balign 32\n" ++
-  "srss_key:\n  .zero 32"
+  "srss_key:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "srss_rlpval:\n  .zero 40\n" ++
+  "srss_rlpval_len:\n  .zero 8"
 
 def ziskStorageRootSingleSlotProbeUnit : BuildUnit := {
   body        := NOP

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **468**
-- ziskemu round-trip scripts: **460** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **479**
+- ziskemu round-trip scripts: **469** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **466**
-- ziskemu round-trip scripts: **458** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **479**
+- ziskemu round-trip scripts: **469** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -109,7 +109,7 @@ when the underlying state changes.
 | Reference fork | Frontier/Shanghai (most opcodes); Amsterdam draft fork referenced for SDIV/SMOD |
 | Pin | `ethereum/execution-specs@ec23140` (gitlink in `.gitmodules`) |
 | Per-opcode reference-link audit | manual; `EvmWord.<op>` defs cite Python files in their docstrings (not yet machine-checked) |
-| EEST fixture pass rate | ✗ harness not yet wired (parking-lot dependency on D obligations 3 + 4) |
+| EEST fixture pass rate | 🟡 harness wired (`zkevm@v0.4.0`, Amsterdam) + first SOUND 105-byte full-matches on no-transaction blocks: eip4895 2/30, eip7928 3/150, **0 false positives** across a broad cross-family scan. Soundness gates: no-transaction gate (verdict only judges tx-empty blocks) + EIP-7928 BAL gas-limit check; state recompute = EIP-2935/4788 system writes + withdrawal balance credits → `mpt_state_root`. Tx/EVM execution (Steps 3-6) unbuilt ⇒ tx-bearing blocks rejected conservatively. |
 | RPC block replay | ✗ not started |
 
 ## G — Trust base

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **474**
-- ziskemu round-trip scripts: **466** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **479**
+- ziskemu round-trip scripts: **469** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **478**
-- ziskemu round-trip scripts: **469** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **480**
+- ziskemu round-trip scripts: **470** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **473**
-- ziskemu round-trip scripts: **465** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **479**
+- ziskemu round-trip scripts: **469** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-account-apply-storage-check.sh
+++ b/scripts/codegen-zisk-account-apply-storage-check.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# codegen-zisk-account-apply-storage-check.sh -- verify account_apply_storage_slot
+# (bead fhsxz.2.4.2.5 step c) against the Python MPT reference, incl. the REAL
+# EIP-2935 history-contract genesis write derived from an eip4895 fixture.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else echo "ziskemu not found" >&2; exit 1; fi
+fi
+VDIR="$REPO_ROOT/gen-out/aps"; mkdir -p "$VDIR"
+echo "==> build + emit probe"
+lake build codegen >/dev/null
+lake exe codegen --program zisk_account_apply_storage_slot --halt linux93 -o "$REPO_ROOT/gen-out/zisk_account_apply_storage_slot" >/dev/null
+
+uv run --directory execution-specs --quiet python3 - "$VDIR" "$REPO_ROOT/scripts" <<'PY'
+import sys, os, struct
+VDIR, SCRIPTS = sys.argv[1], sys.argv[2]
+sys.path.insert(0, SCRIPTS)
+import mpt_ref as m
+import rlp
+EMPTY=bytes.fromhex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+def nib(b):
+    o=[]
+    for x in b: o+=[x>>4,x&0xf]
+    return o
+def srss(slot, val):
+    return m.trie_root(m.leaf_node(nib(m.k256(slot)), val))
+def pack(acct, slot, val):
+    # file: [0:8]acct_len [8:16]val_len [16:48]slot [48:80]val [128:]acct
+    body=bytearray(struct.pack("<Q",len(acct))+struct.pack("<Q",len(val)))
+    body+=slot; body+=val.ljust(32,b"\x00")  # slot(32)+val padded to 32 -> ends at 80
+    body+=b"\x00"*(128-len(body))
+    body+=acct
+    while len(body)%8: body.append(0)
+    return bytes(body)
+cases=[]
+# 1) EIP-2935-style: empty-storage contract, write slot 0 -> 32-byte parentHash
+ph=b"\x5d"*32
+acct=rlp.encode([b"\x01", b"", EMPTY, b"\xba"*32])
+new_sr=srss(b"\x00"*32, ph)
+exp=rlp.encode([b"\x01", b"", new_sr, b"\xba"*32])
+cases.append(("eip2935_slot0", acct, b"\x00"*32, ph, 0, exp))
+# 2) EIP-4788-style: empty-storage contract, write slot 12 -> word 0x0c
+acct2=rlp.encode([b"\x01", b"", EMPTY, b"\xcc"*32])
+new_sr2=srss((12).to_bytes(32,"big"), b"\x0c")
+exp2=rlp.encode([b"\x01", b"", new_sr2, b"\xcc"*32])
+cases.append(("eip4788_slot12", acct2, (12).to_bytes(32,"big"), b"\x0c", 0, exp2))
+# 3) conservative: NON-empty prior storage -> status 1
+acct3=rlp.encode([b"\x01", b"", b"\xb1"*32, b"\xba"*32])
+cases.append(("nonempty_conservative", acct3, b"\x00"*32, ph, 1, b""))
+for name,acct,slot,val,status,exp in cases:
+    open(f"{VDIR}/{name}.input","wb").write(pack(acct,slot,val))
+    open(f"{VDIR}/{name}.expected","w").write(f"{status} {exp.hex()}\n")
+print("wrote", len(cases), "cases")
+PY
+
+fail=0
+for f in "$VDIR"/*.input; do
+  b="${f%.input}"; out="$b.out"
+  "$ZISKEMU" -e gen-out/zisk_account_apply_storage_slot.elf -i "$f" -o "$out" -n 20000000 >/dev/null 2>&1 </dev/null
+  st="$(od -An -tu8 -j 0 -N 8 "$out"|tr -d ' \n')"
+  olen="$(od -An -tu8 -j 8 -N 8 "$out"|tr -d ' \n')"
+  got=""; [[ "$olen" -gt 0 && "$olen" -lt 250 ]] && got="$(xxd -p -s 16 -l "$olen" "$out"|tr -d '\n')"
+  read exp_st exp_hex < "$b.expected"
+  name="$(basename "$b")"
+  if [[ "$exp_st" == "1" ]]; then
+    [[ "$st" == "1" ]] && echo "  PASS $name (conservative status=1)" || { echo "  FAIL $name status=$st want 1"; fail=1; }
+  else
+    if [[ "$st" == "0" && "$got" == "$exp_hex" ]]; then echo "  PASS $name (new account len=$olen)"
+    else echo "  FAIL $name status=$st len=$olen"; echo "    got=$got"; echo "    exp=$exp_hex"; fail=1; fi
+  fi
+done
+[[ "$fail" -eq 0 ]] && echo "==> PASS: account_apply_storage_slot matches the Python MPT reference" || { echo "==> FAIL"; exit 1; }


### PR DESCRIPTION
## What

**Step (d) — the full block state-transition verdict, producing the first correct
VALID verdicts on real EEST fixtures.** `block_state_root` composes the EIP-2935 +
EIP-4788 system-contract storage writes **with** the withdrawal balance credits
into one `mpt_state_root` recompute; `block_verdict` = header-validate +
`block_state_root` + `memcmp(recomputed, payload.state_root)`;
`stateless_verdict_v2` is the real-SSZ glue (extractors → params → block_verdict).

## Result (real `zkevm@v0.4.0` eip4895 fixtures, `zisk_stateless_verdict_v2`)

**2/30 verdicts MATCH** (`bal_withdrawal_empty_block`, `bal_withdrawal_no_evm_execution`
— the pure withdrawal+system-write blocks), **0 FALSE POSITIVES**. The recomputed
post-state root equals the fixture block `stateRoot` exactly. The other 28 are
sound conservative misses (verdict 0) — they also run transactions / contract
creation / selfdestruct the recompute doesn't model yet.

## Bug fixed (was THE blocker)

`storage_root_single_slot` fed the **raw** storage word to `single_leaf_trie_root`,
but the storage-trie leaf value must be `RLP(word)` (which the leaf node wraps
again). A ≥32-byte word (the EIP-2935 parentHash) needs `0xa1 0xa0‖hash`, not
`0xa0‖hash`; small words (EIP-4788's `0x0c`) are unaffected since `RLP(0x0c)=0x0c`.
Fix: `rlp_encode_bytes` the value first. Validated against an independent full-trie
`patricialize` reference that reproduces the fixture pre/post state roots exactly.

## Stacking / scope

This is the **integration tip**: it bundles the Step-2 verdict deps (#7742–#7753)
+ the storage/system bricks (#7755/#7756/#7757) + the new `BlockVerdict.lean`. The
storage-encoding fix here should also land on #7755. **Next:** wire
`stateless_verdict_v2` into the guest epilogue (write the bit to `OUTPUT[32]`) so
the EEST harness reports the 2 full 105-byte matches (root + tail already match 30/30).

Authored by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
