### PR TITLE
fix(verdict): descend into same-tx-created contract code on CALL/SELFDESTRUCT (bv_fail=44)

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -1112,6 +1112,36 @@ def emitStaticViolationExit : String :=
   "  jal ra, frame_return\n" ++
   "  j .dispatch_loop\n"
 
+/-- SELFDESTRUCT (0xff). Unlike the other exceptional exits, SELFDESTRUCT is a
+    SUCCESSFUL frame halt: the EVM stops the current frame, returns empty data to
+    the caller, and KEEPS the frame's state effects (its balance transfer / EIP-6780
+    deletion already recorded into the non-storage / code effect logs). So at child
+    depth (coc3g.6.5) it must `frame_return` with success word a0 = 1 (NOT 0 — a 0
+    success word is frame_return's REVERT signal, which truncates the child's recorded
+    effects back to the pre-child snapshot, erasing the SELFDESTRUCT deletion +
+    beneficiary credit and the child's prior CALL/CREATE effects). The leftover child
+    gas (568(x20)) is forwarded by frame_return's EIP-150 refund (SELFDESTRUCT does not
+    consume the remaining gas). At depth 0, surface the top-level halt kind 5. -/
+def emitSelfdestructExit : String :=
+  ".exit_selfdestruct:\n" ++
+  "  la x18, evm_call_depth\n" ++
+  "  ld x18, 0(x18)\n" ++
+  "  beqz x18, .exit_selfdestruct_top\n" ++
+  "  li a0, 1\n" ++          -- SUCCESS: keep the child frame's recorded effects
+  "  li a1, 0\n" ++
+  "  li a2, 0\n" ++
+  "  jal ra, frame_return\n" ++
+  "  j .dispatch_loop\n" ++
+  ".exit_selfdestruct_top:\n" ++
+  "  li x16, 0xa0010000\n" ++
+  "  sd x0, 0(x16)\n" ++
+  "  sd x0, 8(x16)\n" ++
+  "  sd x0, 16(x16)\n" ++
+  "  sd x0, 24(x16)\n" ++
+  "  li x17, 5\n" ++         -- halt_kind = SELFDESTRUCT
+  "  sd x17, 32(x16)\n" ++
+  "  j .exit_no_epilogue\n"
+
 
 /-- CREATE/CREATE2 child-frame staging helper emitted into the runtime dispatcher.
 
@@ -1509,6 +1539,7 @@ def emitDispatcherEpilogueCore
     createExecuteInitcodeFrameRuntimeFunction ++ "\n" ++
     createDeployedCodeValidFunction ++ "\n" ++
     createRecordCodeEffectFunction ++ "\n" ++
+    findCodeEffectByAddressFunction ++ "\n" ++
     createCreatorNonceUseFunction ++ "\n" ++
     zkvmModexpSafeFailWrapper ++ "\n" ++
     storageAccessGasFunction ++ "\n" ++
@@ -1570,7 +1601,7 @@ def emitDispatcherEpilogueCore
   emitStaticViolationExit ++
   emitExceptionalExit ".exit_invalid" 4 ++
   emitExceptionalExit ".exit_invalid_op" 3 ++
-  emitExceptionalExit ".exit_selfdestruct" 5 ++
+  emitSelfdestructExit ++
   emitExceptionalExit ".exit_outofgas" 6 ++
   emitExceptionalExit ".exit_stack_underflow" 7 ++
   emitExceptionalExit ".exit_stack_overflow" 8 ++
@@ -2436,6 +2467,7 @@ def emitRuntimeDispatcherEmbeddedHelperFunctions : String :=
   createExecuteInitcodeFrameRuntimeFunction ++ "\n" ++
   createDeployedCodeValidFunction ++ "\n" ++
   createRecordCodeEffectFunction ++ "\n" ++
+  findCodeEffectByAddressFunction ++ "\n" ++
   createCreatorNonceUseFunction ++ "\n" ++
   zkvmModexpSafeFailWrapper ++ "\n" ++
   -- Real RIPEMD160 (0x03) software kernel for the guest closures

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -455,6 +455,19 @@ def callDescendFallThrough
     ".Lcd_nacc_addr_" ++ tag ++ ":\n" ++
     "  lbu t3, 0(t1)\n  sb t3, 0(t0)\n  addi t1, t1, -1\n  addi t0, t0, 1\n  addi t2, t2, -1\n" ++
     "  bnez t2, .Lcd_nacc_addr_" ++ tag ++ "\n" ++
