### PR TITLE
feat(codegen): JUMPDEST-validity check (M15.5) — reject jumps to non-0x5b

### DIFF
--- a/CODEGEN.md
+++ b/CODEGEN.md
@@ -898,8 +898,8 @@ computation). Lifts wired opcode count **108 → 111** (74.5% of the
 **Known limitation: no JUMPDEST-validity check.** The verified
 bodies in this PR unconditionally follow the popped destination.
 A spec-compliant EVM rejects invalid jumps; ours doesn't. Trusted
-test programs all jump to real JUMPDEST bytes. A follow-on PR
-will inline the `LBU + BEQ 0x5b` check.
+test programs all jump to real JUMPDEST bytes. **Resolved (Level 1)
+in M15.5** — the inline `LBU` + `0x5b` check; see that section.
 
 **Other limitations** (same trust model):
 - 256-bit `dest` is truncated to its low 64 bits. EVM jumps with
@@ -914,6 +914,60 @@ will inline the `LBU + BEQ 0x5b` check.
 cases PASS. `scripts/check-progress.sh` exits 0. Legacy
 `scripts/codegen-opcodes-check.sh` also exits 0. Pre-existing
 scripts unchanged.
+
+### M15.5 — JUMPDEST-validity check (Level 1) — **DONE (2026-06-02)**
+
+Closes the M15 known limitation (JUMP/JUMPI unconditionally followed the
+popped destination). A spec-compliant EVM exceptionally halts on a jump to
+a non-JUMPDEST byte; this adds that check. Numbered M15.5 (the follow-on the
+M15 section + the `ControlFlow/Program.lean` docstring both promised) to avoid
+colliding with the M26–M29 numbers reserved for the stateless-track roadmap.
+
+**Scope — Level 1 (`code[dest] == 0x5b` byte check).** Rejects jumps to any
+non-JUMPDEST byte. **Level 2 (deferred):** a `0x5b` inside PUSH immediate data
+is still wrongly accepted; full compliance needs a pushdata-aware
+valid-jumpdest bitmap built by scanning the bytecode at dispatch entry — a
+separate, larger slice. Level 1 already eliminates the dangerous
+"follow garbage past the bytecode into `.data`" cases.
+
+**Dual-use.** The byte *load* lives in the verified `evm_jump`/`evm_jumpi`
+bodies, so the stateless guest's VM (which is designed to plug in these
+bodies) inherits it; only the host-specific halt *routing* is in the codegen
+handler tail.
+
+**Delivered:**
+- **`EvmAsm/Evm64/ControlFlow/Program.lean`** — `evm_jump` (3→4 instr) and
+  `evm_jumpi` (13→15 instr) gain a `validityReg` parameter. `evm_jump` appends
+  `LBU validityReg, 0(x10)` (load `code[dest]`). `evm_jumpi` loads `code[dest]`
+  on the *taken* path and writes the sentinel `0x5b` into `validityReg` on the
+  *not-taken* path (so the downstream check is a no-op for fall-through); the
+  two internal offsets are re-pinned (`BEQ` 12→16, `JAL` 8→12). No specs to
+  update — these bodies have no `cpsTriple` proofs yet.
+- **`EvmAsm/Codegen/Programs/Evm.lean`** — `controlFlowHandlers` passes `.x17`
+  as `validityReg` and swaps JUMP/JUMPI's `.custom "  ret"` tails for the
+  shared `jumpValidityTail` (`li x18, 0x5b ; bne x17, x18, .exit_invalid ;
+  ret`). `x17`/`x18` are free scratch.
+- **`EvmAsm/Codegen/Dispatch.lean`** — `emitDispatcherEpilogue` gains an
+  `.exit_invalid:` label that zero-fills `OUTPUT[0..32]` and tags
+  `halt_kind = 4` (distinct from 0=STOP / 1=RETURN / 2=REVERT, M23) then joins
+  `.exit_no_epilogue`. Reached only via `j .exit_invalid`; placed so it never
+  falls through into `exitBody`.
+- **`EvmAsm/Codegen/Tests/Cases.lean`** — `jump_invalid_dest` (`PUSH1 0x00;
+  JUMP` → `code[0]=0x60≠0x5b`) and `jumpi_taken_invalid` (taken JUMPI to byte 0)
+  both assert `halt_kind = 4` + zero result; `jumpi_not_taken` gains a
+  `halt_kind = 0` assertion confirming the sentinel path doesn't spuriously
+  halt. Existing `jump_forward` / `jumpi_taken` (which jump to real JUMPDEST
+  bytes) still pass. Total cases 82 → 85.
+
+**Known limitations:** Level 2 (pushdata-aware bitmap) deferred. 256-bit `dest`
+still truncated to its low 64 bits (M15 caveat, unchanged). `RegistryInvariants`
+counts unchanged (149 — JUMP/JUMPI stay in `controlFlowHandlers`).
+
+**Exit criteria (met).**
+`scripts/codegen-opcodes-runtime-check.sh` exits 0 with all **85 cases PASS**
+(82 prior + `jump_invalid_dest` + `jumpi_taken_invalid` + the `jumpi_not_taken`
+halt-kind assertion). `scripts/check-progress.sh` exits 0. `lake build
+EvmAsm.Codegen` clean.
 
 ### M16 — KECCAK256 via ECALL bridge (first precompile pattern) — **DONE (2026-05-27)**
 

