### PR TITLE
feat(eest): derive BAL account record arrays

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -73,6 +73,7 @@ import EvmAsm.Codegen.Programs.BalAccountChangeDescriptor
 import EvmAsm.Codegen.Programs.BalAccountNthDescriptor
 import EvmAsm.Codegen.Programs.BalAccountDescriptorArray
 import EvmAsm.Codegen.Programs.BalAccountStateRoot
+import EvmAsm.Codegen.Programs.BalAccountRecordArray
 import EvmAsm.Codegen.Programs.StorageWrite
 import EvmAsm.Codegen.Programs.BlockAccessListHash
 import EvmAsm.Codegen.Programs.AccountApplyStorage
@@ -333,6 +334,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_bal_account_nth_descriptor" => some ziskBalAccountNthDescriptorProbeUnit
   | "zisk_bal_account_descriptor_array" => some ziskBalAccountDescriptorArrayProbeUnit
   | "zisk_bal_account_state_root" => some ziskBalAccountStateRootProbeUnit
+  | "zisk_bal_account_record_array" => some ziskBalAccountRecordArrayProbeUnit
   | "zisk_storage_root_single_slot" => some ziskStorageRootSingleSlotProbeUnit
   | "zisk_account_set_storage_root" => some ziskAccountSetStorageRootProbeUnit
   | "zisk_block_access_list_hash" => some ziskBlockAccessListHashProbeUnit
@@ -1133,6 +1135,7 @@ def knownProgramNames : List String :=
    "zisk_bal_account_nth_descriptor",
    "zisk_bal_account_descriptor_array",
    "zisk_bal_account_state_root",
+   "zisk_bal_account_record_array",
    "zisk_storage_root_single_slot",
    "zisk_account_set_storage_root",
    "zisk_block_access_list_hash",

