### PR TITLE
feat(proofs): reloadRetHandlerSpec + MUL/SIGNEXTEND/BYTE handler specs

### DIFF
--- a/EvmAsm/Codegen/Proofs/HandlerSpecs.lean
+++ b/EvmAsm/Codegen/Proofs/HandlerSpecs.lean
@@ -30,6 +30,8 @@ import EvmAsm.Evm64.MStore8.Spec
 import EvmAsm.Evm64.Dup.Spec
 import EvmAsm.Evm64.Swap.Spec
 import EvmAsm.Evm64.Multiply.Spec
+import EvmAsm.Evm64.SignExtend.Spec
+import EvmAsm.Evm64.Byte.Spec
 import EvmAsm.Evm64.Sub.Spec
 import EvmAsm.Evm64.Lt.Spec
 import EvmAsm.Evm64.Gt.Spec
@@ -1109,6 +1111,84 @@ theorem evmMulHandlerSpec (sp base : Word) (a b : EvmAsm.Evm64.EvmWord)
          EvmAsm.Evm64.evmWordIs (sp + 32) (a * b))) :=
     cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => by xperm_hyp hq) h_body0
   have hlen : EvmAsm.Evm64.evm_mul.length = 63 := by decide
+  exact reloadRetHandlerSpec (by pcFree) (by pcFree) hsave_ne_x0 hlen (by decide) h_body
+    s_init x1_init
+
+-- ============================================================================
+-- 18. Concrete instance — SIGNEXTEND (0x0b), via the reload-handler lift
+-- ============================================================================
+
+/-- Handler-level spec for `h_SIGNEXTEND` (opcode 0x0b). The body clobbers `x10`
+    (post `regOwn`s it), so it lifts through `reloadRetHandlerSpec`. The body is
+    branchy — its step bound (28) is below its instruction count (48) — so we
+    first bump the bound to the length via `cpsTripleWithin_mono_nSteps`, then
+    apply the reload lift. -/
+theorem evmSignExtendHandlerSpec (sp base : Word) (b x : EvmAsm.Evm64.EvmWord)
+    (v5 v6 : Word) (save : Reg) (hsave_ne_x0 : save ≠ .x0)
+    (x10_init s_init x1_init : Word) :
+    cpsTripleWithin (48 + 4) base (x1_init &&& ~~~1)
+      (CodeReq.ofProg base (saveReloadHandlerProgram EvmAsm.Evm64.evm_signextend 1 save))
+      ((save ↦ᵣ s_init) ** (.x10 ↦ᵣ x10_init) **
+        ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
+         EvmAsm.Evm64.evmWordIs sp b ** EvmAsm.Evm64.evmWordIs (sp + 32) x)
+        ** (.x1 ↦ᵣ x1_init))
+      ((save ↦ᵣ x10_init) ** (.x10 ↦ᵣ (x10_init + signExtend12 1)) **
+        ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x6 ** (.x0 ↦ᵣ (0 : Word)) **
+         EvmAsm.Evm64.evmWordIs sp b **
+         EvmAsm.Evm64.evmWordIs (sp + 32) (EvmAsm.Evm64.EvmWord.signextend b x))
+        ** (.x1 ↦ᵣ x1_init)) := by
+  have h0 := EvmAsm.Evm64.evm_signextend_stack_spec_within sp (base + 4) b x v5 v6 x10_init
+  simp only [EvmAsm.Evm64.signextCode] at h0
+  have h1 := cpsTripleWithin_mono_nSteps (show (28 : Nat) ≤ 48 by omega) h0
+  have h_body : cpsTripleWithin 48 (base + 4) ((base + 4) + (192 : Word))
+      (CodeReq.ofProg (base + 4) EvmAsm.Evm64.evm_signextend)
+      ((.x10 ↦ᵣ x10_init) **
+        ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
+         EvmAsm.Evm64.evmWordIs sp b ** EvmAsm.Evm64.evmWordIs (sp + 32) x))
+      (regOwn .x10 **
+        ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x6 ** (.x0 ↦ᵣ (0 : Word)) **
+         EvmAsm.Evm64.evmWordIs sp b **
+         EvmAsm.Evm64.evmWordIs (sp + 32) (EvmAsm.Evm64.EvmWord.signextend b x))) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => by xperm_hyp hq) h1
+  have hlen : EvmAsm.Evm64.evm_signextend.length = 48 := by decide
+  exact reloadRetHandlerSpec (by pcFree) (by pcFree) hsave_ne_x0 hlen (by decide) h_body
+    s_init x1_init
+
+-- ============================================================================
+-- 19. Concrete instance — BYTE (0x1a), via the reload-handler lift
+-- ============================================================================
+
+/-- Handler-level spec for `h_BYTE` (opcode 0x1a). Like SIGNEXTEND: the body
+    clobbers `x10` and is branchy (step bound 29 < instruction count 45), so we
+    bump the bound to the length and lift through `reloadRetHandlerSpec`. -/
+theorem evmByteHandlerSpec (sp base : Word) (idx val : EvmAsm.Evm64.EvmWord)
+    (v5 v6 : Word) (save : Reg) (hsave_ne_x0 : save ≠ .x0)
+    (x10_init s_init x1_init : Word) :
+    cpsTripleWithin (45 + 4) base (x1_init &&& ~~~1)
+      (CodeReq.ofProg base (saveReloadHandlerProgram EvmAsm.Evm64.evm_byte 1 save))
+      ((save ↦ᵣ s_init) ** (.x10 ↦ᵣ x10_init) **
+        ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
+         EvmAsm.Evm64.evmWordIs sp idx ** EvmAsm.Evm64.evmWordIs (sp + 32) val)
+        ** (.x1 ↦ᵣ x1_init))
+      ((save ↦ᵣ x10_init) ** (.x10 ↦ᵣ (x10_init + signExtend12 1)) **
+        ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x6 ** (.x0 ↦ᵣ (0 : Word)) **
+         EvmAsm.Evm64.evmWordIs sp idx **
+         EvmAsm.Evm64.evmWordIs (sp + 32) (EvmAsm.Evm64.EvmWord.byte idx val))
+        ** (.x1 ↦ᵣ x1_init)) := by
+  have h0 := EvmAsm.Evm64.evm_byte_stack_spec_within sp (base + 4) idx val v5 v6 x10_init
+  simp only [EvmAsm.Evm64.evm_byte_code] at h0
+  have h1 := cpsTripleWithin_mono_nSteps (show (29 : Nat) ≤ 45 by omega) h0
+  have h_body : cpsTripleWithin 45 (base + 4) ((base + 4) + (180 : Word))
+      (CodeReq.ofProg (base + 4) EvmAsm.Evm64.evm_byte)
+      ((.x10 ↦ᵣ x10_init) **
+        ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
+         EvmAsm.Evm64.evmWordIs sp idx ** EvmAsm.Evm64.evmWordIs (sp + 32) val))
+      (regOwn .x10 **
+        ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x6 ** (.x0 ↦ᵣ (0 : Word)) **
+         EvmAsm.Evm64.evmWordIs sp idx **
+         EvmAsm.Evm64.evmWordIs (sp + 32) (EvmAsm.Evm64.EvmWord.byte idx val))) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => by xperm_hyp hq) h1
+  have hlen : EvmAsm.Evm64.evm_byte.length = 45 := by decide
   exact reloadRetHandlerSpec (by pcFree) (by pcFree) hsave_ne_x0 hlen (by decide) h_body
     s_init x1_init
 

