### PR TITLE
fix(eest): carry block rlp length trailer

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -655,6 +655,9 @@ def blockVerdictFunction : String :=
   "  jal ra, block_rlp_rebuilt_size\n" ++
   "  bnez a0, .Lbv_block_rlp_parse_fail\n" ++
   "  la t0, bv_block_rlp_len; sd a1, 0(t0)\n" ++
+  "  la t0, bv_block_rlp_fixture_len; ld t2, 0(t0); beqz t2, .Lbv_block_rlp_check_rebuilt\n" ++
+  "  mv a1, t2\n" ++
+  ".Lbv_block_rlp_check_rebuilt:\n" ++
   "  li t1, 0x800000; bgtu a1, t1, .Lbv_block_rlp_limit_fail\n" ++
   "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0); ld a2, 8(s0); ld a3, 16(s0)\n" ++
   "  jal ra, validate_header_rlp_pair\n" ++
@@ -793,6 +796,21 @@ def blockVerdictFunction : String :=
 /-! ## stateless_verdict_v2 -- real-SSZ glue calling block_verdict (system writes). -/
 def statelessVerdictV2Function : String :=
   "stateless_verdict_v2:\n" ++
+  "  li t0, 0x40000000\n" ++
+  "  ld t1, 8(t0)                 # zisk input: u64 stateless blob length\n" ++
+  "  addi t2, t1, 15              # align8(8 + blob_len)\n" ++
+  "  andi t2, t2, -8\n" ++
+  "  addi t3, t0, 8\n" ++
+  "  add t3, t3, t2               # optional trailer start\n" ++
+  "  ld t4, 0(t3)\n" ++
+  "  li t5, 0x31504c52            # scripts/eest-stateless-to-input.py BLOCK_RLP_TRAILER_MAGIC\n" ++
+  "  bne t4, t5, .Lv2_no_block_rlp_trailer\n" ++
+  "  ld t4, 8(t3)\n" ++
+  "  la t5, bv_block_rlp_fixture_len; sd t4, 0(t5)\n" ++
+  "  j .Lv2_after_block_rlp_trailer\n" ++
+  ".Lv2_no_block_rlp_trailer:\n" ++
+  "  la t5, bv_block_rlp_fixture_len; sd zero, 0(t5)\n" ++
+  ".Lv2_after_block_rlp_trailer:\n" ++
   "  addi sp, sp, -64\n" ++
   "  sd ra, 0(sp)\n" ++
   "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
@@ -895,6 +913,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   "  la t1, sri_fail_mode; ld t2, 0(t1); sd t2, 96(t0)\n" ++
   "  la t1, sri_fail_status; ld t2, 0(t1); sd t2, 104(t0)\n" ++
   "  la t1, bv_block_rlp_len; ld t2, 0(t1); sd t2, 112(t0)\n" ++
+  "  la t1, bv_block_rlp_fixture_len; ld t2, 0(t1); sd t2, 120(t0)\n" ++
   "  j .Lv2_pdone\n" ++
   zkvmSha256Function ++ "\n" ++
   zkvmKeccak256Function ++ "\n" ++
@@ -1114,6 +1133,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bv_header_status:\n  .zero 8\n" ++
   "bv_state_status:\n  .zero 8\n" ++
   "bv_block_rlp_len:\n  .zero 8\n" ++
+  "bv_block_rlp_fixture_len:\n  .zero 8\n" ++
   eip7702NonceReuseGuardDataSection ++
   "brl_item_start:\n  .zero 8\n" ++
   "brl_item_end:\n  .zero 8\n" ++

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -427,11 +427,12 @@ format_verdict_debug() {
     sri_mode
     sri_status
     block_rlp_len
+    fixture_block_rlp_len
   )
   local -a words=()
   local i value dbg=""
 
-  raw="$(od -An -v -tu8 -N 120 "$out" 2>/dev/null | xargs || true)"
+  raw="$(od -An -v -tu8 -N 128 "$out" 2>/dev/null | xargs || true)"
   read -r -a words <<< "$raw"
   for i in "${!labels[@]}"; do
     value="${words[$i]:-?}"
