### PR TITLE
fix(verdict): close bv_fail=44 false-rejects on frontier/scenarios (system-contract skip + value-CALL live-balance/nonce)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -1206,7 +1206,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   -- i3djw.3: skip-list for the all-accounts non-storage comparator (3 x 32B-strided
   -- {recipient, sender, coinbase} addresses, gas/value-coupled, pinned on the gas path).
   ".balign 8\n" ++
-  "i3djw_skip_list:\n  .zero 96\n" ++
+  "i3djw_skip_list:\n  .zero 256\n" ++   -- coc3g.6.5: 3 {recipient,sender,coinbase} + 5 genesis system contracts (8*32)
   -- bmvmx.5.5.1 (umbrella-A1): MULTI-TX skip-list for the all-accounts exec-vs-BAL
   -- comparators. A multi-tx block's gas/value-coupled accounts are {sender_i,
   -- recipient_i} for every tx i plus the shared {coinbase} -> up to 2N+1 entries

--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -957,6 +957,16 @@ def blockVerdictFunction : String :=
   "  la a1, i3djw_skip_list; addi a1, a1, 32\n  la a0, bv_public_keys_ptr; ld a0, 0(a0); addi a0, a0, 1\n  jal ra, address_from_pubkey\n" ++
   "  la t0, i3djw_skip_list; addi t0, t0, 64\n  la t1, bmvmx_coinbase_addr\n  li t2, 20\n" ++
   ".Lbv_i3sk2:\n  beqz t2, .Lbv_i3sk2d\n  lbu t3, 0(t1)\n  sb t3, 0(t0)\n  addi t1, t1, 1\n  addi t0, t0, 1\n  addi t2, t2, -1\n  j .Lbv_i3sk2\n.Lbv_i3sk2d:\n" ++
