### PR TITLE
fix(verdict): order end-of-block system storage tuples at block_access_index N+1 (EIP-7928 bv42)

### DIFF
--- a/EvmAsm/Codegen/Programs/AccountTupleSequencesConsistent.lean
+++ b/EvmAsm/Codegen/Programs/AccountTupleSequencesConsistent.lean
@@ -162,6 +162,10 @@ def accountTupleSequencesConsistentData : String :=
 def accountTupleSequencesConsistentEmptySystemData : String :=
   ".balign 8\n" ++
   "bv_system_storage_log_count:\n  .zero 8\n" ++
+  -- lv44p.2.2: the consistency fn now points sust_sys_txindex_ptr at this array.
+  -- The standalone probe runs an empty system log (count 0), so it is never read,
+  -- but the symbol must resolve at link time.
+  "bv_system_storage_txindex:\n  .zero 16\n" ++
   ".balign 32\n" ++
   "bv_system_storage_log:\n  .zero 128\n"
 

--- a/EvmAsm/Codegen/Programs/AccountTupleSequencesConsistent.lean
+++ b/EvmAsm/Codegen/Programs/AccountTupleSequencesConsistent.lean
@@ -114,7 +114,11 @@ def accountTupleSequencesConsistentFunction : String :=
   ".Latsc_vrb:\n  beqz t4, .Latsc_vrn\n  lbu t5, 0(t2); lbu t6, 0(t3); sb t6, 0(t2); sb t5, 0(t3); addi t2, t2, 1; addi t3, t3, -1; addi t4, t4, -1; j .Latsc_vrb\n" ++
   ".Latsc_vrn:\n  addi t1, t1, 40; addi t0, t0, -1; j .Latsc_vr\n" ++
   ".Latsc_vrd:\n" ++
-  "  # exec net-change tuple sequence for this slot: captured system rows first, then user rows.\n" ++
+  "  # exec net-change tuple sequence for this slot: begin-system (idx0) then user (1..N) then end-system (idxN+1).\n" ++
+  -- lv44p.2.2: point system_user_exec_log_slot_tuples at the REAL per-row system
+  -- block_access_index array so end-of-block (EIP-7002/7251) rows order after the
+  -- user txs (index N+1) instead of being mis-stamped 0 and placed first.
+  "  la t0, sust_sys_txindex_ptr; la t1, bv_system_storage_txindex; sd t1, 0(t0)\n" ++
   "  mv a0, s2; la a1, atsc_key_le; la a2, bv_system_storage_log; la t0, bv_system_storage_log_count; ld a3, 0(t0); mv a4, s3; mv a5, s4; mv a6, s5; la a7, atsc_execbuf\n" ++
   "  jal ra, system_user_exec_log_slot_tuples\n" ++
   "  mv t6, a0                                            # exec_count\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -586,6 +586,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   "bv_system_storage_capture_rows:\n  .zero 8\n" ++
   "bv_system_storage_capture_old_count:\n  .zero 8\n" ++
   "bv_system_storage_capture_new_count:\n  .zero 8\n" ++
+  "cssc_stamp_txindex:\n  .zero 8\n" ++       -- lv44p.2.2: block_access_index stamped into captured system rows
   "c1_wcode_ptr:\n  .zero 8\n" ++
   "c1_wcode_len:\n  .zero 8\n" ++
   "c1_er_input:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
@@ -496,6 +496,8 @@ def statelessVerdictV2Function : String :=
   "  beqz t3, .Lc1_w_copyd; lbu t4, 0(t1); sb t4, 0(t2); addi t1, t1, 1; addi t2, t2, 1; addi t3, t3, -1; j .Lc1_w_copy\n" ++
   ".Lc1_w_copyd:\n" ++
   "  la t0, c1_system_log_cursor; ld a0, 0(t0); la t1, evm_env; ld a1, 448(t1); li a2, 0xa0630000; la a3, bv_system_storage_log; la a4, bv_system_storage_txindex; la a5, bv_system_storage_log_count\n" ++
