### PR TITLE
feat(eest): apply BAL account post fields

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -67,6 +67,7 @@ import EvmAsm.Codegen.Programs.SystemWrites
 import EvmAsm.Codegen.Programs.BalGasValid
 import EvmAsm.Codegen.Programs.BalAccountPath
 import EvmAsm.Codegen.Programs.BalAccountPostFields
+import EvmAsm.Codegen.Programs.BalAccountApplyPostFields
 import EvmAsm.Codegen.Programs.StorageWrite
 import EvmAsm.Codegen.Programs.BlockAccessListHash
 import EvmAsm.Codegen.Programs.AccountApplyStorage
@@ -321,6 +322,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_bal_gas_valid"         => some ziskBalGasValidProbeUnit
   | "zisk_bal_account_path"      => some ziskBalAccountPathProbeUnit
   | "zisk_bal_account_post_fields" => some ziskBalAccountPostFieldsProbeUnit
+  | "zisk_bal_account_apply_post_fields" => some ziskBalAccountApplyPostFieldsProbeUnit
   | "zisk_storage_root_single_slot" => some ziskStorageRootSingleSlotProbeUnit
   | "zisk_account_set_storage_root" => some ziskAccountSetStorageRootProbeUnit
   | "zisk_block_access_list_hash" => some ziskBlockAccessListHashProbeUnit
@@ -1115,6 +1117,7 @@ def knownProgramNames : List String :=
    "zisk_bal_gas_valid",
    "zisk_bal_account_path",
    "zisk_bal_account_post_fields",
+   "zisk_bal_account_apply_post_fields",
    "zisk_storage_root_single_slot",
    "zisk_account_set_storage_root",
    "zisk_block_access_list_hash",

