### PR TITLE
feat(call-frame): establish call_frame_arena alias over basr_values (inert)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -536,8 +536,19 @@ def ziskStatelessVerdictV2DataSection : String :=
   "baada_item_len:\n  .zero 8\n" ++
   "basr_records:\n  .zero " ++ toString (bsrMaxStateChanges * bsrAccountRecordBytes) ++
   "\nbasr_paths:\n  .zero " ++ toString (bsrMaxStateChanges * bsrPathBytes) ++
-  "\nbasr_values:\n  .zero " ++ toString (bsrMaxStateChanges * bsrEncodedAccountBytes) ++
-  "\nbasr_accounts:\n  .zero " ++ toString (bsrMaxStateChanges * bsrEncodedAccountBytes) ++ "\n" ++
+  -- .61.3.1: the nested call-frame arena aliases basr_values+basr_accounts.
+  -- These two are block_state_root replay scratch, read ONLY inside
+  -- block_state_root (BlockVerdict.lean <=302) and dead during tx execution
+  -- (gate-verified: no post-replay reader); the contiguous pair is
+  -- 2*bsrMaxStateChanges*bsrEncodedAccountBytes = 244 MiB >= the 1025*FRAME_STRIDE
+  -- = 164 MiB the frame arena needs, so the arena reuses this region (union, zero
+  -- net RAM growth) once the dispatcher is rebased onto frame[0] in .61.3.2.
+  -- `basr_records` (just above) is LIVE during execution (:528/577/620) and is
+  -- excluded by aliasing here, after it. See docs/call-frame-memory-layout.md §5.
+  "\ncall_frame_arena:\n" ++
+  "basr_values:\n  .zero " ++ toString (bsrMaxStateChanges * bsrEncodedAccountBytes) ++
+  "\nbasr_accounts:\n  .zero " ++ toString (bsrMaxStateChanges * bsrEncodedAccountBytes) ++
+  "\ncall_frame_arena_end:\n" ++ "\n" ++
   "bara_item_off:\n  .zero 8\n" ++
   "bara_item_len:\n  .zero 8\n" ++
   "bara_acct_len:\n  .zero 8\n" ++


### PR DESCRIPTION
## Summary
- First, inert step of `.61.3.1` (nested call-frame arena placement): emit
  `call_frame_arena` / `call_frame_arena_end` labels aliasing the contiguous
  `basr_values`+`basr_accounts` `block_state_root` replay scratch.
- That pair is **244 MiB**, **gate-verified execution-dead** (read only inside
  `block_state_root`, `BlockVerdict.lean ≤ 302`; no post-replay reader). The frame
  arena needs `1025 * FRAME_STRIDE` = **164 MiB** ≤ 244 MiB, so it reuses this
  region as a **union** once the dispatcher is rebased onto `frame[0]` (`.61.3.2`)
  — zero net RAM growth, fitting ziskemu's 512 MiB window (which is otherwise
  ~full; see docs §5).
- `basr_records` (LIVE during execution at `:528/577/620` — gas/balance verify)
  sits before `basr_values` and is **excluded** by aliasing here.

## Why inert / safe
Nothing references `call_frame_arena` yet, so the single-frame (depth-0) guest is
**byte-identical**. No new section, no `--section-start` (the earlier
`.callframes`-at-`0xa4000000` approach overlapped `.data` — RAM is full).

## Verification
- Full `lake build` green (3195 jobs); `check-file-size`, `check-unimported` pass;
  no forbidden tactics.
- Guest **links cleanly**: `call_frame_arena` = `basr_values` @ `0xae62e790`,
  `call_frame_arena_end` @ `0xbda54b90`, span 244 MiB, no overlap.

Bead: evm-asm-fhsxz.2.4.2.61.3.1. Builds on the corrected design (#8512).

Authored by @pirapira; implemented by Claude Code