### PR TITLE
fix(verdict): bmvmx.1.6.6 BAL/exec-log key+value byte order in per-tx tuple comparator

### DIFF
--- a/EvmAsm/Codegen/Programs/AccountTupleSequencesConsistent.lean
+++ b/EvmAsm/Codegen/Programs/AccountTupleSequencesConsistent.lean
@@ -83,12 +83,30 @@ def accountTupleSequencesConsistentFunction : String :=
   "  li t5, 32; sub t5, t5, t4; add t0, t6, t5\n" ++
   ".Latsc_kc:\n  beqz t4, .Latsc_kcd\n  lbu t5, 0(t1); sb t5, 0(t0); addi t1, t1, 1; addi t0, t0, 1; addi t4, t4, -1; j .Latsc_kc\n" ++
   ".Latsc_kcd:\n" ++
-  "  # BAL tuple sequence for this slot\n" ++
+  -- bmvmx.1.6.6: atsc_key is 32B BIG-endian (RLP) for the BAL search
+  -- (bal_slot_tuple_sequence compares against the BE-left-padded BAL key,
+  -- BalSlotTupleSequence.lean:36/80). The exec log is LITTLE-endian (slotKey @ +32 =
+  -- EVM-stack 4 LE u64 limbs low-first, Storage.lean:19), so byte-reverse atsc_key ->
+  -- atsc_key_le for exec_log_slot_tuples, AND reverse the BAL tuple VALUES BE->LE below
+  -- (the exec side emits the LE log value verbatim). Mirrors bal_storage_matches_exec_log's
+  -- bsme_krev/bsme_vrev. Old code passed BE atsc_key + BE values to BOTH -> the exec
+  -- compare mismatched the LE log -> exec_count=0 vs bal_count>0 -> false-reject. Latent:
+  -- only the interacting-mtx non-recipient-slot path (.57.11.6.3) reaches here.
+  "  la t0, atsc_key; addi t0, t0, 31; la t1, atsc_key_le; li t2, 32\n" ++
+  ".Latsc_klr:\n  beqz t2, .Latsc_klrd\n  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; j .Latsc_klr\n" ++
+  ".Latsc_klrd:\n" ++
+  "  # BAL tuple sequence for this slot (searched by BE atsc_key)\n" ++
   "  mv a0, s0; mv a1, s1; la a2, atsc_key; la a3, atsc_balbuf\n" ++
   "  jal ra, bal_slot_tuple_sequence\n" ++
   "  la t0, atsc_balcount; sd a0, 0(t0)                   # bal_count\n" ++
-  "  # exec net-change tuple sequence for this slot\n" ++
-  "  mv a0, s2; la a1, atsc_key; mv a2, s3; mv a3, s4; mv a4, s5; la a5, atsc_execbuf\n" ++
+  "  # reverse each BAL tuple's 32B value (BE -> LE) to match the LE exec output\n" ++
+  "  mv t0, a0; la t1, atsc_balbuf                        # t0=count; record = bai@0, value@8\n" ++
+  ".Latsc_vr:\n  beqz t0, .Latsc_vrd\n  addi t2, t1, 8; addi t3, t1, 39; li t4, 16\n" ++
+  ".Latsc_vrb:\n  beqz t4, .Latsc_vrn\n  lbu t5, 0(t2); lbu t6, 0(t3); sb t6, 0(t2); sb t5, 0(t3); addi t2, t2, 1; addi t3, t3, -1; addi t4, t4, -1; j .Latsc_vrb\n" ++
+  ".Latsc_vrn:\n  addi t1, t1, 40; addi t0, t0, -1; j .Latsc_vr\n" ++
+  ".Latsc_vrd:\n" ++
+  "  # exec net-change tuple sequence for this slot (searched by LE atsc_key_le)\n" ++
+  "  mv a0, s2; la a1, atsc_key_le; mv a2, s3; mv a3, s4; mv a4, s5; la a5, atsc_execbuf\n" ++
   "  jal ra, exec_log_slot_tuples\n" ++
   "  mv t6, a0                                            # exec_count\n" ++
   "  # exact list-vs-list comparison\n" ++
