### PR TITLE
fix(eip7702): pass set_code_to_self_destruct[balance_1] — cold access gas + new-beneficiary EIP-7708 log

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -509,6 +509,12 @@ def emitSelfdestructData : String :=
   ".balign 32\n" ++
   "evm_selfdestruct_balance_scratch:\n" ++
   "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "sd_eip7708_from_sw:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "sd_eip7708_to_sw:\n" ++
+  "  .zero 32\n" ++
   ".balign 8\n" ++
   "evm_selfdestruct_created_in_tx:\n" ++
   "  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/NoopHalt.lean
+++ b/EvmAsm/Codegen/Programs/NoopHalt.lean
@@ -225,6 +225,22 @@ private def selfdestructTailAsm : String :=
   "  la a2, " ++ runtimeAccessAccountCountLabel ++ "\n" ++
   "  li a3, " ++ toString runtimeAccessAccountCapacity ++ "\n" ++
   "  jal ra, runtime_access_account_charge\n" ++
+  -- SELFDESTRUCT charges COLD_ACCOUNT_ACCESS (2600) for a COLD beneficiary and 0
+  -- when warm (spec amsterdam vm/instructions/system.py:646-650; unlike CALL, it
+  -- adds NO warm-access cost). runtime_access_account_charge only debited the
+  -- 2500 cold delta (its 100 floor presumes a dispatcher account-opcode floor that
+  -- SELFDESTRUCT's 5000 base lacks), so add the missing 100 ONLY on the cold path
+  -- (helper a0==1) to reach the full 2600; a warm beneficiary stays at 0. Without
+  -- this the cold-beneficiary SELFDESTRUCT under-charged regular gas by 100,
+  -- corrupting the type-4 receipt cumulative (bv_fail=53). Check a0 before the
+  -- x10 restore clobbers it.
+  "  beqz a0, .L_selfdestruct_access_floor_done\n" ++
+  "  ld t0, 568(x20)\n" ++
+  "  li t1, 100\n" ++
+  "  bltu t0, t1, .exit_outofgas\n" ++
+  "  sub t0, t0, t1\n" ++
+  "  sd t0, 568(x20)\n" ++
+  ".L_selfdestruct_access_floor_done:\n" ++
   "  ld x10, 0(sp)\n" ++
   "  ld x12, 8(sp)\n" ++
   "  addi sp, sp, 32\n" ++

--- a/EvmAsm/Codegen/Programs/Selfdestruct.lean
+++ b/EvmAsm/Codegen/Programs/Selfdestruct.lean
@@ -221,7 +221,21 @@ def selfdestructBalanceTransferRuntimeAsm : String :=
   "  sd x0, 0(t0)\n" ++
   "  la t0, sdai_status\n" ++
   "  ld t1, 0(t0)\n" ++
-  "  bnez t1, .L_selfdestruct_transfer_done\n" ++
+  "  beqz t1, .L_selfdestruct_transfer_full\n" ++
+  -- status 4 = beneficiary lookup missed because it is a NEW account. The balance
+  -- move to the new beneficiary is already applied (recomputed state root matches),
+  -- but the spec still emits the EIP-7708 Transfer log to it. The full transfer
+  -- staging below needs the beneficiary RLP (absent for a new account), so instead
+  -- just clear sdai_transfer_status to let selfdestructEip7708LogRuntimeAsm emit the
+  -- log: it reads the transferred amount from the (valid) origin RLP and no-ops on a
+  -- zero balance, so this is correct for both funded and empty new-beneficiary cases.
+  -- status 1/2/3 (no context / header / origin failure) keep skipping (status stays 1).
+  "  li t2, 4\n" ++
+  "  bne t1, t2, .L_selfdestruct_transfer_done\n" ++
+  "  la t0, sdai_transfer_status\n" ++
+  "  sd x0, 0(t0)\n" ++
+  "  j .L_selfdestruct_transfer_done\n" ++
+  ".L_selfdestruct_transfer_full:\n" ++
   "  la t0, sdai_origin_len\n" ++
   "  ld a1, 0(t0)\n" ++
   "  la t0, sdai_beneficiary_len\n" ++
@@ -319,6 +333,19 @@ def selfdestructEip7708LogRuntimeAsm : String :=
   "  addi t1, t1, -1\n" ++
   "  addi t2, t2, -1\n" ++
   "  bnez t2, .L_selfdestruct_eip7708_balance_rev\n" ++
+  -- Build stack-word LE forms of the from/to addresses for the EIP-7708 log topics.
+  -- sdai_origin_address / evm_selfdestruct_beneficiary are canonical 20-byte BE, but
+  -- the receipt log encoder byte-reverses each 32B topic slot (like the CALL value-
+  -- transfer log, which passes env.ADDRESS / stack words), so the address must enter
+  -- as [20-byte LE][12 zero] to come out canonical right-aligned BE.
+  "  la t0, sd_eip7708_from_sw\n  sd x0, 0(t0); sd x0, 8(t0); sd x0, 16(t0); sd x0, 24(t0)\n" ++
+  "  la t1, sdai_origin_address; addi t1, t1, 19; li t2, 20\n" ++
+  ".L_sd7708_from_le:\n" ++
+  "  lbu t4, 0(t1); sb t4, 0(t0); addi t1, t1, -1; addi t0, t0, 1; addi t2, t2, -1; bnez t2, .L_sd7708_from_le\n" ++
+  "  la t0, sd_eip7708_to_sw\n  sd x0, 0(t0); sd x0, 8(t0); sd x0, 16(t0); sd x0, 24(t0)\n" ++
+  "  la t1, evm_selfdestruct_beneficiary; addi t1, t1, 19; li t2, 20\n" ++
+  ".L_sd7708_to_le:\n" ++
+  "  lbu t4, 0(t1); sb t4, 0(t0); addi t1, t1, -1; addi t0, t0, 1; addi t2, t2, -1; bnez t2, .L_sd7708_to_le\n" ++
   "  la t0, sdai_origin_address\n" ++
   "  la t1, evm_selfdestruct_beneficiary\n" ++
   "  li t2, 20\n" ++
@@ -342,7 +369,7 @@ def selfdestructEip7708LogRuntimeAsm : String :=
   "  addi sp, sp, -32\n" ++
   "  sd x10, 0(sp)\n" ++
   "  sd x12, 8(sp)\n" ++
-  "  la a0, sdai_origin_address\n" ++
+  "  la a0, sd_eip7708_from_sw\n" ++
   "  la a1, evm_selfdestruct_balance_scratch\n" ++
   "  jal ra, eip7708_append_burn_log\n" ++
   "  mv t6, a0\n" ++
@@ -355,8 +382,8 @@ def selfdestructEip7708LogRuntimeAsm : String :=
   "  addi sp, sp, -32\n" ++
   "  sd x10, 0(sp)\n" ++
   "  sd x12, 8(sp)\n" ++
-  "  la a0, sdai_origin_address\n" ++
-  "  la a1, evm_selfdestruct_beneficiary\n" ++
+  "  la a0, sd_eip7708_from_sw\n" ++
+  "  la a1, sd_eip7708_to_sw\n" ++
   "  la a2, evm_selfdestruct_balance_scratch\n" ++
   "  jal ra, eip7708_append_transfer_log\n" ++
   "  mv t6, a0\n" ++
@@ -590,6 +617,12 @@ def runtimeSelfdestructAccountInputsDataSection : String :=
   "  .zero 32\n" ++
   ".balign 32\n" ++
   "evm_selfdestruct_balance_scratch:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "sd_eip7708_from_sw:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "sd_eip7708_to_sw:\n" ++
   "  .zero 32\n" ++
   ".balign 8\n" ++
   "evm_selfdestruct_created_in_tx:\n" ++


### PR DESCRIPTION
Flips `set_code_to_self_destruct[balance_1-external]` (00003) to **PASS(full)**. It was a 3-layer stacked bug; layer 1 (BAL nonstorage) shipped in #8992, layers 2–3 are this PR.

## Layer 2 — receipt cumulative −100 (cold SELFDESTRUCT beneficiary)

The spec charges `SELFDESTRUCT_BASE(5000) + (cold ? COLD_ACCOUNT_ACCESS(2600) : 0)`, with **no** warm-access cost (amsterdam `system.py:646-650`). But `runtime_access_account_charge` only debits the 2500 cold delta (its 100 floor presumes a dispatcher account-opcode floor SELFDESTRUCT's 5000 base lacks). Fix: add the missing 100 only on the helper's cold path (a0==1); warm stays 0.

## Layer 3 — EIP-7708 transfer log dropped for a new beneficiary

The receipt was missing the EIP-7708 ETH-transfer log (`bv_block_log_count=0` vs spec 1). Two defects:

1. `selfdestructBalanceTransferRuntimeAsm` skipped on any `sdai_status != 0`; a new external beneficiary gives `sdai_status=4`, leaving `sdai_transfer_status=1` which suppressed the log emitter. The balance move is already applied (state root matches) and the spec still emits the Transfer log, so clear `sdai_transfer_status` on the status==4 path. The emitter reads the amount from the valid origin RLP and no-ops on zero balance.
2. The from/to address topics were passed as canonical 20-byte BE, but the receipt log encoder byte-reverses each 32B topic slot (the working CALL value-transfer log passes stack-word low-limb-first form). Build `[20-byte LE][12 zero]` stack-word forms so the topics come out canonical right-aligned BE. Applies to both transfer and burn log paths.

## Validation

- `set_code_to_self_destruct`: **10/10** (00003 now PASS, was bv_fail=53).
- selfdestruct family: 60/60.
- eip7708 family: 80/80.
- broad 250-case sweep: 250/250.
- 0 regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)