### PR TITLE
fix(precompile): burn child allotment on wrong-length BLAKE2F/KZG call (bv_fail=41)

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
@@ -661,7 +661,12 @@ def basicPrecompileCallTail
     ".L" ++ tag ++ "_blake2f:\n" ++
     "  ld x16, " ++ toString inSizeOff ++ "(x12)\n" ++
     "  li x17, 213\n" ++
-    "  bne x16, x17, 1f\n" ++
+    -- Wrong length raises InvalidParameter (an ExceptionalHalt) BEFORE any gas
+    -- charge: execution-specs zeroes the child frame's gas_left, so the whole
+    -- EIP-150 child allotment is consumed. Burn it like the BLS handlers rather
+    -- than falling through to the regular CALL descent (which would refund the
+    -- forwarded gas and under-count block gas_used by the stipend).
+    "  bne x16, x17, .L" ++ tag ++ "_bn254_fail_allot\n" ++
     "  la x15, evm_precompile_frame\n" ++
     "  li x16, 1\n" ++
     "  sd x16, 0(x15)\n" ++
@@ -706,7 +711,12 @@ def basicPrecompileCallTail
     ".L" ++ tag ++ "_kzg_point_eval:\n" ++
     "  ld x16, " ++ toString inSizeOff ++ "(x12)\n" ++
     "  li x17, 192\n" ++
-    "  bne x16, x17, 1f\n" ++
+    -- Wrong length raises InvalidParameter (an ExceptionalHalt) BEFORE any gas
+    -- charge: execution-specs zeroes the child frame's gas_left, so the whole
+    -- EIP-150 child allotment is consumed. Burn it like the BLS handlers rather
+    -- than falling through to the regular CALL descent (which would refund the
+    -- forwarded gas and under-count block gas_used by the stipend).
+    "  bne x16, x17, .L" ++ tag ++ "_bn254_fail_allot\n" ++
     "  la x15, evm_precompile_frame\n" ++
     "  li x16, 1\n" ++
     "  sd x16, 0(x15)\n" ++


### PR DESCRIPTION
## Problem

EIP-7928 `bal_precompile_call_opcode` false-rejected the 8 fixtures whose tx calls
precompile **0x09 (BLAKE2F)** or **0x0a (KZG point evaluation)** via the CALL family
with empty input. The block header reports `gas_used = 121121` but the guest computed
`21121` — an under-count of exactly **100000**, the forwarded call stipend
(`PUSH3 0x0186a0` in the caller contract `...6009620186a0f100`).

Diagnosed with the `zisk_stateless_verdict_v2` probe: `bv_fail_code = 41` (gas gate),
`recomputed_state_root == payload_root` (state recompute correct), and
`bv_exact_header_gas_used(121121) != bv_exact_expected_gas_used(21121)`.

## Root cause

In `basicPrecompileCallTail` (`ChildFrameHandlerTails.lean`), the BLAKE2F (`len != 213`)
and KZG (`len != 192`) handlers branched to the generic `1f` fall-through on a length
mismatch — the regular CALL **descent**, which treats 0x09/0x0a as an ordinary empty
account, so the CALL "succeeds" and the unused forwarded gas is **refunded**.

Per execution-specs, `blake2f` / `point_evaluation` raise `InvalidParameter` (an
`ExceptionalHalt`) **before** charging gas, and the interpreter sets the child frame's
`gas_left = 0` (`vm/interpreter.py:340-343`) — the **entire EIP-150 child allotment is
consumed**. The BLS12 handlers (0x0b..0x11) already model this by branching to
`.L<tag>_bn254_fail_allot` (computes `A = min(gas_word, 63/64*remaining)` and burns it).

## Fix

Point the BLAKE2F / KZG length-mismatch branches at the same `_bn254_fail_allot` burn
stub the BLS handlers use. Surgical: only the wrong-length path of 0x09/0x0a changes;
valid-length calls are untouched.

## Validation

- Targeted harness: `precompile_call_opcode` **40/40 full-match** (was 32/40); all 8
  failing fixtures flip.
- Verdict scan over all 72 precompile cases: **72/72** pass, the 64 previously-passing
  cases stay passing (no regression).
- Broad random sweep (`--random --seed 4242 --limit 500 --jobs 4`): **0 false-accepts**
  (`guest=01 exp=00` = 0), full-match 413/500, **no precompile_call_opcode failure**.

Remaining eip7928 BAL false-rejects (distinct roots: EIP-7702 delegated-call cold-access,
aborted-account non-storage exec-vs-BAL, and 4788/2935 system invalid-calldata receipts)
are tracked in bead `evm-asm-fva3w`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)