### PR TITLE
fix(post-state): handle noop state descriptors

### DIFF
--- a/EvmAsm/Codegen/Programs/MptStateRootIns.lean
+++ b/EvmAsm/Codegen/Programs/MptStateRootIns.lean
@@ -67,7 +67,7 @@ def mptStateRootInsFunction : String :=
   "  mv a1, s0\n" ++
   "  mv a2, s1\n" ++
   "  la a7, mset_dr_root\n" ++
-  "  li t3, 3; beq t2, t3, .Lsri_after\n" ++
+  "  li t3, 3; beq t2, t3, .Lsri_noop\n" ++
   "  li t3, 2; beq t2, t3, .Lsri_delete\n" ++
   "  beqz t2, .Lsri_modify\n" ++
   "  jal ra, mpt_insert_acc\n" ++
@@ -77,6 +77,9 @@ def mptStateRootInsFunction : String :=
   "  j .Lsri_after\n" ++
   ".Lsri_modify:\n" ++
   "  jal ra, mpt_set_acc\n" ++
+  "  j .Lsri_after\n" ++
+  ".Lsri_noop:\n" ++
+  "  li a0, 0\n" ++
   ".Lsri_after:\n" ++
   "  bnez a0, .Lsri_fail\n" ++
   "  addi s5, s5, 1\n" ++

--- a/scripts/codegen-zisk-mpt-state-root-ins-check.sh
+++ b/scripts/codegen-zisk-mpt-state-root-ins-check.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # codegen-zisk-mpt-state-root-ins-check.sh -- verify mpt_state_root_ins (bead
 # evm-asm-fhsxz.2.4.2.6.3): the insert-aware multi-change driver. The vector is
-# a MODIFY of an existing key followed by an INSERT into an empty branch slot;
-# the insert must resolve the modified root from the appendable node DB. This
-# also validates mpt_insert_acc's DB-resolve path end-to-end.
+# a MODIFY of an existing key followed by an INSERT into an empty branch slot,
+# plus a focused no-op/modify/delete descriptor-mode case. The insert/delete
+# paths must resolve modified roots from the appendable node DB.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
@@ -22,7 +22,7 @@ lake exe codegen --program zisk_mpt_state_root_ins --halt linux93 \
   -o "$REPO_ROOT/gen-out/zisk_mpt_state_root_ins"
 read_u64() { od -An -tu8 -j "$2" -N 8 "$1" | tr -d ' \n'; }
 fail=0
-for name in state_root_ins state_root_ins_deep state_root_ins_dbchild; do
+for name in state_root_ins state_root_ins_deep state_root_ins_dbchild state_root_ins_delete_noop; do
   out="$VDIR/$name.sri.output"
   if ! "$ZISKEMU" -e "$REPO_ROOT/gen-out/zisk_mpt_state_root_ins.elf" \
         -i "$VDIR/$name.input" -o "$out" -n 8000000 >/dev/null 2>&1 </dev/null; then
@@ -32,7 +32,7 @@ for name in state_root_ins state_root_ins_deep state_root_ins_dbchild; do
   act="$(od -An -tx1 -j 0 -N 32 "$out" | tr -d ' \n')"
   exp="$(cat "$VDIR/$name.expected")"
   if [[ "$st" == "0" && "$act" == "$exp" ]]; then
-    echo "  PASS   $name  root=${act:0:16}.. (modify+insert via DB)"
+    echo "  PASS   $name  root=${act:0:16}.."
   else
     echo "  FAIL   $name  status=$st"; echo "    exp $exp"; echo "    got $act"; fail=1
   fi

--- a/scripts/mpt_ref.py
+++ b/scripts/mpt_ref.py
@@ -952,18 +952,28 @@ def vec_state_root_ins_longkey():
                 root=trie_root(root), changes=changes,
                 expected=trie_root(new_root))
 # ---- insert-aware multi-change driver (mpt_state_root_ins .2.4.2.6.3) ------
