### PR TITLE
refactor(codegen): split EVM stack handlers

### DIFF
--- a/EvmAsm/Codegen/Programs/Evm.lean
+++ b/EvmAsm/Codegen/Programs/Evm.lean
@@ -52,6 +52,7 @@ import EvmAsm.Codegen.Dispatch
 import EvmAsm.Codegen.Programs.EvmBasic
 import EvmAsm.Codegen.Programs.EvmTinyInterp
 import EvmAsm.Codegen.Programs.EvmDivModWrappers
+import EvmAsm.Codegen.Programs.EvmStackHandlers
 import EvmAsm.Codegen.Programs.EvmMcopyGas
 import EvmAsm.Codegen.Programs.EvmMemoryGas
 import EvmAsm.Codegen.Programs.Clz
@@ -108,40 +109,6 @@ open EvmAsm.Rv64
 
 private def stackUnderflowGuardSaveX10Asm (wordCount : Nat) : String :=
   stackUnderflowGuardAsm wordCount ++ "\n  mv x9, x10"
-
-/-- PUSH0..PUSH32. Opcode byte = `0x5f + n`; the handler advances
-    `x10` by `1 + n` (one opcode byte + `n` immediate bytes). -/
-def pushHandlers : List OpcodeHandlerSpec :=
-  (List.range 33).map (fun n =>
-    { label   := s!"h_PUSH{n}"
-      opcodes := [0x5f + n]
-      preBody := stackOverflowGuardAsm
-      body    := EvmAsm.Evm64.evm_push n
-      tail    := .advanceAndRet (1 + n) })
-
-/-- DUP1..DUP16. Opcode byte = `0x7f + n` (so DUP1 = `0x80`);
-    width 1. `evm_dup n` duplicates the n-th stack item (1-indexed
-    from top) onto the top. -/
-def dupHandlers : List OpcodeHandlerSpec :=
-  (List.range 16).map (fun i =>
-    let n := i + 1
-    { label   := s!"h_DUP{n}"
-      opcodes := [0x7f + n]
-      preBody := stackUnderflowGuardAsm n
-      body    := EvmAsm.Evm64.evm_dup n
-      tail    := .advanceAndRet 1 })
-
-/-- SWAP1..SWAP16. Opcode byte = `0x8f + n` (so SWAP1 = `0x90`);
-    width 1. `evm_swap n` swaps the top with the (n+1)-th stack
-    item. -/
-def swapHandlers : List OpcodeHandlerSpec :=
-  (List.range 16).map (fun i =>
-    let n := i + 1
-    { label   := s!"h_SWAP{n}"
-      opcodes := [0x8f + n]
-      preBody := stackUnderflowGuardAsm (n + 1)
-      body    := EvmAsm.Evm64.evm_swap n
-      tail    := .advanceAndRet 1 })
 
 /-- Tail used by handlers whose verified body clobbers `x10` (the
     EVM code pointer in our dispatcher convention). Restores `x10`

--- a/EvmAsm/Codegen/Programs/EvmStackHandlers.lean
+++ b/EvmAsm/Codegen/Programs/EvmStackHandlers.lean
@@ -1,0 +1,50 @@
+/-
+  EvmAsm.Codegen.Programs.EvmStackHandlers
+
+  Dispatcher handler families for PUSH, DUP, and SWAP opcodes.
+-/
+
+import EvmAsm.Codegen.Dispatch
+import EvmAsm.Evm64.Push.Program
+import EvmAsm.Evm64.Dup.Program
+import EvmAsm.Evm64.Swap.Program
+
+namespace EvmAsm.Codegen
+
+/-! ## stack opcode handler families -/
+
+/-- PUSH0..PUSH32. Opcode byte = `0x5f + n`; the handler advances
+    `x10` by `1 + n` (one opcode byte + `n` immediate bytes). -/
+def pushHandlers : List OpcodeHandlerSpec :=
+  (List.range 33).map (fun n =>
+    { label   := s!"h_PUSH{n}"
+      opcodes := [0x5f + n]
+      preBody := stackOverflowGuardAsm
+      body    := EvmAsm.Evm64.evm_push n
+      tail    := .advanceAndRet (1 + n) })
+
+/-- DUP1..DUP16. Opcode byte = `0x7f + n` (so DUP1 = `0x80`);
+    width 1. `evm_dup n` duplicates the n-th stack item (1-indexed
+    from top) onto the top. -/
+def dupHandlers : List OpcodeHandlerSpec :=
+  (List.range 16).map (fun i =>
+    let n := i + 1
+    { label   := s!"h_DUP{n}"
+      opcodes := [0x7f + n]
+      preBody := stackUnderflowGuardAsm n
+      body    := EvmAsm.Evm64.evm_dup n
+      tail    := .advanceAndRet 1 })
+
+/-- SWAP1..SWAP16. Opcode byte = `0x8f + n` (so SWAP1 = `0x90`);
+    width 1. `evm_swap n` swaps the top with the (n+1)-th stack
+    item. -/
+def swapHandlers : List OpcodeHandlerSpec :=
+  (List.range 16).map (fun i =>
+    let n := i + 1
+    { label   := s!"h_SWAP{n}"
+      opcodes := [0x8f + n]
+      preBody := stackUnderflowGuardAsm (n + 1)
+      body    := EvmAsm.Evm64.evm_swap n
+      tail    := .advanceAndRet 1 })
+
+end EvmAsm.Codegen


### PR DESCRIPTION
## Summary
- move PUSH/DUP/SWAP dispatcher handler families into `EvmAsm.Codegen.Programs.EvmStackHandlers`
- keep `EvmAsm.Codegen.Programs.Evm` importing the new module so `tinyInterpRegistry` still sees the same names
- reduce `Programs/Evm.lean` by another 34 lines on top of #8257

## Stack
- based on #8257, which is stacked on #8256 and #8255

## Verification
- `lake build EvmAsm.Codegen.Programs.EvmStackHandlers EvmAsm.Codegen.Programs.Evm EvmAsm.Codegen.Programs`
- `lake exe codegen --program runtime_dispatcher --asm-only`
- `scripts/check-file-size.sh --report`
- `scripts/check-unimported.sh`
- `git diff --check`
- `lake build` (passes with the existing LeanRV64D `extension.toCtorIdx` deprecation warning)

Bead: evm-asm-fhsxz.2.4.2.60.17.11

Authored by @pirapira; implemented by Codex.