### PR TITLE
fix(env): stage PREVRANDAO for runtime dispatch

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictContractStage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictContractStage.lean
@@ -148,9 +148,12 @@ def stageRuntimePayloadCodeFunction : String :=
   "  add a5, t3, t5; lbu a6, 0(a5); add a5, t4, t5; sb a6, 0(a5); addi t5, t5, 1; j .Lsrpc_cb\n" ++
   ".Lsrpc_cb_done:\n" ++
   -- NUMBER (word 8 -> +256) = exec u64 @404; TIMESTAMP (word 7 -> +224) = @428;
-  -- GASLIMIT (word 10 -> +320) = @412.
+  -- PREVRANDAO (word 9 -> +288) = exec Bytes32 @372; GASLIMIT (word 10 -> +320) = @412.
   "  ld t3, 404(s2); sd t3, 256(s5)\n" ++
   "  ld t3, 428(s2); sd t3, 224(s5)\n" ++
+  "  addi t3, s2, 372\n" ++
+  "  ld t4, 0(t3); sd t4, 288(s5); ld t4, 8(t3); sd t4, 296(s5)\n" ++
+  "  ld t4, 16(t3); sd t4, 304(s5); ld t4, 24(t3); sd t4, 312(s5)\n" ++
   "  ld t3, 412(s2); sd t3, 320(s5)\n" ++
   -- BASEFEE (word 11 -> +352): 32-byte copy from exec+440.
   "  addi t3, s2, 440\n" ++
@@ -187,7 +190,8 @@ def stageRuntimePayloadCodeFunction : String :=
       +16 first code byte at payload+8               (expect 0x60)
       +24 gas at payload[env_base+448]               (expect 21000 = 0x5208)
       +32 COINBASE low byte at payload[env_base+192] (expect 0xC0)
-      +40 ADDRESS low byte at payload[env_base+0]    (expect 0xAA) -/
+      +40 ADDRESS low byte at payload[env_base+0]    (expect 0xAA)
+      +48 PREVRANDAO low byte at payload[env_base+288] (expect 0x44) -/
 def ziskStageRuntimePayloadCodePrologue : String :=
   "  li sp, 0xa0050000\n" ++
   -- Synthetic context: status@0=0, gas@40=21000, is_creation@48=0, data_len@64=0,
@@ -197,9 +201,10 @@ def ziskStageRuntimePayloadCodePrologue : String :=
   "  li t1, 21000; sd t1, 40(t0)\n" ++
   "  sd zero, 48(t0); sd zero, 64(t0); sd zero, 96(t0)\n" ++
   "  li t1, 0xAA; sb t1, 72(t0)\n" ++
-  -- Synthetic exec payload: coinbase@32 first byte 0xC0, number@404 = 99.
+  -- Synthetic exec payload: coinbase@32 first byte 0xC0, prev_randao@372 first byte 0x44, number@404 = 99.
   "  la t2, srpc_exec\n" ++
   "  li t1, 0xC0; sb t1, 32(t2)\n" ++
+  "  li t1, 0x44; sb t1, 372(t2)\n" ++
   "  li t1, 99; sd t1, 404(t2)\n" ++
   -- Code blob: PUSH1 0x01 PUSH1 0x02 STOP = 0x60 0x01 0x60 0x02 0x00 (5 bytes).
   "  la t3, srpc_code\n" ++
@@ -219,6 +224,7 @@ def ziskStageRuntimePayloadCodePrologue : String :=
   "  ld t1, 448(t2); sd t1, 24(s0)\n" ++
   "  lbu t1, 192(t2); sd t1, 32(s0)\n" ++
   "  lbu t1, 0(t2); sd t1, 40(s0)\n" ++
+  "  lbu t1, 288(t2); sd t1, 48(s0)\n" ++
   "  j .Lsrpcp_done\n" ++
   stageRuntimePayloadCodeFunction ++ "\n" ++
   ".Lsrpcp_done:"
