### PR TITLE
perf(mpt): cache witness node resolution

### DIFF
--- a/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
@@ -478,6 +478,7 @@ def ziskBalAccountApplyPostFieldsPrologue : String :=
   witnessLookupByHashFunction ++ "\n" ++
   nodeDbLookupFunction ++ "\n" ++
   nodeDbAppendFunction ++ "\n" ++
+  mptResolveCacheResetFunction ++ "\n" ++
   mptNodeResolveFunction ++ "\n" ++
   mptNodeKindFunction ++ "\n" ++
   hpDecodeNibblesFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/BalAccountDescriptorArray.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountDescriptorArray.lean
@@ -186,6 +186,7 @@ def balAccountDescriptorArrayDeps : String :=
   witnessLookupByHashFunction ++ "\n" ++
   nodeDbLookupFunction ++ "\n" ++
   nodeDbAppendFunction ++ "\n" ++
+  mptResolveCacheResetFunction ++ "\n" ++
   mptNodeResolveFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
   rlpListCountItemsFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/BalAccountStateRoot.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountStateRoot.lean
@@ -132,6 +132,7 @@ def ziskBalAccountStateRootPrologue : String :=
   witnessLookupByHashFunction ++ "\n" ++
   nodeDbLookupFunction ++ "\n" ++
   nodeDbAppendFunction ++ "\n" ++
+  mptResolveCacheResetFunction ++ "\n" ++
   mptNodeResolveFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
   rlpListCountItemsFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -934,6 +934,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   extcodesizeAtHeaderStateRootFunction ++ "\n" ++
   nodeDbAppendFunction ++ "\n" ++
   nodeDbLookupFunction ++ "\n" ++
+  mptResolveCacheResetFunction ++ "\n" ++
   mptNodeResolveFunction ++ "\n" ++
   mptSetRecordWalkDbFunction ++ "\n" ++
   mptSetAccFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
@@ -57,6 +57,7 @@ def statelessVerdictV2GuestClosure : String :=
   extcodesizeAtHeaderStateRootFunction ++ "\n" ++
   nodeDbAppendFunction ++ "\n" ++
   nodeDbLookupFunction ++ "\n" ++
+  mptResolveCacheResetFunction ++ "\n" ++
   mptNodeResolveFunction ++ "\n" ++
   mptSetRecordWalkDbFunction ++ "\n" ++
   mptSetAccFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/MptDeleteAcc.lean
+++ b/EvmAsm/Codegen/Programs/MptDeleteAcc.lean
@@ -354,6 +354,7 @@ def ziskMptDeleteAccPrologue : String :=
   "  li sp, 0xa0050000\n" ++
   "  la t0, mset_db_count; sd zero, 0(t0)\n" ++
   "  la t0, mset_db_data; la t1, mset_db_top; sd t0, 0(t1)\n" ++
+  "  jal ra, mpt_resolve_cache_reset\n" ++
   "  li t0, 0x40000000\n" ++
   "  ld a2, 8(t0)                # witness_len\n" ++
   "  ld a4, 16(t0)               # path_len\n" ++
@@ -369,6 +370,7 @@ def ziskMptDeleteAccPrologue : String :=
   witnessLookupByHashFunction ++ "\n" ++
   nodeDbLookupFunction ++ "\n" ++
   nodeDbAppendFunction ++ "\n" ++
+  mptResolveCacheResetFunction ++ "\n" ++
   mptNodeResolveFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
   mptNodeKindFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/MptDeleteWalkDb.lean
+++ b/EvmAsm/Codegen/Programs/MptDeleteWalkDb.lean
@@ -66,6 +66,7 @@ def ziskMptDeleteWalkDbPrologue : String :=
   zkvmKeccak256Function ++ "\n" ++
   witnessLookupByHashFunction ++ "\n" ++
   nodeDbLookupFunction ++ "\n" ++
+  mptResolveCacheResetFunction ++ "\n" ++
   mptNodeResolveFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
   mptNodeKindFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/MptIndexedTrieRoot.lean
