### PR TITLE
fix(verdict): bound system-call staging + storage preload so oversized predeploys can't clobber .data (.66.1)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictContractStorage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictContractStorage.lean
@@ -27,10 +27,10 @@ open EvmAsm.Rv64
 
     Calling convention:
       a0 = AccountChanges RLP ptr   a1 = AccountChanges RLP length
-      a2 = out keys ptr (count x 32-byte big-endian slot keys; caller buffer must hold 128)
+      a2 = out keys ptr (count x 32-byte big-endian slot keys; caller buffer must hold 512)
     Returns:
       a0 = entry count (0 on parse failure — conservative). Keys are written only when
-           the count is <= 128 (the caller-buffer cap); if it exceeds 128, NOTHING is
+           the count is <= 512 (the caller-buffer cap); if it exceeds 512, NOTHING is
            written and the true count is returned so the caller can bail conservatively.
 
     Reads item 1 (storage_changes) of the AccountChanges list; for each entry,
@@ -54,11 +54,16 @@ def balRecipientStorageKeysFunction : String :=
   "  jal ra, rlp_list_count_items\n" ++
   "  bnez a0, .Lbrsk_fail\n" ++
   "  la t0, brsk_cnt; ld s5, 0(t0)                   # entry count\n" ++
-  -- bmvmx.1.7.3: cap the write at 128 slots (the caller buffers: bvcd_keys/bvcd_preload
-  -- and csce_keys are all sized for 128). If the BAL declares MORE storage_changes than
-  -- fit, write NOTHING and return the true count so the caller bails conservatively
-  -- (.Ldtrc_unsupported / skip-account) instead of overflowing into adjacent .data.
-  "  li t0, 128; bgtu s5, t0, .Lbrsk_done            # count > cap -> return count, write nothing\n" ++
+  -- bmvmx.1.7.3: cap the write at the caller KEY-buffer size — bvcd_keys, csce_keys and
+  -- sps_keys are all sized 512*32 (fhsxz.2.4.2.66.1 raised the cap from 128: the
+  -- system_contract_errors EEST predeploys legitimately commit 306 storage changes, which
+  -- the system-call preload must stage). If the BAL declares MORE storage_changes than fit,
+  -- write NOTHING and return the true count so the caller bails conservatively
+  -- (.Ldtrc_unsupported / skip-account / requests-hash fail) instead of overflowing into
+  -- adjacent .data. The regular-tx callers still bail at their own >128 thresholds
+  -- (bvcd_preload and the callee-seed table stay 128-sized); only the system-call preload
+  -- path consumes counts up to 512.
+  "  li t0, 512; bgtu s5, t0, .Lbrsk_done            # count > cap -> return count, write nothing\n" ++
   "  mv s6, zero                  # i\n" ++
   "  mv s7, s2                    # out cursor\n" ++
   ".Lbrsk_loop:\n" ++
@@ -113,7 +118,7 @@ def balRecipientStorageKeysFunction : String :=
     Calling convention:
       a0 = AccountChanges RLP ptr   a1 = AccountChanges RLP len
       a2 = out keys ptr             a3 = max slots to write (remaining buffer capacity)
-    Returns a0 = storage_reads count. If count > a3 (or > 128) writes NOTHING and returns the
+    Returns a0 = storage_reads count. If count > a3 (or > 512) writes NOTHING and returns the
     true count so the caller bails conservatively instead of overflowing. Empty/absent
     storage_reads or any parse failure returns 0 (conservative). -/
 def balRecipientStorageReadsKeysFunction : String :=
@@ -136,7 +141,9 @@ def balRecipientStorageReadsKeysFunction : String :=
   "  jal ra, rlp_list_count_items\n" ++
   "  bnez a0, .Lbrsrk_zero\n" ++
   "  la t0, brsk_cnt; ld s6, 0(t0)                   # sr count\n" ++
-  "  li t0, 128; bgtu s6, t0, .Lbrsrk_done           # > cap -> count, write nothing\n" ++
+  -- fhsxz.2.4.2.66.1: absolute clamp raised 128 -> 512 in lockstep with the key buffers;
+  -- the real per-caller bound is a3 (remaining capacity), which every caller passes.
+  "  li t0, 512; bgtu s6, t0, .Lbrsrk_done           # > cap -> count, write nothing\n" ++
   "  bgtu s6, s3, .Lbrsrk_done                       # > remaining capacity -> count, write nothing\n" ++
   "  li s7, 0                     # i (SAVED reg: rlp_list_nth_item clobbers t-regs)\n" ++
   ".Lbrsrk_loop:\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -217,7 +217,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bvcd_key_count:\n  .zero 8\n" ++
   "bvcd_sc_count:\n  .zero 8\n" ++
   "bvcd_i:\n  .zero 8\n" ++
