### PR TITLE
feat(eest): replay EIP-4788 parent-root writes

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -82,6 +82,112 @@ def bsrSysChangeFunction : String :=
   "  addi sp, sp, 48\n" ++
   "  ret"
 
+/-! ## bsr_beacon_change -- record the EIP-4788 two-slot account change.
+    EIP-4788 writes two storage slots in the same beacon-roots account.  The
+    state trie must therefore receive one account-leaf descriptor whose
+    storageRoot reflects both slot writes, not two duplicate state descriptors.
+    a4 = change index. -/
+def bsrBeaconChangeFunction : String :=
+  "bsr_beacon_change:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a4                   # state change index\n" ++
+  "  la a0, bsr_addr_4788; li a1, 20; la a2, bsr_kbuf; jal ra, zkvm_keccak256\n" ++
+  "  slli t0, s0, 6; la t1, bsr_paths; add t2, t1, t0\n" ++
+  "  la t3, bsr_pathp; sd t2, 0(t3)\n" ++
+  "  la a0, bsr_kbuf; li a1, 32; mv a2, t2; jal ra, bytes_to_nibbles\n" ++
+  "  la t0, bsr_root_p; ld a0, 0(t0); la t0, bsr_wit_p; ld a1, 0(t0); la t0, bsr_wl_v; ld a2, 0(t0)\n" ++
+  "  la t0, bsr_pathp; ld a3, 0(t0); li a4, 64; la a5, bsr_acct; la a6, bsr_acct_len\n" ++
+  "  jal ra, mpt_walk\n" ++
+  "  bnez a0, .Lbbc_fail\n" ++
+  "  la t0, bsr_wit_p; ld t1, 0(t0); la t0, aps_witness_ptr; sd t1, 0(t0)\n" ++
+  "  la t0, bsr_wl_v;  ld t1, 0(t0); la t0, aps_witness_len; sd t1, 0(t0)\n" ++
+  "  la a0, bsr_acct; la t0, bsr_acct_len; ld a1, 0(t0); li a2, 2; la a3, aps_off; la a4, aps_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbbc_fail\n" ++
+  "  la t0, aps_len; ld t1, 0(t0); li t2, 32; bne t1, t2, .Lbbc_fail\n" ++
+  "  la t0, aps_off; ld t0, 0(t0); la t1, bsr_acct; add t1, t1, t0; la t0, baap_storage_root_ptr; sd t1, 0(t0)\n" ++
+  "  la t2, aps_empty_root; li t3, 32\n" ++
+  ".Lbbc_empty_cmp:\n" ++
+  "  beqz t3, .Lbbc_empty\n" ++
+  "  lbu t4, 0(t1); lbu t5, 0(t2); bne t4, t5, .Lbbc_nonempty\n" ++
+  "  addi t1, t1, 1; addi t2, t2, 1; addi t3, t3, -1; j .Lbbc_empty_cmp\n" ++
+  ".Lbbc_empty:\n" ++
+  "  li t0, 1; la t1, baap_storage_empty_flag; sd t0, 0(t1); j .Lbbc_init\n" ++
+  ".Lbbc_nonempty:\n" ++
+  "  la t0, baap_storage_empty_flag; sd zero, 0(t0)\n" ++
+  ".Lbbc_init:\n" ++
+  "  la t0, baap_storage_values; la t1, baap_storage_value_cursor; sd t0, 0(t1)\n" ++
+  "  la t0, baap_sc_out_count; sd zero, 0(t0)\n" ++
+  "  # Descriptor 0: timestamp slot -> timestamp value.\n" ++
+  "  la t0, swd_4788_vlen; ld a1, 0(t0); beqz a1, .Lbbc_after_ts\n" ++
+  "  la a0, swd_4788_val; la t2, baap_storage_value_cursor; ld a2, 0(t2); la a3, srss_rlpval_len\n" ++
+  "  jal ra, rlp_encode_bytes\n" ++
+  "  la a0, swd_4788_slot; li a1, 32; la a2, srss_key; jal ra, zkvm_keccak256\n" ++
+  "  la a0, srss_key; li a1, 32; la a2, baap_storage_paths; jal ra, bytes_to_nibbles\n" ++
+  "  la t0, baap_storage_empty_flag; ld t0, 0(t0); bnez t0, .Lbbc_ts_insert\n" ++
+  "  la t0, baap_storage_root_ptr; ld a0, 0(t0); la t0, bsr_wit_p; ld a1, 0(t0); la t0, bsr_wl_v; ld a2, 0(t0)\n" ++
+  "  la a3, baap_storage_paths; li a4, 64; la a5, baap_walk_val; la a6, baap_walk_val_len; jal ra, mpt_walk\n" ++
+  "  beqz a0, .Lbbc_ts_modify\n" ++
+  "  li t0, 1; bne a0, t0, .Lbbc_fail\n" ++
+  ".Lbbc_ts_insert:\n" ++
+  "  li t5, 1; j .Lbbc_ts_mode\n" ++
+  ".Lbbc_ts_modify:\n" ++
+  "  li t5, 0\n" ++
+  ".Lbbc_ts_mode:\n" ++
+  "  la t1, baap_storage_desc; la t2, baap_storage_paths; sd t2, 0(t1); li t2, 64; sd t2, 8(t1)\n" ++
+  "  la t2, baap_storage_value_cursor; ld t3, 0(t2); sd t3, 16(t1); la t4, srss_rlpval_len; ld t4, 0(t4); sd t4, 24(t1); sd t5, 32(t1)\n" ++
+  "  add t3, t3, t4; addi t3, t3, 7; andi t3, t3, -8; sd t3, 0(t2)\n" ++
+  "  la t0, baap_sc_out_count; li t1, 1; sd t1, 0(t0)\n" ++
+  ".Lbbc_after_ts:\n" ++
+  "  # Descriptor 1: timestamp+8191 slot -> parent_beacon_block_root, unless zero.\n" ++
+  "  la t0, swd_4788_root_vlen; ld a1, 0(t0); beqz a1, .Lbbc_apply_storage\n" ++
+  "  la a0, swd_4788_root_val; la t2, baap_storage_value_cursor; ld a2, 0(t2); la a3, srss_rlpval_len\n" ++
+  "  jal ra, rlp_encode_bytes\n" ++
+  "  la a0, swd_4788_root_slot; li a1, 32; la a2, srss_key; jal ra, zkvm_keccak256\n" ++
+  "  la a0, srss_key; li a1, 32; la a2, baap_storage_paths; addi a2, a2, 64; jal ra, bytes_to_nibbles\n" ++
+  "  la t0, baap_storage_empty_flag; ld t0, 0(t0); bnez t0, .Lbbc_root_insert\n" ++
+  "  la t0, baap_storage_root_ptr; ld a0, 0(t0); la t0, bsr_wit_p; ld a1, 0(t0); la t0, bsr_wl_v; ld a2, 0(t0)\n" ++
+  "  la a3, baap_storage_paths; addi a3, a3, 64; li a4, 64; la a5, baap_walk_val; la a6, baap_walk_val_len; jal ra, mpt_walk\n" ++
+  "  beqz a0, .Lbbc_root_modify\n" ++
+  "  li t0, 1; bne a0, t0, .Lbbc_fail\n" ++
+  ".Lbbc_root_insert:\n" ++
+  "  li t5, 1; j .Lbbc_root_mode\n" ++
+  ".Lbbc_root_modify:\n" ++
+  "  li t5, 0\n" ++
+  ".Lbbc_root_mode:\n" ++
+  "  la t0, baap_sc_out_count; ld t0, 0(t0); slli t1, t0, 5; slli t2, t0, 3; add t1, t1, t2; la t2, baap_storage_desc; add t1, t2, t1\n" ++
+  "  slli t2, t0, 6; la t3, baap_storage_paths; add t2, t3, t2; sd t2, 0(t1); li t2, 64; sd t2, 8(t1)\n" ++
+  "  la t2, baap_storage_value_cursor; ld t3, 0(t2); sd t3, 16(t1); la t4, srss_rlpval_len; ld t4, 0(t4); sd t4, 24(t1); sd t5, 32(t1)\n" ++
+  "  add t3, t3, t4; addi t3, t3, 7; andi t3, t3, -8; sd t3, 0(t2)\n" ++
+  "  addi t0, t0, 1; la t1, baap_sc_out_count; sd t0, 0(t1)\n" ++
+  ".Lbbc_apply_storage:\n" ++
+  "  la t0, baap_sc_out_count; ld a4, 0(t0); beqz a4, .Lbbc_fail\n" ++
+  "  la t0, baap_storage_empty_flag; ld t0, 0(t0); beqz t0, .Lbbc_apply_nonempty\n" ++
+  "  la a0, aps_empty_root; mv a1, zero; mv a2, zero; la a3, baap_storage_desc; j .Lbbc_apply_call\n" ++
+  ".Lbbc_apply_nonempty:\n" ++
+  "  la t0, baap_storage_root_ptr; ld a0, 0(t0); la t0, bsr_wit_p; ld a1, 0(t0); la t0, bsr_wl_v; ld a2, 0(t0); la a3, baap_storage_desc\n" ++
+  ".Lbbc_apply_call:\n" ++
+  "  la a5, aps_newsroot; jal ra, mpt_state_root_ins\n" ++
+  "  bnez a0, .Lbbc_fail\n" ++
+  "  la a0, bsr_acct; la t0, bsr_acct_len; ld a1, 0(t0); la a2, aps_newsroot\n" ++
+  "  slli t0, s0, 7; la t1, bsr_newaccts; add a3, t1, t0; la a4, bsr_tmplen\n" ++
+  "  jal ra, account_set_storage_root\n" ++
+  "  bnez a0, .Lbbc_fail\n" ++
+  "  slli t0, s0, 5; slli t4, s0, 3; add t0, t0, t4; la t1, bsr_changes; add t1, t1, t0\n" ++
+  "  la t2, bsr_pathp; ld t2, 0(t2); sd t2, 0(t1); li t3, 64; sd t3, 8(t1)\n" ++
+  "  slli t0, s0, 7; la t2, bsr_newaccts; add t2, t2, t0; sd t2, 16(t1)\n" ++
+  "  la t2, bsr_tmplen; ld t2, 0(t2); sd t2, 24(t1); sd zero, 32(t1)\n" ++
+  "  li a0, 0; j .Lbbc_ret\n" ++
+  ".Lbbc_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lbbc_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
 /-! ## block_state_root -- post-state root after system writes + withdrawals.
     a0 = pre-state root ptr   a1 = witness   a2 = witness_len
     a3 = wds descriptors   a4 = n_wds   a5 = out_root   a6 = SSZ_BASE
