### PR TITLE
fix(verdict): single-tx contract-recipient nonce check exact (catch too-high)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -889,13 +889,9 @@ def blockVerdictFunction : String :=
   "  bnez a0, .Lbv_stx_checks_done\n" ++                          -- sender lookup failed/absent -> skip
   "  la t0, bv_stx_sender_acct; ld t0, 0(t0)\n" ++                -- sender pre-state nonce
   "  la t1, sttc_nonce; ld t1, 0(t1)\n" ++                        -- tx.nonce
-  -- EXACT (not just lower-bound): a single tx's nonce must EQUAL the sender's pre-state nonce
-  -- (spec check_transaction; frontier/validation/transaction/tx_nonce rejects BOTH nonce_diff=-1
-  -- and +1). A single-tx block has exactly one tx from this sender, so the valid nonce is exactly
-  -- pre (no sequencing) -- mirrors the simple-transfer exact check @1082 (bne), extended to the
-  -- contract-recipient/bail path here. Catches too-high as well as too-low; sound (valid single tx
-  -- always has nonce == pre -> never false-rejects). (The multi-tx path keeps the < pre lower bound
-  -- since a sequenced same-sender tx legitimately has nonce > pre; exact there needs per-sender count.)
+  -- EXACT (bne, not < pre): a single tx's nonce must EQUAL pre -- spec rejects too-high too
+  -- (tx_nonce nonce_diff=+1; mirrors @1082; sound: a single tx always has nonce==pre). Multi-tx
+  -- keeps < pre (a sequenced same-sender tx legitimately has nonce > pre).
   "  bne t1, t0, .Lbv_sender_nonce_fail\n" ++                     -- tx.nonce != pre_nonce -> reject (NonceMismatchError)
   "  la a0, tefgp_max_fee\n" ++
   "  la t0, bv_simple_transfer_tx; ld a1, 40(t0)\n" ++            -- gas_limit (u64)

--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -889,7 +889,14 @@ def blockVerdictFunction : String :=
   "  bnez a0, .Lbv_stx_checks_done\n" ++                          -- sender lookup failed/absent -> skip
   "  la t0, bv_stx_sender_acct; ld t0, 0(t0)\n" ++                -- sender pre-state nonce
   "  la t1, sttc_nonce; ld t1, 0(t1)\n" ++                        -- tx.nonce
-  "  bltu t1, t0, .Lbv_sender_nonce_fail\n" ++                    -- tx.nonce < pre_nonce -> reject
+  -- EXACT (not just lower-bound): a single tx's nonce must EQUAL the sender's pre-state nonce
+  -- (spec check_transaction; frontier/validation/transaction/tx_nonce rejects BOTH nonce_diff=-1
+  -- and +1). A single-tx block has exactly one tx from this sender, so the valid nonce is exactly
+  -- pre (no sequencing) -- mirrors the simple-transfer exact check @1082 (bne), extended to the
+  -- contract-recipient/bail path here. Catches too-high as well as too-low; sound (valid single tx
+  -- always has nonce == pre -> never false-rejects). (The multi-tx path keeps the < pre lower bound
+  -- since a sequenced same-sender tx legitimately has nonce > pre; exact there needs per-sender count.)
+  "  bne t1, t0, .Lbv_sender_nonce_fail\n" ++                     -- tx.nonce != pre_nonce -> reject (NonceMismatchError)
   "  la a0, tefgp_max_fee\n" ++
   "  la t0, bv_simple_transfer_tx; ld a1, 40(t0)\n" ++            -- gas_limit (u64)
   "  la a2, bv_upfront_cost\n  jal ra, u256_mul_u64_be\n" ++


### PR DESCRIPTION
## Summary

Follow-up tightening the single-tx contract-recipient nonce check (#8793, merged) from a **lower bound** (`tx.nonce < pre → reject`) to **exact** (`tx.nonce != pre → reject`).

The spec's `check_transaction` rejects **both** a too-low and a too-high nonce — `frontier/validation/transaction/tx_nonce` has `nonce_diff = -1` *and* `+1` both raising `TransactionException`. The lower bound missed the too-high case on this path (a single value-moving tx to a non-self-contained contract with `nonce == pre+1` was accepted though the spec rejects it).

A single-tx block has exactly one tx from the sender, so its valid nonce is exactly the sender's pre-state nonce — this mirrors the simple-transfer exact check `@1082` (`bne`), now extended to the contract-recipient/bail path.

**Sound, no false-reject:** a valid single tx always has `nonce == pre`. (The multi-tx path keeps the `< pre` lower bound, since a sequenced same-sender tx legitimately has `nonce > pre`; exact there needs per-sender counting + a same-sender probe.)

## Validation

- Broad general-fixture sweep: **400/400** full match, 0 fail (no false-reject).
- `frontier/validation/transaction`: **6/6** — incl. `tx_nonce` `+1`/`-1` rejects and `0` accept.
- Full lib build green; file-size / unimported / forbidden-tactics clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)