### PR TITLE
fix(eest): reject missing BAL code preimages

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -67,6 +67,7 @@ import EvmAsm.Codegen.Programs.AccountBalance
 import EvmAsm.Codegen.Programs.MptEncode
 import EvmAsm.Codegen.Programs.SystemWrites
 import EvmAsm.Codegen.Programs.BalGasValid
+import EvmAsm.Codegen.Programs.BalCodePreimages
 import EvmAsm.Codegen.Programs.BalAccountPath
 import EvmAsm.Codegen.Programs.BalAccountPostFields
 import EvmAsm.Codegen.Programs.BalAccountApplyPostFields
@@ -1388,6 +1389,7 @@ end EvmAsm.Codegen
     "EvmAsm/Codegen/Programs/MptEncode.lean",
     "EvmAsm/Codegen/Programs/SystemWrites.lean",
     "EvmAsm/Codegen/Programs/BalGasValid.lean",
+    "EvmAsm/Codegen/Programs/BalCodePreimages.lean",
     "EvmAsm/Codegen/Programs/StorageWrite.lean",
     "EvmAsm/Codegen/Programs/BlockAccessListHash.lean",
     "EvmAsm/Codegen/Programs/AccountApplyStorage.lean",

--- a/EvmAsm/Codegen/Programs/BalCodePreimages.lean
+++ b/EvmAsm/Codegen/Programs/BalCodePreimages.lean
@@ -1,0 +1,74 @@
+/-
+  EvmAsm.Codegen.Programs.BalCodePreimages
+
+  BAL-scoped witness.codes preimage gate for the stateless verdict.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.StateCompose
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+/-! ## bal_code_preimages_valid -- reject touched accounts whose non-empty
+    code_hash is absent from witness.codes.
+
+    This mirrors the executable spec shape where `build_code_db(witness.codes)`
+    maps `keccak(code) -> code`, and `WitnessState.get_code` raises if an
+    executing or EXTCODE-touched account's non-empty code_hash is not present.
+    The helper is deliberately narrow: it only rejects the extcodesize helper's
+    status 5, and otherwise leaves deeper execution/code-read obligations for
+    later gates. -/
+def balCodePreimagesValidFunction : String :=
+  "bal_code_preimages_valid:\n" ++
+  "  addi sp, sp, -112\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp); sd s10, 88(sp)\n" ++
+  "  mv s0, a0                   # BAL ptr\n" ++
+  "  mv s1, a1                   # BAL len\n" ++
+  "  mv s2, a2                   # parent header RLP ptr\n" ++
+  "  mv s3, a3                   # parent header RLP len\n" ++
+  "  mv s4, a4                   # witness.state ptr\n" ++
+  "  mv s5, a5                   # witness.state len\n" ++
+  "  mv s6, a6                   # witness.codes ptr\n" ++
+  "  mv s7, a7                   # witness.codes len\n" ++
+  "  mv a0, s0; mv a1, s1; la a2, bbcv_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lbbcv_parse_fail\n" ++
+  "  la t0, bbcv_count; ld s8, 0(t0)\n" ++
+  "  li s9, 0\n" ++
+  ".Lbbcv_loop:\n" ++
+  "  beq s9, s8, .Lbbcv_ok\n" ++
+  "  mv a0, s0; mv a1, s1; mv a2, s9; la a3, bbcv_off; la a4, bbcv_size\n" ++
+  "  jal ra, rlp_item_span\n" ++
+  "  bnez a0, .Lbbcv_parse_fail\n" ++
+  "  la t0, bbcv_off; ld t1, 0(t0); add s10, s0, t1\n" ++
+  "  la t0, bbcv_size; ld t1, 0(t0); la t2, bbcv_acct_len; sd t1, 0(t2)\n" ++
+  "  mv a0, s10; mv a1, t1; li a2, 0; la a3, bbcv_addr_off; la a4, bbcv_addr_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbbcv_parse_fail\n" ++
+  "  la t0, bbcv_addr_len; ld t1, 0(t0); li t2, 20; bne t1, t2, .Lbbcv_parse_fail\n" ++
+  "  la t0, bbcv_addr_off; ld t1, 0(t0); add a2, s10, t1\n" ++
+  "  mv a0, s2; mv a1, s3; mv a3, s4; mv a4, s5; mv a5, s6; mv a6, s7\n" ++
+  "  jal ra, extcodesize_at_header_state_root\n" ++
+  "  li t0, 5; beq a0, t0, .Lbbcv_missing_code\n" ++
+  "  addi s9, s9, 1; j .Lbbcv_loop\n" ++
+  ".Lbbcv_ok:\n" ++
+  "  li a0, 0; j .Lbbcv_ret\n" ++
+  ".Lbbcv_missing_code:\n" ++
+  "  li a0, 1; j .Lbbcv_ret\n" ++
+  ".Lbbcv_parse_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lbbcv_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp)\n" ++
+  "  addi sp, sp, 112\n" ++
+  "  ret"
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -35,6 +35,8 @@ import EvmAsm.Codegen.Programs.MptInsertAcc
 import EvmAsm.Codegen.Programs.MptDeleteAcc
 import EvmAsm.Codegen.Programs.MptStateRootIns
 import EvmAsm.Codegen.Programs.HeadersKeccak
