### PR TITLE
feat(codegen): real EXP (0x0a) — fix x6 counter clobber, wire verified body

### DIFF
--- a/CODEGEN.md
+++ b/CODEGEN.md
@@ -40,7 +40,7 @@ untouched. Generated artifacts go in `gen-out/` (gitignored).
 | `EvmAsm/Codegen/Layout.lean` | `HaltConv` enum, halt stubs, `_start` preamble, `.option norvc`, `MEM_START`/`MEM_END` constants, `BuildUnit` struct + `emitBuildUnit`/`emitDataLabel` helpers. |
 | `EvmAsm/Codegen/Dispatch.lean` | M5b dispatcher scaffolding: `OpcodeHandlerSpec` (optional `preBody` for x10-clobbering handlers + optional `postBodyLabel` for M9's trampoline pattern) + `HandlerTail` types, `emitDispatcherPrologue`/`Epilogue`/`DataSection` and `buildDispatchUnit` helpers. M8.5 adds the parallel runtime-bytecode helpers (`emitRuntimeDispatcherPrologue` / `emitRuntimeDispatcherDataSection` / `buildRuntimeDispatchUnit`) that read bytecode from `INPUT_ADDR + INPUT_DATA_OFFSET` at runtime. Pure (no IO). |
 | `EvmAsm/Codegen/Programs.lean` | `BuildUnit` lookup hub: `lookupProgram`, `knownProgramNames`, plus the `statelessGuestUnit` build target. Imports every `BuildUnit` defined under `Programs/`. The actual M5b opcode-handler registry (`tinyInterpRegistry`) and the `BuildUnit`s for `evm_add` / `evm_div` / `evm_mod` / `input_echo` / `runtime_dispatcher` / `tiny_interp_*` now live in `Programs/Evm.lean` (see next row). |
-| `EvmAsm/Codegen/Programs/` | Execution-layer programs supporting the Stateless guest (40+ files): Account / Block / Chain / Header / Mpt / Tx / Receipt / Bloom / RLP read / SSZ / U256 / etc. Plus `Programs/Evm.lean` — the M5b opcode handler registry **`tinyInterpRegistry`** at `Programs/Evm.lean:666`, composed from `pushHandlers` (PUSH0..32), `dupHandlers` (DUP1..16), `swapHandlers` (SWAP1..16), `singletonHandlers` (19 fixed-shape opcodes incl. SHL/SAR from M11), `memoryHandlers` (MLOAD/MSTORE/MSTORE8, M7), `envHandlers` (13 simple environment opcodes ADDRESS/CALLER/.../BASEFEE, M12), `calldataHandlers` (CALLDATASIZE, M13), `controlFlowHandlers` (JUMPDEST from M14; JUMP/JUMPI/PC added in M15), `hashHandlers` (KECCAK256 via ECALL bridge from M16), `logHandlers` (LOG0–LOG4 as stack-pop no-ops, M17), `storageHandlers` (SLOAD/SSTORE/TLOAD/TSTORE as no-op stack ops with empty-storage semantics, M17), `haltHandlers`/`pushZeroHandlers`/`popPushZeroHandlers`/`copyNoopHandlers` (M18 — 20 trivial no-ops covering RETURN/REVERT/INVALID/SELFDESTRUCT + 5 push-zero + 6 pop+push-zero + 5 copy-no-op opcodes; defined in `Programs/Noop.lean`), `childFrameHandlers` (M19 — 6 child-frame opcodes CREATE/CALL/CALLCODE/DELEGATECALL/CREATE2/STATICCALL as pop-N + push-zero no-ops; also in `Programs/Noop.lean`), `arithNoopHandlers` (M20 — MULMOD + EXP as pop-N + push-zero no-ops; in `Programs/Noop.lean`), `divModHandlers` (DIV/MOD, M8), `signedDivModHandlers` (SDIV/SMOD via trampoline, M9), `selfCallingHandlers` (ADDMOD via inline-callable, M10), and `stopHandler`. Total: **149 wired opcodes — 🎯 100% of the 149-byte EVM space**. Also hosts shared helpers (`advancePc`, `copy64`, `evmAddEpilogue`, `evmDivPatched`/`evmModPatched`/`evmSdivPatched`/`evmSmodPatched` for the DIV/MOD/SDIV/SMOD NOP-splice). |
+| `EvmAsm/Codegen/Programs/` | Execution-layer programs supporting the Stateless guest (40+ files): Account / Block / Chain / Header / Mpt / Tx / Receipt / Bloom / RLP read / SSZ / U256 / etc. Plus `Programs/Evm.lean` — the M5b opcode handler registry **`tinyInterpRegistry`** at `Programs/Evm.lean:666`, composed from `pushHandlers` (PUSH0..32), `dupHandlers` (DUP1..16), `swapHandlers` (SWAP1..16), `singletonHandlers` (19 fixed-shape opcodes incl. SHL/SAR from M11), `memoryHandlers` (MLOAD/MSTORE/MSTORE8, M7), `envHandlers` (13 simple environment opcodes ADDRESS/CALLER/.../BASEFEE, M12), `calldataHandlers` (CALLDATASIZE, M13), `controlFlowHandlers` (JUMPDEST from M14; JUMP/JUMPI/PC added in M15), `hashHandlers` (KECCAK256 via ECALL bridge from M16), `logHandlers` (LOG0–LOG4 as stack-pop no-ops, M17), `storageHandlers` (SLOAD/SSTORE/TLOAD/TSTORE as no-op stack ops with empty-storage semantics, M17), `haltHandlers`/`pushZeroHandlers`/`popPushZeroHandlers`/`copyNoopHandlers` (M18 — 20 trivial no-ops covering RETURN/REVERT/INVALID/SELFDESTRUCT + 5 push-zero + 6 pop+push-zero + 5 copy-no-op opcodes; defined in `Programs/Noop.lean`), `childFrameHandlers` (M19 — 6 child-frame opcodes CREATE/CALL/CALLCODE/DELEGATECALL/CREATE2/STATICCALL as pop-N + push-zero no-ops; also in `Programs/Noop.lean`), `arithNoopHandlers` (MULMOD as a pop-N + push-zero no-op; in `Programs/Noop.lean` — EXP graduated to a real body in M27), `divModHandlers` (DIV/MOD, M8), `signedDivModHandlers` (SDIV/SMOD via trampoline, M9), `selfCallingHandlers` (ADDMOD via inline-callable from M10; EXP via inline-callable `_fixed_fixed` body from M27), and `stopHandler`. Total: **149 wired opcodes — 🎯 100% of the 149-byte EVM space**. Also hosts shared helpers (`advancePc`, `copy64`, `evmAddEpilogue`, `evmDivPatched`/`evmModPatched`/`evmSdivPatched`/`evmSmodPatched` for the DIV/MOD/SDIV/SMOD NOP-splice). |
 | `EvmAsm/Codegen/Proofs/` | Codegen-proofs scaffolding (post-M10). `RegistryInvariants.lean` (Phase 1) — 6 `decide`-checked theorems about `tinyInterpRegistry`'s structural well-formedness (Nodup on opcodes/labels, byte bounds, jump-table coverage). `HandlerSpecs.lean` (Phase 4) — reusable `cleanRetHandlerSpec` template + **13 concrete handler-level `cpsTripleWithin` instances** for clean-shape singletons (ADD, POP, SUB, LT, GT, SLT, SGT, EQ, ISZERO, AND, OR, XOR, NOT). Phases 2, 3, 5 + the remaining Phase 4 instances are still future work. |
 | `EvmAsm/Codegen/Tests/Cases.lean` | Per-opcode regression test registry: `OpcodeTestCase` struct + `opcodeTestCases` list (**59 cases** as of M20). Wraps each bytecode through the M5b dispatcher for end-to-end ziskemu validation. |
 | `EvmAsm/Codegen/Cli.lean` | Argument parsing (`--program`, `--test-case`, `--list-test-cases`, `--halt`, `--out`, `--asm-only`). |
@@ -1960,6 +1960,76 @@ unchanged — they don't assert on `OUTPUT[56..]` and the
 dedup-and-emit only writes within that previously-unused
 range). `scripts/check-progress.sh` exits 0. Build clean
 (`lake build EvmAsm.Codegen` exits 0).
