### PR TITLE
fix(ssz): cap ByteList list helper scratch usage

### DIFF
--- a/EvmAsm/Codegen/Programs/Ssz.lean
+++ b/EvmAsm/Codegen/Programs/Ssz.lean
@@ -769,12 +769,14 @@ def ziskSszHashTreeRootBytesProbeUnit : BuildUnit := {
       a3 (input)  : list count_limit_log2 (capacity = 2^a3)
       a4 (input)  : 32-byte output ptr
       ra (input)  : return
-      a0 (output) : 0 (ZKVM_EOK)
+      a0 (output) : 0 (ZKVM_EOK), 1 if the section exceeds this helper's
+                    scratch-supported bounds
 
     PR-S11 caps N (element count) at 32, matching the inner
-    merkleize cap. Output is byte-identical to
+    merkleize cap, and each ByteList element at 1024 bytes, matching
+    `ssz_hash_tree_root_bytes` scratch. Output is byte-identical to
     `SszList[ByteList[B], M](...).hash_tree_root()` from
-    `remerkleable` for any compliant input. -/
+    `remerkleable` for any input within those helper bounds. -/
 def sszHashTreeRootListByteListFunction : String :=
   "ssz_hash_tree_root_list_bytelist:\n" ++
   "  addi sp, sp, -64\n" ++
@@ -791,7 +793,13 @@ def sszHashTreeRootListByteListFunction : String :=
   "  lbu t5, 1(s0); slli t5, t5, 8;  or t0, t0, t5\n" ++
   "  lbu t5, 2(s0); slli t5, t5, 16; or t0, t0, t5\n" ++
   "  lbu t5, 3(s0); slli t5, t5, 24; or t0, t0, t5\n" ++
+  "  andi t5, t0, 3\n" ++
+  "  bnez t5, .Lszls_fail       # offset_0 must equal 4*N\n" ++
   "  srli s5, t0, 2             # s5 = N (element count)\n" ++
+  "  beqz s5, .Lszls_fail       # non-empty section cannot encode an empty list\n" ++
+  "  li t5, 32\n" ++
+  "  bltu t5, s5, .Lszls_fail   # child root scratch is 32 roots\n" ++
+  "  bltu s1, t0, .Lszls_fail   # offset table must fit in section\n" ++
   "  li s6, 0                   # s6 = i (loop counter)\n" ++
   ".Lszls_loop:\n" ++
   "  beq s6, s5, .Lszls_done_loop\n" ++
@@ -801,6 +809,9 @@ def sszHashTreeRootListByteListFunction : String :=
   "  lbu t5, 1(t1); slli t5, t5, 8;  or t2, t2, t5\n" ++
   "  lbu t5, 2(t1); slli t5, t5, 16; or t2, t2, t5\n" ++
   "  lbu t5, 3(t1); slli t5, t5, 24; or t2, t2, t5\n" ++
+  "  slli t3, s5, 2\n" ++
+  "  bltu t2, t3, .Lszls_fail   # element data starts after offset table\n" ++
+  "  bltu s1, t2, .Lszls_fail   # element start must be in section\n" ++
   "  add a0, s0, t2             # el_i_start\n" ++
   "  addi t3, s6, 1\n" ++
   "  beq t3, s5, .Lszls_use_end\n" ++
@@ -810,17 +821,25 @@ def sszHashTreeRootListByteListFunction : String :=
   "  lbu t5, 1(t3); slli t5, t5, 8;  or t4, t4, t5\n" ++
   "  lbu t5, 2(t3); slli t5, t5, 16; or t4, t4, t5\n" ++
   "  lbu t5, 3(t3); slli t5, t5, 24; or t4, t4, t5\n" ++
+  "  bltu t4, t2, .Lszls_fail   # offsets must be monotone\n" ++
+  "  bltu s1, t4, .Lszls_fail   # next element start must be in section\n" ++
   "  add t4, s0, t4             # el_i_end\n" ++
   "  j .Lszls_have_end\n" ++
   ".Lszls_use_end:\n" ++
   "  add t4, s0, s1             # el_i_end = section_end\n" ++
   ".Lszls_have_end:\n" ++
   "  sub a1, t4, a0             # el_i_len\n" ++
+  "  li t1, 32\n" ++
+  "  sll t1, t1, s2             # declared ByteList byte capacity\n" ++
+  "  bltu t1, a1, .Lszls_fail   # reject element longer than ByteList[B]\n" ++
+  "  li t0, 1024\n" ++
+  "  bltu t0, a1, .Lszls_fail   # ssz_hash_tree_root_bytes scratch supports <=1024B\n" ++
   "  mv a2, s2                  # byte_log2\n" ++
   "  la a3, ssz_ltb_child_roots\n" ++
   "  slli t0, s6, 5             # 32*i\n" ++
   "  add a3, a3, t0             # &child_roots[i]\n" ++
   "  jal ra, ssz_hash_tree_root_bytes\n" ++
+  "  bnez a0, .Lszls_fail\n" ++
   "  addi s6, s6, 1\n" ++
   "  j .Lszls_loop\n" ++
   ".Lszls_done_loop:\n" ++
@@ -861,6 +880,14 @@ def sszHashTreeRootListByteListFunction : String :=
   "  jal ra, zkvm_sha256\n" ++
   ".Lszls_ret:\n" ++
   "  li a0, 0\n" ++
+  "  j .Lszls_restore\n" ++
+  ".Lszls_fail:\n" ++
+  "  sd zero,  0(s4)\n" ++
+  "  sd zero,  8(s4)\n" ++
+  "  sd zero, 16(s4)\n" ++
+  "  sd zero, 24(s4)\n" ++
+  "  li a0, 1\n" ++
+  ".Lszls_restore:\n" ++
   "  ld ra,  0(sp)\n" ++
   "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
   "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
@@ -884,6 +911,8 @@ def ziskSszHashTreeRootListByteListPrologue : String :=
   "  addi a0, a5, 32             # section ptr\n" ++
   "  li a4, 0xa0010000           # OUTPUT_ADDR\n" ++
   "  jal ra, ssz_hash_tree_root_list_bytelist\n" ++
+  "  li t0, 0xa0010020\n" ++
+  "  sd a0, 0(t0)                # OUTPUT+32 = status\n" ++
   "  j .Lzs11_done\n" ++
   zkvmSha256Function ++ "\n" ++
   sszPackBytesFunction ++ "\n" ++
@@ -965,7 +994,7 @@ def ziskSszHashTreeRootListByteListProbeUnit : BuildUnit := {
       a1 (input)  : section_len
       a2 (input)  : 32-byte output ptr
       ra (input)  : return
-      a0 (output) : 0 (ZKVM_EOK)
+      a0 (output) : 0 (ZKVM_EOK), nonzero if a nested list exceeds helper bounds
 
     Per-field caps inherited from PR-S11: each list's N ≤ 32.
     Test fixtures stay well below; production-sized witnesses
@@ -991,6 +1020,7 @@ def sszHashTreeRootExecutionWitnessFunction : String :=
   "  li a3, 20\n" ++
   "  la a4, ssz_ew_field_roots\n" ++
   "  jal ra, ssz_hash_tree_root_list_bytelist\n" ++
+  "  bnez a0, .Lszew_ret\n" ++
   "  # Field 1: codes (List[ByteList[2^24], 2^16]; byte_log2=19, count_log2=16)\n" ++
   "  add a0, s0, s4              # codes_start\n" ++
   "  add t0, s0, s5              # codes_end\n" ++
@@ -1000,6 +1030,7 @@ def sszHashTreeRootExecutionWitnessFunction : String :=
   "  la a4, ssz_ew_field_roots\n" ++
   "  addi a4, a4, 32\n" ++
   "  jal ra, ssz_hash_tree_root_list_bytelist\n" ++
+  "  bnez a0, .Lszew_ret\n" ++
   "  # Field 2: headers (List[ByteList[2^10], 2^8]; byte_log2=5, count_log2=8)\n" ++
   "  add a0, s0, s5              # headers_start\n" ++
   "  sub a1, s6, a0\n" ++
@@ -1008,6 +1039,7 @@ def sszHashTreeRootExecutionWitnessFunction : String :=
   "  la a4, ssz_ew_field_roots\n" ++
   "  addi a4, a4, 64\n" ++
   "  jal ra, ssz_hash_tree_root_list_bytelist\n" ++
+  "  bnez a0, .Lszew_ret\n" ++
   "  # Merkleize 3 field roots, capacity = 4 slots (limit_log2 = 2)\n" ++
   "  la a0, ssz_ew_field_roots\n" ++
   "  li a1, 3\n" ++
@@ -1015,6 +1047,7 @@ def sszHashTreeRootExecutionWitnessFunction : String :=
   "  mv a3, s2\n" ++
   "  jal ra, ssz_merkleize\n" ++
   "  li a0, 0\n" ++
+  ".Lszew_ret:\n" ++
   "  ld ra,  0(sp)\n" ++
   "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
   "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
@@ -1034,6 +1067,8 @@ def ziskSszHashTreeRootExecutionWitnessPrologue : String :=
   "  addi a0, a3, 16             # section ptr\n" ++
   "  li a2, 0xa0010000           # OUTPUT_ADDR\n" ++
   "  jal ra, ssz_hash_tree_root_execution_witness\n" ++
+  "  li t0, 0xa0010020\n" ++
+  "  sd a0, 0(t0)                # OUTPUT+32 = status\n" ++
   "  j .Lzs12_done\n" ++
   zkvmSha256Function ++ "\n" ++
   sszPackBytesFunction ++ "\n" ++

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -298,7 +298,7 @@ This is the verified gas-cost surrogate.
 ## D — Codegen reach
 
 - Programs in `EvmAsm/Codegen/Programs.lean` registry: **843**
-- ziskemu round-trip scripts: **600** under `scripts/codegen-*.sh`
+- ziskemu round-trip scripts: **601** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-ssz-list-bytelist-cap-check.sh
+++ b/scripts/codegen-zisk-ssz-list-bytelist-cap-check.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# codegen-zisk-ssz-list-bytelist-cap-check.sh -- verify PR-S11 bounds.
+#
+# The helper stages child roots in a 1024-byte scratch buffer, so it supports at
+# most 32 ByteList elements. Each nested ByteList root currently uses the
+# 1024-byte ssz_hash_tree_root_bytes scratch. This script checks one valid root
+# against a Python SSZ recomputation and checks that oversized cases return a
+# nonzero status with a zero output root.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+VDIR="gen-out/ssz-list-bytelist-cap"
+mkdir -p "$VDIR"
+
+echo "==> lake build codegen"
+lake build codegen >/dev/null
+
+echo "==> emit zisk_ssz_hash_tree_root_list_bytelist ELF"
+lake exe codegen --program zisk_ssz_hash_tree_root_list_bytelist --halt linux93 \
+  -o gen-out/zisk_ssz_hash_tree_root_list_bytelist >/dev/null
+
+python3 - "$VDIR" <<'PY'
+import hashlib
+import os
+import struct
+import sys
+
+VDIR = sys.argv[1]
+
+def zero_hashes(depth):
+    zs = [b"\x00" * 32]
+    for _ in range(depth + 1):
+        zs.append(hashlib.sha256(zs[-1] + zs[-1]).digest())
+    return zs
+
+def merkleize(chunks, limit_log2):
+    zs = zero_hashes(max(limit_log2, 1))
+    n = len(chunks)
+    if n == 0:
+        return zs[limit_log2]
+    m = 1
+    depth = 0
+    while m < n:
+        m <<= 1
+        depth += 1
+    layer = list(chunks) + [zs[0]] * (m - n)
+    while len(layer) > 1:
+        layer = [
+            hashlib.sha256(layer[2 * i] + layer[2 * i + 1]).digest()
+            for i in range(len(layer) // 2)
+        ]
+    root = layer[0]
+    while depth < limit_log2:
+        root = hashlib.sha256(root + zs[depth]).digest()
+        depth += 1
+    return root
+
+def bytelist_root(value, byte_log2):
+    padded = value + b"\x00" * ((-len(value)) % 32)
+    chunks = [padded[i : i + 32] for i in range(0, len(padded), 32)]
+    partial = merkleize(chunks, byte_log2)
+    return hashlib.sha256(partial + len(value).to_bytes(32, "little")).digest()
+
+def list_root(elements, byte_log2, count_log2):
+    child_roots = [bytelist_root(e, byte_log2) for e in elements]
+    partial = merkleize(child_roots, count_log2)
+    return hashlib.sha256(partial + len(elements).to_bytes(32, "little")).digest()
+
+def section(elements):
+    if not elements:
+        return b""
+    off = 4 * len(elements)
+    offsets = []
+    body = b""
+    for e in elements:
+        offsets.append(off)
+        body += e
+        off += len(e)
+    return b"".join(struct.pack("<I", o) for o in offsets) + body
+
+def write_case(name, elements, byte_log2, count_log2, status):
+    sec = section(elements)
+    with open(os.path.join(VDIR, f"{name}.input"), "wb") as f:
+        f.write(struct.pack("<Q", len(sec)))
+        f.write(struct.pack("<Q", byte_log2))
+        f.write(struct.pack("<Q", count_log2))
+        f.write(sec)
+        pad = (-(24 + len(sec))) % 8
+        if pad:
+            f.write(b"\x00" * pad)
+    if status == 0:
+        root = list_root(elements, byte_log2, count_log2)
+    else:
+        root = b"\x00" * 32
+    with open(os.path.join(VDIR, f"{name}.expected"), "w") as f:
+        f.write(root.hex() + f" {status}\n")
+
+write_case("valid-three", [b"a", b"bc", bytes(range(40))], 2, 5, 0)
+write_case("too-many", [bytes([i]) for i in range(33)], 0, 6, 1)
+write_case("too-large-element", [b"x" * 1025], 6, 5, 1)
+PY
+
+run_case() {
+  local name="$1"
+  local out="$VDIR/$name.output"
+  "$ZISKEMU" -e gen-out/zisk_ssz_hash_tree_root_list_bytelist.elf \
+    -i "$VDIR/$name.input" -o "$out" -n 5000000 \
+    >"$VDIR/$name.emu.log" 2>&1 || { echo "  ERROR $name"; exit 1; }
+  local actual_root actual_status expected_root expected_status
+  actual_root="$(xxd -p -l 32 "$out" | tr -d '\n')"
+  actual_status="$(od -An -tu8 -j 32 -N 8 "$out" | tr -d ' \n')"
+  read expected_root expected_status < "$VDIR/$name.expected"
+  if [[ "$actual_root" == "$expected_root" && "$actual_status" == "$expected_status" ]]; then
+    printf "  %-18s OK status=%s\n" "$name" "$actual_status"
+  else
+    printf "  %-18s FAIL\n    root exp=%s act=%s\n    status exp=%s act=%s\n" \
+      "$name" "$expected_root" "$actual_root" "$expected_status" "$actual_status"
+    exit 1
+  fi
+}
+
+run_case valid-three
+run_case too-many
+run_case too-large-element
+
+echo "==> PASS: ssz_hash_tree_root_list_bytelist enforces helper bounds"


### PR DESCRIPTION
Rebased from #8401 with updated PROGRESS.md (script count 600→601 for the new codegen-zisk-ssz-list-bytelist-cap-check.sh).

## Summary
- Cap ByteList list helper scratch usage

Authored by @pirapira; implemented by Codex.