### PR TITLE
fix(eip7702): encode receipt log address canonically

### DIFF
--- a/EvmAsm/Codegen/Programs/EvmLogHandlers.lean
+++ b/EvmAsm/Codegen/Programs/EvmLogHandlers.lean
@@ -39,10 +39,11 @@ def logTopicCopies (topicCount : Nat) : String :=
       +192..224 ADDRESS context word
       +224..256 CALLER context word
 
-    The descriptor uses the dispatcher's current stack-word byte order
-    (low limb first). A full receipt encoder can canonicalize to the
-    Ethereum byte order later. Overflow writes halt_kind = 4 and exits
-    via `.exit_no_epilogue` instead of silently dropping the event. -/
+    Topic slots use the dispatcher's stack-word byte order (low limb first).
+    The address context is copied from env.ADDRESS as the canonical low-aligned
+    20-byte account address used by top-level runtime staging. Overflow writes
+    halt_kind = 4 and exits via `.exit_no_epilogue` instead of silently dropping
+    the event. -/
 def logCapturePreBody (topicCount : Nat) : String :=
   "  ld x15, 472(x20)\n" ++          -- x15 = event log length
   "  li x16, 1024\n" ++              -- static cap: 1024 descriptors (6c7v9: raised from 16)

--- a/EvmAsm/Codegen/Programs/LogRecordsRlp.lean
+++ b/EvmAsm/Codegen/Programs/LogRecordsRlp.lean
@@ -10,11 +10,10 @@
   input (`receipt_encode` field 3 / `logs_desc_ptr@8`): the per-tx bloom can
   then be derived from the same encoding via `logs_list_bloom_add`.
 
-  Descriptor layout (EvmLogHandlers, native stack-word order — 32-byte words
-  as four LITTLE-ENDIAN u64 limbs):
+  Descriptor layout (EvmLogHandlers):
     +0    topic_count (u64, 0..4)
-    +32   four 32-byte topic slots (LE)
-    +192  executing ADDRESS context word (LE; low 160 bits = the address)
+    +32   four 32-byte topic slots (stack-word / LE order)
+    +192  executing ADDRESS context bytes (canonical 20-byte BE, low-aligned)
   Full data: evm_log_data_meta[i] = {byte offset (u64), data length (u64)}
   into evm_log_data.
 
@@ -71,19 +70,19 @@ def logRecordsEncodeRlpFunction : String :=
   ".Llrr_log_loop:\n" ++
   "  beqz s1, .Llrr_finish\n" ++
   -- ---- per-log inner payload: address item then topics list then data ----
-  -- address: BE bytes = LE word bytes 19..0 of the ADDRESS context word.
+  -- address: descriptor bytes +192..+211 are already canonical BE for the
+  -- top-level runtime payload path; topics below remain stack words and are reversed.
   "  la t0, lrr_addr_be\n" ++
-  "  addi t1, s0, 192\n" ++       -- LE address word
+  "  addi t1, s0, 192\n" ++       -- canonical address bytes
   "  li t2, 0\n" ++
-  ".Llrr_addr_rev:\n" ++
+  ".Llrr_addr_copy:\n" ++
   "  li t3, 20; beq t2, t3, .Llrr_addr_done\n" ++
-  "  li t3, 19; sub t3, t3, t2\n" ++
-  "  add t3, t1, t3\n" ++
+  "  add t3, t1, t2\n" ++
   "  lbu t4, 0(t3)\n" ++
   "  add t3, t0, t2\n" ++
   "  sb t4, 0(t3)\n" ++
   "  addi t2, t2, 1\n" ++
-  "  j .Llrr_addr_rev\n" ++
+  "  j .Llrr_addr_copy\n" ++
   ".Llrr_addr_done:\n" ++
   "  la a0, lrr_addr_be; li a1, 20; la a2, lrr_inner; la a3, lrr_len\n" ++
   "  jal ra, rlp_encode_bytes\n" ++


### PR DESCRIPTION
## Summary
- encode captured receipt-log addresses directly as canonical env.ADDRESS bytes
- keep topic encoding unchanged: stack-word topics are still reversed to canonical order
- fixes EIP-7702 set-code LOG receipt-root false rejects where gas and state roots already matched

Refs beads: evm-asm-i8tqa, evm-asm-8s3zm.

## Validation
- rtk lake build EvmAsm.Codegen.Programs.EvmLogHandlers EvmAsm.Codegen.Programs.LogRecordsRlp EvmAsm.Codegen.Programs.BlockVerdict EvmAsm.Codegen.Programs.BlockVerdictV2
- rtk scripts/codegen-eest-stateless-check.sh --skip 22180 --limit 1 --max-failures 1 --steps 1000000000 --run-dir gen-out/eest-i8tqa-log0-addr
- rtk scripts/codegen-eest-stateless-check.sh --skip 22184 --limit 1 --max-failures 1 --steps 1000000000 --run-dir gen-out/eest-i8tqa-log4-addr
- rtk scripts/codegen-eest-stateless-check.sh --skip 22180 --limit 5 --max-failures 1 --steps 1000000000 --run-dir gen-out/eest-i8tqa-log0-4-addr
- rtk scripts/check-file-size.sh
- rtk scripts/check-unimported.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/EvmLogHandlers.lean EvmAsm/Codegen/Programs/LogRecordsRlp.lean
- git diff --check
- rtk lake build
- rtk scripts/check-no-warnings.sh

Directed by @pirapira; implemented by Codex.