### PR TITLE
fix(gas): skip zero-value tx post-balance gate

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -657,6 +657,11 @@ def blockVerdictFunction : String :=
   "  la a0, bv_simple_transfer_tx\n" ++
   "  jal ra, simple_transfer_tx_context\n" ++
   "  la t2, bv_simple_transfer_tx; ld t0, 0(t2); bnez t0, .Lbv_after_tx_gas_precharge\n" ++
+  "  ld t0,  96(t2); bnez t0, .Lbv_tx_gas_precharge_nonzero_value\n" ++
+  "  ld t0, 104(t2); bnez t0, .Lbv_tx_gas_precharge_nonzero_value\n" ++
+  "  ld t0, 112(t2); bnez t0, .Lbv_tx_gas_precharge_nonzero_value\n" ++
+  "  ld t0, 120(t2); beqz t0, .Lbv_after_tx_gas_precharge\n" ++
+  ".Lbv_tx_gas_precharge_nonzero_value:\n" ++
   "  ld a0, 8(t2); ld a1, 16(t2); ld a3, 24(t2); ld a2, 32(t2)\n" ++
   "  la t2, bv_bal_start; ld a4, 0(t2)\n" ++
   "  la t2, bv_bal_len; ld a5, 0(t2)\n" ++


### PR DESCRIPTION
## Summary
- skip the simple-transfer sender post-balance verifier for zero-value one-transaction calls
- keep the existing tx_gas_bal_post_verify path for nonzero value-transfer transactions
- fixes the observed CLZ/JUMP false reject class where state root matched but successful_validation failed at bv_fail=17

Refs EEST CLZ/JUMP false reject. Bead: evm-asm-fhsxz.2.4.2.57.18.8.

## Verification
- scripts/codegen-stateless-link-check.sh --no-build
- lake build EvmAsm.Codegen.Programs.BlockVerdict codegen
- EEST_EIP7939_CLZ_JUMP_LIMIT=1 EEST_EIP7939_CLZ_JUMP_MIN_FULL=1 EEST_EIP7939_CLZ_JUMP_JOBS=1 EEST_EIP7939_CLZ_JUMP_RUN_DIR=gen-out/eest-eip7939-clz-jump-fix scripts/codegen-eest-eip7939-clz-jump-check.sh
- EEST_EIP7939_CLZ_JUMP_LIMIT=3 EEST_EIP7939_CLZ_JUMP_MIN_FULL=3 EEST_EIP7939_CLZ_JUMP_JOBS=3 EEST_EIP7939_CLZ_JUMP_RUN_DIR=gen-out/eest-eip7939-clz-jump-fix-3 scripts/codegen-eest-eip7939-clz-jump-check.sh
- scripts/codegen-zisk-tx-upfront-precharge-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/BlockVerdict.lean
- git diff --check
- lake build

## Notes
- The focused CLZ/JUMP run improved from root-match/success-mismatch at bv_fail=17 to 3/3 full matches.
- scripts/codegen-zisk-tx-gas-bal-post-verify-check.sh still fails its pre-existing success cases with status 39; this patch does not edit that helper, and the remaining issue belongs to the broader tx-gas post-balance verifier work.

Authored by @pirapira; implemented by Codex