### PR TITLE
fix(verdict): enforce shape-6 collision receipts + correct collision receipt gas (rmqwf)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictCreateCollision.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictCreateCollision.lean
@@ -38,7 +38,12 @@ def blockVerdictCreateCollisionBranch : String :=
   "  la t4, bvgr_runtime_refund_counter_ptr; la t5, bv_runtime_refund_counter; sd t5, 0(t4)\n" ++
   "  la t4, bvgr_runtime_calldata_floor_ptr; la t5, bv_runtime_calldata_floor; sd t5, 0(t4)\n" ++
   "  li t5, 1; la t4, bvgr_runtime_count; sd t5, 0(t4)\n" ++
-  bvReceiptsShapeSet 6 false ++
+  -- rmqwf (class D): enforce the receipts-root/bloom consensus check for top-level
+  -- CREATE collisions. The collision receipt gas is corrected in blockVerdictReceiptsTail
+  -- (shape==6 AND status==0 -> receipt = regular block_inc). The successful-creation
+  -- shape-6 branch (BlockVerdictCreationStage) stays enforce=false until it has fixture
+  -- coverage (top-level creations currently bail to the class-B dispatch shapes 60/61).
+  bvReceiptsShapeSet 6 true ++
   "  j .Lbv_after_tx_gas_precharge\n" ++
   ".Lbv_creation_runtime_try:\n" ++
   "  la a0, bv_simple_transfer_tx; la t0, bv_exec_p; ld a1, 0(t0); jal ra, block_verdict_single_tx_creation_runtime\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -47,6 +47,25 @@ def blockVerdictReceiptsTail : String :=
   "  la a5, bvgr_block_gas_increments\n" ++
   "  la a6, bvgr_tx_exec_state_gas\n" ++
   "  jal ra, block_verdict_receipt_gas_eip8037_adjust\n" ++
