### PR TITLE
test(call-frame): round-trip child runs guarded MSTORE + returns real data

### DIFF
--- a/EvmAsm/Codegen/Programs/CallFrameRoundtrip.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameRoundtrip.lean
@@ -11,16 +11,21 @@
   MANUALLY via `call_frame_descend` (with a fixed child-code blob, so no witness /
   `code_at_header_state_root` is needed), then `j .dispatch_loop`:
 
-    child code = [PUSH1 0; PUSH1 0; RETURN]  → runs at the child frame (depth 1)
-      → depth-aware RETURN sees depth>0 → `frame_return` → restores the parent
-      → parent resumes at parent_pc+1
-    parent code = [<descend placeholder>, PUSH1 0, SSTORE, STOP]
-      → the success word `frame_return` pushed is on the parent stack
-      → `PUSH1 0; SSTORE` stores it to slot 0; `STOP` halts at depth 0
+    child code = [PUSH1 0x42; PUSH1 0; MSTORE; PUSH1 0x20; PUSH1 0; RETURN]
+      → MSTORE is a GUARDED opcode running in the child frame — it exercises the
+        frame-relative stack-underflow guard (the child's x12 lives in the call
+        arena, above the global stack); a broken/global guard would underflow →
+        guest halt_kind 7. It writes mem[0]=0x42, then RETURN(0,32) returns 32 B.
+      → depth-aware RETURN sees depth>0 → `frame_return` → stages the 32-byte
+        returndata into `evm_precompile_frame` and restores the parent at pc+1.
+    parent code = [<descend placeholder>, RETURNDATASIZE, PUSH1 0, SSTORE, STOP]
+      → RETURNDATASIZE reads the staged size (32) and `PUSH1 0; SSTORE` writes it
+        to slot 0; `STOP` halts at depth 0.
 
