### PR TITLE
feat(rv64/rlp): regOwn-re-entry RLP list descent (Phase 5, step 7a)

### DIFF
--- a/EvmAsm/Rv64/RLP/UnifiedListDescendConcrete.lean
+++ b/EvmAsm/Rv64/RLP/UnifiedListDescendConcrete.lean
@@ -416,6 +416,70 @@ theorem unified_list_header_descend
         unified_decoder_prog_length (by intro k hk; bv_omega)))
     s_lbu s_dec
 
+set_option maxRecDepth 8000 in
+/-- **`regOwn`-re-entry descent (chainable).** The offset-general descent restated so
+    its PRE is itself a `unified_lenloop_post` (at `O`) and its POST is the next
+    `unified_lenloop_post` (at `O + (encode (.list items)).length`). A descent's post
+    already abstracts the scratch registers to `regOwn` and leaves `x13`/`x15` at the
+    next sibling, so this lets one descent feed DIRECTLY into the next (sequential
+    sibling descent) with a syntactic `unified_lenloop_post` match. Derived from
+    `…_bridge_at` by consuming the 5 owned scratch registers (`x5,x10,x11,x12,x14`)
+    via `cpsTripleWithin_of_forall_regIs_to_regOwn`. -/
+theorem unified_list_descend_concrete_bridge_at_regOwn
+    (base regionBase : Word) (items : List RLPItem) (bs : List Byte) (O : Nat) (tail : List Byte)
+    (halign : regionBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hsize : (encode (.list items)).length < 256 ^ 8)
+    (hitems_ne : items ≠ [])
+    (hdrop : bs.drop O = encode (.list items) ++ tail) :
+    cpsTripleWithin (62 + 63 * items.length) base (base + 308)
+      ((((((CodeReq.singleton base (.LBU .x5 .x13 0)).union
+            (CodeReq.ofProg (base + 4) unified_decoder_prog)).union
+            (CodeReq.singleton (base + 148) (.ADD .x15 .x13 .x11))).union
+            ((((CodeReq.singleton (base + 152) (.LBU .x5 .x13 0)).union
+              (CodeReq.ofProg (base + 156) unified_decoder_prog)).union
+              (CodeReq.singleton (base + 300) (.ADD .x13 .x13 .x11))).union
+              ((CodeReq.singleton (base + 300 + 4) (.BNE .x13 .x15 (-152))).union CodeReq.empty)))))
+      (unified_lenloop_post regionBase bs (regionBase + BitVec.ofNat 64 O))
+      (unified_lenloop_post regionBase bs
+        (regionBase + BitVec.ofNat 64 (O + (encode (.list items)).length))) := by
+  rw [unified_lenloop_post_unfold]
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x5)
+      (P := (.x0 ↦ᵣ (0:Word)) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+        (.x15 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** bytesRegion regionBase bs **
+        regOwn .x10 ** regOwn .x11 ** regOwn .x12 ** regOwn .x14)
+      (fun v5 => ?_))
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x10)
+      (P := (.x0 ↦ᵣ (0:Word)) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+        (.x15 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** bytesRegion regionBase bs **
+        (.x5 ↦ᵣ v5) ** regOwn .x11 ** regOwn .x12 ** regOwn .x14)
+      (fun v10 => ?_))
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x11)
+      (P := (.x0 ↦ᵣ (0:Word)) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+        (.x15 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** bytesRegion regionBase bs **
+        (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** regOwn .x12 ** regOwn .x14)
+      (fun v11 => ?_))
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x12)
+      (P := (.x0 ↦ᵣ (0:Word)) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+        (.x15 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** bytesRegion regionBase bs **
+        (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** regOwn .x14)
+      (fun v12 => ?_))
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x14)
+      (P := (.x0 ↦ᵣ (0:Word)) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+        (.x15 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** bytesRegion regionBase bs **
+        (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12))
+      (fun v14 => ?_))
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+    (unified_list_descend_concrete_bridge_at base regionBase items bs O tail
+      v5 v10 v11 v12 v14 (regionBase + BitVec.ofNat 64 O)
+      halign hover hwin hsize hitems_ne hdrop).1
+
 -- Top-level cross-check (`tail = []`): the program at `base = 0x1000` decodes the
 -- complete list value `[0x01, 0x02]` (`encode = [0xc2, 0x01, 0x02]`) from the region
 -- at `0x2000`, descending the `0xc2` header into its 2-byte payload, in

--- a/PLAN.md
+++ b/PLAN.md
@@ -1565,10 +1565,22 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     `base+N` so the `seq` unifies syntactically (avoids a variable-base `whnf` blowup). `crDisjoint`
     across the two decoder copies via the now-public `ofProg_disjoint_ofProg`. Axiom-clean, 0 sorry,
     0 warnings, no heartbeat override. Concrete `[[1,2],3]` example.