+  -- coc3g.6.5: entries 3..7 = the 5 genesis system/predeploy contracts (EIP-2935 history,
+  -- EIP-4788 beacon-roots, EIP-7002 withdrawal-req, EIP-7251 consolidation-req, EIP-6110 deposit).
+  -- Their code/balance/nonce changes come from the block-level system-call replay / genesis setup
+  -- (validated by the verdict's explicit system replay + the state-root recompute), NOT the per-tx
+  -- exec log, so the exec-vs-BAL non-storage check must skip them. bbcv_sys_2935 starts 5 contiguous
+  -- 20-byte BE address constants. Mirrors bal_all_accounts_storage_consistent's modeled-system skip.
+  "  la t0, i3djw_skip_list; addi t0, t0, 96\n  la t1, bbcv_sys_2935\n  li t4, 5\n" ++
+  ".Lbv_i3sksys_o:\n  li t2, 20\n" ++
+  ".Lbv_i3sksys_i:\n  lbu t3, 0(t1)\n  sb t3, 0(t0)\n  addi t1, t1, 1\n  addi t0, t0, 1\n  addi t2, t2, -1\n  bnez t2, .Lbv_i3sksys_i\n" ++
+  "  addi t0, t0, 12\n  addi t4, t4, -1\n  bnez t4, .Lbv_i3sksys_o\n" ++
   -- bmvmx.5.5.7.3: aggregate the raw non-storage effect log per account (first-pre / last-post)
   -- via the linear helper BEFORE the all-accounts comparators. The comparator's find-loop takes
   -- the FIRST matching effect record, so passing the RAW log compared the BAL's block-FINAL
@@ -970,7 +980,7 @@ def blockVerdictFunction : String :=
   "  la t0, bv_bal_start; ld a0, 0(t0); la t0, bv_bal_len; ld a1, 0(t0)\n" ++
   "  la a2, exec_nonstorage_effect_agg\n" ++
   "  la t0, exec_nonstorage_effect_agg_count; ld a3, 0(t0)\n" ++
-  "  la a4, i3djw_skip_list; li a5, 3\n" ++
+  "  la a4, i3djw_skip_list; li a5, 8\n" ++
   "  jal ra, bal_all_accounts_nonstorage_consistent\n" ++
   "  bnez a0, .Lbv_bal_nonstorage_fail\n" ++
   -- i3djw.3 (REVERSE covers): every exec NON-STORAGE net-change effect must be PRESENT in
@@ -982,7 +992,7 @@ def blockVerdictFunction : String :=
   "  la t0, bv_bal_start; ld a0, 0(t0); la t0, bv_bal_len; ld a1, 0(t0)\n" ++
   "  la a2, exec_nonstorage_effect_agg\n" ++   -- bmvmx.5.5.7.3: same aggregated (sorted, last-post) agg as the forward
   "  la t0, exec_nonstorage_effect_agg_count; ld a3, 0(t0)\n" ++
-  "  la a4, i3djw_skip_list; li a5, 3\n" ++
+  "  la a4, i3djw_skip_list; li a5, 8\n" ++
   "  jal ra, bal_all_accounts_nonstorage_covers\n" ++
   "  bnez a0, .Lbv_bal_nonstorage_covers_fail\n" ++
   -- i3djw.4: all-accounts CODE exec-vs-BAL (FORWARD). Every BAL account that declares a code

--- a/EvmAsm/Codegen/Programs/CallFrameDescend.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameDescend.lean
@@ -346,6 +346,35 @@ def callFrameDescendFunction : String :=
   ".Lcfd_sb_next:\n" ++
   "  addi t1, t1, 64; addi t0, t0, -1; j .Lcfd_sb_scan\n" ++
   ".Lcfd_sb_done:\n" ++
+  -- coc3g.6.4: LIVE-BALANCE overlay. The pre-state staging above (callee_balance_table) gives the
+  -- child its PRE-BLOCK balance. But a callee that already RECEIVED value earlier in this tx (its
+  -- balance was credited by an earlier value-CALL) must descend with the LIVE balance, else its own
+  -- later value-CALL debits from the stale pre-state -> the recorded final balance is short and the
+  -- exec-vs-BAL non-storage comparator false-rejects (bv_fail=44; frontier/scenarios MCOPY b12:
+  -- dd36afb2 receives +1 then sends 3, true 107+1-3=105, but pre-state-debit gave 107-3=104).
+  -- The authoritative live balance = the most-recent recorded post_balance in the non-storage effect
+  -- log (record_nonstorage_effect captures EVERY value-flow credit/debit), so overlay env+32 with
+  -- nonstorage_effect_latest_balance(child_addr) when present; miss -> keep the pre-state staging.
+  -- The effect log post_balance is 32B BE; env+32 is LE-limb (h_SELFBALANCE copies env+32 verbatim),
+  -- so reverse BE -> LE. Scratch: env+696 (32B addr key: 20B BE + 12B zero) and env+728 (32B BE out);
+  -- the env is frameEnvBytes=768 and its fields end at 688, so +696..+759 is free. a0/a1 are leaf-clobbered
+  -- but s-regs (s3/s7/s8/s9/s10/s11) are preserved; ra saved across the helper.
+  "  sd zero, 696(s9); sd zero, 704(s9); sd zero, 712(s9); sd zero, 720(s9)\n" ++   -- zero the 32B addr key (env+696..+727; all 8-aligned)
+  "  sd zero, 728(s9); sd zero, 736(s9); sd zero, 744(s9); sd zero, 752(s9)\n" ++   -- zero the 32B out buffer (env+728..+759)
+  "  addi t0, s9, 696; addi t1, s9, 19; li t2, 20\n" ++   -- write 20B BE addr into the key (low 20 bytes)
+  ".Lcfd_lbov_rev:\n" ++
+  "  lbu t3, 0(t1); sb t3, 0(t0); addi t1, t1, -1; addi t0, t0, 1; addi t2, t2, -1; bnez t2, .Lcfd_lbov_rev\n" ++
+  "  addi sp, sp, -8; sd ra, 0(sp)\n" ++
+  "  addi a0, s9, 696; addi a1, s9, 728\n" ++
+  "  jal ra, nonstorage_effect_latest_balance\n" ++
+  "  mv t6, a0\n" ++                              -- 1 = found
+  "  ld ra, 0(sp); addi sp, sp, 8\n" ++
+  "  beqz t6, .Lcfd_lbov_done\n" ++
+  -- reverse the 32B BE post_balance (env+728) -> env+32 (LE).
+  "  addi t0, s9, 728; addi t1, s9, 63; li t2, 32\n" ++
+  ".Lcfd_lbov_wb:\n" ++
+  "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, 1; addi t1, t1, -1; addi t2, t2, -1; bnez t2, .Lcfd_lbov_wb\n" ++
+  ".Lcfd_lbov_done:\n" ++
   -- nxio8.4.1: snapshot the parent's pre-child EIP-8037 state gas (the global
   -- evm_state_gas_left = state_gas_left reservoir, evm_state_gas_used = state_gas_used) into the
   -- child env so a child REVERT / exceptional halt can restore it in frame_return,

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -320,15 +320,34 @@ def callDescendFallThrough
       -- committing path here (value!=0, ctx present, not self-call, no underflow), so the debit really
       -- happened. pre = post + value (cd_caller_newbal + cd_value_be -> nse_post_bal); post = cd_caller_newbal.
       -- The caller is a CONTRACT (the gas/value-coupled sender/recipient/coinbase are SKIPPED by the
-      -- all-accounts wrapper) doing a CALL, so its nonce is UNCHANGED -> the BAL declares no nonce change
-      -- (has_nonce=0) and the comparator skips the nonce forward-check, so pre_nonce=post_nonce=0 is safe.
+      -- all-accounts wrapper) doing a CALL, so its nonce is UNCHANGED. The record must carry the caller's
+      -- ACTUAL nonce, NOT 0: when this same account is ALSO a value-CALL CALLEE (credit record, which
+      -- records its real nonce from account_at_header_state_root), the aggregate keeps first-pre / LAST-post
+      -- nonce. A debit record recorded LAST with post_nonce=0 would clobber the aggregate's last-post nonce
+      -- to 0, falsely signalling a nonce change (real_nonce -> 0) -> the reverse-nonce check in
+      -- bal_account_nonstorage_consistent fires (BAL declares no nonce change) -> bv_fail=44
+      -- (frontier/scenarios MCOPY b12: dd36afb2 is credited then debits, nonce 1; the debit's post_nonce=0
+      -- made the agg see 1->0). Look up the caller's pre-state nonce (= its current nonce; a plain CALL
+      -- does not bump the caller nonce, only CREATE does) and record pre_nonce=post_nonce=that nonce, so
+      -- the debit and credit records agree and the aggregate's last-post nonce stays the real nonce.
       -- The aggregate keeps first-pre/last-post, so multiple caller value-CALLs collapse to (start,final).
