### PR TITLE
feat(rlp): bridge long-form decoded length to the pure spec (Nat.fromBytesBE)

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -16,6 +16,26 @@ theorem Nat.toBytesBE_zero : Nat.toBytesBE 0 = [] := by
 theorem Nat.fromBytesBE_nil : Nat.fromBytesBE [] = 0 := by
   simp [Nat.fromBytesBE]
 
+/-- The big-endian decode of `bs` is bounded by `256 ^ bs.length`: each byte is
+    `< 256`, so an `n`-byte sequence decodes to a value `< 256 ^ n`. -/
+theorem Nat.fromBytesBE_lt (bs : List Byte) :
+    Nat.fromBytesBE bs < 256 ^ bs.length := by
+  induction bs with
+  | nil => simp [Nat.fromBytesBE]
+  | cons b bs ih =>
+    have hb : b.toNat < 256 := by have := b.isLt; omega
+    have e : Nat.fromBytesBE (b :: bs)
+        = b.toNat * 256 ^ bs.length + Nat.fromBytesBE bs := rfl
+    have hsucc : b.toNat * 256 ^ bs.length + 256 ^ bs.length
+        = (b.toNat + 1) * 256 ^ bs.length := (Nat.succ_mul _ _).symm
+    have hle : (b.toNat + 1) * 256 ^ bs.length ≤ 256 * 256 ^ bs.length :=
+      Nat.mul_le_mul (by omega) (Nat.le_refl _)
+    have hpow : 256 * 256 ^ bs.length = 256 ^ (b :: bs).length := by
+      rw [List.length_cons, Nat.pow_succ, Nat.mul_comm]
+    -- `ih : fromBytesBE bs < 256 ^ bs.length`, with the linear facts above,
+    -- omega chains: fromBytesBE (b::bs) < (b+1)·256^L ≤ 256·256^L = 256^(L+1).
+    omega
+
 /-! ## takeBytes properties -/
 
 /-- Taking 0 bytes always succeeds with an empty prefix and the original list. -/

--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -53,6 +53,9 @@ import EvmAsm.Rv64.RLP.Phase1E5LongListFive
 import EvmAsm.Rv64.RLP.Phase1E5LongListSix
 import EvmAsm.Rv64.RLP.Phase1E5LongListSeven
 import EvmAsm.Rv64.RLP.Phase1E5LongListEight
+import EvmAsm.Rv64.RLP.Phase2LongLengthBridge
+import EvmAsm.Rv64.RLP.Phase1E3LongStringFromBytesBE
+import EvmAsm.Rv64.RLP.Phase1E5LongListFromBytesBE
 import EvmAsm.Rv64.RLP.Phase1StepToPhase3LongString
 import EvmAsm.Rv64.RLP.Phase1ToPhase3SingleByte
 import EvmAsm.Rv64.RLP.Phase1StepToPhase3ShortString

