### PR TITLE
fix(eip7918): pass output ptr to u256_lt_be in blob excess recurrence

### DIFF
--- a/EvmAsm/Codegen/Programs/HeaderBaseFee.lean
+++ b/EvmAsm/Codegen/Programs/HeaderBaseFee.lean
@@ -376,8 +376,11 @@ def headerValidateExcessBlobGasFunction : String :=
   "  bnez a0, .Lhvebg_overflow\n" ++
   "  la a0, hvebg_threshold\n" ++
   "  mv a1, s3\n" ++
-  "  jal ra, u256_lt_be          # threshold < parent_base_fee?\n" ++
-  "  beqz a0, .Lhvebg_normal\n" ++
+  "  la a2, u256m_acc            # u256_lt_be writes the verdict to *a2 (a0 is status)\n" ++
+  "  jal ra, u256_lt_be          # [u256m_acc] = 1 iff threshold < parent_base_fee\n" ++
+  "  la t0, u256m_acc\n" ++
+  "  ld t0, 0(t0)\n" ++
+  "  beqz t0, .Lhvebg_normal\n" ++
   "  li t0, 3\n" ++
   "  divu t1, s1, t0             # used * 7 // 21 == used // 3\n" ++
   "  add s5, s2, t1\n" ++


### PR DESCRIPTION
## Summary
- `header_validate_excess_blob_gas` (EvmAsm/Codegen/Programs/HeaderBaseFee.lean) selected the EIP-7918 blob **reserve-price** branch with `jal u256_lt_be; beqz a0`, but `u256_lt_be(a, b, out_ptr)` writes its verdict to `*a2` and **always returns `a0=0`** (status). With `a2` unset and `a0` read as the boolean, the comparison `16*price < parent_base_fee` was always treated as false, so the reserve-price branch was **never taken** — the guest fell back to the pre-7918 simple recurrence `max(0, parent_excess + parent_used - target)`.
- Effect: every block whose `excess_blob_gas` follows the reserve-price branch was false-rejected (header validation status 602), e.g. all EIP-7918 `reserve_price_boundary` rows where the reserve and simple formulas differ.
- Fix: pass `a2 = u256m_acc` (free after the `16*price` multiply) and branch on the loaded verdict, matching the correct `u256_lt_be` callers in TxPubkey / Secp256k1Field / Secp256k1Recover. The other 5 callers were audited and already pass `a2` correctly; only this site was wrong.

## Verification
- Root-caused via build_struct + RLP-pair probes driving `validate_header_full` / `validate_header_rlp_pair` directly on the failing case (parent.excess=8126464, base_fee=48): before fix the reserve value (8126464) returned 602 and the simple value (6291456) returned 0; after fix this is reversed (correct).
- `scripts/codegen-eest-stateless-check.sh --filter reserve_price_boundary --limit 0 --jobs 2`: **30/30 full match, 0 fail** (was 18/30 full, 12 fail).
- `scripts/codegen-zisk-validate-header-full-check.sh`, `scripts/codegen-zisk-amsterdam-blob-gas-price-check.sh`: still PASS.
- `scripts/check-file-size.sh`, `scripts/check-unimported.sh`, forbidden-tactic scan: clean. Full `lake build`: green (only the known upstream LeanRV64D deprecation warning).

Bead: evm-asm-bisu3.

Authored by @pirapira; implemented by Claude Code