### PR TITLE
fix(dispatcher): discard reverted child's EIP-2929 storage warmth on child REVERT (nxio8.4.3)

### DIFF
--- a/EvmAsm/Codegen/Programs/CallFrameDescend.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameDescend.lean
@@ -314,6 +314,12 @@ def callFrameDescendFunction : String :=
   -- incorporate_child_on_error (which does NOT add child.refund_counter to the
   -- parent). On success it is kept (incorporate_child_on_success accumulates it).
   "  la t1, evm_refund_acc; ld t0, 0(t1); sd t0, 640(s9)       # refund_counter snapshot\n" ++
+  -- nxio8.4.3: snapshot the EIP-2929 storage-warmth count so a child REVERT
+  -- discards the (contract,slot) keys the child warmed — incorporate_child_on_error
+  -- does NOT .update() the parent's accessed_storage_keys (warmth is rolled back).
+  -- The warm-set is append-only; truncating the count on revert reverts the
+  -- additions (the gas already charged stays — regular gas is spent on revert).
+  "  la t1, evm_storage_access_count; ld t0, 0(t1); sd t0, 648(s9)  # warmth count snapshot\n" ++
   -- 9. child env.codeSize (env+496).
   "  ld t0, 72(s7); sd t0, 496(s9)\n" ++
   -- 10. frame-relative stack bounds: point the under/overflow guards at the
@@ -463,6 +469,7 @@ def ziskCallFrameDescendPrologue : String :=
   "  la t0, evm_state_gas_left; li t1, 12345; sd t1, 0(t0)\n" ++
   "  la t0, evm_state_gas_used; li t1, 67890; sd t1, 0(t0)\n" ++
   "  la t0, evm_refund_acc; li t1, 24680; sd t1, 0(t0)\n" ++
+  "  la t0, evm_storage_access_count; li t1, 5; sd t1, 0(t0)\n" ++
   -- to / value words.
   "  la t0, cfd2_to; li t1, 0xbb; sd t1, 0(t0)\n" ++
   "  la t0, cfd2_val; li t1, 0x7; sd t1, 0(t0)\n" ++
@@ -501,6 +508,7 @@ def ziskCallFrameDescendPrologue : String :=
   "  ld t0, 624(x20); sd t0, 176(s0)\n" ++   -- expect 12345 (state_gas_left)
   "  ld t0, 632(x20); sd t0, 184(s0)\n" ++   -- expect 67890 (state_gas_used)
   "  ld t0, 640(x20); sd t0, 192(s0)\n" ++   -- expect 24680 (refund_acc, nxio8.4.2)
+  "  ld t0, 648(x20); sd t0, 200(s0)\n" ++   -- expect 5 (warmth count, nxio8.4.3)
   -- child register bases.
   "  la t1, call_frame_arena; sub t0, x13, t1; sd t0, 56(s0)\n" ++
   "  la t1, call_frame_arena; sub t0, x20, t1; sd t0, 64(s0)\n" ++
@@ -551,6 +559,7 @@ def ziskCallFrameDescendDataSection : String :=
   "evm_state_gas_left:\n  .zero 8\n" ++
   "evm_state_gas_used:\n  .zero 8\n" ++
   "evm_refund_acc:\n  .zero 8\n" ++
+  "evm_storage_access_count:\n  .zero 8\n" ++
   ".balign 8\n" ++
   "cfd2_desc:\n  .zero 96\n" ++
   ".balign 32\n" ++

--- a/EvmAsm/Codegen/Programs/CallFrameReturn.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameReturn.lean
@@ -84,6 +84,12 @@ def frameReturnFunction : String :=
   -- evm_refund_acc to the pre-child snapshot (incorporate_child_on_error does not
   -- add child.refund_counter). Success leaves it (the SSTORE refunds stay).
   "  ld t0, 640(x20); la t1, evm_refund_acc; sd t0, 0(t1)\n" ++
