### PR TITLE
fix(mpt): collapse delete inline survivors

### DIFF
--- a/EvmAsm/Codegen/Programs/MptDeleteAcc.lean
+++ b/EvmAsm/Codegen/Programs/MptDeleteAcc.lean
@@ -119,12 +119,19 @@ def mptDeleteAccFunction : String :=
   "  jal ra, rlp_list_nth_item\n" ++
   "  bnez a0, .Lmdacc_fail\n" ++
   "  la t0, mw_child_length; ld t1, 0(t0)\n" ++
-  "  li t2, 32; bne t1, t2, .Lmdacc_need_collapse\n" ++
+  "  beqz t1, .Lmdacc_need_collapse\n" ++
+  "  li t2, 32; beq t1, t2, .Lmdacc_resolve_hash_child\n" ++
+  "  la t0, mw_child_offset; ld t0, 0(t0); add t0, s3, t0\n" ++
+  "  la t2, mdacc_child_ptr; sd t0, 0(t2)\n" ++
+  "  la t2, mdacc_child_len; sd t1, 0(t2)\n" ++
+  "  j .Lmdacc_classify_child\n" ++
+  ".Lmdacc_resolve_hash_child:\n" ++
   "  la t0, mw_child_offset; ld t0, 0(t0); add a2, s3, t0\n" ++
   "  mv a0, s0; la t0, mdacc_witness_len; ld a1, 0(t0)\n" ++
   "  la a3, mdacc_child_ptr; la a4, mdacc_child_len\n" ++
   "  jal ra, mpt_node_resolve\n" ++
   "  bnez a0, .Lmdacc_need_collapse\n" ++
+  ".Lmdacc_classify_child:\n" ++
   "  la t0, mdacc_child_ptr; ld a0, 0(t0)\n" ++
   "  la t0, mdacc_child_len; ld a1, 0(t0)\n" ++
   "  jal ra, mpt_node_kind\n" ++
@@ -202,15 +209,24 @@ def mptDeleteAccFunction : String :=
   "  jal ra, rlp_list_nth_item\n" ++
   "  bnez a0, .Lmdacc_fail\n" ++
   "  la t0, mw_child_length; ld t1, 0(t0)\n" ++
-  "  li t2, 32; bne t1, t2, .Lmdacc_need_collapse\n" ++
+  "  beqz t1, .Lmdacc_need_collapse\n" ++
   "  la t0, mw_child_offset; ld t0, 0(t0); add t0, s3, t0\n" ++
+  "  li t2, 32; bne t1, t2, .Lmdacc_branch_child_inline\n" ++
   "  la t4, mset_ref; li t5, 0xa0; sb t5, 0(t4); addi t4, t4, 1; li t5, 32\n" ++
   ".Lmdacc_branch_child_hash_cp:\n" ++
   "  beqz t5, .Lmdacc_branch_child_hash_done\n" ++
   "  lbu t6, 0(t0); sb t6, 0(t4); addi t0, t0, 1; addi t4, t4, 1; addi t5, t5, -1; j .Lmdacc_branch_child_hash_cp\n" ++
   ".Lmdacc_branch_child_hash_done:\n" ++
-  "  la t4, mset_ref_len; li t5, 33; sd t5, 0(t4)\n" ++
-  "  la a0, mdacc_collapsed_path; li a1, 1; la a2, mset_ref; li a3, 33\n" ++
+  "  la t4, mset_ref_len; li t5, 33; sd t5, 0(t4); j .Lmdacc_branch_child_ref_ready\n" ++
+  ".Lmdacc_branch_child_inline:\n" ++
+  "  la t4, mset_ref; mv t5, t1\n" ++
+  ".Lmdacc_branch_child_inline_cp:\n" ++
+  "  beqz t5, .Lmdacc_branch_child_inline_done\n" ++
+  "  lbu t6, 0(t0); sb t6, 0(t4); addi t0, t0, 1; addi t4, t4, 1; addi t5, t5, -1; j .Lmdacc_branch_child_inline_cp\n" ++
+  ".Lmdacc_branch_child_inline_done:\n" ++
+  "  la t4, mset_ref_len; sd t1, 0(t4)\n" ++
+  ".Lmdacc_branch_child_ref_ready:\n" ++
+  "  la a0, mdacc_collapsed_path; li a1, 1; la a2, mset_ref; la t0, mset_ref_len; ld a3, 0(t0)\n" ++
   "  la a4, mset_node; la a5, mset_node_len\n" ++
   "  jal ra, mpt_extension_node_encode\n" ++
   "  la t0, mset_node_len; ld s4, 0(t0)\n" ++

--- a/scripts/codegen-zisk-mpt-delete-acc-check.sh
+++ b/scripts/codegen-zisk-mpt-delete-acc-check.sh
@@ -139,6 +139,39 @@ root6 = branch_node(slots6)
 collapsed_branch = extension_node([2], node_ref(child_branch))
 write_case("branch_collapse_branch", trie_root(root6), [1, 0xa, 0xb], [root6, la, child_branch], trie_root(collapsed_branch))
 
