### PR TITLE
fix(system-writes): reduce history slots modulo ring size

### DIFF
--- a/EvmAsm/Codegen/Programs/SystemWrites.lean
+++ b/EvmAsm/Codegen/Programs/SystemWrites.lean
@@ -19,9 +19,8 @@
 
   The slot index is the 32-byte big-endian storage key; the stored value is the
   MINIMAL big-endian word (leading zeros stripped) — what the storage trie leaf's
-  rlp(value) wants. The slot is derived as `number-1` / `timestamp` directly
-  (correct while < 8191, which holds for the EEST single/few-block fixtures; a
-  larger index would just yield a non-matching recompute -> conservative miss).
+  rlp(value) wants. The storage slot is reduced modulo the 8191-entry history
+  buffer before encoding the 32-byte big-endian storage key.
 
   Outputs feed account_apply_storage_slot (one per system contract) in the
   verdict's state recompute.
@@ -110,21 +109,23 @@ def systemWriteDescriptorsFunction : String :=
   "  sd ra, 0(sp); sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
   "  mv s0, a0                   # SSZ_BASE\n" ++
   "  addi s1, s0, 60             # exec_payload\n" ++
-  "  # ---- EIP-2935: slot = number-1, value = parent_hash ----\n" ++
+  "  # ---- EIP-2935: slot = (number-1) % 8191, value = parent_hash ----\n" ++
   "  addi a0, s1, 404; jal ra, swd_read_u64le\n" ++
   "  addi a0, a0, -1             # number - 1\n" ++
+  "  li t0, 8191; remu a0, a0, t0\n" ++
   "  la a1, swd_2935_slot; jal ra, swd_write_be32_u64\n" ++
   "  mv a0, s1; li a1, 32; la a2, swd_2935_val; la a3, swd_2935_vlen\n" ++
   "  jal ra, swd_minimal_copy\n" ++
-  "  # ---- EIP-4788: slot = timestamp, value = timestamp ----\n" ++
+  "  # ---- EIP-4788: slot = timestamp % 8191, value = timestamp ----\n" ++
   "  addi a0, s1, 428; jal ra, swd_read_u64le\n" ++
   "  mv s2, a0                   # timestamp\n" ++
+  "  li t0, 8191; remu a0, a0, t0\n" ++
   "  la a1, swd_4788_slot; jal ra, swd_write_be32_u64\n" ++
   "  mv a0, s2; la a1, swd_ts_be8; jal ra, swd_write_be8\n" ++
   "  la a0, swd_ts_be8; li a1, 8; la a2, swd_4788_val; la a3, swd_4788_vlen\n" ++
   "  jal ra, swd_minimal_copy\n" ++
   "  # ---- EIP-4788: slot = timestamp + 8191, value = parent_beacon_block_root ----\n" ++
-  "  mv a0, s2; li t0, 8191; add a0, a0, t0\n" ++
+  "  mv a0, s2; li t0, 8191; remu a0, a0, t0; add a0, a0, t0\n" ++
   "  la a1, swd_4788_root_slot; jal ra, swd_write_be32_u64\n" ++
   "  addi a0, s0, 24; li a1, 32; la a2, swd_4788_root_val; la a3, swd_4788_root_vlen\n" ++
   "  jal ra, swd_minimal_copy\n" ++

--- a/scripts/codegen-zisk-system-writes-check.sh
+++ b/scripts/codegen-zisk-system-writes-check.sh
@@ -36,11 +36,12 @@ for line in man:
     ep=outer[60:]
     number=int.from_bytes(ep[404:412],"little"); ts=int.from_bytes(ep[428:436],"little")
     ph=ep[0:32]
-    s2935=((number-1)& ((1<<64)-1)).to_bytes(32,"big")
+    s2935=(((number-1) & ((1<<64)-1)) % 8191).to_bytes(32,"big")
     v2935=ph.lstrip(b"\x00") or b""
-    s4788=ts.to_bytes(32,"big")
+    ts_slot=ts % 8191
+    s4788=ts_slot.to_bytes(32,"big")
     v4788=ts.to_bytes(8,"big").lstrip(b"\x00") or b""
-    s4788r=(ts + 8191).to_bytes(32,"big")
+    s4788r=(ts_slot + 8191).to_bytes(32,"big")
     v4788r=outer[24:56].lstrip(b"\x00") or b""
     out.append("\t".join([f[0], inp, s2935.hex(), v2935.hex(), s4788.hex(), v4788.hex(), s4788r.hex(), v4788r.hex()]))
 open(sys.argv[1]+".exp","w").write("\n".join(out)+"\n")

