### PR TITLE
feat(eest): replay non-empty BAL storage batches

### DIFF
--- a/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
@@ -144,18 +144,26 @@ def balAccountApplyPostFieldsFunction : String :=
   "  # Multi-slot BAL storage replay is supported when the account's prior\n" ++
   "  # storage trie is empty: build all storage insert descriptors and apply\n" ++
   "  # them together so the intermediate trie root need not be in the witness.\n" ++
+  "  # Final zero slot values are trie-default no-ops for an empty storage trie.\n" ++
   "  mv a0, s6; mv a1, s7; li a2, 2; la a3, aps_off; la a4, aps_len\n" ++
   "  jal ra, rlp_list_nth_item\n" ++
   "  bnez a0, .Lbaap_fail\n" ++
   "  la t0, aps_len; ld t1, 0(t0); li t2, 32; bne t1, t2, .Lbaap_fail\n" ++
-  "  la t0, aps_off; ld t1, 0(t0); add t1, s6, t1; la t2, aps_empty_root; li t3, 32\n" ++
+  "  la t0, aps_off; ld t1, 0(t0); add t1, s6, t1; la t0, baap_storage_root_ptr; sd t1, 0(t0)\n" ++
+  "  la t2, aps_empty_root; li t3, 32\n" ++
   ".Lbaap_empty_cmp:\n" ++
   "  beqz t3, .Lbaap_empty_ok\n" ++
-  "  lbu t4, 0(t1); lbu t5, 0(t2); bne t4, t5, .Lbaap_fail\n" ++
+  "  lbu t4, 0(t1); lbu t5, 0(t2); bne t4, t5, .Lbaap_nonempty_ok\n" ++
   "  addi t1, t1, 1; addi t2, t2, 1; addi t3, t3, -1; j .Lbaap_empty_cmp\n" ++
   ".Lbaap_empty_ok:\n" ++
+  "  li t0, 1; la t1, baap_storage_empty_flag; sd t0, 0(t1)\n" ++
+  "  j .Lbaap_multi_init\n" ++
+  ".Lbaap_nonempty_ok:\n" ++
+  "  la t0, baap_storage_empty_flag; sd zero, 0(t0)\n" ++
+  ".Lbaap_multi_init:\n" ++
   "  la t0, baap_storage_values; la t1, baap_storage_value_cursor; sd t0, 0(t1)\n" ++
   "  la t0, baap_sc_index; sd zero, 0(t0)\n" ++
+  "  la t0, baap_sc_out_count; sd zero, 0(t0)\n" ++
   ".Lbaap_multi_loop:\n" ++
   "  la t0, baap_sc_index; ld t0, 0(t0); la t1, baap_sc_count; ld t1, 0(t1)\n" ++
   "  beq t0, t1, .Lbaap_multi_apply\n" ++
@@ -203,24 +211,51 @@ def balAccountApplyPostFieldsFunction : String :=
   "  la t1, baap_slot_changes_ptr; ld t1, 0(t1); la t2, baap_item_off; ld t2, 0(t2); add t1, t1, t2\n" ++
   "  la t2, baap_val_off; ld t2, 0(t2); add a0, t1, t2\n" ++
   "  mv a1, t0; la t2, baap_storage_value_cursor; ld a2, 0(t2); la a3, aab_enc_len\n" ++
+  "  bnez a1, .Lbaap_multi_encode_value\n" ++
+  "  la t0, baap_storage_empty_flag; ld t0, 0(t0); beqz t0, .Lbaap_fail\n" ++
+  "  j .Lbaap_multi_skip_zero\n" ++
+  ".Lbaap_multi_encode_value:\n" ++
   "  jal ra, rlp_encode_bytes\n" ++
   "  la a0, baap_slot; li a1, 32; la a2, srss_key\n" ++
   "  jal ra, zkvm_keccak256\n" ++
-  "  la t0, baap_sc_index; ld t0, 0(t0); slli t1, t0, 6; la t2, baap_storage_paths; add a2, t2, t1\n" ++
+  "  la t0, baap_sc_out_count; ld t0, 0(t0); slli t1, t0, 6; la t2, baap_storage_paths; add a2, t2, t1\n" ++
   "  la a0, srss_key; li a1, 32\n" ++
   "  jal ra, bytes_to_nibbles\n" ++
