### PR TITLE
fix(requests): reject non-canonical execution_requests offset0 != 12 (hbo40)

### DIFF
--- a/EvmAsm/Codegen/Programs/RequestsHash.lean
+++ b/EvmAsm/Codegen/Programs/RequestsHash.lean
@@ -26,7 +26,13 @@ def executionRequestsHashFunction : String :=
   "  mv a0, s0; jal ra, bgv_u32le; mv s3, a0\n" ++
   "  addi a0, s0, 4; jal ra, bgv_u32le; mv s4, a0\n" ++
   "  addi a0, s0, 8; jal ra, bgv_u32le; mv s5, a0\n" ++
-  "  li t0, 12; bltu s3, t0, .Lerh_fail\n" ++
+  -- hbo40: canonical SSZ requires the FIRST variable-field offset to EQUAL the fixed-part
+  -- size exactly. SszExecutionRequests has 3 variable SszList fields -> fixed part = 3*4 = 12,
+  -- so offset0 (s3) MUST be 12, not merely >= 12. remerkleable decode_bytes raises on any
+  -- offset0 != 12 (a leading gap between the offset table and the deposits body), so the spec
+  -- rejects it; the old `bltu s3,12` lower-bound accepted offset0 > 12 = a non-canonical
+  -- false-accept. Exact-equality is soundness-additive: every valid block has offset0 == 12.
+  "  li t0, 12; bne s3, t0, .Lerh_fail\n" ++
   "  bltu s4, s3, .Lerh_fail\n" ++
   "  bltu s5, s4, .Lerh_fail\n" ++
   "  bltu s1, s5, .Lerh_fail\n" ++


### PR DESCRIPTION
## Summary
Closes a SSZ-canonicalization **false-accept** found by the audit worker (hermes-c3, `hbo40`): `execution_requests_hash` accepted any `offset0 >= 12` (a lower bound), but **canonical SSZ requires the first variable-field offset to equal the fixed-part size exactly**.

`SszExecutionRequests` (`stateless_ssz.py:141`) is a remerkleable `Container` with 3 variable `SszList` fields → fixed part = 3×4 = **12**-byte offset table, so the deposits body MUST start at offset **12**. `remerkleable.decode_bytes` raises on any `offset0 != 12` (a leading gap), so the reference **rejects** it; the guest's `bltu` lower-bound let `offset0 > 12` (non-canonical SSZ) through — a prover-consistent malformed section with `header.requests_hash` set to match would slip.

## Fix
`RequestsHash.lean:29`: `bltu s3,12` → `bne s3,12` (require `offset0 == 12`).
**Soundness-additive** (only adds a reject): every valid block has `offset0 == 12`, so no false-reject; it only rejects the non-canonical `offset0 != 12` that the spec also rejects.

## Verification (REQUIRES EEST SWEEP)
- eip7685 requests: **12/12 full-match** (incl. the `invalid_multi_type_requests` reject cases).
- Broad random sample (seed 99): **0 false-reject**; the only `ERROR`s were a sibling worker's `pkill` killing ziskemu mid-run — re-confirmed `slotnum_gas_cost` + `set_code_to_log` **full-match** clean.
- Module + full build green (3328 jobs); file-size / unimported / forbidden-tactics clean.

Bead: `evm-asm-hbo40`.

Directed by @pirapira; implemented by Claude Code