### PR TITLE
feat(mpt): mpt_insert — branch-empty-slot + empty-trie insert + bubble-up

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -56,6 +56,7 @@ import EvmAsm.Codegen.Programs.Mpt
 import EvmAsm.Codegen.Programs.MptSet
 import EvmAsm.Codegen.Programs.MptSetAcc
 import EvmAsm.Codegen.Programs.MptInsertWalk
+import EvmAsm.Codegen.Programs.MptInsert
 import EvmAsm.Codegen.Programs.WithdrawalsStateRoot
 import EvmAsm.Codegen.Programs.AccountBalance
 import EvmAsm.Codegen.Programs.MptEncode
@@ -557,6 +558,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_mpt_walk"             => some ziskMptWalkProbeUnit
   | "zisk_mpt_set_record_walk"  => some ziskMptSetRecordWalkProbeUnit
   | "zisk_mpt_insert_walk"      => some ziskMptInsertWalkProbeUnit
+  | "zisk_mpt_insert"           => some ziskMptInsertProbeUnit
   | "zisk_mpt_set"              => some ziskMptSetProbeUnit
   | "zisk_mpt_set_acc"          => some ziskMptSetAccProbeUnit
   | "zisk_mpt_state_root"       => some ziskMptStateRootProbeUnit
@@ -845,6 +847,7 @@ def knownProgramNames : List String :=
    "zisk_mpt_walk",
    "zisk_mpt_set_record_walk",
    "zisk_mpt_insert_walk",
+   "zisk_mpt_insert",
    "zisk_mpt_set",
    "zisk_mpt_set_acc",
    "zisk_mpt_state_root",
@@ -1325,6 +1328,7 @@ end EvmAsm.Codegen
     "EvmAsm/Codegen/Programs/MptSet.lean",
     "EvmAsm/Codegen/Programs/MptSetAcc.lean",
     "EvmAsm/Codegen/Programs/MptInsertWalk.lean",
+    "EvmAsm/Codegen/Programs/MptInsert.lean",
     "EvmAsm/Codegen/Programs/WithdrawalsStateRoot.lean",
     "EvmAsm/Codegen/Programs/AccountBalance.lean",
     "EvmAsm/Codegen/Programs/MptEncode.lean",

