### PR TITLE
feat(verdict): extend basr/call_frame union to bv_system_storage_log (a1vvy step 2)

### DIFF
--- a/EvmAsm/Codegen/CallFrameLayout.lean
+++ b/EvmAsm/Codegen/CallFrameLayout.lean
@@ -156,6 +156,17 @@ theorem frameSlotCount_eq : frameSlotCount = 1025 := by decide
 theorem frameArray_unions_basr_pair :
     2 * (bsrMaxStateChanges * bsrEncodedAccountBytes) ≤ frameArrayBytes := by decide
 
+/-- **a1vvy step 2 union-fits gate (load-bearing):** the basr pair PLUS the
+    Phase-H `bv_system_storage_log` arena (block_state_root system-write capture,
+    dead during Phase-D dispatch) together fit within the frame array, so all
+    three foreign arenas occupy distinct non-overlapping sub-ranges at the front
+    of `call_frame_arena` (`[0,S)`, `[S,2S)`, `[2S, 2S+L)` with
+    `L = bvSystemStorageLogBytes`) and the trailing pad to `frameArrayBytes` stays
+    non-negative. -/
+theorem frameArray_unions_basr_and_syslog :
+    2 * (bsrMaxStateChanges * bsrEncodedAccountBytes) + bvSystemStorageLogBytes
+      ≤ frameArrayBytes := by decide
+
 /-- **The fits proof that actually matters (200M layout):** the BAL/state-replay
     arenas (~83 MiB at the 200M capacity) plus the standalone 1025-slot frame
     array (~164 MiB) together stay well inside the `.data`→`.sszscratch` span

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -560,8 +560,14 @@ def ziskStatelessVerdictV2DataSection : String :=
   -- follow-up tuple-merge comparator.
   "bv_system_storage_log_count:\n  .zero 8\n" ++
   "bv_system_storage_txindex:\n  .zero " ++ toString bvSystemStorageTxindexBytes ++ "\n" ++
-  ".balign 32\n" ++
-  "bv_system_storage_log:\n  .zero " ++ toString bvSystemStorageLogBytes ++ "\n" ++
+  -- a1vvy step 2: bv_system_storage_log (~77 MiB) is UNIONED into call_frame_arena
+  -- (emitted below) rather than allocated standalone. It is Phase-H-only — built
+  -- and consumed entirely within the block_state_root recompute (the count is
+  -- zeroed @BlockVerdictStateRoot:452, populated by BalAllAccountsTupleSequences /
+  -- BlockVerdictSystemStorageCapture, consumed @BlockVerdictStateRoot:498/541),
+  -- capturing system-contract writes FROM THE BAL, not live execution — so it is
+  -- dead during Phase-D dispatch when call_frame_arena is live. Same disjointness
+  -- as the basr pair. Frees another ~77 MiB of .data headroom.
   ".balign 8\n" ++
   "bv_system_storage_capture_status:\n  .zero 8\n" ++
   "bv_system_storage_capture_start:\n  .zero 8\n" ++
@@ -886,7 +892,9 @@ def ziskStatelessVerdictV2DataSection : String :=
   "call_frame_arena:\n" ++
   "basr_values:\n  .zero " ++ toString (bsrMaxStateChanges * bsrEncodedAccountBytes) ++
   "\nbasr_accounts:\n  .zero " ++ toString (bsrMaxStateChanges * bsrEncodedAccountBytes) ++
-  "\n  .zero " ++ toString (frameArrayBytes - 2 * (bsrMaxStateChanges * bsrEncodedAccountBytes)) ++
+  -- a1vvy step 2: bv_system_storage_log unioned here too (offset 2*S, 32-aligned).
+  "\nbv_system_storage_log:\n  .zero " ++ toString bvSystemStorageLogBytes ++
+  "\n  .zero " ++ toString (frameArrayBytes - 2 * (bsrMaxStateChanges * bsrEncodedAccountBytes) - bvSystemStorageLogBytes) ++
   "\ncall_frame_arena_end:\n" ++ "\n" ++
   ".balign 8\n" ++
   "rb_running_block_bloom:\n  .zero 256\n" ++


### PR DESCRIPTION
## What

**Stacked on #9041.** Extends the `call_frame_arena` union to also absorb the ~77 MiB `bv_system_storage_log` arena, freeing another **~77 MiB** of `.data` headroom for the 200M log/receipt capacity lifts (`vv4hr.3.4.*`).

## Soundness

`bv_system_storage_log` is **Phase-H-only**: built and consumed entirely within the `block_state_root` recompute (count zeroed @`BlockVerdictStateRoot:452`, populated by `BalAllAccountsTupleSequences`/`BlockVerdictSystemStorageCapture`, consumed @`BlockVerdictStateRoot:498/541`). It captures system-contract storage writes **from the BAL** (prover-supplied final state), not from live execution — so the BLOCKHASH/EIP-2935 runtime-read concern does **not** apply; it is dead during Phase-D dispatch when `call_frame_arena` is live. A full reference audit found no Phase-D/T reference. Same disjointness as the `basr` pair (#9041).

The three foreign arenas now occupy distinct, 32-aligned, non-overlapping sub-ranges at the front of `call_frame_arena`:

| arena | range |
|---|---|
| `basr_values` | `[0, S)` |
| `basr_accounts` | `[S, 2S)` |
| `bv_system_storage_log` | `[2S, 2S+L)` |
| pad | → `frameArrayBytes` |

`S = bsrMaxStateChanges * bsrEncodedAccountBytes`, `L = bvSystemStorageLogBytes`. New kernel-checked invariant `frameArray_unions_basr_and_syslog` (`2*S + L ≤ frameArrayBytes`) pins the fit.

## Verification

**ELF** (linked `stateless_guest`): `bv_system_storage_log` == `call_frame_arena + 51,209,216` (= 2·S, 32-aligned), `call_frame_arena_end` == `+frameArrayBytes`, no overlap, clean link. `.data` 371.5 MiB → **298.5 MiB**; combined with #9041, headroom rises from main's critical **~32 MiB → ~154 MiB**.

**EEST 0-regress** (`--jobs 8`): default smoke + the **system-contract families** (`eip2935` 44/44, `eip4788`/`system`/`blockhash`/`beacon` 50/50 each — exactly what this arena captures) + `set_code`/`sstore`/`create`/`call_`/`eip7708` = **~544 cases, all full-match (105/105), 0 fail, 0 errored**.

## Net (a1vvy)

The two union steps free **~125 MiB** combined, restoring comfortable `.data` headroom and unblocking the class-D/E capacity-skip close — with this much room, even a *simple fixed-stride* log-arena lift fits (no risky descriptor repack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)