### PR TITLE
feat(rv64/rlp): list-level decode coincidence for schema decoders (Phase 5)

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -105,6 +105,7 @@ import EvmAsm.Rv64.RLP.SchemaListWalkShort
 import EvmAsm.Rv64.RLP.SchemaListWalkLong
 import EvmAsm.Rv64.RLP.SchemaListDecodeExample
 import EvmAsm.Rv64.RLP.SchemaListEncode
+import EvmAsm.Rv64.RLP.SchemaListDecodeCoincidence
 import EvmAsm.Rv64.RLP.SchemaLongListDecodeExample
 import EvmAsm.Rv64.RLP.SchemaDecodeEncoded
 import EvmAsm.Rv64.RLP.SchemaDecodeEncodedExample

--- a/EvmAsm/Rv64/RLP/SchemaListDecodeCoincidence.lean
+++ b/EvmAsm/Rv64/RLP/SchemaListDecodeCoincidence.lean
@@ -1,0 +1,28 @@
+/-
+  EvmAsm.Rv64.RLP.SchemaListDecodeCoincidence
+
+  EL.3 / Phase 5 — list-LEVEL decode coincidence for the schema decoders. The N-field fold
+  yields per-field `schemaDecodes` (each element decodes to its `.bytes` item). This file adds
+  the complementary WHOLE-LIST fact: when the input from `O` is the RLP encoding of the field
+  record, `decode (bs.drop O) = some (.list (schemaItems specs), tail)` — i.e. the buffer the
+  decoder consumes IS, per the pure RLP spec, the encoding of the list of field items. It follows
+  directly from the spec's `decode ∘ encode` round-trip (no fuel / `decodeListPayload` reasoning),
+  and ties the operational decoder's input to the spec at the list level.
+-/
+
+import EvmAsm.Rv64.RLP.SchemaListEncode
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.EL.RLP
+
+/-- **List-level decode coincidence.** If the buffer from `O` is the RLP encoding of the field
+    record, the pure spec decodes it to the list of field items with the same `tail`. -/
+theorem decode_list_of_encoded (bs : List Byte) (specs : List FieldSpec) (O : Nat) (tail : List Byte)
+    (hsize : (encode (.list (schemaItems specs))).length < 256 ^ 8)
+    (hbs : bs.drop O = encode (.list (schemaItems specs)) ++ tail) :
+    decode (bs.drop O) = some (.list (schemaItems specs), tail) := by
+  rw [hbs]
+  exact decode_encode_append (.list (schemaItems specs)) tail hsize
+
+end EvmAsm.Rv64.RLP


### PR DESCRIPTION
## Summary

`decode_list_of_encoded` — the **whole-list** spec coincidence, complementing the N-field fold's per-field `schemaDecodes`. When the input buffer from `O` is the RLP encoding of the field record (`encode (.list (schemaItems specs)) ++ tail`), the pure RLP spec decodes it to `some (.list (schemaItems specs), tail)` — i.e. the buffer the operational decoder consumes *is*, per spec, the encoding of the list of field items.

It follows directly from the spec's `decode ∘ encode` round-trip (`decode_encode_append`) — no fuel / `decodeListPayload` reasoning. This ties the operational decoder's input to the pure spec at the **list level** (the per-field coincidence ties it at the element level).

Stacks on the encode bridge (#9257).

## Verification
- `lake build` of the file + umbrella `EvmAsm.Rv64.RLP` — clean.
- `#print axioms decode_list_of_encoded` → classical only (`propext, Classical.choice, Quot.sound`); 0 sorry.
- `check-forbidden-tactics.sh` OK; `check-no-warnings.sh` → 0 warnings under `EvmAsm/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)