### PR TITLE
fix(codegen): charge value-transfer regular gas for a value-CALL to an empty callee

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -496,6 +496,25 @@ def callDescendFallThrough
   "  j .dispatch_loop\n" ++
   -- empty code (EOA): the call succeeds, runs nothing → push 1
   ".Lcd_empty_" ++ tag ++ ":\n" ++
+  -- bnctz: a value-bearing CALL (mode 0) to an empty/non-existent callee still pays the
+  -- value-transfer REGULAR gas. Spec system.py:444 charges extra_gas = access + CALL_VALUE(9000);
+  -- message_call_gas then funds the empty callee with the 2300 stipend, which returns unused, so
+  -- the NET regular consumed is 9000 - 2300 = 6700 (access is already charged via
+  -- runtime_access_account_charge; the new-account STATE gas is charged above). The .Lcd_empty
+  -- fast-path takes no child frame, so charge that 6700 net here. Without it, block_inc0 (and the
+  -- receipt = block_regular + tx_state) under-count by 6700 -> block_gas_used_call_new_account
+  -- bv_fail=53. x12 is still the parent stack top (value at x12+valueOff) before the pop below.
+  (if mode == 0 then
+     "  ld t0, " ++ toString valueOff ++ "(x12)\n" ++
+     "  ld t1, " ++ toString (valueOff+8) ++ "(x12)\n  or t0, t0, t1\n" ++
+     "  ld t1, " ++ toString (valueOff+16) ++ "(x12)\n  or t0, t0, t1\n" ++
+     "  ld t1, " ++ toString (valueOff+24) ++ "(x12)\n  or t0, t0, t1\n" ++
+     "  beqz t0, .Lcd_empty_noval_" ++ tag ++ "\n" ++
+     "  li t0, 6700\n" ++
+     "  ld t1, 568(x20)\n  bltu t1, t0, .exit_outofgas\n" ++
+     "  sub t1, t1, t0\n  sd t1, 568(x20)\n" ++
+     ".Lcd_empty_noval_" ++ tag ++ ":\n"
+   else "") ++
   "  addi x12, x12, " ++ np ++ "\n" ++
   "  li t0, 1\n" ++
   "  sd t0, 0(x12); sd x0, 8(x12); sd x0, 16(x12); sd x0, 24(x12)\n" ++


### PR DESCRIPTION
## Problem

A value-bearing CALL (mode 0) to an empty / non-existent callee takes the `.Lcd_empty` fast-path (push 1, no child frame) without charging the **value-transfer regular gas**. Per execution-specs `vm/instructions/system.py:444`, the caller pays `extra_gas = access + CALL_VALUE (9000)`; `calculate_message_call_gas` then funds the callee with the 2300 stipend, which an empty callee returns unused — so the **net** regular consumed is `9000 − 2300 = 6700` (access is already charged via `runtime_access_account_charge`; the new-account STATE gas is charged earlier in the descent).

Because the fast-path takes no frame, that 6700 was never charged. The block regular-gas increment (and the receipt, which is `block-regular + tx-state`) under-counted by 6700: `block_gas_used_call_new_account` reached the receipt gate with `cumulative_gas_used` **310147 vs the spec's 316847** and false-rejected (**bv_fail=53**). The under-count was otherwise invisible because `header.gas_used = max(regular, state)` is state-dominated for account-creating value calls.

## Fix

Charge the 6700 net value-transfer regular gas on the `.Lcd_empty` path for a value-bearing CALL (mode 0, value≠0), with an OOG check. (`bnctz`)

## Result

`block_gas_used_call_new_account` → **full pass** (together with the merged #9001 byte-order fix that cleared its bv_fail=45).

Validated: eip8037 **80/80**, value family **60/60**, target **1/1** (broad sweep covered continuously on main).

## Follow-up

The descend path (value-CALL to a *contract*) still omits the value-transfer regular charge — masked by state-dominance in the block check; tracked as a `bnctz` follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)