### PR TITLE
fix(codegen): convert KECCAK256 result to LE-limb stack order

### DIFF
--- a/EvmAsm/Codegen/Programs/EvmHashHandlers.lean
+++ b/EvmAsm/Codegen/Programs/EvmHashHandlers.lean
@@ -58,6 +58,26 @@ def hashHandlers : List OpcodeHandlerSpec :=
         "  jal x1, zkvm_keccak256\n" ++ -- call keccak (clobbers x1, a0, a1, a2)
         "  mv x10, s10\n" ++            -- restore EVM code ptr
         "  mv x12, s11\n" ++            -- restore EVM stack ptr
+        -- zkvm_keccak256 writes a 32-byte BIG-ENDIAN digest (hash[0] = MSB).
+        -- The EVM stack word is little-endian-limb (low limb first), like every
+        -- PUSH/arith result, so byte-reverse the digest in place to match. Without
+        -- this, KECCAK256 results were BE on the stack while everything else was
+        -- LE-limb, so any keccak-then-SSTORE logged a byte-reversed value and the
+        -- exec-vs-BAL storage comparator (which reverses the BE BAL value to LE-limb)
+        -- always mismatched -> bv_fail=34 for every keccak-then-SSTORE contract
+        -- (e.g. precompile call_types storing keccak(returndata)). coc3g.5.
+        "  addi t0, x12, 0\n" ++
+        "  addi t1, x12, 31\n" ++
+        "1:\n" ++
+        "  bgeu t0, t1, 2f\n" ++
+        "  lbu t2, 0(t0)\n" ++
+        "  lbu t3, 0(t1)\n" ++
+        "  sb t3, 0(t0)\n" ++
+        "  sb t2, 0(t1)\n" ++
+        "  addi t0, t0, 1\n" ++
+        "  addi t1, t1, -1\n" ++
+        "  j 1b\n" ++
+        "2:\n" ++
         "  addi x10, x10, 1\n" ++       -- advance PC by 1
         "  j .dispatch_loop") } ]
 


### PR DESCRIPTION
## Problem

`h_KECCAK256` left `zkvm_keccak256`'s **big-endian** 32-byte digest on the EVM stack, but every other stack word (PUSH, arithmetic, slot keys) is stored **little-endian-limb** (low limb first). So a keccak result was byte-reversed relative to the rest of the stack.

The visible symptom: any **keccak-then-SSTORE** logged a byte-reversed value into the persistent storage exec log, and the exec-vs-BAL storage comparator (`bal_storage_matches_exec_log`, which byte-reverses the big-endian BAL post-value to LE-limb) always mismatched → `bv_fail=34` for every keccak-then-SSTORE contract. This includes:
- precompile `call_types` contracts that store `keccak(returndata)` (the dtrc-flip frontier, evm-asm-coc3g.5)
- keccak-as-mapping-key contracts (the slot key is keccak-derived)

Proof the stack is LE-limb: in a single exec-log entry, `slotKey=2` was stored LE-limb (`02 00 00 …`) while the keccak `current` field held the digest's high bytes first (big-endian).

## Fix

Byte-reverse the 32-byte digest in place after `zkvm_keccak256` so it matches the LE-limb stack convention. (`zkvm_keccak256`'s BE output is unchanged — the guest's own keccak callers consume it directly; only the EVM opcode handler needed to convert to stack order.) Numeric local labels keep the reversal correct across the 3 `EvmRegistry` dispatch-table variants.

A test could only have *passed* with the old BE behavior if its keccak digest were byte-reversal-invariant (a palindrome) — i.e. never — so this can only convert false-rejects to passes.

## Validation

- **BLS12-381 g1add family: 48/91 → 91/91 full-match, 0 fail** (the `call_types` cases flipped; the previously-passing cases still pass).
- BLS g1add `call_types` and P256 wycheproof `call_types`: `bv_fail=34 → PASS`.
- The direct `precompile-as-tx-entry-point` path (no keccak SSTORE) is unaffected and still passes.

Expected to flip a large slice of the dominant `bv_fail=34` class across all precompile `call_types` families (BLS×6, BN254×3, P256, ecrecover, sha256) plus keccak-mapping contracts. A full-corpus sweep at review is recommended to quantify the total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)