### PR TITLE
fix(eest): compute transaction root in block verdict

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -22,6 +22,7 @@ import EvmAsm.Codegen.Programs.BalModeledSystem
 import EvmAsm.Codegen.Programs.MptInsertAcc
 import EvmAsm.Codegen.Programs.MptDeleteAcc
 import EvmAsm.Codegen.Programs.MptStateRootIns
+import EvmAsm.Codegen.Programs.MptIndexedTrieRoot
 import EvmAsm.Codegen.Programs.HeadersKeccak
 import EvmAsm.Codegen.Programs.StateCompose
 import EvmAsm.Codegen.Programs.AccountFieldGetters
@@ -302,6 +303,7 @@ def blockVerdictFunction : String :=
   "  la t0, bv_fail_code; sd zero, 0(t0)\n" ++
   "  la t0, bv_header_status; sd zero, 0(t0)\n" ++
   "  la t0, bv_state_status; sd zero, 0(t0)\n" ++
+  "  la t0, bv_tx_root_status; sd zero, 0(t0)\n" ++
   "  ld a0, 0(s0); ld a1, 32(s0); ld a2, 40(s0); ld a3, 48(s0); ld a4, 56(s0)\n" ++
   "  la a5, sv_this_rlp; la a6, sv_this_rlp_len\n" ++
   "  jal ra, block_header_ssz_to_rlp\n" ++
@@ -679,6 +681,47 @@ def statelessVerdictV2Function : String :=
   "  sd s4, 0(s3); la t0, svf_wd_len; ld t1, 0(t0); sd t1, 8(s3)\n" ++
   "  addi s2, s2, 44; addi s4, s4, 72; addi s3, s3, 16; addi s5, s5, 1; j .Lv2_wl\n" ++
   ".Lv2_wd:\n" ++
+  "  la t0, svf_payload; ld t0, 0(t0)\n" ++
+  "  addi a0, t0, 504; jal ra, bgv_u32le; mv s3, a0     # transactions offset\n" ++
+  "  la t0, svf_payload; ld t0, 0(t0)\n" ++
+  "  addi a0, t0, 508; jal ra, bgv_u32le; mv s4, a0     # withdrawals offset\n" ++
+  "  la t0, svf_payload; ld t0, 0(t0); add s2, t0, s3   # tx list ptr\n" ++
+  "  sub s1, s4, s3                                      # tx list len\n" ++
+  "  la t0, svf_tx_count; sd zero, 0(t0)\n" ++
+  "  beqz s1, .Lv2_tx_desc_done\n" ++
+  "  li t0, 4; bltu s1, t0, .Lv2_tx_root_fail\n" ++
+  "  mv a0, s2; jal ra, bgv_u32le                       # first offset = 4 * tx_count\n" ++
+  "  andi t0, a0, 3; bnez t0, .Lv2_tx_root_fail\n" ++
+  "  beqz a0, .Lv2_tx_root_fail\n" ++
+  "  bgtu a0, s1, .Lv2_tx_root_fail\n" ++
+  "  srli s4, a0, 2\n" ++
+  "  li t0, 129; bgeu s4, t0, .Lv2_tx_root_fail\n" ++
+  "  la t0, svf_tx_count; sd s4, 0(t0)\n" ++
+  "  li s5, 0\n" ++
+  "  la s3, svf_tx_descriptors\n" ++
+  ".Lv2_tx_desc_loop:\n" ++
+  "  beq s5, s4, .Lv2_tx_desc_done\n" ++
+  "  slli t0, s5, 2; add a0, s2, t0; jal ra, bgv_u32le  # offset[i]\n" ++
+  "  mv t6, a0\n" ++
+  "  addi t0, s5, 1\n" ++
+  "  beq t0, s4, .Lv2_tx_desc_last\n" ++
+  "  slli t0, t0, 2; add a0, s2, t0; jal ra, bgv_u32le  # offset[i+1]\n" ++
+  "  j .Lv2_tx_desc_have_end\n" ++
+  ".Lv2_tx_desc_last:\n" ++
+  "  mv a0, s1\n" ++
+  ".Lv2_tx_desc_have_end:\n" ++
+  "  bltu a0, t6, .Lv2_tx_root_fail\n" ++
+  "  bgtu a0, s1, .Lv2_tx_root_fail\n" ++
+  "  add t2, s2, t6; sub t3, a0, t6\n" ++
+  "  slli t4, s5, 4; add t5, s3, t4\n" ++
+  "  sd t2, 0(t5); sd t3, 8(t5)\n" ++
+  "  addi s5, s5, 1\n" ++
+  "  j .Lv2_tx_desc_loop\n" ++
+  ".Lv2_tx_desc_done:\n" ++
+  "  la a0, svf_tx_descriptors; la t0, svf_tx_count; ld a1, 0(t0); la a2, svf_tx_root\n" ++
+  "  jal ra, mpt_indexed_trie_root_small\n" ++
+  "  la t0, bv_tx_root_status; sd a0, 0(t0)\n" ++
+  "  bnez a0, .Lv2_tx_root_fail\n" ++
   "  addi a0, s0, 56; jal ra, bgv_u32le; mv s3, a0     # execution_requests offset\n" ++
   "  addi a0, s0, 4;  jal ra, bgv_u32le; mv s4, a0     # witness offset = NPR end\n" ++
   "  addi a0, s0, 16; add a0, a0, s3                   # er section start\n" ++
