### PR TITLE
proof(mulmod): package product split bridge

### DIFF
--- a/DRIFT.md
+++ b/DRIFT.md
@@ -52,6 +52,7 @@ precondition; the excluded domain is **unverified**.
 |---|---|
 | `SDIV` | callable+dispatch shim; evm_sdiv_stack_spec_within conditional on hStack (discharged for divisor=0 and n=1/2/3/n4-call-skip); blocked on DIV/MOD spec-layer migration (bead evm-asm-9iqmw) |
 | `MOD` | stack spec parametric over ModStackSpecCase (bzero / n=1,2,3, all require b.getLimbN 3 = 0); n=4 path not covered. Executable evm_mod uses divK_div128_v4 (PR #4992). Full-domain unconditional closure tracked by bead evm-asm-9iqmw / gh-61 |
+| `SMOD` | all-case v4 wrapper result-stack spec; zero divisor discharged, nonzero path still parameterized by unsigned-MOD callable h_stack |
 
 ### 🟡 `partly` opcodes — no complete top-level triple yet
 
@@ -59,8 +60,7 @@ Pure-spec / `<op>_correct` lemma proven, but no end-to-end stack-spec wrap.
 
 | Opcode | Why not (yet) fully proven |
 |---|---|
-| `SMOD` | smod_correct proven; no top-level Hoare triple |
-| `ADDMOD` | addmod_correct proven; only b=0 stack-spec done |
+| `ADDMOD` | addmod_correct proven; zero-modulus stack spec done for arbitrary b |
 | `MULMOD` | mulmod_correct proven; no top-level Hoare triple |
 | `EXP` | exp_correct proven; program in active development |
 | `CALLDATACOPY` | preamble + partial memory effect; full loop pending |

--- a/EvmAsm/Evm64/MulMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/MulMod/LimbSpec.lean
@@ -10,6 +10,7 @@
 -/
 
 import EvmAsm.Evm64.MulMod.Program
+import EvmAsm.Evm64.MulMod.ProductAlgebra
 import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.XSimp

--- a/EvmAsm/Evm64/MulMod/ProductAlgebra.lean
+++ b/EvmAsm/Evm64/MulMod/ProductAlgebra.lean
@@ -59,6 +59,14 @@ def productHighLimbs (a b : EvmWord) : List Word :=
     productOffsetIndices.length = 8 := by
   rfl
 
+/-- Runtime product-window offsets paired with the corresponding algebraic limb value. -/
+def productOffsetValues (a b : EvmWord) : List (BitVec 12 × Word) :=
+  productOffsetIndices.map (fun offsetIndex => (offsetIndex.1, productLimb a b offsetIndex.2))
+
+@[simp] theorem productOffsetValues_length (a b : EvmWord) :
+    (productOffsetValues a b).length = 8 := by
+  rfl
+
 @[simp] theorem productLowLimbs_length (a b : EvmWord) :
     (productLowLimbs a b).length = 4 := by
   rfl
@@ -200,6 +208,42 @@ private theorem productLimb_low_eq_getLimb (a b : EvmWord) (i : Fin 4) :
   simp only [productLowLimbs_eq, productLimb_zero_eq_mul_getLimb,
     productLimb_one_eq_mul_getLimb, productLimb_two_eq_mul_getLimb,
     productLimb_three_eq_mul_getLimb]
+
+/-- The full product window splits into the low EVM multiplication word followed by
+    the high multiplication word. -/
+@[simp] theorem productLimbs_eq_mul_split_getLimbs (a b : EvmWord) :
+    productLimbs a b =
+      [(a * b).getLimb 0, (a * b).getLimb 1,
+       (a * b).getLimb 2, (a * b).getLimb 3,
+       (EvmWord.mulHigh a b).getLimb 0, (EvmWord.mulHigh a b).getLimb 1,
+       (EvmWord.mulHigh a b).getLimb 2, (EvmWord.mulHigh a b).getLimb 3] := by
+  simp only [productLimbs, productLimb_zero_eq_mul_getLimb,
+    productLimb_one_eq_mul_getLimb, productLimb_two_eq_mul_getLimb,
+    productLimb_three_eq_mul_getLimb, productLimb_four_eq_mulHigh_getLimb_zero,
+    productLimb_five_eq_mulHigh_getLimb_one, productLimb_six_eq_mulHigh_getLimb_two,
+    productLimb_seven_eq_mulHigh_getLimb_three]
+
+/-- Product-window offsets mapped to the low/high split expected by the folded
+    `evm_mulmod_product_layout` postcondition. -/
+@[simp] theorem productOffsetValues_eq_mul_split_getLimbs (a b : EvmWord) :
+    productOffsetValues a b =
+      [((96 : BitVec 12), (a * b).getLimb 0),
+       ((104 : BitVec 12), (a * b).getLimb 1),
+       ((112 : BitVec 12), (a * b).getLimb 2),
+       ((120 : BitVec 12), (a * b).getLimb 3),
+       ((128 : BitVec 12), (EvmWord.mulHigh a b).getLimb 0),
+       ((136 : BitVec 12), (EvmWord.mulHigh a b).getLimb 1),
+       ((144 : BitVec 12), (EvmWord.mulHigh a b).getLimb 2),
+       ((152 : BitVec 12), (EvmWord.mulHigh a b).getLimb 3)] := by
+  simp [productOffsetValues, productOffsetIndices, productLimb_zero_eq_mul_getLimb,
+    productLimb_one_eq_mul_getLimb, productLimb_two_eq_mul_getLimb,
+    productLimb_three_eq_mul_getLimb, productLimb_four_eq_mulHigh_getLimb_zero,
+    productLimb_five_eq_mulHigh_getLimb_one, productLimb_six_eq_mulHigh_getLimb_two,
+    productLimb_seven_eq_mulHigh_getLimb_three]
+
+@[simp] theorem productOffsetValues_offsets (a b : EvmWord) :
+    (productOffsetValues a b).map Prod.fst = mulmodProductOffsets := by
+  simp [productOffsetValues, productOffsetIndices, mulmodProductOffsets]
 
 @[simp] theorem productLimb_zero_eq_mul_correct_limb0 (a b : EvmWord) :
     productLimb a b 0 = a.getLimb 0 * b.getLimb 0 := by


### PR DESCRIPTION
## Summary
- add `productOffsetValues` for concrete product-window offset/value pairs
- prove the eight product limbs split into low `(a * b)` limbs and high `EvmWord.mulHigh` limbs
- expose the offset/value split table through `LimbSpec` consumers

Refs bead: evm-asm-fhsxz.2.4.2.60.2.5.1.4.1.4.4.

Directed by @pirapira; implemented by Codex.

## Verification
- `lake build EvmAsm.Evm64.MulMod.ProductAlgebra`
- `lake build EvmAsm.Evm64.MulMod.LimbSpec`
- `lake build EvmAsm.Evm64.MulMod`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- forbidden-pattern scan on touched files
- `lake build` (passes with pre-existing `LeanRV64D.RiscvExtras` deprecation warning)
