### PR TITLE
fix(receipts): split encoder capacity status

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -105,10 +105,9 @@ def blockVerdictReceiptsTail : String :=
   "  la a0, brr_control; la a1, bv_receipts_rlp; li a2, 65536; la a3, bv_receipts_rlp_len\n" ++
   "  jal ra, receipt_records_encode_no_logs\n" ++
   -- Persist the exact encoder status before branching: 0 success,
-  -- 1 malformed/count over capacity, 2 missing logs descriptor, 3 output/scratch overflow,
-  -- 4 unsupported tx type. Status 3 remains capacity debt; statuses 2/4 are
-  -- malformed enforced-shape data and reject. Status 1 is ambiguous with count
-  -- capacity and remains conservative until the count/capacity split is repaired.
+  -- 1 malformed arena, 2 missing logs descriptor, 3 output/scratch overflow,
+  -- 4 unsupported tx type, 5 record-count capacity overflow. Statuses 3/5 remain
+  -- capacity debt; statuses 1/2/4 are malformed enforced-shape data and reject.
   "  la t2, bv_receipts_encoder_status; sd a0, 0(t2)\n" ++
   "  bnez a0, .Lbv_receipts_encoder_helper_status\n" ++
   "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++

--- a/EvmAsm/Codegen/Programs/ReceiptList.lean
+++ b/EvmAsm/Codegen/Programs/ReceiptList.lean
@@ -38,10 +38,11 @@ open EvmAsm.Rv64.Program
       a3 = u64 out length pointer
       a0 output status:
         0 success
-        1 malformed arena or record count above capacity
+        1 malformed arena
         2 log_count > 0 but the record carries no logs descriptor (@56 == 0)
         3 output capacity or internal scratch overflow
         4 unsupported tx type (> 4)
+        5 record count above capacity
 -/
 def receiptRecordsEncodeNoLogsFunction : String :=
   "receipt_records_encode_no_logs:\n" ++
@@ -57,7 +58,7 @@ def receiptRecordsEncodeNoLogsFunction : String :=
   "  sd zero, 0(s3)\n" ++
   "  ld s4, 0(s0)                # count\n" ++
   "  ld t0, 8(s0)                # capacity\n" ++
-  "  bgtu s4, t0, .Lrlen_malformed\n" ++
+  "  bgtu s4, t0, .Lrlen_count_over_capacity\n" ++
   "  ld s5, 16(s0)               # record base\n" ++
   "  beqz s5, .Lrlen_malformed\n" ++
   "  li s6, 0                    # index\n" ++
@@ -142,6 +143,9 @@ def receiptRecordsEncodeNoLogsFunction : String :=
   "  j .Lrlen_ret\n" ++
   ".Lrlen_type_unsupported:\n" ++
   "  li a0, 4\n" ++
+  "  j .Lrlen_ret\n" ++
+  ".Lrlen_count_over_capacity:\n" ++
+  "  li a0, 5\n" ++
   ".Lrlen_ret:\n" ++
   "  ld ra, 0(sp)\n" ++
   "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
@@ -155,7 +159,9 @@ def receiptRecordsEncodeNoLogsFunction : String :=
     Input layout (file maps to INPUT+8 at 0x40000000):
       INPUT+8  record count
       INPUT+16 output capacity
-      INPUT+24 records, four u64 fields each:
+      INPUT+24 control capacity
+      INPUT+32 mode flags: bit0 force null record base, bit1 bypass append
+      INPUT+40 records, four u64 fields each:
           tx_type, status, cumulative_gas, log_count
 
     Output layout:
@@ -178,14 +184,17 @@ def ziskReceiptRecordsEncodeNoLogsPrologue : String :=
   ".Lrlenp_zero_done:\n" ++
   "  ld s2, 8(s0)                # count\n" ++
   "  ld s3, 16(s0)               # output cap\n" ++
+  "  ld s6, 24(s0)               # control capacity\n" ++
+  "  ld s7, 32(s0)               # mode flags\n" ++
   "  la a0, rle_control\n" ++
-  "  li a1, 16\n" ++
+  "  mv a1, s6\n" ++
   "  la a2, rle_records\n" ++
   "  jal ra, receipt_records_init\n" ++
