### PR TITLE
feat(selfdestruct): track created accounts

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -10,6 +10,7 @@ import EvmAsm.EL.CreateAddressExecutableBridge
 import EvmAsm.EL.CreateArgsBridge
 import EvmAsm.EL.CreateInitcodeBridge
 import EvmAsm.EL.CreateEffects
+import EvmAsm.EL.CreatedAccounts
 import EvmAsm.EL.CreateCollision
 import EvmAsm.EL.CreateCollisionResult
 import EvmAsm.EL.CreateResultBridge

--- a/EvmAsm/EL/CreatedAccounts.lean
+++ b/EvmAsm/EL/CreatedAccounts.lean
@@ -1,0 +1,151 @@
+/-
+  EvmAsm.EL.CreatedAccounts
+
+  Transaction-local account-creation tracking for EIP-6780 SELFDESTRUCT.
+-/
+
+import EvmAsm.EL.Create
+
+namespace EvmAsm.EL
+
+namespace CreatedAccounts
+
+/-- Transaction-local set of accounts created during the current transaction.
+    List membership is enough for the pure bridge; executable handlers can
+    choose a compact concrete representation later. -/
+abbrev CreatedAccountSet := List Address
+
+def empty : CreatedAccountSet :=
+  []
+
+def contains (created : CreatedAccountSet) (address : Address) : Bool :=
+  created.contains address
+
+def markCreated (created : CreatedAccountSet) (address : Address) :
+    CreatedAccountSet :=
+  address :: created
+
+/-- Update the created-account set after a CREATE-family result. Only deployed
+    results with a concrete address mark an account as created in the current
+    transaction. -/
+def markCreateResult (created : CreatedAccountSet) (result : CreateResult) :
+    CreatedAccountSet :=
+  match result.status, result.address? with
+  | .deployed, some address => markCreated created address
+  | _, _ => created
+
+/-- Boolean consumed by the EIP-6780 SELFDESTRUCT effect helper. -/
+def createdInSameTx (created : CreatedAccountSet) (address : Address) : Bool :=
+  contains created address
+
+theorem contains_empty (address : Address) :
+    contains empty address = false := by
+  simp [contains, empty]
+
+theorem contains_markCreated_self (created : CreatedAccountSet) (address : Address) :
+    contains (markCreated created address) address = true := by
+  simp [contains, markCreated]
+
+theorem contains_markCreated_other
+    (created : CreatedAccountSet) {address other : Address}
+    (h_ne : other ≠ address) :
+    contains (markCreated created address) other = contains created other := by
+  unfold contains markCreated
+  simp only [List.contains_cons]
+  simp [h_ne]
+
+theorem markCreateResult_deployed
+    (created : CreatedAccountSet) (address : Address)
+    (state : WorldState) (returndata : List Byte) (gasRemaining : Nat) :
+    markCreateResult created
+        { status := .deployed
+          address? := some address
+          state := state
+          returndata := returndata
+          gasRemaining := gasRemaining } =
+      markCreated created address := rfl
+
+theorem markCreateResult_deployed_none
+    (created : CreatedAccountSet)
+    (state : WorldState) (returndata : List Byte) (gasRemaining : Nat) :
+    markCreateResult created
+        { status := .deployed
+          address? := none
+          state := state
+          returndata := returndata
+          gasRemaining := gasRemaining } =
+      created := rfl
+
+theorem markCreateResult_reverted
+    (created : CreatedAccountSet) (address? : Option Address)
+    (state : WorldState) (returndata : List Byte) (gasRemaining : Nat) :
+    markCreateResult created
+        { status := .reverted
+          address? := address?
+          state := state
+          returndata := returndata
+          gasRemaining := gasRemaining } =
+      created := by
+  cases address? <;> rfl
+
+theorem markCreateResult_failed
+    (created : CreatedAccountSet) (address? : Option Address)
+    (state : WorldState) (returndata : List Byte) (gasRemaining : Nat) :
+    markCreateResult created
+        { status := .failed
+          address? := address?
+          state := state
+          returndata := returndata
+          gasRemaining := gasRemaining } =
+      created := by
+  cases address? <;> rfl
+
+theorem createdInSameTx_empty (address : Address) :
+    createdInSameTx empty address = false :=
+  contains_empty address
+
+theorem createdInSameTx_markCreateResult_deployed_self
+    (created : CreatedAccountSet) (address : Address)
+    (state : WorldState) (returndata : List Byte) (gasRemaining : Nat) :
+    createdInSameTx
+        (markCreateResult created
+          { status := .deployed
+            address? := some address
+            state := state
+            returndata := returndata
+            gasRemaining := gasRemaining })
+        address =
+      true := by
+  simp [createdInSameTx, markCreateResult_deployed, contains_markCreated_self]
+
+theorem createdInSameTx_markCreateResult_reverted
+    (created : CreatedAccountSet) (address : Address) (address? : Option Address)
+    (state : WorldState) (returndata : List Byte) (gasRemaining : Nat) :
+    createdInSameTx
+        (markCreateResult created
+          { status := .reverted
+            address? := address?
+            state := state
+            returndata := returndata
+            gasRemaining := gasRemaining })
+        address =
+      createdInSameTx created address := by
+  cases address? <;> rfl
+
+theorem createdInSameTx_markCreateResult_failed
+    (created : CreatedAccountSet) (address : Address) (address? : Option Address)
+    (state : WorldState) (returndata : List Byte) (gasRemaining : Nat) :
+    createdInSameTx
+        (markCreateResult created
+          { status := .failed
+            address? := address?
+            state := state
+            returndata := returndata
+            gasRemaining := gasRemaining })
+        address =
+      createdInSameTx created address := by
+  cases address? <;> rfl
+
+end CreatedAccounts
+
+end EvmAsm.EL

