### PR TITLE
proof(mulmod): add product layout interface

### DIFF
--- a/DRIFT.md
+++ b/DRIFT.md
@@ -52,6 +52,7 @@ precondition; the excluded domain is **unverified**.
 |---|---|
 | `SDIV` | callable+dispatch shim; evm_sdiv_stack_spec_within conditional on hStack (discharged for divisor=0 and n=1/2/3/n4-call-skip); blocked on DIV/MOD spec-layer migration (bead evm-asm-9iqmw) |
 | `MOD` | stack spec parametric over ModStackSpecCase (bzero / n=1,2,3, all require b.getLimbN 3 = 0); n=4 path not covered. Executable evm_mod uses divK_div128_v4 (PR #4992). Full-domain unconditional closure tracked by bead evm-asm-9iqmw / gh-61 |
+| `SMOD` | all-case v4 wrapper result-stack spec; zero divisor discharged, nonzero path still parameterized by unsigned-MOD callable h_stack |
 
 ### 🟡 `partly` opcodes — no complete top-level triple yet
 
@@ -59,8 +60,7 @@ Pure-spec / `<op>_correct` lemma proven, but no end-to-end stack-spec wrap.
 
 | Opcode | Why not (yet) fully proven |
 |---|---|
-| `SMOD` | smod_correct proven; no top-level Hoare triple |
-| `ADDMOD` | addmod_correct proven; only b=0 stack-spec done |
+| `ADDMOD` | addmod_correct proven; zero-modulus stack spec done for arbitrary b |
 | `MULMOD` | mulmod_correct proven; no top-level Hoare triple |
 | `EXP` | exp_correct proven; program in active development |
 | `CALLDATACOPY` | preamble + partial memory effect; full loop pending |

--- a/EvmAsm/Evm64/MulMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/MulMod/LimbSpec.lean
@@ -316,6 +316,97 @@ theorem evm_mulmod_product_zero_spec_within (sp : Word) (base : Word)
   runBlock I0 I1 I2 I3 I4 I5 I6 I7
 
 -- ============================================================================
+-- evm_mulmod_product_layout
+-- ============================================================================
+
+abbrev evm_mulmod_product_layout_code (base : Word) : CodeReq :=
+  CodeReq.ofProg base evm_mulmod_product_layout
+
+/-- Folded precondition for `evm_mulmod_product_layout`.
+
+    The layout preserves the three input stack words `[a, b, n]` and may
+    overwrite the eight-limb product window at `sp+96..152`. -/
+@[irreducible]
+def evmMulModProductLayoutPre (sp : Word) (a b n : EvmWord)
+    (p0 p1 p2 p3 p4 p5 p6 p7 : Word) : Assertion :=
+  (.x12 ↦ᵣ sp) **
+  (sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
+  ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3) **
+  ((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
+  ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3) **
+  ((sp + 64) ↦ₘ n.getLimbN 0) ** ((sp + 72) ↦ₘ n.getLimbN 1) **
+  ((sp + 80) ↦ₘ n.getLimbN 2) ** ((sp + 88) ↦ₘ n.getLimbN 3) **
+  ((sp + signExtend12 (96 : BitVec 12)) ↦ₘ p0) **
+  ((sp + signExtend12 (104 : BitVec 12)) ↦ₘ p1) **
+  ((sp + signExtend12 (112 : BitVec 12)) ↦ₘ p2) **
+  ((sp + signExtend12 (120 : BitVec 12)) ↦ₘ p3) **
+  ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ p4) **
+  ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+  ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+  ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7)
+
+/-- Folded public postcondition for `evm_mulmod_product_layout`.
+
+    The first four product-window limbs are the low 256 bits of `a * b`; the
+    last four are the high 256 bits of the full 512-bit product. -/
+@[irreducible]
+def evmMulModProductLayoutPost (sp : Word) (a b n : EvmWord) : Assertion :=
+  (.x12 ↦ᵣ sp) **
+  (sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
+  ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3) **
+  ((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
+  ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3) **
+  ((sp + 64) ↦ₘ n.getLimbN 0) ** ((sp + 72) ↦ₘ n.getLimbN 1) **
+  ((sp + 80) ↦ₘ n.getLimbN 2) ** ((sp + 88) ↦ₘ n.getLimbN 3) **
+  ((sp + signExtend12 (96 : BitVec 12)) ↦ₘ (a * b).getLimbN 0) **
+  ((sp + signExtend12 (104 : BitVec 12)) ↦ₘ (a * b).getLimbN 1) **
+  ((sp + signExtend12 (112 : BitVec 12)) ↦ₘ (a * b).getLimbN 2) **
+  ((sp + signExtend12 (120 : BitVec 12)) ↦ₘ (a * b).getLimbN 3) **
+  ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ (EvmWord.mulHigh a b).getLimbN 0) **
+  ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ (EvmWord.mulHigh a b).getLimbN 1) **
+  ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ (EvmWord.mulHigh a b).getLimbN 2) **
+  ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ (EvmWord.mulHigh a b).getLimbN 3)
+
+theorem evmMulModProductLayoutPre_unfold (sp : Word) (a b n : EvmWord)
+    (p0 p1 p2 p3 p4 p5 p6 p7 : Word) :
+    evmMulModProductLayoutPre sp a b n p0 p1 p2 p3 p4 p5 p6 p7 =
+      ((.x12 ↦ᵣ sp) **
+       (sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
+       ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3) **
+       ((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
+       ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3) **
+       ((sp + 64) ↦ₘ n.getLimbN 0) ** ((sp + 72) ↦ₘ n.getLimbN 1) **
+       ((sp + 80) ↦ₘ n.getLimbN 2) ** ((sp + 88) ↦ₘ n.getLimbN 3) **
+       ((sp + signExtend12 (96 : BitVec 12)) ↦ₘ p0) **
+       ((sp + signExtend12 (104 : BitVec 12)) ↦ₘ p1) **
+       ((sp + signExtend12 (112 : BitVec 12)) ↦ₘ p2) **
+       ((sp + signExtend12 (120 : BitVec 12)) ↦ₘ p3) **
+       ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ p4) **
+       ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+       ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+       ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7)) := by
+  delta evmMulModProductLayoutPre; rfl
+
+theorem evmMulModProductLayoutPost_unfold (sp : Word) (a b n : EvmWord) :
+    evmMulModProductLayoutPost sp a b n =
+      ((.x12 ↦ᵣ sp) **
+       (sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
+       ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3) **
+       ((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
+       ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3) **
+       ((sp + 64) ↦ₘ n.getLimbN 0) ** ((sp + 72) ↦ₘ n.getLimbN 1) **
+       ((sp + 80) ↦ₘ n.getLimbN 2) ** ((sp + 88) ↦ₘ n.getLimbN 3) **
+       ((sp + signExtend12 (96 : BitVec 12)) ↦ₘ (a * b).getLimbN 0) **
+       ((sp + signExtend12 (104 : BitVec 12)) ↦ₘ (a * b).getLimbN 1) **
+       ((sp + signExtend12 (112 : BitVec 12)) ↦ₘ (a * b).getLimbN 2) **
+       ((sp + signExtend12 (120 : BitVec 12)) ↦ₘ (a * b).getLimbN 3) **
+       ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ (EvmWord.mulHigh a b).getLimbN 0) **
+       ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ (EvmWord.mulHigh a b).getLimbN 1) **
+       ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ (EvmWord.mulHigh a b).getLimbN 2) **
+       ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ (EvmWord.mulHigh a b).getLimbN 3)) := by
+  delta evmMulModProductLayoutPost; rfl
+
+-- ============================================================================
 -- evm_mulmod_product_propagate_carry
 -- ============================================================================
 


### PR DESCRIPTION
## Summary
- decompose the full product-layout composition bead into proof-sized child beads
- add `evm_mulmod_product_layout_code` as the local product-layout code handle
- add folded `evmMulModProductLayoutPre` and `evmMulModProductLayoutPost` interfaces for later composition proofs
- expose unfold lemmas for the folded product-layout pre/post assertions

Refs bead: evm-asm-fhsxz.2.4.2.60.2.5.1.4.1.5.1.

Directed by @pirapira; implemented by Codex.

## Verification
- `lake build EvmAsm.Evm64.MulMod.LimbSpec`
- `lake build EvmAsm.Evm64.MulMod`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- forbidden-pattern scan on touched file
- `lake build` (passes with pre-existing `LeanRV64D.RiscvExtras` deprecation warning)
