### PR TITLE
fix(verdict): restore sp after DIV/MOD/SDIV/SMOD/ADDMOD — system-contract BAL store to invalid address (ziskemu mem.rs:593 panic)

### DIFF
--- a/EvmAsm/Codegen/Programs/EvmDivModHandlers.lean
+++ b/EvmAsm/Codegen/Programs/EvmDivModHandlers.lean
@@ -9,8 +9,22 @@ import EvmAsm.Codegen.Programs.EvmDivModWrappers
 
 namespace EvmAsm.Codegen
 
+-- The verified DIV/MOD body (`evm_div` / `evm_mod`) uses `x2` (= `sp`) as a
+-- general-purpose working register for its multi-precision arithmetic (e.g.
+-- `ld sp, -128(a2); jr sp` for the internal dispatch, and the bignum
+-- multiply-subtract chain that overwrites `sp` with intermediate limbs). In the
+-- dispatcher, `sp` is the LP64 helper-call stack pointer (= `lp64_sp_top`), so a
+-- handler whose body clobbers it MUST restore it before returning to
+-- `.dispatch_loop`, or the next helper-call prologue (`addi sp, sp, -N;
+-- sd ra, 0(sp)` in `frame_return` / `h_SSTORE` / …) stores through a garbage
+-- (often tiny / negative) `sp` and ziskemu faults (`mem.rs:593` invalid addr).
+-- This is the same `sp`-restore that `expTail` (EvmSelfCallingHandlers.lean)
+-- performs for the EXP body, which clobbers `x2` for the identical reason.
+-- (No `la x2, exp_scratch` preBody is needed here: the DIV/MOD body only ever
+-- treats `x2` as a value register — it never does `sp`-relative *stores* — so
+-- it cannot scribble into the `lp64_stack` region the way EXP does.)
 private def divModTail : HandlerTail :=
