### PR TITLE
feat(receipts): capture LOG events in dispatcher

### DIFF
--- a/EvmAsm/Codegen/Cli.lean
+++ b/EvmAsm/Codegen/Cli.lean
@@ -118,16 +118,18 @@ def main (args : List String) : IO UInt32 := do
           -- as long as it uses `read -r name expected` (extra fields
           -- just get dropped).
           for tc in Tests.opcodeTestCases do
-            -- M21..M25: 9-column TSV. Columns:
+            -- M21..M26: 11-column TSV. Columns:
             --   1 name, 2 expectedOutHex, 3 bytecode, 4 calldata,
             --   5 storage, 6 expectedHaltKind,
             --   7 expectedPersistentLogLength (M24),
             --   8 expectedTransientLogLength (M24),
-            --   9 expectedPostStorage (M25 — slot data at OUTPUT+56).
+            --   9 expectedPostStorage (M25 — slot data at OUTPUT+56),
+            --   10 expectedEventLogCount (M26 — OUTPUT+56),
+            --   11 expectedEventLogFirst (M26 — descriptor at OUTPUT+64).
             -- All cols beyond 3 are optional; the bash runner asserts
             -- only the ones with non-empty values.
             IO.println
-              s!"{tc.name}\t{tc.expectedOutHex}\t{tc.bytecode}\t{tc.calldata}\t{tc.storage}\t{tc.expectedHaltKind}\t{tc.expectedPersistentLogLength}\t{tc.expectedTransientLogLength}\t{tc.expectedPostStorage}"
+              s!"{tc.name}\t{tc.expectedOutHex}\t{tc.bytecode}\t{tc.calldata}\t{tc.storage}\t{tc.expectedHaltKind}\t{tc.expectedPersistentLogLength}\t{tc.expectedTransientLogLength}\t{tc.expectedPostStorage}\t{tc.expectedEventLogCount}\t{tc.expectedEventLogFirst}"
           return 0
       | .program => do
           match lookupProgram opts.target with

--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -158,6 +158,8 @@ def emitDispatcherPrologue : String :=
   "  sd x0, 448(x20)\n" ++         -- env.persistentLogLengthOff = 0
   "  sd x0, 456(x20)\n" ++         -- env.persistentLogCheckpointOff = 0
   "  sd x0, 464(x20)\n" ++         -- env.transientLogLengthOff = 0
+  "  sd x0, 472(x20)\n" ++         -- env.eventLogLengthOff = 0
+  "  sd x0, 480(x20)\n" ++         -- env.eventLogCheckpointOff = 0
   ".dispatch_loop:\n" ++
   "  lbu x5, 0(x10)\n" ++
   "  la x6, opcode_handlers\n" ++
@@ -279,7 +281,29 @@ def emitDispatcherEpilogue
   "6:\n" ++                         -- loop step
   "  addi x15, x15, -1\n" ++
   "  bnez x15, 1b\n" ++
