### PR TITLE
test(modexp): include memory gas for zero header

### DIFF
--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -1408,10 +1408,11 @@ def opcodeTestCases : List OpcodeTestCase :=
       gasLimit         := "617" }
   , -- A present but all-zero 96-byte MODEXP header has the same decoded
     -- lengths as empty input and also returns success with empty returndata.
+    -- The nonempty input window still pays STATICCALL memory expansion gas.
     { name           := "staticcall_modexp_zero_header_success"
       bytecode       := "0x60, 0x00, 0x60, 0x00, 0x60, 0x60, 0x60, 0x00, 0x60, 0x05, 0x60, 0xff, 0xfa, 0x00"
       expectedOutHex := "0100000000000000000000000000000000000000000000000000000000000000"
-      gasLimit       := "618" }
+      gasLimit       := "627" }
   , -- MODEXP header with modulus_len=1 charges the decoded 500 minimum.
     -- Missing modulus bytes decode as zero, so the one-byte output is 0 and
     -- the precompile succeeds.


### PR DESCRIPTION
## Summary
- adjust the MODEXP zero-header runtime fixture to include STATICCALL memory expansion gas for its 96-byte input window
- document why the decoded MODEXP lengths match empty input while the CALL setup gas does not

## Verification
- `scripts/codegen-opcodes-runtime-check.sh` (expected remaining failures dropped from 12 to 11; `staticcall_modexp_zero_header_success` now passes; remaining failures are existing precompile gas/BLS runtime cases)
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Tests/Cases.lean` (no matches)
- `lake build` (passes; existing `LeanRV64D/RiscvExtras.lean:115:12` deprecation warning remains)

Bead: evm-asm-fhsxz.2.4.2.57.6.1.1

Authored by @pirapira; implemented by Codex.