### PR TITLE
proof(mulmod): lift inner 64-bit loop spec into reduce512_loop

### DIFF
--- a/EvmAsm/Evm64/MulMod.lean
+++ b/EvmAsm/Evm64/MulMod.lean
@@ -23,6 +23,7 @@ import EvmAsm.Evm64.MulMod.ReduceInnerStepTail
 import EvmAsm.Evm64.MulMod.ReduceInnerStepSubtract
 import EvmAsm.Evm64.MulMod.ReduceInnerStepSpecs
 import EvmAsm.Evm64.MulMod.ReduceBitLoop
+import EvmAsm.Evm64.MulMod.ReduceOuterLoop
 import EvmAsm.Evm64.MulMod.LimbSpec
 import EvmAsm.Evm64.MulMod.AddPartialSpecs
 import EvmAsm.Evm64.MulMod.AddPartialTable

--- a/EvmAsm/Evm64/MulMod/ReduceOuterLoop.lean
+++ b/EvmAsm/Evm64/MulMod/ReduceOuterLoop.lean
@@ -1,0 +1,47 @@
+/-
+  EvmAsm.Evm64.MulMod.ReduceOuterLoop
+
+  Outer eight-limb loop of the MULMOD 512-bit reducer. This file lifts the
+  inner 64-bit bit-loop spec into the enclosing `evm_mulmod_reduce512_loop`
+  code (the inner step sits at byte offset 8), and (later) composes the outer
+  loop body and its eight-limb induction.
+-/
+
+import EvmAsm.Evm64.MulMod.ReduceBitLoop
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Tactics
+
+/-- The inner reducer-step block sits at byte offset 8 within
+    `evm_mulmod_reduce512_loop` (after `LD x17` and `ADDI x15`). -/
+theorem evm_mulmod_reduce512_loop_inner_code_sub (base : Word) :
+    ∀ a i, evm_mulmod_reduce512_inner_step_code (base + 8) a = some i →
+      (CodeReq.ofProg base evm_mulmod_reduce512_loop) a = some i := by
+  intro a i h
+  unfold evm_mulmod_reduce512_inner_step_code at h
+  refine CodeReq.ofProg_mono_subrange base
+    [Instr.LD .x17 .x16 0, Instr.ADDI .x15 .x0 64]
+    evm_mulmod_reduce512_inner_step
+    [Instr.ADDI .x16 .x16 4088, Instr.ADDI .x18 .x18 4095,
+      Instr.BNE .x18 .x0 (-272 : BitVec 13)]
+    ?_ a i ?_
+  · decide
+  · exact h
+
+/-- The inner 64-bit bit loop, lifted to the enclosing `reduce512_loop` code:
+    it runs from byte offset 8 to byte offset 264 (where the pointer-advance
+    instructions begin), folding the current product limb `w` into the
+    remainder. -/
+theorem evm_mulmod_reduce512_loop_bit_loop_spec_within
+    (sp base w x19v x20v : Word) (r n : EvmWord) :
+    cpsTripleWithin (64 * 64) (base + 8) (base + 8 + 256)
+      (CodeReq.ofProg base evm_mulmod_reduce512_loop)
+      (mulModReduceBitLoopPre sp w (BitVec.ofNat 64 64) x19v x20v r n)
+      (mulModReduceBitLoopPost sp (mulModReduceStepN r n w 64) n) :=
+  cpsTripleWithin_extend_code
+    (hmono := evm_mulmod_reduce512_loop_inner_code_sub base)
+    (h := evm_mulmod_reduce512_bit_loop_spec_within sp (base + 8) w x19v x20v r n)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
`evm_mulmod_reduce512_loop_bit_loop_spec_within` — the inner 64-bit bit loop runs at byte offset 8 within the enclosing `evm_mulmod_reduce512_loop` (after `LD x17` and `ADDI x15`). This lifts the merged inner-loop spec there:
- `evm_mulmod_reduce512_loop_inner_code_sub` via `CodeReq.ofProg_mono_subrange`, supplying the 2-instr prefix / 64-instr inner step / 3-instr suffix as `pre`/`mid`/`suf` (treats the inner step opaquely as `mid`, avoiding deep structural recursion in the slice proof).
- `cpsTripleWithin_extend_code` to lift the spec onto `reduce512_loop`.

Foundation for the outer-loop body composition (bead 4.4.4.2). Bead: evm-asm-fhsxz.2.4.2.60.2.5.1.4.4.4.1

## Verification
- `lake build EvmAsm.Evm64.MulMod.ReduceOuterLoop`, full `lake build`
- `scripts/check-forbidden-tactics.sh`, `scripts/check-file-size.sh`, `scripts/check-unimported.sh`
- `#print axioms` → `propext`, `Classical.choice`, `Quot.sound` only
- no `sorry`/`admit`/`native_decide`/`bv_decide`/heartbeat/recdepth changes

Directed by @pirapira; implemented by Claude Code