### PR TITLE
fix(eest): reject EIP-8037 gas inclusion overflow

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -29,6 +29,7 @@ import EvmAsm.Codegen.Programs.SystemWrites
 import EvmAsm.Codegen.Programs.AccountApplyStorage
 import EvmAsm.Codegen.Programs.StatelessVerdict
 import EvmAsm.Codegen.Programs.BalGasValid
+import EvmAsm.Codegen.Programs.TxExtract
 import EvmAsm.Codegen.Programs.BalAccountStateRoot
 import EvmAsm.Codegen.Programs.MptInsertAcc
 import EvmAsm.Codegen.Programs.MptDeleteAcc
@@ -360,6 +361,207 @@ def blockStateRootFunction : String :=
   "  addi sp, sp, 48\n" ++
   "  ret"
 
+/-! ## eip8037_tx_gas_gate -- conservative legacy transaction inclusion gate.
+    a0 = exec_payload ptr   a1 = BAL ptr   a2 = BAL len   a3 = block_gas_limit
+    a0 (output) = 0 ok/unsupported, 1 regular overflow, 2 state overflow.
+
+    This mirrors Amsterdam `check_transaction` only for the legacy tx fixtures we
+    can parse cheaply here. Unsupported typed txs, malformed tx lists, or large
+    transaction counts fail open so the state-root verdict does not reject blocks
+    for a partial gas model. -/
+def eip8037TxGasGateFunction : String :=
+  "eip8037_state_used_before_tx:\n" ++
+  "  addi sp, sp, -96\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp); sd s10, 88(sp)\n" ++
+  "  mv s0, a0                   # BAL ptr\n" ++
+  "  mv s1, a1                   # BAL len\n" ++
+  "  mv s2, a2                   # target tx index (1-based)\n" ++
+  "  mv s3, a3                   # out ptr\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  mv a0, s0; mv a1, s1; la a2, bsg_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lesub_ok\n" ++
+  "  la t0, bsg_count; ld s4, 0(t0)        # account count\n" ++
+  "  li s5, 0                              # account i\n" ++
+  ".Lesub_acct_loop:\n" ++
+  "  beq s5, s4, .Lesub_ok\n" ++
+  "  mv a0, s0; mv a1, s1; mv a2, s5; la a3, bsg_off; la a4, bsg_len\n" ++
+  "  jal ra, rlp_item_span\n" ++
+  "  bnez a0, .Lesub_ok\n" ++
+  "  la t0, bsg_off; ld t1, 0(t0); add s6, s0, t1     # account ptr\n" ++
+  "  la t0, bsg_len; ld s7, 0(t0)                     # account len\n" ++
+  "  mv a0, s6; mv a1, s7; li a2, 1; la a3, bsg_off; la a4, bsg_len\n" ++
+  "  jal ra, rlp_item_span                              # storage_changes list\n" ++
+  "  bnez a0, .Lesub_next_acct\n" ++
+  "  la t0, bsg_off; ld t1, 0(t0); add s8, s6, t1      # storage_changes ptr\n" ++
+  "  la t0, bsg_len; ld s9, 0(t0)                      # storage_changes len\n" ++
+  "  mv a0, s8; mv a1, s9; la a2, bsg_slot_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lesub_next_acct\n" ++
+  "  la t0, bsg_slot_count; ld s10, 0(t0)\n" ++
+  "  li s6, 0                                          # slot i\n" ++
+  ".Lesub_slot_loop:\n" ++
+  "  beq s6, s10, .Lesub_next_acct\n" ++
+  "  mv a0, s8; mv a1, s9; mv a2, s6; la a3, bsg_slot_off; la a4, bsg_slot_len\n" ++
+  "  jal ra, rlp_item_span\n" ++
+  "  bnez a0, .Lesub_next_slot\n" ++
+  "  la t0, bsg_slot_off; ld t1, 0(t0); add t2, s8, t1 # slot-change ptr\n" ++
+  "  la t0, bsg_slot_len; ld t3, 0(t0)                 # slot-change len\n" ++
+  "  la t0, bsg_slot_ptr; sd t2, 0(t0); la t0, bsg_slot_item_len; sd t3, 0(t0)\n" ++
+  "  mv a0, t2; mv a1, t3; li a2, 1; la a3, bsg_changes_off; la a4, bsg_changes_len\n" ++
+  "  jal ra, rlp_item_span                              # per-slot changes list\n" ++
+  "  bnez a0, .Lesub_next_slot\n" ++
+  "  la t0, bsg_slot_ptr; ld t2, 0(t0); la t0, bsg_changes_off; ld t1, 0(t0); add t2, t2, t1\n" ++
+  "  la t0, bsg_changes_ptr; sd t2, 0(t0)\n" ++
+  "  la t0, bsg_changes_len; ld t3, 0(t0)\n" ++
+  "  mv a0, t2; mv a1, t3; la a2, bsg_change_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lesub_next_slot\n" ++
+  "  la t0, bsg_change_count; ld t4, 0(t0); beqz t4, .Lesub_next_slot\n" ++
+  "  addi t4, t4, -1                                  # final change only\n" ++
+  "  la t0, bsg_changes_ptr; ld a0, 0(t0); la t0, bsg_changes_len; ld a1, 0(t0); mv a2, t4; la a3, bsg_change_off; la a4, bsg_change_len\n" ++
+  "  jal ra, rlp_item_span\n" ++
+  "  bnez a0, .Lesub_next_slot\n" ++
+  "  la t0, bsg_changes_ptr; ld t2, 0(t0); la t0, bsg_change_off; ld t1, 0(t0); add t2, t2, t1\n" ++
+  "  la t0, bsg_change_len; ld t3, 0(t0)\n" ++
+  "  la t0, bsg_change_ptr; sd t2, 0(t0); la t0, bsg_change_item_len; sd t3, 0(t0)\n" ++
+  "  mv a0, t2; mv a1, t3; li a2, 0; la a3, bsg_idx_off; la a4, bsg_idx_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lesub_next_slot\n" ++
+  "  la t0, bsg_change_ptr; ld a0, 0(t0); la t0, bsg_change_item_len; ld a1, 0(t0); li a2, 0; la a3, bsg_index\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lesub_next_slot\n" ++
+  "  la t0, bsg_index; ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lesub_next_slot                         # system writes do not spend tx state gas\n" ++
+  "  bgeu t1, s2, .Lesub_next_slot\n" ++
+  "  la t0, bsg_change_ptr; ld a0, 0(t0); la t0, bsg_change_item_len; ld a1, 0(t0); li a2, 1; la a3, bsg_value_off; la a4, bsg_value_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lesub_next_slot\n" ++
+  "  la t0, bsg_value_len; ld t1, 0(t0); beqz t1, .Lesub_next_slot\n" ++
+  "  ld t2, 0(s3); li t3, 97920; add t2, t2, t3; sd t2, 0(s3)\n" ++
+  ".Lesub_next_slot:\n" ++
+  "  addi s6, s6, 1; j .Lesub_slot_loop\n" ++
+  ".Lesub_next_acct:\n" ++
+  "  addi s5, s5, 1; j .Lesub_acct_loop\n" ++
+  ".Lesub_ok:\n" ++
+  "  li a0, 0\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp)\n" ++
+  "  addi sp, sp, 96\n" ++
+  "  ret\n" ++
+  "eip8037_tx_gas_gate:\n" ++
+  "  addi sp, sp, -112\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp); sd s10, 88(sp); sd s11, 96(sp)\n" ++
+  "  mv s0, a0                   # exec_payload\n" ++
+  "  mv s1, a1                   # BAL ptr\n" ++
+  "  mv s2, a2                   # BAL len\n" ++
+  "  mv s3, a3                   # gas_limit\n" ++
+  "  li s4, 0                    # accumulated worst regular gas\n" ++
+  "  addi a0, s0, 504; jal ra, bgv_u32le\n" ++
+  "  add s5, s0, a0              # tx list ptr\n" ++
+  "  addi a0, s0, 508; jal ra, bgv_u32le\n" ++
+  "  sub s6, a0, a0              # clear before bounds checks\n" ++
+  "  add t0, s0, a0              # withdrawals ptr\n" ++
+  "  sub s6, t0, s5              # tx list len\n" ++
+  "  bltu t0, s5, .Letg_ok\n" ++
+  "  beqz s6, .Letg_ok\n" ++
+  "  mv a0, s5; jal ra, bgv_u32le\n" ++
+  "  andi t0, a0, 3; bnez t0, .Letg_ok\n" ++
+  "  srli s7, a0, 2              # tx_count = first offset / 4\n" ++
+  "  beqz s7, .Letg_ok\n" ++
+  "  li t0, 16; bgtu s7, t0, .Letg_ok\n" ++
+  "  li s8, 0                    # tx index, 0-based\n" ++
+  ".Letg_tx_loop:\n" ++
+  "  beq s8, s7, .Letg_ok\n" ++
+  "  slli t0, s8, 2; add t1, s5, t0; mv a0, t1; jal ra, bgv_u32le\n" ++
+  "  mv s9, a0                   # item_off\n" ++
+  "  addi t0, s8, 1\n" ++
+  "  beq t0, s7, .Letg_last_tx\n" ++
+  "  slli t1, t0, 2; add t1, s5, t1; mv a0, t1; jal ra, bgv_u32le\n" ++
+  "  j .Letg_have_next\n" ++
+  ".Letg_last_tx:\n" ++
+  "  mv a0, s6\n" ++
+  ".Letg_have_next:\n" ++
+  "  bltu a0, s9, .Letg_ok\n" ++
+  "  sub s10, a0, s9             # tx len\n" ++
+  "  add s9, s5, s9              # tx ptr\n" ++
+  "  mv a0, s9; mv a1, s10; la a2, bsg_tx_type; la a3, bsg_tx_inner\n" ++
+  "  jal ra, tx_type_dispatch\n" ++
+  "  bnez a0, .Letg_ok\n" ++
+  "  la t0, bsg_tx_type; ld t1, 0(t0); bnez t1, .Letg_ok  # legacy only\n" ++
+  "  mv a0, s9; mv a1, s10; li a2, 2; la a3, bsg_tx_gas\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Letg_ok\n" ++
+  "  li s11, 21000               # intrinsic regular\n" ++
+  "  mv a0, s9; mv a1, s10; li a2, 5; la a3, bsg_data_off; la a4, bsg_data_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Letg_ok\n" ++
+  "  la t0, bsg_data_off; ld t1, 0(t0); add t1, s9, t1\n" ++
+  "  la t0, bsg_data_len; ld t2, 0(t0)\n" ++
+  "  li t3, 0\n" ++
+  ".Letg_data_loop:\n" ++
+  "  beq t3, t2, .Letg_data_done\n" ++
+  "  add t4, t1, t3; lbu t5, 0(t4); beqz t5, .Letg_data_zero\n" ++
+  "  addi s11, s11, 16; j .Letg_data_next\n" ++
+  ".Letg_data_zero:\n" ++
+  "  addi s11, s11, 4\n" ++
+  ".Letg_data_next:\n" ++
+  "  addi t3, t3, 1; j .Letg_data_loop\n" ++
+  ".Letg_data_done:\n" ++
+  "  mv a0, s9; mv a1, s10; li a2, 3; la a3, bsg_to_off; la a4, bsg_to_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Letg_ok\n" ++
+  "  li t6, 0                    # intrinsic state\n" ++
+  "  la t0, bsg_to_len; ld t1, 0(t0); bnez t1, .Letg_intrinsic_done\n" ++
+  "  li t0, 9000; add s11, s11, t0\n" ++
+  "  la t0, bsg_data_len; ld t1, 0(t0); addi t1, t1, 31; srli t1, t1, 5; slli t1, t1, 1; add s11, s11, t1\n" ++
+  "  li t6, 183600\n" ++
+  ".Letg_intrinsic_done:\n" ++
+  "  la t0, bsg_tx_gas; ld t1, 0(t0)\n" ++
+  "  bltu t1, t6, .Letg_ok\n" ++
+  "  sub t2, t1, t6              # tx.gas - intrinsic.state\n" ++
+  "  li t3, 16777216\n" ++
+  "  bleu t2, t3, .Letg_regular_have\n" ++
+  "  mv t2, t3\n" ++
+  ".Letg_regular_have:\n" ++
+  "  bltu s3, s4, .Letg_regular_fail\n" ++
+  "  sub t4, s3, s4\n" ++
+  "  bgtu t2, t4, .Letg_regular_fail\n" ++
+  "  add s4, s4, t2\n" ++
+  "  bltu t1, s11, .Letg_ok\n" ++
+  "  sub t2, t1, s11             # tx.gas - intrinsic.regular\n" ++
+  "  la t0, bsg_worst_state; sd t2, 0(t0)\n" ++
+  "  addi a2, s8, 1\n" ++
+  "  mv a0, s1; mv a1, s2; la a3, bsg_prior_state\n" ++
+  "  jal ra, eip8037_state_used_before_tx\n" ++
+  "  la t0, bsg_worst_state; ld t2, 0(t0)\n" ++
+  "  la t0, bsg_prior_state; ld t3, 0(t0)\n" ++
+  "  bltu s3, t3, .Letg_state_fail\n" ++
+  "  sub t4, s3, t3\n" ++
+  "  bgtu t2, t4, .Letg_state_fail\n" ++
+  "  addi s8, s8, 1; j .Letg_tx_loop\n" ++
+  ".Letg_regular_fail:\n" ++
+  "  li a0, 1; j .Letg_ret\n" ++
+  ".Letg_state_fail:\n" ++
+  "  li a0, 2; j .Letg_ret\n" ++
+  ".Letg_ok:\n" ++
+  "  li a0, 0\n" ++
+  ".Letg_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp); ld s11, 96(sp)\n" ++
+  "  addi sp, sp, 112\n" ++
+  "  ret"
+
 /-! ## block_verdict -- step2_verdict with the FULL (system + withdrawal) recompute.
     a0 = params ptr (the step2_verdict struct)   a1 = SSZ_BASE
     a0 (output) = verdict bit. -/
