### PR TITLE
feat(secp256k1): software scalar multiplication over affine point ops

### DIFF
--- a/EvmAsm/Codegen/Programs/Secp256k1Curve.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1Curve.lean
@@ -47,7 +47,8 @@ def secp256k1CurveDataSection : String :=
   "secc_inv:\n  .zero 32\n" ++
   "secc_tmp0:\n  .zero 32\n" ++
   "secc_tmp1:\n  .zero 32\n" ++
-  "secc_tmp2:\n  .zero 32\n"
+  "secc_tmp2:\n  .zero 32\n" ++
+  "secc_point_tmp:\n  .zero 64\n"
 
 /-- Double an affine point. a0=input x||y, a1=output x||y. Returns 1 for infinity. -/
 def secp256k1PointDoubleFunction : String :=
@@ -196,10 +197,102 @@ def secp256k1PointAddFunction : String :=
   "  addi sp, sp, 40\n" ++
   "  ret"
 
+
+private def secp256k1PointCopy64Function : String :=
+  "secp256k1_point_copy64:\n" ++
+  "  li t0, 64\n" ++
+  ".Lsecc_copy64_loop:\n" ++
+  "  beqz t0, .Lsecc_copy64_ret\n" ++
+  "  lbu t1, 0(a0)\n" ++
+  "  sb t1, 0(a1)\n" ++
+  "  addi a0, a0, 1\n" ++
+  "  addi a1, a1, 1\n" ++
+  "  addi t0, t0, -1\n" ++
+  "  j .Lsecc_copy64_loop\n" ++
+  ".Lsecc_copy64_ret:\n" ++
+  "  ret"
+
+private def secp256k1PointZero64Function : String :=
+  "secp256k1_point_zero64:\n" ++
+  "  li t0, 64\n" ++
+  ".Lsecc_zero64_loop:\n" ++
+  "  beqz t0, .Lsecc_zero64_ret\n" ++
+  "  sb zero, 0(a0)\n" ++
+  "  addi a0, a0, 1\n" ++
+  "  addi t0, t0, -1\n" ++
+  "  j .Lsecc_zero64_loop\n" ++
+  ".Lsecc_zero64_ret:\n" ++
+  "  ret"
+
+/-- Multiply an affine point by a 256-bit big-endian scalar.
+    a0=scalar32, a1=base x||y, a2=output x||y. Returns 1 when the result is
+    the point at infinity, represented as zeroed output. -/
+def secp256k1ScalarMulFunction : String :=
+  "secp256k1_scalar_mul:\n" ++
+  "  addi sp, sp, -72\n" ++
+  "  sd ra, 0(sp); sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  sd s3, 32(sp); sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  mv s0, a0                      # scalar bytes\n" ++
+  "  mv s1, a1                      # base point\n" ++
+  "  mv s2, a2                      # accumulator/output\n" ++
+  "  mv a0, s2\n" ++
+  "  jal ra, secp256k1_point_zero64\n" ++
+  "  li s3, 1                       # accumulator is infinity\n" ++
+  "  li s4, 0                       # byte index\n" ++
+  ".Lsecc_mul_byte_loop:\n" ++
+  "  li t0, 32\n" ++
+  "  bgeu s4, t0, .Lsecc_mul_done\n" ++
+  "  add t0, s0, s4\n" ++
+  "  lbu s5, 0(t0)\n" ++
+  "  li s6, 128\n" ++
+  ".Lsecc_mul_bit_loop:\n" ++
+  "  beqz s6, .Lsecc_mul_next_byte\n" ++
+  "  bnez s3, .Lsecc_mul_skip_double\n" ++
+  "  mv a0, s2\n" ++
+  "  la a1, secc_point_tmp\n" ++
+  "  jal ra, secp256k1_point_double\n" ++
+  "  mv s3, a0\n" ++
+  "  la a0, secc_point_tmp\n" ++
+  "  mv a1, s2\n" ++
+  "  jal ra, secp256k1_point_copy64\n" ++
+  ".Lsecc_mul_skip_double:\n" ++
+  "  and t0, s5, s6\n" ++
+  "  beqz t0, .Lsecc_mul_advance_bit\n" ++
+  "  beqz s3, .Lsecc_mul_add_base\n" ++
+  "  mv a0, s1\n" ++
+  "  mv a1, s2\n" ++
+  "  jal ra, secp256k1_point_copy64\n" ++
+  "  li s3, 0\n" ++
+  "  j .Lsecc_mul_advance_bit\n" ++
+  ".Lsecc_mul_add_base:\n" ++
+  "  mv a0, s2\n" ++
+  "  mv a1, s1\n" ++
+  "  la a2, secc_point_tmp\n" ++
+  "  jal ra, secp256k1_point_add\n" ++
+  "  mv s3, a0\n" ++
+  "  la a0, secc_point_tmp\n" ++
+  "  mv a1, s2\n" ++
+  "  jal ra, secp256k1_point_copy64\n" ++
+  ".Lsecc_mul_advance_bit:\n" ++
+  "  srli s6, s6, 1\n" ++
+  "  j .Lsecc_mul_bit_loop\n" ++
+  ".Lsecc_mul_next_byte:\n" ++
+  "  addi s4, s4, 1\n" ++
+  "  j .Lsecc_mul_byte_loop\n" ++
+  ".Lsecc_mul_done:\n" ++
+  "  mv a0, s3\n" ++
+  "  ld ra, 0(sp); ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  ld s3, 32(sp); ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  addi sp, sp, 72\n" ++
+  "  ret"
+
 def secp256k1CurveCommonFunctions : String :=
   secp256k1FieldCommonFunctions ++ "\n" ++
   secp256k1PointDoubleFunction ++ "\n" ++
