### PR TITLE
fix(codegen): restore staged parent frame bases

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -2755,6 +2755,11 @@ def emitRuntimeDispatcherEmbeddedHelperData : String :=
   ".balign 32\n" ++
   "frame_call_ctx:\n" ++
   "  .zero 32800\n" ++
+  -- `frame_parent_bases`: exact parent memory/env bases by CHILD depth. Depth 0
+  -- can be a staged stateless replay buffer rather than the global labels.
+  ".balign 16\n" ++
+  "frame_parent_bases:\n" ++
+  "  .zero 16400\n" ++
   -- Call descriptor + zero value word filled by the CALL descent
   -- (`callDescendFallThrough`) and consumed by `call_frame_descend`.
   ".balign 8\n" ++
@@ -3113,6 +3118,8 @@ def runtimeDispatcherStandaloneFrameData : String :=
   "frame_save_area:\n  .zero 16400\n" ++
   ".balign 32\n" ++
   "frame_call_ctx:\n  .zero 32800\n" ++
+  ".balign 16\n" ++
+  "frame_parent_bases:\n  .zero 16400\n" ++
   ".balign 32\n" ++
   "call_frame_arena:\n  .zero " ++ toString (0x29000 : Nat) ++ "\n" ++
   ".balign 8\n" ++

--- a/EvmAsm/Codegen/Programs/CallBalanceGate.lean
+++ b/EvmAsm/Codegen/Programs/CallBalanceGate.lean
@@ -117,6 +117,8 @@ def callBalanceGateData : String :=
   "frame_save_area:\n  .zero 16400\n" ++
   ".balign 32\n" ++
   "frame_call_ctx:\n  .zero 32800\n" ++
+  ".balign 16\n" ++
+  "frame_parent_bases:\n  .zero 16400\n" ++
   ".balign 32\n" ++
   "call_frame_arena:\n  .zero " ++ toString (0x29000 : Nat) ++ "\n" ++
   ".balign 8\n" ++

--- a/EvmAsm/Codegen/Programs/CallFrameDescend.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameDescend.lean
@@ -204,13 +204,14 @@ def callFrameForwardGasFunction : String :=
       2. `frame_depth_push` → child depth d;
       3. save the return-context `frame_call_ctx[d]` = (parent_x12,
          outOff_abs = parent_mem + outOff, outSize, netPopBytes) for `frame_return`;
-      4. `call_frame_enter(d)` → child memory/stack/env bases (+ child mem zero-init);
-      5. `call_frame_set_call_env` (ADDRESS=to, CALLER=parent.ADDRESS, CALLVALUE);
-      6. `call_frame_set_calldata` (alias child calldata into parent memory);
-      7. `call_frame_forward_gas` (EIP-150 63/64 + stipend) → child env.gasRemaining;
-      8. copy the witness context env+576..616 (header/state/codes ptrs+lens) so the
+      4. save the parent memory/env bases in `frame_parent_bases[d]`;
+      5. `call_frame_enter(d)` → child memory/stack/env bases (+ child mem zero-init);
+      6. `call_frame_set_call_env` (ADDRESS=to, CALLER=parent.ADDRESS, CALLVALUE);
+      7. `call_frame_set_calldata` (alias child calldata into parent memory);
+      8. `call_frame_forward_gas` (EIP-150 63/64 + stipend) → child env.gasRemaining;
+      9. copy the witness context env+576..616 (header/state/codes ptrs+lens) so the
          child's by-address handlers (BALANCE/EXTCODE*/the next descent) resolve;
-      9. set the child code base x21=x10=code_ptr (PC at code[0]) and
+     10. set the child code base x21=x10=code_ptr (PC at code[0]) and
          env.codeSize (env+496) = code_len.
 
     On return the live dispatcher registers are repointed to the child frame and
