### PR TITLE
feat(dispatch): EIP-8037 state gas + Amsterdam SSTORE schedule + per-tx dispatch resets

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -1313,6 +1313,55 @@ def createExecuteInitcodeFrameRuntimeFunction : String :=
   "  li a0, 4\n" ++
   "  ret"
 
+/-- Post-dispatch per-transaction gas settlement fold (nxio8 / EIP-8037).
+
+    The spec's transaction settlement is
+    `tx_gas_used_before_refund = tx.gas - gas_left - state_gas_left`
+    (fork.py process_transaction), with two tx-level error rules:
+    on ANY error (REVERT or exceptional halt) `state_gas_left += state_gas_used`
+    (no state was grown, so the full state-gas charge — including any portion
+    spilled into gas_left — is restored), and the refund counter is discarded
+    (interpreter.py only incorporates `evm.refund_counter` when `error is None`);
+    an exceptional halt additionally burns all remaining regular gas
+    (interpreter.py: `evm.gas_left = Uint(0)`), which the dispatcher's
+    `.exit_*` paths do NOT apply to env+568.
+
+    This helper folds all three rules into the values the gas-result consumers
+    (`tx_gas_result_increments`, the bvgr arena) expect:
+      a0 (output) = effective gas_left  = gas_left' + state_gas_left'
+                    where gas_left' = 0 for exceptional halts, env+568 otherwise,
+                    and state_gas_left' includes the on-error restore;
+      a1 (output) = effective refund_counter = evm_refund_acc, or 0 on error.
+    halt_kind is read from OUTPUT+32 (set by every halt path): 0 STOP / 1 RETURN /
+    5 SELFDESTRUCT are successes; 2 REVERT keeps gas_left but folds state gas and
+    drops refunds; 3/4/6/7/8 are exceptional. Clobbers t0-t3. Read-only
+    (callable repeatedly; mutates no dispatcher state). -/
+def dispatcherTxGasSettleFunction : String :=
+  "dispatcher_tx_gas_settle:\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  ld t1, 32(t0)               # halt_kind\n" ++
+  "  la t0, evm_env\n" ++
+  "  ld t0, 568(t0)              # gas_left\n" ++
+  "  la t2, evm_state_gas_left\n" ++
+  "  ld t2, 0(t2)\n" ++
+  "  la t3, evm_refund_acc\n" ++
+  "  ld a1, 0(t3)\n" ++
+  "  beqz t1, .Ldtgs_success\n" ++
+  "  li t3, 1\n" ++
+  "  beq t1, t3, .Ldtgs_success\n" ++
+  "  li t3, 5\n" ++
+  "  beq t1, t3, .Ldtgs_success\n" ++
+  "  li a1, 0                    # error: refund counter discarded\n" ++
+  "  la t3, evm_state_gas_used\n" ++
+  "  ld t3, 0(t3)\n" ++
+  "  add t2, t2, t3              # error: state_gas_left += state_gas_used\n" ++
+  "  li t3, 2\n" ++
+  "  beq t1, t3, .Ldtgs_success  # REVERT keeps gas_left\n" ++
+  "  li t0, 0                    # exceptional halt burns remaining regular gas\n" ++
+  ".Ldtgs_success:\n" ++
+  "  add a0, t0, t2\n" ++
+  "  ret"
+
 /-- Dispatcher epilogue: handler subroutines (each ends with `ret` or
     `j .exit_label`), the `h_invalid` fallback, and `.exit_label`
     which runs `exitBody` (e.g. `evmAddEpilogue`) and falls through
@@ -1380,6 +1429,7 @@ def emitDispatcherEpilogueCore
     zkvmModexpSafeFailWrapper ++ "\n" ++
     storageAccessGasFunction ++ "\n" ++
     sstoreGasRefundOutcomeFunction ++ "\n" ++
+    dispatcherTxGasSettleFunction ++ "\n" ++
     runtimeAccessAccountSeedFunction ++ "\n" ++
     runtimeAccessSeedInitialAccountsFunction ++ "\n" ++
     runtimeAccessAccountChargeFunction ++ "\n" ++
@@ -1796,6 +1846,26 @@ def emitRuntimeDispatcherSetupWithInputAsm (inputAsm : String) : String :=
   -- .data-baked setup's identical reset (~L974) is unaffected: it reloads x5 right after.
   "  la x28, evm_log_data_used; sd x0, 0(x28)\n" ++     -- reset per-tx full-log-data buffer cursor
   "  la x28, evm_log_data_overflow; sd x0, 0(x28)\n" ++ -- reset per-tx full-log-data overflow flag
