### PR TITLE
feat(precompile): add basic call frame surface

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -108,6 +108,17 @@ def emitJumpTable (registry : List OpcodeHandlerSpec) : String :=
   "opcode_handlers:\n" ++
   String.intercalate "\n" entries
 
+/-- Shared scratch for the CALL/STATICCALL precompile frame surface.
+    Follow-up precompile bodies can write returndata bytes here before
+    copying them into caller memory. Layout:
+      +0  status / success word
+      +8  returndata length
+      +16 first 64 bytes of returndata scratch. -/
+def emitPrecompileFrameData : String :=
+  ".balign 8\n" ++
+  "evm_precompile_frame:\n" ++
+  "  .zero 80\n"
+
 /-- Dispatcher prologue: init EVM pointers (`x10` = code, `x12` =
     stack top, `x13` = EVM memory base) and enter the main
     fetch/decode/dispatch loop. Each iteration loads the opcode byte
@@ -346,6 +357,7 @@ def emitDispatcherDataSection
   ".balign 8\n" ++
   "evm_event_logs:\n" ++
   "  .zero 4096\n" ++     -- M26: 16 × 256-byte bounded LOG event descriptors
+  emitPrecompileFrameData ++
   ".balign 8\n" ++
   "zk3_state:\n" ++
   "  .zero 200\n" ++      -- M16: 25 × u64 keccak permutation state buffer
@@ -487,6 +499,7 @@ def emitRuntimeDispatcherDataSection
   ".balign 8\n" ++
   "evm_event_logs:\n" ++
   "  .zero 4096\n" ++     -- M26: 16 × 256-byte bounded LOG event descriptors
+  emitPrecompileFrameData ++
   ".balign 8\n" ++
   "zk3_state:\n" ++
   "  .zero 200\n" ++      -- M16: 25 × u64 keccak permutation state buffer

--- a/EvmAsm/Codegen/Programs/Noop.lean
+++ b/EvmAsm/Codegen/Programs/Noop.lean
@@ -289,9 +289,18 @@ def copyNoopHandlers : List OpcodeHandlerSpec :=
     Yellow Paper; for our no-op the ordering doesn't matter because
     we drop everything.
 
+    **M27 update**: CALL / STATICCALL now recognize target
+    addresses 0x01..0x04 as the basic precompile frame surface and
+    push success = 1. The per-precompile bodies are still stubs in
+    this slice; follow-up PRs wire IDENTITY / SHA256 / RIPEMD160 /
+    ECRECOVER output semantics.
+
     **Known limitations** (documented in CODEGEN.md M19 narrative):
-    - CALL / CALLCODE / DELEGATECALL / STATICCALL always return 0
-      (= "call failed"). No actual sub-frame execution.
+    - Non-precompile CALL / CALLCODE / DELEGATECALL / STATICCALL
+      still return 0 (= "call failed"). No actual sub-frame
+      execution.
+    - Basic precompile CALL / STATICCALL targets currently return
+      success without producing returndata.
     - CREATE / CREATE2 always return address 0 (= "deployment
       failed"). The would-be deployed code is not executed.
     - No frame stack / recursion. The dispatcher doesn't push a
@@ -307,12 +316,55 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
               SD .x12 .x0 16 ;;
               SD .x12 .x0 24
     , tail := .advanceAndRet 1 }
+  let basicPrecompileCallTail (netPopBytes : Nat) : String :=
+    -- Stack top at entry is the call gas word. The destination
+    -- address is the next word for both CALL and STATICCALL.
+    "  ld x14, 32(x12)\n" ++
+    "  ld x15, 40(x12)\n" ++
+    "  bnez x15, 1f\n" ++
+    "  ld x15, 48(x12)\n" ++
+    "  bnez x15, 1f\n" ++
+    "  ld x15, 56(x12)\n" ++
+    "  bnez x15, 1f\n" ++
+    "  li x15, 1\n" ++
+    "  bltu x14, x15, 1f\n" ++
+    "  li x15, 4\n" ++
+    "  bltu x15, x14, 1f\n" ++
+    "  la x15, evm_precompile_frame\n" ++
+    "  li x16, 1\n" ++
+    "  sd x16, 0(x15)\n" ++
+    "  sd x0, 8(x15)\n" ++
+    "  addi x12, x12, " ++ toString netPopBytes ++ "\n" ++
+    "  li x14, 1\n" ++
+    "  sd x14, 0(x12)\n" ++
+    "  sd x0, 8(x12)\n" ++
+    "  sd x0, 16(x12)\n" ++
+    "  sd x0, 24(x12)\n" ++
+    "  addi x10, x10, 1\n" ++
+    "  ret\n" ++
+    "1:\n" ++
+    "  la x15, evm_precompile_frame\n" ++
+    "  sd x0, 0(x15)\n" ++
+    "  sd x0, 8(x15)\n" ++
+    "  addi x12, x12, " ++ toString netPopBytes ++ "\n" ++
+    "  sd x0, 0(x12)\n" ++
+    "  sd x0, 8(x12)\n" ++
+    "  sd x0, 16(x12)\n" ++
+    "  sd x0, 24(x12)\n" ++
+    "  addi x10, x10, 1\n" ++
+    "  ret"
   [ mkHandler "h_CREATE"        0xf0 64
-  , mkHandler "h_CALL"          0xf1 192
+  , { label := "h_CALL"
+    , opcodes := [0xf1]
+    , body := []
+    , tail := .custom (basicPrecompileCallTail 192) }
   , mkHandler "h_CALLCODE"      0xf2 192
   , mkHandler "h_DELEGATECALL"  0xf4 160
   , mkHandler "h_CREATE2"       0xf5 96
-  , mkHandler "h_STATICCALL"    0xfa 160 ]
+  , { label := "h_STATICCALL"
+    , opcodes := [0xfa]
+    , body := []
+    , tail := .custom (basicPrecompileCallTail 160) } ]
 
 /-- M20 arithmetic no-op handlers (MULMOD, EXP). The last two
     unwired opcodes shipped as placeholders to **hit 100% opcode

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -421,10 +421,13 @@ def opcodeTestCases : List OpcodeTestCase :=
     { name           := "mcopy_pop3"
       bytecode       := "0x60, 0x01, 0x60, 0x02, 0x60, 0x03, 0x5e, 0x60, 0x42, 0x00"
       expectedOutHex := "4200000000000000000000000000000000000000000000000000000000000000" }