--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -225,6 +225,24 @@ def emitDispatcherEpilogue
   zkvmKeccak256Function ++ "\n" ++
   "h_invalid:\n" ++
   "  j .exit_label\n" ++
+  -- M15.5: invalid-jump exceptional halt. JUMP/JUMPI route here (via
+  -- `jumpValidityTail`'s `bne x17, x18, .exit_invalid`) when
+  -- code[dest] != 0x5b. Tag halt_kind = 4 — distinct from 0=STOP /
+  -- 1=RETURN / 2=REVERT (M23) — then join the universal exit. The
+  -- result bytes at OUTPUT[0..32] stay zero (no RETURN ran), which is
+  -- correct for an exceptional halt with no return data. Reached only
+  -- via `j .exit_invalid`; `h_invalid`'s `j .exit_label` above skips
+  -- this block, and it ends with `j .exit_no_epilogue` so it never
+  -- falls through into exitBody.
+  ".exit_invalid:\n" ++
+  "  li x16, 0xa0010000\n" ++       -- OUTPUT_ADDR
+  "  sd x0, 0(x16)\n" ++            -- zero-fill result OUTPUT[0..32]
+  "  sd x0, 8(x16)\n" ++            -- (no RETURN ran on this path, so
+  "  sd x0, 16(x16)\n" ++           --  surface empty return data
+  "  sd x0, 24(x16)\n" ++           --  deterministically)
+  "  li x17, 4\n" ++                -- halt_kind = 4 (invalid jump)
+  "  sd x17, 32(x16)\n" ++
+  "  j .exit_no_epilogue\n" ++
   ".exit_label:\n" ++
   emitProgram exitBody ++ "\n" ++
   ".exit_no_epilogue:\n" ++

--- a/EvmAsm/Codegen/Programs/Evm.lean
+++ b/EvmAsm/Codegen/Programs/Evm.lean
@@ -600,6 +600,16 @@ def calldataHandlers : List OpcodeHandlerSpec :=
                    .x20 .x13 .x14 .x15 .x16 .x17 .x18 .x19
     , tail    := .advanceAndRet 1 } ]
 
+/-- Shared tail for JUMP / JUMPI: the verified body left `code[dest]`
+    (or the `0x5b` sentinel for a not-taken JUMPI) in `x17`. If it
+    isn't a JUMPDEST byte, route to `.exit_invalid` (M15.5 exceptional
+    halt); otherwise `ret` to the dispatch loop, which re-reads the
+    (now-validated) target byte. `x18` is a free scratch temp. -/
+private def jumpValidityTail : HandlerTail :=
+  .custom ("  li x18, 0x5b\n" ++
+           "  bne x17, x18, .exit_invalid\n" ++
+           "  ret")
+
 /-- M14 / M15 control-flow opcodes.
 
     - **JUMPDEST (0x5b, M14)** — no-op marker. Empty body +
@@ -620,11 +630,13 @@ def calldataHandlers : List OpcodeHandlerSpec :=
     registers `x14`/`x15`/`x16` are caller-saved per the existing
     convention.
 
