### PR TITLE
feat(gas): prepare block verdict gas result arena

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictGasResults.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictGasResults.lean
@@ -6,7 +6,10 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.Account
 import EvmAsm.Codegen.Programs.BalGasValid
+import EvmAsm.Codegen.Programs.BlockGasRemaining
+import EvmAsm.Codegen.Programs.BlockVerdictReceiptRecords
 import EvmAsm.Codegen.Programs.TxExtract
 
 namespace EvmAsm.Codegen
@@ -132,6 +135,110 @@ def blockVerdictTxGasLimitsFunction : String :=
   "  addi sp, sp, 112\n" ++
   "  ret"
 
+/-! ## block_verdict_gas_result_arena_prepare
+
+    Populate the block-verdict runtime gas-result arena.
+
+    ABI:
+      a0 = execution payload ptr
+      a1 = runtime `gas_left` u64 array
+      a2 = runtime `refund_counter` u64 array
+      a3 = runtime `calldata_floor_gas_cost` u64 array
+      a4 = runtime result count
+      a5 = arena capacity
+
+    Returns:
+      a0 = status:
+        0 ok
+        1 tx gas-limit materialization failed
+        2 runtime count does not match transaction count
+        3 missing runtime array pointer for a non-empty transaction list
+        4 invalid runtime gas result (`gas_left > tx.gas`)
+      a1 = transaction count
+      a2 = failing transaction index, 1-based; 0 if not transaction-specific
+      a3 = substatus from the failing helper when available
+
+    On success the following aligned arrays are populated for the later verdict
+    gate:
+      bvgr_tx_gas_limits, bvgr_gas_left, bvgr_refund_counter,
+      bvgr_calldata_floor, bvgr_block_gas_increments,
+      bvgr_receipt_gas_increments. -/
+def blockVerdictGasResultArenaPrepareFunction : String :=
+  "block_verdict_gas_result_arena_prepare:\n" ++
+  "  addi sp, sp, -112\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp); sd s10, 88(sp); sd s11, 96(sp)\n" ++
+  "  mv s0, a0                   # execution payload\n" ++
+  "  mv s1, a1                   # runtime gas_left ptr\n" ++
+  "  mv s2, a2                   # runtime refund_counter ptr\n" ++
+  "  mv s3, a3                   # runtime calldata_floor ptr\n" ++
+  "  mv s4, a4                   # runtime count\n" ++
+  "  mv s5, a5                   # arena capacity\n" ++
+  "  la t0, bvgr_arena_status; sd zero, 0(t0)\n" ++
+  "  la t0, bvgr_arena_tx_count; sd zero, 0(t0)\n" ++
+  "  la t0, bvgr_arena_runtime_count; sd s4, 0(t0)\n" ++
+  "  la t0, bvgr_arena_fail_index; sd zero, 0(t0)\n" ++
+  "  la t0, bvgr_arena_substatus; sd zero, 0(t0)\n" ++
+  "  la a1, bvgr_tx_gas_limits\n" ++
+  "  mv a2, s5\n" ++
+  "  mv a0, s0\n" ++
+  "  jal ra, block_verdict_tx_gas_limits\n" ++
+  "  bnez a0, .Lbvgr_arena_tx_fail\n" ++
+  "  mv s6, a1                   # transaction count\n" ++
+  "  la t0, bvgr_arena_tx_count; sd s6, 0(t0)\n" ++
+  "  bne s4, s6, .Lbvgr_arena_count_mismatch\n" ++
+  "  beqz s6, .Lbvgr_arena_ok\n" ++
+  "  beqz s1, .Lbvgr_arena_missing_runtime\n" ++
+  "  beqz s2, .Lbvgr_arena_missing_runtime\n" ++
+  "  beqz s3, .Lbvgr_arena_missing_runtime\n" ++
+  "  mv s7, zero                 # index\n" ++
+  ".Lbvgr_arena_loop:\n" ++
+  "  beq s7, s6, .Lbvgr_arena_ok\n" ++
+  "  slli t0, s7, 3\n" ++
+  "  la t1, bvgr_tx_gas_limits; add t1, t1, t0; ld s8, 0(t1)\n" ++
+  "  add t1, s1, t0; ld s9, 0(t1)\n" ++
+  "  add t1, s2, t0; ld s10, 0(t1)\n" ++
+  "  add t1, s3, t0; ld s11, 0(t1)\n" ++
+  "  la t1, bvgr_gas_left; add t1, t1, t0; sd s9, 0(t1)\n" ++
+  "  la t1, bvgr_refund_counter; add t1, t1, t0; sd s10, 0(t1)\n" ++
+  "  la t1, bvgr_calldata_floor; add t1, t1, t0; sd s11, 0(t1)\n" ++
+  "  mv a0, s8; mv a1, s9; mv a2, s10; mv a3, s11\n" ++
+  "  jal ra, tx_gas_result_increments\n" ++
+  "  bnez a0, .Lbvgr_arena_bad_result\n" ++
+  "  slli t0, s7, 3\n" ++
+  "  la t1, bvgr_block_gas_increments; add t1, t1, t0; sd a1, 0(t1)\n" ++
+  "  la t1, bvgr_receipt_gas_increments; add t1, t1, t0; sd a2, 0(t1)\n" ++
+  "  la t1, bvgr_before_refund; add t1, t1, t0; sd a3, 0(t1)\n" ++
+  "  la t1, bvgr_applied_refund; add t1, t1, t0; sd a4, 0(t1)\n" ++
+  "  addi s7, s7, 1\n" ++
+  "  j .Lbvgr_arena_loop\n" ++
+  ".Lbvgr_arena_ok:\n" ++
+  "  li a0, 0; mv a1, s6; li a2, 0; li a3, 0; j .Lbvgr_arena_store_ret\n" ++
+  ".Lbvgr_arena_tx_fail:\n" ++
+  "  mv t0, a0; mv t1, a1; mv t2, a2\n" ++
+  "  li a0, 1; mv a1, t1; mv a2, t2; mv a3, t0; j .Lbvgr_arena_store_ret\n" ++
+  ".Lbvgr_arena_count_mismatch:\n" ++
+  "  li a0, 2; mv a1, s6; li a2, 0; mv a3, s4; j .Lbvgr_arena_store_ret\n" ++
+  ".Lbvgr_arena_missing_runtime:\n" ++
+  "  li a0, 3; mv a1, s6; li a2, 0; li a3, 0; j .Lbvgr_arena_store_ret\n" ++
+  ".Lbvgr_arena_bad_result:\n" ++
+  "  mv t0, a0\n" ++
+  "  li a0, 4; mv a1, s6; addi a2, s7, 1; mv a3, t0\n" ++
+  ".Lbvgr_arena_store_ret:\n" ++
+  "  la t0, bvgr_arena_status; sd a0, 0(t0)\n" ++
+  "  la t0, bvgr_arena_tx_count; sd a1, 0(t0)\n" ++
+  "  la t0, bvgr_arena_fail_index; sd a2, 0(t0)\n" ++
+  "  la t0, bvgr_arena_substatus; sd a3, 0(t0)\n" ++
+  ".Lbvgr_arena_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp); ld s11, 96(sp)\n" ++
+  "  addi sp, sp, 112\n" ++
+  "  ret"
+
 /-- `zisk_block_verdict_tx_gas_limits`: focused probe for materializing
     transaction gas limits from an execution payload.
 
