### PR TITLE
proof(mulmod): lift final product core block

### DIFF
--- a/DRIFT.md
+++ b/DRIFT.md
@@ -52,6 +52,7 @@ precondition; the excluded domain is **unverified**.
 |---|---|
 | `SDIV` | callable+dispatch shim; evm_sdiv_stack_spec_within conditional on hStack (discharged for divisor=0 and n=1/2/3/n4-call-skip); blocked on DIV/MOD spec-layer migration (bead evm-asm-9iqmw) |
 | `MOD` | stack spec parametric over ModStackSpecCase (bzero / n=1,2,3, all require b.getLimbN 3 = 0); n=4 path not covered. Executable evm_mod uses divK_div128_v4 (PR #4992). Full-domain unconditional closure tracked by bead evm-asm-9iqmw / gh-61 |
+| `SMOD` | all-case v4 wrapper result-stack spec; zero divisor discharged, nonzero path still parameterized by unsigned-MOD callable h_stack |
 
 ### 🟡 `partly` opcodes — no complete top-level triple yet
 
@@ -59,8 +60,7 @@ Pure-spec / `<op>_correct` lemma proven, but no end-to-end stack-spec wrap.
 
 | Opcode | Why not (yet) fully proven |
 |---|---|
-| `SMOD` | smod_correct proven; no top-level Hoare triple |
-| `ADDMOD` | addmod_correct proven; only b=0 stack-spec done |
+| `ADDMOD` | addmod_correct proven; zero-modulus stack spec done for arbitrary b |
 | `MULMOD` | mulmod_correct proven; no top-level Hoare triple |
 | `EXP` | exp_correct proven; program in active development |
 | `CALLDATACOPY` | preamble + partial memory effect; full loop pending |

--- a/EvmAsm/Evm64/MulMod/Compose/ProductCore.lean
+++ b/EvmAsm/Evm64/MulMod/Compose/ProductCore.lean
@@ -730,4 +730,51 @@ theorem evm_mulmod_product_fifteenth_core_finish_evm_mulmod_spec_within
       x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old)
     (hmono := evm_mulmod_program_code_product_fifteenth_core_finish_sub base)
 
+/-- The core+finish block of the final product partial at offset 1756 is subsumed
+    by the top-level `evm_mulmod_program_code`. -/
+theorem evm_mulmod_program_code_product_sixteenth_core_finish_sub
+    (base : Word) :
+    ∀ a i, (evm_mulmod_product_add_partial_core_finish_code (base + 1756)
+        (24 : BitVec 12) (56 : BitVec 12) (144 : BitVec 12) (152 : BitVec 12)) a = some i →
+      (evm_mulmod_program_code base) a = some i := by
+  unfold evm_mulmod_product_add_partial_core_finish_code evm_mulmod_program_code
+  refine CodeReq.ofProg_mono_sub base (base + 1756) evm_mulmod
+    (LD .x5 .x12 (24 : BitVec 12) ;;
+     LD .x6 .x12 (56 : BitVec 12) ;;
+     single (.MUL .x7 .x5 .x6) ;;
+     single (.MULHU .x8 .x5 .x6) ;;
+     LD .x9 .x12 (144 : BitVec 12) ;;
+     ADD .x9 .x9 .x7 ;;
+     SLTU .x10 .x9 .x7 ;;
+     SD .x12 .x9 (144 : BitVec 12) ;;
+     LD .x9 .x12 (152 : BitVec 12) ;;
+     ADD .x11 .x9 .x8 ;;
+     SLTU .x13 .x11 .x8 ;;
+     ADD .x11 .x11 .x10 ;;
+     SLTU .x14 .x11 .x10 ;;
+     OR' .x10 .x13 .x14 ;;
+     SD .x12 .x11 (152 : BitVec 12)) 439 ?_ ?_ ?_ ?_
+  · bv_omega
+  · evm_mulmod_slice_rfl
+  · rw [evm_mulmod_length]
+    decide
+  · rw [evm_mulmod_length]
+    decide
+
+/-- Final product-partial core+finish block lifted onto `evm_mulmod_program_code`. -/
+theorem evm_mulmod_product_sixteenth_core_finish_evm_mulmod_spec_within
+    (sp : Word) (base : Word) (a b lo hi : Word)
+    (x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word) :
+    cpsTripleWithin 15 (base + 1756) ((base + 1756) + 60) (evm_mulmod_program_code base)
+      (evmMulModAddPartialCoreFullPre sp
+        (24 : BitVec 12) (56 : BitVec 12) (144 : BitVec 12) (152 : BitVec 12) a b lo hi
+        x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old)
+      (evmMulModAddPartialCorePost sp
+        (24 : BitVec 12) (56 : BitVec 12) (144 : BitVec 12) (152 : BitVec 12) a b lo hi) :=
+  cpsTripleWithin_extend_code
+    (h := evm_mulmod_product_add_partial_core_finish_spec_within sp (base + 1756)
+      (24 : BitVec 12) (56 : BitVec 12) (144 : BitVec 12) (152 : BitVec 12) a b lo hi
+      x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old)
+    (hmono := evm_mulmod_program_code_product_sixteenth_core_finish_sub base)
+
 end EvmAsm.Evm64.MulMod.Compose


### PR DESCRIPTION
## Summary
- stack on top of PR #9102
- lift the final MULMOD product partial core+finish block onto evm_mulmod_program_code
- complete ProductCore lifts for all sixteen product partials

Base PR: #9102

Directed by @pirapira; implemented by Codex