### PR TITLE
fix(blob-gas): compute amsterdam blob gas price in u256 for header validation

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -1009,6 +1009,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   headerValidatePostMergeFunction ++ "\n" ++
   headerValidateExtraDataLengthFunction ++ "\n" ++
   amsterdamBlobGasPriceFunction ++ "\n" ++
+  amsterdamBlobGasPriceU256Function ++ "\n" ++
   eip1559CalcBaseFeePerGasFunction ++ "\n" ++
   headerValidateBaseFeeFunction ++ "\n" ++
   headerValidateExcessBlobGasFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
@@ -95,6 +95,7 @@ def statelessVerdictV2GuestClosure : String :=
   headerValidatePostMergeFunction ++ "\n" ++
   headerValidateExtraDataLengthFunction ++ "\n" ++
   amsterdamBlobGasPriceFunction ++ "\n" ++
+  amsterdamBlobGasPriceU256Function ++ "\n" ++
   eip1559CalcBaseFeePerGasFunction ++ "\n" ++
   headerValidateBaseFeeFunction ++ "\n" ++
   headerValidateExcessBlobGasFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -730,6 +730,70 @@ def amsterdamBlobGasPriceFunction : String :=
   "  addi sp, sp, 48\n" ++
   "  ret"
 
+/-! ## amsterdam_blob_gas_price_u256 -- wide-result blob fee fake exponential
+
+    Same `taylor_exponential(1, excess_blob_gas, 11684671)` as
+    `amsterdam_blob_gas_price`, but accumulates in 256-bit precision and
+    returns the price as a 32-byte big-endian u256. The u64 helper saturates
+    to a `status=1` overflow once the (denominator-scaled) accumulator leaves
+    the u64 envelope (around excess ≈ 328M), which is well below the EIP-4844
+    consensus-reachable range: e.g. `excess_blob_gas = 564,002,816` yields a
+    blob gas price ≈ e^48 ≈ 9.4e20 (~70 bits). The spec's `taylor_exponential`
+    is arbitrary precision, so a u64-overflowing helper false-rejects valid
+    headers in `header_validate_excess_blob_gas` (the EIP-7918 reserve-price
+    comparison `BLOB_BASE_COST * base_fee > PER_BLOB * blob_gas_price`). This
+    256-bit variant handles the full reachable range; it only reports overflow
+    if the price itself would exceed 2^256 (unreachable for valid blocks).
+
+    Calling convention:
+      a0 (input)  : excess_blob_gas (u64)
+      a1 (input)  : output price ptr (32 bytes, BE)
+      ra (input)  : return
+      a0 (output) : status, 0 ok / 1 u256 overflow (output left undefined).
+
+    Uses 64 bytes of stack scratch for the two u256 accumulators plus the
+    `u256_mul_u64_be` `.data` scratch (`u256m_acc`). Composes u256_from_u64_be,
+    u256_is_zero, u256_add_be, u256_mul_u64_be, u256_div_u64_be. -/
+def amsterdamBlobGasPriceU256Function : String :=
+  "amsterdam_blob_gas_price_u256:\n" ++
+  "  addi sp, sp, -128\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  sd s3, 32(sp); sd s4, 40(sp); sd s5, 48(sp)\n" ++
+  "  mv s0, a0                   # numerator = excess_blob_gas\n" ++
+  "  mv s5, a1                   # caller output price ptr (u256 BE)\n" ++
+  "  li s1, 11684671             # Amsterdam BLOB_BASE_FEE_UPDATE_FRACTION\n" ++
+  "  li s2, 1                    # i\n" ++
+  "  addi s3, sp, 64             # numerator_accumulated (u256 scratch)\n" ++
+  "  addi s4, sp, 96             # output accumulator (u256 scratch)\n" ++
+  "  mv a0, s1; mv a1, s3; jal ra, u256_from_u64_be   # accum = denominator\n" ++
+  "  li a0, 0; mv a1, s4; jal ra, u256_from_u64_be    # output = 0\n" ++
+  ".Labgpu_loop:\n" ++
+  "  mv a0, s3; jal ra, u256_is_zero\n" ++
+  "  bnez a0, .Labgpu_done\n" ++
+  "  mv a0, s4; mv a1, s3; mv a2, s4; jal ra, u256_add_be   # output += accum\n" ++
+  "  bnez a0, .Labgpu_overflow\n" ++
+  "  mv a0, s3; mv a1, s0; mv a2, s3; jal ra, u256_mul_u64_be  # accum *= excess\n" ++
+  "  bnez a0, .Labgpu_overflow\n" ++
+  "  mulhu t0, s1, s2; bnez t0, .Labgpu_overflow         # deni = denom*i fits u64\n" ++
+  "  mul t1, s1, s2\n" ++
+  "  srli t0, t1, 56; bnez t0, .Labgpu_overflow          # and within div helper's 2^56\n" ++
+  "  mv a0, s3; mv a1, t1; mv a2, s3; jal ra, u256_div_u64_be  # accum //= deni\n" ++
+  "  addi s2, s2, 1\n" ++
+  "  j .Labgpu_loop\n" ++
+  ".Labgpu_done:\n" ++
+  "  mv a0, s4; mv a1, s1; mv a2, s5; jal ra, u256_div_u64_be  # price = output//denom\n" ++
+  "  li a0, 0\n" ++
+  "  j .Labgpu_u256_ret\n" ++
+  ".Labgpu_overflow:\n" ++
+  "  li a0, 1\n" ++
+  ".Labgpu_u256_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  ld s3, 32(sp); ld s4, 40(sp); ld s5, 48(sp)\n" ++
+  "  addi sp, sp, 128\n" ++
+  "  ret"
+
 /-- `zisk_amsterdam_blob_gas_price`: probe BuildUnit. Reads
     `excess_blob_gas` from host input, writes `(status, price)` to
     OUTPUT. -/

