### PR TITLE
refactor(codegen): split EVM mcopy handler

### DIFF
--- a/EvmAsm/Codegen/Programs/Evm.lean
+++ b/EvmAsm/Codegen/Programs/Evm.lean
@@ -57,7 +57,7 @@ import EvmAsm.Codegen.Programs.EvmSlotnumHandlers
 import EvmAsm.Codegen.Programs.EvmBlobContextHandlers
 import EvmAsm.Codegen.Programs.EvmBlockHashHandlers
 import EvmAsm.Codegen.Programs.EvmCalldataHandlers
-import EvmAsm.Codegen.Programs.EvmMcopyGas
+import EvmAsm.Codegen.Programs.EvmMcopyHandlers
 import EvmAsm.Codegen.Programs.EvmMemoryGas
 import EvmAsm.Codegen.Programs.Clz
 import EvmAsm.Codegen.Programs.EvmBalance
@@ -110,53 +110,6 @@ open EvmAsm.Rv64
     All other opcode bytes fall to `h_invalid` (emitted automatically
     by `emitDispatcherEpilogue`), which takes the same exit path as
     STOP. -/
-
-/-- EIP-5656 MCOPY for the concrete dispatcher. The handler rejects
-    unsupported 256-bit memory ranges, consumes low u64 limbs for
-    `(dest, src, length)`, charges dynamic gas, updates MSIZE for both
-    read and write ranges, then performs `memmove`-style byte copying
-    so overlapping ranges are handled correctly. -/
-def mcopyHandlers : List OpcodeHandlerSpec :=
-  [ { label   := "h_MCOPY"
-      opcodes := [0x5e]
-      preBody := stackUnderflowGuardAsm 3
-      body    := []
-      tail    := .custom <|
-        "  ld x14, 0(x12)\n" ++          -- destination offset
-        "  ld x15, 32(x12)\n" ++         -- source offset
-        "  ld x16, 64(x12)\n" ++         -- length
-        mcopyRangeGuardAsm ++
-        mcopyDynamicGasAsm ++
-        "  addi x12, x12, 96\n" ++
-        "  beqz x16, .Lmcopy_done\n" ++
-        updateActiveMemorySizeAsm "mcopy_src" "x15" "x16" "x17" "x18" "x19" "x6" false ++
-        updateActiveMemorySizeAsm "mcopy_dst" "x14" "x16" "x17" "x18" "x19" "x6" false ++
-        "  add x17, x13, x14\n" ++       -- destination pointer
-        "  add x18, x13, x15\n" ++       -- source pointer
-        "  add x19, x15, x16\n" ++       -- source end offset
-        "  bleu x14, x15, .Lmcopy_forward\n" ++
-        "  bgeu x14, x19, .Lmcopy_forward\n" ++
-        "  add x17, x17, x16\n" ++
-        "  add x18, x18, x16\n" ++
-        ".Lmcopy_backward_loop:\n" ++
-        "  beqz x16, .Lmcopy_done\n" ++
-        "  addi x17, x17, -1\n" ++
-        "  addi x18, x18, -1\n" ++
-        "  lbu x19, 0(x18)\n" ++
-        "  sb x19, 0(x17)\n" ++
-        "  addi x16, x16, -1\n" ++
-        "  j .Lmcopy_backward_loop\n" ++
-        ".Lmcopy_forward:\n" ++
-        "  beqz x16, .Lmcopy_done\n" ++
-        "  lbu x19, 0(x18)\n" ++
-        "  sb x19, 0(x17)\n" ++
-        "  addi x18, x18, 1\n" ++
-        "  addi x17, x17, 1\n" ++
-        "  addi x16, x16, -1\n" ++
-        "  j .Lmcopy_forward\n" ++
-        ".Lmcopy_done:\n" ++
-        "  addi x10, x10, 1\n" ++
-        "  ret" } ]
 
 /-- Scanner shared by JUMP / taken-JUMPI validation: require `code[dest]`
     to be JUMPDEST, then scan from `x21` to `x10`, skipping PUSH data. -/

