### PR TITLE
feat(verdict): wire all-accounts code-reverse comparator into block_verdict (i3djw)

### DIFF
--- a/EvmAsm/Codegen/Programs/BalAllAccountsCodeCovers.lean
+++ b/EvmAsm/Codegen/Programs/BalAllAccountsCodeCovers.lean
@@ -118,14 +118,19 @@ def ziskBalAllAccountsCodeCoversPrologue : String :=
   rlpListCountItemsFunction ++ "\n" ++
   ".Lbacov_pdone:"
 
-def ziskBalAllAccountsCodeCoversDataSection : String :=
-  ".section .data\n" ++
+/-- Scratch cells for `bal_all_accounts_code_covers` (reusable: linked into the probe
+    AND the block_verdict data section when the comparator is wired into the verdict). -/
+def balAllAccountsCodeCoversData : String :=
   ".balign 8\n" ++
   "bacov_acct_count:\n  .zero 8\n" ++
   "bacov_acct_off:\n  .zero 8\n" ++
   "bacov_acct_len:\n  .zero 8\n" ++
   "bacov_addr_off:\n  .zero 8\n" ++
   "bacov_addr_len:\n  .zero 8\n"
+
+def ziskBalAllAccountsCodeCoversDataSection : String :=
+  ".section .data\n" ++
+  balAllAccountsCodeCoversData
 
 def ziskBalAllAccountsCodeCoversProbeUnit : BuildUnit := {
   body        := NOP

--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -1037,6 +1037,18 @@ def blockVerdictFunction : String :=
   "  la a5, bv_simple_transfer_tx; addi a5, a5, 72\n" ++
   "  jal ra, bal_all_accounts_tuple_sequences_consistent\n" ++
   "  bnez a0, .Lbv_bal_tuple_fail\n" ++
+  -- i3djw (all-accounts CODE reverse): every account execution changed code for (CREATE/CREATE2
+  -- deploy, has_code_change=1 in exec_code_effect_log) must be PRESENT in the BAL -- catching a
+  -- producer that hides a created account by omitting it. Presence-only (a present account's declared
+  -- code is validated by the forward per-account direction). exec_code_effect_log is populated by the
+  -- CREATE deposit (.8b, #8623); it is EMPTY pre-.8c (CREATE is self-contained-rejected), so this is
+  -- inert until CREATE activation (.8c-3) and conservative (parse fail / omitted account -> reject).
+  -- NOTE for .8c-3: add a per-tx reset of exec_code_effect_count (not reset today; harmless while the
+  -- log is empty, but REQUIRED once CREATE writes it so stale records don't carry across txs).
+  "  la t0, bv_bal_start; ld a0, 0(t0); la t0, bv_bal_len; ld a1, 0(t0)\n" ++
+  "  la a2, exec_code_effect_log; la t0, exec_code_effect_count; ld a3, 0(t0)\n" ++
+  "  jal ra, bal_all_accounts_code_covers\n" ++
+  "  bnez a0, .Lbv_bal_code_covers_fail\n" ++
   -- bmvmx.1.6.7: recipient storage_reads exec consistency. storage_reads (AccountChanges
   -- item 2) is consensus-bound but NOT in the state root, so verify every BAL read slot
   -- was actually accessed by the recipient (appears in the exec log). bvcd_acct_ptr/len
@@ -1303,6 +1315,8 @@ def blockVerdictFunction : String :=
   "  li t0, 41; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_bal_tuple_fail:\n" ++              -- bmvmx.1.6.6: a non-recipient account's per-slot (block_access_index,value) tuple sequence != exec
   "  li t0, 42; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
+  ".Lbv_bal_code_covers_fail:\n" ++        -- i3djw: execution deployed/cleared code for an account the BAL omits (hidden created/destroyed account)
+  "  li t0, 43; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_zero:\n" ++
   "  li a0, 0\n" ++
   ".Lbv_ret:\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -15,6 +15,7 @@ import EvmAsm.Codegen.Programs.Eip7702NonceReuseGuard
 import EvmAsm.Codegen.Programs.BalStorageMatchesExecLog
 import EvmAsm.Codegen.Programs.BalStorageCoversExecLog
 import EvmAsm.Codegen.Programs.BalAllAccountsStorage
+import EvmAsm.Codegen.Programs.BalAllAccountsCodeCovers
 import EvmAsm.Codegen.Programs.AccountTupleSequencesConsistent
 import EvmAsm.Codegen.Programs.BalSlotTupleSequence
 import EvmAsm.Codegen.Programs.ExecLogSlotTuples
@@ -220,6 +221,8 @@ def ziskStatelessVerdictV2DataSection : String :=
   balStorageCoversExecLogData ++
   -- bmvmx.1.6.4.3 all-accounts storage check scratch (bal_all_accounts_storage_consistent, c2bal_*).
   balAllAccountsStorageConsistentData ++
+  -- i3djw all-accounts CODE reverse scratch (bal_all_accounts_code_covers, bacov_*).
+  balAllAccountsCodeCoversData ++
   -- bmvmx.1.6.7 storage_reads exec-consistency scratch.
   balStorageReadsInExecLogData ++
   -- bmvmx.1.6.3 recipient nonce/code-change emptiness probe (rlp_list_nth_item out cells).

--- a/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
@@ -22,6 +22,7 @@ import EvmAsm.Codegen.Programs.BalAddrExecLogKey
 import EvmAsm.Codegen.Programs.BalStorageMatchesExecLog
 import EvmAsm.Codegen.Programs.BalStorageCoversExecLog
 import EvmAsm.Codegen.Programs.BalAllAccountsStorage
+import EvmAsm.Codegen.Programs.BalAllAccountsCodeCovers
 import EvmAsm.Codegen.Programs.BalStorageReadsExecLog
 import EvmAsm.Codegen.Programs.ExecLogLatestValue
 import EvmAsm.Codegen.Programs.BlockVerdictTxsIndependent
@@ -70,6 +71,7 @@ def ziskStatelessVerdictV2ProbeUnit : BuildUnit := {
   accountTupleSequencesConsistentFunction ++ "\n" ++
   balAllAccountsTupleSequencesConsistentFunction ++ "\n" ++   -- bmvmx.1.6.6: per-slot tuple-sequence all-accounts
   balStorageReadsInExecLogFunction ++ "\n" ++   -- bmvmx.1.6.7: storage_reads exec consistency
+  balAllAccountsCodeCoversFunction ++ "\n" ++   -- i3djw: all-accounts CODE reverse (hidden created/destroyed account)
     -- .6.2.2.2.a: multi-tx dispatch helpers (independence guard + per-index tx
     -- context extractor) wired ahead of the gated multi-tx loop (.6.2.2.2.b).
     btiScanTuplesFunction ++ "\n" ++
@@ -272,6 +274,7 @@ def statelessVerdictV2GuestClosure : String :=
   accountTupleSequencesConsistentFunction ++ "\n" ++
   balAllAccountsTupleSequencesConsistentFunction ++ "\n" ++   -- bmvmx.1.6.6: per-slot tuple-sequence all-accounts
   balStorageReadsInExecLogFunction ++ "\n" ++   -- bmvmx.1.6.7: storage_reads exec consistency
+  balAllAccountsCodeCoversFunction ++ "\n" ++   -- i3djw: all-accounts CODE reverse (hidden created/destroyed account)
   -- .6.2.2.2.a: multi-tx dispatch helpers — bal_txs_independent (independence
   -- guard) + its bti_scan_* walkers, and multi_tx_nth_context (per-index tx
   -- context extractor) — wired ahead of the gated multi-tx loop (.6.2.2.2.b).


### PR DESCRIPTION
## Summary
`i3djw` wiring (the all-accounts CODE-reverse direction; the wiring is "c1's block_verdict domain" per the bead, now unblocked since the `.8b` deposit #8623 populates `exec_code_effect_log`). After the all-accounts storage + tuple checks, the verdict now runs `bal_all_accounts_code_covers` over the execution-derived code-effect log: every account execution deployed/cleared code for (`has_code_change=1`) must be **present** in the block_access_list — catching a producer that **hides a created/destroyed contract** by omitting its account. New verdict fail code **43** (`.Lbv_bal_code_covers_fail`).

- Presence-only (a present account's declared code is validated by the forward per-account direction).
- Linked the helper + a reusable `balAllAccountsCodeCoversData` scratch def into both verdict closures (`BlockVerdictV2`) and the verdict data section (`BlockVerdictDataSection`), refactoring the probe to share the def.

## Soundness / inertness
- **Inert today**: `exec_code_effect_log` is empty pre-`.8c` (CREATE is self-contained-rejected → no deposit runs), so the comparator iterates 0 records and passes trivially — **no EEST behavior change**. It goes live once CREATE is activated (`.8c-3`).
- Conservative (parse failure / omitted account → reject).
- **NOTE for `.8c-3`**: add a per-tx reset of `exec_code_effect_count` (not reset today; harmless while empty, required once CREATE writes it across txs).

## Verification
- `lake build` (full, 3300 jobs) green; `file-size`/`unimported` (2162)/`forbidden-tactics` pass.
- `stateless_guest` **emit/assemble/link** (`bal_all_accounts_code_covers` + `bacov_*` resolve in the verdict closure, no dup labels).
- `zisk_bal_all_accounts_code_covers` probe **3/3 PASS** (covered→0, omitted→1, unchanged_skip→0) — the data-def refactor is non-regressing.

Bead: i3djw (bmvmx.1.6.4.4) — the code-reverse wiring slice.

Authored by @pirapira; implemented by Claude Code