### PR TITLE
fix(eip7708): suppress top-level transfer log for self-transfers (sender == recipient)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -741,6 +741,18 @@ def blockVerdictFunction : String :=
   "  la t0, bmvmx_avail; ld t0, 0(t0); beqz t0, .Lbv_tl7708_skip\n" ++
   "  la t0, bmvmx_value; ld t1, 0(t0); ld t2, 8(t0); or t1, t1, t2; ld t2, 16(t0); or t1, t1, t2; ld t2, 24(t0); or t1, t1, t2\n" ++
   "  beqz t1, .Lbv_tl7708_skip\n" ++
+  -- EIP-7708 self-suppression: emit the transfer log ONLY to a DIFFERENT account. The spec
+  -- emits at the value-bearing call only when caller != current_target (amsterdam
+  -- interpreter.py:314 / vm/__init__.py emit_transfer_log). For a top-level transfer to SELF
+  -- (sender == recipient) NO log is emitted; without this guard the guest emits a spurious log
+  -- -> extra receipt log -> receipts_root/logs_bloom mismatch -> false-reject (transfer_to_self_no_log).
+  -- Compare the 20 BE address bytes: sender (bmvmx_sender_addr[0..19]) vs recipient (bmvmx_ctx+72..91).
+  "  la t0, bmvmx_sender_addr; la t1, bmvmx_ctx; addi t1, t1, 72; li t2, 20\n" ++
+  ".Lbv_tl_selfcmp:\n" ++
+  "  beqz t2, .Lbv_tl7708_skip                # all 20 bytes equal -> self-transfer -> suppress log\n" ++
+  "  lbu t3, 0(t0); lbu t4, 0(t1); bne t3, t4, .Lbv_tl_notself\n" ++
+  "  addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1; j .Lbv_tl_selfcmp\n" ++
+  ".Lbv_tl_notself:\n" ++
   "  addi sp, sp, -16\n  sd x20, 0(sp)\n" ++
   -- from32 = reverse(bmvmx_sender_addr[0..19]) into the low 20 bytes (LE), high 12 zeroed
   "  la t0, eip7708_tl_from32\n  sd x0, 0(t0); sd x0, 8(t0); sd x0, 16(t0); sd x0, 24(t0)\n" ++


### PR DESCRIPTION
## Summary
`eip7708_eth_transfer_logs/transfer_to_self_no_log.json` false-rejected (succ guest=00, exp=01). The Part 2 top-level EIP-7708 transfer-log emission guarded only on `bmvmx_avail` + `value != 0` — **missing the spec's `caller != current_target` self-suppression** (amsterdam `interpreter.py:314`: emit the transfer log only to a *different* account). For a tx transferring value to itself, the guest emitted a **spurious transfer log → extra receipt log → header `receipts_root`/`logs_bloom` mismatch → false-reject**.

- **Fix:** before emitting, compare the 20 BE address bytes of sender (`bmvmx_sender_addr`) vs recipient (`bmvmx_ctx+72`); skip the log when equal. Non-self transfers fall through unchanged.

## Validation
- Full **eip7708 suite: 107/107 full match**, 0 errored — `transfer_to_self_no_log` flips 00→01; every other transfer-log row unchanged (no regression).

## Related
The CALL/CALLCODE self-transfer variant (same missing `caller != current_target` guard, in the contract-call path) is tracked separately as **h2cv5**.

Refs eip7708. Bead: evm-asm-17ux0.

Authored by @pirapira; implemented by Claude Code