### PR TITLE
proof(mulmod): bit-loop iterate semantics + counter arithmetic

### DIFF
--- a/EvmAsm/Evm64/MulMod/ReduceSemantics.lean
+++ b/EvmAsm/Evm64/MulMod/ReduceSemantics.lean
@@ -103,4 +103,37 @@ def mulModReduceBitWord (bit : Bool) : EvmWord :=
     mulModReduceBitWord true = (1 : EvmWord) := by
   rfl
 
+/-- Iterate the bit-serial reducer step over the top `k` bits of the product
+    word `w`: each step consumes `w`'s most significant bit and shifts `w` left
+    by one. After 64 steps the limb `w` is fully folded into the remainder. -/
+def mulModReduceStepN (r n : EvmWord) (w : Word) : Nat → EvmWord
+  | 0 => r
+  | k + 1 =>
+    mulModReduceStepN (mulModReduceStep r n (mulModReduceInputBit w)) n (w <<< 1) k
+
+@[simp] theorem mulModReduceStepN_zero (r n : EvmWord) (w : Word) :
+    mulModReduceStepN r n w 0 = r := rfl
+
+theorem mulModReduceStepN_succ (r n : EvmWord) (w : Word) (k : Nat) :
+    mulModReduceStepN r n w (k + 1) =
+      mulModReduceStepN (mulModReduceStep r n (mulModReduceInputBit w)) n (w <<< 1) k :=
+  rfl
+
+/-- The bit-loop counter (`x15`) after the loop's `ADDI x15, x15, -1`: starting
+    from `m` remaining iterations it becomes `m - 1`. -/
+theorem mulModReduceBitCounter_decr (m : Nat) (h1 : 1 ≤ m) (h64 : m ≤ 64) :
+    BitVec.ofNat 64 m + signExtend12 (4095 : BitVec 12) = BitVec.ofNat 64 (m - 1) := by
+  have hse : signExtend12 (4095 : BitVec 12) = (-1 : BitVec 64) := by decide
+  rw [hse]; bv_omega
+
+/-- The decremented bit-loop counter is zero exactly when one iteration
+    remained. -/
+theorem mulModReduceBitCounter_eq_zero_iff (m : Nat) (h1 : 1 ≤ m) (h64 : m ≤ 64) :
+    (BitVec.ofNat 64 m + signExtend12 (4095 : BitVec 12) = 0) ↔ m = 1 := by
+  have hse : signExtend12 (4095 : BitVec 12) = (-1 : BitVec 64) := by decide
+  rw [hse]
+  constructor
+  · intro h; bv_omega
+  · intro h; subst h; decide
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
Pure prerequisites for the inner 64-bit reducer loop induction (bead 4.4.3.3), independent of the in-flight building-blocks PR:
- `mulModReduceStepN` — iterate `mulModReduceStep` over the top `k` bits of the shifting product word (MSB-first), with `_zero` / `_succ` structural lemmas. The loop invariant's remainder is `mulModReduceStepN r n w k` after `k` iterations.
- `mulModReduceBitCounter_decr` — the `ADDI x15, x15, -1` counter step: `ofNat m + (-1) = ofNat (m-1)` for `1 ≤ m ≤ 64`.
- `mulModReduceBitCounter_eq_zero_iff` — the decremented counter is zero iff exactly one iteration remained.

These let the loop induction case-split on the `x15` counter and thread it to the induction hypothesis.

Bead: evm-asm-fhsxz.2.4.2.60.2.5.1.4.4.3.3

## Verification
- `lake build EvmAsm.Evm64.MulMod.ReduceSemantics`, full `lake build`
- `scripts/check-forbidden-tactics.sh`, `scripts/check-file-size.sh`, `scripts/check-unimported.sh`
- `#print axioms` → `propext`, `Quot.sound` only
- no `sorry`/`admit`/`native_decide`/`bv_decide`/heartbeat/recdepth changes

Directed by @pirapira; implemented by Claude Code