### PR TITLE
fix(dispatcher): charge code-deposit state gas on CREATE deposit (nxio8.6)

### DIFF
--- a/EvmAsm/Codegen/Programs/NoopHalt.lean
+++ b/EvmAsm/Codegen/Programs/NoopHalt.lean
@@ -58,6 +58,30 @@ private def returnRevertTail (kind : Nat) (rollbackAsm : String := "")
       "  add a0, x13, x14\n  mv a1, x15\n" ++
       "  jal ra, create_deployed_code_valid\n" ++
       "  bnez a0, .Lrr_crinv_" ++ toString kind ++ "\n" ++
+      -- nxio8.6: charge code-deposit STATE gas = deployed_code_len(x15) * COST_PER_STATE_BYTE(1530)
+      -- (spec amsterdam vm/interpreter.py:241-242 charge_state_gas(evm, ulen(code)*1530), AFTER the
+      -- 0xEF/MAX_CODE_SIZE validity gate just above, BEFORE the deposit). Mirrors the SSTORE
+      -- charge_state_gas pattern (Storage.lean): drain the global evm_state_gas_left reservoir; spill
+      -- the remainder into the child frame gas_left (568(x20) = child env, before frame_return); if
+      -- both are short, OOG-FAIL the CREATE (consume all child gas, push 0 via .Lrr_crinv) -- a valid
+      -- block never OOGs at deposit, so no false-reject. evm_state_gas_used += charge on the non-OOG
+      -- paths (spec raises BEFORE state_gas_used += amount; gas.py:302-311). Previously DROPPED ->
+      -- state gas under-counted -> EIP-7778/8037 state budget too lenient (false-accept on state-heavy
+      -- creation blocks); this makes the exec state gas (bvgr_tx_exec_state_gas) spec-accurate.
+      -- x13/x14/x15 preserved by create_deployed_code_valid (#8629) and untouched here (only t0-t3 +
+      -- the child gas_left). x15 <= MAX_CODE_SIZE (0x8000) so x15*1530 cannot overflow u64.
+      "  li t0, 1530\n  mul t0, x15, t0\n" ++
+      "  la t1, evm_state_gas_left\n  ld t2, 0(t1)\n" ++
+      "  bgeu t2, t0, .Lrr_csg_res_" ++ toString kind ++ "\n" ++
+      "  sub t3, t0, t2\n  sd x0, 0(t1)\n" ++                                  -- reservoir short: spill = charge - reservoir; reservoir = 0
+      "  ld t2, 568(x20)\n  bgeu t2, t3, .Lrr_csg_spill_" ++ toString kind ++ "\n" ++  -- child gas_left >= spill -> ok
+      "  sd x0, 568(x20)\n  j .Lrr_crinv_" ++ toString kind ++ "\n" ++         -- OOG: consume all child gas, CREATE fails
+      ".Lrr_csg_spill_" ++ toString kind ++ ":\n" ++
+      "  sub t2, t2, t3\n  sd t2, 568(x20)\n  j .Lrr_csg_used_" ++ toString kind ++ "\n" ++
+      ".Lrr_csg_res_" ++ toString kind ++ ":\n" ++
+      "  sub t2, t2, t0\n  sd t2, 0(t1)\n" ++                                  -- reservoir covers it
+      ".Lrr_csg_used_" ++ toString kind ++ ":\n" ++
+      "  la t1, evm_state_gas_used\n  ld t2, 0(t1)\n  add t2, t2, t0\n  sd t2, 0(t1)\n" ++
       "  la a0, create_address_be\n  add a1, x13, x14\n  mv a2, x15\n" ++
       "  jal ra, create_record_code_effect\n" ++
       -- i3djw.2: record the created account's NON-STORAGE effect (pre absent 0/0; post


### PR DESCRIPTION
## Summary

Closes `nxio8.6`: the CREATE deposit (`returnRevertTail` RETURN branch in `NoopHalt.lean`, after `create_deployed_code_valid`'s 0xEF/MAX_CODE_SIZE gate, before `create_record_code_effect`) did **not** charge the EIP-7778 code-deposit **state** gas. Spec amsterdam `vm/interpreter.py:241-242` charges `charge_state_gas(evm, ulen(contract_code) * COST_PER_STATE_BYTE)` there. Dropping it made `evm_state_gas_used` under-count → the EIP-7778/8037 state budget is too lenient (false-accept on state-heavy creation blocks) and the per-tx exec state gas (`bvgr_tx_exec_state_gas`, #8768) is inaccurate.

## Fix

Charge `deployed_code_len(x15) * COST_PER_STATE_BYTE(1530)`, mirroring the verified SSTORE `charge_state_gas` pattern (`Storage.lean`) **exactly**:
- drain the global `evm_state_gas_left` reservoir;
- spill the remainder into the child frame `gas_left` (`568(x20)`);
- **OOG-fail** the CREATE (consume all child gas, push 0 via the existing `.Lrr_crinv` path) when both reservoirs are short;
- `evm_state_gas_used += charge` on the non-OOG paths (spec raises **before** `state_gas_used += amount`, `gas.py:302-311`).

`x13/x14/x15` are preserved (`create_deployed_code_valid` #8629 + untouched here); `x15 <= MAX_CODE_SIZE` so `x15*1530` fits u64.

**Sound:** a valid block never OOGs at deposit, so the OOG-fail path never triggers on valid blocks (no false-reject); the charge aligns the guest with the spec on the reservoir (common) and spill (large-code) paths. The OOG-fail edge reuses the existing CREATE-fail machinery (`.Lrr_crinv` + the merged `nxio8.4` parent `incorporate_child_on_error` state-gas fold-back).

## Validation

- Full `lake build` green; `stateless_guest` ELF assembles; `check-forbidden-tactics` / `check-file-size` pass.
- **Reservoir path: creation sweep 100/100 FULL MATCH** — includes the `eip8037_state_creation_gas_cost_increase` fixtures (e.g. `create_insufficient_balance_returns_reservoir`) that directly test creation state-gas/reservoir behavior.
- **Spill path: `eip7954_increase_max_contract_size` 30/30 FULL MATCH** — large-code (≥32KB) deploys that drain the reservoir into `gas_left`.
- 0 errored, 0 fail across both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)