### PR TITLE
fix(eip8037): take max(before_refund, dimension) for type-4 receipt gas (fixes #8989 regression)

### DIFF
--- a/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
+++ b/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
@@ -469,7 +469,18 @@ def blockVerdictReceiptGasEip8037AdjustFunction : String :=
   "  la t0, bvgr_before_refund; add t0, t0, t1; ld t3, 0(t0)\n" ++   -- t3 = before_refund[i]
   "  ld t0, 104(sp); add t0, t0, t1; ld t4, 0(t0); sub t3, t3, t4\n" ++  -- t3 -= tx_exec_state_gas[i]
   "  add t0, s4, t1; ld t4, 0(t0); add t3, t3, t4\n" ++              -- t3 += tx_total_state_gas[i]
-  "  la t0, bvrga_auth_count; ld t0, 0(t0); li t4, 7500; mul t4, t0, t4; add t3, t3, t4\n" ++  -- t3 += 7500*auth_count
+  "  la t0, bvrga_auth_count; ld t0, 0(t0); li t4, 7500; mul t4, t0, t4; add t3, t3, t4\n" ++  -- t3 += 7500*auth_count (dimension reconstruction)
+  -- huo4a fix: take max(dimension, before_refund). When the runtime under-charged the
+  -- per-auth intrinsic (e.g. set_code_to_self_destruct, gas_left>0) the dimension
+  -- reconstruction is the larger, correct value; when before_refund already reflects the
+  -- full charge (e.g. set_code_to_sstore that exhausts gas, gas_left=0) before_refund is
+  -- the larger, correct value (the dimension under-counts because exec_state then holds the
+  -- unspent state reservoir, not the consumed state). #8989 omitted this max and regressed
+  -- set_code_to_sstore[tx_value_1].
+  "  la t0, bvgr_before_refund; add t0, t0, t1; ld t4, 0(t0)\n" ++   -- t4 = before_refund[i] (reload)
+  "  bgeu t3, t4, .Lbvrga_type4_dimmax\n" ++
+  "  mv t3, t4\n" ++
+  ".Lbvrga_type4_dimmax:\n" ++
   "  li t4, 5; divu t5, t3, t4\n" ++                                 -- t5 = combined // 5
   "  la t0, bvgr_refund_counter; add t0, t0, t1; ld t6, 0(t0)\n" ++  -- t6 = refund_counter[i]
   "  bleu t6, t5, .Lbvrga_type4_refmin\n" ++


### PR DESCRIPTION
## Summary
PR #8989 regressed `set_code_to_sstore[tx_value_1]`. Root cause: the dimension formula `before_refund − exec_state + tx_total_state + 7500·auth` under-counts when the tx exhausts gas (`gas_left=0`), because `exec_state` then holds the unspent state **reservoir** (not consumed state), so subtracting it is wrong; in that case the raw `before_refund` already equals the spec receipt.

Fix: `receipt = max(before_refund, dimension)`. When the runtime under-charged the EIP-7702 per-auth intrinsic (`gas_left>0`, e.g. `set_code_to_self_destruct`) the dimension reconstruction is the larger, correct value; when `before_refund` already reflects the full charge (`gas_left=0`, e.g. `set_code_to_sstore`) `before_refund` is the larger, correct value. One uniform rule for all type-4 receipts; verdict-side only (no runtime/OOG change).

## Validation (proper fail-set comparison — what #8989 skipped)
`eip7702_set_code_tx` family, 400 cases:
- **pre-#8989 (old branchy adjust): 10 fails. This branch: 7 fails.**
- **NEW regressions vs pre-#8989: NONE.**
- **FIXED vs pre-#8989: +3** — `authorization_reusing_nonce`, `delegation_clearing_and_set`, `ext_code_on_self_set_code`.
- Direct ziskemu on the #8989-regressed cases: `set_code_to_sstore` 00000/00001 → succ=01 (restored); 00002/00003 stay passing.
- The 7 remaining fails are pre-existing separate bugs (set_code_to_log `+378` intrinsic over-charge; `set_code_to_self_destruct` bv_fail=44 BAL; `self_code_on_set_code`), all failing on pre-#8989 too — unrelated to receipt gas.

Net: strictly better than both #8989 (fixes the sstore regression) and pre-#8989 (+3 fixed, 0 regressions).

Bead: evm-asm-huo4a.

Directed by @pirapira; implemented by Claude Code