### PR TITLE
fix(storage): preserve x13 (mem base) across the SLOAD/SSTORE EIP-2929 access charge

### DIFF
--- a/EvmAsm/Codegen/Programs/CreateRoundtrip.lean
+++ b/EvmAsm/Codegen/Programs/CreateRoundtrip.lean
@@ -14,21 +14,26 @@
   (.8c).
 
   Setup: a depth-0 frame whose memory is pre-loaded with init code and whose
-  bytecode does a CREATE then SSTOREs the result:
+  bytecode does TWO sequential CREATEs by the same creator, SSTORE'ing each:
 
     init code @ mem[0] (10 B): PUSH1 0xAA; PUSH1 0; MSTORE8; PUSH1 1; PUSH1 0; RETURN
       → MSTORE8 mem[0]=0xAA, RETURN(0,1) returns the 1-byte deployed code {0xAA}.
-    parent code (11 B): PUSH1 10; PUSH1 0; PUSH1 0; CREATE; PUSH1 0; SSTORE; STOP
-      → CREATE(value=0, offset=0, size=10) stages mem[0..10], runs the mini-interp
-        (create_child_status=2, deployed {0xAA}), pushes the derived address; then
-        PUSH1 0; SSTORE writes the address to storage slot 0; STOP halts at depth 0.
+    parent code (21 B):
+        PUSH1 10; PUSH1 0; PUSH1 0; CREATE; PUSH1 0; SSTORE   (slot 0 = addr1)
+        PUSH1 10; PUSH1 0; PUSH1 0; CREATE; PUSH1 1; SSTORE   (slot 1 = addr2)
+        STOP
+      → each CREATE(value=0, offset=0, size=10) stages mem[0..10], runs the mini-interp
+        (create_child_status=2, deployed {0xAA}), pushes the derived address.
 
   No account-witness context is attached (env+584 = 0), so the tail takes the clean
-  path (skip balance/collision gates, create_nonce defaults to 0) and the address is
-  keccak(rlp([env.ADDRESS, 0]))[12:] — non-zero. A correct round trip therefore
-  writes storage slot 0 = the (non-zero) deployed address. The check script asserts
-  halt_kind 0, one emitted slot, slot key 0, and a NON-ZERO slot value (CREATE
-  deployed + pushed an address through the inline tail).
+  path (skip balance/collision gates). The per-creator running nonce (.8c-1) makes the
+  first CREATE use nonce 0 and the second nonce 1, so addr1 = keccak(rlp([ADDRESS,0]))
+  and addr2 = keccak(rlp([ADDRESS,1])) — DISTINCT non-zero addresses. This also guards
+  the dispatcher mem-base (x13) survival across SSTORE: the SSTORE between the two
+  CREATEs must NOT corrupt x13 (the EIP-2929 access-charge once clobbered a3=x13 — the
+  double-CREATE panic fhsxz.2.4.2.61.8.3.4), else the second CREATE's staging reads a
+  bogus base. The check script asserts halt_kind 0, two emitted slots, slot 0 == the
+  nonce-0 address (regression), and slot 1 != slot 0 (distinct; x13 intact).
 -/
 
 import EvmAsm.Codegen.Dispatch
@@ -48,7 +53,7 @@ def createRoundtripPrologue : String :=
   "  la x10, cr_parent_code\n" ++
   "  la x21, cr_parent_code\n" ++
   "  li t0, 1000000\n  sd t0, 568(x20)\n" ++        -- gasRemaining
-  "  li t0, 11\n  sd t0, 496(x20)\n" ++             -- codeSize (parent code len)
+  "  li t0, 21\n  sd t0, 496(x20)\n" ++             -- codeSize (2-CREATE verify)
   "  sd x0, 448(x20); sd x0, 456(x20); sd x0, 464(x20)\n" ++   -- storage log length etc.
   "  sd x0, 472(x20); sd x0, 480(x20)\n" ++
   "  sd x0, 584(x20)\n" ++                          -- no account-witness ctx -> clean CREATE path
@@ -87,7 +92,8 @@ def createRoundtripData : String :=
   "call_frame_arena:\n  .zero " ++ toString (0x29000 : Nat) ++ "\n" ++
   ".balign 8\n" ++
   -- parent: PUSH1 10; PUSH1 0; PUSH1 0; CREATE; PUSH1 0; SSTORE; STOP.
-  "cr_parent_code:\n  .byte 0x60, 0x0a, 0x60, 0x00, 0x60, 0x00, 0xf0, 0x60, 0x00, 0x55, 0x00\n" ++
+  "cr_parent_code:\n  .byte 0x60, 0x0a, 0x60, 0x00, 0x60, 0x00, 0xf0, 0x60, 0x00, 0x55\n" ++
+  "  .byte 0x60, 0x0a, 0x60, 0x00, 0x60, 0x00, 0xf0, 0x60, 0x01, 0x55, 0x00\n" ++
   -- init code: PUSH1 0xAA; PUSH1 0; MSTORE8; PUSH1 1; PUSH1 0; RETURN -> deploys {0xAA}.
   "cr_init_code:\n  .byte 0x60, 0xaa, 0x60, 0x00, 0x53, 0x60, 0x01, 0x60, 0x00, 0xf3\n" ++
   ".balign 8\n" ++

