### PR TITLE
fix(eest): compute BAL hash in block verdict

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -39,6 +39,7 @@ import EvmAsm.Codegen.Programs.BlockVerdictGasResults
 import EvmAsm.Codegen.Programs.BlockVerdictTransactions
 import EvmAsm.Codegen.Programs.MptEncodeLeafBranch
 import EvmAsm.Codegen.Programs.TxBlobGas
+import EvmAsm.Codegen.Programs.BlockAccessListHash
 
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransfer
 import EvmAsm.Codegen.Programs.TxGasBalPostVerify
@@ -686,6 +687,9 @@ def statelessVerdictV2Function : String :=
   "  la a2, erh_requests_hash\n" ++
   "  jal ra, execution_requests_hash\n" ++
   "  bnez a0, .Lv2_requests_hash_fail\n" ++
+  "  mv a0, s0; la a1, svf_bal_hash\n" ++
+  "  jal ra, block_access_list_hash\n" ++
+  "  bnez a0, .Lv2_bal_hash_fail\n" ++
   "  la t1, sv_params\n" ++
   "  la t0, svf_payload;        ld t0, 0(t0); sd t0, 0(t1)\n" ++
   "  la t0, svf_parent_rlp;     ld t0, 0(t0); sd t0, 8(t1)\n" ++
@@ -695,7 +699,7 @@ def statelessVerdictV2Function : String :=
   "  la t0, svf_zero32;         sd t0, 40(t1)\n" ++
   "  addi t0, s0, 24;           sd t0, 48(t1)\n" ++
   "  la t0, erh_requests_hash;  sd t0, 56(t1)\n" ++
-  "  la t0, svf_zero32;         sd t0, 96(t1)\n" ++
+  "  la t0, svf_bal_hash;       sd t0, 96(t1)\n" ++
   "  la t0, svf_descriptors;    sd t0, 64(t1)\n" ++
   "  la t0, svf_wds_count;      ld t0, 0(t0); sd t0, 72(t1)\n" ++
   "  la t0, svf_witness;        ld t0, 0(t0); sd t0, 80(t1)\n" ++
@@ -720,6 +724,9 @@ def statelessVerdictV2Function : String :=
   "  j .Lv2_zero\n" ++
   ".Lv2_requests_hash_fail:\n" ++
   "  li t0, 24; la t1, bv_fail_code; sd t0, 0(t1)\n" ++
+  "  j .Lv2_zero\n" ++
+  ".Lv2_bal_hash_fail:\n" ++
+  "  li t0, 30; la t1, bv_fail_code; sd t0, 0(t1)\n" ++
   "  j .Lv2_zero\n" ++
   ".Lv2_chain_config_fail:\n" ++
   "  li t0, 26; la t1, bv_fail_code; sd t0, 0(t1)\n" ++
@@ -861,6 +868,8 @@ def ziskStatelessVerdictV2Prologue : String :=
   rlpBytesEncodedSizeFunction ++ "\n" ++
   rlpListEncodedSizeFunction ++ "\n" ++
   blockRlpRebuiltSizeFunction ++ "\n" ++
+  bahU32leFunction ++ "\n" ++
+  blockAccessListHashFunction ++ "\n" ++
   executionRequestsHashFunction ++ "\n" ++
   step2VerdictFunction ++ "\n" ++
   headerExtractStateRootFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -20,6 +20,10 @@ def ziskStatelessVerdictV2DataSection : String :=
   runtimeAccessAccountOutcomeData ++ "\n" ++
   storageAccessGasData ++ "\n" ++
   executionRequestsHashDataSection ++ "\n" ++
+  ".balign 32\n" ++
+  "svf_bal_hash:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "bah_bal_start:\n  .zero 8\n" ++
   ".balign 8\n" ++
   "sltr_field_len:\n  .zero 8\n" ++
   "sltr_nibble_count:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
@@ -89,6 +89,8 @@ def statelessVerdictV2GuestClosure : String :=
   rlpBytesEncodedSizeFunction ++ "\n" ++
   rlpListEncodedSizeFunction ++ "\n" ++
   blockRlpRebuiltSizeFunction ++ "\n" ++
+  bahU32leFunction ++ "\n" ++
+  blockAccessListHashFunction ++ "\n" ++
   executionRequestsHashFunction ++ "\n" ++
   step2VerdictFunction ++ "\n" ++
   headerExtractStateRootFunction ++ "\n" ++


### PR DESCRIPTION
## Summary
- compute `block_access_list_hash` from the SSZ payload block-access-list bytes in `stateless_verdict_v2`
- pass the computed hash into the 23-field Amsterdam header reconstruction instead of the zero placeholder
- wire the BAL-hash helper and scratch labels into the stateless verdict probe and embedded guest closure

## Verification
- `lake build EvmAsm.Codegen.Programs.BlockVerdict EvmAsm.Codegen.Programs.BlockVerdictV2`
- `scripts/codegen-stateless-link-check.sh`
- `scripts/codegen-zisk-block-access-list-hash-check.sh`
- `bash -n scripts/codegen-eest-stateless-check.sh`
- `scripts/codegen-eest-stateless-check.sh --skip 22662 --limit 1 --jobs 1 --quiet-passes --steps 1000000000 --run-dir gen-out/eest-bal-hash-no-evm` => PASS(full)
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`

Bead: evm-asm-oro9d.4

Authored by @pirapira; implemented by Codex.