### PR TITLE
docs(eest): record eip7934 input equivalence

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockRlpSize.lean
+++ b/EvmAsm/Codegen/Programs/BlockRlpSize.lean
@@ -4,7 +4,9 @@
   RISC-V helpers for EIP-7934 block RLP size enforcement. The main helper
   computes the exact canonical `len(rlp.encode(Block(...)))` from the SSZ
   ExecutionPayload shape consumed by the stateless guest, plus the caller's
-  already rebuilt header RLP length.
+  already rebuilt header RLP length. This assumes the stateless input represents
+  the same block that execution-specs validates; see
+  `docs/execution-specs-feedback.md` for the EIP-7934 fixture-equivalence note.
 -/
 
 import EvmAsm.Rv64.Program

--- a/docs/execution-specs-feedback.md
+++ b/docs/execution-specs-feedback.md
@@ -123,3 +123,62 @@ at CSR `0x805` per `SYSCALL_SHA256F_ID`).
 
 This note exists so the upstream discussion can be revived later
 without re-deriving the cost picture from scratch.
+
+
+---
+
+## 2. EIP-7934 block RLP limit fixtures and stateless input equivalence
+
+**Where:**
+[`forks/osaka/fork.py`](https://github.com/ethereum/execution-specs/blob/d7fe16ab80dc7a39b802dcd990c69056326a0b59/src/ethereum/forks/osaka/fork.py#L222-L223)
+checks `len(rlp.encode(block)) > MAX_RLP_BLOCK_SIZE` before header and body
+validation.
+
+The zkVM guest should enforce the same rule without trusting fixture sidecars:
+it receives schema-prefixed `statelessInputBytes`, decodes `StatelessInput`,
+reconstructs the canonical block shape from that structured input, and compares
+the rebuilt RLP length to `8_388_608`. The raw fixture `blocks[].rlp` must not be
+appended as an auxiliary input; if the guest needs it, the stateless input schema
+is missing data.
+
+### Current zkevm fixture mismatch
+
+The cached zkevm fixture
+
+```text
+gen-out/eest-fixtures/zkevm@v0.4.0/fixtures/fixtures/blockchain_tests/for_amsterdam/osaka/eip7934_block_rlp_limit/max_block_rlp_size/block_at_rlp_size_limit_boundary.json
+```
+
+contains three boundary cases whose `statelessInputBytes` are byte-identical but
+whose fixture block RLP differs by one byte:
+
+| case | SHA-256(statelessInputBytes) prefix | decoded payload `extra_data` | fixture header `extra_data` | fixture block RLP length |
+| --- | --- | ---: | ---: | ---: |
+| `max_rlp_size_minus_1_byte` | `62d9f1361945ff5d` | 0 | 11 | 8,388,607 |
+| `max_rlp_size` | `62d9f1361945ff5d` | 0 | 12 | 8,388,608 |
+| `max_rlp_size_plus_1_byte` | `62d9f1361945ff5d` | 0 | 13 | 8,388,609 |
+
+Using execution-specs' own stateless decoder on those bytes gives the same
+semantic input for all three cases: `extra_data_len=0`, `tx_count=34`,
+`sum(len(tx))=8,387,806`, and no withdrawals. Reproduce the fixture-side check
+with `scripts/eest-eip7934-input-equivalence.py` under the execution-specs uv
+environment. The repo's RISC-V `zisk_stateless_verdict_v2` probe likewise
+computes the same rebuilt block RLP length (`8,388,562`) for all three inputs
+from the data it can see.
+
+### Consequence
+
+A guest that only reads `statelessInputBytes` cannot distinguish those three
+boundary cases. The correct fix is not a ziskemu input trailer or a raw fixture
+RLP side channel. Either the zkevm fixture generator must serialize the final
+block data that execution-specs validates into `statelessInputBytes`, or the
+stateless input schema must be extended with structured block-construction data
+that lets the guest reconstruct exactly `rlp.encode(block)`.
+
+### Status in this repo
+
+`EvmAsm/Codegen/Programs/BlockRlpSize.lean` follows the desired guest-side shape:
+it rebuilds block RLP length from the SSZ `ExecutionPayload`, the rebuilt header
+RLP length, an empty ommers list, and withdrawals. This is sound only under the
+input-equivalence invariant above: the decoded stateless input must represent the
+same block whose RLP execution-specs validated.

--- a/scripts/eest-eip7934-input-equivalence.py
+++ b/scripts/eest-eip7934-input-equivalence.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Inspect EIP-7934 zkevm fixtures for block/stateless-input equivalence.
+
+Run from the repo root via execution-specs dependencies, for example:
+
+    uv run --directory execution-specs --quiet python3 \
+        ../scripts/eest-eip7934-input-equivalence.py \
+        ../gen-out/eest-fixtures/zkevm@v0.4.0/fixtures/fixtures/blockchain_tests/for_amsterdam/osaka/eip7934_block_rlp_limit/max_block_rlp_size/block_at_rlp_size_limit_boundary.json
+
+The check intentionally does not feed raw fixture RLP to the guest. It reports
+whether the structured stateless input carries the same block-size-relevant data
+that execution-specs validates with len(rlp.encode(block)).
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+from ethereum.forks.amsterdam.stateless_guest import deserialize_stateless_input
+from ethereum_rlp import rlp
+
+
+def _hex_bytes(s: str) -> bytes:
+    return bytes.fromhex(s[2:] if s.startswith("0x") else s)
+
+
+def iter_stateless_blocks(path: Path):
+    doc = json.loads(path.read_text())
+    for test_name, test_case in doc.items():
+        blocks = test_case.get("blocks") if isinstance(test_case, dict) else None
+        if not isinstance(blocks, list):
+            continue
+        short = test_name.split("::")[-1] if "::" in test_name else test_name
+        for block_index, block in enumerate(blocks):
+            if not isinstance(block, dict):
+                continue
+            sib = block.get("statelessInputBytes")
+            raw_rlp = block.get("rlp")
+            if sib and raw_rlp:
+                yield short, block_index, _hex_bytes(sib), _hex_bytes(raw_rlp)
+
+
+def inspect(path: Path) -> int:
+    rows = []
+    for (
+        test_name,
+        block_index,
+        stateless_input,
+        block_rlp,
+    ) in iter_stateless_blocks(path):
+        decoded_input = deserialize_stateless_input(stateless_input)
+        payload = decoded_input.new_payload_request.execution_payload
+        decoded_block = rlp.decode(block_rlp)
+        header = decoded_block[0]
+        header_extra_data = bytes(header[12])
+        rows.append(
+            (
+                test_name,
+                block_index,
+                hashlib.sha256(stateless_input).hexdigest()[:16],
+                len(payload.extra_data),
+                len(header_extra_data),
+                len(payload.transactions),
+                sum(len(tx) for tx in payload.transactions),
+                len(payload.withdrawals),
+                len(block_rlp),
+            )
+        )
+
+    print(
+        "test	block	stateless_sha16	payload_extra_len	"
+        "fixture_header_extra_len	tx_count	tx_bytes	withdrawals	block_rlp_len"
+    )
+    for row in rows:
+        print("	".join(str(x) for x in row))
+
+    mismatches = [row for row in rows if row[3] != row[4]]
+    if mismatches:
+        print(f"mismatch: {len(mismatches)} block(s) differ in extra_data length")
+        return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("fixture", type=Path)
+    args = parser.parse_args()
+    return inspect(args.fixture)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- document the corrected EIP-7934 direction: the guest must compute block RLP length from statelessInputBytes, not from raw fixture RLP sidecars
- record evidence that the current zkevm boundary fixture has byte-identical stateless inputs while fixture block RLP extra_data lengths differ
- add scripts/eest-eip7934-input-equivalence.py to reproduce the fixture mismatch under execution-specs dependencies

## Evidence
The checker reports the three boundary cases share statelessInputBytes SHA prefix 62d9f1361945ff5d and decode to payload extra_data_len=0, while fixture block RLP header extra_data lengths are 11, 12, and 13. The existing RISC-V verdict probe computes one common rebuilt block RLP length, 8388562, from the visible stateless input.

## Verification
- python3 -m py_compile scripts/eest-eip7934-input-equivalence.py
- lake build EvmAsm.Codegen.Programs.BlockRlpSize
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/BlockRlpSize.lean docs/execution-specs-feedback.md scripts/eest-eip7934-input-equivalence.py
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build

Diagnostic expected to fail on current cached fixture:
- uv run --directory execution-specs --quiet python3 ../scripts/eest-eip7934-input-equivalence.py ../gen-out/eest-fixtures/zkevm@v0.4.0/fixtures/fixtures/blockchain_tests/for_amsterdam/osaka/eip7934_block_rlp_limit/max_block_rlp_size/block_at_rlp_size_limit_boundary.json

Bead: evm-asm-fhsxz.2.4.2.60.5.6.1.1.

Authored by @pirapira; implemented by Codex.