### PR TITLE
feat(exp): expose induction control cases from pre

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean
@@ -126,6 +126,44 @@ theorem expTwoMulFixedIterPreNWithInductionFrame_control_from_framed_pre
       nextLimb evmSp :=
   (expTwoMulFixedIterPreNWithInductionFrame_pure_from_framed_pre hPreR).2.2.1
 
+theorem expTwoMulFixedIterPreNWithInductionFrame_control_step_cases_from_pre
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {ps : PartialState}
+    (hPre :
+      expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 ps) :
+    controlC6 + signExtend12 (-1 : BitVec 12) = 0 ∨
+      (controlC6 + signExtend12 (-1 : BitVec 12)).toNat = 1 ∨
+      (controlC6 + signExtend12 (-1 : BitVec 12) ≠ 0 ∧
+        (controlC6 + signExtend12 (-1 : BitVec 12)).toNat ≠ 1 ∧
+        k % 64 < 62) :=
+  expTwoMulFixedControlInvariant_step_cases
+    (expTwoMulFixedIterPreNWithInductionFrame_control hPre)
+
+theorem expTwoMulFixedIterPreNWithInductionFrame_control_step_cases_from_framed_pre
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {R : Assertion} {ps : PartialState}
+    (hPreR :
+      (expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 ** R) ps) :
+    controlC6 + signExtend12 (-1 : BitVec 12) = 0 ∨
+      (controlC6 + signExtend12 (-1 : BitVec 12)).toNat = 1 ∨
+      (controlC6 + signExtend12 (-1 : BitVec 12) ≠ 0 ∧
+        (controlC6 + signExtend12 (-1 : BitVec 12)).toNat ≠ 1 ∧
+        k % 64 < 62) :=
+  expTwoMulFixedControlInvariant_step_cases
+    (expTwoMulFixedIterPreNWithInductionFrame_control_from_framed_pre hPreR)
+
 theorem expTwoMulFixedIterPreNWithInductionFrame_reload_of_control
     {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
     {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld


### PR DESCRIPTION
## Summary
- add fact-level reload/pre-reload/ordinary control case wrappers from the EXP induction-frame precondition
- add the framed-precondition counterpart for later recursive continuation consumers
- keep the wrappers on the raw control facts needed to invoke the direct-loop case-specific theorems

Refs #92. Bead: evm-asm-20z6.13.7.2.16.

## Validation
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedInductionFramePre`
- `lake build EvmAsm.Evm64.Exp`
- `scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean`
- `git diff --check`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean` (no matches)
- `scripts/check-unimported.sh`
- `lake build` (passes; existing LeanRV64D `extension.toCtorIdx` deprecation warning only)

Authored by @pirapira; implemented by Codex.
