### PR TITLE
fix(stateless): validate covered payload block hashes

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -23,6 +23,7 @@ import EvmAsm.Codegen.Programs.MptInsertAcc
 import EvmAsm.Codegen.Programs.MptDeleteAcc
 import EvmAsm.Codegen.Programs.MptStateRootIns
 import EvmAsm.Codegen.Programs.HeadersKeccak
+import EvmAsm.Codegen.Programs.Header
 import EvmAsm.Codegen.Programs.StateCompose
 import EvmAsm.Codegen.Programs.AccountFieldGetters
 import EvmAsm.Codegen.Programs.BalCodePreimages
@@ -39,6 +40,7 @@ import EvmAsm.Codegen.Programs.BlockVerdictGasResults
 import EvmAsm.Codegen.Programs.BlockVerdictTransactions
 import EvmAsm.Codegen.Programs.MptEncodeLeafBranch
 import EvmAsm.Codegen.Programs.TxBlobGas
+import EvmAsm.Codegen.Programs.TxRoot
 import EvmAsm.Codegen.Programs.BlockAccessListHash
 
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransfer
@@ -306,6 +308,15 @@ def blockVerdictFunction : String :=
   "  ld a0, 0(s0); ld a1, 32(s0); ld a2, 40(s0); ld a3, 48(s0); ld a4, 56(s0); ld a7, 96(s0)\n" ++
   "  la a5, sv_this_rlp; la a6, sv_this_rlp_len\n" ++
   "  jal ra, block_header_ssz_to_rlp\n" ++
+  "  la t0, bv_block_hash_check_enabled; ld t0, 0(t0); beqz t0, .Lbv_block_hash_ok\n" ++
+  "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0); la a2, bv_block_hash\n" ++
+  "  jal ra, block_hash_from_header\n" ++
+  "  la t0, bv_block_hash; ld t1, 0(s0); addi t1, t1, 472; li t2, 32\n" ++
+  ".Lbv_block_hash_cmp:\n" ++
+  "  beqz t2, .Lbv_block_hash_ok\n" ++
+  "  lbu t3, 0(t0); lbu t4, 0(t1); bne t3, t4, .Lbv_block_hash_mismatch\n" ++
+  "  addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1; j .Lbv_block_hash_cmp\n" ++
+  ".Lbv_block_hash_ok:\n" ++
   "  ld a0, 0(s0); la t0, sv_this_rlp_len; ld a1, 0(t0); mv a2, s3\n" ++
   "  jal ra, block_rlp_rebuilt_size\n" ++
   "  bnez a0, .Lbv_block_rlp_parse_fail\n" ++
@@ -623,6 +634,8 @@ def blockVerdictFunction : String :=
   "  li t0, 27; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_blob_gas_used_fail:\n" ++
   "  li t0, 33; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
+  ".Lbv_block_hash_mismatch:\n" ++
+  "  li t0, 31; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_zero:\n" ++
   "  li a0, 0\n" ++
   ".Lbv_ret:\n" ++
@@ -704,13 +717,44 @@ def statelessVerdictV2Function : String :=
   "  mv a0, s0; la a1, svf_bal_hash\n" ++
   "  jal ra, block_access_list_hash\n" ++
   "  bnez a0, .Lv2_bal_hash_fail\n" ++
+  "  la t0, bv_block_hash_check_enabled; sd zero, 0(t0)\n" ++
+  "  la t0, svf_payload; ld t3, 0(t0)\n" ++
+  "  addi a0, t3, 504; jal ra, bgv_u32le; mv t4, a0     # transactions_offset\n" ++
+  "  la t0, svf_payload; ld t3, 0(t0)\n" ++
+  "  addi a0, t3, 508; jal ra, bgv_u32le; mv t5, a0     # withdrawals_offset\n" ++
+  "  bltu t5, t4, .Lv2_header_roots_done\n" ++
+  "  sub t6, t5, t4                                      # tx list byte length\n" ++
+  "  beqz t6, .Lv2_tx_root_empty\n" ++
+  "  la t0, svf_payload; ld t3, 0(t0); add t2, t3, t4    # tx list ptr\n" ++
+  "  mv a0, t2; jal ra, bgv_u32le                        # first SSZ offset\n" ++
+  "  li t0, 4; bne a0, t0, .Lv2_header_roots_done\n" ++
+  "  li t0, 4; bltu t6, t0, .Lv2_header_roots_done\n" ++
+  "  la t0, svf_payload; ld t3, 0(t0); add t2, t3, t4\n" ++
+  "  addi a0, t2, 4; addi a1, t6, -4; la a2, svf_transactions_root\n" ++
+  "  jal ra, mpt_one_leaf_root_indexed\n" ++
+  "  j .Lv2_tx_root_ok\n" ++
+  ".Lv2_tx_root_empty:\n" ++
+  "  la a0, svf_transactions_root; la a1, aps_empty_root; li a2, 32\n" ++
+  "  jal ra, mset_memcpy\n" ++
+  ".Lv2_tx_root_ok:\n" ++
+  "  la t0, svf_payload; ld t3, 0(t0)\n" ++
+  "  addi a0, t3, 508; jal ra, bgv_u32le; mv t5, a0     # withdrawals_offset\n" ++
+  "  la t0, svf_payload; ld t3, 0(t0)\n" ++
+  "  addi a0, t3, 528; jal ra, bgv_u32le; mv t6, a0     # block_access_list_offset\n" ++
+  "  bltu t6, t5, .Lv2_header_roots_done\n" ++
+  "  sub t6, t6, t5                                      # withdrawals byte length\n" ++
+  "  bnez t6, .Lv2_header_roots_done\n" ++
+  "  la a0, svf_withdrawals_root; la a1, aps_empty_root; li a2, 32\n" ++
+  "  jal ra, mset_memcpy\n" ++
+  "  li t0, 1; la t1, bv_block_hash_check_enabled; sd t0, 0(t1)\n" ++
+  ".Lv2_header_roots_done:\n" ++
   "  la t1, sv_params\n" ++
   "  la t0, svf_payload;        ld t0, 0(t0); sd t0, 0(t1)\n" ++
   "  la t0, svf_parent_rlp;     ld t0, 0(t0); sd t0, 8(t1)\n" ++
   "  la t0, svf_parent_rlp_len; ld t0, 0(t0); sd t0, 16(t1)\n" ++
   "  la t0, svf_parent_sr;      sd t0, 24(t1)\n" ++
