### PR TITLE
feat(verdict): validate multi-tx sender FINAL nonce vs pre+count (bmvmx.5.5.2 B1)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -1041,6 +1041,16 @@ def ziskStatelessVerdictV2DataSection : String :=
   ".balign 8\n" ++
   "exec_nonstorage_effect_agg_count:\n  .zero 8\n" ++
   "exec_nonstorage_effect_agg:\n  .zero 7168\n" ++
+  -- bmvmx.5.5.2 (umbrella-B1): scratch for the multi-tx per-sender FINAL-nonce check
+  -- (BAL sender post nonce == pre + total sender tx count). bv_b1_finals is the 88-byte
+  -- bal_account_nonstorage_finals output (separate from c2nsc_finals, which A2a's
+  -- comparator uses); bv_b1_acct_ptr/len receive the sender's BAL AccountChanges.
+  ".balign 8\n" ++
+  "bv_b1_count:\n  .zero 8\n" ++
+  "bv_b1_expected:\n  .zero 8\n" ++
+  "bv_b1_acct_ptr:\n  .zero 8\n" ++
+  "bv_b1_acct_len:\n  .zero 8\n" ++
+  "bv_b1_finals:\n  .zero 88\n" ++
   -- i3djw.3: scratch for bal_all_accounts_nonstorage_consistent + its per-account deps
   -- (bal_account_nonstorage_consistent / _finals). rfu_* is already linked (other rlp users).
   ".balign 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -647,25 +647,74 @@ def blockVerdictFunction : String :=
   "  la t1, bv_exec_p; ld t1, 0(t1); addi t1, t1, 32; li t3, 0\n" ++    -- src = fee_recipient (exec_p+32)
   ".Lbv_skl_cb:\n  li t4, 20; beq t3, t4, .Lbv_skl_cb_d\n  add t4, t1, t3; lbu a0, 0(t4); add t4, t6, t3; sb a0, 0(t4); addi t3, t3, 1; j .Lbv_skl_cb\n.Lbv_skl_cb_d:\n" ++
   "  la t2, bv_tx_count; ld t2, 0(t2); slli t3, t2, 1; addi t3, t3, 1; la t0, bv_mtx_skip_count; sd t3, 0(t0)\n" ++  -- count = 2N+1
