### PR TITLE
proof(mulmod): add short carry partial specs

### DIFF
--- a/DRIFT.md
+++ b/DRIFT.md
@@ -52,6 +52,7 @@ precondition; the excluded domain is **unverified**.
 |---|---|
 | `SDIV` | callable+dispatch shim; evm_sdiv_stack_spec_within conditional on hStack (discharged for divisor=0 and n=1/2/3/n4-call-skip); blocked on DIV/MOD spec-layer migration (bead evm-asm-9iqmw) |
 | `MOD` | stack spec parametric over ModStackSpecCase (bzero / n=1,2,3, all require b.getLimbN 3 = 0); n=4 path not covered. Executable evm_mod uses divK_div128_v4 (PR #4992). Full-domain unconditional closure tracked by bead evm-asm-9iqmw / gh-61 |
+| `SMOD` | all-case v4 wrapper result-stack spec; zero divisor discharged, nonzero path still parameterized by unsigned-MOD callable h_stack |
 
 ### 🟡 `partly` opcodes — no complete top-level triple yet
 
@@ -59,8 +60,7 @@ Pure-spec / `<op>_correct` lemma proven, but no end-to-end stack-spec wrap.
 
 | Opcode | Why not (yet) fully proven |
 |---|---|
-| `SMOD` | smod_correct proven; no top-level Hoare triple |
-| `ADDMOD` | addmod_correct proven; only b=0 stack-spec done |
+| `ADDMOD` | addmod_correct proven; zero-modulus stack spec done for arbitrary b |
 | `MULMOD` | mulmod_correct proven; no top-level Hoare triple |
 | `EXP` | exp_correct proven; program in active development |
 | `CALLDATACOPY` | preamble + partial memory effect; full loop pending |

--- a/EvmAsm/Evm64/MulMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/MulMod/LimbSpec.lean
@@ -843,6 +843,414 @@ theorem evm_mulmod_product_propagate_carry_112_120_128_136_144_152_spec_within
   runBlock I0 I1 I2 I3 I4 I5 I6 I7 I8 I9 I10 I11 I12 I13 I14 I15 I16 I17 I18 I19 I20 I21 I22 I23
 
 
+
+-- ============================================================================
+-- Concrete add-partial calls with multi-limb carry suffixes
+-- ============================================================================
+
+/-- Product-layout call `evm_mulmod_product_add_partial 24 40 128 136 [144, 152]`. -/
+theorem evm_mulmod_product_add_partial_24_40_128_136_144_152_spec_within
+    (sp base : Word) (a b lo hi p6 p7 : Word)
+    (x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word) :
+    cpsTripleWithin (15 + 8) base (base + 60 + 32)
+      ((evm_mulmod_product_add_partial_core_finish_code base
+          (24 : BitVec 12) (40 : BitVec 12) (128 : BitVec 12) (136 : BitVec 12)).union
+        (evm_mulmod_product_propagate_carry_code (base + 60) [144, 152]))
+      (evmMulModAddPartialCoreFullPre sp
+        (24 : BitVec 12) (40 : BitVec 12) (128 : BitVec 12) (136 : BitVec 12) a b lo hi
+        x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old **
+       (((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7)))
+      (((.x12 ↦ᵣ sp) **
+        (.x10 ↦ᵣ mulModCarryStepCarry p7
+          (mulModCarryStepCarry p6 (mulModAddPartialHiCarry hi lo a b))) **
+        (.x9 ↦ᵣ mulModCarryStepValue p7
+          (mulModCarryStepCarry p6 (mulModAddPartialHiCarry hi lo a b))) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p6 (mulModAddPartialHiCarry hi lo a b)) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p7
+            (mulModCarryStepCarry p6 (mulModAddPartialHiCarry hi lo a b)))) **
+       (.x5 ↦ᵣ a) **
+       (.x6 ↦ᵣ b) **
+       (.x7 ↦ᵣ mulModAddPartialLoProduct a b) **
+       (.x8 ↦ᵣ mulModAddPartialHiProduct a b) **
+       (.x11 ↦ᵣ mulModAddPartialHiValue hi lo a b) **
+       (.x13 ↦ᵣ mulModAddPartialHiBaseCarry hi a b) **
+       (.x14 ↦ᵣ mulModAddPartialHiCarryFromLo hi lo a b) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ a) **
+       ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ b) **
+       ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ mulModAddPartialLoValue lo a b) **
+       ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ mulModAddPartialHiValue hi lo a b)) := by
+  have core := evm_mulmod_product_add_partial_core_finish_spec_within sp base
+    (24 : BitVec 12) (40 : BitVec 12) (128 : BitVec 12) (136 : BitVec 12) a b lo hi
+    x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old
+  have carry := evm_mulmod_product_propagate_carry_144_152_spec_within sp (base + 60)
+    (mulModAddPartialHiCarry hi lo a b) hi p6 p7
+  unfold evmMulModAddPartialCoreFullPre evmMulModAddPartialCorePost at core
+  unfold evmMulModAddPartialCoreFullPre
+  unfold mulModCarryStepValue mulModCarryStepCarry at carry ⊢
+  unfold mulModAddPartialHiCarry mulModAddPartialHiCarryFromLo at core carry ⊢
+  unfold mulModAddPartialHiValue mulModAddPartialHiBaseCarry at core carry ⊢
+  unfold mulModAddPartialHiBaseValue mulModAddPartialLoCarry at core carry ⊢
+  unfold mulModAddPartialLoValue mulModAddPartialHiProduct at core carry ⊢
+  unfold mulModAddPartialLoProduct at core carry ⊢
+  have coreF := cpsTripleWithin_frameR
+    (((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+      ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7))
+    (by pcFree) core
+  seqFrame coreF carry
+
+/-- Product-layout call `evm_mulmod_product_add_partial 16 48 128 136 [144, 152]`. -/
+theorem evm_mulmod_product_add_partial_16_48_128_136_144_152_spec_within
+    (sp base : Word) (a b lo hi p6 p7 : Word)
+    (x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word) :
+    cpsTripleWithin (15 + 8) base (base + 60 + 32)
+      ((evm_mulmod_product_add_partial_core_finish_code base
+          (16 : BitVec 12) (48 : BitVec 12) (128 : BitVec 12) (136 : BitVec 12)).union
+        (evm_mulmod_product_propagate_carry_code (base + 60) [144, 152]))
+      (evmMulModAddPartialCoreFullPre sp
+        (16 : BitVec 12) (48 : BitVec 12) (128 : BitVec 12) (136 : BitVec 12) a b lo hi
+        x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old **
+       (((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7)))
+      (((.x12 ↦ᵣ sp) **
+        (.x10 ↦ᵣ mulModCarryStepCarry p7
+          (mulModCarryStepCarry p6 (mulModAddPartialHiCarry hi lo a b))) **
+        (.x9 ↦ᵣ mulModCarryStepValue p7
+          (mulModCarryStepCarry p6 (mulModAddPartialHiCarry hi lo a b))) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p6 (mulModAddPartialHiCarry hi lo a b)) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p7
+            (mulModCarryStepCarry p6 (mulModAddPartialHiCarry hi lo a b)))) **
+       (.x5 ↦ᵣ a) **
+       (.x6 ↦ᵣ b) **
+       (.x7 ↦ᵣ mulModAddPartialLoProduct a b) **
+       (.x8 ↦ᵣ mulModAddPartialHiProduct a b) **
+       (.x11 ↦ᵣ mulModAddPartialHiValue hi lo a b) **
+       (.x13 ↦ᵣ mulModAddPartialHiBaseCarry hi a b) **
+       (.x14 ↦ᵣ mulModAddPartialHiCarryFromLo hi lo a b) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ a) **
+       ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ b) **
+       ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ mulModAddPartialLoValue lo a b) **
+       ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ mulModAddPartialHiValue hi lo a b)) := by
+  have core := evm_mulmod_product_add_partial_core_finish_spec_within sp base
+    (16 : BitVec 12) (48 : BitVec 12) (128 : BitVec 12) (136 : BitVec 12) a b lo hi
+    x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old
+  have carry := evm_mulmod_product_propagate_carry_144_152_spec_within sp (base + 60)
+    (mulModAddPartialHiCarry hi lo a b) hi p6 p7
+  unfold evmMulModAddPartialCoreFullPre evmMulModAddPartialCorePost at core
+  unfold evmMulModAddPartialCoreFullPre
+  unfold mulModCarryStepValue mulModCarryStepCarry at carry ⊢
+  unfold mulModAddPartialHiCarry mulModAddPartialHiCarryFromLo at core carry ⊢
+  unfold mulModAddPartialHiValue mulModAddPartialHiBaseCarry at core carry ⊢
+  unfold mulModAddPartialHiBaseValue mulModAddPartialLoCarry at core carry ⊢
+  unfold mulModAddPartialLoValue mulModAddPartialHiProduct at core carry ⊢
+  unfold mulModAddPartialLoProduct at core carry ⊢
+  have coreF := cpsTripleWithin_frameR
+    (((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+      ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7))
+    (by pcFree) core
+  seqFrame coreF carry
+
+/-- Product-layout call `evm_mulmod_product_add_partial 8 56 128 136 [144, 152]`. -/
+theorem evm_mulmod_product_add_partial_8_56_128_136_144_152_spec_within
+    (sp base : Word) (a b lo hi p6 p7 : Word)
+    (x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word) :
+    cpsTripleWithin (15 + 8) base (base + 60 + 32)
+      ((evm_mulmod_product_add_partial_core_finish_code base
+          (8 : BitVec 12) (56 : BitVec 12) (128 : BitVec 12) (136 : BitVec 12)).union
+        (evm_mulmod_product_propagate_carry_code (base + 60) [144, 152]))
+      (evmMulModAddPartialCoreFullPre sp
+        (8 : BitVec 12) (56 : BitVec 12) (128 : BitVec 12) (136 : BitVec 12) a b lo hi
+        x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old **
+       (((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7)))
+      (((.x12 ↦ᵣ sp) **
+        (.x10 ↦ᵣ mulModCarryStepCarry p7
+          (mulModCarryStepCarry p6 (mulModAddPartialHiCarry hi lo a b))) **
+        (.x9 ↦ᵣ mulModCarryStepValue p7
+          (mulModCarryStepCarry p6 (mulModAddPartialHiCarry hi lo a b))) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p6 (mulModAddPartialHiCarry hi lo a b)) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p7
+            (mulModCarryStepCarry p6 (mulModAddPartialHiCarry hi lo a b)))) **
+       (.x5 ↦ᵣ a) **
+       (.x6 ↦ᵣ b) **
+       (.x7 ↦ᵣ mulModAddPartialLoProduct a b) **
+       (.x8 ↦ᵣ mulModAddPartialHiProduct a b) **
+       (.x11 ↦ᵣ mulModAddPartialHiValue hi lo a b) **
+       (.x13 ↦ᵣ mulModAddPartialHiBaseCarry hi a b) **
+       (.x14 ↦ᵣ mulModAddPartialHiCarryFromLo hi lo a b) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ a) **
+       ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ b) **
+       ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ mulModAddPartialLoValue lo a b) **
+       ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ mulModAddPartialHiValue hi lo a b)) := by
+  have core := evm_mulmod_product_add_partial_core_finish_spec_within sp base
+    (8 : BitVec 12) (56 : BitVec 12) (128 : BitVec 12) (136 : BitVec 12) a b lo hi
+    x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old
+  have carry := evm_mulmod_product_propagate_carry_144_152_spec_within sp (base + 60)
+    (mulModAddPartialHiCarry hi lo a b) hi p6 p7
+  unfold evmMulModAddPartialCoreFullPre evmMulModAddPartialCorePost at core
+  unfold evmMulModAddPartialCoreFullPre
+  unfold mulModCarryStepValue mulModCarryStepCarry at carry ⊢
+  unfold mulModAddPartialHiCarry mulModAddPartialHiCarryFromLo at core carry ⊢
+  unfold mulModAddPartialHiValue mulModAddPartialHiBaseCarry at core carry ⊢
+  unfold mulModAddPartialHiBaseValue mulModAddPartialLoCarry at core carry ⊢
+  unfold mulModAddPartialLoValue mulModAddPartialHiProduct at core carry ⊢
+  unfold mulModAddPartialLoProduct at core carry ⊢
+  have coreF := cpsTripleWithin_frameR
+    (((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+      ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7))
+    (by pcFree) core
+  seqFrame coreF carry
+
+/-- Product-layout call `evm_mulmod_product_add_partial 24 32 120 128 [136, 144, 152]`. -/
+theorem evm_mulmod_product_add_partial_24_32_120_128_136_144_152_spec_within
+    (sp base : Word) (a b lo hi p5 p6 p7 : Word)
+    (x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word) :
+    cpsTripleWithin (15 + 12) base (base + 60 + 48)
+      ((evm_mulmod_product_add_partial_core_finish_code base
+          (24 : BitVec 12) (32 : BitVec 12) (120 : BitVec 12) (128 : BitVec 12)).union
+        (evm_mulmod_product_propagate_carry_code (base + 60) [136, 144, 152]))
+      (evmMulModAddPartialCoreFullPre sp
+        (24 : BitVec 12) (32 : BitVec 12) (120 : BitVec 12) (128 : BitVec 12) a b lo hi
+        x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old **
+       (((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7)))
+      (((.x12 ↦ᵣ sp) **
+        (.x10 ↦ᵣ mulModCarryStepCarry p7
+          (mulModCarryStepCarry p6
+            (mulModCarryStepCarry p5 (mulModAddPartialHiCarry hi lo a b)))) **
+        (.x9 ↦ᵣ mulModCarryStepValue p7
+          (mulModCarryStepCarry p6
+            (mulModCarryStepCarry p5 (mulModAddPartialHiCarry hi lo a b)))) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p5 (mulModAddPartialHiCarry hi lo a b)) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p6
+            (mulModCarryStepCarry p5 (mulModAddPartialHiCarry hi lo a b))) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p7
+            (mulModCarryStepCarry p6
+              (mulModCarryStepCarry p5 (mulModAddPartialHiCarry hi lo a b))))) **
+       (.x5 ↦ᵣ a) **
+       (.x6 ↦ᵣ b) **
+       (.x7 ↦ᵣ mulModAddPartialLoProduct a b) **
+       (.x8 ↦ᵣ mulModAddPartialHiProduct a b) **
+       (.x11 ↦ᵣ mulModAddPartialHiValue hi lo a b) **
+       (.x13 ↦ᵣ mulModAddPartialHiBaseCarry hi a b) **
+       (.x14 ↦ᵣ mulModAddPartialHiCarryFromLo hi lo a b) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ a) **
+       ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ b) **
+       ((sp + signExtend12 (120 : BitVec 12)) ↦ₘ mulModAddPartialLoValue lo a b) **
+       ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ mulModAddPartialHiValue hi lo a b)) := by
+  have core := evm_mulmod_product_add_partial_core_finish_spec_within sp base
+    (24 : BitVec 12) (32 : BitVec 12) (120 : BitVec 12) (128 : BitVec 12) a b lo hi
+    x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old
+  have carry := evm_mulmod_product_propagate_carry_136_144_152_spec_within sp (base + 60)
+    (mulModAddPartialHiCarry hi lo a b) hi p5 p6 p7
+  unfold evmMulModAddPartialCoreFullPre evmMulModAddPartialCorePost at core
+  unfold evmMulModAddPartialCoreFullPre
+  unfold mulModCarryStepValue mulModCarryStepCarry at carry ⊢
+  unfold mulModAddPartialHiCarry mulModAddPartialHiCarryFromLo at core carry ⊢
+  unfold mulModAddPartialHiValue mulModAddPartialHiBaseCarry at core carry ⊢
+  unfold mulModAddPartialHiBaseValue mulModAddPartialLoCarry at core carry ⊢
+  unfold mulModAddPartialLoValue mulModAddPartialHiProduct at core carry ⊢
+  unfold mulModAddPartialLoProduct at core carry ⊢
+  have coreF := cpsTripleWithin_frameR
+    (((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+      ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+      ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7))
+    (by pcFree) core
+  seqFrame coreF carry
+
+/-- Product-layout call `evm_mulmod_product_add_partial 16 40 120 128 [136, 144, 152]`. -/
+theorem evm_mulmod_product_add_partial_16_40_120_128_136_144_152_spec_within
+    (sp base : Word) (a b lo hi p5 p6 p7 : Word)
+    (x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word) :
+    cpsTripleWithin (15 + 12) base (base + 60 + 48)
+      ((evm_mulmod_product_add_partial_core_finish_code base
+          (16 : BitVec 12) (40 : BitVec 12) (120 : BitVec 12) (128 : BitVec 12)).union
+        (evm_mulmod_product_propagate_carry_code (base + 60) [136, 144, 152]))
+      (evmMulModAddPartialCoreFullPre sp
+        (16 : BitVec 12) (40 : BitVec 12) (120 : BitVec 12) (128 : BitVec 12) a b lo hi
+        x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old **
+       (((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7)))
+      (((.x12 ↦ᵣ sp) **
+        (.x10 ↦ᵣ mulModCarryStepCarry p7
+          (mulModCarryStepCarry p6
+            (mulModCarryStepCarry p5 (mulModAddPartialHiCarry hi lo a b)))) **
+        (.x9 ↦ᵣ mulModCarryStepValue p7
+          (mulModCarryStepCarry p6
+            (mulModCarryStepCarry p5 (mulModAddPartialHiCarry hi lo a b)))) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p5 (mulModAddPartialHiCarry hi lo a b)) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p6
+            (mulModCarryStepCarry p5 (mulModAddPartialHiCarry hi lo a b))) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p7
+            (mulModCarryStepCarry p6
+              (mulModCarryStepCarry p5 (mulModAddPartialHiCarry hi lo a b))))) **
+       (.x5 ↦ᵣ a) **
+       (.x6 ↦ᵣ b) **
+       (.x7 ↦ᵣ mulModAddPartialLoProduct a b) **
+       (.x8 ↦ᵣ mulModAddPartialHiProduct a b) **
+       (.x11 ↦ᵣ mulModAddPartialHiValue hi lo a b) **
+       (.x13 ↦ᵣ mulModAddPartialHiBaseCarry hi a b) **
+       (.x14 ↦ᵣ mulModAddPartialHiCarryFromLo hi lo a b) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ a) **
+       ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ b) **
+       ((sp + signExtend12 (120 : BitVec 12)) ↦ₘ mulModAddPartialLoValue lo a b) **
+       ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ mulModAddPartialHiValue hi lo a b)) := by
+  have core := evm_mulmod_product_add_partial_core_finish_spec_within sp base
+    (16 : BitVec 12) (40 : BitVec 12) (120 : BitVec 12) (128 : BitVec 12) a b lo hi
+    x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old
+  have carry := evm_mulmod_product_propagate_carry_136_144_152_spec_within sp (base + 60)
+    (mulModAddPartialHiCarry hi lo a b) hi p5 p6 p7
+  unfold evmMulModAddPartialCoreFullPre evmMulModAddPartialCorePost at core
+  unfold evmMulModAddPartialCoreFullPre
+  unfold mulModCarryStepValue mulModCarryStepCarry at carry ⊢
+  unfold mulModAddPartialHiCarry mulModAddPartialHiCarryFromLo at core carry ⊢
+  unfold mulModAddPartialHiValue mulModAddPartialHiBaseCarry at core carry ⊢
+  unfold mulModAddPartialHiBaseValue mulModAddPartialLoCarry at core carry ⊢
+  unfold mulModAddPartialLoValue mulModAddPartialHiProduct at core carry ⊢
+  unfold mulModAddPartialLoProduct at core carry ⊢
+  have coreF := cpsTripleWithin_frameR
+    (((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+      ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+      ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7))
+    (by pcFree) core
+  seqFrame coreF carry
+
+/-- Product-layout call `evm_mulmod_product_add_partial 8 48 120 128 [136, 144, 152]`. -/
+theorem evm_mulmod_product_add_partial_8_48_120_128_136_144_152_spec_within
+    (sp base : Word) (a b lo hi p5 p6 p7 : Word)
+    (x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word) :
+    cpsTripleWithin (15 + 12) base (base + 60 + 48)
+      ((evm_mulmod_product_add_partial_core_finish_code base
+          (8 : BitVec 12) (48 : BitVec 12) (120 : BitVec 12) (128 : BitVec 12)).union
+        (evm_mulmod_product_propagate_carry_code (base + 60) [136, 144, 152]))
+      (evmMulModAddPartialCoreFullPre sp
+        (8 : BitVec 12) (48 : BitVec 12) (120 : BitVec 12) (128 : BitVec 12) a b lo hi
+        x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old **
+       (((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7)))
+      (((.x12 ↦ᵣ sp) **
+        (.x10 ↦ᵣ mulModCarryStepCarry p7
+          (mulModCarryStepCarry p6
+            (mulModCarryStepCarry p5 (mulModAddPartialHiCarry hi lo a b)))) **
+        (.x9 ↦ᵣ mulModCarryStepValue p7
+          (mulModCarryStepCarry p6
+            (mulModCarryStepCarry p5 (mulModAddPartialHiCarry hi lo a b)))) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p5 (mulModAddPartialHiCarry hi lo a b)) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p6
+            (mulModCarryStepCarry p5 (mulModAddPartialHiCarry hi lo a b))) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p7
+            (mulModCarryStepCarry p6
+              (mulModCarryStepCarry p5 (mulModAddPartialHiCarry hi lo a b))))) **
+       (.x5 ↦ᵣ a) **
+       (.x6 ↦ᵣ b) **
+       (.x7 ↦ᵣ mulModAddPartialLoProduct a b) **
+       (.x8 ↦ᵣ mulModAddPartialHiProduct a b) **
+       (.x11 ↦ᵣ mulModAddPartialHiValue hi lo a b) **
+       (.x13 ↦ᵣ mulModAddPartialHiBaseCarry hi a b) **
+       (.x14 ↦ᵣ mulModAddPartialHiCarryFromLo hi lo a b) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ a) **
+       ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ b) **
+       ((sp + signExtend12 (120 : BitVec 12)) ↦ₘ mulModAddPartialLoValue lo a b) **
+       ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ mulModAddPartialHiValue hi lo a b)) := by
+  have core := evm_mulmod_product_add_partial_core_finish_spec_within sp base
+    (8 : BitVec 12) (48 : BitVec 12) (120 : BitVec 12) (128 : BitVec 12) a b lo hi
+    x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old
+  have carry := evm_mulmod_product_propagate_carry_136_144_152_spec_within sp (base + 60)
+    (mulModAddPartialHiCarry hi lo a b) hi p5 p6 p7
+  unfold evmMulModAddPartialCoreFullPre evmMulModAddPartialCorePost at core
+  unfold evmMulModAddPartialCoreFullPre
+  unfold mulModCarryStepValue mulModCarryStepCarry at carry ⊢
+  unfold mulModAddPartialHiCarry mulModAddPartialHiCarryFromLo at core carry ⊢
+  unfold mulModAddPartialHiValue mulModAddPartialHiBaseCarry at core carry ⊢
+  unfold mulModAddPartialHiBaseValue mulModAddPartialLoCarry at core carry ⊢
+  unfold mulModAddPartialLoValue mulModAddPartialHiProduct at core carry ⊢
+  unfold mulModAddPartialLoProduct at core carry ⊢
+  have coreF := cpsTripleWithin_frameR
+    (((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+      ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+      ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7))
+    (by pcFree) core
+  seqFrame coreF carry
+
+/-- Product-layout call `evm_mulmod_product_add_partial 0 56 120 128 [136, 144, 152]`. -/
+theorem evm_mulmod_product_add_partial_0_56_120_128_136_144_152_spec_within
+    (sp base : Word) (a b lo hi p5 p6 p7 : Word)
+    (x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word) :
+    cpsTripleWithin (15 + 12) base (base + 60 + 48)
+      ((evm_mulmod_product_add_partial_core_finish_code base
+          (0 : BitVec 12) (56 : BitVec 12) (120 : BitVec 12) (128 : BitVec 12)).union
+        (evm_mulmod_product_propagate_carry_code (base + 60) [136, 144, 152]))
+      (evmMulModAddPartialCoreFullPre sp
+        (0 : BitVec 12) (56 : BitVec 12) (120 : BitVec 12) (128 : BitVec 12) a b lo hi
+        x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old **
+       (((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7)))
+      (((.x12 ↦ᵣ sp) **
+        (.x10 ↦ᵣ mulModCarryStepCarry p7
+          (mulModCarryStepCarry p6
+            (mulModCarryStepCarry p5 (mulModAddPartialHiCarry hi lo a b)))) **
+        (.x9 ↦ᵣ mulModCarryStepValue p7
+          (mulModCarryStepCarry p6
+            (mulModCarryStepCarry p5 (mulModAddPartialHiCarry hi lo a b)))) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p5 (mulModAddPartialHiCarry hi lo a b)) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p6
+            (mulModCarryStepCarry p5 (mulModAddPartialHiCarry hi lo a b))) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p7
+            (mulModCarryStepCarry p6
+              (mulModCarryStepCarry p5 (mulModAddPartialHiCarry hi lo a b))))) **
+       (.x5 ↦ᵣ a) **
+       (.x6 ↦ᵣ b) **
+       (.x7 ↦ᵣ mulModAddPartialLoProduct a b) **
+       (.x8 ↦ᵣ mulModAddPartialHiProduct a b) **
+       (.x11 ↦ᵣ mulModAddPartialHiValue hi lo a b) **
+       (.x13 ↦ᵣ mulModAddPartialHiBaseCarry hi a b) **
+       (.x14 ↦ᵣ mulModAddPartialHiCarryFromLo hi lo a b) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ a) **
+       ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ b) **
+       ((sp + signExtend12 (120 : BitVec 12)) ↦ₘ mulModAddPartialLoValue lo a b) **
+       ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ mulModAddPartialHiValue hi lo a b)) := by
+  have core := evm_mulmod_product_add_partial_core_finish_spec_within sp base
+    (0 : BitVec 12) (56 : BitVec 12) (120 : BitVec 12) (128 : BitVec 12) a b lo hi
+    x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old
+  have carry := evm_mulmod_product_propagate_carry_136_144_152_spec_within sp (base + 60)
+    (mulModAddPartialHiCarry hi lo a b) hi p5 p6 p7
+  unfold evmMulModAddPartialCoreFullPre evmMulModAddPartialCorePost at core
+  unfold evmMulModAddPartialCoreFullPre
+  unfold mulModCarryStepValue mulModCarryStepCarry at carry ⊢
+  unfold mulModAddPartialHiCarry mulModAddPartialHiCarryFromLo at core carry ⊢
+  unfold mulModAddPartialHiValue mulModAddPartialHiBaseCarry at core carry ⊢
+  unfold mulModAddPartialHiBaseValue mulModAddPartialLoCarry at core carry ⊢
+  unfold mulModAddPartialLoValue mulModAddPartialHiProduct at core carry ⊢
+  unfold mulModAddPartialLoProduct at core carry ⊢
+  have coreF := cpsTripleWithin_frameR
+    (((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+      ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+      ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7))
+    (by pcFree) core
+  seqFrame coreF carry
+
 -- ============================================================================
 -- evm_mulmod_reduce512_init
 -- ============================================================================


### PR DESCRIPTION
## Summary
- add named MULMOD add-partial specs for carry tail [144, 152]
- add named MULMOD add-partial specs for carry tail [136, 144, 152]
- compose the existing core+finish proof with concrete carry suffix proofs

## Stack
- Stacked on PR #9107, branch feat/mulmod-one-carry-partials

## Verification
- lake build EvmAsm.Evm64.MulMod.LimbSpec
- lake build EvmAsm.Evm64.MulMod
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- forbidden-pattern scan on EvmAsm/Evm64/MulMod/LimbSpec.lean: no matches
- git diff --check
- lake build: passes; known pre-existing LeanRV64D/RiscvExtras.lean deprecation warning

Bead: evm-asm-fhsxz.2.4.2.60.2.5.1.4.1.3.4

Directed by @pirapira; implemented by Codex.
