### PR TITLE
feat(rv64/rlp): recursive N-field walk infrastructure (Phase 5, step 13)

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -78,6 +78,7 @@ import EvmAsm.Rv64.RLP.UnifiedScalarFieldDecode
 import EvmAsm.Rv64.RLP.UnifiedScalarFieldStore
 import EvmAsm.Rv64.RLP.UnifiedTwoScalarFieldWalk
 import EvmAsm.Rv64.RLP.ScalarFieldWalkChain
+import EvmAsm.Rv64.RLP.ScalarFieldWalkInfra
 import EvmAsm.Rv64.RLP.NestedDescendOne
 import EvmAsm.Rv64.RLP.UnifiedDecodeItem
 import EvmAsm.Rv64.RLP.UnifiedDecodeItemReconverge

--- a/EvmAsm/Rv64/RLP/ScalarFieldWalkInfra.lean
+++ b/EvmAsm/Rv64/RLP/ScalarFieldWalkInfra.lean
@@ -1,0 +1,103 @@
+/-
+  EvmAsm.Rv64.RLP.ScalarFieldWalkInfra
+
+  EL.3 / Phase 5 — infrastructure for the recursive N-field scalar walk.
+
+  The three-field walk (`unified_three_scalar_field_walk`) was unrolled by hand. To
+  decode a fixed schema of N scalar fields by recursion, we need three pieces, all
+  assembled here (the recursive walk theorem itself follows in a later step):
+
+  1. `unified_scalar_field_decode_and_store_at_regOwn_memOwn` — the decode-and-store
+     unit with BOTH its scratch registers (`regOwn`) AND its output cell (`memOwn`)
+     owned abstractly. This is the atomic unit the recursive walk iterates: a field's
+     output slot holds an unknown old value (it gets overwritten), so the walk's
+     precondition is a fold of `memOwn` cells, peeled one per step.
+
+  2. `nFieldWalkCR base rOut fields` — the recursive CodeReq of the unrolled N-unit
+     program (unit `i` at `base + 184*i`).
+
+  3. `scalarFieldUnitCR_disjoint_walkCR` — a single unit's CodeReq is disjoint from the
+     whole rest-of-walk CodeReq (proved by induction on the field list, each step a
+     `scalarFieldUnitCR_disjoint`). This discharges the `cpsTripleWithin_seq` obligation
+     in the recursive walk's inductive step with one lemma.
+-/
+
+import EvmAsm.Rv64.RLP.ScalarFieldWalkChain
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL.RLP
+open EvmAsm.Rv64.Tactics
+
+set_option maxRecDepth 8000 in
+/-- **`regOwn` + `memOwn` re-entry unit.** Like `unified_scalar_field_decode_and_store_at_regOwn`
+    but the output cell is also owned abstractly (`memOwn`) rather than at a known old
+    value — the atomic unit a multi-field walk iterates over a fold of `memOwn` slots. -/
+theorem unified_scalar_field_decode_and_store_at_regOwn_memOwn
+    (base regionBase : Word) (rOut : Reg) (outBase : Word) (offset : BitVec 12)
+    (bs : List Byte) (O : Nat) (data : List Byte) (tail : List Byte)
+    (v11Old v15Old : Word)
+    (hlen1 : 1 ≤ data.length) (hlen8 : data.length ≤ 8)
+    (halign : regionBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdrop : bs.drop O = encode (.bytes data) ++ tail) :
+    cpsTripleWithin (64 + 6 * data.length) base (base + 184)
+      (scalarFieldUnitCR base rOut offset)
+      (((regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) ** (.x11 ↦ᵣ v11Old) **
+        (regOwn .x12) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (regOwn .x14) **
+        (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs) **
+       ((rOut ↦ᵣ outBase) ** memOwn (outBase + signExtend12 offset)))
+      (((rOut ↦ᵣ outBase) ** (.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE data)) **
+        ((outBase + signExtend12 offset) ↦ₘ BitVec.ofNat 64 (Nat.fromBytesBE data))) **
+       ((.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 (O + (encode (.bytes data)).length))) **
+        regOwn .x14 ** regOwn .x12 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs **
+        regOwn .x5 ** regOwn .x10 ** (.x15 ↦ᵣ v15Old)))
+    ∧ decodeScalar (bs.drop O) = some (Nat.fromBytesBE data, tail) := by
+  refine ⟨?_, ?_⟩
+  · refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (cpsTripleWithin_of_forall_memIs_to_memOwn (a := outBase + signExtend12 offset)
+        (P := ((regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) ** (.x11 ↦ᵣ v11Old) **
+          (regOwn .x12) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (regOwn .x14) **
+          (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs) ** (rOut ↦ᵣ outBase))
+        (fun vOld => ?_))
+    have h := (unified_scalar_field_decode_and_store_at_regOwn base regionBase rOut outBase vOld
+      offset bs O data tail v11Old v15Old hlen1 hlen8 halign hover hwin hdrop).1
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (show cpsTripleWithin _ _ _ (scalarFieldUnitCR base rOut offset) _ _ from h)
+  · exact (unified_scalar_field_decode_and_store_at_regOwn base regionBase rOut outBase 0 offset
+      bs O data tail v11Old v15Old hlen1 hlen8 halign hover hwin hdrop).2
+
+/-- The CodeReq of the unrolled N-field walk: unit `i` (a `scalarFieldUnitCR`) lives at
+    `base + 184*i`. -/
+def nFieldWalkCR (base : Word) (rOut : Reg) : List (BitVec 12 × List Byte) → CodeReq
+  | [] => CodeReq.empty
+  | (off, _) :: rest => (scalarFieldUnitCR base rOut off).union (nFieldWalkCR (base + 184) rOut rest)
+
+/-- **Single unit ⊥ rest-of-walk.** A scalar-field unit at `base` is disjoint from the
+    CodeReq of an N-field walk starting at `bw ≥ base + 184`. Proved by induction on the
+    field list; the building block for the recursive walk's `cpsTripleWithin_seq`. -/
+theorem scalarFieldUnitCR_disjoint_walkCR (base bw : Word) (rOut rOut' : Reg) (off : BitVec 12)
+    (fields : List (BitVec 12 × List Byte))
+    (hsep : base.toNat + 184 ≤ bw.toNat)
+    (hov : bw.toNat + 184 * fields.length < 2 ^ 64) :
+    (scalarFieldUnitCR base rOut off).Disjoint (nFieldWalkCR bw rOut' fields) := by
+  induction fields generalizing bw with
+  | nil => simpa [nFieldWalkCR] using CodeReq.Disjoint.empty_right (scalarFieldUnitCR base rOut off)
+  | cons f rest ih =>
+    obtain ⟨offf, _dataf⟩ := f
+    rw [nFieldWalkCR]
+    refine CodeReq.Disjoint.union_right ?_ ?_
+    · exact scalarFieldUnitCR_disjoint base bw rOut rOut' off offf hsep
+        (by simp only [List.length_cons] at hov; omega)
+    · exact ih (bw + 184)
+        (by have : bw.toNat + 184 < 2 ^ 64 := by
+              simp only [List.length_cons] at hov; omega
+            bv_omega)
+        (by have hb : (bw + 184).toNat = bw.toNat + 184 := by
+              have : bw.toNat + 184 < 2 ^ 64 := by simp only [List.length_cons] at hov; omega
+              bv_omega
+            simp only [List.length_cons] at hov; omega)
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -1645,10 +1645,22 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     via `append_assoc` + `← drop_drop`/`drop_append_length`). The concrete inductive step toward N. Built
     first try. Axiom-clean, 0 sorry, 0 warnings, no heartbeat override. Three-byte example: `42/7/9 →
     0x3000/0x3008/0x3010`.
-  - **Next (recursive N-field walk → STF decoders):** with the per-pair disjointness now a one-liner, define
-    the N-field walk by recursion over a list of field descriptors `(offset, data)` and prove by induction
-    (inductive step = one `regOwn` unit ⨾ the rest; the output cells become an opaque `**`-fold framed
-    through each step). Then chain N `regOwn`-pre decode-and-store units across a
+  - ✅ **Step 13 — recursive N-field walk infrastructure** (`ScalarFieldWalkInfra.lean`).
+    Three pieces that unblock the recursive walk: **`unified_scalar_field_decode_and_store_at_regOwn_memOwn`**
+    — the atomic unit with BOTH `regOwn` scratch AND a `memOwn` output cell (one extra
+    `cpsTripleWithin_of_forall_memIs_to_memOwn` peel over the step-11 regOwn variant), so the walk's pre is a
+    fold of `memOwn` slots; **`nFieldWalkCR base rOut fields`** — the recursive CodeReq of the unrolled
+    N-unit program (unit `i` = `scalarFieldUnitCR` at `base + 184*i`); **`scalarFieldUnitCR_disjoint_walkCR`**
+    — a single unit ⊥ the whole rest-of-walk CodeReq, by induction on the field list (each step a
+    `scalarFieldUnitCR_disjoint`), which discharges the recursive walk's `cpsTripleWithin_seq` obligation in
+    one application. Built first try. Axiom-clean, 0 sorry, 0 warnings, no heartbeat override.
+  - **Next (recursive N-field walk theorem):** define `nFieldOutOwn`/`nFieldOutVal` (the `**`-folds of the
+    output cells, bottoming out at `empAssertion`) and prove **`unified_n_scalar_field_walk`** by induction on
+    the field list: nil = `cpsTripleWithin_refl` (weaken `x11` to `regOwn`); cons = the `regOwn`+`memOwn` unit
+    ⨾ the IH, framing the rest-cells through the unit and the written cell through the IH, disjointness via
+    `scalarFieldUnitCR_disjoint_walkCR`. The crux risk is `xperm_hyp` reconciling the intermediate state with
+    the opaque fold conjunct (keep `nFieldOutOwn`/`Val` non-reducible so they stay single atoms). Then chain N
+    `regOwn`-pre decode-and-store units across a
     fixed `(offset, fieldData)` schema (recursion/fold over the list, list-induction on the CodeReq unions
     and frame bookkeeping) → concrete STF transaction (9 fields) / header (~19 fields) decoders producing the
     `BlockInput`. Wide scalars (uint256) / byte-arrays (20/32-byte address/hash) / zero-length scalars


### PR DESCRIPTION
## Summary

Phase 5 of the RLP RISC-V decoder (EL.3): the infrastructure that unblocks a **recursive N-field scalar walk** (the walk theorem itself follows in the next step). Three pieces in `EvmAsm/Rv64/RLP/ScalarFieldWalkInfra.lean`:

1. **`unified_scalar_field_decode_and_store_at_regOwn_memOwn`** — the atomic unit a multi-field walk iterates: the decode-and-store unit with **both** its scratch registers (`regOwn`) and its output cell (`memOwn`) owned abstractly. One extra `cpsTripleWithin_of_forall_memIs_to_memOwn` peel over the step-11 `regOwn` variant. A field's output slot holds an unknown old value (overwritten), so the walk's precondition is a fold of `memOwn` slots peeled one per step.

2. **`nFieldWalkCR base rOut fields`** — the recursive CodeReq of the unrolled N-unit program (unit `i` = `scalarFieldUnitCR` at `base + 184*i`).

3. **`scalarFieldUnitCR_disjoint_walkCR`** — a single unit's CodeReq is disjoint from the whole rest-of-walk CodeReq, proved by induction on the field list (each step a `scalarFieldUnitCR_disjoint` from step 12). This discharges the recursive walk's `cpsTripleWithin_seq` disjointness obligation in one application, instead of an O(N²) leaf expansion.

## Stacking

Stacked on `feat/rv64-rlp-two-field-walk` (PR #9089, steps 11–12), which this imports. Retarget to `main` once #9089 merges.

## Verification
- `lake build` + umbrella `EvmAsm.Rv64.RLP` — clean, 0 warnings under `EvmAsm/`.
- `#print axioms` on both theorems → `[propext, Classical.choice, Quot.sound]` only; 0 sorry.
- `scripts/check-forbidden-tactics.sh` OK; no `maxHeartbeats` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)