### PR TITLE
test(eip6110): cover deposit-derived requests hash

### DIFF
--- a/EvmAsm/Codegen/Programs/DepositDerivationE2E.lean
+++ b/EvmAsm/Codegen/Programs/DepositDerivationE2E.lean
@@ -24,6 +24,7 @@ import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.MaterializeLogRecords
 import EvmAsm.Codegen.Programs.ParseDepositRequests
+import EvmAsm.Codegen.Programs.AssembleExecutionRequests
 
 namespace EvmAsm.Codegen
 
@@ -33,9 +34,12 @@ open EvmAsm.Rv64
     Input (after the ziskemu length wrapper at 0x40000000):
       bytes 8.. : the 576-byte DepositEvent ABI payload (one deposit log's data)
     Output (at 0xa0010000):
-      +0  status (0 ok / 1 malformed deposit)
-      +8  total deposit-request bytes written (expect 192)
-      +16 the 192-byte deposit body (pubkey48 || wc32 || amount8 || sig96 || index8). -/
+      +0   c1_dstatus-style parse status (0 ok / 1 malformed deposit)
+      +8   c1_dlen-style total deposit-request bytes written (expect 192)
+      +16  the 192-byte deposit body (pubkey48 || wc32 || amount8 || sig96 || index8)
+      +208 c1_erh_status-style verify(zero header hash) (expect 1 mismatch)
+      +216 c1_erh_status-style verify(correct derived hash) (expect 0 match)
+      +224 c1_erh_status-style verify(corrupted header hash) (expect 1 mismatch). -/
 def ziskDepositDerivationE2EPrologue : String :=
   "  li sp, 0xa0050000\n" ++
   "  li a6, 0x40000000\n" ++
@@ -66,6 +70,7 @@ def ziskDepositDerivationE2EPrologue : String :=
   -- parse_deposit_requests(records, 1, body, status)
   "  la a0, dde_records\n  li a1, 1\n  la a2, dde_body\n  la a3, dde_status\n" ++
   "  jal ra, parse_deposit_requests\n" ++
+  "  la t0, dde_len; sd a0, 0(t0)\n" ++
   -- output: status, total bytes, then the 192-byte body
   "  li t0, 0xa0010000\n" ++
   "  la t1, dde_status; ld t2, 0(t1); sd t2, 0(t0)\n" ++
@@ -75,10 +80,36 @@ def ziskDepositDerivationE2EPrologue : String :=
   "  beqz t4, .Ldde_dd\n" ++
   "  lbu t5, 0(t1); sb t5, 0(t3); addi t1, t1, 1; addi t3, t3, 1; addi t4, t4, -1; j .Ldde_dump\n" ++
   ".Ldde_dd:\n" ++
+  -- Verify the execution-derived deposit body against a matching and forged header.requests_hash.
+  -- This mirrors BlockVerdictReceiptsTail's c1_dbody/c1_dlen -> requests_hash_verify flow.
+  "  la t0, dde_hash; sd zero, 0(t0); sd zero, 8(t0); sd zero, 16(t0); sd zero, 24(t0)\n" ++
+  "  la a0, dde_body; la t0, dde_len; ld a1, 0(t0); li a2, 0; li a3, 0; li a4, 0; li a5, 0\n" ++
+  "  la a6, dde_hash; la a7, dde_section\n" ++
+  "  jal ra, requests_hash_verify\n" ++
+  "  li t0, 0xa0010000; sd a0, 208(t0)\n" ++
+  "  la t1, rhv_hash; la t2, dde_hash; li t3, 32\n" ++
+  ".Ldde_hash_cp:\n" ++
+  "  beqz t3, .Ldde_hash_cpd\n" ++
+  "  lbu t4, 0(t1); sb t4, 0(t2); addi t1, t1, 1; addi t2, t2, 1; addi t3, t3, -1; j .Ldde_hash_cp\n" ++
+  ".Ldde_hash_cpd:\n" ++
+  "  la a0, dde_body; la t0, dde_len; ld a1, 0(t0); li a2, 0; li a3, 0; li a4, 0; li a5, 0\n" ++
+  "  la a6, dde_hash; la a7, dde_section\n" ++
+  "  jal ra, requests_hash_verify\n" ++
+  "  li t0, 0xa0010000; sd a0, 216(t0)\n" ++
+  "  la t0, dde_hash; lbu t1, 0(t0); xori t1, t1, 0xff; sb t1, 0(t0)\n" ++
+  "  la a0, dde_body; la t0, dde_len; ld a1, 0(t0); li a2, 0; li a3, 0; li a4, 0; li a5, 0\n" ++
+  "  la a6, dde_hash; la a7, dde_section\n" ++
+  "  jal ra, requests_hash_verify\n" ++
+  "  li t0, 0xa0010000; sd a0, 224(t0)\n" ++
   "  j .Ldde_done\n" ++
   materializeLogRecordsFunction ++ "\n" ++
   parseDepositRequestsFunction ++ "\n" ++
   extractDepositDataFunction ++ "\n" ++
+  requestsHashVerifyFunction ++ "\n" ++
+  assembleExecutionRequestsFunction ++ "\n" ++
+  executionRequestsHashFunction ++ "\n" ++
+  bgvU32leFunction ++ "\n" ++
+  zkvmSha256Function ++ "\n" ++
   ".Ldde_done:"
 
 def ziskDepositDerivationE2EDataSection : String :=
@@ -104,7 +135,15 @@ def ziskDepositDerivationE2EDataSection : String :=
   "dde_records:\n  .zero 1024\n" ++
   ".balign 8\n" ++
   "dde_body:\n  .zero 256\n" ++
-  "dde_status:\n  .zero 8\n"
+  "dde_status:\n  .zero 8\n" ++
+  "dde_len:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "dde_hash:\n  .zero 32\n" ++
+  "rhv_hash:\n  .zero 32\n" ++
+  ".balign 8\n" ++
+  "dde_section:\n  .zero 1024\n" ++
+  executionRequestsHashShaDataSection ++ "\n" ++
+  executionRequestsHashDataSection
 
 def ziskDepositDerivationE2EProbeUnit : BuildUnit := {
   body        := NOP

--- a/scripts/codegen-zisk-deposit-derivation-e2e-check.sh
+++ b/scripts/codegen-zisk-deposit-derivation-e2e-check.sh
@@ -4,8 +4,9 @@
 # End-to-end deposit-request derivation: a synthesized M26 descriptor for a real
 # DepositEvent (address/topic0 stored little-endian) + its 576-byte ABI payload ->
 # materialize_log_records (LE->BE canonicalization) -> parse_deposit_requests ->
-# extract_deposit_data -> the 192-byte deposit body. Confirms materialize's OUTPUT
-# record format agrees with what parse_deposit_requests consumes.
+# extract_deposit_data -> the 192-byte deposit body. Then feed that execution-derived
+# deposit body through requests_hash_verify with empty withdrawal/consolidation bodies
+# and assert the valid derived hash accepts while a forged header hash rejects.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
@@ -49,11 +50,19 @@ d = open('gen-out/zisk_dde.output', 'rb').read()
 status = struct.unpack('<Q', d[0:8])[0]
 total = struct.unpack('<Q', d[8:16])[0]
 body = d[16:16 + 192]
+verify_zero = struct.unpack('<Q', d[208:216])[0]
+verify_match = struct.unpack('<Q', d[216:224])[0]
+verify_corrupt = struct.unpack('<Q', d[224:232])[0]
 exp = open('gen-out/zisk_dde.expect', 'rb').read()
-ok = (status == 0 and total == 192 and body == exp)
-print(f"  status={status} total={total} body_match={body == exp}")
+ok = (status == 0 and total == 192 and body == exp and verify_zero == 1 and verify_match == 0 and verify_corrupt == 1)
+print(
+    f"  c1_dstatus={status} c1_dlen={total} body_match={body == exp} "
+    f"c1_erh_status(zero)={verify_zero} c1_erh_status(correct)={verify_match} "
+    f"c1_erh_status(corrupt)={verify_corrupt}"
+)
 if not ok:
-    print("  FAIL: end-to-end deposit derivation incorrect")
+    print("  FAIL: derived deposit body did not yield sound requests_hash verification")
+    print("  (expect status=0, total=192, body_match=True, verify(zero)=1, verify(correct)=0, verify(corrupt)=1)")
     raise SystemExit(1)
-print("  PASS: descriptor -> materialize -> parse_deposit_requests -> 192-byte deposit body")
+print("  PASS: descriptor -> materialize -> parse_deposit_requests -> derived deposit requests_hash accept/reject")
 PY


### PR DESCRIPTION
## Summary
- extend zisk_deposit_derivation_e2e so the parsed deposit-log body feeds requests_hash_verify
- keep c1_dstatus/c1_dlen-style output visible and add c1_erh_status-style zero/correct/corrupt checks
- update the check script to assert derived deposit requests_hash accepts the correct header hash and rejects a forged one

Bead: evm-asm-8uld3.2.3.3.3.3

Verification:
- lake build EvmAsm.Codegen.Programs.DepositDerivationE2E
- scripts/codegen-zisk-deposit-derivation-e2e-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- scripts/check-progress.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/DepositDerivationE2E.lean scripts/codegen-zisk-deposit-derivation-e2e-check.sh (no matches)
- git diff --check
- lake build
- scripts/check-no-warnings.sh

Directed by @pirapira; implemented by Codex.