### PR TITLE
fix(receipts): split completeness gate by shape

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -132,6 +132,8 @@ def ziskStatelessVerdictV2Prologue : String :=
   "  la t1, bv_withdrawals_root_valid; ld t2, 0(t1); sd t2, 384(t0)\n" ++
   "  la t1, bv_tx_root_status; ld t2, 0(t1); sd t2, 392(t0)\n" ++
   "  la t1, svf_tx_count; ld t2, 0(t1); sd t2, 400(t0)\n" ++
+  "  la t1, bv_receipts_completeness_shape; ld t2, 0(t1); sd t2, 408(t0)\n" ++
+  "  la t1, bv_receipts_enforce_enabled; ld t2, 0(t1); sd t2, 416(t0)\n" ++
   "  j .Lv2_pdone\n" ++
   zkvmSha256Function ++ "\n" ++
   zkvmKeccak256Function ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -974,6 +974,21 @@ def ziskStatelessVerdictV2DataSection : String :=
   ".balign 8\n" ++
   "bmvmx_avail:\n  .zero 8\n" ++
   "eip7708_tl_typed_avail:\n  .zero 8\n" ++
+  -- Receipts completeness shape for the enforcement tail:
+  --   0 unknown/none
+  --   1 legacy single-tx simple EOA
+  --   2 typed single-tx simple EOA
+  --   3 single-tx calldata contract dispatch complete
+  --   4 multi-tx EOA dispatch complete
+  --   5 multi-tx contract dispatch complete
+  --   60 top-level creation unsupported
+  --   61 runtime dispatch miss / non-self-contained
+  --   62 other multi-tx unsupported bail
+  -- `bv_receipts_enforce_enabled` is the stable gate bit consumed by
+  -- BlockVerdictReceiptsTail; the older availability flags remain as
+  -- compatibility/debug signals for the paths that originally introduced them.
+  "bv_receipts_completeness_shape:\n  .zero 8\n" ++
+  "bv_receipts_enforce_enabled:\n  .zero 8\n" ++
   "bmvmx_gas_used:\n  .zero 8\n" ++
   "bmvmx_txoff:\n  .zero 8\n" ++
   "bmvmx_ctx:\n  .zero 192\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -1,11 +1,7 @@
 /-
   EvmAsm.Codegen.Programs.BlockVerdictFunction
 
-  Extracted from `BlockVerdict.lean` to keep every file under the
-  `FileSizeGuard` line cap. Holds `blockVerdictFunction`, the full
-  state-transition verdict assembly string (header rebuild + post-state
-  recompute + state-root compare). It is concatenated into the
-  `zisk_stateless_verdict_v2` probe prologue back in `BlockVerdict.lean`.
+  Main block_verdict assembly string, split from BlockVerdict.lean for FileSizeGuard.
 -/
 
 import EvmAsm.Rv64.Program
@@ -14,6 +10,7 @@ import EvmAsm.Codegen.Programs.BlockVerdictTransactions
 import EvmAsm.Codegen.Programs.BlockVerdictReceiptsTail
 import EvmAsm.Codegen.Programs.BlockVerdictMtxTail
 import EvmAsm.Codegen.Programs.BlockVerdictMtxEoa
+import EvmAsm.Codegen.Programs.BlockVerdictReceiptGate
 
 namespace EvmAsm.Codegen
 
@@ -77,7 +74,7 @@ def blockVerdictFunction : String :=
   -- and block_state_root (BlockVerdict.lean:67-302) reads none of these globals.
   "  la t0, bmvmx_avail; sd zero, 0(t0)\n" ++
   "  la t0, eip7708_tl_typed_avail; sd zero, 0(t0)\n" ++
