### PR TITLE
feat(mcopy): wire runtime memory copy

### DIFF
--- a/CODEGEN.md
+++ b/CODEGEN.md
@@ -707,14 +707,12 @@ bodies clobber `x10` as a JAL-target scratch.
   and `jumpTable_non_invalid_count`) from 91 → 93. Discharged by
   `decide` / `set_option maxRecDepth 2048 in decide` as before.
 
-**MSIZE (0x59) deferred.** The verified `evm_msize` Program exists
-(`EvmAsm/Evm64/MSize/Program.lean`, slice 6 of issue #99) and is a
-pure read of a memory-size cell, but slices 1–5 — updating that cell
-from MLOAD/MSTORE/MSTORE8 on memory expansion — have not shipped:
-`evm_mload` / `evm_mstore` / `evm_mstore8` take no `sizeReg`
-parameter and never reference `sizeLoc`. Wiring MSIZE today would
-push a 4-limb zero regardless of EVM-memory touches. Drop into
-`memoryHandlers` once issue #99 slices 1–5 land.
+**MSIZE (0x59) runtime slice.** The dispatcher maintains an
+active-memory-size cell in `evm_env` and wires MSIZE to push it as a
+low-u64 EVM word. MLOAD, MSTORE, MSTORE8, CALLDATACOPY, and MCOPY
+update that cell with 32-byte EVM rounding. This is a concrete
+runtime path, not the verified `evm_msize` Program yet, and exact
+memory gas / OOG behavior is still deferred.
 
 **EXP (0x0a) still blocked** pending the upstream
 `evm_exp_msb_saved_bit_two_mul_fixed_fixed` callee-saved variant.
@@ -1042,7 +1040,7 @@ Crosses the **90% coverage milestone** (135/149) and reaches
 verified body), EXP (blocked upstream), and the **6 child-frame
 opcodes** (CALL/CREATE family — the real gap to 100%).
 
-**Why no-ops.** Each of the 20 opcodes ships with at least one
+**Why no-ops.** Each of the remaining 16 opcodes ships with at least one
 spec-incompliance because the dispatcher has no model for the
 relevant state (accounts, calldata, block history, blob context,
 return-data buffers). Trusted bytecode that doesn't depend on
@@ -1056,19 +1054,19 @@ guardrail at the bottom of `Programs.lean`:
   INVALID (0xfe), SELFDESTRUCT (0xff). `body := []` + `.custom`
   tail that inlines the right `addi x12, x12, …` pop and
   `j .exit_label`.
-- **`pushZeroHandlers` (5 entries)**: CODESIZE (0x38),
-  RETURNDATASIZE (0x3d), BLOBBASEFEE (0x4a), MSIZE (0x59), GAS
-  (0x5a). 5-instruction body: decrement `x12` by 32 (push), then
+- **`pushZeroHandlers` (4 entries)**: CODESIZE (0x38),
+  RETURNDATASIZE (0x3d), BLOBBASEFEE (0x4a), GAS (0x5a).
+  5-instruction body: decrement `x12` by 32 (push), then
   4 × `SD .x12 .x0 …` (zero limbs).
-- **`popPushZeroHandlers` (6 entries)**: BALANCE (0x31),
-  CALLDATALOAD (0x35), EXTCODESIZE (0x3b), EXTCODEHASH (0x3f),
-  BLOCKHASH (0x40), BLOBHASH (0x49). Same shape as M17 SLOAD:
+- **`popPushZeroHandlers` (5 entries)**: BALANCE (0x31),
+  EXTCODESIZE (0x3b), EXTCODEHASH (0x3f), BLOCKHASH (0x40),
+  BLOBHASH (0x49). Same shape as M17 SLOAD:
   net stack delta 0; 4 × `SD .x12 .x0 …` overwrites the popped
   slot with zeros.