--- a/EvmAsm/Rv64/RLP/Phase1E3LongStringFromBytesBE.lean
+++ b/EvmAsm/Rv64/RLP/Phase1E3LongStringFromBytesBE.lean
@@ -1,0 +1,475 @@
+/-
+  EvmAsm.Rv64.RLP.Phase1E3LongStringFromBytesBE
+
+  End-to-end spec-correctness restatements of the long byte-string (e3)
+  full paths: the decoder's output length register `x11` equals the value the
+  pure RLP spec decodes, `BitVec.ofNat 64 (Nat.fromBytesBE [e0, …, e_{N-1}])`,
+  where `ei = extractByte wordVal (byteOffset (ptr + i))`.
+
+  Each theorem wraps the corresponding `rlp_phase1_e3_0x…_…_byte_length_spec_within`
+  full path and rewrites the raw big-endian accumulation in `x11` to the
+  `Nat.fromBytesBE` form via the bridge lemmas in `Phase2LongLengthBridge.lean`.
+  Proof shape (per N ≥ 2): rewrite the *goal* backwards
+  (`← rlp_be_len_N`, `← …_post_unfold`) into the closure's `_post`, then close
+  with the underlying full path. The `lenLen = 1` path (`0xB8`) collapses the
+  accumulation to a single byte, so it uses `rlp_be_byte_eq_fromBytesBE`.
+-/
+
+import EvmAsm.Rv64.RLP.Phase1E3LongStringOne
+import EvmAsm.Rv64.RLP.Phase1E3LongStringTwo
+import EvmAsm.Rv64.RLP.Phase1E3LongStringThree
+import EvmAsm.Rv64.RLP.Phase1E3LongStringFour
+import EvmAsm.Rv64.RLP.Phase1E3LongStringFive
+import EvmAsm.Rv64.RLP.Phase1E3LongStringSix
+import EvmAsm.Rv64.RLP.Phase1E3LongStringSeven
+import EvmAsm.Rv64.RLP.Phase1E3LongStringEight
+import EvmAsm.Rv64.RLP.Phase2LongLengthBridge
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL.RLP
+
+/-- `0xB8` long string (`lenLen = 1`): `x11 = ofNat (fromBytesBE [e0])`. -/
+theorem rlp_phase1_e3_0xB8_one_byte_length_fromBytesBE_spec_within
+    (v10 v11Old v12Old v13 v14Old wordVal dwordAddr : Word)
+    (off1 off2 off3 back : BitVec 13)
+    (base e3_target : Word)
+    (htarget : (base + 16 + 4) + signExtend13 off3 = e3_target)
+    (halign : alignToDword (v13 + signExtend12 (1 : BitVec 12)) = dwordAddr)
+    (hvalid : isValidByteAccess (v13 + signExtend12 (1 : BitVec 12)) = true)
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          (rlp_phase1_step_code 0xC0 off3 (base + 16))))).Disjoint
+        (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))
+    (hd_loop :
+      ((((rlp_phase1_step_code 0x80 off1 base).union
+         ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+           (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+         (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))).Disjoint
+        (CodeReq.ofProg (e3_target + 12) (rlp_phase2_long_loop_body_prog back))) :
+    let ptr := v13 + signExtend12 (1 : BitVec 12)
+    let e0 := extractByte wordVal (byteOffset ptr)
+    cpsTripleWithin 15 base ((e3_target + 12) + 24)
+      (((((rlp_phase1_step_code 0x80 off1 base).union
+          ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+            (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+          (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))).union
+          (CodeReq.ofProg (e3_target + 12) (rlp_phase2_long_loop_body_prog back)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ (0xB8 : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ (0xB8 : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xC0 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE [e0])) **
+        (.x12 ↦ᵣ e0.zeroExtend 64) **
+        (.x13 ↦ᵣ ((v13 + signExtend12 (1 : BitVec 12)) + 1)) **
+        (.x14 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ wordVal)) := by
+  intro ptr e0
+  rw [← rlp_be_byte_eq_fromBytesBE e0]
+  exact rlp_phase1_e3_0xB8_one_byte_length_spec_within
+    v10 v11Old v12Old v13 v14Old wordVal dwordAddr off1 off2 off3 back base
+    e3_target htarget halign hvalid hd_phase3 hd_loop
+
+/-- `0xB9` long string (`lenLen = 2`): `x11 = ofNat (fromBytesBE [e0, e1])`. -/
+theorem rlp_phase1_e3_0xB9_two_byte_length_fromBytesBE_spec_within
+    (v10 v11Old v12Old v13 v14Old wordVal dwordAddr : Word)
+    (off1 off2 off3 back : BitVec 13)
+    (base e3_target : Word)
+    (htarget : (base + 16 + 4) + signExtend13 off3 = e3_target)
+    (halign1 : alignToDword (v13 + signExtend12 (1 : BitVec 12)) = dwordAddr)
+    (halign2 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 1) = dwordAddr)
+    (hvalid1 : isValidByteAccess (v13 + signExtend12 (1 : BitVec 12)) = true)
+    (hvalid2 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 1) = true)
+    (hback : ((e3_target + 12) + 20) + signExtend13 back = (e3_target + 12))
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          (rlp_phase1_step_code 0xC0 off3 (base + 16))))).Disjoint
+        (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))
+    (hd_loop :
+      ((((rlp_phase1_step_code 0x80 off1 base).union
+         ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+           (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+         (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))).Disjoint
+        (CodeReq.ofProg (e3_target + 12) (rlp_phase2_long_loop_body_prog back))) :
+    let ptr := v13 + signExtend12 (1 : BitVec 12)
+    let e0 := extractByte wordVal (byteOffset ptr)
+    let e1 := extractByte wordVal (byteOffset (ptr + 1))
+    cpsTripleWithin 21 base ((e3_target + 12) + 24)
+      (((((rlp_phase1_step_code 0x80 off1 base).union
+          ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+            (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+          (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))).union
+          (CodeReq.ofProg (e3_target + 12) (rlp_phase2_long_loop_body_prog back)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ (0xB9 : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x5 ↦ᵣ (0xB9 : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xC0 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE [e0, e1])) **
+        (.x13 ↦ᵣ (ptr + 2)) ** (.x14 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ e1.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (dwordAddr ↦ₘ wordVal)) := by
+  intro ptr e0 e1
+  rw [← rlp_be_len_2_eq_fromBytesBE e0 e1,
+      ← rlp_phase2_long_loop_two_byte_post_unfold]
+  exact rlp_phase1_e3_0xB9_two_byte_length_spec_within
+    v10 v11Old v12Old v13 v14Old wordVal dwordAddr off1 off2 off3 back base
+    e3_target htarget halign1 halign2 hvalid1 hvalid2 hback hd_phase3 hd_loop
+
+/-- `0xBA` long string (`lenLen = 3`). -/
+theorem rlp_phase1_e3_0xBA_three_byte_length_fromBytesBE_spec_within
+    (v10 v11Old v12Old v13 v14Old wordVal dwordAddr : Word)
+    (off1 off2 off3 back : BitVec 13)
+    (base e3_target : Word)
+    (htarget : (base + 16 + 4) + signExtend13 off3 = e3_target)
+    (halign1 : alignToDword (v13 + signExtend12 (1 : BitVec 12)) = dwordAddr)
+    (halign2 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 1) = dwordAddr)
+    (halign3 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 2) = dwordAddr)
+    (hvalid1 : isValidByteAccess (v13 + signExtend12 (1 : BitVec 12)) = true)
+    (hvalid2 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 1) = true)
+    (hvalid3 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 2) = true)
+    (hback : ((e3_target + 12) + 20) + signExtend13 back = (e3_target + 12))
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          (rlp_phase1_step_code 0xC0 off3 (base + 16))))).Disjoint
+        (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))
+    (hd_loop :
+      ((((rlp_phase1_step_code 0x80 off1 base).union
+         ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+           (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+         (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))).Disjoint
+        (CodeReq.ofProg (e3_target + 12) (rlp_phase2_long_loop_body_prog back))) :
+    let ptr := v13 + signExtend12 (1 : BitVec 12)
+    let e0 := extractByte wordVal (byteOffset ptr)
+    let e1 := extractByte wordVal (byteOffset (ptr + 1))
+    let e2 := extractByte wordVal (byteOffset (ptr + 2))
+    cpsTripleWithin 27 base ((e3_target + 12) + 24)
+      (((((rlp_phase1_step_code 0x80 off1 base).union
+          ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+            (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+          (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))).union
+          (CodeReq.ofProg (e3_target + 12) (rlp_phase2_long_loop_body_prog back)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ (0xBA : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x5 ↦ᵣ (0xBA : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xC0 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE [e0, e1, e2])) **
+        (.x13 ↦ᵣ (ptr + 3)) ** (.x14 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ e2.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (dwordAddr ↦ₘ wordVal)) := by
+  intro ptr e0 e1 e2
+  rw [← rlp_be_len_3_eq_fromBytesBE e0 e1 e2,
+      ← rlp_phase2_long_loop_three_byte_post_unfold]
+  exact rlp_phase1_e3_0xBA_three_byte_length_spec_within
+    v10 v11Old v12Old v13 v14Old wordVal dwordAddr off1 off2 off3 back base
+    e3_target htarget halign1 halign2 halign3 hvalid1 hvalid2 hvalid3 hback
+    hd_phase3 hd_loop
+
+/-- `0xBB` long string (`lenLen = 4`). -/
+theorem rlp_phase1_e3_0xBB_four_byte_length_fromBytesBE_spec_within
+    (v10 v11Old v12Old v13 v14Old wordVal dwordAddr : Word)
+    (off1 off2 off3 back : BitVec 13)
+    (base e3_target : Word)
+    (htarget : (base + 16 + 4) + signExtend13 off3 = e3_target)
+    (halign1 : alignToDword (v13 + signExtend12 (1 : BitVec 12)) = dwordAddr)
+    (halign2 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 1) = dwordAddr)
+    (halign3 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 2) = dwordAddr)
+    (halign4 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 3) = dwordAddr)
+    (hvalid1 : isValidByteAccess (v13 + signExtend12 (1 : BitVec 12)) = true)
+    (hvalid2 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 1) = true)
+    (hvalid3 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 2) = true)
+    (hvalid4 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 3) = true)
+    (hback : ((e3_target + 12) + 20) + signExtend13 back = (e3_target + 12))
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          (rlp_phase1_step_code 0xC0 off3 (base + 16))))).Disjoint
+        (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))
+    (hd_loop :
+      ((((rlp_phase1_step_code 0x80 off1 base).union
+         ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+           (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+         (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))).Disjoint
+        (CodeReq.ofProg (e3_target + 12) (rlp_phase2_long_loop_body_prog back))) :
+    let ptr := v13 + signExtend12 (1 : BitVec 12)
+    let e0 := extractByte wordVal (byteOffset ptr)
+    let e1 := extractByte wordVal (byteOffset (ptr + 1))
+    let e2 := extractByte wordVal (byteOffset (ptr + 2))
+    let e3 := extractByte wordVal (byteOffset (ptr + 3))
+    cpsTripleWithin 33 base ((e3_target + 12) + 24)
+      (((((rlp_phase1_step_code 0x80 off1 base).union
+          ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+            (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+          (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))).union
+          (CodeReq.ofProg (e3_target + 12) (rlp_phase2_long_loop_body_prog back)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ (0xBB : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x5 ↦ᵣ (0xBB : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xC0 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE [e0, e1, e2, e3])) **
+        (.x13 ↦ᵣ (ptr + 4)) ** (.x14 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ e3.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (dwordAddr ↦ₘ wordVal)) := by
+  intro ptr e0 e1 e2 e3
+  rw [← rlp_be_len_4_eq_fromBytesBE e0 e1 e2 e3,
+      ← rlp_phase2_long_loop_four_byte_post_unfold]
+  exact rlp_phase1_e3_0xBB_four_byte_length_spec_within
+    v10 v11Old v12Old v13 v14Old wordVal dwordAddr off1 off2 off3 back base
+    e3_target htarget halign1 halign2 halign3 halign4
+    hvalid1 hvalid2 hvalid3 hvalid4 hback hd_phase3 hd_loop
+
+/-- `0xBC` long string (`lenLen = 5`). -/
+theorem rlp_phase1_e3_0xBC_five_byte_length_fromBytesBE_spec_within
+    (v10 v11Old v12Old v13 v14Old wordVal dwordAddr : Word)
+    (off1 off2 off3 back : BitVec 13)
+    (base e3_target : Word)
+    (htarget : (base + 16 + 4) + signExtend13 off3 = e3_target)
+    (halign1 : alignToDword (v13 + signExtend12 (1 : BitVec 12)) = dwordAddr)
+    (halign2 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 1) = dwordAddr)
+    (halign3 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 2) = dwordAddr)
+    (halign4 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 3) = dwordAddr)
+    (halign5 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 4) = dwordAddr)
+    (hvalid1 : isValidByteAccess (v13 + signExtend12 (1 : BitVec 12)) = true)
+    (hvalid2 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 1) = true)
+    (hvalid3 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 2) = true)
+    (hvalid4 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 3) = true)
+    (hvalid5 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 4) = true)
+    (hback : ((e3_target + 12) + 20) + signExtend13 back = (e3_target + 12))
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          (rlp_phase1_step_code 0xC0 off3 (base + 16))))).Disjoint
+        (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))
+    (hd_loop :
+      ((((rlp_phase1_step_code 0x80 off1 base).union
+         ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+           (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+         (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))).Disjoint
+        (CodeReq.ofProg (e3_target + 12) (rlp_phase2_long_loop_body_prog back))) :
+    let ptr := v13 + signExtend12 (1 : BitVec 12)
+    let e0 := extractByte wordVal (byteOffset ptr)
+    let e1 := extractByte wordVal (byteOffset (ptr + 1))
+    let e2 := extractByte wordVal (byteOffset (ptr + 2))
+    let e3 := extractByte wordVal (byteOffset (ptr + 3))
+    let e4 := extractByte wordVal (byteOffset (ptr + 4))
+    cpsTripleWithin 39 base ((e3_target + 12) + 24)
+      (((((rlp_phase1_step_code 0x80 off1 base).union
+          ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+            (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+          (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))).union
+          (CodeReq.ofProg (e3_target + 12) (rlp_phase2_long_loop_body_prog back)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ (0xBC : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x5 ↦ᵣ (0xBC : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xC0 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE [e0, e1, e2, e3, e4])) **
+        (.x13 ↦ᵣ (ptr + 5)) ** (.x14 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ e4.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (dwordAddr ↦ₘ wordVal)) := by
+  intro ptr e0 e1 e2 e3 e4
+  rw [← rlp_be_len_5_eq_fromBytesBE e0 e1 e2 e3 e4,
+      ← rlp_phase2_long_loop_five_byte_post_unfold]
+  exact rlp_phase1_e3_0xBC_five_byte_length_spec_within
+    v10 v11Old v12Old v13 v14Old wordVal dwordAddr off1 off2 off3 back base
+    e3_target htarget halign1 halign2 halign3 halign4 halign5
+    hvalid1 hvalid2 hvalid3 hvalid4 hvalid5 hback hd_phase3 hd_loop
+
+/-- `0xBD` long string (`lenLen = 6`). -/
+theorem rlp_phase1_e3_0xBD_six_byte_length_fromBytesBE_spec_within
+    (v10 v11Old v12Old v13 v14Old wordVal dwordAddr : Word)
+    (off1 off2 off3 back : BitVec 13)
+    (base e3_target : Word)
+    (htarget : (base + 16 + 4) + signExtend13 off3 = e3_target)
+    (halign1 : alignToDword (v13 + signExtend12 (1 : BitVec 12)) = dwordAddr)
+    (halign2 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 1) = dwordAddr)
+    (halign3 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 2) = dwordAddr)
+    (halign4 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 3) = dwordAddr)
+    (halign5 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 4) = dwordAddr)
+    (halign6 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 5) = dwordAddr)
+    (hvalid1 : isValidByteAccess (v13 + signExtend12 (1 : BitVec 12)) = true)
+    (hvalid2 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 1) = true)
+    (hvalid3 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 2) = true)
+    (hvalid4 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 3) = true)
+    (hvalid5 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 4) = true)
+    (hvalid6 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 5) = true)
+    (hback : ((e3_target + 12) + 20) + signExtend13 back = (e3_target + 12))
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          (rlp_phase1_step_code 0xC0 off3 (base + 16))))).Disjoint
+        (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))
+    (hd_loop :
+      ((((rlp_phase1_step_code 0x80 off1 base).union
+         ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+           (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+         (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))).Disjoint
+        (CodeReq.ofProg (e3_target + 12) (rlp_phase2_long_loop_body_prog back))) :
+    let ptr := v13 + signExtend12 (1 : BitVec 12)
+    let e0 := extractByte wordVal (byteOffset ptr)
+    let e1 := extractByte wordVal (byteOffset (ptr + 1))
+    let e2 := extractByte wordVal (byteOffset (ptr + 2))
+    let e3 := extractByte wordVal (byteOffset (ptr + 3))
+    let e4 := extractByte wordVal (byteOffset (ptr + 4))
+    let e5 := extractByte wordVal (byteOffset (ptr + 5))
+    cpsTripleWithin 45 base ((e3_target + 12) + 24)
+      (((((rlp_phase1_step_code 0x80 off1 base).union
+          ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+            (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+          (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))).union
+          (CodeReq.ofProg (e3_target + 12) (rlp_phase2_long_loop_body_prog back)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ (0xBD : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x5 ↦ᵣ (0xBD : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xC0 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE [e0, e1, e2, e3, e4, e5])) **
+        (.x13 ↦ᵣ (ptr + 6)) ** (.x14 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ e5.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (dwordAddr ↦ₘ wordVal)) := by
+  intro ptr e0 e1 e2 e3 e4 e5
+  rw [← rlp_be_len_6_eq_fromBytesBE e0 e1 e2 e3 e4 e5,
+      ← rlp_phase2_long_loop_six_byte_post_unfold]
+  exact rlp_phase1_e3_0xBD_six_byte_length_spec_within
+    v10 v11Old v12Old v13 v14Old wordVal dwordAddr off1 off2 off3 back base
+    e3_target htarget halign1 halign2 halign3 halign4 halign5 halign6
+    hvalid1 hvalid2 hvalid3 hvalid4 hvalid5 hvalid6 hback hd_phase3 hd_loop
+
+/-- `0xBE` long string (`lenLen = 7`). -/
+theorem rlp_phase1_e3_0xBE_seven_byte_length_fromBytesBE_spec_within
+    (v10 v11Old v12Old v13 v14Old wordVal dwordAddr : Word)
+    (off1 off2 off3 back : BitVec 13)
+    (base e3_target : Word)
+    (htarget : (base + 16 + 4) + signExtend13 off3 = e3_target)
+    (halign1 : alignToDword (v13 + signExtend12 (1 : BitVec 12)) = dwordAddr)
+    (halign2 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 1) = dwordAddr)
+    (halign3 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 2) = dwordAddr)
+    (halign4 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 3) = dwordAddr)
+    (halign5 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 4) = dwordAddr)
+    (halign6 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 5) = dwordAddr)
+    (halign7 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 6) = dwordAddr)
+    (hvalid1 : isValidByteAccess (v13 + signExtend12 (1 : BitVec 12)) = true)
+    (hvalid2 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 1) = true)
+    (hvalid3 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 2) = true)
+    (hvalid4 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 3) = true)
+    (hvalid5 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 4) = true)
+    (hvalid6 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 5) = true)
+    (hvalid7 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 6) = true)
+    (hback : ((e3_target + 12) + 20) + signExtend13 back = (e3_target + 12))
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          (rlp_phase1_step_code 0xC0 off3 (base + 16))))).Disjoint
+        (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))
+    (hd_loop :
+      ((((rlp_phase1_step_code 0x80 off1 base).union
+         ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+           (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+         (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))).Disjoint
+        (CodeReq.ofProg (e3_target + 12) (rlp_phase2_long_loop_body_prog back))) :
+    let ptr := v13 + signExtend12 (1 : BitVec 12)
+    let e0 := extractByte wordVal (byteOffset ptr)
+    let e1 := extractByte wordVal (byteOffset (ptr + 1))
+    let e2 := extractByte wordVal (byteOffset (ptr + 2))
+    let e3 := extractByte wordVal (byteOffset (ptr + 3))
+    let e4 := extractByte wordVal (byteOffset (ptr + 4))
+    let e5 := extractByte wordVal (byteOffset (ptr + 5))
+    let e6 := extractByte wordVal (byteOffset (ptr + 6))
+    cpsTripleWithin 51 base ((e3_target + 12) + 24)
+      (((((rlp_phase1_step_code 0x80 off1 base).union
+          ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+            (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+          (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))).union
+          (CodeReq.ofProg (e3_target + 12) (rlp_phase2_long_loop_body_prog back)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ (0xBE : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x5 ↦ᵣ (0xBE : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xC0 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE [e0, e1, e2, e3, e4, e5, e6])) **
+        (.x13 ↦ᵣ (ptr + 7)) ** (.x14 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ e6.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (dwordAddr ↦ₘ wordVal)) := by
+  intro ptr e0 e1 e2 e3 e4 e5 e6
+  rw [← rlp_be_len_7_eq_fromBytesBE e0 e1 e2 e3 e4 e5 e6,
+      ← rlp_phase2_long_loop_seven_byte_post_unfold]
+  exact rlp_phase1_e3_0xBE_seven_byte_length_spec_within
+    v10 v11Old v12Old v13 v14Old wordVal dwordAddr off1 off2 off3 back base
+    e3_target htarget halign1 halign2 halign3 halign4 halign5 halign6 halign7
+    hvalid1 hvalid2 hvalid3 hvalid4 hvalid5 hvalid6 hvalid7 hback hd_phase3 hd_loop
+
+/-- `0xBF` long string (`lenLen = 8`, the maximum). -/
+theorem rlp_phase1_e3_0xBF_eight_byte_length_fromBytesBE_spec_within
+    (v10 v11Old v12Old v13 v14Old wordVal dwordAddr : Word)
+    (off1 off2 off3 back : BitVec 13)
+    (base e3_target : Word)
+    (htarget : (base + 16 + 4) + signExtend13 off3 = e3_target)
+    (halign1 : alignToDword (v13 + signExtend12 (1 : BitVec 12)) = dwordAddr)
+    (halign2 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 1) = dwordAddr)
+    (halign3 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 2) = dwordAddr)
+    (halign4 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 3) = dwordAddr)
+    (halign5 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 4) = dwordAddr)
+    (halign6 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 5) = dwordAddr)
+    (halign7 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 6) = dwordAddr)
+    (halign8 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 7) = dwordAddr)
+    (hvalid1 : isValidByteAccess (v13 + signExtend12 (1 : BitVec 12)) = true)
+    (hvalid2 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 1) = true)
+    (hvalid3 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 2) = true)
+    (hvalid4 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 3) = true)
+    (hvalid5 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 4) = true)
+    (hvalid6 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 5) = true)
+    (hvalid7 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 6) = true)
+    (hvalid8 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 7) = true)
+    (hback : ((e3_target + 12) + 20) + signExtend13 back = (e3_target + 12))
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          (rlp_phase1_step_code 0xC0 off3 (base + 16))))).Disjoint
+        (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))
+    (hd_loop :
+      ((((rlp_phase1_step_code 0x80 off1 base).union
+         ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+           (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+         (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))).Disjoint
+        (CodeReq.ofProg (e3_target + 12) (rlp_phase2_long_loop_body_prog back))) :
+    let ptr := v13 + signExtend12 (1 : BitVec 12)
+    let e0 := extractByte wordVal (byteOffset ptr)
+    let e1 := extractByte wordVal (byteOffset (ptr + 1))
+    let e2 := extractByte wordVal (byteOffset (ptr + 2))
+    let e3 := extractByte wordVal (byteOffset (ptr + 3))
+    let e4 := extractByte wordVal (byteOffset (ptr + 4))
+    let e5 := extractByte wordVal (byteOffset (ptr + 5))
+    let e6 := extractByte wordVal (byteOffset (ptr + 6))
+    let e7 := extractByte wordVal (byteOffset (ptr + 7))
+    cpsTripleWithin 57 base ((e3_target + 12) + 24)
+      (((((rlp_phase1_step_code 0x80 off1 base).union
+          ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+            (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+          (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))).union
+          (CodeReq.ofProg (e3_target + 12) (rlp_phase2_long_loop_body_prog back)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ (0xBF : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x5 ↦ᵣ (0xBF : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xC0 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64
+          (Nat.fromBytesBE [e0, e1, e2, e3, e4, e5, e6, e7])) **
+        (.x13 ↦ᵣ (ptr + 8)) ** (.x14 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ e7.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (dwordAddr ↦ₘ wordVal)) := by
+  intro ptr e0 e1 e2 e3 e4 e5 e6 e7
+  rw [← rlp_be_len_8_eq_fromBytesBE e0 e1 e2 e3 e4 e5 e6 e7,
+      ← rlp_phase2_long_loop_eight_byte_post_unfold]
+  exact rlp_phase1_e3_0xBF_eight_byte_length_spec_within
+    v10 v11Old v12Old v13 v14Old wordVal dwordAddr off1 off2 off3 back base
+    e3_target htarget halign1 halign2 halign3 halign4 halign5 halign6 halign7
+    halign8 hvalid1 hvalid2 hvalid3 hvalid4 hvalid5 hvalid6 hvalid7 hvalid8
+    hback hd_phase3 hd_loop
+
+end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Phase1E5LongListFromBytesBE.lean
+++ b/EvmAsm/Rv64/RLP/Phase1E5LongListFromBytesBE.lean
@@ -1,0 +1,490 @@
+/-
+  EvmAsm.Rv64.RLP.Phase1E5LongListFromBytesBE
+
+  End-to-end spec-correctness restatements of the long list (e5) full paths:
+  the decoder's output length register `x11` equals
+  `BitVec.ofNat 64 (Nat.fromBytesBE [e0, …, e_{N-1}])`, the value the pure RLP
+  spec decodes, where `ei = extractByte wordVal (byteOffset (ptr + i))`.
+
+  Each theorem wraps the corresponding e5 full path and rewrites the raw
+  big-endian accumulation in `x11` to the `Nat.fromBytesBE` form via
+  `Phase2LongLengthBridge.lean`. Proof shape: rewrite the *goal* backwards
+  (`← rlp_be_len_N`, `← …_post_unfold`) into the closure's `_post`, then close
+  with the underlying full path.
+-/
+
+import EvmAsm.Rv64.RLP.Phase1E5LongListOne
+import EvmAsm.Rv64.RLP.Phase1E5LongListTwo
+import EvmAsm.Rv64.RLP.Phase1E5LongListThree
+import EvmAsm.Rv64.RLP.Phase1E5LongListFour
+import EvmAsm.Rv64.RLP.Phase1E5LongListFive
+import EvmAsm.Rv64.RLP.Phase1E5LongListSix
+import EvmAsm.Rv64.RLP.Phase1E5LongListSeven
+import EvmAsm.Rv64.RLP.Phase1E5LongListEight
+import EvmAsm.Rv64.RLP.Phase2LongLengthBridge
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL.RLP
+
+/-- `0xF8` long list (`lenLen = 1`): `x11 = ofNat (fromBytesBE [e0])`. -/
+theorem rlp_phase1_e5_0xF8_one_byte_length_fromBytesBE_spec_within
+    (v10 v11Old v12Old v13 v14Old wordVal dwordAddr : Word)
+    (off1 off2 off3 off4 back : BitVec 13)
+    (base : Word)
+    (halign1 : alignToDword (v13 + signExtend12 (1 : BitVec 12)) = dwordAddr)
+    (hvalid1 : isValidByteAccess (v13 + signExtend12 (1 : BitVec 12)) = true)
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24)))))).Disjoint
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))
+    (hd_loop :
+      ((((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))).Disjoint
+        (CodeReq.ofProg (base + 44) (rlp_phase2_long_loop_body_prog back))) :
+    let ptr := v13 + signExtend12 (1 : BitVec 12)
+    let e0 := extractByte wordVal (byteOffset ptr)
+    cpsTripleWithin 17 base ((base + 44) + 24)
+      (((((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))).union
+        (CodeReq.ofProg (base + 44) (rlp_phase2_long_loop_body_prog back)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ (0xF8 : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x5 ↦ᵣ (0xF8 : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xF8 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE [e0])) **
+        (.x13 ↦ᵣ (ptr + 1)) ** (.x14 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ e0.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (dwordAddr ↦ₘ wordVal)) := by
+  intro ptr e0
+  rw [← rlp_be_len_1_eq_fromBytesBE e0,
+      ← rlp_phase2_long_loop_one_byte_post_unfold]
+  exact rlp_phase1_e5_0xF8_one_byte_length_spec_within
+    v10 v11Old v12Old v13 v14Old wordVal dwordAddr off1 off2 off3 off4 back base
+    halign1 hvalid1 hd_phase3 hd_loop
+
+/-- `0xF9` long list (`lenLen = 2`). -/
+theorem rlp_phase1_e5_0xF9_two_byte_length_fromBytesBE_spec_within
+    (v10 v11Old v12Old v13 v14Old wordVal dwordAddr : Word)
+    (off1 off2 off3 off4 back : BitVec 13)
+    (base : Word)
+    (halign1 : alignToDword (v13 + signExtend12 (1 : BitVec 12)) = dwordAddr)
+    (halign2 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 1) = dwordAddr)
+    (hvalid1 : isValidByteAccess (v13 + signExtend12 (1 : BitVec 12)) = true)
+    (hvalid2 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 1) = true)
+    (hback : ((base + 44) + 20) + signExtend13 back = (base + 44))
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24)))))).Disjoint
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))
+    (hd_loop :
+      ((((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))).Disjoint
+        (CodeReq.ofProg (base + 44) (rlp_phase2_long_loop_body_prog back))) :
+    let ptr := v13 + signExtend12 (1 : BitVec 12)
+    let e0 := extractByte wordVal (byteOffset ptr)
+    let e1 := extractByte wordVal (byteOffset (ptr + 1))
+    cpsTripleWithin 23 base ((base + 44) + 24)
+      (((((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))).union
+        (CodeReq.ofProg (base + 44) (rlp_phase2_long_loop_body_prog back)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ (0xF9 : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x5 ↦ᵣ (0xF9 : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xF8 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE [e0, e1])) **
+        (.x13 ↦ᵣ (ptr + 2)) ** (.x14 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ e1.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (dwordAddr ↦ₘ wordVal)) := by
+  intro ptr e0 e1
+  rw [← rlp_be_len_2_eq_fromBytesBE e0 e1,
+      ← rlp_phase2_long_loop_two_byte_post_unfold]
+  exact rlp_phase1_e5_0xF9_two_byte_length_spec_within
+    v10 v11Old v12Old v13 v14Old wordVal dwordAddr off1 off2 off3 off4 back base
+    halign1 halign2 hvalid1 hvalid2 hback hd_phase3 hd_loop
+
+/-- `0xFA` long list (`lenLen = 3`). -/
+theorem rlp_phase1_e5_0xFA_three_byte_length_fromBytesBE_spec_within
+    (v10 v11Old v12Old v13 v14Old wordVal dwordAddr : Word)
+    (off1 off2 off3 off4 back : BitVec 13)
+    (base : Word)
+    (halign1 : alignToDword (v13 + signExtend12 (1 : BitVec 12)) = dwordAddr)
+    (halign2 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 1) = dwordAddr)
+    (halign3 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 2) = dwordAddr)
+    (hvalid1 : isValidByteAccess (v13 + signExtend12 (1 : BitVec 12)) = true)
+    (hvalid2 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 1) = true)
+    (hvalid3 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 2) = true)
+    (hback : ((base + 44) + 20) + signExtend13 back = (base + 44))
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24)))))).Disjoint
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))
+    (hd_loop :
+      ((((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))).Disjoint
+        (CodeReq.ofProg (base + 44) (rlp_phase2_long_loop_body_prog back))) :
+    let ptr := v13 + signExtend12 (1 : BitVec 12)
+    let e0 := extractByte wordVal (byteOffset ptr)
+    let e1 := extractByte wordVal (byteOffset (ptr + 1))
+    let e2 := extractByte wordVal (byteOffset (ptr + 2))
+    cpsTripleWithin 29 base ((base + 44) + 24)
+      (((((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))).union
+        (CodeReq.ofProg (base + 44) (rlp_phase2_long_loop_body_prog back)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ (0xFA : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x5 ↦ᵣ (0xFA : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xF8 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE [e0, e1, e2])) **
+        (.x13 ↦ᵣ (ptr + 3)) ** (.x14 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ e2.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (dwordAddr ↦ₘ wordVal)) := by
+  intro ptr e0 e1 e2
+  rw [← rlp_be_len_3_eq_fromBytesBE e0 e1 e2,
+      ← rlp_phase2_long_loop_three_byte_post_unfold]
+  exact rlp_phase1_e5_0xFA_three_byte_length_spec_within
+    v10 v11Old v12Old v13 v14Old wordVal dwordAddr off1 off2 off3 off4 back base
+    halign1 halign2 halign3 hvalid1 hvalid2 hvalid3 hback hd_phase3 hd_loop
+
+/-- `0xFB` long list (`lenLen = 4`). -/
+theorem rlp_phase1_e5_0xFB_four_byte_length_fromBytesBE_spec_within
+    (v10 v11Old v12Old v13 v14Old wordVal dwordAddr : Word)
+    (off1 off2 off3 off4 back : BitVec 13)
+    (base : Word)
+    (halign1 : alignToDword (v13 + signExtend12 (1 : BitVec 12)) = dwordAddr)
+    (halign2 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 1) = dwordAddr)
+    (halign3 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 2) = dwordAddr)
+    (halign4 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 3) = dwordAddr)
+    (hvalid1 : isValidByteAccess (v13 + signExtend12 (1 : BitVec 12)) = true)
+    (hvalid2 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 1) = true)
+    (hvalid3 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 2) = true)
+    (hvalid4 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 3) = true)
+    (hback : ((base + 44) + 20) + signExtend13 back = (base + 44))
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24)))))).Disjoint
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))
+    (hd_loop :
+      ((((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))).Disjoint
+        (CodeReq.ofProg (base + 44) (rlp_phase2_long_loop_body_prog back))) :
+    let ptr := v13 + signExtend12 (1 : BitVec 12)
+    let e0 := extractByte wordVal (byteOffset ptr)
+    let e1 := extractByte wordVal (byteOffset (ptr + 1))
+    let e2 := extractByte wordVal (byteOffset (ptr + 2))
+    let e3 := extractByte wordVal (byteOffset (ptr + 3))
+    cpsTripleWithin 35 base ((base + 44) + 24)
+      (((((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))).union
+        (CodeReq.ofProg (base + 44) (rlp_phase2_long_loop_body_prog back)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ (0xFB : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x5 ↦ᵣ (0xFB : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xF8 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE [e0, e1, e2, e3])) **
+        (.x13 ↦ᵣ (ptr + 4)) ** (.x14 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ e3.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (dwordAddr ↦ₘ wordVal)) := by
+  intro ptr e0 e1 e2 e3
+  rw [← rlp_be_len_4_eq_fromBytesBE e0 e1 e2 e3,
+      ← rlp_phase2_long_loop_four_byte_post_unfold]
+  exact rlp_phase1_e5_0xFB_four_byte_length_spec_within
+    v10 v11Old v12Old v13 v14Old wordVal dwordAddr off1 off2 off3 off4 back base
+    halign1 halign2 halign3 halign4 hvalid1 hvalid2 hvalid3 hvalid4 hback
+    hd_phase3 hd_loop
+
+/-- `0xFC` long list (`lenLen = 5`). -/
+theorem rlp_phase1_e5_0xFC_five_byte_length_fromBytesBE_spec_within
+    (v10 v11Old v12Old v13 v14Old wordVal dwordAddr : Word)
+    (off1 off2 off3 off4 back : BitVec 13)
+    (base : Word)
+    (halign1 : alignToDword (v13 + signExtend12 (1 : BitVec 12)) = dwordAddr)
+    (halign2 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 1) = dwordAddr)
+    (halign3 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 2) = dwordAddr)
+    (halign4 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 3) = dwordAddr)
+    (halign5 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 4) = dwordAddr)
+    (hvalid1 : isValidByteAccess (v13 + signExtend12 (1 : BitVec 12)) = true)
+    (hvalid2 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 1) = true)
+    (hvalid3 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 2) = true)
+    (hvalid4 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 3) = true)
+    (hvalid5 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 4) = true)
+    (hback : ((base + 44) + 20) + signExtend13 back = (base + 44))
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24)))))).Disjoint
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))
+    (hd_loop :
+      ((((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))).Disjoint
+        (CodeReq.ofProg (base + 44) (rlp_phase2_long_loop_body_prog back))) :
+    let ptr := v13 + signExtend12 (1 : BitVec 12)
+    let e0 := extractByte wordVal (byteOffset ptr)
+    let e1 := extractByte wordVal (byteOffset (ptr + 1))
+    let e2 := extractByte wordVal (byteOffset (ptr + 2))
+    let e3 := extractByte wordVal (byteOffset (ptr + 3))
+    let e4 := extractByte wordVal (byteOffset (ptr + 4))
+    cpsTripleWithin 41 base ((base + 44) + 24)
+      (((((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))).union
+        (CodeReq.ofProg (base + 44) (rlp_phase2_long_loop_body_prog back)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ (0xFC : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x5 ↦ᵣ (0xFC : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xF8 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE [e0, e1, e2, e3, e4])) **
+        (.x13 ↦ᵣ (ptr + 5)) ** (.x14 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ e4.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (dwordAddr ↦ₘ wordVal)) := by
+  intro ptr e0 e1 e2 e3 e4
+  rw [← rlp_be_len_5_eq_fromBytesBE e0 e1 e2 e3 e4,
+      ← rlp_phase2_long_loop_five_byte_post_unfold]
+  exact rlp_phase1_e5_0xFC_five_byte_length_spec_within
+    v10 v11Old v12Old v13 v14Old wordVal dwordAddr off1 off2 off3 off4 back base
+    halign1 halign2 halign3 halign4 halign5
+    hvalid1 hvalid2 hvalid3 hvalid4 hvalid5 hback hd_phase3 hd_loop
+
+/-- `0xFD` long list (`lenLen = 6`). -/
+theorem rlp_phase1_e5_0xFD_six_byte_length_fromBytesBE_spec_within
+    (v10 v11Old v12Old v13 v14Old wordVal dwordAddr : Word)
+    (off1 off2 off3 off4 back : BitVec 13)
+    (base : Word)
+    (halign1 : alignToDword (v13 + signExtend12 (1 : BitVec 12)) = dwordAddr)
+    (halign2 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 1) = dwordAddr)
+    (halign3 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 2) = dwordAddr)
+    (halign4 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 3) = dwordAddr)
+    (halign5 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 4) = dwordAddr)
+    (halign6 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 5) = dwordAddr)
+    (hvalid1 : isValidByteAccess (v13 + signExtend12 (1 : BitVec 12)) = true)
+    (hvalid2 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 1) = true)
+    (hvalid3 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 2) = true)
+    (hvalid4 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 3) = true)
+    (hvalid5 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 4) = true)
+    (hvalid6 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 5) = true)
+    (hback : ((base + 44) + 20) + signExtend13 back = (base + 44))
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24)))))).Disjoint
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))
+    (hd_loop :
+      ((((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))).Disjoint
+        (CodeReq.ofProg (base + 44) (rlp_phase2_long_loop_body_prog back))) :
+    let ptr := v13 + signExtend12 (1 : BitVec 12)
+    let e0 := extractByte wordVal (byteOffset ptr)
+    let e1 := extractByte wordVal (byteOffset (ptr + 1))
+    let e2 := extractByte wordVal (byteOffset (ptr + 2))
+    let e3 := extractByte wordVal (byteOffset (ptr + 3))
+    let e4 := extractByte wordVal (byteOffset (ptr + 4))
+    let e5 := extractByte wordVal (byteOffset (ptr + 5))
+    cpsTripleWithin 47 base ((base + 44) + 24)
+      (((((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))).union
+        (CodeReq.ofProg (base + 44) (rlp_phase2_long_loop_body_prog back)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ (0xFD : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x5 ↦ᵣ (0xFD : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xF8 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE [e0, e1, e2, e3, e4, e5])) **
+        (.x13 ↦ᵣ (ptr + 6)) ** (.x14 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ e5.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (dwordAddr ↦ₘ wordVal)) := by
+  intro ptr e0 e1 e2 e3 e4 e5
+  rw [← rlp_be_len_6_eq_fromBytesBE e0 e1 e2 e3 e4 e5,
+      ← rlp_phase2_long_loop_six_byte_post_unfold]
+  exact rlp_phase1_e5_0xFD_six_byte_length_spec_within
+    v10 v11Old v12Old v13 v14Old wordVal dwordAddr off1 off2 off3 off4 back base
+    halign1 halign2 halign3 halign4 halign5 halign6
+    hvalid1 hvalid2 hvalid3 hvalid4 hvalid5 hvalid6 hback hd_phase3 hd_loop
+
+/-- `0xFE` long list (`lenLen = 7`). -/
+theorem rlp_phase1_e5_0xFE_seven_byte_length_fromBytesBE_spec_within
+    (v10 v11Old v12Old v13 v14Old wordVal dwordAddr : Word)
+    (off1 off2 off3 off4 back : BitVec 13)
+    (base : Word)
+    (halign1 : alignToDword (v13 + signExtend12 (1 : BitVec 12)) = dwordAddr)
+    (halign2 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 1) = dwordAddr)
+    (halign3 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 2) = dwordAddr)
+    (halign4 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 3) = dwordAddr)
+    (halign5 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 4) = dwordAddr)
+    (halign6 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 5) = dwordAddr)
+    (halign7 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 6) = dwordAddr)
+    (hvalid1 : isValidByteAccess (v13 + signExtend12 (1 : BitVec 12)) = true)
+    (hvalid2 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 1) = true)
+    (hvalid3 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 2) = true)
+    (hvalid4 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 3) = true)
+    (hvalid5 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 4) = true)
+    (hvalid6 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 5) = true)
+    (hvalid7 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 6) = true)
+    (hback : ((base + 44) + 20) + signExtend13 back = (base + 44))
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24)))))).Disjoint
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))
+    (hd_loop :
+      ((((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))).Disjoint
+        (CodeReq.ofProg (base + 44) (rlp_phase2_long_loop_body_prog back))) :
+    let ptr := v13 + signExtend12 (1 : BitVec 12)
+    let e0 := extractByte wordVal (byteOffset ptr)
+    let e1 := extractByte wordVal (byteOffset (ptr + 1))
+    let e2 := extractByte wordVal (byteOffset (ptr + 2))
+    let e3 := extractByte wordVal (byteOffset (ptr + 3))
+    let e4 := extractByte wordVal (byteOffset (ptr + 4))
+    let e5 := extractByte wordVal (byteOffset (ptr + 5))
+    let e6 := extractByte wordVal (byteOffset (ptr + 6))
+    cpsTripleWithin 53 base ((base + 44) + 24)
+      (((((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))).union
+        (CodeReq.ofProg (base + 44) (rlp_phase2_long_loop_body_prog back)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ (0xFE : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x5 ↦ᵣ (0xFE : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xF8 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64
+          (Nat.fromBytesBE [e0, e1, e2, e3, e4, e5, e6])) **
+        (.x13 ↦ᵣ (ptr + 7)) ** (.x14 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ e6.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (dwordAddr ↦ₘ wordVal)) := by
+  intro ptr e0 e1 e2 e3 e4 e5 e6
+  rw [← rlp_be_len_7_eq_fromBytesBE e0 e1 e2 e3 e4 e5 e6,
+      ← rlp_phase2_long_loop_seven_byte_post_unfold]
+  exact rlp_phase1_e5_0xFE_seven_byte_length_spec_within
+    v10 v11Old v12Old v13 v14Old wordVal dwordAddr off1 off2 off3 off4 back base
+    halign1 halign2 halign3 halign4 halign5 halign6 halign7
+    hvalid1 hvalid2 hvalid3 hvalid4 hvalid5 hvalid6 hvalid7 hback hd_phase3 hd_loop
+
+/-- `0xFF` long list (`lenLen = 8`, the maximum). -/
+theorem rlp_phase1_e5_0xFF_eight_byte_length_fromBytesBE_spec_within
+    (v10 v11Old v12Old v13 v14Old wordVal dwordAddr : Word)
+    (off1 off2 off3 off4 back : BitVec 13)
+    (base : Word)
+    (halign1 : alignToDword (v13 + signExtend12 (1 : BitVec 12)) = dwordAddr)
+    (halign2 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 1) = dwordAddr)
+    (halign3 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 2) = dwordAddr)
+    (halign4 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 3) = dwordAddr)
+    (halign5 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 4) = dwordAddr)
+    (halign6 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 5) = dwordAddr)
+    (halign7 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 6) = dwordAddr)
+    (halign8 : alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + 7) = dwordAddr)
+    (hvalid1 : isValidByteAccess (v13 + signExtend12 (1 : BitVec 12)) = true)
+    (hvalid2 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 1) = true)
+    (hvalid3 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 2) = true)
+    (hvalid4 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 3) = true)
+    (hvalid5 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 4) = true)
+    (hvalid6 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 5) = true)
+    (hvalid7 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 6) = true)
+    (hvalid8 : isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + 7) = true)
+    (hback : ((base + 44) + 20) + signExtend13 back = (base + 44))
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24)))))).Disjoint
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))
+    (hd_loop :
+      ((((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))).Disjoint
+        (CodeReq.ofProg (base + 44) (rlp_phase2_long_loop_body_prog back))) :
+    let ptr := v13 + signExtend12 (1 : BitVec 12)
+    let e0 := extractByte wordVal (byteOffset ptr)
+    let e1 := extractByte wordVal (byteOffset (ptr + 1))
+    let e2 := extractByte wordVal (byteOffset (ptr + 2))
+    let e3 := extractByte wordVal (byteOffset (ptr + 3))
+    let e4 := extractByte wordVal (byteOffset (ptr + 4))
+    let e5 := extractByte wordVal (byteOffset (ptr + 5))
+    let e6 := extractByte wordVal (byteOffset (ptr + 6))
+    let e7 := extractByte wordVal (byteOffset (ptr + 7))
+    cpsTripleWithin 59 base ((base + 44) + 24)
+      (((((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))).union
+        (CodeReq.ofProg (base + 44) (rlp_phase2_long_loop_body_prog back)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ (0xFF : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x5 ↦ᵣ (0xFF : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xF8 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64
+          (Nat.fromBytesBE [e0, e1, e2, e3, e4, e5, e6, e7])) **
+        (.x13 ↦ᵣ (ptr + 8)) ** (.x14 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ e7.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (dwordAddr ↦ₘ wordVal)) := by
+  intro ptr e0 e1 e2 e3 e4 e5 e6 e7
+  rw [← rlp_be_len_8_eq_fromBytesBE e0 e1 e2 e3 e4 e5 e6 e7,
+      ← rlp_phase2_long_loop_eight_byte_post_unfold]
+  exact rlp_phase1_e5_0xFF_eight_byte_length_spec_within
+    v10 v11Old v12Old v13 v14Old wordVal dwordAddr off1 off2 off3 off4 back base
+    halign1 halign2 halign3 halign4 halign5 halign6 halign7 halign8
+    hvalid1 hvalid2 hvalid3 hvalid4 hvalid5 hvalid6 hvalid7 hvalid8 hback
+    hd_phase3 hd_loop
+
+end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Phase2LongLengthBridge.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLengthBridge.lean
@@ -35,7 +35,7 @@ theorem rlp_be_byte_eq_fromBytesBE (e0 : Byte) :
     e0.zeroExtend 64 = BitVec.ofNat 64 (Nat.fromBytesBE [e0]) := by
   apply BitVec.eq_of_toNat_eq
   simp only [BitVec.toNat_setWidth, BitVec.toNat_ofNat, Nat.fromBytesBE,
-             List.length_cons, List.length_nil]
+             List.length_nil]
   have h0 := e0.isLt
   omega
 
@@ -49,7 +49,7 @@ theorem rlp_be_len_1_eq_fromBytesBE (e0 : Byte) :
   apply BitVec.eq_of_toNat_eq
   simp only [BitVec.toNat_add, BitVec.toNat_shiftLeft, BitVec.toNat_setWidth,
              BitVec.toNat_ofNat, Nat.shiftLeft_eq, Nat.fromBytesBE,
-             List.length_cons, List.length_nil]
+             List.length_nil]
   have hz : BitVec.toNat (0 : Word) = 0 := rfl
   have h0 := e0.isLt
   omega

--- a/EvmAsm/Rv64/RLP/Phase2LongLengthBridge.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLengthBridge.lean
@@ -1,0 +1,153 @@
+/-
+  EvmAsm.Rv64.RLP.Phase2LongLengthBridge
+
+  Semantic bridge for the RLP long-form length loop: the big-endian shift-add
+  accumulation that the Phase 2 loop closures leave in `x11` equals the value
+  the **pure** RLP spec decodes via `Nat.fromBytesBE`.
+
+  For length-of-length `N ∈ {1..8}`, the closure
+  `rlp_phase2_long_loop_{N}_byte_post` (with `len = 0`) sets `x11` to
+  `(((0 <<< 8) + b1) <<< 8 + b2) … + bN`, where each `bi = ei.zeroExtend 64`
+  is a zero-extended byte (`ei.toNat < 256`). Since `N ≤ 8`, the decoded value
+  is `< 256 ^ 8 = 2 ^ 64`, so there is no 64-bit overflow and the accumulation
+  equals `BitVec.ofNat 64 (Nat.fromBytesBE [e0, …, e_{N-1}])`.
+
+  These per-`N` equalities are consumed by the `…_fromBytesBE` full-path
+  restatements (`Phase1E3LongStringFromBytesBE.lean` /
+  `Phase1E5LongListFromBytesBE.lean`) to express the decoder's end-to-end
+  output length in spec terms. Each LHS is transcribed to match the
+  corresponding `rlp_phase2_long_loop_{N}_byte_post` `length'` exactly, so the
+  downstream rewrites fire.
+-/
+
+import EvmAsm.Rv64.RLP.Phase2LongLoopEight
+import EvmAsm.EL.RLP.Properties
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL.RLP
+
+/-- A single zero-extended byte already *is* its own big-endian decode:
+    `Nat.fromBytesBE [e0] = e0.toNat`. Used for the `lenLen = 1` long-string
+    path (`0xB8`), whose closure collapses `(0 <<< 8) + e0` to `e0`. -/
+theorem rlp_be_byte_eq_fromBytesBE (e0 : Byte) :
+    e0.zeroExtend 64 = BitVec.ofNat 64 (Nat.fromBytesBE [e0]) := by
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_setWidth, BitVec.toNat_ofNat, Nat.fromBytesBE,
+             List.length_cons, List.length_nil]
+  have h0 := e0.isLt
+  omega
+
+/-- Shared simp set + closing `omega` for the long-form length bridge: push
+    `toNat` through the shift-add chain, unfold `Nat.fromBytesBE` over the
+    concrete byte list, and discharge the (literal-modulus, byte-bounded)
+    arithmetic. -/
+theorem rlp_be_len_1_eq_fromBytesBE (e0 : Byte) :
+    ((0 : Word) <<< 8) + e0.zeroExtend 64
+      = BitVec.ofNat 64 (Nat.fromBytesBE [e0]) := by
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_add, BitVec.toNat_shiftLeft, BitVec.toNat_setWidth,
+             BitVec.toNat_ofNat, Nat.shiftLeft_eq, Nat.fromBytesBE,
+             List.length_cons, List.length_nil]
+  have hz : BitVec.toNat (0 : Word) = 0 := rfl
+  have h0 := e0.isLt
+  omega
+
+theorem rlp_be_len_2_eq_fromBytesBE (e0 e1 : Byte) :
+    (((0 : Word) <<< 8) + e0.zeroExtend 64) <<< 8 + e1.zeroExtend 64
+      = BitVec.ofNat 64 (Nat.fromBytesBE [e0, e1]) := by
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_add, BitVec.toNat_shiftLeft, BitVec.toNat_setWidth,
+             BitVec.toNat_ofNat, Nat.shiftLeft_eq, Nat.fromBytesBE,
+             List.length_cons, List.length_nil]
+  have hz : BitVec.toNat (0 : Word) = 0 := rfl
+  have h0 := e0.isLt; have h1 := e1.isLt
+  omega
+
+theorem rlp_be_len_3_eq_fromBytesBE (e0 e1 e2 : Byte) :
+    ((((0 : Word) <<< 8) + e0.zeroExtend 64) <<< 8 + e1.zeroExtend 64) <<< 8
+        + e2.zeroExtend 64
+      = BitVec.ofNat 64 (Nat.fromBytesBE [e0, e1, e2]) := by
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_add, BitVec.toNat_shiftLeft, BitVec.toNat_setWidth,
+             BitVec.toNat_ofNat, Nat.shiftLeft_eq, Nat.fromBytesBE,
+             List.length_cons, List.length_nil]
+  have hz : BitVec.toNat (0 : Word) = 0 := rfl
+  have h0 := e0.isLt; have h1 := e1.isLt; have h2 := e2.isLt
+  omega
+
+theorem rlp_be_len_4_eq_fromBytesBE (e0 e1 e2 e3 : Byte) :
+    (((((0 : Word) <<< 8) + e0.zeroExtend 64) <<< 8 + e1.zeroExtend 64) <<< 8
+        + e2.zeroExtend 64) <<< 8 + e3.zeroExtend 64
+      = BitVec.ofNat 64 (Nat.fromBytesBE [e0, e1, e2, e3]) := by
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_add, BitVec.toNat_shiftLeft, BitVec.toNat_setWidth,
+             BitVec.toNat_ofNat, Nat.shiftLeft_eq, Nat.fromBytesBE,
+             List.length_cons, List.length_nil]
+  have hz : BitVec.toNat (0 : Word) = 0 := rfl
+  have h0 := e0.isLt; have h1 := e1.isLt; have h2 := e2.isLt; have h3 := e3.isLt
+  omega
+
+theorem rlp_be_len_5_eq_fromBytesBE (e0 e1 e2 e3 e4 : Byte) :
+    ((((((0 : Word) <<< 8) + e0.zeroExtend 64) <<< 8 + e1.zeroExtend 64) <<< 8
+        + e2.zeroExtend 64) <<< 8 + e3.zeroExtend 64) <<< 8 + e4.zeroExtend 64
+      = BitVec.ofNat 64 (Nat.fromBytesBE [e0, e1, e2, e3, e4]) := by
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_add, BitVec.toNat_shiftLeft, BitVec.toNat_setWidth,
+             BitVec.toNat_ofNat, Nat.shiftLeft_eq, Nat.fromBytesBE,
+             List.length_cons, List.length_nil]
+  have hz : BitVec.toNat (0 : Word) = 0 := rfl
+  have h0 := e0.isLt; have h1 := e1.isLt; have h2 := e2.isLt; have h3 := e3.isLt
+  have h4 := e4.isLt
+  omega
+
+theorem rlp_be_len_6_eq_fromBytesBE (e0 e1 e2 e3 e4 e5 : Byte) :
+    (((((((0 : Word) <<< 8) + e0.zeroExtend 64) <<< 8 + e1.zeroExtend 64) <<< 8
+        + e2.zeroExtend 64) <<< 8 + e3.zeroExtend 64) <<< 8 + e4.zeroExtend 64) <<< 8
+        + e5.zeroExtend 64
+      = BitVec.ofNat 64 (Nat.fromBytesBE [e0, e1, e2, e3, e4, e5]) := by
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_add, BitVec.toNat_shiftLeft, BitVec.toNat_setWidth,
+             BitVec.toNat_ofNat, Nat.shiftLeft_eq, Nat.fromBytesBE,
+             List.length_cons, List.length_nil]
+  have hz : BitVec.toNat (0 : Word) = 0 := rfl
+  have h0 := e0.isLt; have h1 := e1.isLt; have h2 := e2.isLt; have h3 := e3.isLt
+  have h4 := e4.isLt; have h5 := e5.isLt
+  omega
+
+theorem rlp_be_len_7_eq_fromBytesBE (e0 e1 e2 e3 e4 e5 e6 : Byte) :
+    ((((((((0 : Word) <<< 8) + e0.zeroExtend 64) <<< 8 + e1.zeroExtend 64) <<< 8
+        + e2.zeroExtend 64) <<< 8 + e3.zeroExtend 64) <<< 8 + e4.zeroExtend 64) <<< 8
+        + e5.zeroExtend 64) <<< 8 + e6.zeroExtend 64
+      = BitVec.ofNat 64 (Nat.fromBytesBE [e0, e1, e2, e3, e4, e5, e6]) := by
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_add, BitVec.toNat_shiftLeft, BitVec.toNat_setWidth,
+             BitVec.toNat_ofNat, Nat.shiftLeft_eq, Nat.fromBytesBE,
+             List.length_cons, List.length_nil]
+  have hz : BitVec.toNat (0 : Word) = 0 := rfl
+  have h0 := e0.isLt; have h1 := e1.isLt; have h2 := e2.isLt; have h3 := e3.isLt
+  have h4 := e4.isLt; have h5 := e5.isLt; have h6 := e6.isLt
+  omega
+
+theorem rlp_be_len_8_eq_fromBytesBE (e0 e1 e2 e3 e4 e5 e6 e7 : Byte) :
+    (((((((((0 : Word) <<< 8) + e0.zeroExtend 64) <<< 8 + e1.zeroExtend 64) <<< 8
+        + e2.zeroExtend 64) <<< 8 + e3.zeroExtend 64) <<< 8 + e4.zeroExtend 64) <<< 8
+        + e5.zeroExtend 64) <<< 8 + e6.zeroExtend 64) <<< 8 + e7.zeroExtend 64
+      = BitVec.ofNat 64 (Nat.fromBytesBE [e0, e1, e2, e3, e4, e5, e6, e7]) := by
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_add, BitVec.toNat_shiftLeft, BitVec.toNat_setWidth,
+             BitVec.toNat_ofNat, Nat.shiftLeft_eq, Nat.fromBytesBE,
+             List.length_cons, List.length_nil]
+  have hz : BitVec.toNat (0 : Word) = 0 := rfl
+  have h0 := e0.isLt; have h1 := e1.isLt; have h2 := e2.isLt; have h3 := e3.isLt
+  have h4 := e4.isLt; have h5 := e5.isLt; have h6 := e6.isLt; have h7 := e7.isLt
+  omega
+
+-- Concrete sanity checks: the bridge yields the *spec value*, not just a
+-- well-typed term. `[0x01, 0x00]` big-endian = 256.
+example : ((0 : Word) <<< 8) + (0x05 : Byte).zeroExtend 64
+    = BitVec.ofNat 64 (Nat.fromBytesBE [(0x05 : Byte)]) := by decide
+example : Nat.fromBytesBE [(0x01 : Byte), (0x00 : Byte)] = 256 := by decide
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -1078,6 +1078,19 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     big-endian length by reference to that closure's `…_post`. All
     16 theorems are axiom-clean (only `propext`/`Classical.choice`/
     `Quot.sound`), 0 sorry. Wired into the `EvmAsm.Rv64.RLP` umbrella.
