### PR TITLE
fix(codegen): OOG on >u64 MLOAD/MSTORE/MSTORE8 memory offset (bv_fail=41)

### DIFF
--- a/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
+++ b/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
@@ -76,11 +76,47 @@ def updateActiveMemorySizeAsm
   "  sd " ++ roundedReg ++ ", " ++ toString activeMemorySizeOff ++ "(x20)\n" ++
   ".Lmemsize_" ++ tag ++ "_done:\n"
 
+/-- OOG guard for a memory access whose length is a NONZERO constant
+    (MLOAD/MSTORE = 32, MSTORE8 = 1). For such accesses the EVM always grows
+    memory to `offset + length`, so an `offset` that does not fit in a u64 — or
+    whose low limb `+ length` wraps — has a memory-expansion cost vastly beyond
+    any block gas limit and exceptionally halts (`evm.gas_left = 0`). The low-
+    limb-only memory-gas path (`updateActiveMemorySizeAsm`) would otherwise read
+    a truncated/wrapped offset and charge trivial gas, under-counting gas_used.
+
+    `offsetReg` already holds the low offset limb (loaded by the caller from
+    `0(x12)`); this reads the three high limbs from `8/16/24(x12)` into
+    `scratchReg` and routes any nonzero high limb — or a `low + length`
+    wraparound — to `.exit_outofgas` (halt_kind 6). `offsetReg` is preserved;
+    `scratchReg` is clobbered. Mirrors the high-limb guards already present in
+    `returnRevertMemoryGasAsm` / `callMemoryExpansionGasAsm`. Sound: it can only
+    turn a should-OOG access from a trivial charge into the correct OOG, so it
+    never lowers gas_used (no false-accept). -/
+def memConstOffsetOogGuardAsm
+    (offsetReg scratchReg : String) (length : Nat) : String :=
+  "  ld " ++ scratchReg ++ ", 8(x12)\n" ++
+  "  bnez " ++ scratchReg ++ ", .exit_outofgas\n" ++
+  "  ld " ++ scratchReg ++ ", 16(x12)\n" ++
+  "  bnez " ++ scratchReg ++ ", .exit_outofgas\n" ++
+  "  ld " ++ scratchReg ++ ", 24(x12)\n" ++
+  "  bnez " ++ scratchReg ++ ", .exit_outofgas\n" ++
+  "  addi " ++ scratchReg ++ ", " ++ offsetReg ++ ", " ++ toString length ++ "\n" ++
+  "  bltu " ++ scratchReg ++ ", " ++ offsetReg ++ ", .exit_outofgas\n"
+
 /-- `updateActiveMemorySizeAsm` for a constant access length (MLOAD/MSTORE =
-    32, MSTORE8 = 1). Materializes the length into `tmpLengthReg` first. -/
+    32, MSTORE8 = 1). Materializes the length into `tmpLengthReg` first.
+
+    For a nonzero `length` it FIRST emits `memConstOffsetOogGuardAsm`, so a
+    256-bit offset that cannot be represented in a u64 (or whose low limb wraps
+    when the length is added) exceptionally halts instead of charging trivial
+    truncated-offset gas. `offsetReg` must already hold the low offset limb and
+    the full 256-bit offset must live at `0(x12)` (as for MLOAD/MSTORE/MSTORE8).
+    `maskReg` doubles as the guard scratch (it is clobbered by the size helper
+    anyway). -/
 def updateActiveMemorySizeConstAsm
     (tag offsetReg tmpLengthReg roundedReg currentReg maskReg gasTmpReg : String)
     (chargeGas : Bool) (length : Nat) : String :=
+  (if length == 0 then "" else memConstOffsetOogGuardAsm offsetReg maskReg length) ++
   "  li " ++ tmpLengthReg ++ ", " ++ toString length ++ "\n" ++
   updateActiveMemorySizeAsm tag offsetReg tmpLengthReg roundedReg currentReg maskReg gasTmpReg chargeGas
 


### PR DESCRIPTION
## Problem

The eip7708 `*_no_log` cluster (and other coc3g/dtrc re-execution false-rejects) reject with **bv_fail=41** (`.Lbv_block_gas_used_over_fail`: `header.gas_used > expected_gas_used`), NOT bv_fail=53 (spurious receipt log). The EIP-7708 transfer log lives in the env-log arena (`env+472`) and is already rolled back on child failure by `frame_return` (it does not merge `s10` when `s0==0`); the receipts comparator never runs because the exact EIP-8037 block-gas check rejects first.

Probe-confirmed on `reverted_transaction_no_log[out_of_gas]`: the recipient runs `PUSH1 0; PUSH32 0xff..ff; MSTORE`. The spec OOGs (gas_used = gas_limit = 100000); the guest computed `expected_gas_used = 21012` (intrinsic only).

## Root cause

`MLOAD`/`MSTORE`/`MSTORE8` loaded only the **low 64-bit limb** of the memory offset (`ld x15, 0(x12)`) and fed it to the memory-expansion gas path. A 256-bit offset with nonzero high limbs truncated to its low limb (and a low limb near `2^64` wrapped when the constant length was added), so the access charged trivial memory-expansion gas instead of exceptionally halting. Per execution-specs such an access costs far beyond any block gas limit and OOGs (`evm.gas_left = 0`, all gas consumed). Under the coc3g/dtrc real-re-execution flip this under-counted runtime gas_used → bv_fail=41.

## Fix

`memConstOffsetOogGuardAsm` (`EvmMemoryGas.lean`) routes any nonzero high offset limb (`8/16/24(x12)`) or a `low + length` wraparound to `.exit_outofgas` before the size/gas update — mirroring the high-limb guards already in `returnRevertMemoryGasAsm` / `callMemoryExpansionGasAsm`. It is emitted by `updateActiveMemorySizeConstAsm` for the nonzero constant lengths (MLOAD/MSTORE = 32, MSTORE8 = 1); the three memory handlers are its only callers and all pass the offset at `0(x12)`.

**Soundness:** the guard can only turn a should-OOG access from a trivial charge into the correct OOG, so it never lowers computed `gas_used` — it cannot introduce a false-accept; it only removes a false-reject.

## Validation

Seed 4242, limit 500, jobs 4, on BOTH plain-main baseline and this fix:

- full-match **444 → 445** (+1); fail 38 → 37
- per-case diff vs plain main: **FLIPPED** = `reverted_transaction_no_log[out_of_gas]`; **REGRESSED = 0**
- **false-accepts (guest=01 exp=00) = 0** on both runs
- `lake build` green; `scripts/check-forbidden-tactics.sh` OK; no `sorry`/`native_decide`/`bv_decide`

The remaining eip7708 `*_no_log` cases (create_out_of_gas, create_collision, create_insufficient_balance, failed_inner_operation, inner_call_succeeds_outer_reverts, initcode_calls_with_value) still bv_fail=41/44 from distinct deeper inner-frame (CREATE/CALL) failed-execution gas-accounting causes — tracked under `evm-asm-coc3g.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)