### PR TITLE
fix(verdict): stage authenticated EIP-7843 slot_number into SLOTNUM env word (eip7843 slotnum_value)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictContractStage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictContractStage.lean
@@ -174,8 +174,23 @@ def stageRuntimePayloadCodeFunction : String :=
   "  li t6, 32; beq t5, t6, .Lsrpc_cv_done\n" ++
   "  add a5, t3, t5; lbu a6, 0(a5); li a5, 31; sub a5, a5, t5; add a5, t4, a5; sb a6, 0(a5); addi t5, t5, 1; j .Lsrpc_cv\n" ++
   ".Lsrpc_cv_done:\n" ++
-  -- Trailer (relative to env_base s5): SLOTNUM@+416 (zero), gas@+448,
-  -- validate@+456, is_creation@+464, witness lens@+472/+480/+488 (zero).
+  -- EIP-7843 SLOTNUM (trailer word @env_base+416, low limb): the block-header
+  -- slot_number (SSZ field 23, u64 LE @exec_payload+532) is authenticated as part
+  -- of the reconstructed header hash (BlockHeaderSszToRlp field 23). The
+  -- dispatcher copies this word to evm_env+624, which h_SLOTNUM pushes. Read the
+  -- u64 byte-wise (LBU): exec_payload = SSZ_BASE+60 is mod-8 = 6, so a direct
+  -- 8-byte ld at +532 (mod 8 = 2) would be a misaligned access (traps in the
+  -- verified RV64 subset). slot is u64 -> only limb0 (the +416 dword) is nonzero;
+  -- the upper 3 limbs stay 0 (payload pre-zeroed). LE source -> LE limb0 directly.
+  "  li t3, 0; li t4, 0\n" ++
+  ".Lsrpc_slot:\n" ++
+  "  li t5, 8; beq t4, t5, .Lsrpc_slot_done\n" ++
+  "  add t5, s2, t4; addi t5, t5, 532; lbu t6, 0(t5); slli a5, t4, 3; sll t6, t6, a5; or t3, t3, t6\n" ++
+  "  addi t4, t4, 1; j .Lsrpc_slot\n" ++
+  ".Lsrpc_slot_done:\n" ++
+  "  sd t3, 416(s5)                       # SLOTNUM limb0 = slot_number (u64 LE)\n" ++
+  -- Trailer (relative to env_base s5): gas@+448, validate@+456, is_creation@+464,
+  -- witness lens@+472/+480/+488 (zero).
   "  ld t3, 40(s1); sd t3, 448(s5)        # gas limit (ctx tx gas)\n" ++
   "  li t3, 1; sd t3, 456(s5)             # validate_tx_gas = 1\n" ++
   "  ld t3, 48(s1); sd t3, 464(s5)        # is_creation\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
@@ -50,7 +50,7 @@ open EvmAsm.Rv64
       +72   u64 current_block_number       (= 0)
       +80   u64 blockhash_count            (= 0)
       +88   13 simple-env words
-      +504  SLOTNUM word                   (= 0)
+      +504  SLOTNUM word                   (EIP-7843 slot_number, exec@532)
       +536  u64 gas_limit                  (= context tx gas limit)
       +544  u64 validate_tx_gas flag       (= 0; see note below)
       +552  u64 is_creation flag           (= 1)
@@ -132,6 +132,20 @@ def stageCreationRuntimePayloadFunction : String :=
   "  addi t1, s1, 96\n" ++
   "  ld t2, 0(t1); sd t2, 96(t6); ld t2, 8(t1); sd t2, 104(t6)\n" ++
   "  ld t2, 16(t1); sd t2, 112(t6); ld t2, 24(t1); sd t2, 120(t6)\n" ++
+  -- EIP-7843 SLOTNUM (trailer word @env_base+416, low limb): block-header
+  -- slot_number (SSZ field 23, u64 LE @exec_payload+532) is authenticated as part
+  -- of the reconstructed header hash. The dispatcher copies this word to
+  -- evm_env+624, which h_SLOTNUM pushes. Read byte-wise (LBU): exec_payload =
+  -- SSZ_BASE+60 is mod-8 = 6, so a direct 8-byte ld at +532 (mod 8 = 2) would be
+  -- misaligned (traps in the verified RV64 subset). slot is u64 -> only limb0
+  -- (+416) is set; upper 3 limbs stay 0 (payload pre-zeroed). LE -> LE limb0.
+  "  li t1, 0; li t2, 0\n" ++
+  ".Lscrp_slot:\n" ++
+  "  li t3, 8; beq t2, t3, .Lscrp_slot_done\n" ++
+  "  add t3, s2, t2; addi t3, t3, 532; lbu t4, 0(t3); slli t5, t2, 3; sll t4, t4, t5; or t1, t1, t4\n" ++
+  "  addi t2, t2, 1; j .Lscrp_slot\n" ++
+  ".Lscrp_slot_done:\n" ++
+  "  sd t1, 416(t6)               # SLOTNUM limb0 = slot_number (u64 LE)\n" ++
   -- Trailer: gas@+448, validate@+456 = 0, is_creation@+464 = 1.
   "  ld t1, 40(s1); sd t1, 448(t6)\n" ++
   "  li t1, 1; sd t1, 464(t6)\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictRuntimePayload.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictRuntimePayload.lean