@@ -104,10 +210,9 @@ def blockStateRootFunction : String :=
   "  la a0, bsr_addr_2935; la a1, swd_2935_slot; la a2, swd_2935_val\n" ++
   "  la t0, swd_2935_vlen; ld a3, 0(t0); li a4, 0\n" ++
   "  jal ra, bsr_sys_change; bnez a0, .Lbsr_cons\n" ++
-  "  # system change 1 = EIP-4788\n" ++
-  "  la a0, bsr_addr_4788; la a1, swd_4788_slot; la a2, swd_4788_val\n" ++
-  "  la t0, swd_4788_vlen; ld a3, 0(t0); li a4, 1\n" ++
-  "  jal ra, bsr_sys_change; bnez a0, .Lbsr_cons\n" ++
+  "  # system change 1 = EIP-4788 (timestamp + parent-root slots in one account)\n" ++
+  "  li a4, 1\n" ++
+  "  jal ra, bsr_beacon_change; bnez a0, .Lbsr_cons\n" ++
   "  # BAL account changes are tx-execution account post-values. Append them before\n" ++
   "  # withdrawals so withdrawal credits can update a BAL-touched account in place.\n" ++
   "  li s1, 2                     # change counter (2 system changes already recorded)\n" ++
@@ -457,6 +562,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   balAccountStateRootFunction ++ "\n" ++
   balAccountStateRootAutoFunction ++ "\n" ++
   bsrSysChangeFunction ++ "\n" ++