+def state_root_ins_mode(mode) -> int:
+    if isinstance(mode, bool):
+        return 1 if mode else 0
+    return int(mode)
+
+
 def build_state_root_ins_input(root_hash, changes, witness_section) -> bytes:
     """ziskemu -i body for zisk_mpt_state_root_ins (file maps to INPUT+8):
       +8 witness_len | +16 n_changes | +24 root_hash(32B)
-      +56 table: N x (path_len:u64, value_len:u64, is_insert:u64)
-      then blobs path0,value0,... (each 8-aligned) | then witness."""
+      +56 table: N x (path_len:u64, value_len:u64, mode:u64)
+      then blobs path0,value0,... (each 8-aligned) | then witness.
+
+    Mode values mirror mpt_state_root_ins descriptors: 0=modify, 1=insert,
+    2=delete, 3=noop. Historical callers still pass booleans.
+    """
     body = bytearray()
     body += struct.pack("<Q", len(witness_section))
     body += struct.pack("<Q", len(changes))
     body += root_hash
-    for (path, value, isins) in changes:
-        body += struct.pack("<QQQ", len(path), len(value), 1 if isins else 0)
-    for (path, value, isins) in changes:
+    for (path, value, mode) in changes:
+        body += struct.pack("<QQQ", len(path), len(value), state_root_ins_mode(mode))
+    for (path, value, mode) in changes:
         body += bytes(path)
         while len(body) % 8 != 0:
             body += b"\x00"
@@ -1057,6 +1067,28 @@ def vec_state_root_ins_dbchild():
     return dict(name="state_root_ins_dbchild", witness=[root, bb, leaf_a],
                 root=trie_root(root), changes=changes,
                 expected=trie_root(root2))
+
+
+def vec_state_root_ins_delete_noop():
+    """Descriptor mode coverage for the post-state trie driver. change0 is a
+    no-op, change1 modifies leaf A and places the new root in the DB, and
+    change2 deletes leaf B from that DB-resident root. This exercises modes
+    3 and 2 in one sequential descriptor run."""
+    a_old, b_old, a_new = b"A" * 32, b"B" * 32, b"a-after-noop" * 3
+    leaf_a = leaf_node([0xa, 0xb], a_old)
+    leaf_b = leaf_node([0xc, 0xd], b_old)
+    slots = [b"\x80"] * 16
+    slots[0x1] = node_ref(leaf_a)
+    slots[0x2] = node_ref(leaf_b)
+    root = branch_node(slots)
+    root2 = leaf_node([0x1, 0xa, 0xb], a_new)
+    changes = [
+        ([0x1, 0xa, 0xb], b"ignored-noop-value", 3),
+        ([0x1, 0xa, 0xb], a_new, 0),
+        ([0x2, 0xc, 0xd], b"", 2),
+    ]
+    return dict(name="state_root_ins_delete_noop", witness=[root, leaf_a, leaf_b],
+                root=trie_root(root), changes=changes, expected=trie_root(root2))
 
 
 if __name__ == "__main__":
@@ -1202,3 +1234,11 @@ if __name__ == "__main__":
         f.write(sridc["expected"].hex())
     print(f"{'sri_dbchild':12} root={sridc['root'].hex()[:16]}.. "
           f"final_root={sridc['expected'].hex()} (insert via DB-modified child)")
+    sridn = vec_state_root_ins_delete_noop()
+    sec = ssz_section(sridn["witness"])
+    with open(f"{outdir}/state_root_ins_delete_noop.input", "wb") as f:
+        f.write(build_state_root_ins_input(sridn["root"], sridn["changes"], sec))
+    with open(f"{outdir}/state_root_ins_delete_noop.expected", "w") as f:
+        f.write(sridn["expected"].hex())
+    print(f"{'sri_del_noop':12} root={sridn['root'].hex()[:16]}.. "
+          f"final_root={sridn['expected'].hex()} (noop+modify+delete)")


### PR DESCRIPTION
## Summary
- Fix `mpt_state_root_ins` mode 3 no-op descriptors so they return success instead of checking a stale `a0` value.
- Extend the `mpt_state_root_ins` reference/probe with an explicit no-op, modify, delete descriptor sequence.
- The new vector checks delete after a DB-resident modified root and the canonical collapsed trie root.

## Verification
- `scripts/codegen-zisk-mpt-state-root-ins-check.sh` (4/4 pass)
- `lake build EvmAsm.Codegen.Programs.MptStateRootIns`
- `python3 -m py_compile scripts/mpt_ref.py`
- `bash -n scripts/codegen-zisk-mpt-state-root-ins-check.sh`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/MptStateRootIns.lean scripts/mpt_ref.py scripts/codegen-zisk-mpt-state-root-ins-check.sh` (no matches)
- `git diff --check`
- `lake build`

Bead: evm-asm-fhsxz.2.4.2.59.10.

Authored by @pirapira; implemented by Codex