### PR TITLE
feat(rv64/rlp): multi-field scalar walk — 2-field + reusable unit-CR + 3-field (Phase 5, steps 11–12)

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -76,6 +76,7 @@ import EvmAsm.Rv64.RLP.UnifiedListDescendSiblings
 import EvmAsm.Rv64.RLP.UnifiedFieldScalarRead
 import EvmAsm.Rv64.RLP.UnifiedScalarFieldDecode
 import EvmAsm.Rv64.RLP.UnifiedScalarFieldStore
+import EvmAsm.Rv64.RLP.UnifiedTwoScalarFieldWalk
 import EvmAsm.Rv64.RLP.NestedDescendOne
 import EvmAsm.Rv64.RLP.UnifiedDecodeItem
 import EvmAsm.Rv64.RLP.UnifiedDecodeItemReconverge

--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -77,6 +77,7 @@ import EvmAsm.Rv64.RLP.UnifiedFieldScalarRead
 import EvmAsm.Rv64.RLP.UnifiedScalarFieldDecode
 import EvmAsm.Rv64.RLP.UnifiedScalarFieldStore
 import EvmAsm.Rv64.RLP.UnifiedTwoScalarFieldWalk
+import EvmAsm.Rv64.RLP.ScalarFieldWalkChain
 import EvmAsm.Rv64.RLP.NestedDescendOne
 import EvmAsm.Rv64.RLP.UnifiedDecodeItem
 import EvmAsm.Rv64.RLP.UnifiedDecodeItemReconverge

