### PR TITLE
refactor(codegen): split EVM divmod wrappers

### DIFF
--- a/EvmAsm/Codegen/Programs/Evm.lean
+++ b/EvmAsm/Codegen/Programs/Evm.lean
@@ -51,6 +51,7 @@ import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Dispatch
 import EvmAsm.Codegen.Programs.EvmBasic
 import EvmAsm.Codegen.Programs.EvmTinyInterp
+import EvmAsm.Codegen.Programs.EvmDivModWrappers
 import EvmAsm.Codegen.Programs.EvmMcopyGas
 import EvmAsm.Codegen.Programs.EvmMemoryGas
 import EvmAsm.Codegen.Programs.Clz
@@ -63,74 +64,6 @@ import EvmAsm.Codegen.Programs.Storage
 namespace EvmAsm.Codegen
 
 open EvmAsm.Rv64
-
-/-! ## divK NOP-splice helpers (used by both M2 standalone DIV/MOD
-    wrappers and the M8 dispatcher handlers, so hoisted above the
-    M5b registry section that references them) -/
-
-/-- `EvmAsm.Evm64.evm_div` with the NOP "exit PC" at internal index 267
-    replaced by a forward `JAL .x0 +304` that skips the 75-instruction
-    inline `divK_div128_v4` subroutine and lands at the instruction
-    immediately following the body. In the M2 standalone wrapper that
-    landing site is the start of `evmAddEpilogue`; in the M8
-    dispatcher wrapper (M5b registry) it is the `mv x10, x9` of the
-    handler's `x10RestoreAdvance1` tail. -/
-def evmDivPatched : Program :=
-  (EvmAsm.Evm64.evm_div : List Instr).take 267 ++
-  [Instr.JAL .x0 (304 : BitVec 21)] ++
-  (EvmAsm.Evm64.evm_div : List Instr).drop 268
-
-/-- `EvmAsm.Evm64.evm_mod` with the same NOP-splice as `evmDivPatched`.
-    Same +304 byte offset because the MOD body has the identical
-    343-instruction layout (267 main + NOP + 75 subroutine). -/
-def evmModPatched : Program :=
-  (EvmAsm.Evm64.evm_mod : List Instr).take 267 ++
-  [Instr.JAL .x0 (304 : BitVec 21)] ++
-  (EvmAsm.Evm64.evm_mod : List Instr).drop 268
-
-/-- `EvmAsm.Evm64.evm_sdiv` with the leading `ADDI .x18 .x1 0`
-    save_ra_block removed (413 instructions instead of 414). The
-    M9 trampoline handler sets `x18 = &h_SDIV_done` in `preBody`;
-    the body's existing `JALR x0, x18, 0` then jumps to our
-    restore stub instead of clobbering `x18` with `x1`.
-
-    The first instruction of `evm_sdiv_wrapper` is
-    `evm_sdiv_save_ra_block .x18` = `ADDI .x18 .x1 0`
-    (`EvmAsm/Evm64/SDiv/Program.lean:180`). Splicing it off lets
-    our trampoline target stick. -/
-def evmSdivPatched : Program :=
-  (EvmAsm.Evm64.evm_sdiv : List Instr).drop 1
-
-/-- `EvmAsm.Evm64.evm_smod` with the same leading-save_ra splice
-    as `evmSdivPatched`. SMOD's wrapper is structurally identical
-    to SDIV's at the entry/exit boundary (only the conditional-
-    negate path differs). -/
-def evmSmodPatched : Program :=
-  (EvmAsm.Evm64.evm_smod : List Instr).drop 1
-
-/-- `EvmAsm.Evm64.evm_div_v5` with the NOP exit slot patched to skip the
-    longer 85-instruction v5 div128 subroutine. -/
-def evmDivV5Patched : Program :=
-  (EvmAsm.Evm64.evm_div_v5 : List Instr).take 267 ++
-  [Instr.JAL .x0 (344 : BitVec 21)] ++
-  (EvmAsm.Evm64.evm_div_v5 : List Instr).drop 268
-
-/-- `EvmAsm.Evm64.evm_mod_v5` with the same v5 NOP-splice as
-    `evmDivV5Patched`. -/
-def evmModV5Patched : Program :=
-  (EvmAsm.Evm64.evm_mod_v5 : List Instr).take 267 ++
-  [Instr.JAL .x0 (344 : BitVec 21)] ++
-  (EvmAsm.Evm64.evm_mod_v5 : List Instr).drop 268
-
-/-- `EvmAsm.Evm64.evm_sdiv_v5` with the leading save-ra block removed for
-    trampoline-style handlers. -/
-def evmSdivV5Patched : Program :=
-  (EvmAsm.Evm64.evm_sdiv_v5 : List Instr).drop 1
-
-/-- `EvmAsm.Evm64.evm_smod_v5` with the leading save-ra block removed for
-    trampoline-style handlers. -/
-def evmSmodV5Patched : Program :=
-  (EvmAsm.Evm64.evm_smod_v5 : List Instr).drop 1
 
 /-! ## tiny_interp_dispatch — M5b runtime fetch/decode/dispatch loop
 

