### PR TITLE
fix(eip6110): support large deposit request bodies

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -194,7 +194,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   "  la t1, bv_b2_count; ld t2, 0(t1); sd t2, 848(t0)\n" ++
   "  li t2, " ++ toString bvMtxCommittedChunkCapacity ++ "; sd t2, 856(t0)\n" ++
   "  li t2, " ++ toString bvMtxCommittedChunkBytes ++ "; sd t2, 864(t0)\n" ++
-  "  la t1, bv_mtx_nonce_seen_count; ld t2, 0(t1); sd t2, 872(t0)\n" ++
+  "  li t2, 0; sd t2, 872(t0)  # retired nonce-seen debug counter\n" ++
   "  li t2, 16; sd t2, 880(t0)\n" ++
   "  la t1, bv_tx_count; ld t2, 0(t1); sd t2, 888(t0)\n" ++
   "  la t1, brr_control; ld t2, 0(t1); sd t2, 896(t0)\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -566,13 +566,13 @@ def ziskStatelessVerdictV2DataSection : String :=
   -- instead of corrupting .data.
   "c1_staging:\n  .zero " ++ toString c1StagingBytes ++ "\n" ++
   ".balign 8\n" ++
-  "c1_er_assembled:\n  .zero 32768\n" ++
+  "c1_er_assembled:\n  .zero " ++ toString bvMaxExecutionRequestSectionBytes ++ "\n" ++
   "c1_er_assembled_len:\n  .zero 8\n" ++
   "c1_erh_status:\n  .zero 8\n" ++
   "c1_notx_deposit_body_len:\n  .zero 8\n" ++
   "c1_dstatus:\n  .zero 8\n" ++
   "c1_dlen:\n  .zero 8\n" ++
-  "c1_dbody:\n  .zero 32768\n" ++
+  "c1_dbody:\n  .zero " ++ toString bvMaxDepositRequestBodyBytes ++ "\n" ++
   "c1_log_records:\n  .zero 81920\n" ++
   "c1_ccode_ptr:\n  .zero 8\n" ++
   "c1_ccode_len:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
@@ -149,6 +149,13 @@ def bvReceiptListPayloadBytes : Nat := 32768
 def bvReceiptConsensusDescCapacity : Nat := 128
 def bvReceiptConsensusDescBytes : Nat := bvReceiptConsensusDescCapacity * 16
 
+/-- Amsterdam SSZ execution-request capacity:
+    deposits 8192*192, withdrawals 16*76, consolidations 2*116, plus the
+    3-entry offset table used by the guest's flattened request-section body. -/
+def bvMaxDepositRequestBodyBytes : Nat := 8192 * 192
+def bvMaxExecutionRequestSectionBytes : Nat :=
+  12 + bvMaxDepositRequestBodyBytes + 16 * 76 + 2 * 116
+
 /-- `c1_staging` (system-call payload buffer) byte size: must hold
     round8(predeploy codelen) + preload_count*64 + m29_count*32 + 584.
     Predeploy code comes from the witness and is NOT EIP-170-bounded, but the

--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -98,7 +98,9 @@ def blockVerdictReceiptsTail : String :=
   "  la a0, c1_dbody; la t2, c1_dlen; ld a1, 0(t2)\n" ++
   "  la a2, dbsr_wbody; la t2, dbsr_wlen; ld a3, 0(t2)\n" ++
   "  la a4, dbsr_cbody; la t2, dbsr_clen; ld a5, 0(t2)\n" ++
-  "  add t0, a1, a3; add t0, t0, a5; addi t0, t0, 12; la t1, c1_er_assembled_len; sd t0, 0(t1)\n" ++
+  "  add t0, a1, a3; add t0, t0, a5; addi t0, t0, 12\n" ++
+  "  li t2, " ++ toString bvMaxExecutionRequestSectionBytes ++ "; bgtu t0, t2, .Lbv_requests_hash_fail\n" ++
+  "  la t1, c1_er_assembled_len; sd t0, 0(t1)\n" ++
   "  la a6, erh_requests_hash\n" ++
   "  la a7, c1_er_assembled\n" ++
   "  jal ra, requests_hash_verify\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
