### PR TITLE
fix(verdict): restore sv_this_rlp in dispatch_tx_runtime_code (repair…

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -114,7 +114,7 @@ def seedCalleeStorageFunction : String :=
   "  la t0, csce_key_i; ld t1, 0(t0); la t2, csce_key_n; ld t3, 0(t2); beq t1, t3, .Lscs_acct_next\n" ++
   "  la t0, callee_seed_count; ld t2, 0(t0); li t3, 128; bgeu t2, t3, .Lscs_done   # table cap\n" ++
   "  slli t4, t1, 5; la t5, csce_keys; add a3, t5, t4   # slot key ptr\n" ++
-  "  la t0, sv_pre_rlp_ptr; ld a0, 0(t0); la t0, sv_pre_rlp_len; ld a1, 0(t0)\n" ++   -- .57.11.6.5: PRE-state (parent) header for witness lookups
+  "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++   -- repair(#8685): restore this-block header; PRE-header only helps WITH the mtx fix (kept on the mtx branch)
   "  la t0, csce_addrp; ld a2, 0(t0)\n" ++
   "  mv a4, s0; mv a5, s1; mv a6, s0; mv a7, s1\n" ++
   "  jal ra, slot_at_header_state_root\n" ++
@@ -158,7 +158,7 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  mv s0, a1                    # witness.state ptr\n" ++
   "  mv s1, a2                    # witness.state len\n" ++
   "  mv s2, a0                    # context record ptr\n" ++
-  "  la t0, sv_pre_rlp_ptr; ld a0, 0(t0); la t0, sv_pre_rlp_len; ld a1, 0(t0)\n" ++   -- .57.11.6.5: PRE-state (parent) header for witness lookups
+  "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++   -- repair(#8685): restore this-block header; PRE-header only helps WITH the mtx fix (kept on the mtx branch)
   "  addi a2, s2, 72\n" ++
   "  mv a3, s0; mv a4, s1\n" ++
   "  la t0, svf_codes_ptr; ld a5, 0(t0); la t0, svf_codes_len; ld a6, 0(t0)\n" ++
@@ -185,7 +185,7 @@ def dispatchTxRuntimeCodeFunction : String :=
   ".Ldtrc_sloop:\n" ++
   "  la t0, bvcd_i; ld t1, 0(t0); la t2, bvcd_key_count; ld t3, 0(t2); beq t1, t3, .Ldtrc_stage\n" ++
   "  slli t4, t1, 5; la t5, bvcd_keys; add a3, t5, t4\n" ++
-  "  la t0, sv_pre_rlp_ptr; ld a0, 0(t0); la t0, sv_pre_rlp_len; ld a1, 0(t0)\n" ++   -- .57.11.6.5: PRE-state (parent) header for witness lookups
+  "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++   -- repair(#8685): restore this-block header; PRE-header only helps WITH the mtx fix (kept on the mtx branch)
   "  addi a2, s2, 72\n" ++
   "  mv a4, s0; mv a5, s1; mv a6, s0; mv a7, s1\n" ++
   "  jal ra, slot_at_header_state_root\n" ++
@@ -317,7 +317,7 @@ def dispatchTxRuntimeCodeFunction : String :=
   -- INERT until yisv8.2 removes SELFBALANCE(0x47) from the self-contained reject set.
   -- Conservative: a lookup miss/error leaves SELFBALANCE 0. balance_at_header_state_root
   -- preserves s-regs (s0=state ptr, s1=state len, s2=ctx survive); clobbers only dead a/t-regs.
-  "  la t0, sv_pre_rlp_ptr; ld a0, 0(t0)\n  la t0, sv_pre_rlp_len; ld a1, 0(t0)\n" ++   -- .57.11.6.5: PRE-state (parent) header for witness lookups
+  "  la a0, sv_this_rlp\n  la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++   -- repair(#8685): restore this-block header (see above)
   "  addi a2, s2, 72\n" ++                       -- recipient addr (ctx+72)
   "  mv a3, s0; mv a4, s1\n" ++                   -- witness state ptr/len
   "  la a5, yisv8_self_bal\n" ++


### PR DESCRIPTION
… PR #8685 regression)

PR #8685 rerouted dispatch_tx_runtime_code's witness lookups (code/slot/balance_at_ header_state_root) from sv_this_rlp (this block's header) to the parent/PRE-state header, and that regressed >10% of EEST rows on main. Root cause:

account_at_address traverses the witness MPT FROM the given state_root (State.lean / mpt_lookup_by_key), and the stateless witness is PRE-state-rooted. So the OLD single-tx contract dispatch using sv_this_rlp (this block's POST-state root) ALWAYS bailed (the POST root is not a node in the PRE-rooted witness) -> the block fell back to the conservative gate-A path, which gave the correct verdict (rows passed). #8685 made single-tx contract dispatch SUCCEED (PRE root is in the witness) -> it began feeding the runtime-result EIP-7778/8037 block-gas gate (gate B), which mis-verdicts those blocks -> broad regression. The conservative bail had been masking gate B's incorrectness for contract recipients.

Critically, #8685 fixed nothing on main on its own: the multi-tx false-accept fixture still false-accepts (its calldata-bail removal lives only on the mtx work branch), so standalone the PRE-header change was pure regression.

This restores sv_this_rlp for dispatch's witness lookups (back to the conservative, correct pre-#8685 behavior). The PRE-state-header logic is preserved on the multi-tx branch (feat/dispatch-pre-header-wip), to land TOGETHER with the calldata fix and gated to the mtx loop, where runtime_count is actually needed and gate B's correctness for that gated case can be validated. The now-inert sv_pre_rlp global / stash / base_fee guard are left in place (harmless dead scaffolding the mtx re-land reuses).

REQUIRES EEST SWEEP: confirm the >10% regression is gone (rows restored to their pre-#8685 verdicts).

Refs #8685. Bead: evm-asm-fhsxz.2.4.2.57.11.6.5.

Directed by @pirapira; implemented by Claude Code