### PR TITLE
fix(spike): default SPIKE_SRC to a relative path, not a hardcoded user dir

### DIFF
--- a/scripts/spike/README.md
+++ b/scripts/spike/README.md
@@ -9,7 +9,7 @@ No guest/codegen changes — SPIKE adapts to the existing ELF's contract.
 ## Status
 
 **Working & validated (macOS arm64):**
-- SPIKE builds from source at `$SPIKE_SRC` (default `/Users/dhsorens/devel/riscv-isa-sim`).
+- SPIKE builds from source at `$SPIKE_SRC` (default: a `riscv-isa-sim` checkout sibling to this repo).
 - `build.sh` produces `libziskaccel.so` (extension for stock `spike --extlib`) AND
   `spike_run` (custom driver: `spike_run <guest.elf> <input> <output>`, a drop-in
   for `ziskemu -e/-i/-o`).

--- a/scripts/spike/build.sh
+++ b/scripts/spike/build.sh
@@ -6,7 +6,8 @@
 # Requires riscv-isa-sim checked out + built at $SPIKE_SRC, and a riscv64 as/ld.
 set -euo pipefail
 cd "$(dirname "$0")"
-SPIKE_SRC="${SPIKE_SRC:-/Users/dhsorens/devel/riscv-isa-sim}"
+# Default to a riscv-isa-sim checkout sibling to this repo; override with SPIKE_SRC.
+SPIKE_SRC="${SPIKE_SRC:-$(cd ../../.. && pwd)/riscv-isa-sim}"
 SPIKE_BUILD="${SPIKE_BUILD:-$SPIKE_SRC/build}"
 BOOST_INC="${BOOST_INC:-/opt/homebrew/include}"
 AS="${RISCV_AS:-riscv64-elf-as}"


### PR DESCRIPTION
Addresses the review nit on #9408 (thanks @pirapira):

> scripts/spike/build.sh:9 — It's odd to see the username here. Maybe a relative path will do.

`build.sh` hardcoded `/Users/dhsorens/devel/riscv-isa-sim` as the `SPIKE_SRC` default. Now it defaults to a `riscv-isa-sim` checkout **sibling to this repo** (`$(cd ../../.. && pwd)/riscv-isa-sim`), still overridable via `SPIKE_SRC`. README's documented default updated to match.

Verified the build script still produces `libziskaccel.so` + `spike_run` (with `SPIKE_SRC` pointed at a local checkout). No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)