--- a/EvmAsm/Codegen/Programs/HeaderBaseFee.lean
+++ b/EvmAsm/Codegen/Programs/HeaderBaseFee.lean
@@ -364,11 +364,9 @@ def headerValidateExcessBlobGasFunction : String :=
   "  li t0, 1835008              # 14 * 131072\n" ++
   "  bltu s4, t0, .Lhvebg_expected_zero\n" ++
   "  mv a0, s2\n" ++
-  "  jal ra, amsterdam_blob_gas_price\n" ++
-  "  bnez a0, .Lhvebg_overflow\n" ++
-  "  mv a0, a1                   # blob gas price\n" ++
   "  la a1, hvebg_threshold\n" ++
-  "  jal ra, u256_from_u64_be\n" ++
+  "  jal ra, amsterdam_blob_gas_price_u256   # threshold = blob gas price (u256)\n" ++
+  "  bnez a0, .Lhvebg_overflow\n" ++
   "  la a0, hvebg_threshold\n" ++
   "  li a1, 16\n" ++
   "  la a2, hvebg_threshold\n" ++
@@ -552,6 +550,7 @@ def ziskValidateHeaderFullPrologue : String :=
   headerValidatePostMergeFunction ++ "\n" ++
   headerValidateExtraDataLengthFunction ++ "\n" ++
   amsterdamBlobGasPriceFunction ++ "\n" ++
+  amsterdamBlobGasPriceU256Function ++ "\n" ++
   eip1559CalcBaseFeePerGasFunction ++ "\n" ++
   headerValidateBaseFeeFunction ++ "\n" ++
   headerValidateExcessBlobGasFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/StatelessVerdict.lean
+++ b/EvmAsm/Codegen/Programs/StatelessVerdict.lean
@@ -177,6 +177,7 @@ def ziskStatelessVerdictPrologue : String :=
   headerValidatePostMergeFunction ++ "\n" ++
   headerValidateExtraDataLengthFunction ++ "\n" ++
   amsterdamBlobGasPriceFunction ++ "\n" ++
