### PR TITLE
feat(rv64): bytesRegion_lbu_within — read byte i across dwords

### DIFF
--- a/EvmAsm/Rv64/MemRegion.lean
+++ b/EvmAsm/Rv64/MemRegion.lean
@@ -12,6 +12,7 @@
 -/
 
 import EvmAsm.Rv64.ByteOps
+import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Rv64
 
@@ -49,5 +50,146 @@ theorem bytesRegion_pcFree (base : Word) (bs : List (BitVec 8)) :
     (bytesRegion base bs).pcFree :=
   bytesRegionAux_pcFree _ base bs
 
+/-! ## Address arithmetic for an aligned base + byte offset -/
+
+private theorem nat_and_seven (n : Nat) : n &&& 7 = n % 8 := by
+  have : (7 : Nat) = 2 ^ 3 - 1 := by decide
+  rw [this, Nat.and_two_pow_sub_one_eq_mod]
+
+/-- For a dword-aligned `base` and an in-range offset `i`, the byte offset of
+    `base + i` is `i % 8`. -/
+theorem byteOffset_add_ofNat_of_aligned {base : Word} {i : Nat}
+    (halign : base.toNat % 8 = 0) (hover : base.toNat + i < 2 ^ 64) :
+    byteOffset (base + BitVec.ofNat 64 i) = i % 8 := by
+  have hi : i < 2 ^ 64 := by omega
+  unfold byteOffset
+  rw [BitVec.toNat_and, BitVec.toNat_add, BitVec.toNat_ofNat, Nat.mod_eq_of_lt hi,
+      Nat.mod_eq_of_lt hover]
+  show (base.toNat + i) &&& 7 = i % 8
+  rw [nat_and_seven]
+  omega
+
+/-- For a dword-aligned `base` and an in-range offset `i`, aligning `base + i`
+    down to its dword gives `base + 8*(i/8)`. -/
+theorem alignToDword_add_ofNat_of_aligned {base : Word} {i : Nat}
+    (halign : base.toNat % 8 = 0) (hover : base.toNat + i < 2 ^ 64) :
+    alignToDword (base + BitVec.ofNat 64 i) = base + BitVec.ofNat 64 (8 * (i / 8)) := by
+  have hbo := byteOffset_add_ofNat_of_aligned halign hover
+  have hdecomp := alignToDword_add_byteOffset (base + BitVec.ofNat 64 i)
+  rw [hbo] at hdecomp
+  -- hdecomp : alignToDword (base + ofNat i) + ofNat (i % 8) = base + ofNat i
+  have hi : i < 2 ^ 64 := by omega
+  have hi8 : i % 8 < 2 ^ 64 := by omega
+  have haddr : (base + BitVec.ofNat 64 i).toNat = base.toNat + i := by
+    rw [BitVec.toNat_add, BitVec.toNat_ofNat, Nat.mod_eq_of_lt hi, Nat.mod_eq_of_lt hover]
+  have hAle : (alignToDword (base + BitVec.ofNat 64 i)).toNat ≤ base.toNat + i := by
+    unfold alignToDword; rw [BitVec.toNat_and, ← haddr]; exact Nat.and_le_left
+  have hd := congrArg BitVec.toNat hdecomp
+  rw [BitVec.toNat_add, BitVec.toNat_ofNat, Nat.mod_eq_of_lt hi8, haddr] at hd
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_add, BitVec.toNat_ofNat]
+  have hAlt := (alignToDword (base + BitVec.ofNat 64 i)).isLt
+  omega
+
+/-! ## Dword extraction -/
+
+/-- Assertion-level (`=`) associativity, from the pointwise `sepConj_assoc`. -/
+private theorem sepConj_assoc_eq {P Q R : Assertion} :
+    ((P ** Q) ** R) = (P ** (Q ** R)) := by
+  funext h; exact propext (sepConj_assoc h)
+
+/-- Assertion-level (`=`) left identity, from the pointwise `sepConj_emp_left`. -/
+private theorem sepConj_emp_left_eq {P : Assertion} : (empAssertion ** P) = P := by
+  funext h; exact propext (sepConj_emp_left h)
+
+/-- Extract the `dw`-th dword cell from a region (the chunk may be the partial
+    last one — `packBytes` zero-pads), framing the rest. -/
+theorem bytesRegion_dword_at (regionBase : Word) (bs : List (BitVec 8)) (dw : Nat)
+    (hdw : 8 * dw < bs.length) :
+    ∃ front rest : Assertion, front.pcFree ∧ rest.pcFree ∧
+      bytesRegion regionBase bs
+        = (front ** (((regionBase + BitVec.ofNat 64 (8 * dw)) ↦ₘ
+            packBytes ((bs.drop (8 * dw)).take 8)) ** rest)) := by
+  induction dw generalizing regionBase bs with
+  | zero =>
+    have hne : bs ≠ [] := by intro h; subst h; simp at hdw
+    refine ⟨empAssertion, bytesRegion (regionBase + 8) (bs.drop 8),
+      pcFree_emp, bytesRegion_pcFree _ _, ?_⟩
+    rw [bytesRegion_eq_cons regionBase bs hne]
+    simp [sepConj_emp_left_eq]
+  | succ k ih =>
+    have hne : bs ≠ [] := by intro h; subst h; simp at hdw
+    have hdw' : 8 * k < (bs.drop 8).length := by rw [List.length_drop]; omega
+    obtain ⟨front', rest', hf', hr', heq'⟩ := ih (regionBase + 8) (bs.drop 8) hdw'
+    have haddr : (regionBase + 8) + BitVec.ofNat 64 (8 * k)
+        = regionBase + BitVec.ofNat 64 (8 * (k + 1)) := by
+      rw [BitVec.add_assoc]; congr 1
+      apply BitVec.eq_of_toNat_eq
+      have h8 : (8 : BitVec 64).toNat = 8 := by decide
+      rw [BitVec.toNat_add, BitVec.toNat_ofNat, BitVec.toNat_ofNat, h8]
+      omega
+    have hdrop : (bs.drop 8).drop (8 * k) = bs.drop (8 * (k + 1)) := by
+      rw [List.drop_drop]; congr 1; omega
+    refine ⟨(regionBase ↦ₘ packBytes (bs.take 8)) ** front', rest',
+      pcFree_sepConj pcFree_memIs hf', hr', ?_⟩
+    rw [bytesRegion_eq_cons regionBase bs hne, heq', haddr, hdrop, ← sepConj_assoc_eq]
+
+/-! ## Reading a byte from the region (the keystone) -/
+
+/-- **`LBU` reads byte `i` from the region.** Reading the byte at `regionBase + i`
+    (`i < bs.length`, region base dword-aligned, no address overflow) yields
+    `bs[i]` — the multi-dword read the single-`dwordAddr` loop could not express. -/
+theorem bytesRegion_lbu_within (rd rs1 : Reg) (regionBase vOld : Word) (base : Word)
+    (bs : List (BitVec 8)) (i : Nat) (hrd : rd ≠ .x0)
+    (halign : regionBase.toNat % 8 = 0) (hi : i < bs.length)
+    (hover : regionBase.toNat + i < 2 ^ 64)
+    (hvalid : isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true) :
+    cpsTripleWithin 1 base (base + 4)
+      (CodeReq.singleton base (.LBU rd rs1 0))
+      ((rs1 ↦ᵣ (regionBase + BitVec.ofNat 64 i)) ** (rd ↦ᵣ vOld) ** bytesRegion regionBase bs)
+      ((rs1 ↦ᵣ (regionBase + BitVec.ofNat 64 i)) **
+       (rd ↦ᵣ ((bs[i]'hi).zeroExtend 64)) ** bytesRegion regionBase bs) := by
+  have hq : 8 * (i / 8) < bs.length := by omega
+  obtain ⟨front, rest, hf, hr, heq⟩ := bytesRegion_dword_at regionBase bs (i / 8) hq
+  set dwordAddr := regionBase + BitVec.ofNat 64 (8 * (i / 8)) with hdwa
+  set wordVal := packBytes ((bs.drop (8 * (i / 8))).take 8) with hwv
+  have hptr_eq : (regionBase + BitVec.ofNat 64 i) + signExtend12 (0 : BitVec 12)
+      = regionBase + BitVec.ofNat 64 i := by show _ + (0 : Word) = _; bv_omega
+  have halign' :
+      alignToDword ((regionBase + BitVec.ofNat 64 i) + signExtend12 (0 : BitVec 12)) = dwordAddr := by
+    rw [hptr_eq]; exact alignToDword_add_ofNat_of_aligned halign hover
+  have hvalid' :
+      isValidByteAccess ((regionBase + BitVec.ofNat 64 i) + signExtend12 (0 : BitVec 12)) = true := by
+    rw [hptr_eq]; exact hvalid
+  have lbu := generic_lbu_spec_within rd rs1 (regionBase + BitVec.ofNat 64 i) vOld 0 base
+    dwordAddr wordVal hrd halign' hvalid'
+  rw [hptr_eq] at lbu
+  have hbyte : extractByte wordVal (byteOffset (regionBase + BitVec.ofNat 64 i)) = bs[i]'hi := by
+    rw [byteOffset_add_ofNat_of_aligned halign hover, hwv,
+        extractByte_packBytes _ _ (by omega)
+          (by rw [List.length_take, List.length_drop]; omega),
+        List.getElem_take, List.getElem_drop]
+    congr 1; omega
+  rw [hbyte] at lbu
+  rw [heq]
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hp => by xperm_hyp hp)
+    (cpsTripleWithin_frameR (front ** rest) (pcFree_sepConj hf hr) lbu)
+
+/-- Cross-check: reading byte 9 of a 10-byte region (second dword, byte offset 1)
+    — a cross-dword read the single-`dwordAddr` `hwin` model could not express. -/
+example (base regionBase vOld : Word) (rd rs1 : Reg) (hrd : rd ≠ .x0)
+    (bs : List (BitVec 8)) (hlen : bs.length = 10)
+    (halign : regionBase.toNat % 8 = 0) (hover : regionBase.toNat + 9 < 2 ^ 64)
+    (hvalid : isValidByteAccess (regionBase + BitVec.ofNat 64 9) = true) :
+    cpsTripleWithin 1 base (base + 4)
+      (CodeReq.singleton base (.LBU rd rs1 0))
+      ((rs1 ↦ᵣ (regionBase + BitVec.ofNat 64 9)) ** (rd ↦ᵣ vOld) ** bytesRegion regionBase bs)
+      ((rs1 ↦ᵣ (regionBase + BitVec.ofNat 64 9)) **
+       (rd ↦ᵣ ((bs[9]'(by omega)).zeroExtend 64)) ** bytesRegion regionBase bs) :=
+  bytesRegion_lbu_within rd rs1 regionBase vOld base bs 9 hrd halign (by omega) hover hvalid
+
 end EvmAsm.Rv64
+
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1229,9 +1229,19 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
   byte-packing primitives (`packBytes`, `extractByte_packBytes`, `packDword`)
   were **relocated** from `Evm64/CodeRegion.lean` down to `Rv64/ByteOps.lean`
   (their natural home; one source of truth for both layers). Axiom-clean, 0 sorry.
-  **Next:** `bytesRegion_lbu_within` (read byte `i` across dwords — needs the
-  `alignToDword (alignedBase + i)` arithmetic the loop currently *assumes*), then
-  the list-decode loop + 5-exit reconvergence.
+- ✅ **`bytesRegion_lbu_within` — read byte `i` across dwords** (`MemRegion.lean`).
+  An `LBU` at `regionBase + i` (`i < bs.length`, base dword-aligned, no overflow)
+  reads `bs[i]` — the multi-dword read the single-`dwordAddr` `hwin` model could
+  not express (cross-check: reads byte 9 of a 10-byte / 2-dword region). New
+  supporting lemmas: `alignToDword_add_ofNat_of_aligned`
+  (`alignToDword (base + i) = base + 8*(i/8)`) and `byteOffset_add_ofNat_of_aligned`
+  (`= i % 8`) — the BitVec masking arithmetic the existing loop *assumes*; plus
+  `bytesRegion_dword_at` (extract the `dw`-th dword cell, partial last chunk OK).
+  Composition mirrors `Evm64/Push`: `generic_lbu_spec_within` +
+  `extractByte_packBytes`, framed via `cpsTripleWithin_frameR` + `xperm_hyp`.
+  Axiom-clean, 0 sorry. **Next:** the list-decode loop (single-byte items →
+  `decodeItems_singleByte_run`, then varying-size) + the unified decoder's 5-exit
+  reconvergence.
 - Phase 5: Recursive list decode (iterative with explicit stack)
 - Phase 6: Top-level pipeline (`read_input` -> decode -> `write_output`)
 - **Host I/O ABI**: See `docs/zkvm-host-io-interface.md`; SP1


### PR DESCRIPTION
> Stacked on #8974 (byte-region foundation). Base retargets to `main` once #8974 merges.

## Summary

The keystone read primitive for the RV64 RLP list decoder: an `LBU` reading byte
index `i < bs.length` at `regionBase + i` (base dword-aligned, no address
overflow) yields `bs[i]` — the **multi-dword** read the existing decoder's
single-`dwordAddr` `hwin` model cannot express. All in `EvmAsm/Rv64/MemRegion.lean`.

New supporting lemmas:
- **`byteOffset_add_ofNat_of_aligned`** — `byteOffset (base + i) = i % 8`.
- **`alignToDword_add_ofNat_of_aligned`** — `alignToDword (base + i) = base + 8·(i/8)`.
  (The BitVec masking arithmetic the existing loop currently *assumes* via `hwin`;
  proved via `toNat` + `Nat.and_two_pow_sub_one_eq_mod` + `alignToDword_add_byteOffset`.)
- **`bytesRegion_dword_at`** — extract the `dw`-th dword cell, framing the rest
  (handles the **partial last chunk**, unlike `evmCodeIs_split_at` which needs a
  full dword).
- **`bytesRegion_lbu_within`** — the keystone, composing the dword split + the
  alignment facts + `generic_lbu_spec_within` + `extractByte_packBytes`, framed
  via `cpsTripleWithin_frameR` + `xperm_hyp` (mirroring `Evm64/Push`'s byte read).

A cross-check reads byte 9 of a 10-byte (2-dword) region — the cross-dword read.

## Verification

- Full `lake build` green; `check-no-warnings` (0 under `EvmAsm/`); `check-forbidden-tactics`.
- `#print axioms bytesRegion_lbu_within` / `alignToDword_add_ofNat_of_aligned` →
  `[propext, Classical.choice, Quot.sound]`; 0 sorry. No `bv_decide`.

## Next

The list-decode loop (single-byte items → `decodeItems_singleByte_run`, then
varying-size) + the unified decoder's 5-exit reconvergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)