### PR TITLE
fix(verdict): roll back nonstorage effects for failed inner value-CALLs (bv_fail=44)

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -2728,7 +2728,16 @@ def emitRuntimeDispatcherEmbeddedHelperData : String :=
   -- fva3w: per-CALL flag set when a non-self value transfer needs an EIP-7708 Transfer log;
   -- the emit is DEFERRED (child env on descend so a revert rolls it back; parent env on the
   -- empty-callee path, committed). One-shot: cleared at CALL entry and on emit.
-  "cd_xfer_log_pending:\n  .zero 8\n"
+  "cd_xfer_log_pending:\n  .zero 8\n" ++
+  -- drj99.1 (failed-inner rollback): pre-snapshot of exec_nonstorage_effect_count/overflow taken by
+  -- callDescendFallThrough BEFORE the value-CALL caller-debit/callee-credit records, consumed by
+  -- call_frame_descend so frame_return rolls those records back on a child OOG/REVERT. `armed` is a
+  -- one-shot flag: set on the value-CALL committing path, consumed by call_frame_descend, and
+  -- disarmed at every CALL/CREATE descent entry to clear a stale arm from a non-descending value-CALL.
+  ".balign 8\n" ++
+  "cd_nse_presnap_armed:\n  .zero 8\n" ++
+  "cd_nse_presnap_count:\n  .zero 8\n" ++
+  "cd_nse_presnap_overflow:\n  .zero 8\n"
 
 /-- Runtime-bytecode `.data` section. Drops the `evm_code:` block
     (no baked bytecode); everything else matches the `.data`-baked

--- a/EvmAsm/Codegen/Programs/CallFrameDescend.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameDescend.lean
@@ -400,8 +400,23 @@ def callFrameDescendFunction : String :=
   -- exactly like storage/log cursors above; otherwise the block-verdict reverse
   -- BAL covers checks see stale created-account effects and false-reject valid
   -- reverted-create blocks.
+  -- drj99.1 (failed-inner rollback): the CALL value-transfer non-storage effects (caller-debit +
+  -- callee-credit) are appended by callDescendFallThrough BEFORE this descent, so the LIVE count
+  -- here is already PAST them. On a child OOG/REVERT the spec discards the value transfer, so those
+  -- records must be rolled back too -- snapshot the PRE-recording count (cd_nse_presnap_*) the CALL
+  -- path armed, not the live count. CREATE / other descenders leave cd_nse_presnap_armed=0 and use
+  -- the live count (their effects are recorded inside the child, after this snapshot). Consume the
+  -- one-shot flag so a later non-arming descent does not reuse a stale pre-snap.
+  "  la t1, cd_nse_presnap_armed; ld t2, 0(t1)\n" ++
+  "  beqz t2, .Lcfd_nse_live\n" ++
+  "  sd x0, 0(t1)                              # consume the one-shot armed flag\n" ++
+  "  la t1, cd_nse_presnap_count; ld t0, 0(t1); sd t0, 656(s9)\n" ++
+  "  la t1, cd_nse_presnap_overflow; ld t0, 0(t1); sd t0, 664(s9)\n" ++
+  "  j .Lcfd_nse_snap_done\n" ++
+  ".Lcfd_nse_live:\n" ++
   "  la t1, exec_nonstorage_effect_count; ld t0, 0(t1); sd t0, 656(s9)  # nonstorage effect count snapshot\n" ++
   "  la t1, exec_nonstorage_effect_overflow; ld t0, 0(t1); sd t0, 664(s9)  # nonstorage overflow snapshot\n" ++
+  ".Lcfd_nse_snap_done:\n" ++
   "  la t1, exec_code_effect_count; ld t0, 0(t1); sd t0, 672(s9)  # code effect count snapshot\n" ++
   "  la t1, exec_code_effect_next; ld t0, 0(t1); sd t0, 680(s9)  # code effect heap cursor snapshot\n" ++
   "  la t1, exec_code_effect_overflow; ld t0, 0(t1); sd t0, 688(s9)  # code effect overflow snapshot\n" ++

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -221,6 +221,18 @@ def callDescendFallThrough
     "  ld x10, 96(sp)\n  ld x12, 104(sp)\n  ld x13, 112(sp)\n  addi sp, sp, 128\n" ++
     ".Lcd_xlog_skip_" ++ site ++ tag ++ ":\n"
   "  la t0, cd_xfer_log_pending\n  sd x0, 0(t0)\n" ++
+  -- drj99.1 (failed-inner rollback): DISARM the value-CALL non-storage-effect pre-snapshot at every
+  -- CALL entry. A value-bearing CALL records the caller-debit + callee-credit NON-STORAGE effects in
+  -- the parent BEFORE `jal call_frame_descend`, but the spec (interpreter.py process_message +
+  -- state_tracker.rollback_transaction) DISCARDS the value transfer when the child OOGs / REVERTs /
+  -- exceptional-halts. So the committing record path below snapshots the PRE-recording count into
+  -- cd_nse_presnap_* and ARMS the flag; call_frame_descend then snapshots THAT pre-snap (not the
+  -- post-recording live count) into the child env, so frame_return truncates AWAY the value-CALL
+  -- records on a child failure (matching the rolled-back transfer -> BAL records no net change;
+  -- failed_inner_operation_no_log call_out_of_gas / call_reverted: bv_fail=44). On child SUCCESS the
+  -- records are kept. Disarming here clears a stale arm left by an earlier value-CALL that armed then
+  -- routed to .Lcd_empty/.Lcd_fail (no descend to consume it); create_frame_descend disarms too.
+  "  la t0, cd_nse_presnap_armed; sd x0, 0(t0)\n" ++
   "  la x15, evm_precompile_frame\n" ++
   "  sd x0, 0(x15)\n" ++
   "  sd x0, 8(x15)\n" ++
