### PR TITLE
fix(verdict): key EIP-7702 delegated SSTORE storage by the delegating EOA (bv_fail=34)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -1119,6 +1119,12 @@ def ziskStatelessVerdictV2DataSection : String :=
   "dtrc_recipkey:\n  .zero 32\n" ++
   "dtrc_threadval:\n  .zero 32\n" ++
   "dtrc_slotkey_le:\n  .zero 32\n" ++   -- ogjan: LE byte-reverse of bvcd_keys[i] for the exec_log_latest_value slotKey match
+  -- coc3g.5: 20-byte EIP-7702 delegated TARGET address scratch. When the recipient's
+  -- resolved code is a 0xef0100||target marker (a prior-block-delegated EOA), the
+  -- dispatch follows the marker to the target's code while keeping env.ADDRESS = the
+  -- delegating EOA (so SSTORE keys the EOA's storage, per interpreter.py message setup).
+  ".balign 8\n" ++
+  "dtrc_deleg_target:\n  .zero 32\n" ++
   -- bmvmx.1.4.4: single-tx EOA settlement scalars precomputed before
   -- block_state_root (additive; no consumer yet -> verdict byte-identical).
   -- Consumed later by .4.1/.4.2 to build execution-derived sender/coinbase leaves.

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -233,6 +233,40 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  la t0, svf_codes_ptr; ld a5, 0(t0); la t0, svf_codes_len; ld a6, 0(t0)\n" ++
   "  jal ra, code_at_header_state_root\n" ++
   "  bnez a0, .Ldtrc_code_lookup_unsupported\n" ++
+  -- coc3g.5: EIP-7702 prior-block delegation follow. The DIRECT recipient code lookup
+  -- (this path, taken when the recipient was NOT delegated in THIS block) may return a
+  -- 0xef0100||target marker (23 bytes) — a prior-block-delegated EOA whose pre/post-state
+  -- code is the delegation designator. The spec (interpreter.py process_message) runs the
+  -- DELEGATED TARGET's code while keeping current_target = the delegating EOA, so
+  -- env.ADDRESS (stage_runtime_payload_code ADDRESS@0 = ctx+72 = the EOA) is UNCHANGED and
+  -- SSTORE keys the EOA's own storage; only message.code is re-pointed at the target's
+  -- code. Without this the marker bytes ran as bytecode (no SSTORE), so the EOA's BAL
+  -- storage_change was absent from the exec log -> bv_fail=34. Follow is applied ONLY here
+  -- (not on the same-block-delegation path below, which already resolved the one-hop
+  -- target code): EIP-7702 delegation is single-hop, never recursively chained.
+  "  la t0, cahsr_code_length; ld t2, 0(t0); li t3, 23; bne t2, t3, .Ldtrc_have_code\n" ++
+  "  la t0, svf_codes_ptr; ld t1, 0(t0); la t2, cahsr_code_offset; ld t3, 0(t2); add t4, t1, t3\n" ++
+  "  lbu t2, 0(t4); li t3, 0xef; bne t2, t3, .Ldtrc_have_code\n" ++
+  "  lbu t2, 1(t4); li t3, 0x01; bne t2, t3, .Ldtrc_have_code\n" ++
+  "  lbu t2, 2(t4); bnez t2, .Ldtrc_have_code\n" ++
+  -- Copy the 20-byte target address (marker bytes 3..22) into dtrc_deleg_target.
+  "  la t1, dtrc_deleg_target; addi t5, t4, 3; li t6, 20\n" ++
+  ".Ldtrc_deleg_copy:\n" ++
+  "  beqz t6, .Ldtrc_deleg_copied\n" ++
+  "  lbu t2, 0(t5); sb t2, 0(t1); addi t5, t5, 1; addi t1, t1, 1; addi t6, t6, -1; j .Ldtrc_deleg_copy\n" ++
+  ".Ldtrc_deleg_copied:\n" ++
+  -- Re-resolve the TARGET's code against the same header the recipient resolved under.
+  "  la t0, dtrc_hdr_ptr; ld a0, 0(t0); la t0, dtrc_hdr_len; ld a1, 0(t0)\n" ++
+  "  la a2, dtrc_deleg_target\n" ++
+  "  mv a3, s0; mv a4, s1\n" ++
+  "  la t0, svf_codes_ptr; ld a5, 0(t0); la t0, svf_codes_len; ld a6, 0(t0)\n" ++
+  "  jal ra, code_at_header_state_root\n" ++
+  "  bnez a0, .Ldtrc_code_lookup_unsupported\n" ++
+  -- Warm the delegated target (EIP-2929 accessed_addresses.add(delegated_address)).
+  "  la a0, dtrc_deleg_target; la a1, " ++ runtimeAccessAccountTableLabel ++ "\n" ++
+  "  la a2, " ++ runtimeAccessAccountCountLabel ++ "\n" ++
+  "  li a3, " ++ toString runtimeAccessAccountCapacity ++ "\n" ++
+  "  jal ra, runtime_access_account_seed\n" ++
   "  j .Ldtrc_have_code\n" ++
   ".Ldtrc_same_block_delegation_code:\n" ++
   "  la t0, sv_pre_rlp_ptr; ld t1, 0(t0); la t2, dtrc_hdr_ptr; sd t1, 0(t2)\n" ++


### PR DESCRIPTION
## Problem

A transaction whose `to` is a **prior-block-delegated EOA** (its code is the `0xef0100||target` EIP-7702 delegation marker) reached the contract-dispatch path but **executed the 23-byte marker bytes as bytecode** rather than following the delegation. The marker produced no SSTORE, so the EOA's BAL `storage_change` was absent from the persistent exec log and `bal_storage_matches_exec_log` rejected with **bv_fail=34** — even though the recomputed state root matched the payload (a false-reject).

## Spec

execution-specs amsterdam `vm/interpreter.py::process_message`: when a delegated account is called,
```python
delegated_address = get_delegated_code_address(message.code)
if delegated_address is not None:
    message.accessed_addresses.add(delegated_address)
    message.code = get_code(tx_state, get_account(tx_state, delegated_address).code_hash)
    message.code_address = delegated_address
```
`message.code` is re-pointed at the delegated TARGET's code, but `message.current_target` (the storage context) **stays the delegating EOA**. So SSTORE keys the EOA's own storage.

The guest already stages `env.ADDRESS` = the recipient EOA (`stage_runtime_payload_code` ADDRESS@0 = ctx+72), so storage keying was already correct; the only missing piece was running the TARGET's code instead of the marker.

## Fix

In `dispatch_tx_runtime_code`, on the **direct recipient code lookup** branch (taken when the recipient was not delegated in *this* block), detect a 23-byte `0xef0100||target` marker, re-resolve the target's code via `code_at_header_state_root`, warm the delegated target (EIP-2929 `accessed_addresses`), and dispatch the target's code in the EOA's storage context. Applied **only** on the direct-lookup branch — the same-block-delegation path already resolves the one-hop target; EIP-7702 delegation is single-hop, never recursively chained.

## Validation

- `bal_7702_delegated_storage_access` flips `00→01`; the full 105-byte guest output **byte-matches** the EEST `statelessOutputBytes` (including `successful_validation=01`).
- Seed-4242 limit-500 sweep: **full match 463** (≥462 baseline), succ match 463, **0 false-accepts** (`guest=01 exp=00` == 0).
- Per-case output-diff vs `main` over all 20 `bal_7702` cases: **only** `bal_7702_delegated_storage_access` changed; the other 19 byte-identical.
- `scripts/check-forbidden-tactics.sh` green. Address copy is byte-wise (`lbu`/`sb`) — no misaligned RV64 loads.

## Out of scope

The `bal_7702_multi_hop_delegation_chain` chain/loop variants remain bv_fail=34: their `tx.to` is a *real contract* that CALLs into delegated EOAs, requiring nested-CALL frame descent through delegation — a separate, larger executor-replay path (tracked under coc3g.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)