@@ -229,7 +235,8 @@ def ziskStageRuntimePayloadCodePrologue : String :=
     storage_end=co+24=32; M29 cur@payload[72], count@[80], hashes@[88]; env_base = 88+64 = 152.
     OUTPUT: +0 srpc_env_base (expect 152); +8 M29 count payload[80] (expect 2);
       +16 M29 cur payload[72] (expect 0x5A); +24 M29 hash0 payload[88] (expect 0x11);
-      +32 ADDRESS low byte payload[152] (expect 0xAA); +40 gas payload[152+448] (expect 21000). -/
+      +32 ADDRESS low byte payload[152] (expect 0xAA); +40 gas payload[152+448] (expect 21000);
+      +48 PREVRANDAO low byte payload[152+288] (expect 0x44). -/
 def ziskStageRuntimePayloadCodeM29Prologue : String :=
   "  li sp, 0xa0050000\n" ++
   "  la t0, srpc_ctx\n" ++
@@ -239,6 +246,7 @@ def ziskStageRuntimePayloadCodeM29Prologue : String :=
   "  li t1, 0xAA; sb t1, 72(t0)\n" ++
   "  la t2, srpc_exec\n" ++
   "  li t1, 0xC0; sb t1, 32(t2)\n" ++
+  "  li t1, 0x44; sb t1, 372(t2)\n" ++
   "  li t1, 99; sd t1, 404(t2)\n" ++
   "  la t3, srpc_code\n" ++
   "  li t1, 0x60; sb t1, 0(t3); li t1, 0x01; sb t1, 1(t3)\n" ++
@@ -259,6 +267,7 @@ def ziskStageRuntimePayloadCodeM29Prologue : String :=
   "  li t2, 152; add t2, t0, t2\n" ++
   "  lbu t1, 0(t2); sd t1, 32(s0)\n" ++                           -- ADDRESS low byte at env_base (expect 0xAA)
   "  ld t1, 448(t2); sd t1, 40(s0)\n" ++                          -- gas at env_base+448 (expect 21000)
+  "  lbu t1, 288(t2); sd t1, 48(s0)\n" ++                          -- PREVRANDAO low byte (expect 0x44)
   "  j .Lsrpcm29_done\n" ++
   stageRuntimePayloadCodeFunction ++ "\n" ++
   ".Lsrpcm29_done:"

--- a/EvmAsm/Codegen/Programs/BlockVerdictRuntimePayload.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictRuntimePayload.lean
@@ -13,6 +13,9 @@
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransfer
+import EvmAsm.Codegen.Programs.BalGasValid
+import EvmAsm.Codegen.Programs.Header
+import EvmAsm.Codegen.Programs.U256
 
 namespace EvmAsm.Codegen
 
@@ -105,6 +108,12 @@ def stageRuntimePayloadFunction : String :=
   "  ld t2, 404(a2); sd t2, 344(s0)\n" ++
   -- TIMESTAMP (word 7 -> +312): exec u64 @428.
   "  ld t2, 428(a2); sd t2, 312(s0)\n" ++
