### PR TITLE
fix(verdict): hoist fee-validity check to run unconditionally for single-tx (bmvmx.5)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -1094,6 +1094,12 @@ def ziskStatelessVerdictV2DataSection : String :=
   ".balign 8\n" ++
   "bv_upfront_cost:\n  .zero 32\n" ++
   "bv_upfront_islt:\n  .zero 8\n" ++
+  -- bmvmx.5: out scratch for the hoisted single-tx fee-validity gate's
+  -- tx_effective_gas_pricing call (effective_gas_price / priority_fee_per_gas, 32B BE
+  -- each). Only the call's status (2/3) is consumed; the values are unused here.
+  ".balign 8\n" ++
+  "bv_fee_egp_scratch:\n  .zero 32\n" ++
+  "bv_fee_prio_scratch:\n  .zero 32\n" ++
   -- bmvmx.1.6.6: scratch for the all-accounts per-slot tuple-sequence check (#8606). batsc_* is
   -- the wrapper's own scratch; the sub-helpers' scratch (atsc_*/bts_*/els_*) come from their Data
   -- defs. rfu_* (rlp_field_to_u64) is already provided above; slot_tuple_sequences_match is

--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -511,6 +511,29 @@ def blockVerdictFunction : String :=
   "  la a0, bv_simple_transfer_tx\n" ++
   "  jal ra, simple_transfer_tx_context\n" ++
   "  la t2, bv_simple_transfer_tx; ld t0, 0(t2); bnez t0, .Lbv_after_tx_gas_precharge\n" ++
+  -- bmvmx.5 (fee-validity hoist, single-tx): the spec check_transaction fee-validity
+  -- pre-conditions -- max_fee_per_gas >= base_fee_per_gas (InsufficientMaxFeePerGasError)
+  -- and max_priority_fee_per_gas <= max_fee_per_gas (PriorityFeeGreaterThanMaxFeeError,
+  -- amsterdam/fork.py check_transaction) -- are PATH-INDEPENDENT: they read only the tx
+  -- fee fields and the block base_fee, no execution or sender lookup. They were enforced
+  -- ONLY inside the value-movement-free contract path (.Lbv_sbc_safe status 50, ~line 1006),
+  -- so a value-MOVING contract recipient (CALL/DELEGATECALL/SELFDESTRUCT bytecode), a
+  -- coinbase sender, or a block with withdrawals collateral-SKIPPED the fee check -- a
+  -- latent false-accept (an adversarial max_fee<base_fee / priority>max_fee tx on those
+  -- paths is spec-rejected but guest-accepted). Hoist it here, UNCONDITIONALLY for the
+  -- single tx, before the value-move / EOA-vs-contract split. tx_effective_gas_pricing
+  -- returns 2 (priority>max_fee) / 3 (max_fee<base_fee) for exactly those two spec errors;
+  -- status 1 (extraction failed) / 4 (egp overflow) are "cannot determine" -> fall through
+  -- (never newly false-reject). A valid block never carries such a tx, so this only ADDS
+  -- rejects the spec also makes -- strictly sound, no false-reject. (Multi-tx loop fee gate
+  -- + the nonce-eligibility/upfront-balance hoists are bmvmx.5 follow-ups.)
+  "  la t2, bv_simple_transfer_tx\n" ++
+  "  ld a0, 8(t2); ld a1, 16(t2); ld a2, 32(t2)\n" ++           -- tx ptr, tx len, base_fee_per_gas ptr
+  "  la a3, bv_fee_egp_scratch; la a4, bv_fee_prio_scratch\n" ++
+  "  jal ra, tx_effective_gas_pricing\n" ++
+  "  li t1, 2; beq a0, t1, .Lbv_fee_invalid_fail\n" ++          -- priority_fee > max_fee -> reject
+  "  li t1, 3; beq a0, t1, .Lbv_fee_invalid_fail\n" ++          -- max_fee < base_fee -> reject
+  "  la t2, bv_simple_transfer_tx\n" ++                         -- restore t2 (jal clobbered it) for the code-hash route below
   -- evm-asm-fhsxz.2.4.2.57.11.6.4.3.2: route a contract recipient (non-empty code)
   -- to the execution-derived contract dispatch; EOA (empty-code) recipients fall
   -- through to the existing simple-transfer path BYTE-IDENTICALLY (no regression).


### PR DESCRIPTION
## Summary

Closes the single-tx slice of **bmvmx.5** (check_transaction coverage gap): the spec's fee-validity pre-conditions are now enforced unconditionally per single tx, not just on the value-movement-free contract branch.

The spec `check_transaction` fee-validity pre-conditions — `max_fee_per_gas >= base_fee_per_gas` (`InsufficientMaxFeePerGasError`) and `max_priority_fee_per_gas <= max_fee_per_gas` (`PriorityFeeGreaterThanMaxFeeError`, amsterdam/fork.py) — are **path-independent**: they read only the tx fee fields and the block `base_fee`, with no execution or sender lookup.

On the single-tx path they were enforced **only** inside the value-movement-free contract branch (`.Lbv_sbc_safe` status 50, `BlockVerdictFunction.lean:~1006`). So a **value-MOVING** contract recipient (CALL/DELEGATECALL/SELFDESTRUCT bytecode), a **coinbase sender**, or a block **carrying withdrawals** collateral-SKIPPED the fee check — a latent **false-accept**: an adversarial `max_fee<base_fee` / `priority>max_fee` tx on those paths is spec-rejected but the guest accepted it.

## Fix

Hoist the check into the single-tx path right after `simple_transfer_tx_context`, **before** the value-move / EOA-vs-contract split, so it runs unconditionally for every reachable single tx (EOA + empty-calldata-to-contract, value-moving or not, withdrawal blocks or not).

- Reuses the already-linked, probe-validated `tx_effective_gas_pricing` helper: status **2** (priority>max_fee) / **3** (max_fee<base_fee) are exactly the two spec errors; status **1** (extraction failed) / **4** (egp overflow) are "cannot determine" → fall through (never newly false-reject).
- Reuses the existing `.Lbv_fee_invalid_fail` reject path (fail code 49).
- Adds two 32B output scratch buffers (only the helper's status is consumed).

**Soundness:** strictly additive — a valid block never carries a `max_fee<base_fee` or `priority>max_fee` tx (consensus requires fee validity), so this only ADDS rejects the spec also makes. No false-reject by construction (reads the same `bv_simple_transfer_tx[32]` base_fee the existing line-996 check uses).

## Validation

- Full `lake build` green; `stateless_guest` ELF assembles.
- `check-forbidden-tactics` / `check-file-size` / `check-unimported` all pass.
- `codegen-eest-eip7708-simple-transfer-check.sh` (single-tx EOA — the gate's own path): **full match 1/1** (all 105 bytes), no regression.
- No proofs touched → axioms unaffected.

## Follow-ups (bmvmx.5 remainder)

- Multi-tx loop fee gate (parallel insertion after `multi_tx_nth_context`).
- Nonce-eligibility (`tx.nonce == pre`) + upfront-balance hoists (these need the sender BAL lookup, so they require splitting `tx_gas_bal_post_verify_runtime`'s pre-validation half out of the value-move guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)