### PR TITLE
feat(exp): expose induction successor cases from holdsFor

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean
@@ -643,4 +643,54 @@ theorem expTwoMulFixedIterPreNWithInductionFrame_succ_no_reload_cases_from_frame
     expTwoMulFixedIterPreNWithInductionFrame_succ_no_reload_cases_from_pre
       hPre hC6
 
+theorem expTwoMulFixedIterPreNWithInductionFrame_succ_no_reload_cases_from_holdsFor
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {R : Assertion} {s : MachineState}
+    (hPreR :
+      (expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 ** R).holdsFor s)
+    (hC6 : controlC6 + signExtend12 (-1 : BitVec 12) ≠ 0) :
+    (expTwoMulFixedControlInvariant exponentWord (k + 1)
+        (controlC6 + signExtend12 (-1 : BitVec 12)) ptr nextLimb evmSp ∧
+      expTwoMulFixedIterPreNWithInductionFrame (k + 1) baseWord exponentWord
+        (controlC6 + signExtend12 (-1 : BitVec 12)) e machineC6 iterCount
+        v10 v18 ptr nextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+        e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 =
+        expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+          (controlC6 + signExtend12 (-1 : BitVec 12)) e machineC6 iterCount
+          v10 v18 ptr nextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+          e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+          (expTwoMulFixedReloadTailFrameN exponentWord (k + 1) ptr)) ∨
+      (expTwoMulFixedControlInvariant exponentWord (k + 1)
+          (controlC6 + signExtend12 (-1 : BitVec 12)) ptr nextLimb evmSp ∧
+        expTwoMulFixedIterPreNWithInductionFrame (k + 1) baseWord exponentWord
+          (controlC6 + signExtend12 (-1 : BitVec 12)) e machineC6 iterCount
+          v10 v18 ptr nextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+          e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 =
+          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+            (controlC6 + signExtend12 (-1 : BitVec 12)) e machineC6 iterCount
+            v10 v18 ptr nextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+            e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+            (expTwoMulFixedPreReloadFrameN exponentWord (k + 1) ptr)) ∨
+      (expTwoMulFixedControlInvariant exponentWord (k + 1)
+          (controlC6 + signExtend12 (-1 : BitVec 12)) ptr nextLimb evmSp ∧
+        expTwoMulFixedIterPreNWithInductionFrame (k + 1) baseWord exponentWord
+          (controlC6 + signExtend12 (-1 : BitVec 12)) e machineC6 iterCount
+          v10 v18 ptr nextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+          e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 =
+          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+            (controlC6 + signExtend12 (-1 : BitVec 12)) e machineC6 iterCount
+            v10 v18 ptr nextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+            e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+            (expTwoMulFixedSavedNextLimbFrameN exponentWord (k + 1) ptr) ∧
+        (k + 1) % 64 < 62) := by
+  obtain ⟨ps, _h_compat, hPreRps⟩ := hPreR
+  exact expTwoMulFixedIterPreNWithInductionFrame_succ_no_reload_cases_from_framed_pre
+    hPreRps hC6
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add `expTwoMulFixedIterPreNWithInductionFrame_succ_no_reload_cases_from_holdsFor`
- expose the no-reload successor reload/pre-reload/ordinary induction-frame split directly from a MachineState `holdsFor` framed precondition
- stack on #8084 so recursive EXP CPS composition can instantiate the next folded induction precondition without manual partial-state unwrapping

## Validation
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedInductionFramePre`
- `lake build EvmAsm.Evm64.Exp`
- `scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean`
- `git diff --check`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean` (no matches)
- `scripts/check-unimported.sh`
- `lake build` (passes with existing LeanRV64D/RiscvExtras.lean deprecation warning)

Bead: evm-asm-20z6.13.7.2.34

Authored by @pirapira; implemented by Codex.
