### PR TITLE
feat(requests): link EIP-6110 deposit-request derivation into stateless verdict guest (8uld3.2.3.2)

### DIFF
--- a/EvmAsm/Codegen/Programs/StatelessGuest.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuest.lean
@@ -20,6 +20,7 @@ import EvmAsm.Codegen.Programs.StatelessGuestData
 import EvmAsm.Codegen.Programs.StatelessGuestEpilogue
 import EvmAsm.Codegen.Programs.BlockVerdictV2
 import EvmAsm.Codegen.Programs.SystemCallStaging
+import EvmAsm.Codegen.Programs.ParseDepositRequests
 import EvmAsm.Stateless.Entry
 
 namespace EvmAsm.Codegen
@@ -68,6 +69,12 @@ def statelessGuestUnit : BuildUnit := {
     deriveConsolidationRequestsFunction ++ "\n" ++
     stageSystemCallFunction ++ "\n" ++
     stageSystemCallPayloadFunction ++ "\n" ++
+    -- 8uld3.2.3.2 (B): link the EIP-6110 deposit-request derivation (parse_deposit_requests
+    -- scans block receipts for DEPOSIT_CONTRACT_ADDRESS logs -> type-0 deposit bodies, +
+    -- extract_deposit_data). Self-contained (no dispatcher deps). Additive — unused until .C
+    -- replaces the SSZ-deposits trust (BlockVerdictStateRoot.lean:430-445) with derivation.
+    parseDepositRequestsFunction ++ "\n" ++
+    extractDepositDataFunction ++ "\n" ++
     ".Lstateless_guest_halt_after_runtime_dispatcher:\n"
   -- guest scratch + the Step-2 verdict's data (zk3_state / rfu_* are dedup'd out
   -- of the guest section since the appended verdict section provides them). The
@@ -90,6 +97,22 @@ def statelessGuestUnit : BuildUnit := {
     withdrawalRequestPredeployAddrData ++
     consolidationRequestPredeployAddrData ++
     deriveBlockSystemRequestsData ++ "\n" ++
+    -- 8uld3.2.3.2 (B): deposit-derivation data (DEPOSIT_CONTRACT_ADDRESS, deposit event sig,
+    -- pdr_out body buffer, pdr_status). None present in the guest/dispatcher data.
+    ".balign 8\n" ++
+    "pdr_deposit_addr:\n" ++
+    "  .byte 0x00, 0x00, 0x00, 0x00, 0x21, 0x9a, 0xb5, 0x40\n" ++
+    "  .byte 0x35, 0x6c, 0xbb, 0x83, 0x9c, 0xbe, 0x05, 0x30\n" ++
+    "  .byte 0x3d, 0x77, 0x05, 0xfa\n" ++
+    ".balign 8\n" ++
+    "pdr_deposit_sig:\n" ++
+    "  .byte 0x64, 0x9b, 0xbc, 0x62, 0xd0, 0xe3, 0x13, 0x42\n" ++
+    "  .byte 0xaf, 0xea, 0x4e, 0x5c, 0xd8, 0x2d, 0x40, 0x49\n" ++
+    "  .byte 0xe7, 0xe1, 0xee, 0x91, 0x2f, 0xc0, 0x88, 0x9a\n" ++
+    "  .byte 0xa7, 0x90, 0x80, 0x3b, 0xe3, 0x90, 0x38, 0xc5\n" ++
+    ".balign 8\n" ++
+    "pdr_out:\n  .zero 2048\n" ++
+    "pdr_status:\n  .zero 8\n" ++
     emitRuntimeDispatcherDataSectionSharedGuest callFrameGuestRegistry
 }
 


### PR DESCRIPTION
## Summary
- **8uld3.2.3.2 (B)**: links `parse_deposit_requests` (scans block receipts for `DEPOSIT_CONTRACT_ADDRESS` logs → type-0 deposit request bodies) + `extract_deposit_data` + the deposit data (`DEPOSIT_CONTRACT_ADDRESS` / `DEPOSIT_EVENT_SIGNATURE_HASH` / `pdr_out` / `pdr_status`) into the **stateless verdict guest** (`statelessGuestUnit`).
- A pure receipts scanner — **no dispatcher/call-frame deps** — so it links cleanly; none of its symbols were already in the guest/dispatcher data.
- The verdict currently **trusts** the SSZ deposits (BlockVerdictStateRoot.lean:430-445, only a no-tx empty-deposits guard). This makes the derivation available so `8uld3.2.3.3` (C) can replace that trust with `parse_deposit_requests` over the receipts. **Additive + inert** until C wires it.

## Verification
- `stateless_guest` builds + links green.
- `multi_transaction_gas_accounting` **16/16 full match, 0 fail** (no regression — harness inert).
- `check-file-size` / `check-unimported` / forbidden-tactics: clean.

Stacked on #8700 (8uld3.2.3.1 / A) — both touch `statelessGuestUnit`; independent in scope per the decomposition.

Bead: evm-asm-8uld3.2.3.2 (parent: evm-asm-8uld3.2.3).

Authored by @pirapira; implemented by Claude Code