### PR TITLE
feat(rv64/rlp): validating singleByte decoder for untrusted input (#9373 Phase B.2)

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -141,3 +141,4 @@ import EvmAsm.Rv64.RLP.Phase6WriteOutput
 import EvmAsm.Rv64.RLP.Phase6DecodeWrite
 import EvmAsm.Rv64.RLP.Phase6Pipeline
 import EvmAsm.Rv64.RLP.UnifiedDecodeItemShortBytesValidated
+import EvmAsm.Rv64.RLP.UnifiedDecodeItemSingleByteValidated

--- a/EvmAsm/Rv64/RLP/UnifiedDecodeItemSingleByteValidated.lean
+++ b/EvmAsm/Rv64/RLP/UnifiedDecodeItemSingleByteValidated.lean
@@ -1,0 +1,80 @@
+/-
+  EvmAsm.Rv64.RLP.UnifiedDecodeItemSingleByteValidated
+
+  Phase B of issue #9373 — the VALIDATING singleByte RLP single-item decoder over UNTRUSTED input.
+  A `singleByte` prefix (`p < 0x80`) is *always* a valid canonical RLP encoding of the one-byte
+  string `[p]` (the prefix IS the data), so — unlike short/long byte strings and lists — there is
+  no failure case: the decoder cannot reject. The "validating" interface is therefore a plain
+  single-exit `cpsTripleWithin` whose post carries the success verdict
+  `⌜decode (pfx :: rest) = some (.bytes [pfx], rest)⌝`, with NO validity hypotheses on the input.
+
+  This is the `singleByte` arm of the eventual 5-way unified validating decoder (the untrusted
+  analogue of `rlp_decode_single_item_reconverged_all_region`). It frames the full untrusted-decoder
+  register/memory interface (`x12`/`x13 = regionBase`/`x14`/`x15 = L`/`bytesRegion`) through the
+  register-only e1 handler so it composes uniformly with the other (branching) class arms.
+-/
+
+import EvmAsm.Rv64.RLP.Phase1ToPhase3SingleByte
+import EvmAsm.Rv64.MemRegion
+import EvmAsm.EL.RLP.ByteStringDecodeBridge
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL.RLP
+open EvmAsm.EL.RLP.ByteStringDecodeBridge
+open EvmAsm.Rv64.Tactics
+
+/-- **Validating singleByte single-item decoder, at offset 0.** From an untrusted
+    `bytesRegion regionBase (pfx :: rest)` with a `singleByte` prefix (`pfx < 0x80`), the e1
+    handler runs in 3 steps and the post carries `⌜decode (pfx :: rest) = some (.bytes [pfx], rest)⌝`.
+    No validity hypotheses, no failure exit: a canonical single byte always decodes. -/
+theorem rlp_decode_singleByte_validated
+    (pfx : Byte) (rest : List Byte)
+    (v10 v11Old v12 v14 v15 : Word)
+    (regionBase : Word)
+    (offset : BitVec 13) (base target : Word)
+    (h_class : classifyPrefix pfx = .singleByte)
+    (htarget : (base + 4) + signExtend13 offset = target)
+    (hd : (rlp_phase1_step_code 0x80 offset base).Disjoint
+            (CodeReq.ofProg target rlp_phase3_single_byte_prog)) :
+    cpsTripleWithin 3 base (target + 4)
+      ((rlp_phase1_step_code 0x80 offset base).union
+         (CodeReq.ofProg target rlp_phase3_single_byte_prog))
+      ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ regionBase) ** (.x14 ↦ᵣ v14) **
+        (.x15 ↦ᵣ v15) ** bytesRegion regionBase (pfx :: rest))
+      ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0x80 : BitVec 12))) **
+        (.x11 ↦ᵣ (1 : Word)) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ regionBase) ** (.x14 ↦ᵣ v14) **
+        (.x15 ↦ᵣ v15) ** bytesRegion regionBase (pfx :: rest) **
+        ⌜decode (pfx :: rest) = some (.bytes [pfx], rest)⌝) := by
+  -- The success verdict is unconditional for a canonical single byte.
+  have hsome : decode (pfx :: rest) = some (.bytes [pfx], rest) := by
+    rw [decode_cons_eq_decodeAux_fuel,
+        show 2 * rest.length + 2 = (2 * rest.length + 1) + 1 from rfl,
+        decodeAux_cons_singleByte_eq_some_iff (2 * rest.length + 1) pfx rest h_class [pfx] rest]
+    exact ⟨rfl, rfl⟩
+  -- The register-only e1 handler, framed with the full untrusted-decoder state.
+  have handler := rlp_phase1_e1_single_byte_of_class_spec_within pfx v10 v11Old offset base target
+    htarget h_class hd
+  have framed := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ regionBase) ** (.x14 ↦ᵣ v14) **
+      (.x15 ↦ᵣ v15) ** bytesRegion regionBase (pfx :: rest))
+    (by exact pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs
+      (pcFree_sepConj pcFree_regIs (bytesRegion_pcFree _ _))))) handler
+  -- Reshape the framed pre to the goal pre (xperm), and append the verdict to the post.
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) ?_ framed
+  intro s hq
+  have hgoal := (sepConj_pure_right s).2 ⟨hq, hsome⟩
+  xperm_hyp hgoal
+
+-- Concrete cross-check: a single byte `0x42` decodes to the one-byte string `[0x42]`.
+example (regionBase base target : Word) (offset : BitVec 13) (v10 v11 v12 v14 v15 : Word)
+    (htarget : (base + 4) + signExtend13 offset = target)
+    (hd : (rlp_phase1_step_code 0x80 offset base).Disjoint
+            (CodeReq.ofProg target rlp_phase3_single_byte_prog)) :=
+  rlp_decode_singleByte_validated (0x42 : Byte) [0x99] v10 v11 v12 v14 v15 regionBase
+    offset base target (by decide) htarget hd
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -1932,6 +1932,33 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     record to `publicValues` and recovering every field value. Concrete end-to-end example: the host
     supplies `[0xc4,0x2a,0x82,0x01,0x02]` at `0x2000`, decoded to `0x3000` and committed.
     Axiom-clean, 0 sorry, no `bv_decide`/`native_decide`, no heartbeat overrides.