-  "4:\n"                            -- done — fall through to halt stub
+  "4:\n" ++                         -- done — surface first LOG event, then halt
+  -- M26: event LOG capture test surface. If receipt event logs
+  -- exist, this intentionally reuses the storage diagnostic window:
+  --   OUTPUT+56       : event log count (u64 LE)
+  --   OUTPUT+64..256  : first event descriptor prefix
+  -- Current opcode probes assert either storage post-state or LOG
+  -- capture, not both. A future wider receipt-output ABI should
+  -- carry both without sharing this test-only window.
+  "  li x16, 0xa0010000\n" ++
+  "  ld x17, 472(x20)\n" ++
+  "  beqz x17, 8f\n" ++
+  "  sd x17, 56(x16)\n" ++
+  "  la x18, evm_event_logs\n" ++
+  "  addi x19, x16, 64\n" ++
+  "  li x21, 192\n" ++
+  "7:\n" ++
+  "  lbu x22, 0(x18)\n" ++
+  "  sb x22, 0(x19)\n" ++
+  "  addi x18, x18, 1\n" ++
+  "  addi x19, x19, 1\n" ++
+  "  addi x21, x21, -1\n" ++
+  "  bnez x21, 7b\n" ++
+  "8:\n"                            -- done — fall through to halt stub
 
 /-- `.data` section layout (starts at `0xa0000000` per
     `Driver.lean`'s `-Tdata=...`):
@@ -318,7 +342,10 @@ def emitDispatcherDataSection
   ".balign 8\n" ++
   "evm_env:\n" ++
   "  .zero 512\n" ++      -- 13 SimpleEnvField slots × 32 B + calldata/return-data
-                          -- + M22/M24 log-state cells up to env+472 (envSize = 472)
+                          -- + M22/M24/M26 log-state cells up to env+480
+  ".balign 8\n" ++
+  "evm_event_logs:\n" ++
+  "  .zero 4096\n" ++     -- M26: 16 × 256-byte bounded LOG event descriptors
   ".balign 8\n" ++
   "zk3_state:\n" ++
   "  .zero 200\n" ++      -- M16: 25 × u64 keccak permutation state buffer
@@ -393,6 +420,8 @@ def emitRuntimeDispatcherPrologue : String :=
   "  sd x6, 448(x20)\n" ++         -- env.persistentLogLengthOff = preload count
   "  sd x6, 456(x20)\n" ++         -- env.persistentLogCheckpointOff = preload count
   "  sd x0, 464(x20)\n" ++         -- env.transientLogLengthOff = 0
+  "  sd x0, 472(x20)\n" ++         -- env.eventLogLengthOff = 0
+  "  sd x0, 480(x20)\n" ++         -- env.eventLogCheckpointOff = 0
   "  addi x5, x5, 8\n" ++          -- x5 = src ptr (first preload entry)
   "  li x7, 0xa0630000\n" ++       -- x7 = dst ptr (STATE_TRACKER_AREA persistent log)
   ".preload_expand_loop:\n" ++
@@ -454,7 +483,10 @@ def emitRuntimeDispatcherDataSection
   ".balign 8\n" ++
   "evm_env:\n" ++
   "  .zero 512\n" ++      -- 13 SimpleEnvField slots × 32 B + calldata/return-data
-                          -- + M22/M24 log-state cells up to env+472 (envSize = 472)
+                          -- + M22/M24/M26 log-state cells up to env+480
+  ".balign 8\n" ++
+  "evm_event_logs:\n" ++
+  "  .zero 4096\n" ++     -- M26: 16 × 256-byte bounded LOG event descriptors
   ".balign 8\n" ++
   "zk3_state:\n" ++
   "  .zero 200\n" ++      -- M16: 25 × u64 keccak permutation state buffer

--- a/EvmAsm/Codegen/Programs/Evm.lean
+++ b/EvmAsm/Codegen/Programs/Evm.lean
@@ -692,39 +692,123 @@ def hashHandlers : List OpcodeHandlerSpec :=
         "  addi x10, x10, 1\n" ++       -- advance PC by 1
         "  j .dispatch_loop") } ]
 
-/-- M17 LOG opcodes (LOG0..LOG4). Wired as **stack-pop no-ops** —
-    the EVM emits a log event that affects the receipt root, but
-    NOT the OUTPUT_ADDR our dispatcher surfaces, so for codegen
-    we just consume the right number of stack words and advance.
+/-- Copy `topicCount` stack words into an event-log descriptor.
+    Descriptor topics live at entry offsets 32, 64, 96, and 128. -/
+def logTopicCopies (topicCount : Nat) : String :=
+  String.intercalate "" <|
+    (List.range topicCount).map fun i =>
+      let stackOff := 64 + i * 32
+      let entryOff := 32 + i * 32
+      "  ld x21, " ++ toString stackOff ++ "(x12)\n" ++
+      "  sd x21, " ++ toString entryOff ++ "(x14)\n" ++
+      "  ld x21, " ++ toString (stackOff + 8) ++ "(x12)\n" ++
+      "  sd x21, " ++ toString (entryOff + 8) ++ "(x14)\n" ++
+      "  ld x21, " ++ toString (stackOff + 16) ++ "(x12)\n" ++
+      "  sd x21, " ++ toString (entryOff + 16) ++ "(x14)\n" ++
+      "  ld x21, " ++ toString (stackOff + 24) ++ "(x12)\n" ++
+      "  sd x21, " ++ toString (entryOff + 24) ++ "(x14)\n"
 
