### PR TITLE
feat(block-verdict): integrate single-frame contract-recipient dispatch

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -479,6 +479,19 @@ def blockVerdictFunction : String :=
   "  la a0, bv_simple_transfer_tx\n" ++
   "  jal ra, simple_transfer_tx_context\n" ++
   "  la t2, bv_simple_transfer_tx; ld t0, 0(t2); bnez t0, .Lbv_after_tx_gas_precharge\n" ++
+  -- evm-asm-fhsxz.2.4.2.57.11.6.4.3.2: route a contract recipient (non-empty code)
+  -- to the execution-derived contract dispatch; EOA (empty-code) recipients fall
+  -- through to the existing simple-transfer path BYTE-IDENTICALLY (no regression).
+  "  ld a0, 8(s0); ld a1, 16(s0); addi a2, t2, 72; ld a3, 80(s0); ld a4, 88(s0); la a5, bv_tx_recipient_code_hash\n" ++
+  "  jal ra, code_hash_at_header_state_root\n" ++
+  "  bnez a0, .Lbv_cd_eoa_restore        # code-hash lookup failed -> conservative EOA path\n" ++
+  "  la t0, bv_tx_recipient_code_hash; la t1, chahsr_empty_code_hash\n" ++
+  "  ld t3,  0(t0); ld t4,  0(t1); bne t3, t4, .Lbv_contract_dispatch\n" ++
+  "  ld t3,  8(t0); ld t4,  8(t1); bne t3, t4, .Lbv_contract_dispatch\n" ++
+  "  ld t3, 16(t0); ld t4, 16(t1); bne t3, t4, .Lbv_contract_dispatch\n" ++
+  "  ld t3, 24(t0); ld t4, 24(t1); bne t3, t4, .Lbv_contract_dispatch\n" ++
+  ".Lbv_cd_eoa_restore:\n" ++
+  "  la t2, bv_simple_transfer_tx        # restore t2 for the EOA path (jal clobbered it)\n" ++
   "  ld t0,  96(t2); bnez t0, .Lbv_tx_gas_precharge_nonzero_value\n" ++
   "  ld t0, 104(t2); bnez t0, .Lbv_tx_gas_precharge_nonzero_value\n" ++
   "  ld t0, 112(t2); bnez t0, .Lbv_tx_gas_precharge_nonzero_value\n" ++
@@ -619,6 +632,85 @@ def blockVerdictFunction : String :=
   "  la a1, bv_runtime_payload\n" ++
   "  la t2, bv_exec_p; ld a2, 0(t2)\n" ++
   "  jal ra, stage_runtime_payload\n" ++
