### PR TITLE
fix(receipts): skip receipts enforcement for calldata-bearing txs (latent false-reject)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -1244,6 +1244,13 @@ def blockVerdictFunction : String :=
   -- receipts-root mismatch. Skip enforcement there (accept) until Part 2 covers all tx types.
   -- Follow-up: extend Part 2 (tx-type-agnostic sender/recipient/value) + this gate.
   "  la t2, bmvmx_avail; ld t2, 0(t2); beqz t2, .Lbv_receipts_accept\n" ++
+  -- .63.1.6.2.7.1: SKIP enforcement when the tx carries calldata. The materialized receipt's
+  -- cumulative_gas currently omits the intrinsic calldata cost (+ EIP-7623 floor) for the
+  -- single-tx EOA-transfer path (dumped 21000 exactly for a 1-byte-calldata transfer), so a
+  -- calldata-bearing tx would produce a wrong cumulative_gas -> spurious receipts-root mismatch
+  -- -> false-reject. Conservatively accept those until the cumulative_gas is fixed to include
+  -- intrinsic calldata. (No-calldata transfers: gas == 21000 is exact, so they stay enforced.)
+  "  la t2, bmvmx_ctx; ld t2, 64(t2); bnez t2, .Lbv_receipts_accept\n" ++
   "  la a0, brr_control; la a1, bv_receipts_rlp; li a2, 65536; la a3, bv_receipts_rlp_len\n" ++
   "  jal ra, receipt_records_encode_no_logs\n" ++
   "  bnez a0, .Lbv_receipts_accept                # encode failed/unsupported -> conservative accept\n" ++


### PR DESCRIPTION
## Summary
The tx-bearing receipts-consensus enforcement (#8736) has a **latent false-reject**: the materialized receipt's `cumulative_gas` omits the intrinsic calldata cost (+ EIP-7623 floor). Dumped **exactly `21000`** for `eip7708_eth_transfer_logs/eip_mainnet/simple_transfer_mainnet` (a 1-byte-calldata simple transfer), where the spec's `gas_used` is `21000 + calldata + floor`. So any **enforced legacy single-tx that carries calldata** would get a wrong `cumulative_gas` → spurious receipts-root mismatch → **false-reject (a P0 conformance bug)**. The #8736 spot-checks passed only because none of them enforced such a tx.

## Fix (conservative mitigation)
Skip enforcement (conservative accept) when the tx carries calldata (`bmvmx_ctx+64 != 0`). No-calldata transfers stay enforced (`gas==21000` is exact there). This **cannot introduce a false-reject** — it only narrows enforcement.

## Validation
- **20/20 random EEST full match, 0 errored** (the mitigation doesn't regress).
- `lake build`, `check-file-size`, `check-unimported` green.

## Follow-up
The proper fix — thread `bvgr_calldata_floor` + the intrinsic calldata into the per-tx receipt `cumulative_gas` — is tracked under `.63.1.6.2.7` (it also resolves the `.6.2.7` non-legacy 53, whose root cause is the same).

Bead: `evm-asm-fhsxz.2.4.2.63.1.6.2`.

Authored by @pirapira; implemented by Claude Code