### PR TITLE
feat(mpt): mpt_insert_walk — divergence-classifying MPT descent

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -55,6 +55,7 @@ import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.Mpt
 import EvmAsm.Codegen.Programs.MptSet
 import EvmAsm.Codegen.Programs.MptSetAcc
+import EvmAsm.Codegen.Programs.MptInsertWalk
 import EvmAsm.Codegen.Programs.WithdrawalsStateRoot
 import EvmAsm.Codegen.Programs.AccountBalance
 import EvmAsm.Codegen.Programs.MptEncode
@@ -555,6 +556,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_hp_decode_nibbles"    => some ziskHpDecodeNibblesProbeUnit
   | "zisk_mpt_walk"             => some ziskMptWalkProbeUnit
   | "zisk_mpt_set_record_walk"  => some ziskMptSetRecordWalkProbeUnit
+  | "zisk_mpt_insert_walk"      => some ziskMptInsertWalkProbeUnit
   | "zisk_mpt_set"              => some ziskMptSetProbeUnit
   | "zisk_mpt_set_acc"          => some ziskMptSetAccProbeUnit
   | "zisk_mpt_state_root"       => some ziskMptStateRootProbeUnit
@@ -842,6 +844,7 @@ def knownProgramNames : List String :=
    "zisk_hp_decode_nibbles",
    "zisk_mpt_walk",
    "zisk_mpt_set_record_walk",
+   "zisk_mpt_insert_walk",
    "zisk_mpt_set",
    "zisk_mpt_set_acc",
    "zisk_mpt_state_root",
@@ -1321,6 +1324,7 @@ end EvmAsm.Codegen
     "EvmAsm/Codegen/Programs/Mpt.lean",
     "EvmAsm/Codegen/Programs/MptSet.lean",
     "EvmAsm/Codegen/Programs/MptSetAcc.lean",
+    "EvmAsm/Codegen/Programs/MptInsertWalk.lean",
     "EvmAsm/Codegen/Programs/WithdrawalsStateRoot.lean",
     "EvmAsm/Codegen/Programs/AccountBalance.lean",
     "EvmAsm/Codegen/Programs/MptEncode.lean",