-    **M15 known limitation**: JUMP / JUMPI do NOT validate the
-    destination is a JUMPDEST byte. A spec-compliant EVM rejects
-    invalid jumps; ours unconditionally follows them. Trusted test
-    programs only jump to real JUMPDESTs. A follow-on PR will
-    inline the `LBU + BEQ 0x5b` check. -/
+    **M15.5 JUMPDEST-validity (Level 1)**: JUMP / JUMPI now load
+    `code[dest]` into `x17` (the verified bodies do this; JUMPI's
+    not-taken path writes the sentinel `0x5b`). `jumpValidityTail`
+    compares `x17` to `0x5b` and routes a mismatch to the
+    dispatcher's `.exit_invalid` (exceptional halt, `halt_kind = 4`).
+    Level 2 (pushdata-aware bitmap) is still future work — see the
+    `ControlFlow/Program.lean` docstring. -/
 def controlFlowHandlers : List OpcodeHandlerSpec :=
   [ { label := "h_JUMPDEST"
     , opcodes := [0x5b]
@@ -632,12 +644,12 @@ def controlFlowHandlers : List OpcodeHandlerSpec :=
     , tail    := .advanceAndRet 1 }
   , { label := "h_JUMP"
     , opcodes := [0x56]
-    , body    := EvmAsm.Evm64.ControlFlow.evm_jump .x21 .x14
-    , tail    := .custom "  ret" }
+    , body    := EvmAsm.Evm64.ControlFlow.evm_jump .x21 .x14 .x17
+    , tail    := jumpValidityTail }
   , { label := "h_JUMPI"
     , opcodes := [0x57]
-    , body    := EvmAsm.Evm64.ControlFlow.evm_jumpi .x21 .x14 .x15 .x16
-    , tail    := .custom "  ret" }
+    , body    := EvmAsm.Evm64.ControlFlow.evm_jumpi .x21 .x14 .x15 .x16 .x17
+    , tail    := jumpValidityTail }
   , { label := "h_PC"
     , opcodes := [0x58]
     , body    := EvmAsm.Evm64.ControlFlow.evm_pc .x21 .x14

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -322,7 +322,26 @@ def opcodeTestCases : List OpcodeTestCase :=
     -- of jumping to the (out-of-bounds) dest.
     { name           := "jumpi_not_taken"
       bytecode       := "0x60, 0x00, 0x60, 0xff, 0x57, 0x60, 0x42, 0x00"
-      expectedOutHex := "4200000000000000000000000000000000000000000000000000000000000000" }
+      expectedOutHex := "4200000000000000000000000000000000000000000000000000000000000000"
+      -- M15.5: confirm the not-taken JUMPI sentinel path does NOT
+      -- spuriously trip the validity check — it halts normally (STOP,
+      -- halt_kind 0) with 0x42, not the invalid-jump halt_kind 4.
+      expectedHaltKind := "0000000000000000" }
+    -- ## M15.5 JUMPDEST-validity (Level 1): invalid jumps exceptionally
+    -- halt with halt_kind = 4 and empty (zero) return data.
+  , -- PUSH1 0x00; JUMP — dest = 0 → code[0] = 0x60 (PUSH1), not 0x5b.
+    -- Invalid jump → .exit_invalid → halt_kind 4, result = 0.
+    { name             := "jump_invalid_dest"
+      bytecode         := "0x60, 0x00, 0x56"
+      expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind := "0400000000000000" }
+  , -- PUSH1 0x01 (cond); PUSH1 0x00 (dest); JUMPI — cond != 0 so the
+    -- jump is taken to dest = 0; code[0] = 0x60, not 0x5b → invalid.
+    -- Exercises the JUMPI taken-path validity load (halt_kind 4).
+    { name             := "jumpi_taken_invalid"
+      bytecode         := "0x60, 0x01, 0x60, 0x00, 0x57"
+      expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind := "0400000000000000" }
     -- ## M16 hash opcode (KECCAK256 via ECALL bridge to Zisk accelerator)
     -- KECCAK256 pops offset (top of stack) and size (next word), hashes the
     -- memory[offset..offset+size] region, pushes the 32-byte digest.

--- a/EvmAsm/Evm64/ControlFlow/Program.lean
+++ b/EvmAsm/Evm64/ControlFlow/Program.lean
@@ -26,16 +26,27 @@
     nonzero (any bit in any of the 4 limbs set), behaves like JUMP.
     Otherwise advances `x10` by 1 (the JUMPI opcode is 1 byte).
 
-  ## Known limitation (M15)
+  ## JUMPDEST-validity (M15.5, Level 1)
 
-  These bodies do NOT validate that `dest` lands on a JUMPDEST byte
-  (`code[dest] == 0x5b`). A spec-compliant EVM rejects invalid jumps;
-  ours unconditionally follows them. The follow-on PR (M15.5 / M16)
-  will add the inline `LBU + BEQ 0x5b` check. For now we trust the
-  program — the codegen-side test cases all jump to real JUMPDEST
-  bytes.
+  `JUMP` / `JUMPI` now load `code[dest]` into `validityReg` (the
+  conditional-jump *taken* path of `JUMPI` does the load; the
+  *not-taken* path writes the sentinel `0x5b` so the same downstream
+  check is a no-op). The codegen handler tail compares `validityReg`
+  to `0x5b` and routes a mismatch to the dispatcher's exceptional-halt
+  path (`.exit_invalid`). Keeping only the byte *load* here (not the
+  branch-to-halt, which needs a host-specific label) lets the stateless
+  guest VM reuse these bodies with its own halt routing.
 
