### PR TITLE
fix(verdict): EIP-7928 BAL coinbase-seed + CALLCODE no-transfer (bv_fail=44)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -955,7 +955,16 @@ def blockVerdictFunction : String :=
   "  la t0, i3djw_skip_list\n  la t1, bv_simple_transfer_tx; addi t1, t1, 72\n  li t2, 20\n" ++
   ".Lbv_i3sk0:\n  beqz t2, .Lbv_i3sk0d\n  lbu t3, 0(t1)\n  sb t3, 0(t0)\n  addi t1, t1, 1\n  addi t0, t0, 1\n  addi t2, t2, -1\n  j .Lbv_i3sk0\n.Lbv_i3sk0d:\n" ++
   "  la a1, i3djw_skip_list; addi a1, a1, 32\n  la a0, bv_public_keys_ptr; ld a0, 0(a0); addi a0, a0, 1\n  jal ra, address_from_pubkey\n" ++
-  "  la t0, i3djw_skip_list; addi t0, t0, 64\n  la t1, bmvmx_coinbase_addr\n  li t2, 20\n" ++
+  -- coc3g.BAL: seed skip entry 2 = the block coinbase from the ALWAYS-AVAILABLE exec payload
+  -- (bv_exec_p+32 = fee_recipient), NOT bmvmx_coinbase_addr. The latter is populated only when
+  -- the bmvmx single-tx preamble runs, which BAILS (.Lbmvmx_done) for non-legacy txs (type
+  -- 2930/1559/4844/7702) at BlockVerdictFunction:113 -> for an EIP-2930 access-list tx
+  -- bmvmx_coinbase_addr is left zero and the coinbase (which always receives the priority-fee
+  -- balance change) is not skip-listed -> bv_fail=44 (its fee credit has no per-tx exec
+  -- non-storage effect). The coinbase's post-balance is independently pinned by the state-root
+  -- recompute (which APPLIES the BAL deltas and checks the header root; BlockVerdictStateRoot:268),
+  -- so skip-listing it here is sound (same as sender/recipient — gas/value/fee-coupled).
+  "  la t0, i3djw_skip_list; addi t0, t0, 64\n  la t1, bv_exec_p; ld t1, 0(t1); addi t1, t1, 32\n  li t2, 20\n" ++
   ".Lbv_i3sk2:\n  beqz t2, .Lbv_i3sk2d\n  lbu t3, 0(t1)\n  sb t3, 0(t0)\n  addi t1, t1, 1\n  addi t0, t0, 1\n  addi t2, t2, -1\n  j .Lbv_i3sk2\n.Lbv_i3sk2d:\n" ++
   -- coc3g.6.5: entries 3..7 = the 5 genesis system/predeploy contracts (EIP-2935 history,
   -- EIP-4788 beacon-roots, EIP-7002 withdrawal-req, EIP-7251 consolidation-req, EIP-6110 deposit).

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -379,6 +379,16 @@ def callDescendFallThrough
       "  jal ra, record_nonstorage_effect\n" ++
       "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
       ".Lcd_deb_done_" ++ tag ++ ":\n") ++
