### PR TITLE
fix(bal): handle same-tx create selfdestruct storage

### DIFF
--- a/EvmAsm/Codegen/Programs/BalAllAccountsStorage.lean
+++ b/EvmAsm/Codegen/Programs/BalAllAccountsStorage.lean
@@ -209,7 +209,11 @@ def ziskBalAllAccountsStorageConsistentDataSection : String :=
   ".balign 8\n" ++
   "bv_system_storage_log_count:\n  .zero 8\n" ++
   ".balign 32\n" ++
-  "bv_system_storage_log:\n  .zero 128\n"
+  "bv_system_storage_log:\n  .zero 128\n" ++
+  ".balign 8\n" ++
+  "exec_nonstorage_effect_count:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "exec_nonstorage_effect_log:\n  .zero 112\n"
 
 def ziskBalAllAccountsStorageConsistentProbeUnit : BuildUnit := {
   body        := NOP

--- a/EvmAsm/Codegen/Programs/BalStorageCoversExecLog.lean
+++ b/EvmAsm/Codegen/Programs/BalStorageCoversExecLog.lean
@@ -110,6 +110,35 @@ def balStorageCoversExecLogFunction : String :=
   "  ld t1, 120(s5); ld t2, 88(s5); bne t1, t2, .Lbsce_netchange\n" ++
   "  j .Lbsce_next                        # no net change -> not required in the BAL\n" ++
   ".Lbsce_netchange:\n" ++
+  -- A contract created and SELFDESTRUCTed in the same transaction does not commit
+  -- constructor storage writes. The raw exec log still records them, but EIP-7928
+  -- exposes those touched slots as storage_reads, not storage_changes. Restrict the
+  -- demotion to the user pass and require execution evidence: a nonstorage-effect
+  -- row for this account whose final balance and nonce are both zero.
+  "  bnez s8, .Lbsce_require_storage_change\n" ++
+  "  la t0, exec_nonstorage_effect_count; ld t4, 0(t0); beqz t4, .Lbsce_require_storage_change\n" ++
+  "  la t5, exec_nonstorage_effect_log\n" ++
+  "  mv t0, zero\n" ++
+  ".Lbsce_deleted_scan:\n" ++
+  "  beq t0, t4, .Lbsce_require_storage_change\n" ++
+  "  li t1, 112; mul t2, t0, t1; add t3, t5, t2\n" ++
+  "  li t1, 0\n" ++
+  ".Lbsce_deleted_addr_cmp:\n" ++
+  "  li t2, 20; beq t1, t2, .Lbsce_deleted_addr_match\n" ++
+  "  add t6, t3, t1; lbu t6, 0(t6)\n" ++
+  "  li t2, 19; sub t2, t2, t1; add t2, s0, t2; lbu t2, 0(t2)\n" ++
+  "  bne t6, t2, .Lbsce_deleted_next\n" ++
+  "  addi t1, t1, 1; j .Lbsce_deleted_addr_cmp\n" ++
+  ".Lbsce_deleted_addr_match:\n" ++
+  "  ld t1, 64(t3); ld t2, 72(t3); or t1, t1, t2\n" ++
+  "  ld t2, 80(t3); or t1, t1, t2\n" ++
+  "  ld t2, 88(t3); or t1, t1, t2\n" ++
+  "  bnez t1, .Lbsce_deleted_next\n" ++
+  "  ld t1, 104(t3); bnez t1, .Lbsce_deleted_next\n" ++
+  "  j .Lbsce_next                        # same-tx-deleted account: storage writes demoted to reads\n" ++
+  ".Lbsce_deleted_next:\n" ++
+  "  addi t0, t0, 1; j .Lbsce_deleted_scan\n" ++
+  ".Lbsce_require_storage_change:\n" ++
   -- The exec slot/current are stack-word order (LE u64 limbs); the BAL keys/vals
   -- are big-endian (RLP). Byte-reverse the exec slot (32..64) and current (96..128)
   -- into bsce_slotrev / bsce_currev (big-endian) to match the BAL side.
@@ -301,7 +330,11 @@ def ziskBalStorageCoversExecLogDataSection : String :=
   ".balign 8\n" ++
   "bv_system_storage_log_count:\n  .zero 8\n" ++
   ".balign 32\n" ++
-  "bv_system_storage_log:\n  .zero 128\n"
+  "bv_system_storage_log:\n  .zero 128\n" ++
+  ".balign 8\n" ++
+  "exec_nonstorage_effect_count:\n  .zero 8\n" ++
+  ".balign 32\n" ++
+  "exec_nonstorage_effect_log:\n  .zero 112\n"
 
 def ziskBalStorageCoversExecLogProbeUnit : BuildUnit := {
   body        := NOP

--- a/EvmAsm/Codegen/Programs/NoopHalt.lean
+++ b/EvmAsm/Codegen/Programs/NoopHalt.lean
@@ -346,10 +346,20 @@ private def selfdestructTailAsm : String :=
   -- indexed and depth 0 is the top frame, never a CREATE child) to mirror the other halt exits and
   -- keep the slot clean for reuse. Guarded on depth>0 so a top-level SELFDESTRUCT is untouched.
   "  la t0, evm_call_depth\n  ld t0, 0(t0)\n  beqz t0, .L_sd_flag_clear_done\n" ++
-  "  la t1, create_frame_flag\n  slli t2, t0, 3\n  add t1, t1, t2\n  sd x0, 0(t1)\n" ++
+  "  la t1, create_frame_flag\n  slli t2, t0, 3\n  add t1, t1, t2\n  ld t3, 0(t1)\n  sd x0, 0(t1)\n" ++
+  "  bnez t3, .L_sd_create_return\n" ++
   ".L_sd_flag_clear_done:\n" ++
   "  addi x12, x12, 32\n" ++
-  "  j .exit_selfdestruct"
+  "  j .exit_selfdestruct\n" ++
+  ".L_sd_create_return:\n" ++
+  "  li a0, 1\n  li a1, 0\n  li a2, 0\n" ++
+  "  jal ra, frame_return\n" ++
+  "  la t1, create_address_be\n  addi t1, t1, 19\n  mv t2, x12\n  li t3, 20\n" ++
+  ".L_sd_create_addr_loop:\n" ++
+  "  beqz t3, .L_sd_create_addr_done\n" ++
+  "  lbu t4, 0(t1)\n  sb t4, 0(t2)\n  addi t1, t1, -1\n  addi t2, t2, 1\n  addi t3, t3, -1\n  j .L_sd_create_addr_loop\n" ++
+  ".L_sd_create_addr_done:\n" ++
+  "  j .dispatch_loop"
 
 /-- M18 / M23 / M31 EVM-terminating opcodes. `depthAware` makes RETURN/REVERT
     return to the parent frame (via `frame_return`) when `evm_call_depth > 0`


### PR DESCRIPTION
## Summary
- return the CREATE address when initcode terminates via SELFDESTRUCT, without depositing code
- let BAL reverse storage coverage skip constructor storage writes for accounts deleted in the same tx, guarded by the exec nonstorage deletion row
- add focused probe data stubs for the new nonstorage-effect labels

## Tests
- lake build
- scripts/codegen-eest-stateless-check.sh --filter bal_create_storage_op_then_selfdestruct_same_tx --jobs 1 --quiet-passes --min-full 1 --run-dir gen-out/eest-bbow4-6-storage-selfdestruct-rebased
- scripts/codegen-eest-stateless-check.sh --filter bal_create_selfdestruct_to_self_with_call --jobs 1 --quiet-passes --min-full 1 --run-dir gen-out/eest-bbow4-6-selfdestruct-self-call
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check

## Notes
- dependency #9304 is already merged into main
- bal_callcode_with_value_in_static_context still fails separately with bv_fail=34