### PR TITLE
feat(verdict): raise non-storage effect-log cap 64->256 to enforce mid-size blocks

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -1198,11 +1198,13 @@ def ziskStatelessVerdictV2DataSection : String :=
   -- for the multi-tx nonstorage comparators. record_nonstorage_effect APPENDS one record
   -- per CALL, so a multi-tx-touched account has N records; fold them into one entry keyed
   -- by the 20B BE address (first-seen pre kept, last-seen post overwritten) so the per-
-  -- account comparator sees the block-aggregate {pre, post}. Dedup -> count <= the log cap
-  -- (64), so 64 x 112 B suffices.
+  -- account comparator sees the block-aggregate {pre, post}. Dedup -> count <= the log cap,
+  -- so cap x 112 B suffices. MUST equal nonstorageEffectLogCap * 112 (NonstorageEffectLog.lean):
+  -- the .Lbv_agg_append loop has no separate bounds check, so an undersized buffer here is a
+  -- heap overflow. Currently 256 * 112 = 28672 (raised with the cap, bmvmx.5.5.2.2.9 partial).
   ".balign 8\n" ++
   "exec_nonstorage_effect_agg_count:\n  .zero 8\n" ++
-  "exec_nonstorage_effect_agg:\n  .zero 7168\n" ++
+  "exec_nonstorage_effect_agg:\n  .zero 28672\n" ++
   -- bmvmx.5.5.2 (umbrella-B1): scratch for the multi-tx per-sender FINAL-nonce check
   -- (BAL sender post nonce == pre + total sender tx count). bv_b1_finals is the 88-byte
   -- bal_account_nonstorage_finals output (separate from c2nsc_finals, which A2a's

--- a/EvmAsm/Codegen/Programs/NonstorageEffectLog.lean
+++ b/EvmAsm/Codegen/Programs/NonstorageEffectLog.lean
@@ -34,8 +34,14 @@ namespace EvmAsm.Codegen
 
 open EvmAsm.Rv64
 
-/-- Capacity (entries) of the non-storage effect log — touched non-recipient accounts per tx. -/
-def nonstorageEffectLogCap : Nat := 64
+/-- Capacity (entries) of the non-storage effect log — touched non-recipient accounts per tx.
+    Raised 64→256 (bmvmx.5.5.2.2.9 partial): blocks with 64–256 non-storage (balance/nonce)
+    effects no longer overflow → the A2a all-accounts exec-vs-BAL comparator and the B2.3
+    cumulative-balance check ENFORCE them instead of conservatively skipping on overflow.
+    Blocks with >256 such effects still overflow (skip), so the larger A2a/agg work cannot
+    push a near-step-budget huge block past its budget. The exec_nonstorage_effect_log and
+    exec_nonstorage_effect_agg buffers are both sized at this cap × 112 B. -/
+def nonstorageEffectLogCap : Nat := 256
 
 /-! ## record_nonstorage_effect
     Append one per-account balance/nonce effect record (c2#5 layout, 112 B fixed).


### PR DESCRIPTION
Raises `nonstorageEffectLogCap` 64→256 so blocks with 64–256 non-storage (balance/nonce) effects are **enforced** by the A2a exec-vs-BAL comparator + B2.3 cumulative-balance check instead of conservatively skipped on overflow. Partial elimination of the `bmvmx.5.5.2.2.9` effect-log-overflow skip.

**Sound by construction:** a larger arena only enables more enforcement — it cannot false-reject (valid blocks still pass A2a/B2.3). Blocks with >256 such effects still overflow/skip, so the larger aggregation work cannot push a near-step-budget huge block past its budget. The hardcoded `exec_nonstorage_effect_agg` buffer is grown in lockstep (7168→28672 = cap×112; the `.Lbv_agg_append` loop has no separate bounds check).

**Validation:** build clean; all 22 eip8037 `block_2d_gas` fixtures (incl the 1021-tx `block_2d_gas_valid_when_cumulative_exceeds_limit`) PASS(full), 0 fail. Broad sweep result in a comment.

Full 200M-gas capacity remains the `bmvmx.5.5.7.*` track (needs the O(N²) aggregation linearized first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)