@@ -691,7 +734,7 @@ def statelessVerdictV2Function : String :=
   "  la t0, svf_parent_rlp;     ld t0, 0(t0); sd t0, 8(t1)\n" ++
   "  la t0, svf_parent_rlp_len; ld t0, 0(t0); sd t0, 16(t1)\n" ++
   "  la t0, svf_parent_sr;      sd t0, 24(t1)\n" ++
-  "  la t0, svf_zero32;         sd t0, 32(t1)\n" ++
+  "  la t0, svf_tx_root;        sd t0, 32(t1)\n" ++
   "  la t0, svf_zero32;         sd t0, 40(t1)\n" ++
   "  addi t0, s0, 24;           sd t0, 48(t1)\n" ++
   "  la t0, erh_requests_hash;  sd t0, 56(t1)\n" ++
@@ -719,6 +762,9 @@ def statelessVerdictV2Function : String :=
   "  j .Lv2_zero\n" ++
   ".Lv2_requests_hash_fail:\n" ++
   "  li t0, 24; la t1, bv_fail_code; sd t0, 0(t1)\n" ++
+  "  j .Lv2_zero\n" ++
+  ".Lv2_tx_root_fail:\n" ++
+  "  li t0, 32; la t1, bv_fail_code; sd t0, 0(t1)\n" ++
   "  j .Lv2_zero\n" ++
   ".Lv2_chain_config_fail:\n" ++
   "  li t0, 26; la t1, bv_fail_code; sd t0, 0(t1)\n" ++
@@ -785,6 +831,8 @@ def ziskStatelessVerdictV2Prologue : String :=
   "  la t1, bv_tx_gas_precharge; ld t2, 0(t1); sd t2, 352(t0)\n" ++
   "  la t1, bv_simple_transfer_recipient; ld t2, 0(t1); sd t2, 360(t0)\n" ++
   "  la t1, bv_simple_transfer_fee_recipient; ld t2, 0(t1); sd t2, 368(t0)\n" ++
+  "  la t1, bv_tx_root_status; ld t2, 0(t1); sd t2, 376(t0)\n" ++
+  "  la t1, svf_tx_count; ld t2, 0(t1); sd t2, 384(t0)\n" ++
   "  j .Lv2_pdone\n" ++
   zkvmSha256Function ++ "\n" ++
   zkvmKeccak256Function ++ "\n" ++
@@ -844,6 +892,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   mptInsertAccFunction ++ "\n" ++
   mptStateRootInsFunction ++ "\n" ++
   withdrawalsStateRootFunction ++ "\n" ++
+  mptIndexedTrieRootSmallFunction ++ "\n" ++
   validateHeaderBasicFunction ++ "\n" ++
   checkGasLimitFunction ++ "\n" ++
   headerValidatePostMergeFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -20,6 +20,11 @@ def ziskStatelessVerdictV2DataSection : String :=
   runtimeAccessAccountOutcomeData ++ "\n" ++
   storageAccessGasData ++ "\n" ++
   executionRequestsHashDataSection ++ "\n" ++
