### PR TITLE
fix(eip8037): defer regular overflow to exact gas check

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -667,7 +667,6 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bsg_auth_off:\n  .zero 8\n" ++
   "bsg_auth_len:\n  .zero 8\n" ++
   "bsg_auth_count:\n  .zero 8\n" ++
-  "bsg_header_gas_used:\n  .zero 8\n" ++
   "bsg_min_block_gas:\n  .zero 8\n" ++
   "alc_scratch:\n  .zero 8\n" ++
   "alc_entry_offset:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictGasGate.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictGasGate.lean
@@ -30,11 +30,9 @@ open EvmAsm.Rv64
     also mirrors the execution-spec pre-execution block-gas
     availability check when it can prove rejection from the intrinsic/floor gas
     lower bound of prior transactions. Single-transaction overflow is always
-    invalid. Multi-transaction regular overflow is rejected only when the
-    accumulated worst-regular gas before the overflowing transaction agrees with
-    the block header's final `gas_used`; otherwise this conservative bound may
-    be above execution-spec `block_gas_used` because prior transactions returned
-    unused gas, so the gate fails open. -/
+    invalid. Multi-transaction worst-regular overflow is not a safe
+    pre-runtime rejection because prior transactions may return unused gas; it
+    is deferred to the post-runtime exact gas-used check for supported rows. -/
 def eip8037TxGasGateFunction : String :=
   "eip8037_state_used_before_tx:\n" ++
   "  addi sp, sp, -96\n" ++
@@ -161,8 +159,6 @@ def eip8037TxGasGateFunction : String :=
   "  li s4, 0                    # accumulated worst regular gas\n" ++
   "  la t0, bsg_min_block_gas; sd zero, 0(t0)\n" ++
   "  la t0, bsg_exact_state_ok; sd zero, 0(t0)\n" ++
-  "  addi a0, s0, 420; jal ra, bgv_u64le       # header gas_used\n" ++
-  "  la t0, bsg_header_gas_used; sd a0, 0(t0)\n" ++
   "  addi a0, s0, 504; jal ra, bgv_u32le\n" ++
   "  add s5, s0, a0              # tx list ptr\n" ++
   "  addi a0, s0, 508; jal ra, bgv_u32le\n" ++
@@ -409,8 +405,8 @@ def eip8037TxGasGateFunction : String :=
   "  addi s8, s8, 1; j .Letg_tx_loop\n" ++
   ".Letg_regular_fail:\n" ++
   "  li t0, 1; beq s7, t0, .Letg_regular_reject\n" ++
-  "  la t0, bsg_header_gas_used; ld t0, 0(t0)\n" ++
-  "  beq s4, t0, .Letg_regular_reject\n" ++
+  "  # Multi-tx worst-regular overflow is only an upper bound before runtime.\n" ++
+  "  # Supported rows are checked exactly after gas-result arena materializes.\n" ++
   "  j .Letg_ok\n" ++
   ".Letg_regular_reject:\n" ++
   "  li a0, 1; j .Letg_ret\n" ++


### PR DESCRIPTION
## Summary
- remove the pre-runtime multi-tx header-gas-used shortcut from the EIP-8037 tx gas gate
- keep single-tx regular overflow rejection, while deferring multi-tx worst-regular overflow to the post-runtime exact gas-used path from the stack base
- remove the now-dead bsg_header_gas_used scratch cell

## Validation
- rtk lake build EvmAsm.Codegen.Programs.BlockVerdictGasGate EvmAsm.Codegen.Programs.BlockVerdictDataSection EvmAsm.Codegen.Programs.BlockVerdictV2 EvmAsm.Codegen.Programs.BlockVerdict
- rtk scripts/codegen-eest-eip8037-block-regular-check.sh
- rtk scripts/codegen-eest-stateless-check.sh --skip 2612 --limit 1 --max-failures 1 --jobs 1 --quiet-passes
- rtk scripts/codegen-eest-eip8037-state-dominates-check.sh
- rtk scripts/codegen-eest-eip8037-pricing-various-gas-check.sh
- rtk scripts/codegen-zisk-eip8037-block-gas-used-check.sh
- rtk scripts/codegen-zisk-eip8037-tx-state-gas-net-array-check.sh
- rtk git diff --check
- rtk scripts/check-file-size.sh
- rtk scripts/check-unimported.sh
- rtk lake build
- rtk scripts/check-no-warnings.sh
- rtk scripts/check-forbidden-tactics.sh
- rtk env EEST_EIP8037_RESERVOIR_STEPS=5000000000 scripts/codegen-eest-eip8037-reservoir-check.sh

Bead: evm-asm-xbi56.3

Authored by @pirapira; implemented by Codex