### PR TITLE
feat(codegen): real CODESIZE + CODECOPY over the running bytecode (M33)

### DIFF
--- a/CODEGEN.md
+++ b/CODEGEN.md
@@ -1805,6 +1805,45 @@ prior case regresses. (Two BLOCKHASH cases — `blockhash_parent`,
 a **pre-existing** env-offset drift in the BLOCKHASH handler, unrelated to this
 PR.) `lake build EvmAsm.Codegen` clean.
 
+### M33 — Real CODESIZE (0x38) + CODECOPY (0x39): graduate from no-ops — **DONE (2026-06-04)**
+
+CODESIZE and CODECOPY are the one account-state slice that needs **no witness /
+external-account model** — they read the *currently executing* bytecode, which
+the dispatcher already holds in memory (code base in `x21`, exact length in a new
+env cell). This graduates the last two stubs out of `Noop.lean` and leaves
+`pushZeroHandlers` / `copyNoopHandlers` empty.
+
+**Design:** a new env cell `codeSize` at `env+496` (the free gap between
+`activeMemorySize` @488 and the M28 blob cells @512) holds the exact running
+bytecode length. Both prologues seed it: the runtime-bytecode prologue stores the
+input-trailer length (exact, pre-rounding) read at `0x40000008`; the `.data`-baked
+prologue computes `evm_code_end − evm_code` via a new `evm_code_end:` label
+emitted right after the baked bytecode (avoids the `.balign 32` over-count before
+`evm_memory`).
+
+**Delivered:**
+- **`EvmAsm/Evm64/Code/CopyProgram.lean`** — verified `evm_codecopy` body (18
+  instrs), sibling of `Calldata.evm_calldatacopy`: pops `(destOffset, dataOffset,
+  size)`, copies `code[dataOffset..]` → `memory[destOffset..]` with zero-fill past
+  `len(code)`. Source base from a register (`x21`), source length from `env+496`.
+  Length theorems included; axiom-clean.
+- **`Dispatch.lean`** — both prologues seed `env+496`; data section emits
+  `evm_code_end:`.
+- **`Programs/Evm.lean`** — new `codeHandlers` (CODESIZE custom-asm env-cell push,
+  mirroring MSIZE/GAS; CODECOPY = `evm_codecopy` body + `stackUnderflowGuardAsm 3`
+  / `updateActiveMemorySizeAsm` preBody), wired into `tinyInterpRegistry`.
+- **`Programs/Noop.lean`** — `pushZeroHandlers` / `copyNoopHandlers` now empty.
+- **Tests** — `codesize_basic` (len 5 incl. trailing data), `codecopy_basic`
+  (1 in-bounds byte → MLOAD), `codecopy_zero_pad` (offset past `len` → all zero).
+
+**Exit criteria (met).** `scripts/codegen-opcodes-runtime-check.sh` → ALL PASS
+(182 cases, incl. the 3 new); the `.data`-baked `tiny_interp_dispatch_add`
+assembles + runs on ziskemu (validates `evm_code_end`); `scripts/check-progress.sh`
+exits 0; `lake build EvmAsm.Codegen` clean.
+
+**Out of scope:** CODESIZE/CODECOPY gas is still the M30 static base (no
+per-word copy cost); witness-backed BALANCE/EXTCODE* are a separate track.
+
 ### M24 — Storage on Option A: append-log + journal + real TLOAD/TSTORE — **DONE (2026-05-29)**
 
 The storage memory-layout decision (issue **#7130**) landed

--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -429,6 +429,14 @@ def emitDispatcherPrologue : String :=
   "  la x12, evm_stack_top\n" ++
   "  la x13, evm_memory\n" ++
   "  la x20, evm_env\n" ++
+  -- M33: stash the exact running-bytecode length at env+496 for CODESIZE /
+  -- CODECOPY. `evm_code_end` is emitted right after the baked bytecode in
+  -- the data section, so `evm_code_end - evm_code` is the exact byte count
+  -- (x10 still holds `evm_code` from the `la` above; `.balign 32` padding
+  -- before `evm_memory` would over-count, hence the dedicated end label).
+  "  la x5, evm_code_end\n" ++
+  "  sub x5, x5, x10\n" ++         -- x5 = len(code) = evm_code_end - evm_code
+  "  sd x5, 496(x20)\n" ++         -- env.codeSize = running bytecode length
   -- M21: .data-baked variant has no calldata input. Initialize env's
   -- callDataPtrOff (416) to point at a safe zero region (`evm_memory`)
   -- and callDataLenOff (424) to 0. Any CALLDATALOAD reads zeros from
@@ -699,6 +707,7 @@ def emitDispatcherDataSection
   ".balign 8\n" ++
   "evm_code:\n" ++
   s!"  .byte {bytecodeBytes}\n" ++
+  "evm_code_end:\n" ++   -- M33: exact end of baked bytecode (CODESIZE/CODECOPY length)
   ".balign 32\n" ++
   "evm_memory:\n" ++
   "  .zero 0x8000\n" ++   -- 32 KiB EVM memory (M7 onward)
@@ -791,7 +800,8 @@ def emitRuntimeDispatcherSetup : String :=
   -- to 8-byte boundary, add to bytecode start (x10), and that's the
   -- calldata-length address. Eight bytes past it is the calldata.
   "  li x5, 0x40000008\n" ++       -- &(bytecode length)
-  "  ld x5, 0(x5)\n" ++            -- x5 = bytecode length
+  "  ld x5, 0(x5)\n" ++            -- x5 = bytecode length (exact)
+  "  sd x5, 496(x20)\n" ++         -- M33: env.codeSize = bytecode length (CODESIZE/CODECOPY)
   "  addi x5, x5, 7\n" ++          -- round up to 8-byte boundary
   "  srli x5, x5, 3\n" ++
   "  slli x5, x5, 3\n" ++          -- x5 = padded bytecode length

--- a/EvmAsm/Codegen/Programs/Evm.lean
+++ b/EvmAsm/Codegen/Programs/Evm.lean
@@ -17,6 +17,7 @@ import EvmAsm.Evm64.Byte.Program
 import EvmAsm.Evm64.Calldata.LoadProgram
 import EvmAsm.Evm64.Calldata.CopyProgram
 import EvmAsm.Evm64.Calldata.SizeProgram
+import EvmAsm.Evm64.Code.CopyProgram
 import EvmAsm.Evm64.ControlFlow.Program
 import EvmAsm.Evm64.DivMod.Callable
 import EvmAsm.Evm64.DivMod.Program
@@ -615,6 +616,44 @@ def gasHandlers : List OpcodeHandlerSpec :=
         "  sd x0, 24(x12)\n" ++
         "  addi x10, x10, 1\n" ++
         "  ret" } ]