+++ b/EvmAsm/Codegen/Programs/MptIndexedTrieRoot.lean
@@ -107,6 +107,7 @@ def ziskMptIndexedTrieRootSmallPrologue : String :=
   witnessLookupByHashFunction ++ "\n" ++
   nodeDbLookupFunction ++ "\n" ++
   nodeDbAppendFunction ++ "\n" ++
+  mptResolveCacheResetFunction ++ "\n" ++
   mptNodeResolveFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
   mptNodeKindFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/MptInsertAcc.lean
+++ b/EvmAsm/Codegen/Programs/MptInsertAcc.lean
@@ -308,6 +308,7 @@ def ziskMptInsertAccPrologue : String :=
   "  li sp, 0xa0050000\n" ++
   "  la t0, mset_db_count; sd zero, 0(t0)\n" ++
   "  la t0, mset_db_data; la t1, mset_db_top; sd t0, 0(t1)\n" ++
+  "  jal ra, mpt_resolve_cache_reset\n" ++
   "  li t0, 0x40000000\n" ++
   "  ld a2, 8(t0)                # witness_len\n" ++
   "  ld a4, 16(t0)               # path_len\n" ++
@@ -328,6 +329,7 @@ def ziskMptInsertAccPrologue : String :=
   witnessLookupByHashFunction ++ "\n" ++
   nodeDbLookupFunction ++ "\n" ++
   nodeDbAppendFunction ++ "\n" ++
+  mptResolveCacheResetFunction ++ "\n" ++
   mptNodeResolveFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
   mptNodeKindFunction ++ "\n" ++
@@ -364,6 +366,7 @@ def ziskMptInsertAccDataSection : String :=
   "mset_db_top:\n  .zero 8\n" ++
   ".balign 8\n" ++
   "mset_db_hash:\n  .zero 32\n" ++
+  mptResolveCacheDataSection ++ "\n" ++
   ".balign 8\n" ++
   "mset_db_data:\n  .zero 8388608"
 

--- a/EvmAsm/Codegen/Programs/MptInsertWalkDb.lean
+++ b/EvmAsm/Codegen/Programs/MptInsertWalkDb.lean
@@ -265,6 +265,7 @@ def ziskMptInsertWalkDbPrologue : String :=
   zkvmKeccak256Function ++ "\n" ++
   witnessLookupByHashFunction ++ "\n" ++
   nodeDbLookupFunction ++ "\n" ++
+  mptResolveCacheResetFunction ++ "\n" ++
   mptNodeResolveFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
   mptNodeKindFunction ++ "\n" ++
@@ -288,6 +289,7 @@ def ziskMptInsertWalkDbDataSection : String :=
   "mset_db_top:\n  .zero 8\n" ++
   ".balign 8\n" ++
   "mset_db_hash:\n  .zero 32\n" ++
+  mptResolveCacheDataSection ++ "\n" ++
   ".balign 8\n" ++
   "mset_db_data:\n  .zero 8388608"
 

--- a/EvmAsm/Codegen/Programs/MptSetAcc.lean
+++ b/EvmAsm/Codegen/Programs/MptSetAcc.lean
@@ -108,6 +108,31 @@ def nodeDbLookupFunction : String :=
   "  li a0, 1\n" ++
   "  ret"
 
