### PR TITLE
fix(eip7918): read u256_lt_be result from memory in excess-blob-gas recurrence

### DIFF
--- a/EvmAsm/Codegen/Programs/HeaderBaseFee.lean
+++ b/EvmAsm/Codegen/Programs/HeaderBaseFee.lean
@@ -376,7 +376,9 @@ def headerValidateExcessBlobGasFunction : String :=
   "  bnez a0, .Lhvebg_overflow\n" ++
   "  la a0, hvebg_threshold\n" ++
   "  mv a1, s3\n" ++
-  "  jal ra, u256_lt_be          # threshold < parent_base_fee?\n" ++
+  "  addi a2, sp, 56             # u256_lt_be writes its result to *a2, not a0\n" ++
+  "  jal ra, u256_lt_be          # *(sp+56) = (16*price < parent_base_fee)\n" ++
+  "  ld a0, 56(sp)\n" ++
   "  beqz a0, .Lhvebg_normal\n" ++
   "  li t0, 3\n" ++
   "  divu t1, s1, t0             # used * 7 // 21 == used // 3\n" ++


### PR DESCRIPTION
## Summary
- `header_validate_excess_blob_gas` evaluated the EIP-7918 reserve-price branch condition (`BLOB_BASE_COST*parent.base_fee > PER_BLOB*blob_gas_price`, i.e. `16*price < parent.base_fee`) by calling `u256_lt_be` and branching on `a0`. But `u256_lt_be`'s contract writes its boolean result to the **`*a2` output pointer** and **always returns `a0=0`** (success). The call passed no `a2` and tested `beqz a0` — unconditionally true — so the **reserve branch was never taken** and the guest always used the simple recurrence `max(0, parent_excess + parent_used - target)`.
- This false-rejected (`header=602`, `validate_header_full` step-6 mismatch) every block whose parent sits in the EIP-7918 reserve regime.
- **Fix**: pass an output pointer (a free 8-byte slot in the existing frame, `sp+56`) and load the comparison result before branching. This was the only `u256_lt_be` call site testing `a0` instead of the memory result (verified by grep).

## Verification
- `reserve_price_boundary`: **18/30 → 24/30 full match** — all 12 `header=602` rows now pass header validation; **no regression** (full-match count strictly increased).
- 6 rows now surface a separate, previously-masked `succ=00` / `bv_fail=0` failure (`header=0`) — tracked for follow-up.
- Full `lake build` green; `check-file-size.sh`/`check-unimported.sh` clean; no `sorry`/`native_decide`/`bv_decide`.

Bead: evm-asm-bisu3.

Authored by @pirapira; implemented by Claude Code