### PR TITLE
proof(mulmod): package add-partial layout table

### DIFF
--- a/DRIFT.md
+++ b/DRIFT.md
@@ -52,6 +52,7 @@ precondition; the excluded domain is **unverified**.
 |---|---|
 | `SDIV` | callable+dispatch shim; evm_sdiv_stack_spec_within conditional on hStack (discharged for divisor=0 and n=1/2/3/n4-call-skip); blocked on DIV/MOD spec-layer migration (bead evm-asm-9iqmw) |
 | `MOD` | stack spec parametric over ModStackSpecCase (bzero / n=1,2,3, all require b.getLimbN 3 = 0); n=4 path not covered. Executable evm_mod uses divK_div128_v4 (PR #4992). Full-domain unconditional closure tracked by bead evm-asm-9iqmw / gh-61 |
+| `SMOD` | all-case v4 wrapper result-stack spec; zero divisor discharged, nonzero path still parameterized by unsigned-MOD callable h_stack |
 
 ### 🟡 `partly` opcodes — no complete top-level triple yet
 
@@ -59,8 +60,7 @@ Pure-spec / `<op>_correct` lemma proven, but no end-to-end stack-spec wrap.
 
 | Opcode | Why not (yet) fully proven |
 |---|---|
-| `SMOD` | smod_correct proven; no top-level Hoare triple |
-| `ADDMOD` | addmod_correct proven; only b=0 stack-spec done |
+| `ADDMOD` | addmod_correct proven; zero-modulus stack spec done for arbitrary b |
 | `MULMOD` | mulmod_correct proven; no top-level Hoare triple |
 | `EXP` | exp_correct proven; program in active development |
 | `CALLDATACOPY` | preamble + partial memory effect; full loop pending |

--- a/EvmAsm/Evm64/MulMod.lean
+++ b/EvmAsm/Evm64/MulMod.lean
@@ -16,6 +16,7 @@ import EvmAsm.Evm64.MulMod.Program
 import EvmAsm.Evm64.MulMod.ProductAlgebra
 import EvmAsm.Evm64.MulMod.LimbSpec
 import EvmAsm.Evm64.MulMod.AddPartialSpecs
+import EvmAsm.Evm64.MulMod.AddPartialTable
 import EvmAsm.Evm64.MulMod.AddrNorm
 import EvmAsm.Evm64.MulMod.Compose.Base
 import EvmAsm.Evm64.MulMod.Compose.ProductCore

--- a/EvmAsm/Evm64/MulMod/AddPartialTable.lean
+++ b/EvmAsm/Evm64/MulMod/AddPartialTable.lean
@@ -1,0 +1,97 @@
+/-
+  EvmAsm.Evm64.MulMod.AddPartialTable
+
+  Stable, product-layout ordered names for the concrete MULMOD add-partial
+  specs.  These aliases let the product composition proof cite each call by
+  ordinal without unfolding `evm_mulmod_product_add_partial`.
+-/
+
+import EvmAsm.Evm64.MulMod.AddPartialSpecs
+
+namespace EvmAsm.Evm64
+
+-- ============================================================================
+-- Product-layout add-partial call table
+-- ============================================================================
+
+/-- Layout call 00: offsets `(0, 32, 96, 104)`, carry tail `[112, 120, 128, 136, 144, 152]`,
+    entry `base`, exit `base + 60 + 96`, bound `15 + 24`. -/
+abbrev evm_mulmod_product_add_partial_layout_call00_spec_within :=
+  evm_mulmod_product_add_partial_0_32_96_104_112_120_128_136_144_152_spec_within
+
+/-- Layout call 01: offsets `(8, 32, 104, 112)`, carry tail `[120, 128, 136, 144, 152]`,
+    entry `base`, exit `base + 60 + 80`, bound `15 + 20`. -/
+abbrev evm_mulmod_product_add_partial_layout_call01_spec_within :=
+  evm_mulmod_product_add_partial_8_32_104_112_120_128_136_144_152_spec_within
+
+/-- Layout call 02: offsets `(0, 40, 104, 112)`, carry tail `[120, 128, 136, 144, 152]`,
+    entry `base`, exit `base + 60 + 80`, bound `15 + 20`. -/
+abbrev evm_mulmod_product_add_partial_layout_call02_spec_within :=
+  evm_mulmod_product_add_partial_0_40_104_112_120_128_136_144_152_spec_within
+
+/-- Layout call 03: offsets `(16, 32, 112, 120)`, carry tail `[128, 136, 144, 152]`,
+    entry `base`, exit `base + 60 + 64`, bound `15 + 16`. -/
+abbrev evm_mulmod_product_add_partial_layout_call03_spec_within :=
+  evm_mulmod_product_add_partial_16_32_112_120_128_136_144_152_spec_within
+
+/-- Layout call 04: offsets `(8, 40, 112, 120)`, carry tail `[128, 136, 144, 152]`,
+    entry `base`, exit `base + 60 + 64`, bound `15 + 16`. -/
+abbrev evm_mulmod_product_add_partial_layout_call04_spec_within :=
+  evm_mulmod_product_add_partial_8_40_112_120_128_136_144_152_spec_within
+
+/-- Layout call 05: offsets `(0, 48, 112, 120)`, carry tail `[128, 136, 144, 152]`,
+    entry `base`, exit `base + 60 + 64`, bound `15 + 16`. -/
+abbrev evm_mulmod_product_add_partial_layout_call05_spec_within :=
+  evm_mulmod_product_add_partial_0_48_112_120_128_136_144_152_spec_within
+
+/-- Layout call 06: offsets `(24, 32, 120, 128)`, carry tail `[136, 144, 152]`,
+    entry `base`, exit `base + 60 + 48`, bound `15 + 12`. -/
+abbrev evm_mulmod_product_add_partial_layout_call06_spec_within :=
+  evm_mulmod_product_add_partial_24_32_120_128_136_144_152_spec_within
+
+/-- Layout call 07: offsets `(16, 40, 120, 128)`, carry tail `[136, 144, 152]`,
+    entry `base`, exit `base + 60 + 48`, bound `15 + 12`. -/
+abbrev evm_mulmod_product_add_partial_layout_call07_spec_within :=
+  evm_mulmod_product_add_partial_16_40_120_128_136_144_152_spec_within
+
+/-- Layout call 08: offsets `(8, 48, 120, 128)`, carry tail `[136, 144, 152]`,
+    entry `base`, exit `base + 60 + 48`, bound `15 + 12`. -/
+abbrev evm_mulmod_product_add_partial_layout_call08_spec_within :=
+  evm_mulmod_product_add_partial_8_48_120_128_136_144_152_spec_within
+
+/-- Layout call 09: offsets `(0, 56, 120, 128)`, carry tail `[136, 144, 152]`,
+    entry `base`, exit `base + 60 + 48`, bound `15 + 12`. -/
+abbrev evm_mulmod_product_add_partial_layout_call09_spec_within :=
+  evm_mulmod_product_add_partial_0_56_120_128_136_144_152_spec_within
+
+/-- Layout call 10: offsets `(24, 40, 128, 136)`, carry tail `[144, 152]`,
+    entry `base`, exit `base + 60 + 32`, bound `15 + 8`. -/
+abbrev evm_mulmod_product_add_partial_layout_call10_spec_within :=
+  evm_mulmod_product_add_partial_24_40_128_136_144_152_spec_within
+
+/-- Layout call 11: offsets `(16, 48, 128, 136)`, carry tail `[144, 152]`,
+    entry `base`, exit `base + 60 + 32`, bound `15 + 8`. -/
+abbrev evm_mulmod_product_add_partial_layout_call11_spec_within :=
+  evm_mulmod_product_add_partial_16_48_128_136_144_152_spec_within
+
+/-- Layout call 12: offsets `(8, 56, 128, 136)`, carry tail `[144, 152]`,
+    entry `base`, exit `base + 60 + 32`, bound `15 + 8`. -/
+abbrev evm_mulmod_product_add_partial_layout_call12_spec_within :=
+  evm_mulmod_product_add_partial_8_56_128_136_144_152_spec_within
+
+/-- Layout call 13: offsets `(24, 48, 136, 144)`, carry tail `[152]`,
+    entry `base`, exit `base + 60 + 16`, bound `15 + 4`. -/
+abbrev evm_mulmod_product_add_partial_layout_call13_spec_within :=
+  evm_mulmod_product_add_partial_24_48_136_144_152_spec_within
+
+/-- Layout call 14: offsets `(16, 56, 136, 144)`, carry tail `[152]`,
+    entry `base`, exit `base + 60 + 16`, bound `15 + 4`. -/
+abbrev evm_mulmod_product_add_partial_layout_call14_spec_within :=
+  evm_mulmod_product_add_partial_16_56_136_144_152_spec_within
+
+/-- Layout call 15: offsets `(24, 56, 144, 152)`, carry tail `[]`,
+    entry `base`, exit `base + 60`, bound `15`. -/
+abbrev evm_mulmod_product_add_partial_layout_call15_spec_within :=
+  evm_mulmod_product_add_partial_144_152_nil_spec_within
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add `AddPartialTable.lean` with stable layout-call aliases `call00` through `call15`
- document each product-layout add-partial call's offsets, carry tail, exit PC, and cycle bound
- import the table through the MulMod umbrella for downstream composition proofs

## Verification
- `lake build EvmAsm.Evm64.MulMod.AddPartialTable`
- `lake build EvmAsm.Evm64.MulMod`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- forbidden-pattern scan on touched files
