### PR TITLE
fix(eip4844): tolerate u256 max_fee_per_blob_gas in tx_eip4844_decode

### DIFF
--- a/EvmAsm/Codegen/Programs/TxDecode4844.lean
+++ b/EvmAsm/Codegen/Programs/TxDecode4844.lean
@@ -77,7 +77,7 @@ open EvmAsm.Rv64.Program
       a0 (output) : 0 success / 1 parse fail (incl. blob fee > u64) -/
 def txEip4844DecodeFunction : String :=
   "tx_eip4844_decode:\n" ++
-  "  addi sp, sp, -48\n" ++
+  "  addi sp, sp, -64\n" ++          -- +32B scratch (sp+32) for the u256 blob-fee read
   "  sd ra,  0(sp)\n" ++
   "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
   "  mv s0, a0                  # inner_rlp ptr\n" ++
@@ -148,11 +148,25 @@ def txEip4844DecodeFunction : String :=
   "  bnez a0, .Lt48_fail\n" ++
   "  la t0, t48_offset; ld t1, 0(t0); sw t1, 152(s2)\n" ++
   "  la t0, t48_length; ld t1, 0(t0); sw t1, 156(s2)\n" ++
-  "  # Field 9: max_fee_per_blob_gas (u64 at 160; rejects > 8B BE)\n" ++
-  "  mv a0, s0; mv a1, s1; li a2, 9\n" ++
-  "  addi a3, s2, 160\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  # Field 9: max_fee_per_blob_gas. Spec type is u256; we keep a low-64-bit\n" ++
+  "  # view at offset 160 and TOLERATE values > u64 rather than rejecting. In\n" ++
+  "  # the high blob-fee regime (parent excess_blob_gas > ~328M), the blob gas\n" ++
+  "  # price exceeds u64, so a valid tx's max_fee_per_blob_gas does too; the old\n" ++
+  "  # rlp_field_to_u64 reject false-rejected those valid blob txs. Callers that\n" ++
+  "  # need the full value re-extract via rlp_field_to_u256_be at field index 9.\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 9; addi a3, sp, 32\n" ++
+  "  jal ra, rlp_field_to_u256_be\n" ++
   "  bnez a0, .Lt48_fail\n" ++
+  "  addi t0, sp, 32             # low 64 bits (BE bytes 24..31) -> u64 LE @160\n" ++
+  "  lbu t1, 24(t0); slli t1, t1, 56\n" ++
+  "  lbu t2, 25(t0); slli t2, t2, 48; or t1, t1, t2\n" ++
+  "  lbu t2, 26(t0); slli t2, t2, 40; or t1, t1, t2\n" ++
+  "  lbu t2, 27(t0); slli t2, t2, 32; or t1, t1, t2\n" ++
+  "  lbu t2, 28(t0); slli t2, t2, 24; or t1, t1, t2\n" ++
+  "  lbu t2, 29(t0); slli t2, t2, 16; or t1, t1, t2\n" ++
+  "  lbu t2, 30(t0); slli t2, t2,  8; or t1, t1, t2\n" ++
+  "  lbu t2, 31(t0);                  or t1, t1, t2\n" ++
+  "  sd t1, 160(s2)\n" ++
   "  # Field 10: blob_versioned_hashes (u32 off+len at 168/172)\n" ++
   "  mv a0, s0; mv a1, s1; li a2, 10\n" ++
   "  la a3, t48_offset; la a4, t48_length\n" ++
@@ -182,7 +196,7 @@ def txEip4844DecodeFunction : String :=
   ".Lt48_ret:\n" ++
   "  ld ra,  0(sp)\n" ++
   "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
-  "  addi sp, sp, 48\n" ++
+  "  addi sp, sp, 64\n" ++
   "  ret"
 
 /-- `zisk_tx_eip4844_decode`: probe BuildUnit. Reads (inner_len,


### PR DESCRIPTION
## Summary
- `tx_eip4844_decode` rejected (status=1) any `max_fee_per_blob_gas` whose RLP encoding exceeded 8 bytes (field 9 was read with `rlp_field_to_u64`). The EIP-4844 spec types `max_fee_per_blob_gas` as **u256**, and in the high blob-fee regime (parent `excess_blob_gas` > ~328M, where the blob gas price exceeds u64) a **valid** blob tx's `max_fee_per_blob_gas` legitimately exceeds u64 — so the reject false-failed valid blob txs.
- Concretely this broke `ssz_tx_list_versioned_hashes_match` (`is_valid_versioned_hashes`): on `correct_decreasing_blob_gas_costs` row 5482, the walker decoded the block's first blob tx, hit the field-9 reject, returned code 2 → **`bv_fail=27`** (false-reject of a valid block).
- **Fix**: read field 9 with `rlp_field_to_u256_be` into stack scratch and store the low 64 bits as the existing u64 view at struct offset 160 (identical for values that fit u64), without rejecting larger values. Callers needing the full value re-extract via `rlp_field_to_u256_be` at field index 9 (as the docstring already notes).

## Verification
- Row 5482 advances past the versioned-hashes check (**`bv_fail` 27 → 10**); no crash.
- `correct_increasing_blob_gas_costs` normal-fee rows still full-match (decode unchanged for `max_fee ≤ u64`); 0 errored.
- Full `lake build` green; `check-file-size.sh`/`check-unimported.sh` clean; no `sorry`/`native_decide`/`bv_decide`.

## Scope / remaining
Stacked on #8479 (the blob-gas-price u256 header fix). Row 5482 does **not** yet full-match — the `>328M` regime still needs the EIP-8037 gas-gate blob-fee comparison and the V2 header-chain validation widened to u256 (a gate change there proceeds further but unmasks a downstream near-null store). Tracked in bead lcx60.1.

Bead: evm-asm-lcx60.1.

Authored by @pirapira; implemented by Claude Code