### PR TITLE
fix(eest): skip code preimages for transfer-only BAL entries

### DIFF
--- a/EvmAsm/Codegen/Programs/BalCodePreimages.lean
+++ b/EvmAsm/Codegen/Programs/BalCodePreimages.lean
@@ -12,15 +12,16 @@ namespace EvmAsm.Codegen
 
 open EvmAsm.Rv64
 
-/-! ## bal_code_preimages_valid -- reject touched accounts whose non-empty
-    code_hash is absent from witness.codes.
+/-! ## bal_code_preimages_valid -- reject code-read-shaped accounts whose
+    non-empty code_hash is absent from witness.codes.
 
     This mirrors the executable spec shape where `build_code_db(witness.codes)`
     maps `keccak(code) -> code`, and `WitnessState.get_code` raises if an
     executing or EXTCODE-touched account's non-empty code_hash is not present.
-    The helper is deliberately narrow: it only rejects the extcodesize helper's
-    status 5, and otherwise leaves deeper execution/code-read obligations for
-    later gates. -/
+    The helper is deliberately narrow: balance-only and nonce-only BAL entries
+    are transfer/account-creation effects, not code reads, so they are skipped.
+    All other BAL entries still reject the extcodesize helper's status 5 and
+    leave deeper obligations for later gates. -/
 def balCodePreimagesValidFunction : String :=
   "bal_code_preimages_valid:\n" ++
   "  addi sp, sp, -112\n" ++
@@ -52,10 +53,60 @@ def balCodePreimagesValidFunction : String :=
   "  jal ra, rlp_list_nth_item\n" ++
   "  bnez a0, .Lbbcv_parse_fail\n" ++
   "  la t0, bbcv_addr_len; ld t1, 0(t0); li t2, 20; bne t1, t2, .Lbbcv_parse_fail\n" ++
+  "  # Balance-only / nonce-only BAL entries record transfer/account-creation\n" ++
+  "  # effects and do not imply that the account bytecode was read.\n" ++
+  "  # Skip exactly [addr, [], [], nonempty_balance_changes, [], []] or\n" ++
+  "  # [addr, [], [], [], nonempty_nonce_changes, []].\n" ++
+  "  mv a0, s10; la t0, bbcv_acct_len; ld a1, 0(t0); li a2, 1; la a3, bbcv_field_off; la a4, bbcv_field_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbbcv_parse_fail\n" ++
+  "  la t0, bbcv_field_off; ld t1, 0(t0); add a0, s10, t1; la t0, bbcv_field_len; ld a1, 0(t0); la a2, bbcv_field_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lbbcv_parse_fail\n" ++
+  "  la t0, bbcv_field_count; ld t1, 0(t0); bnez t1, .Lbbcv_check_code\n" ++
+  "  mv a0, s10; la t0, bbcv_acct_len; ld a1, 0(t0); li a2, 2; la a3, bbcv_field_off; la a4, bbcv_field_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbbcv_parse_fail\n" ++
+  "  la t0, bbcv_field_off; ld t1, 0(t0); add a0, s10, t1; la t0, bbcv_field_len; ld a1, 0(t0); la a2, bbcv_field_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lbbcv_parse_fail\n" ++
+  "  la t0, bbcv_field_count; ld t1, 0(t0); bnez t1, .Lbbcv_check_code\n" ++
+  "  mv a0, s10; la t0, bbcv_acct_len; ld a1, 0(t0); li a2, 3; la a3, bbcv_field_off; la a4, bbcv_field_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbbcv_parse_fail\n" ++
+  "  la t0, bbcv_field_off; ld t1, 0(t0); add a0, s10, t1; la t0, bbcv_field_len; ld a1, 0(t0); la a2, bbcv_field_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lbbcv_parse_fail\n" ++
+  "  la t0, bbcv_field_count; ld t1, 0(t0)\n" ++
+  "  la t2, bbcv_balance_count; sd t1, 0(t2)\n" ++
+  "  mv a0, s10; la t0, bbcv_acct_len; ld a1, 0(t0); li a2, 4; la a3, bbcv_field_off; la a4, bbcv_field_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbbcv_parse_fail\n" ++
+  "  la t0, bbcv_field_off; ld t1, 0(t0); add a0, s10, t1; la t0, bbcv_field_len; ld a1, 0(t0); la a2, bbcv_field_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lbbcv_parse_fail\n" ++
+  "  la t0, bbcv_field_count; ld t1, 0(t0)\n" ++
+  "  la t2, bbcv_nonce_count; sd t1, 0(t2)\n" ++
+  "  mv a0, s10; la t0, bbcv_acct_len; ld a1, 0(t0); li a2, 5; la a3, bbcv_field_off; la a4, bbcv_field_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbbcv_parse_fail\n" ++
+  "  la t0, bbcv_field_off; ld t1, 0(t0); add a0, s10, t1; la t0, bbcv_field_len; ld a1, 0(t0); la a2, bbcv_field_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lbbcv_parse_fail\n" ++
+  "  la t0, bbcv_field_count; ld t1, 0(t0); bnez t1, .Lbbcv_check_code\n" ++
+  "  la t0, bbcv_balance_count; ld t1, 0(t0)\n" ++
+  "  la t2, bbcv_nonce_count; ld t3, 0(t2)\n" ++
+  "  beqz t1, .Lbbcv_maybe_nonce_only\n" ++
+  "  beqz t3, .Lbbcv_next\n" ++
+  "  j .Lbbcv_check_code\n" ++
+  ".Lbbcv_maybe_nonce_only:\n" ++
+  "  bnez t3, .Lbbcv_next\n" ++
+  ".Lbbcv_check_code:\n" ++
   "  la t0, bbcv_addr_off; ld t1, 0(t0); add a2, s10, t1\n" ++
   "  mv a0, s2; mv a1, s3; mv a3, s4; mv a4, s5; mv a5, s6; mv a6, s7\n" ++
   "  jal ra, extcodesize_at_header_state_root\n" ++
   "  li t0, 5; beq a0, t0, .Lbbcv_missing_code\n" ++
