### PR TITLE
docs(exp): refresh property test regression note

### DIFF
--- a/scripts/codegen-evm_exp-property-check.sh
+++ b/scripts/codegen-evm_exp-property-check.sh
@@ -14,16 +14,17 @@
 #                    Omit to run forever.
 #   --seed=N       : fixed PRNG seed for reproducibility; default: $RANDOM.
 #   --timeout=SECS : wall-clock seconds per case before declaring TIMEOUT
-#                    (default: 10). The known x6 bug causes an infinite loop
-#                    in ziskemu for most inputs — timeout == bug detected.
+#                    (default: 10). Timeouts are treated as runtime
+#                    regressions.
 #
 # Exit:
 #   0 — every tested case matched expected (only possible with --count=N)
 #   1 — at least one case failed / timed out, or the build step errored
 #
-# Note: the current EXP implementation has a known bug — mul_callable
-# clobbers x6 which the EXP loop uses as its per-limb bit counter. Most
-# random inputs will produce wrong results; this script exposes that.
+# Note: this script originally exposed the x6 counter-clobber regression in
+# the EXP loop. The current `_fixed_fixed` body keeps the bit counter in x22;
+# keep this property test around as the regression gate before promoting EXP
+# into required runtime frontier coverage.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

- refresh the EXP property-check script note now that the active body uses the fixed x22 counter path
- record the script as the regression gate before EXP is promoted into required runtime frontier coverage

## Audit

- Python execution-specs treat EXP as total for the arithmetic result: pop base, pop exponent, and push `U256(pow(base, exponent, 2**256))`; gas metering remains tracked separately.
- The current dispatcher routes `h_EXP` through `evmExpComposed`, which uses `evm_exp_fixed_fixed`; that body keeps the per-limb bit counter in x22 rather than the clobbered x6 path this script originally exposed.
- Existing runtime registry cases cover basic dispatcher smoke (`exp_basic`, `exp_zero`), while the standalone property harness now covers the broader pow-mod body behavior.

## Follow-up Beads

- `evm-asm-fhsxz.2.4.2.60.2.9`: add total EXP frontier cases.
- `evm-asm-fhsxz.2.4.2.60.2.10`: require EXP runtime frontier coverage.
- `evm-asm-fhsxz.2.4.2.60.2.11`: triage remaining EXP EEST failures after promotion.

## Validation

- `scripts/codegen-evm_exp-property-check.sh --count=24 --seed=8036 --timeout=20`
- `scripts/codegen-opcodes-runtime-check.sh`
- `lake build EvmAsm.Codegen.Programs.ExpProperty EvmAsm.Codegen.Tests.Cases`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`

Bead: `evm-asm-fhsxz.2.4.2.60.2.8`

Authored by @pirapira; implemented by Codex.
