### PR TITLE
fix(receipts): allow calldata contract dispatch

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -67,6 +67,7 @@ import EvmAsm.Codegen.Programs.BlockVerdictChainConfig
 import EvmAsm.Codegen.Programs.BlockVerdictParams
 import EvmAsm.Codegen.Programs.BlockVerdictDataSection
 import EvmAsm.Codegen.Programs.BlockVerdictRuntimePayload
+import EvmAsm.Codegen.Programs.BlockVerdictSingleTxLog
 import EvmAsm.Codegen.Programs.BlockVerdictStateRoot
 import EvmAsm.Codegen.Programs.BlockVerdictFunction
 import EvmAsm.Codegen.Programs.MultiTxSenderDebit
@@ -279,6 +280,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   headerExtractLogsBloomFunction ++ "\n" ++
   bloomEqFunction ++ "\n" ++
   blockVerdictFunction ++ "\n" ++
+  blockVerdictSingleTxTopLevelLogFunction ++ "\n" ++
   rlpListCountItemsFunction ++ "\n" ++
   bgvU32leFunction ++ "\n" ++
   bgvU64leFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -716,6 +716,7 @@ def blockVerdictFunction : String :=
   "  ld t3, 24(t0); ld t4, 24(t1); bne t3, t4, .Lbv_contract_dispatch\n" ++
   ".Lbv_cd_eoa_restore:\n" ++
   "  la t2, bv_simple_transfer_tx        # restore t2 for the EOA path (jal clobbered it)\n" ++
+  "  ld t0, 64(t2); bnez t0, .Lbv_after_tx_gas_precharge  # EOA calldata not staged here\n" ++
   "  ld t0,  96(t2); bnez t0, .Lbv_tx_gas_precharge_nonzero_value\n" ++
   "  ld t0, 104(t2); bnez t0, .Lbv_tx_gas_precharge_nonzero_value\n" ++
   "  ld t0, 112(t2); bnez t0, .Lbv_tx_gas_precharge_nonzero_value\n" ++
@@ -1026,10 +1027,11 @@ def blockVerdictFunction : String :=
   "  la a0, bv_stx_sender_acct; addi a0, a0, 8\n  la a1, bv_upfront_cost\n  la a2, bv_upfront_islt\n  jal ra, u256_lt_be\n" ++
   "  la t0, bv_upfront_islt; ld t0, 0(t0)\n  bnez t0, .Lbv_sender_upfront_fail\n" ++
   ".Lbv_stx_checks_done:\n" ++
+  "  jal ra, bv_emit_single_tx_tl7708\n" ++
   "  la a0, bv_simple_transfer_tx\n" ++
   "  ld a1, 80(s0); ld a2, 88(s0)\n" ++
   "  jal ra, dispatch_tx_runtime_code\n" ++
-  "  bnez a0, .Lbv_after_tx_gas_precharge\n" ++
+  "  bnez a0, .Lbv_contract_dispatch_unsupported\n" ++
   -- fhsxz.2.4.2.57.11.6.5.2.1 P1: persist tx0's executed state gas into bvgr_tx_exec_state_gas[0].
   -- Clobbers only a0/t0-t2, preserves the dispatch results a1-a4 stored below. Behavior-neutral.
   "  li a0, 0; jal ra, dispatcher_capture_exec_state_gas\n" ++
@@ -1375,6 +1377,9 @@ def blockVerdictFunction : String :=
   "  beqz t2, .Lbv_after_tx_gas_precharge\n" ++                  -- sender == coinbase -> skip
   "  lbu t3, 0(t0); lbu t4, 0(t1); bne t3, t4, .Lbv_sender_bal_fail\n" ++
   "  addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1; j .Lbv_sbc_cb_cmp\n" ++
+  ".Lbv_contract_dispatch_unsupported:\n" ++
+  "  la t0, eip7708_tl_typed_avail; sd zero, 0(t0)\n" ++
+  "  j .Lbv_after_tx_gas_precharge\n" ++
   ".Lbv_after_tx_gas_precharge:\n" ++
   -- fhsxz.2.4.2.57.11.6.5.2.1.3: prefill the transaction-count and
   -- intrinsic-state-gas substrate BEFORE eip8037_tx_gas_gate. The gate still

