### PR TITLE
fix(dispatcher): charge create_account_state_gas on the CREATE/CREATE2 opcode (nxio8.8)

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
@@ -258,8 +258,32 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     -- create_frame_descend reads the endowment from x12 (stack top) itself; do NOT pass it in
     -- a0 (== x10 the PC) -- that would clobber the parent return PC the descent saves (#8608).
     -- a1 = netPopBytes (frame_return pops the CREATE args: 64 for CREATE / 96 for CREATE2).
+    -- nxio8.8: charge create_account_state_gas = STATE_BYTES_PER_NEW_ACCOUNT(120)*COST_PER_STATE_BYTE(1530)
+    -- = 183600 (spec amsterdam vm/instructions/system.py:89, pay-before-execute, BEFORE the init child).
+    -- Mirror charge_state_gas (Storage.lean): drain evm_state_gas_left; spill the remainder into the
+    -- PARENT gas_left (568(x20), still the parent env here, before the descend); OOG-fail the CREATE
+    -- (push 0 via 7f) when both reservoirs are short. evm_state_gas_used += charge. Preserves the
+    -- dispatcher state x10/x12/x13/x20/x21 (only t0-t3 + the parent gas_left). The charge is REFUNDED
+    -- on child failure by the snapshot bump after create_frame_descend below (the descent snapshots
+    -- POST-charge into child_env+624/632, so adding/subtracting 183600 makes incorporate_child_on_error's
+    -- rollback restore the PRE-charge reservoir/used -- matching spec 'refunded on any failure path').
+    "  li t0, 183600\n" ++
+    "  la t1, evm_state_gas_left\n  ld t2, 0(t1)\n" ++
+    "  bgeu t2, t0, .Lcr_csg_res_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
+    "  sub t3, t0, t2\n  sd x0, 0(t1)\n" ++
+    "  ld t2, 568(x20)\n  bltu t2, t3, 7f\n" ++
+    "  sub t2, t2, t3\n  sd t2, 568(x20)\n  j .Lcr_csg_used_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
+    ".Lcr_csg_res_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
+    "  sub t2, t2, t0\n  sd t2, 0(t1)\n" ++
+    ".Lcr_csg_used_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
+    "  la t1, evm_state_gas_used\n  ld t2, 0(t1)\n  add t2, t2, t0\n  sd t2, 0(t1)\n" ++
     "  li a1, " ++ toString netPopBytes ++ "\n" ++
     "  jal x1, create_frame_descend\n" ++
+    -- nxio8.8 refund-on-failure: the descent snapshotted state-gas POST-charge into child_env+624/632;
+    -- bump the snapshot by the charge so incorporate_child_on_error restores the PRE-charge reservoir
+    -- on child error/revert (x20 = child env here). On child success the snapshot is unused (charge stands).
+    "  ld t0, 624(x20)\n  li t1, 183600\n  add t0, t0, t1\n  sd t0, 624(x20)\n" ++
+    "  ld t0, 632(x20)\n  sub t0, t0, t1\n  sd t0, 632(x20)\n" ++
     "  j .dispatch_loop\n" ++
     "7:\n" ++
     "  addi x12, x12, " ++ toString netPopBytes ++ "\n" ++


### PR DESCRIPTION
## Summary

The runtime CREATE/CREATE2 opcode (`createCallTail`) did not charge the EIP-7778 **account-creation state gas**. Spec amsterdam `vm/instructions/system.py:89` charges `charge_state_gas(evm, STATE_BYTES_PER_NEW_ACCOUNT × COST_PER_STATE_BYTE = 120×1530 = 183600)` pay-before-execute, **refunded on any child failure**. Dropping it under-counted runtime state gas (EIP-7778/8037 state budget too lenient + inaccurate `bvgr_tx_exec_state_gas`). (The TX-intrinsic creation-gas was already charged; this is the runtime CREATE-opcode path.)

## Fix

Before `create_frame_descend`, charge 183600 via the SSTORE `charge_state_gas` mirror (`Storage.lean`): drain `evm_state_gas_left`; spill into the parent `gas_left` (`568(x20)`); **OOG-fail** the CREATE (push 0 via the existing `7f` path) when both short; `evm_state_gas_used += charge`.

**Refund-on-failure:** the descent snapshots state-gas *post-charge* into `child_env+624/632`, so after it returns we bump the snapshot (`+183600` to 624, `-183600` to 632) — making `incorporate_child_on_error`'s rollback restore the *pre-charge* reservoir on child error/revert (= spec "refunded on any failure path"); on success the snapshot is unused and the charge stands. Parameterized for CREATE (`f0`) and CREATE2 (`f5`).

**Sound:** a valid block's CREATE either affords the charge (reservoir/spill) or genuinely OOGs (spec fails it too) → no false-reject; reverted CREATEs refund it.

## Validation

- Full `lake build` green; `stateless_guest` ELF assembles; forbidden-tactics/file-size gates pass.
- **`create` sweep 100/100 FULL MATCH** — incl. `eip1014_create2/create2_revert` (the **refund** oracle: a reverted CREATE2 refunds the charge) and `eip8037_state_creation_gas_cost_increase`.
- **`eip7954_increase_max_contract_size` 30/30 FULL MATCH** (large-CREATE charge).
- 0 errored, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)