### PR TITLE
feat(eest): add generic BAL storage replay

### DIFF
--- a/EvmAsm/Codegen/Programs/AccountApplyStorage.lean
+++ b/EvmAsm/Codegen/Programs/AccountApplyStorage.lean
@@ -28,6 +28,8 @@ import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.MptEncode
 import EvmAsm.Codegen.Programs.MptSet
 import EvmAsm.Codegen.Programs.StorageWrite
+import EvmAsm.Codegen.Programs.MptSetAcc
+import EvmAsm.Codegen.Programs.MptInsertAcc
 
 namespace EvmAsm.Codegen
 
@@ -86,6 +88,89 @@ def accountApplyStorageSlotFunction : String :=
   "  addi sp, sp, 64\n" ++
   "  ret"
 
+
+/-! ## account_apply_storage_slot_acc
+    Same external ABI as `account_apply_storage_slot`, but handles non-empty
+    prior storage roots by updating the storage trie through `mpt_set_acc`.
+    The caller must set `aps_witness_ptr` / `aps_witness_len` to the witness
+    section containing the storage trie nodes before calling this helper. -/
+def accountApplyStorageSlotAccFunction : String :=
+  "account_apply_storage_slot_acc:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0                   # account\n" ++
+  "  mv s1, a1                   # account len\n" ++
+  "  mv s2, a2                   # slot_key\n" ++
+  "  mv s3, a3                   # value\n" ++
+  "  mv s4, a4                   # value len\n" ++
+  "  mv s5, a5                   # out\n" ++
+  "  mv s6, a6                   # out len\n" ++
+  "  # field 2 = storageRoot -> aps_off / aps_len\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 2; la a3, aps_off; la a4, aps_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lapsa_parsefail\n" ++
+  "  la t0, aps_len; ld t1, 0(t0); li t2, 32; bne t1, t2, .Lapsa_conservative\n" ++
+  "  la t0, aps_off; ld t1, 0(t0); add t1, s0, t1   # storageRoot ptr\n" ++
+  "  la t2, aps_empty_root; li t3, 32\n" ++
+  ".Lapsa_cmp:\n" ++
+  "  beqz t3, .Lapsa_empty\n" ++
+  "  lbu t4, 0(t1); lbu t5, 0(t2); bne t4, t5, .Lapsa_nonempty\n" ++
+  "  addi t1, t1, 1; addi t2, t2, 1; addi t3, t3, -1; j .Lapsa_cmp\n" ++
+  ".Lapsa_empty:\n" ++
+  "  mv a0, s2; mv a1, s3; mv a2, s4; la a3, aps_newsroot\n" ++
+  "  jal ra, storage_root_single_slot\n" ++
+  "  j .Lapsa_set_account\n" ++
+  ".Lapsa_nonempty:\n" ++
+  "  # Need caller-provided witness for the existing storage trie.\n" ++
+  "  la t0, aps_witness_ptr; ld t0, 0(t0); beqz t0, .Lapsa_conservative\n" ++
+  "  # RLP(value) is the leaf value stored in the storage trie.\n" ++
+  "  mv a0, s3; mv a1, s4; la a2, srss_rlpval; la a3, srss_rlpval_len\n" ++
+  "  jal ra, rlp_encode_bytes\n" ++
+  "  # Storage path = nibbles(keccak256(slot_key)).\n" ++
+  "  mv a0, s2; li a1, 32; la a2, srss_key\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  la a0, srss_key; li a1, 32; la a2, aps_path\n" ++
+  "  jal ra, bytes_to_nibbles\n" ++
+  "  # Update the non-empty storage trie through mpt_set_acc.\n" ++
+  "  la t0, mset_db_count; sd zero, 0(t0)\n" ++
+  "  la t0, mset_db_data; la t1, mset_db_top; sd t0, 0(t1)\n" ++
+  "  la t0, aps_off; ld t0, 0(t0); add a0, s0, t0\n" ++
+  "  la t0, aps_witness_ptr; ld a1, 0(t0)\n" ++
+  "  la t0, aps_witness_len; ld a2, 0(t0)\n" ++
+  "  la a3, aps_path; li a4, 64\n" ++
+  "  la a5, srss_rlpval; la t0, srss_rlpval_len; ld a6, 0(t0); la a7, aps_newsroot\n" ++
+  "  jal ra, mpt_set_acc\n" ++
+  "  beqz a0, .Lapsa_set_account\n" ++
+  "  # If the slot was absent, insert it into the existing storage trie.\n" ++
+  "  la t0, mset_db_count; sd zero, 0(t0)\n" ++
+  "  la t0, mset_db_data; la t1, mset_db_top; sd t0, 0(t1)\n" ++
+  "  la t0, aps_off; ld t0, 0(t0); add a0, s0, t0\n" ++
+  "  la t0, aps_witness_ptr; ld a1, 0(t0)\n" ++
+  "  la t0, aps_witness_len; ld a2, 0(t0)\n" ++
+  "  la a3, aps_path; li a4, 64\n" ++
+  "  la a5, srss_rlpval; la t0, srss_rlpval_len; ld a6, 0(t0); la a7, aps_newsroot\n" ++
+  "  jal ra, mpt_insert_acc\n" ++
+  "  bnez a0, .Lapsa_conservative\n" ++
+  ".Lapsa_set_account:\n" ++
+  "  mv a0, s0; mv a1, s1; la a2, aps_newsroot; mv a3, s5; mv a4, s6\n" ++
+  "  jal ra, account_set_storage_root\n" ++
+  "  bnez a0, .Lapsa_parsefail\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lapsa_ret\n" ++
+  ".Lapsa_conservative:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lapsa_ret\n" ++
+  ".Lapsa_parsefail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lapsa_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
 /-! ### zisk_account_apply_storage_slot probe.
     Input (file -> INPUT+8): file[0:8]=account_len, file[8:16]=value_len,
       file[16:48]=slot_key(32B), file[48:80]=value(<=32B), file[128:]=account RLP.
