### PR TITLE
fix(eest): accept top-level create collision touches

### DIFF
--- a/EvmAsm/Codegen/Programs/BalCodePreimages.lean
+++ b/EvmAsm/Codegen/Programs/BalCodePreimages.lean
@@ -7,6 +7,7 @@
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.StateCompose
+import EvmAsm.Codegen.Programs.Address
 
 namespace EvmAsm.Codegen
 
@@ -34,9 +35,11 @@ open EvmAsm.Rv64
     the executable spec touches the beneficiary account there without reading
     its bytecode. A pure account-touch row is also accepted when it is the
     `CREATE(to, 0)` address for a legacy transaction target and witness bytecode
-    contains a CREATE opcode, matching the CREATE collision predicate path
-    (`account_has_code_or_nonce` / `account_has_storage`) which does not read
-    bytecode. Rows that carry storage or code activity still reject the
+    contains a CREATE opcode, or when it is the top-level CREATE(sender, nonce)
+    address for a legacy contract-creation transaction. Both match CREATE
+    collision predicate paths (`account_has_code_or_nonce` /
+    `account_has_storage`) which do not read bytecode. Rows that carry storage
+    or code activity still reject the
     extcodesize helper's status 5 and leave deeper obligations for later gates.
     -/
 def balCodePreimagesValidFunction : String :=
@@ -339,8 +342,6 @@ def balCodePreimagesValidFunction : String :=
   "  mv s0, a0                  # 20-byte target address ptr\n" ++
   "  mv s1, a1                  # witness.codes ptr\n" ++
   "  mv s2, a2                  # witness.codes len\n" ++
-  "  jal ra, bal_codes_contains_create_opcode\n" ++
-  "  beqz a0, .Lbcc_no\n" ++
   "  la t0, bv_exec_p; ld s3, 0(t0)\n" ++
   "  la t0, bv_tx_off; ld s4, 0(t0)\n" ++
   "  beqz s3, .Lbcc_no\n" ++
@@ -380,7 +381,31 @@ def balCodePreimagesValidFunction : String :=
   "  jal ra, rlp_list_nth_item\n" ++
   "  bnez a0, .Lbcc_next_tx\n" ++
   "  la t0, bsg_change_ptr; ld t3, 0(t0)\n" ++
-  "  la t0, bsg_to_len; ld t1, 0(t0); li t2, 20; bne t1, t2, .Lbcc_next_tx\n" ++
+  "  la t0, bsg_to_len; ld t1, 0(t0); li t2, 20; beq t1, t2, .Lbcc_internal_create\n" ++
+  "  bnez t1, .Lbcc_next_tx\n" ++
+  "  # Top-level legacy contract creation: compare target with CREATE(sender, nonce).\n" ++
+  "  la t0, bv_public_keys_ptr; ld t4, 0(t0)\n" ++
+  "  la t0, bv_public_keys_len; ld t5, 0(t0)\n" ++
+  "  beqz t4, .Lbcc_next_tx\n" ++
+  "  li t0, 65; mul t1, s8, t0; add t2, t1, t0; bgtu t2, t5, .Lbcc_next_tx\n" ++
+  "  add a0, t4, t1; addi a0, a0, 1       # skip SEC1 0x04 prefix\n" ++
+  "  la a1, bbcv_sender_addr; jal ra, address_from_pubkey\n" ++
+  "  la t0, bsg_change_ptr; ld a0, 0(t0); la t0, bsg_change_item_len; ld a1, 0(t0)\n" ++
+  "  li a2, 0; la a3, bsg_tx_nonce; jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lbcc_next_tx\n" ++
+  "  la a0, bbcv_sender_addr; la t0, bsg_tx_nonce; ld a1, 0(t0); la a2, bbcv_create_addr\n" ++
+  "  jal ra, address_compute_create\n" ++
+  "  la t0, bbcv_create_addr; li t1, 0\n" ++
+  ".Lbcc_cmp_top_create_addr:\n" ++
+  "  li t2, 20; beq t1, t2, .Lbcc_yes\n" ++
+  "  add t3, t0, t1; lbu t3, 0(t3)\n" ++
+  "  add t4, s0, t1; lbu t4, 0(t4)\n" ++
+  "  bne t3, t4, .Lbcc_next_tx\n" ++
+  "  addi t1, t1, 1; j .Lbcc_cmp_top_create_addr\n" ++
+  ".Lbcc_internal_create:\n" ++
+  "  jal ra, bal_codes_contains_create_opcode\n" ++
+  "  beqz a0, .Lbcc_next_tx\n" ++
+  "  la t0, bsg_change_ptr; ld t3, 0(t0)\n" ++
   "  la t0, bsg_to_off; ld t1, 0(t0); add t3, t3, t1\n" ++
   "  la t0, bsr_kbuf            # RLP([to, 0]) buffer\n" ++
   "  li t1, 0xd6; sb t1, 0(t0)\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -28,6 +28,7 @@ import EvmAsm.Codegen.Programs.BalCodePreimages
 import EvmAsm.Codegen.Programs.BlockVerdictModeledSystem
 import EvmAsm.Codegen.Programs.BlockRlpSize
 import EvmAsm.Codegen.Programs.RequestsHash