-    Stack pop counts (per the EVM Yellow Paper): LOGn pops
-    `(2 + n)` 256-bit words = offset, size, and `n` topics. So
-    pop bytes = `(2 + n) × 32`: 64, 96, 128, 160, 192 for n=0..4.
+/-- M26 LOG capture prefix. Appends a bounded 256-byte descriptor:
+      +0  topic count (u64)
+      +8  memory offset low u64
+      +16 memory size low u64
+      +24 copied data length (min(size, 32))
+      +32..160 four 32-byte topic slots
+      +160..192 first up to 32 data bytes
+      +192..224 ADDRESS context word
+      +224..256 CALLER context word
 
-    All entries share the standard `.advanceAndRet 1` tail (PC
-    advances by 1 byte; ret). The body is a single
-    `ADDI .x12 .x12 popBytes` that moves the EVM stack ptr UP
-    (EVM stack grows DOWN, so increasing x12 pops).
+    The descriptor uses the dispatcher's current stack-word byte order
+    (low limb first). A full receipt encoder can canonicalize to the
+    Ethereum byte order later. Overflow writes halt_kind = 4 and exits
+    via `.exit_no_epilogue` instead of silently dropping the event. -/
+def logCapturePreBody (topicCount : Nat) : String :=
+  "  ld x15, 472(x20)\n" ++          -- x15 = event log length
+  "  li x16, 16\n" ++                -- static cap: 16 descriptors
+  "  bgeu x15, x16, 9f\n" ++
+  "  la x14, evm_event_logs\n" ++
+  "  slli x16, x15, 8\n" ++          -- entry offset = count * 256
+  "  add x14, x14, x16\n" ++         -- x14 = descriptor pointer
+  -- Zero the full descriptor before filling the fields/topics/data prefix.
+  "  mv x16, x14\n" ++
+  "  li x17, 32\n" ++
+  "1:\n" ++
+  "  sd x0, 0(x16)\n" ++
+  "  addi x16, x16, 8\n" ++
+  "  addi x17, x17, -1\n" ++
+  "  bnez x17, 1b\n" ++
+  "  li x16, " ++ toString topicCount ++ "\n" ++
+  "  sd x16, 0(x14)\n" ++
+  "  ld x17, 0(x12)\n" ++            -- memory offset low u64
+  "  ld x18, 32(x12)\n" ++           -- memory size low u64
+  "  sd x17, 8(x14)\n" ++
+  "  sd x18, 16(x14)\n" ++
+  logTopicCopies topicCount ++
+  -- Capture the local address and caller context from the env block.
+  "  ld x21, 0(x20)\n" ++
+  "  sd x21, 192(x14)\n" ++
+  "  ld x21, 8(x20)\n" ++
+  "  sd x21, 200(x14)\n" ++
+  "  ld x21, 16(x20)\n" ++
+  "  sd x21, 208(x14)\n" ++
+  "  ld x21, 24(x20)\n" ++
+  "  sd x21, 216(x14)\n" ++
+  "  ld x21, 64(x20)\n" ++
+  "  sd x21, 224(x14)\n" ++
+  "  ld x21, 72(x20)\n" ++
+  "  sd x21, 232(x14)\n" ++
+  "  ld x21, 80(x20)\n" ++
+  "  sd x21, 240(x14)\n" ++
+  "  ld x21, 88(x20)\n" ++
+  "  sd x21, 248(x14)\n" ++
+  "  li x19, 32\n" ++
+  "  bgeu x19, x18, 2f\n" ++
+  "  mv x18, x19\n" ++
+  "2:\n" ++
+  "  sd x18, 24(x14)\n" ++
+  "  add x22, x13, x17\n" ++         -- source = evm_memory + offset
+  "  addi x23, x14, 160\n" ++        -- data-prefix destination
+  "3:\n" ++
+  "  beqz x18, 4f\n" ++
+  "  lbu x24, 0(x22)\n" ++
+  "  sb x24, 0(x23)\n" ++
+  "  addi x22, x22, 1\n" ++
+  "  addi x23, x23, 1\n" ++
+  "  addi x18, x18, -1\n" ++
+  "  j 3b\n" ++
+  "4:\n" ++
+  "  addi x15, x15, 1\n" ++
+  "  sd x15, 472(x20)\n" ++
+  "  j 8f\n" ++
+  "9:\n" ++
+  "  li x16, 0xa0010000\n" ++
+  "  li x17, 4\n" ++                 -- LOG buffer overflow
+  "  sd x17, 32(x16)\n" ++
+  "  j .exit_no_epilogue\n" ++
+  "8:\n"
 
