### PR TITLE
feat(requests): C.1 — derive EIP-7002/7251 requests_hash by executing the predeploys [8uld3.2.3.3.1]

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -325,6 +325,16 @@ def ziskStatelessVerdictV2DataSection : String :=
   "svf_codes_len:\n  .zero 8\n" ++
   "svf_headers_ptr:\n  .zero 8\n" ++
   "svf_headers_len:\n  .zero 8\n" ++
+  -- 8uld3.2.3.3.1 (C.1): scratch for execution-derived withdrawal+consolidation requests_hash.
+  ".balign 8\n" ++
+  "c1_saved_logcount:\n  .zero 8\n" ++
+  "c1_wcode_ptr:\n  .zero 8\n" ++
+  "c1_wcode_len:\n  .zero 8\n" ++
+  "c1_er_input:\n  .zero 8\n" ++
+  ".balign 8\n" ++
+  "c1_staging:\n  .zero 4096\n" ++
+  ".balign 8\n" ++
+  "c1_er_assembled:\n  .zero 2048\n" ++
   "svf_headers_count:\n  .zero 8\n" ++
   "bbcv_count:\n  .zero 8\n" ++
   "bbcv_off:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -332,7 +332,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   "c1_wcode_len:\n  .zero 8\n" ++
   "c1_er_input:\n  .zero 8\n" ++
   ".balign 8\n" ++
-  "c1_staging:\n  .zero 4096\n" ++
+  "c1_staging:\n  .zero 32768\n" ++   -- Fix7: system-call payload = env_base+504; env_base grows with the predeploy's storage preload (up to 128 slots*64) + M29 block hashes. 4096 overflowed for above-max queues (100 slots -> ~7.5KB) -> truncated storage section -> SLOAD miss -> empty derived body.
   ".balign 8\n" ++
   "c1_er_assembled:\n  .zero 2048\n" ++
   "c1_ccode_ptr:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -344,6 +344,8 @@ def ziskStatelessVerdictV2DataSection : String :=
   "c1_bal_start:\n  .zero 8\n" ++
   "c1_bal_len:\n  .zero 8\n" ++
   "c1_bal_count:\n  .zero 8\n" ++
+  "c1_saved_s0:\n  .zero 8\n" ++
+  "c1_saved_s3:\n  .zero 8\n" ++
   "svf_headers_count:\n  .zero 8\n" ++
   "bbcv_count:\n  .zero 8\n" ++
   "bbcv_off:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -341,6 +341,9 @@ def ziskStatelessVerdictV2DataSection : String :=
   "c1_bal_acct_len:\n  .zero 8\n" ++
   ".balign 8\n" ++
   "c1_preload:\n  .zero 8192\n" ++
+  "c1_bal_start:\n  .zero 8\n" ++
+  "c1_bal_len:\n  .zero 8\n" ++
+  "c1_bal_count:\n  .zero 8\n" ++
   "svf_headers_count:\n  .zero 8\n" ++
   "bbcv_count:\n  .zero 8\n" ++
   "bbcv_off:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -335,6 +335,12 @@ def ziskStatelessVerdictV2DataSection : String :=
   "c1_staging:\n  .zero 4096\n" ++
   ".balign 8\n" ++
   "c1_er_assembled:\n  .zero 2048\n" ++
+  "c1_ccode_ptr:\n  .zero 8\n" ++
+  "c1_ccode_len:\n  .zero 8\n" ++
+  "c1_bal_acct_ptr:\n  .zero 8\n" ++
+  "c1_bal_acct_len:\n  .zero 8\n" ++
+  ".balign 8\n" ++
+  "c1_preload:\n  .zero 8192\n" ++
   "svf_headers_count:\n  .zero 8\n" ++
   "bbcv_count:\n  .zero 8\n" ++
   "bbcv_off:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
@@ -422,6 +422,13 @@ def statelessVerdictV2Function : String :=
   "  bnez a0, .Lv2_withdrawals_root_fail\n" ++
   "  addi a0, s0, 56; jal ra, bgv_u32le; mv s3, a0     # execution_requests offset\n" ++
   "  addi a0, s0, 4;  jal ra, bgv_u32le; mv s4, a0     # witness offset = NPR end\n" ++
+  -- 8uld3.2.3.3.1 Fix3: the system-call derives below run runtime_dispatcher_call, which
+  -- clobbers ALL s-registers (SystemCallStaging:96-99 — it resets sp to lp64_sp_top and the
+  -- predeploy EVM execution overwrites the s-regs). s0(NPR base)/s3(er offset) are needed
+  -- AFTER the derives (deposit extraction, no-tx deposit check, block_access_list_hash,
+  -- block_verdict) so save them now and reload after the last derive. (The original
+  -- "callees preserve s-regs" claim below was wrong: the dispatcher does NOT.)
+  "  la t0, c1_saved_s0; sd s0, 0(t0); la t0, c1_saved_s3; sd s3, 0(t0)\n" ++
   -- 8uld3.2.3.3.1 (C.1): hash the EXECUTION-DERIVED withdrawal(EIP-7002)+consolidation(EIP-7251)
   -- request bodies instead of trusting the SSZ-input ones (deposits stay SSZ-trusted -> .3.3).
   -- Snapshot/restore the exec-log count (evm_env+448) around the system calls so their SSTORE
@@ -508,6 +515,8 @@ def statelessVerdictV2Function : String :=
   ".Lc1_c_copyd:\n" ++
   "  la t0, evm_env; la t2, c1_saved_logcount; ld t1, 0(t2); sd t1, 448(t0)\n" ++
   "  la t0, scc_preload_count; sd zero, 0(t0)\n" ++
+  -- 8uld3.2.3.3.1 Fix3: reload s0/s3 clobbered by the derives' dispatcher runs (see save above).
+  "  la t0, c1_saved_s0; ld s0, 0(t0); la t0, c1_saved_s3; ld s3, 0(t0)\n" ++
   "  addi t0, s0, 16; add t0, t0, s3; la t1, c1_er_input; sd t0, 0(t1)\n" ++
   "  la t0, c1_er_input; ld t1, 0(t0); addi a0, t1, 4; jal ra, bgv_u32le\n" ++
   "  la t0, c1_er_input; ld t1, 0(t0); addi t2, t1, 12; addi t3, a0, -12\n" ++
@@ -529,7 +538,7 @@ def statelessVerdictV2Function : String :=
   -- (Withdrawals/consolidations are NOT checked: the 7002/7251 system contracts can
   -- enqueue those in a no-tx block.) execution_requests_hash already validated the
   -- offset table (>=12 bytes, monotonic), so reading offset[0]/offset[1] is safe and
-  -- offset[1] >= offset[0]. s0/s3 (NPR base / er offset) survive the call (s-regs).
+  -- offset[1] >= offset[0]. s0/s3 (NPR base / er offset) were reloaded after the derives (Fix3).
   "  la t0, svf_tx_count; ld t0, 0(t0); bnez t0, .Lv2_after_notx_deposits\n" ++
   "  addi a0, s0, 16; add a0, a0, s3; jal ra, bgv_u64le   # offset[0] | offset[1]<<32\n" ++
   "  srli t0, a0, 32                                       # deposits end (offset[1])\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
