### PR TITLE
feat(eest): handle account trie extension inserts

### DIFF
--- a/EvmAsm/Codegen/Programs/MptInsertAcc.lean
+++ b/EvmAsm/Codegen/Programs/MptInsertAcc.lean
@@ -14,8 +14,7 @@
       so the next change can resolve it).
 
   Supported cases (sound for 64-nibble account paths): EMPTY_TRIE,
-  BRANCH_EMPTY_SLOT, LEAF_SPLIT. EXTENSION_SPLIT stays conservative (status 1
-  -> caller MISS, never a false positive). The node DB (mset_db_*) is global
+  BRANCH_EMPTY_SLOT, LEAF_SPLIT, EXTENSION_SPLIT. The node DB (mset_db_*) is global
   and reset by the caller (mpt_state_root / the probe) before the first change.
 -/
 
@@ -60,7 +59,8 @@ def mptInsertAccFunction : String :=
   "  li t2, 3; beq t1, t2, .Lacc_empty\n" ++
   "  li t2, 0; beq t1, t2, .Lacc_branch_empty\n" ++
   "  li t2, 1; beq t1, t2, .Lacc_leaf_split\n" ++
-  "  li a0, 1; j .Lacc_ret       # ext-split / exists / branch-value: conservative\n" ++
+  "  li t2, 2; beq t1, t2, .Lacc_ext_split\n" ++
+  "  li a0, 1; j .Lacc_ret       # exists / branch-value: conservative\n" ++
   ".Lacc_empty:\n" ++
   "  mv a0, s1; mv a1, s2; mv a2, s3; mv a3, s4\n" ++
   "  la a4, ins_node; la a5, ins_node_len\n" ++
@@ -132,6 +132,106 @@ def mptInsertAccFunction : String :=
   "  la a2, ins_ref; la a3, ins_ref_len\n" ++
   "  jal ra, mpt_node_slot_encode\n" ++
   ".Lacc_ls_bubble:\n" ++
