### PR TITLE
feat(rv64/rlp): spec-side bridge from RLP list encoding to decoder input (Phase 5)

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -104,6 +104,7 @@ import EvmAsm.Rv64.RLP.SchemaListWalk
 import EvmAsm.Rv64.RLP.SchemaListWalkShort
 import EvmAsm.Rv64.RLP.SchemaListWalkLong
 import EvmAsm.Rv64.RLP.SchemaListDecodeExample
+import EvmAsm.Rv64.RLP.SchemaListEncode
 import EvmAsm.Rv64.RLP.NestedDescendOne
 import EvmAsm.Rv64.RLP.UnifiedDecodeItem
 import EvmAsm.Rv64.RLP.UnifiedDecodeItemReconverge

--- a/EvmAsm/Rv64/RLP/SchemaListEncode.lean
+++ b/EvmAsm/Rv64/RLP/SchemaListEncode.lean
@@ -1,0 +1,55 @@
+/-
+  EvmAsm.Rv64.RLP.SchemaListEncode
+
+  EL.3 / Phase 5 — spec-side bridge connecting a field schema to its RLP LIST encoding. The
+  decoder's instantiation helper (`schemaValid_of_concat`) wants the input buffer to be
+  `schemaEncBytes specs ++ tail`. This file shows that string IS the payload of the RLP list
+  encoding of the fields (`encode (.list (schemaItems specs))`): the list payload `encodeItems`
+  is exactly the per-field-encoding concatenation `schemaEncBytes`. So a caller whose input is a
+  genuine `encode (.list …)` of the field items can discharge the decoder's concat hypothesis
+  structurally — closing the gap between "input is the RLP encoding of these fields" and "the
+  decoder runs."
+-/
+
+import EvmAsm.Rv64.RLP.SchemaFoldConcat
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.EL.RLP
+
+/-- The RLP items a schema's fields encode to (each field is a byte string). -/
+def schemaItems (specs : List FieldSpec) : List RLPItem :=
+  specs.map (fun f => RLPItem.bytes f.data)
+
+/-- **Schema payload = list payload.** The RLP list payload (`encodeItems`) of the field items
+    is exactly the decoder's expected `schemaEncBytes`. -/
+theorem encodeItems_schemaItems (specs : List FieldSpec) :
+    encode.encodeItems (schemaItems specs) = schemaEncBytes specs := by
+  induction specs with
+  | nil => rfl
+  | cons f rest ih =>
+    simp only [schemaItems, List.map_cons, encode.encodeItems, schemaEncBytes] at *
+    rw [ih]
+
+/-- **Short-list encoding of a field schema.** When the schema's payload fits in a short list
+    (`≤ 55` bytes), the RLP encoding of the field items is the 1-byte header `0xC0 + len`
+    followed by `schemaEncBytes`. -/
+theorem encode_list_schemaItems_short (specs : List FieldSpec)
+    (hlen : (schemaEncBytes specs).length ≤ 55) :
+    encode (.list (schemaItems specs))
+      = [BitVec.ofNat 8 (0xC0 + (schemaEncBytes specs).length)] ++ schemaEncBytes specs := by
+  simp only [encode, encodeItems_schemaItems]
+  rw [if_pos hlen]
+
+/-- **Concat hypothesis from a short-list-encoded input.** If the buffer from `O` is the RLP
+    short-list encoding of the field items followed by `tail`, then the payload at `O+1` is
+    `schemaEncBytes specs ++ tail` — exactly `schemaValid_of_concat`'s concatenation premise
+    (and the short-list payload starts at `O+1`). -/
+theorem schemaConcat_of_encode_list_short (bs : List Byte) (specs : List FieldSpec)
+    (O : Nat) (tail : List Byte) (hlen : (schemaEncBytes specs).length ≤ 55)
+    (hbs : bs.drop O = encode (.list (schemaItems specs)) ++ tail) :
+    bs.drop (O + 1) = schemaEncBytes specs ++ tail := by
+  rw [← List.drop_drop, hbs, encode_list_schemaItems_short specs hlen]
+  simp
+
+end EvmAsm.Rv64.RLP


### PR DESCRIPTION
## Summary

A pure spec-side bridge connecting a field schema to its RLP **list encoding**, so a caller whose input is a genuine `encode (.list <fields>)` can discharge the decoder's concat hypothesis (`schemaValid_of_concat`) structurally — closing the gap between "the input is the RLP encoding of these fields" and "the decoder runs."

- **`schemaItems`** — the RLP items the schema's fields encode to (each a byte string).
- **`encodeItems_schemaItems`** — the RLP list payload (`encode.encodeItems`) of the field items equals the decoder's expected `schemaEncBytes` (by induction).
- **`encode_list_schemaItems_short`** — for a short-list-sized payload (`≤ 55`), the encoding is the 1-byte header `0xC0 + len` followed by `schemaEncBytes`.
- **`schemaConcat_of_encode_list_short`** — from `bs.drop O = encode (.list (schemaItems specs)) ++ tail`, derive `bs.drop (O+1) = schemaEncBytes specs ++ tail` — exactly `schemaValid_of_concat`'s concatenation premise, at the short-list payload offset `O+1`.

Pure spec-side (no machine state); independent of the open example PRs.

## Verification
- `lake build` of the file + umbrella `EvmAsm.Rv64.RLP` — clean.
- `#print axioms` (both lemmas) → classical only (`propext, Quot.sound`); 0 sorry.
- `check-forbidden-tactics.sh` OK; `check-no-warnings.sh` → 0 warnings under `EvmAsm/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)