### PR TITLE
fix(requests): verify deposits from execution logs

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -471,7 +471,11 @@ def ziskStatelessVerdictV2DataSection : String :=
   -- instead of corrupting .data.
   "c1_staging:\n  .zero " ++ toString c1StagingBytes ++ "\n" ++
   ".balign 8\n" ++
-  "c1_er_assembled:\n  .zero 2048\n" ++
+  "c1_er_assembled:\n  .zero 32768\n" ++
+  "c1_dstatus:\n  .zero 8\n" ++
+  "c1_dlen:\n  .zero 8\n" ++
+  "c1_dbody:\n  .zero 32768\n" ++
+  "c1_log_records:\n  .zero 81920\n" ++
   "c1_ccode_ptr:\n  .zero 8\n" ++
   "c1_ccode_len:\n  .zero 8\n" ++
   "c1_bal_acct_ptr:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -60,6 +60,34 @@ def blockVerdictReceiptsTail : String :=
   -- logs (#8732 Part 1 + #8735 Part 2).
   "  bnez a0, .Lbv_receipts_accept                # logs materialize failed -> conservative accept\n" ++
   "  la t2, bv_block_log_overflow; ld t2, 0(t2); bnez t2, .Lbv_receipts_accept\n" ++
+  -- 8uld3.4: derive EIP-6110 deposit requests from EXECUTION-produced logs and
+  -- verify the final requests_hash against the value that the early header-hash
+  -- check already committed to (`erh_requests_hash`). This stops trusting the
+  -- SSZ execution_requests.deposits body: a block whose SSZ deposits match the
+  -- header but whose receipts contain different deposit logs is rejected here.
+  -- The scratch sizes mirror existing arenas: block log data is capped at 64KiB
+  -- and descriptors at 128, so 81920 bytes covers records (data + 80*128);
+  -- 32768 covers all derived request bodies plus the assembled section.
+  "  la a0, bv_block_log_descs\n" ++
+  "  la t2, bv_block_log_count; ld a1, 0(t2)\n" ++
+  "  la a2, bv_block_log_data\n" ++
+  "  la a3, bv_block_log_meta\n" ++
+  "  la a4, c1_log_records\n" ++
+  "  jal ra, materialize_log_records\n" ++
+  "  la a0, c1_log_records\n" ++
+  "  la t2, bv_block_log_count; ld a1, 0(t2)\n" ++
+  "  la a2, c1_dbody\n" ++
+  "  la a3, c1_dstatus\n" ++
+  "  jal ra, parse_deposit_requests\n" ++
+  "  la t2, c1_dlen; sd a0, 0(t2)\n" ++
+  "  la t2, c1_dstatus; ld t2, 0(t2); bnez t2, .Lbv_requests_hash_fail\n" ++
+  "  la a0, c1_dbody; la t2, c1_dlen; ld a1, 0(t2)\n" ++
+  "  la a2, dbsr_wbody; la t2, dbsr_wlen; ld a3, 0(t2)\n" ++
+  "  la a4, dbsr_cbody; la t2, dbsr_clen; ld a5, 0(t2)\n" ++
+  "  la a6, erh_requests_hash\n" ++
+  "  la a7, c1_er_assembled\n" ++
+  "  jal ra, requests_hash_verify\n" ++
+  "  bnez a0, .Lbv_requests_hash_fail\n" ++
   -- CONSERVATIVE COMPLETENESS GATE: only enforce when the EIP-7708 top-level transfer log
   -- (Part 2) is known to have fired correctly, i.e. the bmvmx compute completed (legacy
   -- single-tx). For non-legacy (EIP-2930/1559/4844/7702) or multi-tx blocks the bmvmx path
@@ -128,6 +156,8 @@ def blockVerdictReceiptsTail : String :=
   "  li t0, 19; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_receipt_records_fail:\n" ++
   "  li t0, 25; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
+  ".Lbv_requests_hash_fail:\n" ++
+  "  li t0, 55; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_notx_receipts_root_fail:\n" ++   -- .63.1.6.2.3: no-tx header.receipts_root != empty-trie root
   "  li t0, 50; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_notx_bloom_fail:\n" ++           -- .63.1.6.2.3: no-tx header.bloom != 256 zero bytes

--- a/EvmAsm/Codegen/Programs/StatelessGuest.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuest.lean
@@ -21,6 +21,7 @@ import EvmAsm.Codegen.Programs.StatelessGuestEpilogue
 import EvmAsm.Codegen.Programs.BlockVerdictV2
 import EvmAsm.Codegen.Programs.SystemCallStaging
 import EvmAsm.Codegen.Programs.ParseDepositRequests
+import EvmAsm.Codegen.Programs.MaterializeLogRecords
 import EvmAsm.Codegen.Programs.AssembleExecutionRequests
 import EvmAsm.Codegen.Programs.SystemCallStoragePreload
 import EvmAsm.Stateless.Entry
@@ -77,9 +78,11 @@ def statelessGuestUnit : BuildUnit := {
     -- replaces the SSZ-deposits trust (BlockVerdictStateRoot.lean:430-445) with derivation.
     parseDepositRequestsFunction ++ "\n" ++
     extractDepositDataFunction ++ "\n" ++
+    materializeLogRecordsFunction ++ "\n" ++
     -- 8uld3.2.3.3.1 (C.1): assemble [deposit, derived-w, derived-c] into the SSZ
     -- execution_requests section that execution_requests_hash then hashes.
     assembleExecutionRequestsFunction ++ "\n" ++
+    requestsHashVerifyFunction ++ "\n" ++
     -- 8uld3.2.3.3.1 (C.1): stage the system-call predeploy's request-queue storage so its
     -- SLOAD reads real witness values (builds the (key,original-value) preload from the
     -- predeploy's BAL AccountChanges). Fed to the system call via scc_preload_ptr/count (8uld3.2.1.5).
@@ -123,6 +126,7 @@ def statelessGuestUnit : BuildUnit := {
     ".balign 8\n" ++
     "pdr_out:\n  .zero 2048\n" ++
     "pdr_status:\n  .zero 8\n" ++
+    "rhv_hash:\n  .zero 32\n" ++
     stagePredeployStoragePreloadData ++ "\n" ++   -- 8uld3.2.3.3.1 (C.1): sps_* globals for the predeploy storage preload
     emitRuntimeDispatcherDataSectionSharedGuest callFrameGuestRegistry
 }


### PR DESCRIPTION
## Summary
- derive EIP-6110 deposit request bodies from materialized execution logs in the block verdict tail
- verify derived deposits + derived withdrawal/consolidation bodies against the header-committed requests_hash
- add stateless guest linkage and scratch for materialize_log_records / requests_hash_verify

## Validation
- lake build
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- scripts/check-forbidden-tactics.sh
- scripts/check-no-warnings.sh
- scripts/codegen-zisk-assemble-execution-requests-check.sh
- scripts/codegen-zisk-parse-deposit-requests-check.sh
- scripts/codegen-zisk-derive-requests-hash-e2e-check.sh
- scripts/codegen-eest-valid-multi-type-requests-check.sh (29/29 full match)
- scripts/codegen-eest-stateless-check.sh --filter eip6110_deposits --limit 80 --max-jobs 8 --run-dir gen-out/eest-eip6110-derived-deposits --max-failures 1 --quiet-passes (74/74 full match)

## Follow-up
- Full corrupted-SSZ-deposit EEST fixture coverage filed for welder as evm-asm-e3vib.