### PR TITLE
fix(create): deposit empty initcode at code-size stop

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -971,6 +971,16 @@ def emitDispatchLoopCodeSizeStopGuard (depthAwareStop : Bool := false) : String 
     "  la t0, evm_call_depth\n" ++
     "  ld t0, 0(t0)\n" ++
     "  beqz t0, .exit_label\n" ++
+    "  la t1, create_frame_flag\n" ++
+    "  slli t2, t0, 3\n" ++
+    "  add t1, t1, t2\n" ++
+    "  ld t3, 0(t1)\n" ++
+    "  beqz t3, 2f\n" ++
+    "  sd x0, 0(t1)\n" ++
+    "  li x14, 0\n" ++
+    "  li x15, 0\n" ++
+    "  j .Lcreate_deposit_from_halt_1\n" ++
+    "2:\n" ++
     "  li a0, 1\n" ++
     "  li a1, 0\n" ++
     "  li a2, 0\n" ++


### PR DESCRIPTION
## Summary
- route depth-aware code-size STOP through the CREATE deposit path for CREATE child frames
- preserve ordinary child-frame STOP behavior for non-CREATE frames
- fixes empty-initcode CREATE returning success word 1 instead of the derived address

## Testing
- lake build
- scripts/codegen-eest-stateless-check.sh --filter create_no_double_charge_new_account --limit 1 --jobs 1 --quiet-passes --min-full 1 --run-dir gen-out/eest-bbow4-5-fix-no-double-charge
- scripts/codegen-eest-stateless-check.sh --filter top_level_failure_propagated_state_gas --limit 2 --jobs 1 --quiet-passes --min-full 2 --run-dir gen-out/eest-bbow4-5-fix-top-level-state-gas
- scripts/check-forbidden-tactics.sh
- scripts/check-unimported.sh
- scripts/check-file-size.sh
- scripts/check-no-warnings.sh

Directed by @pirapira; implemented by Codex.