### PR TITLE
test: require addmod runtime frontier coverage

### DIFF
--- a/scripts/codegen-core-opcode-frontier-check.sh
+++ b/scripts/codegen-core-opcode-frontier-check.sh
@@ -77,6 +77,11 @@ REQUIRED_CASES=(
   "MUL:mul_basic"
   "DIV:div_basic"
   "MOD:mod_basic"
+  "ADDMOD:addmod_basic"
+  "ADDMOD:addmod_div_zero"
+  "ADDMOD:addmod_carry_pow256_mod_7"
+  "ADDMOD:addmod_carry_pow256_mod_2_128_plus_1"
+  "ADDMOD:addmod_carry_reduced_sum_subtracts_n"
   "MULMOD:mulmod_zero_modulus"
   "MULMOD:mulmod_small_nonzero"
   "MULMOD:mulmod_high_product_nonzero"
@@ -112,7 +117,6 @@ REQUIRED_CASES=(
 )
 
 PARTIAL_MEMBERS=(
-  "ADDMOD:carry-out path tracked separately until 257-bit reduction is enforced"
   "EXP:software implementation remains tracked separately"
 )
 


### PR DESCRIPTION
Summary:
- Promote landed total ADDMOD runtime cases into the core opcode frontier coverage gate.
- Require ADDMOD basic, div-zero, and carry-path representatives.
- Remove the stale ADDMOD partial-member note so EXP remains the only explicitly partial arithmetic opcode.

Validation:
- scripts/codegen-core-opcode-frontier-check.sh --no-eest
- scripts/codegen-core-opcode-frontier-check.sh --no-runtime --filter addmod --limit 5 --jobs 16 --max-failures 1
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' scripts/codegen-core-opcode-frontier-check.sh
- lake build

Bead: evm-asm-fhsxz.2.4.2.60.2.4.5

Authored by @pirapira; implemented by Codex.