### PR TITLE
fix(verdict): activate CHAINID for dispatched self-contained contracts (6121j.1)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictRuntimePayload.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictRuntimePayload.lean
@@ -107,6 +107,13 @@ def stageRuntimePayloadFunction : String :=
   "  ld t2, 428(a2); sd t2, 312(s0)\n" ++
   -- GASLIMIT (word 10 -> +408): exec u64 @412.
   "  ld t2, 412(a2); sd t2, 408(s0)\n" ++
+  -- 6121j.1: CHAINID (word 12 -> +472): bv_chain_id (u64, set by chain_config_valid during the
+  -- verdict's config validation, BEFORE dispatch). Direct u64 copy like NUMBER/TIMESTAMP/GASLIMIT
+  -- above (the handler evm_env_load .chainId reads env+384 the same way). Activates CHAINID for
+  -- dispatched self-contained contracts -- previously conservatively rejected (#8782) because the
+  -- env word was unstaged so a dispatched contract read CHAINID=0 (false-accept). Now staged with
+  -- the real chain id, so the reject is lifted (see BlockVerdictSelfContained .Lbsc_check).
+  "  la t1, bv_chain_id; ld t2, 0(t1); sd t2, 472(s0)\n" ++
   -- COINBASE (word 6 -> +280): exec 20-byte address @32, right-aligned into a
   -- 32-byte big-endian stack word. Copy the 20 bytes byte-by-byte so the
   -- staged word has the address in its low 20 bytes (matching how the env

--- a/EvmAsm/Codegen/Programs/BlockVerdictSelfContained.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictSelfContained.lean
@@ -83,7 +83,8 @@ def bytecodeIsSelfContainedFunction : String :=
   -- gate fails open). Feature-completeness follow-up (6121j): STAGE the real values and re-activate
   -- (CHAINID const, PREVRANDAO header copy, BLOBBASEFEE = taylor_exponential blob gas price).
   "  li t3, 0x44; beq t2, t3, .Lbsc_unsafe\n" ++   -- PREVRANDAO (unstaged env -> reads 0)
-  "  li t3, 0x46; beq t2, t3, .Lbsc_unsafe\n" ++   -- CHAINID (unstaged env -> reads 0)
+  -- CHAINID (0x46) ACTIVATED (6121j.1): stage_runtime_payload_code now stages bv_chain_id into the
+  -- CHAINID env word (+472 -> EvmEnv+384), so a dispatched contract reads the real chain id. Lifted.
   "  li t3, 0x4a; beq t2, t3, .Lbsc_unsafe\n" ++   -- BLOBBASEFEE (unstaged evm_env+512 -> reads 0)
   "  addi t0, t0, 1; j .Lbsc_loop\n" ++
   ".Lbsc_safe:\n" ++


### PR DESCRIPTION
## Summary

Follow-up to #8782 (which conservatively **rejected** PREVRANDAO/CHAINID/BLOBBASEFEE in `bytecode_is_self_contained` because their env words were unstaged → a dispatched contract read 0 = false-accept). This **activates CHAINID (0x46)** by staging the real chain id, restoring exec-derived dispatch coverage for the (common) CHAINID-using contracts.

## Change

- `stage_runtime_payload_code` (`BlockVerdictRuntimePayload.lean`) now stages `bv_chain_id` into the CHAINID env word (payload +472 → EvmEnv+384, word 12) — a direct u64 copy mirroring NUMBER/TIMESTAMP/GASLIMIT. `bv_chain_id` is set by `chain_config_valid` during the verdict's config validation (before dispatch); the handler `evm_env_load .chainId` reads `env+384` the same way.
- `BlockVerdictSelfContained.lean`: drop the `0x46` reject (keep `0x44` PREVRANDAO / `0x4a` BLOBBASEFEE rejected — those env words remain unstaged; follow-ups in `6121j.1`).

**Sound:** the chain id is the real (config-validated) value, so dispatched CHAINID-using contracts execute correctly. Any other-cause dispatch divergence would surface in EEST (caught below), not silently.

## Validation

- Full `lake build` green; `stateless_guest` ELF assembles; forbidden-tactics/file-size gates pass.
- **Broad EEST sweep 220/220 FULL MATCH** (no regression).
- **`eip1344_chainid` 5/5 FULL MATCH** — directly validates the now-dispatched CHAINID reads the correct chain id.
- 0 errored, 0 fail.

## Follow-up (`6121j.1`)

PREVRANDAO (header `prev_randao` copy → env+288) and BLOBBASEFEE (`taylor_exponential` blob gas price → env+512) activation remain — recipe recorded on the bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)