@@ -430,6 +632,16 @@ def blockVerdictFunction : String :=
   "  la t2, bv_bal_len; ld a1, 0(t2)            # bal_len\n" ++
   "  jal ra, bal_gas_valid\n" ++
   "  bnez a0, .Lbv_bal_gas_fail          # BAL gas exceeded (or parse fail) -> invalid\n" ++
+  "  # EIP-8037 tx inclusion gas gate: reject parse-supported legacy tx blocks\n" ++
+  "  # whose worst regular/state gas exceeds the remaining 2D block budget.\n" ++
+  "  la t2, bv_exec_p; ld a0, 0(t2)             # exec_payload\n" ++
+  "  la t2, bv_bal_start; ld a1, 0(t2)          # bal_start\n" ++
+  "  la t2, bv_bal_len; ld a2, 0(t2)            # bal_len\n" ++
+  "  la t2, bv_exec_p; ld t1, 0(t2); addi a0, t1, 412; jal ra, bgv_u64le\n" ++
+  "  mv a3, a0                                  # gas_limit\n" ++
+  "  la t2, bv_exec_p; ld a0, 0(t2)\n" ++
+  "  jal ra, eip8037_tx_gas_gate\n" ++
+  "  bnez a0, .Lbv_eip8037_gas_fail\n" ++
   "  li a0, 1; j .Lbv_ret\n" ++
   ".Lbv_cmp_mismatch:\n" ++
   "  li t0, 1; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