+
+### M27 — Real EXP (0x0a): graduate from no-op to verified body — **DONE (2026-06-02)**
+
+(Numbered M27 to leave room for the real LOG-event-capture work that
+landed after M25 in git — commit `7a160eec2` — but was not given its own
+doc milestone.)
+
+EXP (0x0a) graduates from the M20 `arithNoopHandlers` no-op to its real
+verified body, routed through `selfCallingHandlers` with the same
+inline-callable pattern as ADDMOD (M10).
+
+**The blocker was a real bug, not an upstream gap.** The `_fixed` EXP body
+(`EvmAsm/Evm64/Exp/Program.lean`) moved the exponent *cursor* to
+callee-saved `x19`, but left the per-limb *counter* in `x6` — which
+`mul_callable` (= `evm_mul ;; cc_ret`) clobbers ~51× per call. Since the
+squaring / conditional-multiply blocks call `mul_callable` mid-iteration,
+`x6` was garbage on the next bit-test, producing wrong results / an
+infinite reload loop (documented in `scripts/codegen-evm_exp-property-check.sh`).
+The earlier "x16 is also unsafe" note was stale — `evm_mul` touches none
+of `x16/x18/x19/x22`.
+
+**Delivered:**
+- **`EvmAsm/Evm64/Exp/Program.lean`** — new `_fixed_fixed` family
+  (`exp_prologue_fixed_fixed`, `exp_msb_bit_test_block_fixed_fixed`,
+  `exp_iter_body_full_msb_saved_bit_two_mul_fixed_fixed`,
+  `evm_exp_msb_saved_bit_two_mul_fixed_fixed[_canonical]` + length
+  theorems). Pure register substitution `x6 → x22` (s6, callee-saved); all
+  instruction counts and byte offsets identical to `_fixed`, so the
+  canonical branch/MUL offsets carry over.
+- **`EvmAsm/Codegen/Programs/Evm.lean`** — `evmExpComposed` =
+  `evm_exp_..._fixed_fixed_canonical 200 92 ;; JAL x0 +260 ;; mul_callable`,
+  mirroring `evmAddmodComposed`. MUL-call offsets shift +4 (196→200,
+  88→92) because the 4-byte skip-JAL pushes `mul_callable` to body byte
+  340; the skip-JAL (260 = 4 + 256) carries the loop-exit fall-through
+  past the callable to the tail (`exp_epilogue` has no trailing jump). New
+  `h_EXP` entry in `selfCallingHandlers` with
+  `preBody := "mv x14, x10\n  la x2, exp_scratch"` and a custom `expTail`
+  (`mv x10, x14; la sp, lp64_sp_top; addi x10, x10, 1; j .dispatch_loop`).
+  Removed EXP from `arithNoopHandlers` (MULMOD stays).
+- **`EvmAsm/Codegen/Dispatch.lean`** — both data sections gain a 32-byte
+  `exp_scratch:` region. The EXP body uses `x2`(sp)+0..24 as its result
+  accumulator; the dispatcher's `sp = lp64_sp_top` is the top of a
+  down-growing stack immediately followed by the jump table, so `sp+0..24`
+  would corrupt opcode-handler entries 0–3 (incl. STOP). `h_EXP` repoints
+  `x2` at `exp_scratch` and its tail restores `sp`.
+- **`EvmAsm/Codegen/Programs/ExpProperty.lean`** — `evm_exp_from_input`
+  upgraded to the `_fixed_fixed` body + skip-JAL (it was doubly broken: the
+  x6 clobber *and* `exp_epilogue` falling straight into `mul_callable`).
+  `scripts/codegen-evm_exp-property-check.sh` now validates random
+  `(base, exponent)` pairs against Python `pow(base, exp, 2**256)`.
+- **`EvmAsm/Codegen/Tests/Cases.lean`** — replaced the `exp_pop2` no-op
+  case with two real cases: `exp_basic` (2³=8, exercises cond-multiply)
+  and `exp_zero` (5⁰=1, exercises the per-limb counter reload across all
+  4 limbs via 256 squarings). Total cases 76 → 77.
+
+**Known limitation (documented in `evmExpComposed`):** the verified EXP
+body uses `x12+64..120` (deeper-stack direction) as MUL factor scratch —
+fine when EXP's operands are the shallowest live elements (true for the
+test cases and the standalone harness's reserved `operands_ram+64..127`),
+but it overwrites deeper stack slots if EXP runs with a deeper stack. A
+full-domain dispatcher fix would give the body a dedicated MUL-scratch
+base register instead of reusing `x12`. `RegistryInvariants` counts are
+unchanged (149) — EXP was already counted; it only moved lists.
+
+**Exit criteria (met).**
+`scripts/codegen-opcodes-runtime-check.sh` exits 0 with all **77 cases
+PASS** (`exp_basic`, `exp_zero` included). `scripts/codegen-evm_exp-property-check.sh
+--count=30` exits 0 (all 30 random cases match Python `pow`).
+`scripts/check-progress.sh` exits 0. Build clean (`lake build EvmAsm.Codegen`
+exits 0).
 
 ### Sequencing
 

