### PR TITLE
fix(eest): accept internal create2 collision touches

### DIFF
--- a/EvmAsm/Codegen/Programs/BalCodePreimages.lean
+++ b/EvmAsm/Codegen/Programs/BalCodePreimages.lean
@@ -35,9 +35,11 @@ open EvmAsm.Rv64
     the executable spec touches the beneficiary account there without reading
     its bytecode. A pure account-touch row is also accepted when it is the
     `CREATE(to, 0)` address for a legacy transaction target and witness bytecode
-    contains a CREATE opcode, or when it is the top-level CREATE(sender, nonce)
-    address for a legacy contract-creation transaction. Both match CREATE
-    collision predicate paths (`account_has_code_or_nonce` /
+    contains a CREATE opcode, when it is the top-level CREATE(sender, nonce)
+    address for a legacy contract-creation transaction, or when it is a
+    CREATE2 address for a BAL creator row with nonce/storage activity, a
+    recoverable literal salt, and copied initcode present in witness.codes.
+    These match CREATE collision predicate paths (`account_has_code_or_nonce` /
     `account_has_storage`) which do not read bytecode. Rows that carry storage
     or code activity still reject the
     extcodesize helper's status 5 and leave deeper obligations for later gates.
@@ -166,6 +168,9 @@ def balCodePreimagesValidFunction : String :=
   "  bnez a0, .Lbbcv_next\n" ++
   "  la t0, bbcv_addr_off; ld t1, 0(t0); add a0, s10, t1; mv a1, s6; mv a2, s7; mv a3, s0; mv a4, s1\n" ++
   "  jal ra, bal_contains_internal_create_collision_touch\n" ++
+  "  bnez a0, .Lbbcv_next\n" ++
+  "  la t0, bbcv_addr_off; ld t1, 0(t0); add a0, s10, t1; mv a1, s6; mv a2, s7; mv a3, s0; mv a4, s1\n" ++
+  "  jal ra, bal_contains_internal_create2_collision_touch\n" ++
   "  bnez a0, .Lbbcv_next\n" ++
   "  j .Lbbcv_missing_code\n" ++
   ".Lbbcv_missing_code:\n" ++
@@ -517,6 +522,192 @@ def balCodePreimagesValidFunction : String :=
   "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
   "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp); ld s11, 96(sp)\n" ++
   "  addi sp, sp, 112\n" ++
+  "  ret\n" ++
+  "\n" ++
+  "# Return 1 iff witness bytecode exposes a literal CREATE2 salt and a BAL\n" ++
+  "# creator row with nonce/storage activity produces target for some witness\n" ++
+  "# code element used as copied initcode.\n" ++
+  "bal_contains_internal_create2_collision_touch:\n" ++
+  "  addi sp, sp, -104\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp); sd s10, 88(sp); sd s11, 96(sp)\n" ++
+  "  mv s0, a0                  # 20-byte target address ptr\n" ++
+  "  mv s1, a1                  # witness.codes ptr\n" ++
+  "  mv s2, a2                  # witness.codes len\n" ++
+  "  mv s3, a3                  # BAL ptr\n" ++
+  "  mv s4, a4                  # BAL len\n" ++
+  "  mv a0, s1; mv a1, s2; la a2, bbcv_create2_salt\n" ++
+  "  jal ra, bal_codes_find_create2_push4_salt\n" ++
+  "  beqz a0, .Lbic2_no\n" ++
+  "  mv a0, s3; mv a1, s4; la a2, bbcv_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lbic2_no\n" ++
+  "  la t0, bbcv_count; ld s5, 0(t0)\n" ++
+  "  li s6, 0                  # BAL row index\n" ++
+  ".Lbic2_row_loop:\n" ++
+  "  beq s6, s5, .Lbic2_no\n" ++
+  "  mv a0, s3; mv a1, s4; mv a2, s6; la a3, bbcv_off; la a4, bbcv_size\n" ++
+  "  jal ra, rlp_item_span\n" ++
+  "  bnez a0, .Lbic2_next_row\n" ++
+  "  la t0, bbcv_off; ld t1, 0(t0); add s7, s3, t1     # row ptr\n" ++
+  "  la t0, bbcv_size; ld s8, 0(t0)                    # row len\n" ++
+  "  mv a0, s7; mv a1, s8; li a2, 0; la a3, bbcv_addr_off; la a4, bbcv_addr_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbic2_next_row\n" ++
+  "  la t0, bbcv_addr_len; ld t1, 0(t0); li t2, 20; bne t1, t2, .Lbic2_next_row\n" ++
+  "  la t0, bbcv_addr_off; ld t1, 0(t0); add s9, s7, t1 # creator address ptr\n" ++
+  "  mv a0, s7; mv a1, s8; li a2, 4; la a3, bbcv_field_off; la a4, bbcv_field_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbic2_check_storage\n" ++
+  "  la t0, bbcv_field_off; ld t1, 0(t0); add a0, s7, t1\n" ++
+  "  la t0, bbcv_field_len; ld a1, 0(t0); la a2, bbcv_field_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lbic2_check_storage\n" ++
+  "  la t0, bbcv_field_count; ld t1, 0(t0); bnez t1, .Lbic2_try_creator\n" ++
+  ".Lbic2_check_storage:\n" ++
+  "  mv a0, s7; mv a1, s8; li a2, 2; la a3, bbcv_field_off; la a4, bbcv_field_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbic2_next_row\n" ++
+  "  la t0, bbcv_field_off; ld t1, 0(t0); add a0, s7, t1\n" ++
+  "  la t0, bbcv_field_len; ld a1, 0(t0); la a2, bbcv_field_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lbic2_next_row\n" ++
+  "  la t0, bbcv_field_count; ld t1, 0(t0); beqz t1, .Lbic2_next_row\n" ++
+  ".Lbic2_try_creator:\n" ++
+  "  mv a0, s0; mv a1, s1; mv a2, s2; mv a3, s9; la a4, bbcv_create2_salt\n" ++
+  "  jal ra, bal_try_create2_initcodes\n" ++
+  "  bnez a0, .Lbic2_yes\n" ++
+  ".Lbic2_next_row:\n" ++
+  "  addi s6, s6, 1; j .Lbic2_row_loop\n" ++
+  ".Lbic2_yes:\n" ++
+  "  li a0, 1; j .Lbic2_ret\n" ++
+  ".Lbic2_no:\n" ++
+  "  li a0, 0\n" ++
+  ".Lbic2_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp); ld s11, 96(sp)\n" ++
+  "  addi sp, sp, 104\n" ++
+  "  ret\n" ++
+  "\n" ++
+  "# Return 1 after writing a 32-byte salt when a code element contains\n" ++
+  "# PUSH4 <salt>; ...; CREATE2. The PUSH4 literal is zero-extended to BE32.\n" ++
+  "bal_codes_find_create2_push4_salt:\n" ++
+  "  addi sp, sp, -88\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp)\n" ++
+  "  mv s0, a0                  # witness.codes ptr\n" ++
+  "  mv s1, a1                  # witness.codes len\n" ++
+  "  mv s2, a2                  # 32-byte salt output\n" ++
+  "  beqz s1, .Lbc2s_no\n" ++
+  "  mv a0, s0; jal ra, bgv_u32le\n" ++
+  "  andi t0, a0, 3; bnez t0, .Lbc2s_no\n" ++
+  "  srli s3, a0, 2             # code count\n" ++
+  "  beqz s3, .Lbc2s_no\n" ++
+  "  li s4, 0                   # code index\n" ++
+  ".Lbc2s_elem_loop:\n" ++
+  "  beq s4, s3, .Lbc2s_no\n" ++
+  "  slli t0, s4, 2; add a0, s0, t0; jal ra, bgv_u32le\n" ++
+  "  mv s5, a0                  # element offset\n" ++
+  "  addi t0, s4, 1\n" ++
+  "  beq t0, s3, .Lbc2s_last\n" ++
+  "  slli t1, t0, 2; add a0, s0, t1; jal ra, bgv_u32le\n" ++
+  "  j .Lbc2s_have_end\n" ++
+  ".Lbc2s_last:\n" ++
+  "  mv a0, s1\n" ++
+  ".Lbc2s_have_end:\n" ++
+  "  bltu a0, s5, .Lbc2s_next_elem\n" ++
+  "  add s6, s0, s5; sub s7, a0, s5\n" ++
+  "  li t0, 6; bltu s7, t0, .Lbc2s_next_elem\n" ++
+  "  sub s8, s7, t0             # max PUSH4 offset with one following byte\n" ++
+  "  li s9, 0                   # scan offset\n" ++
+  ".Lbc2s_scan_loop:\n" ++
+  "  bgtu s9, s8, .Lbc2s_next_elem\n" ++
+  "  add t1, s6, s9\n" ++
+  "  lbu t2, 0(t1); li t3, 0x63; bne t2, t3, .Lbc2s_advance_scan\n" ++
+  "  addi t4, s9, 5             # search after PUSH4 immediate\n" ++
+  ".Lbc2s_find_create2:\n" ++
+  "  beq t4, s7, .Lbc2s_advance_scan\n" ++
+  "  add t5, s6, t4; lbu t5, 0(t5); li t6, 0xf5; beq t5, t6, .Lbc2s_write_salt\n" ++
+  "  addi t4, t4, 1; j .Lbc2s_find_create2\n" ++
+  ".Lbc2s_write_salt:\n" ++
+  "  sd zero, 0(s2); sd zero, 8(s2); sd zero, 16(s2); sw zero, 24(s2)\n" ++
+  "  lbu t0, 1(t1); sb t0, 28(s2)\n" ++
+  "  lbu t0, 2(t1); sb t0, 29(s2)\n" ++
+  "  lbu t0, 3(t1); sb t0, 30(s2)\n" ++
+  "  lbu t0, 4(t1); sb t0, 31(s2)\n" ++
+  "  li a0, 1; j .Lbc2s_ret\n" ++
+  ".Lbc2s_advance_scan:\n" ++
+  "  addi s9, s9, 1; j .Lbc2s_scan_loop\n" ++
+  ".Lbc2s_next_elem:\n" ++
+  "  addi s4, s4, 1; j .Lbc2s_elem_loop\n" ++
+  ".Lbc2s_no:\n" ++
+  "  li a0, 0\n" ++
+  ".Lbc2s_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp)\n" ++
+  "  addi sp, sp, 88\n" ++
+  "  ret\n" ++
+  "\n" ++
+  "# Try every witness code element as copied initcode for CREATE2.\n" ++
+  "bal_try_create2_initcodes:\n" ++
+  "  addi sp, sp, -88\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp)\n" ++
+  "  mv s0, a0                  # target address ptr\n" ++
+  "  mv s1, a1                  # witness.codes ptr\n" ++
+  "  mv s2, a2                  # witness.codes len\n" ++
+  "  mv s3, a3                  # creator address ptr\n" ++
+  "  mv s4, a4                  # salt ptr\n" ++
+  "  beqz s2, .Lbtci_no\n" ++
+  "  mv a0, s1; jal ra, bgv_u32le\n" ++
+  "  andi t0, a0, 3; bnez t0, .Lbtci_no\n" ++
+  "  srli s5, a0, 2             # code count\n" ++
+  "  beqz s5, .Lbtci_no\n" ++
+  "  li s6, 0                   # code index\n" ++
+  ".Lbtci_elem_loop:\n" ++
+  "  beq s6, s5, .Lbtci_no\n" ++
+  "  slli t0, s6, 2; add a0, s1, t0; jal ra, bgv_u32le\n" ++
+  "  mv s7, a0                  # element offset\n" ++
+  "  addi t0, s6, 1\n" ++
+  "  beq t0, s5, .Lbtci_last\n" ++
+  "  slli t1, t0, 2; add a0, s1, t1; jal ra, bgv_u32le\n" ++
+  "  j .Lbtci_have_end\n" ++
+  ".Lbtci_last:\n" ++
+  "  mv a0, s2\n" ++
+  ".Lbtci_have_end:\n" ++
+  "  bltu a0, s7, .Lbtci_next_elem\n" ++
+  "  add s8, s1, s7; sub s9, a0, s7\n" ++
+  "  mv a0, s3; mv a1, s4; mv a2, s8; mv a3, s9; la a4, bbcv_create_addr\n" ++
+  "  jal ra, address_compute_create2\n" ++
+  "  la t0, bbcv_create_addr; li t1, 0\n" ++
+  ".Lbtci_cmp_addr:\n" ++
+  "  li t2, 20; beq t1, t2, .Lbtci_yes\n" ++
+  "  add t3, t0, t1; lbu t3, 0(t3)\n" ++
+  "  add t4, s0, t1; lbu t4, 0(t4)\n" ++
+  "  bne t3, t4, .Lbtci_next_elem\n" ++
+  "  addi t1, t1, 1; j .Lbtci_cmp_addr\n" ++
+  ".Lbtci_next_elem:\n" ++
+  "  addi s6, s6, 1; j .Lbtci_elem_loop\n" ++
+  ".Lbtci_yes:\n" ++
+  "  li a0, 1; j .Lbtci_ret\n" ++
+  ".Lbtci_no:\n" ++
+  "  li a0, 0\n" ++
+  ".Lbtci_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp)\n" ++
+  "  addi sp, sp, 88\n" ++
   "  ret\n" ++
   "\n" ++
   "# Return 1 iff any witness code byte is CREATE (0xf0).\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -1022,6 +1022,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   eip8037TxGasGateFunction ++ "\n" ++
   addressFromPubkeyFunction ++ "\n" ++
   addressComputeCreateFunction ++ "\n" ++
+  addressComputeCreate2Function ++ "\n" ++
   enrgU32leFunction ++ "\n" ++
   eip7702NonceReuseGuardFunction ++ "\n" ++
   statelessVerdictV2Function ++ "\n" ++
@@ -1155,6 +1156,10 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bbcv_code_hash:\n  .zero 32\n" ++
   "bbcv_sender_addr:\n  .zero 32\n" ++
   "bbcv_create_addr:\n  .zero 32\n" ++
+  "bbcv_create2_salt:\n  .zero 32\n" ++
+  "ac2_inner_digest:\n  .zero 32\n" ++
+  "ac2_outer_digest:\n  .zero 32\n" ++
+  "ac2_preimage:\n  .zero 88\n" ++
   "ac_buffer:\n  .zero 32\n" ++
   ".balign 8\n" ++
   "ac_nonce_be:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
@@ -139,6 +139,7 @@ def statelessVerdictV2GuestClosure : String :=
   eip8037TxGasGateFunction ++ "\n" ++
   addressFromPubkeyFunction ++ "\n" ++
   addressComputeCreateFunction ++ "\n" ++
+  addressComputeCreate2Function ++ "\n" ++
   enrgU32leFunction ++ "\n" ++
   eip7702NonceReuseGuardFunction ++ "\n" ++
   statelessVerdictV2Function


### PR DESCRIPTION
## Summary
- Stack on PR #7936 and handle the remaining create_fail_result CREATE2 child collision cases.
- Accept pure missing-code BAL touches when a nonce/storage-changing BAL creator row plus a recovered literal CREATE2 salt and copied witness initcode recompute the touched address exactly.
- Wire address_compute_create2 and its scratch buffers into the stateless verdict closures.

Refs #7936. Bead: evm-asm-fhsxz.2.4.2.60.6.4.3.2.

## Verification
- lake build EvmAsm.Codegen.Programs.BalCodePreimages EvmAsm.Codegen.Programs.BlockVerdict EvmAsm.Codegen.Programs.BlockVerdictV2
- scripts/codegen-eest-stateless-check.sh --filter create_fail_result --limit 20 --jobs 1 --max-failures 20 --quiet-passes --steps 200000000 --run-dir /tmp/eest-create-fail-result-create2-fix-4
  - selected 10, full match 10, root match 10, succ match 10, tail match 10, fail 0
- scripts/codegen-eest-stateless-check.sh --filter init_colliding_with_non_empty_account --limit 5 --jobs 1 --max-failures 5 --quiet-passes --steps 200000000 --run-dir /tmp/eest-init-colliding-smoke-create2
  - selected 5, full match 5, fail 0
- scripts/codegen-eest-stateless-check.sh --filter init_collision_create_opcode --limit 3 --jobs 1 --max-failures 3 --quiet-passes --steps 200000000 --run-dir /tmp/eest-create-opcode-smoke-create2
  - selected 3, full match 3, fail 0
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Codegen/Programs/BalCodePreimages.lean EvmAsm/Codegen/Programs/BlockVerdict.lean EvmAsm/Codegen/Programs/BlockVerdictV2.lean
- git diff --check
- scripts/codegen-zisk-address-compute-create2-check.sh
- lake build

Authored by @pirapira; implemented by Codex