### PR TITLE
test(mpt): state_root_ins_deep — depth≥1 insert-after-modify via the DB

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **478**
-- ziskemu round-trip scripts: **469** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **485**
+- ziskemu round-trip scripts: **475** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **473**
-- ziskemu round-trip scripts: **465** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **484**
+- ziskemu round-trip scripts: **474** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-mpt-insert-check.sh
+++ b/scripts/codegen-zisk-mpt-insert-check.sh
@@ -34,7 +34,7 @@ read_u64() { od -An -tu8 -j "$2" -N 8 "$1" | tr -d ' \n'; }
 
 fail=0
 for name in mi_branch_empty mi_empty_trie mi_ext_then_branch \
-            mi_leaf_split mi_leaf_split_m0; do
+            mi_leaf_split mi_leaf_split_m0 mi_leafsplit_depth1; do
   out="$VDIR/$name.mi.output"
   if ! "$ZISKEMU" -e "$REPO_ROOT/gen-out/zisk_mpt_insert.elf" \
         -i "$VDIR/$name.input" -o "$out" -n 5000000 >/dev/null 2>&1 </dev/null; then

--- a/scripts/codegen-zisk-mpt-state-root-ins-check.sh
+++ b/scripts/codegen-zisk-mpt-state-root-ins-check.sh
@@ -22,7 +22,7 @@ lake exe codegen --program zisk_mpt_state_root_ins --halt linux93 \
   -o "$REPO_ROOT/gen-out/zisk_mpt_state_root_ins"
 read_u64() { od -An -tu8 -j "$2" -N 8 "$1" | tr -d ' \n'; }
 fail=0
-for name in state_root_ins; do
+for name in state_root_ins state_root_ins_deep; do
   out="$VDIR/$name.sri.output"
   if ! "$ZISKEMU" -e "$REPO_ROOT/gen-out/zisk_mpt_state_root_ins.elf" \
         -i "$VDIR/$name.input" -o "$out" -n 8000000 >/dev/null 2>&1 </dev/null; then

--- a/scripts/codegen-zisk-mpt-state-root-ins-check.sh
+++ b/scripts/codegen-zisk-mpt-state-root-ins-check.sh
@@ -22,7 +22,7 @@ lake exe codegen --program zisk_mpt_state_root_ins --halt linux93 \
   -o "$REPO_ROOT/gen-out/zisk_mpt_state_root_ins"
 read_u64() { od -An -tu8 -j "$2" -N 8 "$1" | tr -d ' \n'; }
 fail=0
-for name in state_root_ins state_root_ins_deep; do
+for name in state_root_ins state_root_ins_deep state_root_ins_dbchild; do
   out="$VDIR/$name.sri.output"
   if ! "$ZISKEMU" -e "$REPO_ROOT/gen-out/zisk_mpt_state_root_ins.elf" \
         -i "$VDIR/$name.input" -o "$out" -n 8000000 >/dev/null 2>&1 </dev/null; then

--- a/scripts/mpt_ref.py
+++ b/scripts/mpt_ref.py
@@ -639,8 +639,38 @@ def vec_mi_leaf_split_m0():
                 path=[9, 6, 7], value=val, expected=trie_root(branch))
 
 
+def vec_mi_leafsplit_depth1():
+    """R slot5 -> branch B (hash); B slot7 -> leaf LA key [a,b]. Insert path
+    [5,7,9,c] diverges at LA (m=0) -> LEAF_SPLIT at DEPTH 1 (ancestors R,B): the
+    new branch replaces LA at B slot7, bubbling through B then R. mi_leaf_split
+    was depth 0; this exercises the leaf-split terminal under ancestors."""
+    la = leaf_node([0xa, 0xb], b"L" * 40)       # >=32 hash-ref
+    slots_b = [b"\x80"] * 16
+    slots_b[0x7] = node_ref(la)
+    b = branch_node(slots_b)
+    slots_r = [b"\x80"] * 16
+    slots_r[0x5] = node_ref(b)
+    root = branch_node(slots_r)
+    val = b"newdeep"
+    old2 = leaf_node([0xb], b"L" * 40)          # LA[m+1..]=[b]
+    new2 = leaf_node([0xc], val)                # P[m+1..]=[c]
+    spl = [b"\x80"] * 16
+    spl[0xa] = node_ref(old2)
+    spl[0x9] = node_ref(new2)
+    split_branch = branch_node(spl)
+    slots_b2 = list(slots_b)
+    slots_b2[0x7] = node_ref(split_branch)
+    b2 = branch_node(slots_b2)
+    slots_r2 = list(slots_r)
+    slots_r2[0x5] = node_ref(b2)
+    root2 = branch_node(slots_r2)
+    return dict(name="mi_leafsplit_depth1", witness=[root, b, la],
+                root=trie_root(root), path=[0x5, 0x7, 0x9, 0xc], value=val,
+                expected=trie_root(root2))
+
+
 MI_VECTORS = [vec_mi_branch_empty, vec_mi_empty_trie, vec_mi_ext_then_branch,
-              vec_mi_leaf_split, vec_mi_leaf_split_m0]
+              vec_mi_leaf_split, vec_mi_leaf_split_m0, vec_mi_leafsplit_depth1]
 
 
 # ---- insert-aware multi-change driver (mpt_state_root_ins .2.4.2.6.3) ------
