### PR TITLE
docs(call-frame): clarify x22 shared_env split is proof-cheap (parametric env-load)

### DIFF
--- a/docs/call-frame-memory-layout.md
+++ b/docs/call-frame-memory-layout.md
@@ -114,13 +114,27 @@ LOG accumulation list — see §6 for the per-frame *checkpoint* into it),
 `opcode_handlers`, `lp64_stack`, `zk3_state`, account-witness/precompile/modexp/
 sha256 scratch, and the whole BlockVerdict verdict-spine data.
 
-> **Implementation note:** keep the *intra-frame* env field offsets identical to
-> today (0,32,64,96,416,424,496,568, log 448-480). Handlers that do
-> `ld …, N(x20)` keep working once `x20` points at the *per-frame* env subblock.
-> The shared fields move to a separate `shared_env` block addressed by a new
-> dedicated register (proposal: **x22 = shared_env base**), and the handlers for
-> ORIGIN/GASPRICE/COINBASE/…/BLOBBASEFEE/BLOCKHASH/SLOTNUM switch from `N(x20)`
-> to `M(x22)`. This is the one mechanical handler edit the split forces.
+> **Implementation note.** The shared fields move to a separate `shared_env`
+> block addressed by a dedicated register (**x22 = shared_env base**); the
+> shared-field handlers (ORIGIN/GASPRICE/COINBASE/…/BLOBBASEFEE/BLOCKHASH/SLOTNUM)
+> read it instead of the per-frame env.
+>
+> This is **proof-cheap**, not proof-blocked. The env handlers are the verified
+> `evm_env_load .x20 .x15 .<field>` Program, but `evm_env_load_spec_within`
+> (`EvmAsm/Evm64/Env/Spec.lean:115`) is *parametric* over both `envBaseReg` and
+> `field` — it's a layout/framing triple ("load the 4 limbs of `field.value env`
+> from `envAddr + field.offset + 8*i`"), with no arithmetic tied to a specific
+> register or offset. So the split needs only: (a) pass `.x22` as the base for
+> shared-field handlers (the generic lemma already covers any base register), and
+> (b) give the shared fields their `shared_env`-relative offsets via the
+> `SimpleEnvField.offset` map (`EvmAsm/Evm64/Env/Field.lean:72`) — the same
+> generic lemma applies at the new offsets unchanged. No new proof obligations.
+>
+> (Alternative considered: keep one full contiguous env per frame and *replicate*
+> the shared fields, copying them parent→child on descent — also proof-trivial,
+> ~0.4 MiB + a small per-descent memcpy. The `x22` split is preferred as the
+> single-source-of-truth for block/tx-global env; replication is the fallback if
+> reserving x22 proves inconvenient.)
 
 ---
 
@@ -196,9 +210,9 @@ Per-frame registers recomputed as `frame_array_base + depth*FRAME_STRIDE + sub`:
 | x10 | PC (offset into code) | yes (saved to `frame_pc` on descent) |
 | x12 | operand stack ptr (grows ↓) | yes (= `frame[d]+frame_stack_top`) |
 | x13 | memBaseReg (EVM memory base) | yes (= `frame[d]+frame_mem`) |
-| x20 | per-frame env base | yes (= `frame[d]+frame_env`) |
+| x20 | per-frame env base (per-frame fields only) | yes (= `frame[d]+frame_env`) |
 | x21 | code base (→ witness.codes slice) | yes (saved to `frame_codebase`) |
-| x22 | **shared_env base** (new) | no (constant) |
+| x22 | **shared_env base** (block/tx-global env; proof-cheap, see §3 note) | no (constant) |
 | x2  | lp64 helper sp | no (shared; helpers run within one frame at a time) |
 | x?? | **depth counter** (proposal: a fixed `.data` cell `evm_call_depth`) | global |
 


### PR DESCRIPTION
## Summary
- Clarifies the call-frame design's env-split section: re-pointing the
  shared-field handlers (ORIGIN/GASPRICE/COINBASE/…/BLOBBASEFEE/BLOCKHASH/SLOTNUM)
  to a dedicated `x22 = shared_env` base is **proof-cheap, not proof-blocked**.
- The env reads go through the verified `evm_env_load` Program, but
  `evm_env_load_spec_within` (`EvmAsm/Evm64/Env/Spec.lean:115`) is **parametric
  over both `envBaseReg` and `field`** — a layout/framing triple with no
  arithmetic tied to a specific register or offset. So the split needs only
  (a) passing `.x22` as the base (generic lemma covers any base register) and
  (b) `shared_env`-relative offsets via `SimpleEnvField.offset`
  (`EvmAsm/Evm64/Env/Field.lean:72`); the same lemma applies unchanged.
- Records the replication approach (full contiguous env per frame, copy shared
  fields on descent) as the proof-trivial fallback.

No semantic change to the layout — this de-risks the `.61.3` implementation by
documenting that the verified env-handler surface can be re-pointed freely.

Bead: evm-asm-fhsxz.2.4.2.61 (call-frame skeleton; design clarification).

Authored by @pirapira; implemented by Claude Code