### PR TITLE
feat(env): load simple context opcodes from runtime input

### DIFF
--- a/EvmAsm/Codegen/Cli.lean
+++ b/EvmAsm/Codegen/Cli.lean
@@ -118,19 +118,19 @@ def main (args : List String) : IO UInt32 := do
           -- as long as it uses `read -r name expected` (extra fields
           -- just get dropped).
           for tc in Tests.opcodeTestCases do
-            -- M21..M28: 12-column TSV. Columns:
+            -- M21..M29: 13-column TSV. Columns:
             --   1 name, 2 expectedOutHex, 3 bytecode, 4 calldata,
-            --   5 storage, 6 blobBaseFee,
-            --   7 expectedHaltKind,
-            --   8 expectedPersistentLogLength (M24),
-            --   9 expectedTransientLogLength (M24),
-            --   10 expectedPostStorage (M25 — slot data at OUTPUT+56),
-            --   11 expectedEventLogCount (M26 — OUTPUT+56),
-            --   12 expectedEventLogFirst (M26 — descriptor at OUTPUT+64).
+            --   5 storage, 6 blobBaseFee, 7 env,
+            --   8 expectedHaltKind,
+            --   9 expectedPersistentLogLength (M24),
+            --   10 expectedTransientLogLength (M24),
+            --   11 expectedPostStorage (M25 — slot data at OUTPUT+56),
+            --   12 expectedEventLogCount (M26 — OUTPUT+56),
+            --   13 expectedEventLogFirst (M26 — descriptor at OUTPUT+64).
             -- All cols beyond 3 are optional; the bash runner asserts
             -- only the ones with non-empty values.
             IO.println
-              s!"{tc.name}\t{tc.expectedOutHex}\t{tc.bytecode}\t{tc.calldata}\t{tc.storage}\t{tc.blobBaseFee}\t{tc.expectedHaltKind}\t{tc.expectedPersistentLogLength}\t{tc.expectedTransientLogLength}\t{tc.expectedPostStorage}\t{tc.expectedEventLogCount}\t{tc.expectedEventLogFirst}"
+              s!"{tc.name}\t{tc.expectedOutHex}\t{tc.bytecode}\t{tc.calldata}\t{tc.storage}\t{tc.blobBaseFee}\t{tc.env}\t{tc.expectedHaltKind}\t{tc.expectedPersistentLogLength}\t{tc.expectedTransientLogLength}\t{tc.expectedPostStorage}\t{tc.expectedEventLogCount}\t{tc.expectedEventLogFirst}"
           return 0
       | .program => do
           match lookupProgram opts.target with

--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -513,6 +513,22 @@ def emitRuntimeDispatcherPrologue : String :=
   "  sd x8, 528(x20)\n" ++
   "  ld x8, 24(x5)\n" ++
   "  sd x8, 536(x20)\n" ++
+  -- M29: the optional simple-env trailer follows BLOBBASEFEE and
+  -- carries 13 contiguous 32-byte slots matching `EvmEnv` layout
+  -- offsets 0..415: ADDRESS, SELFBALANCE, CALLER, CALLVALUE, ORIGIN,
+  -- GASPRICE, COINBASE, TIMESTAMP, NUMBER, PREVRANDAO, GASLIMIT,
+  -- BASEFEE, CHAINID. Copying all 416 bytes preserves zero defaults
+  -- when the packer emits its default all-zero trailer.
+  "  addi x5, x5, 32\n" ++         -- x5 = simple-env trailer start
+  "  mv x6, x20\n" ++              -- x6 = evm_env destination
+  "  li x7, 52\n" ++               -- 13 words × 4 dwords
+  ".env_trailer_copy_loop:\n" ++
+  "  ld x8, 0(x5)\n" ++
+  "  sd x8, 0(x6)\n" ++
+  "  addi x5, x5, 8\n" ++
+  "  addi x6, x6, 8\n" ++
+  "  addi x7, x7, -1\n" ++
+  "  bnez x7, .env_trailer_copy_loop\n" ++
   ".dispatch_loop:\n" ++
   "  lbu x5, 0(x10)\n" ++
   "  la x6, opcode_handlers\n" ++

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -46,6 +46,12 @@ structure OpcodeTestCase where
       the runtime input packer serializes it in EVM-stack byte order.
       Empty string = zero blob base fee. -/
   blobBaseFee    : String := ""
+  /-- Optional simple environment values (M29). Format is comma- or
+      whitespace-separated `field=hex` pairs accepted by
+      `scripts/pack-bytecode.py --env`, e.g.
+      `"caller=0x1234,timestamp=0x2a"`. Empty string = every simple
+      env opcode reads zero, preserving the pre-M29 behavior. -/
+  env            : String := ""
   /-- Optional expected halt-kind at `OUTPUT_ADDR + 32` (M23).
       16 hex chars = 8-byte LE u64 (e.g. `"0100000000000000"` for
       RETURN = 1, `"0200000000000000"` for REVERT = 2). Empty
