### PR TITLE
fix(codegen): skip NEW_ACCOUNT state gas for created-in-tx SELFDESTRUCT beneficiary (EIP-6780 to_self)

### DIFF
--- a/EvmAsm/Codegen/Programs/Selfdestruct.lean
+++ b/EvmAsm/Codegen/Programs/Selfdestruct.lean
@@ -81,6 +81,27 @@ def selfdestructNewAccountSurchargeAsm : String :=
   "  ld t1, 0(t0)\n" ++
   "  beqz t1, .L_selfdestruct_surcharge_done\n" ++
   ".L_selfdestruct_charge_new_account:\n" ++
+  -- coc3g.6 (EIP-6780 self-destruct-to-self / created-in-tx beneficiary): the spec gates the
+  -- NEW_ACCOUNT state-gas charge on `not is_account_alive(beneficiary)` (amsterdam
+  -- vm/instructions/system.py selfdestruct: needs_state_gas). `is_account_alive` consults the LIVE
+  -- state, which includes accounts CREATEd earlier in this same tx (tx_state.created_accounts) --
+  -- but `account_exists_at_header_state_root` / `account_is_empty_at_header_state_root` above only
+  -- see the BLOCK-PRE witness, where a same-tx-created contract is ABSENT. So a SELFDESTRUCT whose
+  -- beneficiary is a same-tx-created contract (e.g. selfdestruct-to-self of a freshly CREATEd child,
+  -- bytecode `30ff`) was wrongly classified as new-account and charged STATE_BYTES_PER_NEW_ACCOUNT
+  -- state gas. That spurious charge both over-counts state gas AND (when it drains the reservoir +
+  -- spills into the frame) derails the SD tail so the created-in-tx deletion was never recorded ->
+  -- the exec-vs-BAL non-storage comparator false-rejected (bv_fail=44). Mirror is_account_alive's
+  -- created_accounts membership: if the beneficiary has a code-effect record (the CREATE deposit
+  -- appended one this tx), it is ALIVE -> skip the charge. find_code_effect_by_address clobbers
+  -- t0-t6 + a0(=x10); save x10/x12 (x20=s4 is preserved by the helper, but the call itself does
+  -- not touch it).
+  "  addi sp, sp, -16\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n" ++
+  "  la a0, exec_code_effect_log\n  la t0, exec_code_effect_count\n  ld a1, 0(t0)\n  la a2, evm_selfdestruct_beneficiary\n" ++
+  "  jal ra, find_code_effect_by_address\n" ++
+  "  mv t1, a0\n" ++
+  "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  addi sp, sp, 16\n" ++
+  "  bnez t1, .L_selfdestruct_surcharge_done\n" ++   -- beneficiary created this tx (alive) -> no NEW_ACCOUNT state gas
   -- nxio8.8 (EIP-8037 state dimension): SELFDESTRUCT to a new (not-alive) beneficiary with a
   -- non-zero originator balance creates the beneficiary account, costing
   -- StateGasCosts.NEW_ACCOUNT = STATE_BYTES_PER_NEW_ACCOUNT(120)*COST_PER_STATE_BYTE(1530) = 183600


### PR DESCRIPTION
## Summary

Finishes the `selfdestruct_same_tx_via_call` family started by #9065 (which fixed the `to_other` half). The 6 `to_self` cases (call_once / call_twice / call_twice_with_value × transfer_during_call / transfer_during_create) false-rejected with **bv_fail=44** (exec-vs-BAL non-storage mismatch). They now pass.

## Root cause

The child contract (bytecode `30ff` = `ADDRESS; SELFDESTRUCT`) is **CREATEd in this tx** then CALLed, and self-destructs to **itself**. Under EIP-6780 a created-in-tx contract that self-destructs is deleted with its balance burned (net-zero balance/nonce/code), so the BAL declares no change for it.

The amsterdam spec gates the NEW_ACCOUNT state-gas charge on `not is_account_alive(beneficiary)` (`vm/instructions/system.py` `selfdestruct: needs_state_gas`). `is_account_alive` consults the **live** state, which includes `tx_state.created_accounts`. The guest's surcharge only consulted the **block-pre witness** (`account_exists_at_header_state_root` / `account_is_empty_at_header_state_root`), where a same-tx-created contract is **absent** — so the self beneficiary (= the just-created child) was wrongly classified as a new account and charged `STATE_BYTES_PER_NEW_ACCOUNT` state gas.

That spurious charge drained the state reservoir / spilled into the frame and derailed the SELFDESTRUCT tail: `x20` (env base) was corrupted before the created-in-tx detection (`find_code_effect_by_address` on `env.ADDRESS`), so `evm_selfdestruct_created_in_tx` was never set, the EIP-6780 deletion record (post nonce/balance → 0/0) was never written, and the comparator saw the CREATE deposit's `nonce 1 / balance endowment` against a silent BAL → bv_fail=44. (Verified by spare-slot verdict-probe instrumentation; all temp instrumentation reverted.)

## Fix

In `selfdestructNewAccountSurchargeAsm`, before charging NEW_ACCOUNT state gas, mirror `is_account_alive`'s `created_accounts` membership: look up the beneficiary in `exec_code_effect_log` (the CREATE deposit appended a record this tx). On a hit the beneficiary is **alive** → skip the charge. This is the exact spec model; it can only remove a spurious charge, never add one, so it cannot introduce a false-accept.

## Validation (EEST `zkevm@v0.4.0`)

- All 12 `selfdestruct_same_tx_via_call` verdict-probe cases now `verdict=1` (the 6 `to_self` flip from bv_fail=44; the 6 `to_other` stay passing).
- Broad sweep `--random --seed 4242 --limit 500 --jobs 4 --max-jobs 4`: full match **428 → 434 (+6)**, fail **54 → 48**, **0 false-accepts** (`guest=01 exp=00` == 0) on both baseline and fix, **0 regression**.
- No `native_decide` / `bv_decide` / `sorry`; build green.

The `selfdestruct_to_self_same_tx` *with_balance* CREATE/CREATE2 cases remain **bv_fail=41** (a distinct pre-existing failure, unchanged by this fix); tracked as a follow-up under `coc3g.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)