### PR TITLE
feat(rv64/rlp): tail-general loop closure + interior RLP list descent (Phase 5)

### DIFF
--- a/EvmAsm/Rv64/RLP/UnifiedItemStride.lean
+++ b/EvmAsm/Rv64/RLP/UnifiedItemStride.lean
@@ -40,9 +40,9 @@ theorem flat_or_long (item : RLPItem) : isFlatItem item ∨ isLongItem item := b
 
 /-- The `lenOfLen` length bytes the decoder reads from the region (starting at
     `off+1`) are exactly the encoding's `Nat.toBytesBE payloadCount`. -/
-private theorem long_lenBytes_in_region (head : RLPItem) (tail : List RLPItem)
+private theorem long_lenBytes_in_region (head : RLPItem) (rest : List Byte)
     (bs : List Byte) (off : Nat) (hlong : isLongItem head)
-    (hdrop : bs.drop off = encode head ++ encode.encodeItems tail) :
+    (hdrop : bs.drop off = encode head ++ rest) :
     (bs.drop (off + 1)).take (itemLenOfLen head) = Nat.toBytesBE (itemPayloadCount head) := by
   have hdd : bs.drop (off + 1) = (bs.drop off).drop 1 := by
     rw [List.drop_drop]
@@ -71,9 +71,9 @@ private theorem long_lenBytes_in_region (head : RLPItem) (tail : List RLPItem)
 /-- **Unified stride-equivalence.** For any item whose encoding sits at byte
     offset `off` of the region, the body's per-item advance lands at
     `regionBase + ofNat (off + (encode item).length)`. -/
-theorem encode_head_eq_itemNextPtrRegion (head : RLPItem) (tail : List RLPItem)
+theorem encode_head_eq_itemNextPtrRegion (head : RLPItem) (rest : List Byte)
     (regionBase : Word) (off : Nat) (bs : List Byte)