-  .custom "  mv x10, x14\n  addi x10, x10, 1\n  ret"
+  .custom "  mv x10, x14\n  la sp, lp64_sp_top\n  addi x10, x10, 1\n  ret"
 
 def divModHandlers : List OpcodeHandlerSpec :=
   [ { label   := "h_DIV"

--- a/EvmAsm/Codegen/Programs/EvmSelfCallingHandlers.lean
+++ b/EvmAsm/Codegen/Programs/EvmSelfCallingHandlers.lean
@@ -46,7 +46,14 @@ private def evmAddmodRuntimeTail : HandlerTail :=
     "  bne x5, x0, .Laddmod_sub_n\n  ld x6, 24(x12)\n  ld x7, 56(x12)\n  bltu x7, x6, .Laddmod_sub_n\n  bltu x6, x7, .Laddmod_done\n  ld x6, 16(x12)\n  ld x7, 48(x12)\n  bltu x7, x6, .Laddmod_sub_n\n  bltu x6, x7, .Laddmod_done\n  ld x6, 8(x12)\n  ld x7, 40(x12)\n  bltu x7, x6, .Laddmod_sub_n\n  bltu x6, x7, .Laddmod_done\n  ld x6, 0(x12)\n  ld x7, 32(x12)\n  bltu x6, x7, .Laddmod_done\n.Laddmod_sub_n:\n  ld x6, 0(x12)\n  ld x7, 32(x12)\n  sub x5, x6, x7\n  sltu x11, x6, x7\n  sd x5, 0(x12)\n  ld x6, 8(x12)\n  ld x7, 40(x12)\n  sub x5, x6, x7\n  sltu x10, x6, x7\n  sub x5, x5, x11\n  sltu x11, x5, x11\n  or x11, x10, x11\n  sd x5, 8(x12)\n  ld x6, 16(x12)\n  ld x7, 48(x12)\n  sub x5, x6, x7\n  sltu x10, x6, x7\n  sub x5, x5, x11\n  sltu x11, x5, x11\n  or x11, x10, x11\n  sd x5, 16(x12)\n  ld x6, 24(x12)\n  ld x7, 56(x12)\n  sub x5, x6, x7\n  sub x5, x5, x11\n  sd x5, 24(x12)\n  j .Laddmod_done\n.Laddmod_no_carry:\n  jal x1, .Laddmod_mod_callable\n  j .Laddmod_done\n.Laddmod_zero:",
     emitProgram EvmAsm.Evm64.evm_addmod_phase2_zero_path,
     emitProgram EvmAsm.Evm64.evm_addmod_epilogue,
-    ".Laddmod_done:\n  mv x10, x14\n  addi x10, x10, 1\n  j .dispatch_loop\n.Laddmod_mod_callable:",
+    -- The carry/no-carry paths `jal x1, .Laddmod_mod_callable` into
+    -- `evm_mod_callable_v4` (the verified DIV/MOD core), which uses `x2` (= `sp`)
+    -- as a general-purpose register. Restore the LP64 helper-call stack pointer
+    -- before resuming `.dispatch_loop`, else the next helper-call prologue
+    -- (`sd ra, 0(sp)`) faults on a garbage `sp` (ziskemu `mem.rs:593`). Same
+    -- `sp`-restore as `divModTail` / `expTail`. (Harmless on the zero path,
+    -- which never calls MOD.)
+    ".Laddmod_done:\n  mv x10, x14\n  la sp, lp64_sp_top\n  addi x10, x10, 1\n  j .dispatch_loop\n.Laddmod_mod_callable:",
     emitProgram EvmAsm.Evm64.evm_mod_callable_v4]
 
 /-- Runtime ADDMOD handler assembly. Supports the no-carry lane by reusing

--- a/EvmAsm/Codegen/Programs/EvmSignedDivModHandlers.lean
+++ b/EvmAsm/Codegen/Programs/EvmSignedDivModHandlers.lean
@@ -16,8 +16,15 @@ namespace EvmAsm.Codegen
     `JAL .x1` into `evm_div_callable_v4` / `evm_mod_callable_v4`
     clobbers `x1` mid-body; `x1` no longer holds the dispatcher's
     continuation by the time control reaches this tail. -/
+-- Like h_DIV/h_MOD, `evm_sdiv` / `evm_smod` run the verified DIV/MOD core
+-- (`evm_div_callable_v4` / `evm_mod_callable_v4`), which uses `x2` (= `sp`) as a
+-- general-purpose working register. In the dispatcher `sp` is the LP64
+-- helper-call stack pointer (`lp64_sp_top`), so restore it before resuming
+-- `.dispatch_loop` or the next helper-call prologue (`sd ra, 0(sp)`) faults on a
+-- garbage `sp` (ziskemu `mem.rs:593` invalid addr). Mirrors `divModTail` /
+-- `expTail`.
 private def signedDivModTail : HandlerTail :=
-  .custom "  mv x10, x14\n  addi x10, x10, 1\n  j .dispatch_loop"
+  .custom "  mv x10, x14\n  la sp, lp64_sp_top\n  addi x10, x10, 1\n  j .dispatch_loop"
 
 /-- M9 signed division handlers: SDIV (0x05) and SMOD (0x07).
 


### PR DESCRIPTION
## Root cause

The verified DIV/MOD core (`evm_div` / `evm_mod`, and the `evm_*_callable_v4` shims that SDIV/SMOD/ADDMOD invoke) uses `x2` (= `sp`) as a **general-purpose working register** — the multi-precision bignum multiply-subtract chain, plus `ld sp,-128(a2); jr sp` for its internal dispatch.

In the dispatcher, `sp` is the **LP64 helper-call stack pointer** (`lp64_sp_top`, set once in the prologue and never re-seeded per opcode). The `h_DIV`/`h_MOD`/`h_SDIV`/`h_SMOD`/`h_ADDMOD` handler tails did **not** restore `sp` after their body — unlike `h_EXP`, whose `expTail` already does `la sp, lp64_sp_top` for the identical reason (the EXP body also clobbers `x2`).

So after a MOD ran inside an EIP-4788 / EIP-2935 / EIP-7002 / EIP-7251 system-contract predeploy, `sp` held a tiny garbage value, and the **next helper-call prologue** (`addi sp,sp,-N; sd ra,0(sp)`) stored through a small/negative address → ziskemu `Mem::write_silent() invalid addr` (`core/src/mem.rs:593`). This crashed ~18 system-contract block-access-list cases **before any verdict** — a completeness gap, not a false-reject.

Two faulting sites (both `sd ra,0(sp)` prologues, same root):
- `0x80035630` (`frame_return` prologue) — EIP-4788/2935 *query* blocks (predeploy does MOD then STOP/RETURN → frame pop).
- `0x8003b768` (`h_SSTORE` prologue) — EIP-7002/7251 *request/dequeue* blocks (predeploy does MOD then SSTORE).

## Fix

Append `la sp, lp64_sp_top` to each affected handler tail (`divModTail`, `signedDivModTail`, and the ADDMOD `.Laddmod_done` convergence path). `sp` is the helper C-stack pointer, invisible to EVM state, so restoring it is transparent to a correct verdict and can only *prevent* crashes. No `la x2, scratch` preBody is needed (as EXP has): the DIV/MOD body treats `x2` as a value register only — it never does `sp`-relative *stores*, so it can't scribble into the `lp64_stack` region.

## Validation (seed 4242, 500-case EEST stateless sweep, ziskemu, `--jobs 4`)

| metric | baseline (main) | fix |
|---|---|---|
| errored | **18** | **0** |
| full match | 482 | **488** |
| fail | 0 | 12 (all `succ guest=00 exp=01` = sound rejects) |
| **false-accepts** (`guest=01 exp=00`) | 0 | **0** |

Per-case base-vs-fix diff: **exactly the 18 formerly-errored cases flip `ERROR → OK`** (6 now full-match, 12 sound-reject — strictly better than crashing); the other **482 cases are byte-identical** (`.output` + `.result.tsv` compared bytewise, 0 diffs). The 12 residual rejects are a pre-existing verdict-modeling gap in the system-contract request/query BAL cross-check (`bv_fail=34/37`, with `recomputed_state_root == payload_state_root`), distinct from this crash.

`scripts/check-forbidden-tactics.sh` green; full `lake build` green; no `sorry`.

Bead: evm-asm-5gr63

🤖 Generated with [Claude Code](https://claude.com/claude-code)