### PR TITLE
fix(eest): reset BAL storage scratch per account

### DIFF
--- a/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
@@ -123,6 +123,11 @@ def balAccountApplyPostFieldsFunction : String :=
   "  mv s6, s0                   # current account ptr\n" ++
   "  mv s7, s1                   # current account len\n" ++
   "  la t0, baap_fail_code; sd zero, 0(t0)\n" ++
+  "  la t0, baap_storage_empty_flag; sd zero, 0(t0)\n" ++
+  "  la t0, baap_storage_delete_flag; sd zero, 0(t0)\n" ++
+  "  la t0, baap_storage_delete_count; sd zero, 0(t0)\n" ++
+  "  la t0, baap_storage_delete_index; sd zero, 0(t0)\n" ++
+  "  la t0, baap_sc_out_count; sd zero, 0(t0)\n" ++
   "  mv a0, s2; mv a1, s3\n" ++
   "  la a2, baap_bal; la a3, baap_bal_len; la a4, baap_nonce; la a5, baap_nonce_len\n" ++
   "  jal ra, bal_account_post_fields\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -573,9 +573,9 @@ def ziskStatelessVerdictV2DataSection : String :=
   ".balign 8\n" ++
   "ins_ref2:\n  .zero 64\n" ++
   ".balign 8\n" ++
-  "ins_node:\n  .zero 2048\n" ++
+  "ins_node:\n  .zero 131072\n" ++
   ".balign 8\n" ++
-  "ins_node2:\n  .zero 2048\n" ++
+  "ins_node2:\n  .zero 131072\n" ++
   ".balign 8\n" ++
   "ins_empty_branch:\n" ++
   "  .byte 0xd1,0x80,0x80,0x80,0x80,0x80,0x80,0x80\n" ++

--- a/EvmAsm/Codegen/Programs/MptSet.lean
+++ b/EvmAsm/Codegen/Programs/MptSet.lean
@@ -649,7 +649,7 @@ def ziskMptSetDataSection : String :=
   ".balign 8\n" ++
   "mlnen_hp_buf:\n  .zero 1024\n" ++
   ".balign 8\n" ++
-  "mlnen_payload_buf:\n  .zero 16384\n" ++
+  "mlnen_payload_buf:\n  .zero 131072\n" ++
   ".balign 8\n" ++
   "mset_span_start:\n  .zero 8\n" ++
   "mset_span_size:\n  .zero 8\n" ++


### PR DESCRIPTION
## Summary

- grow the shared MPT leaf/node scratch buffers used by stateless block verdict so transaction-root computation can encode large typed transactions without corrupting later replay state
- reset BAL account storage scratch globals at `bal_account_apply_post_fields` entry so modeled system-write replay cannot leak stale storage counters/flags into later BAL rows
- fixes the row 20449 BLS G1MSM state-root mismatch after the transaction-root buffer issue is handled
- also fixes row 18551 `stack_overflow_m1_push`, which had the same descriptor-4 state-root replay failure shape on `main`

## Notes

The user bisected the earlier crash/corruption class to `1743d7f50cadf271a8e0e89180bed36ec6bf0673` (`fix(eest): compute transaction root in block verdict`). That commit made transaction-root MPT leaf encoding part of block verdict, and large type-4 transaction rows can exceed the old 16 KiB/2 KiB scratch buffers.

After the buffer growth, row 20449 still produced a clean semantic mismatch. A descriptor-hash diagnostic showed descriptors 0-3 matched execution-specs, while descriptor 4 had the correct path/len/mode but a different post-account value hash. The standalone BAL account applier matched execution-specs for that same account, so the mismatch came from stale shared BAAP scratch state left by prior modeled system-write replay in block verdict.

Row 18551 (`stStackTests/stack_overflow_m1_push`, rerun_skip=18550) fails on `main` with `sri_index=4 sri_mode=1 sri_status=2`, then passes on this PR branch, confirming it is covered by the same state-root replay fix.

## Tests

- `rtk lake build codegen`
- `rtk scripts/codegen-eest-stateless-check.sh --skip 20448 --limit 1 --random --seed 1038362722 --jobs 1 --max-failures 1 --quiet-passes`
- `rtk scripts/codegen-eest-stateless-check.sh --skip 1294 --limit 1 --random --seed 1038362722 --jobs 1 --max-failures 1 --quiet-passes`
- `rtk scripts/codegen-eest-stateless-check.sh --skip 18550 --limit 1 --random --seed 1038362722 --jobs 1 --max-failures 1 --quiet-passes`
