### PR TITLE
fix(codegen): expose created code to extcodecopy

### DIFF
--- a/EvmAsm/Codegen/Programs/EvmAccountWitness.lean
+++ b/EvmAsm/Codegen/Programs/EvmAccountWitness.lean
@@ -46,6 +46,7 @@ private def extcodehashWitnessTail : HandlerTail :=
     "  sd x10, 0(sp)\n" ++
     "  sd x12, 8(sp)\n" ++
     "  sd x21, 16(sp)\n" ++
+    "  sd x13, 24(sp)\n" ++
     "  la a0, eahsr_address_scratch\n" ++
     "  la a1, " ++ runtimeAccessAccountTableLabel ++ "\n" ++
     "  la a2, " ++ runtimeAccessAccountCountLabel ++ "\n" ++
@@ -54,11 +55,13 @@ private def extcodehashWitnessTail : HandlerTail :=
     "  ld x10, 0(sp)\n" ++
     "  ld x12, 8(sp)\n" ++
     "  ld x21, 16(sp)\n" ++
+    "  ld x13, 24(sp)\n" ++
     "  addi sp, sp, 32\n" ++
     "  addi sp, sp, -32\n" ++
     "  sd x10, 0(sp)\n" ++
     "  sd x12, 8(sp)\n" ++
     "  sd x21, 16(sp)\n" ++
+    "  sd x13, 24(sp)\n" ++
     "  la a0, eahsr_address_scratch\n" ++
     "  jal ra, runtime_same_block_delegation_code\n" ++
     "  bnez a0, .Lextcodehash_after_same_block\n" ++
@@ -69,6 +72,7 @@ private def extcodehashWitnessTail : HandlerTail :=
     "  ld x10, 0(sp)\n" ++
     "  ld x12, 8(sp)\n" ++
     "  ld x21, 16(sp)\n" ++
+    "  ld x13, 24(sp)\n" ++
     "  la t0, rsbd_hash; addi t0, t0, 31; mv t1, x12; li t2, 32\n" ++
     ".Lextcodehash_same_block_rev:\n" ++
     "  beqz t2, .Lextcodehash_same_block_rev_done\n" ++
@@ -81,6 +85,7 @@ private def extcodehashWitnessTail : HandlerTail :=
     "  ld x10, 0(sp)\n" ++
     "  ld x12, 8(sp)\n" ++
     "  ld x21, 16(sp)\n" ++
+    "  ld x13, 24(sp)\n" ++
     "  addi sp, sp, 32\n" ++
     "  ld t0, 584(x20)\n" ++          -- header length; zero means no witness context
     "  beqz t0, .Lextcodehash_no_context\n" ++
@@ -88,6 +93,7 @@ private def extcodehashWitnessTail : HandlerTail :=
     "  sd x10, 0(sp)\n" ++
     "  sd x12, 8(sp)\n" ++
     "  sd x21, 16(sp)\n" ++
+    "  sd x13, 24(sp)\n" ++
     "  ld a0, 576(x20)\n" ++         -- header ptr
     "  ld a1, 584(x20)\n" ++         -- header len
     "  la a2, eahsr_address_scratch\n" ++
@@ -98,6 +104,7 @@ private def extcodehashWitnessTail : HandlerTail :=
     "  ld x10, 0(sp)\n" ++
     "  ld x12, 8(sp)\n" ++
     "  ld x21, 16(sp)\n" ++
+    "  ld x13, 24(sp)\n" ++
     "  addi sp, sp, 32\n" ++
     "  addi x10, x10, 1\n" ++
     "  j .dispatch_loop\n" ++
@@ -122,6 +129,7 @@ private def extcodesizeWitnessTail : HandlerTail :=
     "  sd x10, 0(sp)\n" ++
     "  sd x12, 8(sp)\n" ++
     "  sd x21, 16(sp)\n" ++
+    "  sd x13, 24(sp)\n" ++
     "  la a0, eahsr_address_scratch\n" ++
     "  la a1, " ++ runtimeAccessAccountTableLabel ++ "\n" ++
     "  la a2, " ++ runtimeAccessAccountCountLabel ++ "\n" ++
@@ -130,11 +138,13 @@ private def extcodesizeWitnessTail : HandlerTail :=
     "  ld x10, 0(sp)\n" ++
     "  ld x12, 8(sp)\n" ++
     "  ld x21, 16(sp)\n" ++
+    "  ld x13, 24(sp)\n" ++
     "  addi sp, sp, 32\n" ++
     "  addi sp, sp, -32\n" ++
     "  sd x10, 0(sp)\n" ++
     "  sd x12, 8(sp)\n" ++
     "  sd x21, 16(sp)\n" ++
+    "  sd x13, 24(sp)\n" ++
     "  la a0, eahsr_address_scratch\n" ++
     "  jal ra, runtime_same_block_delegation_code\n" ++
     "  bnez a0, .Lextcodesize_after_same_block\n" ++