-  "bvcd_keys:\n  .zero 4096\n" ++      -- bmvmx.1.7.3: up to 128 x 32-byte slot keys (was 16; bal_recipient_storage_keys caps at 128)
+  "bvcd_keys:\n  .zero 16384\n" ++     -- fhsxz.2.4.2.66.1: 512 x 32-byte slot keys (bal_recipient_storage_keys now caps at 512; the dispatch-tx caller still bails >128 — bvcd_preload stays 128-sized — but the keys it writes before that bail must fit)
   "bvcd_preload:\n  .zero 8192\n" ++   -- bmvmx.1.7.3: up to 128 x 64-byte (key,value) pairs (was 16)
   -- bmvmx.1.6.2 exec-vs-BAL recipient storage check scratch (bal_storage_change_values +
   -- bal_storage_matches_exec_log), now linked into the verdict's contract-dispatch tail.
@@ -245,7 +245,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   "csce_key_i:\n  .zero 8\n" ++ "csce_key_n:\n  .zero 8\n" ++
   ".balign 32\n" ++
   "csce_addrkey:\n  .zero 32\n" ++
-  "csce_keys:\n  .zero 4096\n" ++   -- up to 128 x 32-byte slot keys
+  "csce_keys:\n  .zero 16384\n" ++   -- fhsxz.2.4.2.66.1: 512 x 32-byte slot keys (matches the raised bal_recipient_storage_keys cap; the seed loop still skips accounts >128)
 
   "bv_eip7778_status:\n  .zero 8\n" ++
   "bv_eip7778_index:\n  .zero 8\n" ++
@@ -332,7 +332,15 @@ def ziskStatelessVerdictV2DataSection : String :=
   "c1_wcode_len:\n  .zero 8\n" ++
   "c1_er_input:\n  .zero 8\n" ++
   ".balign 8\n" ++
-  "c1_staging:\n  .zero 32768\n" ++   -- Fix7: system-call payload = env_base+504; env_base grows with the predeploy's storage preload (up to 128 slots*64) + M29 block hashes. 4096 overflowed for above-max queues (100 slots -> ~7.5KB) -> truncated storage section -> SLOAD miss -> empty derived body.
+  -- Fix7: system-call payload = env_base+504; env_base grows with the predeploy's storage preload (up to 128 slots*64) + M29 block hashes. 4096 overflowed for above-max queues (100 slots -> ~7.5KB) -> truncated storage section -> SLOAD miss -> empty derived body.
+  -- fhsxz.2.4.2.66.1: 32768 overflowed for the system_contract_errors EEST predeploys
+  -- (modified 7002/7251 contracts of 72946 B; predeploy code is NOT EIP-170-bounded):
+  -- stage_runtime_payload_code's zero+code copy ran ~40 KiB past the buffer, smashing
+  -- every .data global above (c1_saved_*, dbsr_*, rlp args) -> ERROR(exit)/false-reject.
+  -- 131072 fits round8(code) + preload + M29 + 584 for those rows; the new size guard in
+  -- stage_system_call_payload (SystemCallStaging.lean, keep its 131072 literal in sync)
+  -- bails on anything larger instead of corrupting .data.
+  "c1_staging:\n  .zero 131072\n" ++
   ".balign 8\n" ++
   "c1_er_assembled:\n  .zero 2048\n" ++
   "c1_ccode_ptr:\n  .zero 8\n" ++
@@ -340,7 +348,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   "c1_bal_acct_ptr:\n  .zero 8\n" ++
   "c1_bal_acct_len:\n  .zero 8\n" ++
   ".balign 8\n" ++
-  "c1_preload:\n  .zero 8192\n" ++
+  "c1_preload:\n  .zero 32768\n" ++   -- fhsxz.2.4.2.66.1: 512 x 64-byte (key,value) pairs (was 128; the system_contract_errors predeploys commit 306 BAL storage changes that the system-call preload must stage)
   "c1_bal_start:\n  .zero 8\n" ++
   "c1_bal_len:\n  .zero 8\n" ++
   "c1_bal_count:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