+  "  bnez a0, .Lbv_after_tx_gas_precharge\n" ++
+  "  la t4, runtime_dispatcher_input_ptr; la t5, bv_runtime_payload; addi t5, t5, 8; sd t5, 0(t4)\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd s0, 0(sp); sd s1, 8(sp); sd s2, 16(sp); sd s3, 24(sp)\n" ++
+  "  jal ra, runtime_dispatcher_call\n" ++
+  "  ld s0, 0(sp); ld s1, 8(sp); ld s2, 16(sp); ld s3, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  la t4, runtime_dispatcher_input_ptr; sd zero, 0(t4)\n" ++
+  "  la t2, evm_env; ld t3, 568(t2)\n" ++
+  "  la t4, bv_runtime_gas_left; sd t3, 0(t4)\n" ++
+  "  la t4, runtime_tx_calldata_floor; ld t5, 0(t4)\n" ++
+  "  la t4, bv_runtime_calldata_floor; sd t5, 0(t4)\n" ++
+  "  la t4, bv_runtime_refund_counter; sd zero, 0(t4)\n" ++
+  "  la t4, bvgr_runtime_gas_left_ptr; la t5, bv_runtime_gas_left; sd t5, 0(t4)\n" ++
+  "  la t4, bvgr_runtime_refund_counter_ptr; la t5, bv_runtime_refund_counter; sd t5, 0(t4)\n" ++
+  "  la t4, bvgr_runtime_calldata_floor_ptr; la t5, bv_runtime_calldata_floor; sd t5, 0(t4)\n" ++
+  "  li t5, 1; la t4, bvgr_runtime_count; sd t5, 0(t4)\n" ++
+  "  j .Lbv_after_tx_gas_precharge       # EOA runtime done; skip the contract-dispatch block\n" ++
+  -- evm-asm-fhsxz.2.4.2.57.11.6.4.3.2: contract-recipient execution. Reached only
+  -- from the early contract-vs-EOA branch. Gated on bytecode_is_self_contained so we
+  -- only feed runtime gas to the EIP-7778/8037 gate when execution is exact (own
+  -- storage only, no un-staged state); any miss/unsupported branches to
+  -- .Lbv_after_tx_gas_precharge with bvgr_runtime_count left 0 (conservative).
+  ".Lbv_contract_dispatch:\n" ++
+  "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++
+  "  la t2, bv_simple_transfer_tx; addi a2, t2, 72\n" ++
+  "  ld a3, 80(s0); ld a4, 88(s0)\n" ++
+  "  la t0, svf_codes_ptr; ld a5, 0(t0); la t0, svf_codes_len; ld a6, 0(t0)\n" ++
+  "  jal ra, code_at_header_state_root\n" ++
+  "  bnez a0, .Lbv_after_tx_gas_precharge\n" ++
+  "  la t0, svf_codes_ptr; ld t1, 0(t0); la t2, cahsr_code_offset; ld t3, 0(t2); add a0, t1, t3\n" ++
+  "  la t2, cahsr_code_length; ld a1, 0(t2)\n" ++
+  "  la t0, bvcd_code_ptr; sd a0, 0(t0); la t0, bvcd_code_len; sd a1, 0(t0)\n" ++
+  "  jal ra, bytecode_is_self_contained\n" ++
+  "  bnez a0, .Lbv_after_tx_gas_precharge\n" ++
+  "  la t0, bv_bal_start; ld a0, 0(t0); la t0, bv_bal_len; ld a1, 0(t0)\n" ++
+  "  la t2, bv_simple_transfer_tx; addi a2, t2, 72; la a3, bvcd_acct_ptr; la a4, bvcd_acct_len\n" ++
+  "  jal ra, bal_find_account_by_address\n" ++
+  "  li t0, 2; beq a0, t0, .Lbv_after_tx_gas_precharge\n" ++
+  "  bnez a0, .Lbv_cd_zero_storage\n" ++
+  "  la t0, bvcd_acct_ptr; ld a0, 0(t0); la t0, bvcd_acct_len; ld a1, 0(t0); la a2, bvcd_keys\n" ++
+  "  jal ra, bal_recipient_storage_keys\n" ++
+  "  la t0, bvcd_key_count; sd a0, 0(t0); j .Lbv_cd_read_storage\n" ++
+  ".Lbv_cd_zero_storage:\n" ++
+  "  la t0, bvcd_key_count; sd zero, 0(t0)\n" ++
+  ".Lbv_cd_read_storage:\n" ++
+  "  la t0, bvcd_i; sd zero, 0(t0)\n" ++
+  ".Lbv_cd_sloop:\n" ++
+  "  la t0, bvcd_i; ld t1, 0(t0); la t2, bvcd_key_count; ld t3, 0(t2); beq t1, t3, .Lbv_cd_stage\n" ++
+  "  slli t4, t1, 5; la t5, bvcd_keys; add a3, t5, t4\n" ++
+  "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++
+  "  la t2, bv_simple_transfer_tx; addi a2, t2, 72\n" ++
+  "  ld a4, 80(s0); ld a5, 88(s0); ld a6, 80(s0); ld a7, 88(s0)\n" ++
+  "  jal ra, slot_at_header_state_root\n" ++
+  "  la t0, bvcd_i; ld t1, 0(t0); slli t2, t1, 6; la t3, bvcd_preload; add t4, t3, t2\n" ++
+  "  slli t2, t1, 5; la t3, bvcd_keys; add t5, t3, t2\n" ++
+  "  li t6, 0\n" ++
+  ".Lbv_cd_kcopy:\n" ++
+  "  li t2, 32; beq t6, t2, .Lbv_cd_kdone\n" ++
+  "  add t2, t5, t6; lbu t3, 0(t2); add t2, t4, t6; sb t3, 0(t2); addi t6, t6, 1; j .Lbv_cd_kcopy\n" ++
+  ".Lbv_cd_kdone:\n" ++
+  "  li t2, 5; beq a0, t2, .Lbv_cd_vzero\n" ++
+  "  bnez a0, .Lbv_after_tx_gas_precharge\n" ++
+  "  la t5, sahsr_u256; li t6, 0\n" ++
+  ".Lbv_cd_vcopy:\n" ++
+  "  li t2, 32; beq t6, t2, .Lbv_cd_vdone\n" ++
+  "  add t2, t5, t6; lbu t3, 0(t2); add t2, t4, t6; addi t2, t2, 32; sb t3, 0(t2); addi t6, t6, 1; j .Lbv_cd_vcopy\n" ++
+  ".Lbv_cd_vzero:\n" ++
+  "  li t6, 0\n" ++
+  ".Lbv_cd_vzloop:\n" ++
+  "  li t2, 32; beq t6, t2, .Lbv_cd_vdone\n" ++
+  "  add t2, t4, t6; addi t2, t2, 32; sb zero, 0(t2); addi t6, t6, 1; j .Lbv_cd_vzloop\n" ++
+  ".Lbv_cd_vdone:\n" ++
+  "  la t0, bvcd_i; ld t1, 0(t0); addi t1, t1, 1; sd t1, 0(t0); j .Lbv_cd_sloop\n" ++
+  ".Lbv_cd_stage:\n" ++
+  "  la a0, bv_simple_transfer_tx; la a1, bv_runtime_payload; la t2, bv_exec_p; ld a2, 0(t2)\n" ++
+  "  la t0, bvcd_code_ptr; ld a3, 0(t0); la t0, bvcd_code_len; ld a4, 0(t0)\n" ++
+  "  la a5, bvcd_preload; la t0, bvcd_key_count; ld a6, 0(t0)\n" ++
+  "  jal ra, stage_runtime_payload_code\n" ++
   "  bnez a0, .Lbv_after_tx_gas_precharge\n" ++
   "  la t4, runtime_dispatcher_input_ptr; la t5, bv_runtime_payload; addi t5, t5, 8; sd t5, 0(t4)\n" ++
   "  addi sp, sp, -32\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -191,10 +191,21 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bvgr_runtime_calldata_floor_ptr:\n  .zero 8\n" ++
   "bvgr_runtime_count:\n  .zero 8\n" ++
   ".balign 8\n" ++
