### PR TITLE
feat(eest): add BAL account path helper

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -62,6 +62,7 @@ import EvmAsm.Codegen.Programs.AccountBalance
 import EvmAsm.Codegen.Programs.MptEncode
 import EvmAsm.Codegen.Programs.SystemWrites
 import EvmAsm.Codegen.Programs.BalGasValid
+import EvmAsm.Codegen.Programs.BalAccountPath
 import EvmAsm.Codegen.Programs.StorageWrite
 import EvmAsm.Codegen.Programs.BlockAccessListHash
 import EvmAsm.Codegen.Programs.AccountApplyStorage
@@ -314,6 +315,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_single_leaf_trie_root" => some ziskSingleLeafTrieRootProbeUnit
   | "zisk_system_write_descriptors" => some ziskSystemWriteDescriptorsProbeUnit
   | "zisk_bal_gas_valid"         => some ziskBalGasValidProbeUnit
+  | "zisk_bal_account_path"      => some ziskBalAccountPathProbeUnit
   | "zisk_storage_root_single_slot" => some ziskStorageRootSingleSlotProbeUnit
   | "zisk_account_set_storage_root" => some ziskAccountSetStorageRootProbeUnit
   | "zisk_block_access_list_hash" => some ziskBlockAccessListHashProbeUnit
@@ -1100,6 +1102,7 @@ def knownProgramNames : List String :=
    "zisk_single_leaf_trie_root",
    "zisk_system_write_descriptors",
    "zisk_bal_gas_valid",
+   "zisk_bal_account_path",
    "zisk_storage_root_single_slot",
    "zisk_account_set_storage_root",
    "zisk_block_access_list_hash",

