### PR TITLE
perf(secp256k1): back field mul and point ops with ziskemu accelerators (~1e11 -> ~2e6 steps)

### DIFF
--- a/EvmAsm/Codegen/Programs/Secp256k1Curve.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1Curve.lean
@@ -3,6 +3,13 @@
 
   Codegen-only affine secp256k1 curve helpers for staged software public-key
   recovery. Points are 64-byte big-endian affine records: x || y.
+
+  `secp256k1_point_add` / `secp256k1_point_double` are backed by the ziskemu
+  Secp256k1Add/Secp256k1Dbl accelerators (`csrs 0x803` / `csrs 0x804` with a
+  little-endian-limb parameter pointer, emitted as pre-encoded `.4byte`s for
+  the plain `rv64imac` toolchain). The affine special cases the accelerators
+  exclude (input at infinity, doubling with y = 0, adding points with equal
+  x) stay in software, preserving the original call surface and return codes.
 -/
 
 import EvmAsm.Rv64.Program
@@ -42,13 +49,13 @@ def secp256k1CurveDataSection : String :=
   "secp256k1_generator_2:\n" ++
   generator2PointAsm ++
   ".balign 8\n" ++
-  "secc_slope:\n  .zero 32\n" ++
-  "secc_den:\n  .zero 32\n" ++
-  "secc_inv:\n  .zero 32\n" ++
-  "secc_tmp0:\n  .zero 32\n" ++
-  "secc_tmp1:\n  .zero 32\n" ++
-  "secc_tmp2:\n  .zero 32\n" ++
-  "secc_point_tmp:\n  .zero 64\n"
+  "secc_point_tmp:\n  .zero 64\n" ++
+  -- Little-endian limb staging for the ziskemu Secp256k1Add/Dbl accelerators
+  -- (x||y, four u64 limbs per coordinate, least-significant limb first) plus
+  -- the static Secp256k1Add parameter block {&p1, &p2}; the result lands in p1.
+  "secc_le_p1:\n  .zero 64\n" ++
+  "secc_le_p2:\n  .zero 64\n" ++
+  "secc_add_params:\n  .quad secc_le_p1, secc_le_p2\n"
 
 /-- Double an affine point. a0=input x||y, a1=output x||y. Returns 1 for infinity. -/
 def secp256k1PointDoubleFunction : String :=
@@ -68,59 +75,22 @@ def secp256k1PointDoubleFunction : String :=
   "  j .Lsecc_double_ret\n" ++
   ".Lsecc_double_finite:\n" ++
   "  mv a0, s0\n" ++
-  "  la a2, secc_tmp0\n" ++
-  "  jal ra, secf_square_mod_p     # tmp0 = x^2\n" ++
-  "  la a0, secc_tmp0\n" ++
-  "  mv a1, a0\n" ++
-  "  la a2, secc_tmp1\n" ++
-  "  jal ra, secf_add_mod_p        # tmp1 = 2*x^2\n" ++
-  "  la a0, secc_tmp1\n" ++
-  "  la a1, secc_tmp0\n" ++
-  "  la a2, secc_tmp0\n" ++
-  "  jal ra, secf_add_mod_p        # tmp0 = 3*x^2\n" ++
+  "  la a1, secc_le_p1\n" ++
+  "  jal ra, secf_be_to_le         # p1.x\n" ++
   "  addi a0, s0, 32\n" ++
-  "  mv a1, a0\n" ++
-  "  la a2, secc_den\n" ++
-  "  jal ra, secf_add_mod_p        # den = 2*y\n" ++
-  "  la a0, secc_den\n" ++
-  "  la a1, secc_inv\n" ++
-  "  jal ra, secf_inv_mod_p\n" ++
-  "  bnez a0, .Lsecc_double_inf\n" ++
-  "  la a0, secc_tmp0\n" ++
-  "  la a1, secc_inv\n" ++
-  "  la a2, secc_slope\n" ++
-  "  jal ra, secf_mul_mod_p        # slope\n" ++
-  "  la a0, secc_slope\n" ++
-  "  la a2, secc_tmp0\n" ++
-  "  jal ra, secf_square_mod_p     # slope^2\n" ++
-  "  la a0, secc_tmp0\n" ++
-  "  mv a1, s0\n" ++
-  "  la a2, secc_tmp0\n" ++
-  "  jal ra, secf_sub_mod_p\n" ++
-  "  la a0, secc_tmp0\n" ++
-  "  mv a1, s0\n" ++
-  "  mv a2, s1\n" ++
-  "  jal ra, secf_sub_mod_p        # out.x = slope^2 - 2*x\n" ++
-  "  mv a0, s0\n" ++
+  "  la a1, secc_le_p1\n" ++
+  "  addi a1, a1, 32\n" ++
+  "  jal ra, secf_be_to_le         # p1.y\n" ++
+  "  la t0, secc_le_p1\n" ++
+  "  .4byte 0x8042a073             # csrs 0x804, t0 -> Secp256k1Dbl\n" ++
+  "  la a0, secc_le_p1\n" ++
   "  mv a1, s1\n" ++
