### PR TITLE
fix(verdict): reject mtx block when a tx recipient is unresolvable at pre-state root (.57.11.6.5.4 e)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -447,7 +447,16 @@ def blockVerdictFunction : String :=
   "  la t0, bv_mtx_ctx; ld t0, 0(t0); bnez t0, .Lbv_mtx_bail        # unsupported tx shape\n" ++
   "  ld a0, 8(s0); ld a1, 16(s0); la a2, bv_mtx_ctx; addi a2, a2, 72; ld a3, 80(s0); ld a4, 88(s0); la a5, bv_tx_recipient_code_hash\n" ++
   "  jal ra, code_hash_at_header_state_root\n" ++
-  "  bnez a0, .Lbv_mtx_bail                         # recipient code-hash lookup failed\n" ++
+  -- fhsxz.2.4.2.57.11.6.5.4 (e): code 2 = MPT could not resolve this tx's recipient at the
+  -- pre-state root. The recipient is ACCESSED (the tx sends to it), so a complete stateless
+  -- witness MUST carry it -> code 2 means the witness genuinely lacks a node on its path
+  -- (verified: the multi_transaction_gas_accounting GAS_USED_OVERFLOW witness omits tx1's
+  -- recipient node, 22 vs the valid variant's 24 nodes). An unverifiable accessed account =>
+  -- the block cannot be statelessly validated as valid => REJECT (not conservative-accept,
+  -- which was the false-accept). A valid block's witness always resolves the recipient
+  -- (code 0), so this never false-rejects. Codes 3/4 (decode/header) stay conservative.
+  "  li t1, 2; beq a0, t1, .Lbv_mtx_recipient_unresolvable_fail\n" ++
+  "  bnez a0, .Lbv_mtx_bail                         # other lookup failure (3/4) -> conservative\n" ++
   "  la t0, bv_tx_recipient_code_hash; la t1, chahsr_empty_code_hash\n" ++
   "  ld t3,  0(t0); ld t4,  0(t1); bne t3, t4, .Lbv_mtx_is_contract\n" ++
   "  ld t3,  8(t0); ld t4,  8(t1); bne t3, t4, .Lbv_mtx_is_contract\n" ++
@@ -1130,6 +1139,8 @@ def blockVerdictFunction : String :=
   "  li t0, 35; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_block_gas_used_over_fail:\n" ++   -- g8zeq.1.4.2: header.gas_used > max(block_regular, block_state) (over-claim)
   "  li t0, 41; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
+  ".Lbv_mtx_recipient_unresolvable_fail:\n" ++   -- fhsxz.2.4.2.57.11.6.5.4 (e): mtx tx recipient unresolvable at pre-state root (incomplete witness)
+  "  li t0, 47; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_block_hash_mismatch:\n" ++
   "  li t0, 31; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_bal_storage_mismatch_fail:\n" ++   -- bmvmx.1.6.2: recipient BAL storage != execution


### PR DESCRIPTION
## ⚠️ REQUIRES EEST SWEEP (draft) — accept→reject change

Changes the multi-tx verdict from conservative-ACCEPT to REJECT on one bail condition. Must be validated by the full EEST stateless sweep before un-drafting. **Inert on current main** (the mtx loop bails earlier at tx0's `sv_this_rlp` dispatch); becomes active once the **mtx re-land** (PRE-header gating) makes the loop reach the per-tx recipient check — so ideally swept together with the re-land.

## Summary — the (e) false-accept

The multi-tx loop (`BlockVerdict.lean` `.Lbv_mtx_loop`) bailed **conservatively (accept)** when a tx's recipient code-hash lookup returned **code 2** (state-trie MPT parse error / missing node). For the `multi_transaction_gas_accounting` **GAS_USED_OVERFLOW** rows (11,12,15,16) this is the **(e) FALSE-ACCEPT**: the guest accepts a block the spec rejects.

## Root cause (decisive, from the fixture)

An MPT traversal of both variants' `executionWitness.state` for tx1's recipient `0x323c…248e`:

| variant | nodes | tx1 recipient resolves? |
|---|---|---|
| exceed=False (**VALID**, exp=None) | 24 | **FOUND_LEAF** (code 0) |
| exceed=True (**INVALID**, GAS_USED_OVERFLOW) | 22 | **MISSING_NODE** — the node `2dfb8a…` on its keccak path is **absent** → code 2 |

So the invalid block's witness **genuinely lacks** tx1's recipient node (not a parser gap, not address byte-order — c2 confirmed the address parses correctly). The guest hits code 2 and bail-**accepts**.

## Fix

A tx recipient is **always accessed** (the tx sends to it), so a complete stateless witness MUST carry it. code 2 (cannot resolve at the pre-state root) ⇒ the witness can't support validating the block ⇒ **REJECT** (`bv_fail_code=47`). A valid block's witness always resolves the recipient (code 0) — verified by the VALID variant's `FOUND_LEAF` — so this **never false-rejects**. Rejects only on code 2 (genuine missing node); codes 3/4 (account-decode / header-parse) stay conservative to avoid false-rejects from our own parsing.

## Soundness

- No false-reject: valid blocks resolve every accessed recipient (code 0). Residual risk is only our MPT parser choking on a *well-formed* node (would surface as a valid block newly `bv_fail=47`) — exactly what the sweep checks.
- Correct reject: complements #8694 (d′) — valid mtx rows dispatch + accept (gas now correct), invalid rows reject here. Together they resolve the full `multi_transaction_gas_accounting` STORAGE_CLEAR test.

Bead: evm-asm-fhsxz.2.4.2.57.11.6.5.4. Complements #8694, #8695.

Directed by @pirapira; implemented by Claude Code