### PR TITLE
refactor(codegen): split EVM memory handlers

### DIFF
--- a/EvmAsm/Codegen/Programs/Evm.lean
+++ b/EvmAsm/Codegen/Programs/Evm.lean
@@ -54,6 +54,7 @@ import EvmAsm.Codegen.Programs.EvmTinyInterp
 import EvmAsm.Codegen.Programs.EvmDivModWrappers
 import EvmAsm.Codegen.Programs.EvmStackHandlers
 import EvmAsm.Codegen.Programs.EvmSingletonHandlers
+import EvmAsm.Codegen.Programs.EvmMemoryHandlers
 import EvmAsm.Codegen.Programs.EvmMcopyGas
 import EvmAsm.Codegen.Programs.EvmMemoryGas
 import EvmAsm.Codegen.Programs.Clz
@@ -112,62 +113,6 @@ open EvmAsm.Rv64
 -- `updateActiveMemorySizeConstAsm` (active-memory high-water tracking +
 -- memory-expansion gas) live in `Programs/EvmMemoryGas.lean` (file-size
 -- guardrail; imported above).
-
-/-- M7 memory opcodes. Register-parameterized; the dispatcher
-    prologue sets up `x13 = &evm_memory` (see
-    `EvmAsm/Codegen/Dispatch.lean`). The scratch registers `x14..x18`
-    are caller-saved across the `jalr` from the dispatcher loop;
-    nothing else in the registry preserves them.
-
-    Stack-pointer bookkeeping is internal to the verified bodies:
-    `evm_mload` is net stack-neutral, while `evm_mstore` and
-    `evm_mstore8` each end with `ADDI .x12 .x12 64` so the wrapper
-    uses the standard `.advanceAndRet 1` tail. None of the memory
-    opcodes touch `x10`, so no `preBody` is needed. -/
-def memoryHandlers : List OpcodeHandlerSpec :=
-  [ -- MLOAD: pop offset, push value. memBase=x13;
-    -- scratch: offReg=x15, byteReg=x16, accReg=x17, addrReg=x18.
-    { label   := "h_MLOAD"
-      opcodes := [0x51]
-      preBody := stackUnderflowGuardAsm 1 ++ "\n" ++
-                 "  ld x15, 0(x12)\n" ++
-                 updateActiveMemorySizeConstAsm "mload" "x15" "x16" "x17" "x18" "x19" "x6" true 32
-      body    := EvmAsm.Evm64.evm_mload .x15 .x16 .x17 .x18 .x13
-      tail    := .advanceAndRet 1 }
-  , -- MSTORE: pop offset + value, write 32 bytes BE to memory.
-    -- valReg=x14 (scratch; placeholder per evm_mstore docstring).
-    { label   := "h_MSTORE"
-      opcodes := [0x52]
-      preBody := stackUnderflowGuardAsm 2 ++ "\n" ++
-                 "  ld x15, 0(x12)\n" ++
-                 updateActiveMemorySizeConstAsm "mstore" "x15" "x16" "x17" "x18" "x19" "x6" true 32
-      body    := EvmAsm.Evm64.evm_mstore .x15 .x14 .x16 .x17 .x18 .x13
-      tail    := .advanceAndRet 1 }
-  , -- MSTORE8: pop offset + value, write 1 byte to memory.
-    { label   := "h_MSTORE8"
-      opcodes := [0x53]
-      preBody := stackUnderflowGuardAsm 2 ++ "\n" ++
-                 "  ld x15, 0(x12)\n" ++
-                 updateActiveMemorySizeConstAsm "mstore8" "x15" "x16" "x17" "x18" "x19" "x6" true 1
-      body    := EvmAsm.Evm64.evm_mstore8 .x15 .x14 .x18 .x13
-      tail    := .advanceAndRet 1 } ]
-
-/-- MSIZE pushes the dispatcher-maintained active memory size. It is
-    updated by the concrete memory handlers in this file using the
-    EVM's 32-byte rounding rule. -/
-def memoryMetadataHandlers : List OpcodeHandlerSpec :=
-  [ { label   := "h_MSIZE"
-      opcodes := [0x59]
-      body    := []
-      tail    := .custom <|
-        "  addi x12, x12, -32\n" ++
-        "  ld x14, " ++ toString activeMemorySizeOff ++ "(x20)\n" ++
-        "  sd x14, 0(x12)\n" ++
-        "  sd x0, 8(x12)\n" ++
-        "  sd x0, 16(x12)\n" ++
-        "  sd x0, 24(x12)\n" ++
-        "  addi x10, x10, 1\n" ++
-        "  ret" } ]
 
 /-- M30: GAS (0x5a) pushes the dispatcher-maintained remaining gas
     (env+568, charged per-opcode by the dispatch loop). Mirrors the