@@ -180,6 +287,111 @@ def ziskBlockVerdictTxGasLimitsProbeUnit : BuildUnit := {
   body        := NOP
   prologueAsm := ziskBlockVerdictTxGasLimitsPrologue
   dataAsm     := ziskBlockVerdictTxGasLimitsDataSection
+}
+
+/-- `zisk_block_verdict_gas_result_arena`: focused probe for the runtime
+    gas-result arena ABI. Input places the execution payload at `INPUT_ADDR+8`
+    and runtime result arrays at `INPUT_ADDR+0x1008`:
+      +0   count
+      +8   gas_left[16]
+      +136 refund_counter[16]
+      +264 calldata_floor_gas_cost[16]
+      +392 block_gas_limit
+
+    Output:
+      +0  arena status
+      +8  tx count
+      +16 runtime count
+      +24 fail index
+      +32 substatus
+      +40 first tx gas
+      +48 first block increment
+      +56 first receipt increment
+      +64 EIP-7778 status
+      +72 EIP-7778 failing index
+      +80 EIP-7778 used/final-used value
+      +88 receipt materializer status
+      +96 receipt record count -/
+def ziskBlockVerdictGasResultArenaPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li s0, 0x40001008\n" ++
+  "  li a0, 0x40000008\n" ++
+  "  addi a1, s0, 8\n" ++
+  "  addi a2, s0, 136\n" ++
+  "  addi a3, s0, 264\n" ++
+  "  ld a4, 0(s0)\n" ++
+  "  li a5, 16\n" ++
+  "  jal ra, block_verdict_gas_result_arena_prepare\n" ++
+  "  li s1, 0xa0010000\n" ++
+  "  sd a0, 0(s1); sd a1, 8(s1)\n" ++
+  "  la t0, bvgr_arena_runtime_count; ld t1, 0(t0); sd t1, 16(s1)\n" ++
+  "  sd a2, 24(s1); sd a3, 32(s1)\n" ++
+  "  la t0, bvgr_tx_gas_limits; ld t1, 0(t0); sd t1, 40(s1)\n" ++
+  "  la t0, bvgr_block_gas_increments; ld t1, 0(t0); sd t1, 48(s1)\n" ++
+  "  la t0, bvgr_receipt_gas_increments; ld t1, 0(t0); sd t1, 56(s1)\n" ++
+  "  bnez a0, .Lbvgr_arena_probe_skip_consumers\n" ++
+  "  ld a0, 392(s0)              # block_gas_limit\n" ++
+  "  la a1, bvgr_tx_gas_limits\n" ++
+  "  la a2, bvgr_gas_left\n" ++
+  "  la a3, bvgr_refund_counter\n" ++
+  "  la a4, bvgr_calldata_floor\n" ++
+  "  la t0, bvgr_arena_tx_count; ld a5, 0(t0)\n" ++
+  "  la a6, bvgr_block_gas_increments\n" ++
+  "  jal ra, eip7778_remaining_block_gas_from_results\n" ++
+  "  sd a0, 64(s1); sd a1, 72(s1); sd a2, 80(s1)\n" ++
+  "  li a0, 0x40000008\n" ++
+  "  la a1, bvgr_receipt_gas_increments\n" ++
+  "  la t0, bvgr_arena_tx_count; ld a2, 0(t0)\n" ++
+  "  jal ra, block_receipt_records_materialize\n" ++
+  "  la t0, brr_status; ld t1, 0(t0); sd t1, 88(s1)\n" ++
+  "  la t0, brr_control; ld t1, 0(t0); sd t1, 96(s1)\n" ++
+  "  j .Lbvgr_arena_probe_done\n" ++
+  ".Lbvgr_arena_probe_skip_consumers:\n" ++
+  "  li t0, 255; sd t0, 64(s1); sd t0, 88(s1)\n" ++
+  "  j .Lbvgr_arena_probe_done\n" ++
+  bgvU32leFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  txTypeDispatchFunction ++ "\n" ++
+  txExtractNonceAndGasFunction ++ "\n" ++
+  txGasResultIncrementsFunction ++ "\n" ++
+  eip7778RemainingBlockGasCheckFunction ++ "\n" ++
+  eip7778RemainingBlockGasFromResultsFunction ++ "\n" ++
+  receiptRecordsFunction ++ "\n" ++
+  blockReceiptRecordsMaterializeFunction ++ "\n" ++
+  blockVerdictTxGasLimitsFunction ++ "\n" ++
+  blockVerdictGasResultArenaPrepareFunction ++ "\n" ++
+  ".Lbvgr_arena_probe_done:"
+
+def ziskBlockVerdictGasResultArenaDataSection : String :=
+  ziskBlockVerdictTxGasLimitsDataSection ++
+  "bvgr_arena_status:\n  .zero 8\n" ++
+  "bvgr_arena_tx_count:\n  .zero 8\n" ++
+  "bvgr_arena_runtime_count:\n  .zero 8\n" ++
+  "bvgr_arena_fail_index:\n  .zero 8\n" ++
+  "bvgr_arena_substatus:\n  .zero 8\n" ++
+  "bvgr_gas_left:\n  .zero 128\n" ++
+  "bvgr_refund_counter:\n  .zero 128\n" ++
+  "bvgr_calldata_floor:\n  .zero 128\n" ++
+  "bvgr_block_gas_increments:\n  .zero 128\n" ++
+  "bvgr_receipt_gas_increments:\n  .zero 128\n" ++
+  "bvgr_before_refund:\n  .zero 128\n" ++
+  "bvgr_applied_refund:\n  .zero 128\n" ++
+  "brr_status:\n  .zero 8\n" ++
+  "brr_append_status:\n  .zero 8\n" ++
+  "brr_tx_type:\n  .zero 8\n" ++
+  "brr_tx_inner:\n  .zero 8\n" ++
+  "brr_tx_gas:\n  .zero 8\n" ++
+  "brr_receipt_gas_ptr:\n  .zero 8\n" ++
+  "brr_receipt_gas_count:\n  .zero 8\n" ++
+  "brr_control:\n  .zero 24\n" ++
+  ".balign 8\n" ++
+  "brr_records:\n  .zero 1024\n"
+
+def ziskBlockVerdictGasResultArenaProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockVerdictGasResultArenaPrologue
+  dataAsm     := ziskBlockVerdictGasResultArenaDataSection
 }
 
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/RegistryNamesTail.lean
+++ b/EvmAsm/Codegen/Programs/RegistryNamesTail.lean
@@ -13,6 +13,7 @@ def knownProgramNamesTail : List String :=
    "zisk_typed_receipt_encode",
    "zisk_receipt_records_probe",
    "zisk_block_verdict_tx_gas_limits",
