### PR TITLE
proof(mulmod): outer-loop BNE loop-control spec

### DIFF
--- a/EvmAsm/Evm64/MulMod/ReduceOuterLoop.lean
+++ b/EvmAsm/Evm64/MulMod/ReduceOuterLoop.lean
@@ -192,4 +192,30 @@ theorem evm_mulmod_reduce512_loop_advance_spec_within (base x16v x18v : Word) :
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hp => by xperm_hyp hp)
     (cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h16f h18f)
 
+/-- Outer-loop control `BNE x18, x0, -272` at byte offset 272: loops back to
+    `base` while the eight-limb counter `x18` is nonzero, falls through to
+    `base + 276` (the post-loop) when it reaches zero. -/
+theorem evm_mulmod_reduce512_loop_branch_spec_within (base x18v : Word) :
+    cpsBranchWithin 1 (base + 272)
+      (CodeReq.ofProg base evm_mulmod_reduce512_loop)
+      ((.x18 ↦ᵣ x18v) ** (.x0 ↦ᵣ (0 : Word)))
+      base ((.x18 ↦ᵣ x18v) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜x18v ≠ (0 : Word)⌝)
+      (base + 276) ((.x18 ↦ᵣ x18v) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜x18v = (0 : Word)⌝) := by
+  have hsub : ∀ a i,
+      CodeReq.singleton (base + 272) (Instr.BNE .x18 .x0 (-272 : BitVec 13)) a = some i →
+      (CodeReq.ofProg base evm_mulmod_reduce512_loop) a = some i := by
+    rw [← CodeReq.ofProg_singleton]
+    refine CodeReq.ofProg_mono_sub base (base + 272) evm_mulmod_reduce512_loop
+      [Instr.BNE .x18 .x0 (-272 : BitVec 13)] 68 ?_ ?_ ?_ ?_
+    · rw [show BitVec.ofNat 64 (4 * 68) = (272 : Word) by decide]
+    · rfl
+    · rw [evm_mulmod_reduce512_loop_length]; decide
+    · rw [evm_mulmod_reduce512_loop_length]; decide
+  have hbne := bne_spec_gen_within .x18 .x0 (-272 : BitVec 13) x18v (0 : Word) (base + 272)
+  have htaken : ((base + 272) + signExtend13 (-272 : BitVec 13) : Word) = base := by
+    rw [show signExtend13 (-272 : BitVec 13) = (-272 : Word) from by decide]; bv_omega
+  have hnt : ((base + 272) + 4 : Word) = base + 276 := by bv_omega
+  rw [htaken, hnt] at hbne
+  exact cpsBranchWithin_extend_code (hmono := hsub) (h := hbne)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
`evm_mulmod_reduce512_loop_branch_spec_within` — the `BNE x18, x0, -272` at byte offset 272 (index 68): loops back to `base` while the eight-limb counter `x18` is nonzero, falls through to `base + 276` when it reaches zero.

Lifted via the explicit-index `ofProg_mono_sub` (`take 1` `rfl`) + `cpsBranchWithin_extend_code` over `bne_spec_gen_within`, normalizing the taken target `(base+272) + signExtend13(-272) = base`.

Completes the three outer-loop-body building blocks (fold-one-limb, advance, branch); the body `cpsBranchWithin` assembly comes next. Stacked on #9387.

Bead: evm-asm-fhsxz.2.4.2.60.2.5.1.4.4.4.2

## Verification
- `lake build EvmAsm.Evm64.MulMod.ReduceOuterLoop`, full `lake build`
- `scripts/check-forbidden-tactics.sh`, `scripts/check-file-size.sh`, `scripts/check-unimported.sh`
- `#print axioms` → `propext`, `Classical.choice`, `Quot.sound` only
- no `sorry`/`admit`/`native_decide`/`bv_decide`/heartbeat/recdepth changes

Directed by @pirapira; implemented by Claude Code