### PR TITLE
fix(verdict): mtx committed-value threading slotKey BE->LE (ogjan)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -790,6 +790,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bv_mtx_committed:\n  .zero 16384\n" ++
   "dtrc_recipkey:\n  .zero 32\n" ++
   "dtrc_threadval:\n  .zero 32\n" ++
+  "dtrc_slotkey_le:\n  .zero 32\n" ++   -- ogjan: LE byte-reverse of bvcd_keys[i] for the exec_log_latest_value slotKey match
   -- bmvmx.1.4.4: single-tx EOA settlement scalars precomputed before
   -- block_state_root (additive; no consumer yet -> verdict byte-identical).
   -- Consumed later by .4.1/.4.2 to build execution-derived sender/coinbase leaves.

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -286,7 +286,17 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  li t3, 20; beq t2, t3, .Ldtrc_rkeyd\n" ++
   "  add t3, t1, t2; lbu t4, 0(t3); la t5, dtrc_recipkey; add t5, t5, t2; sb t4, 0(t5); addi t2, t2, 1; j .Ldtrc_rkey\n" ++
   ".Ldtrc_rkeyd:\n" ++
-  "  la t0, bvcd_i; ld t1, 0(t0); slli t2, t1, 5; la t3, bvcd_keys; add a1, t3, t2   # a1 = slotKey ptr\n" ++
+  -- ogjan: bvcd_keys[i] is 32B BIG-endian (RLP), but bv_mtx_committed's slotKey@32 is LITTLE-
+  -- endian (EVM-stack limb order, preload-fed post-#8694/C.1). Byte-reverse it into dtrc_slotkey_le
+  -- so exec_log_latest_value's slotKey compare (a1 vs entry@32) matches the LE snapshot; else this
+  -- interacting-mtx committed-value threading silently no-ops (BE!=LE -> never found). The addrHash
+  -- (a0=dtrc_recipkey) stays BE-left-aligned -- it matches the snapshot addrHash@0 (env.ADDRESS,
+  -- BE, SLOAD self-match); reversing it too would BREAK the addrHash match.
+  "  la t0, bvcd_i; ld t1, 0(t0); slli t2, t1, 5; la t3, bvcd_keys; add t3, t3, t2  # &bvcd_keys[i] (BE)\n" ++
+  "  addi t3, t3, 31; la a1, dtrc_slotkey_le; li t4, 32\n" ++
+  ".Ldtrc_klr:\n  beqz t4, .Ldtrc_klrd\n  lbu t5, 0(t3); sb t5, 0(a1); addi t3, t3, -1; addi a1, a1, 1; addi t4, t4, -1; j .Ldtrc_klr\n" ++
+  ".Ldtrc_klrd:\n" ++
+  "  la a1, dtrc_slotkey_le                          # a1 = LE slotKey ptr\n" ++
   "  la a0, dtrc_recipkey; la a2, bv_mtx_committed; la t0, bv_mtx_committed_count; ld a3, 0(t0); la a4, dtrc_threadval\n" ++
   "  jal ra, exec_log_latest_value\n" ++
   "  beqz a0, .Ldtrc_nothread                       # no prior-tx committed value -> keep witness value\n" ++


### PR DESCRIPTION
## Summary
The interacting-multi-tx committed-value threading (`BlockVerdictDispatchTx`, `.6.5.3`) looks up a recipient slot's prior-tx committed value via `exec_log_latest_value(addrHash, slotKey)` against the `bv_mtx_committed` snapshot. It passed `a1 = bvcd_keys[i]` — the BAL slot key, **32-byte big-endian** (RLP) — but the snapshot's `slotKey@32` is **little-endian** (EVM-stack limb order, preload-fed post-#8694). So the BE key never matched the LE snapshot → `exec_log_latest_value` returned not-found → fell through `.Ldtrc_nothread` → the prior-tx committed value was **silently not threaded** (the verdict used the block-pre witness value). Same byte-order class as bmvmx.1.6.6 (#8705).

**Fix:** byte-reverse `bvcd_keys[i]` BE→LE into `dtrc_slotkey_le` before the call. The `addrHash` (`a0 = dtrc_recipkey`) stays **big-endian-left-aligned** — it matches the snapshot's `addrHash@0` (env.ADDRESS verbatim, BE, SLOAD self-match); reversing it too would *break* the addrHash match. Byte orders confirmed with c1 (who owns this `.6.3/.6.5.3` lane and handed me the bead).

Latent: the threading is only reached for interacting multi-tx (`bv_mtx_committed_count != 0`); single-tx/tx0 bail at `.Ldtrc_nothread`, so this is transparent today.

## Verification
- Live-path regression: `multi_transaction_gas_accounting` **16/16 full match** (threading inert for current rows). full `lake build` green; size/unimported/forbidden gates pass.
- Correct-by-construction: confirmed byte orders with c1 — slotKey@32 LE (preload-fed), addrHash@0 BE (env.ADDRESS). Mirrors the `bmvmx.1.6.6` / `bsme_krev` reversal.
- End-to-end EEST verification of the threaded path is gated on the interacting-mtx `.57.11.6.3` work (c1's lane); c1 will confirm there.

Refs #ogjan. Bead: evm-asm-ogjan.

Directed by @pirapira; implemented by Claude Code.