### PR TITLE
fix(eest): size ziskemu auto jobs by build flavor

### DIFF
--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -37,7 +37,14 @@
 #     --filter SUBSTR    only fixtures whose relpath contains SUBSTR
 #     --steps N          ziskemu max steps (default $EEST_STEPS or 50000000)
 #     --jobs N|auto      parallel ziskemu jobs (default $EEST_JOBS or auto)
-#     --job-mem-mib N    memory budget per ziskemu job (default $EEST_JOB_MEM_MIB or 8192)
+#     --job-mem-mib N|auto
+#                        memory budget per ziskemu job (default $EEST_JOB_MEM_MIB
+#                        or auto). Auto is derived from the ziskemu build:
+#                        stock builds budget ~7000 MiB/process; patched lowmem
+#                        builds advertising PATCHED-lowmem budget 1024 MiB/process
+#                        for this stateless guest workload.
+#                        CPU cap uses one core/job on patched builds and four
+#                        cores/job on stock builds unless EEST_JOB_CPU_THREADS is set.
 #     --min-succ N       exit 1 if fewer than N succ-bit matches (regression gate)
 #     --min-full N       exit 1 if fewer than N full (105-byte) matches (regression gate)
 #     --min-root N       exit 1 if fewer than N root matches (regression gate)
@@ -60,8 +67,8 @@ FILTER=""
 # halt long before this and are not slowed.
 STEPS="${EEST_STEPS:-50000000}"
 JOBS="${EEST_JOBS:-auto}"
-JOB_MEM_MIB="${EEST_JOB_MEM_MIB:-8192}"
-JOB_CPU_THREADS="${EEST_JOB_CPU_THREADS:-4}"
+JOB_MEM_MIB="${EEST_JOB_MEM_MIB:-auto}"
+JOB_CPU_THREADS="${EEST_JOB_CPU_THREADS:-auto}"
 MEM_RESERVE_MIB="${EEST_MEM_RESERVE_MIB:-4096}"
 MIN_SUCC=""
 MIN_FULL=""