--- a/EvmAsm/Codegen/Programs/EvmStorageAccessGas.lean
+++ b/EvmAsm/Codegen/Programs/EvmStorageAccessGas.lean
@@ -117,6 +117,15 @@ def storageAccessKeyInsertAsm (doneLabel : String) : String :=
     The dispatcher's opcode table charges SLOAD/SSTORE 100 before the
     handler runs, so this helper only charges the EIP-2929 cold delta
     (`COLD_SLOAD_COST - WARM_STORAGE_READ_COST = 2100 - 100 = 2000`).
+
+    Register note: the charged gas delta is held in `a4` (recorded into the
+    access-outcome log), NOT `a3` — because `a3` is the dispatcher's per-frame
+    memory base (`x13`) and SLOAD/SSTORE call this helper from the dispatch tail
+    WITHOUT saving x13 (they save only x1/x10/x12, the regs the arg setup
+    clobbers). Using `a3` for the delta would corrupt x13 to 0/2000, so any
+    SLOAD/SSTORE followed by a memory-touching opcode (MLOAD/MSTORE/CREATE/CALL)
+    would read/write at the bogus base (e.g. the double-CREATE ziskemu panic,
+    fhsxz.2.4.2.61.8.3.4). a4 is caller-saved and not a dispatcher invariant.
 -/
 def storageAccessGasFunction : String :=
   "evm_storage_access_charge_key:\n" ++
@@ -155,7 +164,7 @@ def storageAccessGasFunction : String :=
   "  ld t5, 24(a1)\n" ++
   "  bne t4, t5, .Lsag_next\n" ++
   "  li a0, 0\n" ++
-  "  li a3, 0\n" ++
+  "  li a4, 0\n" ++
   "  j .Lsag_record_and_ret\n" ++
   ".Lsag_next:\n" ++
   "  addi t3, t3, 64\n" ++
@@ -191,15 +200,15 @@ def storageAccessGasFunction : String :=
   "  addi t2, t2, 1\n" ++
   "  sd t2, 0(t1)\n" ++
   "  li a0, 1\n" ++
-  s!"  li a3, {storageAccessColdDeltaGas}\n" ++
+  s!"  li a4, {storageAccessColdDeltaGas}\n" ++
   "  j .Lsag_record_and_ret\n" ++
   ".Lsag_oog:\n" ++
   "  li a0, 2\n" ++
-  "  li a3, 0\n" ++
+  "  li a4, 0\n" ++
   "  j .Lsag_record_and_ret\n" ++
   ".Lsag_full:\n" ++
   "  li a0, 3\n" ++
-  "  li a3, 0\n" ++
+  "  li a4, 0\n" ++
   "  j .Lsag_record_and_ret\n" ++
   ".Lsag_record_and_ret:\n" ++
   "  la t0, evm_storage_access_outcome_count\n" ++
@@ -222,7 +231,7 @@ def storageAccessGasFunction : String :=
   "  ld t4, 16(a1); sd t4, 48(t3)\n" ++
   "  ld t4, 24(a1); sd t4, 56(t3)\n" ++
   "  sd a0, 64(t3)               # status/outcome\n" ++
-  "  sd a3, 72(t3)               # gas delta charged\n" ++
+  "  sd a4, 72(t3)               # gas delta charged\n" ++
   "  sd zero, 80(t3)\n" ++
   "  sd zero, 88(t3)\n" ++
   ".Lsag_record_skip:\n" ++

--- a/scripts/codegen-zisk-create-roundtrip-check.sh
+++ b/scripts/codegen-zisk-create-roundtrip-check.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 # codegen-zisk-create-roundtrip-check.sh
 # End-to-end verification of the INLINE CREATE descent through the real dispatch
-# loop (bead fhsxz.2.4.2.61.8): a depth-0 frame whose bytecode does CREATE then
-# SSTOREs the deployed address to slot 0. Asserts halt 0, one emitted slot, key 0,
-# and a NON-ZERO value (CREATE staged init code, ran the mini-interp, derived +
-# pushed a keccak address through the inline tail). No input.
+# loop (bead fhsxz.2.4.2.61.8): a depth-0 frame whose bytecode does TWO sequential
+# CREATEs by the same creator, SSTORE'ing each deployed address (slot 0, slot 1).
+# Asserts halt 0, TWO emitted slots, and that slot{0,1} are DISTINCT non-zero
+# addresses (slot 0 == the nonce-0 address regression; slot 1 != slot 0, proving the
+# .8c-1 per-creator nonce increment AND that x13/mem-base survives SSTORE -> the
+# double-CREATE panic fhsxz.2.4.2.61.8.3.4 is fixed). No input.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
@@ -39,13 +41,23 @@ python3 - <<'PY'
 import struct, sys
 d = open('gen-out/zisk_create_roundtrip.out', 'rb').read()
 def w(off): return struct.unpack('<Q', d[off:off+8])[0]