-  "  la a2, secc_tmp0\n" ++
-  "  jal ra, secf_sub_mod_p        # tmp0 = x - out.x\n" ++
-  "  la a0, secc_slope\n" ++
-  "  la a1, secc_tmp0\n" ++
-  "  la a2, secc_tmp1\n" ++
-  "  jal ra, secf_mul_mod_p\n" ++
-  "  la a0, secc_tmp1\n" ++
-  "  addi a1, s0, 32\n" ++
-  "  addi a2, s1, 32\n" ++
-  "  jal ra, secf_sub_mod_p        # out.y\n" ++
+  "  jal ra, secf_le_to_be         # out.x\n" ++
+  "  la a0, secc_le_p1\n" ++
+  "  addi a0, a0, 32\n" ++
+  "  addi a1, s1, 32\n" ++
+  "  jal ra, secf_le_to_be         # out.y\n" ++
   "  li a0, 0\n" ++
-  "  j .Lsecc_double_ret\n" ++
-  ".Lsecc_double_inf:\n" ++
-  "  mv a0, s1\n" ++
-  "  jal ra, secf_zero32\n" ++
-  "  addi a0, s1, 32\n" ++
-  "  jal ra, secf_zero32\n" ++
-  "  li a0, 1\n" ++
   ".Lsecc_double_ret:\n" ++
   "  ld ra, 0(sp); ld s0, 8(sp); ld s1, 16(sp)\n" ++
   "  addi sp, sp, 32\n" ++
@@ -145,45 +115,29 @@ def secp256k1PointAddFunction : String :=
   "  jal ra, secp256k1_point_double\n" ++
   "  j .Lsecc_add_ret\n" ++
   ".Lsecc_add_distinct_x:\n" ++
-  "  addi a0, s1, 32\n" ++
-  "  addi a1, s0, 32\n" ++
-  "  la a2, secc_tmp0\n" ++
-  "  jal ra, secf_sub_mod_p        # y2-y1\n" ++
-  "  mv a0, s1\n" ++
-  "  mv a1, s0\n" ++
-  "  la a2, secc_den\n" ++
-  "  jal ra, secf_sub_mod_p        # x2-x1\n" ++
-  "  la a0, secc_den\n" ++
-  "  la a1, secc_inv\n" ++
-  "  jal ra, secf_inv_mod_p\n" ++
-  "  bnez a0, .Lsecc_add_inf\n" ++
-  "  la a0, secc_tmp0\n" ++
-  "  la a1, secc_inv\n" ++
-  "  la a2, secc_slope\n" ++
-  "  jal ra, secf_mul_mod_p\n" ++
-  "  la a0, secc_slope\n" ++
-  "  la a2, secc_tmp1\n" ++
-  "  jal ra, secf_square_mod_p\n" ++
-  "  la a0, secc_tmp1\n" ++
-  "  mv a1, s0\n" ++
-  "  la a2, secc_tmp1\n" ++
-  "  jal ra, secf_sub_mod_p\n" ++
-  "  la a0, secc_tmp1\n" ++
-  "  mv a1, s1\n" ++
-  "  mv a2, s2\n" ++
-  "  jal ra, secf_sub_mod_p        # out.x\n" ++
   "  mv a0, s0\n" ++
+  "  la a1, secc_le_p1\n" ++
+  "  jal ra, secf_be_to_le         # p1.x\n" ++
+  "  addi a0, s0, 32\n" ++
+  "  la a1, secc_le_p1\n" ++
+  "  addi a1, a1, 32\n" ++
+  "  jal ra, secf_be_to_le         # p1.y\n" ++
+  "  mv a0, s1\n" ++
+  "  la a1, secc_le_p2\n" ++
+  "  jal ra, secf_be_to_le         # p2.x\n" ++
+  "  addi a0, s1, 32\n" ++
+  "  la a1, secc_le_p2\n" ++
+  "  addi a1, a1, 32\n" ++
+  "  jal ra, secf_be_to_le         # p2.y\n" ++
+  "  la t0, secc_add_params\n" ++
+  "  .4byte 0x8032a073             # csrs 0x803, t0 -> Secp256k1Add\n" ++
+  "  la a0, secc_le_p1\n" ++
   "  mv a1, s2\n" ++
