### PR TITLE
fix(runtime): size EIP-2929 warm-address table to the block-gas bound

### DIFF
--- a/EvmAsm/Codegen/Programs/EvmAccessGas.lean
+++ b/EvmAsm/Codegen/Programs/EvmAccessGas.lean
@@ -15,7 +15,20 @@ namespace EvmAsm.Codegen
 
 open EvmAsm.Rv64
 
-def runtimeAccessAccountCapacity : Nat := 64
+-- EIP-2929 accessed-addresses (warm) table capacity. Real execution-specs keeps
+-- `accessed_addresses` unbounded; the only practical bound is the block gas
+-- limit, since adding a distinct address costs at least the cheapest cold path
+-- (EIP-2930 access-list entry = 2400 gas). A 200M-gas block can therefore touch
+-- at most 200_000_000 / 2400 ≈ 83_334 distinct addresses, so the table must hold
+-- at least that many or a cold access against a full table wrongly OOGs the frame
+-- (`.Lraag_cold` -> `.exit_outofgas`) — the EIP-7251 consolidation
+-- `call_depth_high` false-reject (bead fhsxz.17): a ~1023-deep chain of distinct
+-- relay contracts filled the old 64-entry table at depth ~60 and OOG'd, consuming
+-- the whole forwarded budget. Sized to the project's standard gas-derived account
+-- bound (100_000, matching `bsrAccountSlotCap`/`bsrMaxBalItems`); the linear scan
+-- cost is O(actual distinct count), independent of this capacity, so raising it
+-- only widens the table (100_000 * 32 = ~3.2 MiB) and the OOG threshold.
+def runtimeAccessAccountCapacity : Nat := 100000
 def runtimeAccessAccountRecordSize : Nat := 32
 def runtimeAccessColdDeltaGas : Nat := 2500
 def runtimeAccessAccountOutcomeCapacity : Nat := 64

--- a/EvmAsm/Codegen/Programs/SeedTxAccessList.lean
+++ b/EvmAsm/Codegen/Programs/SeedTxAccessList.lean
@@ -26,6 +26,7 @@
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.EvmAccessGas
 import EvmAsm.Codegen.Programs.EvmStorageAccessGas
 import EvmAsm.Codegen.Programs.TxExtract
 import EvmAsm.Codegen.Programs.TxDecode2930
@@ -102,7 +103,7 @@ def seedTxAccessListFunction : String :=
   -- runtime_access_account_seed's expectation; the seed preserves s4..s9 (saves
   -- only s0..s3), so the slot loop below is intact. Idempotent / table-full safe.
   "  la a0, stal_token; la a1, evm_access_account_table\n" ++
-  "  la a2, evm_access_account_count; li a3, 64\n" ++
+  "  la a2, evm_access_account_count; li a3, " ++ toString runtimeAccessAccountCapacity ++ "\n" ++
   "  jal ra, runtime_access_account_seed\n" ++
   "  # entry field 1 = slots sub-list (list item -> item-start offset).\n" ++
   "  mv a0, s4; mv a1, s5; li a2, 1\n" ++


### PR DESCRIPTION
## Summary
- The EIP-2929 accessed-addresses (warm) table held only **64** entries. A cold account access against a *full* table jumps to `.exit_outofgas` in `runtime_access_account_charge` (`EvmAccessGas.lean`), OOG-ing the frame. Real execution-specs keeps `accessed_addresses` **unbounded**, so this is a false-reject.
- Raise `runtimeAccessAccountCapacity` **64 → 100000** (gas-derived: a 200M-gas block can add at most ~200M/2400 distinct addresses via the cheapest cold/access-list path; matches the project's `bsrAccountSlotCap`/`bsrMaxBalItems`). The linear table scan is `O(actual distinct count)`, independent of capacity, so this only widens the table (~3.2 MiB) and the OOG threshold — no perf impact on normal cases.
- Replace the hardcoded `64` in the access-list seed (`SeedTxAccessList.lean`) with the same constant.

## Root cause (bead `evm-asm-fhsxz.17`)
EIP-7251 `consolidation_requests` `call_depth_high` is a ~1023-deep chain of **distinct** relay contracts, each `CALL(GAS, next, …)`. The spec recurses to depth 260 (63/64 gas-limited), using 712669 gas/tx. The guest filled the 64-entry warm table at depth ~60, OOG'd, and consumed the entire ~3.78M forwarded budget → block `gas_used` over-claim → `bv_fail=41`. (Diagnosed via guest instrumentation; see the bead.)

## Validation
- `eip7251_consolidations` family: **167/167 full match** (previously failed `call_depth_high`).
- Broad random sample: **600/600 full match, 0 regression**.

Refs bead: evm-asm-fhsxz.17.

Directed by @pirapira; implemented by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)