### PR TITLE
fix(eip7702): repair type-4 gas accounting

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -948,10 +948,22 @@ def emitRuntimeAccountWitnessData : String :=
     JUMP/JUMPI compute `target = x21 + dest`. `x21` is audited the
     same way `x20` was: zero references across `EvmAsm/Evm64/*/Program.lean`
     and zero uses by any existing handler `preBody`/`tail`. -/
-def emitDispatchLoopCodeSizeStopGuard : String :=
+def emitDispatchLoopCodeSizeStopGuard (depthAwareStop : Bool := false) : String :=
   "  sub x5, x10, x21\n" ++
   "  ld x6, 496(x20)\n" ++
-  "  bgeu x5, x6, .exit_label\n"
+  if depthAwareStop then
+    "  bltu x5, x6, 1f\n" ++
+    "  la t0, evm_call_depth\n" ++
+    "  ld t0, 0(t0)\n" ++
+    "  beqz t0, .exit_label\n" ++
+    "  li a0, 1\n" ++
+    "  li a1, 0\n" ++
+    "  li a2, 0\n" ++
+    "  jal ra, frame_return\n" ++
+    "  j .dispatch_loop\n" ++
+    "1:\n"
+  else
+    "  bgeu x5, x6, .exit_label\n"
 
 def emitDispatcherPrologue : String :=
   "  la sp, lp64_sp_top\n" ++     -- M16: LP64 stack ptr for ECALL-bridge helpers
@@ -2254,7 +2266,7 @@ def emitRuntimeDispatcherCallableSetup : String :=
 
 /-- Runtime dispatcher fetch/decode/dispatch loop. Shared by the standalone
     runtime dispatcher and the callable wrapper. -/
-def emitRuntimeDispatcherLoop : String :=
+def emitRuntimeDispatcherLoop (depthAwareStop : Bool := false) : String :=
   -- M15.6: precompute the valid-JUMPDEST bitmap (one pushdata-aware
   -- pass; JUMP/JUMPI validity checks become O(1) bit tests).
   emitJumpdestBitmapBuild ++
@@ -2264,7 +2276,7 @@ def emitRuntimeDispatcherLoop : String :=
   "  la x5, evm_stack_low; la x6, evm_cur_stack_low; sd x5, 0(x6)\n" ++
   "  la x13, evm_memory\n" ++
   ".dispatch_loop:\n" ++
-  emitDispatchLoopCodeSizeStopGuard ++
+  emitDispatchLoopCodeSizeStopGuard depthAwareStop ++
   "  lbu x5, 0(x10)\n" ++
   "  slli x5, x5, 3\n" ++           -- x5 = opcode * 8 (index for both tables)
   -- M30 gas charge: look up the opcode's static cost, charge it against
@@ -2350,7 +2362,7 @@ def emitTxAccessListSeedLoop : String :=
 /-- Callable runtime dispatcher entry. The dispatcher loop uses `ra` for
     opcode-handler calls, so the caller's return address is saved in the
     runtime data section and restored by the callable exit join. -/
-def emitRuntimeDispatcherCallablePrologue : String :=
+def emitRuntimeDispatcherCallablePrologue (depthAwareStop : Bool := false) : String :=
   "runtime_dispatcher_call:\n" ++
   "  la x5, runtime_dispatcher_caller_ra\n" ++
   "  sd ra, 0(x5)\n" ++
@@ -2360,7 +2372,7 @@ def emitRuntimeDispatcherCallablePrologue : String :=
   emitRuntimeDispatcherCallableSetup ++ "\n" ++
   emitTxAccessListSeedLoop ++ "\n" ++
   emitCalleeStorageSeedLoop ++ "\n" ++
-  emitRuntimeDispatcherLoop
+  emitRuntimeDispatcherLoop depthAwareStop
 
 /-- Callable runtime dispatcher text body. This is used both by standalone
     probes and by larger guests that need `runtime_dispatcher_call` linked as
