### PR TITLE
fix(eest): reject missing MPT child proof nodes

### DIFF
--- a/EvmAsm/Codegen/Programs/Mpt.lean
+++ b/EvmAsm/Codegen/Programs/Mpt.lean
@@ -725,7 +725,7 @@ def mptWalkFunction : String :=
   "  la a3, mw_lookup_offset\n" ++
   "  la a4, mw_lookup_length\n" ++
   "  jal ra, witness_lookup_by_hash\n" ++
-  "  bnez a0, .Lmw_not_found\n" ++
+  "  bnez a0, .Lmw_parse_fail    # referenced child hash missing => bad proof\n" ++
   "  la t0, mw_lookup_offset; ld t1, 0(t0); add s7, s0, t1\n" ++
   "  la t0, mw_lookup_length; ld s8, 0(t0)\n" ++
   "  j .Lmw_loop\n" ++
@@ -804,7 +804,7 @@ def mptWalkFunction : String :=
   "  la a3, mw_lookup_offset\n" ++
   "  la a4, mw_lookup_length\n" ++
   "  jal ra, witness_lookup_by_hash\n" ++
-  "  bnez a0, .Lmw_not_found\n" ++
+  "  bnez a0, .Lmw_parse_fail    # referenced extension child hash missing => bad proof\n" ++
   "  la t0, mw_lookup_offset; ld t1, 0(t0); add s7, s0, t1\n" ++
   "  la t0, mw_lookup_length; ld s8, 0(t0)\n" ++
   "  j .Lmw_loop\n" ++

--- a/scripts/codegen-zisk-mpt-walk-check.sh
+++ b/scripts/codegen-zisk-mpt-walk-check.sh
@@ -225,6 +225,10 @@ APPLE10_HEX=$(python3 -c "print((b'apple' * 10).hex())")
 BANANA10_HEX=$(python3 -c "print((b'banana' * 10).hex())")
 run_case "branch_hash3"  "030a0b" "$ROOT4_HEX" "$WITNESS4_HEX" 0 "$APPLE10_HEX"  || FAILED=1
 run_case "branch_hash7"  "070c0d" "$ROOT4_HEX" "$WITNESS4_HEX" 0 "$BANANA10_HEX" || FAILED=1
+# If a branch points to a hashed child, that child must be present in the
+# witness. This is a malformed proof, not a valid absence proof.
+WITNESS4_MISSING_CHILD_HEX=$(build_ssz_section "$BRANCH4_HEX")
+run_case "branch_hash_missing_child" "030a0b" "$ROOT4_HEX" "$WITNESS4_MISSING_CHILD_HEX" 2 "" || FAILED=1
 
 # Fixture 5: 3-level MPT with extension. Path: [1,2,3,4,5,6,7]
 # Extension at root with path [1,2,3], child = branch


### PR DESCRIPTION
## Summary
- Treat missing referenced MPT branch/extension child hashes as malformed proofs instead of valid absence.
- Add a ziskemu mpt_walk regression for an omitted hashed branch child.

## Test Evidence
- `lake build EvmAsm.Codegen.Programs.Mpt`
- `scripts/codegen-zisk-mpt-walk-check.sh`
- `scripts/codegen-zisk-mpt-set-check.sh`
- `scripts/codegen-zisk-bal-account-record-array-check.sh`
- `scripts/codegen-eest-stateless-check.sh --filter validation_state_missing_failed_call_target_account_proof_node --limit 5 --jobs 32 --max-failures 1 --steps 50000000`
- `scripts/codegen-eest-stateless-check.sh --filter witness_validation_state --limit 20 --jobs 32 --max-failures 3 --steps 50000000`
- `scripts/codegen-eest-stateless-check.sh --filter validation_codes --limit 20 --jobs 32 --max-failures 1 --steps 50000000`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`

Note: a broad `--limit 100 --max-failures 1` smoke stopped on the known burn-log BAL code-preimage false negative covered by PR #7829, not on this MPT proof change.

Refs #114. Bead: evm-asm-fhsxz.2.4.2.17.

Authored by @pirapira; implemented by Codex.