### PR TITLE
feat(rv64/rlp): leaf-field scalar value read (Phase 5, step 8)

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -73,6 +73,7 @@ import EvmAsm.Rv64.RLP.UnifiedListLoopConcrete
 import EvmAsm.Rv64.RLP.UnifiedListDescendConcrete
 import EvmAsm.Rv64.RLP.UnifiedListDescendNested
 import EvmAsm.Rv64.RLP.UnifiedListDescendSiblings
+import EvmAsm.Rv64.RLP.UnifiedFieldScalarRead
 import EvmAsm.Rv64.RLP.NestedDescendOne
 import EvmAsm.Rv64.RLP.UnifiedDecodeItem
 import EvmAsm.Rv64.RLP.UnifiedDecodeItemReconverge

--- a/EvmAsm/Rv64/RLP/UnifiedFieldScalarRead.lean
+++ b/EvmAsm/Rv64/RLP/UnifiedFieldScalarRead.lean
@@ -1,0 +1,113 @@
+/-
+  EvmAsm.Rv64.RLP.UnifiedFieldScalarRead
+
+  EL.3 / Phase 5 — leaf-field SCALAR VALUE read. Given a decoded RLP `.bytes`
+  field's payload pointer (`x13`) and length (`x11`) — the register convention the
+  single-item decoder leaves behind — this reads the `n` payload bytes big-endian
+  and computes `x11 = Nat.fromBytesBE (payload)`, advancing `x13` to the next field.
+  The missing value-extraction step for the fixed-schema STF header/tx decoders.
+
+  Reuses the Phase-2 big-endian region loop (`rlp_phase2_long_loop_region_n_spec_within`);
+  the only new code is a 2-instruction impedance-match glue (move the length from
+  `x11` to the loop's count register `x14`, and zero the accumulator `x11`).
+
+  Layout (program base `base`; aligned `regionBase`, buffer `bs`, payload offset `off`):
+      base       ADDI x14, x11, 0     ; x14 := payload length (count)
+      base+4     ADDI x11, x0, 0      ; x11 := 0 (BE accumulator)
+      base+8     < 6-instr BE loop, n iterations >   (base+8 .. base+32)
+      base+32    (exit)
+-/
+
+import EvmAsm.Rv64.RLP.Phase2LongLoopRegion
+import EvmAsm.Rv64.Tactics.SeqFrame
+import EvmAsm.Rv64.Tactics.XPermPure
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL.RLP
+open EvmAsm.Rv64.Tactics
+
+/-- **Leaf-field scalar value read.** From the single-item decoder's output
+    convention — `x13 = regionBase + ofNat off` (payload pointer), `x11 = ofNat n`
+    (payload length, `1 ≤ n ≤ 8`) — the program reads the `n` payload bytes
+    big-endian into `x11 = Nat.fromBytesBE ((bs.drop off).take n)` (the field's
+    scalar value) and advances `x13` to `off + n` (the next field). -/
+theorem unified_field_scalar_read
+    (base regionBase : Word) (bs : List Byte) (off n : Nat) (v12Old v14Old : Word)
+    (hn1 : 1 ≤ n) (hn8 : n ≤ 8)
+    (halign : regionBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < n →
+        off + i < bs.length
+        ∧ isValidByteAccess (regionBase + BitVec.ofNat 64 (off + i)) = true) :
+    cpsTripleWithin (2 + 6 * n) base (base + 32)
+      (((CodeReq.singleton base (.ADDI .x14 .x11 0)).union
+          (CodeReq.singleton (base + 4) (.ADDI .x11 .x0 0))).union
+          (CodeReq.ofProg (base + 8) (rlp_phase2_long_loop_body_prog (-20))))
+      ((.x11 ↦ᵣ BitVec.ofNat 64 n) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 off)) **
+       (.x14 ↦ᵣ v14Old) ** (.x12 ↦ᵣ v12Old) ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs)
+      ((.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE ((bs.drop off).take n))) **
+       (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 (off + n))) ** (.x14 ↦ᵣ (0 : Word)) **
+       (.x12 ↦ᵣ (bs.getD (off + (n - 1)) 0).zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+       bytesRegion regionBase bs) := by
+  -- s_mv : ADDI x14, x11, 0  — copy the length into the loop's count register
+  have mv_raw := addi_spec_gen_within .x14 .x11 v14Old (BitVec.ofNat 64 n) 0 base (by decide)
+  rw [show (BitVec.ofNat 64 n) + signExtend12 (0 : BitVec 12) = BitVec.ofNat 64 n from by
+        rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]; bv_omega] at mv_raw
+  have s_mv : cpsTripleWithin 1 base (base + 4)
+      (CodeReq.singleton base (.ADDI .x14 .x11 0))
+      ((.x11 ↦ᵣ BitVec.ofNat 64 n) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 off)) **
+       (.x14 ↦ᵣ v14Old) ** (.x12 ↦ᵣ v12Old) ** (.x0 ↦ᵣ (0:Word)) ** bytesRegion regionBase bs)
+      ((.x11 ↦ᵣ BitVec.ofNat 64 n) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 off)) **
+       (.x14 ↦ᵣ BitVec.ofNat 64 n) ** (.x12 ↦ᵣ v12Old) ** (.x0 ↦ᵣ (0:Word)) ** bytesRegion regionBase bs) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp)
+      (cpsTripleWithin_frameR
+        ((.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 off)) ** (.x12 ↦ᵣ v12Old) **
+         (.x0 ↦ᵣ (0:Word)) ** bytesRegion regionBase bs)
+        (by pcFree) mv_raw)
+  -- s_li : ADDI x11, x0, 0  — zero the big-endian accumulator
+  have li_raw := addi_x0_spec_gen_within .x11 (BitVec.ofNat 64 n) 0 (base + 4) (by decide)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide] at li_raw
+  have s_li : cpsTripleWithin 1 (base + 4) (base + 4 + 4)
+      (CodeReq.singleton (base + 4) (.ADDI .x11 .x0 0))
+      ((.x11 ↦ᵣ BitVec.ofNat 64 n) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 off)) **
+       (.x14 ↦ᵣ BitVec.ofNat 64 n) ** (.x12 ↦ᵣ v12Old) ** (.x0 ↦ᵣ (0:Word)) ** bytesRegion regionBase bs)
+      ((.x11 ↦ᵣ (0:Word)) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 off)) **
+       (.x14 ↦ᵣ BitVec.ofNat 64 n) ** (.x12 ↦ᵣ v12Old) ** (.x0 ↦ᵣ (0:Word)) ** bytesRegion regionBase bs) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp)
+      (cpsTripleWithin_frameR
+        ((.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 off)) ** (.x14 ↦ᵣ BitVec.ofNat 64 n) **
+         (.x12 ↦ᵣ v12Old) ** bytesRegion regionBase bs)
+        (by pcFree) li_raw)
+  rw [show base + 4 + 4 = base + 8 from by bv_omega] at s_li
+  have t_glue := cpsTripleWithin_seq (CodeReq.Disjoint.singleton (by bv_omega)) s_mv s_li
+  -- t_loop : the big-endian read loop
+  have hback : (base + 8 + 20) + signExtend13 (-20 : BitVec 13) = base + 8 := by
+    rw [show signExtend13 (-20 : BitVec 13) = (-20 : Word) from by decide]; bv_omega
+  have t_loop := rlp_phase2_long_loop_region_n_spec_within n hn1 hn8 regionBase v12Old off bs
+    (base + 8) (-20) halign hover hwin hback
+  have hd : (((CodeReq.singleton base (.ADDI .x14 .x11 0)).union
+        (CodeReq.singleton (base + 4) (.ADDI .x11 .x0 0)))).Disjoint
+      (CodeReq.ofProg (base + 8) (rlp_phase2_long_loop_body_prog (-20))) :=
+    CodeReq.Disjoint.union_left
+      (CodeReq.Disjoint.singleton_ofProg
+        (CodeReq.ofProg_none_range_len (base + 8) (rlp_phase2_long_loop_body_prog (-20)) 6 base
+          (by rfl) (by intro k hk; bv_omega)))
+      (CodeReq.Disjoint.singleton_ofProg
+        (CodeReq.ofProg_none_range_len (base + 8) (rlp_phase2_long_loop_body_prog (-20)) 6 (base + 4)
+          (by rfl) (by intro k hk; bv_omega)))
+  have composed := cpsTripleWithin_seq hd t_glue t_loop
+  rw [show base + 8 + 24 = base + 32 from by bv_omega,
+      show (1 + 1) + 6 * n = 2 + 6 * n from by ring] at composed
+  exact composed
+
+-- Concrete cross-check: read the 3-byte scalar `[0x01, 0x02, 0x03]` at offset 0 of
+-- the buffer `[0x01, 0x02, 0x03]` from `0x2000` ⇒ `x11 = 0x010203 = fromBytesBE [1,2,3]`.
+example :=
+  unified_field_scalar_read (0x1000 : Word) (0x2000 : Word)
+    [(0x01 : Byte), (0x02 : Byte), (0x03 : Byte)] 0 3 0 0
+    (by decide) (by decide) (by decide) (by decide)
+    (by intro i hi; interval_cases i <;> exact ⟨by decide, by decide⟩)
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -1588,10 +1588,24 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     range argument (à la `ofProg_disjoint_ofProg`) instead of a 7×7 `Disjoint.*` cascade; reused by the
     N-sibling walk. Axiom-clean, 0 sorry, 0 warnings, no heartbeat override. Concrete `[0xc1,0x01,0xc1,0x02]`
     example.