@@ -123,6 +208,15 @@ def ziskAccountApplyStorageSlotPrologue : String :=
   mptSpliceSlotFunction ++ "\n" ++
   accountSetStorageRootFunction ++ "\n" ++
   accountApplyStorageSlotFunction ++ "\n" ++
+  accountApplyStorageSlotAccFunction ++ "\n" ++
+  mptLeafNodeEncodeFromNibblesFunction ++ "\n" ++
+  mptNodeSlotEncodeFunction ++ "\n" ++
+  nodeDbAppendFunction ++ "\n" ++
+  nodeDbLookupFunction ++ "\n" ++
+  mptNodeResolveFunction ++ "\n" ++
+  mptSetRecordWalkDbFunction ++ "\n" ++
+  mptSetAccFunction ++ "\n" ++
+  mptInsertAccFunction ++ "\n" ++
   ".Laps_pdone:"
 
 def ziskAccountApplyStorageSlotDataSection : String :=
@@ -158,8 +252,11 @@ def ziskAccountApplyStorageSlotDataSection : String :=
   "aps_off:\n  .zero 8\n" ++
   "aps_len:\n  .zero 8\n" ++
   "aps_out_len:\n  .zero 8\n" ++
+  "aps_witness_ptr:\n  .zero 8\n" ++
+  "aps_witness_len:\n  .zero 8\n" ++
   ".balign 32\n" ++
   "aps_newsroot:\n  .zero 32\n" ++
+  "aps_path:\n  .zero 64\n" ++
   "aps_empty_root:\n" ++
   "  .byte 0x56, 0xe8, 0x1f, 0x17, 0x1b, 0xcc, 0x55, 0xa6\n" ++
   "  .byte 0xff, 0x83, 0x45, 0xe6, 0x92, 0xc0, 0xf8, 0x6e\n" ++

--- a/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
@@ -95,14 +95,19 @@ def balAccountApplyPostFieldsFunction : String :=
   "  la a3, baap_item_off; la a4, baap_item_len\n" ++
   "  jal ra, rlp_list_nth_item\n" ++
   "  bnez a0, .Lbaap_fail\n" ++
-  "  la t0, baap_item_len; ld t0, 0(t0); li t1, 32; bgtu t0, t1, .Lbaap_fail\n" ++
+  "  la t0, baap_sc_ptr; ld t0, 0(t0); la t1, baap_item_off; ld t1, 0(t1); add t0, t0, t1\n" ++
+  "  la t1, baap_item_len; ld t1, 0(t1); la t2, baap_code_item_ptr; sd t0, 0(t2)\n" ++
+  "  mv a0, t0; mv a1, t1; li a2, 0; la a3, baap_val_off; la a4, baap_val_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbaap_fail\n" ++
+  "  la t0, baap_val_len; ld t0, 0(t0); li t1, 32; bgtu t0, t1, .Lbaap_fail\n" ++
   "  la t0, baap_slot; li t1, 0\n" ++
   ".Lbaap_slot_zero:\n" ++
   "  li t2, 32; beq t1, t2, .Lbaap_slot_zero_done\n" ++
   "  add t3, t0, t1; sb zero, 0(t3); addi t1, t1, 1; j .Lbaap_slot_zero\n" ++
   ".Lbaap_slot_zero_done:\n" ++