+la_small = leaf_node([0xa], b"A")
+lb_small = leaf_node([0xc], b"B")
+assert len(la_small) < 32 and len(lb_small) < 32
+slots_inline_leaf = [b"\x80"] * 16
+slots_inline_leaf[1] = node_ref(la_small); slots_inline_leaf[2] = node_ref(lb_small)
+root_inline_leaf = branch_node(slots_inline_leaf)
+collapsed_inline_leaf = leaf_node([2, 0xc], b"B")
+write_case("branch_collapse_inline_leaf", trie_root(root_inline_leaf), [1, 0xa],
+           [root_inline_leaf, la_small], trie_root(collapsed_inline_leaf))
+
+ext_small = extension_node([3], node_ref(lb_small))
+assert len(ext_small) < 32
+slots_inline_ext = [b"\x80"] * 16
+slots_inline_ext[1] = node_ref(la_small); slots_inline_ext[2] = node_ref(ext_small)
+root_inline_ext = branch_node(slots_inline_ext)
+collapsed_inline_ext = extension_node([2, 3], node_ref(lb_small))
+write_case("branch_collapse_inline_extension", trie_root(root_inline_ext), [1, 0xa],
+           [root_inline_ext, la_small], trie_root(collapsed_inline_ext))
+
+lc_small = leaf_node([0xe], b"C")
+ld_small = leaf_node([0xf], b"D")
+assert len(lc_small) < 32 and len(ld_small) < 32
+child_slots_inline = [b"\x80"] * 16
+child_slots_inline[4] = node_ref(lc_small); child_slots_inline[5] = node_ref(ld_small)
+child_branch_inline = branch_node(child_slots_inline)
+assert len(child_branch_inline) < 32
+slots_inline_branch = [b"\x80"] * 16
+slots_inline_branch[1] = node_ref(la_small); slots_inline_branch[2] = node_ref(child_branch_inline)
+root_inline_branch = branch_node(slots_inline_branch)
+collapsed_inline_branch = extension_node([2], node_ref(child_branch_inline))
+write_case("branch_collapse_inline_branch", trie_root(root_inline_branch), [1, 0xa],
+           [root_inline_branch, la_small], trie_root(collapsed_inline_branch))
+
 # The survivor branch has a non-empty slot 0 whose hash begins with a high
 # nibble that looks like a compact leaf prefix. Delete collapse must classify
 # the survivor as a branch before trying leaf/extension extractors.
@@ -191,7 +224,7 @@ lake exe codegen --program zisk_mpt_delete_acc --halt linux93 \
 read_u64() { od -An -tu8 -j "$2" -N 8 "$1" | tr -d ' \n'; }
 
 fail=0
-for name in leaf_to_empty branch_no_collapse branch_collapse_leaf branch_value_collapse branch_collapse_extension branch_collapse_branch branch_collapse_branch_leaflike_slot0 extension_bubble_branch_no_collapse extension_merge_leaf extension_merge_extension; do
+for name in leaf_to_empty branch_no_collapse branch_collapse_leaf branch_value_collapse branch_collapse_extension branch_collapse_branch branch_collapse_inline_leaf branch_collapse_inline_extension branch_collapse_inline_branch branch_collapse_branch_leaflike_slot0 extension_bubble_branch_no_collapse extension_merge_leaf extension_merge_extension; do
   out="$VDIR/$name.output"
   if ! "$ZISKEMU" -e "$REPO_ROOT/gen-out/zisk_mpt_delete_acc.elf" \
         -i "$VDIR/$name.input" -o "$out" -n 10000000 >/dev/null 2>&1 </dev/null; then


### PR DESCRIPTION
## Summary
- let `mpt_delete_acc` classify inline survivor child refs directly during branch collapse instead of requiring every survivor to be a 32-byte hash
- preserve hash-ref resolution for 32-byte refs
- teach branch-survivor collapse to re-emit either hashed or inline child refs when building the replacement extension
- add zisk regression vectors for inline leaf, inline extension, and inline branch survivors

## Verification
- `scripts/codegen-zisk-mpt-delete-acc-check.sh`
- `lake build EvmAsm.Codegen.Programs.MptDeleteAcc codegen`
- `git diff --check`
- `scripts/check-file-size.sh`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/MptDeleteAcc.lean scripts/codegen-zisk-mpt-delete-acc-check.sh` (no matches)\n- `scripts/codegen-zisk-mpt-delete-walk-db-check.sh`\n- `scripts/check-unimported.sh`\n- `lake build`\n\nFull `lake build` still reports the existing `LeanRV64D/RiscvExtras.lean` `extension.toCtorIdx` deprecation warning.