### PR TITLE
feat(receipts): un-gate tx-bearing receipts-consensus enforcement (.63.1.6.2.3 slice B)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -1221,12 +1221,38 @@ def blockVerdictFunction : String :=
   "  jal ra, block_receipt_records_materialize\n" ++
   "  la t2, brr_status; ld t2, 0(t2); bnez t2, .Lbv_receipt_records_fail\n" ++
   -- .63.1.6.2.1: encode per-record logs RLP + bloom and fill logs_desc_ptr.
-  -- INERT (debug status only): nothing consumes the encoded records until the
-  -- receipts consensus enforcement lands (gated on the EIP-7708 transfer-log
-  -- emission gap — see the receipts-blocker bead).
   "  la a0, brr_control\n" ++
   "  jal ra, block_receipt_logs_materialize\n" ++
   "  la t2, bv_receipt_logs_status; sd a0, 0(t2)\n" ++
+  -- .63.1.6.2.3 (slice B): TX-BEARING receipts-consensus enforcement. execution-specs
+  -- apply_body recomputes receipt_root = root(receipts_trie) and block_logs_bloom and hard-
+  -- rejects on a header mismatch (fork.py 368-371). Encode the materialized per-tx receipt
+  -- records (status||cumulative_gas||bloom||logs, with the .2.1 log descriptors @56) into one
+  -- RLP list, then validate header.receipts_root == MPT(indexed(receipts)) AND header.bloom ==
+  -- OR(receipt blooms) via the shared consensus validator. CONSERVATIVE: any materialize/encode
+  -- helper failure (logs status != 0, block-log overflow, encode status != 0) or a validator
+  -- helper error (status 1/3) falls through to accept -- only a confirmed root/bloom MISMATCH
+  -- (status 2/4) rejects, so unsupported shapes never false-reject. Depends on complete transfer
+  -- logs (#8732 Part 1 + #8735 Part 2).
+  "  bnez a0, .Lbv_receipts_accept                # logs materialize failed -> conservative accept\n" ++
+  "  la t2, bv_block_log_overflow; ld t2, 0(t2); bnez t2, .Lbv_receipts_accept\n" ++
+  -- CONSERVATIVE COMPLETENESS GATE: only enforce when the EIP-7708 top-level transfer log
+  -- (Part 2) is known to have fired correctly, i.e. the bmvmx compute completed (legacy
+  -- single-tx). For non-legacy (EIP-2930/1559/4844/7702) or multi-tx blocks the bmvmx path
+  -- stays conservative (BlockVerdict.lean:156) and Part 2 does not emit, so the materialized
+  -- receipt would be MISSING the top-level transfer log -> a confirmed-but-spurious
+  -- receipts-root mismatch. Skip enforcement there (accept) until Part 2 covers all tx types.
+  -- Follow-up: extend Part 2 (tx-type-agnostic sender/recipient/value) + this gate.
+  "  la t2, bmvmx_avail; ld t2, 0(t2); beqz t2, .Lbv_receipts_accept\n" ++
+  "  la a0, brr_control; la a1, bv_receipts_rlp; li a2, 65536; la a3, bv_receipts_rlp_len\n" ++
+  "  jal ra, receipt_records_encode_no_logs\n" ++
+  "  bnez a0, .Lbv_receipts_accept                # encode failed/unsupported -> conservative accept\n" ++
+  "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++
+  "  la a2, bv_receipts_rlp; la t0, bv_receipts_rlp_len; ld a3, 0(t0)\n" ++
+  "  jal ra, block_validate_receipts_consensus_list\n" ++
+  "  li t0, 2; beq a0, t0, .Lbv_receipts_root_mismatch\n" ++
+  "  li t0, 4; beq a0, t0, .Lbv_receipts_bloom_mismatch\n" ++
+  ".Lbv_receipts_accept:\n" ++
   "  li a0, 1; j .Lbv_ret\n" ++
   ".Lbv_receipts_no_runtime_gas:\n" ++
   "  la t2, bv_exec_p; ld a0, 0(t2)\n" ++
@@ -1282,6 +1308,10 @@ def blockVerdictFunction : String :=
   "  li t0, 50; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_notx_bloom_fail:\n" ++           -- .63.1.6.2.3: no-tx header.bloom != 256 zero bytes
   "  li t0, 51; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
+  ".Lbv_receipts_root_mismatch:\n" ++     -- .63.1.6.2.3 (slice B): tx-bearing header.receipts_root mismatch
+  "  li t0, 53; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
+  ".Lbv_receipts_bloom_mismatch:\n" ++    -- .63.1.6.2.3 (slice B): tx-bearing header.logs_bloom mismatch
+  "  li t0, 54; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_versioned_hashes_fail:\n" ++
   "  li t0, 27; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_withdrawals_root_fail:\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -225,6 +225,55 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bv_logs_rlp_arena:\n  .zero 65536\n" ++
   "bv_record_blooms:\n  .zero 4096\n" ++
   "bv_record_logs_desc:\n  .zero 512\n" ++
+  -- .63.1.6.2.3: encoded full-receipt RLP list (status||cumulative_gas||bloom||logs per
+  -- receipt) for block_validate_receipts_consensus_list. The encoder's internal payload
+  -- scratch caps at 32768; 64 KiB leaves margin for the list prefix + max receipts.
+  "bv_receipts_rlp:\n  .zero 65536\n" ++
+  "bv_receipts_rlp_len:\n  .zero 8\n" ++
+  -- .63.1.6.2.3: receipt_encode + receipt_records_encode_no_logs scratch (these labels were
+  -- probe-only in ziskReceiptRecordsEncodeNoLogsDataSection before the tx-bearing un-gate linked
+  -- the encoder into the guest). re_payload_buf (16K) / rle_payload_buf (32K) are the per-receipt
+  -- and list payload scratch; rle_empty_logs/rle_zero_bloom are the no-log receipt constants.
+  ".balign 8\n" ++
+  "rle_control:\n  .zero 24\n" ++
+  "rle_records:\n  .zero 1024\n" ++
+  "rle_field_len:\n  .zero 8\n" ++
+  "rle_prefix_len:\n  .zero 8\n" ++
+  "re_field_len:\n  .zero 8\n" ++
+  "re_cursor:\n  .zero 8\n" ++
+  "re_total_payload:\n  .zero 8\n" ++
+  ".balign 8\n" ++
+  "rle_empty_logs:\n  .byte 0xc0\n" ++
+  ".balign 8\n" ++
+  "rle_zero_bloom:\n  .zero 256\n" ++
+  ".balign 8\n" ++
+  "re_payload_buf:\n  .zero 16384\n" ++
+  ".balign 8\n" ++
+  "rle_payload_buf:\n  .zero 32768\n" ++
+  -- .63.1.6.2.3: block_validate_logs_bloom + block_logs_bloom_from_receipts_list scratch
+  -- (helb_offset/helb_length are already linked via header_extract_logs_bloom).
+  ".balign 8\n" ++
+  "relb_offset:\n  .zero 8\n" ++
+  "relb_length:\n  .zero 8\n" ++
+  "blbr_count:\n  .zero 8\n" ++
+  "blbr_offset:\n  .zero 8\n" ++
+  "blbr_length:\n  .zero 8\n" ++
+  ".balign 8\n" ++
+  "blbr_scratch_bloom:\n  .zero 256\n" ++
+  ".balign 8\n" ++
+  "bvlb_header_bloom:\n  .zero 256\n" ++
+  ".balign 8\n" ++
+  "bvlb_computed_bloom:\n  .zero 256\n" ++
+  -- .63.1.6.2.3: block_validate_receipts_consensus_list scratch (the indexed-trie/root and
+  -- logs-bloom sub-scratch are already linked above / via the no-tx receipts path).
+  ".balign 8\n" ++
+  "brcl_count:\n  .zero 8\n" ++
+  "brcl_offset:\n  .zero 8\n" ++
+  "brcl_length:\n  .zero 8\n" ++
+  "brcl_root_valid:\n  .zero 8\n" ++
+  "brcl_bloom_valid:\n  .zero 8\n" ++
+  ".balign 8\n" ++
+  "brcl_value_descs:\n  .zero 2048\n" ++
   -- scratch for log_records_encode_rlp (lrr_*) and the bloom accumulators
   -- (bav_/lba_/llba_ — zk3_state is already defined by the guest).
   logRecordsRlpDataSection ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
@@ -6,6 +6,11 @@
 -/
 
 import EvmAsm.Codegen.Programs.BlockVerdict
+-- .63.1.6.2.3 (slice B): full-receipt encoder + combined root+bloom validator
+import EvmAsm.Codegen.Programs.Receipt
+import EvmAsm.Codegen.Programs.ReceiptList
+import EvmAsm.Codegen.Programs.BloomBlock
+import EvmAsm.Codegen.Programs.ReceiptsConsensus
 import EvmAsm.Codegen.Programs.EvmBasic
 import EvmAsm.Codegen.Programs.EvmRegistry
 import EvmAsm.Codegen.Programs.RequestsHash
@@ -257,6 +262,21 @@ def statelessVerdictV2GuestClosure : String :=
   -- already linked for the transactions/withdrawals root checks).
   headerExtractReceiptsRootFunction ++ "\n" ++
   blockValidateReceiptsRootIndexedFunction ++ "\n" ++