+
+/-- M33: running-code opcodes CODESIZE (0x38) and CODECOPY (0x39).
+    Both operate on the *currently executing* bytecode, which the
+    dispatcher already holds in memory — code base in `x21` and exact
+    byte length in the `env+codeSizeOff` (= 496) cell, seeded by both
+    dispatcher prologues. No witness / external-account state is needed
+    (unlike BALANCE / EXTCODE*), so these are self-contained.
+
+    - **CODESIZE** — mirrors the MSIZE/GAS env-cell-push shape: push
+      `env.codeSize` as a 256-bit word (low limb = length, high limbs 0).
+    - **CODECOPY** — pops `(destOffset, dataOffset, size)` and runs the
+      verified `Code.evm_codecopy` byte loop (sibling of CALLDATACOPY),
+      copying `code[dataOffset..]` into `memory[destOffset..]` with
+      zero-fill past `len(code)`. The `preBody` charges memory expansion
+      (`updateActiveMemorySizeAsm`) over the destination range and guards
+      against stack underflow (3 operands). -/
+def codeHandlers : List OpcodeHandlerSpec :=
+  [ { label   := "h_CODESIZE"
+      opcodes := [0x38]
+      body    := []
+      tail    := .custom <|
+        "  addi x12, x12, -32\n" ++
+        "  ld x14, " ++ toString EvmAsm.Evm64.Code.codeSizeOff ++ "(x20)\n" ++
+        "  sd x14, 0(x12)\n" ++
+        "  sd x0, 8(x12)\n" ++
+        "  sd x0, 16(x12)\n" ++
+        "  sd x0, 24(x12)\n" ++
+        "  addi x10, x10, 1\n" ++
+        "  ret" }
+  , { label   := "h_CODECOPY"
+      opcodes := [0x39]
+      preBody := stackUnderflowGuardAsm 3 ++ "\n" ++
+                 "  ld x14, 0(x12)\n" ++        -- destOffset low limb (MSIZE range)
+                 "  ld x15, 64(x12)\n" ++       -- size low limb (MSIZE range)
+                 updateActiveMemorySizeAsm "codecopy" "x14" "x15" "x16" "x17" "x18"
+      body    := EvmAsm.Evm64.Code.evm_codecopy
+                   .x20 .x13 .x21 .x14 .x15 .x16 .x17 .x18
+      tail    := .advanceAndRet 1 } ]
 
 /-- M12 simple environment opcodes (13 of them, one record each).
 
