### PR TITLE
feat(eest): index BAL account descriptors

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -70,6 +70,7 @@ import EvmAsm.Codegen.Programs.BalAccountPostFields
 import EvmAsm.Codegen.Programs.BalAccountApplyPostFields
 import EvmAsm.Codegen.Programs.BalAccountChangeValue
 import EvmAsm.Codegen.Programs.BalAccountChangeDescriptor
+import EvmAsm.Codegen.Programs.BalAccountNthDescriptor
 import EvmAsm.Codegen.Programs.StorageWrite
 import EvmAsm.Codegen.Programs.BlockAccessListHash
 import EvmAsm.Codegen.Programs.AccountApplyStorage
@@ -327,6 +328,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_bal_account_apply_post_fields" => some ziskBalAccountApplyPostFieldsProbeUnit
   | "zisk_bal_account_change_value" => some ziskBalAccountChangeValueProbeUnit
   | "zisk_bal_account_change_descriptor" => some ziskBalAccountChangeDescriptorProbeUnit
+  | "zisk_bal_account_nth_descriptor" => some ziskBalAccountNthDescriptorProbeUnit
   | "zisk_storage_root_single_slot" => some ziskStorageRootSingleSlotProbeUnit
   | "zisk_account_set_storage_root" => some ziskAccountSetStorageRootProbeUnit
   | "zisk_block_access_list_hash" => some ziskBlockAccessListHashProbeUnit
@@ -1124,6 +1126,7 @@ def knownProgramNames : List String :=
    "zisk_bal_account_apply_post_fields",
    "zisk_bal_account_change_value",
    "zisk_bal_account_change_descriptor",
+   "zisk_bal_account_nth_descriptor",
    "zisk_storage_root_single_slot",
    "zisk_account_set_storage_root",
    "zisk_block_access_list_hash",

