### PR TITLE
fix(eest): warm coinbase for runtime account access

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictContractStage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictContractStage.lean
@@ -141,11 +141,12 @@ def stageRuntimePayloadCodeFunction : String :=
   ".Lsrpc_m29_done:\n" ++
   -- env words base (now after the M29 block).
   "  add s5, s0, t1               # s5 = &env_words (env_base)\n" ++
-  -- COINBASE (word 6 -> +192): exec 20-byte address @32, low-aligned.
+  -- COINBASE (word 6 -> +192): exec 20-byte canonical address at payload byte 32,
+  -- reversed into the low 160 bits of the EVM stack word layout.
   "  addi t3, s2, 32; addi t4, s5, 192; li t5, 0\n" ++
   ".Lsrpc_cb:\n" ++
   "  li t6, 20; beq t5, t6, .Lsrpc_cb_done\n" ++
-  "  add a5, t3, t5; lbu a6, 0(a5); add a5, t4, t5; sb a6, 0(a5); addi t5, t5, 1; j .Lsrpc_cb\n" ++
+  "  add a5, t3, t5; lbu a6, 0(a5); li a5, 19; sub a5, a5, t5; add a5, t4, a5; sb a6, 0(a5); addi t5, t5, 1; j .Lsrpc_cb\n" ++
   ".Lsrpc_cb_done:\n" ++
   -- NUMBER (word 8 -> +256) = exec u64 @404; TIMESTAMP (word 7 -> +224) = @428;
   -- PREVRANDAO (word 9 -> +288) = exec Bytes32 @372; GASLIMIT (word 10 -> +320) = @412.

--- a/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
@@ -110,11 +110,12 @@ def stageCreationRuntimePayloadFunction : String :=
   "  li t0, 1; sd t0, 0(s0)\n" ++
   -- Env trailer starts at +88 for one padded bytecode dword and no calldata/storage.
   "  addi t6, s0, 88              # env base\n" ++
-  -- COINBASE (word 6 -> +192): exec 20-byte address @32, low-aligned.
+  -- COINBASE (word 6 -> +192): exec 20-byte canonical address at payload byte 32,
+  -- reversed into the low 160 bits of the EVM stack word layout.
   "  addi t1, s2, 32; addi t2, t6, 192; li t3, 0\n" ++
   ".Lscrp_coinbase:\n" ++
   "  li t4, 20; beq t3, t4, .Lscrp_coinbase_done\n" ++
-  "  add t5, t1, t3; lbu t4, 0(t5); add t5, t2, t3; sb t4, 0(t5)\n" ++
+  "  add t5, t1, t3; lbu t4, 0(t5); li t5, 19; sub t5, t5, t3; add t5, t2, t5; sb t4, 0(t5)\n" ++
   "  addi t3, t3, 1; j .Lscrp_coinbase\n" ++
   ".Lscrp_coinbase_done:\n" ++
   -- NUMBER (word 8), TIMESTAMP (word 7), GASLIMIT (word 10).

--- a/EvmAsm/Codegen/Programs/BlockVerdictRuntimePayload.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictRuntimePayload.lean
@@ -123,17 +123,15 @@ def stageRuntimePayloadFunction : String :=
   -- env word was unstaged so a dispatched contract read CHAINID=0 (false-accept). Now staged with
   -- the real chain id, so the reject is lifted (see BlockVerdictSelfContained .Lbsc_check).
   "  la t1, bv_chain_id; ld t2, 0(t1); sd t2, 472(s0)\n" ++
-  -- COINBASE (word 6 -> +280): exec 20-byte address @32, right-aligned into a
-  -- 32-byte big-endian stack word. Copy the 20 bytes byte-by-byte so the
-  -- staged word has the address in its low 20 bytes (matching how the env
-  -- trailer copy treats these words verbatim).
+  -- COINBASE (word 6 -> +280): exec 20-byte canonical address at payload byte 32,
+  -- reversed into the low 160 bits of the EVM stack word layout.
   "  addi t1, a2, 32              # exec coinbase ptr\n" ++
   "  addi t3, s0, 280             # dst env word\n" ++
   "  li t4, 0\n" ++
   ".Lsrp_coinbase_loop:\n" ++
   "  li t5, 20; beq t4, t5, .Lsrp_coinbase_done\n" ++
   "  add t6, t1, t4; lbu t5, 0(t6)\n" ++
-  "  add t6, t3, t4; sb t5, 0(t6)\n" ++
+  "  li t6, 19; sub t6, t6, t4; add t6, t3, t6; sb t5, 0(t6)\n" ++
   "  addi t4, t4, 1; j .Lsrp_coinbase_loop\n" ++
   ".Lsrp_coinbase_done:\n" ++
   -- 6121j.1: BLOBBASEFEE — stage the block blob gas price into the payload blob_base_fee slot @+32

--- a/EvmAsm/Codegen/Programs/EvmAccessGas.lean
+++ b/EvmAsm/Codegen/Programs/EvmAccessGas.lean
@@ -267,6 +267,7 @@ def runtimeAccessWordToBe20Asm (tag srcReg dstReg idxReg tmpReg : String) : Stri
     words known before opcode execution:
       - ADDRESS/current executing account at env+0
       - CALLER at env+64
+      - COINBASE at env+192
       - ORIGIN/sender at env+256
 
     The standalone runtime does not currently carry a distinct tx.to/create
@@ -292,6 +293,14 @@ def runtimeAccessSeedInitialAccountsFunction : String :=
   "  addi t1, x20, 64\n" ++
   "  mv t2, s0\n" ++
   runtimeAccessWordToBe20Asm "caller" "t1" "t2" "t3" "t4" ++
+  "  mv a0, s0\n" ++
+  "  la a1, " ++ runtimeAccessAccountTableLabel ++ "\n" ++
+  "  la a2, " ++ runtimeAccessAccountCountLabel ++ "\n" ++
+  "  li a3, " ++ toString runtimeAccessAccountCapacity ++ "\n" ++
+  "  jal ra, runtime_access_account_seed\n" ++
+  "  addi t1, x20, 192\n" ++
+  "  mv t2, s0\n" ++
+  runtimeAccessWordToBe20Asm "coinbase" "t1" "t2" "t3" "t4" ++
   "  mv a0, s0\n" ++
   "  la a1, " ++ runtimeAccessAccountTableLabel ++ "\n" ++
   "  la a2, " ++ runtimeAccessAccountCountLabel ++ "\n" ++


### PR DESCRIPTION
## Summary
- stage COINBASE env words in the same low-160-bit EVM stack-word byte layout used by address consumers
- seed COINBASE as an initially warm account for runtime EIP-2929 account access gas
- fixes the EIP-8037 observed-coinbase b1 receipt/success mismatch tracked by bead evm-asm-5agq9

## Validation
- scripts/codegen-eest-stateless-check.sh --skip 2612 --limit 1 --max-failures 1 --steps 1000000000 --run-dir gen-out/eest-coinbase-b1-final
- scripts/codegen-eest-stateless-check.sh --skip 2611 --limit 2 --max-failures 1 --steps 1000000000 --run-dir gen-out/eest-coinbase-adjacent-final (expected remaining separate P0: b0 still fails)
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' edited files
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build
- scripts/check-no-warnings.sh