### PR TITLE
feat(rv64/rlp): empty-scalar canonical chain + emptyScalarUnitCR (Phase 5, step 50)

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -78,6 +78,7 @@ import EvmAsm.Rv64.RLP.UnifiedScalarFieldDecode
 import EvmAsm.Rv64.RLP.UnifiedScalarFieldStore
 import EvmAsm.Rv64.RLP.UnifiedScalarFieldZero
 import EvmAsm.Rv64.RLP.UnifiedEmptyScalarField
+import EvmAsm.Rv64.RLP.UnifiedEmptyScalarFieldCanonical
 import EvmAsm.Rv64.RLP.UnifiedTwoScalarFieldWalk
 import EvmAsm.Rv64.RLP.ScalarFieldWalkChain
 import EvmAsm.Rv64.RLP.ScalarFieldWalkInfra

--- a/EvmAsm/Rv64/RLP/FieldUnitDisjoint.lean
+++ b/EvmAsm/Rv64/RLP/FieldUnitDisjoint.lean
@@ -91,6 +91,44 @@ theorem scalar_region_unit_cr_none_below (base : Word) (rOut : Reg) (fieldImm : 
   simp only [scalarRegionUnitCR, CodeReq.union, hl1, hl2, hl3, hl4, hl5, hl6, hl7]
 
 -- ---------------------------------------------------------------------------
+-- Empty (n=0) scalar unit: CR is `none` outside `[base, base+248)`.
+-- ---------------------------------------------------------------------------
+
+/-- The empty (`n=0`) scalar-into-region unit's CodeReq: descend (`base .. base+148`) ⨾
+    `ADDI x14, rOut, fieldImm` + 8-iteration spill chain (no read loop). -/
+def emptyScalarUnitCR (base : Word) (rOut : Reg) (fieldImm : BitVec 12) : CodeReq :=
+  ((CodeReq.singleton base (.LBU .x5 .x13 0)).union
+      (CodeReq.ofProg (base + 4) unified_decoder_prog)).union
+    ((CodeReq.singleton (base + 148) (.ADDI .x14 rOut fieldImm)).union
+      (spillChainCR (base + 148 + 4) 8))
+
+/-- The empty-scalar unit misses every address at or above `base + 248`. -/
+theorem empty_scalar_unit_cr_none_above (base : Word) (rOut : Reg) (fieldImm : BitVec 12)
+    (a : Word) (hcode : base.toNat + 248 < 2 ^ 64) (h : base.toNat + 248 ≤ a.toNat) :
+    emptyScalarUnitCR base rOut fieldImm a = none := by
+  have hl1 : CodeReq.singleton base (.LBU .x5 .x13 0) a = none := CodeReq.singleton_miss (by bv_omega)
+  have hl2 : CodeReq.ofProg (base + 4) unified_decoder_prog a = none :=
+    CodeReq.ofProg_none_range_len _ _ 36 a unified_decoder_prog_length (fun k hk => by bv_omega)
+  have hl3 : CodeReq.singleton (base + 148) (.ADDI .x14 rOut fieldImm) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have hl4 : spillChainCR (base + 148 + 4) 8 a = none :=
+    spillChainCR_none _ a 8 (fun j hj => by bv_omega)
+  simp only [emptyScalarUnitCR, CodeReq.union, hl1, hl2, hl3, hl4]
+
+/-- The empty-scalar unit misses every address below `base`. -/
+theorem empty_scalar_unit_cr_none_below (base : Word) (rOut : Reg) (fieldImm : BitVec 12)
+    (a : Word) (hcode : base.toNat + 248 < 2 ^ 64) (h : a.toNat < base.toNat) :
+    emptyScalarUnitCR base rOut fieldImm a = none := by
+  have hl1 : CodeReq.singleton base (.LBU .x5 .x13 0) a = none := CodeReq.singleton_miss (by bv_omega)
+  have hl2 : CodeReq.ofProg (base + 4) unified_decoder_prog a = none :=
+    CodeReq.ofProg_none_range_len _ _ 36 a unified_decoder_prog_length (fun k hk => by bv_omega)
+  have hl3 : CodeReq.singleton (base + 148) (.ADDI .x14 rOut fieldImm) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have hl4 : spillChainCR (base + 148 + 4) 8 a = none :=
+    spillChainCR_none _ a 8 (fun j hj => by bv_omega)
+  simp only [emptyScalarUnitCR, CodeReq.union, hl1, hl2, hl3, hl4]
+
+-- ---------------------------------------------------------------------------
 -- Byte-array unit: CR is `none` outside `[base, base + (152 + 20·len))`.
 -- ---------------------------------------------------------------------------
 

--- a/EvmAsm/Rv64/RLP/UnifiedEmptyScalarFieldCanonical.lean
+++ b/EvmAsm/Rv64/RLP/UnifiedEmptyScalarFieldCanonical.lean
@@ -1,0 +1,183 @@
+/-
+  EvmAsm.Rv64.RLP.UnifiedEmptyScalarFieldCanonical
+
+  EL.3 / Phase 5 — the canonical re-entry chain for the EMPTY (`n=0`) scalar field unit
+  (`UnifiedEmptyScalarField`), paralleling the non-empty scalar region chain
+  (`_at_regOwn` → `_canonical` → `_fully_canonical`). The empty unit has the identical scratch
+  pre/post shape as the non-empty scalar region unit (only the spill value `0`, the `x13` stride,
+  the step count and code range differ), so each peeling layer mirrors its scalar counterpart with
+  the underlying unit swapped. The endpoint
+  `unified_empty_scalar_field_decode_and_store_region_fully_canonical` has the uniform all-`regOwn`
+  scratch interface the N-field fold (`schema_walk`) consumes, with CR `emptyScalarUnitCR` — the
+  prerequisite for integrating zero-valued scalar fields into the schema engine.
+-/
+
+import EvmAsm.Rv64.RLP.UnifiedEmptyScalarField
+import EvmAsm.Rv64.RLP.FieldUnitDisjoint
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL.RLP
+open EvmAsm.Rv64.Tactics
+
+set_option maxRecDepth 8000 in
+/-- **`regOwn`-re-entry empty-scalar field.** As `unified_empty_scalar_field_decode_and_store_region`
+    but `x5, x10, x11, x12` are `regOwn` in the precondition — callable after a prior field. -/
+theorem unified_empty_scalar_field_decode_and_store_region_at_regOwn
+    (base regionBase : Word) (rOut : Reg) (outBase : Word) (fieldImm : BitVec 12)
+    (bs : List Byte) (O : Nat) (tail : List Byte) (outBytes : List Byte) (di0 : Nat)
+    (v14Old v15Old : Word)
+    (halign : regionBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdrop : bs.drop O = encode (.bytes ([] : List Byte)) ++ tail)
+    (hdalign : outBase.toNat % 8 = 0) (hdst : di0 + 8 ≤ outBytes.length)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hImm : signExtend12 fieldImm = BitVec.ofNat 64 di0)
+    (hcode : base.toNat + (148 + 4 + 12 * 8) < 2 ^ 64) :
+    cpsTripleWithin (61 + (1 + 3 * 8)) base (base + 148 + 4 + BitVec.ofNat 64 (12 * 8))
+      (((CodeReq.singleton base (.LBU .x5 .x13 0)).union
+          (CodeReq.ofProg (base + 4) unified_decoder_prog)).union
+        ((CodeReq.singleton (base + 148) (.ADDI .x14 rOut fieldImm)).union
+          (spillChainCR (base + 148 + 4) 8)))
+      (((regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) ** (regOwn .x11) **
+        (regOwn .x12) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (.x14 ↦ᵣ v14Old) **
+        (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs) **
+       ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes))
+      (((regOwn .x11) ** (.x14 ↦ᵣ (outBase + BitVec.ofNat 64 (di0 + 8))) ** (rOut ↦ᵣ outBase) **
+        bytesRegion outBase
+          (spillRange outBytes (BitVec.ofNat 64 (Nat.fromBytesBE ([] : List Byte))) di0 8)) **
+       ((.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 (O + (encode (.bytes ([] : List Byte))).length))) **
+        regOwn .x12 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs **
+        regOwn .x5 ** regOwn .x10 ** (.x15 ↦ᵣ v15Old)))
+    ∧ decodeScalar (bs.drop O) = some (0, tail) := by
+  refine ⟨?_, ?_⟩
+  · refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x5)
+        (P := (.x0 ↦ᵣ (0 : Word)) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+          (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs **
+          ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes) **
+          regOwn .x10 ** regOwn .x11 ** regOwn .x12)
+        (fun v5 => ?_))
+    refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x10)
+        (P := (.x0 ↦ᵣ (0 : Word)) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+          (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs **
+          ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes) **
+          (.x5 ↦ᵣ v5) ** regOwn .x11 ** regOwn .x12)
+        (fun v10 => ?_))
+    refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x11)
+        (P := (.x0 ↦ᵣ (0 : Word)) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+          (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs **
+          ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes) **
+          (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** regOwn .x12)
+        (fun v11 => ?_))
+    refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x12)
+        (P := (.x0 ↦ᵣ (0 : Word)) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+          (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs **
+          ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes) **
+          (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11))
+        (fun v12 => ?_))
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (unified_empty_scalar_field_decode_and_store_region base regionBase rOut outBase fieldImm bs O
+        tail outBytes di0 v5 v10 v11 v12 v14Old v15Old halign hover hwin hdrop hdalign hdst hdov
+        hdval hImm hcode).1
+  · exact (unified_empty_scalar_field_decode_and_store_region base regionBase rOut outBase fieldImm
+      bs O tail outBytes di0 0 0 0 0 v14Old v15Old halign hover hwin hdrop hdalign hdst hdov hdval
+      hImm hcode).2
+
+set_option maxRecDepth 8000 in
+/-- **Canonical empty-scalar field.** As `…_at_regOwn` but `x15` is also `regOwn` in the
+    precondition (CR named `emptyScalarUnitCR`). -/
+theorem unified_empty_scalar_field_decode_and_store_region_canonical
+    (base regionBase : Word) (rOut : Reg) (outBase : Word) (fieldImm : BitVec 12)
+    (bs : List Byte) (O : Nat) (tail : List Byte) (outBytes : List Byte) (di0 : Nat)
+    (v14Old : Word)
+    (halign : regionBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdrop : bs.drop O = encode (.bytes ([] : List Byte)) ++ tail)
+    (hdalign : outBase.toNat % 8 = 0) (hdst : di0 + 8 ≤ outBytes.length)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hImm : signExtend12 fieldImm = BitVec.ofNat 64 di0)
+    (hcode : base.toNat + (148 + 4 + 12 * 8) < 2 ^ 64) :
+    cpsTripleWithin (61 + (1 + 3 * 8)) base (base + 148 + 4 + BitVec.ofNat 64 (12 * 8))
+      (emptyScalarUnitCR base rOut fieldImm)
+      (((regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) ** (regOwn .x11) **
+        (regOwn .x12) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (.x14 ↦ᵣ v14Old) **
+        (regOwn .x15) ** bytesRegion regionBase bs) **
+       ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes))
+      (((regOwn .x11) ** (.x14 ↦ᵣ (outBase + BitVec.ofNat 64 (di0 + 8))) ** (rOut ↦ᵣ outBase) **
+        bytesRegion outBase
+          (spillRange outBytes (BitVec.ofNat 64 (Nat.fromBytesBE ([] : List Byte))) di0 8)) **
+       ((.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 (O + (encode (.bytes ([] : List Byte))).length))) **
+        regOwn .x12 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs **
+        regOwn .x5 ** regOwn .x10 ** (regOwn .x15)))
+    ∧ decodeScalar (bs.drop O) = some (0, tail) := by
+  refine ⟨?_, ?_⟩
+  · refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x15)
+        (P := (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) ** (regOwn .x11) **
+          (regOwn .x12) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (.x14 ↦ᵣ v14Old) **
+          bytesRegion regionBase bs ** ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes))
+        (fun v15 => ?_))
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+        (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+          (regIs_implies_regOwn .x15))))))))
+      (unified_empty_scalar_field_decode_and_store_region_at_regOwn base regionBase rOut outBase
+        fieldImm bs O tail outBytes di0 v14Old v15 halign hover hwin hdrop hdalign hdst hdov hdval
+        hImm hcode).1
+  · exact (unified_empty_scalar_field_decode_and_store_region_at_regOwn base regionBase rOut outBase
+      fieldImm bs O tail outBytes di0 v14Old 0 halign hover hwin hdrop hdalign hdst hdov hdval hImm
+      hcode).2
+
+set_option maxRecDepth 8000 in
+/-- **Fully-canonical empty-scalar field.** As `…_canonical` but `x14` is also `regOwn` in both
+    pre and post — the uniform scratch interface the N-field fold consumes. -/
+theorem unified_empty_scalar_field_decode_and_store_region_fully_canonical
+    (base regionBase : Word) (rOut : Reg) (outBase : Word) (fieldImm : BitVec 12)
+    (bs : List Byte) (O : Nat) (tail : List Byte) (outBytes : List Byte) (di0 : Nat)
+    (halign : regionBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdrop : bs.drop O = encode (.bytes ([] : List Byte)) ++ tail)
+    (hdalign : outBase.toNat % 8 = 0) (hdst : di0 + 8 ≤ outBytes.length)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hImm : signExtend12 fieldImm = BitVec.ofNat 64 di0)
+    (hcode : base.toNat + (148 + 4 + 12 * 8) < 2 ^ 64) :
+    cpsTripleWithin (61 + (1 + 3 * 8)) base (base + 148 + 4 + BitVec.ofNat 64 (12 * 8))
+      (emptyScalarUnitCR base rOut fieldImm)
+      (((regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) ** (regOwn .x11) **
+        (regOwn .x12) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (regOwn .x14) **
+        (regOwn .x15) ** bytesRegion regionBase bs) **
+       ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes))
+      (((regOwn .x11) ** (regOwn .x14) ** (rOut ↦ᵣ outBase) **
+        bytesRegion outBase
+          (spillRange outBytes (BitVec.ofNat 64 (Nat.fromBytesBE ([] : List Byte))) di0 8)) **
+       ((.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 (O + (encode (.bytes ([] : List Byte))).length))) **
+        regOwn .x12 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs **
+        regOwn .x5 ** regOwn .x10 ** (regOwn .x15)))
+    ∧ decodeScalar (bs.drop O) = some (0, tail) := by
+  refine ⟨?_, ?_⟩
+  · refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x14)
+        (P := (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) ** (regOwn .x11) **
+          (regOwn .x12) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+          (regOwn .x15) ** bytesRegion regionBase bs ** ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes))
+        (fun v14 => ?_))
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (sepConj_mono_left (sepConj_mono_right (sepConj_mono_left (regIs_implies_regOwn .x14))))
+      (unified_empty_scalar_field_decode_and_store_region_canonical base regionBase rOut outBase
+        fieldImm bs O tail outBytes di0 v14 halign hover hwin hdrop hdalign hdst hdov hdval hImm
+        hcode).1
+  · exact (unified_empty_scalar_field_decode_and_store_region_canonical base regionBase rOut outBase
+      fieldImm bs O tail outBytes di0 0 halign hover hwin hdrop hdalign hdst hdov hdval hImm hcode).2
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -1829,9 +1829,13 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     `0x80` (`x13 → next`, `x11 = 0`) ⨾ scalar store-region leaf spilling `0` (`spillRange out 0 di 8`).
     `fieldSize = 248` (32 B shorter than the non-empty scalar unit; no read loop). Coincides with
     `decodeScalar (bs.drop O) = some (0, tail)`.
