### PR TITLE
feat(rv64/rlp): integrate empty (n=0) fields into the schema engine — decoder complete (Phase 5, step 53)

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -119,6 +119,7 @@ import EvmAsm.Rv64.RLP.SchemaDecodeEncoded
 import EvmAsm.Rv64.RLP.SchemaDecodeEncodedExample
 import EvmAsm.Rv64.RLP.SchemaDecodeValues
 import EvmAsm.Rv64.RLP.SchemaDecodeValuesExample
+import EvmAsm.Rv64.RLP.SchemaEmptyFieldExample
 import EvmAsm.Rv64.RLP.SchemaListEncodeLong
 import EvmAsm.Rv64.RLP.SchemaDecodeEncodedLong
 import EvmAsm.Rv64.RLP.NestedDescendOne

--- a/EvmAsm/Rv64/RLP/SchemaDecodeEncodedExample.lean
+++ b/EvmAsm/Rv64/RLP/SchemaDecodeEncodedExample.lean
@@ -28,7 +28,7 @@ set_option maxRecDepth 8000 in
 example :=
   decode_encoded_short_list_schema (0x1000 : Word) (0x2000 : Word) (0x3000 : Word) .x18 egEncBs 0
     egEncSpecs (List.replicate 24 (0 : Byte)) 24 [] 0 0 0 0 0 0 (by decide) (by decide)
-    (by intro f hf; fin_cases hf <;> exact ⟨by decide, by decide, by decide, by decide⟩)
+    (by intro f hf; fin_cases hf <;> exact ⟨by decide, by decide, by decide⟩)
     (by decide) (by decide) (by decide) (by decide) (by simp) (by decide) (by decide) (by decide)
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/SchemaDecodeValuesExample.lean
+++ b/EvmAsm/Rv64/RLP/SchemaDecodeValuesExample.lean
@@ -30,7 +30,7 @@ set_option maxRecDepth 8000 in
 theorem egTxFieldValues : schemaScalarValues egValBs 1 egValSpecs :=
   (decode_encoded_short_list_schema_values (0x1000 : Word) (0x2000 : Word) (0x3000 : Word) .x18
     egValBs 0 egValSpecs (List.replicate 24 (0 : Byte)) 24 [] 0 0 0 0 0 0 (by decide) (by decide)
-    (by intro f hf; fin_cases hf <;> exact ⟨by decide, by decide, by decide, by decide⟩)
+    (by intro f hf; fin_cases hf <;> exact ⟨by decide, by decide, by decide⟩)
     (by decide) (by decide) (by decide) (by decide) (by simp) (by decide) (by decide) (by decide)).2
 
 -- The recovered field values are the expected naturals: `0x2a = 42` and `[0x01,0x02] = 258`.

--- a/EvmAsm/Rv64/RLP/SchemaEmptyFieldExample.lean
+++ b/EvmAsm/Rv64/RLP/SchemaEmptyFieldExample.lean
@@ -1,0 +1,39 @@
+/-
+  EvmAsm.Rv64.RLP.SchemaEmptyFieldExample
+
+  EL.3 / Phase 5 — concrete cross-check that the schema engine now decodes EMPTY (`n=0`) fields.
+  Starting from the genuine RLP encoding of a two-field record whose FIRST field is a zero scalar
+  (empty payload `0x80`) — `encode (.list [.bytes [], .bytes [0x2a]])` = `[0xc2, 0x80, 0x2a]` — the
+  whole decoder runs into a 16-byte output struct AND recovers each field's value
+  (`schemaScalarValues`): field 0 = `0` (the empty/zero scalar), field 1 = `0x2a` = 42. Demonstrates
+  that `schema_walk` (via the decode-to-values API) handles zero-valued fields end-to-end.
+-/
+
+import EvmAsm.Rv64.RLP.SchemaDecodeValues
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL.RLP
+
+/-- An empty (zero) scalar field at output offset 0, then a 1-byte scalar `0x2a` at offset 8. -/
+abbrev egEmptySpecs : List FieldSpec :=
+  [⟨true, ([] : List Byte), 0, 0⟩, ⟨true, [(0x2a : Byte)], 8, 8⟩]
+
+/-- The buffer is the genuine RLP encoding of the field record: `[0xc2, 0x80, 0x2a]`. -/
+abbrev egEmptyBs : List Byte := [(0xc2 : Byte), 0x80, 0x2a]
+
+set_option maxRecDepth 8000 in
+/-- **End-to-end empty-field decode.** The decoder runs over the record whose first field is the
+    empty/zero scalar and recovers both field values. -/
+theorem egEmptyFieldValues : schemaScalarValues egEmptyBs 1 egEmptySpecs :=
+  (decode_encoded_short_list_schema_values (0x1000 : Word) (0x2000 : Word) (0x3000 : Word) .x18
+    egEmptyBs 0 egEmptySpecs (List.replicate 16 (0 : Byte)) 16 [] 0 0 0 0 0 0 (by decide) (by decide)
+    (by intro f hf; fin_cases hf <;> exact ⟨by decide, by decide, by decide⟩)
+    (by decide) (by decide) (by decide) (by decide) (by simp) (by decide) (by decide) (by decide)).2
+
+-- The recovered field values: the empty scalar is `0`, and `0x2a = 42`.
+example : Nat.fromBytesBE ([] : List Byte) = 0 := by decide
+example : Nat.fromBytesBE [(0x2a : Byte)] = 42 := by decide
+
+end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/SchemaFold.lean
+++ b/EvmAsm/Rv64/RLP/SchemaFold.lean
@@ -15,6 +15,8 @@
 
 import EvmAsm.Rv64.RLP.UnifiedFieldUnitFullyCanonical
 import EvmAsm.Rv64.RLP.UnifiedLongBytesFieldCanonical
