### PR TITLE
feat(precompile): bridge IDENTITY result bytes

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -32,6 +32,7 @@ import EvmAsm.EL.Blake2fInputBridge
 import EvmAsm.EL.Blake2fResultBridge
 import EvmAsm.EL.Blake2fEcallBridge
 import EvmAsm.EL.Blake2fPrecompileDispatch
+import EvmAsm.EL.IdentityPrecompileResultBridge
 import EvmAsm.EL.KeccakStatusBridge
 import EvmAsm.EL.Secp256k1VerifyInputBridge
 import EvmAsm.EL.Secp256k1VerifyResultBridge

--- a/EvmAsm/EL/IdentityPrecompileResultBridge.lean
+++ b/EvmAsm/EL/IdentityPrecompileResultBridge.lean
@@ -1,0 +1,62 @@
+/-
+  EvmAsm.EL.IdentityPrecompileResultBridge
+
+  Pure bridge from EVM IDENTITY precompile input to EVM precompile results.
+
+  Authored by @pirapira; implemented by Codex.
+-/
+
+import EvmAsm.Evm64.PrecompileResult
+
+namespace EvmAsm.EL
+
+namespace IdentityPrecompileResultBridge
+
+abbrev Byte := BitVec 8
+abbrev PrecompileInput := EvmAsm.Evm64.PrecompileInput
+abbrev PrecompileResult := EvmAsm.Evm64.PrecompileResult
+
+def outputBytesFromInput (input : PrecompileInput) : List Byte :=
+  input.input
+
+def fromIdentityInput (gasRemaining : Nat) (input : PrecompileInput) : PrecompileResult :=
+  EvmAsm.Evm64.PrecompileResult.ok (outputBytesFromInput input) gasRemaining
+
+def gasRemainingAfterCost (input : PrecompileInput) (cost : Nat) : Nat :=
+  input.gas - cost
+
+theorem outputBytesFromInput_eq (input : PrecompileInput) :
+    outputBytesFromInput input = input.input := rfl
+
+theorem outputBytesFromInput_length (input : PrecompileInput) :
+    (outputBytesFromInput input).length = input.input.length := rfl
+
+theorem fromIdentityInput_eq_ok (gasRemaining : Nat) (input : PrecompileInput) :
+    fromIdentityInput gasRemaining input =
+      EvmAsm.Evm64.PrecompileResult.ok input.input gasRemaining := rfl
+
+theorem fromIdentityInput_output (gasRemaining : Nat) (input : PrecompileInput) :
+    (fromIdentityInput gasRemaining input).output = input.input := rfl
+
+theorem fromIdentityInput_output_length (gasRemaining : Nat) (input : PrecompileInput) :
+    (fromIdentityInput gasRemaining input).output.length = input.input.length := rfl
+
+theorem fromIdentityInput_status (gasRemaining : Nat) (input : PrecompileInput) :
+    (fromIdentityInput gasRemaining input).status = .success := rfl
+
+theorem fromIdentityInput_gasRemaining (gasRemaining : Nat) (input : PrecompileInput) :
+    (fromIdentityInput gasRemaining input).gasRemaining = gasRemaining := rfl
+
+theorem gasRemainingAfterCost_le_inputGas (input : PrecompileInput) (cost : Nat) :
+    gasRemainingAfterCost input cost ≤ input.gas := by
+  simp [gasRemainingAfterCost]
+
+theorem fromIdentityInput_preservesGasBound
+    {gasRemaining : Nat} {input : PrecompileInput} (h_gas : gasRemaining ≤ input.gas) :
+    EvmAsm.Evm64.PrecompileResult.preservesGasBound input
+      (fromIdentityInput gasRemaining input) := by
+  simpa [fromIdentityInput, EvmAsm.Evm64.PrecompileResult.preservesGasBound] using h_gas
+
+end IdentityPrecompileResultBridge
+
+end EvmAsm.EL


### PR DESCRIPTION
## Summary
- Add a pure IDENTITY input-to-PrecompileResult adapter.
- Return input bytes exactly as identity returndata.
- Preserve gasRemaining and expose output/gas lemmas for downstream dispatch wiring.

## Verification
- lake build EvmAsm.EL.IdentityPrecompileResultBridge EvmAsm.EL
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/EL/IdentityPrecompileResultBridge.lean EvmAsm/EL.lean
- git diff --check
- lake build

Bead: evm-asm-fhsxz.2.4.2.62.2.2.1

Authored by @pirapira; implemented by Codex.