### PR TITLE
eest: auto-scale ziskemu parallelism from --version

### DIFF
--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -40,6 +40,15 @@
 #     --min-full N       exit 1 if fewer than N full (105-byte) matches (regression gate)
 #     --min-root N       exit 1 if fewer than N root matches (regression gate)
 #     --tag TAG          EEST fixture tag (default $EEST_FIXTURE_TAG or zkevm@v0.4.0)
+#     --jobs N           run N ziskemu invocations in parallel (default: auto).
+#                        The auto value is derived from the ziskemu build: a
+#                        stock build peaks at ~6.5 GB RSS per process (because it
+#                        allocates a flat ROM array spanning the 127 MB gap up to
+#                        the embedded float library), so only a few fit in RAM; a
+#                        "PATCHED-lowmem" build (float library split into its own
+#                        array) peaks at ~22 MB, so we can run ~one-per-core.
+#                        See ziskemu --version to tell which build is installed.
+#                        Override with --jobs N or $EEST_JOBS.
 #
 # Exit:
 #   0 -- ran to completion (baseline mode), or all --min-* thresholds met
@@ -61,6 +70,8 @@ MIN_SUCC=""
 MIN_FULL=""
 MIN_ROOT=""
 TAG="${EEST_FIXTURE_TAG:-zkevm@v0.4.0}"
+# Parallelism: empty => auto-detect from the ziskemu build (see below).
+JOBS="${EEST_JOBS:-}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -72,6 +83,7 @@ while [[ $# -gt 0 ]]; do
     --min-full) MIN_FULL="$2"; shift 2 ;;
     --min-root) MIN_ROOT="$2"; shift 2 ;;
     --tag) TAG="$2"; shift 2 ;;
+    --jobs) JOBS="$2"; shift 2 ;;
     *) echo "unknown arg: $1" >&2; exit 1 ;;
   esac
 done
@@ -88,6 +100,38 @@ if [[ -z "$ZISKEMU" ]]; then
     exit 1
   fi
 fi
+
+# --- pick parallelism based on the ziskemu build ----------------------------
+# ziskemu's peak RSS is dominated by a fixed allocation built at ELF-load time,
+# independent of the program or step budget. A stock build keeps every ROM
+# instruction in one flat array indexed from the program base; because the
+# embedded float library is linked ~127 MB above the program, that array spans
+# the whole gap (~33M entries) and costs ~6.5 GB. A "PATCHED-lowmem" build moves
+# the float library into its own array, dropping peak RSS to ~22 MB. We size the
+# job pool accordingly: stock => memory-bound (few jobs); patched => core-bound.
+ZISKEMU_VERSION="$("$ZISKEMU" --version 2>/dev/null || echo unknown)"
+if [[ "$ZISKEMU_VERSION" == *PATCHED-lowmem* ]]; then
+  ZISKEMU_FLAVOR="patched-lowmem"
+  PER_PROC_MB=128          # ~22 MB peak + headroom
+else
+  ZISKEMU_FLAVOR="stock"
+  PER_PROC_MB=7000         # ~6.5 GB peak, rounded up
+fi
+
+CPUS="$(nproc 2>/dev/null || echo 1)"
+if [[ -z "$JOBS" ]]; then
+  # MemAvailable is the realistic cap; fall back to MemTotal, then 1 job.
+  AVAIL_MB="$(awk '/^MemAvailable:/{print int($2/1024); f=1} END{if(!f) print 0}' /proc/meminfo 2>/dev/null || echo 0)"
+  [[ "$AVAIL_MB" -le 0 ]] && AVAIL_MB="$(awk '/^MemTotal:/{print int($2/1024)}' /proc/meminfo 2>/dev/null || echo "$PER_PROC_MB")"
+  MEM_JOBS=$(( AVAIL_MB / PER_PROC_MB ))
+  (( MEM_JOBS < 1 )) && MEM_JOBS=1
+  JOBS=$(( CPUS < MEM_JOBS ? CPUS : MEM_JOBS ))
+fi
+(( JOBS < 1 )) && JOBS=1
+
+echo "==> ziskemu: $ZISKEMU"
+echo "    version: $ZISKEMU_VERSION"
+echo "    flavor:  $ZISKEMU_FLAVOR (~${PER_PROC_MB} MB/proc budget) -> jobs=$JOBS (cpus=$CPUS)"
 
 # --- locate fixtures --------------------------------------------------------
 FX="${EEST_FIXTURES_DIR:-$REPO_ROOT/gen-out/eest-fixtures/$TAG/fixtures/fixtures}"
@@ -125,13 +169,33 @@ MANIFEST="$RUN_DIR/manifest.tsv"
 #   root [0:32]   = new_payload_request_root  (hex chars 0..64)
 #   succ [32]     = successful_validation     (hex chars 64..66)
 #   tail [33:105] = u32 offset (=37) + 68-byte chain_config (hex 66..210)
