### PR TITLE
feat(eest): locate BAL section for replay

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -326,6 +326,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_single_leaf_trie_root" => some ziskSingleLeafTrieRootProbeUnit
   | "zisk_system_write_descriptors" => some ziskSystemWriteDescriptorsProbeUnit
   | "zisk_bal_gas_valid"         => some ziskBalGasValidProbeUnit
+  | "zisk_bal_section_info"      => some ziskBalSectionInfoProbeUnit
   | "zisk_bal_account_path"      => some ziskBalAccountPathProbeUnit
   | "zisk_bal_account_post_fields" => some ziskBalAccountPostFieldsProbeUnit
   | "zisk_bal_account_apply_post_fields" => some ziskBalAccountApplyPostFieldsProbeUnit
@@ -1128,6 +1129,7 @@ def knownProgramNames : List String :=
    "zisk_single_leaf_trie_root",
    "zisk_system_write_descriptors",
    "zisk_bal_gas_valid",
+   "zisk_bal_section_info",
    "zisk_bal_account_path",
    "zisk_bal_account_post_fields",
    "zisk_bal_account_apply_post_fields",

--- a/EvmAsm/Codegen/Programs/BalGasValid.lean
+++ b/EvmAsm/Codegen/Programs/BalGasValid.lean
@@ -115,6 +115,61 @@ def bgvU64leFunction : String :=
   ".Lbgv64d:\n" ++
   "  mv a0, t0; ret"
 
+/-! ## bal_section_info -- locate BAL RLP inside an SszStatelessInput.
+    a0 = SSZ_BASE   a1 = out BAL ptr   a2 = out BAL len   a3 = out account count
+    a0 (output) = 0 ok / 1 parse error. -/
+def balSectionInfoFunction : String :=
+  "bal_section_info:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp)\n" ++
+  "  mv s0, a0                   # SSZ_BASE\n" ++
+  "  mv s3, a1                   # out ptr cell\n" ++
+  "  mv s4, a2                   # out len cell\n" ++
+  "  mv s5, a3                   # out count cell\n" ++
+  "  addi s1, s0, 16             # NPR = SSZ_BASE+16\n" ++
+  "  addi s2, s0, 60             # exec_payload = SSZ_BASE+60\n" ++
+  "  addi a0, s2, 528; jal ra, bgv_u32le\n" ++
+  "  add t0, s2, a0              # bal_start\n" ++
+  "  sd t0, 0(s3)\n" ++
+  "  addi a0, s1, 4; jal ra, bgv_u32le\n" ++
+  "  add t1, s1, a0              # bal_end\n" ++
+  "  ld t0, 0(s3); sub t1, t1, t0\n" ++
+  "  sd t1, 0(s4)\n" ++
+  "  mv a0, t0; mv a1, t1; mv a2, s5\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lbsi_fail\n" ++
+  "  li a0, 0; j .Lbsi_ret\n" ++
+  ".Lbsi_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lbsi_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_bal_section_info`: probe. Fed the SAME `-i` input as the guest.
+    Output: OUTPUT+0 = status, OUTPUT+8 = BAL ptr, OUTPUT+16 = BAL len,
+    OUTPUT+24 = account count. -/
+def ziskBalSectionInfoPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a0, 0x40000000; addi a0, a0, 18    # SSZ_BASE\n" ++
+  "  li a1, 0xa0010008\n" ++
+  "  li a2, 0xa0010010\n" ++
+  "  li a3, 0xa0010018\n" ++
+  "  jal ra, bal_section_info\n" ++
+  "  li t0, 0xa0010000; sd a0, 0(t0)\n" ++
+  "  j .Lbsi_pdone\n" ++
+  rlpItemSizeFunction ++ "\n" ++
+  rlpItemSpanFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  bgvU32leFunction ++ "\n" ++
+  bgvU64leFunction ++ "\n" ++
+  balSectionInfoFunction ++ "\n" ++
+  ".Lbsi_pdone:"
+
 /-- `zisk_bal_gas_valid`: probe. Fed the SAME `-i` input as the guest. Navigates
     to the block_access_list section + block_gas_limit and runs bal_gas_valid.
     Output: OUTPUT+0 = result (0 valid / 1 exceeded / 2 parse error). -/
