### PR TITLE
feat(precompile): add BLS12 map-Fp2-to-G2 framing

### DIFF
--- a/EvmAsm/Stateless/VM/Precompiles.lean
+++ b/EvmAsm/Stateless/VM/Precompiles.lean
@@ -38,6 +38,7 @@
 import EvmAsm.EL.Bn254G1AddEcallBridge
 import EvmAsm.EL.Bn254G1MulEcallBridge
 import EvmAsm.EL.Bn254PairingEcallBridge
+import EvmAsm.EL.Bls12MapFp2ToG2EcallBridge
 import EvmAsm.EL.KzgPointEvalEcallBridge
 import EvmAsm.EL.ModexpEcallBridge
 import EvmAsm.EL.Secp256r1VerifyEcallBridge
@@ -531,6 +532,143 @@ theorem gasCost_one_byte_small_exp :
       simp [execute, h_valid, h_not, h_status]
 
 end Modexp
+
+namespace BLS12
+
+namespace MapFp2ToG2
+
+abbrev MemoryReader := EvmAsm.EL.Bls12MapFp2ToG2InputBridge.MemoryReader
+abbrev AcceleratorInput := EvmAsm.EL.Bls12MapFp2ToG2InputBridge.AcceleratorInput
+abbrev AcceleratorResult := EvmAsm.EL.Bls12MapFp2ToG2ResultBridge.AcceleratorResult
+
+/-- EVM precompile address for BLS12-381 map-Fp2-to-G2. -/
+def address : Nat := 0x11
+
+/-- Osaka executable-spec fixed gas cost for BLS12-381 map-Fp2-to-G2. -/
+def gasCost : Nat := 23800
+
+/-- BLS12 map-Fp2-to-G2 consumes exactly one 128-byte Fp2 element. -/
+def inputLength : Nat := 128
+
+/-- Invalid length, invalid field element, or accelerator failure returns no bytes. -/
+def emptyOutput : ByteList := []
+
+/--
+Result surface exposed by the pure BLS12-381 map-Fp2-to-G2 framing layer.
+`exceptional = true` records executable-spec `InvalidParameter` cases.
+-/
+structure Result where
+  exceptional : Bool
+  status : ZkvmStatus
+  output : ByteList
+  gasCharged : Nat
+  deriving Repr
+
+/--
+Build the accelerator input from EVM call data. The executable spec first checks
+`len(data) == 128`; callers must guard this helper with that exact length check.
+-/
+def acceleratorInputFromCallData (memory : MemoryReader) (dataStart : Nat) :
+    AcceleratorInput :=
+  EvmAsm.EL.Bls12MapFp2ToG2InputBridge.bls12MapFp2ToG2InputFromMemory
+    memory dataStart
+
+/--
+Pure BLS12-381 map-Fp2-to-G2 precompile framing. Field-element validation and
+map-to-curve arithmetic are supplied by the accelerator model.
+-/
+def execute
+    (accelerator : AcceleratorInput → AcceleratorResult)
+    (memory : MemoryReader) (dataStart dataLength : Nat) : Result :=
+  if dataLength = inputLength then
+    let input := acceleratorInputFromCallData memory dataStart
+    let result := EvmAsm.EL.Bls12MapFp2ToG2EcallBridge.executeBls12MapFp2ToG2Ecall accelerator
+      (EvmAsm.EL.Bls12MapFp2ToG2EcallBridge.requestFromInput input)
+    match result.status with
+    | .eok =>
+        { exceptional := false
+          status := result.status
+          output := EvmAsm.EL.Bls12MapFp2ToG2ResultBridge.g2PointBytesList result.output.point
+          gasCharged := gasCost }
+    | .efail =>
+        { exceptional := true
+          status := result.status
+          output := emptyOutput
+          gasCharged := gasCost }
+  else
+    { exceptional := true
+      status := .efail
+      output := emptyOutput
+      gasCharged := 0 }
+
+theorem emptyOutput_length :
+    emptyOutput.length = 0 := rfl
+
+@[simp] theorem execute_badLength
+    (accelerator : AcceleratorInput → AcceleratorResult)
+    (memory : MemoryReader) (dataStart dataLength : Nat)
+    (h_length : dataLength ≠ inputLength) :
+    execute accelerator memory dataStart dataLength =
+      { exceptional := true
+        status := .efail
+        output := emptyOutput
+        gasCharged := 0 } := by
+  simp [execute, h_length]
+
+@[simp] theorem execute_status
+    (accelerator : AcceleratorInput → AcceleratorResult)
+    (memory : MemoryReader) (dataStart : Nat) :
+    (execute accelerator memory dataStart inputLength).status =
+      (accelerator (acceleratorInputFromCallData memory dataStart)).status := by
+  cases h_status : (accelerator (acceleratorInputFromCallData memory dataStart)).status <;>
+    simp [execute, inputLength, h_status,
+      EvmAsm.EL.Bls12MapFp2ToG2EcallBridge.executeBls12MapFp2ToG2Ecall,
+      EvmAsm.EL.Bls12MapFp2ToG2EcallBridge.requestFromInput]
+
+@[simp] theorem execute_output_eok
+    (accelerator : AcceleratorInput → AcceleratorResult)
+    (memory : MemoryReader) (dataStart : Nat)
+    (h_status : (accelerator (acceleratorInputFromCallData memory dataStart)).status = .eok) :
+    (execute accelerator memory dataStart inputLength).output =
+      EvmAsm.EL.Bls12MapFp2ToG2ResultBridge.g2PointBytesList
+        (accelerator (acceleratorInputFromCallData memory dataStart)).output.point := by
+  simp [execute, inputLength, h_status,
+    EvmAsm.EL.Bls12MapFp2ToG2EcallBridge.executeBls12MapFp2ToG2Ecall,
+    EvmAsm.EL.Bls12MapFp2ToG2EcallBridge.requestFromInput]
+
+@[simp] theorem execute_output_efail
+    (accelerator : AcceleratorInput → AcceleratorResult)
+    (memory : MemoryReader) (dataStart : Nat)
+    (h_status : (accelerator (acceleratorInputFromCallData memory dataStart)).status = .efail) :
+    (execute accelerator memory dataStart inputLength).output = emptyOutput := by
+  simp [execute, inputLength, h_status,
+    EvmAsm.EL.Bls12MapFp2ToG2EcallBridge.executeBls12MapFp2ToG2Ecall,
+    EvmAsm.EL.Bls12MapFp2ToG2EcallBridge.requestFromInput]
+
+theorem execute_output_eok_length
+    (accelerator : AcceleratorInput → AcceleratorResult)
+    (memory : MemoryReader) (dataStart : Nat)
+    (h_status : (accelerator (acceleratorInputFromCallData memory dataStart)).status = .eok) :
+    (execute accelerator memory dataStart inputLength).output.length = 192 := by
+  simp [execute_output_eok accelerator memory dataStart h_status,
+    EvmAsm.EL.Bls12MapFp2ToG2ResultBridge.g2PointBytesList_length]
+
+@[simp] theorem execute_gasCharged
+    (accelerator : AcceleratorInput → AcceleratorResult)
+    (memory : MemoryReader) (dataStart dataLength : Nat) :
+    (execute accelerator memory dataStart dataLength).gasCharged =
+      if dataLength = inputLength then gasCost else 0 := by
+  by_cases h_length : dataLength = inputLength
+  · subst dataLength
+    cases h_status : (accelerator (acceleratorInputFromCallData memory dataStart)).status <;>
+      simp [execute, inputLength, h_status,
+        EvmAsm.EL.Bls12MapFp2ToG2EcallBridge.executeBls12MapFp2ToG2Ecall,
+        EvmAsm.EL.Bls12MapFp2ToG2EcallBridge.requestFromInput]
+  · simp [execute, h_length]
+
+end MapFp2ToG2
+
+end BLS12
 
 namespace KzgPointEvaluation
 


### PR DESCRIPTION
## Summary
- add pure BLS12-381 map-Fp2-to-G2 EVM framing under `BLS12.MapFp2ToG2`
- model Osaka executable-spec exact input length, fixed gas cost, invalid-length exceptional result, and accelerator failure result
- delegate field validation and map-to-curve arithmetic to the existing accelerator bridge and expose status/output/gas simp theorems

Bead: evm-asm-fhsxz.2.4.2.62.3.7.4

## Verification
- `lake build EvmAsm.Stateless.VM.Precompiles`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Stateless/VM/Precompiles.lean` (no matches)
- `lake build`

Authored by @pirapira; implemented by Codex.