### PR TITLE
feat(precompile): wire sha256 call

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -119,6 +119,26 @@ def emitPrecompileFrameData : String :=
   "evm_precompile_frame:\n" ++
   "  .zero 80\n"
 
+/-- Scratch buffers used by `zkvm_sha256`. The wrapper expects these
+    labels to exist in the dispatcher's data section. -/
+def emitSha256Data : String :=
+  ".balign 8\n" ++
+  "sha256_w_iv:\n" ++
+  "  .quad 0xbb67ae856a09e667\n" ++
+  "  .quad 0xa54ff53a3c6ef372\n" ++
+  "  .quad 0x9b05688c510e527f\n" ++
+  "  .quad 0x5be0cd191f83d9ab\n" ++
+  ".balign 8\n" ++
+  "sha256_w_state:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "sha256_w_input:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "sha256_w_params:\n" ++
+  "  .quad sha256_w_state\n" ++
+  "  .quad sha256_w_input\n"
+
 /-- Dispatcher prologue: init EVM pointers (`x10` = code, `x12` =
     stack top, `x13` = EVM memory base) and enter the main
     fetch/decode/dispatch loop. Each iteration loads the opcode byte
@@ -195,16 +215,13 @@ def emitDispatcherPrologue : String :=
 def emitDispatcherEpilogue
     (registry : List OpcodeHandlerSpec) (exitBody : Program) : String :=
   String.intercalate "\n" (registry.map OpcodeHandlerSpec.emitSubroutine) ++ "\n" ++
-  -- M16: the keccak subroutine sits BETWEEN the handler subroutines
+  -- M16/M27: hash subroutines sit BETWEEN the handler subroutines
   -- and the `h_invalid:` / `.exit_label:` blocks so it's reachable only
-  -- via `jal x1, zkvm_keccak256` (not by fall-through from exitBody).
+  -- via explicit `jal`s (not by fall-through from exitBody).
   -- Each handler subroutine ends with `ret` / `j .dispatch_loop`, so
-  -- they don't fall through into this label. The subroutine itself
-  -- ends with `ret`, returning to whoever JAL'd it. Provides label
-  -- `zkvm_keccak256` for `hashHandlers` (M16: KECCAK256; M17+: LOG /
-  -- precompiles). Wraps Zisk's `csrs 0x800, a0` accelerator
-  -- (`.4byte 0x80052073`) as a sponge-mode loop. Inputs via LP64
-  -- a0/a1/a2; uses the dispatcher-side `zk3_state` data label.
+  -- they don't fall through into these labels. The subroutines end
+  -- with `ret`, returning to whoever JAL'd them.
+  zkvmSha256Function ++ "\n" ++
   zkvmKeccak256Function ++ "\n" ++
   "h_invalid:\n" ++
   "  j .exit_label\n" ++
@@ -358,6 +375,7 @@ def emitDispatcherDataSection
   "evm_event_logs:\n" ++
   "  .zero 4096\n" ++     -- M26: 16 × 256-byte bounded LOG event descriptors
   emitPrecompileFrameData ++
+  emitSha256Data ++
   ".balign 8\n" ++
   "zk3_state:\n" ++
   "  .zero 200\n" ++      -- M16: 25 × u64 keccak permutation state buffer
@@ -500,6 +518,7 @@ def emitRuntimeDispatcherDataSection
   "evm_event_logs:\n" ++
   "  .zero 4096\n" ++     -- M26: 16 × 256-byte bounded LOG event descriptors
   emitPrecompileFrameData ++
+  emitSha256Data ++
   ".balign 8\n" ++
   "zk3_state:\n" ++
   "  .zero 200\n" ++      -- M16: 25 × u64 keccak permutation state buffer

--- a/EvmAsm/Codegen/Programs/Noop.lean
+++ b/EvmAsm/Codegen/Programs/Noop.lean
@@ -291,16 +291,16 @@ def copyNoopHandlers : List OpcodeHandlerSpec :=
 
     **M27 update**: CALL / STATICCALL now recognize target
     addresses 0x01..0x04 as the basic precompile frame surface.
