### PR TITLE
fix(dispatcher): charge code_hash_gas on CREATE deposit (nxio8.7)

### DIFF
--- a/EvmAsm/Codegen/Programs/NoopHalt.lean
+++ b/EvmAsm/Codegen/Programs/NoopHalt.lean
@@ -58,6 +58,15 @@ private def returnRevertTail (kind : Nat) (rollbackAsm : String := "")
       "  add a0, x13, x14\n  mv a1, x15\n" ++
       "  jal ra, create_deployed_code_valid\n" ++
       "  bnez a0, .Lrr_crinv_" ++ toString kind ++ "\n" ++
+      -- nxio8.7: charge code_hash_gas (keccak-per-word, REGULAR/GAS dim) = OPCODE_KECCACK256_PER_WORD(6)
+      -- * ceil32(deployed_code_len)/32 = 6 * ((x15+31)>>5) words, spec amsterdam vm/interpreter.py:236-240
+      -- charge_gas, BEFORE the state-gas charge ('regular before state' ordering). Simple charge_gas
+      -- (no reservoir/spill): drain the child frame gas_left (568(x20)); OOG-fail the CREATE
+      -- (-> .Lrr_crinv) if short. A valid block never OOGs at deposit -> no false-reject. x15 preserved.
+      "  addi t0, x15, 31\n  srli t0, t0, 5\n" ++                  -- words = ceil32(len)/32
+      "  li t1, 6\n  mul t0, t0, t1\n" ++                          -- code_hash_gas = 6 * words
+      "  ld t1, 568(x20)\n  bltu t1, t0, .Lrr_crinv_" ++ toString kind ++ "\n" ++   -- gas_left < code_hash_gas -> OOG, CREATE fails
+      "  sub t1, t1, t0\n  sd t1, 568(x20)\n" ++                   -- gas_left -= code_hash_gas
       -- nxio8.6: charge code-deposit STATE gas = deployed_code_len(x15) * COST_PER_STATE_BYTE(1530)
       -- (spec amsterdam vm/interpreter.py:241-242 charge_state_gas(evm, ulen(code)*1530), AFTER the
       -- 0xEF/MAX_CODE_SIZE validity gate just above, BEFORE the deposit). Mirrors the SSTORE


### PR DESCRIPTION
## Summary

Follow-up to #8783 (nxio8.6, the STATE-dim code-deposit gas, already merged). Completes the full Amsterdam 2D code-deposit cost at the CREATE deposit. Spec amsterdam `vm/interpreter.py:236-240` charges, before the state-gas charge, the REGULAR/GAS-dim `code_hash_gas = OPCODE_KECCACK256_PER_WORD(6) * ceil32(ulen(code)) // 32` via `charge_gas`. The guest dropped it → regular gas under-counted on code deposit → latent false-accept.

## Fix

Charge `6 * ((deployed_code_len(x15)+31)>>5)` words via a simple `charge_gas` (no reservoir/spill, unlike the state charge): drain the child frame `gas_left` (`568(x20)`); OOG-fail the CREATE (existing `.Lrr_crinv`) when short. Placed **before** the #8783 state-gas charge per the spec's "regular before state" ordering. `x15` preserved.

Together with #8783: full Amsterdam code-deposit cost = **6/word (GAS) + len×1530 (STATE)** (Amsterdam removed the old 200/byte `CODE_DEPOSIT_COST` for this 2D split).

**Sound:** a valid block never OOGs at deposit → no false-reject.

## Validation

- Full `lake build` green; `stateless_guest` ELF assembles; forbidden-tactics/file-size gates pass.
- **Creation sweep 100/100 FULL MATCH** — incl. `eip8037_state_creation_gas_cost_increase` (the precise creation-gas fixtures).
- **`eip7954_increase_max_contract_size` 30/30 FULL MATCH** — large-code deploys where `code_hash_gas` (6×1024 words) is significant.
- 0 errored, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)