### PR TITLE
fix(receipts): loop legacy receipt records

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -1001,8 +1001,11 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bv_blockhash_required_headers:\n  .zero 8\n" ++
   "brr_status:\n  .zero 8\n" ++
   "brr_append_status:\n  .zero 8\n" ++
+  "rfu_offset:\n  .zero 8\n" ++
+  "rfu_length:\n  .zero 8\n" ++
   "brr_tx_type:\n  .zero 8\n" ++
   "brr_tx_inner:\n  .zero 8\n" ++
+  "brr_tx_gas:\n  .zero 8\n" ++
   "brr_control:\n  .zero 24\n" ++
   ".balign 8\n" ++
   "brr_records:\n  .zero 1024\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptRecords.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptRecords.lean
@@ -19,17 +19,19 @@ open EvmAsm.Rv64.Program
 /-! ## block_receipt_records_materialize -- first receipt-record integration.
     a0 = execution payload ptr.
 
-    This deliberately handles only the smallest useful materialization surface
-    before full transaction execution exists: zero transactions leaves the arena
-    empty, and one legacy transaction in an otherwise successful block appends a
-    success record with cumulative_gas_used = payload.gas_used and no logs. Other
-    transaction shapes leave a debug status but do not affect the block verdict. -/
+    This deliberately handles only a small materialization surface before full
+    transaction execution exists: zero transactions leaves the arena empty, and
+    legacy transactions append success records with cumulative_gas_used equal to
+    the running sum of their gas-limit fields. Exact post-refund gas and failure
+    status are filled by later gas-metered execution slices. Other transaction
+    shapes leave a debug status but do not affect the block verdict. -/
 def blockReceiptRecordsMaterializeFunction : String :=
   "block_receipt_records_materialize:\n" ++
-  "  addi sp, sp, -80\n" ++
+  "  addi sp, sp, -120\n" ++
   "  sd ra, 0(sp)\n" ++
   "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
   "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp); sd s10, 88(sp); sd s11, 96(sp)\n" ++
   "  mv s0, a0                   # execution payload\n" ++
   "  la t0, brr_status; sd zero, 0(t0)\n" ++
   "  la t0, brr_append_status; sd zero, 0(t0)\n" ++
@@ -47,26 +49,55 @@ def blockReceiptRecordsMaterializeFunction : String :=
   "  andi t0, a0, 3; bnez t0, .Lbrr_unsupported\n" ++
   "  srli s5, a0, 2              # tx_count\n" ++
   "  beqz s5, .Lbrr_ok\n" ++
-  "  li t0, 1; bne s5, t0, .Lbrr_unsupported\n" ++
   "  bgtu a0, s4, .Lbrr_unsupported\n" ++
-  "  mv s6, a0                   # first tx offset\n" ++
-  "  sub s7, s4, s6              # tx len\n" ++
-  "  add s6, s3, s6              # tx ptr\n" ++
-  "  mv a0, s6; mv a1, s7; la a2, brr_tx_type; la a3, brr_tx_inner\n" ++
+  "  mv s6, zero                 # tx index\n" ++
+  "  mv s7, zero                 # cumulative gas\n" ++
+  ".Lbrr_tx_loop:\n" ++
+  "  beq s6, s5, .Lbrr_ok\n" ++
+  "  slli t0, s6, 2\n" ++
+  "  add a0, s3, t0\n" ++
+  "  jal ra, bgv_u32le\n" ++
+  "  mv s8, a0                   # current tx offset\n" ++
+  "  bltu s8, s5, .Lbrr_unsupported\n" ++
+  "  slli t0, s5, 2\n" ++
+  "  bltu s8, t0, .Lbrr_unsupported\n" ++
+  "  bgtu s8, s4, .Lbrr_unsupported\n" ++
+  "  addi t0, s6, 1\n" ++
+  "  beq t0, s5, .Lbrr_last_tx\n" ++
+  "  slli t1, t0, 2\n" ++
+  "  add a0, s3, t1\n" ++
+  "  jal ra, bgv_u32le\n" ++
+  "  mv s9, a0                   # next tx offset\n" ++
+  "  j .Lbrr_have_next\n" ++
+  ".Lbrr_last_tx:\n" ++
+  "  mv s9, s4                   # final tx ends at list end\n" ++
+  ".Lbrr_have_next:\n" ++
+  "  bltu s9, s8, .Lbrr_unsupported\n" ++
+  "  bgtu s9, s4, .Lbrr_unsupported\n" ++
+  "  add s10, s3, s8             # tx ptr\n" ++
+  "  sub s11, s9, s8             # tx len\n" ++
+  "  mv a0, s10; mv a1, s11; la a2, brr_tx_type; la a3, brr_tx_inner\n" ++
   "  jal ra, tx_type_dispatch\n" ++
   "  bnez a0, .Lbrr_unsupported\n" ++
   "  la t0, brr_tx_type; ld t1, 0(t0); bnez t1, .Lbrr_unsupported\n" ++
