### PR TITLE
fix(codegen): stage nested-frame SELFBALANCE from a pre-resolved balance table

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -396,6 +396,18 @@ def ziskStatelessVerdictV2DataSection : String :=
   ".balign 32\n" ++
   "csce_addrkey:\n  .zero 32\n" ++
   "csce_keys:\n  .zero " ++ toString (bsrAccountSlotCap * 32) ++ "\n" ++   -- .66.1.2: bsrAccountSlotCap x 32-byte slot keys (matches the gas-derived bal_recipient_storage_keys cap; the seed loop still skips accounts >128)
+  -- 1ipxd.1: pre-resolved per-account balance table for nested-frame SELFBALANCE.
+  -- seed_callee_storage fills it (clean pre-execution context, where the witness MPT walk
+  -- works — it returns absent mid-EVM-execution); call_frame_descend reads it to stage a
+  -- child frame's env+32. Entry = 64 B: canonical-BE 20-byte address (zero-padded to 32) @0,
+  -- balance @32 in LE-limb (stack-word) order so the descend copies it verbatim to the LE
+  -- EVM stack via h_SELFBALANCE (odq06 byte-order lesson). 128 cap. csce_bal_struct = the
+  -- account_at_header_state_root output (nonce@0 / balance@8..40 BE / sroot / codehash).
+  ".balign 8\n" ++
+  "csce_bal_struct:\n  .zero 104\n" ++
+  "callee_balance_count:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "callee_balance_table:\n  .zero " ++ toString (128 * 64) ++ "\n" ++
 
   "bv_eip7778_status:\n  .zero 8\n" ++
   "bv_eip7778_index:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -86,6 +86,7 @@ def seedCalleeStorageFunction : String :=
   "  mv s1, a1                    # witness len\n" ++
   "  mv s2, a2                    # recipient 20B addr ptr\n" ++
   "  la t0, callee_seed_count; sd zero, 0(t0)\n" ++
+  "  la t0, callee_balance_count; sd zero, 0(t0)\n" ++   -- 1ipxd.1: reset per-account SELFBALANCE table
   "  la t0, bv_bal_start; ld a0, 0(t0); la t0, bv_bal_len; ld a1, 0(t0); la a2, csce_acct_n\n" ++
   "  jal ra, rlp_list_count_items\n" ++
   "  bnez a0, .Lscs_done                # BAL parse error -> seed nothing (conservative)\n" ++
@@ -102,6 +103,28 @@ def seedCalleeStorageFunction : String :=
   "  bnez a0, .Lscs_acct_next\n" ++
   "  la t0, csce_dlen; ld t1, 0(t0); li t2, 20; bne t1, t2, .Lscs_acct_next   # item0 not a 20B address\n" ++
   "  la t0, csce_doff; ld t1, 0(t0); add t1, s3, t1; la t0, csce_addrp; sd t1, 0(t0)   # addr ptr (BE)\n" ++
+  -- 1ipxd.1: pre-resolve this BAL account's balance into callee_balance_table (clean
+  -- pre-execution context; the witness MPT walk returns absent if run mid-EVM-execution
+  -- inside call_frame_descend). Covers the recipient too (it IS a BAL account; the recipient
+  -- skip below is storage-only). Key = canonical-BE 20-byte addr (csce_addrp); value = balance
+  -- stored LE-limb so the descend copies it verbatim to the LE EVM stack (odq06 byte-order).
+  -- Header = svf_parent_rlp (parent/witness root; the single-tx POST header bails). The verdict
+  -- witness.state = s0/s1 (= bv_witness_state). account_at_header_state_root preserves s0-s7.
+  "  la t0, callee_balance_count; ld t1, 0(t0); li t2, 128; bgeu t1, t2, .Lscs_bal_done\n" ++
+  "  la t0, svf_parent_rlp; ld a0, 0(t0); la t0, svf_parent_rlp_len; ld a1, 0(t0)\n" ++
+  "  la t0, csce_addrp; ld a2, 0(t0); li a3, 20; mv a4, s0; mv a5, s1; la a6, csce_bal_struct\n" ++
+  "  jal ra, account_at_header_state_root\n" ++
+  "  bnez a0, .Lscs_bal_done\n" ++                  -- absent/error -> skip (descend default 0)
+  "  la t0, callee_balance_count; ld t1, 0(t0); slli t2, t1, 6; la t3, callee_balance_table; add t3, t3, t2\n" ++
+  -- addr (canonical BE, csce_addrp) -> entry+0..19, zero-pad +20..31
+  "  la t0, csce_addrp; ld t0, 0(t0)\n" ++
+  "  ld t4, 0(t0); sd t4, 0(t3); ld t4, 8(t0); sd t4, 8(t3); lwu t4, 16(t0); sw t4, 16(t3); sw zero, 20(t3); sd zero, 24(t3)\n" ++
+  -- balance: csce_bal_struct+8..40 is BE; byte-reverse the 32 bytes into entry+32 (LE-limb).
+  "  la t4, csce_bal_struct; addi t4, t4, 39; addi t5, t3, 32; li t6, 32\n" ++
+  ".Lscs_bal_rev:\n" ++
+  "  lbu t0, 0(t4); sb t0, 0(t5); addi t4, t4, -1; addi t5, t5, 1; addi t6, t6, -1; bnez t6, .Lscs_bal_rev\n" ++
+  "  la t0, callee_balance_count; ld t1, 0(t0); addi t1, t1, 1; sd t1, 0(t0)\n" ++
+  ".Lscs_bal_done:\n" ++
   -- Skip the recipient (already preloaded BE by dispatch_tx_runtime_code).
   "  li t3, 0\n" ++
   ".Lscs_rcmp:\n" ++

