### PR TITLE
feat(eest): prepare BAL account change values

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -68,6 +68,7 @@ import EvmAsm.Codegen.Programs.BalGasValid
 import EvmAsm.Codegen.Programs.BalAccountPath
 import EvmAsm.Codegen.Programs.BalAccountPostFields
 import EvmAsm.Codegen.Programs.BalAccountApplyPostFields
+import EvmAsm.Codegen.Programs.BalAccountChangeValue
 import EvmAsm.Codegen.Programs.StorageWrite
 import EvmAsm.Codegen.Programs.BlockAccessListHash
 import EvmAsm.Codegen.Programs.AccountApplyStorage
@@ -323,6 +324,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_bal_account_path"      => some ziskBalAccountPathProbeUnit
   | "zisk_bal_account_post_fields" => some ziskBalAccountPostFieldsProbeUnit
   | "zisk_bal_account_apply_post_fields" => some ziskBalAccountApplyPostFieldsProbeUnit
+  | "zisk_bal_account_change_value" => some ziskBalAccountChangeValueProbeUnit
   | "zisk_storage_root_single_slot" => some ziskStorageRootSingleSlotProbeUnit
   | "zisk_account_set_storage_root" => some ziskAccountSetStorageRootProbeUnit
   | "zisk_block_access_list_hash" => some ziskBlockAccessListHashProbeUnit
@@ -1118,6 +1120,7 @@ def knownProgramNames : List String :=
    "zisk_bal_account_path",
    "zisk_bal_account_post_fields",
    "zisk_bal_account_apply_post_fields",
+   "zisk_bal_account_change_value",
    "zisk_storage_root_single_slot",
    "zisk_account_set_storage_root",
    "zisk_block_access_list_hash",