-halt, cnt, key, val = w(32), w(56), w(64), w(96)
-print(f"  halt_kind(+32)  = {halt} (exp 0)")
-print(f"  slot count(+56) = {cnt} (exp 1)")
-print(f"  slot0 key(+64)  = {key} (exp 0)")
-print(f"  slot0 val(+96)  = {hex(val)} (exp != 0 : deployed CREATE address low limb)")
-if halt == 0 and cnt == 1 and key == 0 and val != 0:
-    print("==> PASS: inline CREATE descent deployed + pushed a non-zero address through the dispatch loop")
+# Emitted slots: count at +56, then (key@+0, val@+32) 64 B records from +64.
+# Output order is reverse-chronological (last-written first); match by key.
+halt, cnt = w(32), w(56)
+ka, va = w(64), w(96)
+kb, vb = w(128), w(160)
+slots = {ka: va, kb: vb}
+KNOWN = 0xcb804a576fa48eb1   # nonce-0 CREATE address low limb (original single-CREATE regression)
+print(f"  halt_kind(+32)   = {halt} (exp 0)")
+print(f"  slot count(+56)  = {cnt} (exp 2)")
+print(f"  record0 (+64/+96)   key={ka} val={hex(va)}")
+print(f"  record1 (+128/+160) key={kb} val={hex(vb)}")
+ok = (halt == 0 and cnt == 2 and 0 in slots and 1 in slots
+      and slots[0] == KNOWN and slots[1] != 0 and slots[1] != slots[0])
+if ok:
+    print(f"  slot0 (nonce 0) = {hex(slots[0])} (== known {hex(KNOWN)})")
+    print(f"  slot1 (nonce 1) = {hex(slots[1])} (!= slot0 -> distinct; x13 survived SSTORE)")
+    print("==> PASS: two sequential CREATEs by one creator deployed DISTINCT addresses (double-CREATE panic fixed)")
 else:
     print("==> FAIL"); sys.exit(1)
 PY


### PR DESCRIPTION
## Summary
Fixes a register-clobber bug that corrupts the dispatcher's per-frame **memory base (x13)** on every SLOAD/SSTORE, and is the root cause of the double-CREATE panic (`fhsxz.2.4.2.61.8.3.4`).

`evm_storage_access_charge_key` used **`a3`** as its gas-delta scratch (`li a3,0` / `li a3,2000`, recorded into the access-outcome log). But **`a3` == `x13`** — the dispatcher's per-frame memory base — and the SLOAD/SSTORE handlers call this helper from the dispatch tail saving only `x1/x10/x12` (the regs the `mv a0,x20` / `addi a2,x20,568` arg setup clobbers), **not x13**. So every SLOAD/SSTORE left `x13 = 0` (warm) or `2000=0x7d0` (cold), and any subsequent memory-touching opcode (`MLOAD`/`MSTORE`/`MSTORE8`/`CREATE`/`CALL`) then accessed the bogus base — an unmapped-address panic in ziskemu.

This was **latent** for single-SSTORE-then-STOP bytecode (x13 unused after) but breaks any SLOAD/SSTORE-then-memory-op contract now that the dispatcher executes contract code (bmvmx.1.7). The double-CREATE panic was the symptom: the SSTORE between two CREATEs set `x13=0x7d0`, so the 2nd CREATE's `create_stage_initcode_frame` copy loop read init code from `0x7d0` → `Mem::read() section not found for addr 2000=7d0`.

## Fix
Hold the gas delta in **`a4`** (caller-saved, not a dispatcher invariant) instead of `a3`. `a4` is unused by the leaf helper, and neither caller reads it (both `mv x14,a0` the *status* after the call). The delta is still recorded correctly, so **gas accounting is unchanged**.

## Verification
- **Hardened `zisk_create_roundtrip` to two sequential CREATEs** — now **PASSES**: halt 0, two distinct addresses (`0xcb804a576fa48eb1` nonce-0 + `0x83e2bd3090a6fef3` nonce-1), no panic. (Was the failing repro; now a permanent regression guard for both `.8c-1` and the x13 fix.)
- `storage-access-gas` probe **PASSES** (cold-delta charge + warm-key tracking unchanged).
- Single-CREATE address regression preserved (`slot 0 == 0xcb804a576fa48eb1`).
- Full `lake build` (3236), `file-size`, `unimported` (2162), `forbidden-tactics`, and `stateless_guest` link all green.

Closes the double-CREATE panic blocker; unblocks `.8c-3` (multi-CREATE contracts no longer crash). Bead: fhsxz.2.4.2.61.8.3.4.

Authored by @pirapira; implemented by Claude Code