### PR TITLE
feat(receipts): no-tx receipts consensus check + per-tx receipt status capture

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -1331,7 +1331,10 @@ def createExecuteInitcodeFrameRuntimeFunction : String :=
       a0 (output) = effective gas_left  = gas_left' + state_gas_left'
                     where gas_left' = 0 for exceptional halts, env+568 otherwise,
                     and state_gas_left' includes the on-error restore;
-      a1 (output) = effective refund_counter = evm_refund_acc, or 0 on error.
+      a1 (output) = effective refund_counter = evm_refund_acc, or 0 on error;
+      a2 (output) = tx success bit (1 when halt_kind is 0 STOP / 1 RETURN /
+                    5 SELFDESTRUCT; 0 on REVERT or an exceptional halt) — the
+                    receipt `succeeded` field (.63.1.6.2.1).
     halt_kind is read from OUTPUT+32 (set by every halt path): 0 STOP / 1 RETURN /
     5 SELFDESTRUCT are successes; 2 REVERT keeps gas_left but folds state gas and
     drops refunds; 3/4/6/7/8 are exceptional. Clobbers t0-t3. Read-only
@@ -1346,12 +1349,14 @@ def dispatcherTxGasSettleFunction : String :=
   "  ld t2, 0(t2)\n" ++
   "  la t3, evm_refund_acc\n" ++
   "  ld a1, 0(t3)\n" ++
+  "  li a2, 1                    # tx success bit (receipt `succeeded`)\n" ++
   "  beqz t1, .Ldtgs_success\n" ++
   "  li t3, 1\n" ++
   "  beq t1, t3, .Ldtgs_success\n" ++
   "  li t3, 5\n" ++
   "  beq t1, t3, .Ldtgs_success\n" ++
   "  li a1, 0                    # error: refund counter discarded\n" ++
+  "  li a2, 0                    # error: receipt status = 0\n" ++
   "  la t3, evm_state_gas_used\n" ++
   "  ld t3, 0(t3)\n" ++
   "  add t2, t2, t3              # error: state_gas_left += state_gas_used\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -38,6 +38,8 @@ import EvmAsm.Codegen.Programs.Address
 import EvmAsm.Codegen.Programs.Eip7702NonceReuseGuard
 import EvmAsm.Codegen.Programs.BlockVerdictReceiptRecords
 import EvmAsm.Codegen.Programs.BlockVerdictGasResults
+import EvmAsm.Codegen.Programs.ReceiptsRootIndexed
+import EvmAsm.Codegen.Programs.Bloom
 import EvmAsm.Codegen.Programs.BlockVerdictTransactions
 import EvmAsm.Codegen.Programs.MptEncodeLeafBranch
 import EvmAsm.Codegen.Programs.TxBlobGas
@@ -309,6 +311,29 @@ def blockVerdictFunction : String :=
   -- nonzero header.gas_used raises InvalidBlock. Verify it here instead of trusting it.
   "  la t5, bv_exec_p; ld t4, 0(t5); addi a0, t4, 420; jal ra, bgv_u64le   # header.gas_used\n" ++
   "  bnez a0, .Lbv_notx_gas_used_fail\n" ++
