### PR TITLE
feat(eest): stream one-leaf transaction trie roots

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -953,6 +953,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   mptStateRootInsFunction ++ "\n" ++
   mptOneLeafRootIndexedFunction ++ "\n" ++
   withdrawalsStateRootFunction ++ "\n" ++
+  mptIndexedTrieRootOneLeafFunction ++ "\n" ++
   mptIndexedTrieRootSmallFunction ++ "\n" ++
   headerExtractWithdrawalsRootFunction ++ "\n" ++
   blockValidateWithdrawalsRootIndexedFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
@@ -74,6 +74,7 @@ def statelessVerdictV2GuestClosure : String :=
   mptStateRootInsFunction ++ "\n" ++
   mptOneLeafRootIndexedFunction ++ "\n" ++
   withdrawalsStateRootFunction ++ "\n" ++
+  mptIndexedTrieRootOneLeafFunction ++ "\n" ++
   mptIndexedTrieRootSmallFunction ++ "\n" ++
   headerExtractWithdrawalsRootFunction ++ "\n" ++
   blockValidateWithdrawalsRootIndexedFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/MptIndexedTrieRoot.lean
+++ b/EvmAsm/Codegen/Programs/MptIndexedTrieRoot.lean
@@ -28,6 +28,139 @@ open EvmAsm.Rv64
       index 0    -> RLP 0x80 -> nibbles [8,0]
       index 1..127 -> single byte -> nibbles [hi,lo]
 -/