-  "  la t0, svf_zero32;         sd t0, 32(t1)\n" ++
-  "  la t0, svf_zero32;         sd t0, 40(t1)\n" ++
+  "  la t0, svf_transactions_root; sd t0, 32(t1)\n" ++
+  "  la t0, svf_withdrawals_root;  sd t0, 40(t1)\n" ++
   "  addi t0, s0, 24;           sd t0, 48(t1)\n" ++
   "  la t0, erh_requests_hash;  sd t0, 56(t1)\n" ++
   "  la t0, svf_bal_hash;       sd t0, 96(t1)\n" ++
@@ -865,6 +909,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   mptInsertWalkDbFunction ++ "\n" ++
   mptInsertAccFunction ++ "\n" ++
   mptStateRootInsFunction ++ "\n" ++
+  mptOneLeafRootIndexedFunction ++ "\n" ++
   withdrawalsStateRootFunction ++ "\n" ++
   validateHeaderBasicFunction ++ "\n" ++
   checkGasLimitFunction ++ "\n" ++
@@ -884,6 +929,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   blockRlpRebuiltSizeFunction ++ "\n" ++
   bahU32leFunction ++ "\n" ++
   blockAccessListHashFunction ++ "\n" ++
+  blockHashFromHeaderFunction ++ "\n" ++
   executionRequestsHashFunction ++ "\n" ++
   step2VerdictFunction ++ "\n" ++
   headerExtractStateRootFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -22,6 +22,11 @@ def ziskStatelessVerdictV2DataSection : String :=
   executionRequestsHashDataSection ++ "\n" ++
   ".balign 32\n" ++
   "svf_bal_hash:\n  .zero 32\n" ++
+  "svf_transactions_root:\n  .zero 32\n" ++
+  "svf_withdrawals_root:\n  .zero 32\n" ++
+  "bv_block_hash:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "bv_block_hash_check_enabled:\n  .zero 8\n" ++
   ".balign 8\n" ++
   "bah_bal_start:\n  .zero 8\n" ++
   ".balign 8\n" ++
@@ -34,6 +39,9 @@ def ziskStatelessVerdictV2DataSection : String :=
   "sltr_hp_buf:\n  .zero 1024\n" ++
   "sltr_payload_buf:\n  .zero 16384\n" ++
   "sltr_node_buf:\n  .zero 16384\n" ++
+  "mtoli_nibbles:\n  .zero 8\n" ++
+  "mtoli_leaf_len:\n  .zero 8\n" ++
+  "mtoli_leaf_buf:\n  .zero 16384\n" ++
   ".balign 32\n" ++
   "srss_key:\n  .zero 32\n" ++
   ".balign 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
@@ -72,6 +72,7 @@ def statelessVerdictV2GuestClosure : String :=
   mptInsertWalkDbFunction ++ "\n" ++
   mptInsertAccFunction ++ "\n" ++
   mptStateRootInsFunction ++ "\n" ++
+  mptOneLeafRootIndexedFunction ++ "\n" ++
   withdrawalsStateRootFunction ++ "\n" ++
   validateHeaderBasicFunction ++ "\n" ++
   checkGasLimitFunction ++ "\n" ++
@@ -91,6 +92,7 @@ def statelessVerdictV2GuestClosure : String :=
   blockRlpRebuiltSizeFunction ++ "\n" ++
   bahU32leFunction ++ "\n" ++
   blockAccessListHashFunction ++ "\n" ++
+  blockHashFromHeaderFunction ++ "\n" ++
   executionRequestsHashFunction ++ "\n" ++
   step2VerdictFunction ++ "\n" ++
   headerExtractStateRootFunction ++ "\n" ++


### PR DESCRIPTION
## Summary
- compute empty or single-transaction header roots before rebuilding the payload header
- compare keccak256(rlp(header)) against ExecutionPayload.block_hash when transactions and withdrawals roots are covered
- keep unsupported multi-transaction or non-empty-withdrawal root cases on the prior non-enforcing path to avoid false rejects

Bead: evm-asm-wplgx.3.

## Checks
- lake build EvmAsm.Codegen.Programs.BlockVerdict EvmAsm.Codegen.Programs.BlockVerdictV2 codegen
- scripts/codegen-stateless-link-check.sh --no-build
- scripts/codegen-eest-stateless-check.sh --skip 301 --limit 1 --random --seed 868113405 --jobs 1 --max-failures 1 --show-passes
- mutated generated row-302 input at ExecutionPayload.block_hash[0]; reran stateless_guest.elf; observed success_byte=0
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/BlockVerdict.lean EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean EvmAsm/Codegen/Programs/BlockVerdictV2.lean
- git diff --check
- lake build (passes with existing LeanRV64D/RiscvExtras.lean deprecation warning)

Authored by @pirapira; implemented by Codex.