+  -- lv44p.2.2: end-of-block system calls run at block_access_index N+1 (= svf_tx_count+1).
+  "  la t2, svf_tx_count; ld a6, 0(t2); addi a6, a6, 1\n" ++
   "  jal ra, capture_system_storage_exec_rows\n" ++
   "  # side capture failure is non-fatal for verdict parity; request bodies were already copied\n" ++
   "  la t0, evm_env; ld t1, 448(t0); la t2, c1_system_log_cursor; sd t1, 0(t2)\n" ++
@@ -539,6 +541,8 @@ def statelessVerdictV2Function : String :=
   "  beqz t3, .Lc1_c_copyd; lbu t4, 0(t1); sb t4, 0(t2); addi t1, t1, 1; addi t2, t2, 1; addi t3, t3, -1; j .Lc1_c_copy\n" ++
   ".Lc1_c_copyd:\n" ++
   "  la t0, c1_system_log_cursor; ld a0, 0(t0); la t1, evm_env; ld a1, 448(t1); li a2, 0xa0630000; la a3, bv_system_storage_log; la a4, bv_system_storage_txindex; la a5, bv_system_storage_log_count\n" ++
+  -- lv44p.2.2: end-of-block system calls run at block_access_index N+1 (= svf_tx_count+1).
+  "  la t2, svf_tx_count; ld a6, 0(t2); addi a6, a6, 1\n" ++
   "  jal ra, capture_system_storage_exec_rows\n" ++
   "  # side capture failure is non-fatal for verdict parity; request bodies were already copied\n" ++
   "  la t0, evm_env; ld t1, 448(t0); la t2, c1_system_log_cursor; sd t1, 0(t2)\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictSystemStorageCapture.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictSystemStorageCapture.lean
@@ -20,11 +20,15 @@ open EvmAsm.Rv64
     a3 = side storage log base
     a4 = side txindex base
     a5 = side count ptr
+    a6 = block_access_index to stamp into the side txindex for every copied row
     a0 (output) = 0 copied / 1 malformed end<start / 2 side arena overflow.
 
-    Copies rows in [start,end) into the side arena and writes txindex=0 for
+    Copies rows in [start,end) into the side arena and writes txindex=a6 for
     every copied row. The caller keeps restoring the regular log count, so this
     side arena is the only durable record of system-call storage writes.
+    lv44p.2.2: end-of-block system calls (EIP-7002/7251) run at block_access_index
+    N+1, so the caller passes N+1 here; the tuple comparator then orders these
+    end-of-block rows AFTER the user transactions instead of mis-stamping them 0.
 
     Debug globals record the last attempted range and count calculation so
     non-fatal request-derivation callers can expose why side capture was
@@ -42,6 +46,7 @@ def captureSystemStorageExecRowsFunction : String :=
   "  mv s3, a3                    # side log base\n" ++
   "  mv s4, a4                    # side txindex base\n" ++
   "  mv s5, a5                    # side count ptr\n" ++
+  "  la t0, cssc_stamp_txindex; sd a6, 0(t0)   # lv44p.2.2: block_access_index to stamp\n" ++
   "  la t0, bv_system_storage_capture_start; sd s0, 0(t0)\n" ++
   "  la t0, bv_system_storage_capture_end; sd s1, 0(t0)\n" ++
   "  la t0, bv_system_storage_capture_status; sd zero, 0(t0)\n" ++
@@ -62,7 +67,7 @@ def captureSystemStorageExecRowsFunction : String :=
   "  add t4, s0, t3; slli t4, t4, 7; add t4, s2, t4   # src row\n" ++
   "  ld t0, 0(s5); add t0, t0, t3\n" ++
   "  slli t5, t0, 7; add t5, s3, t5                   # dst row\n" ++
-  "  slli t6, t0, 3; add t6, s4, t6; sd zero, 0(t6)    # side txindex = 0\n" ++
+  "  slli t6, t0, 3; add t6, s4, t6; la t1, cssc_stamp_txindex; ld t1, 0(t1); sd t1, 0(t6)   # side txindex = a6 (block_access_index)\n" ++
   "  ld t6, 0(t4); sd t6, 0(t5); ld t6, 8(t4); sd t6, 8(t5)\n" ++
   "  ld t6, 16(t4); sd t6, 16(t5); ld t6, 24(t4); sd t6, 24(t5)\n" ++
   "  ld t6, 32(t4); sd t6, 32(t5); ld t6, 40(t4); sd t6, 40(t5)\n" ++