-- **`copyNoopHandlers` (5 entries)**: CALLDATACOPY (0x37),
-  CODECOPY (0x39), EXTCODECOPY (0x3c), RETURNDATACOPY (0x3e),
-  MCOPY (0x5e). 1-instruction body: `ADDI .x12 .x12 96` (or 128
-  for EXTCODECOPY's 4-pop).
+- **`copyNoopHandlers` (3 entries)**: CODECOPY (0x39),
+  EXTCODECOPY (0x3c), RETURNDATACOPY (0x3e). 1-instruction body:
+  `ADDI .x12 .x12 96` (or 128 for EXTCODECOPY's 4-pop). CALLDATACOPY
+  and MCOPY have since moved to concrete runtime handlers.
 
 `EvmAsm/Codegen/Proofs/RegistryInvariants.lean` counts bumped
 121 → 141. All 6 invariant theorems now use `set_option
@@ -1088,8 +1086,8 @@ entries). Phase 1 recompile ~16 s, well under the 30 s budget.
   state).
 - CALLDATALOAD / CALLDATACOPY read empty calldata.
 - CODESIZE / CODECOPY / RETURNDATASIZE / RETURNDATACOPY /
-  EXTCODECOPY / MCOPY return / copy zero data.
-- BLOBBASEFEE / GAS / MSIZE always 0.
+  EXTCODECOPY return / copy zero data.
+- BLOBBASEFEE / GAS always 0.
 - RETURN / REVERT halt with whatever's at EVM stack top after
   the pop (deterministic if the program pre-pushes a known
   value).

--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -191,6 +191,7 @@ def emitDispatcherPrologue : String :=
   "  sd x0, 464(x20)\n" ++         -- env.transientLogLengthOff = 0
   "  sd x0, 472(x20)\n" ++         -- env.eventLogLengthOff = 0
   "  sd x0, 480(x20)\n" ++         -- env.eventLogCheckpointOff = 0
+  "  sd x0, 488(x20)\n" ++         -- runtime activeMemorySize = 0
   ".dispatch_loop:\n" ++
   "  lbu x5, 0(x10)\n" ++
   "  la x6, opcode_handlers\n" ++
@@ -452,6 +453,7 @@ def emitRuntimeDispatcherPrologue : String :=
   "  sd x0, 464(x20)\n" ++         -- env.transientLogLengthOff = 0
   "  sd x0, 472(x20)\n" ++         -- env.eventLogLengthOff = 0
   "  sd x0, 480(x20)\n" ++         -- env.eventLogCheckpointOff = 0
+  "  sd x0, 488(x20)\n" ++         -- runtime activeMemorySize = 0
   "  addi x5, x5, 8\n" ++          -- x5 = src ptr (first preload entry)
   "  li x7, 0xa0630000\n" ++       -- x7 = dst ptr (STATE_TRACKER_AREA persistent log)
   ".preload_expand_loop:\n" ++

--- a/EvmAsm/Codegen/Programs/Evm.lean
+++ b/EvmAsm/Codegen/Programs/Evm.lean
@@ -443,6 +443,32 @@ def swapHandlers : List OpcodeHandlerSpec :=
 private def x10RestoreAdvance1 : HandlerTail :=
   .custom "  mv x10, x9\n  addi x10, x10, 1\n  ret"
 
+/-- Dispatcher env offset used by the concrete runtime handlers for
+    active memory size in bytes. The env data block is 512 bytes, and
+    offsets 472 / 480 are already used by event-log metadata. -/
+private def activeMemorySizeOff : Nat := 488
+
+/-- Inline asm that updates the runtime `MSIZE` high-water mark from
+    one memory access `(offset, length)`, using low u64 limbs. If
+    `length = 0`, the EVM does not expand memory even for large
+    offsets. -/
+private def updateActiveMemorySizeAsm
+    (tag offsetReg lengthReg roundedReg currentReg maskReg : String) : String :=
+  "  beqz " ++ lengthReg ++ ", .Lmemsize_" ++ tag ++ "_done\n" ++
+  "  add " ++ roundedReg ++ ", " ++ offsetReg ++ ", " ++ lengthReg ++ "\n" ++
+  "  addi " ++ roundedReg ++ ", " ++ roundedReg ++ ", 31\n" ++
+  "  li " ++ maskReg ++ ", -32\n" ++
+  "  and " ++ roundedReg ++ ", " ++ roundedReg ++ ", " ++ maskReg ++ "\n" ++
+  "  ld " ++ currentReg ++ ", " ++ toString activeMemorySizeOff ++ "(x20)\n" ++
+  "  bgeu " ++ currentReg ++ ", " ++ roundedReg ++ ", .Lmemsize_" ++ tag ++ "_done\n" ++
+  "  sd " ++ roundedReg ++ ", " ++ toString activeMemorySizeOff ++ "(x20)\n" ++
+  ".Lmemsize_" ++ tag ++ "_done:\n"
+
+private def updateActiveMemorySizeConstAsm
+    (tag offsetReg tmpLengthReg roundedReg currentReg maskReg : String) (length : Nat) : String :=
+  "  li " ++ tmpLengthReg ++ ", " ++ toString length ++ "\n" ++
+  updateActiveMemorySizeAsm tag offsetReg tmpLengthReg roundedReg currentReg maskReg
+
 /-- Fixed-shape singleton opcodes: parameter-free verified `Program`s
     that fit the standard `<body>` + `addi x10, x10, 1` + `ret` ABI.
 
@@ -489,19 +515,42 @@ def memoryHandlers : List OpcodeHandlerSpec :=
     -- scratch: offReg=x15, byteReg=x16, accReg=x17, addrReg=x18.
     { label   := "h_MLOAD"
       opcodes := [0x51]
+      preBody := "  ld x15, 0(x12)\n" ++
+                 updateActiveMemorySizeConstAsm "mload" "x15" "x16" "x17" "x18" "x19" 32
       body    := EvmAsm.Evm64.evm_mload .x15 .x16 .x17 .x18 .x13
       tail    := .advanceAndRet 1 }
   , -- MSTORE: pop offset + value, write 32 bytes BE to memory.
     -- valReg=x14 (scratch; placeholder per evm_mstore docstring).
     { label   := "h_MSTORE"
       opcodes := [0x52]
+      preBody := "  ld x15, 0(x12)\n" ++
+                 updateActiveMemorySizeConstAsm "mstore" "x15" "x16" "x17" "x18" "x19" 32
       body    := EvmAsm.Evm64.evm_mstore .x15 .x14 .x16 .x17 .x18 .x13
       tail    := .advanceAndRet 1 }
   , -- MSTORE8: pop offset + value, write 1 byte to memory.
     { label   := "h_MSTORE8"
       opcodes := [0x53]
+      preBody := "  ld x15, 0(x12)\n" ++
+                 updateActiveMemorySizeConstAsm "mstore8" "x15" "x16" "x17" "x18" "x19" 1
       body    := EvmAsm.Evm64.evm_mstore8 .x15 .x14 .x18 .x13
       tail    := .advanceAndRet 1 } ]
+
+/-- MSIZE pushes the dispatcher-maintained active memory size. It is
+    updated by the concrete memory handlers in this file using the
+    EVM's 32-byte rounding rule. -/
+def memoryMetadataHandlers : List OpcodeHandlerSpec :=
+  [ { label   := "h_MSIZE"
+      opcodes := [0x59]
+      body    := []
+      tail    := .custom <|
+        "  addi x12, x12, -32\n" ++
+        "  ld x14, " ++ toString activeMemorySizeOff ++ "(x20)\n" ++
+        "  sd x14, 0(x12)\n" ++
+        "  sd x0, 8(x12)\n" ++
+        "  sd x0, 16(x12)\n" ++
+        "  sd x0, 24(x12)\n" ++
+        "  addi x10, x10, 1\n" ++
+        "  ret" } ]
 
 /-- M12 simple environment opcodes (13 of them, one record each).
 
@@ -596,9 +645,56 @@ def calldataHandlers : List OpcodeHandlerSpec :=
     -- (M7); the remaining 6 args are caller-saved scratch.
     { label   := "h_CALLDATACOPY"
     , opcodes := [0x37]
+    , preBody := "  ld x14, 0(x12)\n" ++
+                 "  ld x15, 64(x12)\n" ++
+                 updateActiveMemorySizeAsm "calldatacopy" "x14" "x15" "x16" "x17" "x18"
     , body    := EvmAsm.Evm64.Calldata.evm_calldatacopy
                    .x20 .x13 .x14 .x15 .x16 .x17 .x18 .x19
     , tail    := .advanceAndRet 1 } ]
+
+/-- EIP-5656 MCOPY for the concrete dispatcher. The handler consumes
+    low u64 limbs for `(dest, src, length)`, updates MSIZE for both
+    read and write ranges, then performs `memmove`-style byte copying
+    so overlapping ranges are handled correctly. Gas charging and
+    256-bit overflow/OOG detection are tracked separately. -/
+def mcopyHandlers : List OpcodeHandlerSpec :=
+  [ { label   := "h_MCOPY"
+      opcodes := [0x5e]
+      body    := []
+      tail    := .custom <|
+        "  ld x14, 0(x12)\n" ++          -- destination offset
+        "  ld x15, 32(x12)\n" ++         -- source offset
+        "  ld x16, 64(x12)\n" ++         -- length
+        "  addi x12, x12, 96\n" ++
+        "  beqz x16, .Lmcopy_done\n" ++
+        updateActiveMemorySizeAsm "mcopy_src" "x15" "x16" "x17" "x18" "x19" ++
+        updateActiveMemorySizeAsm "mcopy_dst" "x14" "x16" "x17" "x18" "x19" ++
+        "  add x17, x13, x14\n" ++       -- destination pointer
+        "  add x18, x13, x15\n" ++       -- source pointer
+        "  add x19, x15, x16\n" ++       -- source end offset
+        "  bleu x14, x15, .Lmcopy_forward\n" ++
+        "  bgeu x14, x19, .Lmcopy_forward\n" ++
+        "  add x17, x17, x16\n" ++
+        "  add x18, x18, x16\n" ++
+        ".Lmcopy_backward_loop:\n" ++
+        "  beqz x16, .Lmcopy_done\n" ++
+        "  addi x17, x17, -1\n" ++
+        "  addi x18, x18, -1\n" ++
+        "  lbu x19, 0(x18)\n" ++
+        "  sb x19, 0(x17)\n" ++
+        "  addi x16, x16, -1\n" ++
+        "  j .Lmcopy_backward_loop\n" ++
+        ".Lmcopy_forward:\n" ++
+        "  beqz x16, .Lmcopy_done\n" ++
+        "  lbu x19, 0(x18)\n" ++
+        "  sb x19, 0(x17)\n" ++
+        "  addi x18, x18, 1\n" ++
+        "  addi x17, x17, 1\n" ++
+        "  addi x16, x16, -1\n" ++
+        "  j .Lmcopy_forward\n" ++
+        ".Lmcopy_done:\n" ++
+        "  addi x10, x10, 1\n" ++
+        "  ret" } ]
 
 /-- M14 / M15 control-flow opcodes.
 
@@ -1004,9 +1100,9 @@ def stopHandler : OpcodeHandlerSpec :=
     the list for a spec whose `opcodes` contains the byte. -/
 def tinyInterpRegistry : List OpcodeHandlerSpec :=
   pushHandlers ++ dupHandlers ++ swapHandlers ++ singletonHandlers ++
-  memoryHandlers ++ envHandlers ++ calldataHandlers ++
+  memoryHandlers ++ memoryMetadataHandlers ++ envHandlers ++ calldataHandlers ++
   controlFlowHandlers ++ hashHandlers ++ logHandlers ++
-  storageHandlers ++ haltHandlers ++ pushZeroHandlers ++
+  storageHandlers ++ mcopyHandlers ++ haltHandlers ++ pushZeroHandlers ++
   popPushZeroHandlers ++ copyNoopHandlers ++ childFrameHandlers ++
   arithNoopHandlers ++ divModHandlers ++ signedDivModHandlers ++
   selfCallingHandlers ++ [stopHandler]

--- a/EvmAsm/Codegen/Programs/Noop.lean
+++ b/EvmAsm/Codegen/Programs/Noop.lean
@@ -10,7 +10,7 @@
 
   Four builders are exported:
   - `haltHandlers` — RETURN, REVERT, INVALID, SELFDESTRUCT
-  - `pushZeroHandlers` — CODESIZE, RETURNDATASIZE, MSIZE, GAS
+  - `pushZeroHandlers` — CODESIZE, RETURNDATASIZE, GAS (MSIZE has a real implementation in Programs/Evm.lean)
   - `popPushZeroHandlers` — BALANCE, CALLDATALOAD, EXTCODESIZE,
     EXTCODEHASH (BLOBHASH and BLOCKHASH have real implementations in Programs/Evm.lean)
   - `copyNoopHandlers` — CALLDATACOPY, CODECOPY, EXTCODECOPY,
@@ -190,8 +190,6 @@ def pushZeroHandlers : List OpcodeHandlerSpec :=
   [ { label := "h_CODESIZE", opcodes := [0x38]
     , body := pushZeroBody, tail := .advanceAndRet 1 }
   , { label := "h_RETURNDATASIZE", opcodes := [0x3d]
-    , body := pushZeroBody, tail := .advanceAndRet 1 }
-  , { label := "h_MSIZE", opcodes := [0x59]
     , body := pushZeroBody, tail := .advanceAndRet 1 }
   , { label := "h_GAS", opcodes := [0x5a]
     , body := pushZeroBody, tail := .advanceAndRet 1 } ]

--- a/EvmAsm/Codegen/Programs/Noop.lean
+++ b/EvmAsm/Codegen/Programs/Noop.lean
@@ -2,7 +2,7 @@
   EvmAsm.Codegen.Programs.Noop
 
   M18 stack-pop / push-zero / halt no-op handler builders. These
-  20 opcodes share the same "trusted bytecode, no host state model"
+  16 opcodes share the same "trusted bytecode, no host state model"
   shape: pop the right number of EVM stack words, optionally push
   32 zero bytes, advance PC by 1 (or halt). Lifted out of
   `Programs/Evm.lean` per the file-size guard at the bottom of
@@ -10,14 +10,12 @@
 
   Four builders are exported:
   - `haltHandlers` — RETURN, REVERT, INVALID, SELFDESTRUCT
-  - `pushZeroHandlers` — CODESIZE, RETURNDATASIZE, BLOBBASEFEE,
-    MSIZE, GAS
-  - `popPushZeroHandlers` — BALANCE, CALLDATALOAD, EXTCODESIZE,
+  - `pushZeroHandlers` — CODESIZE, RETURNDATASIZE, BLOBBASEFEE, GAS
+  - `popPushZeroHandlers` — BALANCE, EXTCODESIZE,
     EXTCODEHASH, BLOCKHASH, BLOBHASH
-  - `copyNoopHandlers` — CALLDATACOPY, CODECOPY, EXTCODECOPY,
-    RETURNDATACOPY, MCOPY
+  - `copyNoopHandlers` — CODECOPY, EXTCODECOPY, RETURNDATACOPY
 
-  All 20 opcodes ship with at least one spec-incompliance (returns
+  All 16 opcodes ship with at least one spec-incompliance (returns
   zero / drops side effects) because the dispatcher has no model
   for the relevant state (accounts, calldata, block history, blob
   context, return-data buffers). Trusted bytecode that avoids
@@ -164,7 +162,7 @@ def haltHandlers : List OpcodeHandlerSpec :=
     , tail := .custom "  addi x12, x12, 32\n  j .exit_label" } ]
 
 /-- M18 push-zero handlers (CODESIZE, RETURNDATASIZE, BLOBBASEFEE,
-    MSIZE, GAS). Each opcode pushes a single 32-byte zero value onto
+    GAS). Each opcode pushes a single 32-byte zero value onto
     the EVM stack — no input, no output content.
 
     Body (5 instructions): decrement `x12` by 32 (push), then write
@@ -175,8 +173,6 @@ def haltHandlers : List OpcodeHandlerSpec :=
     - RETURNDATASIZE pushes 0 (no caller return-data buffer).
     - BLOBBASEFEE pushes 0 (no Dencun blob context in our `EvmEnv`
       yet).
-    - MSIZE pushes 0 (memory-expansion bookkeeping deferred to
-      issue #99).
     - GAS pushes 0 (no gas metering in the dispatcher). -/
 def pushZeroHandlers : List OpcodeHandlerSpec :=
   let pushZeroBody : Program :=
@@ -190,8 +186,6 @@ def pushZeroHandlers : List OpcodeHandlerSpec :=
   , { label := "h_RETURNDATASIZE", opcodes := [0x3d]
     , body := pushZeroBody, tail := .advanceAndRet 1 }
   , { label := "h_BLOBBASEFEE", opcodes := [0x4a]
-    , body := pushZeroBody, tail := .advanceAndRet 1 }
-  , { label := "h_MSIZE", opcodes := [0x59]
     , body := pushZeroBody, tail := .advanceAndRet 1 }
   , { label := "h_GAS", opcodes := [0x5a]
     , body := pushZeroBody, tail := .advanceAndRet 1 } ]
@@ -233,13 +227,12 @@ def popPushZeroHandlers : List OpcodeHandlerSpec :=
   , { label := "h_BLOBHASH", opcodes := [0x49]
     , body := body, tail := .advanceAndRet 1 } ]
 
-/-- M18 copy-no-op handlers (CODECOPY, EXTCODECOPY, RETURNDATACOPY,
-    MCOPY). Each opcode pops 3 or 4 stack values and would copy
+/-- M18 copy-no-op handlers (CODECOPY, EXTCODECOPY, RETURNDATACOPY).
+    Each opcode pops 3 or 4 stack values and would copy
     bytes into EVM memory. As no-ops we just drop the stack args.
 
     Body: a single `ADDI .x12 .x12 (popBytes)`. CODECOPY /
-    RETURNDATACOPY / MCOPY pop 3 words = 96 bytes; EXTCODECOPY pops
-    4 = 128.
+    RETURNDATACOPY pop 3 words = 96 bytes; EXTCODECOPY pops 4 = 128.
 
     **Known limitations**: the copies are dropped on the floor.
     Programs that copy into EVM memory and then MLOAD see whatever
@@ -260,9 +253,6 @@ def copyNoopHandlers : List OpcodeHandlerSpec :=
     , body := ADDI .x12 .x12 (BitVec.ofNat 12 128)
     , tail := .advanceAndRet 1 }
   , { label := "h_RETURNDATACOPY", opcodes := [0x3e]
-    , body := ADDI .x12 .x12 (BitVec.ofNat 12 96)
-    , tail := .advanceAndRet 1 }
-  , { label := "h_MCOPY", opcodes := [0x5e]
     , body := ADDI .x12 .x12 (BitVec.ofNat 12 96)
     , tail := .advanceAndRet 1 } ]
 

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -241,6 +241,12 @@ def opcodeTestCases : List OpcodeTestCase :=
     { name           := "mstore8_basic"
       bytecode       := "0x60, 0xff, 0x60, 0x00, 0x53, 0x60, 0x00, 0x51, 0x00"
       expectedOutHex := "00000000000000000000000000000000000000000000000000000000000000ff" }
+  , -- PUSH1 0x40; MLOAD; MSIZE; STOP
+    -- MLOAD touches memory[0x40..0x60), so MSIZE reports the rounded
+    -- active size 0x60.
+    { name           := "mload_updates_msize"
+      bytecode       := "0x60, 0x40, 0x51, 0x59, 0x00"
+      expectedOutHex := "6000000000000000000000000000000000000000000000000000000000000000" }
     -- ## M12 simple environment opcodes (ADDRESS, CALLER, …)
     -- The evm_env data region is zero-initialised by the dispatcher's
     -- .data section. Each test confirms the handler routes through
@@ -379,8 +385,8 @@ def opcodeTestCases : List OpcodeTestCase :=
     -- `opcodeTestCases` (test `tstore_tload_round_trip`, which
     -- additionally asserts the transient log_length surface).
     -- ## M18 trivial no-op handlers (94.6% coverage milestone)
-    -- 20 opcodes across 4 builders: haltHandlers (4), pushZeroHandlers
-    -- (5), popPushZeroHandlers (6), copyNoopHandlers (5). One
+    -- 16 opcodes across 4 builders: haltHandlers (4), pushZeroHandlers
+    -- (4), popPushZeroHandlers (5), copyNoopHandlers (3). One
     -- representative test per builder + an INVALID smoke.
   , -- PUSH1 0xff; PUSH1 0x11; PUSH1 0x22; RETURN
     -- RETURN(offset=0x22, size=0x11) reads 0x11 bytes from
@@ -415,12 +421,29 @@ def opcodeTestCases : List OpcodeTestCase :=
       bytecode       := "0x60, 0xab, 0x31, 0x00"
       expectedOutHex := "0000000000000000000000000000000000000000000000000000000000000000" }
   , -- PUSH1 0x01; PUSH1 0x02; PUSH1 0x03; MCOPY; PUSH1 0x42; STOP
-    -- MCOPY pops 3 args (no-op copy); PUSH1 0x42 lands on the empty
-    -- stack. Expected: 0x42 in low limb. Smoke test for
-    -- copyNoopHandlers.
+    -- MCOPY pops 3 args; PUSH1 0x42 lands on the empty stack.
     { name           := "mcopy_pop3"
       bytecode       := "0x60, 0x01, 0x60, 0x02, 0x60, 0x03, 0x5e, 0x60, 0x42, 0x00"
       expectedOutHex := "4200000000000000000000000000000000000000000000000000000000000000" }
+  , -- MSTORE8 writes 0xab at memory[0]; MCOPY(dest=1, src=0, len=1)
+    -- copies that byte to memory[1]. MLOAD(0) observes bytes 0 and 1.
+    { name           := "mcopy_copies_byte"
+      bytecode       := "0x60, 0xab, 0x60, 0x00, 0x53, 0x60, 0x01, 0x60, 0x00, 0x60, 0x01, 0x5e, 0x60, 0x00, 0x51, 0x00"
+      expectedOutHex := "000000000000000000000000000000000000000000000000000000000000abab" }
+  , -- MCOPY(dest=0x40, src=0, len=1) expands memory to 0x60.
+    { name           := "mcopy_msize_dest_range"
+      bytecode       := "0x60, 0x01, 0x60, 0x00, 0x60, 0x40, 0x5e, 0x59, 0x00"
+      expectedOutHex := "6000000000000000000000000000000000000000000000000000000000000000" }
+  , -- MCOPY(dest=0, src=0x40, len=1) expands memory to 0x60 from
+    -- the read range as required by EIP-5656.
+    { name           := "mcopy_msize_source_range"
+      bytecode       := "0x60, 0x01, 0x60, 0x40, 0x60, 0x00, 0x5e, 0x59, 0x00"
+      expectedOutHex := "6000000000000000000000000000000000000000000000000000000000000000" }
+  , -- MCOPY with len=0 does not expand memory even with non-zero
+    -- source and destination offsets.
+    { name           := "mcopy_zero_length_keeps_msize"
+      bytecode       := "0x60, 0x00, 0x60, 0x80, 0x60, 0xff, 0x5e, 0x59, 0x00"
+      expectedOutHex := "0000000000000000000000000000000000000000000000000000000000000000" }
     -- ## M19/M27 child-frame opcodes (CREATE/CALL/CALLCODE/
     -- DELEGATECALL/CREATE2/STATICCALL). CREATE-family and
     -- non-precompile CALL-family targets remain pop-N + push-zero


### PR DESCRIPTION
## Summary
- add dispatcher active-memory-size bookkeeping and wire MSIZE to report it
- replace the MCOPY no-op with a concrete low-u64 memmove-style runtime handler
- update MLOAD/MSTORE/MSTORE8/CALLDATACOPY/MCOPY to expand the active memory size and add focused opcode cases

## Follow-up
- exact EIP-5656 gas charging, overflow, and OOG behavior remains tracked in bead evm-asm-fhsxz.2.4.2.60.3.1.1

## Tests
- `lake build`
- `scripts/codegen-opcodes-check.sh` (MCOPY/MSIZE cases pass; script still exits nonzero on pre-existing unrelated cases: call_sha256_precompile_aa200, calldatasize_with_input, calldataload_basic, calldatacopy_basic, sload_preloaded_match)