+  -- PREVRANDAO (word 9 -> +376): 32-byte direct copy from exec+372.
+  "  addi t1, a2, 372\n" ++
+  "  ld t2, 0(t1); sd t2, 376(s0)\n" ++
+  "  ld t2, 8(t1); sd t2, 384(s0)\n" ++
+  "  ld t2, 16(t1); sd t2, 392(s0)\n" ++
+  "  ld t2, 24(t1); sd t2, 400(s0)\n" ++
   -- GASLIMIT (word 10 -> +408): exec u64 @412.
   "  ld t2, 412(a2); sd t2, 408(s0)\n" ++
   -- 6121j.1: CHAINID (word 12 -> +472): bv_chain_id (u64, set by chain_config_valid during the
@@ -176,6 +185,7 @@ def stageRuntimePayloadFunction : String :=
       +56   staged witness.codes len
       +64   staged gas_limit
       +72   context status (for diagnostics)
+      +80   PREVRANDAO low byte (env word 9 @ payload+376)
 -/
 def ziskStageRuntimePayloadPrologue : String :=
   "  li sp, 0xa0050000\n" ++
@@ -208,6 +218,7 @@ def ziskStageRuntimePayloadPrologue : String :=
   "  ld t2, 576(t1); sd t2, 56(t0)  # witness.codes len\n" ++
   "  ld t2, 536(t1); sd t2, 64(t0)  # gas_limit\n" ++
   "  li t3, 0xa0020000; ld t2, 0(t3); sd t2, 72(t0)  # context status\n" ++
+  "  lbu t2, 376(t1); sd t2, 80(t0)  # PREVRANDAO low byte\n" ++
   "  j .Lsrpp_done\n" ++
   rlpListNthItemFunction ++ "\n" ++
   rlpFieldToU64Function ++ "\n" ++
@@ -218,6 +229,13 @@ def ziskStageRuntimePayloadPrologue : String :=
   txExtractValueFunction ++ "\n" ++
   txExtractDataSectionFunction ++ "\n" ++
   simpleTransferTxContextFunction ++ "\n" ++
+  bgvU64leFunction ++ "\n" ++
+  u256FromU64BeFunction ++ "\n" ++
+  u256IsZeroFunction ++ "\n" ++
+  u256AddBeFunction ++ "\n" ++
+  u256MulU64BeFunction ++ "\n" ++
+  u256DivU64BeFunction ++ "\n" ++
+  amsterdamBlobGasPriceU256Function ++ "\n" ++
   stageRuntimePayloadFunction ++ "\n" ++
   ".Lsrpp_done:"
 
@@ -231,6 +249,8 @@ def ziskStageRuntimePayloadDataSection : String :=
   "bv_tx_item_start:\n  .zero 8\n" ++
   "bv_public_keys_ptr:\n  .zero 8\n" ++
   "bv_public_keys_len:\n  .zero 8\n" ++
+  "bv_chain_id:\n  .zero 8\n" ++
+  "u256m_acc:\n  .zero 40\n" ++
   "teng_type:\n  .zero 8\n" ++
   "teng_inner_off:\n  .zero 8\n" ++
   "rfu_offset:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictSelfContained.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictSelfContained.lean
@@ -71,18 +71,8 @@ def bytecodeIsSelfContainedFunction : String :=
   --   non-storage effect log -- nonstorage_effect_latest_balance in balance_at_header_state_root,
   --   falling back to the pre-state witness when no value transfer touched the account).
   -- (The BALANCE 0x31 reject is REMOVED here; 0xff was removed by ee21v.)
-  -- 6121j: PREVRANDAO(0x44) / CHAINID(0x46) / BLOBBASEFEE(0x4a) are NOT yet activated -- the
-  -- verdict's contract-stage path does NOT stage their env words (prev_randao / chain_id /
-  -- blob_base_fee), so a DISPATCHED self-contained contract reads 0 for them instead of the real
-  -- value (BLOBBASEFEE handler reads the zeroed evm_env+512; CHAINID/PREVRANDAO read unstaged env).
-  -- A self-contained contract using any of them would execute against wrong env, and its
-  -- exec-derived sender/recipient balance+gas results could match a FORGED BAL the spec rejects
-  -- (false-accept). Reject here so such contracts take the conservative .Ldtrc_unsupported bail
-  -- (BlockVerdictDispatchTx.lean:212: skip the exec-derived check, rely on the independent
-  -- BAL/state-root checks). Sound + no false-reject (the bail is conservative-accept; the EIP-7778
-  -- gate fails open). Feature-completeness follow-up (6121j): STAGE the real values and re-activate
-  -- (CHAINID const, PREVRANDAO header copy, BLOBBASEFEE = taylor_exponential blob gas price).
-  "  li t3, 0x44; beq t2, t3, .Lbsc_unsafe\n" ++   -- PREVRANDAO (unstaged env -> reads 0)
+  -- PREVRANDAO (0x44) ACTIVATED (ha909): stage_runtime_payload_code now copies the execution
+  -- payload prev_randao Bytes32 into env word 9, so dispatched contracts read the real header mix.
   -- CHAINID (0x46) ACTIVATED (6121j.1): stage_runtime_payload_code now stages bv_chain_id into the
   -- CHAINID env word (+472 -> EvmEnv+384), so a dispatched contract reads the real chain id. Lifted.
   -- BLOBBASEFEE (0x4a) ACTIVATED (6121j.1): stage_runtime_payload_code now stages the block blob