-  "  la t0, baap_item_len; ld t1, 0(t0); li t2, 32; sub t2, t2, t1; la t3, baap_slot; add t3, t3, t2\n" ++
-  "  la t0, baap_sc_ptr; ld t0, 0(t0); la t2, baap_item_off; ld t2, 0(t2); add t0, t0, t2\n" ++
+  "  la t0, baap_val_len; ld t1, 0(t0); li t2, 32; sub t2, t2, t1; la t3, baap_slot; add t3, t3, t2\n" ++
+  "  la t0, baap_code_item_ptr; ld t0, 0(t0); la t2, baap_val_off; ld t2, 0(t2); add t0, t0, t2\n" ++
   ".Lbaap_slot_cp:\n" ++
   "  beqz t1, .Lbaap_slot_done\n" ++
   "  lbu t2, 0(t0); sb t2, 0(t3); addi t0, t0, 1; addi t3, t3, 1; addi t1, t1, -1; j .Lbaap_slot_cp\n" ++
@@ -130,7 +135,7 @@ def balAccountApplyPostFieldsFunction : String :=
   "  la t1, baap_slot_changes_ptr; ld t1, 0(t1); la t2, baap_item_off; ld t2, 0(t2); add t1, t1, t2\n" ++
   "  la t2, baap_val_off; ld t2, 0(t2); add a3, t1, t2\n" ++
   "  mv a0, s6; mv a1, s7; la a2, baap_slot; mv a4, t0; la a5, baap_tmp2; la a6, baap_tmp2_len\n" ++
-  "  jal ra, account_apply_storage_slot\n" ++
+  "  jal ra, account_apply_storage_slot_acc\n" ++
   "  bnez a0, .Lbaap_fail\n" ++
   "  la s6, baap_tmp2; la t0, baap_tmp2_len; ld s7, 0(t0)\n" ++
   "  # Apply nonce first if present.\n" ++
@@ -202,6 +207,8 @@ def ziskBalAccountApplyPostFieldsPrologue : String :=
   mptSpliceSlotFunction ++ "\n" ++
   accountSetStorageRootFunction ++ "\n" ++
   accountApplyStorageSlotFunction ++ "\n" ++
+  accountApplyStorageSlotAccFunction ++ "\n" ++
+  mptInsertAccFunction ++ "\n" ++
   accountSetUintFieldFunction ++ "\n" ++
   balAccountPostFieldsFunction ++ "\n" ++
   balAccountApplyPostFieldsFunction ++ "\n" ++
@@ -228,8 +235,11 @@ def ziskBalAccountApplyPostFieldsDataSection : String :=
   "asr_ref:\n  .zero 40\n" ++
   "aps_off:\n  .zero 8\n" ++
   "aps_len:\n  .zero 8\n" ++
+  "aps_witness_ptr:\n  .zero 8\n" ++
+  "aps_witness_len:\n  .zero 8\n" ++
   ".balign 32\n" ++
   "aps_newsroot:\n  .zero 32\n" ++
+  "aps_path:\n  .zero 64\n" ++
   "aps_empty_root:\n" ++
   "  .byte 0x56, 0xe8, 0x1f, 0x17, 0x1b, 0xcc, 0x55, 0xa6\n" ++
   "  .byte 0xff, 0x83, 0x45, 0xe6, 0x92, 0xc0, 0xf8, 0x6e\n" ++

--- a/EvmAsm/Codegen/Programs/BalAccountStateRoot.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountStateRoot.lean
@@ -37,6 +37,7 @@ def balAccountStateRootFunction : String :=
   "  mv s3, a5                   # account records\n" ++
   "  mv s4, a6                   # n\n" ++
   "  mv s5, a7                   # out root\n" ++
+  "  la t0, aps_witness_ptr; sd s1, 0(t0); la t0, aps_witness_len; sd s2, 0(t0)\n" ++
   "  mv a0, a3; mv a1, a4; mv a2, s3; mv a3, s4\n" ++
   "  la a4, basr_desc; la a5, basr_paths; la a6, basr_values\n" ++
   "  jal ra, bal_account_descriptor_array\n" ++