+# Phase 1 -- run every guest input on ziskemu, up to $JOBS at a time. Each run
+# records its exit code to "$RUN_DIR/$label.exit"; classification (phase 2) is
+# kept serial so the tallies and the per-fixture report stay deterministic and
+# in manifest order regardless of $JOBS.
+run_one() {
+  local label="$1" input="$2"
+  local rc=0
+  "$ZISKEMU" -e gen-out/stateless_guest.elf -i "$input" -o "$RUN_DIR/$label.output" \
+      -n "$STEPS" >"$RUN_DIR/$label.emu.log" 2>&1 </dev/null || rc=$?
+  printf '%s' "$rc" > "$RUN_DIR/$label.exit"
+}
+
+echo "==> run $(wc -l < "$MANIFEST" | tr -d ' ') guest inputs on ziskemu (jobs=$JOBS)"
+while IFS=$'\t' read -r label input _rest; do
+  run_one "$label" "$input" &
+  # Bound concurrency: while $JOBS are already running, wait for one to finish.
+  while (( $(jobs -rp | wc -l) >= JOBS )); do wait -n; done
+done < "$MANIFEST"
+wait
+
+# Phase 2 -- classify the recorded outputs (serial, manifest order).
 total=0 err=0 full=0 succ=0 root=0 tail=0 fail=0 rod=0
 while IFS=$'\t' read -r label input expected_hex succ_bit input_len relpath; do
   total=$((total + 1))
   out="$RUN_DIR/$label.output"
-  log="$RUN_DIR/$label.emu.log"
-  if ! "$ZISKEMU" -e gen-out/stateless_guest.elf -i "$input" -o "$out" \
-        -n "$STEPS" >"$log" 2>&1 </dev/null; then
+  rc="$(cat "$RUN_DIR/$label.exit" 2>/dev/null || echo 1)"
+  if [[ "$rc" != 0 ]]; then
     err=$((err + 1)); echo "  ERROR(exit)   $relpath"; continue
   fi
   actual_hex="$(xxd -p -l 105 "$out" 2>/dev/null | tr -d '\n' || true)"
@@ -166,6 +230,8 @@ BASELINE="$REPO_ROOT/gen-out/eest-baseline.txt"
   echo "  fixture tag: $TAG"
   echo "  selection:   $([[ $ALL -eq 1 ]] && echo all || echo "limit=$LIMIT")${FILTER:+ filter=$FILTER}"
   echo "  ziskemu:     $ZISKEMU (steps=$STEPS)"
+  echo "  zisk build:  $ZISKEMU_FLAVOR -- $ZISKEMU_VERSION"
+  echo "  jobs:        $JOBS (cpus=$CPUS, ~${PER_PROC_MB} MB/proc budget)"
   echo "  total:       $total"
   echo "  errored:     $err"
   echo "  ran:         $ran"


### PR DESCRIPTION
## What

The EEST stateless conformance runner (`scripts/codegen-eest-stateless-check.sh`) ran `ziskemu` **serially**. This change parallelizes it and **sizes the job pool automatically from the ziskemu build**, detected via `ziskemu --version`.

## Why

`ziskemu`'s peak RSS is a *fixed* allocation made at ELF-load time — independent of the guest program or the `-n` step budget (measured constant ~6.5 GB whether `-n` is 1k or 10M):

- **Stock build:** every ROM instruction lives in one flat `Vec<ZiskInst>` indexed from the program base (`0x80000000`). The embedded float library is linked at `FLOAT_LIB_ROM_ADDR ≈ 0x87F00000`, ~127 MB above the program, so the array must span the whole gap — **~33 M `ZiskInst` entries × ~200 B ≈ 6.2 GiB**, almost all empty padding. Confirmed via gdb backtrace into `zisk_core::elf2rom::elf2rom` → `rayon … collect`.
- **Patched build:** splitting the float library into its own array drops peak RSS to **~22 MB**. Such a build self-identifies in `--version` with the suffix `[PATCHED-lowmem-floatlibsplit]`.

So the right degree of parallelism depends entirely on which build is installed: stock is memory-bound (a couple of processes saturate RAM), patched is core-bound.

## How

- Reads `ziskemu --version`; classifies the build as `patched-lowmem` (~128 MB/proc budget) or `stock` (~7000 MB/proc budget).
- Auto job count = `min(nproc, MemAvailable / per-proc-budget)`, floor 1. Override with `--jobs N` or `$EEST_JOBS`.
- Runs ziskemu in a bounded background pool (`wait -n`); **classification stays serial**, so tallies and the per-fixture report remain deterministic and in manifest order.
- Baseline file now records the detected build flavor and chosen job count.

## Validation

| build | detected | jobs | result |
|---|---|---|---|
| patched | `patched-lowmem` | 32 (cpus=32) | `--limit 16` → 16/16 full match, 0 errors |
| stock | `stock` | 2 (`--jobs 2`) | `--limit 4` → 4/4 full match, 0 errors |

Separately, the patched `ziskemu` was checked for output parity against the stock binary: **25/25 real EEST inputs and all bundled `gen-out/*.elf` produce byte-identical output**.

> Note: this PR only changes the runner script. The low-memory `ziskemu` is an out-of-tree build of the emulator (float-library array split) and is detected — not required; on a stock `ziskemu` the script simply chooses a memory-safe (smaller) job count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)