### PR TITLE
feat(verdict): reinstate basr/call_frame union to reclaim 48.8 MiB .data (a1vvy)

### DIFF
--- a/EvmAsm/Codegen/CallFrameLayout.lean
+++ b/EvmAsm/Codegen/CallFrameLayout.lean
@@ -96,19 +96,28 @@ def sszScratchBase : Nat := 0xbf500000
 /-- Total bytes the pre-allocated frame array occupies. -/
 def frameArrayBytes : Nat := frameSlotCount * frameStride
 
-/-! ## Placement: standalone block after the BAL-replay arenas (200M layout)
+/-! ## Placement: the frame arena UNIONS the BAL-replay basr pair (a1vvy, 200M)
 
     ziskemu's RAM is 512 MiB (`0xa0000000..0xc0000000`). Under the former
     1G-sized BAL arenas (`bsrMaxBalItems = 500000`, ~416 MiB) there was no free
     window, so the frame arena *aliased* the contiguous, execution-dead
     `basr_values`+`basr_accounts` pair (the #8513 union, 244 MiB ≥ 164 MiB).
     The Amsterdam target is 200M block gas (`bsrMaxBalItems = 100000`), which
-    shrinks the BAL arenas to ~83 MiB — the basr pair (~49 MiB) can no longer
-    host the frame array, and the freed ~333 MiB means it no longer needs to:
-    `call_frame_arena` is a standalone pre-zeroed `.zero frameArrayBytes` block
-    emitted right after `basr_accounts` (`BlockVerdictDataSection.lean`), and
-    the execution-dead soundness gate on `basr_values`/`basr_accounts` is no
-    longer load-bearing. See `docs/call-frame-memory-layout.md` §5. -/
+    shrinks the BAL arenas to ~83 MiB; the union was retired (standalone arena)
+    while the BAL downsize left free RAM. The 200M log/receipt capacity lifts
+    (`vv4hr.3.4.*`) have since consumed that slack (measured `.data` headroom
+    fell to ~59 MiB), so a1vvy REINSTATES the union to reclaim ~49 MiB.
+
+    The size relation flipped: the frame array (`frameArrayBytes` ~165 MiB) is now
+    LARGER than the basr pair (~49 MiB), so the pair is coalesced into the FRONT
+    of `call_frame_arena` (`BlockVerdictDataSection.lean`) rather than the arena
+    aliasing into the pair. Soundness is the same execution-dead disjointness
+    #8513 established and is now load-bearing again: `basr_values`/`basr_accounts`
+    are referenced ONLY in `BalAccountStateRoot`/`BlockVerdictStateRoot` (Phase H,
+    pre-dispatch state-root recompute) with no post-replay reader, while
+    `call_frame_arena` is referenced ONLY by `CallFrameBase`/`Descend`/`Return`
+    (Phase D dispatch) — sequential, disjoint live windows. See
+    `docs/call-frame-memory-layout.md` §5. -/
 
 /-- Total bytes of all 200M-sized BAL/state-replay static arenas
     (`bsr_changes` + `basr_records/paths/values/accounts` +
@@ -136,6 +145,16 @@ theorem frameMeta_within_stride : frameMetaOff + frameMetaBytes ≤ frameStride 
 
 /-- 1025 slots cover depths 0..1024 inclusive. -/
 theorem frameSlotCount_eq : frameSlotCount = 1025 := by decide
+
+/-- **a1vvy union-fits gate (load-bearing):** the coalesced `basr_values` +
+    `basr_accounts` pair fits within the frame array, so placing both at the
+    front of `call_frame_arena` (with a trailing pad to `frameArrayBytes`) keeps
+    every frame slot inside the arena. The two basr arenas occupy distinct,
+    non-overlapping sub-ranges `[0, S)` and `[S, 2S)` where
+    `S = bsrMaxStateChanges * bsrEncodedAccountBytes`. Replaces the retired
+    `frameArray_fits_union` (which had the size relation the other way). -/
+theorem frameArray_unions_basr_pair :
+    2 * (bsrMaxStateChanges * bsrEncodedAccountBytes) ≤ frameArrayBytes := by decide
 
 /-- **The fits proof that actually matters (200M layout):** the BAL/state-replay
     arenas (~83 MiB at the 200M capacity) plus the standalone 1025-slot frame

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -865,18 +865,28 @@ def ziskStatelessVerdictV2DataSection : String :=
   "baada_item_len:\n  .zero 8\n" ++
   "basr_records:\n  .zero " ++ toString (bsrMaxStateChanges * bsrAccountRecordBytes) ++
   "\nbasr_paths:\n  .zero " ++ toString (bsrMaxStateChanges * bsrPathBytes) ++
-  "\nbasr_values:\n  .zero " ++ toString (bsrMaxStateChanges * bsrEncodedAccountBytes) ++
-  "\nbasr_accounts:\n  .zero " ++ toString (bsrMaxStateChanges * bsrEncodedAccountBytes) ++
-  -- .61.3.1, re-sized for the 200M block-gas target: the nested call-frame arena
-  -- is now a STANDALONE 1025*frameStride pre-zeroed block. It used to alias
-  -- basr_values+basr_accounts (the #8513 union, forced by the 1G-sized BAL arenas
-  -- leaving no free RAM), but at the 200M capacity that pair is ~49 MiB — smaller
-  -- than the ~164 MiB frame array — while the BAL downsize frees ~333 MiB, so the
-  -- arena gets its own region (and the basr_* execution-dead soundness gate is no
-  -- longer load-bearing). Fit pinned by `frameArray_and_balArenas_fit`
-  -- (CallFrameLayout.lean); ELF ground truth = readelf -lW top RW LOAD < 0xc0000000.
+  -- a1vvy (2026-06-18): REINSTATED #8513 union to reclaim ~49 MiB of .data
+  -- headroom for the 200M log/receipt capacity lifts (vv4hr.3.4.*). basr_values +
+  -- basr_accounts are block_state_root replay scratch, referenced ONLY in
+  -- BalAccountStateRoot/BlockVerdictStateRoot (Phase H: pre-dispatch state-root
+  -- recompute) and dead from the first tx dispatch onward (#8513 gate-verified:
+  -- no post-replay reader; re-confirmed 2026-06-18 — no Phase D/T reference).
+  -- call_frame_arena is referenced ONLY by CallFrameBase/Descend/Return (Phase D
+  -- dispatch). The phases are sequential with disjoint live windows, so the frame
+  -- array reuses the basr pair's space as a union. The size relation FLIPPED vs
+  -- #8513 (frame ~165 MiB > basr pair ~49 MiB at the 200M capacity), so instead of
+  -- the arena aliasing INTO the pair, the pair is coalesced into the FRONT of
+  -- call_frame_arena (both labels point inside the arena; the trailing .zero pads
+  -- to the full frameArrayBytes). basr_values/basr_accounts are reached via
+  -- independent `la`, so relocation is transparent; they stay 32-aligned and keep
+  -- their original contiguous delta. Fit + non-overlap pinned by
+  -- `frameArray_unions_basr_pair` (CallFrameLayout.lean); ELF ground truth =
+  -- readelf -lW top RW LOAD < 0xc0000000.
   "\n.balign 32\n" ++
-  "call_frame_arena:\n  .zero " ++ toString frameArrayBytes ++
+  "call_frame_arena:\n" ++
+  "basr_values:\n  .zero " ++ toString (bsrMaxStateChanges * bsrEncodedAccountBytes) ++
+  "\nbasr_accounts:\n  .zero " ++ toString (bsrMaxStateChanges * bsrEncodedAccountBytes) ++
+  "\n  .zero " ++ toString (frameArrayBytes - 2 * (bsrMaxStateChanges * bsrEncodedAccountBytes)) ++
   "\ncall_frame_arena_end:\n" ++ "\n" ++
   ".balign 8\n" ++
   "rb_running_block_bloom:\n  .zero 256\n" ++


### PR DESCRIPTION
## What

Reinstates the retired **#8513 `call_frame_arena` ↔ `basr` union** to reclaim **48.8 MiB** of `.data` headroom, addressing the RAM tightness flagged while scoping the 200M log/receipt capacity lifts (`vv4hr.3.4.*`).

## Why now

The 200M lifts had consumed the slack that retiring #8513 freed. On current `main` the measured gap from `.data` end to `.sszscratch` (`0xbf500000`) had fallen to **~32 MiB** — too tight for the remaining lifts (the packed log arena alone wants ~48 MiB).

## The union

- `basr_values` + `basr_accounts` are `block_state_root` replay scratch, referenced **only** in `BalAccountStateRoot`/`BlockVerdictStateRoot` (Phase H, pre-dispatch state-root recompute), with no post-replay reader (#8513 gate-verified; re-confirmed here by a full reference audit — no Phase D/T reference).
- `call_frame_arena` is referenced **only** by `CallFrameBase`/`Descend`/`Return` (Phase D dispatch).
- The two phases run **sequentially with disjoint live windows**, so the frame array reuses the `basr` pair's space.

The size relation **flipped** vs #8513 (the frame array ~165 MiB is now *larger* than the `basr` pair ~48.8 MiB at the 200M capacity), so the pair is coalesced into the **front** of `call_frame_arena` (both labels point inside the arena; a trailing `.zero` pads to `frameArrayBytes`) rather than the arena aliasing into the pair. `basr_*` are reached via independent `la`, so relocation is transparent; they stay 32-aligned and keep their original contiguous delta.

New kernel-checked invariant `frameArray_unions_basr_pair` (`2*S ≤ frameArrayBytes`) pins the fit.

## Verification

**ELF layout** (linked `stateless_guest`):
- `basr_values` == `call_frame_arena` (`0xae321240`) ✓
- `basr_accounts` == `call_frame_arena + 25,604,608` (distinct, non-overlapping) ✓
- `.data` shrinks ~420 MiB → **371.5 MiB**; headroom **~32 MiB → ~81.5 MiB** ✓
- links clean, `.data` end well below `.sszscratch` ✓

**EEST 0-regress** (`--jobs 8`): default smoke + `set_code` + `call_` + `sstore` + `create` = **250 cases, all full-match (105/105 bytes), 0 fail, 0 errored** — exactly the families that stress the `basr` (state-root) ↔ `call_frame` (nested dispatch) disjointness.

## Follow-up

Next `a1vvy` step: extend the union to `bv_system_storage_log` (77 MiB, also Phase-H) for a further reclaim, once its no-D/T-reader liveness is verified the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)