-  "  la a2, secc_tmp1\n" ++
-  "  jal ra, secf_sub_mod_p        # x1-out.x\n" ++
-  "  la a0, secc_slope\n" ++
-  "  la a1, secc_tmp1\n" ++
-  "  la a2, secc_tmp2\n" ++
-  "  jal ra, secf_mul_mod_p\n" ++
-  "  la a0, secc_tmp2\n" ++
-  "  addi a1, s0, 32\n" ++
-  "  addi a2, s2, 32\n" ++
-  "  jal ra, secf_sub_mod_p\n" ++
+  "  jal ra, secf_le_to_be         # out.x\n" ++
+  "  la a0, secc_le_p1\n" ++
+  "  addi a0, a0, 32\n" ++
+  "  addi a1, s2, 32\n" ++
+  "  jal ra, secf_le_to_be         # out.y\n" ++
   "  li a0, 0\n" ++
   "  j .Lsecc_add_ret\n" ++
   ".Lsecc_add_inf:\n" ++

--- a/EvmAsm/Codegen/Programs/Secp256k1Field.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1Field.lean
@@ -3,6 +3,13 @@
 
   Codegen-only secp256k1 prime-field helpers for staged software
   public-key recovery. Values are 32-byte big-endian integers.
+
+  The modular multiplies (`secf_mul_mod_p`, `secf_mul_mod_n`) are backed by
+  the ziskemu `Arith256Mod` accelerator (`csrs 0x802` with a parameter-block
+  pointer, emitted as a pre-encoded `.4byte` so the plain `rv64imac`
+  toolchain assembles it). Inputs convert between the 32-byte big-endian
+  call surface and the accelerator's little-endian u64-limb format via
+  `secf_be_to_le` / `secf_le_to_be`.
 -/
 
 import EvmAsm.Rv64.Program
@@ -66,12 +73,29 @@ def secp256k1FieldDataSection : String :=
   ".balign 8\n" ++
   "secf_cmp:\n" ++
   "  .zero 8\n" ++
+  -- Little-endian 4x-u64-limb staging for the ziskemu `Arith256Mod`
+  -- accelerator (`d = (a*b + c) mod module`), plus its two static parameter
+  -- blocks (one per modulus). The accelerator reads {a,b,c,module} and writes
+  -- d; `secf_le_zero` doubles as the read-only c = 0.
   ".balign 8\n" ++
-  "secf_mul_res:\n" ++
+  "secf_le_a:\n" ++
   "  .zero 32\n" ++
-  ".balign 8\n" ++
-  "secf_mul_acc:\n" ++
+  "secf_le_b:\n" ++
   "  .zero 32\n" ++
+  "secf_le_d:\n" ++
+  "  .zero 32\n" ++
+  "secf_le_zero:\n" ++
+  "  .zero 32\n" ++
+  "secf_le_p:\n" ++
+  "  .quad 0xFFFFFFFEFFFFFC2F, 0xFFFFFFFFFFFFFFFF\n" ++
+  "  .quad 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF\n" ++
+  "secf_le_n:\n" ++
+  "  .quad 0xBFD25E8CD0364141, 0xBAAEDCE6AF48A03B\n" ++
+  "  .quad 0xFFFFFFFFFFFFFFFE, 0xFFFFFFFFFFFFFFFF\n" ++
+  "secf_arith_params_p:\n" ++
+  "  .quad secf_le_a, secf_le_b, secf_le_zero, secf_le_p, secf_le_d\n" ++
+  "secf_arith_params_n:\n" ++
+  "  .quad secf_le_a, secf_le_b, secf_le_zero, secf_le_n, secf_le_d\n" ++
   ".balign 8\n" ++
   "secf_pow_result:\n" ++
   "  .zero 32\n" ++
@@ -99,6 +123,62 @@ def secp256k1FieldZero32Function : String :=
   "  sd zero,  8(a0)\n" ++
   "  sd zero, 16(a0)\n" ++
   "  sd zero, 24(a0)\n" ++
