### PR TITLE
fix(verdict): reset the per-created-account code-effect log per tx

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -943,6 +943,9 @@ def emitDispatcherPrologue : String :=
   "  la x5, evm_refund_acc; sd x0, 0(x5)\n" ++   -- bmvmx.1.6.3: reset per-tx refund counter
   "  la x5, create_nonce_table_count; sd x0, 0(x5)\n" ++   -- .61.8c-1: reset per-creator nonce table per tx
   "  la x5, create_nonce_table_overflow; sd x0, 0(x5)\n" ++
+  "  la x5, exec_code_effect_count; sd x0, 0(x5)\n" ++   -- i3djw/.8c: reset the per-created-account code-effect log per tx
+  "  la x5, exec_code_effect_next; sd x0, 0(x5)\n" ++    -- (else CREATE deposits + code_covers carry stale records across txs)
+  "  la x5, exec_code_effect_overflow; sd x0, 0(x5)\n" ++
   "  sd x0, 464(x20)\n" ++         -- env.transientLogLengthOff = 0
   "  sd x0, 472(x20)\n" ++         -- env.eventLogLengthOff = 0
   "  sd x0, 480(x20)\n" ++         -- env.eventLogCheckpointOff = 0


### PR DESCRIPTION
## Summary
A `.8c-3` prerequisite, landed early while inert. The CREATE deposit (`.8b`, #8623) appends deployed-code records to `exec_code_effect_log`, and the all-accounts code-reverse comparator (`bal_all_accounts_code_covers`, #8626) iterates them — but neither resets the log per tx.

- Today this is harmless (the log is empty: CREATE is self-contained-rejected pre-`.8c`).
- Once CREATE is activated (`.8c-3`), an unreset log would carry **stale records across txs** in a multi-tx block, so `code_covers` could reject on a prior tx's created account.
- Resets `exec_code_effect_count`/`next`/`overflow` per tx in the dispatcher setup, alongside the existing `evm_refund_acc` (bmvmx.1.6.3) and `create_nonce_table` (`.8c-1`) per-tx resets.

## Verification
- `lake build` green; `stateless_guest` **emit/assemble/link** (the `exec_code_effect_*` symbols resolve in the guest setup); `forbidden-tactics` green.
- **No behavior change today**: zeroes already-zero cells, and the reset is outside the `create_roundtrip` probe's prologue path.

Bead: i3djw / fhsxz.2.4.2.61.8.3 (the `.8c-3` per-tx-reset prerequisite).

Authored by @pirapira; implemented by Claude Code