### PR TITLE
fix(eest): replay BAL storage in block verdict

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -123,6 +123,10 @@ def blockStateRootFunction : String :=
   "  la t0, bsr_bal_start; ld a3, 0(t0); la t0, bsr_bal_len; ld a4, 0(t0); mv a5, t6\n" ++
   "  la a6, basr_records; la a7, basr_accounts\n" ++
   "  jal ra, bal_account_record_array; bnez a0, .Lbsr_cons\n" ++
+  "  # `bal_account_apply_post_fields` may replay BAL storage changes through\n" ++
+  "  # `account_apply_storage_slot_acc`, which reads the shared witness globals.\n" ++
+  "  la t0, bsr_wit_p; ld t1, 0(t0); la t0, aps_witness_ptr; sd t1, 0(t0)\n" ++
+  "  la t0, bsr_wl_v;  ld t1, 0(t0); la t0, aps_witness_len; sd t1, 0(t0)\n" ++
   "  la t0, bsr_bal_start; ld a0, 0(t0); la t0, bsr_bal_len; ld a1, 0(t0); la a2, basr_records\n" ++
   "  la t0, bsr_bal_count; ld a3, 0(t0); la a4, basr_desc; la a5, basr_paths; la a6, basr_values\n" ++
   "  jal ra, bal_account_descriptor_array; bnez a0, .Lbsr_cons\n" ++


### PR DESCRIPTION
## Summary
- initialize the BAL storage replay witness globals in `block_state_root` before direct descriptor-array replay
- fixes `bal_withdrawal_and_state_access_same_account`, where block-level BAL replay used `account_apply_storage_slot_acc` without the current witness pointer/length
- brings the focused `block_access_lists_eip4895` EEST selection to 32/32 full matches

Refs #7788. Bead: evm-asm-fhsxz.2.4.2.6.6.

Authored by @pirapira; implemented by Codex.

## Tests
- `lake build EvmAsm.Codegen.Programs.BlockVerdict`
- `lake exe codegen --program stateless_guest --halt linux93 -o gen-out/stateless_guest`
- previously failing fixture `bal_withdrawal_and_state_access_same_account` now byte-matches the expected 105-byte output
- `lake exe codegen --program zisk_stateless_verdict_v2 --halt linux93 -o gen-out/zisk_stateless_verdict_v2`
- `scripts/codegen-eest-stateless-check.sh --all --filter block_access_lists_eip4895 --steps 200000000 --min-full 32`
- `lake build codegen`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- touched-file forbidden marker scan
- `git diff --check`
- `lake build`
