### PR TITLE
feat(create): derive runtime create addresses

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -18,6 +18,7 @@
 
 import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.Address
 import EvmAsm.Codegen.Programs.HashBridge
 import EvmAsm.Codegen.Programs.EvmOpcodes
 import EvmAsm.Codegen.Programs.EvmOpcodesExtcodecopy
@@ -389,6 +390,42 @@ def emitRuntimeAccountWitnessData : String :=
   "ecc_match_len:\n" ++
   "  .zero 8\n" ++
   ".balign 32\n" ++
+  "nonce_state_root:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "nonce_acct_struct:\n" ++
+  "  .zero 104\n" ++
+  ".balign 8\n" ++
+  "create_nonce:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "create_sender_be:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "create_salt_be:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "create_address_be:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "ac_buffer:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "ac_nonce_be:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "ac_digest:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "ac2_inner_digest:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "ac2_outer_digest:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "ac2_preimage:\n" ++
+  "  .zero 88\n" ++
+  ".balign 32\n" ++
   "ecc_empty_code_hash:\n" ++
   "  .byte 0xc5, 0xd2, 0x46, 0x01, 0x86, 0xf7, 0x23, 0x3c\n" ++
   "  .byte 0x92, 0x7e, 0x7d, 0xb2, 0xdc, 0xc7, 0x03, 0xc0\n" ++
@@ -536,9 +573,12 @@ def emitDispatcherEpilogue
   accountAtAddressFunction ++ "\n" ++
   headerExtractStateRootFunction ++ "\n" ++
   balanceAtHeaderStateRootFunction ++ "\n" ++
+  nonceAtHeaderStateRootFunction ++ "\n" ++
   extcodehashAtHeaderStateRootFunction ++ "\n" ++
   extcodesizeAtHeaderStateRootFunction ++ "\n" ++
   extcodecopyAtHeaderStateRootFunction ++ "\n" ++
+  addressComputeCreateFunction ++ "\n" ++
+  addressComputeCreate2Function ++ "\n" ++
   "h_invalid:\n" ++
   "  j .exit_label\n" ++
   -- Exceptional-halt exits (reached only via `j <label>`; `h_invalid`'s

--- a/EvmAsm/Codegen/Programs/Noop.lean
+++ b/EvmAsm/Codegen/Programs/Noop.lean
@@ -279,10 +279,10 @@ def returnDataHandlers : List OpcodeHandlerSpec :=
         "  ret" } ]
 
 /-- M19 child-frame opcodes (CREATE, CALL, CALLCODE, DELEGATECALL,
-    CREATE2, STATICCALL). All ship as **pop-N + push-zero** no-ops:
-    the dispatcher pops the EVM-spec input count, then writes 32
-    zero bytes into the new top-of-stack slot (= "call failed" /
-    "create returned address 0").
+    CREATE2, STATICCALL). CALL-family non-precompile paths still ship as
+    **pop-N + push-zero** no-ops. CREATE-family paths decode operands and
+    derive the target address, while later slices still own collision checks,
+    child execution, and code-deposit descriptors.
 
     Net stack delta per opcode (= pop − push, multiplied by 32):
 
@@ -331,8 +331,8 @@ def returnDataHandlers : List OpcodeHandlerSpec :=
       execution.
     - ECRECOVER / RIPEMD160 CALL / STATICCALL targets currently
       return success without producing returndata.
-    - CREATE / CREATE2 always return address 0 (= "deployment
-      failed"). The would-be deployed code is not executed.
+    - CREATE / CREATE2 derive and push the would-be target address, but
+      the would-be deployed code is not executed or deposited yet.
     - No frame stack / recursion. The dispatcher doesn't push a
       sub-frame, run called code, and resume. Real frame-stack
       design is deferred (likely tied to STF integration). -/
@@ -349,9 +349,9 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
               SD .x12 .x0 24
     , tail := .advanceAndRet 1 }
   let createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
-    -- Explicitly decode CREATE-family operands before the still-unsupported
-    -- execution branch. Stack order mirrors CreateArgsStackDecode:
-    -- value, offset, size, and then salt for CREATE2.
+    -- Decode CREATE-family operands, derive the would-be target address using
+    -- the shared CREATE/CREATE2 address helpers, and leave later slices to add
+    -- collision checks, child execution, and code-deposit descriptors.
     "  la x15, evm_precompile_frame\n" ++
     "  sd x0, 0(x15)\n" ++
     "  sd x0, 8(x15)\n" ++