@@ -1388,7 +1427,7 @@ def stopHandler : OpcodeHandlerSpec :=
 def tinyInterpRegistry : List OpcodeHandlerSpec :=
   pushHandlers ++ dupHandlers ++ swapHandlers ++ singletonHandlers ++
   memoryHandlers ++ memoryMetadataHandlers ++ gasHandlers ++ envHandlers ++
-  blobContextHandlers ++ blockHashHandlers ++ calldataHandlers ++
+  blobContextHandlers ++ blockHashHandlers ++ calldataHandlers ++ codeHandlers ++
   controlFlowHandlers ++ hashHandlers ++ logHandlers ++
   balanceWitnessHandlers ++ accountWitnessHandlers ++ extcodecopyWitnessHandlers ++ storageHandlers ++
   mcopyHandlers ++ haltHandlers ++ pushZeroHandlers ++ returnDataHandlers ++

--- a/EvmAsm/Codegen/Programs/Noop.lean
+++ b/EvmAsm/Codegen/Programs/Noop.lean
@@ -10,10 +10,13 @@
 
   Four builders are exported:
   - `haltHandlers` — RETURN, REVERT, INVALID, SELFDESTRUCT
-  - `pushZeroHandlers` — CODESIZE (MSIZE/GAS and RETURNDATASIZE have real implementations)
-  - `popPushZeroHandlers` — (BALANCE and EXTCODESIZE both have witness-backed implementations)
-    (EXTCODEHASH, BLOBHASH, and BLOCKHASH have real implementations in Programs/Evm.lean)
-  - `copyNoopHandlers` — CODECOPY
+  - `pushZeroHandlers` — empty (CODESIZE graduated to `codeHandlers` in M33;
+    MSIZE/GAS/RETURNDATASIZE have real implementations)
+  - `popPushZeroHandlers` — empty (BALANCE and EXTCODESIZE both have
+    witness-backed implementations; EXTCODEHASH, BLOBHASH, and BLOCKHASH
+    have real implementations in Programs/Evm.lean)
+  - `copyNoopHandlers` — empty (CALLDATACOPY/CODECOPY/RETURNDATACOPY all
+    have real implementations; CODECOPY graduated to `codeHandlers` in M33)
   - `returnDataHandlers` — RETURNDATASIZE and RETURNDATACOPY
 
   These opcodes ship with at least one spec-incompliance (returns
@@ -151,28 +154,16 @@ def haltHandlers : List OpcodeHandlerSpec :=
     , body := []
     , tail := .custom "  addi x12, x12, 32\n  j .exit_selfdestruct" } ]
 
