### PR TITLE
fix(eip7702): observe same-block delegation code

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -49,6 +49,7 @@ import EvmAsm.Codegen.Programs.EvmAccessGas
 import EvmAsm.Codegen.Programs.SeedTxAccessList
 import EvmAsm.Codegen.Programs.AccountBalance
 import EvmAsm.Codegen.Programs.EIP7708Logs
+import EvmAsm.Codegen.Programs.RuntimeSameBlockCode
 import EvmAsm.Codegen.Programs.CallFrameBase
 import EvmAsm.Codegen.Programs.CallFrameSwitch
 import EvmAsm.Codegen.Programs.CallFrameDescend
@@ -1478,6 +1479,7 @@ def emitDispatcherEpilogueCore
     extcodehashAtHeaderStateRootFunction ++ "\n" ++
     extcodesizeAtHeaderStateRootFunction ++ "\n" ++
     extcodecopyAtHeaderStateRootFunction ++ "\n" ++
+    runtimeSameBlockDelegationCodeFunction ++ "\n" ++
     hasCodeOrNonceAtHeaderStateRootFunction ++ "\n" ++
     addressComputeCreateFunction ++ "\n" ++
     addressComputeCreate2Function ++ "\n" ++
@@ -2385,6 +2387,7 @@ def emitRuntimeDispatcherEmbeddedHelperFunctions : String :=
   accountIsEmptyAtHeaderStateRootFunction ++ "\n" ++
   extcodehashAtHeaderStateRootFunction ++ "\n" ++
   extcodecopyAtHeaderStateRootFunction ++ "\n" ++
+  runtimeSameBlockDelegationCodeFunction ++ "\n" ++
   hasCodeOrNonceAtHeaderStateRootFunction ++ "\n" ++
   createStageInitcodeFrameRuntimeFunction ++ "\n" ++
   createExecuteInitcodeFrameRuntimeFunction ++ "\n" ++
@@ -2668,6 +2671,7 @@ def emitRuntimeDispatcherDataSectionCore
   "  .zero 8\n" ++
   "runtime_tx_access_list_seed_fn:\n" ++
   "  .zero 8\n" ++
+  runtimeSameBlockDelegationCodeData ++
   ".balign 8\n" ++
   "txal_type:\n  .zero 8\n" ++
   "txal_inner_off:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -201,15 +201,19 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  la t0, sv_pre_rlp_ptr; ld t1, 0(t0); la t2, dtrc_hdr_ptr; sd t1, 0(t2)\n" ++
   "  la t0, sv_pre_rlp_len; ld t1, 0(t0); la t2, dtrc_hdr_len; sd t1, 0(t2)\n" ++
   ".Ldtrc_hdr_done:\n" ++
+  "  addi a0, s2, 72; mv a1, s0; mv a2, s1; li a3, 0\n" ++
+  "  jal ra, bal_same_block_delegation_code_resolve\n" ++
+  "  beqz a0, .Ldtrc_same_block_delegation_code\n" ++
   "  la t0, dtrc_hdr_ptr; ld a0, 0(t0); la t0, dtrc_hdr_len; ld a1, 0(t0)\n" ++
   "  addi a2, s2, 72\n" ++
   "  mv a3, s0; mv a4, s1\n" ++
   "  la t0, svf_codes_ptr; ld a5, 0(t0); la t0, svf_codes_len; ld a6, 0(t0)\n" ++
   "  jal ra, code_at_header_state_root\n" ++
-  "  beqz a0, .Ldtrc_have_code\n" ++
-  "  addi a0, s2, 72; mv a1, s0; mv a2, s1; li a3, 0\n" ++
-  "  jal ra, bal_same_block_delegation_code_resolve\n" ++
   "  bnez a0, .Ldtrc_code_lookup_unsupported\n" ++
+  "  j .Ldtrc_have_code\n" ++
+  ".Ldtrc_same_block_delegation_code:\n" ++
+  "  la t0, sv_pre_rlp_ptr; ld t1, 0(t0); la t2, dtrc_hdr_ptr; sd t1, 0(t2)\n" ++
+  "  la t0, sv_pre_rlp_len; ld t1, 0(t0); la t2, dtrc_hdr_len; sd t1, 0(t2)\n" ++
   ".Ldtrc_have_code:\n" ++
   "  la t0, svf_codes_ptr; ld t1, 0(t0); la t2, cahsr_code_offset; ld t3, 0(t2); add a0, t1, t3\n" ++
   "  la t2, cahsr_code_length; ld a1, 0(t2)\n" ++