@@ -94,14 +84,15 @@ def bytecodeIsSelfContainedFunction : String :=
   ".Lbsc_unsafe:\n" ++
   "  li a0, 1; ret"
 
-/-- `zisk_bytecode_is_self_contained`: probe over four hand-written bytecodes. Post-activation
-    (ee21v + yisv8 removed the last rejects) NO opcode is un-staged, so all four scan
-    self-contained (0).
+/-- `zisk_bytecode_is_self_contained`: probe over hand-written bytecodes. Post-activation
+    (ee21v + yisv8 + ha909 removed the last rejects) these opcodes scan self-contained (0).
     Output:
       +0  scan of PUSH1 0x07 PUSH1 0x01 SSTORE STOP (expect 0 self-contained)
       +8  scan of PUSH1 0x00 BALANCE   (60 00 31)   (expect 0 — BALANCE activated, yisv8)
       +16 scan of PUSH1 0xF1 STOP (0xF1 is push DATA, not CALL) (expect 0)
-      +24 scan of PUSH1 0x00 SELFDESTRUCT (60 00 FF) (expect 0 — SELFDESTRUCT activated, ee21v) -/
+      +24 scan of PUSH1 0x00 SELFDESTRUCT (60 00 FF) (expect 0 — SELFDESTRUCT activated, ee21v)
+      +32 scan of PUSH1 0x00 BLOCKHASH (60 00 40) (expect 0 — M29 staged, 3vc2p.4)
+      +40 scan of PREVRANDAO STOP (44 00) (expect 0 — PREVRANDAO staged, ha909) -/
 def ziskBytecodeIsSelfContainedPrologue : String :=
   "  li sp, 0xa0050000\n" ++
   "  li s0, 0xa0010000\n" ++
@@ -127,6 +118,10 @@ def ziskBytecodeIsSelfContainedPrologue : String :=
   "  la t0, bsc_codeE\n" ++
   "  li t1, 0x60; sb t1, 0(t0); sb zero, 1(t0); li t1, 0x40; sb t1, 2(t0)\n" ++
   "  la a0, bsc_codeE; li a1, 3; jal ra, bytecode_is_self_contained; sd a0, 32(s0)\n" ++
+  -- code F: 44 00 (PREVRANDAO STOP -> self-contained: prev_randao env word staged, ha909).
+  "  la t0, bsc_codeF\n" ++
+  "  li t1, 0x44; sb t1, 0(t0); sb zero, 1(t0)\n" ++
+  "  la a0, bsc_codeF; li a1, 2; jal ra, bytecode_is_self_contained; sd a0, 40(s0)\n" ++
   "  j .Lbscp_done\n" ++
   bytecodeIsSelfContainedFunction ++ "\n" ++
   ".Lbscp_done:"
@@ -138,7 +133,8 @@ def ziskBytecodeIsSelfContainedDataSection : String :=
   "bsc_codeB:\n  .zero 16\n" ++
   "bsc_codeC:\n  .zero 16\n" ++
   "bsc_codeD:\n  .zero 16\n" ++