@@ -443,6 +655,8 @@ def blockVerdictFunction : String :=
   "  li t0, 5; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_bal_gas_fail:\n" ++
   "  li t0, 7; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
+  ".Lbv_eip8037_gas_fail:\n" ++
+  "  addi t0, a0, 7; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_zero:\n" ++
   "  li a0, 0\n" ++
   ".Lbv_ret:\n" ++
@@ -529,6 +743,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   witnessLookupByHashFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
   rlpFieldToU64Function ++ "\n" ++
+  txTypeDispatchFunction ++ "\n" ++
   rlpFieldToU256BeFunction ++ "\n" ++
   mptNodeKindFunction ++ "\n" ++
   mptBranchChildFunction ++ "\n" ++
@@ -626,6 +841,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   bgvU64leFunction ++ "\n" ++
   balSectionInfoFunction ++ "\n" ++
   balGasValidFunction ++ "\n" ++
+  eip8037TxGasGateFunction ++ "\n" ++
   statelessVerdictV2Function ++ "\n" ++
   ".Lv2_pdone:"
 
@@ -727,6 +943,37 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bv_fail_code:\n  .zero 8\n" ++
   "bv_header_status:\n  .zero 8\n" ++
   "bv_state_status:\n  .zero 8\n" ++
+  -- eip8037_tx_gas_gate scratch:
+  "bsg_count:\n  .zero 8\n" ++
+  "bsg_off:\n  .zero 8\n" ++
+  "bsg_len:\n  .zero 8\n" ++
+  "bsg_slot_count:\n  .zero 8\n" ++
+  "bsg_slot_off:\n  .zero 8\n" ++
+  "bsg_slot_len:\n  .zero 8\n" ++
+  "bsg_slot_ptr:\n  .zero 8\n" ++
+  "bsg_slot_item_len:\n  .zero 8\n" ++
+  "bsg_changes_off:\n  .zero 8\n" ++
+  "bsg_changes_len:\n  .zero 8\n" ++
+  "bsg_changes_ptr:\n  .zero 8\n" ++
+  "bsg_change_count:\n  .zero 8\n" ++
+  "bsg_change_off:\n  .zero 8\n" ++
+  "bsg_change_len:\n  .zero 8\n" ++
+  "bsg_change_ptr:\n  .zero 8\n" ++
+  "bsg_change_item_len:\n  .zero 8\n" ++
+  "bsg_idx_off:\n  .zero 8\n" ++
+  "bsg_idx_len:\n  .zero 8\n" ++
+  "bsg_index:\n  .zero 8\n" ++
+  "bsg_value_off:\n  .zero 8\n" ++
+  "bsg_value_len:\n  .zero 8\n" ++
+  "bsg_tx_type:\n  .zero 8\n" ++
+  "bsg_tx_inner:\n  .zero 8\n" ++
+  "bsg_tx_gas:\n  .zero 8\n" ++
+  "bsg_data_off:\n  .zero 8\n" ++
+  "bsg_data_len:\n  .zero 8\n" ++
+  "bsg_to_off:\n  .zero 8\n" ++
+  "bsg_to_len:\n  .zero 8\n" ++
+  "bsg_worst_state:\n  .zero 8\n" ++
+  "bsg_prior_state:\n  .zero 8\n" ++
   "bsr_fail_code:\n  .zero 8\n" ++
   "sri_cur_mode:\n  .zero 8\n" ++
   "sri_fail_index:\n  .zero 8\n" ++