+  -- rmqwf (class D): top-level CREATE-collision receipt gas correction. The collision
+  -- branch (BlockVerdictCreateCollision) hardcodes bv_runtime_gas_left=0 (it bypasses
+  -- dispatcher_tx_gas_settle since no initcode executes), so tx_gas_result_increments
+  -- computes before_refund = tx.gas - 0, WRONGLY folding the intrinsic state reservation
+  -- into the receipt increment. Per amsterdam fork.py:1122-1138 an error tx returns the
+  -- state dimension (state_gas_left += state_gas_used + new_account_refund), so the spec
+  -- receipt = tx.gas - gas_left - state_gas_left = the REGULAR gas only. blockVerdictExactGasCheck
+  -- already normalized bvgr_block_gas_increments[0] to that regular dimension (it subtracts
+  -- the peeled state gas + applies the calldata floor), and for an error tx refund=0 so
+  -- receipt == block_inc. Mirror it. Gate: shape==6 (the single-tx top-level-creation
+  -- classification, set ONLY by CreateCollision/CreationStage) AND bv_tx_status_arr[0]==0
+  -- (error) -> the collision uniquely (successful creation has status=1; non-collision CREATE
+  -- errors route to the runtime path with a correct settle-derived gas_left). No other shape/
+  -- status is touched.
+  "  la t0, bv_receipts_completeness_shape; ld t0, 0(t0); li t1, 6; bne t0, t1, .Lbv_rmqwf_collision_done\n" ++
+  "  la t0, bv_tx_status_arr; ld t0, 0(t0); bnez t0, .Lbv_rmqwf_collision_done\n" ++
+  "  la t0, bvgr_block_gas_increments; ld t1, 0(t0)\n" ++
+  "  la t0, bvgr_receipt_gas_increments; sd t1, 0(t0)\n" ++
+  ".Lbv_rmqwf_collision_done:\n" ++
   -- bmvmx.5.5.2.2.12: bvgr_receipt_gas_increments[i] is now the spec-exact per-tx gas_used, so run
   -- the RELOCATED multi-tx B2.2/B2.3 sender cumulative-balance check here (it was skipped at
   -- .Lbv_mtx_done because the gas chain hadn't run yet). The B2 code lives in

--- a/scripts/dump_receipts_for_fixture.py
+++ b/scripts/dump_receipts_for_fixture.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Dump per-receipt cumulative_gas_used (spec ground truth) for a zisk .input.
+
+Run:  uv run --directory execution-specs --quiet python3 \
+        ../scripts/dump_receipts_for_fixture.py <path-to.input>
+"""
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def add_specs(root: Path) -> None:
+    src = root / "execution-specs" / "src"
+    if src.is_dir():
+        sys.path.insert(0, str(src))
+
+
+def unpack_zisk_input(path: Path) -> bytes:
+    data = path.read_bytes()
+    n = int.from_bytes(data[:8], "little")
+    return data[8 : 8 + n]
+
+
+def main() -> int:
+    root = repo_root()
+    add_specs(root)
+    inp = Path(sys.argv[1])
+    blob = unpack_zisk_input(inp)
+
+    import ethereum.forks.amsterdam.fork as fork
+
+    orig_make = fork.make_receipt
+    idx = {"i": 0}
+
+    def traced_make_receipt(tx, error, cumulative_gas_used, logs):
+        print(
+            f"RECEIPT[{idx['i']}] cumulative_gas_used={int(cumulative_gas_used)} "
+            f"error={error is not None} n_logs={len(logs)}"
+        )
+        idx["i"] += 1
+        return orig_make(tx, error, cumulative_gas_used, logs)
+
+    fork.make_receipt = traced_make_receipt
+
+    from ethereum.forks.amsterdam.stateless_guest import run_stateless_guest
+
+    try:
+        out = run_stateless_guest(blob)
+        print("run_stateless_guest OK, output_len=", len(out))
+        print("succ_byte(=output[32])=", out[32] if len(out) > 32 else "n/a")
+    except Exception as e:  # noqa: BLE001
+        print("run_stateless_guest raised:", type(e).__name__, str(e)[:200])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+# (appended) richer dump available by importing make_receipt trace above.


### PR DESCRIPTION
## Summary

Closes the **class-D conservative receipts skip** for top-level CREATE collisions (shape 6) and fixes the masked collision receipt-gas bug it was hiding. Part of the "pass all EEST without skipped checks" goal (bead `evm-asm-rmqwf`).

### The bug
The collision branch (`BlockVerdictCreateCollision`) hardcodes `bv_runtime_gas_left=0` because no initcode executes, bypassing `dispatcher_tx_gas_settle`. `tx_gas_result_increments` then computes `before_refund = tx.gas - 0`, which **wrongly folds the intrinsic state reservation into the receipt cumulative gas** (e.g. guest 214606 vs spec 31006, diff = the 183600 refunded state reservation). Per amsterdam `fork.py:1122-1138`, an error tx returns the entire state dimension (`state_gas_left += state_gas_used + new_account_refund`), so the spec receipt `gas_used = tx.gas - gas_left - state_gas_left` = the **regular gas only**. This was masked because shape 6 had receipts enforcement gated off (conservative accept).

### The fix
`blockVerdictExactGasCheck` already normalizes `bvgr_block_gas_increments` to that regular dimension (peels state gas, applies the calldata floor); since an error tx has `refund=0`, `receipt == block_inc`. So in `blockVerdictReceiptsTail` (after the EIP-8037 receipt adjust) we mirror `block_inc` into the receipt increment, **gated on `shape==6 AND bv_tx_status_arr[0]==0`**. That gate is exact: shape 6 is set only by the single-tx top-level creation paths — `CreateCollision` (status 0 collision) and `CreationStage` (status 1 successful STOP creation) — so `shape==6 AND status==0` uniquely identifies the collision. No other shape/status is touched.

With the receipt corrected, `CreateCollision` flips to `enforce=true` so the receipts-root/bloom consensus check runs for collisions. The `CreationStage` successful-creation shape-6 branch stays `enforce=false` until it has fixture coverage (top-level creations currently bail to the class-B dispatch shapes 60/61).

## Validation (EEST zkevm@v0.4.0, `--no-build` on the rebuilt main ELF)
- **create family: 1052/1052 full match, 0 fail** (all collision / revert / mixed-success-failure variants)
- **broad random cross-family: 600/600 full match, 0 fail**
- target `create_tx_collision_refunds_intrinsic_new_account`: was a false-reject under enforcement (receipt 214606 vs spec 31006, validator=2 / bv_fail=53); **now succ=1, bv_fail=0, validator_status=0, receipt[0]=31006** (spec-exact)
- `block_gas_used_call_new_account` (shape 5, already enforced): no regression (succ=1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)