### PR TITLE
feat(blob): wire runtime blob base fee opcode

### DIFF
--- a/EvmAsm/Codegen/Cli.lean
+++ b/EvmAsm/Codegen/Cli.lean
@@ -118,18 +118,19 @@ def main (args : List String) : IO UInt32 := do
           -- as long as it uses `read -r name expected` (extra fields
           -- just get dropped).
           for tc in Tests.opcodeTestCases do
-            -- M21..M26: 11-column TSV. Columns:
+            -- M21..M28: 12-column TSV. Columns:
             --   1 name, 2 expectedOutHex, 3 bytecode, 4 calldata,
-            --   5 storage, 6 expectedHaltKind,
-            --   7 expectedPersistentLogLength (M24),
-            --   8 expectedTransientLogLength (M24),
-            --   9 expectedPostStorage (M25 — slot data at OUTPUT+56),
-            --   10 expectedEventLogCount (M26 — OUTPUT+56),
-            --   11 expectedEventLogFirst (M26 — descriptor at OUTPUT+64).
+            --   5 storage, 6 blobBaseFee,
+            --   7 expectedHaltKind,
+            --   8 expectedPersistentLogLength (M24),
+            --   9 expectedTransientLogLength (M24),
+            --   10 expectedPostStorage (M25 — slot data at OUTPUT+56),
+            --   11 expectedEventLogCount (M26 — OUTPUT+56),
+            --   12 expectedEventLogFirst (M26 — descriptor at OUTPUT+64).
             -- All cols beyond 3 are optional; the bash runner asserts
             -- only the ones with non-empty values.
             IO.println
-              s!"{tc.name}\t{tc.expectedOutHex}\t{tc.bytecode}\t{tc.calldata}\t{tc.storage}\t{tc.expectedHaltKind}\t{tc.expectedPersistentLogLength}\t{tc.expectedTransientLogLength}\t{tc.expectedPostStorage}\t{tc.expectedEventLogCount}\t{tc.expectedEventLogFirst}"
+              s!"{tc.name}\t{tc.expectedOutHex}\t{tc.bytecode}\t{tc.calldata}\t{tc.storage}\t{tc.blobBaseFee}\t{tc.expectedHaltKind}\t{tc.expectedPersistentLogLength}\t{tc.expectedTransientLogLength}\t{tc.expectedPostStorage}\t{tc.expectedEventLogCount}\t{tc.expectedEventLogFirst}"
           return 0
       | .program => do
           match lookupProgram opts.target with

--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -191,6 +191,10 @@ def emitDispatcherPrologue : String :=
   "  sd x0, 464(x20)\n" ++         -- env.transientLogLengthOff = 0
   "  sd x0, 472(x20)\n" ++         -- env.eventLogLengthOff = 0
   "  sd x0, 480(x20)\n" ++         -- env.eventLogCheckpointOff = 0
+  "  sd x0, 512(x20)\n" ++         -- M28: blobBaseFee trailer slot = 0
+  "  sd x0, 520(x20)\n" ++
+  "  sd x0, 528(x20)\n" ++
+  "  sd x0, 536(x20)\n" ++
   ".dispatch_loop:\n" ++
   "  lbu x5, 0(x10)\n" ++
   "  la x6, opcode_handlers\n" ++
@@ -369,8 +373,9 @@ def emitDispatcherDataSection
   "  .zero 0x8000\n" ++   -- 32 KiB EVM memory (M7 onward)
   ".balign 8\n" ++
   "evm_env:\n" ++
-  "  .zero 512\n" ++      -- 13 SimpleEnvField slots × 32 B + calldata/return-data
+  "  .zero 544\n" ++      -- 13 SimpleEnvField slots × 32 B + calldata/return-data
                           -- + M22/M24/M26 log-state cells up to env+480
+                          -- + M28 BLOBBASEFEE word at env+512
   ".balign 8\n" ++
   "evm_event_logs:\n" ++
   "  .zero 4096\n" ++     -- M26: 16 × 256-byte bounded LOG event descriptors
