### PR TITLE
fix(receipts): expose validator status

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -134,6 +134,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   "  la t1, svf_tx_count; ld t2, 0(t1); sd t2, 400(t0)\n" ++
   "  la t1, bv_receipts_completeness_shape; ld t2, 0(t1); sd t2, 408(t0)\n" ++
   "  la t1, bv_receipts_enforce_enabled; ld t2, 0(t1); sd t2, 416(t0)\n" ++
+  "  la t1, bv_receipts_validator_status; ld t2, 0(t1); sd t2, 424(t0)\n" ++
   "  j .Lv2_pdone\n" ++
   zkvmSha256Function ++ "\n" ++
   zkvmKeccak256Function ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -231,6 +231,10 @@ def ziskStatelessVerdictV2DataSection : String :=
   -- scratch caps at 32768; 64 KiB leaves margin for the list prefix + max receipts.
   "bv_receipts_rlp:\n  .zero 65536\n" ++
   "bv_receipts_rlp_len:\n  .zero 8\n" ++
+  -- Status returned by block_validate_receipts_consensus_list in the receipts tail:
+  -- 0 success, 1 receipts-root helper failure, 2 receipts-root mismatch,
+  -- 3 logs-bloom helper failure, 4 logs-bloom mismatch.
+  "bv_receipts_validator_status:\n  .zero 8\n" ++
   -- .63.1.6.2.3: receipt_encode + receipt_records_encode_no_logs scratch (these labels were
   -- probe-only in ziskReceiptRecordsEncodeNoLogsDataSection before the tx-bearing un-gate linked
   -- the encoder into the guest). re_payload_buf (16K) / rle_payload_buf (32K) are the per-receipt

--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -102,6 +102,10 @@ def blockVerdictReceiptsTail : String :=
   "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++
   "  la a2, bv_receipts_rlp; la t0, bv_receipts_rlp_len; ld a3, 0(t0)\n" ++
   "  jal ra, block_validate_receipts_consensus_list\n" ++
+  -- Persist the exact validator status before branching: 0 success, 1 receipts-root helper
+  -- failure, 2 root mismatch, 3 logs-bloom helper failure, 4 bloom mismatch. Only the two
+  -- confirmed consensus mismatches reject; helper failures remain conservative accepts.
+  "  la t2, bv_receipts_validator_status; sd a0, 0(t2)\n" ++
   "  li t0, 2; beq a0, t0, .Lbv_receipts_root_mismatch\n" ++
   "  li t0, 4; beq a0, t0, .Lbv_receipts_bloom_mismatch\n" ++
   ".Lbv_receipts_accept:\n" ++

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -733,6 +733,12 @@ format_verdict_debug() {
       dbg="${dbg:+$dbg }${receipts_gate_labels[$i]}=$value"
     done
   fi
+  if [[ "$(stat -c%s "$out" 2>/dev/null || echo 0)" -ge 432 ]]; then
+    raw="$(od -An -v -tu8 -j 424 -N 8 "$out" 2>/dev/null | xargs || true)"
+    read -r -a words <<< "$raw"
+    value="${words[0]:-?}"
+    dbg="${dbg:+$dbg }receipts_validator_status=$value"
+  fi
   echo "$dbg"
 }
 


### PR DESCRIPTION
## Summary
- persist block_validate_receipts_consensus_list status before receipts-tail branching
- keep behavior unchanged: statuses 2/4 still reject, helper-error statuses remain conservative accepts
- add receipts_validator_status to the EEST verdict debug formatter

## Validation
- lake build EvmAsm.Codegen.Programs.BlockVerdictV2
- lake exe codegen --program zisk_stateless_verdict_v2 --halt linux93 -o /tmp/zisk_stateless_verdict_v2_validator_status --asm-only
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg forbidden-pattern scan on edited files (no matches)
- bash -n scripts/codegen-eest-stateless-check.sh
- git diff --check
- lake build

Refs #8855. Bead: evm-asm-fhsxz.2.4.2.63.1.6.2.7.3.4.5.

Authored by @pirapira; implemented by Codex