+  "  ret"
+
+/-- Convert a 32-byte big-endian buffer (`a0`, byte-addressed, any alignment)
+    into four little-endian u64 limbs (`a1`, 8-aligned), least-significant
+    limb first — the ziskemu accelerator operand format. Leaf helper;
+    clobbers only `t` registers. -/
+def secp256k1FieldBeToLeFunction : String :=
+  "secf_be_to_le:\n" ++
+  "  li t0, 0                   # limb index\n" ++
+  ".Lsecf_b2l_quad:\n" ++
+  "  li t1, 24\n" ++
+  "  slli t2, t0, 3\n" ++
+  "  sub t1, t1, t2\n" ++
+  "  add t1, a0, t1             # BE offset of the limb's MSB\n" ++
+  "  li t3, 0\n" ++
+  "  li t4, 8\n" ++
+  ".Lsecf_b2l_byte:\n" ++
+  "  slli t3, t3, 8\n" ++
+  "  lbu t5, 0(t1)\n" ++
+  "  or t3, t3, t5\n" ++
+  "  addi t1, t1, 1\n" ++
+  "  addi t4, t4, -1\n" ++
+  "  bnez t4, .Lsecf_b2l_byte\n" ++
+  "  slli t2, t0, 3\n" ++
+  "  add t2, a1, t2\n" ++
+  "  sd t3, 0(t2)\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  li t1, 4\n" ++
+  "  bne t0, t1, .Lsecf_b2l_quad\n" ++
+  "  ret"
+
+/-- Convert four little-endian u64 limbs (`a0`, 8-aligned) into a 32-byte
+    big-endian buffer (`a1`, byte-addressed, any alignment). Inverse of
+    `secf_be_to_le`. Leaf helper; clobbers only `t` registers. -/
+def secp256k1FieldLeToBeFunction : String :=
+  "secf_le_to_be:\n" ++
+  "  li t0, 0                   # limb index\n" ++
+  ".Lsecf_l2b_quad:\n" ++
+  "  slli t1, t0, 3\n" ++
+  "  add t2, a0, t1\n" ++
+  "  ld t3, 0(t2)\n" ++
+  "  li t1, 31\n" ++
+  "  slli t2, t0, 3\n" ++
+  "  sub t1, t1, t2\n" ++
+  "  add t1, a1, t1             # BE offset of the limb's LSB\n" ++
+  "  li t4, 8\n" ++
+  ".Lsecf_l2b_byte:\n" ++
+  "  andi t5, t3, 0xff\n" ++
+  "  sb t5, 0(t1)\n" ++
+  "  srli t3, t3, 8\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  addi t4, t4, -1\n" ++
+  "  bnez t4, .Lsecf_l2b_byte\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  li t1, 4\n" ++
+  "  bne t0, t1, .Lsecf_l2b_quad\n" ++
   "  ret"
 
 /-- Return bit `a1` of a 32-byte BE field element, numbering bits from the LSB. -/
@@ -315,62 +395,37 @@ def secp256k1FieldSubFunction : String :=
 
 
 /--