-    -- ## M19 child-frame opcodes (CREATE/CALL/CALLCODE/DELEGATECALL/
-    -- CREATE2/STATICCALL) — wired as pop-N + push-zero no-ops.
-    -- Each opcode pops the EVM-spec input count and writes 32 zero
-    -- bytes to the new top-of-stack slot ("call failed" / "address 0").
+    -- ## M19/M27 child-frame opcodes (CREATE/CALL/CALLCODE/
+    -- DELEGATECALL/CREATE2/STATICCALL). CREATE-family and
+    -- non-precompile CALL-family targets remain pop-N + push-zero
+    -- no-ops. M27 adds a basic precompile frame surface for CALL /
+    -- STATICCALL to addresses 0x01..0x04; those stubs push success =
+    -- 1 so later PRs can hang per-precompile returndata bodies off
+    -- the recognized branch.
     -- Three representative test cases spanning the net-pop spectrum
     -- (CREATE = 2, STATICCALL = 5, CALL = 6).
   , -- PUSH1 0x01; PUSH1 0x02; PUSH1 0x03; CREATE; PUSH1 0x42; STOP
@@ -451,6 +454,19 @@ def opcodeTestCases : List OpcodeTestCase :=
     { name           := "staticcall_pop6_push_zero"
       bytecode       := "0x60, 0x01, 0x60, 0x02, 0x60, 0x03, 0x60, 0x04, 0x60, 0x05, 0x60, 0x06, 0xfa, 0x60, 0xab, 0x00"
       expectedOutHex := "ab00000000000000000000000000000000000000000000000000000000000000" }
+  , -- CALL to basic precompile address 0x04 (IDENTITY) reaches the
+    -- precompile-specific frame stub and pushes success = 1. Stack
+    -- args are pushed bottom-to-top: out_size, out_off, in_size,
+    -- in_off, value, to, gas.
+    { name           := "call_identity_precompile_stub_success"
+      bytecode       := "0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x04, 0x60, 0xff, 0xf1, 0x00"
+      expectedOutHex := "0100000000000000000000000000000000000000000000000000000000000000" }
+  , -- STATICCALL to basic precompile address 0x04 reaches the same
+    -- frame surface. Args: out_size, out_off, in_size, in_off, to,
+    -- gas.
+    { name           := "staticcall_identity_precompile_stub_success"
+      bytecode       := "0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x04, 0x60, 0xff, 0xfa, 0x00"
+      expectedOutHex := "0100000000000000000000000000000000000000000000000000000000000000" }
     -- ## M20 arithmetic no-ops (MULMOD, EXP) — the LAST TWO unwired
     -- opcodes; M20 brings tinyInterpRegistry to 100% coverage 🎯.
     -- Both ship as placeholders; real upgrades follow in M21+.


### PR DESCRIPTION
## Summary
- recognize CALL and STATICCALL targets 0x01..0x04 as basic precompile frame stubs
- add a shared dispatcher precompile frame scratch label for status and returndata length
- add runtime opcode tests for CALL/STATICCALL to the identity precompile stub while preserving non-precompile CALL-family regression coverage

Refs: evm-asm-fhsxz.2.4.2.62.2.1
Bead: evm-asm-fhsxz.2.4.2.62.2.1

## Verification
- lake build EvmAsm.Codegen.Dispatch EvmAsm.Codegen.Programs.Noop EvmAsm.Codegen.Tests.Cases
- scripts/codegen-opcodes-runtime-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Dispatch.lean EvmAsm/Codegen/Programs/Noop.lean EvmAsm/Codegen/Tests/Cases.lean
- lake build

Authored by @pirapira; implemented by Codex.