### PR TITLE
fix(verdict): roll back exec effect logs on top-level tx abort (bv_fail=44)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -1232,6 +1232,20 @@ def ziskStatelessVerdictV2DataSection : String :=
   ".balign 8\n" ++
   "exec_nonstorage_effect_agg_count:\n  .zero 8\n" ++
   "exec_nonstorage_effect_agg:\n  .zero " ++ toString (nonstorageEffectLogCap * 112) ++ "\n" ++
+  -- fva3w: pre-tx snapshots of the exec effect logs. A top-level tx that REVERTS or
+  -- exceptionally aborts discards ALL its state changes (the spec rolls them back), so the
+  -- value-transfer / CREATE non-storage + code effects recorded during it must be discarded
+  -- too. Child frames already roll back via frame_return; but a top-level abort (INVALID /
+  -- REVERT / OOG at depth 0) takes .exit_*_top with NO frame_return -> the effects survived,
+  -- and the all-accounts non-storage comparator then saw a value change the BAL (correctly,
+  -- net-zero) omitted -> bv_fail=44 (bal_aborted_account_access invalid/revert-call/callcode).
+  -- Snapshot before the tx runtime dispatch; truncate back to it when the tx errored (status 0).
+  ".balign 8\n" ++
+  "bv_tx_effect_snap_ns_count:\n  .zero 8\n" ++
+  "bv_tx_effect_snap_ns_overflow:\n  .zero 8\n" ++
+  "bv_tx_effect_snap_code_count:\n  .zero 8\n" ++
+  "bv_tx_effect_snap_code_next:\n  .zero 8\n" ++
+  "bv_tx_effect_snap_code_overflow:\n  .zero 8\n" ++
   -- bmvmx.5.5.2 (umbrella-B1): scratch for the multi-tx per-sender FINAL-nonce check
   -- (BAL sender post nonce == pre + total sender tx count). bv_b1_finals is the 88-byte
   -- bal_account_nonstorage_finals output (separate from c2nsc_finals, which A2a's

--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -783,6 +783,16 @@ def blockVerdictFunction : String :=
   "  la t0, bv_upfront_islt; ld t0, 0(t0)\n  bnez t0, .Lbv_sender_upfront_fail\n" ++
   ".Lbv_stx_checks_done:\n" ++
   "  jal ra, bv_emit_single_tx_tl7708\n" ++
+  -- fva3w: snapshot the exec effect logs before the contract runtime dispatch. A top-level
+  -- tx that reverts/aborts (INVALID/REVERT/OOG at depth 0) discards its state changes; its
+  -- value-transfer / CREATE effects must be rolled back too (child frames roll back via
+  -- frame_return; the depth-0 .exit_*_top path does not). Truncated after dispatch when the tx
+  -- errored (status 0), exactly as frame_return truncates a reverted child.
+  "  la t0, exec_nonstorage_effect_count; ld t1, 0(t0); la t0, bv_tx_effect_snap_ns_count; sd t1, 0(t0)\n" ++
+  "  la t0, exec_nonstorage_effect_overflow; ld t1, 0(t0); la t0, bv_tx_effect_snap_ns_overflow; sd t1, 0(t0)\n" ++
+  "  la t0, exec_code_effect_count; ld t1, 0(t0); la t0, bv_tx_effect_snap_code_count; sd t1, 0(t0)\n" ++
+  "  la t0, exec_code_effect_next; ld t1, 0(t0); la t0, bv_tx_effect_snap_code_next; sd t1, 0(t0)\n" ++
+  "  la t0, exec_code_effect_overflow; ld t1, 0(t0); la t0, bv_tx_effect_snap_code_overflow; sd t1, 0(t0)\n" ++
   "  la a0, bv_simple_transfer_tx\n" ++
   "  ld a1, 80(s0); ld a2, 88(s0)\n" ++
   "  jal ra, dispatch_tx_runtime_code\n" ++
@@ -796,6 +806,18 @@ def blockVerdictFunction : String :=
   -- raw evm_refund_acc read.
   "  la t4, bv_runtime_refund_counter; sd a3, 0(t4)\n" ++
   "  la t4, bv_tx_status_arr; sd a4, 0(t4)\n" ++   -- .63.1.6.2.1: receipt status, tx 0
+  -- fva3w: the tx errored (a4 == 0 = REVERT / exceptional abort) -> roll back the exec effect
+  -- logs to the pre-tx snapshot, discarding the rolled-back value-transfer / CREATE effects so
+  -- the all-accounts non-storage/code comparators see net-zero for a touched-but-aborted account
+  -- (EIP-7928 records the access in the BAL but the state change is rolled back). Mirrors
+  -- frame_return's reverted-child truncation. a4 != 0 (success) leaves the effects committed.
+  "  bnez a4, .Lbv_tx0_effects_kept\n" ++
+  "  la t0, bv_tx_effect_snap_ns_count; ld t1, 0(t0); la t0, exec_nonstorage_effect_count; sd t1, 0(t0)\n" ++
+  "  la t0, bv_tx_effect_snap_ns_overflow; ld t1, 0(t0); la t0, exec_nonstorage_effect_overflow; sd t1, 0(t0)\n" ++
+  "  la t0, bv_tx_effect_snap_code_count; ld t1, 0(t0); la t0, exec_code_effect_count; sd t1, 0(t0)\n" ++
+  "  la t0, bv_tx_effect_snap_code_next; ld t1, 0(t0); la t0, exec_code_effect_next; sd t1, 0(t0)\n" ++
+  "  la t0, bv_tx_effect_snap_code_overflow; ld t1, 0(t0); la t0, exec_code_effect_overflow; sd t1, 0(t0)\n" ++
+  ".Lbv_tx0_effects_kept:\n" ++
   "  la t4, bv_tx_is_creation_arr; la t5, bv_simple_transfer_tx; ld t5, 48(t5); sd t5, 0(t4)\n" ++
   "  la t4, bv_last_log_start; ld t5, 0(t4); la t4, bv_tx_log_window; sd t5, 0(t4)\n" ++
   "  la t4, bv_last_log_count; ld t5, 0(t4); la t4, bv_tx_log_window; sd t5, 8(t4)\n" ++


### PR DESCRIPTION
## Summary

Fixes the last remaining `eip7928` sub-family on bead `evm-asm-fva3w`:
`bal_aborted_account_access` (bv_fail=44, exec-vs-BAL non-storage).

EIP-7928 records an account in the BAL when it is **accessed** even if the
touching frame later reverts — the state change is rolled back, so the account's
net non-storage effect is zero (the BAL lists it with all-empty changes).

## Root cause

A value-bearing CALL/CALLCODE records the caller-debit and callee-credit
non-storage effects at descent (`ChildFrameHandlers`), **before**
`call_frame_descend` snapshots the effect count. When the **top-level** (depth-0)
tx frame then aborts via INVALID/REVERT/OOG, control takes `.exit_*_top`, which
has **no** `frame_return` and so never truncates the effect logs. The recorded
value transfer survived, and `bal_all_accounts_nonstorage_consistent` found an
exec balance change for the touched-but-reverted callee that the BAL (correctly)
declares net-zero → value mismatch at `.Lc3ns_found` → **bv_fail=44**.

Only the value-transferring `call`/`callcode` variants failed; `delegatecall`/
`staticcall` carry no value and already passed.

## Fix

Snapshot `exec_nonstorage_effect_*` and `exec_code_effect_*` before the contract
runtime dispatch, and truncate them back to the snapshot when the tx errored
(`dispatch_tx_runtime_code` returns `a4 == 0` = REVERT/exceptional). This mirrors
exactly what `frame_return` does for a reverted **child** frame, applied to the
depth-0 tx. Soundness: success (`a4 != 0`) leaves the effects committed unchanged.

## Validation

- 16/16 `bal_aborted_account_access` verdict-probe cases pass.
- seed-4242 / 500 sweep (`--jobs 4 --max-jobs 4`): full match **438 → 444 (+6)**,
  fail 44 → 38, **0 false-accepts** (`guest=01 exp=00` = 0), **0 regression**
  (every changed case flips 0→1 on a genuinely-valid block; root/tail unchanged
  482/482).
- +6 = 4× `bal_aborted_account_access` (invalid/revert × call/callcode) + 2×
  `inner_call_succeeds_outer_reverts_no_log` (same root cause: outer-frame revert).
- `scripts/check-forbidden-tactics.sh` OK; `lake build codegen` green.

Disjoint from open PRs #9069 (Dispatch/ChildFrameHandlers/Selfdestruct) — this
touches only the BAL/verdict exec-effect-rollback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)