+  -- nxio8.4.3: truncate the EIP-2929 storage-warmth set to the pre-child count,
+  -- discarding keys the reverted child warmed (incorporate_child_on_error rolls
+  -- back accessed_storage_keys). The keys array beyond the count is stale but a
+  -- future cold access overwrites slot[count]. Success leaves it (warmth
+  -- propagates up per incorporate_child_on_success).
+  "  ld t0, 648(x20); la t1, evm_storage_access_count; sd t0, 0(t1)\n" ++
   ".Lfr_sgas_done:\n" ++
   -- Load the saved call-context for the CURRENT (child) depth.
   "  la t0, evm_call_depth\n" ++
@@ -243,7 +249,8 @@ def ziskFrameReturnPrologue : String :=
   "  la t0, evm_state_gas_left; li t1, 1000; sd t1, 0(t0)\n" ++
   "  la t0, evm_state_gas_used; li t1, 2000; sd t1, 0(t0)\n" ++
   "  la t0, evm_refund_acc; li t1, 3000; sd t1, 0(t0)\n" ++   -- nxio8.4.2: success leaves refund
-  "  la t0, fr_child_env; li t1, 333; sd t1, 624(t0); li t1, 444; sd t1, 632(t0); li t1, 888; sd t1, 640(t0)\n" ++
+  "  la t0, evm_storage_access_count; li t1, 11; sd t1, 0(t0)\n" ++   -- nxio8.4.3: success leaves warmth
+  "  la t0, fr_child_env; li t1, 333; sd t1, 624(t0); li t1, 444; sd t1, 632(t0); li t1, 888; sd t1, 640(t0); li t1, 22; sd t1, 648(t0)\n" ++
   "  li a0, 1; li a1, 0; li a2, 0\n" ++
   "  jal ra, frame_return\n" ++
   "  sd x10, 0(s0)                  # expect 0x101 (parent_pc 0x100 + 1)\n" ++
@@ -263,6 +270,7 @@ def ziskFrameReturnPrologue : String :=
   "  la t0, evm_state_gas_left; ld t1, 0(t0); sd t1, 160(s0)  # expect 1000\n" ++
   "  la t0, evm_state_gas_used; ld t1, 0(t0); sd t1, 168(s0)  # expect 2000\n" ++
   "  la t0, evm_refund_acc; ld t1, 0(t0); sd t1, 192(s0)      # expect 3000 (success leaves)\n" ++
+  "  la t0, evm_storage_access_count; ld t1, 0(t0); sd t1, 208(s0)  # expect 11 (success leaves)\n" ++
   -- ---- Scenario B: depth 2 -> 1, REVERT-style with a returndata byte ----
   "  la t0, evm_call_depth; li t1, 2; sd t1, 0(t0)\n" ++
   -- frame_save_area[1] = (pc=0x300, cb=0x444)
@@ -285,7 +293,8 @@ def ziskFrameReturnPrologue : String :=
   "  la t0, evm_state_gas_left; li t1, 7777; sd t1, 0(t0)\n" ++
   "  la t0, evm_state_gas_used; li t1, 8888; sd t1, 0(t0)\n" ++
   "  la t0, evm_refund_acc; li t1, 9999; sd t1, 0(t0)\n" ++   -- child-modified refund
-  "  la t0, fr_child_env; li t1, 555; sd t1, 624(t0); li t1, 666; sd t1, 632(t0); li t1, 777; sd t1, 640(t0)\n" ++
+  "  la t0, evm_storage_access_count; li t1, 33; sd t1, 0(t0)\n" ++   -- child-modified warmth count
+  "  la t0, fr_child_env; li t1, 555; sd t1, 624(t0); li t1, 666; sd t1, 632(t0); li t1, 777; sd t1, 640(t0); li t1, 44; sd t1, 648(t0)\n" ++
   "  li a0, 0; la a1, fr_ret; li a2, 4\n" ++
   "  jal ra, frame_return\n" ++
   "  la t0, call_frame_arena; sub t0, x13, t0; sd t0, 56(s0)   # expect 0\n" ++
