### PR TITLE
feat(precompile): call BLS12 G1 MSM backend from runtime

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -622,6 +622,7 @@ def emitDispatcherEpilogue
   addressComputeCreateFunction ++ "\n" ++
   addressComputeCreate2Function ++ "\n" ++
   zkvmBls12G1AddSafeFailWrapper ++ "\n" ++
+  zkvmBls12G1MsmSafeFailWrapper ++ "\n" ++
   "h_invalid:\n" ++
   "  j .exit_label\n" ++
   -- Exceptional-halt exits (reached only via `j <label>`; `h_invalid`'s

--- a/EvmAsm/Codegen/Programs/Noop.lean
+++ b/EvmAsm/Codegen/Programs/Noop.lean
@@ -677,17 +677,30 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
     "  sd x16, 8(x15)\n" ++
     "  j 7b\n" ++
     -- BLS12-381 G1 MSM: execution-specs rejects empty input and non-160
-    -- multiples before charging gas or invoking curve arithmetic.
+    -- multiples before charging gas or invoking curve arithmetic. Valid-length
+    -- input invokes the linkable backend wrapper; the current safe-fail shim
+    -- surfaces EVM precompile failure instead of placeholder success.
     "14:\n" ++
-    "  ld x17, " ++ toString inSizeOff ++ "(x12)\n" ++
-    "  beqz x17, 1f\n" ++
+    "  ld x18, " ++ toString inSizeOff ++ "(x12)\n" ++
+    "  beqz x18, 1f\n" ++
     "  li x16, 160\n" ++
-    "  remu x17, x17, x16\n" ++
+    "  remu x17, x18, x16\n" ++
     "  bnez x17, 1f\n" ++
     "  la x15, evm_precompile_frame\n" ++
+    "  mv s10, x10\n" ++
+    "  mv s11, x12\n" ++
+    "  addi a0, x15, 144\n" ++
+    "  divu a1, x18, x16\n" ++
+    "  addi a2, x15, 336\n" ++
+    "  jal x1, zkvm_bls12_g1_msm\n" ++
+    "  mv x10, s10\n" ++
+    "  mv x12, s11\n" ++
+    "  la x15, evm_precompile_frame\n" ++
+    "  bnez a0, 1f\n" ++
     "  li x16, 1\n" ++
     "  sd x16, 0(x15)\n" ++
-    "  sd x0, 8(x15)\n" ++
+    "  li x16, 128\n" ++
+    "  sd x16, 8(x15)\n" ++
     "  j 7b\n" ++
     -- BLS12-381 G2 ADD: execution-specs rejects unless calldata length is 512.
     -- Valid-length output is wired in a later accelerator-body slice; for now

--- a/EvmAsm/Codegen/Programs/PrecompileBackendProbes.lean
+++ b/EvmAsm/Codegen/Programs/PrecompileBackendProbes.lean
@@ -25,6 +25,15 @@ def zkvmBls12G1AddSafeFailWrapper : String :=
   "  li a0, -1\n" ++
   "  ret"
 
+/-- Linkable bare-RV64 wrapper for `zkvm_bls12_g1_msm(pairs, count, result)`.
+    See `zkvmBls12G1AddSafeFailWrapper`: runtime callers need deterministic
+    EFAIL until the success-producing backend/replay path is available. -/
+def zkvmBls12G1MsmSafeFailWrapper : String :=
+  ".globl zkvm_bls12_g1_msm\n" ++
+  "zkvm_bls12_g1_msm:\n" ++
+  "  li a0, -1\n" ++
+  "  ret"
+
 /-- Probe driver for the BLS12 G1 ADD wrapper. It initializes two 96-byte
     zero point buffers and a 96-byte result buffer, calls the wrapper, then
     writes a compact record at OUTPUT_ADDR:

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -997,10 +997,11 @@ def opcodeTestCases : List OpcodeTestCase :=
       bytecode         := "0x60, 0x00, 0x60, 0x00, 0x60, 0xa1, 0x60, 0x00, 0x60, 0x00, 0x60, 0x0c, 0x60, 0xff, 0xf1, 0x00"
       expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
       expectedHaltKind := "0000000000000000" }
-  , -- Valid-length BLS12 G1 MSM reaches the active precompile surface.
-    { name             := "staticcall_bls12_g1_msm_valid_length_success"
+  , -- Valid-length BLS12 G1 MSM now invokes the backend wrapper. Current
+    -- ziskemu returns deterministic EFAIL, so EVM observes precompile failure.
+    { name             := "staticcall_bls12_g1_msm_valid_length_backend_failure"
       bytecode         := "0x60, 0x00, 0x60, 0x00, 0x60, 0xa0, 0x60, 0x00, 0x60, 0x0c, 0x60, 0xff, 0xfa, 0x00"
-      expectedOutHex   := "0100000000000000000000000000000000000000000000000000000000000000"
+      expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
       expectedHaltKind := "0000000000000000" }
   , -- BLS12 G2 ADD rejects invalid input length before any accelerator body.
     { name             := "call_bls12_g2_add_invalid_length_fails"


### PR DESCRIPTION
## Summary
- export a linkable `zkvm_bls12_g1_msm` safe-fail wrapper for runtime dispatch
- route valid-length BLS12 G1 MSM CALL/STATICCALL through the backend ABI instead of placeholder success
- update the runtime regression so current deterministic EFAIL maps to EVM precompile failure

Refs #8121. Bead: evm-asm-fhsxz.2.4.2.62.3.5.3.6.

Validation:
- `lake build EvmAsm.Codegen.Programs.PrecompileBackendProbes EvmAsm.Codegen.Dispatch EvmAsm.Codegen.Programs.Noop EvmAsm.Codegen.Tests.Cases`
- `scripts/codegen-zisk-bls12-backend-probes-check.sh --require-ready`
- `scripts/codegen-opcodes-runtime-check.sh` (192/192)
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- forbidden-pattern scan for sorry/admit/maxHeartbeats/maxRecDepth in edited files
- `lake build`

Authored by @pirapira; implemented by Codex.