+/-! ## mpt_resolve_cache_reset -- clear the witness-node resolver cache.
+
+    The cache is direct-mapped and stores only successful witness-section
+    resolutions. It is reset alongside the appended node DB so cached absolute
+    input pointers never cross probe/block invocations. -/
+def mptResolveCacheResetFunction : String :=
+  "mpt_resolve_cache_reset:\n" ++
+  "  la t0, mset_res_cache_valid\n" ++
+  "  li t1, 4096\n" ++
+  ".Lmrc_reset_loop:\n" ++
+  "  beqz t1, .Lmrc_reset_done\n" ++
+  "  sd zero, 0(t0)\n" ++
+  "  addi t0, t0, 8\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lmrc_reset_loop\n" ++
+  ".Lmrc_reset_done:\n" ++
+  "  ret"
+
+/-- Backing storage for `mpt_node_resolve`'s direct-mapped witness cache. -/
+def mptResolveCacheDataSection : String :=
+  ".balign 8\n" ++
+  "mset_res_cache_valid:\n  .zero 32768\n" ++
+  ".balign 32\n" ++
+  "mset_res_cache_data:\n  .zero 196608"
+
 /-! ## mpt_node_resolve -- hash -> absolute node ptr (DB, then witness)
 
     a0 = witness ptr, a1 = witness_len, a2 = target hash ptr,
@@ -123,6 +148,24 @@ def mptNodeResolveFunction : String :=
   "  mv a0, s2; mv a1, s3; mv a2, s4\n" ++
   "  jal ra, node_db_lookup\n" ++
   "  beqz a0, .Lres_ret\n" ++
+  "  # Direct-mapped cache for witness-section resolutions. DB lookup wins;\n" ++
+  "  # the cache only avoids repeated scans of the immutable witness list.\n" ++
+  "  lbu t0, 0(s2)\n" ++
+  "  lbu t1, 1(s2); slli t1, t1, 8; or t0, t0, t1; li t2, 4095; and t0, t0, t2\n" ++
+  "  la t1, mset_res_cache_valid\n" ++
+  "  slli t2, t0, 3; add t1, t1, t2\n" ++
+  "  ld t2, 0(t1); beqz t2, .Lres_cache_miss\n" ++
+  "  slli t2, t0, 5; slli t3, t0, 4; add t2, t2, t3   # 48 * index\n" ++
+  "  la t3, mset_res_cache_data; add t2, t3, t2\n" ++
+  "  ld t3,  0(t2); ld t4,  0(s2); bne t3, t4, .Lres_cache_miss\n" ++
+  "  ld t3,  8(t2); ld t4,  8(s2); bne t3, t4, .Lres_cache_miss\n" ++
+  "  ld t3, 16(t2); ld t4, 16(s2); bne t3, t4, .Lres_cache_miss\n" ++
+  "  ld t3, 24(t2); ld t4, 24(s2); bne t3, t4, .Lres_cache_miss\n" ++
+  "  ld t3, 32(t2); sd t3, 0(s3)\n" ++
+  "  ld t3, 40(t2); sd t3, 0(s4)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lres_ret\n" ++
+  ".Lres_cache_miss:\n" ++
   "  mv a0, s0; mv a1, s1; mv a2, s2\n" ++
   "  la a3, mset_res_off; la a4, mset_res_len\n" ++
   "  jal ra, witness_lookup_by_hash\n" ++
@@ -130,6 +173,17 @@ def mptNodeResolveFunction : String :=
   "  la t0, mset_res_off; ld t1, 0(t0); add t1, s0, t1   # abs = witness + off\n" ++
   "  sd t1, 0(s3)\n" ++
   "  la t0, mset_res_len; ld t1, 0(t0); sd t1, 0(s4)\n" ++
+  "  lbu t0, 0(s2)\n" ++
+  "  lbu t1, 1(s2); slli t1, t1, 8; or t0, t0, t1; li t2, 4095; and t0, t0, t2\n" ++
+  "  slli t2, t0, 5; slli t3, t0, 4; add t2, t2, t3   # 48 * index\n" ++
+  "  la t3, mset_res_cache_data; add t2, t3, t2\n" ++
+  "  ld t3,  0(s2); sd t3,  0(t2)\n" ++
+  "  ld t3,  8(s2); sd t3,  8(t2)\n" ++
+  "  ld t3, 16(s2); sd t3, 16(t2)\n" ++
+  "  ld t3, 24(s2); sd t3, 24(t2)\n" ++
+  "  ld t3, 0(s3); sd t3, 32(t2)\n" ++
+  "  ld t3, 0(s4); sd t3, 40(t2)\n" ++
+  "  la t1, mset_res_cache_valid; slli t3, t0, 3; add t1, t1, t3; li t3, 1; sd t3, 0(t1)\n" ++
   "  li a0, 0\n" ++
   ".Lres_ret:\n" ++
   "  ld ra, 0(sp); ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
