### PR TITLE
docs(precompile): record RIPEMD160 backend gap

### DIFF
--- a/docs/eest-precompile-frontier.md
+++ b/docs/eest-precompile-frontier.md
@@ -23,7 +23,7 @@ columns describe only the latest harness selection.
 | Precompile account warming / absence | `0x01..0x14`, `0x100` | VM call gas/account-access path before dispatch | `evm-asm-fhsxz.2.4.2.62.1` |
 | ECRECOVER | `0x01` | `zkvm_secp256k1_ecrecover` bridge exists; stateless dispatch missing | `evm-asm-fhsxz.2.4.2.62.2` |
 | SHA256 | `0x02` | `zkvm_sha256` bridge exists; stateless dispatch missing | `evm-asm-fhsxz.2.4.2.62.2` |
-| RIPEMD160 | `0x03` | `zkvm_ripemd160` bridge exists; stateless dispatch missing | `evm-asm-fhsxz.2.4.2.62.2` |
+| RIPEMD160 | `0x03` | `zkvm_ripemd160` bridge exists at the desired ABI level, but the local ziskemu installation has no named RIPEMD160 backend; backend/probe required before dispatch | `evm-asm-fhsxz.2.4.2.62.2` |
 | IDENTITY | `0x04` | in-guest memory copy; no accelerator | `evm-asm-fhsxz.2.4.2.62.2` |
 | MODEXP | `0x05` | `zkvm_modexp` bridge exists; gas/return-data framing missing | `evm-asm-fhsxz.2.4.2.62.3` |
 | BN254 add/mul/pairing | `0x06..0x08` | `zkvm_bn254_*` bridges exist; call framing missing | `evm-asm-fhsxz.2.4.2.62.3` |

--- a/docs/zkvm-accelerators-interface.md
+++ b/docs/zkvm-accelerators-interface.md
@@ -84,6 +84,32 @@ The table is intentionally path-based: if a bridge module is renamed or split,
 this table should be updated in the same PR so downstream readers can trace
 from the C symbol to the Lean payload and ECALL surface.
 
+## Installed ziskemu backend notes
+
+The zkvm-standards row above is the desired ABI surface, not proof that the
+locally installed `ziskemu` has a concrete backend for every symbol. As of the
+2026-06-02 local installation used for EEST work:
+
+- `zkvm_sha256` is implemented in this repo as a guest wrapper around
+  ziskemu's SHA-256 compression intrinsic at CSR `0x805`; see
+  `EvmAsm/Codegen/Programs/HashBridge.lean` and
+  `scripts/codegen-zisk-zkvm-sha256-check.sh`.
+- `zkvm_keccak256` is similarly implemented as a guest sponge wrapper around
+  ziskemu's Keccak-f[1600] primitive.
+- No named RIPEMD160 backend is present in the local zisk sources. Searches for
+  `ripemd`, `RIPEMD`, `zkvm_ripemd`, and `ripemd160` under
+  `/home/zksecurity/.zisk/zisk` and `/home/zksecurity/zisk` find no callable
+  symbol or implementation file.
+- ziskemu's `emulator-asm` tree does contain a "precompile results" stream/cache
+  facility, but that path replays externally supplied result words. It is not a
+  RIPEMD160 computation backend and is not exposed by the `ziskemu` CLI used by
+  the current codegen/EEST scripts.
+
+Therefore, RIPEMD160 dispatch should not be wired as if a backend already
+exists. The next implementation slice must either add/prove a concrete zisk
+RIPEMD160 backend path, or explicitly implement RIPEMD160 in the guest and test
+it against Ethereum's `hashlib.new("ripemd160", data)` behavior.
+
 ## Calling convention
 
 The guest follows LP64 as documented in


### PR DESCRIPTION
## Summary
- document that `zkvm_ripemd160` is the desired ABI surface but the local ziskemu installation has no named RIPEMD160 backend
- distinguish SHA256/Keccak guest wrappers from ziskemu's precompile-results replay/cache path
- update the EEST precompile frontier so RIPEMD160 dispatch waits for a real backend/probe or explicit guest implementation

## Verification
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' docs/zkvm-accelerators-interface.md docs/eest-precompile-frontier.md` returned no matches
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build EvmAsm.Codegen.Programs.HashBridge EvmAsm.Codegen.Programs.HashProbes`
- `lake build`

Refs: Bead `evm-asm-fhsxz.2.4.2.62.2.4.1`.

Authored by @pirapira; implemented by Codex.