### PR TITLE
feat(create): wire per-creator running nonce into the CREATE tail (.8c-1)

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -21,6 +21,7 @@ import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.SstoreGasRefund
 import EvmAsm.Codegen.Programs.CreateCodeEffectLog
 import EvmAsm.Codegen.Programs.CreateDeployedCodeValid
+import EvmAsm.Codegen.Programs.CreateCreatorNonce
 import EvmAsm.Codegen.CallFrameLayout
 import EvmAsm.Codegen.Programs.Address
 import EvmAsm.Codegen.Programs.HashBridge
@@ -574,7 +575,10 @@ def emitCreateChildFrameData : String :=
   "  .zero 0x10000\n" ++
   -- bmvmx.1.6.3 / .61.8b (.8b-2): the per-created-account CODE-effect log, co-located with
   -- create_child_code so it is defined in every closure whose CREATE tail deposits into it.
-  createCodeEffectLogData
+  createCodeEffectLogData ++ "\n" ++
+  -- .61.8c-1: per-creator running-nonce table (multi-CREATE address correctness), co-located
+  -- so the CREATE tail's create_creator_nonce_use resolves in every closure.
+  createNonceTableData
 
 /-- Scratch labels shared by runtime account-witness helpers.
 
@@ -937,6 +941,8 @@ def emitDispatcherPrologue : String :=
   "  sd x0, 448(x20)\n" ++         -- env.persistentLogLengthOff = 0
   "  sd x0, 456(x20)\n" ++         -- env.persistentLogCheckpointOff = 0
   "  la x5, evm_refund_acc; sd x0, 0(x5)\n" ++   -- bmvmx.1.6.3: reset per-tx refund counter
+  "  la x5, create_nonce_table_count; sd x0, 0(x5)\n" ++   -- .61.8c-1: reset per-creator nonce table per tx
+  "  la x5, create_nonce_table_overflow; sd x0, 0(x5)\n" ++
   "  sd x0, 464(x20)\n" ++         -- env.transientLogLengthOff = 0
   "  sd x0, 472(x20)\n" ++         -- env.eventLogLengthOff = 0
   "  sd x0, 480(x20)\n" ++         -- env.eventLogCheckpointOff = 0
@@ -1340,6 +1346,7 @@ def emitDispatcherEpilogueCore
     createExecuteInitcodeFrameRuntimeFunction ++ "\n" ++
     createDeployedCodeValidFunction ++ "\n" ++
     createRecordCodeEffectFunction ++ "\n" ++
+    createCreatorNonceUseFunction ++ "\n" ++
     zkvmModexpSafeFailWrapper ++ "\n" ++
     storageAccessGasFunction ++ "\n" ++
     sstoreGasRefundOutcomeFunction ++ "\n" ++
@@ -2090,6 +2097,7 @@ def emitRuntimeDispatcherEmbeddedHelperFunctions : String :=
   createExecuteInitcodeFrameRuntimeFunction ++ "\n" ++
   createDeployedCodeValidFunction ++ "\n" ++
   createRecordCodeEffectFunction ++ "\n" ++
+  createCreatorNonceUseFunction ++ "\n" ++
   zkvmModexpSafeFailWrapper ++ "\n" ++
   storageAccessGasFunction ++ "\n" ++
   sstoreGasRefundOutcomeFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -231,6 +231,20 @@ def childFrameHandlers
     "  ld x18, 0(x18)\n" ++
     "  li x19, -1\n" ++
     "  beq x18, x19, 7f\n" ++
+    -- .61.8c-1: replace the bare pre-state nonce with the per-creator RUNNING nonce, so a SECOND
+    -- CREATE by the same creator in this tx uses a distinct nonce (-> distinct address) -- the EVM
+    -- increments the creator's nonce on each CREATE/CREATE2. x18 holds the witness pre-state nonce;
+    -- create_creator_nonce_use seeds the per-creator table with it on the first CREATE and returns the
+    -- running value (advancing the table; both CREATE and CREATE2 bump it). a0==x10 (the dispatcher
+    -- PC) is clobbered by the call, so save/restore x10; the result (a0) is stored to create_nonce
+    -- BEFORE restoring x10 (the #8608 lesson). create_creator_nonce_use preserves x12/x13/x20/x21.
+    "  mv s10, x10\n" ++
+    "  la a0, create_sender_be\n" ++
+    "  mv a1, x18\n" ++
+    "  jal x1, create_creator_nonce_use\n" ++
+    "  la x18, create_nonce\n" ++
+    "  sd a0, 0(x18)\n" ++
+    "  mv x10, s10\n" ++
     (if hasSalt then
       -- Convert the CREATE2 salt stack word to canonical 32-byte big-endian.
       "  la x18, create_salt_be\n" ++


### PR DESCRIPTION
## Summary
Fixes the multi-CREATE address bug that would surface once CREATE is activated (`.8c-3`). The inline CREATE tail re-sourced the creator nonce from the **pre-state** (`nonce_at_header_state_root`) on every CREATE, so two CREATEs by the same creator in one tx computed the **same** address.

- Wires `create_creator_nonce_use` (#8612, the per-creator running-nonce table) at the address-derivation step: seeds the table with the witness pre-state nonce on the first CREATE and returns the running value (advancing the table) on each subsequent CREATE/CREATE2 by that creator. Feeds `create_nonce` → `address_compute_create` and bumps the table for CREATE2 too (both increment the creator nonce per EVM).
- Linked the helper + table data into both dispatcher closures (+ the shared CREATE child data), imported `CreateCreatorNonce` into `Dispatch`, and added the per-tx table reset (`create_nonce_table_count`/`overflow` := 0) next to the `evm_refund_acc` reset.
- Register care (the #8608 lesson): `a0 == x10` (PC), so x10 is saved around the call and the result stored to `create_nonce` **before** restoring x10; the helper preserves x12/x13/x20/x21.

## Verification
- `lake build` (full, 3300 jobs) green; `file-size`/`unimported`/`forbidden-tactics` pass.
- **`zisk_create_roundtrip` PASSES unchanged** — single CREATE with no witness → `create_creator_nonce_use(creator, 0) = 0` → same address `0xcb804a576fa48eb1` (non-regressing).
- `stateless_guest` **and** the probe closure emit/assemble/link (the helper/table/per-tx-reset symbols resolve, no dup labels).
- The per-creator increment semantics are independently probe-verified by `zisk_create_creator_nonce_use` (#8612: A→5,6,7; B→0,1).
- **Inert until `.8c-3`** (CREATE recipients are self-contained-rejected pre-`.8c`).

Bead: fhsxz.2.4.2.61.8.3.1 (child of `.8c`).

Authored by @pirapira; implemented by Claude Code