+  -- nxio8: per-TRANSACTION dispatch state that previously leaked across calls in a
+  -- multi-tx block (the callable dispatcher is invoked once per tx in one guest run):
+  --   * evm_refund_acc — EIP-3529 refund counter is per tx (only the baked prologue
+  --     reset it; a 2nd dispatch call inherited tx 1's refunds).
+  --   * evm_storage_access_count — EIP-2929 accessed_storage_keys is per tx
+  --     (prepare_message builds a fresh set); a 2nd call saw tx 1's keys as warm.
+  --   * evm_state_gas_left / evm_state_gas_used — EIP-8037 per-tx state-gas
+  --     reservoir + usage (seeded below on the validate-tx-gas path).
+  -- evm_storage_access_outcome_count is NOT reset: the outcome log is an append-only
+  -- cross-tx diagnostic surface (bal_storage_access_outcome_descriptors).
+  "  la x28, evm_refund_acc; sd x0, 0(x28)\n" ++
+  "  la x28, evm_storage_access_count; sd x0, 0(x28)\n" ++
+  "  la x28, evm_state_gas_left; sd x0, 0(x28)\n" ++
+  "  la x28, evm_state_gas_used; sd x0, 0(x28)\n" ++
+  -- halt_kind (OUTPUT+32) = 0: the skip-finalization (verdict-callable) exit
+  -- join never writes the success kind, so without this reset a prior
+  -- dispatch's REVERT/exceptional kind would leak into dispatcher_tx_gas_settle.
+  -- The exceptional exits and RETURN/REVERT tails overwrite it during this
+  -- dispatch; a clean STOP leaves this 0.
+  "  li x28, 0xa0010000; sd x0, 32(x28)\n" ++
   "  sd x0, 480(x20)\n" ++         -- env.eventLogCheckpointOff = 0
   "  sd x0, 488(x20)\n" ++         -- runtime activeMemorySize = 0
   "  sd x0, 512(x20)\n" ++         -- M28: blobBaseFee[0] = 0 (overwritten by trailer load below)
@@ -2013,6 +2083,21 @@ def emitRuntimeDispatcherSetupWithInputAsm (inputAsm : String) : String :=
   "  bltu x6, x7, .exit_outofgas\n" ++
   "  bltu x6, x10, .exit_outofgas\n" ++
   "  sub x6, x6, x7\n" ++
+  -- nxio8 (EIP-8037): split execution gas into gas_left and the state-gas
+  -- reservoir (fork.py: gas = min(TX_MAX_GAS_LIMIT - intrinsic.regular,
+  -- execution_gas); state_gas_reservoir = execution_gas - gas). x7 still holds
+  -- the regular intrinsic cost; x6 = execution_gas. For tx.gas ≤ 16,777,216 the
+  -- reservoir is 0 and gas_left is unchanged. evm_state_gas_left was reset to 0
+  -- above, so the no-reservoir fall-through needs no store.
+  "  li x8, 16777216\n" ++          -- TX_MAX_GAS_LIMIT (EIP-7825 cap)
+  "  bgeu x7, x8, .exit_outofgas\n" ++   -- intrinsic.regular ≥ cap: spec-invalid tx
+  "  sub x8, x8, x7\n" ++           -- x8 = regular gas budget
+  "  bleu x6, x8, .runtime_tx_gas_no_reservoir\n" ++
+  "  sub x9, x6, x8\n" ++           -- x9 = state_gas_reservoir
+  "  mv x6, x8\n" ++                -- gas_left capped at the regular budget
+  "  la x11, evm_state_gas_left\n" ++
+  "  sd x9, 0(x11)\n" ++
+  ".runtime_tx_gas_no_reservoir:\n" ++
   ".runtime_tx_gas_done:\n" ++
   "  sd x6, 568(x20)\n" ++          -- env.gasRemaining = execution gas
   "  ld x6, 0(x5)\n" ++            -- x6 = header_len
@@ -2169,6 +2254,7 @@ def emitRuntimeDispatcherEmbeddedHelperFunctions : String :=
   zkvmModexpSafeFailWrapper ++ "\n" ++
   storageAccessGasFunction ++ "\n" ++
   sstoreGasRefundOutcomeFunction ++ "\n" ++
+  dispatcherTxGasSettleFunction ++ "\n" ++
   runtimeAccessAccountSeedFunction ++ "\n" ++
   runtimeAccessSeedInitialAccountsFunction ++ "\n" ++
   runtimeAccessAccountChargeFunction ++ "\n" ++
@@ -2450,11 +2536,24 @@ def emitRuntimeDispatcherDataSectionCore
   ".balign 8\n" ++
   "evm_refund_acc:\n" ++
   "  .zero 8\n" ++
+  -- nxio8: EIP-8037 state-gas cells. `evm_state_gas_left` is the per-tx state-gas
+  -- reservoir (fork.py: state_gas_reservoir = execution_gas - min(TX_MAX_GAS_LIMIT
+  -- - intrinsic.regular, execution_gas); 0 for tx.gas ≤ 16,777,216). The SSTORE
+  -- handler's charge_state_gas drains it first and spills the remainder into
+  -- env.gasRemaining (vm/gas.py charge_state_gas). `evm_state_gas_used` accumulates
+  -- charges (the credit_state_gas_refund clamp + the on-error restore both need it).
+  -- Settlement (spec: tx.gas - gas_left - state_gas_left) folds the final
+  -- state_gas_left back via dispatcher_tx_gas_settle. Reset per dispatch call.
+  ".balign 8\n" ++
+  "evm_state_gas_left:\n" ++
+  "  .zero 8\n" ++
+  "evm_state_gas_used:\n" ++
+  "  .zero 8\n" ++
   ".balign 32\n" ++
   "srfd_zero:\n" ++
   "  .zero 32\n" ++
   "srfd_out:\n" ++
-  "  .zero 32\n" ++
+  "  .zero 40\n" ++
   -- bmvmx.1.6.6 enabler: per-entry block_access_index, PARALLEL to the 128 B exec-log
   -- entries at 0xa0630000 (so the existing scans are byte-identical). exec_log_txindex[i]
   -- = the tx's block_access_index for persistent-log entry i; the SSTORE handler stamps
@@ -2674,15 +2773,18 @@ def buildRuntimeDispatchGasCaptureProbeUnit
   body        := []
   prologueAsm :=
     "  jal ra, runtime_dispatcher_call\n" ++
-    "  la t2, evm_env\n" ++
-    "  ld t3, 568(t2)             # gas_left = env.gasRemaining\n" ++
+    -- nxio8: settle fold (EIP-8037 state gas + tx-error rules); a0 = effective
+    -- gas_left (env[568] + evm_state_gas_left with the error folds), a1 = the
+    -- effective refund counter (0 when the tx erred).
+    "  jal ra, dispatcher_tx_gas_settle\n" ++
+    "  mv t3, a0\n" ++
+    "  mv t6, a1\n" ++
     "  la t4, rdg_gas_left\n" ++
     "  sd t3, 0(t4)\n" ++
     "  la t4, runtime_tx_calldata_floor\n" ++
     "  ld t5, 0(t4)               # EIP-7623 calldata floor\n" ++
     "  la t4, rdg_calldata_floor\n" ++
     "  sd t5, 0(t4)\n" ++
-    "  la t6, evm_refund_acc; ld t6, 0(t6)   # refund_counter (EIP-3529 SSTORE refund accumulator)\n" ++
     "  la t4, rdg_refund_counter\n" ++
     "  sd t6, 0(t4)\n" ++
     "  li t0, 0xa0010000\n" ++

--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -2698,6 +2698,49 @@ def emitRuntimeDispatcherDataSectionSharedGuest
     (registry : List OpcodeHandlerSpec) : String :=
   emitRuntimeDispatcherDataSectionCore registry false false
 
+/-- Frame/CREATE helper closure for STANDALONE runtime-dispatcher units.
+
+    The registry handlers reference `create_frame_descend` (h_CREATE/h_CREATE2
+    tails, .61.8.3.5), `u256_sub_be` (the CREATE endowment math), and
+    `nonstorage_effect_latest_balance` (the live-BALANCE read, yisv8) — but
+    those functions were only linked by the guest closure
+    (`emitRuntimeDispatcherEmbeddedHelperFunctions`) and by probes that bundle
+    them ad hoc, so the standalone `runtime_dispatcher` / callable-probe ELFs
+    stopped linking when those handlers landed. This mirrors the proven probe
+    bundle (see `ziskSstoreClearGasProbeUnit`). Kept OUT of
+    `emitDispatcherEpilogueCore`'s shared-helpers branch: probes that already
+    bundle these functions use that branch, and a second copy would be a
+    duplicate-label assembler error. -/
+def runtimeDispatcherStandaloneFrameHelpers : String :=
+  u256SubBeFunction ++ "\n" ++
+  frameBaseFunction ++ "\n" ++
+  frameDepthPushFunction ++ "\n" ++
+  frameDepthPopFunction ++ "\n" ++
+  frameSaveRegsFunction ++ "\n" ++
+  frameLoadRegsFunction ++ "\n" ++
+  callFrameEnterFunction ++ "\n" ++
+  callFrameSetCallEnvFunction ++ "\n" ++
+  callFrameSetCalldataFunction ++ "\n" ++
+  callFrameForwardGasFunction ++ "\n" ++
+  callFrameDescendFunction ++ "\n" ++
+  createFrameDescendFunction ++ "\n" ++
+  frameReturnFunction ++ "\n" ++
+  recordNonstorageEffectFunction ++ "\n" ++
+  nonstorageEffectLatestBalanceFunction
+
+/-- Frame-arena data labels for the standalone frame-helper closure
+    (the guest defines these in `BlockVerdictDataSection`; the bundling
+    probes each define their own copies). -/
+def runtimeDispatcherStandaloneFrameData : String :=
+  ".balign 8\n" ++
+  "evm_call_depth:\n  .zero 8\n" ++
+  ".balign 16\n" ++
+  "frame_save_area:\n  .zero 16400\n" ++
+  ".balign 32\n" ++
+  "frame_call_ctx:\n  .zero 32800\n" ++
+  ".balign 32\n" ++
+  "call_frame_arena:\n  .zero " ++ toString (0x29000 : Nat) ++ "\n"
+
 /-- Build a runtime-bytecode `BuildUnit` for `registry` + `exitBody`.
     The emitted ELF doesn't carry any bytecode — the test harness
     supplies it at runtime via `ziskemu -i <file>` (8-byte LE length
@@ -2707,8 +2750,14 @@ def buildRuntimeDispatchUnit
     (exitBody : Program) : BuildUnit := {
   body        := []
   prologueAsm := emitRuntimeDispatcherPrologue
-  epilogueAsm := emitDispatcherEpilogue registry exitBody
-  dataAsm     := emitRuntimeDispatcherDataSection registry
+  -- The frame helpers go BEFORE the epilogue: the prologue's dispatch loop
+  -- ends with `j .dispatch_loop` (no fall-through into them) and every helper
+  -- ends with `ret`, while the epilogue's exit join must keep falling through
+  -- to the halt stub `emitBuildUnit` appends after `epilogueAsm`.
+  epilogueAsm := runtimeDispatcherStandaloneFrameHelpers ++ "\n" ++
+                 emitDispatcherEpilogue registry exitBody
+  dataAsm     := emitRuntimeDispatcherDataSection registry ++ "\n" ++
+                 runtimeDispatcherStandaloneFrameData
 }
 
 /-- Build a probe `BuildUnit` that exercises the callable runtime dispatcher
@@ -2731,8 +2780,10 @@ def buildRuntimeDispatchCallableProbeUnit
     "  li x10, 0\n" ++
     "  ecall\n" ++
     emitRuntimeDispatcherCallablePrologue
-  epilogueAsm := emitDispatcherCallableEpilogue registry exitBody
-  dataAsm     := emitRuntimeDispatcherDataSection registry
+  epilogueAsm := runtimeDispatcherStandaloneFrameHelpers ++ "\n" ++
+                 emitDispatcherCallableEpilogue registry exitBody
+  dataAsm     := emitRuntimeDispatcherDataSection registry ++ "\n" ++
+                 runtimeDispatcherStandaloneFrameData
 }
 
 /-- Build a probe `BuildUnit` that runs one staged transaction through the
@@ -2801,9 +2852,11 @@ def buildRuntimeDispatchGasCaptureProbeUnit
     "  li x10, 0\n" ++
     "  ecall\n" ++
     emitRuntimeDispatcherCallablePrologue
-  epilogueAsm := emitDispatcherCallableEpilogue registry exitBody
+  epilogueAsm := runtimeDispatcherStandaloneFrameHelpers ++ "\n" ++
+                 emitDispatcherCallableEpilogue registry exitBody
   dataAsm     :=
     emitRuntimeDispatcherDataSection registry ++ "\n" ++
+    runtimeDispatcherStandaloneFrameData ++
     ".balign 8\n" ++
     "rdg_gas_left:\n  .zero 128\n" ++
     "rdg_refund_counter:\n  .zero 128\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -481,7 +481,9 @@ def blockVerdictFunction : String :=
   "  la t0, bv_mtx_i; ld t1, 0(t0); slli t0, t1, 3\n" ++
   "  la t3, bv_mtx_gas_left; add t3, t3, t0; sd a1, 0(t3)\n" ++
   "  la t3, bv_mtx_calldata; add t3, t3, t0; sd a2, 0(t3)\n" ++
-  "  la t3, bv_mtx_refund;   add t3, t3, t0; la t4, evm_refund_acc; ld t4, 0(t4); sd t4, 0(t3)\n" ++
+  -- nxio8: a3 = the settle-folded refund counter (0 when the tx erred), not a
+  -- raw evm_refund_acc read.
+  "  la t3, bv_mtx_refund;   add t3, t3, t0; sd a3, 0(t3)\n" ++
   -- fhsxz.2.4.2.57.11.6.3.2: snapshot this tx's committed storage into the cross-tx table,
   -- re-keyed (addrHash) to its recipient (bv_mtx_ctx+72, 20B zero-padded to 32) so the next
   -- tx's preload can thread a prior tx's committed value. The live exec log (env+448 entries
@@ -686,11 +688,13 @@ def blockVerdictFunction : String :=
   "  ld s0, 0(sp); ld s1, 8(sp); ld s2, 16(sp); ld s3, 24(sp)\n" ++
   "  addi sp, sp, 32\n" ++
   "  la t4, runtime_dispatcher_input_ptr; sd zero, 0(t4)\n" ++
-  "  la t2, evm_env; ld t3, 568(t2)\n" ++
-  "  la t4, bv_runtime_gas_left; sd t3, 0(t4)\n" ++
+  -- nxio8: settle fold (EIP-8037 state gas + tx-error rules) instead of a raw
+  -- env[568] read; a0 = effective gas_left, a1 = effective refund counter.
+  "  jal ra, dispatcher_tx_gas_settle\n" ++
+  "  la t4, bv_runtime_gas_left; sd a0, 0(t4)\n" ++
+  "  la t4, bv_runtime_refund_counter; sd a1, 0(t4)\n" ++
   "  la t4, runtime_tx_calldata_floor; ld t5, 0(t4)\n" ++
   "  la t4, bv_runtime_calldata_floor; sd t5, 0(t4)\n" ++
-  "  la t4, bv_runtime_refund_counter; la t5, evm_refund_acc; ld t5, 0(t5); sd t5, 0(t4)\n" ++
   "  la t4, bvgr_runtime_gas_left_ptr; la t5, bv_runtime_gas_left; sd t5, 0(t4)\n" ++
   "  la t4, bvgr_runtime_refund_counter_ptr; la t5, bv_runtime_refund_counter; sd t5, 0(t4)\n" ++
   "  la t4, bvgr_runtime_calldata_floor_ptr; la t5, bv_runtime_calldata_floor; sd t5, 0(t4)\n" ++
@@ -732,7 +736,9 @@ def blockVerdictFunction : String :=
   "  bnez a0, .Lbv_after_tx_gas_precharge\n" ++
   "  la t4, bv_runtime_gas_left; sd a1, 0(t4)\n" ++
   "  la t4, bv_runtime_calldata_floor; sd a2, 0(t4)\n" ++
-  "  la t4, bv_runtime_refund_counter; la t5, evm_refund_acc; ld t5, 0(t5); sd t5, 0(t4)\n" ++
+  -- nxio8: a3 = the settle-folded refund counter (0 when the tx erred), not a
+  -- raw evm_refund_acc read.
+  "  la t4, bv_runtime_refund_counter; sd a3, 0(t4)\n" ++
   "  la t4, bvgr_runtime_gas_left_ptr; la t5, bv_runtime_gas_left; sd t5, 0(t4)\n" ++
   "  la t4, bvgr_runtime_refund_counter_ptr; la t5, bv_runtime_refund_counter; sd t5, 0(t4)\n" ++
   "  la t4, bvgr_runtime_calldata_floor_ptr; la t5, bv_runtime_calldata_floor; sd t5, 0(t4)\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -49,8 +49,12 @@ open EvmAsm.Rv64
     Returns:
       a0 = status: 0 = supported, gas measured; non-zero = unsupported / lookup
            miss / not self-contained (caller should stay conservative)
-      a1 = gas_left (evm_env[568]) on status 0
+      a1 = effective gas_left on status 0: env[568] + evm_state_gas_left with
+           the spec's tx-level error rules folded in by dispatcher_tx_gas_settle
+           (exceptional halt → regular gas burnt; any error → state-gas restore)
       a2 = calldata_floor (runtime_tx_calldata_floor) on status 0
+      a3 = effective refund counter on status 0 (evm_refund_acc, or 0 when the
+           tx erred — interpreter.py discards the refund counter on error)
 
     Preserves the caller's s0..s3 (block_verdict holds its input frame in s0). -/
 /-! ## seed_callee_storage (bmvmx.1.6.4.2.b)
@@ -417,7 +421,15 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  ld s0, 0(sp); ld s1, 8(sp); ld s2, 16(sp); ld s3, 24(sp)\n" ++
   "  addi sp, sp, 32\n" ++
   "  la t4, runtime_dispatcher_input_ptr; sd zero, 0(t4)\n" ++
-  "  la t2, evm_env; ld t3, 568(t2)\n" ++
+  -- nxio8: spec-exact per-tx settlement fold (EIP-8037). dispatcher_tx_gas_settle
+  -- returns a0 = gas_left + state_gas_left with the tx-error rules applied
+  -- (exceptional halt burns regular gas; any error restores state gas and
+  -- discards refunds) and a1 = the effective refund counter — so the bvgr
+  -- consumers' `tx.gas - gas_left` formula matches
+  -- `tx.gas - gas_left - state_gas_left` from fork.py process_transaction.
+  "  jal ra, dispatcher_tx_gas_settle\n" ++
+  "  mv t3, a0                    # effective gas_left\n" ++
+  "  mv a3, a1                    # effective refund_counter\n" ++
   "  la t4, runtime_tx_calldata_floor; ld t5, 0(t4)\n" ++
   "  mv a1, t3                    # gas_left\n" ++
   "  mv a2, t5                    # calldata_floor\n" ++

--- a/EvmAsm/Codegen/Programs/EvmDispatchUnits.lean
+++ b/EvmAsm/Codegen/Programs/EvmDispatchUnits.lean
@@ -500,17 +500,21 @@ def ziskDeriveBlockSystemRequestsProbeUnit : BuildUnit := {
     "call_frame_arena:\n  .zero " ++ toString (0x29000 : Nat) ++ "\n"
 }
 
-/-! ## zisk_sstore_clear_gas_probe (diagnostic for .57.11.6.5.3 / d')
+/-! ## zisk_sstore_clear_gas_probe (regression pin for the SSTORE-clear charge; was the .57.11.6.5.3 / d' reproducer)
 
-    Pins the (d'/bv_fail=41) regular-gas undercount: dispatch the multi_transaction_gas_accounting
-    tx0 recipient bytecode (10× PUSH0; PUSH1 i; SSTORE — clearing slots 0..9, each preloaded to 1)
-    with gas=71050, and dump the post-dispatch env.gasRemaining (env+568) + persistent-log count
-    (env+448). SPEC charges 21000 intrinsic + 10×5000 (cold SSTORE-clear) + 50 pushes = 71050 (full)
-    -> gas_left ~0, log count = 10 preload + 10 SSTORE appends = 20. If gas_left ≈ 25200 (c2#48's
-    block_inc[0]=45850 = 71050-25200) -> tx0 under-executes (~5 SSTOREs); the log count tells how
-    many SSTOREs ran. Stages via stage_runtime_payload_code with the 10-slot preload; bundles the
-    same dispatcher + frame-helper closure as the derive probes (so it links standalone, unlike the
-    plain runtime_dispatcher unit).
+    Dispatches the multi_transaction_gas_accounting tx0 recipient bytecode
+    (10× PUSH0; PUSH1 i; SSTORE — clearing slots 0..9, each preloaded to 1)
+    with gas=71050, and dumps the post-dispatch env.gasRemaining (env+568) +
+    persistent-log count (env+448). SPEC charges 21000 intrinsic + 10×5000
+    (cold clean-changing SSTORE-clear: 2100 cold + 2900 regular) + 50 pushes =
+    71050 (full) -> gas_left = 0, log count = 10 preload + 10 SSTORE appends =
+    20. (The probe originally pinned the d' undercharge — gas_left 25200 —
+    which had TWO causes, both fixed: the BAL preload keys were staged BE and
+    invisible to the LE exec-log scan, and this probe's own preload mirrored
+    that BE staging.) Stages via stage_runtime_payload_code with the 10-slot
+    LE preload; bundles the same dispatcher + frame-helper closure as the
+    derive probes (so it links standalone, unlike the plain runtime_dispatcher
+    unit).
     Output (0xa0010000): +0 gas_left (env+568), +8 persistent_log_count (env+448),
     +16 status (0 ok / 1 staging unsupported). -/
 def ziskSstoreClearGasProbeUnit : BuildUnit := {
@@ -524,13 +528,19 @@ def ziskSstoreClearGasProbeUnit : BuildUnit := {
     "  addi t1, t0, 72; la t2, scgp_recip; li t3, 20\n" ++
     ".Lscgp_rc:\n  beqz t3, .Lscgp_rcd; lbu t4, 0(t2); sb t4, 0(t1); addi t2, t2, 1; addi t1, t1, 1; addi t3, t3, -1; j .Lscgp_rc\n" ++
     ".Lscgp_rcd:\n" ++
-    -- build the 10-slot preload (count*64: key:32 BE, value:32 BE). zero 640B, then set key[i].byte31=i, value[i].byte63=1
+    -- build the 10-slot preload (count*64: key:32, value:32, both in the EVM
+    -- stack/exec-log LITTLE-ENDIAN-limb order that stage_runtime_payload_code
+    -- copies verbatim — dispatch_tx_runtime_code byte-reverses the BAL's BE keys
+    -- BEFORE staging, so the staged format is LE). zero 640B, then set
+    -- key[i].byte0=i, value[i].byte0=1 (i.e. key=i, value=1 as LE words). The
+    -- original BE staging (key byte31=i) left slots 1..9 invisible to the LE
+    -- scan, which is what this probe's old 25200 "expected undercharge" pinned.
     "  la t0, scgp_preload; li t1, 80\n" ++
     ".Lscgp_zp:\n  sd zero, 0(t0); addi t0, t0, 8; addi t1, t1, -1; bnez t1, .Lscgp_zp\n" ++
     "  la t0, scgp_preload; li t1, 0\n" ++
     ".Lscgp_bp:\n  li t2, 10; beq t1, t2, .Lscgp_bpd\n" ++
-    "  slli t3, t1, 6; add t4, t0, t3; addi t5, t4, 31; sb t1, 0(t5)\n" ++         -- key[i] byte31 = i
-    "  addi t5, t4, 63; li t6, 1; sb t6, 0(t5)\n" ++                               -- value[i] byte63 = 1
+    "  slli t3, t1, 6; add t4, t0, t3; sb t1, 0(t4)\n" ++                          -- key[i] byte0 = i (LE)
+    "  addi t5, t4, 32; li t6, 1; sb t6, 0(t5)\n" ++                               -- value[i] byte0 = 1 (LE)
     "  addi t1, t1, 1; j .Lscgp_bp\n" ++
     ".Lscgp_bpd:\n" ++
     -- stage_runtime_payload_code(ctx, out, exec, code, 40, preload, 10)

--- a/EvmAsm/Codegen/Programs/SstoreGasRefund.lean
+++ b/EvmAsm/Codegen/Programs/SstoreGasRefund.lean
@@ -23,13 +23,23 @@ open EvmAsm.Rv64
     a4 = output ptr
 
     Output:
-      +0  gas cost u64
+      +0  gas cost u64 (regular gas only; the EIP-8037 state-gas charge for a
+          zero-origin creation is accounted by the caller via
+          `evm_state_gas_left`/`evm_state_gas_used`)
       +8  refund delta i64 encoded as two's-complement u64
       +16 changed flag (current != new)
       +24 accessed-after flag (always 1 for a successful SSTORE access)
+      +32 zero-restore state-gas credit flag (original == new == 0 with a
+          change → the caller applies credit_state_gas_refund(97920))
 
     Mirrors execution-specs/src/ethereum/forks/amsterdam/vm/instructions/storage.py:
-    cold surcharge, original/current/new gas branch, and refund counter branch. -/
+    cold surcharge, original/current/new gas branch, and refund counter branch.
+    Amsterdam dropped the legacy EIP-2200 SET(20000) split: clean-changing
+    charges COLD_STORAGE_WRITE - COLD_STORAGE_ACCESS = 2900 regardless of the
+    original being zero (the creation charge moved to EIP-8037 state gas), and
+    the restore refund is uniformly COLD_STORAGE_WRITE - COLD_STORAGE_ACCESS -
+    WARM_ACCESS = 2800 (the zero-restore case additionally credits state gas,
+    surfaced via the +32 flag). -/
 def sstoreGasRefundOutcomeFunction : String :=
   "sstore_gas_refund_outcome:\n" ++
   "  addi sp, sp, -80\n" ++
@@ -77,18 +87,14 @@ def sstoreGasRefundOutcomeFunction : String :=
   ".Lsgr_access_warm:\n" ++
   "  beqz s3, .Lsgr_warm_access_cost\n" ++
   "  bnez s4, .Lsgr_warm_access_cost\n" ++
-  "  beqz s0, .Lsgr_reset_cost\n" ++
-  "  li t0, 20000\n" ++
-  "  add s6, s6, t0\n" ++
-  "  j .Lsgr_refund\n" ++
-  ".Lsgr_reset_cost:\n" ++
-  "  li t0, 2900                 # COLD_STORAGE_WRITE - COLD_STORAGE_ACCESS\n" ++
-  "  add s6, s6, t0\n" ++
+  "  li t0, 2900                 # clean-changing: COLD_STORAGE_WRITE - COLD_STORAGE_ACCESS\n" ++
+  "  add s6, s6, t0\n" ++        -- (Amsterdam: no SET split; zero-origin creation is EIP-8037 state gas)
   "  j .Lsgr_refund\n" ++
   ".Lsgr_warm_access_cost:\n" ++
   "  li t0, 100\n" ++
   "  add s6, s6, t0\n" ++
   ".Lsgr_refund:\n" ++
+  "  li t2, 0                    # zero-restore state-gas credit flag\n" ++
   "  bnez s4, .Lsgr_store\n" ++
   "  bnez s0, .Lsgr_restore_check\n" ++
   "  bnez s1, .Lsgr_reverse_clear\n" ++
@@ -101,13 +107,10 @@ def sstoreGasRefundOutcomeFunction : String :=
   "  sub s7, s7, t0\n" ++
   ".Lsgr_restore_check:\n" ++
   "  beqz s5, .Lsgr_store\n" ++
-  "  beqz s0, .Lsgr_restore_nonzero\n" ++
-  "  li t0, 19900                # STORAGE_SET - WARM_ACCESS\n" ++
+  "  li t0, 2800                 # restore: COLD_STORAGE_WRITE - COLD_STORAGE_ACCESS - WARM_ACCESS\n" ++
   "  add s7, s7, t0\n" ++
-  "  j .Lsgr_store\n" ++
-  ".Lsgr_restore_nonzero:\n" ++
-  "  li t0, 2800                 # COLD_STORAGE_WRITE - COLD_STORAGE_ACCESS - WARM_ACCESS\n" ++
-  "  add s7, s7, t0\n" ++
+  "  beqz s0, .Lsgr_store\n" ++
+  "  li t2, 1                    # zero restore: caller credits state gas (EIP-8037)\n" ++
   ".Lsgr_store:\n" ++
   "  sd s6, 0(a4)\n" ++
   "  sd s7, 8(a4)\n" ++
@@ -115,6 +118,7 @@ def sstoreGasRefundOutcomeFunction : String :=
   "  sd t0, 16(a4)\n" ++
   "  li t0, 1\n" ++
   "  sd t0, 24(a4)\n" ++
+  "  sd t2, 32(a4)\n" ++
   "  li a0, 0\n" ++
   "  ld ra, 0(sp)\n" ++
   "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
@@ -133,7 +137,8 @@ def sstoreGasRefundOutcomeFunction : String :=
       OUTPUT+8  gas cost
       OUTPUT+16 refund delta i64/two's-complement u64
       OUTPUT+24 changed flag
-      OUTPUT+32 accessed-after flag -/
+      OUTPUT+32 accessed-after flag
+      OUTPUT+40 zero-restore state-gas credit flag -/
 def ziskSstoreGasRefundOutcomePrologue : String :=
   "  li sp, 0xa0050000\n" ++
   "  li t0, 0x40000000\n" ++

--- a/EvmAsm/Codegen/Programs/Storage.lean
+++ b/EvmAsm/Codegen/Programs/Storage.lean
@@ -74,15 +74,21 @@ open EvmAsm.Rv64
     - `x18`: pointer to found log entry's original value (`entry+64`), or zero.
     - `x19`: storage-access status (`0` warm, `1` cold).
 
-    Clobbers `x5`, `x6`, `x14`-`x17`. Jumps to `.exit_outofgas` if the
+    Clobbers `x5`, `x6`, `x9`, `x14`-`x17`. Jumps to `.exit_outofgas` if the
     additional debit cannot be paid. The static dispatch table already charged
     100 gas for SSTORE, and `evm_storage_access_charge_key` already charged the
     2000 cold delta, so this computes the remaining debit to match Amsterdam's
     `vm/instructions/storage.py`:
-    - clean zero -> nonzero: +19900 warm, +20000 cold
-    - clean nonzero update: +2800 warm, +2900 cold
+    - clean-changing (original == current ≠ new): +2800 warm, +2900 cold
+      (Amsterdam dropped the legacy EIP-2200 SET split — COLD_STORAGE_WRITE -
+      COLD_STORAGE_ACCESS = 2900 regardless of the original being zero); when
+      the original is zero this is a state CREATION, so it additionally charges
+      the EIP-8037 state gas STATE_BYTES_PER_STORAGE_SET(64) ×
+      COST_PER_STATE_BYTE(1530) = 97,920 via the charge_state_gas rule: drain
+      `evm_state_gas_left` first, spill the remainder into env.gasRemaining,
+      OOG when both are short; `evm_state_gas_used` accumulates the charge.
     - dirty/noop branch: +0 warm, +100 cold
-    Refund-counter updates are still handled separately by later gas work. -/
+    Refund-counter updates are handled by `sstore_gas_refund_outcome` below. -/
 def sstoreValueTransitionGasAsm : String :=
   -- x14 = OR of the new value limbs. For a missing slot, original=current=0.
   "  mv x14, x0\n" ++
@@ -138,27 +144,28 @@ def sstoreValueTransitionGasAsm : String :=
   "  or x17, x17, x6\n" ++
   "  bnez x16, .Lsstore_dirty_or_noop\n" ++
   "  beqz x17, .Lsstore_dirty_or_noop\n" ++
-  "  beqz x15, .Lsstore_clean_zero\n" ++
-  "  li x14, 2800\n" ++
+  "  li x9, 0\n" ++                  -- x9 = needs_state_gas (zero-origin creation)
+  "  bnez x15, .Lsstore_clean_changing\n" ++
+  "  li x9, 1\n" ++
+  ".Lsstore_clean_changing:\n" ++
+  "  li x14, 2800\n" ++              -- COLD_STORAGE_WRITE - COLD_STORAGE_ACCESS - warm floor
   "  beqz x19, .Lsstore_charge_delta\n" ++
   "  li x14, 2900\n" ++
   "  j .Lsstore_charge_delta\n" ++
-  ".Lsstore_clean_zero:\n" ++
-  "  li x14, 19900\n" ++
-  "  beqz x19, .Lsstore_charge_delta\n" ++
-  "  li x14, 20000\n" ++
-  "  j .Lsstore_charge_delta\n" ++
   ".Lsstore_missing_slot:\n" ++
+  "  li x9, 0\n" ++
   "  bnez x14, .Lsstore_missing_nonzero\n" ++
   "  beqz x19, .Lsstore_gas_done\n" ++
   "  li x14, 100\n" ++
   "  j .Lsstore_charge_delta\n" ++
-  ".Lsstore_missing_nonzero:\n" ++
-  "  li x14, 19900\n" ++
+  ".Lsstore_missing_nonzero:\n" ++   -- missing slot = original = current = 0: creation
+  "  li x9, 1\n" ++
+  "  li x14, 2800\n" ++
   "  beqz x19, .Lsstore_charge_delta\n" ++
-  "  li x14, 20000\n" ++
+  "  li x14, 2900\n" ++
   "  j .Lsstore_charge_delta\n" ++
   ".Lsstore_dirty_or_noop:\n" ++
+  "  li x9, 0\n" ++
   "  beqz x19, .Lsstore_gas_done\n" ++
   "  li x14, 100\n" ++
   ".Lsstore_charge_delta:\n" ++
@@ -166,6 +173,30 @@ def sstoreValueTransitionGasAsm : String :=
   "  bltu x15, x14, .exit_outofgas\n" ++
   "  sub x15, x15, x14\n" ++
   "  sd x15, 568(x20)\n" ++
+  -- EIP-8037 state gas for a zero-origin set (charge AFTER the regular debit so
+  -- a regular-gas OOG never drains the reservoir, matching the spec's "charge
+  -- regular gas before state gas" ordering in storage.py sstore).
+  "  beqz x9, .Lsstore_gas_done\n" ++
+  "  la x15, evm_state_gas_left\n" ++
+  "  ld x16, 0(x15)\n" ++
+  "  li x14, 97920\n" ++             -- STATE_BYTES_PER_STORAGE_SET(64) × COST_PER_STATE_BYTE(1530)
+  "  bgeu x16, x14, .Lsstore_state_from_reservoir\n" ++
+  "  sub x14, x14, x16\n" ++         -- spill = charge - reservoir
+  "  sd x0, 0(x15)\n" ++
+  "  ld x16, 568(x20)\n" ++
+  "  bltu x16, x14, .exit_outofgas\n" ++
+  "  sub x16, x16, x14\n" ++
+  "  sd x16, 568(x20)\n" ++
+  "  j .Lsstore_state_charged\n" ++
+  ".Lsstore_state_from_reservoir:\n" ++
+  "  sub x16, x16, x14\n" ++
+  "  sd x16, 0(x15)\n" ++
+  ".Lsstore_state_charged:\n" ++
+  "  la x15, evm_state_gas_used\n" ++
+  "  ld x16, 0(x15)\n" ++
+  "  li x14, 97920\n" ++
+  "  add x16, x16, x14\n" ++
+  "  sd x16, 0(x15)\n" ++
   ".Lsstore_gas_done:\n"
 
 /-- M24 Option A storage handlers. -/
@@ -268,6 +299,13 @@ def storageHandlers : List OpcodeHandlerSpec :=
     , opcodes := [0x55]
     , preBody :=
         stackUnderflowGuardAsm 2 ++ "\n" ++
+        -- Amsterdam SSTORE stipend guard: `check_gas(evm, CALL_STIPEND + 1)`
+        -- (storage.py) fails the op when gas_left < 2301 at instruction entry,
+        -- WITHOUT charging. The dispatch loop already deducted the 100 static
+        -- floor, so the equivalent post-deduction threshold here is 2201.
+        "  ld x14, 568(x20)\n" ++
+        "  li x15, 2201\n" ++
+        "  bltu x14, x15, .exit_outofgas\n" ++
         -- EIP-2929 storage-key access gas. The dispatch table already
         -- charged SSTORE's 100 warm floor, so this helper only charges
         -- the 2000 cold delta on first key touch. Run before the scan /
@@ -351,6 +389,22 @@ def storageHandlers : List OpcodeHandlerSpec :=
         "  jal ra, sstore_gas_refund_outcome\n" ++
         "  la x14, srfd_out; ld x15, 8(x14)\n" ++      -- signed refund delta
         "  la x14, evm_refund_acc; ld x16, 0(x14); add x16, x16, x15; sd x16, 0(x14)\n" ++
+        -- EIP-8037 zero-restore credit (storage.py: original == new == 0 with a
+        -- change → credit_state_gas_refund(STATE_BYTES_PER_STORAGE_SET ×
+        -- COST_PER_STATE_BYTE)): apply min(97920, evm_state_gas_used) back into
+        -- evm_state_gas_left. The cross-frame `state_gas_refund_pending`
+        -- remainder is dropped (single-frame state-gas model; the clamp keeps
+        -- the credit sound — it can never exceed what this tx charged).
+        "  la x14, srfd_out; ld x15, 32(x14)\n" ++     -- zero-restore credit flag
+        "  beqz x15, 11f\n" ++
+        "  la x14, evm_state_gas_used; ld x15, 0(x14)\n" ++
+        "  li x16, 97920\n" ++
+        "  bleu x15, x16, 10f\n" ++
+        "  mv x15, x16\n" ++                            -- applied = min(97920, used)
+        "10:\n" ++
+        "  ld x16, 0(x14); sub x16, x16, x15; sd x16, 0(x14)\n" ++
+        "  la x14, evm_state_gas_left; ld x16, 0(x14); add x16, x16, x15; sd x16, 0(x14)\n" ++
+        "11:\n" ++
         "  ld x1, 0(sp); ld x10, 8(sp); ld x12, 16(sp); ld x13, 24(sp); addi sp, sp, 32\n" ++
         "  ld x15, 448(x20)\n" ++         -- reload current log_length
         "  li x14, 0xa0630000\n" ++

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -2380,21 +2380,41 @@ def opcodeTestCases : List OpcodeTestCase :=
       expectedOutHex := "0000000000000000000000000000000000000000000000000000000000000000"
       gasLimit       := "2208" }
   , -- PUSH1 value; PUSH1 key; SSTORE; STOP. Clean zero -> nonzero
-    -- SSTORE costs 2100 cold access + 20000 STORAGE_SET.
+    -- Amsterdam SSTORE costs 2100 cold access + 2900 regular (no EIP-2200 SET
+    -- split) + 97,920 EIP-8037 state gas (64 × 1530) for the zero-origin
+    -- creation, spilled into regular gas (raw-gas tests have an empty
+    -- state-gas reservoir): 6 + 5000 + 97920 = 102,926.
     { name                        := "sstore_cold_gas_exact"
       bytecode                    := "0x60, 0x42, 0x60, 0x00, 0x55, 0x00"
       expectedOutHex              := "0000000000000000000000000000000000000000000000000000000000000000"
       expectedPersistentLogLength := "0100000000000000"
-      gasLimit                    := "22106" }
+      gasLimit                    := "102926" }
   , -- One gas short of the first cold SSTORE must halt out-of-gas before append.
     { name                        := "sstore_cold_gas_out_of_gas"
       bytecode                    := "0x60, 0x42, 0x60, 0x00, 0x55, 0x00"
       expectedOutHex              := "0000000000000000000000000000000000000000000000000000000000000000"
       expectedHaltKind            := "0600000000000000"
       expectedPersistentLogLength := "0000000000000000"
-      gasLimit                    := "22105" }
+      gasLimit                    := "102925" }
+  , -- Amsterdam SSTORE stipend rule: check_gas(CALL_STIPEND + 1) fails the op
+    -- when gas_left < 2301 at instruction entry, even though this noop store
+    -- (missing slot, value 0) would only cost 2200: 6 (pushes) leave 2300.
+    { name                        := "sstore_stipend_out_of_gas"
+      bytecode                    := "0x60, 0x00, 0x60, 0x00, 0x55, 0x00"
+      expectedOutHex              := "0000000000000000000000000000000000000000000000000000000000000000"
+      expectedHaltKind            := "0600000000000000"
+      expectedPersistentLogLength := "0000000000000000"
+      gasLimit                    := "2306" }
+  , -- One more gas passes the stipend check; the cold noop store then costs
+    -- 100 static + 2000 cold delta + 100 cold-noop branch = 2200 and appends.
+    { name                        := "sstore_stipend_boundary_ok"
+      bytecode                    := "0x60, 0x00, 0x60, 0x00, 0x55, 0x00"
+      expectedOutHex              := "0000000000000000000000000000000000000000000000000000000000000000"
+      expectedPersistentLogLength := "0100000000000000"
+      gasLimit                    := "2307" }
   , -- Clean nonzero -> nonzero update with a preloaded original costs
-    -- 2100 cold access + (5000 - 2100) storage write gas.
+    -- 2100 cold access + (5000 - 2100) storage write gas (no state gas: the
+    -- original is non-zero).
     { name                        := "sstore_preloaded_nonzero_update_gas_exact"
       bytecode                    := "0x61, 0xbe, 0xef, 0x60, 0x00, 0x55, 0x00"
       storage                     := "(0x00, 0xdead)"
@@ -2402,12 +2422,12 @@ def opcodeTestCases : List OpcodeTestCase :=
       expectedPersistentLogLength := "0200000000000000"
       gasLimit                    := "5006" }
   , -- The second SSTORE to the same key is warm and dirty: first write costs
-    -- 3 + 3 + 22100, second write costs 3 + 3 + 100, STOP costs 0.
+    -- 3 + 3 + 5000 + 97920 (zero-origin creation), second 3 + 3 + 100, STOP 0.
     { name                        := "sstore_repeat_same_key_warm_gas_exact"
       bytecode                    := "0x60, 0x11, 0x60, 0x00, 0x55, 0x60, 0x22, 0x60, 0x00, 0x55, 0x00"
       expectedOutHex              := "0000000000000000000000000000000000000000000000000000000000000000"
       expectedPersistentLogLength := "0200000000000000"
-      gasLimit                    := "22212" }
+      gasLimit                    := "103032" }
   , -- PUSH2 0xbeef; PUSH1 0x00; SSTORE; PUSH1 0x00; SLOAD; STOP with
     -- preload [(0x00, 0xdead)]. SSTORE finds a matching key and
     -- appends a new current-value entry. SLOAD reads back 0xbeef.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1490,10 +1490,26 @@ through ECALL bridges (extending `EvmAsm/EL/Keccak*EcallBridge.lean`).
     unwired → verdict byte-identical): `sstore_regular_gas` (#8630), `memory_expansion_gas` (#8631),
     `keccak256`/`copy`/`log`/`exp` per-unit leaves (#8633). EIP-2929 cold/warm is already charged via
     `evm_storage_access_gas`.
-  - **Remaining** (dispatcher-gas metering, c1 domain): wire these dynamic charges into the opcode
-    handlers all-at-once (composing with the static base + cold/warm, no double-count) + the missing
-    EIP-2930 access-list intrinsic in the runtime tx-gas; needs an EEST contract-row sweep
-    (false-reject risk). Until then contract gas-gating stays inaccurate.
+  - **Dynamic-gas wiring LANDED** (2026-06-09, c1): warmth table live in `h_SLOAD`/`h_SSTORE`,
+    SSTORE value-transition gas + refund accumulation, M31 memory-expansion / copy / keccak /
+    log / exp dynamic gas in all memory-touching handlers, account warmth in
+    BALANCE/EXTCODE*/CALL*/SELFDESTRUCT. eip7778 EEST filter = 32/32 full-match.
+  - **Amsterdam schedule + EIP-8037 state gas** (2026-06-12, branch
+    `feat/dispatcher-eip8037-state-gas`, bead `nxio8`): SSTORE moved off the legacy Cancun
+    schedule (20000 SET / 19900 zero-restore refund) to Amsterdam (2900 clean-changing +
+    97,920 EIP-8037 state gas for zero-origin creation via `evm_state_gas_left`/`evm_state_gas_used`
+    + the reservoir split at TX_MAX_GAS_LIMIT, restore refund 2800 + state credit); SSTORE
+    stipend `check_gas(2301)`; per-dispatch-call resets for `evm_refund_acc` /
+    `evm_storage_access_count` / state cells / halt_kind (all leaked across multi-tx
+    dispatch calls); `dispatcher_tx_gas_settle` folds the spec's tx-level settlement
+    (error → state restore + refund discard, exceptional halt → regular gas burnt) into
+    the `dispatch_tx_runtime_code` / block-verdict gas captures; the standalone
+    `runtime_dispatcher`/callable-probe ELFs link again (frame-helper closure bundled —
+    they had been unlinkable since the CREATE-descent handlers landed).
+  - **Remaining**: EIP-2930 access-list storage-key seeding (`evm_storage_access_seed_key`
+    exists, unwired) + the access-list intrinsic in the runtime tx-gas; child-frame
+    `incorporate_child_on_error` state-gas/refund/warmth rollback (global cells, no
+    per-frame snapshot); creation-tx intrinsic state gas + code-deposit state gas.
 
 - 🔶 **EIP-8025 witness code-preimage rejects (beads `ok3nl`/#8638, `mkwwf`; 2026-06)**: the spec rejects a
   block when execution reads a `code_hash` absent from the witness (`WitnessState.get_code` raises). (a)

--- a/scripts/codegen-zisk-block-verdict-gas-result-arena-check.sh
+++ b/scripts/codegen-zisk-block-verdict-gas-result-arena-check.sh
@@ -201,7 +201,11 @@ run_case "one_legacy"    "one_legacy"    "0,1,1,0,0,21000,21000,21000,0,0,21000,
 run_case "two_overflow"  "two_overflow"  "0,2,2,0,0,21000,21000,21000,1,2,21000,0,2" || FAILED=1
 run_case "bad_remaining" "bad_remaining" "4,1,1,1,1,21000,0,0,255,0,0,255,0" || FAILED=1
 run_case "count_mismatch" "count_mismatch" "2,2,1,0,1,21000,0,0,255,0,0,255,0" || FAILED=1
-run_case "typed_2930"    "typed_2930"    "0,1,1,0,0,62000,61000,61000,0,0,61000,1,0" || FAILED=1
+# typed_2930's receipt fields were written when block_receipt_records_materialize
+# still rejected non-legacy txs (brr_status=1, 0 records); the full typed
+# receipt encoder (daddd84db, .63.1.6.2.2) now materializes type-1 receipts,
+# so the consumer tail is brr_status=0 with 1 record.
+run_case "typed_2930"    "typed_2930"    "0,1,1,0,0,62000,61000,61000,0,0,61000,0,1" || FAILED=1
 
 if [[ "$FAILED" -ne 0 ]]; then
   exit 1

--- a/scripts/codegen-zisk-runtime-dispatcher-gas-capture-check.sh
+++ b/scripts/codegen-zisk-runtime-dispatcher-gas-capture-check.sh
@@ -93,11 +93,15 @@ run_case "stop_empty" 21005 "" "0x00" \
 run_case "gas_stop_empty" 21005 "" "0x5a, 0x00" \
   3 0 21000 0 || FAILED=1
 
-# Nonzero calldata raises the EIP-7623 floor to 21040 (intrinsic 21016).
+# Nonzero calldata raises the EIP-7976 floor: every calldata byte counts 4
+# tokens x TX_DATA_TOKEN_FLOOR(16) = 64 uniformly (mlp31 / #8701), so one byte
+# gives floor 21064; the intrinsic data cost stays 4 tokens x 4 = 16 (21016).
 # Execution starts from tx.gas - intrinsic; STOP costs 0, so
-# gas_left = 21042 - 21016 = 26. Captured floor is 21040.
-run_case "stop_nonzero_calldata" 21042 "ff" "0x00" \
-  26 0 21040 0 || FAILED=1
+# gas_left = 21100 - 21016 = 84. Captured floor is 21064.
+# (The pre-mlp31 expectation 21042/26/21040 made the tx floor-short after
+# #8701 — the validate-tx-gas gate now correctly OOG-rejects gas 21042.)
+run_case "stop_nonzero_calldata" 21100 "ff" "0x00" \
+  84 0 21064 0 || FAILED=1
 
 # REVERT (0xfd) with empty memory returns halt_kind 2 and keeps gas_left from
 # the post-execution gasRemaining. PUSH1 0, PUSH1 0, REVERT: two PUSH1 (3 each)

--- a/scripts/codegen-zisk-sstore-clear-gas-check.sh
+++ b/scripts/codegen-zisk-sstore-clear-gas-check.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
-# codegen-zisk-sstore-clear-gas-check.sh -- diagnostic for bead .57.11.6.5.3 (d'/bv_fail=41).
+# codegen-zisk-sstore-clear-gas-check.sh -- regression pin for the SSTORE-clear
+# charge (formerly the bead .57.11.6.5.3 d'/bv_fail=41 undercount reproducer).
 #
-# Reproduces the multi_transaction_gas_accounting tx0 regular-gas undercount STANDALONE:
-# dispatch 10x (PUSH0; PUSH1 i; SSTORE) clearing slots 0..9 (each preloaded to 1) with gas=71050.
-# FINDINGS (claude-c1): the dispatch runs ALL 10 SSTOREs (log_count=20) but charges only 45850
-# (gas_left=25200) vs the spec's 71050 (10 cold SSTORE-clears @5000). Isolated: the FIRST SSTORE
-# charges 5000 (correct cold); the 2nd+ DISTINCT slots charge 2200 = 100 static + 2000 cold-access
-# + 100 DIRTY transition -> the handler mis-sees repeated-tx SSTOREs as DIRTY (wrong original/current
-# from the log scan), charging the 100 dirty path instead of 2900 clean-changing. This is the (d')
-# block_regular undercount that false-rejects mtx rows 1-8 (bv_fail=41).
-# Asserts the dispatch INVARIANTS (status=0, all 10 SSTOREs executed) and documents the undercharge
-# (gas_left=25200; the fix target is gas_left~0 / each SSTORE 5000).
+# Dispatches 10x (PUSH0; PUSH1 i; SSTORE) clearing slots 0..9 (each preloaded to 1)
+# with gas=71050. Amsterdam spec: 21000 intrinsic + 10 x (2 + 3 + 5000) = 71050,
+# where each cold clean-changing SSTORE-clear is 2100 cold + 2900 regular = 5000
+# (no EIP-8037 state gas: the original is non-zero). Expects gas_left == 0 and all
+# 10 SSTOREs executed (log_count = 10 preload + 10 appends = 20).
+# History: this used to assert the d' undercharge (gas_left=25200), caused by
+# BE-staged preload keys being invisible to the LE exec-log scan -- fixed in
+# dispatch_tx_runtime_code (BAL keys) and in the probe's own preload (now LE).
 set -euo pipefail
 cd "$(dirname "$0")/.."
 ZISKEMU="${ZISKEMU:-}"
@@ -33,11 +32,6 @@ print(f"  status={st} gas_left={gl} log_count={lc} (block_inc={71050-gl})")
 # correctness invariants: staged+dispatched ok, all 10 SSTOREs ran (10 preload + 10 appends = 20)
 assert st==0, f"staging/dispatch failed (status={st})"
 assert lc==20, f"not all 10 SSTOREs executed (log_count={lc}, expected 20)"
-if gl==0:
-    print("  FIXED: gas_left=0 -> all SSTORE-clears charged correctly (5000 each). Update this check.")
-else:
-    print(f"  KNOWN BUG (d'/.57.11.6.5.3): gas_left={gl} (expect 25200) -> block_regular undercount; "
-          f"2nd+ SSTOREs charged ~2200 (dirty) not 5000 (cold clean-changing). Fix target: gas_left~0.")
-    assert gl==25200, f"undercharge magnitude changed ({gl} != 25200) -- investigate"
-print("  PASS (reproducer): dispatch ran all 10 SSTOREs; the undercharge is characterized.")
+assert gl==0, f"SSTORE-clear charge drifted: gas_left={gl}, expected 0 (each clear = 5000)"
+print("  PASS: all 10 cold SSTORE-clears charged the full 5000 (gas_left=0).")
 PY

--- a/scripts/codegen-zisk-sstore-gas-refund-outcome-check.sh
+++ b/scripts/codegen-zisk-sstore-gas-refund-outcome-check.sh
@@ -42,19 +42,20 @@ PY
 
 run_case() {
   local name="$1" warm="$2" original="$3" current="$4" new="$5"
-  local exp_gas="$6" exp_refund="$7" exp_changed="$8"
+  local exp_gas="$6" exp_refund="$7" exp_changed="$8" exp_credit="$9"
   local in_file="gen-out/sstore_gas_${name}.input"
   local out_file="gen-out/sstore_gas_${name}.output"
   make_input "$in_file" "$warm" "$original" "$current" "$new"
   "$ZISKEMU" -e gen-out/zisk_sstore_gas_refund_outcome.elf \
     -i "$in_file" -o "$out_file" -n 2000000 >/dev/null 2>&1 </dev/null \
     || { echo "  ERROR  $name"; return 1; }
-  local status gas refund_raw changed accessed
+  local status gas refund_raw changed accessed credit
   status="$(od -An -tu8 -j 0 -N 8 "$out_file" | tr -d ' \n')"
   gas="$(od -An -tu8 -j 8 -N 8 "$out_file" | tr -d ' \n')"
   refund_raw="$(od -An -tu8 -j 16 -N 8 "$out_file" | tr -d ' \n')"
   changed="$(od -An -tu8 -j 24 -N 8 "$out_file" | tr -d ' \n')"
   accessed="$(od -An -tu8 -j 32 -N 8 "$out_file" | tr -d ' \n')"
+  credit="$(od -An -tu8 -j 40 -N 8 "$out_file" | tr -d ' \n')"
   local refund
   refund="$(python3 - "$refund_raw" <<'PY'
 import sys
@@ -65,26 +66,30 @@ print(u)
 PY
 )"
   if [[ "$status" == "0" && "$gas" == "$exp_gas" && "$refund" == "$exp_refund" &&
-        "$changed" == "$exp_changed" && "$accessed" == "1" ]]; then
-    echo "  PASS   $name gas=$gas refund=$refund changed=$changed"
+        "$changed" == "$exp_changed" && "$accessed" == "1" && "$credit" == "$exp_credit" ]]; then
+    echo "  PASS   $name gas=$gas refund=$refund changed=$changed credit=$credit"
   else
     echo "  FAIL   $name"
-    echo "    expected status=0 gas=$exp_gas refund=$exp_refund changed=$exp_changed accessed=1"
-    echo "    actual   status=$status gas=$gas refund=$refund changed=$changed accessed=$accessed"
+    echo "    expected status=0 gas=$exp_gas refund=$exp_refund changed=$exp_changed accessed=1 credit=$exp_credit"
+    echo "    actual   status=$status gas=$gas refund=$refund changed=$changed accessed=$accessed credit=$credit"
     return 1
   fi
 }
 
 fail=0
-# warm original/current/new -> gas, refund_delta, changed
-run_case warm_set_zero_to_nonzero 1 0 0 1 20000 0 1 || fail=1
-run_case cold_set_zero_to_nonzero 0 0 0 1 22100 0 1 || fail=1
-run_case warm_reset_nonzero       1 5 5 7 2900 0 1 || fail=1
-run_case warm_noop                1 5 5 5 100 0 0 || fail=1
-run_case warm_clear_refund        1 5 5 0 2900 4800 1 || fail=1
-run_case warm_reverse_clear       1 5 0 7 100 -4800 1 || fail=1
-run_case warm_restore_zero        1 0 7 0 100 19900 1 || fail=1
-run_case warm_restore_nonzero     1 5 7 5 100 2800 1 || fail=1
+# Amsterdam schedule: the regular gas has NO EIP-2200 SET split (a zero-origin
+# creation charges 2900 like any clean-changing write; the 97,920 EIP-8037 state
+# gas is the CALLER's charge, surfaced only via the credit flag on zero-restore),
+# and the restore refund is uniformly 2800.
+# warm original/current/new -> gas, refund_delta, changed, state_credit
+run_case warm_set_zero_to_nonzero 1 0 0 1 2900 0 1 0 || fail=1
+run_case cold_set_zero_to_nonzero 0 0 0 1 5000 0 1 0 || fail=1
+run_case warm_reset_nonzero       1 5 5 7 2900 0 1 0 || fail=1
+run_case warm_noop                1 5 5 5 100 0 0 0 || fail=1
+run_case warm_clear_refund        1 5 5 0 2900 4800 1 0 || fail=1
+run_case warm_reverse_clear       1 5 0 7 100 -4800 1 0 || fail=1
+run_case warm_restore_zero        1 0 7 0 100 2800 1 1 || fail=1
+run_case warm_restore_nonzero     1 5 7 5 100 2800 1 0 || fail=1
 
 [[ "$fail" -eq 0 ]] && echo "==> PASS: SSTORE gas/refund outcome matches reference cases" \
   || { echo "==> FAIL"; exit 1; }


### PR DESCRIPTION
## Summary

Closes the remaining dispatcher-gas exactness gaps for contract execution (bead `evm-asm-nxio8`): the Amsterdam SSTORE schedule, the EIP-8037 state-gas dimension, per-transaction dispatch-state resets, and the spec's tx-level gas settlement — so the gas results feeding the EIP-7778/8037 block-gas gates match `execution-specs` for the measured contract shapes.

Most of the dynamic-gas wiring described in nxio8 had already landed (2026-06-09: live EIP-2929 warmth table in `h_SLOAD`/`h_SSTORE`, SSTORE value-transition gas + refund accumulation, M31 memory-expansion/copy/keccak/log/exp charges, account warmth in BALANCE/EXTCODE*/CALL*). What this PR fixes is what was still divergent from the vendored Amsterdam specs:

### SSTORE: legacy Cancun schedule → Amsterdam (Storage.lean, SstoreGasRefund.lean)
- Clean-changing writes charged the legacy `STORAGE_SET` 20000 (total 22100 cold) for a zero origin. Amsterdam charges `COLD_STORAGE_WRITE − COLD_STORAGE_ACCESS` = **2900 regardless of the original being zero** (`vm/instructions/storage.py`), with the storage-creation cost moved to **EIP-8037 state gas**: `STATE_BYTES_PER_STORAGE_SET(64) × COST_PER_STATE_BYTE(1530)` = **97,920**, charged via `charge_state_gas` (drain the reservoir, spill the remainder into `gasRemaining`, OOG when both are short).
- The zero-restore refund was the legacy 19900; Amsterdam refunds **2800** uniformly for restores and additionally credits the state gas back (`credit_state_gas_refund`, clamped to `state_gas_used`).
- Adds the spec's SSTORE stipend guard `check_gas(CALL_STIPEND + 1)` (OOG when gas_left < 2301 at instruction entry; < 2201 after the dispatch loop's static-100 pre-charge).
- `sstore_gas_refund_outcome` moves to the same schedule and surfaces a new `+32` zero-restore state-credit flag for the handler.