-      -- a0/a2/a3 alias x10/x12/x13 -> save/restore around both helpers; nse_post_bal is free here (the
-      -- callee-credit below reuses it afterwards).
+      -- a0..a6 alias x10/x12/x13 etc. -> save/restore around the helpers; nse_acct is free here (the
+      -- callee-credit below reloads it); nse_post_bal is free here too.
+      -- caller's pre-state account -> nse_acct (nonce@0). On any lookup error use nonce 0 (conservative:
+      -- a wrong-low nonce can only false-REJECT, never false-accept).
+      "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
+      "  ld a0, 576(x20)\n  ld a1, 584(x20)\n  la a2, cd_caller_be\n  li a3, 20\n  ld a4, 592(x20)\n  ld a5, 600(x20)\n  la a6, nse_acct\n" ++
+      "  jal ra, account_at_header_state_root\n" ++
+      "  mv t0, a0\n" ++                                    -- status
+      "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
+      "  beqz t0, .Lcd_deb_have_nonce_" ++ tag ++ "\n" ++   -- status 0 = found -> nse_acct.nonce valid
+      "  la t0, nse_acct\n  sd zero, 0(t0)\n" ++            -- not found / error -> nonce 0
+      ".Lcd_deb_have_nonce_" ++ tag ++ ":\n" ++
       "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
       "  la a0, cd_caller_newbal\n  la a1, cd_value_be\n  la a2, nse_post_bal\n" ++   -- nse_post_bal = post + value = pre
       "  jal ra, u256_add_be\n" ++