-  secp256k1PointAddFunction
+  secp256k1PointAddFunction ++ "\n" ++
+  secp256k1PointCopy64Function ++ "\n" ++
+  secp256k1PointZero64Function ++ "\n" ++
+  secp256k1ScalarMulFunction
 
 def ziskSecp256k1CurvePointOpsPrologue : String :=
   "  li sp, 0xa0050000\n" ++
@@ -213,6 +306,12 @@ def ziskSecp256k1CurvePointOpsPrologue : String :=
   "  li a2, 0xa0010050\n" ++
   "  jal ra, secp256k1_point_add\n" ++
   "  li t0, 0xa0010048\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  li a0, 0x40000008\n" ++
+  "  la a1, secp256k1_generator\n" ++
+  "  li a2, 0xa0010098\n" ++
+  "  jal ra, secp256k1_scalar_mul\n" ++
+  "  li t0, 0xa0010090\n" ++
   "  sd a0, 0(t0)\n" ++
   "  j .Lsecc_probe_done\n" ++
   secp256k1CurveCommonFunctions ++ "\n" ++

--- a/scripts/codegen-zisk-secp256k1-curve-check.sh
+++ b/scripts/codegen-zisk-secp256k1-curve-check.sh
@@ -26,35 +26,80 @@ echo "==> emit ${program} ELF"
 lake exe codegen --program "$program" --halt linux93 -o "gen-out/${program}"
 
 out_file="gen-out/${program}.output"
+input_file="gen-out/${program}.input"
 exp_file="gen-out/${program}.expected"
 log_file="gen-out/${program}.emu.log"
+
+# Static double/add probe slots (independent of the scalar input):
+#   bytes 0x00..0x48  = double(G)            -> infinity flag (u64 LE) || 2G
+#   bytes 0x48..0x90  = add(G,G)             -> infinity flag (u64 LE) || 2G
+# Scalar-mul probe slot (driven by the 32-byte big-endian scalar input):
+#   bytes 0x90..0xd8  = scalar_mul(k, G)     -> infinity flag (u64 LE) || k*G
+# The ziskemu -o window is 256 bytes, so we cannot emit k=1,2,3 in one run.
+# Instead we re-run the ELF once per scalar, feeding k via the guest input,
+# and check the static prefix plus the per-k scalar slot each time.
 
 python3 - "$exp_file" <<'PYSCRIPT'
 import struct
 import sys
 
+point1 = bytes.fromhex(
+    '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
+    '483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8'
+)
 point2 = bytes.fromhex(
     'c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5'
     '1ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a'
 )
-expected = struct.pack('<Q', 0) + point2 + struct.pack('<Q', 0) + point2
+point3 = bytes.fromhex(
+    'f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9'
+    '388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e672'
+)
+# Static double/add prefix: bytes 0x00..0x90.
+prefix = (
+    struct.pack('<Q', 0) + point2 +
+    struct.pack('<Q', 0) + point2
+)
 with open(sys.argv[1], 'wb') as f:
-    f.write(expected)
+    f.write(prefix)
 PYSCRIPT
 
