### PR TITLE
feat(rlp): classifyPrefix-level pure-spec wrappers for e1/e2 exits

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase1E2FullPath.lean
+++ b/EvmAsm/Rv64/RLP/Phase1E2FullPath.lean
@@ -118,4 +118,68 @@ theorem rlp_phase1_e2_full_path_spec'_within
     (rlp_phase1_step_code_disjoint_8 0x80 0xB8 off1 off2 base)
     hd_phase3
 
+/--
+  Class-level short-string wrapper for the full Phase 1 → Phase 3 e2 path.
+  The executable path theorem still supplies the branch facts; this restates
+  the output length as the pure RLP short-bytes payload length. Mirrors
+  `rlp_phase1_e4_full_path_payload_len_of_class_spec_within`.
+-/
+theorem rlp_phase1_e2_full_path_payload_len_of_class_spec_within
+    (pfx : EvmAsm.EL.RLP.Byte) (v10 v11Old v13 : Word)
+    (off1 off2 : BitVec 13) (base e2_target : Word)
+    (htarget : (base + 8 + 4) + signExtend13 off2 = e2_target)
+    (h_class : EvmAsm.EL.RLP.classifyPrefix pfx =
+      EvmAsm.EL.RLP.PrefixClass.shortBytes)
+    (hd_phase3 : ((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).Disjoint
+                 (CodeReq.ofProg e2_target rlp_phase3_short_string_prog)) :
+    cpsTripleWithin 6 base (e2_target + 8)
+      (((rlp_phase1_step_code 0x80 off1 base).union
+          (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+         (CodeReq.ofProg e2_target rlp_phase3_short_string_prog))
+      ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x13 ↦ᵣ v13))
+      ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xB8 : BitVec 12))) **
+        (.x11 ↦ᵣ
+          (BitVec.ofNat 64 (EvmAsm.EL.RLP.rlpPrefixShortBytesPayloadLen pfx) : Word)) **
+        (.x13 ↦ᵣ (v13 + signExtend12 (1 : BitVec 12)))) := by
+  have h_range :=
+    (EvmAsm.EL.RLP.classifyPrefix_shortBytes_iff pfx).mp h_class
+  have hmod : pfx.toNat % 18446744073709551616 = pfx.toNat :=
+    Nat.mod_eq_of_lt (by omega)
+  have hv5_lo :
+      ¬ BitVec.ult (pfx.zeroExtend 64)
+        ((0 : Word) + signExtend12 (0x80 : BitVec 12)) := by
+    rw [BitVec.ult_eq_decide]
+    simp only [BitVec.toNat_setWidth]
+    have hk : (((0 : Word) + signExtend12 (0x80 : BitVec 12)).toNat) = 0x80 := by decide
+    rw [hk, hmod]
+    simp only [decide_eq_true_eq]
+    omega
+  have hv5_hi :
+      BitVec.ult (pfx.zeroExtend 64)
+        ((0 : Word) + signExtend12 (0xB8 : BitVec 12)) := by
+    rw [BitVec.ult_eq_decide]
+    simp only [BitVec.toNat_setWidth]
+    have hk : (((0 : Word) + signExtend12 (0xB8 : BitVec 12)).toNat) = 0xB8 := by decide
+    rw [hk, hmod]
+    simp only [decide_eq_true_eq]
+    omega
+  have h_add_sub :
+      pfx.zeroExtend 64 + signExtend12 (-(0x80 : BitVec 12)) =
+        pfx.zeroExtend 64 - (0x80 : Word) := by
+    have hs : signExtend12 (-(0x80 : BitVec 12)) = -(0x80 : Word) := by decide
+    rw [hs, BitVec.sub_eq_add_neg]
+  have h_len :=
+    EvmAsm.EL.RLP.rlpPrefixShortBytesPayloadLen_toWord_of_class pfx h_class
+  have h_add :
+      pfx.zeroExtend 64 + signExtend12 (-(0x80 : BitVec 12)) =
+        (BitVec.ofNat 64 (EvmAsm.EL.RLP.rlpPrefixShortBytesPayloadLen pfx) : Word) := by
+    rw [h_add_sub, ← h_len]
+  rw [← h_add]
+  exact rlp_phase1_e2_full_path_spec'_within
+    (pfx.zeroExtend 64) v10 v11Old v13 off1 off2 base e2_target
+    htarget hv5_lo hv5_hi hd_phase3
+
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Phase1ToPhase3SingleByte.lean
+++ b/EvmAsm/Rv64/RLP/Phase1ToPhase3SingleByte.lean
@@ -153,4 +153,45 @@ theorem rlp_phase1_e1_then_single_byte_spec_at_0x7F_within
     (0x7F : Word) v10 v11Old offset base target htarget
     (by decide) hd
 