+  "  bnez s7, .Lrlenp_direct_control\n" ++
   "  ld s2, 8(s0)                # count (reload after helper call)\n" ++
   "  ld s3, 16(s0)               # output cap\n" ++
   "  li s4, 0                    # index\n" ++
-  "  addi s5, s0, 24             # input record cursor\n" ++
+  "  addi s5, s0, 40             # input record cursor\n" ++
   ".Lrlenp_append_loop:\n" ++
   "  beq s4, s2, .Lrlenp_encode\n" ++
   "  ld a1, 0(s5)                # tx type\n" ++
@@ -201,6 +210,15 @@ def ziskReceiptRecordsEncodeNoLogsPrologue : String :=
   "  addi s4, s4, 1\n" ++
   "  addi s5, s5, 32\n" ++
   "  j .Lrlenp_append_loop\n" ++
+  ".Lrlenp_direct_control:\n" ++
+  "  la t0, rle_control\n" ++
+  "  ld t1, 8(s0); sd t1, 0(t0)  # direct count\n" ++
+  "  ld t1, 24(s0); sd t1, 8(t0) # direct capacity\n" ++
+  "  andi t2, s7, 1; bnez t2, .Lrlenp_direct_null_base\n" ++
+  "  la t1, rle_records; sd t1, 16(t0)\n" ++
+  "  j .Lrlenp_encode\n" ++
+  ".Lrlenp_direct_null_base:\n" ++
+  "  sd zero, 16(t0)\n" ++
   ".Lrlenp_encode:\n" ++
   "  la a0, rle_control\n" ++
   "  li a1, 0xa0010010\n" ++

--- a/scripts/codegen-zisk-receipt-records-encode-no-logs-check.sh
+++ b/scripts/codegen-zisk-receipt-records-encode-no-logs-check.sh
@@ -27,20 +27,23 @@ lake exe codegen --program zisk_receipt_records_encode_no_logs --halt linux93 \
 
 REPO_ROOT="$(pwd)"
 
-# run_case <name> <cap> <records> <exp_status>
+# run_case <name> <output_cap> <control_cap> <mode_flags> <records> <exp_status>
 # records grammar: tx_type:status:cumulative_gas:log_count[, ...]
+# mode_flags: bit0 force null record base, bit1 bypass append and call encoder directly.
 run_case() {
-  local name="$1" cap="$2" records="$3" exp_status="$4"
+  local name="$1" cap="$2" control_cap="$3" flags="$4" records="$5" exp_status="$6"
   local in_file="$REPO_ROOT/gen-out/zisk_receipt_records_encode_no_logs_${name}.input"
   local out_file="$REPO_ROOT/gen-out/zisk_receipt_records_encode_no_logs_${name}.output"
   local exp_file="$REPO_ROOT/gen-out/zisk_receipt_records_encode_no_logs_${name}.expected"
 
-  python3 - "$in_file" "$exp_file" "$cap" "$records" "$exp_status" <<'PY'
+  python3 - "$in_file" "$exp_file" "$cap" "$control_cap" "$flags" "$records" "$exp_status" <<'PY'
 import struct
 import sys
 
-in_file, exp_file, cap_s, records_s, exp_status_s = sys.argv[1:]
+in_file, exp_file, cap_s, control_cap_s, flags_s, records_s, exp_status_s = sys.argv[1:]
 cap = int(cap_s)
+control_cap = int(control_cap_s)
+flags = int(flags_s)
 exp_status = int(exp_status_s)
 
 def parse_records(text):
@@ -86,10 +89,12 @@ def receipt(tx_type: int, status: int, gas: int) -> bytes:
     return (bytes([tx_type]) + inner) if tx_type else inner
 
 records = parse_records(records_s)
-payload = bytearray(16 + 32 * len(records))
+payload = bytearray(32 + 32 * len(records))
 payload[0:8] = struct.pack("<Q", len(records))
 payload[8:16] = struct.pack("<Q", cap)
-cursor = 16
+payload[16:24] = struct.pack("<Q", control_cap)
+payload[24:32] = struct.pack("<Q", flags)
+cursor = 32
 for row in records:
     payload[cursor:cursor + 32] = struct.pack("<QQQQ", *row)
     cursor += 32
@@ -132,18 +137,21 @@ PY
 }
 
 FAILED=0