@@ -359,7 +359,7 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
     "  ld x15, 32(x12)\n" ++   -- offset low limb
     "  ld x16, 64(x12)\n" ++   -- size low limb
     (if hasSalt then
-      "  ld x17, 96(x12)\n"   -- salt low limb
+      "  ld x17, 96(x12)\n"   -- salt low limb; full salt is converted below
      else
       "") ++
     -- A nonzero high limb in size is outside the current static memory
@@ -379,12 +379,95 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
     "  bnez x18, .exit_outofgas\n" ++
     "  add x18, x15, x16\n" ++
     "  bltu x18, x15, .exit_outofgas\n" ++
+    "  li x19, 0x8000\n" ++
+    "  bltu x19, x18, .exit_outofgas\n" ++
     "1:\n" ++
+    -- Convert env.ADDRESS from stack-word representation to the canonical
+    -- 20-byte big-endian input expected by address_compute_create*.
+    "  la x18, create_sender_be\n" ++
+    "  addi x19, x20, 19\n" ++
+    "  li x23, 20\n" ++
+    "2:\n" ++
+    "  lbu x24, 0(x19)\n" ++
+    "  sb x24, 0(x18)\n" ++
+    "  addi x19, x19, -1\n" ++
+    "  addi x18, x18, 1\n" ++
+    "  addi x23, x23, -1\n" ++
+    "  bnez x23, 2b\n" ++
+    -- Default to nonce 0 when no account-witness context is attached.
+    "  la x18, create_nonce\n" ++
+    "  sd x0, 0(x18)\n" ++
+    "  ld a1, 584(x20)\n" ++
+    "  beqz a1, 3f\n" ++
+    "  mv s9, x13\n" ++
+    "  mv s10, x10\n" ++
+    "  mv s11, x12\n" ++
+    "  ld a0, 576(x20)\n" ++
+    "  la a2, create_sender_be\n" ++
+    "  ld a3, 592(x20)\n" ++
+    "  ld a4, 600(x20)\n" ++
+    "  la a5, create_nonce\n" ++
+    "  jal x1, nonce_at_header_state_root\n" ++
+    "  mv x13, s9\n" ++
+    "  mv x10, s10\n" ++
+    "  mv x12, s11\n" ++
+    "  beqz a0, 3f\n" ++
+    "  la x18, create_nonce\n" ++
+    "  sd x0, 0(x18)\n" ++
+    "3:\n" ++
+    (if hasSalt then
+      -- Convert the CREATE2 salt stack word to canonical 32-byte big-endian.
+      "  la x18, create_salt_be\n" ++
+      "  addi x19, x12, 127\n" ++
+      "  li x23, 32\n" ++
+      "4:\n" ++
+      "  lbu x24, 0(x19)\n" ++
+      "  sb x24, 0(x18)\n" ++
+      "  addi x19, x19, -1\n" ++
+      "  addi x18, x18, 1\n" ++
+      "  addi x23, x23, -1\n" ++
+      "  bnez x23, 4b\n" ++
+      "  mv s9, x13\n" ++
+      "  mv s10, x10\n" ++
+      "  mv s11, x12\n" ++
+      "  la a0, create_sender_be\n" ++
+      "  la a1, create_salt_be\n" ++
+      "  add a2, x13, x15\n" ++
+      "  mv a3, x16\n" ++
+      "  la a4, create_address_be\n" ++
+      "  jal x1, address_compute_create2\n" ++
+      "  mv x13, s9\n" ++
+      "  mv x10, s10\n" ++
+      "  mv x12, s11\n"
+     else
+      "  mv s9, x13\n" ++
+      "  mv s10, x10\n" ++
+      "  mv s11, x12\n" ++
+      "  la a0, create_sender_be\n" ++
+      "  ld a1, create_nonce\n" ++
+      "  la a2, create_address_be\n" ++
+      "  jal x1, address_compute_create\n" ++
+      "  mv x13, s9\n" ++
+      "  mv x10, s10\n" ++
+      "  mv x12, s11\n") ++
     "  addi x12, x12, " ++ toString netPopBytes ++ "\n" ++
+    -- Push the derived 160-bit address as an EVM stack word: low 160 bits in
+    -- stack byte order, high 96 bits zero.
     "  sd x0, 0(x12)\n" ++
     "  sd x0, 8(x12)\n" ++
     "  sd x0, 16(x12)\n" ++
     "  sd x0, 24(x12)\n" ++
