### PR TITLE
fix(codegen): stage CHAINID for contract dispatch

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictContractStage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictContractStage.lean
@@ -160,6 +160,10 @@ def stageRuntimePayloadCodeFunction : String :=
   "  addi t3, s2, 440\n" ++
   "  ld t4, 0(t3); sd t4, 352(s5); ld t4, 8(t3); sd t4, 360(s5)\n" ++
   "  ld t4, 16(t3); sd t4, 368(s5); ld t4, 24(t3); sd t4, 376(s5)\n" ++
+  -- CHAINID (word 12 -> +384): chain_config_valid captured the execution
+  -- chain id before contract dispatch. Store it as the low limb of the EVM
+  -- stack-word layout, matching the simple-transfer staging path.
+  "  la t3, bv_chain_id; ld t4, 0(t3); sd t4, 384(s5)\n" ++
   -- ADDRESS (word 0 -> +0): recipient (ctx+72, 20-byte BE address), converted
   -- to the EVM stack-word layout (low limb first) used by env loads and storage logs.
   "  addi t3, s1, 72; mv t4, s5; li t5, 0\n" ++


### PR DESCRIPTION
## Summary
- stage the execution chain id into the contract-recipient runtime payload env word
- align stage_runtime_payload_code with the existing simple-transfer CHAINID staging path

## Validation
- lake build EvmAsm.Codegen.Programs.BlockVerdictContractStage
- scripts/codegen-eest-stateless-check.sh --filter chainid --jobs 1 --quiet-passes --max-failures 20 --run-dir gen-out/eest-context-env-chainid-fix (5/5 full match)
- scripts/codegen-eest-stateless-check.sh --filter blobbasefee --jobs 1 --quiet-passes --max-failures 20 --run-dir gen-out/eest-context-env-blobbasefee-main (3/4 full match; residual stack-overflow bv_fail=36, not this CHAINID path)
- scripts/codegen-eest-stateless-check.sh --filter block_info --jobs 1 --quiet-passes --max-failures 20 --run-dir gen-out/eest-context-env-block-info-guard (4/5 full match; residual difficulty bv_fail=37)
- scripts/codegen-eest-stateless-check.sh --filter base_fee_diff_places --jobs 1 --quiet-passes --max-failures 20 --run-dir gen-out/eest-context-env-basefee-guard (stopped after 20 residual failures across nested BASEFEE scenarios; unchanged residual, tracked on bead)
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- scripts/check-no-warnings.sh
- lake build

Bead: evm-asm-coc3g.5.3.2