### PR TITLE
fix(dispatcher): roll back child-frame EIP-8037 state gas on REVERT (nxio8.4.1)

### DIFF
--- a/EvmAsm/Codegen/Programs/CallFrameDescend.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameDescend.lean
@@ -300,6 +300,15 @@ def callFrameDescendFunction : String :=
   "  ld t0, 472(s3); sd t0, 472(s9)   # eventLogLength\n" ++
   "  sd t0, 480(s9)                    # eventLogCheckpoint = current\n" ++
   "  sd x0, 488(s9)                    # activeMemorySize = 0 (fresh child memory)\n" ++
+  -- nxio8.4.1: snapshot the parent's pre-child EIP-8037 state gas (the global
+  -- evm_state_gas_left = state_gas_left reservoir, evm_state_gas_used = state_gas_used) into the
+  -- child env so a child REVERT / exceptional halt can restore it in frame_return,
+  -- matching execution-specs incorporate_child_on_error (the reverted child's
+  -- entire state-gas allocation is returned to the parent and state_gas_used is
+  -- NOT accumulated). s9 = child env; env offsets 624/632 are free (the env is
+  -- frameEnvBytes=768 and its fields end at 616). Mirrors persistentLogCheckpoint.
+  "  la t1, evm_state_gas_left; ld t0, 0(t1); sd t0, 624(s9)   # state_gas_left snapshot\n" ++
+  "  la t1, evm_state_gas_used; ld t0, 0(t1); sd t0, 632(s9)   # state_gas_used snapshot\n" ++
   -- 9. child env.codeSize (env+496).
   "  ld t0, 72(s7); sd t0, 496(s9)\n" ++
   -- 10. frame-relative stack bounds: point the under/overflow guards at the
@@ -445,6 +454,9 @@ def ziskCallFrameDescendPrologue : String :=
   "  li t1, 0xaa; sd t1, 0(t0)\n" ++
   "  li t1, 100000; sd t1, 568(t0)\n" ++
   "  li t1, 0x592; sd t1, 592(t0)\n" ++
+  -- nxio8.4.1: pre-child state gas; descend must snapshot it into child env+624/632.
+  "  la t0, evm_state_gas_left; li t1, 12345; sd t1, 0(t0)\n" ++
+  "  la t0, evm_state_gas_used; li t1, 67890; sd t1, 0(t0)\n" ++
   -- to / value words.
   "  la t0, cfd2_to; li t1, 0xbb; sd t1, 0(t0)\n" ++
   "  la t0, cfd2_val; li t1, 0x7; sd t1, 0(t0)\n" ++
@@ -479,6 +491,9 @@ def ziskCallFrameDescendPrologue : String :=
   "  ld t0, 568(x20); sd t0, 128(s0)\n" ++
   "  ld t0, 496(x20); sd t0, 136(s0)\n" ++
   "  ld t0, 592(x20); sd t0, 144(s0)\n" ++
+  -- nxio8.4.1: descend snapshotted pre-child state gas into child env+624/632.
+  "  ld t0, 624(x20); sd t0, 176(s0)\n" ++   -- expect 12345 (state_gas_left)
+  "  ld t0, 632(x20); sd t0, 184(s0)\n" ++   -- expect 67890 (state_gas_used)
   -- child register bases.
   "  la t1, call_frame_arena; sub t0, x13, t1; sd t0, 56(s0)\n" ++
   "  la t1, call_frame_arena; sub t0, x20, t1; sd t0, 64(s0)\n" ++
@@ -524,6 +539,10 @@ def ziskCallFrameDescendDataSection : String :=
   -- Frame-relative stack-bound cells (descend overwrites them; zeroed stubs here).
   "evm_cur_stack_top:\n  .zero 8\n" ++
   "evm_cur_stack_low:\n  .zero 8\n" ++
+  -- nxio8.4.1: EIP-8037 state-gas globals (real symbols in the guest dispatcher
+  -- data section; stubbed so the probe links + can verify the descend snapshot).
+  "evm_state_gas_left:\n  .zero 8\n" ++
+  "evm_state_gas_used:\n  .zero 8\n" ++
   ".balign 8\n" ++
   "cfd2_desc:\n  .zero 96\n" ++
   ".balign 32\n" ++

--- a/EvmAsm/Codegen/Programs/CallFrameReturn.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameReturn.lean
@@ -69,6 +69,18 @@ def frameReturnFunction : String :=
   -- Capture the child frame's leftover gas (x20 = child env at entry) for the
   -- EIP-150 refund below; held in s7 across the x20 repoint.
   "  ld s7, 568(x20)\n" ++
