### PR TITLE
fix(verdict): exact failed-inner-op gas_used (bv_fail=41 over-claim)

### DIFF
--- a/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
+++ b/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
@@ -76,6 +76,25 @@ def updateActiveMemorySizeAsm
   "  sd " ++ roundedReg ++ ", " ++ toString activeMemorySizeOff ++ "(x20)\n" ++
   ".Lmemsize_" ++ tag ++ "_done:\n"
 
+/-- Guard the HIGH 192 bits of a 256-bit memory offset (stack word at `0(x12)`,
+    low limb at +0, high limbs at +8/+16/+24) for the fixed-length memory opcodes
+    MLOAD/MSTORE/MSTORE8. The access length is a nonzero constant (1 or 32), so the
+    EVM always touches memory and `offset + length` must fit the memory cost model;
+    any offset >= 2^64 (a nonzero high limb) makes the word count and quadratic
+    memory-expansion cost astronomically large — execution-specs
+    `calculate_gas_extend_memory` then OOGs on `charge_gas`. So route a nonzero high
+    limb straight to `.exit_outofgas` (matching the existing high-limb guards in
+    `returnRevertMemoryGasAsm` / `callMemoryExpansionGasAsm` / `keccakRangeGuardAsm`,
+    which `updateActiveMemorySizeAsm` itself does NOT perform — it only sees the low
+    limb). `tmpReg` is clobbered; must be free before `updateActiveMemorySize*`. -/
+def fixedMemoryOffsetHighLimbGuardAsm (tmpReg : String) : String :=
+  "  ld " ++ tmpReg ++ ", 8(x12)\n" ++
+  "  bnez " ++ tmpReg ++ ", .exit_outofgas\n" ++
+  "  ld " ++ tmpReg ++ ", 16(x12)\n" ++
+  "  bnez " ++ tmpReg ++ ", .exit_outofgas\n" ++
+  "  ld " ++ tmpReg ++ ", 24(x12)\n" ++
+  "  bnez " ++ tmpReg ++ ", .exit_outofgas\n"
+
 /-- `updateActiveMemorySizeAsm` for a constant access length (MLOAD/MSTORE =
     32, MSTORE8 = 1). Materializes the length into `tmpLengthReg` first. -/
 def updateActiveMemorySizeConstAsm