@@ -177,6 +182,7 @@ def ziskCaptureSystemStorageExecRowsPrologue : String :=
   "  addi t0, t0, 128; li t1, 0x2222; sd t1, 0(t0); li t1, 0x222f; sd t1, 120(t0)\n" ++
   "  addi t0, t0, 128; li t1, 0x3333; sd t1, 0(t0); li t1, 0x333f; sd t1, 120(t0)\n" ++
   "  li a0, 1; li a1, 3; la a2, cssc_src; la a3, cssc_side_log; la a4, cssc_side_txindex; la a5, cssc_side_count\n" ++
+  "  li a6, 0\n" ++   -- lv44p.2.2 probe: stamp txindex 0 (probe asserts side txindex==0)
   "  jal ra, capture_system_storage_exec_rows\n" ++
   "  li t0, 0xa0010000\n" ++
   "  sd a0, 0(t0)\n" ++
@@ -184,11 +190,13 @@ def ziskCaptureSystemStorageExecRowsPrologue : String :=
   "  la t1, cssc_side_txindex; ld t2, 0(t1); sd t2, 16(t0); ld t2, 8(t1); sd t2, 24(t0)\n" ++
   "  la t1, cssc_side_log; ld t2, 0(t1); sd t2, 32(t0); ld t2, 248(t1); sd t2, 40(t0)\n" ++
   "  li a0, 3; li a1, 1; la a2, cssc_src; la a3, cssc_side_log; la a4, cssc_side_txindex; la a5, cssc_side_count\n" ++
+  "  li a6, 0\n" ++   -- lv44p.2.2 probe: stamp txindex 0 (probe asserts side txindex==0)
   "  jal ra, capture_system_storage_exec_rows\n" ++
   "  li t0, 0xa0010000\n" ++
   "  sd a0, 48(t0)\n" ++
   "  li t1, " ++ toString (bvSystemStorageLogCapacity - 1) ++ "; la t2, cssc_side_count; sd t1, 0(t2)\n" ++
   "  li a0, 1; li a1, 2; la a2, cssc_src; li a3, 0xa1000000; li a4, 0xa0800000; la a5, cssc_side_count\n" ++
+  "  li a6, 0\n" ++   -- lv44p.2.2 probe: stamp txindex 0 (probe asserts side txindex==0)
   "  jal ra, capture_system_storage_exec_rows\n" ++
   "  li t0, 0xa0010000\n" ++
   "  sd a0, 56(t0)\n" ++
@@ -196,6 +204,7 @@ def ziskCaptureSystemStorageExecRowsPrologue : String :=
   "  li t3, 0xa1000000; li t4, " ++ toString ((bvSystemStorageLogCapacity - 1) * 128) ++ "; add t3, t3, t4; ld t5, 0(t3); sd t5, 72(t0)\n" ++
   "  li t1, " ++ toString bvSystemStorageLogCapacity ++ "; la t2, cssc_side_count; sd t1, 0(t2)\n" ++
   "  li a0, 1; li a1, 2; la a2, cssc_src; li a3, 0xa1000000; li a4, 0xa0800000; la a5, cssc_side_count\n" ++
+  "  li a6, 0\n" ++   -- lv44p.2.2 probe: stamp txindex 0 (probe asserts side txindex==0)
   "  jal ra, capture_system_storage_exec_rows\n" ++
   "  li t0, 0xa0010000\n" ++
   "  sd a0, 80(t0)\n" ++
@@ -223,7 +232,8 @@ def ziskCaptureSystemStorageExecRowsDataSection : String :=
   "bv_system_storage_capture_end:\n  .zero 8\n" ++
   "bv_system_storage_capture_rows:\n  .zero 8\n" ++
   "bv_system_storage_capture_old_count:\n  .zero 8\n" ++
