### PR TITLE
feat(precompile): gate BLS12 G2 runtime calls by length

### DIFF
--- a/EvmAsm/Codegen/Programs/Noop.lean
+++ b/EvmAsm/Codegen/Programs/Noop.lean
@@ -313,6 +313,12 @@ def returnDataHandlers : List OpcodeHandlerSpec :=
     absent-account calls with success = 1 and empty returndata so the
     precompile_absence fixtures do not stop at the dispatcher surface.
 
+    **M27.2 update**: CALL / STATICCALL also recognize BLS12-381 G2
+    active precompile addresses 0x0d (G2 ADD) and 0x0e (G2 MSM).
+    This first runtime slice implements the execution-specs input-length
+    gates before the future accelerator body: G2 ADD requires exactly
+    512 bytes; G2 MSM requires a nonzero multiple of 288 bytes.
+
     **Known limitations** (documented in CODEGEN.md M19 narrative):
     - Non-precompile CALL / CALLCODE / DELEGATECALL / STATICCALL
       still return 0 (= "call failed"). No actual sub-frame
@@ -354,6 +360,10 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
     "  bltu x14, x15, 1f\n" ++
     "  li x15, 4\n" ++
     "  bgeu x15, x14, 11f\n" ++
+    "  li x15, 0x0d\n" ++
+    "  beq x14, x15, 13f\n" ++
+    "  li x15, 0x0e\n" ++
+    "  beq x14, x15, 14f\n" ++
     "  li x15, 0x12\n" ++
     "  beq x14, x15, 12f\n" ++
     "  li x15, 0x101\n" ++
@@ -448,6 +458,31 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
     "  bnez x22, 10b\n" ++
     "  j 7b\n" ++
     "12:\n" ++
+    "  la x15, evm_precompile_frame\n" ++
+    "  li x16, 1\n" ++
+    "  sd x16, 0(x15)\n" ++
+    "  sd x0, 8(x15)\n" ++
+    "  j 7b\n" ++
+    -- BLS12-381 G2 ADD: execution-specs rejects unless calldata length is 512.
+    -- Valid-length output is wired in a later accelerator-body slice; for now
+    -- it reaches the active-precompile success surface with empty returndata.
+    "13:\n" ++
+    "  ld x17, " ++ toString inSizeOff ++ "(x12)\n" ++
+    "  li x16, 512\n" ++
+    "  bne x17, x16, 1f\n" ++
+    "  la x15, evm_precompile_frame\n" ++
+    "  li x16, 1\n" ++
+    "  sd x16, 0(x15)\n" ++
+    "  sd x0, 8(x15)\n" ++
+    "  j 7b\n" ++
+    -- BLS12-381 G2 MSM: execution-specs rejects empty input and non-288
+    -- multiples before charging gas or invoking curve arithmetic.
+    "14:\n" ++
+    "  ld x17, " ++ toString inSizeOff ++ "(x12)\n" ++
+    "  beqz x17, 1f\n" ++
+    "  li x16, 288\n" ++
+    "  remu x17, x17, x16\n" ++
+    "  bnez x17, 1f\n" ++
     "  la x15, evm_precompile_frame\n" ++
     "  li x16, 1\n" ++
     "  sd x16, 0(x15)\n" ++

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -831,6 +831,33 @@ def opcodeTestCases : List OpcodeTestCase :=
       bytecode         := "0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x12, 0x60, 0x00, 0xf1, 0x50, 0x3d, 0x00"
       expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
       expectedHaltKind := "0000000000000000" }
+  , -- BLS12 G2 ADD rejects invalid input length before any accelerator body.
+    { name             := "call_bls12_g2_add_invalid_length_fails"
+      bytecode         := "0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x0d, 0x60, 0xff, 0xf1, 0x00"
+      expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind := "0000000000000000" }
+  , -- Valid-length BLS12 G2 ADD reaches the active precompile surface.
+    -- Output bytes are a follow-up accelerator-body slice; this gate only
+    -- proves address recognition and the execution-specs length check.
+    { name             := "call_bls12_g2_add_valid_length_success"
+      bytecode         := "0x60, 0x00, 0x60, 0x00, 0x61, 0x02, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x0d, 0x60, 0xff, 0xf1, 0x00"
+      expectedOutHex   := "0100000000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind := "0000000000000000" }
+  , -- BLS12 G2 MSM rejects empty input.
+    { name             := "staticcall_bls12_g2_msm_zero_length_fails"
+      bytecode         := "0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x0e, 0x60, 0xff, 0xfa, 0x00"
+      expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind := "0000000000000000" }
+  , -- BLS12 G2 MSM rejects non-288-multiple input.
+    { name             := "call_bls12_g2_msm_non_multiple_length_fails"
+      bytecode         := "0x60, 0x00, 0x60, 0x00, 0x61, 0x01, 0x21, 0x60, 0x00, 0x60, 0x00, 0x60, 0x0e, 0x60, 0xff, 0xf1, 0x00"
+      expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind := "0000000000000000" }
+  , -- Valid-length BLS12 G2 MSM reaches the active precompile surface.
+    { name             := "staticcall_bls12_g2_msm_valid_length_success"
+      bytecode         := "0x60, 0x00, 0x60, 0x00, 0x61, 0x01, 0x20, 0x60, 0x00, 0x60, 0x0e, 0x60, 0xff, 0xfa, 0x00"
+      expectedOutHex   := "0100000000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind := "0000000000000000" }
   , -- CALL to IDENTITY records the full precompile returndata buffer,
     -- so RETURNDATASIZE reports the input size even when out_size is short.
     { name             := "call_identity_returndatasize_three"


### PR DESCRIPTION
## Summary
- recognize BLS12-381 G2 ADD/MSM active precompile addresses in the runtime CALL/STATICCALL surface
- apply execution-specs input length gates for 0x0d and 0x0e before the future accelerator body
- add opcode runtime cases for invalid and valid-length BLS G2 CALL/STATICCALL paths

## Notes
- Valid-length paths still use the existing success/empty-returndata placeholder; full BLS accelerator output remains under the broader dispatch parent/follow-up work.
- Desired behavior checked against execution-specs Osaka bls12_381_g2.py: G2 ADD requires 512 bytes; G2 MSM requires nonzero multiples of 288 bytes.

## Validation
- lake build EvmAsm.Codegen.Programs.Evm EvmAsm.Codegen.Tests.Cases
- scripts/codegen-opcodes-runtime-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build

Bead: evm-asm-fhsxz.2.4.2.62.3.6.2

Authored by @pirapira; implemented by Codex.