+  bsrBeaconChangeFunction ++ "\n" ++
   blockStateRootFunction ++ "\n" ++
   blockVerdictFunction ++ "\n" ++
   rlpListCountItemsFunction ++ "\n" ++
@@ -507,9 +613,14 @@ def ziskStatelessVerdictV2DataSection : String :=
   "swd_4788_slot:\n  .zero 32\n" ++
   ".balign 32\n" ++
   "swd_4788_val:\n  .zero 32\n" ++
+  ".balign 32\n" ++
+  "swd_4788_root_slot:\n  .zero 32\n" ++
+  ".balign 32\n" ++
+  "swd_4788_root_val:\n  .zero 32\n" ++
   ".balign 8\n" ++
   "swd_2935_vlen:\n  .zero 8\n" ++
   "swd_4788_vlen:\n  .zero 8\n" ++
+  "swd_4788_root_vlen:\n  .zero 8\n" ++
   "swd_ts_be8:\n  .zero 8\n" ++
   -- block_state_root scratch:
   ".balign 8\n" ++
@@ -806,6 +917,7 @@ def statelessVerdictV2GuestClosure : String :=
   balAccountStateRootFunction ++ "\n" ++
   balAccountStateRootAutoFunction ++ "\n" ++
   bsrSysChangeFunction ++ "\n" ++
