### PR TITLE
feat(rv64/rlp): integrate long byte-arrays into the schema engine (Phase 5, step 46)

### DIFF
--- a/EvmAsm/Rv64/RLP/SchemaFold.lean
+++ b/EvmAsm/Rv64/RLP/SchemaFold.lean
@@ -14,6 +14,7 @@
 -/
 
 import EvmAsm.Rv64.RLP.UnifiedFieldUnitFullyCanonical
+import EvmAsm.Rv64.RLP.UnifiedLongBytesFieldCanonical
 import EvmAsm.Rv64.RLP.UnifiedHeteroFieldWalk
 
 namespace EvmAsm.Rv64.RLP
@@ -92,7 +93,7 @@ def SchemaValid (bs : List Byte) (outLen : Nat) : Nat → List FieldSpec → Pro
   | O, f :: rest =>
     1 ≤ f.data.length ∧
     (if f.isScalar then f.data.length ≤ 8
-     else f.data.length ≤ 55 ∧ (encode (.bytes f.data)).length < 256 ^ 8) ∧
+     else (encode (.bytes f.data)).length < 256 ^ 8) ∧
     signExtend12 f.imm = BitVec.ofNat 64 f.di ∧
     f.di + fieldWriteLen f ≤ outLen ∧
     bs.drop O = encode (.bytes f.data) ++ bs.drop (O + fieldEnc f) ∧
@@ -227,7 +228,7 @@ theorem field_step (regionBase outBase : Word) (rOut : Reg) (bs : List Byte) (ou
     (hdval : ∀ i, i < out.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
     (hl1 : 1 ≤ f.data.length)
     (hkind : if f.isScalar then f.data.length ≤ 8
-      else f.data.length ≤ 55 ∧ (encode (.bytes f.data)).length < 256 ^ 8)
+      else (encode (.bytes f.data)).length < 256 ^ 8)
     (himm : signExtend12 f.imm = BitVec.ofNat 64 f.di)
     (hdst : f.di + fieldWriteLen f ≤ out.length)
     (hcode : base.toNat + fieldSize f < 2 ^ 64)
@@ -256,20 +257,34 @@ theorem field_step (regionBase outBase : Word) (rOut : Reg) (bs : List Byte) (ou
         halign hover hwin hdropf hdalign hdst hdov hdval himm hcs).2
   · simp only [fieldSteps, fieldSize, fieldCR, fieldUpdate, fieldWriteLen, fieldEnc, schemaINV, hs]
       at hkind hdst ⊢
-    obtain ⟨hlen55, hsize⟩ := hkind
+    have hsize := hkind
     have hcb : base.toNat + (148 + 4 + 20 * f.data.length) < 2 ^ 64 := by
       have : base.toNat + (152 + 20 * f.data.length) < 2 ^ 64 := by simpa [fieldSize, hs] using hcode
       omega
-    refine ⟨?_, ?_⟩
-    · have ht := (unified_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase
-        f.imm bs O f.data (bs.drop (O + (encode (.bytes f.data)).length)) out f.di hl1 hlen55 hsize
-        halign hdalign hover hwin himm hdst hdov hdval hcb hdropf).1
-      rw [show base + 148 + 4 + BitVec.ofNat 64 (20 * f.data.length)
-        = base + BitVec.ofNat 64 (152 + 20 * f.data.length) from by bv_omega] at ht
-      exact cpsTripleWithin_weaken (fun _ h => h) (fun _ hp => by xperm_hyp hp) ht
-    · exact (unified_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase
-        f.imm bs O f.data (bs.drop (O + (encode (.bytes f.data)).length)) out f.di hl1 hlen55 hsize
-        halign hdalign hover hwin himm hdst hdov hdval hcb hdropf).2
+    have hexit : base + 148 + 4 + BitVec.ofNat 64 (20 * f.data.length)
+        = base + BitVec.ofNat 64 (152 + 20 * f.data.length) := by bv_omega
+    -- Dispatch on the byte-array length: short (`≤ 55`) vs long (`> 55`) form. Both units have
+    -- the identical triple shape, so the conclusion is uniform.
+    by_cases hL : f.data.length ≤ 55
+    · refine ⟨?_, ?_⟩
+      · have ht := (unified_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase
+          f.imm bs O f.data (bs.drop (O + (encode (.bytes f.data)).length)) out f.di hl1 hL hsize
+          halign hdalign hover hwin himm hdst hdov hdval hcb hdropf).1
+        rw [hexit] at ht
+        exact cpsTripleWithin_weaken (fun _ h => h) (fun _ hp => by xperm_hyp hp) ht
+      · exact (unified_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase
+          f.imm bs O f.data (bs.drop (O + (encode (.bytes f.data)).length)) out f.di hl1 hL hsize
+          halign hdalign hover hwin himm hdst hdov hdval hcb hdropf).2
+    · have hlong : 55 < f.data.length := Nat.lt_of_not_le hL
+      refine ⟨?_, ?_⟩
+      · have ht := (unified_long_bytes_field_decode_and_copy_fully_canonical base regionBase rOut
+          outBase f.imm bs O f.data (bs.drop (O + (encode (.bytes f.data)).length)) out f.di hlong
+          hsize halign hdalign hover hwin himm hdst hdov hdval hcb hdropf).1
+        rw [hexit] at ht
+        exact cpsTripleWithin_weaken (fun _ h => h) (fun _ hp => by xperm_hyp hp) ht
+      · exact (unified_long_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase
+          f.imm bs O f.data (bs.drop (O + (encode (.bytes f.data)).length)) out f.di hlong hsize
+          halign hdalign hover hwin himm hdst hdov hdval hcb hdropf).2
 
 set_option maxRecDepth 8000 in
 /-- **N-field heterogeneous fold.** Decode an arbitrary schema (`List FieldSpec`, scalar |

--- a/EvmAsm/Rv64/RLP/SchemaFoldConcat.lean
+++ b/EvmAsm/Rv64/RLP/SchemaFoldConcat.lean
@@ -25,7 +25,7 @@ def schemaEncBytes : List FieldSpec → List Byte
 def fieldCoreValid (outLen : Nat) (f : FieldSpec) : Prop :=
   1 ≤ f.data.length ∧
   (if f.isScalar then f.data.length ≤ 8
-   else f.data.length ≤ 55 ∧ (encode (.bytes f.data)).length < 256 ^ 8) ∧
+   else (encode (.bytes f.data)).length < 256 ^ 8) ∧
   signExtend12 f.imm = BitVec.ofNat 64 f.di ∧
   f.di + fieldWriteLen f ≤ outLen
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1809,10 +1809,17 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     mechanically). Endpoint `unified_long_bytes_field_decode_and_copy_fully_canonical` has the uniform
     all-`regOwn` interface `schema_walk` consumes — the prerequisite for integrating `> 55`-byte fields into
     the schema engine.
