### PR TITLE
feat(eest): derive BAL records during state replay

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -334,6 +334,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_bal_account_nth_descriptor" => some ziskBalAccountNthDescriptorProbeUnit
   | "zisk_bal_account_descriptor_array" => some ziskBalAccountDescriptorArrayProbeUnit
   | "zisk_bal_account_state_root" => some ziskBalAccountStateRootProbeUnit
+  | "zisk_bal_account_state_root_auto" => some ziskBalAccountStateRootAutoProbeUnit
   | "zisk_bal_account_record_array" => some ziskBalAccountRecordArrayProbeUnit
   | "zisk_storage_root_single_slot" => some ziskStorageRootSingleSlotProbeUnit
   | "zisk_account_set_storage_root" => some ziskAccountSetStorageRootProbeUnit
@@ -1135,6 +1136,7 @@ def knownProgramNames : List String :=
    "zisk_bal_account_nth_descriptor",
    "zisk_bal_account_descriptor_array",
    "zisk_bal_account_state_root",
+   "zisk_bal_account_state_root_auto",
    "zisk_bal_account_record_array",
    "zisk_storage_root_single_slot",
    "zisk_account_set_storage_root",

--- a/EvmAsm/Codegen/Programs/BalAccountStateRoot.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountStateRoot.lean
@@ -9,6 +9,7 @@
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.BalAccountDescriptorArray
+import EvmAsm.Codegen.Programs.BalAccountRecordArray
 import EvmAsm.Codegen.Programs.MptStateRootIns
 
 namespace EvmAsm.Codegen
@@ -46,6 +47,38 @@ def balAccountStateRootFunction : String :=
   "  ld ra, 0(sp)\n" ++
   "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
   "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  addi sp, sp, 96\n" ++
+  "  ret"
+
+/-! ## bal_account_state_root_auto -- derive records + replay BAL account changes
+
+    a0 = root_hash ptr        a1 = witness ptr       a2 = witness length
+    a3 = BAL list ptr         a4 = BAL list length   a5 = n records/items
+    a6 = out root ptr         a0 (output) = 0 ok / nonzero failure. -/
+def balAccountStateRootAutoFunction : String :=
+  "bal_account_state_root_auto:\n" ++
+  "  addi sp, sp, -96\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0                   # root hash ptr\n" ++
+  "  mv s1, a1                   # witness ptr\n" ++
+  "  mv s2, a2                   # witness len\n" ++
+  "  mv s3, a3                   # BAL list ptr\n" ++
+  "  mv s4, a4                   # BAL list len\n" ++
+  "  mv s5, a5                   # n\n" ++
+  "  mv s6, a6                   # out root\n" ++
+  "  mv a0, s0; mv a1, s1; mv a2, s2; mv a3, s3; mv a4, s4; mv a5, s5\n" ++
+  "  la a6, basr_records; la a7, basr_accounts\n" ++
+  "  jal ra, bal_account_record_array\n" ++
+  "  bnez a0, .Lbasra_ret\n" ++
+  "  mv a0, s0; mv a1, s1; mv a2, s2; mv a3, s3; mv a4, s4\n" ++
+  "  la a5, basr_records; mv a6, s5; mv a7, s6\n" ++
+  "  jal ra, bal_account_state_root\n" ++
+  ".Lbasra_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
   "  addi sp, sp, 96\n" ++
   "  ret"
 
@@ -110,6 +143,7 @@ def ziskBalAccountStateRootPrologue : String :=
   rlpItemSizeFunction ++ "\n" ++
   rlpItemSpanFunction ++ "\n" ++
   msetMemcpyFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
   mptSpliceSlotFunction ++ "\n" ++
   mptLeafExtractFunction ++ "\n" ++
   mptExtensionNodeEncodeFunction ++ "\n" ++
@@ -120,10 +154,12 @@ def ziskBalAccountStateRootPrologue : String :=
   balAccountChangeValueFunction ++ "\n" ++
   balAccountChangeDescriptorFunction ++ "\n" ++
   balAccountDescriptorArrayFunction ++ "\n" ++
+  balAccountRecordArrayFunction ++ "\n" ++
   mptSetAccFunction ++ "\n" ++
   mptInsertAccFunction ++ "\n" ++
   mptStateRootInsFunction ++ "\n" ++
   balAccountStateRootFunction ++ "\n" ++
