### PR TITLE
proof(mulmod): lift eighth product core block

### DIFF
--- a/EvmAsm/Evm64/MulMod/Compose/ProductCore.lean
+++ b/EvmAsm/Evm64/MulMod/Compose/ProductCore.lean
@@ -354,4 +354,51 @@ theorem evm_mulmod_product_seventh_core_finish_evm_mulmod_spec_within
       x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old)
     (hmono := evm_mulmod_program_code_product_seventh_core_finish_sub base)
 
+/-- The core+finish block of the eighth product partial at offset 1004 is subsumed
+    by the top-level `evm_mulmod_program_code`. -/
+theorem evm_mulmod_program_code_product_eighth_core_finish_sub
+    (base : Word) :
+    ∀ a i, (evm_mulmod_product_add_partial_core_finish_code (base + 1004)
+        (16 : BitVec 12) (40 : BitVec 12) (120 : BitVec 12) (128 : BitVec 12)) a = some i →
+      (evm_mulmod_program_code base) a = some i := by
+  unfold evm_mulmod_product_add_partial_core_finish_code evm_mulmod_program_code
+  refine CodeReq.ofProg_mono_sub base (base + 1004) evm_mulmod
+    (LD .x5 .x12 (16 : BitVec 12) ;;
+     LD .x6 .x12 (40 : BitVec 12) ;;
+     single (.MUL .x7 .x5 .x6) ;;
+     single (.MULHU .x8 .x5 .x6) ;;
+     LD .x9 .x12 (120 : BitVec 12) ;;
+     ADD .x9 .x9 .x7 ;;
+     SLTU .x10 .x9 .x7 ;;
+     SD .x12 .x9 (120 : BitVec 12) ;;
+     LD .x9 .x12 (128 : BitVec 12) ;;
+     ADD .x11 .x9 .x8 ;;
+     SLTU .x13 .x11 .x8 ;;
+     ADD .x11 .x11 .x10 ;;
+     SLTU .x14 .x11 .x10 ;;
+     OR' .x10 .x13 .x14 ;;
+     SD .x12 .x11 (128 : BitVec 12)) 251 ?_ ?_ ?_ ?_
+  · bv_omega
+  · evm_mulmod_slice_rfl
+  · rw [evm_mulmod_length]
+    decide
+  · rw [evm_mulmod_length]
+    decide
+
+/-- Eighth product-partial core+finish block lifted onto `evm_mulmod_program_code`. -/
+theorem evm_mulmod_product_eighth_core_finish_evm_mulmod_spec_within
+    (sp : Word) (base : Word) (a b lo hi : Word)
+    (x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word) :
+    cpsTripleWithin 15 (base + 1004) ((base + 1004) + 60) (evm_mulmod_program_code base)
+      (evmMulModAddPartialCoreFullPre sp
+        (16 : BitVec 12) (40 : BitVec 12) (120 : BitVec 12) (128 : BitVec 12) a b lo hi
+        x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old)
+      (evmMulModAddPartialCorePost sp
+        (16 : BitVec 12) (40 : BitVec 12) (120 : BitVec 12) (128 : BitVec 12) a b lo hi) :=
+  cpsTripleWithin_extend_code
+    (h := evm_mulmod_product_add_partial_core_finish_spec_within sp (base + 1004)
+      (16 : BitVec 12) (40 : BitVec 12) (120 : BitVec 12) (128 : BitVec 12) a b lo hi
+      x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old)
+    (hmono := evm_mulmod_program_code_product_eighth_core_finish_sub base)
+
 end EvmAsm.Evm64.MulMod.Compose


### PR DESCRIPTION
## Summary
- stack on top of PR #9093
- lift the eighth MULMOD product partial core+finish block onto evm_mulmod_program_code
- verify the concrete slice at offset 1004 using the generic add-partial core-finish CPS triple

Base PR: #9093

Directed by @pirapira; implemented by Codex