### PR TITLE
fix(eip7702): preserve cold access receipt gas

### DIFF
--- a/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
+++ b/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
@@ -468,9 +468,10 @@ def blockVerdictReceiptGasEip8037AdjustFunction : String :=
   -- authority did not already hold a delegation indicator, the net auth-base
   -- state component. `tx_total_state_gas - tx_exec_state_gas` distinguishes
   -- that case from the already-delegated path, which is already correct with
-  -- just PER_AUTH_BASE_COST. The 5000-per-auth subtraction matches the
-  -- receipt-side refund interaction observed in execution-specs for this
-  -- settlement-derived branch.
+  -- just PER_AUTH_BASE_COST. The 2500-per-auth subtraction preserves the
+  -- delegated target's cold-account delta in receipt gas while removing the
+  -- receipt-side state settlement refund observed in execution-specs for this
+  -- branch.
   "  add t3, t3, t6\n" ++
   "  ld t4, 104(sp); beqz t4, .Lbvrga_type4_store_regular\n" ++
   "  slli t1, s6, 3; add t4, t4, t1; ld t4, 0(t4)\n" ++
@@ -479,7 +480,7 @@ def blockVerdictReceiptGasEip8037AdjustFunction : String :=
   "  bleu t5, t0, .Lbvrga_type4_have_net_auth_state\n" ++
   "  mv t5, t0\n" ++
   ".Lbvrga_type4_have_net_auth_state:\n" ++
-  "  la t1, bvrga_auth_count; ld t1, 0(t1); li t4, 5000; mul t4, t4, t1\n" ++
+  "  la t1, bvrga_auth_count; ld t1, 0(t1); li t4, 2500; mul t4, t4, t1\n" ++
   "  bleu t5, t4, .Lbvrga_type4_store_regular\n" ++
   "  sub t5, t5, t4; add t3, t3, t5\n" ++
   ".Lbvrga_type4_store_regular:\n" ++


### PR DESCRIPTION
## Summary
- adjust the type-4 receipt gas settlement-derived branch to subtract 2500/auth instead of 5000/auth
- preserves the delegated target cold-account delta in cumulative receipt gas for pointer_to_static_reentry
- follows up #8977 after its self-sponsored receipt-gas repair

## Verification
- scripts/codegen-eest-stateless-check.sh --skip 22600 --limit 1 --max-failures 1
- scripts/codegen-eest-stateless-check.sh --skip 22144 --limit 1 --max-failures 1
- scripts/codegen-eest-stateless-check.sh --skip 22175 --limit 1 --max-failures 1

Bead: evm-asm-r401q