### PR TITLE
feat(precompile): call BLS12 G2 MSM backend from runtime

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -624,6 +624,7 @@ def emitDispatcherEpilogue
   zkvmBls12G1AddSafeFailWrapper ++ "\n" ++
   zkvmBls12G1MsmSafeFailWrapper ++ "\n" ++
   bls12SafeFailWrapper "zkvm_bls12_g2_add" "0x10d" ++ "\n" ++
+  bls12SafeFailWrapper "zkvm_bls12_g2_msm" "0x10e" ++ "\n" ++
   "h_invalid:\n" ++
   "  j .exit_label\n" ++
   -- Exceptional-halt exits (reached only via `j <label>`; `h_invalid`'s

--- a/EvmAsm/Codegen/Programs/Noop.lean
+++ b/EvmAsm/Codegen/Programs/Noop.lean
@@ -726,14 +726,26 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
     "  sd x0, 8(x15)\n" ++
     "  j 7b\n" ++
     -- BLS12-381 G2 MSM: execution-specs rejects empty input and non-288
-    -- multiples before charging gas or invoking curve arithmetic.
+    -- multiples before charging gas or invoking curve arithmetic. Valid-length
+    -- input invokes the linkable backend wrapper; the current safe-fail shim
+    -- surfaces EVM precompile failure instead of placeholder success.
     "16:\n" ++
-    "  ld x17, " ++ toString inSizeOff ++ "(x12)\n" ++
-    "  beqz x17, 1f\n" ++
+    "  ld x18, " ++ toString inSizeOff ++ "(x12)\n" ++
+    "  beqz x18, 1f\n" ++
     "  li x16, 288\n" ++
-    "  remu x17, x17, x16\n" ++
+    "  remu x17, x18, x16\n" ++
     "  bnez x17, 1f\n" ++
     "  la x15, evm_precompile_frame\n" ++
+    "  mv s10, x10\n" ++
+    "  mv s11, x12\n" ++
+    "  addi a0, x15, 144\n" ++
+    "  divu a1, x18, x16\n" ++
+    "  addi a2, x15, 336\n" ++
+    "  jal x1, zkvm_bls12_g2_msm\n" ++
+    "  mv x10, s10\n" ++
+    "  mv x12, s11\n" ++
+    "  la x15, evm_precompile_frame\n" ++
+    "  bnez a0, 1f\n" ++
     "  li x16, 1\n" ++
     "  sd x16, 0(x15)\n" ++
     "  sd x0, 8(x15)\n" ++

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -1024,10 +1024,11 @@ def opcodeTestCases : List OpcodeTestCase :=
       bytecode         := "0x60, 0x00, 0x60, 0x00, 0x61, 0x01, 0x21, 0x60, 0x00, 0x60, 0x00, 0x60, 0x0e, 0x60, 0xff, 0xf1, 0x00"
       expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
       expectedHaltKind := "0000000000000000" }
-  , -- Valid-length BLS12 G2 MSM reaches the active precompile surface.
-    { name             := "staticcall_bls12_g2_msm_valid_length_success"
+  , -- Valid-length BLS12 G2 MSM now invokes the backend wrapper. Current
+    -- ziskemu returns deterministic EFAIL, so EVM observes precompile failure.
+    { name             := "staticcall_bls12_g2_msm_valid_length_backend_failure"
       bytecode         := "0x60, 0x00, 0x60, 0x00, 0x61, 0x01, 0x20, 0x60, 0x00, 0x60, 0x0e, 0x60, 0xff, 0xfa, 0x00"
-      expectedOutHex   := "0100000000000000000000000000000000000000000000000000000000000000"
+      expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
       expectedHaltKind := "0000000000000000" }
   , -- CALL to IDENTITY records the full precompile returndata buffer,
     -- so RETURNDATASIZE reports the input size even when out_size is short.


### PR DESCRIPTION
## Summary
- call `zkvm_bls12_g2_msm` from the valid-length BLS12 G2 MSM runtime path
- link a deterministic safe-fail wrapper for runtime dispatcher ELFs
- update the runtime regression from placeholder success to backend failure

Stacked on PR #8125.
Bead: evm-asm-fhsxz.2.4.2.62.3.6.4.

## Validation
- `lake build EvmAsm.Codegen.Programs.Noop EvmAsm.Codegen.Dispatch EvmAsm.Codegen.Tests.Cases`
- BLS backend probe suite: ready=7, not_ready=0, unexpected=0
- runtime opcode/precompile ziskemu suite: ALL PASS (192 case(s))
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- forbidden-pattern scan for `sorry`, `admit`, `set_option maxHeartbeats`, `set_option maxRecDepth` in touched files
- `lake build`

Authored by @pirapira; implemented by Codex.