-/-- M18 push-zero handler for CODESIZE.
-    The opcode pushes a single 32-byte zero value onto
-    the EVM stack — no input, no output content.
-    (MSIZE and GAS graduated to real env-cell-reading handlers in
-    Programs/Evm.lean.)
+/-- M18 push-zero handlers — now empty.
 
-    Body (5 instructions): decrement `x12` by 32 (push), then write
-    four 8-byte zero limbs via `SD .x12 .x0 …`.
-
-    **Known limitations** (documented in CODEGEN.md M18 narrative):
-    - CODESIZE pushes 0 instead of the running code's length. -/
+    All former members have graduated to real env-cell-reading handlers
+    in `Programs/Evm.lean`:
+    - MSIZE / GAS (M30) → `memoryMetadataHandlers` / `gasHandlers`.
+    - RETURNDATASIZE (M32) → `returnDataHandlers`.
+    - CODESIZE (M33) → `codeHandlers` (pushes the running bytecode length
+      from `env.codeSize`). -/
 def pushZeroHandlers : List OpcodeHandlerSpec :=
-  let pushZeroBody : Program :=
-    ADDI .x12 .x12 (-32) ;;
-    SD .x12 .x0 0 ;;
-    SD .x12 .x0 8 ;;
-    SD .x12 .x0 16 ;;
-    SD .x12 .x0 24
-  -- GAS (0x5a) graduated to a real handler in Programs/Evm.lean (M30) —
-  -- it pushes env.gasRemaining maintained by the dispatch-loop gas charge.
-  [ { label := "h_CODESIZE", opcodes := [0x38]
-    , body := pushZeroBody, tail := .advanceAndRet 1 } ]
+  []
 
 /-- M18 pop-and-push-zero handlers (BALANCE and EXTCODESIZE).
     This opcode pops one 32-byte input (an address) and pushes a 32-byte zero
@@ -201,29 +192,17 @@ def pushZeroHandlers : List OpcodeHandlerSpec :=
 def popPushZeroHandlers : List OpcodeHandlerSpec :=
   []
 
-/-- M18 copy-no-op handler for CODECOPY.
-    CODECOPY pops 3 stack words and would copy bytes into EVM memory.
-    As a no-op we just drop the stack args.
+/-- M18 copy-no-op handlers — now empty.
 
-    Body: a single `ADDI .x12 .x12 96`.
-
-    **Known limitations**: the copies are dropped on the floor.
-    Programs that copy into EVM memory and then MLOAD see whatever
-    was there before (typically zero, since `evm_memory` is
-    zero-initialised by the dispatcher's data section). For trusted
-    programs that don't depend on these reads, this is correct.
-
-    **M21 update**: CALLDATACOPY (0x37) was removed from this group
-    and now has a real implementation in `calldataHandlers` (see
-    `Programs/Evm.lean`).
-
-    **M32 update**: RETURNDATACOPY (0x3e) moved to `returnDataHandlers`
-    below and reads the dispatcher-maintained precompile return-data frame. -/
+    All former members have graduated to real handlers in
+    `Programs/Evm.lean`:
+    - CALLDATACOPY (M21) → `calldataHandlers`.
+    - RETURNDATACOPY (M32) → `returnDataHandlers` (EIP-211 bounds against
+      the dispatcher-maintained precompile return-data frame).
+    - CODECOPY (M33) → `codeHandlers` (verified `Code.evm_codecopy` byte
+      loop over the running bytecode, zero-filling past `len(code)`). -/
 def copyNoopHandlers : List OpcodeHandlerSpec :=
-  [ { label := "h_CODECOPY", opcodes := [0x39]
-    , preBody := stackUnderflowGuardAsm 3
-    , body := ADDI .x12 .x12 (BitVec.ofNat 12 96)
-    , tail := .advanceAndRet 1 } ]
+  []
 
 /-- Runtime RETURNDATASIZE / RETURNDATACOPY handlers backed by
     `evm_precompile_frame`. CALL/STATICCALL precompile paths store

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -1137,6 +1137,32 @@ def opcodeTestCases : List OpcodeTestCase :=
       bytecode       := "0x60, 0x04, 0x60, 0x00, 0x60, 0x00, 0x37, 0x60, 0x00, 0x51, 0x00"
       calldata       := "0xdeadbeef"
       expectedOutHex := "00000000000000000000000000000000000000000000000000000000efbeadde" }
