### PR TITLE
fix(eest): validate withdrawals root in block verdict

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -40,6 +40,7 @@ import EvmAsm.Codegen.Programs.BlockVerdictTransactions
 import EvmAsm.Codegen.Programs.MptEncodeLeafBranch
 import EvmAsm.Codegen.Programs.TxBlobGas
 import EvmAsm.Codegen.Programs.BlockAccessListHash
+import EvmAsm.Codegen.Programs.WithdrawalsRootIndexed
 
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransfer
 import EvmAsm.Codegen.Programs.TxGasBalPostVerify
@@ -303,6 +304,8 @@ def blockVerdictFunction : String :=
   "  la t0, bv_fail_code; sd zero, 0(t0)\n" ++
   "  la t0, bv_header_status; sd zero, 0(t0)\n" ++
   "  la t0, bv_state_status; sd zero, 0(t0)\n" ++
+  "  la t0, bv_withdrawals_root_status; sd zero, 0(t0)\n" ++
+  "  la t0, bv_withdrawals_root_valid; sd zero, 0(t0)\n" ++
   "  ld a0, 0(s0); ld a1, 32(s0); ld a2, 40(s0); ld a3, 48(s0); ld a4, 56(s0); ld a7, 96(s0)\n" ++
   "  la a5, sv_this_rlp; la a6, sv_this_rlp_len\n" ++
   "  jal ra, block_header_ssz_to_rlp\n" ++
@@ -315,6 +318,12 @@ def blockVerdictFunction : String :=
   "  jal ra, validate_header_rlp_pair\n" ++
   "  mv s1, a0\n" ++
   "  la t0, bv_header_status; sd s1, 0(t0)\n" ++
+  "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0); ld a2, 64(s0); ld a3, 72(s0)\n" ++
+  "  jal ra, block_validate_withdrawals_root_indexed\n" ++
+  "  la t0, bv_withdrawals_root_status; sd a0, 0(t0)\n" ++
+  "  la t0, bv_withdrawals_root_valid; sd a1, 0(t0)\n" ++
+  "  bnez a0, .Lbv_withdrawals_root_fail\n" ++
+  "  beqz a1, .Lbv_withdrawals_root_fail\n" ++
   "  ld a0, 24(s0); ld a1, 80(s0); ld a2, 88(s0); ld a3, 64(s0); ld a4, 72(s0)\n" ++
   "  la a5, sv_recomputed; mv a6, s3\n" ++
   "  jal ra, block_state_root\n" ++
@@ -608,6 +617,8 @@ def blockVerdictFunction : String :=
   "  li t0, 25; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_versioned_hashes_fail:\n" ++
   "  li t0, 27; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
+  ".Lbv_withdrawals_root_fail:\n" ++
+  "  li t0, 31; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_zero:\n" ++
   "  li a0, 0\n" ++
   ".Lbv_ret:\n" ++
@@ -679,6 +690,9 @@ def statelessVerdictV2Function : String :=
   "  sd s4, 0(s3); la t0, svf_wd_len; ld t1, 0(t0); sd t1, 8(s3)\n" ++
   "  addi s2, s2, 44; addi s4, s4, 72; addi s3, s3, 16; addi s5, s5, 1; j .Lv2_wl\n" ++
   ".Lv2_wd:\n" ++
+  "  la a0, svf_descriptors; la t0, svf_wds_count; ld a1, 0(t0); la a2, svf_withdrawals_root\n" ++
+  "  jal ra, mpt_indexed_trie_root_small\n" ++
+  "  bnez a0, .Lv2_withdrawals_root_fail\n" ++
   "  addi a0, s0, 56; jal ra, bgv_u32le; mv s3, a0     # execution_requests offset\n" ++
   "  addi a0, s0, 4;  jal ra, bgv_u32le; mv s4, a0     # witness offset = NPR end\n" ++
   "  addi a0, s0, 16; add a0, a0, s3                   # er section start\n" ++
@@ -695,7 +709,7 @@ def statelessVerdictV2Function : String :=
   "  la t0, svf_parent_rlp_len; ld t0, 0(t0); sd t0, 16(t1)\n" ++
   "  la t0, svf_parent_sr;      sd t0, 24(t1)\n" ++
   "  la t0, svf_zero32;         sd t0, 32(t1)\n" ++
-  "  la t0, svf_zero32;         sd t0, 40(t1)\n" ++
+  "  la t0, svf_withdrawals_root; sd t0, 40(t1)\n" ++
   "  addi t0, s0, 24;           sd t0, 48(t1)\n" ++
   "  la t0, erh_requests_hash;  sd t0, 56(t1)\n" ++
   "  la t0, svf_bal_hash;       sd t0, 96(t1)\n" ++
@@ -726,6 +740,9 @@ def statelessVerdictV2Function : String :=
   "  j .Lv2_zero\n" ++
   ".Lv2_bal_hash_fail:\n" ++
   "  li t0, 30; la t1, bv_fail_code; sd t0, 0(t1)\n" ++
+  "  j .Lv2_zero\n" ++
+  ".Lv2_withdrawals_root_fail:\n" ++
+  "  li t0, 31; la t1, bv_fail_code; sd t0, 0(t1)\n" ++
   "  j .Lv2_zero\n" ++
   ".Lv2_chain_config_fail:\n" ++
   "  li t0, 26; la t1, bv_fail_code; sd t0, 0(t1)\n" ++
