### PR TITLE
fix(codegen): link tx_eip4844_validate_blob_hashes into the verdict probe prologue

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -971,6 +971,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   rlpFieldToU64Function ++ "\n" ++
   txTypeDispatchFunction ++ "\n" ++
   txEip4844DecodeFunction ++ "\n" ++
+  txEip4844ValidateBlobHashesFunction ++ "\n" ++
   sszTxListVersionedHashesMatchFunction ++ "\n" ++
   txExtractToAddressFunction ++ "\n" ++
   txExtractValueFunction ++ "\n" ++


### PR DESCRIPTION
## Summary
Fixes the link regression in **evm-asm-pkod3**. PR #8493 wired `eip8037_tx_gas_gate` to call `tx_eip4844_validate_blob_hashes` (the EIP-4844 KZG version-byte check) and linked that helper into `statelessVerdictV2GuestClosure` (the guest body) — but **not** into `ziskStatelessVerdictV2Prologue` (the `zisk_stateless_verdict_v2` debug verdict probe), which also concatenates `eip8037_tx_gas_gate`. The `stateless_guest` ELF linked fine, so the breakage stayed latent until the debug verdict ELF was built:

```
riscv64-elf-ld: ...zisk_stateless_verdict_v2_debug.o: in function `eip8037_tx_gas_gate':
(.text+0x134ec): undefined reference to `tx_eip4844_validate_blob_hashes'
```

Concatenate `txEip4844ValidateBlobHashesFunction` in `ziskStatelessVerdictV2Prologue` right after `txEip4844DecodeFunction` (its scratch + deps are already in the verdict data section).

## Verification
- `zisk_stateless_verdict_v2` now links to ELF (was: undefined reference); `tx_eip4844_validate_blob_hashes` defined exactly once.
- `stateless_guest` still links to ELF with the helper defined exactly once (no double-definition).
- `lake build`, `check-file-size.sh`, `check-unimported.sh` clean; no forbidden tactics.

One-line fix. Bead: evm-asm-pkod3.

Authored by @pirapira; implemented by Claude Code