@@ -1019,10 +1266,12 @@ def statelessVerdictV2GuestClosure : String :=
   blockStateRootFunction ++ "\n" ++
   blockVerdictFunction ++ "\n" ++
   rlpListCountItemsFunction ++ "\n" ++
+  txTypeDispatchFunction ++ "\n" ++
   bgvU32leFunction ++ "\n" ++
   bgvU64leFunction ++ "\n" ++
   balSectionInfoFunction ++ "\n" ++
   balGasValidFunction ++ "\n" ++
+  eip8037TxGasGateFunction ++ "\n" ++
   statelessVerdictV2Function
 
 /-- The data section the guest needs for the embedded verdict closure (same as the


### PR DESCRIPTION
## Summary
- add a conservative legacy-transaction EIP-8037 inclusion gate to `block_verdict`
- check worst regular gas against cumulative regular block budget and worst state gas against prior BAL-backed storage state gas
- reject the known `state_gas_reservoir` false positives while failing open for unsupported typed/large transaction cases

## Validation
- `lake build EvmAsm.Codegen.Programs.BlockVerdict`
- `lake exe codegen --program zisk_stateless_verdict_v2 --halt linux93 -o gen-out/zisk_stateless_verdict_v2`
- direct ziskemu fixtures:
  - `00701 ... exceed_block_gas_limit_True`: verdict 0, fail code 8
  - `00703 ... block_state_gas_limit_boundary exceeded`: verdict 0, fail code 9
  - `00708 ... creation_tx_state_check_exceeded`: verdict 0, fail code 9
  - `00700 ... exceed_block_gas_limit_False`: verdict 1
  - `00702 ... block_state_gas_limit_boundary exact_fit`: verdict 1
  - `00707 ... creation_tx_regular_check_subtracts_intrinsic_state`: verdict 1
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/BlockVerdict.lean`
- `git diff --check`
- `lake build`

Note: the large `00697_test_block_2d_gas_valid_when_cumulative_exceeds_limit` direct run did not produce output locally; ziskemu exited `EmulationNoCompleted` even with a 200M step cap. The gate fails open for >16 txs, and the adjacent valid boundary cases above cover the new parse-supported path.

Bead: evm-asm-fhsxz.2.4.2.13

Authored by @pirapira; implemented by Codex