@@ -502,8 +503,8 @@ selectedCount="${#manifestLines[@]}"
 
 run_case() {
   local line="$1"
-  local label input expected_hex succ_bit input_len gas_limit relpath
-  IFS=$'\t' read -r label input expected_hex succ_bit input_len gas_limit relpath <<< "$line"
+  local label input expected_hex succ_bit input_len gas_limit block_rlp_len relpath
+  IFS=$'\t' read -r label input expected_hex succ_bit input_len gas_limit block_rlp_len relpath <<< "$line"
   local out="$RUN_DIR/$label.output"
   local log="$RUN_DIR/$label.emu.log"
   local result="$RUN_DIR/$label.result.tsv"
@@ -553,8 +554,8 @@ total=0 err=0 full=0 succ=0 root=0 tail=0 fail=0 rod=0
 classify_case_result() {
   local line="$1"
   local require_result="${2:-0}"
-  local label input expected_hex succ_bit input_len gas_limit relpath result status actual_hex exp r s t
-  IFS=$'\t' read -r label input expected_hex succ_bit input_len gas_limit relpath <<< "$line"
+  local label input expected_hex succ_bit input_len gas_limit block_rlp_len relpath result status actual_hex exp r s t
+  IFS=$'\t' read -r label input expected_hex succ_bit input_len gas_limit block_rlp_len relpath <<< "$line"
   if [[ -n "${classifiedLabels[$label]+x}" ]]; then
     return 0
   fi

--- a/scripts/eest-stateless-to-input.py
+++ b/scripts/eest-stateless-to-input.py
@@ -14,10 +14,14 @@ This tool walks a directory of such fixtures and, for every block that
 has ``statelessInputBytes``, writes a ziskemu ``-i`` input file in the
 exact layout ``scripts/stateless-gen-input.py`` uses
 (``<u64 LE length><blob><zero pad to 8>``), and emits a TSV manifest
-that the harness (``codegen-eest-stateless-check.sh``) iterates.
+that the harness (``codegen-eest-stateless-check.sh``) iterates. When a fixture
+block carries raw block RLP, the input file also carries an auxiliary trailer:
+``u64 magic, u64 block_rlp_len, block_rlp_bytes, zero pad to 8``. The guest's
+legacy SSZ pointer remains unchanged; RISC-V code can opt into the trailer by
+checking the magic at the end of the padded SSZ blob.
 
 Manifest columns (tab-separated, one row per guest invocation):
-  label  input_file  expected_hex  succ_bit  input_len  block_gas_limit  fixture_relpath
+  label  input_file  expected_hex  succ_bit  input_len  block_gas_limit  block_rlp_len  fixture_relpath
 
 Usage:
   eest-stateless-to-input.py --fixtures-dir DIR --out-dir DIR
@@ -38,11 +42,18 @@ import sys
 from pathlib import Path
 
 
-def pack_ziskemu_input(blob: bytes) -> bytes:
-    """Mirror scripts/stateless-gen-input.py: 8-byte LE length, blob, pad to 8."""
+BLOCK_RLP_TRAILER_MAGIC = 0x31504C52  # "RLP1", little-endian u64
+
+
+def pack_ziskemu_input(blob: bytes, block_rlp: bytes = b"") -> bytes:
+    """Mirror scripts/stateless-gen-input.py, with an optional block-RLP trailer."""
     total = 8 + len(blob)
     pad = (-total) % 8
-    return struct.pack("<Q", len(blob)) + blob + (b"\x00" * pad)
+    packed = struct.pack("<Q", len(blob)) + blob + (b"\x00" * pad)
+    if not block_rlp:
+        return packed
+    trailer = struct.pack("<QQ", BLOCK_RLP_TRAILER_MAGIC, len(block_rlp)) + block_rlp
+    return packed + trailer + (b"\x00" * ((-len(trailer)) % 8))
 
 
 def sanitize(s: str) -> str:
@@ -59,7 +70,7 @@ def stateless_input_block_gas_limit(blob: bytes) -> int:
 
 
 def iter_blocks(fixture_path: Path):
-    """Yield (label, input_bytes, expected_bytes, block_gas_limit) for each stateless block."""
+    """Yield (label, input_bytes, expected_bytes, block_gas_limit, block_rlp) per block."""
     try:
         doc = json.loads(fixture_path.read_text())
     except (json.JSONDecodeError, OSError) as exc:  # corrupt / unreadable
@@ -82,11 +93,13 @@ def iter_blocks(fixture_path: Path):
                 ib = bytes.fromhex(sib[2:] if sib.startswith("0x") else sib)
                 ob = bytes.fromhex(sob[2:] if sob.startswith("0x") else sob)
                 gas_limit = stateless_input_block_gas_limit(ib)
+                rlp_hex = blk.get("rlp") or ""
+                block_rlp = bytes.fromhex(rlp_hex[2:] if rlp_hex.startswith("0x") else rlp_hex) if rlp_hex else b""
             except ValueError as exc:
                 print(f"  warn: bad hex in {fixture_path}: {exc}", file=sys.stderr)
                 continue
             label = sanitize(f"{short}#b{bi}")
-            yield label, ib, ob, gas_limit
+            yield label, ib, ob, gas_limit, block_rlp
 
 
 def main() -> int:
@@ -122,7 +135,7 @@ def main() -> int:
             relpath = str(fp.relative_to(fixtures_dir))
             if args.filter and args.filter not in relpath:
                 continue
-            for label, ib, ob, gas_limit in iter_blocks(fp):
+            for label, ib, ob, gas_limit, block_rlp in iter_blocks(fp):
                 if selected < args.skip:
                     selected += 1
                     continue
@@ -148,7 +161,7 @@ def main() -> int:
                 used_labels.add(uniq)
 
                 input_file = out_dir / f"{uniq}.input"
-                input_file.write_bytes(pack_ziskemu_input(ib))
+                input_file.write_bytes(pack_ziskemu_input(ib, block_rlp))
                 succ_bit = ob[32] if len(ob) > 32 else -1
                 mf.write(
                     "\t".join(
@@ -159,6 +172,7 @@ def main() -> int:
                             str(succ_bit),
                             str(len(ib)),
                             str(gas_limit),
+                            str(len(block_rlp)),
                             relpath,
                         ]
                     )


### PR DESCRIPTION
## Summary
- append fixture block RLP as an optional trailer after the existing padded EEST stateless input wrapper
- add block_rlp_len to the converter manifest and fixture_block_rlp_len to the fixed-size verdict debug probe
- use the carried fixture block RLP length for the RISC-V EIP-7934 cap check when the trailer is present

## Notes
- this preserves the legacy SSZ pointer layout; old inputs without the RLP1 trailer continue to use the rebuilt SSZ-derived block RLP length
- the trailer currently carries raw fixture block RLP material from EEST JSON; authenticating/rebuilding the whole block remains follow-up work for bead evm-asm-fhsxz.2.4.2.60.5.6.1.1
- the EIP-7934 boundary fixtures have identical statelessInputBytes for at/minus/plus one byte, so this side data is what lets the guest distinguish the lengths

## Verification
- python3 scripts/eest-stateless-to-input.py --fixtures-dir gen-out/eest-fixtures/zkevm@v0.4.0/fixtures/fixtures --out-dir /tmp/eip7934-input-check --filter eip7934_block_rlp_limit/max_block_rlp_size/block_at_rlp_size_limit_boundary.json --limit 3
- lake build codegen
- lake exe codegen --program zisk_stateless_verdict_v2 --halt linux93 -o /tmp/zisk_stateless_verdict_v2_check
- lake exe codegen --program stateless_guest --halt linux93 -o /tmp/stateless_guest_check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build

Refs #7929. Bead: evm-asm-fhsxz.2.4.2.60.5.6.1.1.

Authored by @pirapira; implemented by Codex.