### PR TITLE
fix(eip7702): skip 21k-only precharge verifier

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -749,6 +749,7 @@ def blockVerdictFunction : String :=
   "  ld t3, 24(t0); ld t4, 24(t1); bne t3, t4, .Lbv_after_tx_gas_precharge\n" ++
   "  la t2, bv_simple_transfer_tx\n" ++
   "  ld t0, 160(t2); li t1, 3; beq t0, t1, .Lbv_after_tx_gas_precharge  # blob txs need blob-aware settlement\n" ++
+  "  li t1, 4; beq t0, t1, .Lbv_after_tx_gas_precharge  # EIP-7702 auth-list intrinsic gas is not 21k-only\n" ++
   "  ld a0, 8(t2); ld a1, 16(t2); ld a3, 24(t2); ld a2, 32(t2)\n" ++
   "  la t2, bv_bal_start; ld a4, 0(t2)\n" ++
   "  la t2, bv_bal_len; ld a5, 0(t2)\n" ++


### PR DESCRIPTION
## Summary
- skip the EOA 21k-only post-balance precharge verifier for type-4 EIP-7702 transactions
- keep type-4 rows on the conservative gas/state path because authorization-list intrinsic gas makes the 21k refund model invalid

## Validation
- lake build
- scripts/check-no-warnings.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- scripts/check-forbidden-tactics.sh
- git diff --check
- EEST focused: --filter bal_7702_invalid_authority_has_code_authorization --limit 1 PASS(full)
- EEST nearby: --filter block_access_lists_eip7702 --limit 20 PASS(full) 20/20

Fixes bead evm-asm-fhsxz.15.