### PR TITLE
fix(verdict): charge NEW_ACCOUNT state gas on insufficient-balance CALL-to-new (bv41)

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -696,6 +696,55 @@ def callDescendFallThrough
      "  li t0, 6700\n" ++
      "  ld t1, 568(x20)\n  bltu t1, t0, .exit_outofgas\n" ++
      "  sub t1, t1, t0\n  sd t1, 568(x20)\n" ++
+     -- bbow4.2.2 (bv41): the NEW_ACCOUNT state-gas charge (nxio8.8, below) lives in the
+     -- descend tail, which this insufficient-balance early-exit BYPASSES. Spec
+     -- system.py:463-465 charges `if value != 0 and not is_account_alive(to):
+     -- charge_state_gas(NEW_ACCOUNT)` BEFORE the balance check, so it stands even when the
+     -- value-CALL fails on insufficient balance. Mirror the nxio8.8 charge here (mode 0 only;
+     -- CALLCODE mode 2 recipient = current_target, always alive). value>0 is guaranteed
+     -- (insuffbal => caller balance < value, balance>=0). x12 is still the parent stack top
+     -- (callee at x12+32); x20 the parent env (witness ctx env+576..616). Without it
+     -- bvgr_tx_exec_state_gas under-counts by 183600 -> block_state under-count -> bv41.
+     (if mode != 0 then "" else
+       "  ld t3, 584(x20)\n  beqz t3, .Lcd_ibnacc_done_" ++ tag ++ "\n" ++   -- no witness ctx -> conservative skip
+       "  la t0, cd_callee_be\n  addi t1, x12, " ++ toString (32+19) ++ "\n  li t2, 20\n" ++
+       ".Lcd_ibnacc_addr_" ++ tag ++ ":\n" ++
+       "  lbu t3, 0(t1)\n  sb t3, 0(t0)\n  addi t1, t1, -1\n  addi t0, t0, 1\n  addi t2, t2, -1\n" ++
+       "  bnez t2, .Lcd_ibnacc_addr_" ++ tag ++ "\n" ++
+       -- created this tx -> alive -> no charge
+       "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
+       "  la a0, exec_code_effect_log\n  la t0, exec_code_effect_count\n  ld a1, 0(t0)\n  la a2, cd_callee_be\n" ++
+       "  jal ra, find_code_effect_by_address\n  mv t6, a0\n" ++
+       "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
+       "  bnez t6, .Lcd_ibnacc_done_" ++ tag ++ "\n" ++
+       -- account_exists_at_header_state_root(callee)
+       "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
+       "  ld a0, 576(x20)\n  ld a1, 584(x20)\n  la a2, cd_callee_be\n  ld a3, 592(x20)\n  ld a4, 600(x20)\n" ++
+       "  jal ra, account_exists_at_header_state_root\n  mv t6, a0\n" ++
+       "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
+       "  bnez t6, .Lcd_ibnacc_done_" ++ tag ++ "\n" ++           -- lookup err -> conservative skip
+       "  la t0, aex_predicate\n  ld t1, 0(t0)\n" ++
+       "  beqz t1, .Lcd_ibnacc_charge_" ++ tag ++ "\n" ++         -- not exists -> not alive -> charge
+       -- exists: account_is_empty_at_header_state_root(callee)
+       "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
+       "  ld a0, 576(x20)\n  ld a1, 584(x20)\n  la a2, cd_callee_be\n  ld a3, 592(x20)\n  ld a4, 600(x20)\n" ++
+       "  jal ra, account_is_empty_at_header_state_root\n  mv t6, a0\n" ++
+       "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
+       "  bnez t6, .Lcd_ibnacc_done_" ++ tag ++ "\n" ++           -- lookup err -> skip
+       "  la t0, aie_predicate\n  ld t1, 0(t0)\n" ++
+       "  beqz t1, .Lcd_ibnacc_done_" ++ tag ++ "\n" ++           -- exists & not empty = alive -> no charge
+       ".Lcd_ibnacc_charge_" ++ tag ++ ":\n" ++
+       liStateGasRuntime "t0" amsterdamStateBytesPerNewAccountV2 ++   -- NEW_ACCOUNT state gas = 120*1530 = 183600
+       "  la t1, evm_state_gas_left\n  ld t2, 0(t1)\n" ++
+       "  bgeu t2, t0, .Lcd_ibnacc_res_" ++ tag ++ "\n" ++
+       "  sub t3, t0, t2\n  sd x0, 0(t1)\n" ++
+       "  ld t2, 568(x20)\n  bltu t2, t3, .exit_outofgas\n" ++
+       "  sub t2, t2, t3\n  sd t2, 568(x20)\n  j .Lcd_ibnacc_used_" ++ tag ++ "\n" ++
+       ".Lcd_ibnacc_res_" ++ tag ++ ":\n" ++
+       "  sub t2, t2, t0\n  sd t2, 0(t1)\n" ++
+       ".Lcd_ibnacc_used_" ++ tag ++ ":\n" ++
+       "  la t1, evm_state_gas_used\n  ld t2, 0(t1)\n  add t2, t2, t0\n  sd t2, 0(t1)\n" ++
+       ".Lcd_ibnacc_done_" ++ tag ++ ":\n") ++
      "  j .Lcd_fail_" ++ tag ++ "\n"
    else "") ++
   -- empty code (EOA): the call succeeds, runs nothing → push 1


