### PR TITLE
feat(layout): 200M Amsterdam block-gas support — right-sized arenas + gas-derived system-call caps

### DIFF
--- a/EvmAsm/Codegen/CallFrameLayout.lean
+++ b/EvmAsm/Codegen/CallFrameLayout.lean
@@ -96,22 +96,31 @@ def sszScratchBase : Nat := 0xbf500000
 /-- Total bytes the pre-allocated frame array occupies. -/
 def frameArrayBytes : Nat := frameSlotCount * frameStride
 
-/-! ## Placement: union with the BAL-replay scratch (NOT a free `.data` gap)
+/-! ## Placement: standalone block after the BAL-replay arenas (200M layout)
 
-    ziskemu's RAM is only 512 MiB (`0xa0000000..0xc0000000`) and the guest `.data`
-    already spans ~427 MiB — there is NO free window for a standalone arena (an
-    earlier draft placed it at `0xa4000000`, which overlaps `.data`; the linker
-    rejects it). Instead the frame arena **aliases** the contiguous
-    `basr_values`+`basr_accounts` `block_state_root` replay scratch, which is
-    execution-dead (read only inside `block_state_root`; gate-verified). So the
-    arena's base is a **link-time symbol** (`call_frame_arena = &basr_values`,
-    not a fixed VMA), and the meaningful invariant is that the frame arena fits
-    inside that union, not inside a phantom gap. See
-    `docs/call-frame-memory-layout.md` §5. -/
+    ziskemu's RAM is 512 MiB (`0xa0000000..0xc0000000`). Under the former
+    1G-sized BAL arenas (`bsrMaxBalItems = 500000`, ~416 MiB) there was no free
+    window, so the frame arena *aliased* the contiguous, execution-dead
+    `basr_values`+`basr_accounts` pair (the #8513 union, 244 MiB ≥ 164 MiB).
+    The Amsterdam target is 200M block gas (`bsrMaxBalItems = 100000`), which
+    shrinks the BAL arenas to ~83 MiB — the basr pair (~49 MiB) can no longer
+    host the frame array, and the freed ~333 MiB means it no longer needs to:
+    `call_frame_arena` is a standalone pre-zeroed `.zero frameArrayBytes` block
+    emitted right after `basr_accounts` (`BlockVerdictDataSection.lean`), and
+    the execution-dead soundness gate on `basr_values`/`basr_accounts` is no
+    longer load-bearing. See `docs/call-frame-memory-layout.md` §5. -/
 
-/-- The `basr_values`+`basr_accounts` union the frame arena reuses: two
-    contiguous `bsrMaxStateChanges * bsrEncodedAccountBytes` arenas. -/
-def balReplayUnionBytes : Nat := 2 * (bsrMaxStateChanges * bsrEncodedAccountBytes)
+/-- Total bytes of all 200M-sized BAL/state-replay static arenas
+    (`bsr_changes` + `basr_records/paths/values/accounts` +
+    `baap_storage_desc/paths/delete_paths/values`), matching the `.zero`
+    declarations in `BlockVerdictDataSection.lean`. -/
+def balArenaTotalBytes : Nat :=
+  bsrMaxStateChanges * bsrStateChangeBytes
+    + bsrMaxStateChanges * bsrAccountRecordBytes
+    + bsrMaxStateChanges * bsrPathBytes
+    + 2 * (bsrMaxStateChanges * bsrEncodedAccountBytes)
+    + bsrMaxBalItems * baapStorageDescBytes
+    + 3 * (bsrMaxBalItems * bsrPathBytes)
 
 /-! ## Verified consistency invariants (kernel-checked `decide`) -/
 
@@ -128,16 +137,19 @@ theorem frameMeta_within_stride : frameMetaOff + frameMetaBytes ≤ frameStride 
 /-- 1025 slots cover depths 0..1024 inclusive. -/
 theorem frameSlotCount_eq : frameSlotCount = 1025 := by decide
 
-/-- **The fits proof that actually matters:** the whole 1025-slot frame array
-    fits inside the `basr_values`+`basr_accounts` union it overlays (244 MiB vs
-    164 MiB — 84 MiB headroom), so the arena reuses that execution-dead region
-    with zero net RAM growth. (This replaces the earlier `frameArray_fits` that
-    compared against a phantom free `.data` gap.) -/
-theorem frameArray_fits_union : frameArrayBytes ≤ balReplayUnionBytes := by decide
+/-- **The fits proof that actually matters (200M layout):** the BAL/state-replay
+    arenas (~83 MiB at the 200M capacity) plus the standalone 1025-slot frame
+    array (~164 MiB) together stay well inside the `.data`→`.sszscratch` span
+    (453 MiB) — ~206 MiB of slack for the remaining `.data` objects (~80 MiB
+    measured). The ELF-level ground truth is `readelf -lW`: the top RW LOAD
+    address must stay below the 0xc0000000 RAM ceiling. (Replaces
+    `frameArray_fits_union`, which pinned the retired #8513 basr aliasing.) -/
+theorem frameArray_and_balArenas_fit :
+    balArenaTotalBytes + frameArrayBytes ≤ sszScratchBase - dataBase := by decide
 
 /-- The usable `.data`→`.sszscratch` span is `0x1c500000` = 475,004,928 B
-    = 453 MiB — but it is NOT free (the BAL-replay arenas consume ~385 MiB of it),
-    which is why the arena overlays them rather than taking a fresh slice. -/
+    = 453 MiB. Under the 200M layout the BAL-replay arenas (~83 MiB) and the
+    standalone frame array (~164 MiB) leave ample room for the rest of `.data`. -/
 theorem data_gap_bytes : sszScratchBase - dataBase = 0x1c500000 := by decide
 
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -2381,7 +2381,7 @@ def emitRuntimeDispatcherEmbeddedHelperData : String :=
   -- (1025 entries × 16 B), indexed by depth 0..1024. These back the
   -- frame_depth_push/pop and frame_save_regs/load_regs helpers linked above.
   -- `call_frame_arena` itself lives in the guest verdict data
-  -- (BlockVerdictDataSection, aliasing basr_values).
+  -- (BlockVerdictDataSection, a standalone block after basr_accounts).
   ".balign 8\n" ++
   "evm_call_depth:\n" ++
   "  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/AccountTupleSequencesConsistent.lean
+++ b/EvmAsm/Codegen/Programs/AccountTupleSequencesConsistent.lean
@@ -18,9 +18,10 @@
   a no-op there; it bites once the multi-tx loop sets `current_block_access_index` per
   tx (.57.11.6.3).
 
-  Buffer note: `atsc_balbuf`/`atsc_execbuf` hold up to 256 tuples (40 B each) per slot;
-  the producers write `count` records, so wiring against blocks whose per-slot tuple
-  count can exceed 256 must enlarge these (bounded by the block's transaction count).
+  Buffer note: `atsc_balbuf`/`atsc_execbuf` hold up to bsrMaxTuplesPerSlot tuples
+  (40 B each) per slot (.66.1.2: gas-derived — per-slot tuple count is bounded by the
+  block's transaction count, <= ~9.5k at 200M gas). bal_slot_tuple_sequence writes
+  nothing and returns the true count above the cap; the call site bails to .Latsc_fail.
 -/
 
 import EvmAsm.Rv64.Program
@@ -30,6 +31,7 @@ import EvmAsm.Codegen.Programs.Tx
 import EvmAsm.Codegen.Programs.BalSlotTupleSequence
 import EvmAsm.Codegen.Programs.ExecLogSlotTuples
 import EvmAsm.Codegen.Programs.SlotTupleSequencesMatch
+import EvmAsm.Codegen.Programs.BlockVerdictParams
 
 namespace EvmAsm.Codegen
 
@@ -98,6 +100,9 @@ def accountTupleSequencesConsistentFunction : String :=
   "  # BAL tuple sequence for this slot (searched by BE atsc_key)\n" ++
   "  mv a0, s0; mv a1, s1; la a2, atsc_key; la a3, atsc_balbuf\n" ++
   "  jal ra, bal_slot_tuple_sequence\n" ++
+  -- .66.1.2: > bsrMaxTuplesPerSlot -> the helper wrote nothing (returns the true count);
+  -- bail conservatively instead of comparing against stale atsc_balbuf contents.
+  "  li t0, " ++ toString bsrMaxTuplesPerSlot ++ "; bgtu a0, t0, .Latsc_fail\n" ++
   "  la t0, atsc_balcount; sd a0, 0(t0)                   # bal_count\n" ++
   "  # reverse each BAL tuple's 32B value (BE -> LE) to match the LE exec output\n" ++
   "  mv t0, a0; la t1, atsc_balbuf                        # t0=count; record = bai@0, value@8\n" ++
@@ -136,8 +141,8 @@ def accountTupleSequencesConsistentData : String :=
   ".balign 32\n" ++
   "atsc_key:\n  .zero 32\n" ++
   "atsc_key_le:\n  .zero 32\n" ++       -- LE byte-reverse of atsc_key for the exec-log search (bmvmx.1.6.6)
-  "atsc_balbuf:\n  .zero 10240\n" ++   -- up to 256 tuples * 40B
-  "atsc_execbuf:\n  .zero 10240\n"
+  "atsc_balbuf:\n  .zero " ++ toString (bsrMaxTuplesPerSlot * 40) ++ "\n" ++   -- .66.1.2: bsrMaxTuplesPerSlot tuples * 40B (was 256; one net-change tuple per tx, ~9.5k max at 200M)
+  "atsc_execbuf:\n  .zero " ++ toString (bsrMaxTuplesPerSlot * 40) ++ "\n"
 
 /-- `zisk_account_tuple_sequences_consistent`: focused probe.
     Input (after the ziskemu length wrapper at 0x40000000):

--- a/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
@@ -14,6 +14,7 @@ import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.AccountBalance
 import EvmAsm.Codegen.Programs.AccountApplyStorage
 import EvmAsm.Codegen.Programs.BalAccountPostFields
+import EvmAsm.Codegen.Programs.BlockVerdictParams
 import EvmAsm.Codegen.Programs.MptStateRootIns
 
 import EvmAsm.Codegen.Programs.MptEncodeLeafBranch
@@ -265,7 +266,7 @@ def balAccountApplyPostFieldsFunction : String :=
   ".Lbaap_multi_loop:\n" ++
   "  la t0, baap_sc_index; ld t0, 0(t0); la t1, baap_sc_count; ld t1, 0(t1)\n" ++
   "  beq t0, t1, .Lbaap_multi_apply\n" ++
-  "  li t2, 60000; bgeu t0, t2, .Lbaap_fail\n" ++
+  "  li t2, " ++ toString bsrMaxBalItems ++ "; bgeu t0, t2, .Lbaap_fail\n" ++
   "  la t1, baap_sc_ptr; ld a0, 0(t1); la t1, baap_sc_len; ld a1, 0(t1); mv a2, t0\n" ++
   "  la a3, baap_item_off; la a4, baap_item_len\n" ++
   "  jal ra, rlp_list_nth_item\n" ++
@@ -315,7 +316,7 @@ def balAccountApplyPostFieldsFunction : String :=
   "  addi a0, a0, 1; addi a1, a1, -1; j .Lbaap_multi_value_strip_zero\n" ++
   ".Lbaap_multi_zero_value:\n" ++
   "  la t0, baap_storage_empty_flag; ld t0, 0(t0); bnez t0, .Lbaap_multi_skip_zero\n" ++
-  "  la t0, baap_storage_delete_count; ld t0, 0(t0); li t1, 60000; bgeu t0, t1, .Lbaap_fail\n" ++
+  "  la t0, baap_storage_delete_count; ld t0, 0(t0); li t1, " ++ toString bsrMaxBalItems ++ "; bgeu t0, t1, .Lbaap_fail\n" ++
   "  li t1, 1; la t2, baap_storage_delete_flag; sd t1, 0(t2)\n" ++
   "  la a0, baap_slot; li a1, 32; la a2, srss_key\n" ++
   "  jal ra, zkvm_keccak256\n" ++

--- a/EvmAsm/Codegen/Programs/BalSlotTupleSequence.lean
+++ b/EvmAsm/Codegen/Programs/BalSlotTupleSequence.lean
@@ -26,6 +26,7 @@ import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.Tx
+import EvmAsm.Codegen.Programs.BlockVerdictParams
 
 namespace EvmAsm.Codegen
 
@@ -34,7 +35,10 @@ open EvmAsm.Rv64
 /-! ## bal_slot_tuple_sequence
     a0 = AccountChanges RLP ptr   a1 = AccountChanges RLP length
     a2 = target slot key ptr (32-byte big-endian)   a3 = out buffer ptr
-    a0 (output) = tuple count for the matching slot (0 if not found / parse failure). -/
+         (caller buffer must hold bsrMaxTuplesPerSlot x 40-byte records)
+    a0 (output) = tuple count for the matching slot (0 if not found / parse failure;
+    if > bsrMaxTuplesPerSlot, NOTHING is written and the true count is returned —
+    the caller must treat counts above the cap as a conservative bail). -/
 def balSlotTupleSequenceFunction : String :=
   "bal_slot_tuple_sequence:\n" ++
   "  addi sp, sp, -80\n" ++
@@ -102,6 +106,12 @@ def balSlotTupleSequenceFunction : String :=
   "  jal ra, rlp_list_count_items\n" ++
   "  bnez a0, .Lbts_notfound\n" ++
   "  la t0, bts_tcnt; ld s7, 0(t0)                    # reuse s7 = tuple count\n" ++
+  -- fhsxz.2.4.2.66.1.1/.66.1.2: bound the output. Every consumer buffer (sps_tuples,
+  -- atsc_balbuf) holds bsrMaxTuplesPerSlot 40-byte records; an adversarial BAL can
+  -- declare more tuples than any legitimate <=200M block (one net-change tuple per tx).
+  -- Above the cap, write NOTHING and return the true count (jump straight to done) so
+  -- callers bail conservatively instead of this loop overflowing adjacent .data.
+  "  li t0, " ++ toString bsrMaxTuplesPerSlot ++ "; bgtu s7, t0, .Lbts_done\n" ++
   "  li s4, 0                     # reuse s4 = tuple index j (sc ptr no longer needed)\n" ++
   ".Lbts_tloop:\n" ++
   "  beq s4, s7, .Lbts_done\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictContractStorage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictContractStorage.lean
@@ -16,6 +16,7 @@
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.BlockVerdictParams
 
 namespace EvmAsm.Codegen
 
@@ -27,7 +28,8 @@ open EvmAsm.Rv64
 
     Calling convention:
       a0 = AccountChanges RLP ptr   a1 = AccountChanges RLP length
-      a2 = out keys ptr (count x 32-byte big-endian slot keys; caller buffer must hold 512)
+      a2 = out keys ptr (count x 32-byte big-endian slot keys; caller buffer must hold
+           bsrAccountSlotCap entries)
     Returns:
       a0 = entry count (0 on parse failure — conservative). Keys are written only when
            the count is <= 512 (the caller-buffer cap); if it exceeds 512, NOTHING is
@@ -54,16 +56,17 @@ def balRecipientStorageKeysFunction : String :=
   "  jal ra, rlp_list_count_items\n" ++
   "  bnez a0, .Lbrsk_fail\n" ++
   "  la t0, brsk_cnt; ld s5, 0(t0)                   # entry count\n" ++
-  -- bmvmx.1.7.3: cap the write at the caller KEY-buffer size — bvcd_keys, csce_keys and
-  -- sps_keys are all sized 512*32 (fhsxz.2.4.2.66.1 raised the cap from 128: the
-  -- system_contract_errors EEST predeploys legitimately commit 306 storage changes, which
-  -- the system-call preload must stage). If the BAL declares MORE storage_changes than fit,
-  -- write NOTHING and return the true count so the caller bails conservatively
-  -- (.Ldtrc_unsupported / skip-account / requests-hash fail) instead of overflowing into
-  -- adjacent .data. The regular-tx callers still bail at their own >128 thresholds
-  -- (bvcd_preload and the callee-seed table stay 128-sized); only the system-call preload
-  -- path consumes counts up to 512.
-  "  li t0, 512; bgtu s5, t0, .Lbrsk_done            # count > cap -> return count, write nothing\n" ++
+  -- bmvmx.1.7.3 / fhsxz.2.4.2.66.1.2: cap the write at the caller KEY-buffer size —
+  -- bvcd_keys, csce_keys and sps_keys are all sized bsrAccountSlotCap*32. The cap is
+  -- gas-derived (= bsrMaxBalItems: one account's changes+reads can absorb the whole
+  -- 200M BAL budget; the former 512 cap false-rejected queue-heavy blocks far below
+  -- 200M). If the BAL declares MORE storage_changes than fit, write NOTHING and return
+  -- the true count so the caller bails conservatively (.Ldtrc_unsupported /
+  -- skip-account / requests-hash fail) instead of overflowing into adjacent .data. The
+  -- regular-tx callers still bail at their own >128 thresholds (bvcd_preload and the
+  -- callee-seed table stay 128-sized); only the system-call preload path consumes
+  -- large counts.
+  "  li t0, " ++ toString bsrAccountSlotCap ++ "; bgtu s5, t0, .Lbrsk_done            # count > cap -> return count, write nothing\n" ++
   "  mv s6, zero                  # i\n" ++
   "  mv s7, s2                    # out cursor\n" ++
   ".Lbrsk_loop:\n" ++
@@ -141,9 +144,9 @@ def balRecipientStorageReadsKeysFunction : String :=
   "  jal ra, rlp_list_count_items\n" ++
   "  bnez a0, .Lbrsrk_zero\n" ++
   "  la t0, brsk_cnt; ld s6, 0(t0)                   # sr count\n" ++
-  -- fhsxz.2.4.2.66.1: absolute clamp raised 128 -> 512 in lockstep with the key buffers;
-  -- the real per-caller bound is a3 (remaining capacity), which every caller passes.
-  "  li t0, 512; bgtu s6, t0, .Lbrsrk_done           # > cap -> count, write nothing\n" ++
+  -- fhsxz.2.4.2.66.1.2: absolute clamp = bsrAccountSlotCap, in lockstep with the key
+  -- buffers; the real per-caller bound is a3 (remaining capacity), which every caller passes.
+  "  li t0, " ++ toString bsrAccountSlotCap ++ "; bgtu s6, t0, .Lbrsrk_done           # > cap -> count, write nothing\n" ++
   "  bgtu s6, s3, .Lbrsrk_done                       # > remaining capacity -> count, write nothing\n" ++
   "  li s7, 0                     # i (SAVED reg: rlp_list_nth_item clobbers t-regs)\n" ++
   ".Lbrsrk_loop:\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -218,7 +218,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bvcd_key_count:\n  .zero 8\n" ++
   "bvcd_sc_count:\n  .zero 8\n" ++
   "bvcd_i:\n  .zero 8\n" ++
-  "bvcd_keys:\n  .zero 16384\n" ++     -- fhsxz.2.4.2.66.1: 512 x 32-byte slot keys (bal_recipient_storage_keys now caps at 512; the dispatch-tx caller still bails >128 — bvcd_preload stays 128-sized — but the keys it writes before that bail must fit)
+  "bvcd_keys:\n  .zero " ++ toString (bsrAccountSlotCap * 32) ++ "\n" ++     -- .66.1.2: bsrAccountSlotCap x 32-byte slot keys (bal_recipient_storage_keys caps at the gas-derived bsrAccountSlotCap; the dispatch-tx caller still bails >128 — bvcd_preload stays 128-sized — but the keys the helper writes before that bail must fit)
   "bvcd_preload:\n  .zero 8192\n" ++   -- bmvmx.1.7.3: up to 128 x 64-byte (key,value) pairs (was 16)
   -- bmvmx.1.6.2 exec-vs-BAL recipient storage check scratch (bal_storage_change_values +
   -- bal_storage_matches_exec_log), now linked into the verdict's contract-dispatch tail.
@@ -246,7 +246,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   "csce_key_i:\n  .zero 8\n" ++ "csce_key_n:\n  .zero 8\n" ++
   ".balign 32\n" ++
   "csce_addrkey:\n  .zero 32\n" ++
-  "csce_keys:\n  .zero 16384\n" ++   -- fhsxz.2.4.2.66.1: 512 x 32-byte slot keys (matches the raised bal_recipient_storage_keys cap; the seed loop still skips accounts >128)
+  "csce_keys:\n  .zero " ++ toString (bsrAccountSlotCap * 32) ++ "\n" ++   -- .66.1.2: bsrAccountSlotCap x 32-byte slot keys (matches the gas-derived bal_recipient_storage_keys cap; the seed loop still skips accounts >128)
 
   "bv_eip7778_status:\n  .zero 8\n" ++
   "bv_eip7778_index:\n  .zero 8\n" ++
@@ -338,10 +338,12 @@ def ziskStatelessVerdictV2DataSection : String :=
   -- (modified 7002/7251 contracts of 72946 B; predeploy code is NOT EIP-170-bounded):
   -- stage_runtime_payload_code's zero+code copy ran ~40 KiB past the buffer, smashing
   -- every .data global above (c1_saved_*, dbsr_*, rlp args) -> ERROR(exit)/false-reject.
-  -- 131072 fits round8(code) + preload + M29 + 584 for those rows; the new size guard in
-  -- stage_system_call_payload (SystemCallStaging.lean, keep its 131072 literal in sync)
-  -- bails on anything larger instead of corrupting .data.
-  "c1_staging:\n  .zero 131072\n" ++
+  -- .66.1.2: sized by the shared c1StagingBytes constant (BlockVerdictParams.lean) =
+  -- bsrMaxWitnessBytes + bsrAccountSlotCap*64 + 16384 — fits round8(code <= witness cap)
+  -- + the gas-derived preload + M29 + 584. The size guard in stage_system_call_payload
+  -- (SystemCallStaging.lean) uses the same constant and bails on anything larger
+  -- instead of corrupting .data.
+  "c1_staging:\n  .zero " ++ toString c1StagingBytes ++ "\n" ++
   ".balign 8\n" ++
   "c1_er_assembled:\n  .zero 2048\n" ++
   "c1_ccode_ptr:\n  .zero 8\n" ++
@@ -349,7 +351,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   "c1_bal_acct_ptr:\n  .zero 8\n" ++
   "c1_bal_acct_len:\n  .zero 8\n" ++
   ".balign 8\n" ++
-  "c1_preload:\n  .zero 32768\n" ++   -- fhsxz.2.4.2.66.1: 512 x 64-byte (key,value) pairs (was 128; the system_contract_errors predeploys commit 306 BAL storage changes that the system-call preload must stage)
+  "c1_preload:\n  .zero " ++ toString (bsrAccountSlotCap * 64) ++ "\n" ++   -- .66.1.2: bsrAccountSlotCap x 64-byte (key,value) pairs — gas-derived (a 200M block's user txs can legitimately put up to the whole BAL budget of changes+reads on a predeploy; the former 512 false-rejected those blocks)
   "c1_bal_start:\n  .zero 8\n" ++
   "c1_bal_len:\n  .zero 8\n" ++
   "c1_bal_count:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -6,6 +6,7 @@
 -/
 
 import EvmAsm.Codegen.Programs.BlockVerdictParams
+import EvmAsm.Codegen.CallFrameLayout
 import EvmAsm.Codegen.Programs.StatelessVerdict
 import EvmAsm.Codegen.Programs.RequestsHash
 import EvmAsm.Codegen.Programs.BalAccountHasStateChange
@@ -612,18 +613,18 @@ def ziskStatelessVerdictV2DataSection : String :=
   "baada_item_len:\n  .zero 8\n" ++
   "basr_records:\n  .zero " ++ toString (bsrMaxStateChanges * bsrAccountRecordBytes) ++
   "\nbasr_paths:\n  .zero " ++ toString (bsrMaxStateChanges * bsrPathBytes) ++
-  -- .61.3.1: the nested call-frame arena aliases basr_values+basr_accounts.
-  -- These two are block_state_root replay scratch, read ONLY inside
-  -- block_state_root (BlockVerdict.lean <=302) and dead during tx execution
-  -- (gate-verified: no post-replay reader); the contiguous pair is
-  -- 2*bsrMaxStateChanges*bsrEncodedAccountBytes = 244 MiB >= the 1025*FRAME_STRIDE
-  -- = 164 MiB the frame arena needs, so the arena reuses this region (union, zero
-  -- net RAM growth) once the dispatcher is rebased onto frame[0] in .61.3.2.
-  -- `basr_records` (just above) is LIVE during execution (:528/577/620) and is
-  -- excluded by aliasing here, after it. See docs/call-frame-memory-layout.md §5.
-  "\ncall_frame_arena:\n" ++
-  "basr_values:\n  .zero " ++ toString (bsrMaxStateChanges * bsrEncodedAccountBytes) ++
+  "\nbasr_values:\n  .zero " ++ toString (bsrMaxStateChanges * bsrEncodedAccountBytes) ++
   "\nbasr_accounts:\n  .zero " ++ toString (bsrMaxStateChanges * bsrEncodedAccountBytes) ++
+  -- .61.3.1, re-sized for the 200M block-gas target: the nested call-frame arena
+  -- is now a STANDALONE 1025*frameStride pre-zeroed block. It used to alias
+  -- basr_values+basr_accounts (the #8513 union, forced by the 1G-sized BAL arenas
+  -- leaving no free RAM), but at the 200M capacity that pair is ~49 MiB — smaller
+  -- than the ~164 MiB frame array — while the BAL downsize frees ~333 MiB, so the
+  -- arena gets its own region (and the basr_* execution-dead soundness gate is no
+  -- longer load-bearing). Fit pinned by `frameArray_and_balArenas_fit`
+  -- (CallFrameLayout.lean); ELF ground truth = readelf -lW top RW LOAD < 0xc0000000.
+  "\n.balign 32\n" ++
+  "call_frame_arena:\n  .zero " ++ toString frameArrayBytes ++
   "\ncall_frame_arena_end:\n" ++ "\n" ++
   "bara_item_off:\n  .zero 8\n" ++
   "bara_item_len:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
@@ -13,11 +13,15 @@ import EvmAsm.Codegen.Programs.EvmStorageAccessGas
 namespace EvmAsm.Codegen
 
 def bsrBalGasCost : Nat := 2000
-/-- Static BAL/state replay arena capacity. This is sized like the former 1G
-    worst-case BAL budget, but high declared block gas is not itself a layout
-    error: the guest first applies Amsterdam's gas-derived BAL rule, then checks
-    actual decoded item counts against these arenas. -/
-def bsrMaxBalItems : Nat := 500000
+/-- Static BAL/state replay arena capacity, sized for the Amsterdam 200M
+    block-gas target: `bal_items <= block_gas_limit / 2000` = 100,000 items at
+    200,000,000 gas. (The former 500,000 value was the 1G worst case, which is
+    out of scope — it cost ~349 MB of the fixed 512 MiB ziskemu RAM window.)
+    High declared block gas is not itself a layout error: the guest first
+    applies Amsterdam's gas-derived BAL rule, then checks actual decoded item
+    counts against these arenas; blocks whose actual counts exceed the
+    capacities take the conservative bsr_fail path. -/
+def bsrMaxBalItems : Nat := 100000
 def bsrModeledSystemChanges : Nat := 2
 def bsrMaxWithdrawalChanges : Nat := 16
 def bsrMaxAuxChanges : Nat := bsrModeledSystemChanges + bsrMaxWithdrawalChanges

--- a/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
@@ -31,6 +31,27 @@ def bsrMaxAccessAccounts : Nat := runtimeAccessAccountOutcomeCapacity
 def bsrMaxAccountAccessOutcomes : Nat := runtimeAccessAccountOutcomeCapacity
 def bsrMaxStorageAccessOutcomes : Nat := storageAccessOutcomeMaxRecords
 
+/-- Per-account storage-slot staging capacity for the BAL key/preload helpers
+    (`bal_recipient_storage_keys`, `bal_recipient_storage_reads_keys`,
+    `stage_predeploy_storage_preload` and their consumer buffers `sps_keys` /
+    `bvcd_keys` / `csce_keys` / `c1_preload`). One account's changes+reads can
+    absorb the entire gas-derived BAL budget (storage reads are the cheapest
+    BAL item), so the only bound that avoids conservative rejects of legitimate
+    200M blocks is `bsrMaxBalItems` itself. Counts above this make the helpers
+    write nothing and return the true count; callers bail conservatively
+    (fhsxz.2.4.2.66.1.2 — the former 512 cap false-rejected queue-heavy
+    blocks far below 200M). -/
+def bsrAccountSlotCap : Nat := bsrMaxBalItems
+
+/-- Max per-slot change-tuple count staged by `bal_slot_tuple_sequence`
+    (consumer buffers `sps_tuples` / `atsc_balbuf` / `atsc_execbuf`, 40 B per
+    tuple). A slot receives at most one net-change tuple per tx (plus the
+    block-end system write and a possible seed entry), and a 200M block holds
+    at most 200,000,000 / 21,000 = 9,523 txs; 10,000 adds margin. Above this
+    the helper writes nothing and returns the true count — callers bail
+    conservatively (also closes the .66.1.1 unbounded-write corruption). -/
+def bsrMaxTuplesPerSlot : Nat := 10000
+
 /-- Conservative upper bound on `witness.state` byte length accepted by
     `block_state_root`. Beyond this the post-state recompute bails conservatively
     (bsr_fail=111). This is a coarse size guard, NOT a fixed-buffer limit: the
@@ -40,6 +61,15 @@ def bsrMaxStorageAccessOutcomes : Nat := storageAccessOutcomeMaxRecords
     reservoir fixtures push >256 KiB witnesses, e.g. evm-asm-zbvak's 336 KB row);
     512 KiB keeps a guard while accepting those blocks. -/
 def bsrMaxWitnessBytes : Nat := 524288
+
+/-- `c1_staging` (system-call payload buffer) byte size: must hold
+    round8(predeploy codelen) + preload_count*64 + m29_count*32 + 584.
+    Predeploy code comes from the witness and is NOT EIP-170-bounded, but the
+    whole witness is <= `bsrMaxWitnessBytes`; preloads <= `bsrAccountSlotCap`;
+    m29 <= 256 hashes (8 KiB) + 584 header fit in the 16 KiB slack. The
+    `stage_system_call_payload` size guard uses this same constant (it bails
+    soundly on anything larger instead of corrupting `.data`). -/
+def c1StagingBytes : Nat := bsrMaxWitnessBytes + bsrAccountSlotCap * 64 + 16384
 def bsrAccountRecordBytes : Nat := 24
 def bsrPathBytes : Nat := 64
 def bsrEncodedAccountBytes : Nat := 256

--- a/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
@@ -465,11 +465,12 @@ def statelessVerdictV2Function : String :=
   ".Lc1_w_addrd:\n" ++
   "  la t0, c1_bal_acct_ptr; ld a0, 0(t0); la t0, c1_bal_acct_len; ld a1, 0(t0); la a2, c1_preload\n" ++
   "  jal ra, stage_predeploy_storage_preload\n" ++
-  -- fhsxz.2.4.2.66.1: a count above the 512 cap means NOTHING was staged (the preload
-  -- bails write-nothing); storing it would make stage_runtime_payload_code copy count*64
+  -- fhsxz.2.4.2.66.1/.66.1.2: a count above the gas-derived bsrAccountSlotCap means
+  -- NOTHING was staged (the preload bails write-nothing — including the per-slot
+  -- tuple-overflow case); storing it would make stage_runtime_payload_code copy count*64
   -- garbage bytes from past c1_preload into the payload -> wrong execution. Conservative
-  -- reject instead (sound: at worst a false-reject of a >512-slot system-call block).
-  "  li t1, 512; bgtu a0, t1, .Lv2_requests_hash_fail\n" ++
+  -- reject instead (sound: only blocks beyond the 200M BAL budget can trip this).
+  "  li t1, " ++ toString bsrAccountSlotCap ++ "; bgtu a0, t1, .Lv2_requests_hash_fail\n" ++
   "  la t0, scc_preload_count; sd a0, 0(t0); la t1, c1_preload; la t0, scc_preload_ptr; sd t1, 0(t0)\n" ++
   "  j .Lc1_w_derive\n" ++
   ".Lc1_w_nopreload:\n" ++
@@ -506,8 +507,9 @@ def statelessVerdictV2Function : String :=
   ".Lc1_c_addrd:\n" ++
   "  la t0, c1_bal_acct_ptr; ld a0, 0(t0); la t0, c1_bal_acct_len; ld a1, 0(t0); la a2, c1_preload\n" ++
   "  jal ra, stage_predeploy_storage_preload\n" ++
-  -- fhsxz.2.4.2.66.1: same >cap conservative reject as the withdrawal site above.
-  "  li t1, 512; bgtu a0, t1, .Lv2_requests_hash_fail\n" ++
+  -- fhsxz.2.4.2.66.1/.66.1.2: same gas-derived >cap conservative reject as the
+  -- withdrawal site above.
+  "  li t1, " ++ toString bsrAccountSlotCap ++ "; bgtu a0, t1, .Lv2_requests_hash_fail\n" ++
   "  la t0, scc_preload_count; sd a0, 0(t0); la t1, c1_preload; la t0, scc_preload_ptr; sd t1, 0(t0)\n" ++
   "  j .Lc1_c_derive\n" ++
   ".Lc1_c_nopreload:\n" ++

--- a/EvmAsm/Codegen/Programs/CallFrameBase.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameBase.lean
@@ -11,8 +11,9 @@
   x20=base+frameEnvOff) on a depth bump.
 
   `FRAME_STRIDE = 0x29000` (CallFrameLayout.frameStride). The arena symbol
-  `call_frame_arena` aliases `basr_values` in the guest (#8513); this module's
-  probe links a local stub to test the offset arithmetic in isolation.
+  `call_frame_arena` is a standalone pre-zeroed block in the guest (it aliased
+  `basr_values` under the retired 1G layout, #8513); this module's probe links
+  a local stub to test the offset arithmetic in isolation.
 -/
 
 import EvmAsm.Rv64.Program

--- a/EvmAsm/Codegen/Programs/CallFrameReturn.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameReturn.lean
@@ -29,7 +29,7 @@
     `frame_call_ctx`   1025 × 32 B (parent_x12, outoff_abs, outsize, netPopBytes)
                        indexed by the CHILD depth — saved by the descent, consumed
                        here on the matching return.
-    `call_frame_arena` overlay base for frames 1..1024 (FRAME_STRIDE 0x29000);
+    `call_frame_arena` base for frames 1..1024 (FRAME_STRIDE 0x29000);
     `evm_memory`/`evm_env` the depth-0 register bases.
   Child-frame sub-offsets: frameMemOff=0, frameEnvOff=0x28400.
 -/

--- a/EvmAsm/Codegen/Programs/SystemCallStaging.lean
+++ b/EvmAsm/Codegen/Programs/SystemCallStaging.lean
@@ -20,6 +20,7 @@ import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.AmsterdamSystemTx
 import EvmAsm.Codegen.Programs.BlockVerdictContractStage
+import EvmAsm.Codegen.Programs.BlockVerdictParams
 
 namespace EvmAsm.Codegen
 
@@ -59,7 +60,7 @@ def stageSystemCallPayloadFunction : String :=
   -- dispatch_tx_runtime_code). stage_runtime_payload_code zeroes + writes
   -- round8(codelen) + storage_count*64 + m29_count*32 + 584 bytes into the output
   -- buffer with no bound of its own; every verdict call site passes c1_staging
-  -- (131072 B, BlockVerdictDataSection.lean — keep the literal in sync). Predeploy
+  -- (c1StagingBytes, BlockVerdictParams.lean — shared constant, .66.1.2). Predeploy
   -- code is read from the witness and NOT EIP-170-bounded (the system_contract_errors
   -- EEST predeploys are 72946 B), so an unchecked copy clobbers the .data globals
   -- above c1_staging. Bail (a0=1, unsupported -> requests-hash fail) instead of
@@ -67,7 +68,7 @@ def stageSystemCallPayloadFunction : String :=
   "  addi t1, s2, 7; andi t1, t1, -8\n" ++                                         -- round8(codelen)
   "  la t0, scc_preload_count; ld t2, 0(t0); slli t2, t2, 6; add t1, t1, t2\n" ++  -- + storage_count*64
   "  la t0, m29_stage_count; ld t2, 0(t0); slli t2, t2, 5; add t1, t1, t2\n" ++    -- + M29 hashes (count*32)
-  "  addi t1, t1, 584; li t2, 131072; bgtu t1, t2, .Lscc_toobig\n" ++              -- payload > buffer -> bail
+  "  addi t1, t1, 584; li t2, " ++ toString c1StagingBytes ++ "; bgtu t1, t2, .Lscc_toobig\n" ++              -- payload > buffer -> bail
   -- stage_runtime_payload_code(ctx, out, exec, code, codelen, null, 0)
   -- 8uld3.2.1.5: pass the predeploy STORAGE preload (a5/a6) so the predeploy's SLOAD of its
   -- request queue reads the staged witness values (not garbage). scc_preload_ptr/count default

--- a/EvmAsm/Codegen/Programs/SystemCallStoragePreload.lean
+++ b/EvmAsm/Codegen/Programs/SystemCallStoragePreload.lean
@@ -23,6 +23,8 @@ import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.StateCompose
 import EvmAsm.Codegen.Programs.BlockVerdictContractStorage
+import EvmAsm.Codegen.Programs.BlockVerdictParams
+import EvmAsm.Codegen.Programs.BalSlotTupleSequence
 
 namespace EvmAsm.Codegen
 
@@ -30,13 +32,18 @@ open EvmAsm.Rv64
 
 /-! ## stage_predeploy_storage_preload
     a0 = predeploy AccountChanges RLP ptr   a1 = AccountChanges RLP length
-    a2 = out ptr (count x 64-byte (key:32 BE, value:32 BE) pairs; caller buffer >= 512*64)
+    a2 = out ptr (count x 64-byte (key:32 BE, value:32 BE) pairs; caller buffer >=
+         bsrAccountSlotCap*64)
     Globals (caller-set): sps_addr (20-byte predeploy address), sps_header / sps_header_len,
       sps_state / sps_state_len, sps_storage / sps_storage_len.
-    Returns a0 = slot count (0 on parse failure; if > 512, nothing written, true count
-    returned so the caller MUST bail conservatively — staging a count the buffer doesn't
-    hold reads garbage past c1_preload; fhsxz.2.4.2.66.1 raised the cap from 128 because
-    the system_contract_errors EEST predeploys commit 306 storage changes). -/
+    Returns a0 = slot count (0 on parse failure; if > bsrAccountSlotCap — or if any slot
+    carries > bsrMaxTuplesPerSlot change tuples — nothing/partial-keys-only written and a
+    count > bsrAccountSlotCap returned so the caller MUST bail conservatively — staging a
+    count the buffer doesn't hold reads garbage past c1_preload. fhsxz.2.4.2.66.1 raised
+    the cap 128 -> 512 for the 306-change system_contract_errors predeploys;
+    fhsxz.2.4.2.66.1.2 made it gas-derived: a 200M block's user txs can legitimately put
+    thousands of changes+reads on a predeploy, so the only non-rejecting bound is the
+    BAL-item budget itself). -/
 def stagePredeployStoragePreloadFunction : String :=
   "stage_predeploy_storage_preload:\n" ++
   "  addi sp, sp, -64\n" ++
@@ -50,7 +57,7 @@ def stagePredeployStoragePreloadFunction : String :=
   "  la a2, sps_keys\n" ++
   "  jal ra, bal_recipient_storage_keys\n" ++
   "  mv s1, a0                    # changes-slot count\n" ++
-  "  li t0, 512\n  bgtu s1, t0, .Lspsp_done\n" ++   -- >512 changes: bail (write nothing, return count)
+  "  li t0, " ++ toString bsrAccountSlotCap ++ "\n  bgtu s1, t0, .Lspsp_done\n" ++   -- >cap changes: bail (write nothing, return count)
   -- 8uld3.2.3.3.1 Fix2: ALSO stage the predeploy's storage_READS (AccountChanges item 2).
   -- A no-requests predeploy reads the queue head/tail/count slots it never writes, so a
   -- changes-only preload leaves those SLOADs reading garbage (the e0010046 unmapped-read
@@ -58,10 +65,10 @@ def stagePredeployStoragePreloadFunction : String :=
   -- pre-block value for each. (a0/a1 were clobbered by the changes call; restore from s5/s6.)
   "  mv a0, s5; mv a1, s6\n" ++
   "  slli t0, s1, 5; la t1, sps_keys; add a2, t1, t0   # &sps_keys[changes_count]\n" ++
-  "  li t0, 512; sub a3, t0, s1                         # remaining capacity\n" ++
+  "  li t0, " ++ toString bsrAccountSlotCap ++ "; sub a3, t0, s1                         # remaining capacity\n" ++
   "  jal ra, bal_recipient_storage_reads_keys\n" ++
   "  add s1, s1, a0                                     # total = changes + reads\n" ++
-  "  li t0, 512\n  bgtu s1, t0, .Lspsp_done\n" ++   -- combined >512: bail
+  "  li t0, " ++ toString bsrAccountSlotCap ++ "\n  bgtu s1, t0, .Lspsp_done\n" ++   -- combined >cap: bail
   -- Fix6 pre-pass: sps_sysidx = MAX block_access_index across the predeploy's changed slots.
   -- The block-end system call is the last writer, so its index is this max; a slot's pre-system
   -- value (what the predeploy reads) is the last change tuple with index < sps_sysidx.
@@ -72,6 +79,9 @@ def stagePredeployStoragePreloadFunction : String :=
   "  slli t0, s2, 5; la t1, sps_keys; add a2, t1, t0\n" ++
   "  mv a0, s5; mv a1, s6; la a3, sps_tuples\n" ++
   "  jal ra, bal_slot_tuple_sequence\n" ++
+  -- .66.1.2: > bsrMaxTuplesPerSlot tuples -> the helper wrote nothing; bail conservatively
+  -- (force a count the caller's cap check rejects) instead of scanning stale sps_tuples.
+  "  li t0, " ++ toString bsrMaxTuplesPerSlot ++ "; bgtu a0, t0, .Lspsp_toobig\n" ++
   "  li t0, 0\n" ++
   ".Lspsp_premax:\n" ++
   "  beq t0, a0, .Lspsp_premaxd\n" ++
@@ -105,6 +115,7 @@ def stagePredeployStoragePreloadFunction : String :=
   -- slot has no pre-system change (only system-written: queue head/excess read pre-state).
   "  mv a0, s5; mv a1, s6; mv a2, s3; la a3, sps_tuples\n" ++
   "  jal ra, bal_slot_tuple_sequence\n" ++         -- a0 = tuple count (0 if slot absent)
+  "  li t0, " ++ toString bsrMaxTuplesPerSlot ++ "; bgtu a0, t0, .Lspsp_toobig\n" ++   -- .66.1.2: helper wrote nothing -> bail
   "  li t0, 0\n" ++                                 -- j
   "  li t5, 0\n" ++                                 -- found new_value ptr (0 = none)
   "  la t4, sps_sysidx; ld t4, 0(t4)\n" ++          -- t4 = system-call index (global max)
@@ -146,6 +157,10 @@ def stagePredeployStoragePreloadFunction : String :=
   "  addi t2, s4, 32; sd zero, 0(t2); sd zero, 8(t2); sd zero, 16(t2); sd zero, 24(t2)\n" ++
   ".Lspsp_next:\n" ++
   "  addi s2, s2, 1\n  j .Lspsp_loop\n" ++
+  -- .66.1.2: per-slot tuple overflow -> return a count above bsrAccountSlotCap so every
+  -- caller's existing `bgtu a0, cap` check routes to its conservative bail.
+  ".Lspsp_toobig:\n" ++
+  "  li s1, " ++ toString (bsrAccountSlotCap + 1) ++ "\n" ++
   ".Lspsp_done:\n" ++
   "  mv a0, s1\n" ++
   "  ld ra, 0(sp)\n" ++
@@ -158,9 +173,9 @@ def stagePredeployStoragePreloadFunction : String :=
     the predeploy address + the slot-key scratch buffer). -/
 def stagePredeployStoragePreloadData : String :=
   ".balign 8\n" ++
-  "sps_keys:\n  .zero 16384\n" ++      -- 512 x 32-byte slot keys (fhsxz.2.4.2.66.1: was 128)
+  "sps_keys:\n  .zero " ++ toString (bsrAccountSlotCap * 32) ++ "\n" ++      -- bsrAccountSlotCap x 32-byte slot keys (.66.1.2: gas-derived, was 512)
   ".balign 8\n" ++
-  "sps_tuples:\n  .zero 20480\n" ++    -- Fix6: 512 x 40-byte (block_access_index, new_value) tuples per slot
+  "sps_tuples:\n  .zero " ++ toString (bsrMaxTuplesPerSlot * 40) ++ "\n" ++    -- Fix6: bsrMaxTuplesPerSlot x 40-byte (block_access_index, new_value) tuples per slot (.66.1.2)
   "sps_sysidx:\n  .zero 8\n" ++        -- Fix6: system-call block_access_index (= max change index)
   ".balign 8\n" ++
   "sps_addr:\n  .zero 32\n" ++         -- predeploy address (20B, padded)
@@ -175,7 +190,9 @@ def stagePredeployStoragePreloadData : String :=
     AccountChanges (brsk_acct: one slot key 0x00..07) + a NULL witness (sps_* default 0),
     so slot_at_header_state_root fails and values are 0. Verifies the key enumeration +
     (key,value) pairing; the real MPT value-lookup is verified by the 8uld3.2.2 wiring.
-    Output: +0 count (expect 1); +8 key byte31 (expect 0x07); +16 value byte0 (expect 0). -/
+    Output: +0 count (expect 1); +8 key byte31 (expect 0x00 — Fix5 writes the key
+    BE->LE-reversed, so the BE key 0x00..07 has 0x07 at byte 0); +16 value byte0
+    (expect 0); +24 key byte0 (expect 0x07). -/
 def ziskStagePredeployStoragePreloadPrologue : String :=
   "  li sp, 0xa0050000\n" ++
   "  la a0, brsk_acct\n  li a1, 63\n  la a2, spsp_out\n" ++
@@ -189,6 +206,11 @@ def ziskStagePredeployStoragePreloadPrologue : String :=
   "  j .Lspspp_done\n" ++
   stagePredeployStoragePreloadFunction ++ "\n" ++
   balRecipientStorageKeysFunction ++ "\n" ++
+  -- 8uld3 Fix2/Fix6 added these calls to the preload; the probe must link them too
+  -- (pre-existing link failure fixed alongside .66.1.2).
+  balRecipientStorageReadsKeysFunction ++ "\n" ++
+  balSlotTupleSequenceFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
   rlpListCountItemsFunction ++ "\n" ++
   -- slot_at_header_state_root + its MPT deps (rlpListNthItem is in this set):
   zkvmKeccak256Function ++ "\n" ++
@@ -211,6 +233,8 @@ def ziskStagePredeployStoragePreloadPrologue : String :=
 def ziskStagePredeployStoragePreloadDataSection : String :=
   ziskBalRecipientStorageKeysDataSection ++ "\n" ++   -- brsk_* scratch + brsk_acct fixture
   ziskSlotAtHeaderStateRootDataSection ++ "\n" ++     -- slot MPT scratch + sahsr_u256
+  balSlotTupleSequenceData ++ "\n" ++                  -- bts_* scratch (Fix6 tuple pre-pass)
+  ziskRlpFieldToU64DataSection ++ "\n" ++              -- rfu_* scratch for rlp_field_to_u64
   stagePredeployStoragePreloadData ++ "\n" ++          -- sps_* (null witness by default)
   ".balign 8\n" ++
   "spsp_out:\n  .zero 8256\n"

--- a/docs/agents/eest-static-layout.md
+++ b/docs/agents/eest-static-layout.md
@@ -44,7 +44,8 @@ from the same count and resize the matching backing storage together.
 Large static arenas can outgrow the previous linked `.data` location. When
 that happens, treat the ELF memory map as part of the layout: keep linked
 `.data`, fixed working-RAM anchors, public output, and `.sszscratch` disjoint.
-The current 1G-cap stateless guest layout puts `.data` at `0xa3000000` and
+The current stateless guest layout (sized for the Amsterdam 200M block-gas
+target, `bsrMaxBalItems = 100000`) puts `.data` at `0xa3000000` and
 `.sszscratch` at `0xbf500000`, both inside the verified RAM zone. Keep the
 linked `.data` growth below the `.sszscratch` start and leave headroom below
 `0xc0000000`.

--- a/docs/call-frame-memory-layout.md
+++ b/docs/call-frame-memory-layout.md
@@ -189,7 +189,18 @@ Total frame array = `1025 * 0x29000` = `0xA429000` ≈ **164.2 MiB** (depths
 
 ---
 
-## 5. Memory-map placement — RAM is full; overlay the BAL-replay arenas
+## 5. Memory-map placement — overlay RETIRED; standalone arena under the 200M layout
+
+> **UPDATE (2026-06-11).** The BAL-replay arenas were right-sized from the 1G
+> worst case (`bsrMaxBalItems = 500000`, ~416 MiB) to the Amsterdam 200M target
+> (`bsrMaxBalItems = 100000`, ~83 MiB), freeing ~333 MiB of the 512 MiB window.
+> `call_frame_arena` is now a **standalone** pre-zeroed `.zero` block emitted
+> after `basr_accounts` (`BlockVerdictDataSection.lean`) — the union described
+> below no longer exists (the shrunken `basr_values`+`basr_accounts` pair, ~49
+> MiB, could not host the 164 MiB frame array anyway), and the execution-dead
+> soundness gate on `basr_values`/`basr_accounts` is no longer load-bearing.
+> Fit: `frameArray_and_balArenas_fit` in `CallFrameLayout.lean` + `readelf -lW`.
+> §5's union design is kept below as the historical record.
 
 > **CORRECTION (empirically validated 2026-06-08).** An earlier draft of this
 > section assumed `.data` is ~16 MiB and the `0xa4000000..0xbf500000` window is

--- a/docs/eest-1g-block-gas-layout-plan.md
+++ b/docs/eest-1g-block-gas-layout-plan.md
@@ -1,5 +1,17 @@
 # EEST 1G Block-Gas Layout Plan
 
+> **SUPERSEDED (2026-06-11): the static layout is right-sized to the 200M
+> Amsterdam block-gas target.** The 1G sizing below was implemented (PR #8089)
+> but cost ~416 MiB of the fixed 512 MiB ziskemu RAM window and forced the
+> call-frame arena into the #8513 `basr_values`+`basr_accounts` union. Amsterdam
+> aims at 200,000,000 gas, so `bsrMaxBalItems` is now **100,000**
+> (= 200M / 2000), the BAL arenas shrink to ~83 MiB, and `call_frame_arena` is a
+> standalone ~164 MiB block (the union and its execution-dead soundness gate are
+> retired). Blocks declaring more than 200M gas still launch; if their actual
+> BAL/state-change counts exceed the 100,018-row caps they take the conservative
+> `bsr_fail` path. The sizing *mechanics* below remain the reference; only the
+> 500,000-item column is obsolete.
+
 This is the implementation plan for bead
 `evm-asm-fhsxz.2.4.2.57.9.1.1`. It replaces the PR #8044 direction of
 classifying high-gas EIP-8037 fixtures as `ERROR(layout)`: the desired behavior

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -480,10 +480,10 @@ resolve_riscv_tool() {
 
 patch_bsr_caps_asm() {
   local asm="$1"
-  local old_witness="  la t0, bsr_fail_code; sd zero, 0(t0); li t1, 262144; bgtu a2, t1, .Lbsr_cons_change_cap"
+  local old_witness="  la t0, bsr_fail_code; sd zero, 0(t0); li t1, 524288; bgtu a2, t1, .Lbsr_cons_change_cap"
   local new_witness="  la t0, bsr_fail_code; sd zero, 0(t0); li t1, $BSR_WITNESS_CAP; bgtu a2, t1, .Lbsr_cons_change_cap"
-  local old_bal=$'  li t0, 2000; divu t1, a0, t0\n  la t2, bsr_bal_count; ld t6, 0(t2); bgtu t6, t1, .Lbsr_cons_change_cap; add t0, s1, t6; li t1, 500018; bgtu t0, t1, .Lbsr_cons_change_cap'
-  local new_bal=$'  li t0, 2000; divu t1, a0, t0\n  la t2, bsr_bal_count; ld t6, 0(t2); bgtu t6, t1, .Lbsr_cons_change_cap; li t1, '"$BSR_BAL_CAP"$'; bgtu t6, t1, .Lbsr_cons_change_cap; add t0, s1, t6; li t1, 500018; bgtu t0, t1, .Lbsr_cons_change_cap'
+  local old_bal=$'  li t0, 2000; divu t1, a0, t0\n  la t2, bsr_bal_count; ld t6, 0(t2); bgtu t6, t1, .Lbsr_cons_change_cap; add t0, s1, t6; li t1, 100018; bgtu t0, t1, .Lbsr_cons_change_cap'
+  local new_bal=$'  li t0, 2000; divu t1, a0, t0\n  la t2, bsr_bal_count; ld t6, 0(t2); bgtu t6, t1, .Lbsr_cons_change_cap; li t1, '"$BSR_BAL_CAP"$'; bgtu t6, t1, .Lbsr_cons_change_cap; add t0, s1, t6; li t1, 100018; bgtu t0, t1, .Lbsr_cons_change_cap'
   local as_tool ld_tool
 
   python3 - "$asm" "$BSR_WITNESS_CAP" "$old_witness" "$new_witness" "$BSR_BAL_CAP" "$old_bal" "$new_bal" <<'PYPATCH'

--- a/scripts/codegen-zisk-stage-predeploy-storage-preload-check.sh
+++ b/scripts/codegen-zisk-stage-predeploy-storage-preload-check.sh
@@ -38,7 +38,10 @@ count = struct.unpack('<Q', d[0:8])[0]
 k31 = struct.unpack('<Q', d[8:16])[0]
 v0  = struct.unpack('<Q', d[16:24])[0]
 k0  = struct.unpack('<Q', d[24:32])[0]
-ok = (count == 1 and k31 == 0x07 and v0 == 0 and k0 == 0)
+# 8uld3.2.3.3.1 Fix5: the preload writes the KEY byte-reversed (BE->LE) so the
+# dispatcher's little-endian SLOAD key matches -- the BE slot key 0x00..07 lands
+# with 0x07 at byte 0 and 0x00 at byte 31.
+ok = (count == 1 and k31 == 0 and v0 == 0 and k0 == 0x07)
 print(f"  count={count} key[0].b31={hex(k31)} value[0].b0={hex(v0)} key[0].b0={hex(k0)}")
 if not ok:
     print("  FAIL: storage-preload key enumeration / pairing incorrect")


### PR DESCRIPTION
## Summary

Amsterdam targets **200,000,000** block gas, not 1G. This PR right-sizes the stateless guest's static layout to that budget and makes the system-call staging caps gas-derived, so legitimate ≤200M blocks can no longer be conservatively rejected by fixture-sized constants.

### Commit 1 — `feat(layout)`: right-size BSR arenas + call_frame_arena (bead `fhsxz.2.4.2.57.9.1.5`)
- `bsrMaxBalItems` 500,000 → **100,000** (= 200M / 2000; `bsrMaxStateChanges` 100,018): BAL/replay arenas shrink 436 MB → 87 MB.
- `call_frame_arena` detached from the #8513 `basr_values`+`basr_accounts` union into a **standalone pre-zeroed 1025×0x29000 block** — the shrunken pair (~49 MiB) can no longer host the ~164 MiB frame array, and the freed ~333 MiB means it no longer needs to. The union's execution-dead soundness gate is retired. `frameArray_fits_union` → kernel-checked `frameArray_and_balArenas_fit`.
- The two hard-coded `60000` storage guards in `BalAccountApplyPostFields` now derive from `bsrMaxBalItems`.
- Harness `patch_bsr_caps_asm` match strings updated (500018 → 100018; stale witness literal 262144 → 524288).
- Docs: 1G plan marked superseded; call-frame doc §5; eest-static-layout.

### Commit 2 — `fix(verdict)`: gas-derive the system-call preload/staging caps (bead `fhsxz.2.4.2.66.1.2`)
- #8718 made the over-cap paths sound but sized them to the failing fixture (512 slots). A predeploy's BAL entry accumulates user-tx-driven changes+reads that scale with block gas, so one account can absorb the entire 200M BAL budget — the 512 cap would false-reject queue-heavy blocks far below 200M.
- `bsrAccountSlotCap = bsrMaxBalItems` (100,000): helper caps, `c1_preload`, `sps_keys`/`bvcd_keys`/`csce_keys`.
- `bsrMaxTuplesPerSlot = 10,000`: `bal_slot_tuple_sequence` now **bounds its output** (write-nothing + return-true-count above cap, closing the `.66.1.1` unbounded-write corruption for its consumers) with over-cap bails at all call sites; `sps_tuples`/`atsc_balbuf`/`atsc_execbuf` sized to match.
- `c1StagingBytes` (~6.9 MB) shared between the `c1_staging` arena and the `stage_system_call_payload` guard (previously two literals kept in sync by comment).
- Dispatch-tx 128-caps deliberately kept (scaling them cascades into exec-log/state-tracker capacities; rationale in the bead).
- Fixes the pre-existing `zisk_stage_predeploy_storage_preload` probe link failure + stale pre-Fix5 key expectation.

### Memory budget (the hard constraint)
ziskemu's RAM window is a fixed 512 MiB (`0xa0000000..0xc0000000`). `.data` top: **0xbfc3a8c8 (~4 MiB headroom) → 0xb4aae068 (~178 MiB headroom)**, verified with `readelf -lW`; ELF file 448 MB → 284 MB.

## Validation (all full 105-byte verdict matches)

| Class | Gas limits | Result |
|---|---|---|
| `state_gas_pricing` | 1M–1G | 68/68 |
| `system_contract_errors` | 36M–120M | 8/8 |
| `eip7934` RLP-limit blocks (8 MB inputs) | 554M | 10/10 |
| `stMemoryStressTest` | >200M declared | 77/77 |
| `stReturnDataTest` | >200M declared | 271/271 |
| all remaining >200M `ported_static` | up to 2⁶³−1 | 431/431 |
| fixed-seed regression (`--random --seed 42 --limit 20`) | mixed | 20/20 |

Two transient `ERROR exit` rows during the sweeps were earlyoom kills under shared-box memory pressure (0-byte emu.logs; both rerun standalone to full match) — not guest bugs.

Probe checks: `zisk_stage_predeploy_storage_preload`, `zisk_bal_slot_tuple_sequence` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)