-  - **Next (sibling stride + schema decoders):** after descending item k, `itemNextPtrRegion` (the stride,
-    `encode_head_eq_itemNextPtrRegion`) positions at item k+1 — enabling sequential descent into a list's
-    items (block → header, txs, ommers). Then leaf-field reads + concrete STF header/tx schema decoders
-    producing the `BlockInput` the STF consumes.
+  - ✅ **Step 7a — `regOwn`-re-entry descent** (`UnifiedListDescendConcrete.lean`).
+    **`unified_list_descend_concrete_bridge_at_regOwn`**: the offset-general descent restated so its PRE is
+    itself a `unified_lenloop_post` (at `O`) and its POST the next `unified_lenloop_post` (at `O + (encode
+    (.list items)).length`). Since a descent's post abstracts the scratch registers to `regOwn` and leaves
+    `x13`/`x15` at the next sibling, this lets one descent feed DIRECTLY into the next with a syntactic
+    `unified_lenloop_post` match — the chainable building block for sequential sibling descent. Derived
+    from `…_bridge_at` by consuming the 5 owned scratch registers (`x5,x10,x11,x12,x14`) via
+    `cpsTripleWithin_of_forall_regIs_to_regOwn` (the Evm64 SDiv/SMod idiom) — each peel pinned with explicit
+    `(r := …) (P := …)` so `xperm_hyp` resolves the interspersed-register reshape; `rw
+    [unified_lenloop_post_unfold]` unfolds only the pre (post keeps a distinct `endPtr`). Axiom-clean,
+    0 sorry, 0 warnings, no heartbeat override.
+  - **Next (step 7b — two-sibling descent):** compose `…_bridge_at` (item 0) ⨾ `…_at_regOwn` (item 1 at the
+    stride offset `O + (encode (.list A)).length`) for `bs.drop O = encode (.list A) ++ encode (.list B) ++
+    tail` — both intermediate states are `unified_lenloop_post`, so the `seq` matches syntactically. Then
+    N-sibling unrolled walk (block = 3 sub-lists) + leaf-field reads → concrete STF header/tx schema
+    decoders producing the `BlockInput` the STF consumes.
 - Phase 6: Top-level pipeline (`read_input` -> decode -> `write_output`)
 - **Host I/O ABI**: See `docs/zkvm-host-io-interface.md`; SP1
   `HINT_LEN`/`HINT_READ`/`COMMIT` are legacy handler shapes, not the target


### PR DESCRIPTION
## Summary

Adds **`unified_list_descend_concrete_bridge_at_regOwn`** — the **chainable** RLP list descent, the building block for sequential sibling descent (and thus the fixed-schema STF block decoder: descend `[header, txs, ommers]` in turn).

It restates the offset-general descent (#9053) so its **pre is itself a `unified_lenloop_post`** (at offset `O`) and its **post the next `unified_lenloop_post`** (at `O + (encode (.list items)).length`). Because a descent's post already abstracts the scratch registers to `regOwn` and leaves `x13`/`x15` at the *next sibling*, this variant lets one descent feed **directly** into the next with a syntactic `unified_lenloop_post` match — no re-specialization at the call site.

(Branches cleanly off `main` now that #9044/#9053/#9054 have landed.)

## How it's proved

Derived from `unified_list_descend_concrete_bridge_at` by consuming the 5 owned scratch registers (`x5,x10,x11,x12,x14`) via `cpsTripleWithin_of_forall_regIs_to_regOwn` — the established Evm64 SDiv/SMod idiom. Two details that made it go through:
- Each peel is pinned with explicit `(r := …) (P := …)` so `xperm_hyp` can resolve the reshape (the registers are *interspersed* with `x0↦0`, `x13↦ptr`, `bytesRegion`, so the rightmost-peel rule needs an explicit permutation target).
- `rw [unified_lenloop_post_unfold]` unfolds **only the pre** — the post carries a distinct `endPtr`, so it stays folded and matches `…_bridge_at`'s post.

## Why (sequential sibling descent)

The forward direction is the only one that works: a `regOwn` post **cannot** entail a specific `↦ᵣ` pre (`seq_perm` is the wrong way), so chaining descents genuinely requires a `regOwn`-pre variant. With both intermediate states now `unified_lenloop_post`, the upcoming two-sibling `seq` is a syntactic match.

## Verification

- Full `EvmAsm` build — clean, **0 warnings**.
- `#print axioms unified_list_descend_concrete_bridge_at_regOwn` → `[propext, Classical.choice, Quot.sound]`; 0 sorry.
- `scripts/check-forbidden-tactics.sh` OK; **no `maxHeartbeats` override**.

Follow-up (step 7b): the two-sibling descent composing `…_bridge_at` ⨾ `…_at_regOwn`, then N-sibling walks → concrete header/tx schema decoders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)