### PR TITLE
fix(codegen): correct env+32 selfBalance LE/BE byte-order in value-op debit

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
@@ -236,16 +236,24 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     -- here). The created account's env+32 credit (init-code SELFBALANCE) is a follow-up.
     "  ld t3, 584(x20)\n  beqz t3, .Lcr_deb_done_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
     "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
-    "  addi a0, x20, 32\n" ++                            -- a0 = creator LIVE balance (env .selfBalance, BE)
+    -- env+32 (.selfBalance) is LITTLE-ENDIAN (byte 0 = LSB), same convention as CALLVALUE@96;
+    -- u256_sub_be is big-endian (byte 31 = LSB). The prior code fed env+32 STRAIGHT to u256_sub_be
+    -- -> byte-scrambled selfBalance debit (drj99.1 part 4). Reverse env[32..63] (LE) ->
+    -- create_creator_newbal (BE), subtract in place (a0==a2 byte-safe), reverse the result back.
+    "  addi t0, x20, 63\n  la t1, create_creator_newbal\n  li t2, 32\n" ++
+    ".Lcr_sbrev_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
+    "  lbu t3, 0(t0)\n  sb t3, 0(t1)\n  addi t0, t0, -1\n  addi t1, t1, 1\n  addi t2, t2, -1\n  bnez t2, .Lcr_sbrev_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
+    "  la a0, create_creator_newbal\n" ++               -- a0 = creator LIVE balance, now BE
     "  la a1, create_value_be\n" ++                      -- a1 = endowment (BE)
-    "  la a2, create_creator_newbal\n" ++                -- a2 = out (= balance - endowment)
+    "  la a2, create_creator_newbal\n" ++                -- a2 = out (in place = balance - endowment, BE)
     "  jal ra, u256_sub_be\n" ++
     "  mv t0, a0\n" ++                                   -- t0 = borrow flag (before x10=a0 restore)
     "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
     "  bnez t0, .Lcr_deb_done_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++   -- underflow -> skip
-    "  la t0, create_creator_newbal\n  addi t1, x20, 32\n" ++
-    "  ld t2, 0(t0)\n  sd t2, 0(t1)\n  ld t2, 8(t0)\n  sd t2, 8(t1)\n" ++
-    "  ld t2, 16(t0)\n  sd t2, 16(t1)\n  ld t2, 24(t0)\n  sd t2, 24(t1)\n" ++
+    -- reverse create_creator_newbal (BE) back into env+32 (LE)
+    "  la t0, create_creator_newbal\n  addi t1, x20, 63\n  li t2, 32\n" ++
+    ".Lcr_sbwb_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
+    "  lbu t3, 0(t0)\n  sb t3, 0(t1)\n  addi t0, t0, 1\n  addi t1, t1, -1\n  addi t2, t2, -1\n  bnez t2, .Lcr_sbwb_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
     ".Lcr_deb_done_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
     createStageInitcodeFrameCallAsm (if hasSalt then 1 else 0) ++
     -- .61.8.3.5.3 (.5c): execute the staged init code in a REAL child frame via the full

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -294,16 +294,26 @@ def callDescendFallThrough
       "  addi t0, t0, 1\n  addi t1, t1, 1\n  addi t2, t2, -1\n  j .Lcd_selfchk_" ++ tag ++ "\n" ++
       ".Lcd_notself_" ++ tag ++ ":\n" ++
       "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
-      "  addi a0, x20, 32\n" ++                            -- a0 = caller LIVE balance (env .selfBalance, BE)
+      -- env+32 (.selfBalance) is LITTLE-ENDIAN (stack-word: byte 0 = LSB), the same convention as
+      -- CALLVALUE@96 (which NoopHalt reverses x20+127->+96 to obtain BE); u256_sub_be is big-endian
+      -- (byte 31 = LSB, U256.lean). The prior code fed env+32 STRAIGHT to u256_sub_be -> byte-scrambled
+      -- selfBalance debit (drj99.1 part 4). Reverse env[32..63] (LE) -> cd_caller_newbal (BE), subtract
+      -- in place (a0==a2 is byte-safe: u256_sub_be reads a0[i] then writes a2[i] at the same index),
+      -- then reverse the result back to env+32 (LE).
+      "  addi t0, x20, 63\n  la t1, cd_caller_newbal\n  li t2, 32\n" ++
+      ".Lcd_sbrev_" ++ tag ++ ":\n" ++
+      "  lbu t3, 0(t0)\n  sb t3, 0(t1)\n  addi t0, t0, -1\n  addi t1, t1, 1\n  addi t2, t2, -1\n  bnez t2, .Lcd_sbrev_" ++ tag ++ "\n" ++
+      "  la a0, cd_caller_newbal\n" ++                     -- a0 = caller LIVE balance, now BE
       "  la a1, cd_value_be\n" ++                          -- a1 = transferred value (BE)