+  ".balign 32\n" ++
+  "svf_tx_root:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "svf_tx_count:\n  .zero 8\n" ++
+  "svf_tx_descriptors:\n  .zero 2048\n" ++
   ".balign 8\n" ++
   "sltr_field_len:\n  .zero 8\n" ++
   "sltr_nibble_count:\n  .zero 8\n" ++
@@ -141,6 +146,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bv_fail_code:\n  .zero 8\n" ++
   "bv_header_status:\n  .zero 8\n" ++
   "bv_state_status:\n  .zero 8\n" ++
+  "bv_tx_root_status:\n  .zero 8\n" ++
   "bv_block_rlp_len:\n  .zero 8\n" ++
   "bv_blockhash_required_headers:\n  .zero 8\n" ++
   "brr_status:\n  .zero 8\n" ++
@@ -153,6 +159,10 @@ def ziskStatelessVerdictV2DataSection : String :=
   "brr_control:\n  .zero 24\n" ++
   ".balign 8\n" ++
   "brr_records:\n  .zero 1024\n" ++
+  "itr_empty_witness:\n  .zero 8\n" ++
+  "itr_value_descs:\n  .zero 2048\n" ++
+  "itr_paths:\n  .zero 256\n" ++
+  "itr_changes:\n  .zero 8192\n" ++
   "bvgr_runtime_gas_left_ptr:\n  .zero 8\n" ++
   "bvgr_runtime_refund_counter_ptr:\n  .zero 8\n" ++
   "bvgr_runtime_calldata_floor_ptr:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
@@ -73,6 +73,7 @@ def statelessVerdictV2GuestClosure : String :=
   mptInsertAccFunction ++ "\n" ++
   mptStateRootInsFunction ++ "\n" ++
   withdrawalsStateRootFunction ++ "\n" ++
+  mptIndexedTrieRootSmallFunction ++ "\n" ++
   validateHeaderBasicFunction ++ "\n" ++
   checkGasLimitFunction ++ "\n" ++
   headerValidatePostMergeFunction ++ "\n" ++

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -556,6 +556,18 @@ format_verdict_debug() {
       dbg="${dbg:+$dbg }${simple_transfer_labels[$i]}=$value"
     done
   fi
+  if [[ "$(stat -c%s "$out" 2>/dev/null || echo 0)" -ge 392 ]]; then
+    raw="$(od -An -v -tu8 -j 376 -N 16 "$out" 2>/dev/null | xargs || true)"
+    read -r -a words <<< "$raw"
+    local -a tx_root_labels=(
+      tx_root_status
+      tx_count
+    )
+    for i in "${!tx_root_labels[@]}"; do
+      value="${words[$i]:-?}"
+      dbg="${dbg:+$dbg }${tx_root_labels[$i]}=$value"
+    done
+  fi
   echo "$dbg"
 }
 


### PR DESCRIPTION
## Summary
- parse the SSZ execution payload transaction list in `stateless_verdict_v2`
- build `{ptr,len}` descriptors for each transaction and compute the indexed transaction trie root with `mpt_indexed_trie_root_small`
- feed the computed root into block-header reconstruction instead of the zero placeholder, and add a stable `bv_fail=32` path for tx-root construction failures
- include the indexed-trie helper and scratch labels in both the probe and embedded stateless guest closures

## Verification
- `lake build EvmAsm.Codegen.Programs.BlockVerdict EvmAsm.Codegen.Programs.BlockVerdictV2`
- `scripts/codegen-stateless-link-check.sh`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `bash -n scripts/codegen-eest-stateless-check.sh`
- `scripts/codegen-eest-stateless-check.sh --skip 22662 --limit 1 --jobs 1 --quiet-passes --steps 1000000000 --run-dir gen-out/eest-tx-root-no-tx` => PASS(full)
- `scripts/codegen-eest-stateless-check.sh --skip 113 --limit 1 --jobs 1 --quiet-passes --steps 1000000000 --run-dir gen-out/eest-tx-root-one-known` => reaches later known gas/receipt false-accept path: `bv_fail=0 header=0 state=0`, recomputed state root matches payload state root, remaining mismatch is `succ guest=01 exp=00` with `brr_status=3 gas_arena_status=2 gas_arena_tx_count=2 gas_arena_runtime_count=0`
- `lake build`

Bead: evm-asm-oro9d.1