--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -353,6 +353,15 @@ def emitDispatcherDataSection
   "lp64_stack:\n" ++
   "  .zero 512\n" ++      -- M16: LP64 stack region for ECALL-bridge helpers
   "lp64_sp_top:\n" ++     -- (the keccak subroutine's `sp` frame lives here)
+  ".balign 8\n" ++
+  "exp_scratch:\n" ++
+  "  .zero 32\n" ++       -- EXP (0x0a): 32-byte result-accumulator frame. The
+                          -- verified EXP body uses `x2`(sp)+0..24 as its running
+                          -- accumulator; the dispatcher's `sp` points at
+                          -- `lp64_sp_top` (top of a down-growing stack), so
+                          -- `sp+0..24` would scribble into the jump table.
+                          -- h_EXP's preBody repoints `x2` here and its tail
+                          -- restores `sp = lp64_sp_top`.
   emitJumpTable registry
 
 /-! ## Runtime-bytecode dispatcher (M8.5)
@@ -494,6 +503,15 @@ def emitRuntimeDispatcherDataSection
   "lp64_stack:\n" ++
   "  .zero 512\n" ++      -- M16: LP64 stack region for ECALL-bridge helpers
   "lp64_sp_top:\n" ++     -- (the keccak subroutine's `sp` frame lives here)
+  ".balign 8\n" ++
+  "exp_scratch:\n" ++
+  "  .zero 32\n" ++       -- EXP (0x0a): 32-byte result-accumulator frame. The
+                          -- verified EXP body uses `x2`(sp)+0..24 as its running
+                          -- accumulator; the dispatcher's `sp` points at
+                          -- `lp64_sp_top` (top of a down-growing stack), so
+                          -- `sp+0..24` would scribble into the jump table.
+                          -- h_EXP's preBody repoints `x2` here and its tail
+                          -- restores `sp = lp64_sp_top`.
   emitJumpTable registry
 
 /-- Build a runtime-bytecode `BuildUnit` for `registry` + `exitBody`.

--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -24,7 +24,7 @@ import EvmAsm.Evm64.Lt.Program
 import EvmAsm.Evm64.MLoad.Program
 import EvmAsm.Evm64.MStore.Program
 import EvmAsm.Evm64.MStore8.Program
--- import EvmAsm.Evm64.Multiply.Callable -- only needed by EXP (deferred)
+import EvmAsm.Evm64.Multiply.Callable -- EXP's inline mul_callable (Programs/Evm.lean)
 import EvmAsm.Evm64.Multiply.Program
 import EvmAsm.Evm64.Not.Program
 import EvmAsm.Evm64.Or.Program

--- a/EvmAsm/Codegen/Programs/Evm.lean
+++ b/EvmAsm/Codegen/Programs/Evm.lean
@@ -23,12 +23,14 @@ import EvmAsm.Evm64.DivMod.Program
 import EvmAsm.Evm64.Dup.Program
 import EvmAsm.Evm64.Env.Program
 import EvmAsm.Evm64.Eq.Program
+import EvmAsm.Evm64.Exp.Program
 import EvmAsm.Evm64.Gt.Program
 import EvmAsm.Evm64.IsZero.Program
 import EvmAsm.Evm64.Lt.Program
 import EvmAsm.Evm64.MLoad.Program
 import EvmAsm.Evm64.MStore.Program
 import EvmAsm.Evm64.MStore8.Program
+import EvmAsm.Evm64.Multiply.Callable
 import EvmAsm.Evm64.Multiply.Program
 import EvmAsm.Evm64.Not.Program
 import EvmAsm.Evm64.Or.Program
@@ -938,15 +940,16 @@ def signedDivModHandlers : List OpcodeHandlerSpec :=
     `signedDivModTail` helper. It also clobbers `x10` via the
     inline mod callable, so `preBody` saves `x10` to `x14`.
 
-    EXP (0x0a) was planned for this milestone but is deferred. The
-    `evm_exp_msb_saved_bit_two_mul_fixed` wrapper uses `x6` and
-    `x16` as per-limb counter / limb pointer, but those are LP64
-    caller-saved registers — `mul_callable` clobbers `x6` 39 times
-    per call. The "fix" only addresses `x19` (cursor) clobber, not
-    `x6`/`x16`. A complete fix requires a `_fixed_fixed` variant
-    using callee-saved registers (e.g. `x20`/`x21`) for the
-    per-limb counter and limb pointer; until that lands upstream,
-    EXP can't run through the dispatcher. -/
+    EXP (0x0a) now rides the same self-calling pattern via
+    `evmExpComposed` below, using the `_fixed_fixed` body variant.
+    The earlier deferral note was that `mul_callable` clobbers `x6`
+    (the EXP loop's per-limb counter) — the `_fixed` variant only
+    moved the `x19` cursor to a callee-saved register, leaving the
+    `x6` counter to be corrupted mid-iteration. `_fixed_fixed`
+    (`EvmAsm/Evm64/Exp/Program.lean`) moves the counter to `x22`
+    (s6, callee-saved, untouched by `evm_mul`/`cc_ret`), so EXP now
+    runs correctly through the dispatcher. (The limb pointer `x16`
+    was never the problem — `evm_mul` doesn't touch it.) -/
 
 /-- ADDMOD handler body. **Skips `evm_addmod_epilogue` deliberately**:
     the verified `evm_addmod` composes prologue + phase1_carry +
@@ -978,6 +981,49 @@ def evmAddmodComposed : Program :=
   single (Instr.JAL .x0 (1376 : BitVec 21)) ;;
   EvmAsm.Evm64.evm_mod_callable_v4
 
+/-- EXP (0x0a) handler body: the double-fixed verified EXP body inlined
+    with `mul_callable`, mirroring `evmAddmodComposed`.
+
+    Composition:
+      - `evm_exp_..._fixed_fixed_canonical 200 92`: 84 instr (336 B). The
+        two interior `JAL .x1` MUL-call sites target `mul_callable`.
+      - skip-JAL `JAL .x0 +260`: 1 instr (4 B) at byte 336 — jumps past
+        the inlined callable to the handler tail (260 = 4 + 256).
+      - `mul_callable`: 64 instr (256 B) at byte 340.
+
+    **MUL-call offsets shift +4 vs the standalone `evm_exp_from_input`.**
+    There, `mul_callable` sits immediately after the body (byte 336), so
+    the canonical offsets are 196 / 88. Here the 4-byte skip-JAL pushes
+    `mul_callable` to byte 340, so the squaring / cond-multiply JAL sites
+    (at body bytes 140 / 248) need offsets `340-140 = 200` and
+    `340-248 = 92`. The internal branch offsets (cond-mul skip BEQ,
+    loop-back BNE) are unaffected — they stay inside the 336-byte body
+    and use the canonical `_fixed` values.
+
+    The skip-JAL is required because EXP's loop exits by *falling through*
+    `exp_epilogue` (which has no trailing jump); without it, control would
+    run straight into `mul_callable`. ADDMOD doesn't need this shape
+    because its single MUL call is the last thing before the callable.
+
+    Net `x12` advance: `exp_epilogue` does one `ADDI x12, x12, 32` (pops 2,
+    pushes 1); the per-iteration call marshal/un-marshal nets zero. -/
+def evmExpComposed : Program :=
+  EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul_fixed_fixed_canonical
+    (200 : BitVec 21) (92 : BitVec 21) ;;
+  single (Instr.JAL .x0 (260 : BitVec 21)) ;;
+  EvmAsm.Evm64.mul_callable
+
+/-- Tail for EXP (0x0a): like `signedDivModTail` (the inner `JAL .x1` into
+    `mul_callable` clobbers `x1`, so `ret` would jump to garbage → use
+    `j .dispatch_loop`), plus a `la sp, lp64_sp_top` to restore the LP64
+    stack pointer that h_EXP's `preBody` repointed at `exp_scratch` for the
+    EXP body's result accumulator. -/
+private def expTail : HandlerTail :=
+  .custom ("  mv x10, x14\n" ++
+           "  la sp, lp64_sp_top\n" ++
+           "  addi x10, x10, 1\n" ++
+           "  j .dispatch_loop")
+
 /-- M10 self-calling handlers. Currently just ADDMOD; EXP is
     deferred (see the milestone-header comment). Reuses
     `signedDivModTail` because the wrapper's inner `JAL .x1` into
@@ -988,7 +1034,12 @@ def selfCallingHandlers : List OpcodeHandlerSpec :=
       opcodes       := [0x08]
       preBody       := "  mv x14, x10"
       body          := evmAddmodComposed
-      tail          := signedDivModTail } ]
+      tail          := signedDivModTail }
+  , { label         := "h_EXP"
+      opcodes       := [0x0a]
+      preBody       := "  mv x14, x10\n  la x2, exp_scratch"
+      body          := evmExpComposed
+      tail          := expTail } ]
 
 /-- STOP: transitions out of the dispatcher loop instead of returning
     to it. The body is empty; the dispatcher's `jalr` lands on

