### PR TITLE
fix(verdict): enforce single-tx contract-recipient nonce/balance lower bounds (bmvmx.5)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -1112,6 +1112,9 @@ def ziskStatelessVerdictV2DataSection : String :=
   -- (account_at_header_state_root output; nonce@0).
   "bv_mtx_sender_addr:\n  .zero 32\n" ++
   "bv_mtx_sender_acct:\n  .zero 128\n" ++
+  -- bmvmx.5: single-tx contract-recipient sender scratch (same role as the mtx pair, i=0 path).
+  "bv_stx_sender_addr:\n  .zero 32\n" ++
+  "bv_stx_sender_acct:\n  .zero 128\n" ++
   -- bmvmx.1.6.6: scratch for the all-accounts per-slot tuple-sequence check (#8606). batsc_* is
   -- the wrapper's own scratch; the sub-helpers' scratch (atsc_*/bts_*/els_*) come from their Data
   -- defs. rfu_* (rlp_field_to_u64) is already provided above; slot_tuple_sequences_match is

--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -872,6 +872,33 @@ def blockVerdictFunction : String :=
   "  la a3, bv_cf_code_off; la a4, bv_cf_code_len\n" ++
   "  jal ra, witness_lookup_by_hash\n" ++
   "  bnez a0, .Lbv_code_preimage_fail            # current-frame code preimage absent -> reject\n" ++
+  -- bmvmx.5 (single-tx CONTRACT-recipient nonce/balance lower bound): a non-self-contained
+  -- contract recipient bails inside dispatch_tx_runtime_code (.Ldtrc_unsupported, many points)
+  -- -> skips the @1020 sender checks, so a single value-moving tx to such a recipient with a bad
+  -- nonce/balance was accepted (spec check_transaction rejects: Nonce/InsufficientBalance). Check
+  -- HERE, before dispatch, on the contract path only (EOA/simple-transfer never reaches here ->
+  -- no redundant lookup; the self-contained path redundantly re-checks @1020, harmless). Same
+  -- proven pattern as the multi-tx checks (#8791/#8792) with i=0: sender = public_keys[0] (=
+  -- bv_public_keys_ptr, verified bound to tx[0]'s signer @339), sttc_nonce = tx.nonce (single-tx
+  -- context build), tefgp_max_fee (tx_effective_gas_pricing @566), gas/value from bv_simple_transfer_tx.
+  -- Sound lower bounds (reject if tx.nonce<pre or pre_balance<upfront) -> no false-reject.
+  "  la a0, bv_public_keys_ptr; ld a0, 0(a0); addi a0, a0, 1\n" ++   -- public_keys[0]+1 (skip SEC1 0x04)
+  "  la a1, bv_stx_sender_addr; jal ra, address_from_pubkey\n" ++
+  "  ld a0, 8(s0); ld a1, 16(s0); la a2, bv_stx_sender_addr; li a3, 20; ld a4, 80(s0); ld a5, 88(s0); la a6, bv_stx_sender_acct\n" ++
+  "  jal ra, account_at_header_state_root\n" ++
+  "  bnez a0, .Lbv_stx_checks_done\n" ++                          -- sender lookup failed/absent -> skip
+  "  la t0, bv_stx_sender_acct; ld t0, 0(t0)\n" ++                -- sender pre-state nonce
+  "  la t1, sttc_nonce; ld t1, 0(t1)\n" ++                        -- tx.nonce
+  "  bltu t1, t0, .Lbv_sender_nonce_fail\n" ++                    -- tx.nonce < pre_nonce -> reject
+  "  la a0, tefgp_max_fee\n" ++
+  "  la t0, bv_simple_transfer_tx; ld a1, 40(t0)\n" ++            -- gas_limit (u64)
+  "  la a2, bv_upfront_cost\n  jal ra, u256_mul_u64_be\n" ++
+  "  bnez a0, .Lbv_sender_upfront_fail\n" ++
+  "  la a0, bv_upfront_cost\n  la t0, bv_simple_transfer_tx; addi a1, t0, 96\n  la a2, bv_upfront_cost\n  jal ra, u256_add_be\n" ++
+  "  bnez a0, .Lbv_sender_upfront_fail\n" ++
+  "  la a0, bv_stx_sender_acct; addi a0, a0, 8\n  la a1, bv_upfront_cost\n  la a2, bv_upfront_islt\n  jal ra, u256_lt_be\n" ++
+  "  la t0, bv_upfront_islt; ld t0, 0(t0)\n  bnez t0, .Lbv_sender_upfront_fail\n" ++
+  ".Lbv_stx_checks_done:\n" ++
   "  la a0, bv_simple_transfer_tx\n" ++
   "  ld a1, 80(s0); ld a2, 88(s0)\n" ++
   "  jal ra, dispatch_tx_runtime_code\n" ++


### PR DESCRIPTION
## Summary

Third `bmvmx.5` increment (the multi-tx nonce #8791 + balance #8792 increments are now merged to main). A single value-moving tx to a **non-self-contained contract** recipient bails inside `dispatch_tx_runtime_code` (`.Ldtrc_unsupported`) and so skips the `@1020` sender check block — so a bad nonce / insufficient upfront balance was accepted though the spec rejects it (`check_transaction` → `NonceMismatchError` / `InsufficientBalanceError`). Latent false-accept.

## Change

Added the nonce + upfront-balance lower bounds in `BlockVerdictFunction.lean` just **before the single-tx `dispatch_tx_runtime_code` call**, on the contract-recipient path only (after the code-preimage gate; EOA/simple-transfer never reaches here → no redundant lookup; self-contained redundantly re-checks `@1020`, harmless).

Same proven pattern as #8791/#8792 with `i=0`:
- sender = `address_from_pubkey(public_keys[0]+1)` (verified bound to tx[0]'s signer @339, no new ecrecover),
- `sttc_nonce` = tx.nonce (single-tx context build), `tefgp_max_fee` (set @566), gas/value from `bv_simple_transfer_tx`,
- reject if `tx.nonce < pre_nonce` **or** `pre_balance < gas_limit*max_fee + value`; lookup fail/absent → skip (conservative).

**Sound, no false-reject:** a valid tx always covers `nonce ≥ pre` and `balance ≥ upfront`.

## Validation

- Broad general-fixture sweep on current main: **400/400** full match, 0 fail (the single-tx contract path is heavily exercised).
- eip8037 sweep: **201/201** full match (on the identical change).
- Full lib build green; file-size / unimported / forbidden-tactics clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)