### PR TITLE
fix(kzg): emit correct point-eval modulus

### DIFF
--- a/EvmAsm/Codegen/Programs/PrecompileRuntime.lean
+++ b/EvmAsm/Codegen/Programs/PrecompileRuntime.lean
@@ -572,6 +572,7 @@ def precompileSuccessKzgPointEvalAsm
   "  sb x16, 7(x18)\n" ++
   "  li x16, 0x33\n" ++
   "  sb x16, 8(x18)\n" ++
+  "  li x16, 0x39\n" ++
   "  sb x16, 9(x18)\n" ++
   "  li x16, 0xd8\n" ++
   "  sb x16, 10(x18)\n" ++


### PR DESCRIPTION
## Summary
- fix the hand-emitted BLS modulus bytes returned by the KZG point-evaluation precompile
- byte 9 of the modulus returndata is now 0x39, matching BLS_MODULUS, instead of reusing 0x33 from the previous byte

## Validation
- rtk scripts/codegen-eest-stateless-check.sh --filter point_evaluation_precompile --limit 1 --jobs 1 --quiet-passes --run-dir gen-out/eest-coc3g-5-3-1-kzg-modulus-byte-fix-one --min-full 1
- rtk scripts/codegen-eest-stateless-check.sh --filter point_evaluation_precompile --limit 20 --jobs 1 --quiet-passes --run-dir gen-out/eest-coc3g-5-3-1-kzg-modulus-byte-fix-20 --min-full 20 (expected remaining failures: 12/20 full matches; later call-type rows still bv_fail=34)
- rtk lake build

Stacked on #9356 / fix/p256-calltypes-success-propagation.

Bead: evm-asm-coc3g.5.3.1