### PR TITLE
refactor(codegen): split EVM blob context handlers

### DIFF
--- a/EvmAsm/Codegen/Programs/Evm.lean
+++ b/EvmAsm/Codegen/Programs/Evm.lean
@@ -56,6 +56,7 @@ import EvmAsm.Codegen.Programs.EvmMemoryHandlers
 import EvmAsm.Codegen.Programs.EvmGasHandlers
 import EvmAsm.Codegen.Programs.EvmCodeHandlers
 import EvmAsm.Codegen.Programs.EvmEnvHandlers
+import EvmAsm.Codegen.Programs.EvmSlotnumHandlers
 import EvmAsm.Codegen.Programs.EvmMcopyGas
 import EvmAsm.Codegen.Programs.EvmMemoryGas
 import EvmAsm.Codegen.Programs.Clz
@@ -109,25 +110,6 @@ open EvmAsm.Rv64
     All other opcode bytes fall to `h_invalid` (emitted automatically
     by `emitDispatcherEpilogue`), which takes the same exit path as
     STOP. -/
-
-/-- EIP-7843 SLOTNUM (0x4b). The runtime input trailer carries the current
-    consensus slot number as a 256-bit stack word. The dispatcher prologue
-    copies that word to `evm_env + 624`; this handler pushes it unchanged. -/
-def slotnumContextHandlers : List OpcodeHandlerSpec :=
-  let slotnumBody : Program :=
-    ADDI .x12 .x12 (-32) ;;
-    LD .x15 .x20 (BitVec.ofNat 12 624) ;;
-    SD .x12 .x15 0 ;;
-    LD .x15 .x20 (BitVec.ofNat 12 632) ;;
-    SD .x12 .x15 8 ;;
-    LD .x15 .x20 (BitVec.ofNat 12 640) ;;
-    SD .x12 .x15 16 ;;
-    LD .x15 .x20 (BitVec.ofNat 12 648) ;;
-    SD .x12 .x15 24
-  [ { label := "h_SLOTNUM"
-    , opcodes := [0x4b]
-    , body := slotnumBody
-    , tail := .advanceAndRet 1 } ]
 
 /-! ## M28 blob-context opcodes
 

--- a/EvmAsm/Codegen/Programs/Evm.lean
+++ b/EvmAsm/Codegen/Programs/Evm.lean
@@ -57,6 +57,7 @@ import EvmAsm.Codegen.Programs.EvmGasHandlers
 import EvmAsm.Codegen.Programs.EvmCodeHandlers
 import EvmAsm.Codegen.Programs.EvmEnvHandlers
 import EvmAsm.Codegen.Programs.EvmSlotnumHandlers
+import EvmAsm.Codegen.Programs.EvmBlobContextHandlers
 import EvmAsm.Codegen.Programs.EvmMcopyGas
 import EvmAsm.Codegen.Programs.EvmMemoryGas
 import EvmAsm.Codegen.Programs.Clz
@@ -110,69 +111,6 @@ open EvmAsm.Rv64
     All other opcode bytes fall to `h_invalid` (emitted automatically
     by `emitDispatcherEpilogue`), which takes the same exit path as
     STOP. -/