+### EL.4 Untrusted-input RLP decoders (#9373, in progress)
+The Phase-1..6 decoder above assumes the input is a well-formed encoding (precondition
+`bs = encode(...) ++ tail`). Issue #9373 wants decoders over **untrusted** input whose spec covers
+both outcomes: valid RLP of the expected shape → success, else → **fail** (nonzero `a0`); plus
+**specialized** per-shape decoders (header/tx/MPT) that **abort early** the moment a fixed-arity list
+shows more elements than expected (no decode-then-count). Layering:
+- **Phase A — pure rejection bridges (done).** `EvmAsm/EL/RLP/{ByteStringDecodeBridge,ListDecodeBridge,
+  ReadLength,FullDecode}.lean` give per-class `…_eq_some_iff` AND `…_eq_none_of_*` characterizations
+  (OOB length, leading-zero/`≤55` non-canonical long form, single-byte-not-wrapped, list leftover) — the
+  verdicts a validating decoder discharges. The pure `decode`/`decodeFully`/`decodeScalar` already reject
+  every invalidity class.
+- **Phase B — RV64 validating decoders (in progress).** 2-exit `cpsBranchWithin` with `⌜decode = some…⌝`
+  / `⌜decode = none⌝` posts and NO validity hypotheses; untrusted-length contract `x15 = L`
+  (the codegen K20 model), a thin wrapper sets `a0`.
+  - ✅ **B.1 — validating shortBytes (non-singleton)** (`UnifiedDecodeItemShortBytesValidated.lean`,
+    `rlp_decode_shortBytes_validated`): handler ⨾ `BLTU x11, x15` bound check. Taken (`len < L`) ⇒
+    `decode = some (.bytes …)`; fall ⇒ `decode = none` (truncated). `payloadLen ≠ 1` (singleton-canonical
+    check vacuous).
+  - ✅ **B.2 — validating singleByte** (`UnifiedDecodeItemSingleByteValidated.lean`,
+    `rlp_decode_singleByte_validated`): a canonical single byte always decodes, so a single-exit
+    `cpsTripleWithin` carrying `⌜decode = some (.bytes [pfx], rest)⌝`; full untrusted-decoder register/mem
+    interface framed through the e1 handler. No failure case. Axiom-clean, concrete `0x42` example.
+  - ⏳ **Next**: `0x81` singleton-canonical sub-branch (drops `hns`, completes shortBytes); longBytes
+    (bound + leading-zero/`≤55` rejection); shortList/longList payload-window; 5-way unified validating
+    decoder; then the early-abort field walker (Step 2) → block-header decoder (Step 3, target order:
+    header → EIP-1559 tx → MPT node → legacy tx).
+
 - **Host I/O ABI**: See `docs/zkvm-host-io-interface.md`; SP1
   `HINT_LEN`/`HINT_READ`/`COMMIT` are legacy handler shapes, not the target
   C ABI.


### PR DESCRIPTION
## Summary

Phase B.2 of #9373 — the `singleByte` arm of the untrusted single-item RLP decoder.

A canonical single byte (`p < 0x80`) is *always* a valid RLP encoding of the one-byte string `[p]` (the prefix IS the data), so unlike short/long byte strings and lists there is **no failure case**. The validating interface is therefore a single-exit `cpsTripleWithin` whose post carries the success verdict `⌜decode (pfx :: rest) = some (.bytes [pfx], rest)⌝`, with **no validity hypotheses** on the input.

`rlp_decode_singleByte_validated` (`UnifiedDecodeItemSingleByteValidated.lean`) frames the full untrusted-decoder register/memory interface (`x12` / `x13 = regionBase` / `x14` / `x15 = L` / `bytesRegion`) through the register-only e1 handler `rlp_phase1_e1_single_byte_of_class_spec_within`, then appends the verdict via `sepConj_pure_right`. The verdict is discharged unconditionally by the Phase-A bridge `decodeAux_cons_singleByte_eq_some_iff`. The uniform interface lets this compose with the other (branching) class arms in the eventual 5-way unified validating decoder.

This follows Phase B.1 (validating shortBytes, merged in b6f848b3e) and is part of the untrusted-input decoder arc tracked in the new PLAN.md §EL.4.

## Test plan
- `lake build EvmAsm.Rv64.RLP` ✅ (builds, concrete `0x42` cross-check `example`)
- Axiom-clean: `#print axioms rlp_decode_singleByte_validated` → `[propext, Classical.choice, Quot.sound]` only
- `scripts/check-forbidden-tactics.sh` ✅ (no `bv_decide`/`native_decide`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)