-  "bv_runtime_payload:\n  .zero 584\n" ++
+  "bv_runtime_payload:\n  .zero 4096\n" ++
   "bv_runtime_gas_left:\n  .zero 8\n" ++
   "bv_runtime_refund_counter:\n  .zero 8\n" ++
   "bv_runtime_calldata_floor:\n  .zero 8\n" ++
+  -- Contract-recipient dispatch scratch (evm-asm-fhsxz.2.4.2.57.11.6.4.3.2).
+  ".balign 8\n" ++
+  "bvcd_code_ptr:\n  .zero 8\n" ++
+  "bvcd_code_len:\n  .zero 8\n" ++
+  "bvcd_acct_ptr:\n  .zero 8\n" ++
+  "bvcd_acct_len:\n  .zero 8\n" ++
+  "bvcd_key_count:\n  .zero 8\n" ++
+  "bvcd_i:\n  .zero 8\n" ++
+  "bvcd_keys:\n  .zero 512\n" ++       -- up to 16 x 32-byte slot keys
+  "bvcd_preload:\n  .zero 1024\n" ++   -- up to 16 x 64-byte (key,value) pairs
+
   "bv_eip7778_status:\n  .zero 8\n" ++
   "bv_eip7778_index:\n  .zero 8\n" ++
   "bv_eip7778_used:\n  .zero 8\n" ++
