### PR TITLE
fix(verdict): raise captured-LOG descriptor cap 16 -> 1024 (6c7v9)

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -1593,7 +1593,7 @@ def emitDispatcherDataSection
   "  .zero 8192\n" ++     -- M29: 256 × 32-byte recent BLOCKHASH ancestors
   ".balign 8\n" ++
   "evm_event_logs:\n" ++
-  "  .zero 4096\n" ++     -- M26: 16 × 256-byte bounded LOG event descriptors
+  "  .zero 262144\n" ++   -- M26: 1024 × 256-byte bounded LOG event descriptors (6c7v9: was 16×256)
   emitSelfdestructData ++
   eip7708SyntheticLogTopicData ++
   storageAccessGasData ++
@@ -2293,7 +2293,7 @@ def emitRuntimeDispatcherDataSectionCore
   "  .zero 8192\n" ++     -- M29: 256 × 32-byte recent BLOCKHASH ancestors
   ".balign 8\n" ++
   "evm_event_logs:\n" ++
-  "  .zero 4096\n" ++     -- M26: 16 × 256-byte bounded LOG event descriptors
+  "  .zero 262144\n" ++   -- M26: 1024 × 256-byte bounded LOG event descriptors (6c7v9: was 16×256)
   emitSelfdestructData ++
   eip7708SyntheticLogTopicData ++
   (if includeSharedHelperData then storageAccessGasData else "") ++

--- a/EvmAsm/Codegen/Programs/Bloom.lean
+++ b/EvmAsm/Codegen/Programs/Bloom.lean
@@ -367,7 +367,7 @@ def capturedLogsBloomAddFunction : String :=
 " ++
   "  mv s2, a2                   # descriptor count
 " ++
-  "  li t0, 16
+  "  li t0, 1024
 " ++
   "  bgtu s2, t0, .Lclba_count_fail
 " ++

--- a/EvmAsm/Codegen/Programs/EIP7708Logs.lean
+++ b/EvmAsm/Codegen/Programs/EIP7708Logs.lean
@@ -64,7 +64,7 @@ def eip7708SyntheticLogFunctions : String :=
   "  li t0, 3\n" ++
   "  bgtu a0, t0, .Leip7708_bad_topic_count\n" ++
   "  ld t0, 472(x20)\n" ++
-  "  li t1, 16\n" ++
+  "  li t1, 1024\n" ++               -- 6c7v9: raised log-descriptor cap from 16
   "  bgeu t0, t1, .Leip7708_overflow\n" ++
   "  la t2, evm_event_logs\n" ++
   "  slli t1, t0, 8\n" ++
@@ -177,7 +177,7 @@ def eip7708SyntheticLogDataSection : String :=
   "  .zero 624\n" ++
   ".balign 8\n" ++
   "evm_event_logs:\n" ++
-  "  .zero 4096\n" ++
+  "  .zero 262144\n" ++   -- 6c7v9: 1024 × 256-byte LOG event descriptors (was 4096 = 16×256)
   eip7708SyntheticLogTopicData ++
   "eip7708_probe_sender:\n" ++
   "  .quad 0x1111111111111111, 0x1111111111111111, 0x0000000011111111, 0\n" ++

--- a/EvmAsm/Codegen/Programs/EvmLogHandlers.lean
+++ b/EvmAsm/Codegen/Programs/EvmLogHandlers.lean
@@ -44,7 +44,7 @@ def logTopicCopies (topicCount : Nat) : String :=
     via `.exit_no_epilogue` instead of silently dropping the event. -/
 def logCapturePreBody (topicCount : Nat) : String :=
   "  ld x15, 472(x20)\n" ++          -- x15 = event log length
-  "  li x16, 16\n" ++                -- static cap: 16 descriptors
+  "  li x16, 1024\n" ++              -- static cap: 1024 descriptors (6c7v9: raised from 16)
   "  bgeu x15, x16, 9f\n" ++
   "  la x14, evm_event_logs\n" ++
   "  slli x16, x15, 8\n" ++          -- entry offset = count * 256

--- a/EvmAsm/Codegen/Programs/RuntimeAccountWitness.lean
+++ b/EvmAsm/Codegen/Programs/RuntimeAccountWitness.lean
@@ -128,7 +128,7 @@ def runtimeAccountWitnessProbeDataSection : String :=
   "  .zero 8192\n" ++
   ".balign 8\n" ++
   "evm_event_logs:\n" ++
-  "  .zero 4096\n" ++
+  "  .zero 262144\n" ++   -- 6c7v9: 1024 × 256-byte LOG event descriptors (was 4096 = 16×256)
   emitPrecompileFrameData ++
   emitSha256Data ++
   ".balign 8\n" ++