@@ -68,6 +69,7 @@ def balAccountStateRootAutoFunction : String :=
   "  mv s4, a4                   # BAL list len\n" ++
   "  mv s5, a5                   # n\n" ++
   "  mv s6, a6                   # out root\n" ++
+  "  la t0, aps_witness_ptr; sd s1, 0(t0); la t0, aps_witness_len; sd s2, 0(t0)\n" ++
   "  mv a0, s0; mv a1, s1; mv a2, s2; mv a3, s3; mv a4, s4; mv a5, s5\n" ++
   "  la a6, basr_records; la a7, basr_accounts\n" ++
   "  jal ra, bal_account_record_array\n" ++
@@ -149,6 +151,7 @@ def ziskBalAccountStateRootPrologue : String :=
   storageRootSingleSlotFunction ++ "\n" ++
   accountSetStorageRootFunction ++ "\n" ++
   accountApplyStorageSlotFunction ++ "\n" ++
+  accountApplyStorageSlotAccFunction ++ "\n" ++
   mptLeafExtractFunction ++ "\n" ++
   mptExtensionNodeEncodeFunction ++ "\n" ++
   accountSetUintFieldFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -429,6 +429,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   storageRootSingleSlotFunction ++ "\n" ++
   accountSetStorageRootFunction ++ "\n" ++
   accountApplyStorageSlotFunction ++ "\n" ++
+  accountApplyStorageSlotAccFunction ++ "\n" ++
   swdReadU64leFunction ++ "\n" ++
   swdWriteBe32U64Function ++ "\n" ++
   swdWriteBe8Function ++ "\n" ++
@@ -476,8 +477,11 @@ def ziskStatelessVerdictV2DataSection : String :=
   "asr_ref:\n  .zero 40\n" ++
   "aps_off:\n  .zero 8\n" ++
   "aps_len:\n  .zero 8\n" ++
+  "aps_witness_ptr:\n  .zero 8\n" ++
+  "aps_witness_len:\n  .zero 8\n" ++
   ".balign 32\n" ++
   "aps_newsroot:\n  .zero 32\n" ++
+  "aps_path:\n  .zero 64\n" ++
   "aps_empty_root:\n" ++
   "  .byte 0x56, 0xe8, 0x1f, 0x17, 0x1b, 0xcc, 0x55, 0xa6\n" ++
   "  .byte 0xff, 0x83, 0x45, 0xe6, 0x92, 0xc0, 0xf8, 0x6e\n" ++
@@ -764,6 +768,7 @@ def statelessVerdictV2GuestClosure : String :=
   storageRootSingleSlotFunction ++ "\n" ++
   accountSetStorageRootFunction ++ "\n" ++
   accountApplyStorageSlotFunction ++ "\n" ++
+  accountApplyStorageSlotAccFunction ++ "\n" ++
   swdReadU64leFunction ++ "\n" ++
   swdWriteBe32U64Function ++ "\n" ++
   swdWriteBe8Function ++ "\n" ++


### PR DESCRIPTION
## Summary
- add account_apply_storage_slot_acc for non-empty storage roots using mpt_set_acc, with mpt_insert_acc fallback for absent slots
- thread the BAL state witness into the storage replay helper through existing scratch labels
- fix BAL storageChanges slot parsing to extract StorageChange field 0 rather than treating the whole item as slot bytes

## Tests
- lake build EvmAsm.Codegen.Programs.AccountApplyStorage
- lake build EvmAsm.Codegen.Programs.BalAccountApplyPostFields
- lake build EvmAsm.Codegen.Programs.BlockVerdict
- lake build codegen
- lake exe codegen --program zisk_stateless_verdict_v2 --halt linux93 -o gen-out/zisk_stateless_verdict_v2
- scripts/codegen-eest-stateless-check.sh --all --filter block_access_lists_eip4895 --steps 200000000 --min-full 31 (31/32 full, 32/32 root)
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "sorry|admit|TODO|dbg_trace|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Codegen/Programs/AccountApplyStorage.lean EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean EvmAsm/Codegen/Programs/BalAccountStateRoot.lean EvmAsm/Codegen/Programs/BlockVerdict.lean
- lake build

Remaining focused BAL failure: bal_withdrawal_and_state_access_same_account still returns successful_validation=0; this PR adds the generic storage replay substrate and fixes slot parsing, but does not yet close that final fixture.

Authored by @pirapira; implemented by Codex.