### PR TITLE
feat(call-frame): value-bearing CALL balance gate -> correct fail-push

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -2217,7 +2217,14 @@ def emitRuntimeDispatcherEmbeddedHelperData : String :=
   ".balign 8\n" ++
   "cd_desc:\n  .zero 96\n" ++
   ".balign 32\n" ++
-  "cd_zero_word:\n  .zero 32\n"
+  "cd_zero_word:\n  .zero 32\n" ++
+  -- Scratch for the value-bearing CALL balance gate (`callDescendFallThrough`):
+  -- the caller address (env+0) as canonical 20-byte big-endian, and the call
+  -- value + looked-up caller balance as 32-byte big-endian for the compare.
+  ".balign 8\n" ++
+  "cd_caller_be:\n  .zero 32\n" ++
+  "cd_value_be:\n  .zero 32\n" ++
+  "cd_balance_be:\n  .zero 32\n"
 
 /-- Runtime-bytecode `.data` section. Drops the `evm_code:` block
     (no baked bytecode); everything else matches the `.data`-baked

--- a/EvmAsm/Codegen/Programs/NoopChildFrame.lean
+++ b/EvmAsm/Codegen/Programs/NoopChildFrame.lean
@@ -1201,6 +1201,10 @@ def callPushZeroFallThrough (netPopBytes : Nat) : String :=
     args, x13=parent memory, x20=parent env, x21=parent code base), this:
       1. clears the precompile frame;
       2. depth gate: `evm_call_depth >= 1024` → push 0 (fail);
+      2b. balance gate (value-bearing CALL only): if the caller (frame ADDRESS,
+         env+0) balance < transfer value → push 0 (fail, no descent), per EVM
+         `generic_call`. Skipped for STATICCALL (no value), value==0, or when no
+         account-witness context is attached (env+584 == 0);
       3. resolves the callee bytecode via `code_at_header_state_root` (witness ctx
          from env+576..616). It preserves x20/x21 but clobbers the a-regs (x10/x12/
          x13), so those are saved across the call. status 2 (EMPTY_CODE / EOA) →
@@ -1224,6 +1228,62 @@ def callDescendFallThrough
   "  ld t0, 0(t0)\n" ++
   "  li t1, 1024\n" ++
   "  bgeu t0, t1, .Lcd_fail_" ++ tag ++ "\n" ++
