### PR TITLE
fix(codegen): flip selfdestruct_same_tx_via_call to_other (3-part EIP-7708/access fix)

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
@@ -227,6 +227,24 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     "  ld x18, 0(x18)\n" ++
     "  bnez x18, 7f\n" ++
     "6:\n" ++
+    -- coc3g.6 CAUSE 2: mirror spec generic_create (amsterdam vm/instructions/system.py:122
+    -- `evm.accessed_addresses.add(contract_address)`). On the committing CREATE path the derived
+    -- contract address is WARM for the rest of the tx, so a later CALL/SELFDESTRUCT to it pays the
+    -- WARM floor (100), not COLD_ACCOUNT_ACCESS (2600). Without this, a same-tx value-CALL to the
+    -- just-created child charged the 2500 cold delta (verified: selfdestruct_same_tx_via_call
+    -- to_other receipt cumulativeGasUsed over-counted by exactly 2500 -> bv_fail=53). The warm
+    -- table is a single global (evm_access_account_table, capacity 100000, reset only at tx setup),
+    -- so the seed persists across create_frame_descend into the parent's subsequent CALL.
+    -- runtime_access_account_seed inserts WITHOUT charging gas and ignores duplicates; it clobbers
+    -- the a-regs that alias x10/x12/x13, so save/restore them. create_address_be is the canonical
+    -- 20-byte BE address (a0 expects exactly that).
+    "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
+    "  la a0, create_address_be\n" ++
+    "  la a1, " ++ runtimeAccessAccountTableLabel ++ "\n" ++
+    "  la a2, " ++ runtimeAccessAccountCountLabel ++ "\n" ++
+    "  li a3, " ++ toString runtimeAccessAccountCapacity ++ "\n" ++
+    "  jal ra, runtime_access_account_seed\n" ++
+    "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
     -- 5em02.2: debit the creator's LIVE balance (env+32 = .selfBalance, big-endian) by the
     -- endowment, so SELFBALANCE reads B-endowment after a CREATE (the transfer was inert ->
     -- false-reject for value-creating contracts). Reached only on the committing path (value
@@ -315,6 +333,45 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     "  la t0, create_creator_newbal\n  addi t1, x20, 63\n  li t2, 32\n" ++
     ".Lcr_sbc_wb_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
     "  lbu t3, 0(t0)\n  sb t3, 0(t1)\n  addi t0, t0, 1\n  addi t1, t1, -1\n  addi t2, t2, -1\n  bnez t2, .Lcr_sbc_wb_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
+    -- coc3g.6 CAUSE 3: EIP-7708 transfer log for the CREATE endowment value move. Spec
+    -- interpreter.py:307-316 emits Transfer(caller, current_target, value) at EVERY message-call
+    -- frame entry with should_transfer_value and value!=0 and caller!=current_target, AFTER the
+    -- tx-state snapshot and BEFORE the initcode runs. The CREATE child frame moves `endowment` from
+    -- the creator (caller) to the created child (current_target). Without it, the
+    -- selfdestruct_same_tx_via_call transfer_during_create / create_opcode_emits_log receipts were
+    -- missing this log -> bv_fail=53 receipts-root mismatch. Emitted HERE -- after create_frame_descend
+    -- switched x20 to the CHILD env (post-snapshot: descend set the child eventLogCheckpoint@480 to
+    -- the current count) and BEFORE `j .dispatch_loop` runs the initcode -- so the log (a) lands in
+    -- the correct order (before any initcode logs) and (b) is ROLLED BACK by frame_return when the
+    -- child reverts/fails (failed_create_with_value_no_log expects NO log). caller != child always
+    -- (a freshly-derived address), so the only guard is value!=0. The appender reads from=topic1 (a0,
+    -- stack-word LE), to=topic2 (a1, stack-word LE), amount (a2, stack-word LE -> reversed to BE).
+    -- The create_sender_be/create_address_be (canonical 20B BE) + create_value_be (32B BE) globals are
+    -- still valid (descend doesn't clobber them; the initcode hasn't run). Gated on the account-witness
+    -- ctx (env+584) so create_value_be is the valid endowment the gate populated. Stack frame (96B):
+    -- sp+0 from_sw(32), sp+32 to_sw(32), sp+64 val_sw(32 partial)/x10/x12/x13 -- use a 128B frame.
+    "  ld t3, 584(x20)\n  beqz t3, .Lcr_tl_done_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
+    "  la t0, create_value_be\n  ld t1, 0(t0); ld t2, 8(t0); or t1, t1, t2; ld t2, 16(t0); or t1, t1, t2; ld t2, 24(t0); or t1, t1, t2\n" ++
+    "  beqz t1, .Lcr_tl_done_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++   -- value == 0: no log
+    "  addi sp, sp, -128\n  sd x10, 96(sp)\n  sd x12, 104(sp)\n  sd x13, 112(sp)\n" ++
+    -- from_sw = [reverse(create_sender_be) low 20][12 zero] (sp+0)
+    "  sd zero, 0(sp); sd zero, 8(sp); sd zero, 16(sp); sd zero, 24(sp)\n" ++
+    "  la t0, create_sender_be; addi t0, t0, 19; addi t1, sp, 0; li t2, 20\n" ++
+    ".Lcr_tl_from_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
+    "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, .Lcr_tl_from_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
+    -- to_sw = [reverse(create_address_be) low 20][12 zero] (sp+32)
+    "  sd zero, 32(sp); sd zero, 40(sp); sd zero, 48(sp); sd zero, 56(sp)\n" ++
+    "  la t0, create_address_be; addi t0, t0, 19; addi t1, sp, 32; li t2, 20\n" ++
+    ".Lcr_tl_to_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
+    "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, .Lcr_tl_to_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
+    -- val_sw = reverse(create_value_be) = LE 32 bytes (sp+64)
+    "  la t0, create_value_be; addi t0, t0, 31; addi t1, sp, 64; li t2, 32\n" ++
+    ".Lcr_tl_val_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
+    "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, .Lcr_tl_val_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
+    "  addi a0, sp, 0\n  addi a1, sp, 32\n  addi a2, sp, 64\n" ++   -- from = from_sw, to = to_sw, amount = val_sw
+    "  jal ra, eip7708_append_transfer_log\n" ++
+    "  ld x10, 96(sp)\n  ld x12, 104(sp)\n  ld x13, 112(sp)\n  addi sp, sp, 128\n" ++
+    ".Lcr_tl_done_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
     "  j .dispatch_loop\n" ++
     "7:\n" ++
     "  addi x12, x12, " ++ toString netPopBytes ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/Selfdestruct.lean
+++ b/EvmAsm/Codegen/Programs/Selfdestruct.lean
@@ -306,6 +306,16 @@ def selfdestructEip7708LogRuntimeAsm : String :=
   "  la t0, evm_selfdestruct_log_status\n" ++
   "  li t1, 1\n" ++
   "  sd t1, 0(t0)\n" ++
+  -- coc3g.6 CAUSE 1: a contract CREATEd-in-this-tx is absent from the block-pre witness, so the
+  -- account-transfer stage never ran (sdai_transfer_status=3) and account_extract_balance(origin_rlp)
+  -- would parse the wrong/empty RLP. EIP-7708 still requires the synthetic Transfer/Burn log for the
+  -- live balance moved out of the destroyed child. Branch here: read the child's LIVE balance (its
+  -- latest recorded non-storage post_balance, BE) via nonstorage_effect_latest_balance keyed on
+  -- sdai_origin_address, bypassing the transfer-status gate. Runs BEFORE selfdestructBeneficiaryNonstorageAsm
+  -- records the child's deletion (which resets the latest to 0), so the live balance is present.
+  "  la t0, evm_selfdestruct_created_in_tx\n" ++
+  "  ld t0, 0(t0)\n" ++
+  "  bnez t0, .L_selfdestruct_eip7708_created\n" ++
   "  la t0, sdai_transfer_status\n" ++
   "  ld t1, 0(t0)\n" ++
   "  bnez t1, .L_selfdestruct_eip7708_done\n" ++
