### PR TITLE
fix(eest): stage code-path blob base fee

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictContractStage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictContractStage.lean
@@ -127,9 +127,13 @@ def stageRuntimePayloadCodeFunction : String :=
   "  lbu t6, 0(t4); sb t6, 0(t3); addi t3, t3, 1; addi t4, t4, 1; addi t5, t5, -1; j .Lsrpc_scopy\n" ++
   ".Lsrpc_scopy_done:\n" ++
   -- 3vc2p.3b: M29 block at storage-end (t3 = s0 + co + 24 + storage*64 after the copy loop).
-  -- blob-base-fee@+0 (32) and blob_hash_count@+32 (8) stay 0 (already zeroed; no blob hashes);
-  -- then M29 cur@+40, count@+48, and count*32 hashes@+56 from the staging globals. With
-  -- m29_stage_count=0 this writes cur=count=0 and no hashes (byte-identical to the prior 0 gap).
+  -- BLOBBASEFEE occupies the first 32-byte word in this block; compute it from
+  -- exec.excess_blob_gas just like stage_runtime_payload. The remaining M29 fields
+  -- are blob_hash_count@+32, cur@+40, count@+48, and count*32 hashes@+56.
+  "  mv s5, t3\n" ++
+  "  addi a0, s2, 520; jal ra, bgv_u64le\n" ++
+  "  mv a1, s5; jal ra, amsterdam_blob_gas_price_u256\n" ++
+  "  mv t3, s5\n" ++
   "  la t4, m29_stage_cur;   ld t5, 0(t4); sd t5, 40(t3)\n" ++
   "  la t4, m29_stage_count; ld t6, 0(t4); sd t6, 48(t3)\n" ++
   "  addi t4, t3, 56              # dst = storage_end + 56 (M29 hashes)\n" ++


### PR DESCRIPTION
## Summary
- compute the code-aware runtime payload BLOBBASEFEE word from exec.excess_blob_gas
- keep the existing M29 block layout intact after the 32-byte blob-base-fee slot

## Validation
- lake build EvmAsm.Codegen.Programs.BlockVerdictContractStage
- git diff --check
- focused EIP-4844 excess_blob_gas row now advances from storage/root mismatch (bv_fail=34) to exact gas mismatch (bv_fail=41): recomputed_state_root equals payload_state_root, gas_arena_tx_count=1, gas_arena_runtime_count=1

## Follow-up
The same focused row still false-rejects at the exact gas gate. Temporary debug showed runtime_gas_left=0, tx_status=0, halt_kind=6 (out-of-gas), so the next slice is the SSTORE/EIP-8037 state-gas charge path for this BLOBBASEFEE; SSTORE fixture.

Directed by @pirapira; implemented by Codex.