### PR TITLE
RLP RV64: length-driven list-loop body (Phase 5 step 2)

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -63,6 +63,7 @@ import EvmAsm.Rv64.RLP.Phase1E5LongListFull
 import EvmAsm.Rv64.RLP.Phase1LongFullRegion
 import EvmAsm.Rv64.RLP.UnifiedDecodeItemReconvergeAllRegion
 import EvmAsm.Rv64.RLP.UnifiedListLoopBody
+import EvmAsm.Rv64.RLP.UnifiedLenLoopBody
 import EvmAsm.Rv64.RLP.UnifiedItemStride
 import EvmAsm.Rv64.RLP.UnifiedListLoop
 import EvmAsm.Rv64.RLP.UnifiedDecoderConcrete

--- a/EvmAsm/Rv64/RLP/UnifiedLenLoopBody.lean
+++ b/EvmAsm/Rv64/RLP/UnifiedLenLoopBody.lean
@@ -1,0 +1,219 @@
+/-
+  EvmAsm.Rv64.RLP.UnifiedLenLoopBody
+
+  EL.3 / Phase 5 — one iteration (BODY) of the LENGTH-DRIVEN unified RV64 RLP
+  list-decode loop. Unlike the count-driven body (`unified_body_spec_within`,
+  `UnifiedListLoopBody.lean`), which decrements an item counter, this body stops
+  when the data pointer reaches a precomputed END pointer held invariant in `x15`.
+  This needs no item count (which the decoder cannot produce) and stops at the
+  payload end regardless of trailing bytes — the foundation for nested decode,
+  pairing with the descend-one-level window (`NestedDescendOne.lean`).
+
+      loop_top (lbase):  LBU  x5, x13, 0          ; prefix bs[i] → x5
+                         < region all-class decoder: lbase+4 .. joinPC, 60 steps >
+      joinPC:            ADD  x13, x13, x11        ; x13 := payloadPtr + payloadLen
+      (joinPC+4):        BNE  x13, x15, back       ; loop if x13 ≠ endPtr (taken → lbase)
+
+  `x15` holds the loop-invariant end pointer `endPtr` (the decoder never touches
+  x15, so it survives the 60-step decode framed); x10/x12/x14 are decoder scratch;
+  `x11` holds the decoded length (consumed by `ADD`). The decoder is an OPAQUE
+  `cpsTripleWithin 60` hypothesis (`decoder_base = lbase+4`), discharged by the
+  concrete region decoder in a later PR. Analog of `unified_body_spec_within`.
+-/
+
+import EvmAsm.Rv64.RLP.UnifiedListLoopBody
+import EvmAsm.Rv64.Tactics.ExtractPure
+import EvmAsm.Rv64.Tactics.XPermPure
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL.RLP
+
+-- ============================================================================
+-- Bundled post for either exit of the length-driven loop body
+-- ============================================================================
+
+/-- Bundled post for the length-driven body. Like `unified_body_post` but `x15`
+    holds the loop-invariant end pointer `endPtr` (no decremented counter). -/
+@[irreducible]
+def unified_lenloop_body_post (regionBase : Word) (bs : List (BitVec 8)) (pfx : Byte)
+    (v10New v11New v12New nextPtr v14New endPtr : Word) (P : Prop) : Assertion :=
+  (.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10New) **
+    (.x11 ↦ᵣ v11New) ** (.x12 ↦ᵣ v12New) ** (.x13 ↦ᵣ nextPtr) ** (.x14 ↦ᵣ v14New) **
+    (.x15 ↦ᵣ endPtr) ** bytesRegion regionBase bs ** ⌜P⌝
+
+theorem unified_lenloop_body_post_unfold (regionBase : Word) (bs : List (BitVec 8)) (pfx : Byte)
+    (v10New v11New v12New nextPtr v14New endPtr : Word) (P : Prop) :
+    unified_lenloop_body_post regionBase bs pfx v10New v11New v12New nextPtr v14New endPtr P =
+    ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10New) **
+      (.x11 ↦ᵣ v11New) ** (.x12 ↦ᵣ v12New) ** (.x13 ↦ᵣ nextPtr) ** (.x14 ↦ᵣ v14New) **
+      (.x15 ↦ᵣ endPtr) ** bytesRegion regionBase bs ** ⌜P⌝) := by
+  delta unified_lenloop_body_post; rfl
+
+theorem unified_lenloop_body_post_pure {regionBase : Word} {bs : List (BitVec 8)} {pfx : Byte}
+    {v10New v11New v12New nextPtr v14New endPtr : Word} {P : Prop} :
+    ∀ hp, unified_lenloop_body_post regionBase bs pfx v10New v11New v12New nextPtr v14New endPtr P hp
+      → P := by
+  intro hp hpost
+  simp only [unified_lenloop_body_post_unfold] at hpost
+  open EvmAsm.Rv64.Tactics in extract_pure hpost
+  exact hpost.1
+
+-- ============================================================================
+-- Length-driven loop body spec (one iteration): a 2-exit cpsBranchWithin
+-- ============================================================================
+
+/-- Step-bounded spec for one pass through the length-driven list-loop body. The
+    region all-class decoder is the opaque triple `decoder` (`decoder_base =
+    lbase + 4`, 60 steps); the per-item stride is `itemNextPtrRegion`; the guard
+    compares the advanced pointer `x13` to the invariant end pointer `x15 = endPtr`
+    (`BNE x13 x15` → loop while not at the end). -/
+theorem unified_lenloop_body_spec_within
+    (regionBase v5Old v10 v11Old v12Old v14Old endPtr : Word)
+    (lbase joinPC decoder_base : Word) (dcr : CodeReq) (back : BitVec 13)
+    (bs : List (BitVec 8)) (i : Nat)
+    (halign : regionBase.toNat % 8 = 0) (hi : i < bs.length)
+    (hover : regionBase.toNat + i < 2 ^ 64)
+    (hvalid : isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdec_base : decoder_base = lbase + 4)
+    (decoder : cpsTripleWithin 60 decoder_base joinPC dcr
+       ((.x5 ↦ᵣ (bs[i]'hi).zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 i)) **
+        (.x14 ↦ᵣ v14Old) ** bytesRegion regionBase bs)
+       ((.x5 ↦ᵣ (bs[i]'hi).zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x10 ↦ᵣ itemResidue (bs[i]'hi)) ** (.x11 ↦ᵣ itemLenRegion (bs[i]'hi) bs i) **
+        (.x12 ↦ᵣ itemX12Region (bs[i]'hi) bs i v12Old) **
+        (.x13 ↦ᵣ itemPtrRegion (bs[i]'hi) regionBase i) **
+        (.x14 ↦ᵣ itemX14 (bs[i]'hi) v14Old) ** bytesRegion regionBase bs))
+    (hback : (joinPC + 4) + signExtend13 back = lbase)
+    (hne_lj : lbase ≠ joinPC) (hne_lj4 : lbase ≠ joinPC + 4)
+    (hd_lbu_dec : (CodeReq.singleton lbase (.LBU .x5 .x13 0)).Disjoint dcr)
+    (hd_dec_add : dcr.Disjoint (CodeReq.singleton joinPC (.ADD .x13 .x13 .x11)))
+    (hd_dec_bne : dcr.Disjoint (CodeReq.singleton (joinPC + 4) (.BNE .x13 .x15 back))) :
+    cpsBranchWithin 63 lbase
+      ((((CodeReq.singleton lbase (.LBU .x5 .x13 0)).union dcr).union
+          (CodeReq.singleton joinPC (.ADD .x13 .x13 .x11))).union
+          ((CodeReq.singleton (joinPC + 4) (.BNE .x13 .x15 back)).union CodeReq.empty))
+      ((.x5 ↦ᵣ v5Old) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
+       (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 i)) ** (.x14 ↦ᵣ v14Old) **
+       (.x15 ↦ᵣ endPtr) ** bytesRegion regionBase bs)
+      lbase
+        (unified_lenloop_body_post regionBase bs (bs[i]'hi) (itemResidue (bs[i]'hi))
+          (itemLenRegion (bs[i]'hi) bs i) (itemX12Region (bs[i]'hi) bs i v12Old)
+          (itemNextPtrRegion (bs[i]'hi) regionBase i bs) (itemX14 (bs[i]'hi) v14Old)
+          endPtr (itemNextPtrRegion (bs[i]'hi) regionBase i bs ≠ endPtr))
+      (joinPC + 8)
+        (unified_lenloop_body_post regionBase bs (bs[i]'hi) (itemResidue (bs[i]'hi))
+          (itemLenRegion (bs[i]'hi) bs i) (itemX12Region (bs[i]'hi) bs i v12Old)
+          (itemNextPtrRegion (bs[i]'hi) regionBase i bs) (itemX14 (bs[i]'hi) v14Old)
+          endPtr (itemNextPtrRegion (bs[i]'hi) regionBase i bs = endPtr)) := by
+  set pfx := bs[i]'hi with hpfx
+  simp only [unified_lenloop_body_post_unfold]
+  set bz := pfx.zeroExtend 64 with hbz
+  -- Step 1: LBU x5, x13, 0 — load the prefix byte into x5.
+  have lbu_raw := bytesRegion_lbu_within .x5 .x13 regionBase v5Old lbase bs i
+    (by decide) halign hi hover hvalid
+  have s_lbu : cpsTripleWithin 1 lbase (lbase + 4)
+      (CodeReq.singleton lbase (.LBU .x5 .x13 0))
+      ((.x5 ↦ᵣ v5Old) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
+       (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 i)) ** (.x14 ↦ᵣ v14Old) **
+       (.x15 ↦ᵣ endPtr) ** bytesRegion regionBase bs)
+      ((.x5 ↦ᵣ bz) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
+       (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 i)) ** (.x14 ↦ᵣ v14Old) **
+       (.x15 ↦ᵣ endPtr) ** bytesRegion regionBase bs) :=
+    cpsTripleWithin_weaken
+      (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp)
+      (cpsTripleWithin_frameR
+        ((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) **
+         (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ endPtr))
+        (by pcFree) lbu_raw)
+  -- Step 2: the region decoder (opaque), framed with x15 = endPtr (untouched).
+  rw [hdec_base] at decoder
+  have s_dec : cpsTripleWithin 60 (lbase + 4) joinPC dcr
+      ((.x5 ↦ᵣ bz) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
+       (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 i)) ** (.x14 ↦ᵣ v14Old) **
+       (.x15 ↦ᵣ endPtr) ** bytesRegion regionBase bs)
+      ((.x5 ↦ᵣ bz) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ itemResidue pfx) **
+       (.x11 ↦ᵣ itemLenRegion pfx bs i) ** (.x12 ↦ᵣ itemX12Region pfx bs i v12Old) **
+       (.x13 ↦ᵣ itemPtrRegion pfx regionBase i) ** (.x14 ↦ᵣ itemX14 pfx v14Old) **
+       (.x15 ↦ᵣ endPtr) ** bytesRegion regionBase bs) :=
+    cpsTripleWithin_weaken
+      (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp)
+      (cpsTripleWithin_frameR (.x15 ↦ᵣ endPtr) (by pcFree) decoder)
+  -- Step 3: ADD x13, x13, x11 — advance x13 to the next item start.
+  have add_raw := add_spec_gen_rd_eq_rs1_within .x13 .x11
+    (itemPtrRegion pfx regionBase i) (itemLenRegion pfx bs i) joinPC (by nofun)
+  have s_add : cpsTripleWithin 1 joinPC (joinPC + 4)
+      (CodeReq.singleton joinPC (.ADD .x13 .x13 .x11))
+      ((.x5 ↦ᵣ bz) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ itemResidue pfx) **
+       (.x11 ↦ᵣ itemLenRegion pfx bs i) ** (.x12 ↦ᵣ itemX12Region pfx bs i v12Old) **
+       (.x13 ↦ᵣ itemPtrRegion pfx regionBase i) ** (.x14 ↦ᵣ itemX14 pfx v14Old) **
+       (.x15 ↦ᵣ endPtr) ** bytesRegion regionBase bs)
+      ((.x5 ↦ᵣ bz) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ itemResidue pfx) **
+       (.x11 ↦ᵣ itemLenRegion pfx bs i) ** (.x12 ↦ᵣ itemX12Region pfx bs i v12Old) **
+       (.x13 ↦ᵣ itemNextPtrRegion pfx regionBase i bs) ** (.x14 ↦ᵣ itemX14 pfx v14Old) **
+       (.x15 ↦ᵣ endPtr) ** bytesRegion regionBase bs) :=
+    cpsTripleWithin_weaken
+      (fun _ hp => by xperm_hyp hp) (fun _ hp => by simp only [itemNextPtrRegion]; xperm_hyp hp)
+      (cpsTripleWithin_frameR
+        ((.x5 ↦ᵣ bz) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ itemResidue pfx) **
+         (.x12 ↦ᵣ itemX12Region pfx bs i v12Old) ** (.x14 ↦ᵣ itemX14 pfx v14Old) **
+         (.x15 ↦ᵣ endPtr) ** bytesRegion regionBase bs)
+        (by pcFree) add_raw)
+  -- Step 4: BNE x13, x15, back — loop while the pointer has not reached endPtr.
+  have bne_raw := bne_spec_gen_within .x13 .x15 back
+    (itemNextPtrRegion pfx regionBase i bs) endPtr (joinPC + 4)
+  have bne_framed : cpsBranchWithin 1 (joinPC + 4)
+      (CodeReq.singleton (joinPC + 4) (.BNE .x13 .x15 back))
+      ((.x5 ↦ᵣ bz) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ itemResidue pfx) **
+       (.x11 ↦ᵣ itemLenRegion pfx bs i) ** (.x12 ↦ᵣ itemX12Region pfx bs i v12Old) **
+       (.x13 ↦ᵣ itemNextPtrRegion pfx regionBase i bs) ** (.x14 ↦ᵣ itemX14 pfx v14Old) **
+       (.x15 ↦ᵣ endPtr) ** bytesRegion regionBase bs)
+      lbase
+        ((.x5 ↦ᵣ bz) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ itemResidue pfx) **
+         (.x11 ↦ᵣ itemLenRegion pfx bs i) ** (.x12 ↦ᵣ itemX12Region pfx bs i v12Old) **
+         (.x13 ↦ᵣ itemNextPtrRegion pfx regionBase i bs) ** (.x14 ↦ᵣ itemX14 pfx v14Old) **
+         (.x15 ↦ᵣ endPtr) ** bytesRegion regionBase bs
+           ** ⌜itemNextPtrRegion pfx regionBase i bs ≠ endPtr⌝)
+      (joinPC + 8)
+        ((.x5 ↦ᵣ bz) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ itemResidue pfx) **
+         (.x11 ↦ᵣ itemLenRegion pfx bs i) ** (.x12 ↦ᵣ itemX12Region pfx bs i v12Old) **
+         (.x13 ↦ᵣ itemNextPtrRegion pfx regionBase i bs) ** (.x14 ↦ᵣ itemX14 pfx v14Old) **
+         (.x15 ↦ᵣ endPtr) ** bytesRegion regionBase bs
+           ** ⌜itemNextPtrRegion pfx regionBase i bs = endPtr⌝) := by
+    have h_eq : (joinPC + 4 : Word) + 4 = joinPC + 8 := by bv_omega
+    rw [h_eq, hback] at bne_raw
+    exact cpsBranchWithin_weaken
+      (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp)
+      (cpsBranchWithin_frameR
+        ((.x5 ↦ᵣ bz) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ itemResidue pfx) **
+         (.x11 ↦ᵣ itemLenRegion pfx bs i) ** (.x12 ↦ᵣ itemX12Region pfx bs i v12Old) **
+         (.x14 ↦ᵣ itemX14 pfx v14Old) ** bytesRegion regionBase bs)
+        (by pcFree) bne_raw)
+  -- Extend the BNE CR with a trailing empty (to match the seq output shape).
+  have bne_ext : cpsBranchWithin 1 (joinPC + 4)
+      ((CodeReq.singleton (joinPC + 4) (.BNE .x13 .x15 back)).union CodeReq.empty) _ _ _ _ _ :=
+    cpsBranchWithin_extend_code
+      (fun a _ hcr => by
+        show (CodeReq.singleton (joinPC + 4) (.BNE .x13 .x15 back)).union CodeReq.empty a = _
+        simp only [CodeReq.union, hcr])
+      bne_framed
+  -- Disjointness for the union chain.
+  have hd2 : ((CodeReq.singleton lbase (.LBU .x5 .x13 0)).union dcr).Disjoint
+      (CodeReq.singleton joinPC (.ADD .x13 .x13 .x11)) :=
+    CodeReq.Disjoint.union_left (CodeReq.Disjoint.singleton hne_lj) hd_dec_add
+  have hd3 : (((CodeReq.singleton lbase (.LBU .x5 .x13 0)).union dcr).union
+      (CodeReq.singleton joinPC (.ADD .x13 .x13 .x11))).Disjoint
+      ((CodeReq.singleton (joinPC + 4) (.BNE .x13 .x15 back)).union CodeReq.empty) :=
+    CodeReq.Disjoint.union_right
+      (CodeReq.Disjoint.union_left
+        (CodeReq.Disjoint.union_left (CodeReq.Disjoint.singleton hne_lj4) hd_dec_bne)
+        (CodeReq.Disjoint.singleton (by bv_omega)))
+      (CodeReq.Disjoint.empty_right _)
+  -- Compose the chain.
+  have t12 := cpsTripleWithin_seq hd_lbu_dec s_lbu s_dec
+  have t123 := cpsTripleWithin_seq hd2 t12 s_add
+  exact cpsTripleWithin_seq_cpsBranchWithin hd3 t123 bne_ext
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -1482,14 +1482,23 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     `classifyPrefix_shortList_iff` + `encode_list_short`, long-list via `classifyPrefix_encode_head_long`
     + `encode_list_long` + `take_left'`/`drop_left'` + `fromBytesBE_toBytesBE`. Plus `decode_list_descend`
     (top-level round-trip) and concrete nested `example`s. Axiom-clean, 0 sorry.
-  - **Next (step 2 — operational descent assembly):** a combined program (header single-item decoder +
-    list loop at the payload offset) decoding a top-level nested list end-to-end, coinciding with
-    `decode` — `cpsTripleWithin_seq` of `unified_decoder_spec` + `unified_loop_spec_within`, with `x15 =
-    items.length` as a precondition (count deferred). Then **step 3+** — a **length-driven** loop (decode
-    until `x13` reaches `payload_end`, no known count; the prerequisite for genuine recursion), then
-    either bounded fixed-depth composition for the STF's block/tx structure or the general explicit-stack
-    recursive decoder. NOTE the impedance mismatch: the existing loop is COUNT-driven (`x15 =
-    items.length`) but real decode is LENGTH-driven — resolving that is step 3's crux.
+  - ✅ **Step 2 — length-driven loop body** (`UnifiedLenLoopBody.lean`). Exploration confirmed the
+    count-driven descent is a dead end (the decoder yields a payload byte-length in `x11`, not an item
+    count; the count is symbolic, unloadable) — so the foundation is a LENGTH-driven loop.
+    **`unified_lenloop_body_spec_within`**: one iteration as `cpsBranchWithin 63` over `LBU x5,x13,0` +
+    opaque region decoder (`cpsTripleWithin 60`) + `ADD x13,x13,x11` + **`BNE x13,x15,back`** — guard
+    compares the advanced pointer to the invariant end pointer `x15 = endPtr` (no counter, one fewer
+    instr than the count-driven body); taken (`itemNextPtrRegion ≠ endPtr`)→`lbase`, fall (`= endPtr`)→
+    `joinPC+8`. With no counter, `x15` holds `endPtr` (the decoder never touches it, framed through the
+    60-step decode). `unified_lenloop_body_post` (+`_unfold`/`_pure`). Faithful mirror of the
+    count-driven `unified_body_spec_within` with the guard swapped; built first try, axiom-clean, 0 sorry.
+  - **Next (step 3 — length-driven closure):** induct over `items`, `x13` from `O` to `endOff`, `x15 =
+    endPtr` fixed; prove it decodes `items` and `x13` reaches `endPtr` exactly after the last item. NEW
+    key lemma: `x13 ≠ endPtr` for every intermediate item (address injectivity of `regionBase + ofNat ·`
+    on `[O, endOff]`, from `hover` no-wraparound). Bridge to the length-driven pure `decodeItems`. Then
+    **step 4** — concrete + descent (compose with #9033's window: header decode → set `x15 := payload
+    end` → length-driven loop → genuine one-level descent matching `decode (.list items)`), then arbitrary
+    depth (bounded composition for the STF block/tx structure, or the explicit-stack generalization).
 - Phase 6: Top-level pipeline (`read_input` -> decode -> `write_output`)
 - **Host I/O ABI**: See `docs/zkvm-host-io-interface.md`; SP1
   `HINT_LEN`/`HINT_READ`/`COMMIT` are legacy handler shapes, not the target


### PR DESCRIPTION
## Summary

The body of a **length-driven** list-decode loop — the foundation for nested RLP decode.

Step 1 (#9033) showed the count-driven loop is a dead end for nesting: the single-item decoder yields a payload *byte-length* (`x11`), not an *item count*, and `items.length` is symbolic — no instruction can load it. The pure `decodeItems` is length-driven (recurse until the byte list is empty). So the foundation is a loop that stops when the data pointer reaches a precomputed **end pointer**.

New file `EvmAsm/Rv64/RLP/UnifiedLenLoopBody.lean`:

- **`unified_lenloop_body_spec_within`** — one iteration as `cpsBranchWithin 63`:
  ```
  lbase      LBU  x5, x13, 0
  lbase+4    < region all-class decoder, 60 steps >
  joinPC     ADD  x13, x13, x11        ; x13 := payloadPtr + payloadLen
  joinPC+4   BNE  x13, x15, back       ; loop while x13 ≠ endPtr  (taken → lbase)
  ```
  The guard compares the advanced pointer to the loop-invariant end pointer `x15 = endPtr` — **no counter**, one fewer instruction than the count-driven body. Taken (`itemNextPtrRegion ≠ endPtr`) loops back to `lbase`; fall-through (`= endPtr`) exits at `joinPC+8`. With no counter, `x15` is free to hold `endPtr`; the decoder never touches it, so it survives the 60-step decode framed.
- **`unified_lenloop_body_post`** (+ `_unfold`/`_pure`).

A faithful mirror of the count-driven `unified_body_spec_within` (#9026) with the guard swapped from `ADDI x15 -1; BNE x15 x0` to `BNE x13 x15`. Built on the first attempt.

## Context

Phase 5 (nested decode), step 2. Next: **step 3 — the length-driven closure** (induct over items; prove `x13` reaches `endPtr` exactly after the last item — the new lemma is pointer-≠-end via address injectivity from no-wraparound; bridge to the length-driven pure `decodeItems`), then **step 4** — compose with #9033's window for genuine one-level descent, then arbitrary depth.

## Verification

- `lake build` clean (module + umbrella `EvmAsm.Rv64.RLP`).
- `scripts/check-forbidden-tactics.sh` OK (no `bv_decide`/`native_decide`); `scripts/check-no-warnings.sh` → 0 warnings under `EvmAsm/`.
- `#print axioms unified_lenloop_body_spec_within` → `[propext, Classical.choice, Quot.sound]`; 0 `sorry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)