### PR TITLE
feat(precompile): pack BLS12 G2 ADD success output

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -225,14 +225,17 @@ def emitGasCostTable : String :=
     copying them into caller memory. Layout:
       +0  status / success word
       +8  returndata length
-      +16 first 128 bytes of returndata scratch
+      +16 first 256 bytes of returndata scratch
       +144 BLS12 G1 ADD compact p1 scratch
       +240 BLS12 G1 ADD compact p2 scratch
-      +336 BLS12 G1 ADD compact result scratch. -/
+      +336 BLS12 G1 ADD compact result scratch
+      +144 BLS12 G2 ADD compact p1 scratch
+      +336 BLS12 G2 ADD compact p2 scratch
+      +528 BLS12 G2 ADD compact result scratch. -/
 def emitPrecompileFrameData : String :=
   ".balign 8\n" ++
   "evm_precompile_frame:\n" ++
-  "  .zero 432\n"
+  "  .zero 720\n"
 
 /-- Scratch buffers used by `zkvm_sha256`. The wrapper expects these
     labels to exist in the dispatcher's data section. -/

--- a/EvmAsm/Codegen/Programs/Noop.lean
+++ b/EvmAsm/Codegen/Programs/Noop.lean
@@ -206,13 +206,13 @@ def copyNoopHandlers : List OpcodeHandlerSpec :=
 
 /-- Runtime RETURNDATASIZE / RETURNDATACOPY handlers backed by
     `evm_precompile_frame`. CALL/STATICCALL precompile paths store
-    their return-data length at `+8` and up to 128 bytes at `+16`.
+    their return-data length at `+8` and up to 256 bytes at `+16`.
     Non-precompile, absent-account, CREATE, and CREATE2 paths clear
     the length to model an empty return-data buffer.
 
     RETURNDATACOPY follows execution-specs EIP-211 behavior for bounds:
     copying past the current buffer is an exceptional halt, not zero-fill.
-    This first runtime slice retains a 128-byte prefix of child returndata, so
+    This runtime slice retains a 256-byte prefix of child returndata, so
     copies beyond that retained prefix are also exceptional until a wider
     return-data arena lands. -/
 def returnDataHandlers : List OpcodeHandlerSpec :=
@@ -239,7 +239,7 @@ def returnDataHandlers : List OpcodeHandlerSpec :=
         "  add x19, x15, x16\n" ++
         "  bltu x19, x15, .exit_invalid\n" ++
         "  bltu x18, x19, .exit_invalid\n" ++
-        "  li x18, 128\n" ++
+        "  li x18, 256\n" ++
         "  bltu x18, x19, .exit_invalid\n" ++
         "  addi x12, x12, 96\n" ++
         "  beqz x16, 2f\n" ++
@@ -573,11 +573,11 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
     "  add x18, x13, x18\n" ++    -- x18 = identity input bytes
     "  ld x19, " ++ toString outOffsetOff ++ "(x12)\n" ++
     "  add x19, x13, x19\n" ++    -- x19 = caller output bytes
-    -- Copy up to 128 bytes of returndata into the shared frame.
+    -- Copy up to 256 bytes of returndata into the shared frame.
     "  mv x22, x18\n" ++
     "  addi x23, x15, 16\n" ++
     "  mv x24, x17\n" ++
-    "  li x16, 128\n" ++
+    "  li x16, 256\n" ++
     "  bgeu x16, x24, 2f\n" ++
     "  mv x24, x16\n" ++
     "2:\n" ++
@@ -721,9 +721,48 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
     "  mv x12, s11\n" ++
     "  la x15, evm_precompile_frame\n" ++
     "  bnez a0, 1f\n" ++
+    -- EIP-2537 `g2_to_bytes`: each compact 48-byte FQ component is left-padded
+    -- to a 64-byte big-endian field element.
+    "  addi x18, x15, 16\n" ++
+    "  addi x19, x15, 528\n" ++
+    "  li x23, 4\n" ++
+    "17:\n" ++
+    "  li x22, 16\n" ++
+    "18:\n" ++
+    "  sb x0, 0(x18)\n" ++
+    "  addi x18, x18, 1\n" ++
+    "  addi x22, x22, -1\n" ++
+    "  bnez x22, 18b\n" ++
+    "  li x22, 48\n" ++
+    "19:\n" ++
+    "  lbu x16, 0(x19)\n" ++
+    "  sb x16, 0(x18)\n" ++
+    "  addi x19, x19, 1\n" ++
+    "  addi x18, x18, 1\n" ++
+    "  addi x22, x22, -1\n" ++
+    "  bnez x22, 19b\n" ++
+    "  addi x23, x23, -1\n" ++
+    "  bnez x23, 17b\n" ++
     "  li x16, 1\n" ++
     "  sd x16, 0(x15)\n" ++
