### PR TITLE
fix(eip8025): reject missing current-frame code preimage

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -928,6 +928,21 @@ def blockVerdictFunction : String :=
   -- increment (receipt_inc) is exact; the EIP-7778 block-gas gate is unaffected
   -- (it uses block_inc, which is refund-independent).
   ".Lbv_contract_dispatch:\n" ++
+  -- evm-asm-ok3nl (EIP-8025 witness validation): the currently-executing frame's
+  -- code must be present in witness.codes. The executable spec loads it via
+  -- WitnessState.get_code (witness_state.py), whose `self._code_db[code_hash]`
+  -- raises -> InvalidBlock when the preimage is absent. We reach here only when
+  -- the recipient's code_hash is non-empty (the contract path), so require that
+  -- preimage up-front; otherwise the staged dispatch silently bails to the
+  -- conservative fall-through and the missing current-frame code is never caught
+  -- (false-accept: guest=01 exp=00). bal_code_preimages_valid's BAL-row-shape
+  -- heuristic skips the recipient, so this targeted gate is the binding check.
+  "  la t0, svf_codes_ptr; ld a0, 0(t0)\n" ++
+  "  la t0, svf_codes_len; ld a1, 0(t0)\n" ++
+  "  la a2, bv_tx_recipient_code_hash\n" ++
+  "  la a3, bv_cf_code_off; la a4, bv_cf_code_len\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  bnez a0, .Lbv_code_preimage_fail            # current-frame code preimage absent -> reject\n" ++
   "  la a0, bv_simple_transfer_tx\n" ++
   "  ld a1, 80(s0); ld a2, 88(s0)\n" ++
   "  jal ra, dispatch_tx_runtime_code\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -368,6 +368,8 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bbcv_scan_size:\n  .zero 8\n" ++
   "bbcv_scan_addr_off:\n  .zero 8\n" ++
   "bbcv_scan_addr_len:\n  .zero 8\n" ++
+  "bv_cf_code_off:\n  .zero 8\n" ++
+  "bv_cf_code_len:\n  .zero 8\n" ++
   ".balign 32\n" ++
   "bv_tx_recipient_code_hash:\n  .zero 32\n" ++
   "bbcv_sender_addr:\n  .zero 32\n" ++


### PR DESCRIPTION
## Summary
- Fixes the EIP-8025 false accept `validation_codes_missing_current_frame_code` (soundness P0, `evm-asm-ok3nl`): the guest accepted a block the spec rejects (`succ guest=01 exp=00`, `verdict=1 bv_fail=0`).
- Root cause: a contract recipient whose `code_hash` is non-empty but whose code is **absent from `witness.codes`** slipped through every gate. `dispatch_tx_runtime_code` bails on the missing preimage and `BlockVerdict`'s contract path branched to the conservative `.Lbv_after_tx_gas_precharge` fall-through (no reject); `bal_code_preimages_valid`'s BAL-row-shape heuristic skips the recipient. `.58.5` was never a real fix (closed "verified fixed after merges"); a fixture re-gen (block_rlp_len 709→743) re-exposed the gap.
- Spec basis: `WitnessState.get_code` does `self._code_db[code_hash]`, which raises → `InvalidBlock` for any executed code hash absent from the witness, including the currently-executing frame (`interpreter.py` `message.code = get_code(...)`).
- Fix: at `.Lbv_contract_dispatch` (reached only when the recipient `code_hash != EMPTY_CODE_HASH`), require the preimage via `witness_lookup_by_hash(witness.codes, bv_tx_recipient_code_hash)` **before** dispatch; a miss rejects (`.Lbv_code_preimage_fail`, `bv_fail=11`).
- Soundness: adds a reject only, cannot introduce a false-accept.

## Verification
`--filter validation_codes_missing` (9 fixtures): `current_frame_code` now **FULL** (`succ=00=exp`); **8/9 full, 0 regressions**. The passing siblings (`external_code_read_target`, `sender_delegation_marker`, `7702_delegated_target_code`, `7702_delegation_marker`, `redelegation_old_marker`, `second_marker_in_delegation_chain`, `delegated_code_on_insufficient_balance_call`) carry their recipient code, so the lookup hits and they stay green. The lone remaining fail (`implicit_system_contract_code`) is a **separate pre-existing false-accept** (`bv_fail=0`, untouched by this reject) filed as its own P0.

Refs #8025. Bead: evm-asm-ok3nl.

Authored by @pirapira; implemented by Claude Code