### PR TITLE
fix(eip7708): canonicalize synthetic log emitter

### DIFF
--- a/EvmAsm/Codegen/Programs/EIP7708Logs.lean
+++ b/EvmAsm/Codegen/Programs/EIP7708Logs.lean
@@ -96,11 +96,12 @@ def eip7708SyntheticLogFunctions : String :=
   "  addi t1, t1, 1\n" ++
   "  addi t3, t3, -1\n" ++
   "  bnez t3, .Leip7708_amount_rev\n" ++
-  "  li t0, -2\n" ++
+  -- log_records_encode_rlp consumes descriptor+192 as canonical 20-byte BE.
+  "  li t0, -1\n" ++
   "  sd t0, 192(t2)\n" ++
   "  li t0, -1\n" ++
   "  sd t0, 200(t2)\n" ++
-  "  li t0, 0xffffffff\n" ++
+  "  li t0, 0xfeffffff\n" ++
   "  sd t0, 208(t2)\n" ++
   "  sd x0, 216(t2)\n" ++
   "  sd x0, 224(t2)\n" ++

--- a/scripts/codegen-zisk-eip7708-synthetic-logs-check.sh
+++ b/scripts/codegen-zisk-eip7708-synthetic-logs-check.sh
@@ -63,7 +63,7 @@ def descriptor(topic_count: int, topics: list[bytes], amount_word: bytes) -> byt
     for i, topic in enumerate(topics):
         d[32 + 32 * i : 64 + 32 * i] = topic
     d[160:192] = amount_word[::-1]
-    d[192:224] = bytes.fromhex('fe' + 'ff' * 19) + bytes(12)
+    d[192:224] = bytes.fromhex('ff' * 19 + 'fe') + bytes(12)
     return bytes(d)
 
 sender = word_from_address_byte(0x11)


### PR DESCRIPTION
## Summary
- store the EIP-7708 synthetic log emitter as canonical SYSTEM_ADDRESS bytes in receipt descriptors
- update the focused synthetic-log descriptor probe expectation

## Verification
- rtk scripts/codegen-eest-eip7708-simple-transfer-check.sh --max-failures 1
- rtk scripts/codegen-eest-eip7708-fork-transition-check.sh --max-failures 10
- rtk scripts/codegen-zisk-eip7708-synthetic-logs-check.sh
- rtk scripts/codegen-eest-stateless-check.sh --skip 23156 --limit 1 --max-failures 1
- rtk scripts/check-file-size.sh
- rtk lake build

Directed by @pirapira; implemented by Codex.