### PR TITLE
fix(stateless): gate STATELESS_INPUT_SCHEMA_ID before successful_validation (b2ov4)

### DIFF
--- a/EvmAsm/Codegen/Programs/StatelessGuestEpilogue.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuestEpilogue.lean
@@ -791,6 +791,26 @@ def statelessGuestEpilogue : String :=
   ".Lsg_npr_restore:\n" ++
   "  add t3, t1, t2; ld t4, 0(t3); add t3, t0, t2; sd t4, 0(t3)\n" ++
   "  addi t2, t2, 8; li t3, 112; bltu t2, t3, .Lsg_npr_restore\n" ++
+  -- b2ov4: enforce STATELESS_INPUT_SCHEMA_ID before emitting a successful
+  -- validation. The spec's deserialize_stateless_input (amsterdam
+  -- stateless_guest.py:31-40) reads the leading 2 bytes big-endian and RAISES
+  -- ValueError unless they equal STATELESS_INPUT_SCHEMA_ID (=0x0001,
+  -- stateless_ssz.py:64) BEFORE any SSZ decode/verify. The guest reads the SSZ
+  -- body unconditionally from SSZ_BASE = INPUT+18, never consulting the 2-byte
+  -- schema prefix at INPUT+16, so a wrong-schema-but-otherwise-valid input would
+  -- decode and could reach succ=01 -- a false-accept of input the Python entry
+  -- point rejects. Gate it here (a0 = verdict bit; force 0 on a schema mismatch).
+  -- INPUT base = 0x40000000, schema id = bytes [INPUT+16]=0x00, [INPUT+17]=0x01.
+  -- Every real fixture carries 0x0001, so this is transparent to passing rows.
+  "  li t1, 0x40000000; addi t1, t1, 16   # &schema_id (2 bytes, big-endian)\n" ++
+  "  lbu t2, 0(t1)                        # schema_id hi byte (must be 0x00)\n" ++
+  "  lbu t3, 1(t1)                        # schema_id lo byte (must be 0x01)\n" ++
+  "  bnez t2, .Lsg_bad_schema\n" ++
+  "  li t4, 1; bne t3, t4, .Lsg_bad_schema\n" ++
+  "  j .Lsg_schema_ok\n" ++
+  ".Lsg_bad_schema:\n" ++
+  "  li a0, 0                             # unsupported schema id -> reject (succ=00)\n" ++
+  ".Lsg_schema_ok:\n" ++
   "  li t0, 0xa0010000; sb a0, 32(t0)\n" ++
   "  # Restore zisk's trap vector before the final Linux-93 halt ecall.\n" ++
   "  li t0, 0xa0009828          # zisk MTVEC memory slot\n" ++


### PR DESCRIPTION
## Summary
- `deserialize_stateless_input` (execution-specs amsterdam `stateless_guest.py:31-40`) reads the leading 2 bytes of the stateless input **big-endian** and RAISES `ValueError` unless they equal `STATELESS_INPUT_SCHEMA_ID` (`0x0001`, `stateless_ssz.py:64`) — BEFORE any SSZ decode or `verify_stateless_new_payload`.
- The RISC-V guest read the SSZ body unconditionally from `SSZ_BASE = INPUT+18` and **never consulted the 2-byte schema prefix at `INPUT+16`**. The schema value is used nowhere else, so a wrong-schema-but-otherwise-valid input would decode and could reach `succ=01` — a false-accept of input the Python entry point rejects. No existing offset check catches it.
- Fix: a schema-id gate at the guest's final `succ` stamp (`StatelessGuestEpilogue`). If `INPUT[16:18] != 0x0001` (bytes `0x00 0x01`), force the verdict bit to 0. Soundness-additive; transparent to every real fixture (all carry `0x0001`).

## Verification
- **Regression (no false-reject):** 10 diverse rows — 6 accepted + 4 rejected, spanning finalization / blob / CODECOPY / suicide / multi-tx-STORAGE_CLEAR / intrinsic-gas / insufficient-balance-blob — each reproduce their exact expected 105-byte output. The gate is transparent to real inputs.
- **Schema-mutation (gate works):** flipping an accepted input's schema id `0x0001 → 0x0002` flips the guest from `succ=01` to `succ=00`; the unmutated input stays `succ=01`.
- `lake build` green (3250 jobs); file-size / unimported / forbidden-tactic gates pass.

## Scope / follow-up
- Closes the **schema-id** half of b2ov4's acceptance. The broader "canonical `SszStatelessInput` container/list bounds gate before reading derived fields" is left as a follow-up child (several malformed-offset cases are already rejected by existing checks like `RequestsHash` `offset0==12` and the SSZ list-multiple/cap checks; a general canonical-decode gate is a separate, larger change).

Refs #b2ov4. Bead: evm-asm-b2ov4.

Directed by @pirapira; implemented by Claude Code.