### PR TITLE
fix(verdict): exact gas on CREATE/CREATE2 EIP-684 collision (bv_fail=41)

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
@@ -88,6 +88,32 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     "  addi x18, x18, 1\n" ++
     "  addi x23, x23, -1\n" ++
     "  bnez x23, 2b\n" ++
+    -- coc3g.7: pay-before-execute NEW_ACCOUNT state gas, mirroring spec generic_create
+    -- (amsterdam vm/instructions/system.py:88-93 `charge_state_gas(STATE_BYTES_PER_NEW_ACCOUNT
+    -- * COST_PER_STATE_BYTE)` = 120*1530 = 183600), which runs BEFORE the balance/nonce/depth
+    -- bail AND the EIP-684 code-or-nonce collision check. When the reservoir + regular gas_left
+    -- cannot cover that charge the spec raises OutOfGasError: an exceptional halt that burns ALL
+    -- remaining regular gas (interpreter.py: `evm.regular_gas_used += evm.gas_left;
+    -- evm.gas_left = 0`). On the committing path the charge itself is applied later (the
+    -- liStateGasRuntime drain at .5c, which subtracts the same 183600), and on every BAIL path
+    -- (balance/nonce/collision) the spec charges then immediately refunds it (net 0 on
+    -- state_gas_used) -- so the ONLY observable effect of this early charge is the OOG abort.
+    -- Modelling that abort here (route to .exit_outofgas = halt_kind 6 -> dispatcher_tx_gas_settle
+    -- burns all gas) is the missing piece for create_collision_no_log (CREATE/CREATE2): the spec
+    -- OOGs at charge_state_gas before the collision branch, consuming the full gas limit, while
+    -- the guest previously took the cheap collision push-0 path -> under-charged header.gas_used.
+    -- Gated on the account-witness context (env+584) like the balance/collision checks; a
+    -- pure-arithmetic guard that can only ADD a required abort, never weaken one (soundness:
+    -- never admits a block the spec rejects). Clobbers t0/t1; a1 is reloaded by the gate below.
+    "  ld a1, 584(x20)\n" ++
+    "  beqz a1, .Lcr_csg_oog_ok_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
+    liStateGasRuntime "t0" amsterdamStateBytesPerNewAccountV2 ++   -- t0 = NEW_ACCOUNT state gas = 120*1530 = 183600
+    "  la t1, evm_state_gas_left; ld t1, 0(t1)\n" ++
+    "  bgeu t1, t0, .Lcr_csg_oog_ok_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++   -- reservoir alone covers it
+    "  sub t0, t0, t1\n" ++                                          -- remaining after draining the reservoir
+    "  ld t1, 568(x20)\n" ++                                         -- regular gas_left
+    "  bltu t1, t0, .exit_outofgas\n" ++                             -- reservoir + gas_left < 183600 -> exceptional halt
+    ".Lcr_csg_oog_ok_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
     -- With account-witness context, enforce the executable-spec
     -- insufficient-balance zero-result branch before deriving success.
     "  ld a1, 584(x20)\n" ++


### PR DESCRIPTION
## Problem

`create_collision_no_log` (CREATE + CREATE2) false-rejected with `bv_fail=41` (guest under-computes block regular gas). The guest reconstructed `header.gas_used` ~30023 while the block header expects the full gas limit (200000). State root matches; this is purely a gas-metering divergence.

## Root cause

The CREATE family tail (`createUnsupportedTail`) charged the NEW_ACCOUNT state gas (`120 * 1530 = 183600`) only on the **committing** path and only **after** the EIP-684 collision check. The spec's `generic_create` (execution-specs amsterdam `vm/instructions/system.py:88-93`) charges `charge_state_gas(NEW_ACCOUNT)` **first** — before the balance/nonce/depth bail AND the collision check.

For this fixture the state-gas charge cannot be afforded (`gas_left 169977 < 183600`), so the spec raises `OutOfGasError` **before reaching the collision branch**. That exceptional halt burns all remaining regular gas (`interpreter.py: evm.regular_gas_used += evm.gas_left; evm.gas_left = 0`), so `header.gas_used` = full gas limit. The guest instead took the cheap collision push-0 path (~30023 gas), under-charging.

Confirmed by running execution-specs amsterdam directly on the fixture (both CREATE and CREATE2 OOG at `charge_state_gas` before the collision check).

## Fix

A pure-arithmetic early guard in `createUnsupportedTail`, placed right before the balance/nonce/collision checks (mirroring the spec's `charge_state_gas`-first order). Gated on the account-witness context (`env+584`), it routes to `.exit_outofgas` (halt_kind 6 → `dispatcher_tx_gas_settle` burns all gas) when `evm_state_gas_left + gas_left < 183600`.

- On every bail path the spec charges-then-refunds the state gas (net 0 `state_gas_used`), so the only observable effect of the early charge is this OOG abort.
- On the committing path the charge is still applied later at `.5c` (the same 183600), and the guard only passes when the charge is affordable.
- The guard can only **add** a required abort, never weaken one → sound (never admits a block the spec rejects).

A dedicated guard (not the shared `7f` fail label) keeps the other `7f` arrivals (insufficient-balance / nonce-overflow / well-gassed collision) untouched.

## Validation

- `lake build` clean; `scripts/check-forbidden-tactics.sh` green.
- Both target cases flip `00→01` (full-match) with exact gas.
- Sweep (`--random --seed 4242 --limit 500 --jobs 4 --max-jobs 4`): full-match **462 → 464** (+2), **0 false-accepts** (`guest=01 exp=00` = 0). 18 fails on both = `ERROR(exit)` external-kill noise on heavy BAL fixtures (not correctness).
- **Per-case output-diff vs main (all 482 common cases): exactly 2 cases differ, both intended** (`create_collision_no_log` CREATE + CREATE2, succ `0→1`); 0 other cases changed.

Closes the `create_collision_no_log` slice of bead `coc3g.7`. (The well-gassed collision variants — `burned_gas_counted`, `init_collision` — hit a distinct root: the collision branch's `regular_gas_used += create_message_gas` consumption; left for a follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)