### PR TITLE
refactor(codegen): split EVM code handlers

### DIFF
--- a/EvmAsm/Codegen/Programs/Evm.lean
+++ b/EvmAsm/Codegen/Programs/Evm.lean
@@ -21,7 +21,6 @@ import EvmAsm.Evm64.ControlFlow.Program
 import EvmAsm.Evm64.DivMod.Callable
 import EvmAsm.Evm64.DivMod.Program
 import EvmAsm.Evm64.Dup.Program
-import EvmAsm.Evm64.Env.Program
 import EvmAsm.Evm64.Eq.Program
 import EvmAsm.Evm64.Exp.Program
 import EvmAsm.Evm64.Gt.Program
@@ -56,6 +55,7 @@ import EvmAsm.Codegen.Programs.EvmSingletonHandlers
 import EvmAsm.Codegen.Programs.EvmMemoryHandlers
 import EvmAsm.Codegen.Programs.EvmGasHandlers
 import EvmAsm.Codegen.Programs.EvmCodeHandlers
+import EvmAsm.Codegen.Programs.EvmEnvHandlers
 import EvmAsm.Codegen.Programs.EvmMcopyGas
 import EvmAsm.Codegen.Programs.EvmMemoryGas
 import EvmAsm.Codegen.Programs.Clz
@@ -109,44 +109,6 @@ open EvmAsm.Rv64
     All other opcode bytes fall to `h_invalid` (emitted automatically
     by `emitDispatcherEpilogue`), which takes the same exit path as
     STOP. -/
-
-/-- M12 simple environment opcodes (13 of them, one record each).
-
-    All 13 share the verified body
-    `EvmAsm.Evm64.Env.evm_env_load envBaseReg tmpReg field`
-    (9 instructions = 36 bytes per handler) parameterized over a
-    `SimpleEnvField`. The dispatcher prologue sets `x20 = &evm_env`
-    (a 416-byte = 13×32 region in `.data` initialised to zero), and
-    each handler passes `.x20` as `envBaseReg` plus `.x15` as
-    `tmpReg`. None of these bodies touch `x10`, so `preBody := ""`.
-
-    `x20` was chosen over `x14` (the M8/M9/M10 save register) because
-    DIV/MOD/SDIV/SMOD/ADDMOD all use `preBody := "mv x14, x10"` —
-    `x14` is explicitly "outside the dispatcher's preserved set" per
-    M8's docstring. `x20` is a callee-saved LP64 register with zero
-    references in any `EvmAsm/Evm64/*/Program.lean` and zero uses by
-    any existing handler's `preBody`/`tail`, making it the cleanest
-    long-term home for the env base.
-
-    The env region is zero-initialised; non-zero env values come
-    from a future host-preload PR. The wiring correctness (each
-    opcode byte routes to the right field offset, x12 advances, the
-    32 bytes land on the stack) is what M12 validates. -/
-def envHandlers : List OpcodeHandlerSpec :=
-  [ { label := "h_ADDRESS"    , opcodes := [0x30], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .address    , tail := .advanceAndRet 1 }
-  , { label := "h_ORIGIN"     , opcodes := [0x32], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .origin     , tail := .advanceAndRet 1 }
-  , { label := "h_CALLER"     , opcodes := [0x33], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .caller     , tail := .advanceAndRet 1 }
-  , { label := "h_CALLVALUE"  , opcodes := [0x34], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .callValue  , tail := .advanceAndRet 1 }
-  , { label := "h_GASPRICE"   , opcodes := [0x3a], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .gasPrice   , tail := .advanceAndRet 1 }
-  , { label := "h_COINBASE"   , opcodes := [0x41], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .coinbase   , tail := .advanceAndRet 1 }
-  , { label := "h_TIMESTAMP"  , opcodes := [0x42], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .timestamp  , tail := .advanceAndRet 1 }
-  , { label := "h_NUMBER"     , opcodes := [0x43], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .number     , tail := .advanceAndRet 1 }
-  , { label := "h_PREVRANDAO" , opcodes := [0x44], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .prevrandao , tail := .advanceAndRet 1 }
-  , { label := "h_GASLIMIT"   , opcodes := [0x45], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .gasLimit   , tail := .advanceAndRet 1 }
-  , { label := "h_CHAINID"    , opcodes := [0x46], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .chainId    , tail := .advanceAndRet 1 }
-  , { label := "h_SELFBALANCE", opcodes := [0x47], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .selfBalance, tail := .advanceAndRet 1 }
-  , { label := "h_BASEFEE"    , opcodes := [0x48], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .baseFee    , tail := .advanceAndRet 1 } ]
-
 
 /-- EIP-7843 SLOTNUM (0x4b). The runtime input trailer carries the current
     consensus slot number as a 256-bit stack word. The dispatcher prologue

