### PR TITLE
proof(mulmod): fold one product limb in the outer reducer loop

### DIFF
--- a/EvmAsm/Evm64/MulMod/ReduceBitLoop.lean
+++ b/EvmAsm/Evm64/MulMod/ReduceBitLoop.lean
@@ -17,7 +17,7 @@ open EvmAsm.Rv64.Tactics
 /-- The non-scratch resources carried unchanged across one reducer bit step:
     the frame pointer, the shifting product word, the bit counter, the carry
     scratch `x19/x20`, and the remainder/modulus memory windows. -/
-private def bitLoopCommon
+def bitLoopCommon
     (sp x17Old x15 x19Old x20Old : Word) (r n : EvmWord) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x17 ↦ᵣ x17Old) ** (.x15 ↦ᵣ x15) ** (.x0 ↦ᵣ (0 : Word)) **
   (.x19 ↦ᵣ x19Old) ** (.x20 ↦ᵣ x20Old) **

--- a/EvmAsm/Evm64/MulMod/ReduceOuterLoop.lean
+++ b/EvmAsm/Evm64/MulMod/ReduceOuterLoop.lean
@@ -88,4 +88,50 @@ theorem evm_mulmod_reduce512_loop_prefix_spec_within
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hp => by xperm_hyp hp)
     (cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hLDf hADDIf)
 
+/-- One outer-loop iteration up to the pointer-advance: load the product limb
+    at `x16`, run the inner 64-bit bit loop, and land at byte offset 264 with
+    that limb folded into the remainder (`mulModReduceStepN r n limb 64`). -/
+theorem evm_mulmod_reduce512_loop_fold_one_limb_spec_within
+    (sp base ptr oldX17 oldX15 x19v x20v limb : Word) (r n : EvmWord) :
+    cpsTripleWithin (2 + 64 * 64) base (base + 8 + 256)
+      (CodeReq.ofProg base evm_mulmod_reduce512_loop)
+      ((.x12 ↦ᵣ sp) ** (.x16 ↦ᵣ ptr) ** (.x17 ↦ᵣ oldX17) ** (.x15 ↦ᵣ oldX15) **
+       (.x0 ↦ᵣ (0 : Word)) ** (.x19 ↦ᵣ x19v) ** (.x20 ↦ᵣ x20v) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
+       ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 0) **
+       ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 1) **
+       ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 2) **
+       ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 3) **
+       ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 0) **
+       ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 1) **
+       ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 2) **
+       ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 3) **
+       ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb))
+      (mulModReduceBitLoopPost sp (mulModReduceStepN r n limb 64) n **
+       (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb)) := by
+  have hpf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x19 ↦ᵣ x19v) ** (.x20 ↦ᵣ x20v) **
+     regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
+     ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 0) **
+     ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 1) **
+     ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 2) **
+     ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 3) **
+     ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 0) **
+     ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 1) **
+     ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 2) **
+     ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 3))
+    (by pcFree)
+    (evm_mulmod_reduce512_loop_prefix_spec_within base ptr oldX17 oldX15 limb)
+  have hif := cpsTripleWithin_frameR
+    ((.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb))
+    (by pcFree)
+    (evm_mulmod_reduce512_loop_bit_loop_spec_within sp base limb x19v x20v r n)
+  exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hp => by xperm_hyp hp)
+    (cpsTripleWithin_seq_perm_same_cr
+      (fun h hq => by
+        rw [show (BitVec.ofNat 64 64) = (0 : Word) + signExtend12 (64 : BitVec 12) from by decide]
+        unfold mulModReduceBitLoopPre bitLoopCommon
+        xperm_hyp hq)
+      hpf hif)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
`evm_mulmod_reduce512_loop_fold_one_limb_spec_within` — composes the loop-body prefix (load limb into `x17`, arm `x15 := 64`) with the lifted inner 64-bit bit loop, giving `cpsTripleWithin base → base+264` that folds the current product limb into the remainder (`mulModReduceStepN r n limb 64`).

- The prefix-post / bit-loop-pre connection reconciles `x15` (`0 + signExtend12 64 = ofNat 64`, by `decide`) and frames the bit-loop scratch / remainder / modulus onto the prefix and the limb pointer/value onto the inner loop.
- Exposes `bitLoopCommon` (was `private`) so the connecting permutation can unfold the bit-loop precondition.

Toward the outer-loop body (bead 4.4.4.2). The trailing pointer-advance + `BNE` are tracked separately (offset-lifting past the 64-instruction inner step).

## Verification
- `lake build EvmAsm.Evm64.MulMod.ReduceOuterLoop`, full `lake build`
- `scripts/check-forbidden-tactics.sh`, `scripts/check-file-size.sh`, `scripts/check-unimported.sh`
- `#print axioms` → `propext`, `Classical.choice`, `Quot.sound` only
- no `sorry`/`admit`/`native_decide`/`bv_decide`/heartbeat/recdepth changes

Directed by @pirapira; implemented by Claude Code