-    **Known limitation**: LOG events are dropped (no receipt log
-    list). Spec-compliant emission is deferred until the host
-    gets a log syscall (Zisk's `zkvm_accelerators.h` doesn't
-    have one today). Trusted test programs that don't depend on
-    log persistence continue running correctly. -/
+/-- M26 LOG opcodes (LOG0..LOG4). Each handler captures a bounded
+    event descriptor, pops `(2 + n)` EVM words, advances PC by one
+    byte, and returns to the dispatcher. -/
 def logHandlers : List OpcodeHandlerSpec :=
   [ { label := "h_LOG0", opcodes := [0xa0]
+    , preBody := logCapturePreBody 0
     , body := ADDI .x12 .x12 (BitVec.ofNat 12 64)
     , tail := .advanceAndRet 1 }
   , { label := "h_LOG1", opcodes := [0xa1]
+    , preBody := logCapturePreBody 1
     , body := ADDI .x12 .x12 (BitVec.ofNat 12 96)
     , tail := .advanceAndRet 1 }
   , { label := "h_LOG2", opcodes := [0xa2]
+    , preBody := logCapturePreBody 2
     , body := ADDI .x12 .x12 (BitVec.ofNat 12 128)
     , tail := .advanceAndRet 1 }
   , { label := "h_LOG3", opcodes := [0xa3]
+    , preBody := logCapturePreBody 3
     , body := ADDI .x12 .x12 (BitVec.ofNat 12 160)
     , tail := .advanceAndRet 1 }
   , { label := "h_LOG4", opcodes := [0xa4]
+    , preBody := logCapturePreBody 4
     , body := ADDI .x12 .x12 (BitVec.ofNat 12 192)
     , tail := .advanceAndRet 1 } ]
 

--- a/EvmAsm/Codegen/Programs/Noop.lean
+++ b/EvmAsm/Codegen/Programs/Noop.lean
@@ -144,10 +144,13 @@ def haltHandlers : List OpcodeHandlerSpec :=
         -- prologue (post-preload); transient log resets to 0
         -- (transient storage starts empty at tx start). RETURN /
         -- STOP / INVALID / SELFDESTRUCT do NOT roll back — they
-        -- commit successfully.
+        -- commit successfully. M26 also restores receipt event logs
+        -- to the transaction checkpoint.
         "  ld x17, 456(x20)\n" ++         -- persistentLogCheckpointOff
         "  sd x17, 448(x20)\n" ++         -- persistentLogLengthOff = checkpoint
         "  sd x0, 464(x20)\n" ++          -- transientLogLengthOff = 0
+        "  ld x17, 480(x20)\n" ++         -- eventLogCheckpointOff
+        "  sd x17, 472(x20)\n" ++         -- eventLogLengthOff = checkpoint
         "  j .exit_no_epilogue" }
   , -- INVALID (M18 no-op, deferred halt-kind tagging). Flows through
     -- .exit_label → evmAddEpilogue → halt_kind = 0.

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -73,6 +73,25 @@ structure OpcodeTestCase where
       M22's `--storage` packer and the existing storage-test
       `expectedOutHex` values. Empty string = don't assert. -/
   expectedPostStorage : String := ""