+import EvmAsm.Codegen.Programs.Address
 import EvmAsm.Codegen.Programs.Eip7702NonceReuseGuard
 namespace EvmAsm.Codegen
 
@@ -611,6 +612,8 @@ def publicKeysValidFunction : String :=
   "  remu t1, s7, t0; bnez t1, .Lpkv_fail\n" ++
   "  divu s8, s7, t0             # public key count\n" ++
   "  bne s8, s4, .Lpkv_fail\n" ++
+  "  la t0, bv_public_keys_ptr; sd s5, 0(t0)\n" ++
+  "  la t0, bv_public_keys_len; sd s7, 0(t0)\n" ++
   "  li s9, 0\n" ++
   ".Lpkv_loop:\n" ++
   "  beq s9, s8, .Lpkv_ok\n" ++
@@ -1018,6 +1021,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   balCodePreimagesValidFunction ++ "\n" ++
   eip8037TxGasGateFunction ++ "\n" ++
   addressFromPubkeyFunction ++ "\n" ++
+  addressComputeCreateFunction ++ "\n" ++
   enrgU32leFunction ++ "\n" ++
   eip7702NonceReuseGuardFunction ++ "\n" ++
   statelessVerdictV2Function ++ "\n" ++
@@ -1115,6 +1119,8 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bv_bal_start:\n  .zero 8\n" ++
   "bv_bal_len:\n  .zero 8\n" ++
   "bv_tx_off:\n  .zero 8\n" ++
+  "bv_public_keys_ptr:\n  .zero 8\n" ++
+  "bv_public_keys_len:\n  .zero 8\n" ++
   "bv_fail_code:\n  .zero 8\n" ++
   "bv_header_status:\n  .zero 8\n" ++
   "bv_state_status:\n  .zero 8\n" ++
@@ -1147,6 +1153,13 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bbcv_fee_recipient_valid:\n  .zero 8\n.balign 8\nbbcv_fee_recipient:\n  .zero 20\n" ++
   ".balign 32\n" ++
   "bbcv_code_hash:\n  .zero 32\n" ++
+  "bbcv_sender_addr:\n  .zero 32\n" ++
+  "bbcv_create_addr:\n  .zero 32\n" ++
+  "ac_buffer:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "ac_nonce_be:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "ac_digest:\n  .zero 32\n" ++
   "bbcv_stop_code_hash:\n" ++
   "  .quad 0x14281e7a9e7836bc, 0x7d818f8229424636, 0x9165d677b4f71266, 0x8ac9bc64e0a996ff\n" ++
   ".balign 32\n" ++
@@ -1183,6 +1196,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bsg_count:\n  .zero 8\n" ++
   "bsg_off:\n  .zero 8\n" ++
   "bsg_len:\n  .zero 8\n" ++
+  "bsg_tx_nonce:\n  .zero 8\n" ++
   "bsg_slot_count:\n  .zero 8\n" ++
   "bsg_slot_off:\n  .zero 8\n" ++
   "bsg_slot_len:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
@@ -138,6 +138,7 @@ def statelessVerdictV2GuestClosure : String :=
   balCodePreimagesValidFunction ++ "\n" ++
   eip8037TxGasGateFunction ++ "\n" ++
   addressFromPubkeyFunction ++ "\n" ++
+  addressComputeCreateFunction ++ "\n" ++
   enrgU32leFunction ++ "\n" ++
   eip7702NonceReuseGuardFunction ++ "\n" ++
   statelessVerdictV2Function


### PR DESCRIPTION
## Summary
- persist the validated SSZ public_keys section for block verdict helpers
- extend the BAL code-preimage exemption to top-level legacy contract-creation collisions by computing CREATE(sender, nonce)
- link address_compute_create in both the standalone verdict probe and embedded stateless guest closure

## Verification
- lake build EvmAsm.Codegen.Programs.BlockVerdict
- lake build EvmAsm.Codegen.Programs.BlockVerdictV2
- scripts/codegen-eest-stateless-check.sh --filter init_colliding_with_non_empty_account --limit 5 --jobs 1 --max-failures 5 --quiet-passes --steps 200000000 --run-dir /tmp/eest-eip3607-init-final
  - full match: 5 / 5
- scripts/codegen-eest-stateless-check.sh --filter init_collision_create_opcode --limit 3 --jobs 1 --max-failures 3 --quiet-passes --steps 200000000 --run-dir /tmp/eest-create-collision-opcode-smoke
  - full match: 3 / 3
- lake build

Note: the earlier --no-build verification runs rebuilt only the debug probe and left the guest ELF stale; final verification above was run without --no-build so the stateless_guest ELF was regenerated.