+    -- ## M33 real CODESIZE / CODECOPY (running-bytecode region)
+    -- These read the running bytecode from `env.codeSize` (env+496, the
+    -- exact length seeded by both dispatcher prologues) and the preserved
+    -- code base in `x21`. No witness / external-account state is needed.
+  , -- CODESIZE; STOP; then 3 trailing data bytes — total code length 5.
+    -- CODESIZE pushes the FULL length (including the never-executed
+    -- trailing bytes) → 5. Low limb LE = 05 00 …
+    { name           := "codesize_basic"
+      bytecode       := "0x38, 0x00, 0xaa, 0xbb, 0xcc"
+      expectedOutHex := "0500000000000000000000000000000000000000000000000000000000000000" }
+  , -- CODECOPY one in-bounds byte, then MLOAD it back.
+    --   PUSH1 0x01 (size); PUSH1 0x0b (offset=11); PUSH1 0x1f (dest=31);
+    --   CODECOPY; PUSH1 0x00; MLOAD; STOP; <data byte 0xab at offset 11>.
+    -- code[11]=0xab is copied to memory[31]; MLOAD(0) reads it as the
+    -- least-significant byte of the loaded word → V = 0xab. Low limb
+    -- LE = ab 00 …
+    { name           := "codecopy_basic"
+      bytecode       := "0x60, 0x01, 0x60, 0x0b, 0x60, 0x1f, 0x39, 0x60, 0x00, 0x51, 0x00, 0xab"
+      expectedOutHex := "ab00000000000000000000000000000000000000000000000000000000000000" }
+  , -- CODECOPY entirely past len(code) → zero-fill, then MLOAD = 0.
+    --   PUSH1 0x20 (size=32); PUSH1 0xff (offset=255, well past len=11);
+    --   PUSH1 0x00 (dest=0); CODECOPY; PUSH1 0x00; MLOAD; STOP.
+    -- Every source byte is out of bounds, so memory[0..32] is zero-filled.
+    { name           := "codecopy_zero_pad"
+      bytecode       := "0x60, 0x20, 0x60, 0xff, 0x60, 0x00, 0x39, 0x60, 0x00, 0x51, 0x00"
+      expectedOutHex := "0000000000000000000000000000000000000000000000000000000000000000" }
     -- ## M22 real storage (SLOAD / SSTORE via pre-loaded slot table)
     -- The dispatcher prologue copies the input file's storage segment
     -- into a writable `evm_slot_table` (16 KiB, 256 slots × 64 B) and

