### PR TITLE
fix(verdict): record created-in-tx SELFDESTRUCT effects for constructor self-destructs (bv_fail=44/53)

### DIFF
--- a/EvmAsm/Codegen/Programs/NoopHalt.lean
+++ b/EvmAsm/Codegen/Programs/NoopHalt.lean
@@ -293,6 +293,27 @@ private def selfdestructTailAsm : String :=
   -- built sdai_origin_address = env.ADDRESS (BE) only when an account-witness ctx (584(x20)) is present;
   -- guard on that. find_code_effect_by_address clobbers t0-t6 + a0(=x10) -> save x10/x12.
   "  ld t0, 584(x20)\n  beqz t0, .L_selfdestruct_created_in_tx_done\n" ++
+  -- coc3g.6.2: a contract whose constructor SELFDESTRUCTs (initcode `..ff`) NEVER deposits code,
+  -- so exec_code_effect_log has NO record for it and find_code_effect_by_address below would MISS
+  -- -> created_in_tx stays 0 -> the SD took the witness-present path which BAILS (the child is
+  -- absent from the block-pre witness) -> the beneficiary credit / child deletion were never
+  -- recorded -> bv_fail=44 (selfdestruct_to_*_same_tx with_balance). The spec's authoritative
+  -- created-in-tx signal is `originator in tx_state.created_accounts` (system.py selfdestruct:687),
+  -- which is set at generic_create (account creation), BEFORE the initcode runs -- independent of
+  -- any code deposit. We are running INSIDE the CREATE child frame here (the SD halts the
+  -- constructor), and create_frame_descend set create_frame_flag[current_depth]=1 (cleared only by
+  -- the RETURN/REVERT deposit, NOT this SD path), so the flag at the current depth IS exactly that
+  -- created_accounts membership for the originator. Detect it directly -- this is the precise spec
+  -- signal and needs no code deposit. (The code-effect-log check below still covers a created child
+  -- that DEPLOYED code and is later SELFDESTRUCTed by a CALL from a parent frame, where this flag's
+  -- depth no longer matches.) Soundness: this can only mark the genuinely-created originator as
+  -- created-in-tx (recording MORE exec effects the BAL declares), never a witnessed account.
+  "  la t0, evm_call_depth\n  ld t0, 0(t0)\n" ++
+  "  la t1, create_frame_flag\n  slli t2, t0, 3\n  add t1, t1, t2\n  ld t1, 0(t1)\n" ++
+  "  beqz t1, .L_selfdestruct_ctit_codecheck\n" ++
+  "  la t0, evm_selfdestruct_created_in_tx\n  li t2, 1\n  sd t2, 0(t0)\n" ++
+  "  j .L_selfdestruct_created_in_tx_done\n" ++   -- no code record to clear (constructor never deposited)
+  ".L_selfdestruct_ctit_codecheck:\n" ++
   "  addi sp, sp, -16\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n" ++
   "  la a0, exec_code_effect_log\n  la t0, exec_code_effect_count\n  ld a1, 0(t0)\n  la a2, sdai_origin_address\n" ++
   "  jal ra, find_code_effect_by_address\n" ++
@@ -316,6 +337,17 @@ private def selfdestructTailAsm : String :=
   "  li x15, 1\n" ++
   "  sd x15, 0(x14)\n" ++
   selfdestructBeneficiaryNonstorageAsm ++
+  -- coc3g.6.2: a CREATE child frame that halts via SELFDESTRUCT (constructor `..ff`) goes to
+  -- .exit_selfdestruct, which (unlike RETURN/REVERT/STOP) does NOT clear create_frame_flag[depth].
+  -- Now that the created-in-tx detection above CONSUMES this flag, a stale 1 left in this depth's
+  -- slot would be inherited by a later CALL frame descending into the same (reused) depth slot --
+  -- if that CALL frame then SELFDESTRUCTs, the stale flag would falsely mark a witnessed account as
+  -- created-in-tx (a potential false-ACCEPT). Clear it here (depth>0 only; the flag table is depth-
+  -- indexed and depth 0 is the top frame, never a CREATE child) to mirror the other halt exits and
+  -- keep the slot clean for reuse. Guarded on depth>0 so a top-level SELFDESTRUCT is untouched.
+  "  la t0, evm_call_depth\n  ld t0, 0(t0)\n  beqz t0, .L_sd_flag_clear_done\n" ++
+  "  la t1, create_frame_flag\n  slli t2, t0, 3\n  add t1, t1, t2\n  sd x0, 0(t1)\n" ++
+  ".L_sd_flag_clear_done:\n" ++
   "  addi x12, x12, 32\n" ++
   "  j .exit_selfdestruct"
 

