### PR TITLE
fix(create): preserve failed child gas accounting

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
@@ -308,6 +308,24 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     ".Lcr_sbwb_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
     "  lbu t3, 0(t0)\n  sb t3, 0(t1)\n  addi t0, t0, 1\n  addi t1, t1, -1\n  addi t2, t2, -1\n  bnez t2, .Lcr_sbwb_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
     ".Lcr_deb_done_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
+    -- bbow4.2.5.1: a zero-endowment CREATE still increments the creator's
+    -- nonce even when the child later REVERTs / exceptionally halts. The
+    -- deposit-time creator record only runs on successful CREATE, and records
+    -- appended after create_frame_descend are rolled back by frame_return on
+    -- child failure. Emit the zero-value nonce-only effect in the parent before
+    -- descent so the all-accounts non-storage check can match the BAL.
+    "  ld t3, 584(x20)\n  beqz t3, .Lcr_creator_nonce_effect_done_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
+    "  la t0, create_value_be\n  ld t1, 0(t0); ld t2, 8(t0); or t1, t1, t2; ld t2, 16(t0); or t1, t1, t2; ld t2, 24(t0); or t1, t1, t2\n" ++
+    "  bnez t1, .Lcr_creator_nonce_effect_done_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
+    "  la t0, nse_create_pre_bal\n  addi t1, x20, 63\n  li t2, 32\n" ++
+    ".Lcr_creator_nonce_bal_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
+    "  lbu t3, 0(t1)\n  sb t3, 0(t0)\n  addi t1, t1, -1\n  addi t0, t0, 1\n  addi t2, t2, -1\n  bnez t2, .Lcr_creator_nonce_bal_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
+    "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
+    "  la t0, create_nonce\n  ld a3, 0(t0)\n  addi a4, a3, 1\n" ++
+    "  la a0, create_sender_be\n  la a1, nse_create_pre_bal\n  la a2, nse_create_pre_bal\n" ++
+    "  jal ra, record_nonstorage_effect\n" ++
+    "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
+    ".Lcr_creator_nonce_effect_done_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
     createStageInitcodeFrameCallAsm (if hasSalt then 1 else 0) ++
     -- .61.8.3.5.3 (.5c): execute the staged init code in a REAL child frame via the full
     -- dispatch loop (create_frame_descend, .5a, reusing call_frame_descend), REPLACING the

--- a/EvmAsm/Codegen/Programs/NoopHalt.lean
+++ b/EvmAsm/Codegen/Programs/NoopHalt.lean
@@ -151,6 +151,12 @@ private def returnRevertTail (kind : Nat) (rollbackAsm : String := "")
       "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
       "  j .dispatch_loop\n" ++
       ".Lrr_crinv_" ++ toString kind ++ ":\n" ++
+      -- bbow4.2.5.1: invalid deployed code / code-deposit OOG is an
+      -- exceptional CREATE failure. execution-specs process_create_message
+      -- restores the child state snapshot and sets child gas_left = 0 before
+      -- incorporate_child_on_error, so the parent does not get the forwarded
+      -- gas back through frame_return.
+      "  sd x0, 568(x20)\n" ++
       "  li a0, 0\n  li a1, 0\n  li a2, 0\n" ++
       "  jal ra, frame_return\n" ++
       "  j .dispatch_loop\n") ++


### PR DESCRIPTION
## Summary
- record zero-endowment CREATE creator nonce effects before child descent so failed child frames satisfy BAL non-storage checks
- burn child gas on exceptional deploy failure before frame_return so invalid-prefix CREATE gas matches the payload header

## Verification
- rtk lake build EvmAsm.Codegen.Programs.NoopHalt EvmAsm.Codegen.Programs.ChildFrameHandlerTails EvmAsm.Codegen.Programs.BlockVerdict
- rtk scripts/codegen-eest-stateless-check.sh --filter create_child_halt_refunds_state_gas --jobs 1 --quiet-passes --min-full 4 --run-dir gen-out/eest-bbow4-2-5-1-child-halt-fix2
- rtk scripts/codegen-eest-stateless-check.sh --filter create_mixed_success_and_failure_block_accounting --jobs 1 --quiet-passes --min-full 2 --run-dir gen-out/eest-bbow4-2-5-1-mixed-fix2
- rtk scripts/codegen-eest-stateless-check.sh --filter state_gas_create --jobs 1 --quiet-passes --min-full 1 --run-dir gen-out/eest-bbow4-2-5-1-state-gas-create-smoke (47/50 full match; remaining failures are create2_address_collision/create_collision_refunds_state_gas, covered by child bead evm-asm-bbow4.2.5.2)
- rtk scripts/check-file-size.sh
- rtk scripts/check-unimported.sh
- rtk rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean EvmAsm/Codegen/Programs/NoopHalt.lean
- rtk lake build
- rtk git diff --check

Bead: evm-asm-bbow4.2.5.1

Directed by @pirapira; implemented by Codex.