### PR TITLE
fix(eest): fail open on eip8037 regular overflow

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictGasGate.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictGasGate.lean
@@ -25,11 +25,10 @@ open EvmAsm.Rv64
     parse cheaply: `max(intrinsic_gas, calldata_floor_gas_cost) <= tx.gas`.
     The EIP-8037 `TX_MAX_GAS_LIMIT` cap is applied only to the worst-regular-gas
     bound below, not as a transaction-validity rule. Malformed tx lists, unknown
-    tx types still fail open so the state-root verdict does not reject blocks for
-    unsupported gas model parts. Multi-transaction regular-gas overflow is
-    rejected when the payload gas-used field shows the block stopped before the
-    gas limit: EIP-7778 invalid blocks can otherwise match the conservative
-    state-root replay after an overflowing second transaction is rejected. -/
+    tx types, and multi-transaction regular-reservoir overflow still fail open so
+    the state-root verdict does not reject valid state-dominated EIP-8037 blocks
+    before exact execution gas accounting is available. Single-transaction
+    overflow cannot be rescued by state-dominance, so it remains rejected. -/
 def eip8037TxGasGateFunction : String :=
   "eip8037_state_used_before_tx:\n" ++
   "  addi sp, sp, -96\n" ++
@@ -279,8 +278,6 @@ def eip8037TxGasGateFunction : String :=
   "  addi s8, s8, 1; j .Letg_tx_loop\n" ++
   ".Letg_regular_fail:\n" ++
   "  li t0, 1; beq s7, t0, .Letg_regular_reject\n" ++
-  "  addi a0, s0, 420; jal ra, bgv_u64le       # payload.gas_used\n" ++
-  "  bltu a0, s3, .Letg_regular_reject\n" ++
   "  j .Letg_ok\n" ++
   ".Letg_regular_reject:\n" ++
   "  li a0, 1; j .Letg_ret\n" ++


### PR DESCRIPTION
## Summary
- fail open for multi-transaction EIP-8037 regular-reservoir overflow in the conservative transaction gas gate
- keep single-transaction regular overflow rejection and existing intrinsic/state gas checks
- update the gate comment to document the state-dominated fixture behavior

## Evidence
- `lake build EvmAsm.Codegen.Programs.BlockVerdictGasGate`
- `scripts/codegen-eest-eip8037-state-dominates-check.sh --run-dir gen-out/eest-eip8037-state-dominates-fix` -> selected=4, full match=4, fail=0, error=0
- `scripts/codegen-eest-eip7778-block-gas-check.sh --filter eip7778_block_gas_accounting_without_refunds/gas_accounting/multi_transaction_gas_accounting.json --limit 4 --jobs 1 --max-failures 4 --run-dir gen-out/eest-eip7778-after-state-dominates-fix` -> stopped after first two rows full-matched; third row was a long diagnostic ziskemu run using ~30 GiB RSS
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`

Bead: `evm-asm-z5zx6`

Authored by @pirapira; implemented by Codex.