### PR TITLE
feat(header): decode Amsterdam blob gas fields

### DIFF
--- a/EvmAsm/Codegen/Programs/HeaderBaseFee.lean
+++ b/EvmAsm/Codegen/Programs/HeaderBaseFee.lean
@@ -343,8 +343,8 @@ def ziskHeaderValidateBaseFeeProbeUnit : BuildUnit := {
       a0 (input)  : this header's RLP ptr
       a1 (input)  : this header's RLP byte length
       a2 (input)  : this header's PR-K39 extended-decode struct
-                    (128 B, with gas_limit @ 80, gas_used @ 88,
-                    base_fee_per_gas @ 96..128)
+                    (144 B, with gas_limit @ 80, gas_used @ 88,
+                    base_fee_per_gas @ 96..128, blob fields @ 128..144)
       a3 (input)  : parent header's PR-K39 extended-decode struct
                     (same layout)
       ra (input)  : return
@@ -360,8 +360,8 @@ def validateHeaderFullFunction : String :=
   "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
   "  mv s0, a0                   # this_rlp ptr\n" ++
   "  mv s1, a1                   # this_rlp_len\n" ++
-  "  mv s2, a2                   # this_struct (128 B)\n" ++
-  "  mv s3, a3                   # parent_struct (128 B)\n" ++
+  "  mv s2, a2                   # this_struct (144 B)\n" ++
+  "  mv s3, a3                   # parent_struct (144 B)\n" ++
   "  # Step 1: post_merge check\n" ++
   "  mv a0, s0; mv a1, s1\n" ++
   "  jal ra, header_validate_post_merge\n" ++
@@ -411,8 +411,8 @@ def validateHeaderFullFunction : String :=
   "  ret"
 
 /-- `zisk_validate_header_full`: probe BuildUnit. Reads (this_rlp_len,
-    this_rlp_bytes [up to 1024 B], this_struct 128 B, parent_struct
-    128 B) from host input, writes 8-byte composite status to OUTPUT. -/
+    this_rlp_bytes [up to 1024 B], this_struct 144 B, parent_struct
+    144 B) from host input, writes 8-byte composite status to OUTPUT. -/
 def ziskValidateHeaderFullPrologue : String :=
   "  li sp, 0xa0050000\n" ++
   "  li a4, 0x40000000\n" ++
@@ -420,14 +420,14 @@ def ziskValidateHeaderFullPrologue : String :=
   "  addi a0, a4, 16             # this_rlp ptr\n" ++
   "  addi a2, a4, 16             # placeholder; reset after rlp\n" ++
   "  # this_struct offset = 16 + rlp_len_aligned\n" ++
-  "  # parent_struct offset = this_struct + 128\n" ++
+  "  # parent_struct offset = this_struct + 144\n" ++
   "  # We require the caller to lay them out at fixed positions:\n" ++
   "  # bytes 8..16  : rlp_len\n" ++
   "  # bytes 16..16+1024 : this_rlp (padded to 1024)\n" ++
-  "  # bytes 1040..1168  : this_struct (128 B)\n" ++
-  "  # bytes 1168..1296  : parent_struct (128 B)\n" ++
+  "  # bytes 1040..1184  : this_struct (144 B)\n" ++
+  "  # bytes 1184..1328  : parent_struct (144 B)\n" ++
   "  li a2, 0x40000410           # this_struct  (= INPUT_ADDR + 1040)\n" ++
-  "  li a3, 0x40000490           # parent_struct (= INPUT_ADDR + 1168)\n" ++
+  "  li a3, 0x400004a0           # parent_struct (= INPUT_ADDR + 1184)\n" ++
   "  jal ra, validate_header_full\n" ++
   "  li t0, 0xa0010000\n" ++
   "  sd a0, 0(t0)                # status\n" ++

--- a/EvmAsm/Codegen/Programs/HeaderDecode.lean
+++ b/EvmAsm/Codegen/Programs/HeaderDecode.lean
@@ -5,7 +5,7 @@
   per the file-size hard cap. Hosts:
 
     K38  header_minimal_decode  (parent_hash + state_root + number + timestamp)