--- a/EvmAsm/Codegen/Programs/Evm.lean
+++ b/EvmAsm/Codegen/Programs/Evm.lean
@@ -52,6 +52,7 @@ import EvmAsm.Codegen.Dispatch
 import EvmAsm.Codegen.Programs.EvmBasic
 import EvmAsm.Codegen.Programs.EvmTinyInterp
 import EvmAsm.Codegen.Programs.EvmDivModWrappers
+import EvmAsm.Codegen.Programs.EvmStackHandlers
 import EvmAsm.Codegen.Programs.EvmMcopyGas
 import EvmAsm.Codegen.Programs.EvmMemoryGas
 import EvmAsm.Codegen.Programs.Clz
@@ -108,40 +109,6 @@ open EvmAsm.Rv64
 
 private def stackUnderflowGuardSaveX10Asm (wordCount : Nat) : String :=
   stackUnderflowGuardAsm wordCount ++ "\n  mv x9, x10"
-
-/-- PUSH0..PUSH32. Opcode byte = `0x5f + n`; the handler advances
-    `x10` by `1 + n` (one opcode byte + `n` immediate bytes). -/
-def pushHandlers : List OpcodeHandlerSpec :=
-  (List.range 33).map (fun n =>
-    { label   := s!"h_PUSH{n}"
-      opcodes := [0x5f + n]
-      preBody := stackOverflowGuardAsm
-      body    := EvmAsm.Evm64.evm_push n
-      tail    := .advanceAndRet (1 + n) })
-
-/-- DUP1..DUP16. Opcode byte = `0x7f + n` (so DUP1 = `0x80`);
-    width 1. `evm_dup n` duplicates the n-th stack item (1-indexed
-    from top) onto the top. -/
-def dupHandlers : List OpcodeHandlerSpec :=
-  (List.range 16).map (fun i =>
-    let n := i + 1
-    { label   := s!"h_DUP{n}"
-      opcodes := [0x7f + n]
-      preBody := stackUnderflowGuardAsm n
-      body    := EvmAsm.Evm64.evm_dup n
-      tail    := .advanceAndRet 1 })
-
-/-- SWAP1..SWAP16. Opcode byte = `0x8f + n` (so SWAP1 = `0x90`);
-    width 1. `evm_swap n` swaps the top with the (n+1)-th stack
-    item. -/
-def swapHandlers : List OpcodeHandlerSpec :=
-  (List.range 16).map (fun i =>
-    let n := i + 1
-    { label   := s!"h_SWAP{n}"
-      opcodes := [0x8f + n]
-      preBody := stackUnderflowGuardAsm (n + 1)
-      body    := EvmAsm.Evm64.evm_swap n
-      tail    := .advanceAndRet 1 })
 
 /-- Tail used by handlers whose verified body clobbers `x10` (the
     EVM code pointer in our dispatcher convention). Restores `x10`