+  -- nxio8.4.1: on a child REVERT / exceptional halt (success word s0 == 0) restore
+  -- the parent's pre-child EIP-8037 state gas, snapshotted into the child env
+  -- (env+624/632) by call_frame_descend. incorporate_child_on_error returns the
+  -- reverted child's entire state-gas allocation (used + left) to the parent and
+  -- does NOT accumulate its state_gas_used; the guest's globals (evm_state_gas_left /
+  -- evm_state_gas_used) were mutated in place by the child's SSTOREs, so we roll them back
+  -- to the snapshot. On success (s0 != 0) leave them — the child's state gas stays
+  -- accumulated (incorporate_child_on_success). x20 = child env here (pre-repoint).
+  "  bnez s0, .Lfr_sgas_done\n" ++
+  "  ld t0, 624(x20); la t1, evm_state_gas_left; sd t0, 0(t1)\n" ++
+  "  ld t0, 632(x20); la t1, evm_state_gas_used; sd t0, 0(t1)\n" ++
+  ".Lfr_sgas_done:\n" ++
   -- Load the saved call-context for the CURRENT (child) depth.
   "  la t0, evm_call_depth\n" ++
   "  ld t1, 0(t0)                   # t1 = child depth d\n" ++
@@ -222,6 +234,11 @@ def ziskFrameReturnPrologue : String :=
   "  la x20, fr_child_env\n" ++                       -- child env for the gas read
   "  la t0, fr_child_env; li t1, 50; sd t1, 568(t0)\n" ++   -- child leftover gas = 50
   "  la t0, evm_env;      li t1, 100; sd t1, 568(t0)\n" ++  -- parent gas = 100
+  -- nxio8.4.1: state gas before a SUCCESS return = 1000/2000; success leaves the
+  -- globals (child state-gas stays accumulated); the +624/632 snapshot is ignored.
+  "  la t0, evm_state_gas_left; li t1, 1000; sd t1, 0(t0)\n" ++
+  "  la t0, evm_state_gas_used; li t1, 2000; sd t1, 0(t0)\n" ++
+  "  la t0, fr_child_env; li t1, 333; sd t1, 624(t0); li t1, 444; sd t1, 632(t0)\n" ++
   "  li a0, 1; li a1, 0; li a2, 0\n" ++
   "  jal ra, frame_return\n" ++
   "  sd x10, 0(s0)                  # expect 0x101 (parent_pc 0x100 + 1)\n" ++
@@ -237,6 +254,9 @@ def ziskFrameReturnPrologue : String :=
   "  la t0, evm_precompile_frame; ld t1, 8(t0); sd t1, 120(s0)  # expect 0\n" ++
   -- EIP-150 gas refund: parent gas 100 + child leftover 50 = 150.
   "  la t0, evm_env; ld t1, 568(t0); sd t1, 144(s0)  # expect 150\n" ++
+  -- nxio8.4.1: SUCCESS leaves the state-gas globals unchanged (1000/2000).
+  "  la t0, evm_state_gas_left; ld t1, 0(t0); sd t1, 160(s0)  # expect 1000\n" ++
+  "  la t0, evm_state_gas_used; ld t1, 0(t0); sd t1, 168(s0)  # expect 2000\n" ++
   -- ---- Scenario B: depth 2 -> 1, REVERT-style with a returndata byte ----
   "  la t0, evm_call_depth; li t1, 2; sd t1, 0(t0)\n" ++
   -- frame_save_area[1] = (pc=0x300, cb=0x444)
@@ -252,6 +272,13 @@ def ziskFrameReturnPrologue : String :=
   "  la x20, fr_child_env\n" ++
   "  la t0, fr_child_env; li t1, 30; sd t1, 568(t0)\n" ++   -- child leftover gas = 30
   "  la t0, call_frame_arena; li t2, 0x28400; add t0, t0, t2; li t1, 200; sd t1, 568(t0)\n" ++  -- parent (frame[1]) gas = 200
+  -- nxio8.4.1: child mutated the state-gas globals to 7777/8888; the pre-child
+  -- snapshot (555/666) lives in the child env at +624/632. A REVERT must roll the
+  -- globals back to the snapshot (incorporate_child_on_error returns the child's
+  -- entire state-gas allocation; state_gas_used is not accumulated).
+  "  la t0, evm_state_gas_left; li t1, 7777; sd t1, 0(t0)\n" ++
+  "  la t0, evm_state_gas_used; li t1, 8888; sd t1, 0(t0)\n" ++
+  "  la t0, fr_child_env; li t1, 555; sd t1, 624(t0); li t1, 666; sd t1, 632(t0)\n" ++
   "  li a0, 0; la a1, fr_ret; li a2, 4\n" ++
   "  jal ra, frame_return\n" ++
   "  la t0, call_frame_arena; sub t0, x13, t0; sd t0, 56(s0)   # expect 0\n" ++
@@ -267,6 +294,9 @@ def ziskFrameReturnPrologue : String :=
   "  la t0, evm_precompile_frame; lbu t1, 16(t0); sd t1, 136(s0)  # expect 0xab\n" ++
   -- EIP-150 gas refund: parent gas 200 + child leftover 30 = 230.
   "  la t0, call_frame_arena; li t2, 0x28400; add t0, t0, t2; ld t1, 568(t0); sd t1, 152(s0)  # expect 230\n" ++
+  -- nxio8.4.1: REVERT restored the state-gas globals to the child-env snapshot.
+  "  la t0, evm_state_gas_left; ld t1, 0(t0); sd t1, 176(s0)  # expect 555\n" ++
+  "  la t0, evm_state_gas_used; ld t1, 0(t0); sd t1, 184(s0)  # expect 666\n" ++
   "  j .Lfr_done\n" ++
   frameReturnFunction ++ "\n" ++
   ".Lfr_done:"
