### PR TITLE
fix(verdict): check_transaction upfront-balance pre-validation (bmvmx.2)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -977,6 +977,33 @@ def blockVerdictFunction : String :=
   "  bne t0, t1, .Lbv_sender_nonce_fail         # tx.nonce != pre_nonce -> reject (NonceMismatchError)\n" ++
   "  la a0, tgbpvr_lookup; jal ra, sender_post_nonce_consistent\n" ++
   "  li t1, 1; beq a0, t1, .Lbv_sender_nonce_fail\n" ++
+  -- bmvmx.2 (check_transaction balance pre-validation): reject if
+  -- sender_pre_balance < gas_limit*max_fee_per_gas + tx.value (execution-specs
+  -- amsterdam/fork.py check_transaction raises InsufficientBalanceError). The
+  -- runtime verify only proves BAL post == pre - actual_debit and SKIPS (not
+  -- rejects) on insufficiency; the spec requires the sender cover the UPFRONT max
+  -- gas_limit*max_fee (>= the actual debit), so a tx funded between actual-debit
+  -- and upfront would otherwise false-accept. Operands all live here: max_fee =
+  -- tefgp_max_fee (written by tx_effective_gas_pricing inside the line-956 verify),
+  -- gas_limit = bv_simple_transfer_tx[40], value = bv_simple_transfer_tx[96] (BE),
+  -- pre_balance = tgbpvr_lookup[48] (BE). u256_mul_u64_be returns 1 on overflow
+  -- (a*b >= 2^256); u256_add_be returns carry-out; u256_lt_be writes 1 iff a<b.
+  "  la a0, tefgp_max_fee\n" ++
+  "  la t0, bv_simple_transfer_tx; ld a1, 40(t0)   # gas_limit (u64)\n" ++
+  "  la a2, bv_upfront_cost\n" ++
+  "  jal ra, u256_mul_u64_be\n" ++
+  "  bnez a0, .Lbv_sender_upfront_fail              # gas_limit*max_fee >= 2^256 -> reject\n" ++
+  "  la a0, bv_upfront_cost\n" ++
+  "  la t0, bv_simple_transfer_tx; addi a1, t0, 96  # tx.value (32B BE)\n" ++
+  "  la a2, bv_upfront_cost\n" ++
+  "  jal ra, u256_add_be\n" ++
+  "  bnez a0, .Lbv_sender_upfront_fail              # upfront cost + value >= 2^256 -> reject\n" ++
+  "  la a0, tgbpvr_lookup; addi a0, a0, 48          # sender pre_balance (32B BE)\n" ++
+  "  la a1, bv_upfront_cost\n" ++
+  "  la a2, bv_upfront_islt\n" ++
+  "  jal ra, u256_lt_be\n" ++
+  "  la t0, bv_upfront_islt; ld t0, 0(t0)\n" ++
+  "  bnez t0, .Lbv_sender_upfront_fail              # pre_balance < upfront -> reject\n" ++
   -- bmvmx.1.6.3 (recipient balance slice): the contract recipient RECEIVES tx.value and, on this
   -- value-movement-free path (no CALL/CALLCODE/DELEGATECALL/SELFDESTRUCT; CREATE is self-contained-
   -- rejected), its balance changes only by +value, so recipient_post == recipient_pre + value.
@@ -1186,6 +1213,8 @@ def blockVerdictFunction : String :=
   "  li t0, 45; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_bal_code_consistent_fail:\n" ++    -- i3djw.4: a BAL account's declared code change != exec code-effect (and not a 7702 delegation)
   "  li t0, 46; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
+  ".Lbv_sender_upfront_fail:\n" ++         -- bmvmx.2: sender_pre_balance < gas_limit*max_fee + value (InsufficientBalanceError)
+  "  li t0, 48; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_zero:\n" ++
   "  li a0, 0\n" ++
   ".Lbv_ret:\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -954,6 +954,13 @@ def ziskStatelessVerdictV2DataSection : String :=
   "tgbpvr_lookup:\n  .zero 168\n" ++
   ".balign 8\n" ++
   "bv_sender_bal_check:\n  .zero 192\n" ++
+  -- bmvmx.2: scratch for the check_transaction upfront-balance pre-validation
+  -- (sender_pre_balance >= gas_limit*max_fee_per_gas + tx.value). bv_upfront_cost
+  -- holds max_fee*gas_limit then (+ value) the upfront cost; bv_upfront_islt the
+  -- u256_lt_be verdict (1 iff pre_balance < upfront -> reject).
+  ".balign 8\n" ++
+  "bv_upfront_cost:\n  .zero 32\n" ++
+  "bv_upfront_islt:\n  .zero 8\n" ++
   -- bmvmx.1.6.6: scratch for the all-accounts per-slot tuple-sequence check (#8606). batsc_* is
   -- the wrapper's own scratch; the sub-helpers' scratch (atsc_*/bts_*/els_*) come from their Data
   -- defs. rfu_* (rlp_field_to_u64) is already provided above; slot_tuple_sequences_match is


### PR DESCRIPTION
## Summary
Completes **bmvmx.2** (the nonce slice #8712 is merged). The verdict checked the BAL post-balance *effect* (`post == pre - actual_debit`), but the runtime verify only proves that and **skips** (not rejects) on insufficiency — so it never enforced the spec's `check_transaction` **pre**-condition `sender.balance >= tx.gas·max_fee_per_gas + tx.value` (execution-specs amsterdam/fork.py raises `InsufficientBalanceError`). The upfront max (`gas_limit·max_fee`) is ≥ the actual debit, so a tx funded **between actual-debit and upfront** would false-accept a block the spec rejects.

## Change (`BlockVerdict.lean`, after the nonce pre-check)
All operands live on the simple-transfer EOA path:
- `max_fee_per_gas = tefgp_max_fee` (written by `tx_effective_gas_pricing` inside the line-956 runtime verify)
- `gas_limit = bv_simple_transfer_tx[40]`; `value = bv_simple_transfer_tx[96]` (BE)
- `pre_balance = tgbpvr_lookup[48]` (BE; witness-proven)

`upfront = max_fee·gas_limit` (`u256_mul_u64_be`; **reject on its overflow flag** = product ≥ 2²⁵⁶) `+ value` (`u256_add_be`; **reject on carry-out**); then **reject** via the new `.Lbv_sender_upfront_fail` (`bv_fail_code 48`) when `pre_balance < upfront` (`u256_lt_be`). Overflow on either wide op ⇒ upfront > 2²⁵⁶ > any balance ⇒ sound reject. All three u256 helpers are already linked in the verdict (BlockVerdict.lean:1309-1315).

## Verification — EEST sweep (self-run; operator no longer sweeps locally)
`codegen-eest-stateless-check.sh --random --seed 42 --limit 24 --jobs 2`, run on the branch **after merging current `main`** (incl. #8711 selfdestruct activation):
```
selected: 24   ran: 24   errored: 0
full match: 24   succ: 24   root: 24   tail: 24
fail: 0
```
24/24 full match — incl. `eip7708_eth_transfer_logs` rows that exercise this path. Reject-only and transparent for valid (funded) txs; a misaligned operand would have false-rejected them. Source + size/unimported gates clean; guest builds + links.

## Scope
Balance slice of **bmvmx.2**. With the merged nonce slice #8712, this closes bmvmx.2's two `check_transaction` pre-validations; the sender-key recovery is the separate, secp256k1-gated **bmvmx.3**. Refs bmvmx.2.

Directed by @pirapira; implemented by Claude Code.