### PR TITLE
fix(verdict): charge EIP-7702 delegation-target cold access on CALL (bv_fail=41)

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
@@ -326,6 +326,58 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     "  addi x10, x10, 1\n" ++
     "  j .dispatch_loop"
 
+/-- EIP-7702 delegation access charge for a CALL-family callee (bv_fail=41,
+    bal_7702_delegated_via_call_opcode). After the callee's own EIP-2929 access
+    is charged, execution-specs Amsterdam ALSO charges the delegation TARGET's
+    access when the callee is a `0xef0100||addr` delegation marker
+    (`calculate_delegation_cost`, eoa_delegation.py:126; applied in CALL/CALLCODE/
+    DELEGATECALL/STATICCALL, system.py:444-455 / 567-578):
+      extra_gas += COLD_ACCOUNT_ACCESS (2600) if target ∉ accessed_addresses
+                 += WARM_ACCESS (100)        otherwise
+    and adds the target to accessed_addresses on first touch.
+
+    The callee's BE address is staged at `evm_access_seed_addr` by the caller. We
+    resolve the callee's pre-state code via `code_at_header_state_root` (witness
+    ctx env+576..616, exactly as `callDescendFallThrough`); on a 23-byte
+    `ef 01 00`-prefixed body the trailing 20 bytes ARE the target's canonical BE
+    address, so we charge it through `runtime_access_account_charge` (which debits
+    2500 on cold + inserts, 0 on warm) and then add the missing 100
+    UNCONDITIONALLY — yielding 2600 cold / 100 warm to match the spec exactly
+    (the 100 dispatcher warm-floor that backs the callee's own access has no
+    counterpart for the delegation target, which the spec charges in full).
+
+    Soundness: a non-delegated callee (status != 0, length != 23, or wrong prefix)
+    charges nothing — this can only ADD a required charge, never weaken one.
+    Preserves x10/x12/x13 (the helpers clobber the aliasing a-regs) and the
+    caller's s9/s10/s11 (callee-saved across both helpers); x20/x21 are preserved
+    by both helpers. -/
+def callDelegationAccessChargeAsm (tag : String) : String :=
+  "  addi sp, sp, -32\n  sd x10, 0(sp); sd x12, 8(sp); sd x13, 16(sp)\n" ++
+  "  ld a0, 576(x20)\n  ld a1, 584(x20)\n  la a2, " ++ runtimeAccessSeedScratchLabel ++ "\n" ++
+  "  ld a3, 592(x20)\n  ld a4, 600(x20)\n  ld a5, 608(x20)\n  ld a6, 616(x20)\n" ++
+  "  jal ra, code_at_header_state_root\n" ++
+  "  mv t2, a0\n" ++
+  "  ld x10, 0(sp); ld x12, 8(sp); ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
+  -- not found / error -> not delegated -> no charge
+  "  bnez t2, .Lcdac_done_" ++ tag ++ "\n" ++
+  "  la t3, cahsr_code_length; ld t3, 0(t3); li t4, 23; bne t3, t4, .Lcdac_done_" ++ tag ++ "\n" ++
+  "  ld t3, 608(x20); la t4, cahsr_code_offset; ld t4, 0(t4); add t3, t3, t4\n" ++  -- t3 = code ptr
+  "  lbu t4, 0(t3); li t5, 0xef; bne t4, t5, .Lcdac_done_" ++ tag ++ "\n" ++
+  "  lbu t4, 1(t3); li t5, 0x01; bne t4, t5, .Lcdac_done_" ++ tag ++ "\n" ++
+  "  lbu t4, 2(t3); bnez t4, .Lcdac_done_" ++ tag ++ "\n" ++
+  -- delegation marker: target = code[3..22] (20-byte canonical BE) at t3+3.
+  -- runtime_access_account_charge reads 20 bytes from a0 (read-only), so pass it
+  -- the in-place marker bytes; it debits 2500 + inserts on cold, 0 on warm.
+  "  addi sp, sp, -32\n  sd x10, 0(sp); sd x12, 8(sp); sd x13, 16(sp)\n" ++
+  "  addi a0, t3, 3\n  la a1, " ++ runtimeAccessAccountTableLabel ++ "\n" ++
+  "  la a2, " ++ runtimeAccessAccountCountLabel ++ "\n  li a3, " ++ toString runtimeAccessAccountCapacity ++ "\n" ++
+  "  jal ra, runtime_access_account_charge\n" ++
+  "  ld x10, 0(sp); ld x12, 8(sp); ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
+  -- add the 100 warm-floor the helper omits, so total = 2600 cold / 100 warm.
+  "  ld t0, 568(x20)\n  li t1, 100\n  bltu t0, t1, .exit_outofgas\n" ++
+  "  sub t0, t0, t1\n  sd t0, 568(x20)\n" ++
+  ".Lcdac_done_" ++ tag ++ ":\n"
+
 def basicPrecompileCallTail
       (tag : String) (netPopBytes inOffsetOff inSizeOff outOffsetOff outSizeOff : Nat)
       (fallThroughAsm : String) : String :=
