### PR TITLE
feat(rv64/rlp): depth-2 nested RLP list descent (Phase 5, step 6b)

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -71,6 +71,7 @@ import EvmAsm.Rv64.RLP.UnifiedListLoop
 import EvmAsm.Rv64.RLP.UnifiedDecoderConcrete
 import EvmAsm.Rv64.RLP.UnifiedListLoopConcrete
 import EvmAsm.Rv64.RLP.UnifiedListDescendConcrete
+import EvmAsm.Rv64.RLP.UnifiedListDescendNested
 import EvmAsm.Rv64.RLP.NestedDescendOne
 import EvmAsm.Rv64.RLP.UnifiedDecodeItem
 import EvmAsm.Rv64.RLP.UnifiedDecodeItemReconverge

--- a/EvmAsm/Rv64/RLP/UnifiedListDescendConcrete.lean
+++ b/EvmAsm/Rv64/RLP/UnifiedListDescendConcrete.lean
@@ -42,7 +42,7 @@ private theorem region_ptr_add (regionBase : Word) (a b : Nat) :
   simp only [BitVec.toNat_add, BitVec.toNat_ofNat, Nat.add_mod_mod, Nat.mod_add_mod]
 
 /-- Two programs at non-overlapping address ranges have disjoint code requirements. -/
-private theorem ofProg_disjoint_ofProg (b1 b2 : Word) (p1 p2 : List Instr) (n1 n2 : Nat)
+theorem ofProg_disjoint_ofProg (b1 b2 : Word) (p1 p2 : List Instr) (n1 n2 : Nat)
     (h1 : p1.length = n1) (h2 : p2.length = n2)
     (hsep : ∀ k1, k1 < n1 → ∀ k2, k2 < n2 →
       b1 + BitVec.ofNat 64 (4 * k1) ≠ b2 + BitVec.ofNat 64 (4 * k2)) :
@@ -349,6 +349,72 @@ theorem unified_list_descend_concrete_bridge
       show (0 : Nat) + (encode (.list items)).length = (encode (.list items)).length
         from Nat.zero_add _, List.drop_zero] at h
   exact h
