### PR TITLE
fix(verdict): reject SELFDESTRUCT (0xff) in bytecode_is_self_contained (un-staged beneficiary gas)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictSelfContained.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictSelfContained.lean
@@ -15,8 +15,14 @@
   Unsafe opcodes (need un-staged state): BALANCE(0x31), ORIGIN(0x32),
   CALLER(0x33), GASPRICE(0x3a), EXTCODESIZE(0x3b), EXTCODECOPY(0x3c),
   EXTCODEHASH(0x3f), BLOCKHASH(0x40), SELFBALANCE(0x47), CREATE(0xf0),
-  CREATE2(0xf5). PUSH1..PUSH32 (0x60..0x7f) data bytes are skipped so push
-  immediates are never misread as opcodes.
+  CREATE2(0xf5), SELFDESTRUCT(0xff). PUSH1..PUSH32 (0x60..0x7f) data bytes are
+  skipped so push immediates are never misread as opcodes.
+
+  SELFDESTRUCT(0xff) is rejected because its gas adds cold-beneficiary-access
+  (EIP-2929) + account-creation (when the beneficiary is empty and balance>0),
+  both depending on the un-staged beneficiary account; the dispatcher only
+  charges the 5000 base (Dispatch.lean `0xff => 5000`), so a SELFDESTRUCT
+  contract dispatched here would be under-charged.
 
   The message-call opcodes CALL(0xf1)/CALLCODE(0xf2)/DELEGATECALL(0xf4)/
   STATICCALL(0xfa) are NO LONGER rejected: the call-frame descent
@@ -66,17 +72,19 @@ def bytecodeIsSelfContainedFunction : String :=
   "  li t3, 0x47; beq t2, t3, .Lbsc_unsafe\n" ++   -- SELFBALANCE
   "  li t3, 0xf0; beq t2, t3, .Lbsc_unsafe\n" ++   -- CREATE
   "  li t3, 0xf5; beq t2, t3, .Lbsc_unsafe\n" ++   -- CREATE2
+  "  li t3, 0xff; beq t2, t3, .Lbsc_unsafe\n" ++   -- SELFDESTRUCT (beneficiary cold/warm + account-creation gas is un-staged)
   "  addi t0, t0, 1; j .Lbsc_loop\n" ++
   ".Lbsc_safe:\n" ++
   "  li a0, 0; ret\n" ++
   ".Lbsc_unsafe:\n" ++
   "  li a0, 1; ret"
 
-/-- `zisk_bytecode_is_self_contained`: probe over three hand-written bytecodes.
+/-- `zisk_bytecode_is_self_contained`: probe over four hand-written bytecodes.
     Output:
       +0  scan of PUSH1 0x07 PUSH1 0x01 SSTORE STOP (expect 0 self-contained)
       +8  scan of PUSH1 0x00 BALANCE                (expect 1 unsafe; CALL now allowed)
-      +16 scan of PUSH1 0xF1 STOP (0xF1 is push DATA, not CALL) (expect 0) -/
+      +16 scan of PUSH1 0xF1 STOP (0xF1 is push DATA, not CALL) (expect 0)
+      +24 scan of PUSH1 0x00 SELFDESTRUCT (60 00 FF) (expect 1 unsafe) -/
 def ziskBytecodeIsSelfContainedPrologue : String :=
   "  li sp, 0xa0050000\n" ++
   "  li s0, 0xa0010000\n" ++
@@ -95,6 +103,10 @@ def ziskBytecodeIsSelfContainedPrologue : String :=
   "  la t0, bsc_codeC\n" ++
   "  li t1, 0x60; sb t1, 0(t0); li t1, 0xF1; sb t1, 1(t0); sb zero, 2(t0)\n" ++
   "  la a0, bsc_codeC; li a1, 3; jal ra, bytecode_is_self_contained; sd a0, 16(s0)\n" ++
+  -- code D: 60 00 FF (PUSH1 0 SELFDESTRUCT -> unsafe: beneficiary state is un-staged).
+  "  la t0, bsc_codeD\n" ++
+  "  li t1, 0x60; sb t1, 0(t0); sb zero, 1(t0); li t1, 0xFF; sb t1, 2(t0)\n" ++
+  "  la a0, bsc_codeD; li a1, 3; jal ra, bytecode_is_self_contained; sd a0, 24(s0)\n" ++
   "  j .Lbscp_done\n" ++
   bytecodeIsSelfContainedFunction ++ "\n" ++
   ".Lbscp_done:"
@@ -104,7 +116,8 @@ def ziskBytecodeIsSelfContainedDataSection : String :=
   ".balign 8\n" ++
   "bsc_codeA:\n  .zero 16\n" ++
   "bsc_codeB:\n  .zero 16\n" ++
-  "bsc_codeC:\n  .zero 16\n"
+  "bsc_codeC:\n  .zero 16\n" ++
+  "bsc_codeD:\n  .zero 16\n"
 
 def ziskBytecodeIsSelfContainedProbeUnit : BuildUnit := {
   body        := NOP


### PR DESCRIPTION
## Summary
- **Soundness fix** (found by audit): `bytecode_is_self_contained` — the gate deciding whether a contract recipient may be gas-measured by the non-call-frame dispatch — was **missing SELFDESTRUCT (0xff)** from its un-staged-state reject set (it had BALANCE/ORIGIN/CALLER/GASPRICE/EXTCODE\*/BLOCKHASH/SELFBALANCE/CREATE/CREATE2).
- The dispatcher *handles* `0xff` (`Dispatch.lean` `0xff => 5000` base + `.exit_selfdestruct`), charging only the **5000 base** — but the spec SELFDESTRUCT gas also adds **cold-beneficiary-access** (EIP-2929, 2600) and **account-creation** (25000 when the beneficiary is empty and balance>0), both depending on the **un-staged** beneficiary account. So a SELFDESTRUCT contract was wrongly deemed self-contained, dispatched, and **under-charged by up to 27600 gas** → the EIP-7778/8037 block-gas gate could accept an over-budget block (**false-accept**).

## Fix
Add `0xff` to the reject set + document why.

## Soundness
**Only adds conservative rejects** — SELFDESTRUCT contracts now bail to the conservative path like every other un-staged-state opcode; no false-accept can be introduced, and bytecode without `0xff` is byte-identical.

## Verification
- Probe `zisk_bytecode_is_self_contained` extended with a `60 00 FF` (PUSH1 0 SELFDESTRUCT) case → expect unsafe=1. Ran it: `A(SSTORE)=0 B(BALANCE)=1 C(PUSH-data)=0 D(SELFDESTRUCT)=1` PASS (existing cases unchanged).
- Targeted EEST sweep `--filter selfdestruct --limit 20 --jobs 2`: **20/20 full match, 0 regressions** (the passing rows verify via the post-state-root recompute, not the gas-measurement path).
- Full build + file-size / unimported / forbidden-tactics gates pass.

Refs #8475. Bead: tpdo1.

Authored by @pirapira; implemented by Claude Code