### PR TITLE
feat(precompile): pack BLS12 G1 ADD success output

### DIFF
--- a/EvmAsm/Codegen/Programs/Noop.lean
+++ b/EvmAsm/Codegen/Programs/Noop.lean
@@ -671,6 +671,42 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
     "  mv x12, s11\n" ++
     "  la x15, evm_precompile_frame\n" ++
     "  bnez a0, 1f\n" ++
+    -- EIP-2537 `g1_to_bytes`: each compact 48-byte coordinate is left-padded
+    -- to a 64-byte big-endian field element.
+    "  addi x18, x15, 16\n" ++
+    "  li x22, 16\n" ++
+    "17:\n" ++
+    "  sb x0, 0(x18)\n" ++
+    "  addi x18, x18, 1\n" ++
+    "  addi x22, x22, -1\n" ++
+    "  bnez x22, 17b\n" ++
+    "  addi x18, x15, 336\n" ++
+    "  addi x19, x15, 32\n" ++
+    "  li x22, 48\n" ++
+    "18:\n" ++
+    "  lbu x16, 0(x18)\n" ++
+    "  sb x16, 0(x19)\n" ++
+    "  addi x18, x18, 1\n" ++
+    "  addi x19, x19, 1\n" ++
+    "  addi x22, x22, -1\n" ++
+    "  bnez x22, 18b\n" ++
+    "  addi x18, x15, 80\n" ++
+    "  li x22, 16\n" ++
+    "19:\n" ++
+    "  sb x0, 0(x18)\n" ++
+    "  addi x18, x18, 1\n" ++
+    "  addi x22, x22, -1\n" ++
+    "  bnez x22, 19b\n" ++
+    "  addi x18, x15, 384\n" ++
+    "  addi x19, x15, 96\n" ++
+    "  li x22, 48\n" ++
+    "20:\n" ++
+    "  lbu x16, 0(x18)\n" ++
+    "  sb x16, 0(x19)\n" ++
+    "  addi x18, x18, 1\n" ++
+    "  addi x19, x19, 1\n" ++
+    "  addi x22, x22, -1\n" ++
+    "  bnez x22, 20b\n" ++
     "  li x16, 1\n" ++
     "  sd x16, 0(x15)\n" ++
     "  li x16, 128\n" ++


### PR DESCRIPTION
## Summary
- pack successful BLS12 G1 ADD compact accelerator output into EIP-2537 128-byte returndata
- zero-pad each 48-byte coordinate to 64 bytes before the generic precompile returndata copy
- leave the current safe-fail backend behavior unchanged; backend failure still maps to EVM precompile failure

Bead: evm-asm-fhsxz.2.4.2.62.3.5.3.9.

## Validation
- `lake build EvmAsm.Codegen.Programs.Noop EvmAsm.Codegen.Dispatch EvmAsm.Codegen.Tests.Cases`
- BLS backend probe suite: ready=7, not_ready=0, unexpected=0
- runtime opcode/precompile ziskemu suite: ALL PASS (192 case(s))
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- forbidden-pattern scan for `sorry`, `admit`, `set_option maxHeartbeats`, `set_option maxRecDepth` in `EvmAsm/Codegen/Programs/Noop.lean`
- `lake build`

Authored by @pirapira; implemented by Codex.