@@ -611,6 +622,59 @@ def ziskStatelessVerdictV2DataSection : String :=
   "mxne_cursor:\n  .zero 8\n" ++
   "mxne_total_payload:\n  .zero 8\n" ++
   "mxne_hp_buf:\n  .zero 1024\n" ++
-  "mxne_payload_buf:\n  .zero 16384\n"
+  "mxne_payload_buf:\n  .zero 16384\n" ++
+  -- .6.4.3.2 contract-dispatch leaf-helper scratch. Shared scratch (zk3_state,
+  -- wlh_*, mnk_*, mbc_*, mw_*, mlk_*, ad_*, aa_*, hesr_*) is already provided by
+  -- this guest data section, so only the slot/code-side private labels are added
+  -- here (deduped against the guest object via nm). The contract-stage/self-
+  -- contained/bal-find/bal-storage probe scratch uses unique prefixes (srpc_,
+  -- bsc_, bfa_, brsk_) so it cannot collide.
+  -- slot_at_index leaf scratch:
+  ".balign 8\n" ++
+  "si_value_len:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "si_value_scratch:\n  .zero 256\n" ++
+  -- slot_at_header_state_root scratch:
+  ".balign 32\n" ++
+  "sahsr_state_root:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "sahsr_acct_struct:\n  .zero 104\n" ++
+  ".balign 32\n" ++
+  "sahsr_u256:\n  .zero 32\n" ++
+  -- code_at_header_state_root scratch:
+  ".balign 32\n" ++
+  "cahsr_state_root:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "cahsr_acct_struct:\n  .zero 104\n" ++
+  "cahsr_code_offset:\n  .zero 8\n" ++
+  "cahsr_code_length:\n  .zero 8\n" ++
+  -- stage_runtime_payload_code private scratch:
+  ".balign 8\n" ++
+  "srpc_ctx:\n  .zero 192\n" ++
+  "srpc_exec:\n  .zero 512\n" ++
+  "srpc_code:\n  .zero 64\n" ++
+  "srpc_payload:\n  .zero 1024\n" ++
+  -- bal_find_account_by_address private scratch:
+  ".balign 8\n" ++
+  "bfa_cnt:\n  .zero 8\n" ++
+  "bfa_aoff:\n  .zero 8\n" ++
+  "bfa_alen:\n  .zero 8\n" ++
+  "bfa_doff:\n  .zero 8\n" ++
+  "bfa_dlen:\n  .zero 8\n" ++
+  "bfa_out_ptr:\n  .zero 8\n" ++
+  "bfa_out_len:\n  .zero 8\n" ++
+  "bfa_addr_hit:\n  .zero 20\n" ++
+  "bfa_addr_miss:\n  .zero 20\n" ++
+  -- bal_recipient_storage_keys private scratch:
+  ".balign 8\n" ++
+  "brsk_off:\n  .zero 8\n" ++
+  "brsk_len:\n  .zero 8\n" ++
+  "brsk_cnt:\n  .zero 8\n" ++
+  "brsk_eoff:\n  .zero 8\n" ++
+  "brsk_elen:\n  .zero 8\n" ++
+  "brsk_soff:\n  .zero 8\n" ++
+  "brsk_slen:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "brsk_out:\n  .zero 256\n"
 
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
@@ -13,6 +13,10 @@ import EvmAsm.Codegen.Programs.TxBlobGas
 import EvmAsm.Codegen.Programs.SszWithdrawal
 
 import EvmAsm.Codegen.Programs.MptEncodeLeafBranch
