### PR TITLE
fix(eip7702): reverse LOG receipt address to canonical BE

### DIFF
--- a/EvmAsm/Codegen/Programs/EvmLogHandlers.lean
+++ b/EvmAsm/Codegen/Programs/EvmLogHandlers.lean
@@ -67,14 +67,21 @@ def logCapturePreBody (topicCount : Nat) : String :=
   "  sd x18, 16(x14)\n" ++
   logTopicCopies topicCount ++
   -- Capture the local address and caller context from the env block.
-  "  ld x21, 0(x20)\n" ++
-  "  sd x21, 192(x14)\n" ++
-  "  ld x21, 8(x20)\n" ++
-  "  sd x21, 200(x14)\n" ++
-  "  ld x21, 16(x20)\n" ++
-  "  sd x21, 208(x14)\n" ++
-  "  ld x21, 24(x20)\n" ++
-  "  sd x21, 216(x14)\n" ++
+  -- env.ADDRESS @ env+0 is the EVM stack-word layout (low limb first, since #8967),
+  -- but the receipt log encoder (LogRecordsRlp) consumes descriptor+192 as the
+  -- canonical 20-byte BE address, so reverse the 20 address bytes here. The
+  -- descriptor was pre-zeroed, so the upper 12 bytes of the +192 word stay zero
+  -- (matching the canonical low-aligned form the encoder + bloom expect).
+  "  addi x22, x20, 19\n" ++        -- src = env+19 (MSB of the LE address)
+  "  addi x23, x14, 192\n" ++       -- dst = descriptor+192 (canonical BE)
+  "  li x16, 20\n" ++
+  "42:\n" ++
+  "  lbu x21, 0(x22)\n" ++
+  "  sb x21, 0(x23)\n" ++
+  "  addi x22, x22, -1\n" ++
+  "  addi x23, x23, 1\n" ++
+  "  addi x16, x16, -1\n" ++
+  "  bnez x16, 42b\n" ++
   "  ld x21, 64(x20)\n" ++
   "  sd x21, 224(x14)\n" ++
   "  ld x21, 72(x20)\n" ++


### PR DESCRIPTION
## Problem

`set_code_to_log` LOG0–4 regressed to `bv_fail=53` (receipts-root mismatch). Proof of regression: the i8tqa-era ELF (PR #8940) **accepts** LOG0 (succ byte = 01); current main **rejects** it (00) — only the verdict byte differs, the requests root is identical, and `cumulative_gas` + `state_root` are both correct. So the receipt RLP's **log address/bloom** is wrong, not the gas.

## Root cause (bisected)

PR #8967 ("self-sponsored set-code") converted `env.ADDRESS` (env+0) from canonical big-endian to the EVM **stack-word layout (low limb first)** so env loads / the `ADDRESS` opcode read it consistently. But:

- The LOG capture (`logCapturePreBody`) copies `env.ADDRESS` straight into the descriptor's `+192` address slot.
- The receipt log encoder (`LogRecordsRlp`, since PR #8940) consumes `descriptor+192` as the **canonical 20-byte BE** address.

So post-#8967 the captured log address was byte-reversed → wrong receipt log address + bloom → wrong receipts root.

Bisect: `e35ac8a5f`(#8940) PASS · #8941/#8943/#8944 PASS · **#8967 FAIL**.

## Fix

Reverse the 20 address bytes when writing `descriptor+192` in the LOG capture, restoring the encoder's canonical-BE contract. The descriptor is pre-zeroed, so the upper 12 bytes stay zero (the low-aligned form the encoder + bloom expect). The EIP-7708 synthetic-log path is unaffected — it writes its system magic address into `descriptor+192` in BE directly, not via this capture.

## Validation

- `set_code_to_log` LOG0–4: **5/5 PASS(full)** (were `bv_fail=53`).
- eip7708 LOG family: **80/80**.
- Broad 400-case sweep: **400/400**, 0 regressions, 0 LOG-related failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)