-  "  la t0, baap_sc_index; ld t0, 0(t0); slli t1, t0, 5; slli t2, t0, 3; add t1, t1, t2\n" ++
+  "  la t0, baap_storage_empty_flag; ld t0, 0(t0); bnez t0, .Lbaap_mslot_insert\n" ++
+  "  la t0, baap_storage_root_ptr; ld a0, 0(t0)\n" ++
+  "  la t0, aps_witness_ptr; ld a1, 0(t0); la t0, aps_witness_len; ld a2, 0(t0)\n" ++
+  "  la t0, baap_sc_out_count; ld t0, 0(t0); slli t1, t0, 6; la t2, baap_storage_paths; add a3, t2, t1\n" ++
+  "  li a4, 64; la a5, baap_walk_val; la a6, baap_walk_val_len\n" ++
+  "  jal ra, mpt_walk\n" ++
+  "  beqz a0, .Lbaap_mslot_modify\n" ++
+  "  li t0, 1; bne a0, t0, .Lbaap_fail\n" ++
+  ".Lbaap_mslot_insert:\n" ++
+  "  li t5, 1; j .Lbaap_mslot_have_mode\n" ++
+  ".Lbaap_mslot_modify:\n" ++
+  "  li t5, 0\n" ++
+  ".Lbaap_mslot_have_mode:\n" ++
+  "  la t0, baap_sc_out_count; ld t0, 0(t0); slli t1, t0, 5; slli t2, t0, 3; add t1, t1, t2\n" ++
   "  la t2, baap_storage_desc; add t1, t2, t1\n" ++
   "  slli t2, t0, 6; la t3, baap_storage_paths; add t2, t3, t2; sd t2, 0(t1)\n" ++
   "  li t2, 64; sd t2, 8(t1)\n" ++
   "  la t2, baap_storage_value_cursor; ld t3, 0(t2); sd t3, 16(t1)\n" ++
   "  la t4, aab_enc_len; ld t4, 0(t4); sd t4, 24(t1)\n" ++
-  "  li t5, 1; sd t5, 32(t1)\n" ++
+  "  sd t5, 32(t1)\n" ++
   "  add t3, t3, t4; addi t3, t3, 7; andi t3, t3, -8; sd t3, 0(t2)\n" ++
+  "  addi t0, t0, 1; la t1, baap_sc_out_count; sd t0, 0(t1)\n" ++
+  ".Lbaap_multi_skip_zero:\n" ++
+  "  la t0, baap_sc_index; ld t0, 0(t0)\n" ++
   "  addi t0, t0, 1; la t1, baap_sc_index; sd t0, 0(t1); j .Lbaap_multi_loop\n" ++
   ".Lbaap_multi_apply:\n" ++
+  "  la t0, baap_sc_out_count; ld a4, 0(t0); beqz a4, .Lbaap_nonce\n" ++
+  "  la t0, baap_storage_empty_flag; ld t0, 0(t0); beqz t0, .Lbaap_multi_apply_nonempty\n" ++
   "  la a0, aps_empty_root; mv a1, zero; mv a2, zero; la a3, baap_storage_desc\n" ++
-  "  la t0, baap_sc_count; ld a4, 0(t0); la a5, aps_newsroot\n" ++
+  "  j .Lbaap_multi_apply_call\n" ++
+  ".Lbaap_multi_apply_nonempty:\n" ++
+  "  la t0, baap_storage_root_ptr; ld a0, 0(t0)\n" ++
+  "  la t0, aps_witness_ptr; ld a1, 0(t0); la t0, aps_witness_len; ld a2, 0(t0); la a3, baap_storage_desc\n" ++
+  ".Lbaap_multi_apply_call:\n" ++
+  "  la a5, aps_newsroot\n" ++
   "  jal ra, mpt_state_root_ins\n" ++
   "  bnez a0, .Lbaap_fail\n" ++
   "  mv a0, s6; mv a1, s7; la a2, aps_newsroot; la a3, baap_tmp2; la a4, baap_tmp2_len\n" ++
@@ -294,6 +329,7 @@ def ziskBalAccountApplyPostFieldsPrologue : String :=
   mptNodeResolveFunction ++ "\n" ++
   mptNodeKindFunction ++ "\n" ++
   hpDecodeNibblesFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
   mptSetRecordWalkDbFunction ++ "\n" ++
   mptInsertWalkDbFunction ++ "\n" ++
   mptLeafNodeEncodeFromNibblesFunction ++ "\n" ++
@@ -366,6 +402,10 @@ def ziskBalAccountApplyPostFieldsDataSection : String :=
   "baap_sc_ptr:\n  .zero 8\n" ++
   "baap_sc_count:\n  .zero 8\n" ++
   "baap_sc_index:\n  .zero 8\n" ++
+  "baap_sc_out_count:\n  .zero 8\n" ++
+  "baap_storage_empty_flag:\n  .zero 8\n" ++
+  "baap_storage_root_ptr:\n  .zero 8\n" ++
+  "baap_walk_val_len:\n  .zero 8\n" ++
   "baap_item_off:\n  .zero 8\n" ++
   "baap_item_len:\n  .zero 8\n" ++
   "baap_slot_changes_off:\n  .zero 8\n" ++
@@ -392,6 +432,7 @@ def ziskBalAccountApplyPostFieldsDataSection : String :=
   "baap_tmp2:\n  .zero 512\n" ++
   "baap_tmp3:\n  .zero 512\n" ++
   "baap_storage_value_cursor:\n  .zero 8\n" ++
