### PR TITLE
RLP RV64: fully concrete end-to-end long-item list decoder (step 6c)

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -66,6 +66,7 @@ import EvmAsm.Rv64.RLP.UnifiedListLoopBody
 import EvmAsm.Rv64.RLP.UnifiedItemStride
 import EvmAsm.Rv64.RLP.UnifiedListLoop
 import EvmAsm.Rv64.RLP.UnifiedDecoderConcrete
+import EvmAsm.Rv64.RLP.UnifiedListLoopConcrete
 import EvmAsm.Rv64.RLP.UnifiedDecodeItem
 import EvmAsm.Rv64.RLP.UnifiedDecodeItemReconverge
 import EvmAsm.Rv64.RLP.UnifiedDecodeItemReconvergeAll

--- a/EvmAsm/Rv64/RLP/UnifiedListLoopConcrete.lean
+++ b/EvmAsm/Rv64/RLP/UnifiedListLoopConcrete.lean
@@ -1,0 +1,101 @@
+/-
+  EvmAsm.Rv64.RLP.UnifiedListLoopConcrete
+
+  EL.3 — the fully CONCRETE end-to-end ALL-class RLP list decoder. Wires the
+  concrete single-item decoder (`unified_decoder_spec`, `UnifiedDecoderConcrete.lean`)
+  into the unified list-loop bridge (`unified_loop_bridge`, `UnifiedListLoop.lean`),
+  discharging the loop's abstract `UnifiedDecoderH` and all its code-layout
+  side-conditions. The result `unified_list_loop_concrete_bridge` has NO abstract
+  hypotheses: a real RV64 program — `[LBU x5,x13,0] ++ unified_decoder_prog ++
+  [ADD, ADDI, BNE]` laid out at `lbase` — decodes a non-empty list of ARBITRARY
+  RLP items (all 5 classes, including long strings/lists) from `bytesRegion` in
+  `64 * items.length` steps AND coincides with the pure `decodeItems` round-trip.
+  This completes single-level long-item list decoding (the all-class analog of
+  `FlatListLoopConcrete.lean`).
+
+  Layout (program base `lbase`; the loop scaffold brackets the 36-instruction
+  decoder, so `joinPC = lbase + 148`, loop exit `lbase + 160`):
+      lbase       LBU  x5, x13, 0          ; read prefix byte
+      lbase+4     < unified_decoder_prog : 36 instr, joins at lbase+148 >
+      lbase+148   ADD  x13, x13, x11       ; advance to next item
+      lbase+152   ADDI x15, x15, -1        ; item counter (x15)
+      lbase+156   BNE  x15, x0, -156       ; loop back to lbase
+-/
+
+import EvmAsm.Rv64.RLP.UnifiedListLoop
+import EvmAsm.Rv64.RLP.UnifiedDecoderConcrete
+import EvmAsm.Rv64.Tactics.SeqFrame
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL.RLP
+open EvmAsm.Rv64.Tactics
+
+/-- **Fully concrete end-to-end all-class list decoder.** The RV64 program laid
+    out at `lbase` (loop scaffold + `unified_decoder_prog`) decodes a non-empty
+    list of arbitrary RLP items from `bytesRegion regionBase (encode.encodeItems
+    items)` in `64 * items.length` steps — leaving the pointer at the region end
+    and the counter zero — and the pure decoder recovers exactly `items`. No
+    abstract decoder hypothesis remains. -/
+theorem unified_list_loop_concrete_bridge
+    (lbase regionBase : Word) (items : List RLPItem) (v5Old v10 v11Old v12Old v14Old : Word)
+    (halign : regionBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + (encode.encodeItems items).length < 2 ^ 64)
+    (hne : items ≠ [])
+    (hwin : ∀ i, i < (encode.encodeItems items).length →
+       isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hsize : (encode.encodeItems items).length < 256 ^ 8) :
+    cpsTripleWithin (64 * items.length) lbase (lbase + 148 + 12)
+      (((((CodeReq.singleton lbase (.LBU .x5 .x13 0)).union
+            (CodeReq.ofProg (lbase + 4) unified_decoder_prog)).union
+            (CodeReq.singleton (lbase + 148) (.ADD .x13 .x13 .x11))).union
+            (CodeReq.singleton (lbase + 148 + 4) (.ADDI .x15 .x15 (-1)))).union
+            ((CodeReq.singleton (lbase + 148 + 8) (.BNE .x15 .x0 (-156))).union CodeReq.empty))
+      ((.x5 ↦ᵣ v5Old) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
+       (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ regionBase) ** (.x14 ↦ᵣ v14Old) **
+       (.x15 ↦ᵣ BitVec.ofNat 64 items.length) ** bytesRegion regionBase (encode.encodeItems items))
+      (unified_loop_post regionBase (encode.encodeItems items)
+        (regionBase + BitVec.ofNat 64 (encode.encodeItems items).length))
+    ∧ decodeItems (2 * (encode.encodeItems items).length + 1) (encode.encodeItems items)
+        = some (items, []) := by
+  -- Discharge the loop's abstract decoder hypothesis with the concrete decoder spec.
+  have decoderH : UnifiedDecoderH regionBase (lbase + 4) (lbase + 148)
+      (CodeReq.ofProg (lbase + 4) unified_decoder_prog) (encode.encodeItems items) := by
+    intro i hi v10' v11' v12' v14' hwindow
+    have hd := unified_decoder_spec (lbase + 4) regionBase (encode.encodeItems items) i hi
+      v10' v11' v12' v14' halign hover hwindow
+    rwa [show (lbase + 4) + 144 = lbase + 148 from by bv_omega] at hd
+  have hback : (lbase + 148 + 8) + signExtend13 (-156 : BitVec 13) = lbase := by
+    have h156 : signExtend13 (-156 : BitVec 13) = (-156 : Word) := by decide
+    rw [h156]; bv_omega
+  -- The decoder occupies `[lbase+4, lbase+148)`; every loop-scaffold address is outside it.
+  have dcr_none : ∀ (a : Word),
+      (∀ k, k < 36 → a ≠ (lbase + 4) + BitVec.ofNat 64 (4 * k)) →
+      CodeReq.ofProg (lbase + 4) unified_decoder_prog a = none :=
+    fun a h => CodeReq.ofProg_none_range_len (lbase + 4) unified_decoder_prog 36 a
+      unified_decoder_prog_length h
+  exact unified_loop_bridge regionBase lbase (lbase + 148) (lbase + 4)
+    (CodeReq.ofProg (lbase + 4) unified_decoder_prog) (-156)
+    items v5Old v10 v11Old v12Old v14Old halign hover rfl decoderH hback
+    (by bv_omega) (by bv_omega) (by bv_omega)
+    (CodeReq.Disjoint.singleton_ofProg (dcr_none lbase (by intro k hk; bv_omega)))
+    (CodeReq.Disjoint.ofProg_singleton (dcr_none (lbase + 148) (by intro k hk; bv_omega)))
+    (CodeReq.Disjoint.ofProg_singleton (dcr_none (lbase + 148 + 4) (by intro k hk; bv_omega)))
+    (CodeReq.Disjoint.ofProg_singleton (dcr_none (lbase + 148 + 8) (by intro k hk; bv_omega)))
+    hne hwin hsize
+
+-- Concrete cross-check: the program at `lbase = 0x1000` decodes the two-item list
+-- `[0x01, 0x02]` from the region at `0x2000` (in `64 * 2 = 128` steps), and the
+-- pure decoder recovers it. The inferred type is the full end-to-end bridge.
+example :=
+  unified_list_loop_concrete_bridge (0x1000 : Word) (0x2000 : Word)
+    [.bytes [(0x01 : Byte)], .bytes [(0x02 : Byte)]] 0 0 0 0 0
+    (by decide) (by decide) (by decide)
+    (by intro i hi
+        have hlen : (encode.encodeItems
+            [.bytes [(0x01 : Byte)], .bytes [(0x02 : Byte)]]).length = 2 := by decide
+        rw [hlen] at hi; interval_cases i <;> decide)
+    (by decide)
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -1457,11 +1457,20 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     the region decoder's `e_target + k` form (syntactic unification, not BitVec defeq) and skip
     `simp only [rlp_phase1_step_code]` in the subset proofs (defeq handles the abbrev); needs
     `set_option maxHeartbeats 800000`/`maxRecDepth 8000`. Axiom-clean, 0 sorry, 0 warnings.
