### PR TITLE
feat(rv64): flat-item RLP list-decode n-closure + decodeItems bridge

### DIFF
--- a/EvmAsm/Rv64/RLP/FlatListLoop.lean
+++ b/EvmAsm/Rv64/RLP/FlatListLoop.lean
@@ -9,9 +9,16 @@
   loop body (`fll_body_spec_within`) in one pass, advancing the pointer by
   `itemTotalLen` of the item's first byte. `encode_head_eq_itemTotalLen` proves
   this stride equals `(encode item).length` — the bridge between the machine
-  loop and the pure `encode`/`decodeItems` round-trip. The n-iteration closure
-  (count-induction over a list of flat items, threading the variable byte
-  offset) and the `decodeItems` bridge build on these (next PR).
+  loop and the pure `encode`/`decodeItems` round-trip.
+
+  On that foundation: `fll_loop_spec_within` is the **n-iteration closure**
+  (structural induction over a list of flat items, threading the variable byte
+  offset via `bs.drop O = encode.encodeItems items` and applying
+  `fll_body_spec_within` per item with the decoder supplied as a ∀-hypothesis
+  `decoderH`); `fll_loop_n_spec_within` is the offset-0 entry; and
+  `fll_loop_bridge` conjoins the operational loop with the pure
+  `decodeItems` round-trip (`decode_encode_mutual.2`). Uniform
+  `15 * items.length` steps; only the per-item byte stride varies.
 -/
 
 import EvmAsm.Rv64.RLP.FlatListLoopBody
@@ -155,6 +162,307 @@ theorem encode_head_eq_itemTotalLen (item : RLPItem) (hflat : isFlatItem item) :
     have hsub : (0xC0 + (encode.encodeItems items).length) - 0xC0 = (encode.encodeItems items).length := by omega
     rw [hsub]; bv_omega
 
