### PR TITLE
feat(exp): rewrite selected false continuation frame

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFrameLoopDirect.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFrameLoopDirect.lean
@@ -504,6 +504,52 @@ theorem expTwoMulFixedDirectHeadTailFrameN_ordinary_of_control
     exact False.elim (hC6 hZero)
   · rfl
 
+theorem expTwoMulFixedDirectHeadFalseFrameN_reload_of_control
+    {exponentWord : EvmWord} {k : Nat}
+    {controlC6 e iterCount ptr nextLimb : Word}
+    (hC6 : controlC6 + signExtend12 (-1 : BitVec 12) = 0) :
+    expTwoMulFixedDirectHeadFalseFrameN exponentWord k controlC6 e
+        iterCount ptr nextLimb =
+      expReloadTailDirectFalseFrameN exponentWord k controlC6 e iterCount ptr
+        nextLimb := by
+  rw [expTwoMulFixedDirectHeadFalseFrameN]
+  rw [expTwoMulFixedControlDec_unfold]
+  exact if_pos hC6
+
+theorem expTwoMulFixedDirectHeadFalseFrameN_pre_reload_of_control
+    {exponentWord : EvmWord} {k : Nat}
+    {controlC6 e iterCount ptr nextLimb : Word}
+    (hC6 : (controlC6 + signExtend12 (-1 : BitVec 12)).toNat = 1) :
+    expTwoMulFixedDirectHeadFalseFrameN exponentWord k controlC6 e
+        iterCount ptr nextLimb =
+      expPreReloadDirectFalseFrameN exponentWord k controlC6 e iterCount ptr
+        nextLimb := by
+  rw [expTwoMulFixedDirectHeadFalseFrameN]
+  rw [expTwoMulFixedControlDec_unfold]
+  split
+  · rename_i hZero
+    have hNatZero : (controlC6 + signExtend12 (-1 : BitVec 12)).toNat = 0 := by
+      rw [hZero]
+      decide
+    exact False.elim (Nat.zero_ne_one (by rw [← hNatZero, hC6]))
+  · rfl
+
+theorem expTwoMulFixedDirectHeadFalseFrameN_ordinary_of_control
+    {exponentWord : EvmWord} {k : Nat}
+    {controlC6 e iterCount ptr nextLimb : Word}
+    (hC6 : controlC6 + signExtend12 (-1 : BitVec 12) ≠ 0)
+    (hNotPre :
+      (controlC6 + signExtend12 (-1 : BitVec 12)).toNat ≠ 1) :
+    expTwoMulFixedDirectHeadFalseFrameN exponentWord k controlC6 e
+        iterCount ptr nextLimb =
+      expReloadLimbDirectFalseFrame controlC6 e iterCount ptr nextLimb := by
+  rw [expTwoMulFixedDirectHeadFalseFrameN]
+  rw [expTwoMulFixedControlDec_unfold]
+  split
+  · rename_i hZero
+    exact False.elim (hC6 hZero)
+  · rfl
+
 /-- Direct head step over the folded induction precondition with a single
     post-frame selector.
 


### PR DESCRIPTION
## Summary
- add reload, pre-reload, and ordinary rewrite lemmas for `expTwoMulFixedDirectHeadFalseFrameN`
- mirror the selected tail-frame rewrite surface so the direct-head dispatcher can later consume selected false continuation hypotheses

## Validation
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedInductionFrameLoopDirect`
- `lake build EvmAsm.Evm64.Exp`
- `scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFrameLoopDirect.lean`
- `git diff --check`
- `rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFrameLoopDirect.lean` (no matches)
- `scripts/check-unimported.sh`
- `lake build` (passes with known LeanRV64D deprecation warning)

Refs #92.
Bead: evm-asm-20z6.13.7.2.22

Authored by @pirapira; implemented by Codex.
