### PR TITLE
fix(requests): reject overflowed deposit-log capture

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -175,8 +175,9 @@ def blockVerdictReceiptsTail : String :=
   -- Persist the exact log-materializer status before branching:
   -- 0 success, 1 malformed log window or RLP encode failure, 2 bloom helper failure,
   -- 3 block-log arena/capture overflow. For enforced receipt shapes, statuses 1/2
-  -- are malformed supported data and reject; status 3 remains capacity debt and
-  -- conservatively accepts.
+  -- are malformed supported data and reject. A separately recorded block-log overflow
+  -- rejects below before derived-deposit requests_hash verification, since a hidden
+  -- deposit log would make the derived request body incomplete.
   -- .63.1.6.2.3 (slice B): TX-BEARING receipts-consensus enforcement. execution-specs
   -- apply_body recomputes receipt_root = root(receipts_trie) and block_logs_bloom and hard-
   -- rejects on a header mismatch (fork.py 368-371). Encode the materialized per-tx receipt
@@ -187,16 +188,18 @@ def blockVerdictReceiptsTail : String :=
   -- instead of silently accepting. Confirmed root/bloom mismatches reject as before.
   "  bnez a0, .Lbv_receipt_logs_helper_status\n" ++
   -- `bv_block_log_overflow` is recorded separately from the helper return status because
-  -- block_log_window_snapshot can set it before this tail runs. Overflow remains capacity
-  -- debt and never becomes a reject without EEST/spec coverage evidence.
-  "  la t2, bv_block_log_overflow; ld t2, 0(t2); bnez t2, .Lbv_receipts_accept\n" ++
+  -- block_log_window_snapshot can set it before this tail runs. Do not accept on overflow:
+  -- derived EIP-6110 deposits are computed from captured logs, and an uncaptured log could
+  -- be a deposit event. Reject through the requests_hash class instead of trusting an
+  -- incomplete derived deposit body.
+  "  la t2, bv_block_log_overflow; ld t2, 0(t2); bnez t2, .Lbv_requests_hash_fail\n" ++
   -- 8uld3.4: derive EIP-6110 deposit requests from EXECUTION-produced logs and
   -- verify the final requests_hash against the value that the early header-hash
   -- check already committed to (`erh_requests_hash`). This stops trusting the
   -- SSZ execution_requests.deposits body: a block whose SSZ deposits match the
   -- header but whose receipts contain different deposit logs is rejected here.
-  -- The scratch sizes mirror the named block-log and request-body arenas;
-  -- over-capacity remains conservative and is tracked by follow-up capacity beads.
+  -- The scratch sizes mirror the named block-log and request-body arenas; over-capacity
+  -- in the captured block-log stream rejects above rather than skipping this check.
   "  la a0, bv_block_log_descs\n" ++
   "  la t2, bv_block_log_count; ld a1, 0(t2)\n" ++
   "  la a2, bv_block_log_data\n" ++


### PR DESCRIPTION
## Summary
- route bv_block_log_overflow through the derived requests_hash failure path instead of accepting
- update comments around receipt/log materialization to reflect that hidden deposit logs make derived deposits incomplete

Bead: evm-asm-8uld3.2.3.3.3.

## Validation
- lake build EvmAsm.Codegen.Programs.BlockVerdictReceiptsTail
- git diff --check
- edited-file forbidden-pattern scan
- scripts/codegen-zisk-deposit-derivation-e2e-check.sh
- scripts/codegen-zisk-assemble-execution-requests-check.sh
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- scripts/check-forbidden-tactics.sh
- lake build
- scripts/check-no-warnings.sh
- scripts/codegen-eest-valid-multi-type-requests-check.sh (29/29 full match)
- scripts/codegen-eest-stateless-check.sh --filter eip6110_deposits --jobs 1 --quiet-passes --max-failures 5 --run-dir gen-out/eest-8uld3-log-overflow-eip6110 (existing bv37/bv41 frontier remains; no bv55 overflow regression observed)

Note: scripts/codegen-zisk-derive-requests-hash-e2e-check.sh currently fails to link its standalone probe due to missing dispatcher globals unrelated to this change.

Directed by @pirapira; implemented by Codex.