### PR TITLE
fix(eest): reject zero-gas tx payloads

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -275,6 +275,10 @@ def blockVerdictFunction : String :=
   "  j .Lbv_after_tx_gate\n" ++
   ".Lbv_tx_present:\n" ++
   "  la t5, bsr_bal_count; ld t5, 0(t5); beqz t5, .Lbv_zero  # tx blocks need BAL replay\n" ++
+  "  # Any included transaction must consume nonzero gas. This catches rejected\n" ++
+  "  # tx payloads whose state/BAL roots otherwise match the conservative replay.\n" ++
+  "  la t5, bv_exec_p; ld t4, 0(t5); addi a0, t4, 420; jal ra, bgv_u64le   # gas_used\n" ++
+  "  beqz a0, .Lbv_zero\n" ++
   ".Lbv_after_tx_gate:\n" ++
   "  # EIP-7928 BAL gas-limit rule: reject if the block_access_list exceeds the\n" ++
   "  # gas limit (a semantic invalidity not caught by header/state checks).\n" ++


### PR DESCRIPTION
## Summary
- reject transaction-bearing payloads with zero gas_used in block_verdict
- catches the EIP-4895 insufficient-funds tx case whose roots/tail otherwise matched conservative replay
- builds on merged PR #7791

## Validation
- lake build EvmAsm.Codegen.Programs.BlockVerdict
- lake exe codegen --program stateless_guest --halt linux93 -o gen-out/stateless_guest
- scripts/codegen-eest-stateless-check.sh --all --filter eip4895 --steps 200000000 --min-full 136
  - full: 136/140, root: 140/140, succ: 136/140, tail: 140/140, fail: 4
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/BlockVerdict.lean
- git diff --check
- lake build

Bead: evm-asm-fhsxz.2.4.2.5

Authored by @pirapira; implemented by Codex.