--- a/EvmAsm/Codegen/Programs/EvmDivModWrappers.lean
+++ b/EvmAsm/Codegen/Programs/EvmDivModWrappers.lean
@@ -1,0 +1,84 @@
+/-
+  EvmAsm.Codegen.Programs.EvmDivModWrappers
+
+  Patched DIV/MOD wrapper helpers used by standalone codegen units and
+  dispatcher handlers.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Evm64.DivMod.Program
+import EvmAsm.Evm64.SDiv.Program
+import EvmAsm.Evm64.SMod.Program
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+/-! ## divK NOP-splice helpers (used by both M2 standalone DIV/MOD
+    wrappers and the M8 dispatcher handlers). -/
+
+/-- `EvmAsm.Evm64.evm_div` with the NOP "exit PC" at internal index 267
+    replaced by a forward `JAL .x0 +304` that skips the 75-instruction
+    inline `divK_div128_v4` subroutine and lands at the instruction
+    immediately following the body. In the M2 standalone wrapper that
+    landing site is the start of `evmAddEpilogue`; in the M8
+    dispatcher wrapper (M5b registry) it is the `mv x10, x9` of the
+    handler's `x10RestoreAdvance1` tail. -/
+def evmDivPatched : Program :=
+  (EvmAsm.Evm64.evm_div : List Instr).take 267 ++
+  [Instr.JAL .x0 (304 : BitVec 21)] ++
+  (EvmAsm.Evm64.evm_div : List Instr).drop 268
+
+/-- `EvmAsm.Evm64.evm_mod` with the same NOP-splice as `evmDivPatched`.
+    Same +304 byte offset because the MOD body has the identical
+    343-instruction layout (267 main + NOP + 75 subroutine). -/
+def evmModPatched : Program :=
+  (EvmAsm.Evm64.evm_mod : List Instr).take 267 ++
+  [Instr.JAL .x0 (304 : BitVec 21)] ++
+  (EvmAsm.Evm64.evm_mod : List Instr).drop 268
+
+/-- `EvmAsm.Evm64.evm_sdiv` with the leading `ADDI .x18 .x1 0`
+    save_ra_block removed (413 instructions instead of 414). The
+    M9 trampoline handler sets `x18 = &h_SDIV_done` in `preBody`;
+    the body's existing `JALR x0, x18, 0` then jumps to our
+    restore stub instead of clobbering `x18` with `x1`.
+
+    The first instruction of `evm_sdiv_wrapper` is
+    `evm_sdiv_save_ra_block .x18` = `ADDI .x18 .x1 0`
+    (`EvmAsm/Evm64/SDiv/Program.lean:180`). Splicing it off lets
+    our trampoline target stick. -/
+def evmSdivPatched : Program :=
+  (EvmAsm.Evm64.evm_sdiv : List Instr).drop 1
+
+/-- `EvmAsm.Evm64.evm_smod` with the same leading-save_ra splice
+    as `evmSdivPatched`. SMOD's wrapper is structurally identical
+    to SDIV's at the entry/exit boundary (only the conditional-
+    negate path differs). -/
+def evmSmodPatched : Program :=
+  (EvmAsm.Evm64.evm_smod : List Instr).drop 1
+
+/-- `EvmAsm.Evm64.evm_div_v5` with the NOP exit slot patched to skip the
+    longer 85-instruction v5 div128 subroutine. -/
+def evmDivV5Patched : Program :=
+  (EvmAsm.Evm64.evm_div_v5 : List Instr).take 267 ++
+  [Instr.JAL .x0 (344 : BitVec 21)] ++
+  (EvmAsm.Evm64.evm_div_v5 : List Instr).drop 268
+
+/-- `EvmAsm.Evm64.evm_mod_v5` with the same v5 NOP-splice as
+    `evmDivV5Patched`. -/
+def evmModV5Patched : Program :=
+  (EvmAsm.Evm64.evm_mod_v5 : List Instr).take 267 ++
+  [Instr.JAL .x0 (344 : BitVec 21)] ++
+  (EvmAsm.Evm64.evm_mod_v5 : List Instr).drop 268
+
+/-- `EvmAsm.Evm64.evm_sdiv_v5` with the leading save-ra block removed for
+    trampoline-style handlers. -/
+def evmSdivV5Patched : Program :=
+  (EvmAsm.Evm64.evm_sdiv_v5 : List Instr).drop 1
+
+/-- `EvmAsm.Evm64.evm_smod_v5` with the leading save-ra block removed for
+    trampoline-style handlers. -/
+def evmSmodV5Patched : Program :=
+  (EvmAsm.Evm64.evm_smod_v5 : List Instr).drop 1
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/EvmStackHandlers.lean
+++ b/EvmAsm/Codegen/Programs/EvmStackHandlers.lean
@@ -1,0 +1,50 @@
+/-
+  EvmAsm.Codegen.Programs.EvmStackHandlers
+
+  Dispatcher handler families for PUSH, DUP, and SWAP opcodes.
+-/
+
+import EvmAsm.Codegen.Dispatch
+import EvmAsm.Evm64.Push.Program
+import EvmAsm.Evm64.Dup.Program
+import EvmAsm.Evm64.Swap.Program
+
+namespace EvmAsm.Codegen
+
+/-! ## stack opcode handler families -/
+
+/-- PUSH0..PUSH32. Opcode byte = `0x5f + n`; the handler advances
+    `x10` by `1 + n` (one opcode byte + `n` immediate bytes). -/
+def pushHandlers : List OpcodeHandlerSpec :=
+  (List.range 33).map (fun n =>
+    { label   := s!"h_PUSH{n}"
+      opcodes := [0x5f + n]
+      preBody := stackOverflowGuardAsm
+      body    := EvmAsm.Evm64.evm_push n
+      tail    := .advanceAndRet (1 + n) })
+
+/-- DUP1..DUP16. Opcode byte = `0x7f + n` (so DUP1 = `0x80`);
+    width 1. `evm_dup n` duplicates the n-th stack item (1-indexed
+    from top) onto the top. -/
+def dupHandlers : List OpcodeHandlerSpec :=
+  (List.range 16).map (fun i =>
+    let n := i + 1
+    { label   := s!"h_DUP{n}"
+      opcodes := [0x7f + n]
+      preBody := stackUnderflowGuardAsm n
+      body    := EvmAsm.Evm64.evm_dup n
+      tail    := .advanceAndRet 1 })
+
+/-- SWAP1..SWAP16. Opcode byte = `0x8f + n` (so SWAP1 = `0x90`);
+    width 1. `evm_swap n` swaps the top with the (n+1)-th stack
+    item. -/
+def swapHandlers : List OpcodeHandlerSpec :=
+  (List.range 16).map (fun i =>
+    let n := i + 1
+    { label   := s!"h_SWAP{n}"
+      opcodes := [0x8f + n]
+      preBody := stackUnderflowGuardAsm (n + 1)
+      body    := EvmAsm.Evm64.evm_swap n
+      tail    := .advanceAndRet 1 })
+
+end EvmAsm.Codegen


### PR DESCRIPTION
## Summary
- move patched DIV/MOD wrapper helpers into `EvmAsm.Codegen.Programs.EvmDivModWrappers`
- keep `EvmAsm.Codegen.Programs.Evm` importing the new module so dispatcher and standalone registry names stay unchanged
- reduce `Programs/Evm.lean` by another 68 lines on top of #8256

## Stack
- based on #8256, which is based on #8255

## Verification
- `lake build EvmAsm.Codegen.Programs.EvmDivModWrappers EvmAsm.Codegen.Programs.Evm EvmAsm.Codegen.Programs`
- `lake exe codegen --program evm_div_v5 --asm-only`
- `lake exe codegen --program evm_mod_v5 --asm-only`
- `lake exe codegen --program evm_sdiv_v5 --asm-only`
- `lake exe codegen --program evm_smod_v5 --asm-only`
- `scripts/check-file-size.sh --report`
- `scripts/check-unimported.sh`
- `git diff --check`
- `lake build` (passes with the existing LeanRV64D `extension.toCtorIdx` deprecation warning)

Bead: evm-asm-fhsxz.2.4.2.60.17.10

Authored by @pirapira; implemented by Codex.