### PR TITLE
feat(codegen): charge keccak dynamic gas

### DIFF
--- a/EvmAsm/Codegen/Programs/Evm.lean
+++ b/EvmAsm/Codegen/Programs/Evm.lean
@@ -1013,7 +1013,12 @@ def controlFlowHandlers : List OpcodeHandlerSpec :=
 def hashHandlers : List OpcodeHandlerSpec :=
   [ { label := "h_KECCAK256"
     , opcodes := [0x20]
-    , preBody := stackUnderflowGuardAsm 2
+    , preBody := stackUnderflowGuardAsm 2 ++ "\n" ++
+                 keccakRangeGuardAsm ++
+                 "  ld x14, 0(x12)\n" ++
+                 "  ld x15, 32(x12)\n" ++
+                 keccakWordGasAsm "x15" ++
+                 updateActiveMemorySizeAsm "keccak" "x14" "x15" "x16" "x17" "x18" "x6" true
     , body    := []
     , tail    := .custom (
         "  mv s10, x10\n" ++           -- save EVM code ptr

--- a/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
+++ b/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
@@ -84,4 +84,46 @@ def updateActiveMemorySizeConstAsm
   "  li " ++ tmpLengthReg ++ ", " ++ toString length ++ "\n" ++
   updateActiveMemorySizeAsm tag offsetReg tmpLengthReg roundedReg currentReg maskReg gasTmpReg chargeGas
 
+/-- Range guard for KECCAK256/SHA3 before dynamic gas or hashing. The runtime
+    memory arena is u64-addressed; a non-zero high limb in `size` represents an
+    astronomically large non-zero hash range, so it is reported as OOG. Per
+    execution-specs, zero-size KECCAK does not expand memory, so high offset
+    limbs are accepted when the low size limb is zero. Low-limb
+    `offset + size` wraparound also routes to OOG. -/
+def keccakRangeGuardAsm : String :=
+  -- Any non-zero high size limb means size is non-zero but not representable.
+  "  ld x5, 40(x12)\n" ++
+  "  bnez x5, .exit_outofgas\n" ++
+  "  ld x5, 48(x12)\n" ++
+  "  bnez x5, .exit_outofgas\n" ++
+  "  ld x5, 56(x12)\n" ++
+  "  bnez x5, .exit_outofgas\n" ++
+  "  ld x15, 32(x12)\n" ++
+  "  beqz x15, .Lkeccak_range_ok\n" ++
+  -- Non-zero size expands/hashes the input range, so offset must be u64.
+  "  ld x5, 8(x12)\n" ++
+  "  bnez x5, .exit_outofgas\n" ++
+  "  ld x5, 16(x12)\n" ++
+  "  bnez x5, .exit_outofgas\n" ++
+  "  ld x5, 24(x12)\n" ++
+  "  bnez x5, .exit_outofgas\n" ++
+  "  ld x14, 0(x12)\n" ++
+  "  add x5, x14, x15\n" ++
+  "  bltu x5, x14, .exit_outofgas\n" ++
+  ".Lkeccak_range_ok:\n"
+
+/-- KECCAK256/SHA3 word gas. The dispatch loop already charges the fixed
+    opcode base cost (30), so this charges only `6 * ceil(size / 32)` against
+    `env.gasRemaining`. `sizeReg` is preserved; x5/x6 are clobbered. -/
+def keccakWordGasAsm (sizeReg : String) : String :=
+  "  addi x5, " ++ sizeReg ++ ", 31\n" ++
+  "  srli x5, x5, 5\n" ++
+  "  slli x6, x5, 2\n" ++
+  "  add x6, x6, x5\n" ++
+  "  add x6, x6, x5\n" ++
+  "  ld x5, 568(x20)\n" ++
+  "  bltu x5, x6, .exit_outofgas\n" ++
+  "  sub x5, x5, x6\n" ++
+  "  sd x5, 568(x20)\n"
+
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -540,6 +540,41 @@ def opcodeTestCases : List OpcodeTestCase :=
     { name           := "keccak256_empty"
       bytecode       := "0x60, 0x00, 0x60, 0x00, 0x20, 0x00"
       expectedOutHex := "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" }
+  , -- MSTORE8 pre-expands memory to one word, then KECCAK256 hashes one
+    -- byte. Total gas at the exact threshold:
+    -- PUSH1*4 (12) + MSTORE8 static (3) + memory expansion (3)
+    -- + KECCAK static (30) + KECCAK word gas (6) = 54.
+    { name           := "keccak256_word_gas_sufficient"
+      bytecode       := "0x60, 0xab, 0x60, 0x00, 0x53, 0x60, 0x01, 0x60, 0x00, 0x20, 0x00"
+      expectedOutHex := "468fc9c005382579139846222b7b0aebc9182ba073b2455938a86d9753bfb078"
+      gasLimit       := "54" }
+  , -- One gas short of the same one-byte KECCAK path. The fixed opcode
+    -- charge succeeds, then the new 6-gas word charge routes to OOG.
+    { name             := "keccak256_word_gas_oog"
+      bytecode         := "0x60, 0xab, 0x60, 0x00, 0x53, 0x60, 0x01, 0x60, 0x00, 0x20, 0x00"
+      expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind := "0600000000000000"
+      gasLimit         := "53" }
+  , -- Hash 33 zero bytes from initially empty memory. KECCAK charges two
+    -- input words (12) plus two-word memory expansion (6), in addition
+    -- to two PUSHes (6) and the fixed KECCAK base (30): total 54.
+    { name           := "keccak256_33_bytes_memory_gas_sufficient"
+      bytecode       := "0x60, 0x21, 0x60, 0x00, 0x20, 0x00"
+      expectedOutHex := "f39a869f62e75cf5f0bf914688a6b289caf2049435d8e68c5c5e6d05e44913f3"
+      gasLimit       := "54" }
+  , -- Zero-size KECCAK does not expand memory, so a high offset limb is
+    -- accepted and still hashes the empty byte string.
+    { name           := "keccak256_zero_size_high_offset_ok"
+      bytecode       := "0x60, 0x00, 0x68, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00"
+      expectedOutHex := "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+      gasLimit       := "36" }
+  , -- A non-zero high size limb represents an unbounded hash range for
+    -- this u64-addressed runtime and is reported as OOG before hashing.
+    { name             := "keccak256_high_size_oog"
+      bytecode         := "0x68, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x60, 0x00, 0x20, 0x00"
+      expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind := "0600000000000000"
+      gasLimit         := "36" }
     -- ## M26 LOG opcodes (LOG0-LOG4) — bounded event capture.
     -- LOGn pops (2+n) 256-bit words, advances PC, and appends a
     -- 256-byte descriptor to the dispatcher's receipt-event buffer.


### PR DESCRIPTION
## Summary
- charge KECCAK256/SHA3 dynamic word gas (`6 * ceil(size / 32)`) in the runtime dispatcher after the static base charge
- reuse the existing memory-expansion gas helper for the KECCAK input range
- add range/OOG guards for non-representable non-zero hash ranges while preserving zero-size high-offset behavior
- add focused runtime cases for exact-fit, OOG, 33-byte memory expansion, and high-limb edge cases

Bead: evm-asm-fhsxz.2.4.2.57.15.1

## Validation
- `rtk lake build EvmAsm.Codegen.Tests.Cases`
- focused runtime dispatcher run for `keccak256_empty`, `keccak256_word_gas_sufficient`, `keccak256_word_gas_oog`, `keccak256_33_bytes_memory_gas_sufficient`, `keccak256_zero_size_high_offset_ok`, `keccak256_high_size_oog`
- `rtk scripts/check-file-size.sh`
- `rtk scripts/check-unimported.sh`
- `rtk rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/Evm.lean EvmAsm/Codegen/Programs/EvmMemoryGas.lean EvmAsm/Codegen/Tests/Cases.lean` (no matches)
- `rtk git diff --check`
- `rtk lake build` (existing LeanRV64D deprecation warning only)

Authored by @pirapira; implemented by Codex.