@@ -380,6 +434,7 @@ def ziskMptSetAccPrologue : String :=
   "  # init node DB: count = 0, top = &mset_db_data.\n" ++
   "  la t0, mset_db_count; sd zero, 0(t0)\n" ++
   "  la t0, mset_db_data; la t1, mset_db_top; sd t0, 0(t1)\n" ++
+  "  jal ra, mpt_resolve_cache_reset\n" ++
   "  # ---- update 1 ----\n" ++
   "  li t0, 0x40000000\n" ++
   "  ld a2, 8(t0)                # witness_len\n" ++
@@ -436,6 +491,7 @@ def ziskMptSetAccPrologue : String :=
   mptSpliceSlotFunction ++ "\n" ++
   nodeDbAppendFunction ++ "\n" ++
   nodeDbLookupFunction ++ "\n" ++
+  mptResolveCacheResetFunction ++ "\n" ++
   mptNodeResolveFunction ++ "\n" ++
   mptSetRecordWalkDbFunction ++ "\n" ++
   mptSetAccFunction ++ "\n" ++
@@ -456,6 +512,7 @@ def ziskMptSetAccDataSection : String :=
   "mset_rw_len:\n  .zero 8\n" ++
   ".balign 32\n" ++
   "mset_db_hash:\n  .zero 32\n" ++
+  mptResolveCacheDataSection ++ "\n" ++
   ".balign 32\n" ++
   "mset_tmproot:\n  .zero 32\n" ++
   ".balign 8\n" ++
@@ -508,6 +565,7 @@ def mptStateRootFunction : String :=
   "  # init node DB\n" ++
   "  la t0, mset_db_count; sd zero, 0(t0)\n" ++
   "  la t0, mset_db_data; la t1, mset_db_top; sd t0, 0(t1)\n" ++
+  "  jal ra, mpt_resolve_cache_reset\n" ++
   "  li s5, 0                    # i\n" ++
   ".Lsr_loop:\n" ++
   "  beq s5, s3, .Lsr_done\n" ++
@@ -598,6 +656,7 @@ def ziskMptStateRootPrologue : String :=
   mptSpliceSlotFunction ++ "\n" ++
   nodeDbAppendFunction ++ "\n" ++
   nodeDbLookupFunction ++ "\n" ++
+  mptResolveCacheResetFunction ++ "\n" ++
   mptNodeResolveFunction ++ "\n" ++
   mptSetRecordWalkDbFunction ++ "\n" ++
   mptSetAccFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/MptStateRootIns.lean
+++ b/EvmAsm/Codegen/Programs/MptStateRootIns.lean
@@ -48,6 +48,7 @@ def mptStateRootInsFunction : String :=
   "  # init the node DB (shared by mpt_set_acc + mpt_insert_acc)\n" ++
   "  la t0, mset_db_count; sd zero, 0(t0)\n" ++
   "  la t0, mset_db_data; la t1, mset_db_top; sd t0, 0(t1)\n" ++
+  "  jal ra, mpt_resolve_cache_reset\n" ++
   "  la t0, sri_fail_index; sd zero, 0(t0)\n" ++
   "  la t0, sri_fail_mode; sd zero, 0(t0)\n" ++
   "  la t0, sri_fail_status; sd zero, 0(t0)\n" ++
@@ -153,6 +154,7 @@ def ziskMptStateRootInsPrologue : String :=
   witnessLookupByHashFunction ++ "\n" ++
   nodeDbLookupFunction ++ "\n" ++
   nodeDbAppendFunction ++ "\n" ++