-    (hdrop : bs.drop off = encode head ++ encode.encodeItems tail)
+    (hdrop : bs.drop off = encode head ++ rest)
     (hsize : itemPayloadCount head < 256 ^ 8) :
     itemNextPtrRegion ((encode head)[0]'(encode_nonempty head)) regionBase off bs
       = regionBase + BitVec.ofNat 64 (off + (encode head).length) := by
@@ -112,7 +112,7 @@ theorem encode_head_eq_itemNextPtrRegion (head : RLPItem) (tail : List RLPItem)
           rw [hb, classifyPrefix_longList_iff, htn] at h; omega
       simp only [itemPtrRegion, itemLenRegion, hcls]
       rw [encode_long_lenOfLen_eq_bytes hlong hsize',
-          long_lenBytes_in_region (.bytes data) tail bs off (by simp [isLongItem]; omega) hdrop,
+          long_lenBytes_in_region (.bytes data) rest bs off (by simp [isLongItem]; omega) hdrop,
           encode_long_lenBytes_read (.bytes data), region_ptr_add',
           encode_long_length_eq (.bytes data) (by simp [isLongItem]; omega)]
       have harg : (off + 1) + itemLenOfLen (.bytes data) + itemPayloadCount (.bytes data)
@@ -139,7 +139,7 @@ theorem encode_head_eq_itemNextPtrRegion (head : RLPItem) (tail : List RLPItem)
         · exact h
       simp only [itemPtrRegion, itemLenRegion, hcls]
       rw [encode_long_lenOfLen_eq_list hlong hsize',
-          long_lenBytes_in_region (.list items) tail bs off (by simp [isLongItem]; omega) hdrop,
+          long_lenBytes_in_region (.list items) rest bs off (by simp [isLongItem]; omega) hdrop,
           encode_long_lenBytes_read (.list items), region_ptr_add',
           encode_long_length_eq (.list items) (by simp [isLongItem]; omega)]
       have harg : (off + 1) + itemLenOfLen (.list items) + itemPayloadCount (.list items)
@@ -156,7 +156,7 @@ example (regionBase : Word) :
         regionBase 0 (encode (.bytes [1, 2, 3]))
       = regionBase + BitVec.ofNat 64 (0 + (encode (.bytes [1, 2, 3])).length) :=
   encode_head_eq_itemNextPtrRegion (.bytes [1, 2, 3]) [] regionBase 0
-    (encode (.bytes [1, 2, 3])) (by simp [encode.encodeItems]) (by decide)
+    (encode (.bytes [1, 2, 3])) (by simp) (by decide)
 
 -- A 56-byte string (long): exercises the runtime-read length path.
 example (regionBase : Word) :
@@ -165,6 +165,6 @@ example (regionBase : Word) :
       = regionBase
           + BitVec.ofNat 64 (0 + (encode (.bytes (List.replicate 56 (0 : Byte)))).length) :=
   encode_head_eq_itemNextPtrRegion (.bytes (List.replicate 56 (0 : Byte))) [] regionBase 0
-    (encode (.bytes (List.replicate 56 (0 : Byte)))) (by simp [encode.encodeItems]) (by decide)
+    (encode (.bytes (List.replicate 56 (0 : Byte)))) (by simp) (by decide)
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/UnifiedLenLoop.lean
+++ b/EvmAsm/Rv64/RLP/UnifiedLenLoop.lean
@@ -58,9 +58,9 @@ theorem unified_lenloop_spec_within
     (hd_lbu_dec : (CodeReq.singleton lbase (.LBU .x5 .x13 0)).Disjoint dcr)
     (hd_dec_add : dcr.Disjoint (CodeReq.singleton joinPC (.ADD .x13 .x13 .x11)))
     (hd_dec_bne : dcr.Disjoint (CodeReq.singleton (joinPC + 4) (.BNE .x13 .x15 back))) :
-    ∀ (items : List RLPItem) (O : Nat) (v5Old v10 v11Old v12Old v14Old : Word),
+    ∀ (items : List RLPItem) (O : Nat) (btail : List Byte) (v5Old v10 v11Old v12Old v14Old : Word),
       items ≠ [] →
-      bs.drop O = encode.encodeItems items →
+      bs.drop O = encode.encodeItems items ++ btail →
       (∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true) →
       cpsTripleWithin (63 * items.length) lbase (joinPC + 8)
         ((((CodeReq.singleton lbase (.LBU .x5 .x13 0)).union dcr).union
@@ -74,13 +74,15 @@ theorem unified_lenloop_spec_within
           (regionBase + BitVec.ofNat 64 (O + (encode.encodeItems items).length))) := by
   intro items
   induction items with
-  | nil => intro O v5Old v10 v11Old v12Old v14Old hne _ _; exact absurd rfl hne
+  | nil => intro O btail v5Old v10 v11Old v12Old v14Old hne _ _; exact absurd rfl hne
   | cons head tail ih =>
-    intro O v5Old v10 v11Old v12Old v14Old _ hdrop hwin
-    have hsplit : bs.drop O = encode head ++ encode.encodeItems tail := by
-      rw [hdrop]; rfl
+    intro O btail v5Old v10 v11Old v12Old v14Old _ hdrop hwin
+    have hsplit : bs.drop O = encode head ++ (encode.encodeItems tail ++ btail) := by
+      rw [hdrop, show encode.encodeItems (head :: tail)
+            = encode head ++ encode.encodeItems tail from rfl, List.append_assoc]
     have hO : O < bs.length := by
-      have hlen : (bs.drop O).length = (encode head ++ encode.encodeItems tail).length := by
+      have hlen : (bs.drop O).length
+          = (encode head ++ (encode.encodeItems tail ++ btail)).length := by
         rw [hsplit]
       rw [List.length_drop, List.length_append] at hlen
       have := encode_nonempty head; omega
@@ -107,15 +109,19 @@ theorem unified_lenloop_spec_within
         omega
     have hnext : itemNextPtrRegion (bs[O]'hO) regionBase O bs
         = regionBase + BitVec.ofNat 64 (O + (encode head).length) := by
-      rw [hbsO]; exact encode_head_eq_itemNextPtrRegion head tail regionBase O bs hsplit hsizeHead
+      rw [hbsO]
+      exact encode_head_eq_itemNextPtrRegion head (encode.encodeItems tail ++ btail) regionBase O bs
+        hsplit hsizeHead
     have hoverO : regionBase.toNat + O < 2 ^ 64 := by omega
     have hvalidO : isValidByteAccess (regionBase + BitVec.ofNat 64 O) = true := hwin O hO
     have hwinO : regionLongWindow regionBase bs O hO :=
-      regionLongWindow_of_split regionBase bs head tail O hO hbsO hsplit hsizeHead hwin
+      regionLongWindow_of_split regionBase bs head (encode.encodeItems tail ++ btail) O hO hbsO hsplit
+        hsizeHead hwin
     -- the total length of these items is bounded (≤ bs.length, from the drop)
     have htot : O + (encode.encodeItems (head :: tail)).length ≤ bs.length := by
-      have e : (bs.drop O).length = (encode.encodeItems (head :: tail)).length := by rw [hdrop]
-      rw [List.length_drop] at e; omega
+      have e : (bs.drop O).length = (encode.encodeItems (head :: tail) ++ btail).length := by
+        rw [hdrop]
+      rw [List.length_drop, List.length_append] at e; omega
     set endPtr := regionBase + BitVec.ofNat 64 (O + (encode.encodeItems (head :: tail)).length)
       with hep
     cases tail with
@@ -148,7 +154,7 @@ theorem unified_lenloop_spec_within
                     (sepConj_mono_right
                       (fun h' hp' => ((sepConj_pure_right h').1 hp').1)))))))) h hp
     | cons h2 t2 =>
-      have hdrop' : bs.drop (O + (encode head).length) = encode.encodeItems (h2 :: t2) := by
+      have hdrop' : bs.drop (O + (encode head).length) = encode.encodeItems (h2 :: t2) ++ btail := by
         rw [← List.drop_drop, hsplit, List.drop_append_length]
       -- one-step unfold of the cons (avoid `simp` over-expanding recursively).
       have hsplit_len : (encode.encodeItems (head :: h2 :: t2)).length
@@ -202,7 +208,7 @@ theorem unified_lenloop_spec_within
           (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
             (sepConj_mono_right (sepConj_mono_right
               (fun h' hp' => ((sepConj_pure_right h').1 hp').1))))))))) h hp