@@ -465,6 +465,11 @@ def statelessVerdictV2Function : String :=
   ".Lc1_w_addrd:\n" ++
   "  la t0, c1_bal_acct_ptr; ld a0, 0(t0); la t0, c1_bal_acct_len; ld a1, 0(t0); la a2, c1_preload\n" ++
   "  jal ra, stage_predeploy_storage_preload\n" ++
+  -- fhsxz.2.4.2.66.1: a count above the 512 cap means NOTHING was staged (the preload
+  -- bails write-nothing); storing it would make stage_runtime_payload_code copy count*64
+  -- garbage bytes from past c1_preload into the payload -> wrong execution. Conservative
+  -- reject instead (sound: at worst a false-reject of a >512-slot system-call block).
+  "  li t1, 512; bgtu a0, t1, .Lv2_requests_hash_fail\n" ++
   "  la t0, scc_preload_count; sd a0, 0(t0); la t1, c1_preload; la t0, scc_preload_ptr; sd t1, 0(t0)\n" ++
   "  j .Lc1_w_derive\n" ++
   ".Lc1_w_nopreload:\n" ++
@@ -501,6 +506,8 @@ def statelessVerdictV2Function : String :=
   ".Lc1_c_addrd:\n" ++
   "  la t0, c1_bal_acct_ptr; ld a0, 0(t0); la t0, c1_bal_acct_len; ld a1, 0(t0); la a2, c1_preload\n" ++
   "  jal ra, stage_predeploy_storage_preload\n" ++
+  -- fhsxz.2.4.2.66.1: same >cap conservative reject as the withdrawal site above.
+  "  li t1, 512; bgtu a0, t1, .Lv2_requests_hash_fail\n" ++
   "  la t0, scc_preload_count; sd a0, 0(t0); la t1, c1_preload; la t0, scc_preload_ptr; sd t1, 0(t0)\n" ++
   "  j .Lc1_c_derive\n" ++
   ".Lc1_c_nopreload:\n" ++

--- a/EvmAsm/Codegen/Programs/SystemCallStaging.lean
+++ b/EvmAsm/Codegen/Programs/SystemCallStaging.lean
@@ -55,6 +55,19 @@ def stageSystemCallPayloadFunction : String :=
   "  beqz t3, .Lscc_recip_d\n" ++
   "  lbu t4, 0(t2); sb t4, 0(t1); addi t2, t2, 1; addi t1, t1, 1; addi t3, t3, -1; j .Lscc_recip\n" ++
   ".Lscc_recip_d:\n" ++
+  -- fhsxz.2.4.2.66.1: conservative payload-size guard (mirrors bmvmx.1.7.2 in
+  -- dispatch_tx_runtime_code). stage_runtime_payload_code zeroes + writes
+  -- round8(codelen) + storage_count*64 + m29_count*32 + 584 bytes into the output
+  -- buffer with no bound of its own; every verdict call site passes c1_staging
+  -- (131072 B, BlockVerdictDataSection.lean — keep the literal in sync). Predeploy
+  -- code is read from the witness and NOT EIP-170-bounded (the system_contract_errors
+  -- EEST predeploys are 72946 B), so an unchecked copy clobbers the .data globals
+  -- above c1_staging. Bail (a0=1, unsupported -> requests-hash fail) instead of
+  -- corrupting .data. System-call calldata is always empty (ctx@64 stays 0).
+  "  addi t1, s2, 7; andi t1, t1, -8\n" ++                                         -- round8(codelen)
+  "  la t0, scc_preload_count; ld t2, 0(t0); slli t2, t2, 6; add t1, t1, t2\n" ++  -- + storage_count*64
+  "  la t0, m29_stage_count; ld t2, 0(t0); slli t2, t2, 5; add t1, t1, t2\n" ++    -- + M29 hashes (count*32)
+  "  addi t1, t1, 584; li t2, 131072; bgtu t1, t2, .Lscc_toobig\n" ++              -- payload > buffer -> bail
   -- stage_runtime_payload_code(ctx, out, exec, code, codelen, null, 0)
   -- 8uld3.2.1.5: pass the predeploy STORAGE preload (a5/a6) so the predeploy's SLOAD of its
   -- request queue reads the staged witness values (not garbage). scc_preload_ptr/count default
@@ -83,6 +96,9 @@ def stageSystemCallPayloadFunction : String :=
   "  add a5, t3, t5; lbu a6, 0(a5); li a5, 19; sub a5, a5, t5; add a5, t4, a5; sb a6, 0(a5); addi t5, t5, 1; j .Lscc_origin\n" ++
   ".Lscc_origin_d:\n" ++
   "  li a0, 0\n" ++