+
+/-- **List-header descent primitive.** `LBU x5,x13,0 ++ unified_decoder_prog` at
+    `base` (61 steps, `base .. base+148`): from `x13 = regionBase + ofNat O` pointing
+    at a `.list` value (whose region window `hwindow0` holds), it leaves `x13 =
+    itemPtrRegion` (the payload pointer) and `x11 = itemLenRegion` (the payload
+    length) — the reusable "descend one list level to its payload" step. Composed
+    with `unified_list_descend_concrete_bridge_at` (at the payload offset) it gives
+    nested descent; used directly by the STF schema decoders for each list level. -/
+theorem unified_list_header_descend
+    (base regionBase : Word) (bs : List Byte) (O : Nat) (hO : O < bs.length)
+    (v5Old v10 v11Old v12Old v14Old v15Old : Word)
+    (halign : regionBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hvalid0 : isValidByteAccess (regionBase + BitVec.ofNat 64 O) = true)
+    (hwindow0 : regionLongWindow regionBase bs O hO) :
+    cpsTripleWithin 61 base (base + 148)
+      ((CodeReq.singleton base (.LBU .x5 .x13 0)).union
+        (CodeReq.ofProg (base + 4) unified_decoder_prog))
+      ((.x5 ↦ᵣ v5Old) ** (.x0 ↦ᵣ (0:Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
+       (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (.x14 ↦ᵣ v14Old) **
+       (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs)
+      ((.x5 ↦ᵣ (bs[O]'hO).zeroExtend 64) ** (.x0 ↦ᵣ (0:Word)) **
+       (.x10 ↦ᵣ itemResidue (bs[O]'hO)) **
+       (.x11 ↦ᵣ itemLenRegion (bs[O]'hO) bs O) **
+       (.x12 ↦ᵣ itemX12Region (bs[O]'hO) bs O v12Old) **
+       (.x13 ↦ᵣ itemPtrRegion (bs[O]'hO) regionBase O) **
+       (.x14 ↦ᵣ itemX14 (bs[O]'hO) v14Old) **
+       (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs) := by
+  have hover0 : regionBase.toNat + O < 2 ^ 64 := by omega
+  have lbu_raw := bytesRegion_lbu_within .x5 .x13 regionBase v5Old base
+    bs O (by decide) halign hO hover0 hvalid0
+  have s_lbu : cpsTripleWithin 1 base (base + 4)
+      (CodeReq.singleton base (.LBU .x5 .x13 0))
+      ((.x5 ↦ᵣ v5Old) ** (.x0 ↦ᵣ (0:Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
+       (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (.x14 ↦ᵣ v14Old) **
+       (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs)
+      ((.x5 ↦ᵣ (bs[O]'hO).zeroExtend 64) ** (.x0 ↦ᵣ (0:Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
+       (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (.x14 ↦ᵣ v14Old) **
+       (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp)
+      (cpsTripleWithin_frameR
+        ((.x0 ↦ᵣ (0:Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) **
+         (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ v15Old))
+        (by pcFree) lbu_raw)
+  have dec_raw := unified_decoder_spec (base + 4) regionBase bs O hO
+    v10 v11Old v12Old v14Old halign hover hwindow0
+  rw [show (base + 4) + 144 = base + 148 from by bv_omega] at dec_raw
+  have s_dec : cpsTripleWithin 60 (base + 4) (base + 148)
+      (CodeReq.ofProg (base + 4) unified_decoder_prog)
+      ((.x5 ↦ᵣ (bs[O]'hO).zeroExtend 64) ** (.x0 ↦ᵣ (0:Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
+       (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (.x14 ↦ᵣ v14Old) **
+       (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs)
+      ((.x5 ↦ᵣ (bs[O]'hO).zeroExtend 64) ** (.x0 ↦ᵣ (0:Word)) **
+       (.x10 ↦ᵣ itemResidue (bs[O]'hO)) **
+       (.x11 ↦ᵣ itemLenRegion (bs[O]'hO) bs O) **
+       (.x12 ↦ᵣ itemX12Region (bs[O]'hO) bs O v12Old) **
+       (.x13 ↦ᵣ itemPtrRegion (bs[O]'hO) regionBase O) **
+       (.x14 ↦ᵣ itemX14 (bs[O]'hO) v14Old) **
+       (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp)
+      (cpsTripleWithin_frameR (.x15 ↦ᵣ v15Old) (by pcFree) dec_raw)
+  exact cpsTripleWithin_seq
+    (CodeReq.Disjoint.singleton_ofProg
+      (CodeReq.ofProg_none_range_len (base + 4) unified_decoder_prog 36 base
+        unified_decoder_prog_length (by intro k hk; bv_omega)))
+    s_lbu s_dec
 
 -- Top-level cross-check (`tail = []`): the program at `base = 0x1000` decodes the
 -- complete list value `[0x01, 0x02]` (`encode = [0xc2, 0x01, 0x02]`) from the region

--- a/EvmAsm/Rv64/RLP/UnifiedListDescendNested.lean
+++ b/EvmAsm/Rv64/RLP/UnifiedListDescendNested.lean
@@ -1,0 +1,204 @@
+/-
+  EvmAsm.Rv64.RLP.UnifiedListDescendNested
+
+  EL.3 / Phase 5 — DEPTH-2 nested RLP list descent. A concrete RV64 program
+  descends TWO levels: the outer list header (to its payload pointer), then the
+  first sub-list item (itself a `.list`), fully decoding the inner list — and
+  coincides with the pure nested `decode`. The recursive step toward the
+  fixed-schema STF block/header/tx decoders.
+
+  Layout (program base `base`; aligned `regionBase`, whole buffer `bs`):
+      base       LBU x5,x13,0 ++ unified_decoder_prog   ; OUTER header
+                 (base .. base+148)                      ;   x13 → outer payload ptr
+      base+148   < inner descent at offset payloadOff >  ; decode the inner .list
+                 (base+148 .. base+456)
+      base+456   (exit)
+
+  Composes `unified_list_header_descend` (outer, offset 0) with
+  `unified_list_descend_concrete_bridge_at` (inner, at the outer payload offset):
+  reading at an OFFSET into the single aligned region — never re-anchoring at the
+  unaligned payload pointer — is what makes the two levels compose.
+-/
+
+import EvmAsm.Rv64.RLP.UnifiedListDescendConcrete
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL.RLP
+open EvmAsm.Rv64.Tactics
+
+set_option maxRecDepth 8000 in
+/-- **Concrete depth-2 RLP list descent.** For an outer list whose head is itself a
+    list (`.list (.list innerItems :: rest)`) embedded at the front of the buffer
+    `bs = encode (.list (.list innerItems :: rest)) ++ outerTail`, the program
+    descends the outer header to its payload pointer (offset `payloadOff`), then
+    descends the inner `.list innerItems` there — in `123 + 63 * innerItems.length`
+    steps — coinciding with the pure nested `decode` (both the outer value and the
+    inner sub-list). -/
+theorem unified_list_descend_nested_bridge
+    (base regionBase : Word) (innerItems rest : List RLPItem) (outerTail : List Byte)
+    (v5Old v10 v11Old v12Old v14Old v15Old : Word)
+    (halign : regionBase.toNat % 8 = 0)
+    (hover : regionBase.toNat
+      + (encode (.list (.list innerItems :: rest)) ++ outerTail).length < 2 ^ 64)
+    (hwin : ∀ i, i < (encode (.list (.list innerItems :: rest)) ++ outerTail).length →
+       isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hsize_outer : (encode (.list (.list innerItems :: rest))).length < 256 ^ 8)
+    (hsize_inner : (encode (.list innerItems)).length < 256 ^ 8)
+    (hinner_ne : innerItems ≠ []) :
+    ∃ payloadOff,
+      cpsTripleWithin (61 + (62 + 63 * innerItems.length)) base (base + 456)
+        (((CodeReq.singleton base (.LBU .x5 .x13 0)).union
+            (CodeReq.ofProg (base + 4) unified_decoder_prog)).union
+          ((((((CodeReq.singleton (base + 148) (.LBU .x5 .x13 0)).union
+                (CodeReq.ofProg (base + 152) unified_decoder_prog)).union
+                (CodeReq.singleton (base + 296) (.ADD .x15 .x13 .x11))).union
+                ((((CodeReq.singleton (base + 300) (.LBU .x5 .x13 0)).union
+                  (CodeReq.ofProg (base + 304) unified_decoder_prog)).union
+                  (CodeReq.singleton (base + 448) (.ADD .x13 .x13 .x11))).union
+                  ((CodeReq.singleton (base + 448 + 4) (.BNE .x13 .x15 (-152))).union
+                    CodeReq.empty))))))
+        ((.x5 ↦ᵣ v5Old) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
+         (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ regionBase) ** (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ v15Old) **
+         bytesRegion regionBase (encode (.list (.list innerItems :: rest)) ++ outerTail))
+        (unified_lenloop_post regionBase
+          (encode (.list (.list innerItems :: rest)) ++ outerTail)
+          (regionBase + BitVec.ofNat 64 (payloadOff + (encode (.list innerItems)).length)))
+      ∧ (encode (.list (.list innerItems :: rest)) ++ outerTail).drop payloadOff
+          = encode (.list innerItems) ++ (encode.encodeItems rest ++ outerTail)
+      ∧ decode (encode (.list (.list innerItems :: rest)) ++ outerTail)
+          = some (.list (.list innerItems :: rest), outerTail) := by
+  set outerItems := (.list innerItems :: rest : List RLPItem) with houter
+  set bs := encode (.list outerItems) ++ outerTail with hbsdef
+  -- outer value sizes
+  have hsize_outer' : (encode.encodeItems outerItems).length < 256 ^ 8 := by
+    have hle : (encode.encodeItems outerItems).length ≤ (encode (.list outerItems)).length := by
+      by_cases h : (encode.encodeItems outerItems).length ≤ 55
+      · rw [encode_list_short outerItems h]; simp only [List.length_cons]; omega
+      · rw [encode_list_long outerItems (by omega)]
+        simp only [List.length_cons, List.length_append]; omega
+    omega
+  -- outer header window (offset 0)
+  have hO0 : 0 < bs.length := by
+    rw [hbsdef, List.length_append]; have := encode_nonempty (RLPItem.list outerItems); omega
+  have hdrop0 : bs.drop 0 = encode (.list outerItems) ++ outerTail := by rw [List.drop_zero]
+  have hbs_head : bs[0]'hO0 = (encode (.list outerItems))[0]'(encode_nonempty (RLPItem.list outerItems)) := by
+    have key : (bs.drop 0)[0]'(by rw [List.length_drop]; omega)
+        = (encode (.list outerItems))[0]'(encode_nonempty (RLPItem.list outerItems)) :=
+      (List.getElem_of_eq hdrop0 _).trans (List.getElem_append_left (encode_nonempty _))
+    rw [← key]; simp
+  obtain ⟨payloadOff, hptr, hlen, hdpay⟩ :=
+    list_item_payload_window outerItems outerTail regionBase 0 bs hdrop0 hsize_outer'
+  rw [show ((encode (.list outerItems))[0]'(encode_nonempty (RLPItem.list outerItems)))
+        = (bs[0]'hO0) from hbs_head.symm] at hptr hlen
+  -- the outer payload is `encode (.list innerItems) ++ (encode.encodeItems rest ++ outerTail)`
+  have hdrop_inner : bs.drop payloadOff
+      = encode (.list innerItems) ++ (encode.encodeItems rest ++ outerTail) := by
+    rw [hdpay, houter,
+      show encode.encodeItems (.list innerItems :: rest)
+        = encode (.list innerItems) ++ encode.encodeItems rest from rfl, List.append_assoc]
+  refine ⟨payloadOff, ?_, hdrop_inner, ?_⟩
+  · -- operational: outer header ⨾ inner descent
+    have hwindow0 : regionLongWindow regionBase bs 0 hO0 :=
+      regionLongWindow_of_split regionBase bs (.list outerItems) outerTail 0 hO0
+        hbs_head hdrop0 (by simpa [itemPayloadCount] using hsize_outer') hwin
+    have hvalid0 : isValidByteAccess (regionBase + BitVec.ofNat 64 0) = true := hwin 0 hO0
+    have outer := unified_list_header_descend base regionBase bs 0 hO0
+      v5Old v10 v11Old v12Old v14Old v15Old halign hover hvalid0 hwindow0
+    rw [show regionBase + BitVec.ofNat 64 0 = regionBase from by simp, hptr] at outer
+    have inner := (unified_list_descend_concrete_bridge_at (base + 148) regionBase innerItems bs
+      payloadOff (encode.encodeItems rest ++ outerTail)
+      ((bs[0]'hO0).zeroExtend 64) (itemResidue (bs[0]'hO0)) (itemLenRegion (bs[0]'hO0) bs 0)
+      (itemX12Region (bs[0]'hO0) bs 0 v12Old) (itemX14 (bs[0]'hO0) v14Old) v15Old
+      halign hover hwin hsize_inner hinner_ne hdrop_inner).1
+    -- normalize the inner program's `(base+148)+k` addresses to `base+(148+k)` form
+    rw [show base + 148 + 4 = base + 152 from by bv_omega,
+        show base + 148 + 148 = base + 296 from by bv_omega,
+        show base + 148 + 152 = base + 300 from by bv_omega,
+        show base + 148 + 156 = base + 304 from by bv_omega,
+        show base + 148 + 300 = base + 448 from by bv_omega,
+        show base + 148 + 308 = base + 456 from by bv_omega] at inner
+    -- disjointness: outer header code ⊥ inner descent code (non-overlapping ranges)
+    have dcr_none4 : ∀ (a : Word),
+        (∀ k, k < 36 → a ≠ (base + 4) + BitVec.ofNat 64 (4 * k)) →
+        CodeReq.ofProg (base + 4) unified_decoder_prog a = none :=
+      fun a h => CodeReq.ofProg_none_range_len (base + 4) unified_decoder_prog 36 a
+        unified_decoder_prog_length h
+    have dcr_none_i152 : ∀ (a : Word),
+        (∀ k, k < 36 → a ≠ (base + 152) + BitVec.ofNat 64 (4 * k)) →
+        CodeReq.ofProg (base + 152) unified_decoder_prog a = none :=
+      fun a h => CodeReq.ofProg_none_range_len (base + 152) unified_decoder_prog 36 a
+        unified_decoder_prog_length h
+    have dcr_none_i304 : ∀ (a : Word),
+        (∀ k, k < 36 → a ≠ (base + 304) + BitVec.ofNat 64 (4 * k)) →
+        CodeReq.ofProg (base + 304) unified_decoder_prog a = none :=
+      fun a h => CodeReq.ofProg_none_range_len (base + 304) unified_decoder_prog 36 a
+        unified_decoder_prog_length h
+    have hdisj :
+        ((CodeReq.singleton base (.LBU .x5 .x13 0)).union
+            (CodeReq.ofProg (base + 4) unified_decoder_prog)).Disjoint
+          ((((((CodeReq.singleton (base + 148) (.LBU .x5 .x13 0)).union
+                (CodeReq.ofProg (base + 152) unified_decoder_prog)).union
+                (CodeReq.singleton (base + 296) (.ADD .x15 .x13 .x11))).union
+                ((((CodeReq.singleton (base + 300) (.LBU .x5 .x13 0)).union
+                  (CodeReq.ofProg (base + 304) unified_decoder_prog)).union
+                  (CodeReq.singleton (base + 448) (.ADD .x13 .x13 .x11))).union
+                  ((CodeReq.singleton (base + 448 + 4) (.BNE .x13 .x15 (-152))).union
+                    CodeReq.empty))))) :=
+      CodeReq.Disjoint.union_left
+        -- LBU @ base  ⊥  inner CR
+        (CodeReq.Disjoint.union_right
+          (CodeReq.Disjoint.union_right
+            (CodeReq.Disjoint.union_right
+              (CodeReq.Disjoint.singleton (by bv_omega))
+              (CodeReq.Disjoint.singleton_ofProg (dcr_none_i152 base (by intro k hk; bv_omega))))
+            (CodeReq.Disjoint.singleton (by bv_omega)))
+          (CodeReq.Disjoint.union_right
+            (CodeReq.Disjoint.union_right
+              (CodeReq.Disjoint.union_right
+                (CodeReq.Disjoint.singleton (by bv_omega))
+                (CodeReq.Disjoint.singleton_ofProg (dcr_none_i304 base (by intro k hk; bv_omega))))
+              (CodeReq.Disjoint.singleton (by bv_omega)))
+            (CodeReq.Disjoint.union_right
+              (CodeReq.Disjoint.singleton (by bv_omega)) (CodeReq.Disjoint.empty_right _))))
+        -- ofProg (base+4)  ⊥  inner CR
+        (CodeReq.Disjoint.union_right
+          (CodeReq.Disjoint.union_right
+            (CodeReq.Disjoint.union_right
+              (CodeReq.Disjoint.ofProg_singleton (dcr_none4 (base + 148) (by intro k hk; bv_omega)))
+              (ofProg_disjoint_ofProg (base + 4) (base + 152) _ _ 36 36
+                unified_decoder_prog_length unified_decoder_prog_length
+                (by intro k1 hk1 k2 hk2; bv_omega)))
+            (CodeReq.Disjoint.ofProg_singleton (dcr_none4 (base + 296) (by intro k hk; bv_omega))))
+          (CodeReq.Disjoint.union_right
+            (CodeReq.Disjoint.union_right
+              (CodeReq.Disjoint.union_right
+                (CodeReq.Disjoint.ofProg_singleton (dcr_none4 (base + 300) (by intro k hk; bv_omega)))
+                (ofProg_disjoint_ofProg (base + 4) (base + 304) _ _ 36 36
+                  unified_decoder_prog_length unified_decoder_prog_length
+                  (by intro k1 hk1 k2 hk2; bv_omega)))
+              (CodeReq.Disjoint.ofProg_singleton (dcr_none4 (base + 448) (by intro k hk; bv_omega))))
+            (CodeReq.Disjoint.union_right
+              (CodeReq.Disjoint.ofProg_singleton (dcr_none4 (base + 448 + 4) (by intro k hk; bv_omega)))
+              (CodeReq.Disjoint.empty_right _))))
+    exact cpsTripleWithin_seq hdisj outer inner
+  · -- pure: the outer value round-trips with its trailer
+    exact decode_encode_append (.list outerItems) outerTail hsize_outer
+
+-- Depth-2 cross-check: the program at `base = 0x1000` decodes the nested list
+-- `[[0x01, 0x02], 0x03]` (`encode = [0xc4, 0xc2, 0x01, 0x02, 0x03]`) from `0x2000`,
+-- descending the outer `0xc4` header to its payload, then the inner `0xc2` sub-list
+-- → `[.bytes [1], .bytes [2]]`, in `123 + 63 * 2 = 249` steps.
+example :=
+  unified_list_descend_nested_bridge (0x1000 : Word) (0x2000 : Word)
+    [.bytes [(0x01 : Byte)], .bytes [(0x02 : Byte)]] [.bytes [(0x03 : Byte)]] []
+    0 0 0 0 0 0
+    (by decide) (by decide)
+    (by intro i hi
+        have hlen : (encode (.list [.list [.bytes [(0x01 : Byte)], .bytes [(0x02 : Byte)]],
+            .bytes [(0x03 : Byte)]]) ++ ([] : List Byte)).length = 5 := by decide
+        rw [hlen] at hi; interval_cases i <;> decide)
+    (by decide) (by decide) (by decide)
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -1552,10 +1552,23 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     descent wrapper needed it. `unified_list_descend_concrete_bridge` is now the `O = 0` corollary. This
     is the building block that makes **nested descent composable** (descend a sub-list at its parent's
     payload offset). Axiom-clean, 0 sorry, 0 warnings. Concrete `O = 2` example.
-  - **Next (step 6b — depth-2 composition):** a header-descend primitive (`LBU + decoder` → `x13 =`
-    payload pointer) + compose outer header (O=0) with the offset-general descent at `payloadOff_outer`
-    for `.list (.list innerItems :: rest)`, fully decoding the first sub-list — coinciding with the pure
-    nested `decode`. Then sibling-stride + leaf reads → concrete STF block/header/tx schema decoders.
+  - ✅ **Step 6b — depth-2 nested descent** (`UnifiedListDescendNested.lean`).
+    **`unified_list_header_descend`** (in `UnifiedListDescendConcrete.lean`): the reusable header-descend
+    primitive — `LBU + unified_decoder_prog` at offset `O` leaves `x13 = itemPtrRegion` (payload pointer),
+    `x11 = itemLenRegion` (payload length). **`unified_list_descend_nested_bridge`**: for an outer list
+    whose head is itself a list (`.list (.list innerItems :: rest)`) at the front of `bs = encode (.list
+    (.list innerItems :: rest)) ++ outerTail`, the program descends the outer header (offset 0) to its
+    payload pointer (offset `payloadOff`), then descends the inner `.list innerItems` there via
+    `unified_list_descend_concrete_bridge_at` — in `123 + 63 * innerItems.length` steps — coinciding with
+    the pure nested `decode`. Reading at an OFFSET into the single aligned region (never re-anchoring) is
+    what makes the two levels compose; the inner program's `(base+148)+k` addresses are normalized to
+    `base+N` so the `seq` unifies syntactically (avoids a variable-base `whnf` blowup). `crDisjoint`
+    across the two decoder copies via the now-public `ofProg_disjoint_ofProg`. Axiom-clean, 0 sorry,
+    0 warnings, no heartbeat override. Concrete `[[1,2],3]` example.
+  - **Next (sibling stride + schema decoders):** after descending item k, `itemNextPtrRegion` (the stride,
+    `encode_head_eq_itemNextPtrRegion`) positions at item k+1 — enabling sequential descent into a list's
+    items (block → header, txs, ommers). Then leaf-field reads + concrete STF header/tx schema decoders
+    producing the `BlockInput` the STF consumes.
 - Phase 6: Top-level pipeline (`read_input` -> decode -> `write_output`)
 - **Host I/O ABI**: See `docs/zkvm-host-io-interface.md`; SP1
   `HINT_LEN`/`HINT_READ`/`COMMIT` are legacy handler shapes, not the target


### PR DESCRIPTION
## Summary

A concrete RV64 program that **descends two levels** of nested RLP — the outer list header, then the first sub-list item (itself a `.list`) — fully decoding the inner list and coinciding with the pure nested `decode`. The recursive step toward the fixed-schema STF block/header/tx decoders.

- **`unified_list_header_descend`** — the reusable header-descend primitive: `LBU + unified_decoder_prog` at offset `O` leaves `x13 = itemPtrRegion` (payload pointer) and `x11 = itemLenRegion` (payload length). Used by every list level (incl. the STF schema decoders).
- **`unified_list_descend_nested_bridge`** — for an outer list whose head is a list (`.list (.list innerItems :: rest)`) at the front of `bs = encode (.list (.list innerItems :: rest)) ++ outerTail`: descends the outer header (offset 0) to its payload pointer (offset `payloadOff`), then descends the inner `.list innerItems` there via `unified_list_descend_concrete_bridge_at` — in `123 + 63 * innerItems.length` steps — coinciding with the pure nested `decode` (both the outer value and the inner sub-list).

> **Stacked on #9053** (offset-general descent), which is stacked on #9044. Based on `feat/rv64-rlp-nested-descend` so the diff shows only the depth-2 work; will retarget/rebase as the stack lands.

## Two notable mechanics

- **Composition by offset, not re-anchoring**: `bytesRegion` is dword-granular anchored at one aligned base, so the inner sub-list (at the generally-unaligned payload pointer) is decoded by reading at an *offset* into the same region — which is exactly what `unified_list_descend_concrete_bridge_at` (#9053) provides.
- **Address normalization**: the inner program's `(base+148)+k` addresses are `rw`-normalized to `base+N` before `cpsTripleWithin_seq`, so the composition unifies syntactically — avoiding a variable-base `whnf` blowup. Cross-decoder disjointness uses the now-public `ofProg_disjoint_ofProg`.

## Verification

- Full `EvmAsm` build — clean, **0 warnings**.
- `#print axioms unified_list_descend_nested_bridge` → `[propext, Classical.choice, Quot.sound]`; 0 sorry.
- `scripts/check-forbidden-tactics.sh` OK; **no `maxHeartbeats` override**.
- Concrete depth-2 example: `[[0x01, 0x02], 0x03]` (`encode = [0xc4, 0xc2, 0x01, 0x02, 0x03]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)