--- a/EvmAsm/Codegen/Programs/Selfdestruct.lean
+++ b/EvmAsm/Codegen/Programs/Selfdestruct.lean
@@ -370,9 +370,19 @@ def selfdestructEip7708LogRuntimeAsm : String :=
   "  mv a0, sp\n" ++
   "  la a1, evm_selfdestruct_balance_scratch\n" ++
   "  jal ra, nonstorage_effect_latest_balance\n" ++
+  "  mv t5, a0\n" ++                                  -- t5 = 1 found / 0 miss
   "  ld x10, 32(sp)\n" ++
   "  ld x12, 40(sp)\n" ++
   "  addi sp, sp, 64\n" ++
+  -- coc3g.6.2: a constructor-SELFDESTRUCT child deposited no nonstorage effect (no RETURN), so the
+  -- latest-balance lookup MISSES. Its live balance is the child's selfBalance env+32 (the endowment
+  -- credited at create_frame_descend), and x20 IS the child env here. On a miss, read env+32 (LE,
+  -- byte 32 = LSB) into evm_selfdestruct_balance_scratch (BE, byte 31 = LSB) so the burn/transfer
+  -- log amount is the moved balance. (The byte-reverse below then flips it to LE for the log encoder.)
+  "  bnez t5, .L_selfdestruct_eip7708_have_balance\n" ++
+  "  la t0, evm_selfdestruct_balance_scratch; addi t1, x20, 63; li t2, 32\n" ++
+  ".L_sd7708_envbal_rev:\n" ++
+  "  lbu t3, 0(t1); sb t3, 0(t0); addi t1, t1, -1; addi t0, t0, 1; addi t2, t2, -1; bnez t2, .L_sd7708_envbal_rev\n" ++
   ".L_selfdestruct_eip7708_have_balance:\n" ++
   "  la t0, evm_selfdestruct_balance_scratch\n" ++
   "  addi t1, t0, 31\n" ++
@@ -512,6 +522,15 @@ def selfdestructBeneficiaryNonstorageAsm : String :=
   "  sd zero, 32(sp); sd zero, 40(sp); sd zero, 48(sp); sd zero, 56(sp)\n" ++
   "  mv a0, sp; addi a1, sp, 32\n" ++
   "  jal ra, nonstorage_effect_latest_balance\n" ++   -- a0 = 1 found / 0 miss (out left 0 on miss)
+  -- coc3g.6.2: a constructor-SELFDESTRUCT child has no recorded nonstorage effect (no RETURN deposit),
+  -- so the latest-balance lookup misses; its live balance is env+32 (the endowment, LE), and x20 is the
+  -- child env here. On a miss read env+32 (LE) -> sp+32 (BE) so `transferred` = the moved balance and
+  -- the beneficiary credit below records the BAL's declared +balance (else bv_fail=44 NOTFOUND).
+  "  bnez a0, .L_sdbn_ci_have_transferred\n" ++
+  "  addi t0, sp, 32; addi t1, x20, 63; li t2, 32\n" ++
+  ".L_sdbn_envbal_rev:\n" ++
+  "  lbu t3, 0(t1); sb t3, 0(t0); addi t1, t1, -1; addi t0, t0, 1; addi t2, t2, -1; bnez t2, .L_sdbn_envbal_rev\n" ++
+  ".L_sdbn_ci_have_transferred:\n" ++
   -- record the child's DELETION (balance 0, nonce 0) -- reuse sp+0..31 as a zero balance.
   "  sd zero, 0(sp); sd zero, 8(sp); sd zero, 16(sp); sd zero, 24(sp)\n" ++
   "  la a0, sdai_origin_address\n  mv a1, sp\n  mv a2, sp\n  li a3, 0\n  li a4, 0\n" ++


