### PR TITLE
fix(receipts): ungate blob multi-tx EOA receipts

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -2131,15 +2131,18 @@ def emitRuntimeDispatcherSetupWithInputAsm (inputAsm : String) : String :=
   ".runtime_tx_gas_access_list:\n" ++
   -- Access-list counts are supplied by transaction-aware callers. Legacy and
   -- standalone runtime probes leave both labels zero, preserving the old path.
-  -- tokens_in_access_list = 80 * address_count + 128 * storage_key_count;
-  -- the floor adds 16 gas per token, while regular intrinsic gas adds
-  -- 2400/address and 1900/storage key.
+  -- tokens_in_access_list = 80 * address_count + 128 * storage_key_count.
+  -- Amsterdam regular intrinsic gas includes both the legacy access-list
+  -- surcharge (2400/address, 1900/storage key) and the EIP-7623 access-token
+  -- floor surcharge (16 gas per token); the separate floor accumulator keeps
+  -- only the calldata-floor value used by the post-refund max.
   "  la x11, runtime_tx_access_list_address_count\n" ++
   "  ld x11, 0(x11)\n" ++
   "  beqz x11, .runtime_tx_gas_access_slots\n" ++
   "  li x15, 2400\n" ++
   ".runtime_tx_gas_addr_loop:\n" ++
   "  add x7, x7, x15\n" ++
+  "  addi x7, x7, 1280\n" ++
   "  addi x10, x10, 1280\n" ++
   "  addi x11, x11, -1\n" ++
   "  bnez x11, .runtime_tx_gas_addr_loop\n" ++
@@ -2151,6 +2154,7 @@ def emitRuntimeDispatcherSetupWithInputAsm (inputAsm : String) : String :=
   "  li x14, 2048\n" ++
   ".runtime_tx_gas_slot_loop:\n" ++
   "  add x7, x7, x15\n" ++
+  "  add x7, x7, x14\n" ++
   "  add x10, x10, x14\n" ++
   "  addi x11, x11, -1\n" ++
   "  bnez x11, .runtime_tx_gas_slot_loop\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -341,6 +341,8 @@ def ziskStatelessVerdictV2DataSection : String :=
   -- conservatively for any payload that would still exceed this, so the staging write can
   -- never overflow into the adjacent gas-result / bvcd_* cells.
   "bv_runtime_payload:\n  .zero 65536\n" ++
+  "bv_stop_code:\n  .byte 0x00\n" ++
+  ".balign 8\n" ++
   "bv_runtime_gas_left:\n  .zero 8\n" ++
   "bv_runtime_refund_counter:\n  .zero 8\n" ++
   "bv_runtime_calldata_floor:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -418,10 +418,9 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  jal ra, seed_callee_storage\n" ++
   -- fhsxz.2.4.2.57.18.10: pass access-list cardinalities into the runtime
   -- dispatcher's tx-gas validator so the captured calldata floor and regular
-  -- intrinsic gas include tokens_in_access_list. The context builders reject
-  -- type 3/4 before this helper; type 0 has no access list, type 1 uses field 7,
-  -- and type 2 uses field 8 of the inner RLP payload. Parse failures bail
-  -- conservatively instead of undercounting.
+  -- intrinsic gas include tokens_in_access_list. Type 0 has no access list,
+  -- type 1 uses field 7, and EIP-1559/blob/7702 typed txs use field 8 of the
+  -- inner RLP payload. Parse failures bail conservatively instead of undercounting.
   "  la t0, runtime_tx_access_list_address_count; sd zero, 0(t0)\n" ++
   "  la t0, runtime_tx_access_list_storage_key_count; sd zero, 0(t0)\n" ++
   -- nxio8.5.2b: pass the same access-list span to the callable setup so it can
@@ -431,8 +430,9 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  la t0, runtime_tx_access_list_seed_fn; sd zero, 0(t0)\n" ++
   "  ld t0, 160(s2); beqz t0, .Ldtrc_access_done\n" ++
   "  li a2, 7; li t1, 1; beq t0, t1, .Ldtrc_access_field\n" ++
-  "  li t1, 2; bne t0, t1, .Ldtrc_access_list_unsupported\n" ++
-  "  li a2, 8\n" ++
+  "  li a2, 8; li t1, 2; beq t0, t1, .Ldtrc_access_field\n" ++
+  "  li t1, 3; beq t0, t1, .Ldtrc_access_field\n" ++
+  "  li t1, 4; bne t0, t1, .Ldtrc_access_list_unsupported\n" ++
   ".Ldtrc_access_field:\n" ++
   "  ld a0, 176(s2); ld a1, 184(s2); la a3, bsg_access_off; la a4, bsg_access_len\n" ++
   "  jal ra, rlp_list_nth_item\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictGasGate.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictGasGate.lean