--- a/EvmAsm/Codegen/Programs/EvmMcopyHandlers.lean
+++ b/EvmAsm/Codegen/Programs/EvmMcopyHandlers.lean
@@ -1,0 +1,60 @@
+/-
+  EvmAsm.Codegen.Programs.EvmMcopyHandlers
+
+  Dispatcher handler for MCOPY.
+-/
+
+import EvmAsm.Codegen.Dispatch
+import EvmAsm.Codegen.Programs.EvmMcopyGas
+import EvmAsm.Codegen.Programs.EvmMemoryGas
+
+namespace EvmAsm.Codegen
+
+/-- EIP-5656 MCOPY for the concrete dispatcher. The handler rejects
+    unsupported 256-bit memory ranges, consumes low u64 limbs for
+    `(dest, src, length)`, charges dynamic gas, updates MSIZE for both
+    read and write ranges, then performs `memmove`-style byte copying
+    so overlapping ranges are handled correctly. -/
+def mcopyHandlers : List OpcodeHandlerSpec :=
+  [ { label   := "h_MCOPY"
+      opcodes := [0x5e]
+      preBody := stackUnderflowGuardAsm 3
+      body    := []
+      tail    := .custom <|
+        "  ld x14, 0(x12)\n" ++          -- destination offset
+        "  ld x15, 32(x12)\n" ++         -- source offset
+        "  ld x16, 64(x12)\n" ++         -- length
+        mcopyRangeGuardAsm ++
+        mcopyDynamicGasAsm ++
+        "  addi x12, x12, 96\n" ++
+        "  beqz x16, .Lmcopy_done\n" ++
+        updateActiveMemorySizeAsm "mcopy_src" "x15" "x16" "x17" "x18" "x19" "x6" false ++
+        updateActiveMemorySizeAsm "mcopy_dst" "x14" "x16" "x17" "x18" "x19" "x6" false ++
+        "  add x17, x13, x14\n" ++       -- destination pointer
+        "  add x18, x13, x15\n" ++       -- source pointer
+        "  add x19, x15, x16\n" ++       -- source end offset
+        "  bleu x14, x15, .Lmcopy_forward\n" ++
+        "  bgeu x14, x19, .Lmcopy_forward\n" ++
+        "  add x17, x17, x16\n" ++
+        "  add x18, x18, x16\n" ++
+        ".Lmcopy_backward_loop:\n" ++
+        "  beqz x16, .Lmcopy_done\n" ++
+        "  addi x17, x17, -1\n" ++
+        "  addi x18, x18, -1\n" ++
+        "  lbu x19, 0(x18)\n" ++
+        "  sb x19, 0(x17)\n" ++
+        "  addi x16, x16, -1\n" ++
+        "  j .Lmcopy_backward_loop\n" ++
+        ".Lmcopy_forward:\n" ++
+        "  beqz x16, .Lmcopy_done\n" ++
+        "  lbu x19, 0(x18)\n" ++
+        "  sb x19, 0(x17)\n" ++
+        "  addi x18, x18, 1\n" ++
+        "  addi x17, x17, 1\n" ++
+        "  addi x16, x16, -1\n" ++
+        "  j .Lmcopy_forward\n" ++
+        ".Lmcopy_done:\n" ++
+        "  addi x10, x10, 1\n" ++
+        "  ret" } ]
+
+end EvmAsm.Codegen


### PR DESCRIPTION
## Summary
- move MCOPY dispatcher handler construction into `EvmMcopyHandlers.lean`
- keep `mcopyHandlers` exported through `Evm.lean` for the runtime dispatcher registry
- reduce `Evm.lean` from 712 to 665 lines in this stacked slice

Stacked on PR #8267. Bead: `evm-asm-fhsxz.2.4.2.60.17.21`.

## Verification
- `lake build EvmAsm.Codegen.Programs.EvmMcopyHandlers EvmAsm.Codegen.Programs.Evm EvmAsm.Codegen.Programs`
- `lake exe codegen --program runtime_dispatcher --asm-only`
- `scripts/check-file-size.sh --report`
- `scripts/check-unimported.sh`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/Evm.lean EvmAsm/Codegen/Programs/EvmMcopyHandlers.lean`\n- `git diff --check`\n- `lake build`\n\nFull build passes with the existing LeanRV64D `extension.toCtorIdx` deprecation warning only.\n\nAuthored by @pirapira; implemented by Codex.