--- a/EvmAsm/EL/SelfdestructEffects.lean
+++ b/EvmAsm/EL/SelfdestructEffects.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.EL.CallValueTransfer
+import EvmAsm.EL.CreatedAccounts
 import EvmAsm.EL.MessageCallExecution
 
 namespace EvmAsm.EL
@@ -227,6 +228,58 @@ theorem eip6780SelfdestructEffect_preExisting_beneficiaryBalance?
       some (beneficiaryBalance + accountBalance) :=
   postCancunSelfdestructEffect_beneficiaryBalance?
     accountBalance beneficiaryBalance h_beneficiary h_ne
+
+theorem eip6780SelfdestructEffect_accountsToDelete_fromCreatedSet_created
+    (state : WorldState) (created : CreatedAccounts.CreatedAccountSet)
+    (account beneficiary : Address)
+    (accountBalance beneficiaryBalance : Word256)
+    (h_created : CreatedAccounts.createdInSameTx created account = true) :
+    (eip6780SelfdestructEffect
+        state account beneficiary accountBalance beneficiaryBalance
+        (CreatedAccounts.createdInSameTx created account)).sideEffects.accountsToDelete =
+      [account] := by
+  rw [h_created]
+  exact eip6780SelfdestructEffect_sameTx_accountsToDelete
+    state account beneficiary accountBalance beneficiaryBalance
+
+theorem eip6780SelfdestructEffect_accountsToDelete_fromCreatedSet_preExisting
+    (state : WorldState) (created : CreatedAccounts.CreatedAccountSet)
+    (account beneficiary : Address)
+    (accountBalance beneficiaryBalance : Word256)
+    (h_not_created : CreatedAccounts.createdInSameTx created account = false) :
+    (eip6780SelfdestructEffect
+        state account beneficiary accountBalance beneficiaryBalance
+        (CreatedAccounts.createdInSameTx created account)).sideEffects.accountsToDelete =
+      [] := by
+  rw [h_not_created]
+  exact eip6780SelfdestructEffect_preExisting_accountsToDelete
+    state account beneficiary accountBalance beneficiaryBalance
+
+theorem eip6780SelfdestructEffect_state_fromCreatedSet_created_deleted
+    (state : WorldState) (created : CreatedAccounts.CreatedAccountSet)
+    (account beneficiary : Address)
+    (accountBalance beneficiaryBalance : Word256)
+    (h_created : CreatedAccounts.createdInSameTx created account = true) :
+    WorldState.getAccount
+        (eip6780SelfdestructEffect
+          state account beneficiary accountBalance beneficiaryBalance
+          (CreatedAccounts.createdInSameTx created account)).state
+        account =
+      none := by
+  rw [h_created]
+  exact eip6780SelfdestructEffect_sameTx_accountDeleted
+    state account beneficiary accountBalance beneficiaryBalance
+
+theorem eip6780SelfdestructEffect_fromEmptyCreatedSet_accountsToDelete
+    (state : WorldState) (account beneficiary : Address)
+    (accountBalance beneficiaryBalance : Word256) :
+    (eip6780SelfdestructEffect
+        state account beneficiary accountBalance beneficiaryBalance
+        (CreatedAccounts.createdInSameTx CreatedAccounts.empty account)).sideEffects.accountsToDelete =
+      [] := by
+  rw [CreatedAccounts.createdInSameTx_empty]
+  exact eip6780SelfdestructEffect_preExisting_accountsToDelete
+    state account beneficiary accountBalance beneficiaryBalance
 
 end SelfdestructEffects
 


### PR DESCRIPTION
## Summary
- add `EvmAsm.EL.CreatedAccounts` as a transaction-local created-account set
- mark only deployed CREATE-family results as created in the current transaction
- connect the created-account set to EIP-6780 SELFDESTRUCT deletion selection with named lemmas

## Verification
- `lake build EvmAsm.EL.CreatedAccounts EvmAsm.EL.SelfdestructEffects EvmAsm.EL`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/EL/CreatedAccounts.lean EvmAsm/EL/SelfdestructEffects.lean EvmAsm/EL.lean`\n- `scripts/check-file-size.sh`\n- `scripts/check-unimported.sh`\n- `git diff --check`\n- `lake build`\n\n## Bead\n- `evm-asm-fhsxz.2.4.2.60.6.2.3`\n\nAuthored by @pirapira; implemented by Codex.