+  -- .63.1.6.2.3 (slice A): NO-TX receipts consensus. execution-specs apply_body
+  -- recomputes receipt_root = root(receipts_trie) and block_logs_bloom =
+  -- logs_bloom(block_logs) and hard-rejects on a header mismatch (fork.py
+  -- 368-371). A no-tx block has an EMPTY receipts trie and ZERO block logs
+  -- (system txs and withdrawals contribute neither receipts nor block_logs),
+  -- so header.receipts_root must be the empty-trie root and header.bloom must
+  -- be 256 zero bytes. The guest never checked either — the audited
+  -- false-accept (hermes-c3, bead .63.1.6): a crafted no-tx block with a
+  -- tampered bloom/receipt_root and a self-consistent payload.block_hash
+  -- passed every gate. Compute the empty indexed-trie root through the real
+  -- validator (count = 0) and compare the extracted header bloom to zeros.
+  "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++
+  "  la a2, bvrri_value_descs; li a3, 0\n" ++
+  "  jal ra, block_validate_receipts_root_indexed\n" ++
+  "  bnez a0, .Lbv_notx_receipts_root_fail\n" ++
+  "  beqz a1, .Lbv_notx_receipts_root_fail\n" ++
+  "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++
+  "  la a2, bv_header_bloom\n" ++
+  "  jal ra, header_extract_logs_bloom\n" ++
+  "  bnez a0, .Lbv_notx_bloom_fail\n" ++
+  "  la a0, bv_header_bloom; la a1, bv_zero_bloom; la a2, bv_bloom_eq_out\n" ++
+  "  jal ra, bloom_eq\n" ++
+  "  la t0, bv_bloom_eq_out; ld t0, 0(t0); beqz t0, .Lbv_notx_bloom_fail\n" ++
   "  j .Lbv_after_tx_gate\n" ++
   blockVerdictEmptyTransactionCheckAsm ++
   "  la t5, bsr_bal_count; ld t5, 0(t5); beqz t5, .Lbv_no_bal_for_tx  # tx blocks need BAL replay\n" ++
@@ -484,6 +509,7 @@ def blockVerdictFunction : String :=
   -- nxio8: a3 = the settle-folded refund counter (0 when the tx erred), not a
   -- raw evm_refund_acc read.
   "  la t3, bv_mtx_refund;   add t3, t3, t0; sd a3, 0(t3)\n" ++
