### PR TITLE
fix(eip8037): lift receipt record capacity

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
@@ -127,12 +127,11 @@ def bvSystemStorageLogCapacity : Nat := 16384
 def bvSystemStorageLogBytes : Nat := bvSystemStorageLogCapacity * 128
 def bvSystemStorageTxindexBytes : Nat := bvSystemStorageLogCapacity * 8
 
-/-- Receipt/log arena capacities are deliberately separate from the transaction
-    count cap. Capacity overflow is conservative receipt-enforcement debt
-    (accept/no enforcement), while malformed data inside an enforced shape may
-    still reject. These names preserve the current static sizes while making the
-    independent limits explicit for the follow-up capacity slices. -/
-def bvReceiptRecordCapacity : Nat := 16
+/-- Receipt/log arena capacities are deliberately separated by resource type.
+    Receipt records are per transaction and therefore use the full Amsterdam
+    200M intrinsic-floor transaction count target; log/RLP byte arenas remain
+    independent capacity slices tracked under `evm-asm-vv4hr.3`. -/
+def bvReceiptRecordCapacity : Nat := bvMtxFullTxCap
 def bvReceiptRecordBytes : Nat := 64
 def bvReceiptRecordsBytes : Nat := bvReceiptRecordCapacity * bvReceiptRecordBytes
 def bvBlockLogDescCapacity : Nat := 128
@@ -208,13 +207,13 @@ def bmvFullLogWindowArenaBytes : Nat :=
 #guard bvMtxCommittedBytes = 16384
 #guard bvMtxCommittedChunkCapacity = 512
 #guard bvMtxCommittedChunkBytes = 65536
-#guard bvReceiptRecordsBytes = 1024
+#guard bvReceiptRecordsBytes = 609472
 #guard bvBlockLogDescBytes = 32768
 #guard bvBlockLogMetaBytes = 2048
 #guard bvBlockLogDataBytes = 65536
 #guard bvLogsRlpArenaBytes = 65536
-#guard bvRecordBloomsBytes = 4096
-#guard bvRecordLogsDescBytes = 512
+#guard bvRecordBloomsBytes = 2437888
+#guard bvRecordLogsDescBytes = 304736
 #guard bvReceiptsRlpBytes = 65536
 #guard bvReceiptEncodePayloadBytes = 16384
 #guard bvReceiptListPayloadBytes = 32768

--- a/docs/eest-200m-resource-audit.md
+++ b/docs/eest-200m-resource-audit.md
@@ -29,7 +29,7 @@ The distinction matters:
 | Sender aggregation | Up to `9523` txs, repeated or distinct senders | Active sender tables use `bvMtxActiveTxCap = 1024` | Gap: aggregation slices under `evm-asm-vv4hr.1`; related existing P1 `evm-asm-bmvmx.5.5.7.3`. |
 | Committed storage threading | All unique `(recipient, slotKey)` keys reachable under 200M | `bvMtxCommittedChunkCapacity = 512` | Gap: `evm-asm-vv4hr.2`. |
 | System storage side capture | All modeled system-call SSTORE rows needed by BAL checks | `bvSystemStorageLogCapacity = 16384`; some paths are best-effort | Gap: `evm-asm-vv4hr.7`; related ungate beads `evm-asm-hwngs`, `evm-asm-40igg`. |
-| Receipt records | Up to the supported tx count | `bvReceiptRecordCapacity = 16` | Gap: `evm-asm-vv4hr.3`. |
+| Receipt records | Up to the supported tx count | `bvReceiptRecordCapacity = bvMtxFullTxCap = 9523` | Covered for per-tx records; log/RLP capacity remains separate. |
 | Block log descriptors | All supported execution-derived logs | `bvBlockLogDescCapacity = 128` | Gap: `evm-asm-vv4hr.3`. |
 | Log/RLP bytes | Aggregate log payloads and receipt-list RLP for supported blocks | `bvBlockLogDataBytes = 65536`, `bvLogsRlpArenaBytes = 65536`, `bvReceiptsRlpBytes = 65536` | Gap: `evm-asm-vv4hr.3`. |
 | Execution requests hash input | EIP-6110 deposits `8192 * 192`, withdrawals `16 * 76`, consolidations `2 * 116` | `erh_blob = 1572865` | Hash helper covers the deposit body cap. |