+import EvmAsm.Codegen.Programs.StateCompose
+import EvmAsm.Codegen.Programs.BalCodePreimages
 
 namespace EvmAsm.Codegen
 
@@ -714,6 +716,19 @@ def blockVerdictFunction : String :=
   "  la t2, bv_bal_len; ld a1, 0(t2)            # bal_len\n" ++
   "  jal ra, bal_gas_valid\n" ++
   "  bnez a0, .Lbv_bal_gas_fail          # BAL gas exceeded (or parse fail) -> invalid\n" ++
+  "  # Witness integrity: for every BAL account with non-empty pre-state code,\n" ++
+  "  # witness.codes must contain that code hash, matching execution-specs'\n" ++
+  "  # WitnessState.get_code behavior for missing non-empty code preimages.\n" ++
+  "  la t2, bv_bal_start; ld a0, 0(t2)\n" ++
+  "  la t2, bv_bal_len; ld a1, 0(t2)\n" ++
+  "  ld a2, 8(s0)                  # parent header RLP\n" ++
+  "  ld a3, 16(s0)                 # parent header RLP length\n" ++
+  "  ld a4, 80(s0)                 # witness.state ptr\n" ++
+  "  ld a5, 88(s0)                 # witness.state len\n" ++
+  "  la t2, svf_codes_ptr; ld a6, 0(t2)\n" ++
+  "  la t2, svf_codes_len; ld a7, 0(t2)\n" ++
+  "  jal ra, bal_code_preimages_valid\n" ++
+  "  bnez a0, .Lbv_code_preimage_fail\n" ++
   "  # EIP-8037 tx inclusion gas gate: reject parse-supported legacy tx blocks\n" ++
   "  # whose worst regular/state gas exceeds the remaining 2D block budget.\n" ++
   "  la t2, bv_exec_p; ld a0, 0(t2)             # exec_payload\n" ++
@@ -739,6 +754,8 @@ def blockVerdictFunction : String :=
   "  li t0, 6; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_bal_gas_fail:\n" ++
   "  li t0, 7; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
+  ".Lbv_code_preimage_fail:\n" ++
+  "  li t0, 11; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_eip8037_gas_fail:\n" ++
   "  addi t0, a0, 7; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_zero:\n" ++
@@ -768,8 +785,15 @@ def statelessVerdictV2Function : String :=
   "  add t0, s0, a0; la t1, svf_witness_section; sd t0, 0(t1)\n" ++
   "  addi a0, s0, 8; jal ra, bgv_u32le          # chain_config outer offset\n" ++
   "  add t0, s0, a0; la t1, svf_witness_end; sd t0, 0(t1)\n" ++