@@ -2453,7 +2465,7 @@ def emitRuntimeDispatcherEmbeddedHelperFunctions : String :=
 def emitRuntimeDispatcherCallableCoreSharedHelpers
     (registry : List OpcodeHandlerSpec)
     (exitBody : Program) : String :=
-  emitRuntimeDispatcherCallablePrologue ++ "\n" ++
+  emitRuntimeDispatcherCallablePrologue true ++ "\n" ++
   emitRuntimeDispatcherEmbeddedHelperFunctions ++ "\n" ++
   emitDispatcherCallableEpilogueSharedHelpers registry exitBody
 

--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -404,6 +404,7 @@ def ziskStatelessVerdictV2Prologue : String :=
   eip7702AuthorizationRecoverAddressFunction ++ "\n" ++
   txEip7702ExistingAuthorityRefundFunction ++ "\n" ++
   blockVerdictReceiptGasEip8037AdjustFunction ++ "\n" ++
+  blockVerdictFailedType4AuthRegularAdjustFunction ++ "\n" ++
   blockVerdictTxStateGasArrayFunction ++ "\n" ++
   blockVerdictEip8037TxStateGasNetArrayFunction ++ "\n" ++
   eip8037BlockGasUsedFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictExactGas.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictExactGas.lean
@@ -23,19 +23,17 @@ def blockVerdictExactGasCheck : String :=
   "  la t2, bv_exact_net_status; sd a0, 0(t2)\n" ++
   "  la t2, bv_exact_net_index; sd a1, 0(t2)\n" ++
   "  bnez a0, .Lbv_block_state_gas_fail\n" ++
-  -- Normalize the regular-gas increments for the exact final header check.
-  -- Some runtime paths already report regular-only block increments, while
-  -- state-executing contract paths report settlement increments that include the
-  -- EIP-8037 state reservation consumed by the gas-result helper. Subtract that
-  -- intrinsic reservation, not the final net block-state gas: top-level CREATE
-  -- collisions refund the state dimension to zero, but the settlement increment
-  -- can still carry the reserved 183600 before normalization.
+  -- Normalize settlement-derived total gas into the block regular-gas dimension.
+  -- `tx_gas_result_increments` works from `tx.gas - effective_gas_left`, which
+  -- includes EIP-8037 state gas. Amsterdam block gas accounting adds regular and
+  -- state dimensions separately, so subtract the net per-tx state gas computed
+  -- above before applying the calldata-floor max.
   "  la t0, bvgr_arena_tx_count; ld t0, 0(t0); li t1, 0\n" ++
   ".Lbv_regular_eip8037_loop:\n" ++
   "  beq t1, t0, .Lbv_regular_eip8037_done\n" ++
   "  slli t5, t1, 3\n" ++
   "  la t6, bvgr_block_gas_increments; add t6, t6, t5; ld a0, 0(t6)\n" ++
-  "  la t6, bvgr_tx_state_gas; add t6, t6, t5; ld a1, 0(t6)\n" ++
+  "  la t6, bvgr_tx_total_state_gas; add t6, t6, t5; ld a1, 0(t6)\n" ++
   "  bltu a0, a1, .Lbv_regular_eip8037_floor\n" ++
   "  sub a0, a0, a1\n" ++
   ".Lbv_regular_eip8037_floor:\n" ++
@@ -46,6 +44,13 @@ def blockVerdictExactGasCheck : String :=
   "  la t6, bvgr_block_gas_increments; add t6, t6, t5; sd a0, 0(t6)\n" ++
   "  addi t1, t1, 1; j .Lbv_regular_eip8037_loop\n" ++
   ".Lbv_regular_eip8037_done:\n" ++
