### PR TITLE
feat(eest): package BAL account descriptors

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -69,6 +69,7 @@ import EvmAsm.Codegen.Programs.BalAccountPath
 import EvmAsm.Codegen.Programs.BalAccountPostFields
 import EvmAsm.Codegen.Programs.BalAccountApplyPostFields
 import EvmAsm.Codegen.Programs.BalAccountChangeValue
+import EvmAsm.Codegen.Programs.BalAccountChangeDescriptor
 import EvmAsm.Codegen.Programs.StorageWrite
 import EvmAsm.Codegen.Programs.BlockAccessListHash
 import EvmAsm.Codegen.Programs.AccountApplyStorage
@@ -325,6 +326,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_bal_account_post_fields" => some ziskBalAccountPostFieldsProbeUnit
   | "zisk_bal_account_apply_post_fields" => some ziskBalAccountApplyPostFieldsProbeUnit
   | "zisk_bal_account_change_value" => some ziskBalAccountChangeValueProbeUnit
+  | "zisk_bal_account_change_descriptor" => some ziskBalAccountChangeDescriptorProbeUnit
   | "zisk_storage_root_single_slot" => some ziskStorageRootSingleSlotProbeUnit
   | "zisk_account_set_storage_root" => some ziskAccountSetStorageRootProbeUnit
   | "zisk_block_access_list_hash" => some ziskBlockAccessListHashProbeUnit
@@ -1121,6 +1123,7 @@ def knownProgramNames : List String :=
    "zisk_bal_account_post_fields",
    "zisk_bal_account_apply_post_fields",
    "zisk_bal_account_change_value",
+   "zisk_bal_account_change_descriptor",
    "zisk_storage_root_single_slot",
    "zisk_account_set_storage_root",
    "zisk_block_access_list_hash",