--- a/EvmAsm/Codegen/Programs/BalAccountRecordArray.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountRecordArray.lean
@@ -1,0 +1,164 @@
+/-
+  EvmAsm.Codegen.Programs.BalAccountRecordArray
+
+  Derive the pre-account record table that `bal_account_state_root` consumes:
+  for each BAL AccountChanges item, walk the pre-state trie to find the account
+  RLP, or use the canonical empty-account RLP when the account is absent.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.BalAccountPath
+import EvmAsm.Codegen.Programs.Mpt
+import EvmAsm.Codegen.Programs.MptSet
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+/-! ## bal_account_record_array -- BAL list -> pre-account records
+
+    a0 = root_hash ptr        a1 = witness ptr       a2 = witness length
+    a3 = BAL list ptr         a4 = BAL list length   a5 = n records/items
+    a6 = records out ptr      a7 = account arena out ptr
+    a0 (output) = 0 ok / 1 conservative failure.
+
+    Record layout matches `bal_account_descriptor_array`:
+      +0 account_ptr | +8 account_len | +16 is_insert.
+
+    Found accounts are copied into the caller-provided arena with is_insert=0.
+    Missing accounts use the canonical empty account RLP with is_insert=1. -/
+def balAccountRecordArrayFunction : String :=
+  "bal_account_record_array:\n" ++
+  "  addi sp, sp, -112\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp); sd s8, 72(sp); sd s9, 80(sp)\n" ++
+  "  mv s0, a0                   # root hash ptr\n" ++
+  "  mv s1, a1                   # witness ptr\n" ++
+  "  mv s2, a2                   # witness len\n" ++
+  "  mv s3, a3                   # BAL list ptr\n" ++
+  "  mv s4, a4                   # BAL list len\n" ++
+  "  mv s5, a5                   # n\n" ++
+  "  mv s6, a6                   # records out base\n" ++
+  "  mv s7, a7                   # account arena cursor\n" ++
+  "  li s8, 0                    # i\n" ++
+  ".Lbara_loop:\n" ++
+  "  beq s8, s5, .Lbara_ok\n" ++
+  "  mv a0, s3; mv a1, s4; mv a2, s8\n" ++
+  "  la a3, bara_item_off; la a4, bara_item_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbara_fail\n" ++
+  "  la t0, bara_item_off; ld t0, 0(t0); add a0, s3, t0\n" ++
+  "  la t0, bara_item_len; ld a1, 0(t0)\n" ++
+  "  la a2, bara_path\n" ++
+  "  jal ra, bal_account_path\n" ++
+  "  bnez a0, .Lbara_fail\n" ++
+  "  mv a0, s0; mv a1, s1; mv a2, s2; la a3, bara_path; li a4, 64\n" ++
+  "  la a5, bara_acct; la a6, bara_acct_len\n" ++
+  "  jal ra, mpt_walk\n" ++
+  "  beqz a0, .Lbara_found\n" ++
+  "  li t0, 1; bne a0, t0, .Lbara_fail\n" ++
+  "  la s9, bara_empty_account\n" ++
+  "  li t1, 70\n" ++
+  "  li t2, 1                    # is_insert\n" ++
+  "  j .Lbara_record\n" ++
+  ".Lbara_found:\n" ++
+  "  la s9, bara_acct\n" ++
+  "  la t0, bara_acct_len; ld t1, 0(t0)\n" ++
+  "  li t0, 256; bgtu t1, t0, .Lbara_fail\n" ++
+  "  li t2, 0                    # modify existing\n" ++
+  ".Lbara_record:\n" ++
+  "  mv a0, s7; mv a1, s9; mv a2, t1\n" ++
+  "  jal ra, mset_memcpy\n" ++
+  "  slli t0, s8, 4; slli t3, s8, 3; add t0, t0, t3; add t0, s6, t0\n" ++
+  "  sd s7, 0(t0); sd t1, 8(t0); sd t2, 16(t0)\n" ++
+  "  add s7, s7, t1; addi s7, s7, 7; andi s7, s7, -8\n" ++
+  "  addi s8, s8, 1\n" ++
+  "  j .Lbara_loop\n" ++
+  ".Lbara_ok:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbara_ret\n" ++
+  ".Lbara_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lbara_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp); ld s8, 72(sp); ld s9, 80(sp)\n" ++
+  "  addi sp, sp, 112\n" ++
+  "  ret"
+
+/-- `zisk_bal_account_record_array`: probe BuildUnit.
+    Input layout (file maps to INPUT+8 at 0x40000000):
+      +8  witness length (u64)
+      +16 n (u64)
+      +24 BAL list length (u64)
+      +32 root hash (32 bytes)
+      +64 BAL AccountChanges list bytes, padded to 8 bytes
+      then witness section
+    Output layout:
+      OUTPUT+0  = status
+      OUTPUT+8  = records
+      OUTPUT+64 = account arena. -/
+def ziskBalAccountRecordArrayPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t0, 0x40000000\n" ++
+  "  ld a2, 8(t0)                # witness len\n" ++
+  "  ld a5, 16(t0)               # n\n" ++
+  "  ld a4, 24(t0)               # BAL list len\n" ++
+  "  addi a0, t0, 32             # root hash ptr\n" ++
+  "  addi a3, t0, 64             # BAL list ptr\n" ++
+  "  add t1, a3, a4; addi t1, t1, 7; andi t1, t1, -8\n" ++
+  "  mv a1, t1                   # witness ptr\n" ++
+  "  li a6, 0xa0010008           # records out\n" ++
+  "  li a7, 0xa0010040           # account arena out\n" ++
+  "  jal ra, bal_account_record_array\n" ++
+  "  li t0, 0xa0010000; sd a0, 0(t0)\n" ++
+  "  j .Lbara_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  msetMemcpyFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  balAccountPathFunction ++ "\n" ++
+  balAccountRecordArrayFunction ++ "\n" ++
+  ".Lbara_pdone:"
+
+def ziskBalAccountRecordArrayDataSection : String :=
+  ziskMptWalkDataSection ++ "\n" ++
+  ".balign 8\n" ++
+  "bara_item_off:\n  .zero 8\n" ++
+  "bara_item_len:\n  .zero 8\n" ++
+  "bara_acct_len:\n  .zero 8\n" ++
+  "bacp_off:\n  .zero 8\n" ++
+  "bacp_len:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "bacp_hash:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "bara_path:\n  .zero 64\n" ++
+  "bara_acct:\n  .zero 256\n" ++
+  ".balign 8\n" ++
+  "bara_empty_account:\n" ++
+  "  .byte 0xf8,0x44,0x80,0x80,0xa0\n" ++
+  "  .byte 0x56,0xe8,0x1f,0x17,0x1b,0xcc,0x55,0xa6\n" ++
+  "  .byte 0xff,0x83,0x45,0xe6,0x92,0xc0,0xf8,0x6e\n" ++
+  "  .byte 0x5b,0x48,0xe0,0x1b,0x99,0x6c,0xad,0xc0\n" ++
+  "  .byte 0x01,0x62,0x2f,0xb5,0xe3,0x63,0xb4,0x21\n" ++
+  "  .byte 0xa0\n" ++
+  "  .byte 0xc5,0xd2,0x46,0x01,0x86,0xf7,0x23,0x3c\n" ++
+  "  .byte 0x92,0x7e,0x7d,0xb2,0xdc,0xc7,0x03,0xc0\n" ++
+  "  .byte 0xe5,0x00,0xb6,0x53,0xca,0x82,0x27,0x3b\n" ++
+  "  .byte 0x7b,0xfa,0xd8,0x04,0x5d,0x85,0xa4,0x70\n" ++
+  ".balign 8\n" ++
+  "bara_pad:\n  .zero 8"
+
+def ziskBalAccountRecordArrayProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBalAccountRecordArrayPrologue
+  dataAsm     := ziskBalAccountRecordArrayDataSection
+}
+
+end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **494**
-- ziskemu round-trip scripts: **484** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **495**
+- ziskemu round-trip scripts: **485** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-bal-account-record-array-check.sh
+++ b/scripts/codegen-zisk-bal-account-record-array-check.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# codegen-zisk-bal-account-record-array-check.sh -- verify BAL pre-account record extraction.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else echo "ziskemu not found" >&2; exit 1; fi
+fi
+
+VDIR="$REPO_ROOT/gen-out/mpt-set"
+echo "==> generate BAL account record-array vector"
+uv run --directory execution-specs --quiet python3 - "$VDIR" <<'PYGEN'
+import os
+import struct
+import sys
+from ethereum.crypto.hash import keccak256
+
+outdir = sys.argv[1]
+os.makedirs(outdir, exist_ok=True)
+
+
+def minimal_be(n: int) -> bytes:
+    if n == 0:
+        return b""
+    return n.to_bytes((n.bit_length() + 7) // 8, "big")
+
+
+def rlp_bytes(x: bytes) -> bytes:
+    if len(x) == 1 and x[0] < 0x80:
+        return x
+    if len(x) <= 55:
+        return bytes([0x80 + len(x)]) + x
+    l = minimal_be(len(x))
+    return bytes([0xb7 + len(l)]) + l + x
+
+
+def rlp_list(xs):
+    payload = b"".join(xs)
+    if len(payload) <= 55:
+        return bytes([0xc0 + len(payload)]) + payload
+    l = minimal_be(len(payload))
+    return bytes([0xf7 + len(l)]) + l + payload
+
+
+def rlp_int(n: int) -> bytes:
+    return rlp_bytes(minimal_be(n))
+
+
+def account_rlp(nonce: int, balance: int, storage_root=None, code_hash=None) -> bytes:
+    storage_root = storage_root or bytes.fromhex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+    code_hash = code_hash or bytes.fromhex("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+    return rlp_list([rlp_int(nonce), rlp_int(balance), rlp_bytes(storage_root), rlp_bytes(code_hash)])
+
+
+def change_pair(index: int, value: bytes) -> bytes:
+    return rlp_list([rlp_int(index), value])
+
+
+def account_change(address: bytes, balance_changes=None, nonce_changes=None) -> bytes:
+    balance_changes = balance_changes or []
+    nonce_changes = nonce_changes or []
+    bc = [change_pair(i, rlp_int(v)) for i, v in balance_changes]
+    nc = [change_pair(i, rlp_int(v)) for i, v in nonce_changes]
+    return rlp_list([rlp_bytes(address), rlp_list([]), rlp_list([]),
+                     rlp_list(bc), rlp_list(nc), rlp_list([])])
+
+
+def account_path(address: bytes) -> bytes:
+    out = bytearray()
+    for b in keccak256(address):
+        out.append(b >> 4)
+        out.append(b & 0x0f)
+    return bytes(out)
+
+
+def hp_leaf(path):
+    assert len(path) % 2 == 0
+    out = bytearray([0x20])
+    for i in range(0, len(path), 2):
+        out.append((path[i] << 4) | path[i + 1])
+    return bytes(out)
+
+
+def leaf_node(path, value: bytes) -> bytes:
+    return rlp_list([rlp_bytes(hp_leaf(path)), rlp_bytes(value)])
+
+
+def ssz_section(elements):
+    out = bytearray()
+    off = 4 * len(elements)
+    for element in elements:
+        out += struct.pack("<I", off)
+        off += len(element)
+    for element in elements:
+        out += element
+    return bytes(out)
+
+
+def align8_body(body: bytearray):
+    while len(body) % 8 != 0:
+        body += b"\x00"
+
+
+def build_input(root_hash, witness, bal_list, n):
+    body = bytearray()
+    body += struct.pack("<QQQ", len(witness), n, len(bal_list))
+    body += root_hash
+    body += bal_list
+    align8_body(body)
+    body += witness
+    align8_body(body)
+    return bytes(body)
+
+
+present_addr = bytes.fromhex("c0f6dc9e5836f54caadbf59cc69346c508e1992b")
+missing_addr = bytes.fromhex("0000000000000000000000000000000000000002")
+old_account = account_rlp(1, 5)
+empty_account = account_rlp(0, 0)
+old_leaf = leaf_node(account_path(present_addr), old_account)
+root_hash = keccak256(old_leaf)
+bal_list = rlp_list([
+    account_change(present_addr, balance_changes=[(1, 10 ** 10)]),
+    account_change(missing_addr, balance_changes=[(1, 9)], nonce_changes=[(1, 7)]),
+])
+with open(f"{outdir}/bara_present_missing.input", "wb") as f:
+    f.write(build_input(root_hash, ssz_section([old_leaf]), bal_list, 2))
+with open(f"{outdir}/bara_present_missing.expected", "w") as f:
+    f.write(old_account.hex() + "\n")
+    f.write(empty_account.hex() + "\n")
+print(f"bara_present_missing root={root_hash.hex()[:16]}.. lens={[len(old_account), len(empty_account)]}")
+PYGEN
+
+echo "==> lake build codegen"
+lake build codegen >/dev/null
+
+echo "==> emit zisk_bal_account_record_array probe ELF"
+lake exe codegen --program zisk_bal_account_record_array --halt linux93 \
+  -o "$REPO_ROOT/gen-out/zisk_bal_account_record_array"
+
+out="$VDIR/bara_present_missing.output"
+"$ZISKEMU" -e "$REPO_ROOT/gen-out/zisk_bal_account_record_array.elf" \
+  -i "$VDIR/bara_present_missing.input" -o "$out" -n 4000000 >/dev/null 2>&1 </dev/null
+status="$(od -An -tu8 -j 0 -N 8 "$out" | tr -d ' \n')"
+mapfile -t expected < "$VDIR/bara_present_missing.expected"
+fail=0
+if [[ "$status" != "0" ]]; then
+  echo "  FAIL   status=$status"
+  fail=1
+fi
+arena_off=64
+for i in 0 1; do
+  desc_off=$((8 + 24 * i))
+  ptr="$(od -An -tu8 -j "$desc_off" -N 8 "$out" | tr -d ' \n')"
+  len="$(od -An -tu8 -j $((desc_off + 8)) -N 8 "$out" | tr -d ' \n')"
+  flag="$(od -An -tu8 -j $((desc_off + 16)) -N 8 "$out" | tr -d ' \n')"
+  expected_flag="$i"
+  expected_ptr=$((0xa0010000 + arena_off))
+  account="$(xxd -p -s "$arena_off" -l "$len" "$out" | tr -d '\n')"
+  if [[ "$ptr" != "$expected_ptr" || "$flag" != "$expected_flag" || "$account" != "${expected[$i]}" ]]; then
+    echo "  FAIL   row=$i ptr=$ptr len=$len flag=$flag"
+    echo "    expected ptr=$expected_ptr flag=$expected_flag account=${expected[$i]}"
+    echo "    actual account=$account"
+    fail=1
+  else
+    echo "  PASS   row=$i len=$len flag=$flag"
+  fi
+  arena_off=$(( (arena_off + len + 7) & ~7 ))
+done
+[[ "$fail" -eq 0 ]] && echo "==> PASS: bal_account_record_array matches reference" \
+  || { echo "==> FAIL"; exit 1; }


### PR DESCRIPTION
## Summary
- add bal_account_record_array to derive pre-account records from a BAL AccountChanges list and pre-state witness
- mark missing accounts as inserts using the canonical empty-account RLP, while found accounts are copied into an account arena
- expose zisk_bal_account_record_array and cover present+missing accounts with a ziskemu checker

Refs #7778. Bead: evm-asm-fhsxz.2.4.2.6.6.

## Verification
- lake build EvmAsm.Codegen.Programs.BalAccountRecordArray
- scripts/codegen-zisk-bal-account-record-array-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|DEBUG' EvmAsm/Codegen/Programs.lean EvmAsm/Codegen/Programs/BalAccountRecordArray.lean scripts/codegen-zisk-bal-account-record-array-check.sh
- lake build

Authored by @pirapira; implemented by Codex