@@ -117,6 +135,7 @@ def accountTupleSequencesConsistentData : String :=
   "atsc_balcount:\n  .zero 8\n" ++
   ".balign 32\n" ++
   "atsc_key:\n  .zero 32\n" ++
+  "atsc_key_le:\n  .zero 32\n" ++       -- LE byte-reverse of atsc_key for the exec-log search (bmvmx.1.6.6)
   "atsc_balbuf:\n  .zero 10240\n" ++   -- up to 256 tuples * 40B
   "atsc_execbuf:\n  .zero 10240\n"
 

--- a/scripts/codegen-zisk-account-tuple-sequences-check.sh
+++ b/scripts/codegen-zisk-account-tuple-sequences-check.sh
@@ -37,23 +37,25 @@ run_case() {
   MODE="$mode" uv run --directory execution-specs --quiet python3 -c "
 import struct, sys, os, rlp
 mode=os.environ['MODE']
-def b32(n): return n.to_bytes(32,'big')
+def b32(n): return n.to_bytes(32,'big')        # BAL (RLP) keys/values = big-endian
+def b32le(n): return n.to_bytes(32,'little')   # exec-log slotKey/value = LE EVM-stack limbs (Storage.lean:19)
 addr=bytes(range(1,21)); addrHash=bytes([0xAA])*32
-K=b32(7); J=b32(9); O=b32(0)
-def entry(sk,cur,O=O): return addrHash+sk+O+cur   # 128B: addrHash|slotKey|original|current
+O=b32le(0)
+# exec-log entries store slotKey + value in the real guest's LITTLE-endian stack-word order.
+def entry(sk_n,cur_n): return addrHash+b32le(sk_n)+O+b32le(cur_n)   # 128B: addrHash|slotKey|original|current
 
 # exec-log for slot 7: tx1 -> 0x11, tx3 -> 0x33  => reconstructs [(1,0x11),(3,0x33)]
-rows=[(entry(K,b32(0x11)),1),(entry(K,b32(0x33)),3)]
-# BAL storage_changes for slot 7 (SlotChanges = [slot_key, [[bai,new_value],...]])
-sc=[[K, [[1,b32(0x11)],[3,b32(0x33)]]]]
+rows=[(entry(7,0x11),1),(entry(7,0x33),3)]
+# BAL storage_changes for slot 7 (SlotChanges = [slot_key, [[bai,new_value],...]]), big-endian.
+sc=[[b32(7), [[1,b32(0x11)],[3,b32(0x33)]]]]
 
 if mode=='wrong_tuple':
-    sc=[[K, [[1,b32(0x11)],[3,b32(0x99)]]]]            # final tuple value wrong vs exec 0x33
+    sc=[[b32(7), [[1,b32(0x11)],[3,b32(0x99)]]]]            # final tuple value wrong vs exec 0x33
 elif mode=='extra_bal_tuple':
-    sc=[[K, [[1,b32(0x11)],[3,b32(0x33)],[5,b32(0x55)]]]]  # spurious extra tuple BAL has, exec doesn't
+    sc=[[b32(7), [[1,b32(0x11)],[3,b32(0x33)],[5,b32(0x55)]]]]  # spurious extra tuple BAL has, exec doesn't
 elif mode=='multi_slot':
-    rows=rows+[(entry(J,b32(0x22)),2)]                 # exec slot 9: tx2 -> 0x22
-    sc=sc+[[J, [[2,b32(0x22)]]]]
+    rows=rows+[(entry(9,0x22),2)]                 # exec slot 9: tx2 -> 0x22
+    sc=sc+[[b32(9), [[2,b32(0x22)]]]]
 
 acct=rlp.encode([addr, sc, [], [], [], []])
 count=len(rows)

--- a/scripts/codegen-zisk-bal-all-accounts-tuple-sequences-check.sh
+++ b/scripts/codegen-zisk-bal-all-accounts-tuple-sequences-check.sh
@@ -36,14 +36,16 @@ run_case() {
   MODE="$mode" uv run --directory execution-specs --quiet python3 -c "
 import struct, sys, os, rlp
 mode=os.environ['MODE']
-def b32(n): return n.to_bytes(32,'big')
+def b32(n): return n.to_bytes(32,'big')        # BAL (RLP) keys/values = big-endian
+def b32le(n): return n.to_bytes(32,'little')   # exec-log slotKey/value = LE stack-word (Storage.lean:19)
 callee=bytes(range(1,21)); recipient=bytes(range(0x21,0x35))
 ckey=callee[::-1]+b'\x00'*12          # bal_addr_to_exec_log_key(callee): addr reversed, low-aligned
-K=b32(7); O=b32(0)
-def entry(ah,sk,cur,o=O): return ah+sk+o+cur  # 128B addrHash|slotKey|original|current
+K=b32(7); O=b32le(0)
+# exec-log entries store slotKey + value in the real little-endian stack-word order.
+def entry(ah,sk_n,cur_n,o=O): return ah+b32le(sk_n)+o+b32le(cur_n)  # 128B addrHash|slotKey|original|current
 
 # exec-log for callee's slot 7: tx1 -> 0x11, tx3 -> 0x33  => reconstructs [(1,0x11),(3,0x33)]
-rows=[(entry(ckey,K,b32(0x11)),1),(entry(ckey,K,b32(0x33)),3)]
+rows=[(entry(ckey,7,0x11),1),(entry(ckey,7,0x33),3)]
 callee_sc=[[K, [[1,b32(0x11)],[3,b32(0x33)]]]]
 recip_sc =[[K, [[1,b32(0xDEAD)],[2,b32(0xBEEF)]]]]   # recipient storage (BE-keyed; must be SKIPPED)
 accounts=[[callee, callee_sc, [], [], [], []], [recipient, recip_sc, [], [], [], []]]


### PR DESCRIPTION
## Summary
`account_tuple_sequences_consistent` (the per-tx tuple comparator that closes the finals-only false-accept gap) built **one** 32-byte big-endian `atsc_key` and passed it to **both** `bal_slot_tuple_sequence` and `exec_log_slot_tuples` — but the two sides use opposite byte orders:
- The **BAL** (RLP) is big-endian: `bal_slot_tuple_sequence` compares the key against the BE-left-padded BAL key (`BalSlotTupleSequence.lean:36/80`) and emits `new_value` big-endian.
- The **execution storage log** is little-endian: `slotKey@32` / `current@96` are EVM-stack 4-LE-u64-limb, low byte first (`Storage.lean:19`); `exec_log_slot_tuples` emits the LE value verbatim.

So the BE `atsc_key` never matched the LE exec-log slotKey (`exec_count=0` vs `bal_count>0`), and even with a matching key the BE-vs-LE `new_value` compare (`slot_tuple_sequences_match` checks the 32 value bytes exactly) would mismatch → **false-reject of a consistent slot**. Latent: the atsc path is reached only for non-recipient-slot writes in interacting multi-tx (gated on `.57.11.6.3`); recipient-slot single-tx rows go through `bal_storage_matches_exec_log`.

**Fix** (mirrors the working `bal_storage_matches_exec_log` `bsme_krev`/`bsme_vrev`): keep `atsc_key` big-endian for the BAL search; byte-reverse it into `atsc_key_le` for the exec-log search; and reverse each BAL tuple's 32-byte value BE→LE so the list-vs-list compare is LE-vs-LE.

Also corrects the **probe test**, which constructed the exec-log entries big-endian (self-consistent with the BE BAL) and therefore could not catch the bug — the exec-log slotKey/value now use the real little-endian stack-word format.

## Verification (probe — self-contained, not execution-gated)
`codegen-zisk-account-tuple-sequences-check.sh` with the corrected LE exec-log format:
- **Fixed** comparator: all four pass — `consistent=0, wrong_tuple=1, extra_bal_tuple=1, multi_slot=0`.
- **Unfixed** comparator (reverted just the guest, kept the LE test): **FAILS** — `consistent` and `multi_slot` → `status=1` (false-reject). Clean before/after demonstrating the bug and the fix.
- full `lake build` green (3250 jobs); size / unimported / forbidden-tactic gates pass.

End-to-end EEST verification of this slot path remains gated on the interacting-multi-tx `.57.11.6.3` work (the atsc path isn't reached until a non-recipient slot is written); the unit fix is verified now via the probe.

Refs #bmvmx.1.6.6. Bead: evm-asm-bmvmx.1.6.6.

Directed by @pirapira; implemented by Claude Code.