--- a/EvmAsm/Codegen/Proofs/HandlerSpecs.lean
+++ b/EvmAsm/Codegen/Proofs/HandlerSpecs.lean
@@ -22,6 +22,7 @@
 -/
 
 import EvmAsm.Codegen.Programs
+import EvmAsm.Codegen.Proofs.ReloadHandler
 import EvmAsm.Evm64.Add.Spec
 import EvmAsm.Evm64.Pop.Spec
 import EvmAsm.Evm64.Push0.Spec

--- a/EvmAsm/Codegen/Proofs/HandlerSpecs.lean
+++ b/EvmAsm/Codegen/Proofs/HandlerSpecs.lean
@@ -29,6 +29,7 @@ import EvmAsm.Evm64.Push0.Spec
 import EvmAsm.Evm64.MStore8.Spec
 import EvmAsm.Evm64.Dup.Spec
 import EvmAsm.Evm64.Swap.Spec
+import EvmAsm.Evm64.Multiply.Spec
 import EvmAsm.Evm64.Sub.Spec
 import EvmAsm.Evm64.Lt.Spec
 import EvmAsm.Evm64.Gt.Spec
@@ -1067,5 +1068,48 @@ theorem evmSwapHandlerSpec (sp base : Word) (n : Nat) (hn1 : 1 ≤ n) (hn16 : n 
     rw [this]
   rw [hAdvance] at h
   exact h
+
+-- ============================================================================
+-- 17. Concrete instance — MUL (0x02), via the reload-handler lift
+-- ============================================================================
+
+/-- Handler-level spec for `h_MUL` (opcode 0x02). The MUL body CLOBBERS the
+    EVM code pointer `x10` (it is used as a multiplication scratch register, so
+    `evmMulStackPost` only `regOwn`s it) and so cannot use the clean-ret tail.
+    Instead it lifts through `reloadRetHandlerSpec`: the handler saves `x10`
+    into `save`, runs the 63-instruction `evm_mul` body, reloads `x10`, advances
+    the EVM code pointer by 1, and returns. First application of the reload
+    lift; the same recipe (`rw [evm_X_code_eq_ofProg]`, factor P/Q via `xperm`,
+    apply `reloadRetHandlerSpec`) handles all 7 x10-clobbering opcodes. -/
+theorem evmMulHandlerSpec (sp base : Word) (a b : EvmAsm.Evm64.EvmWord)
+    (v5 v6 v7 v11 : Word) (save : Reg) (hsave_ne_x0 : save ≠ .x0)
+    (x10_init s_init x1_init : Word) :
+    cpsTripleWithin (63 + 4) base (x1_init &&& ~~~1)
+      (CodeReq.ofProg base (saveReloadHandlerProgram EvmAsm.Evm64.evm_mul 1 save))
+      ((save ↦ᵣ s_init) ** (.x10 ↦ᵣ x10_init) **
+        ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) **
+         EvmAsm.Evm64.evmWordIs sp a ** EvmAsm.Evm64.evmWordIs (sp + 32) b)
+        ** (.x1 ↦ᵣ x1_init))
+      ((save ↦ᵣ x10_init) ** (.x10 ↦ᵣ (x10_init + signExtend12 1)) **
+        ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 **
+         memOwn sp ** memOwn (sp + 8) ** memOwn (sp + 16) ** memOwn (sp + 24) **
+         EvmAsm.Evm64.evmWordIs (sp + 32) (a * b))
+        ** (.x1 ↦ᵣ x1_init)) := by
+  have h_body0 := EvmAsm.Evm64.evm_mul_stack_spec_within sp (base + 4) a b v5 v6 v7 x10_init v11
+  rw [EvmAsm.Evm64.evm_mul_code_eq_ofProg] at h_body0
+  unfold EvmAsm.Evm64.evmMulStackPost at h_body0
+  have h_body : cpsTripleWithin 63 (base + 4) ((base + 4) + (252 : Word))
+      (CodeReq.ofProg (base + 4) EvmAsm.Evm64.evm_mul)
+      ((.x10 ↦ᵣ x10_init) **
+        ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) **
+         EvmAsm.Evm64.evmWordIs sp a ** EvmAsm.Evm64.evmWordIs (sp + 32) b))
+      (regOwn .x10 **
+        ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 **
+         memOwn sp ** memOwn (sp + 8) ** memOwn (sp + 16) ** memOwn (sp + 24) **
+         EvmAsm.Evm64.evmWordIs (sp + 32) (a * b))) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => by xperm_hyp hq) h_body0
+  have hlen : EvmAsm.Evm64.evm_mul.length = 63 := by decide
+  exact reloadRetHandlerSpec (by pcFree) (by pcFree) hsave_ne_x0 hlen (by decide) h_body
+    s_init x1_init
 
 end EvmAsm.Codegen.Proofs