+  "  j .Lscc_ret\n" ++
+  ".Lscc_toobig:\n" ++
+  "  li a0, 1\n" ++
   ".Lscc_ret:\n" ++
   "  ld ra, 0(sp)\n" ++
   "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++

--- a/EvmAsm/Codegen/Programs/SystemCallStoragePreload.lean
+++ b/EvmAsm/Codegen/Programs/SystemCallStoragePreload.lean
@@ -7,7 +7,7 @@
 
   Composes the existing primitives:
     * bal_recipient_storage_keys (BlockVerdictContractStorage) — enumerate the predeploy's
-      accessed slot keys from its BAL AccountChanges entry (cap 128).
+      accessed slot keys from its BAL AccountChanges entry (cap 512).
     * slot_at_header_state_root (StateCompose) — for each key, walk the witness MPT
       (header.state_root -> account leaf -> storage trie -> slot) to the ORIGINAL pre-block
       value; the 32-byte u256 lands in the `sahsr_u256` global (a0 = status, nonzero = fail).
@@ -30,11 +30,13 @@ open EvmAsm.Rv64
 
 /-! ## stage_predeploy_storage_preload
     a0 = predeploy AccountChanges RLP ptr   a1 = AccountChanges RLP length
-    a2 = out ptr (count x 64-byte (key:32 BE, value:32 BE) pairs; caller buffer >= 128*64)
+    a2 = out ptr (count x 64-byte (key:32 BE, value:32 BE) pairs; caller buffer >= 512*64)
     Globals (caller-set): sps_addr (20-byte predeploy address), sps_header / sps_header_len,
       sps_state / sps_state_len, sps_storage / sps_storage_len.
-    Returns a0 = slot count (0 on parse failure; if > 128, nothing written, true count
-    returned so the caller bails conservatively). -/
+    Returns a0 = slot count (0 on parse failure; if > 512, nothing written, true count
+    returned so the caller MUST bail conservatively — staging a count the buffer doesn't
+    hold reads garbage past c1_preload; fhsxz.2.4.2.66.1 raised the cap from 128 because
+    the system_contract_errors EEST predeploys commit 306 storage changes). -/
 def stagePredeployStoragePreloadFunction : String :=
   "stage_predeploy_storage_preload:\n" ++
   "  addi sp, sp, -64\n" ++
@@ -48,7 +50,7 @@ def stagePredeployStoragePreloadFunction : String :=
   "  la a2, sps_keys\n" ++
   "  jal ra, bal_recipient_storage_keys\n" ++
   "  mv s1, a0                    # changes-slot count\n" ++
-  "  li t0, 128\n  bgtu s1, t0, .Lspsp_done\n" ++   -- >128 changes: bail (write nothing, return count)
+  "  li t0, 512\n  bgtu s1, t0, .Lspsp_done\n" ++   -- >512 changes: bail (write nothing, return count)
   -- 8uld3.2.3.3.1 Fix2: ALSO stage the predeploy's storage_READS (AccountChanges item 2).
   -- A no-requests predeploy reads the queue head/tail/count slots it never writes, so a
   -- changes-only preload leaves those SLOADs reading garbage (the e0010046 unmapped-read
@@ -56,10 +58,10 @@ def stagePredeployStoragePreloadFunction : String :=
   -- pre-block value for each. (a0/a1 were clobbered by the changes call; restore from s5/s6.)
   "  mv a0, s5; mv a1, s6\n" ++
   "  slli t0, s1, 5; la t1, sps_keys; add a2, t1, t0   # &sps_keys[changes_count]\n" ++
-  "  li t0, 128; sub a3, t0, s1                         # remaining capacity\n" ++
+  "  li t0, 512; sub a3, t0, s1                         # remaining capacity\n" ++
   "  jal ra, bal_recipient_storage_reads_keys\n" ++
   "  add s1, s1, a0                                     # total = changes + reads\n" ++
-  "  li t0, 128\n  bgtu s1, t0, .Lspsp_done\n" ++   -- combined >128: bail
+  "  li t0, 512\n  bgtu s1, t0, .Lspsp_done\n" ++   -- combined >512: bail
   -- Fix6 pre-pass: sps_sysidx = MAX block_access_index across the predeploy's changed slots.
   -- The block-end system call is the last writer, so its index is this max; a slot's pre-system
   -- value (what the predeploy reads) is the last change tuple with index < sps_sysidx.
@@ -156,7 +158,7 @@ def stagePredeployStoragePreloadFunction : String :=
     the predeploy address + the slot-key scratch buffer). -/
 def stagePredeployStoragePreloadData : String :=
   ".balign 8\n" ++