-  - **Next:** empty-scalar canonical chain (→ `schemaINV` interface) + `emptyScalarUnitCR`; empty-bytes
-    region unit + canonical; then engine integration (data-dependent `fieldSize`/`fieldCR`/`fieldSteps`,
-    `field_step` dispatch, `SchemaValid` relax).
+  - ✅ **Step 50 — empty-scalar canonical chain + `emptyScalarUnitCR`** (`UnifiedEmptyScalarFieldCanonical.lean`
+    + `FieldUnitDisjoint.lean`): the `_at_regOwn` → `_canonical` → `_fully_canonical` peeling chain (mirrors
+    the non-empty scalar chain — identical pre/post shape) to the uniform `regOwn` interface with CR
+    `emptyScalarUnitCR`, plus the CR def + `empty_scalar_unit_cr_none_{above,below}` (range `[base, base+248)`).
+    The empty-scalar unit is now fold-ready.
+  - **Next:** empty-bytes region unit + canonical; then engine integration (data-dependent `fieldSize`/
+    `fieldCR`/`fieldSteps` for the scalar kind, `field_step` dispatch, `SchemaValid`/`fieldCoreValid` relax).
 - Phase 6: Top-level pipeline (`read_input` -> decode -> `write_output`)
 - **Host I/O ABI**: See `docs/zkvm-host-io-interface.md`; SP1
   `HINT_LEN`/`HINT_READ`/`COMMIT` are legacy handler shapes, not the target