--- a/EvmAsm/Codegen/Programs/MptInsert.lean
+++ b/EvmAsm/Codegen/Programs/MptInsert.lean
@@ -1,0 +1,223 @@
+/-
+  EvmAsm.Codegen.Programs.MptInsert
+
+  mpt_insert (bead evm-asm-fhsxz.2.4.2.6.2): insert a NEW key into a witness-
+  backed MPT and return the new root. Account creation for withdrawals to
+  absent / precompile recipients (parent bead .2.4.2.6).
+
+  Composes mpt_insert_walk (sibling .1, classifies WHERE the absent key
+  diverges) + a per-case terminal restructure + the SAME bubble-up pass that
+  mpt_set uses (re-encode each ancestor's touched slot, hash at >=32 B, keccak
+  the root).
+
+  Cases supported in THIS slice (sound for fixed-length 64-nibble account
+  paths, which never end inside a node):
+    case 3 EMPTY_TRIE        : root := keccak(leaf(full_path, value)).
+    case 0 BRANCH_EMPTY_SLOT : fill the terminal branch's empty slot
+                               path[consumed] with leaf(path[consumed+1..],
+                               value); bubble up the ancestor stack.
+
+  Conservative (returns status 1, caller -> conservative MISS, never a false
+  positive) on:
+    case 1 LEAF_SPLIT / case 2 EXTENSION_SPLIT : need a new branch (+ optional
+      extension); deferred to a follow-up. case 4 EXISTS / 5 BRANCH_VALUE : not
+      on the withdrawal-insert path.
+
+  Reuses mpt_set's leaf encoder / node-slot encoder / splice helpers verbatim.
+  All scratch is 8-aligned; the no-misaligned invariant holds (nibbles read
+  byte-wise inside the reused helpers).
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.MptSet
+import EvmAsm.Codegen.Programs.MptInsertWalk
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+/-! ## mpt_insert -- insert a NEW (path, value), recompute the root.
+
+    Calling convention (mirrors mpt_set, with value where new_value was):
+      a0 (input)  : root_hash ptr (32 bytes)
+      a1 (input)  : witness section ptr
+      a2 (input)  : witness section length
+      a3 (input)  : path_nibbles ptr (one byte per nibble)
+      a4 (input)  : path_nibbles length
+      a5 (input)  : value ptr
+      a6 (input)  : value length
+      a7 (input)  : out_root ptr (32 bytes, written on success)
+      a0 (output) : 0 (ok) / 1 (unsupported divergence / incomplete witness ->
+                    conservative) / 2 (parse / splice fail) -/
+def mptInsertFunction : String :=
+  "mpt_insert:\n" ++
+  "  addi sp, sp, -96\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp)\n" ++
+  "  mv s0, a1                   # witness ptr\n" ++
+  "  mv s1, a3                   # path ptr\n" ++
+  "  mv s2, a4                   # path_len\n" ++
+  "  mv s3, a5                   # value ptr\n" ++
+  "  mv s4, a6                   # value_len\n" ++
+  "  mv s5, a7                   # out_root\n" ++
+  "  la t0, ins_wl; sd a2, 0(t0) # stash witness_len\n" ++
+  "  # ---- classify divergence (a0=root_hash unchanged) ----\n" ++
+  "  mv a1, s0\n" ++
+  "  la t0, ins_wl; ld a2, 0(t0)\n" ++
+  "  mv a3, s1\n" ++
+  "  mv a4, s2\n" ++
+  "  la a5, ins_stack\n" ++
+  "  la a6, ins_meta\n" ++
+  "  jal ra, mpt_insert_walk\n" ++
+  "  bnez a0, .Lins_ret          # incomplete witness / parse -> propagate\n" ++
+  "  la t0, ins_meta\n" ++
+  "  ld s6, 0(t0)                # depth (ancestors)\n" ++
+  "  ld s8, 8(t0)                # consumed (ancestor nibbles)\n" ++
+  "  ld t1, 16(t0)               # case\n" ++
+  "  li t2, 3; beq t1, t2, .Lins_empty\n" ++
+  "  li t2, 0; beq t1, t2, .Lins_branch_empty\n" ++
+  "  li a0, 1; j .Lins_ret       # leaf/ext-split etc.: conservative (follow-up)\n" ++
+  ".Lins_empty:\n" ++
+  "  # root := keccak(leaf(full path, value)).\n" ++
+  "  mv a0, s1; mv a1, s2; mv a2, s3; mv a3, s4\n" ++
+  "  la a4, ins_node; la a5, ins_node_len\n" ++
+  "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  la a0, ins_node; la t0, ins_node_len; ld a1, 0(t0); mv a2, s5\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  li a0, 0; j .Lins_ret\n" ++
+  ".Lins_branch_empty:\n" ++
+  "  # leaf = leaf(path[consumed+1..], value).\n" ++
+  "  add a0, s1, s8; addi a0, a0, 1\n" ++
+  "  sub a1, s2, s8; addi a1, a1, -1\n" ++
+  "  mv a2, s3; mv a3, s4\n" ++
+  "  la a4, ins_node; la a5, ins_node_len\n" ++
+  "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  # leaf_ref = node_slot_encode(leaf).\n" ++
+  "  la a0, ins_node; la t0, ins_node_len; ld a1, 0(t0)\n" ++
+  "  la a2, ins_ref; la a3, ins_ref_len\n" ++
+  "  jal ra, mpt_node_slot_encode\n" ++
+  "  # splice the terminal branch's slot[path[consumed]] := leaf_ref.\n" ++
+  "  la t0, ins_meta; ld t1, 24(t0)        # terminal_offset\n" ++
+  "  add a0, s0, t1\n" ++
+  "  la t0, ins_meta; ld a1, 32(t0)        # terminal_len\n" ++
+  "  add t2, s1, s8; lbu a2, 0(t2)         # nibble = path[consumed]\n" ++
+  "  la a3, ins_ref; la t0, ins_ref_len; ld a4, 0(t0)\n" ++
+  "  la a5, ins_node; la a6, ins_node_len\n" ++
+  "  jal ra, mpt_splice_slot\n" ++
+  "  bnez a0, .Lins_fail\n" ++
+  "  # ins_ref := node_slot_encode(new branch), then bubble up.\n" ++
+  "  la a0, ins_node; la t0, ins_node_len; ld a1, 0(t0)\n" ++
+  "  la a2, ins_ref; la a3, ins_ref_len\n" ++
+  "  jal ra, mpt_node_slot_encode\n" ++
+  "  mv s7, s6                   # i = depth\n" ++
+  ".Lins_bubble:\n" ++
+  "  beqz s7, .Lins_root\n" ++
+  "  addi s7, s7, -1\n" ++
+  "  la t0, ins_stack\n" ++
+  "  slli t1, s7, 5; add t0, t0, t1        # &record[i]\n" ++
+  "  ld t2, 0(t0)                # node_offset\n" ++
+  "  ld t3, 8(t0)                # node_len\n" ++
+  "  ld t4, 16(t0)               # kind (0 branch / 1 ext)\n" ++
+  "  ld t5, 24(t0)               # nibble\n" ++
+  "  add a0, s0, t2; mv a1, t3\n" ++
+  "  beqz t4, .Lins_k_branch\n" ++
+  "  li a2, 1; j .Lins_k_done\n" ++
+  ".Lins_k_branch:\n" ++
+  "  mv a2, t5\n" ++
+  ".Lins_k_done:\n" ++
+  "  la a3, ins_ref; la t0, ins_ref_len; ld a4, 0(t0)\n" ++
+  "  la a5, ins_node; la a6, ins_node_len\n" ++
+  "  jal ra, mpt_splice_slot\n" ++
+  "  bnez a0, .Lins_fail\n" ++
+  "  la a0, ins_node; la t0, ins_node_len; ld a1, 0(t0)\n" ++
+  "  la a2, ins_ref; la a3, ins_ref_len\n" ++
+  "  jal ra, mpt_node_slot_encode\n" ++
+  "  j .Lins_bubble\n" ++
+  ".Lins_root:\n" ++
+  "  la a0, ins_node; la t0, ins_node_len; ld a1, 0(t0); mv a2, s5\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  li a0, 0\n" ++
+  ".Lins_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp)\n" ++
+  "  addi sp, sp, 96\n" ++
+  "  ret\n" ++
+  ".Lins_fail:\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lins_ret"
+
+/-- `zisk_mpt_insert`: probe BuildUnit. Reuses `scripts/mpt_ref.py`
+    `build_probe_input` layout (value where new_value was) and writes the new
+    32-byte root to OUTPUT+0, status to OUTPUT+32 -- same as the mpt_set probe,
+    so the check script compares OUTPUT[0:32] against the reference root.
+    Output layout:
+      OUTPUT+0  : 32-byte recomputed new root
+      OUTPUT+32 : status (0 ok / 1 unsupported|miss / 2 fail) -/
+def ziskMptInsertPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t0, 0x40000000\n" ++
+  "  ld a2, 8(t0)                # witness_len\n" ++
+  "  ld a4, 16(t0)               # path_len\n" ++
+  "  ld a6, 24(t0)               # value_len\n" ++
+  "  addi a0, t0, 32             # root_hash ptr (INPUT+32)\n" ++
+  "  addi a3, t0, 64             # path ptr (INPUT+64)\n" ++
+  "  add a5, a3, a4              # value ptr = path + path_len\n" ++
+  "  add t1, a4, a6\n" ++
+  "  addi t1, t1, 7\n" ++
+  "  andi t1, t1, -8\n" ++
+  "  add a1, a3, t1             # witness ptr\n" ++
+  "  li a7, 0xa0010000          # out_root at OUTPUT+0 (32 B)\n" ++
+  "  jal ra, mpt_insert\n" ++
+  "  li t0, 0xa0010020\n" ++
+  "  sd a0, 0(t0)               # status at OUTPUT+32\n" ++
+  "  j .Lmins_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  mptInsertWalkFunction ++ "\n" ++
+  hpEncodeNibblesFunction ++ "\n" ++
+  rlpEncodeBytesFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  mptLeafNodeEncodeFromNibblesFunction ++ "\n" ++
+  mptNodeSlotEncodeFunction ++ "\n" ++
+  rlpItemSizeFunction ++ "\n" ++
+  rlpItemSpanFunction ++ "\n" ++
+  msetMemcpyFunction ++ "\n" ++
+  mptSpliceSlotFunction ++ "\n" ++
+  mptInsertFunction ++ "\n" ++
+  ".Lmins_pdone:"
+
+/-- Data section: the mpt_set probe scratch (mw_*, mlnen_*, mset_*) + the
+    walk's `iw_empty_trie_root` + mpt_insert's own buffers (`ins_*`). All
+    labels are disjoint. -/
+def ziskMptInsertDataSection : String :=
+  ziskMptSetDataSection ++ "\n" ++
+  ".balign 8\n" ++
+  iwEmptyTrieRootData ++ "\n" ++
+  ".balign 8\n" ++
+  "ins_wl:\n  .zero 8\n" ++
+  "ins_node_len:\n  .zero 8\n" ++
+  "ins_ref_len:\n  .zero 8\n" ++
+  ".balign 8\n" ++
+  "ins_meta:\n  .zero 48\n" ++
+  ".balign 8\n" ++
+  "ins_stack:\n  .zero 2048\n" ++
+  ".balign 8\n" ++
+  "ins_ref:\n  .zero 64\n" ++
+  ".balign 8\n" ++
+  "ins_node:\n  .zero 2048"
+
+def ziskMptInsertProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskMptInsertPrologue
+  dataAsm     := ziskMptInsertDataSection
+}
+
+end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **478**
-- ziskemu round-trip scripts: **469** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **482**
+- ziskemu round-trip scripts: **472** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **473**
-- ziskemu round-trip scripts: **465** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **481**
+- ziskemu round-trip scripts: **471** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **481**
-- ziskemu round-trip scripts: **471** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **482**
+- ziskemu round-trip scripts: **472** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-mpt-insert-check.sh
+++ b/scripts/codegen-zisk-mpt-insert-check.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# codegen-zisk-mpt-insert-check.sh -- verify mpt_insert (bead
+# evm-asm-fhsxz.2.4.2.6.2): insert a NEW key into a witness-backed MPT and
+# recompute the root, against the validated Python reference scripts/mpt_ref.py.
+#
+# mpt_insert = mpt_insert_walk (classify divergence) + per-case terminal
+# restructure + the mpt_set bubble-up. This slice supports EMPTY_TRIE and
+# BRANCH_EMPTY_SLOT (depth 0 and depth 1). The probe writes the new 32-byte
+# root to OUTPUT+0 and status to OUTPUT+32; we compare both against the
+# reference (expected new root, status 0).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else echo "ziskemu not found" >&2; exit 1; fi
+fi
+
+VDIR="$REPO_ROOT/gen-out/mpt-set"
+echo "==> generate vectors via the validated Python reference"
+uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/mpt_ref.py" "$VDIR"
+
+echo "==> lake build codegen"
+lake build codegen >/dev/null
+
+echo "==> emit zisk_mpt_insert probe ELF"
+lake exe codegen --program zisk_mpt_insert --halt linux93 \
+  -o "$REPO_ROOT/gen-out/zisk_mpt_insert"
+
+read_u64() { od -An -tu8 -j "$2" -N 8 "$1" | tr -d ' \n'; }
+
+fail=0
+for name in mi_branch_empty mi_empty_trie mi_ext_then_branch; do
+  out="$VDIR/$name.mi.output"
+  if ! "$ZISKEMU" -e "$REPO_ROOT/gen-out/zisk_mpt_insert.elf" \
+        -i "$VDIR/$name.input" -o "$out" -n 5000000 >/dev/null 2>&1 </dev/null; then
+    echo "  ERROR  $name (ziskemu)"; fail=1; continue
+  fi
+  st="$(read_u64 "$out" 32)"
+  act="$(od -An -tx1 -j 0 -N 32 "$out" | tr -d ' \n')"
+  exp="$(cat "$VDIR/$name.expected")"
+  if [[ "$st" == "0" && "$act" == "$exp" ]]; then
+    echo "  PASS   $name  root=${act:0:16}.."
+  else
+    echo "  FAIL   $name  status=$st"
+    echo "         expected $exp"
+    echo "         got      $act"
+    fail=1
+  fi
+done
+[[ "$fail" -eq 0 ]] && echo "==> PASS: mpt_insert matches reference" \
+  || { echo "==> FAIL"; exit 1; }

