### PR TITLE
fix(receipts): gate blob multi-tx EOA receipts

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictMtxEoa.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictMtxEoa.lean
@@ -66,7 +66,17 @@ def blockVerdictMtxEoaSettlement : String :=
   "  la t3, bv_tx_status_arr; add t3, t3, t0; sd a2, 0(t3)\n" ++
   "  la t4, runtime_tx_calldata_floor; ld t5, 0(t4)\n" ++
   "  la t3, bv_mtx_calldata; add t3, t3, t0; sd t5, 0(t3)\n" ++
-  bvReceiptsShapeSet 4 true ++  "  slli t4, t1, 4\n" ++
+  -- Blob txs still need blob-aware multi-tx settlement before the receipt
+  -- consensus encoder is complete for this shape. Keep the verdict
+  -- conservative instead of false-rejecting valid pre-fund blob blocks.
+  "  la t4, bv_mtx_ctx; ld t4, 160(t4); li t5, 3; beq t4, t5, .Lbv_mtx_eoa_receipts_blob\n" ++
+  "  la t4, bv_receipts_completeness_shape; ld t4, 0(t4); li t5, 60; bgeu t4, t5, .Lbv_mtx_eoa_receipts_ready\n" ++
+  bvReceiptsShapeSet 4 true ++
+  "  j .Lbv_mtx_eoa_receipts_ready\n" ++
+  ".Lbv_mtx_eoa_receipts_blob:\n" ++
+  bvReceiptsShapeSet 64 false ++
+  ".Lbv_mtx_eoa_receipts_ready:\n" ++
+  "  slli t4, t1, 4\n" ++
   "  la t3, bv_tx_log_window; add t3, t3, t4\n" ++
   "  la t4, bv_last_log_start; ld t5, 0(t4); sd t5, 0(t3)\n" ++
   "  la t4, bv_last_log_count; ld t5, 0(t4); sd t5, 8(t3)\n" ++


### PR DESCRIPTION
## Summary
- mark multi-tx EOA type-3 blob receipt enforcement as incomplete until blob-aware settlement is implemented
- keep non-blob multi-tx EOA receipt enforcement unchanged, including existing receipt-root/bloom mismatch rejection paths
- fixes P0 bead evm-asm-ng3is and also addresses the related max_blobs pre-fund false-reject shape tracked by evm-asm-fhsxz.16

## Verification
- scripts/codegen-eest-stateless-check.sh --all --filter blockchain_tests/for_amsterdam/cancun/eip4844_blobs/blob_txs/sufficient_balance_blob_tx_pre_fund_tx.json --skip 274 --limit 14 --jobs 1 --max-failures 1 --run-dir gen-out/eest-run/ng3is-single-suffix
- direct ziskemu patched row 00274: public output full-matches expected bytes; debug verdict=1 bv_fail=0 block_rlp_len=982
- direct ziskemu related max_blobs row 00000: public output full-matches expected bytes; debug verdict=1 bv_fail=0
- scripts/codegen-zisk-block-validate-receipts-consensus-list-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- scripts/check-no-warnings.sh
- lake build