+  /-- Optional expected receipt event-log count at
+      `OUTPUT_ADDR + 56` (M26). 16 hex chars = 8-byte LE u64.
+      This shares the storage post-state diagnostic window; tests
+      should assert one surface or the other. Empty string = don't
+      assert. -/
+  expectedEventLogCount : String := ""
+  /-- Optional expected prefix of the first event-log descriptor at
+      `OUTPUT_ADDR + 64` (M26). Hex string of arbitrary length;
+      runner reads `len/2` bytes and compares. Layout begins:
+        - +0: u64 topic count
+        - +8: u64 memory offset
+        - +16: u64 memory size
+        - +24: u64 copied data length
+        - +32..160: four topic slots in stack-word byte order
+        - +160..192: first up to 32 copied memory bytes
+        - +192..224: ADDRESS context word
+        - +224..256: CALLER context word
+      Empty string = don't assert. -/
+  expectedEventLogFirst : String := ""
 
 /-- Registry of test cases. M5a/M5b's two original bytecodes are
     migrated as `add_basic` / `add_chain`; M6b adds ~20 more — one
@@ -316,22 +335,43 @@ def opcodeTestCases : List OpcodeTestCase :=
     { name           := "keccak256_empty"
       bytecode       := "0x60, 0x00, 0x60, 0x00, 0x20, 0x00"
       expectedOutHex := "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" }
-    -- ## M17 LOG opcodes (LOG0-LOG4) — wired as stack-pop no-ops.
-    -- LOGn pops (2+n) 256-bit words and advances PC; the EVM event
-    -- is dropped (no host log syscall yet).
+    -- ## M26 LOG opcodes (LOG0-LOG4) — bounded event capture.
+    -- LOGn pops (2+n) 256-bit words, advances PC, and appends a
+    -- 256-byte descriptor to the dispatcher's receipt-event buffer.
   , -- PUSH1 0x11; PUSH1 0x22; LOG0; PUSH1 0x33; STOP — LOG0 pops the
     -- two pushed words; PUSH1 0x33 lands on the now-empty stack.
-    -- Confirms byte 0xa0 routes correctly and stack delta is +64.
-    { name           := "log0_pop"
-      bytecode       := "0x60, 0x11, 0x60, 0x22, 0xa0, 0x60, 0x33, 0x00"
-      expectedOutHex := "3300000000000000000000000000000000000000000000000000000000000000" }
+    -- Also checks descriptor header: topics=0, offset=0x22,
+    -- size=0x11, copied data length=0x11.
+    { name                   := "log0_pop"
+      bytecode               := "0x60, 0x11, 0x60, 0x22, 0xa0, 0x60, 0x33, 0x00"
+      expectedOutHex         := "3300000000000000000000000000000000000000000000000000000000000000"
+      expectedEventLogCount  := "0100000000000000"
+      expectedEventLogFirst  := "0000000000000000220000000000000011000000000000001100000000000000" }
   , -- PUSH1 0x01..0x06; LOG4; PUSH1 0xff; STOP — LOG4 pops the six
     -- pushed words (offset + size + 4 topics); PUSH1 0xff lands on
     -- the now-empty stack. Confirms byte 0xa4 routes correctly and