@@ -44,7 +44,7 @@ open EvmAsm.Rv64
       +80   u64 blockhash_count            (= 0)
       +88   13 simple-env words (416 B)    (COINBASE/TIMESTAMP/NUMBER/
                                             GASLIMIT/BASEFEE staged from exec)
-      +504  SLOTNUM word (32 B)            (= 0)
+      +504  SLOTNUM word (32 B)            (EIP-7843 slot_number, exec@532)
       +536  u64 gas_limit                  (= context tx gas limit)
       +544  u64 validate_tx_gas flag       (= 1)
       +552  u64 is_creation flag           (= context is_creation, 0 here)
@@ -145,6 +145,20 @@ def stageRuntimePayloadFunction : String :=
   "  addi a0, a2, 520; jal ra, bgv_u64le\n" ++                       -- a0 = excess_blob_gas (u64)
   "  addi a1, s0, 32; jal ra, amsterdam_blob_gas_price_u256\n" ++    -- price (u256 BE) -> payload+32 (overflow unreachable for valid blocks)
   "  ld a0, 16(sp)\n" ++                                             -- restore ctx ptr for the trailer
+  -- EIP-7843 SLOTNUM (payload word @+504, low limb): block-header slot_number
+  -- (SSZ field 23, u64 LE @exec_payload+532) is authenticated as part of the
+  -- reconstructed header hash. The dispatcher copies payload+504 -> evm_env+624,
+  -- which h_SLOTNUM pushes. Read byte-wise (LBU): exec_payload = SSZ_BASE+60 is
+  -- mod-8 = 6, so a direct 8-byte ld at +532 (mod 8 = 2) would be misaligned
+  -- (traps in the verified RV64 subset). slot is u64 -> only limb0 (+504) is set;
+  -- upper 3 limbs stay 0 (payload pre-zeroed). LE source -> LE limb0 directly.
+  "  li t0, 0; li t1, 0\n" ++
+  ".Lsrp_slot:\n" ++
+  "  li t2, 8; beq t1, t2, .Lsrp_slot_done\n" ++
+  "  add t2, a2, t1; addi t2, t2, 532; lbu t3, 0(t2); slli t4, t1, 3; sll t3, t3, t4; or t0, t0, t3\n" ++
+  "  addi t1, t1, 1; j .Lsrp_slot\n" ++
+  ".Lsrp_slot_done:\n" ++
+  "  sd t0, 504(s0)               # SLOTNUM limb0 = slot_number (u64 LE)\n" ++
   -- Transaction gas / control trailer.
   "  ld t0, 40(a0)                # context tx gas limit\n" ++
   "  sd t0, 536(s0)               # gas_limit\n" ++


### PR DESCRIPTION
## Problem

EIP-7843 `SLOTNUM` (opcode `0x4b`) returns the block consensus slot number. The dispatcher prologue copies the SLOTNUM env word (`payload+504` -> `evm_env+624`) and `h_SLOTNUM` pushes it. But the verdict re-execution **staged that word as a hardcoded `0`**, so `SLOTNUM` always pushed `0`.

Tests that do `SLOTNUM; PUSH1 0; SSTORE` a non-zero slot therefore recomputed a wrong state root and **false-rejected** (`guest=00`, `exp=01`). 4 fails in `eip7843_slotnum/slotnum/slotnum_value.json`: `slot_4096`, `slot_large`, `slot_max_u64`, `slot_one` (only `slot_zero` passed).

## Fix

The slot is **authenticated**: block-header SSZ field 23 `slot_number` (u64 LE at `exec_payload+532`) is RLP-encoded as header field 23 (`BlockHeaderSszToRlp`), so it is part of the header hash the verdict reconstructs and checks — sound to stage.

All three staging sites now read it into the SLOTNUM word's low limb (slot is u64 -> upper 3 limbs stay 0; LE source -> LE limb0 directly):
- `BlockVerdictContractStage` — recipient-with-code path (the one these tests hit)
- `BlockVerdictRuntimePayload` — EOA STOP path
- `BlockVerdictCreationStage` — CREATE path

### Alignment
`exec_payload = SSZ_BASE+60` is `mod 8 = 6`, so a direct 8-byte `ld` at `+532` (`mod 8 = 2`) is a **misaligned access** (traps in the verified RV64 subset). The slot is read **byte-wise** via an LBU/shift/OR loop, like the existing `sg_load_u32le`/`bgv_u64le` helpers.

## Validation

`scripts/codegen-eest-stateless-check.sh --random --seed 4242 --limit 500 --jobs 4 --max-jobs 4`:

| metric | main (before) | this PR |
|---|---|---|
| full match | 444 | **448** |
| fail | 38 | **34** |
| errored | 18 | 18 |
| false-accepts (`guest=01 exp=00`) | 0 | **0** |

Output-diff vs main: **exactly 4 cases changed**, all `succ 00 -> 01`, and they are precisely the 4 non-zero `slotnum_value` cases. **No other case changed** (0 regressions, 0 new fail families).

Filtered run `--filter slotnum_value`: **5/5 full match** (incl. `slot_zero`).

`lake build` green; `scripts/check-forbidden-tactics.sh` green (no `native_decide`/`bv_decide`/`sorry`).

Closes evm-asm-3ky6s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)