### PR TITLE
fix(eip7702): align set-code receipt gas

### DIFF
--- a/EvmAsm/Codegen/Programs/BalAllAccountsNonstorage.lean
+++ b/EvmAsm/Codegen/Programs/BalAllAccountsNonstorage.lean
@@ -134,8 +134,17 @@ def balAllAccountsNonstorageConsistentFunction : String :=
   "  bnez a0, .Lc3ns_fail                     # parse failure -> reject\n" ++
   "  la t0, c2nsc_finals\n" ++
   "  ld t1, 0(t0);  bnez t1, .Lc3ns_fail      # has_balance declared but no exec effect -> reject\n" ++
+  "  ld t1, 56(t0); beqz t1, .Lc3ns_no_7702_code\n" ++
+  "  # EIP-7702 set_delegation installs 0xef0100||target directly from authorization,\n" ++
+  "  # so an authority account can have BAL nonce/code changes without a CALL/CREATE exec effect.\n" ++
+  "  ld t2, 72(t0); li t3, 23; bne t2, t3, .Lc3ns_fail\n" ++
+  "  ld t2, 64(t0); add t2, s7, t2\n" ++
+  "  lbu t3, 0(t2); li t4, 0xef; bne t3, t4, .Lc3ns_fail\n" ++
+  "  lbu t3, 1(t2); li t4, 0x01; bne t3, t4, .Lc3ns_fail\n" ++
+  "  lbu t3, 2(t2); bnez t3, .Lc3ns_fail\n" ++
+  "  j .Lc3ns_next\n" ++
+  ".Lc3ns_no_7702_code:\n" ++
   "  ld t1, 40(t0); bnez t1, .Lc3ns_fail      # has_nonce\n" ++
-  "  ld t1, 56(t0); bnez t1, .Lc3ns_fail      # has_code\n" ++
   "  # declares no non-storage change (storage-only callee) -> nothing to check here\n" ++
   ".Lc3ns_next:\n" ++
   "  addi s5, s5, 1; j .Lc3ns_loop\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -103,7 +103,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   "  la t1, bv_exact_block_status; ld t2, 0(t1); sd t2, 136(t0)\n" ++
   "  la t1, bv_exact_header_gas_used; ld t2, 0(t1); sd t2, 144(t0)\n" ++
   "  la t1, bv_exact_expected_gas_used; ld t2, 0(t1); sd t2, 152(t0)\n" ++
-  "  la t1, brr_records; ld t2, 80(t1); sd t2, 160(t0)\n" ++
+  "  la t1, brr_records; ld t2, 16(t1); sd t2, 160(t0)\n" ++
   "  la t1, sv_recomputed; ld t2, 0(t1); sd t2, 168(t0)\n" ++
   "  la t1, sv_recomputed; ld t2, 8(t1); sd t2, 176(t0)\n" ++
   "  la t1, sv_recomputed; ld t2, 16(t1); sd t2, 184(t0)\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictBalFindAccount.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictBalFindAccount.lean
@@ -67,6 +67,7 @@ def balFindAccountByAddressFunction : String :=
   "  lbu t5, 0(t1); lbu t6, 0(t3); bne t5, t6, .Lbfa_next\n" ++
   "  addi t1, t1, 1; addi t3, t3, 1; addi t4, t4, -1; j .Lbfa_cmp\n" ++
   ".Lbfa_match:\n" ++
+  "  la t6, bfa_index; sd s6, 0(t6)\n" ++
   "  la t0, bfa_aoff; ld t0, 0(t0); add t1, s0, t0; sd t1, 0(s3)\n" ++
   "  la t0, bfa_alen; ld t2, 0(t0); sd t2, 0(s4)\n" ++
   "  li a0, 0; j .Lbfa_ret\n" ++
@@ -112,6 +113,7 @@ def ziskBalFindAccountByAddressDataSection : String :=
   ".section .data\n" ++
   ".balign 8\n" ++
   "bfa_cnt:\n  .zero 8\n" ++
+  "bfa_index:\n  .zero 8\n" ++
   "bfa_aoff:\n  .zero 8\n" ++
   "bfa_alen:\n  .zero 8\n" ++
   "bfa_doff:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -449,6 +449,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   "teer_auth_off:\n  .zero 8\n" ++
   "teer_auth_len:\n  .zero 8\n" ++
   "teer_auth_count:\n  .zero 8\n" ++
+  "teer_records_ptr:\n  .zero 8\n" ++
   "teer_tuple_off:\n  .zero 8\n" ++
   "teer_tuple_len:\n  .zero 8\n" ++
   "teer_target_off:\n  .zero 8\n" ++
