### PR TITLE
fix(eip8037): seed auth state gas reservoir

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -2289,6 +2289,18 @@ def emitRuntimeDispatcherSetupWithInputAsm (inputAsm : String) : String :=
   "  la x11, evm_state_gas_left\n" ++
   "  sd x9, 0(x11)\n" ++
   ".runtime_tx_gas_no_reservoir:\n" ++
+  -- EIP-7702 validate_authorization refunds state gas into the message reservoir
+  -- when the recovered authority already exists (and, separately, for existing
+  -- delegation code). Transaction-aware callers compute the exact BAL/pre-state
+  -- refund and stage it in runtime_tx_auth_state_refund before this setup runs.
+  "  la x11, runtime_tx_auth_state_refund\n" ++
+  "  ld x9, 0(x11)\n" ++
+  "  beqz x9, .runtime_tx_auth_state_refund_done\n" ++
+  "  la x11, evm_state_gas_left\n" ++
+  "  ld x8, 0(x11)\n" ++
+  "  add x8, x8, x9\n" ++
+  "  sd x8, 0(x11)\n" ++
+  ".runtime_tx_auth_state_refund_done:\n" ++
   ".runtime_tx_gas_done:\n" ++
   "  sd x6, 568(x20)\n" ++          -- env.gasRemaining = execution gas
   "  ld x6, 0(x5)\n" ++            -- x6 = header_len
@@ -2807,6 +2819,8 @@ def emitRuntimeDispatcherDataSectionCore
   "runtime_tx_auth_list_len:\n" ++
   "  .zero 8\n" ++
   "runtime_tx_auth_warm_fn:\n" ++
+  "  .zero 8\n" ++
+  "runtime_tx_auth_state_refund:\n" ++
   "  .zero 8\n" ++
   runtimeSameBlockDelegationCodeData ++
   ".balign 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -593,6 +593,17 @@ def dispatchTxRuntimeCodeFunction : String :=
   -- links secp256k1_recover_pubkey_staged; standalone dispatch probes leave
   -- the pointer 0 and keep the legacy empty-returndata success).
   "  la t4, ecrecover_backend_ptr; la t5, secp256k1_recover_pubkey_staged; sd t5, 0(t4)\n" ++
+  -- EIP-7702 `set_delegation` refunds the NEW_ACCOUNT state component into the
+  -- message state-gas reservoir when the recovered authority already exists.
+  -- The callable dispatcher resets its state-gas cells during setup, so compute
+  -- the refund here and hand it to setup through `runtime_tx_auth_state_refund`.
+  "  la t4, teer_records_ptr; la t5, basr_records; sd t5, 0(t4)\n" ++
+  "  la t4, runtime_tx_auth_state_refund; sd zero, 0(t4)\n" ++
+  "  ld a0, 8(s2); ld a1, 16(s2)\n" ++
+  "  la t4, bv_bal_start; ld a2, 0(t4); la t4, bv_bal_len; ld a3, 0(t4)\n" ++
+  "  la t4, bv_chain_id; ld a4, 0(t4); la t4, current_block_access_index; ld a5, 0(t4)\n" ++
+  "  jal ra, tx_eip7702_existing_authority_refund\n" ++
+  "  la t4, runtime_tx_auth_state_refund; sd a0, 0(t4)\n" ++
   "  addi sp, sp, -32\n" ++
   "  sd s0, 0(sp); sd s1, 8(sp); sd s2, 16(sp); sd s3, 24(sp)\n" ++
   "  jal ra, runtime_dispatcher_call\n" ++


### PR DESCRIPTION
## Summary
- compute the EIP-7702 existing-authority state-gas refund before runtime dispatch
- stage that refund through runtime dispatcher setup so it survives the setup reset
- add the staged refund to evm_state_gas_left after the base tx reservoir split

## Validation
- rtk scripts/codegen-eest-stateless-check.sh --filter auth_state_gas_scales_with_cpsb --jobs 1 --quiet-passes --run-dir gen-out/eest-auth-cpsb-fix --min-full 10
- rtk scripts/codegen-eest-stateless-check.sh --all --filter eip8037_state_creation_gas_cost_increase/state_gas_pricing --jobs 1 --quiet-passes --run-dir gen-out/eest-state-gas-pricing-fix-all --min-full 68
- rtk scripts/codegen-eest-eip8037-state-pricing-high-gas-check.sh --jobs 1
- rtk lake build
- rtk scripts/check-file-size.sh
- rtk scripts/check-unimported.sh
- rtk scripts/check-no-warnings.sh
- forbidden-pattern scan on touched files