-  So a correct round trip writes storage slot 0 = 1 (the propagated success word).
-  The check script asserts OUTPUT's dedup'd storage pair is (slot 0, value 1) and
-  halt_kind 0 — i.e. the child returned to the parent and success propagated.
+  So a correct round trip writes storage slot 0 = 32 (the child returndata size) —
+  exercising the frame-relative guard (#8539) AND the returndata staging (#8541)
+  end-to-end. The check script asserts the dedup'd storage pair is (slot 0, 32)
+  and halt_kind 0.
 -/
 
 import EvmAsm.Codegen.Dispatch
@@ -44,7 +49,7 @@ def callFrameRoundtripPrologue : String :=
   "  la x10, rt_parent_code\n" ++
   "  la x21, rt_parent_code\n" ++
   "  li t0, 1000000\n  sd t0, 568(x20)\n" ++       -- parent gasRemaining
-  "  li t0, 5\n  sd t0, 496(x20)\n" ++              -- parent codeSize
+  "  li t0, 6\n  sd t0, 496(x20)\n" ++              -- parent codeSize
   "  sd x0, 448(x20); sd x0, 456(x20); sd x0, 464(x20)\n" ++
   "  sd x0, 472(x20); sd x0, 480(x20)\n" ++
   "  la t0, evm_call_depth; sd x0, 0(t0)\n" ++
@@ -57,7 +62,7 @@ def callFrameRoundtripPrologue : String :=
   "  sd x0, 40(t2); sd x0, 48(t2)\n" ++             -- outOff / outSize = 0
   "  li t3, 192; sd t3, 56(t2)\n" ++                -- netPopBytes
   "  la t3, rt_child_code; sd t3, 64(t2)\n" ++      -- code_ptr = child code
-  "  li t3, 5; sd t3, 72(t2)\n" ++                  -- code_len (PUSH1 0; PUSH1 0; RETURN)
+  "  li t3, 10; sd t3, 72(t2)\n" ++                 -- code_len (PUSH1 0x42;PUSH1 0;MSTORE;PUSH1 0x20;PUSH1 0;RETURN)
   "  li t3, 100000; sd t3, 80(t2)\n" ++             -- requested_gas
   "  sd x0, 88(t2)\n" ++                            -- value_nonzero = 0
   "  la a1, rt_cd_desc\n" ++
@@ -94,10 +99,16 @@ def callFrameRoundtripData : String :=
   "rt_cd_zero:\n  .zero 32\n" ++
   "rt_to_word:\n  .zero 32\n" ++
   ".balign 8\n" ++
-  -- parent: [descend-placeholder, PUSH1 0x00, SSTORE, STOP]; child: [STOP]
-  "rt_parent_code:\n  .byte 0x00, 0x60, 0x00, 0x55, 0x00\n" ++
-  -- child: PUSH1 0; PUSH1 0; RETURN  (a depth-1 RETURN that resumes the parent)
-  "rt_child_code:\n  .byte 0x60, 0x00, 0x60, 0x00, 0xf3\n" ++
+  -- parent: [descend-placeholder, RETURNDATASIZE, PUSH1 0x00, SSTORE, STOP].
+  -- On the child's return the parent resumes at pc+1 (RETURNDATASIZE), which reads
+  -- the child's 32-byte returndata size from evm_precompile_frame (staged by
+  -- frame_return), then SSTOREs it to slot 0 (so slot 0 == 32 proves the staging).
+  "rt_parent_code:\n  .byte 0x00, 0x3d, 0x60, 0x00, 0x55, 0x00\n" ++
+  -- child: PUSH1 0x42; PUSH1 0; MSTORE; PUSH1 0x20; PUSH1 0; RETURN. The MSTORE
+  -- is a GUARDED opcode running in the child frame — it exercises the
+  -- frame-relative underflow guard (a child-frame x12 in the call arena). It
+  -- writes mem[0]=0x42 then RETURN(0,32) returns a 32-byte buffer.
+  "rt_child_code:\n  .byte 0x60, 0x42, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3\n" ++
   ".balign 8\n" ++
   -- Non-zero tail pad. ziskemu reads the final bytes of `.data` as 0 (the
   -- data-tail-zeroing artifact, memory: ziskemu-zeroes-data-tail-pad-probe-

--- a/scripts/codegen-zisk-call-roundtrip-check.sh
+++ b/scripts/codegen-zisk-call-roundtrip-check.sh
@@ -40,7 +40,7 @@ checks = [
     ('halt_kind (OUTPUT+32)',      u64(32), 0),
     ('emitted slot count (+56)',   u64(56), 1),
     ('slot 0 key low (+64)',       u64(64), 0),
-    ('slot 0 value low (+96)',     u64(96), 1),
+    ('slot 0 value low (+96)',     u64(96), 32),
 ]
 failed = False
 for label, got, exp in checks:
@@ -51,5 +51,6 @@ sys.exit(1 if failed else 0)
 PY
 
 echo
-echo "==> PASS: child RETURN returned to the parent via frame_return and the success"
-echo "          word propagated (slot 0 = 1) — nested-call execution round-trips"
+echo "==> PASS: child ran a GUARDED MSTORE + RETURN(0,32); frame_return staged the"
+echo "          returndata; parent RETURNDATASIZE read 32 -> slot 0 = 32 (frame-relative"
+echo "          guard + returndata staging verified end-to-end through the dispatcher)"


### PR DESCRIPTION
## Summary
- Strengthen `zisk_call_roundtrip` to verify the frame-relative stack guards (#8539) **and** the returndata staging (#8541) **together**, end-to-end through the live dispatcher — instead of only the trivial empty-STOP/RETURN path.
- Child code becomes `[PUSH1 0x42; PUSH1 0; MSTORE; PUSH1 0x20; PUSH1 0; RETURN]`: the **MSTORE is a guarded opcode running in the child frame** (x12 in the call arena), so it exercises the frame-relative underflow guard — a broken/global guard would underflow and halt the guest (`halt_kind 7`). The child then `RETURN(0,32)` returns a 32-byte buffer; `frame_return` stages it into `evm_precompile_frame`. The parent resume code becomes `[<placeholder>; RETURNDATASIZE; PUSH1 0; SSTORE; STOP]`, reading the staged size and writing `slot 0 = 32`.

## Verification
- Assert `halt_kind 0` and `slot 0 value = 32` — **4/4 pass**.
- Probe-only change (not linked into the guest, so the guest binary is byte-identical); full `lake build` + file-size/unimported/forbidden-tactics gates green.

> **Stacked on #8541** (base `feat/callframe-returndata-staging`, which includes #8539); retarget to `main` as the stack merges.

Refs #8475. Bead: evm-asm-fhsxz.2.4.2.61.6.6.2.

Authored by @pirapira; implemented by Claude Code