### PR TITLE
fix(eip8037): detect same-tx create2 collisions

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
@@ -14,12 +14,11 @@ import EvmAsm.Codegen.Programs.EvmAccessGas
 import EvmAsm.Codegen.Programs.EvmMemoryGas
 import EvmAsm.Codegen.Programs.Modexp
 import EvmAsm.Codegen.Programs.CreateRuntime
+import EvmAsm.Codegen.Programs.CreateSameTxCollision
 import EvmAsm.Codegen.Programs.PrecompileRuntime
 import EvmAsm.Codegen.Programs.AmsterdamSystemTx
 import EvmAsm.Rv64.Program
-
 namespace EvmAsm.Codegen
-
 open EvmAsm.Rv64
 
 def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
@@ -260,6 +259,7 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     "  la x18, hcon_predicate\n" ++
     "  ld x18, 0(x18)\n" ++
     "  bnez x18, .Lcr_collision_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
+    createSameTxCollisionScanAsm hasSalt ++
     "6:\n" ++
     -- coc3g.6 CAUSE 2: mirror spec generic_create (amsterdam vm/instructions/system.py:122
     -- `evm.accessed_addresses.add(contract_address)`). On the committing CREATE path the derived

--- a/EvmAsm/Codegen/Programs/CreateSameTxCollision.lean
+++ b/EvmAsm/Codegen/Programs/CreateSameTxCollision.lean
@@ -1,0 +1,41 @@
+/-
+  EvmAsm.Codegen.Programs.CreateSameTxCollision
+
+  Shared CREATE/CREATE2 same-transaction collision scan.
+-/
+
+namespace EvmAsm.Codegen
+
+/-- Scan the live non-storage effect log for the latest effect on the derived
+    CREATE/CREATE2 address. If the latest post nonce is nonzero, EIP-684 treats
+    the next CREATE-family operation to that address as a collision even though
+    the account was absent from pre-state. -/
+def createSameTxCollisionScanAsm (hasSalt : Bool) : String :=
+  "  la t0, exec_nonstorage_effect_count\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  la t2, exec_nonstorage_effect_log\n" ++
+  "  li t6, 0\n" ++
+  ".Lcr_same_tx_col_loop_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
+  "  beqz t1, .Lcr_same_tx_col_done_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
+  "  mv t3, t2\n" ++
+  "  la t4, create_address_be\n" ++
+  "  li t5, 20\n" ++
+  ".Lcr_same_tx_col_cmp_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
+  "  beqz t5, .Lcr_same_tx_col_match_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
+  "  lbu x18, 0(t3)\n" ++
+  "  lbu x19, 0(t4)\n" ++
+  "  bne x18, x19, .Lcr_same_tx_col_next_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t4, t4, 1\n" ++
+  "  addi t5, t5, -1\n" ++
+  "  j .Lcr_same_tx_col_cmp_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
+  ".Lcr_same_tx_col_match_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
+  "  ld t6, 104(t2)\n" ++
+  ".Lcr_same_tx_col_next_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
+  "  addi t2, t2, 112\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lcr_same_tx_col_loop_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
+  ".Lcr_same_tx_col_done_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
+  "  bnez t6, .Lcr_collision_" ++ (if hasSalt then "f5" else "f0") ++ "\n"
+
+end EvmAsm.Codegen


### PR DESCRIPTION
## Summary
- add a CREATE-family same-transaction collision scan over the live non-storage effect log
- route a second CREATE2 to an address created earlier in the transaction through the existing zero-result collision path
- keep ChildFrameHandlerTails under the file-size cap by extracting the scan assembly into a sibling module

Bead: evm-asm-bbow4.2.5.10.

## Validation
- rtk lake build
- rtk scripts/check-file-size.sh
- rtk scripts/check-unimported.sh
- rtk scripts/check-no-warnings.sh
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|native_decide|bv_decide' EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean EvmAsm/Codegen/Programs/CreateSameTxCollision.lean
- rtk scripts/codegen-eest-stateless-check.sh --filter create2_address_collision --jobs 1 --quiet-passes --run-dir gen-out/eest-bbow4-2-5-create2-collision-final --min-full 1
- rtk scripts/codegen-eest-stateless-check.sh --filter state_gas_create --jobs 1 --quiet-passes --run-dir gen-out/eest-bbow4-2-5-create2-collision-state-gas-min45 --min-full 45

Note: rtk scripts/check-heartbeats-approved.sh still fails on pre-existing .claude/worktrees/agent-a2cf797abef59ac94 heartbeat mentions, not on touched files.

Directed by @pirapira; implemented by Codex.