### PR TITLE
fix(eest): skip value netting for EIP-7708 self-transfer BAL post-balance

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictSimpleTransfer.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictSimpleTransfer.lean
@@ -214,6 +214,8 @@ def blockVerdictTxGasPrechargeDataSection : String :=
   "tgbpv_value:\n  .zero 32\n" ++
   ".balign 8\n" ++
   "tgbpv_nonce:\n  .zero 8\n" ++
+  "tgbpv_to_addr:\n  .zero 24\n" ++
+  "tgbpv_is_creation:\n  .zero 8\n" ++
   "tgbpv_lookup:\n  .zero 168\n" ++
   "tgbpv_records:\n  .zero 4096\n" ++
   "bv_tx_gas_precharge:\n  .zero 224\n"

--- a/EvmAsm/Codegen/Programs/TxGasBalPostVerify.lean
+++ b/EvmAsm/Codegen/Programs/TxGasBalPostVerify.lean
@@ -190,6 +190,22 @@ def txGasBalPostVerifyFunction : String :=
   "  li t0, 37; sd t0, 0(s7)\n" ++
   "  j .Ltgbpv_ret\n" ++
   ".Ltgbpv_value_ok:\n" ++
+  "  # Self-transfer detection. When the recipient equals the sender, the\n" ++
+  "  # transferred value returns to the sender within the same transaction, so\n" ++
+  "  # the sender's BAL post balance is charged + refund with NO value netting\n" ++
+  "  # (EIP-7708 transfer_to_self). Extract the recipient and compare it byte\n" ++
+  "  # for byte against the sender address recorded by the BAL lookup; on a\n" ++
+  "  # match, skip the value subtraction entirely.\n" ++
+  "  mv a0, s0; mv a1, s1; la a2, tgbpv_to_addr; la a3, tgbpv_is_creation\n" ++
+  "  jal ra, tx_extract_to_address\n" ++
+  "  bnez a0, .Ltgbpv_value_subtract\n" ++
+  "  la t0, tgbpv_is_creation; ld t1, 0(t0); bnez t1, .Ltgbpv_value_subtract\n" ++
+  "  la t0, tgbpv_to_addr; la t1, tgbpv_lookup; addi t1, t1, 16; li t2, 20\n" ++
+  ".Ltgbpv_self_cmp:\n" ++
+  "  beqz t2, .Ltgbpv_value_sub_ok\n" ++
+  "  lbu t3, 0(t0); lbu t4, 0(t1); bne t3, t4, .Ltgbpv_value_subtract\n" ++
+  "  addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1; j .Ltgbpv_self_cmp\n" ++
+  ".Ltgbpv_value_subtract:\n" ++
   "  la a0, tgbpv_expected_balance; la a1, tgbpv_value; la a2, tgbpv_expected_balance\n" ++
   "  jal ra, u256_sub_be\n" ++
   "  beqz a0, .Ltgbpv_value_sub_ok\n" ++
@@ -355,6 +371,8 @@ def ziskTxGasBalPostVerifyDataSection : String :=
   "tgbpv_value:\n  .zero 32\n" ++
   ".balign 8\n" ++
   "tgbpv_nonce:\n  .zero 8\n" ++
+  "tgbpv_to_addr:\n  .zero 24\n" ++
+  "tgbpv_is_creation:\n  .zero 8\n" ++
   "tgbpv_lookup:\n  .zero 168\n" ++
   "tgbpv_records:\n  .zero 4096"
 


### PR DESCRIPTION
## Summary
- `tx_gas_bal_post_verify` computed the sender's expected BAL post balance as `charged + refund - value`. For a self-transfer (recipient == sender), the value returns to the sender within the same transaction, so the correct post balance is `charged + refund` with **no** value netting.
- The verifier now extracts the tx recipient (`tx_extract_to_address`) and, when it byte-matches the sender address from the BAL lookup (and is not a contract creation), skips the value subtraction.
- Adds two `.data` scratch slots (`tgbpv_to_addr`, `tgbpv_is_creation`) to the verifier probe data section and the real-guest data section.

## Evidence
EEST row `blockchain_tests/.../eip7708_eth_transfer_logs/transfer_logs/transfer_to_self_no_log.json` previously gave `succ guest=00 exp=01` with `bv_fail=17` (verdict sub-check 17 = simple-transfer gas precharge / BAL post-balance). State root was already correct (`recomputed == payload`); only the verdict sub-check rejected. After the fix the same rerun reports:

```
full match:    1   (all 105 bytes)
fail:          0
```

Reproduce (`--jobs 1`):
```
scripts/codegen-eest-stateless-check.sh --skip 86 --limit 1 --random --seed 1524097157 --jobs 1 --max-failures 1 --quiet-passes
```

Gates: `lake build` green; `check-file-size.sh`, `check-unimported.sh` pass; no forbidden tokens.

Bead: evm-asm-ahppf.

Authored by @pirapira; implemented by Hermes-bot