+  "  la t1, svf_witness_section; ld t0, 0(t1); addi a0, t0, 4; jal ra, bgv_u32le # codes offset\n" ++
+  "  mv t5, a0\n" ++
   "  la t1, svf_witness_section; ld t0, 0(t1); addi a0, t0, 8; jal ra, bgv_u32le # headers offset\n" ++
-  "  la t1, svf_witness_section; ld t0, 0(t1); add t2, t0, a0\n" ++
+  "  mv t6, a0\n" ++
+  "  bltu t6, t5, .Lv2_zero\n" ++
+  "  la t1, svf_witness_section; ld t0, 0(t1); add t2, t0, t5\n" ++
+  "  la t3, svf_codes_ptr; sd t2, 0(t3)\n" ++
+  "  sub t4, t6, t5; la t3, svf_codes_len; sd t4, 0(t3)\n" ++
+  "  add t2, t0, t6\n" ++
   "  la t3, svf_headers_ptr; sd t2, 0(t3)\n" ++
   "  la t1, svf_witness_end; ld t1, 0(t1); bltu t1, t2, .Lv2_zero\n" ++
   "  sub a1, t1, t2; la t3, svf_headers_len; sd a1, 0(t3)\n" ++
@@ -871,6 +895,10 @@ def ziskStatelessVerdictV2Prologue : String :=
   mptSpliceSlotFunction ++ "\n" ++
   accountAddBalanceFunction ++ "\n" ++
   mptWalkFunction ++ "\n" ++
+  mptLookupByKeyFunction ++ "\n" ++
+  accountDecodeFunction ++ "\n" ++
+  accountAtAddressFunction ++ "\n" ++
+  extcodesizeAtHeaderStateRootFunction ++ "\n" ++
   nodeDbAppendFunction ++ "\n" ++
   nodeDbLookupFunction ++ "\n" ++
   mptNodeResolveFunction ++ "\n" ++
@@ -945,6 +973,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   headersValidateChainFunction ++ "\n" ++
   balSectionInfoFunction ++ "\n" ++
   balGasValidFunction ++ "\n" ++
+  balCodePreimagesValidFunction ++ "\n" ++
   eip8037TxGasGateFunction ++ "\n" ++
   statelessVerdictV2Function ++ "\n" ++
   ".Lv2_pdone:"
@@ -1049,9 +1078,36 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bv_state_status:\n  .zero 8\n" ++
   "svf_witness_section:\n  .zero 8\n" ++
   "svf_witness_end:\n  .zero 8\n" ++
+  "svf_codes_ptr:\n  .zero 8\n" ++
+  "svf_codes_len:\n  .zero 8\n" ++
   "svf_headers_ptr:\n  .zero 8\n" ++
   "svf_headers_len:\n  .zero 8\n" ++
   "svf_headers_count:\n  .zero 8\n" ++
