### PR TITLE
fix(create): record collision nonce effects

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
@@ -470,6 +470,9 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     --   final_parent_gas = spill + floor(gas_after_state / 64)
     -- without mutating state-gas globals; collision has net-zero state gas.
     ".Lcr_collision_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
+    "  ld t3, 584(x20)\n  beqz t3, .Lcr_collision_nonce_done_" ++ (if hasSalt then "f5" else "f0") ++ "\n  la t0, nse_create_pre_bal\n  addi t1, x20, 63\n  li t2, 32\n.Lcr_collision_nonce_bal_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
+    "  lbu t3, 0(t1)\n  sb t3, 0(t0)\n  addi t1, t1, -1\n  addi t0, t0, 1\n  addi t2, t2, -1\n  bnez t2, .Lcr_collision_nonce_bal_" ++ (if hasSalt then "f5" else "f0") ++ "\n  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
+    "  la t0, create_nonce\n  ld a3, 0(t0)\n  addi a4, a3, 1\n  la a0, create_sender_be\n  la a1, nse_create_pre_bal\n  la a2, nse_create_pre_bal\n  jal ra, record_nonstorage_effect\n  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n.Lcr_collision_nonce_done_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
     liStateGasRuntime "t0" amsterdamStateBytesPerNewAccountV2 ++
     "  la t1, evm_state_gas_left\n  ld t1, 0(t1)\n" ++
     "  li t2, 0\n" ++


### PR DESCRIPTION
Parent gas-accounting fix #9308 has landed; this PR carries the remaining collision nonce-effect fix.

Bead: evm-asm-bbow4.2.5.2

## Summary
- Record a nonce-only creator non-storage effect on CREATE/CREATE2 address collision paths.
- Keeps collision behavior aligned with execution-specs generic_create: the creator nonce increments even though no child frame is entered and no value transfer/deposit occurs.

## Verification
- lake build EvmAsm.Codegen.Programs.ChildFrameHandlerTails EvmAsm.Codegen.Programs.BlockVerdict
- scripts/codegen-eest-stateless-check.sh --filter create_collision_refunds_state_gas --jobs 1 --quiet-passes --min-full 2 --run-dir gen-out/eest-bbow4-2-5-2-collision-final
- scripts/codegen-eest-stateless-check.sh --filter create_code_deposit_oog_refunds_state_gas --jobs 1 --quiet-passes --min-full 2 --run-dir gen-out/eest-bbow4-2-5-2-code-deposit-oog-final
- scripts/codegen-eest-stateless-check.sh --filter code_deposit_oog_preserves_parent_reservoir --jobs 1 --quiet-passes --min-full 1 --run-dir gen-out/eest-bbow4-2-5-2-code-deposit-preserve-final
- scripts/codegen-eest-stateless-check.sh --filter state_gas_create --jobs 1 --quiet-passes --min-full 50 --run-dir gen-out/eest-bbow4-2-5-2-state-gas-create-smoke (49/50 full matches; remaining create2_address_collision bv_fail=36 is outside this bead scope)
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean (no matches)
- git diff --check
- lake build

Directed by @pirapira; implemented by Codex.