--- a/EvmAsm/Codegen/Proofs/ReloadHandler.lean
+++ b/EvmAsm/Codegen/Proofs/ReloadHandler.lean
@@ -15,11 +15,17 @@
 
 import EvmAsm.Rv64.InstructionSpecs
 import EvmAsm.Evm64.CallingConvention
+import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Codegen.Proofs
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.Tactics
 open EvmAsm.Evm64 (cc_ret)
+
+/-- `4 * nSteps` as a 64-bit code-offset Word (local mirror of the private
+    `fourTimes` in HandlerSpecs; the two never collide — both are file-private). -/
+private def fourTimes (nSteps : Nat) : Word := BitVec.ofNat 64 (4 * nSteps)
 
 /-- The save/reload handler ABI: save the EVM code pointer `x10` into `save`,
     run the (x10-clobbering) `body`, reload `x10` from `save`, advance by `n`
@@ -48,30 +54,155 @@ theorem mv_dst_regOwn_spec_within (rd rs : Reg) (v : Word) (addr : Word)
   cpsTripleWithin_of_forall_regIs_to_regOwn
     (fun vOld => mv_spec_within rd rs v vOld addr hrd_ne_x0)
 
-/-
-  ## Remaining step: `reloadRetHandlerSpec`
-
-  With the pieces above, the full lift composes (mirroring `cleanRetHandlerSpec`,
-  HandlerSpecs.lean:95-260, extended from 3 to 5 sub-blocks):
-
-    given  h_body : cpsTripleWithin nSteps (base+4) ((base+4) + fourTimes nSteps)
-                      (ofProg (base+4) body)
-                      (R ** (.x10 ↦ᵣ x10_init)) (S ** regOwn .x10)
-    derive cpsTripleWithin (nSteps+4) base (x1_init &&& ~~~1)
-             (ofProg base (saveReloadHandlerProgram body n save))
-             (R ** (.x10 ↦ᵣ x10_init) ** (.save ↦ᵣ s_init) ** (.x1 ↦ᵣ x1_init))
-             (S ** (.x10 ↦ᵣ (x10_init + signExtend12 n)) ** (.save ↦ᵣ x10_init)
-                ** (.x1 ↦ᵣ x1_init))
-
-  Five sub-blocks: (1) `MV save x10` @ base, (2) body @ base+4, (3)
-  `mv_dst_regOwn_spec_within .x10 save` @ base+4+4·len (consumes regOwn .x10),
-  (4) `ADDI x10 x10 n` @ base+8+4·len, (5) `cc_ret` @ base+12+4·len. Compose
-  with `cpsTripleWithin_seq` + per-pair `CodeReq.Disjoint`; an inter-piece
-  `cpsTripleWithin_weaken`/`xperm` is needed between (1) and (2) (x10 moves
-  from being adjacent to `save` to adjacent to `R`). Apply to Multiply by
-  permuting `evm_mul_stack_spec_within`'s P into `R ** (.x10 ↦ᵣ v10)` form
-  (v10 := x10_init) and Q (= `evmMulStackPost` which carries `regOwn .x10`)
-  into `S ** regOwn .x10`.
--/
+/-- Handler-level lift for an x10-clobbering EVM opcode body. Given a body
+    spec whose precondition owns the EVM code pointer `x10` (at value
+    `x10_init`, separated as `(.x10 ↦ᵣ x10_init) ** R`) and whose
+    postcondition merely *owns* `x10` (`regOwn .x10 ** S`, i.e. the body left
+    garbage in it), the `saveReloadHandlerProgram` wrapper produces a full
+    handler spec: it saves `x10` into `save`, runs the body, reloads `x10`,
+    advances the EVM code pointer by `n`, and returns. The dual of
+    `cleanRetHandlerSpec` for the 7 x10-clobbering opcodes
+    (Multiply/SignExtend/Byte/AddMod/SDiv/SMod/Push). Five sub-blocks composed
+    via `cpsTripleWithin_seq`; the `regOwn .x10` in the body's post is consumed
+    by `mv_dst_regOwn_spec_within`. -/
+theorem reloadRetHandlerSpec
+    {nSteps : Nat} {base : Word} {body : List Instr} {R S : Assertion} {n : BitVec 12}
+    {save : Reg} {x10_init : Word}
+    (hRpcFree : R.pcFree) (hSpcFree : S.pcFree)
+    (hsave_ne_x0 : save ≠ .x0)
+    (hBodyLen : body.length = nSteps)
+    (hBodyLenBound : nSteps < 2 ^ 60)
+    (h_body : cpsTripleWithin nSteps (base + 4) ((base + 4) + fourTimes nSteps)
+                (CodeReq.ofProg (base + 4) body)
+                ((.x10 ↦ᵣ x10_init) ** R) (regOwn .x10 ** S))
+    (s_init x1_init : Word) :
+    cpsTripleWithin (nSteps + 4) base (x1_init &&& ~~~1)
+      (CodeReq.ofProg base (saveReloadHandlerProgram body n save))
+      ((save ↦ᵣ s_init) ** (.x10 ↦ᵣ x10_init) ** R ** (.x1 ↦ᵣ x1_init))
+      ((save ↦ᵣ x10_init) ** (.x10 ↦ᵣ (x10_init + signExtend12 n)) ** S
+        ** (.x1 ↦ᵣ x1_init)) := by
+  have hNBound : (4 * nSteps : Nat) < 2 ^ 64 := by
+    have : (2:Nat)^60 * 4 ≤ 2^64 := by decide
+    omega
+  -- pieces
+  have p1 :
+      cpsTripleWithin 1 base (base + 4) (CodeReq.singleton base (.MV save .x10))
+        ((save ↦ᵣ s_init) ** (.x10 ↦ᵣ x10_init) ** R ** (.x1 ↦ᵣ x1_init))
+        ((save ↦ᵣ x10_init) ** (.x10 ↦ᵣ x10_init) ** R ** (.x1 ↦ᵣ x1_init)) := by
+    have core := mv_spec_within save .x10 x10_init s_init base hsave_ne_x0
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => by xperm_hyp hq)
+      (cpsTripleWithin_frameR (R ** (.x1 ↦ᵣ x1_init)) (pcFree_sepConj hRpcFree pcFree_regIs) core)
+  have p2 :
+      cpsTripleWithin nSteps (base + 4) ((base + 4) + fourTimes nSteps)
+        (CodeReq.ofProg (base + 4) body)
+        ((save ↦ᵣ x10_init) ** (.x10 ↦ᵣ x10_init) ** R ** (.x1 ↦ᵣ x1_init))
+        ((save ↦ᵣ x10_init) ** regOwn .x10 ** S ** (.x1 ↦ᵣ x1_init)) := by
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => by xperm_hyp hq)
+      (cpsTripleWithin_frameL ((save ↦ᵣ x10_init)) pcFree_regIs
+        (cpsTripleWithin_frameR ((.x1 ↦ᵣ x1_init)) pcFree_regIs h_body))
+  have p3 :
+      cpsTripleWithin 1 ((base + 4) + fourTimes nSteps) (((base + 4) + fourTimes nSteps) + 4)
+        (CodeReq.singleton ((base + 4) + fourTimes nSteps) (.MV .x10 save))
+        ((save ↦ᵣ x10_init) ** regOwn .x10 ** S ** (.x1 ↦ᵣ x1_init))
+        ((save ↦ᵣ x10_init) ** (.x10 ↦ᵣ x10_init) ** S ** (.x1 ↦ᵣ x1_init)) := by
+    have core := mv_dst_regOwn_spec_within .x10 save x10_init
+      ((base + 4) + fourTimes nSteps) (by decide)
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => by xperm_hyp hq)
+      (cpsTripleWithin_frameR (S ** (.x1 ↦ᵣ x1_init)) (pcFree_sepConj hSpcFree pcFree_regIs) core)
+  have p4 :
+      cpsTripleWithin 1 (((base + 4) + fourTimes nSteps) + 4) ((((base + 4) + fourTimes nSteps) + 4) + 4)
+        (CodeReq.singleton (((base + 4) + fourTimes nSteps) + 4) (.ADDI .x10 .x10 n))
+        ((save ↦ᵣ x10_init) ** (.x10 ↦ᵣ x10_init) ** S ** (.x1 ↦ᵣ x1_init))
+        ((save ↦ᵣ x10_init) ** (.x10 ↦ᵣ (x10_init + signExtend12 n)) ** S ** (.x1 ↦ᵣ x1_init)) := by
+    have core := addi_spec_same_within .x10 x10_init n (((base + 4) + fourTimes nSteps) + 4) (by decide)
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => by xperm_hyp hq)
+      (cpsTripleWithin_frameL ((save ↦ᵣ x10_init)) pcFree_regIs
+        (cpsTripleWithin_frameR (S ** (.x1 ↦ᵣ x1_init)) (pcFree_sepConj hSpcFree pcFree_regIs) core))
+  have p5 :
+      cpsTripleWithin 1 ((((base + 4) + fourTimes nSteps) + 4) + 4) (x1_init &&& ~~~1)
+        (CodeReq.singleton ((((base + 4) + fourTimes nSteps) + 4) + 4) (.JALR .x0 .x1 0))
+        ((save ↦ᵣ x10_init) ** (.x10 ↦ᵣ (x10_init + signExtend12 n)) ** S ** (.x1 ↦ᵣ x1_init))
+        ((save ↦ᵣ x10_init) ** (.x10 ↦ᵣ (x10_init + signExtend12 n)) ** S ** (.x1 ↦ᵣ x1_init)) := by
+    have core := EvmAsm.Evm64.ret_spec_within' ((((base + 4) + fourTimes nSteps) + 4) + 4) x1_init
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => by xperm_hyp hq)
+      (cpsTripleWithin_frameL ((save ↦ᵣ x10_init) ** (.x10 ↦ᵣ (x10_init + signExtend12 n)) ** S)
+        (pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs hSpcFree)) core)
+  -- disjointness helpers
+  have hbody_none : ∀ (a : Word),
+      (∀ k : Nat, k < nSteps → a ≠ (base + 4) + BitVec.ofNat 64 (4 * k)) →
+      CodeReq.ofProg (base + 4) body a = none := by
+    intro a ha
+    apply CodeReq.ofProg_none_range
+    intro k hk
+    rw [hBodyLen] at hk
+    exact ha k hk
+  have d12 : (CodeReq.singleton base (.MV save .x10)).Disjoint
+      (CodeReq.ofProg (base + 4) body) := by
+    apply CodeReq.Disjoint.singleton_ofProg
+    apply hbody_none; intro k hk heq
+    have : (4 * k : Nat) < 2 ^ 64 := by omega
+    bv_omega
+  have d123 : ((CodeReq.singleton base (.MV save .x10)).union
+      (CodeReq.ofProg (base + 4) body)).Disjoint
+      (CodeReq.singleton ((base + 4) + fourTimes nSteps) (.MV .x10 save)) := by
+    apply CodeReq.Disjoint.union_left
+    · apply CodeReq.Disjoint.singleton; simp only [fourTimes]; bv_omega
+    · apply CodeReq.Disjoint.ofProg_singleton
+      apply hbody_none; intro k hk heq
+      simp only [fourTimes] at heq
+      have : (4 * k : Nat) < 2 ^ 64 := by omega
+      bv_omega
+  have d1234 : (((CodeReq.singleton base (.MV save .x10)).union
+      (CodeReq.ofProg (base + 4) body)).union
+      (CodeReq.singleton ((base + 4) + fourTimes nSteps) (.MV .x10 save))).Disjoint
+      (CodeReq.singleton (((base + 4) + fourTimes nSteps) + 4) (.ADDI .x10 .x10 n)) := by
+    apply CodeReq.Disjoint.union_left
+    · apply CodeReq.Disjoint.union_left
+      · apply CodeReq.Disjoint.singleton; simp only [fourTimes]; bv_omega
+      · apply CodeReq.Disjoint.ofProg_singleton
+        apply hbody_none; intro k hk heq
+        simp only [fourTimes] at heq
+        have : (4 * k : Nat) < 2 ^ 64 := by omega
+        bv_omega
+    · apply CodeReq.Disjoint.singleton; bv_omega
+  have d12345 : ((((CodeReq.singleton base (.MV save .x10)).union
+      (CodeReq.ofProg (base + 4) body)).union
+      (CodeReq.singleton ((base + 4) + fourTimes nSteps) (.MV .x10 save))).union
+      (CodeReq.singleton (((base + 4) + fourTimes nSteps) + 4) (.ADDI .x10 .x10 n))).Disjoint
+      (CodeReq.singleton ((((base + 4) + fourTimes nSteps) + 4) + 4) (.JALR .x0 .x1 0)) := by
+    apply CodeReq.Disjoint.union_left
+    · apply CodeReq.Disjoint.union_left
+      · apply CodeReq.Disjoint.union_left
+        · apply CodeReq.Disjoint.singleton; simp only [fourTimes]; bv_omega
+        · apply CodeReq.Disjoint.ofProg_singleton
+          apply hbody_none; intro k hk heq
+          simp only [fourTimes] at heq
+          have : (4 * k : Nat) < 2 ^ 64 := by omega
+          bv_omega
+      · apply CodeReq.Disjoint.singleton; simp only [fourTimes]; bv_omega
+    · apply CodeReq.Disjoint.singleton; bv_omega
+  -- seq compose
+  have s12 := cpsTripleWithin_seq d12 p1 p2
+  have s123 := cpsTripleWithin_seq d123 s12 p3
+  have s1234 := cpsTripleWithin_seq d1234 s123 p4
+  have s12345 := cpsTripleWithin_seq d12345 s1234 p5
+  -- align CodeReq
+  have hCodeEq :
+      ((((CodeReq.singleton base (.MV save .x10)).union
+        (CodeReq.ofProg (base + 4) body)).union
+        (CodeReq.singleton ((base + 4) + fourTimes nSteps) (.MV .x10 save))).union
+        (CodeReq.singleton (((base + 4) + fourTimes nSteps) + 4) (.ADDI .x10 .x10 n))).union
+        (CodeReq.singleton ((((base + 4) + fourTimes nSteps) + 4) + 4) (.JALR .x0 .x1 0))
+      = CodeReq.ofProg base (saveReloadHandlerProgram body n save) := by
+    change _ = CodeReq.ofProg base
+      ([Instr.MV save .x10] ++ (body ++ ([Instr.MV .x10 save] ++
+        ([Instr.ADDI .x10 .x10 n] ++ [Instr.JALR .x0 .x1 0]))))
+    rw [CodeReq.ofProg_append, CodeReq.ofProg_append, CodeReq.ofProg_append,
+      CodeReq.ofProg_append]
+    simp only [CodeReq.ofProg_singleton, List.length_cons, List.length_nil,
+      hBodyLen, fourTimes, ← CodeReq.union_assoc]
+    repeat' congr 1
+  rw [← hCodeEq, show nSteps + 4 = 1 + nSteps + 1 + 1 + 1 from by omega]
+  exact s12345
 
 end EvmAsm.Codegen.Proofs