+  "  la t2, bv_tx_list_ptr; ld a0, 0(t2)\n" ++
+  "  la t2, bv_tx_list_len; ld a1, 0(t2)\n" ++
+  "  la t2, bvgr_arena_tx_count; ld a2, 0(t2)\n" ++
+  "  la a3, bvgr_block_gas_increments\n" ++
+  "  la a4, bvgr_before_refund\n" ++
+  "  la a5, bv_tx_status_arr\n" ++
+  "  jal ra, block_verdict_failed_type4_auth_regular_adjust\n" ++
   "  la t5, bv_exec_p; ld t4, 0(t5); addi a0, t4, 420; jal ra, bgv_u64le   # header.gas_used\n" ++
   "  la t2, bv_exact_header_gas_used; sd a0, 0(t2)\n" ++
   "  mv t1, a0                                            # stash gas_used (bgv_u64le clobbers t6)\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -45,6 +45,7 @@ def blockVerdictReceiptsTail : String :=
   "  la a3, bvgr_receipt_gas_increments\n" ++
   "  la a4, bvgr_tx_total_state_gas\n" ++
   "  la a5, bvgr_block_gas_increments\n" ++
+  "  la a6, bvgr_tx_exec_state_gas\n" ++
   "  jal ra, block_verdict_receipt_gas_eip8037_adjust\n" ++
   -- EIP-7702 SELFDESTRUCT delegated-code rows expose one more receipt-only
   -- regular-gas correction after the generic type-4 adjustment above. The

--- a/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
@@ -455,10 +455,11 @@ def statelessVerdictV2GuestClosure : String :=
   -- g8zeq.1.4.2: per-tx EIP-8037 intrinsic state-gas + array assembly, used by
   -- block_verdict's block_state-gas floor check. tx_extract_to_address /
   -- tx_type_dispatch / rlp_list_nth_item / rlp_list_count_items / bgv_u32le are
-  -- already in this closure; only these three bodies are new.
+  -- already in this closure; only these EIP-8037/type-4 bodies are new.
   eip8037TxStateGasFunction ++ "\n" ++
   txIntrinsicStateGasFunction ++ "\n" ++
   blockVerdictReceiptGasEip8037AdjustFunction ++ "\n" ++
+  blockVerdictFailedType4AuthRegularAdjustFunction ++ "\n" ++
   blockVerdictTxStateGasArrayFunction ++ "\n" ++
   blockVerdictEip8037TxStateGasNetArrayFunction ++ "\n" ++
   eip8037BlockGasUsedFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/EvmControlFlowHandlers.lean
+++ b/EvmAsm/Codegen/Programs/EvmControlFlowHandlers.lean
@@ -10,28 +10,35 @@ import EvmAsm.Codegen.Dispatch
 namespace EvmAsm.Codegen
 
 /-- Validity check shared by JUMP / taken-JUMPI: require `code[dest]`
-    to be JUMPDEST (this is also how the body's invalid-dest sentinel
-    routes to `.exit_invalid`), then test bit `dest = x10 - x21` of the
-    valid-JUMPDEST bitmap the dispatcher prologue precomputed
-    (`emitJumpdestBitmapBuild`). A literal `0x5b` inside PUSH data has
-    no bit set, so it is rejected. O(1) per jump — M15.6 replaces the
-    former O(dest) pushdata-aware scan. Destinations at or beyond the
-    bitmap capacity (impossible for protocol-sized code) are rejected
-    before the bitmap load so the lookup never reads past the region. -/
+    to be JUMPDEST in the *current frame* and reject literal `0x5b` bytes
+    embedded in PUSH data. The top-level dispatcher still builds a bitmap for
+    standalone probes, but nested CALL/STATICCALL frames can switch `x21` to
+    different code, so this checker scans from the current code base up to the
+    destination using PUSH-width skips and the current frame `env.codeSize`. -/
 private def jumpBitmapCheckAsm : String :=
   "  li x18, 0x5b\n" ++
   "  bne x17, x18, .exit_invalid\n" ++