--- a/EvmAsm/Evm64/Code/CopyProgram.lean
+++ b/EvmAsm/Evm64/Code/CopyProgram.lean
@@ -1,0 +1,113 @@
+/-
+  EvmAsm.Evm64.Code.CopyProgram
+
+  RISC-V program implementing the EVM `CODECOPY` opcode for the codegen
+  runtime interpreter.
+
+  CODECOPY pops `(destOffset, dataOffset, size)` and copies `size` bytes of
+  the *currently executing* bytecode `code[dataOffset .. dataOffset+size)`
+  into EVM memory at `memory[destOffset ..]`, zero-filling any source byte
+  at or beyond `len(code)`.
+
+  This is the sibling of `Calldata.evm_calldatacopy`; the only differences
+  are the source region and its length:
+
+    - source base   : caller-supplied `codeBaseReg` (the dispatcher's
+                       preserved code-base register `x21`), instead of
+                       `env.callDataPtr`.
+    - source length : `env.codeSize` at `env + 496` (the M33 cell the
+                       dispatcher prologue seeds with the running bytecode
+                       length), instead of `env.callDataLen`.
+
+  The loop body (the trailing 10 instructions) is byte-for-byte identical to
+  `evm_calldatacopy`, including the PC-relative branch offsets, so the same
+  zero-fill semantics apply.
+
+  18 instructions = 72 bytes.
+
+  Register convention (all caller-saved temporaries per LP64):
+    `envBaseReg`  — environment-block base (`x20`); only `env+496` is read.
+    `memBaseReg`  — EVM memory buffer base (`x13`).
+    `codeBaseReg` — running-bytecode base (`x21`); never written.
+    `destReg`     — destOffset low limb → running absolute dest pointer.
+    `srcReg`      — dataOffset low limb → running absolute source pointer.
+    `cntReg`      — size low limb; loop guard, decremented each iteration.
+    `endReg`      — `codeBase + codeSize` (one past the last in-bounds byte).
+    `byteReg`     — per-iteration scratch byte.
+
+  Only the low limb of each popped word is read (matching the MSTORE /
+  CALLDATACOPY conventions). Memory-expansion (`evmMemSizeIs`) bookkeeping is
+  handled by the handler `preBody` (`updateActiveMemorySizeAsm`), not here —
+  same arrangement as `Calldata.evm_calldatacopy`.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Rv64.SepLogic
+
+namespace EvmAsm.Evm64
+namespace Code
+
+open EvmAsm.Rv64
+
+/-- Byte offset of the M33 `codeSize` cell within the dispatcher env block.
+    Lives in the free gap between `activeMemorySize` (488) and the M28 blob
+    cells (512); raw-literal layout matching the dispatcher prologue's
+    `sd x5, 496(x20)`. -/
+def codeSizeOff : Nat := 496
+
+/-- Top-level RISC-V program implementing the EVM `CODECOPY` opcode. See the
+    file header for the stack convention, register roles, and the byte-by-byte
+    loop layout (shared with `Calldata.evm_calldatacopy`).
+
+    18 instructions = 72 bytes. -/
+def evm_codecopy
+    (envBaseReg memBaseReg codeBaseReg destReg srcReg cntReg endReg
+      byteReg : Reg) : Program :=
+  -- Preamble: pop 3 stack words and compute absolute pointers.
+  LD destReg .x12 0 ;;
+  LD srcReg  .x12 32 ;;
+  LD cntReg  .x12 64 ;;
+  ADDI .x12 .x12 (BitVec.ofNat 12 96) ;;
+  LD endReg envBaseReg (BitVec.ofNat 12 codeSizeOff) ;;   -- endReg := len(code)
+  ADD endReg endReg codeBaseReg ;;                         -- endReg := codeBase + len
+  ADD destReg memBaseReg destReg ;;                        -- dest := memBase + destOff
+  ADD srcReg codeBaseReg srcReg ;;                         -- src  := codeBase + srcOff
+  -- Loop body (identical to evm_calldatacopy).
+  single (.BEQ cntReg .x0 (BitVec.ofNat 13 40)) ;;
+  single (.BGEU srcReg endReg (BitVec.ofNat 13 12)) ;;
+  LBU byteReg srcReg 0 ;;
+  single (.JAL .x0 (BitVec.ofNat 21 8)) ;;
+  ADDI byteReg .x0 0 ;;
+  SB destReg byteReg 0 ;;
+  ADDI srcReg srcReg 1 ;;
+  ADDI destReg destReg 1 ;;
+  ADDI cntReg cntReg (-1 : BitVec 12) ;;
+  single (.JAL .x0 (-36 : BitVec 21))
+
+/-- `CodeReq` for `evm_codecopy` placed at `base`. -/
+abbrev evm_codecopy_code
+    (envBaseReg memBaseReg codeBaseReg destReg srcReg cntReg endReg
+      byteReg : Reg) (base : Word) : CodeReq :=
+  CodeReq.ofProg base
+    (evm_codecopy envBaseReg memBaseReg codeBaseReg destReg srcReg cntReg
+      endReg byteReg)
+
+/-- `evm_codecopy` is exactly 18 RISC-V instructions. -/
+theorem evm_codecopy_length
+    (envBaseReg memBaseReg codeBaseReg destReg srcReg cntReg endReg
+      byteReg : Reg) :
+    (evm_codecopy envBaseReg memBaseReg codeBaseReg destReg srcReg cntReg
+        endReg byteReg).length = 18 := by
+  simp [evm_codecopy, LD, ADDI, ADD, LBU, SB, single, seq,
+    Program.length_append]
+
+/-- `evm_codecopy` occupies 72 bytes in RV64 code memory. -/
+theorem evm_codecopy_byte_length
+    (envBaseReg memBaseReg codeBaseReg destReg srcReg cntReg endReg
+      byteReg : Reg) :
+    4 * (evm_codecopy envBaseReg memBaseReg codeBaseReg destReg srcReg cntReg
+        endReg byteReg).length = 72 := by
+  rw [evm_codecopy_length]
+
+end Code
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