+  mptResolveCacheResetFunction ++ "\n" ++
   mptNodeResolveFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
   mptNodeKindFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/StatelessVerdict.lean
+++ b/EvmAsm/Codegen/Programs/StatelessVerdict.lean
@@ -161,6 +161,7 @@ def ziskStatelessVerdictPrologue : String :=
   mptWalkFunction ++ "\n" ++
   nodeDbAppendFunction ++ "\n" ++
   nodeDbLookupFunction ++ "\n" ++
+  mptResolveCacheResetFunction ++ "\n" ++
   mptNodeResolveFunction ++ "\n" ++
   mptSetRecordWalkDbFunction ++ "\n" ++
   mptSetAccFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/Step2Verdict.lean
+++ b/EvmAsm/Codegen/Programs/Step2Verdict.lean
@@ -180,6 +180,7 @@ def ziskStep2VerdictPrologue : String :=
   mptWalkFunction ++ "\n" ++
   nodeDbAppendFunction ++ "\n" ++
   nodeDbLookupFunction ++ "\n" ++
+  mptResolveCacheResetFunction ++ "\n" ++
   mptNodeResolveFunction ++ "\n" ++
   mptSetRecordWalkDbFunction ++ "\n" ++
   mptSetAccFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/WithdrawalsRootIndexed.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalsRootIndexed.lean
@@ -122,6 +122,7 @@ def ziskBlockValidateWithdrawalsRootIndexedPrologue : String :=
   witnessLookupByHashFunction ++ "\n" ++
   nodeDbLookupFunction ++ "\n" ++
   nodeDbAppendFunction ++ "\n" ++
+  mptResolveCacheResetFunction ++ "\n" ++
   mptNodeResolveFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
   mptNodeKindFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/WithdrawalsStateRoot.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalsStateRoot.lean
@@ -180,6 +180,7 @@ def ziskWithdrawalsStateRootPrologue : String :=
   mptWalkFunction ++ "\n" ++
   nodeDbAppendFunction ++ "\n" ++
   nodeDbLookupFunction ++ "\n" ++
+  mptResolveCacheResetFunction ++ "\n" ++
   mptNodeResolveFunction ++ "\n" ++
   mptSetRecordWalkDbFunction ++ "\n" ++
   mptSetAccFunction ++ "\n" ++


### PR DESCRIPTION
Summary:
- Add a 4096-entry direct-mapped cache for immutable witness-section node resolutions in mpt_node_resolve.
- Keep the existing DB-first lookup order, verify all 32 hash bytes on cache hits, and reset the cache alongside the appended node DB.
- Wire the reset helper/data through the generated MPT, withdrawals, stateless verdict, and block verdict assembly closures that emit mpt_node_resolve.

Large-witness result:
- This is a partial performance slice for bead evm-asm-tmhmh.1.1, not completion of that bead.
- The EIP-7251 consolidation_requests selected index 138 verdict probe still exits with EmulationNoCompleted under --bsr-witness-cap 262144 at 2B steps.

Verification:
- lake build EvmAsm.Codegen.Programs.MptSetAcc EvmAsm.Codegen.Programs.MptInsertAcc EvmAsm.Codegen.Programs.MptDeleteAcc EvmAsm.Codegen.Programs.MptStateRootIns EvmAsm.Codegen.Programs.BlockVerdict EvmAsm.Codegen.Programs.BlockVerdictV2
- scripts/codegen-zisk-mpt-state-root-check.sh
- scripts/codegen-zisk-mpt-state-root-ins-check.sh
- scripts/codegen-zisk-mpt-insert-acc-check.sh
- scripts/codegen-zisk-withdrawals-state-root-check.sh
- direct ziskemu repro of the large EIP-7251 verdict probe with --bsr-witness-cap 262144: still EmulationNoCompleted
- rg -n sorry|admit|set_option maxHeartbeats|set_option maxRecDepth <edited files>
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build

Bead: evm-asm-tmhmh.1.1.

Authored by @pirapira; implemented by Codex.