+  - ✅ **Long-form length bridged to the pure spec (`Nat.fromBytesBE`).**
+    The full-path outputs above leave `x11` as a raw big-endian
+    accumulation; `Phase2LongLengthBridge.lean` proves it equals the value
+    the pure RLP spec decodes. Core: `rlp_be_len_{1..8}_eq_fromBytesBE`
+    (and `rlp_be_byte_eq_fromBytesBE`) show
+    `(((0 <<< 8) + e0) <<< 8 …) + e_{N-1} = BitVec.ofNat 64 (Nat.fromBytesBE
+    [e0,…,e_{N-1}])` for `N ≤ 8` (no 64-bit overflow since the value is
+    `< 256^8 = 2^64`), backed by the pure bound `Nat.fromBytesBE_lt`
+    (`EL/RLP/Properties.lean`). `Phase1E{3,5}…FromBytesBE.lean` thread this
+    through to 16 end-to-end `…_fromBytesBE_spec_within` restatements whose
+    postcondition states `x11 = BitVec.ofNat 64 (Nat.fromBytesBE [extractByte
+    …, …])` — i.e. the decoder computes the *spec-correct* length, not just a
+    bitvector. All axiom-clean, 0 sorry.
   - Remaining: the planned general `n`-iteration closure (replacing the
     unrolled 1–8 closures via induction over the byte counter),
     cross-doubleword length spans, and the short/long-list error exits


