### PR TITLE
fix(verdict): run multi-tx nonstorage exec-vs-BAL check for withdrawals blocks (close skip bmvmx.5.5.9)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictMtxTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictMtxTail.lean
@@ -250,15 +250,22 @@ def blockVerdictMtxValidationTail : String :=
   "  bnez a0, .Lbv_bal_tuple_fail\n" ++
   -- bmvmx.5.5.1 (umbrella-A2a): all-accounts NON-STORAGE exec-vs-BAL for the MULTI-TX path
   -- (the single-tx comparators @1077-1094 were skipped by the @618 jump -> bmvmx.5.5). Wired
-  -- here, consuming the A1 skip-list. CONSERVATIVE guards (skip -> never false-reject, like the
-  -- gas-path wds guard @1174): (a) effect-log overflow; (b) withdrawals (system-level credits land
-  -- in the BAL but not the tx-execution effect log). Both -> skip. NOTE (bmvmx.5.5.7.3): with
-  -- nonstorageEffectLogCap = 32768 the overflow guard is now UNREACHABLE under the 200M block-gas
-  -- envelope (cheapest record-producing op is a value-CALL at GAS_WARM_ACCESS+GAS_CALL_VALUE=9100
-  -- regular gas, so <= 200M/9100 ~= 21978 < 32768 raw records), so (a) no longer skips any in-scope
-  -- block. The withdrawals guard (b) is a SEPARATE conservative skip class (still open: needs
-  -- withdrawal credits modeled as effects).
-  "  la t0, exec_nonstorage_effect_overflow; ld t0, 0(t0); bnez t0, .Lbv_mtx_ns_skip\n  la t0, svf_wds_count; ld t0, 0(t0); bnez t0, .Lbv_mtx_ns_skip\n" ++
+  -- here, consuming the A1 skip-list. CONSERVATIVE guard: effect-log overflow (skip -> never
+  -- false-reject). NOTE (bmvmx.5.5.7.3): with nonstorageEffectLogCap = 32768 the overflow guard is
+  -- now UNREACHABLE under the 200M block-gas envelope (cheapest record-producing op is a value-CALL
+  -- at GAS_WARM_ACCESS+GAS_CALL_VALUE=9100 regular gas, so <= 200M/9100 ~= 21978 < 32768 raw
+  -- records), so it no longer skips any in-scope block.
+  -- bmvmx.5.5.9: the WITHDRAWALS skip is REMOVED. EIP-4895 withdrawal credits land in the BAL but
+  -- not the tx-execution effect log; the prior `svf_wds_count -> skip` bailed the WHOLE nonstorage
+  -- exec-vs-BAL check whenever the block had withdrawals, leaving non-withdrawal accounts (CALL-
+  -- value callees / CREATE / SELFDESTRUCT) unchecked. That is unnecessary: withdrawal-recipient
+  -- balances are independently validated by withdrawals_state_root (pre-state + amount, folded into
+  -- the post-state root vs the header), the FORWARD comparator runs in LENIENT mode (a BAL account
+  -- with no matching exec effect -- exactly a withdrawal recipient -- is skipped, not rejected), and
+  -- the COVERS direction only iterates EXEC effects (withdrawal recipients have none, so they are
+  -- never flagged). So running the check with withdrawals present is 0-regress for valid blocks and
+  -- ENFORCES the exec-vs-BAL consistency of every effect-having account in a withdrawals block.
+  "  la t0, exec_nonstorage_effect_overflow; ld t0, 0(t0); bnez t0, .Lbv_mtx_ns_skip\n" ++
   -- Aggregate exec_nonstorage_effect_log per-account into exec_nonstorage_effect_agg, keyed by
   -- the 20B BE address @rec+0, keeping first-seen pre + last-seen post per account (BAL final ==
   -- exec post / net-change post!=pre). bmvmx.5.5.7.3: this was an inline O(raw*distinct) scan;


### PR DESCRIPTION
## Summary

Removes the conservative skip that bailed the **entire** multi-tx nonstorage exec-vs-BAL check (forward + covers) whenever a block had EIP-4895 withdrawals (`bmvmx.5.5.9` — the first conservative-skip-class closure). That skip left non-withdrawal accounts (CALL-value callees / CREATE / SELFDESTRUCT beneficiaries) in a withdrawals block **unchecked** — a real false-accept hole.

## Why removing it is sound (and 0-regress)

- **Withdrawal-recipient balances** are already independently validated by `withdrawals_state_root` (pre-state witness + `amount_gwei·1e9`, folded into the post-state root compared against the header).
- The **forward** comparator runs in **lenient** mode — a BAL account with no matching exec effect (exactly a withdrawal recipient, whose credit is not a tx-exec effect) is skipped, not rejected.
- The **covers** direction iterates only **exec** effects — withdrawal recipients have none, so they're never flagged.

So with withdrawals present the check now **enforces** exec-vs-BAL consistency for every effect-having account, while withdrawal recipients are handled correctly. The overflow guard stays (unreachable under 200M post cap-32768); B2.3's separate withdrawals skip (a sender that is also a withdrawal recipient) is untouched.

## Validation (`--jobs 8`, post-merge with main)

- **eip4895 (withdrawals) family: 140/140, fail=0** — the now-running check is 0-regress on withdrawals blocks.
- **broad random 400: fail=0**; **eip7928 (696, incl `bal_invalid_*`): fail=0** — invalid fixtures still reject; the now-running covers/forward don't false-flag.
- **set_code_to_sstore / eip7702: fail=0** post-merge (with ln9ly #9034). Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
