### PR TITLE
RLP RV64: nested decode — descend-one-level kernel (Phase 5 step 1)

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -67,6 +67,7 @@ import EvmAsm.Rv64.RLP.UnifiedItemStride
 import EvmAsm.Rv64.RLP.UnifiedListLoop
 import EvmAsm.Rv64.RLP.UnifiedDecoderConcrete
 import EvmAsm.Rv64.RLP.UnifiedListLoopConcrete
+import EvmAsm.Rv64.RLP.NestedDescendOne
 import EvmAsm.Rv64.RLP.UnifiedDecodeItem
 import EvmAsm.Rv64.RLP.UnifiedDecodeItemReconverge
 import EvmAsm.Rv64.RLP.UnifiedDecodeItemReconvergeAll

--- a/EvmAsm/Rv64/RLP/NestedDescendOne.lean
+++ b/EvmAsm/Rv64/RLP/NestedDescendOne.lean
@@ -1,0 +1,129 @@
+/-
+  EvmAsm.Rv64.RLP.NestedDescendOne
+
+  EL.3 / Phase 5 (nested decode) — the descend-one-level kernel. The single-item
+  decoder, applied to a `.list` item, leaves `x13 = itemPtrRegion` (payload start
+  pointer) and `x11 = itemLenRegion` (payload byte length). `list_item_payload_window`
+  proves that this operational window is EXACTLY the `encode.encodeItems items`
+  payload — the bytes the pure `decodeAux` hands to `decodeItems` when it recurses
+  into a list. This is the all-class analog, for the payload window, of the 5a
+  stride lemma (`encode_head_eq_itemNextPtrRegion`), and the inductive kernel a
+  recursive-descent decoder rests on: a caller can frame the payload sub-window
+  `bs.drop payloadOff = encode.encodeItems items (++ tail)` and run the list loop on
+  it to descend one level.
+-/
+
+import EvmAsm.Rv64.RLP.UnifiedItemStride
+import EvmAsm.EL.RLP.Properties
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL.RLP
+
+set_option maxRecDepth 4000
+
+/-- `(BitVec.ofNat 8 k).toNat = k` for a byte-sized `k`. -/
+private theorem toNat_ofNat8' {k : Nat} (h : k < 256) : (BitVec.ofNat 8 k).toNat = k := by
+  rw [BitVec.toNat_ofNat, show (2 : Nat) ^ 8 = 256 from rfl]; omega
+
+/-- **List-item payload window.** For a `.list items` item at byte offset `off` of
+    the region, the single-item decoder's window — `itemPtrRegion` (the `x13`
+    payload pointer) and `itemLenRegion` (the `x11` payload length) — points exactly
+    at the `encode.encodeItems items` payload. The third conjunct
+    (`bs.drop payloadOff = encode.encodeItems items ++ tail`) is precisely the
+    precondition the list loop consumes, so a caller can descend into the sub-list. -/
+theorem list_item_payload_window (items : List RLPItem) (tail : List Byte)
+    (regionBase : Word) (off : Nat) (bs : List Byte)
+    (hdrop : bs.drop off = encode (.list items) ++ tail)
+    (hsize : (encode.encodeItems items).length < 256 ^ 8) :
+    ∃ payloadOff,
+      itemPtrRegion ((encode (.list items))[0]'(encode_nonempty _)) regionBase off
+        = regionBase + BitVec.ofNat 64 payloadOff
+      ∧ itemLenRegion ((encode (.list items))[0]'(encode_nonempty _)) bs off
+        = BitVec.ofNat 64 (encode.encodeItems items).length
+      ∧ bs.drop payloadOff = encode.encodeItems items ++ tail := by
+  by_cases h55 : (encode.encodeItems items).length ≤ 55
+  · -- short list: header is one prefix byte; payload starts at `off + 1`
+    have henc : encode (.list items)
+        = BitVec.ofNat 8 (0xC0 + (encode.encodeItems items).length)
+            :: encode.encodeItems items :=
+      encode_list_short items h55
+    have hb : (encode (.list items))[0]'(encode_nonempty _)
+        = BitVec.ofNat 8 (0xC0 + (encode.encodeItems items).length) := by simp [henc]
+    have hcls : classifyPrefix ((encode (.list items))[0]'(encode_nonempty _)) = .shortList := by
+      rw [hb, classifyPrefix_shortList_iff, toNat_ofNat8' (by omega)]; omega
+    refine ⟨off + 1, ?_, ?_, ?_⟩
+    · simp only [itemPtrRegion, hcls]
+    · simp only [itemLenRegion, hcls]
+      rw [hb, rlpPrefixShortListPayloadLen, toNat_ofNat8' (by omega)]
+      congr 1; omega
+    · have hdd : bs.drop (off + 1) = (bs.drop off).drop 1 := by rw [List.drop_drop]
+      rw [hdd, hdrop, henc]
+      simp only [List.cons_append, List.drop_succ_cons, List.drop_zero]
+  · -- long list: header is prefix + `lenOfLen` length bytes; payload after them
+    rw [Nat.not_le] at h55
+    have hle : (Nat.toBytesBE (encode.encodeItems items).length).length ≤ 8 :=
+      Nat.toBytesBE_length_le _ 8 hsize
+    have henc : encode (.list items)
+        = BitVec.ofNat 8 (0xF7 + (Nat.toBytesBE (encode.encodeItems items).length).length)
+            :: (Nat.toBytesBE (encode.encodeItems items).length ++ encode.encodeItems items) :=
+      encode_list_long items h55
+    have hb : (encode (.list items))[0]'(encode_nonempty _)
+        = BitVec.ofNat 8 (0xF7 + (Nat.toBytesBE (encode.encodeItems items).length).length) := by
+      simp [henc]
+    have hcls : classifyPrefix ((encode (.list items))[0]'(encode_nonempty _)) = .longList := by
+      rcases classifyPrefix_encode_head_long (.list items) (by simp [isLongItem]; omega)
+        (by simpa [itemPayloadCount] using hsize) with h | h
+      · exfalso; rw [hb, classifyPrefix_longBytes_iff, toNat_ofNat8' (by omega)] at h; omega
+      · exact h
+    have hlol : rlpPrefixLongListLenOfLen ((encode (.list items))[0]'(encode_nonempty _))
+        = (Nat.toBytesBE (encode.encodeItems items).length).length := by
+      rw [hb, rlpPrefixLongListLenOfLen, toNat_ofNat8' (by omega)]; omega
+    refine ⟨(off + 1) + (Nat.toBytesBE (encode.encodeItems items).length).length, ?_, ?_, ?_⟩
+    · simp only [itemPtrRegion, hcls, hlol]
+    · -- the read length bytes round-trip to the payload count
+      simp only [itemLenRegion, hcls, hlol]
+      have hlenbytes : (bs.drop (off + 1)).take (Nat.toBytesBE (encode.encodeItems items).length).length
+          = Nat.toBytesBE (encode.encodeItems items).length := by
+        have hdd : bs.drop (off + 1) = (bs.drop off).drop 1 := by rw [List.drop_drop]
+        rw [hdd, hdrop, henc]
+        simp only [List.cons_append, List.append_assoc, List.drop_succ_cons, List.drop_zero]
+        exact List.take_left' rfl
+      rw [hlenbytes, Nat.fromBytesBE_toBytesBE]
+    · -- skip the prefix + length bytes to reach the payload
+      have hdd : bs.drop ((off + 1) + (Nat.toBytesBE (encode.encodeItems items).length).length)
+          = ((bs.drop off).drop 1).drop (Nat.toBytesBE (encode.encodeItems items).length).length := by
+        rw [List.drop_drop, List.drop_drop]; congr 1; omega
+      rw [hdd, hdrop, henc]
+      simp only [List.cons_append, List.append_assoc, List.drop_succ_cons, List.drop_zero]
+      exact List.drop_left' rfl
+
+/-- **Descend connection (top-level).** A top-level list decodes to its items, and
+    the operational payload window points at exactly the bytes `decodeItems`
+    consumes — so the list loop applied to `bs.drop payloadOff = encode.encodeItems
+    items` descends one level, matching the pure `decode`/`decodeAux` recursion. -/
+theorem decode_list_descend (items : List RLPItem)
+    (hsize : (encode (.list items)).length < 256 ^ 8) :
+    decode (encode (.list items)) = some (.list items, []) :=
+  decode_encode (.list items) hsize
+
+-- Sanity: a two-item nested list. The window points at the payload `[0x01, 0x02]`
+-- (the encoded sub-items), and the pure decoder recovers the nested structure.
+example (regionBase : Word) :=
+  list_item_payload_window [.bytes [(0x01 : Byte)], .bytes [(0x02 : Byte)]] []
+    regionBase 0 (encode (.list [.bytes [(0x01 : Byte)], .bytes [(0x02 : Byte)]]))
+    (by simp) (by decide)
+
+example :
+    decode (encode (.list [.bytes [(0x01 : Byte)], .bytes [(0x02 : Byte)]]))
+      = some (.list [.bytes [(0x01 : Byte)], .bytes [(0x02 : Byte)]], []) :=
+  decode_list_descend _ (by decide)
+
+-- A genuinely nested example (a list containing an empty list and a sub-list).
+example :
+    decode (encode (.list [.list [], .bytes [(0x01 : Byte)], .list [.bytes [(0x02 : Byte)]]]))
+      = some (.list [.list [], .bytes [(0x01 : Byte)], .list [.bytes [(0x02 : Byte)]]], []) :=
+  decode_list_descend _ (by decide)
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -1472,6 +1472,24 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
 - **Phase 4 done.** RLP single-level list decoding (flat #9004–#9008 + long-item #9020–#9031) is
   complete. Remaining for feature-complete RLP:
 - Phase 5: Recursive list decode (iterative with explicit stack)
+  - ✅ **Step 1 — descend-one-level kernel** (`NestedDescendOne.lean`). **`list_item_payload_window`**:
+    for a `.list items` item at offset `off`, the single-item decoder's window (`x13 = itemPtrRegion`
+    payload pointer, `x11 = itemLenRegion` payload length) points at EXACTLY the `encode.encodeItems
+    items` payload — `∃ payloadOff, itemPtrRegion = regionBase + ofNat payloadOff ∧ itemLenRegion =
+    ofNat (encodeItems items).length ∧ bs.drop payloadOff = encode.encodeItems items ++ tail` (the
+    third conjunct is precisely the list loop's `hdrop` precondition, so a caller can descend). The
+    all-class analog, for the payload window, of the 5a stride lemma; short-list via
+    `classifyPrefix_shortList_iff` + `encode_list_short`, long-list via `classifyPrefix_encode_head_long`
+    + `encode_list_long` + `take_left'`/`drop_left'` + `fromBytesBE_toBytesBE`. Plus `decode_list_descend`
+    (top-level round-trip) and concrete nested `example`s. Axiom-clean, 0 sorry.
+  - **Next (step 2 — operational descent assembly):** a combined program (header single-item decoder +
+    list loop at the payload offset) decoding a top-level nested list end-to-end, coinciding with
+    `decode` — `cpsTripleWithin_seq` of `unified_decoder_spec` + `unified_loop_spec_within`, with `x15 =
+    items.length` as a precondition (count deferred). Then **step 3+** — a **length-driven** loop (decode
+    until `x13` reaches `payload_end`, no known count; the prerequisite for genuine recursion), then
+    either bounded fixed-depth composition for the STF's block/tx structure or the general explicit-stack
+    recursive decoder. NOTE the impedance mismatch: the existing loop is COUNT-driven (`x15 =
+    items.length`) but real decode is LENGTH-driven — resolving that is step 3's crux.
 - Phase 6: Top-level pipeline (`read_input` -> decode -> `write_output`)
 - **Host I/O ABI**: See `docs/zkvm-host-io-interface.md`; SP1
   `HINT_LEN`/`HINT_READ`/`COMMIT` are legacy handler shapes, not the target


### PR DESCRIPTION
## Summary

First step of **Phase 5 (nested/recursive RLP decode)** — the self-contained inductive kernel. The current decoder treats a `.list` item *opaquely* (computes its total length and skips its bytes via the stride); the pure spec *recurses* (`decodeAux` calls `decodeItems` on the payload). This PR establishes the fact that bridges the two: **the single-item decoder's window for a list item IS the sub-list payload**.

New file `EvmAsm/Rv64/RLP/NestedDescendOne.lean`:

- **`list_item_payload_window`** — for a `.list items` item at byte offset `off`, the decoder's `x13 = itemPtrRegion` (payload pointer) and `x11 = itemLenRegion` (payload length) point at exactly the `encode.encodeItems items` payload:
  ```
  ∃ payloadOff, itemPtrRegion … = regionBase + ofNat payloadOff
    ∧ itemLenRegion … = ofNat (encode.encodeItems items).length
    ∧ bs.drop payloadOff = encode.encodeItems items ++ tail
  ```
  The third conjunct is precisely the list loop's `hdrop` precondition, so a caller can frame the payload sub-window and run the loop to **descend one level**. This is the all-class analog, for the payload window, of the 5a stride lemma (`encode_head_eq_itemNextPtrRegion`) — short-list via `classifyPrefix_shortList_iff` + `encode_list_short`; long-list via `classifyPrefix_encode_head_long` + `encode_list_long` + `take_left'`/`drop_left'` + `fromBytesBE_toBytesBE`.
- **`decode_list_descend`** — top-level nested round-trip, plus concrete nested `example`s (including a list containing an empty list and a sub-list).

## Context

The pure spec already handles arbitrary nesting (mutual `decodeAux`/`decodeItems` recursion, fuel-bounded; `decode_encode_mutual` proves nested round-trips at any depth). This kernel is the operational↔recursive-branch link a recursive-descent decoder rests on.

Deferred to later steps (per the agreed "kernel first" strategy): the **operational descent assembly** (wiring the decoder window into the loop via `cpsTripleWithin_seq`, step 2) and the **length-driven loop** needed for genuine recursion (step 3). Note the impedance mismatch the kernel surfaced — the existing loop is *count-driven* (`x15 = items.length`) while real RLP decode is *length-driven*; resolving that is step 3's crux, after which we choose bounded fixed-depth composition (for the STF's block/tx structure) vs. the general explicit-stack recursive decoder.

## Verification

- `lake build` clean (module + umbrella `EvmAsm.Rv64.RLP`).
- `scripts/check-forbidden-tactics.sh` OK (no `bv_decide`/`native_decide`); `scripts/check-no-warnings.sh` → 0 warnings under `EvmAsm/`.
- `#print axioms list_item_payload_window` / `decode_list_descend` → `[propext, Classical.choice, Quot.sound]`; 0 `sorry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)