--- a/scripts/eest-run-monitor.sh
+++ b/scripts/eest-run-monitor.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# eest-run-monitor.sh -- summarize a running codegen-eest-stateless-check run.
+#
+# Usage:
+#   scripts/eest-run-monitor.sh [--pid PID] [--interval SEC] [--once] [RUN_DIR]
+#
+# If RUN_DIR is omitted, the newest gen-out/eest-run/run-* directory is used.
+# The monitor prints compact progress, result classification, ziskemu RSS, and
+# optional parent-process liveness. It is read-only and safe to run while a test
+# script is still writing result files.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+PID=""
+INTERVAL=10
+ONCE=0
+RUN_DIR=""
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/eest-run-monitor.sh [options] [RUN_DIR]
+
+Options:
+  --pid PID          parent test-script PID to watch for liveness
+  --interval SEC     seconds between updates (default 10)
+  --once             print one snapshot and exit
+  -h, --help         show this help
+USAGE
+}
+
+require_arg() {
+  local opt="$1"
+  if [[ $# -lt 2 || -z "${2:-}" ]]; then
+    echo "$opt requires an argument" >&2
+    usage >&2
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --pid) require_arg "$1" "${2:-}"; PID="$2"; shift 2 ;;
+    --interval) require_arg "$1" "${2:-}"; INTERVAL="$2"; shift 2 ;;
+    --once) ONCE=1; shift ;;
+    *)
+      if [[ -n "$RUN_DIR" ]]; then
+        echo "unexpected argument: $1" >&2
+        usage >&2
+        exit 1
+      fi
+      RUN_DIR="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -n "$PID" && ! "$PID" =~ ^[0-9]+$ ]]; then
+  echo "--pid must be numeric (got: $PID)" >&2
+  exit 1
+fi
+if ! [[ "$INTERVAL" =~ ^[0-9]+$ ]] || [[ "$INTERVAL" -lt 1 ]]; then
+  echo "--interval must be a positive integer (got: $INTERVAL)" >&2
+  exit 1
+fi
+
+if [[ -z "$RUN_DIR" ]]; then
+  RUN_DIR="$(find gen-out/eest-run -maxdepth 1 -type d -name 'run-*' 2>/dev/null | sort | tail -n 1 || true)"
+fi
+if [[ -z "$RUN_DIR" || ! -d "$RUN_DIR" ]]; then
+  echo "run directory not found: ${RUN_DIR:-<latest>}" >&2
+  exit 1
+fi
+
+MANIFEST="$RUN_DIR/manifest.tsv"
+
+snapshot() {
+  local now selected completed ok err full succ root tail fail rod running note
+  now="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  selected=0
+  [[ -f "$MANIFEST" ]] && selected="$(wc -l < "$MANIFEST" | tr -d ' ')"
+  completed="$(find "$RUN_DIR" -maxdepth 1 -name '*.result.tsv' 2>/dev/null | wc -l | tr -d ' ')"
+  running="$(pgrep -fc "ziskemu .*${RUN_DIR}" || true)"
+  note=""
+  if [[ -n "$PID" ]]; then
+    if kill -0 "$PID" 2>/dev/null; then
+      note="parent=alive"
+    else
+      note="parent=exited"
+    fi
+  fi
+
+  read -r ok err full succ root tail fail rod < <(
+    awk -F '\t' '
+      BEGIN { ok=err=full=succ=root=tail=fail=rod=0 }
+      FNR==NR {
+        expected_by_label[$1] = substr($3, 1, 210)
+        rel[$1] = $7
+        next
+      }
+      {
+        label = FILENAME
+        sub(/^.*\//, "", label)
+        sub(/\.result\.tsv$/, "", label)
+        if ($1 != "OK") { err++; next }
+        ok++
+        actual = $2
+        expected = expected_by_label[label]
+        r = (substr(actual, 1, 64) == substr(expected, 1, 64))
+        s = (substr(actual, 65, 2) == substr(expected, 65, 2))
+        t = (substr(actual, 67, 144) == substr(expected, 67, 144))
+        if (r) root++
+        if (s) succ++
+        if (t) tail++
+        if (actual == expected) full++
+        else {
+          fail++
+          if (!r && s && t) rod++
+        }
+      }
+      END { print ok, err, full, succ, root, tail, fail, rod }
+    ' "$MANIFEST" "$RUN_DIR"/*.result.tsv 2>/dev/null || echo "0 0 0 0 0 0 0 0"
+  )
+
+  printf '%s run=%s selected=%s completed=%s ok=%s err=%s full=%s succ=%s root=%s tail=%s fail=%s root_only=%s ziskemu=%s %s\n' \
+    "$now" "$RUN_DIR" "$selected" "$completed" "$ok" "$err" "$full" "$succ" "$root" "$tail" "$fail" "$rod" "$running" "$note"
+
+  ps -o pid,ppid,rss,comm,args -C ziskemu 2>/dev/null \
+    | awk -v run="$RUN_DIR" 'NR == 1 || index($0, run) { print "  " $0 }'
+}
+
+while true; do
+  snapshot
+  [[ "$ONCE" -eq 1 ]] && exit 0
+  if [[ -n "$PID" ]] && ! kill -0 "$PID" 2>/dev/null; then
+    exit 0
+  fi
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## Summary
- Reduce EIP-2935 and EIP-4788 system-write storage slots modulo the 8191-entry history ring before encoding storage keys.
- Update the system-write zisk probe expectation for modulo slot derivation.
- Add `scripts/eest-run-monitor.sh` to summarize long EEST run progress and ziskemu RSS from a run directory instead of chat-level polling.

## Evidence
- Decoded failing `eip4788_beacon_root` fixtures showed timestamp `2^64 - 2` with BAL slots `4094` and `12285`, while the guest was deriving raw timestamp slots.
- `lake build EvmAsm.Codegen.Programs.SystemWrites`
- `scripts/codegen-zisk-system-writes-check.sh eip4788_beacon_root 40`
- `scripts/eest-run-monitor.sh --once gen-out/eest-run/run-20260602T091618Z-107178` reported `selected=40 completed=40 ok=40 full=40 succ=40 root=40 tail=40 fail=0`.
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `bash -n scripts/eest-run-monitor.sh scripts/codegen-zisk-system-writes-check.sh`
- `git diff --check`
- `lake build`

Bead: evm-asm-fhsxz.2.4.2.59.13

Authored by @pirapira; implemented by Codex.