-    -- stack delta is +192.
-    { name           := "log4_pop"
-      bytecode       := "0x60, 0x01, 0x60, 0x02, 0x60, 0x03, 0x60, 0x04, 0x60, 0x05, 0x60, 0x06, 0xa4, 0x60, 0xff, 0x00"
-      expectedOutHex := "ff00000000000000000000000000000000000000000000000000000000000000" }
+    -- stack delta is +192. The descriptor records offset=6,
+    -- size=5, and topics 4,3,2,1 in stack-pop order.
+    { name                   := "log4_pop"
+      bytecode               := "0x60, 0x01, 0x60, 0x02, 0x60, 0x03, 0x60, 0x04, 0x60, 0x05, 0x60, 0x06, 0xa4, 0x60, 0xff, 0x00"
+      expectedOutHex         := "ff00000000000000000000000000000000000000000000000000000000000000"
+      expectedEventLogCount  := "0100000000000000"
+      expectedEventLogFirst  := "04000000000000000600000000000000050000000000000005000000000000000400000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000" }
+  , -- MSTORE8 writes 0xab at memory[0]; LOG2 then captures offset=0,
+    -- size=1, topics 0x11 and 0x22, and data prefix byte 0xab.
+    { name                   := "log2_captures_topic_and_data"
+      bytecode               := "0x60, 0xab, 0x60, 0x00, 0x53, 0x60, 0x22, 0x60, 0x11, 0x60, 0x01, 0x60, 0x00, 0xa2, 0x60, 0x00, 0x00"
+      expectedOutHex         := "0000000000000000000000000000000000000000000000000000000000000000"
+      expectedEventLogCount  := "0100000000000000"
+      expectedEventLogFirst  := "02000000000000000000000000000000010000000000000001000000000000001100000000000000000000000000000000000000000000000000000000000000220000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab00000000000000000000000000000000000000000000000000000000000000" }
+  , -- Seventeen empty LOG0s exceed the static 16-entry cap. The 17th
+    -- handler exits with halt_kind=4 and leaves the visible event
+    -- count at 16; it must not silently drop the event and continue.
+    { name                   := "log0_overflow_status"
+      bytecode               := "0x60, 0x00, 0x60, 0x00, 0xa0, 0x60, 0x00, 0x60, 0x00, 0xa0, 0x60, 0x00, 0x60, 0x00, 0xa0, 0x60, 0x00, 0x60, 0x00, 0xa0, 0x60, 0x00, 0x60, 0x00, 0xa0, 0x60, 0x00, 0x60, 0x00, 0xa0, 0x60, 0x00, 0x60, 0x00, 0xa0, 0x60, 0x00, 0x60, 0x00, 0xa0, 0x60, 0x00, 0x60, 0x00, 0xa0, 0x60, 0x00, 0x60, 0x00, 0xa0, 0x60, 0x00, 0x60, 0x00, 0xa0, 0x60, 0x00, 0x60, 0x00, 0xa0, 0x60, 0x00, 0x60, 0x00, 0xa0, 0x60, 0x00, 0x60, 0x00, 0xa0, 0x60, 0x00, 0x60, 0x00, 0xa0, 0x60, 0x00, 0x60, 0x00, 0xa0, 0x60, 0x00, 0x60, 0x00, 0xa0, 0x00"
+      expectedOutHex         := "0000000000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind       := "0400000000000000"
+      expectedEventLogCount  := "1000000000000000" }
     -- ## M17 / M22 / M24 transient storage (TLOAD/TSTORE)
     -- M24 graduated TLOAD/TSTORE from M17 no-ops to real Option A
     -- transient storage: a separate append-log at 0xa0830000.

--- a/scripts/codegen-opcodes-runtime-check.sh
+++ b/scripts/codegen-opcodes-runtime-check.sh
@@ -46,10 +46,10 @@ lake build codegen
 echo "==> emit + link runtime_dispatcher.elf (once)"
 lake exe codegen --program runtime_dispatcher --halt linux93 -o gen-out/runtime_dispatcher
 
-# `--list-test-cases` is a 5-column TSV:
-#   <name> <expected_hex> <bytecode_csv> <calldata> <storage>
-# (M21: 4th column = calldata, empty = no calldata, back-compat.)
-# (M22: 5th column = storage preload, empty = no preload.)
+# `--list-test-cases` is an optional-field TSV:
+#   <name> <expected_hex> <bytecode_csv> <calldata> <storage> ...
+# M21 adds calldata; M22 adds storage preload; later columns carry
+# optional output-surface assertions.
 # Single source of truth lives in `EvmAsm/Codegen/Tests/Cases.lean`.
 LIST_FILE="gen-out/.opcodes-list"
 lake exe codegen --list-test-cases >"$LIST_FILE"
