### PR TITLE
fix(eip7702): stage callvalue for delegated set-code receipts

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictContractStage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictContractStage.lean
@@ -167,10 +167,13 @@ def stageRuntimePayloadCodeFunction : String :=
   "  li t6, 20; beq t5, t6, .Lsrpc_ad_done\n" ++
   "  li a5, 19; sub a5, a5, t5; add a5, t3, a5; lbu a6, 0(a5); add a5, t4, t5; sb a6, 0(a5); addi t5, t5, 1; j .Lsrpc_ad\n" ++
   ".Lsrpc_ad_done:\n" ++
-  -- CALLVALUE (word 3 -> +96): 32-byte copy of ctx value (ctx+96).
-  "  addi t3, s1, 96\n" ++
-  "  ld a5, 0(t3); sd a5, 96(s5); ld a5, 8(t3); sd a5, 104(s5)\n" ++
-  "  ld a5, 16(t3); sd a5, 112(s5); ld a5, 24(t3); sd a5, 120(s5)\n" ++
+  -- CALLVALUE (word 3 -> +96): context value is stored BE in the tx context;
+  -- reverse it into the low-limb-first EVM stack-word layout that env loads push.
+  "  addi t3, s1, 96; addi t4, s5, 96; li t5, 0\n" ++
+  ".Lsrpc_cv:\n" ++
+  "  li t6, 32; beq t5, t6, .Lsrpc_cv_done\n" ++
+  "  add a5, t3, t5; lbu a6, 0(a5); li a5, 31; sub a5, a5, t5; add a5, t4, a5; sb a6, 0(a5); addi t5, t5, 1; j .Lsrpc_cv\n" ++
+  ".Lsrpc_cv_done:\n" ++
   -- Trailer (relative to env_base s5): SLOTNUM@+416 (zero), gas@+448,
   -- validate@+456, is_creation@+464, witness lens@+472/+480/+488 (zero).
   "  ld t3, 40(s1); sd t3, 448(s5)        # gas limit (ctx tx gas)\n" ++

--- a/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
+++ b/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
@@ -469,9 +469,9 @@ def blockVerdictReceiptGasEip8037AdjustFunction : String :=
   -- state component. `tx_total_state_gas - tx_exec_state_gas` distinguishes
   -- that case from the already-delegated path, which is already correct with
   -- just PER_AUTH_BASE_COST. The 2500-per-auth subtraction preserves the
-  -- delegated target's cold-account delta in receipt gas while removing the
-  -- receipt-side state settlement refund observed in execution-specs for this
-  -- branch.
+  -- delegated target's cold-account delta in receipt gas. Execution-specs
+  -- receipt gas includes this full net auth-state component; do not apply the
+  -- 2500 state-clear refund here.
   "  add t3, t3, t6\n" ++
   "  ld t4, 104(sp); beqz t4, .Lbvrga_type4_store_regular\n" ++
   "  slli t1, s6, 3; add t4, t4, t1; ld t4, 0(t4)\n" ++
@@ -480,9 +480,7 @@ def blockVerdictReceiptGasEip8037AdjustFunction : String :=
   "  bleu t5, t0, .Lbvrga_type4_have_net_auth_state\n" ++
   "  mv t5, t0\n" ++
   ".Lbvrga_type4_have_net_auth_state:\n" ++
-  "  la t1, bvrga_auth_count; ld t1, 0(t1); li t4, 2500; mul t4, t4, t1\n" ++
-  "  bleu t5, t4, .Lbvrga_type4_store_regular\n" ++
-  "  sub t5, t5, t4; add t3, t3, t5\n" ++
+  "  add t3, t3, t5\n" ++
   ".Lbvrga_type4_store_regular:\n" ++
   "  j .Lbvrga_type4_store_adjusted\n" ++
   ".Lbvrga_type4_check_state:\n" ++


### PR DESCRIPTION
## Summary
- reverse staged CALLVALUE into the EVM env word layout before delegated runtime execution
- keep the full EIP-8037 auth-state component in type-4 receipt gas accounting

Refs bead evm-asm-m9ajy.

## Verification
- lake exe codegen --program stateless_guest --halt linux93 -o gen-out/eest-m9ajy-repro/stateless_guest_final
- ziskemu exact row 22312, then byte-compare against fixture statelessOutputBytes: match=True
- ziskemu nearby rows 22306 and 22309, then byte-compare against fixture statelessOutputBytes: match=True for both
- scripts/check-forbidden-tactics.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- scripts/check-no-warnings.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' edited files returned no matches

Directed by @pirapira; implemented by Codex.