-  "  addi a0, s0, 420; jal ra, bgv_u64le        # payload.gas_used\n" ++
-  "  mv a3, a0                                  # cumulative gas\n" ++
+  "  mv a0, s10; mv a1, s11; li a2, 2; la a3, brr_tx_gas\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lbrr_unsupported\n" ++
+  "  la t0, brr_tx_gas; ld t1, 0(t0)\n" ++
+  "  add t2, s7, t1\n" ++
+  "  bltu t2, s7, .Lbrr_unsupported\n" ++
+  "  mv s7, t2\n" ++
   "  la a0, brr_control\n" ++
   "  li a1, 0                    # legacy tx type\n" ++
   "  li a2, 1                    # successful execution\n" ++
+  "  mv a3, s7                   # cumulative gas\n" ++
   "  li a4, 0                    # pre-tx event log checkpoint\n" ++
   "  li a5, 0                    # final event log count\n" ++
   "  jal ra, receipt_records_append_runtime_result\n" ++
   "  la t0, brr_append_status; sd a0, 0(t0)\n" ++
   "  bnez a0, .Lbrr_append_fail\n" ++
-  "  j .Lbrr_ok\n" ++
+  "  addi s6, s6, 1\n" ++
+  "  j .Lbrr_tx_loop\n" ++
   ".Lbrr_unsupported:\n" ++
   "  li t0, 1; la t1, brr_status; sd t0, 0(t1); j .Lbrr_ret\n" ++
   ".Lbrr_append_fail:\n" ++
@@ -77,7 +108,8 @@ def blockReceiptRecordsMaterializeFunction : String :=
   "  ld ra, 0(sp)\n" ++
   "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
   "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
-  "  addi sp, sp, 80\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp); ld s11, 96(sp)\n" ++
+  "  addi sp, sp, 120\n" ++
   "  ret"
 
 /-- `zisk_block_receipt_records_materialize`: focused probe for the first
@@ -89,7 +121,9 @@ def blockReceiptRecordsMaterializeFunction : String :=
       +8  receipt count
       +16 append status
       +24 first-record nth status
-      +32 first 64-byte record copy, zero if absent. -/
+      +32 first 64-byte record copy, zero if absent
+      +96 last-record nth status
+      +104 last 64-byte record copy, zero if absent. -/
 def ziskBlockReceiptRecordsMaterializePrologue : String :=
   "  li sp, 0xa0050000\n" ++
   "  li t0, 0xa0010000\n" ++
@@ -110,10 +144,16 @@ def ziskBlockReceiptRecordsMaterializePrologue : String :=
   "  la a0, brr_control; li a1, 0; addi a2, s0, 32\n" ++
   "  jal ra, receipt_record_nth\n" ++
   "  sd a0, 24(s0)\n" ++
+  "  la t1, brr_control; ld t2, 0(t1); addi a1, t2, -1\n" ++
+  "  la a0, brr_control; addi a2, s0, 104\n" ++
+  "  jal ra, receipt_record_nth\n" ++
+  "  sd a0, 96(s0)\n" ++
   "  j .Lbrrp_done\n" ++
   bgvU32leFunction ++ "\n" ++
   bgvU64leFunction ++ "\n" ++
   txTypeDispatchFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
   receiptRecordsFunction ++ "\n" ++
   blockReceiptRecordsMaterializeFunction ++ "\n" ++
   ".Lbrrp_done:"
@@ -123,8 +163,11 @@ def ziskBlockReceiptRecordsMaterializeDataSection : String :=
   ".balign 8\n" ++
   "brr_status:\n  .zero 8\n" ++
   "brr_append_status:\n  .zero 8\n" ++
+  "rfu_offset:\n  .zero 8\n" ++
+  "rfu_length:\n  .zero 8\n" ++
   "brr_tx_type:\n  .zero 8\n" ++
   "brr_tx_inner:\n  .zero 8\n" ++
+  "brr_tx_gas:\n  .zero 8\n" ++
   "brr_control:\n  .zero 24\n" ++
   ".balign 8\n" ++
   "brr_records:\n  .zero 1024"

--- a/scripts/codegen-zisk-block-receipt-records-materialize-check.sh
+++ b/scripts/codegen-zisk-block-receipt-records-materialize-check.sh
@@ -28,7 +28,9 @@ lake exe codegen --program zisk_block_receipt_records_materialize --halt linux93
 REPO_ROOT="$(pwd)"
 
 # run_case <name> <mode>
