### PR TITLE
fix(eest): accept balance-only BAL code touches

### DIFF
--- a/EvmAsm/Codegen/Programs/BalCodePreimages.lean
+++ b/EvmAsm/Codegen/Programs/BalCodePreimages.lean
@@ -30,7 +30,8 @@ open EvmAsm.Rv64
     Amsterdam warms/touches coinbase without reading its bytecode. A
     literal `PUSH20 <address>; EXTCODEHASH` occurs in witness bytecode, since
     EXTCODEHASH reads the account leaf's code_hash and does not call
-    WitnessState.get_code. A pure account-touch row is also accepted when a
+    WitnessState.get_code. Likewise, literal `PUSH20 <address>; BALANCE`
+    reads only the account leaf's balance. A pure account-touch row is also accepted when a
     legacy transaction data payload contains `PUSH20 <address>; SELFDESTRUCT`:
     the executable spec touches the beneficiary account there without reading
     its bytecode. A pure account-touch row is also accepted when it is the
@@ -158,6 +159,10 @@ def balCodePreimagesValidFunction : String :=
   "  mv a0, s6; mv a1, s7\n" ++
   "  jal ra, bal_codes_contains_push20_extcodehash\n" ++
   "  bnez a0, .Lbbcv_next\n" ++
+  "  la t0, bbcv_addr_off; ld t1, 0(t0); add a2, s10, t1\n" ++
+  "  mv a0, s6; mv a1, s7\n" ++
+  "  jal ra, bal_codes_contains_push20_balance\n" ++
+  "  bnez a0, .Lbbcv_next\n" ++
   "  la t0, bbcv_addr_off; ld t1, 0(t0); add a0, s10, t1\n" ++
   "  jal ra, bal_txs_contains_push20_selfdestruct\n" ++
   "  bnez a0, .Lbbcv_next\n" ++
@@ -244,6 +249,78 @@ def balCodePreimagesValidFunction : String :=
   ".Lbce_no:\n" ++
   "  li a0, 0\n" ++
   ".Lbce_ret:\n" ++
+  "  ld s0, 0(sp); ld s1, 8(sp); ld s2, 16(sp)\n" ++
+  "  ld s3, 24(sp); ld s4, 32(sp); ld s5, 40(sp)\n" ++
+  "  addi sp, sp, 56\n" ++
+  "  ret\n" ++
+  "\n" ++
+  "# Return 1 iff any witness code contains PUSH20 <addr>; BALANCE.\n" ++
+  "# BALANCE reads account.balance from the state leaf and does not require\n" ++
+  "# WitnessState.get_code for the touched account.\n" ++
+  "bal_codes_contains_push20_balance:\n" ++
+  "  addi sp, sp, -56\n" ++
+  "  sd s0, 0(sp); sd s1, 8(sp); sd s2, 16(sp)\n" ++
+  "  sd s3, 24(sp); sd s4, 32(sp); sd s5, 40(sp)\n" ++
+  "  mv s0, a0                  # witness.codes section ptr\n" ++
+  "  mv s1, a1                  # witness.codes section len\n" ++
+  "  mv s2, a2                  # 20-byte target address ptr\n" ++
+  "  beqz s1, .Lbcb_no\n" ++
+  "  lwu t0, 0(s0)              # first element offset = 4*N\n" ++
+  "  srli s3, t0, 2             # s3 = N\n" ++
+  "  li s4, 0\n" ++
+  ".Lbcb_elem_loop:\n" ++
+  "  beq s4, s3, .Lbcb_no\n" ++
+  "  slli t0, s4, 2\n" ++
+  "  add t1, s0, t0\n" ++
+  "  lwu t2, 0(t1)              # element offset\n" ++
+  "  add s5, s0, t2             # element start\n" ++
+  "  addi t3, s4, 1\n" ++
+  "  beq t3, s3, .Lbcb_elem_end_section\n" ++
+  "  slli t3, t3, 2\n" ++
+  "  add t3, s0, t3\n" ++
+  "  lwu t4, 0(t3)\n" ++
+  "  add t4, s0, t4             # element end\n" ++
+  "  j .Lbcb_have_elem_end\n" ++
+  ".Lbcb_elem_end_section:\n" ++
+  "  add t4, s0, s1\n" ++
+  ".Lbcb_have_elem_end:\n" ++
+  "  sub t4, t4, s5             # element len\n" ++
+  "  li t5, 22\n" ++
+  "  bltu t4, t5, .Lbcb_next_elem\n" ++
+  "  sub t6, t4, t5             # max start offset\n" ++
+  "  li t0, 0                   # scan offset\n" ++
+  ".Lbcb_scan_loop:\n" ++
+  "  bgtu t0, t6, .Lbcb_next_elem\n" ++
+  "  add t1, s5, t0\n" ++
+  "  lbu t2, 0(t1)\n" ++
+  "  li t3, 0x73                # PUSH20\n" ++
+  "  bne t2, t3, .Lbcb_advance_scan\n" ++
+  "  li t3, 0                   # address byte index\n" ++
+  ".Lbcb_addr_loop:\n" ++
+  "  li t2, 20\n" ++
+  "  beq t3, t2, .Lbcb_check_opcode\n" ++
+  "  add t4, t1, t3\n" ++
+  "  lbu t4, 1(t4)\n" ++
+  "  add t5, s2, t3\n" ++
+  "  lbu t5, 0(t5)\n" ++
+  "  bne t4, t5, .Lbcb_advance_scan\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  j .Lbcb_addr_loop\n" ++
+  ".Lbcb_check_opcode:\n" ++
+  "  lbu t4, 21(t1)\n" ++
+  "  li t5, 0x31                # BALANCE\n" ++
+  "  beq t4, t5, .Lbcb_yes\n" ++
+  ".Lbcb_advance_scan:\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  j .Lbcb_scan_loop\n" ++
+  ".Lbcb_next_elem:\n" ++
+  "  addi s4, s4, 1\n" ++
+  "  j .Lbcb_elem_loop\n" ++
+  ".Lbcb_yes:\n" ++
+  "  li a0, 1; j .Lbcb_ret\n" ++
+  ".Lbcb_no:\n" ++
+  "  li a0, 0\n" ++
+  ".Lbcb_ret:\n" ++
   "  ld s0, 0(sp); ld s1, 8(sp); ld s2, 16(sp)\n" ++
   "  ld s3, 24(sp); ld s4, 32(sp); ld s5, 40(sp)\n" ++
   "  addi sp, sp, 56\n" ++


### PR DESCRIPTION
## Summary
- accept pure BAL account-touch rows when witness bytecode contains literal `PUSH20 <address>; BALANCE`
- avoid requiring the touched account's code preimage for BALANCE, which only reads the account leaf balance
- clears the scenarios.json `program_BALANCE` b31-b36 succ-bit failure cluster

## Verification
- `lake build EvmAsm.Codegen.Programs.BalCodePreimages`
- `lake build EvmAsm.Codegen.Programs.BlockVerdict`
- `scripts/codegen-zisk-balance-at-header-state-root-check.sh`
- `scripts/codegen-eest-stateless-check.sh --filter frontier/scenarios/scenarios/scenarios --skip 105 --limit 6 --jobs 1 --max-failures 6 --quiet-passes --steps 200000000 --run-dir /tmp/eest-balance-scenarios-pr` (6/6 full match)
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build EvmAsm.Codegen.Programs.Evm`
- `lake build`

Bead: evm-asm-fhsxz.2.4.2.60.5.3.1

Authored by @pirapira; implemented by Codex.