### PR TITLE
fix(codegen): align Amsterdam CREATE gas

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -349,7 +349,9 @@ def emitJumpTable (registry : List OpcodeHandlerSpec) : String :=
     Sourced from the standard EVM gas tiers
     (`execution-specs/src/ethereum/forks/prague/vm/gas.py`): ZERO=0,
     JUMPDEST=1, BASE=2, VERYLOW=3, LOW=5, MID=8, HIGH=10, BLOCKHASH=20,
-    KECCAK256 base=30, LOG base=375, warm access=100, CREATE=32000.
+    KECCAK256 base=30, LOG base=375, warm access=100. Amsterdam/EIP-8037
+    moves the account-growth portion of CREATE/CREATE2 into state gas, so the
+    regular static base is 9000 rather than the pre-Amsterdam 32000.
 
     **Static base costs only** — all *dynamic* components are dropped:
     memory-expansion, copy (per-word), KECCAK/LOG per-word/per-topic, EXP
@@ -402,7 +404,7 @@ def staticGasCost (op : Nat) : Nat :=
     | 0x5e => 3                                              -- MCOPY (base)
     | 0x5f => 2                                              -- PUSH0 (BASE)
     -- child frames (base; dynamic call/create costs dropped)
-    | 0xf0 => 32000 | 0xf5 => 32000                          -- CREATE, CREATE2
+    | 0xf0 => 9000 | 0xf5 => 9000                              -- CREATE, CREATE2
     | 0xf1 | 0xf2 | 0xf4 | 0xfa => 100                       -- CALL,CALLCODE,DELEGATECALL,STATICCALL
     | 0xff => 5000                                           -- SELFDESTRUCT (base)
     -- STOP (0x00), RETURN (0xf3), REVERT (0xfd), INVALID (0xfe),

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
@@ -264,11 +264,12 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     -- PARENT gas_left (568(x20), still the parent env here, before the descend); OOG-fail the CREATE
     -- (push 0 via 7f) when both reservoirs are short. evm_state_gas_used += charge. Preserves the
     -- dispatcher state x10/x12/x13/x20/x21 (only t0-t3 + the parent gas_left). The charge is REFUNDED
-    -- on child failure by the snapshot bump after create_frame_descend below (the descent snapshots
-    -- POST-charge into child_env+624/632, so adding/subtracting 183600 makes incorporate_child_on_error's
-    -- rollback restore the PRE-charge reservoir/used -- matching spec 'refunded on any failure path').
+    -- on child failure by the snapshot rewrite after create_frame_descend below. The descent snapshots
+    -- POST-charge into child_env+624/632, so we preserve the pre-charge reservoir and subtract 183600
+    -- from the used snapshot; incorporate_child_on_error then restores the exact pre-charge state and
+    -- frame_return can also restore any regular-gas spill.
     "  li t0, 183600\n" ++
-    "  la t1, evm_state_gas_left\n  ld t2, 0(t1)\n" ++
+    "  la t1, evm_state_gas_left\n  ld t2, 0(t1)\n  mv t4, t2\n" ++
     "  bgeu t2, t0, .Lcr_csg_res_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
     "  sub t3, t0, t2\n  sd x0, 0(t1)\n" ++
     "  ld t2, 568(x20)\n  bltu t2, t3, 7f\n" ++
@@ -277,13 +278,16 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     "  sub t2, t2, t0\n  sd t2, 0(t1)\n" ++
     ".Lcr_csg_used_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
     "  la t1, evm_state_gas_used\n  ld t2, 0(t1)\n  add t2, t2, t0\n  sd t2, 0(t1)\n" ++
+    "  addi sp, sp, -16\n  sd t4, 0(sp)\n" ++
     "  li a1, " ++ toString netPopBytes ++ "\n" ++
     "  jal x1, create_frame_descend\n" ++
+    "  ld t4, 0(sp)\n  addi sp, sp, 16\n" ++
     -- nxio8.8 refund-on-failure: the descent snapshotted state-gas POST-charge into child_env+624/632;
-    -- bump the snapshot by the charge so incorporate_child_on_error restores the PRE-charge reservoir
-    -- on child error/revert (x20 = child env here). On child success the snapshot is unused (charge stands).
-    "  ld t0, 624(x20)\n  li t1, 183600\n  add t0, t0, t1\n  sd t0, 624(x20)\n" ++
-    "  ld t0, 632(x20)\n  sub t0, t0, t1\n  sd t0, 632(x20)\n" ++
+    -- rewrite the snapshot to the PRE-charge reservoir/used values. On child error/revert,
+    -- frame_return restores those globals and restores any regular-gas spill to the parent;
+    -- on child success the snapshot is unused and the charge stands.
+    "  sd t4, 624(x20)\n" ++
+    "  ld t0, 632(x20)\n  li t1, 183600\n  sub t0, t0, t1\n  sd t0, 632(x20)\n" ++
     "  j .dispatch_loop\n" ++
     "7:\n" ++
     "  addi x12, x12, " ++ toString netPopBytes ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
