### PR TITLE
feat(eest): add BAL account post-field extractor

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -66,6 +66,7 @@ import EvmAsm.Codegen.Programs.MptEncode
 import EvmAsm.Codegen.Programs.SystemWrites
 import EvmAsm.Codegen.Programs.BalGasValid
 import EvmAsm.Codegen.Programs.BalAccountPath
+import EvmAsm.Codegen.Programs.BalAccountPostFields
 import EvmAsm.Codegen.Programs.StorageWrite
 import EvmAsm.Codegen.Programs.BlockAccessListHash
 import EvmAsm.Codegen.Programs.AccountApplyStorage
@@ -319,6 +320,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_system_write_descriptors" => some ziskSystemWriteDescriptorsProbeUnit
   | "zisk_bal_gas_valid"         => some ziskBalGasValidProbeUnit
   | "zisk_bal_account_path"      => some ziskBalAccountPathProbeUnit
+  | "zisk_bal_account_post_fields" => some ziskBalAccountPostFieldsProbeUnit
   | "zisk_storage_root_single_slot" => some ziskStorageRootSingleSlotProbeUnit
   | "zisk_account_set_storage_root" => some ziskAccountSetStorageRootProbeUnit
   | "zisk_block_access_list_hash" => some ziskBlockAccessListHashProbeUnit
@@ -1112,6 +1114,7 @@ def knownProgramNames : List String :=
    "zisk_system_write_descriptors",
    "zisk_bal_gas_valid",
    "zisk_bal_account_path",
+   "zisk_bal_account_post_fields",
    "zisk_storage_root_single_slot",
    "zisk_account_set_storage_root",
    "zisk_block_access_list_hash",

