### PR TITLE
feat(exp): expose selected frame holdsFor wrappers

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean
@@ -330,6 +330,126 @@ theorem expTwoMulFixedIterPreNWithInductionFrame_ordinary_of_control
   rw [expTwoMulFixedIterPreNWithInductionFrame_unfold,
     expTwoMulFixedInductionFrameN_ordinary_of_control hC6 hNotPre]
 
+theorem expTwoMulFixedIterPreNWithInductionFrame_reload_from_framed_pre
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {R : Assertion} {ps : PartialState}
+    (hPreR :
+      (expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 ** R) ps)
+    (hC6 : controlC6 + signExtend12 (-1 : BitVec 12) = 0) :
+    (expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord controlC6
+      e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+      (expTwoMulFixedReloadTailFrameN exponentWord k ptr) ** R) ps := by
+  rwa [← expTwoMulFixedIterPreNWithInductionFrame_reload_of_control hC6]
+
+theorem expTwoMulFixedIterPreNWithInductionFrame_reload_from_holdsFor
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {R : Assertion} {s : MachineState}
+    (hPreR :
+      (expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 ** R).holdsFor s)
+    (hC6 : controlC6 + signExtend12 (-1 : BitVec 12) = 0) :
+    (expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord controlC6
+      e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+      (expTwoMulFixedReloadTailFrameN exponentWord k ptr) ** R).holdsFor s := by
+  obtain ⟨ps, h_compat, hPreRps⟩ := hPreR
+  exact ⟨ps, h_compat,
+    expTwoMulFixedIterPreNWithInductionFrame_reload_from_framed_pre
+      hPreRps hC6⟩
+
+theorem expTwoMulFixedIterPreNWithInductionFrame_pre_reload_from_framed_pre
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {R : Assertion} {ps : PartialState}
+    (hPreR :
+      (expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 ** R) ps)
+    (hC6 : (controlC6 + signExtend12 (-1 : BitVec 12)).toNat = 1) :
+    (expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord controlC6
+      e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+      (expTwoMulFixedPreReloadFrameN exponentWord k ptr) ** R) ps := by
+  rwa [← expTwoMulFixedIterPreNWithInductionFrame_pre_reload_of_control hC6]
+
+theorem expTwoMulFixedIterPreNWithInductionFrame_pre_reload_from_holdsFor
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {R : Assertion} {s : MachineState}
+    (hPreR :
+      (expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 ** R).holdsFor s)
+    (hC6 : (controlC6 + signExtend12 (-1 : BitVec 12)).toNat = 1) :
+    (expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord controlC6
+      e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+      (expTwoMulFixedPreReloadFrameN exponentWord k ptr) ** R).holdsFor s := by
+  obtain ⟨ps, h_compat, hPreRps⟩ := hPreR
+  exact ⟨ps, h_compat,
+    expTwoMulFixedIterPreNWithInductionFrame_pre_reload_from_framed_pre
+      hPreRps hC6⟩
+
+theorem expTwoMulFixedIterPreNWithInductionFrame_ordinary_from_framed_pre
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {R : Assertion} {ps : PartialState}
+    (hPreR :
+      (expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 ** R) ps)
+    (hC6 : controlC6 + signExtend12 (-1 : BitVec 12) ≠ 0)
+    (hNotPre : (controlC6 + signExtend12 (-1 : BitVec 12)).toNat ≠ 1) :
+    (expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord controlC6
+      e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+      (expTwoMulFixedSavedNextLimbFrameN exponentWord k ptr) ** R) ps := by
+  rwa [← expTwoMulFixedIterPreNWithInductionFrame_ordinary_of_control
+    hC6 hNotPre]
+
+theorem expTwoMulFixedIterPreNWithInductionFrame_ordinary_from_holdsFor
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {R : Assertion} {s : MachineState}
+    (hPreR :
+      (expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 ** R).holdsFor s)
+    (hC6 : controlC6 + signExtend12 (-1 : BitVec 12) ≠ 0)
+    (hNotPre : (controlC6 + signExtend12 (-1 : BitVec 12)).toNat ≠ 1) :
+    (expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord controlC6
+      e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+      (expTwoMulFixedSavedNextLimbFrameN exponentWord k ptr) ** R).holdsFor s := by
+  obtain ⟨ps, h_compat, hPreRps⟩ := hPreR
+  exact ⟨ps, h_compat,
+    expTwoMulFixedIterPreNWithInductionFrame_ordinary_from_framed_pre
+      hPreRps hC6 hNotPre⟩
+
 theorem expTwoMulFixedIterPreNWithInductionFrame_step_cases_of_control
     {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
     {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld


### PR DESCRIPTION
## Summary
- add framed-pre wrappers that rewrite the folded EXP induction precondition to the selected reload, pre-reload, and ordinary state-frame assertions
- add matching MachineState holdsFor wrappers so recursive EXP CPS consumers can keep working at the holdsFor surface
- keep this stacked on #8086 and reuse the existing selected-frame equality lemmas; no runtime behavior changes

## Validation
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedInductionFramePre
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean (no matches)
- scripts/check-unimported.sh
- lake build (passes with existing LeanRV64D/RiscvExtras.lean extension.toCtorIdx deprecation warning)