### PR TITLE
feat(multi-tx): cross-tx storage threading wiring (dormant behind independence bail)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -671,6 +671,7 @@ def blockVerdictFunction : String :=
   "  jal ra, bal_txs_independent\n" ++
   "  bnez a0, .Lbv_mtx_bail                         # interacting / parse error -> conservative\n" ++
   "  la t0, bv_mtx_i; sd zero, 0(t0)\n" ++
+  "  la t0, bv_mtx_committed_count; sd zero, 0(t0)  # fhsxz.2.4.2.57.11.6.3.2: empty cross-tx committed table\n" ++
   ".Lbv_mtx_loop:\n" ++
   "  la t0, bv_mtx_i; ld t1, 0(t0); la t2, bv_tx_count; ld t2, 0(t2); beq t1, t2, .Lbv_mtx_done\n" ++
   "  la a0, bv_mtx_ctx; mv a1, t1; jal ra, multi_tx_nth_context\n" ++
@@ -698,6 +699,36 @@ def blockVerdictFunction : String :=
   "  la t3, bv_mtx_gas_left; add t3, t3, t0; sd a1, 0(t3)\n" ++
   "  la t3, bv_mtx_calldata; add t3, t3, t0; sd a2, 0(t3)\n" ++
   "  la t3, bv_mtx_refund;   add t3, t3, t0; la t4, evm_refund_acc; ld t4, 0(t4); sd t4, 0(t3)\n" ++
+  -- fhsxz.2.4.2.57.11.6.3.2: snapshot this tx's committed storage into the cross-tx table,
+  -- re-keyed (addrHash) to its recipient (bv_mtx_ctx+72, 20B zero-padded to 32) so the next
+  -- tx's preload can thread a prior tx's committed value. The live exec log (env+448 entries
+  -- at 0xa0630000) holds the recipient's own slots only (dispatch_tx_runtime_code requires
+  -- self-contained), so a single recipient re-tag is correct. Append (last-write-wins via
+  -- exec_log_latest_value's last-match); bail conservatively if the table overflows.
+  "  la t0, evm_env; ld t0, 448(t0)                 # t0 = live log entry count\n" ++
+  "  la t1, bv_mtx_committed_count; ld t1, 0(t1)    # t1 = table count\n" ++
+  "  li t2, 0xa0630000                              # t2 = live log base\n" ++
+  "  li t3, 0                                       # j = 0\n" ++
+  ".Lbv_mtx_snap:\n" ++
+  "  beq t3, t0, .Lbv_mtx_snap_done\n" ++
+  "  li t4, 128; bgeu t1, t4, .Lbv_mtx_bail         # committed table full -> conservative\n" ++
+  "  slli t4, t3, 7; add t4, t2, t4                 # src = live[j]\n" ++
+  "  slli t5, t1, 7; la t6, bv_mtx_committed; add t5, t6, t5   # dst = table[count]\n" ++
+  "  sd zero, 0(t5); sd zero, 8(t5); sd zero, 16(t5); sd zero, 24(t5)   # addrHash = 0, then recipient 20B\n" ++
+  "  la t6, bv_mtx_ctx; addi t6, t6, 72; li a0, 0\n" ++
+  ".Lbv_mtx_snap_k:\n" ++
+  "  li a1, 20; beq a0, a1, .Lbv_mtx_snap_kd\n" ++
+  "  add a2, t6, a0; lbu a3, 0(a2); add a2, t5, a0; sb a3, 0(a2); addi a0, a0, 1; j .Lbv_mtx_snap_k\n" ++
+  ".Lbv_mtx_snap_kd:\n" ++
+  "  ld a0, 32(t4);  sd a0, 32(t5);  ld a0, 40(t4);  sd a0, 40(t5)\n" ++   -- slotKey
+  "  ld a0, 48(t4);  sd a0, 48(t5);  ld a0, 56(t4);  sd a0, 56(t5)\n" ++
+  "  ld a0, 64(t4);  sd a0, 64(t5);  ld a0, 72(t4);  sd a0, 72(t5)\n" ++   -- original
+  "  ld a0, 80(t4);  sd a0, 80(t5);  ld a0, 88(t4);  sd a0, 88(t5)\n" ++
+  "  ld a0, 96(t4);  sd a0, 96(t5);  ld a0, 104(t4); sd a0, 104(t5)\n" ++  -- current
+  "  ld a0, 112(t4); sd a0, 112(t5); ld a0, 120(t4); sd a0, 120(t5)\n" ++
+  "  addi t1, t1, 1; addi t3, t3, 1; j .Lbv_mtx_snap\n" ++
+  ".Lbv_mtx_snap_done:\n" ++
+  "  la t4, bv_mtx_committed_count; sd t1, 0(t4)\n" ++
   "  la t0, bv_mtx_i; ld t1, 0(t0); addi t1, t1, 1; sd t1, 0(t0); j .Lbv_mtx_loop\n" ++
   ".Lbv_mtx_done:\n" ++
   "  la t4, bvgr_runtime_gas_left_ptr; la t5, bv_mtx_gas_left; sd t5, 0(t4)\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -755,6 +755,19 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bv_mtx_refund:\n  .zero 128\n" ++
   "bv_mtx_calldata:\n  .zero 128\n" ++
   "bv_mtx_ctx:\n  .zero 192\n" ++
+  -- fhsxz.2.4.2.57.11.6.3.2: cross-tx committed-storage table. After each per-tx dispatch
+  -- the multi-tx loop appends the live exec log's entries here, re-keyed (addrHash) to that
+  -- tx's recipient (its entries are all the recipient's own — dispatch_tx_runtime_code
+  -- requires self-contained), so the NEXT tx's preload can thread a prior tx's committed
+  -- value via exec_log_latest_value. 128 entries × 128 B; count 0 for tx0 / single-tx /
+  -- independent blocks -> no threading -> byte-identical. dtrc_recipkey / dtrc_threadval are
+  -- the per-slot query key (recipient 20B, zero-padded) and the threaded-value output buffer.
+  ".balign 8\n" ++
+  "bv_mtx_committed_count:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "bv_mtx_committed:\n  .zero 16384\n" ++
+  "dtrc_recipkey:\n  .zero 32\n" ++
+  "dtrc_threadval:\n  .zero 32\n" ++
   -- bmvmx.1.4.4: single-tx EOA settlement scalars precomputed before
   -- block_state_root (additive; no consumer yet -> verdict byte-identical).
   -- Consumed later by .4.1/.4.2 to build execution-derived sender/coinbase leaves.

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -206,6 +206,28 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  li t2, 32; beq t6, t2, .Ldtrc_vdone\n" ++
   "  add t2, t4, t6; addi t2, t2, 32; sb zero, 0(t2); addi t6, t6, 1; j .Ldtrc_vzloop\n" ++
   ".Ldtrc_vdone:\n" ++