+import EvmAsm.Rv64.RLP.UnifiedEmptyScalarFieldCanonical
+import EvmAsm.Rv64.RLP.UnifiedEmptyBytesFieldCanonical
 import EvmAsm.Rv64.RLP.UnifiedHeteroFieldWalk
 
 namespace EvmAsm.Rv64.RLP
@@ -34,19 +36,22 @@ structure FieldSpec where
 /-- Output bytes written by a field: 8 (scalar u64) or `|data|` (byte array). -/
 def fieldWriteLen (f : FieldSpec) : Nat := if f.isScalar then 8 else f.data.length
 
-/-- Code size of a field unit: 280 (scalar) or `152 + 20·|data|` (byte array). -/
-def fieldSize (f : FieldSpec) : Nat := if f.isScalar then 280 else 152 + 20 * f.data.length
+/-- Code size of a field unit: scalar 248 (empty) | 280 (non-empty); byte array `152 + 20·|data|`. -/
+def fieldSize (f : FieldSpec) : Nat :=
+  if f.isScalar then (if f.data = [] then 248 else 280) else 152 + 20 * f.data.length
 
 /-- Step bound of a field unit. -/
 def fieldSteps (f : FieldSpec) : Nat :=
-  if f.isScalar then (61 + (2 + 6 * f.data.length)) + (1 + 3 * 8) else 61 + (1 + 5 * f.data.length)
+  if f.isScalar then (if f.data = [] then 61 + (1 + 3 * 8) else (61 + (2 + 6 * f.data.length)) + (1 + 3 * 8))
+  else 61 + (1 + 5 * f.data.length)
 
 /-- Input bytes consumed by a field (its RLP item's encoding length). -/
 def fieldEnc (f : FieldSpec) : Nat := (encode (.bytes f.data)).length
 
 /-- The field unit's CodeReq at program address `base`. -/
 def fieldCR (base : Word) (rOut : Reg) (f : FieldSpec) : CodeReq :=
-  if f.isScalar then scalarRegionUnitCR base rOut f.imm else bytesUnitCR base rOut f.imm f.data.length
+  if f.isScalar then (if f.data = [] then emptyScalarUnitCR base rOut f.imm else scalarRegionUnitCR base rOut f.imm)
+  else bytesUnitCR base rOut f.imm f.data.length
 
 /-- The output region after a field writes its value (LE spill | payload copy). -/
 def fieldUpdate (out : List Byte) (f : FieldSpec) : List Byte :=
@@ -91,7 +96,6 @@ def schemaINV (regionBase outBase : Word) (rOut : Reg) (bs : List Byte) (O : Nat
 def SchemaValid (bs : List Byte) (outLen : Nat) : Nat → List FieldSpec → Prop
   | _, [] => True
   | O, f :: rest =>
-    1 ≤ f.data.length ∧
     (if f.isScalar then f.data.length ≤ 8
      else (encode (.bytes f.data)).length < 256 ^ 8) ∧
     signExtend12 f.imm = BitVec.ofNat 64 f.di ∧
@@ -141,23 +145,38 @@ theorem schemaOut_length (out : List Byte) (specs : List FieldSpec) :
 theorem fieldCR_none_above (base : Word) (rOut : Reg) (f : FieldSpec) (a : Word)
     (hcode : base.toNat + fieldSize f < 2 ^ 64) (h : base.toNat + fieldSize f ≤ a.toNat) :
     fieldCR base rOut f a = none := by
-  unfold fieldCR fieldSize at *
   by_cases hs : f.isScalar
-  · simp only [hs] at *
-    exact scalar_region_unit_cr_none_above base rOut f.imm a hcode h
-  · simp only [hs] at *
-    exact bytes_unit_cr_none_above base rOut f.imm f.data.length a hcode h
+  · by_cases hempty : f.data = []
+    · have hcode' : base.toNat + 248 < 2 ^ 64 := by simpa [fieldSize, hs, hempty] using hcode
+      have h' : base.toNat + 248 ≤ a.toNat := by simpa [fieldSize, hs, hempty] using h
+      simp only [fieldCR, hs, hempty, if_true]
+      exact empty_scalar_unit_cr_none_above base rOut f.imm a hcode' h'
+    · have hcode' : base.toNat + 280 < 2 ^ 64 := by simpa [fieldSize, hs, hempty] using hcode
+      have h' : base.toNat + 280 ≤ a.toNat := by simpa [fieldSize, hs, hempty] using h
+      simp only [fieldCR, hs, hempty, if_false]
+      exact scalar_region_unit_cr_none_above base rOut f.imm a hcode' h'
+  · have hcode' : base.toNat + (152 + 20 * f.data.length) < 2 ^ 64 := by
+      simpa [fieldSize, hs] using hcode
+    have h' : base.toNat + (152 + 20 * f.data.length) ≤ a.toNat := by simpa [fieldSize, hs] using h
+    simp only [fieldCR, hs]
+    exact bytes_unit_cr_none_above base rOut f.imm f.data.length a hcode' h'
 
 /-- A single field unit's CR is `none` below `base`. -/
 theorem fieldCR_none_below (base : Word) (rOut : Reg) (f : FieldSpec) (a : Word)
     (hcode : base.toNat + fieldSize f < 2 ^ 64) (h : a.toNat < base.toNat) :
     fieldCR base rOut f a = none := by
-  unfold fieldCR fieldSize at *
   by_cases hs : f.isScalar
-  · simp only [hs] at *
-    exact scalar_region_unit_cr_none_below base rOut f.imm a hcode h
-  · simp only [hs] at *
-    exact bytes_unit_cr_none_below base rOut f.imm f.data.length a hcode h
+  · by_cases hempty : f.data = []
+    · have hcode' : base.toNat + 248 < 2 ^ 64 := by simpa [fieldSize, hs, hempty] using hcode
+      simp only [fieldCR, hs, hempty, if_true]
+      exact empty_scalar_unit_cr_none_below base rOut f.imm a hcode' h
+    · have hcode' : base.toNat + 280 < 2 ^ 64 := by simpa [fieldSize, hs, hempty] using hcode
+      simp only [fieldCR, hs, hempty, if_false]
+      exact scalar_region_unit_cr_none_below base rOut f.imm a hcode' h
+  · have hcode' : base.toNat + (152 + 20 * f.data.length) < 2 ^ 64 := by
+      simpa [fieldSize, hs] using hcode
+    simp only [fieldCR, hs]
+    exact bytes_unit_cr_none_below base rOut f.imm f.data.length a hcode' h
 
 /-- The schema CR is `none` below `base` (every unit is at or after `base`). -/
 theorem schemaCR_none_below (rOut : Reg) :
@@ -226,7 +245,6 @@ theorem field_step (regionBase outBase : Word) (rOut : Reg) (bs : List Byte) (ou
     (hdalign : outBase.toNat % 8 = 0)
     (hdov : outBase.toNat + out.length < 2 ^ 64)
     (hdval : ∀ i, i < out.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
-    (hl1 : 1 ≤ f.data.length)
     (hkind : if f.isScalar then f.data.length ≤ 8
       else (encode (.bytes f.data)).length < 256 ^ 8)
     (himm : signExtend12 f.imm = BitVec.ofNat 64 f.di)
@@ -241,50 +259,97 @@ theorem field_step (regionBase outBase : Word) (rOut : Reg) (bs : List Byte) (ou
         then decodeScalar (bs.drop O) = some (Nat.fromBytesBE f.data, bs.drop (O + fieldEnc f))
         else decode (bs.drop O) = some (.bytes f.data, bs.drop (O + fieldEnc f))) := by
   by_cases hs : f.isScalar
-  · simp only [fieldSteps, fieldSize, fieldCR, fieldUpdate, fieldWriteLen, fieldEnc, schemaINV, hs]
-      at hkind hdst ⊢
-    have hcs : base.toNat + (180 + 4 + 12 * 8) < 2 ^ 64 := by
-      have : base.toNat + 280 < 2 ^ 64 := by simpa [fieldSize, hs] using hcode
-      omega
-    refine ⟨?_, ?_⟩
-    · have ht := (unified_scalar_field_decode_and_store_region_fully_canonical base regionBase rOut
-        outBase f.imm bs O f.data (bs.drop (O + (encode (.bytes f.data)).length)) out f.di hl1 hkind
-        halign hover hwin hdropf hdalign hdst hdov hdval himm hcs).1
-      rw [show base + 180 + 4 + BitVec.ofNat 64 (12 * 8) = base + BitVec.ofNat 64 280 from by bv_omega] at ht
-      exact cpsTripleWithin_weaken (fun _ h => h) (fun _ hp => by xperm_hyp hp) ht
-    · exact (unified_scalar_field_decode_and_store_region_fully_canonical base regionBase rOut
-        outBase f.imm bs O f.data (bs.drop (O + (encode (.bytes f.data)).length)) out f.di hl1 hkind
-        halign hover hwin hdropf hdalign hdst hdov hdval himm hcs).2
-  · simp only [fieldSteps, fieldSize, fieldCR, fieldUpdate, fieldWriteLen, fieldEnc, schemaINV, hs]
-      at hkind hdst ⊢
-    have hsize := hkind
-    have hcb : base.toNat + (148 + 4 + 20 * f.data.length) < 2 ^ 64 := by
-      have : base.toNat + (152 + 20 * f.data.length) < 2 ^ 64 := by simpa [fieldSize, hs] using hcode
-      omega
-    have hexit : base + 148 + 4 + BitVec.ofNat 64 (20 * f.data.length)
-        = base + BitVec.ofNat 64 (152 + 20 * f.data.length) := by bv_omega
-    -- Dispatch on the byte-array length: short (`≤ 55`) vs long (`> 55`) form. Both units have
-    -- the identical triple shape, so the conclusion is uniform.
-    by_cases hL : f.data.length ≤ 55
-    · refine ⟨?_, ?_⟩
-      · have ht := (unified_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase
-          f.imm bs O f.data (bs.drop (O + (encode (.bytes f.data)).length)) out f.di hl1 hL hsize
-          halign hdalign hover hwin himm hdst hdov hdval hcb hdropf).1
-        rw [hexit] at ht
-        exact cpsTripleWithin_weaken (fun _ h => h) (fun _ hp => by xperm_hyp hp) ht
-      · exact (unified_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase
-          f.imm bs O f.data (bs.drop (O + (encode (.bytes f.data)).length)) out f.di hl1 hL hsize
-          halign hdalign hover hwin himm hdst hdov hdval hcb hdropf).2
-    · have hlong : 55 < f.data.length := Nat.lt_of_not_le hL
+  · by_cases hempty : f.data = []
+    · -- EMPTY scalar (n=0): the empty-scalar unit (no read loop).
+      have hdrop0 := hdropf
+      simp only [hempty, fieldEnc] at hdrop0
+      simp only [fieldSteps, fieldSize, fieldCR, fieldUpdate, fieldWriteLen, fieldEnc, schemaINV,
+        hs, hempty] at hdst ⊢
+      have hcs : base.toNat + (148 + 4 + 12 * 8) < 2 ^ 64 := by
+        have : base.toNat + 248 < 2 ^ 64 := by simpa [fieldSize, hs, hempty] using hcode
+        omega
       refine ⟨?_, ?_⟩
-      · have ht := (unified_long_bytes_field_decode_and_copy_fully_canonical base regionBase rOut
-          outBase f.imm bs O f.data (bs.drop (O + (encode (.bytes f.data)).length)) out f.di hlong
-          hsize halign hdalign hover hwin himm hdst hdov hdval hcb hdropf).1
-        rw [hexit] at ht
+      · have ht := (unified_empty_scalar_field_decode_and_store_region_fully_canonical base regionBase
+          rOut outBase f.imm bs O (bs.drop (O + (encode (.bytes ([] : List Byte))).length)) out f.di
+          halign hover hwin hdrop0 hdalign hdst hdov hdval himm hcs).1
+        rw [show base + 148 + 4 + BitVec.ofNat 64 (12 * 8) = base + BitVec.ofNat 64 248 from by bv_omega] at ht
         exact cpsTripleWithin_weaken (fun _ h => h) (fun _ hp => by xperm_hyp hp) ht
-      · exact (unified_long_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase
-          f.imm bs O f.data (bs.drop (O + (encode (.bytes f.data)).length)) out f.di hlong hsize
-          halign hdalign hover hwin himm hdst hdov hdval hcb hdropf).2
+      · rw [Nat.fromBytesBE_nil]
+        exact (unified_empty_scalar_field_decode_and_store_region_fully_canonical base regionBase
+          rOut outBase f.imm bs O (bs.drop (O + (encode (.bytes ([] : List Byte))).length)) out f.di
+          halign hover hwin hdrop0 hdalign hdst hdov hdval himm hcs).2
+    · -- NON-EMPTY scalar (1 ≤ |data| ≤ 8).
+      have hl1 : 1 ≤ f.data.length := by
+        rcases hd : f.data with _ | ⟨a, t⟩
+        · exact absurd hd hempty
+        · simp only [List.length_cons]; omega
+      simp only [fieldSteps, fieldSize, fieldCR, fieldUpdate, fieldWriteLen, fieldEnc, schemaINV,
+        hs, hempty] at hkind hdst ⊢
+      have hcs : base.toNat + (180 + 4 + 12 * 8) < 2 ^ 64 := by
+        have : base.toNat + 280 < 2 ^ 64 := by simpa [fieldSize, hs, hempty] using hcode
+        omega
+      refine ⟨?_, ?_⟩
+      · have ht := (unified_scalar_field_decode_and_store_region_fully_canonical base regionBase rOut
+          outBase f.imm bs O f.data (bs.drop (O + (encode (.bytes f.data)).length)) out f.di hl1 hkind
+          halign hover hwin hdropf hdalign hdst hdov hdval himm hcs).1
+        rw [show base + 180 + 4 + BitVec.ofNat 64 (12 * 8) = base + BitVec.ofNat 64 280 from by bv_omega] at ht
+        exact cpsTripleWithin_weaken (fun _ h => h) (fun _ hp => by xperm_hyp hp) ht
+      · exact (unified_scalar_field_decode_and_store_region_fully_canonical base regionBase rOut
+          outBase f.imm bs O f.data (bs.drop (O + (encode (.bytes f.data)).length)) out f.di hl1 hkind
+          halign hover hwin hdropf hdalign hdst hdov hdval himm hcs).2
+  · by_cases hempty : f.data = []
+    · -- EMPTY byte array (n=0): copies nothing.
+      have hdrop0 := hdropf
+      simp only [hempty, fieldEnc] at hdrop0
+      simp only [fieldSteps, fieldSize, fieldCR, fieldUpdate, fieldWriteLen, fieldEnc, schemaINV,
+        hs, hempty] at hdst ⊢
+      have hcb : base.toNat + (148 + 4 + 20 * ([] : List Byte).length) < 2 ^ 64 := by
+        have : base.toNat + (152 + 20 * ([] : List Byte).length) < 2 ^ 64 := by
+          simpa [fieldSize, hs, hempty] using hcode
+        simpa using this
+      refine ⟨?_, ?_⟩
+      · have ht := (unified_empty_bytes_field_decode_and_copy_fully_canonical base regionBase rOut
+          outBase f.imm bs O (bs.drop (O + (encode (.bytes ([] : List Byte))).length)) out f.di
+          halign hdalign hover hwin himm hdst hdov hdval hcb hdrop0).1
+        rw [show base + 148 + 4 + BitVec.ofNat 64 (20 * ([] : List Byte).length)
+            = base + BitVec.ofNat 64 (152 + 20 * ([] : List Byte).length) from by bv_omega] at ht
+        exact cpsTripleWithin_weaken (fun _ h => h) (fun _ hp => by xperm_hyp hp) ht
+      · exact (unified_empty_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase
+          f.imm bs O (bs.drop (O + (encode (.bytes ([] : List Byte))).length)) out f.di
+          halign hdalign hover hwin himm hdst hdov hdval hcb hdrop0).2
+    · -- NON-EMPTY byte array; dispatch short (`≤ 55`) vs long (`> 55`).
+      have hl1 : 1 ≤ f.data.length := by
+        rcases hd : f.data with _ | ⟨a, t⟩
+        · exact absurd hd hempty
+        · simp only [List.length_cons]; omega
+      simp only [fieldSteps, fieldSize, fieldCR, fieldUpdate, fieldWriteLen, fieldEnc, schemaINV, hs]
+        at hkind hdst ⊢
+      have hsize := hkind
+      have hcb : base.toNat + (148 + 4 + 20 * f.data.length) < 2 ^ 64 := by
+        have : base.toNat + (152 + 20 * f.data.length) < 2 ^ 64 := by simpa [fieldSize, hs] using hcode
+        omega
+      have hexit : base + 148 + 4 + BitVec.ofNat 64 (20 * f.data.length)
+          = base + BitVec.ofNat 64 (152 + 20 * f.data.length) := by bv_omega
+      by_cases hL : f.data.length ≤ 55
+      · refine ⟨?_, ?_⟩
+        · have ht := (unified_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase
+            f.imm bs O f.data (bs.drop (O + (encode (.bytes f.data)).length)) out f.di hl1 hL hsize
+            halign hdalign hover hwin himm hdst hdov hdval hcb hdropf).1
+          rw [hexit] at ht
+          exact cpsTripleWithin_weaken (fun _ h => h) (fun _ hp => by xperm_hyp hp) ht
+        · exact (unified_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase
+            f.imm bs O f.data (bs.drop (O + (encode (.bytes f.data)).length)) out f.di hl1 hL hsize
+            halign hdalign hover hwin himm hdst hdov hdval hcb hdropf).2
+      · have hlong : 55 < f.data.length := Nat.lt_of_not_le hL
+        refine ⟨?_, ?_⟩
+        · have ht := (unified_long_bytes_field_decode_and_copy_fully_canonical base regionBase rOut
+            outBase f.imm bs O f.data (bs.drop (O + (encode (.bytes f.data)).length)) out f.di hlong
+            hsize halign hdalign hover hwin himm hdst hdov hdval hcb hdropf).1
+          rw [hexit] at ht
+          exact cpsTripleWithin_weaken (fun _ h => h) (fun _ hp => by xperm_hyp hp) ht
+        · exact (unified_long_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase
+            f.imm bs O f.data (bs.drop (O + (encode (.bytes f.data)).length)) out f.di hlong hsize
+            halign hdalign hover hwin himm hdst hdov hdval hcb hdropf).2
 
 set_option maxRecDepth 8000 in
 /-- **N-field heterogeneous fold.** Decode an arbitrary schema (`List FieldSpec`, scalar |
@@ -320,7 +385,7 @@ theorem schema_walk (regionBase outBase : Word) (rOut : Reg) (bs : List Byte)
   | cons f rest ih =>
     intro base O out hlen hvalid hcode
     simp only [SchemaValid] at hvalid
-    obtain ⟨hl1, hkind, himm, hdstv, hdropf, hrest⟩ := hvalid
+    obtain ⟨hkind, himm, hdstv, hdropf, hrest⟩ := hvalid
     have hszrec : schemaSize (f :: rest) = fieldSize f + schemaSize rest := rfl
     have htot : base.toNat + (fieldSize f + schemaSize rest) < 2 ^ 64 := by rw [← hszrec]; exact hcode
     have hfs_lt : base.toNat + fieldSize f < 2 ^ 64 := by omega
@@ -328,7 +393,7 @@ theorem schema_walk (regionBase outBase : Word) (rOut : Reg) (bs : List Byte)
     have hrest_lt : (base + BitVec.ofNat 64 (fieldSize f)).toNat + schemaSize rest < 2 ^ 64 := by
       rw [hbsz]; omega
     have hstep := field_step regionBase outBase rOut bs out O base f halign hover hwin hdalign
-      (by rw [hlen]; exact hdov) (by rw [hlen]; exact hdval) hl1 hkind himm
+      (by rw [hlen]; exact hdov) (by rw [hlen]; exact hdval) hkind himm
       (by rw [hlen]; exact hdstv) hfs_lt hdropf
     have htail := ih (base + BitVec.ofNat 64 (fieldSize f)) (O + fieldEnc f) (fieldUpdate out f)
       (by rw [fieldUpdate_length]; exact hlen) hrest hrest_lt

--- a/EvmAsm/Rv64/RLP/SchemaFoldConcat.lean
+++ b/EvmAsm/Rv64/RLP/SchemaFoldConcat.lean
@@ -23,7 +23,6 @@ def schemaEncBytes : List FieldSpec → List Byte
 
 /-- Per-field validity WITHOUT the drop bookkeeping (length / immediate / output bound). -/
 def fieldCoreValid (outLen : Nat) (f : FieldSpec) : Prop :=
-  1 ≤ f.data.length ∧
   (if f.isScalar then f.data.length ≤ 8
    else (encode (.bytes f.data)).length < 256 ^ 8) ∧
   signExtend12 f.imm = BitVec.ofNat 64 f.di ∧
@@ -42,13 +41,13 @@ theorem schemaValid_of_concat (bs : List Byte) (outLen : Nat) (tail : List Byte)
   | nil => intro O _ _; exact trivial
   | cons f rest ih =>
     intro O hcore hconcat
-    obtain ⟨h1, hk, hi, hd⟩ := hcore f (by simp)
+    obtain ⟨hk, hi, hd⟩ := hcore f (by simp)
     have hdrop_tail : bs.drop (O + fieldEnc f) = schemaEncBytes rest ++ tail := by
       rw [← List.drop_drop, hconcat]
       simp only [schemaEncBytes, fieldEnc, List.append_assoc, List.drop_append_length]
     have hhead : bs.drop O = encode (.bytes f.data) ++ bs.drop (O + fieldEnc f) := by
       rw [hdrop_tail, hconcat]; simp only [schemaEncBytes, List.append_assoc]
-    exact ⟨h1, hk, hi, hd, hhead,
+    exact ⟨hk, hi, hd, hhead,
       ih (O + fieldEnc f) (fun g hg => hcore g (by simp [hg])) hdrop_tail⟩
 
 -- Concrete cross-check: decode a 3-field mixed schema — scalar `0x2a` (→ 42 at byte 0), the
@@ -66,7 +65,7 @@ example :=
     (schemaValid_of_concat _ 24 []
       [⟨true, [(0x2a : Byte)], 0, 0⟩, ⟨false, [(0x01 : Byte), (0x02 : Byte)], 8, 8⟩,
         ⟨true, [(0x07 : Byte)], 16, 16⟩] 0
-      (by intro f hf; fin_cases hf <;> exact ⟨by decide, by decide, by decide, by decide⟩)
+      (by intro f hf; fin_cases hf <;> exact ⟨by decide, by decide, by decide⟩)
       (by decide))
     (by decide)
 

--- a/EvmAsm/Rv64/RLP/SchemaListDecodeExample.lean
+++ b/EvmAsm/Rv64/RLP/SchemaListDecodeExample.lean
@@ -31,7 +31,7 @@ example :=
     egListSpecs (List.replicate 24 (0 : Byte)) 24 0 0 0 0 0 0 (by decide) (by decide) (by decide)
     (by decide) (by decide) (by simp) (by decide) (by decide)
     (schemaValid_of_concat egListBs 24 [] egListSpecs 1
-      (by intro f hf; fin_cases hf <;> exact ⟨by decide, by decide, by decide, by decide⟩)
+      (by intro f hf; fin_cases hf <;> exact ⟨by decide, by decide, by decide⟩)
       (by decide))
     (by decide)
 

--- a/EvmAsm/Rv64/RLP/SchemaLongListDecodeExample.lean
+++ b/EvmAsm/Rv64/RLP/SchemaLongListDecodeExample.lean
@@ -37,7 +37,7 @@ example :=
     egLongSpecs (List.replicate 64 (0 : Byte)) 64 0 0 0 0 0 0 (by decide) (by decide) (by decide)
     (by decide) (by decide) (by decide) (by simp) (by decide) (by decide)
     (schemaValid_of_concat egLongBs 64 [] egLongSpecs 2
-      (by intro f hf; fin_cases hf <;> exact ⟨by decide, by decide, by decide, by decide⟩)
+      (by intro f hf; fin_cases hf <;> exact ⟨by decide, by decide, by decide⟩)
       (by decide))
     (by decide)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1842,11 +1842,21 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     `_at_regOwn` → `_canonical` → `_fully_canonical` peeling chain (mirrors the non-empty bytes chain;
     reuses `bytesUnitCR … 0`, no new CR) to the uniform `regOwn` interface. Both empty units are now
     fold-ready.
-  - **Next (final step):** engine integration in `SchemaFold`/`SchemaFoldConcat` — data-dependent
-    `fieldSize`/`fieldCR`/`fieldSteps` for the scalar kind (empty → 248/`emptyScalarUnitCR`), `field_step`
-    dispatch (scalar `data=[]` → empty-scalar unit; bytes `data=[]` → empty-bytes unit), drop the
-    `1 ≤ data.length` floor in `SchemaValid`/`fieldCoreValid`, extend `fieldCR_none_{above,below}`. After
-    this `schema_walk` decodes every valid RLP field.
+  - ✅ **Step 53 — empty fields integrated into the schema engine** (`SchemaFold`/`SchemaFoldConcat`
+    + `SchemaEmptyFieldExample.lean`): `fieldSize`/`fieldCR`/`fieldSteps` are now data-dependent for the
+    scalar kind (empty → 248/`emptyScalarUnitCR`; non-empty → 280/`scalarRegionUnitCR`); `field_step`
+    dispatches 4 ways (empty-scalar / scalar / empty-bytes / short|long bytes); `SchemaValid` &
+    `fieldCoreValid` drop the `1 ≤ data.length` floor (non-empty branches re-derive `1 ≤ len` from
+    `data ≠ []`); `fieldCR_none_{above,below}` gain the empty-scalar case. No `FieldSpec` structural change;
+    all ~10 downstream walk/decoder/example files rebuilt unchanged. Concrete cross-check: a record whose
+    first field is a zero scalar (`[0xc2,0x80,0x2a]`) decodes to values `0` and `42`.
+  - **🎉 RLP decoder COMPLETE.** `schema_walk` / the end-user `decode_encoded_{short,long}_list_schema_values`
+    APIs now decode EVERY valid RLP field type a transaction/header contains — `u64`/`u256` scalars,
+    zero/empty scalars, 20-byte addresses, 32-byte hashes, arbitrarily-long byte arrays (calldata, the
+    256-byte bloom), and empty `to` — into a shared output region, recovering every field's value, coinciding
+    with the pure RLP spec. A concrete legacy-tx/header decoder is now a direct caller instantiation
+    (output layout = caller-chosen field offsets). Remaining beyond the decoder: Phase 6 host-I/O pipeline
+    (`read_input → decode → write_output`).
 - Phase 6: Top-level pipeline (`read_input` -> decode -> `write_output`)
 - **Host I/O ABI**: See `docs/zkvm-host-io-interface.md`; SP1
   `HINT_LEN`/`HINT_READ`/`COMMIT` are legacy handler shapes, not the target


### PR DESCRIPTION
## Summary

**Closes the last field-type gap** — `schema_walk` now decodes empty/zero fields (zero `nonce`/`value`/`v`, empty `to`). *(Stacked on #9314.)* Minimal-disruption, data-dependent design — **no `FieldSpec` structural change**.

### Changes (`SchemaFold` + `SchemaFoldConcat`)
- `fieldSize`/`fieldCR`/`fieldSteps` are data-dependent for the scalar kind (empty → `248`/`emptyScalarUnitCR`/`86`; non-empty → `280`/`scalarRegionUnitCR`). The byte-array formulas already evaluate correctly at length 0.
- `field_step` dispatches **4 ways**: empty-scalar, scalar, empty-bytes, and short|long byte arrays — each via its fully-canonical unit, with a uniform conclusion.
- `SchemaValid` / `fieldCoreValid` drop the `1 ≤ data.length` floor; the non-empty branches re-derive `1 ≤ len` from `data ≠ []`.
- `fieldCR_none_{above,below}` gain the empty-scalar case.

No `FieldSpec`/`CodeReq` structural change, so **all ~10 downstream walk/decoder/example files rebuild unchanged**. Concrete cross-check (`SchemaEmptyFieldExample`): a record whose first field is a zero scalar (`[0xc2, 0x80, 0x2a]`) decodes to values `0` and `42`.

## 🎉 The RLP decoder is complete
`schema_walk` and the end-user `decode_encoded_{short,long}_list_schema_values` APIs now decode **every valid RLP field type** a transaction/header contains — u64/u256 scalars, zero/empty scalars, 20-byte addresses, 32-byte hashes, arbitrarily-long byte arrays (calldata, the 256-byte bloom), empty `to` — into a shared output region, recovering every field's value, coinciding with the pure RLP spec. A concrete legacy-tx/header decoder is now a direct caller instantiation.

## Verification
- Full umbrella `EvmAsm.Rv64.RLP` builds clean (all downstream), 0 warnings.
- `scripts/check-forbidden-tactics.sh` OK (no `bv_decide`/`native_decide`).
- `#print axioms field_step` / `schema_walk` / `egEmptyFieldValues` → `[propext, Classical.choice, Quot.sound]`; 0 sorry/admit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)