@@ -439,6 +444,7 @@ def emitRuntimeDispatcherPrologue : String :=
   --
   -- Input layout (unchanged from M22 `pack-bytecode.py --storage`):
   --   <u64 slot_count> followed by slot_count × (key:32, value:32)
+  --   then a 32-byte BLOBBASEFEE word (M28; zero by default)
   -- Output layout (Option A):
   --   STATE_TRACKER_AREA + i*128 = (addrHash=0:32, slotKey:32,
   --                                 original=value:32, current=value:32)
@@ -488,6 +494,16 @@ def emitRuntimeDispatcherPrologue : String :=
   "  addi x6, x6, -1\n" ++
   "  j .preload_expand_loop\n" ++
   ".preload_expand_done:\n" ++
+  -- M28: x5 now points at the blob-base-fee trailer. Copy the 32-byte
+  -- EVM-stack word into a separate env slot; opcode 0x4a loads it.
+  "  ld x8, 0(x5)\n" ++
+  "  sd x8, 512(x20)\n" ++
+  "  ld x8, 8(x5)\n" ++
+  "  sd x8, 520(x20)\n" ++
+  "  ld x8, 16(x5)\n" ++
+  "  sd x8, 528(x20)\n" ++
+  "  ld x8, 24(x5)\n" ++
+  "  sd x8, 536(x20)\n" ++
   ".dispatch_loop:\n" ++
   "  lbu x5, 0(x10)\n" ++
   "  la x6, opcode_handlers\n" ++
@@ -512,8 +528,9 @@ def emitRuntimeDispatcherDataSection
   "  .zero 0x8000\n" ++   -- 32 KiB EVM memory (M7 onward)
   ".balign 8\n" ++
   "evm_env:\n" ++
-  "  .zero 512\n" ++      -- 13 SimpleEnvField slots × 32 B + calldata/return-data
+  "  .zero 544\n" ++      -- 13 SimpleEnvField slots × 32 B + calldata/return-data
                           -- + M22/M24/M26 log-state cells up to env+480
+                          -- + M28 BLOBBASEFEE word at env+512
   ".balign 8\n" ++
   "evm_event_logs:\n" ++
   "  .zero 4096\n" ++     -- M26: 16 × 256-byte bounded LOG event descriptors

--- a/EvmAsm/Codegen/Programs/Evm.lean
+++ b/EvmAsm/Codegen/Programs/Evm.lean
@@ -540,6 +540,32 @@ def envHandlers : List OpcodeHandlerSpec :=
   , { label := "h_SELFBALANCE", opcodes := [0x47], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .selfBalance, tail := .advanceAndRet 1 }
   , { label := "h_BASEFEE"    , opcodes := [0x48], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .baseFee    , tail := .advanceAndRet 1 } ]
 
+/-! ## M28 blob-context opcodes
+
+  `BLOBBASEFEE` (0x4a) is an Amsterdam/Cancun context opcode. The
+  executable spec computes it as `calculate_blob_gas_price(block_env.excess_blob_gas)`;
+  this runtime dispatcher receives that already-computed 256-bit word in the
+  `pack-bytecode.py --blob-base-fee` input trailer and copies it to `evm_env+512`.
+
+  `BLOBHASH` (0x49) remains in `popPushZeroHandlers` until a follow-up slice
+  adds an indexed table for `tx_env.blob_versioned_hashes`, including the
+  execution-specs out-of-range-zero behavior. -/
+def blobContextHandlers : List OpcodeHandlerSpec :=
+  let body : Program :=
+    ADDI .x12 .x12 (-32) ;;
+    LD .x15 .x20 (BitVec.ofNat 12 512) ;;
+    SD .x12 .x15 0 ;;
+    LD .x15 .x20 (BitVec.ofNat 12 520) ;;
+    SD .x12 .x15 8 ;;
+    LD .x15 .x20 (BitVec.ofNat 12 528) ;;
+    SD .x12 .x15 16 ;;
+    LD .x15 .x20 (BitVec.ofNat 12 536) ;;
+    SD .x12 .x15 24
+  [ { label := "h_BLOBBASEFEE"
+    , opcodes := [0x4a]
+    , body := body
+    , tail := .advanceAndRet 1 } ]
+
 /-- M13 calldata-context opcodes. Sibling to `envHandlers` — reads the
     `callDataLenOff = 424` cell from the same env block that M12
     initialises via `la x20, evm_env`.
