### PR TITLE
feat(codegen): emit create_initcode_size_valid from the cpsTriple-proven cisvProgram

### DIFF
--- a/EvmAsm/Codegen/Programs/CreateInitcodeSizeValid.lean
+++ b/EvmAsm/Codegen/Programs/CreateInitcodeSizeValid.lean
@@ -22,6 +22,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 
 namespace EvmAsm.Codegen
 
@@ -30,17 +31,23 @@ open EvmAsm.Rv64
 /-- EIP-3860 MAX_INITCODE_SIZE (bytes) = 2 * Amsterdam/EIP-7954 MAX_CODE_SIZE (32768) = 65536. -/
 def maxInitcodeSize : Nat := 65536
 
+/-- The `create_initcode_size_valid` body as a STRUCTURED RV64 program (a0=x10,
+    t0=x5; `bgtu a0,t0,L` ≡ `bltu x5,x10,.+12`, `ret` ≡ `jalr x0,0(x1)`). This is
+    what `emitProgram` renders below — byte-identical to the former hand-written
+    asm — and what `EvmAsm.Codegen.Proofs.cisv_spec` proves as a `cpsTriple`:
+    `a0 := (if maxInitcodeSize < len then 1 else 0); return`. -/
+def cisvProgram : Program :=
+  [ .LI .x5 (65536 : Word), .BLTU .x5 .x10 (12 : BitVec 13),
+    .LI .x10 (0 : Word), .JALR .x0 .x1 0,
+    .LI .x10 (1 : Word), .JALR .x0 .x1 0 ]
+
 /-! ## create_initcode_size_valid
     a0 = init code length (bytes)
     a0 (output) = 0 valid / 1 invalid (len > MAX_INITCODE_SIZE).
-    Leaf; clobbers t0. -/
+    Leaf; clobbers t0. Emitted from the verified `cisvProgram` (cpsTriple-proven
+    by `cisv_spec`); byte-identical to the prior hand-written asm. -/
 def createInitcodeSizeValidFunction : String :=
-  "create_initcode_size_valid:\n" ++
-  "  li t0, " ++ toString maxInitcodeSize ++ "\n" ++
-  "  bgtu a0, t0, .Lcisv_invalid    # len > MAX_INITCODE_SIZE (EIP-3860)\n" ++
-  "  li a0, 0; ret\n" ++
-  ".Lcisv_invalid:\n" ++
-  "  li a0, 1; ret"
+  "create_initcode_size_valid:\n" ++ emitProgram cisvProgram
 
 /-- `zisk_create_initcode_size_valid`: known-answer probe. Surfaces 4 results to
     OUTPUT (0xa0010000):

--- a/EvmAsm/Codegen/Proofs/CreateInitcodeSizeValidSpec.lean
+++ b/EvmAsm/Codegen/Proofs/CreateInitcodeSizeValidSpec.lean
@@ -21,6 +21,7 @@
 import EvmAsm.Rv64.InstructionSpecs
 import EvmAsm.Evm64.CallingConvention
 import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Codegen.Programs.CreateInitcodeSizeValid
 namespace EvmAsm.Rv64
 open EvmAsm.Rv64.Tactics
 
@@ -118,4 +119,20 @@ theorem cisv_spec (base v5old len x1_init : Word) :
     · apply CodeReq.Disjoint.union_right <;> apply CodeReq.Disjoint.union_right <;>
         apply CodeReq.Disjoint.singleton <;> bv_omega
   exact cpsTripleWithin_seq hdpro hpro hmerge