-  "bsc_codeE:\n  .zero 16\n"
+  "bsc_codeE:\n  .zero 16\n" ++
+  "bsc_codeF:\n  .zero 16\n"
 
 def ziskBytecodeIsSelfContainedProbeUnit : BuildUnit := {
   body        := NOP

--- a/scripts/codegen-zisk-stage-runtime-payload-check.sh
+++ b/scripts/codegen-zisk-stage-runtime-payload-check.sh
@@ -79,6 +79,8 @@ struct.pack_into('<Q', payload, 64 - 8 + 404, 0x1234)
 struct.pack_into('<Q', payload, 64 - 8 + 412, 0x55aa)
 # timestamp u64 (@guest +64 + 428 -> file +484).
 struct.pack_into('<Q', payload, 64 - 8 + 428, 0x99)
+# prev_randao Bytes32 (@guest +64 + 372 -> file +428), first byte marker.
+payload[64 - 8 + 372] = 0x44
 
 for i in range(pubkeys_len):
     payload[320 - 8 + i] = (i + 1) & 0xff
@@ -109,7 +111,7 @@ run_case() {
     -i "$in_file" -o "$out_file" -n 1000000 \
     >"$log_file" 2>&1 || true
 
-  local a_status a_bc a_cd a_gf a_ic a_hl a_ws a_wc a_gl
+  local a_status a_bc a_cd a_gf a_ic a_hl a_ws a_wc a_gl a_pr
   a_status="$(xxd -p -l 8 "$out_file" 2>/dev/null | tr -d '\n')"
   a_bc="$(dd if="$out_file" bs=1 skip=8  count=8 2>/dev/null | xxd -p | tr -d '\n')"
   a_cd="$(dd if="$out_file" bs=1 skip=16 count=8 2>/dev/null | xxd -p | tr -d '\n')"
@@ -119,32 +121,38 @@ run_case() {
   a_ws="$(dd if="$out_file" bs=1 skip=48 count=8 2>/dev/null | xxd -p | tr -d '\n')"
   a_wc="$(dd if="$out_file" bs=1 skip=56 count=8 2>/dev/null | xxd -p | tr -d '\n')"
   a_gl="$(dd if="$out_file" bs=1 skip=64 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  a_pr="$(dd if="$out_file" bs=1 skip=80 count=8 2>/dev/null | xxd -p | tr -d '\n')"
 
-  local e_status e_bc e_cd e_gf e_ic e_gl e_zero
+  local e_status e_bc e_cd e_gf e_ic e_gl e_pr e_zero
   e_status="$(le64_hex "$exp_status")"
   e_bc="$(le64_hex "$exp_bc_len")"
   e_cd="$(le64_hex "$exp_cd_len")"
   e_gf="$(le64_hex "$exp_gas_flag")"
   e_ic="$(le64_hex "$exp_is_creation")"
   e_gl="$(le64_hex "$exp_gas_limit")"
+  if [[ "$exp_status" == "0" ]]; then
+    e_pr="$(le64_hex 68)"
+  else
+    e_pr="$(le64_hex 0)"
+  fi
   e_zero="$(le64_hex 0)"
 
   if [[ "$a_status" == "$e_status" && "$a_bc" == "$e_bc" && \
         "$a_cd" == "$e_cd" && "$a_gf" == "$e_gf" && \
         "$a_ic" == "$e_ic" && "$a_gl" == "$e_gl" && \
-        "$a_hl" == "$e_zero" && "$a_ws" == "$e_zero" && \
-        "$a_wc" == "$e_zero" ]]; then
-    printf "  %-22s OK   status=%s bc=%s cd=%s gas_flag=%s creation=%s gas=%s\n" \
+        "$a_pr" == "$e_pr" && "$a_hl" == "$e_zero" && \
+        "$a_ws" == "$e_zero" && "$a_wc" == "$e_zero" ]]; then
+    printf "  %-22s OK   status=%s bc=%s cd=%s gas_flag=%s creation=%s gas=%s prev_randao=%s\n" \
       "$name" "$exp_status" "$exp_bc_len" "$exp_cd_len" "$exp_gas_flag" \
-      "$exp_is_creation" "$exp_gas_limit"
+      "$exp_is_creation" "$exp_gas_limit" "$([[ "$exp_status" == "0" ]] && echo 0x44 || echo 0x00)"
     return 0
   fi
 
   printf "  %-22s FAIL\n" "$name"
-  printf "    expected status=%s bc=%s cd=%s gf=%s ic=%s gl=%s witness=0/0/0\n" \
-    "$e_status" "$e_bc" "$e_cd" "$e_gf" "$e_ic" "$e_gl"
-  printf "    actual   status=%s bc=%s cd=%s gf=%s ic=%s gl=%s witness=%s/%s/%s\n" \
-    "$a_status" "$a_bc" "$a_cd" "$a_gf" "$a_ic" "$a_gl" "$a_hl" "$a_ws" "$a_wc"
+  printf "    expected status=%s bc=%s cd=%s gf=%s ic=%s gl=%s pr=%s witness=0/0/0\n" \
+    "$e_status" "$e_bc" "$e_cd" "$e_gf" "$e_ic" "$e_gl" "$e_pr"
+  printf "    actual   status=%s bc=%s cd=%s gf=%s ic=%s gl=%s pr=%s witness=%s/%s/%s\n" \
+    "$a_status" "$a_bc" "$a_cd" "$a_gf" "$a_ic" "$a_gl" "$a_pr" "$a_hl" "$a_ws" "$a_wc"
   printf "    emulator log: %s\n" "$log_file"
   return 1
 }