### PR DESCRIPTION
## What

A value-bearing `CALL` (mode 0) to a **not-alive** account that fails on **insufficient
balance** must still charge the EIP-8037 `NEW_ACCOUNT` state gas (120 × 1530 = 183600). The
guest charged it only in the descend tail (nxio8.8), which the **insufficient-balance
early-exit bypasses** — so the executed state gas under-counted by 183600, the reconstructed
`block_state_gas` came up short, and the SSZ header's `gas_used` (= `max(block_regular,
block_state)`) appeared to over-claim → false-reject `bv_fail=41`.

Spec (`vm/instructions/system.py:463-465`): `if value != 0 and not is_account_alive(to):
charge_state_gas(NEW_ACCOUNT)` runs **before** the balance check (which lives inside the
message call), so the charge stands even when the call fails on insufficient balance.

Found by the full-corpus EEST sweep. `call_insufficient_balance_returns_reservoir` has two
variants: `existing_account` (callee alive → no NEW_ACCOUNT → already passed) and
`new_account` (callee not-alive → NEW_ACCOUNT charged → was failing bv41).

## How

In `callDescendFallThrough`'s `.Lcd_insuffbal_` path (mode 0 only — CALLCODE's recipient is
`current_target`, always alive), mirror the descend-tail nxio8.8 charge before `j .Lcd_fail_`:
build the callee address, skip if created-this-tx, resolve aliveness via
`account_exists`/`account_is_empty_at_header_state_root` (the authenticated witness context),
and on not-alive charge `NEW_ACCOUNT` state gas (drain `evm_state_gas_left`, spill into the
frame gas, OOG → `.exit_outofgas`, `state_gas_used += charge`). Additive (`+49` lines) — the
working sufficient-balance/descend path is untouched.

## Soundness

The charge fires only on `value != 0` (from the EVM stack) **and** callee not-alive
(`account_exists`/`account_is_empty` resolved **against the header state root**, i.e.
authenticated), with **conservative skip on any uncertainty** (no witness context / lookup
error → no charge). So it can never *over*-charge from a failed lookup. The over-claim
(`bv41`) and state-floor (`bv35`) checks form a pair that turns any state-gas error into a
false-*reject* (safe), never a false-accept; the only false-accept vector — the inclusion
gate's under-count, flagged in `DispatcherExecStateGas` — is *tightened* by this fix. Validated
**0 false-accepts** on the full corpus.

## Validation

- `call_insufficient_balance_returns_reservoir` both variants (existing + new account) → full match.
- Full corpus (2871 fixtures): 0 false-accepts, 0 errored, false-rejects -1 (the new_account variant flips), 0 errored, 0 regress.
- `scripts/check-forbidden-tactics.sh`: OK (pure asm).

Bead: `evm-asm-bbow4.2.2` (cluster B of the full-corpus frontier `evm-asm-bbow4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
