### PR TITLE
fix(verdict): exact gas for CALLCODE value transfer + EIP-2930 listed-slot warmth (bv_fail=41)

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -672,15 +672,21 @@ def callDescendFallThrough
    else "") ++
   -- empty code (EOA): the call succeeds, runs nothing → push 1
   ".Lcd_empty_" ++ tag ++ ":\n" ++
-  -- bnctz: a value-bearing CALL (mode 0) to an empty/non-existent callee still pays the
+  -- bnctz: a value-bearing CALL/CALLCODE (mode 0/2) to an empty/non-existent callee still pays the
   -- value-transfer REGULAR gas. Spec system.py:444 charges extra_gas = access + CALL_VALUE(9000);
   -- message_call_gas then funds the empty callee with the 2300 stipend, which returns unused, so
   -- the NET regular consumed is 9000 - 2300 = 6700 (access is already charged via
   -- runtime_access_account_charge; the new-account STATE gas is charged above). The .Lcd_empty
   -- fast-path takes no child frame, so charge that 6700 net here. Without it, block_inc0 (and the
   -- receipt = block_regular + tx_state) under-count by 6700 -> block_gas_used_call_new_account
-  -- bv_fail=53. x12 is still the parent stack top (value at x12+valueOff) before the pop below.
-  (if mode == 0 then
+  -- bv_fail=53.
+  -- coc3g.7 (bv_fail=41, bal_nonexistent callcode_positive_value): CALLCODE (mode 2) with value to a
+  -- nonexistent CODE target (`to = current_target`, code from the popped address = empty) also runs
+  -- nothing and pays this 6700 net (spec callcode: transfer_gas_cost = CALL_VALUE(9000), stipend 2300
+  -- refunded). CALLCODE charges NO new-account state gas (its recipient is current_target, always
+  -- alive) so this regular 6700 is the only value cost. STATICCALL/DELEGATECALL are value-less, so
+  -- gate on `valueBearing` (mode 0 OR 2). x12 is still the parent stack top (value at x12+valueOff).
+  (if valueBearing then
      "  ld t0, " ++ toString valueOff ++ "(x12)\n" ++
      "  ld t1, " ++ toString (valueOff+8) ++ "(x12)\n  or t0, t0, t1\n" ++
      "  ld t1, " ++ toString (valueOff+16) ++ "(x12)\n  or t0, t0, t1\n" ++

--- a/EvmAsm/Codegen/Programs/SeedTxAccessList.lean
+++ b/EvmAsm/Codegen/Programs/SeedTxAccessList.lean
@@ -93,6 +93,19 @@ def seedTxAccessListFunction : String :=
   "  add t5, t3, t4; sb t6, 0(t5)\n" ++
   "  addi t4, t4, 1; j .Lstal_addr_cp\n" ++
   ".Lstal_addr_done:\n" ++
+  -- bal_2930: build the env.ADDRESS-format token (address reversed into bytes 0..L-1
+  -- of a zeroed 32-byte word = the address as a little-endian 256-bit integer) used
+  -- by the storage-key warm set. stal_token holds the address big-endian in bytes
+  -- 0..L-1 (L = stal_alen, normally 20); reverse it: token_le[L-1-i] = token[i].
+  "  la t0, stal_token_le; sd zero, 0(t0); sd zero, 8(t0); sd zero, 16(t0); sd zero, 24(t0)\n" ++
+  "  la t3, stal_token; la t4, stal_token_le; la t0, stal_alen; ld t2, 0(t0); li t1, 0\n" ++
+  ".Lstal_addr_rev:\n" ++
+  "  beq t1, t2, .Lstal_addr_rev_done\n" ++
+  "  add t5, t3, t1; lbu t6, 0(t5)\n" ++          -- token[i] (big-endian byte i)
+  "  sub t5, t2, t1; addi t5, t5, -1\n" ++         -- L-1-i
+  "  add t5, t4, t5; sb t6, 0(t5)\n" ++            -- token_le[L-1-i] = token[i]
+  "  addi t1, t1, 1; j .Lstal_addr_rev\n" ++
+  ".Lstal_addr_rev_done:\n" ++
   -- w35wj: also seed the access-list ACCOUNT address into the EIP-2929 runtime
   -- account warm table. execution-specs warms access_list_addresses before
   -- execution (fork.py:1085-1091), so the first account-touching opcode
@@ -124,9 +137,25 @@ def seedTxAccessListFunction : String :=
   "  la a3, stal_koff; la a4, stal_klen\n" ++
   "  jal ra, rlp_list_nth_item\n" ++
   "  bnez a0, .Lstal_fail\n" ++
-  "  la t0, stal_koff; ld t1, 0(t0); add t1, s6, t1   # slot content ptr (a1)\n" ++
-  "  la a0, stal_token; mv a1, t1\n" ++
+  "  la t0, stal_koff; ld t1, 0(t0); add t1, s6, t1   # slot content ptr (big-endian, <=32B)\n" ++
+  -- bal_2930: build the 32-byte LITTLE-ENDIAN slot key the SLOAD/SSTORE handler uses
+  -- (the EVM stack stores the slot value low-byte-first). The RLP slot is big-endian
+  -- with leading zeros stripped (length stal_klen): slot_le[klen-1-i] = slot_be[i].
+  -- Guard klen > 32 (malformed/adversarial RLP): skip this key (a missed warm seed only
+  -- over-charges, never under-charges) rather than overflow the 32-byte slot buffer.
+  "  la t0, stal_klen; ld t2, 0(t0); li t5, 32; bgtu t2, t5, .Lstal_slot_skip\n" ++
+  "  la t0, stal_slot_le; sd zero, 0(t0); sd zero, 8(t0); sd zero, 16(t0); sd zero, 24(t0)\n" ++
+  "  la t3, stal_slot_le; li t4, 0\n" ++
+  ".Lstal_slot_rev:\n" ++
+  "  beq t4, t2, .Lstal_slot_rev_done\n" ++
+  "  add t5, t1, t4; lbu t6, 0(t5)\n" ++          -- slot_be[i]
+  "  sub t5, t2, t4; addi t5, t5, -1\n" ++         -- klen-1-i
+  "  add t5, t3, t5; sb t6, 0(t5)\n" ++            -- slot_le[klen-1-i] = slot_be[i]
+  "  addi t4, t4, 1; j .Lstal_slot_rev\n" ++
+  ".Lstal_slot_rev_done:\n" ++
+  "  la a0, stal_token_le; la a1, stal_slot_le\n" ++
   "  jal ra, evm_storage_access_seed_key\n" ++
+  ".Lstal_slot_skip:\n" ++
   "  addi s9, s9, 1; j .Lstal_slot_loop\n" ++
   ".Lstal_entry_next:\n" ++
   "  addi s3, s3, 1; j .Lstal_entry_loop\n" ++
@@ -156,7 +185,17 @@ def seedTxAccessListDataSection : String :=
   "stal_koff:\n  .zero 8\n" ++
   "stal_klen:\n  .zero 8\n" ++
   ".balign 8\n" ++
-  "stal_token:\n  .zero 32\n"
+  "stal_token:\n  .zero 32\n" ++
+  -- bal_2930 (bv_fail=41): storage-key warm set keys on env.ADDRESS (the 20-byte
+  -- address as a little-endian 256-bit word: low 20 bytes = address reversed) and
+  -- the slot in EVM stack order (little-endian). The RLP access list gives both
+  -- big-endian, so the storage-key seed needs an LE address token + a 32-byte LE
+  -- slot that MATCH the SLOAD/SSTORE lookup key (the account-warm seed above keeps
+  -- the canonical-BE stal_token, which is the format runtime_access_account_charge
+  -- expects).
+  ".balign 8\n" ++
+  "stal_token_le:\n  .zero 32\n" ++
+  "stal_slot_le:\n  .zero 32\n"
 
 
 /-! ## tx_access_list_span


### PR DESCRIPTION
## Summary

Two distinct **exact-spec** gas corrections for `bv_fail=41` (the guest's reconstructed `header.gas_used` diverges from the header → false-reject). Each is independently isolated and validated with **0 false-accepts**.

### 1. CALLCODE value-transfer regular gas (under-charge 6700)
`bal_nonexistent_account_access_value_transfer[callcode_positive_value]`: the `.Lcd_empty` fast-path (a CALL/CALLCODE to an empty/nonexistent code target that runs nothing) charged the net value-transfer regular gas `GAS_CALL_VALUE(9000) − GAS_CALL_STIPEND(2300) = 6700` only for `mode==0` (CALL). A value-bearing **CALLCODE** (mode 2) was skipped → block_regular_gas under-counted by 6700.

Spec (`vm/instructions/system.py` `callcode`): `transfer_gas_cost = CALL_VALUE` when value≠0; `message_call_gas` funds the empty callee with the 2300 stipend (returned unused) → net 6700. CALLCODE keeps `to = current_target` (alive) so it charges **no** new-account state gas — the 6700 regular is the only value cost. Fix: gate the 6700 charge on `valueBearing` (mode 0 **or** 2); STATICCALL/DELEGATECALL stay value-less.

### 2. EIP-2930 access-list storage-key warmth byte-order (over-charge 2000)
`bal_2930_slot_listed_and_unlisted_reads` (and `_writes`, and `stEIP2930/storage_costs[declaredKeyRead]`): `seed_tx_access_list` stored the EIP-2929 warm storage key as `(address big-endian left-aligned, slot big-endian from RLP)`, but the SLOAD/SSTORE handler keys on `(env.ADDRESS = address as a little-endian 256-bit word, slot in EVM stack order = little-endian)`. The seeded key never matched the runtime lookup, so a **listed** slot SLOAD/SSTORE was charged the 2000 cold delta it should skip → regular gas over-counted by 2000.

Fix: build an LE address token + a 32-byte LE slot (reversed from the BE RLP fields) for the storage-key seed so it matches the handler's lookup key; keep the canonical-BE token for the account-warm seed (`runtime_access_account_charge` expects BE). Guard malformed slot length > 32 (skip — a missed warm seed only over-charges, never under-charges).

## Validation (base-vs-fixed verdict, per-case output diff)
- **random 500 (seed 4242): 0 false-accepts, 0 regressions, +2 flips** (`storage_costs[declaredKeyRead]`, `basefee_example`).
- **eip7928 BAL family (696): 0-FA, 0-regress, +3 flips** (`bal_2930` reads + writes, `callcode_positive`).
- **eip7981 access-list cost (105): 0-FA, 0-regress.** eip7708 (107): 0-FA, 0-regress.
- `scripts/check-forbidden-tactics.sh` OK; aligned-safe (byte-wise LBU/SB reversals).

`call_to_delegated_account_with_value` (the third targeted singleton) is **not** included: its 6700 under-charge is a *symptom* of the value-CALL to a pre-state-delegated EOA routing to the call-fail path (push 0) instead of running the delegated target — a delegation-resolution gap in the single-tx dispatch (the known `dtrc_use_pre_header=0` POST-header bail), not a pure gas fix. Documented for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)