+  "  mv s7, s6\n" ++
+  "  j .Lacc_bubble\n" ++
+  ".Lacc_ext_split:\n" ++
+  "  # Split the terminal extension. Rebuild its remainder under a branch,\n" ++
+  "  # add the new leaf on the divergent nibble, optionally wrap the shared\n" ++
+  "  # prefix in a new extension, then bubble through ancestors.\n" ++
+  "  la t0, ins_meta; ld s9, 24(t0)        # terminal extension ptr ABSOLUTE\n" ++
+  "  la t0, ins_meta; ld a1, 32(t0)        # terminal extension len\n" ++
+  "  mv a0, s9; li a2, 0; la a3, mle_path_off; la a4, mle_path_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lacc_fail\n" ++
+  "  la t0, mle_path_off; ld t0, 0(t0); add a0, s9, t0\n" ++
+  "  la t0, mle_path_len; ld a1, 0(t0)\n" ++
+  "  la a2, ins_k; la a3, ins_kcount; la a4, ins_niba\n" ++
+  "  jal ra, hp_decode_nibbles\n" ++
+  "  bnez a0, .Lacc_fail\n" ++
+  "  la t0, ins_niba; ld t0, 0(t0); bnez t0, .Lacc_fail\n" ++
+  "  # child_ref from extension item 1. For hash refs, rlp_list_nth_item strips\n" ++
+  "  # the 0xa0 byte, so re-wrap 32-byte refs before feeding extension encode.\n" ++
+  "  la t0, ins_meta; ld a1, 32(t0); mv a0, s9; li a2, 1; la a3, mle_path_off; la a4, ins_lv_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lacc_fail\n" ++
+  "  la t0, mle_path_off; ld t0, 0(t0); add t0, s9, t0; la t1, ins_lv_ptr; sd t0, 0(t1)\n" ++
+  "  la t1, ins_lv_len; ld t2, 0(t1); li t3, 32; bne t2, t3, .Lacc_ext_child_inline\n" ++
+  "  la t4, ins_ref; li t5, 0xa0; sb t5, 0(t4); addi t4, t4, 1; li t5, 32\n" ++
+  ".Lacc_ext_child_hash_cp:\n" ++
+  "  beqz t5, .Lacc_ext_child_hash_done\n" ++
+  "  lbu t6, 0(t0); sb t6, 0(t4); addi t0, t0, 1; addi t4, t4, 1; addi t5, t5, -1; j .Lacc_ext_child_hash_cp\n" ++
+  ".Lacc_ext_child_hash_done:\n" ++
+  "  li t5, 33; la t4, ins_ref_len; sd t5, 0(t4); j .Lacc_ext_child_ready\n" ++
+  ".Lacc_ext_child_inline:\n" ++
+  "  la t4, ins_ref; mv t5, t2\n" ++
+  ".Lacc_ext_child_inline_cp:\n" ++
+  "  beqz t5, .Lacc_ext_child_inline_done\n" ++
+  "  lbu t6, 0(t0); sb t6, 0(t4); addi t0, t0, 1; addi t4, t4, 1; addi t5, t5, -1; j .Lacc_ext_child_inline_cp\n" ++
+  ".Lacc_ext_child_inline_done:\n" ++
+  "  la t4, ins_ref_len; sd t2, 0(t4)\n" ++
+  ".Lacc_ext_child_ready:\n" ++
+  "  la t0, ins_meta; ld t1, 40(t0); la t2, ins_m; sd t1, 0(t2)\n" ++
+  "  la t2, ins_k; add t2, t2, t1; lbu t3, 0(t2); la t4, ins_niba; sd t3, 0(t4)\n" ++
+  "  add t2, s1, s8; add t2, t2, t1; lbu t3, 0(t2); la t4, ins_nibb; sd t3, 0(t4)\n" ++
+  "  # old side: if extension remainder after the divergent nibble is non-empty,\n" ++
+  "  # wrap the existing child_ref in a shorter extension; otherwise use it as-is.\n" ++
+  "  la t0, ins_kcount; ld t1, 0(t0); la t2, ins_m; ld t3, 0(t2)\n" ++
+  "  sub t4, t1, t3; addi t4, t4, -1\n" ++
+  "  beqz t4, .Lacc_ext_old_ready\n" ++
+  "  la a0, ins_k; add a0, a0, t3; addi a0, a0, 1\n" ++
+  "  mv a1, t4; la a2, ins_ref; la t0, ins_ref_len; ld a3, 0(t0)\n" ++
+  "  la a4, ins_node; la a5, ins_node_len\n" ++
+  "  jal ra, mpt_extension_node_encode\n" ++
+  "  la a0, ins_node; la t0, ins_node_len; ld a1, 0(t0)\n" ++
+  "  jal ra, node_db_append\n" ++
+  "  la a0, ins_node; la t0, ins_node_len; ld a1, 0(t0)\n" ++
+  "  la a2, ins_ref; la a3, ins_ref_len\n" ++
+  "  jal ra, mpt_node_slot_encode\n" ++
+  ".Lacc_ext_old_ready:\n" ++
+  "  # new side leaf = leaf(path[consumed+m+1..], value).\n" ++
+  "  la t2, ins_m; ld t3, 0(t2)\n" ++
+  "  add a0, s1, s8; add a0, a0, t3; addi a0, a0, 1\n" ++
+  "  sub a1, s2, s8; sub a1, a1, t3; addi a1, a1, -1\n" ++
+  "  mv a2, s3; mv a3, s4\n" ++
+  "  la a4, ins_node2; la a5, ins_node2_len\n" ++
+  "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  la a0, ins_node2; la t0, ins_node2_len; ld a1, 0(t0)\n" ++
+  "  jal ra, node_db_append\n" ++
+  "  la a0, ins_node2; la t0, ins_node2_len; ld a1, 0(t0)\n" ++
+  "  la a2, ins_ref2; la a3, ins_ref2_len\n" ++
+  "  jal ra, mpt_node_slot_encode\n" ++
+  "  # branch with old and new children.\n" ++
+  "  la a0, ins_empty_branch; li a1, 18\n" ++
+  "  la t0, ins_niba; ld a2, 0(t0)\n" ++
+  "  la a3, ins_ref; la t0, ins_ref_len; ld a4, 0(t0)\n" ++
+  "  la a5, ins_node; la a6, ins_node_len\n" ++
+  "  jal ra, mpt_splice_slot\n" ++
+  "  bnez a0, .Lacc_fail\n" ++
+  "  la a0, ins_node; la t0, ins_node_len; ld a1, 0(t0)\n" ++
+  "  la t0, ins_nibb; ld a2, 0(t0)\n" ++
+  "  la a3, ins_ref2; la t0, ins_ref2_len; ld a4, 0(t0)\n" ++
+  "  la a5, ins_node2; la a6, ins_node2_len\n" ++
+  "  jal ra, mpt_splice_slot\n" ++
+  "  bnez a0, .Lacc_fail\n" ++
+  "  la a0, ins_node2; la t0, ins_node2_len; ld a1, 0(t0)\n" ++
+  "  jal ra, node_db_append\n" ++
+  "  la a0, ins_node2; la t0, ins_node2_len; ld a1, 0(t0)\n" ++
+  "  la a2, ins_ref; la a3, ins_ref_len\n" ++
+  "  jal ra, mpt_node_slot_encode\n" ++
+  "  la t0, ins_node2_len; ld t1, 0(t0); la t2, ins_node_len; sd t1, 0(t2)\n" ++
+  "  la a0, ins_node; la a1, ins_node2; mv a2, t1\n" ++
+  "  jal ra, mset_memcpy\n" ++
+  "  la t0, ins_m; ld t1, 0(t0); beqz t1, .Lacc_ext_bubble\n" ++
+  "  la a0, ins_k; mv a1, t1\n" ++
+  "  la a2, ins_ref; la t0, ins_ref_len; ld a3, 0(t0)\n" ++
+  "  la a4, ins_node; la a5, ins_node_len\n" ++
+  "  jal ra, mpt_extension_node_encode\n" ++
+  "  la a0, ins_node; la t0, ins_node_len; ld a1, 0(t0)\n" ++
+  "  jal ra, node_db_append\n" ++
+  "  la a0, ins_node; la t0, ins_node_len; ld a1, 0(t0)\n" ++
+  "  la a2, ins_ref; la a3, ins_ref_len\n" ++
+  "  jal ra, mpt_node_slot_encode\n" ++
+  ".Lacc_ext_bubble:\n" ++
   "  mv s7, s6\n" ++
   "  j .Lacc_bubble\n" ++
   ".Lacc_branch_empty:\n" ++


### PR DESCRIPTION
## Summary
- add DB-aware EXTENSION_SPLIT handling to mpt_insert_acc
- rebuild the split extension into old/new branch children, append fresh nodes to the shared node DB, and bubble the new ref through ancestors
- leave EXISTS and BRANCH_VALUE conservative

## Validation
- lake build EvmAsm.Codegen.Programs.MptInsertAcc
- scripts/codegen-eest-stateless-check.sh --all --filter withdrawing_to_precompiles --steps 200000000 --min-root 72
  - 72/72 root match, 72/72 tail match, 36/72 full; remaining positive-precompile withdrawals still fail successful_validation because the recomputed post-state root mismatches payload.state_root
- lake build codegen
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build

## Notes
The focused EEST run plus temporary local instrumentation showed the positive precompile cases now reach the post-state-root comparison path; the next slice should fix the remaining state-root mismatch for inserted precompile accounts.