### PR TITLE
fix(eest): dedupe verdict RLP scratch labels

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -1010,8 +1010,6 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bv_blockhash_required_headers:\n  .zero 8\n" ++
   "brr_status:\n  .zero 8\n" ++
   "brr_append_status:\n  .zero 8\n" ++
-  "rfu_offset:\n  .zero 8\n" ++
-  "rfu_length:\n  .zero 8\n" ++
   "brr_tx_type:\n  .zero 8\n" ++
   "brr_tx_inner:\n  .zero 8\n" ++
   "brr_tx_gas:\n  .zero 8\n" ++


### PR DESCRIPTION
## Summary
- remove duplicate `rfu_offset` / `rfu_length` declarations from the stateless verdict V2 data composition
- reuse the shared RLP field scratch already supplied by the Step-2 verdict data section
- restores `stateless_guest` assembly and lets the EIP-7934 boundary fixture run

## Tests
- `scripts/codegen-eest-stateless-check.sh --filter block_at_rlp_size_limit_boundary.json --limit 5 --jobs 1 --max-failures 5 --show-passes`
  - selected 3, full match 3, errored 0, fail 0
- `lake build EvmAsm.Codegen.Programs.BlockVerdict EvmAsm.Codegen.Programs`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/BlockVerdict.lean` (no matches)\n- `lake build`\n\nBead: `evm-asm-fhsxz.2.4.2.60.5.6.5`\n\nAuthored by @pirapira; implemented by Codex.