+  -- .63.1.6.2.3 (slice B): tx-bearing enforcement needs the full-receipt encoder
+  -- (receipt_records_encode_no_logs + receipt_encode + rlp_encode_u64) and the combined
+  -- root+bloom validator (block_validate_receipts_consensus_list + block_validate_logs_bloom).
+  -- rlp_list_nth_item / rlp_list_count_items / rlp_encode_bytes / rlp_encode_list_prefix /
+  -- receipt_records are already linked.
+  rlpEncodeU64Function ++ "\n" ++
+  receiptEncodeFunction ++ "\n" ++
+  receiptRecordsEncodeNoLogsFunction ++ "\n" ++
+  blockValidateLogsBloomFunction ++ "\n" ++
+  -- block_validate_logs_bloom -> block_logs_bloom_from_receipts_list -> receipt_extract_logs_bloom
+  -- + bloom_or_into (the logs_list_bloom_add / bloom_add_value family is already linked).
+  receiptExtractLogsBloomFunction ++ "\n" ++
+  bloomOrIntoFunction ++ "\n" ++
+  blockLogsBloomFromReceiptsListFunction ++ "\n" ++
+  blockValidateReceiptsConsensusListFunction ++ "\n" ++
   headerExtractLogsBloomFunction ++ "\n" ++
   bloomEqFunction ++ "\n" ++
   blockVerdictFunction ++ "\n" ++