-  Multiply two field elements modulo p using double-and-add over 256 bits.
-  This is a correctness-first route for recovery scaffolding; later work can
-  replace it with a faster reduction strategy behind the same call surface.
+  Multiply two field elements modulo p via the ziskemu `Arith256Mod`
+  accelerator: `d = (a*b + 0) mod p` with exact 512-bit intermediate math,
+  so unreduced 256-bit inputs are accepted and the output is fully reduced.
+  The raw `.4byte 0x8022a073` is `csrs 0x802, t0` (`SYSCALL_ARITH256_MOD_ID`
+  with the parameter-block pointer in `t0`), pre-encoded so the
+  `-march=rv64imac` toolchain assembles it without `Zicsr` (the same pattern
+  as the Keccak-f probe's `.4byte 0x80052073`).
 -/
 def secp256k1FieldMulFunction : String :=
   "secf_mul_mod_p:\n" ++
-  "  addi sp, sp, -64\n" ++
+  "  addi sp, sp, -32\n" ++
   "  sd ra,  0(sp)\n" ++
   "  sd s0,  8(sp)\n" ++
   "  sd s1, 16(sp)\n" ++
-  "  sd s2, 24(sp)\n" ++
-  "  sd s3, 32(sp)\n" ++
-  "  sd s4, 40(sp)\n" ++
-  "  sd s5, 48(sp)\n" ++
-  "  mv s0, a0\n" ++
-  "  mv s1, a1\n" ++
-  "  mv s2, a2\n" ++
-  "  la s4, secf_mul_res\n" ++
-  "  la s5, secf_mul_acc\n" ++
-  "  mv a0, s4\n" ++
-  "  jal ra, secf_zero32\n" ++
+  "  mv s0, a1\n" ++
+  "  mv s1, a2\n" ++
+  "  la a1, secf_le_a\n" ++
+  "  jal ra, secf_be_to_le\n" ++
   "  mv a0, s0\n" ++
-  "  mv a1, s5\n" ++
-  "  jal ra, secf_reduce_once\n" ++
-  "  li s3, 0\n" ++
-  ".Lsecf_mul_loop:\n" ++
-  "  li t0, 256\n" ++
-  "  beq s3, t0, .Lsecf_mul_done\n" ++
-  "  mv a0, s1\n" ++
-  "  mv a1, s3\n" ++
-  "  jal ra, secf_get_bit_lsb\n" ++
-  "  beqz a0, .Lsecf_mul_double\n" ++
-  "  mv a0, s4\n" ++
-  "  mv a1, s5\n" ++
-  "  mv a2, s4\n" ++
-  "  jal ra, secf_add_mod_p\n" ++
-  ".Lsecf_mul_double:\n" ++
-  "  mv a0, s5\n" ++
-  "  mv a1, s5\n" ++
-  "  mv a2, s5\n" ++
-  "  jal ra, secf_add_mod_p\n" ++
-  "  addi s3, s3, 1\n" ++
-  "  j .Lsecf_mul_loop\n" ++
-  ".Lsecf_mul_done:\n" ++
-  "  mv a0, s4\n" ++
-  "  mv a1, s2\n" ++
-  "  jal ra, secf_copy32\n" ++
+  "  la a1, secf_le_b\n" ++
+  "  jal ra, secf_be_to_le\n" ++
+  "  la t0, secf_arith_params_p\n" ++
+  "  .4byte 0x8022a073           # csrs 0x802, t0 -> Arith256Mod\n" ++
+  "  la a0, secf_le_d\n" ++
+  "  mv a1, s1\n" ++
+  "  jal ra, secf_le_to_be\n" ++
   "  li a0, 0\n" ++
   "  ld ra,  0(sp)\n" ++
   "  ld s0,  8(sp)\n" ++
   "  ld s1, 16(sp)\n" ++
-  "  ld s2, 24(sp)\n" ++
-  "  ld s3, 32(sp)\n" ++
-  "  ld s4, 40(sp)\n" ++
-  "  ld s5, 48(sp)\n" ++
-  "  addi sp, sp, 64\n" ++
+  "  addi sp, sp, 32\n" ++
   "  ret"
 
 /-- Square one field element modulo p. -/
@@ -552,10 +607,11 @@ def secp256k1FieldSqrtFunction : String :=
   is the secp256k1 group order rather than the field prime `p`. The helpers
   below mirror the mod-p stack one-for-one, swapping only the modulus constant
   (`secf_n_be` / `secf_n_c_be`) and the Fermat exponent (`secf_n_minus_2_be`).
-  The multiply is the same modulus-agnostic Russian-peasant double-and-add, so
-  no special reduction is required. Scratch buffers (`secf_mul_res`,
-  `secf_mul_acc`, `secf_pow_result`, `secf_pow_base`, `secf_tmp0`, `secf_cmp`)
-  are reused from the mod-p helpers: the two stacks never run concurrently. -/
+  The multiply is the same modulus-parameterized `Arith256Mod` accelerator
+  call, so no special reduction is required. Scratch buffers (`secf_le_a`,
+  `secf_le_b`, `secf_le_d`, `secf_pow_result`, `secf_pow_base`, `secf_tmp0`,
+  `secf_cmp`) are reused from the mod-p helpers: the two stacks never run
+  concurrently. -/
 
 /-- Reduce a value known to be below `2n` by subtracting n at most once.
     a0 = input, a1 = output; returns a0 = 1 if n was subtracted, else 0. -/
@@ -630,59 +686,32 @@ def secp256k1ScalarFieldAddFunction : String :=
   "  addi sp, sp, 48\n" ++
   "  ret"
 
-/-- Multiply two scalars modulo n using double-and-add over 256 bits. -/
+/-- Multiply two scalars modulo n via the ziskemu `Arith256Mod` accelerator
+    (same route as `secf_mul_mod_p`, with the modulus parameter block
+    pointing at n instead of p). -/
 def secp256k1ScalarFieldMulFunction : String :=
   "secf_mul_mod_n:\n" ++
-  "  addi sp, sp, -64\n" ++
+  "  addi sp, sp, -32\n" ++
   "  sd ra,  0(sp)\n" ++
   "  sd s0,  8(sp)\n" ++
   "  sd s1, 16(sp)\n" ++
-  "  sd s2, 24(sp)\n" ++
-  "  sd s3, 32(sp)\n" ++
-  "  sd s4, 40(sp)\n" ++
-  "  sd s5, 48(sp)\n" ++
-  "  mv s0, a0\n" ++
-  "  mv s1, a1\n" ++
-  "  mv s2, a2\n" ++
-  "  la s4, secf_mul_res\n" ++
-  "  la s5, secf_mul_acc\n" ++
-  "  mv a0, s4\n" ++
-  "  jal ra, secf_zero32\n" ++
+  "  mv s0, a1\n" ++
+  "  mv s1, a2\n" ++
+  "  la a1, secf_le_a\n" ++
+  "  jal ra, secf_be_to_le\n" ++
   "  mv a0, s0\n" ++
-  "  mv a1, s5\n" ++
-  "  jal ra, secf_reduce_once_n\n" ++
-  "  li s3, 0\n" ++
-  ".Lsecf_muln_loop:\n" ++
-  "  li t0, 256\n" ++
-  "  beq s3, t0, .Lsecf_muln_done\n" ++
-  "  mv a0, s1\n" ++
-  "  mv a1, s3\n" ++
-  "  jal ra, secf_get_bit_lsb\n" ++
-  "  beqz a0, .Lsecf_muln_double\n" ++
-  "  mv a0, s4\n" ++
-  "  mv a1, s5\n" ++
-  "  mv a2, s4\n" ++
-  "  jal ra, secf_add_mod_n\n" ++
-  ".Lsecf_muln_double:\n" ++
-  "  mv a0, s5\n" ++
-  "  mv a1, s5\n" ++
-  "  mv a2, s5\n" ++
-  "  jal ra, secf_add_mod_n\n" ++
-  "  addi s3, s3, 1\n" ++
-  "  j .Lsecf_muln_loop\n" ++
-  ".Lsecf_muln_done:\n" ++
-  "  mv a0, s4\n" ++
-  "  mv a1, s2\n" ++
-  "  jal ra, secf_copy32\n" ++
+  "  la a1, secf_le_b\n" ++
+  "  jal ra, secf_be_to_le\n" ++
+  "  la t0, secf_arith_params_n\n" ++
+  "  .4byte 0x8022a073           # csrs 0x802, t0 -> Arith256Mod\n" ++
+  "  la a0, secf_le_d\n" ++
+  "  mv a1, s1\n" ++
+  "  jal ra, secf_le_to_be\n" ++
   "  li a0, 0\n" ++
   "  ld ra,  0(sp)\n" ++
   "  ld s0,  8(sp)\n" ++
   "  ld s1, 16(sp)\n" ++
-  "  ld s2, 24(sp)\n" ++
-  "  ld s3, 32(sp)\n" ++
-  "  ld s4, 40(sp)\n" ++
-  "  ld s5, 48(sp)\n" ++
-  "  addi sp, sp, 64\n" ++
+  "  addi sp, sp, 32\n" ++
   "  ret"
 
 /-- Square one scalar modulo n. -/
@@ -784,6 +813,8 @@ def secp256k1FieldCommonFunctions : String :=
   u256LtBeFunction ++ "\n" ++
   secp256k1FieldCopy32Function ++ "\n" ++
   secp256k1FieldZero32Function ++ "\n" ++
+  secp256k1FieldBeToLeFunction ++ "\n" ++
+  secp256k1FieldLeToBeFunction ++ "\n" ++
   secp256k1FieldGetBitFunction ++ "\n" ++
   secp256k1FieldIsZeroFunction ++ "\n" ++
   secp256k1FieldEq32Function ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/TxPubkey.lean
+++ b/EvmAsm/Codegen/Programs/TxPubkey.lean
@@ -291,12 +291,11 @@ def txPubkeyEcrecoverStageMaterialFunction : String :=
     `Secp256k1Field` mod-n scalar helpers (reduce/mul/inv), the `Secp256k1Recover`
     R-decompression, and the `Secp256k1Curve` scalar-mul / point-add primitives.
 
-    PERFORMANCE: these primitives are the naive software stack -- bit-serial
-    double-and-add field multiply with a per-point-op Fermat field inversion -- so
-    one recovery is ~1e11 ziskemu steps, far over the stateless guest's budget.
-    Correctness is established here; before wiring recovery into the stateless
-    `public_keys` path the curve stack needs projective/Jacobian coordinates,
-    windowed/Shamir scalar multiplication, or the ecrecover accelerator.
+    PERFORMANCE: the field multiplies and affine point operations are backed
+    by the ziskemu accelerators (`Arith256Mod` / `Secp256k1Add` /
+    `Secp256k1Dbl`, see `Secp256k1Field` / `Secp256k1Curve`), so one full
+    recovery is ~2e6 ziskemu steps -- comfortably inside the stateless guest's
+    ~1e9 step budget (the earlier all-software stack was ~1e11 steps).
 
     Calling convention:
       a0 (input)  : encoded transaction ptr
@@ -448,8 +447,8 @@ def txPubkeyRecoverRawDataSection : String :=
     supplied 64 coordinate bytes against the recovered `x || y`.
 
     The prefix is checked BEFORE recovery: a non-`0x04` key can never match a
-    valid recovered point, and the early-out keeps the bad-prefix path free of the
-    expensive software recovery (~1e11 ziskemu steps), so it can be probed fast.
+    valid recovered point, and the early-out keeps the bad-prefix path free of
+    the recovery math (~2e6 ziskemu steps), so it can be probed fast.
 
     Calling convention:
       a0 (input)  : encoded transaction ptr
@@ -736,10 +735,10 @@ def ziskTxPubkeyRecoverRawStatusProbeUnit : BuildUnit := {
 /-- `zisk_tx_pubkey_public_key_matches_status`: probe BuildUnit.
 
     Drives `tx_pubkey_public_key_matches` over one transaction and a supplied
-    SEC1 public key. The cheap cases (bad prefix; signature-material failure) are
-    decided before the expensive recovery, so they run in a small step budget;
-    the match/mismatch cases run full software recovery and are gated behind the
-    check script's `RECOVER_RAW_FULL=1` switch (~1e11 steps).
+    SEC1 public key. The cheap cases (bad prefix; signature-material failure)
+    are decided before the recovery, so they run in a small step budget; the
+    match/mismatch cases run a full accelerator-backed recovery (~2e6 steps,
+    gated behind the check script's `RECOVER_RAW_FULL=1` switch).
 
     Input layout:
       bytes  0.. 8 : tx byte length

--- a/scripts/codegen-zisk-tx-pubkey-public-key-matches-check.sh
+++ b/scripts/codegen-zisk-tx-pubkey-public-key-matches-check.sh
@@ -7,17 +7,16 @@
 # equal recover_transaction_public_key(chain_id, tx).
 #
 # The helper checks the supplied 0x04 SEC1 prefix and the signature-material
-# class BEFORE running the expensive software recovery, so the bad-prefix
-# (status 2) and material-failure (status 10) cases are decided in a small step
-# budget. The match (status 0) and mismatch (status 1) cases require a full
-# software recovery.
+# class BEFORE running the recovery, so the bad-prefix (status 2) and
+# material-failure (status 10) cases are decided in a small step budget. The
+# match (status 0) and mismatch (status 1) cases require a full recovery.
 #
-# COST: one full recovery composes the naive Secp256k1Field/Curve primitives
-# (bit-serial multiply + per-point-op Fermat inversion), so it is ~1e11 ziskemu
-# steps (~10+ minutes). The match/mismatch success cases are therefore gated
-# behind RECOVER_RAW_FULL=1; the default run only exercises the fast routing
-# (bad prefix + material failure). Performance work before wiring recovery into
-# the stateless public_keys path is tracked separately.
+# COST: one full recovery composes the ziskemu-accelerator-backed
+# Secp256k1Field/Curve primitives (Arith256Mod modular multiply;
+# Secp256k1Add/Dbl affine point ops), so it is ~2e6 ziskemu steps. The
+# match/mismatch cases stay behind RECOVER_RAW_FULL=1 (they rebuild signed-tx
+# vectors via execution-specs/coincurve) and are gated at the stateless
+# guest's 1e9 step budget, so a regression past the budget fails this script.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
@@ -159,11 +158,12 @@ run_case "bad_prefix"    "bad_prefix"    2  10000000 0 || FAILED=1
 run_case "material_fail" "material_fail" 10 10000000 0 || FAILED=1
 
 if [[ "${RECOVER_RAW_FULL:-0}" == "1" ]]; then
-  echo "==> RECOVER_RAW_FULL=1: running full software recovery (slow, ~1e11 steps)"
+  echo "==> RECOVER_RAW_FULL=1: running full recovery (~2e6 steps, gated at 1e9)"
   # Valid legacy EIP-155 tx signed by private key 1: the supplied G key matches
   # (status 0); a one-byte-flipped key mismatches (status 1).
-  run_case "match"    "match"    0 200000000000 1 || FAILED=1
-  run_case "mismatch" "mismatch" 1 200000000000 0 || FAILED=1
+  # The 1e9 cap is the stateless guest step budget (evm-asm-mcogi.5.5).
+  run_case "match"    "match"    0 1000000000 1 || FAILED=1
+  run_case "mismatch" "mismatch" 1 1000000000 0 || FAILED=1
 else
   echo "==> (skipping full match/mismatch cases; set RECOVER_RAW_FULL=1 to run them)"
 fi

--- a/scripts/codegen-zisk-tx-pubkey-recover-raw-status-check.sh
+++ b/scripts/codegen-zisk-tx-pubkey-recover-raw-status-check.sh
@@ -10,14 +10,12 @@
 # underlying material status preserved in the side slot. This deliberately does
 # NOT compare stateless public_keys; that lands in later children.
 #
-# COST: the recovery composes the naive Secp256k1Field/Curve primitives
-# (bit-serial double-and-add field multiply with a per-point-op Fermat field
-# inversion), so ONE recovery is ~1e11 ziskemu steps (~10+ minutes). The valid
-# end-to-end success case is therefore OPT-IN, gated behind RECOVER_RAW_FULL=1.
-# The default run only exercises the fast material-failure routing. The
-# performance work needed before wiring recovery into the stateless public_keys
-# path (projective/Jacobian coordinates, windowed/Shamir scalar multiplication,
-# or the zkvm_secp256k1_ecrecover accelerator) is tracked separately.
+# COST: the recovery composes the ziskemu-accelerator-backed Secp256k1Field/
+# Curve primitives (Arith256Mod modular multiply; Secp256k1Add/Dbl affine point
+# ops), so ONE recovery is ~2e6 ziskemu steps. The success case stays behind
+# RECOVER_RAW_FULL=1 (it rebuilds the signed-tx vector via execution-specs/
+# coincurve) and is gated at the stateless guest's 1e9 step budget, so a
+# regression past the budget fails this script (EmulationNoCompleted).
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
@@ -154,10 +152,11 @@ FAILED=0
 run_case "bad_s_high" "bad_s_high" 10 43 10000000 0 || FAILED=1
 
 if [[ "${RECOVER_RAW_FULL:-0}" == "1" ]]; then
-  echo "==> RECOVER_RAW_FULL=1: running full software recovery (slow, ~1e11 steps)"
+  echo "==> RECOVER_RAW_FULL=1: running full recovery (~2e6 steps, gated at 1e9)"
   # Valid legacy EIP-155 tx signed by private key 1: recovery must return
   # status 0 and the secp256k1 generator point G as the recovered public key.
-  run_case "legacy_eip155" "legacy_eip155" 0 0 200000000000 1 || FAILED=1
+  # The 1e9 cap is the stateless guest step budget (evm-asm-mcogi.5.5).
+  run_case "legacy_eip155" "legacy_eip155" 0 0 1000000000 1 || FAILED=1
 else
   echo "==> (skipping full recovery success case; set RECOVER_RAW_FULL=1 to run it)"
 fi


### PR DESCRIPTION
## Summary

Closes the **evm-asm-mcogi.5.5** performance gate: one full software secp256k1 ECDSA public-key recovery drops from **~1e11 ziskemu steps to 1,981,044 steps** (measured, `RECOVER_RAW_FULL=1` legacy EIP-155 priv=1 vector, recovering exactly G) — ~500x under the stateless guest's ~1e9 step budget. This unblocks wiring tx-sender recovery into the stateless verdict (evm-asm-bmvmx.3 / mcogi.3).

## What changed

The hot primitives are re-backed by ziskemu accelerators, with every call surface (32-byte big-endian buffers, registers, return codes) unchanged so all downstream recovery code works as-is:

- `secf_mul_mod_p` / `secf_mul_mod_n` → **Arith256Mod** (`csrs 0x802`): exact `d = (a*b + c) mod m` with the modulus as a parameter; one op replaces the 256-iteration bit-serial loop for both moduli. Fermat inv/sqrt/pow inherit the speedup.
- `secp256k1_point_add` / `secp256k1_point_double` → **Secp256k1Add/Dbl** (`csrs 0x803/0x804`): kills the per-point-op Fermat field inversion. Affine special cases (infinity, y=0 doubling, equal-x add) stay in software.
- CSR instructions are pre-encoded `.4byte` words (the existing Keccak-f probe pattern) — no `Zicsr`/toolchain change, no symbol linking. New `secf_be_to_le`/`secf_le_to_be` helpers bridge to the accelerator limb format; all memory accesses stay naturally aligned.

Note: mcogi.5.1 had classified the accelerator route "not link-ready", but that only covered undefined-symbol routes (`syscall_secp256k1_add` etc.); the raw CSR encoding needs no linking and is verified working end-to-end.

## Verification

- `scripts/codegen-zisk-secp256k1-field-check.sh` — all add/sub/mul/square/inv/sqrt cases PASS vs Python oracles
- `scripts/codegen-zisk-secp256k1-curve-check.sh` / `-scalar-check.sh` / `-recover-check.sh` — PASS
- `RECOVER_RAW_FULL=1 scripts/codegen-zisk-tx-pubkey-recover-raw-status-check.sh` — PASS, status 0, pubkey == G
- `RECOVER_RAW_FULL=1 scripts/codegen-zisk-tx-pubkey-public-key-matches-check.sh` — PASS (match=0, mismatch=1)
- Full-recovery script cases now gated at `-n 1000000000` (the stateless budget), so a perf regression fails the script
- `lake build codegen`, check-file-size, check-unimported, forbidden-tactics, `git diff --check` all clean

Bead: evm-asm-mcogi.5.5 (unblocks evm-asm-mcogi.3, evm-asm-mcogi.4, evm-asm-bmvmx.3)