### PR TITLE
fix(codegen): record created-in-tx SELFDESTRUCT account deletion (EIP-6780)

### DIFF
--- a/EvmAsm/Codegen/Programs/Selfdestruct.lean
+++ b/EvmAsm/Codegen/Programs/Selfdestruct.lean
@@ -422,6 +422,22 @@ conservative-accept stay unaffected). The all-accounts wrapper skips {sender,rec
 restores the dispatcher's x10/x12 around each helper call (mirrors the eip7708 fragment). -/
 def selfdestructBeneficiaryNonstorageAsm : String :=
   "  la t0, evm_selfdestruct_staged; ld t0, 0(t0); beqz t0, .L_sdbn_done\n" ++
+  -- drj99.1: a created-in-this-tx contract that SELFDESTRUCTs is DELETED (EIP-6780). The CREATE deposit
+  -- recorded it (nonce 1, balance = endowment); record its DELETION (balance 0, nonce 0) so the aggregate's
+  -- last-post-wins gives the BAL's deleted final (0/0) -- without this the deposit's nonce=1 lingers and the
+  -- all-accounts non-storage comparator rejects (bv_fail=44 nonce-mismatch, balance 0=0). The origin is NOT
+  -- in the block-pre witness (created this tx), so the witness-present origin-debit path below skips it; this
+  -- record fires on the created_in_tx flag regardless of sdai_status. sdai_origin_address = the
+  -- selfdestructing contract's env ADDRESS (set from env, not the lookup), i.e. the created contract.
+  -- Enables no new behavior (records the deletion that already happens) -> no cascade. a0/a2 alias x10/x12.
+  "  la t0, evm_selfdestruct_created_in_tx; ld t0, 0(t0); beqz t0, .L_sdbn_chk_witness\n" ++
+  "  addi sp, sp, -48\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n" ++
+  "  sd zero, 16(sp); sd zero, 24(sp); sd zero, 32(sp); sd zero, 40(sp)\n" ++   -- 32B zero balance scratch
+  "  la a0, sdai_origin_address\n  addi a1, sp, 16\n  addi a2, sp, 16\n  li a3, 0\n  li a4, 0\n" ++
+  "  jal ra, record_nonstorage_effect\n" ++
+  "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  addi sp, sp, 48\n" ++
+  "  j .L_sdbn_done\n" ++
+  ".L_sdbn_chk_witness:\n" ++
   "  la t0, sdai_status; ld t0, 0(t0); beqz t0, .L_sdbn_origin_ok\n" ++
   "  li t1, 4; bne t0, t1, .L_sdbn_done\n" ++
   ".L_sdbn_origin_ok:\n" ++


### PR DESCRIPTION
## Problem

A contract created in the same transaction that then SELFDESTRUCTs is **deleted** (EIP-6780). The CREATE-RETURN deposit records the created account (nonce 1, balance = endowment), but nothing recorded its subsequent deletion — so the all-accounts non-storage comparator sees the exec leave nonce=1 while the BAL declares the account gone (final nonce 0) → `bv_fail=44` nonce-mismatch (balance already 0) for create+selfdestruct-same-tx blocks once single-tx contract dispatch executes. One slice of the `drj99.1` unrecorded-effect class.

## Fix

The existing witness-present origin-debit path can't cover this: a created-in-this-tx account is absent from the block-pre witness, so its `sdai_status` lookup misses and that path skips. Add a separate record gated on `evm_selfdestruct_created_in_tx`, firing regardless of the lookup:

```
record_nonstorage_effect(origin = sdai_origin_address,
                         pre = post = 0 (balance), pre_nonce = post_nonce = 0)
```

The aggregate keeps first-pre/last-post, so the deposit's first-pre (0/0) + this last-post (0/0) collapse the account to its deleted final, matching the BAL. `sdai_origin_address` is the selfdestructing contract's env ADDRESS (set from env, not the lookup). Records the deletion that already happens → enables no new behavior → does not cascade.

## Validation (EEST, `--filter selfdestruct` = 698 inputs)

- **flip OFF (shipped config): 0 FAIL, 0 false-accepts** (0-regress).

Note: under the flip these cases also hit `bv_fail=41` (gas) next — the harness reports the first failing check, so this slice advances them past the nonce check but they only PASS once the coupled gas/storage reconstruction also lands. This PR is the sound prerequisite for that bundle.

Part of `evm-asm-drj99.1` — the created-in-tx SELFDESTRUCT deletion slice.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)