### PR TITLE
fix(verdict): dispatch_tx_runtime_code uses PRE-state header for witness lookups [REQUIRES EEST SWEEP]

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -78,6 +78,11 @@ def blockVerdictFunction : String :=
   "  sd ra, 0(sp); sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
   "  mv s0, a0                   # params\n" ++
   "  mv s3, a1                   # SSZ_BASE\n" ++
+  -- fhsxz.2.4.2.57.11.6.5: stash the parent (PRE-state) header RLP ptr/len so
+  -- dispatch_tx_runtime_code's witness lookups use the PRE-state root (witness root),
+  -- not sv_this_rlp (this block's POST-state header). 8(s0)/16(s0) is the parent header.
+  "  ld t0, 8(s0); la t1, sv_pre_rlp_ptr; sd t0, 0(t1)\n" ++
+  "  ld t0, 16(s0); la t1, sv_pre_rlp_len; sd t0, 0(t1)\n" ++
   "  la t0, bv_fail_code; sd zero, 0(t0)\n" ++
   "  la t0, bv_header_status; sd zero, 0(t0)\n" ++
   "  la t0, bv_state_status; sd zero, 0(t0)\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -810,6 +810,15 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bmvmx_coinbase_credit:\n  .zero 32\n" ++
   -- .6.2.2.2.b: multi-tx dispatch loop index cursor.
   "bv_mtx_i:\n  .zero 8\n" ++
+  -- fhsxz.2.4.2.57.11.6.5: parent (PRE-state) header RLP ptr/len, stashed by
+  -- block_verdict from its input frame (8(s0)/16(s0)). dispatch_tx_runtime_code's
+  -- witness lookups (code/slot/balance_at_header_state_root) MUST use the PRE-state
+  -- root (the witness is the parent's post-state = this block's pre-state proof),
+  -- not sv_this_rlp (this block's POST-state header), else a recipient whose account
+  -- changes within the block (e.g. an SSTORE contract) is unprovable -> false bail.
+  ".balign 8\n" ++
+  "sv_pre_rlp_ptr:\n  .zero 8\n" ++
+  "sv_pre_rlp_len:\n  .zero 8\n" ++
   -- bmvmx.1.4.2 compare: validate the coinbase credit against the BAL (additive; match flag only).
   ".balign 8\n" ++
   "bmvmx_coinbase_addr:\n  .zero 20\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -114,7 +114,7 @@ def seedCalleeStorageFunction : String :=
   "  la t0, csce_key_i; ld t1, 0(t0); la t2, csce_key_n; ld t3, 0(t2); beq t1, t3, .Lscs_acct_next\n" ++
   "  la t0, callee_seed_count; ld t2, 0(t0); li t3, 128; bgeu t2, t3, .Lscs_done   # table cap\n" ++
   "  slli t4, t1, 5; la t5, csce_keys; add a3, t5, t4   # slot key ptr\n" ++
-  "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++
+  "  la t0, sv_pre_rlp_ptr; ld a0, 0(t0); la t0, sv_pre_rlp_len; ld a1, 0(t0)\n" ++   -- .57.11.6.5: PRE-state (parent) header for witness lookups
   "  la t0, csce_addrp; ld a2, 0(t0)\n" ++
   "  mv a4, s0; mv a5, s1; mv a6, s0; mv a7, s1\n" ++
   "  jal ra, slot_at_header_state_root\n" ++
@@ -158,7 +158,7 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  mv s0, a1                    # witness.state ptr\n" ++
   "  mv s1, a2                    # witness.state len\n" ++
   "  mv s2, a0                    # context record ptr\n" ++
-  "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++
+  "  la t0, sv_pre_rlp_ptr; ld a0, 0(t0); la t0, sv_pre_rlp_len; ld a1, 0(t0)\n" ++   -- .57.11.6.5: PRE-state (parent) header for witness lookups
   "  addi a2, s2, 72\n" ++
   "  mv a3, s0; mv a4, s1\n" ++
   "  la t0, svf_codes_ptr; ld a5, 0(t0); la t0, svf_codes_len; ld a6, 0(t0)\n" ++
@@ -185,7 +185,7 @@ def dispatchTxRuntimeCodeFunction : String :=
   ".Ldtrc_sloop:\n" ++
   "  la t0, bvcd_i; ld t1, 0(t0); la t2, bvcd_key_count; ld t3, 0(t2); beq t1, t3, .Ldtrc_stage\n" ++
   "  slli t4, t1, 5; la t5, bvcd_keys; add a3, t5, t4\n" ++
-  "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++
+  "  la t0, sv_pre_rlp_ptr; ld a0, 0(t0); la t0, sv_pre_rlp_len; ld a1, 0(t0)\n" ++   -- .57.11.6.5: PRE-state (parent) header for witness lookups
   "  addi a2, s2, 72\n" ++
   "  mv a4, s0; mv a5, s1; mv a6, s0; mv a7, s1\n" ++
   "  jal ra, slot_at_header_state_root\n" ++
@@ -293,6 +293,13 @@ def dispatchTxRuntimeCodeFunction : String :=
   -- byte order matches a word GASPRICE pushes. INERT until 3vc2p.4 (self-contained
   -- recipients don't read GASPRICE). Conservative: a pricing failure leaves gasPrice 0.
   "  ld a0, 8(s2); ld a1, 16(s2); ld a2, 32(s2)\n" ++
+  -- fhsxz.2.4.2.57.11.6.5: skip gas-pricing when base_fee ptr (ctx+32) is null. The
+  -- multi-tx context (multi_tx_nth_context) leaves +32 zero (base_fee is a per-call
+  -- input the loop doesn't supply); tx_effective_gas_pricing would then deref a null
+  -- base_fee (u256_sub_be max_fee - base_fee reads addr 0 -> ziskemu mem panic). GASPRICE
+  -- is INERT for self-contained recipients, so leaving it 0 here is correct (same as the
+  -- existing pricing-failure path). Mirrors the .Ldtrc_no_sender guard on the pubkey (+24).
+  "  beqz a2, .Ldtrc_no_gasprice\n" ++
   "  la a3, gp_egp; la a4, gp_prio\n" ++
   "  jal ra, tx_effective_gas_pricing\n" ++
   "  bnez a0, .Ldtrc_no_gasprice\n" ++
@@ -310,7 +317,7 @@ def dispatchTxRuntimeCodeFunction : String :=
   -- INERT until yisv8.2 removes SELFBALANCE(0x47) from the self-contained reject set.
   -- Conservative: a lookup miss/error leaves SELFBALANCE 0. balance_at_header_state_root
   -- preserves s-regs (s0=state ptr, s1=state len, s2=ctx survive); clobbers only dead a/t-regs.
-  "  la a0, sv_this_rlp\n  la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++
+  "  la t0, sv_pre_rlp_ptr; ld a0, 0(t0)\n  la t0, sv_pre_rlp_len; ld a1, 0(t0)\n" ++   -- .57.11.6.5: PRE-state (parent) header for witness lookups
   "  addi a2, s2, 72\n" ++                       -- recipient addr (ctx+72)
   "  mv a3, s0; mv a4, s1\n" ++                   -- witness state ptr/len
   "  la a5, yisv8_self_bal\n" ++


### PR DESCRIPTION
## Summary
`dispatch_tx_runtime_code` (contract-recipient runtime gas measurement) keyed all its witness lookups — `code_at_header_state_root`, `slot_at_header_state_root`, `balance_at_header_state_root`, and `seed_callee_storage` — on **`sv_this_rlp`** = *this* block's header, whose `state_root` is the **POST**-execution root. But the stateless witness is the **PRE**-state proof (parent's post-state = this block's pre-state). For any recipient whose account changes within the block (e.g. a contract that SSTOREs), the post-state account node isn't in the witness → `code_at_header_state_root` returns 1 ("account not in state trie") → dispatch bails and the runtime gas is never measured.

- Stash the parent (PRE-state) header ptr/len (`block_verdict` frame `8(s0)/16(s0)` — the same header the multi-tx loop's `code_hash_at_header_state_root` already uses) into a new `sv_pre_rlp_ptr/len` global, and route dispatch's witness lookups through it.
- `block_verdict`'s own block-hash / state-root checks keep using `sv_this_rlp` unchanged.
- Guard the GASPRICE staging on a null `base_fee` ptr (`ctx+32==0`) — otherwise `tx_effective_gas_pricing` derefs null (`u256_sub_be(max_fee − base_fee)`). GASPRICE is inert for self-contained recipients, so skipping leaves it 0 (mirrors the existing null-pubkey `.Ldtrc_no_sender` guard).

## How it was found
Instrumented the `multi_transaction_gas_accounting` P0 false-accept: `code_at_header_state_root` returned 1 for tx0's SSTORE recipient under `sv_this_rlp` (POST), while the loop's `code_hash_at` (parent header, PRE) found it. With this fix, tx0 dispatches successfully.

## Scope / effect
Storage-mutating **single-tx** contract recipients now dispatch (and feed the EIP-7778/8037 block-gas gate) instead of bailing conservatively. This is the foundation for the multi-tx false-accept fix (`evm-asm-fhsxz.2.4.2.57.11.6.5`), but it's an independent correctness fix.

## ⚠️ REQUIRES EEST SWEEP
Changes dispatch behavior for storage-mutating contract recipients (more blocks may now run the block-gas gate). Please run the full EEST sweep to confirm no regression before un-drafting.

Bead: `evm-asm-fhsxz.2.4.2.57.11.6.5`.

Directed by @pirapira; implemented by Claude Code