### PR TITLE
fix(codegen): preserve precompile staging code base

### DIFF
--- a/EvmAsm/Codegen/Programs/PrecompileRuntime.lean
+++ b/EvmAsm/Codegen/Programs/PrecompileRuntime.lean
@@ -321,13 +321,13 @@ def stagePrecompileInputWindowAsm
   "  add x19, x19, x13\n" ++
   "  li x22, " ++ toString sourceOff ++ "\n" ++
   "  add x19, x19, x22\n" ++
-  precompileFrameAddi "x21" frameOff ++
+  precompileFrameAddi "x24" frameOff ++
   ".L" ++ tag ++ "_copy:\n" ++
   "  beqz x18, .L" ++ tag ++ "_done\n" ++
   "  lbu x23, 0(x19)\n" ++
-  "  sb x23, 0(x21)\n" ++
+  "  sb x23, 0(x24)\n" ++
   "  addi x19, x19, 1\n" ++
-  "  addi x21, x21, 1\n" ++
+  "  addi x24, x24, 1\n" ++
   "  addi x18, x18, -1\n" ++
   "  j .L" ++ tag ++ "_copy\n" ++
   ".L" ++ tag ++ "_done:\n"


### PR DESCRIPTION
## Summary
- keep stagePrecompileInputWindowAsm off dispatcher register x21
- use x24 as the staged-copy destination pointer so precompile success paths resume with the correct code base
- fixes P256 CALLCODE/DELEGATECALL/STATICCALL call_types success propagation after inline precompile handling

## Validation
- lake build
- scripts/codegen-eest-stateless-check.sh --filter call_types --limit 1 --jobs 1 --quiet-passes --run-dir gen-out/eest-coc3g-5-1-x21-fix-one --min-full 1
- scripts/codegen-eest-stateless-check.sh --filter call_types --jobs 1 --quiet-passes --run-dir gen-out/eest-coc3g-5-1-x21-fix-full --min-full 50