+  bsrBeaconChangeFunction ++ "\n" ++
   blockStateRootFunction ++ "\n" ++
   blockVerdictFunction ++ "\n" ++
   rlpListCountItemsFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/SystemWrites.lean
+++ b/EvmAsm/Codegen/Programs/SystemWrites.lean
@@ -123,6 +123,11 @@ def systemWriteDescriptorsFunction : String :=
   "  mv a0, s2; la a1, swd_ts_be8; jal ra, swd_write_be8\n" ++
   "  la a0, swd_ts_be8; li a1, 8; la a2, swd_4788_val; la a3, swd_4788_vlen\n" ++
   "  jal ra, swd_minimal_copy\n" ++
+  "  # ---- EIP-4788: slot = timestamp + 8191, value = parent_beacon_block_root ----\n" ++
+  "  mv a0, s2; li t0, 8191; add a0, a0, t0\n" ++
+  "  la a1, swd_4788_root_slot; jal ra, swd_write_be32_u64\n" ++
+  "  addi a0, s0, 24; li a1, 32; la a2, swd_4788_root_val; la a3, swd_4788_root_vlen\n" ++
+  "  jal ra, swd_minimal_copy\n" ++
   "  li a0, 0\n" ++
   "  ld ra, 0(sp); ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
   "  addi sp, sp, 32\n" ++
@@ -130,7 +135,8 @@ def systemWriteDescriptorsFunction : String :=
 
 /-! ### zisk_system_write_descriptors probe. Fed a real fixture SSZ input.
     Output: +0 swd_2935_slot(32) +32 2935_vlen +40 2935_val(32)
-            +72 swd_4788_slot(32) +104 4788_vlen +112 4788_val(32). -/
+            +72 swd_4788_slot(32) +104 4788_vlen +112 4788_val(32)
+            +144 swd_4788_root_slot(32) +176 root_vlen +184 root_val(32). -/
 def ziskSystemWriteDescriptorsPrologue : String :=
   "  li sp, 0xa0050000\n" ++
   "  li a0, 0x40000000; addi a0, a0, 18    # SSZ_BASE\n" ++
@@ -158,6 +164,17 @@ def ziskSystemWriteDescriptorsPrologue : String :=
   "  li t3, 32; beq t2, t3, .Lswp_c4d\n" ++
   "  add t4, t1, t2; lbu t5, 0(t4); addi t6, t0, 112; add t6, t6, t2; sb t5, 0(t6); addi t2, t2, 1; j .Lswp_c4\n" ++
   ".Lswp_c4d:\n" ++
+  "  la t1, swd_4788_root_slot; li t2, 0\n" ++
+  ".Lswp_c5:\n" ++
+  "  li t3, 32; beq t2, t3, .Lswp_c5d\n" ++
+  "  add t4, t1, t2; lbu t5, 0(t4); addi t6, t0, 144; add t6, t6, t2; sb t5, 0(t6); addi t2, t2, 1; j .Lswp_c5\n" ++
+  ".Lswp_c5d:\n" ++
+  "  la t1, swd_4788_root_vlen; ld t5, 0(t1); sd t5, 176(t0)\n" ++
+  "  la t1, swd_4788_root_val; li t2, 0\n" ++
+  ".Lswp_c6:\n" ++
+  "  li t3, 32; beq t2, t3, .Lswp_c6d\n" ++
+  "  add t4, t1, t2; lbu t5, 0(t4); addi t6, t0, 184; add t6, t6, t2; sb t5, 0(t6); addi t2, t2, 1; j .Lswp_c6\n" ++
+  ".Lswp_c6d:\n" ++
   "  j .Lswd_pdone\n" ++
   swdReadU64leFunction ++ "\n" ++
   swdWriteBe32U64Function ++ "\n" ++
@@ -176,9 +193,14 @@ def ziskSystemWriteDescriptorsDataSection : String :=
   "swd_4788_slot:\n  .zero 32\n" ++
   ".balign 32\n" ++
   "swd_4788_val:\n  .zero 32\n" ++