+
+/-! ## mpt_indexed_trie_root_one_leaf -- streaming one-leaf transaction trie root
+
+    Specialized path for the common EIP-7934 boundary case where the transaction
+    trie has exactly one value. The general MPT insertion path materializes the
+    whole leaf node in a fixed 16 KiB scratch buffer; this helper only buffers
+    the small RLP prefixes and absorbs the large transaction bytes directly into
+    keccak.
+
+    a0 = value ptr, a1 = value len, a2 = out root ptr; returns a0 = 0. -/
+def mptIndexedTrieRootOneLeafFunction : String :=
+  "mpt_indexed_trie_root_one_leaf:\n" ++
+  "  addi sp, sp, -120\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp)\n" ++
+  "  mv s1, a0                   # value ptr\n" ++
+  "  mv s2, a1                   # value len\n" ++
+  "  mv s3, a2                   # out root\n" ++
+  "  la s0, zk3_state\n" ++
+  "  mv t0, s0; li t1, 25\n" ++
+  ".Litol_zero:\n" ++
+  "  sd zero, 0(t0); addi t0, t0, 8; addi t1, t1, -1; bnez t1, .Litol_zero\n" ++
+  "  li s4, 0                    # current keccak rate offset\n" ++
+  "  # Build the RLP encoding prefixes for leaf([8,0], value).\n" ++
+  "  li t0, 1\n" ++
+  "  bne s2, t0, .Litol_value_has_prefix\n" ++
+  "  lbu t1, 0(s1)\n" ++
+  "  li t2, 128\n" ++
+  "  bltu t1, t2, .Litol_value_single_byte\n" ++
+  ".Litol_value_has_prefix:\n" ++
+  "  li a0, 0x80\n" ++
+  "  mv a1, s2\n" ++
+  "  addi a2, sp, 88             # value prefix scratch\n" ++
+  "  jal ra, rlp_prefix_to_buffer\n" ++
+  "  mv s5, a0                   # value prefix len\n" ++
+  "  add s6, s5, s2              # encoded value item len\n" ++
+  "  j .Litol_value_len_done\n" ++
+  ".Litol_value_single_byte:\n" ++
+  "  li s5, 0                    # no RLP string prefix\n" ++
+  "  mv s6, s2                   # encoded value item len = 1\n" ++
+  ".Litol_value_len_done:\n" ++
+  "  addi a1, s6, 3              # list payload: hp item (3) + value item\n" ++
+  "  li a0, 0xc0\n" ++
+  "  addi a2, sp, 104            # list prefix scratch\n" ++
+  "  jal ra, rlp_prefix_to_buffer\n" ++
+  "  mv s7, a0                   # list prefix len\n" ++
+  "  addi t0, sp, 112            # hp item scratch\n" ++
+  "  li t1, 0x82; sb t1, 0(t0)\n" ++
+  "  li t1, 0x20; sb t1, 1(t0)\n" ++
+  "  li t1, 0x80; sb t1, 2(t0)\n" ++
+  "  addi a0, sp, 104; mv a1, s7; jal ra, .Litol_absorb\n" ++
+  "  addi a0, sp, 112; li a1, 3; jal ra, .Litol_absorb\n" ++
+  "  beqz s5, .Litol_absorb_value\n" ++
+  "  addi a0, sp, 88; mv a1, s5; jal ra, .Litol_absorb\n" ++
+  ".Litol_absorb_value:\n" ++
+  "  mv a0, s1; mv a1, s2; jal ra, .Litol_absorb\n" ++
+  "  # keccak padding at the current rate offset.\n" ++
+  "  add t0, s0, s4\n" ++
+  "  lbu t1, 0(t0); xori t1, t1, 0x01; sb t1, 0(t0)\n" ++
+  "  addi t0, s0, 135\n" ++
+  "  lbu t1, 0(t0); xori t1, t1, 0x80; sb t1, 0(t0)\n" ++
+  "  mv a0, s0\n" ++
+  "  .4byte 0x80052073\n" ++
+  "  ld t0,  0(s0); sd t0,  0(s3)\n" ++
+  "  ld t0,  8(s0); sd t0,  8(s3)\n" ++
+  "  ld t0, 16(s0); sd t0, 16(s3)\n" ++
+  "  ld t0, 24(s0); sd t0, 24(s3)\n" ++
+  "  li a0, 0\n" ++
+  ".Litol_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp)\n" ++
+  "  addi sp, sp, 120\n" ++
+  "  ret\n" ++
+  "  # Absorb a0/a1 bytes into zk3_state using LBU so unaligned SSZ values are OK.\n" ++
+  ".Litol_absorb:\n" ++
+  "  mv s8, a0\n" ++
+  "  mv s9, a1\n" ++
+  ".Litol_absorb_loop:\n" ++
+  "  beqz s9, .Litol_absorb_ret\n" ++
+  "  lbu t0, 0(s8)\n" ++
+  "  add t1, s0, s4\n" ++
+  "  lbu t2, 0(t1)\n" ++
+  "  xor t2, t2, t0\n" ++
+  "  sb t2, 0(t1)\n" ++
+  "  addi s8, s8, 1\n" ++
+  "  addi s9, s9, -1\n" ++
+  "  addi s4, s4, 1\n" ++
+  "  li t3, 136\n" ++
+  "  bne s4, t3, .Litol_absorb_loop\n" ++
+  "  mv a0, s0\n" ++
+  "  .4byte 0x80052073\n" ++
+  "  li s4, 0\n" ++
+  "  j .Litol_absorb_loop\n" ++
+  ".Litol_absorb_ret:\n" ++
+  "  ret\n" ++
+  "  # rlp_prefix_to_buffer(base, len, out): base is 0x80 or 0xc0.\n" ++
+  "rlp_prefix_to_buffer:\n" ++
+  "  li t0, 55\n" ++
+  "  bgtu a1, t0, .Lrptb_long\n" ++
+  "  add t1, a0, a1\n" ++
+  "  sb t1, 0(a2)\n" ++
+  "  li a0, 1\n" ++
+  "  ret\n" ++
+  ".Lrptb_long:\n" ++
+  "  mv t0, a1\n" ++
+  "  li t1, 0                    # len(len)\n" ++
+  ".Lrptb_count:\n" ++
+  "  addi t1, t1, 1\n" ++
+  "  srli t0, t0, 8\n" ++
+  "  bnez t0, .Lrptb_count\n" ++
+  "  addi t2, a0, 55\n" ++
+  "  add t2, t2, t1\n" ++
+  "  sb t2, 0(a2)\n" ++
+  "  li t2, 0                    # output byte index\n" ++
+  ".Lrptb_store:\n" ++
+  "  beq t2, t1, .Lrptb_done\n" ++
+  "  sub t3, t1, t2\n" ++
+  "  addi t3, t3, -1\n" ++
+  "  slli t3, t3, 3\n" ++
+  "  srl t4, a1, t3\n" ++
+  "  andi t4, t4, 255\n" ++
+  "  add t5, a2, t2\n" ++
+  "  sb t4, 1(t5)\n" ++
+  "  addi t2, t2, 1\n" ++
+  "  j .Lrptb_store\n" ++
+  ".Lrptb_done:\n" ++
+  "  addi a0, t1, 1\n" ++
+  "  ret"
+
 def mptIndexedTrieRootSmallFunction : String :=
   "mpt_indexed_trie_root_small:\n" ++
   "  addi sp, sp, -56\n" ++
@@ -39,6 +172,8 @@ def mptIndexedTrieRootSmallFunction : String :=
   "  mv s2, a2                   # out root\n" ++
   "  li t0, 129\n" ++
   "  bgeu s1, t0, .Litr_fail\n" ++
+  "  li t0, 1\n" ++
+  "  beq s1, t0, .Litr_one_leaf\n" ++
   "  li s3, 0                    # i\n" ++
   ".Litr_build_loop:\n" ++
   "  beq s3, s1, .Litr_build_done\n" ++
@@ -63,6 +198,12 @@ def mptIndexedTrieRootSmallFunction : String :=
   "  li t5, 1; sd t5, 32(s4)     # mode = insert\n" ++
   "  addi s3, s3, 1\n" ++
   "  j .Litr_build_loop\n" ++