--- a/EvmAsm/Codegen/Programs/BalAccountPath.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountPath.lean
@@ -1,0 +1,91 @@
+/-
+  EvmAsm.Codegen.Programs.BalAccountPath
+
+  BAL account-change preprocessing for state-root replay. A block access list
+  AccountChanges item is RLP-encoded as:
+    [address, storage_changes, storage_reads, balance_changes, nonce_changes, code_changes]
+
+  This helper extracts field 0 (the 20-byte account address) and converts it to
+  the world-state trie path: bytes_to_nibbles(keccak256(address)). It is the BAL
+  analogue of withdrawal_to_path_delta's address-to-path half, but without a
+  withdrawal amount.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.Mpt
+import EvmAsm.Codegen.Programs.RlpRead
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+/-! ## bal_account_path -- BAL AccountChanges RLP -> state-trie path
+
+    a0 = AccountChanges RLP ptr   a1 = AccountChanges RLP length
+    a2 = out path ptr (64 bytes, one nibble each)
+    a0 (output) = 0 ok / 1 parse fail or address length != 20.
+
+    path = bytes_to_nibbles(keccak256(address)). -/
+def balAccountPathFunction : String :=
+  "bal_account_path:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra, 0(sp); sd s0, 8(sp); sd s1, 16(sp)\n" ++
+  "  mv s0, a0                   # account-change ptr\n" ++
+  "  mv s1, a2                   # out path ptr\n" ++
+  "  # field 0 = address bytes.\n" ++
+  "  li a2, 0; la a3, bacp_off; la a4, bacp_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbacp_fail\n" ++
+  "  la t0, bacp_len; ld t1, 0(t0); li t2, 20; bne t1, t2, .Lbacp_fail\n" ++
+  "  la t0, bacp_off; ld t0, 0(t0); add a0, s0, t0\n" ++
+  "  li a1, 20; la a2, bacp_hash\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  la a0, bacp_hash; li a1, 32; mv a2, s1\n" ++
+  "  jal ra, bytes_to_nibbles\n" ++
+  "  li a0, 0; j .Lbacp_ret\n" ++
+  ".Lbacp_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lbacp_ret:\n" ++
+  "  ld ra, 0(sp); ld s0, 8(sp); ld s1, 16(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_bal_account_path`: probe BuildUnit.
+    Input layout (file maps to INPUT+8 at 0x40000000):
+      +8  AccountChanges RLP length (u64)
+      +16 AccountChanges RLP bytes
+    Output layout:
+      OUTPUT+0 : status (0 ok / 1 fail)
+      OUTPUT+8 : path (64 nibble bytes) -/
+def ziskBalAccountPathPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t0, 0x40000000\n" ++
+  "  ld a1, 8(t0)                # account-change RLP length\n" ++
+  "  addi a0, t0, 16             # account-change RLP ptr\n" ++
+  "  li a2, 0xa0010008           # out path at OUTPUT+8\n" ++
+  "  jal ra, bal_account_path\n" ++
+  "  li t0, 0xa0010000; sd a0, 0(t0)   # status at OUTPUT+0\n" ++
+  "  j .Lbacp_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  balAccountPathFunction ++ "\n" ++
+  ".Lbacp_pdone:"
+
+def ziskBalAccountPathDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n  .zero 200\n" ++
+  "bacp_off:\n  .zero 8\n" ++
+  "bacp_len:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "bacp_hash:\n  .zero 32"
+
+def ziskBalAccountPathProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBalAccountPathPrologue
+  dataAsm     := ziskBalAccountPathDataSection
+}
+
+end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **486**
-- ziskemu round-trip scripts: **476** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **487**
+- ziskemu round-trip scripts: **477** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-bal-account-path-check.sh
+++ b/scripts/codegen-zisk-bal-account-path-check.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# codegen-zisk-bal-account-path-check.sh -- verify bal_account_path
+# against the Python BAL AccountChanges reference.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else echo "ziskemu not found" >&2; exit 1; fi
+fi
+
+VDIR="$REPO_ROOT/gen-out/mpt-set"
+echo "==> generate vectors via the validated Python reference"
+uv run --directory execution-specs --quiet python3 "$REPO_ROOT/scripts/mpt_ref.py" "$VDIR"
+
+echo "==> lake build codegen"
+lake build codegen >/dev/null
+
+echo "==> emit zisk_bal_account_path probe ELF"
+lake exe codegen --program zisk_bal_account_path --halt linux93 \
+  -o "$REPO_ROOT/gen-out/zisk_bal_account_path"
+
+fail=0
+for name in bacp_empty bacp_changes bacp_precompile; do
+  out="$VDIR/$name.output"
+  "$ZISKEMU" -e "$REPO_ROOT/gen-out/zisk_bal_account_path.elf" \
+    -i "$VDIR/$name.input" -o "$out" -n 2000000 >/dev/null 2>&1 </dev/null \
+    || { echo "  ERROR  $name"; fail=1; continue; }
+  status="$(od -An -tu8 -j 0 -N 8 "$out" | tr -d ' \n')"
+  actual="$(xxd -p -s 8 -l 64 "$out" | tr -d '\n')"
+  expected="$(cat "$VDIR/$name.path")"
+  if [[ "$status" == "0" && "$actual" == "$expected" ]]; then echo "  PASS   $name  ${actual:0:32}..."
+  else echo "  FAIL   $name status=$status"; echo "    expected: $expected"; echo "    actual:   $actual"; fail=1; fi
+done
+[[ "$fail" -eq 0 ]] && echo "==> PASS: bal_account_path matches reference" \
+  || { echo "==> FAIL"; exit 1; }

--- a/scripts/mpt_ref.py
+++ b/scripts/mpt_ref.py
@@ -374,6 +374,52 @@ def vec_account_add_balance():
     return out
 
 