--- a/EvmAsm/Codegen/Programs/BlockVerdictSimpleTransfer.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictSimpleTransfer.lean
@@ -30,7 +30,7 @@ open EvmAsm.Rv64
 
     Output:
       +0   status
-             0  ok: single tx, 65-byte pubkey, non-creation, empty calldata
+             0  ok: single tx, 65-byte pubkey, non-creation,
                 legacy/2930/1559/blob/7702 tx
              1  transaction count is not exactly one
              2  public key bundle is not exactly 65 bytes
@@ -42,7 +42,7 @@ open EvmAsm.Rv64
              40 value extraction failed
              50 data-section extraction failed
              60 contract creation transaction
-             61 non-empty calldata/initcode
+             61 reserved (formerly non-empty calldata/initcode)
              62 reserved (formerly EIP-4844 blob unsupported)
              63 reserved (formerly EIP-7702 set-code unsupported)
       +8   tx ptr
@@ -138,8 +138,6 @@ def simpleTransferTxContextFunction : String :=
   "  ld t0, 48(s0); beqz t0, .Lsttc_not_creation\n" ++
   "  li t1, 60; sd t1, 0(s0); j .Lsttc_ret\n" ++
   ".Lsttc_not_creation:\n" ++
-  "  ld t0, 64(s0); beqz t0, .Lsttc_ok\n" ++
-  "  li t1, 61; sd t1, 0(s0); j .Lsttc_ret\n" ++
   ".Lsttc_ok:\n" ++
   "  sd zero, 0(s0); j .Lsttc_ret\n" ++
   ".Lsttc_item_oob:\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictSingleTxLog.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictSingleTxLog.lean
@@ -1,0 +1,51 @@
+/-
+  EvmAsm.Codegen.Programs.BlockVerdictSingleTxLog
+
+  Small helper for block_verdict's single-transaction contract-recipient path.
+  It emits the EIP-7708 top-level value-transfer log before runtime dispatch so
+  receipt log order matches execution-specs: top-level value movement first,
+  then recipient-code logs.
+-/
+
+import EvmAsm.Rv64.Program
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+def blockVerdictSingleTxTopLevelLogFunction : String :=
+  "bv_emit_single_tx_tl7708:\n" ++
+  "  addi sp, sp, -16\n" ++
+  "  sd ra, 0(sp); sd x20, 8(sp)\n" ++
+  "  la t0, bv_simple_transfer_tx; ld t1, 0(t0); bnez t1, .Lbvestl_ret\n" ++
+  "  addi t1, t0, 96; ld t2, 0(t1); ld t3, 8(t1); or t2, t2, t3; ld t3, 16(t1); or t2, t2, t3; ld t3, 24(t1); or t2, t2, t3\n" ++
+  "  beqz t2, .Lbvestl_ret\n" ++
+  "  ld a0, 24(t0); beqz a0, .Lbvestl_ret\n" ++
+  "  la a1, bmvmx_sender_addr; jal ra, address_from_pubkey\n" ++
+  "  la t0, bmvmx_sender_addr; la t1, bv_simple_transfer_tx; addi t1, t1, 72; li t2, 20\n" ++
+  ".Lbvestl_selfcmp:\n" ++
+  "  beqz t2, .Lbvestl_ret\n" ++
+  "  lbu t3, 0(t0); lbu t4, 0(t1); bne t3, t4, .Lbvestl_notself\n" ++
+  "  addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1; j .Lbvestl_selfcmp\n" ++
+  ".Lbvestl_notself:\n" ++
+  "  la t0, eip7708_tl_from32\n  sd x0, 0(t0); sd x0, 8(t0); sd x0, 16(t0); sd x0, 24(t0)\n" ++
+  "  la t1, bmvmx_sender_addr; addi t1, t1, 19; mv t2, t0; li t3, 20\n" ++
+  ".Lbvestl_from:\n  beqz t3, .Lbvestl_from_done\n  lbu t4, 0(t1); sb t4, 0(t2); addi t1, t1, -1; addi t2, t2, 1; addi t3, t3, -1; j .Lbvestl_from\n" ++
+  ".Lbvestl_from_done:\n" ++
+  "  la t0, eip7708_tl_to32\n  sd x0, 0(t0); sd x0, 8(t0); sd x0, 16(t0); sd x0, 24(t0)\n" ++
+  "  la t1, bv_simple_transfer_tx; addi t1, t1, 91; mv t2, t0; li t3, 20\n" ++
+  ".Lbvestl_to:\n  beqz t3, .Lbvestl_to_done\n  lbu t4, 0(t1); sb t4, 0(t2); addi t1, t1, -1; addi t2, t2, 1; addi t3, t3, -1; j .Lbvestl_to\n" ++
+  ".Lbvestl_to_done:\n" ++
+  "  la t0, eip7708_tl_val32\n  la t1, bv_simple_transfer_tx; addi t1, t1, 127; mv t2, t0; li t3, 32\n" ++
+  ".Lbvestl_val:\n  beqz t3, .Lbvestl_val_done\n  lbu t4, 0(t1); sb t4, 0(t2); addi t1, t1, -1; addi t2, t2, 1; addi t3, t3, -1; j .Lbvestl_val\n" ++
+  ".Lbvestl_val_done:\n" ++
+  "  la x20, evm_env\n  la a0, eip7708_tl_from32\n  la a1, eip7708_tl_to32\n  la a2, eip7708_tl_val32\n" ++
+  "  jal ra, eip7708_append_transfer_log\n" ++
+  "  bnez a0, .Lbvestl_ret\n" ++
+  "  li t1, 1; la t0, eip7708_tl_typed_avail; sd t1, 0(t0)\n" ++
+  ".Lbvestl_ret:\n" ++
+  "  ld ra, 0(sp); ld x20, 8(sp)\n" ++
+  "  addi sp, sp, 16\n" ++
+  "  ret"
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
@@ -25,6 +25,7 @@ import EvmAsm.Codegen.Programs.SystemCallStoragePreload
 
 import EvmAsm.Codegen.Programs.MptEncodeLeafBranch
 import EvmAsm.Codegen.Programs.BlockVerdictContractStage