### EIP-8037 state-gas dimension (Dispatch.lean)
- New per-tx cells `evm_state_gas_left` / `evm_state_gas_used`; the validate-tx-gas path splits execution gas into `gas_left` and the state-gas reservoir at `TX_MAX_GAS_LIMIT = 16,777,216` (EIP-7825), matching `fork.py`'s `state_gas_reservoir` computation.
- New `dispatcher_tx_gas_settle` helper folds the spec's transaction settlement into the captured results: effective gas_left = `gas_left + state_gas_left`; on any error `state_gas_left += state_gas_used` (no state was grown) and the refund counter is discarded; an exceptional halt burns the remaining regular gas. Wired into `dispatch_tx_runtime_code` (which now also returns the effective refund counter in `a3`) and both block-verdict capture sites.

### Per-transaction dispatch-state resets (Dispatch.lean)
The callable dispatcher (invoked once per tx in multi-tx blocks) never reset:
- `evm_refund_acc` — EIP-3529 refunds are per tx; tx *i+1* inherited tx *i*'s refunds;
- `evm_storage_access_count` — EIP-2929 `accessed_storage_keys` is per tx; tx *i+1* saw tx *i*'s keys as warm (under-charging cold accesses);
- `halt_kind` (OUTPUT+32) — the skip-finalization exit join never writes the success kind, so a prior tx's REVERT kind could leak into the settlement fold.

