### PR TITLE
fix(verdict): re-tag preloaded storage addrHash to env.ADDRESS

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -1855,6 +1855,24 @@ def emitRuntimeDispatcherSetupWithInputAsm (inputAsm : String) : String :=
   "  ld x8, 24(x5)\n" ++
   "  sd x8, 648(x20)\n" ++
   "  addi x5, x5, 32\n" ++
+  -- Re-tag the preloaded storage entries' addrHash to the executing frame's
+  -- env.ADDRESS (now loaded above). The preload-expand wrote addrHash=0, but
+  -- SLOAD/SSTORE key on env.ADDRESS (per-contract storage isolation), so without
+  -- this the recipient's own SLOAD would miss its preloaded slots and read 0.
+  -- All preloaded entries are the recipient's own storage, so a single
+  -- env.ADDRESS tag is correct. (Nested-callee storage preload is a follow-up.)
+  "  ld x6, 448(x20)\n" ++          -- x6 = preload count
+  "  li x7, 0xa0630000\n" ++        -- x7 = persistent log base
+  ".retag_preload_loop:\n" ++
+  "  beqz x6, .retag_preload_done\n" ++
+  "  ld x8, 0(x20);  sd x8, 0(x7)\n" ++
+  "  ld x8, 8(x20);  sd x8, 8(x7)\n" ++
+  "  ld x8, 16(x20); sd x8, 16(x7)\n" ++
+  "  ld x8, 24(x20); sd x8, 24(x7)\n" ++
+  "  addi x7, x7, 128\n" ++
+  "  addi x6, x6, -1\n" ++
+  "  j .retag_preload_loop\n" ++
+  ".retag_preload_done:\n" ++
   -- M30/M35/M31: gas limit trailer, optional transaction intrinsic-gas
   -- validation controls, then optional account-witness context. When the
   -- tx-gas validation flag is zero, the gas trailer is treated as execution


### PR DESCRIPTION
## Summary
Latent regression from #8546 (per-contract storage keying), exposed by #8559 (descent activation). The runtime dispatcher's preload-expand wrote each preloaded storage entry with `addrHash=0`, but #8546 made SLOAD/SSTORE key on the executing frame's `env.ADDRESS`. `stage_runtime_payload_code` sets `env.ADDRESS = recipient` (nonzero), so the recipient's own SLOAD (`addrHash=recipient`) no longer matched its preloaded entries (`addrHash=0`) → read 0 instead of the witness value.

(Latent because the env words load *after* the preload-expand and the 40-row #8546 sample lacked a self-contained storage-reading contract recipient.)

## Fix
A **re-tag pass** added right after the env-trailer copy (once `env.ADDRESS` is loaded): for each of `env.persistentLogLength` preloaded entries at the persistent log base, set `addrHash[+0..32] = env.ADDRESS`. All preloaded entries are the recipient's own storage, so a single `env.ADDRESS` tag is correct. EOA simple transfers preload no storage (count 0) → no-op, **byte-identical**.

Nested-callee storage preload (so a CALLed contract's own SLOADs resolve) is a separate follow-up.

## Verification
- Guest assembles (no label collision); `zisk_storage_multicontract` still passes; full `lake build` + gates green.
- @pirapira to run EEST at scale to confirm recipient-storage contract rows recover.

Refs #8475. Bead: evm-asm-bmvmx.1.7.1.

Authored by @pirapira; implemented by Claude Code