@@ -717,6 +747,36 @@ def vec_state_root_ins_deep():
     changes = [([0x1, 0xa, 0xb], a_new, False),
                ([0x2, 0x7, 0xe, 0xf], vins, True)]
     return dict(name="state_root_ins_deep", witness=[root, leaf_a, bb],
+                root=trie_root(root), changes=changes,
+                expected=trie_root(root2))
+
+
+def vec_state_root_ins_dbchild():
+    """R slot5 -> branch B; B slot5 -> leaf A, slot7 empty. change0 = MODIFY
+    key A (path 5,5,a,b) -> re-encodes B AND R into the DB. change1 = INSERT at
+    B slot7 (path 5,7,e,f): descends R'(DB) slot5 -> B'(DB, MODIFIED by change0)
+    -> empty slot7. So the insert must resolve a DB-modified INTERMEDIATE node
+    (B') and bubble through two DB-resident ancestors -- the case neither
+    state_root_ins nor state_root_ins_deep exercised."""
+    a_old, a_new, vins = b"A" * 32, b"a-new" * 8, b"ins" * 12
+    leaf_a = leaf_node([0xa, 0xb], a_old)
+    slots_b = [b"\x80"] * 16
+    slots_b[0x5] = node_ref(leaf_a)
+    bb = branch_node(slots_b)
+    slots_r = [b"\x80"] * 16
+    slots_r[0x5] = node_ref(bb)
+    root = branch_node(slots_r)
+    # post
+    slots_b2 = list(slots_b)
+    slots_b2[0x5] = node_ref(leaf_node([0xa, 0xb], a_new))
+    slots_b2[0x7] = node_ref(leaf_node([0xe, 0xf], vins))
+    bb2 = branch_node(slots_b2)
+    slots_r2 = list(slots_r)
+    slots_r2[0x5] = node_ref(bb2)
+    root2 = branch_node(slots_r2)
+    changes = [([0x5, 0x5, 0xa, 0xb], a_new, False),
+               ([0x5, 0x7, 0xe, 0xf], vins, True)]
+    return dict(name="state_root_ins_dbchild", witness=[root, bb, leaf_a],
                 root=trie_root(root), changes=changes,
                 expected=trie_root(root2))
 
@@ -829,3 +889,11 @@ if __name__ == "__main__":
         f.write(srid["expected"].hex())
     print(f"{'sri_deep':12} root={srid['root'].hex()[:16]}.. "
           f"final_root={srid['expected'].hex()} (modify+insert depth>=1)")
+    sridc = vec_state_root_ins_dbchild()
+    sec = ssz_section(sridc["witness"])
+    with open(f"{outdir}/state_root_ins_dbchild.input", "wb") as f:
+        f.write(build_state_root_ins_input(sridc["root"], sridc["changes"], sec))
+    with open(f"{outdir}/state_root_ins_dbchild.expected", "w") as f:
+        f.write(sridc["expected"].hex())
+    print(f"{'sri_dbchild':12} root={sridc['root'].hex()[:16]}.. "
+          f"final_root={sridc['expected'].hex()} (insert via DB-modified child)")

--- a/scripts/mpt_ref.py
+++ b/scripts/mpt_ref.py
@@ -688,6 +688,39 @@ def vec_state_root_ins():
                 expected=trie_root(new_root))
 
 
