### PR TITLE
docs(block-logs): derive 200m capture targets

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
@@ -160,6 +160,31 @@ def bvSystemStorageTxindexBytes : Nat := bvSystemStorageLogCapacity * 8
 def bvReceiptRecordCapacity : Nat := bvMtxFullTxCap
 def bvReceiptRecordBytes : Nat := 64
 def bvReceiptRecordsBytes : Nat := bvReceiptRecordCapacity * bvReceiptRecordBytes
+
+/-- Current EEST resource target for Amsterdam/Prague/Osaka stateless blocks. -/
+def bvResourceBlockGasLimit : Nat := 200000000
+
+/-- EVM LOG base gas. A zero-topic, zero-data LOG0 is the cheapest way to
+    increase the number of execution-derived receipt log descriptors. -/
+def bvBlockLogMinGas : Nat := 375
+
+/-- EVM LOG data gas per byte. Topic/base gas can only reduce the number of
+    data bytes that fit inside the same block gas target. -/
+def bvBlockLogDataByteGas : Nat := 8
+
+/-- Full descriptor target for the 200M resource work. This is a target for
+    follow-up resizing/chunking, not the active arena used by the guest today. -/
+def bvBlockLogFullDescTarget : Nat :=
+  bvResourceBlockGasLimit / bvBlockLogMinGas
+def bvBlockLogFullDescBytes : Nat := bvBlockLogFullDescTarget * 256
+def bvBlockLogFullMetaBytes : Nat := bvBlockLogFullDescTarget * 16
+
+/-- Full copied-log-data byte target for the 200M resource work. It deliberately
+    uses a simple upper bound (`gas_limit / LOGDATA_GAS`) so the implementation
+    target covers every execution-specs-valid mix of LOG base/topic/data gas. -/
+def bvBlockLogFullDataBytes : Nat :=
+  bvResourceBlockGasLimit / bvBlockLogDataByteGas
+
 def bvBlockLogDescCapacity : Nat := 128
 def bvBlockLogDescBytes : Nat := bvBlockLogDescCapacity * 256
 def bvBlockLogMetaBytes : Nat := bvBlockLogDescCapacity * 16
@@ -258,6 +283,13 @@ def bmvFullLogWindowArenaBytes : Nat :=
 #guard bvMtxCommittedFullKeyCap = 600000
 #guard bvMtxCommittedFullBytes = 76800000
 #guard bvReceiptRecordsBytes = 609472
+#guard bvResourceBlockGasLimit = 200000000
+#guard bvBlockLogMinGas = 375
+#guard bvBlockLogDataByteGas = 8
+#guard bvBlockLogFullDescTarget = 533333
+#guard bvBlockLogFullDescBytes = 136533248
+#guard bvBlockLogFullMetaBytes = 8533328
+#guard bvBlockLogFullDataBytes = 25000000
 #guard bvBlockLogDescBytes = 32768
 #guard bvBlockLogMetaBytes = 2048
 #guard bvBlockLogDataBytes = 65536

--- a/docs/bmvmx-full-tx-capacity-design.md
+++ b/docs/bmvmx-full-tx-capacity-design.md
@@ -38,7 +38,9 @@ The current `main` implementation has several independent ceilings:
   records, record bloom storage, and record log descriptors derive from
   `bvMtxFullTxCap = 9523`; block-log descriptors, log data bytes, log-list RLP,
   receipt-list scratch/RLP, and consensus receipt descriptors remain separately
-  capped.
+  capped. The 200M block-log capture targets are gas-derived, not tx-derived:
+  `bvBlockLogFullDescTarget = 533333` cheapest LOG0 descriptors and
+  `bvBlockLogFullDataBytes = 25000000` copied LOG data bytes.
 
 ## Decision
 
@@ -150,6 +152,8 @@ The follow-up work should land in separate PRs:
 - Decouple the remaining receipt/log validation capacity from the tx cap and
   connect block-log capture, log-list RLP, receipt-list RLP, and consensus
   descriptor traversal to the log/receipt streaming or digest substrate. The
+  first block-log capture target is static and gas-derived: `533333` descriptors
+  (`200000000 / 375`) and `25000000` copied data bytes (`200000000 / 8`). The
   per-tx receipt record storage is already full-capacity.
 - Full-capacity evidence wrapper: `scripts/codegen-bmvmx-full-capacity-probes.sh`
   now resolves both `bvMtxActiveTxCap` and `bvMtxFullTxCap`, scans available