@@ -1004,7 +1030,7 @@ def stopHandler : OpcodeHandlerSpec :=
     the list for a spec whose `opcodes` contains the byte. -/
 def tinyInterpRegistry : List OpcodeHandlerSpec :=
   pushHandlers ++ dupHandlers ++ swapHandlers ++ singletonHandlers ++
-  memoryHandlers ++ envHandlers ++ calldataHandlers ++
+  memoryHandlers ++ envHandlers ++ blobContextHandlers ++ calldataHandlers ++
   controlFlowHandlers ++ hashHandlers ++ logHandlers ++
   storageHandlers ++ haltHandlers ++ pushZeroHandlers ++
   popPushZeroHandlers ++ copyNoopHandlers ++ childFrameHandlers ++

--- a/EvmAsm/Codegen/Programs/Noop.lean
+++ b/EvmAsm/Codegen/Programs/Noop.lean
@@ -10,8 +10,7 @@
 
   Four builders are exported:
   - `haltHandlers` — RETURN, REVERT, INVALID, SELFDESTRUCT
-  - `pushZeroHandlers` — CODESIZE, RETURNDATASIZE, BLOBBASEFEE,
-    MSIZE, GAS
+  - `pushZeroHandlers` — CODESIZE, RETURNDATASIZE, MSIZE, GAS
   - `popPushZeroHandlers` — BALANCE, CALLDATALOAD, EXTCODESIZE,
     EXTCODEHASH, BLOCKHASH, BLOBHASH
   - `copyNoopHandlers` — CALLDATACOPY, CODECOPY, EXTCODECOPY,
@@ -163,8 +162,8 @@ def haltHandlers : List OpcodeHandlerSpec :=
     , body := []
     , tail := .custom "  addi x12, x12, 32\n  j .exit_label" } ]
 
-/-- M18 push-zero handlers (CODESIZE, RETURNDATASIZE, BLOBBASEFEE,
-    MSIZE, GAS). Each opcode pushes a single 32-byte zero value onto
+/-- M18 push-zero handlers (CODESIZE, RETURNDATASIZE, MSIZE, GAS).
+    Each opcode pushes a single 32-byte zero value onto
     the EVM stack — no input, no output content.
 
     Body (5 instructions): decrement `x12` by 32 (push), then write
@@ -173,8 +172,6 @@ def haltHandlers : List OpcodeHandlerSpec :=
     **Known limitations** (documented in CODEGEN.md M18 narrative):
     - CODESIZE pushes 0 instead of the running code's length.
     - RETURNDATASIZE pushes 0 (no caller return-data buffer).