+++ b/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
@@ -191,7 +191,7 @@ def callMemoryExpansionGasAsm
   ".Lcallmem_" ++ tag ++ "_done:\n"
 
 /-- CREATE-family initcode dynamic gas. The dispatch loop already charges
-    `OPCODE_CREATE_BASE = 32000`; this charges the EIP-3860 initcode word
+    `OPCODE_CREATE_BASE = 9000`; this charges the EIP-3860 initcode word
     cost `2 * ceil32(size) / 32`, and for CREATE2 also the EIP-1014 hashcost
     `6 * ceil32(size) / 32`. Memory expansion is handled separately by
     `updateActiveMemorySizeAsm` over the same initcode range.

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -1205,31 +1205,31 @@ def opcodeTestCases : List OpcodeTestCase :=
       expectedHaltKind := "0000000000000000" }
   , -- CREATE2 size=1 charges static CREATE base, EIP-3860 initcode word
     -- gas, EIP-1014 hashcost, and memory expansion: 4 PUSH1s (12) +
-    -- 32000 + 8 + 3.
+    -- 9000 + 8 + 3.
     { name             := "create2_initcode_len1_gas_exact"
       bytecode         := "0x60, 0x00, 0x60, 0x01, 0x60, 0x00, 0x60, 0x00, 0xf5, 0x00"
       expectedOutHex   := "38bf260bb3b098f0ff6ff250028ff8b42b2e1a4d000000000000000000000000"
       expectedHaltKind := "0000000000000000"
-      gasLimit         := "32023" }
+      gasLimit         := "9023" }
   , -- One less gas fails in CREATE2's dynamic initcode charge before
     -- address derivation or later unsupported deployment slices.
     { name             := "create2_initcode_len1_out_of_gas"
       bytecode         := "0x60, 0x00, 0x60, 0x01, 0x60, 0x00, 0x60, 0x00, 0xf5, 0x00"
       expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
       expectedHaltKind := "0600000000000000"
-      gasLimit         := "32022" }
+      gasLimit         := "9022" }
   , -- At 33 bytes CREATE2 rounds to two words for both EIP-3860 and
-    -- EIP-1014 hashcost: 4 PUSH1s (12) + 32000 + 16 + memory gas 6.
+    -- EIP-1014 hashcost: 4 PUSH1s (12) + 9000 + 16 + memory gas 6.
     { name             := "create2_initcode_len33_gas_exact"
       bytecode         := "0x60, 0x00, 0x60, 0x21, 0x60, 0x00, 0x60, 0x00, 0xf5, 0x00"
       expectedOutHex   := "05539a1fc4f022d6cdeb61c98ff5d21bf5d5d9b9000000000000000000000000"
       expectedHaltKind := "0000000000000000"
-      gasLimit         := "32034" }
+      gasLimit         := "9034" }
   , { name             := "create2_initcode_len33_out_of_gas"
       bytecode         := "0x60, 0x00, 0x60, 0x21, 0x60, 0x00, 0x60, 0x00, 0xf5, 0x00"
       expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
       expectedHaltKind := "0600000000000000"
-      gasLimit         := "32033" }
+      gasLimit         := "9033" }
   , -- CREATE2 size is the third decoded word. High size limbs are rejected
     -- before later address/precheck/deployment slices consume initcode.
     { name             := "create2_high_size_limb_out_of_gas"


### PR DESCRIPTION
## Summary
- Set CREATE/CREATE2 dispatcher static regular gas to Amsterdam/EIP-8037's 9000 base instead of the pre-Amsterdam 32000 value.
- Preserve the exact pre-charge state-gas reservoir snapshot for CREATE child-frame rollback so regular spill is restored on child failure.
- Update focused CREATE2 gas limits/comments to match the Amsterdam base.

## Verification
- scripts/codegen-eest-stateless-check.sh --skip 1715 --limit 1 --max-failures 1 --steps 1000000000 --run-dir gen-out/eest-eip8025-reverted-create-final: PASS(full)
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Dispatch.lean EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean EvmAsm/Codegen/Programs/EvmMemoryGas.lean EvmAsm/Codegen/Tests/Cases.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build
- scripts/check-no-warnings.sh

Bead: evm-asm-k9nxt.

Authored by @pirapira; implemented by Codex