+  ".Litr_one_leaf:\n" ++
+  "  ld a0, 0(s0)                # value ptr\n" ++
+  "  ld a1, 8(s0)                # value len\n" ++
+  "  mv a2, s2                   # out root\n" ++
+  "  jal ra, mpt_indexed_trie_root_one_leaf\n" ++
+  "  j .Litr_ret\n" ++
   ".Litr_build_done:\n" ++
   "  la a0, iw_empty_trie_root\n" ++
   "  la a1, itr_empty_witness\n" ++
@@ -133,6 +274,7 @@ def ziskMptIndexedTrieRootSmallPrologue : String :=
   mptDeleteAccFunction ++ "\n" ++
   mptInsertAccFunction ++ "\n" ++
   mptStateRootInsFunction ++ "\n" ++
+  mptIndexedTrieRootOneLeafFunction ++ "\n" ++
   mptIndexedTrieRootSmallFunction ++ "\n" ++
   ".Litrp_done:"
 

--- a/EvmAsm/Codegen/Programs/ReceiptsConsensus.lean
+++ b/EvmAsm/Codegen/Programs/ReceiptsConsensus.lean
@@ -156,6 +156,7 @@ def ziskBlockValidateReceiptsConsensusListPrologue : String :=
   mptDeleteAccFunction ++ "\n" ++
   mptInsertAccFunction ++ "\n" ++
   mptStateRootInsFunction ++ "\n" ++
+  mptIndexedTrieRootOneLeafFunction ++ "\n" ++
   mptIndexedTrieRootSmallFunction ++ "\n" ++
   headerExtractReceiptsRootFunction ++ "\n" ++
   blockValidateReceiptsRootIndexedFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/ReceiptsRootIndexed.lean
+++ b/EvmAsm/Codegen/Programs/ReceiptsRootIndexed.lean
@@ -147,6 +147,7 @@ def ziskBlockValidateReceiptsRootIndexedPrologue : String :=
   mptDeleteAccFunction ++ "\n" ++
   mptInsertAccFunction ++ "\n" ++
   mptStateRootInsFunction ++ "\n" ++
+  mptIndexedTrieRootOneLeafFunction ++ "\n" ++
   mptIndexedTrieRootSmallFunction ++ "\n" ++
   headerExtractReceiptsRootFunction ++ "\n" ++
   blockValidateReceiptsRootIndexedFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/WithdrawalsRootIndexed.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalsRootIndexed.lean
@@ -148,6 +148,7 @@ def ziskBlockValidateWithdrawalsRootIndexedPrologue : String :=
   mptDeleteAccFunction ++ "\n" ++
   mptInsertAccFunction ++ "\n" ++
   mptStateRootInsFunction ++ "\n" ++
+  mptIndexedTrieRootOneLeafFunction ++ "\n" ++
   mptIndexedTrieRootSmallFunction ++ "\n" ++
   headerExtractWithdrawalsRootFunction ++ "\n" ++
   blockValidateWithdrawalsRootIndexedFunction ++ "\n" ++

--- a/scripts/codegen-zisk-mpt-indexed-trie-root-small-check.sh
+++ b/scripts/codegen-zisk-mpt-indexed-trie-root-small-check.sh
@@ -88,6 +88,7 @@ LONG1="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 FAILED=0
 run_case "empty" "[]" 0 || FAILED=1
 run_case "one_short" "['01']" 0 || FAILED=1
+run_case "one_large" "[('ab' * 200000)]" 0 || FAILED=1
 run_case "two_short" "['01','02']" 0 || FAILED=1
 run_case "three_mixed" "['01','$LONG0','03']" 0 || FAILED=1
 run_case "four_long" "['$LONG0','$LONG1','$LONG0','$LONG1']" 0 || FAILED=1


### PR DESCRIPTION
## Summary
- add a stack-local streaming path for indexed tries with exactly one value, avoiding fixed MPT leaf scratch materialization for large transaction values
- route direct indexed-root users through the new helper and keep existing multi-value behavior unchanged
- add a 200KB one-leaf ziskemu regression to scripts/codegen-zisk-mpt-indexed-trie-root-small-check.sh

Bead: evm-asm-deaqj
Follow-up: evm-asm-deaqj.1 tracks the remaining multi-leaf large transaction trie-root work. Exact row 12970 has 34 transactions of about 250117 bytes each, so this PR does not make that row pass by itself.

## Verification
- lake build codegen
- rtk scripts/codegen-zisk-mpt-indexed-trie-root-small-check.sh
- rtk scripts/codegen-eest-stateless-check.sh --skip 12969 --limit 1 --random --seed 1307548980 --jobs 1 --max-failures 1 --quiet-passes  # errored=0, root/tail match, succ mismatch remains
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build
- git diff --check HEAD~2..HEAD

Authored by @pirapira; implemented by Codex.