@@ -464,7 +468,10 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  la t1, bsg_access_len; ld t2, 0(t1); la t0, runtime_tx_access_list_len; sd t2, 0(t0)\n" ++
   "  la t0, runtime_tx_access_list_seed_fn; la t1, seed_tx_access_list; sd t1, 0(t0)\n" ++
   ".Ldtrc_access_done:\n" ++
+  "  la t4, ecc_same_block_hit; sd zero, 0(t4)\n" ++
   "  la t4, runtime_dispatcher_input_ptr; la t5, bv_runtime_payload; addi t5, t5, 8; sd t5, 0(t4)\n" ++
+  "  la t4, bv_bal_start; ld t5, 0(t4); la t4, runtime_current_bal_ptr; sd t5, 0(t4)\n" ++
+  "  la t4, bv_bal_len; ld t5, 0(t4); la t4, runtime_current_bal_len; sd t5, 0(t4)\n" ++
   -- .62.2.5: arm the ECRECOVER backend for this dispatch (the guest closure
   -- links secp256k1_recover_pubkey_staged; standalone dispatch probes leave
   -- the pointer 0 and keep the legacy empty-returndata success).
@@ -475,6 +482,8 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  ld s0, 0(sp); ld s1, 8(sp); ld s2, 16(sp); ld s3, 24(sp)\n" ++
   "  addi sp, sp, 32\n" ++
   "  la t4, runtime_dispatcher_input_ptr; sd zero, 0(t4)\n" ++
+  "  la t4, runtime_current_bal_ptr; sd zero, 0(t4)\n" ++
+  "  la t4, runtime_current_bal_len; sd zero, 0(t4)\n" ++
   -- .63.1.6.2.1: snapshot this tx's event-log window into the block log arena
   -- BEFORE the next dispatch overwrites the capture buffers; the caller stores
   -- the bv_last_log_* window into its per-tx slot.

--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -437,6 +437,10 @@ def blockVerdictFunction : String :=
   "  ld a0, 8(s0); ld a1, 16(s0); addi a2, t2, 72; ld a3, 80(s0); ld a4, 88(s0); la a5, bv_tx_recipient_code_hash\n" ++
   "  jal ra, code_hash_at_header_state_root\n" ++
   "  bnez a0, .Lbv_cd_eoa_restore        # code-hash lookup failed -> conservative EOA path\n" ++
+  "  la t2, bv_simple_transfer_tx\n" ++
+  "  addi a0, t2, 72; ld a1, 80(s0); ld a2, 88(s0); li a3, 0\n" ++
+  "  jal ra, bal_same_block_delegation_code_resolve\n" ++
+  "  beqz a0, .Lbv_cd_same_block_delegation\n" ++
   "  la t0, bv_tx_recipient_code_hash; la t1, chahsr_empty_code_hash\n" ++
   "  ld t3,  0(t0); ld t4,  0(t1); bne t3, t4, .Lbv_contract_dispatch\n" ++
   "  ld t3,  8(t0); ld t4,  8(t1); bne t3, t4, .Lbv_contract_dispatch\n" ++
@@ -446,6 +450,7 @@ def blockVerdictFunction : String :=
   "  addi a0, t2, 72; ld a1, 80(s0); ld a2, 88(s0); li a3, 0\n" ++
   "  jal ra, bal_same_block_delegation_code_resolve\n" ++
   "  bnez a0, .Lbv_cd_eoa_restore\n" ++
+  ".Lbv_cd_same_block_delegation:\n" ++
   "  la t0, cahsr_acct_struct; addi t0, t0, 72; la t1, bv_tx_recipient_code_hash\n" ++
   "  ld t2, 0(t0); sd t2, 0(t1); ld t2, 8(t0); sd t2, 8(t1); ld t2, 16(t0); sd t2, 16(t1); ld t2, 24(t0); sd t2, 24(t1)\n" ++
   "  li t0, 1; la t1, dtrc_use_pre_header; sd t0, 0(t1)\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -58,6 +58,11 @@ def blockVerdictReceiptsTail : String :=
   "  la t0, evm_selfdestruct_staged; ld t0, 0(t0); beqz t0, .Lbv_receipt_sd_skip\n" ++
   "  la t4, bvgr_receipt_gas_increments; ld t5, 0(t4); li t6, 32690; add t5, t5, t6; sd t5, 0(t4); j .Lbv_receipt_sd_skip\n" ++
   ".Lbv_receipt_sd_skip:\n" ++