--- a/scripts/mpt_ref.py
+++ b/scripts/mpt_ref.py
@@ -562,6 +562,52 @@ def insert_walk_expected(v: dict) -> list[tuple[str, int, int]]:
     return out
 
 
+# ---- insert vectors (mpt_insert .2.4.2.6.2): expected NEW root ------------
+# Insert an ABSENT key; expected = the re-rooted trie. Covers the cases the
+# first mpt_insert slice supports: EMPTY_TRIE and BRANCH_EMPTY_SLOT (depth 0
+# and depth 1 with an extension ancestor).
+def vec_mi_branch_empty():
+    la = leaf_node([0xa, 0xb], b"v1")
+    slots = [b"\x80"] * 16
+    slots[1] = node_ref(la)
+    root = branch_node(slots)
+    val = b"newval"
+    new_leaf = leaf_node([0x7, 0x8], val)        # path[consumed+1..] = [7,8]
+    slots2 = list(slots)
+    slots2[3] = node_ref(new_leaf)               # nibble path[consumed] = 3
+    new_root = branch_node(slots2)
+    return dict(name="mi_branch_empty", witness=[root], root=trie_root(root),
+                path=[0x3, 0x7, 0x8], value=val, expected=trie_root(new_root))
+
+
+def vec_mi_empty_trie():
+    val = b"hello"
+    new_root = leaf_node([0x1, 0x2, 0x3, 0x4], val)
+    return dict(name="mi_empty_trie", witness=[], root=EMPTY_TRIE_ROOT,
+                path=[0x1, 0x2, 0x3, 0x4], value=val,
+                expected=trie_root(new_root))
+
+
+def vec_mi_ext_then_branch():
+    la = leaf_node([0xc], b"z" * 40)             # big -> branch hash-referenced
+    slots = [b"\x80"] * 16
+    slots[1] = node_ref(la)
+    branch = branch_node(slots)
+    root = extension_node([0x5, 0x6], node_ref(branch))
+    val = b"zzz"
+    new_leaf = leaf_node([0xc], val)             # path[consumed+1..] = [c]
+    slots2 = list(slots)
+    slots2[3] = node_ref(new_leaf)               # nibble path[consumed=2] = 3
+    new_branch = branch_node(slots2)
+    new_root = extension_node([0x5, 0x6], node_ref(new_branch))
+    return dict(name="mi_ext_then_branch", witness=[root, branch],
+                root=trie_root(root), path=[0x5, 0x6, 0x3, 0xc], value=val,
+                expected=trie_root(new_root))
+
+
+MI_VECTORS = [vec_mi_branch_empty, vec_mi_empty_trie, vec_mi_ext_then_branch]
+
+
 if __name__ == "__main__":
     import os
     outdir = sys.argv[1] if len(sys.argv) > 1 else "gen-out/mpt-set"
