### PR TITLE
fix(verdict): reject type-3/4 contract creation and empty type-4 authorization list (p6ggi)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictGasGate.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictGasGate.lean
@@ -277,6 +277,23 @@ def eip8037TxGasGateFunction : String :=
   "  jal ra, tx_eip4844_validate_blob_hashes\n" ++
   "  bnez a0, .Letg_validate_fail\n" ++
   ".Letg_after_blob_precheck:\n" ++
+  "  # p6ggi: EIP-4844 (type 3) and EIP-7702 (type 4) forbid contract creation:\n" ++
+  "  # an empty 'to' raises TransactionTypeContractCreationError (fork.py:664-666).\n" ++
+  "  # Type 4 additionally requires a non-empty authorization_list, else\n" ++
+  "  # EmptyAuthorizationListError (fork.py:668-670). Both are InvalidBlock on the\n" ++
+  "  # block-validation path, so a block carrying such a tx is rejected. to_len and\n" ++
+  "  # auth_count here are the same reliably-parsed fields the gate already branches\n" ++
+  "  # on (init-code limit, CREATE/auth state gas); a valid type-3/4 tx has a 20-byte\n" ++
+  "  # 'to' and a valid type-4 tx has >=1 authorization, so neither is false-rejected.\n" ++
+  "  la t0, bsg_tx_type; ld t1, 0(t0)\n" ++
+  "  li t2, 4; beq t1, t2, .Letg_type47_auth_check\n" ++
+  "  li t2, 3; beq t1, t2, .Letg_type34_create_check\n" ++
+  "  j .Letg_after_type34_checks\n" ++
+  ".Letg_type47_auth_check:\n" ++
+  "  la t0, bsg_auth_count; ld t2, 0(t0); beqz t2, .Letg_validate_fail\n" ++
+  ".Letg_type34_create_check:\n" ++
+  "  la t0, bsg_to_len; ld t2, 0(t0); beqz t2, .Letg_validate_fail\n" ++
+  ".Letg_after_type34_checks:\n" ++
   "  la t0, bsg_data_ptr; ld a0, 0(t0)\n" ++
   "  la t0, bsg_data_len; ld a1, 0(t0)\n" ++
   "  la t0, bsg_to_len; ld a2, 0(t0); seqz a2, a2\n" ++


### PR DESCRIPTION
## Summary
execution-specs `check_transaction` (fork.py:664-670) raises two `InvalidBlock` subclasses the EIP-8037 gas gate did not mirror:

```python
if isinstance(tx, (BlobTransaction, SetCodeTransaction)):
    if not isinstance(tx.to, Address):
        raise TransactionTypeContractCreationError(tx)   # empty 'to' for type 3 & 4
if isinstance(tx, SetCodeTransaction):
    if not any(tx.authorizations):
        raise EmptyAuthorizationListError(...)            # empty auth list for type 4
```

The gate processed a type-3 (blob) / type-4 (set-code) tx with an empty `to` as an ordinary creation tx and treated a type-4 tx with an empty `authorization_list` as "no auth state gas" — never rejecting either. A block carrying such an invalid tx could escape the gate (status 0 → no reject).

## Fix
At `.Letg_after_blob_precheck` (reached by all tx types, after fields are parsed), dispatch on `bsg_tx_type`:
- **type 4** → reject empty `auth_count`, then fall through to the empty-`to` check;
- **type 3** → empty-`to` check only;
- others → skip.

Both reuse the existing `.Letg_validate_fail` (status 3) → caller's `bnez a0, .Lbv_eip8037_gas_fail` → negative verdict.

## Soundness
`to_len`/`auth_count` are the same parsed fields the gate already branches on (init-code limit @221, CREATE/auth state gas @293/296). A valid type-3/4 tx has a 20-byte `to` (`to_len!=0`) and a valid type-4 has `>=1` authorization (`auth_count!=0`) → **no valid tx is false-rejected**; only the two spec-reject shapes flip to reject.

Build + link clean; gates clean. Bead: evm-asm-p6ggi (hermes-c3 audit finding).

Authored by @pirapira; implemented by Claude Code