### PR TITLE
feat(exp): dispatch direct head to selected frame

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFrameLoopDirect.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFrameLoopDirect.lean
@@ -335,4 +335,198 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDire
       ⟨hp, hcompat, psPre, psR, hdisj, hunion, hPre, hRps⟩
       hpc
 
+
+/-- Direct head step over the folded induction precondition with a single
+    post-frame selector.
+
+    The framed precondition carries the control invariant, so this wrapper
+    splits reload, pre-reload, and ordinary no-reload cases internally and
+    rewrites `expTwoMulFixedDirectHeadFrameN` to the selected branch post. -/
+theorem cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDirect_directHeadFrameN_of_pre
+    {baseWord exponentWord : EvmWord} {k iterations : Nat}
+    (controlC6 e machineC6 iterCount v10 v18 ptr nextLimb
+      nextNextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 : Word)
+    (base : Word)
+    (Q : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hControlMachine : controlC6 = machineC6)
+    (hk : k < 256)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hReloadBranch :
+      k < 255 →
+      ∀ (bit : Bool)
+        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expReloadDirectBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            (expReloadTailDirectTailFrameN exponentWord k ptr
+              nextNextLimb))
+          (Q ** expReloadTailDirectTailFrameN exponentWord k ptr
+            nextNextLimb))
+    (hReloadFalse :
+      k < 255 →
+      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expReloadDirectFalsePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
+            (expReloadTailDirectFalseFrameN exponentWord k controlC6 e
+              iterCount ptr nextLimb))
+          (Q ** expReloadTailDirectTailFrameN exponentWord k ptr
+            nextNextLimb))
+    (hReloadTrue :
+      k < 255 →
+      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expReloadDirectTruePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
+            (expReloadTailDirectTrueFrameN exponentWord k controlC6 e
+              iterCount ptr nextLimb))
+          (Q ** expReloadTailDirectTailFrameN exponentWord k ptr
+            nextNextLimb))
+    (hPreBranch :
+      k < 255 →
+      ∀ (bit : Bool)
+        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expReloadDirectBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            (expPreReloadDirectTailFrameN exponentWord k ptr
+              nextNextLimb))
+          (Q ** expPreReloadDirectTailFrameN exponentWord k ptr
+            nextNextLimb))
+    (hPreFalse :
+      k < 255 →
+      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expReloadDirectFalsePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
+            (expPreReloadDirectFalseFrameN exponentWord k controlC6 e
+              iterCount ptr nextLimb))
+          (Q ** expPreReloadDirectTailFrameN exponentWord k ptr
+            nextNextLimb))
+    (hPreTrue :
+      k < 255 →
+      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expReloadDirectTruePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
+            (expPreReloadDirectTrueFrameN exponentWord k controlC6 e
+              iterCount ptr nextLimb))
+          (Q ** expPreReloadDirectTailFrameN exponentWord k ptr
+            nextNextLimb))
+    (hOrdBranch :
+      k < 255 →
+      ∀ (bit : Bool)
+        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expReloadDirectBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            (expReloadLimbDirectTailFrame ptr nextNextLimb))
+          (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
+    (hOrdFalse :
+      k < 255 →
+      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expReloadDirectFalsePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
+            (expReloadLimbDirectFalseFrame controlC6 e iterCount ptr
+              nextLimb))
+          (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
+    (hOrdTrue :
+      k < 255 →
+      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expReloadDirectTruePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
+            (expReloadLimbDirectTrueFrame controlC6 e iterCount ptr
+              nextLimb))
+          (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
+    (hExit :
+      k = 255 →
+      ∀ ps,
+        expTwoMulFixedIterCaseExitPost iterCount e machineC6 ptr nextLimb
+          sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+        Q ps) :
+    cpsTripleWithin (expTwoMulFixedIterationsBodyBound (iterations + 1))
+      (base + 44) (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11)
+      (Q ** expTwoMulFixedDirectHeadFrameN exponentWord k controlC6 ptr) := by
+  intro R hR s hcr hPreR hpc
+  have hPreRForCases := hPreR
+  obtain ⟨_, _, _, _, _, _, hPre, _⟩ := hPreRForCases
+  have hCases :=
+    expTwoMulFixedIterPreNWithInductionFrame_control_step_cases_from_pre
+      hPre
+  rcases hCases with hReload | hPreReload | ⟨hOrd, hNotPre, _hMod⟩
+  · rw [expTwoMulFixedDirectHeadFrameN_reload_of_control hReload]
+    exact
+      cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDirect_reloadTail_of_pre
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb
+        nextNextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+        e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 base Q hbase
+        hControlMachine hk hBase hReload hNextNext hReloadBranch
+        hReloadFalse hReloadTrue hExit
+        R hR s hcr hPreR hpc
+  · rw [expTwoMulFixedDirectHeadFrameN_pre_reload_of_control hPreReload]
+    exact
+      cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDirect_preReload_of_pre
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb
+        nextNextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+        e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 base Q hbase
+        hControlMachine hk hBase hPreReload hNextNext hPreBranch hPreFalse
+        hPreTrue hExit
+        R hR s hcr hPreR hpc
+  · rw [expTwoMulFixedDirectHeadFrameN_ordinary_of_control hOrd hNotPre]
+    exact
+      cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDirect_ordinary_of_pre
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb
+        nextNextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+        e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 base Q hbase
+        hControlMachine hk hBase hOrd hNotPre hNextNext hOrdBranch
+        hOrdFalse hOrdTrue hExit
+        R hR s hcr hPreR hpc
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add `cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDirect_directHeadFrameN_of_pre`
- dispatch the folded induction precondition to reload, pre-reload, or ordinary direct-head wrappers while targeting one `expTwoMulFixedDirectHeadFrameN` post surface

## Validation
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedInductionFrameLoopDirect`
- `lake build EvmAsm.Evm64.Exp`
- `scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFrameLoopDirect.lean`
- `git diff --check`
- `rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFrameLoopDirect.lean` (no matches)
- `scripts/check-unimported.sh`
- `lake build` (passes with known LeanRV64D deprecation warning)

Refs #92.
Bead: evm-asm-20z6.13.7.2.18

Authored by @pirapira; implemented by Codex.
