### PR TITLE
fix(codegen): BLOCKHASH reads block number/count from correct env offsets

### DIFF
--- a/EvmAsm/Codegen/Programs/Evm.lean
+++ b/EvmAsm/Codegen/Programs/Evm.lean
@@ -659,8 +659,8 @@ def blobContextHandlers : List OpcodeHandlerSpec :=
 /-- M29 BLOCKHASH handler backed by the runtime block-history trailer.
 
     Runtime input supplies:
-      - `env + 544`: current block number (`cur`, u64)
-      - `env + 552`: number of loaded recent hashes (`count`, clamped to 256)
+      - `env + 552`: current block number (`cur`, u64)
+      - `env + 560`: number of loaded recent hashes (`count`, clamped to 256)
       - `evm_block_hashes`: `count` 32-byte hashes in increasing block-number
         order, matching execution-specs' `block_env.block_hashes`.
 
@@ -684,10 +684,10 @@ def blockHashHandlers : List OpcodeHandlerSpec :=
         "  ld x14, 24(x12)\n" ++
         "  bnez x14, .Lblockhash_zero\n" ++
         "  ld x14, 0(x12)\n" ++       -- x14 = target block number
-        "  ld x15, 544(x20)\n" ++     -- x15 = current block number (env+544, past M28 blobBaseFee)
+        "  ld x15, 552(x20)\n" ++     -- x15 = current block number (env+552)
         "  bgeu x14, x15, .Lblockhash_zero\n" ++
         "  sub x16, x15, x14\n" ++    -- x16 = cur - target, strictly positive
-        "  ld x17, 552(x20)\n" ++     -- x17 = loaded hash count (env+552)
+        "  ld x17, 560(x20)\n" ++     -- x17 = loaded hash count (env+560)
         "  bgtu x16, x17, .Lblockhash_zero\n" ++
         "  sub x17, x17, x16\n" ++    -- index = count - age
         "  slli x17, x17, 5\n" ++     -- index × 32


### PR DESCRIPTION
## Summary

`BLOCKHASH` (0x40) returns 0 for every valid lookup on `main`. The handler reads the current block number from `env+544` and the recent-hash count from `env+552` — but those offsets belong to **M28's blob cells** (`env+544` = `blobHashCount`, `env+552` = the M29 `currentBlockNumber`).

When M28 inserted the blob-context cells at `env+512..544`, the M29 block-number / count cells moved to `env+552` / `env+560`, but the BLOCKHASH handler (and its docstring) still used the pre-M28 offsets. So it read `blobHashCount` (0 in tests) as the "current block number", making the window check `bgeu target, cur` always take the zero path.

## Fix

Read current block number from `env+552` and count from `env+560`, matching what **both** dispatcher prologues actually write (`Dispatch.lean`: `sd x6, 552(x20)` / `sd x6, 560(x20)`). Also corrects the handler docstring's offset notes. 4 lines, one file.

## Tests

`scripts/codegen-opcodes-runtime-check.sh` → **ALL PASS (108 cases)**. `blockhash_parent` and `blockhash_historical` were **failing on `main`** before this fix and now pass; the three zero-path blockhash cases stay green. `check-progress.sh` exits 0; `lake build EvmAsm.Codegen` clean.

## Context

Surfaced while adding gas metering (#7921), which documented these two cases as pre-existing failures on `main`. This fix is independent of that PR (branched off `main`); merging it turns the opcode suite green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