+import EvmAsm.Codegen.Programs.BlockVerdictSingleTxLog
 import EvmAsm.Codegen.Programs.BlockVerdictSelfContained
 import EvmAsm.Codegen.Programs.BlockVerdictBalFindAccount
 import EvmAsm.Codegen.Programs.BlockVerdictContractStorage
@@ -392,6 +393,7 @@ def statelessVerdictV2GuestClosure : String :=
   balRecipientStorageKeysFunction ++ "\n" ++
   balRecipientStorageReadsKeysFunction ++ "\n" ++
   stageRuntimePayloadCodeFunction ++ "\n" ++
+  blockVerdictSingleTxTopLevelLogFunction ++ "\n" ++
   -- .6.2.2.1: contract-recipient runtime gas-measurement tail extracted from
   -- block_verdict so the multi-tx dispatch loop can reuse it.
   dispatchTxRuntimeCodeFunction ++ "\n" ++


### PR DESCRIPTION
## Summary\n- allow the shared single-tx context to carry calldata for non-creation txs\n- keep EOA calldata conservative because the EOA payload staging path still assumes empty calldata\n- emit a single-tx contract top-level EIP-7708 value-transfer log before runtime dispatch, while clearing the completeness flag if dispatch bails\n\n## Validation\n- lake build\n- lake exe codegen --program stateless_guest --halt linux93 -o gen-out/stateless_guest-calldata-receipts\n- scripts/codegen-eest-stateless-check.sh --filter calldata --limit 20 --jobs 1 --max-jobs 1 --max-failures 1 --run-dir gen-out/eest-calldata-receipts-smoke2\n- scripts/codegen-eest-stateless-check.sh --filter call_opcodes_transfer_log_behavior --limit 10 --jobs 1 --max-jobs 1 --max-failures 1 --run-dir gen-out/eest-calldata-contract-log-smoke2\n- scripts/codegen-eest-stateless-check.sh --filter eip7708_eth_transfer_logs/transfer_logs --limit 40 --jobs 1 --max-jobs 1 --max-failures 1 --run-dir gen-out/eest-calldata-eip7708-transfer-sweep\n- scripts/check-no-warnings.sh\n- scripts/check-file-size.sh\n- scripts/check-unimported.sh\n- scripts/check-forbidden-tactics.sh\n- git diff --check\n\nNote: the existing calldata/transfer-log fixtures I found either pass full-match or remain conservative in debug counters; this PR opens the supported contract-dispatch path at source level and preserves conservative behavior when dispatch does not complete.