@@ -336,6 +336,11 @@ def eip8037TxGasGateFunction : String :=
   "  la a6, bsg_intrinsic_gas; la a7, bsg_floor_gas\n" ++
   "  jal ra, intrinsic_gas_amsterdam_counts\n" ++
   "  bnez a0, .Letg_ok\n" ++
+  "  la t0, bsg_floor_gas; ld t1, 0(t0)\n" ++
+  "  slli t2, s8, 3; la t3, bv_mtx_calldata; add t3, t3, t2; ld t4, 0(t3)\n" ++
+  "  bgeu t4, t1, .Letg_floor_stored\n" ++
+  "  sd t1, 0(t3)\n" ++
+  ".Letg_floor_stored:\n" ++
   "  # EIP-8037 intrinsic.state gas: CREATE new-account reserve plus EIP-7702\n" ++
   "  # authorization reserve (calculate_intrinsic_cost). Computed once here and\n" ++
   "  # consumed by both the per-tx sufficiency test and the 2D block accounting.\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictMtxEoa.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictMtxEoa.lean
@@ -21,8 +21,29 @@ def blockVerdictMtxEoaSettlement : String :=
   "  la a0, bv_mtx_ctx\n" ++
   "  la a1, bv_runtime_payload\n" ++
   "  la t2, bv_exec_p; ld a2, 0(t2)\n" ++
-  "  jal ra, stage_runtime_payload\n" ++
+  "  la a3, bv_stop_code\n" ++
+  "  li a4, 1\n" ++
+  "  li a5, 0\n" ++
+  "  li a6, 0\n" ++
+  "  jal ra, stage_runtime_payload_code\n" ++
   "  bnez a0, .Lbv_mtx_bail\n" ++
+  "  la t0, runtime_tx_access_list_address_count; sd zero, 0(t0)\n" ++
+  "  la t0, runtime_tx_access_list_storage_key_count; sd zero, 0(t0)\n" ++
+  "  la t6, bv_mtx_ctx; ld t0, 160(t6); beqz t0, .Lbv_mtx_eoa_access_ready\n" ++
+  "  li t1, 1; li a2, 7; beq t0, t1, .Lbv_mtx_eoa_access_field\n" ++
+  "  li a2, 8; li t1, 2; beq t0, t1, .Lbv_mtx_eoa_access_field\n" ++
+  "  li t1, 3; beq t0, t1, .Lbv_mtx_eoa_access_field\n" ++
+  "  li t1, 4; bne t0, t1, .Lbv_mtx_bail\n" ++
+  ".Lbv_mtx_eoa_access_field:\n" ++
+  "  ld a0, 176(t6); ld a1, 184(t6); la a3, bsg_access_off; la a4, bsg_access_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbv_mtx_bail\n" ++
+  "  la t6, bv_mtx_ctx; la t0, bsg_access_off; ld t0, 0(t0); ld a0, 176(t6); add a0, a0, t0\n" ++
+  "  la t0, bsg_access_len; ld a1, 0(t0)\n" ++
+  "  la a2, runtime_tx_access_list_address_count; la a3, runtime_tx_access_list_storage_key_count\n" ++
+  "  jal ra, access_list_count\n" ++
+  "  bnez a0, .Lbv_mtx_bail\n" ++
+  ".Lbv_mtx_eoa_access_ready:\n" ++
   "  la t4, runtime_dispatcher_input_ptr; la t5, bv_runtime_payload; addi t5, t5, 8; sd t5, 0(t4)\n" ++
   "  addi sp, sp, -32\n" ++
   "  sd s0, 0(sp); sd s1, 8(sp); sd s2, 16(sp); sd s3, 24(sp)\n" ++
@@ -66,16 +87,10 @@ def blockVerdictMtxEoaSettlement : String :=
   "  la t3, bv_tx_status_arr; add t3, t3, t0; sd a2, 0(t3)\n" ++
   "  la t4, runtime_tx_calldata_floor; ld t5, 0(t4)\n" ++
   "  la t3, bv_mtx_calldata; add t3, t3, t0; sd t5, 0(t3)\n" ++