-  Slice planned under M15 of `CODEGEN.md`.
+  ### Remaining gap (Level 2)
+
+  This is a byte check, not a full JUMPDEST-validity analysis: a `0x5b`
+  byte that sits inside PUSH immediate data is *not* a legal jump target
+  but passes this check. Full compliance needs a valid-jumpdest bitmap
+  built by scanning the bytecode (accounting for PUSH1–32 operands) at
+  dispatch entry — a separate, larger slice. Level 1 already eliminates
+  the dangerous "follow garbage past the bytecode into `.data`" cases.
+
+  Slice planned under M15.5 of `CODEGEN.md`.
 -/
 
 import EvmAsm.Rv64.Program
@@ -62,15 +73,20 @@ def evm_pc (codeBaseReg tmpReg : Reg) : Program :=
     Pops the destination from the EVM stack (low 64 bits of the top
     256-bit word) and updates `x10 := codeBaseReg + dest`. The
     dispatcher loop resumes at the new PC.
-    `destReg` is a caller-saved temporary distinct from `x0`, `x10`,
-    `x12`, `codeBaseReg`. 3 instructions = 12 bytes.
+    `destReg` / `validityReg` are caller-saved temporaries distinct from
+    `x0`, `x10`, `x12`, `codeBaseReg` (and each other). 4 instructions
+    = 16 bytes.
+
+    The trailing `LBU validityReg, 0(x10)` loads `code[dest]` for the
+    JUMPDEST-validity check; the handler tail compares it to `0x5b`.
 
     Upper 3 limbs of the popped word are ignored (assumes `dest <
     2^64`, which holds for any realistic EVM bytecode). -/
-def evm_jump (codeBaseReg destReg : Reg) : Program :=
+def evm_jump (codeBaseReg destReg validityReg : Reg) : Program :=
   LD destReg .x12 0 ;;
   ADDI .x12 .x12 32 ;;
-  ADD .x10 codeBaseReg destReg
+  ADD .x10 codeBaseReg destReg ;;
+  LBU validityReg .x10 0
 
 /-- Parameterized RISC-V program implementing `JUMPI` (0x57).
     Pops `dest` (top of stack) and `cond` (second). If `cond` is
@@ -78,16 +94,22 @@ def evm_jump (codeBaseReg destReg : Reg) : Program :=
     `x10 := codeBaseReg + dest`. Otherwise advances `x10` by 1
     (fall-through).
 
-    `destReg`, `condReg`, `tmpReg` are pairwise distinct caller-saved
-    temporaries, also distinct from `x0`, `x10`, `x12`, `codeBaseReg`.
-    13 instructions = 52 bytes.
+    `destReg`, `condReg`, `tmpReg`, `validityReg` are pairwise distinct
+    caller-saved temporaries, also distinct from `x0`, `x10`, `x12`,
+    `codeBaseReg`. 15 instructions = 60 bytes.
 