+    -- fva3w.BAL: the callee-credit non-storage effect + the EIP-7708 pending transfer log
+    -- below are CALL (mode 0) ONLY. CALLCODE (mode 2) runs the code at `code_address` but
+    -- keeps execution in the caller's context: the spec sets `to = current_target = caller`
+    -- (system.py:537) and process_message moves ether caller->current_target(=caller), a
+    -- net-zero SELF-transfer, and emits NO transfer log (interpreter.py:307-318: the log
+    -- only fires when caller != current_target). The stack `to` word (x12+32) for CALLCODE is
+    -- the CODE address (e.g. 5fecc07e), which receives nothing — recording a balance credit
+    -- for it was a false non-storage effect (the BAL omits it) -> bv_fail=44
+    -- (bal_callcode_nested_value_transfer, nonexistent_account_access_value_transfer-callcode).
+    (if mode != 0 then "" else
     -- i3djw.1: record the value-transfer NON-STORAGE effect for the callee so the
     -- all-accounts non-storage comparator (i3djw.3) can validate it against the BAL.
     -- The callee receives `value`; record (callee, pre_balance, pre+value, nonce, nonce)
@@ -463,7 +473,7 @@ def callDescendFallThrough
     "  addi t0, t0, 1\n  addi t1, t1, 1\n  addi t2, t2, -1\n  j .Lcd_tl_selfchk_" ++ tag ++ "\n" ++
     ".Lcd_tl_notself_" ++ tag ++ ":\n" ++
     "  la t0, cd_xfer_log_pending\n  li t1, 1\n  sd t1, 0(t0)\n" ++
-    ".Lcd_nse_done_" ++ tag ++ ":\n") ++
+    ".Lcd_nse_done_" ++ tag ++ ":\n")) ++
   -- nxio8.8 (EIP-8037): CALL (mode 0) with value!=0 to a not-alive callee creates the
   -- account -> charge_state_gas(NEW_ACCOUNT = STATE_BYTES_PER_NEW_ACCOUNT(120)*COST_PER_STATE_BYTE(1530)
   -- = 183600). Spec vm/instructions/system.py:463-464: `if value != 0 and not is_account_alive(to):


### PR DESCRIPTION
## What

Two cleanly-isolable, fully-validated fixes for **EIP-7928 Block-Access-List** non-storage exec-vs-BAL false-rejects (`bv_fail=44`), diagnosed against the `eip7928_block_level_access_lists` fixtures.

### 1. Coinbase skip-list seed for non-legacy txs (`BlockVerdictFunction.lean`)
The non-storage BAL check's `i3djw_skip_list` entry 2 (block coinbase) was seeded from `bmvmx_coinbase_addr`, which is populated only when the bmvmx preamble runs — but that **bails for non-legacy txs** (type 2930/1559/4844/7702), leaving the entry zero. So for a non-legacy tx the real coinbase's priority-fee balance change had no matching per-tx exec effect → false-reject. Fixed by seeding the coinbase skip entry from the always-available `bv_exec_p+32` (block `fee_recipient`).

**Soundness:** this corrects *which* address the established coinbase-skip pattern skips (the storage check already skips system contracts identically). The coinbase post-balance is independently pinned by the state-root recompute (which applies the BAL deltas and checks the header root), so skipping the real coinbase from the per-tx non-storage comparison cannot hide a discrepancy. Byte-wise address copy (no misaligned load). Validated at 0 false-accepts (below).

### 2. CALLCODE records no value transfer (`ChildFrameHandlers.lean`)
The callee-credit non-storage effect + the EIP-7708 pending transfer log were recorded for both CALL and CALLCODE. Per spec (`system.py` `generic_call`, `instructions/system.py` CALLCODE sets `to = current_target = caller`), CALLCODE is a net-zero self-transfer: no credit to the *code* address, no transfer log. The guest credited the code address, which the BAL correctly omits → false-reject. Gated the credit + pending log to CALL (mode 0) only, matching the existing caller-debit gate.

## Validation

- seed-4242 / 500, `--jobs 4 --max-jobs 4`, foreground: full-match **444 → 450 (+6)**, **false-accepts (`guest=01 exp=00`) = 0**.
- **Per-case output-diff vs main: exactly 6 succ-byte flips, all `00→01`; 0 regressions, 0 root-hash diffs.**
- eip7928 verdict probe (first 150): 0 false-positives; the 3 `bal_7702_*` cases unchanged (left, see below).
- `lake build` clean; `scripts/check-forbidden-tactics.sh` green; no proof/tactic changes.

## Scope / overlap note

- Merges cleanly with the other open PRs (#9070/#9071/#9072) — disjoint file regions (0 conflict markers verified).
- The 6 flips include `bal_aborted_account_access` (×2), which **#9070** also fixes via a different mechanism (rolling back exec effect logs on top-level tx abort). Both fixes are independently sound (0-FA); the cumulative full-match across the two PRs is therefore not naively additive. The flips **unique** to this PR are the CALLCODE cases and the non-legacy-coinbase 2930 cases (`call_opcodes_transfer_log_behavior-CALLCODE`, `call_with_value_to_coinbase_no_priority_fee_log`).

## Left for follow-up (precise ground-truth on bead)

- `bal_7702_*` (bv_fail=34): SSTORE runs in the *delegating* account's storage context but the dispatch's `bal_storage_matches_exec_log` doesn't follow the 7702 delegation / keys by the target — needs the contract-dispatch replay to model 7702 delegated-storage context.
- Secondary `bv_fail=41` (gas over-claim) and `bv_fail=53` (receipts) exposed *behind* these fixes on some 2930/value-transfer cases — deeper gas/receipts reconstruction classes, state root matches (sound, false-reject only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
