### PR TITLE
feat(precompile): implement identity copy

### DIFF
--- a/EvmAsm/Codegen/Programs/Noop.lean
+++ b/EvmAsm/Codegen/Programs/Noop.lean
@@ -290,17 +290,18 @@ def copyNoopHandlers : List OpcodeHandlerSpec :=
     we drop everything.
 
     **M27 update**: CALL / STATICCALL now recognize target
-    addresses 0x01..0x04 as the basic precompile frame surface and
-    push success = 1. The per-precompile bodies are still stubs in
-    this slice; follow-up PRs wire IDENTITY / SHA256 / RIPEMD160 /
-    ECRECOVER output semantics.
+    addresses 0x01..0x04 as the basic precompile frame surface.
+    IDENTITY (0x04) copies input bytes to caller output memory and
+    pushes success = 1. The crypto precompiles 0x01..0x03 remain
+    success stubs in this slice; follow-up PRs wire SHA256 /
+    RIPEMD160 / ECRECOVER output semantics.
 
     **Known limitations** (documented in CODEGEN.md M19 narrative):
     - Non-precompile CALL / CALLCODE / DELEGATECALL / STATICCALL
       still return 0 (= "call failed"). No actual sub-frame
       execution.
-    - Basic precompile CALL / STATICCALL targets currently return
-      success without producing returndata.
+    - Basic crypto precompile CALL / STATICCALL targets currently
+      return success without producing returndata.
     - CREATE / CREATE2 always return address 0 (= "deployment
       failed"). The would-be deployed code is not executed.
     - No frame stack / recursion. The dispatcher doesn't push a
@@ -316,7 +317,8 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
               SD .x12 .x0 16 ;;
               SD .x12 .x0 24
     , tail := .advanceAndRet 1 }
-  let basicPrecompileCallTail (netPopBytes : Nat) : String :=
+  let basicPrecompileCallTail
+      (netPopBytes inOffsetOff inSizeOff outOffsetOff outSizeOff : Nat) : String :=
     -- Stack top at entry is the call gas word. The destination
     -- address is the next word for both CALL and STATICCALL.
     "  ld x14, 32(x12)\n" ++
@@ -334,6 +336,46 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
     "  li x16, 1\n" ++
     "  sd x16, 0(x15)\n" ++
     "  sd x0, 8(x15)\n" ++
+    "  li x16, 4\n" ++
+    "  bne x14, x16, 7f\n" ++
+    "  ld x17, " ++ toString inSizeOff ++ "(x12)\n" ++
+    "  sd x17, 8(x15)\n" ++       -- returndata length = full input size
+    "  ld x18, " ++ toString inOffsetOff ++ "(x12)\n" ++
+    "  add x18, x13, x18\n" ++    -- x18 = identity input bytes
+    "  ld x19, " ++ toString outOffsetOff ++ "(x12)\n" ++
+    "  add x19, x13, x19\n" ++    -- x19 = caller output bytes
+    -- Copy up to 64 bytes of returndata into the shared frame.
+    "  mv x22, x18\n" ++
+    "  addi x23, x15, 16\n" ++
+    "  mv x24, x17\n" ++
+    "  li x16, 64\n" ++
+    "  bgeu x16, x24, 2f\n" ++
+    "  mv x24, x16\n" ++
+    "2:\n" ++
+    "  beqz x24, 4f\n" ++
+    "3:\n" ++
+    "  lbu x16, 0(x22)\n" ++
+    "  sb x16, 0(x23)\n" ++
+    "  addi x22, x22, 1\n" ++
+    "  addi x23, x23, 1\n" ++
+    "  addi x24, x24, -1\n" ++
+    "  bnez x24, 3b\n" ++
+    -- Copy min(input_size, output_size) bytes to caller memory.
+    "4:\n" ++
+    "  mv x22, x17\n" ++
+    "  ld x23, " ++ toString outSizeOff ++ "(x12)\n" ++
+    "  bgeu x23, x22, 5f\n" ++
+    "  mv x22, x23\n" ++
+    "5:\n" ++
+    "  beqz x22, 7f\n" ++
+    "6:\n" ++
+    "  lbu x16, 0(x18)\n" ++
+    "  sb x16, 0(x19)\n" ++
+    "  addi x18, x18, 1\n" ++
+    "  addi x19, x19, 1\n" ++
+    "  addi x22, x22, -1\n" ++
+    "  bnez x22, 6b\n" ++
+    "7:\n" ++
     "  addi x12, x12, " ++ toString netPopBytes ++ "\n" ++
     "  li x14, 1\n" ++
     "  sd x14, 0(x12)\n" ++