+  "  la t3, bv_tx_status_arr; add t3, t3, t0; sd a4, 0(t3)\n" ++   -- .63.1.6.2.1: receipt status, tx i
   -- fhsxz.2.4.2.57.11.6.3.2: snapshot this tx's committed storage into the cross-tx table,
   -- re-keyed (addrHash) to its recipient (bv_mtx_ctx+72, 20B zero-padded to 32) so the next
   -- tx's preload can thread a prior tx's committed value. The live exec log (env+448 entries
@@ -693,6 +719,7 @@ def blockVerdictFunction : String :=
   "  jal ra, dispatcher_tx_gas_settle\n" ++
   "  la t4, bv_runtime_gas_left; sd a0, 0(t4)\n" ++
   "  la t4, bv_runtime_refund_counter; sd a1, 0(t4)\n" ++
+  "  la t4, bv_tx_status_arr; sd a2, 0(t4)\n" ++   -- .63.1.6.2.1: receipt status, tx 0
   "  la t4, runtime_tx_calldata_floor; ld t5, 0(t4)\n" ++
   "  la t4, bv_runtime_calldata_floor; sd t5, 0(t4)\n" ++
   "  la t4, bvgr_runtime_gas_left_ptr; la t5, bv_runtime_gas_left; sd t5, 0(t4)\n" ++
@@ -739,6 +766,7 @@ def blockVerdictFunction : String :=
   -- nxio8: a3 = the settle-folded refund counter (0 when the tx erred), not a
   -- raw evm_refund_acc read.
   "  la t4, bv_runtime_refund_counter; sd a3, 0(t4)\n" ++
+  "  la t4, bv_tx_status_arr; sd a4, 0(t4)\n" ++   -- .63.1.6.2.1: receipt status, tx 0
   "  la t4, bvgr_runtime_gas_left_ptr; la t5, bv_runtime_gas_left; sd t5, 0(t4)\n" ++
   "  la t4, bvgr_runtime_refund_counter_ptr; la t5, bv_runtime_refund_counter; sd t5, 0(t4)\n" ++
   "  la t4, bvgr_runtime_calldata_floor_ptr; la t5, bv_runtime_calldata_floor; sd t5, 0(t4)\n" ++
@@ -1135,6 +1163,7 @@ def blockVerdictFunction : String :=
   "  la t2, bv_exec_p; ld a0, 0(t2)\n" ++
   "  la a1, bvgr_receipt_gas_increments\n" ++
   "  la t2, bvgr_arena_tx_count; ld a2, 0(t2)\n" ++
+  "  la a3, bv_tx_status_arr\n" ++   -- .63.1.6.2.1: per-tx settle success bits
   "  jal ra, block_receipt_records_materialize\n" ++
   "  la t2, brr_status; ld t2, 0(t2); bnez t2, .Lbv_receipt_records_fail\n" ++
   "  li a0, 1; j .Lbv_ret\n" ++
@@ -1142,6 +1171,7 @@ def blockVerdictFunction : String :=
   "  la t2, bv_exec_p; ld a0, 0(t2)\n" ++
   "  li a1, 0\n" ++
   "  li a2, 0\n" ++
+  "  li a3, 0\n" ++
   "  jal ra, block_receipt_records_materialize\n" ++
   "  li a0, 1; j .Lbv_ret\n" ++
   ".Lbv_cmp_mismatch:\n" ++
@@ -1184,6 +1214,10 @@ def blockVerdictFunction : String :=
   "  li t0, 19; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_receipt_records_fail:\n" ++
   "  li t0, 25; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
+  ".Lbv_notx_receipts_root_fail:\n" ++   -- .63.1.6.2.3: no-tx header.receipts_root != empty-trie root
+  "  li t0, 50; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
+  ".Lbv_notx_bloom_fail:\n" ++           -- .63.1.6.2.3: no-tx header.bloom != 256 zero bytes
+  "  li t0, 51; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_versioned_hashes_fail:\n" ++
   "  li t0, 27; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_withdrawals_root_fail:\n" ++
@@ -1426,6 +1460,12 @@ def ziskStatelessVerdictV2Prologue : String :=
   publicKeysValidFunction ++ "\n" ++
   receiptRecordsFunction ++ "\n" ++
   blockReceiptRecordsMaterializeFunction ++ "\n" ++
+  -- .63.1.6.2.3: receipts-consensus validators (the indexed-trie family is
+  -- already linked above for the transactions/withdrawals root checks).
+  headerExtractReceiptsRootFunction ++ "\n" ++
+  blockValidateReceiptsRootIndexedFunction ++ "\n" ++
+  headerExtractLogsBloomFunction ++ "\n" ++
+  bloomEqFunction ++ "\n" ++
   blockVerdictFunction ++ "\n" ++
   rlpListCountItemsFunction ++ "\n" ++
   bgvU32leFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -182,6 +182,11 @@ def ziskStatelessVerdictV2DataSection : String :=
   "brr_tx_gas:\n  .zero 8\n" ++
   "brr_receipt_gas_ptr:\n  .zero 8\n" ++
   "brr_receipt_gas_count:\n  .zero 8\n" ++
+  -- .63.1.6.2.1: per-tx execution-status plumbing. bv_tx_status_arr holds the
+  -- dispatcher_tx_gas_settle success bit per tx (single-tx path writes index 0,
+  -- the mtx loop index i); brr_tx_status_ptr is the materializer's saved arg.
+  "brr_tx_status_ptr:\n  .zero 8\n" ++
+  "bv_tx_status_arr:\n  .zero 128\n" ++
   "brr_control:\n  .zero 24\n" ++
   ".balign 8\n" ++
   "brr_records:\n  .zero 1024\n" ++
@@ -195,6 +200,24 @@ def ziskStatelessVerdictV2DataSection : String :=
   "itr_value_descs:\n  .zero 32768\n" ++
   "itr_paths:\n  .zero 16384\n" ++
   "itr_changes:\n  .zero 81920\n" ++
+  -- .63.1.6.2.3: receipts-consensus scratch (mirrors the hewr_/bvwri_ withdrawals
+  -- pair above). herr_/helb_ are header field-extraction cursors; bvrri_* the
+  -- expected/computed receipts roots + per-receipt {ptr,len} descriptors (16 B ×
+  -- 128, same cap as mpt_indexed_trie_root_small); bv_header_bloom /
+  -- bv_zero_bloom / bv_bloom_eq_out drive the header.logs_bloom compare.
+  "herr_offset:\n  .zero 8\n" ++
+  "herr_length:\n  .zero 8\n" ++
+  "helb_offset:\n  .zero 8\n" ++
+  "helb_length:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "bvrri_expected_root:\n  .zero 32\n" ++
+  "bvrri_computed_root:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "bvrri_value_descs:\n  .zero 2048\n" ++
+  ".balign 8\n" ++
+  "bv_header_bloom:\n  .zero 256\n" ++
+  "bv_zero_bloom:\n  .zero 256\n" ++
+  "bv_bloom_eq_out:\n  .zero 8\n" ++
   "bvgr_runtime_gas_left_ptr:\n  .zero 8\n" ++
   "bvgr_runtime_refund_counter_ptr:\n  .zero 8\n" ++
   "bvgr_runtime_calldata_floor_ptr:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -55,6 +55,8 @@ open EvmAsm.Rv64
       a2 = calldata_floor (runtime_tx_calldata_floor) on status 0
       a3 = effective refund counter on status 0 (evm_refund_acc, or 0 when the
            tx erred — interpreter.py discards the refund counter on error)
+      a4 = tx success bit on status 0 (1 for STOP/RETURN/SELFDESTRUCT halts,
+           0 for REVERT/exceptional — the receipt `succeeded` field)
 
     Preserves the caller's s0..s3 (block_verdict holds its input frame in s0). -/
 /-! ## seed_callee_storage (bmvmx.1.6.4.2.b)
@@ -430,6 +432,7 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  jal ra, dispatcher_tx_gas_settle\n" ++
   "  mv t3, a0                    # effective gas_left\n" ++
   "  mv a3, a1                    # effective refund_counter\n" ++
+  "  mv a4, a2                    # tx success bit (receipt status, .63.1.6.2.1)\n" ++
   "  la t4, runtime_tx_calldata_floor; ld t5, 0(t4)\n" ++
   "  mv a1, t3                    # gas_left\n" ++
   "  mv a2, t5                    # calldata_floor\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictGasResults.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictGasResults.lean
@@ -342,6 +342,7 @@ def ziskBlockVerdictGasResultArenaPrologue : String :=
   "  li a0, 0x40000008\n" ++
   "  la a1, bvgr_receipt_gas_increments\n" ++
   "  la t0, bvgr_arena_tx_count; ld a2, 0(t0)\n" ++
+  "  li a3, 0\n" ++   -- gas-only probe: record every tx as successful
   "  jal ra, block_receipt_records_materialize\n" ++
   "  la t0, brr_status; ld t1, 0(t0); sd t1, 88(s1)\n" ++
   "  la t0, brr_control; ld t1, 0(t0); sd t1, 96(s1)\n" ++
@@ -383,6 +384,7 @@ def ziskBlockVerdictGasResultArenaDataSection : String :=
   "brr_tx_inner:\n  .zero 8\n" ++
   "brr_tx_gas:\n  .zero 8\n" ++
   "brr_receipt_gas_ptr:\n  .zero 8\n" ++
+  "brr_tx_status_ptr:\n  .zero 8\n" ++
   "brr_receipt_gas_count:\n  .zero 8\n" ++
   "brr_control:\n  .zero 24\n" ++
   ".balign 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptRecords.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptRecords.lean
@@ -20,13 +20,17 @@ open EvmAsm.Rv64.Program
     a0 = execution payload ptr.
     a1 = pointer to `a2` u64 receipt gas increments from runtime results.
     a2 = receipt gas increment count.
+    a3 = per-tx execution status array ptr (u64 per tx: 1 success / 0 failed),
+         or 0 to record every tx as successful (.63.1.6.2.1 — the verdict
+         passes the dispatcher_tx_gas_settle success bits via bv_tx_status_arr;
+         probes that only exercise the gas chain pass 0).
 
     This deliberately handles only a small materialization surface before full
     transaction execution exists: zero transactions leaves the arena empty, and
-    legacy transactions append success records with cumulative_gas_used equal to
-    the running sum of the runtime-provided receipt gas increments. Other
-    transaction shapes, or missing runtime gas increments, leave a debug status
-    but do not affect the block verdict. -/
+    transactions append records with the runtime-captured execution status and
+    cumulative_gas_used equal to the running sum of the runtime-provided
+    receipt gas increments. Other transaction shapes, or missing runtime gas
+    increments, leave a debug status but do not affect the block verdict. -/
 def blockReceiptRecordsMaterializeFunction : String :=
   "block_receipt_records_materialize:\n" ++
   "  addi sp, sp, -120\n" ++
@@ -37,6 +41,7 @@ def blockReceiptRecordsMaterializeFunction : String :=
   "  mv s0, a0                   # execution payload\n" ++
   "  la t0, brr_receipt_gas_ptr; sd a1, 0(t0)\n" ++
   "  la t0, brr_receipt_gas_count; sd a2, 0(t0)\n" ++
+  "  la t0, brr_tx_status_ptr; sd a3, 0(t0)\n" ++
   "  la t0, brr_status; sd zero, 0(t0)\n" ++
   "  la t0, brr_append_status; sd zero, 0(t0)\n" ++
   "  la a0, brr_control; li a1, 16; la a2, brr_records\n" ++
@@ -98,7 +103,15 @@ def blockReceiptRecordsMaterializeFunction : String :=
   "  mv s7, t2\n" ++
   "  la a0, brr_control\n" ++
   "  la t0, brr_tx_type; ld a1, 0(t0)   # tx type (0 legacy / 1-4 typed)\n" ++
-  "  li a2, 1                    # successful execution\n" ++
+  -- .63.1.6.2.1: per-tx execution status from the runtime capture (1 when the
+  -- dispatch halted via STOP/RETURN/SELFDESTRUCT, 0 on REVERT/exceptional —
+  -- the spec's `error is None` receipt bit); a null array keeps the old
+  -- all-success behavior for gas-only probes.
+  "  la t0, brr_tx_status_ptr; ld t0, 0(t0)\n" ++
+  "  li a2, 1\n" ++
+  "  beqz t0, .Lbrr_status_ready\n" ++
+  "  slli t1, s6, 3; add t0, t0, t1; ld a2, 0(t0)\n" ++
+  ".Lbrr_status_ready:\n" ++
   "  mv a3, s7                   # cumulative gas\n" ++
   "  li a4, 0                    # pre-tx event log checkpoint\n" ++
   "  li a5, 0                    # final event log count\n" ++
@@ -155,6 +168,7 @@ def ziskBlockReceiptRecordsMaterializePrologue : String :=
   "  li a1, 0x40001010\n" ++
   "  li t0, 0x40001008\n" ++
   "  ld a2, 0(t0)\n" ++
+  "  li a3, 0\n" ++
   "  jal ra, block_receipt_records_materialize\n" ++
   "  li s0, 0xa0010000\n" ++
   "  la t1, brr_status; ld t2, 0(t1); sd t2, 0(s0)\n" ++
@@ -188,6 +202,7 @@ def ziskBlockReceiptRecordsMaterializeDataSection : String :=
   "brr_tx_inner:\n  .zero 8\n" ++
   "brr_tx_gas:\n  .zero 8\n" ++
   "brr_receipt_gas_ptr:\n  .zero 8\n" ++
+  "brr_tx_status_ptr:\n  .zero 8\n" ++
   "brr_receipt_gas_count:\n  .zero 8\n" ++
   "brr_control:\n  .zero 24\n" ++
   ".balign 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
@@ -235,6 +235,12 @@ def statelessVerdictV2GuestClosure : String :=
   publicKeysValidFunction ++ "\n" ++
   receiptRecordsFunction ++ "\n" ++
   blockReceiptRecordsMaterializeFunction ++ "\n" ++
+  -- .63.1.6.2.3: receipts-consensus validators (the indexed-trie family is
+  -- already linked for the transactions/withdrawals root checks).
+  headerExtractReceiptsRootFunction ++ "\n" ++
+  blockValidateReceiptsRootIndexedFunction ++ "\n" ++
+  headerExtractLogsBloomFunction ++ "\n" ++
+  bloomEqFunction ++ "\n" ++
   blockVerdictFunction ++ "\n" ++
   rlpListCountItemsFunction ++ "\n" ++
   txTypeDispatchFunction ++ "\n" ++


### PR DESCRIPTION
## Summary

First two slices of wiring guest-computed receipts into the stateless verdict (bead `evm-asm-fhsxz.2.4.2.63.1.6.2`), **stacked on #8721** (the dynamic-gas PR), whose `dispatcher_tx_gas_settle` fold supplies the per-tx execution status this PR threads into receipt records.

### No-tx receipts consensus check (.2.3 slice A) — closes an audited false-accept

`execution-specs` `apply_body` recomputes `receipt_root = root(block_output.receipts_trie)` and `block_logs_bloom = logs_bloom(block_output.block_logs)` and hard-rejects on a header mismatch (`fork.py:368-371`). For a **no-tx block** the receipts trie is empty and `block_logs` is `()` — system transactions and withdrawals contribute neither receipts nor block logs — so `header.receipt_root` must be the empty-trie root and `header.bloom` must be 256 zero bytes.

The verdict never checked either field. hermes-c3's static audit (recorded on bead `.63.1.6`) showed this is a **reachable soundness false-accept**: the `block_hash` gate rebuilds the header RLP from the *claimed* `receipt_root`/`bloom`, so a crafted no-tx block with a tampered bloom (and a self-consistent `payload.block_hash`) passed every gate and returned `valid=1` while the spec rejects it.

The no-tx branch of `block_verdict` now:
- computes the empty indexed-trie root through the real validator (`block_validate_receipts_root_indexed` with count = 0) and compares it against `header.receipts_root` (fail code 50 on mismatch);
- extracts `header.logs_bloom` and compares it against 256 zero bytes via `bloom_eq` (fail code 51).

The validators (`header_extract_receipts_root`, `block_validate_receipts_root_indexed`, `header_extract_logs_bloom`, `bloom_eq`) are linked into both verdict closures (probe bundle + guest bundle); the `mpt_indexed_trie_root_small` family was already linked for the transactions/withdrawals root checks.

### Per-tx receipt execution status (.2.1 first half)

Receipt records previously hardcoded `status = 1`. Now:
- `dispatcher_tx_gas_settle` additionally returns the tx success bit (`halt_kind` 0 STOP / 1 RETURN / 5 SELFDESTRUCT → 1; REVERT or exceptional halt → 0 — the spec's `error is None` receipt field);
- `dispatch_tx_runtime_code` surfaces it as a new `a4` return;
- all three verdict capture sites (EOA, single-tx contract, mtx loop) record it into the new `bv_tx_status_arr`;
- `block_receipt_records_materialize` takes the array as a new `a3` argument and stamps the per-tx status into each record (passing 0 keeps the legacy all-success behavior, used by the gas-only probes).

## Validation

- `codegen-stateless-link-check.sh` — guest links.
- zisk probes green: `block-validate-empty-receipts-root`, `block-validate-receipts-root-indexed`, `bloom-eq`, `block-receipt-records-materialize`, `block-verdict-gas-result-arena`.
- EEST (zkevm@v0.4.0): eip4895 (withdrawals = no-tx blocks, exercising the new enforcement): **40/40 full match**; fixed-seed random-20 regression: **20/20 full match**.
- `check-file-size.sh`, `check-forbidden-tactics.sh` — green.

## Remaining for the receipts lane (recorded on the bead)

Per-tx **log windows** (each dispatcher call resets/overwrites the event-log arena, so the verdict loops must snapshot descriptors + data per tx), a logs-RLP encoder from the captured descriptors, per-receipt blooms, and extending the root/bloom enforcement to exact-measured tx-bearing blocks. Note for that work: build the per-receipt trie descriptors from the records' `encoded_ptr/len` fields — typed receipts are `type_byte || rlp(inner)` and cannot be re-parsed out of the carrier list with `rlp_list_nth_item`.

Bead: `evm-asm-fhsxz.2.4.2.63.1.6.2` (depends on #8721)

Authored by @pirapira; implemented by Claude Code.
