### PR TITLE
refactor(codegen): split EVM slotnum handler

### DIFF
--- a/EvmAsm/Codegen/Programs/Evm.lean
+++ b/EvmAsm/Codegen/Programs/Evm.lean
@@ -56,6 +56,7 @@ import EvmAsm.Codegen.Programs.EvmMemoryHandlers
 import EvmAsm.Codegen.Programs.EvmGasHandlers
 import EvmAsm.Codegen.Programs.EvmCodeHandlers
 import EvmAsm.Codegen.Programs.EvmEnvHandlers
+import EvmAsm.Codegen.Programs.EvmSlotnumHandlers
 import EvmAsm.Codegen.Programs.EvmMcopyGas
 import EvmAsm.Codegen.Programs.EvmMemoryGas
 import EvmAsm.Codegen.Programs.Clz
@@ -109,25 +110,6 @@ open EvmAsm.Rv64
     All other opcode bytes fall to `h_invalid` (emitted automatically
     by `emitDispatcherEpilogue`), which takes the same exit path as
     STOP. -/
-
-/-- EIP-7843 SLOTNUM (0x4b). The runtime input trailer carries the current
-    consensus slot number as a 256-bit stack word. The dispatcher prologue
-    copies that word to `evm_env + 624`; this handler pushes it unchanged. -/
-def slotnumContextHandlers : List OpcodeHandlerSpec :=
-  let slotnumBody : Program :=
-    ADDI .x12 .x12 (-32) ;;
-    LD .x15 .x20 (BitVec.ofNat 12 624) ;;
-    SD .x12 .x15 0 ;;
-    LD .x15 .x20 (BitVec.ofNat 12 632) ;;
-    SD .x12 .x15 8 ;;
-    LD .x15 .x20 (BitVec.ofNat 12 640) ;;
-    SD .x12 .x15 16 ;;
-    LD .x15 .x20 (BitVec.ofNat 12 648) ;;
-    SD .x12 .x15 24
-  [ { label := "h_SLOTNUM"
-    , opcodes := [0x4b]
-    , body := slotnumBody
-    , tail := .advanceAndRet 1 } ]
 
 /-! ## M28 blob-context opcodes
 

--- a/EvmAsm/Codegen/Programs/EvmSlotnumHandlers.lean
+++ b/EvmAsm/Codegen/Programs/EvmSlotnumHandlers.lean
@@ -1,0 +1,33 @@
+/-
+  EvmAsm.Codegen.Programs.EvmSlotnumHandlers
+
+  Dispatcher handler for EIP-7843 SLOTNUM.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Dispatch
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+/-- EIP-7843 SLOTNUM (0x4b). The runtime input trailer carries the current
+    consensus slot number as a 256-bit stack word. The dispatcher prologue
+    copies that word to `evm_env + 624`; this handler pushes it unchanged. -/
+def slotnumContextHandlers : List OpcodeHandlerSpec :=
+  let slotnumBody : Program :=
+    ADDI .x12 .x12 (-32) ;;
+    LD .x15 .x20 (BitVec.ofNat 12 624) ;;
+    SD .x12 .x15 0 ;;
+    LD .x15 .x20 (BitVec.ofNat 12 632) ;;
+    SD .x12 .x15 8 ;;
+    LD .x15 .x20 (BitVec.ofNat 12 640) ;;
+    SD .x12 .x15 16 ;;
+    LD .x15 .x20 (BitVec.ofNat 12 648) ;;
+    SD .x12 .x15 24
+  [ { label := "h_SLOTNUM"
+    , opcodes := [0x4b]
+    , body := slotnumBody
+    , tail := .advanceAndRet 1 } ]
+
+end EvmAsm.Codegen


### PR DESCRIPTION
## Summary
- move SLOTNUM dispatcher handler construction into `EvmSlotnumHandlers.lean`
- keep `slotnumContextHandlers` exported through `Evm.lean` for the runtime dispatcher registry
- reduce `Evm.lean` from 914 to 896 lines in this stacked slice

Stacked on PR #8263. Bead: `evm-asm-fhsxz.2.4.2.60.17.17`.

## Verification
- `lake build EvmAsm.Codegen.Programs.EvmSlotnumHandlers EvmAsm.Codegen.Programs.Evm EvmAsm.Codegen.Programs`
- `lake exe codegen --program runtime_dispatcher --asm-only`
- `scripts/check-file-size.sh --report`
- `scripts/check-unimported.sh`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/Evm.lean EvmAsm/Codegen/Programs/EvmSlotnumHandlers.lean`\n- `git diff --check`\n- `lake build`\n\nFull build passes with the existing LeanRV64D `extension.toCtorIdx` deprecation warning only.\n\nAuthored by @pirapira; implemented by Codex.