### PR TITLE
feat(create): in-exec balance debit on CREATE endowment (5em02.2)

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -862,6 +862,9 @@ def emitRuntimeAccountWitnessData : String :=
   ".balign 32\n" ++
   "create_balance_be:\n" ++
   "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "create_creator_newbal:\n" ++
+  "  .zero 32\n" ++
   emitCreateChildFrameData ++
   ".balign 8\n" ++
   "ac_buffer:\n" ++
@@ -2322,6 +2325,9 @@ def emitRuntimeDispatcherEmbeddedHelperData : String :=
   "  .zero 32\n" ++
   ".balign 32\n" ++
   "create_balance_be:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "create_creator_newbal:\n" ++
   "  .zero 32\n" ++
   emitCreateChildFrameData ++
   ".balign 8\n" ++

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -312,6 +312,27 @@ def childFrameHandlers
     "  ld x18, 0(x18)\n" ++
     "  bnez x18, 7f\n" ++
     "6:\n" ++
+    -- 5em02.2: debit the creator's LIVE balance (env+32 = .selfBalance, big-endian) by the
+    -- endowment, so SELFBALANCE reads B-endowment after a CREATE (the transfer was inert ->
+    -- false-reject for value-creating contracts). Reached only on the committing path (value
+    -- gate passed, no address collision). ctx-gated (create_value_be valid, populated BE by
+    -- the gate above) + borrow-guarded (the gate checked PRE-state balance; the live env+32 may
+    -- be lower from an earlier same-frame value-op -> conservative skip on underflow). Same
+    -- single-tx failure-rollback caveat as 5em02.1 (a CREATE that later reverts is not undone
+    -- here). The created account's env+32 credit (init-code SELFBALANCE) is a follow-up.
+    "  ld t3, 584(x20)\n  beqz t3, .Lcr_deb_done_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
+    "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
+    "  addi a0, x20, 32\n" ++                            -- a0 = creator LIVE balance (env .selfBalance, BE)
+    "  la a1, create_value_be\n" ++                      -- a1 = endowment (BE)
+    "  la a2, create_creator_newbal\n" ++                -- a2 = out (= balance - endowment)
+    "  jal ra, u256_sub_be\n" ++
+    "  mv t0, a0\n" ++                                   -- t0 = borrow flag (before x10=a0 restore)
+    "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
+    "  bnez t0, .Lcr_deb_done_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++   -- underflow -> skip
+    "  la t0, create_creator_newbal\n  addi t1, x20, 32\n" ++
+    "  ld t2, 0(t0)\n  sd t2, 0(t1)\n  ld t2, 8(t0)\n  sd t2, 8(t1)\n" ++
+    "  ld t2, 16(t0)\n  sd t2, 16(t1)\n  ld t2, 24(t0)\n  sd t2, 24(t1)\n" ++
+    ".Lcr_deb_done_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
     createStageInitcodeFrameCallAsm (if hasSalt then 1 else 0) ++
     -- .61.8.3.5.3 (.5c): execute the staged init code in a REAL child frame via the full
     -- dispatch loop (create_frame_descend, .5a, reusing call_frame_descend), REPLACING the

--- a/EvmAsm/Codegen/Programs/CreateRoundtrip.lean
+++ b/EvmAsm/Codegen/Programs/CreateRoundtrip.lean
@@ -80,7 +80,8 @@ def createRoundtripPrologue : String :=
   callFrameDescendFunction ++ "\n" ++
   createFrameDescendFunction ++ "\n" ++   -- .61.8.3.5: CREATE tail now descends via create_frame_descend
   frameReturnFunction ++ "\n" ++
-  recordNonstorageEffectFunction   -- i3djw.2: CREATE-RETURN deposit records the created account's non-storage effect
+  recordNonstorageEffectFunction ++ "\n" ++   -- i3djw.2: CREATE-RETURN deposit records the created account's non-storage effect
+  u256SubBeFunction   -- 5em02.2: the CREATE descent's creator in-exec balance debit
 
 def createRoundtripData : String :=
   emitRuntimeDispatcherDataSection callFrameProbeRegistry ++ "\n" ++


### PR DESCRIPTION
## Summary
- Mirrors the 5em02.1 caller debit (#8676, sweep-passed) for the CREATE descent: at the committing path (label `6` — value gate passed, no address collision), **debit the creator's live `env+32`** (`.selfBalance`, big-endian) by the endowment (`create_value_be`, BE) via `u256_sub_be`, so SELFBALANCE reads `B−endowment` after a CREATE (the transfer was inert → false-reject for value-creating contracts).
- ctx-gated (`create_value_be` valid) + borrow-guarded (live `env+32` may be below pre-state from an earlier same-frame value-op → conservative skip). Labels suffixed by `hasSalt` (CREATE `0xf0` / CREATE2 `0xf5`). `create_creator_newbal` scratch in both Dispatch data sections; `u256SubBeFunction` linked into the CreateRoundtrip probe (already in the production verdict).

## Verification
- `zisk_create_roundtrip` **PASS** — value=0 CREATE → debit no-op, double-CREATE roundtrip still deploys distinct addresses, no regression. Full build + gates green.

## REQUIRES EEST SWEEP
Changes SELFBALANCE reads on value-bearing CREATEs (verdict execution path). The local probe is value=0 (debit no-op); the actual debit is sweep-validated (like 5em02.1). Same single-tx failure-rollback caveat as 5em02.1; the created account's `env+32` credit (init-code SELFBALANCE) is a follow-up.

Refs #8475. Bead: evm-asm-5em02.2 (parent evm-asm-5em02). Completes the SELF in-exec balance spine alongside 5em02.1.

Authored by @pirapira; implemented by Claude Code