+  -- fhsxz.2.4.2.57.11.6.3.2 cross-tx threading: if a prior tx in this block committed a
+  -- value for (recipient, slotKey), stage that committed value as this slot's preload
+  -- (original==current) instead of the block-pre witness value, so this tx's SSTORE gas/
+  -- refund uses the in-block committed original. bv_mtx_committed_count is 0 for tx0 /
+  -- single-tx / independent blocks -> no match -> byte-identical. Recipient key = ctx+72
+  -- (20B, zero-padded to 32) — the same re-keying the snapshot uses.
+  "  la t0, bv_mtx_committed_count; ld a3, 0(t0); beqz a3, .Ldtrc_nothread\n" ++
+  "  la t0, dtrc_recipkey; sd zero, 0(t0); sd zero, 8(t0); sd zero, 16(t0); sd zero, 24(t0)\n" ++
+  "  addi t1, s2, 72; li t2, 0\n" ++
+  ".Ldtrc_rkey:\n" ++
+  "  li t3, 20; beq t2, t3, .Ldtrc_rkeyd\n" ++
+  "  add t3, t1, t2; lbu t4, 0(t3); la t5, dtrc_recipkey; add t5, t5, t2; sb t4, 0(t5); addi t2, t2, 1; j .Ldtrc_rkey\n" ++
+  ".Ldtrc_rkeyd:\n" ++
+  "  la t0, bvcd_i; ld t1, 0(t0); slli t2, t1, 5; la t3, bvcd_keys; add a1, t3, t2   # a1 = slotKey ptr\n" ++
+  "  la a0, dtrc_recipkey; la a2, bv_mtx_committed; la t0, bv_mtx_committed_count; ld a3, 0(t0); la a4, dtrc_threadval\n" ++
+  "  jal ra, exec_log_latest_value\n" ++
+  "  beqz a0, .Ldtrc_nothread                       # no prior-tx committed value -> keep witness value\n" ++
+  "  la t0, bvcd_i; ld t1, 0(t0); slli t2, t1, 6; la t3, bvcd_preload; add t4, t3, t2   # preload entry i\n" ++
+  "  la t5, dtrc_threadval\n" ++
+  "  ld t6, 0(t5);  sd t6, 32(t4); ld t6, 8(t5);  sd t6, 40(t4)\n" ++
+  "  ld t6, 16(t5); sd t6, 48(t4); ld t6, 24(t5); sd t6, 56(t4)\n" ++
+  ".Ldtrc_nothread:\n" ++
   "  la t0, bvcd_i; ld t1, 0(t0); addi t1, t1, 1; sd t1, 0(t0); j .Ldtrc_sloop\n" ++
   ".Ldtrc_stage:\n" ++
   "  mv a0, s2; la a1, bv_runtime_payload; la t2, bv_exec_p; ld a2, 0(t2)\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
