### PR TITLE
fix(dispatch): EIP-7976 calldata floor counts zero bytes uniformly (mlp31)

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -1976,12 +1976,19 @@ def emitRuntimeDispatcherSetupWithInputAsm (inputAsm : String) : String :=
   "  beqz x8, .runtime_tx_gas_create_words\n" ++
   "  lbu x11, 0(x9)\n" ++
   "  beqz x11, .runtime_tx_gas_zero_byte\n" ++
-  "  addi x7, x7, 16\n" ++
-  "  addi x10, x10, 64\n" ++   -- u13jh: EIP-7623 floor = 4 tokens * TX_DATA_TOKEN_FLOOR(16) per non-zero byte (was stale 40 = *10)
+  "  addi x7, x7, 16\n" ++       -- non-zero data_cost = 4 tokens * STANDARD_TOKEN_COST(4)
+  "  addi x10, x10, 64\n" ++   -- floor = 4 tokens * TX_DATA_TOKEN_FLOOR(16) = 64 per non-zero byte
   "  j .runtime_tx_gas_data_step\n" ++
   ".runtime_tx_gas_zero_byte:\n" ++
-  "  addi x7, x7, 4\n" ++
-  "  addi x10, x10, 16\n" ++   -- u13jh: EIP-7623 floor = 1 token * TX_DATA_TOKEN_FLOOR(16) per zero byte (was stale 10 = *10)
+  "  addi x7, x7, 4\n" ++       -- zero-byte data_cost (count_tokens_in_data) = 1 token * 4
+  -- mlp31: EIP-7976 makes the calldata FLOOR count EVERY byte uniformly at
+  -- TX_DATA_TOKEN_STANDARD(4) tokens (transactions.py: floor_tokens_in_calldata =
+  -- ulen(tx.data) * 4), so a zero byte adds 4 * TX_DATA_TOKEN_FLOOR(16) = 64 to the
+  -- floor, NOT the EIP-7623 zero=1-token weighting (the old 16). The zero/non-zero
+  -- split survives only for the non-floor data_cost accumulator (x7). The old 16 here
+  -- under-counted the floor by 48 per zero byte; the gate is `bltu x6, x10` (reject if
+  -- gas < floor), so the under-count was a false-accept of floor-short txs.
+  "  addi x10, x10, 64\n" ++
   ".runtime_tx_gas_data_step:\n" ++
   "  addi x9, x9, 1\n" ++
   "  addi x8, x8, -1\n" ++


### PR DESCRIPTION
## Summary
- The runtime tx-gas path (`Dispatch.lean` `.runtime_tx_gas_data_loop`) computed the EIP-7976 calldata **floor** with the stale EIP-7623 zero=1/non-zero=4 token weighting: a zero calldata byte added only `16` (1 token × `TX_DATA_TOKEN_FLOOR`=16) to the floor accumulator `x10`, vs `64` (4 tokens × 16) for a non-zero byte.
- EIP-7976 (Amsterdam) makes the floor count **every** calldata byte uniformly at `TX_DATA_TOKEN_STANDARD`=4 tokens (`execution-specs amsterdam/transactions.py:673`: `floor_tokens_in_calldata = ulen(tx.data) * 4`), so each byte — zero or not — contributes `4 × 16 = 64`. Fix: the zero-byte branch now adds `64`.
- Soundness-additive: the floor gate is `bltu x6, x10` (reject if `gas < floor`), so the prior under-count (−48 gas per zero byte) was a **false-accept** of floor-short transactions whose calldata contains zero bytes. Raising the floor to the spec value can only reject previously-mis-accepted blocks; valid blocks stay valid.
- The non-floor `data_cost` accumulator (`x7`) correctly retains the zero=1/non-zero=4 split (`count_tokens_in_data`) and is **unchanged**.

## Cross-checks
- The guest's own static `intrinsic_gas_amsterdam_counts` probe already encodes the floor uniformly: `IntrinsicGas.lean` computes `floor calldata tokens = 4 * data_len` then `× 16 + 21000` — the runtime path now matches it.
- `floor = 21000 + 16 * (4 * data_len + access_tokens)` (probe docstring) — i.e. 64/byte.

## Verification
- All **50** `amsterdam/eip7976_increase_calldata_floor_cost` EEST rows reach **full 105-byte match** (`full match: 50, fail: 0`).
- `lake build` (full, 3250 jobs) green; file-size / unimported / forbidden-tactic gates pass.

## Out of scope (separate follow-up)
- The runtime `x10` floor loop walks only calldata and does **not** add `tokens_in_access_list` to the floor (the static probe does, via `access_tokens`). An access-list-bearing tx whose floor binds would still be under-counted by the access-list floor tokens. Distinct from this zero-byte fix; flagging for a follow-up bead.

Refs #mlp31. Bead: evm-asm-mlp31.

Directed by @pirapira; implemented by Claude Code.