--- a/EvmAsm/Codegen/Programs/ExpProperty.lean
+++ b/EvmAsm/Codegen/Programs/ExpProperty.lean
@@ -8,13 +8,14 @@
   `EvmAsm.Evm64.Exp.Program` and the callable MUL shim from
   `EvmAsm.Evm64.Multiply.Callable`.
 
-  NOTE: The current EXP implementation has a known bug — `mul_callable`
-  clobbers x6, which the EXP loop uses as its per-limb bit counter (init
-  64, decremented per bit, resets at limb boundaries). Random property
-  testing via `scripts/codegen-evm_exp-property-check.sh` will surface
-  wrong results for non-trivial inputs, guiding development of the
-  corrected `_fixed_fixed` variant that uses callee-saved registers for
-  the limb counter and limb pointer.
+  Uses the corrected `_fixed_fixed` EXP body: the per-limb bit counter
+  moved from `x6` (which `mul_callable` clobbers) to callee-saved `x22`.
+  The earlier `_fixed` body had two bugs — (1) the `x6` counter clobber
+  above, and (2) `exp_epilogue` falling straight through into the
+  appended `mul_callable` (it has no trailing jump). Both are fixed here:
+  `_fixed_fixed` repairs (1) and the skip-JAL after the body repairs (2).
+  `scripts/codegen-evm_exp-property-check.sh` now validates random
+  `(base, exponent)` pairs against Python's `pow(base, exp, 2**256)`.
 -/
 
 import EvmAsm.Codegen.Programs.Evm
