### PR TITLE
fix(eip8037): return failed child state gas

### DIFF
--- a/EvmAsm/Codegen/Programs/CallFrameReturn.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameReturn.lean
@@ -102,8 +102,15 @@ def frameReturnFunction : String :=
   ".Lfr_sgas_add_spill:\n" ++
   "  add s7, s7, t2\n" ++
   ".Lfr_sgas_no_spill:\n" ++
-  "  ld t0, 624(x20); la t1, evm_state_gas_left; sd t0, 0(t1)\n" ++
-  "  ld t0, 632(x20); la t1, evm_state_gas_used; sd t0, 0(t1)\n" ++
+  "  ld t0, 632(x20)                 # used0\n" ++
+  "  la t1, evm_state_gas_used; ld t2, 0(t1)  # used\n" ++
+  "  la t1, evm_state_gas_left; ld t3, 0(t1)  # child_left\n" ++
+  "  bleu t2, t0, .Lfr_sgas_restore_left_done\n" ++
+  "  sub t2, t2, t0                 # child_used_delta\n" ++
+  "  add t3, t3, t2                 # child_left + child_used_delta\n" ++
+  ".Lfr_sgas_restore_left_done:\n" ++
+  "  la t1, evm_state_gas_left; sd t3, 0(t1)\n" ++
+  "  la t1, evm_state_gas_used; sd t0, 0(t1)\n" ++
   -- nxio8.4.2: discard the reverted child's EIP-3529 refund additions by restoring
   -- evm_refund_acc to the pre-child snapshot (incorporate_child_on_error does not
   -- add child.refund_counter). Success leaves it (the SSTORE refunds stay).


### PR DESCRIPTION
## Summary
- return failed child state gas back to the parent state-gas reservoir as child_left + child_used_delta
- keep rolling evm_state_gas_used back to the parent snapshot on failed child return

## Validation
- rtk scripts/codegen-eest-stateless-check.sh --filter nested_failure_resets_to_tx_reservoir --skip 15 --limit 1 --jobs 1 --quiet-passes --run-dir gen-out/eest-bbow4-2-3-1-row15-clean --min-full 1: 1/1 full match
- rtk scripts/codegen-eest-stateless-check.sh --filter nested_failure_resets_to_tx_reservoir --jobs 1 --quiet-passes --run-dir gen-out/eest-bbow4-2-3-1-final --min-full 48: 48/48 full match
- rtk scripts/codegen-eest-stateless-check.sh --filter full_gas_consumption --jobs 1 --quiet-passes --run-dir gen-out/eest-bbow4-2-3-1-full-gas --min-full 24: 24/24 full match
- rtk lake build
- rtk scripts/check-file-size.sh
- rtk scripts/check-unimported.sh
- rtk scripts/check-forbidden-tactics.sh
- rtk scripts/check-no-warnings.sh
- rtk git diff --check
- rtk rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|sgas_trace' EvmAsm/Codegen/Programs/CallFrameReturn.lean: no matches

## Notes
- auth_refund_block_gas_accounting remains 0/4 on this main-based branch because the separate auth refund fix is still in PR #9316, not in main.