### PR TITLE
feat(mpt): support 3-byte RLP index keys in indexed trie root (>=256 entries)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -768,7 +768,7 @@ def statelessVerdictV2Function : String :=
   "  beqz a0, .Lv2_tx_root_fail\n" ++
   "  bgtu a0, s1, .Lv2_tx_root_fail\n" ++
   "  srli s4, a0, 2\n" ++
-  "  li t0, 257; bgeu s4, t0, .Lv2_tx_root_fail\n" ++
+  "  li t0, 2049; bgeu s4, t0, .Lv2_tx_root_fail\n" ++
   "  la t0, svf_tx_count; sd s4, 0(t0)\n" ++
   "  li s5, 0\n" ++
   "  la s3, svf_tx_descriptors\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -32,7 +32,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bv_block_hash_check_enabled:\n  .zero 8\n" ++
   ".balign 8\n" ++
   "svf_tx_count:\n  .zero 8\n" ++
-  "svf_tx_descriptors:\n  .zero 4096\n" ++
+  "svf_tx_descriptors:\n  .zero 32768\n" ++
   "bah_bal_start:\n  .zero 8\n" ++
   ".balign 8\n" ++
   "sltr_field_len:\n  .zero 8\n" ++
@@ -183,9 +183,9 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bvwri_computed_root:\n  .zero 32\n" ++
   ".balign 8\n" ++
   "itr_empty_witness:\n  .zero 8\n" ++
-  "itr_value_descs:\n  .zero 2048\n" ++
-  "itr_paths:\n  .zero 1024\n" ++
-  "itr_changes:\n  .zero 10240\n" ++
+  "itr_value_descs:\n  .zero 32768\n" ++
+  "itr_paths:\n  .zero 16384\n" ++
+  "itr_changes:\n  .zero 81920\n" ++
   "bvgr_runtime_gas_left_ptr:\n  .zero 8\n" ++
   "bvgr_runtime_refund_counter_ptr:\n  .zero 8\n" ++
   "bvgr_runtime_calldata_floor_ptr:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/MptIndexedTrieRoot.lean
+++ b/EvmAsm/Codegen/Programs/MptIndexedTrieRoot.lean
@@ -480,7 +480,7 @@ def mptIndexedTrieRootSmallFunction : String :=
   "  mv s0, a0                   # value descriptors\n" ++
   "  mv s1, a1                   # n values\n" ++
   "  mv s2, a2                   # out root\n" ++
-  "  li t0, 257\n" ++
+  "  li t0, 2049\n" ++
   "  bgeu s1, t0, .Litr_fail\n" ++
   "  li t0, 1\n" ++
   "  beq s1, t0, .Litr_one_leaf\n" ++
@@ -496,8 +496,10 @@ def mptIndexedTrieRootSmallFunction : String :=
   "  slli t0, s3, 4; add t0, s0, t0     # &value_desc[i]\n" ++
   "  ld t1, 0(t0)                       # value ptr\n" ++
   "  ld t2, 8(t0)                       # value len\n" ++
-  "  slli t3, s3, 2; la t4, itr_paths; add t4, t4, t3\n" ++
+  "  slli t3, s3, 3; la t4, itr_paths; add t4, t4, t3\n" ++
   "  beqz s3, .Litr_key_zero\n" ++
+  "  li t0, 256\n" ++
+  "  bgeu s3, t0, .Litr_key_three_byte\n" ++
   "  li t0, 128\n" ++
   "  bgeu s3, t0, .Litr_key_two_byte\n" ++
   "  srli t5, s3, 4\n" ++
@@ -512,6 +514,16 @@ def mptIndexedTrieRootSmallFunction : String :=
   "  andi t6, s3, 15\n" ++
   "  sb t5, 2(t4); sb t6, 3(t4)\n" ++
   "  li t0, 4\n" ++
+  "  j .Litr_key_done\n" ++
+  ".Litr_key_three_byte:\n" ++
+  "  # 256<=i<65536 -> rlp(i) = 0x82 hi lo -> nibbles [8,2, hi>>4,hi&15, lo>>4,lo&15]\n" ++
+  "  li t5, 8; sb t5, 0(t4)\n" ++
+  "  li t5, 2; sb t5, 1(t4)\n" ++
+  "  srli t5, s3, 12; andi t5, t5, 15; sb t5, 2(t4)\n" ++
+  "  srli t5, s3,  8; andi t5, t5, 15; sb t5, 3(t4)\n" ++
+  "  srli t5, s3,  4; andi t5, t5, 15; sb t5, 4(t4)\n" ++
+  "  andi t6, s3, 15; sb t6, 5(t4)\n" ++
+  "  li t0, 6\n" ++
   "  j .Litr_key_done\n" ++
   ".Litr_key_zero:\n" ++
   "  li t5, 8; sb t5, 0(t4); sb zero, 1(t4)\n" ++
