### PR TITLE
docs(eest): track Amsterdam scenario frontier

### DIFF
--- a/docs/eest-feature-surfaces.md
+++ b/docs/eest-feature-surfaces.md
@@ -22,6 +22,7 @@ precompile gas or call/create gas.
 
 | Surface | Owning bead | Example filter | Why it matters |
 | --- | --- | --- | --- |
+| Frontier scenario matrices | `evm-asm-fhsxz.2.4.2.54.2` | `frontier/scenarios/scenarios/scenarios` | Tracks Amsterdam `blockchain_tests/for_amsterdam` scenario failures across CALL/CREATE/revert/static-context combinations. See [`docs/eest-scenarios-frontier.md`](eest-scenarios-frontier.md). |
 | Simple tx/value transfer | `evm-asm-fhsxz.2.4.2.56` | `validation/transaction` | Establishes the basic transaction state transition before contract code. |
 | Gas accounting | `evm-asm-fhsxz.2.4.2.57` | `precompile_warming` | Turns warm/cold, intrinsic, memory, call, refund, and OOG fixtures into semantic failures. |
 | Witness-backed state reads | `evm-asm-fhsxz.2.4.2.58` | `sload_non_const` | Replaces local/stub reads for `BALANCE`, `SLOAD`, `EXTCODE*`, and account existence. |

--- a/docs/eest-scenarios-frontier.md
+++ b/docs/eest-scenarios-frontier.md
@@ -1,0 +1,37 @@
+# EEST Scenario Frontier
+
+The Amsterdam blockchain-test fixture reported by the user is generated at:
+
+```text
+gen-out/eest-fixtures/zkevm@v0.4.0/fixtures/fixtures/blockchain_tests/for_amsterdam/frontier/scenarios/scenarios/scenarios.json
+```
+
+It comes from `execution-specs/tests/frontier/scenarios/test_scenarios.py` and
+the generators under `execution-specs/tests/frontier/scenarios/scenarios/`.
+The current cached fixture contains 34 test-program entries and 1,258 stateless
+blocks.
+
+This is a broad feature-completeness frontier, not a narrow opcode fixture. The
+scenario generator combines CALL, CREATE, revert, double-call, and static-context
+execution shapes, then runs many operation programs through those shapes. A
+failure here can point at several existing surfaces at once: call/create frame
+execution, revert propagation, environment opcodes, storage/log/selfdestruct
+effects, returndata, gas, receipts, and post-state root computation.
+
+The owning bead is `evm-asm-fhsxz.2.4.2.54.2`. Use this fixture filter when
+probing it through the stateless harness:
+
+```bash
+scripts/codegen-eest-stateless-check.sh \
+  --filter frontier/scenarios/scenarios/scenarios \
+  --limit 1 \
+  --jobs 1 \
+  --quiet-passes \
+  --max-failures 1 \
+  --steps 200000000
+```
+
+When triaging failures, first identify the test-program id in the fixture name
+(for example `program_SSTORE_SLOAD`, `program_LOGS`, or
+`program_ALL_FRONTIER_OPCODES`), then categorize the failing scenario by the
+missing implementation surface before creating a narrower implementation bead.

--- a/scripts/eest-feature-surface-report.py
+++ b/scripts/eest-feature-surface-report.py
@@ -30,6 +30,16 @@ class Surface:
 
 SURFACES: tuple[Surface, ...] = (
     Surface(
+        key="scenarios",
+        title="frontier scenario matrices",
+        bead="evm-asm-fhsxz.2.4.2.54.2",
+        default_filter="frontier/scenarios/scenarios/scenarios",
+        patterns=(
+            "frontier/scenarios/scenarios/scenarios",
+            "frontier/scenarios/test_scenarios",
+        ),
+    ),
+    Surface(
         key="tx",
         title="simple tx/value transfer",
         bead="evm-asm-fhsxz.2.4.2.56",


### PR DESCRIPTION
## Summary
- add the Amsterdam `frontier/scenarios/scenarios/scenarios` fixture to the EEST feature-surface classifier
- document the generated `blockchain_tests/for_amsterdam` path, source generator, block count, and stateless harness filter
- link the scenario frontier note from the feature-surface overview

## Verification
- `scripts/eest-feature-surface-report.py --format tsv --example-limit 5 | rg 'scenarios|unclassified'`\n- `python3 -m py_compile scripts/eest-feature-surface-report.py`\n- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' scripts/eest-feature-surface-report.py docs/eest-feature-surfaces.md docs/eest-scenarios-frontier.md`\n- `scripts/check-file-size.sh`\n- `scripts/check-unimported.sh`\n- `git diff --check`\n- `lake build`\n\n## Bead\n- `evm-asm-fhsxz.2.4.2.54.2`\n\nAuthored by @pirapira; implemented by Codex.