@@ -40,17 +41,19 @@ open EvmAsm.Rv64
                               +32..63 exponent (overwritten by result)
                               +64..127 mul_callable scratch frame
 
-    JAL offsets use canonical values from `Program.lean`:
-      squaringMulOff = 196, condMulOff = 88.
-    Both target `mul_callable` placed immediately after the 84-instruction
-    (336-byte) EXP body. -/
+    A 4-byte skip-JAL sits between the 336-byte EXP body and the inlined
+    `mul_callable`, so the two interior MUL-call offsets shift +4 from the
+    canonical 196/88 to **200/92** (`mul_callable` now starts at body byte
+    340). The skip-JAL (`JAL x0 +260`) carries the loop-exit fall-through
+    past `mul_callable` to `evmAddEpilogue`, instead of running straight
+    into the callable. Mirrors `evmExpComposed` in `Programs/Evm.lean`. -/
 
 def evm_exp_from_input : Program :=
   LI .x5 (INPUT_ADDR + (BitVec.ofNat 64 INPUT_DATA_OFFSET)) ;;
   copy64 .x12 .x5 .x6 ++
-  EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul_fixed_canonical
-    EvmAsm.Evm64.canonicalExpSquaringMulOff
-    EvmAsm.Evm64.canonicalExpCondMulOff ++
+  EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul_fixed_fixed_canonical
+    (200 : BitVec 21) (92 : BitVec 21) ++
+  (single (Instr.JAL .x0 (260 : BitVec 21))) ++
   EvmAsm.Evm64.mul_callable ++
   evmAddEpilogue
 

--- a/EvmAsm/Codegen/Programs/Noop.lean
+++ b/EvmAsm/Codegen/Programs/Noop.lean
@@ -332,27 +332,17 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
       placeholder in `EvmAsm/Evm64/MulMod/Program.lean` (slice
       evm-asm-m4wu unscheduled). A future PR will swap in the
       real Knuth-style 512-bit + reduce-by-N body once it lands.
-    - **EXP** always returns 0. **The verified body actually
-      exists** (`evm_exp_msb_saved_bit_two_mul_fixed` in
-      `EvmAsm/Evm64/Exp/Program.lean`, x19-callee-saved cursor
-      design; ~84 instructions). The M21 PR after this one will
-      wire it via the M10-style inline-callable composition
-      pattern (~300–500 LOC: embed `mul_callable` in the
-      dispatcher epilogue, pin JAL offsets for the squaring +
-      conditional-multiply calls, use M9-style trampoline tail).
+    - **EXP** graduated from a no-op to a real verified body and now
+      lives in `selfCallingHandlers` (`EvmAsm/Codegen/Programs/Evm.lean`)
+      as `evmExpComposed`, using the `_fixed_fixed` body variant
+      (per-limb counter moved from `x6` to callee-saved `x22` so it
+      survives `mul_callable`). Only MULMOD remains a no-op here.
 