+
+/-
+  DEPLOYMENT LINK. `cisv_spec`'s code is the disjoint union of the six
+  singletons at `base, base+4, base+8, …, base+20` — i.e. exactly
+  `CodeReq.ofProg base EvmAsm.Codegen.cisvProgram` (the six-instruction structured
+  program). The codegen now emits this gate via `emitProgram cisvProgram`
+  (CreateInitcodeSizeValid.lean), byte-identical to the former hand-written asm
+  (`bgtu a0,t0,L` ≡ `bltu x5,x10,.+12`, `ret` ≡ `jalr x0,0(x1)`,
+  `li t0,65536` = `lui` = `li x5,65536`) and probe-verified
+  (scripts/codegen-zisk-create-initcode-size-valid-check.sh: len 0/32/65536/65537
+  → 0/0/0/1). So the deployed `create_initcode_size_valid` block carries this
+  cpsTriple. A single named restatement over `ofProg base cisvProgram` is a
+  cosmetic follow-up (needs a CodeReq union-AC/funext alignment).
+-/
+
+end EvmAsm.Rv64
 

--- a/EvmAsm/Codegen/Proofs/CreateInitcodeSizeValidSpec.lean
+++ b/EvmAsm/Codegen/Proofs/CreateInitcodeSizeValidSpec.lean
@@ -120,19 +120,57 @@ theorem cisv_spec (base v5old len x1_init : Word) :
         apply CodeReq.Disjoint.singleton <;> bv_omega
   exact cpsTripleWithin_seq hdpro hpro hmerge
 
-/-
-  DEPLOYMENT LINK. `cisv_spec`'s code is the disjoint union of the six
-  singletons at `base, base+4, base+8, …, base+20` — i.e. exactly
-  `CodeReq.ofProg base EvmAsm.Codegen.cisvProgram` (the six-instruction structured
-  program). The codegen now emits this gate via `emitProgram cisvProgram`
-  (CreateInitcodeSizeValid.lean), byte-identical to the former hand-written asm
-  (`bgtu a0,t0,L` ≡ `bltu x5,x10,.+12`, `ret` ≡ `jalr x0,0(x1)`,
-  `li t0,65536` = `lui` = `li x5,65536`) and probe-verified
-  (scripts/codegen-zisk-create-initcode-size-valid-check.sh: len 0/32/65536/65537
-  → 0/0/0/1). So the deployed `create_initcode_size_valid` block carries this
-  cpsTriple. A single named restatement over `ofProg base cisvProgram` is a
-  cosmetic follow-up (needs a CodeReq union-AC/funext alignment).
--/
+/-- Commutativity of `CodeReq.union` for disjoint code maps. No general
+    `union_comm` holds (overlapping maps prefer their left argument), but for
+    disjoint maps the order is irrelevant — exactly what the deployment-link
+    alignment below needs to match `ofProg`'s sequential layout to `cisv_spec`'s
+    branch-merge layout. -/
+theorem CodeReq.union_comm_of_disjoint {cr1 cr2 : CodeReq} (hd : cr1.Disjoint cr2) :
+    cr1.union cr2 = cr2.union cr1 := by
+  funext a
+  simp only [CodeReq.union]
+  rcases hd a with h1 | h2
+  · rw [h1]; cases cr2 a <;> rfl
+  · rw [h2]; cases cr1 a <;> rfl
+
+/-- The DEPLOYED gate carries the cpsTriple. `cisv_spec` restated over
+    `CodeReq.ofProg base EvmAsm.Codegen.cisvProgram` — the six-instruction
+    STRUCTURED program the codegen actually emits (via `emitProgram`,
+    byte-identical to the prior asm, probe-verified 0/0/0/1). This is the
+    explicit proof↔deployment link: the emitted `create_initcode_size_valid`
+    block satisfies `a0 := (if 65536 < len then 1 else 0); return`. The alignment
+    reassociates `ofProg`'s sequential six-singleton layout into `cisv_spec`'s
+    branch-merge layout (arms reordered) via `union_comm_of_disjoint`. -/
+theorem cisv_deployed_spec (base v5old len x1_init : Word) :
+    cpsTripleWithin 4 base (x1_init &&& ~~~1)
+      (CodeReq.ofProg base EvmAsm.Codegen.cisvProgram)
+      ((.x5 ↦ᵣ v5old) ** (.x10 ↦ᵣ len) ** (.x1 ↦ᵣ x1_init))
+      ((.x5 ↦ᵣ (65536 : Word)) **
+       (.x10 ↦ᵣ (if BitVec.ult (65536 : Word) len then (1 : Word) else 0)) **
+       (.x1 ↦ᵣ x1_init)) := by
+  have hAB : ((CodeReq.singleton (base + 8) (.LI .x10 (0 : Word))).union
+        (CodeReq.singleton (base + 8 + 4) (.JALR .x0 .x1 0))).Disjoint
+      ((CodeReq.singleton (base + 16) (.LI .x10 (1 : Word))).union
+        (CodeReq.singleton (base + 16 + 4) (.JALR .x0 .x1 0))) := by
+    apply CodeReq.Disjoint.union_left <;> apply CodeReq.Disjoint.union_right <;>
+      apply CodeReq.Disjoint.singleton <;> bv_omega
+  have hcode : CodeReq.ofProg base EvmAsm.Codegen.cisvProgram =
+      ((CodeReq.singleton base (.LI .x5 (65536 : Word))).union
+        ((CodeReq.singleton (base + 4) (.BLTU .x5 .x10 (12 : BitVec 13))).union
+          (((CodeReq.singleton (base + 16) (.LI .x10 (1 : Word))).union
+              (CodeReq.singleton (base + 16 + 4) (.JALR .x0 .x1 0))).union
+           ((CodeReq.singleton (base + 8) (.LI .x10 (0 : Word))).union
+              (CodeReq.singleton (base + 8 + 4) (.JALR .x0 .x1 0)))))) := by
+    simp only [EvmAsm.Codegen.cisvProgram]
+    rw [CodeReq.ofProg_cons, CodeReq.ofProg_cons, CodeReq.ofProg_cons,
+        CodeReq.ofProg_cons, CodeReq.ofProg_cons, CodeReq.ofProg_singleton]
+    rw [show ((base + 4) + 4 : Word) = base + 8 from by bv_omega,
+        show ((base + 8) + 4 + 4 : Word) = base + 16 from by bv_omega]
+    congr 1
+    congr 1
+    rw [← CodeReq.union_assoc]
+    exact CodeReq.union_comm_of_disjoint hAB
+  rw [hcode]; exact cisv_spec base v5old len x1_init
 
 end EvmAsm.Rv64
 


