### PR TITLE
feat(precompile): bridge BLS12 pairing result bytes

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -48,6 +48,7 @@ import EvmAsm.EL.Bls12MapFp2ToG2EcallBridge
 import EvmAsm.EL.Bls12PairingInputBridge
 import EvmAsm.EL.Bls12PairingResultBridge
 import EvmAsm.EL.Bls12PairingEcallBridge
+import EvmAsm.EL.Bls12PairingPrecompileResultBridge
 import EvmAsm.EL.Bls12G1AddInputBridge
 import EvmAsm.EL.Bls12G1AddResultBridge
 import EvmAsm.EL.Bls12G1AddEcallBridge

--- a/EvmAsm/EL/Bls12PairingPrecompileResultBridge.lean
+++ b/EvmAsm/EL/Bls12PairingPrecompileResultBridge.lean
@@ -1,0 +1,116 @@
+/-
+  EvmAsm.EL.Bls12PairingPrecompileResultBridge
+
+  Bridge from BLS12-381 pairing accelerator ECALL results to EVM precompile results.
+
+  Authored by @pirapira; implemented by Codex.
+-/
+
+import EvmAsm.EL.Bls12PairingEcallBridge
+import EvmAsm.Evm64.PrecompileResult
+
+namespace EvmAsm.EL
+
+namespace Bls12PairingPrecompileResultBridge
+
+abbrev Byte := EvmAsm.EL.Byte
+abbrev PrecompileResult := EvmAsm.Evm64.PrecompileResult
+
+def zeroPad31 : List Byte := List.replicate 31 0
+
+def verifiedByte (verified : Bool) : Byte :=
+  if verified then 1 else 0
+
+/-- Execution-specs pairing output: left-padded 32-byte word `0` or `1`. -/
+def pairingOutputBytes (verified : Bool) : List Byte :=
+  zeroPad31 ++ [verifiedByte verified]
+
+def outputBytesFromResult (result : Bls12PairingEcallBridge.Bls12PairingResult) : List Byte :=
+  pairingOutputBytes result.output.verified
+
+def fromPairingResult
+    (gasRemaining : Nat) (result : Bls12PairingEcallBridge.Bls12PairingResult) :
+    PrecompileResult :=
+  match result.status with
+  | .eok => EvmAsm.Evm64.PrecompileResult.ok (outputBytesFromResult result) gasRemaining
+  | .efail => EvmAsm.Evm64.PrecompileResult.fail gasRemaining
+
+def gasRemainingAfterCost (input : EvmAsm.Evm64.PrecompileInput) (cost : Nat) : Nat :=
+  input.gas - cost
+
+theorem zeroPad31_length : zeroPad31.length = 31 := by
+  simp [zeroPad31]
+
+theorem verifiedByte_true : verifiedByte true = 1 := rfl
+
+theorem verifiedByte_false : verifiedByte false = 0 := rfl
+
+theorem pairingOutputBytes_true :
+    pairingOutputBytes true = zeroPad31 ++ [1] := rfl
+
+theorem pairingOutputBytes_false :
+    pairingOutputBytes false = zeroPad31 ++ [0] := rfl
+
+theorem pairingOutputBytes_length (verified : Bool) :
+    (pairingOutputBytes verified).length = 32 := by
+  simp [pairingOutputBytes, zeroPad31_length]
+
+theorem outputBytesFromResult_length
+    (result : Bls12PairingEcallBridge.Bls12PairingResult) :
+    (outputBytesFromResult result).length = 32 := by
+  simp [outputBytesFromResult, pairingOutputBytes_length]
+
+theorem outputBytesFromResult_true
+    {result : Bls12PairingEcallBridge.Bls12PairingResult}
+    (h_verified : result.output.verified = true) :
+    outputBytesFromResult result = zeroPad31 ++ [1] := by
+  simp [outputBytesFromResult, pairingOutputBytes, verifiedByte, h_verified]
+
+theorem outputBytesFromResult_false
+    {result : Bls12PairingEcallBridge.Bls12PairingResult}
+    (h_verified : result.output.verified = false) :
+    outputBytesFromResult result = zeroPad31 ++ [0] := by
+  simp [outputBytesFromResult, pairingOutputBytes, verifiedByte, h_verified]
+
+theorem fromPairingResult_eok
+    {gasRemaining : Nat} {result : Bls12PairingEcallBridge.Bls12PairingResult}
+    (h_status : result.status = .eok) :
+    fromPairingResult gasRemaining result =
+      EvmAsm.Evm64.PrecompileResult.ok (outputBytesFromResult result) gasRemaining := by
+  simp [fromPairingResult, h_status]
+
+theorem fromPairingResult_efail
+    {gasRemaining : Nat} {result : Bls12PairingEcallBridge.Bls12PairingResult}
+    (h_status : result.status = .efail) :
+    fromPairingResult gasRemaining result = EvmAsm.Evm64.PrecompileResult.fail gasRemaining := by
+  simp [fromPairingResult, h_status]
+
+theorem fromPairingResult_output_length
+    {gasRemaining : Nat} {result : Bls12PairingEcallBridge.Bls12PairingResult}
+    (h_status : result.status = .eok) :
+    (fromPairingResult gasRemaining result).output.length = 32 := by
+  rw [fromPairingResult_eok h_status]
+  simp [outputBytesFromResult_length]
+
+@[simp] theorem fromPairingResult_failure_output_length
+    {gasRemaining : Nat} {result : Bls12PairingEcallBridge.Bls12PairingResult}
+    (h_status : result.status = .efail) :
+    (fromPairingResult gasRemaining result).output.length = 0 := by
+  rw [fromPairingResult_efail h_status]
+  rfl
+
+theorem gasRemainingAfterCost_le_inputGas
+    (input : EvmAsm.Evm64.PrecompileInput) (cost : Nat) :
+    gasRemainingAfterCost input cost ≤ input.gas := by
+  simp [gasRemainingAfterCost]
+
+theorem fromPairingResult_gasRemaining
+    (gasRemaining : Nat) (result : Bls12PairingEcallBridge.Bls12PairingResult) :
+    (fromPairingResult gasRemaining result).gasRemaining = gasRemaining := by
+  cases h_status : result.status <;>
+    simp [fromPairingResult, h_status, EvmAsm.Evm64.PrecompileResult.ok,
+      EvmAsm.Evm64.PrecompileResult.fail]
+
+end Bls12PairingPrecompileResultBridge
+
+end EvmAsm.EL


### PR DESCRIPTION
## Summary
- add a pure bridge from BLS12-381 pairing ECALL results to common PrecompileResult
- assemble execution-specs-visible 32-byte boolean return data for true and false pairing checks
- prove success/failure output lengths and gas/result projections for later CALL/STATICCALL dispatch wiring

## Bead
- evm-asm-fhsxz.2.4.2.62.3.7.3.2

## Verification
- rtk lake build EvmAsm.EL.Bls12PairingPrecompileResultBridge EvmAsm.EL
- rtk scripts/check-file-size.sh
- rtk scripts/check-unimported.sh
- rtk rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/EL/Bls12PairingPrecompileResultBridge.lean EvmAsm/EL.lean (no matches)
- rtk git diff --check
- rtk lake build

Authored by @pirapira; implemented by Codex.