### PR TITLE
fix(verdict): order EIP-7708 transfer log by execution order vs contract LOGs

### DIFF
--- a/EvmAsm/Codegen/Programs/EvmLogHandlers.lean
+++ b/EvmAsm/Codegen/Programs/EvmLogHandlers.lean
@@ -20,14 +20,18 @@ def logTopicCopies (topicCount : Nat) : String :=
     (List.range topicCount).map fun i =>
       let stackOff := 64 + i * 32
       let entryOff := 32 + i * 32
-      "  ld x21, " ++ toString stackOff ++ "(x12)\n" ++
-      "  sd x21, " ++ toString entryOff ++ "(x14)\n" ++
-      "  ld x21, " ++ toString (stackOff + 8) ++ "(x12)\n" ++
-      "  sd x21, " ++ toString (entryOff + 8) ++ "(x14)\n" ++
-      "  ld x21, " ++ toString (stackOff + 16) ++ "(x12)\n" ++
-      "  sd x21, " ++ toString (entryOff + 16) ++ "(x14)\n" ++
-      "  ld x21, " ++ toString (stackOff + 24) ++ "(x12)\n" ++
-      "  sd x21, " ++ toString (entryOff + 24) ++ "(x14)\n"
+      -- x25 (NOT x21) as the copy temp: x21 is the dispatcher's reserved EVM
+      -- code-base register (PC = x10 - x21); clobbering it breaks the code-size
+      -- stop guard / PC / JUMP after a LOG, halting the frame early (a LOG
+      -- followed by any further opcode, e.g. LOG0-then-CALL).
+      "  ld x25, " ++ toString stackOff ++ "(x12)\n" ++
+      "  sd x25, " ++ toString entryOff ++ "(x14)\n" ++
+      "  ld x25, " ++ toString (stackOff + 8) ++ "(x12)\n" ++
+      "  sd x25, " ++ toString (entryOff + 8) ++ "(x14)\n" ++
+      "  ld x25, " ++ toString (stackOff + 16) ++ "(x12)\n" ++
+      "  sd x25, " ++ toString (entryOff + 16) ++ "(x14)\n" ++
+      "  ld x25, " ++ toString (stackOff + 24) ++ "(x12)\n" ++
+      "  sd x25, " ++ toString (entryOff + 24) ++ "(x14)\n"
 
 /-- M26 LOG capture prefix. Appends a bounded 256-byte descriptor:
       +0  topic count (u64)
@@ -72,24 +76,31 @@ def logCapturePreBody (topicCount : Nat) : String :=
   -- canonical 20-byte BE address, so reverse the 20 address bytes here. The
   -- descriptor was pre-zeroed, so the upper 12 bytes of the +192 word stay zero
   -- (matching the canonical low-aligned form the encoder + bloom expect).