+  "  la t2, bvgr_arena_tx_count; ld t2, 0(t2); li t3, 1; bne t2, t3, .Lbv_receipt_ecc_skip\n" ++
+  "  la t2, bv_simple_transfer_tx; ld t2, 160(t2); li t3, 4; bne t2, t3, .Lbv_receipt_ecc_skip\n" ++
+  "  la t0, ecc_same_block_hit; ld t0, 0(t0); beqz t0, .Lbv_receipt_ecc_skip\n" ++
+  "  la t4, bvgr_receipt_gas_increments; ld t5, 0(t4); li t6, 32690; add t5, t5, t6; sd t5, 0(t4)\n" ++
+  ".Lbv_receipt_ecc_skip:\n" ++
   "  la t2, bv_exec_p; ld a0, 0(t2)\n" ++
   "  la a1, bvgr_receipt_gas_increments\n" ++
   "  la t2, bvgr_arena_tx_count; ld a2, 0(t2)\n" ++

--- a/EvmAsm/Codegen/Programs/EvmAccountWitness.lean
+++ b/EvmAsm/Codegen/Programs/EvmAccountWitness.lean
@@ -8,6 +8,7 @@ import EvmAsm.Codegen.Dispatch
 import EvmAsm.Codegen.Programs.EvmAccessGas
 import EvmAsm.Codegen.Programs.EvmOpcodes
 import EvmAsm.Codegen.Programs.StateCompose
+import EvmAsm.Codegen.Programs.RuntimeSameBlockCode
 
 namespace EvmAsm.Codegen
 
@@ -44,6 +45,7 @@ private def extcodehashWitnessTail : HandlerTail :=
     "  addi sp, sp, -32\n" ++
     "  sd x10, 0(sp)\n" ++
     "  sd x12, 8(sp)\n" ++
+    "  sd x21, 16(sp)\n" ++
     "  la a0, eahsr_address_scratch\n" ++
     "  la a1, " ++ runtimeAccessAccountTableLabel ++ "\n" ++
     "  la a2, " ++ runtimeAccessAccountCountLabel ++ "\n" ++
@@ -51,12 +53,41 @@ private def extcodehashWitnessTail : HandlerTail :=
     "  jal ra, runtime_access_account_charge\n" ++
     "  ld x10, 0(sp)\n" ++
     "  ld x12, 8(sp)\n" ++
+    "  ld x21, 16(sp)\n" ++
+    "  addi sp, sp, 32\n" ++
+    "  addi sp, sp, -32\n" ++
+    "  sd x10, 0(sp)\n" ++
+    "  sd x12, 8(sp)\n" ++
+    "  sd x21, 16(sp)\n" ++
+    "  la a0, eahsr_address_scratch\n" ++
+    "  jal ra, runtime_same_block_delegation_code\n" ++
+    "  bnez a0, .Lextcodehash_after_same_block\n" ++
+    "  la t0, rsbd_code_ptr; ld a0, 0(t0)\n" ++
+    "  la t0, rsbd_code_len; ld a1, 0(t0)\n" ++
+    "  la a2, rsbd_hash\n" ++
+    "  jal ra, zkvm_keccak256\n" ++
+    "  ld x10, 0(sp)\n" ++
+    "  ld x12, 8(sp)\n" ++
+    "  ld x21, 16(sp)\n" ++
+    "  la t0, rsbd_hash; addi t0, t0, 31; mv t1, x12; li t2, 32\n" ++
+    ".Lextcodehash_same_block_rev:\n" ++
+    "  beqz t2, .Lextcodehash_same_block_rev_done\n" ++
+    "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; j .Lextcodehash_same_block_rev\n" ++
+    ".Lextcodehash_same_block_rev_done:\n" ++
+    "  addi sp, sp, 32\n" ++
+    "  addi x10, x10, 1\n" ++
+    "  j .dispatch_loop\n" ++
+    ".Lextcodehash_after_same_block:\n" ++
+    "  ld x10, 0(sp)\n" ++
+    "  ld x12, 8(sp)\n" ++
+    "  ld x21, 16(sp)\n" ++
     "  addi sp, sp, 32\n" ++
     "  ld t0, 584(x20)\n" ++          -- header length; zero means no witness context
     "  beqz t0, .Lextcodehash_no_context\n" ++
     "  addi sp, sp, -32\n" ++
     "  sd x10, 0(sp)\n" ++
     "  sd x12, 8(sp)\n" ++
+    "  sd x21, 16(sp)\n" ++
     "  ld a0, 576(x20)\n" ++         -- header ptr
     "  ld a1, 584(x20)\n" ++         -- header len
     "  la a2, eahsr_address_scratch\n" ++