+  -- account_at_address / extcodesize_at_header_state_root scratch:
+  "bbcv_count:\n  .zero 8\n" ++
+  "bbcv_off:\n  .zero 8\n" ++
+  "bbcv_size:\n  .zero 8\n" ++
+  "bbcv_acct_len:\n  .zero 8\n" ++
+  "bbcv_addr_off:\n  .zero 8\n" ++
+  "bbcv_addr_len:\n  .zero 8\n" ++
+  "ad_offset:\n  .zero 8\n" ++
+  "ad_length:\n  .zero 8\n" ++
+  "aa_value_len:\n  .zero 8\n" ++
+  "ecsahsr_dummy_offset:\n  .zero 8\n" ++
+  "ecsahsr_code_len:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "aa_value_scratch:\n  .zero 256\n" ++
+  "ecsahsr_state_root:\n  .zero 32\n" ++
+  "mlk_keccak_buf:\n  .zero 32\n" ++
+  "mlk_nibble_buf:\n  .zero 64\n" ++
+  ".balign 8\n" ++
+  "ecsahsr_acct_struct:\n  .zero 104\n" ++
+  ".balign 32\n" ++
+  "ecsahsr_empty_code_hash:\n" ++
+  "  .byte 0xc5, 0xd2, 0x46, 0x01, 0x86, 0xf7, 0x23, 0x3c\n" ++
+  "  .byte 0x92, 0x7e, 0x7d, 0xb2, 0xdc, 0xc7, 0x03, 0xc0\n" ++
+  "  .byte 0xe5, 0x00, 0xb6, 0x53, 0xca, 0x82, 0x27, 0x3b\n" ++
+  "  .byte 0x7b, 0xfa, 0xd8, 0x04, 0x5d, 0x85, 0xa4, 0x70\n" ++
   ".balign 32\n" ++
   "vh_keccak_table:\n" ++
   "  .zero 8192\n" ++
@@ -1315,6 +1371,10 @@ def statelessVerdictV2GuestClosure : String :=
   mptSpliceSlotFunction ++ "\n" ++
   accountAddBalanceFunction ++ "\n" ++
   mptWalkFunction ++ "\n" ++
+  mptLookupByKeyFunction ++ "\n" ++
+  accountDecodeFunction ++ "\n" ++
+  accountAtAddressFunction ++ "\n" ++
+  extcodesizeAtHeaderStateRootFunction ++ "\n" ++
   nodeDbAppendFunction ++ "\n" ++
   nodeDbLookupFunction ++ "\n" ++
   mptNodeResolveFunction ++ "\n" ++
@@ -1389,6 +1449,7 @@ def statelessVerdictV2GuestClosure : String :=
   headersValidateChainFunction ++ "\n" ++
   balSectionInfoFunction ++ "\n" ++
   balGasValidFunction ++ "\n" ++
+  balCodePreimagesValidFunction ++ "\n" ++
   eip8037TxGasGateFunction ++ "\n" ++
   statelessVerdictV2Function
 


### PR DESCRIPTION
## Summary

- Extract `witness.codes` from the stateless input next to `witness.headers`.
- Add `bal_code_preimages_valid`, which walks BAL accounts through the parent state root and rejects non-empty pre-state `code_hash` values missing from `witness.codes`.
- Wire the helper into the zisk stateless verdict probe and guest closure, using the existing `extcodesize_at_header_state_root`/account lookup implementation from `StateCompose`.

This follows the executable spec shape in `execution-specs/src/ethereum/forks/amsterdam/stateless.py` and `witness_state.py`: `build_code_db(witness.codes)` maps `keccak(code) -> code`, and non-empty missing code preimages should make validation fail. The current gate is conservative because BAL does not precisely identify which code hashes execution actually read; it fixes the missing-code false positives while some unrelated valid code-bearing BAL cases remain conservative misses in the broad window.

## Validation

- `lake build EvmAsm.Codegen.Programs.BlockVerdict`
- `lake exe codegen --program zisk_stateless_verdict_v2 --halt linux93 -o gen-out/zisk_stateless_verdict_v2`
- `scripts/codegen-zisk-stateless-verdict-check.sh --filter validation_codes --limit 20 --steps 50000000` -> 11/11 matches, 0 false positives
- `scripts/codegen-eest-stateless-check.sh --filter validation_codes --limit 20 --jobs 32 --steps 50000000` -> 11/11 full matches
- `scripts/codegen-eest-stateless-check.sh --skip 2000 --limit 1000 --jobs 32 --steps 50000000` -> 988/1000 full matches, 1 emulator error (previous comparable window was 987/1000)
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- marker scan on touched files (only pre-existing descriptive `placeholder` string in `Programs.lean`)
- `lake build`

Bead: `evm-asm-fhsxz.2.4.2.16`