### PR TITLE
feat(eest): widen BAL storage replay scratch

### DIFF
--- a/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
@@ -246,7 +246,7 @@ def balAccountApplyPostFieldsFunction : String :=
   ".Lbaap_multi_loop:\n" ++
   "  la t0, baap_sc_index; ld t0, 0(t0); la t1, baap_sc_count; ld t1, 0(t1)\n" ++
   "  beq t0, t1, .Lbaap_multi_apply\n" ++
-  "  li t2, 32; bgeu t0, t2, .Lbaap_fail\n" ++
+  "  li t2, 64; bgeu t0, t2, .Lbaap_fail\n" ++
   "  la t1, baap_sc_ptr; ld a0, 0(t1); la t1, baap_sc_len; ld a1, 0(t1); mv a2, t0\n" ++
   "  la a3, baap_item_off; la a4, baap_item_len\n" ++
   "  jal ra, rlp_list_nth_item\n" ++
@@ -529,9 +529,9 @@ def ziskBalAccountApplyPostFieldsDataSection : String :=
   "baap_tmp3:\n  .zero 512\n" ++
   "baap_storage_value_cursor:\n  .zero 8\n" ++
   "baap_walk_val:\n  .zero 128\n" ++
-  "baap_storage_desc:\n  .zero 1280\n" ++
-  "baap_storage_paths:\n  .zero 2048\n" ++
-  "baap_storage_values:\n  .zero 2048\n" ++
+  "baap_storage_desc:\n  .zero 2560\n" ++
+  "baap_storage_paths:\n  .zero 4096\n" ++
+  "baap_storage_values:\n  .zero 4096\n" ++
   "baap_out_pad:\n  .zero 8"
 
 def ziskBalAccountApplyPostFieldsProbeUnit : BuildUnit := {

--- a/EvmAsm/Codegen/Programs/BalAccountStateRoot.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountStateRoot.lean
@@ -254,9 +254,9 @@ def ziskBalAccountStateRootDataSection : String :=
   "baap_tmp2:\n  .zero 512\n" ++
   "baap_tmp3:\n  .zero 512\n" ++
   "baap_storage_value_cursor:\n  .zero 8\n" ++
-  "baap_storage_desc:\n  .zero 1280\n" ++
-  "baap_storage_paths:\n  .zero 2048\n" ++
-  "baap_storage_values:\n  .zero 2048\n" ++
+  "baap_storage_desc:\n  .zero 2560\n" ++
+  "baap_storage_paths:\n  .zero 4096\n" ++
+  "baap_storage_values:\n  .zero 4096\n" ++
   "bacp_off:\n  .zero 8\n" ++
   "bacp_len:\n  .zero 8\n" ++
   ".balign 32\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -740,9 +740,9 @@ def ziskStatelessVerdictV2DataSection : String :=
   "baap_tmp3:\n  .zero 512\n" ++
   "baap_storage_value_cursor:\n  .zero 8\n" ++
   "baap_walk_val:\n  .zero 128\n" ++
-  "baap_storage_desc:\n  .zero 1280\n" ++
-  "baap_storage_paths:\n  .zero 2048\n" ++
-  "baap_storage_values:\n  .zero 2048\n" ++
+  "baap_storage_desc:\n  .zero 2560\n" ++
+  "baap_storage_paths:\n  .zero 4096\n" ++
+  "baap_storage_values:\n  .zero 4096\n" ++
   "bacp_off:\n  .zero 8\n" ++
   "bacp_len:\n  .zero 8\n" ++
   ".balign 32\n" ++


### PR DESCRIPTION
## Summary
- raise BAL multi-storage replay cap from 32 to 64 entries
- resize descriptor/path/value scratch buffers used by standalone BAL replay and stateless verdict data
- cover the EIP-7002 partial-sweep block with 44 queue storage changes while keeping mixed non-empty deletion conservative

## Validation
- `lake build EvmAsm.Codegen.Programs.BalAccountApplyPostFields EvmAsm.Codegen.Programs.BalAccountStateRoot EvmAsm.Codegen.Programs.BlockVerdict`
- `scripts/codegen-eest-stateless-check.sh --limit 20 --filter bal_7002_partial_sweep --steps 200000000 --jobs 32` -> 1/2 full, 2/2 root, 1/2 succ, 0 errors
- `scripts/codegen-eest-stateless-check.sh --limit 500 --steps 200000000 --jobs 32` -> 499/500 full, 500/500 root, 499/500 succ, 0 errors
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean EvmAsm/Codegen/Programs/BalAccountStateRoot.lean EvmAsm/Codegen/Programs/BlockVerdict.lean` -> no matches
- `lake build`

## Frontier
- stacked on #7803
- first-500 EEST frontier is now one remaining miss: `bal_7002_partial_sweep.json` block 2
- that remaining case needs mixed non-empty storage deletion support, because it writes slot 0 and deletes queue slots 2 and 3 from an existing storage trie

Bead: evm-asm-fhsxz.2.4.2.5

Authored by @pirapira; implemented by Codex.