### PR TITLE
fix(receipts): classify creation tx contexts

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -94,7 +94,7 @@ def blockVerdictFunction : String :=
   "  srli t1, a0, 2; la t0, bv_tx_count; sd t1, 0(t0)\n" ++
   "  li t0, 1; bne t1, t0, .Lbmvmx_done\n" ++                       -- single-tx class only
   "  la a0, bmvmx_ctx; li a1, 0; jal ra, multi_tx_nth_context\n" ++
-  "  la t0, bmvmx_ctx; ld t0, 0(t0); bnez t0, .Lbmvmx_done\n" ++   -- unsupported tx shape
+  "  la t0, bmvmx_ctx; ld t1, 0(t0); bnez t1, .Lbmvmx_done; ld t1, 48(t0); bnez t1, .Lbmvmx_done\n" ++   -- unsupported/creation tx shape
   -- bmvmx.1.4.3.1 envelope (cheap half): restrict the exec-derived balance compare to a
   -- LEGACY (type-0, no access list) single tx. Outside legacy, stay conservative: jump to
   -- .Lbmvmx_done (skip the whole inert compute; bmvmx_avail stays 0, so .4.3.2's gate never
@@ -444,7 +444,7 @@ def blockVerdictFunction : String :=
   ".Lbv_mtx_loop:\n" ++
   "  la t0, bv_mtx_i; ld t1, 0(t0); la t2, bv_tx_count; ld t2, 0(t2); beq t1, t2, .Lbv_mtx_done\n" ++
   "  la a0, bv_mtx_ctx; mv a1, t1; jal ra, multi_tx_nth_context\n" ++
-  "  la t0, bv_mtx_ctx; ld t0, 0(t0); bnez t0, .Lbv_mtx_bail        # unsupported tx shape\n" ++
+  "  la t0, bv_mtx_ctx; ld t2, 0(t0); bnez t2, .Lbv_mtx_bail; ld t2, 48(t0); bnez t2, .Lbv_mtx_bail        # unsupported/creation tx shape\n" ++
   -- bmvmx.5 (fee-validity hoist, multi-tx): same PATH-INDEPENDENT check_transaction
   -- fee-validity test as the single-tx gate (max_fee>=base_fee / priority<=max_fee),
   -- run per tx in the mtx loop. bv_mtx_ctx holds tx ptr@8 / len@16 (simple_transfer layout,
@@ -680,7 +680,7 @@ def blockVerdictFunction : String :=
   ".Lbv_singletx:\n" ++
   "  la a0, bv_simple_transfer_tx\n" ++
   "  jal ra, simple_transfer_tx_context\n" ++
-  "  la t2, bv_simple_transfer_tx; ld t0, 0(t2); bnez t0, .Lbv_after_tx_gas_precharge\n" ++
+  "  la t2, bv_simple_transfer_tx; ld t0, 0(t2); bnez t0, .Lbv_after_tx_gas_precharge; ld t0, 48(t2); bnez t0, .Lbv_after_tx_gas_precharge\n" ++
   -- bmvmx.5 (fee-validity hoist, single-tx): the spec check_transaction fee-validity
   -- pre-conditions -- max_fee_per_gas >= base_fee_per_gas (InsufficientMaxFeePerGasError)
   -- and max_priority_fee_per_gas <= max_fee_per_gas (PriorityFeeGreaterThanMaxFeeError,

--- a/EvmAsm/Codegen/Programs/BlockVerdictMultiTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictMultiTx.lean
@@ -46,7 +46,7 @@ open EvmAsm.Rv64
     populates only the transaction-intrinsic fields.
 
     Status (record +0):
-      0  ok: non-creation, legacy/2930/1559/blob/7702 tx
+      0  ok: classified creation or non-creation, legacy/2930/1559/blob/7702 tx
       3  malformed transaction list (too short / offset table not 4-aligned /
          offset out of range)
       4  transaction item is empty
@@ -56,8 +56,8 @@ open EvmAsm.Rv64
       30 to-address extraction failed
       40 value extraction failed
       50 data-section extraction failed
-      60 contract creation transaction
-      61 non-empty calldata/initcode
+      60 reserved (formerly contract creation transaction)
+      61 reserved (formerly non-empty calldata/initcode)
       62 reserved (formerly EIP-4844 blob unsupported)
       63 reserved (formerly EIP-7702 set-code unsupported) -/
 def multiTxNthContextFunction : String :=
@@ -130,8 +130,6 @@ def multiTxNthContextFunction : String :=
   "  beqz a0, .Lmtx_data_ok\n" ++
   "  li t0, 50; sd t0, 0(s0); j .Lmtx_ret\n" ++
   ".Lmtx_data_ok:\n" ++
-  "  ld t0, 48(s0); beqz t0, .Lmtx_not_creation\n" ++
-  "  li t1, 60; sd t1, 0(s0); j .Lmtx_ret\n" ++
   ".Lmtx_not_creation:\n" ++
   -- fhsxz.2.4.2.57.11.6.5 (experiment): allow calldata-bearing txs. ctx+56/+64 hold
   -- the calldata ptr/len (tx_extract_data_section); dispatch's stage_runtime_payload_code

--- a/EvmAsm/Codegen/Programs/BlockVerdictSimpleTransfer.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictSimpleTransfer.lean
@@ -30,7 +30,7 @@ open EvmAsm.Rv64
 
     Output:
       +0   status
-             0  ok: single tx, 65-byte pubkey, non-creation,
+             0  ok: single tx, 65-byte pubkey, classified creation or non-creation,
                 legacy/2930/1559/blob/7702 tx
              1  transaction count is not exactly one
              2  public key bundle is not exactly 65 bytes
@@ -41,7 +41,7 @@ open EvmAsm.Rv64
              30 to-address extraction failed
              40 value extraction failed
              50 data-section extraction failed
-             60 contract creation transaction
+             60 reserved (formerly contract creation transaction)
              61 reserved (formerly non-empty calldata/initcode)
              62 reserved (formerly EIP-4844 blob unsupported)
              63 reserved (formerly EIP-7702 set-code unsupported)
@@ -135,8 +135,6 @@ def simpleTransferTxContextFunction : String :=
   "  beqz a0, .Lsttc_data_ok\n" ++
   "  li t0, 50; sd t0, 0(s0); j .Lsttc_ret\n" ++
   ".Lsttc_data_ok:\n" ++
-  "  ld t0, 48(s0); beqz t0, .Lsttc_not_creation\n" ++
-  "  li t1, 60; sd t1, 0(s0); j .Lsttc_ret\n" ++
   ".Lsttc_not_creation:\n" ++
   ".Lsttc_ok:\n" ++
   "  sd zero, 0(s0); j .Lsttc_ret\n" ++


### PR DESCRIPTION
## Summary
- allow single and multi tx context builders to classify top-level creation txs as status 0 while preserving the existing is_creation flag and initcode ptr/len fields
- keep current verdict consumers conservative by bailing on is_creation before non-creation settlement/receipt paths
- reserve the old creation rejection status code 60 in context docs

## Validation
- lake build
- scripts/codegen-eest-stateless-check.sh --filter contract_creation_tx --limit 10 --jobs 1 --max-jobs 1 --max-failures 1 --run-dir gen-out/eest-creation-context (2/2 PASS full)
- scripts/codegen-eest-stateless-check.sh --filter eip7708_eth_transfer_logs/transfer_logs --limit 40 --jobs 1 --max-jobs 1 --max-failures 1 --run-dir gen-out/eest-creation-context-eip7708 (40/40 PASS full)
- scripts/check-no-warnings.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- scripts/check-forbidden-tactics.sh
- git diff --check

Bead: evm-asm-fhsxz.2.4.2.63.1.6.2.7.3.3.1