+def bal_account_change_rlp(address: bytes,
+                           storage_changes: list[bytes] | None = None,
+                           storage_reads: list[bytes] | None = None,
+                           balance_changes: list[tuple[int, int]] | None = None,
+                           nonce_changes: list[tuple[int, int]] | None = None,
+                           code_changes: list[tuple[int, bytes]] | None = None) -> bytes:
+    def change_pair(index: int, value_rlp: bytes) -> bytes:
+        return rlp_list([rlp_int(index), value_rlp])
+
+    storage_changes = storage_changes or []
+    storage_reads = storage_reads or []
+    balance_changes = balance_changes or []
+    nonce_changes = nonce_changes or []
+    code_changes = code_changes or []
+    sc = [rlp_list([rlp_bytes(slot), rlp_list([])]) for slot in storage_changes]
+    sr = [rlp_bytes(slot) for slot in storage_reads]
+    bc = [change_pair(i, rlp_int(v)) for i, v in balance_changes]
+    nc = [change_pair(i, rlp_int(v)) for i, v in nonce_changes]
+    cc = [change_pair(i, rlp_bytes(code)) for i, code in code_changes]
+    return rlp_list([rlp_bytes(address), rlp_list(sc), rlp_list(sr),
+                     rlp_list(bc), rlp_list(nc), rlp_list(cc)])
+
+
+def build_bacp_input(account_change: bytes) -> bytes:
+    body = struct.pack("<Q", len(account_change)) + account_change
+    while len(body) % 8 != 0:
+        body += b"\x00"
+    return body
+
+
+def vec_bal_account_path():
+    cases = [
+        ("bacp_empty", bytes.fromhex("00112233445566778899aabbccddeeff00112233"), {}),
+        ("bacp_changes", bytes.fromhex("c0f6dc9e5836f54caadbf59cc69346c508e1992b"),
+         dict(storage_reads=[(0x200b).to_bytes(2, "big")],
+              balance_changes=[(1, 5), (2, 10 ** 10)],
+              nonce_changes=[(1, 1)])),
+        ("bacp_precompile", bytes.fromhex("0000000000000000000000000000000000000001"),
+         dict(balance_changes=[(1, 10 ** 10)])),
+    ]
+    return [dict(name=name,
+                 account_change=bal_account_change_rlp(addr, **kwargs),
+                 path=bytes_to_nibbles_py(k256(addr)))
+            for name, addr, kwargs in cases]
+
+
 # ---- withdrawal -> (path, wei delta) preprocessing (.2.2.1) ---------------
 def withdrawal_rlp(index: int, vindex: int, address: bytes, amount: int) -> bytes:
     """Shanghai+ withdrawal RLP: rlp([index, validator_index, address, amount])."""
@@ -679,6 +725,12 @@ if __name__ == "__main__":
             f.write(v["expected"].hex())
         print(f"{v['name']:12} field={v['field_index']} value={v['value']} "
               f"new_account={v['expected'].hex()}")
+    for v in vec_bal_account_path():
+        with open(f"{outdir}/{v['name']}.input", "wb") as f:
+            f.write(build_bacp_input(v["account_change"]))
+        with open(f"{outdir}/{v['name']}.path", "w") as f:
+            f.write(v["path"].hex())
+        print(f"{v['name']:12} path={v['path'].hex()[:16]}..")
     for v in vec_withdrawal_to_path_delta():
         body = struct.pack("<Q", len(v["wd"])) + v["wd"]
         while len(body) % 8 != 0:


### PR DESCRIPTION
## Summary
- add `bal_account_path` for BAL AccountChanges address -> state-trie path preprocessing
- register `zisk_bal_account_path`
- add Python reference vectors covering empty, balance/nonce-bearing, and precompile BAL entries

This stacks on #7770 and is a foundation PR for replaying BAL balance/nonce changes into the stateless state-root recompute.

Bead: evm-asm-fhsxz.2.4.2.6.6.

Verification:
- `lake build EvmAsm.Codegen.Programs.BalAccountPath`
- `python3 -m py_compile scripts/mpt_ref.py`
- `scripts/codegen-zisk-bal-account-path-check.sh`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`

Authored by @pirapira; implemented by Codex.