### PR TITLE
fix(creation): record top-level created account effects

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
@@ -6,6 +6,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.NonstorageEffectLog
 
 namespace EvmAsm.Codegen
 
@@ -247,6 +248,7 @@ def blockVerdictSingleTxCreationRuntimeFunction : String :=
   "  sd ra, 0(sp)\n" ++
   "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
   "  mv s0, a0\n" ++
+  "  la t0, bv_creation_ctx_ptr; sd s0, 0(t0)  # stable across runtime dispatcher\n" ++
   "  mv s1, a1\n" ++
   "  la a1, bv_runtime_payload\n" ++
   "  mv a2, s1\n" ++
@@ -263,6 +265,17 @@ def blockVerdictSingleTxCreationRuntimeFunction : String :=
   "  la t4, bv_runtime_refund_counter; sd a1, 0(t4)\n" ++
   "  la t4, bv_tx_status_arr; sd a2, 0(t4)\n" ++
   "  la t4, bv_tx_is_creation_arr; sd s2, 0(t4)\n" ++
+  -- Successful top-level STOP creation makes the created account alive with
+  -- the transaction value as balance and nonce 1. Record that execution-derived
+  -- effect before BAL all-account non-storage comparisons run.
+  "  beqz a2, .Lbvcr_created_effect_done\n" ++
+  "  la a0, bv_create_addr\n" ++
+  "  la a1, nse_zero_bal\n" ++
+  "  la a2, bv_creation_ctx_ptr; ld a2, 0(a2); addi a2, a2, 96\n" ++
+  "  li a3, 0\n" ++
+  "  li a4, 1\n" ++
+  "  jal ra, record_nonstorage_effect\n" ++
+  ".Lbvcr_created_effect_done:\n" ++
   "  la t4, bv_last_log_start; ld t5, 0(t4); la t4, bv_tx_log_window; sd t5, 0(t4)\n" ++
   "  la t4, bv_last_log_count; ld t5, 0(t4); la t4, bv_tx_log_window; sd t5, 8(t4)\n" ++
   "  la t4, runtime_tx_calldata_floor; ld t5, 0(t4)\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -645,6 +645,9 @@ def ziskStatelessVerdictV2DataSection : String :=
   ".balign 32\n" ++
   "bv_tx_recipient_code_hash:\n  .zero 32\n" ++
   "bv_create_addr:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "bv_creation_ctx_ptr:\n  .zero 8\n" ++
+  ".balign 32\n" ++
   "bbcv_sender_addr:\n  .zero 32\n" ++
   "bbcv_create_addr:\n  .zero 32\n" ++
   "bbcv_create2_salt:\n  .zero 32\n" ++
@@ -658,7 +661,6 @@ def ziskStatelessVerdictV2DataSection : String :=
   "ac_digest:\n  .zero 32\n" ++
   "bbcv_stop_code_hash:\n" ++
   "  .quad 0x14281e7a9e7836bc, 0x7d818f8229424636, 0x9165d677b4f71266, 0x8ac9bc64e0a996ff\n" ++
-  ".balign 32\n" ++
   "chahsr_state_root:\n  .zero 32\n" ++
   ".balign 8\n" ++
   "chahsr_acct_struct:\n  .zero 104\n" ++

--- a/EvmAsm/Codegen/Programs/EvmDispatchUnits.lean
+++ b/EvmAsm/Codegen/Programs/EvmDispatchUnits.lean
@@ -87,7 +87,11 @@ def runtimeDispatcherGasCaptureProbeUnit : BuildUnit :=
       +136 null-initcode helper status         (expect 3)
       +144 runtime_count after null initcode   (expect 0)
       +152 long-initcode helper status         (expect 3)
