### PR TITLE
feat(exp): select direct head continuation frames

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFrameLoopDirect.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFrameLoopDirect.lean
@@ -342,6 +342,44 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDire
     The framed precondition carries the control invariant, so this wrapper
     splits reload, pre-reload, and ordinary no-reload cases internally and
     rewrites `expTwoMulFixedDirectHeadFrameN` to the selected branch post. -/
+
+@[irreducible]
+def expTwoMulFixedDirectHeadTailFrameN
+    (exponentWord : EvmWord) (k : Nat) (controlC6 ptr nextNextLimb : Word) :
+    Assertion :=
+  if expTwoMulFixedControlDec controlC6 = (0 : Word) then
+    expReloadTailDirectTailFrameN exponentWord k ptr nextNextLimb
+  else if (expTwoMulFixedControlDec controlC6).toNat = 1 then
+    expPreReloadDirectTailFrameN exponentWord k ptr nextNextLimb
+  else
+    expReloadLimbDirectTailFrame ptr nextNextLimb
+
+@[irreducible]
+def expTwoMulFixedDirectHeadFalseFrameN
+    (exponentWord : EvmWord) (k : Nat)
+    (controlC6 e iterCount ptr nextLimb : Word) : Assertion :=
+  if expTwoMulFixedControlDec controlC6 = (0 : Word) then
+    expReloadTailDirectFalseFrameN exponentWord k controlC6 e iterCount ptr
+      nextLimb
+  else if (expTwoMulFixedControlDec controlC6).toNat = 1 then
+    expPreReloadDirectFalseFrameN exponentWord k controlC6 e iterCount ptr
+      nextLimb
+  else
+    expReloadLimbDirectFalseFrame controlC6 e iterCount ptr nextLimb
+
+@[irreducible]
+def expTwoMulFixedDirectHeadTrueFrameN
+    (exponentWord : EvmWord) (k : Nat)
+    (controlC6 e iterCount ptr nextLimb : Word) : Assertion :=
+  if expTwoMulFixedControlDec controlC6 = (0 : Word) then
+    expReloadTailDirectTrueFrameN exponentWord k controlC6 e iterCount ptr
+      nextLimb
+  else if (expTwoMulFixedControlDec controlC6).toNat = 1 then
+    expPreReloadDirectTrueFrameN exponentWord k controlC6 e iterCount ptr
+      nextLimb
+  else
+    expReloadLimbDirectTrueFrame controlC6 e iterCount ptr nextLimb
+
 theorem cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDirect_directHeadFrameN_of_pre
     {baseWord exponentWord : EvmWord} {k iterations : Nat}
     (controlC6 e machineC6 iterCount v10 v18 ptr nextLimb


### PR DESCRIPTION
## Summary
- add `expTwoMulFixedDirectHeadTailFrameN`
- add `expTwoMulFixedDirectHeadFalseFrameN`
- add `expTwoMulFixedDirectHeadTrueFrameN`
- select reload-tail, pre-reload, or ordinary recursive continuation frames through `expTwoMulFixedControlDec`

## Validation
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedInductionFrameLoopDirect`
- `lake build EvmAsm.Evm64.Exp`
- `scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFrameLoopDirect.lean`
- `git diff --check`
- `rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFrameLoopDirect.lean` (no matches)
- `scripts/check-unimported.sh`
- `lake build` (passes with known LeanRV64D deprecation warning)

Refs #92.
Bead: evm-asm-20z6.13.7.2.19

Authored by @pirapira; implemented by Codex.