--- a/EvmAsm/Codegen/Programs/CallFrameDescend.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameDescend.lean
@@ -320,6 +320,32 @@ def callFrameDescendFunction : String :=
   "  addi t0, s3, 128; addi t1, s9, 128; li t2, 288\n" ++
   ".Lcfd_envconst:\n" ++
   "  ld t3, 0(t0); sd t3, 0(t1); addi t0, t0, 8; addi t1, t1, 8; addi t2, t2, -8; bnez t2, .Lcfd_envconst\n" ++
+  -- 8c (1ipxd.1): stage the child's SELFBALANCE (env+32) from the pre-resolved balance table.
+  -- call_frame_set_call_env stages ADDRESS/CALLER/CALLVALUE but NOT selfBalance (a per-frame
+  -- balance, not a tx constant), so a nested SELFBALANCE would read BAL-replay-dirtied garbage;
+  -- pointer_reentry's re-entered EOA SSTOREs SELFBALANCE=1000 and the directly-called contract
+  -- 100. The witness lookup can't run here (mid-EVM-execution the MPT walk returns absent), so
+  -- dispatch_tx_runtime_code pre-resolved every BAL account's balance into callee_balance_table
+  -- (LE-limb order). Reverse the child ADDRESS@0 (20B stack-word/LE, MSB at env+19) into the free
+  -- child-env scratch (env+696; frameEnvBytes=768, fields end 688) -> canonical BE, scan the table,
+  -- and copy the matching LE balance verbatim into env+32 (h_SELFBALANCE copies env+32 to the LE
+  -- stack dword-for-dword). Miss -> leave 0. CALLCODE/DELEGATECALL: ADDRESS = parent's, still the
+  -- storage-context account.
+  "  sd zero, 32(s9); sd zero, 40(s9); sd zero, 48(s9); sd zero, 56(s9)\n" ++
+  "  addi t0, s9, 696; addi t1, s9, 19; li t2, 20\n" ++
+  ".Lcfd_sb_rev:\n" ++
+  "  lbu t3, 0(t1); sb t3, 0(t0); addi t1, t1, -1; addi t0, t0, 1; addi t2, t2, -1; bnez t2, .Lcfd_sb_rev\n" ++
+  "  la t0, callee_balance_count; ld t0, 0(t0); la t1, callee_balance_table\n" ++
+  ".Lcfd_sb_scan:\n" ++
+  "  beqz t0, .Lcfd_sb_done\n" ++
+  "  ld t2, 0(t1); ld t3, 696(s9); bne t2, t3, .Lcfd_sb_next\n" ++
+  "  ld t2, 8(t1); ld t3, 704(s9); bne t2, t3, .Lcfd_sb_next\n" ++
+  "  lwu t2, 16(t1); lwu t3, 712(s9); bne t2, t3, .Lcfd_sb_next\n" ++
+  "  ld t2, 32(t1); sd t2, 32(s9); ld t2, 40(t1); sd t2, 40(s9); ld t2, 48(t1); sd t2, 48(s9); ld t2, 56(t1); sd t2, 56(s9)\n" ++
+  "  j .Lcfd_sb_done\n" ++
+  ".Lcfd_sb_next:\n" ++
+  "  addi t1, t1, 64; addi t0, t0, -1; j .Lcfd_sb_scan\n" ++
+  ".Lcfd_sb_done:\n" ++
   -- nxio8.4.1: snapshot the parent's pre-child EIP-8037 state gas (the global
   -- evm_state_gas_left = state_gas_left reservoir, evm_state_gas_used = state_gas_used) into the
   -- child env so a child REVERT / exceptional halt can restore it in frame_return,


### PR DESCRIPTION
## Summary

A child CALL frame's `env.selfBalance` (env+32) was never staged. `call_frame_set_call_env` sets ADDRESS/CALLER/CALLVALUE, but `selfBalance` is a per-frame *balance* (the executing account's), not a tx constant covered by the env-constant inheritance (#9009). So a nested `SELFBALANCE` read BAL-replay-dirtied garbage; when `SSTORE`'d it false-rejected valid blocks (`bv_fail=34`) — e.g. `eip7702_set_code_tx/.../pointer_reentry`: the re-entered EOA stores `SELFBALANCE=1000`, the directly-called contract stores 100.

The witness balance lookup can't run inside `call_frame_descend` (mid-EVM-execution the MPT walk returns absent — same finding as odq06/#9010). So `dispatch_tx_runtime_code` pre-resolves every BAL account's balance in the **clean pre-execution context** (`seed_callee_storage`, where the witness walk works) into `callee_balance_table`, keyed by canonical-BE address, with the balance stored in **LE-limb order**. The lookup uses `svf_parent_rlp` (the parent/witness-root header; the single-tx POST header bails) + the verdict's full witness.state. `call_frame_descend` reverses the child ADDRESS to canonical BE, scans the table, and copies the matching LE balance verbatim into env+32 (`h_SELFBALANCE` copies env+32 to the LE EVM stack dword-for-dword). A miss leaves SELFBALANCE 0 (conservative).

## Validation

- `pointer_reentry`: **PASS(full)** (1/1, 0 fail) — was `bv_fail=34`.
- `eip7702_set_code_tx` family: **90/90 full-match, 0 regressions**.
- Broad random sample: **100/100 full-match, 0 regressions**.
- `lake build` clean; `check-forbidden-tactics` OK.

## Soundness

The witness pre-state balance is exact for value-unchanged accounts; the post-state-root recompute independently backstops any wrong value (no false-accept). Builds on the LE byte-order + `svf_parent_rlp` lessons from #9010.

Refs evm-asm-1ipxd.1; completes the nested half of evm-asm-1ipxd (the env-constant half shipped in #9009). Bead: evm-asm-1ipxd.1.

Directed by @pirapira; implemented by Claude Code