### PR TITLE
feat(eest): replay BAL accounts into state root

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -72,6 +72,7 @@ import EvmAsm.Codegen.Programs.BalAccountChangeValue
 import EvmAsm.Codegen.Programs.BalAccountChangeDescriptor
 import EvmAsm.Codegen.Programs.BalAccountNthDescriptor
 import EvmAsm.Codegen.Programs.BalAccountDescriptorArray
+import EvmAsm.Codegen.Programs.BalAccountStateRoot
 import EvmAsm.Codegen.Programs.StorageWrite
 import EvmAsm.Codegen.Programs.BlockAccessListHash
 import EvmAsm.Codegen.Programs.AccountApplyStorage
@@ -331,6 +332,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_bal_account_change_descriptor" => some ziskBalAccountChangeDescriptorProbeUnit
   | "zisk_bal_account_nth_descriptor" => some ziskBalAccountNthDescriptorProbeUnit
   | "zisk_bal_account_descriptor_array" => some ziskBalAccountDescriptorArrayProbeUnit
+  | "zisk_bal_account_state_root" => some ziskBalAccountStateRootProbeUnit
   | "zisk_storage_root_single_slot" => some ziskStorageRootSingleSlotProbeUnit
   | "zisk_account_set_storage_root" => some ziskAccountSetStorageRootProbeUnit
   | "zisk_block_access_list_hash" => some ziskBlockAccessListHashProbeUnit
@@ -1130,6 +1132,7 @@ def knownProgramNames : List String :=
    "zisk_bal_account_change_descriptor",
    "zisk_bal_account_nth_descriptor",
    "zisk_bal_account_descriptor_array",
+   "zisk_bal_account_state_root",
    "zisk_storage_root_single_slot",
    "zisk_account_set_storage_root",
    "zisk_block_access_list_hash",