@@ -422,9 +422,49 @@ def statelessVerdictV2Function : String :=
   "  bnez a0, .Lv2_withdrawals_root_fail\n" ++
   "  addi a0, s0, 56; jal ra, bgv_u32le; mv s3, a0     # execution_requests offset\n" ++
   "  addi a0, s0, 4;  jal ra, bgv_u32le; mv s4, a0     # witness offset = NPR end\n" ++
-  "  addi a0, s0, 16; add a0, a0, s3                   # er section start\n" ++
-  "  sub a1, s4, s3; addi a1, a1, -16                  # er section len\n" ++
-  "  la a2, erh_requests_hash\n" ++
+  -- 8uld3.2.3.3.1 (C.1): hash the EXECUTION-DERIVED withdrawal(EIP-7002)+consolidation(EIP-7251)
+  -- request bodies instead of trusting the SSZ-input ones (deposits stay SSZ-trusted -> .3.3).
+  -- Snapshot/restore the exec-log count (evm_env+448) around the system calls so their SSTORE
+  -- effects stay OUT of the storage comparator (preserving its current passing behavior; the
+  -- 7002/7251 predeploy writes are EIP-7928 index-0 system writes the comparator already
+  -- tolerates). s0=NPR base, s3=er offset survive (callees preserve s-regs). The predeploy code
+  -- is resolved at the PRE-state (parent header). witness.state = svf_witness_section+off0 ..
+  -- svf_codes_ptr; witness.codes = svf_codes_ptr/len.
+  "  la t0, evm_env; ld t1, 448(t0); la t2, c1_saved_logcount; sd t1, 0(t2)\n" ++
+  "  la t0, svf_witness_section; ld t1, 0(t0); mv a0, t1; jal ra, bgv_u32le\n" ++
+  "  la t0, svf_witness_section; ld t1, 0(t0); add a3, t1, a0\n" ++
+  "  la t0, svf_codes_ptr; ld t1, 0(t0); sub a4, t1, a3\n" ++
+  "  la t0, svf_parent_rlp; ld a0, 0(t0); la t0, svf_parent_rlp_len; ld a1, 0(t0)\n" ++
+  "  la a2, withdrawal_request_predeploy_addr\n" ++
+  "  la t0, svf_codes_ptr; ld a5, 0(t0); la t0, svf_codes_len; ld a6, 0(t0)\n" ++
+  "  jal ra, code_at_header_state_root\n" ++
+  "  bnez a0, .Lv2_requests_hash_fail\n" ++
+  "  la t0, svf_codes_ptr; ld t1, 0(t0); la t2, cahsr_code_offset; ld t3, 0(t2); add t4, t1, t3\n" ++
+  "  la t0, c1_wcode_ptr; sd t4, 0(t0); la t2, cahsr_code_length; ld t3, 0(t2); la t0, c1_wcode_len; sd t3, 0(t0)\n" ++
+  "  la t0, svf_witness_section; ld t1, 0(t0); mv a0, t1; jal ra, bgv_u32le\n" ++
+  "  la t0, svf_witness_section; ld t1, 0(t0); add a3, t1, a0\n" ++
+  "  la t0, svf_codes_ptr; ld t1, 0(t0); sub a4, t1, a3\n" ++
+  "  la t0, svf_parent_rlp; ld a0, 0(t0); la t0, svf_parent_rlp_len; ld a1, 0(t0)\n" ++
+  "  la a2, consolidation_request_predeploy_addr\n" ++
+  "  la t0, svf_codes_ptr; ld a5, 0(t0); la t0, svf_codes_len; ld a6, 0(t0)\n" ++
+  "  jal ra, code_at_header_state_root\n" ++
+  "  bnez a0, .Lv2_requests_hash_fail\n" ++
+  "  la t0, svf_codes_ptr; ld t1, 0(t0); la t2, cahsr_code_offset; ld t3, 0(t2); add a2, t1, t3\n" ++
+  "  la t2, cahsr_code_length; ld a3, 0(t2)\n" ++
+  "  la t0, c1_wcode_ptr; ld a0, 0(t0); la t0, c1_wcode_len; ld a1, 0(t0)\n" ++
+  "  la t0, svf_payload; ld a4, 0(t0); la a5, c1_staging\n" ++
+  "  jal ra, derive_block_system_requests\n" ++
+  "  la t0, evm_env; la t2, c1_saved_logcount; ld t1, 0(t2); sd t1, 448(t0)\n" ++
+  "  bnez a0, .Lv2_requests_hash_fail\n" ++
+  "  addi t0, s0, 16; add t0, t0, s3; la t1, c1_er_input; sd t0, 0(t1)\n" ++
+  "  la t0, c1_er_input; ld t1, 0(t0); addi a0, t1, 4; jal ra, bgv_u32le\n" ++
+  "  la t0, c1_er_input; ld t1, 0(t0); addi t2, t1, 12; addi t3, a0, -12\n" ++
+  "  mv a0, t2; mv a1, t3\n" ++
+  "  la t0, dbsr_wbody; mv a2, t0; la t0, dbsr_wlen; ld a3, 0(t0)\n" ++
+  "  la t0, dbsr_cbody; mv a4, t0; la t0, dbsr_clen; ld a5, 0(t0)\n" ++
+  "  la a6, c1_er_assembled\n" ++
+  "  jal ra, assemble_execution_requests\n" ++
+  "  mv a1, a0; la a0, c1_er_assembled; la a2, erh_requests_hash\n" ++
   "  jal ra, execution_requests_hash\n" ++
   "  bnez a0, .Lv2_requests_hash_fail\n" ++
   -- hv09f.1: parse_deposit_requests scans receipts for deposit-contract logs; a

--- a/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
@@ -431,6 +431,7 @@ def statelessVerdictV2Function : String :=
   -- is resolved at the PRE-state (parent header). witness.state = svf_witness_section+off0 ..
   -- svf_codes_ptr; witness.codes = svf_codes_ptr/len.
   "  la t0, evm_env; ld t1, 448(t0); la t2, c1_saved_logcount; sd t1, 0(t2)\n" ++
+  -- == WITHDRAWAL (EIP-7002): code_at -> BAL preload -> system call -> copy body ==
   "  la t0, svf_witness; ld a3, 0(t0); la t0, svf_witness_len; ld a4, 0(t0)\n" ++
   "  la t0, svf_parent_rlp; ld a0, 0(t0); la t0, svf_parent_rlp_len; ld a1, 0(t0)\n" ++
   "  la a2, withdrawal_request_predeploy_addr\n" ++
@@ -439,19 +440,71 @@ def statelessVerdictV2Function : String :=
   "  bnez a0, .Lv2_requests_hash_fail\n" ++
   "  la t0, svf_codes_ptr; ld t1, 0(t0); la t2, cahsr_code_offset; ld t3, 0(t2); add t4, t1, t3\n" ++
   "  la t0, c1_wcode_ptr; sd t4, 0(t0); la t2, cahsr_code_length; ld t3, 0(t2); la t0, c1_wcode_len; sd t3, 0(t0)\n" ++