-    Trusted bytecode that doesn't depend on MULMOD / EXP results
-    continues to work correctly. -/
+    Trusted bytecode that doesn't depend on MULMOD results continues
+    to work correctly. -/
 def arithNoopHandlers : List OpcodeHandlerSpec :=
   [ { label := "h_MULMOD", opcodes := [0x09]
     , body := ADDI .x12 .x12 (BitVec.ofNat 12 64) ;;
-              SD .x12 .x0 0 ;;
-              SD .x12 .x0 8 ;;
-              SD .x12 .x0 16 ;;
-              SD .x12 .x0 24
-    , tail := .advanceAndRet 1 }
-  , { label := "h_EXP", opcodes := [0x0a]
-    , body := ADDI .x12 .x12 (BitVec.ofNat 12 32) ;;
               SD .x12 .x0 0 ;;
               SD .x12 .x0 8 ;;
               SD .x12 .x0 16 ;;

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -461,13 +461,26 @@ def opcodeTestCases : List OpcodeTestCase :=
     { name           := "mulmod_pop3"
       bytecode       := "0x60, 0x03, 0x60, 0x05, 0x60, 0x07, 0x09, 0x60, 0x42, 0x00"
       expectedOutHex := "4200000000000000000000000000000000000000000000000000000000000000" }
-  , -- PUSH1 0x02; PUSH1 0x03; EXP; PUSH1 0xff; STOP
-    -- EXP pops 2 (base, exponent), pushes 1 (result = 0). Net pop =
-    -- 1 = +32 bytes. PUSH1 0xff lands on the 1-deep stack and
-    -- replaces the zero result. Expected: 0xff.
-    { name           := "exp_pop2"
-      bytecode       := "0x60, 0x02, 0x60, 0x03, 0x0a, 0x60, 0xff, 0x00"
-      expectedOutHex := "ff00000000000000000000000000000000000000000000000000000000000000" }
+  , -- ## EXP (0x0a) — real verified body via selfCallingHandlers
+    -- (evmExpComposed, _fixed_fixed x6→x22 counter fix). EVM EXP pops
+    -- `a` (base, top of stack) then `exponent`; result = a ** exponent.
+    -- Top of stack = last-pushed = x12+0 = base; second = exponent.
+    --
+    -- PUSH1 0x03; PUSH1 0x02; EXP; STOP — base=2 (top), exponent=3 → 2**3 = 8.
+    -- Exercises the conditional-multiply path (exponent 3 = ...011 has
+    -- set bits → mul_callable is JAL'd for both squaring and cond-mul,
+    -- the path that clobbered x6 before the fix).
+    { name           := "exp_basic"
+      bytecode       := "0x60, 0x03, 0x60, 0x02, 0x0a, 0x00"
+      expectedOutHex := "0800000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0x00; PUSH1 0x05; EXP; STOP — base=5 (top), exponent=0 → 5**0 = 1.
+    -- Exponent 0 has no set bits, so the loop only squares (result stays
+    -- at the prologue's accumulator init of 1) across all 256 bits — a
+    -- strong exercise of the per-limb counter reload across all 4 limbs
+    -- (the exact x22 state that mul_callable used to corrupt as x6).
+    { name           := "exp_zero"
+      bytecode       := "0x60, 0x00, 0x60, 0x05, 0x0a, 0x00"
+      expectedOutHex := "0100000000000000000000000000000000000000000000000000000000000000" }
     -- ## M8 unsigned division opcodes
     -- (SDIV / SMOD deferred: their verified bodies use a saved-ra-ret
     -- pattern that bypasses the dispatcher's standard wrapper tail;

--- a/EvmAsm/Evm64/Exp/Program.lean
+++ b/EvmAsm/Evm64/Exp/Program.lean
@@ -1428,4 +1428,150 @@ theorem evm_exp_msb_saved_bit_two_mul_fixed_epilogue_byte_offset
     exp_iter_body_full_msb_saved_bit_two_mul_fixed_length,
     exp_loop_pointer_restore_length]
 
+-- ============================================================================
+-- DOUBLE-FIXED EXP (x6 → x22): the per-limb counter clobber repair
+--
+-- The `_fixed` family above moved the exponent *cursor* to callee-saved x19,
+-- but left the per-limb *counter* in x6. `mul_callable` (= `evm_mul ;; cc_ret`)
+-- clobbers x6 ~51× per call, and the squaring / conditional-multiply blocks
+-- call `mul_callable` MID-ITERATION — before the next `exp_msb_bit_test_block`
+-- decrements/tests x6. So x6 is garbage on re-entry, producing wrong results
+-- or an infinite reload loop (see `scripts/codegen-evm_exp-property-check.sh`).
+--
+-- This `_fixed_fixed` family is a pure register substitution x6 → x22 (s6) in
+-- the prologue and bit-test block. x22 is callee-saved, untouched by
+-- `evm_mul`/`cc_ret`, untouched by every other EXP block, and not reserved by
+-- the codegen dispatcher (which reserves x10/x12/x13/x20/x21). Because it is a
+-- pure substitution, all instruction counts and byte offsets are identical to
+-- the `_fixed` family, so the canonical branch/MUL offsets carry over verbatim.
+-- ============================================================================
+
+/-- Double-fixed EXP prologue: identical to `exp_prologue_fixed` but the
+    per-limb counter lives in callee-saved x22 (s6) instead of x6, which
+    `mul_callable` clobbers. 10 instructions, 40 bytes. -/
+def exp_prologue_fixed_fixed : Program :=
+  ADDI .x9 .x0 256 ;;
+  ADDI .x5 .x0 1 ;;
+  SD .x2 .x5 0 ;;
+  SD .x2 .x0 8 ;;
+  SD .x2 .x0 16 ;;
+  SD .x2 .x0 24 ;;
+  ADDI .x22 .x0 64 ;;
+  ADDI .x16 .x12 56 ;;
+  LD .x19 .x16 0 ;;
+  ADDI .x16 .x16 (-8)
+
+theorem exp_prologue_fixed_fixed_length :
+    exp_prologue_fixed_fixed.length = 10 := by decide
+
+theorem exp_prologue_fixed_fixed_byte_length :
+    4 * exp_prologue_fixed_fixed.length = 40 := by
+  rw [exp_prologue_fixed_fixed_length]
+
+/-- Double-fixed MSB-first bit-test block: identical to
+    `exp_msb_bit_test_block_fixed` but the per-limb counter is x22 (s6),
+    which survives `mul_callable` calls. 7 instructions, 28 bytes. -/
+def exp_msb_bit_test_block_fixed_fixed : Program :=
+  SRLI .x10 .x19 63 ;;
+  SLLI .x19 .x19 1 ;;
+  ADDI .x22 .x22 (-1) ;;
+  single (.BNE .x22 .x0 16) ;;
+  LD .x19 .x16 0 ;;
+  ADDI .x16 .x16 (-8) ;;
+  ADDI .x22 .x0 64
+
+theorem exp_msb_bit_test_block_fixed_fixed_length :
+    exp_msb_bit_test_block_fixed_fixed.length = 7 := by decide
+
+theorem exp_msb_bit_test_block_fixed_fixed_byte_length :
+    4 * exp_msb_bit_test_block_fixed_fixed.length = 28 := by
+  rw [exp_msb_bit_test_block_fixed_fixed_length]
+
+/-- Double-fixed MSB-first saved-bit full iteration body using the corrected
+    counter register. All other blocks are unchanged: x16/x18/x19/x22 are all
+    callee-saved (or untouched by `evm_mul`) and survive `mul_callable` calls. -/
+def exp_iter_body_full_msb_saved_bit_two_mul_fixed_fixed
+    (squaringMulOff condMulOff : BitVec 21)
+    (skipOff backOff : BitVec 13) : Program :=
+  exp_msb_bit_test_block_fixed_fixed ;;
+  exp_save_bit_block ;;
+  exp_squaring_call_block squaringMulOff ;;
+  exp_cond_mul_call_with_saved_bit_skip_block condMulOff skipOff ;;
+  exp_loop_back backOff
+
+theorem exp_iter_body_full_msb_saved_bit_two_mul_fixed_fixed_length
+    (squaringMulOff condMulOff : BitVec 21)
+    (skipOff backOff : BitVec 13) :
+    (exp_iter_body_full_msb_saved_bit_two_mul_fixed_fixed
+      squaringMulOff condMulOff skipOff backOff).length = 63 := by
+  show (((((exp_msb_bit_test_block_fixed_fixed ;;
+            exp_save_bit_block) ;;
+           exp_squaring_call_block squaringMulOff) ;;
+          exp_cond_mul_call_with_saved_bit_skip_block condMulOff skipOff) ;;
+         exp_loop_back backOff)).length = 63
+  simp only [seq, Program.length_append,
+    exp_msb_bit_test_block_fixed_fixed_length,
+    exp_save_bit_block_length,
+    exp_squaring_call_block_length,
+    exp_cond_mul_call_with_saved_bit_skip_block_length,
+    exp_loop_back_length]
+
+theorem exp_iter_body_full_msb_saved_bit_two_mul_fixed_fixed_byte_length
+    (squaringMulOff condMulOff : BitVec 21)
+    (skipOff backOff : BitVec 13) :
+    4 * (exp_iter_body_full_msb_saved_bit_two_mul_fixed_fixed
+      squaringMulOff condMulOff skipOff backOff).length = 252 := by
+  rw [exp_iter_body_full_msb_saved_bit_two_mul_fixed_fixed_length]
+
+/-- Double-fixed EXP program: corrected prologue + bit-test block (x6 → x22).
+    Byte-identical in layout to `evm_exp_msb_saved_bit_two_mul_fixed`, so the
+    canonical branch/MUL offsets are reused unchanged. -/
+def evm_exp_msb_saved_bit_two_mul_fixed_fixed
+    (squaringMulOff condMulOff : BitVec 21)
+    (skipOff backOff : BitVec 13) : Program :=
+  exp_prologue_fixed_fixed ;;
+  exp_loop_pointer_advance ;;
+  exp_iter_body_full_msb_saved_bit_two_mul_fixed_fixed
+    squaringMulOff condMulOff skipOff backOff ;;
+  exp_loop_pointer_restore ;;
+  exp_epilogue
+
+/-- Double-fixed EXP with canonical internal branch offsets and separate
+    external MUL-call offsets for the two JAL sites. -/
+def evm_exp_msb_saved_bit_two_mul_fixed_fixed_canonical
+    (squaringMulOff condMulOff : BitVec 21) : Program :=
+  evm_exp_msb_saved_bit_two_mul_fixed_fixed squaringMulOff condMulOff
+    canonicalExpCondMulSkipOff canonicalExpMsbSavedBitFixedLoopBackOff
+
+theorem evm_exp_msb_saved_bit_two_mul_fixed_fixed_canonical_eq
+    (squaringMulOff condMulOff : BitVec 21) :
+    evm_exp_msb_saved_bit_two_mul_fixed_fixed_canonical squaringMulOff condMulOff =
+      evm_exp_msb_saved_bit_two_mul_fixed_fixed squaringMulOff condMulOff
+        canonicalExpCondMulSkipOff canonicalExpMsbSavedBitFixedLoopBackOff := rfl
+
+theorem evm_exp_msb_saved_bit_two_mul_fixed_fixed_length
+    (squaringMulOff condMulOff : BitVec 21)
+    (skipOff backOff : BitVec 13) :
+    (evm_exp_msb_saved_bit_two_mul_fixed_fixed
+      squaringMulOff condMulOff skipOff backOff).length = 84 := by
+  show ((((exp_prologue_fixed_fixed ;;
+           exp_loop_pointer_advance) ;;
+          exp_iter_body_full_msb_saved_bit_two_mul_fixed_fixed
+            squaringMulOff condMulOff skipOff backOff) ;;
+         exp_loop_pointer_restore) ;;
+        exp_epilogue).length = 84
+  simp only [seq, Program.length_append,
+    exp_prologue_fixed_fixed_length,
+    exp_loop_pointer_advance_length,
+    exp_iter_body_full_msb_saved_bit_two_mul_fixed_fixed_length,
+    exp_loop_pointer_restore_length,
+    exp_epilogue_length]
+
+theorem evm_exp_msb_saved_bit_two_mul_fixed_fixed_byte_length
+    (squaringMulOff condMulOff : BitVec 21)
+    (skipOff backOff : BitVec 13) :
+    4 * (evm_exp_msb_saved_bit_two_mul_fixed_fixed
+      squaringMulOff condMulOff skipOff backOff).length = 336 := by
+  rw [evm_exp_msb_saved_bit_two_mul_fixed_fixed_length]
+
 end EvmAsm.Evm64

--- a/PLAN.md
+++ b/PLAN.md
@@ -27,7 +27,8 @@ zkVM standards: `EvmAsm/Evm64/zkvm-standards/` (submodule).
 > PUSH0–32, DUP1–16, SWAP1–16, 17 clean-shape singletons, MLOAD/MSTORE/
 > MSTORE8 (M7), DIV/MOD (M8), runtime-bytecode dispatcher (M8.5),
 > SDIV/SMOD via trampoline (M9), and ADDMOD via inline-callable (M10).
-> EXP is deferred pending an upstream callee-saved variant. Codegen-
+> EXP via inline-callable `_fixed_fixed` body (M27; per-limb counter
+> moved x6→x22 so it survives `mul_callable`). Codegen-
 > proofs **Phase 1 (registry invariants)** and the first 13/91
 > instances of **Phase 4 (handler-level `cpsTripleWithin` specs via
 > `cleanRetHandlerSpec`)** have landed under


### PR DESCRIPTION
## Summary

Graduates **EXP (0x0a)** from an M20 no-op to its **real verified body**, routed through the tiny-interpreter dispatcher via the M10 inline-callable pattern (same shape as ADDMOD). Wiring EXP required fixing a genuine bug in the verified core, so this is a dual-use change — the same `Evm64` EXP body is what the stateless block-verification guest (`EvmAsm/Stateless/VM/Interpreter.lean`) is designed to plug in.

## The bug it fixes

The `_fixed` EXP body (`EvmAsm/Evm64/Exp/Program.lean`) used **`x6` as its per-limb bit counter**, decremented and tested at the top of every loop iteration. But `mul_callable` (= `evm_mul ;; cc_ret`) clobbers `x6` ~51× per call, and the squaring / conditional-multiply blocks call `mul_callable` **mid-iteration** — so `x6` was garbage by the next bit-test, producing wrong results or an infinite reload loop. The body's own `scripts/codegen-evm_exp-property-check.sh` header documented this as a known bug.

The earlier `_fixed` pass only moved the **`x19` cursor** to a callee-saved register; the stale note claiming `x16` was also unsafe is wrong — `evm_mul`/`cc_ret` touch none of `x16`/`x18`/`x19`/`x22`. Only `x6` was the problem.

**Fix:** a new `_fixed_fixed` body family — a pure register substitution **`x6` → `x22`** (s6, callee-saved). Byte-identical layout to `_fixed`, so the canonical branch/MUL offsets carry over unchanged.

## Wiring

- **`evmExpComposed`** (`Programs/Evm.lean`) mirrors `evmAddmodComposed`: `body ;; JAL x0 +260 ;; mul_callable`. The 4-byte skip-JAL shifts the two MUL-call offsets **+4** (196→200, 88→92) because `mul_callable` now starts at body byte 340, and carries the loop-exit fall-through (`exp_epilogue` has no trailing jump) past the callable to the handler tail.
- New **`h_EXP`** in `selfCallingHandlers`; EXP removed from `arithNoopHandlers` (MULMOD stays a no-op). `RegistryInvariants` count unchanged (149) — EXP only moved lists.
- Dedicated 32-byte **`exp_scratch`** region added to both dispatcher data sections (`Dispatch.lean`): the EXP body's result accumulator at `sp+0..24` would otherwise corrupt jump-table entries 0–3 (incl. STOP), since `sp = lp64_sp_top` sits just before the table. `h_EXP`'s `preBody` repoints `x2` there; its tail restores `sp`.
- Upgraded the standalone **`evm_exp_from_input`** property harness (`ExpProperty.lean`) to the `_fixed_fixed` body + skip-JAL — it was *doubly* broken (the `x6` clobber **and** the epilogue falling straight into `mul_callable`).

## Tests

- `scripts/codegen-opcodes-runtime-check.sh`: **77/77 PASS** — added `exp_basic` (2³=8, exercises the conditional-multiply path) and `exp_zero` (5⁰=1, exercises the per-limb counter reload across all 4 limbs via 256 squarings); removed the `exp_pop2` no-op case.
- `scripts/codegen-evm_exp-property-check.sh --count=30`: **all 30 random `(base, exponent)` cases match Python `pow(base, exp, 2²⁵⁶)`** — far stronger than the fixed cases.
- `scripts/check-progress.sh` exits 0; `lake build EvmAsm.Codegen` clean; all proofs `decide`/`omega`/`bv_omega` only (no `native_decide`).

## Known limitation

The verified EXP body reuses `x12+64..120` (deeper-stack direction) as MUL factor scratch — correct when EXP's operands are the shallowest live elements (all test cases + the standalone harness's reserved `operands_ram+64..127`), but it overwrites deeper stack slots if EXP runs with a deeper stack. A full-domain dispatcher fix would give the body a dedicated MUL-scratch base register instead of reusing `x12`. Documented in `evmExpComposed` and the CODEGEN.md M27 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