--- a/EvmAsm/Codegen/Programs/BalAccountStateRoot.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountStateRoot.lean
@@ -1,0 +1,175 @@
+/-
+  EvmAsm.Codegen.Programs.BalAccountStateRoot
+
+  Bridge BAL account descriptor preparation into `mpt_state_root_ins`: given a
+  pre-state root/witness, a BAL AccountChanges list, and caller-supplied
+  pre-account records, recompute the post state root for those account changes.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.BalAccountDescriptorArray
+import EvmAsm.Codegen.Programs.MptStateRootIns
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+/-! ## bal_account_state_root -- BAL descriptors + mpt_state_root_ins
+
+    a0 = root_hash ptr        a1 = witness ptr       a2 = witness length
+    a3 = BAL list ptr         a4 = BAL list length   a5 = account records ptr
+    a6 = n records/items      a7 = out root ptr
+    a0 (output) = 0 ok / nonzero failure.
+
+    Account records use `bal_account_descriptor_array`'s 24-byte layout:
+      +0 account_ptr | +8 account_len | +16 is_insert. -/
+def balAccountStateRootFunction : String :=
+  "bal_account_state_root:\n" ++
+  "  addi sp, sp, -96\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  mv s0, a0                   # root hash ptr\n" ++
+  "  mv s1, a1                   # witness ptr\n" ++
+  "  mv s2, a2                   # witness len\n" ++
+  "  mv s3, a5                   # account records\n" ++
+  "  mv s4, a6                   # n\n" ++
+  "  mv s5, a7                   # out root\n" ++
+  "  mv a0, a3; mv a1, a4; mv a2, s3; mv a3, s4\n" ++
+  "  la a4, basr_desc; la a5, basr_paths; la a6, basr_values\n" ++
+  "  jal ra, bal_account_descriptor_array\n" ++
+  "  bnez a0, .Lbasr_ret\n" ++
+  "  mv a0, s0; mv a1, s1; mv a2, s2; la a3, basr_desc; mv a4, s4; mv a5, s5\n" ++
+  "  jal ra, mpt_state_root_ins\n" ++
+  ".Lbasr_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  addi sp, sp, 96\n" ++
+  "  ret"
+
+/-- `zisk_bal_account_state_root`: probe BuildUnit.
+    Input layout (file maps to INPUT+8 at 0x40000000):
+      +8  witness length (u64)
+      +16 n (u64)
+      +24 BAL list length (u64)
+      +32 root hash (32 bytes)
+      +64 table: n x (account_len:u64, is_insert:u64)
+      then account RLP blobs, each padded to 8 bytes
+      then BAL AccountChanges list bytes, padded to 8 bytes
+      then witness section
+    Output: OUTPUT+0 = final root, OUTPUT+32 = status. -/
+def ziskBalAccountStateRootPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t0, 0x40000000\n" ++
+  "  ld a2, 8(t0)                # witness len\n" ++
+  "  ld a6, 16(t0)               # n\n" ++
+  "  ld a4, 24(t0)               # BAL list len\n" ++
+  "  addi a0, t0, 32             # root hash ptr\n" ++
+  "  addi t1, t0, 64             # input table\n" ++
+  "  slli t2, a6, 4; add t3, t1, t2   # account blob cursor\n" ++
+  "  la a5, basr_records         # account records out\n" ++
+  "  li t4, 0\n" ++
+  ".Lbasrp_records:\n" ++
+  "  beq t4, a6, .Lbasrp_records_done\n" ++
+  "  slli t5, t4, 4; add t5, t1, t5\n" ++
+  "  ld s6, 0(t5)                # account len\n" ++
+  "  ld s7, 8(t5)                # is_insert\n" ++
+  "  slli t5, t4, 4; slli t6, t4, 3; add t5, t5, t6; add t5, a5, t5\n" ++
+  "  sd t3, 0(t5); sd s6, 8(t5); sd s7, 16(t5)\n" ++
+  "  add t3, t3, s6; addi t3, t3, 7; andi t3, t3, -8\n" ++
+  "  addi t4, t4, 1\n" ++
+  "  j .Lbasrp_records\n" ++
+  ".Lbasrp_records_done:\n" ++
+  "  mv a3, t3                   # BAL list ptr\n" ++
+  "  add t3, t3, a4; addi t3, t3, 7; andi t3, t3, -8\n" ++
+  "  mv a1, t3                   # witness ptr\n" ++
+  "  li a7, 0xa0010000           # out root\n" ++
+  "  jal ra, bal_account_state_root\n" ++
+  "  li t0, 0xa0010020; sd a0, 0(t0)\n" ++
+  "  j .Lbasr_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  nodeDbLookupFunction ++ "\n" ++
+  nodeDbAppendFunction ++ "\n" ++
+  mptNodeResolveFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  mptSetRecordWalkDbFunction ++ "\n" ++
+  mptInsertWalkDbFunction ++ "\n" ++
+  hpEncodeNibblesFunction ++ "\n" ++
+  rlpEncodeUintBeFunction ++ "\n" ++
+  rlpEncodeBytesFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  mptLeafNodeEncodeFromNibblesFunction ++ "\n" ++
+  mptNodeSlotEncodeFunction ++ "\n" ++
+  rlpItemSizeFunction ++ "\n" ++
+  rlpItemSpanFunction ++ "\n" ++
+  msetMemcpyFunction ++ "\n" ++
+  mptSpliceSlotFunction ++ "\n" ++
+  mptLeafExtractFunction ++ "\n" ++
+  mptExtensionNodeEncodeFunction ++ "\n" ++
+  accountSetUintFieldFunction ++ "\n" ++
+  balAccountPathFunction ++ "\n" ++
+  balAccountPostFieldsFunction ++ "\n" ++
+  balAccountApplyPostFieldsFunction ++ "\n" ++
+  balAccountChangeValueFunction ++ "\n" ++
+  balAccountChangeDescriptorFunction ++ "\n" ++
+  balAccountDescriptorArrayFunction ++ "\n" ++
+  mptSetAccFunction ++ "\n" ++
+  mptInsertAccFunction ++ "\n" ++
+  mptStateRootInsFunction ++ "\n" ++
+  balAccountStateRootFunction ++ "\n" ++
+  ".Lbasr_pdone:"
+
+/-- Data section combines the MPT state-root driver scratch with only the
+    BAL/account-rewrite labels that are not already provided by MPT scratch. -/
+def ziskBalAccountStateRootDataSection : String :=
+  ziskMptStateRootInsDataSection ++ "\n" ++
+  ".balign 8\n" ++
+  "aab_enc_len:\n  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aab_enc:\n  .zero 64\n" ++
+  ".balign 8\n" ++
+  "bpf_list_off:\n  .zero 8\n" ++
+  "bpf_list_len:\n  .zero 8\n" ++
+  "bpf_list_ptr:\n  .zero 8\n" ++
+  "bpf_count:\n  .zero 8\n" ++
+  "bpf_item_off:\n  .zero 8\n" ++
+  "bpf_item_len:\n  .zero 8\n" ++
+  "bpf_item_ptr:\n  .zero 8\n" ++
+  "bpf_val_off:\n  .zero 8\n" ++
+  "bpf_val_len:\n  .zero 8\n" ++
+  "baap_bal_len:\n  .zero 8\n" ++
+  "baap_nonce_len:\n  .zero 8\n" ++
+  "baap_tmp_len:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "baap_bal:\n  .zero 32\n" ++
+  "baap_nonce:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "baap_tmp:\n  .zero 512\n" ++
+  "bacp_off:\n  .zero 8\n" ++
+  "bacp_len:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "bacp_hash:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "baacd_value_len:\n  .zero 8\n" ++
+  "baada_item_off:\n  .zero 8\n" ++
+  "baada_item_len:\n  .zero 8\n" ++
+  "basr_records:\n  .zero 4096\n" ++
+  "basr_desc:\n  .zero 4096\n" ++
+  "basr_paths:\n  .zero 8192\n" ++
+  "basr_values:\n  .zero 16384\n" ++
+  "basr_pad:\n  .zero 8"
+
+def ziskBalAccountStateRootProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBalAccountStateRootPrologue
+  dataAsm     := ziskBalAccountStateRootDataSection
+}
+
+end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **493**
-- ziskemu round-trip scripts: **483** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **494**
+- ziskemu round-trip scripts: **484** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-bal-account-state-root-check.sh
+++ b/scripts/codegen-zisk-bal-account-state-root-check.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# codegen-zisk-bal-account-state-root-check.sh -- verify BAL account replay into mpt_state_root_ins.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else echo "ziskemu not found" >&2; exit 1; fi
+fi
+
+VDIR="$REPO_ROOT/gen-out/mpt-set"
+echo "==> generate BAL account state-root vector"
+uv run --directory execution-specs --quiet python3 - "$VDIR" <<'PYGEN'
+import os
+import struct
+import sys
+from ethereum.crypto.hash import keccak256
+
+outdir = sys.argv[1]
+os.makedirs(outdir, exist_ok=True)
+
+
+def minimal_be(n: int) -> bytes:
+    if n == 0:
+        return b""
+    return n.to_bytes((n.bit_length() + 7) // 8, "big")
+
+
+def rlp_bytes(x: bytes) -> bytes:
+    if len(x) == 1 and x[0] < 0x80:
+        return x
+    if len(x) <= 55:
+        return bytes([0x80 + len(x)]) + x
+    l = minimal_be(len(x))
+    return bytes([0xb7 + len(l)]) + l + x
+
+
+def rlp_list(xs):
+    payload = b"".join(xs)
+    if len(payload) <= 55:
+        return bytes([0xc0 + len(payload)]) + payload
+    l = minimal_be(len(payload))
+    return bytes([0xf7 + len(l)]) + l + payload
+
+
+def rlp_int(n: int) -> bytes:
+    return rlp_bytes(minimal_be(n))
+
+
+def account_rlp(nonce: int, balance: int) -> bytes:
+    # Compact account-shaped value for a small one-leaf state trie probe.
+    return rlp_list([rlp_int(nonce), rlp_int(balance), rlp_bytes(b""), rlp_bytes(b"")])
+
+
+def change_pair(index: int, value: bytes) -> bytes:
+    return rlp_list([rlp_int(index), value])
+
+
+def account_change(address: bytes, balance_changes=None, nonce_changes=None) -> bytes:
+    balance_changes = balance_changes or []
+    nonce_changes = nonce_changes or []
+    bc = [change_pair(i, rlp_int(v)) for i, v in balance_changes]
+    nc = [change_pair(i, rlp_int(v)) for i, v in nonce_changes]
+    return rlp_list([rlp_bytes(address), rlp_list([]), rlp_list([]),
+                     rlp_list(bc), rlp_list(nc), rlp_list([])])
+
+
+def account_path(address: bytes) -> bytes:
+    out = bytearray()
+    for b in keccak256(address):
+        out.append(b >> 4)
+        out.append(b & 0x0f)
+    return bytes(out)
+
+
+def hp_leaf(path):
+    # Leaf, even-length 64-nibble account path: flags byte 0x20 then packed path.
+    assert len(path) % 2 == 0
+    out = bytearray([0x20])
+    for i in range(0, len(path), 2):
+        out.append((path[i] << 4) | path[i + 1])
+    return bytes(out)
+
+
+def leaf_node(path, value: bytes) -> bytes:
+    return rlp_list([rlp_bytes(hp_leaf(path)), rlp_bytes(value)])
+
+
+def ssz_section(elements):
+    out = bytearray()
+    off = 4 * len(elements)
+    for element in elements:
+        out += struct.pack("<I", off)
+        off += len(element)
+    for element in elements:
+        out += element
+    return bytes(out)
+
+
+def align8_body(body: bytearray):
+    while len(body) % 8 != 0:
+        body += b"\x00"
+
+
+def build_input(root_hash, witness, bal_list, accounts, flags):
+    body = bytearray()
+    body += struct.pack("<QQQ", len(witness), len(accounts), len(bal_list))
+    body += root_hash
+    for account, flag in zip(accounts, flags):
+        body += struct.pack("<QQ", len(account), flag)
+    for account in accounts:
+        body += account
+        align8_body(body)
+    body += bal_list
+    align8_body(body)
+    body += witness
+    align8_body(body)
+    return bytes(body)
+
+
+addr = bytes.fromhex("c0f6dc9e5836f54caadbf59cc69346c508e1992b")
+old_account = account_rlp(1, 5)
+new_account = account_rlp(1, 10 ** 10)
+path = account_path(addr)
+old_leaf = leaf_node(path, old_account)
+new_leaf = leaf_node(path, new_account)
+root_hash = keccak256(old_leaf)
+expected = keccak256(new_leaf)
+bal_list = rlp_list([account_change(addr, balance_changes=[(1, 10 ** 10)])])
+with open(f"{outdir}/basr_modify.input", "wb") as f:
+    f.write(build_input(root_hash, ssz_section([old_leaf]), bal_list, [old_account], [0]))
+with open(f"{outdir}/basr_modify.expected", "w") as f:
+    f.write(expected.hex())
+print(f"basr_modify root={root_hash.hex()[:16]}.. expected={expected.hex()[:16]}..")
+PYGEN
+
+echo "==> lake build codegen"
+lake build codegen >/dev/null
+
+echo "==> emit zisk_bal_account_state_root probe ELF"
+lake exe codegen --program zisk_bal_account_state_root --halt linux93 \
+  -o "$REPO_ROOT/gen-out/zisk_bal_account_state_root"
+
+out="$VDIR/basr_modify.output"
+"$ZISKEMU" -e "$REPO_ROOT/gen-out/zisk_bal_account_state_root.elf" \
+  -i "$VDIR/basr_modify.input" -o "$out" -n 12000000 >/dev/null 2>&1 </dev/null
+status="$(od -An -tu8 -j 32 -N 8 "$out" | tr -d ' \n')"
+actual="$(xxd -p -s 0 -l 32 "$out" | tr -d '\n')"
+expected="$(cat "$VDIR/basr_modify.expected")"
+if [[ "$status" == "0" && "$actual" == "$expected" ]]; then
+  echo "  PASS   basr_modify root=${actual:0:16}.."
+  echo "==> PASS: bal_account_state_root matches reference"
+else
+  echo "  FAIL   basr_modify status=$status"
+  echo "    expected: $expected"
+  echo "    actual:   $actual"
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add bal_account_state_root to turn BAL account changes plus pre-account records into mpt_state_root_ins descriptors
- expose zisk_bal_account_state_root through the codegen registry
- add a ziskemu checker for a BAL balance modification replayed through a one-leaf state trie

## Verification
- lake build EvmAsm.Codegen.Programs.BalAccountStateRoot
- scripts/codegen-zisk-bal-account-state-root-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|DEBUG' EvmAsm/Codegen/Programs.lean EvmAsm/Codegen/Programs/BalAccountStateRoot.lean scripts/codegen-zisk-bal-account-state-root-check.sh
- lake build