### PR TITLE
fix(dispatcher): discard reverted child's EIP-3529 refund on child REVERT (nxio8.4.2)

### DIFF
--- a/EvmAsm/Codegen/Programs/CallFrameDescend.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameDescend.lean
@@ -309,6 +309,11 @@ def callFrameDescendFunction : String :=
   -- frameEnvBytes=768 and its fields end at 616). Mirrors persistentLogCheckpoint.
   "  la t1, evm_state_gas_left; ld t0, 0(t1); sd t0, 624(s9)   # state_gas_left snapshot\n" ++
   "  la t1, evm_state_gas_used; ld t0, 0(t1); sd t0, 632(s9)   # state_gas_used snapshot\n" ++
+  -- nxio8.4.2: also snapshot the EIP-3529 refund accumulator (evm_refund_acc) so a
+  -- child REVERT discards the child's refund_counter additions, matching
+  -- incorporate_child_on_error (which does NOT add child.refund_counter to the
+  -- parent). On success it is kept (incorporate_child_on_success accumulates it).
+  "  la t1, evm_refund_acc; ld t0, 0(t1); sd t0, 640(s9)       # refund_counter snapshot\n" ++
   -- 9. child env.codeSize (env+496).
   "  ld t0, 72(s7); sd t0, 496(s9)\n" ++
   -- 10. frame-relative stack bounds: point the under/overflow guards at the
@@ -457,6 +462,7 @@ def ziskCallFrameDescendPrologue : String :=
   -- nxio8.4.1: pre-child state gas; descend must snapshot it into child env+624/632.
   "  la t0, evm_state_gas_left; li t1, 12345; sd t1, 0(t0)\n" ++
   "  la t0, evm_state_gas_used; li t1, 67890; sd t1, 0(t0)\n" ++
+  "  la t0, evm_refund_acc; li t1, 24680; sd t1, 0(t0)\n" ++
   -- to / value words.
   "  la t0, cfd2_to; li t1, 0xbb; sd t1, 0(t0)\n" ++
   "  la t0, cfd2_val; li t1, 0x7; sd t1, 0(t0)\n" ++
@@ -494,6 +500,7 @@ def ziskCallFrameDescendPrologue : String :=
   -- nxio8.4.1: descend snapshotted pre-child state gas into child env+624/632.
   "  ld t0, 624(x20); sd t0, 176(s0)\n" ++   -- expect 12345 (state_gas_left)
   "  ld t0, 632(x20); sd t0, 184(s0)\n" ++   -- expect 67890 (state_gas_used)
+  "  ld t0, 640(x20); sd t0, 192(s0)\n" ++   -- expect 24680 (refund_acc, nxio8.4.2)
   -- child register bases.
   "  la t1, call_frame_arena; sub t0, x13, t1; sd t0, 56(s0)\n" ++
   "  la t1, call_frame_arena; sub t0, x20, t1; sd t0, 64(s0)\n" ++
@@ -543,6 +550,7 @@ def ziskCallFrameDescendDataSection : String :=
   -- data section; stubbed so the probe links + can verify the descend snapshot).
   "evm_state_gas_left:\n  .zero 8\n" ++
   "evm_state_gas_used:\n  .zero 8\n" ++
+  "evm_refund_acc:\n  .zero 8\n" ++
   ".balign 8\n" ++
   "cfd2_desc:\n  .zero 96\n" ++
   ".balign 32\n" ++

--- a/EvmAsm/Codegen/Programs/CallFrameReturn.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameReturn.lean
@@ -80,6 +80,10 @@ def frameReturnFunction : String :=
   "  bnez s0, .Lfr_sgas_done\n" ++
   "  ld t0, 624(x20); la t1, evm_state_gas_left; sd t0, 0(t1)\n" ++
   "  ld t0, 632(x20); la t1, evm_state_gas_used; sd t0, 0(t1)\n" ++
+  -- nxio8.4.2: discard the reverted child's EIP-3529 refund additions by restoring
+  -- evm_refund_acc to the pre-child snapshot (incorporate_child_on_error does not
+  -- add child.refund_counter). Success leaves it (the SSTORE refunds stay).
+  "  ld t0, 640(x20); la t1, evm_refund_acc; sd t0, 0(t1)\n" ++
   ".Lfr_sgas_done:\n" ++
   -- Load the saved call-context for the CURRENT (child) depth.
   "  la t0, evm_call_depth\n" ++
@@ -238,7 +242,8 @@ def ziskFrameReturnPrologue : String :=
   -- globals (child state-gas stays accumulated); the +624/632 snapshot is ignored.
   "  la t0, evm_state_gas_left; li t1, 1000; sd t1, 0(t0)\n" ++
   "  la t0, evm_state_gas_used; li t1, 2000; sd t1, 0(t0)\n" ++
-  "  la t0, fr_child_env; li t1, 333; sd t1, 624(t0); li t1, 444; sd t1, 632(t0)\n" ++
+  "  la t0, evm_refund_acc; li t1, 3000; sd t1, 0(t0)\n" ++   -- nxio8.4.2: success leaves refund
+  "  la t0, fr_child_env; li t1, 333; sd t1, 624(t0); li t1, 444; sd t1, 632(t0); li t1, 888; sd t1, 640(t0)\n" ++
   "  li a0, 1; li a1, 0; li a2, 0\n" ++
   "  jal ra, frame_return\n" ++
   "  sd x10, 0(s0)                  # expect 0x101 (parent_pc 0x100 + 1)\n" ++
