### PR TITLE
chore(eest): print verdict state roots

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -765,6 +765,15 @@ def ziskStatelessVerdictV2Prologue : String :=
   "  la t1, brr_records; ld t2, 0(t1); sd t2, 144(t0)\n" ++
   "  la t1, brr_records; ld t2, 8(t1); sd t2, 152(t0)\n" ++
   "  la t1, brr_records; ld t2, 16(t1); sd t2, 160(t0)\n" ++
+  "  la t1, sv_recomputed; ld t2, 0(t1); sd t2, 168(t0)\n" ++
+  "  la t1, sv_recomputed; ld t2, 8(t1); sd t2, 176(t0)\n" ++
+  "  la t1, sv_recomputed; ld t2, 16(t1); sd t2, 184(t0)\n" ++
+  "  la t1, sv_recomputed; ld t2, 24(t1); sd t2, 192(t0)\n" ++
+  "  la t1, sv_params; ld t1, 0(t1); addi t1, t1, 52\n" ++
+  "  ld t2, 0(t1); sd t2, 200(t0)\n" ++
+  "  ld t2, 8(t1); sd t2, 208(t0)\n" ++
+  "  ld t2, 16(t1); sd t2, 216(t0)\n" ++
+  "  ld t2, 24(t1); sd t2, 224(t0)\n" ++
   "  j .Lv2_pdone\n" ++
   zkvmSha256Function ++ "\n" ++
   zkvmKeccak256Function ++ "\n" ++

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -515,6 +515,14 @@ format_verdict_debug() {
     value="${words[$i]:-?}"
     dbg="${dbg:+$dbg }${labels[$i]}=$value"
   done
+  if [[ "$(stat -c%s "$out" 2>/dev/null || echo 0)" -ge 232 ]]; then
+    local recomputed_state_root payload_state_root
+    recomputed_state_root="$(xxd -p -s 168 -l 32 "$out" 2>/dev/null | tr -d '\n' || true)"
+    payload_state_root="$(xxd -p -s 200 -l 32 "$out" 2>/dev/null | tr -d '\n' || true)"
+    if [[ -n "$recomputed_state_root" && -n "$payload_state_root" ]]; then
+      dbg="$dbg recomputed_state_root=$recomputed_state_root payload_state_root=$payload_state_root"
+    fi
+  fi
   echo "$dbg"
 }
 


### PR DESCRIPTION
## Summary
- extend the fixed-size `zisk_stateless_verdict_v2` debug probe with the recomputed post-state root and the payload state root
- teach `codegen-eest-stateless-check.sh` to print those roots when the debug output contains them
- keep the public stateless guest output unchanged; this only improves failure diagnostics

## EIP-7825 triage enabled by this
Focused failure now reports:

```text
recomputed_state_root=506ab6f50eb8d963e9d74de3ffcee8cf4685d3e13a95c778cdcd365c787873fe
payload_state_root=067157e158eaa8eeac3b4fff13e2bd8397d24182e7091fdd350bb0dc70a6acf6
```

The follow-up fix remains tracked in `evm-asm-8ds5x`; investigation narrowed it to accumulated `mpt_delete_acc` branch/extension collapse replay: direct delete prefixes match Python through 64 deletes and first diverge at prefix 86.

## Tests
- `bash -n scripts/codegen-eest-stateless-check.sh`
- `scripts/check-file-size.sh`
- `scripts/codegen-eest-stateless-check.sh --filter eip7825_transaction_gas_limit_cap/tx_gas_limit/maximum_gas_refund.json --limit 1 --jobs 3 --quiet-passes --max-failures 1 --run-dir gen-out/eest-eip7825-debug-roots-pr` (expected focused failure; verifies debug roots are printed)