-  - **Next (step 6c, analog of #9008):** `UnifiedListLoopConcrete.lean` — assemble `[LBU] ++
-    unified_decoder_prog ++ [ADD, ADDI, BNE]`, build `UnifiedDecoderH` from `unified_decoder_spec`
-    (decoder_base = lbase+4, joinPC = lbase+4+144, threading the window guard per item), call
-    `unified_loop_bridge` for the no-abstract-hypotheses end-to-end + concrete 2-item `example` —
-    completes single-level long-item list decoding.
+  - ✅ **Step 6c — fully concrete end-to-end** (`UnifiedListLoopConcrete.lean`, analog of #9008).
+    **`unified_list_loop_concrete_bridge`** has NO abstract hypotheses: the real RV64 program `[LBU
+    x5,x13,0] ++ unified_decoder_prog ++ [ADD x13 x13 x11, ADDI x15 x15 -1, BNE x15 x0 -156]` at `lbase`
+    (scaffold bracketing the 36-instr decoder so `joinPC = lbase+148`, exit `lbase+160`, back-edge
+    `-156`) **decodes a non-empty list of ARBITRARY RLP items (all 5 classes, long strings/lists
+    included) from `bytesRegion` in `64*items.length` steps AND coincides with the pure `decodeItems`
+    round-trip**. Discharges `unified_loop_bridge`'s abstract `UnifiedDecoderH` via `unified_decoder_spec
+    (lbase+4)` (`rwa [(lbase+4)+144 = lbase+148]`); back-edge `signExtend13 (-156) = -156` by `decide`;
+    scaffold/decoder disjointness via `dcr_none` (`ofProg_none_range_len`, n=36) + `Disjoint.singleton_
+    ofProg`/`ofProg_singleton`. Concrete 2-item `example`. Built first try, axiom-clean, 0 sorry. **This
+    completes the long-item RLP list-decoder arc — single-level lists of all 5 classes now decode
+    end-to-end in real RISC-V with a kernel-checkable round-trip proof.**
+- **Phase 4 done.** RLP single-level list decoding (flat #9004–#9008 + long-item #9020–#9031) is
+  complete. Remaining for feature-complete RLP:
 - Phase 5: Recursive list decode (iterative with explicit stack)
 - Phase 6: Top-level pipeline (`read_input` -> decode -> `write_output`)
 - **Host I/O ABI**: See `docs/zkvm-host-io-interface.md`; SP1


### PR DESCRIPTION
## Summary

Completes the long-item RLP list-decoder arc — the all-class analog of the flat `FlatListLoopConcrete.lean` (#9008). `unified_list_loop_concrete_bridge` has **NO abstract hypotheses**: a real RV64 program decodes a non-empty list of **arbitrary RLP items (all 5 classes, including long strings and lists)** from `bytesRegion` in `64 · items.length` steps **and** coincides with the pure `decodeItems` round-trip.

New file `EvmAsm/Rv64/RLP/UnifiedListLoopConcrete.lean`. Program at `lbase`:

```
lbase       LBU  x5, x13, 0           ; read prefix byte
lbase+4     < unified_decoder_prog : 36 instr, joins at lbase+148 >
lbase+148   ADD  x13, x13, x11        ; advance to next item
lbase+152   ADDI x15, x15, -1         ; item counter
lbase+156   BNE  x15, x0, -156        ; loop back to lbase
lbase+160   (exit)
```

The proof wires the concrete single-item decoder (`unified_decoder_spec`, #9031) into the loop bridge (`unified_loop_bridge`, #9028):
- the abstract `UnifiedDecoderH` is discharged by `unified_decoder_spec (lbase+4)` (with `(lbase+4)+144 = lbase+148`), threading the `regionLongWindow` guard (#9029) per item;
- the outer-loop back-edge `signExtend13 (-156) = -156` by `decide` + `bv_omega`;
- the 4 scaffold/decoder disjointness goals via `dcr_none` (`ofProg_none_range_len`, n=36) + `Disjoint.singleton_ofProg`/`ofProg_singleton`.

Plus a concrete 2-item `example`. Built on the first attempt.

## Context

Long-item list-loop arc, **step 6c** — the final step. With this, **Phase 4 (RLP single-level list decoding) is complete**: flat (#9004–#9008) + long-item (#9020–#9031) lists of all 5 classes now decode end-to-end in real RISC-V with a kernel-checkable round-trip proof. Remaining RLP work: Phase 5 (nested/recursive lists) and Phase 6 (top-level `read_input → decode → write_output` pipeline).

## Verification

- `lake build` clean (module + umbrella `EvmAsm.Rv64.RLP`).
- `scripts/check-forbidden-tactics.sh` OK (no `bv_decide`/`native_decide`); `scripts/check-no-warnings.sh` → 0 warnings under `EvmAsm/`.
- `#print axioms unified_list_loop_concrete_bridge` → `[propext, Classical.choice, Quot.sound]`; 0 `sorry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)