### PR TITLE
fix(verdict): CREATE value gate uses live balance (exact failed-initcode gas, bv_fail=41)

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
@@ -102,21 +102,29 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     "  addi x18, x18, 1\n" ++
     "  addi x23, x23, -1\n" ++
     "  bnez x23, 10b\n" ++
-    "  mv s9, x13\n" ++
-    "  mv s10, x10\n" ++
-    "  mv s11, x12\n" ++
-    "  ld a0, 576(x20)\n" ++
-    "  ld a1, 584(x20)\n" ++
-    "  la a2, create_sender_be\n" ++
-    "  ld a3, 592(x20)\n" ++
-    "  ld a4, 600(x20)\n" ++
-    "  la a5, create_balance_be\n" ++
-    "  jal x1, balance_at_header_state_root\n" ++
-    "  mv t0, a0\n" ++
-    "  mv x13, s9\n" ++
-    "  mv x10, s10\n" ++
-    "  mv x12, s11\n" ++
-    "  bnez t0, 7f\n" ++
+    -- coc3g.6 / coc3g.7: value-sufficiency gate uses the creator's LIVE balance, NOT the
+    -- witness pre-state balance. The spec's generic_create checks
+    -- `get_account(tx_state, sender).balance < endowment` against the LIVE mutable tx state
+    -- (amsterdam vm/instructions/system.py:108-119), and the endowment DEBIT below
+    -- (.Lcr_deb_done, lines ~256-276) already debits the LIVE balance env+32 (.selfBalance).
+    -- The previous gate compared the witness pre-state balance (balance_at_header_state_root)
+    -- against the endowment, which falsely bailed when the creator is funded THIS tx (e.g. the
+    -- tx.to recipient does CREATE(value): witness balance = 0 but live balance = pre + tx.value).
+    -- That false bail skipped the entire CREATE descend, so a failing initcode (OOG / invalid
+    -- opcode) never burned its child-frame gas allotment -> parent gas_used under-charged
+    -- (create_out_of_gas: recomputed 30111 vs spec 311927, bv_fail=41).
+    -- env+32 (.selfBalance) is LITTLE-ENDIAN (byte 0 = LSB); reverse env[32..63] -> create_balance_be
+    -- (BE, byte 31 = LSB) so the byte-wise compare below (BE vs create_value_be BE) is correct.
+    "  addi x18, x20, 63\n" ++
+    "  la x19, create_balance_be\n" ++
+    "  li x23, 32\n" ++
+    "12:\n" ++
+    "  lbu x24, 0(x18)\n" ++
+    "  sb x24, 0(x19)\n" ++
+    "  addi x18, x18, -1\n" ++
+    "  addi x19, x19, 1\n" ++
+    "  addi x23, x23, -1\n" ++
+    "  bnez x23, 12b\n" ++
     "  la x18, create_balance_be\n" ++
     "  la x19, create_value_be\n" ++
     "  li x23, 32\n" ++


### PR DESCRIPTION
## Problem

The CREATE-family handler (`createUnsupportedTail` in
`EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean`) gated the
insufficient-balance zero-result branch on the creator's **witness
(pre-state) balance** (`balance_at_header_state_root`), comparing it to
the endowment and bailing to the push-0 path on a shortfall.

This diverges from execution-specs amsterdam `generic_create`
(`vm/instructions/system.py:108-119`), which checks
`get_account(tx_state, sender).balance < endowment` against the **LIVE**
mutable tx state. The endowment **debit** later in the very same handler
already operates on the live balance `env+32` (.selfBalance).

A creator funded **this tx** (e.g. the `tx.to` recipient that runs
`CREATE(value)`) has witness balance `0` but live balance
`pre + tx.value`, so the old gate **falsely bailed** and skipped the
entire CREATE descend. A failing initcode (OOG / invalid opcode /
oversized code-deposit) therefore never burned its child-frame gas
allotment, and the parent's reported `gas_used` under-charged.

Confirmed via the `zisk_stateless_verdict_v2` probe — `create_out_of_gas`:
recomputed `gas_used = 30111` vs spec `311927`, `bv_fail=41`; the gate
bailed (`wbal_bail=1`) and never descended (`descend=0`).

## Fix

Stage the live balance `env+32` (LE) reversed into `create_balance_be`
(BE) and run the existing byte-wise `< endowment` compare — exactly
mirroring the live-balance endowment debit below it. The existing
descend infrastructure (`create_frame_descend` + dispatch loop) already
burns the child OOG gas correctly once the gate lets it through, so
**issue 2 (exact OOG gas) needs no further change** — the recomputed
gas matches the spec to the unit once descend happens.

## Validation

`scripts/codegen-eest-stateless-check.sh --random --seed 4242 --limit 500
--jobs 4 --max-jobs 4`, per-case **output-diff of the shipped guest vs
main**:

- **3 succ-bit flips, all `00 -> 01`**, all matching the expected bit:
  `create_out_of_gas[create_out_of_gas_code_deposit / memory_expansion /
  invalid_opcode]`. Recomputed `gas_used` **exactly** equals the spec
  header `gas_used` (311927 / 311928 / 311927).
- **479 cases byte-identical to main**, **0 non-succ byte diffs**,
  **0 regressions** (no `01 -> 00`).
- **0 false-accepts** (`guest=01 exp=00` == 0).
- The true insufficient-balance cases still correctly bail (live balance
  `1` / `0` < endowment), so no soundness loss.

`scripts/check-forbidden-tactics.sh` green; `lake build` clean.

## Out of scope (next)

- `failed_inner_operation[call_insufficient_balance]` (bv_fail=41) is the
  **CALL** analog (not CREATE) — different path (CALL value gate), not
  touched here.
- `initcode_calls_with_value` / `failed_inner_operation` reverted/OOG
  CALL cases remain `bv_fail=44` (exec-vs-BAL nonstorage balance), which
  already descend and are unrelated to this gate.

bead: coc3g.6 / coc3g.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)