@@ -156,8 +164,9 @@ run_case "legacy_ok"      legacy      1 65 0 1 0 1 0 21000 || FAILED=1
 run_case "eip1559_ok"     eip1559     1 65 0 1 0 1 0 21000 || FAILED=1
 # Unsupported context (count != 1) -> stage status 1, no payload staged.
 run_case "zero_tx"        legacy      0 65 1 0 0 0 0 0 || FAILED=1
-# Non-empty calldata -> extractor status 61 -> stage status 1.
-run_case "nonempty_data"  legacy_data 1 65 1 0 0 0 0 0 || FAILED=1
+# Non-empty calldata to an EOA is staged with the calldata length preserved; later
+# gas/account gates decide whether the transaction is executable.
+run_case "nonempty_data"  legacy_data 1 65 0 1 2 1 0 21000 || FAILED=1
 
 echo
 if [[ $FAILED -eq 0 ]]; then


### PR DESCRIPTION
## Summary
- copy execution-payload prev_randao into runtime env word 9 for both STOP and contract-code staging paths
- lift the bytecode_is_self_contained PREVRANDAO(0x44) reject
- extend staging/self-contained probes to assert the PREVRANDAO slot directly
- make the stage_runtime_payload probe self-contained for its CHAINID/BLOBBASEFEE helper deps and update the stale nonempty-calldata expectation to match staged calldata

## Validation
- rtk lake build EvmAsm.Codegen.Programs.BlockVerdictRuntimePayload EvmAsm.Codegen.Programs.BlockVerdictContractStage EvmAsm.Codegen.Programs.BlockVerdictSelfContained EvmAsm.Codegen.Programs.BlockVerdict
- rtk scripts/codegen-zisk-stage-runtime-payload-check.sh
- zisk_stage_runtime_payload_code output == [5, 88, 0x60, 21000, 0xC0, 0xAA, 0x44]
- zisk_stage_runtime_payload_code_m29 output == [152, 2, 0x5A, 0x11, 0xAA, 21000, 0x44]
- zisk_bytecode_is_self_contained output == [0, 0, 0, 0, 0, 0]
- rtk git diff --check
- rtk scripts/check-forbidden-tactics.sh
- rtk scripts/check-unimported.sh
- rtk scripts/check-file-size.sh
- rtk lake build
- rtk scripts/check-no-warnings.sh

Bead: evm-asm-ha909.