@@ -322,6 +332,27 @@ def selfdestructEip7708LogRuntimeAsm : String :=
   "  ld x12, 8(sp)\n" ++
   "  addi sp, sp, 32\n" ++
   "  bnez t6, .L_selfdestruct_eip7708_balance_fail\n" ++
+  "  j .L_selfdestruct_eip7708_have_balance\n" ++
+  ".L_selfdestruct_eip7708_created:\n" ++
+  -- Stack frame (64B): sp+0 key(32B: 20B BE child addr + 12B zero), sp+32 = x10/x12 save.
+  "  addi sp, sp, -64\n" ++
+  "  sd x10, 32(sp)\n" ++
+  "  sd x12, 40(sp)\n" ++
+  "  sd zero, 0(sp); sd zero, 8(sp); sd zero, 16(sp); sd zero, 24(sp)\n" ++
+  "  la t0, sdai_origin_address; addi t1, sp, 0; li t2, 20\n" ++
+  ".L_sd7708_ck:\n" ++
+  "  beqz t2, .L_sd7708_ck_d\n" ++
+  "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1; j .L_sd7708_ck\n" ++
+  ".L_sd7708_ck_d:\n" ++
+  -- zero the scratch (miss leaves it untouched -> value 0 -> no-op log), then read the live balance.
+  "  la t0, evm_selfdestruct_balance_scratch; sd zero, 0(t0); sd zero, 8(t0); sd zero, 16(t0); sd zero, 24(t0)\n" ++
+  "  mv a0, sp\n" ++
+  "  la a1, evm_selfdestruct_balance_scratch\n" ++
+  "  jal ra, nonstorage_effect_latest_balance\n" ++
+  "  ld x10, 32(sp)\n" ++
+  "  ld x12, 40(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  ".L_selfdestruct_eip7708_have_balance:\n" ++
   "  la t0, evm_selfdestruct_balance_scratch\n" ++
   "  addi t1, t0, 31\n" ++
   "  li t2, 16\n" ++


