### PR TITLE
fix(eip8037): handle top-level create collisions

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictCreateCollision.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictCreateCollision.lean
@@ -1,0 +1,48 @@
+/-
+  EvmAsm.Codegen.Programs.BlockVerdictCreateCollision
+
+  Top-level CREATE collision handling for block_verdict.
+-/
+
+import EvmAsm.Codegen.Programs.BlockVerdictParams
+import EvmAsm.Codegen.Programs.BlockVerdictReceiptGate
+
+namespace EvmAsm.Codegen
+
+/-- Single-transaction top-level CREATE collision branch.
+
+    Execution-specs Amsterdam returns a transaction error output for a top-level
+    contract-creation address collision: regular gas is fully consumed,
+    state_gas_used/state_refund remain zero, and no initcode executes. The
+    branch derives CREATE(sender, tx.nonce), checks the pre-state EIP-684
+    code-or-nonce predicate, and materializes the corresponding gas-result
+    windows before falling through to the shared gas gates. -/
+def blockVerdictCreateCollisionBranch : String :=
+  ".Lbv_creation_dispatch:\n" ++
+  "  la t0, bv_simple_transfer_tx; ld a0, 24(t0); la a1, bmvmx_sender_addr; jal ra, address_from_pubkey\n" ++
+  "  la t0, sttc_nonce; ld a1, 0(t0); la a0, bmvmx_sender_addr; la a2, bv_create_addr; jal ra, address_compute_create\n" ++
+  "  ld a0, 8(s0); ld a1, 16(s0); la a2, bv_create_addr; ld a3, 80(s0); ld a4, 88(s0)\n" ++
+  "  jal ra, has_code_or_nonce_at_header_state_root\n" ++
+  "  bnez a0, .Lbv_creation_runtime_try\n" ++
+  "  la t0, hcon_predicate; ld t0, 0(t0); beqz t0, .Lbv_creation_runtime_try\n" ++
+  "  # Top-level CREATE collision: execution-specs returns an error output with\n" ++
+  "  # gas_left=0 and zero state_gas_used/state_refund, so the intrinsic CREATE\n" ++
+  "  # state reservation must not contribute to block_state_gas_used.\n" ++
+  "  la t4, bv_runtime_gas_left; sd zero, 0(t4)\n" ++
+  "  la t4, bv_runtime_refund_counter; sd zero, 0(t4)\n" ++
+  "  la t4, bv_runtime_calldata_floor; sd zero, 0(t4)\n" ++
+  "  la t4, bv_tx_status_arr; sd zero, 0(t4)\n" ++
+  "  la t4, bv_tx_is_creation_arr; li t5, 1; sd t5, 0(t4)\n" ++
+  "  li a0, 0; jal ra, dispatcher_capture_exec_state_gas\n" ++
+  "  la t4, bvgr_runtime_gas_left_ptr; la t5, bv_runtime_gas_left; sd t5, 0(t4)\n" ++
+  "  la t4, bvgr_runtime_refund_counter_ptr; la t5, bv_runtime_refund_counter; sd t5, 0(t4)\n" ++
+  "  la t4, bvgr_runtime_calldata_floor_ptr; la t5, bv_runtime_calldata_floor; sd t5, 0(t4)\n" ++
+  "  li t5, 1; la t4, bvgr_runtime_count; sd t5, 0(t4)\n" ++
+  bvReceiptsShapeSet 6 false ++
+  "  j .Lbv_after_tx_gas_precharge\n" ++
+  ".Lbv_creation_runtime_try:\n" ++
+  "  la a0, bv_simple_transfer_tx; la t0, bv_exec_p; ld a1, 0(t0); jal ra, block_verdict_single_tx_creation_runtime\n" ++
+  "  beqz a0, .Lbv_after_tx_gas_precharge\n.Lbv_creation_unsupported:\n"
+
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -638,6 +638,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bv_cf_code_len:\n  .zero 8\n" ++
   ".balign 32\n" ++
   "bv_tx_recipient_code_hash:\n  .zero 32\n" ++
+  "bv_create_addr:\n  .zero 32\n" ++
   "bbcv_sender_addr:\n  .zero 32\n" ++
   "bbcv_create_addr:\n  .zero 32\n" ++
   "bbcv_create2_salt:\n  .zero 32\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictExactGas.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictExactGas.lean