-    K39  header_extended_decode (full 15-field header decode)
+    K39  header_extended_decode (full Amsterdam header decode)
     K55  coinbase_extract_from_header (beneficiary getter)
 
   Compose K20 / K34 / K35 (RlpRead + Tx).
@@ -162,6 +162,8 @@ def ziskHeaderMinimalDecodeProbeUnit : BuildUnit := {
       80..88   gas_limit      (field 9, u64)
       88..96   gas_used       (field 10, u64)
       96..128  base_fee_per_gas (field 15, u256 BE)
+     128..136  blob_gas_used    (field 17, u64)
+     136..144  excess_blob_gas  (field 18, u64)
 
     The base_fee_per_gas field exists from EIP-1559 (London)
     onward. Headers older than London don't have it; this
@@ -170,7 +172,7 @@ def ziskHeaderMinimalDecodeProbeUnit : BuildUnit := {
     Calling convention:
       a0 (input)  : header_rlp ptr
       a1 (input)  : header byte length
-      a2 (input)  : 128-byte output struct ptr
+      a2 (input)  : 144-byte output struct ptr
       ra (input)  : return
       a0 (output) : 0 success / 1 parse fail. -/
 def headerExtendedDecodeFunction : String :=
@@ -233,6 +235,16 @@ def headerExtendedDecodeFunction : String :=
   "  addi a3, s2, 96\n" ++
   "  jal ra, rlp_field_to_u256_be\n" ++
   "  bnez a0, .Lhed_fail\n" ++
+  "  # Field 17: blob_gas_used\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 17\n" ++
+  "  addi a3, s2, 128\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lhed_fail\n" ++
+  "  # Field 18: excess_blob_gas\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 18\n" ++
+  "  addi a3, s2, 136\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lhed_fail\n" ++
   "  li a0, 0\n" ++
   "  j .Lhed_ret\n" ++
   ".Lhed_fail:\n" ++
@@ -250,8 +262,8 @@ def ziskHeaderExtendedDecodePrologue : String :=
   "  ld a1, 8(a3)                # header_len\n" ++
   "  addi a0, a3, 16             # header ptr\n" ++
   "  li a2, 0xa0010008           # struct at OUTPUT + 8\n" ++
-  "  # Pre-zero 128 bytes.\n" ++
-  "  mv t0, a2; li t1, 16\n" ++
+  "  # Pre-zero 144 bytes.\n" ++
+  "  mv t0, a2; li t1, 18\n" ++
   ".Lhed_zinit:\n" ++
   "  beqz t1, .Lhed_zdone\n" ++
   "  sd zero, 0(t0)\n" ++

--- a/EvmAsm/Codegen/Programs/Step2Verdict.lean
+++ b/EvmAsm/Codegen/Programs/Step2Verdict.lean
@@ -234,9 +234,9 @@ def ziskStep2VerdictDataSection : String :=
   ".balign 32\n" ++
   "hvph_computed:\n  .zero 32\n" ++
   ".balign 8\n" ++
-  "vhrp_this_struct:\n  .zero 128\n" ++
+  "vhrp_this_struct:\n  .zero 144\n" ++
   ".balign 8\n" ++
-  "vhrp_parent_struct:\n  .zero 128\n" ++
+  "vhrp_parent_struct:\n  .zero 144\n" ++
   -- block_header_ssz_to_rlp extras (zk3_state already present)
   ".balign 32\n" ++
   "bhr_empty_ommers:\n" ++

--- a/EvmAsm/Codegen/Programs/ValidateHeaderPair.lean
+++ b/EvmAsm/Codegen/Programs/ValidateHeaderPair.lean
@@ -8,7 +8,7 @@
   Step-2 verdict (.2.4) can set successful_validation.
 
   Given two RLP headers (this, parent) it:
-    1. header_extended_decode (K39) each into a 128-byte field struct;
+    1. header_extended_decode (K39) each into a 144-byte field struct;
     2. validate_header_full (K75) — post-merge + extra_data + gas/number/
        timestamp + gas-limit drift + EIP-1559 base-fee, all against the
        parent struct;
@@ -53,7 +53,7 @@ def validateHeaderRlpPairFunction : String :=
   "  mv s1, a1                   # this len\n" ++
   "  mv s2, a2                   # parent rlp\n" ++
   "  mv s3, a3                   # parent len\n" ++
-  "  # decode this header -> vhrp_this_struct (128 B).\n" ++
+  "  # decode this header -> vhrp_this_struct (144 B).\n" ++
   "  la a2, vhrp_this_struct\n" ++
   "  jal ra, header_extended_decode\n" ++
   "  bnez a0, .Lvhrp_this_parse\n" ++
@@ -152,9 +152,9 @@ def ziskValidateHeaderRlpPairDataSection : String :=
   ".balign 32\n" ++
   "hvph_computed:\n  .zero 32\n" ++
   ".balign 8\n" ++
-  "vhrp_this_struct:\n  .zero 128\n" ++
+  "vhrp_this_struct:\n  .zero 144\n" ++
   ".balign 8\n" ++
-  "vhrp_parent_struct:\n  .zero 128"
+  "vhrp_parent_struct:\n  .zero 144"
 
 def ziskValidateHeaderRlpPairProbeUnit : BuildUnit := {
   body        := NOP

--- a/scripts/codegen-zisk-header-extended-decode-check.sh
+++ b/scripts/codegen-zisk-header-extended-decode-check.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # codegen-zisk-header-extended-decode-check.sh -- PR-K39.
 #
-# Decode 7 header fields: parent_hash, state_root, number,
-# timestamp, gas_limit, gas_used, base_fee_per_gas.
+# Decode 9 header fields: parent_hash, state_root, number,
+# timestamp, gas_limit, gas_used, base_fee_per_gas, blob_gas_used,
+# excess_blob_gas.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
@@ -31,7 +32,7 @@ lake exe codegen --program zisk_header_extended_decode --halt linux93 \
 REPO_ROOT="$(pwd)"
 
 run_case() {
-  local name="$1" parent_hex="$2" state_root_hex="$3" number="$4" timestamp="$5" gas_limit="$6" gas_used="$7" base_fee="$8"
+  local name="$1" parent_hex="$2" state_root_hex="$3" number="$4" timestamp="$5" gas_limit="$6" gas_used="$7" base_fee="$8" blob_gas_used="$9" excess_blob_gas="${10}"
 
   local in_file="$REPO_ROOT/gen-out/zisk_header_extended_decode_${name}.input"
   local out_file="$REPO_ROOT/gen-out/zisk_header_extended_decode_${name}.output"
@@ -48,8 +49,10 @@ timestamp = $timestamp
 gas_limit = $gas_limit
 gas_used = $gas_used
 base_fee = $base_fee
+blob_gas_used = $blob_gas_used
+excess_blob_gas = $excess_blob_gas
 
-# Synthetic 16-field header (post-EIP-1559) with the indices populated.
+# Synthetic Amsterdam header with blob-gas fields populated.
 fields = [
     parent_hash,    # 0: parent_hash
     b'\x22' * 32,   # 1: ommers_hash
@@ -67,6 +70,10 @@ fields = [
     b'\x77' * 32,   # 13: prev_randao
     b'\x00' * 8,    # 14: nonce
     base_fee,       # 15: base_fee_per_gas
+    b'\x88' * 32,   # 16: withdrawals_root
+    blob_gas_used,  # 17: blob_gas_used
+    excess_blob_gas,# 18: excess_blob_gas
+    b'\x99' * 32,   # 19: parent_beacon_block_root
 ]
 header_rlp = rlp.encode(fields)
 
@@ -85,6 +92,8 @@ expected += struct.pack('<Q', timestamp)
 expected += struct.pack('<Q', gas_limit)
 expected += struct.pack('<Q', gas_used)
 expected += base_fee.to_bytes(32, 'big')
+expected += struct.pack('<Q', blob_gas_used)
+expected += struct.pack('<Q', excess_blob_gas)
 with open(sys.argv[2], 'wb') as f:
     f.write(expected)
 " "$in_file" "$exp_file"
@@ -99,7 +108,7 @@ with open(sys.argv[2], 'wb') as f:
   expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
 
   if [[ "$actual" == "$expected" ]]; then
-    printf "  %-26s OK   #%d gas=%d/%d basefee=%d\n" "$name" "$number" "$gas_used" "$gas_limit" "$base_fee"
+    printf "  %-26s OK   #%s gas=%s/%s basefee=%s blob=%s excess=%s\n" "$name" "$number" "$gas_used" "$gas_limit" "$base_fee" "$blob_gas_used" "$excess_blob_gas"
     return 0
   else
     printf "  %-26s FAIL\n    expected: %s\n    actual:   %s\n" "$name" "$expected" "$actual"
@@ -111,14 +120,14 @@ PARENT="$(printf '11%.0s' $(seq 1 32))"
 STATE_ROOT="$(printf '44%.0s' $(seq 1 32))"
 
 FAILED=0
-run_case "post_london_typical"  "$PARENT" "$STATE_ROOT" 1234567 1700000000 30000000  15000000  1000000000   || FAILED=1
-run_case "low_base_fee"         "$PARENT" "$STATE_ROOT" 1       1000       30000000  0         7            || FAILED=1
-run_case "high_base_fee"        "$PARENT" "$STATE_ROOT" 999999  1700000000 30000000  29999999  115792089237316195423570985008687907853269984665640564039457584007913129639935 || FAILED=1
-run_case "min_gas_used"         "$PARENT" "$STATE_ROOT" 5000    1500000000 8000000   21000     500000000    || FAILED=1
+run_case "amsterdam_typical"    "$PARENT" "$STATE_ROOT" 1234567 1700000000 30000000  15000000  1000000000  1835008 0       || FAILED=1
+run_case "low_base_fee"         "$PARENT" "$STATE_ROOT" 1       1000       30000000  0         7           0       0       || FAILED=1
+run_case "high_base_fee"        "$PARENT" "$STATE_ROOT" 999999  1700000000 30000000  29999999  115792089237316195423570985008687907853269984665640564039457584007913129639935 2752512 131072 || FAILED=1
+run_case "min_gas_used"         "$PARENT" "$STATE_ROOT" 5000    1500000000 8000000   21000     500000000   131072  42      || FAILED=1
 
 echo
 if [[ $FAILED -eq 0 ]]; then
-  echo "==> PASS: header_extended_decode extracts 7 fields with EIP-1559 base_fee"
+  echo "==> PASS: header_extended_decode extracts Amsterdam header fields"
   exit 0
 else
   echo "==> FAIL"

--- a/scripts/codegen-zisk-validate-header-full-check.sh
+++ b/scripts/codegen-zisk-validate-header-full-check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # codegen-zisk-validate-header-full-check.sh -- PR-K75.
 #
-# Run all five header validation checks (post_merge, extra_data,
+# Run header validation checks (post_merge, extra_data,
 # basic, gas_limit, base_fee) in sequence and verify the
 # composite return code.
 set -euo pipefail
@@ -74,8 +74,8 @@ rlp_bytes = rlp.encode(this_fields)
 if len(rlp_bytes) > 1024:
     raise RuntimeError(f'rlp too long for fixture: {len(rlp_bytes)}')
 
-# Build extended-decode structs (128 B each)
-def build_struct(parent_hash, state_root, number, ts, gl, gu, bf):
+# Build extended-decode structs (144 B each)
+def build_struct(parent_hash, state_root, number, ts, gl, gu, bf, blob_gas_used=0, excess_blob_gas=0):
     out  = parent_hash
     out += state_root
     out += struct.pack('<Q', number)
@@ -83,7 +83,9 @@ def build_struct(parent_hash, state_root, number, ts, gl, gu, bf):
     out += struct.pack('<Q', gl)
     out += struct.pack('<Q', gu)
     out += bf.to_bytes(32, 'big')
-    assert len(out) == 128
+    out += struct.pack('<Q', blob_gas_used)
+    out += struct.pack('<Q', excess_blob_gas)
+    assert len(out) == 144
     return out
 
 this_struct   = build_struct(b'\x11' * 32, b'\x44' * 32,
@@ -97,9 +99,9 @@ parent_struct = build_struct(b'\x22' * 32, b'\x55' * 32,
 out  = struct.pack('<Q', len(rlp_bytes))   # bytes 0..8: rlp_len
 out += rlp_bytes
 out += b'\x00' * (1024 - len(rlp_bytes))   # pad rlp area to 1024 B
-out += this_struct                          # 128 B
-out += parent_struct                        # 128 B
-assert len(out) == 8 + 1024 + 256
+out += this_struct                          # 144 B
+out += parent_struct                        # 144 B
+assert len(out) == 8 + 1024 + 288
 
 with open(sys.argv[1], 'wb') as f:
     f.write(out)

--- a/scripts/codegen-zisk-validate-header-rlp-pair-check.sh
+++ b/scripts/codegen-zisk-validate-header-rlp-pair-check.sh
@@ -4,7 +4,7 @@
 # its parent?" check (header_extended_decode x2 + validate_header_full +
 # header_validate_parent_hash).
 #
-# Builds a valid London+-style (this, parent) header pair where parent
+# Builds a valid Amsterdam-style (this, parent) header pair where parent
 # gas_used == gas_limit/2 (so the EIP-1559 child base-fee is unchanged) and
 # this.parent_hash == keccak256(parent_rlp). Expects status 0. Then three
 # invalid tweaks: wrong number (rejected), wrong base-fee (rejected), and a
@@ -38,8 +38,8 @@ def k256(b):
 
 def header(parent_hash, number, gas_limit, gas_used, timestamp, base_fee,
            state_root=b"\x44" * 32, extra=b"", difficulty=0,
-           nonce=b"\x00" * 8):
-    # London+-style 16-field header (field 15 = base_fee_per_gas).
+           nonce=b"\x00" * 8, blob_gas_used=0, excess_blob_gas=0):
+    # Amsterdam-style header with blob-gas fields.
     return [
         parent_hash,            # 0
         EMPTY_OMMERS,           # 1
@@ -57,6 +57,10 @@ def header(parent_hash, number, gas_limit, gas_used, timestamp, base_fee,
         b"\x77" * 32,           # 13 prev_randao
         nonce,                  # 14
         base_fee,               # 15
+        b"\x88" * 32,           # 16 withdrawals_root
+        blob_gas_used,          # 17
+        excess_blob_gas,        # 18
+        b"\x99" * 32,           # 19 parent_beacon_block_root
     ]
 
 GL, BF = 30_000_000, 1_000_000_000


### PR DESCRIPTION
## Summary
- extend `header_extended_decode` output to 144 bytes with `blob_gas_used` and `excess_blob_gas`
- grow validate-header scratch buffers and probe inputs to use Amsterdam-style header structs
- update header decoder/validator regressions to cover blob fields

Refs/Bead: `evm-asm-raihp`.

This is the decode/layout foundation for Amsterdam `excess_blob_gas` validation. It does not yet wire the recurrence check into `validate_header_full`; follow-up beads are `evm-asm-raihp.1`, `evm-asm-raihp.2`, and `evm-asm-raihp.3`.

## Verification
- `scripts/codegen-zisk-header-extended-decode-check.sh`
- `scripts/codegen-zisk-validate-header-full-check.sh`
- `scripts/codegen-zisk-validate-header-rlp-pair-check.sh`
- `lake build EvmAsm.Codegen.Programs.HeaderDecode EvmAsm.Codegen.Programs.HeaderBaseFee EvmAsm.Codegen.Programs.ValidateHeaderPair EvmAsm.Codegen.Programs.Step2Verdict codegen`
- `git diff --check`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- forbidden scan over edited files: no matches
- `lake build`

Full `lake build` still reports the existing `LeanRV64D/RiscvExtras.lean` deprecation warning.

Authored by @pirapira; implemented by Codex.