--- a/EvmAsm/Codegen/Programs/EvmMemoryHandlers.lean
+++ b/EvmAsm/Codegen/Programs/EvmMemoryHandlers.lean
@@ -31,6 +31,7 @@ def memoryHandlers : List OpcodeHandlerSpec :=
     { label   := "h_MLOAD"
       opcodes := [0x51]
       preBody := stackUnderflowGuardAsm 1 ++ "\n" ++
+                 fixedMemoryOffsetHighLimbGuardAsm "x16" ++
                  "  ld x15, 0(x12)\n" ++
                  updateActiveMemorySizeConstAsm "mload" "x15" "x16" "x17" "x18" "x19" "x6" true 32
       body    := EvmAsm.Evm64.evm_mload .x15 .x16 .x17 .x18 .x13
@@ -40,6 +41,7 @@ def memoryHandlers : List OpcodeHandlerSpec :=
     { label   := "h_MSTORE"
       opcodes := [0x52]
       preBody := stackUnderflowGuardAsm 2 ++ "\n" ++
+                 fixedMemoryOffsetHighLimbGuardAsm "x16" ++
                  "  ld x15, 0(x12)\n" ++
                  updateActiveMemorySizeConstAsm "mstore" "x15" "x16" "x17" "x18" "x19" "x6" true 32
       body    := EvmAsm.Evm64.evm_mstore .x15 .x14 .x16 .x17 .x18 .x13
@@ -48,6 +50,7 @@ def memoryHandlers : List OpcodeHandlerSpec :=
     { label   := "h_MSTORE8"
       opcodes := [0x53]
       preBody := stackUnderflowGuardAsm 2 ++ "\n" ++
+                 fixedMemoryOffsetHighLimbGuardAsm "x16" ++
                  "  ld x15, 0(x12)\n" ++
                  updateActiveMemorySizeConstAsm "mstore8" "x15" "x16" "x17" "x18" "x19" "x6" true 1
       body    := EvmAsm.Evm64.evm_mstore8 .x15 .x14 .x18 .x13


### PR DESCRIPTION
## Summary

The fixed-length memory opcodes **MLOAD (0x51)**, **MSTORE (0x52)**, **MSTORE8 (0x53)** in the runtime dispatcher loaded only the LOW 64-bit limb of the 256-bit memory offset and never checked the high 192 bits before charging memory-expansion gas. An offset `>= 2^64` therefore wrapped in the low-limb arithmetic and silently "succeeded" instead of exceptionally halting — so the guest UNDER-computed `header.gas_used` and false-rejected with `bv_fail=41` (`.Lbv_block_gas_used_over_fail`, header.gas_used > guest's computed max(block_regular, block_state)).

## Spec model (execution-specs amsterdam, authoritative `origin/forks/amsterdam`)

`calculate_gas_extend_memory`: for a nonzero constant access length (1 or 32) the EVM always touches `offset + length`. For any offset `>= 2^64`, words `>= 2^59` and the quadratic memory cost is `~6.5e32` gas — astronomically larger than any block gas limit (`~2e8`) — so `charge_gas` always raises `OutOfGasError`. The frame's remaining regular gas is then fully burned (`interpreter.py`: `evm.regular_gas_used += evm.gas_left; evm.gas_left = Uint(0)`), and `tx_regular_gas = intrinsic.regular + regular_gas_used` becomes the full frame budget.

## Fix

Add `fixedMemoryOffsetHighLimbGuardAsm` (EvmMemoryGas.lean) which routes a nonzero high offset limb straight to `.exit_outofgas` — mirroring the high-limb guards that already exist in `returnRevertMemoryGasAsm` / `callMemoryExpansionGasAsm` / `keccakRangeGuardAsm` (and which `updateActiveMemorySizeAsm` itself does NOT perform — it only sees the low limb). Wired into the three handlers' `preBody` (EvmMemoryHandlers.lean).

## Soundness

The guard can ONLY add OOG-rejection for offsets the spec already OOGs:
- It cannot **false-accept** — it only raises the reconstructed `gas_used`.
- It cannot **false-reject a valid block** — no valid block has a `>= 2^64` fixed-memory offset (the gas cost is `~6.5e32`, impossible under any block gas limit).

## Validation

- **eip7708 `*_no_log` family, main-vs-fix per-case output diff**: EXACTLY one case changes — `test_reverted_transaction_no_log[out_of_gas]` succ `00 -> 01` (guest gas_used 21012 -> spec 100000 = tx.gas); all other cases byte-identical. full-match 17 -> 18, **0 false-accepts**.
- **500-case random sweep (seed 4242)**: **0 false-accepts**, full-match 445 (errored=18 are pre-existing system-contract BUDGET cases, unrelated).
- Handler-level body proofs (`HandlerSpecs.lean`) are decoupled from `preBody`, so unaffected; `scripts/check-forbidden-tactics.sh` green.

## Out of scope (diagnosed, not fixed here)

The other eip7708 `*_no_log` `bv_fail=41` cases — `create_out_of_gas` (×2) and `call_insufficient_balance` — are blocked on **live per-frame balance** (the CREATE handler bails on the WITNESS balance, which is 0, instead of the live balance = pre + tx.value, so it never descends to burn the inner CREATE's gas) and **inner-CALL gas accounting**. These are the structural `coc3g.13`/`.14` items, not this opcode-metering gap. The remaining `*_no_log` failures are `bv_fail=44` (BAL nonstorage), a different track.

Refs: `evm-asm-coc3g.7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)