### PR TITLE
fix(dispatch): correct runtime EIP-7623 calldata-floor multiplier to 16 (u13jh)

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -1883,11 +1883,11 @@ def emitRuntimeDispatcherSetupWithInputAsm (inputAsm : String) : String :=
   "  lbu x11, 0(x9)\n" ++
   "  beqz x11, .runtime_tx_gas_zero_byte\n" ++
   "  addi x7, x7, 16\n" ++
-  "  addi x10, x10, 40\n" ++
+  "  addi x10, x10, 64\n" ++   -- u13jh: EIP-7623 floor = 4 tokens * TX_DATA_TOKEN_FLOOR(16) per non-zero byte (was stale 40 = *10)
   "  j .runtime_tx_gas_data_step\n" ++
   ".runtime_tx_gas_zero_byte:\n" ++
   "  addi x7, x7, 4\n" ++
-  "  addi x10, x10, 10\n" ++
+  "  addi x10, x10, 16\n" ++   -- u13jh: EIP-7623 floor = 1 token * TX_DATA_TOKEN_FLOOR(16) per zero byte (was stale 10 = *10)
   ".runtime_tx_gas_data_step:\n" ++
   "  addi x9, x9, 1\n" ++
   "  addi x8, x8, -1\n" ++


### PR DESCRIPTION
## Summary
The runtime dispatcher's `--validate-tx-gas` calldata-floor accumulator (`x10`) used a **stale `TX_DATA_TOKEN_FLOOR=10`** (`+40`/non-zero byte = 4 tokens×10, `+10`/zero byte = 1 token×10). Amsterdam's `TX_DATA_TOKEN_FLOOR` is **16** (`vm/gas.py:117-120`), so the floor is `21000 + 16*(4*nonzero + zero)` → `+64`/non-zero, `+16`/zero. Corrected both increments (`40→64`, `10→16`).

## Why it matters
This runtime floor is persisted to `runtime_tx_calldata_floor` and threaded through `tx_gas_result_increments` as `max(.., floor)`, feeding `block_gas_used` + the receipts-root / EIP-7778 accounting (fork.py:1142-1144). A too-low floor made the guest's `block_gas_used` disagree with the header's spec-computed value for **calldata-floor-dominated transactions** (the `eip7976_increase_calldata_floor_cost` family) → false mismatch.

The fix aligns the runtime path with the spec **and** with the guest's own intrinsic-gas path (`intrinsic_gas_amsterdam_counts`), which already used `*16` (g8zeq.2 / #8438) — the two implementations were disagreeing.

Build + link clean; gates clean. Bead: evm-asm-u13jh (hermes-c3 audit finding).

Authored by @pirapira; implemented by Claude Code