-    IDENTITY (0x04) copies input bytes to caller output memory and
-    pushes success = 1. The crypto precompiles 0x01..0x03 remain
-    success stubs in this slice; follow-up PRs wire SHA256 /
-    RIPEMD160 / ECRECOVER output semantics.
+    SHA256 (0x02) hashes input bytes through `zkvm_sha256`,
+    IDENTITY (0x04) copies input bytes to caller output memory, and
+    both push success = 1. ECRECOVER / RIPEMD160 remain success
+    stubs in this slice; follow-up PRs wire their output semantics.
 
     **Known limitations** (documented in CODEGEN.md M19 narrative):
     - Non-precompile CALL / CALLCODE / DELEGATECALL / STATICCALL
       still return 0 (= "call failed"). No actual sub-frame
       execution.
-    - Basic crypto precompile CALL / STATICCALL targets currently
+    - ECRECOVER / RIPEMD160 CALL / STATICCALL targets currently
       return success without producing returndata.
     - CREATE / CREATE2 always return address 0 (= "deployment
       failed"). The would-be deployed code is not executed.
@@ -336,6 +336,8 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
     "  li x16, 1\n" ++
     "  sd x16, 0(x15)\n" ++
     "  sd x0, 8(x15)\n" ++
+    "  li x16, 2\n" ++
+    "  beq x14, x16, 8f\n" ++
     "  li x16, 4\n" ++
     "  bne x14, x16, 7f\n" ++
     "  ld x17, " ++ toString inSizeOff ++ "(x12)\n" ++
@@ -383,7 +385,40 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
     "  sd x0, 16(x12)\n" ++
     "  sd x0, 24(x12)\n" ++
     "  addi x10, x10, 1\n" ++
-    "  ret\n" ++
+    "  j .dispatch_loop\n" ++
+    -- SHA256: digest = sha256(memory[in_offset .. in_offset+in_size)).
+    -- The wrapper uses the LP64 a0/a1/a2 registers, so save the
+    -- dispatcher code and stack pointers before setting up arguments.
+    "8:\n" ++
+    "  li x16, 32\n" ++
+    "  sd x16, 8(x15)\n" ++
+    "  mv s10, x10\n" ++
+    "  mv s11, x12\n" ++
+    "  ld a1, " ++ toString inSizeOff ++ "(x12)\n" ++
+    "  ld x18, " ++ toString inOffsetOff ++ "(x12)\n" ++
+    "  add a0, x13, x18\n" ++
+    "  addi a2, x15, 16\n" ++
+    "  jal x1, zkvm_sha256\n" ++
+    "  mv x10, s10\n" ++
+    "  mv x12, s11\n" ++
+    "  la x15, evm_precompile_frame\n" ++
+    "  ld x23, " ++ toString outSizeOff ++ "(x12)\n" ++
+    "  li x22, 32\n" ++
+    "  bgeu x23, x22, 9f\n" ++
+    "  mv x22, x23\n" ++
+    "9:\n" ++
+    "  beqz x22, 7b\n" ++
+    "  addi x18, x15, 16\n" ++
+    "  ld x19, " ++ toString outOffsetOff ++ "(x12)\n" ++
+    "  add x19, x13, x19\n" ++
+    "10:\n" ++
+    "  lbu x16, 0(x18)\n" ++
+    "  sb x16, 0(x19)\n" ++
+    "  addi x18, x18, 1\n" ++
+    "  addi x19, x19, 1\n" ++
+    "  addi x22, x22, -1\n" ++
+    "  bnez x22, 10b\n" ++
+    "  j 7b\n" ++
     "1:\n" ++
     "  la x15, evm_precompile_frame\n" ++
     "  sd x0, 0(x15)\n" ++
@@ -394,7 +429,7 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
     "  sd x0, 16(x12)\n" ++
     "  sd x0, 24(x12)\n" ++
     "  addi x10, x10, 1\n" ++
-    "  ret"
+    "  j .dispatch_loop"
   [ mkHandler "h_CREATE"        0xf0 64
   , { label := "h_CALL"
     , opcodes := [0xf1]

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -481,6 +481,24 @@ def opcodeTestCases : List OpcodeTestCase :=
       bytecode         := "0x60, 0xaa, 0x60, 0x00, 0x53, 0x60, 0xbb, 0x60, 0x01, 0x53, 0x60, 0xcc, 0x60, 0x02, 0x53, 0x60, 0x02, 0x60, 0x40, 0x60, 0x03, 0x60, 0x00, 0x60, 0x04, 0x60, 0xff, 0xfa, 0x50, 0x60, 0x03, 0x60, 0x40, 0xf3"
       expectedOutHex   := "aabb000000000000000000000000000000000000000000000000000000000000"
       expectedHaltKind := "0100000000000000" }
+  , -- STATICCALL to SHA256 over empty input writes the canonical
+    -- sha256("") digest to caller memory.
+    { name             := "staticcall_sha256_precompile_empty"
+      bytecode         := "0x60, 0x20, 0x60, 0x40, 0x60, 0x00, 0x60, 0x00, 0x60, 0x02, 0x60, 0xff, 0xfa, 0x50, 0x60, 0x20, 0x60, 0x40, 0xf3"
+      expectedOutHex   := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      expectedHaltKind := "0100000000000000" }
+  , -- CALL to SHA256 over memory[0..3) = "abc".
+    { name             := "call_sha256_precompile_abc"
+      bytecode         := "0x60, 0x61, 0x60, 0x00, 0x53, 0x60, 0x62, 0x60, 0x01, 0x53, 0x60, 0x63, 0x60, 0x02, 0x53, 0x60, 0x20, 0x60, 0x40, 0x60, 0x03, 0x60, 0x00, 0x60, 0x00, 0x60, 0x02, 0x60, 0xff, 0xf1, 0x50, 0x60, 0x20, 0x60, 0x40, 0xf3"
+      expectedOutHex   := "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+      expectedHaltKind := "0100000000000000" }
+  , -- CALLDATACOPY loads 200 bytes of 0xaa into memory, then CALL
+    -- hashes it through SHA256. This covers the multi-block path.
+    { name             := "call_sha256_precompile_aa200"
+      bytecode         := "0x60, 0xc8, 0x60, 0x00, 0x60, 0x00, 0x37, 0x60, 0x20, 0x60, 0x40, 0x60, 0xc8, 0x60, 0x00, 0x60, 0x00, 0x60, 0x02, 0x60, 0xff, 0xf1, 0x50, 0x60, 0x20, 0x60, 0x40, 0xf3"
+      calldata         := "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      expectedOutHex   := "605ed279d0a1af786c79054f9424d196ed6a1f0331100a923d711885d42099bb"
+      expectedHaltKind := "0100000000000000" }
     -- ## M20 arithmetic no-ops (MULMOD, EXP) — the LAST TWO unwired
     -- opcodes; M20 brings tinyInterpRegistry to 100% coverage 🎯.
     -- Both ship as placeholders; real upgrades follow in M21+.


### PR DESCRIPTION
## Summary
- emit `zkvm_sha256` and its scratch buffers from the runtime dispatcher
- route CALL/STATICCALL precompile address `0x02` through the SHA256 wrapper
- copy `min(32, output_size)` digest bytes to caller memory and record returndata length/prefix in `evm_precompile_frame`
- add runtime opcode coverage for empty, `abc`, and 200-byte SHA256 precompile inputs

Stacked on #7886.
Refs: evm-asm-fhsxz.2.4.2.62.2.3
Bead: evm-asm-fhsxz.2.4.2.62.2.3

## Verification
- scripts/codegen-zisk-zkvm-sha256-check.sh
- lake build EvmAsm.Codegen.Dispatch EvmAsm.Codegen.Programs.Noop EvmAsm.Codegen.Tests.Cases
- scripts/codegen-opcodes-runtime-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Dispatch.lean EvmAsm/Codegen/Programs/Noop.lean EvmAsm/Codegen/Tests/Cases.lean
- lake build

Authored by @pirapira; implemented by Codex.