### PR TITLE
proof(mulmod): expose final no-carry partial spec

### DIFF
--- a/DRIFT.md
+++ b/DRIFT.md
@@ -52,6 +52,7 @@ precondition; the excluded domain is **unverified**.
 |---|---|
 | `SDIV` | callable+dispatch shim; evm_sdiv_stack_spec_within conditional on hStack (discharged for divisor=0 and n=1/2/3/n4-call-skip); blocked on DIV/MOD spec-layer migration (bead evm-asm-9iqmw) |
 | `MOD` | stack spec parametric over ModStackSpecCase (bzero / n=1,2,3, all require b.getLimbN 3 = 0); n=4 path not covered. Executable evm_mod uses divK_div128_v4 (PR #4992). Full-domain unconditional closure tracked by bead evm-asm-9iqmw / gh-61 |
+| `SMOD` | all-case v4 wrapper result-stack spec; zero divisor discharged, nonzero path still parameterized by unsigned-MOD callable h_stack |
 
 ### 🟡 `partly` opcodes — no complete top-level triple yet
 
@@ -59,8 +60,7 @@ Pure-spec / `<op>_correct` lemma proven, but no end-to-end stack-spec wrap.
 
 | Opcode | Why not (yet) fully proven |
 |---|---|
-| `SMOD` | smod_correct proven; no top-level Hoare triple |
-| `ADDMOD` | addmod_correct proven; only b=0 stack-spec done |
+| `ADDMOD` | addmod_correct proven; zero-modulus stack spec done for arbitrary b |
 | `MULMOD` | mulmod_correct proven; no top-level Hoare triple |
 | `EXP` | exp_correct proven; program in active development |
 | `CALLDATACOPY` | preamble + partial memory effect; full loop pending |

--- a/EvmAsm/Evm64/MulMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/MulMod/LimbSpec.lean
@@ -500,6 +500,32 @@ theorem evm_mulmod_product_add_partial_core_finish_spec_within
     hi hiOff (base + 56)
   runBlock I0 I1 I2 I3 I4 I5 I6 I7 I8 I9 I10 I11 I12 I13 I14
 
+/-- Final product partial with no carry-tail suffix. This is the last
+    `evm_mulmod_product_add_partial` call in the 4x4 schoolbook product layout. -/
+theorem evm_mulmod_product_add_partial_144_152_nil_spec_within
+    (sp base : Word) (a b lo hi : Word)
+    (x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word) :
+    cpsTripleWithin 15 base (base + 60)
+      (CodeReq.ofProg base
+        (evm_mulmod_product_add_partial
+          (24 : BitVec 12) (56 : BitVec 12) (144 : BitVec 12) (152 : BitVec 12) []))
+      (evmMulModAddPartialCoreFullPre sp
+        (24 : BitVec 12) (56 : BitVec 12) (144 : BitVec 12) (152 : BitVec 12) a b lo hi
+        x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old)
+      (evmMulModAddPartialCorePost sp
+        (24 : BitVec 12) (56 : BitVec 12) (144 : BitVec 12) (152 : BitVec 12) a b lo hi) := by
+  change cpsTripleWithin 15 base (base + 60)
+      (evm_mulmod_product_add_partial_core_finish_code base
+        (24 : BitVec 12) (56 : BitVec 12) (144 : BitVec 12) (152 : BitVec 12))
+      (evmMulModAddPartialCoreFullPre sp
+        (24 : BitVec 12) (56 : BitVec 12) (144 : BitVec 12) (152 : BitVec 12) a b lo hi
+        x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old)
+      (evmMulModAddPartialCorePost sp
+        (24 : BitVec 12) (56 : BitVec 12) (144 : BitVec 12) (152 : BitVec 12) a b lo hi)
+  exact evm_mulmod_product_add_partial_core_finish_spec_within sp base
+    (24 : BitVec 12) (56 : BitVec 12) (144 : BitVec 12) (152 : BitVec 12) a b lo hi
+    x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old
+
 abbrev evm_mulmod_product_add_partial_finish_code (base : Word) (hiOff : BitVec 12) : CodeReq :=
   CodeReq.ofProg base (OR' .x10 .x13 .x14 ;; SD .x12 .x11 hiOff)
 


### PR DESCRIPTION
## Summary
- stack on top of PR #9104
- add `evm_mulmod_product_add_partial_144_152_nil_spec_within` in `LimbSpec.lean`
- reuse the existing core+finish proof for the empty carry-tail final product partial

Refs #91. Bead: evm-asm-fhsxz.2.4.2.60.2.5.1.4.1.3.2.2.

Verification:
- `lake build EvmAsm.Evm64.MulMod.LimbSpec`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- forbidden-pattern scan on `EvmAsm/Evm64/MulMod/LimbSpec.lean` (no matches)
- `git diff --check`
- `lake build` (known pre-existing `LeanRV64D/RiscvExtras.lean` deprecation warning only)

Directed by @pirapira; implemented by Codex.