### PR TITLE
feat(precompile): encode RIPEMD160 output padding contract

### DIFF
--- a/EvmAsm/EL/Ripemd160ResultBridge.lean
+++ b/EvmAsm/EL/Ripemd160ResultBridge.lean
@@ -4,10 +4,11 @@
   Bridge from the zkVM RIPEMD160 accelerator output to the EVM stack word
   returned by the precompile-facing executable spec.
 
-  The accelerator returns a 20-byte hash (`zkvm_ripemd160_hash`); the EVM
-  precompile 0x03 left-pads that to a 32-byte stack word, so big-endian
-  decoding of the bare 20-byte list naturally yields a value with the high
-  12 bytes zero.
+  The RIPEMD160 computation boundary returns a raw 20-byte digest. The EVM
+  precompile 0x03 returns 32 bytes: 12 leading zero bytes followed by that
+  digest, matching execution-specs' `left_pad_zero_bytes(hash_bytes, 32)`.
+  Big-endian decoding of the bare 20-byte digest naturally yields the same
+  stack word, with the high 12 bytes zero.
 -/
 
 import EvmAsm.EL.KeccakResultBridge
@@ -28,6 +29,14 @@ structure AcceleratorOutput where
 def hashBytesList (hash : HashBytes) : List Byte :=
   List.ofFn hash
 
+/-- EVM RIPEMD160 returndata: 12 leading zero bytes followed by the digest. -/
+def evmOutputBytesFromHash (hash : HashBytes) : List Byte :=
+  List.replicate 12 0 ++ hashBytesList hash
+
+/-- EVM RIPEMD160 returndata from an accelerator/software output payload. -/
+def evmOutputBytesFromAcceleratorOutput (output : AcceleratorOutput) : List Byte :=
+  evmOutputBytesFromHash output.hash
+
 /-- Big-endian byte conversion matching executable-spec `U256.from_be_bytes`. -/
 def wordFromBigEndianBytes (bytes : List Byte) : EvmWord :=
   KeccakResultBridge.wordFromBigEndianBytes bytes
@@ -45,6 +54,22 @@ def stackWordFromAcceleratorOutput (output : AcceleratorOutput) : EvmWord :=
 theorem hashBytesList_length (hash : HashBytes) :
     (hashBytesList hash).length = 20 := by
   simp [hashBytesList]
+
+theorem evmOutputBytesFromHash_length (hash : HashBytes) :
+    (evmOutputBytesFromHash hash).length = 32 := by
+  simp [evmOutputBytesFromHash, hashBytesList]
+
+theorem evmOutputBytesFromHash_take_padding (hash : HashBytes) :
+    (evmOutputBytesFromHash hash).take 12 = List.replicate 12 0 := by
+  simp [evmOutputBytesFromHash]
+
+theorem evmOutputBytesFromHash_drop_padding (hash : HashBytes) :
+    (evmOutputBytesFromHash hash).drop 12 = hashBytesList hash := by
+  simp [evmOutputBytesFromHash]
+
+theorem evmOutputBytesFromAcceleratorOutput_length (output : AcceleratorOutput) :
+    (evmOutputBytesFromAcceleratorOutput output).length = 32 :=
+  evmOutputBytesFromHash_length output.hash
 
 @[simp] theorem wordFromBigEndianBytes_nil :
     wordFromBigEndianBytes [] = 0 := rfl

--- a/docs/zkvm-accelerators-interface.md
+++ b/docs/zkvm-accelerators-interface.md
@@ -110,6 +110,14 @@ exists. The next implementation slice must either add/prove a concrete zisk
 RIPEMD160 backend path, or explicitly implement RIPEMD160 in the guest and test
 it against Ethereum's `hashlib.new("ripemd160", data)` behavior.
 
+RIPEMD160 has two byte-level boundaries. The computation boundary produces the
+raw 20-byte digest. The EVM precompile output boundary is 32 bytes: 12 leading
+zero bytes followed by that digest, matching execution-specs
+`left_pad_zero_bytes(hash_bytes, 32)`. The Lean bridge records this as
+`Ripemd160ResultBridge.evmOutputBytesFromHash`; dispatch code should copy those
+32 bytes as returndata, while stack-word views may decode the raw 20-byte
+digest as a big-endian word because the high 12 bytes are then zero.
+
 ECRECOVER is only partially supported at the zisk layer:
 
 - ziskemu has secp256k1 point-add and point-double primitives


### PR DESCRIPTION
## Summary
- Add explicit RIPEMD160 EVM output-byte helpers: 12 leading zero bytes followed by the raw 20-byte digest.
- Add Lean shape lemmas for 32-byte output length, padding prefix, and digest suffix.
- Document the raw digest vs EVM returndata boundary against execution-specs `left_pad_zero_bytes(hash_bytes, 32)`.

## Verification
- `lake build EvmAsm.EL.Ripemd160ResultBridge`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/EL/Ripemd160ResultBridge.lean docs/zkvm-accelerators-interface.md` (no matches)
- `git diff --check`
- `lake build`

Bead: evm-asm-fhsxz.2.4.2.62.2.4.3.

Authored by @pirapira; implemented by Codex