-  - **Next (N-sibling walk → schema decoders):** repeat `…_at_regOwn` + `descend_cr_disjoint` for the
-    block's 3 fixed sub-lists `[header, txs, ommers]`. Then leaf-field reads (extract a flat field's
-    bytes/scalar at its payload pointer) → concrete STF header (~19 fields) / transaction (9 fields)
-    decoders producing the `BlockInput` the STF consumes.
+  - ✅ **Step 8 — leaf-field scalar value read** (`UnifiedFieldScalarRead.lean`).
+    **`unified_field_scalar_read`**: from the single-item decoder's output convention — `x13 = regionBase +
+    ofNat off` (payload pointer), `x11 = ofNat n` (payload length, `1 ≤ n ≤ 8`) — reads the `n` payload
+    bytes big-endian into `x11 = Nat.fromBytesBE ((bs.drop off).take n)` (the field's scalar value) and
+    advances `x13` to `off + n` (the next field), in `2 + 6*n` steps. The first **value-extraction** step
+    (prior steps gave only framing/pointers). Reuses the Phase-2 region BE loop
+    (`rlp_phase2_long_loop_region_n_spec_within`); the only new code is a 2-instruction impedance glue
+    (`ADDI x14 x11 0` to move the length into the loop's count register, `ADDI x11 x0 0` to zero the
+    accumulator). Axiom-clean, 0 sorry, 0 warnings, no heartbeat override. Concrete `[0x01,0x02,0x03] →
+    0x010203` example.
+  - **Next (full scalar field decode → field walk → schema decoders):** compose `unified_decoder_spec` ⨾
+    `unified_field_scalar_read`, coinciding with the pure `decodeScalar (bs.drop O) = some (Nat.fromBytesBE
+    data, rest)` (needs a small `.bytes`-payload-window lemma). Then a per-field walk (decode + value-read +
+    stride) over a fixed schema → concrete STF transaction (9 fields) / header (~19 fields) decoders
+    producing the `BlockInput`. Wide scalars (uint256) / byte-arrays (20/32-byte address/hash) / zero-length
+    scalars (`n = 0`) need multi-word / byte-copy / branch variants. (The 3-sibling sub-list walk — block's
+    `[header, txs, ommers]` framing via repeated `…_at_regOwn` + `descend_cr_disjoint` — is trivial glue,
+    deferred until the schema decoders need it.)
 - Phase 6: Top-level pipeline (`read_input` -> decode -> `write_output`)
 - **Host I/O ABI**: See `docs/zkvm-host-io-interface.md`; SP1
   `HINT_LEN`/`HINT_READ`/`COMMIT` are legacy handler shapes, not the target


### PR DESCRIPTION
## Summary

Adds **`unified_field_scalar_read`** — the first **value-extraction** step in the RLP decoder (every prior step produced only *framing*: pointers and lengths).

From the single-item decoder's output convention — `x13 = regionBase + ofNat off` (payload pointer), `x11 = ofNat n` (payload length, `1 ≤ n ≤ 8`) — it reads the `n` payload bytes **big-endian** into `x11 = Nat.fromBytesBE ((bs.drop off).take n)` (the field's scalar value) and advances `x13` to `off + n` (the next field), in `2 + 6·n` steps. This is the core of the per-field walk the fixed-schema STF header/transaction decoders need.

(Branches cleanly off `main` — the #9044→#9056 stack has all landed.)

## How it works

Reuses the Phase-2 region big-endian loop (`rlp_phase2_long_loop_region_n_spec_within`) wholesale. The only new code is a **2-instruction impedance-match glue**, because the decoder leaves the length in `x11` but the loop wants the count in `x14` and a zeroed accumulator:

```
ADDI x14, x11, 0    ; x14 := payload length (loop count)
ADDI x11, x0, 0     ; x11 := 0 (BE accumulator)
< 6-instr BE loop, n iterations >
```

Composed via `cpsTripleWithin_seq`; the glue ⊥ loop disjointness is two `singleton_ofProg` (`ofProg_none_range_len`) facts.

## Verification

- Full `EvmAsm` build — clean, **0 warnings**.
- `#print axioms unified_field_scalar_read` → `[propext, Classical.choice, Quot.sound]`; 0 sorry.
- `scripts/check-forbidden-tactics.sh` OK; **no `maxHeartbeats` override**.
- Concrete example: read `[0x01, 0x02, 0x03]` → `x11 = 0x010203`.

## Follow-ups
- **Full scalar field decode**: `unified_decoder_spec` ⨾ this read, coinciding with the pure `decodeScalar` (needs a small `.bytes`-payload-window lemma).
- **Field walk → schema decoders**: per-field (decode + value-read + stride) over a fixed schema → STF transaction (9 fields) / header (~19 fields) decoders. Wide scalars (uint256), byte-arrays (address/hash), and zero-length scalars need multi-word / byte-copy / branch variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)