### PR TITLE
fix(codegen): track live balances across repeated selfdestruct

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -448,7 +448,18 @@ def callDescendFallThrough
     ".Lcd_nse_zero_pre_" ++ tag ++ ":\n" ++
     "  la t0, nse_acct\n  sd zero, 0(t0); sd zero, 8(t0); sd zero, 16(t0); sd zero, 24(t0); sd zero, 32(t0)\n" ++
     ".Lcd_nse_have_pre_" ++ tag ++ ":\n" ++
-    -- post_balance = pre_balance (nse_acct+8) + value (cd_value_be, populated above)
+    -- sr5m3.1: overlay the callee credit's pre_balance with the latest same-transaction
+    -- non-storage effect when one exists. Header pre-state alone is stale for a pre-existing
+    -- account that already moved value in this transaction, e.g. CALL target runs
+    -- SELFDESTRUCT first (recording target balance 1 -> 0) and is then called with value 1;
+    -- the second CALL credit must record 0 -> 1, not header 1 -> 2. The nonce still comes
+    -- from header pre-state because value transfer does not bump it. The helper overwrites
+    -- nse_acct+8 only on a hit; miss keeps the header/zero pre_balance above.
+    "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
+    "  la a0, nse_callee_be\n  la a1, nse_acct\n  addi a1, a1, 8\n" ++
+    "  jal ra, nonstorage_effect_latest_balance\n" ++
+    "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
+    -- post_balance = live/header pre_balance (nse_acct+8) + value (cd_value_be, populated above)
     "  addi sp, sp, -16\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n" ++
     "  la a0, nse_acct\n  addi a0, a0, 8\n  la a1, cd_value_be\n  la a2, nse_post_bal\n" ++
     "  jal ra, u256_add_be\n" ++

--- a/EvmAsm/Codegen/Programs/Selfdestruct.lean
+++ b/EvmAsm/Codegen/Programs/Selfdestruct.lean
@@ -608,8 +608,8 @@ def selfdestructBeneficiaryNonstorageAsm : String :=
   "  la t0, sdai_status; ld t0, 0(t0); beqz t0, .L_sdbn_origin_ok\n" ++
   "  li t1, 4; bne t0, t1, .L_sdbn_done\n" ++
   ".L_sdbn_origin_ok:\n" ++
-  "  addi sp, sp, -112\n" ++
-  "  sd x10, 96(sp); sd x12, 104(sp)\n" ++
+  "  addi sp, sp, -144\n" ++
+  "  sd x10, 128(sp); sd x12, 136(sp)\n" ++
   "  la a0, sdai_origin_rlp; la t0, sdai_origin_len; ld a1, 0(t0); addi a2, sp, 64\n" ++
   "  jal ra, account_extract_balance\n" ++
   "  ld t0, 64(sp); ld t1, 72(sp); or t0, t0, t1; ld t1, 80(sp); or t0, t0, t1; ld t1, 88(sp); or t0, t0, t1\n" ++
@@ -627,6 +627,19 @@ def selfdestructBeneficiaryNonstorageAsm : String :=
   ".L_sdbn_pre_zero:\n" ++
   "  sd zero, 0(sp); sd zero, 8(sp); sd zero, 16(sp); sd zero, 24(sp)\n" ++
   ".L_sdbn_have_pre:\n" ++
+  -- sr5m3.2: pre-existing SELFDESTRUCT can credit the same beneficiary multiple times
+  -- in one transaction. Header/pre-witness balance is stale after the first credit, so
+  -- prefer the latest non-storage post_balance for the beneficiary when present. This
+  -- keeps the second SELFDESTRUCT credit's post balance at live_pre + origin_balance.
+  -- Stack use: sp+0 beneficiary pre, sp+32 post, sp+64 origin balance, sp+96 key.
+  "  sd zero, 96(sp); sd zero, 104(sp); sd zero, 112(sp); sd zero, 120(sp)\n" ++
+  "  la t0, evm_selfdestruct_beneficiary; addi t1, sp, 96; li t2, 20\n" ++
+  ".L_sdbn_live_bk:\n" ++
+  "  beqz t2, .L_sdbn_live_bk_d\n" ++
+  "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1; j .L_sdbn_live_bk\n" ++
+  ".L_sdbn_live_bk_d:\n" ++
+  "  addi a0, sp, 96; mv a1, sp\n" ++
+  "  jal ra, nonstorage_effect_latest_balance\n" ++
   "  mv a0, sp; addi a1, sp, 64; addi a2, sp, 32\n" ++
   "  jal ra, u256_add_be\n" ++
   "  la a0, evm_selfdestruct_beneficiary; mv a1, sp; addi a2, sp, 32; li a3, 0; li a4, 0\n" ++
@@ -646,7 +659,7 @@ def selfdestructBeneficiaryNonstorageAsm : String :=
   "  la a0, sdai_origin_address; addi a1, sp, 64; addi a2, sp, 8\n" ++                    -- a1 = pre_bal (origin), a2 = post_bal (0)
   "  jal ra, record_nonstorage_effect\n" ++
   ".L_sdbn_restore:\n" ++
-  "  ld x10, 96(sp); ld x12, 104(sp); addi sp, sp, 112\n" ++
+  "  ld x10, 128(sp); ld x12, 136(sp); addi sp, sp, 144\n" ++
   ".L_sdbn_done:\n"
 
 /--


### PR DESCRIPTION
## Summary
- overlay CALL callee credit pre-balance with latest same-transaction nonstorage post-balance
- overlay pre-existing SELFDESTRUCT beneficiary credit with latest same-transaction beneficiary balance
- fixes the focused EIP-8037 pre-existing selfdestructed-account value-call slice where the same target selfdestructs twice in one tx

## Verification
- scripts/codegen-eest-stateless-check.sh --filter call_value_to_pre_existing_selfdestructed_account --limit 2 --jobs 1 --quiet-passes --min-full 2 --run-dir gen-out/eest-bbow4-3-preexisting-fix2
- lake build
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- scripts/check-no-warnings.sh
- scripts/check-forbidden-tactics.sh
- scripts/codegen-zisk-selfdestruct-transfer-descriptors-check.sh
- scripts/codegen-zisk-selfdestruct-balance-transfer-check.sh
- scripts/codegen-zisk-nonstorage-effect-aggregate-check.sh
- scripts/codegen-zisk-nonstorage-effect-log-check.sh
- git diff --check

## Note
- scripts/codegen-zisk-call-value-effect-check.sh is not linkable on this branch due existing standalone closure misses such as callee_balance_count, cd_xfer_log_pending, witness_codes_lookup_by_hash, and account_extract_nonce; it does not fail on the new nonstorage_effect_latest_balance reference.