@@ -613,9 +625,9 @@ def ziskMptIndexedTrieRootSmallDataSection : String :=
   ziskMptStateRootInsDataSection ++ "\n" ++
   ".balign 8\n" ++
   "itr_empty_witness:\n  .zero 8\n" ++
-  "itr_value_descs:\n  .zero 4096\n" ++
-  "itr_paths:\n  .zero 1024\n" ++
-  "itr_changes:\n  .zero 10240"
+  "itr_value_descs:\n  .zero 32768\n" ++
+  "itr_paths:\n  .zero 16384\n" ++
+  "itr_changes:\n  .zero 81920"
 
 def ziskMptIndexedTrieRootSmallProbeUnit : BuildUnit := {
   body        := NOP

--- a/scripts/codegen-zisk-mpt-indexed-trie-root-small-check.sh
+++ b/scripts/codegen-zisk-mpt-indexed-trie-root-small-check.sh
@@ -135,12 +135,30 @@ PY
 )"
 run_case "over_128_keys" "$OVER_128_VALUES" 0 || FAILED=1
 
-TOO_MANY="$(python3 - <<'PY'
+# 257 entries: index 256 needs a 3-byte RLP index key (rlp(256)=0x82 0x01 0x00 ->
+# nibbles [8,2,0,1,0,0]). Now supported (was rejected under the old 256 cap).
+KEYS_257="$(python3 - <<'PY'
 vals = [f"{i % 256:02x}" for i in range(257)]
 print("[" + ",".join(repr(v) for v in vals) + "]")
 PY
 )"
-run_case "too_many" "$TOO_MANY" 1 || FAILED=1
+run_case "keys_257_three_byte" "$KEYS_257" 0 || FAILED=1
+
+# 300 entries: more 3-byte index keys (256..299).
+KEYS_300="$(python3 - <<'PY'
+vals = [f"{i % 256:02x}" for i in range(300)]
+print("[" + ",".join(repr(v) for v in vals) + "]")
+PY
+)"
+run_case "keys_300_three_byte" "$KEYS_300" 0 || FAILED=1
+
+# New cap: >=2049 entries is rejected (status 1) by mpt_indexed_trie_root_small.
+OVER_CAP="$(python3 - <<'PY'
+vals = [f"{i % 256:02x}" for i in range(2049)]
+print("[" + ",".join(repr(v) for v in vals) + "]")
+PY
+)"
+run_case "over_cap_2049" "$OVER_CAP" 1 || FAILED=1
 
 [[ "$FAILED" -eq 0 ]] && echo "==> PASS: indexed trie root builder matches execution-specs" \
   || { echo "==> FAIL"; exit 1; }


### PR DESCRIPTION
## Summary
- The indexed trie-root builder (`mpt_indexed_trie_root_small`, used for tx/receipt/withdrawal roots) only encoded 1-byte (0..127) and 2-byte (128..255, `0x81 XX`) RLP index keys and capped at 256 entries — false-rejecting valid blocks with ≥257 txs/withdrawals, while execution-specs computes the correct trie root for any count.
- Added the **3-byte index-key** case: for `256 ≤ i < 65536`, `rlp(i) = 0x82 hi lo` → nibbles `[8, 2, hi>>4, hi&15, lo>>4, lo&15]`.
- Widened the `itr_paths` per-entry stride **4→8 bytes** (a 6-nibble path no longer overruns the next slot), raised the `mpt_indexed_trie_root_small` cap and the `BlockVerdict` tx-root cap **256→2048**, and enlarged `itr_paths`/`itr_changes`/`svf_tx_descriptors` buffers in both the production (`BlockVerdictDataSection`) and probe (`MptIndexedTrieRoot`) data sections.

## Verification
- `scripts/codegen-zisk-mpt-indexed-trie-root-small-check.sh` (compares against the real `ethereum.merkle_patricia_trie` root): new **`keys_257_three_byte`** (index 256 = 3-byte key) and **`keys_300_three_byte`** produce spec-correct roots; **`over_cap_2049`** rejects (status 1); all existing 0..256 cases unchanged → **no regression**.
- EEST regression (`scripts/codegen-eest-stateless-check.sh --jobs 2`): `frontier/opcodes/all_opcodes` 3/3, `reserve_price_boundary` 3/3, `multiple_deposit_from_same_eoa_high_count` (200-tx) 1/1 — all still full-match.
- `scripts/check-file-size.sh`, `scripts/check-unimported.sh`, forbidden-tactic scan: clean. Full `lake build`: green.

## Scope
Addresses the ≥129-entry indexed-trie-root gap (bead `evm-asm-r9zq0`, children `.1`/`.2`). The 1021-tx `block_2d_gas_valid_when_cumulative_exceeds_limit` fixture now advances **past** the tx-root cap but still fails in the post-state-root replay (`bsr_fail=111`) — a separate large-block state-root capacity issue tracked under `evm-asm-r9zq0.3`.

Bead: evm-asm-r9zq0.1.

Authored by @pirapira; implemented by Claude Code