### PR TITLE
fix(stateless): canonical SszStatelessInput outer-offset gate (b2ov4.1)

### DIFF
--- a/EvmAsm/Codegen/Programs/StatelessGuestEpilogue.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuestEpilogue.lean
@@ -805,12 +805,40 @@ def statelessGuestEpilogue : String :=
   "  li t1, 0x40000000; addi t1, t1, 16   # &schema_id (2 bytes, big-endian)\n" ++
   "  lbu t2, 0(t1)                        # schema_id hi byte (must be 0x00)\n" ++
   "  lbu t3, 1(t1)                        # schema_id lo byte (must be 0x01)\n" ++
-  "  bnez t2, .Lsg_bad_schema\n" ++
-  "  li t4, 1; bne t3, t4, .Lsg_bad_schema\n" ++
-  "  j .Lsg_schema_ok\n" ++
-  ".Lsg_bad_schema:\n" ++
-  "  li a0, 0                             # unsupported schema id -> reject (succ=00)\n" ++
-  ".Lsg_schema_ok:\n" ++
+  "  bnez t2, .Lsg_bad_input\n" ++
+  "  li t4, 1; bne t3, t4, .Lsg_bad_input\n" ++
+  -- b2ov4.1: canonical SszStatelessInput outer-offset gate. The spec decodes the
+  -- SSZ via remerkleable, which raises on non-canonical offsets BEFORE the verdict
+  -- reads any derived field. SszStatelessInput has 4 variable-length fields
+  -- (new_payload_request, witness, chain_config, public_keys -- chain_config is
+  -- variable via active_fork.blob_schedule = SszOptionalBlobSchedule), so the fixed
+  -- part is 4*4 = 16 bytes and the 4 u32-LE offsets live at SSZ_BASE+0/4/8/12.
+  -- Canonical SSZ requires: offset[0] == 16 (no gap before the first field),
+  -- offsets non-decreasing, and offset[3] (last field start) <= the SSZ section
+  -- length. The guest navigates these offsets unchecked, so a non-canonical offset
+  -- table could mis-slice fields and still reach succ=01. Byte-wise u32 loads
+  -- (SSZ_BASE = 0x40000012 is only 2-aligned). Transparent to real fixtures.
+  "  li t1, 0x40000012                    # SSZ_BASE (INPUT+18)\n" ++
+  "  lbu t2, 0(t1); lbu t3, 1(t1); slli t3, t3, 8; or t2, t2, t3\n" ++
+  "  lbu t3, 2(t1); slli t3, t3, 16; or t2, t2, t3; lbu t3, 3(t1); slli t3, t3, 24; or t2, t2, t3\n" ++
+  "  li t4, 16; bne t2, t4, .Lsg_bad_input  # offset[0] == fixed part (16)\n" ++
+  "  lbu t3, 4(t1); lbu t5, 5(t1); slli t5, t5, 8; or t3, t3, t5\n" ++
+  "  lbu t5, 6(t1); slli t5, t5, 16; or t3, t3, t5; lbu t5, 7(t1); slli t5, t5, 24; or t3, t3, t5\n" ++
+  "  bltu t3, t2, .Lsg_bad_input          # offset[1] >= offset[0]\n" ++
+  "  mv t2, t3\n" ++
+  "  lbu t3, 8(t1); lbu t5, 9(t1); slli t5, t5, 8; or t3, t3, t5\n" ++
+  "  lbu t5, 10(t1); slli t5, t5, 16; or t3, t3, t5; lbu t5, 11(t1); slli t5, t5, 24; or t3, t3, t5\n" ++
+  "  bltu t3, t2, .Lsg_bad_input          # offset[2] >= offset[1]\n" ++
+  "  mv t2, t3\n" ++
+  "  lbu t3, 12(t1); lbu t5, 13(t1); slli t5, t5, 8; or t3, t3, t5\n" ++
+  "  lbu t5, 14(t1); slli t5, t5, 16; or t3, t3, t5; lbu t5, 15(t1); slli t5, t5, 24; or t3, t3, t5\n" ++
+  "  bltu t3, t2, .Lsg_bad_input          # offset[3] >= offset[2]\n" ++
+  "  li t4, 0x40000008; ld t5, 0(t4); addi t5, t5, -2  # SSZ_len = host_blob_len - schema(2)\n" ++
+  "  bgtu t3, t5, .Lsg_bad_input          # offset[3] <= SSZ section length\n" ++
+  "  j .Lsg_input_ok\n" ++
+  ".Lsg_bad_input:\n" ++
+  "  li a0, 0                             # bad schema id or non-canonical SSZ offsets -> reject (succ=00)\n" ++
+  ".Lsg_input_ok:\n" ++
   "  li t0, 0xa0010000; sb a0, 32(t0)\n" ++
   "  # Restore zisk's trap vector before the final Linux-93 halt ecall.\n" ++
   "  li t0, 0xa0009828          # zisk MTVEC memory slot\n" ++


### PR DESCRIPTION
## Summary
- Second half of b2ov4 (the schema-id gate is #8703, this PR's **base** — stacked). The spec decodes the stateless input via remerkleable, which raises on non-canonical SSZ offsets **before** the verdict reads any derived field.
- `SszStatelessInput` has 4 variable-length fields (`new_payload_request`, `witness`, `chain_config`, `public_keys` — `chain_config` is variable via `active_fork.blob_schedule = SszOptionalBlobSchedule`), so the fixed part is 16 bytes and the 4 u32-LE offsets are at `SSZ_BASE+0/4/8/12`.
- The guest navigated these offsets **unchecked**, so a non-canonical offset table could mis-slice fields and still reach `succ=01`. This extends the schema-id gate (same site, before the succ stamp) to enforce: `offset[0]==16` (no leading gap), offsets non-decreasing, and `offset[3] <= SSZ section length` (= host blob length − 2 schema bytes). Any violation forces the verdict bit to 0. Byte-wise u32 loads (`SSZ_BASE=0x40000012` is only 2-aligned).

## Verification
- **Regression:** 50 diverse eip-family rows reproduce their exact 105-byte output — transparent to real canonical inputs. Observed offset table for `finalization_burn_log`: `offset[0]=16, [1]=1486, [2]=5233, [3]=5301` (monotonic, in range).
- **Mutation:** setting `offset[0]=20` (≠16) on an accepted input flips succ `01→00`; unmutated stays `01`.
- `lake build` green; size / unimported / forbidden-tactic gates pass.

Stacked on #8703; base retargets to `main` when #8703 merges. Together these close b2ov4 (schema + canonical offsets).

Refs #b2ov4. Bead: evm-asm-b2ov4.1.

Directed by @pirapira; implemented by Claude Code.