@@ -156,6 +211,12 @@ def ziskBalGasValidDataSection : String :=
 def ziskBalGasValidProbeUnit : BuildUnit := {
   body        := NOP
   prologueAsm := ziskBalGasValidPrologue
+  dataAsm     := ziskBalGasValidDataSection
+}
+
+def ziskBalSectionInfoProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBalSectionInfoPrologue
   dataAsm     := ziskBalGasValidDataSection
 }
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **496**
-- ziskemu round-trip scripts: **486** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **497**
+- ziskemu round-trip scripts: **487** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-bal-section-info-check.sh
+++ b/scripts/codegen-zisk-bal-section-info-check.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# codegen-zisk-bal-section-info-check.sh -- verify BAL SSZ locator on real EEST inputs.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+TAG="${EEST_FIXTURE_TAG:-zkevm@v0.4.0}"
+FILTER="${1:-block_access_lists_eip4895}"
+LIMIT="${2:-16}"
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else echo "ziskemu not found" >&2; exit 1; fi
+fi
+FX="${EEST_FIXTURES_DIR:-$REPO_ROOT/gen-out/eest-fixtures/$TAG/fixtures/fixtures}"
+[[ -d "$FX" ]] || { echo "fixtures not found at $FX" >&2; exit 1; }
+RUN="$REPO_ROOT/gen-out/bsi-check"; rm -rf "$RUN"; mkdir -p "$RUN"
+
+echo "==> build + emit probe + convert fixtures"
+lake build codegen >/dev/null
+lake exe codegen --program zisk_bal_section_info --halt linux93 \
+  -o "$REPO_ROOT/gen-out/zisk_bal_section_info" >/dev/null
+python3 scripts/eest-stateless-to-input.py --fixtures-dir "$FX" --out-dir "$RUN" \
+  --limit "$LIMIT" --filter "$FILTER" >/dev/null
+MAN="$RUN/manifest.tsv"; [[ -s "$MAN" ]] || { echo "no fixtures" >&2; exit 1; }
+
+uv run --directory execution-specs --quiet python3 - "$MAN" "$REPO_ROOT/scripts" "$REPO_ROOT" > "$RUN/expected.tsv" <<'PY'
+import os, sys
+sys.path.insert(0, sys.argv[2])
+import rlp
+repo = sys.argv[3]
+base = 0x40000000 + 18
+for line in open(sys.argv[1]):
+    fields = line.rstrip("\n").split("\t")
+    if len(fields) < 2:
+        continue
+    label, inp = fields[0], fields[1]
+    if not os.path.isabs(inp):
+        inp = os.path.join(repo, inp)
+    try:
+        data = open(inp, "rb").read()
+        length = int.from_bytes(data[0:8], "little")
+        outer = data[8:8 + length][2:]
+        u32 = lambda b, o: int.from_bytes(b[o:o + 4], "little")
+        ep = outer[60:]
+        npr = outer[16:]
+        bal_off = u32(ep, 528)
+        bal_end_rel = u32(npr, 4) - 44
+        bal = ep[bal_off:bal_end_rel]
+        ptr = base + 60 + bal_off
+        print(f"{label}\t{ptr}\t{len(bal)}\t{len(rlp.decode(bal))}")
+    except Exception:
+        print(f"{label}\tERR\tERR\tERR")
+PY
+
+declare -A INP REL
+while IFS=$'\t' read -r label inp expected status invalid rel; do
+  INP[$label]="$inp"; REL[$label]="$rel"
+done < "$MAN"
+
+pass=0; fail=0
+while IFS=$'\t' read -r label exp_ptr exp_len exp_count; do
+  [[ "$exp_ptr" == "ERR" ]] && continue
+  inp="${INP[$label]:-}"; [[ -z "$inp" ]] && continue
+  out="$RUN/$label.out"
+  "$ZISKEMU" -e gen-out/zisk_bal_section_info.elf -i "$inp" -o "$out" -n 5000000 >/dev/null 2>&1 </dev/null || {
+    echo "  ERROR  $label"; fail=$((fail+1)); continue
+  }
+  st="$(od -An -tu8 -j 0 -N 8 "$out" | tr -d ' \n')"
+  ptr="$(od -An -tu8 -j 8 -N 8 "$out" | tr -d ' \n')"
+  len="$(od -An -tu8 -j 16 -N 8 "$out" | tr -d ' \n')"
+  count="$(od -An -tu8 -j 24 -N 8 "$out" | tr -d ' \n')"
+  if [[ "$st" == "0" && "$ptr" == "$exp_ptr" && "$len" == "$exp_len" && "$count" == "$exp_count" ]]; then
+    echo "  PASS   $(basename "${REL[$label]}") len=$len count=$count"
+    pass=$((pass+1))
+  else
+    echo "  FAIL   $label status=$st ptr=$ptr len=$len count=$count"
+    echo "    expected ptr=$exp_ptr len=$exp_len count=$exp_count ($(basename "${REL[$label]}"))"
+    fail=$((fail+1))
+  fi
+done < "$RUN/expected.tsv"
+
+echo "bal_section_info: pass=$pass fail=$fail"
+[[ "$fail" -eq 0 && "$pass" -gt 0 ]] && echo "==> PASS: bal_section_info locates BAL RLP" \
+  || { echo "==> FAIL"; exit 1; }


### PR DESCRIPTION
## Summary
- add bal_section_info to locate the block_access_list RLP inside stateless SSZ input
- return BAL pointer, byte length, and account count for the upcoming BlockVerdict BAL replay call
- expose zisk_bal_section_info and verify it on real EIP-4895 BAL fixtures

Refs #7780. Bead: evm-asm-fhsxz.2.4.2.6.6.

## Verification
- lake build EvmAsm.Codegen.Programs.BalGasValid
- scripts/codegen-zisk-bal-section-info-check.sh block_access_lists_eip4895 8
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|DEBUG' EvmAsm/Codegen/Programs.lean EvmAsm/Codegen/Programs/BalGasValid.lean scripts/codegen-zisk-bal-section-info-check.sh
- lake build

Authored by @pirapira; implemented by Codex