@@ -66,6 +97,7 @@ private def extcodehashWitnessTail : HandlerTail :=
     "  jal ra, extcodehash_at_header_state_root\n" ++
     "  ld x10, 0(sp)\n" ++
     "  ld x12, 8(sp)\n" ++
+    "  ld x21, 16(sp)\n" ++
     "  addi sp, sp, 32\n" ++
     "  addi x10, x10, 1\n" ++
     "  j .dispatch_loop\n" ++
@@ -89,6 +121,7 @@ private def extcodesizeWitnessTail : HandlerTail :=
     "  addi sp, sp, -32\n" ++
     "  sd x10, 0(sp)\n" ++
     "  sd x12, 8(sp)\n" ++
+    "  sd x21, 16(sp)\n" ++
     "  la a0, eahsr_address_scratch\n" ++
     "  la a1, " ++ runtimeAccessAccountTableLabel ++ "\n" ++
     "  la a2, " ++ runtimeAccessAccountCountLabel ++ "\n" ++
@@ -96,12 +129,37 @@ private def extcodesizeWitnessTail : HandlerTail :=
     "  jal ra, runtime_access_account_charge\n" ++
     "  ld x10, 0(sp)\n" ++
     "  ld x12, 8(sp)\n" ++
+    "  ld x21, 16(sp)\n" ++
+    "  addi sp, sp, 32\n" ++
+    "  addi sp, sp, -32\n" ++
+    "  sd x10, 0(sp)\n" ++
+    "  sd x12, 8(sp)\n" ++
+    "  sd x21, 16(sp)\n" ++
+    "  la a0, eahsr_address_scratch\n" ++
+    "  jal ra, runtime_same_block_delegation_code\n" ++
+    "  bnez a0, .Lextcodesize_after_same_block\n" ++
+    "  la t0, rsbd_code_len; ld t1, 0(t0)\n" ++
+    "  ld x10, 0(sp)\n" ++
+    "  ld x12, 8(sp)\n" ++
+    "  ld x21, 16(sp)\n" ++
+    "  addi sp, sp, 32\n" ++
+    "  sd t1, 0(x12)\n" ++
+    "  sd zero, 8(x12)\n" ++
+    "  sd zero, 16(x12)\n" ++
+    "  sd zero, 24(x12)\n" ++
+    "  addi x10, x10, 1\n" ++
+    "  j .dispatch_loop\n" ++
+    ".Lextcodesize_after_same_block:\n" ++
+    "  ld x10, 0(sp)\n" ++
+    "  ld x12, 8(sp)\n" ++
+    "  ld x21, 16(sp)\n" ++
     "  addi sp, sp, 32\n" ++
     "  ld t0, 584(x20)\n" ++
     "  beqz t0, .Lextcodesize_no_context\n" ++
     "  addi sp, sp, -32\n" ++
     "  sd x10, 0(sp)\n" ++
     "  sd x12, 8(sp)\n" ++
+    "  sd x21, 16(sp)\n" ++
     "  ld a0, 576(x20)\n" ++         -- header ptr
     "  ld a1, 584(x20)\n" ++         -- header len
     "  la a2, eahsr_address_scratch\n" ++
@@ -114,6 +172,7 @@ private def extcodesizeWitnessTail : HandlerTail :=
     "  ld t1, 0(t0)\n" ++
     "  ld x10, 0(sp)\n" ++
     "  ld x12, 8(sp)\n" ++
+    "  ld x21, 16(sp)\n" ++
     "  addi sp, sp, 32\n" ++
     "  sd t1, 0(x12)\n" ++
     "  sd zero, 8(x12)\n" ++

--- a/EvmAsm/Codegen/Programs/EvmBalance.lean
+++ b/EvmAsm/Codegen/Programs/EvmBalance.lean
@@ -46,6 +46,8 @@ private def balanceWitnessTail : HandlerTail :=
 " ++
     "  sd x12, 8(sp)
 " ++
+    "  sd x21, 16(sp)
+" ++
     "  la a0, eahsr_address_scratch
 " ++
     "  la a1, " ++ runtimeAccessAccountTableLabel ++ "
@@ -60,6 +62,8 @@ private def balanceWitnessTail : HandlerTail :=
 " ++
     "  ld x12, 8(sp)
 " ++
+    "  ld x21, 16(sp)
+" ++
     "  addi sp, sp, 32
 " ++
     "  ld t0, 584(x20)
@@ -71,6 +75,8 @@ private def balanceWitnessTail : HandlerTail :=
     "  sd x10, 0(sp)
 " ++
     "  sd x12, 8(sp)