@@ -990,6 +991,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   -- bal_find_account_by_address private scratch:
   ".balign 8\n" ++
   "bfa_cnt:\n  .zero 8\n" ++
+  "bfa_index:\n  .zero 8\n" ++
   "bfa_aoff:\n  .zero 8\n" ++
   "bfa_alen:\n  .zero 8\n" ++
   "bfa_doff:\n  .zero 8\n" ++
@@ -1273,12 +1275,16 @@ def ziskStatelessVerdictV2DataSection : String :=
   "tgbpvr_expected:\n  .zero 32\n" ++
   "tgbpvr_zero:\n  .zero 32\n" ++
   "tgbpvr_blobdebit:\n  .zero 32\n" ++
+  "tgbpvr_authdebit:\n  .zero 32\n" ++
   ".balign 8\n" ++
   "tgbpvr_to:\n  .zero 24\n" ++
   "tgbpvr_iscreation:\n  .zero 8\n" ++
   "tgbpvr_tx_type:\n  .zero 8\n" ++
   "tgbpvr_inner_off:\n  .zero 8\n" ++
   "tgbpvr_blob_count:\n  .zero 8\n" ++
+  "tgbpvr_auth_off:\n  .zero 8\n" ++
+  "tgbpvr_auth_len:\n  .zero 8\n" ++
+  "tgbpvr_auth_count:\n  .zero 8\n" ++
   "tgbpvr_lookup:\n  .zero 168\n" ++
   ".balign 8\n" ++
   "bv_sender_bal_check:\n  .zero 192\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -1100,22 +1100,31 @@ def blockVerdictFunction : String :=
   -- if the delegated runtime later reverts/errors. The all-accounts code/nonstorage paths
   -- cover those effects; the self-contained-recipient unchanged assumption does not apply.
   "  la t0, bv_simple_transfer_tx; ld t1, 160(t0); li t2, 4; bne t1, t2, .Lbv_recipient_nc_check\n" ++
-  "  la t0, bmvmx_sender_addr; la t1, bv_simple_transfer_tx; addi t1, t1, 72; li t2, 20\n" ++
+  "  la a0, bv_public_keys_ptr; ld a0, 0(a0); addi a0, a0, 1; la a1, bv_stx_sender_addr; jal ra, address_from_pubkey\n" ++
+  "  la t0, bv_stx_sender_addr; la t1, bv_simple_transfer_tx; addi t1, t1, 72; li t2, 20\n" ++
   ".Lbv_recipient_sender_cmp:\n" ++
   "  beqz t2, .Lbv_recipient_nc_done\n" ++
   "  lbu t3, 0(t0); lbu t4, 0(t1); bne t3, t4, .Lbv_recipient_nc_check\n" ++
   "  addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1; j .Lbv_recipient_sender_cmp\n" ++
   ".Lbv_recipient_nc_check:\n" ++
