### PR TITLE
feat(verdict): activate SELFDESTRUCT(0xff) execution (ee21v)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictSelfContained.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictSelfContained.lean
@@ -74,9 +74,11 @@ def bytecodeIsSelfContainedFunction : String :=
   -- BLOCKHASH handler resolves through real execution.
   -- yisv8.2: SELFBALANCE(0x47) NO LONGER rejected (#8650); CREATE/CREATE2 NO LONGER rejected
   -- (#8649); EXTCODE*(0x3b/0x3c/0x3f) NO LONGER rejected (yisv8.2 part 2).
-  -- BALANCE(0x31) stays rejected (volatile balance, cross-account witness M31 needed);
-  -- SELFDESTRUCT(0xff) stays rejected (beneficiary state un-staged).
-  "  li t3, 0xff; beq t2, t3, .Lbsc_unsafe\n" ++   -- SELFDESTRUCT (beneficiary cold/warm + account-creation gas is un-staged)
+  -- BALANCE(0x31) stays rejected (volatile balance, cross-account witness M31 needed).
+  -- ee21v: SELFDESTRUCT(0xff) NO LONGER rejected -- selfdestructTailAsm already executes the
+  -- beneficiary access-gas charge (runtime_access_account_charge), new-account surcharge, balance
+  -- transfer, and EIP-7708 log; the beneficiary access state is staged like the EXTCODE*/yisv8.2
+  -- cross-account witness. (li t3, 0xff; beq t2, t3, .Lbsc_unsafe REMOVED.)
   "  addi t0, t0, 1; j .Lbsc_loop\n" ++
   ".Lbsc_safe:\n" ++
   "  li a0, 0; ret\n" ++


### PR DESCRIPTION
## Summary
Activates SELFDESTRUCT(0xff) execution in the verdict — removes it from the self-contained reject set so 0xff-containing contracts EXECUTE (sound) instead of bailing to BAL-replay trust. Closes `evm-asm-ee21v`.

**⚠️ DRAFT — REQUIRES EEST SWEEP** (self-contained reject-set / accept-path change).

## Why this is a one-line change
The SELFDESTRUCT *execution* handler is already fully built — `selfdestructTailAsm` (NoopHalt.lean:168) copies the beneficiary off the stack, charges `runtime_access_account_charge` (cold/warm beneficiary access gas), adds the new-account surcharge, does the balance transfer, emits the EIP-7708 log, and exits (halt kind 5). The beneficiary access state is staged via the same EXTCODE*/yisv8.2 cross-account witness path. 0xff was simply *gated off* at BlockVerdictSelfContained.lean:79 — like EXTCODE*/SELFBALANCE/CREATE before it. This PR removes that gate.

## Verified
`--filter selfdestruct`: **25/25 PASS(full)**, covering **both EIP-6780 branches**:
- `selfdestruct_same_tx_via_call` / `to_self_same_tx` / `to_different_address_same_tx` (created-this-tx → **deletes**)
- `selfdestruct_to_self_pre_existing_no_log` (pre-existing → **no delete**)
- `selfdestruct_finalization_after_priority_fee`

So EIP-6780 (delete only if created-this-tx) is honored, and these rows now pass via execution rather than trust.

Bead: evm-asm-ee21v.

Authored by @pirapira; implemented by Claude Code