-  -- Blob txs still need blob-aware multi-tx settlement before the receipt
-  -- consensus encoder is complete for this shape. Keep the verdict
-  -- conservative instead of false-rejecting valid pre-fund blob blocks.
-  "  la t4, bv_mtx_ctx; ld t4, 160(t4); li t5, 3; beq t4, t5, .Lbv_mtx_eoa_receipts_blob\n" ++
   "  la t4, bv_receipts_completeness_shape; ld t4, 0(t4); li t5, 60; bgeu t4, t5, .Lbv_mtx_eoa_receipts_ready\n" ++
   bvReceiptsShapeSet 4 true ++
-  "  j .Lbv_mtx_eoa_receipts_ready\n" ++
-  ".Lbv_mtx_eoa_receipts_blob:\n" ++
-  bvReceiptsShapeSet 64 false ++
   ".Lbv_mtx_eoa_receipts_ready:\n" ++
+  "  la t0, bv_mtx_i; ld t1, 0(t0)\n" ++
   "  slli t4, t1, 4\n" ++
   "  la t3, bv_tx_log_window; add t3, t3, t4\n" ++
   "  la t4, bv_last_log_start; ld t5, 0(t4); sd t5, 0(t3)\n" ++

--- a/scripts/codegen-zisk-runtime-tx-intrinsic-gas-check.sh
+++ b/scripts/codegen-zisk-runtime-tx-intrinsic-gas-check.sh
@@ -71,17 +71,19 @@ run_case "empty_call_reject" \
   "0000000000000000000000000000000000000000000000000000000000000000" \
   "0600000000000000" || FAILED=1
 
-# Nonzero calldata byte has intrinsic 21016 but EIP-7623 floor 21040.
+# Nonzero calldata raises the EIP-7976 floor: every byte counts 4 tokens
+# x TX_DATA_TOKEN_FLOOR(16) = 64 uniformly, so one byte gives floor 21064;
+# the intrinsic data cost stays 4 tokens x 4 = 16 (21016).
 run_case "nonzero_calldata_floor_reject" \
-  21039 0 "ff" \
+  21063 0 "ff" \
   "0000000000000000000000000000000000000000000000000000000000000000" \
   "0600000000000000" || FAILED=1
 
 # If the floor is covered, execution still starts from tx.gas - intrinsic.
-# 21042 - 21016 - GAS(2) = 24.
+# 21066 - 21016 - GAS(2) = 48.
 run_case "nonzero_calldata_floor_accept" \
-  21042 0 "ff" \
-  "1800000000000000000000000000000000000000000000000000000000000000" \
+  21066 0 "ff" \
+  "3000000000000000000000000000000000000000000000000000000000000000" \
   "0000000000000000" || FAILED=1
 
 # Creation adds 32000 intrinsic gas. 53005 - 53000 - GAS(2) = 3.


### PR DESCRIPTION
## Summary
- remove the conservative type-3/blob multi-tx EOA receipt gate for supported rows
- stage precise STOP runtime payloads for EOA settlement and seed access-list counts for typed txs
- charge Amsterdam access-token floor in runtime intrinsic gas and preserve per-tx calldata floor windows
- fix tx log-window capture after receipt shape setup clobbered the transaction index
- update the runtime tx intrinsic-gas probe to the EIP-7976 21064 one-byte floor boundary

## Validation
- `rtk lake build EvmAsm.Codegen.Dispatch EvmAsm.Codegen.Programs.BlockVerdictMtxEoa EvmAsm.Codegen.Programs.BlockVerdictDispatchTx EvmAsm.Codegen.Programs.BlockVerdictGasGate EvmAsm.Codegen.Programs.BlockVerdictDataSection EvmAsm.Codegen.Programs.BlockVerdict`
- `rtk scripts/codegen-zisk-runtime-tx-intrinsic-gas-check.sh`
- `rtk scripts/codegen-zisk-block-receipt-records-materialize-check.sh`
- `rtk scripts/codegen-zisk-block-validate-receipts-consensus-list-check.sh`
- `rtk scripts/codegen-eest-stateless-check.sh --all --filter blockchain_tests/for_amsterdam/cancun/eip4844_blobs/blob_txs/sufficient_balance_blob_tx_pre_fund_tx.json --skip 274 --limit 14 --jobs 1 --max-failures 1 --run-dir gen-out/eest-run/uh164-final-14b`
- `rtk scripts/check-file-size.sh`
- `rtk scripts/check-unimported.sh`
- `rtk rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Dispatch.lean EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean EvmAsm/Codegen/Programs/BlockVerdictGasGate.lean EvmAsm/Codegen/Programs/BlockVerdictMtxEoa.lean scripts/codegen-zisk-runtime-tx-intrinsic-gas-check.sh`
- `rtk lake build`

Refs #8863. Bead: evm-asm-uh164.

Authored by @pirapira; implemented by Codex
