### PR TITLE
fix(eip8037): compute type-4 receipt gas as tx_regular + tx_state

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -47,24 +47,12 @@ def blockVerdictReceiptsTail : String :=
   "  la a5, bvgr_block_gas_increments\n" ++
   "  la a6, bvgr_tx_exec_state_gas\n" ++
   "  jal ra, block_verdict_receipt_gas_eip8037_adjust\n" ++
-  -- NOTE (msdfw): a previous narrow EIP-7702 SELFDESTRUCT receipt correction
-  -- here unconditionally added 32690 to the single-tx type-4 receipt increment
-  -- whenever evm_selfdestruct_staged was set. That was a pre-8977 workaround for
-  -- when block_verdict_receipt_gas_eip8037_adjust under-counted the per-auth
-  -- state component. After PR #8977 the generic type-4 adjust adds the full
-  -- per-authorization state component (42690) on the single-auth path, so the
-  -- runtime regular increment already reconstructs tx_gas_used_after_refund for
-  -- delegated SELFDESTRUCT rows (e.g. set_code_to_self_destruct balance_1: the
-  -- receipt is 128929 + 42690 = 171619, matching execution-specs). The extra
-  -- +32690 double-counted and produced a spurious receipts-root mismatch
-  -- (bv_fail=53). The other set_code_to_self_destruct parametrizations are
-  -- conservative-accept shapes whose verdict does not depend on the receipt
-  -- increment, so dropping this correction is safe.
-  "  la t2, bvgr_arena_tx_count; ld t2, 0(t2); li t3, 1; bne t2, t3, .Lbv_receipt_ecc_skip\n" ++
-  "  la t2, bv_simple_transfer_tx; ld t2, 160(t2); li t3, 4; bne t2, t3, .Lbv_receipt_ecc_skip\n" ++
-  "  la t0, ecc_same_block_hit; ld t0, 0(t0); beqz t0, .Lbv_receipt_ecc_skip\n" ++
-  "  la t4, bvgr_receipt_gas_increments; ld t5, 0(t4); li t6, 32690; add t5, t5, t6; sd t5, 0(t4)\n" ++
-  ".Lbv_receipt_ecc_skip:\n" ++
+  -- huo4a: block_verdict_receipt_gas_eip8037_adjust now computes the type-4
+  -- receipt cumulative_gas SPEC-EXACTLY (= tx_regular_gas + tx_state_gas from the
+  -- verdict-side arrays + PER_AUTH_BASE_COST*auth, then refund + calldata floor),
+  -- so the prior narrow per-shape receipt add-ons here (the SELFDESTRUCT +32690,
+  -- removed in #8988, and the EXTCODECOPY-same-block ecc_same_block_hit +32690)
+  -- are subsumed and removed -- re-adding them would double-count.
   "  la t2, bv_exec_p; ld a0, 0(t2)\n" ++
   "  la a1, bvgr_receipt_gas_increments\n" ++
   "  la t2, bvgr_arena_tx_count; ld a2, 0(t2)\n" ++

--- a/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
+++ b/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
@@ -451,64 +451,36 @@ def blockVerdictReceiptGasEip8037AdjustFunction : String :=
   "  la t0, bvrga_auth_len; ld a1, 0(t0); la a2, bvrga_auth_count\n" ++
   "  jal ra, rlp_list_count_items\n" ++
   "  bnez a0, .Lbvrga_next\n" ++
-  -- Amsterdam type-4 receipt gas includes the per-authorization state
-  -- component in `tx_gas_used_after_refund`, but not the whole EIP-8037 state
-  -- dimension. The runtime increment already contains regular execution/auth
-  -- gas; add 42690 per authorization tuple. Decode failures leave it intact.
-  "  la t0, bvrga_auth_count; ld t0, 0(t0); li t1, 42690; mul t4, t0, t1; li t1, 7500; mul t6, t0, t1\n" ++
-  "  slli t1, s6, 3; add t2, s3, t1; ld t3, 0(t2)\n" ++
-  "  beqz s5, .Lbvrga_type4_check_state\n" ++
-  "  add t5, s5, t1; ld t5, 0(t5); bgtu t3, t5, .Lbvrga_type4_maybe_auth_regular\n" ++
-  "  j .Lbvrga_type4_check_state\n" ++
-  ".Lbvrga_type4_maybe_auth_regular:\n" ++
-  "  beqz s4, .Lbvrga_next\n" ++
-  "  add t5, s4, t1; ld t5, 0(t5); li t0, 35190; la t1, bvrga_auth_count; ld t1, 0(t1); mul t0, t0, t1\n" ++
-  "  bleu t5, t0, .Lbvrga_next\n" ++
-  -- Receipt gas for type-4 txs includes auth regular gas and, when the
-  -- authority did not already hold a delegation indicator, the net auth-base
-  -- state component. `tx_total_state_gas - tx_exec_state_gas` distinguishes
-  -- that case from the already-delegated path, which is already correct with
-  -- just PER_AUTH_BASE_COST. The 2500-per-auth subtraction preserves the
-  -- delegated target's cold-account delta in receipt gas. Execution-specs
-  -- receipt gas includes this full net auth-state component; do not apply the
-  -- 2500 state-clear refund here.
-  "  add t3, t3, t6\n" ++
-  "  ld t4, 104(sp); beqz t4, .Lbvrga_type4_store_regular\n" ++
-  "  slli t1, s6, 3; add t4, t4, t1; ld t4, 0(t4)\n" ++
-  "  bleu t5, t4, .Lbvrga_type4_store_regular\n" ++
-  "  sub t5, t5, t4\n" ++
-  "  bleu t5, t0, .Lbvrga_type4_have_net_auth_state\n" ++
-  "  mv t5, t0\n" ++
-  ".Lbvrga_type4_have_net_auth_state:\n" ++
-  "  add t3, t3, t5\n" ++
-  ".Lbvrga_type4_store_regular:\n" ++
-  "  j .Lbvrga_type4_store_adjusted\n" ++
-  ".Lbvrga_type4_check_state:\n" ++
-  "  beqz s4, .Lbvrga_type4_add_auth\n" ++
-  "  add t5, s4, t1; ld t5, 0(t5); bgeu t3, t5, .Lbvrga_type4_add_state\n" ++
-  "  beqz s5, .Lbvrga_type4_state_floor\n" ++
-  "  la t0, bvrga_auth_count; ld t0, 0(t0); li t1, 1; bne t0, t1, .Lbvrga_type4_state_floor\n" ++
-  "  slli t1, s6, 3; add t0, s5, t1; ld t0, 0(t0); bne t0, t3, .Lbvrga_type4_state_floor\n" ++
-  "  add t3, t3, t4; j .Lbvrga_type4_store_adjusted\n" ++
-  ".Lbvrga_type4_state_floor:\n" ++
-  "  sub t0, t4, t6\n" ++
-  liAmsterdamNewAccountStateGas "t1" ++
-  "  add t0, t0, t1; bltu t5, t0, .Lbvrga_type4_add_auth\n" ++
-  "  add t3, t3, t5; add t3, t3, t6; j .Lbvrga_type4_store_adjusted\n" ++
-  ".Lbvrga_type4_add_auth:\n" ++
-  "  add t3, t3, t4; j .Lbvrga_type4_store_adjusted\n" ++
-  ".Lbvrga_type4_add_state:\n" ++
-  "  add t3, t3, t5; add t3, t3, t6\n" ++
-  ".Lbvrga_type4_store_adjusted:\n" ++
-  "  la t0, bvrga_auth_count; ld t0, 0(t0); li t1, 1; bleu t0, t1, .Lbvrga_type4_store_final\n" ++
-  "  beqz s4, .Lbvrga_type4_store_final\n" ++
-  "  slli t1, s6, 3; add t5, s4, t1; ld t5, 0(t5)\n" ++
-  "  li t1, " ++ toString (amsterdamStateBytesPerAuthBase * amsterdamCostPerStateByte) ++ "\n" ++
-  "  mul t4, t0, t1; bgtu t5, t4, .Lbvrga_type4_store_final\n" ++
-  "  addi t0, t0, -1; mul t0, t0, t1; bleu t3, t0, .Lbvrga_type4_store_final\n" ++
-  "  sub t3, t3, t0\n" ++
+  -- huo4a: compute the type-4 receipt cumulative_gas SPEC-EXACTLY as the two
+  -- EIP-8037 block dimensions, replacing the prior per-shape +42690/+35190/2500
+  -- reconstruction. The runtime's regular pool omits the EIP-7702 per-auth
+  -- regular intrinsic (PER_AUTH_BASE_COST=7500/auth) and the auth-state intrinsic,
+  -- so the raw `bvgr_before_refund` (= tx.gas - (gas_left+state_gas_left)) is the
+  -- regular-execution + state-execution consumed but MISSING those intrinsics.
+  -- The spec receipt = tx_regular_gas + tx_state_gas (verified: msdfw 38509+133110
+  -- =171619). tx_state_gas is already correct in `bvgr_tx_total_state_gas` (net of
+  -- the new-account state refund); tx_regular_gas = (before_refund - exec_state) +
+  -- PER_AUTH_BASE_COST*auth_count. So the corrected pre-refund combined gas =
+  --   before_refund[i] - tx_exec_state_gas[i] + tx_total_state_gas[i] + 7500*auth_count
+  -- then apply the EIP-3529 gas refund (min(combined//5, refund_counter[i])) and the
+  -- EIP-7623 calldata floor (amsterdam fork.py:1132-1144). All inputs are verdict-
+  -- side arrays; no runtime change (the EIP-8037 2D-gas runtime stays as-is, 249/250).
+  "  slli t1, s6, 3\n" ++
+  "  la t0, bvgr_before_refund; add t0, t0, t1; ld t3, 0(t0)\n" ++   -- t3 = before_refund[i]
+  "  ld t0, 104(sp); add t0, t0, t1; ld t4, 0(t0); sub t3, t3, t4\n" ++  -- t3 -= tx_exec_state_gas[i]
+  "  add t0, s4, t1; ld t4, 0(t0); add t3, t3, t4\n" ++              -- t3 += tx_total_state_gas[i]
+  "  la t0, bvrga_auth_count; ld t0, 0(t0); li t4, 7500; mul t4, t0, t4; add t3, t3, t4\n" ++  -- t3 += 7500*auth_count
+  "  li t4, 5; divu t5, t3, t4\n" ++                                 -- t5 = combined // 5
+  "  la t0, bvgr_refund_counter; add t0, t0, t1; ld t6, 0(t0)\n" ++  -- t6 = refund_counter[i]
+  "  bleu t6, t5, .Lbvrga_type4_refmin\n" ++
+  "  mv t6, t5\n" ++
+  ".Lbvrga_type4_refmin:\n" ++
+  "  sub t3, t3, t6\n" ++                                            -- t3 = combined - refund
+  "  la t0, bvgr_calldata_floor; add t0, t0, t1; ld t4, 0(t0)\n" ++  -- t4 = calldata_floor[i]
+  "  bgeu t3, t4, .Lbvrga_type4_store_final\n" ++
+  "  mv t3, t4\n" ++
   ".Lbvrga_type4_store_final:\n" ++
-  "  sd t3, 0(t2)\n" ++
+  "  add t2, s3, t1; sd t3, 0(t2)\n" ++                              -- bvgr_receipt_gas_increments[i] = receipt
   "  j .Lbvrga_next\n" ++
   ".Lbvrga_next:\n" ++
   "  addi s6, s6, 1; j .Lbvrga_loop\n" ++


### PR DESCRIPTION
## Summary
- Replace the fragile per-shape EIP-7702 receipt-gas reconstruction in `block_verdict_receipt_gas_eip8037_adjust` (the branchy `+42690/+35190/2500` add-state/add-auth logic) with the spec-exact decomposition:

  `receipt = max((before_refund − tx_exec_state_gas + tx_total_state_gas + PER_AUTH_BASE_COST·auth_count) − gas_refund, calldata_floor)`

  which is `tx_regular_gas + tx_state_gas` (amsterdam `make_receipt` / `process_transaction`, fork.py:1132–1205), computed entirely from verdict-side arrays the guest already has.
- Remove the now-subsumed narrow EXTCODECOPY-same-block (`ecc_same_block_hit`) `+32690` receipt add-on in `BlockVerdictReceiptsTail` (the SELFDESTRUCT `+32690` was already removed in #8988). The clean formula computes the receipt from scratch, so re-adding either would double-count.

## Why
Ground-truth instrumentation showed the runtime regular pool omits the EIP-7702 per-auth regular intrinsic (`PER_AUTH_BASE_COST=7500/auth`), so the raw `before_refund` is short by that term; the prior per-shape constants were compensating shape-by-shape. The formula adds it back explicitly. **No runtime/OOG change** — the EIP-8037 2D-gas execution path is untouched.

## Validation
- `set_code_to_self_destruct[balance_1]`: receipt 171619 (= 38509 + 133110), succ=01 (stays passing, now via the clean formula not `+42690`).
- `--filter eip7702_set_code_tx --limit 120`: 120/120 full match.
- Random sweep (`--random --seed 20260616 --limit 500`): **500/500 full match, 0 fail, 0 errored**.
- `lake build` green (pre-existing `LeanRV64D/RiscvExtras.lean` deprecation warning only); `check-file-size.sh`, `check-unimported.sh` clean; no `sorry`/`maxHeartbeats`/`maxRecDepth`.

## Follow-ups (isolated by this change)
The remaining `bv_fail=53` false-rejects are now pinned to **separate intrinsic/execution over-charge bugs** (`before_refund` too high), not receipt-reconstruction: `pointer_to_static_reentry` (+2500 cold-access), `set_code_to_log` (+378 intrinsic) — tracked in evm-asm-5tmlt / evm-asm-mk3ic.

Bead: evm-asm-huo4a.

Directed by @pirapira; implemented by Claude Code