@@ -357,14 +399,14 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
   , { label := "h_CALL"
     , opcodes := [0xf1]
     , body := []
-    , tail := .custom (basicPrecompileCallTail 192) }
+    , tail := .custom (basicPrecompileCallTail 192 96 128 160 192) }
   , mkHandler "h_CALLCODE"      0xf2 192
   , mkHandler "h_DELEGATECALL"  0xf4 160
   , mkHandler "h_CREATE2"       0xf5 96
   , { label := "h_STATICCALL"
     , opcodes := [0xfa]
     , body := []
-    , tail := .custom (basicPrecompileCallTail 160) } ]
+    , tail := .custom (basicPrecompileCallTail 160 64 96 128 160) } ]
 
 /-- M20 arithmetic no-op handlers (MULMOD, EXP). The last two
     unwired opcodes shipped as placeholders to **hit 100% opcode

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -467,6 +467,20 @@ def opcodeTestCases : List OpcodeTestCase :=
     { name           := "staticcall_identity_precompile_stub_success"
       bytecode       := "0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x04, 0x60, 0xff, 0xfa, 0x00"
       expectedOutHex := "0100000000000000000000000000000000000000000000000000000000000000" }
+  , -- IDENTITY via CALL copies three input bytes from memory[0..3)
+    -- into caller output memory[0x40..0x43). POP drops the success
+    -- word; RETURN exposes the copied bytes directly.
+    { name             := "call_identity_precompile_copies_memory"
+      bytecode         := "0x60, 0xaa, 0x60, 0x00, 0x53, 0x60, 0xbb, 0x60, 0x01, 0x53, 0x60, 0xcc, 0x60, 0x02, 0x53, 0x60, 0x03, 0x60, 0x40, 0x60, 0x03, 0x60, 0x00, 0x60, 0x00, 0x60, 0x04, 0x60, 0xff, 0xf1, 0x50, 0x60, 0x03, 0x60, 0x40, 0xf3"
+      expectedOutHex   := "aabbcc0000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind := "0100000000000000" }
+  , -- STATICCALL to IDENTITY with output_size=2 and input_size=3
+    -- copies only the short caller output buffer. Returning three
+    -- bytes from the output region proves the third byte remains zero.
+    { name             := "staticcall_identity_precompile_short_output"
+      bytecode         := "0x60, 0xaa, 0x60, 0x00, 0x53, 0x60, 0xbb, 0x60, 0x01, 0x53, 0x60, 0xcc, 0x60, 0x02, 0x53, 0x60, 0x02, 0x60, 0x40, 0x60, 0x03, 0x60, 0x00, 0x60, 0x04, 0x60, 0xff, 0xfa, 0x50, 0x60, 0x03, 0x60, 0x40, 0xf3"
+      expectedOutHex   := "aabb000000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind := "0100000000000000" }
     -- ## M20 arithmetic no-ops (MULMOD, EXP) — the LAST TWO unwired
     -- opcodes; M20 brings tinyInterpRegistry to 100% coverage 🎯.
     -- Both ship as placeholders; real upgrades follow in M21+.


### PR DESCRIPTION
## Summary
- implement IDENTITY (address 0x04) in the CALL/STATICCALL precompile frame surface
- copy `min(input_size, output_size)` bytes from EVM memory to caller output memory using byte accesses
- record returndata length and a bounded returndata prefix in `evm_precompile_frame`
- add runtime opcode tests for CALL identity copying and STATICCALL short-output copying

Refs: evm-asm-fhsxz.2.4.2.62.2.2
Bead: evm-asm-fhsxz.2.4.2.62.2.2

## Verification
- lake build EvmAsm.Codegen.Programs.Noop EvmAsm.Codegen.Tests.Cases
- scripts/codegen-opcodes-runtime-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/Noop.lean EvmAsm/Codegen/Tests/Cases.lean
- lake build

Authored by @pirapira; implemented by Codex.