### PR TITLE
fix(eest): grow MPT buffers for large tx roots

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -573,9 +573,9 @@ def ziskStatelessVerdictV2DataSection : String :=
   ".balign 8\n" ++
   "ins_ref2:\n  .zero 64\n" ++
   ".balign 8\n" ++
-  "ins_node:\n  .zero 2048\n" ++
+  "ins_node:\n  .zero 131072\n" ++
   ".balign 8\n" ++
-  "ins_node2:\n  .zero 2048\n" ++
+  "ins_node2:\n  .zero 131072\n" ++
   ".balign 8\n" ++
   "ins_empty_branch:\n" ++
   "  .byte 0xd1,0x80,0x80,0x80,0x80,0x80,0x80,0x80\n" ++

--- a/EvmAsm/Codegen/Programs/MptSet.lean
+++ b/EvmAsm/Codegen/Programs/MptSet.lean
@@ -649,7 +649,7 @@ def ziskMptSetDataSection : String :=
   ".balign 8\n" ++
   "mlnen_hp_buf:\n  .zero 1024\n" ++
   ".balign 8\n" ++
-  "mlnen_payload_buf:\n  .zero 16384\n" ++
+  "mlnen_payload_buf:\n  .zero 131072\n" ++
   ".balign 8\n" ++
   "mset_span_start:\n  .zero 8\n" ++
   "mset_span_size:\n  .zero 8\n" ++


### PR DESCRIPTION
## Summary

- Grow the MPT leaf payload scratch used by stateless transaction-root computation from 16 KiB to 128 KiB.
- Grow stateless MPT insert node buffers from 2 KiB to 128 KiB.
- This fixes the EIP-7976 type-4 row 1295 ziskemu panic introduced by transaction-root computation for large transactions.

## Context

A git bisect identified `1743d7f50cadf271a8e0e89180bed36ec6bf0673` (`fix(eest): compute transaction root in block verdict`) as the first bad commit for the row 1295 panic. The failing row has a ~63 KiB input, and transaction-root computation encodes the transaction as an MPT leaf value. The old 16 KiB `mlnen_payload_buf` and 2 KiB `ins_node`/`ins_node2` arenas were too small, corrupting later pointers and producing a ziskemu `Mem::write_silent()` panic at `0x0101010101010101`.

The generated ELF after this change has `.data` size `0x1aa73370`, still below `.sszscratch` at `0xbf500000`.

## Verification

- `lake build codegen`
- `scripts/codegen-eest-stateless-check.sh --skip 1294 --limit 1 --random --seed 1038362722 --jobs 1 --max-failures 1 --quiet-passes`
  - result: `full match: 1`, `errored: 0`, `fail: 0`
- `scripts/check-file-size.sh`
- `git diff --check`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean EvmAsm/Codegen/Programs/MptSet.lean`

Bead: `evm-asm-7hiez`

Authored by @pirapira; implemented by Codex.
