### PR TITLE
fix(verdict): cap recipient storage-key preload vs bvcd_keys overflow (bmvmx.1.7.3) [REQUIRES EEST SWEEP]

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictContractStorage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictContractStorage.lean
@@ -27,9 +27,11 @@ open EvmAsm.Rv64
 
     Calling convention:
       a0 = AccountChanges RLP ptr   a1 = AccountChanges RLP length
-      a2 = out keys ptr (count x 32-byte big-endian slot keys)
+      a2 = out keys ptr (count x 32-byte big-endian slot keys; caller buffer must hold 128)
     Returns:
-      a0 = count of slot keys written (0 on parse failure — conservative).
+      a0 = entry count (0 on parse failure — conservative). Keys are written only when
+           the count is <= 128 (the caller-buffer cap); if it exceeds 128, NOTHING is
+           written and the true count is returned so the caller can bail conservatively.
 
     Reads item 1 (storage_changes) of the AccountChanges list; for each entry,
     reads item 0 (the slot key) and writes it left-padded to 32 bytes. -/
@@ -52,6 +54,11 @@ def balRecipientStorageKeysFunction : String :=
   "  jal ra, rlp_list_count_items\n" ++
   "  bnez a0, .Lbrsk_fail\n" ++
   "  la t0, brsk_cnt; ld s5, 0(t0)                   # entry count\n" ++
+  -- bmvmx.1.7.3: cap the write at 128 slots (the caller buffers: bvcd_keys/bvcd_preload
+  -- and csce_keys are all sized for 128). If the BAL declares MORE storage_changes than
+  -- fit, write NOTHING and return the true count so the caller bails conservatively
+  -- (.Ldtrc_unsupported / skip-account) instead of overflowing into adjacent .data.
+  "  li t0, 128; bgtu s5, t0, .Lbrsk_done            # count > cap -> return count, write nothing\n" ++
   "  mv s6, zero                  # i\n" ++
   "  mv s7, s2                    # out cursor\n" ++
   ".Lbrsk_loop:\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -211,8 +211,8 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bvcd_acct_len:\n  .zero 8\n" ++
   "bvcd_key_count:\n  .zero 8\n" ++
   "bvcd_i:\n  .zero 8\n" ++
-  "bvcd_keys:\n  .zero 512\n" ++       -- up to 16 x 32-byte slot keys
-  "bvcd_preload:\n  .zero 1024\n" ++   -- up to 16 x 64-byte (key,value) pairs
+  "bvcd_keys:\n  .zero 4096\n" ++      -- bmvmx.1.7.3: up to 128 x 32-byte slot keys (was 16; bal_recipient_storage_keys caps at 128)
+  "bvcd_preload:\n  .zero 8192\n" ++   -- bmvmx.1.7.3: up to 128 x 64-byte (key,value) pairs (was 16)
   -- bmvmx.1.6.2 exec-vs-BAL recipient storage check scratch (bal_storage_change_values +
   -- bal_storage_matches_exec_log), now linked into the verdict's contract-dispatch tail.
   balStorageChangeValuesData ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -107,6 +107,7 @@ def seedCalleeStorageFunction : String :=
   "  jal ra, bal_addr_to_exec_log_key                # csce_addrkey = LE callee exec-log key\n" ++
   "  mv a0, s3; la t0, csce_alen; ld a1, 0(t0); la a2, csce_keys\n" ++
   "  jal ra, bal_recipient_storage_keys              # csce_keys[] (own buffer, 128 cap)\n" ++
+  "  li t0, 128; bgtu a0, t0, .Lscs_acct_next        # bmvmx.1.7.3: >128 slots wouldn't fit csce_keys -> skip this account (seed nothing)\n" ++
   "  la t0, csce_key_n; sd a0, 0(t0)\n" ++
   "  la t0, csce_key_i; sd zero, 0(t0)\n" ++
   ".Lscs_slot_loop:\n" ++
@@ -175,6 +176,7 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  bnez a0, .Ldtrc_zero_storage\n" ++
   "  la t0, bvcd_acct_ptr; ld a0, 0(t0); la t0, bvcd_acct_len; ld a1, 0(t0); la a2, bvcd_keys\n" ++
   "  jal ra, bal_recipient_storage_keys\n" ++
+  "  li t0, 128; bgtu a0, t0, .Ldtrc_unsupported   # bmvmx.1.7.3: >128 storage slots wouldn't fit bvcd_keys/preload -> bail\n" ++
   "  la t0, bvcd_key_count; sd a0, 0(t0); j .Ldtrc_read_storage\n" ++
   ".Ldtrc_zero_storage:\n" ++
   "  la t0, bvcd_key_count; sd zero, 0(t0)\n" ++


### PR DESCRIPTION
## Summary

**Latent buffer overflow (same class as #8659).** `bal_recipient_storage_keys` wrote **all** BAL `storage_changes` slot keys to its out buffer with **no cap**. `dispatch_tx_runtime_code` passed `bvcd_keys` (512B = **16 slots**) and then filled `bvcd_preload` (1024B = 16 pairs). A self-contained contract recipient with **>16 storage changes** in the BAL overflowed both into adjacent `.data`. `seed_callee_storage` (`csce_keys` 4096 = 128) had the same issue for >128-slot accounts. Tested rows pass because recipients change few slots.

## Fix

1. **Cap `bal_recipient_storage_keys` at 128** — after computing the entry count, if it exceeds 128, write **nothing** and return the true count so callers detect the overflow (a post-call guard alone is too late — the function writes unconditionally).
2. **Enlarge `bvcd_keys` 512→4096 and `bvcd_preload` 1024→8192** (128 slots, matching `csce_keys`).
3. **`dispatch_tx_runtime_code` bails** to `.Ldtrc_unsupported` when the count exceeds 128.
4. **`seed_callee_storage` skips** the account (seeds nothing) when the count exceeds 128.

The count-1 probe path is unaffected.

## Verification (short of the sweep)

- `lake build` green; the verdict ELF assembles + links.
- The `zisk_bal_recipient_storage_keys` probe still returns `count=1` with `slotkey[31]=0x07` (normal ≤128 path unchanged).
- `check-file-size.sh` / `check-unimported.sh` / `check-forbidden-tactics.sh` pass.

## ⚠️ REQUIRES EEST SWEEP

Changes behavior for contract recipients with >16 storage changes: overflow-corruption → correct execution for ≤128 slots, conservative bail beyond.

Refs #8475. Bead: evm-asm-bmvmx.1.7.3.

Authored by @pirapira; implemented by Claude Code