-# mode=empty: no transactions. mode=legacy_stop: one legacy tx whose data field is STOP (0x00).
+# mode=empty: no transactions.
+# mode=legacy_stop: one legacy tx whose data field is STOP (0x00).
+# mode=two_legacy_stop: two legacy STOP txs, testing the SSZ offset-table loop.
 run_case() {
   local name="$1" mode="$2"
   local in_file="$REPO_ROOT/gen-out/zisk_block_receipt_records_${name}.input"
@@ -70,30 +72,47 @@ def rlp_list(items) -> bytes:
     l = len(payload).to_bytes((len(payload).bit_length() + 7) // 8, 'big')
     return bytes([0xf7 + len(l)]) + l + payload
 
-legacy_stop_tx = rlp_list([
+def legacy_stop_tx(gas_limit: int) -> bytes:
+    return rlp_list([
     rlp_int(0),                  # nonce
     rlp_int(1),                  # gas_price
-    rlp_int(21000),              # gas_limit
+    rlp_int(gas_limit),          # gas_limit
     rlp_bytes(bytes(20)),        # to
     rlp_int(0),                  # value
     rlp_bytes(b'\x00'),          # data: STOP
     rlp_int(27),                 # v
     rlp_int(1),                  # r
     rlp_int(1),                  # s
-])
+    ])
 
 if mode == 'empty':
     wd_off = TX_OFF
     expected_count = 0
     expected_first_status = 1
+    expected_last_status = 1
     first_record = (0, 0, 0, 0, 0, 0, 0, 0)
+    last_record = (0, 0, 0, 0, 0, 0, 0, 0)
 elif mode == 'legacy_stop':
-    tx_list = struct.pack('<I', 4) + legacy_stop_tx
+    tx = legacy_stop_tx(21000)
+    tx_list = struct.pack('<I', 4) + tx
     payload[TX_OFF:TX_OFF + len(tx_list)] = tx_list
     wd_off = TX_OFF + len(tx_list)
     expected_count = 1
     expected_first_status = 0
+    expected_last_status = 0
     first_record = (0, 1, GAS_USED, 0, 0, 0, 0, 0)
+    last_record = first_record
+elif mode == 'two_legacy_stop':
+    tx1 = legacy_stop_tx(21000)
+    tx2 = legacy_stop_tx(22000)
+    tx_list = struct.pack('<II', 8, 8 + len(tx1)) + tx1 + tx2
+    payload[TX_OFF:TX_OFF + len(tx_list)] = tx_list
+    wd_off = TX_OFF + len(tx_list)
+    expected_count = 2
+    expected_first_status = 0
+    expected_last_status = 0
+    first_record = (0, 1, 21000, 0, 0, 0, 0, 0)
+    last_record = (0, 1, 43000, 0, 0, 0, 0, 0)
 else:
     raise ValueError(mode)
 
@@ -101,12 +120,14 @@ payload[508:512] = struct.pack('<I', wd_off)
 with open(in_file, 'wb') as f:
     f.write(payload)
 
-out = bytearray(96)
+out = bytearray(168)
 out[0:8] = struct.pack('<Q', 0)                    # brr_status
 out[8:16] = struct.pack('<Q', expected_count)       # count
 out[16:24] = struct.pack('<Q', 0)                   # append status
 out[24:32] = struct.pack('<Q', expected_first_status)
 out[32:96] = struct.pack('<QQQQQQQQ', *first_record)
+out[96:104] = struct.pack('<Q', expected_last_status)
+out[104:168] = struct.pack('<QQQQQQQQ', *last_record)
 with open(expected_file, 'w') as f:
     f.write(out.hex())
 EOF_PY
@@ -116,7 +137,7 @@ EOF_PY
     >"$REPO_ROOT/gen-out/zisk_block_receipt_records_${name}.emu.log" 2>&1 || true
 
   local actual expected
-  actual="$(dd if="$out_file" bs=1 count=96 2>/dev/null | xxd -p | tr -d '\n')"
+  actual="$(dd if="$out_file" bs=1 count=168 2>/dev/null | xxd -p | tr -d '\n')"
   expected="$(cat "$expected_file")"
   if [[ "$actual" == "$expected" ]]; then
     printf "  %-18s OK\n" "$name"
@@ -131,6 +152,7 @@ EOF_PY
 FAILED=0
 run_case "empty" empty || FAILED=1
 run_case "legacy_stop" legacy_stop || FAILED=1
+run_case "two_legacy_stop" two_legacy_stop || FAILED=1
 
 if [[ $FAILED -eq 0 ]]; then
   echo "==> PASS: block receipt-record materializer probe"


### PR DESCRIPTION
## Summary
- replace the one-transaction receipt-record materializer special case with an SSZ variable-list loop over legacy transactions
- record cumulative gas as a running sum of legacy transaction gas-limit fields until exact post-refund execution gas is wired
- extend the focused receipt-record ziskemu probe to check empty, one-legacy, and two-legacy transaction lists, including first and last records

Bead: evm-asm-fhsxz.2.4.2.63.1.6.2.1.4.

## Verification
- scripts/codegen-zisk-block-receipt-records-materialize-check.sh
- lake build EvmAsm.Codegen.Programs.BlockVerdictReceiptRecords EvmAsm.Codegen.Programs.BlockVerdict EvmAsm.Codegen.Programs.BlockVerdictV2
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/BlockVerdictReceiptRecords.lean EvmAsm/Codegen/Programs/BlockVerdict.lean scripts/codegen-zisk-block-receipt-records-materialize-check.sh
- git diff --check
- lake build

Authored by @pirapira; implemented by Codex.