-
-/-! ## M28 blob-context opcodes
-
-  `BLOBBASEFEE` (0x4a) is an Amsterdam/Cancun context opcode. The
-  executable spec computes it as `calculate_blob_gas_price(block_env.excess_blob_gas)`;
-  this runtime dispatcher receives that already-computed 256-bit word in the
-  `pack-bytecode.py --blob-base-fee` input trailer and copies it to `evm_env+512`.
-
-  `BLOBHASH` (0x49) reads `tx_env.blob_versioned_hashes[index]` from the
-  bounded `evm_blob_hashes` table. The runtime prologue copies up to 16
-  entries from `pack-bytecode.py --blob-hashes` and stores the copied count at
-  `evm_env+544`; indexes outside that count, or indexes with nonzero high
-  limbs, push zero per execution-specs. -/
-def blobContextHandlers : List OpcodeHandlerSpec :=
-  let blobBaseFeeBody : Program :=
-    ADDI .x12 .x12 (-32) ;;
-    LD .x15 .x20 (BitVec.ofNat 12 512) ;;
-    SD .x12 .x15 0 ;;
-    LD .x15 .x20 (BitVec.ofNat 12 520) ;;
-    SD .x12 .x15 8 ;;
-    LD .x15 .x20 (BitVec.ofNat 12 528) ;;
-    SD .x12 .x15 16 ;;
-    LD .x15 .x20 (BitVec.ofNat 12 536) ;;
-    SD .x12 .x15 24
-  [ { label := "h_BLOBBASEFEE"
-    , opcodes := [0x4a]
-    , body := blobBaseFeeBody
-    , tail := .advanceAndRet 1 } ]
-  ++
-  [ { label := "h_BLOBHASH"
-    , opcodes := [0x49]
-    , preBody := stackUnderflowGuardAsm 1
-    , body := []
-    , tail := .custom <|
-        "  ld x14, 8(x12)\n" ++          -- high limbs must be zero
-        "  bnez x14, .Lblobhash_zero\n" ++
-        "  ld x14, 16(x12)\n" ++
-        "  bnez x14, .Lblobhash_zero\n" ++
-        "  ld x14, 24(x12)\n" ++
-        "  bnez x14, .Lblobhash_zero\n" ++
-        "  ld x14, 0(x12)\n" ++          -- x14 = low u64 index
-        "  ld x15, 544(x20)\n" ++        -- x15 = copied blob_hash_count
-        "  bgeu x14, x15, .Lblobhash_zero\n" ++
-        "  slli x14, x14, 5\n" ++        -- 32 bytes per versioned hash
-        "  la x15, evm_blob_hashes\n" ++
-        "  add x15, x15, x14\n" ++
-        "  ld x16, 0(x15)\n" ++
-        "  sd x16, 0(x12)\n" ++
-        "  ld x16, 8(x15)\n" ++
-        "  sd x16, 8(x12)\n" ++
-        "  ld x16, 16(x15)\n" ++
-        "  sd x16, 16(x12)\n" ++
-        "  ld x16, 24(x15)\n" ++
-        "  sd x16, 24(x12)\n" ++
-        "  addi x10, x10, 1\n" ++
-        "  ret\n" ++
-        ".Lblobhash_zero:\n" ++
-        "  sd x0, 0(x12)\n" ++
-        "  sd x0, 8(x12)\n" ++
-        "  sd x0, 16(x12)\n" ++
-        "  sd x0, 24(x12)\n" ++
-        "  addi x10, x10, 1\n" ++
-        "  ret" } ]
 
 /-- M29 BLOCKHASH handler backed by the runtime block-history trailer.
 