+    -- coc3g.6.5: a callee CREATEd earlier in THIS tx is ALIVE (has code/nonce), so is_account_alive(to)
+    -- is True -> no NEW_ACCOUNT state-gas charge. It is ABSENT from the block-pre witness, so
+    -- account_exists_at_header_state_root below would falsely report "not exists" -> wrongly charge the
+    -- 183600 new-account state gas -> OOG (.exit_outofgas) -> the value-CALL exceptional-fails and the
+    -- child never descends/runs (bv_fail=44). Detect created-in-tx via the code-effect log (the CREATE
+    -- deposit recorded the deployed code there) and skip the charge. find_code_effect_by_address
+    -- clobbers t0-t6 + a0(=x10); save x10/x12/x13.
+    "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
+    "  la a0, exec_code_effect_log\n  la t0, exec_code_effect_count\n  ld a1, 0(t0)\n  la a2, cd_callee_be\n" ++
+    "  jal ra, find_code_effect_by_address\n" ++
+    "  mv t6, a0\n" ++
+    "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
+    "  bnez t6, .Lcd_nacc_done_" ++ tag ++ "\n" ++           -- created this tx -> alive -> no charge
     -- account_exists_at_header_state_root(callee) -> aex_predicate (helper clobbers a-regs aliasing x10/x12/x13)
     "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
     "  ld a0, 576(x20)\n  ld a1, 584(x20)\n  la a2, cd_callee_be\n  ld a3, 592(x20)\n  ld a4, 600(x20)\n" ++
@@ -532,6 +545,38 @@ def callDescendFallThrough
   "  ld x10, 0(sp); ld x12, 8(sp); ld x13, 16(sp); ld t2, 24(sp)\n" ++
   "  addi sp, sp, 32\n" ++
   "  beqz t3, .Lcd_descend_" ++ tag ++ "\n" ++
+  -- coc3g.6.5: CALL into a SAME-TX-CREATED contract. A child CREATEd earlier in this tx is
+  -- ABSENT from the block-pre witness, so code_at_header_state_root returns status 1 (account
+  -- not in state trie) and the delegation resolver also misses -> the call falsely routed to
+  -- .Lcd_empty (empty EOA, push 1) and the child's runtime (e.g. its SELFDESTRUCT / outgoing
+  -- value-CALLs) NEVER ran in re-execution -> its deletion / beneficiary credit were never
+  -- recorded -> the exec-vs-BAL non-storage comparator false-rejects (bv_fail=44 on
+  -- selfdestruct_same_tx_via_call + create-then-call families). The CREATE deposit already
+  -- appended the child's deployed code to exec_code_effect_log (create_record_code_effect @
+  -- NoopHalt). On the code-lookup MISS, fall back to find_code_effect_by_address(cd_callee_be):
+  -- on a hit, point the descend code/len at the recorded entry (code bytes @ record+48, len @
+  -- record+40) by setting cahsr_code_offset/length so 608(x20)+offset == record+48 (the existing
+  -- .Lcd_descend_ path computes code_ptr = 608(x20)+cahsr_code_offset), then DESCEND so the child
+  -- runtime runs. Soundness: descending records MORE exec effects (never a SKIP), and the BAL
+  -- comparator independently checks each declared final, so this can only fix false-REJECTs, never
+  -- introduce a false-accept. The caller-debit / callee-credit / EIP-7708 transfer log above are
+  -- recorded ONCE before this decision (unchanged whether we descend or not), so descending does
+  -- not double-count them; the child's own SELFDESTRUCT records the deletion / beneficiary credit
+  -- separately. find_code_effect_by_address clobbers t0-t6 + a0(=x10); save x10/x12/x13.
+  "  addi sp, sp, -32\n" ++
+  "  sd x10, 0(sp); sd x12, 8(sp); sd x13, 16(sp)\n" ++
+  "  la a0, exec_code_effect_log; la t0, exec_code_effect_count; ld a1, 0(t0); la a2, cd_callee_be\n" ++
+  "  jal ra, find_code_effect_by_address\n" ++
+  "  mv t4, a0\n" ++                                   -- t4 = record ptr or 0
+  "  ld x10, 0(sp); ld x12, 8(sp); ld x13, 16(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  beqz t4, .Lcd_callee_nocreate_" ++ tag ++ "\n" ++ -- no code-effect record -> fall through to status check
+  "  ld t5, 40(t4); la t6, cahsr_code_length; sd t5, 0(t6)\n" ++  -- cahsr_code_length = record.code_len
+  "  addi t5, t4, 48\n" ++                             -- t5 = record+48 = absolute code ptr
+  "  ld t6, 608(x20); sub t5, t5, t6\n" ++             -- offset = (record+48) - codes_base
+  "  la t6, cahsr_code_offset; sd t5, 0(t6)\n" ++      -- cahsr_code_offset = offset (608(x20)+offset == record+48)
+  "  j .Lcd_descend_" ++ tag ++ "\n" ++
+  ".Lcd_callee_nocreate_" ++ tag ++ ":\n" ++
   "  li t3, 1\n" ++
   "  beq t2, t3, .Lcd_empty_" ++ tag ++ "\n" ++
   -- fail (status 2/3/4/5): pop args, push 0

