### PR TITLE
fix(codegen): inherit tx/block-constant env fields into nested call frames

### DIFF
--- a/EvmAsm/Codegen/Programs/CallFrameDescend.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameDescend.lean
@@ -309,6 +309,17 @@ def callFrameDescendFunction : String :=
   "  ld t0, 472(s3); sd t0, 472(s9)   # eventLogLength\n" ++
   "  sd t0, 480(s9)                    # eventLogCheckpoint = current\n" ++
   "  sd x0, 488(s9)                    # activeMemorySize = 0 (fresh child memory)\n" ++
+  -- 8b2 (1ipxd): inherit the tx/block-constant env fields (txOrigin@128 .. chainId@384,
+  -- a contiguous 288-byte block env+128..415) from the parent. call_frame_set_call_env
+  -- sets only the per-frame fields (ADDRESS@0 / CALLER@64 / CALLVALUE@96 / selfBalance@32
+  -- below), so without this a nested frame's ORIGIN / GASPRICE / COINBASE / TIMESTAMP /
+  -- NUMBER / PREVRANDAO / GASLIMIT / BASEFEE / CHAINID read the BAL-replay-dirtied arena
+  -- (garbage/0); pointer_reentry's re-entered frame SSTOREs ORIGIN()=0 instead of the tx
+  -- sender, so the recipient BAL storage compare false-rejects a valid block. These nine
+  -- fields are tx/block constants (identical in every frame), so a verbatim copy is exact.
+  "  addi t0, s3, 128; addi t1, s9, 128; li t2, 288\n" ++
+  ".Lcfd_envconst:\n" ++
+  "  ld t3, 0(t0); sd t3, 0(t1); addi t0, t0, 8; addi t1, t1, 8; addi t2, t2, -8; bnez t2, .Lcfd_envconst\n" ++
   -- nxio8.4.1: snapshot the parent's pre-child EIP-8037 state gas (the global
   -- evm_state_gas_left = state_gas_left reservoir, evm_state_gas_used = state_gas_used) into the
   -- child env so a child REVERT / exceptional halt can restore it in frame_return,


### PR DESCRIPTION
## Problem

`call_frame_descend` stages only the **per-frame** env fields (ADDRESS, CALLER, CALLVALUE, isStatic) when entering a child CALL frame. It never copied the **tx/block-constant** env block (`env+128..415`: `txOrigin`, `gasPrice`, `blockCoinbase`, `blockTimestamp`, `blockNumber`, `blockPrevrandao`, `blockGasLimit`, `blockBaseFee`, `chainId`).

The child env lives in the BAL-replay-dirtied arena, so a nested frame's `ORIGIN` / `GASPRICE` / `COINBASE` / `TIMESTAMP` / `NUMBER` / `PREVRANDAO` / `GASLIMIT` / `BASEFEE` / `CHAINID` read **garbage**. When such a value is `SSTORE`d, the verdict's BAL-storage exec-log compare sees a wrong final value and **false-rejects a valid block** (`bv_fail=34`).

Found on `set_code_txs_2/pointer_reentry` (bead `evm-asm-1ipxd`): the re-entered EOA does `SSTORE(slot, ORIGIN())` and the replay logged `0` instead of the tx sender.

## Fix

In `call_frame_descend`, after the child env-init, verbatim-copy the parent's `env[128..415]` (a contiguous 288-byte block) into the child. These nine fields are tx/block constants — identical in every frame within a transaction — so the copy is exact. For CALLCODE/DELEGATECALL the constants are inherited the same way.

## Validation

- A nested `ORIGIN` flips from `0` to the tx sender (instrumented).
- `eip7702_set_code_tx` family: **60/60 full-match, 0 regressions**.
- Broad random sample: **80/80 full-match, 0 regressions**.
- `lake build` clean; `check-forbidden-tactics` OK.

## Scope

This is the **env-constant** half of `evm-asm-1ipxd`. `pointer_reentry` also exercises nested `SELFBALANCE` (a per-frame *balance*, not a tx constant), which needs a separate pre-resolution mechanism — tracked as a follow-up on the bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)