### PR TITLE
feat(mulmod): N≠0 body result = EVM word for n ≤ 2^255 [A3]

### DIFF
--- a/EvmAsm/Evm64/MulMod.lean
+++ b/EvmAsm/Evm64/MulMod.lean
@@ -64,4 +64,6 @@ import EvmAsm.Evm64.MulMod.Compose.ProductSuffix
 import EvmAsm.Evm64.MulMod.Compose.ProductReduceBridge
 import EvmAsm.Evm64.MulMod.Compose.ProductReduce
 import EvmAsm.Evm64.MulMod.Compose.ProductReduceValue
+import EvmAsm.Evm64.MulMod.Compose.ZeroPathBody
+import EvmAsm.Evm64.MulMod.Compose.ZeroPathTail
 import EvmAsm.Evm64.MulMod.Spec

--- a/EvmAsm/Evm64/MulMod.lean
+++ b/EvmAsm/Evm64/MulMod.lean
@@ -57,6 +57,7 @@ import EvmAsm.Evm64.MulMod.ProductLayoutColumn7Target
 import EvmAsm.Evm64.MulMod.ProductLayoutHighTargets
 import EvmAsm.Evm64.MulMod.ProductLayoutSpec
 import EvmAsm.Evm64.MulMod.AddrNorm
+import EvmAsm.Evm64.MulMod.MulModResultWord
 import EvmAsm.Evm64.MulMod.Compose.Base
 import EvmAsm.Evm64.MulMod.Compose.Reducer
 import EvmAsm.Evm64.MulMod.Compose.ProductCore

--- a/EvmAsm/Evm64/MulMod.lean
+++ b/EvmAsm/Evm64/MulMod.lean
@@ -63,4 +63,5 @@ import EvmAsm.Evm64.MulMod.Compose.ProductCore
 import EvmAsm.Evm64.MulMod.Compose.ProductSuffix
 import EvmAsm.Evm64.MulMod.Compose.ProductReduceBridge
 import EvmAsm.Evm64.MulMod.Compose.ProductReduce
+import EvmAsm.Evm64.MulMod.Compose.ProductReduceValue
 import EvmAsm.Evm64.MulMod.Spec

--- a/EvmAsm/Evm64/MulMod/Compose/ProductReduceValue.lean
+++ b/EvmAsm/Evm64/MulMod/Compose/ProductReduceValue.lean
@@ -1,0 +1,67 @@
+/-
+  EvmAsm.Evm64.MulMod.Compose.ProductReduceValue
+
+  Value-level restatement of `evm_mulmod_product_reduce_evm_mulmod_spec_within`:
+  for `0 < n ≤ 2^255` the result slots hold the EVM `MULMOD` result word
+  `BitVec.ofNat 256 (a·b mod n)` rather than the raw
+  `mulModReduceOuterFold` fold. Rewriting via
+  `mulModReduceOuterFold_productLimb_eq_evmWord` turns the value form back into
+  the fold and discharges the goal with the A2 spec.
+-/
+
+import EvmAsm.Evm64.MulMod.Compose.ProductReduce
+import EvmAsm.Evm64.MulMod.ReduceCarryAgree
+
+namespace EvmAsm.Evm64.MulMod.Compose
+
+open EvmAsm.Rv64
+open EvmAsm.Evm64
+open EvmAsm.Evm64.MulMod.ProductAlgebra
+
+/-- Value-level form of `evm_mulmod_product_reduce_evm_mulmod_spec_within`: for
+    `0 < n ≤ 2^255` the result limbs equal those of the EVM `MULMOD` result word
+    `BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat)` instead of the raw outer
+    fold. -/
+theorem evm_mulmod_product_reduce_value_evm_mulmod_spec_within
+    (sp base : Word) (a b n : EvmWord)
+    (p0 p1 p2 p3 p4 p5 p6 p7 : Word)
+    (x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word)
+    (v16Old v18Old r0 r1 r2 r3 : Word)
+    (hn0 : 0 < n.toNat) (hn : n.toNat ≤ 2 ^ 255) :
+    cpsTripleWithin (440 + (6 + (2 + 64 * 64 + 2 + 1) * 8 + 8 + 1))
+      (base + 56) ((base + 1816) + 336) (evm_mulmod_program_code base)
+      ((evmMulModProductLayoutPre sp a b n p0 p1 p2 p3 p4 p5 p6 p7 **
+        ((.x5 ↦ᵣ x5Old) ** (.x6 ↦ᵣ x6Old) ** (.x7 ↦ᵣ x7Old) ** (.x8 ↦ᵣ x8Old) **
+         (.x9 ↦ᵣ x9Old) ** (.x10 ↦ᵣ x10Old) ** (.x11 ↦ᵣ x11Old) **
+         (.x13 ↦ᵣ x13Old) ** (.x14 ↦ᵣ x14Old))) **
+       ((.x16 ↦ᵣ v16Old) ** (.x18 ↦ᵣ v18Old) ** (.x0 ↦ᵣ 0) **
+        ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ r3) **
+        regOwn .x15 ** regOwn .x17 ** regOwn .x19 ** regOwn .x20))
+      (((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
+        ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3) **
+        ((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
+        ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3) **
+        regOwn .x8 ** regOwn .x9 ** regOwn .x14) **
+       ((.x12 ↦ᵣ (sp + signExtend12 (64 : BitVec 12))) **
+        (((.x5 ↦ᵣ EvmWord.getLimbN (BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat)) 3) **
+          ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN (BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat)) 0) **
+          ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN (BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat)) 1) **
+          ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN (BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat)) 2) **
+          ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ EvmWord.getLimbN (BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat)) 3) **
+          ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN (BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat)) 0) **
+          ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN (BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat)) 1) **
+          ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN (BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat)) 2) **
+          ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN (BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat)) 3)) **
+         (((.x15 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+           regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
+           regOwn .x17 ** regOwn .x19 ** regOwn .x20 ** regOwn .x16 ** regOwn .x18) **
+          limbChain (sp + signExtend12 (152 : BitVec 12)) (fun i => productLimb a b (7 - i)) 8)))) := by
+  rw [← mulModReduceOuterFold_productLimb_eq_evmWord a b n hn0 hn]
+  exact evm_mulmod_product_reduce_evm_mulmod_spec_within sp base a b n
+    p0 p1 p2 p3 p4 p5 p6 p7 x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old
+    v16Old v18Old r0 r1 r2 r3
+
+end EvmAsm.Evm64.MulMod.Compose


### PR DESCRIPTION
## Summary
- Add `evm_mulmod_product_reduce_value_evm_mulmod_spec_within`: the `[A2]` composed N≠0 body with its result rewritten from the reducer fold to the **EVM `MULMOD` result word**.
- For `0 < n ≤ 2^255`, the result slots `sp+64..88` (and `x5`) hold `getLimbN (BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat)) k`.

Proof: `rw [← mulModReduceOuterFold_productLimb_eq_evmWord a b n hn0 hn]` reduces the goal to the `[A2]` spec, then `exact`.

Bead `evm-asm-fhsxz.2.4.2.60.2.5.1.4.9` [A3]. Stacked on #9422 [A2]. Kernel-clean: `#print axioms` = `{propext, Classical.choice, Quot.sound}`; no `native_decide`/`bv_decide`/`sorry`/`admit`, no heartbeat/recdepth bumps. `lake build EvmAsm.Evm64.MulMod` and full `lake build` pass.

Refs #91.

Directed by @pirapira; implemented by Claude Code