### PR TITLE
fix(system-tx): reset system_call_returndata_len before each system call

### DIFF
--- a/EvmAsm/Codegen/Programs/SystemCallStaging.lean
+++ b/EvmAsm/Codegen/Programs/SystemCallStaging.lean
@@ -123,6 +123,14 @@ def stageSystemCallFunction : String :=
   "  la t0, ssc_saved_ra; sd ra, 0(t0)\n" ++
   "  la t0, ssc_saved_s0; sd s0, 0(t0)\n" ++
   "  mv s0, a4                    # out payload ptr (used only pre-dispatch)\n" ++
+  -- 87gow: reset the captured return-data length to 0 BEFORE each system call. The capture
+  -- (NoopHalt) writes system_call_returndata_len ONLY on a depth-0 RETURN <= 4096 bytes; a
+  -- predeploy that ends in a clean STOP (empty return_data, spec fork.py:976-997) or an
+  -- oversized return does NOT write it. Without this reset the consolidation system call would
+  -- inherit the withdrawal call's stale length -> a spurious consolidation request body ->
+  -- wrong header.requests_hash -> false-reject/accept. Spec: each return_data is a SEPARATE
+  -- MessageCallOutput; empty == len 0.
+  "  li t0, 0; la t1, system_call_returndata_len; sd t0, 0(t1)\n" ++
   "  li t0, 1; la t1, system_call_mode; sd t0, 0(t1)\n" ++       -- enable depth-0 RETURN capture
   "  jal ra, stage_system_call_payload\n" ++                     -- a0..a4 already set by caller
   "  bnez a0, .Lssc_fail\n" ++                                   -- staging rejected -> bail (no dispatch)


### PR DESCRIPTION
## Summary
Audit **87gow**. The depth-0 RETURN capture (`NoopHalt`) writes `system_call_returndata_len` **only on a RETURN ≤ 4096 bytes** — a predeploy that ends in a clean **STOP** (empty `return_data`) or an oversized return doesn't write it. `stage_system_call` never reset the global, so the EIP-7251 **consolidation** system call could inherit the EIP-7002 **withdrawal** call's stale length → a spurious consolidation request body → wrong `header.requests_hash` → **false-reject** (or false-accept).

- **Fix:** reset `system_call_returndata_len = 0` at the top of `stage_system_call`, so a no-RETURN / oversized predeploy yields empty (len 0) instead of the previous call's value. Per spec (amsterdam `fork.py:976-997`) the withdrawal and consolidation calls are separate `MessageCallOutput`s; empty == len 0.
- One line, no new symbol (the global is already read in the same function). Full build green.

## Validation
Source-level (full `lake build` green); the operator runs the full sweep. Most likely to exercise: `--filter eip7002`, `--filter eip7251`, `--filter eip7685` (sequential withdrawal→consolidation system calls).

Refs eip7002, eip7251. Bead: evm-asm-87gow.

Authored by @pirapira; implemented by Claude Code