+  amsterdamBlobGasPriceU256Function ++ "\n" ++
   eip1559CalcBaseFeePerGasFunction ++ "\n" ++
   headerValidateBaseFeeFunction ++ "\n" ++
   headerValidateExcessBlobGasFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/Step2Verdict.lean
+++ b/EvmAsm/Codegen/Programs/Step2Verdict.lean
@@ -198,6 +198,7 @@ def ziskStep2VerdictPrologue : String :=
   headerValidatePostMergeFunction ++ "\n" ++
   headerValidateExtraDataLengthFunction ++ "\n" ++
   amsterdamBlobGasPriceFunction ++ "\n" ++
+  amsterdamBlobGasPriceU256Function ++ "\n" ++
   eip1559CalcBaseFeePerGasFunction ++ "\n" ++
   headerValidateBaseFeeFunction ++ "\n" ++
   headerValidateExcessBlobGasFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/ValidateHeaderPair.lean
+++ b/EvmAsm/Codegen/Programs/ValidateHeaderPair.lean
@@ -115,6 +115,7 @@ def ziskValidateHeaderRlpPairPrologue : String :=
   headerValidatePostMergeFunction ++ "\n" ++
   headerValidateExtraDataLengthFunction ++ "\n" ++
   amsterdamBlobGasPriceFunction ++ "\n" ++
+  amsterdamBlobGasPriceU256Function ++ "\n" ++
   eip1559CalcBaseFeePerGasFunction ++ "\n" ++
   headerValidateBaseFeeFunction ++ "\n" ++
   headerValidateExcessBlobGasFunction ++ "\n" ++


### PR DESCRIPTION
## Summary
- `header_validate_excess_blob_gas` (EIP-4844 excess-blob-gas recurrence + EIP-7918 reserve-price comparison) called the **u64-only** `amsterdam_blob_gas_price`, which saturates to a `status=1` overflow once the denominator-scaled Taylor accumulator leaves the u64 envelope (~excess 328M). The spec's `taylor_exponential` is arbitrary precision, so the guest **false-rejected** valid headers in the `>328M` regime.
  - `correct_decreasing_blob_gas_costs` row 5482: `parent_excess_blobs_4303` ⇒ `excess_blob_gas = 564,002,816`, blob gas price ≈ e^48 ≈ 9.4e20 (~70 bits) ⇒ `header=601` false-reject.
- Add `amsterdam_blob_gas_price_u256`: the same `taylor_exponential(1, excess, 11684671)` accumulated in **256-bit precision** (two stack u256 buffers + the `u256_mul_u64_be` scratch), returning a 32-byte BE u256. Composes the existing u256 toolkit (`from_u64`/`is_zero`/`add`/`mul_u64`/`div_u64`); only reports overflow if the price would exceed 2^256 (unreachable for valid blocks). `header_validate_excess_blob_gas` now feeds the u256 price straight into the `16*price` reserve comparison. The u64 helper is retained for its other caller (the blob-fee gas gate).

## Verification
- Row 5482 header probe: **601 → 0** (header validation now passes; state root already matched).
- `eip7918 reserve_price_boundary`: **6/6 full match** — no regression on the reserve-price comparison that consumes this price.
- Full `lake build` green; `check-file-size.sh`, `check-unimported.sh` clean; no `sorry`/`native_decide`/`bv_decide`.

## Remaining work on this row
Row 5482 does **not** yet full-match: with the header fixed, a separate, previously-masked EIP-4844 **versioned-hashes** false-reject surfaces (`bv_fail=27`, `is_valid_versioned_hashes`). Filed as a follow-up. This PR fixes the documented blob-gas-price root cause and the whole `>328M` header regime (also benefits the EIP-7918 reserve-price family).

Bead: evm-asm-lcx60.

Authored by @pirapira; implemented by Claude Code