--- a/EvmAsm/Codegen/Programs/NoopHalt.lean
+++ b/EvmAsm/Codegen/Programs/NoopHalt.lean
@@ -234,6 +234,10 @@ private def returnRevertTail (kind : Nat) (rollbackAsm : String := "")
 
 /-- Stage the popped SELFDESTRUCT beneficiary for later EIP-6780 state work. -/
 private def selfdestructTailAsm : String :=
+  -- coc3g.6.5: reset the created-in-tx marker at the start of every SELFDESTRUCT (it is set
+  -- below only when the selfdestructing account has a code-effect record from a CREATE earlier
+  -- in THIS tx execution; a stale 1 from a previous selfdestruct would mis-route this one).
+  "  la x14, evm_selfdestruct_created_in_tx\n  sd x0, 0(x14)\n" ++
   "  la x14, evm_selfdestruct_beneficiary\n" ++
   "  mv x15, x14\n" ++
   "  li x16, 4\n" ++
@@ -280,6 +284,32 @@ private def selfdestructTailAsm : String :=
   "  addi sp, sp, 32\n" ++
   selfdestructNewAccountSurchargeAsm ++
   selfdestructLoadAccountInputsAsm ++
+  -- coc3g.6.5: a contract CREATEd earlier in THIS tx that SELFDESTRUCTs is DELETED (EIP-6780).
+  -- Detect that by looking up the selfdestructing account (env.ADDRESS, canonical BE) in
+  -- exec_code_effect_log (the CREATE deposit recorded the deployed code there); on a hit set
+  -- evm_selfdestruct_created_in_tx=1 so the downstream balance-transfer / EIP-7708 log / beneficiary
+  -- nonstorage record (Selfdestruct.lean) take the created-in-tx paths (emit a Burn for self-destruct
+  -- to-self; record the child's deletion to 0/0 + the beneficiary credit). selfdestructLoadAccountInputsAsm
+  -- built sdai_origin_address = env.ADDRESS (BE) only when an account-witness ctx (584(x20)) is present;
+  -- guard on that. find_code_effect_by_address clobbers t0-t6 + a0(=x10) -> save x10/x12.
+  "  ld t0, 584(x20)\n  beqz t0, .L_selfdestruct_created_in_tx_done\n" ++
+  "  addi sp, sp, -16\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n" ++
+  "  la a0, exec_code_effect_log\n  la t0, exec_code_effect_count\n  ld a1, 0(t0)\n  la a2, sdai_origin_address\n" ++
+  "  jal ra, find_code_effect_by_address\n" ++
+  "  mv t1, a0\n" ++                                  -- t1 = code-effect record ptr (or 0)
+  "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  addi sp, sp, 16\n" ++
+  "  beqz t1, .L_selfdestruct_created_in_tx_done\n" ++
+  "  la t0, evm_selfdestruct_created_in_tx\n  li t2, 1\n  sd t2, 0(t0)\n" ++
+  -- coc3g.6.5: EIP-6780 DELETES the created-in-tx contract, so its deployed code is removed --
+  -- a created-then-destroyed-same-tx account has NET-ZERO code change and the BAL declares no
+  -- codeChange. The CREATE deposit appended a code-effect record (has_code_change=1) to
+  -- exec_code_effect_log; without removing it the code comparator (bv_fail=46) sees an exec code
+  -- change with no matching BAL codeChange. Zero the record's has_code_change field (record+32) so
+  -- both the forward (bal_account_code_consistent: has_code_change=0 + BAL silent -> consistent) and
+  -- the reverse (_covers: has_code_change=0 -> no obligation) treat it as no code change. KEEP code_len
+  -- (record+40) so both comparators' variable-stride walk stays aligned.
+  "  sd x0, 32(t1)\n" ++
+  ".L_selfdestruct_created_in_tx_done:\n" ++
   selfdestructBalanceTransferRuntimeAsm ++
   selfdestructEip7708LogRuntimeAsm ++
   "  la x14, evm_selfdestruct_staged\n" ++

--- a/EvmAsm/Codegen/Programs/Selfdestruct.lean
+++ b/EvmAsm/Codegen/Programs/Selfdestruct.lean
@@ -432,11 +432,79 @@ def selfdestructBeneficiaryNonstorageAsm : String :=
   -- selfdestructing contract's env ADDRESS (set from env, not the lookup), i.e. the created contract.
   -- Enables no new behavior (records the deletion that already happens) -> no cascade. a0/a2 alias x10/x12.
   "  la t0, evm_selfdestruct_created_in_tx; ld t0, 0(t0); beqz t0, .L_sdbn_chk_witness\n" ++
-  "  addi sp, sp, -48\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n" ++
-  "  sd zero, 16(sp); sd zero, 24(sp); sd zero, 32(sp); sd zero, 40(sp)\n" ++   -- 32B zero balance scratch
-  "  la a0, sdai_origin_address\n  addi a1, sp, 16\n  addi a2, sp, 16\n  li a3, 0\n  li a4, 0\n" ++
+  -- coc3g.6.5: created-in-tx SELFDESTRUCT. The deleted child's whole LIVE balance moves to the
+  -- beneficiary (or is BURNED on self-destruct-to-self). Two exec records are needed:
+  --   (1) the child's DELETION (balance 0, nonce 0) so the aggregate's last-post gives the BAL's
+  --       deleted final (0/0) -- else the CREATE deposit's nonce=1 / CALL credit linger (bv_fail=44
+  --       disc=1 inconsistent); and
+  --   (2) the beneficiary's CREDIT (+ the child's live balance) so the BAL's +balance has a match
+  --       (bv_fail=44 disc=2 NOTFOUND; selfdestruct_same_tx_via_call to_other).
+  -- The child is absent from the block-pre witness, so its live balance = its LATEST recorded
+  -- non-storage post_balance (the CREATE endowment + any CALL credit), read via
+  -- nonstorage_effect_latest_balance BEFORE we record the child's deletion (which would reset the
+  -- latest to 0). transferred==0 or beneficiary==origin (burn) -> no beneficiary record. The
+  -- beneficiary's pre = its latest live balance (other in-tx credits) if present, else its block-pre
+  -- balance (account_at_header_state_root), else 0; post = pre + transferred; nonce unchanged.
+  -- Stack frame (256B): sp+0 key(32B), sp+32 transferred(32B), sp+64 benef pre(32B),
+  -- sp+96 benef post(32B), sp+128 account struct(104B), sp+240/248 = x10/x12 save. a0..a6 alias
+  -- x10/x12/x13 -> saved/restored across the frame.
+  "  addi sp, sp, -256\n  sd x10, 240(sp)\n  sd x12, 248(sp)\n" ++
+  -- child addr key = sdai_origin_address (20B BE) + 12B zero -> sp+0
+  "  sd zero, 0(sp); sd zero, 8(sp); sd zero, 16(sp); sd zero, 24(sp)\n" ++
+  "  la t0, sdai_origin_address; addi t1, sp, 0; li t2, 20\n" ++
+  ".L_sdbn_ctk:\n" ++
+  "  beqz t2, .L_sdbn_ctk_d\n" ++
+  "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1; j .L_sdbn_ctk\n" ++
+  ".L_sdbn_ctk_d:\n" ++
+  -- transferred = child's latest live balance (sp+32); miss -> 0.
+  "  sd zero, 32(sp); sd zero, 40(sp); sd zero, 48(sp); sd zero, 56(sp)\n" ++
+  "  mv a0, sp; addi a1, sp, 32\n" ++
+  "  jal ra, nonstorage_effect_latest_balance\n" ++   -- a0 = 1 found / 0 miss (out left 0 on miss)
+  -- record the child's DELETION (balance 0, nonce 0) -- reuse sp+0..31 as a zero balance.
+  "  sd zero, 0(sp); sd zero, 8(sp); sd zero, 16(sp); sd zero, 24(sp)\n" ++
+  "  la a0, sdai_origin_address\n  mv a1, sp\n  mv a2, sp\n  li a3, 0\n  li a4, 0\n" ++
   "  jal ra, record_nonstorage_effect\n" ++