@@ -295,6 +307,15 @@ def callDescendFallThrough
     "  addi t0, t0, 1\n  addi t1, t1, 1\n  addi t2, t2, -1\n" ++
     "  bnez t2, .Lcd_cmp_" ++ tag ++ "\n" ++
     ".Lcd_balok_" ++ tag ++ ":\n" ++
+    -- drj99.1 (failed-inner rollback): snapshot the PRE-recording non-storage effect count/overflow
+    -- and ARM the flag, BEFORE the caller-debit / callee-credit records below. call_frame_descend
+    -- snapshots this pre-snap into the child env (env+656/664) so frame_return rolls these records
+    -- back on a child OOG/REVERT (the spec discards the value transfer). On the value==0 / no-ctx
+    -- skip into .Lcd_balok no records are appended, so pre-snap == live count (harmless); on the
+    -- empty-callee / fail paths the records are kept/irrelevant and the next CALL/CREATE disarms.
+    "  la t0, exec_nonstorage_effect_count; ld t1, 0(t0); la t0, cd_nse_presnap_count; sd t1, 0(t0)\n" ++
+    "  la t0, exec_nonstorage_effect_overflow; ld t1, 0(t0); la t0, cd_nse_presnap_overflow; sd t1, 0(t0)\n" ++
+    "  la t0, cd_nse_presnap_armed; li t1, 1; sd t1, 0(t0)\n" ++
     -- 5em02.1: debit the caller's LIVE balance (env+32 = .selfBalance, big-endian) by the
     -- transferred value so SELFBALANCE reads B-V mid-execution. The transfer was inert, so
     -- SELFBALANCE read the staged pre-state balance -> false-reject for value-moving

--- a/EvmAsm/Codegen/Programs/CreateFrameDescend.lean
+++ b/EvmAsm/Codegen/Programs/CreateFrameDescend.lean
@@ -46,6 +46,11 @@ def createFrameDescendFunction : String :=
   "create_frame_descend:\n" ++
   "  addi sp, sp, -16\n" ++
   "  sd ra, 0(sp)\n" ++
+  -- drj99.1 (failed-inner rollback): disarm the value-CALL non-storage pre-snapshot so this CREATE
+  -- descent uses the LIVE effect count for the child env snapshot (its endowment/creator effects are
+  -- recorded INSIDE the child at the RETURN deposit, after the snapshot). Clears a stale arm left by
+  -- a prior value-CALL that armed then routed to .Lcd_empty/.Lcd_fail without descending.
+  "  la t0, cd_nse_presnap_armed; sd x0, 0(t0)\n" ++
   -- NB: do NOT take the endowment ptr in a0 -- a0 == x10 (the dispatcher PC), and
   -- call_frame_descend below saves x10 as the parent return PC (#8608/#8629 lesson).
   -- The CREATE value operand is the stack top (x12+0), so read it from x12 directly.


### PR DESCRIPTION
## What

Rolls back the non-storage (balance/nonce) effects of a **failed inner value-CALL** so the per-tx exec-vs-BAL reconciliation matches (`bv_fail=44`), for `failed_inner_operation_no_log` variants `call_out_of_gas`, `call_out_of_gas_memory_expansion`, `call_reverted`.

## Root cause

The caller-debit + callee-credit non-storage effect records are appended in `callDescendFallThrough` **before** `jal call_frame_descend`. But `call_frame_descend` snapshots the *live* `exec_nonstorage_effect_count` into the child env — already *past* those two records. So when the child OOGs/reverts, `frame_return`'s rollback (which truncates the effect log back to the child's snapshot) leaves the caller-debit/callee-credit in place. Per execution-specs (`vm/interpreter.py` `process_message` error path + `state_tracker.rollback_transaction`), a failed value-CALL discards the value transfer entirely. The leaked callee-credit (exec pre=0 → post=value) then trips the comparator's reverse-check against the BAL (which correctly records no net change) → `bv_fail=44`.

## Fix

The value-CALL committing path snapshots the **pre-recording** count/overflow into new globals (`cd_nse_presnap_{count,overflow}`) and arms a one-shot flag (`cd_nse_presnap_armed`). `call_frame_descend` uses that pre-snapshot for the child env's rollback point when armed (so `frame_return` rolls the caller-debit/callee-credit back on child failure), and the live count otherwise. The flag is disarmed at every CALL/CREATE descent entry, so a stale arm can't leak from a value-CALL that routed to `.Lcd_empty`/`.Lcd_fail`. 8-byte aligned loads/stores only.

**Soundness:** this only *removes* effect records that the spec discards on a failed transfer — it makes the exec recomputation spec-correct; the comparator still rejects a forged BAL (a real net change would still appear and be compared). Confirmed 0 false-accepts.

## Validation

- Targeted: the 3 `failed_inner_operation` value-CALL-failure cases flip `00→01`; the 2 already-passing variants stay passing.
- eip7708 family (107): **+3, 0 regression, 0 false-accept** (per-case base-vs-fix diff).
- block_access_list family (678): **0 change, 0 regression**.
- Random sweep seed 4242, 500 (full `stateless_guest`): **full-match 465 → 468, false-accepts (`guest=01 exp=00`) = 0**.
- `lake build` green; `check-forbidden-tactics.sh` green; no diagnostics left in source.

## Scope / follow-up

The related `initcode_calls_with_value` (CREATE/CREATE2) `bv_fail=44` is a **distinct** cause (the created account's aggregate first-pre reflects mid-execution live balance, not block-pre) — it touches the shared CREATE-with-value recording path and is left for the drj99.1 follow-up (documented on the bead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