@@ -142,6 +152,7 @@ private def extcodesizeWitnessTail : HandlerTail :=
     "  ld x10, 0(sp)\n" ++
     "  ld x12, 8(sp)\n" ++
     "  ld x21, 16(sp)\n" ++
+    "  ld x13, 24(sp)\n" ++
     "  addi sp, sp, 32\n" ++
     "  sd t1, 0(x12)\n" ++
     "  sd zero, 8(x12)\n" ++
@@ -153,6 +164,7 @@ private def extcodesizeWitnessTail : HandlerTail :=
     "  ld x10, 0(sp)\n" ++
     "  ld x12, 8(sp)\n" ++
     "  ld x21, 16(sp)\n" ++
+    "  ld x13, 24(sp)\n" ++
     "  addi sp, sp, 32\n" ++
     "  ld t0, 584(x20)\n" ++
     "  beqz t0, .Lextcodesize_no_context\n" ++
@@ -160,6 +172,7 @@ private def extcodesizeWitnessTail : HandlerTail :=
     "  sd x10, 0(sp)\n" ++
     "  sd x12, 8(sp)\n" ++
     "  sd x21, 16(sp)\n" ++
+    "  sd x13, 24(sp)\n" ++
     "  ld a0, 576(x20)\n" ++         -- header ptr
     "  ld a1, 584(x20)\n" ++         -- header len
     "  la a2, eahsr_address_scratch\n" ++
@@ -173,6 +186,7 @@ private def extcodesizeWitnessTail : HandlerTail :=
     "  ld x10, 0(sp)\n" ++
     "  ld x12, 8(sp)\n" ++
     "  ld x21, 16(sp)\n" ++
+    "  ld x13, 24(sp)\n" ++
     "  addi sp, sp, 32\n" ++
     "  sd t1, 0(x12)\n" ++
     "  sd zero, 8(x12)\n" ++

--- a/EvmAsm/Codegen/Programs/EvmExtcodecopy.lean
+++ b/EvmAsm/Codegen/Programs/EvmExtcodecopy.lean
@@ -243,6 +243,66 @@ private def extcodecopyWitnessTail : HandlerTail :=
 " ++
     "  addi sp, sp, 64
 " ++
+    -- A same-transaction CREATE deposit is not visible in the header-state code
+    -- witness. The CREATE return path records deployed bytes in
+    -- exec_code_effect_log, so EXTCODECOPY must consult that current-code overlay
+    -- before falling back to the pre-block trie helper.
+    "  addi sp, sp, -64
+" ++
+    "  sd x10, 0(sp)
+" ++
+    "  sd x12, 8(sp)
+" ++
+    "  sd x13, 16(sp)
+" ++
+    "  sd x14, 24(sp)
+" ++
+    "  sd x15, 32(sp)
+" ++
+    "  sd x19, 40(sp)
+" ++
+    "  sd x21, 48(sp)
+" ++
+    "  la a0, exec_code_effect_log
+" ++
+    "  la t0, exec_code_effect_count; ld a1, 0(t0)
+" ++
+    "  la a2, ecc_address_scratch
+" ++
+    "  jal ra, find_code_effect_by_address
+" ++
+    "  mv t0, a0
+" ++
+    "  ld x10, 0(sp)
+" ++
+    "  ld x12, 8(sp)
+" ++
+    "  ld x13, 16(sp)
+" ++
+    "  ld x14, 24(sp)
+" ++
+    "  ld x15, 32(sp)
+" ++
+    "  ld x19, 40(sp)
+" ++
+    "  ld x21, 48(sp)
+" ++
+    "  addi sp, sp, 64
+" ++
+    "  beqz t0, .Lrt_ecc_no_create_effect
+" ++
+    "  addi t1, t0, 48
+" ++
+    "  ld t2, 40(t0)
+" ++
+    "  ld t3, 64(x12)
+" ++
+    "  li t4, 0
+" ++
+    "  j .Lrt_ecc_same_loop
+" ++
+    ".Lrt_ecc_no_create_effect:
+" ++
     "  ld t0, 608(x20)
 " ++         -- witness.codes ptr
     "  la t1, eccp_codes_ptr


### PR DESCRIPTION
## Summary
- preserve x13 across EXTCODESIZE/EXTCODEHASH witness helper calls so EVM memory base survives account lookups
- let EXTCODECOPY read same-transaction CREATE deposits from exec_code_effect_log before falling back to header-state code
- fixes the base_fee_diff_places d24 path where CREATE is followed by EXTCODECOPY from the freshly created address

Validation:
- lake build EvmAsm.Codegen.Programs.BlockVerdict
- clean focused d24 zisk_stateless_verdict_v2 run: output word0=1, word1=0
- lake build
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- touched-file forbidden-pattern scan

Note: this branch is stacked locally on fix/context-env-callcode-basefee; gh rejected that branch as a PR base, so this PR is opened against main.

Bead: evm-asm-coc3g.5.3.2.

Directed by @pirapira; implemented by Codex.
