### PR TITLE
fix(gas): CALL value-to-not-alive-account charges EIP-8037 new-account state gas

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -2540,7 +2540,10 @@ def emitRuntimeDispatcherEmbeddedHelperData : String :=
   "cd_caller_be:\n  .zero 32\n" ++
   "cd_value_be:\n  .zero 32\n" ++
   "cd_balance_be:\n  .zero 32\n" ++
-  "cd_caller_newbal:\n  .zero 32\n"
+  "cd_caller_newbal:\n  .zero 32\n" ++
+  -- nxio8.8: the CALL callee (`to`) as canonical 20-byte big-endian, for the
+  -- EIP-8037 new-account state-gas check (is_account_alive(to)) in callDescendFallThrough.
+  "cd_callee_be:\n  .zero 32\n"
 
 /-- Runtime-bytecode `.data` section. Drops the `evm_code:` block
     (no baked bytecode); everything else matches the `.data`-baked

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -363,6 +363,60 @@ def callDescendFallThrough
     "  jal ra, eip7708_append_transfer_log\n" ++
     "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
     ".Lcd_nse_done_" ++ tag ++ ":\n") ++
+  -- nxio8.8 (EIP-8037): CALL (mode 0) with value!=0 to a not-alive callee creates the
+  -- account -> charge_state_gas(NEW_ACCOUNT = STATE_BYTES_PER_NEW_ACCOUNT(120)*COST_PER_STATE_BYTE(1530)
+  -- = 183600). Spec vm/instructions/system.py:463-464: `if value != 0 and not is_account_alive(to):
+  -- charge_state_gas(NEW_ACCOUNT)`. Charged in the PARENT here (before the frame switch). NOT
+  -- refunded on child failure: the spec charges it BEFORE saving call_state_gas_reservoir (line 480),
+  -- so state_gas_used stays; and a not-alive callee has no code -> the CALL routes to .Lcd_empty
+  -- (no child frame at all), so the charge simply stands. CALLCODE(mode 2) recipient is
+  -- current_target (always alive) -> excluded; STATICCALL/DELEGATECALL carry no value. Mirrors the
+  -- SELFDESTRUCT new-beneficiary charge (#8789): same is_account_alive helpers + charge_state_gas.
+  (if mode != 0 then "" else
+    "  ld t3, " ++ toString valueOff ++ "(x12)\n" ++
+    "  ld t4, " ++ toString (valueOff+8) ++ "(x12)\n  or t3, t3, t4\n" ++
+    "  ld t4, " ++ toString (valueOff+16) ++ "(x12)\n  or t3, t3, t4\n" ++
+    "  ld t4, " ++ toString (valueOff+24) ++ "(x12)\n  or t3, t3, t4\n" ++
+    "  beqz t3, .Lcd_nacc_done_" ++ tag ++ "\n" ++           -- value == 0: no charge
+    "  ld t3, 584(x20)\n  beqz t3, .Lcd_nacc_done_" ++ tag ++ "\n" ++   -- no account-witness ctx: skip
+    -- callee (`to`) word at x12+32: build cd_callee_be = reverse(mem[x12+32 .. x12+51]) = canonical
+    -- 20-byte big-endian (stack words are LE-stored; mirrors the SELFDESTRUCT beneficiary / cd_caller_be).
+    "  la t0, cd_callee_be\n  addi t1, x12, " ++ toString (32+19) ++ "\n  li t2, 20\n" ++
+    ".Lcd_nacc_addr_" ++ tag ++ ":\n" ++
+    "  lbu t3, 0(t1)\n  sb t3, 0(t0)\n  addi t1, t1, -1\n  addi t0, t0, 1\n  addi t2, t2, -1\n" ++
+    "  bnez t2, .Lcd_nacc_addr_" ++ tag ++ "\n" ++
+    -- account_exists_at_header_state_root(callee) -> aex_predicate (helper clobbers a-regs aliasing x10/x12/x13)
+    "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
+    "  ld a0, 576(x20)\n  ld a1, 584(x20)\n  la a2, cd_callee_be\n  ld a3, 592(x20)\n  ld a4, 600(x20)\n" ++
+    "  jal ra, account_exists_at_header_state_root\n" ++
+    "  mv t6, a0\n" ++
+    "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
+    "  bnez t6, .Lcd_nacc_done_" ++ tag ++ "\n" ++           -- lookup err -> conservative skip (no charge)
+    "  la t0, aex_predicate\n  ld t1, 0(t0)\n" ++
+    "  beqz t1, .Lcd_nacc_charge_" ++ tag ++ "\n" ++         -- not exists -> not alive -> charge
+    -- exists: account_is_empty_at_header_state_root(callee) -> aie_predicate
+    "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
+    "  ld a0, 576(x20)\n  ld a1, 584(x20)\n  la a2, cd_callee_be\n  ld a3, 592(x20)\n  ld a4, 600(x20)\n" ++
+    "  jal ra, account_is_empty_at_header_state_root\n" ++
+    "  mv t6, a0\n" ++
+    "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
+    "  bnez t6, .Lcd_nacc_done_" ++ tag ++ "\n" ++           -- lookup err -> skip
+    "  la t0, aie_predicate\n  ld t1, 0(t0)\n" ++
+    "  beqz t1, .Lcd_nacc_done_" ++ tag ++ "\n" ++           -- exists & not empty = alive -> no charge
+    ".Lcd_nacc_charge_" ++ tag ++ ":\n" ++
+    -- charge_state_gas(183600): drain evm_state_gas_left, spill remainder into the frame gas_left
+    -- (568(x20)), OOG -> .exit_outofgas when both reservoirs short; state_gas_used += 183600.
+    "  li t0, 183600\n" ++
+    "  la t1, evm_state_gas_left\n  ld t2, 0(t1)\n" ++
+    "  bgeu t2, t0, .Lcd_nacc_res_" ++ tag ++ "\n" ++
+    "  sub t3, t0, t2\n  sd x0, 0(t1)\n" ++
+    "  ld t2, 568(x20)\n  bltu t2, t3, .exit_outofgas\n" ++
+    "  sub t2, t2, t3\n  sd t2, 568(x20)\n  j .Lcd_nacc_used_" ++ tag ++ "\n" ++
+    ".Lcd_nacc_res_" ++ tag ++ ":\n" ++
+    "  sub t2, t2, t0\n  sd t2, 0(t1)\n" ++
+    ".Lcd_nacc_used_" ++ tag ++ ":\n" ++
+    "  la t1, evm_state_gas_used\n  ld t2, 0(t1)\n  add t2, t2, t0\n  sd t2, 0(t1)\n" ++
+    ".Lcd_nacc_done_" ++ tag ++ ":\n") ++
   -- resolve callee code (save x10/x12/x13 — code_at_header_state_root clobbers a-regs)
   "  addi sp, sp, -32\n" ++
   "  sd x10, 0(sp); sd x12, 8(sp); sd x13, 16(sp)\n" ++


### PR DESCRIPTION
## Summary

`nxio8.8` audit, verified against `origin/forks/amsterdam` (the EIP-8037 state-creation-gas spec). A value-bearing **CALL** to a **not-alive** callee creates the account; the spec (`vm/instructions/system.py:463-464`) charges it in the **state dimension**:

```python
charge_gas(evm, extra_gas + extend_memory.cost)
if value != 0 and not is_account_alive(tx_state, to):
    charge_state_gas(evm, StateGasCosts.NEW_ACCOUNT)   # 120 * 1530 = 183600
```

The guest's `callDescendFallThrough` did **not** charge it — `callExtraGasFunction` even documents that it excludes the new-account cost as "a separate mechanism," but nothing invoked that mechanism. So the state dimension was under-charged for CALL-to-new (a latent false-accept; the charge feeds `evm_state_gas_used` → the `bvgr` EIP-8037 2D substrate + gates execution OOG).

## Change

Add the charge in `callDescendFallThrough`, **`mode==0` (CALL) only**, after the value-transfer block and before code resolution:
1. re-check `value != 0`;
2. build the callee `to` as canonical 20-byte big-endian into `cd_callee_be` (reverse of the LE-stored stack word — mirroring `cd_caller_be` / the SELFDESTRUCT beneficiary, since the `account_*` helpers key the trie by `keccak(address)`);
3. `is_account_alive(to)` via `account_exists_at_header_state_root` + `account_is_empty_at_header_state_root` (charge iff `!exists OR is_empty`);
4. the proven `charge_state_gas` pattern (drain `evm_state_gas_left`, spill into `gas_left` 568(x20), OOG → `.exit_outofgas`; `state_gas_used += 183600`).

**No refund snapshot**: the spec charges this *before* saving `call_state_gas_reservoir` (so it isn't refunded on child failure), and a not-alive callee has no code → the CALL routes to `.Lcd_empty` (no child frame) → the charge stands. **CALLCODE** (mode 2) recipient is `current_target` (always alive) → excluded; **STATICCALL/DELEGATECALL** carry no value. Directly mirrors the SELFDESTRUCT new-beneficiary charge (#8789).

## Validation

Full `eip8037` sweep **in isolation off main**: **201/201 full match**, 0 fail, 0 error — including `state_gas_call/{call_value_transfer_new_account, call_new_account_no_regular_account_creation_cost, call_value_transfer_existing_account_no_state_gas, callcode_value_no_new_account_state_gas, call_new_account_header_gas_used}`. Full lib build green; forbidden-tactics / file-size / unimported all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)