--- a/EvmAsm/Codegen/Programs/Evm.lean
+++ b/EvmAsm/Codegen/Programs/Evm.lean
@@ -17,7 +17,6 @@ import EvmAsm.Evm64.Byte.Program
 import EvmAsm.Evm64.Calldata.LoadProgram
 import EvmAsm.Evm64.Calldata.CopyProgram
 import EvmAsm.Evm64.Calldata.SizeProgram
-import EvmAsm.Evm64.Code.CopyProgram
 import EvmAsm.Evm64.ControlFlow.Program
 import EvmAsm.Evm64.DivMod.Callable
 import EvmAsm.Evm64.DivMod.Program
@@ -56,6 +55,7 @@ import EvmAsm.Codegen.Programs.EvmStackHandlers
 import EvmAsm.Codegen.Programs.EvmSingletonHandlers
 import EvmAsm.Codegen.Programs.EvmMemoryHandlers
 import EvmAsm.Codegen.Programs.EvmGasHandlers
+import EvmAsm.Codegen.Programs.EvmCodeHandlers
 import EvmAsm.Codegen.Programs.EvmMcopyGas
 import EvmAsm.Codegen.Programs.EvmMemoryGas
 import EvmAsm.Codegen.Programs.Clz
@@ -109,45 +109,6 @@ open EvmAsm.Rv64
     All other opcode bytes fall to `h_invalid` (emitted automatically
     by `emitDispatcherEpilogue`), which takes the same exit path as
     STOP. -/
-
-/-- M33: running-code opcodes CODESIZE (0x38) and CODECOPY (0x39).
-    Both operate on the *currently executing* bytecode, which the
-    dispatcher already holds in memory — code base in `x21` and exact
-    byte length in the `env+codeSizeOff` (= 496) cell, seeded by both
-    dispatcher prologues. No witness / external-account state is needed
-    (unlike BALANCE / EXTCODE*), so these are self-contained.
-
-    - **CODESIZE** — mirrors the MSIZE/GAS env-cell-push shape: push
-      `env.codeSize` as a 256-bit word (low limb = length, high limbs 0).
-    - **CODECOPY** — pops `(destOffset, dataOffset, size)` and runs the
-      verified `Code.evm_codecopy` byte loop (sibling of CALLDATACOPY),
-      copying `code[dataOffset..]` into `memory[destOffset..]` with
-      zero-fill past `len(code)`. The `preBody` charges memory expansion
-      (`updateActiveMemorySizeAsm`) over the destination range and guards
-      against stack underflow (3 operands). -/
-def codeHandlers : List OpcodeHandlerSpec :=
-  [ { label   := "h_CODESIZE"
-      opcodes := [0x38]
-      body    := []
-      tail    := .custom <|
-        "  addi x12, x12, -32\n" ++
-        "  ld x14, " ++ toString EvmAsm.Evm64.Code.codeSizeOff ++ "(x20)\n" ++
-        "  sd x14, 0(x12)\n" ++
-        "  sd x0, 8(x12)\n" ++
-        "  sd x0, 16(x12)\n" ++
-        "  sd x0, 24(x12)\n" ++
-        "  addi x10, x10, 1\n" ++
-        "  ret" }
-  , { label   := "h_CODECOPY"
-      opcodes := [0x39]
-      preBody := stackUnderflowGuardAsm 3 ++ "\n" ++
-                 "  ld x14, 0(x12)\n" ++        -- destOffset low limb (MSIZE range)
-                 "  ld x15, 64(x12)\n" ++       -- size low limb (MSIZE range)
-                 copyWordGasAsm "codecopy" "x15" "x16" "x17" "x18" ++
-                 updateActiveMemorySizeAsm "codecopy" "x14" "x15" "x16" "x17" "x18" "x6" true
-      body    := EvmAsm.Evm64.Code.evm_codecopy
-                   .x20 .x13 .x21 .x14 .x15 .x16 .x17 .x18
-      tail    := .advanceAndRet 1 } ]
 
 /-- M12 simple environment opcodes (13 of them, one record each).
 

