### PR TITLE
feat(rv64/rlp): Phase 6 decode⨾write + full read⨾decode⨾write pipeline (steps 60-61)

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -138,3 +138,5 @@ import EvmAsm.Rv64.RLP.Phase1ToPhase3SingleByte
 import EvmAsm.Rv64.RLP.Phase1StepToPhase3ShortString
 import EvmAsm.Rv64.RLP.Phase6ReadDecode
 import EvmAsm.Rv64.RLP.Phase6WriteOutput
+import EvmAsm.Rv64.RLP.Phase6DecodeWrite
+import EvmAsm.Rv64.RLP.Phase6Pipeline

--- a/EvmAsm/Rv64/RLP/Phase6DecodeWrite.lean
+++ b/EvmAsm/Rv64/RLP/Phase6DecodeWrite.lean
@@ -1,0 +1,181 @@
+/-
+  EvmAsm.Rv64.RLP.Phase6DecodeWrite
+
+  EL.3 / Phase 6 — `decode ⨾ write_output`. Composes the end-to-end RLP-list schema decoder
+  (`decode_encoded_short_list_schema_values`, which decodes the record into the output
+  `bytesRegion` and recovers every field value via `schemaScalarValues`) with the `write_output`
+  wrapper (`rlp_phase6_write_output_spec_within_exact`), so the decoded output region is committed
+  to the host public-values stream.
+
+  The decoder's `schemaINV` post exposes the scratch registers as `regOwn`, so the write wrapper
+  is first lifted to a `regOwn` precondition (`rlp_phase6_write_output_spec_regOwn`) before the
+  `cpsTripleWithin_seq`; the decoder-leftover state (input pointer/region, x0/x12/x14/x15) is
+  framed through the write, and the ECALL instruction + initial public values are framed through
+  the decode. The reshaping between the decoder post and the write pre is the standard
+  `cpsTripleWithin_weaken … xperm_hyp` permutation (same idiom as `unified_scalar_field_decode_and_store`).
+-/
+
+import EvmAsm.Rv64.RLP.Phase6WriteOutput
+import EvmAsm.Rv64.RLP.SchemaDecodeValues
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL.RLP
+open EvmAsm.Rv64.Tactics
+
+-- ============================================================================
+-- `regOwn`-precondition write wrapper: x10/x11/x5 abstracted so the wrapper is
+-- callable directly on a decoder's `schemaINV` post (which releases them as `regOwn`).
+-- ============================================================================
+
+/-- The `write_output` wrapper with its three clobbered scratch registers (`x10`, `x11`, `x5`)
+    owned abstractly (`regOwn`) in the precondition — the form a decoder's `schemaINV` post
+    supplies. Derived from `rlp_phase6_write_output_spec_within_exact` by peeling each scratch
+    register via `cpsTripleWithin_of_forall_regIs_to_regOwn`. -/
+theorem rlp_phase6_write_output_spec_regOwn
+    (rOut : Reg) (outBase : Word) (out old : List (BitVec 8)) (base : Word)
+    (halign : outBase.toNat % 8 = 0) (hover : outBase.toNat + out.length < 2 ^ 64) :
+    cpsTripleWithin 4 base (base + 16)
+      (CodeReq.ofProg base (rlp_phase6_write_output_prog rOut (BitVec.ofNat 64 out.length)))
+      ((rOut ↦ᵣ outBase) ** regOwn .x10 ** regOwn .x11 ** regOwn .x5 **
+        (base + 12 ↦ᵢ .ECALL) ** bytesRegion outBase out ** publicValuesIs old)
+      ((rOut ↦ᵣ outBase) ** (.x10 ↦ᵣ outBase) ** (.x11 ↦ᵣ (BitVec.ofNat 64 out.length)) **
+        (.x5 ↦ᵣ (BitVec.ofNat 64 0x10)) ** (base + 12 ↦ᵢ .ECALL) **
+        bytesRegion outBase out ** publicValuesIs (old ++ out)) := by
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x5)
+      (P := (rOut ↦ᵣ outBase) ** regOwn .x10 ** regOwn .x11 **
+        (base + 12 ↦ᵢ .ECALL) ** bytesRegion outBase out ** publicValuesIs old)
+      (fun v5 => ?_))
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x11)
+      (P := (rOut ↦ᵣ outBase) ** regOwn .x10 ** (.x5 ↦ᵣ v5) **
+        (base + 12 ↦ᵢ .ECALL) ** bytesRegion outBase out ** publicValuesIs old)
+      (fun v11 => ?_))
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x10)
+      (P := (rOut ↦ᵣ outBase) ** (.x11 ↦ᵣ v11) ** (.x5 ↦ᵣ v5) **
+        (base + 12 ↦ᵢ .ECALL) ** bytesRegion outBase out ** publicValuesIs old)
+      (fun v10 => ?_))
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+    (rlp_phase6_write_output_spec_within_exact rOut outBase out old v10 v11 v5 base halign hover)
+
+set_option maxRecDepth 8000 in
+/-- **Decode a short-list RLP record, then commit it.** Runs the end-to-end schema decoder
+    (`decode_encoded_short_list_schema_values`) — decoding the record into `bytesRegion outBase
+    (schemaOut out specs)` and recovering every field value (`schemaScalarValues`) — then the
+    `write_output` wrapper, appending the decoded output region to the host public-values stream
+    (`publicValuesIs old → publicValuesIs (old ++ schemaOut out specs)`). The write code sits at
+    `base_w := (base+148) + schemaSize specs` (the decoder's exit). -/
+theorem rlp_phase6_decode_and_write
+    (base regionBase outBase : Word) (rOut : Reg) (bs : List Byte) (O : Nat)
+    (specs : List FieldSpec) (out old : List Byte) (outLen : Nat) (tail : List Byte)
+    (v5Old v10 v11Old v12Old v14Old v15Old : Word)
+    (hsize : (schemaEncBytes specs).length ≤ 55)
+    (hbs : bs.drop O = encode (.list (schemaItems specs)) ++ tail)
+    (hcore : ∀ f, f ∈ specs → fieldCoreValid outLen f)
+    (halign : regionBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hlen : out.length = outLen)
+    (hdov : outBase.toNat + outLen < 2 ^ 64)
+    (hdval : ∀ i, i < outLen → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + (148 + schemaSize specs + 16) < 2 ^ 64) :
+    cpsTripleWithin ((61 + schemaSteps specs) + 4) base
+        (((base + 148) + BitVec.ofNat 64 (schemaSize specs)) + 16)
+      ((((CodeReq.singleton base (.LBU .x5 .x13 0)).union
+          (CodeReq.ofProg (base + 4) unified_decoder_prog)).union
+          (schemaCR (base + 148) rOut specs)).union
+        (CodeReq.ofProg ((base + 148) + BitVec.ofNat 64 (schemaSize specs))
+          (rlp_phase6_write_output_prog rOut (BitVec.ofNat 64 (schemaOut out specs).length))))
+      (((.x5 ↦ᵣ v5Old) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
+        (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (.x14 ↦ᵣ v14Old) **
+        (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs) **
+       ((rOut ↦ᵣ outBase) ** bytesRegion outBase out) **
+       ((((base + 148) + BitVec.ofNat 64 (schemaSize specs)) + 12 ↦ᵢ .ECALL) **
+        publicValuesIs old))
+      (((rOut ↦ᵣ outBase) ** (.x10 ↦ᵣ outBase) **
+        (.x11 ↦ᵣ (BitVec.ofNat 64 (schemaOut out specs).length)) **
+        (.x5 ↦ᵣ (BitVec.ofNat 64 0x10)) **
+        (((base + 148) + BitVec.ofNat 64 (schemaSize specs)) + 12 ↦ᵢ .ECALL) **
+        bytesRegion outBase (schemaOut out specs) **
+        publicValuesIs (old ++ schemaOut out specs)) **
+       ((.x0 ↦ᵣ (0 : Word)) ** regOwn .x12 **
+        (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 ((O + 1) + schemaEnc specs))) **
+        regOwn .x14 ** regOwn .x15 ** bytesRegion regionBase bs))
+    ∧ schemaScalarValues bs (O + 1) specs := by
+  -- The decoder.
+  obtain ⟨t_dec, hvals⟩ := decode_encoded_short_list_schema_values base regionBase outBase rOut
+    bs O specs out outLen tail v5Old v10 v11Old v12Old v14Old v15Old hsize hbs hcore halign hover
+    hwin hdalign hlen hdov hdval (by omega)
+  refine ⟨?_, hvals⟩
+  -- Frame the ECALL instruction + the initial public values through the decode.
+  have t_dec_f := cpsTripleWithin_frameR
+    (((((base + 148) + BitVec.ofNat 64 (schemaSize specs)) + 12 ↦ᵢ .ECALL)) ** publicValuesIs old)
+    (by exact pcFree_sepConj pcFree_instrAt pcFree_publicValuesIs) t_dec
+  rw [schemaINV] at t_dec_f
+  -- The decoded output region has length `outLen` (= out.length).
+  have hsout : (schemaOut out specs).length = out.length := schemaOut_length out specs
+  -- The write wrapper (regOwn scratch), framed with the decoder-leftover state it doesn't touch.
+  have s_write0 := rlp_phase6_write_output_spec_regOwn rOut outBase (schemaOut out specs) old
+    ((base + 148) + BitVec.ofNat 64 (schemaSize specs))
+    hdalign (by rw [hsout, hlen]; exact hdov)
+  -- Frame the decoder-leftover state (input region + scratch the write doesn't touch) onto the
+  -- write wrapper.
+  have s_write := cpsTripleWithin_frameR
+    ((.x0 ↦ᵣ (0 : Word)) ** regOwn .x12 **
+      (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 ((O + 1) + schemaEnc specs))) **
+      regOwn .x14 ** regOwn .x15 ** bytesRegion regionBase bs)
+    (by exact pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regOwn
+      (pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regOwn
+        (pcFree_sepConj pcFree_regOwn (bytesRegion_pcFree _ _))))))
+    s_write0
+  -- Disjointness: decoder CR (base .. base_w) ⊥ write CR (at base_w), by code ranges
+  -- (`crDisjoint`/`seqFrame` time out on the opaque 36-instruction decoder `ofProg`).
+  have hbw : ((base + 148) + BitVec.ofNat 64 (schemaSize specs)).toNat
+      = base.toNat + 148 + schemaSize specs := by
+    have : schemaSize specs < 2 ^ 64 := by omega
+    bv_omega
+  have hd : ((((CodeReq.singleton base (.LBU .x5 .x13 0)).union
+        (CodeReq.ofProg (base + 4) unified_decoder_prog)).union
+        (schemaCR (base + 148) rOut specs))).Disjoint
+      (CodeReq.ofProg ((base + 148) + BitVec.ofNat 64 (schemaSize specs))
+        (rlp_phase6_write_output_prog rOut (BitVec.ofNat 64 (schemaOut out specs).length))) := by
+    refine codeReq_disjoint_of_ranges _ _
+      ((base + 148) + BitVec.ofNat 64 (schemaSize specs)).toNat ?_ ?_
+    · intro a ha
+      rw [hbw] at ha
+      have h1 : CodeReq.singleton base (.LBU .x5 .x13 0) a = none :=
+        CodeReq.singleton_miss (by bv_omega)
+      have h2 : CodeReq.ofProg (base + 4) unified_decoder_prog a = none :=
+        CodeReq.ofProg_none_range_len _ _ 36 a unified_decoder_prog_length
+          (fun k hk => by bv_omega)
+      have h3 : schemaCR (base + 148) rOut specs a = none :=
+        schemaCR_none_above rOut specs (base + 148) a (by bv_omega) (by bv_omega)
+      simp only [CodeReq.union, h1, h2, h3]
+    · intro a ha
+      rw [hbw] at ha
+      exact CodeReq.ofProg_none_range_len _ _ 4 a rfl (fun k hk => by bv_omega)
+  -- Provide `s_write` first so the middle assertion is pinned (concrete) before the reshape;
+  -- the nested `refine` then resolves the target before the `xperm` goal is elaborated.
+  refine cpsTripleWithin_seq hd ?_ s_write
+  refine cpsTripleWithin_weaken ?_ ?_ t_dec_f
+  · intro h hp; xperm_hyp hp
+  · intro h hp; xperm_hyp hp
+
+-- Concrete cross-check: decode the short RLP list `[0xc4, 0x2a, 0x82, 0x01, 0x02]`
+-- (= `RLP.list [bytes [0x2a], bytes [0x01,0x02]]`) at region `0x2000` into a 24-byte output
+-- struct at `0x3000` (via `x18`), then commit the struct to the public-values stream.
+example :=
+  rlp_phase6_decode_and_write (0x1000 : Word) (0x2000 : Word) (0x3000 : Word) .x18
+    [(0xc4 : Byte), 0x2a, 0x82, 0x01, 0x02] 0
+    [⟨true, [(0x2a : Byte)], 0, 0⟩, ⟨false, [(0x01 : Byte), (0x02 : Byte)], 8, 8⟩]
+    (List.replicate 24 (0 : Byte)) [] 24 []
+    0 0 0 0 0 0
+    (by decide) (by decide)
+    (by intro f hf; fin_cases hf <;> exact ⟨by decide, by decide, by decide⟩)
+    (by decide) (by decide) (by decide) (by decide) (by simp) (by decide) (by decide) (by decide)
+
+end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Phase6Pipeline.lean
+++ b/EvmAsm/Rv64/RLP/Phase6Pipeline.lean
@@ -1,0 +1,168 @@
+/-
+  EvmAsm.Rv64.RLP.Phase6Pipeline
+
+  EL.3 / Phase 6 — the **complete top-level RLP pipeline**: `read_input ⨾ decode ⨾ write_output`.
+  Composes the read⨾decode unit (`rlp_phase6_read_and_decode`) with the `write_output` wrapper
+  (`rlp_phase6_write_output_spec_regOwn`): the host `read_input` syscall hands the RLP buffer to
+  the schema decoder, which decodes the record into the output `bytesRegion`, and `write_output`
+  commits that region to the host public-values stream.
+
+  From the host-ABI input contract (`inputBufBaseIs buf_base`, `privateInputIs input`,
+  `bytesRegion buf_base input` with `input = encode (.list (schemaItems specs)) ++ tail`), the whole
+  program runs end to end in `(5 + (61 + schemaSteps specs)) + 4` steps, leaving
+  `publicValues = old ++ schemaOut out specs` and recovering every field value
+  (`schemaScalarValues`). This closes the RLP arc: RLP bytes in → decode → committed output, with a
+  kernel-checkable round-trip proof against the pure RLP spec.
+-/
+
+import EvmAsm.Rv64.RLP.Phase6ReadDecode
+import EvmAsm.Rv64.RLP.Phase6DecodeWrite
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL.RLP
+open EvmAsm.Rv64.Tactics
+
+set_option maxRecDepth 8000 in
+/-- **The full RLP pipeline: read ⨾ decode ⨾ write.** From the host-ABI input contract, run the
+    `read_input` syscall + `LD` (input-pointer hand-off), the schema decoder, and the `write_output`
+    syscall. The decoded output region is committed to the public-values stream
+    (`publicValuesIs old → publicValuesIs (old ++ schemaOut out specs)`) and every field value is
+    recovered (`schemaScalarValues`). The write code sits at `base_w := (base+20+148) + schemaSize`. -/
+theorem rlp_phase6_read_decode_write
+    (ptr_ptr_off size_ptr_off : BitVec 12) (rOut : Reg)
+    (sp buf_base outBase old_ptr old_size v10 v11 v5 v13 v14 v15 : Word)
+    (input : List (BitVec 8)) (out old : List Byte) (outLen : Nat) (tail : List Byte)
+    (specs : List FieldSpec) (base : Word)
+    (hvalid_a0 : isValidDwordAccess (sp + signExtend12 ptr_ptr_off) = true)
+    (hvalid_a1 : isValidDwordAccess (sp + signExtend12 size_ptr_off) = true)
+    (hsize : (schemaEncBytes specs).length ≤ 55)
+    (hinput : input = encode (.list (schemaItems specs)) ++ tail)
+    (hcore : ∀ f, f ∈ specs → fieldCoreValid outLen f)
+    (halign : buf_base.toNat % 8 = 0)
+    (hover : buf_base.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (buf_base + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hlen : out.length = outLen)
+    (hdov : outBase.toNat + outLen < 2 ^ 64)
+    (hdval : ∀ i, i < outLen → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + (20 + 148 + schemaSize specs + 16) < 2 ^ 64) :
+    cpsTripleWithin ((5 + (61 + schemaSteps specs)) + 4) base
+        (((base + 20 + 148) + BitVec.ofNat 64 (schemaSize specs)) + 16)
+      ((((CodeReq.ofProg base (rlp_phase4_read_input_len_prog ptr_ptr_off size_ptr_off)).union
+          (CodeReq.singleton (base + 16) (.LD .x13 .x12 ptr_ptr_off))).union
+        (((CodeReq.singleton (base + 20) (.LBU .x5 .x13 0)).union
+            (CodeReq.ofProg (base + 20 + 4) unified_decoder_prog)).union
+          (schemaCR (base + 20 + 148) rOut specs))).union
+        (CodeReq.ofProg ((base + 20 + 148) + BitVec.ofNat 64 (schemaSize specs))
+          (rlp_phase6_write_output_prog rOut (BitVec.ofNat 64 (schemaOut out specs).length))))
+      ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x5 ↦ᵣ v5) ** (.x13 ↦ᵣ v13) **
+        (.x0 ↦ᵣ (0 : Word)) ** (.x14 ↦ᵣ v14) ** (.x15 ↦ᵣ v15) ** (rOut ↦ᵣ outBase) **
+        (base + 12 ↦ᵢ .ECALL) **
+        ((sp + signExtend12 ptr_ptr_off) ↦ₘ old_ptr) **
+        ((sp + signExtend12 size_ptr_off) ↦ₘ old_size) **
+        inputBufBaseIs buf_base ** privateInputIs input **
+        bytesRegion buf_base input ** bytesRegion outBase out **
+        ((((base + 20 + 148) + BitVec.ofNat 64 (schemaSize specs)) + 12 ↦ᵢ .ECALL) **
+         publicValuesIs old))
+      (((rOut ↦ᵣ outBase) ** (.x10 ↦ᵣ outBase) **
+        (.x11 ↦ᵣ (BitVec.ofNat 64 (schemaOut out specs).length)) **
+        (.x5 ↦ᵣ (BitVec.ofNat 64 0x10)) **
+        (((base + 20 + 148) + BitVec.ofNat 64 (schemaSize specs)) + 12 ↦ᵢ .ECALL) **
+        bytesRegion outBase (schemaOut out specs) **
+        publicValuesIs (old ++ schemaOut out specs)) **
+       ((.x0 ↦ᵣ (0 : Word)) ** regOwn .x12 **
+        (.x13 ↦ᵣ (buf_base + BitVec.ofNat 64 ((0 + 1) + schemaEnc specs))) **
+        regOwn .x14 ** regOwn .x15 ** bytesRegion buf_base input **
+        (base + 12 ↦ᵢ .ECALL) **
+        ((sp + signExtend12 ptr_ptr_off) ↦ₘ buf_base) **
+        ((sp + signExtend12 size_ptr_off) ↦ₘ (BitVec.ofNat 64 input.length)) **
+        inputBufBaseIs buf_base ** privateInputIs input))
+    ∧ schemaScalarValues input (0 + 1) specs := by
+  -- read ⨾ decode (steps 54–55).
+  obtain ⟨t_rd, hvals⟩ := rlp_phase6_read_and_decode ptr_ptr_off size_ptr_off rOut sp buf_base
+    outBase old_ptr old_size v10 v11 v5 v13 v14 v15 input out outLen tail specs base
+    hvalid_a0 hvalid_a1 hsize hinput hcore halign hover hwin hdalign hlen hdov hdval (by omega)
+  refine ⟨?_, hvals⟩
+  -- Frame the write ECALL instruction + initial public values through read⨾decode.
+  have t_rd_f := cpsTripleWithin_frameR
+    (((((base + 20 + 148) + BitVec.ofNat 64 (schemaSize specs)) + 12 ↦ᵢ .ECALL)) **
+      publicValuesIs old)
+    (by exact pcFree_sepConj pcFree_instrAt pcFree_publicValuesIs) t_rd
+  rw [schemaINV] at t_rd_f
+  have hsout : (schemaOut out specs).length = out.length := schemaOut_length out specs
+  -- The write wrapper (regOwn scratch), framed with all the read⨾decode-leftover state.
+  have s_write0 := rlp_phase6_write_output_spec_regOwn rOut outBase (schemaOut out specs) old
+    ((base + 20 + 148) + BitVec.ofNat 64 (schemaSize specs))
+    hdalign (by rw [hsout, hlen]; exact hdov)
+  have s_write := cpsTripleWithin_frameR
+    ((.x0 ↦ᵣ (0 : Word)) ** regOwn .x12 **
+      (.x13 ↦ᵣ (buf_base + BitVec.ofNat 64 ((0 + 1) + schemaEnc specs))) **
+      regOwn .x14 ** regOwn .x15 ** bytesRegion buf_base input **
+      (base + 12 ↦ᵢ .ECALL) **
+      ((sp + signExtend12 ptr_ptr_off) ↦ₘ buf_base) **
+      ((sp + signExtend12 size_ptr_off) ↦ₘ (BitVec.ofNat 64 input.length)) **
+      inputBufBaseIs buf_base ** privateInputIs input)
+    (by
+      repeat (first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs | exact pcFree_regOwn | exact pcFree_instrAt
+        | exact pcFree_memIs | exact pcFree_inputBufBaseIs | exact pcFree_privateInputIs
+        | exact bytesRegion_pcFree _ _))
+    s_write0
+  -- Disjointness: read⨾decode CR (base .. base_w) ⊥ write CR (at base_w), by ranges.
+  have hbw : ((base + 20 + 148) + BitVec.ofNat 64 (schemaSize specs)).toNat
+      = base.toNat + 20 + 148 + schemaSize specs := by
+    have : schemaSize specs < 2 ^ 64 := by omega
+    bv_omega
+  have hd : ((((CodeReq.ofProg base (rlp_phase4_read_input_len_prog ptr_ptr_off size_ptr_off)).union
+        (CodeReq.singleton (base + 16) (.LD .x13 .x12 ptr_ptr_off))).union
+        (((CodeReq.singleton (base + 20) (.LBU .x5 .x13 0)).union
+            (CodeReq.ofProg (base + 20 + 4) unified_decoder_prog)).union
+          (schemaCR (base + 20 + 148) rOut specs)))).Disjoint
+      (CodeReq.ofProg ((base + 20 + 148) + BitVec.ofNat 64 (schemaSize specs))
+        (rlp_phase6_write_output_prog rOut (BitVec.ofNat 64 (schemaOut out specs).length))) := by
+    refine codeReq_disjoint_of_ranges _ _
+      ((base + 20 + 148) + BitVec.ofNat 64 (schemaSize specs)).toNat ?_ ?_
+    · intro a ha
+      rw [hbw] at ha
+      have hp1 : CodeReq.ofProg base (rlp_phase4_read_input_len_prog ptr_ptr_off size_ptr_off) a = none :=
+        CodeReq.ofProg_none_range_len base _ 4 a
+          (rlp_phase4_read_input_len_prog_length ptr_ptr_off size_ptr_off) (fun k hk => by bv_omega)
+      have hp2 : CodeReq.singleton (base + 16) (.LD .x13 .x12 ptr_ptr_off) a = none :=
+        CodeReq.singleton_miss (by bv_omega)
+      have hq1 : CodeReq.singleton (base + 20) (.LBU .x5 .x13 0) a = none :=
+        CodeReq.singleton_miss (by bv_omega)
+      have hq2 : CodeReq.ofProg (base + 20 + 4) unified_decoder_prog a = none :=
+        CodeReq.ofProg_none_range_len (base + 20 + 4) unified_decoder_prog 36 a
+          unified_decoder_prog_length (fun k hk => by bv_omega)
+      have hq3 : schemaCR (base + 20 + 148) rOut specs a = none :=
+        schemaCR_none_above rOut specs (base + 20 + 148) a (by bv_omega) (by bv_omega)
+      simp only [CodeReq.union, hp1, hp2, hq1, hq2, hq3]
+    · intro a ha
+      rw [hbw] at ha
+      exact CodeReq.ofProg_none_range_len _ _ 4 a rfl (fun k hk => by bv_omega)
+  -- Provide `s_write` first so the middle assertion is concrete before the reshape.
+  refine cpsTripleWithin_seq hd ?_ s_write
+  refine cpsTripleWithin_weaken ?_ ?_ t_rd_f
+  · intro h hp; xperm_hyp hp
+  · intro h hp; xperm_hyp hp
+
+-- Concrete end-to-end cross-check of the WHOLE pipeline: the host supplies the short RLP list
+-- `[0xc4, 0x2a, 0x82, 0x01, 0x02]` (= `RLP.list [bytes [0x2a], bytes [0x01,0x02]]`) at the input
+-- buffer `0x2000` (via the `read_input` syscall through SP-relative cells at `0x5000`/`0x5008`);
+-- the program decodes it into the 24-byte output struct at `0x3000` (via `x18`) and commits that
+-- struct to the public-values stream. Program base `0x1000`.
+example :=
+  rlp_phase6_read_decode_write (0 : BitVec 12) (8 : BitVec 12) .x18
+    (0x5000 : Word) (0x2000 : Word) (0x3000 : Word) 0 0 0 0 0 0 0 0
+    [(0xc4 : Byte), 0x2a, 0x82, 0x01, 0x02]
+    (List.replicate 24 (0 : Byte)) [] 24 []
+    [⟨true, [(0x2a : Byte)], 0, 0⟩, ⟨false, [(0x01 : Byte), (0x02 : Byte)], 8, 8⟩]
+    (0x1000 : Word)
+    (by decide) (by decide) (by decide) (by decide)
+    (by intro f hf; fin_cases hf <;> exact ⟨by decide, by decide, by decide⟩)
+    (by decide) (by decide) (by decide) (by decide) (by simp) (by decide) (by decide) (by decide)
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -1873,9 +1873,12 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     with the pure RLP spec. A concrete legacy-tx/header decoder is now a direct caller instantiation
     (output layout = caller-chosen field offsets). Remaining beyond the decoder: Phase 6 host-I/O pipeline
     (`read_input → decode → write_output`).