+   "zisk_block_verdict_gas_result_arena",
    "zisk_single_leaf_trie_root",
    "zisk_system_write_descriptors",
    "zisk_bal_gas_valid",

--- a/EvmAsm/Codegen/Programs/RegistryTail.lean
+++ b/EvmAsm/Codegen/Programs/RegistryTail.lean
@@ -286,7 +286,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_rlp_encode_u64" => some ziskRlpEncodeU64ProbeUnit
   | "zisk_receipt_encode" => some ziskReceiptEncodeProbeUnit
   | "zisk_typed_receipt_encode" => some ziskTypedReceiptEncodeProbeUnit
-  | "zisk_receipt_records_probe" => some ziskReceiptRecordsProbeUnit | "zisk_block_receipt_records_materialize" => some ziskBlockReceiptRecordsMaterializeProbeUnit | "zisk_block_verdict_tx_gas_limits" => some ziskBlockVerdictTxGasLimitsProbeUnit | "zisk_eip7778_remaining_block_gas_check" => some ziskEip7778RemainingBlockGasCheckProbeUnit
+  | "zisk_receipt_records_probe" => some ziskReceiptRecordsProbeUnit | "zisk_block_receipt_records_materialize" => some ziskBlockReceiptRecordsMaterializeProbeUnit | "zisk_block_verdict_tx_gas_limits" => some ziskBlockVerdictTxGasLimitsProbeUnit | "zisk_block_verdict_gas_result_arena" => some ziskBlockVerdictGasResultArenaProbeUnit | "zisk_eip7778_remaining_block_gas_check" => some ziskEip7778RemainingBlockGasCheckProbeUnit
   | "zisk_single_leaf_trie_root" => some ziskSingleLeafTrieRootProbeUnit
   | "zisk_system_write_descriptors" => some ziskSystemWriteDescriptorsProbeUnit
   | "zisk_bal_gas_valid"         => some ziskBalGasValidProbeUnit | "zisk_storage_access_gas" => some ziskStorageAccessGasProbeUnit