--- a/EvmAsm/Codegen/Programs/MptInsertWalk.lean
+++ b/EvmAsm/Codegen/Programs/MptInsertWalk.lean
@@ -1,0 +1,413 @@
+/-
+  EvmAsm.Codegen.Programs.MptInsertWalk
+
+  mpt_insert_walk (bead evm-asm-fhsxz.2.4.2.6.1): the divergence-classifying
+  descent that is the foundation for inserting a NEW key into a witness-backed
+  MPT (account creation for withdrawals to absent/precompile recipients).
+
+  It mirrors `mpt_set_record_walk` (Programs/MptSet.lean), which descends a key
+  and jumps to a single `not_found` exit at every divergence. mpt_insert_walk
+  instead CLASSIFIES the divergence and records the context a later restructure +
+  bubble-up pass (mpt_insert, bead .2.4.2.6.2) needs:
+
+    case 0 BRANCH_EMPTY_SLOT : path reaches a branch whose child slot for the
+                               next nibble is empty. The branch is the terminal
+                               (un-pushed from the ancestor stack); the new leaf
+                               goes at slot path[consumed], key path[consumed+1..].
+    case 1 LEAF_SPLIT        : path reaches a leaf whose key diverges. match_len
+                               = shared-prefix nibbles; split into branch (+ an
+                               extension for the shared prefix).
+    case 2 EXTENSION_SPLIT   : path diverges inside an extension's key segment.
+                               match_len = matched ext nibbles.
+    case 3 EMPTY_TRIE        : root == EMPTY_TRIE_ROOT; the whole trie is a single
+                               new leaf.
+    case 4 EXISTS            : the key is already present (a value-update, not an
+                               insert). Does not occur in the withdrawal path
+                               (the caller mpt_walks first), reported defensively.
+    case 5 BRANCH_VALUE      : path is exhausted exactly at a branch (value slot
+                               16). Does not occur for fixed-length 64-nibble
+                               account paths, reported defensively.
+
+  The ancestor stack (`stack_out`, 32 B per branch/extension above the terminal,
+  root->leaf order) is recorded identically to mpt_set_record_walk so the same
+  bubble-up pass re-roots after the terminal is restructured.
+
+  Reuses mpt_walk's scratch labels (mw_*) from `ziskMptWalkDataSection`; adds
+  `iw_empty_trie_root` (the 32-byte EMPTY_TRIE_ROOT = keccak256(rlp(b''))).
+  All multi-byte work is on 8-aligned scratch; path/key nibbles are read
+  byte-wise (no-misaligned invariant).
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.Mpt
+import EvmAsm.Codegen.Programs.MptSet
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+/-! ## mpt_insert_walk -- classify where an ABSENT key diverges from the trie
+
+    Calling convention (identical inputs to mpt_set_record_walk):
+      a0 (input)  : root_hash ptr (32 bytes)
+      a1 (input)  : witness section ptr
+      a2 (input)  : witness section_len
+      a3 (input)  : path_nibbles ptr (one byte per nibble)
+      a4 (input)  : path_nibbles_len
+      a5 (input)  : stack_out ptr (32 bytes per ancestor node)
+      a6 (input)  : meta_out ptr (48 bytes)
+      ra (input)  : return
+      a0 (output) : 0 (diverged + classified, see case) / 1 (incomplete witness,
+                    lookup miss) / 2 (parse error)
+
+    `stack_out` entry layout (32 bytes, one per ancestor BRANCH/EXTENSION on the
+    root->terminal path, in root->leaf order) -- same as mpt_set_record_walk:
+      +0 node_offset : u64   byte offset within the witness section
+      +8 node_len    : u64
+      +16 kind       : u64   0 = branch, 1 = extension
+      +24 nibble     : u64   branch: child index taken; extension: 0
+
+    `meta_out` layout (48 bytes):
+      +0  depth           : u64  number of ancestor stack_out entries
+      +8  consumed        : u64  path nibbles consumed by ancestors (NOT incl.
+                                 the terminal's own divergence)
+      +16 case            : u64  0..5 (see file header)
+      +24 terminal_offset : u64  byte offset of the terminal node's RLP (0 if
+                                 EMPTY_TRIE)
+      +32 terminal_len    : u64  full RLP length of the terminal node
+      +40 match_len       : u64  case 1/2: shared-prefix nibbles at the terminal;
+                                 else 0 -/
+def mptInsertWalkFunction : String :=
+  "mpt_insert_walk:\n" ++
+  "  addi sp, sp, -96\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp)\n" ++
+  "  mv s0, a1                   # s0 = witness ptr\n" ++
+  "  mv s1, a2                   # s1 = witness_len\n" ++
+  "  mv s2, a3                   # s2 = path_nibbles ptr\n" ++
+  "  mv s3, a4                   # s3 = path_nibbles_len\n" ++
+  "  mv s4, a5                   # s4 = stack_out cursor\n" ++
+  "  mv s5, a6                   # s5 = meta_out ptr\n" ++
+  "  li s9, 0                    # s9 = depth\n" ++
+  "  # Copy root_hash to mw_lookup_hash for the first lookup.\n" ++
+  "  la t0, mw_lookup_hash\n" ++
+  "  ld t1,  0(a0); sd t1,  0(t0)\n" ++
+  "  ld t1,  8(a0); sd t1,  8(t0)\n" ++
+  "  ld t1, 16(a0); sd t1, 16(t0)\n" ++
+  "  ld t1, 24(a0); sd t1, 24(t0)\n" ++
+  "  # EMPTY_TRIE_ROOT? -> case 3 (whole trie is a single new leaf).\n" ++
+  "  la t2, iw_empty_trie_root\n" ++
+  "  ld t3, 0(t0); ld t4, 0(t2); bne t3, t4, .Liw_lookup_root\n" ++
+  "  ld t3, 8(t0); ld t4, 8(t2); bne t3, t4, .Liw_lookup_root\n" ++
+  "  ld t3, 16(t0); ld t4, 16(t2); bne t3, t4, .Liw_lookup_root\n" ++
+  "  ld t3, 24(t0); ld t4, 24(t2); bne t3, t4, .Liw_lookup_root\n" ++
+  "  li t5, 3; j .Liw_empty\n" ++
+  ".Liw_lookup_root:\n" ++
+  "  mv a0, s0\n" ++
+  "  mv a1, s1\n" ++
+  "  la a2, mw_lookup_hash\n" ++
+  "  la a3, mw_lookup_offset\n" ++
+  "  la a4, mw_lookup_length\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  bnez a0, .Liw_miss\n" ++
+  "  la t0, mw_lookup_offset; ld t1, 0(t0); add s7, s0, t1\n" ++
+  "  la t0, mw_lookup_length; ld s8, 0(t0)\n" ++
+  "  li s6, 0\n" ++
+  ".Liw_loop:\n" ++
+  "  mv a0, s7\n" ++
+  "  mv a1, s8\n" ++
+  "  jal ra, mpt_node_kind\n" ++
+  "  beqz a0, .Liw_branch\n" ++
+  "  li t0, 1; beq a0, t0, .Liw_extension\n" ++
+  "  li t0, 2; beq a0, t0, .Liw_leaf\n" ++
+  "  j .Liw_parse_fail\n" ++
+  ".Liw_branch:\n" ++
+  "  beq s6, s3, .Liw_branch_value\n" ++
+  "  add t0, s2, s6              # &path[consumed]\n" ++
+  "  lbu t1, 0(t0)               # nibble (item index)\n" ++
+  "  # push record (node_offset, node_len, kind=0 branch, nibble)\n" ++
+  "  sub t2, s7, s0              # node_offset within witness\n" ++
+  "  sd t2,  0(s4)\n" ++
+  "  sd s8,  8(s4)\n" ++
+  "  sd zero, 16(s4)            # kind = 0 (branch)\n" ++
+  "  sd t1, 24(s4)\n" ++
+  "  addi s4, s4, 32\n" ++
+  "  addi s9, s9, 1\n" ++
+  "  # descend into child slot via rlp_list_nth_item.\n" ++
+  "  mv a0, s7\n" ++
+  "  mv a1, s8\n" ++
+  "  mv a2, t1                   # nibble\n" ++
+  "  la a3, mw_child_offset\n" ++
+  "  la a4, mw_child_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  addi s6, s6, 1\n" ++
+  "  bnez a0, .Liw_parse_fail\n" ++
+  "  la t0, mw_child_length; ld t1, 0(t0)\n" ++
+  "  beqz t1, .Liw_branch_empty  # empty slot -> insert point\n" ++
+  "  li t2, 32\n" ++
+  "  beq t1, t2, .Liw_branch_hash\n" ++
+  "  # Inlined (length 1..31): node = (s7 + child_offset, child_length).\n" ++
+  "  la t0, mw_child_offset; ld t2, 0(t0)\n" ++
+  "  add s7, s7, t2\n" ++
+  "  mv s8, t1\n" ++
+  "  j .Liw_loop\n" ++
+  ".Liw_branch_hash:\n" ++
+  "  la t0, mw_child_offset; ld t1, 0(t0)\n" ++
+  "  add t2, s7, t1\n" ++
+  "  la t3, mw_lookup_hash\n" ++
+  "  ld t4,  0(t2); sd t4,  0(t3)\n" ++
+  "  ld t4,  8(t2); sd t4,  8(t3)\n" ++
+  "  ld t4, 16(t2); sd t4, 16(t3)\n" ++
+  "  ld t4, 24(t2); sd t4, 24(t3)\n" ++
+  "  mv a0, s0\n" ++
+  "  mv a1, s1\n" ++
+  "  la a2, mw_lookup_hash\n" ++
+  "  la a3, mw_lookup_offset\n" ++
+  "  la a4, mw_lookup_length\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  bnez a0, .Liw_miss\n" ++
+  "  la t0, mw_lookup_offset; ld t1, 0(t0); add s7, s0, t1\n" ++
+  "  la t0, mw_lookup_length; ld s8, 0(t0)\n" ++
+  "  j .Liw_loop\n" ++
+  ".Liw_branch_empty:\n" ++
+  "  # The branch (just pushed) is the terminal: un-push it; ancestors = s9-1.\n" ++
+  "  addi s4, s4, -32\n" ++
+  "  addi s9, s9, -1\n" ++
+  "  li t5, 0                    # case 0 BRANCH_EMPTY_SLOT\n" ++
+  "  addi s6, s6, -1             # consumed = ancestors' nibbles (drop branch nibble)\n" ++
+  "  li t6, 0                    # match_len = 0\n" ++
+  "  j .Liw_record\n" ++
+  ".Liw_branch_value:\n" ++
+  "  # Path exhausted at a branch (value slot 16). Defensive (not for 64-nibble\n" ++
+  "  # account paths). The branch is the terminal; it is NOT on the stack.\n" ++
+  "  li t5, 5                    # case 5 BRANCH_VALUE\n" ++
+  "  li t6, 0\n" ++
+  "  j .Liw_record\n" ++
+  ".Liw_extension:\n" ++
+  "  mv a0, s7\n" ++
+  "  mv a1, s8\n" ++
+  "  li a2, 0\n" ++
+  "  la a3, mw_path_offset\n" ++
+  "  la a4, mw_path_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Liw_parse_fail\n" ++
+  "  la t0, mw_path_offset; ld t1, 0(t0); add a0, s7, t1\n" ++
+  "  la t0, mw_path_length; ld a1, 0(t0)\n" ++
+  "  la a2, mw_nibble_buf\n" ++
+  "  la a3, mw_nibble_count\n" ++
+  "  la a4, mw_is_leaf\n" ++
+  "  jal ra, hp_decode_nibbles\n" ++
+  "  bnez a0, .Liw_parse_fail\n" ++
+  "  la t0, mw_is_leaf; ld t1, 0(t0)\n" ++
+  "  bnez t1, .Liw_parse_fail    # node kind said extension; HP says leaf\n" ++
+  "  la t0, mw_nibble_count; ld t1, 0(t0)    # t1 = ext nibble count\n" ++
+  "  # common prefix of ext nibbles (mw_nibble_buf) vs path[consumed..].\n" ++
+  "  sub t2, s3, s6              # remaining path nibbles\n" ++
+  "  mv t3, t1                   # cmp_limit = min(ext_count, remaining)\n" ++
+  "  bgeu t2, t1, .Liw_ext_lim_ok\n" ++
+  "  mv t3, t2\n" ++
+  ".Liw_ext_lim_ok:\n" ++
+  "  la t4, mw_nibble_buf\n" ++
+  "  add t5, s2, s6              # &path[consumed]\n" ++
+  "  li t6, 0                    # match counter\n" ++
+  ".Liw_ext_cmp:\n" ++
+  "  beq t6, t3, .Liw_ext_cmp_done\n" ++
+  "  add a0, t4, t6; lbu a1, 0(a0)\n" ++
+  "  add a0, t5, t6; lbu a2, 0(a0)\n" ++
+  "  bne a1, a2, .Liw_ext_cmp_done\n" ++
+  "  addi t6, t6, 1\n" ++
+  "  j .Liw_ext_cmp\n" ++
+  ".Liw_ext_cmp_done:\n" ++
+  "  # full match iff matched all ext nibbles AND ext fits in remaining path.\n" ++
+  "  bne t6, t1, .Liw_ext_split\n" ++
+  "  bgtu t1, t2, .Liw_ext_split # ext longer than remaining -> split\n" ++
+  "  # full extension match: push it and descend into its child (item 1).\n" ++
+  "  sub a0, s7, s0\n" ++
+  "  sd a0,  0(s4)\n" ++
+  "  sd s8,  8(s4)\n" ++
+  "  li a1, 1; sd a1, 16(s4)     # kind = 1 (extension)\n" ++
+  "  sd zero, 24(s4)\n" ++
+  "  addi s4, s4, 32\n" ++
+  "  addi s9, s9, 1\n" ++
+  "  add s6, s6, t1              # consume the ext nibbles\n" ++
+  "  mv a0, s7\n" ++
+  "  mv a1, s8\n" ++
+  "  li a2, 1\n" ++
+  "  la a3, mw_child_offset\n" ++
+  "  la a4, mw_child_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Liw_parse_fail\n" ++
+  "  la t0, mw_child_length; ld t1, 0(t0)\n" ++
+  "  la t0, mw_child_offset; ld t2, 0(t0)\n" ++
+  "  add t3, s7, t2\n" ++
+  "  li t4, 32\n" ++
+  "  beq t1, t4, .Liw_ext_hash\n" ++
+  "  mv s7, t3\n" ++
+  "  mv s8, t1\n" ++
+  "  j .Liw_loop\n" ++
+  ".Liw_ext_hash:\n" ++
+  "  la t4, mw_lookup_hash\n" ++
+  "  ld t5,  0(t3); sd t5,  0(t4)\n" ++
+  "  ld t5,  8(t3); sd t5,  8(t4)\n" ++
+  "  ld t5, 16(t3); sd t5, 16(t4)\n" ++
+  "  ld t5, 24(t3); sd t5, 24(t4)\n" ++
+  "  mv a0, s0\n" ++
+  "  mv a1, s1\n" ++
+  "  la a2, mw_lookup_hash\n" ++
+  "  la a3, mw_lookup_offset\n" ++
+  "  la a4, mw_lookup_length\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  bnez a0, .Liw_miss\n" ++
+  "  la t0, mw_lookup_offset; ld t1, 0(t0); add s7, s0, t1\n" ++
+  "  la t0, mw_lookup_length; ld s8, 0(t0)\n" ++
+  "  j .Liw_loop\n" ++
+  ".Liw_ext_split:\n" ++
+  "  # t6 = match_len; the extension is the terminal (not pushed).\n" ++
+  "  li t5, 2                    # case 2 EXTENSION_SPLIT (t6 already = match_len)\n" ++
+  "  j .Liw_record\n" ++
+  ".Liw_leaf:\n" ++
+  "  mv a0, s7\n" ++
+  "  mv a1, s8\n" ++
+  "  li a2, 0\n" ++
+  "  la a3, mw_path_offset\n" ++
+  "  la a4, mw_path_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Liw_parse_fail\n" ++
+  "  la t0, mw_path_offset; ld t1, 0(t0); add a0, s7, t1\n" ++
+  "  la t0, mw_path_length; ld a1, 0(t0)\n" ++
+  "  la a2, mw_nibble_buf\n" ++
+  "  la a3, mw_nibble_count\n" ++
+  "  la a4, mw_is_leaf\n" ++
+  "  jal ra, hp_decode_nibbles\n" ++
+  "  bnez a0, .Liw_parse_fail\n" ++
+  "  la t0, mw_is_leaf; ld t1, 0(t0)\n" ++
+  "  li t2, 1\n" ++
+  "  bne t1, t2, .Liw_parse_fail # node kind said leaf; HP says extension\n" ++
+  "  la t0, mw_nibble_count; ld t1, 0(t0)    # t1 = leaf key nibble count\n" ++
+  "  sub t2, s3, s6              # remaining path nibbles\n" ++
+  "  mv t3, t1                   # cmp_limit = min(leaf_count, remaining)\n" ++
+  "  bgeu t2, t1, .Liw_leaf_lim_ok\n" ++
+  "  mv t3, t2\n" ++
+  ".Liw_leaf_lim_ok:\n" ++
+  "  la t4, mw_nibble_buf\n" ++
+  "  add t5, s2, s6              # &path[consumed]\n" ++
+  "  li t6, 0                    # match counter\n" ++
+  ".Liw_leaf_cmp:\n" ++
+  "  beq t6, t3, .Liw_leaf_cmp_done\n" ++
+  "  add a0, t4, t6; lbu a1, 0(a0)\n" ++
+  "  add a0, t5, t6; lbu a2, 0(a0)\n" ++
+  "  bne a1, a2, .Liw_leaf_cmp_done\n" ++
+  "  addi t6, t6, 1\n" ++
+  "  j .Liw_leaf_cmp\n" ++
+  ".Liw_leaf_cmp_done:\n" ++
+  "  # EXISTS iff matched all leaf nibbles AND leaf key length == remaining.\n" ++
+  "  bne t6, t1, .Liw_leaf_split\n" ++
+  "  bne t1, t2, .Liw_leaf_split\n" ++
+  "  li t5, 4                    # case 4 EXISTS (t6 already = match_len)\n" ++
+  "  j .Liw_record\n" ++
+  ".Liw_leaf_split:\n" ++
+  "  li t5, 1                    # case 1 LEAF_SPLIT (t6 already = match_len)\n" ++
+  "  j .Liw_record\n" ++
+  ".Liw_record:\n" ++
+  "  # t5 = case, t6 = match_len; terminal = (s7,s8); ancestors depth = s9.\n" ++
+  "  sd s9, 0(s5)               # depth\n" ++
+  "  sd s6, 8(s5)               # consumed\n" ++
+  "  sd t5, 16(s5)              # case\n" ++
+  "  sub t0, s7, s0; sd t0, 24(s5)  # terminal_offset\n" ++
+  "  sd s8, 32(s5)              # terminal_len\n" ++
+  "  sd t6, 40(s5)              # match_len\n" ++
+  "  li a0, 0\n" ++
+  "  j .Liw_ret\n" ++
+  ".Liw_empty:\n" ++
+  "  # case 3 EMPTY_TRIE: no ancestors, no terminal node.\n" ++
+  "  sd zero, 0(s5)             # depth = 0\n" ++
+  "  sd zero, 8(s5)             # consumed = 0\n" ++
+  "  sd t5, 16(s5)              # case = 3\n" ++
+  "  sd zero, 24(s5)            # terminal_offset = 0\n" ++
+  "  sd zero, 32(s5)            # terminal_len = 0\n" ++
+  "  sd zero, 40(s5)            # match_len = 0\n" ++
+  "  li a0, 0\n" ++
+  "  j .Liw_ret\n" ++
+  ".Liw_miss:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Liw_ret\n" ++
+  ".Liw_parse_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Liw_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp)\n" ++
+  "  addi sp, sp, 96\n" ++
+  "  ret"
+
+/-! ## iw_empty_trie_root data + probe data section.
+    EMPTY_TRIE_ROOT = keccak256(rlp(b'')) =
+      0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421 -/
+def iwEmptyTrieRootData : String :=
+  "iw_empty_trie_root:\n" ++
+  "  .byte 0x56,0xe8,0x1f,0x17,0x1b,0xcc,0x55,0xa6\n" ++
+  "  .byte 0xff,0x83,0x45,0xe6,0x92,0xc0,0xf8,0x6e\n" ++
+  "  .byte 0x5b,0x48,0xe0,0x1b,0x99,0x6c,0xad,0xc0\n" ++
+  "  .byte 0x01,0x62,0x2f,0xb5,0xe3,0x63,0xb4,0x21"
+
+/-- `zisk_mpt_insert_walk`: probe BuildUnit. Reuses the mpt_set probe input
+    layout (scripts/mpt_ref.py `build_probe_input`); the new_value field is
+    present but ignored by the walk.
+    Input layout (file maps to INPUT+8 at 0x40000000):
+      INPUT+8  : witness_len (u64)
+      INPUT+16 : path_len (u64)
+      INPUT+24 : new_value_len (u64)         [ignored]
+      INPUT+32 : root_hash (32 bytes)
+      INPUT+64 : path_nibbles (1B each)
+      INPUT+64+path_len : new_value
+      8-aligned : witness section
+    Output layout:
+      OUTPUT+0   : status (0 ok / 1 miss / 2 fail)
+      OUTPUT+8   : meta (depth, consumed, case, terminal_offset, terminal_len,
+                   match_len) -- 48 B
+      OUTPUT+128 : ancestor stack records, 32 B each -/
+def ziskMptInsertWalkPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld t6, 8(a7)                # witness_len\n" ++
+  "  ld t5, 16(a7)               # path_len\n" ++
+  "  ld t4, 24(a7)               # new_value_len\n" ++
+  "  addi a0, a7, 32             # root_hash ptr (INPUT+32)\n" ++
+  "  addi a3, a7, 64             # path_nibbles ptr (INPUT+64)\n" ++
+  "  # witness ptr = path_ptr + roundup8(path_len + new_value_len).\n" ++
+  "  add t3, t5, t4\n" ++
+  "  addi t3, t3, 7\n" ++
+  "  andi t3, t3, -8\n" ++
+  "  add a1, a3, t3              # witness ptr\n" ++
+  "  mv a2, t6                   # witness_len\n" ++
+  "  mv a4, t5                   # path_len\n" ++
+  "  li a5, 0xa0010080           # stack_out at OUTPUT + 128\n" ++
+  "  li a6, 0xa0010008           # meta_out at OUTPUT + 8\n" ++
+  "  jal ra, mpt_insert_walk\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status at OUTPUT + 0\n" ++
+  "  j .Liw_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  mptInsertWalkFunction ++ "\n" ++
+  ".Liw_pdone:"
+
+def ziskMptInsertWalkDataSection : String :=
+  ziskMptWalkDataSection ++ "\n" ++
+  ".balign 8\n" ++
+  iwEmptyTrieRootData
+
+def ziskMptInsertWalkProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskMptInsertWalkPrologue
+  dataAsm     := ziskMptInsertWalkDataSection
+}
+
+end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **473**
-- ziskemu round-trip scripts: **465** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **480**
+- ziskemu round-trip scripts: **470** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **478**
-- ziskemu round-trip scripts: **469** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **481**
+- ziskemu round-trip scripts: **471** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **480**
-- ziskemu round-trip scripts: **470** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **481**
+- ziskemu round-trip scripts: **471** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-mpt-insert-walk-check.sh
+++ b/scripts/codegen-zisk-mpt-insert-walk-check.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# codegen-zisk-mpt-insert-walk-check.sh -- verify the MPT INSERT divergence
+# walk (bead evm-asm-fhsxz.2.4.2.6.1) against the validated Python reference
+# scripts/mpt_ref.py.
+#
+# mpt_insert_walk forks mpt_set_record_walk: it descends an ABSENT key and,
+# instead of a single not-found exit, CLASSIFIES where the path diverges and
+# records the terminal node + ancestor stack for a later insert + bubble-up.
+# This harness runs the `zisk_mpt_insert_walk` probe on five divergence shapes
+# (branch-empty-slot / leaf-split / ext-split / empty-trie / ext-then-branch)
+# and checks every u64 field of the probe OUTPUT against mpt_ref's prediction.
+#
+# Probe OUTPUT layout (u64 fields, little-endian):
+#   +0   status (0 ok / 1 incomplete-witness miss / 2 parse-fail)
+#   +8   meta.depth        +16 meta.consumed       +24 meta.case
+#   +32  meta.terminal_offset  +40 meta.terminal_len  +48 meta.match_len
+#   +128 record[i] = (node_offset, node_len, kind, nibble), 32 B each
+#
+# mpt_ref.py emits "<field> <output_byte_offset> <u64_value>" lines per shape
+# in <name>.iwexpected; we read each u64 from OUTPUT (od -tu8) and diff.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else echo "ziskemu not found" >&2; exit 1; fi
+fi
+
+VDIR="$REPO_ROOT/gen-out/mpt-set"
+echo "==> generate vectors via the validated Python reference"
+uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/mpt_ref.py" "$VDIR"
+
+echo "==> lake build codegen"
+lake build codegen >/dev/null
+
+echo "==> emit zisk_mpt_insert_walk probe ELF"
+lake exe codegen --program zisk_mpt_insert_walk --halt linux93 \
+  -o "$REPO_ROOT/gen-out/zisk_mpt_insert_walk"
+
+read_u64() {  # read_u64 <file> <byte_offset>  -> decimal u64 (little-endian)
+  od -An -tu8 -j "$2" -N 8 "$1" | tr -d ' \n'
+}
+
+fail=0
+for name in iw_branch_empty iw_leaf_split iw_ext_split iw_empty_trie \
+            iw_ext_then_branch_empty; do
+  out="$VDIR/$name.iw.output"
+  if ! "$ZISKEMU" -e "$REPO_ROOT/gen-out/zisk_mpt_insert_walk.elf" \
+        -i "$VDIR/$name.input" -o "$out" -n 5000000 >/dev/null 2>&1 </dev/null; then
+    echo "  ERROR  $name (ziskemu)"; fail=1; continue
+  fi
+  shape_ok=1; details=""
+  while read -r field off exp; do
+    [[ -z "$field" ]] && continue
+    act="$(read_u64 "$out" "$off")"
+    if [[ "$act" != "$exp" ]]; then
+      shape_ok=0; details+=$'\n'"      $field @${off}: expected $exp got $act"
+    fi
+  done < "$VDIR/$name.iwexpected"
+  if [[ "$shape_ok" -eq 1 ]]; then
+    c="$(read_u64 "$out" 24)"; d="$(read_u64 "$out" 8)"
+    echo "  PASS   $name  (case=$c depth=$d)"
+  else
+    echo "  FAIL   $name$details"; fail=1
+  fi
+done
+[[ "$fail" -eq 0 ]] && echo "==> PASS: mpt_insert_walk matches reference" \
+  || { echo "==> FAIL"; exit 1; }