@@ -23,6 +23,7 @@ import EvmAsm.Codegen.Programs.BalStorageMatchesExecLog
 import EvmAsm.Codegen.Programs.BalStorageCoversExecLog
 import EvmAsm.Codegen.Programs.BalAllAccountsStorage
 import EvmAsm.Codegen.Programs.BalStorageReadsExecLog
+import EvmAsm.Codegen.Programs.ExecLogLatestValue
 import EvmAsm.Codegen.Programs.BlockVerdictTxsIndependent
 import EvmAsm.Codegen.Programs.BlockVerdictMultiTx
 import EvmAsm.Codegen.Programs.TxIntrinsicStateGas
@@ -64,6 +65,7 @@ def ziskStatelessVerdictV2ProbeUnit : BuildUnit := {
   balAllAccountsStorageConsistentFunction ++ "\n" ++   -- bmvmx.1.6.4.3: all-accounts forward+reverse
   balSlotTupleSequenceFunction ++ "\n" ++
   execLogSlotTuplesFunction ++ "\n" ++
+  execLogLatestValueFunction ++ "\n" ++   -- fhsxz.2.4.2.57.11.6.3.2: cross-tx storage threading lookup
   slotTupleSequencesMatchFunction ++ "\n" ++
   accountTupleSequencesConsistentFunction ++ "\n" ++
   balAllAccountsTupleSequencesConsistentFunction ++ "\n" ++   -- bmvmx.1.6.6: per-slot tuple-sequence all-accounts
@@ -265,6 +267,7 @@ def statelessVerdictV2GuestClosure : String :=
   balAllAccountsStorageConsistentFunction ++ "\n" ++   -- bmvmx.1.6.4.3: all-accounts forward+reverse
   balSlotTupleSequenceFunction ++ "\n" ++
   execLogSlotTuplesFunction ++ "\n" ++
+  execLogLatestValueFunction ++ "\n" ++   -- fhsxz.2.4.2.57.11.6.3.2: cross-tx storage threading lookup
   slotTupleSequencesMatchFunction ++ "\n" ++
   accountTupleSequencesConsistentFunction ++ "\n" ++
   balAllAccountsTupleSequencesConsistentFunction ++ "\n" ++   -- bmvmx.1.6.6: per-slot tuple-sequence all-accounts


### PR DESCRIPTION
## Summary
- `fhsxz.2.4.2.57.11.6.3.2` — the cross-tx storage-threading **mechanism** that `.6.3.3` will activate to flip the `multi_transaction_gas_accounting` interacting-tx **false-accept** (rows 00010/00011/00014/00015: `succ guest=01 exp=00`, `gas_arena_runtime_count=0`). Operator P0 lane (interacting multi-tx substrate); c1 green-lit me taking this on a branch (c1#17).
- Builds directly on `exec_log_latest_value` (#8616, merged).

## Mechanism
Each per-tx dispatch resets `env.persistentLogLength` to its preload count, so the exec log does **not** accumulate across the `.Lbv_mtx_*` dispatches. This wires:
- a cross-tx committed-storage table (`bv_mtx_committed`, 128 entries) in verdict scratch;
- after each `dispatch_tx_runtime_code`, the mtx loop **snapshots** the live exec log into the table, re-keyed (`addrHash`) to that tx's recipient — its entries are all the recipient's own (dispatch requires self-contained), so the keying is recipient-scoped;
- in `dispatch_tx_runtime_code`'s recipient slot-loop, after `slot_at_header_state_root`, **query** the table via `exec_log_latest_value` by `(recipient, slotKey)` and, on a hit, stage the prior tx's committed value as this slot's preload (`original==current`) so the SSTORE gas/refund uses the in-block committed original.

## Dormant + safe this PR
The independence bail (`bal_txs_independent != 0 -> bail`) is **kept**, so interacting blocks never reach the loop body and the threading stays dormant. For **independent** multi-tx blocks the snapshot+override runs but finds no cross-tx match (disjoint accounts); for single-tx/tx0 the table count is 0 → override skipped. The verdict is **behavior-identical for every currently-handled block**.

## Verification
- Full build + file-size/unimported/forbidden-tactics gates green; both verdict ELFs emit+link (`exec_log_latest_value` linked into both closures).
- `multi_transaction_gas_accounting` EEST sweep (16 rows, `--jobs 2`): **12 full match** (all independent rows, unchanged — confirms the threading is a no-op for them), **4 fail** (00010/00011/00014/00015 — the interacting rows that still bail; `.6.3.3` relaxes the bail to flip them). The 12/4 split matches the pre-change baseline → **no regression**.

Refs #8475. Bead: fhsxz.2.4.2.57.11.6.3.2 (parent .57.11.6.3 → .57.11.6).

Authored by @pirapira; implemented by Claude Code