@@ -792,6 +809,8 @@ def ziskStatelessVerdictV2Prologue : String :=
   "  la t1, bv_tx_gas_precharge; ld t2, 0(t1); sd t2, 352(t0)\n" ++
   "  la t1, bv_simple_transfer_recipient; ld t2, 0(t1); sd t2, 360(t0)\n" ++
   "  la t1, bv_simple_transfer_fee_recipient; ld t2, 0(t1); sd t2, 368(t0)\n" ++
+  "  la t1, bv_withdrawals_root_status; ld t2, 0(t1); sd t2, 376(t0)\n" ++
+  "  la t1, bv_withdrawals_root_valid; ld t2, 0(t1); sd t2, 384(t0)\n" ++
   "  j .Lv2_pdone\n" ++
   zkvmSha256Function ++ "\n" ++
   zkvmKeccak256Function ++ "\n" ++
@@ -851,6 +870,9 @@ def ziskStatelessVerdictV2Prologue : String :=
   mptInsertAccFunction ++ "\n" ++
   mptStateRootInsFunction ++ "\n" ++
   withdrawalsStateRootFunction ++ "\n" ++
+  mptIndexedTrieRootSmallFunction ++ "\n" ++
+  headerExtractWithdrawalsRootFunction ++ "\n" ++
+  blockValidateWithdrawalsRootIndexedFunction ++ "\n" ++
   validateHeaderBasicFunction ++ "\n" ++
   checkGasLimitFunction ++ "\n" ++
   headerValidatePostMergeFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -22,6 +22,8 @@ def ziskStatelessVerdictV2DataSection : String :=
   executionRequestsHashDataSection ++ "\n" ++
   ".balign 32\n" ++
   "svf_bal_hash:\n  .zero 32\n" ++
+  ".balign 32\n" ++
+  "svf_withdrawals_root:\n  .zero 32\n" ++
   ".balign 8\n" ++
   "bah_bal_start:\n  .zero 8\n" ++
   ".balign 8\n" ++
@@ -145,6 +147,8 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bv_fail_code:\n  .zero 8\n" ++
   "bv_header_status:\n  .zero 8\n" ++
   "bv_state_status:\n  .zero 8\n" ++
+  "bv_withdrawals_root_status:\n  .zero 8\n" ++
+  "bv_withdrawals_root_valid:\n  .zero 8\n" ++
   "bv_block_rlp_len:\n  .zero 8\n" ++
   "bv_blockhash_required_headers:\n  .zero 8\n" ++
   "brr_status:\n  .zero 8\n" ++
@@ -157,6 +161,14 @@ def ziskStatelessVerdictV2DataSection : String :=
   "brr_control:\n  .zero 24\n" ++
   ".balign 8\n" ++
   "brr_records:\n  .zero 1024\n" ++
+  "hewr_offset:\n  .zero 8\n" ++
+  "hewr_length:\n  .zero 8\n" ++
+  "bvwri_expected_root:\n  .zero 32\n" ++
+  "bvwri_computed_root:\n  .zero 32\n" ++
+  "itr_empty_witness:\n  .zero 8\n" ++
+  "itr_value_descs:\n  .zero 2048\n" ++
+  "itr_paths:\n  .zero 256\n" ++
+  "itr_changes:\n  .zero 8192\n" ++
   "bvgr_runtime_gas_left_ptr:\n  .zero 8\n" ++
   "bvgr_runtime_refund_counter_ptr:\n  .zero 8\n" ++
   "bvgr_runtime_calldata_floor_ptr:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
@@ -73,6 +73,9 @@ def statelessVerdictV2GuestClosure : String :=
   mptInsertAccFunction ++ "\n" ++
   mptStateRootInsFunction ++ "\n" ++
   withdrawalsStateRootFunction ++ "\n" ++
+  mptIndexedTrieRootSmallFunction ++ "\n" ++
+  headerExtractWithdrawalsRootFunction ++ "\n" ++
+  blockValidateWithdrawalsRootIndexedFunction ++ "\n" ++
   validateHeaderBasicFunction ++ "\n" ++
   checkGasLimitFunction ++ "\n" ++
   headerValidatePostMergeFunction ++ "\n" ++

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -556,6 +556,18 @@ format_verdict_debug() {
       dbg="${dbg:+$dbg }${simple_transfer_labels[$i]}=$value"
     done
   fi
+  if [[ "$(stat -c%s "$out" 2>/dev/null || echo 0)" -ge 392 ]]; then
+    raw="$(od -An -v -tu8 -j 376 -N 16 "$out" 2>/dev/null | xargs || true)"
+    read -r -a words <<< "$raw"
+    local -a withdrawals_root_labels=(
+      wd_root_status
+      wd_root_valid
+    )
+    for i in "${!withdrawals_root_labels[@]}"; do
+      value="${words[$i]:-?}"
+      dbg="${dbg:+$dbg }${withdrawals_root_labels[$i]}=$value"
+    done
+  fi
   echo "$dbg"
 }
 


### PR DESCRIPTION
Rebased from #8396 to resolve conflict with the BlockVerdictDataSection refactor.

## Summary
- compute the indexed withdrawals trie root from SSZ withdrawal descriptors before filling stateless block verdict params
- feed the computed root into header reconstruction and revalidate it in block_verdict with the existing indexed withdrawals-root helper
- expose withdrawals-root status/valid words in the EEST verdict debug output
- data-section labels (svf_withdrawals_root, bv_withdrawals_root_{status,valid}, hewr_*, bvwri_*, itr_*) placed in BlockVerdictDataSection.lean

Authored by @pirapira; implemented by Codex.