### PR TITLE
feat(mulmod): result-word ↔ EvmWord.mulmod bridge lemmas [C2/C3 prereq]

### DIFF
--- a/EvmAsm/Evm64/MulMod.lean
+++ b/EvmAsm/Evm64/MulMod.lean
@@ -57,6 +57,7 @@ import EvmAsm.Evm64.MulMod.ProductLayoutColumn7Target
 import EvmAsm.Evm64.MulMod.ProductLayoutHighTargets
 import EvmAsm.Evm64.MulMod.ProductLayoutSpec
 import EvmAsm.Evm64.MulMod.AddrNorm
+import EvmAsm.Evm64.MulMod.MulModResultWord
 import EvmAsm.Evm64.MulMod.Compose.Base
 import EvmAsm.Evm64.MulMod.Compose.Reducer
 import EvmAsm.Evm64.MulMod.Compose.ProductCore

--- a/EvmAsm/Evm64/MulMod/MulModResultWord.lean
+++ b/EvmAsm/Evm64/MulMod/MulModResultWord.lean
@@ -1,0 +1,30 @@
+/-
+  EvmAsm.Evm64.MulMod.MulModResultWord
+
+  Bridging lemmas between the EVM `MULMOD` reference word `EvmWord.mulmod`
+  and the concrete result words produced by the two dispatch arms of the
+  assembled `evm_mulmod` program. The reducer (N ≠ 0 arm) leaves
+  `BitVec.ofNat 256 ((a·b) mod n)`; the zero path (N = 0 arm) leaves `0`.
+  These align both arms to a single `EvmWord.mulmod a b n` result word, the
+  unified postcondition the top-level dispatch merge converges on.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.MulMod
+
+namespace EvmAsm.Evm64
+
+namespace EvmWord
+
+/-- The `N = 0` arm: `MULMOD` returns the zero word. -/
+@[simp] theorem mulmod_zero (a b : EvmWord) : EvmWord.mulmod a b 0 = 0 := by
+  simp [EvmWord.mulmod]
+
+/-- The `N ≠ 0` arm: `MULMOD` is the reduced product word `(a·b) mod N`. -/
+theorem mulmod_of_ne_zero (a b n : EvmWord) (h : n ≠ 0) :
+    EvmWord.mulmod a b n = BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat) := by
+  unfold EvmWord.mulmod
+  rw [if_neg h]
+
+end EvmWord
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `EvmWord.mulmod_zero`: `mulmod a b 0 = 0` (the N=0 arm).
- Add `EvmWord.mulmod_of_ne_zero`: `n ≠ 0 → mulmod a b n = BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat)` (the N≠0 arm).
- These align the two `evm_mulmod` dispatch arms — the N≠0 reducer result `BitVec.ofNat 256 ((a·b) mod n)` and the N=0 zero result — to a single `EvmWord.mulmod a b n` result word: the unified postcondition the dispatch merge (`[C2]`) converges on and the stack spec (`[C3]`) targets.

Both are immediate from the definition of `EvmWord.mulmod`.

Bead `evm-asm-fhsxz.2.4.2.60.2.5.1.4.12` [C2/C3 prerequisite]. Kernel-clean: `#print axioms` = `[]` (pure definitional); no `native_decide`/`bv_decide`/`sorry`/`admit`, no heartbeat/recdepth bumps. `lake build EvmAsm.Evm64.MulMod` and full `lake build` pass.

Refs #91.

Directed by @pirapira; implemented by Claude Code