--- a/EvmAsm/Rv64/RLP/ScalarFieldWalkChain.lean
+++ b/EvmAsm/Rv64/RLP/ScalarFieldWalkChain.lean
@@ -1,0 +1,191 @@
+/-
+  EvmAsm.Rv64.RLP.ScalarFieldWalkChain
+
+  EL.3 / Phase 5 — reusable scalar-field-unit CodeReq + chaining beyond two fields.
+
+  The two-field walk (`unified_two_scalar_field_walk`) discharged the unit-A ⊥ unit-B
+  disjointness with an explicit 36-leaf term. Chaining a *third* unit that way would
+  need 72+ leaves, and an N-field walk is hopeless. This file factors the decode-and-
+  store unit's 46-slot CodeReq into a named `scalarFieldUnitCR` and proves, ONCE, a
+  range-based disjointness lemma `scalarFieldUnitCR_disjoint` (à la `descend_cr_disjoint`):
+  two units whose 184-byte code ranges don't overlap have disjoint CodeReqs. Composing
+  any number of units is then a handful of `union_left`/`union_right` + one lemma
+  application per pair.
+
+  `unified_three_scalar_field_walk` demonstrates it: compose `unified_two_scalar_field_walk`
+  (fields A, B) with one more `regOwn` unit (field C), each storing to its own output
+  slot. This is the concrete inductive step toward the fixed-schema N-field decoders.
+
+  Unit layout (46 instruction slots `base + 4*k`, k = 0..45):
+      k=0       LBU x5, x13, 0
+      k=1..36   unified_decoder_prog       (base+4 .. base+144)
+      k=37      ADDI x14, x11, 0           (base+148)
+      k=38      ADDI x11, x0, 0            (base+152)
+      k=39..44  rlp_phase2_long_loop_body  (base+156 .. base+176)
+      k=45      SD rOut, x11, offset       (base+180)
+-/
+
+import EvmAsm.Rv64.RLP.UnifiedTwoScalarFieldWalk
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL.RLP
+open EvmAsm.Rv64.Tactics
+
+/-- The 46-slot CodeReq of one scalar-field decode-and-store unit at `base`
+    (`unified_scalar_field_decode_and_store`'s code requirement, named for reuse). -/
+def scalarFieldUnitCR (base : Word) (rOut : Reg) (offset : BitVec 12) : CodeReq :=
+  (((CodeReq.singleton base (.LBU .x5 .x13 0)).union
+      (CodeReq.ofProg (base + 4) unified_decoder_prog)).union
+      (((CodeReq.singleton (base + 148) (.ADDI .x14 .x11 0)).union
+          (CodeReq.singleton (base + 152) (.ADDI .x11 .x0 0))).union
+          (CodeReq.ofProg (base + 156) (rlp_phase2_long_loop_body_prog (-20))))).union
+      (CodeReq.singleton (base + 180) (.SD rOut .x11 offset))
+
+/-- A scalar-field unit maps to `none` at any address outside its 46 instruction slots
+    `{base + 4*k : k < 46}`. -/
+theorem scalarFieldUnitCR_none (base : Word) (rOut : Reg) (offset : BitVec 12) (a : Word)
+    (h : ∀ k, k < 46 → a ≠ base + BitVec.ofNat 64 (4 * k)) :
+    scalarFieldUnitCR base rOut offset a = none := by
+  have ep1 : CodeReq.ofProg (base + 4) unified_decoder_prog a = none :=
+    CodeReq.ofProg_none_range_len (base + 4) unified_decoder_prog 36 a unified_decoder_prog_length
+      (fun k hk => by
+        have := h (k + 1) (by omega)
+        rwa [show base + BitVec.ofNat 64 (4 * (k + 1)) = (base + 4) + BitVec.ofNat 64 (4 * k)
+          from by bv_omega] at this)
+  have ep2 : CodeReq.ofProg (base + 156) (rlp_phase2_long_loop_body_prog (-20)) a = none :=
+    CodeReq.ofProg_none_range_len (base + 156) (rlp_phase2_long_loop_body_prog (-20)) 6 a (by rfl)
+      (fun k hk => by
+        have := h (k + 39) (by omega)
+        rwa [show base + BitVec.ofNat 64 (4 * (k + 39)) = (base + 156) + BitVec.ofNat 64 (4 * k)
+          from by bv_omega] at this)
+  have s0 : CodeReq.singleton base (.LBU .x5 .x13 0) a = none :=
+    CodeReq.singleton_miss (by have := h 0 (by omega); simpa using this)
+  have s37 : CodeReq.singleton (base + 148) (.ADDI .x14 .x11 0) a = none :=
+    CodeReq.singleton_miss (by have := h 37 (by omega); bv_omega)
+  have s38 : CodeReq.singleton (base + 152) (.ADDI .x11 .x0 0) a = none :=
+    CodeReq.singleton_miss (by have := h 38 (by omega); bv_omega)
+  have s45 : CodeReq.singleton (base + 180) (.SD rOut .x11 offset) a = none :=
+    CodeReq.singleton_miss (by have := h 45 (by omega); bv_omega)
+  simp only [scalarFieldUnitCR, CodeReq.union, s0, ep1, s37, s38, ep2, s45]
+
+/-- **Reusable scalar-field-unit disjointness.** Two units whose 184-byte code ranges
+    don't overlap (`base2 ≥ base1 + 184`) have disjoint CodeReqs. The building block for
+    chaining any number of decode-and-store units. -/
+theorem scalarFieldUnitCR_disjoint (base1 base2 : Word) (rOut1 rOut2 : Reg)
+    (off1 off2 : BitVec 12)
+    (hsep : base1.toNat + 184 ≤ base2.toNat) (hov : base2.toNat + 184 < 2 ^ 64) :
+    (scalarFieldUnitCR base1 rOut1 off1).Disjoint (scalarFieldUnitCR base2 rOut2 off2) := by
+  intro a
+  by_cases hin : ∀ k, k < 46 → a ≠ base1 + BitVec.ofNat 64 (4 * k)
+  · exact Or.inl (scalarFieldUnitCR_none base1 rOut1 off1 a hin)
+  · push Not at hin
+    obtain ⟨k, hk, rfl⟩ := hin
+    exact Or.inr (scalarFieldUnitCR_none base2 rOut2 off2 _ (fun k2 hk2 => by bv_omega))
+
+set_option maxRecDepth 8000 in
+/-- **Three-field walk.** Decode-and-store scalar fields A, B, C (at consecutive buffer
+    offsets) into output slots `offA`, `offB`, `offC` through one output pointer `rOut`.
+    Composes `unified_two_scalar_field_walk` (A, B) with one more `regOwn` unit (C);
+    each prior cell is framed through the later units. The unit-AB ⊥ unit-C disjointness
+    is two `scalarFieldUnitCR_disjoint` applications. Carries all three `decodeScalar`
+    peels. -/
+theorem unified_three_scalar_field_walk
+    (base regionBase : Word) (rOut : Reg) (outBase memOldA memOldB memOldC : Word)
+    (offA offB offC : BitVec 12)
+    (bs : List Byte) (OA : Nat) (dataA dataB dataC tail : List Byte)
+    (v5Old v10 v11Old v12Old v14Old v15Old : Word)
+    (hlenA1 : 1 ≤ dataA.length) (hlenA8 : dataA.length ≤ 8)
+    (hlenB1 : 1 ≤ dataB.length) (hlenB8 : dataB.length ≤ 8)
+    (hlenC1 : 1 ≤ dataC.length) (hlenC8 : dataC.length ≤ 8)
+    (halign : regionBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hcode : base.toNat + 552 < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdrop : bs.drop OA =
+      encode (.bytes dataA) ++ encode (.bytes dataB) ++ encode (.bytes dataC) ++ tail) :
+    cpsTripleWithin
+        (((64 + 6 * dataA.length) + (64 + 6 * dataB.length)) + (64 + 6 * dataC.length))
+        base (base + 552)
+      ((scalarFieldUnitCR base rOut offA).union (scalarFieldUnitCR (base + 184) rOut offB)
+        |>.union (scalarFieldUnitCR (base + 368) rOut offC))
+      (((((.x5 ↦ᵣ v5Old) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
+          (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 OA)) ** (.x14 ↦ᵣ v14Old) **
+          (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs) **
+         ((rOut ↦ᵣ outBase) ** ((outBase + signExtend12 offA) ↦ₘ memOldA))) **
+        ((outBase + signExtend12 offB) ↦ₘ memOldB)) **
+       ((outBase + signExtend12 offC) ↦ₘ memOldC))
+      ((((rOut ↦ᵣ outBase) ** (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE dataC)) **
+          ((outBase + signExtend12 offC) ↦ₘ BitVec.ofNat 64 (Nat.fromBytesBE dataC))) **
+         ((.x13 ↦ᵣ (regionBase + BitVec.ofNat 64
+              (((OA + (encode (.bytes dataA)).length) + (encode (.bytes dataB)).length)
+                + (encode (.bytes dataC)).length))) **
+          regOwn .x14 ** regOwn .x12 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs **
+          regOwn .x5 ** regOwn .x10 ** (.x15 ↦ᵣ v15Old))) **
+       (((outBase + signExtend12 offA) ↦ₘ BitVec.ofNat 64 (Nat.fromBytesBE dataA)) **
+        ((outBase + signExtend12 offB) ↦ₘ BitVec.ofNat 64 (Nat.fromBytesBE dataB))))
+    ∧ decodeScalar (bs.drop OA)
+        = some (Nat.fromBytesBE dataA,
+            encode (.bytes dataB) ++ (encode (.bytes dataC) ++ tail))
+    ∧ decodeScalar (bs.drop (OA + (encode (.bytes dataA)).length))
+        = some (Nat.fromBytesBE dataB, encode (.bytes dataC) ++ tail)
+    ∧ decodeScalar (bs.drop ((OA + (encode (.bytes dataA)).length)
+          + (encode (.bytes dataB)).length))
+        = some (Nat.fromBytesBE dataC, tail) := by
+  -- Buffer-offset / drop bookkeeping for the three consecutive fields.
+  have hdropR : bs.drop OA =
+      encode (.bytes dataA) ++ (encode (.bytes dataB) ++ (encode (.bytes dataC) ++ tail)) := by
+    rw [hdrop]; simp only [List.append_assoc]
+  have hdrop2 : bs.drop OA =
+      encode (.bytes dataA) ++ encode (.bytes dataB) ++ (encode (.bytes dataC) ++ tail) := by
+    rw [hdropR, ← List.append_assoc]
+  have hdropBmid : bs.drop (OA + (encode (.bytes dataA)).length) =
+      encode (.bytes dataB) ++ (encode (.bytes dataC) ++ tail) := by
+    rw [← List.drop_drop, hdropR, List.drop_append_length]
+  have hdropC : bs.drop ((OA + (encode (.bytes dataA)).length) + (encode (.bytes dataB)).length) =
+      encode (.bytes dataC) ++ tail := by
+    rw [← List.drop_drop, hdropBmid, List.drop_append_length]
+  -- Fields A, B via the two-field walk (its `tail` is C's encoding ++ the real tail).
+  obtain ⟨tAB, hpA, hpB⟩ := unified_two_scalar_field_walk base regionBase rOut outBase memOldA
+    memOldB offA offB bs OA dataA dataB (encode (.bytes dataC) ++ tail)
+    v5Old v10 v11Old v12Old v14Old v15Old hlenA1 hlenA8 hlenB1 hlenB8 halign hover hwin hdrop2
+  -- Field C via the regOwn unit (its scratch is regOwn after A, B; x11 = B's value).
+  obtain ⟨tC, hpC⟩ := unified_scalar_field_decode_and_store_at_regOwn (base + 368) regionBase rOut
+    outBase memOldC offC bs ((OA + (encode (.bytes dataA)).length) + (encode (.bytes dataB)).length)
+    dataC tail (BitVec.ofNat 64 (Nat.fromBytesBE dataB)) v15Old hlenC1 hlenC8 halign hover hwin
+    hdropC
+  -- Frame field C's cell through A,B and fields A,B's (written) cells through C.
+  have tAB' := cpsTripleWithin_frameR ((outBase + signExtend12 offC) ↦ₘ memOldC) (by pcFree) tAB
+  have tC' := cpsTripleWithin_frameR
+    (((outBase + signExtend12 offA) ↦ₘ BitVec.ofNat 64 (Nat.fromBytesBE dataA)) **
+     ((outBase + signExtend12 offB) ↦ₘ BitVec.ofNat 64 (Nat.fromBytesBE dataB))) (by pcFree) tC
+  rw [show base + 368 + 184 = base + 552 from by bv_omega] at tC'
+  -- Disjointness: (unit-A ∪ unit-B) ⊥ unit-C, via the reusable range lemma.
+  have hd : ((scalarFieldUnitCR base rOut offA).union
+      (scalarFieldUnitCR (base + 184) rOut offB)).Disjoint
+      (scalarFieldUnitCR (base + 368) rOut offC) :=
+    CodeReq.Disjoint.union_left
+      (scalarFieldUnitCR_disjoint base (base + 368) rOut rOut offA offC (by bv_omega) (by bv_omega))
+      (scalarFieldUnitCR_disjoint (base + 184) (base + 368) rOut rOut offB offC
+        (by bv_omega) (by bv_omega))
+  refine ⟨?_, hpA, hpB, hpC⟩
+  exact cpsTripleWithin_seq hd
+    (cpsTripleWithin_weaken (fun _ h => h) (fun _ hp => by xperm_hyp hp) tAB') tC'
+
+-- Concrete cross-check: decode three single-byte scalars `0x2a`, `0x07`, `0x09`
+-- (= 42, 7, 9) from `[0x2a, 0x07, 0x09]` at `0x2000`, storing them to `0x3000`,
+-- `0x3008`, `0x3010` via `x18` ⇒ all three output cells written.
+example :=
+  unified_three_scalar_field_walk (0x1000 : Word) (0x2000 : Word) .x18 (0x3000 : Word) 0 0 0
+    0 8 16 [(0x2a : Byte), (0x07 : Byte), (0x09 : Byte)] 0
+    [(0x2a : Byte)] [(0x07 : Byte)] [(0x09 : Byte)] [] 0 0 0 0 0 0
+    (by decide) (by decide) (by decide) (by decide) (by decide) (by decide)
+    (by decide) (by decide) (by decide)
+    (by intro i hi
+        have hlen : ([(0x2a : Byte), (0x07 : Byte), (0x09 : Byte)]).length = 3 := by decide
+        rw [hlen] at hi
+        interval_cases i <;> decide)
+    (by decide)
+
+end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/UnifiedTwoScalarFieldWalk.lean
+++ b/EvmAsm/Rv64/RLP/UnifiedTwoScalarFieldWalk.lean
@@ -1,0 +1,286 @@
+/-
+  EvmAsm.Rv64.RLP.UnifiedTwoScalarFieldWalk
+
+  EL.3 / Phase 5 — the first end-to-end MULTI-FIELD walk. Two contributions:
+
+  1. `unified_scalar_field_decode_and_store_at_regOwn` — a `regOwn`-precondition
+     variant of `unified_scalar_field_decode_and_store`. The decode clobbers its
+     scratch registers (`x5, x10, x12, x14`) and so RELEASES them as `regOwn` in its
+     post; the concrete unit, however, REQUIRES them concrete in its pre, so a second
+     field's unit cannot consume the first's output. Peeling those four scratch
+     registers to `regOwn` (via `cpsTripleWithin_of_forall_regIs_to_regOwn`) makes the
+     unit callable after a prior field has run.
+
+  2. `unified_two_scalar_field_walk` — decode-and-store field A → output slot `offA`,
+     then field B → slot `offB`, through one output base pointer `rOut` (the STF
+     calling convention: output struct base in `a2`, one slot offset per field). The
+     concrete unit handles field A; the `regOwn` variant handles field B (its scratch
+     is `regOwn` after A). The first unit's `x13` (advanced to the next field) feeds
+     the second's payload pointer with no glue code, exactly as the sibling-descent
+     walk (`unified_list_descend_two_siblings_bridge`) chains two descents.
+
+  Layout (program base `base`; aligned `regionBase`, buffer `bs`, field-A offset `OA`):
+      base       < unified_scalar_field_decode_and_store : field A >   (base .. base+184)
+      base+184   < unified_scalar_field_decode_and_store : field B >   (base+184 .. base+368)
+      base+368   (exit)
+-/
+
+import EvmAsm.Rv64.RLP.UnifiedScalarFieldStore
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL.RLP
+open EvmAsm.Rv64.Tactics
+
+set_option maxRecDepth 8000 in
+/-- **`regOwn`-re-entry decode-and-store (chainable).** `unified_scalar_field_decode_and_store`
+    restated so the four clobbered scratch registers (`x5, x10, x12, x14`) are owned
+    abstractly (`regOwn`) in the precondition instead of held at concrete values. A
+    decode-and-store's post already releases exactly those four to `regOwn`, so this
+    lets one field unit feed DIRECTLY into the next. `x11`/`x15` stay concrete
+    (the prior unit supplies them: the value and the preserved scratch). Derived from
+    the concrete unit by consuming the four owned scratch registers via
+    `cpsTripleWithin_of_forall_regIs_to_regOwn`. -/
+theorem unified_scalar_field_decode_and_store_at_regOwn
+    (base regionBase : Word) (rOut : Reg) (outBase memOld : Word) (offset : BitVec 12)
+    (bs : List Byte) (O : Nat) (data : List Byte) (tail : List Byte)
+    (v11Old v15Old : Word)
+    (hlen1 : 1 ≤ data.length) (hlen8 : data.length ≤ 8)
+    (halign : regionBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdrop : bs.drop O = encode (.bytes data) ++ tail) :
+    cpsTripleWithin (64 + 6 * data.length) base (base + 184)
+      ((((CodeReq.singleton base (.LBU .x5 .x13 0)).union
+          (CodeReq.ofProg (base + 4) unified_decoder_prog)).union
+          (((CodeReq.singleton (base + 148) (.ADDI .x14 .x11 0)).union
+              (CodeReq.singleton (base + 152) (.ADDI .x11 .x0 0))).union
+              (CodeReq.ofProg (base + 156) (rlp_phase2_long_loop_body_prog (-20))))).union
+          (CodeReq.singleton (base + 180) (.SD rOut .x11 offset)))
+      (((regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) ** (.x11 ↦ᵣ v11Old) **
+        (regOwn .x12) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (regOwn .x14) **
+        (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs) **
+       ((rOut ↦ᵣ outBase) ** ((outBase + signExtend12 offset) ↦ₘ memOld)))
+      (((rOut ↦ᵣ outBase) ** (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE data)) **
+        ((outBase + signExtend12 offset) ↦ₘ BitVec.ofNat 64 (Nat.fromBytesBE data))) **
+       ((.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 (O + (encode (.bytes data)).length))) **
+        regOwn .x14 ** regOwn .x12 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs **
+        regOwn .x5 ** regOwn .x10 ** (.x15 ↦ᵣ v15Old)))
+    ∧ decodeScalar (bs.drop O) = some (Nat.fromBytesBE data, tail) := by
+  refine ⟨?_, ?_⟩
+  · refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x5)
+        (P := (.x0 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ v11Old) **
+          (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (.x15 ↦ᵣ v15Old) **
+          bytesRegion regionBase bs **
+          ((rOut ↦ᵣ outBase) ** ((outBase + signExtend12 offset) ↦ₘ memOld)) **
+          regOwn .x10 ** regOwn .x12 ** regOwn .x14)
+        (fun v5 => ?_))
+    refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x10)
+        (P := (.x0 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ v11Old) **
+          (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (.x15 ↦ᵣ v15Old) **
+          bytesRegion regionBase bs **
+          ((rOut ↦ᵣ outBase) ** ((outBase + signExtend12 offset) ↦ₘ memOld)) **
+          (.x5 ↦ᵣ v5) ** regOwn .x12 ** regOwn .x14)
+        (fun v10 => ?_))
+    refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x12)
+        (P := (.x0 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ v11Old) **
+          (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (.x15 ↦ᵣ v15Old) **
+          bytesRegion regionBase bs **
+          ((rOut ↦ᵣ outBase) ** ((outBase + signExtend12 offset) ↦ₘ memOld)) **
+          (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** regOwn .x14)
+        (fun v12 => ?_))
+    refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x14)
+        (P := (.x0 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ v11Old) **
+          (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (.x15 ↦ᵣ v15Old) **
+          bytesRegion regionBase bs **
+          ((rOut ↦ᵣ outBase) ** ((outBase + signExtend12 offset) ↦ₘ memOld)) **
+          (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x12 ↦ᵣ v12))
+        (fun v14 => ?_))
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (unified_scalar_field_decode_and_store base regionBase rOut outBase memOld offset
+        bs O data tail v5 v10 v11Old v12 v14 v15Old hlen1 hlen8 halign hover hwin hdrop).1
+  · exact (unified_scalar_field_decode_and_store base regionBase rOut outBase memOld offset
+      bs O data tail 0 0 v11Old 0 0 v15Old hlen1 hlen8 halign hover hwin hdrop).2
+
+set_option maxRecDepth 8000 in
+/-- **Two-field walk.** Decode-and-store scalar field A (at buffer offset `OA`) into
+    output slot `offA`, then field B (at `OA + len(field A)`) into slot `offB`, through
+    one output base pointer `rOut`. The concrete unit handles field A; the `regOwn`
+    variant handles field B, whose scratch is `regOwn` after A ran. Field A advances
+    `x13` to exactly field B's payload pointer — no glue code. The first cell (holding
+    A's value) is framed through B, and B's cell through A, so both output slots end up
+    written. Coincides with the two pure `decodeScalar` peels. -/
+theorem unified_two_scalar_field_walk
+    (base regionBase : Word) (rOut : Reg) (outBase memOldA memOldB : Word) (offA offB : BitVec 12)
+    (bs : List Byte) (OA : Nat) (dataA dataB tail : List Byte)
+    (v5Old v10 v11Old v12Old v14Old v15Old : Word)
+    (hlenA1 : 1 ≤ dataA.length) (hlenA8 : dataA.length ≤ 8)
+    (hlenB1 : 1 ≤ dataB.length) (hlenB8 : dataB.length ≤ 8)
+    (halign : regionBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdrop : bs.drop OA = encode (.bytes dataA) ++ encode (.bytes dataB) ++ tail) :
+    cpsTripleWithin ((64 + 6 * dataA.length) + (64 + 6 * dataB.length)) base (base + 368)
+      (((((CodeReq.singleton base (.LBU .x5 .x13 0)).union
+            (CodeReq.ofProg (base + 4) unified_decoder_prog)).union
+            (((CodeReq.singleton (base + 148) (.ADDI .x14 .x11 0)).union
+                (CodeReq.singleton (base + 152) (.ADDI .x11 .x0 0))).union
+                (CodeReq.ofProg (base + 156) (rlp_phase2_long_loop_body_prog (-20))))).union
+            (CodeReq.singleton (base + 180) (.SD rOut .x11 offA))).union
+        ((((CodeReq.singleton (base + 184) (.LBU .x5 .x13 0)).union
+            (CodeReq.ofProg (base + 184 + 4) unified_decoder_prog)).union
+            (((CodeReq.singleton (base + 184 + 148) (.ADDI .x14 .x11 0)).union
+                (CodeReq.singleton (base + 184 + 152) (.ADDI .x11 .x0 0))).union
+                (CodeReq.ofProg (base + 184 + 156) (rlp_phase2_long_loop_body_prog (-20))))).union
+            (CodeReq.singleton (base + 184 + 180) (.SD rOut .x11 offB))))
+      ((((.x5 ↦ᵣ v5Old) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
+          (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 OA)) ** (.x14 ↦ᵣ v14Old) **
+          (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs) **
+         ((rOut ↦ᵣ outBase) ** ((outBase + signExtend12 offA) ↦ₘ memOldA))) **
+       ((outBase + signExtend12 offB) ↦ₘ memOldB))
+      ((((rOut ↦ᵣ outBase) ** (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE dataB)) **
+          ((outBase + signExtend12 offB) ↦ₘ BitVec.ofNat 64 (Nat.fromBytesBE dataB))) **
+         ((.x13 ↦ᵣ (regionBase + BitVec.ofNat 64
+              ((OA + (encode (.bytes dataA)).length) + (encode (.bytes dataB)).length))) **
+          regOwn .x14 ** regOwn .x12 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs **
+          regOwn .x5 ** regOwn .x10 ** (.x15 ↦ᵣ v15Old))) **
+       ((outBase + signExtend12 offA) ↦ₘ BitVec.ofNat 64 (Nat.fromBytesBE dataA)))
+    ∧ decodeScalar (bs.drop OA) = some (Nat.fromBytesBE dataA, encode (.bytes dataB) ++ tail)
+    ∧ decodeScalar (bs.drop (OA + (encode (.bytes dataA)).length))
+        = some (Nat.fromBytesBE dataB, tail) := by
+  -- Field A's payload is followed by field B's encoding (re-associate the append).
+  have hdropA : bs.drop OA = encode (.bytes dataA) ++ (encode (.bytes dataB) ++ tail) := by
+    rw [hdrop, List.append_assoc]
+  -- Field B starts exactly after field A's encoding.
+  have hdropB : bs.drop (OA + (encode (.bytes dataA)).length) = encode (.bytes dataB) ++ tail := by
+    rw [← List.drop_drop, hdropA, List.drop_append_length]
+  obtain ⟨tA, hpureA⟩ := unified_scalar_field_decode_and_store base regionBase rOut outBase memOldA
+    offA bs OA dataA (encode (.bytes dataB) ++ tail) v5Old v10 v11Old v12Old v14Old v15Old
+    hlenA1 hlenA8 halign hover hwin hdropA
+  obtain ⟨tB, hpureB⟩ := unified_scalar_field_decode_and_store_at_regOwn (base + 184) regionBase rOut
+    outBase memOldB offB bs (OA + (encode (.bytes dataA)).length) dataB tail
+    (BitVec.ofNat 64 (Nat.fromBytesBE dataA)) v15Old hlenB1 hlenB8 halign hover hwin hdropB
+  -- Frame field B's output cell through field A, and field A's (written) cell through field B.
+  have tA' := cpsTripleWithin_frameR ((outBase + signExtend12 offB) ↦ₘ memOldB) (by pcFree) tA
+  have tB' := cpsTripleWithin_frameR
+    ((outBase + signExtend12 offA) ↦ₘ BitVec.ofNat 64 (Nat.fromBytesBE dataA)) (by pcFree) tB
+  rw [show base + 184 + 184 = base + 368 from by bv_omega] at tB'
+  -- Field-A unit (base .. base+184) ⊥ field-B unit (base+184 .. base+368): full 6×6 leaf split.
+  have hd : (((((CodeReq.singleton base (.LBU .x5 .x13 0)).union
+        (CodeReq.ofProg (base + 4) unified_decoder_prog)).union
+        (((CodeReq.singleton (base + 148) (.ADDI .x14 .x11 0)).union
+            (CodeReq.singleton (base + 152) (.ADDI .x11 .x0 0))).union
+            (CodeReq.ofProg (base + 156) (rlp_phase2_long_loop_body_prog (-20))))).union
+        (CodeReq.singleton (base + 180) (.SD rOut .x11 offA)))).Disjoint
+      ((((CodeReq.singleton (base + 184) (.LBU .x5 .x13 0)).union
+          (CodeReq.ofProg (base + 184 + 4) unified_decoder_prog)).union
+          (((CodeReq.singleton (base + 184 + 148) (.ADDI .x14 .x11 0)).union
+              (CodeReq.singleton (base + 184 + 152) (.ADDI .x11 .x0 0))).union
+              (CodeReq.ofProg (base + 184 + 156) (rlp_phase2_long_loop_body_prog (-20))))).union
+          (CodeReq.singleton (base + 184 + 180) (.SD rOut .x11 offB))) := by
+    -- A singleton A-leaf at `aX` (avoiding all of field-B's slots) ⊥ the field-B unit
+    -- (split right into its 6 leaves). The four singleton A-leaves reuse this.
+    have sDisj : ∀ (aX : Word) (iX : Instr),
+        aX ≠ base + 184 → aX ≠ base + 184 + 148 → aX ≠ base + 184 + 152 →
+        aX ≠ base + 184 + 180 →
+        (∀ k, k < 36 → aX ≠ (base + 184 + 4) + BitVec.ofNat 64 (4 * k)) →
+        (∀ k, k < 6 → aX ≠ (base + 184 + 156) + BitVec.ofNat 64 (4 * k)) →
+        (CodeReq.singleton aX iX).Disjoint
+          ((((CodeReq.singleton (base + 184) (.LBU .x5 .x13 0)).union
+              (CodeReq.ofProg (base + 184 + 4) unified_decoder_prog)).union
+              (((CodeReq.singleton (base + 184 + 148) (.ADDI .x14 .x11 0)).union
+                  (CodeReq.singleton (base + 184 + 152) (.ADDI .x11 .x0 0))).union
+                  (CodeReq.ofProg (base + 184 + 156) (rlp_phase2_long_loop_body_prog (-20))))).union
+              (CodeReq.singleton (base + 184 + 180) (.SD rOut .x11 offB))) :=
+      fun _ _ h1 h148 h152 h180 hp4 hp156 =>
+        CodeReq.Disjoint.union_right
+          (CodeReq.Disjoint.union_right
+            (CodeReq.Disjoint.union_right
+              (CodeReq.Disjoint.singleton h1)
+              (CodeReq.Disjoint.singleton_ofProg
+                (CodeReq.ofProg_none_range_len _ _ 36 _ unified_decoder_prog_length hp4)))
+            (CodeReq.Disjoint.union_right
+              (CodeReq.Disjoint.union_right
+                (CodeReq.Disjoint.singleton h148)
+                (CodeReq.Disjoint.singleton h152))
+              (CodeReq.Disjoint.singleton_ofProg
+                (CodeReq.ofProg_none_range_len _ _ 6 _ (by rfl) hp156))))
+          (CodeReq.Disjoint.singleton h180)
+    refine CodeReq.Disjoint.union_left
+      (CodeReq.Disjoint.union_left (CodeReq.Disjoint.union_left ?_ ?_)
+        (CodeReq.Disjoint.union_left (CodeReq.Disjoint.union_left ?_ ?_) ?_)) ?_
+    · -- LBU singleton (base) vs field-B unit:
+      exact sDisj _ _ (by bv_omega) (by bv_omega) (by bv_omega) (by bv_omega)
+        (by intro k hk; bv_omega) (by intro k hk; bv_omega)
+    · -- decoder ofProg (base+4, length 36) vs the field-B union:
+      exact CodeReq.Disjoint.union_right
+        (CodeReq.Disjoint.union_right
+          (CodeReq.Disjoint.union_right
+            (CodeReq.Disjoint.ofProg_singleton
+              (CodeReq.ofProg_none_range_len _ _ 36 _ unified_decoder_prog_length
+                (by intro k hk; bv_omega)))
+            (CodeReq.ofProg_disjoint_range_len _ _ 36 _ _ 36 unified_decoder_prog_length
+              unified_decoder_prog_length (by intro k1 k2 hk1 hk2; bv_omega)))
+          (CodeReq.Disjoint.union_right
+            (CodeReq.Disjoint.union_right
+              (CodeReq.Disjoint.ofProg_singleton
+                (CodeReq.ofProg_none_range_len _ _ 36 _ unified_decoder_prog_length
+                  (by intro k hk; bv_omega)))
+              (CodeReq.Disjoint.ofProg_singleton
+                (CodeReq.ofProg_none_range_len _ _ 36 _ unified_decoder_prog_length
+                  (by intro k hk; bv_omega))))
+            (CodeReq.ofProg_disjoint_range_len _ _ 36 _ _ 6 unified_decoder_prog_length (by rfl)
+              (by intro k1 k2 hk1 hk2; bv_omega))))
+        (CodeReq.Disjoint.ofProg_singleton
+          (CodeReq.ofProg_none_range_len _ _ 36 _ unified_decoder_prog_length
+            (by intro k hk; bv_omega)))
+    · -- ADDI x14 singleton (base+148) vs field-B unit:
+      exact sDisj _ _ (by bv_omega) (by bv_omega) (by bv_omega) (by bv_omega)
+        (by intro k hk; bv_omega) (by intro k hk; bv_omega)
+    · -- ADDI x11 singleton (base+152) vs field-B unit:
+      exact sDisj _ _ (by bv_omega) (by bv_omega) (by bv_omega) (by bv_omega)
+        (by intro k hk; bv_omega) (by intro k hk; bv_omega)
+    · -- loop ofProg (base+156, length 6) vs the field-B union:
+      exact CodeReq.Disjoint.union_right
+        (CodeReq.Disjoint.union_right
+          (CodeReq.Disjoint.union_right
+            (CodeReq.Disjoint.ofProg_singleton
+              (CodeReq.ofProg_none_range_len _ _ 6 _ (by rfl) (by intro k hk; bv_omega)))
+            (CodeReq.ofProg_disjoint_range_len _ _ 6 _ _ 36 (by rfl) unified_decoder_prog_length
+              (by intro k1 k2 hk1 hk2; bv_omega)))
+          (CodeReq.Disjoint.union_right
+            (CodeReq.Disjoint.union_right
+              (CodeReq.Disjoint.ofProg_singleton
+                (CodeReq.ofProg_none_range_len _ _ 6 _ (by rfl) (by intro k hk; bv_omega)))
+              (CodeReq.Disjoint.ofProg_singleton
+                (CodeReq.ofProg_none_range_len _ _ 6 _ (by rfl) (by intro k hk; bv_omega))))
+            (CodeReq.ofProg_disjoint_range_len _ _ 6 _ _ 6 (by rfl) (by rfl)
+              (by intro k1 k2 hk1 hk2; bv_omega))))
+        (CodeReq.Disjoint.ofProg_singleton
+          (CodeReq.ofProg_none_range_len _ _ 6 _ (by rfl) (by intro k hk; bv_omega)))
+    · -- SD singleton (base+180) vs field-B unit:
+      exact sDisj _ _ (by bv_omega) (by bv_omega) (by bv_omega) (by bv_omega)
+        (by intro k hk; bv_omega) (by intro k hk; bv_omega)
+  refine ⟨?_, hpureA, hpureB⟩
+  exact cpsTripleWithin_seq hd
+    (cpsTripleWithin_weaken (fun _ h => h) (fun _ hp => by xperm_hyp hp) tA') tB'
+
+-- Concrete cross-check: decode two single-byte scalars `0x2a` (= 42) and `0x07` (= 7)
+-- from the buffer `[0x2a, 0x07]` at `0x2000`, storing 42 → `0x3000` (offset 0) and
+-- 7 → `0x3008` (offset 8) via `x18` ⇒ both output cells written, both `decodeScalar` peels.
+example :=
+  unified_two_scalar_field_walk (0x1000 : Word) (0x2000 : Word) .x18 (0x3000 : Word) 0 0 0 8
+    [(0x2a : Byte), (0x07 : Byte)] 0 [(0x2a : Byte)] [(0x07 : Byte)] [] 0 0 0 0 0 0
+    (by decide) (by decide) (by decide) (by decide) (by decide) (by decide)
+    (by intro i hi
+        have hlen : ([(0x2a : Byte), (0x07 : Byte)]).length = 2 := by decide
+        rw [hlen] at hi
+        interval_cases i <;> decide)
+    (by decide)
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -1620,13 +1620,25 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     hyps — a clashing reg just makes the pre vacuous), and the store CR (`SD@base+180`) is disjoint from the
     decoder/read CR (`base .. base+176`). Rides the pure `decodeScalar` fact along. Axiom-clean, 0 sorry, 0
     warnings, no heartbeat override. Concrete `0x2a → 42` store-to-`0x3000` example. Built first try (1.6s).
-  - **Next (regOwn-pre + walk → schema decoders):** make a `regOwn`-pre variant of the decode-and-store unit
-    (peel `x5/x10/x12/x14` per `cpsTripleWithin_of_forall_regIs_to_regOwn`, à la `…_at_regOwn`) and
-    `cpsTripleWithin_seq` two of them — the first end-to-end multi-field walk, each value in its own slot.
-    Then chain N units across a fixed schema → concrete STF transaction (9 fields) / header (~19 fields)
-    decoders producing the `BlockInput`. Wide scalars (uint256) / byte-arrays (20/32-byte address/hash) /
-    zero-length scalars (`n = 0`) need multi-word / byte-copy / branch variants. (The 3-sibling block framing
-    walk via `…_at_regOwn` + `descend_cr_disjoint` is trivial glue, deferred.)
+  - ✅ **Step 11 — first multi-field walk** (`UnifiedTwoScalarFieldWalk.lean`).
+    **`unified_scalar_field_decode_and_store_at_regOwn`**: the decode-and-store unit restated with its four
+    clobbered scratch registers (`x5/x10/x12/x14`) abstracted to `regOwn` in the pre (`x11`/`x15` stay
+    concrete — the prior unit supplies them), via four nested `cpsTripleWithin_of_forall_regIs_to_regOwn`,
+    so it's callable after a prior field has run. **`unified_two_scalar_field_walk`**: `cpsTripleWithin_seq`
+    of a concrete unit (field A → slot `offA`) ⨾ the `regOwn` variant (field B → slot `offB`) through one
+    output pointer `rOut` — the first end-to-end multi-field walk. A's advanced `x13` feeds B's payload
+    pointer with no glue; A's written cell is framed through B and B's cell through A, so both slots end up
+    written; rides the two pure `decodeScalar` peels (`hdropB` via `← drop_drop`/`drop_append_length`). The
+    36-leaf unit-A ⊥ unit-B disjointness is one explicit nested `union_left`/`union_right` term (a local
+    `sDisj` helper shares the 4 singleton A-leaves; `ofProg_disjoint_range_len` for the ofProg pairs; per-leaf
+    explicit lengths to avoid `first`-backtracking whnf-loops). Axiom-clean, 0 sorry, 0 warnings, no heartbeat
+    override. Concrete two-byte example: `42 → 0x3000`, `7 → 0x3008`.
+  - **Next (N-field schema chain → STF decoders):** chain N `regOwn`-pre decode-and-store units across a
+    fixed `(offset, fieldData)` schema (recursion/fold over the list, list-induction on the CodeReq unions
+    and frame bookkeeping) → concrete STF transaction (9 fields) / header (~19 fields) decoders producing the
+    `BlockInput`. Wide scalars (uint256) / byte-arrays (20/32-byte address/hash) / zero-length scalars
+    (`n = 0`) need multi-word / byte-copy / branch variants. (The 3-sibling block framing walk via
+    `…_at_regOwn` + `descend_cr_disjoint` is trivial glue, deferred.)
 - Phase 6: Top-level pipeline (`read_input` -> decode -> `write_output`)
 - **Host I/O ABI**: See `docs/zkvm-host-io-interface.md`; SP1
   `HINT_LEN`/`HINT_READ`/`COMMIT` are legacy handler shapes, not the target

--- a/PLAN.md
+++ b/PLAN.md
@@ -1633,7 +1633,22 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     `sDisj` helper shares the 4 singleton A-leaves; `ofProg_disjoint_range_len` for the ofProg pairs; per-leaf
     explicit lengths to avoid `first`-backtracking whnf-loops). Axiom-clean, 0 sorry, 0 warnings, no heartbeat
     override. Concrete two-byte example: `42 → 0x3000`, `7 → 0x3008`.
