### PR TITLE
fix(eest): add BAL storage replay probe data

### DIFF
--- a/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
@@ -14,6 +14,7 @@ import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.AccountBalance
 import EvmAsm.Codegen.Programs.AccountApplyStorage
 import EvmAsm.Codegen.Programs.BalAccountPostFields
+import EvmAsm.Codegen.Programs.MptStateRootIns
 
 namespace EvmAsm.Codegen
 
@@ -199,6 +200,18 @@ def ziskBalAccountApplyPostFieldsPrologue : String :=
   bytesToNibblesFunction ++ "\n" ++
   hpEncodeNibblesFunction ++ "\n" ++
   zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  nodeDbLookupFunction ++ "\n" ++
+  nodeDbAppendFunction ++ "\n" ++
+  mptNodeResolveFunction ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  mptSetRecordWalkDbFunction ++ "\n" ++
+  mptInsertWalkDbFunction ++ "\n" ++
+  mptLeafNodeEncodeFromNibblesFunction ++ "\n" ++
+  mptNodeSlotEncodeFunction ++ "\n" ++
+  mptLeafExtractFunction ++ "\n" ++
+  mptExtensionNodeEncodeFunction ++ "\n" ++
   singleLeafTrieRootFunction ++ "\n" ++
   storageRootSingleSlotFunction ++ "\n" ++
   rlpItemSizeFunction ++ "\n" ++
@@ -208,6 +221,7 @@ def ziskBalAccountApplyPostFieldsPrologue : String :=
   accountSetStorageRootFunction ++ "\n" ++
   accountApplyStorageSlotFunction ++ "\n" ++
   accountApplyStorageSlotAccFunction ++ "\n" ++
+  mptSetAccFunction ++ "\n" ++
   mptInsertAccFunction ++ "\n" ++
   accountSetUintFieldFunction ++ "\n" ++
   balAccountPostFieldsFunction ++ "\n" ++
@@ -215,8 +229,16 @@ def ziskBalAccountApplyPostFieldsPrologue : String :=
   ".Lbaap_pdone:"
 
 def ziskBalAccountApplyPostFieldsDataSection : String :=
-  ziskAccountAddBalanceDataSection ++ "\n" ++
+  ziskMptStateRootInsDataSection ++ "\n" ++
   ziskBalAccountPostFieldsDataSection ++ "\n" ++
+  ".balign 8\n" ++
+  "aab_bal_off:\n  .zero 8\n" ++
+  "aab_bal_len:\n  .zero 8\n" ++
+  "aab_enc_len:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aab_bal32:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "aab_enc:\n  .zero 64\n" ++
   ".balign 8\n" ++
   "sltr_field_len:\n  .zero 8\n" ++
   "sltr_nibble_count:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BalAccountStateRoot.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountStateRoot.lean
@@ -187,6 +187,34 @@ def ziskBalAccountStateRootDataSection : String :=
   "bpf_item_ptr:\n  .zero 8\n" ++
   "bpf_val_off:\n  .zero 8\n" ++
   "bpf_val_len:\n  .zero 8\n" ++
+  ".balign 8\n" ++
+  "sltr_field_len:\n  .zero 8\n" ++
+  "sltr_nibble_count:\n  .zero 8\n" ++
+  "sltr_hp_len:\n  .zero 8\n" ++
+  "sltr_cursor:\n  .zero 8\n" ++
+  "sltr_total_payload:\n  .zero 8\n" ++
+  "sltr_nibbles:\n  .zero 2048\n" ++
+  "sltr_hp_buf:\n  .zero 1024\n" ++
+  "sltr_payload_buf:\n  .zero 16384\n" ++
+  "sltr_node_buf:\n  .zero 16384\n" ++
+  ".balign 32\n" ++
+  "srss_key:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "srss_rlpval:\n  .zero 40\n" ++
+  "srss_rlpval_len:\n  .zero 8\n" ++
+  "asr_ref:\n  .zero 40\n" ++
+  "aps_off:\n  .zero 8\n" ++
+  "aps_len:\n  .zero 8\n" ++
+  "aps_witness_ptr:\n  .zero 8\n" ++
+  "aps_witness_len:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aps_newsroot:\n  .zero 32\n" ++
+  "aps_path:\n  .zero 64\n" ++
+  "aps_empty_root:\n" ++
+  "  .byte 0x56, 0xe8, 0x1f, 0x17, 0x1b, 0xcc, 0x55, 0xa6\n" ++
+  "  .byte 0xff, 0x83, 0x45, 0xe6, 0x92, 0xc0, 0xf8, 0x6e\n" ++
+  "  .byte 0x5b, 0x48, 0xe0, 0x1b, 0x99, 0x6c, 0xad, 0xc0\n" ++
+  "  .byte 0x01, 0x62, 0x2f, 0xb5, 0xe3, 0x63, 0xb4, 0x21\n" ++
   "baap_bal_len:\n  .zero 8\n" ++
   "baap_nonce_len:\n  .zero 8\n" ++
   "baap_tmp_len:\n  .zero 8\n" ++


### PR DESCRIPTION
## Summary
- add the storage-replay scratch labels needed by `zisk_bal_account_state_root_auto`
- wire the standalone `zisk_bal_account_apply_post_fields` closure to the full MPT insert/set dependency set
- switch the apply-post-fields probe data to the shared MPT state-root insert substrate and add only BAL/account-specific labels on top

## Tests
- `lake build EvmAsm.Codegen.Programs.BalAccountApplyPostFields`
- `lake build EvmAsm.Codegen.Programs.BalAccountStateRoot`
- `lake build codegen`
- `lake exe codegen --program zisk_bal_account_apply_post_fields --halt linux93 -o gen-out/zisk_bal_account_apply_post_fields`
- `lake exe codegen --program zisk_bal_account_state_root_auto --halt linux93 -o gen-out/zisk_bal_account_state_root_auto`
- `lake exe codegen --program zisk_stateless_verdict_v2 --halt linux93 -o gen-out/zisk_stateless_verdict_v2`
- `scripts/codegen-zisk-bal-account-apply-post-fields-check.sh`
- `scripts/codegen-zisk-bal-account-state-root-auto-check.sh`
- `scripts/codegen-eest-stateless-check.sh --all --filter block_access_lists_eip4895 --steps 200000000 --min-full 31` (31/32 full, 32/32 root; remaining known failure is `bal_withdrawal_and_state_access_same_account` successful_validation byte)
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- touched-file forbidden marker scan
- `git diff --check`
- `lake build`
