### PR TITLE
fix(eip7702): drop double-counted selfdestruct receipt gas correction

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -47,18 +47,19 @@ def blockVerdictReceiptsTail : String :=
   "  la a5, bvgr_block_gas_increments\n" ++
   "  la a6, bvgr_tx_exec_state_gas\n" ++
   "  jal ra, block_verdict_receipt_gas_eip8037_adjust\n" ++
-  -- EIP-7702 SELFDESTRUCT delegated-code rows expose one more receipt-only
-  -- regular-gas correction after the generic type-4 adjustment above. The
-  -- exact block gas check is already governed by the EIP-8037 state dimension
-  -- for this shape, but receipts in execution-specs use tx_gas_used_after_refund
-  -- and include the executed SELFDESTRUCT regular path. Keep this narrow:
-  -- single tx, type-4, and the runtime SELFDESTRUCT staging flag set by the
-  -- handler, not mere bytecode containment.
-  "  la t2, bvgr_arena_tx_count; ld t2, 0(t2); li t3, 1; bne t2, t3, .Lbv_receipt_sd_skip\n" ++
-  "  la t2, bv_simple_transfer_tx; ld t2, 160(t2); li t3, 4; bne t2, t3, .Lbv_receipt_sd_skip\n" ++
-  "  la t0, evm_selfdestruct_staged; ld t0, 0(t0); beqz t0, .Lbv_receipt_sd_skip\n" ++
-  "  la t4, bvgr_receipt_gas_increments; ld t5, 0(t4); li t6, 32690; add t5, t5, t6; sd t5, 0(t4); j .Lbv_receipt_sd_skip\n" ++
-  ".Lbv_receipt_sd_skip:\n" ++
+  -- NOTE (msdfw): a previous narrow EIP-7702 SELFDESTRUCT receipt correction
+  -- here unconditionally added 32690 to the single-tx type-4 receipt increment
+  -- whenever evm_selfdestruct_staged was set. That was a pre-8977 workaround for
+  -- when block_verdict_receipt_gas_eip8037_adjust under-counted the per-auth
+  -- state component. After PR #8977 the generic type-4 adjust adds the full
+  -- per-authorization state component (42690) on the single-auth path, so the
+  -- runtime regular increment already reconstructs tx_gas_used_after_refund for
+  -- delegated SELFDESTRUCT rows (e.g. set_code_to_self_destruct balance_1: the
+  -- receipt is 128929 + 42690 = 171619, matching execution-specs). The extra
+  -- +32690 double-counted and produced a spurious receipts-root mismatch
+  -- (bv_fail=53). The other set_code_to_self_destruct parametrizations are
+  -- conservative-accept shapes whose verdict does not depend on the receipt
+  -- increment, so dropping this correction is safe.
   "  la t2, bvgr_arena_tx_count; ld t2, 0(t2); li t3, 1; bne t2, t3, .Lbv_receipt_ecc_skip\n" ++
   "  la t2, bv_simple_transfer_tx; ld t2, 160(t2); li t3, 4; bne t2, t3, .Lbv_receipt_ecc_skip\n" ++
   "  la t0, ecc_same_block_hit; ld t0, 0(t0); beqz t0, .Lbv_receipt_ecc_skip\n" ++


### PR DESCRIPTION
## Summary
- Remove the narrow EIP-7702 SELFDESTRUCT receipt-gas correction in `block_verdict`'s receipts tail (`EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean`) that unconditionally added `32690` to the single-tx type-4 receipt increment whenever `evm_selfdestruct_staged` was set.
- That correction was a pre-#8977 workaround for when `block_verdict_receipt_gas_eip8037_adjust` under-counted the per-authorization state component. After #8977 the generic type-4 adjust already adds the full per-auth state component (`42690`) on the single-auth path, so the runtime regular increment already reconstructs `tx_gas_used_after_refund` for delegated SELFDESTRUCT rows. The extra `+32690` double-counted and produced a spurious receipts-root mismatch (`bv_fail=53`).

## Root cause
For `set_code_to_self_destruct[balance_1-external]` (manifest row 22267), execution-specs computes receipt `cumulative_gas_used = 171619` (= runtime regular `128929` + generic adjust `42690`). The guest emitted `204309` (`= 171619 + 32690`), so `block_validate_receipts_consensus_list` reported a receipts-root mismatch and the block was falsely rejected (`succ guest=00 exp=01`). State-root and header gas already matched.

## Validation
- `scripts/codegen-eest-stateless-check.sh --filter set_code_to_self_destruct --limit 10`: 9/10 full match (was 8/10). The lone remaining fail (balance_1 other parametrization) is a separate pre-existing `bv_fail=44` BAL-nonstorage bug, not receipt gas.
- `--filter selfdestruct --limit 40` (incl. `bal_selfdestruct_to_7702_delegation` and eip8025 `witness_codes_selfdestruct_*`): 40/40 succ match, 0 fail.
- random sweep (`--random --seed 20260616 --limit 200`): 200/200 full match, 0 fail, 0 errored.
- `lake build` green (only the pre-existing `LeanRV64D/RiscvExtras.lean` deprecation warning); `scripts/check-file-size.sh`, `scripts/check-unimported.sh` clean; no `sorry`/`maxHeartbeats`/`maxRecDepth`.

Bead: evm-asm-msdfw.

Directed by @pirapira; implemented by Claude Code