@@ -621,6 +667,17 @@ if __name__ == "__main__":
                 f.write(f"{name} {off} {val}\n")
         print(f"{v['name']:24} case={v['case']} depth={v['depth']} "
               f"consumed={v['consumed']} match_len={v['match_len']}")
+    # insert vectors (mpt_insert): expected NEW root
+    for mk in MI_VECTORS:
+        v = mk()
+        sec = ssz_section(v["witness"])
+        inp = build_probe_input(v["root"], v["path"], v["value"], sec)
+        with open(f"{outdir}/{v['name']}.input", "wb") as f:
+            f.write(inp)
+        with open(f"{outdir}/{v['name']}.expected", "w") as f:
+            f.write(v["expected"].hex())
+        print(f"{v['name']:24} root={v['root'].hex()[:16]}.. "
+              f"new_root={v['expected'].hex()}")
     # accumulating 2-update vector (mpt_set_acc)
     a = vec_acc()
     sec = ssz_section(a["witness"])


### PR DESCRIPTION
## Summary
Second piece of state-trie account INSERT (bead `evm-asm-fhsxz.2.4.2.6.2`). `mpt_insert` inserts a NEW key into a witness-backed MPT and recomputes the root, composing **`mpt_insert_walk`** (sibling `.1`, #7762) + a per-case terminal restructure + the **same bubble-up** pass `mpt_set` uses.

This slice supports the cases that occur for fixed-length 64-nibble account paths into a sparse pre-state:
- **case 3 `EMPTY_TRIE`** → `root = keccak(leaf(full_path, value))`
- **case 0 `BRANCH_EMPTY_SLOT`** → fill the terminal branch's empty slot with `leaf(path[consumed+1..], value)`, then bubble up the ancestor stack.

It is **conservative** (status 1 → caller MISS, never a false positive) on `LEAF_SPLIT` / `EXTENSION_SPLIT` (need a new branch + optional extension — a follow-up child) and the defensive `EXISTS` / `BRANCH_VALUE` cases.

## Verification
Adds the `zisk_mpt_insert` probe + 3 insert vectors to `scripts/mpt_ref.py` + `scripts/codegen-zisk-mpt-insert-check.sh`. All three recompute the **exact reference new root** with status 0:

```
PASS   mi_branch_empty     (case 0, depth 0)
PASS   mi_empty_trie       (case 3)
PASS   mi_ext_then_branch  (case 0, depth 1 — bubble-up through an extension)
```

Full `lake build` green; file-size + unimported checks pass; no-misaligned invariant held (reuses the verified mpt_set helpers).

Refs #35. Bead: evm-asm-fhsxz.2.4.2.6.2. Stacked on `feat/mpt-insert-walk` (#7762).

Authored by @pirapira; implemented by Claude Code