All three are now reset in the per-call setup (the new state-gas cells too).

### Standalone runtime-dispatcher units relinked
The standalone `runtime_dispatcher` / callable-probe ELFs had been **unlinkable on main** since the CREATE-frame-descent and live-BALANCE handlers landed (`create_frame_descend`, `u256_sub_be`, `nonstorage_effect_latest_balance` were only linked by the guest closure). The frame-helper closure is now bundled into the three standalone builders — placed before the epilogue so the exit join keeps falling through to the halt stub. This revives `codegen-opcodes-runtime-check.sh`'s ELF (the gas-exact opcode suite).

### Tests / probes / scripts
- `zisk_sstore_clear_gas_probe` staged its preload keys big-endian, invisible to the little-endian exec-log scan — the probe-side half of the old `d'` undercount (the real path was fixed earlier in `dispatch_tx_runtime_code`). Now stages LE and the check asserts `gas_left = 0` (10 × 5000 cold SSTORE-clears), where it previously pinned the 25200 undercharge.
- SSTORE gas-exact test rows updated to the Amsterdam totals; new stipend-boundary cases (OOG at 2300, pass at 2301).
- Two stale-on-main script expectations refreshed: the gas-capture check predated the mlp31 EIP-7976 floor change (#8701), and the gas-result-arena check predated the typed-receipt encoder (`daddd84db`).

## Validation

- `codegen-zisk-sstore-gas-refund-outcome-check.sh` — 8/8 Amsterdam cases (incl. the new state-credit flag).
- `codegen-zisk-sstore-clear-gas-check.sh` — `gas_left = 0`, all 10 cold clears at 5000.
- `codegen-zisk-sstore-regular-gas-check.sh` — leaf unchanged, still green.
- `codegen-zisk-runtime-dispatcher-gas-capture-check.sh` — green; exercises `dispatcher_tx_gas_settle` on the STOP and REVERT paths.
- `codegen-zisk-tx-gas-result-increments-check.sh`, `codegen-zisk-block-verdict-gas-result-arena-check.sh` — green.
- All 19 SSTORE/SLOAD gas-exact opcode rows pass through the relinked `runtime_dispatcher` (including `sstore_cold_gas_exact` at the new 102,926 total and both stipend boundaries).
- `codegen-stateless-link-check.sh`, `check-file-size.sh`, `check-forbidden-tactics.sh` — green.
- EEST (zkevm@v0.4.0): **eip8037 first-200: 200/200 full match**, **eip8037 remainder (~271 rows): 271/271 full match**, **eip7778: 32/32 full match** (baselines on main: 200/200 and 32/32), random-20 fixed-seed regression: **20/20 full match**.

## Known scope limits (follow-ups, noted on the bead)
- Single-frame state-gas model: child-frame `incorporate_child_on_error` state-gas/refund/warmth rollback needs per-frame snapshots.
- EIP-2930 access-list storage-key seeding (`evm_storage_access_seed_key` exists, unwired) + the access-list intrinsic in the runtime tx-gas path.
- Creation-tx intrinsic state gas and code-deposit state gas.

Bead: `evm-asm-nxio8`

Authored by @pirapira; implemented by Claude Code.
