### PR TITLE
proof(mulmod): add long carry partial specs

### DIFF
--- a/DRIFT.md
+++ b/DRIFT.md
@@ -52,6 +52,7 @@ precondition; the excluded domain is **unverified**.
 |---|---|
 | `SDIV` | callable+dispatch shim; evm_sdiv_stack_spec_within conditional on hStack (discharged for divisor=0 and n=1/2/3/n4-call-skip); blocked on DIV/MOD spec-layer migration (bead evm-asm-9iqmw) |
 | `MOD` | stack spec parametric over ModStackSpecCase (bzero / n=1,2,3, all require b.getLimbN 3 = 0); n=4 path not covered. Executable evm_mod uses divK_div128_v4 (PR #4992). Full-domain unconditional closure tracked by bead evm-asm-9iqmw / gh-61 |
+| `SMOD` | all-case v4 wrapper result-stack spec; zero divisor discharged, nonzero path still parameterized by unsigned-MOD callable h_stack |
 
 ### 🟡 `partly` opcodes — no complete top-level triple yet
 
@@ -59,8 +60,7 @@ Pure-spec / `<op>_correct` lemma proven, but no end-to-end stack-spec wrap.
 
 | Opcode | Why not (yet) fully proven |
 |---|---|
-| `SMOD` | smod_correct proven; no top-level Hoare triple |
-| `ADDMOD` | addmod_correct proven; only b=0 stack-spec done |
+| `ADDMOD` | addmod_correct proven; zero-modulus stack spec done for arbitrary b |
 | `MULMOD` | mulmod_correct proven; no top-level Hoare triple |
 | `EXP` | exp_correct proven; program in active development |
 | `CALLDATACOPY` | preamble + partial memory effect; full loop pending |

--- a/EvmAsm/Evm64/MulMod.lean
+++ b/EvmAsm/Evm64/MulMod.lean
@@ -15,6 +15,7 @@ import EvmAsm.Evm64.MulMod.Layout
 import EvmAsm.Evm64.MulMod.Program
 import EvmAsm.Evm64.MulMod.ProductAlgebra
 import EvmAsm.Evm64.MulMod.LimbSpec
+import EvmAsm.Evm64.MulMod.AddPartialSpecs
 import EvmAsm.Evm64.MulMod.AddrNorm
 import EvmAsm.Evm64.MulMod.Compose.Base
 import EvmAsm.Evm64.MulMod.Compose.ProductCore

--- a/EvmAsm/Evm64/MulMod/AddPartialSpecs.lean
+++ b/EvmAsm/Evm64/MulMod/AddPartialSpecs.lean
@@ -1,0 +1,386 @@
+/-
+  EvmAsm.Evm64.MulMod.AddPartialSpecs
+
+  Concrete product-layout add-partial cpsTriple specs that build on the
+  per-limb MULMOD block specs.
+-/
+
+import EvmAsm.Evm64.MulMod.LimbSpec
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- ============================================================================
+-- Concrete add-partial calls with long carry suffixes
+-- ============================================================================
+
+/-- Product-layout call `evm_mulmod_product_add_partial 16 32 112 120 [128, 136, 144, 152]`. -/
+theorem evm_mulmod_product_add_partial_16_32_112_120_128_136_144_152_spec_within
+    (sp base : Word) (a b lo hi p4 p5 p6 p7 : Word)
+    (x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word) :
+    cpsTripleWithin (15 + 16) base (base + 60 + 64)
+      ((evm_mulmod_product_add_partial_core_finish_code base
+          (16 : BitVec 12) (32 : BitVec 12) (112 : BitVec 12) (120 : BitVec 12)).union
+        (evm_mulmod_product_propagate_carry_code (base + 60) [128, 136, 144, 152]))
+      (evmMulModAddPartialCoreFullPre sp
+        (16 : BitVec 12) (32 : BitVec 12) (112 : BitVec 12) (120 : BitVec 12) a b lo hi
+        x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old **
+       (((((sp + signExtend12 (128 : BitVec 12)) ↦ₘ p4) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7)))))
+      (((.x12 ↦ᵣ sp) **
+        (.x10 ↦ᵣ mulModCarryStepCarry p7 (mulModCarryStepCarry p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModAddPartialHiCarry hi lo a b))))) **
+        (.x9 ↦ᵣ mulModCarryStepValue p7 (mulModCarryStepCarry p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModAddPartialHiCarry hi lo a b))))) **
+        ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p4 (mulModAddPartialHiCarry hi lo a b)) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p5 (mulModCarryStepCarry p4 (mulModAddPartialHiCarry hi lo a b))) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModAddPartialHiCarry hi lo a b)))) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p7 (mulModCarryStepCarry p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModAddPartialHiCarry hi lo a b)))))) **
+       (.x5 ↦ᵣ a) **
+       (.x6 ↦ᵣ b) **
+       (.x7 ↦ᵣ mulModAddPartialLoProduct a b) **
+       (.x8 ↦ᵣ mulModAddPartialHiProduct a b) **
+       (.x11 ↦ᵣ mulModAddPartialHiValue hi lo a b) **
+       (.x13 ↦ᵣ mulModAddPartialHiBaseCarry hi a b) **
+       (.x14 ↦ᵣ mulModAddPartialHiCarryFromLo hi lo a b) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ a) **
+       ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ b) **
+       ((sp + signExtend12 (112 : BitVec 12)) ↦ₘ mulModAddPartialLoValue lo a b) **
+       ((sp + signExtend12 (120 : BitVec 12)) ↦ₘ mulModAddPartialHiValue hi lo a b)) := by
+  have core := evm_mulmod_product_add_partial_core_finish_spec_within sp base
+    (16 : BitVec 12) (32 : BitVec 12) (112 : BitVec 12) (120 : BitVec 12) a b lo hi
+    x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old
+  have carry := evm_mulmod_product_propagate_carry_128_136_144_152_spec_within sp (base + 60)
+    (mulModAddPartialHiCarry hi lo a b) hi p4 p5 p6 p7
+  unfold evmMulModAddPartialCoreFullPre evmMulModAddPartialCorePost at core
+  unfold evmMulModAddPartialCoreFullPre
+  unfold mulModCarryStepValue mulModCarryStepCarry at carry ⊢
+  unfold mulModAddPartialHiCarry mulModAddPartialHiCarryFromLo at core carry ⊢
+  unfold mulModAddPartialHiValue mulModAddPartialHiBaseCarry at core carry ⊢
+  unfold mulModAddPartialHiBaseValue mulModAddPartialLoCarry at core carry ⊢
+  unfold mulModAddPartialLoValue mulModAddPartialHiProduct at core carry ⊢
+  unfold mulModAddPartialLoProduct at core carry ⊢
+  have coreF := cpsTripleWithin_frameR
+    (((((sp + signExtend12 (128 : BitVec 12)) ↦ₘ p4) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7))))
+    (by pcFree) core
+  seqFrame coreF carry
+
+/-- Product-layout call `evm_mulmod_product_add_partial 8 40 112 120 [128, 136, 144, 152]`. -/
+theorem evm_mulmod_product_add_partial_8_40_112_120_128_136_144_152_spec_within
+    (sp base : Word) (a b lo hi p4 p5 p6 p7 : Word)
+    (x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word) :
+    cpsTripleWithin (15 + 16) base (base + 60 + 64)
+      ((evm_mulmod_product_add_partial_core_finish_code base
+          (8 : BitVec 12) (40 : BitVec 12) (112 : BitVec 12) (120 : BitVec 12)).union
+        (evm_mulmod_product_propagate_carry_code (base + 60) [128, 136, 144, 152]))
+      (evmMulModAddPartialCoreFullPre sp
+        (8 : BitVec 12) (40 : BitVec 12) (112 : BitVec 12) (120 : BitVec 12) a b lo hi
+        x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old **
+       (((((sp + signExtend12 (128 : BitVec 12)) ↦ₘ p4) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7)))))
+      (((.x12 ↦ᵣ sp) **
+        (.x10 ↦ᵣ mulModCarryStepCarry p7 (mulModCarryStepCarry p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModAddPartialHiCarry hi lo a b))))) **
+        (.x9 ↦ᵣ mulModCarryStepValue p7 (mulModCarryStepCarry p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModAddPartialHiCarry hi lo a b))))) **
+        ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p4 (mulModAddPartialHiCarry hi lo a b)) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p5 (mulModCarryStepCarry p4 (mulModAddPartialHiCarry hi lo a b))) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModAddPartialHiCarry hi lo a b)))) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p7 (mulModCarryStepCarry p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModAddPartialHiCarry hi lo a b)))))) **
+       (.x5 ↦ᵣ a) **
+       (.x6 ↦ᵣ b) **
+       (.x7 ↦ᵣ mulModAddPartialLoProduct a b) **
+       (.x8 ↦ᵣ mulModAddPartialHiProduct a b) **
+       (.x11 ↦ᵣ mulModAddPartialHiValue hi lo a b) **
+       (.x13 ↦ᵣ mulModAddPartialHiBaseCarry hi a b) **
+       (.x14 ↦ᵣ mulModAddPartialHiCarryFromLo hi lo a b) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ a) **
+       ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ b) **
+       ((sp + signExtend12 (112 : BitVec 12)) ↦ₘ mulModAddPartialLoValue lo a b) **
+       ((sp + signExtend12 (120 : BitVec 12)) ↦ₘ mulModAddPartialHiValue hi lo a b)) := by
+  have core := evm_mulmod_product_add_partial_core_finish_spec_within sp base
+    (8 : BitVec 12) (40 : BitVec 12) (112 : BitVec 12) (120 : BitVec 12) a b lo hi
+    x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old
+  have carry := evm_mulmod_product_propagate_carry_128_136_144_152_spec_within sp (base + 60)
+    (mulModAddPartialHiCarry hi lo a b) hi p4 p5 p6 p7
+  unfold evmMulModAddPartialCoreFullPre evmMulModAddPartialCorePost at core
+  unfold evmMulModAddPartialCoreFullPre
+  unfold mulModCarryStepValue mulModCarryStepCarry at carry ⊢
+  unfold mulModAddPartialHiCarry mulModAddPartialHiCarryFromLo at core carry ⊢
+  unfold mulModAddPartialHiValue mulModAddPartialHiBaseCarry at core carry ⊢
+  unfold mulModAddPartialHiBaseValue mulModAddPartialLoCarry at core carry ⊢
+  unfold mulModAddPartialLoValue mulModAddPartialHiProduct at core carry ⊢
+  unfold mulModAddPartialLoProduct at core carry ⊢
+  have coreF := cpsTripleWithin_frameR
+    (((((sp + signExtend12 (128 : BitVec 12)) ↦ₘ p4) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7))))
+    (by pcFree) core
+  seqFrame coreF carry
+
+/-- Product-layout call `evm_mulmod_product_add_partial 0 48 112 120 [128, 136, 144, 152]`. -/
+theorem evm_mulmod_product_add_partial_0_48_112_120_128_136_144_152_spec_within
+    (sp base : Word) (a b lo hi p4 p5 p6 p7 : Word)
+    (x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word) :
+    cpsTripleWithin (15 + 16) base (base + 60 + 64)
+      ((evm_mulmod_product_add_partial_core_finish_code base
+          (0 : BitVec 12) (48 : BitVec 12) (112 : BitVec 12) (120 : BitVec 12)).union
+        (evm_mulmod_product_propagate_carry_code (base + 60) [128, 136, 144, 152]))
+      (evmMulModAddPartialCoreFullPre sp
+        (0 : BitVec 12) (48 : BitVec 12) (112 : BitVec 12) (120 : BitVec 12) a b lo hi
+        x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old **
+       (((((sp + signExtend12 (128 : BitVec 12)) ↦ₘ p4) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7)))))
+      (((.x12 ↦ᵣ sp) **
+        (.x10 ↦ᵣ mulModCarryStepCarry p7 (mulModCarryStepCarry p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModAddPartialHiCarry hi lo a b))))) **
+        (.x9 ↦ᵣ mulModCarryStepValue p7 (mulModCarryStepCarry p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModAddPartialHiCarry hi lo a b))))) **
+        ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p4 (mulModAddPartialHiCarry hi lo a b)) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p5 (mulModCarryStepCarry p4 (mulModAddPartialHiCarry hi lo a b))) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModAddPartialHiCarry hi lo a b)))) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p7 (mulModCarryStepCarry p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModAddPartialHiCarry hi lo a b)))))) **
+       (.x5 ↦ᵣ a) **
+       (.x6 ↦ᵣ b) **
+       (.x7 ↦ᵣ mulModAddPartialLoProduct a b) **
+       (.x8 ↦ᵣ mulModAddPartialHiProduct a b) **
+       (.x11 ↦ᵣ mulModAddPartialHiValue hi lo a b) **
+       (.x13 ↦ᵣ mulModAddPartialHiBaseCarry hi a b) **
+       (.x14 ↦ᵣ mulModAddPartialHiCarryFromLo hi lo a b) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ a) **
+       ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ b) **
+       ((sp + signExtend12 (112 : BitVec 12)) ↦ₘ mulModAddPartialLoValue lo a b) **
+       ((sp + signExtend12 (120 : BitVec 12)) ↦ₘ mulModAddPartialHiValue hi lo a b)) := by
+  have core := evm_mulmod_product_add_partial_core_finish_spec_within sp base
+    (0 : BitVec 12) (48 : BitVec 12) (112 : BitVec 12) (120 : BitVec 12) a b lo hi
+    x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old
+  have carry := evm_mulmod_product_propagate_carry_128_136_144_152_spec_within sp (base + 60)
+    (mulModAddPartialHiCarry hi lo a b) hi p4 p5 p6 p7
+  unfold evmMulModAddPartialCoreFullPre evmMulModAddPartialCorePost at core
+  unfold evmMulModAddPartialCoreFullPre
+  unfold mulModCarryStepValue mulModCarryStepCarry at carry ⊢
+  unfold mulModAddPartialHiCarry mulModAddPartialHiCarryFromLo at core carry ⊢
+  unfold mulModAddPartialHiValue mulModAddPartialHiBaseCarry at core carry ⊢
+  unfold mulModAddPartialHiBaseValue mulModAddPartialLoCarry at core carry ⊢
+  unfold mulModAddPartialLoValue mulModAddPartialHiProduct at core carry ⊢
+  unfold mulModAddPartialLoProduct at core carry ⊢
+  have coreF := cpsTripleWithin_frameR
+    (((((sp + signExtend12 (128 : BitVec 12)) ↦ₘ p4) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7))))
+    (by pcFree) core
+  seqFrame coreF carry
+
+/-- Product-layout call `evm_mulmod_product_add_partial 8 32 104 112 [120, 128, 136, 144, 152]`. -/
+theorem evm_mulmod_product_add_partial_8_32_104_112_120_128_136_144_152_spec_within
+    (sp base : Word) (a b lo hi p3 p4 p5 p6 p7 : Word)
+    (x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word) :
+    cpsTripleWithin (15 + 20) base (base + 60 + 80)
+      ((evm_mulmod_product_add_partial_core_finish_code base
+          (8 : BitVec 12) (32 : BitVec 12) (104 : BitVec 12) (112 : BitVec 12)).union
+        (evm_mulmod_product_propagate_carry_code (base + 60) [120, 128, 136, 144, 152]))
+      (evmMulModAddPartialCoreFullPre sp
+        (8 : BitVec 12) (32 : BitVec 12) (104 : BitVec 12) (112 : BitVec 12) a b lo hi
+        x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old **
+       ((((((sp + signExtend12 (120 : BitVec 12)) ↦ₘ p3) **
+        ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ p4) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7))))))
+      (((.x12 ↦ᵣ sp) **
+        (.x10 ↦ᵣ mulModCarryStepCarry p7 (mulModCarryStepCarry p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModCarryStepCarry p3 (mulModAddPartialHiCarry hi lo a b)))))) **
+        (.x9 ↦ᵣ mulModCarryStepValue p7 (mulModCarryStepCarry p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModCarryStepCarry p3 (mulModAddPartialHiCarry hi lo a b)))))) **
+        ((sp + signExtend12 (120 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p3 (mulModAddPartialHiCarry hi lo a b)) **
+        ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p4 (mulModCarryStepCarry p3 (mulModAddPartialHiCarry hi lo a b))) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p5 (mulModCarryStepCarry p4 (mulModCarryStepCarry p3 (mulModAddPartialHiCarry hi lo a b)))) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModCarryStepCarry p3 (mulModAddPartialHiCarry hi lo a b))))) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p7 (mulModCarryStepCarry p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModCarryStepCarry p3 (mulModAddPartialHiCarry hi lo a b))))))) **
+       (.x5 ↦ᵣ a) **
+       (.x6 ↦ᵣ b) **
+       (.x7 ↦ᵣ mulModAddPartialLoProduct a b) **
+       (.x8 ↦ᵣ mulModAddPartialHiProduct a b) **
+       (.x11 ↦ᵣ mulModAddPartialHiValue hi lo a b) **
+       (.x13 ↦ᵣ mulModAddPartialHiBaseCarry hi a b) **
+       (.x14 ↦ᵣ mulModAddPartialHiCarryFromLo hi lo a b) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ a) **
+       ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ b) **
+       ((sp + signExtend12 (104 : BitVec 12)) ↦ₘ mulModAddPartialLoValue lo a b) **
+       ((sp + signExtend12 (112 : BitVec 12)) ↦ₘ mulModAddPartialHiValue hi lo a b)) := by
+  have core := evm_mulmod_product_add_partial_core_finish_spec_within sp base
+    (8 : BitVec 12) (32 : BitVec 12) (104 : BitVec 12) (112 : BitVec 12) a b lo hi
+    x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old
+  have carry := evm_mulmod_product_propagate_carry_120_128_136_144_152_spec_within sp (base + 60)
+    (mulModAddPartialHiCarry hi lo a b) hi p3 p4 p5 p6 p7
+  unfold evmMulModAddPartialCoreFullPre evmMulModAddPartialCorePost at core
+  unfold evmMulModAddPartialCoreFullPre
+  unfold mulModCarryStepValue mulModCarryStepCarry at carry ⊢
+  unfold mulModAddPartialHiCarry mulModAddPartialHiCarryFromLo at core carry ⊢
+  unfold mulModAddPartialHiValue mulModAddPartialHiBaseCarry at core carry ⊢
+  unfold mulModAddPartialHiBaseValue mulModAddPartialLoCarry at core carry ⊢
+  unfold mulModAddPartialLoValue mulModAddPartialHiProduct at core carry ⊢
+  unfold mulModAddPartialLoProduct at core carry ⊢
+  have coreF := cpsTripleWithin_frameR
+    ((((((sp + signExtend12 (120 : BitVec 12)) ↦ₘ p3) **
+        ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ p4) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7)))))
+    (by pcFree) core
+  seqFrame coreF carry
+
+/-- Product-layout call `evm_mulmod_product_add_partial 0 40 104 112 [120, 128, 136, 144, 152]`. -/
+theorem evm_mulmod_product_add_partial_0_40_104_112_120_128_136_144_152_spec_within
+    (sp base : Word) (a b lo hi p3 p4 p5 p6 p7 : Word)
+    (x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word) :
+    cpsTripleWithin (15 + 20) base (base + 60 + 80)
+      ((evm_mulmod_product_add_partial_core_finish_code base
+          (0 : BitVec 12) (40 : BitVec 12) (104 : BitVec 12) (112 : BitVec 12)).union
+        (evm_mulmod_product_propagate_carry_code (base + 60) [120, 128, 136, 144, 152]))
+      (evmMulModAddPartialCoreFullPre sp
+        (0 : BitVec 12) (40 : BitVec 12) (104 : BitVec 12) (112 : BitVec 12) a b lo hi
+        x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old **
+       ((((((sp + signExtend12 (120 : BitVec 12)) ↦ₘ p3) **
+        ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ p4) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7))))))
+      (((.x12 ↦ᵣ sp) **
+        (.x10 ↦ᵣ mulModCarryStepCarry p7 (mulModCarryStepCarry p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModCarryStepCarry p3 (mulModAddPartialHiCarry hi lo a b)))))) **
+        (.x9 ↦ᵣ mulModCarryStepValue p7 (mulModCarryStepCarry p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModCarryStepCarry p3 (mulModAddPartialHiCarry hi lo a b)))))) **
+        ((sp + signExtend12 (120 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p3 (mulModAddPartialHiCarry hi lo a b)) **
+        ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p4 (mulModCarryStepCarry p3 (mulModAddPartialHiCarry hi lo a b))) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p5 (mulModCarryStepCarry p4 (mulModCarryStepCarry p3 (mulModAddPartialHiCarry hi lo a b)))) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModCarryStepCarry p3 (mulModAddPartialHiCarry hi lo a b))))) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p7 (mulModCarryStepCarry p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModCarryStepCarry p3 (mulModAddPartialHiCarry hi lo a b))))))) **
+       (.x5 ↦ᵣ a) **
+       (.x6 ↦ᵣ b) **
+       (.x7 ↦ᵣ mulModAddPartialLoProduct a b) **
+       (.x8 ↦ᵣ mulModAddPartialHiProduct a b) **
+       (.x11 ↦ᵣ mulModAddPartialHiValue hi lo a b) **
+       (.x13 ↦ᵣ mulModAddPartialHiBaseCarry hi a b) **
+       (.x14 ↦ᵣ mulModAddPartialHiCarryFromLo hi lo a b) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ a) **
+       ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ b) **
+       ((sp + signExtend12 (104 : BitVec 12)) ↦ₘ mulModAddPartialLoValue lo a b) **
+       ((sp + signExtend12 (112 : BitVec 12)) ↦ₘ mulModAddPartialHiValue hi lo a b)) := by
+  have core := evm_mulmod_product_add_partial_core_finish_spec_within sp base
+    (0 : BitVec 12) (40 : BitVec 12) (104 : BitVec 12) (112 : BitVec 12) a b lo hi
+    x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old
+  have carry := evm_mulmod_product_propagate_carry_120_128_136_144_152_spec_within sp (base + 60)
+    (mulModAddPartialHiCarry hi lo a b) hi p3 p4 p5 p6 p7
+  unfold evmMulModAddPartialCoreFullPre evmMulModAddPartialCorePost at core
+  unfold evmMulModAddPartialCoreFullPre
+  unfold mulModCarryStepValue mulModCarryStepCarry at carry ⊢
+  unfold mulModAddPartialHiCarry mulModAddPartialHiCarryFromLo at core carry ⊢
+  unfold mulModAddPartialHiValue mulModAddPartialHiBaseCarry at core carry ⊢
+  unfold mulModAddPartialHiBaseValue mulModAddPartialLoCarry at core carry ⊢
+  unfold mulModAddPartialLoValue mulModAddPartialHiProduct at core carry ⊢
+  unfold mulModAddPartialLoProduct at core carry ⊢
+  have coreF := cpsTripleWithin_frameR
+    ((((((sp + signExtend12 (120 : BitVec 12)) ↦ₘ p3) **
+        ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ p4) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7)))))
+    (by pcFree) core
+  seqFrame coreF carry
+
+/-- Product-layout call `evm_mulmod_product_add_partial 0 32 96 104 [112, 120, 128, 136, 144, 152]`. -/
+theorem evm_mulmod_product_add_partial_0_32_96_104_112_120_128_136_144_152_spec_within
+    (sp base : Word) (a b lo hi p2 p3 p4 p5 p6 p7 : Word)
+    (x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word) :
+    cpsTripleWithin (15 + 24) base (base + 60 + 96)
+      ((evm_mulmod_product_add_partial_core_finish_code base
+          (0 : BitVec 12) (32 : BitVec 12) (96 : BitVec 12) (104 : BitVec 12)).union
+        (evm_mulmod_product_propagate_carry_code (base + 60) [112, 120, 128, 136, 144, 152]))
+      (evmMulModAddPartialCoreFullPre sp
+        (0 : BitVec 12) (32 : BitVec 12) (96 : BitVec 12) (104 : BitVec 12) a b lo hi
+        x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old **
+       (((((((sp + signExtend12 (112 : BitVec 12)) ↦ₘ p2) **
+        ((sp + signExtend12 (120 : BitVec 12)) ↦ₘ p3) **
+        ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ p4) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7)))))))
+      (((.x12 ↦ᵣ sp) **
+        (.x10 ↦ᵣ mulModCarryStepCarry p7 (mulModCarryStepCarry p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModCarryStepCarry p3 (mulModCarryStepCarry p2 (mulModAddPartialHiCarry hi lo a b))))))) **
+        (.x9 ↦ᵣ mulModCarryStepValue p7 (mulModCarryStepCarry p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModCarryStepCarry p3 (mulModCarryStepCarry p2 (mulModAddPartialHiCarry hi lo a b))))))) **
+        ((sp + signExtend12 (112 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p2 (mulModAddPartialHiCarry hi lo a b)) **
+        ((sp + signExtend12 (120 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p3 (mulModCarryStepCarry p2 (mulModAddPartialHiCarry hi lo a b))) **
+        ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p4 (mulModCarryStepCarry p3 (mulModCarryStepCarry p2 (mulModAddPartialHiCarry hi lo a b)))) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p5 (mulModCarryStepCarry p4 (mulModCarryStepCarry p3 (mulModCarryStepCarry p2 (mulModAddPartialHiCarry hi lo a b))))) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModCarryStepCarry p3 (mulModCarryStepCarry p2 (mulModAddPartialHiCarry hi lo a b)))))) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ
+          mulModCarryStepValue p7 (mulModCarryStepCarry p6 (mulModCarryStepCarry p5 (mulModCarryStepCarry p4 (mulModCarryStepCarry p3 (mulModCarryStepCarry p2 (mulModAddPartialHiCarry hi lo a b)))))))) **
+       (.x5 ↦ᵣ a) **
+       (.x6 ↦ᵣ b) **
+       (.x7 ↦ᵣ mulModAddPartialLoProduct a b) **
+       (.x8 ↦ᵣ mulModAddPartialHiProduct a b) **
+       (.x11 ↦ᵣ mulModAddPartialHiValue hi lo a b) **
+       (.x13 ↦ᵣ mulModAddPartialHiBaseCarry hi a b) **
+       (.x14 ↦ᵣ mulModAddPartialHiCarryFromLo hi lo a b) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ a) **
+       ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ b) **
+       ((sp + signExtend12 (96 : BitVec 12)) ↦ₘ mulModAddPartialLoValue lo a b) **
+       ((sp + signExtend12 (104 : BitVec 12)) ↦ₘ mulModAddPartialHiValue hi lo a b)) := by
+  have core := evm_mulmod_product_add_partial_core_finish_spec_within sp base
+    (0 : BitVec 12) (32 : BitVec 12) (96 : BitVec 12) (104 : BitVec 12) a b lo hi
+    x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old
+  have carry := evm_mulmod_product_propagate_carry_112_120_128_136_144_152_spec_within sp (base + 60)
+    (mulModAddPartialHiCarry hi lo a b) hi p2 p3 p4 p5 p6 p7
+  unfold evmMulModAddPartialCoreFullPre evmMulModAddPartialCorePost at core
+  unfold evmMulModAddPartialCoreFullPre
+  unfold mulModCarryStepValue mulModCarryStepCarry at carry ⊢
+  unfold mulModAddPartialHiCarry mulModAddPartialHiCarryFromLo at core carry ⊢
+  unfold mulModAddPartialHiValue mulModAddPartialHiBaseCarry at core carry ⊢
+  unfold mulModAddPartialHiBaseValue mulModAddPartialLoCarry at core carry ⊢
+  unfold mulModAddPartialLoValue mulModAddPartialHiProduct at core carry ⊢
+  unfold mulModAddPartialLoProduct at core carry ⊢
+  have coreF := cpsTripleWithin_frameR
+    (((((((sp + signExtend12 (112 : BitVec 12)) ↦ₘ p2) **
+        ((sp + signExtend12 (120 : BitVec 12)) ↦ₘ p3) **
+        ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ p4) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7))))))
+    (by pcFree) core
+  seqFrame coreF carry
+
+
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add six named MULMOD add-partial specs for long product-layout carry tails
- cover tails [128,136,144,152], [120,128,136,144,152], and [112,120,128,136,144,152]
- split the new theorem set into MulMod/AddPartialSpecs.lean to keep LimbSpec under the file-size guardrail

## Stack
- Stacked on PR #9108, branch feat/mulmod-short-carry-partials

## Verification
- lake build EvmAsm.Evm64.MulMod.AddPartialSpecs
- lake build EvmAsm.Evm64.MulMod.LimbSpec
- lake build EvmAsm.Evm64.MulMod
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- forbidden-pattern scan on touched files: no matches
- git diff --check
- lake build: passes; known pre-existing LeanRV64D/RiscvExtras.lean deprecation warning

Bead: evm-asm-fhsxz.2.4.2.60.2.5.1.4.1.3.5

Directed by @pirapira; implemented by Codex.