-      "  la a0, cd_caller_be\n  la a1, nse_post_bal\n  la a2, cd_caller_newbal\n  li a3, 0\n  li a4, 0\n" ++
+      "  la t0, nse_acct\n  ld a3, 0(t0)\n  mv a4, a3\n" ++   -- pre_nonce = post_nonce = caller's real nonce
+      "  la a0, cd_caller_be\n  la a1, nse_post_bal\n  la a2, cd_caller_newbal\n" ++
       "  jal ra, record_nonstorage_effect\n" ++
       "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
       ".Lcd_deb_done_" ++ tag ++ ":\n") ++


### PR DESCRIPTION
## What

Closes two distinct root causes of **bv_fail=44** false-rejects (exec-vs-BAL non-storage check) on single-tx contract blocks — both diagnosed and validated against `frontier/scenarios` `test_program_*` (bead `evm-asm-coc3g.6.5`). State recompute was already correct in every case (recomputed_state_root == payload_state_root); these are false-rejects from the per-tx exec-vs-BAL reconstruction.

### Commit 1 (`c3addee9e`) — skip modeled-system contracts
The non-storage check compared every BAL account against the per-tx exec effect log, but the genesis system/predeploy contracts (EIP-2935/4788/7002/7251/6110) get their code/state from the **block-level system replay / genesis setup**, not the per-tx exec log — so their deployment `code_changes` were "declared but exec-absent" → false-reject. Fix: add the 5 addresses to the non-storage check's `i3djw_skip_list`, mirroring the proven `bal_all_accounts_storage_consistent` modeled-system skip. (Add-only-skip ⇒ cannot introduce a false-reject; system-contract state is independently pinned by the state-root recompute.)

### Commit 2 (`b31006c02`) — value-CALL live-balance + caller-debit nonce
After commit 1, a matched account (`dd36afb2…`) still mismatched: it receives +1 from a caller then makes its own value-CALL of 3 (true: 107+1−3 = 105), but the exec recorded 104 **and** a spurious nonce 1→0. Two child-frame recording bugs:
1. **Live balance** (`CallFrameDescend`): the callee's `env+32` (SELFBALANCE) was staged from the PRE-STATE `callee_balance_table` only, so its later debit ran `107−3` instead of the live `108−3`. Fix: overlay `env+32` with `nonstorage_effect_latest_balance(child_addr)` (the most-recent recorded post = genuine live balance), pre-state fallback on miss.
2. **Nonce** (`ChildFrameHandlers`): the caller-debit non-storage record hardcoded `pre/post_nonce=0`; since the account is also a value-CALL *callee*, `nonstorage_effect_aggregate`'s last-post nonce got clobbered to 0, firing the reverse-nonce check. Fix: look up the caller's real nonce via `account_at_header_state_root` (plain CALL doesn't bump nonce; lookup error → 0, conservative).

Both mirror execution-specs CALL value-transfer semantics; sound (the final comparator independently checks BAL finals against exec).

## Verification

- `frontier/scenarios` b12: verdict **00→01**, bv_fail 44→0.
- MCOPY scenarios family: **16/37 → 20/37** full-match (new: b7/b10/b11/b12), **0 regressions**.
- Broad random EEST (seed 4242, 250 cases), **independently re-run on the merged branch**: **187/250 → 190/250** full-match (+3: nested_calls_log_order depth 2/3/10), **0 false-accepts** (`guest=01 exp=00`), 0 errors, 0 valid-block regressions.
- `lake build` clean; `check-forbidden-tactics` green; no proof/tactic changes; all temporary instrumentation reverted.

## Scope

This is a real, net-positive dent in the `coc3g` value-flow executor-completion frontier (the dominant bv_fail=44 false-reject class), not a complete close of it — more value-flow shapes remain (tracked under `coc3g.6`). Both fixes are self-contained and 0-regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