-      have ihspec := ih (O + (encode head).length) ((bs[O]'hO).zeroExtend 64)
+      have ihspec := ih (O + (encode head).length) btail ((bs[O]'hO).zeroExtend 64)
         (itemResidue (bs[O]'hO)) (itemLenRegion (bs[O]'hO) bs O)
         (itemX12Region (bs[O]'hO) bs O v12Old) (itemX14 (bs[O]'hO) v14Old)
         (by simp) hdrop' hwin
@@ -243,7 +249,7 @@ theorem unified_lenloop_n_spec_within
   have h := unified_lenloop_spec_within regionBase lbase joinPC decoder_base dcr back
     (encode.encodeItems items) halign hover hdec_base decoderH hback
     hne_lj hne_lj4 hd_lbu_dec hd_dec_add hd_dec_bne
-    items 0 v5Old v10 v11Old v12Old v14Old hne (by rw [List.drop_zero]) hwin
+    items 0 [] v5Old v10 v11Old v12Old v14Old hne (by rw [List.drop_zero, List.append_nil]) hwin
   rw [show regionBase + BitVec.ofNat 64 0 = regionBase from by simp,
       show (0 : Nat) + (encode.encodeItems items).length
         = (encode.encodeItems items).length from Nat.zero_add _] at h

--- a/EvmAsm/Rv64/RLP/UnifiedListDescendConcrete.lean
+++ b/EvmAsm/Rv64/RLP/UnifiedListDescendConcrete.lean
@@ -63,14 +63,14 @@ private theorem ofProg_disjoint_ofProg (b1 b2 : Word) (p1 p2 : List Instr) (n1 n
     context provokes an unbounded `whnf`. The scratch registers `x5/x10/x11/x12/x14`
     are arbitrary (the loop only reads `x13`/`x15`). -/
 private theorem descend_loop_triple
-    (base regionBase : Word) (items : List RLPItem) (payloadOff : Nat)
+    (base regionBase : Word) (items : List RLPItem) (tail : List Byte) (payloadOff : Nat)
     (v5' v10' v11' v12' v14' : Word)
     (halign : regionBase.toNat % 8 = 0)
-    (hover : regionBase.toNat + (encode (.list items)).length < 2 ^ 64)
-    (hwin : ∀ i, i < (encode (.list items)).length →
+    (hover : regionBase.toNat + (encode (.list items) ++ tail).length < 2 ^ 64)
+    (hwin : ∀ i, i < (encode (.list items) ++ tail).length →
        isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
     (hitems_ne : items ≠ [])
-    (hdpay : (encode (.list items)).drop payloadOff = encode.encodeItems items) :
+    (hdpay : (encode (.list items) ++ tail).drop payloadOff = encode.encodeItems items ++ tail) :
     cpsTripleWithin (63 * items.length) (base + 152) (base + 308)
       ((((CodeReq.singleton (base + 152) (.LBU .x5 .x13 0)).union
           (CodeReq.ofProg (base + 156) unified_decoder_prog)).union
@@ -79,8 +79,8 @@ private theorem descend_loop_triple
       ((.x5 ↦ᵣ v5') ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10') ** (.x11 ↦ᵣ v11') **
        (.x12 ↦ᵣ v12') ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 payloadOff)) ** (.x14 ↦ᵣ v14') **
        (.x15 ↦ᵣ (regionBase + BitVec.ofNat 64 (payloadOff + (encode.encodeItems items).length))) **
-       bytesRegion regionBase (encode (.list items)))
-      (unified_lenloop_post regionBase (encode (.list items))
+       bytesRegion regionBase (encode (.list items) ++ tail))
+      (unified_lenloop_post regionBase (encode (.list items) ++ tail)
         (regionBase + BitVec.ofNat 64 (payloadOff + (encode.encodeItems items).length))) := by
   have dcr_none_l : ∀ (a : Word),
       (∀ k, k < 36 → a ≠ (base + 156) + BitVec.ofNat 64 (4 * k)) →
@@ -88,36 +88,38 @@ private theorem descend_loop_triple
     fun a h => CodeReq.ofProg_none_range_len (base + 156) unified_decoder_prog 36 a
       unified_decoder_prog_length h
   have decoderH_loop : UnifiedDecoderH regionBase (base + 156) (base + 300)
-      (CodeReq.ofProg (base + 156) unified_decoder_prog) (encode (.list items)) := by
+      (CodeReq.ofProg (base + 156) unified_decoder_prog) (encode (.list items) ++ tail) := by
     intro i hi v10'' v11'' v12'' v14'' hwindow
-    have hd := unified_decoder_spec (base + 156) regionBase (encode (.list items)) i hi
+    have hd := unified_decoder_spec (base + 156) regionBase (encode (.list items) ++ tail) i hi
       v10'' v11'' v12'' v14'' halign hover hwindow
     rwa [show (base + 156) + 144 = base + 300 from by bv_omega] at hd
   have hback_loop : (base + 300 + 4) + signExtend13 (-152 : BitVec 13) = base + 152 := by
     have h152 : signExtend13 (-152 : BitVec 13) = (-152 : Word) := by decide
     rw [h152]; bv_omega
   have t_loop := unified_lenloop_spec_within regionBase (base + 152) (base + 300) (base + 156)
-    (CodeReq.ofProg (base + 156) unified_decoder_prog) (-152) (encode (.list items))
+    (CodeReq.ofProg (base + 156) unified_decoder_prog) (-152) (encode (.list items) ++ tail)
     halign hover (by bv_omega) decoderH_loop hback_loop (by bv_omega) (by bv_omega)
     (CodeReq.Disjoint.singleton_ofProg (dcr_none_l (base + 152) (by intro k hk; bv_omega)))
     (CodeReq.Disjoint.ofProg_singleton (dcr_none_l (base + 300) (by intro k hk; bv_omega)))
     (CodeReq.Disjoint.ofProg_singleton (dcr_none_l (base + 300 + 4) (by intro k hk; bv_omega)))
-    items payloadOff v5' v10' v11' v12' v14'
+    items payloadOff tail v5' v10' v11' v12' v14'
     hitems_ne hdpay hwin
   rwa [show base + 300 + 8 = base + 308 from by bv_omega] at t_loop
 
 set_option maxRecDepth 8000 in
-/-- **Concrete top-level RLP list descent.** The program at `base` decodes the
-    complete list value `encode (.list items)` from `bytesRegion` — descending the
-    header into the payload via the length-driven loop — in `62 + 63 * items.length`
-    steps, and the pure decoder recovers exactly `.list items`. No abstract
-    hypotheses remain. -/
+/-- **Concrete RLP list descent (interior-general).** The program at `base` decodes
+    a complete list value `encode (.list items)` embedded at the front of the buffer
+    `encode (.list items) ++ tail` from `bytesRegion` — descending the header into
+    the payload via the length-driven loop, stopping at the sub-list boundary and
+    leaving `tail` unread — in `62 + 63 * items.length` steps, and the pure decoder
+    recovers exactly `(.list items, tail)`. `tail = []` is the top-level case. No
+    abstract hypotheses remain. -/
 theorem unified_list_descend_concrete_bridge
-    (base regionBase : Word) (items : List RLPItem)
+    (base regionBase : Word) (items : List RLPItem) (tail : List Byte)
     (v5Old v10 v11Old v12Old v14Old v15Old : Word)
     (halign : regionBase.toNat % 8 = 0)
-    (hover : regionBase.toNat + (encode (.list items)).length < 2 ^ 64)
-    (hwin : ∀ i, i < (encode (.list items)).length →
+    (hover : regionBase.toNat + (encode (.list items) ++ tail).length < 2 ^ 64)
+    (hwin : ∀ i, i < (encode (.list items) ++ tail).length →
        isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
     (hsize : (encode (.list items)).length < 256 ^ 8)
     (hitems_ne : items ≠ []) :
@@ -131,14 +133,19 @@ theorem unified_list_descend_concrete_bridge
               ((CodeReq.singleton (base + 300 + 4) (.BNE .x13 .x15 (-152))).union CodeReq.empty)))))
       ((.x5 ↦ᵣ v5Old) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
        (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ regionBase) ** (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ v15Old) **
-       bytesRegion regionBase (encode (.list items)))
-      (unified_lenloop_post regionBase (encode (.list items))
+       bytesRegion regionBase (encode (.list items) ++ tail))
+      (unified_lenloop_post regionBase (encode (.list items) ++ tail)
         (regionBase + BitVec.ofNat 64 (encode (.list items)).length))
-    ∧ decode (encode (.list items)) = some (.list items, []) := by
-  refine ⟨?_, decode_encode (.list items) hsize⟩
-  -- The whole input region.
-  have hbs0 : 0 < (encode (.list items)).length := encode_nonempty _
-  set bz := ((encode (.list items))[0]'hbs0).zeroExtend 64 with hbz
+    ∧ decode (encode (.list items) ++ tail) = some (.list items, tail) := by
+  refine ⟨?_, decode_encode_append (.list items) tail hsize⟩
+  -- The whole input region `encode (.list items) ++ tail`.
+  have hbs0 : 0 < (encode (.list items) ++ tail).length := by
+    rw [List.length_append]; have := encode_nonempty (RLPItem.list items); omega
+  -- the buffer's first byte is the list value's first byte (the trailer is past it)
+  have hbs_head : (encode (.list items) ++ tail)[0]'hbs0
+      = (encode (.list items))[0]'(encode_nonempty (RLPItem.list items)) :=
+    List.getElem_append_left (encode_nonempty (RLPItem.list items))
+  set bz := ((encode (.list items) ++ tail)[0]'hbs0).zeroExtend 64 with hbz
   have hsize' : (encode.encodeItems items).length < 256 ^ 8 := by
     have hle : (encode.encodeItems items).length ≤ (encode (.list items)).length := by
       by_cases h : (encode.encodeItems items).length ≤ 55
@@ -146,18 +153,17 @@ theorem unified_list_descend_concrete_bridge
       · rw [encode_list_long items (by omega)]
         simp only [List.length_cons, List.length_append]; omega
     omega
-  -- the payload window (top-level: tail = [])
+  -- the payload window (interior: the trailer `tail` follows the list value)
   obtain ⟨payloadOff, hptr, hlen, hdpay⟩ :=
-    list_item_payload_window items [] regionBase 0 (encode (.list items)) (by simp) hsize'
-  rw [List.append_nil] at hdpay
-  -- align the getElem proof term with `hbs0` (proof irrelevance)
+    list_item_payload_window items tail regionBase 0 (encode (.list items) ++ tail) (by simp) hsize'
+  -- align the getElem proof term with the buffer's `bs[0]`
   rw [show ((encode (.list items))[0]'(encode_nonempty (RLPItem.list items)))
-        = ((encode (.list items))[0]'hbs0) from rfl] at hptr hlen
-  -- the header's region window obligation (head = .list items, tail = [])
-  have hwindow0 : regionLongWindow regionBase (encode (.list items)) 0 hbs0 :=
-    regionLongWindow_of_split regionBase (encode (.list items)) (.list items) [] 0 hbs0
-      rfl (by simp [encode.encodeItems]) (by simpa [itemPayloadCount] using hsize') hwin
-  -- payloadOff + payloadLen = total input length (the payload is a suffix)
+        = ((encode (.list items) ++ tail)[0]'hbs0) from hbs_head.symm] at hptr hlen
+  -- the header's region window obligation (head = .list items, rest = tail)
+  have hwindow0 : regionLongWindow regionBase (encode (.list items) ++ tail) 0 hbs0 :=
+    regionLongWindow_of_split regionBase (encode (.list items) ++ tail) (.list items) tail 0 hbs0
+      hbs_head (by simp) (by simpa [itemPayloadCount] using hsize') hwin
+  -- payloadOff + payloadLen = list-value length (the trailer cancels)
   have hpayne : (encode.encodeItems items).length ≠ 0 := by
     cases items with
     | nil => exact absurd rfl hitems_ne
@@ -166,7 +172,7 @@ theorem unified_list_descend_concrete_bridge
       simp only [encode.encodeItems, List.length_append]; omega
   have hpoff_le : payloadOff + (encode.encodeItems items).length = (encode (.list items)).length := by
     have e := congrArg List.length hdpay
-    rw [List.length_drop] at e; omega
+    simp only [List.length_drop, List.length_append] at e; omega
   have hr0 : regionBase + BitVec.ofNat 64 0 = regionBase := by simp
   have hover0 : regionBase.toNat + 0 < 2 ^ 64 := by omega
   have hvalid0 : isValidByteAccess (regionBase + BitVec.ofNat 64 0) = true := hwin 0 hbs0
@@ -176,71 +182,77 @@ theorem unified_list_descend_concrete_bridge
     fun a h => CodeReq.ofProg_none_range_len (base + 4) unified_decoder_prog 36 a
       unified_decoder_prog_length h
   -- t_header : LBU x5,x13,0 ; unified_decoder_prog  (decode the list header)
-  have lbu_raw := bytesRegion_lbu_within .x5 .x13 regionBase v5Old base (encode (.list items)) 0
-    (by decide) halign hbs0 hover0 hvalid0
+  have lbu_raw := bytesRegion_lbu_within .x5 .x13 regionBase v5Old base
+    (encode (.list items) ++ tail) 0 (by decide) halign hbs0 hover0 hvalid0
   have s_lbu : cpsTripleWithin 1 base (base + 4)
       (CodeReq.singleton base (.LBU .x5 .x13 0))
       ((.x5 ↦ᵣ v5Old) ** (.x0 ↦ᵣ (0:Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
        (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 0)) ** (.x14 ↦ᵣ v14Old) **
-       (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase (encode (.list items)))
+       (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase (encode (.list items) ++ tail))
       ((.x5 ↦ᵣ bz) ** (.x0 ↦ᵣ (0:Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
        (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 0)) ** (.x14 ↦ᵣ v14Old) **
-       (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase (encode (.list items))) :=
+       (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase (encode (.list items) ++ tail)) :=
     cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp)
       (cpsTripleWithin_frameR
         ((.x0 ↦ᵣ (0:Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) **
          (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ v15Old))
         (by pcFree) lbu_raw)
-  have dec_raw := unified_decoder_spec (base + 4) regionBase (encode (.list items)) 0 hbs0
+  have dec_raw := unified_decoder_spec (base + 4) regionBase (encode (.list items) ++ tail) 0 hbs0
     v10 v11Old v12Old v14Old halign hover hwindow0
   rw [show (base + 4) + 144 = base + 148 from by bv_omega] at dec_raw
   have s_dec : cpsTripleWithin 60 (base + 4) (base + 148)
       (CodeReq.ofProg (base + 4) unified_decoder_prog)
       ((.x5 ↦ᵣ bz) ** (.x0 ↦ᵣ (0:Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
        (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 0)) ** (.x14 ↦ᵣ v14Old) **
-       (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase (encode (.list items)))
+       (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase (encode (.list items) ++ tail))
       ((.x5 ↦ᵣ bz) ** (.x0 ↦ᵣ (0:Word)) **
-       (.x10 ↦ᵣ itemResidue ((encode (.list items))[0]'hbs0)) **
-       (.x11 ↦ᵣ itemLenRegion ((encode (.list items))[0]'hbs0) (encode (.list items)) 0) **
-       (.x12 ↦ᵣ itemX12Region ((encode (.list items))[0]'hbs0) (encode (.list items)) 0 v12Old) **
-       (.x13 ↦ᵣ itemPtrRegion ((encode (.list items))[0]'hbs0) regionBase 0) **
-       (.x14 ↦ᵣ itemX14 ((encode (.list items))[0]'hbs0) v14Old) **
-       (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase (encode (.list items))) :=
+       (.x10 ↦ᵣ itemResidue ((encode (.list items) ++ tail)[0]'hbs0)) **
+       (.x11 ↦ᵣ itemLenRegion ((encode (.list items) ++ tail)[0]'hbs0)
+          (encode (.list items) ++ tail) 0) **
+       (.x12 ↦ᵣ itemX12Region ((encode (.list items) ++ tail)[0]'hbs0)
+          (encode (.list items) ++ tail) 0 v12Old) **
+       (.x13 ↦ᵣ itemPtrRegion ((encode (.list items) ++ tail)[0]'hbs0) regionBase 0) **
+       (.x14 ↦ᵣ itemX14 ((encode (.list items) ++ tail)[0]'hbs0) v14Old) **
+       (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase (encode (.list items) ++ tail)) :=
     cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp)
       (cpsTripleWithin_frameR (.x15 ↦ᵣ v15Old) (by pcFree) dec_raw)
   have t_header := cpsTripleWithin_seq
     (CodeReq.Disjoint.singleton_ofProg (dcr_none4 base (by intro k hk; bv_omega))) s_lbu s_dec
   -- t_add : ADD x15, x13, x11 — compute endPtr = payloadPtr + payloadLen
   have add_raw := add_spec_gen_within .x15 .x13 .x11
-    (itemPtrRegion ((encode (.list items))[0]'hbs0) regionBase 0)
-    (itemLenRegion ((encode (.list items))[0]'hbs0) (encode (.list items)) 0)
+    (itemPtrRegion ((encode (.list items) ++ tail)[0]'hbs0) regionBase 0)
+    (itemLenRegion ((encode (.list items) ++ tail)[0]'hbs0) (encode (.list items) ++ tail) 0)
     v15Old (base + 148) (by decide)
   rw [show (base + 148) + 4 = base + 152 from by bv_omega] at add_raw
   have s_add : cpsTripleWithin 1 (base + 148) (base + 152)
       (CodeReq.singleton (base + 148) (.ADD .x15 .x13 .x11))
       ((.x5 ↦ᵣ bz) ** (.x0 ↦ᵣ (0:Word)) **
-       (.x10 ↦ᵣ itemResidue ((encode (.list items))[0]'hbs0)) **
-       (.x11 ↦ᵣ itemLenRegion ((encode (.list items))[0]'hbs0) (encode (.list items)) 0) **
-       (.x12 ↦ᵣ itemX12Region ((encode (.list items))[0]'hbs0) (encode (.list items)) 0 v12Old) **
-       (.x13 ↦ᵣ itemPtrRegion ((encode (.list items))[0]'hbs0) regionBase 0) **
-       (.x14 ↦ᵣ itemX14 ((encode (.list items))[0]'hbs0) v14Old) **
-       (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase (encode (.list items)))
+       (.x10 ↦ᵣ itemResidue ((encode (.list items) ++ tail)[0]'hbs0)) **
+       (.x11 ↦ᵣ itemLenRegion ((encode (.list items) ++ tail)[0]'hbs0)
+          (encode (.list items) ++ tail) 0) **
+       (.x12 ↦ᵣ itemX12Region ((encode (.list items) ++ tail)[0]'hbs0)
+          (encode (.list items) ++ tail) 0 v12Old) **
+       (.x13 ↦ᵣ itemPtrRegion ((encode (.list items) ++ tail)[0]'hbs0) regionBase 0) **
+       (.x14 ↦ᵣ itemX14 ((encode (.list items) ++ tail)[0]'hbs0) v14Old) **
+       (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase (encode (.list items) ++ tail))
       ((.x5 ↦ᵣ bz) ** (.x0 ↦ᵣ (0:Word)) **
-       (.x10 ↦ᵣ itemResidue ((encode (.list items))[0]'hbs0)) **
+       (.x10 ↦ᵣ itemResidue ((encode (.list items) ++ tail)[0]'hbs0)) **
        (.x11 ↦ᵣ BitVec.ofNat 64 (encode.encodeItems items).length) **
-       (.x12 ↦ᵣ itemX12Region ((encode (.list items))[0]'hbs0) (encode (.list items)) 0 v12Old) **
+       (.x12 ↦ᵣ itemX12Region ((encode (.list items) ++ tail)[0]'hbs0)
+          (encode (.list items) ++ tail) 0 v12Old) **
        (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 payloadOff)) **
-       (.x14 ↦ᵣ itemX14 ((encode (.list items))[0]'hbs0) v14Old) **
+       (.x14 ↦ᵣ itemX14 ((encode (.list items) ++ tail)[0]'hbs0) v14Old) **
        (.x15 ↦ᵣ (regionBase + BitVec.ofNat 64 (payloadOff + (encode.encodeItems items).length))) **
-       bytesRegion regionBase (encode (.list items))) :=
+       bytesRegion regionBase (encode (.list items) ++ tail)) :=
     cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
       (fun _ hp => by rw [hptr, hlen, region_ptr_add] at hp; xperm_hyp hp)
       (cpsTripleWithin_frameR
         ((.x5 ↦ᵣ bz) ** (.x0 ↦ᵣ (0:Word)) **
-         (.x10 ↦ᵣ itemResidue ((encode (.list items))[0]'hbs0)) **
-         (.x12 ↦ᵣ itemX12Region ((encode (.list items))[0]'hbs0) (encode (.list items)) 0 v12Old) **
-         (.x14 ↦ᵣ itemX14 ((encode (.list items))[0]'hbs0) v14Old) **
-         bytesRegion regionBase (encode (.list items)))
+         (.x10 ↦ᵣ itemResidue ((encode (.list items) ++ tail)[0]'hbs0)) **
+         (.x12 ↦ᵣ itemX12Region ((encode (.list items) ++ tail)[0]'hbs0)
+            (encode (.list items) ++ tail) 0 v12Old) **
+         (.x14 ↦ᵣ itemX14 ((encode (.list items) ++ tail)[0]'hbs0) v14Old) **
+         bytesRegion regionBase (encode (.list items) ++ tail))
         (by pcFree) add_raw)
   have t_ha := cpsTripleWithin_seq
     (CodeReq.Disjoint.union_left (CodeReq.Disjoint.singleton (by bv_omega))
@@ -252,11 +264,11 @@ theorem unified_list_descend_concrete_bridge
       CodeReq.ofProg (base + 156) unified_decoder_prog a = none :=
     fun a h => CodeReq.ofProg_none_range_len (base + 156) unified_decoder_prog 36 a
       unified_decoder_prog_length h
-  have t_loop := descend_loop_triple base regionBase items payloadOff bz
-    (itemResidue ((encode (.list items))[0]'hbs0))
+  have t_loop := descend_loop_triple base regionBase items tail payloadOff bz
+    (itemResidue ((encode (.list items) ++ tail)[0]'hbs0))
     (BitVec.ofNat 64 (encode.encodeItems items).length)
-    (itemX12Region ((encode (.list items))[0]'hbs0) (encode (.list items)) 0 v12Old)
-    (itemX14 ((encode (.list items))[0]'hbs0) v14Old)
+    (itemX12Region ((encode (.list items) ++ tail)[0]'hbs0) (encode (.list items) ++ tail) 0 v12Old)
+    (itemX14 ((encode (.list items) ++ tail)[0]'hbs0) v14Old)
     halign hover hwin hitems_ne hdpay
   -- the header/ADD code is disjoint from the loop code (non-overlapping ranges)
   have hd_big :
@@ -303,17 +315,33 @@ theorem unified_list_descend_concrete_bridge
   rw [hr0, hpoff_le] at composed
   exact composed
 
--- Concrete cross-check: the program at `base = 0x1000` decodes the complete list
--- value `[0x01, 0x02]` (`encode = [0xc2, 0x01, 0x02]`) from the region at `0x2000`,
--- descending the `0xc2` header into its 2-byte payload, in `62 + 63 * 2 = 188`
--- steps — and the pure `decode` recovers exactly `.list [.bytes [1], .bytes [2]]`.
+-- Top-level cross-check (`tail = []`): the program at `base = 0x1000` decodes the
+-- complete list value `[0x01, 0x02]` (`encode = [0xc2, 0x01, 0x02]`) from the region
+-- at `0x2000`, descending the `0xc2` header into its 2-byte payload, in
+-- `62 + 63 * 2 = 188` steps — pure `decode` recovers `(.list […], [])`.
 example :=
   unified_list_descend_concrete_bridge (0x1000 : Word) (0x2000 : Word)
-    [.bytes [(0x01 : Byte)], .bytes [(0x02 : Byte)]] 0 0 0 0 0 0
+    [.bytes [(0x01 : Byte)], .bytes [(0x02 : Byte)]] [] 0 0 0 0 0 0
     (by decide) (by decide)
     (by intro i hi
         have hlen : (encode (.list
-            [.bytes [(0x01 : Byte)], .bytes [(0x02 : Byte)]])).length = 3 := by decide
+            [.bytes [(0x01 : Byte)], .bytes [(0x02 : Byte)]]) ++ ([] : List Byte)).length = 3 := by
+          decide
+        rw [hlen] at hi; interval_cases i <;> decide)
+    (by decide) (by decide)
+
+-- Interior cross-check (`tail = [0xFF]`): the SAME list value embedded in a larger
+-- buffer `[0xc2, 0x01, 0x02, 0xFF]` — the program descends the sub-list, stops at the
+-- boundary leaving the `0xFF` sibling unread, and pure `decode` recovers
+-- `(.list […], [0xFF])`.
+example :=
+  unified_list_descend_concrete_bridge (0x1000 : Word) (0x2000 : Word)
+    [.bytes [(0x01 : Byte)], .bytes [(0x02 : Byte)]] [(0xFF : Byte)] 0 0 0 0 0 0
+    (by decide) (by decide)
+    (by intro i hi
+        have hlen : (encode (.list
+            [.bytes [(0x01 : Byte)], .bytes [(0x02 : Byte)]]) ++ [(0xFF : Byte)]).length = 4 := by
+          decide
         rw [hlen] at hi; interval_cases i <;> decide)
     (by decide) (by decide)
 

--- a/EvmAsm/Rv64/RLP/UnifiedListLoop.lean
+++ b/EvmAsm/Rv64/RLP/UnifiedListLoop.lean
@@ -141,10 +141,10 @@ private theorem classify_list_long {items : List RLPItem}
     makes `regionLongWindow` reduce to `True`. (Exposed for the length-driven loop
     closure, which discharges the same per-item window obligation.) -/
 theorem regionLongWindow_of_split
-    (regionBase : Word) (bs : List (BitVec 8)) (head : RLPItem) (tail : List RLPItem) (O : Nat)
+    (regionBase : Word) (bs : List (BitVec 8)) (head : RLPItem) (rest : List Byte) (O : Nat)
     (hO : O < bs.length)
     (hbsO : bs[O]'hO = (encode head)[0]'(encode_nonempty head))
-    (hsplit : bs.drop O = encode head ++ encode.encodeItems tail)
+    (hsplit : bs.drop O = encode head ++ rest)
     (hsize : itemPayloadCount head < 256 ^ 8)
     (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true) :
     regionLongWindow regionBase bs O hO := by
@@ -249,11 +249,14 @@ theorem unified_loop_spec_within
     -- the next-item pointer lands at offset `O + (encode head).length`
     have hnext : itemNextPtrRegion (bs[O]'hO) regionBase O bs
         = regionBase + BitVec.ofNat 64 (O + (encode head).length) := by
-      rw [hbsO]; exact encode_head_eq_itemNextPtrRegion head tail regionBase O bs hsplit hsizeHead
+      rw [hbsO]
+      exact encode_head_eq_itemNextPtrRegion head (encode.encodeItems tail) regionBase O bs
+        hsplit hsizeHead
     have hoverO : regionBase.toNat + O < 2 ^ 64 := by omega
     have hvalidO : isValidByteAccess (regionBase + BitVec.ofNat 64 O) = true := hwin O hO
     have hwinO : regionLongWindow regionBase bs O hO :=
-      regionLongWindow_of_split regionBase bs head tail O hO hbsO hsplit hsizeHead hwin
+      regionLongWindow_of_split regionBase bs head (encode.encodeItems tail) O hO hbsO hsplit
+        hsizeHead hwin
     cases tail with
     | nil =>
       have body := unified_body_spec_within regionBase v5Old v10 v11Old v12Old v14Old

--- a/PLAN.md
+++ b/PLAN.md
@@ -1529,11 +1529,23 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     application is extracted into a private `descend_loop_triple` so it elaborates in a clean local
     context (inside the main theorem's large context it provokes an unbounded `whnf`). Axiom-clean, 0
     sorry, 0 warnings.
-  - **Next (tail-general closure):** generalize `unified_lenloop_spec_within` to `bs.drop O =
-    encode.encodeItems items ++ tail` (stride/window lemmas only read within each item, so the byte tail
-    is inert) — unlocks descent into INTERIOR sub-lists (with trailing siblings), the recursive step for
-    arbitrary depth (bounded composition for the STF block/tx structure, or the explicit-stack
-    generalization).
+  - ✅ **Step 5 — tail-general closure + interior descent** (`UnifiedListDescendConcrete.lean` et al.).
+    Generalized `unified_lenloop_spec_within` to `bs.drop O = encode.encodeItems items ++ btail` (the
+    stride/window glue — `encode_head_eq_itemNextPtrRegion`, `regionLongWindow_of_split`, and the private
+    `long_lenBytes_in_region` — now take an arbitrary byte suffix `rest : List Byte`, since they only use
+    that `encode head` is a prefix; the byte tail is inert). Then generalized
+    **`unified_list_descend_concrete_bridge`** itself to take a trailing `tail : List Byte`: the program
+    decodes a `.list` value embedded at the front of `encode (.list items) ++ tail`, stopping at the
+    sub-list boundary and leaving `tail` unread, in `62 + 63 * items.length` steps, coinciding with the
+    pure `decode (encode (.list items) ++ tail) = some (.list items, tail)` (via the existing
+    `decode_encode_append`). The buffer-vs-value first byte is bridged by `List.getElem_append_left`
+    (`(encode (.list items) ++ tail)[0] = (encode (.list items))[0]`). `tail = []` recovers the top-level
+    case. Concrete examples for both `tail = []` and `tail = [0xFF]` (`[0xc2,0x01,0x02,0xFF]` ⇒
+    `(.list …, [0xFF])`). Axiom-clean, 0 sorry, 0 warnings, no heartbeat override. **This is the recursive
+    step toward arbitrary depth** (interior sub-lists with trailing siblings).
+  - **Next (arbitrary depth):** with a tail-tolerant one-level descent in hand, compose descents for
+    nested-of-nested (`.list` whose items include further `.list`s) — bounded composition for the
+    concrete STF block/tx shape, or the explicit-stack generalization.
 - Phase 6: Top-level pipeline (`read_input` -> decode -> `write_output`)
 - **Host I/O ABI**: See `docs/zkvm-host-io-interface.md`; SP1
   `HINT_LEN`/`HINT_READ`/`COMMIT` are legacy handler shapes, not the target


### PR DESCRIPTION
## Summary

Generalizes the length-driven RLP list decoder to tolerate **trailing bytes** after the items, unlocking descent into **interior sub-lists** — a `.list` value embedded in a larger buffer with sibling bytes following it (the recursive step toward arbitrary depth / the STF block & tx structure).

The headline result, `unified_list_descend_concrete_bridge`, now takes a trailing `tail : List Byte`: the real RV64 program decodes a `.list` value at the front of `encode (.list items) ++ tail`, stopping at the sub-list boundary and **leaving `tail` unread**, in `62 + 63 * items.length` steps, and coincides with the pure `decode (encode (.list items) ++ tail) = some (.list items, tail)`. `tail = []` recovers the top-level case (#9044).

> **Stacked on #9044** (`feat/rv64-rlp-list-descend-concrete`), which is not yet merged — this PR is based on that branch so the diff shows only the interior-descent work. Once #9044 lands, I'll rebase onto `main` and retarget.

## How it works

The operational core was **already tail-agnostic** — `regionLongWindow`, the loop body, and `unified_decoder_spec` only read *within* each item. So the generalization is mostly threading one parameter:

- **Glue lemmas** `encode_head_eq_itemNextPtrRegion`, `regionLongWindow_of_split`, and the private `long_lenBytes_in_region` now take an arbitrary byte suffix `rest : List Byte` instead of `encode.encodeItems tail`. Their proofs only use that `encode head` is a *prefix*, so the bodies are unchanged; count-driven callers pass `encode.encodeItems tail`.
- **`unified_lenloop_spec_within`** carries a `btail : List Byte`; its precondition becomes `bs.drop O = encode.encodeItems items ++ btail`. End pointer, post, code requirement, and step count are **unchanged** (the loop stops at the items boundary). `unified_lenloop_n_spec_within` passes `[]`.
- The buffer-vs-value first byte is bridged by `List.getElem_append_left` (`(encode (.list items) ++ tail)[0] = (encode (.list items))[0]`).
- **Pure half**: the already-existing `decode_encode_append` (`decode (encode item ++ rest) = some (item, rest)`) — no new pure lemma needed.

## Verification

- Full `EvmAsm` build — clean, **0 warnings**.
- `#print axioms unified_list_descend_concrete_bridge` → `[propext, Classical.choice, Quot.sound]` (classical only); 0 sorry.
- `scripts/check-forbidden-tactics.sh` OK; **no `maxHeartbeats` override** (builds under the default budget).
- Concrete `example`s for `tail = []` and `tail = [0xFF]` (`[0xc2,0x01,0x02,0xFF]` ⇒ `(.list …, [0xFF])`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)