### PR TITLE
feat(verdict): close class-D/E log-arena capacity skip — lift to 200M bounds (vv4hr.3.4.2)

### DIFF
--- a/EvmAsm/Codegen/CallFrameLayout.lean
+++ b/EvmAsm/Codegen/CallFrameLayout.lean
@@ -167,6 +167,19 @@ theorem frameArray_unions_basr_and_syslog :
     2 * (bsrMaxStateChanges * bsrEncodedAccountBytes) + bvSystemStorageLogBytes
       ≤ frameArrayBytes := by decide
 
+/-- **a1vvy step 3 union-fits gate (load-bearing):** the basr pair + the
+    `bv_system_storage_log` arena + the four Phase-H `baap_storage_*` arenas
+    (`baap_storage_desc` + 3 `* bsrPathBytes` path arenas) all fit within the
+    frame array, so the seven coalesced foreign arenas occupy distinct,
+    non-overlapping, 32-aligned sub-ranges at the front of `call_frame_arena`
+    with a non-negative trailing pad to `frameArrayBytes`. All seven are
+    Phase-H (state-root recompute) scratch, dead during the Phase-D dispatch
+    window when the frame array is live. -/
+theorem frameArray_unions_basr_syslog_baap :
+    2 * (bsrMaxStateChanges * bsrEncodedAccountBytes) + bvSystemStorageLogBytes
+      + bsrMaxBalItems * baapStorageDescBytes + 3 * (bsrMaxBalItems * bsrPathBytes)
+      ≤ frameArrayBytes := by decide
+
 /-- **The fits proof that actually matters (200M layout):** the BAL/state-replay
     arenas (~83 MiB at the 200M capacity) plus the standalone 1025-slot frame
     array (~164 MiB) together stay well inside the `.data`→`.sszscratch` span

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -845,10 +845,12 @@ def ziskStatelessVerdictV2DataSection : String :=
   "baap_tmp3:\n  .zero 512\n" ++
   "baap_storage_value_cursor:\n  .zero 8\n" ++
   "baap_walk_val:\n  .zero 128\n" ++
-  "baap_storage_desc:\n  .zero " ++ toString (bsrMaxBalItems * baapStorageDescBytes) ++ "\n" ++
-  "baap_storage_paths:\n  .zero " ++ toString (bsrMaxBalItems * bsrPathBytes) ++ "\n" ++
-  "baap_storage_delete_paths:\n  .zero " ++ toString (bsrMaxBalItems * bsrPathBytes) ++ "\n" ++
-  "baap_storage_values:\n  .zero " ++ toString (bsrMaxBalItems * bsrPathBytes) ++ "\n" ++
+  -- a1vvy step 3: baap_storage_desc/paths/delete_paths/values (~22 MiB) are
+  -- UNIONED into call_frame_arena (emitted below) to free the last .data headroom
+  -- for the vv4hr.3.4.2 full log-arena lift. They are Phase-H-only (referenced only
+  -- in BalAccountApplyPostFields / BlockVerdictSysChange / BlockVerdictStateRoot --
+  -- BAL post-field apply + system-change application within the state-root
+  -- recompute) and dead during Phase-D dispatch when call_frame_arena is live.
   "mdacc_leaf_path:\n  .zero 128\n" ++
   "mdacc_collapsed_path:\n  .zero 128\n" ++
   "bacp_off:\n  .zero 8\n" ++
@@ -894,7 +896,12 @@ def ziskStatelessVerdictV2DataSection : String :=
   "\nbasr_accounts:\n  .zero " ++ toString (bsrMaxStateChanges * bsrEncodedAccountBytes) ++
   -- a1vvy step 2: bv_system_storage_log unioned here too (offset 2*S, 32-aligned).
   "\nbv_system_storage_log:\n  .zero " ++ toString bvSystemStorageLogBytes ++
-  "\n  .zero " ++ toString (frameArrayBytes - 2 * (bsrMaxStateChanges * bsrEncodedAccountBytes) - bvSystemStorageLogBytes) ++
+  -- a1vvy step 3: the four baap_storage_* arenas unioned here (Phase-H, 32-aligned).
+  "\nbaap_storage_desc:\n  .zero " ++ toString (bsrMaxBalItems * baapStorageDescBytes) ++
+  "\nbaap_storage_paths:\n  .zero " ++ toString (bsrMaxBalItems * bsrPathBytes) ++
+  "\nbaap_storage_delete_paths:\n  .zero " ++ toString (bsrMaxBalItems * bsrPathBytes) ++
+  "\nbaap_storage_values:\n  .zero " ++ toString (bsrMaxBalItems * bsrPathBytes) ++
+  "\n  .zero " ++ toString (frameArrayBytes - 2 * (bsrMaxStateChanges * bsrEncodedAccountBytes) - bvSystemStorageLogBytes - (bsrMaxBalItems * baapStorageDescBytes) - 3 * (bsrMaxBalItems * bsrPathBytes)) ++
   "\ncall_frame_arena_end:\n" ++ "\n" ++
   ".balign 8\n" ++
   "rb_running_block_bloom:\n  .zero 256\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
@@ -229,10 +229,21 @@ def bvBlockLogPackedUnitBytes : Nat := 32
 def bvBlockLogPackedDescBytes : Nat :=
   bvBlockLogPackedUnitBytes * bvBlockLogFullDescTarget
 