-  "  la t0, bmvmx_sender_checked; sd zero, 0(t0)\n" ++             -- bmvmx.1.4.3.1: envelope predicate flags default 0
+  bvReceiptsShapeClear ++  "  la t0, bmvmx_sender_checked; sd zero, 0(t0)\n" ++             -- bmvmx.1.4.3.1: envelope predicate flags default 0
   "  la t0, bmvmx_coinbase_checked; sd zero, 0(t0)\n" ++
   "  addi t4, s3, 60; la t0, bv_exec_p; sd t4, 0(t0)\n" ++         -- exec_p = ssz_base(s3)+60 (block_state_root's bsr_exec_p derivation; 0(s0) is NOT populated pre-348)
   "  la t4, bv_exec_p; ld t4, 0(t4); addi a0, t4, 504; jal ra, bgv_u32le\n" ++       -- transactions_offset
@@ -192,12 +189,7 @@ def blockVerdictFunction : String :=
   "  la t0, bmvmx_coinbase_checked; li t1, 1; sd t1, 0(t0)\n" ++       -- bmvmx.1.4.3.1: coinbase compare PERFORMED in-envelope (distinctness cleared below)
   ".Lbmvmx_cb_skip:\n" ++
   "  la t0, bmvmx_avail; li t1, 1; sd t1, 0(t0)\n" ++
-  -- bmvmx.1.4.3.1 distinctness: clear bmvmx_sender_checked if sender overlaps recipient (self-
-  -- transfer: value nets out, debit would overcount value) or coinbase (priority fee credited
-  -- back); clear bmvmx_coinbase_checked if coinbase overlaps sender or recipient (also receives
-  -- value). Reached only when the compute completed (bmvmx_avail just set); sender_addr,
-  -- coinbase_addr and the recipient (bmvmx_ctx+72) are all populated here. Each *_checked is 0
-  -- unless its compare was performed above, so this only narrows, never widens.
+  bvReceiptsShapeSet 1 true ++  -- Distinctness clears the performed sender/coinbase checks when value/fee effects overlap.
   "  la a0, bmvmx_sender_addr; la a1, bmvmx_ctx; addi a1, a1, 72; jal ra, .Lbmvmx_addr20_ne\n" ++
   "  bnez a0, .Lbmvmx_s_vs_cb\n" ++                                    -- sender == recipient -> clear sender_checked
   "  la t0, bmvmx_sender_checked; sd zero, 0(t0)\n" ++
@@ -444,7 +436,7 @@ def blockVerdictFunction : String :=
   ".Lbv_mtx_loop:\n" ++
   "  la t0, bv_mtx_i; ld t1, 0(t0); la t2, bv_tx_count; ld t2, 0(t2); beq t1, t2, .Lbv_mtx_done\n" ++
   "  la a0, bv_mtx_ctx; mv a1, t1; jal ra, multi_tx_nth_context\n" ++
-  "  la t0, bv_mtx_ctx; ld t2, 0(t0); bnez t2, .Lbv_mtx_bail; ld t2, 48(t0); bnez t2, .Lbv_mtx_bail        # unsupported/creation tx shape\n" ++
+  "  la t0, bv_mtx_ctx; ld t2, 0(t0); bnez t2, .Lbv_mtx_bail; ld t2, 48(t0); bnez t2, .Lbv_mtx_creation_unsupported        # creation tx shape\n" ++
   -- bmvmx.5 (fee-validity hoist, multi-tx): same PATH-INDEPENDENT check_transaction
   -- fee-validity test as the single-tx gate (max_fee>=base_fee / priority<=max_fee),
   -- run per tx in the mtx loop. bv_mtx_ctx holds tx ptr@8 / len@16 (simple_transfer layout,
@@ -622,8 +614,8 @@ def blockVerdictFunction : String :=
   ".Lbv_mtx_tl7708_skip:\n" ++
   "  la a0, bv_mtx_ctx; ld a1, 80(s0); ld a2, 88(s0); jal ra, dispatch_tx_runtime_code\n" ++
   "  la t1, dtrc_use_pre_header; sd zero, 0(t1)\n" ++
-  "  bnez a0, .Lbv_mtx_bail                         # dispatch miss / not self-contained\n" ++
-  -- fhsxz.2.4.2.57.11.6.5.2.1 P1: persist this tx's executed state gas into bvgr_tx_exec_state_gas[i]
+  "  bnez a0, .Lbv_mtx_dispatch_unsupported                         # dispatch miss / not self-contained\n" ++
+  bvReceiptsShapeSet 5 true ++  -- fhsxz.2.4.2.57.11.6.5.2.1 P1: persist this tx's executed state gas into bvgr_tx_exec_state_gas[i]
   -- (i = bv_mtx_i; evm_state_gas_used is fresh per-tx). Clobbers only a0/t0-t2, preserves the dispatch
   -- results a1-a4 used below. Behavior-neutral substrate (array not yet read by the gate).
   "  la a0, bv_mtx_i; ld a0, 0(a0); jal ra, dispatcher_capture_exec_state_gas\n" ++
@@ -675,12 +667,19 @@ def blockVerdictFunction : String :=
   "  la t4, bvgr_runtime_calldata_floor_ptr; la t5, bv_mtx_calldata; sd t5, 0(t4)\n" ++
   "  la t4, bvgr_runtime_count; la t5, bv_tx_count; ld t5, 0(t5); sd t5, 0(t4)\n" ++
   blockVerdictMtxValidationTail ++
+  ".Lbv_mtx_creation_unsupported:\n" ++
+  bvReceiptsShapeSet 60 false ++
+  "  j .Lbv_mtx_bail_after_shape\n" ++
+  ".Lbv_mtx_dispatch_unsupported:\n" ++
+  bvReceiptsShapeSet 61 false ++
+  "  j .Lbv_mtx_bail_after_shape\n" ++
   ".Lbv_mtx_bail:\n" ++
+  bvReceiptsShapeSet 62 false ++  ".Lbv_mtx_bail_after_shape:\n" ++
   "  j .Lbv_after_tx_gas_precharge\n" ++
   ".Lbv_singletx:\n" ++
   "  la a0, bv_simple_transfer_tx\n" ++
   "  jal ra, simple_transfer_tx_context\n" ++
-  "  la t2, bv_simple_transfer_tx; ld t0, 0(t2); bnez t0, .Lbv_after_tx_gas_precharge; ld t0, 48(t2); bnez t0, .Lbv_after_tx_gas_precharge\n" ++
+  "  la t2, bv_simple_transfer_tx; ld t0, 0(t2); bnez t0, .Lbv_after_tx_gas_precharge; ld t0, 48(t2); bnez t0, .Lbv_creation_unsupported\n" ++
   -- bmvmx.5 (fee-validity hoist, single-tx): the spec check_transaction fee-validity
   -- pre-conditions -- max_fee_per_gas >= base_fee_per_gas (InsufficientMaxFeePerGasError)
   -- and max_priority_fee_per_gas <= max_fee_per_gas (PriorityFeeGreaterThanMaxFeeError,
@@ -899,7 +898,7 @@ def blockVerdictFunction : String :=
   ".Lbv_tl_typed_vdone:\n" ++
   "  la t0, bv_simple_transfer_tx; ld a0, 24(t0); la a1, bmvmx_sender_addr; jal ra, address_from_pubkey\n" ++
   "  li t1, 1; la t0, eip7708_tl_typed_avail; sd t1, 0(t0)\n" ++
-  ".Lbv_tl7708_ready:\n" ++
+  bvReceiptsShapeSet 2 true ++  ".Lbv_tl7708_ready:\n" ++
   "  la t0, bmvmx_value; ld t1, 0(t0); ld t2, 8(t0); or t1, t1, t2; ld t2, 16(t0); or t1, t1, t2; ld t2, 24(t0); or t1, t1, t2\n" ++
   "  beqz t1, .Lbv_tl7708_skip\n" ++
   -- EIP-7708 self-suppression: emit the transfer log ONLY to a DIFFERENT account. The spec
@@ -1034,7 +1033,7 @@ def blockVerdictFunction : String :=
   "  ld a1, 80(s0); ld a2, 88(s0)\n" ++
   "  jal ra, dispatch_tx_runtime_code\n" ++
   "  bnez a0, .Lbv_contract_dispatch_unsupported\n" ++
-  -- fhsxz.2.4.2.57.11.6.5.2.1 P1: persist tx0's executed state gas into bvgr_tx_exec_state_gas[0].
+  bvReceiptsShapeSet 3 true ++  -- fhsxz.2.4.2.57.11.6.5.2.1 P1: persist tx0's executed state gas into bvgr_tx_exec_state_gas[0].
   -- Clobbers only a0/t0-t2, preserves the dispatch results a1-a4 stored below. Behavior-neutral.
   "  li a0, 0; jal ra, dispatcher_capture_exec_state_gas\n" ++
   "  la t4, bv_runtime_gas_left; sd a1, 0(t4)\n" ++
@@ -1379,9 +1378,11 @@ def blockVerdictFunction : String :=
   "  beqz t2, .Lbv_after_tx_gas_precharge\n" ++                  -- sender == coinbase -> skip
   "  lbu t3, 0(t0); lbu t4, 0(t1); bne t3, t4, .Lbv_sender_bal_fail\n" ++
   "  addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1; j .Lbv_sbc_cb_cmp\n" ++
+  ".Lbv_creation_unsupported:\n" ++
+  bvReceiptsShapeSet 60 false ++  "  j .Lbv_after_tx_gas_precharge\n" ++
   ".Lbv_contract_dispatch_unsupported:\n" ++
   "  la t0, eip7708_tl_typed_avail; sd zero, 0(t0)\n" ++
-  "  j .Lbv_after_tx_gas_precharge\n" ++
+  bvReceiptsShapeSet 61 false ++  "  j .Lbv_after_tx_gas_precharge\n" ++
   ".Lbv_after_tx_gas_precharge:\n" ++
   -- fhsxz.2.4.2.57.11.6.5.2.1.3: prefill the transaction-count and
   -- intrinsic-state-gas substrate BEFORE eip8037_tx_gas_gate. The gate still

--- a/EvmAsm/Codegen/Programs/BlockVerdictMtxEoa.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictMtxEoa.lean
@@ -4,6 +4,8 @@
   Multi-tx EOA recipient settlement fragment for block_verdict.
 -/
 
+import EvmAsm.Codegen.Programs.BlockVerdictReceiptGate
+
 namespace EvmAsm.Codegen
 
 /-- Multi-tx EOA recipient settlement fragment, concatenated at the empty-code
@@ -64,7 +66,7 @@ def blockVerdictMtxEoaSettlement : String :=
   "  la t3, bv_tx_status_arr; add t3, t3, t0; sd a2, 0(t3)\n" ++
   "  la t4, runtime_tx_calldata_floor; ld t5, 0(t4)\n" ++
   "  la t3, bv_mtx_calldata; add t3, t3, t0; sd t5, 0(t3)\n" ++
-  "  slli t4, t1, 4\n" ++
+  bvReceiptsShapeSet 4 true ++  "  slli t4, t1, 4\n" ++
   "  la t3, bv_tx_log_window; add t3, t3, t4\n" ++
   "  la t4, bv_last_log_start; ld t5, 0(t4); sd t5, 0(t3)\n" ++
   "  la t4, bv_last_log_count; ld t5, 0(t4); sd t5, 8(t3)\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptGate.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptGate.lean
@@ -1,0 +1,21 @@
+/-
+  EvmAsm.Codegen.Programs.BlockVerdictReceiptGate
+
+  Small assembly snippets for block_verdict receipt-completeness classification.
+-/
+
+namespace EvmAsm.Codegen
+
+/-- Clear the transaction-shape receipt enforcement classifier. -/
+def bvReceiptsShapeClear : String :=
+  "  la t0, bv_receipts_completeness_shape; sd zero, 0(t0)\n" ++
+  "  la t0, bv_receipts_enforce_enabled; sd zero, 0(t0)\n"
+
+/-- Set the receipt-completeness shape and enforcement bit. -/
+def bvReceiptsShapeSet (shape : Nat) (enforce : Bool) : String :=
+  "  li t1, " ++ toString shape ++
+  "; la t0, bv_receipts_completeness_shape; sd t1, 0(t0); " ++
+  "la t0, bv_receipts_enforce_enabled; " ++
+  (if enforce then "li t1, 1; sd t1, 0(t0)\n" else "sd zero, 0(t0)\n")
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -88,13 +88,13 @@ def blockVerdictReceiptsTail : String :=
   "  la a7, c1_er_assembled\n" ++
   "  jal ra, requests_hash_verify\n" ++
   "  bnez a0, .Lbv_requests_hash_fail\n" ++
-  -- CONSERVATIVE COMPLETENESS GATE: enforce only when the EIP-7708 top-level transfer log
-  -- (Part 2) is known to be represented in the materialized log window. bmvmx_avail covers
-  -- the legacy single-tx path; eip7708_tl_typed_avail covers the narrow type-1/type-2/type-3/type-4
-  -- simple-transfer paths added by bmvmx.7.1/bmvmx.7.3/57t4x. Other typed and multi-tx blocks remain conservative until their
-  -- top-level logs are complete, avoiding confirmed-but-spurious receipts-root mismatches.
-  "  la t2, bmvmx_avail; ld t2, 0(t2); bnez t2, .Lbv_receipts_enforce\n" ++
-  "  la t2, eip7708_tl_typed_avail; ld t2, 0(t2); beqz t2, .Lbv_receipts_accept\n" ++
+  -- CONSERVATIVE COMPLETENESS GATE: enforce only when the transaction-shape-specific
+  -- receipt completeness classifier set bv_receipts_enforce_enabled. The classifier keeps
+  -- legacy simple EOA, typed simple EOA, single-tx contract, multi-tx EOA/contract,
+  -- top-level creation unsupported, and dispatch-miss/non-self-contained reasons separate
+  -- in bv_receipts_completeness_shape so unsupported materialization cannot be confused with
+  -- a consensus comparison that is safe to enforce.
+  "  la t2, bv_receipts_enforce_enabled; ld t2, 0(t2); beqz t2, .Lbv_receipts_accept\n" ++
   ".Lbv_receipts_enforce:\n" ++
   "  la a0, brr_control; la a1, bv_receipts_rlp; li a2, 65536; la a3, bv_receipts_rlp_len\n" ++
   "  jal ra, receipt_records_encode_no_logs\n" ++

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -721,6 +721,18 @@ format_verdict_debug() {
       dbg="${dbg:+$dbg }${tx_root_labels[$i]}=$value"
     done
   fi
+  if [[ "$(stat -c%s "$out" 2>/dev/null || echo 0)" -ge 424 ]]; then
+    raw="$(od -An -v -tu8 -j 408 -N 16 "$out" 2>/dev/null | xargs || true)"
+    read -r -a words <<< "$raw"
+    local -a receipts_gate_labels=(
+      receipts_shape
+      receipts_enforce
+    )
+    for i in "${!receipts_gate_labels[@]}"; do
+      value="${words[$i]:-?}"
+      dbg="${dbg:+$dbg }${receipts_gate_labels[$i]}=$value"
+    done
+  fi
   echo "$dbg"
 }
 


### PR DESCRIPTION
## Summary
- add explicit receipt-completeness shape and enforcement fields for block_verdict
- gate receipts enforcement on the shape-derived enforcement bit instead of the historical availability-flag OR
- surface receipts_shape and receipts_enforce in the EEST verdict debug formatter

## Validation
- lake build EvmAsm.Codegen.Programs.BlockVerdictV2
- lake exe codegen --program zisk_stateless_verdict_v2 --halt linux93 -o /tmp/zisk_stateless_verdict_v2_receipts_gate --asm-only
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg forbidden-pattern scan on edited files (no matches)
- bash -n scripts/codegen-eest-stateless-check.sh
- git diff --check
- lake build

Refs #8855. Bead: evm-asm-fhsxz.2.4.2.63.1.6.2.7.3.4.6.

Authored by @pirapira; implemented by Codex