### PR TITLE
fix(codegen): avoid duplicate stateless debug helpers

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
@@ -128,12 +128,6 @@ def ziskStatelessVerdictV2ProbeUnit : BuildUnit := {
     btiScanStorageChangesFunction ++ "\n" ++
     balTxsIndependentFunction ++ "\n" ++
     multiTxNthContextFunction ++ "\n" ++
-    -- g8zeq.1.4.2: block_verdict's block_state-gas floor check calls
-    -- block_verdict_tx_state_gas_array -> tx_intrinsic_state_gas -> eip8037_tx_state_gas;
-    -- mirror the guest closure so this debug verdict ELF links (je0xd pattern).
-    eip8037TxStateGasFunction ++ "\n" ++
-    txIntrinsicStateGasFunction ++ "\n" ++
-    blockVerdictTxStateGasArrayFunction ++ "\n" ++
     -- bmvmx.3.2: mirror the guest closure's per-tx sender-recovery stack so this
     -- debug verdict ELF links (block_verdict calls verify_public_keys_match_senders).
     verifyPublicKeysSendersGuestFunctions ++ "\n" ++


### PR DESCRIPTION
## Summary
- remove the duplicate EIP-8037 state-gas helper bodies from the standalone stateless verdict v2 debug probe closure
- keep helper ownership in `ziskStatelessVerdictV2Prologue`, which the debug probe already prepends

## Evidence
- `lake build EvmAsm.Codegen.Programs.BlockVerdictV2`
- `scripts/codegen-eest-eip8037-state-dominates-check.sh`
- `scripts/codegen-eest-stateless-check.sh --skip 1715 --limit 1 --max-failures 1 --steps 1000000000 --run-dir gen-out/eest-debug-probe-mslra` reached and ran `emit verdict debug probe` with no duplicate-symbol assembler failure; the remaining EIP-8025 semantic false-reject is tracked separately by `evm-asm-k9nxt`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/BlockVerdictV2.lean` returned no matches
- `git diff --check`
- `lake build`
- `scripts/check-no-warnings.sh`

Bead: evm-asm-mslra.

Authored by @pirapira; implemented by Codex.