### PR TITLE
fix(verdict): activate BLOBBASEFEE for dispatched self-contained contracts (6121j.1)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictRuntimePayload.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictRuntimePayload.lean
@@ -68,7 +68,7 @@ open EvmAsm.Rv64
 -/
 def stageRuntimePayloadFunction : String :=
   "stage_runtime_payload:\n" ++
-  "  addi sp, sp, -16\n" ++
+  "  addi sp, sp, -32\n" ++   -- 6121j.1: +16 extra slot to save a0(ctx) across the BLOBBASEFEE price call
   "  sd ra, 0(sp); sd s0, 8(sp)\n" ++
   "  mv s0, a1                    # output payload ptr\n" ++
   -- Reject any context the extractor did not fully accept.
@@ -120,6 +120,17 @@ def stageRuntimePayloadFunction : String :=
   "  add t6, t3, t4; sb t5, 0(t6)\n" ++
   "  addi t4, t4, 1; j .Lsrp_coinbase_loop\n" ++
   ".Lsrp_coinbase_done:\n" ++
+  -- 6121j.1: BLOBBASEFEE — stage the block blob gas price into the payload blob_base_fee slot @+32
+  -- (the dispatcher copies +32 -> evm_env+512, which the BLOBBASEFEE handler reads). Reuse the
+  -- verdict's amsterdam_blob_gas_price_u256 (= calculate_blob_gas_price = taylor_exponential(1,
+  -- excess_blob_gas, 11684671); co-linked in BlockVerdictV2); excess_blob_gas = SSZ exec field
+  -- @exec+520 (bgv_u64le). Save a0 (ctx, read by the trailer below) across the calls; s0 is
+  -- callee-saved (preserved by the helper). Previously the slot stayed 0 so a dispatched
+  -- BLOBBASEFEE contract read 0 (#8782 rejected it conservatively); now staged with the real price.
+  "  sd a0, 16(sp)\n" ++
+  "  addi a0, a2, 520; jal ra, bgv_u64le\n" ++                       -- a0 = excess_blob_gas (u64)
+  "  addi a1, s0, 32; jal ra, amsterdam_blob_gas_price_u256\n" ++    -- price (u256 BE) -> payload+32 (overflow unreachable for valid blocks)
+  "  ld a0, 16(sp)\n" ++                                             -- restore ctx ptr for the trailer
   -- Transaction gas / control trailer.
   "  ld t0, 40(a0)                # context tx gas limit\n" ++
   "  sd t0, 536(s0)               # gas_limit\n" ++
@@ -131,7 +142,7 @@ def stageRuntimePayloadFunction : String :=
   "  li a0, 0\n" ++
   ".Lsrp_ret:\n" ++
   "  ld ra, 0(sp); ld s0, 8(sp)\n" ++
-  "  addi sp, sp, 16\n" ++
+  "  addi sp, sp, 32\n" ++   -- 6121j.1: matches the -32 frame
   "  ret"
 
 /- Probe input layout (file byte 0 maps to guest INPUT+8, so the probe stores

--- a/EvmAsm/Codegen/Programs/BlockVerdictSelfContained.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictSelfContained.lean
@@ -83,8 +83,10 @@ def bytecodeIsSelfContainedFunction : String :=
   -- gate fails open). Feature-completeness follow-up (6121j): STAGE the real values and re-activate
   -- (CHAINID const, PREVRANDAO header copy, BLOBBASEFEE = taylor_exponential blob gas price).
   "  li t3, 0x44; beq t2, t3, .Lbsc_unsafe\n" ++   -- PREVRANDAO (unstaged env -> reads 0)
-  "  li t3, 0x46; beq t2, t3, .Lbsc_unsafe\n" ++   -- CHAINID (unstaged env -> reads 0)
-  "  li t3, 0x4a; beq t2, t3, .Lbsc_unsafe\n" ++   -- BLOBBASEFEE (unstaged evm_env+512 -> reads 0)
+  "  li t3, 0x46; beq t2, t3, .Lbsc_unsafe\n" ++   -- CHAINID (unstaged env -> reads 0; activated separately, #8785)
+  -- BLOBBASEFEE (0x4a) ACTIVATED (6121j.1): stage_runtime_payload_code now stages the block blob
+  -- gas price (amsterdam_blob_gas_price_u256) into the payload blob_base_fee slot @+32 -> evm_env+512,
+  -- so a dispatched contract reads the real value. Lifted.
   "  addi t0, t0, 1; j .Lbsc_loop\n" ++
   ".Lbsc_safe:\n" ++
   "  li a0, 0; ret\n" ++


### PR DESCRIPTION
## Summary

Follow-up to #8782 (which conservatively **rejected** PREVRANDAO/CHAINID/BLOBBASEFEE — unstaged env words → a dispatched contract read 0 = false-accept) and #8785 (CHAINID activation). This **activates BLOBBASEFEE (0x4a)**.

## Change

- `stage_runtime_payload_code` (`BlockVerdictRuntimePayload.lean`) computes the block blob gas price by **reusing** the verdict's `amsterdam_blob_gas_price_u256` (= `calculate_blob_gas_price` = `taylor_exponential(1, excess_blob_gas, 11684671)`; co-linked in `BlockVerdictV2`) over the SSZ `excess_blob_gas` (`exec+520`), and stages the u256 result into the payload `blob_base_fee` slot `@+32` → dispatcher copies it to `evm_env+512` (the BLOBBASEFEE handler's read). Frame grows 16→32B to save `a0` (context) across the price call; `s0` is callee-saved.
- `BlockVerdictSelfContained.lean`: drop the `0x4a` reject (keeps `0x44` PREVRANDAO rejected — unstaged, unvalidatable; `0x46` CHAINID activated by #8785).

**Sound:** the staged value is the real computed blob gas price, so dispatched BLOBBASEFEE-using contracts execute correctly.

## Validation

- Full `lake build` green; `stateless_guest` ELF assembles; forbidden-tactics/file-size gates pass.
- **`eip7516_blobgasfee` 4/4 FULL MATCH** — the BLOBBASEFEE opcode fixtures; now that `0x4a` is un-rejected they dispatch a BLOBBASEFEE-reading contract, directly validating the staged value + byte order.
- **Broad EEST sweep 200/200 FULL MATCH** (no regression from the frame change / price call).
- 0 errored, 0 fail.

(Independent of #8785: the reject-line and staging edits are at different locations, so they merge cleanly. With #8782+#8785+this, CHAINID + BLOBBASEFEE are activated; PREVRANDAO remains soundly rejected — unvalidatable byte order, no fixture.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)