+" ++
+    "  sd x21, 16(sp)
 " ++
     "  ld a0, 576(x20)
 " ++         -- header ptr
@@ -89,6 +95,8 @@ private def balanceWitnessTail : HandlerTail :=
     "  ld x10, 0(sp)
 " ++
     "  ld x12, 8(sp)
+" ++
+    "  ld x21, 16(sp)
 " ++
     "  addi sp, sp, 32
 " ++

--- a/EvmAsm/Codegen/Programs/EvmExtcodecopy.lean
+++ b/EvmAsm/Codegen/Programs/EvmExtcodecopy.lean
@@ -7,6 +7,7 @@
 import EvmAsm.Codegen.Dispatch
 import EvmAsm.Codegen.Programs.EvmAccessGas
 import EvmAsm.Codegen.Programs.EvmMemoryGas
+import EvmAsm.Codegen.Programs.RuntimeSameBlockCode
 
 namespace EvmAsm.Codegen
 
@@ -49,8 +50,38 @@ private def extcodecopyWitnessTail : HandlerTail :=
 " ++         -- memory_start_index
     "  ld x15, 96(x12)
 " ++         -- size
+    "  ld x5, " ++ toString activeMemorySizeOff ++ "(x20)
+" ++
+    "  la x6, ecc_old_active; sd x5, 0(x6)
+" ++
+    "  addi sp, sp, -8
+" ++
+    "  sd x5, 0(sp)
+" ++
     copyWordGasAsm "extcodecopy" "x15" "x16" "x17" "x18" ++
     updateActiveMemorySizeAsm "extcodecopy" "x14" "x15" "x16" "x17" "x18" "x6" true ++
+    "  ld x5, 0(sp)
+" ++
+    "  addi sp, sp, 8
+" ++
+    "  ld x6, " ++ toString activeMemorySizeOff ++ "(x20)
+" ++
+    "  add x7, x13, x5
+" ++
+    "  add x8, x13, x6
+" ++
+    ".Lrt_ecc_zero_new_mem:
+" ++
+    "  bgeu x7, x8, .Lrt_ecc_zero_new_done
+" ++
+    "  sb zero, 0(x7)
+" ++
+    "  addi x7, x7, 1
+" ++
+    "  j .Lrt_ecc_zero_new_mem
+" ++
+    ".Lrt_ecc_zero_new_done:
+" ++
     "  add x19, x13, x14
 " ++       -- output ptr = evm_memory + memory_start
     "  la t1, ecc_address_scratch
@@ -63,6 +94,8 @@ private def extcodecopyWitnessTail : HandlerTail :=
     "  sd x12, 8(sp)
 " ++
     "  sd x13, 16(sp)
+" ++
+    "  sd x21, 24(sp)
 " ++
     "  la a0, ecc_address_scratch
 " ++
@@ -80,7 +113,135 @@ private def extcodecopyWitnessTail : HandlerTail :=
 " ++
     "  ld x13, 16(sp)
 " ++
+    "  ld x21, 24(sp)
+" ++
     "  addi sp, sp, 32
