### PR TITLE
fix(gas): SELFDESTRUCT new-beneficiary charges EIP-8037 state gas, not legacy 25000

### DIFF
--- a/EvmAsm/Codegen/Programs/Selfdestruct.lean
+++ b/EvmAsm/Codegen/Programs/Selfdestruct.lean
@@ -80,11 +80,28 @@ def selfdestructNewAccountSurchargeAsm : String :=
   "  ld t1, 0(t0)\n" ++
   "  beqz t1, .L_selfdestruct_surcharge_done\n" ++
   ".L_selfdestruct_charge_new_account:\n" ++
-  "  ld t0, 568(x20)\n" ++
-  "  li t1, 25000\n" ++
-  "  bltu t0, t1, .exit_outofgas\n" ++
-  "  sub t0, t0, t1\n" ++
-  "  sd t0, 568(x20)\n" ++
+  -- nxio8.8 (EIP-8037 state dimension): SELFDESTRUCT to a new (not-alive) beneficiary with a
+  -- non-zero originator balance creates the beneficiary account, costing
+  -- StateGasCosts.NEW_ACCOUNT = STATE_BYTES_PER_NEW_ACCOUNT(120)*COST_PER_STATE_BYTE(1530) = 183600
+  -- in the STATE dimension (spec amsterdam vm/instructions/system.py:660-671), NOT the legacy
+  -- 25000 GAS-dim surcharge that this replaces. The GAS-dim cost is only base(5000, dispatch) +
+  -- cold(2600, ee21v access gas); the new-account cost moved entirely to the state dimension under
+  -- EIP-8037. Mirror charge_state_gas (ChildFrameHandlerTails / Storage.lean): drain
+  -- evm_state_gas_left, spill the remainder into the frame gas_left (568(x20)), OOG when both
+  -- reservoirs are short; state_gas_used += charge. No refund snapshot -- the spec does not
+  -- credit_state_gas_refund for SELFDESTRUCT (the charge is permanent within the frame, like the
+  -- 25000 it replaces; the frame-entry 624/632 state-gas snapshot already rolls it back if a parent
+  -- reverts the frame's effects).
+  "  li t0, 183600\n" ++
+  "  la t1, evm_state_gas_left\n  ld t2, 0(t1)\n" ++
+  "  bgeu t2, t0, .L_selfdestruct_csg_res\n" ++
+  "  sub t3, t0, t2\n  sd x0, 0(t1)\n" ++
+  "  ld t2, 568(x20)\n  bltu t2, t3, .exit_outofgas\n" ++
+  "  sub t2, t2, t3\n  sd t2, 568(x20)\n  j .L_selfdestruct_csg_used\n" ++
+  ".L_selfdestruct_csg_res:\n" ++
+  "  sub t2, t2, t0\n  sd t2, 0(t1)\n" ++
+  ".L_selfdestruct_csg_used:\n" ++
+  "  la t1, evm_state_gas_used\n  ld t2, 0(t1)\n  add t2, t2, t0\n  sd t2, 0(t1)\n" ++
   ".L_selfdestruct_surcharge_done:\n"
 
 /--


### PR DESCRIPTION
## Summary

`nxio8.8` audit finding, verified against `origin/forks/amsterdam` (the EIP-8037 *state-creation-gas-cost-increase* spec — note this is **EIP-8037**, the 2D state dimension; the beads' "EIP-7778" label is a misnomer — EIP-7778 is the separate no-refunds change).

SELFDESTRUCT to a **new (not-alive) beneficiary** with a **non-zero originator balance** creates the beneficiary account. Spec `vm/instructions/system.py:660-671` charges this in the **STATE dimension**:

```
state_gas = NEW_ACCOUNT  # STATE_BYTES_PER_NEW_ACCOUNT(120) * COST_PER_STATE_BYTE(1530) = 183600
charge_gas(evm, gas_cost)        # gas_cost = base(5000) + cold(2600) only — NO 25000
charge_state_gas(evm, state_gas)
```

The guest was instead charging the **legacy pre-8037 25000 GAS-dim** surcharge (and 0 state gas). Under the `max(regular, state)` block-gas model this is wrong in both directions:
- **+25000 regular** → false-**reject** risk (inflates the regular dimension)
- **−183600 state** → false-**accept** risk for state-heavy blocks (under-charges the state dimension)

## Change

At `.L_selfdestruct_charge_new_account` (the site whose condition — `originator.balance != 0 AND not is_account_alive(beneficiary)` — already matches the spec), replace the 25000 `gas_left` subtraction with the proven `charge_state_gas` pattern (drain `evm_state_gas_left`, spill remainder into frame `gas_left` 568(x20), OOG → `.exit_outofgas` when both reservoirs short; `state_gas_used += 183600`).

No refund snapshot: the spec does **not** `credit_state_gas_refund` for SELFDESTRUCT (unlike `generic_create`), so the charge is permanent within the frame (as the 25000 it replaces was); the frame-entry 624/632 state-gas snapshot already handles rollback if a parent reverts. `base`(5000, dispatch) and `cold`(2600, ee21v) are charged separately and untouched.

## Validation

`eip8037` `state_gas_selfdestruct` EEST subset: **29/29 full match** (all 105 bytes), including the directly-targeting fixtures:
- `selfdestruct_new_beneficiary_charges_state_gas` — confirms the 183600 state charge
- `selfdestruct_new_beneficiary_no_regular_account_creation_cost` — confirms the legacy 25000 GAS charge is correctly **gone**
- `selfdestruct_existing_beneficiary_no_state_gas` / `selfdestruct_zero_balance_no_state_gas` — the gating condition
- `selfdestruct_state_gas_from_reservoir` — the reservoir drain/spill

Full `eip8037` sweep (201 fixtures) running for regression confidence. Full lib builds green; forbidden-tactics clean; file size 646 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)