-      "  la a2, cd_caller_newbal\n" ++                     -- a2 = out (= balance - value)
+      "  la a2, cd_caller_newbal\n" ++                     -- a2 = out (in place = balance - value, BE)
       "  jal ra, u256_sub_be\n" ++
       "  mv t0, a0\n" ++                                   -- t0 = borrow flag (before x10=a0 restore)
       "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
       "  bnez t0, .Lcd_deb_done_" ++ tag ++ "\n" ++        -- underflow (live < value): conservative skip
-      "  la t0, cd_caller_newbal\n  addi t1, x20, 32\n" ++
-      "  ld t2, 0(t0)\n  sd t2, 0(t1)\n  ld t2, 8(t0)\n  sd t2, 8(t1)\n" ++
-      "  ld t2, 16(t0)\n  sd t2, 16(t1)\n  ld t2, 24(t0)\n  sd t2, 24(t1)\n" ++
+      -- reverse cd_caller_newbal (BE) back into env+32 (LE)
+      "  la t0, cd_caller_newbal\n  addi t1, x20, 63\n  li t2, 32\n" ++
+      ".Lcd_sbwb_" ++ tag ++ ":\n" ++
+      "  lbu t3, 0(t0)\n  sb t3, 0(t1)\n  addi t0, t0, 1\n  addi t1, t1, -1\n  addi t2, t2, -1\n  bnez t2, .Lcd_sbwb_" ++ tag ++ "\n" ++
       ".Lcd_deb_done_" ++ tag ++ ":\n") ++
     -- i3djw.1: record the value-transfer NON-STORAGE effect for the callee so the
     -- all-accounts non-storage comparator (i3djw.3) can validate it against the BAL.


### PR DESCRIPTION
## Problem

The per-frame `selfBalance` slot (`env+32`) is stored **little-endian** (byte 0 = LSB) — the same stack-word convention as `CALLVALUE@96`, which `NoopHalt` reverses (`x20+127 -> +96`) to obtain big-endian. But the two value-op `selfBalance` debit blocks fed `env+32` **straight** into `u256_sub_be` — which is big-endian (byte 31 = LSB, per `U256.lean`) — with **no LE→BE reversal**:

- `5em02.1` value-CALL debit — `ChildFrameHandlers.lean` `.Lcd_notself`
- `5em02.2` CREATE creator-debit — `ChildFrameHandlerTails.lean` `.Lcr_deb`

So the live-balance subtraction was byte-scrambled (it treated the balance's LSB as its MSB), corrupting `env+32` after any value-bearing CALL/CREATE for an existing contract — and thus the value a subsequent `SELFBALANCE` opcode reads.

Confirmed byte order:
- `callee_balance_table` stores the balance LE-limb "so the descend copies it verbatim to the LE EVM stack" (`BlockVerdictDispatchTx`); `call_frame_descend` step 8c copies it verbatim into `env+32`; `h_SELFBALANCE` (`evm_env_load`) copies `env+32` → stack verbatim (no reversal).
- `u256_sub_be` (`U256.lean`) starts at byte index 31 (LSB) with borrow propagating 31→0 = big-endian.

## Fix

At both sites: reverse `env[32..63]` (LE) into the existing `newbal` scratch (BE), run `u256_sub_be` **in place** (`a0==a2` is byte-safe — it reads `a0[i]` then writes `a2[i]` at the same index), then reverse the result back into `env+32` (LE). Reuses the `cd_caller_newbal` / `create_creator_newbal` buffers, so **no new data symbol and no closure-linkage change**.

## Validation

- Both `stateless_guest` and `zisk_stateless_verdict_v2` emit clean (no duplicate-symbol / VMA-overlap).
- EEST flip-off 0-regress: transfer family **139/139 PASS** (the value-CALL debit surface), CREATE family **43/43 PASS**. No behavior depends on the previously-scrambled value.

Part of the `drj99.1` (class-C dispatch) work — `evm-asm-drj99.1.1`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)