-def bvBlockLogDescCapacity : Nat := 128
+-- vv4hr.3.4.2 (2026-06-18): the active block-log arena is lifted to the full
+-- 200M gas-derived bounds, making the `bv_block_log_overflow -> .Lbv_receipts_accept`
+-- capacity skip (BlockVerdictReceiptsTail ~line 95) and the receipt-logs status-3
+-- skip UNREACHABLE: a 200M block emits at most gas/375 = 533,333 logs (each LOG
+-- costs >= bvBlockLogMinGas) and at most gas/8 = 25,000,000 copied data bytes
+-- (each data byte costs bvBlockLogDataByteGas). block_log_window_snapshot keeps
+-- its verbatim 256 B descriptor copy and the readers their 256 B stride -- this is
+-- a PURE capacity bump (no format change). The ~170 MiB arena fits because a1vvy
+-- (#9041/#9042 + the baap union here) reclaimed the .data headroom via the
+-- call_frame_arena phase-disjoint union. Removes the shared class-D (receipts) and
+-- class-E (deposit-derivation) capacity skip: both now always derive/enforce.
+def bvBlockLogDescCapacity : Nat := bvBlockLogFullDescTarget
 def bvBlockLogDescBytes : Nat := bvBlockLogDescCapacity * 256
 def bvBlockLogMetaBytes : Nat := bvBlockLogDescCapacity * 16
-def bvBlockLogDataBytes : Nat := 65536
+def bvBlockLogDataBytes : Nat := bvBlockLogFullDataBytes
 def bvLogsRlpArenaBytes : Nat := 65536
 def bvRecordBloomBytes : Nat := 256
 def bvRecordBloomsBytes : Nat := bvReceiptRecordCapacity * bvRecordBloomBytes
@@ -334,9 +345,11 @@ def bmvFullLogWindowArenaBytes : Nat :=
 #guard bvBlockLogFullDescBytes = 136533248
 #guard bvBlockLogFullMetaBytes = 8533328
 #guard bvBlockLogFullDataBytes = 25000000
-#guard bvBlockLogDescBytes = 32768
-#guard bvBlockLogMetaBytes = 2048
-#guard bvBlockLogDataBytes = 65536
+-- vv4hr.3.4.2: active block-log arena lifted to the full 200M gas-derived bounds
+-- (== bvBlockLogFull* above), making bv_block_log_overflow unreachable under 200M.
+#guard bvBlockLogDescBytes = 136533248
+#guard bvBlockLogMetaBytes = 8533328
+#guard bvBlockLogDataBytes = 25000000
 #guard bvLogsRlpArenaBytes = 65536
 #guard bvRecordBloomsBytes = 2437888
 #guard bvRecordLogsDescBytes = 304736


### PR DESCRIPTION
## What

**The first actual conservative-skip REMOVAL the a1vvy headroom enables.** Removes the `bv_block_log_overflow → .Lbv_receipts_accept` skip (`BlockVerdictReceiptsTail` ~line 95) and the receipt-logs status-3 skip: when the block-log capture buffer overflowed, the guest **accepted without** running the receipts-root/logs-bloom enforcement (**class D**) or the EIP-6110 deposit derivation (**class E**). The arena capped at 128 descriptors / 64 KiB data — far below a 200M block.

## The close (pure capacity bump)

A 200M block emits at most `gas/375 = 533,333` logs and `gas/8 = 25,000,000` copied data bytes (the #9040 derivation). Setting the active caps to those bounds:

```
bvBlockLogDescCapacity := bvBlockLogFullDescTarget   -- 533,333
bvBlockLogDataBytes    := bvBlockLogFullDataBytes      -- 25,000,000
```

makes **both overflow conditions unreachable under 200M**. No format change — `block_log_window_snapshot` keeps its verbatim 256 B descriptor copy and the readers their 256 B stride; the overflow checks read the same constants and auto-raise.

## Why it fits (a1vvy)

The ~170 MiB arena fits because the `call_frame_arena` phase-disjoint union reclaimed the headroom:

| step | arena unioned | freed |
|---|---|---|
| #9041 | `basr_values`+`basr_accounts` | +48.8 MiB |
| #9042 | `bv_system_storage_log` | +77 MiB |
| **this PR (step 3)** | 4× `baap_storage_*` | +22 MiB |

All seven coalesced arenas are **Phase-H** (state-root recompute) scratch, dead during Phase-D dispatch when the frame array is live. New kernel-checked invariant `frameArray_unions_basr_syslog_baap` pins the fit; `baap` liveness re-confirmed by reference audit (only `BalAccountApplyPostFields`/`BlockVerdictSysChange`/`BlockVerdictStateRoot` — no Phase-D/T reference).

## Verification

**ELF**: `.data` 438.7 MiB, **headroom 14.6 MiB** (links cleanly below `.sszscratch`); `baap_storage_desc` at `call_frame_arena + 128,009,216` (= 2S + syslog), no overlap; `bv_block_log` descs+meta span = 145,066,576 (full lift).

**EEST 0-regress** (`--jobs 8`): default smoke + `eip2935`/`eip4788`/`system` (baap union) + `deposit`/`eip6110`/`request` (class-E derivation path) + `set_code`/`sstore`/`create`/`call_`/`eip7708` = **~594 cases, all full-match (105/105), 0 fail, 0 errored**.

## Stack

Stacked on #9042 ← #9041. Closes the shared class-D / class-E capacity skip: any 200M block now always materializes its logs → derives deposits → verifies the requests_hash and (where enforced) the receipts root, instead of conservatively accepting on overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)