+" ++
+    "  ld x14, 32(x12)
+" ++
+    "  ld x15, 96(x12)
+" ++
+    "  add x19, x13, x14
+" ++
+    "  addi sp, sp, -64
+" ++
+    "  sd x10, 0(sp)
+" ++
+    "  sd x12, 8(sp)
+" ++
+    "  sd x13, 16(sp)
+" ++
+    "  sd x14, 24(sp)
+" ++
+    "  sd x15, 32(sp)
+" ++
+    "  sd x19, 40(sp)
+" ++
+    "  sd x21, 48(sp)
+" ++
+    "  la a0, ecc_address_scratch
+" ++
+    "  jal ra, runtime_same_block_delegation_code
+" ++
+    "  bnez a0, .Lrt_ecc_after_same_block
+" ++
+    "  ld x10, 0(sp)
+" ++
+    "  ld x12, 8(sp)
+" ++
+    "  ld x13, 16(sp)
+" ++
+    "  ld x14, 24(sp)
+" ++
+    "  ld x15, 32(sp)
+" ++
+    "  ld x19, 40(sp)
+" ++
+    "  ld x21, 48(sp)
+" ++
+    "  addi sp, sp, 64
+" ++
+    "  la t0, rsbd_code_ptr; ld t1, 0(t0)
+" ++
+    "  la t0, rsbd_code_len; ld t2, 0(t0)
+" ++
+    "  ld t3, 64(x12)
+" ++
+    "  li t4, 0
+" ++
+    ".Lrt_ecc_same_loop:
+" ++
+    "  beq t4, x15, .Lrt_ecc_same_done
+" ++
+    "  add t5, t3, t4
+" ++
+    "  bgeu t5, t2, .Lrt_ecc_same_zero
+" ++
+    "  add t6, t1, t5; lbu t6, 0(t6)
+" ++
+    "  j .Lrt_ecc_same_store
+" ++
+    ".Lrt_ecc_same_zero:
+" ++
+    "  li t6, 0
+" ++
+    ".Lrt_ecc_same_store:
+" ++
+    "  add t0, x19, t4; sb t6, 0(t0)
+" ++
+    "  addi t4, t4, 1; j .Lrt_ecc_same_loop
+" ++
+    ".Lrt_ecc_same_done:
+" ++
+    "  la t0, ecc_same_block_hit; li t1, 1; sd t1, 0(t0)
+" ++
+    "  add t0, x14, x15
+" ++
+    "  la t1, ecc_old_active; ld t1, 0(t1)
+" ++
+    "  bgeu t0, t1, .Lrt_ecc_tail_start_ok
+" ++
+    "  mv t0, t1
+" ++
+    ".Lrt_ecc_tail_start_ok:
+" ++
+    "  ld t2, " ++ toString activeMemorySizeOff ++ "(x20)
+" ++
+    ".Lrt_ecc_tail_zero_loop:
+" ++
+    "  bgeu t0, t2, .Lrt_ecc_tail_zero_done
+" ++
+    "  add t3, x13, t0; sb zero, 0(t3)
+" ++
+    "  addi t0, t0, 1
+" ++
+    "  j .Lrt_ecc_tail_zero_loop
+" ++
+    ".Lrt_ecc_tail_zero_done:
+" ++
+    "  addi x12, x12, 128
+" ++
+    "  addi x10, x10, 1
+" ++
+    "  j .dispatch_loop
+" ++
+    ".Lrt_ecc_after_same_block:
+" ++
+    "  ld x10, 0(sp)
+" ++
+    "  ld x12, 8(sp)
+" ++
+    "  ld x13, 16(sp)
+" ++
+    "  ld x14, 24(sp)
+" ++
+    "  ld x15, 32(sp)
+" ++
+    "  ld x19, 40(sp)
+" ++
+    "  ld x21, 48(sp)
+" ++
+    "  addi sp, sp, 64
 " ++
     "  ld t0, 608(x20)
 " ++         -- witness.codes ptr
@@ -101,6 +262,8 @@ private def extcodecopyWitnessTail : HandlerTail :=
     "  sd x12, 8(sp)
 " ++
     "  sd x13, 16(sp)
+" ++
+    "  sd x21, 24(sp)
 " ++
     "  ld a0, 576(x20)
 " ++         -- header ptr
@@ -127,6 +290,8 @@ private def extcodecopyWitnessTail : HandlerTail :=
     "  ld x12, 8(sp)
 " ++
     "  ld x13, 16(sp)
+" ++
+    "  ld x21, 24(sp)
 " ++
     "  addi sp, sp, 32
 " ++
@@ -161,6 +326,8 @@ private def extcodecopyWitnessTail : HandlerTail :=
     "  ld x12, 8(sp)
 " ++
     "  ld x13, 16(sp)
+" ++
+    "  ld x21, 24(sp)
 " ++
     "  addi sp, sp, 32
 " ++

