### PR TITLE
feat(exp): expose induction control cases from holdsFor

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean
@@ -258,6 +258,26 @@ theorem expTwoMulFixedIterPreNWithInductionFrame_control_step_cases_from_framed_
   expTwoMulFixedControlInvariant_step_cases
     (expTwoMulFixedIterPreNWithInductionFrame_control_from_framed_pre hPreR)
 
+theorem expTwoMulFixedIterPreNWithInductionFrame_control_step_cases_from_holdsFor
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {R : Assertion} {s : MachineState}
+    (hPreR :
+      (expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 ** R).holdsFor s) :
+    controlC6 + signExtend12 (-1 : BitVec 12) = 0 ∨
+      (controlC6 + signExtend12 (-1 : BitVec 12)).toNat = 1 ∨
+      (controlC6 + signExtend12 (-1 : BitVec 12) ≠ 0 ∧
+        (controlC6 + signExtend12 (-1 : BitVec 12)).toNat ≠ 1 ∧
+        k % 64 < 62) := by
+  obtain ⟨ps, _h_compat, hPreRps⟩ := hPreR
+  exact expTwoMulFixedIterPreNWithInductionFrame_control_step_cases_from_framed_pre
+    hPreRps
+
 theorem expTwoMulFixedIterPreNWithInductionFrame_reload_of_control
     {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
     {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld


### PR DESCRIPTION
## Summary
- add `expTwoMulFixedIterPreNWithInductionFrame_control_step_cases_from_holdsFor`
- expose the raw reload/pre-reload/ordinary control-case split directly from a MachineState `holdsFor` framed precondition
- stack on #8085 and complement the selected-frame `holdsFor` helpers for later recursive EXP CPS composition

## Validation
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedInductionFramePre`
- `lake build EvmAsm.Evm64.Exp`
- `scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean`
- `git diff --check`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean` (no matches)
- `scripts/check-unimported.sh`
- `lake build` (passes with existing LeanRV64D/RiscvExtras.lean deprecation warning)

Bead: evm-asm-20z6.13.7.2.35

Authored by @pirapira; implemented by Codex.