-  - **Next (engine long-bytes integration):** since short and long byte units share `fieldSize`/`fieldCR`/
-    `fieldUpdate`, drop the `≤ 55` cap from `field_step` (dispatch short/long on `data.length`) and relax the
-    `SchemaValid`/`fieldCoreValid` bytes condition — lets `schema_walk` decode arbitrarily-long byte fields
-    (calldata, header bloom) with no `FieldSpec`/CR change.
+  - ✅ **Step 46 — long bytes integrated into the schema engine** (`SchemaFold`/`SchemaFoldConcat`):
+    `field_step` now dispatches short (`≤ 55`) vs long (`> 55`) byte-array units on `data.length` (both share
+    `fieldSize`/`fieldCR`/`fieldUpdate`, so the conclusion is uniform), and the `SchemaValid`/`fieldCoreValid`
+    bytes condition drops the `≤ 55` cap (keeps `1 ≤ len` and `(encode …).length < 256^8`). `schema_walk` /
+    `long_list_schema_walk` now decode arbitrarily-long byte fields (calldata, the 256-byte `logsBloom`) with
+    NO `FieldSpec` or CR change — all downstream decoders/examples rebuild unchanged.
+  - **🔀 Remaining (gated on output-layout input).** The schema engine now decodes every field type a real
+    tx/header contains EXCEPT `n=0`/empty fields (still `1 ≤ data.length`; needs an empty field-kind). The
+    final named-struct assembly (legacy-tx 9-field → tx struct) forks on the output-layout choice
+    (contiguous variable-width vs fixed 32-byte slots). Still open: empty-field engine integration; wide
+    32-byte zero-padding if a struct needs fixed slots.
 - Phase 6: Top-level pipeline (`read_input` -> decode -> `write_output`)
 - **Host I/O ABI**: See `docs/zkvm-host-io-interface.md`; SP1
   `HINT_LEN`/`HINT_READ`/`COMMIT` are legacy handler shapes, not the target


### PR DESCRIPTION
## Summary

The N-field fold (`schema_walk`) now decodes **arbitrarily-long** byte-array fields. *(Stacked on #9288.)*

Previously the fold capped byte-array fields at 55 bytes, so it couldn't decode a transaction's calldata or a header's 256-byte `logsBloom`. #9288 produced the fully-canonical long unit, which has the **identical triple shape** (`fieldSize`/`fieldCR`/`fieldUpdate`/step count) as the short unit.

This drops the cap:
- `field_step` dispatches on `data.length` — short (`≤55`) → short unit, long (`>55`) → long unit — with a uniform conclusion.
- The `SchemaValid` / `fieldCoreValid` byte-array condition relaxes from `data.length ≤ 55 ∧ size` to just the size bound (the `1 ≤ len` floor stays in the outer conjunct).

Because both units share `fieldSize`/`fieldCR`/`fieldUpdate`, **no `FieldSpec` or `CodeReq` definition changes**, and every downstream decoder and example (`SchemaListWalk*`, `SchemaDecodeEncoded*`, all examples) rebuilds unchanged.

`schema_walk` / `long_list_schema_walk` now decode every field type a real tx/header contains except `n=0` empty fields.

## Verification
- Full umbrella `EvmAsm.Rv64.RLP` builds clean (all downstream decoders/examples), 0 warnings.
- `scripts/check-forbidden-tactics.sh` OK (no `bv_decide`/`native_decide`).
- `#print axioms schema_walk` / `field_step` → `[propext, Classical.choice, Quot.sound]`; 0 sorry/admit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)