+  "  la t0, bsr_bal_start; ld a0, 0(t0); la t0, bsr_bal_len; ld a1, 0(t0)\n" ++
+  "  la a2, withdrawal_request_predeploy_addr; la a3, c1_bal_acct_ptr; la a4, c1_bal_acct_len\n" ++
+  "  jal ra, bal_find_account_by_address\n" ++
+  "  bnez a0, .Lc1_w_nopreload\n" ++
+  "  la t0, svf_parent_rlp; ld t1, 0(t0); la t2, sps_header; sd t1, 0(t2)\n" ++
+  "  la t0, svf_parent_rlp_len; ld t1, 0(t0); la t2, sps_header_len; sd t1, 0(t2)\n" ++
+  "  la t0, svf_witness; ld t1, 0(t0); la t2, sps_state; sd t1, 0(t2); la t2, sps_storage; sd t1, 0(t2)\n" ++
+  "  la t0, svf_witness_len; ld t1, 0(t0); la t2, sps_state_len; sd t1, 0(t2); la t2, sps_storage_len; sd t1, 0(t2)\n" ++
+  "  la t1, withdrawal_request_predeploy_addr; la t2, sps_addr; li t3, 20\n" ++
+  ".Lc1_w_addr:\n" ++
+  "  beqz t3, .Lc1_w_addrd; lbu t4, 0(t1); sb t4, 0(t2); addi t1, t1, 1; addi t2, t2, 1; addi t3, t3, -1; j .Lc1_w_addr\n" ++
+  ".Lc1_w_addrd:\n" ++
+  "  la t0, c1_bal_acct_ptr; ld a0, 0(t0); la t0, c1_bal_acct_len; ld a1, 0(t0); la a2, c1_preload\n" ++
+  "  jal ra, stage_predeploy_storage_preload\n" ++
+  "  la t0, scc_preload_count; sd a0, 0(t0); la t1, c1_preload; la t0, scc_preload_ptr; sd t1, 0(t0)\n" ++
+  "  j .Lc1_w_derive\n" ++
+  ".Lc1_w_nopreload:\n" ++
+  "  la t0, scc_preload_count; sd zero, 0(t0)\n" ++
+  ".Lc1_w_derive:\n" ++
+  "  la t0, c1_wcode_ptr; ld a0, 0(t0); la t0, c1_wcode_len; ld a1, 0(t0)\n" ++
+  "  la t0, svf_payload; ld a2, 0(t0); la a3, c1_staging\n" ++
+  "  jal ra, derive_withdrawal_requests\n" ++
+  "  bnez a2, .Lv2_requests_hash_fail\n" ++
+  "  la t0, dbsr_wlen; sd a1, 0(t0); mv t1, a0; la t2, dbsr_wbody; mv t3, a1\n" ++
+  ".Lc1_w_copy:\n" ++
+  "  beqz t3, .Lc1_w_copyd; lbu t4, 0(t1); sb t4, 0(t2); addi t1, t1, 1; addi t2, t2, 1; addi t3, t3, -1; j .Lc1_w_copy\n" ++
+  ".Lc1_w_copyd:\n" ++
+  -- == CONSOLIDATION (EIP-7251) ==
   "  la t0, svf_witness; ld a3, 0(t0); la t0, svf_witness_len; ld a4, 0(t0)\n" ++
   "  la t0, svf_parent_rlp; ld a0, 0(t0); la t0, svf_parent_rlp_len; ld a1, 0(t0)\n" ++
   "  la a2, consolidation_request_predeploy_addr\n" ++
   "  la t0, svf_codes_ptr; ld a5, 0(t0); la t0, svf_codes_len; ld a6, 0(t0)\n" ++
   "  jal ra, code_at_header_state_root\n" ++
   "  bnez a0, .Lv2_requests_hash_fail\n" ++
-  "  la t0, svf_codes_ptr; ld t1, 0(t0); la t2, cahsr_code_offset; ld t3, 0(t2); add a2, t1, t3\n" ++
-  "  la t2, cahsr_code_length; ld a3, 0(t2)\n" ++
-  "  la t0, c1_wcode_ptr; ld a0, 0(t0); la t0, c1_wcode_len; ld a1, 0(t0)\n" ++
-  "  la t0, svf_payload; ld a4, 0(t0); la a5, c1_staging\n" ++
-  "  jal ra, derive_block_system_requests\n" ++
+  "  la t0, svf_codes_ptr; ld t1, 0(t0); la t2, cahsr_code_offset; ld t3, 0(t2); add t4, t1, t3\n" ++
+  "  la t0, c1_ccode_ptr; sd t4, 0(t0); la t2, cahsr_code_length; ld t3, 0(t2); la t0, c1_ccode_len; sd t3, 0(t0)\n" ++
+  "  la t0, bsr_bal_start; ld a0, 0(t0); la t0, bsr_bal_len; ld a1, 0(t0)\n" ++
+  "  la a2, consolidation_request_predeploy_addr; la a3, c1_bal_acct_ptr; la a4, c1_bal_acct_len\n" ++
+  "  jal ra, bal_find_account_by_address\n" ++
+  "  bnez a0, .Lc1_c_nopreload\n" ++
+  "  la t0, svf_parent_rlp; ld t1, 0(t0); la t2, sps_header; sd t1, 0(t2)\n" ++
+  "  la t0, svf_parent_rlp_len; ld t1, 0(t0); la t2, sps_header_len; sd t1, 0(t2)\n" ++
+  "  la t0, svf_witness; ld t1, 0(t0); la t2, sps_state; sd t1, 0(t2); la t2, sps_storage; sd t1, 0(t2)\n" ++
+  "  la t0, svf_witness_len; ld t1, 0(t0); la t2, sps_state_len; sd t1, 0(t2); la t2, sps_storage_len; sd t1, 0(t2)\n" ++
+  "  la t1, consolidation_request_predeploy_addr; la t2, sps_addr; li t3, 20\n" ++
+  ".Lc1_c_addr:\n" ++
+  "  beqz t3, .Lc1_c_addrd; lbu t4, 0(t1); sb t4, 0(t2); addi t1, t1, 1; addi t2, t2, 1; addi t3, t3, -1; j .Lc1_c_addr\n" ++
+  ".Lc1_c_addrd:\n" ++
+  "  la t0, c1_bal_acct_ptr; ld a0, 0(t0); la t0, c1_bal_acct_len; ld a1, 0(t0); la a2, c1_preload\n" ++
+  "  jal ra, stage_predeploy_storage_preload\n" ++
+  "  la t0, scc_preload_count; sd a0, 0(t0); la t1, c1_preload; la t0, scc_preload_ptr; sd t1, 0(t0)\n" ++
+  "  j .Lc1_c_derive\n" ++
+  ".Lc1_c_nopreload:\n" ++
+  "  la t0, scc_preload_count; sd zero, 0(t0)\n" ++
+  ".Lc1_c_derive:\n" ++
+  "  la t0, c1_ccode_ptr; ld a0, 0(t0); la t0, c1_ccode_len; ld a1, 0(t0)\n" ++
+  "  la t0, svf_payload; ld a2, 0(t0); la a3, c1_staging\n" ++
+  "  jal ra, derive_consolidation_requests\n" ++
+  "  bnez a2, .Lv2_requests_hash_fail\n" ++
+  "  la t0, dbsr_clen; sd a1, 0(t0); mv t1, a0; la t2, dbsr_cbody; mv t3, a1\n" ++
+  ".Lc1_c_copy:\n" ++
+  "  beqz t3, .Lc1_c_copyd; lbu t4, 0(t1); sb t4, 0(t2); addi t1, t1, 1; addi t2, t2, 1; addi t3, t3, -1; j .Lc1_c_copy\n" ++
+  ".Lc1_c_copyd:\n" ++
   "  la t0, evm_env; la t2, c1_saved_logcount; ld t1, 0(t2); sd t1, 448(t0)\n" ++