### PR DESCRIPTION
## What

The RLP RISC-V decoder's long-form full paths (#8742) compute the decoded length into `x11`, but only as a **raw big-endian bitvector accumulation** `(((0 <<< 8) + e0) <<< 8 + e1) … + e_{N-1}` — with nothing proving it equals the length the **pure** RLP spec decodes. This PR adds that semantic correctness bridge, so the decoder provably computes the *spec-correct* length.

The bridge target is `Nat.fromBytesBE` (`EvmAsm/EL/RLP/Basic.lean`), the spec's big-endian decode used by `readLength`.

## Changes

| File | Content |
|---|---|
| `EvmAsm/EL/RLP/Properties.lean` | `Nat.fromBytesBE_lt : Nat.fromBytesBE bs < 256 ^ bs.length` (pure bound) |
| `EvmAsm/Rv64/RLP/Phase2LongLengthBridge.lean` | `rlp_be_byte_eq_fromBytesBE` + `rlp_be_len_{1..8}_eq_fromBytesBE`: the N-byte accumulation `= BitVec.ofNat 64 (Nat.fromBytesBE [e0,…,e_{N-1}])` |
| `EvmAsm/Rv64/RLP/Phase1E3LongStringFromBytesBE.lean` | 8 e3 (`0xB8`–`0xBF`) end-to-end `…_fromBytesBE_spec_within` restatements |
| `EvmAsm/Rv64/RLP/Phase1E5LongListFromBytesBE.lean` | 8 e5 (`0xF8`–`0xFF`) end-to-end restatements |