### PR DESCRIPTION
## What

Flip the 6 `selfdestruct_same_tx_via_call` **to_other** cases (call_once / call_twice / call_twice_with_value × transfer_during_call / transfer_during_create) from `bv_fail=53` (receipts-root mismatch) to `verdict=1`, by closing three independent guest gaps. Bead `evm-asm-coc3g.6`.

## Why

The to_other family false-rejected. Root-caused to three independent causes, all required together to flip the test:

1. **Missing EIP-7708 SELFDESTRUCT log for a created-in-tx child.** `selfdestructEip7708LogRuntimeAsm` gated on `sdai_transfer_status==0` and read the balance from `sdai_origin_rlp`. A child CREATEd in this tx is absent from the block-pre witness (status=3), so the synthetic Transfer/Burn log was skipped.

2. **The CREATEd child was charged COLD access on the same-tx value-CALL.** Spec `generic_create` (amsterdam `system.py:122`) adds the contract address to `accessed_addresses`, so a later CALL to it pays WARM (100), not `COLD_ACCOUNT_ACCESS` (2600). The guest charged the 2500 cold delta → receipt `cumulativeGasUsed` over-counted by **exactly 2500** in all 6 cases. Confirmed via the verdict probe + runtime access-outcome log: the spurious cold access was the keccak-derived created child (neither `tx.to` nor the beneficiary).

3. **Missing EIP-7708 transfer log for the CREATE endowment.** Spec `interpreter.py:307-316` emits `Transfer(caller, current_target, value)` at every message-call frame entry with `should_transfer_value`, `value != 0`, `caller != current_target` — including the CREATE child frame. The `transfer_during_create` receipts were missing this log (block log count 1/3 vs expected 2/4).

## How

- **`Selfdestruct.lean`** — branch on `evm_selfdestruct_created_in_tx==1`: read the child's LIVE balance via `nonstorage_effect_latest_balance` (keyed on `sdai_origin_address`), bypass the transfer-status gate, then reuse the existing balance-reverse + from/to-sw + burn/transfer dispatch. No-op on value 0.
- **`ChildFrameHandlerTails.lean`** (committing CREATE path) — seed the derived contract address into the global runtime warm table (`runtime_access_account_seed`), mirroring `generic_create`.
- **`ChildFrameHandlerTails.lean`** (after `create_frame_descend`, x20 = child env) — emit the CREATE endowment `Transfer(creator, child, endowment)`. Placed post-snapshot (rolls back via `frame_return` on a child revert — `failed_create_with_value_no_log` expects NO log) and pre-initcode (correct log order). Gated on value != 0.

## Verification

- All 6 to_other inputs flip to `verdict=1`/`bv_fail=0` (filtered harness: full match 6/6 to_other; the 6 to_self correctly stay rejected — no false-accept).
- Broad sweep `--random --seed 4242 --limit 500 --jobs 4 --max-jobs 4`:
  - full match **405 → 416 (+11)**
  - **0 false-accepts** (`guest=01 exp=00` == 0)
  - **0 regressions** (no case that passed on `main` fails here)
  - The +11 = the 6 to_other + 5 bonus gains (`selfdestruct_to_self_same_tx` via CREATE/CREATE2, `create_initcode_stop_emits_log`, `create_opcode_emits_log`), all CREATE-endowment-log / warm-seed beneficiaries.
- No `native_decide`/`bv_decide`; no misaligned RV64 loads/stores; build green; `check-forbidden-tactics` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)