--- a/EvmAsm/Codegen/Programs/EvmMemoryHandlers.lean
+++ b/EvmAsm/Codegen/Programs/EvmMemoryHandlers.lean
@@ -1,0 +1,73 @@
+/-
+  EvmAsm.Codegen.Programs.EvmMemoryHandlers
+
+  Dispatcher handlers for MLOAD, MSTORE, MSTORE8, and MSIZE.
+-/
+
+import EvmAsm.Codegen.Dispatch
+import EvmAsm.Evm64.MLoad.Program
+import EvmAsm.Evm64.MStore.Program
+import EvmAsm.Evm64.MStore8.Program
+import EvmAsm.Codegen.Programs.EvmMemoryGas
+
+namespace EvmAsm.Codegen
+
+/-! ## memory opcode handler families -/
+
+/-- M7 memory opcodes. Register-parameterized; the dispatcher
+    prologue sets up `x13 = &evm_memory` (see
+    `EvmAsm/Codegen/Dispatch.lean`). The scratch registers `x14..x18`
+    are caller-saved across the `jalr` from the dispatcher loop;
+    nothing else in the registry preserves them.
+
+    Stack-pointer bookkeeping is internal to the verified bodies:
+    `evm_mload` is net stack-neutral, while `evm_mstore` and
+    `evm_mstore8` each end with `ADDI .x12 .x12 64` so the wrapper
+    uses the standard `.advanceAndRet 1` tail. None of the memory
+    opcodes touch `x10`, so no `preBody` is needed. -/
+def memoryHandlers : List OpcodeHandlerSpec :=
+  [ -- MLOAD: pop offset, push value. memBase=x13;
+    -- scratch: offReg=x15, byteReg=x16, accReg=x17, addrReg=x18.
+    { label   := "h_MLOAD"
+      opcodes := [0x51]
+      preBody := stackUnderflowGuardAsm 1 ++ "\n" ++
+                 "  ld x15, 0(x12)\n" ++
+                 updateActiveMemorySizeConstAsm "mload" "x15" "x16" "x17" "x18" "x19" "x6" true 32
+      body    := EvmAsm.Evm64.evm_mload .x15 .x16 .x17 .x18 .x13
+      tail    := .advanceAndRet 1 }
+  , -- MSTORE: pop offset + value, write 32 bytes BE to memory.
+    -- valReg=x14 (scratch; placeholder per evm_mstore docstring).
+    { label   := "h_MSTORE"
+      opcodes := [0x52]
+      preBody := stackUnderflowGuardAsm 2 ++ "\n" ++
+                 "  ld x15, 0(x12)\n" ++
+                 updateActiveMemorySizeConstAsm "mstore" "x15" "x16" "x17" "x18" "x19" "x6" true 32
+      body    := EvmAsm.Evm64.evm_mstore .x15 .x14 .x16 .x17 .x18 .x13
+      tail    := .advanceAndRet 1 }
+  , -- MSTORE8: pop offset + value, write 1 byte to memory.
+    { label   := "h_MSTORE8"
+      opcodes := [0x53]
+      preBody := stackUnderflowGuardAsm 2 ++ "\n" ++
+                 "  ld x15, 0(x12)\n" ++
+                 updateActiveMemorySizeConstAsm "mstore8" "x15" "x16" "x17" "x18" "x19" "x6" true 1
+      body    := EvmAsm.Evm64.evm_mstore8 .x15 .x14 .x18 .x13
+      tail    := .advanceAndRet 1 } ]
+
+/-- MSIZE pushes the dispatcher-maintained active memory size. It is
+    updated by the concrete memory handlers in this file using the
+    EVM's 32-byte rounding rule. -/
+def memoryMetadataHandlers : List OpcodeHandlerSpec :=
+  [ { label   := "h_MSIZE"
+      opcodes := [0x59]
+      body    := []
+      tail    := .custom <|
+        "  addi x12, x12, -32\n" ++
+        "  ld x14, " ++ toString activeMemorySizeOff ++ "(x20)\n" ++
+        "  sd x14, 0(x12)\n" ++
+        "  sd x0, 8(x12)\n" ++
+        "  sd x0, 16(x12)\n" ++
+        "  sd x0, 24(x12)\n" ++
+        "  addi x10, x10, 1\n" ++
+        "  ret" } ]
+
+end EvmAsm.Codegen


### PR DESCRIPTION
## Summary
- move MLOAD/MSTORE/MSTORE8 and MSIZE dispatcher handlers into `EvmAsm.Codegen.Programs.EvmMemoryHandlers`
- keep `memoryHandlers` and `memoryMetadataHandlers` exported through `EvmAsm.Codegen.Programs.Evm` for the runtime registry
- reduce `Programs/Evm.lean` by another 56 lines on top of #8259

## Stack
- based on #8259, which is stacked on #8258/#8257/#8256/#8255

## Verification
- `lake build EvmAsm.Codegen.Programs.EvmMemoryHandlers EvmAsm.Codegen.Programs.Evm EvmAsm.Codegen.Programs`
- `lake exe codegen --program runtime_dispatcher --asm-only`
- `scripts/check-file-size.sh --report`
- `scripts/check-unimported.sh`
- `git diff --check`
- `lake build` (passes with the existing LeanRV64D `extension.toCtorIdx` deprecation warning)

Bead: evm-asm-fhsxz.2.4.2.60.17.13

Authored by @pirapira; implemented by Codex.