@@ -250,6 +251,13 @@ def callFrameDescendFunction : String :=
   "  sd t2, 8(t0)\n" ++
   "  ld t2, 48(s7); sd t2, 16(t0)   # outSize\n" ++
   "  ld t2, 56(s7); sd t2, 24(t0)   # netPopBytes\n" ++
+  -- Save the exact parent memory/env bases. Depth-0 may be staged by stateless
+  -- replay code instead of the global `evm_memory`/`evm_env` labels.
+  "  la t0, frame_parent_bases\n" ++
+  "  slli t1, s8, 4                 # d * 16\n" ++
+  "  add t0, t0, t1\n" ++
+  "  sd s2, 0(t0)                   # parent memory base\n" ++
+  "  sd s3, 8(t0)                   # parent env base\n" ++
   -- 4. enter the child frame (rebase + zero-init). Stash the returned child
   --    mem/stack/env bases in callee-saved regs — the helper calls below clobber
   --    a0-a4 (= x10/x11/x12/x13/x14), so the live dispatcher regs are set LAST.
@@ -688,6 +696,8 @@ def ziskCallFrameDescendDataSection : String :=
   "frame_save_area:\n  .zero 16400\n" ++
   ".balign 32\n" ++
   "frame_call_ctx:\n  .zero 32800\n" ++
+  ".balign 16\n" ++
+  "frame_parent_bases:\n  .zero 16400\n" ++
   ".balign 8\n" ++
   -- Frame-relative stack-bound cells (descend overwrites them; zeroed stubs here).
   "evm_cur_stack_top:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/CallFrameReturn.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameReturn.lean
@@ -10,8 +10,8 @@
     2. copy `min(outsize, retlen)` returndata bytes into the parent's output region;
     3. pop `evm_call_depth` (child depth d → parent depth d-1);
     4. restore the parent PC / code-base (x10 / x21) from `frame_save_area`;
-    5. recompute the parent register bases x13 (memory) / x20 (env): the existing
-       `evm_memory` / `evm_env` labels for depth 0, else `frame_base(d-1)+off`;
+    5. restore the exact parent register bases x13 (memory) / x20 (env) from
+       `frame_parent_bases[d]`;
     6. restore the parent stack top x12 to `parent_x12 + netPopBytes` (pop the CALL
        args) and write the success word (1 = STOP/RETURN, 0 = REVERT/exceptional);
     7. advance the parent PC one byte past the CALL opcode;
@@ -29,6 +29,8 @@
     `frame_call_ctx`   1025 × 32 B (parent_x12, outoff_abs, outsize, netPopBytes)
                        indexed by the CHILD depth — saved by the descent, consumed
                        here on the matching return.
+    `frame_parent_bases` 1025 × 16 B (parent memory base, parent env base) indexed
+                       by the CHILD depth.
     `call_frame_arena` base for frames 1..1024 (FRAME_STRIDE 0x29000);
     `evm_memory`/`evm_env` the depth-0 register bases.
   Child-frame sub-offsets: frameMemOff=0, frameEnvOff=0x28400.
@@ -205,7 +207,12 @@ def frameReturnFunction : String :=
   "9:\n" ++
   -- Pop the depth: child d -> parent d-1.
   "  la t0, evm_call_depth\n" ++
-  "  ld t1, 0(t0)\n" ++
+  "  ld t1, 0(t0)                   # t1 = child depth d\n" ++
+  "  la t3, frame_parent_bases\n" ++
+  "  slli t4, t1, 4                 # d * 16\n" ++
+  "  add t3, t3, t4\n" ++
+  "  ld x13, 0(t3)                  # exact parent memory base\n" ++
+  "  ld x20, 8(t3)                  # exact parent env base\n" ++
   "  addi t1, t1, -1                # t1 = parent depth\n" ++
   "  sd t1, 0(t0)\n" ++
   -- Restore parent PC (x10) and code base (x21).