-    Branch offsets:
-    - `BEQ condReg x0 12` skips ADD + JAL (2 instructions, 8 bytes)
-      → lands at the fall-through ADDI.
-    - `JAL x0 8` skips ADDI (1 instruction, 4 bytes) → lands just
-      past the body (the handler's `ret` tail). -/
-def evm_jumpi (codeBaseReg destReg condReg tmpReg : Reg) : Program :=
+    JUMPDEST-validity: the *taken* path loads `code[dest]` into
+    `validityReg`; the *not-taken* path writes the sentinel `0x5b` so
+    the handler tail's `validityReg == 0x5b` check is a no-op for
+    fall-through. The handler tail does the compare + halt routing.
+
+    Branch offsets (re-pinned for the two extra instructions):
+    - `BEQ condReg x0 16` skips ADD + LBU + JAL (3 instructions,
+      12 bytes) → lands at the fall-through `ADDI x10`.
+    - `JAL x0 12` skips the two not-taken instrs (`ADDI x10` +
+      `ADDI validityReg`, 8 bytes) → lands just past the body (the
+      handler's tail). -/
+def evm_jumpi (codeBaseReg destReg condReg tmpReg validityReg : Reg) : Program :=
   LD destReg .x12 0 ;;
   LD condReg .x12 32 ;;
   LD tmpReg .x12 40 ;;
@@ -97,10 +119,12 @@ def evm_jumpi (codeBaseReg destReg condReg tmpReg : Reg) : Program :=
   LD tmpReg .x12 56 ;;
   OR' condReg condReg tmpReg ;;
   ADDI .x12 .x12 64 ;;
-  BEQ condReg .x0 (BitVec.ofNat 13 12) ;;
+  BEQ condReg .x0 (BitVec.ofNat 13 16) ;;
   ADD .x10 codeBaseReg destReg ;;
-  JAL .x0 (BitVec.ofNat 21 8) ;;
-  ADDI .x10 .x10 1
+  LBU validityReg .x10 0 ;;
+  JAL .x0 (BitVec.ofNat 21 12) ;;
+  ADDI .x10 .x10 1 ;;
+  ADDI validityReg .x0 (BitVec.ofNat 12 0x5b)
 
 end ControlFlow
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Closes the **M15 known limitation**: JUMP (0x56) / JUMPI (0x57) *unconditionally* followed the popped destination (flagged in `EvmAsm/Evm64/ControlFlow/Program.lean` and the M15 CODEGEN.md section). A spec-compliant EVM exceptionally halts on a jump to a non-JUMPDEST byte — this adds that check (**Level 1**).

Numbered **M15.5** (the follow-on the M15 section and the `ControlFlow/Program.lean` docstring both promised) to avoid colliding with the M26–M29 numbers reserved for the stateless-track roadmap.

## Design

The check must fire **only when a jump is actually taken** — JUMPI's fall-through must not validate the next instruction. The verified bodies leave `code[dest]` in a **validity register (`x17`)**; JUMPI's *not-taken* path writes the sentinel `0x5b` so a single uniform handler tail works for both. Routing the failure to an exceptional halt is raw asm (a label `j`, which has range — a `BNE` to a far global label would blow RISC-V's ±4 KiB branch range across the 149-handler epilogue).

**Dual-use:** the byte *load* lives in the verified `evm_jump`/`evm_jumpi` bodies, so the stateless guest's VM (`EvmAsm/Stateless/VM/Interpreter.lean`, designed to plug in these bodies) inherits it; only the host-specific halt *routing* is in the codegen handler tail.

## Changes

- **`EvmAsm/Evm64/ControlFlow/Program.lean`** — add a `validityReg` parameter. `evm_jump` (3→4 instr) appends `LBU validityReg, 0(x10)`. `evm_jumpi` (13→15 instr) loads `code[dest]` on the taken path and writes the `0x5b` sentinel on the not-taken path; the two internal offsets are re-pinned (`BEQ` 12→16, `JAL` 8→12). No specs to update — these bodies have no `cpsTriple` proofs.
- **`EvmAsm/Codegen/Programs/Evm.lean`** — `controlFlowHandlers` passes `.x17`; JUMP/JUMPI's `.custom "  ret"` tails become the shared `jumpValidityTail` (`li x18, 0x5b ; bne x17, x18, .exit_invalid ; ret`).
- **`EvmAsm/Codegen/Dispatch.lean`** — `emitDispatcherEpilogue` gains `.exit_invalid`: zero-fills `OUTPUT[0..32]` and tags `halt_kind = 4` (distinct from 0=STOP / 1=RETURN / 2=REVERT, M23) then joins `.exit_no_epilogue`. Reached only via `j .exit_invalid`; placed so it never falls through into `exitBody`.
- **`EvmAsm/Codegen/Tests/Cases.lean`** — `jump_invalid_dest` (`PUSH1 0x00; JUMP` → `code[0]=0x60≠0x5b`) and `jumpi_taken_invalid` (taken JUMPI to byte 0) assert `halt_kind = 4` + zero result; `jumpi_not_taken` gains a `halt_kind = 0` assertion proving the sentinel path doesn't spuriously halt. 82 → 85 cases.

## Scope / limitation

**Level 1** = byte check (`code[dest] == 0x5b`). **Level 2 (deferred):** a `0x5b` inside PUSH immediate data is still wrongly accepted; full compliance needs a pushdata-aware valid-jumpdest bitmap built by scanning the bytecode at dispatch entry — a separate, larger slice. Level 1 already eliminates the dangerous "follow garbage past the bytecode into `.data`" cases. (256-bit `dest`→low-64-bit truncation is the unchanged M15 caveat.)

## Tests

- `scripts/codegen-opcodes-runtime-check.sh`: **85/85 PASS** — valid jumps (`jump_forward`, `jumpi_taken`) still work; both new invalid cases halt with `halt_kind = 4`.
- `scripts/check-progress.sh` exits 0; `lake build EvmAsm.Codegen` clean; `RegistryInvariants` counts unchanged (149).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