+import EvmAsm.Codegen.Programs.BlockVerdictContractStage
+import EvmAsm.Codegen.Programs.BlockVerdictSelfContained
+import EvmAsm.Codegen.Programs.BlockVerdictBalFindAccount
+import EvmAsm.Codegen.Programs.BlockVerdictContractStorage
 
 namespace EvmAsm.Codegen
 
@@ -181,6 +185,20 @@ def statelessVerdictV2GuestClosure : String :=
   txGasSenderBalLookupFunction ++ "\n" ++
   simpleTransferTxContextFunction ++ "\n" ++
   stageRuntimePayloadFunction ++ "\n" ++
+  -- .6.4.3.2 contract-recipient dispatch: state/code lookups + BAL storage-key
+  -- enumeration + self-containment gate + variable pack-bytecode staging. The
+  -- shared callees (account_at_address, header_extract_state_root,
+  -- witness_lookup_by_hash, rlp_list_nth_item/count_items, mset_memcpy) are
+  -- already in this closure; only these top-level bodies + slot leaf helpers
+  -- (slot_at_index/slot_decode_u256) are new.
+  slotDecodeU256Function ++ "\n" ++
+  slotAtIndexFunction ++ "\n" ++
+  slotAtHeaderStateRootFunction ++ "\n" ++
+  codeAtHeaderStateRootFunction ++ "\n" ++
+  bytecodeIsSelfContainedFunction ++ "\n" ++
+  balFindAccountByAddressFunction ++ "\n" ++
+  balRecipientStorageKeysFunction ++ "\n" ++
+  stageRuntimePayloadCodeFunction ++ "\n" ++
   txExtractNonceAndGasFunction ++ "\n" ++
   txExtractGasPricingFunction ++ "\n" ++
   u256MinFunction ++ "\n" ++


### PR DESCRIPTION
## Summary
- Wires the `.6.4.3.2` single-frame **contract-recipient runtime execution** into `block_verdict`: when the tx recipient has non-empty code, the verdict looks up the recipient's code at the header state root, gates it through `bytecode_is_self_contained`, enumerates the BAL storage keys, reads each slot value from the witness, stages the variable pack-bytecode payload via `stage_runtime_payload_code`, and dispatches the runtime interpreter with gas capture — mirroring the existing EOA path's gas-result wiring. EOA recipients keep their current path unchanged.
- **Link fix:** embeds the eight previously-probe-only helper bodies into the guest function closure (`statelessVerdictV2GuestClosure`) so the new calls resolve at link time — `slot_decode_u256`, `slot_at_index`, `slot_at_header_state_root`, `code_at_header_state_root`, `bytecode_is_self_contained`, `bal_find_account_by_address`, `bal_recipient_storage_keys`, `stage_runtime_payload_code` — and imports the four probe modules.
- Their private data labels (`si_*`, `sahsr_*`, `cahsr_*`, `srpc_*`, `bfa_*`, `brsk_*`) are added to `ziskStatelessVerdictV2DataSection`, **deduped against the guest's already-defined shared scratch via `nm`** (zk3_state/wlh_*/mnk_*/mbc_*/mw_*/mlk_*/ad_*/aa_*/hesr_* are not re-emitted), so no duplicate symbols are produced.

## Verification
- Full `lake build` green (3194 jobs, incl. RegistryInvariants).
- Guest ELF links with **0 undefined references / 0 duplicate symbols**; all 11 symbols defined.
- `check-file-size`, `check-unimported`, `check-forbidden-tactics` all pass; no `sorry`/`native_decide`/`bv_decide`.
- A 60-row random EEST sweep (seed 70707, `--no-build` on the freshly-linked ELF) showed **24/24 PASS(full)** with zero regressions before being cut short.

Bead: evm-asm-fhsxz.2.4.2.57.11.6.4.3.2.

Authored by @pirapira; implemented by Claude Code