### PR DESCRIPTION
## What

Records the SELFDESTRUCT effects (beneficiary credit + EIP-7708 burn/transfer log) for a **child contract that self-destructs in its constructor** — flipping the `selfdestruct_to_self_same_tx` (bv_fail=53) and `selfdestruct_to_different_address_same_tx` (bv_fail=44) **with_balance** CREATE/CREATE2 cases.

## Ground-truth correction (supersedes 8+ stale probe cycles on bead coc3g.6.2)

The prior diagnoses predated #9075. Re-measured on current main with full instrumentation, every stale claim is FALSE:
- `dispatch_tx_runtime_code` **runs and succeeds** (no conservative bail).
- The CREATE **descends** (`create_frame_descend count = 1`, not 0) — #9075's live-balance gate fixed this.
- value-gate / state-gas-spill / collision bails all = 0; `x20` is a valid frame env (not 0).

The single real defect: the factory's initcode is `73<benef>ff` (`PUSH20; SELFDESTRUCT`) — the child **self-destructs in its constructor and never RETURNs**, so the CREATE deposit (code-effect record) never runs. The SELFDESTRUCT handler's created-in-tx detection relied solely on `find_code_effect_by_address`, which therefore missed → `created_in_tx = 0` → the handler took the witness-present path → bailed (the child is absent from the block-pre witness) → no beneficiary credit and no burn/transfer log → exec-vs-BAL non-storage NOTFOUND for the beneficiary (bv44), or the receipts/burn-log chain incomplete (bv53).

## Fix

- **`NoopHalt.lean`** (`selfdestructTailAsm`): detect created-in-tx via `create_frame_flag[evm_call_depth]` (set by `create_frame_descend` for the child frame) **in addition to** the code-effect log. This mirrors the spec's authoritative `originator in tx_state.created_accounts` (`system.py` selfdestruct), which is established at `generic_create` **before** the initcode runs — independent of any code deposit. The flag is **cleared on the SELFDESTRUCT exit** (the RETURN/REVERT/STOP exits already clear it), so a later CALL frame reusing the depth slot cannot inherit a stale flag — closing a potential false-accept.
- **`Selfdestruct.lean`**: when `nonstorage_effect_latest_balance` misses (a constructor-SD child has no prior recorded effect), fall back to the child's live `env+32` (.selfBalance, the endowment credited at descend) for the moved-balance amount — so both the EIP-7708 log and the beneficiary credit carry the correct value.

## Validation

- All 4 `selfdestruct_to_*` with_balance CREATE/CREATE2 targets now **PASS** (were failing).
- Random sweep seed 4242 / 500: full-match **469 → 473**, **false-accepts (`guest=01 exp=00`) = 0**.
- **Rigorous regression:** pre-fix base guest built in a worktree, run on the identical 500 inputs, per-case base-vs-fix diff = **exactly 4 cases changed, ALL positive flips; 0 regressions, 0 introduced false-accepts.**
- Other selfdestruct families (`to_system_address`, `bal_2935/4788_selfdestruct_*`, `selfdestruct_to_7702_delegation`, `to_self_cross_tx`) all stay full-match.
- `lake build` green; `check-forbidden-tactics.sh` green; byte-wise (LBU) loads — no misaligned access.

## Scope / follow-up

Distinct remaining cases (separate beads, all false-rejects, never false-accepts): `initcode_calls_with_value` (created-account aggregate first-pre, bv44), `call_to_delegated_account_with_value` (bv41), `bal_nonexistent_account_access_value_transfer` (bv41), `bal_7702_multi_hop_delegation_chain` (bv34), `bal_2930_slot_listed_and_unlisted_writes` (bv53).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
