### PR TITLE
feat(verdict): persist per-tx executed state gas — EIP-7778 2D state-dim substrate (P1)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -394,6 +394,10 @@ def ziskStatelessVerdictV2DataSection : String :=
   -- bvgr_block_gas_increments. Filled by block_verdict_tx_state_gas_array; fed
   -- (with bvgr_block_gas_increments) to eip8037_block_gas_used by g8zeq.1.4.2.
   "bvgr_tx_state_gas:\n  .zero 128\n" ++
+  -- fhsxz.2.4.2.57.11.6.5.2.1 P1: per-tx EXECUTED state gas (net of refunds), filled by
+  -- dispatcher_capture_exec_state_gas at each contract dispatch (16 entries x 8B, mirrors
+  -- bvgr_tx_state_gas). Behavior-neutral substrate for the 2D state-dim (P3 reads it).
+  "bvgr_tx_exec_state_gas:\n  .zero 128\n" ++
   "bvgr_receipt_gas_increments:\n  .zero 128\n" ++
   "bvgr_before_refund:\n  .zero 128\n" ++
   "bvgr_applied_refund:\n  .zero 128\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -486,6 +486,10 @@ def blockVerdictFunction : String :=
   "  la a0, bv_mtx_ctx; ld a1, 80(s0); ld a2, 88(s0); jal ra, dispatch_tx_runtime_code\n" ++
   "  la t1, dtrc_use_pre_header; sd zero, 0(t1)\n" ++
   "  bnez a0, .Lbv_mtx_bail                         # dispatch miss / not self-contained\n" ++
+  -- fhsxz.2.4.2.57.11.6.5.2.1 P1: persist this tx's executed state gas into bvgr_tx_exec_state_gas[i]
+  -- (i = bv_mtx_i; evm_state_gas_used is fresh per-tx). Clobbers only a0/t0-t2, preserves the dispatch
+  -- results a1-a4 used below. Behavior-neutral substrate (array not yet read by the gate).
+  "  la a0, bv_mtx_i; ld a0, 0(a0); jal ra, dispatcher_capture_exec_state_gas\n" ++
   "  la t0, bv_mtx_i; ld t1, 0(t0); slli t0, t1, 3\n" ++
   "  la t3, bv_mtx_gas_left; add t3, t3, t0; sd a1, 0(t3)\n" ++
   "  la t3, bv_mtx_calldata; add t3, t3, t0; sd a2, 0(t3)\n" ++
@@ -820,6 +824,9 @@ def blockVerdictFunction : String :=
   "  ld a1, 80(s0); ld a2, 88(s0)\n" ++
   "  jal ra, dispatch_tx_runtime_code\n" ++
   "  bnez a0, .Lbv_after_tx_gas_precharge\n" ++
+  -- fhsxz.2.4.2.57.11.6.5.2.1 P1: persist tx0's executed state gas into bvgr_tx_exec_state_gas[0].
+  -- Clobbers only a0/t0-t2, preserves the dispatch results a1-a4 stored below. Behavior-neutral.
+  "  li a0, 0; jal ra, dispatcher_capture_exec_state_gas\n" ++
   "  la t4, bv_runtime_gas_left; sd a1, 0(t4)\n" ++
   "  la t4, bv_runtime_calldata_floor; sd a2, 0(t4)\n" ++
   -- nxio8: a3 = the settle-folded refund counter (0 when the tx erred), not a

--- a/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
@@ -14,6 +14,7 @@ import EvmAsm.Codegen.Programs.ReceiptsConsensus
 import EvmAsm.Codegen.Programs.EvmBasic
 import EvmAsm.Codegen.Programs.EvmRegistry
 import EvmAsm.Codegen.Programs.RequestsHash
+import EvmAsm.Codegen.Programs.DispatcherExecStateGas
 import EvmAsm.Codegen.Programs.TxBlobGas
 import EvmAsm.Codegen.Programs.SszWithdrawal
 
@@ -394,6 +395,10 @@ def statelessVerdictV2GuestClosure : String :=
   addressComputeCreate2Function ++ "\n" ++
   enrgU32leFunction ++ "\n" ++
   eip7702NonceReuseGuardFunction ++ "\n" ++
+  -- fhsxz.2.4.2.57.11.6.5.2.1 P1: link dispatcher_capture_exec_state_gas so the verdict can
+  -- persist each tx's executed state gas into bvgr_tx_exec_state_gas (behavior-neutral substrate
+  -- for the EIP-7778 2D state-dim; the array is filled but not yet read by eip8037_state_used_before_tx).
+  dispatcherCaptureExecStateGasFunction ++ "\n" ++
   -- bmvmx.3.2: per-tx sender recovery vs witness public_keys. block_verdict
   -- calls verify_public_keys_match_senders after public_keys_valid; the TX-side
   -- recovery stack (signature extractors + signing-hash + material/stage/


### PR DESCRIPTION
## Summary

Behavior-neutral **substrate** (P1 of 3) for the EIP-7778 2D state-dimension fix (`fhsxz.2.4.2.57.11.6.5.2.1`). Links `dispatcher_capture_exec_state_gas` (#8768's helper, previously probe-only) into the verdict guest, adds the `bvgr_tx_exec_state_gas` array (16×8B) to `BlockVerdictDataSection`, and captures each tx's executed state gas (net of refunds) into `bvgr_tx_exec_state_gas[i]` right after its contract dispatch:
- multi-tx loop (`i = bv_mtx_i`)
- single-tx contract path (`i = 0`)

EOA-recipient txs have no executed state gas → their slots stay 0 (array is `.zero` at load), so no capture is needed (resolves the c2#94 EOA-freshness caveat).

The capture clobbers only `a0`/`t0-t2` (verified against the helper), preserving the dispatch results `a1-a4` used by the surrounding stores.

## Why behavior-neutral

Nothing reads `bvgr_tx_exec_state_gas` yet — the gate still uses the BAL-storage-set count. This is the substrate; the follow-ups deliver the actual 2D state-dim fix:
- **P2**: reorder `block_verdict_tx_state_gas_array` before `eip8037_tx_gas_gate` (both `bvgr_tx_state_gas` and the exec captures must precede the gate).
- **P3**: rewrite `eip8037_state_used_before_tx` to `Σ_{i<target}(bvgr_tx_state_gas[i] + bvgr_tx_exec_state_gas[i])` — closes the latent false-accept (the BAL-count under-counts non-storage state gas). Sound: `≤` real per-tx state gas → no false-reject.

Mirrors the #8768 substrate-first pattern.

## Validation

- Full `lake build` green; `stateless_guest` ELF assembles (no duplicate labels); forbidden-tactics/file-size gates pass.
- **Broad EEST sweep 200/200 FULL MATCH** — confirms behavior-neutral (verdict output unchanged), 0 errored, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)