@@ -257,6 +262,7 @@ def ziskFrameReturnPrologue : String :=
   -- nxio8.4.1: SUCCESS leaves the state-gas globals unchanged (1000/2000).
   "  la t0, evm_state_gas_left; ld t1, 0(t0); sd t1, 160(s0)  # expect 1000\n" ++
   "  la t0, evm_state_gas_used; ld t1, 0(t0); sd t1, 168(s0)  # expect 2000\n" ++
+  "  la t0, evm_refund_acc; ld t1, 0(t0); sd t1, 192(s0)      # expect 3000 (success leaves)\n" ++
   -- ---- Scenario B: depth 2 -> 1, REVERT-style with a returndata byte ----
   "  la t0, evm_call_depth; li t1, 2; sd t1, 0(t0)\n" ++
   -- frame_save_area[1] = (pc=0x300, cb=0x444)
@@ -278,7 +284,8 @@ def ziskFrameReturnPrologue : String :=
   -- entire state-gas allocation; state_gas_used is not accumulated).
   "  la t0, evm_state_gas_left; li t1, 7777; sd t1, 0(t0)\n" ++
   "  la t0, evm_state_gas_used; li t1, 8888; sd t1, 0(t0)\n" ++
-  "  la t0, fr_child_env; li t1, 555; sd t1, 624(t0); li t1, 666; sd t1, 632(t0)\n" ++
+  "  la t0, evm_refund_acc; li t1, 9999; sd t1, 0(t0)\n" ++   -- child-modified refund
+  "  la t0, fr_child_env; li t1, 555; sd t1, 624(t0); li t1, 666; sd t1, 632(t0); li t1, 777; sd t1, 640(t0)\n" ++
   "  li a0, 0; la a1, fr_ret; li a2, 4\n" ++
   "  jal ra, frame_return\n" ++
   "  la t0, call_frame_arena; sub t0, x13, t0; sd t0, 56(s0)   # expect 0\n" ++
@@ -297,6 +304,7 @@ def ziskFrameReturnPrologue : String :=
   -- nxio8.4.1: REVERT restored the state-gas globals to the child-env snapshot.
   "  la t0, evm_state_gas_left; ld t1, 0(t0); sd t1, 176(s0)  # expect 555\n" ++
   "  la t0, evm_state_gas_used; ld t1, 0(t0); sd t1, 184(s0)  # expect 666\n" ++
+  "  la t0, evm_refund_acc; ld t1, 0(t0); sd t1, 200(s0)      # expect 777 (revert restores)\n" ++
   "  j .Lfr_done\n" ++
   frameReturnFunction ++ "\n" ++
   ".Lfr_done:"
@@ -321,6 +329,7 @@ def ziskFrameReturnDataSection : String :=
   -- the guest dispatcher data section; stubbed here so the probe links).
   "evm_state_gas_left:\n  .zero 8\n" ++
   "evm_state_gas_used:\n  .zero 8\n" ++
+  "evm_refund_acc:\n  .zero 8\n" ++
 
   -- Frame-relative stack-bound labels + cells. `evm_stack_top`/`evm_stack_low`
   -- are address-only stubs (frame_return takes their `&` for the depth-0

--- a/scripts/codegen-zisk-call-frame-descend-check.sh
+++ b/scripts/codegen-zisk-call-frame-descend-check.sh
@@ -69,6 +69,8 @@ checks = [
     # env at +624/632 so frame_return can restore it on a child REVERT.
     ('child env state_gas_left snapshot', 12345),
     ('child env state_gas_used snapshot', 67890),
+    # nxio8.4.2: descend also snapshots the EIP-3529 refund accumulator.
+    ('child env refund_acc snapshot',     24680),
 ]
 failed = False
 for i, (label, exp) in enumerate(checks):

--- a/scripts/codegen-zisk-frame-return-check.sh
+++ b/scripts/codegen-zisk-frame-return-check.sh
@@ -70,6 +70,10 @@ checks = [
     ('A state_gas_used (success: unchanged)', 2000),
     ('B state_gas_left (revert: restored)',   555),
     ('B state_gas_used (revert: restored)',   666),
+    # nxio8.4.2: SUCCESS leaves the refund accumulator; REVERT discards the child's
+    # additions by restoring evm_refund_acc to the child-env snapshot.
+    ('A refund_acc (success: unchanged)',     3000),
+    ('B refund_acc (revert: restored)',       777),
 ]
 failed = False
 for i, (label, exp) in enumerate(checks):


### PR DESCRIPTION
Stacked on #8760 (nxio8.4.1). Same descend-snapshot / revert-restore mechanism, extended to the refund accumulator.

## Summary
`incorporate_child_on_error` does **not** add `child.refund_counter` to the parent — a reverted child's gas refunds are discarded with its rolled-back state. The guest accumulates SSTORE refunds into the global `evm_refund_acc`, which a child mutates in place; `frame_return` left it untouched, so a reverted child's refund additions leaked into the parent → over-refund → lower `gas_used` → the EIP-7778 block-gas check too lenient: a latent **false-accept**.

## Fix
`call_frame_descend` snapshots `evm_refund_acc` into the child env (`env+640`, alongside the .4.1 state-gas snapshot at 624/632); `frame_return` restores it on the REVERT/exceptional branch (success leaves it, matching `incorporate_child_on_success`).

## Verification
- Both probes extended + green: `zisk_call_frame_descend` asserts the refund snapshot (24680); `zisk_frame_return` asserts SUCCESS leaves `refund_acc` (3000) and REVERT restores it (777).
- `lake build` + file-size / unimported / forbidden-tactics pass.
- EEST `--no-build` callcall family (child REVERT + SSTORE refund) **24/24 full match**, 0 fail/budget.

nxio8.4.3 (EIP-2929 warmth rollback, exec-log-entangled) remains. Bead: evm-asm-nxio8.4.2.

Authored by @pirapira; implemented by Claude Code