-    "  sd x0, 8(x15)\n" ++
+    "  li x16, 256\n" ++
+    "  sd x16, 8(x15)\n" ++
+    "  ld x22, " ++ toString outSizeOff ++ "(x12)\n" ++
+    "  li x23, 256\n" ++
+    "  bgeu x22, x23, 20f\n" ++
+    "  mv x23, x22\n" ++
+    "20:\n" ++
+    "  beqz x23, 7b\n" ++
+    "  addi x18, x15, 16\n" ++
+    "  ld x19, " ++ toString outOffsetOff ++ "(x12)\n" ++
+    "  add x19, x13, x19\n" ++
+    "21:\n" ++
+    "  lbu x16, 0(x18)\n" ++
+    "  sb x16, 0(x19)\n" ++
+    "  addi x18, x18, 1\n" ++
+    "  addi x19, x19, 1\n" ++
+    "  addi x23, x23, -1\n" ++
+    "  bnez x23, 21b\n" ++
     "  j 7b\n" ++
     -- BLS12-381 G2 MSM: execution-specs rejects empty input and non-288
     -- multiples before charging gas or invoking curve arithmetic.

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -1048,6 +1048,14 @@ def opcodeTestCases : List OpcodeTestCase :=
       calldata         := "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       expectedOutHex   := "aa00000000000000000000000000000000000000000000000000000000000000"
       expectedHaltKind := "0100000000000000" }
+  , -- The shared precompile frame now retains 256 bytes, which is needed by
+    -- EIP-2537 G2 return values. IDENTITY deterministically fills the frame;
+    -- copy byte 255 through RETURNDATACOPY.
+    { name             := "call_identity_returndatacopy_byte255"
+      bytecode         := "0x61, 0x01, 0x00, 0x60, 0x00, 0x60, 0x00, 0x37, 0x60, 0x00, 0x60, 0x00, 0x61, 0x01, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x04, 0x60, 0xff, 0xf1, 0x50, 0x60, 0x01, 0x60, 0xff, 0x60, 0x80, 0x3e, 0x60, 0x01, 0x60, 0x80, 0xf3"
+      calldata         := "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      expectedOutHex   := "aa00000000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind := "0100000000000000" }
   , -- execution-specs raises on RETURNDATACOPY reads past the buffer.
     { name             := "call_identity_returndatacopy_oob"
       bytecode         := "0x60, 0xaa, 0x60, 0x00, 0x53, 0x60, 0xbb, 0x60, 0x01, 0x53, 0x60, 0xcc, 0x60, 0x02, 0x53, 0x60, 0x00, 0x60, 0x40, 0x60, 0x03, 0x60, 0x00, 0x60, 0x00, 0x60, 0x04, 0x60, 0xff, 0xf1, 0x50, 0x60, 0x02, 0x60, 0x02, 0x60, 0x80, 0x3e, 0x00"


### PR DESCRIPTION
## Summary
- pack successful `zkvm_bls12_g2_add` output into EIP-2537 256-byte G2 returndata (`16 zero bytes + 48 compact bytes` for each of four FQ components)
- widen the dispatcher precompile frame retained returndata prefix to 256 bytes and grow the frame for G2 ADD scratch space
- copy `min(256, out_size)` G2 ADD success returndata to caller memory and add an IDENTITY/RETURNDATACOPY byte-255 regression for the widened frame

Stacked on #8125. Bead: evm-asm-fhsxz.2.4.2.62.3.6.8.

## Validation
- `lake build EvmAsm.Codegen.Programs.Noop EvmAsm.Codegen.Dispatch EvmAsm.Codegen.Tests.Cases`
- `scripts/codegen-zisk-bls12-backend-probes-check.sh --require-ready`
- `scripts/codegen-opcodes-runtime-check.sh` (193 cases)
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/Noop.lean EvmAsm/Codegen/Dispatch.lean EvmAsm/Codegen/Tests/Cases.lean`
- `lake build`

Authored by @pirapira; implemented by Codex.