--- a/docs/eest-200m-resource-audit.md
+++ b/docs/eest-200m-resource-audit.md
@@ -30,8 +30,8 @@ The distinction matters:
 | Committed storage threading | All unique `(recipient, slotKey)` keys reachable under 200M | Active `bvMtxCommittedChunkCapacity = 512`; target `bvMtxCommittedFullKeyCap = 600000` | Gap: migrate upsert/lookup/wiring under `evm-asm-vv4hr.2`. |
 | System storage side capture | All modeled system-call SSTORE rows needed by BAL checks | `bvSystemStorageLogCapacity = 600000`, derived as `2 * 30000000 / 100` for withdrawal plus consolidation system calls at the cheapest SSTORE gas floor | Capacity boundary covered by `evm-asm-vv4hr.7.1`; precise tuple binding/evidence remains under `evm-asm-vv4hr.7.2`/`.7.3` and ungate bead `evm-asm-40igg`. |
 | Receipt records | Up to the supported tx count | `bvReceiptRecordCapacity = bvMtxFullTxCap = 9523`; `bvRecordBloomsBytes` and `bvRecordLogsDescBytes` derive from the same cap | Covered for per-tx record/bloom/descriptor storage; log capture and RLP materialization remain separate. |
-| Block log descriptors | All supported execution-derived logs | `bvBlockLogDescCapacity = 128` | Gap: `evm-asm-vv4hr.3.2`. |
-| Log/RLP bytes | Aggregate log payloads and receipt-list RLP for supported blocks | `bvBlockLogDataBytes = 65536`, `bvLogsRlpArenaBytes = 65536`, `bvReceiptsRlpBytes = 65536`, `bvReceiptListPayloadBytes = 32768`, `bvReceiptConsensusDescCapacity = 128` | Gaps: `evm-asm-vv4hr.3.3` and `evm-asm-vv4hr.3.4`. |
+| Block log descriptors | `200000000 / 375 = 533333` cheapest LOG0 descriptors | Active `bvBlockLogDescCapacity = 128`; target `bvBlockLogFullDescTarget = 533333` | Gap: `evm-asm-vv4hr.3.2` must lift capture to the target or an equivalent streaming design. |
+| Log/RLP bytes | Up to `200000000 / 8 = 25000000` copied LOG data bytes; receipt/log RLP for supported blocks | Active `bvBlockLogDataBytes = 65536`; target `bvBlockLogFullDataBytes = 25000000`; `bvLogsRlpArenaBytes = 65536`, `bvReceiptsRlpBytes = 65536`, `bvReceiptListPayloadBytes = 32768`, `bvReceiptConsensusDescCapacity = 128` remain active caps | Gaps: `evm-asm-vv4hr.3.2`, `evm-asm-vv4hr.3.3`, and `evm-asm-vv4hr.3.4`. |
 | Execution requests hash input | EIP-6110 deposits `8192 * 192`, withdrawals `16 * 76`, consolidations `2 * 116` | `erh_blob = 1572865` | Hash helper covers the deposit body cap. |
 | Execution-derived deposit body staging | Deposit body `8192 * 192 = 1572864`; canonicalized deposit log records `8192 * (80 + 576) = 5373952` before parsing | `c1_dbody = bvMaxDepositRequestBodyBytes = 1572864`, `c1_log_records = bvMaxDepositLogRecordBytes = 5373952` | Covered for deposit-only staging; upstream descriptor/data capture and parser guards remain under `evm-asm-vv4hr.3` / `evm-asm-vv4hr.4`. |
 | System-call payload staging | Witness code plus 100k preloads plus M29 slack | `c1StagingBytes = bsrMaxWitnessBytes + bsrAccountSlotCap * 64 + 16384` | Covered by shared guard for current staging model. |
@@ -62,6 +62,28 @@ same way as `.data` staging buffers. The guest should still reject or report
 precise unsupported status when actual decoded log records exceed the staged or
 streamed target.
 
+## Block Log Capture Bounds
+
+Block-log capture is bounded by execution gas rather than by transaction count.
+The cheapest descriptor-producing opcode is `LOG0` with no data, costing `375`
+gas, so a 200M-gas block can produce at most `200000000 / 375 = 533333`
+execution-derived log descriptors. Each captured descriptor currently uses a
+256-byte descriptor row plus a 16-byte rebased data meta row, making the static
+full-target footprint about 138 MiB (`136533248 + 8533328` bytes).
+
+Copied log data has a separate gas bound. `LOGDATA` costs `8` gas per byte, so
+`200000000 / 8 = 25000000` bytes is a conservative upper target for copied log
+data. Base and topic gas only lower the reachable data byte count, but the simple
+upper bound keeps the implementation target independent of the descriptor/data
+mix in a fixture.
+
+These targets are compatible with the current ZisK memory model as a static
+first implementation target: adding descriptor rows, meta rows, and copied data
+is roughly 163 MiB, below the `.data` to `.sszscratch` RAM window. Later RLP and
+trie work may still choose streaming/chunking, but descriptor/data capture should
+not keep the current `128`/`65536` active caps as semantic limits for accepted
+200M-resource fixtures.
+
 ## Follow-Up Beads
 
 Every discovered 200M resource gap has a P1 child bead:
@@ -75,9 +97,12 @@ Every discovered 200M resource gap has a P1 child bead:
   the system-call SSTORE side-capture row cap. The bound is unique-key based:
   duplicate writes update in place and do not consume additional committed slots.
 - `evm-asm-vv4hr.3`: stream or resize receipt/log materialization so receipt
-  roots and logs bloom are not capped by 128 log descriptors, 128 consensus
-  receipt descriptors, 32 KiB receipt-list scratch, or 64 KiB log/receipt RLP
-  arenas. Per-tx receipt records are already sized to the 9,523 full-tx target.
+  roots and logs bloom are not capped by the active 128 log descriptors, 128
+  consensus receipt descriptors, 32 KiB receipt-list scratch, or 64 KiB
+  log/receipt RLP arenas. The block-log capture target is now named as
+  `bvBlockLogFullDescTarget = 533333` descriptors and
+  `bvBlockLogFullDataBytes = 25000000` copied data bytes; per-tx receipt records
+  are already sized to the 9,523 full-tx target.
 - `evm-asm-vv4hr.4`: make execution-derived EIP-6110 deposit request derivation
   cover the full deposit cap. `c1_dbody` is sized to
   `bvMaxDepositRequestBodyBytes = 8192 * 192 = 1572864`, and `c1_log_records`

--- a/scripts/eest-bal-replay-report.py
+++ b/scripts/eest-bal-replay-report.py
@@ -91,6 +91,11 @@ BV_MTX_ARENA_TX_CAP = 1024
 BMV_FULL_TX_CAPACITY = 9523
 BV_MTX_COMMITTED_CHUNK_CAPACITY = 512
 BV_RECEIPT_RECORD_CAPACITY = BMV_FULL_TX_CAPACITY
+BV_RESOURCE_BLOCK_GAS_LIMIT = 200_000_000
+BV_BLOCK_LOG_MIN_GAS = 375
+BV_BLOCK_LOG_DATA_BYTE_GAS = 8
+BV_BLOCK_LOG_DESC_FULL_TARGET = BV_RESOURCE_BLOCK_GAS_LIMIT // BV_BLOCK_LOG_MIN_GAS
+BV_BLOCK_LOG_DATA_FULL_TARGET = BV_RESOURCE_BLOCK_GAS_LIMIT // BV_BLOCK_LOG_DATA_BYTE_GAS
 BV_BLOCK_LOG_DESC_CAPACITY = 128
 BV_BLOCK_LOG_DATA_BYTES = 65536
 BV_LOGS_RLP_ARENA_BYTES = 65536
@@ -213,7 +218,9 @@ def summarize(
         "receipt_records_required": tx_count,
         "receipt_record_cap": BV_RECEIPT_RECORD_CAPACITY,
         "block_log_desc_cap": BV_BLOCK_LOG_DESC_CAPACITY,
+        "block_log_desc_full_target": BV_BLOCK_LOG_DESC_FULL_TARGET,
         "block_log_data_cap": BV_BLOCK_LOG_DATA_BYTES,
+        "block_log_data_full_target": BV_BLOCK_LOG_DATA_FULL_TARGET,
         "logs_rlp_cap": BV_LOGS_RLP_ARENA_BYTES,
         "receipts_rlp_cap": BV_RECEIPTS_RLP_BYTES,
         "receipt_list_payload_cap": BV_RECEIPT_LIST_PAYLOAD_BYTES,
@@ -401,7 +408,9 @@ def main() -> int:
         "receipt_records_required",
         "receipt_record_cap",
         "block_log_desc_cap",
+        "block_log_desc_full_target",
         "block_log_data_cap",
+        "block_log_data_full_target",
         "logs_rlp_cap",
         "receipts_rlp_cap",
         "receipt_list_payload_cap",


### PR DESCRIPTION
## Summary
- add named gas-derived 200M block-log descriptor/data targets in BlockVerdictParams while leaving active guest caps unchanged
- document the LOG0/LOGDATA derivation and ZisK RAM impact in the 200M resource audit/design docs
- expose the full-target values in the BAL replay report output

Bead: evm-asm-vv4hr.3.2.1

## Verification
- rtk lake build EvmAsm.Codegen.Programs.BlockVerdictParams
- rtk python3 -m py_compile scripts/eest-bal-replay-report.py
- rtk python3 scripts/eest-bal-replay-report.py --help
- rtk scripts/check-file-size.sh
- rtk scripts/check-unimported.sh
- rtk rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/BlockVerdictParams.lean scripts/eest-bal-replay-report.py docs/eest-200m-resource-audit.md docs/bmvmx-full-tx-capacity-design.md (no matches)
- rtk git diff --check
- rtk lake build (passes; known pre-existing LeanRV64D/RiscvExtras.lean deprecation warning only)