--- a/EvmAsm/Codegen/Proofs/ReloadHandler.lean
+++ b/EvmAsm/Codegen/Proofs/ReloadHandler.lean
@@ -1,0 +1,77 @@
+/-
+  EvmAsm.Codegen.Proofs.ReloadHandler
+
+  Handler-level lift infrastructure for EVM opcode bodies that CLOBBER the
+  dispatcher's EVM code pointer `x10` (Multiply, SignExtend, Byte, AddMod,
+  SDiv, SMod, Push). Unlike the `cleanRetHandler` (which advances the
+  surviving `x10`), these bodies need `x10` saved before the body and reloaded
+  from the saved register after, before the advance-and-return tail.
+
+  This file provides the foundational, kernel-checked pieces; the full
+  `reloadRetHandlerSpec` lift (composing the five pieces below, mirroring
+  `cleanRetHandlerSpec` in HandlerSpecs.lean) is the remaining step — see the
+  module note at the bottom.
+-/
+
+import EvmAsm.Rv64.InstructionSpecs
+import EvmAsm.Evm64.CallingConvention
+
+namespace EvmAsm.Codegen.Proofs
+
+open EvmAsm.Rv64
+open EvmAsm.Evm64 (cc_ret)
+
+/-- The save/reload handler ABI: save the EVM code pointer `x10` into `save`,
+    run the (x10-clobbering) `body`, reload `x10` from `save`, advance by `n`
+    bytes, and return via `cc_ret`. The dual of `cleanRetHandlerProgram` for
+    x10-clobbering bodies. -/
+def saveReloadHandlerProgram (body : Program) (n : BitVec 12) (save : Reg) : Program :=
+  MV save .x10 ;; body ;; MV .x10 save ;; (Rv64.ADDI .x10 .x10 n) ;; cc_ret
+
+theorem saveReloadHandlerProgram_length (body : Program) (n : BitVec 12) (save : Reg) :
+    (saveReloadHandlerProgram body n save).length = body.length + 4 := by
+  simp only [saveReloadHandlerProgram, seq, MV, Rv64.ADDI, cc_ret, JALR, single,
+    Program.length_append, List.length_cons, List.length_nil]
+  omega
+
+/-- `MV rd rs` consuming a *don't-care* (owned) destination value — the novel
+    step in the reload tail: the reloaded `x10` discards the body's garbage
+    value. Built directly from `mv_spec_within` via the regOwn-elimination
+    rule `cpsTripleWithin_of_forall_regIs_to_regOwn`. This is the piece that
+    resolves the `regOwn .x10` in an x10-clobbering body's postcondition
+    (e.g. `evmMulStackPost`). -/
+theorem mv_dst_regOwn_spec_within (rd rs : Reg) (v : Word) (addr : Word)
+    (hrd_ne_x0 : rd ≠ .x0) :
+    cpsTripleWithin 1 addr (addr + 4) (CodeReq.singleton addr (.MV rd rs))
+      ((rs ↦ᵣ v) ** regOwn rd)
+      ((rs ↦ᵣ v) ** (rd ↦ᵣ v)) :=
+  cpsTripleWithin_of_forall_regIs_to_regOwn
+    (fun vOld => mv_spec_within rd rs v vOld addr hrd_ne_x0)
+
+/-
+  ## Remaining step: `reloadRetHandlerSpec`
+
+  With the pieces above, the full lift composes (mirroring `cleanRetHandlerSpec`,
+  HandlerSpecs.lean:95-260, extended from 3 to 5 sub-blocks):
+
+    given  h_body : cpsTripleWithin nSteps (base+4) ((base+4) + fourTimes nSteps)
+                      (ofProg (base+4) body)
+                      (R ** (.x10 ↦ᵣ x10_init)) (S ** regOwn .x10)
+    derive cpsTripleWithin (nSteps+4) base (x1_init &&& ~~~1)
+             (ofProg base (saveReloadHandlerProgram body n save))
+             (R ** (.x10 ↦ᵣ x10_init) ** (.save ↦ᵣ s_init) ** (.x1 ↦ᵣ x1_init))
+             (S ** (.x10 ↦ᵣ (x10_init + signExtend12 n)) ** (.save ↦ᵣ x10_init)
+                ** (.x1 ↦ᵣ x1_init))
+
+  Five sub-blocks: (1) `MV save x10` @ base, (2) body @ base+4, (3)
+  `mv_dst_regOwn_spec_within .x10 save` @ base+4+4·len (consumes regOwn .x10),
+  (4) `ADDI x10 x10 n` @ base+8+4·len, (5) `cc_ret` @ base+12+4·len. Compose
+  with `cpsTripleWithin_seq` + per-pair `CodeReq.Disjoint`; an inter-piece
+  `cpsTripleWithin_weaken`/`xperm` is needed between (1) and (2) (x10 moves
+  from being adjacent to `save` to adjacent to `R`). Apply to Multiply by
+  permuting `evm_mul_stack_spec_within`'s P into `R ** (.x10 ↦ᵣ v10)` form
+  (v10 := x10_init) and Q (= `evmMulStackPost` which carries `regOwn .x10`)
+  into `S ** regOwn .x10`.
+-/
+
+end EvmAsm.Codegen.Proofs


