### PR TITLE
fix(eest): guard oversized MPT leaf encoding

### DIFF
--- a/EvmAsm/Codegen/Programs/MptDeleteAcc.lean
+++ b/EvmAsm/Codegen/Programs/MptDeleteAcc.lean
@@ -105,6 +105,7 @@ def mptDeleteAccFunction : String :=
   "  la a0, mdacc_collapsed_path; mv a1, zero\n" ++
   "  la a4, mset_node; la a5, mset_node_len\n" ++
   "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  bnez a0, .Lmdacc_fail\n" ++
   "  la t0, mset_node_len; ld s4, 0(t0)\n" ++
   "  la a0, mset_node; mv a1, s4\n" ++
   "  jal ra, node_db_append\n" ++
@@ -155,6 +156,7 @@ def mptDeleteAccFunction : String :=
   "  la a0, mdacc_collapsed_path; la t0, mdacc_leaf_value_ptr; ld a2, 0(t0); la t0, mdacc_leaf_value_len; ld a3, 0(t0)\n" ++
   "  la a4, mset_node; la a5, mset_node_len\n" ++
   "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  bnez a0, .Lmdacc_fail\n" ++
   "  la t0, mset_node_len; ld s4, 0(t0)\n" ++
   "  la a0, mset_node; mv a1, s4\n" ++
   "  jal ra, node_db_append\n" ++
@@ -335,6 +337,7 @@ def mptDeleteAccFunction : String :=
   "  la a0, mdacc_collapsed_path; la t0, mdacc_leaf_value_ptr; ld a2, 0(t0); la t0, mdacc_leaf_value_len; ld a3, 0(t0)\n" ++
   "  la a4, mset_node; la a5, mset_node_len\n" ++
   "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  bnez a0, .Lmdacc_fail\n" ++
   "  la t0, mset_node_len; ld s4, 0(t0)\n" ++
   "  la a0, mset_node; mv a1, s4\n" ++
   "  jal ra, node_db_append\n" ++

--- a/EvmAsm/Codegen/Programs/MptEncodeLeafBranch.lean
+++ b/EvmAsm/Codegen/Programs/MptEncodeLeafBranch.lean
@@ -14,6 +14,15 @@ namespace EvmAsm.Codegen
 open EvmAsm.Rv64
 open EvmAsm.Rv64.Program
 