+  -- x25 (NOT x21) as the byte/word temp here: x21 is the dispatcher's reserved
+  -- EVM code-base register (PC = x10 - x21, JUMP/JUMPI target = x21 + dest, and
+  -- the code-size stop guard `sub x5,x10,x21`). The handler runs mid-dispatch and
+  -- must preserve x21, or any opcode AFTER a LOG (e.g. LOG0-then-CALL) reads a
+  -- corrupted code base -> the stop guard exits the frame early, dropping the rest
+  -- of the bytecode (contract_log_and_transfer_ordering: CALL never executes, so
+  -- the value transfer's BAL non-storage effect + EIP-7708 log are missing).
   "  addi x22, x20, 19\n" ++        -- src = env+19 (MSB of the LE address)
   "  addi x23, x14, 192\n" ++       -- dst = descriptor+192 (canonical BE)
   "  li x16, 20\n" ++
   "42:\n" ++
-  "  lbu x21, 0(x22)\n" ++
-  "  sb x21, 0(x23)\n" ++
+  "  lbu x25, 0(x22)\n" ++
+  "  sb x25, 0(x23)\n" ++
   "  addi x22, x22, -1\n" ++
   "  addi x23, x23, 1\n" ++
   "  addi x16, x16, -1\n" ++
   "  bnez x16, 42b\n" ++
-  "  ld x21, 64(x20)\n" ++
-  "  sd x21, 224(x14)\n" ++
-  "  ld x21, 72(x20)\n" ++
-  "  sd x21, 232(x14)\n" ++
-  "  ld x21, 80(x20)\n" ++
-  "  sd x21, 240(x14)\n" ++
-  "  ld x21, 88(x20)\n" ++
-  "  sd x21, 248(x14)\n" ++
+  "  ld x25, 64(x20)\n" ++
+  "  sd x25, 224(x14)\n" ++
+  "  ld x25, 72(x20)\n" ++
+  "  sd x25, 232(x14)\n" ++
+  "  ld x25, 80(x20)\n" ++
+  "  sd x25, 240(x14)\n" ++
+  "  ld x25, 88(x20)\n" ++
+  "  sd x25, 248(x14)\n" ++
   "  li x19, 32\n" ++
   "  bgeu x19, x18, 2f\n" ++
   "  mv x18, x19\n" ++
@@ -111,28 +122,29 @@ def logCapturePreBody (topicCount : Nat) : String :=
   -- is reclaimed when the emitting frame ends, so the full data is unreadable at
   -- block-end. evm_log_data_meta[index] = (byte offset into evm_log_data, full len)
   -- is kept parallel to evm_event_logs. Live: x14=descriptor, x15=index,
-  -- x17=mem offset, x13=mem base; scratch x16/x18/x19/x21/x22/x23/x24.
+  -- x17=mem offset, x13=mem base; scratch x16/x18/x19/x25/x22/x23/x24.
+  -- (x25 NOT x21: x21 is the dispatcher's reserved EVM code-base register; see above.)
   "  ld x16, 16(x14)\n" ++           -- x16 = full data size (unclamped, stored at +16)
   "  la x18, evm_log_data_used\n" ++
   "  ld x19, 0(x18)\n" ++            -- x19 = used (dst byte offset into evm_log_data)
-  "  la x21, evm_log_data_meta\n" ++
+  "  la x25, evm_log_data_meta\n" ++
   "  slli x22, x15, 4\n" ++
-  "  add x21, x21, x22\n" ++         -- &meta[index]
-  "  sd x19, 0(x21)\n" ++            -- meta[index].offset = used
-  "  sd x16, 8(x21)\n" ++            -- meta[index].len = full size
+  "  add x25, x25, x22\n" ++         -- &meta[index]
+  "  sd x19, 0(x25)\n" ++            -- meta[index].offset = used
+  "  sd x16, 8(x25)\n" ++            -- meta[index].len = full size
   "  li x22, 262144\n" ++
   "  add x23, x19, x16\n" ++         -- end = used + size
   "  bgtu x23, x22, 5f\n" ++         -- overflow -> set flag, still record descriptor
-  "  la x21, evm_log_data\n" ++
-  "  add x21, x21, x19\n" ++         -- dst = evm_log_data + used
+  "  la x25, evm_log_data\n" ++
+  "  add x25, x25, x19\n" ++         -- dst = evm_log_data + used
   "  add x22, x13, x17\n" ++         -- src = evm_memory + offset
   "  mv x24, x16\n" ++               -- remaining = full size
   "6:\n" ++
   "  beqz x24, 7f\n" ++
   "  lbu x23, 0(x22)\n" ++
-  "  sb x23, 0(x21)\n" ++
+  "  sb x23, 0(x25)\n" ++
   "  addi x22, x22, 1\n" ++
-  "  addi x21, x21, 1\n" ++
+  "  addi x25, x25, 1\n" ++
   "  addi x24, x24, -1\n" ++
   "  j 6b\n" ++
   "7:\n" ++                          -- success: used += round8(size)
@@ -144,9 +156,9 @@ def logCapturePreBody (topicCount : Nat) : String :=
   "  sd x15, 472(x20)\n" ++
   "  j 8f\n" ++
   "5:\n" ++                          -- overflow: flag it; descriptor prefix still recorded
-  "  la x21, evm_log_data_overflow\n" ++
+  "  la x25, evm_log_data_overflow\n" ++
   "  li x22, 1\n" ++
-  "  sd x22, 0(x21)\n" ++
+  "  sd x22, 0(x25)\n" ++
   "  addi x15, x15, 1\n" ++
   "  sd x15, 472(x20)\n" ++
   "  j 8f\n" ++


### PR DESCRIPTION
## Problem

`contract_log_and_transfer_ordering` (EIP-7708, `transfer_logs`) was a false-reject. The scenario: a contract runs `LOG0` then `CALL`s an external account with `value=1`, and the test asserts the receipt log ordering: tx-level Transfer log, then the contract's own `LOG0`, then the inner CALL's Transfer log.

The probe (`zisk_stateless_verdict_v2`) showed `bv_fail=44` (`.Lbv_bal_nonstorage_fail`), not the anticipated 53. Diagnosis revealed the inner CALL's value transfer was never recorded (`exec_nonstorage_effect_count=0`) and only 2 of the 3 logs were emitted (tx-level transfer + LOG0; the inner CALL's transfer log was missing).

## Root cause

The runtime dispatch loop never fetched the `CALL` (`0xf1`) opcode — the dispatcher halted right after `LOG0`. The LOG0-4 capture path (`logTopicCopies` + `logCapturePreBody` in `EvmLogHandlers.lean`) used **x21** as a load/store scratch register and never restored it. But **x21 is the runtime EVM dispatcher's reserved code-base register**: `PC = x10 - x21`, `JUMP/JUMPI target = x21 + dest`, and the per-iteration code-size stop guard is `sub x5, x10, x21; bltu x5, codeSize`. Clobbering x21 in a LOG handler corrupts the code base, so the next dispatch iteration mis-computes PC and the stop guard exits the frame early.

This is invisible when a LOG is the last meaningful opcode (the frame STOPs anyway) — so the LOG-only families pass. It only bites when a LOG is followed by further opcodes (LOG0-then-CALL here).

## Fix

Use **x25** (a register the dispatcher does not reserve) as the scratch in both `logTopicCopies` and `logCapturePreBody`, leaving x21 intact across the handler. LOG capture (address/topics/data) is byte-unchanged; the fix only swaps the scratch register. After the fix the CALL executes, recording the callee's BAL non-storage balance effect (clears bv_fail=44) and emitting the inner CALL's EIP-7708 Transfer log at the correct position — yielding the spec's execution-order log sequence.

## Validation

- Per-case base-vs-fix output diff over a **500-case random sweep (seed 4242)**: the ONLY change is `contract_log_and_transfer_ordering` flipping `succ 00 -> 01`; every other case (including the 18 environmentally-errored `bal_*` system-contract cases, identical between base and fix) is byte-identical.
- **0 false-accepts** (no `guest=01 exp=00`).
- eip7708 family: 101 -> 102 full match (5 remaining fails are pre-existing `bv_fail=41` cases, unrelated).
- `set_code_to_log` LOG0-4: 5/5 full match (LOG receipt encoding unaffected).
- `scripts/check-forbidden-tactics.sh` green; `lake build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)