### PR TITLE
test(eest): run failed tx wrapper with three jobs

### DIFF
--- a/scripts/codegen-eest-failed-tx-paris-layout-check.sh
+++ b/scripts/codegen-eest-failed-tx-paris-layout-check.sh
@@ -13,6 +13,7 @@ FX="${EEST_FIXTURES_DIR:-$(pwd)/gen-out/eest-fixtures/$TAG/fixtures/fixtures}"
 [[ -d "$FX" ]] || { echo "fixtures not found at $FX (run scripts/eest-fetch-fixtures.sh '$TAG')" >&2; exit 1; }
 
 RUN_DIR="${RUN_DIR:-gen-out/eest-failed-tx-paris-layout}"
+JOBS="${EEST_FAILED_TX_PARIS_JOBS:-${EEST_JOBS:-3}}"
 case "$RUN_DIR" in
   /*) ;;
   *) RUN_DIR="$PWD/$RUN_DIR" ;;
@@ -31,7 +32,7 @@ echo "==> run failed_tx Paris high-gas launch check"
 scripts/codegen-eest-stateless-check.sh \
   --filter failed_tx_xcf416c53_paris \
   --limit 10 \
-  --jobs 1 \
+  --jobs "$JOBS" \
   --max-failures 1 \
   --quiet-passes \
   --steps "${EEST_FAILED_TX_PARIS_STEPS:-200000000}" \


### PR DESCRIPTION
## Summary
- make `codegen-eest-failed-tx-paris-layout-check.sh` honor `EEST_FAILED_TX_PARIS_JOBS` / `EEST_JOBS`
- default the wrapper to 3 ziskemu jobs instead of hardcoding `--jobs 1`
- keep the high-gas launch check behavior unchanged

Bead: `evm-asm-fhsxz.2.4.2.57.18.3.1`

## Verification
- `bash -n scripts/codegen-eest-failed-tx-paris-layout-check.sh`
- `EEST_JOBS=3 scripts/codegen-eest-failed-tx-paris-layout-check.sh` (`jobs=3`, selected=1, full match=1, fail=0)
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' scripts/codegen-eest-failed-tx-paris-layout-check.sh` (no matches)\n- `git diff --check`\n- `lake build` (passes; existing `LeanRV64D/RiscvExtras.lean:115:12` deprecation warning remains)\n\nAuthored by @pirapira; implemented by Codex.