--- a/scripts/codegen-zisk-block-verdict-gas-result-arena-check.sh
+++ b/scripts/codegen-zisk-block-verdict-gas-result-arena-check.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-verdict-gas-result-arena-check.sh -- block verdict runtime gas-result arena probe.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_verdict_gas_result_arena ELF"
+lake exe codegen --program zisk_block_verdict_gas_result_arena --halt linux93 \
+  -o gen-out/zisk_block_verdict_gas_result_arena
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <mode> <expected_csv>
+run_case() {
+  local name="$1" mode="$2" expected_csv="$3"
+  local in_file="$REPO_ROOT/gen-out/zisk_block_verdict_gas_result_arena_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_verdict_gas_result_arena_${name}.output"
+  local expected_file="$REPO_ROOT/gen-out/zisk_block_verdict_gas_result_arena_${name}.expected"
+
+  python3 - "$in_file" "$expected_file" "$mode" "$expected_csv" <<'PY'
+import struct
+import sys
+
+in_path, expected_path, mode, expected_csv = sys.argv[1:]
+
+def be(n: int) -> bytes:
+    if n == 0:
+        return b""
+    out = bytearray()
+    while n:
+        out.append(n & 0xff)
+        n >>= 8
+    return bytes(reversed(out))
+
+def rlp_bytes(data: bytes) -> bytes:
+    if len(data) == 1 and data[0] < 0x80:
+        return data
+    if len(data) <= 55:
+        return bytes([0x80 + len(data)]) + data
+    lb = be(len(data))
+    return bytes([0xb7 + len(lb)]) + lb + data
+
+def rlp_uint(n: int) -> bytes:
+    return rlp_bytes(be(n))
+
+def rlp_list(items: list[bytes]) -> bytes:
+    payload = b"".join(items)
+    if len(payload) <= 55:
+        return bytes([0xc0 + len(payload)]) + payload
+    lb = be(len(payload))
+    return bytes([0xf7 + len(lb)]) + lb + payload
+
+def legacy_tx(nonce: int, gas: int) -> bytes:
+    return rlp_list([
+        rlp_uint(nonce),
+        rlp_uint(1),
+        rlp_uint(gas),
+        rlp_bytes(bytes.fromhex("1111111111111111111111111111111111111111")),
+        rlp_uint(0),
+        rlp_bytes(b""),
+        rlp_uint(27),
+        rlp_uint(1),
+        rlp_uint(1),
+    ])
+
+def typed_2930_tx(nonce: int, gas: int) -> bytes:
+    return b"\x01" + rlp_list([
+        rlp_uint(1),
+        rlp_uint(nonce),
+        rlp_uint(1),
+        rlp_uint(gas),
+        rlp_bytes(bytes.fromhex("2222222222222222222222222222222222222222")),
+        rlp_uint(0),
+        rlp_bytes(b""),
+        rlp_list([]),
+        rlp_uint(1),
+        rlp_uint(1),
+        rlp_uint(1),
+    ])
+
+def tx_list(txs: list[bytes]) -> bytes:
+    if not txs:
+        return b""
+    first = 4 * len(txs)
+    offsets = []
+    cur = first
+    for tx in txs:
+        offsets.append(cur)
+        cur += len(tx)
+    return b"".join(struct.pack("<I", x) for x in offsets) + b"".join(txs)
+
+payload = bytearray(640)
+tx_off = 600
+count = 0
+gas_left = [0] * 16
+refunds = [0] * 16
+floors = [0] * 16
+block_gas_limit = 0
+
+if mode == "empty":
+    txs = b""
+    count = 0
+    block_gas_limit = 100000
+elif mode == "one_legacy":
+    txs = tx_list([legacy_tx(0, 21000)])
+    count = 1
+    gas_left[0] = 0
+    floors[0] = 21000
+    block_gas_limit = 30000
+elif mode == "two_overflow":
+    txs = tx_list([legacy_tx(0, 21000), legacy_tx(1, 50000)])
+    count = 2
+    gas_left[0] = 0
+    gas_left[1] = 0
+    floors[0] = 21000
+    floors[1] = 21000
+    block_gas_limit = 70000
+elif mode == "bad_remaining":
+    txs = tx_list([legacy_tx(0, 21000)])
+    count = 1
+    gas_left[0] = 22000
+    floors[0] = 21000
+    block_gas_limit = 30000
+elif mode == "count_mismatch":
+    txs = tx_list([legacy_tx(0, 21000), legacy_tx(1, 50000)])
+    count = 1
+    gas_left[0] = 0
+    floors[0] = 21000
+    block_gas_limit = 100000
+elif mode == "typed_2930":
+    txs = tx_list([typed_2930_tx(0, 62000)])
+    count = 1
+    gas_left[0] = 1000
+    floors[0] = 21000
+    block_gas_limit = 100000
+else:
+    raise SystemExit(f"unknown mode: {mode}")
+
+wd_off = tx_off + len(txs)
+payload[504:508] = struct.pack("<I", tx_off)
+payload[508:512] = struct.pack("<I", wd_off)
+payload[tx_off:tx_off + len(txs)] = txs
+
+image = bytearray(0x1400)
+image[:len(payload)] = payload
+base = 0x1000
+struct.pack_into("<Q", image, base, count)
+for i, value in enumerate(gas_left):
+    struct.pack_into("<Q", image, base + 8 + 8 * i, value)
+for i, value in enumerate(refunds):
+    struct.pack_into("<Q", image, base + 136 + 8 * i, value)
+for i, value in enumerate(floors):
+    struct.pack_into("<Q", image, base + 264 + 8 * i, value)
+struct.pack_into("<Q", image, base + 392, block_gas_limit)
+
+with open(in_path, "wb") as f:
+    f.write(image)
+
+expected = [int(x, 0) for x in expected_csv.split(",")]
+with open(expected_path, "wb") as f:
+    for value in expected:
+        f.write(struct.pack("<Q", value))
+PY
+
+  "$ZISKEMU" -e gen-out/zisk_block_verdict_gas_result_arena.elf \
+    -i "$in_file" -o "$out_file" \
+    >"$REPO_ROOT/gen-out/zisk_block_verdict_gas_result_arena_${name}.emu.log" 2>&1 || true
+
+  if ! cmp -n "$(wc -c <"$expected_file")" -s "$expected_file" "$out_file"; then
+    echo "FAIL $name" >&2
+    echo "expected:" >&2
+    od -An -tu8 "$expected_file" >&2
+    echo "actual:" >&2
+    od -An -tu8 -N "$(wc -c <"$expected_file")" "$out_file" >&2 || true
+    echo "emu log:" >&2
+    tail -80 "$REPO_ROOT/gen-out/zisk_block_verdict_gas_result_arena_${name}.emu.log" >&2
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "empty"         "empty"         "0,0,0,0,0,0,0,0,0,0,0,0,0" || FAILED=1
+run_case "one_legacy"    "one_legacy"    "0,1,1,0,0,21000,21000,21000,0,0,21000,0,1" || FAILED=1
+run_case "two_overflow"  "two_overflow"  "0,2,2,0,0,21000,21000,21000,1,2,21000,0,2" || FAILED=1
+run_case "bad_remaining" "bad_remaining" "4,1,1,1,1,21000,0,0,255,0,0,255,0" || FAILED=1
+run_case "count_mismatch" "count_mismatch" "2,2,1,0,1,21000,0,0,255,0,0,255,0" || FAILED=1
+run_case "typed_2930"    "typed_2930"    "0,1,1,0,0,62000,61000,61000,0,0,61000,1,0" || FAILED=1
+
+if [[ "$FAILED" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "==> PASS: block_verdict_gas_result_arena prepares runtime gas-result arrays"


### PR DESCRIPTION
## Summary
- add `block_verdict_gas_result_arena_prepare` to copy runtime gas result arrays into aligned block-verdict arenas
- derive block-gas and receipt-gas increments with `tx_gas_result_increments`
- add a focused ziskemu probe that feeds the arena into the EIP-7778 from-results adapter and receipt materializer

## Verification
- `lake build EvmAsm.Codegen.Programs.BlockVerdictGasResults`
- `scripts/codegen-zisk-block-verdict-gas-result-arena-check.sh`
- `scripts/codegen-zisk-block-verdict-tx-gas-limits-check.sh`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- `lake build` (passes with existing LeanRV64D deprecation warning)

Note: an initial parallel run of the two zisk scripts raced on `lake build codegen` and one clang invocation crashed while the other completed. Rerunning the tx-gas-limit script serially passed.

Stacked on PR #8325. Bead: evm-asm-fhsxz.2.4.2.59.19.2.4.3

Authored by @pirapira; implemented by Codex.