### PR TITLE
fix(codegen): stage recipient SELFBALANCE from the witness-root header in LE order

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -419,7 +419,10 @@ def dispatchTxRuntimeCodeFunction : String :=
   -- INERT until yisv8.2 removes SELFBALANCE(0x47) from the self-contained reject set.
   -- Conservative: a lookup miss/error leaves SELFBALANCE 0. balance_at_header_state_root
   -- preserves s-regs (s0=state ptr, s1=state len, s2=ctx survive); clobbers only dead a/t-regs.
-  "  la t0, dtrc_hdr_ptr; ld a0, 0(t0)\n  la t0, dtrc_hdr_len; ld a1, 0(t0)\n" ++   -- .57.11.6.5: mtx-gated witness-lookup header (resolved at dispatch entry)
+  -- odq06.1: use the PARENT/witness-root header (svf_parent_rlp), NOT dtrc_hdr_ptr (= sv_this_rlp
+  -- POST header for single-tx, whose root is not in the pre-rooted witness -> bails -> SELFBALANCE 0).
+  -- svf_parent_rlp's stateRoot IS the witness root; == sv_pre_rlp so multi-tx is unchanged.
+  "  la t0, svf_parent_rlp; ld a0, 0(t0)\n  la t0, svf_parent_rlp_len; ld a1, 0(t0)\n" ++
   "  addi a2, s2, 72\n" ++                       -- recipient addr (ctx+72)
   "  mv a3, s0; mv a4, s1\n" ++                   -- witness state ptr/len
   "  la a5, yisv8_self_bal\n" ++
@@ -428,9 +431,16 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  la t0, bv_runtime_payload\n" ++
   "  la t5, srpc_env_base; ld t1, 0(t5)\n" ++                -- 3vc2p.5: env_base from stage_runtime_payload_code
   "  add t2, t0, t1; addi t2, t2, 32\n" ++                   -- t2 = &SELFBALANCE word (env_base+32)
-  "  la t3, yisv8_self_bal\n" ++
-  "  ld t4, 0(t3); sd t4, 0(t2); ld t4, 8(t3); sd t4, 8(t2)\n" ++
-  "  ld t4, 16(t3); sd t4, 16(t2); ld t4, 24(t3); sd t4, 24(t2)\n" ++
+  -- odq06.2: stage SELFBALANCE in stack-word (LE-limb) order, NOT big-endian. h_SELFBALANCE
+  -- (0x47) copies env+32..63 dword-for-dword onto the EVM stack, which is LE-limb (low limb
+  -- first); SSTORE then logs that order and the BAL comparator reverses the BE post-value to
+  -- match. balance_at_header_state_root outputs BE (yisv8_self_bal), so a verbatim copy put the
+  -- balance's low byte in env+63 -> SELFBALANCE pushed a low-word of 0 -> SSTORE logged 0 (bv_fail=34
+  -- self_code_on_set_code balance_1). Byte-reverse the 32-byte BE balance into env+32 so the low
+  -- limb lands at env+32. (CALLVALUE@96 was never SSTORE'd+checked, so its order went unvalidated.)
+  "  la t3, yisv8_self_bal; addi t3, t3, 31; mv t4, t2; li t5, 32\n" ++
+  ".Ldtrc_selfbal_rev:\n" ++
+  "  lbu t6, 0(t3); sb t6, 0(t4); addi t3, t3, -1; addi t4, t4, 1; addi t5, t5, -1; bnez t5, .Ldtrc_selfbal_rev\n" ++
   ".Ldtrc_no_selfbal:\n" ++
   -- bmvmx.1.6.4.2.b: seed every non-recipient BAL account's storage into the exec log
   -- so nested callees SLOAD witness values (not 0). Fills callee_seed_table/count, which


### PR DESCRIPTION
## Summary

The single-tx contract-recipient `SELFBALANCE` staging (`dispatch_tx_runtime_code`, yisv8.1) had two bugs that made `SSTORE(SELFBALANCE)` log **0**, false-rejecting valid blocks with `bv_fail=34` (e.g. `eip7702_set_code_tx/.../self_code_on_set_code` balance_1):

1. **Wrong header.** The recipient balance was looked up against `dtrc_hdr_ptr` = `sv_this_rlp` (this block's POST-state header) for single-tx, whose state root is NOT in the pre-rooted witness → `account_at_address` bails → SELFBALANCE stays 0. Use `svf_parent_rlp` (the parent header, whose `stateRoot` IS the witness root — the recompute uses it). `svf_parent_rlp == sv_pre_rlp`, so the multi-tx path is unchanged (no-op there); only single-tx gains.

2. **Wrong byte order.** `h_SELFBALANCE` (0x47) copies `env+32..63` dword-for-dword onto the EVM stack, which is little-endian-limb (low limb first); `SSTORE` logs that order and the BAL comparator byte-reverses the BE post-value to match. But `balance_at_header_state_root` outputs big-endian, so the verbatim copy put the balance's low byte at `env+63` → SELFBALANCE pushed a low-word of 0. Byte-reverse the 32-byte balance into `env+32` so the low limb lands first. (CALLVALUE@96 shares the handler but is never SSTORE'd-and-checked, so its order went unvalidated.)

## Validation

- `self_code_on_set_code` balance_0 + balance_1: both **PASS(full)** (2/2, 0 fail) — was 1 fail.
- `eip7702_set_code_tx` family: **80/80 full-match, 0 regressions**.
- Broad random sample: **90/90 full-match, 0 regressions**.
- `lake build` clean; `check-forbidden-tactics` OK.

## Soundness

The live nonstorage-effect balance is still checked first (mid-tx transfers reflected); the witness pre-state balance is the fallback (exact for value-unchanged recipients); the post-state-root recompute independently backstops any wrong value, so there is no false-accept path.

Refs evm-asm-odq06 (children odq06.1 header + odq06.2 byte-order). Bead: evm-asm-odq06.

Directed by @pirapira; implemented by Claude Code