### PR TITLE
fix(verdict): byte-reverse contract-dispatch storage preload key+value BE->LE (.57.11.6.5.3 d')

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -192,16 +192,33 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  la t0, bvcd_i; ld t1, 0(t0); slli t2, t1, 6; la t3, bvcd_preload; add t4, t3, t2\n" ++
   "  slli t2, t1, 5; la t3, bvcd_keys; add t5, t3, t2\n" ++
   "  li t6, 0\n" ++
+  -- fhsxz.2.4.2.57.11.6.5.3 (d'): the BAL slot key (bvcd_keys) is 32-byte BIG-ENDIAN
+  -- (left-padded), but the EVM stack / exec-log scan (Storage.lean h_SLOAD/h_SSTORE) and the
+  -- runtime SSTORE-appended entries are LITTLE-ENDIAN-limb. Copying the key verbatim left
+  -- preloaded non-zero slots INVISIBLE to the scan (only slot 0 matched, identical in both
+  -- orders) -> SLOAD-of-preload returned 0 and SSTORE saw a missing slot, undercharging gas.
+  -- Byte-REVERSE the key (dst byte 31-i <- src byte i) so the preload entry's slotKey matches
+  -- the stack/append LE order. Validated: with LE preload the 10x SSTORE-clear repro charges
+  -- the full 5000 each (gas_left 25200 -> 0).
   ".Ldtrc_kcopy:\n" ++
   "  li t2, 32; beq t6, t2, .Ldtrc_kdone\n" ++
-  "  add t2, t5, t6; lbu t3, 0(t2); add t2, t4, t6; sb t3, 0(t2); addi t6, t6, 1; j .Ldtrc_kcopy\n" ++
+  "  add t2, t5, t6; lbu t3, 0(t2)\n" ++                              -- t3 = BE key byte i
+  "  li t2, 31; sub t2, t2, t6; add t2, t4, t2; sb t3, 0(t2)\n" ++    -- -> dst byte (31-i): BE->LE
+  "  addi t6, t6, 1; j .Ldtrc_kcopy\n" ++
   ".Ldtrc_kdone:\n" ++
   "  li t2, 5; beq a0, t2, .Ldtrc_vzero\n" ++
   "  bnez a0, .Ldtrc_unsupported\n" ++
   "  la t5, sahsr_u256; li t6, 0\n" ++
+  -- The witness slot value (sahsr_u256) is also u256 BIG-ENDIAN (StateCompose.lean:519);
+  -- byte-REVERSE it into the value field [entry+32..64] (dst byte 63-i <- src byte i) so
+  -- original==current read back as LE limbs match the SSTORE handler's clean/dirty test.
+  -- (The cross-tx threaded value below is already LE — it limb-copies dtrc_threadval from the
+  -- exec log — so it is left as-is.)
   ".Ldtrc_vcopy:\n" ++
   "  li t2, 32; beq t6, t2, .Ldtrc_vdone\n" ++
-  "  add t2, t5, t6; lbu t3, 0(t2); add t2, t4, t6; addi t2, t2, 32; sb t3, 0(t2); addi t6, t6, 1; j .Ldtrc_vcopy\n" ++
+  "  add t2, t5, t6; lbu t3, 0(t2)\n" ++                              -- t3 = BE value byte i
+  "  li t2, 63; sub t2, t2, t6; add t2, t4, t2; sb t3, 0(t2)\n" ++    -- -> dst byte 32+(31-i)=63-i: BE->LE
+  "  addi t6, t6, 1; j .Ldtrc_vcopy\n" ++
   ".Ldtrc_vzero:\n" ++
   "  li t6, 0\n" ++
   ".Ldtrc_vzloop:\n" ++


### PR DESCRIPTION
## ⚠️ REQUIRES EEST SWEEP (draft)

This changes guest **execution behaviour** (storage preload byte order) broadly — every contract-dispatch that touches a non-zero preloaded slot. It must be validated by the full EEST stateless sweep on `main` before un-drafting. The probe-level mechanism is validated (below); the integration is the sweep's job.

## Summary

The verdict's contract-dispatch storage preload (`dispatch_tx_runtime_code`, `BlockVerdictDispatchTx.lean`) copied the BAL slot **key** (`bvcd_keys`, 32-byte **big-endian**, left-padded) and the witness slot **value** (`sahsr_u256`, u256 **big-endian** per `StateCompose.lean:519`) **verbatim** into the exec-log preload entry. But the EVM stack, the `h_SLOAD`/`h_SSTORE` log scan (`Storage.lean`), and runtime SSTORE-**appended** entries are all **little-endian-limb**.

So preloaded entries with a **non-zero slot key were invisible to the scan** — only slot 0 matched (identical in both byte orders). Consequences:
- `SLOAD` of a preloaded slot returned **0** (wrong value).
- `SSTORE` saw a **missing slot** → took the missing-slot/dirty transition path (100) instead of clean-changing (2900) → **undercharged regular gas**; original-value/refund also wrong.

This is the **(d′)** `block_regular` undercount behind the `multi_transaction_gas_accounting` **`bv_fail=41` false-REJECT**: tx0 clears 10 preloaded slots 0..9; only slot 0 was found, slots 1..9 each undercharged 2800 → 9×2800 = **25200** = exactly `header.gas_used − block_regular` (c2's instrumented gap, c2#48).

## Fix

Byte-**reverse** the key (`.Ldtrc_kcopy`, dst byte `31−i`) and the witness value (`.Ldtrc_vcopy`, dst byte `63−i`) BE→LE so preload entries match the stack/append LE order — i.e. **consistent with the already-LE SSTORE-appended entries**, so exec-log consumers (which already handle LE appended keys) treat all entries uniformly. The cross-tx **threaded** value path already stores LE (limb-copy of `dtrc_threadval` from the exec log) and is left unchanged.

## Validation (probe-level)

`zisk_sstore_clear_gas_probe` (#8693) reproducer, with the preload flipped from BE (`byte31=i`) to LE (`byte0=i`):
- BE preload: 9 of 10 SSTOREs miss the scan → `gas_left=25200`.
- LE preload: **all 10 slots found**, each SSTORE-clear charges the full 5000, **`gas_left 25200 → 0`** (block_inc = 71050 = full spec gas).

This validates the byte-order direction end-to-end through the real `h_SSTORE` handler + scan + `.preload_expand_loop`. The fix applies the same BE→LE reversal at the real preload-build site.

## Follow-ups (not in this PR)

- The cross-tx **threading lookup** at `.Ldtrc_*` (line ~224) passes a BE `bvcd_keys` slot key to `exec_log_latest_value` (which scans LE exec-log entries) — same bug class, only reached for mtx tx1+ (`bv_mtx_committed_count>0`); separate from (d′).
- The **callee-seed** path (`.Lscs_*`) limb-copies BE `csce_keys`/`sahsr_u256` into `callee_seed_table` — also needs BE→LE for nested CALLEEs reading preloaded slots.

Refs #8693. Bead: evm-asm-fhsxz.2.4.2.57.11.6.5.3.

Directed by @pirapira; implemented by Claude Code