--- a/EvmAsm/Codegen/Programs/BalAccountPostFields.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountPostFields.lean
@@ -1,0 +1,168 @@
+/-
+  EvmAsm.Codegen.Programs.BalAccountPostFields
+
+  BAL AccountChanges post-value extraction for state-root replay.
+
+  AccountChanges RLP =
+    [address, storage_changes, storage_reads, balance_changes, nonce_changes, code_changes]
+
+  For state replay we need the final post-value for each account field. The BAL
+  lists are ordered by blockAccessIndex, so the final account balance/nonce is
+  the last entry in each corresponding change list. This helper extracts those
+  two optional integers as raw canonical big-endian byte strings.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.RlpRead
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+/-! ## bal_account_post_fields -- BAL AccountChanges -> optional post balance/nonce
+
+    a0 = AccountChanges RLP ptr   a1 = AccountChanges RLP length
+    a2 = out balance bytes ptr (capacity 32)
+    a3 = out balance length ptr (u64, UINT64_MAX means absent)
+    a4 = out nonce bytes ptr (capacity 32)
+    a5 = out nonce length ptr (u64, UINT64_MAX means absent)
+    a0 (output) = 0 ok / 1 parse fail or value length > 32.
+
+    For each nonempty change list, extracts the final item and then field 1 of
+    that item. A zero post-value is represented by length 0, distinct from the
+    absent sentinel. -/
+def balAccountPostFieldsFunction : String :=
+  "bal_account_post_fields:\n" ++
+  "  addi sp, sp, -80\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp)\n" ++
+  "  mv s0, a0                   # account-change ptr\n" ++
+  "  mv s1, a1                   # account-change len\n" ++
+  "  mv s2, a2                   # balance out ptr\n" ++
+  "  mv s3, a3                   # balance len ptr\n" ++
+  "  mv s4, a4                   # nonce out ptr\n" ++
+  "  mv s5, a5                   # nonce len ptr\n" ++
+  "  li t0, -1; sd t0, 0(s3); sd t0, 0(s5)\n" ++
+  "  # balance_changes is field 3.\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 3; la a3, bpf_list_off; la a4, bpf_list_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbpf_fail\n" ++
+  "  la t0, bpf_list_off; ld t0, 0(t0); add t0, s0, t0; la t1, bpf_list_ptr; sd t0, 0(t1)\n" ++
+  "  la t1, bpf_list_len; ld a1, 0(t1); mv a0, t0; la a2, bpf_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lbpf_fail\n" ++
+  "  la t0, bpf_count; ld t0, 0(t0); beqz t0, .Lbpf_nonce\n" ++
+  "  addi a2, t0, -1; la t1, bpf_list_ptr; ld a0, 0(t1); la t1, bpf_list_len; ld a1, 0(t1)\n" ++
+  "  la a3, bpf_item_off; la a4, bpf_item_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbpf_fail\n" ++
+  "  la t0, bpf_list_ptr; ld t0, 0(t0); la t1, bpf_item_off; ld t1, 0(t1); add t0, t0, t1\n" ++
+  "  la t1, bpf_item_len; ld t1, 0(t1)\n" ++
+  "  la t2, bpf_item_ptr; sd t0, 0(t2)\n" ++
+  "  mv a0, t0; mv a1, t1; li a2, 1; la a3, bpf_val_off; la a4, bpf_val_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbpf_fail\n" ++
+  "  la t2, bpf_val_len; ld t2, 0(t2); li t3, 32; bgtu t2, t3, .Lbpf_fail\n" ++
+  "  sd t2, 0(s3)\n" ++
+  "  la t0, bpf_item_ptr; ld t0, 0(t0)\n" ++
+  "  la t3, bpf_val_off; ld t3, 0(t3); add t0, t0, t3\n" ++
+  "  mv t4, s2\n" ++
+  ".Lbpf_bal_cp:\n" ++
+  "  beqz t2, .Lbpf_nonce\n" ++
+  "  lbu t5, 0(t0); sb t5, 0(t4)\n" ++
+  "  addi t0, t0, 1; addi t4, t4, 1; addi t2, t2, -1\n" ++
+  "  j .Lbpf_bal_cp\n" ++
+  ".Lbpf_nonce:\n" ++
+  "  # nonce_changes is field 4.\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 4; la a3, bpf_list_off; la a4, bpf_list_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbpf_fail\n" ++
+  "  la t0, bpf_list_off; ld t0, 0(t0); add t0, s0, t0; la t1, bpf_list_ptr; sd t0, 0(t1)\n" ++
+  "  la t1, bpf_list_len; ld a1, 0(t1); mv a0, t0; la a2, bpf_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lbpf_fail\n" ++
+  "  la t0, bpf_count; ld t0, 0(t0); beqz t0, .Lbpf_ok\n" ++
+  "  addi a2, t0, -1; la t1, bpf_list_ptr; ld a0, 0(t1); la t1, bpf_list_len; ld a1, 0(t1)\n" ++
+  "  la a3, bpf_item_off; la a4, bpf_item_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbpf_fail\n" ++
+  "  la t0, bpf_list_ptr; ld t0, 0(t0); la t1, bpf_item_off; ld t1, 0(t1); add t0, t0, t1\n" ++
+  "  la t1, bpf_item_len; ld t1, 0(t1)\n" ++
+  "  la t2, bpf_item_ptr; sd t0, 0(t2)\n" ++
+  "  mv a0, t0; mv a1, t1; li a2, 1; la a3, bpf_val_off; la a4, bpf_val_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbpf_fail\n" ++
+  "  la t2, bpf_val_len; ld t2, 0(t2); li t3, 32; bgtu t2, t3, .Lbpf_fail\n" ++
+  "  sd t2, 0(s5)\n" ++
+  "  la t0, bpf_item_ptr; ld t0, 0(t0)\n" ++
+  "  la t3, bpf_val_off; ld t3, 0(t3); add t0, t0, t3\n" ++
+  "  mv t4, s4\n" ++
+  ".Lbpf_nonce_cp:\n" ++
+  "  beqz t2, .Lbpf_ok\n" ++
+  "  lbu t5, 0(t0); sb t5, 0(t4)\n" ++
+  "  addi t0, t0, 1; addi t4, t4, 1; addi t2, t2, -1\n" ++
+  "  j .Lbpf_nonce_cp\n" ++
+  ".Lbpf_ok:\n" ++
+  "  li a0, 0; j .Lbpf_ret\n" ++
+  ".Lbpf_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lbpf_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp)\n" ++
+  "  addi sp, sp, 80\n" ++
+  "  ret"
+
+/-- `zisk_bal_account_post_fields`: probe BuildUnit.
+    Input layout (file maps to INPUT+8 at 0x40000000):
+      +8  AccountChanges RLP length (u64)
+      +16 AccountChanges RLP bytes
+    Output layout:
+      OUTPUT+0  : status
+      OUTPUT+8  : balance length (UINT64_MAX absent, 0 zero, otherwise byte len)
+      OUTPUT+16 : balance bytes (32-byte capacity, only first len significant)
+      OUTPUT+48 : nonce length (UINT64_MAX absent, 0 zero, otherwise byte len)
+      OUTPUT+56 : nonce bytes (32-byte capacity, only first len significant) -/
+def ziskBalAccountPostFieldsPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd zero, 0(t0); sd zero, 8(t0); sd zero, 16(t0); sd zero, 24(t0)\n" ++
+  "  sd zero, 32(t0); sd zero, 40(t0); sd zero, 48(t0); sd zero, 56(t0)\n" ++
+  "  sd zero, 64(t0); sd zero, 72(t0); sd zero, 80(t0)\n" ++
+  "  li t0, 0x40000000\n" ++
+  "  ld a1, 8(t0)                # account-change RLP length\n" ++
+  "  addi a0, t0, 16             # account-change RLP ptr\n" ++
+  "  li a2, 0xa0010010           # balance bytes at OUTPUT+16\n" ++
+  "  li a3, 0xa0010008           # balance length at OUTPUT+8\n" ++
+  "  li a4, 0xa0010038           # nonce bytes at OUTPUT+56\n" ++
+  "  li a5, 0xa0010030           # nonce length at OUTPUT+48\n" ++
+  "  jal ra, bal_account_post_fields\n" ++
+  "  li t0, 0xa0010000; sd a0, 0(t0)   # status at OUTPUT+0\n" ++
+  "  j .Lbpf_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  balAccountPostFieldsFunction ++ "\n" ++
+  ".Lbpf_pdone:"
+
+def ziskBalAccountPostFieldsDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "bpf_list_off:\n  .zero 8\n" ++
+  "bpf_list_len:\n  .zero 8\n" ++
+  "bpf_list_ptr:\n  .zero 8\n" ++
+  "bpf_count:\n  .zero 8\n" ++
+  "bpf_item_off:\n  .zero 8\n" ++
+  "bpf_item_len:\n  .zero 8\n" ++
+  "bpf_item_ptr:\n  .zero 8\n" ++
+  "bpf_val_off:\n  .zero 8\n" ++
+  "bpf_val_len:\n  .zero 8"
+
+def ziskBalAccountPostFieldsProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBalAccountPostFieldsPrologue
+  dataAsm     := ziskBalAccountPostFieldsDataSection
+}
+
+end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **487**
-- ziskemu round-trip scripts: **477** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **488**
+- ziskemu round-trip scripts: **478** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-bal-account-post-fields-check.sh
+++ b/scripts/codegen-zisk-bal-account-post-fields-check.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# codegen-zisk-bal-account-post-fields-check.sh -- verify bal_account_post_fields.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else echo "ziskemu not found" >&2; exit 1; fi
+fi
+
+VDIR="$REPO_ROOT/gen-out/mpt-set"
+echo "==> generate BAL post-field vectors"
+python3 - "$VDIR" <<'PYGEN'
+import os
+import struct
+import sys
+
+outdir = sys.argv[1]
+os.makedirs(outdir, exist_ok=True)
+
+
+def minimal_be(n: int) -> bytes:
+    if n == 0:
+        return b""
+    return n.to_bytes((n.bit_length() + 7) // 8, "big")
+
+
+def rlp_bytes(x: bytes) -> bytes:
+    if len(x) == 1 and x[0] < 0x80:
+        return x
+    if len(x) <= 55:
+        return bytes([0x80 + len(x)]) + x
+    l = minimal_be(len(x))
+    return bytes([0xb7 + len(l)]) + l + x
+
+
+def rlp_list(xs):
+    payload = b"".join(xs)
+    if len(payload) <= 55:
+        return bytes([0xc0 + len(payload)]) + payload
+    l = minimal_be(len(payload))
+    return bytes([0xf7 + len(l)]) + l + payload
+
+
+def rlp_int(n: int) -> bytes:
+    return rlp_bytes(minimal_be(n))
+
+
+def change_pair(index: int, value: bytes) -> bytes:
+    return rlp_list([rlp_int(index), value])
+
+
+def bal_account_change_rlp(address: bytes, balance_changes=None, nonce_changes=None):
+    balance_changes = balance_changes or []
+    nonce_changes = nonce_changes or []
+    bc = [change_pair(i, rlp_int(v)) for i, v in balance_changes]
+    nc = [change_pair(i, rlp_int(v)) for i, v in nonce_changes]
+    return rlp_list([rlp_bytes(address), rlp_list([]), rlp_list([]),
+                     rlp_list(bc), rlp_list(nc), rlp_list([])])
+
+
+def build_input(account_change: bytes) -> bytes:
+    body = struct.pack("<Q", len(account_change)) + account_change
+    while len(body) % 8 != 0:
+        body += b"\x00"
+    return body
+
+
+absent = (1 << 64) - 1
+cases = [
+    ("bpf_absent", bytes.fromhex("00112233445566778899aabbccddeeff00112233"), {}, absent, b"", absent, b""),
+    ("bpf_balance_nonce", bytes.fromhex("c0f6dc9e5836f54caadbf59cc69346c508e1992b"),
+     dict(balance_changes=[(1, 5), (2, 10 ** 10)], nonce_changes=[(1, 1)]),
+     len(minimal_be(10 ** 10)), minimal_be(10 ** 10), 1, b"\x01"),
+    ("bpf_nonce_only", bytes.fromhex("0000000000000000000000000000000000000001"),
+     dict(nonce_changes=[(7, 0), (9, 2)]), absent, b"", 1, b"\x02"),
+    ("bpf_zero_balance", bytes.fromhex("0000000000000000000000000000000000000002"),
+     dict(balance_changes=[(1, 0)]), 0, b"", absent, b""),
+]
+
+for name, addr, kwargs, bal_len, bal, nonce_len, nonce in cases:
+    account_change = bal_account_change_rlp(addr, **kwargs)
+    with open(f"{outdir}/{name}.input", "wb") as f:
+        f.write(build_input(account_change))
+    bal_hex = bal.hex() if bal else "-"
+    nonce_hex = nonce.hex() if nonce else "-"
+    with open(f"{outdir}/{name}.expected", "w") as f:
+        f.write("\t".join([str(bal_len), bal_hex, str(nonce_len), nonce_hex]))
+    print(f"{name:18} balance_len={bal_len} nonce_len={nonce_len}")
+PYGEN
+
+echo "==> lake build codegen"
+lake build codegen >/dev/null
+
+echo "==> emit zisk_bal_account_post_fields probe ELF"
+lake exe codegen --program zisk_bal_account_post_fields --halt linux93 \
+  -o "$REPO_ROOT/gen-out/zisk_bal_account_post_fields"
+
+fail=0
+for name in bpf_absent bpf_balance_nonce bpf_nonce_only bpf_zero_balance; do
+  out="$VDIR/$name.output"
+  "$ZISKEMU" -e "$REPO_ROOT/gen-out/zisk_bal_account_post_fields.elf" \
+    -i "$VDIR/$name.input" -o "$out" -n 2000000 >/dev/null 2>&1 </dev/null \
+    || { echo "  ERROR  $name"; fail=1; continue; }
+  status="$(od -An -tu8 -j 0 -N 8 "$out" | tr -d ' \n')"
+  bal_len="$(od -An -tu8 -j 8 -N 8 "$out" | tr -d ' \n')"
+  nonce_len="$(od -An -tu8 -j 48 -N 8 "$out" | tr -d ' \n')"
+  IFS=$'\t' read -r exp_bal_len exp_bal exp_nonce_len exp_nonce < "$VDIR/$name.expected" || true
+  [[ "$exp_bal" == "-" ]] && exp_bal=""
+  [[ "$exp_nonce" == "-" ]] && exp_nonce=""
+  bal=""
+  if [[ "$bal_len" != "18446744073709551615" && "$bal_len" != "0" ]]; then
+    bal="$(xxd -p -s 16 -l "$bal_len" "$out" | tr -d '\n')"
+  fi
+  nonce=""
+  if [[ "$nonce_len" != "18446744073709551615" && "$nonce_len" != "0" ]]; then
+    nonce="$(xxd -p -s 56 -l "$nonce_len" "$out" | tr -d '\n')"
+  fi
+  if [[ "$status" == "0" && "$bal_len" == "$exp_bal_len" && "$bal" == "$exp_bal" && "$nonce_len" == "$exp_nonce_len" && "$nonce" == "$exp_nonce" ]]; then
+    echo "  PASS   $name  bal_len=$bal_len nonce_len=$nonce_len"
+  else
+    echo "  FAIL   $name status=$status"
+    echo "    expected: bal_len=$exp_bal_len bal=$exp_bal nonce_len=$exp_nonce_len nonce=$exp_nonce"
+    echo "    actual:   bal_len=$bal_len bal=$bal nonce_len=$nonce_len nonce=$nonce"
+    fail=1
+  fi
+done
+[[ "$fail" -eq 0 ]] && echo "==> PASS: bal_account_post_fields matches reference" \
+  || { echo "==> FAIL"; exit 1; }


### PR DESCRIPTION
## Summary
- add bal_account_post_fields / zisk_bal_account_post_fields to extract final BAL balance and nonce post values from AccountChanges
- encode absent fields as UINT64_MAX and zero-valued fields as length 0 for account-leaf replay
- add a focused ziskemu checker with local BAL vectors for absent, balance+nonce, nonce-only, and zero-balance cases

## Verification
- lake build EvmAsm.Codegen.Programs.BalAccountPostFields
- scripts/codegen-zisk-bal-account-post-fields-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build

Authored by @pirapira; implemented by Codex.