--- a/EvmAsm/Codegen/Programs/BalAccountNthDescriptor.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNthDescriptor.lean
@@ -1,0 +1,130 @@
+/-
+  EvmAsm.Codegen.Programs.BalAccountNthDescriptor
+
+  Adapter from a BAL AccountChanges list to one `mpt_state_root_ins` descriptor.
+  The caller supplies the pre-state account RLP for the selected account and the
+  insert/modify flag; this helper extracts the N-th BAL item and delegates to
+  `bal_account_change_descriptor`.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.BalAccountChangeDescriptor
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+/-! ## bal_account_nth_descriptor -- BAL list item -> MPT descriptor
+
+    a0 = BAL AccountChanges list ptr   a1 = BAL AccountChanges list length
+    a2 = index N                       a3 = account RLP ptr
+    a4 = account RLP length            a5 = is_insert flag
+    a6 = descriptor out ptr            a7 = path out ptr
+    baan_value_out is the account value output buffer.
+    a0 (output) = 0 ok / 1 failure.
+
+    This helper is intentionally per-item: the replay driver can decide account
+    existence and accumulation policy, then call this to build the descriptor for
+    the selected BAL account change. -/
+def balAccountNthDescriptorFunction : String :=
+  "bal_account_nth_descriptor:\n" ++
+  "  addi sp, sp, -112\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp); sd s8, 72(sp)\n" ++
+  "  mv s0, a0                   # BAL list ptr\n" ++
+  "  mv s1, a1                   # BAL list len\n" ++
+  "  mv s2, a3                   # account ptr\n" ++
+  "  mv s3, a4                   # account len\n" ++
+  "  mv s4, a5                   # is_insert\n" ++
+  "  mv s5, a6                   # descriptor out\n" ++
+  "  mv s6, a7                   # path out\n" ++
+  "  la s7, baan_value_out       # value out\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  la a3, baan_item_off; la a4, baan_item_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbaan_ret\n" ++
+  "  la t0, baan_item_off; ld t0, 0(t0); add s8, s0, t0\n" ++
+  "  la t0, baan_item_len; ld t0, 0(t0)\n" ++
+  "  mv a0, s2; mv a1, s3; mv a2, s8; mv a3, t0\n" ++
+  "  mv a4, s4; mv a5, s5; mv a6, s6; mv a7, s7\n" ++
+  "  jal ra, bal_account_change_descriptor\n" ++
+  ".Lbaan_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp); ld s8, 72(sp)\n" ++
+  "  addi sp, sp, 112\n" ++
+  "  ret"
+
+/-- `zisk_bal_account_nth_descriptor`: probe BuildUnit.
+    Input layout (file maps to INPUT+8 at 0x40000000):
+      +8  account RLP length (u64)
+      +16 BAL list length (u64)
+      +24 index N (u64)
+      +32 is_insert flag (u64)
+      +40 account RLP bytes, padded to 8 bytes
+      then BAL AccountChanges list bytes
+    Output layout:
+      OUTPUT+0   : status
+      OUTPUT+8   : descriptor (40 bytes)
+      OUTPUT+48  : path bytes (64 bytes)
+      OUTPUT+112 : post account RLP bytes
+      OUTPUT+248 : duplicate status -/
+def ziskBalAccountNthDescriptorPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t0, 0x40000000\n" ++
+  "  ld a4, 8(t0)                # account_len\n" ++
+  "  ld a1, 16(t0)               # BAL list len\n" ++
+  "  ld a2, 24(t0)               # index\n" ++
+  "  ld a5, 32(t0)               # is_insert\n" ++
+  "  addi a3, t0, 40             # account ptr\n" ++
+  "  add a0, a3, a4              # BAL list ptr after padded account\n" ++
+  "  addi a0, a0, 7; andi a0, a0, -8\n" ++
+  "  li a6, 0xa0010008           # descriptor at OUTPUT+8\n" ++
+  "  li a7, 0xa0010030           # path at OUTPUT+48\n" ++
+  "  jal ra, bal_account_nth_descriptor\n" ++
+  "  mv t6, a0\n" ++
+  "  bnez t6, .Lbaan_store_status\n" ++
+  "  li t0, 0xa0010008; ld a1, 16(t0); ld a2, 24(t0)\n" ++
+  "  li a0, 0xa0010070; jal ra, mset_memcpy\n" ++
+  ".Lbaan_store_status:\n" ++
+  "  mv a0, t6\n" ++
+  "  li t0, 0xa0010000; sd a0, 0(t0)\n" ++
+  "  li t0, 0xa00100f8; sd a0, 0(t0)\n" ++
+  "  j .Lbaan_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  rlpEncodeUintBeFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  rlpItemSizeFunction ++ "\n" ++
+  rlpItemSpanFunction ++ "\n" ++
+  msetMemcpyFunction ++ "\n" ++
+  mptSpliceSlotFunction ++ "\n" ++
+  accountSetUintFieldFunction ++ "\n" ++
+  balAccountPathFunction ++ "\n" ++
+  balAccountPostFieldsFunction ++ "\n" ++
+  balAccountApplyPostFieldsFunction ++ "\n" ++
+  balAccountChangeValueFunction ++ "\n" ++
+  balAccountChangeDescriptorFunction ++ "\n" ++
+  balAccountNthDescriptorFunction ++ "\n" ++
+  ".Lbaan_pdone:"
+
+def ziskBalAccountNthDescriptorDataSection : String :=
+  ziskBalAccountChangeDescriptorDataSection ++ "\n" ++
+  ".balign 8\n" ++
+  "baan_item_off:\n  .zero 8\n" ++
+  "baan_item_len:\n  .zero 8\n" ++
+  ".balign 8\n" ++
+  "baan_value_out:\n  .zero 512\n" ++
+  "baan_pad:\n  .zero 8"
+
+def ziskBalAccountNthDescriptorProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBalAccountNthDescriptorPrologue
+  dataAsm     := ziskBalAccountNthDescriptorDataSection
+}
+
+end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **491**
-- ziskemu round-trip scripts: **481** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **492**
+- ziskemu round-trip scripts: **482** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-bal-account-nth-descriptor-check.sh
+++ b/scripts/codegen-zisk-bal-account-nth-descriptor-check.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# codegen-zisk-bal-account-nth-descriptor-check.sh -- verify descriptor packaging for an indexed BAL AccountChanges item.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else echo "ziskemu not found" >&2; exit 1; fi
+fi
+
+VDIR="$REPO_ROOT/gen-out/mpt-set"
+echo "==> generate BAL nth-account descriptor vectors"
+uv run --directory execution-specs --quiet python3 - "$VDIR" <<'PYGEN'
+import os
+import struct
+import sys
+from ethereum.crypto.hash import keccak256
+
+outdir = sys.argv[1]
+os.makedirs(outdir, exist_ok=True)
+
+EMPTY_ROOT = bytes.fromhex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+EMPTY_CODE_HASH = bytes.fromhex("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+
+
+def minimal_be(n: int) -> bytes:
+    if n == 0:
+        return b""
+    return n.to_bytes((n.bit_length() + 7) // 8, "big")
+
+
+def rlp_bytes(x: bytes) -> bytes:
+    if len(x) == 1 and x[0] < 0x80:
+        return x
+    if len(x) <= 55:
+        return bytes([0x80 + len(x)]) + x
+    l = minimal_be(len(x))
+    return bytes([0xb7 + len(l)]) + l + x
+
+
+def rlp_list(xs):
+    payload = b"".join(xs)
+    if len(payload) <= 55:
+        return bytes([0xc0 + len(payload)]) + payload
+    l = minimal_be(len(payload))
+    return bytes([0xf7 + len(l)]) + l + payload
+
+
+def rlp_int(n: int) -> bytes:
+    return rlp_bytes(minimal_be(n))
+
+
+def account_rlp(nonce: int, balance: int) -> bytes:
+    return rlp_list([rlp_int(nonce), rlp_int(balance), rlp_bytes(EMPTY_ROOT), rlp_bytes(EMPTY_CODE_HASH)])
+
+
+def change_pair(index: int, value: bytes) -> bytes:
+    return rlp_list([rlp_int(index), value])
+
+
+def account_change(address: bytes, balance_changes=None, nonce_changes=None) -> bytes:
+    balance_changes = balance_changes or []
+    nonce_changes = nonce_changes or []
+    bc = [change_pair(i, rlp_int(v)) for i, v in balance_changes]
+    nc = [change_pair(i, rlp_int(v)) for i, v in nonce_changes]
+    return rlp_list([rlp_bytes(address), rlp_list([]), rlp_list([]),
+                     rlp_list(bc), rlp_list(nc), rlp_list([])])
+
+
+def account_path(address: bytes) -> bytes:
+    out = bytearray()
+    for b in keccak256(address):
+        out.append(b >> 4)
+        out.append(b & 0x0f)
+    return bytes(out)
+
+
+def build_input(account: bytes, bal_list: bytes, idx: int, is_insert: int) -> bytes:
+    body = struct.pack("<QQQQ", len(account), len(bal_list), idx, is_insert) + account
+    while len(body) % 8 != 0:
+        body += b"\x00"
+    body += bal_list
+    while len(body) % 8 != 0:
+        body += b"\x00"
+    return body
+
+
+base = account_rlp(1, 5)
+addr0 = bytes.fromhex("00112233445566778899aabbccddeeff00112233")
+addr1 = bytes.fromhex("c0f6dc9e5836f54caadbf59cc69346c508e1992b")
+addr2 = bytes.fromhex("0000000000000000000000000000000000000002")
+changes = [
+    account_change(addr0),
+    account_change(addr1, balance_changes=[(1, 10 ** 10)]),
+    account_change(addr2, balance_changes=[(1, 9)], nonce_changes=[(1, 7)]),
+]
+bal_list = rlp_list(changes)
+cases = [
+    ("baan_idx1_modify", 1, 0, addr1, account_rlp(1, 10 ** 10)),
+    ("baan_idx2_insert", 2, 1, addr2, account_rlp(7, 9)),
+]
+
+for name, idx, is_insert, addr, expected_value in cases:
+    with open(f"{outdir}/{name}.input", "wb") as f:
+        f.write(build_input(base, bal_list, idx, is_insert))
+    with open(f"{outdir}/{name}.path", "w") as f:
+        f.write(account_path(addr).hex())
+    with open(f"{outdir}/{name}.value", "w") as f:
+        f.write(expected_value.hex())
+    with open(f"{outdir}/{name}.flag", "w") as f:
+        f.write(str(is_insert))
+    print(f"{name:16} idx={idx} path={account_path(addr).hex()[:16]}.. value_len={len(expected_value)} is_insert={is_insert}")
+PYGEN
+
+echo "==> lake build codegen"
+lake build codegen >/dev/null
+
+echo "==> emit zisk_bal_account_nth_descriptor probe ELF"
+lake exe codegen --program zisk_bal_account_nth_descriptor --halt linux93 \
+  -o "$REPO_ROOT/gen-out/zisk_bal_account_nth_descriptor"
+
+fail=0
+for name in baan_idx1_modify baan_idx2_insert; do
+  out="$VDIR/$name.output"
+  "$ZISKEMU" -e "$REPO_ROOT/gen-out/zisk_bal_account_nth_descriptor.elf" \
+    -i "$VDIR/$name.input" -o "$out" -n 2000000 >/dev/null 2>&1 </dev/null \
+    || { echo "  ERROR  $name"; fail=1; continue; }
+  status="$(od -An -tu8 -j 0 -N 8 "$out" | tr -d ' \n')"
+  path_ptr="$(od -An -tu8 -j 8 -N 8 "$out" | tr -d ' \n')"
+  path_len="$(od -An -tu8 -j 16 -N 8 "$out" | tr -d ' \n')"
+  value_ptr="$(od -An -tu8 -j 24 -N 8 "$out" | tr -d ' \n')"
+  value_len="$(od -An -tu8 -j 32 -N 8 "$out" | tr -d ' \n')"
+  is_insert="$(od -An -tu8 -j 40 -N 8 "$out" | tr -d ' \n')"
+  actual_path="$(xxd -p -s 48 -l 64 "$out" | tr -d '\n')"
+  actual_value="$(xxd -p -s 112 -l "$value_len" "$out" | tr -d '\n')"
+  expected_path="$(cat "$VDIR/$name.path")"
+  expected_value="$(cat "$VDIR/$name.value")"
+  expected_flag="$(cat "$VDIR/$name.flag")"
+  expected_len=$(( ${#expected_value} / 2 ))
+  if [[ "$status" == "0" && "$path_ptr" == "2684420144" && "$path_len" == "64" && "$value_ptr" != "0" && "$value_len" == "$expected_len" && "$is_insert" == "$expected_flag" && "$actual_path" == "$expected_path" && "$actual_value" == "$expected_value" ]]; then
+    echo "  PASS   $name  value_len=$value_len is_insert=$is_insert"
+  else
+    echo "  FAIL   $name status=$status"
+    echo "    desc path_ptr=$path_ptr path_len=$path_len value_ptr=$value_ptr value_len=$value_len is_insert=$is_insert"
+    echo "    expected path=$expected_path len=$expected_len flag=$expected_flag value=$expected_value"
+    echo "    actual   path=$actual_path value=$actual_value"
+    fail=1
+  fi
+done
+[[ "$fail" -eq 0 ]] && echo "==> PASS: bal_account_nth_descriptor matches reference" \
+  || { echo "==> FAIL"; exit 1; }


### PR DESCRIPTION
## Summary
- add bal_account_nth_descriptor / zisk_bal_account_nth_descriptor to extract the N-th AccountChanges item from a BAL list
- delegate to bal_account_change_descriptor to produce the mpt_state_root_ins descriptor for the selected account
- add focused ziskemu vectors for modify and insert cases selected by BAL list index

Stacked on #7775. Bead: evm-asm-fhsxz.2.4.2.6.6.

## Verification
- lake build EvmAsm.Codegen.Programs.BalAccountNthDescriptor
- scripts/codegen-zisk-bal-account-nth-descriptor-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build

Authored by @pirapira; implemented by Codex.