-  "sps_keys:\n  .zero 4096\n" ++       -- 128 x 32-byte slot keys
+  "sps_keys:\n  .zero 16384\n" ++      -- 512 x 32-byte slot keys (fhsxz.2.4.2.66.1: was 128)
   ".balign 8\n" ++
   "sps_tuples:\n  .zero 20480\n" ++    -- Fix6: 512 x 40-byte (block_access_index, new_value) tuples per slot
   "sps_sysidx:\n  .zero 8\n" ++        -- Fix6: system-call block_access_index (= max change index)


### PR DESCRIPTION
## Root cause (bead evm-asm-fhsxz.2.4.2.66.1)

The two remaining `system_contract_errors` failures (eip7002 row 00001 ERROR(exit), eip7251 row 00005 false-reject) were never caused by the predeploy's EVM execution writing into `.data` — the corrupting store is the **staging memcpy itself**:

- `stage_runtime_payload_code` zeroes and writes `round8(codelen) + storage*64 + m29*32 + 584` bytes into its output buffer with **no bound**, and the system-call path hands it `c1_staging` (32768 B).
- The modified 7002/7251 predeploys are **72946 bytes** (witness code is not EIP-170-bounded), mostly `0x5b` JUMPDEST padding. The code byte landing at `c1_saved_s0`'s offset (+43056 into the payload) is `0x5b` — exactly the `0x5b5b5b5b5b5b5b5b` poison pointer in the row-00001 crash.
- This explains all the prior dead ends: the 32K→64K staging bump changed nothing (72946 > 65536), the high EVM arenas could never reach the low globals, and row 00005's FAIL is the consolidation staging clobbering the already-derived withdrawal body (`dbsr_wbody`/`dbsr_wlen`).

## Fix

**Commit 1 — staging buffer** (`f5a3ad2f6`):
- `c1_staging` 32768 → 131072: these predeploys must actually EXECUTE (expected verdict is accept-with-empty-requests, so bailing alone would false-reject).
- `stage_system_call_payload` gets a conservative payload-size guard mirroring the bmvmx.1.7.2 guard on the regular-tx dispatch path: payloads that cannot fit return `a0=1` (unsupported → requests-hash fail, a sound reject) instead of corrupting `.data`.

**Commit 2 — storage preload soundness** (`faf56c6c7`): the `reaches_gas_limit` rows commit **306 BAL storage changes**, above the 128-slot preload cap, and the cap's bail returned the *uncapped* count — so `stage_runtime_payload_code` copied `count*64` bytes from the 8192-byte `c1_preload`, staging ~11 KiB of adjacent `.data` as garbage preload entries. (The rows would pass anyway only because these contracts never SLOAD; a >128-slot predeploy that reads its queue would execute on garbage — adversarially a false-accept vector.)
- `bal_recipient_storage_keys` cap 128 → 512; `bvcd_keys`/`csce_keys`/`sps_keys` resized to 512×32 (regular-tx callers keep their own >128 bails; `bvcd_preload` and the callee-seed table stay 128-sized).
- `bal_recipient_storage_reads_keys` absolute clamp 128 → 512 (per-caller `a3` remains the real bound).
- `stage_predeploy_storage_preload` caps 128 → 512; `c1_preload` 8192 → 32768.
- Both C.1 call sites now conservatively **reject** (`.Lv2_requests_hash_fail`) on a >512 count instead of storing it.

## Validation

- `scripts/codegen-eest-stateless-check.sh --filter system_contract_errors`: **6/8 → 8/8 full match** (row 00001 ERROR→PASS, row 00005 FAIL→PASS, the other 6 stay PASS). Reproduced twice: after commit 1 alone and after both commits.
- Operator is running an all-case sweep on this branch.

## Follow-up filed

Child bead (P1) for the same corruption class found adjacent: `bal_slot_tuple_sequence` has no output-buffer cap — an adversarial BAL slot with >512 change-tuples overflows `sps_tuples` (pre-existing on main, not exercised by these fixtures).

Authored by @pirapira; implemented by Claude Code.