### PR TITLE
fix(receipts): expose encoder status

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -135,6 +135,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   "  la t1, bv_receipts_completeness_shape; ld t2, 0(t1); sd t2, 408(t0)\n" ++
   "  la t1, bv_receipts_enforce_enabled; ld t2, 0(t1); sd t2, 416(t0)\n" ++
   "  la t1, bv_receipts_validator_status; ld t2, 0(t1); sd t2, 424(t0)\n" ++
+  "  la t1, bv_receipts_encoder_status; ld t2, 0(t1); sd t2, 432(t0)\n" ++
   "  j .Lv2_pdone\n" ++
   zkvmSha256Function ++ "\n" ++
   zkvmKeccak256Function ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -231,6 +231,10 @@ def ziskStatelessVerdictV2DataSection : String :=
   -- scratch caps at 32768; 64 KiB leaves margin for the list prefix + max receipts.
   "bv_receipts_rlp:\n  .zero 65536\n" ++
   "bv_receipts_rlp_len:\n  .zero 8\n" ++
+  -- Status returned by receipt_records_encode_no_logs in the receipts tail:
+  -- 0 success, 1 malformed/count over capacity, 2 missing logs descriptor,
+  -- 3 output/scratch overflow, 4 unsupported tx type.
+  "bv_receipts_encoder_status:\n  .zero 8\n" ++
   -- Status returned by block_validate_receipts_consensus_list in the receipts tail:
   -- 0 success, 1 receipts-root helper failure, 2 receipts-root mismatch,
   -- 3 logs-bloom helper failure, 4 logs-bloom mismatch.

--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -98,6 +98,10 @@ def blockVerdictReceiptsTail : String :=
   ".Lbv_receipts_enforce:\n" ++
   "  la a0, brr_control; la a1, bv_receipts_rlp; li a2, 65536; la a3, bv_receipts_rlp_len\n" ++
   "  jal ra, receipt_records_encode_no_logs\n" ++
+  -- Persist the exact encoder status before the conservative-accept branch: 0 success,
+  -- 1 malformed/count over capacity, 2 missing logs descriptor, 3 output/scratch overflow,
+  -- 4 unsupported tx type. Any nonzero remains a conservative accept.
+  "  la t2, bv_receipts_encoder_status; sd a0, 0(t2)\n" ++
   "  bnez a0, .Lbv_receipts_accept                # encode failed/unsupported -> conservative accept\n" ++
   "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++
   "  la a2, bv_receipts_rlp; la t0, bv_receipts_rlp_len; ld a3, 0(t0)\n" ++

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -739,6 +739,12 @@ format_verdict_debug() {
     value="${words[0]:-?}"
     dbg="${dbg:+$dbg }receipts_validator_status=$value"
   fi
+  if [[ "$(stat -c%s "$out" 2>/dev/null || echo 0)" -ge 440 ]]; then
+    raw="$(od -An -v -tu8 -j 432 -N 8 "$out" 2>/dev/null | xargs || true)"
+    read -r -a words <<< "$raw"
+    value="${words[0]:-?}"
+    dbg="${dbg:+$dbg }receipts_encoder_status=$value"
+  fi
   echo "$dbg"
 }
 


### PR DESCRIPTION
## Summary
- persist receipt_records_encode_no_logs status before the receipts-tail conservative accept branch
- keep behavior unchanged: every nonzero encoder status still accepts conservatively
- add receipts_encoder_status to the EEST verdict debug formatter

## Validation
- lake build EvmAsm.Codegen.Programs.BlockVerdictV2
- lake exe codegen --program zisk_stateless_verdict_v2 --halt linux93 -o /tmp/zisk_stateless_verdict_v2_encoder_status --asm-only
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg forbidden-pattern scan on edited files (no matches)
- bash -n scripts/codegen-eest-stateless-check.sh
- git diff --check
- lake build

Refs #8855. Bead: evm-asm-fhsxz.2.4.2.63.1.6.2.7.3.4.4.

Authored by @pirapira; implemented by Codex