+  "baap_walk_val:\n  .zero 128\n" ++
   "baap_storage_desc:\n  .zero 1280\n" ++
   "baap_storage_paths:\n  .zero 2048\n" ++
   "baap_storage_values:\n  .zero 2048\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -576,6 +576,10 @@ def ziskStatelessVerdictV2DataSection : String :=
   "baap_sc_ptr:\n  .zero 8\n" ++
   "baap_sc_count:\n  .zero 8\n" ++
   "baap_sc_index:\n  .zero 8\n" ++
+  "baap_sc_out_count:\n  .zero 8\n" ++
+  "baap_storage_empty_flag:\n  .zero 8\n" ++
+  "baap_storage_root_ptr:\n  .zero 8\n" ++
+  "baap_walk_val_len:\n  .zero 8\n" ++
   "baap_item_off:\n  .zero 8\n" ++
   "baap_item_len:\n  .zero 8\n" ++
   "baap_slot_changes_off:\n  .zero 8\n" ++
@@ -602,6 +606,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   "baap_tmp2:\n  .zero 512\n" ++
   "baap_tmp3:\n  .zero 512\n" ++
   "baap_storage_value_cursor:\n  .zero 8\n" ++
+  "baap_walk_val:\n  .zero 128\n" ++
   "baap_storage_desc:\n  .zero 1280\n" ++
   "baap_storage_paths:\n  .zero 2048\n" ++
   "baap_storage_values:\n  .zero 2048\n" ++

--- a/scripts/codegen-zisk-bal-account-apply-post-fields-check.sh
+++ b/scripts/codegen-zisk-bal-account-apply-post-fields-check.sh
@@ -25,6 +25,7 @@ EMPTY_ROOT = bytes.fromhex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc00162
 EMPTY_CODE_HASH = bytes.fromhex("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
 SLOT_1_VALUE_7_ROOT = bytes.fromhex("2e7827dc2c61c322f13f77e6f25dd18844ccc48426dde70301d2d57d138fced8")
 SLOTS_1_2_VALUES_7_9_ROOT = bytes.fromhex("d4768ae8d8aaa8da763864dd76573bdc5d107ac968eb886393419033cc66dac7")
+SLOT_2_VALUE_9_ROOT = bytes.fromhex("ae2775a33ad618be6c0743c3902b06bc4d218ba6186818a6ebdd2ae0826cfd6b")
 
 
 def minimal_be(n: int) -> bytes:
@@ -107,6 +108,18 @@ cases = [
         bal_account_change_rlp(addr, storage_changes=[(1, [(1, 7)]), (2, [(2, 9)])]),
         account_rlp(1, 5, SLOTS_1_2_VALUES_7_9_ROOT),
     ),
+    (
+        "baap_two_storage_one_zero",
+        base,
+        bal_account_change_rlp(addr, storage_changes=[(1, [(1, 0)]), (2, [(2, 9)])]),
+        account_rlp(1, 5, SLOT_2_VALUE_9_ROOT),
+    ),
+    (
+        "baap_two_storage_all_zero",
+        base,
+        bal_account_change_rlp(addr, storage_changes=[(1, [(1, 0)]), (2, [(2, 0)])]),
+        base,
+    ),
 ]
 
 for name, account, account_change, expected in cases:
@@ -125,7 +138,7 @@ lake exe codegen --program zisk_bal_account_apply_post_fields --halt linux93 \
   -o "$REPO_ROOT/gen-out/zisk_bal_account_apply_post_fields"
 
 fail=0
-for name in baap_noop baap_balance baap_nonce baap_both baap_zero_balance baap_storage_only baap_two_storage; do
+for name in baap_noop baap_balance baap_nonce baap_both baap_zero_balance baap_storage_only baap_two_storage baap_two_storage_one_zero baap_two_storage_all_zero; do
   out="$VDIR/$name.output"
   "$ZISKEMU" -e "$REPO_ROOT/gen-out/zisk_bal_account_apply_post_fields.elf" \
     -i "$VDIR/$name.input" -o "$out" -n 2000000 >/dev/null 2>&1 </dev/null \


### PR DESCRIPTION
## Summary
- Extend BAL account post-state replay to batch multi-slot storage changes against non-empty prior storage roots by walking each pre-slot to classify insert versus modify.
- Skip final-zero BAL storage writes when the prior storage trie is empty, matching trie-default semantics.
- Add focused account replay vectors for mixed zero/nonzero and all-zero multi-slot storage changes.

## Validation
- scripts/codegen-zisk-bal-account-apply-post-fields-check.sh
- scripts/codegen-eest-stateless-check.sh --limit 20 --filter block_access_lists_cross_index --steps 200000000 --jobs auto (4/4 full)
- scripts/codegen-eest-stateless-check.sh --limit 160 --filter eip4895 --steps 200000000 --jobs auto --min-full 140 (140/140 full)
- scripts/codegen-eest-stateless-check.sh --limit 400 --steps 200000000 --jobs auto (378/400 full, 399/399 root+tail, 1 errored)
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' <edited files>
- lake build

Refs #114. Bead: evm-asm-fhsxz.2.4.2.5.

Authored by @pirapira; implemented by Codex.