### PR TITLE
fix(create): allow max initcode memory range

### DIFF
--- a/EvmAsm/Codegen/Programs/NoopChildFrame.lean
+++ b/EvmAsm/Codegen/Programs/NoopChildFrame.lean
@@ -131,7 +131,7 @@ def childFrameHandlers : List OpcodeHandlerSpec :=
     "  bnez x18, .exit_outofgas\n" ++
     "  add x18, x15, x16\n" ++
     "  bltu x18, x15, .exit_outofgas\n" ++
-    "  li x19, 0x8000\n" ++
+    "  li x19, 0x10000\n" ++
     "  bltu x19, x18, .exit_outofgas\n" ++
     "1:\n" ++
     createInitcodeGasAsm


### PR DESCRIPTION
## Summary
- raise the CREATE-family runtime memory envelope from 0x8000 to 0x10000
- allow Amsterdam max initcode-size CREATE exact-gas cases to use the full 64 KiB runtime memory arena

Bead: evm-asm-d4vyd

## Verification
- `scripts/codegen-opcodes-runtime-check.sh` → ALL PASS (357 case(s))
- `lake build EvmAsm.Codegen.Programs.NoopChildFrame codegen`
- `git diff --check`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- forbidden-pattern scan over `EvmAsm/Codegen/Programs/NoopChildFrame.lean`
- `lake build`

## Notes
- Full `lake build` still reports the known deprecation warning in `LeanRV64D/RiscvExtras.lean:115:12` for `extension.toCtorIdx`.

Authored by @pirapira; implemented by Codex
