### PR TITLE
feat(requests): link EIP-7002/7251 system-call harness into stateless verdict guest (8uld3.2.3.1)

### DIFF
--- a/EvmAsm/Codegen/Programs/StatelessGuest.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuest.lean
@@ -19,6 +19,7 @@ import EvmAsm.Codegen.Programs.EvmRegistry
 import EvmAsm.Codegen.Programs.StatelessGuestData
 import EvmAsm.Codegen.Programs.StatelessGuestEpilogue
 import EvmAsm.Codegen.Programs.BlockVerdictV2
+import EvmAsm.Codegen.Programs.SystemCallStaging
 import EvmAsm.Stateless.Entry
 
 namespace EvmAsm.Codegen
@@ -57,6 +58,16 @@ def statelessGuestUnit : BuildUnit := {
     statelessGuestEpilogue ++ "\n" ++
     "  j .Lstateless_guest_halt_after_runtime_dispatcher\n" ++
     emitRuntimeDispatcherCallableCoreSharedHelpers callFrameGuestRegistry evmAddEpilogue ++ "\n" ++
+    -- 8uld3.2.3.1 (A): link the EIP-7002/7251 system-call request-derivation harness into the
+    -- verdict guest so it can be wired into the requests_hash path (.2.3.C). The dispatcher core
+    -- + call-frame helpers above (callFrameGuestRegistry) already resolve the harness's runtime_
+    -- dispatcher_call / call-descend deps; stage_runtime_payload_code + code_at_header_state_root
+    -- are in the verdict closure (statelessGuestEpilogue). Additive — unused until .C calls it.
+    deriveBlockSystemRequestsFunction ++ "\n" ++
+    deriveWithdrawalRequestsFunction ++ "\n" ++
+    deriveConsolidationRequestsFunction ++ "\n" ++
+    stageSystemCallFunction ++ "\n" ++
+    stageSystemCallPayloadFunction ++ "\n" ++
     ".Lstateless_guest_halt_after_runtime_dispatcher:\n"
   -- guest scratch + the Step-2 verdict's data (zk3_state / rfu_* are dedup'd out
   -- of the guest section since the appended verdict section provides them). The
@@ -64,6 +75,21 @@ def statelessGuestUnit : BuildUnit := {
   dataAsm     :=
     statelessGuestDataSection ++ "\n" ++
     statelessVerdictV2GuestData ++ "\n" ++
+    -- 8uld3.2.3.1 (A): harness-specific data not provided by the dispatcher/guest data
+    -- (system_call_mode/returndata are in the dispatcher data; m29_*/srpc_env_base/frame data
+    -- are already present). scc_ctx/scc_system_addr/ssc_saved_* are inline-only in the probes.
+    ".balign 8\n" ++
+    "scc_ctx:\n  .zero 192\n" ++
+    ".balign 8\n" ++
+    "scc_system_addr:\n" ++
+    "  .byte 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff\n" ++
+    "  .byte 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe\n" ++
+    ".balign 8\n" ++
+    "ssc_saved_ra:\n  .zero 8\n" ++
+    "ssc_saved_s0:\n  .zero 8\n" ++
+    withdrawalRequestPredeployAddrData ++
+    consolidationRequestPredeployAddrData ++
+    deriveBlockSystemRequestsData ++ "\n" ++
     emitRuntimeDispatcherDataSectionSharedGuest callFrameGuestRegistry
 }
 


### PR DESCRIPTION
## Summary
- **8uld3.2.3.1 (A)**: links the EIP-7002/7251 system-call request-derivation harness (`derive_block_system_requests` + `derive_withdrawal/consolidation_requests` + `stage_system_call(_payload)` + harness data) into the **stateless verdict guest** under `callFrameGuestRegistry` — the verdict's dispatcher registry.
- The harness e2e was previously only proven under `tinyInterpRegistry`; a simple-swap standalone probe **fails to link** (callFrameGuestRegistry's CALL/CREATE handlers pull in the full call-descend / account / code closure). Linking into the verdict guest — which already provides that closure (`emitRuntimeDispatcherCallableCoreSharedHelpers` + `code_at_header_state_root` + `stage_runtime_payload_code`) — is the clean path. `system_call_*` / `m29_*` / frame data are dispatcher/guest-provided and deduped.
- **Additive + inert**: the harness is unused until `8uld3.2.3.3` (C) wires `derive_block_system_requests` into the verdict's `requests_hash` path (replacing the SSZ-input-trust path).

## Verification
- `stateless_guest` builds + links green (no double-def / undefined-ref).
- `multi_transaction_gas_accounting` **16/16 full match, 0 fail** (no regression — harness inert).
- `check-file-size` / `check-unimported` / forbidden-tactics: clean.

Bead: evm-asm-8uld3.2.3.1 (parent: evm-asm-8uld3.2.3 / evm-asm-8uld3.2).

Authored by @pirapira; implemented by Claude Code