-  - **Next (N-field schema chain → STF decoders):** chain N `regOwn`-pre decode-and-store units across a
+  - ✅ **Step 12 — reusable field-unit CR + three-field walk** (`ScalarFieldWalkChain.lean`).
+    **`scalarFieldUnitCR base rOut offset`**: the decode-and-store unit's 46-slot CodeReq named for reuse
+    (defeq to the units' inline CR). **`scalarFieldUnitCR_none`** / **`scalarFieldUnitCR_disjoint`**: a
+    range-based disjointness lemma (à la `descend_cr_disjoint` / `descendCR_none`) — two units whose 184-byte
+    code ranges don't overlap (`base2 ≥ base1 + 184`) have disjoint CodeReqs, proved ONCE. This replaces the
+    36-leaf-per-pair blowup: chaining is now `union_left`/`union_right` + one lemma application per pair.
+    **`unified_three_scalar_field_walk`**: composes `unified_two_scalar_field_walk` (A, B) ⨾ one more `regOwn`
+    unit (C), each prior cell framed through the later units, unit-AB ⊥ unit-C via two
+    `scalarFieldUnitCR_disjoint` applications; carries all three `decodeScalar` peels (offset/drop bookkeeping
+    via `append_assoc` + `← drop_drop`/`drop_append_length`). The concrete inductive step toward N. Built
+    first try. Axiom-clean, 0 sorry, 0 warnings, no heartbeat override. Three-byte example: `42/7/9 →
+    0x3000/0x3008/0x3010`.
+  - **Next (recursive N-field walk → STF decoders):** with the per-pair disjointness now a one-liner, define
+    the N-field walk by recursion over a list of field descriptors `(offset, data)` and prove by induction
+    (inductive step = one `regOwn` unit ⨾ the rest; the output cells become an opaque `**`-fold framed
+    through each step). Then chain N `regOwn`-pre decode-and-store units across a
     fixed `(offset, fieldData)` schema (recursion/fold over the list, list-induction on the CodeReq unions
     and frame bookkeeping) → concrete STF transaction (9 fields) / header (~19 fields) decoders producing the
     `BlockInput`. Wide scalars (uint256) / byte-arrays (20/32-byte address/hash) / zero-length scalars


### PR DESCRIPTION
## Summary

Phase 5 of the RLP RISC-V decoder (EL.3): the first end-to-end **multi-field walk**, plus the reusable infrastructure to chain arbitrarily many fields. Two commits (steps 11 and 12); step 12 imports and extends step 11, so they're bundled here.

### Step 11 — `EvmAsm/Rv64/RLP/UnifiedTwoScalarFieldWalk.lean`
- **`unified_scalar_field_decode_and_store_at_regOwn`**: the decode-and-store unit (#9088) restated with its four clobbered scratch registers (`x5/x10/x12/x14`) abstracted to `regOwn` in the precondition (via nested `cpsTripleWithin_of_forall_regIs_to_regOwn`), so it's callable after a prior field has run. `x11`/`x15` stay concrete — the prior unit supplies them.
- **`unified_two_scalar_field_walk`**: `cpsTripleWithin_seq` of a concrete unit (field A → slot `offA`) with the `regOwn` variant (field B → slot `offB`), through one output base pointer. A's advanced `x13` feeds B's payload pointer with no glue; each cell is framed through the other unit, so both slots are written. Carries both `decodeScalar` peels.

### Step 12 — `EvmAsm/Rv64/RLP/ScalarFieldWalkChain.lean`
- **`scalarFieldUnitCR base rOut offset`**: the unit's 46-slot CodeReq named for reuse (defeq to the units' inline CR).
- **`scalarFieldUnitCR_none` / `scalarFieldUnitCR_disjoint`**: a range-based disjointness lemma (à la `descend_cr_disjoint`/`descendCR_none`) — two units whose 184-byte code ranges don't overlap (`base2 ≥ base1 + 184`) have disjoint CodeReqs, proved **once**. This replaces the 36-leaf-per-pair disjointness blowup with `union_left`/`union_right` + one application per pair.
- **`unified_three_scalar_field_walk`**: composes the two-field walk (A, B) with one more `regOwn` unit (C), each prior cell framed through the later units, unit-AB ⊥ unit-C via two `scalarFieldUnitCR_disjoint` applications. Carries all three `decodeScalar` peels. The concrete inductive step toward a recursive N-field schema walk.

## Verification
- `lake build` of both modules + umbrella `EvmAsm.Rv64.RLP` — clean, 0 warnings under `EvmAsm/`.
- `#print axioms` on all four theorems → `[propext, Classical.choice, Quot.sound]` only; 0 sorry.
- `scripts/check-forbidden-tactics.sh` OK; no `maxHeartbeats` override.
- Concrete examples: `42 → 0x3000`, `7 → 0x3008` (2-field); `42/7/9 → 0x3000/0x3008/0x3010` (3-field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)