-  "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  addi sp, sp, 48\n" ++
+  -- transferred != 0 ?  (sp+32..63 BE)
+  "  ld t0, 32(sp); ld t1, 40(sp); or t0, t0, t1; ld t1, 48(sp); or t0, t0, t1; ld t1, 56(sp); or t0, t0, t1\n" ++
+  "  beqz t0, .L_sdbn_ci_restore\n" ++
+  -- beneficiary == origin (self) ? -> burn, no beneficiary credit
+  "  la t0, sdai_origin_address; la t1, evm_selfdestruct_beneficiary; li t2, 20\n" ++
+  ".L_sdbn_ci_self:\n" ++
+  "  beqz t2, .L_sdbn_ci_restore\n" ++                  -- all equal -> self -> burn -> no credit
+  "  lbu t3, 0(t0); lbu t4, 0(t1); bne t3, t4, .L_sdbn_ci_diff\n" ++
+  "  addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1; j .L_sdbn_ci_self\n" ++
+  ".L_sdbn_ci_diff:\n" ++
+  -- beneficiary pre balance (sp+64): latest live balance if present, else block-pre, else 0.
+  "  sd zero, 64(sp); sd zero, 72(sp); sd zero, 80(sp); sd zero, 88(sp)\n" ++
+  -- key = beneficiary (20B BE) + 12B zero -> sp+0 (transferred preserved at sp+32, benef pre at sp+64)
+  "  sd zero, 0(sp); sd zero, 8(sp); sd zero, 16(sp); sd zero, 24(sp)\n" ++
+  "  la t0, evm_selfdestruct_beneficiary; addi t1, sp, 0; li t2, 20\n" ++
+  ".L_sdbn_ci_bk:\n" ++
+  "  beqz t2, .L_sdbn_ci_bk_d\n" ++
+  "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1; j .L_sdbn_ci_bk\n" ++
+  ".L_sdbn_ci_bk_d:\n" ++
+  "  mv a0, sp; addi a1, sp, 64\n" ++
+  "  jal ra, nonstorage_effect_latest_balance\n" ++
+  "  bnez a0, .L_sdbn_ci_have_pre\n" ++                 -- found a live balance -> sp+64 has it
+  -- no live record: look up block-pre balance via account_at_header_state_root(beneficiary).
+  -- args: header_ptr=576(x20), header_len=584(x20), addr=evm_selfdestruct_beneficiary(20B),
+  -- state_ptr=592(x20), state_len=600(x20), out=acct@sp+128 (nonce@0, balance@8..40). status!=0 -> pre 0.
+  "  ld a0, 576(x20)\n  ld a1, 584(x20)\n  la a2, evm_selfdestruct_beneficiary\n  li a3, 20\n  ld a4, 592(x20)\n  ld a5, 600(x20)\n  addi a6, sp, 128\n" ++
+  "  jal ra, account_at_header_state_root\n" ++
+  "  beqz a0, .L_sdbn_ci_pre_from_acct\n" ++
+  "  sd zero, 64(sp); sd zero, 72(sp); sd zero, 80(sp); sd zero, 88(sp)\n" ++   -- not found -> pre 0
+  "  j .L_sdbn_ci_have_pre\n" ++
+  ".L_sdbn_ci_pre_from_acct:\n" ++
+  -- acct.balance is at (sp+128)+8 = sp+136 (32B BE); copy into sp+64.
+  "  ld t0, 136(sp); sd t0, 64(sp); ld t0, 144(sp); sd t0, 72(sp); ld t0, 152(sp); sd t0, 80(sp); ld t0, 160(sp); sd t0, 88(sp)\n" ++
+  ".L_sdbn_ci_have_pre:\n" ++
+  -- post = pre (sp+64) + transferred (sp+32) -> sp+96 (32B BE).
+  "  addi a0, sp, 64\n  addi a1, sp, 32\n  addi a2, sp, 96\n" ++
+  "  jal ra, u256_add_be\n" ++
+  "  la a0, evm_selfdestruct_beneficiary\n  addi a1, sp, 64\n  addi a2, sp, 96\n  li a3, 0\n  li a4, 0\n" ++  -- pre, post, nonce unchanged
+  "  jal ra, record_nonstorage_effect\n" ++
+  ".L_sdbn_ci_restore:\n" ++
+  "  ld x10, 240(sp)\n  ld x12, 248(sp)\n  addi sp, sp, 256\n" ++
   "  j .L_sdbn_done\n" ++
   ".L_sdbn_chk_witness:\n" ++
   "  la t0, sdai_status; ld t0, 0(t0); beqz t0, .L_sdbn_origin_ok\n" ++