-    - BLOBBASEFEE pushes 0 (no Dencun blob context in our `EvmEnv`
-      yet).
     - MSIZE pushes 0 (memory-expansion bookkeeping deferred to
       issue #99).
     - GAS pushes 0 (no gas metering in the dispatcher). -/
@@ -188,8 +185,6 @@ def pushZeroHandlers : List OpcodeHandlerSpec :=
   [ { label := "h_CODESIZE", opcodes := [0x38]
     , body := pushZeroBody, tail := .advanceAndRet 1 }
   , { label := "h_RETURNDATASIZE", opcodes := [0x3d]
-    , body := pushZeroBody, tail := .advanceAndRet 1 }
-  , { label := "h_BLOBBASEFEE", opcodes := [0x4a]
     , body := pushZeroBody, tail := .advanceAndRet 1 }
   , { label := "h_MSIZE", opcodes := [0x59]
     , body := pushZeroBody, tail := .advanceAndRet 1 }

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -42,6 +42,10 @@ structure OpcodeTestCase where
       string = no preload (table starts empty; SSTORE may grow
       it; SLOAD against an unset key returns zero). -/
   storage        : String := ""
+  /-- Optional BLOBBASEFEE value (M28). Format is a u256 hex integer;
+      the runtime input packer serializes it in EVM-stack byte order.
+      Empty string = zero blob base fee. -/
+  blobBaseFee    : String := ""
   /-- Optional expected halt-kind at `OUTPUT_ADDR + 32` (M23).
       16 hex chars = 8-byte LE u64 (e.g. `"0100000000000000"` for
       RETURN = 1, `"0200000000000000"` for REVERT = 2). Empty
@@ -379,8 +383,8 @@ def opcodeTestCases : List OpcodeTestCase :=
     -- `opcodeTestCases` (test `tstore_tload_round_trip`, which
     -- additionally asserts the transient log_length surface).
     -- ## M18 trivial no-op handlers (94.6% coverage milestone)
-    -- 20 opcodes across 4 builders: haltHandlers (4), pushZeroHandlers
-    -- (5), popPushZeroHandlers (6), copyNoopHandlers (5). One
+    -- 19 opcodes across 4 builders: haltHandlers (4), pushZeroHandlers
+    -- (4), popPushZeroHandlers (6), copyNoopHandlers (5). One
     -- representative test per builder + an INVALID smoke.
   , -- PUSH1 0xff; PUSH1 0x11; PUSH1 0x22; RETURN
     -- RETURN(offset=0x22, size=0x11) reads 0x11 bytes from
@@ -408,6 +412,14 @@ def opcodeTestCases : List OpcodeTestCase :=
     { name           := "gas_push_zero"
       bytecode       := "0x5a, 0x00"
       expectedOutHex := "0000000000000000000000000000000000000000000000000000000000000000" }
+  , -- BLOBBASEFEE; STOP with blob_base_fee = 0x1234. Amsterdam
+    -- execution-specs computes this from block_env.excess_blob_gas;
+    -- the runtime dispatcher receives the already-computed value in
+    -- the input trailer and exposes it through evm_env.
+    { name           := "blobbasefee_from_input"
+      bytecode       := "0x4a, 0x00"
+      blobBaseFee    := "0x1234"
+      expectedOutHex := "3412000000000000000000000000000000000000000000000000000000000000" }
   , -- PUSH1 0xab; BALANCE; STOP — BALANCE pops the pushed 0xab as
     -- the address and overwrites with 0. Expected: 0 in low limb.
     -- Smoke test for popPushZeroHandlers.

--- a/scripts/codegen-opcodes-check.sh
+++ b/scripts/codegen-opcodes-check.sh
@@ -55,14 +55,28 @@ fi
 echo "==> running $TOTAL test case(s)"
 
 FAILED=()
-# `--list-test-cases` emits TSV with `<name>\t<expected>\t<bytecode>`
-# since M8.5; this legacy runner only needs name+expected, so we drop
-# the 3rd column into `_bytecode_unused` to keep `read` honest.
-while IFS=$'\t' read -r name expected _bytecode_unused; do
+SKIPPED=0
+# `--list-test-cases` emits TSV with optional runtime-input columns.
+# This legacy runner bakes bytecode into `.data` and has no input
+# trailer, so it skips cases that require calldata, storage preload, or
+# nonzero blob-base-fee input.
+while IFS= read -r line; do
+  name=$(printf '%s' "$line" | cut -f1)
+  expected=$(printf '%s' "$line" | cut -f2)
+  calldata=$(printf '%s' "$line" | cut -f4)
+  storage=$(printf '%s' "$line" | cut -f5)
+  blob_base_fee=$(printf '%s' "$line" | cut -f6)
   if [[ -z "$name" || -z "$expected" ]]; then
     echo
     echo "==> SKIP: malformed --list-test-cases line"
     FAILED+=("${name:-<unknown>} (malformed-tsv)")
+    continue
+  fi
+
+  if [[ -n "${calldata:-}" || -n "${storage:-}" || -n "${blob_base_fee:-}" ]]; then
+    echo
+    echo "==> SKIP: $name requires runtime input trailer"
+    SKIPPED=$((SKIPPED + 1))
     continue
   fi
 
@@ -71,7 +85,7 @@ while IFS=$'\t' read -r name expected _bytecode_unused; do
   lake exe codegen --test-case "$name" --halt linux93 -o "gen-out/$name"
 
   echo "==> ziskemu -e gen-out/$name.elf -o gen-out/$name.output"
-  "$ZISKEMU" -e "gen-out/$name.elf" -o "gen-out/$name.output" -n 200000 \
+  "$ZISKEMU" -e "gen-out/$name.elf" -o "gen-out/$name.output" -n 500000 \
     >"gen-out/$name.emu.log" 2>&1
 
   actual="$(xxd -p -c 64 -l 32 "gen-out/$name.output" | tr -d '\n')"
@@ -91,7 +105,11 @@ done <"$LIST_FILE"
 
 echo
 if [[ ${#FAILED[@]} -eq 0 ]]; then
-  echo "==> ALL PASS ($TOTAL case(s))"
+  if [[ "$SKIPPED" -eq 0 ]]; then
+    echo "==> ALL PASS ($TOTAL case(s))"
+  else
+    echo "==> ALL PASS ($((TOTAL - SKIPPED)) run, $SKIPPED skipped runtime-input case(s))"
+  fi
   exit 0
 else
   echo "==> FAIL: ${#FAILED[@]} of $TOTAL case(s) failed:"

--- a/scripts/codegen-opcodes-runtime-check.sh
+++ b/scripts/codegen-opcodes-runtime-check.sh
@@ -70,7 +70,7 @@ while IFS= read -r line; do
   # (tab is treated as IFS-whitespace), which silently shifts the
   # storage column into the calldata slot when calldata is empty.
   # `cut -f` preserves empty fields, so we slice each column
-  # explicitly. Order matches `--list-test-cases` 11-column TSV
+  # explicitly. Order matches `--list-test-cases` 12-column TSV
   # (M23 added col 6; M24 added cols 7 and 8 for the log-length
   # assertions; M25 added col 9 for the post-state slot dump; M26
   # added cols 10 and 11 for receipt event-log capture).
@@ -79,12 +79,13 @@ while IFS= read -r line; do
   bytecode_csv=$(printf '%s' "$line" | cut -f3)
   calldata=$(printf '%s' "$line" | cut -f4)
   storage=$(printf '%s' "$line" | cut -f5)
-  expected_halt_kind=$(printf '%s' "$line" | cut -f6)
-  expected_persistent_log_length=$(printf '%s' "$line" | cut -f7)
-  expected_transient_log_length=$(printf '%s' "$line" | cut -f8)
-  expected_post_storage=$(printf '%s' "$line" | cut -f9)
-  expected_event_log_count=$(printf '%s' "$line" | cut -f10)
-  expected_event_log_first=$(printf '%s' "$line" | cut -f11)
+  blob_base_fee=$(printf '%s' "$line" | cut -f6)
+  expected_halt_kind=$(printf '%s' "$line" | cut -f7)
+  expected_persistent_log_length=$(printf '%s' "$line" | cut -f8)
+  expected_transient_log_length=$(printf '%s' "$line" | cut -f9)
+  expected_post_storage=$(printf '%s' "$line" | cut -f10)
+  expected_event_log_count=$(printf '%s' "$line" | cut -f11)
+  expected_event_log_first=$(printf '%s' "$line" | cut -f12)
 
   if [[ -z "$name" || -z "$expected" || -z "$bytecode_csv" ]]; then
     echo
@@ -106,6 +107,9 @@ while IFS= read -r line; do
   fi
   if [[ -n "${storage:-}" ]]; then
     pack_args+=(--storage "$storage")
+  fi
+  if [[ -n "${blob_base_fee:-}" ]]; then
+    pack_args+=(--blob-base-fee "$blob_base_fee")
   fi
   "$PYTHON" scripts/pack-bytecode.py ${pack_args[@]+"${pack_args[@]}"} "$bytecode_csv" "gen-out/$name.input"
 

--- a/scripts/pack-bytecode.py
+++ b/scripts/pack-bytecode.py
@@ -18,10 +18,15 @@ M22 extension: optionally append a third segment carrying a list of
 them into a writable in-`.data` slot table; SLOAD / SSTORE read /
 mutate the table via linear scan.
 
+M28 extension: optionally append a fourth segment carrying the
+BLOBBASEFEE value as one EVM stack word. The dispatcher prologue copies
+it into `evm_env`; opcode 0x4a reads it from there. Defaults to zero.
+
 Usage:
     pack-bytecode.py "0x60, 0x02, 0x60, 0x0a, 0x04, 0x00" output.bin
     pack-bytecode.py --calldata "0xdeadbeef" "0x36, 0x00" output.bin
     pack-bytecode.py --storage "(0x00, 0xdead)" "0x60, 0x00, 0x54, 0x00" output.bin
+    pack-bytecode.py --blob-base-fee 0x1234 "0x4a, 0x00" output.bin
     echo "0x60, 0x00" | pack-bytecode.py - output.bin
 
 Output layout:
@@ -35,6 +40,7 @@ Output layout:
     next 8 bytes       <8-byte LE u64 slot_count>            (M22)
     following          <slot_count × 64-byte (key, value)>   (M22)
                        <zero pad to 8-byte boundary>
+    next 32 bytes      <blob_base_fee as EVM stack word>      (M28)
 
 ziskemu prepends 8 more bytes of its own metadata when loading,
 landing the bytecode-length prefix at INPUT_ADDR+8 and the bytecode
@@ -49,6 +55,7 @@ a zero-length calldata segment appended, which preserves the M17
 "CALLDATA opcodes are no-op" behavior for existing test cases.
 Pre-M22 callers that don't pass --storage get a zero-length storage
 segment appended (SLOAD returns 0, SSTORE appends to an empty table).
+Pre-M28 callers that don't pass --blob-base-fee get a zero word.
 """
 import argparse
 import re
@@ -164,12 +171,19 @@ def main() -> int:
              "interpreted as a u256 integer and serialized in EVM-stack "
              "byte order. Defaults to empty (no preload).",
     )
+    parser.add_argument(
+        "--blob-base-fee",
+        default="",
+        help="Optional BLOBBASEFEE value as a u256 hex integer. Serialized "
+             "in EVM-stack byte order. Defaults to zero.",
+    )
     args = parser.parse_args()
 
     csv = sys.stdin.read() if args.bytecode == "-" else args.bytecode
     bytecode = parse_csv(csv)
     calldata = parse_calldata(args.calldata)
     storage_pairs = parse_storage(args.storage)
+    blob_base_fee = _to_stack_bytes(args.blob_base_fee) if args.blob_base_fee.strip() else b"\x00" * 32
 
     # Bytecode segment: 8B LE length prefix + bytes, padded to 8-byte boundary
     # so the calldata-length cell that follows is aligned.
@@ -188,6 +202,10 @@ def main() -> int:
     for key, value in storage_pairs:
         packed += key + value
     packed = pad_to_8(packed)
+
+    # M28 blob-context trailer: 32-byte BLOBBASEFEE word in stack
+    # representation. It is naturally 8-byte aligned after the storage segment.
+    packed += blob_base_fee
 
     if args.output == "-":
         sys.stdout.buffer.write(packed)


### PR DESCRIPTION
## Summary
- route BLOBBASEFEE through a runtime input-backed env word instead of the push-zero no-op group
- extend opcode input packing/listing with an optional blob-base-fee field and add a nonzero runtime regression
- keep the baked-bytecode opcode runner to cases it can represent, skipping runtime-input cases explicitly

## Verification
- lake build codegen
- scripts/codegen-opcodes-runtime-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build
- scripts/codegen-opcodes-check.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' <edited files>

Bead: evm-asm-fhsxz.2.4.2.60.5.5
Follow-up bead for BLOBHASH: evm-asm-fhsxz.2.4.2.60.5.5.1

Authored by @pirapira; implemented by Codex.