### PR TITLE
fix(header): reject U64 blob_gas_used*7 overflow in excess-blob-gas schedule branch

### DIFF
--- a/EvmAsm/Codegen/Programs/HeaderBaseFee.lean
+++ b/EvmAsm/Codegen/Programs/HeaderBaseFee.lean
@@ -339,6 +339,11 @@ def ziskHeaderValidateBaseFeeProbeUnit : BuildUnit := {
 
     because `PER_BLOB / BLOB_BASE_COST = 16`.
 
+    The schedule branch computes `used // 3` (algebraically `used * 7 // 21`),
+    but the spec's `blob_gas_used * 7` is an overflow-checked U64 multiply:
+    when `blob_gas_used > (2^64-1) // 7` the spec raises OverflowError and the
+    block is invalid, so that range must return the overflow status here too.
+
     Calling convention:
       a0 (input)  : this.excess_blob_gas (u64)
       a1 (input)  : parent.blob_gas_used (u64)
@@ -379,6 +384,8 @@ def headerValidateExcessBlobGasFunction : String :=
   "  la t0, u256m_acc\n" ++
   "  ld t0, 0(t0)\n" ++
   "  beqz t0, .Lhvebg_normal\n" ++
+  "  li t0, 2635249153387078802  # (2^64-1) // 7\n" ++
+  "  bltu t0, s1, .Lhvebg_overflow  # spec: U64 used * 7 raises OverflowError\n" ++
   "  li t0, 3\n" ++
   "  divu t1, s1, t0             # used * 7 // 21 == used // 3\n" ++
   "  add s5, s2, t1\n" ++

--- a/scripts/codegen-zisk-validate-header-full-check.sh
+++ b/scripts/codegen-zisk-validate-header-full-check.sh
@@ -234,6 +234,30 @@ build_test "step6_excess_schedule_wrong" 602 \
   100 1700000000 30000000 15000000 "$BF_50" \
   0 917505 2752512 0 || FAILED=1
 
+# Step 6 fail: schedule branch where the spec's U64 `blob_gas_used * 7`
+# overflows ((2^64-1)//7 + 1 = 2635249153387078803) → OverflowError in the
+# spec, status 601 here. this.excess matches the unguarded `used // 3` value
+# so a guest missing the overflow guard would wrongly return 0.
+MUL_OVERFLOW_USED=2635249153387078803
+MUL_OVERFLOW_EXCESS=$(python3 -c "print($MUL_OVERFLOW_USED // 3)")
+build_test "step6_blob_mul_overflow" 601 \
+  "$EMPTY_OMMERS_HASH" 0 "$ZERO_NONCE" \
+  "" \
+  101 1700000100 30000000 15000000 "$BF_50" \
+  100 1700000000 30000000 15000000 "$BF_50" \
+  0 "$MUL_OVERFLOW_EXCESS" "$MUL_OVERFLOW_USED" 0 || FAILED=1
+
+# All pass: schedule branch at the largest non-overflowing blob_gas_used
+# ((2^64-1)//7, where used * 7 = 2^64-2 still fits in U64).
+MUL_BOUND_USED=2635249153387078802
+MUL_BOUND_EXCESS=$(python3 -c "print($MUL_BOUND_USED // 3)")
+build_test "all_pass_blob_mul_at_bound" 0 \
+  "$EMPTY_OMMERS_HASH" 0 "$ZERO_NONCE" \
+  "" \
+  101 1700000100 30000000 15000000 "$BF_50" \
+  100 1700000000 30000000 15000000 "$BF_50" \
+  0 "$MUL_BOUND_EXCESS" "$MUL_BOUND_USED" 0 || FAILED=1
+
 # All pass: realistic Holesky 60% used scenario
 # parent.gas_used=18000000, target=15000000 (above), bf grows
 # expected = bf + delta where delta = max((bf*3M/15M)/8, 1) = (bf*0.2)/8 = bf*0.025


### PR DESCRIPTION
## Summary
- The Amsterdam reserve-price branch of `header_validate_excess_blob_gas` used the identity `used * 7 // 21 == used // 3`, which silently dropped the spec's overflow-checked U64 multiply: for `parent.blob_gas_used > (2^64-1)//7` the spec (`execution-specs/.../amsterdam/vm/gas.py` `calculate_excess_blob_gas`) raises OverflowError → InvalidBlock, while the guest computed a finite expected value and could accept — a guest-accepts-where-spec-rejects soundness gap on adversarial witness parents.
- Add the `(2^64-1)//7` bound guard before the `divu`, routing to the existing helper-overflow status (601 from `validate_header_full`).
- Extend `scripts/codegen-zisk-validate-header-full-check.sh` with both boundary vectors: `used = bound+1` → 601 (the vector pins `this.excess_blob_gas` to the unguarded `used // 3` value, so a guest missing the guard reads status 0), and `used = bound` → still passes. All 15 probe vectors green; full `lake build` green; file-size/unimported/forbidden-pattern gates pass.

Bead: evm-asm-z6j0j.

Authored by @pirapira; implemented by Claude Code