### PR TITLE
feat(verdict): CREATE-site non-storage effect producer (i3djw.2)

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -593,7 +593,12 @@ def emitCreateChildFrameData : String :=
   "nse_callee_be:\n  .zero 32\n" ++
   ".balign 32\n" ++
   "nse_acct:\n  .zero 104\n" ++
-  "nse_post_bal:\n  .zero 32\n"
+  "nse_post_bal:\n  .zero 32\n" ++
+  -- i3djw.2: CREATE-site producer scratch — the created account's BE-reversed endowment
+  -- (post_balance) and a zero buffer for the absent pre_balance.
+  ".balign 32\n" ++
+  "nse_create_post_bal:\n  .zero 32\n" ++
+  "nse_zero_bal:\n  .zero 32\n"
 
 /-- Scratch labels shared by runtime account-witness helpers.
 

--- a/EvmAsm/Codegen/Programs/CallFrameRoundtrip.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameRoundtrip.lean
@@ -82,7 +82,8 @@ def callFrameRoundtripPrologue : String :=
   callFrameForwardGasFunction ++ "\n" ++
   callFrameDescendFunction ++ "\n" ++
   createFrameDescendFunction ++ "\n" ++   -- .61.8.3.5: CREATE tail (shared registry) descends via create_frame_descend
-  frameReturnFunction
+  frameReturnFunction ++ "\n" ++
+  recordNonstorageEffectFunction   -- i3djw.2: CREATE-RETURN deposit records the created account's non-storage effect
 
 def callFrameRoundtripData : String :=
   emitRuntimeDispatcherDataSection callFrameProbeRegistry ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/CreateRoundtrip.lean
+++ b/EvmAsm/Codegen/Programs/CreateRoundtrip.lean
@@ -79,7 +79,8 @@ def createRoundtripPrologue : String :=
   callFrameForwardGasFunction ++ "\n" ++
   callFrameDescendFunction ++ "\n" ++
   createFrameDescendFunction ++ "\n" ++   -- .61.8.3.5: CREATE tail now descends via create_frame_descend
-  frameReturnFunction
+  frameReturnFunction ++ "\n" ++
+  recordNonstorageEffectFunction   -- i3djw.2: CREATE-RETURN deposit records the created account's non-storage effect
 
 def createRoundtripData : String :=
   emitRuntimeDispatcherDataSection callFrameProbeRegistry ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/NoopHalt.lean
+++ b/EvmAsm/Codegen/Programs/NoopHalt.lean
@@ -60,6 +60,20 @@ private def returnRevertTail (kind : Nat) (rollbackAsm : String := "")
       "  bnez a0, .Lrr_crinv_" ++ toString kind ++ "\n" ++
       "  la a0, create_address_be\n  add a1, x13, x14\n  mv a2, x15\n" ++
       "  jal ra, create_record_code_effect\n" ++
+      -- i3djw.2: record the created account's NON-STORAGE effect (pre absent 0/0; post
+      -- nonce=1, balance=endowment). endowment = child env.CALLVALUE (x20+96), which
+      -- call_frame_set_call_env stored as the LE stack value word, so reverse it to BE
+      -- (read x20+127 down to x20+96) for the BE effect-log convention (matching i3djw.1).
+      -- x20 = child env here (before frame_return restores the parent). a0/a2/a3 alias
+      -- x10/x12/x13 -> saved/restored around record_nonstorage_effect. INERT until i3djw.3
+      -- wires the comparator (and CREATE is self-contained-rejected until .8c-3).
+      "  la t0, nse_create_post_bal\n  addi t1, x20, 127\n  li t2, 32\n" ++
+      ".Lrr_crendow_" ++ toString kind ++ ":\n" ++
+      "  lbu t3, 0(t1)\n  sb t3, 0(t0)\n  addi t1, t1, -1\n  addi t0, t0, 1\n  addi t2, t2, -1\n  bnez t2, .Lrr_crendow_" ++ toString kind ++ "\n" ++
+      "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
+      "  la a0, create_address_be\n  la a1, nse_zero_bal\n  la a2, nse_create_post_bal\n  li a3, 0\n  li a4, 1\n" ++
+      "  jal ra, record_nonstorage_effect\n" ++
+      "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
       "  li a0, 0\n  li a1, 0\n  li a2, 0\n" ++
       "  jal ra, frame_return\n" ++
       "  la t1, create_address_be\n  addi t1, t1, 19\n  mv t2, x12\n  li t3, 20\n" ++


### PR DESCRIPTION
## Summary
- At the CREATE-frame RETURN deposit (`returnRevertTail`, after `create_record_code_effect`, before `frame_return` — where `x20` is still the child env), record the created account's non-storage effect: `addr = create_address_be`, `pre = 0/0` (absent), `post_nonce = 1` (EIP-161), `post_balance = endowment`.
- The endowment is the child `env.CALLVALUE` (`x20+96`), which `call_frame_set_call_env` stores as the **LE** stack value word, so it's reversed (`x20+127`→`+96`) into **BE** for the effect-log convention (matching i3djw.1's `u256_add_be` output). Appended via `record_nonstorage_effect`; a0/a2/a3 alias x10/x12/x13, saved/restored around the call.
- CREATE analog of the merged i3djw.1 CALL-value producer.

## Soundness
- **INERT** for the verdict: the comparator is unwired until i3djw.3, and CREATE is `bytecode_is_self_contained`-rejected until .8c-3.
- New scratch `nse_create_post_bal`/`nse_zero_bal` in the shared CREATE data; `record_nonstorage_effect` linked into the create/call roundtrip probe prologues (they emit the depth-aware CREATE-RETURN branch).

## Verification
- `codegen-zisk-create-roundtrip-check.sh` **PASS** — 2 sequential CREATEs through the real descent + RETURN deposit STILL deploy distinct addresses (nonce-0 `0xcb804a576fa48eb1`, nonce-1 `0x83e2bd3090a6fef3`, halt 0) **with the producer firing**, so the LE→BE reverse + `record_nonstorage_effect` don't corrupt the CREATE-RETURN path (x10/x12/x13 intact).
- `codegen-zisk-call-roundtrip-check.sh` no-regression; `stateless_guest` links; full build + file-size/unimported/forbidden-tactics gates green.

Refs #8475. Bead: evm-asm-i3djw.2.

Authored by @pirapira; implemented by Claude Code