--- a/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
@@ -1,0 +1,134 @@
+/-
+  EvmAsm.Codegen.Programs.BalAccountApplyPostFields
+
+  Compose BAL AccountChanges post-value extraction with account RLP rewriting.
+
+  This is the account-value half of BAL replay for post-state-root recompute:
+  given the pre-state account RLP and one BAL AccountChanges item, apply the
+  final nonce and/or balance post-values reported by the BAL entry. Storage and
+  code changes are handled by separate trie/account-root machinery.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.AccountBalance
+import EvmAsm.Codegen.Programs.BalAccountPostFields
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+/-! ## bal_account_apply_post_fields -- account RLP + BAL item -> post account RLP
+
+    a0 = account RLP ptr        a1 = account RLP length
+    a2 = AccountChanges ptr     a3 = AccountChanges length
+    a4 = output buffer ptr      a5 = u64 out length ptr
+    a0 (output) = 0 ok / 1 parse fail or value length > 32.
+
+    A missing BAL nonce/balance change list leaves that account field unchanged.
+    A zero post-value is represented by length 0 from `bal_account_post_fields`
+    and is spliced as the canonical RLP integer zero. -/
+def balAccountApplyPostFieldsFunction : String :=
+  "bal_account_apply_post_fields:\n" ++
+  "  addi sp, sp, -96\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  mv s0, a0                   # original account ptr\n" ++
+  "  mv s1, a1                   # original account len\n" ++
+  "  mv s2, a2                   # AccountChanges ptr\n" ++
+  "  mv s3, a3                   # AccountChanges len\n" ++
+  "  mv s4, a4                   # out ptr\n" ++
+  "  mv s5, a5                   # out len ptr\n" ++
+  "  mv s6, s0                   # current account ptr\n" ++
+  "  mv s7, s1                   # current account len\n" ++
+  "  mv a0, s2; mv a1, s3\n" ++
+  "  la a2, baap_bal; la a3, baap_bal_len; la a4, baap_nonce; la a5, baap_nonce_len\n" ++
+  "  jal ra, bal_account_post_fields\n" ++
+  "  bnez a0, .Lbaap_fail\n" ++
+  "  # Apply nonce first if present.\n" ++
+  "  la t0, baap_nonce_len; ld t0, 0(t0); li t1, -1; beq t0, t1, .Lbaap_balance\n" ++
+  "  mv a0, s6; mv a1, s7; li a2, 0\n" ++
+  "  la a3, baap_nonce; mv a4, t0; la a5, baap_tmp; la a6, baap_tmp_len\n" ++
+  "  jal ra, account_set_uint_field\n" ++
+  "  bnez a0, .Lbaap_fail\n" ++
+  "  la s6, baap_tmp; la t0, baap_tmp_len; ld s7, 0(t0)\n" ++
+  ".Lbaap_balance:\n" ++
+  "  # Apply balance if present; otherwise copy the current account to the final output.\n" ++
+  "  la t0, baap_bal_len; ld t0, 0(t0); li t1, -1; beq t0, t1, .Lbaap_copy_current\n" ++
+  "  mv a0, s6; mv a1, s7; li a2, 1\n" ++
+  "  la a3, baap_bal; mv a4, t0; mv a5, s4; mv a6, s5\n" ++
+  "  jal ra, account_set_uint_field\n" ++
+  "  j .Lbaap_ret\n" ++
+  ".Lbaap_copy_current:\n" ++
+  "  mv a0, s4; mv a1, s6; mv a2, s7\n" ++
+  "  jal ra, mset_memcpy\n" ++
+  "  sd s7, 0(s5)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbaap_ret\n" ++
+  ".Lbaap_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lbaap_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  addi sp, sp, 96\n" ++
+  "  ret"
+
+/-- `zisk_bal_account_apply_post_fields`: probe BuildUnit.
+    Input layout (file maps to INPUT+8 at 0x40000000):
+      +8  account RLP length (u64)
+      +16 AccountChanges RLP length (u64)
+      +24 account RLP bytes, padded to 8 bytes
+      then AccountChanges RLP bytes
+    Output layout:
+      OUTPUT+0   : new account RLP length
+      OUTPUT+8   : new account RLP bytes
+      OUTPUT+248 : status -/
+def ziskBalAccountApplyPostFieldsPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t0, 0x40000000\n" ++
+  "  ld a1, 8(t0)                # account_len\n" ++
+  "  ld a3, 16(t0)               # AccountChanges len\n" ++
+  "  addi a0, t0, 24             # account ptr\n" ++
+  "  add a2, a0, a1              # AccountChanges ptr after padded account\n" ++
+  "  addi a2, a2, 7; andi a2, a2, -8\n" ++
+  "  li a4, 0xa0010008           # out account bytes at OUTPUT+8\n" ++
+  "  li a5, 0xa0010000           # out account length at OUTPUT+0\n" ++
+  "  jal ra, bal_account_apply_post_fields\n" ++
+  "  li t0, 0xa00100f8; sd a0, 0(t0)   # status at OUTPUT+248\n" ++
+  "  j .Lbaap_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  rlpEncodeUintBeFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  rlpItemSizeFunction ++ "\n" ++
+  rlpItemSpanFunction ++ "\n" ++
+  msetMemcpyFunction ++ "\n" ++
+  mptSpliceSlotFunction ++ "\n" ++
+  accountSetUintFieldFunction ++ "\n" ++
+  balAccountPostFieldsFunction ++ "\n" ++
+  balAccountApplyPostFieldsFunction ++ "\n" ++
+  ".Lbaap_pdone:"
+
+def ziskBalAccountApplyPostFieldsDataSection : String :=
+  ziskAccountAddBalanceDataSection ++ "\n" ++
+  ziskBalAccountPostFieldsDataSection ++ "\n" ++
+  ".balign 8\n" ++
+  "baap_bal_len:\n  .zero 8\n" ++
+  "baap_nonce_len:\n  .zero 8\n" ++
+  "baap_tmp_len:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "baap_bal:\n  .zero 32\n" ++
+  "baap_nonce:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "baap_tmp:\n  .zero 512\n" ++
+  "baap_out_pad:\n  .zero 8"
+
+def ziskBalAccountApplyPostFieldsProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBalAccountApplyPostFieldsPrologue
+  dataAsm     := ziskBalAccountApplyPostFieldsDataSection
+}
+
+end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **488**
-- ziskemu round-trip scripts: **478** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **489**
+- ziskemu round-trip scripts: **479** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-bal-account-apply-post-fields-check.sh
+++ b/scripts/codegen-zisk-bal-account-apply-post-fields-check.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# codegen-zisk-bal-account-apply-post-fields-check.sh -- verify BAL account post-field account RLP rewriting.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else echo "ziskemu not found" >&2; exit 1; fi
+fi
+
+VDIR="$REPO_ROOT/gen-out/mpt-set"
+echo "==> generate BAL account apply-post-field vectors"
+python3 - "$VDIR" <<'PYGEN'
+import os
+import struct
+import sys
+
+outdir = sys.argv[1]
+os.makedirs(outdir, exist_ok=True)
+
+EMPTY_ROOT = bytes.fromhex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+EMPTY_CODE_HASH = bytes.fromhex("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+
+
+def minimal_be(n: int) -> bytes:
+    if n == 0:
+        return b""
+    return n.to_bytes((n.bit_length() + 7) // 8, "big")
+
+
+def rlp_bytes(x: bytes) -> bytes:
+    if len(x) == 1 and x[0] < 0x80:
+        return x
+    if len(x) <= 55:
+        return bytes([0x80 + len(x)]) + x
+    l = minimal_be(len(x))
+    return bytes([0xb7 + len(l)]) + l + x
+
+
+def rlp_list(xs):
+    payload = b"".join(xs)
+    if len(payload) <= 55:
+        return bytes([0xc0 + len(payload)]) + payload
+    l = minimal_be(len(payload))
+    return bytes([0xf7 + len(l)]) + l + payload
+
+
+def rlp_int(n: int) -> bytes:
+    return rlp_bytes(minimal_be(n))
+
+
+def account_rlp(nonce: int, balance: int) -> bytes:
+    return rlp_list([rlp_int(nonce), rlp_int(balance), rlp_bytes(EMPTY_ROOT), rlp_bytes(EMPTY_CODE_HASH)])
+
+
+def change_pair(index: int, value: bytes) -> bytes:
+    return rlp_list([rlp_int(index), value])
+
+
+def bal_account_change_rlp(address: bytes, balance_changes=None, nonce_changes=None):
+    balance_changes = balance_changes or []
+    nonce_changes = nonce_changes or []
+    bc = [change_pair(i, rlp_int(v)) for i, v in balance_changes]
+    nc = [change_pair(i, rlp_int(v)) for i, v in nonce_changes]
+    return rlp_list([rlp_bytes(address), rlp_list([]), rlp_list([]),
+                     rlp_list(bc), rlp_list(nc), rlp_list([])])
+
+
+def build_input(account: bytes, account_change: bytes) -> bytes:
+    body = struct.pack("<QQ", len(account), len(account_change)) + account
+    while len(body) % 8 != 0:
+        body += b"\x00"
+    body += account_change
+    while len(body) % 8 != 0:
+        body += b"\x00"
+    return body
+
+
+addr = bytes.fromhex("c0f6dc9e5836f54caadbf59cc69346c508e1992b")
+base = account_rlp(1, 5)
+cases = [
+    ("baap_noop", base, bal_account_change_rlp(addr), base),
+    ("baap_balance", base, bal_account_change_rlp(addr, balance_changes=[(1, 10 ** 10)]), account_rlp(1, 10 ** 10)),
+    ("baap_nonce", base, bal_account_change_rlp(addr, nonce_changes=[(1, 7)]), account_rlp(7, 5)),
+    ("baap_both", base, bal_account_change_rlp(addr, balance_changes=[(1, 9)], nonce_changes=[(1, 7)]), account_rlp(7, 9)),
+    ("baap_zero_balance", base, bal_account_change_rlp(addr, balance_changes=[(1, 0)]), account_rlp(1, 0)),
+]
+
+for name, account, account_change, expected in cases:
+    with open(f"{outdir}/{name}.input", "wb") as f:
+        f.write(build_input(account, account_change))
+    with open(f"{outdir}/{name}.expected", "w") as f:
+        f.write(expected.hex())
+    print(f"{name:18} account_len={len(account)} expected_len={len(expected)}")
+PYGEN
+
+echo "==> lake build codegen"
+lake build codegen >/dev/null
+
+echo "==> emit zisk_bal_account_apply_post_fields probe ELF"
+lake exe codegen --program zisk_bal_account_apply_post_fields --halt linux93 \
+  -o "$REPO_ROOT/gen-out/zisk_bal_account_apply_post_fields"
+
+fail=0
+for name in baap_noop baap_balance baap_nonce baap_both baap_zero_balance; do
+  out="$VDIR/$name.output"
+  "$ZISKEMU" -e "$REPO_ROOT/gen-out/zisk_bal_account_apply_post_fields.elf" \
+    -i "$VDIR/$name.input" -o "$out" -n 2000000 >/dev/null 2>&1 </dev/null \
+    || { echo "  ERROR  $name"; fail=1; continue; }
+  status="$(od -An -tu8 -j 248 -N 8 "$out" | tr -d ' \n')"
+  got_len="$(od -An -tu8 -j 0 -N 8 "$out" | tr -d ' \n')"
+  expected="$(cat "$VDIR/$name.expected")"
+  got="$(xxd -p -s 8 -l "$got_len" "$out" | tr -d '\n')"
+  exp_len=$(( ${#expected} / 2 ))
+  if [[ "$status" == "0" && "$got_len" == "$exp_len" && "$got" == "$expected" ]]; then
+    echo "  PASS   $name  len=$got_len"
+  else
+    echo "  FAIL   $name status=$status"
+    echo "    expected: len=$exp_len rlp=$expected"
+    echo "    actual:   len=$got_len rlp=$got"
+    fail=1
+  fi
+done
+[[ "$fail" -eq 0 ]] && echo "==> PASS: bal_account_apply_post_fields matches reference" \
+  || { echo "==> FAIL"; exit 1; }


### PR DESCRIPTION
## Summary
- add bal_account_apply_post_fields / zisk_bal_account_apply_post_fields to rewrite an account RLP from one BAL AccountChanges item
- compose bal_account_post_fields with account_set_uint_field so optional final nonce/balance post-values become account leaf values
- add focused ziskemu vectors for no-op, balance-only, nonce-only, both-fields, and zero-balance cases

Bead: evm-asm-fhsxz.2.4.2.6.6.

## Verification
- lake build EvmAsm.Codegen.Programs.BalAccountApplyPostFields
- scripts/codegen-zisk-bal-account-apply-post-fields-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build

Authored by @pirapira; implemented by Codex.