### PR TITLE
feat(dispatch): capture top-level RETURN data for system calls (8uld3.2.1a)

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -1647,6 +1647,15 @@ def emitDispatcherDataSection
   "  .zero 8\n" ++        -- 8uld3.1a: bytes used in evm_log_data this tx (reset with eventLogLength)
   "evm_log_data_overflow:\n" ++
   "  .zero 8\n" ++        -- 8uld3.1a: set to 1 if a log's full data overflowed the buffer -> consumer bails conservatively
+  ".balign 8\n" ++
+  "system_call_mode:\n" ++
+  "  .zero 8\n" ++        -- 8uld3.2.1a: when !=0, a top-level (depth-0) RETURN captures its data into system_call_returndata (for EIP-7002/7251 predeploy system calls). 0 for normal txs -> halt path byte-identical.
+  ".balign 8\n" ++
+  "system_call_returndata_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "system_call_returndata:\n" ++
+  "  .zero 4096\n" ++     -- 8uld3.2.1a: captured top-level RETURN bytes (withdrawal 16x76=1216 / consolidation 2x116=232 max)
   emitSelfdestructData ++
   eip7708SyntheticLogTopicData ++
   storageAccessGasData ++
@@ -2465,6 +2474,15 @@ def emitRuntimeDispatcherDataSectionCore
   "  .zero 8\n" ++        -- 8uld3.1a: bytes used in evm_log_data this tx (reset with eventLogLength)
   "evm_log_data_overflow:\n" ++
   "  .zero 8\n" ++        -- 8uld3.1a: set to 1 if a log's full data overflowed the buffer -> consumer bails conservatively
+  ".balign 8\n" ++
+  "system_call_mode:\n" ++
+  "  .zero 8\n" ++        -- 8uld3.2.1a: when !=0, a top-level (depth-0) RETURN captures its data into system_call_returndata (for EIP-7002/7251 predeploy system calls). 0 for normal txs -> halt path byte-identical.
+  ".balign 8\n" ++
+  "system_call_returndata_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "system_call_returndata:\n" ++
+  "  .zero 4096\n" ++     -- 8uld3.2.1a: captured top-level RETURN bytes (withdrawal 16x76=1216 / consolidation 2x116=232 max)
   emitSelfdestructData ++
   eip7708SyntheticLogTopicData ++
   (if includeSharedHelperData then storageAccessGasData else "") ++

--- a/EvmAsm/Codegen/Programs/NoopHalt.lean
+++ b/EvmAsm/Codegen/Programs/NoopHalt.lean
@@ -94,6 +94,20 @@ private def returnRevertTail (kind : Nat) (rollbackAsm : String := "")
     "  j .dispatch_loop\n" ++
     ".Lrr_halt_" ++ toString kind ++ ":\n"
    else "") ++
+  -- 8uld3.2.1a: when system_call_mode!=0, capture the top-level (depth-0) RETURN data
+  -- (evm_memory[x14..x14+x15]) into system_call_returndata so an EIP-7002/7251 predeploy
+  -- system call's return_data is recoverable. RETURN (kind 1) only; flag is 0 for normal
+  -- txs so the halt path stays byte-identical. x13=mem base, x14=offset, x15=size (read-only).
+  (if kind == 1 then
+    "  la t0, system_call_mode\n  ld t0, 0(t0)\n  beqz t0, .Lrr_nocap_" ++ toString kind ++ "\n" ++
+    "  li t1, 4096\n  bltu t1, x15, .Lrr_nocap_" ++ toString kind ++ "\n" ++   -- oversized -> skip (conservative)
+    "  la t1, system_call_returndata_len\n  sd x15, 0(t1)\n" ++
+    "  add t2, x13, x14\n  la t3, system_call_returndata\n  mv t4, x15\n" ++
+    ".Lrr_capz_" ++ toString kind ++ ":\n" ++
+    "  beqz t4, .Lrr_nocap_" ++ toString kind ++ "\n" ++
+    "  lbu t5, 0(t2)\n  sb t5, 0(t3)\n  addi t2, t2, 1\n  addi t3, t3, 1\n  addi t4, t4, -1\n  j .Lrr_capz_" ++ toString kind ++ "\n" ++
+    ".Lrr_nocap_" ++ toString kind ++ ":\n"
+   else "") ++
   "  li x16, 0xa0010000\n" ++
   "  sd x0, 0(x16)\n" ++
   "  sd x0, 8(x16)\n" ++


### PR DESCRIPTION
## Summary
Foundation for EIP-7002/7251 system-call request derivation. The dispatcher captured only **sub-call** returndata (`frame_return`); a **top-level (depth-0) RETURN** just halted. This adds a flag-gated capture in `returnRevertTail`'s depth-0 RETURN path: when `system_call_mode != 0`, copy `evm_memory[offset..offset+size]` into the new `system_call_returndata` buffer (+ `_len`) before the halt. RETURN (kind 1) only; oversized (>4096) skips conservatively.

## Dormant — no behavior change, no sweep
`system_call_mode` is never set yet (wired by `8uld3.2.1c`), so the flag is 0 for **all** current execution → the capture branch is skipped (`beqz`) → every halt path stays byte-identical. The flag=1 capture is exercised + content-verified in `8uld3.2.1c` (the callable path reads the buffer without halting).

## Verification
Full `lake build` green; `zisk_create_roundtrip` PASS (flag=0, no regression); file-size/unimported/forbidden-tactics gates green.

Refs #8475. Bead: evm-asm-8uld3.2.1.1. Shared foundation for withdrawal (8uld3.2) + consolidation (8uld3.3).

Authored by @pirapira; implemented by Claude Code