### PR TITLE
perf(mpt): bound linear witness lookup

### DIFF
--- a/EvmAsm/Codegen/Programs/Mpt.lean
+++ b/EvmAsm/Codegen/Programs/Mpt.lean
@@ -45,8 +45,13 @@ open EvmAsm.Rv64
 
     Walks every element computing `keccak256(element_bytes)`
     until either a match is found or the list is exhausted.
-    O(N) per call; PR-K20+ will replace with a pre-built bucket
-    table for O(1) average lookups. -/
+
+    The scan is deliberately capped at the default 64 KiB witness-section
+    budget. Experiments may raise `block_state_root`'s outer witness cap, but
+    this routine must not turn that into an unbounded O(N*D) guest run. Larger
+    sections conservatively miss until the NodeDb index is implemented. The
+    index should use a bounded-worst-case structure (sorted table/trie/tree),
+    not an attacker-shaped hash bucket chain. -/
 def witnessLookupByHashFunction : String :=
   "witness_lookup_by_hash:\n" ++
   "  addi sp, sp, -64\n" ++
@@ -59,6 +64,8 @@ def witnessLookupByHashFunction : String :=
   "  mv s3, a3                  # out_offset ptr\n" ++
   "  mv s4, a4                  # out_length ptr\n" ++
   "  beqz s1, .Lwlh_miss        # empty section ⇒ miss\n" ++
+  "  li t0, 65536               # linear-scan budget: default BSR witness cap\n" ++
+  "  bgtu s1, t0, .Lwlh_miss    # larger witnesses need the indexed NodeDb path\n" ++
   "  lwu t0, 0(s0)              # first inner offset = 4 * N\n" ++
   "  srli s5, t0, 2             # s5 = N\n" ++
   "  li s6, 0                   # s6 = i\n" ++

--- a/EvmAsm/Stateless/Witness/NodeDb/Lookup.lean
+++ b/EvmAsm/Stateless/Witness/NodeDb/Lookup.lean
@@ -15,18 +15,38 @@
 
   ## Algorithm (RISC-V plan)
 
-      bucket = hash[0..4] mod NUM_BUCKETS
-      walk linked-list at NODE_DB_BUCKETS[bucket]:
-        for each (entry_hash, ptr, len):
-          if memcmp(entry_hash, hash, 32) == 0:
-            return (ptr, len, OK)
-        return (0, 0, MISSING_NODE)
+      Build a deterministic index over `(keccak256(node), ptr, len)` records,
+      then lookup by comparing the full 32-byte hash. The first draft used
+      `bucket = hash[0..4] mod NUM_BUCKETS` with linked chains, but GH #7929
+      notes that attacker-shaped buckets can become a DoS frontier. Prefer a
+      bounded-worst-case layout such as a sorted flat table with binary search,
+      a trie over hash bytes, or a balanced tree.
 
   On miss, the caller routes to
   `EvmAsm.Stateless.unimplemented_exit` with reason
   `REASON_WITNESS_MISSING_NODE`. A missing node means the witness
   was incomplete -- the prover did not include a required MPT
   node -- which is a stateless-verification failure.
+
+
+  ## Existing implementations surveyed
+
+  - execution-specs builds a Python `Dict[keccak256(entry)] = entry` once in
+    `forks/amsterdam/witness_state.py`, and `incremental_mpt.py` resolves child
+    hashes by dictionary lookup during trie decoding. This confirms the desired
+    semantic model is pre-indexed lookup, not repeated witness-section scans.
+  - geth exposes trie-node reads through keyed database helpers such as
+    `ReadTrieNode` / `ReadLegacyTrieNode` / `ReadStorageTrieNode`; the hot path
+    is a database/cache lookup by node identity, not a linear proof scan.
+  - reth's trie implementation is cursor-oriented (`TrieCursor`,
+    `HashedCursor`) over hashed state/trie data, again avoiding repeated
+    re-hashing of every candidate node per traversal step.
+  - Erigon documents flat key-value state/trie storage and trie `Get` APIs;
+    it also avoids scanning all witness nodes for each child reference.
+
+  For this zkVM guest, a randomized or adversarially-collidable hash table is a
+  poor fit: the prover controls witness bytes. Use a deterministic bounded
+  structure with full-hash equality checks.
 
   ## PR-K19 status
 
@@ -63,8 +83,9 @@
   ## Implementation shape
 
   Uses one 32-byte `.data` scratch (`wlh_scratch_hash`) for the
-  per-iteration keccak output. No element-count cap (linear
-  scan).
+  per-iteration keccak output. The linear scan refuses sections larger than
+  64 KiB, matching the default `block_state_root` witness cap, so raised-cap
+  experiments fail conservatively instead of running for billions of steps.
 -/
 
 namespace EvmAsm.Stateless.Witness.NodeDb.Lookup


### PR DESCRIPTION
## Summary
- fail fast in witness_lookup_by_hash when the SSZ witness section exceeds the default 64 KiB linear-scan budget
- document that the final NodeDb replacement should use a bounded-worst-case index, not attacker-shaped hash bucket chains
- record existing implementation research: execution-specs prebuilds a hash-to-node dict, geth uses keyed trie-node database helpers, reth uses trie/hashed cursors, and Erigon uses flat key-value state/trie access

## Notes
- this is a conservative dev-speed guard, not the final GH #7929 implementation: raised-cap experiments now miss quickly instead of spending billions of steps in the temporary linear scan
- default-cap behavior is unchanged because block_state_root already rejects witness sections above 64 KiB unless the harness patches the cap

## Verification
- lake build EvmAsm.Codegen.Programs.Mpt EvmAsm.Stateless.Witness.NodeDb.Lookup
- lake exe codegen --program zisk_witness_lookup_by_hash --halt linux93 -o /tmp/zisk_witness_lookup_guard_check
- ziskemu -e /tmp/zisk_witness_lookup_guard_check.elf -i /tmp/wlh_over_cap.input -o /tmp/wlh_over_cap.output -n 1000000; od -An -v -tu8 -N 24 /tmp/wlh_over_cap.output  # returned status=1 offset=0 length=0
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build

Refs #7929. Bead: evm-asm-tmhmh.1.1.1.

Authored by @pirapira; implemented by Codex.