-  "bv_system_storage_capture_new_count:\n  .zero 8\n"
+  "bv_system_storage_capture_new_count:\n  .zero 8\n" ++
+  "cssc_stamp_txindex:\n  .zero 8\n"
 
 def ziskCaptureSystemStorageExecRowsProbeUnit : BuildUnit := {
   body        := NOP

--- a/EvmAsm/Codegen/Programs/ExecLogSlotTuples.lean
+++ b/EvmAsm/Codegen/Programs/ExecLogSlotTuples.lean
@@ -57,6 +57,16 @@ def execLogSlotTuplesFunction : String :=
   "  li s6, 0                     # entry index i\n" ++
   ".Lels_loop:\n" ++
   "  beq s6, s3, .Lels_finalize\n" ++
+  -- lv44p.2.2 txindex window filter: when els_txfilter_hi != 0, process entry i only
+  -- if els_txfilter_lo <= txindex[i] < els_txfilter_hi (else skip). Default 0/0 leaves
+  -- every entry in (backward-compatible with all existing callers). Used by
+  -- system_user_exec_log_slot_tuples to split begin-of-block (block_access_index 0)
+  -- from end-of-block (N+1) system rows so each lands in the correct ordered segment.\n" ++
+  "  la t0, els_txfilter_hi; ld t0, 0(t0); beqz t0, .Lels_nofilter\n" ++
+  "  slli t6, s6, 3; add t6, s4, t6; ld t6, 0(t6)        # txindex[i]\n" ++
+  "  la t0, els_txfilter_lo; ld t0, 0(t0); bltu t6, t0, .Lels_next   # txindex < lo -> skip\n" ++
+  "  la t0, els_txfilter_hi; ld t0, 0(t0); bgeu t6, t0, .Lels_next   # txindex >= hi -> skip\n" ++
+  ".Lels_nofilter:\n" ++
   "  slli t0, s6, 7; add t1, s2, t0   # entry ptr\n" ++
   "  # match addrHash (entry@0 vs s0)\n" ++
   "  ld t2, 0(t1);  ld t3, 0(s0);  bne t2, t3, .Lels_next\n" ++
@@ -139,7 +149,10 @@ def execLogSlotTuplesData : String :=
   "els_groupval:\n  .zero 32\n" ++
   "els_grouptx:\n  .zero 8\n" ++
   "els_haverun:\n  .zero 8\n" ++
-  "els_havegrp:\n  .zero 8\n"
+  "els_havegrp:\n  .zero 8\n" ++
+  -- lv44p.2.2: txindex window [lo, hi) filter. Default 0/0 (hi==0) = no filter.
+  "els_txfilter_lo:\n  .zero 8\n" ++
+  "els_txfilter_hi:\n  .zero 8\n"
 
 /-- `zisk_exec_log_slot_tuples`: focused probe.
     Input (after the ziskemu length wrapper at 0x40000000):

--- a/EvmAsm/Codegen/Programs/SystemStorageSlotTuples.lean
+++ b/EvmAsm/Codegen/Programs/SystemStorageSlotTuples.lean
@@ -24,9 +24,22 @@ open EvmAsm.Rv64
     a0 (output) = total tuple count. If total exceeds bsrMaxTuplesPerSlot,
     output writes are suppressed and the caller must reject conservatively.
 
-    Captured system rows all belong to block_access_index 0, so this helper uses
-    a zero-filled txindex arena for the system-side call. User rows keep their
-    existing txindex arena and are appended after the system tuples. -/
+    lv44p.2.2: system rows are NOT all block_access_index 0. Begin-of-block system
+    calls (EIP-2935/4788) run at index 0; END-of-block calls (EIP-7002/7251) run at
+    index N+1, AFTER every user transaction. Both live in the same system log
+    (`bv_system_storage_log`) with their real per-row index in the txindex array. To
+    reconstruct the spec's ordered net-change sequence this helper runs THREE
+    `exec_log_slot_tuples` passes with a txindex window filter and concatenates them
+    in block_access_index order: begin-system (window [0,1)), then user (1..N), then
+    end-system (window [1, 2^64)). Each pass independently re-seeds its running value
+    from the FIRST matching row's `original`, which equals the running value at that
+    point (original = the pre-write value, accumulated across prior segments), so the
+    split passes preserve net-change continuity exactly without shared state.
+
+    The caller sets `sust_sys_txindex_ptr` to the real system txindex array
+    (`bv_system_storage_txindex`); a 0 ptr falls back to the all-zero array (so the
+    standalone probe / legacy callers see every system row at index 0 = begin-only,
+    byte-identical to the prior system-first behaviour). -/
 def systemUserExecLogSlotTuplesFunction : String :=
   "system_user_exec_log_slot_tuples:\n" ++
   "  addi sp, sp, -96\n" ++
@@ -41,15 +54,32 @@ def systemUserExecLogSlotTuplesFunction : String :=
   "  mv s5, a5                    # user row count\n" ++
   "  mv s6, a6                    # user txindex base\n" ++
   "  mv s7, a7                    # out buffer\n" ++
-  "  mv a0, s0; mv a1, s1; mv a2, s2; mv a3, s3; la a4, sust_zero_txindex; la a5, sust_sysbuf\n" ++
+  -- resolve the system txindex array (caller-set ptr, 0 => all-zero array)
+  "  la t0, sust_sys_txindex_ptr; ld t0, 0(t0); bnez t0, .Lsust_systx_set; la t0, sust_zero_txindex\n" ++
+  ".Lsust_systx_set:\n" ++
+  "  la t1, sust_systx; sd t0, 0(t1)\n" ++
+  -- PASS 1: begin-of-block system rows (block_access_index 0): txindex window [0,1)
+  "  la t1, els_txfilter_lo; sd zero, 0(t1); la t1, els_txfilter_hi; li t2, 1; sd t2, 0(t1)\n" ++
+  "  mv a0, s0; mv a1, s1; mv a2, s2; mv a3, s3; la t0, sust_systx; ld a4, 0(t0); la a5, sust_sysbuf\n" ++
   "  jal ra, exec_log_slot_tuples\n" ++
-  "  mv s8, a0                    # system tuple count\n" ++
+  "  mv s8, a0                    # begin-system tuple count\n" ++
+  -- PASS 2: user rows (block_access_index 1..N): no txindex filter
+  "  la t1, els_txfilter_hi; sd zero, 0(t1)\n" ++
   "  mv a0, s0; mv a1, s1; mv a2, s4; mv a3, s5; mv a4, s6; la a5, sust_userbuf\n" ++
   "  jal ra, exec_log_slot_tuples\n" ++
   "  mv s9, a0                    # user tuple count\n" ++
-  "  add t0, s8, s9\n" ++
-  "  li t1, " ++ toString bsrMaxTuplesPerSlot ++ "; bgtu t0, t1, .Lsust_ret_total\n" ++
-  "  li t2, 0                     # copy system tuples\n" ++
+  -- PASS 3: end-of-block system rows (block_access_index >= 1, i.e. N+1): window [1, 2^64)
+  "  la t1, els_txfilter_lo; li t2, 1; sd t2, 0(t1); la t1, els_txfilter_hi; li t2, -1; sd t2, 0(t1)\n" ++
+  "  mv a0, s0; mv a1, s1; mv a2, s2; mv a3, s3; la t0, sust_systx; ld a4, 0(t0); la a5, sust_endbuf\n" ++
+  "  jal ra, exec_log_slot_tuples\n" ++
+  "  la t0, sust_endcount; sd a0, 0(t0)        # end-system tuple count\n" ++
+  -- clear the txindex filter so other exec_log_slot_tuples callers are unaffected
+  "  la t1, els_txfilter_lo; sd zero, 0(t1); la t1, els_txfilter_hi; sd zero, 0(t1)\n" ++
+  -- total = begin + user + end; bail (return true count) if it would overflow out
+  "  la t0, sust_endcount; ld t0, 0(t0); add t6, s8, s9; add t6, t6, t0\n" ++
+  "  li t1, " ++ toString bsrMaxTuplesPerSlot ++ "; bgtu t6, t1, .Lsust_ret_total\n" ++
+  -- segment 1: sust_sysbuf[0..s8) -> out[0..s8)
+  "  li t2, 0\n" ++
   ".Lsust_copy_sys:\n" ++
   "  beq t2, s8, .Lsust_copy_user_start\n" ++
   "  slli t3, t2, 5; slli t4, t2, 3; add t3, t3, t4\n" ++
@@ -60,15 +90,25 @@ def systemUserExecLogSlotTuplesFunction : String :=
   ".Lsust_copy_user_start:\n" ++
   "  li t2, 0\n" ++
   ".Lsust_copy_user:\n" ++
-  "  beq t2, s9, .Lsust_ret_total\n" ++
+  "  beq t2, s9, .Lsust_copy_end_start\n" ++
   "  add t3, s8, t2; slli t4, t3, 5; slli t3, t3, 3; add t4, t4, t3\n" ++
   "  slli t3, t2, 5; slli t5, t2, 3; add t3, t3, t5\n" ++
   "  la t5, sust_userbuf; add t5, t5, t3; add t6, s7, t4\n" ++
   "  ld t0, 0(t5); sd t0, 0(t6); ld t0, 8(t5); sd t0, 8(t6)\n" ++
   "  ld t0, 16(t5); sd t0, 16(t6); ld t0, 24(t5); sd t0, 24(t6); ld t0, 32(t5); sd t0, 32(t6)\n" ++
   "  addi t2, t2, 1; j .Lsust_copy_user\n" ++
+  ".Lsust_copy_end_start:\n" ++
+  "  li t2, 0\n" ++
+  ".Lsust_copy_end:\n" ++
+  "  la t0, sust_endcount; ld t0, 0(t0); beq t2, t0, .Lsust_ret_total\n" ++
+  "  add t3, s8, s9; add t3, t3, t2; slli t4, t3, 5; slli t3, t3, 3; add t4, t4, t3\n" ++
+  "  slli t3, t2, 5; slli t5, t2, 3; add t3, t3, t5\n" ++
+  "  la t5, sust_endbuf; add t5, t5, t3; add t6, s7, t4\n" ++
+  "  ld t0, 0(t5); sd t0, 0(t6); ld t0, 8(t5); sd t0, 8(t6)\n" ++
+  "  ld t0, 16(t5); sd t0, 16(t6); ld t0, 24(t5); sd t0, 24(t6); ld t0, 32(t5); sd t0, 32(t6)\n" ++
+  "  addi t2, t2, 1; j .Lsust_copy_end\n" ++
   ".Lsust_ret_total:\n" ++
-  "  add a0, s8, s9\n" ++
+  "  la t0, sust_endcount; ld t0, 0(t0); add a0, s8, s9; add a0, a0, t0\n" ++
   "  ld ra, 0(sp)\n" ++
   "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
   "  ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp); ld s8, 72(sp); ld s9, 80(sp)\n" ++
@@ -78,9 +118,15 @@ def systemUserExecLogSlotTuplesFunction : String :=
 def systemUserExecLogSlotTuplesData : String :=
   ".balign 8\n" ++
   "sust_zero_txindex:\n  .zero " ++ toString bvSystemStorageTxindexBytes ++ "\n" ++
+  -- lv44p.2.2: caller-set real system txindex array (0 => sust_zero_txindex), and the
+  -- resolved ptr + end-of-block tuple count used by the three-pass reconstruction.
+  "sust_sys_txindex_ptr:\n  .zero 8\n" ++
+  "sust_systx:\n  .zero 8\n" ++
+  "sust_endcount:\n  .zero 8\n" ++
   ".balign 32\n" ++
   "sust_sysbuf:\n  .zero " ++ toString (bsrMaxTuplesPerSlot * 40) ++ "\n" ++
   "sust_userbuf:\n  .zero " ++ toString (bsrMaxTuplesPerSlot * 40) ++ "\n" ++
+  "sust_endbuf:\n  .zero " ++ toString (bsrMaxTuplesPerSlot * 40) ++ "\n" ++
   "sust_out:\n  .zero " ++ toString (bsrMaxTuplesPerSlot * 40) ++ "\n"
 
 def ziskSystemUserExecLogSlotTuplesPrologue : String :=


### PR DESCRIPTION
## What

The EIP-7928 per-slot tuple-sequence check (`bal_all_accounts_tuple_sequences_consistent`)
reconstructed the wrong `(block_access_index, value)` sequence for storage slots written by
**both** a user transaction **and** an end-of-block system call (EIP-7002 withdrawal-request /
EIP-7251 consolidation predeploys). It surfaced as the EEST false-reject
`bal_7002_request_from_contract` (`bv_fail=42`, recomputed state root matched the payload).

### Root cause (diagnosed via instrumented `atsc_balbuf`/`atsc_execbuf` dump)

For the 7002 predeploy `WITHDRAWAL_REQUEST_COUNT` slot in a 1-tx block:
- **BAL declares** `[(idx 1, val 1), (idx 2, val 0)]` — the contract adds a request at tx index 1,
  the end-of-block system call dequeues/resets at index N+1 = 2.
- **Exec reconstructed** `[(idx 0, val 0), (idx 1, val 1)]`.

Two bugs, both in how captured system-storage rows feed the reconstruction:
1. `capture_system_storage_exec_rows` stamped **every** captured row with `txindex = 0`, but
   end-of-block system calls run at `block_access_index = N+1` (per `apply_body` in
   `forks/amsterdam/fork.py`: the builder index is set to `ulen(transactions)+1` before
   `process_withdrawals` / `process_general_purpose_requests`).
2. `system_user_exec_log_slot_tuples` always processed **all** system rows *first*, then user
   rows — but end-of-block writes come *after* the user txs.

So the end-of-block dequeue (whose transition `1→0` *was* captured correctly) surfaced as `(0,0)`
instead of `(2,0)` and in the wrong position.

## How

1. `capture_system_storage_exec_rows` now stamps a caller-supplied `block_access_index` (a6); the
   7002/7251 capture sites pass `N+1 = svf_tx_count + 1`. Begin-of-block 2935/4788 rows still get
   index 0 (via the unchanged `append_modeled_system_storage_tuple_rows`).
2. `exec_log_slot_tuples` gains a txindex window filter (globals `els_txfilter_lo`/`_hi`; default
   `0/0` = no filter, backward-compatible with every existing caller).
3. `system_user_exec_log_slot_tuples` now runs **three ordered passes** concatenated in
   block_access_index order — begin-system (window `[0,1)`), user (`1..N`, no filter), end-system
   (window `[1, 2^64)`) — reading the **real** per-row system txindex array
   (`bv_system_storage_txindex`, threaded via `sust_sys_txindex_ptr`; a 0 ptr falls back to the
   all-zero array so the standalone probe stays byte-identical).

**Why split passes stay correct:** each `exec_log_slot_tuples` pass re-seeds its running value from
the first matching row's `original`, which equals the running value at that point (`original` is
the pre-write value, accumulated across prior segments) — so the segment boundaries preserve
net-change continuity exactly, no shared state needed. Result for the 7002 slot: user pass emits
`(1,1)`; end pass re-seeds running from the end row's `original` (= post-user value 1) and emits
`(2,0)` → `[(1,1),(2,0)]` = BAL.

## Soundness

This is the BAL anti-forgery tuple check: the exec reconstruction must equal the spec sequence for
every `(addr, slot)`, so the prior wrong reconstruction was itself a false-accept vector (a forged
BAL matching the wrong sequence would have been accepted). The fix makes the reconstruction
spec-exact. Validated **0 false-accepts**.

## Validation

- `bal_7002_request_from_contract` → **full match** (was `bv_fail=42`).
- Full `eip7928_block_level_access_lists` family: **0 regress** (2935/4788 begin-of-block,
  7251 consolidation, and all storage/dequeue fixtures unaffected — see PR thread).
- Broad random sweeps seed 4242 / 1234 / 7777 (500 each): **0 false-accepts, 0 regress** (PR thread).
- `scripts/check-forbidden-tactics.sh`: OK (pure asm).

Bead: `evm-asm-lv44p.2` (diagnosis `evm-asm-lv44p.2.1`, fix `evm-asm-lv44p.2.2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