--- a/EvmAsm/Codegen/Programs/BalAccountChangeValue.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountChangeValue.lean
@@ -1,0 +1,113 @@
+/-
+  EvmAsm.Codegen.Programs.BalAccountChangeValue
+
+  Prepare one BAL account change for state-root replay: derive the world-state
+  trie path from the AccountChanges address and rewrite the account RLP with the
+  final nonce/balance post-values carried by the BAL item.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.BalAccountPath
+import EvmAsm.Codegen.Programs.BalAccountApplyPostFields
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+/-! ## bal_account_change_value -- pre account + BAL item -> path + post value
+
+    a0 = account RLP ptr        a1 = account RLP length
+    a2 = AccountChanges ptr     a3 = AccountChanges length
+    a4 = out path ptr (64 bytes, one nibble each)
+    a5 = out account RLP ptr    a6 = u64 out account RLP length ptr
+    a0 (output) = 0 ok / 1 path/apply failure.
+
+    The output `(path, account_value)` is the pair needed for a MODIFY change
+    descriptor in `mpt_state_root_ins`; an external caller still decides whether
+    the account is an insert or modify from the pre-state witness walk. -/
+def balAccountChangeValueFunction : String :=
+  "bal_account_change_value:\n" ++
+  "  addi sp, sp, -80\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0                   # account ptr\n" ++
+  "  mv s1, a1                   # account len\n" ++
+  "  mv s2, a2                   # AccountChanges ptr\n" ++
+  "  mv s3, a3                   # AccountChanges len\n" ++
+  "  mv s4, a4                   # out path ptr\n" ++
+  "  mv s5, a5                   # out account ptr\n" ++
+  "  mv s6, a6                   # out account len ptr\n" ++
+  "  mv a0, s2; mv a1, s3; mv a2, s4\n" ++
+  "  jal ra, bal_account_path\n" ++
+  "  bnez a0, .Lbacv_fail\n" ++
+  "  mv a0, s0; mv a1, s1; mv a2, s2; mv a3, s3; mv a4, s5; mv a5, s6\n" ++
+  "  jal ra, bal_account_apply_post_fields\n" ++
+  "  j .Lbacv_ret\n" ++
+  ".Lbacv_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lbacv_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 80\n" ++
+  "  ret"
+
+/-- `zisk_bal_account_change_value`: probe BuildUnit.
+    Input layout (file maps to INPUT+8 at 0x40000000):
+      +8  account RLP length (u64)
+      +16 AccountChanges RLP length (u64)
+      +24 account RLP bytes, padded to 8 bytes
+      then AccountChanges RLP bytes
+    Output layout:
+      OUTPUT+0   : status
+      OUTPUT+8   : path (64 nibble bytes)
+      OUTPUT+72  : post account RLP length
+      OUTPUT+80  : post account RLP bytes
+      OUTPUT+248 : duplicate status -/
+def ziskBalAccountChangeValuePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t0, 0x40000000\n" ++
+  "  ld a1, 8(t0)                # account_len\n" ++
+  "  ld a3, 16(t0)               # AccountChanges len\n" ++
+  "  addi a0, t0, 24             # account ptr\n" ++
+  "  add a2, a0, a1              # AccountChanges ptr after padded account\n" ++
+  "  addi a2, a2, 7; andi a2, a2, -8\n" ++
+  "  li a4, 0xa0010008           # path at OUTPUT+8\n" ++
+  "  li a5, 0xa0010050           # account value at OUTPUT+80\n" ++
+  "  li a6, 0xa0010048           # account value length at OUTPUT+72\n" ++
+  "  jal ra, bal_account_change_value\n" ++
+  "  li t0, 0xa0010000; sd a0, 0(t0)\n" ++
+  "  li t0, 0xa00100f8; sd a0, 0(t0)\n" ++
+  "  j .Lbacv_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  rlpEncodeUintBeFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  rlpItemSizeFunction ++ "\n" ++
+  rlpItemSpanFunction ++ "\n" ++
+  msetMemcpyFunction ++ "\n" ++
+  mptSpliceSlotFunction ++ "\n" ++
+  accountSetUintFieldFunction ++ "\n" ++
+  balAccountPathFunction ++ "\n" ++
+  balAccountPostFieldsFunction ++ "\n" ++
+  balAccountApplyPostFieldsFunction ++ "\n" ++
+  balAccountChangeValueFunction ++ "\n" ++
+  ".Lbacv_pdone:"
+
+def ziskBalAccountChangeValueDataSection : String :=
+  ziskBalAccountPathDataSection ++ "\n" ++
+  ziskBalAccountApplyPostFieldsDataSection ++ "\n" ++
+  ".balign 8\n" ++
+  "bacv_out_pad:\n  .zero 8"
+
+def ziskBalAccountChangeValueProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBalAccountChangeValuePrologue
+  dataAsm     := ziskBalAccountChangeValueDataSection
+}
+
+end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **489**
-- ziskemu round-trip scripts: **479** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **490**
+- ziskemu round-trip scripts: **480** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-bal-account-change-value-check.sh
+++ b/scripts/codegen-zisk-bal-account-change-value-check.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# codegen-zisk-bal-account-change-value-check.sh -- verify BAL account path + post account value preparation.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else echo "ziskemu not found" >&2; exit 1; fi
+fi
+
+VDIR="$REPO_ROOT/gen-out/mpt-set"
+echo "==> generate BAL account change path+value vectors"
+uv run --directory execution-specs --quiet python3 - "$VDIR" <<'PYGEN'
+import os
+import struct
+import sys
+from ethereum.crypto.hash import keccak256
+
+outdir = sys.argv[1]
+os.makedirs(outdir, exist_ok=True)
+
+EMPTY_ROOT = bytes.fromhex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+EMPTY_CODE_HASH = bytes.fromhex("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+
+
+def minimal_be(n: int) -> bytes:
+    if n == 0:
+        return b""
+    return n.to_bytes((n.bit_length() + 7) // 8, "big")
+
+
+def rlp_bytes(x: bytes) -> bytes:
+    if len(x) == 1 and x[0] < 0x80:
+        return x
+    if len(x) <= 55:
+        return bytes([0x80 + len(x)]) + x
+    l = minimal_be(len(x))
+    return bytes([0xb7 + len(l)]) + l + x
+
+
+def rlp_list(xs):
+    payload = b"".join(xs)
+    if len(payload) <= 55:
+        return bytes([0xc0 + len(payload)]) + payload
+    l = minimal_be(len(payload))
+    return bytes([0xf7 + len(l)]) + l + payload
+
+
+def rlp_int(n: int) -> bytes:
+    return rlp_bytes(minimal_be(n))
+
+
+def account_rlp(nonce: int, balance: int) -> bytes:
+    return rlp_list([rlp_int(nonce), rlp_int(balance), rlp_bytes(EMPTY_ROOT), rlp_bytes(EMPTY_CODE_HASH)])
+
+
+def change_pair(index: int, value: bytes) -> bytes:
+    return rlp_list([rlp_int(index), value])
+
+
+def bal_account_change_rlp(address: bytes, balance_changes=None, nonce_changes=None):
+    balance_changes = balance_changes or []
+    nonce_changes = nonce_changes or []
+    bc = [change_pair(i, rlp_int(v)) for i, v in balance_changes]
+    nc = [change_pair(i, rlp_int(v)) for i, v in nonce_changes]
+    return rlp_list([rlp_bytes(address), rlp_list([]), rlp_list([]),
+                     rlp_list(bc), rlp_list(nc), rlp_list([])])
+
+
+def account_path(address: bytes) -> bytes:
+    h = keccak256(address)
+    out = bytearray()
+    for b in h:
+        out.append(b >> 4)
+        out.append(b & 0x0f)
+    return bytes(out)
+
+
+def build_input(account: bytes, account_change: bytes) -> bytes:
+    body = struct.pack("<QQ", len(account), len(account_change)) + account
+    while len(body) % 8 != 0:
+        body += b"\x00"
+    body += account_change
+    while len(body) % 8 != 0:
+        body += b"\x00"
+    return body
+
+
+base = account_rlp(1, 5)
+cases = [
+    ("bacv_noop", bytes.fromhex("00112233445566778899aabbccddeeff00112233"), base, {}, base),
+    ("bacv_balance", bytes.fromhex("c0f6dc9e5836f54caadbf59cc69346c508e1992b"), base,
+     dict(balance_changes=[(1, 10 ** 10)]), account_rlp(1, 10 ** 10)),
+    ("bacv_nonce", bytes.fromhex("0000000000000000000000000000000000000001"), base,
+     dict(nonce_changes=[(1, 7)]), account_rlp(7, 5)),
+    ("bacv_both", bytes.fromhex("0000000000000000000000000000000000000002"), base,
+     dict(balance_changes=[(1, 9)], nonce_changes=[(1, 7)]), account_rlp(7, 9)),
+]
+
+for name, addr, account, kwargs, expected_value in cases:
+    account_change = bal_account_change_rlp(addr, **kwargs)
+    with open(f"{outdir}/{name}.input", "wb") as f:
+        f.write(build_input(account, account_change))
+    with open(f"{outdir}/{name}.path", "w") as f:
+        f.write(account_path(addr).hex())
+    with open(f"{outdir}/{name}.value", "w") as f:
+        f.write(expected_value.hex())
+    print(f"{name:14} path={account_path(addr).hex()[:16]}.. value_len={len(expected_value)}")
+PYGEN
+
+echo "==> lake build codegen"
+lake build codegen >/dev/null
+
+echo "==> emit zisk_bal_account_change_value probe ELF"
+lake exe codegen --program zisk_bal_account_change_value --halt linux93 \
+  -o "$REPO_ROOT/gen-out/zisk_bal_account_change_value"
+
+fail=0
+for name in bacv_noop bacv_balance bacv_nonce bacv_both; do
+  out="$VDIR/$name.output"
+  "$ZISKEMU" -e "$REPO_ROOT/gen-out/zisk_bal_account_change_value.elf" \
+    -i "$VDIR/$name.input" -o "$out" -n 2000000 >/dev/null 2>&1 </dev/null \
+    || { echo "  ERROR  $name"; fail=1; continue; }
+  status="$(od -An -tu8 -j 0 -N 8 "$out" | tr -d ' \n')"
+  actual_path="$(xxd -p -s 8 -l 64 "$out" | tr -d '\n')"
+  value_len="$(od -An -tu8 -j 72 -N 8 "$out" | tr -d ' \n')"
+  actual_value="$(xxd -p -s 80 -l "$value_len" "$out" | tr -d '\n')"
+  expected_path="$(cat "$VDIR/$name.path")"
+  expected_value="$(cat "$VDIR/$name.value")"
+  expected_len=$(( ${#expected_value} / 2 ))
+  if [[ "$status" == "0" && "$actual_path" == "$expected_path" && "$value_len" == "$expected_len" && "$actual_value" == "$expected_value" ]]; then
+    echo "  PASS   $name  value_len=$value_len"
+  else
+    echo "  FAIL   $name status=$status"
+    echo "    expected path=$expected_path len=$expected_len value=$expected_value"
+    echo "    actual   path=$actual_path len=$value_len value=$actual_value"
+    fail=1
+  fi
+done
+[[ "$fail" -eq 0 ]] && echo "==> PASS: bal_account_change_value matches reference" \
+  || { echo "==> FAIL"; exit 1; }


### PR DESCRIPTION
## Summary
- add bal_account_change_value / zisk_bal_account_change_value to derive the state-trie path for one BAL AccountChanges item and rewrite the account RLP with its nonce/balance post-values
- compose bal_account_path with bal_account_apply_post_fields so BAL replay can produce the path/value pair for mpt_state_root_ins descriptors
- add focused ziskemu vectors checking both Keccak-derived paths and post account RLP values

Bead: evm-asm-fhsxz.2.4.2.6.6.

## Verification
- lake build EvmAsm.Codegen.Programs.BalAccountChangeValue
- scripts/codegen-zisk-bal-account-change-value-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build

Authored by @pirapira; implemented by Codex.