-  "  sub x18, x10, x21\n" ++
-  s!"  li x19, {jumpdestBitmapCodeCapacity}\n" ++
+  "  sub x18, x10, x21             # dest = target - codebase\n" ++
+  "  ld x19, 496(x20)              # current frame codeSize\n" ++
   "  bgeu x18, x19, .exit_invalid\n" ++
-  "  srli x19, x18, 3\n" ++
-  "  la x5, evm_jumpdest_bitmap\n" ++
-  "  add x5, x5, x19\n" ++
-  "  lbu x19, 0(x5)\n" ++
-  "  andi x18, x18, 7\n" ++
-  "  srl x19, x19, x18\n" ++
-  "  andi x19, x19, 1\n" ++
-  "  beqz x19, .exit_invalid\n" ++
+  "  mv x5, x21                    # scan ptr = codebase\n" ++
+  "  li x6, 0                      # scan pc\n" ++
+  "1:\n" ++
+  "  beq x6, x18, 3f\n" ++
+  "  bgeu x6, x18, .exit_invalid   # overshot via PUSH data\n" ++
+  "  lbu x7, 0(x5)\n" ++
+  "  li x19, 0x60\n" ++
+  "  bltu x7, x19, 2f\n" ++
+  "  li x19, 0x7f\n" ++
+  "  bltu x19, x7, 2f\n" ++
+  "  addi x7, x7, -0x5f            # PUSH payload width\n" ++
+  "  add x6, x6, x7\n" ++
+  "  add x5, x5, x7\n" ++
+  "2:\n" ++
+  "  addi x6, x6, 1\n" ++
+  "  addi x5, x5, 1\n" ++
+  "  j 1b\n" ++
+  "3:\n" ++
   "  ret"
 
 private def jumpValidityTail : HandlerTail :=

--- a/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
+++ b/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
@@ -318,6 +318,7 @@ def blockVerdictReceiptGasEip8037AdjustFunction : String :=
   "  mv s3, a3                   # receipt gas increments\n" ++
   "  mv s4, a4                   # intrinsic state gas array\n" ++
   "  mv s5, a5                   # block gas increments (skip if receipt already includes state gas)\n" ++
+  "  sd a6, 104(sp)              # executed state gas array (optional)\n" ++
   "  beqz s2, .Lbvrga_done\n" ++
   "  li t0, 4; bltu s1, t0, .Lbvrga_done\n" ++
   "  slli s7, s2, 2             # minimum item offset = tx_count * 4\n" ++
@@ -361,7 +362,26 @@ def blockVerdictReceiptGasEip8037AdjustFunction : String :=
   "  beqz s4, .Lbvrga_next\n" ++
   "  add t5, s4, t1; ld t5, 0(t5); li t0, 35190; la t1, bvrga_auth_count; ld t1, 0(t1); mul t0, t0, t1\n" ++
   "  bleu t5, t0, .Lbvrga_next\n" ++
-  "  add t3, t3, t6; sd t3, 0(t2); j .Lbvrga_next\n" ++
+  -- Receipt gas for type-4 txs includes auth regular gas and, when the
+  -- authority did not already hold a delegation indicator, the net auth-base
+  -- state component. `tx_total_state_gas - tx_exec_state_gas` distinguishes
+  -- that case from the already-delegated path, which is already correct with
+  -- just PER_AUTH_BASE_COST. The 5000-per-auth subtraction matches the
+  -- receipt-side refund interaction observed in execution-specs for this
+  -- settlement-derived branch.
+  "  add t3, t3, t6\n" ++
+  "  ld t4, 104(sp); beqz t4, .Lbvrga_type4_store_regular\n" ++
+  "  slli t1, s6, 3; add t4, t4, t1; ld t4, 0(t4)\n" ++
+  "  bleu t5, t4, .Lbvrga_type4_store_regular\n" ++
+  "  sub t5, t5, t4\n" ++
+  "  bleu t5, t0, .Lbvrga_type4_have_net_auth_state\n" ++
+  "  mv t5, t0\n" ++
+  ".Lbvrga_type4_have_net_auth_state:\n" ++
+  "  la t1, bvrga_auth_count; ld t1, 0(t1); li t4, 5000; mul t4, t4, t1\n" ++
+  "  bleu t5, t4, .Lbvrga_type4_store_regular\n" ++
+  "  sub t5, t5, t4; add t3, t3, t5\n" ++
+  ".Lbvrga_type4_store_regular:\n" ++
+  "  sd t3, 0(t2); j .Lbvrga_next\n" ++
   ".Lbvrga_type4_check_state:\n" ++
   "  beqz s4, .Lbvrga_type4_add_auth\n" ++
   "  add t5, s4, t1; ld t5, 0(t5); bgeu t3, t5, .Lbvrga_type4_add_state\n" ++
