### PR TITLE
ci(eest): add quiet pass output

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,8 @@ scripts/codegen-opcodes-runtime-check.sh            # M8.5 31-case opcode regres
 
 The EEST stateless-guest conformance harness is documented in
 [docs/eest-stateless-testing.md](docs/eest-stateless-testing.md), including
-large-batch, filtered, parallel, offset-resume, and failure-capped runs.
+large-batch, filtered, parallel, offset-resume, failure-capped, and quiet-output
+runs.
 
 Setup requirements: `riscv64-elf-binutils` (or `riscv-gnu-toolchain`)
 and `ziskemu`. The Zisk emulator can be installed with

--- a/docs/eest-stateless-testing.md
+++ b/docs/eest-stateless-testing.md
@@ -73,6 +73,7 @@ Collect only the first few failures from a large or highly parallel run:
 scripts/codegen-eest-stateless-check.sh \
   --all \
   --jobs 32 \
+  --quiet-passes \
   --max-failures 20 \
   --steps 200000000
 ```
@@ -95,6 +96,11 @@ classified. `--stop-after-failures N` is an alias. With parallel jobs, workers
 that already finished before the stop point may also be reported, but the
 harness stops scheduling new cases and cleans up active workers once the cap is
 observed.
+
+Use `--quiet-passes` (or `EEST_QUIET_PASSES=1`) to suppress per-case
+`PASS(full)` lines while still printing every `FAIL` and `ERROR` plus the final
+summary. This is useful for large `--jobs 32 --max-failures N` searches after a
+long passing prefix. `--show-passes` restores the default verbose pass output.
 
 ## Outputs
 
@@ -134,5 +140,6 @@ scripts/codegen-eest-stateless-check.sh --limit 1000 --min-full 1000
 - `EEST_STEPS=N` or `--steps N`: set the ziskemu step cap.
 - `EEST_JOBS=N` or `--jobs N`: set parallel guest jobs.
 - `--max-failures N` or `--stop-after-failures N`: stop after N failures/errors.
+- `EEST_QUIET_PASSES=1` or `--quiet-passes`: hide per-case pass lines.
 - `EEST_MEM_RESERVE_MIB=N`: reserve host memory when auto-sizing jobs.
 - `EEST_FIXTURES_DIR=/path`: point at an already extracted fixture directory.

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -41,6 +41,7 @@
 #     --max-failures N   stop after N FAIL/ERROR results (default: disabled)
 #     --stop-after-failures N
 #                        alias for --max-failures
+#     --quiet-passes     suppress per-case PASS(full) lines
 #     --job-mem-mib N|auto
 #                        memory budget per ziskemu job (default $EEST_JOB_MEM_MIB
 #                        or auto). Auto is derived from the ziskemu build:
@@ -76,6 +77,7 @@ JOB_MEM_MIB="${EEST_JOB_MEM_MIB:-auto}"
 JOB_CPU_THREADS="${EEST_JOB_CPU_THREADS:-auto}"
 MEM_RESERVE_MIB="${EEST_MEM_RESERVE_MIB:-4096}"
 MAX_FAILURES=""
+QUIET_PASSES="${EEST_QUIET_PASSES:-0}"
 MIN_SUCC=""
 MIN_FULL=""
 MIN_ROOT=""
@@ -95,6 +97,8 @@ Options:
   --jobs N|auto            parallel ziskemu jobs (default $EEST_JOBS or auto)
   --max-failures N         stop after N FAIL/ERROR results
   --stop-after-failures N  alias for --max-failures
+  --quiet-passes           suppress per-case PASS(full) lines
+  --show-passes            print per-case PASS(full) lines, overriding EEST_QUIET_PASSES
   --job-mem-mib N|auto     memory budget per ziskemu job
   --min-succ N             exit 1 if fewer than N succ-bit matches
   --min-full N             exit 1 if fewer than N full matches
@@ -123,6 +127,8 @@ while [[ $# -gt 0 ]]; do
     --steps) require_arg "$1" "${2:-}"; STEPS="$2"; shift 2 ;;
     --jobs) require_arg "$1" "${2:-}"; JOBS="$2"; shift 2 ;;
     --max-failures|--stop-after-failures) require_arg "$1" "${2:-}"; MAX_FAILURES="$2"; shift 2 ;;
+    --quiet-passes) QUIET_PASSES=1; shift ;;
+    --show-passes) QUIET_PASSES=0; shift ;;
     --job-mem-mib) require_arg "$1" "${2:-}"; JOB_MEM_MIB="$2"; shift 2 ;;
     --min-succ) require_arg "$1" "${2:-}"; MIN_SUCC="$2"; shift 2 ;;
     --min-full) require_arg "$1" "${2:-}"; MIN_FULL="$2"; shift 2 ;;
@@ -152,6 +158,14 @@ if [[ -n "$MAX_FAILURES" ]] && { ! [[ "$MAX_FAILURES" =~ ^[0-9]+$ ]] || [[ "$MAX
   echo "--max-failures must be a positive integer when set (got: $MAX_FAILURES)" >&2
   exit 1
 fi
+if ! [[ "$QUIET_PASSES" =~ ^(0|1|true|false|yes|no)$ ]]; then
+  echo "EEST_QUIET_PASSES must be 0/1/true/false/yes/no (got: $QUIET_PASSES)" >&2
+  exit 1
+fi
+case "$QUIET_PASSES" in
+  1|true|yes) QUIET_PASSES=1 ;;
+  *) QUIET_PASSES=0 ;;
+esac
 if ! [[ "$MEM_RESERVE_MIB" =~ ^[0-9]+$ ]]; then
   echo "EEST_MEM_RESERVE_MIB must be a nonnegative integer (got: $MEM_RESERVE_MIB)" >&2
   exit 1
@@ -361,7 +375,8 @@ classify_case_result() {
   [[ "${actual_hex:66:144}" == "${exp:66:144}" ]] && { tail=$((tail + 1)); t=tail; } || t=----
 
   if [[ "$actual_hex" == "$exp" ]]; then
-    full=$((full + 1)); echo "  PASS(full)        $relpath"
+    full=$((full + 1))
+    [[ "$QUIET_PASSES" -eq 1 ]] || echo "  PASS(full)        $relpath"
   else
     fail=$((fail + 1))
     # root-only diff: succ + tail already match, ONLY the 32-byte root


### PR DESCRIPTION
## Summary
- add `--quiet-passes` / `EEST_QUIET_PASSES=1` to suppress per-case `PASS(full)` lines in the EEST stateless harness
- keep `FAIL`/`ERROR` rows and final summaries unchanged, with `--show-passes` to force the default verbose behavior
- document the option for large `--jobs 32 --max-failures N` searches

## Test Evidence
- `bash -n scripts/codegen-eest-stateless-check.sh`
- `scripts/codegen-eest-stateless-check.sh --help`
- `scripts/codegen-eest-stateless-check.sh --skip 20000 --limit 1 --quiet-passes --jobs 1 --steps 200000000 --min-full 1`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- `rg -n sorry/admit/maxHeartbeats/maxRecDepth scripts/codegen-eest-stateless-check.sh docs/eest-stateless-testing.md README.md` only reports existing README prose about the project-wide 0-sorry invariant
- `lake build`

Refs #61
Bead: evm-asm-fhsxz.10

Authored by @pirapira; implemented by Codex.