### PR TITLE
docs(eest): record large witness cap frontier

### DIFF
--- a/docs/agents/eest-static-layout.md
+++ b/docs/agents/eest-static-layout.md
@@ -45,6 +45,23 @@ that happens, treat the ELF memory map as part of the layout: keep linked
 The current stateless guest layout puts `.data` at `0xa5000000` and
 `.sszscratch` at `0xb0000000`, both inside the verified RAM zone.
 
+## State Witness Caps
+
+The `block_state_root` witness-length guard is different from the BAL row and
+state-change arena caps. The witness bytes are carried in the EEST input and
+searched by the MPT helpers; simply raising the guard does not allocate a larger
+`.data` arena, but it can expose execution-time blowups from repeated linear
+witness scans.
+
+Before changing the default witness cap, run both the full stateless harness and
+the fixed-size verdict probe on the exact frontier that motivated the change.
+For example, EIP-7251 `consolidation_requests.json` selected index 138 has
+`witness_len=204888`: the default 64 KiB cap gives a conservative
+`bsr_fail=111`, while an experimental 256 KiB cap reaches
+`EmulationNoCompleted` even in the verdict probe at 2B steps. That means the
+next implementation frontier is replay/indexing performance, not only a larger
+constant.
+
 ## Launch-Time Layout Compatibility
 
 If a static layout supports only up to a chosen maximum block gas limit, the


### PR DESCRIPTION
Summary:
- Recorded the EIP-7251 consolidation_requests selected index 138 witness frontier in docs/agents/eest-static-layout.md.
- Captured that the default 64 KiB BSR witness cap gives conservative bsr_fail=111 with witness_len=204888.
- Captured that raising the cap to 262144 reaches EmulationNoCompleted in both the full harness and the fixed-size verdict probe, so the next frontier is witness replay/indexing performance rather than only a larger constant.
- Created follow-up bead evm-asm-tmhmh.1.1 for the implementation work.

Experimental commands:
- scripts/codegen-eest-stateless-check.sh --filter eip7251_consolidations/consolidations/consolidation_requests.json --skip 138 --limit 1 --jobs 1 --steps 400000000 --max-failures 1 --quiet-passes --bsr-witness-cap 262144
- scripts/codegen-zisk-stateless-verdict-check.sh --filter eip7251_consolidations/consolidations/consolidation_requests.json --skip 138 --limit 1 --steps 2000000000 --max-failures 1 --bsr-witness-cap 262144

Verification:
- rg -n sorry|admit|set_option maxHeartbeats|set_option maxRecDepth docs/agents/eest-static-layout.md
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build

Refs bead: evm-asm-tmhmh.1.
Follow-up bead: evm-asm-tmhmh.1.1.

Authored by @pirapira; implemented by Codex.