-run_case "empty"          256 "-"                              0 || FAILED=1
-run_case "one_success"    512 "0:1:21000:0"                    0 || FAILED=1
-run_case "two_statuses"   768 "0:1:21000:0,0:0:42000:0"        0 || FAILED=1
-run_case "four_receipts"  2048 "0:1:1:0,0:1:127:0,0:1:128:0,0:1:1000000:0" 0 || FAILED=1
+run_case "empty"          256 16 0 "-"                              0 || FAILED=1
+run_case "one_success"    512 16 0 "0:1:21000:0"                    0 || FAILED=1
+run_case "two_statuses"   768 16 0 "0:1:21000:0,0:0:42000:0"        0 || FAILED=1
+run_case "four_receipts"  2048 16 0 "0:1:1:0,0:1:127:0,0:1:128:0,0:1:1000000:0" 0 || FAILED=1
 # log_count>0 with no logs descriptor (probe leaves @56=0) is still a malformed record.
-run_case "log_no_desc"    512 "0:1:21000:1"                    2 || FAILED=1
+run_case "log_no_desc"    512 16 0 "0:1:21000:1"                    2 || FAILED=1
 # typed receipts are now encoded (type_byte || rlp(inner)); EIP-2718 types 1..4.
-run_case "typed_eip2718_2" 512 "2:1:21000:0"                   0 || FAILED=1
-run_case "typed_eip2718_4" 512 "4:0:55000:0"                   0 || FAILED=1
-run_case "typed_mixed"    768 "0:1:21000:0,2:1:42000:0"        0 || FAILED=1
-run_case "type_over_max"  512 "5:1:21000:0"                    4 || FAILED=1
-run_case "small_cap"      1 "-"                                3 || FAILED=1
+run_case "typed_eip2718_2" 512 16 0 "2:1:21000:0"                   0 || FAILED=1
+run_case "typed_eip2718_4" 512 16 0 "4:0:55000:0"                   0 || FAILED=1
+run_case "typed_mixed"    768 16 0 "0:1:21000:0,2:1:42000:0"        0 || FAILED=1
+run_case "type_over_max"  512 16 0 "5:1:21000:0"                    4 || FAILED=1
+run_case "small_cap"      1 16 0 "-"                                3 || FAILED=1
+# Direct-control modes cover encoder status splitting that the append path cannot reach.
+run_case "malformed_null_base" 512 16 1 "-"                         1 || FAILED=1
+run_case "count_over_capacity" 512 1 2 "0:1:21000:0,0:1:42000:0"    5 || FAILED=1
 
 if [[ "$FAILED" -eq 0 ]]; then
   echo "==> PASS: no-log receipt-record list encoder"


### PR DESCRIPTION
## Summary
- split `receipt_records_encode_no_logs` status 1 into malformed arena (1) versus record-count capacity overflow (5)
- make enforced receipt shapes reject malformed encoder status 1 while keeping genuine capacity status 5 conservative
- extend the focused encoder probe with direct-control cases for malformed-null-base and count-over-capacity

## Validation
- `rtk lake build EvmAsm.Codegen.Programs.ReceiptList EvmAsm.Codegen.Programs.BlockVerdictReceiptsTail EvmAsm.Codegen.Programs.BlockVerdict`
- `rtk scripts/codegen-zisk-receipt-records-encode-no-logs-check.sh`
- `rtk scripts/codegen-zisk-block-receipt-records-materialize-check.sh`
- `rtk scripts/codegen-zisk-block-validate-receipts-consensus-list-check.sh`
- `rtk scripts/codegen-eest-stateless-check.sh --all --filter blockchain_tests/for_amsterdam/amsterdam/eip7708_eth_transfer_logs/transfer_logs/transfer_to_special_address.json --skip 0 --limit 1 --jobs 1 --max-failures 1 --run-dir gen-out/eest-run/receipt-encoder-status-split-transfer-smoke` (`4/4 PASS(full)`)
- `rtk git diff --check`
- `rtk scripts/check-file-size.sh`
- `rtk scripts/check-unimported.sh`
- `rtk rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/ReceiptList.lean EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean scripts/codegen-zisk-receipt-records-encode-no-logs-check.sh`
- `rtk lake build`

Stacked on #8865. Bead: evm-asm-fhsxz.2.4.2.63.1.8.1.

Authored by @pirapira; implemented by Codex