-- **Phase 6: Top-level pipeline (`read_input` -> decode -> `write_output`)** — IN PROGRESS.
-  Generic decode-to-output demo (input-buffer contract = host-ABI precondition `bytesRegion inputBufBase
-  privateInput`). Roadmap: read-input hand-off → read⨾decode → write_output + decode⨾write → full pipeline.
+- **🎉 Phase 6 COMPLETE — RLP pipeline end-to-end.** The full top-level pipeline
+  (`read_input → decode → write_output`) is proven: RLP bytes arrive via the host `read_input`
+  syscall, are decoded into the output `bytesRegion`, and the result is committed to the host
+  public-values stream via `write_output`, coinciding with the pure RLP spec
+  (`schemaScalarValues`). Input-buffer contract = host-ABI precondition `bytesRegion inputBufBase
+  privateInput`.
   - ✅ **Step 54 — read-input pointer hand-off** (`Phase6ReadDecode.lean`, `rlp_phase6_read_input_ptr`):
     composes the `read_input` Phase-4 wrapper (`rlp_phase4_read_input_len_spec_within_exact`) with
     `LD x13, x12, ptr_ptr_off`, loading the returned `inputBufBase` into `x13` (the decoder's input
@@ -1892,10 +1895,34 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     `bytesRegion base bs` holds, `readBytes base bs.length = bs` (reconciles byte-granular `readBytes` with
     the dword-packed region via `bytesRegion_dword_at` + `extractByte_packBytes` + an offset induction).
     Connects the decoder's `bytesRegion` output to what `write_output` (which uses `readBytes`) emits.
-  - **Next (write-half remaining):** a `publicValues`-update `holdsFor` framing lemma (mirroring
-    `holdsFor_sepConj_memIs_setMem`) → CPS-level `write_output` ECALL spec (mirror
-    `ecall_read_input_spec_gen_within`, folding in the bridge) → `write_output` wrapper → `decode ⨾
-    write_output` → full `read ⨾ decode ⨾ write` pipeline + concrete example.
+  - ✅ **Step 57 — `publicValues`-append framing** (`Phase6WriteOutput.lean`,
+    `holdsFor_sepConj_publicValuesIs_appendPublicValues` + `compatibleWith_appendPublicValues`): the
+    write-half analogue of `holdsFor_sepConj_memIs_setMem` — threads the host `write_output` append
+    (`publicValuesIs vals → publicValuesIs (vals ++ extra)`) through a separation-logic frame.
+  - ✅ **Step 58 — CPS-level `write_output` ECALL spec** (`Phase6WriteOutput.lean`,
+    `ecall_write_output_spec_gen_within`): the t0=0x10 syscall as a `cpsTripleWithin 1`, folding in
+    `readBytes_of_bytesRegion` so a held `bytesRegion ptr bs` (x11 = bs.length) emits exactly `bs`:
+    `publicValuesIs old → publicValuesIs (old ++ bs)`. Mirror of `ecall_read_input_spec_gen_within`.
+  - ✅ **Step 59 — `write_output` wrapper** (`Phase6WriteOutput.lean`, `rlp_phase6_write_output_prog`
+    + `rlp_phase6_write_output_spec_within_exact`): the 4-instruction wrapper
+    (`ADDI x10,rOut,0; LI x11,len; LI x5,0x10; ECALL`), mirror of
+    `rlp_phase4_read_input_len_spec_within_exact`.
+  - ✅ **Step 60 — `decode ⨾ write_output`** (`Phase6DecodeWrite.lean`, `rlp_phase6_decode_and_write`
+    + reusable `rlp_phase6_write_output_spec_regOwn`): composes the short-list schema decoder with the
+    write wrapper, committing the decoded output region (`publicValuesIs old → publicValuesIs (old ++
+    schemaOut out specs)`). The decoder's `schemaINV` post exposes scratch as `regOwn`, so the write
+    wrapper is first lifted to a `regOwn` pre; the leftover state is framed through. The CR
+    disjointness is range-based (`codeReq_disjoint_of_ranges` + `schemaCR_none_above`) — `crDisjoint`
+    /`seqFrame` time out / `whnf`-blow up on the opaque 36-instruction decoder `ofProg`. The reshape
+    is `cpsTripleWithin_weaken … xperm_hyp` with a nested `refine` so the target is concrete before
+    `xperm` runs (else `Q`/`Q'` are metavars). Concrete `[0xc4,0x2a,0x82,0x01,0x02] → 0x3000` example.
+  - ✅ **Step 61 — full `read ⨾ decode ⨾ write` pipeline** (`Phase6Pipeline.lean`,
+    `rlp_phase6_read_decode_write`): composes the read⨾decode unit (step 55) with the write wrapper —
+    the complete top-level pipeline. From the host-ABI input contract the program runs `read_input` +
+    `LD` + decoder + `write_output` in `(5 + (61 + schemaSteps)) + 4` steps, committing the decoded
+    record to `publicValues` and recovering every field value. Concrete end-to-end example: the host
+    supplies `[0xc4,0x2a,0x82,0x01,0x02]` at `0x2000`, decoded to `0x3000` and committed.
+    Axiom-clean, 0 sorry, no `bv_decide`/`native_decide`, no heartbeat overrides.
 - **Host I/O ABI**: See `docs/zkvm-host-io-interface.md`; SP1
   `HINT_LEN`/`HINT_READ`/`COMMIT` are legacy handler shapes, not the target
   C ABI.


### PR DESCRIPTION
## Summary

Completes **Phase 6** — the full top-level RLP pipeline `read_input → decode → write_output`. Builds on #9368 (write_output host-IO spec layer, steps 57–59, merged).

### Steps

- **Step 60** (`Phase6DecodeWrite.lean`) — `rlp_phase6_decode_and_write`: composes the short-list schema decoder (`decode_encoded_short_list_schema_values`) with the `write_output` wrapper, committing the decoded output region to the public-values stream (`publicValuesIs old → publicValuesIs (old ++ schemaOut out specs)`) while recovering every field value (`schemaScalarValues`). Adds reusable `rlp_phase6_write_output_spec_regOwn` (the `regOwn`-scratch write wrapper that a decoder's `schemaINV` post supplies).
- **Step 61** (`Phase6Pipeline.lean`) — `rlp_phase6_read_decode_write`: composes read⨾decode (#9319/step 55) with the write wrapper — the complete pipeline. From the host-ABI input contract the program runs `read_input` + `LD` + decoder + `write_output` in `(5 + (61 + schemaSteps specs)) + 4` steps, committing the record and recovering every field value.

Both steps ship a concrete end-to-end `example` decoding `[0xc4,0x2a,0x82,0x01,0x02]` (= `RLP.list [bytes [0x2a], bytes [0x01,0x02]]`).

### Notes on proof engineering

- CR disjointness is **range-based** (`codeReq_disjoint_of_ranges` + `schemaCR_none_above`): `crDisjoint`/`seqFrame` time out / `whnf`-blow up on the opaque 36-instruction decoder `ofProg`.
- The `schemaINV`→write-pre reshape is `cpsTripleWithin_weaken … xperm_hyp` under a **nested `refine`** so the target assertion is concrete before `xperm` runs (otherwise `Q`/`Q'` stay metavariables and `xperm` sees nothing to match).

### Verification

- `lake build EvmAsm.Rv64.RLP` ✓ (full umbrella).
- Axiom-clean (`propext`/`Classical.choice`/`Quot.sound` only), 0 `sorry`, no `bv_decide`/`native_decide`, no heartbeat overrides.
- `PLAN.md`: Phase 6 marked 🎉 COMPLETE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)