+  ".Lbbcv_next:\n" ++
   "  addi s9, s9, 1; j .Lbbcv_loop\n" ++
   ".Lbbcv_ok:\n" ++
   "  li a0, 0; j .Lbbcv_ret\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -1090,6 +1090,11 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bbcv_acct_len:\n  .zero 8\n" ++
   "bbcv_addr_off:\n  .zero 8\n" ++
   "bbcv_addr_len:\n  .zero 8\n" ++
+  "bbcv_field_off:\n  .zero 8\n" ++
+  "bbcv_field_len:\n  .zero 8\n" ++
+  "bbcv_field_count:\n  .zero 8\n" ++
+  "bbcv_balance_count:\n  .zero 8\n" ++
+  "bbcv_nonce_count:\n  .zero 8\n" ++
   "ad_offset:\n  .zero 8\n" ++
   "ad_length:\n  .zero 8\n" ++
   "aa_value_len:\n  .zero 8\n" ++


### PR DESCRIPTION
## Summary
- refine `bal_code_preimages_valid` so balance-only and nonce-only BAL entries do not require pre-state bytecode in `witness.codes`
- keep the missing-code rejection for all-empty code-read-shaped BAL entries, storage-change entries, and mixed balance/nonce or code-change entries
- improves the EIP-7708 burn-log slice by removing the broad balance-only code-preimage false negatives; remaining two burn-log misses still fail the code-preimage gate on a narrower shape

Bead: evm-asm-fhsxz.2.4.2.19

## Tests
- `lake build EvmAsm.Codegen.Programs.BlockVerdict`
- `scripts/codegen-eest-stateless-check.sh --filter validation_codes --limit 20 --jobs 32 --max-failures 1 --steps 50000000` -> 11/11 full
- `scripts/codegen-eest-stateless-check.sh --all --filter eip7708_eth_transfer_logs/burn_logs --jobs 32 --steps 50000000` -> 31/33 full, 33/33 root, 31/33 succ, 33/33 tail
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|bbcv_fail_index|DEBUG|dbg' EvmAsm/Codegen/Programs/BalCodePreimages.lean EvmAsm/Codegen/Programs/BlockVerdict.lean`
- `lake build`

Authored by @pirapira; implemented by Codex.