+-- ============================================================================
+-- N-iteration closure: decode a list of flat items
+-- ============================================================================
+
+/-- Bundled post for the whole flat list-loop: the scratch registers
+    `x5/x10/x11` are abstracted to `regOwn` (their final values are irrelevant
+    downstream), the pointer rests at `endPtr`, the counter is zeroed, and the
+    byte region is intact. -/
+@[irreducible]
+def fll_loop_post (regionBase : Word) (bs : List (BitVec 8)) (endPtr : Word) : Assertion :=
+  regOwn .x5 ** (.x0 ↦ᵣ (0 : Word)) ** regOwn .x10 ** regOwn .x11 **
+    (.x13 ↦ᵣ endPtr) ** (.x14 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs
+
+theorem fll_loop_post_unfold (regionBase : Word) (bs : List (BitVec 8)) (endPtr : Word) :
+    fll_loop_post regionBase bs endPtr =
+    (regOwn .x5 ** (.x0 ↦ᵣ (0 : Word)) ** regOwn .x10 ** regOwn .x11 **
+      (.x13 ↦ᵣ endPtr) ** (.x14 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs) := by
+  delta fll_loop_post; rfl
+
+/-- `(regionBase + ofNat O) + ofNat L = regionBase + ofNat (O + L)` — the
+    per-item pointer advance accumulates into a single offset. -/
+private theorem region_ptr_add (regionBase : Word) (O L : Nat) :
+    (regionBase + BitVec.ofNat 64 O) + BitVec.ofNat 64 L
+      = regionBase + BitVec.ofNat 64 (O + L) := by
+  rw [BitVec.add_assoc]
+  congr 1
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_add, BitVec.toNat_ofNat, Nat.add_mod_mod, Nat.mod_add_mod]
+
+/-- The item count never exceeds the encoded byte length (each item is
+    non-empty). Bounds the loop counter for the `≠ 0` guard. -/
+private theorem length_le_encodeItems : ∀ (items : List RLPItem),
+    items.length ≤ (encode.encodeItems items).length
+  | [] => by simp [encode.encodeItems]
+  | i :: is => by
+    simp only [encode.encodeItems, List.length_append, List.length_cons]
+    have := encode_nonempty i
+    have := length_le_encodeItems is
+    omega
+
+/-- **N-iteration closure.** Decoding a non-empty list of FLAT items from the
+    region suffix at offset `O` runs the loop body once per item — a uniform
+    `15 * items.length` steps — advancing `x13` by the total encoded length and
+    zeroing the counter. The flat single-item decoder is supplied abstractly as
+    `decoderH` (∀ over the prefix byte and the live register values); each
+    iteration discharges the body's opaque decoder hypothesis with it, and the
+    stride-equivalence `encode_head_eq_itemTotalLen` re-indexes the pointer. -/
+theorem fll_loop_spec_within
+    (regionBase : Word) (lbase joinPC decoder_base : Word) (dcr : CodeReq) (back : BitVec 13)
+    (bs : List (BitVec 8))
+    (halign : regionBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hdec_base : decoder_base = lbase + 4)
+    (decoderH : ∀ (pfx : Byte) (w10 w11 w13 : Word),
+       (classifyPrefix pfx = .singleByte ∨ classifyPrefix pfx = .shortBytes
+         ∨ classifyPrefix pfx = .shortList) →
+       cpsTripleWithin 11 decoder_base joinPC dcr
+         ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ w10) **
+          (.x11 ↦ᵣ w11) ** (.x13 ↦ᵣ w13))
+         ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x10 ↦ᵣ itemCascadeResidue pfx) ** (.x11 ↦ᵣ itemPayloadLen pfx) **
+          (.x13 ↦ᵣ itemPayloadPtr pfx w13)))
+    (hback : (joinPC + 8) + signExtend13 back = lbase)
+    (hne_lj : lbase ≠ joinPC) (hne_lj4 : lbase ≠ joinPC + 4) (hne_lj8 : lbase ≠ joinPC + 8)
+    (hd_lbu_dec : (CodeReq.singleton lbase (.LBU .x5 .x13 0)).Disjoint dcr)
+    (hd_dec_add : dcr.Disjoint (CodeReq.singleton joinPC (.ADD .x13 .x13 .x11)))
+    (hd_dec_addi : dcr.Disjoint (CodeReq.singleton (joinPC + 4) (.ADDI .x14 .x14 (-1))))
+    (hd_dec_bne : dcr.Disjoint (CodeReq.singleton (joinPC + 8) (.BNE .x14 .x0 back))) :
+    ∀ (items : List RLPItem) (O : Nat) (v5Old v10 v11Old : Word),
+      items ≠ [] →
+      bs.drop O = encode.encodeItems items →
+      (∀ item ∈ items, isFlatItem item) →
+      (∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true) →
+      cpsTripleWithin (15 * items.length) lbase (joinPC + 12)
+        (((((CodeReq.singleton lbase (.LBU .x5 .x13 0)).union dcr).union
+            (CodeReq.singleton joinPC (.ADD .x13 .x13 .x11))).union
+            (CodeReq.singleton (joinPC + 4) (.ADDI .x14 .x14 (-1)))).union
+            ((CodeReq.singleton (joinPC + 8) (.BNE .x14 .x0 back)).union CodeReq.empty))
+        ((.x5 ↦ᵣ v5Old) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
+         (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+         (.x14 ↦ᵣ BitVec.ofNat 64 items.length) ** bytesRegion regionBase bs)
+        (fll_loop_post regionBase bs
+          (regionBase + BitVec.ofNat 64 (O + (encode.encodeItems items).length))) := by
+  intro items
+  induction items with
+  | nil => intro O v5Old v10 v11Old hne _ _ _; exact absurd rfl hne
+  | cons head tail ih =>
+    intro O v5Old v10 v11Old _ hdrop hflat_all hwin
+    -- The remaining encoding at offset `O` is `encode head ++ encode.encodeItems tail`.
+    have hsplit : bs.drop O = encode head ++ encode.encodeItems tail := by
+      rw [hdrop]; rfl
+    -- `O < bs.length` (the suffix is non-empty since `encode head` is).
+    have hO : O < bs.length := by
+      have hlen : (bs.drop O).length = (encode head ++ encode.encodeItems tail).length := by
+        rw [hsplit]
+      rw [List.length_drop, List.length_append] at hlen
+      have := encode_nonempty head; omega
+    -- The current prefix byte is `(encode head)[0]`.
+    have hbsO : bs[O]'hO = (encode head)[0]'(encode_nonempty head) := by
+      have key : (bs.drop O)[0]'(by rw [List.length_drop]; omega)
+          = (encode head)[0]'(encode_nonempty head) :=
+        (List.getElem_of_eq hsplit _).trans (List.getElem_append_left (encode_nonempty head))
+      rw [← key]; simp
+    -- It classifies as a flat prefix.
+    have hflat_O : classifyPrefix (bs[O]'hO) = .singleByte
+        ∨ classifyPrefix (bs[O]'hO) = .shortBytes
+        ∨ classifyPrefix (bs[O]'hO) = .shortList := by
+      rw [hbsO]
+      exact classifyPrefix_encode_head_flat head (hflat_all head (by simp))
+    -- The stride equals the head's encoded length.
+    have hstride : itemTotalLen (bs[O]'hO) = BitVec.ofNat 64 (encode head).length := by
+      rw [hbsO]; exact encode_head_eq_itemTotalLen head (hflat_all head (by simp))
+    -- The next-item pointer lands at offset `O + (encode head).length`.
+    have hnext : itemNextPtr (bs[O]'hO) (regionBase + BitVec.ofNat 64 O)
+        = regionBase + BitVec.ofNat 64 (O + (encode head).length) := by
+      rw [itemNextPtr, hstride, region_ptr_add]
+    have hoverO : regionBase.toNat + O < 2 ^ 64 := by omega
+    have hvalidO : isValidByteAccess (regionBase + BitVec.ofNat 64 O) = true := hwin O hO
+    cases tail with
+    | nil =>
+      -- One item: the body's BNE falls through (counter hits 0).
+      have body := fll_body_spec_within regionBase v5Old v10 v11Old (BitVec.ofNat 64 1)
+        lbase joinPC decoder_base dcr back bs O halign hO hoverO hvalidO hflat_O hdec_base
+        (decoderH (bs[O]'hO) v10 v11Old (regionBase + BitVec.ofNat 64 O) hflat_O)
+        hback hne_lj hne_lj4 hne_lj8 hd_lbu_dec hd_dec_add hd_dec_addi hd_dec_bne
+      rw [show (BitVec.ofNat 64 1 : Word) = BitVec.ofNat 64 (0 + 1) from rfl,
+        word_ofNat_succ_dec 0] at body
+      have h_absurd : ∀ hp,
+          fll_body_post regionBase bs (bs[O]'hO) (itemCascadeResidue (bs[O]'hO))
+            (itemPayloadLen (bs[O]'hO)) (itemNextPtr (bs[O]'hO) (regionBase + BitVec.ofNat 64 O))
+            (BitVec.ofNat 64 0) ((BitVec.ofNat 64 0 : Word) ≠ 0) hp → False :=
+        fun hp hpost => (fll_body_post_pure hp hpost) (by decide)
+      have tri := cpsBranchWithin_ntakenPath body h_absurd
+      refine cpsTripleWithin_weaken (fun _ hp => hp) (fun h hp => ?_) tri
+      simp only [fll_body_post_unfold] at hp
+      rw [hnext] at hp
+      rw [fll_loop_post_unfold,
+        show (encode.encodeItems (head :: [])).length = (encode head).length from by
+          simp only [encode.encodeItems, List.append_nil]]
+      -- weaken the body post: scratch x5/x10/x11 → regOwn, drop the pure fact
+      exact sepConj_mono (regIs_implies_regOwn _)
+        (sepConj_mono_right
+          (sepConj_mono (regIs_implies_regOwn _)
+            (sepConj_mono (regIs_implies_regOwn _)
+              (sepConj_mono_right
+                (sepConj_mono_right
+                  (fun h' hp' => ((sepConj_pure_right h').1 hp').1)))))) h hp
+    | cons h2 t2 =>
+      -- Two or more items: the body's BNE is taken; recurse on the tail.
+      have hdrop' : bs.drop (O + (encode head).length) = encode.encodeItems (h2 :: t2) := by
+        rw [← List.drop_drop, hsplit, List.drop_append_length]
+      -- Counter bound for the loop guard.
+      have hcnt_bound : t2.length + 1 < 18446744073709551616 := by
+        have hcount := length_le_encodeItems (h2 :: t2)
+        have e : (bs.drop (O + (encode head).length)).length
+            = (encode.encodeItems (h2 :: t2)).length := by rw [hdrop']
+        rw [List.length_drop] at e
+        simp only [List.length_cons] at hcount
+        omega
+      have body := fll_body_spec_within regionBase v5Old v10 v11Old
+        (BitVec.ofNat 64 ((h2 :: t2).length + 1))
+        lbase joinPC decoder_base dcr back bs O halign hO hoverO hvalidO hflat_O hdec_base
+        (decoderH (bs[O]'hO) v10 v11Old (regionBase + BitVec.ofNat 64 O) hflat_O)
+        hback hne_lj hne_lj4 hne_lj8 hd_lbu_dec hd_dec_add hd_dec_addi hd_dec_bne
+      rw [word_ofNat_succ_dec (h2 :: t2).length] at body
+      have hne_cnt : (BitVec.ofNat 64 (h2 :: t2).length : Word) ≠ 0 :=
+        word_ofNat_succ_ne_zero t2.length hcnt_bound
+      have h_absurd : ∀ hp,
+          fll_body_post regionBase bs (bs[O]'hO) (itemCascadeResidue (bs[O]'hO))
+            (itemPayloadLen (bs[O]'hO)) (itemNextPtr (bs[O]'hO) (regionBase + BitVec.ofNat 64 O))
+            (BitVec.ofNat 64 (h2 :: t2).length)
+            ((BitVec.ofNat 64 (h2 :: t2).length : Word) = 0) hp → False :=
+        fun hp hpost => absurd (fll_body_post_pure hp hpost) hne_cnt
+      have tri1 := cpsBranchWithin_takenPath body h_absurd
+      -- Weaken the body's taken post to the IH precondition (drop the pure fact,
+      -- re-index the pointer by the stride).
+      have tri1' : cpsTripleWithin 15 lbase lbase
+          (((((CodeReq.singleton lbase (.LBU .x5 .x13 0)).union dcr).union
+              (CodeReq.singleton joinPC (.ADD .x13 .x13 .x11))).union
+              (CodeReq.singleton (joinPC + 4) (.ADDI .x14 .x14 (-1)))).union
+              ((CodeReq.singleton (joinPC + 8) (.BNE .x14 .x0 back)).union CodeReq.empty))
+          ((.x5 ↦ᵣ v5Old) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
+           (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+           (.x14 ↦ᵣ BitVec.ofNat 64 ((h2 :: t2).length + 1)) ** bytesRegion regionBase bs)
+          ((.x5 ↦ᵣ (bs[O]'hO).zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+           (.x10 ↦ᵣ itemCascadeResidue (bs[O]'hO)) ** (.x11 ↦ᵣ itemPayloadLen (bs[O]'hO)) **
+           (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 (O + (encode head).length))) **
+           (.x14 ↦ᵣ BitVec.ofNat 64 (h2 :: t2).length) ** bytesRegion regionBase bs) := by
+        refine cpsTripleWithin_weaken (fun _ hp => hp) (fun h hp => ?_) tri1
+        simp only [fll_body_post_unfold] at hp
+        rw [hnext] at hp
+        exact (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+          (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+            (fun h' hp' => ((sepConj_pure_right h').1 hp').1))))))) h hp
+      have ihspec := ih (O + (encode head).length) ((bs[O]'hO).zeroExtend 64)
+        (itemCascadeResidue (bs[O]'hO)) (itemPayloadLen (bs[O]'hO))
+        (by simp) hdrop'
+        (fun item hitem => hflat_all item (List.mem_cons_of_mem _ hitem)) hwin
+      have composed := cpsTripleWithin_seq_perm_same_cr (fun _ hp => hp) tri1' ihspec
+      rw [show 15 * (head :: h2 :: t2).length = 15 + 15 * (h2 :: t2).length from by
+            simp only [List.length_cons]; ring,
+          show O + (encode.encodeItems (head :: h2 :: t2)).length
+              = (O + (encode head).length) + (encode.encodeItems (h2 :: t2)).length from by
+            simp only [encode.encodeItems, List.length_append]; omega]
+      exact composed
+
+/-- **Loop entry (offset 0).** Running the loop over the whole region
+    `bytesRegion regionBase (encode.encodeItems items)` decodes all `items` in
+    `15 * items.length` steps, leaving the pointer at the region end. -/
+theorem fll_loop_n_spec_within
+    (regionBase : Word) (lbase joinPC decoder_base : Word) (dcr : CodeReq) (back : BitVec 13)
+    (items : List RLPItem) (v5Old v10 v11Old : Word)
+    (halign : regionBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + (encode.encodeItems items).length < 2 ^ 64)
+    (hdec_base : decoder_base = lbase + 4)
+    (decoderH : ∀ (pfx : Byte) (w10 w11 w13 : Word),
+       (classifyPrefix pfx = .singleByte ∨ classifyPrefix pfx = .shortBytes
+         ∨ classifyPrefix pfx = .shortList) →
+       cpsTripleWithin 11 decoder_base joinPC dcr
+         ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ w10) **
+          (.x11 ↦ᵣ w11) ** (.x13 ↦ᵣ w13))
+         ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x10 ↦ᵣ itemCascadeResidue pfx) ** (.x11 ↦ᵣ itemPayloadLen pfx) **
+          (.x13 ↦ᵣ itemPayloadPtr pfx w13)))
+    (hback : (joinPC + 8) + signExtend13 back = lbase)
+    (hne_lj : lbase ≠ joinPC) (hne_lj4 : lbase ≠ joinPC + 4) (hne_lj8 : lbase ≠ joinPC + 8)
+    (hd_lbu_dec : (CodeReq.singleton lbase (.LBU .x5 .x13 0)).Disjoint dcr)
+    (hd_dec_add : dcr.Disjoint (CodeReq.singleton joinPC (.ADD .x13 .x13 .x11)))
+    (hd_dec_addi : dcr.Disjoint (CodeReq.singleton (joinPC + 4) (.ADDI .x14 .x14 (-1))))
+    (hd_dec_bne : dcr.Disjoint (CodeReq.singleton (joinPC + 8) (.BNE .x14 .x0 back)))
+    (hne : items ≠ [])
+    (hflat_all : ∀ item ∈ items, isFlatItem item)
+    (hwin : ∀ i, i < (encode.encodeItems items).length →
+       isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true) :
+    cpsTripleWithin (15 * items.length) lbase (joinPC + 12)
+      (((((CodeReq.singleton lbase (.LBU .x5 .x13 0)).union dcr).union
+          (CodeReq.singleton joinPC (.ADD .x13 .x13 .x11))).union
+          (CodeReq.singleton (joinPC + 4) (.ADDI .x14 .x14 (-1)))).union
+          ((CodeReq.singleton (joinPC + 8) (.BNE .x14 .x0 back)).union CodeReq.empty))
+      ((.x5 ↦ᵣ v5Old) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
+       (.x13 ↦ᵣ regionBase) ** (.x14 ↦ᵣ BitVec.ofNat 64 items.length) **
+       bytesRegion regionBase (encode.encodeItems items))
+      (fll_loop_post regionBase (encode.encodeItems items)
+        (regionBase + BitVec.ofNat 64 (encode.encodeItems items).length)) := by
+  have h := fll_loop_spec_within regionBase lbase joinPC decoder_base dcr back
+    (encode.encodeItems items) halign hover hdec_base decoderH hback
+    hne_lj hne_lj4 hne_lj8 hd_lbu_dec hd_dec_add hd_dec_addi hd_dec_bne
+    items 0 v5Old v10 v11Old hne (by rw [List.drop_zero]) hflat_all hwin
+  rw [show regionBase + BitVec.ofNat 64 0 = regionBase from by simp,
+      show (0 : Nat) + (encode.encodeItems items).length
+        = (encode.encodeItems items).length from Nat.zero_add _] at h
+  exact h
+
+/-- **Flat list-decode bridge.** The operational loop (left) decodes the region
+    in `15 * items.length` steps; the pure decoder (right) recovers exactly
+    `items`, consuming the whole list. The two halves share the region contents
+    `encode.encodeItems items`. The pure depth is `2 * len + 1` (the round-trip
+    `decode_encode_mutual` uses *strict* fuel `2 * len < nDepth`). -/
+theorem fll_loop_bridge
+    (regionBase : Word) (lbase joinPC decoder_base : Word) (dcr : CodeReq) (back : BitVec 13)
+    (items : List RLPItem) (v5Old v10 v11Old : Word)
+    (halign : regionBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + (encode.encodeItems items).length < 2 ^ 64)
+    (hdec_base : decoder_base = lbase + 4)
+    (decoderH : ∀ (pfx : Byte) (w10 w11 w13 : Word),
+       (classifyPrefix pfx = .singleByte ∨ classifyPrefix pfx = .shortBytes
+         ∨ classifyPrefix pfx = .shortList) →
+       cpsTripleWithin 11 decoder_base joinPC dcr
+         ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ w10) **
+          (.x11 ↦ᵣ w11) ** (.x13 ↦ᵣ w13))
+         ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x10 ↦ᵣ itemCascadeResidue pfx) ** (.x11 ↦ᵣ itemPayloadLen pfx) **
+          (.x13 ↦ᵣ itemPayloadPtr pfx w13)))
+    (hback : (joinPC + 8) + signExtend13 back = lbase)
+    (hne_lj : lbase ≠ joinPC) (hne_lj4 : lbase ≠ joinPC + 4) (hne_lj8 : lbase ≠ joinPC + 8)
+    (hd_lbu_dec : (CodeReq.singleton lbase (.LBU .x5 .x13 0)).Disjoint dcr)
+    (hd_dec_add : dcr.Disjoint (CodeReq.singleton joinPC (.ADD .x13 .x13 .x11)))
+    (hd_dec_addi : dcr.Disjoint (CodeReq.singleton (joinPC + 4) (.ADDI .x14 .x14 (-1))))
+    (hd_dec_bne : dcr.Disjoint (CodeReq.singleton (joinPC + 8) (.BNE .x14 .x0 back)))
+    (hne : items ≠ [])
+    (hflat_all : ∀ item ∈ items, isFlatItem item)
+    (hwin : ∀ i, i < (encode.encodeItems items).length →
+       isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hsize : (encode.encodeItems items).length < 256 ^ 8) :
+    cpsTripleWithin (15 * items.length) lbase (joinPC + 12)
+      (((((CodeReq.singleton lbase (.LBU .x5 .x13 0)).union dcr).union
+          (CodeReq.singleton joinPC (.ADD .x13 .x13 .x11))).union
+          (CodeReq.singleton (joinPC + 4) (.ADDI .x14 .x14 (-1)))).union
+          ((CodeReq.singleton (joinPC + 8) (.BNE .x14 .x0 back)).union CodeReq.empty))
+      ((.x5 ↦ᵣ v5Old) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
+       (.x13 ↦ᵣ regionBase) ** (.x14 ↦ᵣ BitVec.ofNat 64 items.length) **
+       bytesRegion regionBase (encode.encodeItems items))
+      (fll_loop_post regionBase (encode.encodeItems items)
+        (regionBase + BitVec.ofNat 64 (encode.encodeItems items).length))
+    ∧ decodeItems (2 * (encode.encodeItems items).length + 1) (encode.encodeItems items)
+        = some (items, []) :=
+  ⟨fll_loop_n_spec_within regionBase lbase joinPC decoder_base dcr back items v5Old v10 v11Old
+      halign hover hdec_base decoderH hback hne_lj hne_lj4 hne_lj8 hd_lbu_dec hd_dec_add
+      hd_dec_addi hd_dec_bne hne hflat_all hwin,
+    (decode_encode_mutual (2 * (encode.encodeItems items).length + 1)).2 items hsize (by omega)⟩
+
 -- Sanity: representative flat items, and the stride-equivalence instantiated.
 example : isFlatItem (.bytes [(0x05 : Byte)]) := by simp [isFlatItem]
 example : isFlatItem (.bytes [(0xAB : Byte)]) := by simp [isFlatItem]
@@ -163,5 +471,13 @@ example :
     itemTotalLen ((encode (.bytes [(0x05 : Byte)]))[0]'(encode_nonempty _))
       = BitVec.ofNat 64 (encode (.bytes [(0x05 : Byte)])).length :=
   encode_head_eq_itemTotalLen _ (by simp [isFlatItem])
+
+-- Cross-check the bridge's pure half on a concrete two-item flat list: the
+-- decoder recovers both items at the canonical depth `2 * len + 1`.
+example :
+    decodeItems (2 * (encode.encodeItems [.bytes [(0x01 : Byte)], .bytes [(0x02 : Byte)]]).length + 1)
+        (encode.encodeItems [.bytes [(0x01 : Byte)], .bytes [(0x02 : Byte)]])
+      = some ([.bytes [(0x01 : Byte)], .bytes [(0x02 : Byte)]], []) := by
+  decide
 
 end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -1333,10 +1333,20 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
   operational per-item stride equals the pure encoding length (per-class
   byte-shape algebra via `encodeBytes`/`encode_list_short`/`classifyPrefix_*_iff`,
   no `bv_decide`). Bridges the machine loop's pointer advance to the pure
-  `encode`/`decodeItems` round-trip. Axiom-clean, 0 sorry. **Next:** the
-  n-iteration closure (count-induction over a flat-item list, threading the
-  variable byte offset, applying `fll_body_spec_within` per item with the
-  decoder as a ∀-hypothesis) + the `decodeItems` bridge (`decode_encode_mutual.2`).
+  `encode`/`decodeItems` round-trip. Axiom-clean, 0 sorry.
+- ✅ **Flat list-loop n-closure + bridge** (`FlatListLoop.lean`). The operational
+  loop over a list of flat items: `fll_loop_spec_within` (structural induction
+  over `items : List RLPItem`, threading the byte offset via
+  `bs.drop O = encode.encodeItems items`, applying `fll_body_spec_within` per
+  item and re-indexing the pointer with `encode_head_eq_itemTotalLen`; the
+  decoder is a ∀-hypothesis `decoderH`, discharged per iteration; uniform
+  `15 * items.length` steps with `regOwn`-abstracted scratch in `fll_loop_post`),
+  `fll_loop_n_spec_within` (offset-0 entry), and `fll_loop_bridge` (conjoins the
+  loop with the pure `decodeItems (2*len+1) … = some (items, [])` via
+  `decode_encode_mutual.2` — strict fuel `2*len < nDepth`). Axiom-clean, 0 sorry.
+  **Next:** the concrete assembled flat-decoder program (discharge the
+  ∀-`decoderH` + its layout disjointness) for a concrete end-to-end loop; then
+  long-item support (decoder length-read → `bytesRegion`).
 - Phase 5: Recursive list decode (iterative with explicit stack)
 - Phase 6: Top-level pipeline (`read_input` -> decode -> `write_output`)
 - **Host I/O ABI**: See `docs/zkvm-host-io-interface.md`; SP1


### PR DESCRIPTION
## Summary

The operational loop over a list of flat RLP items, completing the flat-item list decoder's verification logic. Builds directly on the merged stride-equivalence (#9004) — same file, `EvmAsm/Rv64/RLP/FlatListLoop.lean`.

The flat single-item decoder stays **abstract** (supplied as a ∀-hypothesis); discharging it with the concrete assembled-decoder program is a later PR.

## What's here

- **`fll_loop_post`** — bundled whole-loop post: scratch `x5/x10/x11` abstracted to `regOwn`, pointer at the region end, counter zeroed, region intact.
- **`fll_loop_spec_within`** — the n-iteration closure. Structural induction over `items : List RLPItem`, threading the byte offset via the suffix invariant `bs.drop O = encode.encodeItems items`, applying `fll_body_spec_within` once per item and re-indexing the pointer with the stride-equivalence `encode_head_eq_itemTotalLen`. The decoder is a ∀-hypothesis `decoderH` (over the prefix byte and live register values), discharged each iteration. Uniform `15 * items.length` steps; only the per-item byte stride varies.
- **`fll_loop_n_spec_within`** — the offset-0 loop entry (decodes the whole region).
- **`fll_loop_bridge`** — conjoins the operational loop with the pure round-trip `decodeItems (2*len+1) (encode.encodeItems items) = some (items, [])` via `decode_encode_mutual.2`. Note: strict fuel `2*len < nDepth`, hence `2*len+1`.
- A concrete two-item pure cross-check `example`.

## Verification

- `lake build` green; `scripts/check-no-warnings.sh` → **0 warnings** under `EvmAsm/`.
- `scripts/check-forbidden-tactics.sh` OK (no `native_decide` / `bv_decide`).
- `#print axioms` on `fll_loop_spec_within`, `fll_loop_n_spec_within`, `fll_loop_bridge` → `[propext, Classical.choice, Quot.sound]` only.
- 0 `sorry`/`admit`.

## Next

The concrete assembled flat-decoder program (discharge the ∀-`decoderH` and its layout disjointness) for a concrete end-to-end loop; then long-item support (decoder length-read → `bytesRegion`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)