CODESIZE (`0x38`) and CODECOPY (`0x39`) were the last two opcode stubs in `Noop.lean`. They are the one account-state slice that needs **no witness / external-account model** — both operate on the *currently executing* bytecode, which the dispatcher already holds in memory (code base in `x21`, exact length in a new env cell). This graduates them to real handlers and leaves `pushZeroHandlers` / `copyNoopHandlers` empty.

## Design

A new env cell `codeSize` at `env+496` (the free gap between `activeMemorySize` @488 and the M28 blob cells @512) holds the **exact** running bytecode length. Both prologues seed it:
- **runtime-bytecode prologue** stores the exact input-trailer length read at `0x40000008` (before the 8-byte round-up).
- **`.data`-baked prologue** computes `evm_code_end − evm_code` via a new `evm_code_end:` label emitted right after the baked bytecode (avoids the `.balign 32` over-count before `evm_memory`).

## Changes

- **`EvmAsm/Evm64/Code/CopyProgram.lean`** (new) — verified `evm_codecopy` body (18 instrs), sibling of `Calldata.evm_calldatacopy`: pops `(destOffset, dataOffset, size)`, copies `code[dataOffset..]` → `memory[destOffset..]` with zero-fill past `len(code)`; source base from a register (`x21`), source length from `env+496`. Length theorems included; axiom-clean.
- **`Dispatch.lean`** — both prologues seed `env+496`; data section emits `evm_code_end:`.
- **`Programs/Evm.lean`** — new `codeHandlers` (CODESIZE custom-asm env-cell push mirroring MSIZE/GAS; CODECOPY = `evm_codecopy` body + `stackUnderflowGuardAsm 3` / `updateActiveMemorySizeAsm` preBody), wired into `tinyInterpRegistry`.
- **`Programs/Noop.lean`** — `pushZeroHandlers` / `copyNoopHandlers` now empty.
- **`Tests/Cases.lean`** — `codesize_basic`, `codecopy_basic`, `codecopy_zero_pad`.
- **`CODEGEN.md`** — M33 milestone entry.

## Testing

- `scripts/codegen-opcodes-runtime-check.sh` → **ALL PASS (182 cases**, incl. the 3 new); the 3 new cases also confirmed directly on ziskemu.
- The `.data`-baked `tiny_interp_dispatch_add` assembles + runs on ziskemu (validates the `evm_code_end` label path).
- `scripts/check-progress.sh` exits 0; `lake build EvmAsm.Codegen` clean (incl. `RegistryInvariants`); `Evm.lean` at 1471 lines (under the 1500 cap).

## Out of scope

- CODESIZE/CODECOPY gas is still the M30 static base (no per-word copy cost).
- Witness-backed BALANCE/EXTCODE* are a separate track (largely landed in M32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)