@@ -214,10 +221,9 @@ def frameReturnFunction : String :=
   "  add t0, t0, t2\n" ++
   "  ld x10, 0(t0)                  # parent pc (points AT the CALL opcode)\n" ++
   "  ld x21, 8(t0)                  # parent code base\n" ++
-  -- Recompute parent memory base (x13) and env base (x20).
+  -- x13/x20 already hold the exact parent memory/env bases.
   "  bnez t1, 4f\n" ++
-  "  la x13, evm_memory\n" ++
-  "  la x20, evm_env\n" ++
+
   -- Frame-relative stack bounds: restore the guards to the depth-0 global arena.
   "  la t0, evm_cur_stack_top; la t2, evm_stack_top; sd t2, 0(t0)\n" ++
   "  la t0, evm_cur_stack_low; la t2, evm_stack_low; sd t2, 0(t0)\n" ++
@@ -228,9 +234,6 @@ def frameReturnFunction : String :=
   "  mul t2, t2, t3\n" ++
   "  la t3, call_frame_arena\n" ++
   "  add t2, t3, t2               # frame_base(parent_depth)\n" ++
-  "  mv x13, t2                   # + frameMemOff (0)\n" ++
-  "  li t3, 0x28400\n" ++
-  "  add x20, t2, t3              # + frameEnvOff\n" ++
   -- Frame-relative stack bounds: restore the guards to the parent frame's stack.
   "  li t3, 0x18200\n" ++
   "  add t3, t2, t3               # parent stack top = frame_base + frameStackTopOff\n" ++
@@ -314,6 +317,7 @@ def ziskFrameReturnPrologue : String :=
   "  la t1, fr_out; sd t1, 8(t0)\n" ++
   "  sd x0, 16(t0)\n" ++
   "  li t1, 192; sd t1, 24(t0)\n" ++
+  "  la t0, frame_parent_bases; addi t0, t0, 16; la t1, evm_memory; sd t1, 0(t0); la t1, evm_env; sd t1, 8(t0)\n" ++
   "  la x20, fr_child_env\n" ++                       -- child env for the gas read
   "  la t0, fr_child_env; li t1, 50; sd t1, 568(t0)\n" ++   -- child leftover gas = 50
   "  la t0, evm_env;      li t1, 100; sd t1, 568(t0)\n" ++  -- parent gas = 100
@@ -358,6 +362,7 @@ def ziskFrameReturnPrologue : String :=
   "  la t1, fr_out; sd t1, 8(t0)\n" ++
   "  li t1, 1; sd t1, 16(t0)\n" ++
   "  li t1, 160; sd t1, 24(t0)\n" ++
+  "  la t0, frame_parent_bases; addi t0, t0, 32; la t1, call_frame_arena; sd t1, 0(t0); li t1, 0x28400; la t2, call_frame_arena; add t1, t1, t2; sd t1, 8(t0)\n" ++
   -- returndata source: one byte 0xab
   "  la t0, fr_ret; li t1, 0xab; sb t1, 0(t0)\n" ++
   "  la x20, fr_child_env\n" ++
@@ -413,6 +418,8 @@ def ziskFrameReturnDataSection : String :=
   "frame_save_area:\n  .zero 16400\n" ++
   ".balign 32\n" ++
   "frame_call_ctx:\n  .zero 32800\n" ++          -- 1025 × 32 B
+  ".balign 16\n" ++
+  "frame_parent_bases:\n  .zero 16400\n" ++          -- 1025 × 16 B
   ".balign 32\n" ++
   "call_frame_arena:\n  .zero " ++ toString (0x29000 : Nat) ++ "\n" ++
   ".balign 32\n" ++

--- a/EvmAsm/Codegen/Programs/CallFrameRoundtrip.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameRoundtrip.lean
@@ -93,6 +93,8 @@ def callFrameRoundtripData : String :=
   "frame_save_area:\n  .zero 16400\n" ++
   ".balign 32\n" ++
   "frame_call_ctx:\n  .zero 32800\n" ++