-"$ZISKEMU" -e "gen-out/${program}.elf" -o "$out_file" -n 1000000000 >"$log_file" 2>&1 || true
+# Per-k scalar-multiplication expected k*G points (big-endian x||y).
+declare -A KPOINT
+KPOINT[1]='79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8'
+KPOINT[2]='c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a'
+KPOINT[3]='f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e672'
 
-exp_size="$(stat -c%s "$exp_file")"
-actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
-expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+prefix_expected="$(xxd -p -l 144 "$exp_file" 2>/dev/null | tr -d '\n')"
 
-if [[ "$actual" == "$expected" ]]; then
-  echo "==> PASS: secp256k1 point double(G) and add(G,G) match 2G"
-  exit 0
-else
-  echo "==> FAIL: secp256k1 point helper probe mismatch"
-  echo "    expected: $expected"
-  echo "    actual:   $actual"
-  echo "    ziskemu log: $log_file"
-  exit 1
-fi
+for k in 1 2 3; do
+  python3 -c "import sys; open(sys.argv[1],'wb').write(int(sys.argv[2]).to_bytes(32,'big'))" \
+    "$input_file" "$k"
+  "$ZISKEMU" -e "gen-out/${program}.elf" -i "$input_file" -o "$out_file" -n 1000000000 \
+    >"$log_file" 2>&1 || true
+
+  # Static double/add prefix (bytes 0x00..0x90) must always match.
+  prefix_actual="$(xxd -p -l 144 "$out_file" 2>/dev/null | tr -d '\n')"
+  if [[ "$prefix_actual" != "$prefix_expected" ]]; then
+    echo "==> FAIL: secp256k1 double/add prefix mismatch (k=$k)"
+    echo "    expected: $prefix_expected"
+    echo "    actual:   $prefix_actual"
+    echo "    ziskemu log: $log_file"
+    exit 1
+  fi
+
+  # Scalar slot: infinity flag (8 bytes LE) at 0x90, then k*G at 0x98.
+  flag_actual="$(xxd -p -s 144 -l 8 "$out_file" 2>/dev/null | tr -d '\n')"
+  point_actual="$(xxd -p -s 152 -l 64 "$out_file" 2>/dev/null | tr -d '\n')"
+  if [[ "$flag_actual" != "0000000000000000" || "$point_actual" != "${KPOINT[$k]}" ]]; then
+    echo "==> FAIL: secp256k1 scalar_mul mismatch (k=$k)"
+    echo "    expected flag: 0000000000000000 point: ${KPOINT[$k]}"
+    echo "    actual   flag: $flag_actual point: $point_actual"
+    echo "    ziskemu log: $log_file"
+    exit 1
+  fi
+  echo "    ok: scalar_mul k=$k => ${k}G"
+done
+
+echo "==> PASS: secp256k1 point helpers and scalar multiplication match 2G, k=1=>G, k=2=>2G, k=3=>3G"
+exit 0


### PR DESCRIPTION
## Summary
- Implement `secp256k1_scalar_mul`: MSB-first double-and-add 256-bit scalar multiplication built on the existing software `secp256k1_point_double` / `secp256k1_point_add` affine helpers (`EvmAsm/Codegen/Programs/Secp256k1Curve.lean`), with point-at-infinity status tracking and 64-byte copy/zero helpers.
- The scalar is read big-endian; the accumulator starts at infinity (zeroed output) and the base point is conditionally added per set bit, so the result is usable by `tx_pubkey_recover_raw`.
- Extend the `zisk_secp256k1_curve_point_ops` probe to invoke `scalar_mul` with the guest-supplied scalar, and rework `scripts/codegen-zisk-secp256k1-curve-check.sh` to drive the ELF once per scalar `k=1,2,3` (the 256-byte ziskemu `-o` window cannot hold all point slots in one run), checking the static `double(G)`/`add(G,G)` prefix plus `k*G` each run: **k=1=>G, k=2=>2G, k=3=>3G**.

## Verification
- `lake build` (full) green.
- `scripts/codegen-zisk-secp256k1-curve-check.sh` PASS (k=1=>G, k=2=>2G, k=3=>3G).
- `scripts/check-file-size.sh`, `scripts/check-unimported.sh` clean; no forbidden tactics.

Bead: evm-asm-mcogi.5.3.5.4.

Authored by @pirapira; implemented by Hermes-bot