@@ -70,9 +70,10 @@ while IFS= read -r line; do
   # (tab is treated as IFS-whitespace), which silently shifts the
   # storage column into the calldata slot when calldata is empty.
   # `cut -f` preserves empty fields, so we slice each column
-  # explicitly. Order matches `--list-test-cases` 9-column TSV
+  # explicitly. Order matches `--list-test-cases` 11-column TSV
   # (M23 added col 6; M24 added cols 7 and 8 for the log-length
-  # assertions; M25 added col 9 for the post-state slot dump).
+  # assertions; M25 added col 9 for the post-state slot dump; M26
+  # added cols 10 and 11 for receipt event-log capture).
   name=$(printf '%s' "$line" | cut -f1)
   expected=$(printf '%s' "$line" | cut -f2)
   bytecode_csv=$(printf '%s' "$line" | cut -f3)
@@ -82,6 +83,8 @@ while IFS= read -r line; do
   expected_persistent_log_length=$(printf '%s' "$line" | cut -f7)
   expected_transient_log_length=$(printf '%s' "$line" | cut -f8)
   expected_post_storage=$(printf '%s' "$line" | cut -f9)
+  expected_event_log_count=$(printf '%s' "$line" | cut -f10)
+  expected_event_log_first=$(printf '%s' "$line" | cut -f11)
 
   if [[ -z "$name" || -z "$expected" || -z "$bytecode_csv" ]]; then
     echo
@@ -172,6 +175,33 @@ while IFS= read -r line; do
     echo "  $actual_post_storage"
     if [[ "$actual_post_storage" != "$expected_post_storage" ]]; then
       case_failed="${case_failed:+$case_failed,}post_storage"
+    fi
+  fi
+
+  # M26: receipt event LOG count at OUTPUT+56. This shares the M25
+  # storage diagnostic window; cases should assert one or the other.
+  if [[ -n "${expected_event_log_count:-}" ]]; then
+    actual_event_log_count="$(xxd -p -c 64 -s 56 -l 8 "gen-out/$name.output" | tr -d '\n')"
+    echo "expected event_log_count:"
+    echo "  $expected_event_log_count"
+    echo "actual event_log_count:"
+    echo "  $actual_event_log_count"
+    if [[ "$actual_event_log_count" != "$expected_event_log_count" ]]; then
+      case_failed="${case_failed:+$case_failed,}event_log_count"
+    fi
+  fi
+
+  # M26: first event descriptor prefix at OUTPUT+64. Field length is
+  # variable so each case can assert just the meaningful prefix.
+  if [[ -n "${expected_event_log_first:-}" ]]; then
+    event_first_len_bytes=$(( ${#expected_event_log_first} / 2 ))
+    actual_event_log_first="$(xxd -p -c 512 -s 64 -l "$event_first_len_bytes" "gen-out/$name.output" | tr -d '\n')"
+    echo "expected event_log_first:"
+    echo "  $expected_event_log_first"
+    echo "actual event_log_first:"
+    echo "  $actual_event_log_first"
+    if [[ "$actual_event_log_first" != "$expected_event_log_first" ]]; then
+      case_failed="${case_failed:+$case_failed,}event_log_first"
     fi
   fi
 


### PR DESCRIPTION
## Summary
- Replace LOG0..LOG4 pop-only handlers with bounded event descriptor capture in the runtime dispatcher.
- Store topic count, memory offset/size, data prefix, topics, ADDRESS, and CALLER context in a 16-entry static buffer.
- Surface LOG diagnostics through the opcode test runner and add LOG0, LOG2, LOG4, and overflow ziskemu coverage.
- Roll receipt event length back on REVERT alongside storage logs.

## Notes
- The opcode test ABI has only 256 public-output bytes, so event diagnostics intentionally reuse the existing storage post-state window for LOG-focused tests. Tests assert either storage or event diagnostics, not both.
- Overflow uses halt_kind = 4 and exits through `.exit_no_epilogue`.

## Verification
- `lake build codegen`
- `scripts/codegen-opcodes-runtime-check.sh`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`

Tracked by bead `evm-asm-fhsxz.2.4.2.63.1.2`.