+  ".balign 16\n" ++
+  "frame_parent_bases:\n  .zero 16400\n" ++
   ".balign 32\n" ++
   "call_frame_arena:\n  .zero " ++ toString (0x29000 : Nat) ++ "\n" ++
   ".balign 8\n" ++

--- a/EvmAsm/Codegen/Programs/CallValueEffect.lean
+++ b/EvmAsm/Codegen/Programs/CallValueEffect.lean
@@ -107,6 +107,8 @@ def callValueEffectData : String :=
   "frame_save_area:\n  .zero 16400\n" ++
   ".balign 32\n" ++
   "frame_call_ctx:\n  .zero 32800\n" ++
+  ".balign 16\n" ++
+  "frame_parent_bases:\n  .zero 16400\n" ++
   ".balign 32\n" ++
   "call_frame_arena:\n  .zero " ++ toString (0x29000 : Nat) ++ "\n" ++
   ".balign 8\n" ++

--- a/EvmAsm/Codegen/Programs/CreateRoundtrip.lean
+++ b/EvmAsm/Codegen/Programs/CreateRoundtrip.lean
@@ -91,6 +91,8 @@ def createRoundtripData : String :=
   "frame_save_area:\n  .zero 16400\n" ++
   ".balign 32\n" ++
   "frame_call_ctx:\n  .zero 32800\n" ++
+  ".balign 16\n" ++
+  "frame_parent_bases:\n  .zero 16400\n" ++
   ".balign 32\n" ++
   "call_frame_arena:\n  .zero " ++ toString (0x29000 : Nat) ++ "\n" ++
   ".balign 8\n" ++