@@ -268,6 +274,24 @@ def opcodeTestCases : List OpcodeTestCase :=
     { name           := "env_field_offset_distinct"
       bytecode       := "0x42, 0x43, 0x03, 0x00"
       expectedOutHex := "0000000000000000000000000000000000000000000000000000000000000000" }
+  , -- CALLER; STOP with nonzero runtime env. The packer appends the
+    -- M29 simple-env trailer and the runtime dispatcher copies it into
+    -- evm_env before executing bytecode.
+    { name           := "caller_from_input_env"
+      bytecode       := "0x33, 0x00"
+      expectedOutHex := "3412000000000000000000000000000000000000000000000000000000000000"
+      env            := "caller=0x1234" }
+  , -- TIMESTAMP; STOP with nonzero runtime env.
+    { name           := "timestamp_from_input_env"
+      bytecode       := "0x42, 0x00"
+      expectedOutHex := "2a00000000000000000000000000000000000000000000000000000000000000"
+      env            := "timestamp=0x2a" }
+  , -- BASEFEE; STOP with nonzero runtime env. This is distinct from
+    -- BLOBBASEFEE's separate M28 trailer slot at env+512.
+    { name           := "basefee_from_input_env"
+      bytecode       := "0x48, 0x00"
+      expectedOutHex := "efbe000000000000000000000000000000000000000000000000000000000000"
+      env            := "base_fee=0xbeef" }
     -- ## M13 calldata-context opcode (CALLDATASIZE)
     -- The calldata-length cell at evm_env + 424 is zero-initialised by the
     -- dispatcher's .data section, so CALLDATASIZE pushes 32 zero bytes.

--- a/scripts/codegen-opcodes-check.sh
+++ b/scripts/codegen-opcodes-check.sh
@@ -58,14 +58,15 @@ FAILED=()
 SKIPPED=0
 # `--list-test-cases` emits TSV with optional runtime-input columns.
 # This legacy runner bakes bytecode into `.data` and has no input
-# trailer, so it skips cases that require calldata, storage preload, or
-# nonzero blob-base-fee input.
+# trailer, so it skips cases that require calldata, storage preload,
+# nonzero blob-base-fee input, or nonzero simple-env input.
 while IFS= read -r line; do
   name=$(printf '%s' "$line" | cut -f1)
   expected=$(printf '%s' "$line" | cut -f2)
   calldata=$(printf '%s' "$line" | cut -f4)
   storage=$(printf '%s' "$line" | cut -f5)
   blob_base_fee=$(printf '%s' "$line" | cut -f6)
+  env=$(printf '%s' "$line" | cut -f7)
   if [[ -z "$name" || -z "$expected" ]]; then
     echo
     echo "==> SKIP: malformed --list-test-cases line"
@@ -73,7 +74,7 @@ while IFS= read -r line; do
     continue
   fi
 
-  if [[ -n "${calldata:-}" || -n "${storage:-}" || -n "${blob_base_fee:-}" ]]; then
+  if [[ -n "${calldata:-}" || -n "${storage:-}" || -n "${blob_base_fee:-}" || -n "${env:-}" ]]; then
     echo
     echo "==> SKIP: $name requires runtime input trailer"
     SKIPPED=$((SKIPPED + 1))

--- a/scripts/codegen-opcodes-runtime-check.sh
+++ b/scripts/codegen-opcodes-runtime-check.sh
@@ -70,7 +70,7 @@ while IFS= read -r line; do
   # (tab is treated as IFS-whitespace), which silently shifts the
   # storage column into the calldata slot when calldata is empty.
   # `cut -f` preserves empty fields, so we slice each column
-  # explicitly. Order matches `--list-test-cases` 12-column TSV
+  # explicitly. Order matches `--list-test-cases` 13-column TSV
   # (M23 added col 6; M24 added cols 7 and 8 for the log-length
   # assertions; M25 added col 9 for the post-state slot dump; M26
   # added cols 10 and 11 for receipt event-log capture).
@@ -80,12 +80,13 @@ while IFS= read -r line; do
   calldata=$(printf '%s' "$line" | cut -f4)
   storage=$(printf '%s' "$line" | cut -f5)
   blob_base_fee=$(printf '%s' "$line" | cut -f6)
