### PR TITLE
fix(codegen): record SELFDESTRUCT origin balance debit for BAL reconciliation

### DIFF
--- a/EvmAsm/Codegen/Programs/Selfdestruct.lean
+++ b/EvmAsm/Codegen/Programs/Selfdestruct.lean
@@ -448,6 +448,20 @@ def selfdestructBeneficiaryNonstorageAsm : String :=
   "  jal ra, u256_add_be\n" ++
   "  la a0, evm_selfdestruct_beneficiary; mv a1, sp; addi a2, sp, 32; li a3, 0; li a4, 0\n" ++
   "  jal ra, record_nonstorage_effect\n" ++
+  -- drj99.1 part 5c: record the ORIGIN's debit (balance -> 0, nonce preserved). SELFDESTRUCT moves the
+  -- origin's whole balance to the (different) beneficiary, so the origin's final balance is 0; without a
+  -- matching exec effect the BAL declares the origin's balance->0 with nothing to match -> bv_fail=44 (the
+  -- selfdestruct_* families). We are inside the witness-present (sdai_status 0/4) + origin!=beneficiary +
+  -- origin-balance!=0 path: the origin EXISTED at block-pre (created-in-THIS-tx accounts are absent from the
+  -- block-pre witness and never reach here), so EIP-6780 does NOT delete it -> nonce is PRESERVED. pre_bal =
+  -- origin balance (sp+64, extracted above); post_bal = 0 (sp+8..39); pre_nonce = post_nonce = origin nonce.
+  -- sp+0..63 is free scratch now (beneficiary pre/post already consumed). x10/x12 stay saved at sp+96/104.
+  "  la a0, sdai_origin_rlp; la t0, sdai_origin_len; ld a1, 0(t0); addi a2, sp, 0\n" ++   -- origin nonce -> sp+0
+  "  jal ra, account_extract_nonce\n" ++
+  "  sd zero, 8(sp); sd zero, 16(sp); sd zero, 24(sp); sd zero, 32(sp)\n" ++             -- post_balance = 0 (sp+8..39)
+  "  ld a3, 0(sp); ld a4, 0(sp)\n" ++                                                     -- pre_nonce = post_nonce = origin nonce
+  "  la a0, sdai_origin_address; addi a1, sp, 64; addi a2, sp, 8\n" ++                    -- a1 = pre_bal (origin), a2 = post_bal (0)
+  "  jal ra, record_nonstorage_effect\n" ++
   ".L_sdbn_restore:\n" ++
   "  ld x10, 96(sp); ld x12, 104(sp); addi sp, sp, 112\n" ++
   ".L_sdbn_done:\n"


### PR DESCRIPTION
## Problem

SELFDESTRUCT moves the origin contract's entire balance to the beneficiary, but the guest recorded only the **beneficiary credit** (`selfdestructBeneficiaryNonstorageAsm`) — never the **origin debit** (balance → 0).

So when the per-account non-storage exec-vs-BAL reconciliation runs (`bal_all_accounts_nonstorage_consistent` → `bal_account_nonstorage_consistent`), the BAL declares the origin's balance went to 0 but the exec log has no matching effect → the origin is reported not-found (`bv_fail=44`) for every selfdestruct-with-balance block. This is one slice of the `drj99.1` "unrecorded debit side of value moves" class that blocks removing the class-C single-tx dispatch skip.

## Fix

In the `origin != beneficiary` path (right after the beneficiary credit is recorded), also record the origin's debit:

```
record_nonstorage_effect(origin,
                         pre  = origin balance, post = 0,
                         pre_nonce = post_nonce = origin nonce)
```

We are inside the witness-present (`sdai_status` 0/4) + nonzero-origin-balance path, so the origin **existed at block-pre** — created-in-this-tx accounts are absent from the block-pre witness and never reach this function — hence EIP-6780 does **not** delete it and the nonce is preserved. The aggregate keeps first-pre/last-post per address (`nonstorage_effect_aggregate`), so the recorded `post = 0` is what the comparator checks.

## Validation (EEST, `--filter selfdestruct` = 698 inputs)

- **flip OFF (shipped config): 0 FAIL, 0 false-accepts** (0-regress).
- **flip ON** (single-tx contract dispatch executing, the eventual class-C config): the previously-failing eip7708 cases all PASS — `selfdestruct_same_tx_via_call` (12), `to_different_address` (4), `to_self` (4) — with **0 false-accepts** (`guest=01 exp=00`).

Part of `evm-asm-drj99.1` (the `bv_fail=44` unrecorded-debit-side class) — the SELFDESTRUCT slice. The CREATE creator-debit / CALL caller-debit slices (which need cross-frame success/failure rollback) are tracked separately.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)