@@ -286,7 +316,11 @@ def ziskFrameReturnDataSection : String :=
   ".balign 32\n" ++
   "evm_memory:\n  .zero 64\n" ++
   "evm_env:\n  .zero 640\n" ++          -- enlarged: frame_return refunds gas at env+568
-  "fr_child_env:\n  .zero 640\n" ++       -- child env (x20 at frame_return entry); +568 = child gas
+  "fr_child_env:\n  .zero 768\n" ++       -- child env (x20 at frame_return entry); +568 = child gas, +624/632 = state-gas snapshot (nxio8.4.1)
+  -- nxio8.4.1: global EIP-8037 state-gas accumulators (the real symbols live in
+  -- the guest dispatcher data section; stubbed here so the probe links).
+  "evm_state_gas_left:\n  .zero 8\n" ++
+  "evm_state_gas_used:\n  .zero 8\n" ++
 
   -- Frame-relative stack-bound labels + cells. `evm_stack_top`/`evm_stack_low`
   -- are address-only stubs (frame_return takes their `&` for the depth-0

--- a/scripts/codegen-zisk-call-frame-descend-check.sh
+++ b/scripts/codegen-zisk-call-frame-descend-check.sh
@@ -65,6 +65,10 @@ checks = [
     ('evm_cur_stack_top - &arena',      0x18200),
     ('evm_cur_stack_low - &arena',      0x10200),
     ('parent gas after transfer+cost',  90000),
+    # nxio8.4.1: descend snapshots the parent's pre-child state gas into the child
+    # env at +624/632 so frame_return can restore it on a child REVERT.
+    ('child env state_gas_left snapshot', 12345),
+    ('child env state_gas_used snapshot', 67890),
 ]
 failed = False
 for i, (label, exp) in enumerate(checks):

--- a/scripts/codegen-zisk-frame-return-check.sh
+++ b/scripts/codegen-zisk-frame-return-check.sh
@@ -64,6 +64,12 @@ checks = [
     ('B returndata data[0]',                 0xab),
     ('A gas refund (100+50)',                150),
     ('B gas refund (200+30)',                230),
+    # nxio8.4.1: SUCCESS leaves the EIP-8037 state-gas globals unchanged;
+    # REVERT restores them to the child-env snapshot (incorporate_child_on_error).
+    ('A state_gas_left (success: unchanged)', 1000),
+    ('A state_gas_used (success: unchanged)', 2000),
+    ('B state_gas_left (revert: restored)',   555),
+    ('B state_gas_used (revert: restored)',   666),
 ]
 failed = False
 for i, (label, exp) in enumerate(checks):


### PR DESCRIPTION
## Summary
Closes a latent **false-reject** in the EIP-8037 state-gas accounting for reverting sub-calls (nxio8 residual, my execution-substrate lane).

`incorporate_child_on_error` returns a reverted/exceptional child's **entire** state-gas allocation to the parent (`state_gas_left += child.state_gas_used + child.state_gas_left`) and does **not** accumulate `state_gas_used` — the child's state changes are rolled back. The guest tracks state gas in global accumulators (`evm_state_gas_left` / `evm_state_gas_used`) that a child's SSTOREs mutate in place, but `frame_return` only did the EIP-150 regular-gas refund and never restored them. So a child that charged state gas then REVERTed left `evm_state_gas_used` over-counted → the EIP-8037 block-state-gas floor (`block_state_sum > header.gas_used → reject`) sat too high → a valid block with a reverting state-touching sub-call could be falsely rejected.

## Fix (mirrors the existing per-frame `persistentLogCheckpoint`)
- `call_frame_descend` snapshots the parent's pre-child `evm_state_gas_left`/`evm_state_gas_used` into the child env (`env+624/632`; env is 768 B, fields end at 616; children are always depth≥1 frame-arena frames, and all CALL-family children route through this one descend).
- `frame_return` restores both globals on the child **REVERT/exceptional** branch (`success == 0`); the **success** branch leaves them accumulated (`incorporate_child_on_success`).

Soundness-safe: removes the state-gas false-reject; `refund_counter` + EIP-2929 warmth rollback on child error are separate, pre-existing, unworsened (nxio8.4.2/.4.3). CREATE children get the same once CREATE runtime activates (.61.8).

## Verification
- Both unit probes extended + green: `zisk_call_frame_descend` asserts the child-env snapshot (12345/67890); `zisk_frame_return` asserts SUCCESS leaves the globals (1000/2000) and REVERT restores them to the snapshot (555/666).
- `lake build` + file-size / unimported (0 orphans) / forbidden-tactics pass; no `sorry`/`native_decide`/`bv_decide`.
- EEST `--no-build` (no failing row exists — latent soundness): **callcall** family (child REVERT/OOG) **24/24 full match**, random seed-99 **16/16 full match**, 0 fail / 0 budget / 0 errored.

Bead: evm-asm-nxio8.4.1.

Authored by @pirapira; implemented by Claude Code