-  expected_halt_kind=$(printf '%s' "$line" | cut -f7)
-  expected_persistent_log_length=$(printf '%s' "$line" | cut -f8)
-  expected_transient_log_length=$(printf '%s' "$line" | cut -f9)
-  expected_post_storage=$(printf '%s' "$line" | cut -f10)
-  expected_event_log_count=$(printf '%s' "$line" | cut -f11)
-  expected_event_log_first=$(printf '%s' "$line" | cut -f12)
+  env=$(printf '%s' "$line" | cut -f7)
+  expected_halt_kind=$(printf '%s' "$line" | cut -f8)
+  expected_persistent_log_length=$(printf '%s' "$line" | cut -f9)
+  expected_transient_log_length=$(printf '%s' "$line" | cut -f10)
+  expected_post_storage=$(printf '%s' "$line" | cut -f11)
+  expected_event_log_count=$(printf '%s' "$line" | cut -f12)
+  expected_event_log_first=$(printf '%s' "$line" | cut -f13)
 
   if [[ -z "$name" || -z "$expected" || -z "$bytecode_csv" ]]; then
     echo
@@ -110,6 +111,9 @@ while IFS= read -r line; do
   fi
   if [[ -n "${blob_base_fee:-}" ]]; then
     pack_args+=(--blob-base-fee "$blob_base_fee")
+  fi
+  if [[ -n "${env:-}" ]]; then
+    pack_args+=(--env "$env")
   fi
   "$PYTHON" scripts/pack-bytecode.py ${pack_args[@]+"${pack_args[@]}"} "$bytecode_csv" "gen-out/$name.input"
 

--- a/scripts/pack-bytecode.py
+++ b/scripts/pack-bytecode.py
@@ -22,11 +22,18 @@ M28 extension: optionally append a fourth segment carrying the
 BLOBBASEFEE value as one EVM stack word. The dispatcher prologue copies
 it into `evm_env`; opcode 0x4a reads it from there. Defaults to zero.
 
+M29 extension: optionally append a fifth segment carrying the 13 simple
+environment opcode words in `EvmEnv` 32-byte slot order. The dispatcher
+prologue copies those words into `evm_env` so ADDRESS, ORIGIN, CALLER,
+CALLVALUE, GASPRICE, COINBASE, TIMESTAMP, NUMBER, PREVRANDAO, GASLIMIT,
+CHAINID, SELFBALANCE, and BASEFEE can read nonzero runtime values.
+
 Usage:
     pack-bytecode.py "0x60, 0x02, 0x60, 0x0a, 0x04, 0x00" output.bin
     pack-bytecode.py --calldata "0xdeadbeef" "0x36, 0x00" output.bin
     pack-bytecode.py --storage "(0x00, 0xdead)" "0x60, 0x00, 0x54, 0x00" output.bin
     pack-bytecode.py --blob-base-fee 0x1234 "0x4a, 0x00" output.bin
+    pack-bytecode.py --env "caller=0x1234,timestamp=0x2a" "0x33, 0x00" output.bin
     echo "0x60, 0x00" | pack-bytecode.py - output.bin
 
 Output layout:
@@ -41,6 +48,7 @@ Output layout:
     following          <slot_count × 64-byte (key, value)>   (M22)
                        <zero pad to 8-byte boundary>
     next 32 bytes      <blob_base_fee as EVM stack word>      (M28)
+    next 416 bytes     <13 simple env words in evm_env order> (M29)
 
 ziskemu prepends 8 more bytes of its own metadata when loading,
 landing the bytecode-length prefix at INPUT_ADDR+8 and the bytecode
@@ -56,11 +64,49 @@ a zero-length calldata segment appended, which preserves the M17
 Pre-M22 callers that don't pass --storage get a zero-length storage
 segment appended (SLOAD returns 0, SSTORE appends to an empty table).
 Pre-M28 callers that don't pass --blob-base-fee get a zero word.