-  -- bmvmx.5.5.1 (umbrella-A2a): all-accounts NON-STORAGE exec-vs-BAL for the MULTI-TX path.
-  -- The single-tx path runs these two comparators @1077-1094; the multi-tx path skipped them
-  -- (the @618 jump), leaving every non-gas-coupled account's balance/nonce changes unvalidated
-  -- against execution (bmvmx.5.5). Now wired here, consuming the A1 skip-list. CONSERVATIVE
-  -- guards (skip -> never false-reject, mirroring the gas-path's withdrawal guard @1174):
-  --   (a) effect-log overflow: the 64-entry cap dropped records, so a BAL-declared change might
-  --       lack its exec effect -> a non-coupled account would look forged. Skip.
-  --   (b) withdrawals: system-level balance credits land in the BAL but NOT in the tx-execution
-  --       effect log, so a withdrawal-credited (non-coupled) account would look like a declared
-  --       change with no effect -> false-reject. Skip (multi-tx + withdrawals is a follow-up).
-  "  la t0, exec_nonstorage_effect_overflow; ld t0, 0(t0); bnez t0, .Lbv_mtx_ns_skip\n" ++
-  "  la t0, svf_wds_count; ld t0, 0(t0); bnez t0, .Lbv_mtx_ns_skip\n" ++
+  -- bmvmx.5.5.2 (umbrella-B1): validate each multi-tx SENDER's BAL FINAL nonce == pre_nonce +
+  -- (total count of that sender's txs) -- the multi-tx generalization of the single-tx post-
+  -- nonce check (.Lbv_sender_nonce_fail, status 40). An EOA sender's nonce increments once per
+  -- tx (no internal code), so final == pre+count for every valid block -> never false-rejects;
+  -- catches a BAL forging the sender's final nonce. Post-loop pass; sender_i = skip[2i] (A1),
+  -- validated ONCE (first occurrence). Conservative skips: sender absent from BAL, account_at
+  -- failure, no declared nonce change. Cursor in bv_mtx_skip_idx (survives jals; s0 callee-saved).
+  "  la t0, bv_mtx_skip_idx; sd zero, 0(t0)\n" ++                       -- i = 0
+  ".Lbv_b1_loop:\n" ++
+  "  la t0, bv_mtx_skip_idx; ld t1, 0(t0); la t2, bv_tx_count; ld t2, 0(t2); bgeu t1, t2, .Lbv_b1_done\n" ++
+  "  slli t3, t1, 6; la t4, bv_mtx_skip_list; add t4, t4, t3\n" ++      -- t4 = &sender_i = skip[2i] (offset i*64)
+  "  li t5, 0\n" ++                                                     -- k = 0 (first-occurrence scan)
+  ".Lbv_b1_fchk:\n" ++
+  "  bgeu t5, t1, .Lbv_b1_first\n" ++                                   -- k >= i -> i is the first occurrence
+  "  slli t6, t5, 6; la a0, bv_mtx_skip_list; add a0, a0, t6; li a1, 0\n" ++   -- a0 = &skip[2k]
+  ".Lbv_b1_fcmp:\n" ++
+  "  li a2, 20; beq a1, a2, .Lbv_b1_next\n" ++                          -- skip[2k] == sender_i (20B) -> i is a duplicate -> skip
+  "  add a2, a0, a1; lbu a3, 0(a2); add a2, t4, a1; lbu a4, 0(a2); bne a3, a4, .Lbv_b1_fadv\n" ++
+  "  addi a1, a1, 1; j .Lbv_b1_fcmp\n" ++
+  ".Lbv_b1_fadv:\n" ++
+  "  addi t5, t5, 1; j .Lbv_b1_fchk\n" ++
+  ".Lbv_b1_first:\n" ++
+  "  li t5, 0; li t6, 0\n" ++                                          -- k = 0, count = 0
+  ".Lbv_b1_cnt:\n" ++
+  "  la a5, bv_tx_count; ld a5, 0(a5); bgeu t5, a5, .Lbv_b1_cntd\n" ++
+  "  slli a0, t5, 6; la a1, bv_mtx_skip_list; add a0, a1, a0; li a1, 0\n" ++   -- a0 = &skip[2k]
+  ".Lbv_b1_ccmp:\n" ++
+  "  li a2, 20; beq a1, a2, .Lbv_b1_cmatch\n" ++
+  "  add a2, a0, a1; lbu a3, 0(a2); add a2, t4, a1; lbu a4, 0(a2); bne a3, a4, .Lbv_b1_cadv\n" ++
+  "  addi a1, a1, 1; j .Lbv_b1_ccmp\n" ++
+  ".Lbv_b1_cmatch:\n" ++
+  "  addi t6, t6, 1\n" ++
+  ".Lbv_b1_cadv:\n" ++
+  "  addi t5, t5, 1; j .Lbv_b1_cnt\n" ++
+  ".Lbv_b1_cntd:\n" ++
+  "  la t0, bv_b1_count; sd t6, 0(t0)\n" ++                            -- stash total count (jal clobbers t6)
+  "  ld a0, 8(s0); ld a1, 16(s0); mv a2, t4; li a3, 20; ld a4, 80(s0); ld a5, 88(s0); la a6, bv_mtx_sender_acct\n" ++
+  "  jal ra, account_at_header_state_root\n" ++
+  "  bnez a0, .Lbv_b1_next\n" ++                                       -- sender lookup fail/absent -> skip (conservative)
+  "  la t0, bv_mtx_sender_acct; ld t0, 0(t0)\n" ++                     -- t0 = pre_nonce (nonce@0)
+  "  la t1, bv_b1_count; ld t1, 0(t1); add t0, t0, t1\n" ++            -- expected = pre_nonce + count
+  "  la t1, bv_b1_expected; sd t0, 0(t1)\n" ++                         -- stash (jal clobbers)
+  "  la t0, bv_mtx_skip_idx; ld t1, 0(t0); slli t3, t1, 6; la t4, bv_mtx_skip_list; add t4, t4, t3\n" ++  -- reload t4 = &sender_i
+  "  la t0, bv_bal_start; ld a0, 0(t0); la t0, bv_bal_len; ld a1, 0(t0); mv a2, t4; la a3, bv_b1_acct_ptr; la a4, bv_b1_acct_len\n" ++
+  "  jal ra, bal_find_account_by_address\n" ++
+  "  bnez a0, .Lbv_b1_next\n" ++                                       -- sender absent from BAL -> skip (conservative)
+  "  la t0, bv_b1_acct_ptr; ld a0, 0(t0); la t0, bv_b1_acct_len; ld a1, 0(t0); la a2, bv_b1_finals\n" ++
+  "  jal ra, bal_account_nonstorage_finals\n" ++
+  "  bnez a0, .Lbv_b1_next\n" ++                                       -- parse fail -> skip
+  "  la t0, bv_b1_finals; ld t1, 40(t0); beqz t1, .Lbv_b1_next\n" ++   -- has_nonce == 0 -> skip (conservative)
+  "  ld t1, 48(t0)\n" ++                                               -- t1 = BAL declared final nonce
+  "  la t0, bv_b1_expected; ld t0, 0(t0)\n" ++                         -- t0 = pre_nonce + count
+  "  bne t1, t0, .Lbv_sender_nonce_fail\n" ++                          -- BAL sender final nonce != pre + count -> reject
+  ".Lbv_b1_next:\n" ++
+  "  la t0, bv_mtx_skip_idx; ld t1, 0(t0); addi t1, t1, 1; sd t1, 0(t0); j .Lbv_b1_loop\n" ++
+  ".Lbv_b1_done:\n" ++
+  -- bmvmx.5.5.1 (umbrella-A2a): all-accounts NON-STORAGE exec-vs-BAL for the MULTI-TX path
+  -- (the single-tx comparators @1077-1094 were skipped by the @618 jump -> bmvmx.5.5). Wired
+  -- here, consuming the A1 skip-list. CONSERVATIVE guards (skip -> never false-reject, like the
+  -- gas-path wds guard @1174): (a) effect-log overflow (64-cap dropped records); (b) withdrawals
+  -- (system-level credits land in the BAL but not the tx-execution effect log). Both -> skip.
+  "  la t0, exec_nonstorage_effect_overflow; ld t0, 0(t0); bnez t0, .Lbv_mtx_ns_skip\n  la t0, svf_wds_count; ld t0, 0(t0); bnez t0, .Lbv_mtx_ns_skip\n" ++
   -- Aggregate exec_nonstorage_effect_log per-account into exec_nonstorage_effect_agg, keyed by
   -- the 20B BE address @rec+0: first-seen record copied whole; a later record for the same
-  -- account overwrites only post_balance (+64, 32B) + post_nonce (+104, 8B). Records append in
-  -- tx/exec order, so the kept pre = block-start, the kept post = block-final -- exactly what
-  -- bal_account_nonstorage_consistent compares (BAL final == exec post; net-change post!=pre).
-  -- The count never resets across the block in the real path (only the probe @130 zeroes it),
-  -- so the log already holds every tx's effects. Pure loop (no calls -> counters in t/a regs).
+  -- account overwrites only post_balance (+64,32B) + post_nonce (+104,8B). Records append in
+  -- tx/exec order -> kept pre = block-start, kept post = block-final (what the comparator wants;
+  -- BAL final == exec post / net-change post!=pre). The count never resets across the block in
+  -- the real path (only the probe @130 zeroes it). Pure loop (no calls -> counters in t/a regs).
   "  la t0, exec_nonstorage_effect_agg_count; sd zero, 0(t0)\n" ++
   "  la t0, exec_nonstorage_effect_count; ld t1, 0(t0); li t2, 0\n" ++   -- t1 = raw count, t2 = j
   ".Lbv_agg_loop:\n" ++


### PR DESCRIPTION
## What

First slice of **umbrella-B** (the gas-coupled per-tx validation that A2a's comparators skip). Validates each multi-tx **sender's BAL final nonce == pre_nonce + (total count of that sender's txs)** — the multi-tx generalization of the single-tx post-nonce check (`.Lbv_sender_nonce_fail`, status 40). Builds on #8797 (A1) + #8798 (A2a), both in main.

## Why

The single-tx path validates the BAL sender post nonce against execution; the multi-tx path never did. A prover could forge a sender's final nonce in the BAL, and the consistency-only state-root recompute (which builds the trie from BAL-claimed states) would accept it. This closes that gap for the gas-coupled sender account.

## How

- Post-loop pass at `.Lbv_mtx_done`; `sender_i = bv_mtx_skip_list[2i]` (the A1 skip-list). Each sender validated **once** (at its first occurrence); total count = number of skip-list sender entries matching it.
- `pre_nonce` via `account_at_header_state_root(sender)` against the pre-state header; BAL final nonce via `bal_find_account_by_address` + `bal_account_nonstorage_finals`.
- **Sound**: an EOA sender's nonce increments exactly once per tx it sends (EOAs run no internal code), so `final == pre + count` for every valid block → **never false-rejects**.
- **Conservative skips** (no false-reject): sender absent from BAL, `account_at` failure/absence, no declared nonce change.

## Validation

Full 105-byte match, **0 false-rejects**: full **eip8037** suite 200/200 — including `block_gas_used_mixed_txs` (5 distinct senders, count=1 each, all validated). The same-sender **count>1** path is source-validated: the EEST multi-tx fixtures reaching `.Lbv_mtx_done` all use distinct senders, and the same-sender ones are blob txs that bail (status 62). A welder probe for same-sender legacy multi-tx is filed to cover count>1 at EEST scale. Broad 400-fixture sweep also run.

`lake build` green; file-size / forbidden-tactics / unimported guards pass.

> NOTE: `BlockVerdictFunction.lean` is now at the 1500-line cap. The multi-tx validation tail must be split into its own file before the next addition (filed as a bmvmx.5.5 child).

🤖 Generated with [Claude Code](https://claude.com/claude-code)