### PR TITLE
feat(verdict): stage SELFBALANCE = recipient balance for contract recipients (yisv8.1)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -821,6 +821,9 @@ def ziskStatelessVerdictV2DataSection : String :=
   ".balign 8\n" ++
   "gp_egp:\n  .zero 32\n" ++
   "gp_prio:\n  .zero 32\n" ++
+  -- yisv8.1: recipient self-balance scratch for the env.SELFBALANCE (word 1) staging.
+  ".balign 32\n" ++
+  "yisv8_self_bal:\n  .zero 32\n" ++
   ".balign 8\n" ++
   "bmvmx_sender_match:\n  .zero 8\n" ++
   -- bmvmx.1.4.3.1: envelope predicate scratch. bmvmx_sender_checked / bmvmx_coinbase_checked

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -280,6 +280,26 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  ld t4, 0(t3); sd t4, 0(t2); ld t4, 8(t3); sd t4, 8(t2)\n" ++
   "  ld t4, 16(t3); sd t4, 16(t2); ld t4, 24(t3); sd t4, 24(t2)\n" ++
   ".Ldtrc_no_gasprice:\n" ++
+  -- yisv8.1: SELFBALANCE (word 1 -> env_base+32) = the recipient's own balance from the
+  -- witness (balance_at_header_state_root over env.ADDRESS=recipient, ctx+72), copied
+  -- verbatim (BE) into the env word — mirroring the CALLVALUE/GASPRICE u256 staging (the
+  -- ACTIVE CALLVALUE proves the contract-recipient path's u256 env words are BE-direct).
+  -- INERT until yisv8.2 removes SELFBALANCE(0x47) from the self-contained reject set.
+  -- Conservative: a lookup miss/error leaves SELFBALANCE 0. balance_at_header_state_root
+  -- preserves s-regs (s0=state ptr, s1=state len, s2=ctx survive); clobbers only dead a/t-regs.
+  "  la a0, sv_this_rlp\n  la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++
+  "  addi a2, s2, 72\n" ++                       -- recipient addr (ctx+72)
+  "  mv a3, s0; mv a4, s1\n" ++                   -- witness state ptr/len
+  "  la a5, yisv8_self_bal\n" ++
+  "  jal ra, balance_at_header_state_root\n" ++
+  "  bnez a0, .Ldtrc_no_selfbal\n" ++             -- lookup miss/error -> leave SELFBALANCE 0
+  "  la t0, bv_runtime_payload; ld t1, 0(t0)\n" ++           -- codelen
+  "  addi t1, t1, 7; andi t1, t1, -8; addi t1, t1, 80\n" ++  -- env_base offset = round8(codelen)+80
+  "  add t2, t0, t1; addi t2, t2, 32\n" ++                   -- t2 = &SELFBALANCE word (env_base+32)
+  "  la t3, yisv8_self_bal\n" ++
+  "  ld t4, 0(t3); sd t4, 0(t2); ld t4, 8(t3); sd t4, 8(t2)\n" ++
+  "  ld t4, 16(t3); sd t4, 16(t2); ld t4, 24(t3); sd t4, 24(t2)\n" ++
+  ".Ldtrc_no_selfbal:\n" ++
   -- bmvmx.1.6.4.2.b: seed every non-recipient BAL account's storage into the exec log
   -- so nested callees SLOAD witness values (not 0). Fills callee_seed_table/count, which
   -- the callable dispatcher's seed loop drains during runtime_dispatcher_call's setup.


### PR DESCRIPTION
## Summary
- In `dispatch_tx_runtime_code` (after the GASPRICE staging), look up the recipient's own balance via `balance_at_header_state_root(env.ADDRESS = recipient, ctx+72)` over the witness and copy the 32-byte BE result verbatim into the SELFBALANCE env word (word 1, `env_base+32` = `selfBalanceOff`).
- Mirrors the CALLVALUE/GASPRICE u256 staging — the **active** CALLVALUE (0x34, not self-contained-rejected) proves the contract-recipient path's u256 env words are BE-direct, so SELFBALANCE uses the same verbatim BE copy.
- First slice of `yisv8` (the account-state activation; BALANCE/EXTCODE* already read the staged witness → those are just the yisv8.2 flip).

## Soundness
- **INERT until yisv8.2** removes SELFBALANCE(0x47) from `bytecode_is_self_contained`'s reject set (self-contained recipients never read SELFBALANCE today). Conservative: a lookup miss/error leaves SELFBALANCE 0.
- `balance_at_header_state_root` preserves s-regs (s0/s1/s2 = state ptr/len + ctx survive); the block clobbers only dead a/t-regs (`seed_callee_storage` re-derives a0-a2 next).

## Verification
- `stateless_guest` links (`balance_at_header_state_root` + `yisv8_self_bal` scratch resolve); full build + file-size/unimported/forbidden-tactics gates green. Guest-only (`dispatch_tx_runtime_code`) → the `stage_runtime_payload_code` layout probes + roundtrip probes are unaffected.
- Positive read-verification lands with yisv8.2 (gate flip + a SELFBALANCE contract); no-regression covered by the operator's main EEST run.

Refs #8475. Bead: evm-asm-yisv8.1.

Authored by @pirapira; implemented by Claude Code