-      +160 runtime_count after long initcode   (expect 0) -/
+      +160 runtime_count after long initcode   (expect 0)
+      +168 exec_nonstorage_effect_count        (expect 1)
+      +176 created effect addr[0]              (expect 0xA5)
+      +184 created effect post_balance[0]      (expect 0x42)
+      +192 created effect post_nonce           (expect 1) -/
 def ziskCreationRuntimeWindowsProbeUnit : BuildUnit := {
   body        := []
   prologueAsm :=
@@ -100,6 +104,8 @@ def ziskCreationRuntimeWindowsProbeUnit : BuildUnit := {
     "  la t1, crw_stop_initcode; sd t1, 56(t0)\n" ++
     "  li t1, 1; sd t1, 64(t0)\n" ++
     "  li t1, 0x42; sd t1, 96(t0)\n" ++
+    "  la t0, bv_create_addr; li t1, 0xA5; sb t1, 0(t0)\n" ++
+    "  la t0, exec_nonstorage_effect_count; sd zero, 0(t0)\n" ++
     -- Synthetic exec payload: just enough block env for staging.
     "  la t2, crw_exec\n" ++
     "  li t1, 0xC0; sb t1, 32(t2)\n" ++
@@ -120,6 +126,10 @@ def ziskCreationRuntimeWindowsProbeUnit : BuildUnit := {
     "  la t0, bv_receipts_completeness_shape; ld t1, 0(t0); sd t1, 64(s0)\n" ++
     "  la t0, bv_receipts_enforce_enabled; ld t1, 0(t0); sd t1, 72(s0)\n" ++
     "  la t0, bvgr_tx_exec_state_gas; ld t1, 0(t0); sd t1, 80(s0)\n" ++
+    "  la t0, exec_nonstorage_effect_count; ld t1, 0(t0); sd t1, 168(s0)\n" ++
+    "  la t0, exec_nonstorage_effect_log; lbu t1, 0(t0); sd t1, 176(s0)\n" ++
+    "  lbu t1, 64(t0); sd t1, 184(s0)\n" ++
+    "  ld t1, 104(t0); sd t1, 192(s0)\n" ++
     -- Unsupported non-STOP initcode must not populate runtime_count.
     "  la t0, bvgr_runtime_count; sd zero, 0(t0)\n" ++
     "  la t0, crw_ctx; sd zero, 0(t0); li t1, 1; sd t1, 48(t0); la t1, crw_bad_initcode; sd t1, 56(t0); li t1, 1; sd t1, 64(t0)\n" ++
@@ -174,6 +184,8 @@ def ziskCreationRuntimeWindowsProbeUnit : BuildUnit := {
     recordNonstorageEffectFunction ++ "\n" ++
     nonstorageEffectLatestBalanceFunction ++ "\n" ++
     u256SubBeFunction ++ "\n" ++
+    witnessCodesLookupByHashFunction ++ "\n" ++
+    rlpListCountItemsFunction ++ "\n" ++
     emitRuntimeDispatcherCallablePrologue
   epilogueAsm := emitDispatcherCallableEpilogue tinyInterpRegistry evmAddEpilogue
   dataAsm     :=
@@ -193,7 +205,13 @@ def ziskCreationRuntimeWindowsProbeUnit : BuildUnit := {
     "bv_runtime_calldata_floor:\n  .zero 8\n" ++
     "bv_tx_status_arr:\n  .zero 8192\n" ++
     "bv_tx_is_creation_arr:\n  .zero 8192\n" ++
+    "bv_create_addr:\n  .zero 32\n" ++
+    ".balign 8\n" ++
+    "bv_creation_ctx_ptr:\n  .zero 8\n" ++
     "bv_tx_log_window:\n  .zero 16\n" ++
+    ".balign 32\n" ++
+    "wclh_scratch_hash:\n  .zero 32\n" ++
+    ".balign 8\n" ++
     "bv_last_log_start:\n  .zero 8\n" ++
     "bv_last_log_count:\n  .zero 8\n" ++
     "bv_receipts_completeness_shape:\n  .zero 8\n" ++

--- a/scripts/codegen-zisk-creation-runtime-windows-check.sh
+++ b/scripts/codegen-zisk-creation-runtime-windows-check.sh
@@ -45,9 +45,9 @@ if not out_path.exists():
     print(Path('gen-out/zisk_creation_runtime_windows.emu.log').read_text()[-2000:], file=sys.stderr)
     sys.exit(1)
 out = out_path.read_bytes()
-if len(out) < 168:
-    out += b'\x00' * (168 - len(out))
-words = [struct.unpack_from('<Q', out, i * 8)[0] for i in range(21)]
+if len(out) < 200:
+    out += b'\x00' * (200 - len(out))
+words = [struct.unpack_from('<Q', out, i * 8)[0] for i in range(25)]
 expected = [
     0,      # supported helper status
     1,      # runtime_count after supported
@@ -65,6 +65,10 @@ expected = [
     2, 0,   # non-creation status, runtime_count remains 0
     3, 0,   # null initcode status, runtime_count remains 0
     3, 0,   # long initcode status, runtime_count remains 0
+    1,      # created-account nonstorage effect count
+    0xA5,   # created effect address first byte
+    0x42,   # copied post-balance first byte
+    1,      # created account post nonce
 ]
 labels = [
     'supported_status', 'supported_runtime_count', 'tx_status', 'gas_left',
@@ -72,7 +76,8 @@ labels = [
     'receipt_enforce', 'exec_state_gas', 'non_stop_status', 'non_stop_count',
     'bad_context_status', 'bad_context_count', 'non_creation_status',
     'non_creation_count', 'null_initcode_status', 'null_initcode_count',
-    'long_initcode_status', 'long_initcode_count',
+    'long_initcode_status', 'long_initcode_count', 'nse_effect_count',
+    'nse_created_addr0', 'nse_created_post_balance0', 'nse_created_post_nonce',
 ]
 failed = False
 for label, got, exp in zip(labels, words, expected):


### PR DESCRIPTION
## Summary
- record the created account non-storage effect for successful supported top-level STOP creation txs
- add a stable creation context scratch pointer for the post-balance source after runtime dispatch
- extend the creation-runtime ziskemu smoke to assert effect count, created address, post balance, and post nonce

## Verification
- lake build
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- scripts/check-forbidden-tactics.sh
- scripts/codegen-zisk-creation-runtime-windows-check.sh
- scripts/codegen-eest-stateless-check.sh --filter eip7708_eth_transfer_logs/transfer_logs/contract_creation_tx --limit 10 --max-failures 1 --steps 1000000000

Directed by @pirapira; implemented by Codex.