### PR TITLE
feat(eest): build BAL account descriptor arrays

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -71,6 +71,7 @@ import EvmAsm.Codegen.Programs.BalAccountApplyPostFields
 import EvmAsm.Codegen.Programs.BalAccountChangeValue
 import EvmAsm.Codegen.Programs.BalAccountChangeDescriptor
 import EvmAsm.Codegen.Programs.BalAccountNthDescriptor
+import EvmAsm.Codegen.Programs.BalAccountDescriptorArray
 import EvmAsm.Codegen.Programs.StorageWrite
 import EvmAsm.Codegen.Programs.BlockAccessListHash
 import EvmAsm.Codegen.Programs.AccountApplyStorage
@@ -329,6 +330,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_bal_account_change_value" => some ziskBalAccountChangeValueProbeUnit
   | "zisk_bal_account_change_descriptor" => some ziskBalAccountChangeDescriptorProbeUnit
   | "zisk_bal_account_nth_descriptor" => some ziskBalAccountNthDescriptorProbeUnit
+  | "zisk_bal_account_descriptor_array" => some ziskBalAccountDescriptorArrayProbeUnit
   | "zisk_storage_root_single_slot" => some ziskStorageRootSingleSlotProbeUnit
   | "zisk_account_set_storage_root" => some ziskAccountSetStorageRootProbeUnit
   | "zisk_block_access_list_hash" => some ziskBlockAccessListHashProbeUnit
@@ -1127,6 +1129,7 @@ def knownProgramNames : List String :=
    "zisk_bal_account_change_value",
    "zisk_bal_account_change_descriptor",
    "zisk_bal_account_nth_descriptor",
+   "zisk_bal_account_descriptor_array",
    "zisk_storage_root_single_slot",
    "zisk_account_set_storage_root",
    "zisk_block_access_list_hash",

