### PR TITLE
feat(precompile): gate BLS12 G1 runtime calls by length

### DIFF
--- a/EvmAsm/Codegen/Programs/Noop.lean
+++ b/EvmAsm/Codegen/Programs/Noop.lean
@@ -308,6 +308,12 @@ def returnDataHandlers : List OpcodeHandlerSpec :=
     both push success = 1. ECRECOVER / RIPEMD160 remain success
     stubs in this slice; follow-up PRs wire their output semantics.
 
+    **M27.2 update**: CALL / STATICCALL also recognize BLS12-381 G1
+    active precompile addresses 0x0b (G1 ADD) and 0x0c (G1 MSM).
+    This first runtime slice implements the execution-specs input-length
+    gates before the future accelerator body: G1 ADD requires exactly
+    256 bytes; G1 MSM requires a nonzero multiple of 160 bytes.
+
     **M27.1 update**: inactive near-zero addresses 0x12 and 0x101
     are not precompiles in the Amsterdam active set. Route them as
     absent-account calls with success = 1 and empty returndata so the
@@ -354,6 +360,10 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
     "  bltu x14, x15, 1f\n" ++
     "  li x15, 4\n" ++
     "  bgeu x15, x14, 11f\n" ++
+    "  li x15, 0x0b\n" ++
+    "  beq x14, x15, 13f\n" ++
+    "  li x15, 0x0c\n" ++
+    "  beq x14, x15, 14f\n" ++
     "  li x15, 0x12\n" ++
     "  beq x14, x15, 12f\n" ++
     "  li x15, 0x101\n" ++
@@ -448,6 +458,31 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
     "  bnez x22, 10b\n" ++
     "  j 7b\n" ++
     "12:\n" ++
+    "  la x15, evm_precompile_frame\n" ++
+    "  li x16, 1\n" ++
+    "  sd x16, 0(x15)\n" ++
+    "  sd x0, 8(x15)\n" ++
+    "  j 7b\n" ++
+    -- BLS12-381 G1 ADD: execution-specs rejects unless calldata length is 256.
+    -- Valid-length output is wired in a later accelerator-body slice; for now
+    -- it reaches the active-precompile success surface with empty returndata.
+    "13:\n" ++
+    "  ld x17, " ++ toString inSizeOff ++ "(x12)\n" ++
+    "  li x16, 256\n" ++
+    "  bne x17, x16, 1f\n" ++
+    "  la x15, evm_precompile_frame\n" ++
+    "  li x16, 1\n" ++
+    "  sd x16, 0(x15)\n" ++
+    "  sd x0, 8(x15)\n" ++
+    "  j 7b\n" ++
+    -- BLS12-381 G1 MSM: execution-specs rejects empty input and non-160
+    -- multiples before charging gas or invoking curve arithmetic.
+    "14:\n" ++
+    "  ld x17, " ++ toString inSizeOff ++ "(x12)\n" ++
+    "  beqz x17, 1f\n" ++
+    "  li x16, 160\n" ++
+    "  remu x17, x17, x16\n" ++
+    "  bnez x17, 1f\n" ++
     "  la x15, evm_precompile_frame\n" ++
     "  li x16, 1\n" ++
     "  sd x16, 0(x15)\n" ++

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -831,6 +831,33 @@ def opcodeTestCases : List OpcodeTestCase :=
       bytecode         := "0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x12, 0x60, 0x00, 0xf1, 0x50, 0x3d, 0x00"
       expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
       expectedHaltKind := "0000000000000000" }
+  , -- BLS12 G1 ADD rejects invalid input length before any accelerator body.
+    { name             := "call_bls12_g1_add_invalid_length_fails"
+      bytecode         := "0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x0b, 0x60, 0xff, 0xf1, 0x00"
+      expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind := "0000000000000000" }
+  , -- Valid-length BLS12 G1 ADD reaches the active precompile surface.
+    -- Output bytes are a follow-up accelerator-body slice; this gate only
+    -- proves address recognition and the execution-specs length check.
+    { name             := "call_bls12_g1_add_valid_length_success"
+      bytecode         := "0x60, 0x00, 0x60, 0x00, 0x61, 0x01, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x0b, 0x60, 0xff, 0xf1, 0x00"
+      expectedOutHex   := "0100000000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind := "0000000000000000" }
+  , -- BLS12 G1 MSM rejects empty input.
+    { name             := "staticcall_bls12_g1_msm_zero_length_fails"
+      bytecode         := "0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x0c, 0x60, 0xff, 0xfa, 0x00"
+      expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind := "0000000000000000" }
+  , -- BLS12 G1 MSM rejects non-160-multiple input.
+    { name             := "call_bls12_g1_msm_non_multiple_length_fails"
+      bytecode         := "0x60, 0x00, 0x60, 0x00, 0x60, 0xa1, 0x60, 0x00, 0x60, 0x00, 0x60, 0x0c, 0x60, 0xff, 0xf1, 0x00"
+      expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind := "0000000000000000" }
+  , -- Valid-length BLS12 G1 MSM reaches the active precompile surface.
+    { name             := "staticcall_bls12_g1_msm_valid_length_success"
+      bytecode         := "0x60, 0x00, 0x60, 0x00, 0x60, 0xa0, 0x60, 0x00, 0x60, 0x0c, 0x60, 0xff, 0xfa, 0x00"
+      expectedOutHex   := "0100000000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind := "0000000000000000" }
   , -- CALL to IDENTITY records the full precompile returndata buffer,
     -- so RETURNDATASIZE reports the input size even when out_size is short.
     { name             := "call_identity_returndatasize_three"


### PR DESCRIPTION
## Summary
- recognize BLS12-381 G1 ADD/MSM active precompile addresses in the runtime CALL/STATICCALL surface
- apply execution-specs input length gates for 0x0b and 0x0c before the future accelerator body
- add opcode runtime cases for invalid and valid-length BLS G1 CALL/STATICCALL paths

## Notes
- Valid-length paths still use the existing success/empty-returndata placeholder; full BLS accelerator output remains under the broader dispatch parent/follow-up work.
- Desired behavior checked against execution-specs Osaka bls12_381_g1.py.

## Validation
- lake build EvmAsm.Codegen.Programs.Evm EvmAsm.Codegen.Tests.Cases
- scripts/codegen-opcodes-runtime-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build

Bead: evm-asm-fhsxz.2.4.2.62.3.5.3.4

Authored by @pirapira; implemented by Codex.