-  -- .61.8c-2: once CREATE/CREATE2 is activated in the self-contained gate (.8c-3), a CREATE-executing
-  -- recipient legitimately changes its OWN nonce (the EVM increments the creator's nonce on each
-  -- CREATE) and the created account carries code_changes, so the "code+nonce unchanged" assumption
-  -- above is FALSE for it -- the strict empty-list checks below would FALSE-REJECT a VALID CREATE
-  -- block at .Lbv_bal_recipient_field_fail. Skip the recipient nonce_changes/code_changes checks when
-  -- the recipient bytecode contains CREATE (0xf0) or CREATE2 (0xf5); the created account's nonce/code
-  -- are validated by the all-accounts comparators (bal_all_accounts_code_consistent + i3djw), not the
-  -- recipient-field check. Pushdata-aware scan over bvcd_code, mirroring the .Lbv_sbc_scan value-move
-  -- guard. Conservative (skipping never false-rejects). Inert until .8c-3 (CREATE recipients are
-  -- self-contained-rejected pre-.8c, so this region is unreachable for them today).
+  -- CREATE/CREATE2 and EIP-7702 can legitimately change recipient nonce/code;
+  -- all-accounts comparators cover those effects, so this local recipient-field
+  -- unchanged check must skip those precise surfaces.
+  -- EIP-7702 set-delegation can legitimately update the authorized recipient code;
+  -- sender==recipient also duplicates the sender nonce effect checked below.
+  "  la t0, bv_simple_transfer_tx; ld t1, 160(t0); li t2, 4; bne t1, t2, .Lbv_rnc_sender_guard\n" ++
+  "  la t0, bvcd_acct_ptr; ld a0, 0(t0); la t0, bvcd_acct_len; ld a1, 0(t0); la a2, bacc_finals; jal ra, bal_account_nonstorage_finals\n" ++
+  "  bnez a0, .Lbv_rnc_sender_guard; la t0, bacc_finals; ld t1, 56(t0); beqz t1, .Lbv_rnc_sender_guard\n" ++
+  "  ld t2, 72(t0); li t3, 23; bne t2, t3, .Lbv_rnc_sender_guard; ld t2, 64(t0); la t4, bvcd_acct_ptr; ld t4, 0(t4); add t2, t4, t2\n" ++
+  "  lbu t3, 0(t2); li t4, 0xef; bne t3, t4, .Lbv_rnc_sender_guard; lbu t3, 1(t2); li t4, 0x01; bne t3, t4, .Lbv_rnc_sender_guard\n" ++
+  "  lbu t3, 2(t2); bnez t3, .Lbv_rnc_sender_guard; j .Lbv_recipient_nc_done\n" ++
+  ".Lbv_rnc_sender_guard:\n" ++
+  "  la a0, bv_public_keys_ptr; ld a0, 0(a0); addi a0, a0, 1; la a1, bv_stx_sender_addr; jal ra, address_from_pubkey\n" ++
+  "  la t0, bv_stx_sender_addr; la t1, bv_simple_transfer_tx; addi t1, t1, 72; li t2, 20\n" ++
+  ".Lbv_rnc_sender_cmp:\n" ++
+  "  beqz t2, .Lbv_recipient_code_check; lbu t3, 0(t0); lbu t4, 0(t1); bne t3, t4, .Lbv_rnc_scan_start\n" ++
+  "  addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1; j .Lbv_rnc_sender_cmp\n" ++
+  ".Lbv_rnc_scan_start:\n" ++
   "  la t0, bvcd_code_ptr; ld t0, 0(t0); la t1, bvcd_code_len; ld t1, 0(t1); add t1, t0, t1\n" ++
   ".Lbv_rnc_scan:\n" ++
   "  bgeu t0, t1, .Lbv_rnc_check\n" ++
@@ -1193,8 +1202,7 @@ def blockVerdictFunction : String :=
   -- address in the first 20 bytes.
   "  la t0, i3djw_skip_list\n  la t1, bv_simple_transfer_tx; addi t1, t1, 72\n  li t2, 20\n" ++
   ".Lbv_i3sk0:\n  beqz t2, .Lbv_i3sk0d\n  lbu t3, 0(t1)\n  sb t3, 0(t0)\n  addi t1, t1, 1\n  addi t0, t0, 1\n  addi t2, t2, -1\n  j .Lbv_i3sk0\n.Lbv_i3sk0d:\n" ++
-  "  la t0, i3djw_skip_list; addi t0, t0, 32\n  la t1, bmvmx_sender_addr\n  li t2, 20\n" ++
-  ".Lbv_i3sk1:\n  beqz t2, .Lbv_i3sk1d\n  lbu t3, 0(t1)\n  sb t3, 0(t0)\n  addi t1, t1, 1\n  addi t0, t0, 1\n  addi t2, t2, -1\n  j .Lbv_i3sk1\n.Lbv_i3sk1d:\n" ++
+  "  la a1, i3djw_skip_list; addi a1, a1, 32\n  la a0, bv_public_keys_ptr; ld a0, 0(a0); addi a0, a0, 1\n  jal ra, address_from_pubkey\n" ++
   "  la t0, i3djw_skip_list; addi t0, t0, 64\n  la t1, bmvmx_coinbase_addr\n  li t2, 20\n" ++
   ".Lbv_i3sk2:\n  beqz t2, .Lbv_i3sk2d\n  lbu t3, 0(t1)\n  sb t3, 0(t0)\n  addi t1, t1, 1\n  addi t0, t0, 1\n  addi t2, t2, -1\n  j .Lbv_i3sk2\n.Lbv_i3sk2d:\n" ++
   "  la t0, bv_bal_start; ld a0, 0(t0); la t0, bv_bal_len; ld a1, 0(t0)\n" ++
@@ -1242,26 +1250,9 @@ def blockVerdictFunction : String :=
   "  la t0, evm_env; ld a4, 448(t0)\n" ++
   "  jal ra, bal_storage_reads_in_exec_log\n" ++
   "  bnez a0, .Lbv_bal_reads_fail\n" ++