### PR DESCRIPTION
## What

Makes the stateless verdict's nested **CALL / SELFDESTRUCT descend into same-tx-created contract code** during re-execution — a foundational executor-completion capability for the bv_fail=44 frontier (bead `coc3g.6`).

## Why

A contract that CREATEs a child this tx and then CALLs it: the verdict's `callDescendFallThrough` did `code_at_header_state_root(child)` → **absent** (the child isn't in the block-pre witness, since it was created this tx) → routed to `.Lcd_empty` (treat as empty EOA, push 1) and **never executed the child's code**. So the child's SELFDESTRUCT / value-flow effects were never recorded → exec-vs-BAL non-storage mismatch → **bv_fail=44 false-reject** (state-root was always correct: recomputed == payload). This blocks ~20 SELFDESTRUCT cases plus several CREATE/`*_no_log`/`initcode_calls_with_value` cases.

## How (5 coordinated parts; 3 were hidden blockers found via diagnostics)

1. **CALL code-effect fallback**: on the `code_at_header_state_root` miss, fall back to `find_code_effect_by_address(exec_code_effect_log)` (the CREATE deposit already records the created child's code) and descend into that code instead of `.Lcd_empty`.
2. **New-account state-gas charge**: `account_exists_at_header_state_root` missed the created child → falsely charged 183600 NEW_ACCOUNT state gas → OOG before code resolution. Suppressed when the callee has a code-effect record (created-in-tx ⇒ alive).
3. **`.exit_selfdestruct` frame-return**: passed `a0=0` (REVERT) at child depth → `frame_return` truncated the child's recorded effects. SELFDESTRUCT is a *successful* halt → now passes `a0=1`.
4. **SELFDESTRUCT detection**: set `evm_selfdestruct_created_in_tx` via the code-effect lookup (the real handler never set it before — only probes did), and zero the record's `has_code_change` (EIP-6780 deletes the code ⇒ net-zero).
5. **Beneficiary credit**: the created-in-tx branch records the child deletion (0/0) + the beneficiary credit (child live balance via `nonstorage_effect_latest_balance`).

**Double-count handling (the crux):** the value-CALL caller-debit + callee-credit + EIP-7708 transfer log are recorded exactly once *before* the descend decision, so descending does not re-record them; the child's SELFDESTRUCT records its deletion/credit separately. Confirmed: 0 false-accepts.

## Verification (independently re-run on this branch off current main)

- Build green; `check-forbidden-tactics` green; mirrors execution-specs CALL/SELFDESTRUCT/EIP-6780 semantics.
- Broad random EEST (seed 4242): **500-case** run **0 false-accepts**, 405/500 full-match; **250-case** re-run on this rebased branch **0 false-accepts**, **192/250 (+2)**.
- `selfdestruct_to_different_address_same_tx` CREATE + CREATE2 variants now full-pass.
- Regression sanity: the FAIL set is confined to the same pre-existing false-reject families (eip7708 / eip7928 / eip7843) — **no new family regressed**.

## Scope / follow-up

Foundational + net-positive + 0-regress, but does not close the whole class. The harder `selfdestruct_same_tx_via_call` family now *advances* (to_other: 44→53, the created-in-tx SELFDESTRUCT's EIP-7708 Transfer log isn't emitted yet; to_self: stays 44, detection gap) — both documented with next steps on bead `coc3g.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