@@ -26,14 +26,16 @@ def blockVerdictExactGasCheck : String :=
   -- Normalize the regular-gas increments for the exact final header check.
   -- Some runtime paths already report regular-only block increments, while
   -- state-executing contract paths report settlement increments that include the
-  -- EIP-8037 state dimension. Subtract state only when the increment is large
-  -- enough to contain it; otherwise keep the regular-only value.
+  -- EIP-8037 state reservation consumed by the gas-result helper. Subtract that
+  -- intrinsic reservation, not the final net block-state gas: top-level CREATE
+  -- collisions refund the state dimension to zero, but the settlement increment
+  -- can still carry the reserved 183600 before normalization.
   "  la t0, bvgr_arena_tx_count; ld t0, 0(t0); li t1, 0\n" ++
   ".Lbv_regular_eip8037_loop:\n" ++
   "  beq t1, t0, .Lbv_regular_eip8037_done\n" ++
   "  slli t5, t1, 3\n" ++
   "  la t6, bvgr_block_gas_increments; add t6, t6, t5; ld a0, 0(t6)\n" ++
-  "  la t6, bvgr_tx_total_state_gas; add t6, t6, t5; ld a1, 0(t6)\n" ++
+  "  la t6, bvgr_tx_state_gas; add t6, t6, t5; ld a1, 0(t6)\n" ++
   "  bltu a0, a1, .Lbv_regular_eip8037_floor\n" ++
   "  sub a0, a0, a1\n" ++
   ".Lbv_regular_eip8037_floor:\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -16,6 +16,7 @@ import EvmAsm.Codegen.Programs.CommittedStorageSnapshot
 import EvmAsm.Codegen.Programs.BlockVerdictExactGas
 import EvmAsm.Codegen.Programs.BlockVerdictMtxCoinbase
 import EvmAsm.Codegen.Programs.BlockVerdictEip7702SenderAuth
+import EvmAsm.Codegen.Programs.BlockVerdictCreateCollision
 namespace EvmAsm.Codegen
 
 open EvmAsm.Rv64
@@ -1401,7 +1402,7 @@ def blockVerdictFunction : String :=
   "  beqz t2, .Lbv_after_tx_gas_precharge\n" ++                  -- sender == coinbase -> skip
   "  lbu t3, 0(t0); lbu t4, 0(t1); bne t3, t4, .Lbv_sender_bal_fail\n" ++
   "  addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1; j .Lbv_sbc_cb_cmp\n" ++
-  ".Lbv_creation_dispatch:\n  la a0, bv_simple_transfer_tx; la t0, bv_exec_p; ld a1, 0(t0); jal ra, block_verdict_single_tx_creation_runtime\n  beqz a0, .Lbv_after_tx_gas_precharge\n.Lbv_creation_unsupported:\n" ++
+  blockVerdictCreateCollisionBranch ++
   bvReceiptsShapeSet 60 false ++  "  j .Lbv_after_tx_gas_precharge\n" ++
   ".Lbv_contract_dispatch_unsupported:\n" ++
   "  la t0, eip7708_tl_typed_avail; sd zero, 0(t0)\n" ++


### PR DESCRIPTION
## Summary
- model Amsterdam top-level CREATE address collisions before running creation initcode
- materialize the execution-specs error output with failed tx status, zero net state gas, and gas_left=0
- normalize exact regular gas by subtracting the intrinsic state reservation while keeping block_state_gas_used based on net state gas
- extract the CREATE-collision branch into BlockVerdictCreateCollision.lean to keep BlockVerdictFunction.lean under the file-size cap

## Validation
- rtk lake build EvmAsm.Codegen.Programs.BlockVerdict EvmAsm.Codegen.Programs.BlockVerdictV2
- rtk scripts/codegen-eest-stateless-check.sh --skip 2549 --limit 1 --max-failures 1 --steps 1000000000 --run-dir gen-out/eest-wgimk-create-collision-split
- rtk scripts/check-file-size.sh
- rtk scripts/check-unimported.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/BlockVerdictFunction.lean EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean EvmAsm/Codegen/Programs/BlockVerdictExactGas.lean EvmAsm/Codegen/Programs/BlockVerdict.lean EvmAsm/Codegen/Programs/BlockVerdictV2.lean EvmAsm/Codegen/Programs/BlockVerdictCreateCollision.lean
- git diff --check
- rtk lake build
- rtk scripts/check-no-warnings.sh

Bead: evm-asm-wgimk

Authored by @pirapira; implemented by Codex.