--- a/EvmAsm/Codegen/Programs/EvmDispatchUnits.lean
+++ b/EvmAsm/Codegen/Programs/EvmDispatchUnits.lean
@@ -241,6 +241,8 @@ def ziskCreationRuntimeWindowsProbeUnit : BuildUnit := {
     "frame_save_area:\n  .zero 16400\n" ++
     ".balign 32\n" ++
     "frame_call_ctx:\n  .zero 32800\n" ++
+    ".balign 16\n" ++
+    "frame_parent_bases:\n  .zero 16400\n" ++
     ".balign 32\n" ++
     "call_frame_arena:\n  .zero " ++ toString (0x29000 : Nat) ++ "\n" ++
     ".balign 8\n" ++
@@ -363,6 +365,8 @@ def ziskEcrecoverPrecompileProbeUnit : BuildUnit := {
     "frame_save_area:\n  .zero 16400\n" ++
     ".balign 32\n" ++
     "frame_call_ctx:\n  .zero 32800\n" ++
+    ".balign 16\n" ++
+    "frame_parent_bases:\n  .zero 16400\n" ++
     ".balign 32\n" ++
     "call_frame_arena:\n  .zero " ++ toString (0x29000 : Nat) ++ "\n" ++
     ".balign 8\n" ++
@@ -453,6 +457,8 @@ def ziskStageSystemCallProbeUnit : BuildUnit := {
     "frame_save_area:\n  .zero 16400\n" ++
     ".balign 32\n" ++
     "frame_call_ctx:\n  .zero 32800\n" ++
+    ".balign 16\n" ++
+    "frame_parent_bases:\n  .zero 16400\n" ++
     ".balign 32\n" ++
     "call_frame_arena:\n  .zero " ++ toString (0x29000 : Nat) ++ "\n" ++
     ".balign 8\n" ++
@@ -543,6 +549,8 @@ def ziskDeriveWithdrawalRequestsProbeUnit : BuildUnit := {
     "frame_save_area:\n  .zero 16400\n" ++
     ".balign 32\n" ++
     "frame_call_ctx:\n  .zero 32800\n" ++
+    ".balign 16\n" ++
+    "frame_parent_bases:\n  .zero 16400\n" ++
     ".balign 32\n" ++
     "call_frame_arena:\n  .zero " ++ toString (0x29000 : Nat) ++ "\n" ++
     ".balign 8\n" ++
@@ -633,6 +641,8 @@ def ziskDeriveConsolidationRequestsProbeUnit : BuildUnit := {
     "frame_save_area:\n  .zero 16400\n" ++
     ".balign 32\n" ++
     "frame_call_ctx:\n  .zero 32800\n" ++
+    ".balign 16\n" ++
+    "frame_parent_bases:\n  .zero 16400\n" ++
     ".balign 32\n" ++
     "call_frame_arena:\n  .zero " ++ toString (0x29000 : Nat) ++ "\n" ++
     ".balign 8\n" ++
@@ -760,6 +770,8 @@ def ziskDeriveRequestsHashE2EProbeUnit : BuildUnit := {
     "frame_save_area:\n  .zero 16400\n" ++
     ".balign 32\n" ++
     "frame_call_ctx:\n  .zero 32800\n" ++
+    ".balign 16\n" ++
+    "frame_parent_bases:\n  .zero 16400\n" ++
     ".balign 32\n" ++
     "call_frame_arena:\n  .zero " ++ toString (0x29000 : Nat) ++ "\n" ++
     ".balign 8\n" ++
@@ -851,6 +863,8 @@ def ziskDeriveBlockSystemRequestsProbeUnit : BuildUnit := {
     "frame_save_area:\n  .zero 16400\n" ++
     ".balign 32\n" ++
     "frame_call_ctx:\n  .zero 32800\n" ++
+    ".balign 16\n" ++
+    "frame_parent_bases:\n  .zero 16400\n" ++
     ".balign 32\n" ++
     "call_frame_arena:\n  .zero " ++ toString (0x29000 : Nat) ++ "\n" ++
     ".balign 8\n" ++
@@ -966,6 +980,8 @@ def ziskSstoreClearGasProbeUnit : BuildUnit := {
     "frame_save_area:\n  .zero 16400\n" ++
     ".balign 32\n" ++
     "frame_call_ctx:\n  .zero 32800\n" ++
+    ".balign 16\n" ++
+    "frame_parent_bases:\n  .zero 16400\n" ++
     ".balign 32\n" ++
     "call_frame_arena:\n  .zero " ++ toString (0x29000 : Nat) ++ "\n" ++
     ".balign 8\n" ++


### PR DESCRIPTION
## Summary
- save exact parent memory/env bases in a child-depth `frame_parent_bases` table during CALL descent
- restore those bases in `frame_return` instead of recomputing depth-0 from global `evm_memory`/`evm_env`
- add the new table to the dispatcher/helper standalone data sections

## Verification
- `lake build EvmAsm.Codegen.Programs.CallFrameReturn EvmAsm.Codegen.Programs.CallFrameDescend EvmAsm.Codegen.Dispatch`
- `lake exe codegen --program zisk_stateless_verdict_v2 --halt linux93 -o gen-out/basefee-parent-bases-fixed`
- `scripts/codegen-eest-stateless-check.sh --filter base_fee_diff_places --jobs 1 --quiet-passes --max-failures 1 --run-dir gen-out/eest-context-env-basefee-fixed` now reaches 14 full matches before the next exposed failure at `d24`; the prior first failure is fixed
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- `lake build`

## Known remaining failures
- `scripts/codegen-eest-stateless-check.sh --filter base_fee_diff_places ... --max-failures 1` next fails at `00014_test_base_fee_diff_places_fork_Amsterdam-blockchain_test_from_state_test-d24__b0` with `bv_fail=34`, root/tail match, success mismatch
- `scripts/codegen-zisk-frame-return-check.sh` still reports the REVERT state-gas-left probe mismatch (`got 0x220`, expected `0x22b`)
- `scripts/codegen-zisk-call-frame-descend-check.sh` still does not link standalone because of unresolved helper symbols in the descend closure

Stacked on #9364.

Directed by @pirapira; implemented by Codex.