+    "  la x18, create_address_be\n" ++
+    "  addi x19, x18, 19\n" ++
+    "  mv x22, x12\n" ++
+    "  li x23, 20\n" ++
+    "5:\n" ++
+    "  lbu x24, 0(x19)\n" ++
+    "  sb x24, 0(x22)\n" ++
+    "  addi x19, x19, -1\n" ++
+    "  addi x22, x22, 1\n" ++
+    "  addi x23, x23, -1\n" ++
+    "  bnez x23, 5b\n" ++
     "  addi x10, x10, 1\n" ++
     "  j .dispatch_loop"
   let basicPrecompileCallTail

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -810,11 +810,19 @@ def opcodeTestCases : List OpcodeTestCase :=
       bytecode       := "0x60, 0x01, 0x60, 0x02, 0x60, 0x03, 0xf0, 0x60, 0x42, 0x00"
       expectedOutHex := "4200000000000000000000000000000000000000000000000000000000000000" }
   , -- CREATE explicitly decodes top word as value: a high value limb is
-    -- accepted by this unsupported-zero slice instead of being confused with
-    -- high offset/size and reported as out-of-gas.
-    { name             := "create_high_value_limb_still_unsupported_zero"
+    -- accepted by the address-derivation slice instead of being confused with
+    -- high offset/size and reported as out-of-gas. With zero ADDRESS and
+    -- nonce 0, CREATE derives keccak(rlp([0x00..00, 0]))[12:].
+    { name             := "create_high_value_limb_derives_address"
       bytecode         := "0x60, 0x01, 0x60, 0x00, 0x68, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x00"
-      expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
+      expectedOutHex   := "b18ea46f574a80cb7645b3e4915f34a3160477bd000000000000000000000000"
+      expectedHaltKind := "0000000000000000" }
+  , -- CREATE with a nonzero runtime ADDRESS derives from that caller
+    -- address. The pushed EVM word is the 160-bit address in stack byte order.
+    { name             := "create_address_from_env_nonce_zero"
+      bytecode         := "0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0xf0, 0x00"
+      env              := "address=0x1234567890abcdef1234567890abcdef12345678"
+      expectedOutHex   := "42f1db83cc7370b997a96db7b9ffe7c59c967087000000000000000000000000"
       expectedHaltKind := "0000000000000000" }
   , -- CREATE offset is the second decoded word. For nonempty initcode,
     -- high offset limbs are outside the current runtime memory envelope.
@@ -823,10 +831,17 @@ def opcodeTestCases : List OpcodeTestCase :=
       expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
       expectedHaltKind := "0600000000000000" }
   , -- CREATE2 decodes salt after value/offset/size. High salt limbs are
-    -- allowed here and still return the unsupported-zero result.
-    { name             := "create2_high_salt_limb_still_unsupported_zero"
+    -- allowed and participate in EIP-1014 address derivation.
+    { name             := "create2_high_salt_limb_derives_address"
       bytecode         := "0x68, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x60, 0x01, 0x60, 0x00, 0x60, 0x00, 0xf5, 0x00"
-      expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
+      expectedOutHex   := "9e40e03a1444e5c7a2a23a0565ec2b2d2318b2a4000000000000000000000000"
+      expectedHaltKind := "0000000000000000" }
+  , -- CREATE2 with nonzero ADDRESS and salt=1 over empty initcode derives
+    -- the EIP-1014 address using keccak256(empty) as initcode_hash.
+    { name             := "create2_address_from_env_salt_one_empty_initcode"
+      bytecode         := "0x60, 0x01, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0xf5, 0x00"
+      env              := "address=0x1234567890abcdef1234567890abcdef12345678"
+      expectedOutHex   := "178d3687bd025a14373c429091ba42d0e82d853d000000000000000000000000"
       expectedHaltKind := "0000000000000000" }
   , -- CREATE2 size is the third decoded word. High size limbs are rejected
     -- before later address/precheck/deployment slices consume initcode.


### PR DESCRIPTION
## Summary
- wire CREATE and CREATE2 runtime handlers to the shared address_compute_create/address_compute_create2 helpers
- convert runtime ADDRESS and CREATE2 salt from EVM stack-word order to canonical address-helper inputs
- add opcode runtime cases for CREATE nonce-zero and CREATE2 salt/initcode address derivation

Stacked on PR #8101. Bead: evm-asm-fhsxz.2.4.2.61.1.6.2.

## Validation
- lake build EvmAsm.Codegen.Dispatch EvmAsm.Codegen.Programs.Noop EvmAsm.Codegen.Tests.Cases
- scripts/codegen-opcodes-runtime-check.sh
- scripts/codegen-zisk-address-compute-create2-check.sh
- scripts/codegen-zisk-address-compute-create-check.sh
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Dispatch.lean EvmAsm/Codegen/Programs/Noop.lean EvmAsm/Codegen/Tests/Cases.lean (no matches)
- lake build (passes with existing LeanRV64D extension.toCtorIdx deprecation warning)

Authored by @pirapira; implemented by Codex.