### PR TITLE
test(rv64/rlp): concrete cross-check of the end-user decode API (Phase 5)

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -106,6 +106,7 @@ import EvmAsm.Rv64.RLP.SchemaListWalkLong
 import EvmAsm.Rv64.RLP.SchemaListDecodeExample
 import EvmAsm.Rv64.RLP.SchemaListEncode
 import EvmAsm.Rv64.RLP.SchemaDecodeEncoded
+import EvmAsm.Rv64.RLP.SchemaDecodeEncodedExample
 import EvmAsm.Rv64.RLP.NestedDescendOne
 import EvmAsm.Rv64.RLP.UnifiedDecodeItem
 import EvmAsm.Rv64.RLP.UnifiedDecodeItemReconverge

--- a/EvmAsm/Rv64/RLP/SchemaDecodeEncodedExample.lean
+++ b/EvmAsm/Rv64/RLP/SchemaDecodeEncodedExample.lean
@@ -1,0 +1,34 @@
+/-
+  EvmAsm.Rv64.RLP.SchemaDecodeEncodedExample
+
+  EL.3 / Phase 5 — concrete cross-check of the end-user decode API
+  (`decode_encoded_short_list_schema`). Starting from the GENUINE RLP encoding of a two-field
+  record — `encode (.list [.bytes [0x2a], .bytes [0x01, 0x02]])` = `[0xc4, 0x2a, 0x82, 0x01, 0x02]`
+  — the whole decoder runs into a 24-byte output struct, with the prefix-class fact and
+  `SchemaValid` BOTH derived from the encoding. The caller supplies only the encoding equation
+  (`by decide`), per-field core validity, and region/output well-formedness — demonstrating the
+  "RLP bytes in → verified decode out" path with zero RLP-internal proof obligations.
+-/
+
+import EvmAsm.Rv64.RLP.SchemaDecodeEncoded
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL.RLP
+
+/-- A scalar field (`0x2a`) at output offset 0 and a 2-byte array (`[0x01,0x02]`) at offset 8. -/
+abbrev egEncSpecs : List FieldSpec :=
+  [⟨true, [(0x2a : Byte)], 0, 0⟩, ⟨false, [(0x01 : Byte), (0x02 : Byte)], 8, 8⟩]
+
+/-- The buffer is the genuine RLP encoding of the field record: `[0xc4, 0x2a, 0x82, 0x01, 0x02]`. -/
+abbrev egEncBs : List Byte := [(0xc4 : Byte), 0x2a, 0x82, 0x01, 0x02]
+
+set_option maxRecDepth 8000 in
+example :=
+  decode_encoded_short_list_schema (0x1000 : Word) (0x2000 : Word) (0x3000 : Word) .x18 egEncBs 0
+    egEncSpecs (List.replicate 24 (0 : Byte)) 24 [] 0 0 0 0 0 0 (by decide) (by decide)
+    (by intro f hf; fin_cases hf <;> exact ⟨by decide, by decide, by decide, by decide⟩)
+    (by decide) (by decide) (by decide) (by decide) (by simp) (by decide) (by decide) (by decide)
+
+end EvmAsm.Rv64.RLP


### PR DESCRIPTION
## Summary

Validates `decode_encoded_short_list_schema` (#9260) end-to-end, starting from a **genuine RLP encoding**:

`encode (.list [.bytes [0x2a], .bytes [0x01, 0x02]]) = [0xc4, 0x2a, 0x82, 0x01, 0x02]`

The whole decoder runs into a 24-byte output struct (scalar `0x2a` → 8 LE bytes at offset 0; the 2-byte array → offset 8). The caller supplies **only** the encoding equation (`by decide`), per-field core validity, and region/output well-formedness — the prefix-class fact and `SchemaValid` are derived from the encoding inside the API.

Demonstrates the complete **"RLP bytes in → verified decode out"** path with zero RLP-internal proof obligations.

Stacks on the decode API (#9260).

## Verification
- `lake build` of the file + umbrella `EvmAsm.Rv64.RLP` — clean.
- `check-forbidden-tactics.sh` OK; `check-no-warnings.sh` → 0 warnings under `EvmAsm/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)