+Pre-M29 callers that don't pass --env get zero words for every simple
+environment opcode.
 """
 import argparse
 import re
 import struct
 import sys
+
+ENV_FIELDS = [
+    "address",
+    "self_balance",
+    "caller",
+    "call_value",
+    "origin",
+    "gas_price",
+    "coinbase",
+    "timestamp",
+    "number",
+    "prevrandao",
+    "gas_limit",
+    "base_fee",
+    "chain_id",
+]
+
+ENV_ALIASES = {
+    "selfbalance": "self_balance",
+    "self_balance": "self_balance",
+    "callvalue": "call_value",
+    "call_value": "call_value",
+    "tx_origin": "origin",
+    "gasprice": "gas_price",
+    "gas_price": "gas_price",
+    "prev_randao": "prevrandao",
+    "prevrandao": "prevrandao",
+    "gaslimit": "gas_limit",
+    "gas_limit": "gas_limit",
+    "basefee": "base_fee",
+    "base_fee": "base_fee",
+    "chainid": "chain_id",
+    "chain_id": "chain_id",
+}
+
+ENV_ALIASES.update({field: field for field in ENV_FIELDS})
 
 
 def parse_csv(csv: str) -> bytes:
@@ -126,6 +172,32 @@ def parse_storage(storage_arg: str) -> list[tuple[bytes, bytes]]:
     return out
 
 
+def parse_env(env_arg: str) -> dict[str, bytes]:
+    """Parse a simple-env trailer spec into field -> stack-word bytes.
+
+    Supported form: comma- or whitespace-separated `field=0xVALUE` pairs.
+    Field names accept opcode-style spellings (`CALLVALUE`, `SELFBALANCE`)
+    and snake_case names (`call_value`, `self_balance`).
+    """
+    s = env_arg.strip()
+    if not s:
+        return {}
+    out: dict[str, bytes] = {}
+    for item in re.split(r"[\s,]+", s):
+        if not item:
+            continue
+        if "=" not in item:
+            raise ValueError(f"bad --env item {item!r}; expected field=0xVALUE")
+        raw_name, raw_value = item.split("=", 1)
+        key = raw_name.strip().lower().replace("-", "_")
+        field = ENV_ALIASES.get(key)
+        if field is None:
+            known = ", ".join(ENV_FIELDS)
+            raise ValueError(f"unknown --env field {raw_name!r}; known fields: {known}")
+        out[field] = _to_stack_bytes(raw_value)
+    return out
+
+
 def _to_stack_bytes(hex_blob: str) -> bytes:
     """Decode a hex blob (with optional 0x prefix) as a u256 integer
     and serialize as 32 bytes in EVM-stack representation: 4 LE u64
@@ -177,6 +249,15 @@ def main() -> int:
         help="Optional BLOBBASEFEE value as a u256 hex integer. Serialized "
              "in EVM-stack byte order. Defaults to zero.",
     )
+    parser.add_argument(
+        "--env",
+        default="",
+        help="Optional simple environment values as comma- or whitespace-"
+             "separated field=hex pairs, e.g. 'caller=0x1234,timestamp=0x2a'. "
+             "Fields are address, self_balance, caller, call_value, origin, "
+             "gas_price, coinbase, timestamp, number, prevrandao, gas_limit, "
+             "base_fee, chain_id. Defaults to zero for every field.",
+    )
     args = parser.parse_args()
 
     csv = sys.stdin.read() if args.bytecode == "-" else args.bytecode
@@ -184,6 +265,8 @@ def main() -> int:
     calldata = parse_calldata(args.calldata)
     storage_pairs = parse_storage(args.storage)
     blob_base_fee = _to_stack_bytes(args.blob_base_fee) if args.blob_base_fee.strip() else b"\x00" * 32
+    env_words = {field: b"\x00" * 32 for field in ENV_FIELDS}
+    env_words.update(parse_env(args.env))
 
     # Bytecode segment: 8B LE length prefix + bytes, padded to 8-byte boundary
     # so the calldata-length cell that follows is aligned.
@@ -206,6 +289,10 @@ def main() -> int:
     # M28 blob-context trailer: 32-byte BLOBBASEFEE word in stack
     # representation. It is naturally 8-byte aligned after the storage segment.
     packed += blob_base_fee
+
+    # M29 simple environment trailer: 13 stack words in `evm_env` layout order.
+    for field in ENV_FIELDS:
+        packed += env_words[field]
 
     if args.output == "-":
         sys.stdout.buffer.write(packed)


### PR DESCRIPTION
## Summary
- extend `pack-bytecode.py` with an optional simple-env trailer for the 13 context opcode words
- copy that trailer into `evm_env` in the runtime dispatcher before opcode execution
- add nonzero CALLER, TIMESTAMP, and BASEFEE runtime opcode checks while keeping the baked runner skip behavior

Bead: evm-asm-fhsxz.2.4.2.60.5.2.

## Verification
- `python3 -m py_compile scripts/pack-bytecode.py`
- `bash -n scripts/codegen-opcodes-runtime-check.sh && bash -n scripts/codegen-opcodes-check.sh`
- `lake build codegen`
- focused runtime env cases: CALLER, TIMESTAMP, BASEFEE
- `scripts/codegen-opcodes-runtime-check.sh`
- `scripts/codegen-opcodes-check.sh`
- `git diff --check`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Dispatch.lean EvmAsm/Codegen/Tests/Cases.lean EvmAsm/Codegen/Cli.lean scripts/pack-bytecode.py scripts/codegen-opcodes-runtime-check.sh scripts/codegen-opcodes-check.sh`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`

Authored by @pirapira; implemented by Codex.