### PR DESCRIPTION
## Summary
Un-gates **tx-bearing receipts-consensus enforcement** — the receipts-root / logs-bloom validation keystone — now that the EIP-7708 transfer logs land (#8732 Part 1 CALL + #8735 Part 2 top-level, both merged).

Encode the materialized per-tx receipt records (status‖cumulative_gas‖bloom‖logs, with the `.2.1` log descriptors) via `receipt_records_encode_no_logs` into one RLP list, then validate `header.receipts_root == MPT(indexed(receipts))` **and** `header.logs_bloom == OR(receipt blooms)` via `block_validate_receipts_consensus_list`; reject (fail 53 root / 54 bloom) on a confirmed mismatch. Registers the encoder + combined validator (+ `receipt_encode` / `rlp_encode_u64` / `block_validate_logs_bloom` / `block_logs_bloom_from_receipts_list` / `receipt_extract_logs_bloom` / `bloom_or_into`) into the BlockVerdictV2 guest aggregation + their scratch buffers into the guest `.data`.

## Conservatism (no false-reject)
- Any materialize/encode/validator **helper failure** → conservative accept; only a *confirmed* root/bloom mismatch rejects.
- **Completeness gate**: enforce only when `bmvmx_avail==1` (legacy single-tx, where the Part 2 top-level transfer log fires correctly). Non-legacy (2930/1559/4844/7702) / multi-tx: the bmvmx path stays conservative and Part 2 doesn't emit, so the materialized logs may be incomplete → skip enforcement there. Extending Part 2 to all tx types + widening the gate is a tracked follow-up.

## Validation
- **eip7708 12/12 full match** with enforcement live — transfer-log byte-order + receipt materialization correct end-to-end via receipts_root+bloom.
- **20-row random EEST run: 20/20 full match, 0 errored** (operator-requested, in lieu of the full sweep), on the equivalent complete branch (this is the cherry-picked un-gate on current main; identical tree).
- The one initial false-reject (`simple_transfer_mainnet`, EIP-1559 top-level transfer) was root-caused to Part 2 not firing for non-legacy txs (tx0 log count=0) — the enforcement *correctly* caught the incomplete log; the `bmvmx_avail` gate resolves it soundly.

Bead: `evm-asm-fhsxz.2.4.2.63.1.6.2.6`. Follow-up: extend Part 2 to non-legacy/multi-tx + widen the gate.

Authored by @pirapira; implemented by Claude Code