### PR TITLE
fix(eip4844): decode versioned hash blob txs

### DIFF
--- a/EvmAsm/Codegen/Programs/TxBlobGas.lean
+++ b/EvmAsm/Codegen/Programs/TxBlobGas.lean
@@ -354,12 +354,9 @@ def sszTxListVersionedHashesMatchFunction : String :=
   "  bgtu t1, s11, .Ltvhm_tx_fail\n" ++
   "  add t0, s6, s10; add s10, t0, t1      # inner ptr\n" ++
   "  sub s11, s11, t1                      # inner len\n" ++
-  "  la a2, tvhm_struct\n" ++
-  ".Ltvhm_zinit:\n" ++
-  "  beqz t1, .Ltvhm_zdone\n" ++
-  "  j .Ltvhm_zinit\n" ++
-  ".Ltvhm_zdone:\n" ++
   "  mv a0, s10; mv a1, s11; la a2, tvhm_struct\n" ++
+  "  jal ra, tx_eip4844_decode\n" ++
+  "  bnez a0, .Ltvhm_tx_fail\n" ++
   "  la t0, tvhm_struct\n" ++
   "  lwu t1, 168(t0); lwu t2, 172(t0)\n" ++
   "  add s10, s10, t1             # blob hash list ptr\n" ++
@@ -441,9 +438,19 @@ def ziskSszTxListVersionedHashesMatchPrologue : String :=
   "  j .Ltvhmp_done\n" ++
   bgvU32leFunction ++ "\n" ++
   txTypeDispatchFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  rlpFieldToU256BeFunction ++ "\n" ++
+  txEip4844DecodeFunction ++ "\n" ++
   sszTxListVersionedHashesMatchFunction ++ "\n" ++
   ".Ltvhmp_done:"
 def ziskSszTxListVersionedHashesMatchDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n  .zero 8\n" ++
+  "rfu_length:\n  .zero 8\n" ++
+  "t48_offset:\n  .zero 8\n" ++
+  "t48_length:\n  .zero 8\n" ++
   "tvhm_tx_type:\n  .zero 8\n" ++
   "tvhm_inner_off:\n  .zero 8\n" ++
   "tvhm_blob_count:\n  .zero 8\n" ++


### PR DESCRIPTION
## Summary
- remove the nonterminating type-3 path in `ssz_tx_list_versioned_hashes_match`
- call `tx_eip4844_decode` before reading `blob_versioned_hashes` offsets
- extend the standalone versioned-hashes probe closure with the decoder dependencies

## Verification
- `lake build EvmAsm.Codegen.Programs.TxBlobGas codegen`
- `scripts/codegen-zisk-ssz-tx-list-versioned-hashes-match-check.sh`
- `scripts/codegen-eest-stateless-check.sh --skip 7921 --limit 1 --random --seed 318164544 --jobs 1 --max-failures 1 --show-passes --no-verdict-debug` now reaches semantic `FAIL [root/----/tail]` under the existing 1B default instead of `BUDGET(steps)`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/TxBlobGas.lean` (no matches)
- `git diff --check`
- `lake build` (known `LeanRV64D/RiscvExtras.lean` deprecation warning only)

Bead: evm-asm-twk3n.
Follow-up semantic beads: evm-asm-fob2w.1, evm-asm-fob2w.2.

Authored by @pirapira; implemented by Codex.