### PR TITLE
feat(codegen): gas metering first slice (M30) — per-opcode static cost + out-of-gas

### DIFF
--- a/CODEGEN.md
+++ b/CODEGEN.md
@@ -1604,8 +1604,9 @@ OUTPUT_ADDR (0xa0010000):
               3 = INVALID (0xfe)            — M23.5
               4 = invalid JUMP/JUMPI dest   — M15.5
               5 = SELFDESTRUCT (0xff)       — M23.5
+              6 = out-of-gas                — M30
               (M23 originally left INVALID/SELFDESTRUCT at 0; M15.5 added
-               4, M23.5 added 3/5 — all six kinds are now distinct.)
+               4, M23.5 added 3/5, M30 added 6 — all distinct.)
   +40..256  <unused, room for future surfaces>
 ```
 
@@ -1758,6 +1759,51 @@ SELFDESTRUCT is a normal halt (success=true); both have empty return data.
 (all six halt kinds asserted distinct: RETURN=1, REVERT=2, INVALID=3,
 invalid-jump=4, SELFDESTRUCT=5, STOP=0). `scripts/check-progress.sh` exits 0.
 `lake build EvmAsm.Codegen` clean; `RegistryInvariants` unchanged (149).
+
+### M30 — Gas metering (first slice: static base costs) — **DONE (2026-06-02)**
+
+The first real gas metering in the dispatcher — the cross-cutting feature both
+tracks need (it lets out-of-gas reuse the M23.5 exceptional-halt machinery and
+is the bridge toward the `Stateless/VM/Interpreter.lean` integration).
+**Scope = static base costs only**; dynamic costs (memory expansion, cold/warm
+SLOAD, call stipend, per-word/byte/topic, SSTORE refunds) are deferred.
+
+**Design:** the gas counter is an env cell (`env+568`), not a register — every
+high register is transiently clobbered by some handler. The dispatch loop (both
+prologue variants) charges each opcode's static base cost before executing it;
+underflow routes to `.exit_outofgas` (`halt_kind = 6`). Charge-then-execute
+matches the spec's `charge_gas` order (so GAS reflects its own cost).
+
+**Delivered:**
+- **`Dispatch.lean`** — `staticGasCost : Nat → Nat` (EVM base-cost tiers from
+  `execution-specs/.../prague/vm/gas.py`; halts + unwired bytes = 0) emitted as
+  a 256-`.dword` `opcode_gas_costs:` table in both data sections; the
+  `.dispatch_loop` body looks up `cost = opcode_gas_costs[op]`, `bltu`s to
+  `.exit_outofgas` on underflow, else charges `env+568`. New gas cell at
+  `env+568` (`.zero 568→576`); runtime prologue reads the gas limit from the
+  input trailer, `.data`-baked prologue seeds 30,000,000.
+  `emitExceptionalExit ".exit_outofgas" 6`.
+- **`pack-bytecode.py`** — `--gas N` appends an 8-byte LE gas-limit trailer
+  (default 30,000,000; back-compatible).
+- **`Programs/Evm.lean`** — real `gasHandlers` (GAS 0x5a reads `env+568` and
+  pushes it); removed from `pushZeroHandlers`. `RegistryInvariants` unchanged
+  (149 — GAS only moved lists).
+- **Tests** — `gas_opcode_sufficient` (`GAS; STOP`, limit 1000 → 998 after the
+  charge), `gas_opcode_out_of_gas` (`PUSH1`, limit 2 → `halt_kind = 6`); new
+  `gasLimit` TSV column threaded through `Cli.lean` + the bash runner.
+
+**Limitations** (documented in `staticGasCost`): static base only — state ops
+(SLOAD/SSTORE/CALL/EXTCODE*/KECCAK/LOG/EXP/copies) under-charge; per-iteration
+cost lookup adds ~6 instrs/op; gas-used not yet surfaced at OUTPUT; MSIZE/memory
+gas unchanged. `Layout.lean`'s `envSize` remains stale vs the dispatcher's
+raw-offset env cells (pre-existing; a sync is a separate cleanup).
+
+**Exit criteria (met).**
+`scripts/codegen-opcodes-runtime-check.sh`: the two new gas cases pass and no
+prior case regresses. (Two BLOCKHASH cases — `blockhash_parent`,
+`blockhash_historical` — fail identically on pristine `upstream/main`; they are
+a **pre-existing** env-offset drift in the BLOCKHASH handler, unrelated to this
+PR.) `lake build EvmAsm.Codegen` clean.
 
 ### M24 — Storage on Option A: append-log + journal + real TLOAD/TSTORE — **DONE (2026-05-29)**
 

--- a/EvmAsm/Codegen/Cli.lean
+++ b/EvmAsm/Codegen/Cli.lean
@@ -118,7 +118,7 @@ def main (args : List String) : IO UInt32 := do
           -- as long as it uses `read -r name expected` (extra fields
           -- just get dropped).
           for tc in Tests.opcodeTestCases do
-            -- M21..M29: 16-column TSV. Columns:
+            -- M21..M30: 17-column TSV. Columns:
             --   1 name, 2 expectedOutHex, 3 bytecode, 4 calldata,
             --   5 storage, 6 blobBaseFee (M28), 7 blobHashes (M28),
             --   8 blockNumber (M29), 9 blockHashes (M29),
@@ -128,11 +128,12 @@ def main (args : List String) : IO UInt32 := do
             --   13 expectedTransientLogLength (M24),
             --   14 expectedPostStorage (M25 — slot data at OUTPUT+56),
             --   15 expectedEventLogCount (M26 — OUTPUT+56),
-            --   16 expectedEventLogFirst (M26 — descriptor at OUTPUT+64).
+            --   16 expectedEventLogFirst (M26 — descriptor at OUTPUT+64),
+            --   17 gasLimit (M30 — pack-bytecode.py --gas).
             -- All cols beyond 3 are optional; the bash runner asserts
             -- only the ones with non-empty values.
             IO.println
-              s!"{tc.name}\t{tc.expectedOutHex}\t{tc.bytecode}\t{tc.calldata}\t{tc.storage}\t{tc.blobBaseFee}\t{tc.blobHashes}\t{tc.blockNumber}\t{tc.blockHashes}\t{tc.env}\t{tc.expectedHaltKind}\t{tc.expectedPersistentLogLength}\t{tc.expectedTransientLogLength}\t{tc.expectedPostStorage}\t{tc.expectedEventLogCount}\t{tc.expectedEventLogFirst}"
+              s!"{tc.name}\t{tc.expectedOutHex}\t{tc.bytecode}\t{tc.calldata}\t{tc.storage}\t{tc.blobBaseFee}\t{tc.blobHashes}\t{tc.blockNumber}\t{tc.blockHashes}\t{tc.env}\t{tc.expectedHaltKind}\t{tc.expectedPersistentLogLength}\t{tc.expectedTransientLogLength}\t{tc.expectedPostStorage}\t{tc.expectedEventLogCount}\t{tc.expectedEventLogFirst}\t{tc.gasLimit}"
           return 0
       | .program => do
           match lookupProgram opts.target with

--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -108,6 +108,81 @@ def emitJumpTable (registry : List OpcodeHandlerSpec) : String :=
   "opcode_handlers:\n" ++
   String.intercalate "\n" entries
 
+/-- M30 (gas metering, first slice): the **static base** gas cost of each
+    EVM opcode byte, used by the dispatch loop to charge gas per instruction.
+
+    Sourced from the standard EVM gas tiers
+    (`execution-specs/src/ethereum/forks/prague/vm/gas.py`): ZERO=0,
+    JUMPDEST=1, BASE=2, VERYLOW=3, LOW=5, MID=8, HIGH=10, BLOCKHASH=20,
+    KECCAK256 base=30, LOG base=375, warm access=100, CREATE=32000.
+
+    **Static base costs only** — all *dynamic* components are dropped:
+    memory-expansion, copy (per-word), KECCAK/LOG per-word/per-topic, EXP
+    per-byte, and cold-access surcharges (SLOAD/BALANCE/EXTCODE*/CALL use
+    the warm floor of 100; SSTORE uses 100; cold +2600/+2100 not modeled).
+    So state-touching ops UNDER-charge — fine for the first slice, which
+    establishes the metering machinery; dynamic costs are a follow-up.
+
+    Halt opcodes (STOP/RETURN/REVERT/INVALID/SELFDESTRUCT) and every byte
+    not assigned a real opcode are 0, so trusted programs never spuriously
+    run out of gas on a terminator or an unwired byte. -/
+def staticGasCost (op : Nat) : Nat :=
+  if 0x60 ≤ op ∧ op ≤ 0x7f then 3        -- PUSH1..PUSH32 (VERYLOW)
+  else if 0x80 ≤ op ∧ op ≤ 0x8f then 3   -- DUP1..DUP16 (VERYLOW)
+  else if 0x90 ≤ op ∧ op ≤ 0x9f then 3   -- SWAP1..SWAP16 (VERYLOW)
+  else if 0xa0 ≤ op ∧ op ≤ 0xa4 then 375 -- LOG0..LOG4 (base)
+  else match op with
+    -- arithmetic
+    | 0x01 => 3 | 0x03 => 3                                  -- ADD, SUB
+    | 0x02 => 5 | 0x04 => 5 | 0x05 => 5 | 0x06 => 5 | 0x07 => 5  -- MUL,DIV,SDIV,MOD,SMOD
+    | 0x0b => 5                                              -- SIGNEXTEND
+    | 0x08 => 8 | 0x09 => 8                                  -- ADDMOD, MULMOD
+    | 0x0a => 10                                             -- EXP (base)
+    -- comparison & bitwise (all VERYLOW)
+    | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 => 3
+    | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a => 3
+    | 0x1b | 0x1c | 0x1d => 3
+    | 0x20 => 30                                             -- KECCAK256 (base)
+    -- environment / context
+    | 0x30 => 2 | 0x32 => 2 | 0x33 => 2 | 0x34 => 2 | 0x3a => 2  -- ADDRESS,ORIGIN,CALLER,CALLVALUE,GASPRICE
+    | 0x35 => 3                                              -- CALLDATALOAD (VERYLOW)
+    | 0x36 => 2 | 0x38 => 2 | 0x3d => 2                      -- CALLDATASIZE,CODESIZE,RETURNDATASIZE
+    | 0x37 => 3 | 0x39 => 3 | 0x3e => 3                      -- CALLDATACOPY,CODECOPY,RETURNDATACOPY (base)
+    | 0x31 => 100 | 0x3b => 100 | 0x3f => 100               -- BALANCE,EXTCODESIZE,EXTCODEHASH (warm floor)
+    | 0x3c => 100                                            -- EXTCODECOPY (warm floor, base)
+    | 0x40 => 20                                             -- BLOCKHASH
+    | 0x41 | 0x42 | 0x43 | 0x44 | 0x45 | 0x46 | 0x48 | 0x4a => 2  -- COINBASE..BASEFEE, BLOBBASEFEE
+    | 0x47 => 5                                              -- SELFBALANCE (LOW)
+    | 0x49 => 3                                              -- BLOBHASH
+    -- stack / memory / flow
+    | 0x50 => 2                                              -- POP (BASE)
+    | 0x51 | 0x52 | 0x53 => 3                                -- MLOAD,MSTORE,MSTORE8 (VERYLOW)
+    | 0x54 => 100 | 0x55 => 100                              -- SLOAD,SSTORE (warm/base; dynamic dropped)
+    | 0x56 => 8                                              -- JUMP (MID)
+    | 0x57 => 10                                             -- JUMPI (HIGH)
+    | 0x58 | 0x59 | 0x5a => 2                                -- PC,MSIZE,GAS (BASE)
+    | 0x5b => 1                                              -- JUMPDEST
+    | 0x5c => 100 | 0x5d => 100                              -- TLOAD,TSTORE
+    | 0x5e => 3                                              -- MCOPY (base)
+    | 0x5f => 2                                              -- PUSH0 (BASE)
+    -- child frames (base; dynamic call/create costs dropped)
+    | 0xf0 => 32000 | 0xf5 => 32000                          -- CREATE, CREATE2
+    | 0xf1 | 0xf2 | 0xf4 | 0xfa => 100                       -- CALL,CALLCODE,DELEGATECALL,STATICCALL
+    -- STOP (0x00), RETURN (0xf3), REVERT (0xfd), INVALID (0xfe),
+    -- SELFDESTRUCT (0xff), and all unwired bytes → 0.
+    | _ => 0
+
+/-- Render the 256-entry static gas-cost table (`opcode_gas_costs:`,
+    256 × `.dword`, 2 KiB) into the `.data` section. Indexed by
+    `opcode * 8` — the same index the dispatch loop computes for the
+    jump table. -/
+def emitGasCostTable : String :=
+  let entries :=
+    (List.range 256).map (fun b => s!"  .dword {staticGasCost b}")
+  ".balign 8\n" ++
+  "opcode_gas_costs:\n" ++
+  String.intercalate "\n" entries
+
 /-- Shared scratch for the CALL/STATICCALL precompile frame surface.
     Follow-up precompile bodies can write returndata bytes here before
     copying them into caller memory. Layout:
@@ -199,10 +274,26 @@ def emitDispatcherPrologue : String :=
   "  sd x0, 544(x20)\n" ++         -- M28: blobHashCount = 0
   "  sd x0, 552(x20)\n" ++         -- M29: currentBlockNumber = 0
   "  sd x0, 560(x20)\n" ++         -- M29: blockHashCount = 0
+  -- M30: .data-baked variant has no input gas limit; seed a large
+  -- constant so the per-opcode gas charge never spuriously runs out.
+  "  li x5, 30000000\n" ++
+  "  sd x5, 568(x20)\n" ++         -- env.gasRemaining = 30,000,000
   ".dispatch_loop:\n" ++
   "  lbu x5, 0(x10)\n" ++
+  "  slli x5, x5, 3\n" ++           -- x5 = opcode * 8 (index for both tables)
+  -- M30 gas charge: look up the opcode's static cost, charge it against
+  -- env.gasRemaining (env+568), and route to .exit_outofgas if it would
+  -- underflow. Charge-then-execute matches the spec's `charge_gas` order
+  -- (so e.g. GAS reflects its own cost already deducted). x6/x7 are
+  -- per-iteration scratch; x5 (opcode*8) survives for the dispatch below.
+  "  la x6, opcode_gas_costs\n" ++
+  "  add x6, x6, x5\n" ++
+  "  ld x6, 0(x6)\n" ++             -- x6 = static gas cost
+  "  ld x7, 568(x20)\n" ++          -- x7 = gas remaining
+  "  bltu x7, x6, .exit_outofgas\n" ++
+  "  sub x7, x7, x6\n" ++
+  "  sd x7, 568(x20)\n" ++          -- gasRemaining -= cost
   "  la x6, opcode_handlers\n" ++
-  "  slli x5, x5, 3\n" ++
   "  add x6, x6, x5\n" ++
   "  ld x7, 0(x6)\n" ++
   "  jalr x1, x7, 0\n" ++
@@ -263,9 +354,11 @@ def emitDispatcherEpilogue
   --                            (`jumpValidityTail`'s `bne … .exit_invalid`)
   --   .exit_invalid_op  (3) — M23.5 INVALID opcode (0xfe)
   --   .exit_selfdestruct(5) — M23.5 SELFDESTRUCT (0xff)
+  --   .exit_outofgas    (6) — M30 dispatch-loop gas underflow
   emitExceptionalExit ".exit_invalid" 4 ++
   emitExceptionalExit ".exit_invalid_op" 3 ++
   emitExceptionalExit ".exit_selfdestruct" 5 ++
+  emitExceptionalExit ".exit_outofgas" 6 ++
   ".exit_label:\n" ++
   emitProgram exitBody ++ "\n" ++
   ".exit_no_epilogue:\n" ++
@@ -410,8 +503,9 @@ def emitDispatcherDataSection
   "  .zero 0x8000\n" ++   -- 32 KiB EVM memory (M7 onward)
   ".balign 8\n" ++
   "evm_env:\n" ++
-  "  .zero 568\n" ++      -- 13 SimpleEnvField slots × 32 B + calldata/return-data
-                          -- + M22/M24/M26 log-state cells up to env+480
+  "  .zero 576\n" ++      -- 13 SimpleEnvField slots × 32 B + calldata/return-data
+                          -- + M22/M24/M26 log-state cells + M28/M29 blob/block
+                          -- cells (up to env+560) + M30 gasRemaining at env+568
                           -- + M28 BLOBBASEFEE word at env+512 (32 bytes)
                           -- + M28 blobHashCount at env+544
                           -- + M29 BLOCKHASH current/count at env+552/+560
@@ -442,6 +536,7 @@ def emitDispatcherDataSection
                           -- `sp+0..24` would scribble into the jump table.
                           -- h_EXP's preBody repoints `x2` here and its tail
                           -- restores `sp = lp64_sp_top`.
+  emitGasCostTable ++ "\n" ++
   emitJumpTable registry
 
 /-! ## Runtime-bytecode dispatcher (M8.5)
@@ -639,10 +734,27 @@ def emitRuntimeDispatcherPrologue : String :=
   "  addi x6, x6, 8\n" ++
   "  addi x7, x7, -1\n" ++
   "  bnez x7, .env_trailer_copy_loop\n" ++
+  -- M30: the final input segment is an 8-byte LE u64 gas limit, packed
+  -- after the env trailer by pack-bytecode.py (--gas, default 30M). x5
+  -- points just past the env trailer here.
+  "  ld x6, 0(x5)\n" ++
+  "  sd x6, 568(x20)\n" ++          -- env.gasRemaining = input gas limit
   ".dispatch_loop:\n" ++
   "  lbu x5, 0(x10)\n" ++
+  "  slli x5, x5, 3\n" ++           -- x5 = opcode * 8 (index for both tables)
+  -- M30 gas charge: look up the opcode's static cost, charge it against
+  -- env.gasRemaining (env+568), and route to .exit_outofgas if it would
+  -- underflow. Charge-then-execute matches the spec's `charge_gas` order
+  -- (so e.g. GAS reflects its own cost already deducted). x6/x7 are
+  -- per-iteration scratch; x5 (opcode*8) survives for the dispatch below.
+  "  la x6, opcode_gas_costs\n" ++
+  "  add x6, x6, x5\n" ++
+  "  ld x6, 0(x6)\n" ++             -- x6 = static gas cost
+  "  ld x7, 568(x20)\n" ++          -- x7 = gas remaining
+  "  bltu x7, x6, .exit_outofgas\n" ++
+  "  sub x7, x7, x6\n" ++
+  "  sd x7, 568(x20)\n" ++          -- gasRemaining -= cost
   "  la x6, opcode_handlers\n" ++
-  "  slli x5, x5, 3\n" ++
   "  add x6, x6, x5\n" ++
   "  ld x7, 0(x6)\n" ++
   "  jalr x1, x7, 0\n" ++
@@ -663,8 +775,9 @@ def emitRuntimeDispatcherDataSection
   "  .zero 0x8000\n" ++   -- 32 KiB EVM memory (M7 onward)
   ".balign 8\n" ++
   "evm_env:\n" ++
-  "  .zero 568\n" ++      -- 13 SimpleEnvField slots × 32 B + calldata/return-data
-                          -- + M22/M24/M26 log-state cells up to env+480
+  "  .zero 576\n" ++      -- 13 SimpleEnvField slots × 32 B + calldata/return-data
+                          -- + M22/M24/M26 log-state cells + M28/M29 blob/block
+                          -- cells (up to env+560) + M30 gasRemaining at env+568
                           -- + M28 BLOBBASEFEE word at env+512 (32 bytes)
                           -- + M28 blobHashCount at env+544
                           -- + M29 BLOCKHASH current/count at env+552/+560
@@ -695,6 +808,7 @@ def emitRuntimeDispatcherDataSection
                           -- `sp+0..24` would scribble into the jump table.
                           -- h_EXP's preBody repoints `x2` here and its tail
                           -- restores `sp = lp64_sp_top`.
+  emitGasCostTable ++ "\n" ++
   emitJumpTable registry
 
 /-- Build a runtime-bytecode `BuildUnit` for `registry` + `exitBody`.

--- a/EvmAsm/Codegen/Programs/Evm.lean
+++ b/EvmAsm/Codegen/Programs/Evm.lean
@@ -557,6 +557,26 @@ def memoryMetadataHandlers : List OpcodeHandlerSpec :=
         "  addi x10, x10, 1\n" ++
         "  ret" } ]
 
+/-- M30: GAS (0x5a) pushes the dispatcher-maintained remaining gas
+    (env+568, charged per-opcode by the dispatch loop). Mirrors the
+    MSIZE handler — read the env cell, push it as a 256-bit word (low
+    limb = remaining gas, high limbs 0). The loop charges GAS's own
+    cost (BASE = 2) *before* this handler runs, so the pushed value
+    already reflects it, matching EVM semantics. -/
+def gasHandlers : List OpcodeHandlerSpec :=
+  [ { label   := "h_GAS"
+      opcodes := [0x5a]
+      body    := []
+      tail    := .custom <|
+        "  addi x12, x12, -32\n" ++
+        "  ld x14, 568(x20)\n" ++       -- env.gasRemaining (M30)
+        "  sd x14, 0(x12)\n" ++
+        "  sd x0, 8(x12)\n" ++
+        "  sd x0, 16(x12)\n" ++
+        "  sd x0, 24(x12)\n" ++
+        "  addi x10, x10, 1\n" ++
+        "  ret" } ]
+
 /-- M12 simple environment opcodes (13 of them, one record each).
 
     All 13 share the verified body
@@ -1283,7 +1303,7 @@ def stopHandler : OpcodeHandlerSpec :=
     the list for a spec whose `opcodes` contains the byte. -/
 def tinyInterpRegistry : List OpcodeHandlerSpec :=
   pushHandlers ++ dupHandlers ++ swapHandlers ++ singletonHandlers ++
-  memoryHandlers ++ memoryMetadataHandlers ++ envHandlers ++
+  memoryHandlers ++ memoryMetadataHandlers ++ gasHandlers ++ envHandlers ++
   blobContextHandlers ++ blockHashHandlers ++ calldataHandlers ++
   controlFlowHandlers ++ hashHandlers ++ logHandlers ++
   storageHandlers ++ mcopyHandlers ++ haltHandlers ++ pushZeroHandlers ++

--- a/EvmAsm/Codegen/Programs/Noop.lean
+++ b/EvmAsm/Codegen/Programs/Noop.lean
@@ -10,7 +10,7 @@
 
   Four builders are exported:
   - `haltHandlers` — RETURN, REVERT, INVALID, SELFDESTRUCT
-  - `pushZeroHandlers` — CODESIZE, RETURNDATASIZE, GAS (MSIZE has a real implementation in Programs/Evm.lean)
+  - `pushZeroHandlers` — CODESIZE, RETURNDATASIZE (MSIZE and GAS have real implementations in Programs/Evm.lean)
   - `popPushZeroHandlers` — BALANCE, CALLDATALOAD, EXTCODESIZE,
     EXTCODEHASH (BLOBHASH and BLOCKHASH have real implementations in Programs/Evm.lean)
   - `copyNoopHandlers` — CALLDATACOPY, CODECOPY, EXTCODECOPY,
@@ -167,9 +167,11 @@ def haltHandlers : List OpcodeHandlerSpec :=
     , body := []
     , tail := .custom "  addi x12, x12, 32\n  j .exit_selfdestruct" } ]
 
-/-- M18 push-zero handlers (CODESIZE, RETURNDATASIZE, MSIZE, GAS).
+/-- M18 push-zero handlers (CODESIZE, RETURNDATASIZE).
     Each opcode pushes a single 32-byte zero value onto
     the EVM stack — no input, no output content.
+    (MSIZE and GAS graduated to real env-cell-reading handlers in
+    Programs/Evm.lean.)
 
     Body (5 instructions): decrement `x12` by 32 (push), then write
     four 8-byte zero limbs via `SD .x12 .x0 …`.
@@ -178,8 +180,7 @@ def haltHandlers : List OpcodeHandlerSpec :=
     - CODESIZE pushes 0 instead of the running code's length.
     - RETURNDATASIZE pushes 0 (no caller return-data buffer).
     - MSIZE pushes 0 (memory-expansion bookkeeping deferred to
-      issue #99).
-    - GAS pushes 0 (no gas metering in the dispatcher). -/
+      issue #99). -/
 def pushZeroHandlers : List OpcodeHandlerSpec :=
   let pushZeroBody : Program :=
     ADDI .x12 .x12 (-32) ;;
@@ -187,11 +188,11 @@ def pushZeroHandlers : List OpcodeHandlerSpec :=
     SD .x12 .x0 8 ;;
     SD .x12 .x0 16 ;;
     SD .x12 .x0 24
+  -- GAS (0x5a) graduated to a real handler in Programs/Evm.lean (M30) —
+  -- it pushes env.gasRemaining maintained by the dispatch-loop gas charge.
   [ { label := "h_CODESIZE", opcodes := [0x38]
     , body := pushZeroBody, tail := .advanceAndRet 1 }
   , { label := "h_RETURNDATASIZE", opcodes := [0x3d]
-    , body := pushZeroBody, tail := .advanceAndRet 1 }
-  , { label := "h_GAS", opcodes := [0x5a]
     , body := pushZeroBody, tail := .advanceAndRet 1 } ]
 
 /-- M18 pop-and-push-zero handlers (BALANCE, EXTCODESIZE, EXTCODEHASH).

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -113,6 +113,12 @@ structure OpcodeTestCase where
         - +224..256: CALLER context word
       Empty string = don't assert. -/
   expectedEventLogFirst : String := ""
+  /-- Optional gas limit (M30), decimal or 0x-hex, passed to
+      `pack-bytecode.py --gas`. Empty = use the packer default
+      (30,000,000). Set a small value to exercise the out-of-gas path
+      (the dispatch loop charges each opcode's static base cost; an
+      underflow halts with `expectedHaltKind = 6`). -/
+  gasLimit : String := ""
 
 /-- Registry of test cases. M5a/M5b's two original bytecodes are
     migrated as `add_basic` / `add_chain`; M6b adds ~20 more — one
@@ -521,11 +527,23 @@ def opcodeTestCases : List OpcodeTestCase :=
       bytecode         := "0x60, 0xff, 0xff"
       expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
       expectedHaltKind := "0500000000000000" }
-  , -- GAS; STOP — GAS pushes 0 (no gas metering); STOP halts.
-    -- Expected: 0 in low limb. Smoke test for pushZeroHandlers.
-    { name           := "gas_push_zero"
+  , -- ## M30 gas metering (first slice)
+    -- GAS; STOP with an explicit 1000-gas limit. The dispatch loop
+    -- charges GAS's own static cost (BASE = 2) BEFORE h_GAS runs, so
+    -- GAS pushes the post-charge remaining 998 = 0x3e6; STOP (cost 0)
+    -- surfaces it. (Replaces the pre-M30 `gas_push_zero` no-op test.)
+    { name           := "gas_opcode_sufficient"
       bytecode       := "0x5a, 0x00"
-      expectedOutHex := "0000000000000000000000000000000000000000000000000000000000000000" }
+      expectedOutHex := "e603000000000000000000000000000000000000000000000000000000000000"
+      gasLimit       := "1000" }
+  , -- PUSH1 0x01; STOP with a 2-gas limit. PUSH1's static cost is 3 > 2,
+    -- so the dispatch loop's gas charge underflows on the very first
+    -- opcode → out-of-gas exceptional halt (halt_kind = 6, zero result).
+    { name             := "gas_opcode_out_of_gas"
+      bytecode         := "0x60, 0x01, 0x00"
+      expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind := "0600000000000000"
+      gasLimit         := "2" }
   , -- BLOBBASEFEE; STOP with blob_base_fee = 0x1234. Amsterdam
     -- execution-specs computes this from block_env.excess_blob_gas;
     -- the runtime dispatcher receives the already-computed value in

--- a/scripts/codegen-opcodes-runtime-check.sh
+++ b/scripts/codegen-opcodes-runtime-check.sh
@@ -90,6 +90,7 @@ while IFS= read -r line; do
   expected_post_storage=$(printf '%s' "$line" | cut -f14)
   expected_event_log_count=$(printf '%s' "$line" | cut -f15)
   expected_event_log_first=$(printf '%s' "$line" | cut -f16)
+  gas_limit=$(printf '%s' "$line" | cut -f17)
 
   if [[ -z "$name" || -z "$expected" || -z "$bytecode_csv" ]]; then
     echo
@@ -126,6 +127,9 @@ while IFS= read -r line; do
   fi
   if [[ -n "${env:-}" ]]; then
     pack_args+=(--env "$env")
+  fi
+  if [[ -n "${gas_limit:-}" ]]; then
+    pack_args+=(--gas "$gas_limit")
   fi
   "$PYTHON" scripts/pack-bytecode.py ${pack_args[@]+"${pack_args[@]}"} "$bytecode_csv" "gen-out/$name.input"
 

--- a/scripts/pack-bytecode.py
+++ b/scripts/pack-bytecode.py
@@ -66,6 +66,7 @@ Output layout:
                        Hashes are passed as normal big-endian hex and
                        serialized in EVM-stack byte order.
     next 416 bytes     <13 simple env words in evm_env order>
+    next 8 bytes       <8-byte LE u64 gas limit>             (M30)
 
 ziskemu prepends 8 more bytes of its own metadata when loading,
 landing the bytecode-length prefix at INPUT_ADDR+8 and the bytecode
@@ -341,6 +342,14 @@ def main() -> int:
              "gas_price, coinbase, timestamp, number, prevrandao, gas_limit, "
              "base_fee, chain_id. Defaults to zero for every field.",
     )
+    parser.add_argument(
+        "--gas",
+        default="30000000",
+        help="Gas limit for the run (M30). Accepts decimal or 0x-prefixed "
+             "integer; must fit in u64. The dispatch loop charges each "
+             "opcode's static base cost against this; underflow halts with "
+             "halt_kind = 6. Defaults to 30,000,000.",
+    )
     args = parser.parse_args()
 
     csv = sys.stdin.read() if args.bytecode == "-" else args.bytecode
@@ -355,6 +364,9 @@ def main() -> int:
     block_hashes = parse_block_hashes(args.block_hashes)
     env_words = {field: b"\x00" * 32 for field in ENV_FIELDS}
     env_words.update(parse_env(args.env))
+    gas_limit = int(args.gas, 0)
+    if gas_limit < 0 or gas_limit > 0xFFFFFFFFFFFFFFFF:
+        raise ValueError("--gas must fit in u64")
 
     # Bytecode segment: 8B LE length prefix + bytes, padded to 8-byte boundary
     # so the calldata-length cell that follows is aligned.
@@ -391,6 +403,10 @@ def main() -> int:
     # M29 simple environment trailer: 13 stack words in `evm_env` layout order.
     for field in ENV_FIELDS:
         packed += env_words[field]
+
+    # M30 gas-limit trailer: 8B LE u64, read by the runtime prologue into
+    # env.gasRemaining (env+568). Keeps the file a multiple of 8.
+    packed += struct.pack("<Q", gas_limit)
 
     if args.output == "-":
         sys.stdout.buffer.write(packed)


### PR DESCRIPTION
## Summary

Adds the **first real gas metering** to the tiny-interpreter dispatcher — the cross-cutting feature both tracks need (out-of-gas reuses M23.5's exceptional-halt machinery, and it's the bridge toward the `Stateless/VM/Interpreter.lean` integration). The dispatch loop charges each opcode's static base cost against a gas counter; underflow halts with `halt_kind = 6`.

**Scope = static base costs only.** Dynamic costs (memory expansion, cold/warm SLOAD, call stipend, per-word/byte/topic, SSTORE refunds) are explicitly deferred to a follow-up.

## Design

- **Gas counter = env cell `env+568`**, not a register — every high register is transiently clobbered by some handler (x22 by EXP, others by storage/keccak/M25 loops). Mirrors the existing log-length env cells.
- **`staticGasCost : Nat → Nat`** encodes the EVM base-cost tiers (sourced from `execution-specs/.../prague/vm/gas.py`: ZERO/BASE/VERYLOW/LOW/MID/HIGH, KECCAK=30, LOG=375, CREATE=32000, warm-access floor 100, …). Halt opcodes + unwired bytes = 0 so trusted programs never spuriously OOG. Emitted as a 256-`.dword` `opcode_gas_costs` table in both data sections.
- **Dispatch loop** (both prologue variants — the body is duplicated): after the existing `opcode*8` index, look up `cost`, `bltu` to `.exit_outofgas` on underflow, else charge `env+568`. Charge-then-execute matches the spec's `charge_gas` ordering (so GAS reflects its own cost).
- **Gas limit**: the runtime prologue reads it from a new 8-byte input trailer; the `.data`-baked prologue seeds 30,000,000. `pack-bytecode.py` gains `--gas` (default 30M, back-compatible).
- **Real GAS opcode (0x5a)**: reads `env+568` and pushes it (moved out of `pushZeroHandlers` into `gasHandlers`). `RegistryInvariants` unchanged (149 — GAS only moved lists).

## Tests

- `gas_opcode_sufficient`: `GAS; STOP`, limit 1000 → pushes **998** (GAS's own cost of 2 charged first).
- `gas_opcode_out_of_gas`: `PUSH1`, limit 2 → first opcode (cost 3) underflows → **halt_kind = 6**, zero result.
- New `gasLimit` TSV column threaded through `Cli.lean` + the bash runner. `lake build EvmAsm.Codegen` clean; `check-progress.sh` exits 0.

## ⚠️ Pre-existing failures (NOT introduced by this PR)

`scripts/codegen-opcodes-runtime-check.sh` reports `blockhash_parent` and `blockhash_historical` failing. **These fail identically on pristine `upstream/main`** (verified by stashing this PR's changes and re-running). Root cause: the BLOCKHASH handler reads the current block number from `env+544` / count from `env+552`, but the M28 blob cells shifted those to `env+552` / `env+560` and the handler wasn't updated. Unrelated to gas — a separate one-line offset fix (incoming).

## Limitations (documented in `staticGasCost`)

Static base only — state ops (SLOAD/SSTORE/CALL/EXTCODE*/KECCAK/LOG/EXP/copies) under-charge; per-iteration cost lookup adds ~6 instrs/op; gas-used isn't surfaced at OUTPUT yet; MSIZE/memory gas unchanged. `Layout.lean`'s `envSize` remains stale vs the dispatcher's raw-offset env cells (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
