### PR TITLE
fix(eest): raise stateless step budget

### DIFF
--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -45,7 +45,7 @@
 #     --skip N           skip first N selected stateless blocks after filtering
 #     --limit N          cap to N guest invocations (default 50)
 #     --filter SUBSTR    only fixtures whose relpath contains SUBSTR
-#     --steps N          ziskemu max steps (default $EEST_STEPS or 200000000)
+#     --steps N          ziskemu max steps (default $EEST_STEPS or 1000000000)
 #     --jobs N|auto      parallel ziskemu jobs (default $EEST_JOBS or auto)
 #     --max-failures N   stop after N FAIL/ERROR results (default: disabled)
 #     --stop-after-failures N
@@ -100,16 +100,16 @@ SKIP=0
 LIMIT=50
 FILTER=""
 # Default step cap. ziskemu stops at the guest's halt, so this only bounds
-# runaway/very-large runs. Keep the base harness at the known working EEST
-# cap used by the focused wrapper scripts; normal blocks halt long before
-# this and are not slowed.
-STEPS="${EEST_STEPS:-200000000}"
+# runaway/very-large runs. Keep the base harness high enough for current large
+# EIP-7934 block-RLP-limit fixtures; normal blocks halt long before this and
+# are not slowed.
+STEPS="${EEST_STEPS:-1000000000}"
 # Case-insensitive ERE matched against the ziskemu log when a run does NOT
 # produce a valid 105-byte output, to tell "exhausted the --steps budget"
 # (BUDGET, not a correctness failure) apart from a genuine ERROR. Override
 # EEST_STEP_LIMIT_RE if your ziskemu build phrases step exhaustion
 # differently; a non-match safely falls through to ERROR.
-STEP_LIMIT_RE="${EEST_STEP_LIMIT_RE:-(step[s]? limit|maximum steps|max[_ ]*steps|exceeded.*step|step.*exceeded|out of steps|reached.*steps|step budget)}"
+STEP_LIMIT_RE="${EEST_STEP_LIMIT_RE:-(step[s]? limit|maximum steps|max[_ ]*steps|exceeded.*step|step.*exceeded|out of steps|reached.*steps|step budget|EmulationNoCompleted)}"
 JOBS="${EEST_JOBS:-auto}"
 JOB_MEM_MIB="${EEST_JOB_MEM_MIB:-auto}"
 JOB_CPU_THREADS="${EEST_JOB_CPU_THREADS:-auto}"
@@ -142,7 +142,7 @@ Options:
   --skip N                 skip first N selected stateless blocks after filtering
   --limit N                cap to N guest invocations (default 50)
   --filter SUBSTR          only fixtures whose relpath contains SUBSTR
-  --steps N                ziskemu max steps (default $EEST_STEPS or 200000000)
+  --steps N                ziskemu max steps (default $EEST_STEPS or 1000000000)
   --jobs N|auto            parallel ziskemu jobs (default $EEST_JOBS or auto)
   --max-failures N         stop after N FAIL/ERROR results
   --stop-after-failures N  alias for --max-failures


### PR DESCRIPTION
## Summary
- Raise the generic stateless EEST runner default step cap from 200M to 1B.
- This lets the large EIP-7934 block RLP boundary, all-typed transaction, and withdrawal fixtures halt under the default runner.
- Classify ziskemu's `EmulationNoCompleted` message as `BUDGET` when a deliberately smaller step cap is used.

Beads: evm-asm-fhsxz.2.4.2.60.5.6.4, evm-asm-fhsxz.2.4.2.60.5.6.3, evm-asm-fhsxz.2.4.2.60.5.6.2.

## Tests
- `scripts/codegen-eest-stateless-check.sh --filter eip7934_block_rlp_limit/max_block_rlp_size/block_at_rlp_size_limit_boundary.json --limit 3 --jobs 3 --quiet-passes --max-failures 3 --min-full 3 --run-dir gen-out/eest-eip7934-boundary-default-1b`
- `scripts/codegen-eest-stateless-check.sh --filter eip7934_block_rlp_limit/max_block_rlp_size/block_rlp_size_at_limit_with_all_typed_transactions.json --limit 5 --jobs 3 --quiet-passes --max-failures 5 --min-full 5 --steps 1000000000 --run-dir gen-out/eest-eip7934-all-typed-1b`
- `scripts/codegen-eest-stateless-check.sh --filter eip7934_block_rlp_limit/max_block_rlp_size/block_at_rlp_limit_with_withdrawals.json --limit 1 --jobs 1 --quiet-passes --max-failures 1 --min-full 1 --steps 1000000000 --run-dir gen-out/eest-eip7934-withdrawals-1b`
- `scripts/codegen-eest-stateless-check.sh --filter eip7934_block_rlp_limit/max_block_rlp_size/block_at_rlp_size_limit_boundary.json --limit 1 --jobs 1 --quiet-passes --max-failures 1 --steps 1 --run-dir gen-out/eest-eip7934-boundary-budget-probe`
- `bash -n scripts/codegen-eest-stateless-check.sh`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`

Authored by @pirapira; implemented by Codex.