--- a/EvmAsm/Codegen/Programs/BalAccountChangeDescriptor.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountChangeDescriptor.lean
@@ -1,0 +1,118 @@
+/-
+  EvmAsm.Codegen.Programs.BalAccountChangeDescriptor
+
+  Package one BAL account replay item as an `mpt_state_root_ins` change
+  descriptor: state-trie path, post account value, value length, and the caller
+  supplied insert/modify flag.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.BalAccountChangeValue
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+/-! ## bal_account_change_descriptor -- pre account + BAL item -> MPT descriptor
+
+    a0 = account RLP ptr        a1 = account RLP length
+    a2 = AccountChanges ptr     a3 = AccountChanges length
+    a4 = is_insert flag         a5 = descriptor out ptr (40 bytes)
+    a6 = path out ptr (64 bytes) a7 = account value out ptr
+    baacd_value_len receives the post account value length.
+    a0 (output) = 0 ok / 1 failure.
+
+    Descriptor layout matches `mpt_state_root_ins`:
+      +0 path_ptr | +8 path_len | +16 value_ptr | +24 value_len | +32 is_insert. -/
+def balAccountChangeDescriptorFunction : String :=
+  "bal_account_change_descriptor:\n" ++
+  "  addi sp, sp, -96\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  mv s0, a4                   # is_insert\n" ++
+  "  mv s1, a5                   # descriptor out\n" ++
+  "  mv s2, a6                   # path out\n" ++
+  "  mv s3, a7                   # value out\n" ++
+  "  mv s4, a0                   # account ptr\n" ++
+  "  mv s5, a1                   # account len\n" ++
+  "  mv s6, a2                   # AccountChanges ptr\n" ++
+  "  mv s7, a3                   # AccountChanges len\n" ++
+  "  mv a0, s4; mv a1, s5; mv a2, s6; mv a3, s7\n" ++
+  "  mv a4, s2; mv a5, s3; la a6, baacd_value_len\n" ++
+  "  jal ra, bal_account_change_value\n" ++
+  "  bnez a0, .Lbaacd_ret\n" ++
+  "  sd s2, 0(s1)\n" ++
+  "  li t0, 64; sd t0, 8(s1)\n" ++
+  "  sd s3, 16(s1)\n" ++
+  "  la t0, baacd_value_len; ld t0, 0(t0); sd t0, 24(s1)\n" ++
+  "  sd s0, 32(s1)\n" ++
+  "  li a0, 0\n" ++
+  ".Lbaacd_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  addi sp, sp, 96\n" ++
+  "  ret"
+
+/-- `zisk_bal_account_change_descriptor`: probe BuildUnit.
+    Input layout (file maps to INPUT+8 at 0x40000000):
+      +8  account RLP length (u64)
+      +16 AccountChanges RLP length (u64)
+      +24 is_insert flag (u64)
+      +32 account RLP bytes, padded to 8 bytes
+      then AccountChanges RLP bytes
+    Output layout:
+      OUTPUT+0   : status
+      OUTPUT+8   : descriptor (40 bytes)
+      OUTPUT+48  : path bytes (64 bytes)
+      OUTPUT+112 : post account RLP bytes
+      OUTPUT+248 : duplicate status -/
+def ziskBalAccountChangeDescriptorPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t0, 0x40000000\n" ++
+  "  ld a1, 8(t0)                # account_len\n" ++
+  "  ld a3, 16(t0)               # AccountChanges len\n" ++
+  "  ld a4, 24(t0)               # is_insert\n" ++
+  "  addi a0, t0, 32             # account ptr\n" ++
+  "  add a2, a0, a1              # AccountChanges ptr after padded account\n" ++
+  "  addi a2, a2, 7; andi a2, a2, -8\n" ++
+  "  li a5, 0xa0010008           # descriptor at OUTPUT+8\n" ++
+  "  li a6, 0xa0010030           # path at OUTPUT+48\n" ++
+  "  li a7, 0xa0010070           # value at OUTPUT+112\n" ++
+  "  jal ra, bal_account_change_descriptor\n" ++
+  "  li t0, 0xa0010000; sd a0, 0(t0)\n" ++
+  "  li t0, 0xa00100f8; sd a0, 0(t0)\n" ++
+  "  j .Lbaacd_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  rlpEncodeUintBeFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  rlpItemSizeFunction ++ "\n" ++
+  rlpItemSpanFunction ++ "\n" ++
+  msetMemcpyFunction ++ "\n" ++
+  mptSpliceSlotFunction ++ "\n" ++
+  accountSetUintFieldFunction ++ "\n" ++
+  balAccountPathFunction ++ "\n" ++
+  balAccountPostFieldsFunction ++ "\n" ++
+  balAccountApplyPostFieldsFunction ++ "\n" ++
+  balAccountChangeValueFunction ++ "\n" ++
+  balAccountChangeDescriptorFunction ++ "\n" ++
+  ".Lbaacd_pdone:"
+
+def ziskBalAccountChangeDescriptorDataSection : String :=
+  ziskBalAccountChangeValueDataSection ++ "\n" ++
+  ".balign 8\n" ++
+  "baacd_value_len:\n  .zero 8\n" ++
+  "baacd_pad:\n  .zero 8"
+
+def ziskBalAccountChangeDescriptorProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBalAccountChangeDescriptorPrologue
+  dataAsm     := ziskBalAccountChangeDescriptorDataSection
+}
+
+end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **490**
-- ziskemu round-trip scripts: **480** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **491**
+- ziskemu round-trip scripts: **481** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-bal-account-change-descriptor-check.sh
+++ b/scripts/codegen-zisk-bal-account-change-descriptor-check.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# codegen-zisk-bal-account-change-descriptor-check.sh -- verify BAL account replay descriptor packaging.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else echo "ziskemu not found" >&2; exit 1; fi
+fi
+
+VDIR="$REPO_ROOT/gen-out/mpt-set"
+echo "==> generate BAL account descriptor vectors"
+uv run --directory execution-specs --quiet python3 - "$VDIR" <<'PYGEN'
+import os
+import struct
+import sys
+from ethereum.crypto.hash import keccak256
+
+outdir = sys.argv[1]
+os.makedirs(outdir, exist_ok=True)
+
+EMPTY_ROOT = bytes.fromhex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+EMPTY_CODE_HASH = bytes.fromhex("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+
+
+def minimal_be(n: int) -> bytes:
+    if n == 0:
+        return b""
+    return n.to_bytes((n.bit_length() + 7) // 8, "big")
+
+
+def rlp_bytes(x: bytes) -> bytes:
+    if len(x) == 1 and x[0] < 0x80:
+        return x
+    if len(x) <= 55:
+        return bytes([0x80 + len(x)]) + x
+    l = minimal_be(len(x))
+    return bytes([0xb7 + len(l)]) + l + x
+
+
+def rlp_list(xs):
+    payload = b"".join(xs)
+    if len(payload) <= 55:
+        return bytes([0xc0 + len(payload)]) + payload
+    l = minimal_be(len(payload))
+    return bytes([0xf7 + len(l)]) + l + payload
+
+
+def rlp_int(n: int) -> bytes:
+    return rlp_bytes(minimal_be(n))
+
+
+def account_rlp(nonce: int, balance: int) -> bytes:
+    return rlp_list([rlp_int(nonce), rlp_int(balance), rlp_bytes(EMPTY_ROOT), rlp_bytes(EMPTY_CODE_HASH)])
+
+
+def change_pair(index: int, value: bytes) -> bytes:
+    return rlp_list([rlp_int(index), value])
+
+
+def bal_account_change_rlp(address: bytes, balance_changes=None, nonce_changes=None):
+    balance_changes = balance_changes or []
+    nonce_changes = nonce_changes or []
+    bc = [change_pair(i, rlp_int(v)) for i, v in balance_changes]
+    nc = [change_pair(i, rlp_int(v)) for i, v in nonce_changes]
+    return rlp_list([rlp_bytes(address), rlp_list([]), rlp_list([]),
+                     rlp_list(bc), rlp_list(nc), rlp_list([])])
+
+
+def account_path(address: bytes) -> bytes:
+    h = keccak256(address)
+    out = bytearray()
+    for b in h:
+        out.append(b >> 4)
+        out.append(b & 0x0f)
+    return bytes(out)
+
+
+def build_input(account: bytes, account_change: bytes, is_insert: int) -> bytes:
+    body = struct.pack("<QQQ", len(account), len(account_change), is_insert) + account
+    while len(body) % 8 != 0:
+        body += b"\x00"
+    body += account_change
+    while len(body) % 8 != 0:
+        body += b"\x00"
+    return body
+
+
+base = account_rlp(1, 5)
+cases = [
+    ("baacd_modify", bytes.fromhex("c0f6dc9e5836f54caadbf59cc69346c508e1992b"), base,
+     dict(balance_changes=[(1, 10 ** 10)]), account_rlp(1, 10 ** 10), 0),
+    ("baacd_insert", bytes.fromhex("0000000000000000000000000000000000000002"), base,
+     dict(balance_changes=[(1, 9)], nonce_changes=[(1, 7)]), account_rlp(7, 9), 1),
+]
+
+for name, addr, account, kwargs, expected_value, is_insert in cases:
+    account_change = bal_account_change_rlp(addr, **kwargs)
+    with open(f"{outdir}/{name}.input", "wb") as f:
+        f.write(build_input(account, account_change, is_insert))
+    with open(f"{outdir}/{name}.path", "w") as f:
+        f.write(account_path(addr).hex())
+    with open(f"{outdir}/{name}.value", "w") as f:
+        f.write(expected_value.hex())
+    with open(f"{outdir}/{name}.flag", "w") as f:
+        f.write(str(is_insert))
+    print(f"{name:14} path={account_path(addr).hex()[:16]}.. value_len={len(expected_value)} is_insert={is_insert}")
+PYGEN
+
+echo "==> lake build codegen"
+lake build codegen >/dev/null
+
+echo "==> emit zisk_bal_account_change_descriptor probe ELF"
+lake exe codegen --program zisk_bal_account_change_descriptor --halt linux93 \
+  -o "$REPO_ROOT/gen-out/zisk_bal_account_change_descriptor"
+
+fail=0
+for name in baacd_modify baacd_insert; do
+  out="$VDIR/$name.output"
+  "$ZISKEMU" -e "$REPO_ROOT/gen-out/zisk_bal_account_change_descriptor.elf" \
+    -i "$VDIR/$name.input" -o "$out" -n 2000000 >/dev/null 2>&1 </dev/null \
+    || { echo "  ERROR  $name"; fail=1; continue; }
+  status="$(od -An -tu8 -j 0 -N 8 "$out" | tr -d ' \n')"
+  path_ptr="$(od -An -tu8 -j 8 -N 8 "$out" | tr -d ' \n')"
+  path_len="$(od -An -tu8 -j 16 -N 8 "$out" | tr -d ' \n')"
+  value_ptr="$(od -An -tu8 -j 24 -N 8 "$out" | tr -d ' \n')"
+  value_len="$(od -An -tu8 -j 32 -N 8 "$out" | tr -d ' \n')"
+  is_insert="$(od -An -tu8 -j 40 -N 8 "$out" | tr -d ' \n')"
+  actual_path="$(xxd -p -s 48 -l 64 "$out" | tr -d '\n')"
+  actual_value="$(xxd -p -s 112 -l "$value_len" "$out" | tr -d '\n')"
+  expected_path="$(cat "$VDIR/$name.path")"
+  expected_value="$(cat "$VDIR/$name.value")"
+  expected_flag="$(cat "$VDIR/$name.flag")"
+  expected_len=$(( ${#expected_value} / 2 ))
+  if [[ "$status" == "0" && "$path_ptr" == "2684420144" && "$path_len" == "64" && "$value_ptr" == "2684420208" && "$value_len" == "$expected_len" && "$is_insert" == "$expected_flag" && "$actual_path" == "$expected_path" && "$actual_value" == "$expected_value" ]]; then
+    echo "  PASS   $name  value_len=$value_len is_insert=$is_insert"
+  else
+    echo "  FAIL   $name status=$status"
+    echo "    desc path_ptr=$path_ptr path_len=$path_len value_ptr=$value_ptr value_len=$value_len is_insert=$is_insert"
+    echo "    expected path=$expected_path len=$expected_len flag=$expected_flag value=$expected_value"
+    echo "    actual   path=$actual_path value=$actual_value"
+    fail=1
+  fi
+done
+[[ "$fail" -eq 0 ]] && echo "==> PASS: bal_account_change_descriptor matches reference" \
+  || { echo "==> FAIL"; exit 1; }


### PR DESCRIPTION
## Summary
- add bal_account_change_descriptor / zisk_bal_account_change_descriptor to package one BAL AccountChanges item as an mpt_state_root_ins descriptor
- compose bal_account_change_value and store path/value pointers, lengths, and the caller-supplied insert/modify flag
- add focused ziskemu vectors for modify and insert descriptor cases

Stacked on #7774. Bead: evm-asm-fhsxz.2.4.2.6.6.

## Verification
- lake build EvmAsm.Codegen.Programs.BalAccountChangeDescriptor
- scripts/codegen-zisk-bal-account-change-descriptor-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build

Authored by @pirapira; implemented by Codex.