+/--
+  Class-level single-byte wrapper for the full Phase 1 → Phase 3 e1 path.
+  Restates the dispatch precondition against the pure RLP classifier
+  (`classifyPrefix pfx = .singleByte`); the decoded length is the constant `1`
+  (a canonical single byte `< 0x80` *is* its own payload), so — unlike the
+  short/long forms — there is no length function to bridge, only the input
+  predicate. Completes the per-exit `classifyPrefix`-level bridge set
+  alongside the e2/e3/e4/e5 wrappers.
+-/
+theorem rlp_phase1_e1_single_byte_of_class_spec_within
+    (pfx : EvmAsm.EL.RLP.Byte) (v10 v11Old : Word)
+    (offset : BitVec 13)
+    (base target : Word)
+    (htarget : (base + 4) + signExtend13 offset = target)
+    (h_class : EvmAsm.EL.RLP.classifyPrefix pfx =
+      EvmAsm.EL.RLP.PrefixClass.singleByte)
+    (hd : (rlp_phase1_step_code 0x80 offset base).Disjoint
+            (CodeReq.ofProg target rlp_phase3_single_byte_prog)) :
+    cpsTripleWithin 3 base (target + 4)
+      ((rlp_phase1_step_code 0x80 offset base).union
+         (CodeReq.ofProg target rlp_phase3_single_byte_prog))
+      ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old))
+      ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0x80 : BitVec 12))) **
+        (.x11 ↦ᵣ (1 : Word))) := by
+  have h_lt := (EvmAsm.EL.RLP.classifyPrefix_singleByte_iff pfx).mp h_class
+  have hmod : pfx.toNat % 18446744073709551616 = pfx.toNat :=
+    Nat.mod_eq_of_lt (by omega)
+  have hv5 :
+      BitVec.ult (pfx.zeroExtend 64)
+        ((0 : Word) + signExtend12 (0x80 : BitVec 12)) := by
+    rw [BitVec.ult_eq_decide]
+    simp only [BitVec.toNat_setWidth]
+    have hk : (((0 : Word) + signExtend12 (0x80 : BitVec 12)).toNat) = 0x80 := by decide
+    rw [hk, hmod]
+    simp only [decide_eq_true_eq]
+    omega
+  exact rlp_phase1_e1_then_single_byte_spec_within
+    (pfx.zeroExtend 64) v10 v11Old offset base target htarget hv5 hd
+
 end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -1091,6 +1091,18 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     postcondition states `x11 = BitVec.ofNat 64 (Nat.fromBytesBE [extractByte
     …, …])` — i.e. the decoder computes the *spec-correct* length, not just a
     bitvector. All axiom-clean, 0 sorry.
+  - ✅ **Per-exit `classifyPrefix`-level bridges complete (all five exits).**
+    Every classification exit now has a wrapper restating its full path
+    against the pure RLP classifier `classifyPrefix` (input side) and the
+    matching pure length (output side): e1 `rlp_phase1_e1_single_byte_of_class_spec_within`
+    (`classifyPrefix = .singleByte` → `x11 = 1`), e2
+    `rlp_phase1_e2_full_path_payload_len_of_class_spec_within`
+    (`x11 = ofNat (rlpPrefixShortBytesPayloadLen pfx)`), e4
+    `rlp_phase1_e4_full_path_payload_len_of_class_spec_within`
+    (`rlpPrefixShortListPayloadLen`), and e3/e5's `…_lenOfLen_of_class…`
+    (the long-form `lenLen` counter). The e1/e2 wrappers (this slice) mirror
+    e4 and reuse `rlpPrefixShortBytesPayloadLen_toWord_of_class`
+    (`EL/RLP/ProgramSpec.lean`). Axiom-clean, 0 sorry.
   - Remaining: the planned general `n`-iteration closure (replacing the
     unrolled 1–8 closures via induction over the byte counter),
     cross-doubleword length spans, and the short/long-list error exits


### PR DESCRIPTION
## What

Completes the RLP RISC-V decoder's **per-exit pure-spec bridge set**. Each Phase-1 classification exit has a full path producing `(payload_ptr, payload_len)`; most also carry a `classifyPrefix`-level wrapper that restates the full path against the pure RLP classifier (input) and the matching pure length (output). Before this PR, e1 and e2 were the only exits lacking one:

| Exit | `classifyPrefix`-level wrapper | bridges |
|---|---|---|
| e1 single-byte | **added here** | `classifyPrefix = .singleByte` → `x11 = 1` |
| e2 short bytes | **added here** | `x11 = ofNat (rlpPrefixShortBytesPayloadLen pfx)` |
| e3 long bytes | already | `lenOfLen` counter + `…_fromBytesBE_…` (decoded length) |
| e4 short list | already | `rlpPrefixShortListPayloadLen` |
| e5 long list | already | `lenOfLen` counter + `…_fromBytesBE_…` |

## Changes

- `EvmAsm/Rv64/RLP/Phase1E2FullPath.lean` — `rlp_phase1_e2_full_path_payload_len_of_class_spec_within`. Mirrors `rlp_phase1_e4_full_path_payload_len_of_class_spec_within` exactly: derives the two `ult` bounds from `classifyPrefix_shortBytes_iff`, rewrites the output via the existing `rlpPrefixShortBytesPayloadLen_toWord_of_class`, and closes with `rlp_phase1_e2_full_path_spec'_within`.
- `EvmAsm/Rv64/RLP/Phase1ToPhase3SingleByte.lean` — `rlp_phase1_e1_single_byte_of_class_spec_within`. A single byte `< 0x80` is its own payload (length `1`), so there's no length function to bridge — the wrapper restates the input dispatch predicate via `classifyPrefix_singleByte_iff` and closes with the existing e1 full path.

No new pure lemmas; both reuse existing `EL/RLP` machinery. Wrappers live next to their full paths (as e4's does); no umbrella change.

## Verification

- ✅ `lake build` — full library green (3284 jobs), 0 sorry
- ✅ `scripts/check-no-warnings.sh` — **0 warnings under EvmAsm/** (run pre-push)
- ✅ `scripts/check-forbidden-tactics.sh` — no `native_decide` / `bv_decide`
- ✅ `#print axioms` on both wrappers → only `propext` / `Classical.choice` / `Quot.sound`

## Out of scope (future)

- Unified single-item prefix dispatch (all five exits in one `cpsNBranchWithin` — needs an 8-way runtime lenLen sub-dispatch for the long forms)
- `readLength`-level canonical/`>55` validation
- General n-iteration loop closure

🤖 Generated with [Claude Code](https://claude.com/claude-code)