@@ -88,47 +95,17 @@ if [[ "$JOBS" != "auto" ]] && { ! [[ "$JOBS" =~ ^[0-9]+$ ]] || [[ "$JOBS" -lt 1 
   echo "--jobs must be a positive integer or auto (got: $JOBS)" >&2
   exit 1
 fi
-if ! [[ "$JOB_MEM_MIB" =~ ^[0-9]+$ ]] || [[ "$JOB_MEM_MIB" -lt 1 ]]; then
-  echo "--job-mem-mib must be a positive integer (got: $JOB_MEM_MIB)" >&2
+if [[ "$JOB_MEM_MIB" != "auto" ]] && { ! [[ "$JOB_MEM_MIB" =~ ^[0-9]+$ ]] || [[ "$JOB_MEM_MIB" -lt 1 ]]; }; then
+  echo "--job-mem-mib must be a positive integer or auto (got: $JOB_MEM_MIB)" >&2
   exit 1
 fi
-if ! [[ "$JOB_CPU_THREADS" =~ ^[0-9]+$ ]] || [[ "$JOB_CPU_THREADS" -lt 1 ]]; then
-  echo "EEST_JOB_CPU_THREADS must be a positive integer (got: $JOB_CPU_THREADS)" >&2
+if [[ "$JOB_CPU_THREADS" != "auto" ]] && { ! [[ "$JOB_CPU_THREADS" =~ ^[0-9]+$ ]] || [[ "$JOB_CPU_THREADS" -lt 1 ]]; }; then
+  echo "EEST_JOB_CPU_THREADS must be a positive integer or auto (got: $JOB_CPU_THREADS)" >&2
   exit 1
 fi
 if ! [[ "$MEM_RESERVE_MIB" =~ ^[0-9]+$ ]]; then
   echo "EEST_MEM_RESERVE_MIB must be a nonnegative integer (got: $MEM_RESERVE_MIB)" >&2
   exit 1
-fi
-
-compute_job_cap() {
-  local mem_avail_kib mem_avail_mib mem_cap ncpu cpu_cap cap
-  mem_avail_kib="$(awk '/MemAvailable:/ {print $2}' /proc/meminfo 2>/dev/null || true)"
-  if [[ -z "$mem_avail_kib" ]]; then
-    mem_cap=1
-  else
-    mem_avail_mib=$((mem_avail_kib / 1024))
-    if [[ "$mem_avail_mib" -le "$MEM_RESERVE_MIB" ]]; then
-      mem_cap=1
-    else
-      mem_cap=$(((mem_avail_mib - MEM_RESERVE_MIB) / JOB_MEM_MIB))
-      [[ "$mem_cap" -lt 1 ]] && mem_cap=1
-    fi
-  fi
-  ncpu="$(nproc 2>/dev/null || echo 1)"
-  cpu_cap=$((ncpu / JOB_CPU_THREADS))
-  [[ "$cpu_cap" -lt 1 ]] && cpu_cap=1
-  cap="$mem_cap"
-  [[ "$cpu_cap" -lt "$cap" ]] && cap="$cpu_cap"
-  echo "$cap"
-}
-
-JOB_CAP="$(compute_job_cap)"
-if [[ "$JOBS" == "auto" ]]; then
-  JOBS="$JOB_CAP"
-elif [[ "$JOBS" -gt "$JOB_CAP" ]]; then
-  echo "==> requested --jobs $JOBS capped to $JOB_CAP (job_mem=${JOB_MEM_MIB}MiB, reserve=${MEM_RESERVE_MIB}MiB, cpu_threads/job=$JOB_CPU_THREADS)" >&2
-  JOBS="$JOB_CAP"
 fi
 
 cleanup_children() {
@@ -154,6 +131,67 @@ if [[ -z "$ZISKEMU" ]]; then
     exit 1
   fi
 fi
+
+# --- pick parallelism based on the ziskemu build ----------------------------
+# ziskemu's peak RSS is dominated by a fixed allocation built at ELF-load time,
+# independent of the program or step budget. A stock build keeps every ROM
+# instruction in one flat array indexed from the program base; because the
+# embedded float library is linked ~127 MB above the program, that array spans
+# the whole gap (~33M entries) and costs ~6.5 GB. A "PATCHED-lowmem" build moves
+# the float library into its own array; tiny ELFs measure around 30 MB RSS, while
+# the stateless guest measures around 700 MB RSS on real fixtures. We size this
+# harness for the stateless workload.
+ZISKEMU_VERSION="$("$ZISKEMU" --version 2>/dev/null || echo unknown)"
+if [[ "$ZISKEMU_VERSION" == *PATCHED-lowmem* ]]; then
+  ZISKEMU_FLAVOR="patched-lowmem"
+  ZISKEMU_AUTO_JOB_MEM_MIB=1024
+  ZISKEMU_AUTO_JOB_CPU_THREADS=1
+else
+  ZISKEMU_FLAVOR="stock"
+  ZISKEMU_AUTO_JOB_MEM_MIB=7000
+  ZISKEMU_AUTO_JOB_CPU_THREADS=4
+fi
+if [[ "$JOB_MEM_MIB" == "auto" ]]; then
+  JOB_MEM_MIB="$ZISKEMU_AUTO_JOB_MEM_MIB"
+fi
+if [[ "$JOB_CPU_THREADS" == "auto" ]]; then
+  JOB_CPU_THREADS="$ZISKEMU_AUTO_JOB_CPU_THREADS"
+fi
+
+compute_job_cap() {
+  local mem_avail_kib mem_avail_mib mem_cap ncpu cpu_cap cap
+  mem_avail_kib="$(awk '/MemAvailable:/ {print $2}' /proc/meminfo 2>/dev/null || true)"
+  if [[ -z "$mem_avail_kib" ]]; then
+    mem_cap=1
+  else
+    mem_avail_mib=$((mem_avail_kib / 1024))
+    if [[ "$mem_avail_mib" -le "$MEM_RESERVE_MIB" ]]; then
+      mem_cap=1
+    else
+      mem_cap=$(((mem_avail_mib - MEM_RESERVE_MIB) / JOB_MEM_MIB))
+      [[ "$mem_cap" -lt 1 ]] && mem_cap=1
+    fi
+  fi
+  ncpu="$(nproc 2>/dev/null || echo 1)"
+  cpu_cap=$((ncpu / JOB_CPU_THREADS))
+  [[ "$cpu_cap" -lt 1 ]] && cpu_cap=1
+  cap="$mem_cap"
+  [[ "$cpu_cap" -lt "$cap" ]] && cap="$cpu_cap"
+  echo "$cap"
+}
+
+CPUS="$(nproc 2>/dev/null || echo 1)"
+JOB_CAP="$(compute_job_cap)"
+if [[ "$JOBS" == "auto" ]]; then
+  JOBS="$JOB_CAP"
+elif [[ "$JOBS" -gt "$JOB_CAP" ]]; then
+  echo "==> requested --jobs $JOBS capped to $JOB_CAP (job_mem=${JOB_MEM_MIB}MiB, reserve=${MEM_RESERVE_MIB}MiB, cpu_threads/job=$JOB_CPU_THREADS)" >&2
+  JOBS="$JOB_CAP"
+fi
+
+echo "==> ziskemu: $ZISKEMU"
+echo "    version: $ZISKEMU_VERSION"
+echo "    flavor:  $ZISKEMU_FLAVOR (${JOB_MEM_MIB} MiB/proc budget) -> jobs=$JOBS (cpus=$CPUS)"
 
 # --- locate fixtures --------------------------------------------------------
 FX="${EEST_FIXTURES_DIR:-$REPO_ROOT/gen-out/eest-fixtures/$TAG/fixtures/fixtures}"
@@ -296,6 +334,8 @@ BASELINE="$REPO_ROOT/gen-out/eest-baseline.txt"
   echo "  fixture tag: $TAG"
   echo "  selection:   $([[ $ALL -eq 1 ]] && echo all || echo "limit=$LIMIT")${FILTER:+ filter=$FILTER}"
   echo "  ziskemu:     $ZISKEMU (steps=$STEPS)"
+  echo "  zisk build:  $ZISKEMU_FLAVOR -- $ZISKEMU_VERSION"
+  echo "  jobs:        $JOBS (cpus=$CPUS, ${JOB_MEM_MIB} MiB/proc budget)"
   echo "  total:       $total"
   echo "  errored:     $err"
   echo "  ran:         $ran"
@@ -305,7 +345,6 @@ BASELINE="$REPO_ROOT/gen-out/eest-baseline.txt"
   echo "  tail match:    $tail   (bytes 33:105 = offset + chain_config)"
   echo "  root-only diff:$rod   (succ+tail match; ONLY root differs => 1 field from full)"
   echo "  fail:          $fail"
-  echo "  jobs:          $JOBS"
 } | tee "$BASELINE"
 
 echo "==> wrote baseline: $BASELINE"


### PR DESCRIPTION
## Summary
- Replace PR #7798 with a safer version of ziskemu-aware EEST auto-parallelism.
- Detect `PATCHED-lowmem` from `ziskemu --version` and size jobs from `MemAvailable`, CPU count, and per-build budgets.
- Keep the existing bounded worker/result-file harness behavior instead of switching to the simpler PR #7798 runner.

## Measured memory
- Installed ziskemu: `ziskemu 0.16.0 ... [PATCHED-lowmem-floatlibsplit]`.
- Tiny ELF (`add_basic.elf`): max RSS `30356 kB` (~30 MiB).
- Real `stateless_guest` fixture: max RSS `713788 kB` (~697 MiB).
- Therefore patched stateless runs use a conservative `1024 MiB` per-process auto budget; stock builds stay at `7000 MiB`.

## Validation
- `bash -n scripts/codegen-eest-stateless-check.sh`
- Measured patched install with `/usr/bin/time -v ziskemu ...` on both tiny and stateless guest workloads.
- Smoke invocation reached auto detection and reported `patched-lowmem (1024 MiB/proc budget) -> jobs=32 (cpus=32)` before the clean worktree had to rebuild dependencies.

Supersedes #7798.

Authored by @pirapira; implemented by Codex.