+/-! Conservative bound for `mlnen_payload_buf`.
+
+    The helper RLP-encodes `hp_path || value` into a fixed 16 KiB scratch.
+    Keep the accepted raw value below that capacity with enough room for the
+    value's own RLP prefix and the small HP field. Larger values need a
+    streaming/large-buffer path; returning failure is better than corrupting
+    adjacent globals. -/
+def mptLeafNodeMaxScratchValueBytes : Nat := 16000
+
 /-! ## mpt_leaf_node_encode_from_nibbles -- PR-K168
 
     Encode an MPT leaf node directly from a *nibble* path (one
@@ -66,6 +75,8 @@ def mptLeafNodeEncodeFromNibblesFunction : String :=
   "  bgeu s4, t0, .Lmlnen_fail\n" ++
   "  li t0, 0xbffffff8\n" ++
   "  bgtu s5, t0, .Lmlnen_fail\n" ++
+  "  li t0, " ++ toString mptLeafNodeMaxScratchValueBytes ++ "\n" ++
+  "  bgtu s3, t0, .Lmlnen_fail\n" ++
   "  # ---- Step 1: HP-encode (leaf=true) ----\n" ++
   "  mv a0, s0; mv a1, s1; li a2, 1\n" ++
   "  la a3, mlnen_hp_buf\n" ++

--- a/EvmAsm/Codegen/Programs/MptInsert.lean
+++ b/EvmAsm/Codegen/Programs/MptInsert.lean
@@ -93,6 +93,7 @@ def mptInsertFunction : String :=
   "  mv a0, s1; mv a1, s2; mv a2, s3; mv a3, s4\n" ++
   "  la a4, ins_node; la a5, ins_node_len\n" ++
   "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  bnez a0, .Lins_fail\n" ++
   "  la a0, ins_node; la t0, ins_node_len; ld a1, 0(t0); mv a2, s5\n" ++
   "  jal ra, zkvm_keccak256\n" ++
   "  li a0, 0; j .Lins_ret\n" ++
@@ -115,6 +116,7 @@ def mptInsertFunction : String :=
   "  la t0, ins_lv_ptr; ld a2, 0(t0); la t0, ins_lv_len; ld a3, 0(t0)\n" ++
   "  la a4, ins_node; la a5, ins_node_len\n" ++
   "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  bnez a0, .Lins_fail\n" ++
   "  la a0, ins_node; la t0, ins_node_len; ld a1, 0(t0)\n" ++
   "  la a2, ins_ref; la a3, ins_ref_len\n" ++
   "  jal ra, mpt_node_slot_encode\n" ++
@@ -125,6 +127,7 @@ def mptInsertFunction : String :=
   "  mv a2, s3; mv a3, s4\n" ++
   "  la a4, ins_node2; la a5, ins_node2_len\n" ++
   "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  bnez a0, .Lins_fail\n" ++
   "  la a0, ins_node2; la t0, ins_node2_len; ld a1, 0(t0)\n" ++
   "  la a2, ins_ref2; la a3, ins_ref2_len\n" ++
   "  jal ra, mpt_node_slot_encode\n" ++
@@ -219,6 +222,7 @@ def mptInsertFunction : String :=
   "  mv a2, s3; mv a3, s4\n" ++
   "  la a4, ins_node2; la a5, ins_node2_len\n" ++
   "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  bnez a0, .Lins_fail\n" ++
   "  la a0, ins_node2; la t0, ins_node2_len; ld a1, 0(t0)\n" ++
   "  la a2, ins_ref2; la a3, ins_ref2_len\n" ++
   "  jal ra, mpt_node_slot_encode\n" ++
@@ -259,6 +263,7 @@ def mptInsertFunction : String :=
   "  mv a2, s3; mv a3, s4\n" ++
   "  la a4, ins_node; la a5, ins_node_len\n" ++
   "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  bnez a0, .Lins_fail\n" ++
   "  # leaf_ref = node_slot_encode(leaf).\n" ++
   "  la a0, ins_node; la t0, ins_node_len; ld a1, 0(t0)\n" ++
   "  la a2, ins_ref; la a3, ins_ref_len\n" ++

--- a/EvmAsm/Codegen/Programs/MptInsertAcc.lean
+++ b/EvmAsm/Codegen/Programs/MptInsertAcc.lean
@@ -67,6 +67,7 @@ def mptInsertAccFunction : String :=
   "  mv a0, s1; mv a1, s2; mv a2, s3; mv a3, s4\n" ++
   "  la a4, ins_node; la a5, ins_node_len\n" ++
   "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  bnez a0, .Lacc_fail\n" ++
   "  la a0, ins_node; la t0, ins_node_len; ld a1, 0(t0)\n" ++
   "  jal ra, node_db_append\n" ++
   "  la a0, ins_node; la t0, ins_node_len; ld a1, 0(t0); mv a2, s5\n" ++
@@ -87,6 +88,7 @@ def mptInsertAccFunction : String :=
   "  la t0, ins_lv_ptr; ld a2, 0(t0); la t0, ins_lv_len; ld a3, 0(t0)\n" ++
   "  la a4, ins_node; la a5, ins_node_len\n" ++
   "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  bnez a0, .Lacc_fail\n" ++
   "  la a0, ins_node; la t0, ins_node_len; ld a1, 0(t0)\n" ++
   "  jal ra, node_db_append\n" ++
   "  la a0, ins_node; la t0, ins_node_len; ld a1, 0(t0)\n" ++
@@ -98,6 +100,7 @@ def mptInsertAccFunction : String :=
   "  mv a2, s3; mv a3, s4\n" ++
   "  la a4, ins_node2; la a5, ins_node2_len\n" ++
   "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  bnez a0, .Lacc_fail\n" ++
   "  la a0, ins_node2; la t0, ins_node2_len; ld a1, 0(t0)\n" ++
   "  jal ra, node_db_append\n" ++
   "  la a0, ins_node2; la t0, ins_node2_len; ld a1, 0(t0)\n" ++
@@ -197,6 +200,7 @@ def mptInsertAccFunction : String :=
   "  mv a2, s3; mv a3, s4\n" ++
   "  la a4, ins_node2; la a5, ins_node2_len\n" ++
   "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  bnez a0, .Lacc_fail\n" ++
   "  la a0, ins_node2; la t0, ins_node2_len; ld a1, 0(t0)\n" ++
   "  jal ra, node_db_append\n" ++
   "  la a0, ins_node2; la t0, ins_node2_len; ld a1, 0(t0)\n" ++
@@ -242,6 +246,7 @@ def mptInsertAccFunction : String :=
   "  mv a2, s3; mv a3, s4\n" ++
   "  la a4, ins_node; la a5, ins_node_len\n" ++
   "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  bnez a0, .Lacc_fail\n" ++
   "  la a0, ins_node; la t0, ins_node_len; ld a1, 0(t0)\n" ++
   "  jal ra, node_db_append\n" ++
   "  la a0, ins_node; la t0, ins_node_len; ld a1, 0(t0)\n" ++

--- a/EvmAsm/Codegen/Programs/MptSet.lean
+++ b/EvmAsm/Codegen/Programs/MptSet.lean
@@ -529,6 +529,7 @@ def mptSetFunction : String :=
   "  la a4, mset_node\n" ++
   "  la a5, mset_node_len\n" ++
   "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  bnez a0, .Lmset_ret\n" ++
   "  la t0, mset_node_len; ld s9, 0(t0)   # current node len\n" ++
   "  # ---- current_ref = node_slot_encode(node) ----\n" ++
   "  la a0, mset_node\n" ++

--- a/EvmAsm/Codegen/Programs/MptSetAcc.lean
+++ b/EvmAsm/Codegen/Programs/MptSetAcc.lean
@@ -372,6 +372,7 @@ def mptSetAccFunction : String :=
   "  mv a2, s3; mv a3, s4\n" ++
   "  la a4, mset_node; la a5, mset_node_len\n" ++
   "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  bnez a0, .Lmacc_fail\n" ++
   "  la t0, mset_node_len; ld s9, 0(t0)\n" ++
   "  # append leaf to DB\n" ++
   "  la a0, mset_node; mv a1, s9\n" ++


### PR DESCRIPTION
## Summary
- add a conservative size guard before encoding MPT leaf values into the fixed 16 KiB leaf scratch buffer
- propagate leaf-encode failure through MPT insert/set/delete callers instead of hashing stale or corrupted buffers
- convert EEST row 12970 from top-level ziskemu ERROR(exit) into a normal guest rejection while full large transaction-root support remains tracked separately

Bead: evm-asm-0rxno
Follow-up: evm-asm-deaqj

## Verification
- lake build codegen
- lake build
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rtk scripts/codegen-eest-stateless-check.sh --skip 12969 --limit 1 --random --seed 1307548980 --jobs 1 --max-failures 1 --quiet-passes

Authored by @pirapira; implemented by Codex.