### PR TITLE
fix(eip7702): keep oog set-code block gas normalized

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictExactGas.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictExactGas.lean
@@ -56,6 +56,7 @@ def blockVerdictExactGasCheck : String :=
   "  la a3, bvgr_block_gas_increments\n" ++
   "  la a4, bvgr_before_refund\n" ++
   "  la a5, bv_tx_status_arr\n" ++
+  "  la a6, bvgr_tx_total_state_gas\n" ++
   "  jal ra, block_verdict_failed_type4_auth_regular_adjust\n" ++
   "  la t5, bv_exec_p; ld t4, 0(t5); addi a0, t4, 420; jal ra, bgv_u64le   # header.gas_used\n" ++
   "  la t2, bv_exact_header_gas_used; sd a0, 0(t2)\n" ++

--- a/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
+++ b/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
@@ -529,7 +529,9 @@ def blockVerdictReceiptGasEip8037AdjustFunction : String :=
     supported rows. For failed type-4 execution (REVERT/exceptional status 0),
     execution-specs still counts `PER_AUTH_BASE_COST * auth_count` in the block
     regular dimension. This helper raises `regular_inc[i]` to at least
-    `before_refund[i] + 7500 * auth_count` for failed type-4 transactions.
+    `before_refund[i] + 7500 * auth_count` for failed type-4 transactions,
+    except when exact-gas normalization has already produced
+    `before_refund[i] - tx_state_gas[i]` for an OOG path.
 
     Decode failures are non-gating: the caller keeps the previous regular
     increment. -/
@@ -546,6 +548,7 @@ def blockVerdictFailedType4AuthRegularAdjustFunction : String :=
   "  mv s3, a3                   # regular increments\n" ++
   "  mv s4, a4                   # before-refund increments\n" ++
   "  mv s5, a5                   # tx status array\n" ++
+  "  sd a6, 104(sp)              # tx_state_gas array (optional)\n" ++
   "  beqz s2, .Lbvf4ar_done\n" ++
   "  li t0, 4; bltu s1, t0, .Lbvf4ar_done\n" ++
   "  slli s7, s2, 2\n" ++
@@ -582,7 +585,14 @@ def blockVerdictFailedType4AuthRegularAdjustFunction : String :=
   "  jal ra, rlp_list_count_items\n" ++
   "  bnez a0, .Lbvf4ar_next\n" ++
   "  slli t0, s6, 3\n" ++
-  "  add t1, s4, t0; ld t2, 0(t1)\n" ++
+  "  add t1, s4, t0; ld t2, 0(t1)          # before_refund increment\n" ++
+  "  add t1, s3, t0; ld t3, 0(t1)          # current normalized regular increment\n" ++
+  "  ld t4, 104(sp); beqz t4, .Lbvf4ar_compute_floor\n" ++
+  "  bltu t2, t3, .Lbvf4ar_compute_floor\n" ++
+  "  sub t5, t2, t3\n" ++
+  "  add t4, t4, t0; ld t4, 0(t4)          # tx_state_gas\n" ++
+  "  beq t5, t4, .Lbvf4ar_next             # OOG path already normalized as before_refund - state\n" ++
+  ".Lbvf4ar_compute_floor:\n" ++
   "  la t1, bvrga_auth_count; ld t1, 0(t1); li t3, 7500; mul t1, t1, t3\n" ++
   "  add t2, t2, t1; bltu t2, t1, .Lbvf4ar_next\n" ++
   "  add t1, s3, t0; ld t3, 0(t1); bgeu t3, t2, .Lbvf4ar_next\n" ++


### PR DESCRIPTION
## Summary
- pass net EIP-8037 tx state gas into the failed type-4 exact block-gas adjustment
- skip the type-4 auth-base regular uplift when the regular increment is already normalized as before_refund - tx_state_gas for OOG rows
- preserve the failed/revert uplift used by neighboring set_code_to_sstore rows

Stacked on #8985. Bead: evm-asm-0bzlb.

## Verification
- lake exe codegen --program zisk_stateless_verdict_v2 --halt linux93 -o gen-out/eest-0bzlb-repro/zisk_stateless_verdict_v2_debug_cond
- row 22291 verdict debug: verdict=1 bv_fail=0 exact_header_gas_used=746330 exact_expected_gas_used=746330 receipt1_cumulative=781520
- row 22306 verdict debug: verdict=1 bv_fail=0 exact_header_gas_used=43521 exact_expected_gas_used=43521 receipt1_cumulative=78711
- lake exe codegen --program stateless_guest --halt linux93 -o gen-out/eest-0bzlb-repro/stateless_guest_cond
- full guest byte-compare against fixture statelessOutputBytes: rows 22291, 22306, 22309, and 22312 all match
- scripts/check-forbidden-tactics.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- scripts/check-no-warnings.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' edited files returned no matches

Directed by @pirapira; implemented by Codex.