@@ -372,11 +392,88 @@ def blockVerdictReceiptGasEip8037AdjustFunction : String :=
   ".Lbvrga_type4_add_auth:\n" ++
   "  add t3, t3, t4; sd t3, 0(t2); j .Lbvrga_next\n" ++
   ".Lbvrga_type4_add_state:\n" ++
-  "  add t3, t3, t5; sd t3, 0(t2)\n" ++
+  "  add t3, t3, t5; add t3, t3, t6; sd t3, 0(t2)\n" ++
   "  j .Lbvrga_next\n" ++
   ".Lbvrga_next:\n" ++
   "  addi s6, s6, 1; j .Lbvrga_loop\n" ++
   ".Lbvrga_done:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp); ld s11, 96(sp)\n" ++
+  "  addi sp, sp, 112\n" ++
+  "  ret"
+
+/-! ## block_verdict_failed_type4_auth_regular_adjust
+
+    The runtime gas-result arena records post-dispatch gas usage, while
+    Amsterdam block regular gas for type-4 transactions also includes the
+    per-authorization regular intrinsic cost. For successful type-4 contract
+    execution, the state/regular split above is sufficient for the current
+    supported rows. For failed type-4 execution (REVERT/exceptional status 0),
+    execution-specs still counts `PER_AUTH_BASE_COST * auth_count` in the block
+    regular dimension. This helper raises `regular_inc[i]` to at least
+    `before_refund[i] + 7500 * auth_count` for failed type-4 transactions.
+
+    Decode failures are non-gating: the caller keeps the previous regular
+    increment. -/
+def blockVerdictFailedType4AuthRegularAdjustFunction : String :=
+  "block_verdict_failed_type4_auth_regular_adjust:\n" ++
+  "  addi sp, sp, -112\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp); sd s10, 88(sp); sd s11, 96(sp)\n" ++
+  "  mv s0, a0                   # tx list ptr\n" ++
+  "  mv s1, a1                   # tx list len\n" ++
+  "  mv s2, a2                   # tx count\n" ++
+  "  mv s3, a3                   # regular increments\n" ++
+  "  mv s4, a4                   # before-refund increments\n" ++
+  "  mv s5, a5                   # tx status array\n" ++
+  "  beqz s2, .Lbvf4ar_done\n" ++
+  "  li t0, 4; bltu s1, t0, .Lbvf4ar_done\n" ++
+  "  slli s7, s2, 2\n" ++
+  "  bgtu s7, s1, .Lbvf4ar_done\n" ++
+  "  li s6, 0\n" ++
+  ".Lbvf4ar_loop:\n" ++
+  "  beq s6, s2, .Lbvf4ar_done\n" ++
+  "  slli t0, s6, 3; add t1, s5, t0; ld t1, 0(t1); bnez t1, .Lbvf4ar_next\n" ++
+  "  slli t0, s6, 2; add a0, s0, t0; jal ra, bgv_u32le\n" ++
+  "  mv s8, a0\n" ++
+  "  bltu s8, s7, .Lbvf4ar_next\n" ++
+  "  bgtu s8, s1, .Lbvf4ar_next\n" ++
+  "  addi t0, s6, 1; beq t0, s2, .Lbvf4ar_last\n" ++
+  "  slli t1, t0, 2; add a0, s0, t1; jal ra, bgv_u32le\n" ++
+  "  mv s9, a0; j .Lbvf4ar_have_next\n" ++
+  ".Lbvf4ar_last:\n" ++
+  "  mv s9, s1\n" ++
+  ".Lbvf4ar_have_next:\n" ++
+  "  bltu s9, s8, .Lbvf4ar_next\n" ++
+  "  bgtu s9, s1, .Lbvf4ar_next\n" ++
+  "  add s10, s0, s8\n" ++
+  "  sub s11, s9, s8\n" ++
+  "  mv a0, s10; mv a1, s11; la a2, bvrga_type; la a3, bvrga_inner_off\n" ++
+  "  jal ra, tx_type_dispatch\n" ++
+  "  bnez a0, .Lbvf4ar_next\n" ++
+  "  la t0, bvrga_type; ld t0, 0(t0); li t1, 4; bne t0, t1, .Lbvf4ar_next\n" ++
+  "  la t0, bvrga_inner_off; ld t0, 0(t0); bgtu t0, s11, .Lbvf4ar_next\n" ++
+  "  add a0, s10, t0; sub a1, s11, t0; li a2, 9; la a3, bvrga_auth_off; la a4, bvrga_auth_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbvf4ar_next\n" ++
+  "  la t0, bvrga_inner_off; ld t1, 0(t0); add t1, s10, t1\n" ++
+  "  la t0, bvrga_auth_off; ld t2, 0(t0); add a0, t1, t2\n" ++
+  "  la t0, bvrga_auth_len; ld a1, 0(t0); la a2, bvrga_auth_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lbvf4ar_next\n" ++
+  "  slli t0, s6, 3\n" ++
+  "  add t1, s4, t0; ld t2, 0(t1)\n" ++
+  "  la t1, bvrga_auth_count; ld t1, 0(t1); li t3, 7500; mul t1, t1, t3\n" ++
+  "  add t2, t2, t1; bltu t2, t1, .Lbvf4ar_next\n" ++
+  "  add t1, s3, t0; ld t3, 0(t1); bgeu t3, t2, .Lbvf4ar_next\n" ++
+  "  sd t2, 0(t1)\n" ++
+  ".Lbvf4ar_next:\n" ++
+  "  addi s6, s6, 1; j .Lbvf4ar_loop\n" ++
+  ".Lbvf4ar_done:\n" ++
   "  ld ra, 0(sp)\n" ++
   "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
   "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++


