### PR TITLE
fix(receipts): EIP-7708 CALL transfer-log emits from/to/value as raw stack words

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -1437,19 +1437,23 @@ def callDescendFallThrough
     "  jal ra, record_nonstorage_effect\n" ++
     "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
     -- fhsxz.2.4.2.63.1.6.2.6: EIP-7708 emit_transfer_log for this CALL value move, so the
-    -- value-bearing tx's receipt logs/bloom are complete. from = parent ADDRESS (env+0, 32B
-    -- EVM-word right-aligned), to = callee right-aligned into eip7708_cd_to32, value =
-    -- cd_value_be. Still inside the value!=0 guard. eip7708_append_transfer_log no-ops on a
-    -- zero value and (on the 1024-descriptor cap) drops without appending; ignore its status
-    -- (the receipts encoder gates conservatively on the descriptor/data overflow flags).
+    -- value-bearing tx's receipt logs/bloom are complete. from = parent ADDRESS (env+0),
+    -- to = callee (x12+32), value = value word (x12+valueOff), ALL passed as raw EVM stack
+    -- words (LE-limb). The log materializer (log_records_encode_rlp / materialize_log_records)
+    -- byte-reverses each 32B topic slot to the canonical BE topic, and the appender byte-
+    -- reverses the value into the descriptor's canonical-BE amount — so every field must enter
+    -- in stack-word form. `from` (env.ADDRESS) already is; the callee `to` arg and the value
+    -- arg on the parent stack are the same form, so they pass verbatim. (The earlier BE right-
+    -- aligned `to` into [12:32] and BE `cd_value_be` produced wrong-order topics/data: the
+    -- materializer reverses the WHOLE 32B slot, so the address must sit in the low 20 bytes,
+    -- not the high 12. Latent until receipt-consensus enforcement un-gates.)
+    -- x12 = parent stack top here (restored after record_nonstorage_effect above); the appender
+    -- reads through the a1/a2 pointers into EVM memory, which its own sp frame does not disturb.
+    -- Still inside the value!=0 guard. eip7708_append_transfer_log no-ops on a zero value and
+    -- (on the 1024-descriptor cap) drops without appending; ignore its status (the receipts
+    -- encoder gates conservatively on the descriptor/data overflow flags).
     "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
-    "  la t0, eip7708_cd_to32\n  sd x0, 0(t0)\n  sd x0, 8(t0)\n  sd x0, 16(t0)\n  sd x0, 24(t0)\n" ++
-    "  la t1, nse_callee_be\n  addi t2, t0, 12\n  li t3, 20\n" ++
-    ".Lcd_7708_cpto_" ++ tag ++ ":\n" ++
-    "  beqz t3, .Lcd_7708_cpto_d_" ++ tag ++ "\n" ++
-    "  lbu t4, 0(t1)\n  sb t4, 0(t2)\n  addi t1, t1, 1\n  addi t2, t2, 1\n  addi t3, t3, -1\n  j .Lcd_7708_cpto_" ++ tag ++ "\n" ++
-    ".Lcd_7708_cpto_d_" ++ tag ++ ":\n" ++
-    "  mv a0, x20\n  la a1, eip7708_cd_to32\n  la a2, cd_value_be\n" ++
+    "  mv a0, x20\n  addi a1, x12, 32\n  addi a2, x12, " ++ toString valueOff ++ "\n" ++
     "  jal ra, eip7708_append_transfer_log\n" ++
     "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
     ".Lcd_nse_done_" ++ tag ++ ":\n") ++


### PR DESCRIPTION
## Summary
- Part 1 of the EIP-7708 transfer logs (#8728) fed the CALL value-transfer log's `to` topic as the callee address **right-aligned into bytes [12:32]** and the `value` as **big-endian** `cd_value_be`.
- But the log consumer — `log_records_encode_rlp` / `materialize_log_records` (`LogRecordsRlp.lean:13-17,91-112`) — treats each 32-byte topic slot as a **little-endian stack word** and byte-reverses the whole slot to the canonical `[12 zero][20 addr BE]` EIP topic; the synthetic-log appender likewise byte-reverses the value into the descriptor's canonical-BE amount.
- So a topic slot must carry the address in **low-20 stack-word form** and the value must enter **little-endian**. `from` = env+0 (env.ADDRESS, a stack word) was already correct; `to` (BE in [12:32]) reversed to garbage and `value` (BE) reversed to LE — both wrong.
- **Fix:** pass all three as raw EVM stack words — `from`=env+0 (x20), `to`=callee CALL arg (x12+32), `value`=value word (x12+valueOff) — matching the proven-correct `from`. Removes the BE right-align block entirely.

## Why this was latent
Receipt-consensus enforcement (`fhsxz.2.4.2.63.1.6.2.3`) is gated, so no current test exercises the materialized topics / logs_bloom — the wrong byte-order is invisible today and would only surface as a false-reject once enforcement un-gates. This PR is the prerequisite unblock for that un-gate.

## Validation
- **Inert (gated) → zero regression risk.** eip7708 smoke (guest rebuilt with the fix): **8/8 full match, 0 errored, 0 fail**.
- Correctness by composition of the existing probes: `zisk_eip7708_synthetic_logs` (verbatim low-20 copy into the descriptor) + `zisk_materialize_log_records` (LE topic slot → canonical BE reversal). End-to-end runtime validation lands with the receipt-consensus un-gate.
- Gates: `lake build` (module), `check-file-size.sh`, `check-unimported.sh` all green; no `sorry`/`native_decide`/`bv_decide`/`maxHeartbeats`.

Bead: `evm-asm-fhsxz.2.4.2.63.1.6.2.6`.

Authored by @pirapira; implemented by Claude Code