--- a/EvmAsm/Codegen/Programs/RuntimeSameBlockCode.lean
+++ b/EvmAsm/Codegen/Programs/RuntimeSameBlockCode.lean
@@ -1,0 +1,282 @@
+/-
+  EvmAsm.Codegen.Programs.RuntimeSameBlockCode
+
+  Runtime helper for EIP-7702 same-block code observations. EXTCODESIZE,
+  EXTCODEHASH, and EXTCODECOPY observe an account's current code. During a
+  set-code transaction, that current code can be the BAL's final
+  0xef0100||address delegation marker even though the pre-state trie still has
+  empty code.
+-/
+
+import EvmAsm.Codegen.Programs.RlpRead
+
+namespace EvmAsm.Codegen
+
+/-! ## runtime_same_block_delegation_code
+
+    Calling convention:
+      a0 = 20-byte address ptr
+      runtime_current_bal_ptr/runtime_current_bal_len name the current BAL section
+    Returns:
+      a0 = 0 if the BAL has a final code change for this account and that final
+           code is exactly a 23-byte EIP-7702 delegation marker; in that case
+           rsbd_code_ptr/rsbd_code_len name the marker bytes.
+      a0 = 1 otherwise.
+-/
+def runtimeSameBlockDelegationCodeFunction : String :=
+  "runtime_same_block_delegation_code:
+" ++
+  "  addi sp, sp, -80
+" ++
+  "  sd ra, 0(sp)
+" ++
+  "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)
+" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)
+" ++
+  "  mv s0, a0                    # target address ptr
+" ++
+  "  la t0, runtime_current_bal_ptr; ld s1, 0(t0)
+" ++
+  "  la t0, runtime_current_bal_len; ld s2, 0(t0)
+" ++
+  "  beqz s1, .Lrsbd_no_bal_ptr
+" ++
+  "  beqz s2, .Lrsbd_no_bal_len
+" ++
+  "  mv a0, s1; mv a1, s2; la a2, rsbd_count
+" ++
+  "  jal ra, rlp_list_count_items
+" ++
+  "  bnez a0, .Lrsbd_no_count
+" ++
+  "  la t0, rsbd_count; ld s3, 0(t0)
+" ++
+  "  li s4, 0
+" ++
+  ".Lrsbd_loop:
+" ++
+  "  beq s4, s3, .Lrsbd_no_notfound
+" ++
+  "  mv a0, s1; mv a1, s2; mv a2, s4; la a3, rsbd_acct_off; la a4, rsbd_acct_len
+" ++
+  "  jal ra, rlp_item_span
+" ++
+  "  bnez a0, .Lrsbd_no_span
+" ++
+  "  la t0, rsbd_acct_off; ld t1, 0(t0); add s5, s1, t1
+" ++
+  "  la t0, rsbd_acct_len; ld s6, 0(t0)
+" ++
+  "  mv a0, s5; mv a1, s6; li a2, 0; la a3, rsbd_field_off; la a4, rsbd_field_len
+" ++
+  "  jal ra, rlp_list_nth_item
+" ++
+  "  bnez a0, .Lrsbd_next
+" ++
+  "  la t0, rsbd_field_len; ld t1, 0(t0); li t2, 20; bne t1, t2, .Lrsbd_next
+" ++
+  "  la t0, rsbd_field_off; ld t1, 0(t0); add t1, s5, t1
+" ++
+  "  mv t2, s0; li t3, 20
+" ++
+  ".Lrsbd_addr_cmp:
+" ++
+  "  beqz t3, .Lrsbd_addr_match
+" ++
+  "  lbu t4, 0(t1); lbu t5, 0(t2); bne t4, t5, .Lrsbd_next
+" ++
+  "  addi t1, t1, 1; addi t2, t2, 1; addi t3, t3, -1; j .Lrsbd_addr_cmp
+" ++
+  ".Lrsbd_addr_match:
+" ++
+  "  mv a0, s5; mv a1, s6; li a2, 5; la a3, rsbd_field_off; la a4, rsbd_field_len
+" ++
+  "  jal ra, rlp_list_nth_item                  # code_changes
+" ++
+  "  bnez a0, .Lrsbd_no_code_item
+" ++
+  "  la t0, rsbd_field_off; ld t1, 0(t0); add s7, s5, t1
+" ++
+  "  la t0, rsbd_field_len; ld t1, 0(t0)
+" ++
+  "  mv a0, s7; mv a1, t1; la a2, rsbd_code_count
+" ++
+  "  jal ra, rlp_list_count_items
+" ++
+  "  bnez a0, .Lrsbd_no_code_count
+" ++
+  "  la t0, rsbd_code_count; ld t1, 0(t0); beqz t1, .Lrsbd_no_empty_code_changes
+" ++
+  "  addi t1, t1, -1
+" ++
+  "  la t0, rsbd_field_len; ld a1, 0(t0)
+" ++
+  "  mv a0, s7; mv a2, t1; la a3, rsbd_tuple_off; la a4, rsbd_tuple_len
+" ++
+  "  jal ra, rlp_list_nth_item
+" ++
+  "  bnez a0, .Lrsbd_no_tuple
+" ++
+  "  la t0, rsbd_tuple_off; ld t1, 0(t0); add t1, s7, t1
+" ++
+  "  la t0, rsbd_tuple_len; ld t2, 0(t0)
+" ++
+  "  mv a0, t1; mv a1, t2; li a2, 1; la a3, rsbd_code_off; la a4, rsbd_code_len_cell
+" ++
+  "  jal ra, rlp_list_nth_item
+" ++
+  "  bnez a0, .Lrsbd_no_code_field
+" ++
+  "  la t0, rsbd_code_len_cell; ld t2, 0(t0); li t3, 23; bne t2, t3, .Lrsbd_no_code_len
+" ++
+  "  la t0, rsbd_tuple_off; ld t1, 0(t0); add t1, s7, t1
+" ++
+  "  la t0, rsbd_code_off; ld t2, 0(t0); add t1, t1, t2
+" ++
+  "  lbu t3, 0(t1); li t4, 0xef; bne t3, t4, .Lrsbd_no_marker0
+" ++
+  "  lbu t3, 1(t1); li t4, 0x01; bne t3, t4, .Lrsbd_no_marker1
+" ++
+  "  lbu t3, 2(t1); bnez t3, .Lrsbd_no_marker2
+" ++
+  "  la t0, rsbd_code_ptr; sd t1, 0(t0)
+" ++
+  "  la t0, rsbd_code_len; li t1, 23; sd t1, 0(t0)
+" ++
+  "  li a0, 0; j .Lrsbd_ret
+" ++
+  ".Lrsbd_next:
+" ++
+  "  addi s4, s4, 1; j .Lrsbd_loop
+" ++
+  ".Lrsbd_no:
+" ++
+  "  li a0, 1
+" ++
+  "  j .Lrsbd_ret
+" ++
+  ".Lrsbd_no_bal_ptr:
+" ++
+  "  j .Lrsbd_no
+" ++
+  ".Lrsbd_no_bal_len:
+" ++
+  "  j .Lrsbd_no
+" ++
+  ".Lrsbd_no_count:
+" ++
+  "  j .Lrsbd_no
+" ++
+  ".Lrsbd_no_notfound:
+" ++
+  "  j .Lrsbd_no
+" ++
+  ".Lrsbd_no_span:
+" ++
+  "  j .Lrsbd_no
+" ++
+  ".Lrsbd_no_code_item:
+" ++
+  "  j .Lrsbd_no
+" ++
+  ".Lrsbd_no_code_count:
+" ++
+  "  j .Lrsbd_no
+" ++
+  ".Lrsbd_no_empty_code_changes:
+" ++
+  "  j .Lrsbd_no
+" ++
+  ".Lrsbd_no_tuple:
+" ++
+  "  j .Lrsbd_no
+" ++
+  ".Lrsbd_no_code_field:
+" ++
+  "  j .Lrsbd_no
+" ++
+  ".Lrsbd_no_code_len:
+" ++
+  "  j .Lrsbd_no
+" ++
+  ".Lrsbd_no_marker0:
+" ++
+  "  j .Lrsbd_no
+" ++
+  ".Lrsbd_no_marker1:
+" ++
+  "  j .Lrsbd_no
+" ++
+  ".Lrsbd_no_marker2:
+" ++
+  "  j .Lrsbd_no
+" ++
+  ".Lrsbd_ret:
+" ++
+  "  ld ra, 0(sp)
+" ++
+  "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)
+" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)
+" ++
+  "  addi sp, sp, 80
+" ++
+  "  ret"
+
+def runtimeSameBlockDelegationCodeData : String :=
+  ".balign 8
+" ++
+  "runtime_current_bal_ptr:
+  .zero 8
+" ++
+  "runtime_current_bal_len:
+  .zero 8
+" ++
+  "rsbd_count:
+  .zero 8
+" ++
+  "rsbd_acct_off:
+  .zero 8
+" ++
+  "rsbd_acct_len:
+  .zero 8
+" ++
+  "rsbd_field_off:
+  .zero 8
+" ++
+  "rsbd_field_len:
+  .zero 8
+" ++
+  "rsbd_code_count:
+  .zero 8
+" ++
+  "rsbd_tuple_off:
+  .zero 8
+" ++
+  "rsbd_tuple_len:
+  .zero 8
+" ++
+  "rsbd_code_off:
+  .zero 8
+" ++
+  "rsbd_code_len_cell:
+  .zero 8
+" ++
+  "rsbd_code_ptr:
+  .zero 8
+" ++
+  "rsbd_code_len:
+  .zero 8
+" ++
+  "rsbd_hash:
+  .zero 32
+" ++
+  "ecc_old_active:
+  .zero 8
+" ++
+  "ecc_same_block_hit:
+  .zero 8
+"
+
+end EvmAsm.Codegen


### PR DESCRIPTION
## Summary
- add a runtime BAL helper for same-block EIP-7702 delegation markers
- wire current-code observations into EXTCODESIZE, EXTCODEHASH, and EXTCODECOPY
- preserve EXTCODECOPY zero-fill behavior and correct the single-tx type-4 receipt gas path when same-block EXTCODECOPY executes

Bead: evm-asm-luokq.

Directed by @pirapira; implemented by Codex.