--- a/EvmAsm/Codegen/Programs/BalAccountDescriptorArray.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountDescriptorArray.lean
@@ -1,0 +1,150 @@
+/-
+  EvmAsm.Codegen.Programs.BalAccountDescriptorArray
+
+  Build an `mpt_state_root_ins` descriptor array from a BAL AccountChanges list
+  and caller-supplied pre-account records. This is the list-level adapter above
+  the per-item BAL descriptor helpers.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.BalAccountChangeDescriptor
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+/-! ## bal_account_descriptor_array -- BAL list -> descriptor array
+
+    a0 = BAL AccountChanges list ptr   a1 = BAL AccountChanges list length
+    a2 = account records ptr           a3 = n records/items
+    a4 = descriptors out ptr           a5 = path arena out ptr
+    a6 = value arena out ptr
+    a0 (output) = 0 ok / 1 failure.
+
+    Account record layout is 24 bytes per selected BAL item:
+      +0 account_ptr | +8 account_len | +16 is_insert.
+
+    Descriptor layout matches `mpt_state_root_ins`, 40 bytes per item. Paths are
+    written densely as 64-byte nibble arrays. Values are written densely in the
+    value arena, each rounded up to an 8-byte boundary before the next value. -/
+def balAccountDescriptorArrayFunction : String :=
+  "bal_account_descriptor_array:\n" ++
+  "  addi sp, sp, -112\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp); sd s8, 72(sp)\n" ++
+  "  mv s0, a0                   # BAL list ptr\n" ++
+  "  mv s1, a1                   # BAL list len\n" ++
+  "  mv s2, a2                   # account records\n" ++
+  "  mv s3, a3                   # n\n" ++
+  "  mv s4, a4                   # descriptor cursor\n" ++
+  "  mv s5, a5                   # path cursor\n" ++
+  "  mv s6, a6                   # value cursor\n" ++
+  "  li s7, 0                    # i\n" ++
+  ".Lbaada_loop:\n" ++
+  "  beq s7, s3, .Lbaada_ok\n" ++
+  "  mv a0, s0; mv a1, s1; mv a2, s7\n" ++
+  "  la a3, baada_item_off; la a4, baada_item_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbaada_ret\n" ++
+  "  slli t0, s7, 4; slli t1, s7, 3; add t0, t0, t1; add t0, s2, t0\n" ++
+  "  ld a0, 0(t0)                # account ptr\n" ++
+  "  ld a1, 8(t0)                # account len\n" ++
+  "  ld a4, 16(t0)               # is_insert\n" ++
+  "  la t1, baada_item_off; ld t1, 0(t1); add a2, s0, t1\n" ++
+  "  la t1, baada_item_len; ld a3, 0(t1)\n" ++
+  "  mv a5, s4; mv a6, s5; mv a7, s6\n" ++
+  "  jal ra, bal_account_change_descriptor\n" ++
+  "  bnez a0, .Lbaada_ret\n" ++
+  "  ld s8, 24(s4)               # value length from descriptor\n" ++
+  "  addi s4, s4, 40\n" ++
+  "  addi s5, s5, 64\n" ++
+  "  add s6, s6, s8; addi s6, s6, 7; andi s6, s6, -8\n" ++
+  "  addi s7, s7, 1\n" ++
+  "  j .Lbaada_loop\n" ++
+  ".Lbaada_ok:\n" ++
+  "  li a0, 0\n" ++
+  ".Lbaada_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp); ld s8, 72(sp)\n" ++
+  "  addi sp, sp, 112\n" ++
+  "  ret"
+
+/-- `zisk_bal_account_descriptor_array`: probe BuildUnit.
+    Input layout (file maps to INPUT+8 at 0x40000000):
+      +8  BAL list length (u64)
+      +16 n (u64)
+      +24 table: n x (account_len:u64, is_insert:u64)
+      then account RLP blobs, each padded to 8 bytes
+      then BAL AccountChanges list bytes
+    Output layout:
+      OUTPUT+0   : status
+      OUTPUT+8   : descriptor array
+      OUTPUT+88  : path arena (for two probe rows)
+      OUTPUT+216 : value arena (for compact probe accounts)
+      OUTPUT+248 : duplicate status -/
+def ziskBalAccountDescriptorArrayPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t0, 0x40000000\n" ++
+  "  ld a1, 8(t0)                # BAL list len\n" ++
+  "  ld a3, 16(t0)               # n\n" ++
+  "  addi t1, t0, 24             # input table\n" ++
+  "  slli t2, a3, 4; add t3, t1, t2   # blob cursor after 16*n table\n" ++
+  "  la t4, baada_records        # record table out\n" ++
+  "  li t5, 0\n" ++
+  ".Lbaadap_records:\n" ++
+  "  beq t5, a3, .Lbaadap_records_done\n" ++
+  "  slli t6, t5, 4; add t6, t1, t6\n" ++
+  "  ld a4, 0(t6)                # account len\n" ++
+  "  ld a5, 8(t6)                # is_insert\n" ++
+  "  slli t6, t5, 4; slli a6, t5, 3; add t6, t6, a6; add t6, t4, t6\n" ++
+  "  sd t3, 0(t6); sd a4, 8(t6); sd a5, 16(t6)\n" ++
+  "  add t3, t3, a4; addi t3, t3, 7; andi t3, t3, -8\n" ++
+  "  addi t5, t5, 1\n" ++
+  "  j .Lbaadap_records\n" ++
+  ".Lbaadap_records_done:\n" ++
+  "  mv a0, t3                   # BAL list ptr\n" ++
+  "  la a2, baada_records\n" ++
+  "  li a4, 0xa0010008           # descriptors\n" ++
+  "  li a5, 0xa0010058           # paths\n" ++
+  "  li a6, 0xa00100d8           # values\n" ++
+  "  jal ra, bal_account_descriptor_array\n" ++
+  "  li t0, 0xa0010000; sd a0, 0(t0)\n" ++
+  "  li t0, 0xa00100f8; sd a0, 0(t0)\n" ++
+  "  j .Lbaada_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  rlpEncodeUintBeFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  rlpItemSizeFunction ++ "\n" ++
+  rlpItemSpanFunction ++ "\n" ++
+  msetMemcpyFunction ++ "\n" ++
+  mptSpliceSlotFunction ++ "\n" ++
+  accountSetUintFieldFunction ++ "\n" ++
+  balAccountPathFunction ++ "\n" ++
+  balAccountPostFieldsFunction ++ "\n" ++
+  balAccountApplyPostFieldsFunction ++ "\n" ++
+  balAccountChangeValueFunction ++ "\n" ++
+  balAccountChangeDescriptorFunction ++ "\n" ++
+  balAccountDescriptorArrayFunction ++ "\n" ++
+  ".Lbaada_pdone:"
+
+def ziskBalAccountDescriptorArrayDataSection : String :=
+  ziskBalAccountChangeDescriptorDataSection ++ "\n" ++
+  ".balign 8\n" ++
+  "baada_item_off:\n  .zero 8\n" ++
+  "baada_item_len:\n  .zero 8\n" ++
+  "baada_records:\n  .zero 768\n" ++
+  "baada_pad:\n  .zero 8"
+
+def ziskBalAccountDescriptorArrayProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBalAccountDescriptorArrayPrologue
+  dataAsm     := ziskBalAccountDescriptorArrayDataSection
+}
+
+end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **492**
-- ziskemu round-trip scripts: **482** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **493**
+- ziskemu round-trip scripts: **483** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-bal-account-descriptor-array-check.sh
+++ b/scripts/codegen-zisk-bal-account-descriptor-array-check.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# codegen-zisk-bal-account-descriptor-array-check.sh -- verify BAL list to descriptor-array packaging.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else echo "ziskemu not found" >&2; exit 1; fi
+fi
+
+VDIR="$REPO_ROOT/gen-out/mpt-set"
+echo "==> generate BAL account descriptor-array vector"
+uv run --directory execution-specs --quiet python3 - "$VDIR" <<'PYGEN'
+import os
+import struct
+import sys
+from ethereum.crypto.hash import keccak256
+
+outdir = sys.argv[1]
+os.makedirs(outdir, exist_ok=True)
+
+OUTPUT = 0xA0010000
+PATH_BASE = OUTPUT + 88
+VALUE_BASE = OUTPUT + 216
+
+
+def minimal_be(n: int) -> bytes:
+    if n == 0:
+        return b""
+    return n.to_bytes((n.bit_length() + 7) // 8, "big")
+
+
+def rlp_bytes(x: bytes) -> bytes:
+    if len(x) == 1 and x[0] < 0x80:
+        return x
+    if len(x) <= 55:
+        return bytes([0x80 + len(x)]) + x
+    l = minimal_be(len(x))
+    return bytes([0xb7 + len(l)]) + l + x
+
+
+def rlp_list(xs):
+    payload = b"".join(xs)
+    if len(payload) <= 55:
+        return bytes([0xc0 + len(payload)]) + payload
+    l = minimal_be(len(payload))
+    return bytes([0xf7 + len(l)]) + l + payload
+
+
+def rlp_int(n: int) -> bytes:
+    return rlp_bytes(minimal_be(n))
+
+
+def account_rlp(nonce: int, balance: int) -> bytes:
+    # Compact account-shaped value for the probe; storage_root/code_hash are
+    # empty RLP strings so two output values fit inside the default 256-byte output.
+    return rlp_list([rlp_int(nonce), rlp_int(balance), rlp_bytes(b""), rlp_bytes(b"")])
+
+
+def change_pair(index: int, value: bytes) -> bytes:
+    return rlp_list([rlp_int(index), value])
+
+
+def account_change(address: bytes, balance_changes=None, nonce_changes=None) -> bytes:
+    balance_changes = balance_changes or []
+    nonce_changes = nonce_changes or []
+    bc = [change_pair(i, rlp_int(v)) for i, v in balance_changes]
+    nc = [change_pair(i, rlp_int(v)) for i, v in nonce_changes]
+    return rlp_list([rlp_bytes(address), rlp_list([]), rlp_list([]),
+                     rlp_list(bc), rlp_list(nc), rlp_list([])])
+
+
+def account_path(address: bytes) -> bytes:
+    out = bytearray()
+    for b in keccak256(address):
+        out.append(b >> 4)
+        out.append(b & 0x0f)
+    return bytes(out)
+
+
+def align8(n: int) -> int:
+    return (n + 7) & ~7
+
+
+def build_input(accounts, flags, bal_list: bytes) -> bytes:
+    body = struct.pack("<QQ", len(bal_list), len(accounts))
+    for account, flag in zip(accounts, flags):
+        body += struct.pack("<QQ", len(account), flag)
+    for account in accounts:
+        body += account
+        while len(body) % 8 != 0:
+            body += b"\x00"
+    body += bal_list
+    while len(body) % 8 != 0:
+        body += b"\x00"
+    return body
+
+
+base = account_rlp(1, 5)
+addr0 = bytes.fromhex("c0f6dc9e5836f54caadbf59cc69346c508e1992b")
+addr1 = bytes.fromhex("0000000000000000000000000000000000000002")
+changes = [
+    account_change(addr0, balance_changes=[(1, 10 ** 10)]),
+    account_change(addr1, balance_changes=[(1, 9)], nonce_changes=[(1, 7)]),
+]
+bal_list = rlp_list(changes)
+accounts = [base, base]
+flags = [0, 1]
+values = [account_rlp(1, 10 ** 10), account_rlp(7, 9)]
+paths = [account_path(addr0), account_path(addr1)]
+
+with open(f"{outdir}/baada_two.input", "wb") as f:
+    f.write(build_input(accounts, flags, bal_list))
+value_cursor = VALUE_BASE
+expected_desc = []
+for i, (path, value, flag) in enumerate(zip(paths, values, flags)):
+    expected_desc.append((PATH_BASE + 64 * i, 64, value_cursor, len(value), flag))
+    value_cursor += align8(len(value))
+with open(f"{outdir}/baada_two.expected", "w") as f:
+    f.write("\n".join("\t".join(map(str, row)) for row in expected_desc))
+with open(f"{outdir}/baada_two.paths", "w") as f:
+    f.write("\n".join(p.hex() for p in paths))
+with open(f"{outdir}/baada_two.values", "w") as f:
+    f.write("\n".join(v.hex() for v in values))
+print(f"baada_two n=2 value_lens={[len(v) for v in values]} flags={flags}")
+PYGEN
+
+echo "==> lake build codegen"
+lake build codegen >/dev/null
+
+echo "==> emit zisk_bal_account_descriptor_array probe ELF"
+lake exe codegen --program zisk_bal_account_descriptor_array --halt linux93 \
+  -o "$REPO_ROOT/gen-out/zisk_bal_account_descriptor_array"
+
+out="$VDIR/baada_two.output"
+"$ZISKEMU" -e "$REPO_ROOT/gen-out/zisk_bal_account_descriptor_array.elf" \
+  -i "$VDIR/baada_two.input" -o "$out" -n 2000000 >/dev/null 2>&1 </dev/null
+status="$(od -An -tu8 -j 0 -N 8 "$out" | tr -d ' \n')"
+fail=0
+if [[ "$status" != "0" ]]; then
+  echo "  FAIL   baada_two status=$status"
+  fail=1
+fi
+mapfile -t exp_desc < "$VDIR/baada_two.expected"
+mapfile -t exp_paths < "$VDIR/baada_two.paths"
+mapfile -t exp_values < "$VDIR/baada_two.values"
+value_copy_off=216
+for i in 0 1; do
+  desc_off=$((8 + 40 * i))
+  IFS=$'\t' read -r exp_path_ptr exp_path_len exp_value_ptr exp_value_len exp_flag <<< "${exp_desc[$i]}"
+  path_ptr="$(od -An -tu8 -j "$desc_off" -N 8 "$out" | tr -d ' \n')"
+  path_len="$(od -An -tu8 -j $((desc_off + 8)) -N 8 "$out" | tr -d ' \n')"
+  value_ptr="$(od -An -tu8 -j $((desc_off + 16)) -N 8 "$out" | tr -d ' \n')"
+  value_len="$(od -An -tu8 -j $((desc_off + 24)) -N 8 "$out" | tr -d ' \n')"
+  flag="$(od -An -tu8 -j $((desc_off + 32)) -N 8 "$out" | tr -d ' \n')"
+  path="$(xxd -p -s $((88 + 64 * i)) -l 64 "$out" | tr -d '\n')"
+  value="$(xxd -p -s "$value_copy_off" -l "$value_len" "$out" | tr -d '\n')"
+  if [[ "$path_ptr" != "$exp_path_ptr" || "$path_len" != "$exp_path_len" || "$value_ptr" != "$exp_value_ptr" || "$value_len" != "$exp_value_len" || "$flag" != "$exp_flag" || "$path" != "${exp_paths[$i]}" || "$value" != "${exp_values[$i]}" ]]; then
+    echo "  FAIL   baada_two row=$i"
+    echo "    desc path_ptr=$path_ptr path_len=$path_len value_ptr=$value_ptr value_len=$value_len flag=$flag"
+    echo "    expected path_ptr=$exp_path_ptr path_len=$exp_path_len value_ptr=$exp_value_ptr value_len=$exp_value_len flag=$exp_flag"
+    echo "    path expected=${exp_paths[$i]} actual=$path"
+    echo "    value expected=${exp_values[$i]} actual=$value"
+    fail=1
+  else
+    echo "  PASS   baada_two row=$i value_len=$value_len flag=$flag"
+  fi
+  value_copy_off=$(( (value_copy_off + value_len + 7) & ~7 ))
+done
+[[ "$fail" -eq 0 ]] && echo "==> PASS: bal_account_descriptor_array matches reference" \
+  || { echo "==> FAIL"; exit 1; }


### PR DESCRIPTION
## Summary
- add bal_account_descriptor_array / zisk_bal_account_descriptor_array to turn a BAL AccountChanges list plus pre-account records into an mpt_state_root_ins descriptor array
- iterate selected BAL items, writing dense descriptor, path, and value arenas
- add a focused ziskemu two-row vector covering modify and insert flags

Stacked on #7776. Bead: evm-asm-fhsxz.2.4.2.6.6.

## Verification
- lake build EvmAsm.Codegen.Programs.BalAccountDescriptorArray
- scripts/codegen-zisk-bal-account-descriptor-array-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build

Authored by @pirapira; implemented by Codex.