### PR TITLE
feat(rlp): general long-form full paths (e3/e5 over an arbitrary in-class prefix)

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -55,6 +55,8 @@ import EvmAsm.Rv64.RLP.Phase1E5LongListSeven
 import EvmAsm.Rv64.RLP.Phase1E5LongListEight
 import EvmAsm.Rv64.RLP.Phase2LongLengthBridge
 import EvmAsm.Rv64.RLP.Phase2LongLoopGeneral
+import EvmAsm.Rv64.RLP.Phase1E3LongBytesFull
+import EvmAsm.Rv64.RLP.Phase1E5LongListFull
 import EvmAsm.Rv64.RLP.Phase1E3LongStringFromBytesBE
 import EvmAsm.Rv64.RLP.Phase1E5LongListFromBytesBE
 import EvmAsm.Rv64.RLP.Phase1StepToPhase3LongString

--- a/EvmAsm/Rv64/RLP/Phase1E3LongBytesFull.lean
+++ b/EvmAsm/Rv64/RLP/Phase1E3LongBytesFull.lean
@@ -1,0 +1,159 @@
+/-
+  EvmAsm.Rv64.RLP.Phase1E3LongBytesFull
+
+  EL.3 full Phase 1 → Phase 3 → Phase 2 path for an **arbitrary** long
+  byte-string prefix (e3, `0xB8`–`0xBF`). Composes the Phase 1 e3 cascade +
+  Phase 3 long-string entry (`rlp_phase1_e3_full_path_spec'_within`, leaving the
+  counter `x14 = pfx − 0xB7`, rewritten here to `ofNat (rlpPrefixLongBytesLenOfLen
+  pfx)`) with the general n-iteration loop closure
+  (`rlp_phase2_long_loop_n_byte_spec_within`) at `n = rlpPrefixLongBytesLenOfLen
+  pfx ∈ [1,8]`.
+
+  Result: one theorem, over any long byte-string prefix, giving the decoded
+  payload length `x11 = ofNat (Nat.fromBytesBE (length bytes))`. Long-string
+  analogue of `rlp_phase1_e5_longList_full_spec_within`.
+-/
+
+import EvmAsm.Rv64.RLP.Phase1E3FullPath
+import EvmAsm.Rv64.RLP.Phase2LongLoopGeneral
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Tactics
+open EvmAsm.EL.RLP
+
+/-- Full decode path for an arbitrary long byte-string prefix `pfx`
+    (`classifyPrefix pfx = .longBytes`). The length-of-length
+    `n = rlpPrefixLongBytesLenOfLen pfx` is dispatched through the single
+    long-form loop; `x11` holds the decoded payload length per `Nat.fromBytesBE`. -/
+theorem rlp_phase1_e3_longBytes_full_spec_within
+    (pfx : EvmAsm.EL.RLP.Byte)
+    (v10 v11Old v12Old v13 v14Old wordVal dwordAddr : Word)
+    (off1 off2 off3 back : BitVec 13)
+    (base e3_target : Word)
+    (htarget : (base + 16 + 4) + signExtend13 off3 = e3_target)
+    (h_class : EvmAsm.EL.RLP.classifyPrefix pfx = EvmAsm.EL.RLP.PrefixClass.longBytes)
+    (hwin : ∀ i, i < rlpPrefixLongBytesLenOfLen pfx →
+        alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + BitVec.ofNat 64 i) = dwordAddr
+        ∧ isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + BitVec.ofNat 64 i) = true)
+    (hback : ((e3_target + 12) + 20) + signExtend13 back = (e3_target + 12))
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          (rlp_phase1_step_code 0xC0 off3 (base + 16))))).Disjoint
+        (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))
+    (hd_loop :
+      ((((rlp_phase1_step_code 0x80 off1 base).union
+         ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+           (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+         (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))).Disjoint
+        (CodeReq.ofProg (e3_target + 12) (rlp_phase2_long_loop_body_prog back))) :
+    let ptr := v13 + signExtend12 (1 : BitVec 12)
+    let n := rlpPrefixLongBytesLenOfLen pfx
+    cpsTripleWithin (9 + 6 * n) base ((e3_target + 12) + 24)
+      (((((rlp_phase1_step_code 0x80 off1 base).union
+          ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+            (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+          (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))).union
+          (CodeReq.ofProg (e3_target + 12) (rlp_phase2_long_loop_body_prog back)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x5 ↦ᵣ pfx.zeroExtend 64) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xC0 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE (rlpLoopByteList wordVal ptr n))) **
+        (.x13 ↦ᵣ (ptr + BitVec.ofNat 64 n)) ** (.x14 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ
+          (extractByte wordVal (byteOffset (ptr + BitVec.ofNat 64 (n - 1)))).zeroExtend 64) **
+        (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ wordVal)) := by
+  intro ptr n
+  have hrange := (EvmAsm.EL.RLP.classifyPrefix_longBytes_iff pfx).mp h_class
+  have hmod : pfx.toNat % 18446744073709551616 = pfx.toNat :=
+    Nat.mod_eq_of_lt (by omega)
+  have hn1 : 1 ≤ n := by
+    show 1 ≤ rlpPrefixLongBytesLenOfLen pfx
+    unfold rlpPrefixLongBytesLenOfLen; omega
+  have hn8 : n ≤ 8 := by
+    show rlpPrefixLongBytesLenOfLen pfx ≤ 8
+    unfold rlpPrefixLongBytesLenOfLen; omega
+  have hv5_lo :
+      ¬ BitVec.ult (pfx.zeroExtend 64)
+        ((0 : Word) + signExtend12 (0x80 : BitVec 12)) := by
+    rw [BitVec.ult_eq_decide]
+    simp only [BitVec.toNat_setWidth]
+    have hk : (((0 : Word) + signExtend12 (0x80 : BitVec 12)).toNat) = 0x80 := by decide
+    rw [hk, hmod]; simp only [decide_eq_true_eq]; omega
+  have hv5_mid :
+      ¬ BitVec.ult (pfx.zeroExtend 64)
+        ((0 : Word) + signExtend12 (0xB8 : BitVec 12)) := by
+    rw [BitVec.ult_eq_decide]
+    simp only [BitVec.toNat_setWidth]
+    have hk : (((0 : Word) + signExtend12 (0xB8 : BitVec 12)).toNat) = 0xB8 := by decide
+    rw [hk, hmod]; simp only [decide_eq_true_eq]; omega
+  have hv5_hi :
+      BitVec.ult (pfx.zeroExtend 64)
+        ((0 : Word) + signExtend12 (0xC0 : BitVec 12)) := by
+    rw [BitVec.ult_eq_decide]
+    simp only [BitVec.toNat_setWidth]
+    have hk : (((0 : Word) + signExtend12 (0xC0 : BitVec 12)).toNat) = 0xC0 := by decide
+    rw [hk, hmod]; simp only [decide_eq_true_eq]; omega
+  have prefixSpec := rlp_phase1_e3_full_path_spec'_within
+    (pfx.zeroExtend 64) v10 v11Old v13 v14Old off1 off2 off3 base e3_target
+    htarget hv5_lo hv5_mid hv5_hi hd_phase3
+  -- Rewrite the counter `x14 = pfx − 0xB7` to `ofNat (lenOfLen pfx)`.
+  have hx14 : (pfx.zeroExtend 64) + signExtend12 (-(0xB7 : BitVec 12))
+      = BitVec.ofNat 64 n := by
+    have hs : signExtend12 (-(0xB7 : BitVec 12)) = -(0xB7 : Word) := by decide
+    rw [hs, ← BitVec.sub_eq_add_neg,
+      ← EvmAsm.EL.RLP.rlpPrefixLongBytesLenOfLen_toWord_of_class pfx h_class]
+  rw [hx14] at prefixSpec
+  have prefix' : cpsTripleWithin 9 base (e3_target + 12)
+      (((rlp_phase1_step_code 0x80 off1 base).union
+         ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+           (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+         (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ pfx.zeroExtend 64) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xC0 : BitVec 12))) **
+        (.x11 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ v12Old) **
+        (.x13 ↦ᵣ (v13 + signExtend12 (1 : BitVec 12))) **
+        (.x14 ↦ᵣ (BitVec.ofNat 64 n)) ** (dwordAddr ↦ₘ wordVal)) :=
+    cpsTripleWithin_weaken
+      (fun _ hp => by xperm_hyp hp)
+      (fun _ hp => by xperm_hyp hp)
+      (cpsTripleWithin_frameR
+        ((.x12 ↦ᵣ v12Old) ** (dwordAddr ↦ₘ wordVal)) (by pcFree) prefixSpec)
+  have loop := rlp_phase2_long_loop_n_byte_spec_within n hn1 hn8 ptr v12Old wordVal
+    dwordAddr (e3_target + 12) back hwin hback
+  have loop' : cpsTripleWithin (6 * n) (e3_target + 12) ((e3_target + 12) + 24)
+      (CodeReq.ofProg (e3_target + 12) (rlp_phase2_long_loop_body_prog back))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ pfx.zeroExtend 64) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xC0 : BitVec 12))) **
+        (.x11 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ v12Old) **
+        (.x13 ↦ᵣ (v13 + signExtend12 (1 : BitVec 12))) **
+        (.x14 ↦ᵣ (BitVec.ofNat 64 n)) ** (dwordAddr ↦ₘ wordVal))
+      ((.x5 ↦ᵣ pfx.zeroExtend 64) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xC0 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE (rlpLoopByteList wordVal ptr n))) **
+        (.x13 ↦ᵣ (ptr + BitVec.ofNat 64 n)) ** (.x14 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ
+          (extractByte wordVal (byteOffset (ptr + BitVec.ofNat 64 (n - 1)))).zeroExtend 64) **
+        (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ wordVal)) := by
+    have framed := cpsTripleWithin_frameR
+      ((.x5 ↦ᵣ pfx.zeroExtend 64) **
+       (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xC0 : BitVec 12))))
+      (by pcFree) loop
+    exact cpsTripleWithin_weaken
+      (fun _ hp => by xperm_hyp hp)
+      (fun _ hp => by xperm_hyp hp)
+      framed
+  exact cpsTripleWithin_seq hd_loop prefix' loop'
+
+-- Sanity: the symbolic count `n` resolves to the expected length-of-length.
+example : rlpPrefixLongBytesLenOfLen (0xBA : EvmAsm.EL.RLP.Byte) = 3 := by decide
+example : rlpPrefixLongBytesLenOfLen (0xBF : EvmAsm.EL.RLP.Byte) = 8 := by decide
+
+end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Phase1E5LongListFull.lean
+++ b/EvmAsm/Rv64/RLP/Phase1E5LongListFull.lean
@@ -1,0 +1,132 @@
+/-
+  EvmAsm.Rv64.RLP.Phase1E5LongListFull
+
+  EL.3 full Phase 1 → Phase 3 → Phase 2 path for an **arbitrary** long-list
+  prefix (e5, `0xF8`–`0xFF`). Composes the class-level Phase 1 + Phase 3 entry
+  (`rlp_phase1_e5_full_path_lenOfLen_of_class_spec_within`, which leaves the
+  length-of-length counter `x14 = ofNat (rlpPrefixLongListLenOfLen pfx)`) with
+  the general n-iteration loop closure (`rlp_phase2_long_loop_n_byte_spec_within`)
+  at the symbolic count `n = rlpPrefixLongListLenOfLen pfx ∈ [1,8]`.
+
+  Result: one theorem, over any long-list prefix, giving the decoded payload
+  length `x11 = ofNat (Nat.fromBytesBE (length bytes))` and payload pointer
+  `x13`. Collapses the eight concrete `rlp_phase1_e5_0x…_…_byte_length_*` paths.
+-/
+
+import EvmAsm.Rv64.RLP.Phase1E5FullPath
+import EvmAsm.Rv64.RLP.Phase2LongLoopGeneral
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Tactics
+open EvmAsm.EL.RLP
+
+/-- Full decode path for an arbitrary long-list prefix `pfx` (`classifyPrefix
+    pfx = .longList`). The length-of-length `n = rlpPrefixLongListLenOfLen pfx`
+    is dispatched through the single long-form loop; `x11` holds the decoded
+    payload length per the pure spec `Nat.fromBytesBE`. -/
+theorem rlp_phase1_e5_longList_full_spec_within
+    (pfx : EvmAsm.EL.RLP.Byte)
+    (v10 v11Old v12Old v13 v14Old wordVal dwordAddr : Word)
+    (off1 off2 off3 off4 back : BitVec 13)
+    (base : Word)
+    (h_class : EvmAsm.EL.RLP.classifyPrefix pfx = EvmAsm.EL.RLP.PrefixClass.longList)
+    (hwin : ∀ i, i < rlpPrefixLongListLenOfLen pfx →
+        alignToDword ((v13 + signExtend12 (1 : BitVec 12)) + BitVec.ofNat 64 i) = dwordAddr
+        ∧ isValidByteAccess ((v13 + signExtend12 (1 : BitVec 12)) + BitVec.ofNat 64 i) = true)
+    (hback : ((base + 44) + 20) + signExtend13 back = (base + 44))
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24)))))).Disjoint
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))
+    (hd_loop :
+      ((((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))).Disjoint
+        (CodeReq.ofProg (base + 44) (rlp_phase2_long_loop_body_prog back))) :
+    let ptr := v13 + signExtend12 (1 : BitVec 12)
+    let n := rlpPrefixLongListLenOfLen pfx
+    cpsTripleWithin (11 + 6 * n) base ((base + 44) + 24)
+      (((((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))).union
+        (CodeReq.ofProg (base + 44) (rlp_phase2_long_loop_body_prog back)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x5 ↦ᵣ pfx.zeroExtend 64) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xF8 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE (rlpLoopByteList wordVal ptr n))) **
+        (.x13 ↦ᵣ (ptr + BitVec.ofNat 64 n)) ** (.x14 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ
+          (extractByte wordVal (byteOffset (ptr + BitVec.ofNat 64 (n - 1)))).zeroExtend 64) **
+        (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ wordVal)) := by
+  intro ptr n
+  have hrange := (EvmAsm.EL.RLP.classifyPrefix_longList_iff pfx).mp h_class
+  have hn1 : 1 ≤ n := by
+    show 1 ≤ rlpPrefixLongListLenOfLen pfx
+    unfold rlpPrefixLongListLenOfLen; omega
+  have hn8 : n ≤ 8 := by
+    show rlpPrefixLongListLenOfLen pfx ≤ 8
+    unfold rlpPrefixLongListLenOfLen; omega
+  -- Prefix side: Phase 1 classify + Phase 3 long-list entry, x14 = ofNat n.
+  have prefixSpec := rlp_phase1_e5_full_path_lenOfLen_of_class_spec_within
+    pfx v10 v11Old v13 v14Old off1 off2 off3 off4 base h_class hd_phase3
+  have prefix' : cpsTripleWithin 11 base (base + 44)
+      ((((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14Old) ** (dwordAddr ↦ₘ wordVal))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ pfx.zeroExtend 64) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xF8 : BitVec 12))) **
+        (.x11 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ v12Old) **
+        (.x13 ↦ᵣ (v13 + signExtend12 (1 : BitVec 12))) **
+        (.x14 ↦ᵣ (BitVec.ofNat 64 n)) ** (dwordAddr ↦ₘ wordVal)) :=
+    cpsTripleWithin_weaken
+      (fun _ hp => by xperm_hyp hp)
+      (fun _ hp => by xperm_hyp hp)
+      (cpsTripleWithin_frameR
+        ((.x12 ↦ᵣ v12Old) ** (dwordAddr ↦ₘ wordVal)) (by pcFree) prefixSpec)
+  -- Loop side: general n-iteration closure at n = lenOfLen pfx.
+  have loop := rlp_phase2_long_loop_n_byte_spec_within n hn1 hn8 ptr v12Old wordVal
+    dwordAddr (base + 44) back hwin hback
+  have loop' : cpsTripleWithin (6 * n) (base + 44) ((base + 44) + 24)
+      (CodeReq.ofProg (base + 44) (rlp_phase2_long_loop_body_prog back))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ pfx.zeroExtend 64) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xF8 : BitVec 12))) **
+        (.x11 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ v12Old) **
+        (.x13 ↦ᵣ (v13 + signExtend12 (1 : BitVec 12))) **
+        (.x14 ↦ᵣ (BitVec.ofNat 64 n)) ** (dwordAddr ↦ₘ wordVal))
+      ((.x5 ↦ᵣ pfx.zeroExtend 64) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xF8 : BitVec 12))) **
+        (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE (rlpLoopByteList wordVal ptr n))) **
+        (.x13 ↦ᵣ (ptr + BitVec.ofNat 64 n)) ** (.x14 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ
+          (extractByte wordVal (byteOffset (ptr + BitVec.ofNat 64 (n - 1)))).zeroExtend 64) **
+        (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ wordVal)) := by
+    have framed := cpsTripleWithin_frameR
+      ((.x5 ↦ᵣ pfx.zeroExtend 64) **
+       (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xF8 : BitVec 12))))
+      (by pcFree) loop
+    exact cpsTripleWithin_weaken
+      (fun _ hp => by xperm_hyp hp)
+      (fun _ hp => by xperm_hyp hp)
+      framed
+  exact cpsTripleWithin_seq hd_loop prefix' loop'
+
+-- Sanity: the symbolic count `n` resolves to the expected length-of-length.
+example : rlpPrefixLongListLenOfLen (0xFA : EvmAsm.EL.RLP.Byte) = 3 := by decide
+example : rlpPrefixLongListLenOfLen (0xFF : EvmAsm.EL.RLP.Byte) = 8 := by decide
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -1117,11 +1117,24 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     Supporting: `rlpLoopAcc` (the loop's big-endian fold), `rlpLoopAcc_toNat`
     (mod-form invariant), and `rlpLoopAcc_zero_eq_fromBytesBE` (the fold ↔
     `fromBytesBE` bridge). Axiom-clean, 0 sorry.
-  - Remaining: unified single-item dispatch (compose the Phase-1
-    `cpsNBranchWithin` classifier with all five general handlers, incl. the
-    general long-form full paths that apply the n-iteration closure at the
-    runtime lenLen), cross-doubleword length spans, and `readLength` canonical
-    / `>55` validation.
+  - ✅ **General long-form full paths** (`Phase1E3LongBytesFull.lean` /
+    `Phase1E5LongListFull.lean`). For an **arbitrary** in-class prefix,
+    `rlp_phase1_e3_longBytes_full_spec_within` /
+    `rlp_phase1_e5_longList_full_spec_within` compose the Phase-1 classify +
+    Phase-3 entry with the n-iteration closure at the symbolic
+    `n = rlpPrefixLong{Bytes,List}LenOfLen pfx ∈ [1,8]`, yielding the decoded
+    `x11 = ofNat (Nat.fromBytesBE (rlpLoopByteList …))` and payload pointer
+    `x13`. Collapses the 16 concrete-prefix `…_fromBytesBE_spec_within` paths
+    into 2 parametric theorems (e5 reuses the existing
+    `…_lenOfLen_of_class…` prefix wrapper; e3 rewrites `x14 = pfx − 0xB7` to
+    `ofNat n` via `rlpPrefixLongBytesLenOfLen_toWord_of_class`). Axiom-clean,
+    0 sorry.
+  - Remaining: unified single-item dispatch — compose the Phase-1
+    `cpsNBranchWithin` classifier with all five general handlers (e1/e2/e4 flat
+    + the e3/e5 general long-form full paths); needs a "`cpsNBranch` then
+    per-exit continue" composition (the structurally hardest piece).
+    Also: cross-doubleword length spans, and `readLength` canonical / `>55`
+    validation.
 - Phase 4: `read_input` integration (obtain RLP input pointer + length)
 - Phase 5: Recursive list decode (iterative with explicit stack)
 - Phase 6: Top-level pipeline (`read_input` -> decode -> `write_output`)


### PR DESCRIPTION
## What

Builds the **general long-form full paths**: for an arbitrary long byte-string prefix (e3, `0xB8`–`0xBF`) and an arbitrary long list prefix (e5, `0xF8`–`0xFF`), one theorem each proving the decoder produces the decoded `(payload_ptr, payload_len)` with `payload_len = ofNat (Nat.fromBytesBE …)` — applying #8901's general loop closure at the **symbolic** length-of-length `n = prefix − 0xB7 / − 0xF7 ∈ [1,8]`.

This collapses the 16 concrete-prefix `…_fromBytesBE_spec_within` paths (#8744) into **2 parametric theorems** and is the direct precursor to the unified single-item dispatch.

## How

Each composes the proven prefix-side (Phase 1 classify + Phase 3 entry) with `rlp_phase2_long_loop_n_byte_spec_within` (#8901) via `cpsTripleWithin_seq`, mirroring the concrete `Phase1E{3,5}LongString/List…` recipe.

- `Phase1E5LongListFull.lean` — `rlp_phase1_e5_longList_full_spec_within`. The prefix side already exists at class level (`rlp_phase1_e5_full_path_lenOfLen_of_class_spec_within` leaves `x14 = ofNat (rlpPrefixLongListLenOfLen pfx)`), so it's a direct frame + compose.
- `Phase1E3LongBytesFull.lean` — `rlp_phase1_e3_longBytes_full_spec_within`. Uses `rlp_phase1_e3_full_path_spec'_within` and rewrites the counter `x14 = pfx − 0xB7` to `ofNat n` via `rlpPrefixLongBytesLenOfLen_toWord_of_class`.

`1 ≤ n ≤ 8` comes from `classifyPrefix_long{Bytes,List}_iff`; step bound `{9,11} + 6n`.

## Verification

- ✅ `lake build` — full library green, 0 sorry
- ✅ `scripts/check-no-warnings.sh` — **0 warnings under EvmAsm/** (run pre-push)
- ✅ `scripts/check-forbidden-tactics.sh` — no `native_decide` / `bv_decide`
- ✅ `#print axioms` on both theorems → only `propext` / `Classical.choice` / `Quot.sound`
- Sanity `example`s confirm `n = rlpPrefixLong{Bytes,List}LenOfLen` resolves correctly (e.g. `0xBA → 3`, `0xFF → 8`)

## Next (final milestone step)

Unified single-item dispatch: compose the Phase-1 `cpsNBranchWithin` classifier with all five general handlers (e1/e2/e4 flat + these e3/e5 long-form) — needs a "`cpsNBranch` then per-exit continue" composition.

## Out of scope

- Cross-doubleword length spans (single-doubleword, `n ≤ 8`).
- `readLength` canonical / `>55` validation.

Builds on #8901.

🤖 Generated with [Claude Code](https://claude.com/claude-code)