--- a/EvmAsm/Codegen/Programs/Selfdestruct.lean
+++ b/EvmAsm/Codegen/Programs/Selfdestruct.lean
@@ -506,7 +506,7 @@ def runtimeSelfdestructAccountInputsDataSection : String :=
   "  .zero 8192\n" ++
   ".balign 8\n" ++
   "evm_event_logs:\n" ++
-  "  .zero 4096\n" ++
+  "  .zero 262144\n" ++   -- 6c7v9: 1024 × 256-byte LOG event descriptors (was 4096 = 16×256)
   eip7708SyntheticLogTopicData ++
   emitPrecompileFrameData ++
   emitSha256Data ++

--- a/scripts/codegen-zisk-captured-logs-bloom-add-check.sh
+++ b/scripts/codegen-zisk-captured-logs-bloom-add-check.sh
@@ -74,8 +74,10 @@ def descriptor(address, topics, data=b""):
 raw = json.loads(os.environ["SPEC_JSON"])
 mode = raw.get("mode", "logs")
 if mode == "count_over_cap":
-    count = 17
-    descs = bytes(256 * count)
+    # 6c7v9: the descriptor cap was raised 16 -> 1024; 1025 still exceeds it. The
+    # count gate rejects before any descriptor is read, so the body is a placeholder.
+    count = 1025
+    descs = bytes(256)
     expected_status = 1
     bloom = bytes(256)
 elif mode == "topic_over_cap":
@@ -154,6 +156,9 @@ run_case "one_log4" "{\"logs\":[{\"address\":\"$A1\",\"topics\":[\"$T0\",\"$T1\"
 run_case "two_logs_mixed" "{\"logs\":[{\"address\":\"$A1\",\"topics\":[\"$T0\"],\"data\":\"\"},{\"address\":\"$A2\",\"topics\":[\"$T1\",\"$T2\"],\"data\":\"cafebabe\"}]}" || FAILED=1
 run_case "count_over_cap" '{"mode":"count_over_cap"}' || FAILED=1
 run_case "topic_over_cap" '{"mode":"topic_over_cap"}' || FAILED=1
+# 6c7v9: 20 LOG events (> the former 16-descriptor cap) must now be captured and bloomed.
+many_logs=""; for _i in $(seq 1 20); do many_logs+="{\"address\":\"$A1\",\"topics\":[\"$T0\"],\"data\":\"\"},"; done
+run_case "many_logs_over_old_cap" "{\"logs\":[${many_logs%,}]}" || FAILED=1
 
 echo
 if [[ $FAILED -eq 0 ]]; then


### PR DESCRIPTION
## Summary
execution-specs imposes **no per-block log-count limit**, but the guest hard-capped captured LOG events at **16**: the dispatcher's capture handler halts with `halt_kind=4` once 16 descriptors are stored (`EvmLogHandlers.lean`), and the EIP-7708 transfer-log capture and the `captured_logs_bloom_add` receipt bridge mirror the same 16 cap. Under Amsterdam **every value transfer emits an EIP-7708 log**, so a block with >16 logs (common) was false-rejected.

## Fix
Raise the cap to **1024** consistently across all three cap sites and enlarge every `evm_event_logs` arena from `.zero 4096` (16×256) to `.zero 262144` (1024×256) so cap and backing store stay in lockstep:
- **Caps:** `EvmLogHandlers.lean` (`li x16`), `EIP7708Logs.lean` (`li t1`), `Bloom.lean` `captured_logs_bloom_add` (`li t0`).
- **Arenas:** `Dispatch.lean` (the arena the emitted `stateless_guest` links, ×2 program variants), `EIP7708Logs.lean`, `RuntimeAccountWitness.lean`, `Selfdestruct.lean`.

Raising the cap without the arena would overflow it.

## Soundness
This only **widens an over-strict reject**. Blocks with 17..1024 logs (previously `halt_kind=4`) now capture and bloom correctly; >1024 still halts (rare — full unbounded parity needs a streaming bloom+receipt with no descriptor store, a larger follow-up). **No false-accept:** descriptors are captured and ORed into the bloom exactly as before for the counts now admitted.

Guest ELF grows by exactly **258048 bytes** (one arena: 262144−4096) vs `origin/main` (448233824 → 448491872, +0.058%); the embedded ziskemu memory image dominates the absolute size.

## Validation
`scripts/codegen-zisk-captured-logs-bloom-add-check.sh`: updated `count_over_cap` to 1025 (the new boundary; still rejects, status=1) and added `many_logs_over_old_cap` (20 logs > the former 16 cap) which now succeeds (status=0, 6 bloom bits). All cases pass, as do the EIP-7708 synthetic-log shape checks.

Build + link clean; gates clean. Bead: evm-asm-6c7v9 (hermes-c3 audit; scoped by claude-c1).

Authored by @pirapira; implemented by Claude Code