--- a/EvmAsm/Codegen/Programs/EvmCodeHandlers.lean
+++ b/EvmAsm/Codegen/Programs/EvmCodeHandlers.lean
@@ -1,0 +1,52 @@
+/-
+  EvmAsm.Codegen.Programs.EvmCodeHandlers
+
+  Dispatcher handlers for CODESIZE and CODECOPY.
+-/
+
+import EvmAsm.Codegen.Dispatch
+import EvmAsm.Codegen.Programs.EvmMemoryGas
+import EvmAsm.Evm64.Code.CopyProgram
+
+namespace EvmAsm.Codegen
+
+/-- M33: running-code opcodes CODESIZE (0x38) and CODECOPY (0x39).
+    Both operate on the *currently executing* bytecode, which the
+    dispatcher already holds in memory: code base in `x21` and exact
+    byte length in the `env+codeSizeOff` (= 496) cell, seeded by both
+    dispatcher prologues. No witness / external-account state is needed
+    (unlike BALANCE / EXTCODE*), so these are self-contained.
+
+    - **CODESIZE** mirrors the MSIZE/GAS env-cell-push shape: push
+      `env.codeSize` as a 256-bit word (low limb = length, high limbs 0).
+    - **CODECOPY** pops `(destOffset, dataOffset, size)` and runs the
+      verified `Code.evm_codecopy` byte loop (sibling of CALLDATACOPY),
+      copying `code[dataOffset..]` into `memory[destOffset..]` with
+      zero-fill past `len(code)`. The `preBody` charges memory expansion
+      (`updateActiveMemorySizeAsm`) over the destination range and guards
+      against stack underflow (3 operands). -/
+def codeHandlers : List OpcodeHandlerSpec :=
+  [ { label   := "h_CODESIZE"
+      opcodes := [0x38]
+      body    := []
+      tail    := .custom <|
+        "  addi x12, x12, -32\n" ++
+        "  ld x14, " ++ toString EvmAsm.Evm64.Code.codeSizeOff ++ "(x20)\n" ++
+        "  sd x14, 0(x12)\n" ++
+        "  sd x0, 8(x12)\n" ++
+        "  sd x0, 16(x12)\n" ++
+        "  sd x0, 24(x12)\n" ++
+        "  addi x10, x10, 1\n" ++
+        "  ret" }
+  , { label   := "h_CODECOPY"
+      opcodes := [0x39]
+      preBody := stackUnderflowGuardAsm 3 ++ "\n" ++
+                 "  ld x14, 0(x12)\n" ++        -- destOffset low limb (MSIZE range)
+                 "  ld x15, 64(x12)\n" ++       -- size low limb (MSIZE range)
+                 copyWordGasAsm "codecopy" "x15" "x16" "x17" "x18" ++
+                 updateActiveMemorySizeAsm "codecopy" "x14" "x15" "x16" "x17" "x18" "x6" true
+      body    := EvmAsm.Evm64.Code.evm_codecopy
+                   .x20 .x13 .x21 .x14 .x15 .x16 .x17 .x18
+      tail    := .advanceAndRet 1 } ]
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/EvmEnvHandlers.lean
+++ b/EvmAsm/Codegen/Programs/EvmEnvHandlers.lean
@@ -1,0 +1,49 @@
+/-
+  EvmAsm.Codegen.Programs.EvmEnvHandlers
+
+  Dispatcher handlers for simple environment opcodes.
+-/
+
+import EvmAsm.Codegen.Dispatch
+import EvmAsm.Evm64.Env.Program
+
+namespace EvmAsm.Codegen
+
+/-- M12 simple environment opcodes (13 of them, one record each).
+
+    All 13 share the verified body
+    `EvmAsm.Evm64.Env.evm_env_load envBaseReg tmpReg field`
+    (9 instructions = 36 bytes per handler) parameterized over a
+    `SimpleEnvField`. The dispatcher prologue sets `x20 = &evm_env`
+    (a 416-byte = 13×32 region in `.data` initialised to zero), and
+    each handler passes `.x20` as `envBaseReg` plus `.x15` as
+    `tmpReg`. None of these bodies touch `x10`, so `preBody := ""`.
+
+    `x20` was chosen over `x14` (the M8/M9/M10 save register) because
+    DIV/MOD/SDIV/SMOD/ADDMOD all use `preBody := "mv x14, x10"`:
+    `x14` is explicitly "outside the dispatcher's preserved set" per
+    M8's docstring. `x20` is a callee-saved LP64 register with zero
+    references in any `EvmAsm/Evm64/*/Program.lean` and zero uses by
+    any existing handler's `preBody`/`tail`, making it the cleanest
+    long-term home for the env base.
+
+    The env region is zero-initialised; non-zero env values come
+    from a future host-preload PR. The wiring correctness (each
+    opcode byte routes to the right field offset, x12 advances, the
+    32 bytes land on the stack) is what M12 validates. -/
+def envHandlers : List OpcodeHandlerSpec :=
+  [ { label := "h_ADDRESS"    , opcodes := [0x30], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .address    , tail := .advanceAndRet 1 }
+  , { label := "h_ORIGIN"     , opcodes := [0x32], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .origin     , tail := .advanceAndRet 1 }
+  , { label := "h_CALLER"     , opcodes := [0x33], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .caller     , tail := .advanceAndRet 1 }
+  , { label := "h_CALLVALUE"  , opcodes := [0x34], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .callValue  , tail := .advanceAndRet 1 }
+  , { label := "h_GASPRICE"   , opcodes := [0x3a], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .gasPrice   , tail := .advanceAndRet 1 }
+  , { label := "h_COINBASE"   , opcodes := [0x41], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .coinbase   , tail := .advanceAndRet 1 }
+  , { label := "h_TIMESTAMP"  , opcodes := [0x42], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .timestamp  , tail := .advanceAndRet 1 }
+  , { label := "h_NUMBER"     , opcodes := [0x43], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .number     , tail := .advanceAndRet 1 }
+  , { label := "h_PREVRANDAO" , opcodes := [0x44], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .prevrandao , tail := .advanceAndRet 1 }
+  , { label := "h_GASLIMIT"   , opcodes := [0x45], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .gasLimit   , tail := .advanceAndRet 1 }
+  , { label := "h_CHAINID"    , opcodes := [0x46], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .chainId    , tail := .advanceAndRet 1 }
+  , { label := "h_SELFBALANCE", opcodes := [0x47], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .selfBalance, tail := .advanceAndRet 1 }
+  , { label := "h_BASEFEE"    , opcodes := [0x48], body := EvmAsm.Evm64.Env.evm_env_load .x20 .x15 .baseFee    , tail := .advanceAndRet 1 } ]
+
+end EvmAsm.Codegen


### PR DESCRIPTION
## Summary
- move CODESIZE/CODECOPY dispatcher handler construction into `EvmCodeHandlers.lean`
- keep `codeHandlers` exported through `Evm.lean` for the runtime dispatcher registry
- reduce `Evm.lean` from 991 to 952 lines in this stacked slice

Stacked on PR #8261.

## Verification
- `lake build EvmAsm.Codegen.Programs.EvmCodeHandlers EvmAsm.Codegen.Programs.Evm EvmAsm.Codegen.Programs`
- `lake exe codegen --program runtime_dispatcher --asm-only`
- `scripts/check-file-size.sh --report`
- `scripts/check-unimported.sh`
- `git diff --check`
- `lake build`

Full build passes with the existing LeanRV64D `extension.toCtorIdx` deprecation warning only.