@@ -555,6 +555,8 @@ def statelessVerdictV2Function : String :=
   "  mv a0, t2; mv a1, t3\n" ++
   "  la t0, dbsr_wbody; mv a2, t0; la t0, dbsr_wlen; ld a3, 0(t0)\n" ++
   "  la t0, dbsr_cbody; mv a4, t0; la t0, dbsr_clen; ld a5, 0(t0)\n" ++
+  "  mv t0, a1; add t0, t0, a3; add t0, t0, a5; addi t0, t0, 12\n" ++
+  "  li t1, " ++ toString bvMaxExecutionRequestSectionBytes ++ "; bgtu t0, t1, .Lv2_requests_hash_fail\n" ++
   "  la a6, c1_er_assembled\n" ++
   "  jal ra, assemble_execution_requests\n" ++
   "  la t0, c1_er_assembled_len; sd a0, 0(t0)\n" ++

--- a/EvmAsm/Codegen/Programs/MptIndexedTrieRoot.lean
+++ b/EvmAsm/Codegen/Programs/MptIndexedTrieRoot.lean
@@ -482,6 +482,7 @@ def mptIndexedTrieRootSmallFunction : String :=
   "  mv s2, a2                   # out root\n" ++
   "  li t0, 2049\n" ++
   "  bgeu s1, t0, .Litr_fail\n" ++
+  "  beqz s1, .Litr_empty\n" ++
   "  li t0, 1\n" ++
   "  beq s1, t0, .Litr_one_leaf\n" ++
   "  mv a0, s0\n" ++
@@ -544,6 +545,18 @@ def mptIndexedTrieRootSmallFunction : String :=
   "  ld a1, 8(s0)                # value len\n" ++
   "  mv a2, s2                   # out root\n" ++
   "  jal ra, mpt_indexed_trie_root_one_leaf\n" ++
+  "  j .Litr_ret\n" ++
+  ".Litr_empty:\n" ++
+  "  la t0, iw_empty_trie_root\n" ++
+  "  li t1, 32\n" ++
+  ".Litr_empty_copy:\n" ++
+  "  lbu t2, 0(t0)\n" ++
+  "  sb t2, 0(s2)\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  addi s2, s2, 1\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  bnez t1, .Litr_empty_copy\n" ++
+  "  li a0, 0\n" ++
   "  j .Litr_ret\n" ++
   ".Litr_build_done:\n" ++
   "  la a0, iw_empty_trie_root\n" ++


### PR DESCRIPTION
## Summary
- return the empty trie root from mpt_indexed_trie_root_small for zero-item lists
- size EIP-7685 request scratch buffers for Amsterdam SSZ limits instead of 32 KiB
- guard assembled request sections before hashing and avoid the retired nonce debug symbol in the verdict probe

## Verification
- lake build EvmAsm.Codegen.Programs.BlockVerdictParams EvmAsm.Codegen.Programs.BlockVerdictDataSection EvmAsm.Codegen.Programs.BlockVerdictStateRoot EvmAsm.Codegen.Programs.BlockVerdictReceiptsTail EvmAsm.Codegen.Programs.BlockVerdict
- scripts/codegen-eest-stateless-check.sh --skip 21252 --limit 1 --max-failures 1 --steps 1000000000 --run-dir gen-out/eest-kcopw-repro
- scripts/codegen-zisk-mpt-indexed-trie-root-small-check.sh
- scripts/codegen-zisk-block-access-list-hash-check.sh many_deposits_from_contract 1
- scripts/codegen-zisk-parse-deposit-requests-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- scripts/check-no-warnings.sh --report
- lake build

Bead: evm-asm-kcopw

Authored by @pirapira; implemented by Codex.