### PR TITLE
fix(verdict): exact gas for insufficient-balance value-CALL (bv_fail=41)

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -290,7 +290,7 @@ def callDescendFallThrough
     "  li t2, 32\n" ++
     ".Lcd_cmp_" ++ tag ++ ":\n" ++
     "  lbu t3, 0(t0)\n  lbu t4, 0(t1)\n" ++
-    "  bltu t3, t4, .Lcd_fail_" ++ tag ++ "\n" ++     -- balance < value: insufficient
+    "  bltu t3, t4, .Lcd_insuffbal_" ++ tag ++ "\n" ++ -- balance < value: insufficient (charge the value-CALL net gas, then fail)
     "  bltu t4, t3, .Lcd_balok_" ++ tag ++ "\n" ++    -- balance > value: sufficient
     "  addi t0, t0, 1\n  addi t1, t1, 1\n  addi t2, t2, -1\n" ++
     "  bnez t2, .Lcd_cmp_" ++ tag ++ "\n" ++
@@ -626,6 +626,29 @@ def callDescendFallThrough
   "  sd x0, 0(x12); sd x0, 8(x12); sd x0, 16(x12); sd x0, 24(x12)\n" ++
   "  addi x10, x10, 1\n" ++
   "  j .dispatch_loop\n" ++
+  -- coc3g.7 (bv_fail=41): a value-bearing CALL (mode 0/2) whose caller balance < value
+  -- still pays the value-transfer REGULAR gas, then fails (push 0). The balance gate jumps
+  -- here (NOT to the shared .Lcd_fail_) so this charge does NOT touch the depth-gate or the
+  -- code-resolution-failure (status 2/3/4/5) arrivals, which the spec does NOT bill the
+  -- value-transfer gas. Spec vm/instructions/system.py: charge_gas(extra_gas = access +
+  -- CALL_VALUE(9000)) and charge_gas(message_call_gas.cost) run BEFORE the
+  -- `sender_balance < value` check (system.py:464/477/488); on insufficient balance only the
+  -- sub-call gas (forwarded gas + GAS_CALL_STIPEND(2300)) is returned
+  -- (`evm.gas_left += message_call_gas.sub_call`), so the NET regular consumed for the value
+  -- transfer is 9000 - 2300 = 6700 (access is already charged via runtime_access_account_charge
+  -- before the gate; the value!=0 gate guard guarantees value>0 here so the 6700 is
+  -- unconditional). Without it the reconstructed block_regular_gas under-counts by 6700 ->
+  -- header.gas_used appears to over-claim -> .Lbv_block_gas_used_over_fail (bv_fail=41:
+  -- failed_inner_operation_no_log call_insufficient_balance). The spec's prior
+  -- charge_gas(extra_gas) would have OOG'd if gas_left < 6700, so bailing to .exit_outofgas
+  -- matches the spec. x12 is still the parent stack top; jump back to .Lcd_fail_ to pop+push 0.
+  (if valueBearing then
+     ".Lcd_insuffbal_" ++ tag ++ ":\n" ++
+     "  li t0, 6700\n" ++
+     "  ld t1, 568(x20)\n  bltu t1, t0, .exit_outofgas\n" ++
+     "  sub t1, t1, t0\n  sd t1, 568(x20)\n" ++
+     "  j .Lcd_fail_" ++ tag ++ "\n"
+   else "") ++
   -- empty code (EOA): the call succeeds, runs nothing → push 1
   ".Lcd_empty_" ++ tag ++ ":\n" ++
   -- bnctz: a value-bearing CALL (mode 0) to an empty/non-existent callee still pays the


### PR DESCRIPTION
## Problem

`failed_inner_operation_no_log[call_insufficient_balance]` (EIP-7708 transfer-logs) false-rejected with **bv_fail=41** (`.Lbv_block_gas_used_over_fail`: header.gas_used > reconstructed max(block_regular, block_state)). Ground truth: **spec gas_used=30321 vs guest=23621** — the guest under-charged by exactly **6700**. State root matched the payload; a pure gas false-reject.

## Root cause

A value-bearing CALL/CALLCODE whose caller balance < transfer value still pays the value-transfer REGULAR gas per execution-specs Amsterdam:
- `charge_gas(extra_gas = access + CALL_VALUE(9000))` and `charge_gas(message_call_gas.cost)` run **BEFORE** the `sender_balance < value` check (`vm/instructions/system.py` 464/477/488);
- on insufficient balance only the sub-call gas (`forwarded gas + GAS_CALL_STIPEND(2300)`) is returned (`evm.gas_left += message_call_gas.sub_call`).

Net regular consumed for the value transfer = `CALL_VALUE - GAS_CALL_STIPEND = 9000 - 2300 = 6700`.

The guest's balance gate jumped straight to the shared `.Lcd_fail_` pop/push-0 path, charging nothing for the value transfer — so the reconstructed `block_regular_gas` was 6700 short. (The cold access cost 2600 was already charged via `runtime_access_account_charge` before the gate; the empty-callee fast path `.Lcd_empty_` already charged the 6700, but the insufficient-balance path did not.)

## Fix

`EvmAsm/Codegen/Programs/ChildFrameHandlers.lean` (`callDescendFallThrough`): route the insufficient-balance branch to a new `.Lcd_insuffbal_` label that charges the 6700 net value-transfer gas (mirroring the empty-callee fast path), then jumps to `.Lcd_fail_`. The label is reached **only** by the balance-gate branch, so the depth-gate and the code-resolution-failure (status 2/3/4/5) arrivals at `.Lcd_fail_` are unaffected — the spec does not bill the value-transfer gas there. The `value!=0` gate guard guarantees `value>0`, so the 6700 is unconditional; `.exit_outofgas` on `gas_left < 6700` matches the spec's prior `charge_gas(extra_gas)` OOG. Aligned-safe (8-aligned `ld`/`sd` at `568(x20)`).

## Validation (EEST zkevm@v0.4.0, `--random --seed 4242 --limit 500 --jobs 4`)

- Target flips **00→01** with **exact** spec gas_used=30321.
- Full-match **459 → 460**; fail 23 → 22.
- **0 false-accepts** (`guest=01 exp=00` == 0).
- Per-case output-diff vs `main`: **exactly one** case changes — the intended flip. No regressions (an earlier draft regressed two 7702-delegated value-0 CALL cases via a fall-through; the relocated label fixes that).
- `check-forbidden-tactics.sh` green; no `native_decide`/`bv_decide`/`sorry`.

Updates bead `coc3g.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)