+def vec_state_root_ins_deep():
+    """R branch: slot1 -> leaf A (existing), slot2 -> branch B (hash); B slot5
+    -> leaf B, slot7 empty. change0 = MODIFY key A (slot1) -> R' in the DB;
+    change1 = INSERT at B slot7 via path [2,7,e,f] -- descends R' (resolved
+    from the DB) -> B (witness) -> empty slot7, so the insert's bubble-up must
+    splice a DB-RESIDENT ancestor (R'). This is the depth>=1 insert-after-modify
+    the depth-0 state_root_ins vector never exercised."""
+    a_old, a_new = b"A" * 32, b"a-new" * 8
+    b_old, vins = b"B" * 32, b"ins" * 12
+    leaf_a = leaf_node([0xa, 0xb], a_old)
+    leaf_b = leaf_node([0xc, 0xd], b_old)
+    slots_bb = [b"\x80"] * 16
+    slots_bb[0x5] = node_ref(leaf_b)
+    bb = branch_node(slots_bb)
+    slots_r = [b"\x80"] * 16
+    slots_r[0x1] = node_ref(leaf_a)
+    slots_r[0x2] = node_ref(bb)
+    root = branch_node(slots_r)
+    # post: slot1 leaf updated; B gets a new leaf at slot7
+    slots_bb2 = list(slots_bb)
+    slots_bb2[0x7] = node_ref(leaf_node([0xe, 0xf], vins))
+    bb2 = branch_node(slots_bb2)
+    slots_r2 = list(slots_r)
+    slots_r2[0x1] = node_ref(leaf_node([0xa, 0xb], a_new))
+    slots_r2[0x2] = node_ref(bb2)
+    root2 = branch_node(slots_r2)
+    changes = [([0x1, 0xa, 0xb], a_new, False),
+               ([0x2, 0x7, 0xe, 0xf], vins, True)]
+    return dict(name="state_root_ins_deep", witness=[root, leaf_a, bb],
+                root=trie_root(root), changes=changes,
+                expected=trie_root(root2))
+
+
 if __name__ == "__main__":
     import os
     outdir = sys.argv[1] if len(sys.argv) > 1 else "gen-out/mpt-set"
@@ -788,3 +821,11 @@ if __name__ == "__main__":
         f.write(sri["expected"].hex())
     print(f"{'state_root_ins':12} root={sri['root'].hex()[:16]}.. "
           f"final_root={sri['expected'].hex()} (modify+insert)")
+    srid = vec_state_root_ins_deep()
+    sec = ssz_section(srid["witness"])
+    with open(f"{outdir}/state_root_ins_deep.input", "wb") as f:
+        f.write(build_state_root_ins_input(srid["root"], srid["changes"], sec))
+    with open(f"{outdir}/state_root_ins_deep.expected", "w") as f:
+        f.write(srid["expected"].hex())
+    print(f"{'sri_deep':12} root={srid['root'].hex()[:16]}.. "
+          f"final_root={srid['expected'].hex()} (modify+insert depth>=1)")


### PR DESCRIPTION
## Summary
Adds a `mpt_state_root_ins` vector that closes a coverage gap: change0 **MODIFIES** a leaf (root re-encoded into the node DB), change1 **INSERTS** a sibling whose descent crosses the DB-modified root into a witness subtree — so the insert's bubble-up splices a **DB-resident ancestor**. This is the depth≥1 insert-after-modify the depth-0 `state_root_ins` vector never exercised.

It **PASSES**, confirming the insert engine (`mpt_insert_walk_db` / `mpt_insert_acc` / `mpt_state_root_ins`) is correct here.

## Why
Narrows the eip4895 insert-wiring root-mismatch (bead `evm-asm-fhsxz.2.4.2.6.6`): the engine is now verified correct across depth-2 witness inserts (`mi_depth2`) AND depth≥1 insert-after-modify, so the real-block wrong root points to **unmodeled state** rather than an insert bug — to be confirmed by a pre/post-alloc diff + Python patricialize cross-check.

Refs #35. Bead: evm-asm-fhsxz.2.4.2.6.6. Stacked on `feat/mpt-state-root-ins` (#7767).

Authored by @pirapira; implemented by Claude Code