-  "  bnez a0, .Lv2_requests_hash_fail\n" ++
+  "  la t0, scc_preload_count; sd zero, 0(t0)\n" ++
   "  addi t0, s0, 16; add t0, t0, s3; la t1, c1_er_input; sd t0, 0(t1)\n" ++
   "  la t0, c1_er_input; ld t1, 0(t0); addi a0, t1, 4; jal ra, bgv_u32le\n" ++
   "  la t0, c1_er_input; ld t1, 0(t0); addi t2, t1, 12; addi t3, a0, -12\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
@@ -431,6 +431,9 @@ def statelessVerdictV2Function : String :=
   -- is resolved at the PRE-state (parent header). witness.state = svf_witness_section+off0 ..
   -- svf_codes_ptr; witness.codes = svf_codes_ptr/len.
   "  la t0, evm_env; ld t1, 448(t0); la t2, c1_saved_logcount; sd t1, 0(t2)\n" ++
+  -- 8uld3.2.3.3.1 Fix1: parse the block BAL at the requests_hash point (bsr_bal_start is the
+  -- block_state_root context's, 0 here). s0 is the BAL input (block_access_list_hash uses it @484).
+  "  mv a0, s0; la a1, c1_bal_start; la a2, c1_bal_len; la a3, c1_bal_count; jal ra, bal_section_info\n" ++
   -- == WITHDRAWAL (EIP-7002): code_at -> BAL preload -> system call -> copy body ==
   "  la t0, svf_witness; ld a3, 0(t0); la t0, svf_witness_len; ld a4, 0(t0)\n" ++
   "  la t0, svf_parent_rlp; ld a0, 0(t0); la t0, svf_parent_rlp_len; ld a1, 0(t0)\n" ++
@@ -440,7 +443,7 @@ def statelessVerdictV2Function : String :=
   "  bnez a0, .Lv2_requests_hash_fail\n" ++
   "  la t0, svf_codes_ptr; ld t1, 0(t0); la t2, cahsr_code_offset; ld t3, 0(t2); add t4, t1, t3\n" ++
   "  la t0, c1_wcode_ptr; sd t4, 0(t0); la t2, cahsr_code_length; ld t3, 0(t2); la t0, c1_wcode_len; sd t3, 0(t0)\n" ++
-  "  la t0, bsr_bal_start; ld a0, 0(t0); la t0, bsr_bal_len; ld a1, 0(t0)\n" ++
+  "  la t0, c1_bal_start; ld a0, 0(t0); la t0, c1_bal_len; ld a1, 0(t0)\n" ++
   "  la a2, withdrawal_request_predeploy_addr; la a3, c1_bal_acct_ptr; la a4, c1_bal_acct_len\n" ++
   "  jal ra, bal_find_account_by_address\n" ++
   "  bnez a0, .Lc1_w_nopreload\n" ++
@@ -476,7 +479,7 @@ def statelessVerdictV2Function : String :=
   "  bnez a0, .Lv2_requests_hash_fail\n" ++
   "  la t0, svf_codes_ptr; ld t1, 0(t0); la t2, cahsr_code_offset; ld t3, 0(t2); add t4, t1, t3\n" ++
   "  la t0, c1_ccode_ptr; sd t4, 0(t0); la t2, cahsr_code_length; ld t3, 0(t2); la t0, c1_ccode_len; sd t3, 0(t0)\n" ++
-  "  la t0, bsr_bal_start; ld a0, 0(t0); la t0, bsr_bal_len; ld a1, 0(t0)\n" ++
+  "  la t0, c1_bal_start; ld a0, 0(t0); la t0, c1_bal_len; ld a1, 0(t0)\n" ++
   "  la a2, consolidation_request_predeploy_addr; la a3, c1_bal_acct_ptr; la a4, c1_bal_acct_len\n" ++
   "  jal ra, bal_find_account_by_address\n" ++
   "  bnez a0, .Lc1_c_nopreload\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
@@ -431,9 +431,7 @@ def statelessVerdictV2Function : String :=
   -- is resolved at the PRE-state (parent header). witness.state = svf_witness_section+off0 ..
   -- svf_codes_ptr; witness.codes = svf_codes_ptr/len.
   "  la t0, evm_env; ld t1, 448(t0); la t2, c1_saved_logcount; sd t1, 0(t2)\n" ++
-  "  la t0, svf_witness_section; ld t1, 0(t0); mv a0, t1; jal ra, bgv_u32le\n" ++
-  "  la t0, svf_witness_section; ld t1, 0(t0); add a3, t1, a0\n" ++
-  "  la t0, svf_codes_ptr; ld t1, 0(t0); sub a4, t1, a3\n" ++
+  "  la t0, svf_witness; ld a3, 0(t0); la t0, svf_witness_len; ld a4, 0(t0)\n" ++
   "  la t0, svf_parent_rlp; ld a0, 0(t0); la t0, svf_parent_rlp_len; ld a1, 0(t0)\n" ++
   "  la a2, withdrawal_request_predeploy_addr\n" ++
   "  la t0, svf_codes_ptr; ld a5, 0(t0); la t0, svf_codes_len; ld a6, 0(t0)\n" ++
@@ -441,9 +439,7 @@ def statelessVerdictV2Function : String :=
   "  bnez a0, .Lv2_requests_hash_fail\n" ++
   "  la t0, svf_codes_ptr; ld t1, 0(t0); la t2, cahsr_code_offset; ld t3, 0(t2); add t4, t1, t3\n" ++
   "  la t0, c1_wcode_ptr; sd t4, 0(t0); la t2, cahsr_code_length; ld t3, 0(t2); la t0, c1_wcode_len; sd t3, 0(t0)\n" ++
-  "  la t0, svf_witness_section; ld t1, 0(t0); mv a0, t1; jal ra, bgv_u32le\n" ++
-  "  la t0, svf_witness_section; ld t1, 0(t0); add a3, t1, a0\n" ++
-  "  la t0, svf_codes_ptr; ld t1, 0(t0); sub a4, t1, a3\n" ++
+  "  la t0, svf_witness; ld a3, 0(t0); la t0, svf_witness_len; ld a4, 0(t0)\n" ++
   "  la t0, svf_parent_rlp; ld a0, 0(t0); la t0, svf_parent_rlp_len; ld a1, 0(t0)\n" ++
   "  la a2, consolidation_request_predeploy_addr\n" ++
   "  la t0, svf_codes_ptr; ld a5, 0(t0); la t0, svf_codes_len; ld a6, 0(t0)\n" ++

--- a/EvmAsm/Codegen/Programs/EvmDispatchUnits.lean
+++ b/EvmAsm/Codegen/Programs/EvmDispatchUnits.lean
@@ -100,6 +100,7 @@ def ziskStageSystemCallProbeUnit : BuildUnit := {
     emitRuntimeDispatcherDataSection tinyInterpRegistry ++ "\n" ++
     ".balign 8\n" ++
     "scc_ctx:\n  .zero 192\n" ++
+    "scc_preload_ptr:\n  .zero 8\nscc_preload_count:\n  .zero 8\n" ++
     ".balign 8\n" ++
     "scc_system_addr:\n" ++
     "  .byte 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff\n" ++
@@ -182,6 +183,7 @@ def ziskDeriveWithdrawalRequestsProbeUnit : BuildUnit := {
     emitRuntimeDispatcherDataSection tinyInterpRegistry ++ "\n" ++
     ".balign 8\n" ++
     "scc_ctx:\n  .zero 192\n" ++
+    "scc_preload_ptr:\n  .zero 8\nscc_preload_count:\n  .zero 8\n" ++
     ".balign 8\n" ++
     "scc_system_addr:\n" ++
     "  .byte 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff\n" ++
@@ -262,6 +264,7 @@ def ziskDeriveConsolidationRequestsProbeUnit : BuildUnit := {
     emitRuntimeDispatcherDataSection tinyInterpRegistry ++ "\n" ++
     ".balign 8\n" ++
     "scc_ctx:\n  .zero 192\n" ++
+    "scc_preload_ptr:\n  .zero 8\nscc_preload_count:\n  .zero 8\n" ++
     ".balign 8\n" ++
     "scc_system_addr:\n" ++
     "  .byte 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff\n" ++
@@ -368,6 +371,7 @@ def ziskDeriveRequestsHashE2EProbeUnit : BuildUnit := {
     emitRuntimeDispatcherDataSection tinyInterpRegistry ++ "\n" ++
     ".balign 8\n" ++
     "scc_ctx:\n  .zero 192\n" ++
+    "scc_preload_ptr:\n  .zero 8\nscc_preload_count:\n  .zero 8\n" ++
     ".balign 8\n" ++
     "scc_system_addr:\n" ++
     "  .byte 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff\n" ++
@@ -457,6 +461,7 @@ def ziskDeriveBlockSystemRequestsProbeUnit : BuildUnit := {
     emitRuntimeDispatcherDataSection tinyInterpRegistry ++ "\n" ++
     ".balign 8\n" ++
     "scc_ctx:\n  .zero 192\n" ++
+    "scc_preload_ptr:\n  .zero 8\nscc_preload_count:\n  .zero 8\n" ++
     ".balign 8\n" ++
     "scc_system_addr:\n" ++
     "  .byte 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff\n" ++

--- a/EvmAsm/Codegen/Programs/StatelessGuest.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuest.lean
@@ -21,6 +21,7 @@ import EvmAsm.Codegen.Programs.StatelessGuestEpilogue
 import EvmAsm.Codegen.Programs.BlockVerdictV2
 import EvmAsm.Codegen.Programs.SystemCallStaging
 import EvmAsm.Codegen.Programs.ParseDepositRequests
+import EvmAsm.Codegen.Programs.AssembleExecutionRequests
 import EvmAsm.Stateless.Entry
 
 namespace EvmAsm.Codegen
@@ -75,6 +76,9 @@ def statelessGuestUnit : BuildUnit := {
     -- replaces the SSZ-deposits trust (BlockVerdictStateRoot.lean:430-445) with derivation.
     parseDepositRequestsFunction ++ "\n" ++
     extractDepositDataFunction ++ "\n" ++
+    -- 8uld3.2.3.3.1 (C.1): assemble [deposit, derived-w, derived-c] into the SSZ
+    -- execution_requests section that execution_requests_hash then hashes.
+    assembleExecutionRequestsFunction ++ "\n" ++
     ".Lstateless_guest_halt_after_runtime_dispatcher:\n"
   -- guest scratch + the Step-2 verdict's data (zk3_state / rfu_* are dedup'd out
   -- of the guest section since the appended verdict section provides them). The

--- a/EvmAsm/Codegen/Programs/StatelessGuest.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuest.lean
@@ -22,6 +22,7 @@ import EvmAsm.Codegen.Programs.BlockVerdictV2
 import EvmAsm.Codegen.Programs.SystemCallStaging
 import EvmAsm.Codegen.Programs.ParseDepositRequests
 import EvmAsm.Codegen.Programs.AssembleExecutionRequests
+import EvmAsm.Codegen.Programs.SystemCallStoragePreload
 import EvmAsm.Stateless.Entry
 
 namespace EvmAsm.Codegen
@@ -79,6 +80,10 @@ def statelessGuestUnit : BuildUnit := {
     -- 8uld3.2.3.3.1 (C.1): assemble [deposit, derived-w, derived-c] into the SSZ
     -- execution_requests section that execution_requests_hash then hashes.
     assembleExecutionRequestsFunction ++ "\n" ++
+    -- 8uld3.2.3.3.1 (C.1): stage the system-call predeploy's request-queue storage so its
+    -- SLOAD reads real witness values (builds the (key,original-value) preload from the
+    -- predeploy's BAL AccountChanges). Fed to the system call via scc_preload_ptr/count (8uld3.2.1.5).
+    stagePredeployStoragePreloadFunction ++ "\n" ++
     ".Lstateless_guest_halt_after_runtime_dispatcher:\n"
   -- guest scratch + the Step-2 verdict's data (zk3_state / rfu_* are dedup'd out
   -- of the guest section since the appended verdict section provides them). The
@@ -118,6 +123,7 @@ def statelessGuestUnit : BuildUnit := {
     ".balign 8\n" ++
     "pdr_out:\n  .zero 2048\n" ++
     "pdr_status:\n  .zero 8\n" ++
+    stagePredeployStoragePreloadData ++ "\n" ++   -- 8uld3.2.3.3.1 (C.1): sps_* globals for the predeploy storage preload
     emitRuntimeDispatcherDataSectionSharedGuest callFrameGuestRegistry
 }
 

--- a/EvmAsm/Codegen/Programs/StatelessGuest.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuest.lean
@@ -91,6 +91,7 @@ def statelessGuestUnit : BuildUnit := {
     -- are already present). scc_ctx/scc_system_addr/ssc_saved_* are inline-only in the probes.
     ".balign 8\n" ++
     "scc_ctx:\n  .zero 192\n" ++
+    "scc_preload_ptr:\n  .zero 8\nscc_preload_count:\n  .zero 8\n" ++
     ".balign 8\n" ++
     "scc_system_addr:\n" ++
     "  .byte 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff\n" ++

--- a/EvmAsm/Codegen/Programs/SystemCallStaging.lean
+++ b/EvmAsm/Codegen/Programs/SystemCallStaging.lean
@@ -56,7 +56,11 @@ def stageSystemCallPayloadFunction : String :=
   "  lbu t4, 0(t2); sb t4, 0(t1); addi t2, t2, 1; addi t1, t1, 1; addi t3, t3, -1; j .Lscc_recip\n" ++
   ".Lscc_recip_d:\n" ++
   -- stage_runtime_payload_code(ctx, out, exec, code, codelen, null, 0)
-  "  la a0, scc_ctx\n  mv a1, s4\n  mv a2, s3\n  mv a3, s1\n  mv a4, s2\n  li a5, 0\n  li a6, 0\n" ++
+  -- 8uld3.2.1.5: pass the predeploy STORAGE preload (a5/a6) so the predeploy's SLOAD of its
+  -- request queue reads the staged witness values (not garbage). scc_preload_ptr/count default
+  -- to 0 (empty-storage behavior, unchanged) unless the caller stages a preload first.
+  "  la a0, scc_ctx\n  mv a1, s4\n  mv a2, s3\n  mv a3, s1\n  mv a4, s2\n" ++
+  "  la t0, scc_preload_ptr; ld a5, 0(t0); la t0, scc_preload_count; ld a6, 0(t0)\n" ++
   "  jal ra, stage_runtime_payload_code\n" ++
   "  bnez a0, .Lscc_ret\n" ++                        -- unsupported -> propagate
   -- CALLER (env_base+64) + ORIGIN (env_base+128) = SYSTEM_ADDRESS (mirror 3vc2p.1).
@@ -278,6 +282,7 @@ def ziskStageSystemCallPayloadDataSection : String :=
   ".section .data\n" ++
   ".balign 8\n" ++
   "scc_ctx:\n  .zero 192\n" ++
+  "scc_preload_ptr:\n  .zero 8\nscc_preload_count:\n  .zero 8\n" ++
   ".balign 8\n" ++
   "scc_system_addr:\n" ++   -- SYSTEM_ADDRESS 0xfffffffffffffffffffffffffffffffffffffffe (20B BE)
   "  .byte 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff\n" ++

--- a/EvmAsm/Codegen/Programs/SystemCallStaging.lean
+++ b/EvmAsm/Codegen/Programs/SystemCallStaging.lean
@@ -64,17 +64,23 @@ def stageSystemCallPayloadFunction : String :=
   "  jal ra, stage_runtime_payload_code\n" ++
   "  bnez a0, .Lscc_ret\n" ++                        -- unsupported -> propagate
   -- CALLER (env_base+64) + ORIGIN (env_base+128) = SYSTEM_ADDRESS (mirror 3vc2p.1).
+  -- 8uld3.2.3.3.1 Fix4: write the 20 address bytes BYTE-REVERSED (dst byte 19-i <- src byte i).
+  -- `evm_env_load` copies the env word VERBATIM as 4 little-endian limbs to the EVM stack, so an
+  -- address must sit in env in little-endian (LSB at +0), right-aligned. The big-endian write
+  -- (mirrored from 3vc2p.1, which is INERT — self-contained mtx recipients never run CALLER) made
+  -- the 7002/7251 predeploy see caller != SYSTEM and return the fee-getter result instead of
+  -- processing the queue. Same BE->LE class as the storage preload (#8694).
   "  la t5, srpc_env_base; ld t1, 0(t5)\n" ++
   "  add t2, s4, t1\n" ++                            -- t2 = &env_words
   "  la t3, scc_system_addr; addi t4, t2, 64; li t5, 0\n" ++
   ".Lscc_caller:\n" ++
   "  li t6, 20; beq t5, t6, .Lscc_caller_d\n" ++
-  "  add a5, t3, t5; lbu a6, 0(a5); add a5, t4, t5; sb a6, 0(a5); addi t5, t5, 1; j .Lscc_caller\n" ++
+  "  add a5, t3, t5; lbu a6, 0(a5); li a5, 19; sub a5, a5, t5; add a5, t4, a5; sb a6, 0(a5); addi t5, t5, 1; j .Lscc_caller\n" ++
   ".Lscc_caller_d:\n" ++
   "  addi t4, t2, 128; li t5, 0\n" ++
   ".Lscc_origin:\n" ++
   "  li t6, 20; beq t5, t6, .Lscc_origin_d\n" ++
-  "  add a5, t3, t5; lbu a6, 0(a5); add a5, t4, t5; sb a6, 0(a5); addi t5, t5, 1; j .Lscc_origin\n" ++
+  "  add a5, t3, t5; lbu a6, 0(a5); li a5, 19; sub a5, a5, t5; add a5, t4, a5; sb a6, 0(a5); addi t5, t5, 1; j .Lscc_origin\n" ++
   ".Lscc_origin_d:\n" ++
   "  li a0, 0\n" ++
   ".Lscc_ret:\n" ++

--- a/EvmAsm/Codegen/Programs/SystemCallStoragePreload.lean
+++ b/EvmAsm/Codegen/Programs/SystemCallStoragePreload.lean
@@ -37,15 +37,29 @@ open EvmAsm.Rv64
     returned so the caller bails conservatively). -/
 def stagePredeployStoragePreloadFunction : String :=
   "stage_predeploy_storage_preload:\n" ++
-  "  addi sp, sp, -48\n" ++
+  "  addi sp, sp, -64\n" ++
   "  sd ra, 0(sp)\n" ++
   "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  sd s5, 48(sp); sd s6, 56(sp)\n" ++
   "  mv s0, a2                    # out ptr\n" ++
-  -- bal_recipient_storage_keys(AccountChanges, len, sps_keys) -> count
+  "  mv s5, a0                    # AccountChanges ptr (kept for the reads pass)\n" ++
+  "  mv s6, a1                    # AccountChanges len\n" ++
+  -- bal_recipient_storage_keys(AccountChanges, len, sps_keys) -> changes-slot count
   "  la a2, sps_keys\n" ++
   "  jal ra, bal_recipient_storage_keys\n" ++
-  "  mv s1, a0                    # slot count\n" ++
-  "  li t0, 128\n  bgtu s1, t0, .Lspsp_done\n" ++   -- >128: bail (write nothing, return count)
+  "  mv s1, a0                    # changes-slot count\n" ++
+  "  li t0, 128\n  bgtu s1, t0, .Lspsp_done\n" ++   -- >128 changes: bail (write nothing, return count)
+  -- 8uld3.2.3.3.1 Fix2: ALSO stage the predeploy's storage_READS (AccountChanges item 2).
+  -- A no-requests predeploy reads the queue head/tail/count slots it never writes, so a
+  -- changes-only preload leaves those SLOADs reading garbage (the e0010046 unmapped-read
+  -- crash). Append the reads keys after the changes keys; the loop below stages a real
+  -- pre-block value for each. (a0/a1 were clobbered by the changes call; restore from s5/s6.)
+  "  mv a0, s5; mv a1, s6\n" ++
+  "  slli t0, s1, 5; la t1, sps_keys; add a2, t1, t0   # &sps_keys[changes_count]\n" ++
+  "  li t0, 128; sub a3, t0, s1                         # remaining capacity\n" ++
+  "  jal ra, bal_recipient_storage_reads_keys\n" ++
+  "  add s1, s1, a0                                     # total = changes + reads\n" ++
+  "  li t0, 128\n  bgtu s1, t0, .Lspsp_done\n" ++   -- combined >128: bail
   "  li s2, 0                     # i\n" ++
   ".Lspsp_loop:\n" ++
   "  beq s2, s1, .Lspsp_done\n" ++
@@ -77,7 +91,8 @@ def stagePredeployStoragePreloadFunction : String :=
   "  mv a0, s1\n" ++
   "  ld ra, 0(sp)\n" ++
   "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
-  "  addi sp, sp, 48\n" ++
+  "  ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
   "  ret"
 
 /-- Globals for `stage_predeploy_storage_preload` (caller-set witness/header pointers +

--- a/EvmAsm/Codegen/Programs/SystemCallStoragePreload.lean
+++ b/EvmAsm/Codegen/Programs/SystemCallStoragePreload.lean
@@ -60,6 +60,27 @@ def stagePredeployStoragePreloadFunction : String :=
   "  jal ra, bal_recipient_storage_reads_keys\n" ++
   "  add s1, s1, a0                                     # total = changes + reads\n" ++
   "  li t0, 128\n  bgtu s1, t0, .Lspsp_done\n" ++   -- combined >128: bail
+  -- Fix6 pre-pass: sps_sysidx = MAX block_access_index across the predeploy's changed slots.
+  -- The block-end system call is the last writer, so its index is this max; a slot's pre-system
+  -- value (what the predeploy reads) is the last change tuple with index < sps_sysidx.
+  "  la t0, sps_sysidx; sd zero, 0(t0)\n" ++
+  "  li s2, 0\n" ++
+  ".Lspsp_pre:\n" ++
+  "  beq s2, s1, .Lspsp_pred\n" ++
+  "  slli t0, s2, 5; la t1, sps_keys; add a2, t1, t0\n" ++
+  "  mv a0, s5; mv a1, s6; la a3, sps_tuples\n" ++
+  "  jal ra, bal_slot_tuple_sequence\n" ++
+  "  li t0, 0\n" ++
+  ".Lspsp_premax:\n" ++
+  "  beq t0, a0, .Lspsp_premaxd\n" ++
+  "  slli t1, t0, 5; slli t6, t0, 3; add t1, t1, t6; la t2, sps_tuples; add t2, t2, t1\n" ++
+  "  ld t3, 0(t2); la t4, sps_sysidx; ld t5, 0(t4); bleu t3, t5, .Lspsp_prenext\n" ++
+  "  sd t3, 0(t4)\n" ++
+  ".Lspsp_prenext:\n" ++
+  "  addi t0, t0, 1; j .Lspsp_premax\n" ++
+  ".Lspsp_premaxd:\n" ++
+  "  addi s2, s2, 1; j .Lspsp_pre\n" ++
+  ".Lspsp_pred:\n" ++
   "  li s2, 0                     # i\n" ++
   ".Lspsp_loop:\n" ++
   "  beq s2, s1, .Lspsp_done\n" ++
@@ -74,6 +95,33 @@ def stagePredeployStoragePreloadFunction : String :=
   "  li t1, 32; beq t0, t1, .Lspsp_krevd\n" ++
   "  add t2, s3, t0; lbu t3, 0(t2); li t4, 31; sub t4, t4, t0; add t4, s4, t4; sb t3, 0(t4); addi t0, t0, 1; j .Lspsp_krev\n" ++
   ".Lspsp_krevd:\n" ++
+  -- 8uld3.2.3.3.1 Fix6: the system call runs at block END (it is the LAST writer of these slots,
+  -- so its block_access_index is the MAX across the predeploy's changes — empirically the 7002
+  -- reset lands at the max index, e.g. (idx 1, val 1) then (idx 2, val 0)). The value the predeploy
+  -- READS for a slot = the last BAL storage_changes tuple with index < the system index (sps_sysidx,
+  -- = that global max, computed in the pre-pass above). Fall back to the pre-block MPT value when a
+  -- slot has no pre-system change (only system-written: queue head/excess read pre-state).
+  "  mv a0, s5; mv a1, s6; mv a2, s3; la a3, sps_tuples\n" ++
+  "  jal ra, bal_slot_tuple_sequence\n" ++         -- a0 = tuple count (0 if slot absent)
+  "  li t0, 0\n" ++                                 -- j
+  "  li t5, 0\n" ++                                 -- found new_value ptr (0 = none)
+  "  la t4, sps_sysidx; ld t4, 0(t4)\n" ++          -- t4 = system-call index (global max)
+  ".Lspsp_tscan:\n" ++
+  "  beq t0, a0, .Lspsp_tscand\n" ++
+  "  slli t1, t0, 5; slli t6, t0, 3; add t1, t1, t6; la t2, sps_tuples; add t2, t2, t1\n" ++   -- &rec[j] (40B)
+  "  ld t3, 0(t2); bgeu t3, t4, .Lspsp_tnext\n" ++  -- skip the system write (index >= sysidx)
+  "  addi t5, t2, 8\n" ++                           -- found = &new_value (last pre-system write wins)
+  ".Lspsp_tnext:\n" ++
+  "  addi t0, t0, 1; j .Lspsp_tscan\n" ++
+  ".Lspsp_tscand:\n" ++
+  "  beqz t5, .Lspsp_mptval\n" ++                   -- no regular-tx change -> pre-block MPT value
+  "  li t0, 0\n" ++                                 -- reverse found new_value (32B BE) -> out[i][32:64] LE
+  ".Lspsp_tvrev:\n" ++
+  "  li t1, 32; beq t0, t1, .Lspsp_tvrevd\n" ++
+  "  add t2, t5, t0; lbu t3, 0(t2); li t4, 63; sub t4, t4, t0; add t4, s4, t4; sb t3, 0(t4); addi t0, t0, 1; j .Lspsp_tvrev\n" ++
+  ".Lspsp_tvrevd:\n" ++
+  "  j .Lspsp_next\n" ++
+  ".Lspsp_mptval:\n" ++
   -- slot_at_header_state_root(header, header_len, predeploy_addr, &key[i], state, state_len, storage, storage_len)
   "  la t0, sps_header; ld a0, 0(t0)\n" ++
   "  la t0, sps_header_len; ld a1, 0(t0)\n" ++
@@ -109,6 +157,9 @@ def stagePredeployStoragePreloadFunction : String :=
 def stagePredeployStoragePreloadData : String :=
   ".balign 8\n" ++
   "sps_keys:\n  .zero 4096\n" ++       -- 128 x 32-byte slot keys
+  ".balign 8\n" ++
+  "sps_tuples:\n  .zero 20480\n" ++    -- Fix6: 512 x 40-byte (block_access_index, new_value) tuples per slot
+  "sps_sysidx:\n  .zero 8\n" ++        -- Fix6: system-call block_access_index (= max change index)
   ".balign 8\n" ++
   "sps_addr:\n  .zero 32\n" ++         -- predeploy address (20B, padded)
   "sps_header:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/SystemCallStoragePreload.lean
+++ b/EvmAsm/Codegen/Programs/SystemCallStoragePreload.lean
@@ -65,9 +65,15 @@ def stagePredeployStoragePreloadFunction : String :=
   "  beq s2, s1, .Lspsp_done\n" ++
   "  slli t0, s2, 5; la t1, sps_keys; add s3, t1, t0   # s3 = &key[i] (32B)\n" ++
   "  slli t0, s2, 6; add s4, s0, t0                     # s4 = &out[i] (64B stride)\n" ++
-  -- copy key (32B) -> out[i][0..32]
-  "  ld a5, 0(s3); sd a5, 0(s4); ld a5, 8(s3); sd a5, 8(s4)\n" ++
-  "  ld a5, 16(s3); sd a5, 16(s4); ld a5, 24(s3); sd a5, 24(s4)\n" ++
+  -- 8uld3.2.3.3.1 Fix5: write the preload KEY byte-reversed (BE->LE: dst[31-i]<-src[i]) so the
+  -- dispatcher's SLOAD (little-endian-limb stack key) matches. sps_keys stays BE for the MPT
+  -- lookup (a3) below. Without this, non-zero queue slots were invisible (SLOAD miss -> 0), so a
+  -- non-empty queue derived an EMPTY body -> requests_hash mismatch. Same BE->LE class as #8694.
+  "  li t0, 0\n" ++
+  ".Lspsp_krev:\n" ++
+  "  li t1, 32; beq t0, t1, .Lspsp_krevd\n" ++
+  "  add t2, s3, t0; lbu t3, 0(t2); li t4, 31; sub t4, t4, t0; add t4, s4, t4; sb t3, 0(t4); addi t0, t0, 1; j .Lspsp_krev\n" ++
+  ".Lspsp_krevd:\n" ++
   -- slot_at_header_state_root(header, header_len, predeploy_addr, &key[i], state, state_len, storage, storage_len)
   "  la t0, sps_header; ld a0, 0(t0)\n" ++
   "  la t0, sps_header_len; ld a1, 0(t0)\n" ++
@@ -79,9 +85,12 @@ def stagePredeployStoragePreloadFunction : String :=
   "  la t0, sps_storage_len; ld a7, 0(t0)\n" ++
   "  jal ra, slot_at_header_state_root\n" ++
   "  bnez a0, .Lspsp_zero\n" ++                   -- lookup failed -> value 0 (conservative)
-  "  la t1, sahsr_u256; addi t2, s4, 32\n" ++
-  "  ld a5, 0(t1); sd a5, 0(t2); ld a5, 8(t1); sd a5, 8(t2)\n" ++
-  "  ld a5, 16(t1); sd a5, 16(t2); ld a5, 24(t1); sd a5, 24(t2)\n" ++
+  -- Fix5: value BE->LE reversed into out[i][32..64] (dst[63-i]<-src[i]).
+  "  la t5, sahsr_u256; li t0, 0\n" ++
+  ".Lspsp_vrev:\n" ++
+  "  li t1, 32; beq t0, t1, .Lspsp_vrevd\n" ++
+  "  add t2, t5, t0; lbu t3, 0(t2); li t4, 63; sub t4, t4, t0; add t4, s4, t4; sb t3, 0(t4); addi t0, t0, 1; j .Lspsp_vrev\n" ++
+  ".Lspsp_vrevd:\n" ++
   "  j .Lspsp_next\n" ++
   ".Lspsp_zero:\n" ++
   "  addi t2, s4, 32; sd zero, 0(t2); sd zero, 8(t2); sd zero, 16(t2); sd zero, 24(t2)\n" ++


### PR DESCRIPTION
## Summary

Sound EIP-7002/7251 request derivation: instead of trusting the SSZ-input `execution_requests`, the verdict now **executes the real withdrawal/consolidation predeploys** at the requests_hash point and hashes their derived bodies. Stacked on #8702 (B) → #8700 (A).

**⚠️ DRAFT — REQUIRES EEST SWEEP, and REQUIRES Fix6 before merge** (see Remaining). As-is this would false-reject non-empty-queue 7002/7251 rows, so it must not merge until Fix6 lands.

## Verified results (ziskemu, this branch)
- `bal_7002_no_withdrawal_requests` → **FULL 105-byte MATCH**
- `bal_7002_request_invalid` ×4 (contract_reverts / insufficient_fee / invalid_call_type_callcode / _delegatecall) → **FULL MATCH**
- **30/30 random general (non-requests) rows → FULL MATCH** (no regression from running the predeploys every block)

## The fix chain (this PR's commits)
- **Fix1** parse the block BAL at the requests_hash point (`bsr_bal_start`=0 there → null-BAL lookup); `bal_section_info(s0)` → predeploy found.
- **Fix2** stage the predeploy's storage **reads** (BAL AccountChanges item 2), not just changes — the queue head/tail/count slots it reads but never writes.
- **Fix3** reload `s0`/`s3` clobbered by the derives' `runtime_dispatcher_call` (the previously-mysterious `Mem::read 0xe0010046` crash was this register clobber in the deposit-extraction, not the substrate).
- **Fix4 (keystone)** byte-reverse the SYSTEM **CALLER/ORIGIN** (BE→LE). `evm_env_load` copies the env word verbatim as little-endian limbs to the stack, so a big-endian caller made the predeploy see `caller != SYSTEM` and return its **fee-getter** result (`0x..01`) instead of processing the queue. The mtx never hit this — its self-contained recipients are `bytecode_is_self_contained`-rejected from running CALLER, so the 7002 predeploy is the first contract to actually execute the CALLER opcode.
- **Fix5** byte-reverse the storage preload (key+value, BE→LE) to match the dispatcher SLOAD (#8694 class).

## Remaining before merge — Fix6 (deeper, bmvmx.1.6 class)
Non-empty-queue rows (`bal_7002_request_from_contract`, where a tx adds the request mid-block) still false-reject. The system call runs at **block end** and must see **post-tx** storage (the request the tx wrote), but `stage_predeploy_storage_preload` stages the **pre-block** value (`slot_at_header_state_root` on the parent header) = 0 → predeploy sees an empty queue → empty derived body ≠ the SSZ body. Fix: for changed slots, stage the BAL `storage_changes` new_value before the system tx_index (not the pre-block MPT value); read-only slots keep the pre-block value.

Deposits (.3.3.3) remain SSZ-trusted (blocked on receipts/log materialization, .3.3.2).

Refs #8700, #8702. Bead: evm-asm-8uld3.2.3.3.1.

Authored by @pirapira; implemented by Claude Code