### PR DESCRIPTION
## Summary
Adds the full handler-level lift for EVM opcode bodies that **clobber** the dispatcher's EVM code pointer `x10`, plus its first concrete application.

`EvmAsm/Codegen/Proofs/ReloadHandler.lean`:
- **`saveReloadHandlerProgram`** + length lemma — the save/reload ABI (`MV save x10 ;; body ;; MV x10 save ;; ADDI x10 x10 n ;; cc_ret`), the dual of `cleanRetHandlerProgram`.
- **`mv_dst_regOwn_spec_within`** — `MV` consuming a `regOwn` destination, resolving the `regOwn .x10` in clobbering bodies' postconditions.
- **`reloadRetHandlerSpec`** — the full 5-sub-block lift (composed via `cpsTripleWithin_seq` + `CodeReq.Disjoint`, framed via `cpsTripleWithin_frameL/R` + `xperm`).

`EvmAsm/Codegen/Proofs/HandlerSpecs.lean`:
- **`evmMulHandlerSpec`** (MUL 0x02) — first application: `rw [evm_mul_code_eq_ofProg]` to put the body in `ofProg` form, factor the body spec's P/Q into `(.x10 ↦ x10_init) ** R` / `regOwn .x10 ** S` via `cpsTripleWithin_weaken` + `xperm`, then apply `reloadRetHandlerSpec`. The same recipe handles the other 6 (SignExtend/Byte/AddMod/SDiv/SMod/Push).

All `#print axioms` ⇒ `[propext, Classical.choice, Quot.sound]` only. Opcode coverage now **21 of ~31**.

## Context
Follow-up to #8762 / #8765. The reload lift was the single hardest remaining piece of the opcode-proof layer; with MUL proven through it, the remaining 6 x10-clobbering opcodes are mechanical. Bead evm-asm-z7vt5.

Authored by @pirapira; implemented by Claude Code