### PR TITLE
feat(selfdestruct): model EIP-6780 pure effect

### DIFF
--- a/EvmAsm/EL/SelfdestructEffects.lean
+++ b/EvmAsm/EL/SelfdestructEffects.lean
@@ -97,6 +97,137 @@ theorem postCancunSelfdestructEffect_beneficiaryBalance?
   exact CallValueTransfer.transferValue_calleeBalance?
     accountBalance beneficiaryBalance accountBalance h_beneficiary h_ne
 
+/-- EIP-6780 SELFDESTRUCT effect. Accounts created in the same transaction are
+    still deleted; pre-existing accounts keep the post-Cancun transfer-only
+    behavior exposed by `postCancunSelfdestructEffect`. -/
+def eip6780SelfdestructEffect
+    (state : WorldState) (account beneficiary : Address)
+    (accountBalance beneficiaryBalance : Word256) (createdInSameTx : Bool) :
+    SelfdestructEffect :=
+  if createdInSameTx then
+    let transferredState :=
+      CallValueTransfer.transferValue
+        state account beneficiary accountBalance beneficiaryBalance accountBalance
+    { state := WorldState.deleteAccount transferredState account
+      sideEffects :=
+        { refundCounter := 0
+          logs := LogState.empty
+          accountsToDelete := [account]
+          touchedAccounts := [beneficiary] } }
+  else
+    postCancunSelfdestructEffect state account beneficiary accountBalance beneficiaryBalance
+
+theorem eip6780SelfdestructEffect_preExisting_eq_postCancunSelfdestructEffect
+    (state : WorldState) (account beneficiary : Address)
+    (accountBalance beneficiaryBalance : Word256) :
+    eip6780SelfdestructEffect
+        state account beneficiary accountBalance beneficiaryBalance false =
+      postCancunSelfdestructEffect
+        state account beneficiary accountBalance beneficiaryBalance := rfl
+
+theorem eip6780SelfdestructEffect_sameTx_state
+    (state : WorldState) (account beneficiary : Address)
+    (accountBalance beneficiaryBalance : Word256) :
+    (eip6780SelfdestructEffect
+        state account beneficiary accountBalance beneficiaryBalance true).state =
+      WorldState.deleteAccount
+        (CallValueTransfer.transferValue
+          state account beneficiary accountBalance beneficiaryBalance accountBalance)
+        account := rfl
+
+theorem eip6780SelfdestructEffect_sameTx_refundCounter
+    (state : WorldState) (account beneficiary : Address)
+    (accountBalance beneficiaryBalance : Word256) :
+    (eip6780SelfdestructEffect
+        state account beneficiary accountBalance beneficiaryBalance true).sideEffects.refundCounter =
+      0 := rfl
+
+theorem eip6780SelfdestructEffect_sameTx_logs
+    (state : WorldState) (account beneficiary : Address)
+    (accountBalance beneficiaryBalance : Word256) :
+    (eip6780SelfdestructEffect
+        state account beneficiary accountBalance beneficiaryBalance true).sideEffects.logs =
+      LogState.empty := rfl
+
+theorem eip6780SelfdestructEffect_sameTx_accountsToDelete
+    (state : WorldState) (account beneficiary : Address)
+    (accountBalance beneficiaryBalance : Word256) :
+    (eip6780SelfdestructEffect
+        state account beneficiary accountBalance beneficiaryBalance true).sideEffects.accountsToDelete =
+      [account] := rfl
+
+theorem eip6780SelfdestructEffect_sameTx_touchedAccounts
+    (state : WorldState) (account beneficiary : Address)
+    (accountBalance beneficiaryBalance : Word256) :
+    (eip6780SelfdestructEffect
+        state account beneficiary accountBalance beneficiaryBalance true).sideEffects.touchedAccounts =
+      [beneficiary] := rfl
+
+theorem eip6780SelfdestructEffect_sameTx_accountDeleted
+    (state : WorldState) (account beneficiary : Address)
+    (accountBalance beneficiaryBalance : Word256) :
+    WorldState.getAccount
+        (eip6780SelfdestructEffect
+          state account beneficiary accountBalance beneficiaryBalance true).state
+        account =
+      none := by
+  rw [eip6780SelfdestructEffect_sameTx_state]
+  exact WorldState.getAccount_deleteAccount_same _ _
+
+theorem eip6780SelfdestructEffect_preExisting_refundCounter
+    (state : WorldState) (account beneficiary : Address)
+    (accountBalance beneficiaryBalance : Word256) :
+    (eip6780SelfdestructEffect
+        state account beneficiary accountBalance beneficiaryBalance false).sideEffects.refundCounter =
+      0 := rfl
+
+theorem eip6780SelfdestructEffect_preExisting_logs
+    (state : WorldState) (account beneficiary : Address)
+    (accountBalance beneficiaryBalance : Word256) :
+    (eip6780SelfdestructEffect
+        state account beneficiary accountBalance beneficiaryBalance false).sideEffects.logs =
+      LogState.empty := rfl
+
+theorem eip6780SelfdestructEffect_preExisting_accountsToDelete
+    (state : WorldState) (account beneficiary : Address)
+    (accountBalance beneficiaryBalance : Word256) :
+    (eip6780SelfdestructEffect
+        state account beneficiary accountBalance beneficiaryBalance false).sideEffects.accountsToDelete =
+      [] := rfl
+
+theorem eip6780SelfdestructEffect_preExisting_touchedAccounts
+    (state : WorldState) (account beneficiary : Address)
+    (accountBalance beneficiaryBalance : Word256) :
+    (eip6780SelfdestructEffect
+        state account beneficiary accountBalance beneficiaryBalance false).sideEffects.touchedAccounts =
+      [beneficiary] := rfl
+
+theorem eip6780SelfdestructEffect_preExisting_accountBalance?
+    {state : WorldState} {account beneficiary : Address} {accountRecord : Account}
+    (accountBalance beneficiaryBalance : Word256)
+    (h_account : WorldState.getAccount state account = some accountRecord)
+    (h_ne : account ≠ beneficiary) :
+    WorldState.accountBalance?
+        (eip6780SelfdestructEffect
+          state account beneficiary accountBalance beneficiaryBalance false).state
+        account =
+      some (accountBalance - accountBalance) :=
+  postCancunSelfdestructEffect_accountBalance?
+    accountBalance beneficiaryBalance h_account h_ne
+
+theorem eip6780SelfdestructEffect_preExisting_beneficiaryBalance?
+    {state : WorldState} {account beneficiary : Address} {beneficiaryRecord : Account}
+    (accountBalance beneficiaryBalance : Word256)
+    (h_beneficiary : WorldState.getAccount state beneficiary = some beneficiaryRecord)
+    (h_ne : account ≠ beneficiary) :
+    WorldState.accountBalance?
+        (eip6780SelfdestructEffect
+          state account beneficiary accountBalance beneficiaryBalance false).state
+        beneficiary =
+      some (beneficiaryBalance + accountBalance) :=
+  postCancunSelfdestructEffect_beneficiaryBalance?
+    accountBalance beneficiaryBalance h_beneficiary h_ne
+
 end SelfdestructEffects
 
 end EvmAsm.EL


### PR DESCRIPTION
## Summary
- add `eip6780SelfdestructEffect` for post-Cancun/EIP-6780 SELFDESTRUCT semantics
- preserve the existing transfer-only path for pre-existing accounts
- model same-transaction-created account deletion, deletion side effects, beneficiary touch, and zero refund/log defaults
- expose projection theorems for later concrete handler/spec plumbing

## Verification
- `lake build EvmAsm.EL.SelfdestructEffects`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/EL/SelfdestructEffects.lean`\n- `scripts/check-file-size.sh`\n- `scripts/check-unimported.sh`\n- `git diff --check`\n- `lake build`\n\n## Bead\n- `evm-asm-fhsxz.2.4.2.60.6.2.1`