Each end-to-end theorem's postcondition states `x11 = BitVec.ofNat 64 (Nat.fromBytesBE [extractByte …, …])`.

## How

- **Soundness**: length-of-length `N ≤ 8`, each byte `< 256`, so the decoded value is `< 256^8 = 2^64` — no 64-bit overflow. The core lemmas push `toNat` through the shift-add chain (`BitVec.toNat_shiftLeft`/`_add`/`_setWidth`), unfold `Nat.fromBytesBE` over the concrete byte list, and discharge the resulting literal-modulus, byte-bounded arithmetic with `omega`.
- **End-to-end**: each restatement rewrites *its own goal* backwards (`← rlp_be_len_N`, `← …_post_unfold`) into the closure's `_post`, then closes with the underlying full path — no re-transcription of the nested accumulation, and `exact` absorbs the `let`-bindings by defeq.

## Verification

- ✅ `lake build` — full library green (3281 jobs), 0 sorry
- ✅ `scripts/check-forbidden-tactics.sh` — no `native_decide` / `bv_decide`
- ✅ `#print axioms` on representatives (`Nat.fromBytesBE_lt`, `rlp_be_len_8_eq_fromBytesBE`, `…_e3_0xB8…`, `…_e3_0xBF…`, `…_e5_0xFF…`) → only `propext` / `Classical.choice` / `Quot.sound` (the pure arithmetic lemmas don't even use `Classical.choice`); no `sorryAx` / trust axioms
- ✅ Concrete `example` cross-checks (`Nat.fromBytesBE [0x01, 0x00] = 256`) confirm the bridge yields the spec *value*
- New modules wired into the `EvmAsm.Rv64.RLP` umbrella; PLAN.md updated

## Out of scope (PLAN.md follow-ups)

- Bridging to `readLength` (adds canonical-encoding / `>55` validation — a separate concern; this targets the raw `Nat.fromBytesBE` value)
- General `n`-iteration induction closure for the loop
- Unified single-item prefix dispatch across all five exits

Builds on #8742.

🤖 Generated with [Claude Code](https://claude.com/claude-code)