### PR TITLE
fix(eest): share Amsterdam system tx constants

### DIFF
--- a/EvmAsm/Codegen/Programs/AmsterdamSystemTx.lean
+++ b/EvmAsm/Codegen/Programs/AmsterdamSystemTx.lean
@@ -1,0 +1,62 @@
+/-
+  EvmAsm.Codegen.Programs.AmsterdamSystemTx
+
+  Shared constants for Amsterdam system transactions.  These mirror
+  execution-specs `src/ethereum/forks/amsterdam/fork.py` and `vm/gas.py`:
+  `process_unchecked_system_transaction` constructs a SYSTEM-address call with
+  a fixed 30M regular gas budget and a bounded state-gas reservoir sized for
+  16 storage-set writes.  The concrete system-contract children (EIP-4788,
+  EIP-2935, EIP-7002, EIP-7251) should import this module instead of
+  open-coding these numbers.
+-/
+
+namespace EvmAsm.Codegen
+
+/-- execution-specs Amsterdam `SYSTEM_TRANSACTION_GAS`. -/
+def amsterdamSystemTransactionGas : Nat := 30000000
+
+/-- execution-specs Amsterdam `COST_PER_STATE_BYTE`. -/
+def amsterdamCostPerStateByte : Nat := 1530
+
+/-- execution-specs Amsterdam `STATE_BYTES_PER_STORAGE_SET`. -/
+def amsterdamStateBytesPerStorageSet : Nat := 64
+
+/-- execution-specs Amsterdam `STATE_BYTES_PER_NEW_ACCOUNT`. -/
+def amsterdamStateBytesPerNewAccount : Nat := 120
+
+/-- execution-specs Amsterdam `SYSTEM_MAX_SSTORES_PER_CALL`. -/
+def amsterdamSystemMaxSstoresPerCall : Nat := 16
+
+/-- State gas charged for one zero-to-nonzero storage set. -/
+def amsterdamStorageSetStateGas : Nat :=
+  amsterdamStateBytesPerStorageSet * amsterdamCostPerStateByte
+
+/-- State gas precharged for one new-account creation. -/
+def amsterdamNewAccountStateGas : Nat :=
+  amsterdamStateBytesPerNewAccount * amsterdamCostPerStateByte
+
+/-- State-gas reservoir passed to each Amsterdam system transaction. -/
+def amsterdamSystemStateGasReservoir : Nat :=
+  amsterdamStorageSetStateGas * amsterdamSystemMaxSstoresPerCall
+
+/-- Assembly `li` helper for the per-storage-set state gas constant. -/
+def liAmsterdamStorageSetStateGas (reg : String) : String :=
+  "  li " ++ reg ++ ", " ++ toString amsterdamStorageSetStateGas ++ "\n"
+
+/-- Assembly `li` helper for the new-account intrinsic state gas constant. -/
+def liAmsterdamNewAccountStateGas (reg : String) : String :=
+  "  li " ++ reg ++ ", " ++ toString amsterdamNewAccountStateGas ++ "\n"
+
+/-- Assembly `li` helper for the system transaction regular gas budget. -/
+def liAmsterdamSystemTransactionGas (reg : String) : String :=
+  "  li " ++ reg ++ ", " ++ toString amsterdamSystemTransactionGas ++ "\n"
+
+/-- Assembly `li` helper for the system transaction state-gas reservoir. -/
+def liAmsterdamSystemStateGasReservoir (reg : String) : String :=
+  "  li " ++ reg ++ ", " ++ toString amsterdamSystemStateGasReservoir ++ "\n"
+
+#guard amsterdamStorageSetStateGas = 97920
+#guard amsterdamNewAccountStateGas = 183600
+#guard amsterdamSystemStateGasReservoir = 1566720
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BlockVerdictGasGate.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictGasGate.lean
@@ -10,6 +10,7 @@ import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.TxExtract
 import EvmAsm.Codegen.Programs.IntrinsicGas
+import EvmAsm.Codegen.Programs.AmsterdamSystemTx
 
 namespace EvmAsm.Codegen
 
@@ -105,7 +106,8 @@ def eip8037TxGasGateFunction : String :=
   "  jal ra, rlp_list_nth_item\n" ++
   "  bnez a0, .Lesub_next_slot\n" ++
   "  la t0, bsg_value_len; ld t1, 0(t0); beqz t1, .Lesub_next_slot\n" ++
-  "  ld t2, 0(s3); li t3, 97920; add t2, t2, t3; sd t2, 0(s3)\n" ++
+  "  ld t2, 0(s3);" ++ liAmsterdamStorageSetStateGas "t3" ++
+  "  add t2, t2, t3; sd t2, 0(s3)\n" ++
   ".Lesub_next_slot:\n" ++
   "  addi s6, s6, 1; j .Lesub_slot_loop\n" ++
   ".Lesub_next_acct:\n" ++
@@ -268,7 +270,7 @@ def eip8037TxGasGateFunction : String :=
   "  # Non-creation txs have zero intrinsic state here.\n" ++
   "  li t6, 0\n" ++
   "  la t0, bsg_to_len; ld t2, 0(t0); bnez t2, .Letg_intrinsic_done\n" ++
-  "  li t6, 183600\n" ++
+  liAmsterdamNewAccountStateGas "t6" ++
   ".Letg_intrinsic_done:\n" ++
   "  li t2, 0\n" ++
   "  bltu t1, t6, .Letg_regular_have\n" ++

--- a/EvmAsm/Codegen/Programs/SystemWrites.lean
+++ b/EvmAsm/Codegen/Programs/SystemWrites.lean
@@ -3,7 +3,8 @@
 
   system_write_descriptors (bead evm-asm-fhsxz.2.4.2.5, steps a/b): derive the
   per-block SYSTEM-contract storage writes from the ExecutionPayload — the two
-  system calls every Amsterdam block runs at block start (before withdrawals):
+  modeled startup effects of the two unchecked system calls every Amsterdam
+  block runs at block start (before withdrawals):
 
     * EIP-2935 (history contract 0x0000…2935):
         slot  = (block_number - 1) % 8192
@@ -23,11 +24,14 @@
   history buffer before encoding the 32-byte big-endian storage key.
 
   Outputs feed account_apply_storage_slot (one per system contract) in the
-  verdict's state recompute.
+  verdict's state recompute.  Shared Amsterdam system-transaction gas and
+  reservoir constants live in AmsterdamSystemTx.lean; this helper is the current
+  direct-descriptor shortcut for the EIP-4788/EIP-2935 startup calls.
 -/
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.AmsterdamSystemTx
 
 namespace EvmAsm.Codegen
 


### PR DESCRIPTION
## Summary
- add a shared Amsterdam system transaction constants module matching execution-specs gas/state-gas values
- route existing state-gas assembly literals through named helpers
- document that current EIP-4788/EIP-2935 system writes are direct-descriptor shortcuts for the follow-up system-call work

Refs bead evm-asm-g8zeq.4.2.

## Verification
- lake build EvmAsm.Codegen.Programs.BlockVerdictGasGate
- lake build EvmAsm.Codegen.Programs.SystemWrites
- lake build EvmAsm.Codegen.Programs
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build (passes with existing LeanRV64D/RiscvExtras.lean deprecation warning)

Authored by @pirapira; implemented by Codex.