+  -- balance gate (value-bearing CALL only): EVM `generic_call` rejects the call
+  -- with a pushed 0 when the caller's balance is below the transfer value
+  -- (vm/instructions/system.py; the value is NOT transferred and the sub-call is
+  -- not entered). Mirrors the verified CREATE-path caller-balance lookup: the
+  -- caller is the current frame's ADDRESS (env+0) as canonical 20-byte BE, and
+  -- the value is the stack word at valueOff. STATICCALL has no value (skipped).
+  (if isStatic then "" else
+    "  ld t3, " ++ toString valueOff ++ "(x12)\n" ++
+    "  ld t4, " ++ toString (valueOff+8) ++ "(x12)\n  or t3, t3, t4\n" ++
+    "  ld t4, " ++ toString (valueOff+16) ++ "(x12)\n  or t3, t3, t4\n" ++
+    "  ld t4, " ++ toString (valueOff+24) ++ "(x12)\n  or t3, t3, t4\n" ++
+    "  beqz t3, .Lcd_balok_" ++ tag ++ "\n" ++       -- value == 0: no transfer, skip
+    "  ld t3, 584(x20)\n" ++
+    "  beqz t3, .Lcd_balok_" ++ tag ++ "\n" ++        -- no account-witness ctx: skip
+    -- caller address env+19..env+0 -> cd_caller_be (canonical 20-byte big-endian)
+    "  la t0, cd_caller_be\n" ++
+    "  addi t1, x20, 19\n" ++
+    "  li t2, 20\n" ++
+    ".Lcd_addr_" ++ tag ++ ":\n" ++
+    "  lbu t3, 0(t1)\n  sb t3, 0(t0)\n" ++
+    "  addi t1, t1, -1\n  addi t0, t0, 1\n  addi t2, t2, -1\n" ++
+    "  bnez t2, .Lcd_addr_" ++ tag ++ "\n" ++
+    -- value word x12+valueOff (32 B) -> cd_value_be (big-endian: read +31..+0)
+    "  la t0, cd_value_be\n" ++
+    "  addi t1, x12, " ++ toString (valueOff+31) ++ "\n" ++
+    "  li t2, 32\n" ++
+    ".Lcd_val_" ++ tag ++ ":\n" ++
+    "  lbu t3, 0(t1)\n  sb t3, 0(t0)\n" ++
+    "  addi t1, t1, -1\n  addi t0, t0, 1\n  addi t2, t2, -1\n" ++
+    "  bnez t2, .Lcd_val_" ++ tag ++ "\n" ++
+    -- balance_at_header_state_root(caller) -> cd_balance_be. Save x10/x12/x13
+    -- (helper clobbers the a-regs that alias them); it preserves x20/x21.
+    "  addi sp, sp, -32\n" ++
+    "  sd x10, 0(sp); sd x12, 8(sp); sd x13, 16(sp)\n" ++
+    "  ld a0, 576(x20)\n" ++
+    "  ld a1, 584(x20)\n" ++
+    "  la a2, cd_caller_be\n" ++
+    "  ld a3, 592(x20)\n" ++
+    "  ld a4, 600(x20)\n" ++
+    "  la a5, cd_balance_be\n" ++
+    "  jal ra, balance_at_header_state_root\n" ++
+    "  mv t2, a0\n" ++
+    "  ld x10, 0(sp); ld x12, 8(sp); ld x13, 16(sp)\n" ++
+    "  addi sp, sp, 32\n" ++
+    "  bnez t2, .Lcd_fail_" ++ tag ++ "\n" ++         -- lookup failed/absent -> balance 0 < value
+    -- compare cd_balance_be vs cd_value_be (32-byte big-endian, MSB first)
+    "  la t0, cd_balance_be\n" ++
+    "  la t1, cd_value_be\n" ++
+    "  li t2, 32\n" ++
+    ".Lcd_cmp_" ++ tag ++ ":\n" ++
+    "  lbu t3, 0(t0)\n  lbu t4, 0(t1)\n" ++
+    "  bltu t3, t4, .Lcd_fail_" ++ tag ++ "\n" ++     -- balance < value: insufficient
+    "  bltu t4, t3, .Lcd_balok_" ++ tag ++ "\n" ++    -- balance > value: sufficient
+    "  addi t0, t0, 1\n  addi t1, t1, 1\n  addi t2, t2, -1\n" ++
+    "  bnez t2, .Lcd_cmp_" ++ tag ++ "\n" ++
+    ".Lcd_balok_" ++ tag ++ ":\n") ++
   -- resolve callee code (save x10/x12/x13 — code_at_header_state_root clobbers a-regs)
   "  addi sp, sp, -32\n" ++
   "  sd x10, 0(sp); sd x12, 8(sp); sd x13, 16(sp)\n" ++


### PR DESCRIPTION
## Summary
- The guest CALL descent handler (`callDescendFallThrough`) had the depth gate (`>=1024` → push 0) but not the EIP-150/`generic_call` **balance precheck**. Add it: for a value-bearing CALL, if the caller (current frame `ADDRESS`, env+0) balance is below the transfer value, push 0 and skip the descent (the value is not transferred and the sub-call is not entered), per `vm/instructions/system.py`.
- Mirrors the **verified CREATE-path caller-balance lookup**: caller address (env+19..env+0) → canonical 20-byte big-endian; call value (stack word at `valueOff`, +31..+0) → 32-byte big-endian; `balance_at_header_state_root` (preserves x20/x21; x10/x12/x13 saved across it); big-endian MSB-first compare.
- Gated to **non-static CALL with value != 0** and an attached account-witness context (`env+584 != 0`). STATICCALL is unaffected (no value). New BE scratch buffers `cd_caller_be`/`cd_value_be`/`cd_balance_be` in the guest helper data.

## Verification
- **Depth-0 EEST byte-identity: 40-row smoke = 40/40 full match, 0 fail, 0 error** (the dispatcher's descent is still jumped over in the live verdict flow, and the gate fires only for value-bearing CALLs exceeding balance, so depth-0 is unchanged).
- Guest ELF links cleanly (`balance_at_header_state_root` + `cd_*` symbols resolved). Full `lake build` green; file-size / unimported / forbidden-tactics gates clean.
- The dedicated **witness-based "value > balance → push 0" focused probe** (positive verification) needs a state-witness fixture and is tracked as a follow-up child bead.

Refs #8475. Bead: evm-asm-fhsxz.2.4.2.61.6.4.

Authored by @pirapira; implemented by Claude Code