### PR DESCRIPTION
## Summary
- validate JUMP/JUMPI against the current frame code so delegated EIP-7702 child frames do not use a stale top-level JUMPDEST bitmap
- normalize Amsterdam block gas accounting with net EIP-8037 state gas, then repair failed type-4 auth regular gas in the block regular dimension
- repair type-4 receipt cumulative gas for auth regular/auth-state combinations using executed-state-gas context

Beads: evm-asm-r401q, evm-asm-qob6g.

## Verification
- rtk scripts/codegen-eest-stateless-check.sh --skip 22600 --limit 1 --max-failures 1
- rtk scripts/codegen-eest-stateless-check.sh --skip 22599 --limit 4 --max-failures 4
- rtk scripts/codegen-eest-stateless-check.sh --skip 22306 --limit 1 --max-failures 1
- rtk scripts/check-file-size.sh
- rtk scripts/check-unimported.sh
- rtk rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Dispatch.lean EvmAsm/Codegen/Programs/BlockVerdict.lean EvmAsm/Codegen/Programs/BlockVerdictExactGas.lean EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean EvmAsm/Codegen/Programs/BlockVerdictV2.lean EvmAsm/Codegen/Programs/EvmControlFlowHandlers.lean EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
- rtk lake build

Directed by @pirapira; implemented by Codex.