@@ -305,6 +314,7 @@ def ziskFrameReturnPrologue : String :=
   "  la t0, evm_state_gas_left; ld t1, 0(t0); sd t1, 176(s0)  # expect 555\n" ++
   "  la t0, evm_state_gas_used; ld t1, 0(t0); sd t1, 184(s0)  # expect 666\n" ++
   "  la t0, evm_refund_acc; ld t1, 0(t0); sd t1, 200(s0)      # expect 777 (revert restores)\n" ++
+  "  la t0, evm_storage_access_count; ld t1, 0(t0); sd t1, 216(s0)  # expect 44 (revert restores)\n" ++
   "  j .Lfr_done\n" ++
   frameReturnFunction ++ "\n" ++
   ".Lfr_done:"
@@ -330,6 +340,7 @@ def ziskFrameReturnDataSection : String :=
   "evm_state_gas_left:\n  .zero 8\n" ++
   "evm_state_gas_used:\n  .zero 8\n" ++
   "evm_refund_acc:\n  .zero 8\n" ++
+  "evm_storage_access_count:\n  .zero 8\n" ++
 
   -- Frame-relative stack-bound labels + cells. `evm_stack_top`/`evm_stack_low`
   -- are address-only stubs (frame_return takes their `&` for the depth-0

--- a/scripts/codegen-zisk-call-frame-descend-check.sh
+++ b/scripts/codegen-zisk-call-frame-descend-check.sh
@@ -71,6 +71,8 @@ checks = [
     ('child env state_gas_used snapshot', 67890),
     # nxio8.4.2: descend also snapshots the EIP-3529 refund accumulator.
     ('child env refund_acc snapshot',     24680),
+    # nxio8.4.3: descend also snapshots the EIP-2929 storage-warmth count.
+    ('child env warmth_count snapshot',   5),
 ]
 failed = False
 for i, (label, exp) in enumerate(checks):

--- a/scripts/codegen-zisk-frame-return-check.sh
+++ b/scripts/codegen-zisk-frame-return-check.sh
@@ -74,6 +74,10 @@ checks = [
     # additions by restoring evm_refund_acc to the child-env snapshot.
     ('A refund_acc (success: unchanged)',     3000),
     ('B refund_acc (revert: restored)',       777),
+    # nxio8.4.3: SUCCESS leaves the EIP-2929 warmth count; REVERT truncates it
+    # back to the child-env snapshot (discarding the reverted child's warm keys).
+    ('A warmth_count (success: unchanged)',   11),
+    ('B warmth_count (revert: restored)',     44),
 ]
 failed = False
 for i, (label, exp) in enumerate(checks):


### PR DESCRIPTION
Stacked on #8761 (nxio8.4.2). **Completes `incorporate_child_on_error` for child frames** (state-gas #8760 + refund #8761 + warmth this PR).

## Summary
On child revert, execution-specs does **not** propagate the child's `accessed_storage_keys` to the parent — warmth is rolled back, so a later access to those (contract,slot) keys is charged **cold** again. The guest's EIP-2929 warm set (`evm_storage_access_keys`/`evm_storage_access_count`) is append-only + global; `frame_return` left it untouched → a reverted child's warmed keys stayed warm → later accesses under-charged regular gas → latent **false-accept**.

## Fix
`call_frame_descend` snapshots `evm_storage_access_count` into the child env (`env+648`); `frame_return` restores it on the REVERT branch, truncating the warm set to the pre-child count (stale keys beyond the count are overwritten by the next cold access). Gas already charged stays (regular gas is spent on revert); success leaves the count (warmth propagates up).

## Verification
- Both probes extended + green: `zisk_call_frame_descend` asserts the warmth snapshot (5); `zisk_frame_return` asserts SUCCESS leaves (11) / REVERT restores (44).
- `lake build` + file-size / unimported / forbidden-tactics pass.
- EEST `--no-build` callcall (nested calls + storage + REVERT) **24/24 full match**, 0 fail/budget.

Bead: evm-asm-nxio8.4.3.

Authored by @pirapira; implemented by Claude Code