### PR TITLE
fix(codegen): enforce receipts for type3 transfers

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -874,14 +874,15 @@ def blockVerdictFunction : String :=
   -- block_log_window_snapshot reads evm_env via `la`, so it is unaffected.
   "  la t0, bmvmx_avail; ld t0, 0(t0); bnez t0, .Lbv_tl7708_ready\n" ++
   -- bmvmx.7.1: widen Part-2 top-level transfer-log coverage to the already-supported
-  -- single typed simple-transfer runtime path. Keep this independent from bmvmx_avail:
+  -- single typed simple-transfer runtime path, now including type-3 blob transfers. Keep this independent from bmvmx_avail:
   -- the balance-movement verifier is still legacy-only, but receipts completeness only
   -- needs sender/recipient/value. simple_transfer_tx_context has already accepted the tx,
   -- so +24/+72/+96/+160 are populated here. Reuse bmvmx_sender_addr/bmvmx_value so the
   -- legacy packing block below remains the single source for the EIP-7708 descriptor shape.
   "  la t0, bv_simple_transfer_tx; ld t1, 0(t0); bnez t1, .Lbv_tl7708_skip\n" ++
   "  ld t1, 160(t0); li t2, 1; beq t1, t2, .Lbv_tl_typed_ok\n" ++
-  "  li t2, 2; bne t1, t2, .Lbv_tl7708_skip\n" ++
+  "  li t2, 2; beq t1, t2, .Lbv_tl_typed_ok\n" ++
+  "  li t2, 3; bne t1, t2, .Lbv_tl7708_skip\n" ++
   ".Lbv_tl_typed_ok:\n" ++
   "  addi t1, t0, 96; la t2, bmvmx_value; li t3, 0\n" ++
   ".Lbv_tl_typed_vcopy:\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -91,7 +91,7 @@ def blockVerdictReceiptsTail : String :=
   -- CONSERVATIVE COMPLETENESS GATE: enforce only when the EIP-7708 top-level transfer log
   -- (Part 2) is known to be represented in the materialized log window. bmvmx_avail covers
   -- the legacy single-tx path; eip7708_tl_typed_avail covers the narrow type-1/type-2 simple-transfer
-  -- paths added by bmvmx.7.1. Other typed and multi-tx blocks remain conservative until their
+  -- paths added by bmvmx.7.1 plus the type-3 blob-transfer path from bmvmx.7.3. Other typed and multi-tx blocks remain conservative until their
   -- top-level logs are complete, avoiding confirmed-but-spurious receipts-root mismatches.
   "  la t2, bmvmx_avail; ld t2, 0(t2); bnez t2, .Lbv_receipts_enforce\n" ++
   "  la t2, eip7708_tl_typed_avail; ld t2, 0(t2); beqz t2, .Lbv_receipts_accept\n" ++


### PR DESCRIPTION
## Summary
- Extend the typed simple-transfer EIP-7708 top-level log path from type1/type2 to type3 blob transactions.
- This also widens tx-bearing receipts_root/logs_bloom enforcement for covered type3 transfers through the existing eip7708_tl_typed_avail gate.
- Split type4/EIP-7702 into bead evm-asm-57t4x because authorization-list processing and set-code effects still need a dedicated safe context.

## Validation
- lake build
- scripts/codegen-eest-stateless-check.sh --filter eip7708_eth_transfer_logs --skip 70 --limit 1 --jobs 1 --quiet-passes --run-dir /tmp/bmvmx73-type3-receipts-eip7708-type2 --no-verdict-debug --steps 20000000000
- scripts/codegen-eest-stateless-check.sh --skip 5029 --limit 1 --jobs 1 --quiet-passes --run-dir /tmp/bmvmx73-type3-receipts-5029-current-main --steps 20000000000
- scripts/codegen-eest-stateless-check.sh --limit 400 --jobs 8 --quiet-passes --run-dir /tmp/bmvmx73-type3-receipts-sweep400 --no-verdict-debug --steps 20000000000
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- scripts/check-forbidden-tactics.sh

Bead: evm-asm-bmvmx.7.3