-  -- bmvmx.1.6.3 (balance slice): execution-derived sender BAL post-balance compare.
-  -- dispatch_tx_runtime_code replayed the (self-contained) recipient with EXACT gas, so the
-  -- sender settlement is sender_post = sender_pre - receipt_inc*eff_gas_price - value, computed
-  -- by tx_gas_bal_post_verify_runtime (sender_debit_from_gas #8583 + the runtime gas result).
-  -- This is exact ONLY when execution cannot move value to the sender, so the REJECT is gated
-  -- conservatively (any failed gate -> skip, never newly false-reject). The .Lbv_sbc_scan guard
-  -- below is the SOLE entry into the sender + post-nonce + recipient-balance checks, so all three
-  -- inherit this value-move protection (see the recipient slice's note at .Lbv_rbc_do):
-  --   * recipient bytecode has no CALL(0xf1) / CALLCODE(0xf2) / DELEGATECALL(0xf4) /
-  --     SELFDESTRUCT(0xff) opcode -- the ways execution can move value to/from the sender
-  --     (DELEGATECALL runs delegated code in the recipient's context, which may SELFDESTRUCT to
-  --     the sender; STATICCALL is safe -- static mode forbids value/SELFDESTRUCT). Pushdata-aware
-  --     scan over bvcd_code. SSTORE is NO LONGER bailed: the per-tx EIP-3529 refund is now real
-  --     (evm_refund_acc surfaced into bv_runtime_refund_counter, #8590 merged), so receipt_inc is
-  --     exact for SSTORE-writing recipients too -- the bulk of EEST contract recipients, a large
-  --     coverage gain.
-  --   * the block has no withdrawals (else the sender may be credited),
-  --   * the sender is not the block coinbase (else it also receives the priority fee).
-  -- Only a clean value mismatch (kernel status 40) rejects; every other status (lookup miss,
-  -- post absent, egp/value parse fail, underflow) is treated as "cannot compare" -> skip.
+  -- Execution-derived sender BAL compare. This exact check is entered only after
+  -- value-move gates (no CALL/CALLCODE/DELEGATECALL/SELFDESTRUCT, no withdrawals,
+  -- non-coinbase sender). Status 40 is a clean mismatch; other statuses skip.
   "  la t0, svf_wds_count; ld t0, 0(t0); bnez t0, .Lbv_after_tx_gas_precharge\n" ++
   "  la t0, bvcd_code_ptr; ld t0, 0(t0); la t1, bvcd_code_len; ld t1, 0(t1); add t1, t0, t1\n" ++
   ".Lbv_sbc_scan:\n" ++
@@ -1277,6 +1268,7 @@ def blockVerdictFunction : String :=
   "  li t3, 0xff; beq t2, t3, .Lbv_after_tx_gas_precharge\n" ++   -- SELFDESTRUCT -> value move
   "  addi t0, t0, 1; j .Lbv_sbc_scan\n" ++
   ".Lbv_sbc_safe:\n" ++
+  "  la t0, bvgr_arena_tx_count; ld t0, 0(t0); beqz t0, .Lbv_after_tx_gas_precharge\n" ++
   "  la t0, tgbpvr_in\n" ++
   "  la t1, bv_simple_transfer_tx; ld t2, 40(t1); sd t2, 0(t0)\n" ++       -- gas_limit
   "  la t1, bv_runtime_gas_left; ld t2, 0(t1); sd t2, 8(t0)\n" ++           -- gas_left
@@ -1422,6 +1414,7 @@ def blockVerdictFunction : String :=
   "  la t2, bv_tx_list_ptr; ld a0, 0(t2)\n  la t2, bv_tx_list_len; ld a1, 0(t2)\n" ++
   "  la t2, bvgr_arena_tx_count; ld a2, 0(t2)\n" ++
   "  la a3, bvgr_tx_state_gas\n" ++
+  "  la t2, teer_records_ptr; la t3, basr_records; sd t3, 0(t2)\n" ++
   "  la t2, bv_bal_start; ld a4, 0(t2)\n  la t2, bv_bal_len; ld a5, 0(t2)\n  la t2, bv_chain_id; ld a6, 0(t2)\n" ++
   "  jal ra, block_verdict_tx_state_gas_array\n" ++
   "  beqz a0, .Lbv_pregate_state_gas_ready\n" ++
@@ -1458,6 +1451,7 @@ def blockVerdictFunction : String :=
   "  la t2, bv_tx_list_ptr; ld a0, 0(t2)\n  la t2, bv_tx_list_len; ld a1, 0(t2)\n" ++
   "  la t2, bvgr_arena_tx_count; ld a2, 0(t2)\n" ++
   "  la a3, bvgr_tx_state_gas\n" ++
+  "  la t2, teer_records_ptr; la t3, basr_records; sd t3, 0(t2)\n" ++
   "  la t2, bv_bal_start; ld a4, 0(t2)\n  la t2, bv_bal_len; ld a5, 0(t2)\n  la t2, bv_chain_id; ld a6, 0(t2)\n" ++
   "  jal ra, block_verdict_tx_state_gas_array\n" ++
   -- .57.11.6.5.2: block_verdict_tx_state_gas_array can bail (a0 != 0) even after a successful

--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -43,8 +43,8 @@ def blockVerdictReceiptsTail : String :=
   "  la t2, bv_tx_list_len; ld a1, 0(t2)\n" ++
   "  la t2, bvgr_arena_tx_count; ld a2, 0(t2)\n" ++
   "  la a3, bvgr_receipt_gas_increments\n" ++
-  "  la a4, bvgr_tx_state_gas\n" ++
-  "  la a5, bvgr_tx_exec_state_gas\n" ++
+  "  la a4, bvgr_tx_total_state_gas\n" ++
+  "  la a5, bvgr_block_gas_increments\n" ++
   "  jal ra, block_verdict_receipt_gas_eip8037_adjust\n" ++
   "  la t2, bv_exec_p; ld a0, 0(t2)\n" ++
   "  la a1, bvgr_receipt_gas_increments\n" ++

--- a/EvmAsm/Codegen/Programs/TxGasBalPostVerifyRuntime.lean
+++ b/EvmAsm/Codegen/Programs/TxGasBalPostVerifyRuntime.lean
@@ -174,6 +174,31 @@ def txGasBalPostVerifyRuntimeFunction : String :=
   "  la t0, tgbpvr_in; ld a0, 0(t0); ld a1, 8(t0); ld a2, 16(t0); ld a3, 24(t0)\n" ++
   "  la a4, tgbpvr_egp; la a5, tgbpvr_zero; la a6, tgbpvr_gasdebit\n" ++
   "  jal ra, sender_debit_from_gas\n" ++
+  "  # Type-4 sender settlement includes both the regular auth charge and the AUTH_BASE\n" ++
+  "  # Amsterdam state-gas component for each authorization. The runtime gas result does not\n" ++
+  "  # include this authorization-list settlement term, so add (7500 + 23*1530) per auth.\n" ++
+  "  mv a0, s0; mv a1, s1; la a2, tgbpvr_tx_type; la a3, tgbpvr_inner_off\n" ++
+  "  jal ra, tx_type_dispatch\n" ++
+  "  bnez a0, .Ltgbpvr_after_auth_fee\n" ++
+  "  la t0, tgbpvr_tx_type; ld t1, 0(t0); li t2, 4; bne t1, t2, .Ltgbpvr_after_auth_fee\n" ++
+  "  la t0, tgbpvr_inner_off; ld t3, 0(t0); bltu s1, t3, .Ltgbpvr_after_auth_fee\n" ++
+  "  add a0, s0, t3; sub a1, s1, t3; li a2, 9; la a3, tgbpvr_auth_off; la a4, tgbpvr_auth_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Ltgbpvr_after_auth_fee\n" ++
+  "  la t0, tgbpvr_inner_off; ld t1, 0(t0); add t1, s0, t1\n" ++
+  "  la t0, tgbpvr_auth_off; ld t2, 0(t0); add a0, t1, t2\n" ++
+  "  la t0, tgbpvr_auth_len; ld a1, 0(t0); la a2, tgbpvr_auth_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Ltgbpvr_after_auth_fee\n" ++
+  "  la t0, tgbpvr_auth_count; ld a1, 0(t0); beqz a1, .Ltgbpvr_after_auth_fee\n" ++
+  "  li t0, 42690; mul a1, a1, t0\n" ++
+  "  la a0, tgbpvr_egp; la a2, tgbpvr_authdebit\n" ++
+  "  jal ra, u256_mul_u64_be\n" ++
+  "  bnez a0, .Ltgbpvr_auth_inconclusive\n" ++
+  "  la a0, tgbpvr_gasdebit; la a1, tgbpvr_authdebit; la a2, tgbpvr_gasdebit\n" ++
+  "  jal ra, u256_add_be\n" ++
+  "  bnez a0, .Ltgbpvr_auth_inconclusive\n" ++
+  ".Ltgbpvr_after_auth_fee:\n" ++
   "  mv a0, s0; mv a1, s1; la a2, tgbpvr_tx_type; la a3, tgbpvr_inner_off\n" ++
   "  jal ra, tx_type_dispatch\n" ++
   "  bnez a0, .Ltgbpvr_blob_inconclusive\n" ++
@@ -196,6 +221,8 @@ def txGasBalPostVerifyRuntimeFunction : String :=
   "  jal ra, u256_add_be\n" ++
   "  bnez a0, .Ltgbpvr_blob_overflow\n" ++
   "  j .Ltgbpvr_blob_done\n" ++
+  ".Ltgbpvr_auth_inconclusive:\n" ++
+  "  li t0, 39; sd t0, 0(s7); j .Ltgbpvr_ret\n" ++
   ".Ltgbpvr_blob_inconclusive:\n" ++
   "  li t0, 39; sd t0, 0(s7); j .Ltgbpvr_ret\n" ++
   ".Ltgbpvr_blob_overflow:\n" ++
@@ -375,12 +402,16 @@ def ziskTxGasBalPostVerifyRuntimeDataSection : String :=
   "tgbpvr_expected:\n  .zero 32\n" ++
   "tgbpvr_zero:\n  .zero 32\n" ++
   "tgbpvr_blobdebit:\n  .zero 32\n" ++
+  "tgbpvr_authdebit:\n  .zero 32\n" ++
   ".balign 8\n" ++
   "tgbpvr_to:\n  .zero 24\n" ++
   "tgbpvr_iscreation:\n  .zero 8\n" ++
   "tgbpvr_tx_type:\n  .zero 8\n" ++
   "tgbpvr_inner_off:\n  .zero 8\n" ++
   "tgbpvr_blob_count:\n  .zero 8\n" ++
+  "tgbpvr_auth_off:\n  .zero 8\n" ++
+  "tgbpvr_auth_len:\n  .zero 8\n" ++
+  "tgbpvr_auth_count:\n  .zero 8\n" ++
   "tcbg_struct:\n  .zero 248\n" ++
   ".balign 32\n" ++
   "tcbg_blob_fee_be:\n  .zero 32\n" ++

--- a/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
+++ b/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
@@ -246,17 +246,18 @@ def txEip7702ExistingAuthorityRefundFunction : String :=
   "  lbu t3, 0(t2); lbu t6, 0(t4); bne t3, t6, .Lteer_next\n" ++
   "  addi t2, t2, 1; addi t4, t4, 1; addi t5, t5, -1; j .Lteer_marker_cmp\n" ++
   ".Lteer_marker_match:\n" ++
-  "  # A processed authorization with nonzero auth.nonce proves the authority account\n" ++
-  "  # existed before set_delegation; BAL must show the matching nonce increment.\n" ++
-  "  la t0, teer_auth_nonce; ld t1, 0(t0); beqz t1, .Lteer_existing_code_check\n" ++
-  "  la t0, teer_finals; ld t2, 40(t0); beqz t2, .Lteer_existing_code_check\n" ++
-  "  ld t2, 48(t0); addi t3, t1, 1; bne t2, t3, .Lteer_existing_code_check\n" ++
+  "  # execution-specs set_delegation refunds the NEW_ACCOUNT state component when\n" ++
+  "  # the recovered authority account already exists in pre-state. When block_verdict\n" ++
+  "  # provides teer_records_ptr, use the matched BAL row index to read that pre-record flag.\n" ++
+  "  la t0, teer_records_ptr; ld t0, 0(t0); beqz t0, .Lteer_existing_code_check\n" ++
+  "  la t1, bfa_index; ld t1, 0(t1); slli t2, t1, 4; slli t3, t1, 3; add t2, t2, t3; add t2, t0, t2\n" ++
+  "  ld t3, 16(t2); bnez t3, .Lteer_existing_code_check\n" ++
   liAmsterdamNewAccountStateGas "t3" ++
   "  add s10, s10, t3\n" ++
   ".Lteer_existing_code_check:\n" ++
   "  # The final delegation marker only proves the authority is non-empty after the block.\n" ++
-  "  # Existing-authority refund applies if that code change is no later than this tx;\n" ++
-  "  # the equal-index case is this tx's own set_delegation refund.\n" ++
+  "  # AUTH_BASE is refunded only when a prior transaction already installed delegation code;\n" ++
+  "  # this tx's own set_delegation write is not pre-existing authority_code.\n" ++
   "  la t0, teer_acct_ptr; ld a0, 0(t0); la t0, teer_acct_len; ld a1, 0(t0)\n" ++
   "  li a2, 5; la a3, c2nsf_off; la a4, c2nsf_len\n" ++
   "  jal ra, rlp_list_nth_item\n" ++
@@ -279,7 +280,7 @@ def txEip7702ExistingAuthorityRefundFunction : String :=
   "  li a2, 0; addi a3, sp, 112\n" ++
   "  jal ra, rlp_field_to_u64\n" ++
   "  bnez a0, .Lteer_next\n" ++
-  "  ld t0, 112(sp); ld t1, 104(sp); bgtu t0, t1, .Lteer_next\n" ++
+  "  ld t0, 112(sp); ld t1, 104(sp); bgeu t0, t1, .Lteer_next\n" ++
   ".Lteer_refund_match:\n" ++
   "  li t3, " ++ toString (amsterdamStateBytesPerAuthBase * amsterdamCostPerStateByte) ++ "\n" ++
   "  add s10, s10, t3; j .Lteer_next\n" ++
@@ -300,11 +301,10 @@ def txEip7702ExistingAuthorityRefundFunction : String :=
 
     Add EIP-8037 state-gas components to per-tx receipt gas increments. The
     runtime arena records regular execution gas; Amsterdam receipts use the
-    transaction's total gas accounting, so type-4 authorizations also need their
-    regular auth-list intrinsic charge and every tx needs intrinsic state gas
-    folded into the receipt increment. Executed state gas is part of the block
-    gas accounting, not the receipt cumulative gas. Decode failures are non-gating:
-    the helper leaves that tx's receipt gas at the runtime value. -/
+    transaction's total gas accounting. Type-4 authorizations need their
+    settlement component, while non-type-4 txs keep the generic intrinsic-state
+    fold. Decode failures are non-gating: the helper leaves that tx's receipt gas
+    at the runtime value. -/
 def blockVerdictReceiptGasEip8037AdjustFunction : String :=
   "block_verdict_receipt_gas_eip8037_adjust:\n" ++
   "  addi sp, sp, -112\n" ++
@@ -317,7 +317,7 @@ def blockVerdictReceiptGasEip8037AdjustFunction : String :=
   "  mv s2, a2                   # tx count\n" ++
   "  mv s3, a3                   # receipt gas increments\n" ++
   "  mv s4, a4                   # intrinsic state gas array\n" ++
-  "  mv s5, a5                   # reserved/ignored: executed state gas is not receipt gas\n" ++
+  "  mv s5, a5                   # block gas increments (skip if receipt already includes state gas)\n" ++
   "  beqz s2, .Lbvrga_done\n" ++
   "  li t0, 4; bltu s1, t0, .Lbvrga_done\n" ++
   "  slli s7, s2, 2             # minimum item offset = tx_count * 4\n" ++
@@ -339,16 +339,10 @@ def blockVerdictReceiptGasEip8037AdjustFunction : String :=
   "  bgtu s9, s1, .Lbvrga_next\n" ++
   "  add s10, s0, s8\n" ++
   "  sub s11, s9, s8\n" ++
-  "  slli t0, s6, 3\n" ++
-  "  add t1, s3, t0; ld t2, 0(t1)\n" ++
-  "  beqz s4, .Lbvrga_after_intr_state\n" ++
-  "  add t3, s4, t0; ld t3, 0(t3); add t2, t2, t3\n" ++
-  ".Lbvrga_after_intr_state:\n" ++
-  "  sd t2, 0(t1)\n" ++
   "  mv a0, s10; mv a1, s11; la a2, bvrga_type; la a3, bvrga_inner_off\n" ++
   "  jal ra, tx_type_dispatch\n" ++
-  "  bnez a0, .Lbvrga_next\n" ++
-  "  la t0, bvrga_type; ld t0, 0(t0); li t1, 4; bne t0, t1, .Lbvrga_next\n" ++
+  "  bnez a0, .Lbvrga_generic_state\n" ++
+  "  la t0, bvrga_type; ld t0, 0(t0); li t1, 4; bne t0, t1, .Lbvrga_generic_state\n" ++
   "  la t0, bvrga_inner_off; ld t0, 0(t0); bgtu t0, s11, .Lbvrga_next\n" ++
   "  add a0, s10, t0; sub a1, s11, t0; li a2, 9; la a3, bvrga_auth_off; la a4, bvrga_auth_len\n" ++
   "  jal ra, rlp_list_nth_item\n" ++
@@ -358,9 +352,32 @@ def blockVerdictReceiptGasEip8037AdjustFunction : String :=
   "  la t0, bvrga_auth_len; ld a1, 0(t0); la a2, bvrga_auth_count\n" ++
   "  jal ra, rlp_list_count_items\n" ++
   "  bnez a0, .Lbvrga_next\n" ++
-  "  la t0, bvrga_auth_count; ld t0, 0(t0); li t1, 7500; mul t0, t0, t1\n" ++
-  "  slli t1, s6, 3; add t2, s3, t1; ld t3, 0(t2); add t3, t3, t0; sd t3, 0(t2)\n" ++
+  "  la t0, bvrga_auth_count; ld t0, 0(t0); li t1, 42690; mul t4, t0, t1; li t1, 7500; mul t6, t0, t1\n" ++
+  "  slli t1, s6, 3; add t2, s3, t1; ld t3, 0(t2)\n" ++
+  "  beqz s5, .Lbvrga_type4_check_state\n" ++
+  "  add t5, s5, t1; ld t5, 0(t5); bgtu t3, t5, .Lbvrga_type4_maybe_auth_regular\n" ++
+  "  j .Lbvrga_type4_check_state\n" ++
+  ".Lbvrga_type4_maybe_auth_regular:\n" ++
+  "  beqz s4, .Lbvrga_next\n" ++
+  "  add t5, s4, t1; ld t5, 0(t5); li t0, 35190; la t1, bvrga_auth_count; ld t1, 0(t1); mul t0, t0, t1\n" ++
+  "  bleu t5, t0, .Lbvrga_next\n" ++
+  "  add t3, t3, t6; sd t3, 0(t2); j .Lbvrga_next\n" ++
+  ".Lbvrga_type4_check_state:\n" ++
+  "  beqz s4, .Lbvrga_type4_add_auth\n" ++
+  "  add t5, s4, t1; ld t5, 0(t5); bgeu t3, t5, .Lbvrga_type4_add_state\n" ++
+  ".Lbvrga_type4_add_auth:\n" ++
+  "  add t3, t3, t4; sd t3, 0(t2); j .Lbvrga_next\n" ++
+  ".Lbvrga_type4_add_state:\n" ++
+  "  add t3, t3, t5; sd t3, 0(t2)\n" ++
   "  j .Lbvrga_next\n" ++
+  ".Lbvrga_generic_state:\n" ++
+  "  slli t0, s6, 3\n" ++
+  "  add t1, s3, t0; ld t2, 0(t1)\n" ++
+  "  beqz s4, .Lbvrga_store_next\n" ++
+  "  add t3, s4, t0; ld t3, 0(t3); bgeu t2, t3, .Lbvrga_store_next\n" ++
+  "  add t2, t2, t3\n" ++
+  ".Lbvrga_store_next:\n" ++
+  "  sd t2, 0(t1)\n" ++
   ".Lbvrga_next:\n" ++
   "  addi s6, s6, 1; j .Lbvrga_loop\n" ++
   ".Lbvrga_done:\n" ++
@@ -531,6 +548,7 @@ def ziskBlockVerdictTxStateGasArrayDataSection : String :=
   "teer_auth_off:\n  .zero 8\n" ++
   "teer_auth_len:\n  .zero 8\n" ++
   "teer_auth_count:\n  .zero 8\n" ++
+  "teer_records_ptr:\n  .zero 8\n" ++
   "teer_tuple_off:\n  .zero 8\n" ++
   "teer_tuple_len:\n  .zero 8\n" ++
   "teer_target_off:\n  .zero 8\n" ++
@@ -554,6 +572,7 @@ def ziskBlockVerdictTxStateGasArrayDataSection : String :=
   "rfu_offset:\n  .zero 8\n" ++
   "rfu_length:\n  .zero 8\n" ++
   "bfa_cnt:\n  .zero 8\n" ++
+  "bfa_index:\n  .zero 8\n" ++
   "bfa_aoff:\n  .zero 8\n" ++
   "bfa_alen:\n  .zero 8\n" ++
   "bfa_doff:\n  .zero 8\n" ++


### PR DESCRIPTION
## Summary
- repair EIP-7702 set-code state/refund/receipt gas parity with execution-specs
- use BAL pre-account records for existing-authority NEW_ACCOUNT refunds
- require AUTH_BASE refunds to come from delegation code installed by a prior transaction, not the current set_delegation write

## Validation
- rtk lake build EvmAsm.Codegen.Programs.TxIntrinsicStateGas EvmAsm.Codegen.Programs.BlockVerdict
- rtk scripts/codegen-eest-stateless-check.sh --skip 22108 --limit 1 --max-failures 1 --steps 1000000000 --run-dir gen-out/eest-9j5jl-authbase-prior
- rtk scripts/codegen-eest-stateless-check.sh --skip 22288 --limit 1 --max-failures 1 --steps 1000000000 --run-dir gen-out/eest-b9x5u-authbase-prior
- rtk scripts/check-file-size.sh
- rtk scripts/check-unimported.sh
- git diff --check
- rtk lake build
- rtk scripts/check-no-warnings.sh

Bead: evm-asm-9j5jl
Related: evm-asm-b9x5u

Authored by @pirapira; implemented by Codex.