### PR DESCRIPTION
## Summary

Makes the empty (`n=0`) scalar unit **fold-ready**. *(Stacked on #9309.)*

The N-field fold (`schema_walk`) consumes units with a uniform all-`regOwn` scratch interface; #9309 shipped the plain empty-scalar region unit (concrete scratch). This adds:

- the `_at_regOwn` → `_canonical` → `_fully_canonical` peeling chain, mirroring the non-empty scalar region chain (the empty unit has the **identical** scratch pre/post shape — only the spill value `0`, `x13` stride, step count and code range differ), to the uniform `regOwn` interface;
- `emptyScalarUnitCR` + `empty_scalar_unit_cr_none_{above,below}` in `FieldUnitDisjoint` (range `[base, base+248)`), paralleling the scalar/byte CRs (purely additive).

The endpoint `unified_empty_scalar_field_decode_and_store_region_fully_canonical` has CR `emptyScalarUnitCR` — the prerequisite for integrating zero-valued scalar fields into `schema_walk`.

## Verification
- `lake build` of both files + umbrella `EvmAsm.Rv64.RLP` — clean, 0 warnings.
- `scripts/check-forbidden-tactics.sh` OK (no `bv_decide`/`native_decide`).
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` (CR lemmas: `[propext, Quot.sound]`); 0 sorry/admit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)