### PR TITLE
fix(eest): exempt system contracts from code-preimage gate at missing-code catch-all

### DIFF
--- a/EvmAsm/Codegen/Programs/BalCodePreimages.lean
+++ b/EvmAsm/Codegen/Programs/BalCodePreimages.lean
@@ -256,6 +256,16 @@ def balCodePreimagesValidFunction : String :=
   "  bnez a0, .Lbbcv_next\n" ++
   "  j .Lbbcv_missing_code\n" ++
   ".Lbbcv_missing_code:\n" ++
+  "  # Final reprieve: fork-level system contracts (EIP-2935/4788/7002/7251/\n" ++
+  "  # 6110) never require an ordinary witness.codes bytecode preimage, even\n" ++
+  "  # when their BAL row is balance/nonce-shaped rather than a pure touch\n" ++
+  "  # (e.g. a system call that reaches the gas limit and is tolerated by\n" ++
+  "  # process_unchecked_system_transaction). The executable spec validates\n" ++
+  "  # such blocks without the predeploy code in the witness, so the guest's\n" ++
+  "  # code-preimage gate must not reject them either.\n" ++
+  "  la t0, bbcv_addr_off; ld t1, 0(t0); add a0, s10, t1\n" ++
+  "  jal ra, bbcv_addr_is_system_contract\n" ++
+  "  bnez a0, .Lbbcv_next\n" ++
   "  li a0, 1; j .Lbbcv_ret\n" ++
   ".Lbbcv_parse_fail:\n" ++
   "  li a0, 2\n" ++


### PR DESCRIPTION
## Summary
- `bal_code_preimages_valid` recognized the fork-level system contracts (EIP-2935/4788/7002/7251/6110) only on the pure-touch path. When a system contract's BAL row is balance/nonce-shaped instead of a pure touch — e.g. the EIP-7002 withdrawal predeploy in a `system_contract_reaches_gas_limit` block, where the system call is tolerated by `process_unchecked_system_transaction` — the account reached the `.Lbbcv_missing_code` catch-all and was rejected for a missing `witness.codes` preimage.
- The executable spec validates such blocks **without** the (here 72945-byte) predeploy code in the witness (`witness_len=834`), so the guest must not require it. Added a final is-system-contract reprieve at `.Lbbcv_missing_code`, diverting the five recognized predeploy addresses to `.Lbbcv_next`.
- The guard is strictly more permissive and matches only those five addresses, so it cannot turn any previously-passing row into a failure.

## Verification
- Localized via instrumentation: the rejected account was loop index 0, last-4 address bytes `0x4C007002` = the EIP-7002 withdrawal predeploy `0x00000961ef480eb55e80d19ad83579a64c007002`, which `bbcv_addr_is_system_contract` already recognizes.
- `modified_withdrawal_contract/system_contract_errors`: the `system_contract_reaches_gas_limit` row now reaches **full match** (was `succ guest=00 exp=01`, `bv_fail=11`); the fixture goes from 3/4 to 4/4 full match.
- `lake build`, `check-file-size.sh`, `check-unimported.sh` all green; no forbidden tactics.

Note: a second `reaches_gas_limit` variant (label `00002`) now clears the code-preimage gate (`bv_fail=11`→`0`) but remains blocked by a separate gas-arena/receipts-root issue (`brr_status=3`, `gas_arena_status=2`) — tracked separately.

Bead: evm-asm-49hzw.

Authored by @pirapira; implemented by Claude Code