+  balAccountStateRootAutoFunction ++ "\n" ++
   ".Lbasr_pdone:"
 
 /-- Data section combines the MPT state-root driver scratch with only the
@@ -164,11 +200,65 @@ def ziskBalAccountStateRootDataSection : String :=
   "basr_desc:\n  .zero 4096\n" ++
   "basr_paths:\n  .zero 8192\n" ++
   "basr_values:\n  .zero 16384\n" ++
+  "basr_accounts:\n  .zero 16384\n" ++
+  "bara_item_off:\n  .zero 8\n" ++
+  "bara_item_len:\n  .zero 8\n" ++
+  "bara_acct_len:\n  .zero 8\n" ++
+  ".balign 8\n" ++
+  "bara_path:\n  .zero 64\n" ++
+  "bara_acct:\n  .zero 256\n" ++
+  ".balign 8\n" ++
+  "bara_empty_account:\n" ++
+  "  .byte 0xf8,0x44,0x80,0x80,0xa0\n" ++
+  "  .byte 0x56,0xe8,0x1f,0x17,0x1b,0xcc,0x55,0xa6\n" ++
+  "  .byte 0xff,0x83,0x45,0xe6,0x92,0xc0,0xf8,0x6e\n" ++
+  "  .byte 0x5b,0x48,0xe0,0x1b,0x99,0x6c,0xad,0xc0\n" ++
+  "  .byte 0x01,0x62,0x2f,0xb5,0xe3,0x63,0xb4,0x21\n" ++
+  "  .byte 0xa0\n" ++
+  "  .byte 0xc5,0xd2,0x46,0x01,0x86,0xf7,0x23,0x3c\n" ++
+  "  .byte 0x92,0x7e,0x7d,0xb2,0xdc,0xc7,0x03,0xc0\n" ++
+  "  .byte 0xe5,0x00,0xb6,0x53,0xca,0x82,0x27,0x3b\n" ++
+  "  .byte 0x7b,0xfa,0xd8,0x04,0x5d,0x85,0xa4,0x70\n" ++
+  ".balign 8\n" ++
   "basr_pad:\n  .zero 8"
 
 def ziskBalAccountStateRootProbeUnit : BuildUnit := {
   body        := NOP
   prologueAsm := ziskBalAccountStateRootPrologue
+  dataAsm     := ziskBalAccountStateRootDataSection
+}
+
+/-- `zisk_bal_account_state_root_auto`: same as `bal_account_state_root`, but
+    derives account records from the pre-state witness instead of reading them
+    from the input.
+    Input layout (file maps to INPUT+8 at 0x40000000):
+      +8  witness length (u64)
+      +16 n (u64)
+      +24 BAL list length (u64)
+      +32 root hash (32 bytes)
+      +64 BAL AccountChanges list bytes, padded to 8 bytes
+      then witness section
+    Output: OUTPUT+0 = final root, OUTPUT+32 = status. -/
+def ziskBalAccountStateRootAutoPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t0, 0x40000000\n" ++
+  "  ld a2, 8(t0)                # witness len\n" ++
+  "  ld a5, 16(t0)               # n\n" ++
+  "  ld a4, 24(t0)               # BAL list len\n" ++
+  "  addi a0, t0, 32             # root hash ptr\n" ++
+  "  addi a3, t0, 64             # BAL list ptr\n" ++
+  "  add t1, a3, a4; addi t1, t1, 7; andi t1, t1, -8\n" ++
+  "  mv a1, t1                   # witness ptr\n" ++
+  "  li a6, 0xa0010000           # out root\n" ++
+  "  jal ra, bal_account_state_root_auto\n" ++
+  "  li t0, 0xa0010020; sd a0, 0(t0)\n" ++
+  "  j .Lbasra_pdone\n" ++
+  ziskBalAccountStateRootPrologue ++ "\n" ++
+  ".Lbasra_pdone:"
+
+def ziskBalAccountStateRootAutoProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBalAccountStateRootAutoPrologue
   dataAsm     := ziskBalAccountStateRootDataSection
 }
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **495**
-- ziskemu round-trip scripts: **485** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **496**
+- ziskemu round-trip scripts: **486** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-bal-account-state-root-auto-check.sh
+++ b/scripts/codegen-zisk-bal-account-state-root-auto-check.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# codegen-zisk-bal-account-state-root-auto-check.sh -- verify BAL replay with record derivation.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else echo "ziskemu not found" >&2; exit 1; fi
+fi
+
+VDIR="$REPO_ROOT/gen-out/mpt-set"
+echo "==> generate BAL account state-root auto vector"
+uv run --directory execution-specs --quiet python3 - "$VDIR" <<'PYGEN'
+import os
+import struct
+import sys
+from ethereum.crypto.hash import keccak256
+
+outdir = sys.argv[1]
+os.makedirs(outdir, exist_ok=True)
+
+
+def minimal_be(n: int) -> bytes:
+    if n == 0:
+        return b""
+    return n.to_bytes((n.bit_length() + 7) // 8, "big")
+
+
+def rlp_len_prefix(length: int, base: int) -> bytes:
+    if length < 56:
+        return bytes([base + length])
+    l = minimal_be(length)
+    return bytes([base + 55 + len(l)]) + l
+
+
+def rlp_bytes(x: bytes) -> bytes:
+    if len(x) == 1 and x[0] < 0x80:
+        return x
+    return rlp_len_prefix(len(x), 0x80) + x
+
+
+def rlp_list(xs):
+    payload = b"".join(xs)
+    return rlp_len_prefix(len(payload), 0xc0) + payload
+
+
+def rlp_int(n: int) -> bytes:
+    return rlp_bytes(minimal_be(n))
+
+
+EMPTY_TRIE = bytes.fromhex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+EMPTY_CODE = bytes.fromhex("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+
+
+def account_rlp(nonce: int, balance: int) -> bytes:
+    return rlp_list([rlp_int(nonce), rlp_int(balance), rlp_bytes(EMPTY_TRIE), rlp_bytes(EMPTY_CODE)])
+
+
+def change_pair(index: int, value: bytes) -> bytes:
+    return rlp_list([rlp_int(index), value])
+
+
+def account_change(address: bytes, balance_changes=None, nonce_changes=None) -> bytes:
+    balance_changes = balance_changes or []
+    nonce_changes = nonce_changes or []
+    bc = [change_pair(i, rlp_int(v)) for i, v in balance_changes]
+    nc = [change_pair(i, rlp_int(v)) for i, v in nonce_changes]
+    return rlp_list([rlp_bytes(address), rlp_list([]), rlp_list([]),
+                     rlp_list(bc), rlp_list(nc), rlp_list([])])
+
+
+def account_path(address: bytes) -> list[int]:
+    out = []
+    for b in keccak256(address):
+        out.append(b >> 4)
+        out.append(b & 0x0f)
+    return out
+
+
+def hp_encode(path: list[int], is_leaf: bool) -> bytes:
+    flag = (2 if is_leaf else 0) + (1 if len(path) % 2 else 0)
+    out = bytearray()
+    if len(path) % 2:
+        out.append(flag * 16 + path[0])
+        path = path[1:]
+    else:
+        out.append(flag * 16)
+    for i in range(0, len(path), 2):
+        out.append(path[i] * 16 + path[i + 1])
+    return bytes(out)
+
+
+def leaf_node(path: list[int], value: bytes) -> bytes:
+    return rlp_list([rlp_bytes(hp_encode(path, True)), rlp_bytes(value)])
+
+
+def branch_node(slots: list[bytes], value: bytes = b"") -> bytes:
+    return rlp_len_prefix(sum(len(slot) for slot in slots) + len(rlp_bytes(value)), 0xc0) + b"".join(slots) + rlp_bytes(value)
+
+
+def node_ref(node: bytes) -> bytes:
+    if len(node) < 32:
+        return node
+    return b"\xa0" + keccak256(node)
+
+
+def ssz_section(elements):
+    out = bytearray()
+    off = 4 * len(elements)
+    for element in elements:
+        out += struct.pack("<I", off)
+        off += len(element)
+    for element in elements:
+        out += element
+    return bytes(out)
+
+
+def align8_body(body: bytearray):
+    while len(body) % 8 != 0:
+        body += b"\x00"
+
+
+def build_input(root_hash, witness, bal_list, n):
+    body = bytearray()
+    body += struct.pack("<QQQ", len(witness), n, len(bal_list))
+    body += root_hash
+    body += bal_list
+    align8_body(body)
+    body += witness
+    align8_body(body)
+    return bytes(body)
+
+
+present_addr = bytes.fromhex("c0f6dc9e5836f54caadbf59cc69346c508e1992b")
+present_path = account_path(present_addr)
+for i in range(2, 256):
+    missing_addr = i.to_bytes(20, "big")
+    missing_path = account_path(missing_addr)
+    if missing_path[0] != present_path[0]:
+        break
+else:
+    raise AssertionError("could not find distinct first nibble")
+
+old_account = account_rlp(1, 5)
+present_new = account_rlp(1, 10 ** 10)
+missing_new = account_rlp(7, 9)
+old_leaf = leaf_node(present_path[1:], old_account)
+present_leaf_new = leaf_node(present_path[1:], present_new)
+missing_leaf_new = leaf_node(missing_path[1:], missing_new)
+
+slots = [b"\x80"] * 16
+slots[present_path[0]] = node_ref(old_leaf)
+root = branch_node(slots)
+root_hash = keccak256(root)
+
+post_slots = list(slots)
+post_slots[present_path[0]] = node_ref(present_leaf_new)
+post_slots[missing_path[0]] = node_ref(missing_leaf_new)
+expected = keccak256(branch_node(post_slots))
+
+bal_list = rlp_list([
+    account_change(present_addr, balance_changes=[(1, 10 ** 10)]),
+    account_change(missing_addr, balance_changes=[(1, 9)], nonce_changes=[(1, 7)]),
+])
+with open(f"{outdir}/basra_modify_insert.input", "wb") as f:
+    f.write(build_input(root_hash, ssz_section([root, old_leaf]), bal_list, 2))
+with open(f"{outdir}/basra_modify_insert.expected", "w") as f:
+    f.write(expected.hex())
+print(f"basra_modify_insert slots={present_path[0]},{missing_path[0]} expected={expected.hex()[:16]}..")
+PYGEN
+
+echo "==> lake build codegen"
+lake build codegen >/dev/null
+
+echo "==> emit zisk_bal_account_state_root_auto probe ELF"
+lake exe codegen --program zisk_bal_account_state_root_auto --halt linux93 \
+  -o "$REPO_ROOT/gen-out/zisk_bal_account_state_root_auto"
+
+out="$VDIR/basra_modify_insert.output"
+"$ZISKEMU" -e "$REPO_ROOT/gen-out/zisk_bal_account_state_root_auto.elf" \
+  -i "$VDIR/basra_modify_insert.input" -o "$out" -n 12000000 >/dev/null 2>&1 </dev/null
+status="$(od -An -tu8 -j 32 -N 8 "$out" | tr -d ' \n')"
+actual="$(xxd -p -s 0 -l 32 "$out" | tr -d '\n')"
+expected="$(cat "$VDIR/basra_modify_insert.expected")"
+if [[ "$status" == "0" && "$actual" == "$expected" ]]; then
+  echo "  PASS   basra_modify_insert root=${actual:0:16}.."
+  echo "==> PASS: bal_account_state_root_auto matches reference"
+else
+  echo "  FAIL   basra_modify_insert status=$status"
+  echo "    expected: $expected"
+  echo "    actual:   $actual"
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add bal_account_state_root_auto to derive BAL pre-account records from root/witness before replaying account changes
- expose zisk_bal_account_state_root_auto through the codegen registry
- add a ziskemu branch-trie vector that modifies one existing account and inserts one missing account through BAL replay

Bead: evm-asm-fhsxz.2.4.2.6.6.

## Verification
- lake build EvmAsm.Codegen.Programs.BalAccountStateRoot
- scripts/codegen-zisk-bal-account-state-root-auto-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|DEBUG' EvmAsm/Codegen/Programs.lean EvmAsm/Codegen/Programs/BalAccountStateRoot.lean scripts/codegen-zisk-bal-account-state-root-auto-check.sh
- lake build

Authored by @pirapira; implemented by Codex