@@ -345,6 +397,10 @@ def basicPrecompileCallTail
     "  la a2, " ++ runtimeAccessAccountCountLabel ++ "\n" ++
     "  li a3, " ++ toString runtimeAccessAccountCapacity ++ "\n" ++
     "  jal ra, runtime_access_account_charge\n" ++
+    -- EIP-7702: when the callee is a delegation marker, ALSO charge the delegation
+    -- target's access (cold 2600 / warm 100). callDelegationAccessChargeAsm
+    -- preserves s9/s10/s11 and x10/x12/x13, so the restore below still holds.
+    callDelegationAccessChargeAsm tag ++
     "  mv x13, s9\n" ++
     "  mv x10, s10\n" ++
     "  mv x12, s11\n" ++


### PR DESCRIPTION
## Summary

Fixes the `bal_7702_delegated_via_call_opcode` EIP-7928 BAL sub-family (bead `evm-asm-fva3w`, sub-family A), which false-rejected all four CALL-family opcodes (CALL / CALLCODE / DELEGATECALL / STATICCALL) with **bv_fail=41**.

The guest under-charged regular gas by exactly **2600** (header `gas_used` 26220 vs guest-computed 23620 = `COLD_ACCOUNT_ACCESS`).

## Root cause

execution-specs Amsterdam, after charging the callee's own EIP-2929 access, **also** charges the delegation TARGET's access when the callee resolves to a `0xef0100||addr` EIP-7702 delegation marker (`calculate_delegation_cost`, `eoa_delegation.py:126`; applied in CALL `system.py:444-455` and DELEGATECALL/STATICCALL `system.py:567-578`):

```
extra_gas += COLD_ACCOUNT_ACCESS (2600) if target not in accessed_addresses
           += WARM_ACCESS (100)        otherwise
```
and adds the target to `accessed_addresses` on first touch.

`basicPrecompileCallTail` (the shared CALL-family front) charged only the callee's own access, never the delegation target's.

## Fix

New `callDelegationAccessChargeAsm` runs right after the callee access charge:
1. resolves the callee's pre-state code via `code_at_header_state_root` (same witness ctx env+576..616 as `callDescendFallThrough`);
2. detects the 23-byte `ef 01 00` delegation marker;
3. charges the trailing-20-byte target (in-place, BE) through `runtime_access_account_charge` (2500 cold + insert / 0 warm) plus a flat **100** to reach the spec's 2600 cold / 100 warm (the 100 dispatcher warm-floor that backs the callee's own access has no counterpart for the delegation target, which the spec charges in full).

A non-delegated callee (status ≠ 0, length ≠ 23, or wrong prefix) charges nothing, so this can only **ADD** a required charge — never a false-accept. Preserves `x10/x12/x13` and the caller's `s9/s10/s11`.

## Validation

Seed 4242 / 500 cases, `origin/main` baseline vs this fix (apples-to-apples, `--jobs 4 --max-jobs 4`):

| metric | origin/main | this fix |
|---|---|---|
| full match | 405 | **409** (+4) |
| errored (system-contract families, unrelated) | 18 | 18 (identical set) |
| false-accepts (`guest=01 exp=00`) | 0 | **0** |

Set diff: **0 regressions** (no FULL→not-FULL), **4 fixes** — exactly the four `bal_7702_delegated_via_call_opcode` opcodes flip FAIL→FULL. Verdict probe confirms gas delta 2600→0 on all four.

No `native_decide`/`bv_decide`/`sorry`; pure assembly-string codegen; build green; forbidden-tactics gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)