### PR TITLE
docs(precompile): pin ECRECOVER framing

### DIFF
--- a/EvmAsm/EL/Secp256k1EcrecoverResultBridge.lean
+++ b/EvmAsm/EL/Secp256k1EcrecoverResultBridge.lean
@@ -3,6 +3,13 @@
 
   Bridge from the `zkvm_secp256k1_ecrecover` accelerator output to the
   executable precompile-result surface.
+
+  The accelerator returns a 64-byte uncompressed public key payload. Ethereum
+  ECRECOVER does not return that payload directly: the precompile output is
+  `left_pad_zero_bytes(keccak256(pubkey)[12:32], 32)`, while invalid
+  signatures and failed recovery produce empty return data. The keccak/address
+  framing belongs to the EVM precompile dispatch layer, not to this raw
+  accelerator-result bridge.
 -/
 
 import EvmAsm.Evm64.Accelerators.Status

--- a/docs/eest-precompile-frontier.md
+++ b/docs/eest-precompile-frontier.md
@@ -33,6 +33,47 @@ columns describe only the latest harness selection.
 | P256VERIFY | `0x100` | `zkvm_secp256r1_verify` bridge exists; call framing missing | `evm-asm-fhsxz.2.4.2.62.3` |
 | CALL/STATICCALL/revert/create interactions with precompiles | mixed | VM call/create/revert semantics plus dispatch | `evm-asm-fhsxz.2.4.2.62.1` |
 
+## ECRECOVER framing contract
+
+ECRECOVER dispatch must mirror
+`execution-specs/src/ethereum/forks/frontier/vm/precompiled_contracts/ecrecover.py`
+before calling any `zkvm_secp256k1_ecrecover` backend:
+
+- Charge fixed precompile gas `3000`.
+- Read exactly four 32-byte words from call data with `buffer_read`
+  semantics, so short input is right-padded with zero bytes:
+  `message_hash = data[0:32]`, `v = data[32:64]`,
+  `r = data[64:96]`, `s = data[96:128]`.
+- Interpret `v`, `r`, and `s` as big-endian `U256` values.
+- Accept only `v = 27` or `v = 28`; the backend recovery id is
+  `v - 27`.
+- Reject `r = 0`, `s = 0`, `r >= SECP256K1N`, and
+  `s >= SECP256K1N`.
+- Rejection and backend recovery failure are successful precompile calls with
+  empty return data. The caller's output memory is therefore unchanged except
+  for any generic return-data-copy handling done elsewhere.
+- Successful backend recovery returns a 64-byte uncompressed public key
+  payload. The EVM precompile output is
+  `left_pad_zero_bytes(keccak256(pubkey)[12:32], 32)`: twelve leading zero
+  bytes plus the 20-byte Ethereum address.
+
+Fixture vectors to carry into runtime opcode tests are in
+`execution-specs/tests/frontier/precompiles/test_ecrecover.py`. At minimum,
+use `valid_signature_1`:
+
+```text
+msg_hash = 18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c
+v        = 000000000000000000000000000000000000000000000000000000000000001c
+r        = 73b1693892219d736caba55bdb67216e485557ea6b6af75f37096c9aa6a5a75f
+s        = eeb940b1d03b21e36b0e47e79769f095fe2ab855bd91e3a38756b7d75a9c4549
+output   = 000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b
+```
+
+Also include invalid vectors where `v` is outside `{27, 28}`, `r = 0`,
+`s = 0`, `r = SECP256K1N`, and `s = SECP256K1N`; those expected outputs are
+empty (`b""`) in the execution-spec fixture and must not synthesize a 32-byte
+zero word.
+
 The accelerator bridge source of truth is
 [`docs/zkvm-accelerators-interface.md`](zkvm-accelerators-interface.md). The
 report's path filters intentionally cover benchmark, fork-specific, and ported


### PR DESCRIPTION
## Summary
- document the execution-spec ECRECOVER input parsing, gas, invalid-case, and output framing contract
- record a concrete valid ECRECOVER fixture vector and invalid vector classes for future runtime opcode tests
- clarify that the raw secp256k1 ecrecover bridge returns a 64-byte pubkey, while EVM output is the left-padded address derived from keccak(pubkey)

## Verification
- `lake build EvmAsm.EL.Secp256k1EcrecoverResultBridge`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/EL/Secp256k1EcrecoverResultBridge.lean docs/eest-precompile-frontier.md` returned no matches
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`

Refs: Bead `evm-asm-fhsxz.2.4.2.62.2.5.2`.

Authored by @pirapira; implemented by Codex.