### PR TITLE
fix(verdict): check_transaction nonce pre-validation tx.nonce==sender_pre_nonce (bmvmx.2)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -963,6 +963,18 @@ def blockVerdictFunction : String :=
   -- state-root check (which only validates the prover BAL against the prover header.state_root).
   -- Nonce is value-independent, so no coinbase gate is needed; an absent/oversized post nonce
   -- returns "skip" (2) and never rejects. A BAL post nonce != pre+1 is a prover lie -> reject.
+  -- bmvmx.2 (check_transaction nonce pre-validation): BEFORE the post check, verify the spec's
+  -- pre-condition tx.nonce == sender_pre_nonce (execution-specs amsterdam/fork.py check_transaction
+  -- raises NonceMismatchError otherwise). The post check (post == pre+1) only validates the BAL's
+  -- claimed EFFECT, not that the tx was nonce-ELIGIBLE to execute: an out-of-order tx (tx.nonce !=
+  -- pre, e.g. tx.nonce=7 with pre=3) carrying a BAL post=pre+1 would otherwise false-accept a block
+  -- the spec rejects. pre_nonce = tgbpvr_lookup[80] (the very value the post check reads as "pre");
+  -- tx.nonce = sttc_nonce (extracted by the simple_transfer context build, tx_extract_nonce_and_gas,
+  -- which ran before the gas_limit read above). Value-independent like the post check, so reuse the
+  -- same .Lbv_sender_nonce_fail. Transparent for valid in-order txs (tx.nonce == pre).
+  "  la t0, tgbpvr_lookup; ld t0, 80(t0)        # sender pre_nonce (witness-proven)\n" ++
+  "  la t1, sttc_nonce; ld t1, 0(t1)            # tx.nonce (consensus-bound)\n" ++
+  "  bne t0, t1, .Lbv_sender_nonce_fail         # tx.nonce != pre_nonce -> reject (NonceMismatchError)\n" ++
   "  la a0, tgbpvr_lookup; jal ra, sender_post_nonce_consistent\n" ++
   "  li t1, 1; beq a0, t1, .Lbv_sender_nonce_fail\n" ++
   -- bmvmx.1.6.3 (recipient balance slice): the contract recipient RECEIVES tx.value and, on this


### PR DESCRIPTION
## Summary
The stateless verdict verified the BAL **post**-state nonce effect (`post_nonce == sender_pre_nonce + 1`, via `sender_post_nonce_consistent`) but never the spec's `check_transaction` **pre**-condition `tx.nonce == sender.nonce` (execution-specs amsterdam/fork.py raises `NonceMismatchError` otherwise). The post check only validates the BAL's claimed *effect*, not that the tx was nonce-**eligible** to execute — so an out-of-order tx (e.g. `tx.nonce=7` with `sender_pre_nonce=3`) carrying a BAL `post_nonce=pre+1` would **false-accept** a block the spec rejects.

## Change
Adds the pre-validation immediately before the post check, on the simple-transfer EOA path where both operands are already in hand (`BlockVerdict.lean`):
- `pre_nonce = tgbpvr_lookup[80]` — witness-proven against `parent.state_root`; the very value the post check reads as "pre".
- `tx.nonce = sttc_nonce` — consensus-bound; extracted by the simple_transfer context build (`tx_extract_nonce_and_gas`), before the `gas_limit` read.
- On `tx.nonce != pre_nonce` → reject via the existing `.Lbv_sender_nonce_fail`.

Reject-only and value-independent → transparent for valid in-order txs (`tx.nonce == pre_nonce`).

## Verification — EEST sweep (self-run; operator no longer sweeps locally)
`codegen-eest-stateless-check.sh --random --seed 42 --limit 24 --jobs 2`:
```
selected: 24   ran: 24   errored: 0
full match: 24   (all 105 bytes)
succ match: 24   root match: 24   tail match: 24
fail: 0
```
24/24 full match — including `eip7708_eth_transfer_logs` ETH-transfer rows that exercise this path. A misaligned/garbage `sttc_nonce` or `tgbpvr_lookup` would have false-rejected those valid rows; full transparency confirms both operands are the correct, aligned values. Source gates (forbidden-tactics / file-size / unimported) clean; guest builds + runs.

## Scope
Nonce slice of **bmvmx.2** (filed by the bmvmx audit). The `sender_pre_balance >= gas_limit*max_fee + value` half (needs a 256-bit multiply) is a follow-up. Refs bmvmx.2.

Directed by @pirapira; implemented by Claude Code.