--- a/EvmAsm/Codegen/Programs/EvmBlobContextHandlers.lean
+++ b/EvmAsm/Codegen/Programs/EvmBlobContextHandlers.lean
@@ -1,0 +1,77 @@
+/-
+  EvmAsm.Codegen.Programs.EvmBlobContextHandlers
+
+  Dispatcher handlers for blob context opcodes.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Dispatch
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+/-! ## M28 blob-context opcodes
+
+  `BLOBBASEFEE` (0x4a) is an Amsterdam/Cancun context opcode. The
+  executable spec computes it as `calculate_blob_gas_price(block_env.excess_blob_gas)`;
+  this runtime dispatcher receives that already-computed 256-bit word in the
+  `pack-bytecode.py --blob-base-fee` input trailer and copies it to `evm_env+512`.
+
+  `BLOBHASH` (0x49) reads `tx_env.blob_versioned_hashes[index]` from the
+  bounded `evm_blob_hashes` table. The runtime prologue copies up to 16
+  entries from `pack-bytecode.py --blob-hashes` and stores the copied count at
+  `evm_env+544`; indexes outside that count, or indexes with nonzero high
+  limbs, push zero per execution-specs. -/
+def blobContextHandlers : List OpcodeHandlerSpec :=
+  let blobBaseFeeBody : Program :=
+    ADDI .x12 .x12 (-32) ;;
+    LD .x15 .x20 (BitVec.ofNat 12 512) ;;
+    SD .x12 .x15 0 ;;
+    LD .x15 .x20 (BitVec.ofNat 12 520) ;;
+    SD .x12 .x15 8 ;;
+    LD .x15 .x20 (BitVec.ofNat 12 528) ;;
+    SD .x12 .x15 16 ;;
+    LD .x15 .x20 (BitVec.ofNat 12 536) ;;
+    SD .x12 .x15 24
+  [ { label := "h_BLOBBASEFEE"
+    , opcodes := [0x4a]
+    , body := blobBaseFeeBody
+    , tail := .advanceAndRet 1 } ]
+  ++
+  [ { label := "h_BLOBHASH"
+    , opcodes := [0x49]
+    , preBody := stackUnderflowGuardAsm 1
+    , body := []
+    , tail := .custom <|
+        "  ld x14, 8(x12)\n" ++          -- high limbs must be zero
+        "  bnez x14, .Lblobhash_zero\n" ++
+        "  ld x14, 16(x12)\n" ++
+        "  bnez x14, .Lblobhash_zero\n" ++
+        "  ld x14, 24(x12)\n" ++
+        "  bnez x14, .Lblobhash_zero\n" ++
+        "  ld x14, 0(x12)\n" ++          -- x14 = low u64 index
+        "  ld x15, 544(x20)\n" ++        -- x15 = copied blob_hash_count
+        "  bgeu x14, x15, .Lblobhash_zero\n" ++
+        "  slli x14, x14, 5\n" ++        -- 32 bytes per versioned hash
+        "  la x15, evm_blob_hashes\n" ++
+        "  add x15, x15, x14\n" ++
+        "  ld x16, 0(x15)\n" ++
+        "  sd x16, 0(x12)\n" ++
+        "  ld x16, 8(x15)\n" ++
+        "  sd x16, 8(x12)\n" ++
+        "  ld x16, 16(x15)\n" ++
+        "  sd x16, 16(x12)\n" ++
+        "  ld x16, 24(x15)\n" ++
+        "  sd x16, 24(x12)\n" ++
+        "  addi x10, x10, 1\n" ++
+        "  ret\n" ++
+        ".Lblobhash_zero:\n" ++
+        "  sd x0, 0(x12)\n" ++
+        "  sd x0, 8(x12)\n" ++
+        "  sd x0, 16(x12)\n" ++
+        "  sd x0, 24(x12)\n" ++
+        "  addi x10, x10, 1\n" ++
+        "  ret" } ]
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/EvmSlotnumHandlers.lean
+++ b/EvmAsm/Codegen/Programs/EvmSlotnumHandlers.lean
@@ -1,0 +1,33 @@
+/-
+  EvmAsm.Codegen.Programs.EvmSlotnumHandlers
+
+  Dispatcher handler for EIP-7843 SLOTNUM.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Dispatch
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+/-- EIP-7843 SLOTNUM (0x4b). The runtime input trailer carries the current
+    consensus slot number as a 256-bit stack word. The dispatcher prologue
+    copies that word to `evm_env + 624`; this handler pushes it unchanged. -/
+def slotnumContextHandlers : List OpcodeHandlerSpec :=
+  let slotnumBody : Program :=
+    ADDI .x12 .x12 (-32) ;;
+    LD .x15 .x20 (BitVec.ofNat 12 624) ;;
+    SD .x12 .x15 0 ;;
+    LD .x15 .x20 (BitVec.ofNat 12 632) ;;
+    SD .x12 .x15 8 ;;
+    LD .x15 .x20 (BitVec.ofNat 12 640) ;;
+    SD .x12 .x15 16 ;;
+    LD .x15 .x20 (BitVec.ofNat 12 648) ;;
+    SD .x12 .x15 24
+  [ { label := "h_SLOTNUM"
+    , opcodes := [0x4b]
+    , body := slotnumBody
+    , tail := .advanceAndRet 1 } ]
+
+end EvmAsm.Codegen


### PR DESCRIPTION
## Summary
- move BLOBBASEFEE/BLOBHASH dispatcher handler construction into `EvmBlobContextHandlers.lean`
- keep `blobContextHandlers` exported through `Evm.lean` for the runtime dispatcher registry
- reduce `Evm.lean` from 896 to 834 lines in this stacked slice

Stacked on PR #8264. Bead: `evm-asm-fhsxz.2.4.2.60.17.18`.

## Verification
- `lake build EvmAsm.Codegen.Programs.EvmBlobContextHandlers EvmAsm.Codegen.Programs.Evm EvmAsm.Codegen.Programs`
- `lake exe codegen --program runtime_dispatcher --asm-only`
- `scripts/check-file-size.sh --report`
- `scripts/check-unimported.sh`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/Evm.lean EvmAsm/Codegen/Programs/EvmBlobContextHandlers.lean`\n- `git diff --check`\n- `lake build`\n\nFull build passes with the existing LeanRV64D `extension.toCtorIdx` deprecation warning only.\n\nAuthored by @pirapira; implemented by Codex.