### PR TITLE
fix(verdict): guard contract-payload staging vs bv_runtime_payload overflow + enlarge buffer (bmvmx.1.7.2) [REQUIRES EEST SWEEP]

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -199,7 +199,12 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bvgr_runtime_calldata_floor_ptr:\n  .zero 8\n" ++
   "bvgr_runtime_count:\n  .zero 8\n" ++
   ".balign 8\n" ++
-  "bv_runtime_payload:\n  .zero 4096\n" ++
+  -- bmvmx.1.7.2: sized to fit a max EIP-170 contract (round8(24576)) + 128-slot storage
+  -- preload (128*64=8192) + the 584-byte env/gas trailer + headroom for calldata and the
+  -- future M29 blockhash table (.3b). dispatch_tx_runtime_code's .Ldtrc_stage guard bails
+  -- conservatively for any payload that would still exceed this, so the staging write can
+  -- never overflow into the adjacent gas-result / bvcd_* cells.
+  "bv_runtime_payload:\n  .zero 65536\n" ++
   "bv_runtime_gas_left:\n  .zero 8\n" ++
   "bv_runtime_refund_counter:\n  .zero 8\n" ++
   "bv_runtime_calldata_floor:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -230,6 +230,15 @@ def dispatchTxRuntimeCodeFunction : String :=
   ".Ldtrc_nothread:\n" ++
   "  la t0, bvcd_i; ld t1, 0(t0); addi t1, t1, 1; sd t1, 0(t0); j .Ldtrc_sloop\n" ++
   ".Ldtrc_stage:\n" ++
+  -- bmvmx.1.7.2: conservative payload-size guard. stage_runtime_payload_code writes
+  -- round8(codelen)+round8(calldata)+storage*64+584 bytes into bv_runtime_payload; if that
+  -- exceeds the buffer (65536) the write would overflow into adjacent .data (gas result +
+  -- bvcd_* scratch). EIP-170 bounds code to 24576 but calldata/storage are unbounded, so bail
+  -- conservatively (route to the safe path) instead of corrupting state.
+  "  la t0, bvcd_code_len; ld t1, 0(t0); addi t1, t1, 7; andi t1, t1, -8\n" ++   -- round8(codelen)
+  "  ld t2, 64(s2); addi t2, t2, 7; andi t2, t2, -8; add t1, t1, t2\n" ++         -- + round8(calldata)
+  "  la t0, bvcd_key_count; ld t2, 0(t0); slli t2, t2, 6; add t1, t1, t2\n" ++   -- + storage_count*64
+  "  addi t1, t1, 584; li t2, 65536; bgtu t1, t2, .Ldtrc_unsupported\n" ++       -- payload > buffer -> conservative bail
   "  mv a0, s2; la a1, bv_runtime_payload; la t2, bv_exec_p; ld a2, 0(t2)\n" ++
   "  la t0, bvcd_code_ptr; ld a3, 0(t0); la t0, bvcd_code_len; ld a4, 0(t0)\n" ++
   "  la a5, bvcd_preload; la t0, bvcd_key_count; ld a6, 0(t0)\n" ++


### PR DESCRIPTION
## Summary

**Latent buffer-overflow bug.** `dispatch_tx_runtime_code` stages the contract-recipient payload into `bv_runtime_payload` with **no size guard**, and the buffer was only **4096 bytes**. `stage_runtime_payload_code` writes `round8(codelen) + round8(calldata) + storage_count*64 + 584` bytes. EIP-170 bounds deployed code to 24576, so any self-contained contract recipient whose payload exceeds 4096 (code beyond ~3.5KB, or large calldata/storage) **overflowed** into the adjacent `.data`:

```
bv_runtime_payload (4096)  <- overflow source
bv_runtime_gas_left        <- the gas result the dispatcher reads
bvcd_code_ptr / bvcd_code_len / bvcd_* dispatch scratch
```

…corrupting the gas result and the verdict. The activated contract-recipient rows pass only because their recipients are small (analogous to the 3vc2p.5 env_base bug — both pass the sweep only because tested rows are small).

## Fix

1. **Enlarge `bv_runtime_payload` 4096 → 65536** — fits a max EIP-170 contract (`round8(24576)`) + a 128-slot storage preload (`128*64`) + the 584-byte env/gas trailer + headroom for calldata and the future M29 blockhash table (`.3b`).
2. **Conservative size guard at `.Ldtrc_stage`** — if `round8(codelen)+round8(calldata)+storage*64+584` exceeds the buffer, bail to `.Ldtrc_unsupported` (route to the safe path) rather than corrupt state. The guard computes exactly the byte count `stage_runtime_payload_code` writes (same `code_len` / `calldata@+64` / `key_count` inputs).

## Verification (short of the sweep)

- `lake build` green; the verdict ELF assembles + links.
- The `stage_runtime_payload_code` probe still reports `env_base=88` — stage is untouched, so small-contract behavior is byte-identical.
- `check-file-size.sh` / `check-unimported.sh` / `check-forbidden-tactics.sh` pass.

## ⚠️ REQUIRES EEST SWEEP

Changes behavior for large contract recipients: overflow-corruption → correct execution for payloads ≤ 64KB, conservative bail beyond. The sweep should confirm small-contract rows are unchanged and any large-contract rows are now handled soundly.

Refs #8475. Bead: evm-asm-bmvmx.1.7.2.

Authored by @pirapira; implemented by Claude Code