### PR TITLE
fix(verdict): follow EIP-7702 delegation in CALL descent / pre-state resolution

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -2729,6 +2729,10 @@ def emitRuntimeDispatcherEmbeddedHelperData : String :=
   -- nxio8.8: the CALL callee (`to`) as canonical 20-byte big-endian, for the
   -- EIP-8037 new-account state-gas check (is_account_alive(to)) in callDescendFallThrough.
   "cd_callee_be:\n  .zero 32\n" ++
+  -- coc3g.5/.7: EIP-7702 nested-CALL delegation-follow target (the single-hop delegated
+  -- address extracted from a 0xef0100||addr marker), so the nested CALL runs the TARGET's
+  -- code (mirroring #9078's dtrc-path follow) instead of routing to .Lcd_fail.
+  "cd_deleg_target:\n  .zero 32\n" ++
   -- fva3w: per-CALL flag set when a non-self value transfer needs an EIP-7708 Transfer log;
   -- the emit is DEFERRED (child env on descend so a revert rolls it back; parent env on the
   -- empty-callee path, committed). One-shot: cleared at CALL entry and on emit.

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -598,6 +598,34 @@ def callDescendFallThrough
   "  lbu t4, 0(t3); li t5, 0xef; bne t4, t5, .Lcd_descend_" ++ tag ++ "\n" ++
   "  lbu t4, 1(t3); li t5, 0x01; bne t4, t5, .Lcd_descend_" ++ tag ++ "\n" ++
   "  lbu t4, 2(t3); bnez t4, .Lcd_descend_" ++ tag ++ "\n" ++
+  -- coc3g.7: PRIOR-BLOCK (witness pre-state) EIP-7702 delegation follow on the nested CALL.
+  -- The callee's CURRENT code (resolved via code_at_header_state_root) is a 23-byte
+  -- 0xef0100||target marker -- a delegated EOA whose delegation lives in the WITNESS PRE-STATE
+  -- (not the same-block BAL). The spec (system.py call -> calculate_delegation_cost is SINGLE-HOP
+  -- -> get_code(code_address)) runs the SINGLE-HOP TARGET's code in the callee's storage context,
+  -- never the marker bytes themselves (call_to_delegated_account_with_value: CALL 0x9098.. ->
+  -- delegated to 0x37f5.. = STOP -> succeeds, value transferred + EIP-7708 log emitted; routing to
+  -- .Lcd_fail dropped the value-net REGULAR gas -> bv_fail=41). Extract the 20-byte target (marker
+  -- bytes 3..22) and re-resolve its code against the SAME witness header (env+576/584), exactly like
+  -- #9078's dtrc-path follow. The same-block resolver below only covers in-block (BAL) delegations;
+  -- this handles a target whose delegation lives in the pre-state witness. On a target-code MISS fall
+  -- through to .Lcd_resolve_; env.ADDRESS stays the callee EOA (call_frame_descend keys storage by
+  -- `to`, matching current_target = the EOA). Soundness: descending runs the EXACT code the spec
+  -- runs (single-hop target), recording more exec effects -- it cannot accept a block the spec
+  -- rejects (the BAL comparator independently checks each declared final).
+  "  la t4, cd_deleg_target; addi t5, t3, 3; li t6, 20\n" ++
+  ".Lcd_pdeleg_copy_" ++ tag ++ ":\n" ++
+  "  beqz t6, .Lcd_pdeleg_copied_" ++ tag ++ "\n" ++
+  "  lbu t2, 0(t5); sb t2, 0(t4); addi t5, t5, 1; addi t4, t4, 1; addi t6, t6, -1; j .Lcd_pdeleg_copy_" ++ tag ++ "\n" ++
+  ".Lcd_pdeleg_copied_" ++ tag ++ ":\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd x10, 0(sp); sd x12, 8(sp); sd x13, 16(sp)\n" ++
+  "  ld a0, 576(x20)\n  ld a1, 584(x20)\n  la a2, cd_deleg_target\n  ld a3, 592(x20)\n  ld a4, 600(x20)\n  ld a5, 608(x20)\n  ld a6, 616(x20)\n" ++
+  "  jal ra, code_at_header_state_root\n" ++
+  "  mv t2, a0\n" ++
+  "  ld x10, 0(sp); ld x12, 8(sp); ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
+  "  bnez t2, .Lcd_resolve_" ++ tag ++ "\n" ++   -- target code MISS -> try same-block resolver
+  "  j .Lcd_descend_" ++ tag ++ "\n" ++           -- target code found -> descend on it (cahsr_* now name the target's code)
   ".Lcd_resolve_" ++ tag ++ ":\n" ++
   "  addi sp, sp, -32\n" ++
   "  sd x10, 0(sp); sd x12, 8(sp); sd x13, 16(sp); sd t2, 24(sp)\n" ++


### PR DESCRIPTION
## Summary

A nested `CALL` whose target is a **prior-block EIP-7702-delegated EOA** reached `callDescendFallThrough`'s marker-detection path (`ChildFrameHandlers.lean`), but the only follow-up there was `bal_same_block_delegation_code_resolve`, which covers **only in-block (BAL) delegations**. A delegation that lives in the **witness pre-state** missed that resolver, missed the create-effect fallback, and routed to `.Lcd_fail_` (push 0) **without running the delegated target's code** — so the value-transfer net regular gas (`CALL_VALUE 9000 − stipend 2300 = 6700`) was never charged and the EIP-7708 transfer log never emitted → reconstructed block regular gas under-counted → `bv_fail=41`.

Per execution-specs amsterdam `system.py call()` → `calculate_delegation_cost` (a **single-hop** resolution) → `get_code(code_address)`: a CALL into a delegated account runs the **single-hop target's** code in the callee's storage context (`current_target` stays the delegating EOA, `env.ADDRESS` unchanged), never the marker bytes.

**Fix:** on the marker-found path, extract the 20-byte target (marker bytes 3..22) and re-resolve its code against the **same witness header** (`env+576/584`) via `code_at_header_state_root`, then descend on the target's code — mirroring #9078's dtrc-path delegation follow. On a target-code miss, fall through to the same-block resolver (unchanged). `env.ADDRESS` stays the callee EOA so `SSTORE` keys the EOA's storage.

## Soundness

Descending runs the **exact** code the spec runs (single-hop target), recording **more** exec effects — it can only fix false-REJECTs, never accept a block the spec rejects (the BAL comparator independently checks each declared final). Byte-wise (`lbu`/`sb`) marker-target copy, no misaligned loads; `x10/x12/x13` saved around `code_at_header_state_root`.

## Validation

- `call_to_delegated_account_with_value` flips **00→01** — full 105-byte guest output byte-matches the EEST `statelessOutputBytes`.
- `delegate_call_targets` family: **44/48 full-match** (10 additional `bv_fail=34/41/53`→`00` false-rejects flipped, byte-verified).
- Seed-4242 limit-500 sweep: full match 474, **0 false-accepts** (`guest=01 exp=00` == 0).
- Per-case base-vs-fix verdict/bv_fail diff over all 482 ran cases = **exactly 1 change** (`call_to_delegated` 00→01); eip7702 family diff = 10 positive flips, **0 regressions**.
- `check-forbidden-tactics` green.

## Follow-on (documented, not in this PR)

`bal_7702_multi_hop_delegation_chain` (`bv_fail=34`) needs, on top of this: (a) chain-target same-block-code descent, (b) depth-aware unassigned-opcode (`0xef`) child-frame failure, and (c) **EIP-7702 authority (signer) warming** into the EIP-2929 runtime warm set — the CALL into a same-block-delegated authority is WARM in the spec but COLD in the guest, a 2400 receipt-gas over-count (`bv_fail=53`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)