+  ".balign 32\n" ++
+  "swd_4788_root_slot:\n  .zero 32\n" ++
+  ".balign 32\n" ++
+  "swd_4788_root_val:\n  .zero 32\n" ++
   ".balign 8\n" ++
   "swd_2935_vlen:\n  .zero 8\n" ++
   "swd_4788_vlen:\n  .zero 8\n" ++
+  "swd_4788_root_vlen:\n  .zero 8\n" ++
   "swd_ts_be8:\n  .zero 8"
 
 def ziskSystemWriteDescriptorsProbeUnit : BuildUnit := {

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -37,7 +37,14 @@
 #     --filter SUBSTR    only fixtures whose relpath contains SUBSTR
 #     --steps N          ziskemu max steps (default $EEST_STEPS or 50000000)
 #     --jobs N|auto      parallel ziskemu jobs (default $EEST_JOBS or auto)
-#     --job-mem-mib N    memory budget per ziskemu job (default $EEST_JOB_MEM_MIB or 8192)
+#     --job-mem-mib N|auto
+#                        memory budget per ziskemu job (default $EEST_JOB_MEM_MIB
+#                        or auto). Auto is derived from the ziskemu build:
+#                        stock builds budget ~7000 MiB/process; patched lowmem
+#                        builds advertising PATCHED-lowmem budget 1024 MiB/process
+#                        for this stateless guest workload.
+#                        CPU cap uses one core/job on patched builds and four
+#                        cores/job on stock builds unless EEST_JOB_CPU_THREADS is set.
 #     --min-succ N       exit 1 if fewer than N succ-bit matches (regression gate)
 #     --min-full N       exit 1 if fewer than N full (105-byte) matches (regression gate)
 #     --min-root N       exit 1 if fewer than N root matches (regression gate)
@@ -60,8 +67,8 @@ FILTER=""
 # halt long before this and are not slowed.
 STEPS="${EEST_STEPS:-50000000}"
 JOBS="${EEST_JOBS:-auto}"
-JOB_MEM_MIB="${EEST_JOB_MEM_MIB:-8192}"
-JOB_CPU_THREADS="${EEST_JOB_CPU_THREADS:-4}"
+JOB_MEM_MIB="${EEST_JOB_MEM_MIB:-auto}"
+JOB_CPU_THREADS="${EEST_JOB_CPU_THREADS:-auto}"
 MEM_RESERVE_MIB="${EEST_MEM_RESERVE_MIB:-4096}"
 MIN_SUCC=""
 MIN_FULL=""
@@ -88,47 +95,17 @@ if [[ "$JOBS" != "auto" ]] && { ! [[ "$JOBS" =~ ^[0-9]+$ ]] || [[ "$JOBS" -lt 1 
   echo "--jobs must be a positive integer or auto (got: $JOBS)" >&2
   exit 1
 fi
-if ! [[ "$JOB_MEM_MIB" =~ ^[0-9]+$ ]] || [[ "$JOB_MEM_MIB" -lt 1 ]]; then
-  echo "--job-mem-mib must be a positive integer (got: $JOB_MEM_MIB)" >&2
+if [[ "$JOB_MEM_MIB" != "auto" ]] && { ! [[ "$JOB_MEM_MIB" =~ ^[0-9]+$ ]] || [[ "$JOB_MEM_MIB" -lt 1 ]]; }; then
+  echo "--job-mem-mib must be a positive integer or auto (got: $JOB_MEM_MIB)" >&2
   exit 1
 fi
-if ! [[ "$JOB_CPU_THREADS" =~ ^[0-9]+$ ]] || [[ "$JOB_CPU_THREADS" -lt 1 ]]; then
-  echo "EEST_JOB_CPU_THREADS must be a positive integer (got: $JOB_CPU_THREADS)" >&2
+if [[ "$JOB_CPU_THREADS" != "auto" ]] && { ! [[ "$JOB_CPU_THREADS" =~ ^[0-9]+$ ]] || [[ "$JOB_CPU_THREADS" -lt 1 ]]; }; then
+  echo "EEST_JOB_CPU_THREADS must be a positive integer or auto (got: $JOB_CPU_THREADS)" >&2
   exit 1
 fi
 if ! [[ "$MEM_RESERVE_MIB" =~ ^[0-9]+$ ]]; then
   echo "EEST_MEM_RESERVE_MIB must be a nonnegative integer (got: $MEM_RESERVE_MIB)" >&2
   exit 1
-fi
-
-compute_job_cap() {
-  local mem_avail_kib mem_avail_mib mem_cap ncpu cpu_cap cap
-  mem_avail_kib="$(awk '/MemAvailable:/ {print $2}' /proc/meminfo 2>/dev/null || true)"
-  if [[ -z "$mem_avail_kib" ]]; then
-    mem_cap=1
-  else
-    mem_avail_mib=$((mem_avail_kib / 1024))
-    if [[ "$mem_avail_mib" -le "$MEM_RESERVE_MIB" ]]; then
-      mem_cap=1
-    else
-      mem_cap=$(((mem_avail_mib - MEM_RESERVE_MIB) / JOB_MEM_MIB))
-      [[ "$mem_cap" -lt 1 ]] && mem_cap=1
-    fi
-  fi
-  ncpu="$(nproc 2>/dev/null || echo 1)"
-  cpu_cap=$((ncpu / JOB_CPU_THREADS))
-  [[ "$cpu_cap" -lt 1 ]] && cpu_cap=1
-  cap="$mem_cap"
-  [[ "$cpu_cap" -lt "$cap" ]] && cap="$cpu_cap"
-  echo "$cap"
-}
-
-JOB_CAP="$(compute_job_cap)"
-if [[ "$JOBS" == "auto" ]]; then
-  JOBS="$JOB_CAP"
-elif [[ "$JOBS" -gt "$JOB_CAP" ]]; then
-  echo "==> requested --jobs $JOBS capped to $JOB_CAP (job_mem=${JOB_MEM_MIB}MiB, reserve=${MEM_RESERVE_MIB}MiB, cpu_threads/job=$JOB_CPU_THREADS)" >&2
-  JOBS="$JOB_CAP"
 fi
 
 cleanup_children() {
@@ -154,6 +131,67 @@ if [[ -z "$ZISKEMU" ]]; then
     exit 1
   fi
 fi
+
+# --- pick parallelism based on the ziskemu build ----------------------------
+# ziskemu's peak RSS is dominated by a fixed allocation built at ELF-load time,
+# independent of the program or step budget. A stock build keeps every ROM
+# instruction in one flat array indexed from the program base; because the
+# embedded float library is linked ~127 MB above the program, that array spans
+# the whole gap (~33M entries) and costs ~6.5 GB. A "PATCHED-lowmem" build moves
+# the float library into its own array; tiny ELFs measure around 30 MB RSS, while
+# the stateless guest measures around 700 MB RSS on real fixtures. We size this
+# harness for the stateless workload.
+ZISKEMU_VERSION="$("$ZISKEMU" --version 2>/dev/null || echo unknown)"
+if [[ "$ZISKEMU_VERSION" == *PATCHED-lowmem* ]]; then
+  ZISKEMU_FLAVOR="patched-lowmem"
+  ZISKEMU_AUTO_JOB_MEM_MIB=1024
+  ZISKEMU_AUTO_JOB_CPU_THREADS=1
+else
+  ZISKEMU_FLAVOR="stock"
+  ZISKEMU_AUTO_JOB_MEM_MIB=7000
+  ZISKEMU_AUTO_JOB_CPU_THREADS=4
+fi
+if [[ "$JOB_MEM_MIB" == "auto" ]]; then
+  JOB_MEM_MIB="$ZISKEMU_AUTO_JOB_MEM_MIB"
+fi
+if [[ "$JOB_CPU_THREADS" == "auto" ]]; then
+  JOB_CPU_THREADS="$ZISKEMU_AUTO_JOB_CPU_THREADS"
+fi
+
+compute_job_cap() {
+  local mem_avail_kib mem_avail_mib mem_cap ncpu cpu_cap cap
+  mem_avail_kib="$(awk '/MemAvailable:/ {print $2}' /proc/meminfo 2>/dev/null || true)"
+  if [[ -z "$mem_avail_kib" ]]; then
+    mem_cap=1
+  else
+    mem_avail_mib=$((mem_avail_kib / 1024))
+    if [[ "$mem_avail_mib" -le "$MEM_RESERVE_MIB" ]]; then
+      mem_cap=1
+    else
+      mem_cap=$(((mem_avail_mib - MEM_RESERVE_MIB) / JOB_MEM_MIB))
+      [[ "$mem_cap" -lt 1 ]] && mem_cap=1
+    fi
+  fi
+  ncpu="$(nproc 2>/dev/null || echo 1)"
+  cpu_cap=$((ncpu / JOB_CPU_THREADS))
+  [[ "$cpu_cap" -lt 1 ]] && cpu_cap=1
+  cap="$mem_cap"
+  [[ "$cpu_cap" -lt "$cap" ]] && cap="$cpu_cap"
+  echo "$cap"
+}
+
+CPUS="$(nproc 2>/dev/null || echo 1)"
+JOB_CAP="$(compute_job_cap)"
+if [[ "$JOBS" == "auto" ]]; then
+  JOBS="$JOB_CAP"
+elif [[ "$JOBS" -gt "$JOB_CAP" ]]; then
+  echo "==> requested --jobs $JOBS capped to $JOB_CAP (job_mem=${JOB_MEM_MIB}MiB, reserve=${MEM_RESERVE_MIB}MiB, cpu_threads/job=$JOB_CPU_THREADS)" >&2
+  JOBS="$JOB_CAP"
+fi
+
+echo "==> ziskemu: $ZISKEMU"
+echo "    version: $ZISKEMU_VERSION"
+echo "    flavor:  $ZISKEMU_FLAVOR (${JOB_MEM_MIB} MiB/proc budget) -> jobs=$JOBS (cpus=$CPUS)"
 
 # --- locate fixtures --------------------------------------------------------
 FX="${EEST_FIXTURES_DIR:-$REPO_ROOT/gen-out/eest-fixtures/$TAG/fixtures/fixtures}"
@@ -296,6 +334,8 @@ BASELINE="$REPO_ROOT/gen-out/eest-baseline.txt"
   echo "  fixture tag: $TAG"
   echo "  selection:   $([[ $ALL -eq 1 ]] && echo all || echo "limit=$LIMIT")${FILTER:+ filter=$FILTER}"
   echo "  ziskemu:     $ZISKEMU (steps=$STEPS)"
+  echo "  zisk build:  $ZISKEMU_FLAVOR -- $ZISKEMU_VERSION"
+  echo "  jobs:        $JOBS (cpus=$CPUS, ${JOB_MEM_MIB} MiB/proc budget)"
   echo "  total:       $total"
   echo "  errored:     $err"
   echo "  ran:         $ran"
@@ -305,7 +345,6 @@ BASELINE="$REPO_ROOT/gen-out/eest-baseline.txt"
   echo "  tail match:    $tail   (bytes 33:105 = offset + chain_config)"
   echo "  root-only diff:$rod   (succ+tail match; ONLY root differs => 1 field from full)"
   echo "  fail:          $fail"
-  echo "  jobs:          $JOBS"
 } | tee "$BASELINE"
 
 echo "==> wrote baseline: $BASELINE"

--- a/scripts/codegen-zisk-system-writes-check.sh
+++ b/scripts/codegen-zisk-system-writes-check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # codegen-zisk-system-writes-check.sh -- verify system_write_descriptors
 # (bead fhsxz.2.4.2.5 steps a/b) on REAL EEST fixtures: derive the EIP-2935 +
-# EIP-4788 (slot, value) the block writes straight from the SSZ payload and
+# EIP-4788 (slot, value) pairs the block writes straight from the SSZ payload and
 # check them against the fixture's own header fields (number/timestamp/parentHash).
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -24,7 +24,7 @@ lake exe codegen --program zisk_system_write_descriptors --halt linux93 -o "$REP
 python3 scripts/eest-stateless-to-input.py --fixtures-dir "$FX" --out-dir "$RUN" --limit "$LIMIT" --filter "$FILTER" >/dev/null
 MAN="$RUN/manifest.tsv"; [[ -s "$MAN" ]] || { echo "no fixtures" >&2; exit 1; }
 
-# Derive expected (slot_2935, val_2935, slot_4788, val_4788) from each input's SSZ.
+# Derive expected system writes from each input's SSZ.
 uv run --directory execution-specs --quiet python3 - "$MAN" <<'PY'
 import sys
 man=open(sys.argv[1]).read().strip().splitlines()
@@ -40,13 +40,15 @@ for line in man:
     v2935=ph.lstrip(b"\x00") or b""
     s4788=ts.to_bytes(32,"big")
     v4788=ts.to_bytes(8,"big").lstrip(b"\x00") or b""
-    out.append("\t".join([f[0], inp, s2935.hex(), v2935.hex(), s4788.hex(), v4788.hex()]))
+    s4788r=(ts + 8191).to_bytes(32,"big")
+    v4788r=outer[24:56].lstrip(b"\x00") or b""
+    out.append("\t".join([f[0], inp, s2935.hex(), v2935.hex(), s4788.hex(), v4788.hex(), s4788r.hex(), v4788r.hex()]))
 open(sys.argv[1]+".exp","w").write("\n".join(out)+"\n")
 print(f"derived expected for {len(out)} fixtures")
 PY
 
 fail=0 n=0
-while IFS=$'\t' read -r label inp s2935 v2935 s4788 v4788; do
+while IFS=$'\t' read -r label inp s2935 v2935 s4788 v4788 s4788r v4788r; do
   n=$((n+1)); out="$RUN/$label.out"
   "$ZISKEMU" -e gen-out/zisk_system_write_descriptors.elf -i "$inp" -o "$out" -n 5000000 >/dev/null 2>&1 </dev/null
   g_s2935="$(xxd -p -s 0 -l 32 "$out"|tr -d '\n')"
@@ -55,12 +57,16 @@ while IFS=$'\t' read -r label inp s2935 v2935 s4788 v4788; do
   g_s4788="$(xxd -p -s 72 -l 32 "$out"|tr -d '\n')"
   g_l4788="$(od -An -tu8 -j 104 -N 8 "$out"|tr -d ' \n')"
   g_v4788="$(xxd -p -s 112 -l "${g_l4788:-0}" "$out" 2>/dev/null|tr -d '\n')"
-  if [[ "$g_s2935" == "$s2935" && "$g_v2935" == "$v2935" && "$g_s4788" == "$s4788" && "$g_v4788" == "$v4788" ]]; then
+  g_s4788r="$(xxd -p -s 144 -l 32 "$out"|tr -d '\n')"
+  g_l4788r="$(od -An -tu8 -j 176 -N 8 "$out"|tr -d ' \n')"
+  g_v4788r="$(xxd -p -s 184 -l "${g_l4788r:-0}" "$out" 2>/dev/null|tr -d '\n')"
+  if [[ "$g_s2935" == "$s2935" && "$g_v2935" == "$v2935" && "$g_s4788" == "$s4788" && "$g_v4788" == "$v4788" && "$g_s4788r" == "$s4788r" && "$g_v4788r" == "$v4788r" ]]; then
     echo "  PASS $(basename "$inp")"
   else
     echo "  FAIL $(basename "$inp")"
     echo "    2935 slot g=$g_s2935 e=$s2935"; echo "    2935 val  g=$g_v2935 e=$v2935"
     echo "    4788 slot g=$g_s4788 e=$s4788"; echo "    4788 val  g=$g_v4788 e=$v4788"
+    echo "    4788 root slot g=$g_s4788r e=$s4788r"; echo "    4788 root val  g=$g_v4788r e=$v4788r"
     fail=1
   fi
 done < "$MAN.exp"


### PR DESCRIPTION
## Summary
- Derive the second EIP-4788 system write (`timestamp + 8191 -> parent_beacon_block_root`) from the SSZ payload.
- Batch the two beacon-roots storage writes into one account update before recording the state-trie descriptor, avoiding duplicate state paths.
- Extend the system-write probe to check both EIP-4788 slot/value pairs.

## Why this matters
The previous post-state recompute only applied the EIP-4788 timestamp slot. Amsterdam blocks also write `parent_beacon_block_root` at `timestamp + 8191`, so valid EIP-4788 fixtures conservatively returned `successful_validation = 0`. This PR makes that account update match the actual two-slot system call.

## EEST frontier
- `block_access_lists_eip4788`: 21/21 full matches.
- Broad 400-input sample: 385/400 full, 399/399 root+tail, 1 errored, 14 fail.
- Previous stacked PR #7796 broad sample: 378/400 full, 399/399 root+tail, 1 errored, 21 fail.
- Remaining visible failures are concentrated in EIP-7778 gas-accounting success-bit cases.

## Validation
- `scripts/codegen-zisk-system-writes-check.sh eip4788 20`
- `scripts/codegen-eest-stateless-check.sh --limit 80 --filter block_access_lists_eip4788 --steps 200000000 --jobs auto`
- `scripts/codegen-eest-stateless-check.sh --limit 20 --filter block_access_lists_cross_index --steps 200000000 --jobs auto`
- `scripts/codegen-eest-stateless-check.sh --limit 160 --filter eip4895 --steps 200000000 --jobs auto --min-full 140`
- `scripts/codegen-eest-stateless-check.sh --limit 400 --steps 200000000 --jobs auto`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' <edited files>`
- `lake build`

Refs #114. Bead: evm-asm-fhsxz.2.4.2.5.

Authored by @pirapira; implemented by Codex.