--- a/scripts/codegen-zisk-block-receipt-records-materialize-check.sh
+++ b/scripts/codegen-zisk-block-receipt-records-materialize-check.sh
@@ -31,7 +31,7 @@ REPO_ROOT="$(pwd)"
 # mode=empty: no transactions.
 # mode=legacy_stop: one legacy tx whose data field is STOP (0x00).
 # mode=two_legacy_stop: two legacy STOP txs, testing runtime receipt-gas increments.
-# mode=over_capacity: 17 legacy STOP txs; the receipt-record arena accepts 16 and reports append-capacity debt.
+# mode=seventeen_legacy_stop: 17 legacy STOP txs; covers the former 16-record cap.
 run_case() {
   local name="$1" mode="$2"
   local in_file="$REPO_ROOT/gen-out/zisk_block_receipt_records_${name}.input"
@@ -120,7 +120,7 @@ elif mode == 'two_legacy_stop':
     expected_last_status = 0
     first_record = (0, 1, 18000, 0, 0, 0, 0, 0)
     last_record = (0, 1, 42000, 0, 0, 0, 0, 0)
-elif mode == 'over_capacity':
+elif mode == 'seventeen_legacy_stop':
     txs = [legacy_stop_tx(21000 + i) for i in range(17)]
     offsets = []
     cursor = 4 * len(txs)
@@ -137,13 +137,11 @@ elif mode == 'over_capacity':
         + struct.pack('<' + 'Q' * len(gas_increments), *gas_increments)
     )
     wd_off = TX_OFF + len(tx_list)
-    expected_brr_status = 2
-    expected_append_status = 1
-    expected_count = 16
+    expected_count = len(txs)
     expected_first_status = 0
     expected_last_status = 0
     first_record = (0, 1, gas_increments[0], 0, 0, 0, 0, 0)
-    last_record = (0, 1, sum(gas_increments[:16]), 0, 0, 0, 0, 0)
+    last_record = (0, 1, sum(gas_increments), 0, 0, 0, 0, 0)
 else:
     raise ValueError(mode)
 
@@ -184,7 +182,7 @@ FAILED=0
 run_case "empty" empty || FAILED=1
 run_case "legacy_stop" legacy_stop || FAILED=1
 run_case "two_legacy_stop" two_legacy_stop || FAILED=1
-run_case "over_capacity" over_capacity || FAILED=1
+run_case "seventeen_legacy_stop" seventeen_legacy_stop || FAILED=1
 
 if [[ $FAILED -eq 0 ]]; then
   echo "==> PASS: block receipt-record materializer probe"


### PR DESCRIPTION
## Summary
- size receipt-record materialization to the full Amsterdam 200M tx target instead of the old 16-record cap
- update the receipt-record probe to cover the former 16-record frontier with a 17-tx success case
- refresh the 200M resource audit to mark per-tx receipt records covered while leaving log/RLP arenas tracked separately

## Verification
- lake build EvmAsm.Codegen.Programs.BlockVerdictParams EvmAsm.Codegen.Programs.BlockVerdictReceiptRecords EvmAsm.Codegen.Programs.BlockVerdictDataSection EvmAsm.Codegen.Programs.BlockVerdict
- scripts/codegen-zisk-block-receipt-records-materialize-check.sh
- scripts/codegen-eest-stateless-check.sh --skip 2444 --limit 1 --max-failures 1 --steps 1000000000 --run-dir gen-out/eest-2vw50-repro
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- scripts/check-no-warnings.sh --report
- lake build

Bead: evm-asm-2vw50

Authored by @pirapira; implemented by Codex.