### PR DESCRIPTION
## Summary
Completes the first verdict-glue cpsTriple **end-to-end**, connecting the proof (`cisv_spec`, #8771) to the deployed `create_initcode_size_valid` gate two ways:

**1. Codegen emits the proven program.** The gate is now emitted via `emitProgram` of the **structured `cisvProgram`** — the exact program `cisv_spec` proves — instead of a hand-written asm string.
- **Byte-identical** to the prior asm: `bgtu a0,t0,L` ≡ `bltu x5,x10,.+12` (`t0`=x5, `a0`=x10), `ret` ≡ `jalr x0,0(x1)`, `li t0,65536` = `lui` = `li x5,65536`.
- **Probe-verified**: `scripts/codegen-zisk-create-initcode-size-valid-check.sh` passes (len 0/32/65536/65537 → 0/0/0/1).

**2. A formal proof↔deployment theorem** (`cisv_deployed_spec`). `cisv_spec` restated over `CodeReq.ofProg base cisvProgram` — i.e. over the *exact structured program the codegen emits*. So the deployed block formally carries the cpsTriple `a0 := (if 65536 < len then 1 else 0); return`. The alignment reassociates `ofProg`'s sequential six-singleton layout into `cisv_spec`'s branch-merge layout via a new general lemma `CodeReq.union_comm_of_disjoint`. Axiom-clean (`propext`/`Classical.choice`/`Quot.sound` only).

So the **deployed** `create_initcode_size_valid` block now carries a kernel-checkable Hoare triple — a first concrete instance of the north star's "every codegen'd RV64 block carries a cpsTriple" *in the verdict layer, on code that runs in the guest and passes its test*.

Bead: evm-asm-x43os.

Authored by @pirapira; implemented by Claude Code