--- a/scripts/mpt_ref.py
+++ b/scripts/mpt_ref.py
@@ -454,6 +454,114 @@ def vec_withdrawals_state_root():
                 expected=trie_root(new_root_node))
 
 
+# ---- insert-walk divergence vectors (mpt_insert_walk .2.4.2.6.1) ----------
+# Each vector is a trie + an ABSENT path; the walk must classify WHERE the path
+# diverges and record the terminal node + ancestor stack for a later insert.
+EMPTY_TRIE_ROOT = bytes.fromhex(
+    "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+
+
+def vec_iw_branch_empty():
+    """Root = branch with an inline leaf at nibble 1. Insert path starts at
+    nibble 3 (empty slot) -> case 0 BRANCH_EMPTY_SLOT, terminal = root branch,
+    depth 0 (the branch is un-pushed), consumed 0."""
+    la = leaf_node([0xa, 0xb], b"v1")
+    slots = [b"\x80"] * 16
+    slots[1] = node_ref(la)
+    root = branch_node(slots)
+    return dict(name="iw_branch_empty", witness=[root], root=trie_root(root),
+                path=[0x3, 0x7, 0x8],
+                case=0, depth=0, consumed=0, match_len=0,
+                terminal_index=0, levels=[])
+
+
+def vec_iw_leaf_split():
+    """Root = leaf key [1,2,3,4]. Insert path [1,2,9,9] diverges at the leaf
+    with shared prefix [1,2] -> case 1 LEAF_SPLIT, match_len 2."""
+    root = leaf_node([0x1, 0x2, 0x3, 0x4], b"leaf-value")
+    return dict(name="iw_leaf_split", witness=[root], root=trie_root(root),
+                path=[0x1, 0x2, 0x9, 0x9],
+                case=1, depth=0, consumed=0, match_len=2,
+                terminal_index=0, levels=[])
+
+
+def vec_iw_ext_split():
+    """Root = extension prefix [5,6] -> branch. Insert path [5,9,0,0] diverges
+    inside the extension at position 1 -> case 2 EXTENSION_SPLIT, match_len 1."""
+    la = leaf_node([0xa, 0xb], b"x" * 32)
+    lb = leaf_node([0xc, 0xd], b"y" * 32)
+    slots = [b"\x80"] * 16
+    slots[1] = node_ref(la)
+    slots[2] = node_ref(lb)
+    branch = branch_node(slots)
+    root = extension_node([0x5, 0x6], node_ref(branch))
+    return dict(name="iw_ext_split", witness=[root], root=trie_root(root),
+                path=[0x5, 0x9, 0x0, 0x0],
+                case=2, depth=0, consumed=0, match_len=1,
+                terminal_index=0, levels=[])
+
+
+def vec_iw_empty_trie():
+    """Root = EMPTY_TRIE_ROOT -> case 3 EMPTY_TRIE (single new leaf)."""
+    return dict(name="iw_empty_trie", witness=[], root=EMPTY_TRIE_ROOT,
+                path=[0x1, 0x2],
+                case=3, depth=0, consumed=0, match_len=0,
+                terminal_index=None, levels=[])
+
+
+def vec_iw_ext_then_branch_empty():
+    """Root = extension [5,6] -> branch B (>=32, hash-referenced) with an inline
+    leaf at nibble 1. Insert path [5,6,3,c]: the extension matches fully (pushed
+    as an ancestor), then branch B's slot 3 is empty -> case 0 BRANCH_EMPTY_SLOT,
+    depth 1, consumed 2, terminal = branch B."""
+    la = leaf_node([0xc], b"z" * 40)            # big -> branch B > 32 bytes
+    slots = [b"\x80"] * 16
+    slots[1] = node_ref(la)
+    branch = branch_node(slots)
+    assert len(branch) >= 32, "branch must be hash-referenced for this vector"
+    root = extension_node([0x5, 0x6], node_ref(branch))
+    return dict(name="iw_ext_then_branch_empty",
+                witness=[root, branch], root=trie_root(root),
+                path=[0x5, 0x6, 0x3, 0xc],
+                case=0, depth=1, consumed=2, match_len=0,
+                terminal_index=1, levels=[("extension", 0, 2)])
+
+
+IW_VECTORS = [vec_iw_branch_empty, vec_iw_leaf_split, vec_iw_ext_split,
+              vec_iw_empty_trie, vec_iw_ext_then_branch_empty]
+
+
+def insert_walk_expected(v: dict) -> list[tuple[str, int, int]]:
+    """Expected probe OUTPUT for zisk_mpt_insert_walk as (name, offset, value).
+    OUTPUT: status@0, meta(depth@8, consumed@16, case@24, terminal_offset@32,
+    terminal_len@40, match_len@48), ancestor records 32 B each @128."""
+    witness, levels = v["witness"], v["levels"]
+    offs = element_offsets(witness)
+    if v["terminal_index"] is None:
+        term_off, term_len = 0, 0
+    else:
+        ti = v["terminal_index"]
+        term_off, term_len = offs[ti], len(witness[ti])
+    out = [
+        ("status", 0, 0),
+        ("depth", 8, v["depth"]),
+        ("consumed", 16, v["consumed"]),
+        ("case", 24, v["case"]),
+        ("terminal_offset", 32, term_off),
+        ("terminal_len", 40, term_len),
+        ("match_len", 48, v["match_len"]),
+    ]
+    for i, (kind, nibble, _c) in enumerate(levels):
+        base = 128 + 32 * i
+        out += [
+            (f"rec{i}_offset", base + 0, offs[i]),
+            (f"rec{i}_len", base + 8, len(witness[i])),
+            (f"rec{i}_kind", base + 16, 0 if kind == "branch" else 1),
+            (f"rec{i}_nibble", base + 24, nibble),
+        ]
+    return out
+
+
 if __name__ == "__main__":
     import os
     outdir = sys.argv[1] if len(sys.argv) > 1 else "gen-out/mpt-set"
@@ -500,6 +608,19 @@ if __name__ == "__main__":
         depth = next(val for nm, _o, val in rw if nm == "depth")
         print(f"{v['name']:12} root={v['root'].hex()[:16]}.. "
               f"new_root={v['expected'].hex()[:16]}.. rw_depth={depth}")
+    # insert-walk divergence vectors (mpt_insert_walk)
+    for mk in IW_VECTORS:
+        v = mk()
+        sec = ssz_section(v["witness"])
+        inp = build_probe_input(v["root"], v["path"], b"", sec)
+        with open(f"{outdir}/{v['name']}.input", "wb") as f:
+            f.write(inp)
+        iw = insert_walk_expected(v)
+        with open(f"{outdir}/{v['name']}.iwexpected", "w") as f:
+            for name, off, val in iw:
+                f.write(f"{name} {off} {val}\n")
+        print(f"{v['name']:24} case={v['case']} depth={v['depth']} "
+              f"consumed={v['consumed']} match_len={v['match_len']}")
     # accumulating 2-update vector (mpt_set_acc)
     a = vec_acc()
     sec = ssz_section(a["witness"])


### PR DESCRIPTION
## Summary
First foundation piece for **state-trie account INSERT** (bead `evm-asm-fhsxz.2.4.2.6` — withdrawals to absent/precompile recipients, the ~92-fixture eip4895 lever).

`mpt_insert_walk` mirrors `mpt_set_record_walk`'s descent but, instead of a single `not-found` exit, **classifies where an absent path diverges** and records the terminal node + ancestor stack that a later restructure + bubble-up pass (`mpt_insert`, sibling `.2`) needs:

| case | meaning | context recorded |
|---|---|---|
| 0 `BRANCH_EMPTY_SLOT` | path reaches a branch with an empty child slot | branch un-pushed → terminal; new leaf fills `path[consumed]` |
| 1 `LEAF_SPLIT` | path diverges at a leaf | `match_len` = shared-prefix nibbles |
| 2 `EXTENSION_SPLIT` | path diverges inside an extension | `match_len` = matched ext nibbles |
| 3 `EMPTY_TRIE` | `root == EMPTY_TRIE_ROOT` | single new leaf |
| 4 `EXISTS` / 5 `BRANCH_VALUE` | defensive (not on the withdrawal path) | — |

The ancestor stack (`stack_out`) is recorded identically to `mpt_set_record_walk` so the existing bubble-up pass can re-root after the terminal is restructured.

## Verification
Adds the `zisk_mpt_insert_walk` probe + 5 divergence vectors to `scripts/mpt_ref.py` + `scripts/codegen-zisk-mpt-insert-walk-check.sh`. All five shapes match the validated Python reference **byte-for-byte**:

```
PASS   iw_branch_empty           (case=0 depth=0)
PASS   iw_leaf_split             (case=1 depth=0)   match_len=2
PASS   iw_ext_split              (case=2 depth=0)   match_len=1
PASS   iw_empty_trie             (case=3 depth=0)
PASS   iw_ext_then_branch_empty  (case=0 depth=1)   consumed=2  (ancestor + un-push)
```

No-misaligned invariant respected (path/key nibbles read byte-wise). Full `lake build` green; file-size + unimported checks pass.

Refs #35. Bead: evm-asm-fhsxz.2.4.2.6.1. Stacked on `feat/eest-fullmatch`.

Authored by @pirapira; implemented by Claude Code