### PR TITLE
feat(mulmod): total MULMOD correctness — carry-fix removes n≤2^255

### DIFF
--- a/EvmAsm/Evm64/MulMod.lean
+++ b/EvmAsm/Evm64/MulMod.lean
@@ -70,4 +70,6 @@ import EvmAsm.Evm64.MulMod.Compose.ZeroPathTail
 import EvmAsm.Evm64.MulMod.Compose.Dispatch
 import EvmAsm.Evm64.MulMod.Compose.DispatchZero
 import EvmAsm.Evm64.MulMod.Compose.StackSpec
+import EvmAsm.Evm64.MulMod.Compose.DispatchAll
+import EvmAsm.Evm64.MulMod.Compose.StackSpecAll
 import EvmAsm.Evm64.MulMod.Spec

--- a/EvmAsm/Evm64/MulMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/MulMod/Compose/Base.lean
@@ -477,11 +477,11 @@ theorem evm_mulmod_program_code_reduce512_init_sub
   · rw [evm_mulmod_length, evm_mulmod_reduce512_init_length]; decide
   · rw [evm_mulmod_length]; decide
 
-/-- The reducer result-copy block at offset 2116 is subsumed by the top-level
+/-- The reducer result-copy block at offset 2124 is subsumed by the top-level
     `evm_mulmod_program_code`. -/
 theorem evm_mulmod_program_code_reduce512_write_result_sub
     (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + 2116) evm_mulmod_reduce512_write_result) a = some i →
+    ∀ a i, (CodeReq.ofProg (base + 2124) evm_mulmod_reduce512_write_result) a = some i →
       (evm_mulmod_program_code base) a = some i := by
   intro a i h
   unfold evm_mulmod_program_code
@@ -495,13 +495,13 @@ theorem evm_mulmod_program_code_reduce512_write_result_sub
     evm_mulmod_reduce512_loop
   let mid : Program := evm_mulmod_reduce512_write_result
   let suf : Program := evm_mulmod_epilogue
-  have hpre_len : pre.length = 529 := by
+  have hpre_len : pre.length = 531 := by
     unfold pre
     simp only [seq, Program.length_append, evm_mulmod_nonzero_or_zero_prefix_length,
       evm_mulmod_reduce_zero_path_length, evm_mulmod_epilogue_length,
       evm_mulmod_zero_path_skip_nonzero_length, evm_mulmod_product_layout_length,
       evm_mulmod_reduce512_init_length, evm_mulmod_reduce512_loop_length]
-  have haddr : base + BitVec.ofNat 64 (4 * pre.length) = base + 2116 := by
+  have haddr : base + BitVec.ofNat 64 (4 * pre.length) = base + 2124 := by
     rw [hpre_len]
     bv_omega
   have hfull : pre ++ mid ++ suf = evm_mulmod := by
@@ -524,11 +524,11 @@ theorem evm_mulmod_program_code_reduce512_write_result_sub
     rw [hlen, evm_mulmod_length]
     decide) a i h
 
-/-- The final reducer epilogue at offset 2148 is subsumed by the top-level
+/-- The final reducer epilogue at offset 2156 is subsumed by the top-level
     `evm_mulmod_program_code`. -/
 theorem evm_mulmod_program_code_reduce512_epilogue_sub
     (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + 2148) evm_mulmod_epilogue) a = some i →
+    ∀ a i, (CodeReq.ofProg (base + 2156) evm_mulmod_epilogue) a = some i →
       (evm_mulmod_program_code base) a = some i := by
   intro a i h
   unfold evm_mulmod_program_code
@@ -543,14 +543,14 @@ theorem evm_mulmod_program_code_reduce512_epilogue_sub
     evm_mulmod_reduce512_write_result
   let mid : Program := evm_mulmod_epilogue
   let suf : Program := []
-  have hpre_len : pre.length = 537 := by
+  have hpre_len : pre.length = 539 := by
     unfold pre
     simp only [seq, Program.length_append,
       evm_mulmod_nonzero_or_zero_prefix_length, evm_mulmod_reduce_zero_path_length,
       evm_mulmod_epilogue_length, evm_mulmod_zero_path_skip_nonzero_length,
       evm_mulmod_product_layout_length, evm_mulmod_reduce512_init_length,
       evm_mulmod_reduce512_loop_length, evm_mulmod_reduce512_write_result_length]
-  have haddr : base + BitVec.ofNat 64 (4 * pre.length) = base + 2148 := by
+  have haddr : base + BitVec.ofNat 64 (4 * pre.length) = base + 2156 := by
     rw [hpre_len]
     bv_omega
   have hfull : pre ++ mid ++ suf = evm_mulmod := by
@@ -634,7 +634,7 @@ theorem evm_mulmod_epilogue_evm_mulmod_spec_within
 /-- Zero-path skip spec lifted onto `evm_mulmod_program_code`. -/
 theorem evm_mulmod_zero_path_skip_nonzero_evm_mulmod_spec_within
     (base : Word) :
-    cpsTripleWithin 1 (base + 52) ((base + 52) + signExtend21 (2100 : BitVec 21))
+    cpsTripleWithin 1 (base + 52) ((base + 52) + signExtend21 (2108 : BitVec 21))
       (evm_mulmod_program_code base)
       empAssertion
       empAssertion :=
@@ -714,7 +714,7 @@ theorem evm_mulmod_reduce512_init_evm_mulmod_spec_within (sp : Word) (base : Wor
 /-- Reducer result-copy spec lifted onto `evm_mulmod_program_code`. -/
 theorem evm_mulmod_reduce512_write_result_evm_mulmod_spec_within (sp : Word) (base : Word)
     (v5Old r0 r1 r2 r3 m0 m1 m2 m3 : Word) :
-    cpsTripleWithin 8 (base + 2116) ((base + 2116) + 32) (evm_mulmod_program_code base)
+    cpsTripleWithin 8 (base + 2124) ((base + 2124) + 32) (evm_mulmod_program_code base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5Old) **
        ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ r0) **
        ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ r1) **
@@ -734,7 +734,7 @@ theorem evm_mulmod_reduce512_write_result_evm_mulmod_spec_within (sp : Word) (ba
        ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ r2) **
        ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ r3)) :=
   cpsTripleWithin_extend_code
-    (h := evm_mulmod_reduce512_write_result_spec_within sp (base + 2116)
+    (h := evm_mulmod_reduce512_write_result_spec_within sp (base + 2124)
       v5Old r0 r1 r2 r3 m0 m1 m2 m3)
     (hmono := evm_mulmod_program_code_reduce512_write_result_sub base)
 
@@ -742,11 +742,11 @@ theorem evm_mulmod_reduce512_write_result_evm_mulmod_spec_within (sp : Word) (ba
 /-- Final reducer epilogue spec lifted onto `evm_mulmod_program_code`. -/
 theorem evm_mulmod_reduce512_epilogue_evm_mulmod_spec_within
     (sp : Word) (base : Word) :
-    cpsTripleWithin 1 (base + 2148) ((base + 2148) + 4) (evm_mulmod_program_code base)
+    cpsTripleWithin 1 (base + 2156) ((base + 2156) + 4) (evm_mulmod_program_code base)
       (.x12 ↦ᵣ sp)
       (.x12 ↦ᵣ (sp + signExtend12 (64 : BitVec 12))) :=
   cpsTripleWithin_extend_code
-    (h := evm_mulmod_epilogue_spec_within sp (base + 2148))
+    (h := evm_mulmod_epilogue_spec_within sp (base + 2156))
     (hmono := evm_mulmod_program_code_reduce512_epilogue_sub base)
 
 

--- a/EvmAsm/Evm64/MulMod/Compose/Dispatch.lean
+++ b/EvmAsm/Evm64/MulMod/Compose/Dispatch.lean
@@ -2,7 +2,7 @@
   EvmAsm.Evm64.MulMod.Compose.Dispatch
 
   Top-level dispatch composition for the `evm_mulmod` program over the
-  `N ≠ 0` arm (`0 < n.toNat ≤ 2^255`).
+  `N ≠ 0` arm (`0 < n.toNat`, any modulus).
 
   The prefix branch (`evm_mulmod_nonzero_or_zero_prefix`) ORs the four limbs
   of `n` and branches: `orAll ≠ 0` jumps to the product/reduce body at
@@ -16,7 +16,7 @@
   are rewritten from `BitVec.ofNat 256 (a·b mod n)` to `EvmWord.mulmod a b n`
   via `EvmWord.mulmod_of_ne_zero`.
 
-  Exit address: `(base + 1816) + 336 = base + 2152`, the program exit.
+  Exit address: `(base + 1816) + 344 = base + 2160`, the program exit.
 -/
 
 import EvmAsm.Evm64.MulMod.Compose.ProductReduceValue
@@ -53,7 +53,7 @@ theorem evmWord_ne_zero_of_toNat_pos {n : EvmWord} (h : 0 < n.toNat) : n ≠ 0 :
 
 /-- Full `evm_mulmod` dispatch over the `N ≠ 0` arm.
 
-    Entry `base`, exit `base + 2152` (the program exit). The precondition is the
+    Entry `base`, exit `base + 2160` (the program exit). The precondition is the
     ambient `evm_mulmod` machine state: `x12 ↦ sp`, the `a`/`b`/`n` argument
     windows (`sp + 0 .. sp + 88`), the eight-cell product scratch window
     (`sp + 96 .. sp + 152`, arbitrary input garbage `p0..p7`), the modular
@@ -69,9 +69,9 @@ theorem evm_mulmod_dispatch_evm_mulmod_spec_within
     (p0 p1 p2 p3 p4 p5 p6 p7 : Word)
     (x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word)
     (v16Old v18Old r0 r1 r2 r3 : Word)
-    (hn0 : 0 < n.toNat) (hn : n.toNat ≤ 2 ^ 255) :
-    cpsTripleWithin (8 + (440 + (6 + (2 + 64 * 64 + 2 + 1) * 8 + 8 + 1)))
-      base (base + 2152) (evm_mulmod_program_code base)
+    (hn0 : 0 < n.toNat) :
+    cpsTripleWithin (8 + (440 + (6 + (2 + 66 * 64 + 2 + 1) * 8 + 8 + 1)))
+      base (base + 2160) (evm_mulmod_program_code base)
       -- Ambient pre: branch entry state ** the body's extra resources.
       (((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v5Old) ** (.x5 ↦ᵣ v6Old) ** (.x0 ↦ᵣ 0) **
         ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ n.getLimbN 0) **
@@ -103,7 +103,7 @@ theorem evm_mulmod_dispatch_evm_mulmod_spec_within
         ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3) **
         ((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
         ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3) **
-        regOwn .x8 ** regOwn .x9 ** regOwn .x14) **
+        regOwn .x9 ** regOwn .x14) **
        ((.x12 ↦ᵣ (sp + signExtend12 (64 : BitVec 12))) **
         (((.x5 ↦ᵣ EvmWord.getLimbN (EvmWord.mulmod a b n) 3) **
           ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN (EvmWord.mulmod a b n) 0) **
@@ -115,7 +115,7 @@ theorem evm_mulmod_dispatch_evm_mulmod_spec_within
           ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN (EvmWord.mulmod a b n) 2) **
           ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN (EvmWord.mulmod a b n) 3)) **
          (((.x15 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
-           regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
+           regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
            regOwn .x17 ** regOwn .x19 ** regOwn .x20 ** regOwn .x16 ** regOwn .x18) **
           limbChain (sp + signExtend12 (152 : BitVec 12)) (fun i => productLimb a b (7 - i)) 8)))) := by
   -- R_amb: resources the N ≠ 0 body needs beyond the branch's taken post `Q_t`.
@@ -156,7 +156,7 @@ theorem evm_mulmod_dispatch_evm_mulmod_spec_within
       sp base a b n p0 p1 p2 p3 p4 p5 p6 p7
       (n.getLimbN 3) (n.getLimbN 0 ||| n.getLimbN 1 ||| n.getLimbN 2 ||| n.getLimbN 3)
       x7Old x8Old x9Old x10Old x11Old x13Old x14Old
-      v16Old v18Old r0 r1 r2 r3 hn0 hn
+      v16Old v18Old r0 r1 r2 r3 hn0
     -- Sequence the taken arm with the body; the midpoint coercion strips the
     -- `⌜orAll ≠ 0⌝` pure fact, normalizes the n-cell addresses, and permutes.
     have hcomp := cpsTripleWithin_seq_perm_same_cr
@@ -173,10 +173,10 @@ theorem evm_mulmod_dispatch_evm_mulmod_spec_within
         xperm_hyp hp1)
       h_t0 hbody
     -- Rewrite the result word `BitVec.ofNat 256 (a·b mod n) = EvmWord.mulmod a b n`
-    -- and the exit `base + 1816 + 336 = base + 2152`.
+    -- and the exit `base + 1816 + 344 = base + 2160`.
     have hne : n ≠ 0 := evmWord_ne_zero_of_toNat_pos hn0
     rw [← EvmWord.mulmod_of_ne_zero a b n hne] at hcomp
-    have hexit2 : base + 1816 + 336 = base + 2152 := by
+    have hexit2 : base + 1816 + 344 = base + 2160 := by
       rw [BitVec.add_assoc]; congr 1
     rw [hexit2] at hcomp
     exact hcomp

--- a/EvmAsm/Evm64/MulMod/Compose/DispatchAll.lean
+++ b/EvmAsm/Evm64/MulMod/Compose/DispatchAll.lean
@@ -1,0 +1,173 @@
+/-
+  EvmAsm.Evm64.MulMod.Compose.DispatchAll
+
+  Top-level dispatch composition for the `evm_mulmod` program over **all**
+  moduli `n` (no hypothesis). The two dispatch arms
+  (`evm_mulmod_dispatch_evm_mulmod_spec_within`, `0 < n.toNat`, and
+  `evm_mulmod_dispatch_zero_evm_mulmod_spec_within`, `n = 0`) are weakened to a
+  common abstracted postcondition `evmMulModDispatchPost sp a b n` — the result
+  word `EvmWord.mulmod a b n` at `sp + 64` stays precise, while every scratch
+  register and clobbered stack cell is forgotten as `regOwn`/`memOwn`. A
+  `by_cases n = 0` then combines the arms unconditionally.
+
+  Both arms share the same entry `base`, exit `base + 2160` (the program exit),
+  precondition (the ambient `evm_mulmod` machine state), and result word, so the
+  merge needs no `n ≤ 2^255` restriction now that the reducer is carry-aware.
+  The two arms have different step bounds; the smaller `n = 0` bound is widened
+  to the larger `n ≠ 0` bound with `cpsTripleWithin_mono_nSteps`.
+-/
+
+import EvmAsm.Evm64.MulMod.Compose.Dispatch
+import EvmAsm.Evm64.MulMod.Compose.DispatchZero
+import EvmAsm.Evm64.MulMod.Compose.ProductReduceBridge
+import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Evm64.MulMod.Compose
+
+open EvmAsm.Rv64
+open EvmAsm.Evm64
+open EvmAsm.Evm64.MulMod.ProductAlgebra
+
+/-- The ambient `evm_mulmod` machine state at program entry, shared by both
+    dispatch arms. Verbatim copy of the dispatch arms' precondition. -/
+@[irreducible]
+def evmMulModDispatchPre (sp : Word) (a b n : EvmWord)
+    (v5Old v6Old : Word)
+    (p0 p1 p2 p3 p4 p5 p6 p7 : Word)
+    (x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word)
+    (v16Old v18Old r0 r1 r2 r3 : Word) : Assertion :=
+  ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v5Old) ** (.x5 ↦ᵣ v6Old) ** (.x0 ↦ᵣ 0) **
+    ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ n.getLimbN 0) **
+    ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ n.getLimbN 1) **
+    ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ n.getLimbN 2) **
+    ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ n.getLimbN 3)) **
+   ((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
+    ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3) **
+    ((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
+    ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3) **
+    ((sp + signExtend12 (96 : BitVec 12)) ↦ₘ p0) **
+    ((sp + signExtend12 (104 : BitVec 12)) ↦ₘ p1) **
+    ((sp + signExtend12 (112 : BitVec 12)) ↦ₘ p2) **
+    ((sp + signExtend12 (120 : BitVec 12)) ↦ₘ p3) **
+    ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ p4) **
+    ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+    ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+    ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7) **
+    (.x7 ↦ᵣ x7Old) ** (.x8 ↦ᵣ x8Old) ** (.x9 ↦ᵣ x9Old) ** (.x10 ↦ᵣ x10Old) **
+    (.x11 ↦ᵣ x11Old) ** (.x13 ↦ᵣ x13Old) ** (.x14 ↦ᵣ x14Old) **
+    (.x16 ↦ᵣ v16Old) ** (.x18 ↦ᵣ v18Old) **
+    ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ r0) **
+    ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ r1) **
+    ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ r2) **
+    ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ r3) **
+    regOwn .x15 ** regOwn .x17 ** regOwn .x19 ** regOwn .x20)
+
+/-- Abstracted dispatch postcondition shared by both arms.
+
+    The result word `EvmWord.mulmod a b n` sits at `sp + signExtend12 64` as a
+    precise `evmWordIs`; `x12` advances to `sp + signExtend12 64`. Every other
+    clobbered resource — the 16 scratch registers, the `a`/`b` argument window
+    (`sp .. sp + 56`), the eight-cell product scratch window
+    (`sp + 96 .. sp + 152`), and the modular accumulator window
+    (`sp + 224 .. sp + 248`) — is forgotten as `regOwn`/`memOwn`.
+
+    Bundled `@[irreducible]` so consumers see a handful of opaque atoms. -/
+@[irreducible]
+def evmMulModDispatchPost (sp : Word) (a b n : EvmWord) : Assertion :=
+  (.x12 ↦ᵣ (sp + signExtend12 (64 : BitVec 12))) **
+  evmWordIs (sp + signExtend12 (64 : BitVec 12)) (EvmWord.mulmod a b n) **
+  regOwn .x0 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x8 **
+  regOwn .x9 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 ** regOwn .x14 **
+  regOwn .x15 ** regOwn .x16 ** regOwn .x17 ** regOwn .x18 ** regOwn .x19 **
+  regOwn .x20 **
+  memOwn sp ** memOwn (sp + 8) ** memOwn (sp + 16) ** memOwn (sp + 24) **
+  memOwn (sp + 32) ** memOwn (sp + 40) ** memOwn (sp + 48) ** memOwn (sp + 56) **
+  memOwn (sp + signExtend12 (96 : BitVec 12)) **
+  memOwn (sp + signExtend12 (104 : BitVec 12)) **
+  memOwn (sp + signExtend12 (112 : BitVec 12)) **
+  memOwn (sp + signExtend12 (120 : BitVec 12)) **
+  memOwn (sp + signExtend12 (128 : BitVec 12)) **
+  memOwn (sp + signExtend12 (136 : BitVec 12)) **
+  memOwn (sp + signExtend12 (144 : BitVec 12)) **
+  memOwn (sp + signExtend12 (152 : BitVec 12)) **
+  memOwn (sp + signExtend12 (224 : BitVec 12)) **
+  memOwn (sp + signExtend12 (232 : BitVec 12)) **
+  memOwn (sp + signExtend12 (240 : BitVec 12)) **
+  memOwn (sp + signExtend12 (248 : BitVec 12))
+
+/-- Full `evm_mulmod` dispatch over **all** moduli `n` (no hypothesis).
+
+    Entry `base`, exit `base + 2160` (the program exit). From the ambient
+    machine state `evmMulModDispatchPre`, the program leaves
+    `evmMulModDispatchPost`: the result word `EvmWord.mulmod a b n` at
+    `sp + 64` as `evmWordIs` with everything else forgotten as scratch.
+    Combines the `n ≠ 0` and `n = 0` arms by `by_cases n = 0`; total now that
+    the reducer is carry-aware. -/
+theorem evm_mulmod_dispatch_all_evm_mulmod_spec_within
+    (sp base : Word) (a b n : EvmWord)
+    (v5Old v6Old : Word)
+    (p0 p1 p2 p3 p4 p5 p6 p7 : Word)
+    (x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word)
+    (v16Old v18Old r0 r1 r2 r3 : Word) :
+    cpsTripleWithin (8 + (440 + (6 + (2 + 66 * 64 + 2 + 1) * 8 + 8 + 1)))
+      base (base + 2160) (evm_mulmod_program_code base)
+      (evmMulModDispatchPre sp a b n v5Old v6Old p0 p1 p2 p3 p4 p5 p6 p7
+        x7Old x8Old x9Old x10Old x11Old x13Old x14Old v16Old v18Old r0 r1 r2 r3)
+      (evmMulModDispatchPost sp a b n) := by
+  have se72 : signExtend12 (72 : BitVec 12) = (72 : Word) := by decide
+  have se80 : signExtend12 (80 : BitVec 12) = (80 : Word) := by decide
+  have se88 : signExtend12 (88 : BitVec 12) = (88 : Word) := by decide
+  by_cases hnz : n = 0
+  · -- N = 0 arm: widen the small step bound up to the N ≠ 0 bound.
+    have harm : cpsTripleWithin (8 + (440 + (6 + (2 + 66 * 64 + 2 + 1) * 8 + 8 + 1)))
+        base (base + 2160) (evm_mulmod_program_code base) _ _ :=
+      cpsTripleWithin_mono_nSteps (by decide)
+      (evm_mulmod_dispatch_zero_evm_mulmod_spec_within sp base a b n v5Old v6Old
+        p0 p1 p2 p3 p4 p5 p6 p7 x7Old x8Old x9Old x10Old x11Old x13Old x14Old
+        v16Old v18Old r0 r1 r2 r3 hnz)
+    refine cpsTripleWithin_weaken (fun h hp => by
+        unfold evmMulModDispatchPre at hp; xperm_hyp hp) ?_ harm
+    intro h hq
+    -- Fold the zeroed result cells into `evmWordIs (sp + 64) (mulmod a b n)`.
+    simp only [signExtend12_64, se72, se80, se88] at hq
+    rw [← evmWordIs_sp64_limbs_eq sp (EvmWord.mulmod a b n) _ _ _ _ rfl rfl rfl rfl] at hq
+    -- Forget every concrete scratch register/cell (regIs → regOwn, memIs → memOwn)
+    -- in native order; the trailing `regOwn x15/x17/x19/x20` pass through identity.
+    replace hq := sepConj_mono_right (sepConj_mono (regIs_to_regOwn _ _) (sepConj_mono (regIs_to_regOwn _ _) (sepConj_mono (regIs_to_regOwn _ _) (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono (regIs_to_regOwn _ _) (sepConj_mono (regIs_to_regOwn _ _) (sepConj_mono (regIs_to_regOwn _ _) (sepConj_mono (regIs_to_regOwn _ _) (sepConj_mono (regIs_to_regOwn _ _) (sepConj_mono (regIs_to_regOwn _ _) (sepConj_mono (regIs_to_regOwn _ _) (sepConj_mono (regIs_to_regOwn _ _) (sepConj_mono (regIs_to_regOwn _ _) (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn ((fun _ x => x)))))))))))))))))))))))))))))))))) h hq
+    show evmMulModDispatchPost sp a b n h
+    unfold evmMulModDispatchPost
+    simp only [signExtend12_64]
+    xperm_hyp hq
+  · -- N ≠ 0 arm.
+    have hn0 : 0 < n.toNat := by
+      rcases Nat.eq_zero_or_pos n.toNat with h | h
+      · exact absurd (by rw [← BitVec.toNat_inj]; simpa using h) hnz
+      · exact h
+    have harm := evm_mulmod_dispatch_evm_mulmod_spec_within sp base a b n v5Old v6Old
+      p0 p1 p2 p3 p4 p5 p6 p7 x7Old x8Old x9Old x10Old x11Old x13Old x14Old
+      v16Old v18Old r0 r1 r2 r3 hn0
+    refine cpsTripleWithin_weaken (fun h hp => by
+        unfold evmMulModDispatchPre at hp; xperm_hyp hp) ?_ harm
+    intro h hq
+    -- Unfold the product `limbChain` window into eight explicit cells, then fold
+    -- the result cells into `evmWordIs`.
+    simp only [limbChain_productLimb_eq, signExtend12_64, se72, se80, se88] at hq
+    rw [← evmWordIs_sp64_limbs_eq sp (EvmWord.mulmod a b n) _ _ _ _ rfl rfl rfl rfl] at hq
+    -- Forget every concrete scratch register/cell, navigating the arm's nested
+    -- post tree: G1 (a/b cells + regOwn x9,x14), x12, G2 (x5 + accum cells +
+    -- evmWordIs), G3 (x15,x0 + regOwn …), G4 (product cells).
+    replace hq := sepConj_mono
+      (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn ((fun _ x => x))))))))))
+      (sepConj_mono (fun _ x => x)
+        (sepConj_mono
+          (sepConj_mono (regIs_to_regOwn _ _) (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn ((fun _ x => x)))))))
+          (sepConj_mono
+            (sepConj_mono (regIs_to_regOwn _ _) (sepConj_mono (regIs_to_regOwn _ _) ((fun _ x => x))))
+            (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn (memIs_implies_memOwn))))))))))) h hq
+    show evmMulModDispatchPost sp a b n h
+    unfold evmMulModDispatchPost
+    simp only [signExtend12_64]
+    xperm_hyp hq
+
+end EvmAsm.Evm64.MulMod.Compose

--- a/EvmAsm/Evm64/MulMod/Compose/DispatchZero.lean
+++ b/EvmAsm/Evm64/MulMod/Compose/DispatchZero.lean
@@ -17,7 +17,7 @@
   as `EvmWord.getLimbN (EvmWord.mulmod a b n) k` to match the N ≠ 0 dispatch's
   post shape. The product window and accumulator window are untouched.
 
-  Exit address: `(base + 52) + signExtend21 2100 = base + 2152`, the program
+  Exit address: `(base + 52) + signExtend21 2108 = base + 2160`, the program
   exit.
 -/
 
@@ -35,7 +35,7 @@ open EvmAsm.Evm64.MulMod.ProductAlgebra
 
 /-- Full `evm_mulmod` dispatch over the `N = 0` arm.
 
-    Entry `base`, exit `base + 2152` (the program exit). The precondition is the
+    Entry `base`, exit `base + 2160` (the program exit). The precondition is the
     ambient `evm_mulmod` machine state: `x12 ↦ sp`, the `a`/`b`/`n` argument
     windows (`sp + 0 .. sp + 88`), the eight-cell product scratch window
     (`sp + 96 .. sp + 152`, arbitrary input garbage `p0..p7`), the modular
@@ -54,7 +54,7 @@ theorem evm_mulmod_dispatch_zero_evm_mulmod_spec_within
     (v16Old v18Old r0 r1 r2 r3 : Word)
     (hnz : n = 0) :
     cpsTripleWithin (8 + (4 + 1 + 1))
-      base (base + 2152) (evm_mulmod_program_code base)
+      base (base + 2160) (evm_mulmod_program_code base)
       -- Ambient pre: identical to the N ≠ 0 dispatch PRE.
       (((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v5Old) ** (.x5 ↦ᵣ v6Old) ** (.x0 ↦ᵣ 0) **
         ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ n.getLimbN 0) **
@@ -155,8 +155,8 @@ theorem evm_mulmod_dispatch_zero_evm_mulmod_spec_within
       (fun h hp => by
         xperm_hyp hp)
       h_f0 htailF
-    -- Exit alignment: `(base + 52) + signExtend21 2100 = base + 2152`.
-    have hexit : (base + 52) + signExtend21 (2100 : BitVec 21) = base + 2152 := by
+    -- Exit alignment: `(base + 52) + signExtend21 2108 = base + 2160`.
+    have hexit : (base + 52) + signExtend21 (2108 : BitVec 21) = base + 2160 := by
       rw [BitVec.add_assoc]; congr 1
     rw [hexit] at hcomp
     -- The zeroed result slots equal `EvmWord.getLimbN (EvmWord.mulmod a b n) k`.

--- a/EvmAsm/Evm64/MulMod/Compose/ProductReduce.lean
+++ b/EvmAsm/Evm64/MulMod/Compose/ProductReduce.lean
@@ -25,6 +25,7 @@ open EvmAsm.Rv64
 open EvmAsm.Evm64
 open EvmAsm.Evm64.MulMod.ProductAlgebra
 
+set_option linter.unusedSimpArgs false in
 /-- Compose the product-layout body with the 512-bit reducer into a single
     spec over `evm_mulmod_program_code`, covering the N ≠ 0 path from product
     construction through modular reduction. The product window emitted by
@@ -35,8 +36,8 @@ theorem evm_mulmod_product_reduce_evm_mulmod_spec_within
     (p0 p1 p2 p3 p4 p5 p6 p7 : Word)
     (x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word)
     (v16Old v18Old r0 r1 r2 r3 : Word) :
-    cpsTripleWithin (440 + (6 + (2 + 64 * 64 + 2 + 1) * 8 + 8 + 1))
-      (base + 56) ((base + 1816) + 336) (evm_mulmod_program_code base)
+    cpsTripleWithin (440 + (6 + (2 + 66 * 64 + 2 + 1) * 8 + 8 + 1))
+      (base + 56) ((base + 1816) + 344) (evm_mulmod_program_code base)
       ((evmMulModProductLayoutPre sp a b n p0 p1 p2 p3 p4 p5 p6 p7 **
         ((.x5 ↦ᵣ x5Old) ** (.x6 ↦ᵣ x6Old) ** (.x7 ↦ᵣ x7Old) ** (.x8 ↦ᵣ x8Old) **
          (.x9 ↦ᵣ x9Old) ** (.x10 ↦ᵣ x10Old) ** (.x11 ↦ᵣ x11Old) **
@@ -51,19 +52,19 @@ theorem evm_mulmod_product_reduce_evm_mulmod_spec_within
         ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3) **
         ((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
         ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3) **
-        regOwn .x8 ** regOwn .x9 ** regOwn .x14) **
+        regOwn .x9 ** regOwn .x14) **
        ((.x12 ↦ᵣ (sp + signExtend12 (64 : BitVec 12))) **
-        (((.x5 ↦ᵣ EvmWord.getLimbN (mulModReduceOuterFold n (fun i => productLimb a b (7 - i)) (0 : EvmWord) 8) 3) **
-          ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n (fun i => productLimb a b (7 - i)) (0 : EvmWord) 8) 0) **
-          ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n (fun i => productLimb a b (7 - i)) (0 : EvmWord) 8) 1) **
-          ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n (fun i => productLimb a b (7 - i)) (0 : EvmWord) 8) 2) **
-          ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n (fun i => productLimb a b (7 - i)) (0 : EvmWord) 8) 3) **
-          ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n (fun i => productLimb a b (7 - i)) (0 : EvmWord) 8) 0) **
-          ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n (fun i => productLimb a b (7 - i)) (0 : EvmWord) 8) 1) **
-          ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n (fun i => productLimb a b (7 - i)) (0 : EvmWord) 8) 2) **
-          ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n (fun i => productLimb a b (7 - i)) (0 : EvmWord) 8) 3)) **
+        (((.x5 ↦ᵣ EvmWord.getLimbN (mulModReduceOuterFoldCarry n (fun i => productLimb a b (7 - i)) (0 : EvmWord) 8) 3) **
+          ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n (fun i => productLimb a b (7 - i)) (0 : EvmWord) 8) 0) **
+          ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n (fun i => productLimb a b (7 - i)) (0 : EvmWord) 8) 1) **
+          ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n (fun i => productLimb a b (7 - i)) (0 : EvmWord) 8) 2) **
+          ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n (fun i => productLimb a b (7 - i)) (0 : EvmWord) 8) 3) **
+          ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n (fun i => productLimb a b (7 - i)) (0 : EvmWord) 8) 0) **
+          ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n (fun i => productLimb a b (7 - i)) (0 : EvmWord) 8) 1) **
+          ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n (fun i => productLimb a b (7 - i)) (0 : EvmWord) 8) 2) **
+          ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n (fun i => productLimb a b (7 - i)) (0 : EvmWord) 8) 3)) **
          (((.x15 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
-           regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
+           regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
            regOwn .x17 ** regOwn .x19 ** regOwn .x20 ** regOwn .x16 ** regOwn .x18) **
           limbChain (sp + signExtend12 (152 : BitVec 12)) (fun i => productLimb a b (7 - i)) 8)))) := by
   -- Frame onto the product-layout spec the resources `reduce512` needs that
@@ -86,7 +87,7 @@ theorem evm_mulmod_product_reduce_evm_mulmod_spec_within
      ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3) **
      ((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
      ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3) **
-     regOwn .x8 ** regOwn .x9 ** regOwn .x14)
+     regOwn .x9 ** regOwn .x14)
     (by pcFree)
     (evm_mulmod_reduce512_evm_mulmod_spec_within sp base
       v16Old v18Old r0 r1 r2 r3 n (fun i => productLimb a b (7 - i)))
@@ -94,8 +95,6 @@ theorem evm_mulmod_product_reduce_evm_mulmod_spec_within
   have hmid : (base + 56) + 1760 = base + 1816 := by
     rw [BitVec.add_assoc]; congr 1
   rw [hmid] at h1
-  -- The intermediate assertions are permutations of the same multiset after
-  -- rewriting the reducer's `limbChain` window into the explicit product cells.
   -- Normalize the n-cell addresses `sp + signExtend12 N` (N ∈ {72,80,88}) to the
   -- plain-`Word` form `sp + N` used by `product_layout`'s output. `signExtend12 64`
   -- already has a `@[simp]` lemma; the other three reduce by `decide`.

--- a/EvmAsm/Evm64/MulMod/Compose/ProductReduceValue.lean
+++ b/EvmAsm/Evm64/MulMod/Compose/ProductReduceValue.lean
@@ -2,15 +2,16 @@
   EvmAsm.Evm64.MulMod.Compose.ProductReduceValue
 
   Value-level restatement of `evm_mulmod_product_reduce_evm_mulmod_spec_within`:
-  for `0 < n ≤ 2^255` the result slots hold the EVM `MULMOD` result word
-  `BitVec.ofNat 256 (a·b mod n)` rather than the raw
-  `mulModReduceOuterFold` fold. Rewriting via
-  `mulModReduceOuterFold_productLimb_eq_evmWord` turns the value form back into
-  the fold and discharges the goal with the A2 spec.
+  for **every** positive modulus `n` the result slots hold the EVM `MULMOD`
+  result word `BitVec.ofNat 256 (a·b mod n)` rather than the raw
+  `mulModReduceOuterFoldCarry` fold. Rewriting via the total bridge
+  `mulModReduceOuterFoldCarry_productLimb_eq_evmWord` turns the value form back
+  into the carry-aware fold and discharges the goal with the A2 spec. Since the
+  reducer is genuinely carry-aware, this carries no `n ≤ 2^255` restriction.
 -/
 
 import EvmAsm.Evm64.MulMod.Compose.ProductReduce
-import EvmAsm.Evm64.MulMod.ReduceCarryAgree
+import EvmAsm.Evm64.MulMod.ProductLimbsValue
 
 namespace EvmAsm.Evm64.MulMod.Compose
 
@@ -19,17 +20,17 @@ open EvmAsm.Evm64
 open EvmAsm.Evm64.MulMod.ProductAlgebra
 
 /-- Value-level form of `evm_mulmod_product_reduce_evm_mulmod_spec_within`: for
-    `0 < n ≤ 2^255` the result limbs equal those of the EVM `MULMOD` result word
-    `BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat)` instead of the raw outer
-    fold. -/
+    every positive modulus `n` the result limbs equal those of the EVM `MULMOD`
+    result word `BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat)` instead of the
+    raw carry-aware outer fold. -/
 theorem evm_mulmod_product_reduce_value_evm_mulmod_spec_within
     (sp base : Word) (a b n : EvmWord)
     (p0 p1 p2 p3 p4 p5 p6 p7 : Word)
     (x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word)
     (v16Old v18Old r0 r1 r2 r3 : Word)
-    (hn0 : 0 < n.toNat) (hn : n.toNat ≤ 2 ^ 255) :
-    cpsTripleWithin (440 + (6 + (2 + 64 * 64 + 2 + 1) * 8 + 8 + 1))
-      (base + 56) ((base + 1816) + 336) (evm_mulmod_program_code base)
+    (hn0 : 0 < n.toNat) :
+    cpsTripleWithin (440 + (6 + (2 + 66 * 64 + 2 + 1) * 8 + 8 + 1))
+      (base + 56) ((base + 1816) + 344) (evm_mulmod_program_code base)
       ((evmMulModProductLayoutPre sp a b n p0 p1 p2 p3 p4 p5 p6 p7 **
         ((.x5 ↦ᵣ x5Old) ** (.x6 ↦ᵣ x6Old) ** (.x7 ↦ᵣ x7Old) ** (.x8 ↦ᵣ x8Old) **
          (.x9 ↦ᵣ x9Old) ** (.x10 ↦ᵣ x10Old) ** (.x11 ↦ᵣ x11Old) **
@@ -44,7 +45,7 @@ theorem evm_mulmod_product_reduce_value_evm_mulmod_spec_within
         ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3) **
         ((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
         ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3) **
-        regOwn .x8 ** regOwn .x9 ** regOwn .x14) **
+        regOwn .x9 ** regOwn .x14) **
        ((.x12 ↦ᵣ (sp + signExtend12 (64 : BitVec 12))) **
         (((.x5 ↦ᵣ EvmWord.getLimbN (BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat)) 3) **
           ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN (BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat)) 0) **
@@ -56,10 +57,10 @@ theorem evm_mulmod_product_reduce_value_evm_mulmod_spec_within
           ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN (BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat)) 2) **
           ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN (BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat)) 3)) **
          (((.x15 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
-           regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
+           regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
            regOwn .x17 ** regOwn .x19 ** regOwn .x20 ** regOwn .x16 ** regOwn .x18) **
           limbChain (sp + signExtend12 (152 : BitVec 12)) (fun i => productLimb a b (7 - i)) 8)))) := by
-  rw [← mulModReduceOuterFold_productLimb_eq_evmWord a b n hn0 hn]
+  rw [← mulModReduceOuterFoldCarry_productLimb_eq_evmWord a b n hn0]
   exact evm_mulmod_product_reduce_evm_mulmod_spec_within sp base a b n
     p0 p1 p2 p3 p4 p5 p6 p7 x5Old x6Old x7Old x8Old x9Old x10Old x11Old x13Old x14Old
     v16Old v18Old r0 r1 r2 r3

--- a/EvmAsm/Evm64/MulMod/Compose/Reducer.lean
+++ b/EvmAsm/Evm64/MulMod/Compose/Reducer.lean
@@ -36,14 +36,14 @@ theorem evm_mulmod_program_code_reduce512_sub
     `evm_mulmod_program_code` at offset 1816. -/
 theorem evm_mulmod_reduce512_evm_mulmod_spec_within
     (sp base : Word) (v16Old v18Old r0 r1 r2 r3 : Word) (n : EvmWord) (limbs : Nat → Word) :
-    cpsTripleWithin (6 + (2 + 64 * 64 + 2 + 1) * 8 + 8 + 1) (base + 1816) ((base + 1816) + 336)
+    cpsTripleWithin (6 + (2 + 66 * 64 + 2 + 1) * 8 + 8 + 1) (base + 1816) ((base + 1816) + 344)
       (evm_mulmod_program_code base)
       (((.x12 ↦ᵣ sp) ** (.x16 ↦ᵣ v16Old) ** (.x18 ↦ᵣ v18Old) ** (.x0 ↦ᵣ 0) **
         ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ r0) **
         ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ r1) **
         ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ r2) **
         ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ r3)) **
-       ((regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+       ((regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 **
          regOwn .x13 ** regOwn .x17 ** regOwn .x15 ** regOwn .x19 ** regOwn .x20 **
          ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 0) **
          ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 1) **
@@ -51,17 +51,17 @@ theorem evm_mulmod_reduce512_evm_mulmod_spec_within
          ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 3)) **
         limbChain (sp + signExtend12 (152 : BitVec 12)) limbs 8))
       ((.x12 ↦ᵣ (sp + signExtend12 (64 : BitVec 12))) **
-       (((.x5 ↦ᵣ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 3) **
-         ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 0) **
-         ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 1) **
-         ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 2) **
-         ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 3) **
-         ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 0) **
-         ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 1) **
-         ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 2) **
-         ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 3)) **
+       (((.x5 ↦ᵣ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 3) **
+         ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 0) **
+         ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 1) **
+         ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 2) **
+         ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 3) **
+         ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 0) **
+         ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 1) **
+         ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 2) **
+         ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 3)) **
         (((.x15 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
-          regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
+          regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
           regOwn .x17 ** regOwn .x19 ** regOwn .x20 ** regOwn .x16 ** regOwn .x18) **
          limbChain (sp + signExtend12 (152 : BitVec 12)) limbs 8))) :=
   cpsTripleWithin_extend_code

--- a/EvmAsm/Evm64/MulMod/Compose/StackSpec.lean
+++ b/EvmAsm/Evm64/MulMod/Compose/StackSpec.lean
@@ -2,7 +2,8 @@
   EvmAsm.Evm64.MulMod.Compose.StackSpec
 
   Stack-level lift of the `evm_mulmod` dispatch spec
-  (`evm_mulmod_dispatch_evm_mulmod_spec_within`) over the `N ≠ 0` arm.
+  (`evm_mulmod_dispatch_evm_mulmod_spec_within`) over the `N ≠ 0` arm
+  (`0 < n.toNat`, any modulus).
 
   The per-limb dispatch spec presents the `a` / `b` / `n` argument words and the
   `EvmWord.mulmod a b n` result word as raw limb-level memory atoms. This file
@@ -32,23 +33,23 @@ open EvmAsm.Evm64
 open EvmAsm.Evm64.MulMod.ProductAlgebra
 
 /-- Stack-level lift of `evm_mulmod_dispatch_evm_mulmod_spec_within` over the
-    `N ≠ 0` arm (`0 < n.toNat ≤ 2^255`).
+    `N ≠ 0` arm (`0 < n.toNat`, any modulus).
 
-    Identical entry/exit (`base` → `base + 2152`) and code requirement to the
+    Identical entry/exit (`base` → `base + 2160`) and code requirement to the
     dispatch spec, but the `a` / `b` / `n` argument windows are presented as
     `evmWordIs` predicates rather than four raw limb cells each, and the result
     window is `evmWordIs (sp + signExtend12 64) (EvmWord.mulmod a b n)`. The
     product scratch, modular-accumulator cells, scratch registers and `x12`
     pass through unchanged as a scratch frame. -/
-theorem evm_mulmod_stack_spec_within_nonzero_small
+theorem evm_mulmod_stack_spec_within_nonzero
     (sp base : Word) (a b n : EvmWord)
     (v5Old v6Old : Word)
     (p0 p1 p2 p3 p4 p5 p6 p7 : Word)
     (x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word)
     (v16Old v18Old r0 r1 r2 r3 : Word)
-    (hn0 : 0 < n.toNat) (hn : n.toNat ≤ 2 ^ 255) :
-    cpsTripleWithin (8 + (440 + (6 + (2 + 64 * 64 + 2 + 1) * 8 + 8 + 1)))
-      base (base + 2152) (evm_mulmod_program_code base)
+    (hn0 : 0 < n.toNat) :
+    cpsTripleWithin (8 + (440 + (6 + (2 + 66 * 64 + 2 + 1) * 8 + 8 + 1)))
+      base (base + 2160) (evm_mulmod_program_code base)
       -- Ambient pre: `a`/`b`/`n` argument words as `evmWordIs`, scratch verbatim.
       (((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v5Old) ** (.x5 ↦ᵣ v6Old) ** (.x0 ↦ᵣ 0) **
         evmWordIs (sp + signExtend12 (64 : BitVec 12)) n) **
@@ -74,7 +75,7 @@ theorem evm_mulmod_stack_spec_within_nonzero_small
         ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3) **
         ((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
         ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3) **
-        regOwn .x8 ** regOwn .x9 ** regOwn .x14) **
+        regOwn .x9 ** regOwn .x14) **
        ((.x12 ↦ᵣ (sp + signExtend12 (64 : BitVec 12))) **
         (((.x5 ↦ᵣ EvmWord.getLimbN (EvmWord.mulmod a b n) 3) **
           ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN (EvmWord.mulmod a b n) 0) **
@@ -83,7 +84,7 @@ theorem evm_mulmod_stack_spec_within_nonzero_small
           ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ EvmWord.getLimbN (EvmWord.mulmod a b n) 3) **
           evmWordIs (sp + signExtend12 (64 : BitVec 12)) (EvmWord.mulmod a b n)) **
          (((.x15 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
-           regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
+           regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
            regOwn .x17 ** regOwn .x19 ** regOwn .x20 ** regOwn .x16 ** regOwn .x18) **
           limbChain (sp + signExtend12 (152 : BitVec 12)) (fun i => productLimb a b (7 - i)) 8)))) := by
   have se72 : signExtend12 (72 : BitVec 12) = (72 : Word) := by decide
@@ -106,6 +107,6 @@ theorem evm_mulmod_stack_spec_within_nonzero_small
       xperm_hyp hq)
     (evm_mulmod_dispatch_evm_mulmod_spec_within sp base a b n v5Old v6Old
       p0 p1 p2 p3 p4 p5 p6 p7 x7Old x8Old x9Old x10Old x11Old x13Old x14Old
-      v16Old v18Old r0 r1 r2 r3 hn0 hn)
+      v16Old v18Old r0 r1 r2 r3 hn0)
 
 end EvmAsm.Evm64.MulMod.Compose

--- a/EvmAsm/Evm64/MulMod/Compose/StackSpecAll.lean
+++ b/EvmAsm/Evm64/MulMod/Compose/StackSpecAll.lean
@@ -1,0 +1,90 @@
+/-
+  EvmAsm.Evm64.MulMod.Compose.StackSpecAll
+
+  Total (hypothesis-free, all-`n`) stack-level spec for `evm_mulmod`.
+
+  Lifts `evm_mulmod_dispatch_all_evm_mulmod_spec_within` (the unconditional
+  both-arms dispatch) to present the `a` / `b` / `n` argument words as
+  `evmWordIs` predicates rather than four raw limb cells each. The result word
+  is already exposed as `evmWordIs (sp + signExtend12 64) (EvmWord.mulmod a b n)`
+  by the abstracted `evmMulModDispatchPost`.
+
+  This is the headline MULMOD contract: for **every** modulus `n` (including
+  `n = 0`, where `EvmWord.mulmod a b 0 = 0`, and `n > 2^255`, now that the
+  reducer is carry-aware), running `evm_mulmod` from `base` reaches the program
+  exit `base + 2160` leaving `(a · b) mod n` on the stack top.
+-/
+
+import EvmAsm.Evm64.MulMod.Compose.DispatchAll
+import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Evm64.MulMod.Compose
+
+open EvmAsm.Rv64
+open EvmAsm.Evm64
+open EvmAsm.Evm64.MulMod.ProductAlgebra
+
+/-- Total stack-level MULMOD spec — **hypothesis-free, all `n`**.
+
+    Entry `base`, exit `base + 2160` (the program exit), over
+    `evm_mulmod_program_code base`. The `a` / `b` / `n` argument words are
+    presented as `evmWordIs sp a`, `evmWordIs (sp + 32) b`,
+    `evmWordIs (sp + signExtend12 64) n`; the scratch product window
+    (`sp + 96 .. sp + 152`), modular-accumulator cells (`sp + 224 .. sp + 248`),
+    and scratch registers (`x0, x5 .. x20`) pass through as a frame. On exit the
+    stack top holds `evmWordIs (sp + signExtend12 64) (EvmWord.mulmod a b n)` and
+    everything else is forgotten as `regOwn`/`memOwn` (`evmMulModDispatchPost`).
+
+    Total: no `0 < n.toNat` and no `n ≤ 2^255` hypothesis — the carry-aware
+    reducer computes `(a · b) mod n` for every `n`, and the `n = 0` arm yields
+    `EvmWord.mulmod a b 0 = 0`. -/
+theorem evm_mulmod_stack_spec_within
+    (sp base : Word) (a b n : EvmWord)
+    (v5Old v6Old : Word)
+    (p0 p1 p2 p3 p4 p5 p6 p7 : Word)
+    (x7Old x8Old x9Old x10Old x11Old x13Old x14Old : Word)
+    (v16Old v18Old r0 r1 r2 r3 : Word) :
+    cpsTripleWithin (8 + (440 + (6 + (2 + 66 * 64 + 2 + 1) * 8 + 8 + 1)))
+      base (base + 2160) (evm_mulmod_program_code base)
+      -- Ambient pre: `a`/`b`/`n` argument words as `evmWordIs`, scratch verbatim.
+      (((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v5Old) ** (.x5 ↦ᵣ v6Old) ** (.x0 ↦ᵣ 0) **
+        evmWordIs (sp + signExtend12 (64 : BitVec 12)) n) **
+       (evmWordIs sp a ** evmWordIs (sp + 32) b **
+        ((sp + signExtend12 (96 : BitVec 12)) ↦ₘ p0) **
+        ((sp + signExtend12 (104 : BitVec 12)) ↦ₘ p1) **
+        ((sp + signExtend12 (112 : BitVec 12)) ↦ₘ p2) **
+        ((sp + signExtend12 (120 : BitVec 12)) ↦ₘ p3) **
+        ((sp + signExtend12 (128 : BitVec 12)) ↦ₘ p4) **
+        ((sp + signExtend12 (136 : BitVec 12)) ↦ₘ p5) **
+        ((sp + signExtend12 (144 : BitVec 12)) ↦ₘ p6) **
+        ((sp + signExtend12 (152 : BitVec 12)) ↦ₘ p7) **
+        (.x7 ↦ᵣ x7Old) ** (.x8 ↦ᵣ x8Old) ** (.x9 ↦ᵣ x9Old) ** (.x10 ↦ᵣ x10Old) **
+        (.x11 ↦ᵣ x11Old) ** (.x13 ↦ᵣ x13Old) ** (.x14 ↦ᵣ x14Old) **
+        (.x16 ↦ᵣ v16Old) ** (.x18 ↦ᵣ v18Old) **
+        ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ r3) **
+        regOwn .x15 ** regOwn .x17 ** regOwn .x19 ** regOwn .x20))
+      (evmMulModDispatchPost sp a b n) := by
+  have se72 : signExtend12 (72 : BitVec 12) = (72 : Word) := by decide
+  have se80 : signExtend12 (80 : BitVec 12) = (80 : Word) := by decide
+  have se88 : signExtend12 (88 : BitVec 12) = (88 : Word) := by decide
+  refine cpsTripleWithin_weaken (fun h hp => by
+      -- Pre: unfold the three `evmWordIs` argument words into raw limb cells,
+      -- normalizing the `n`-word's `signExtend12` offsets to `sp + 64/72/80/88`,
+      -- then permute into `evmMulModDispatchPre`.
+      rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ rfl rfl rfl rfl,
+          evmWordIs_sp32_limbs_eq sp b _ _ _ _ rfl rfl rfl rfl] at hp
+      simp only [signExtend12_64] at hp
+      rw [evmWordIs_sp64_limbs_eq sp n _ _ _ _ rfl rfl rfl rfl] at hp
+      unfold evmMulModDispatchPre
+      simp only [signExtend12_64, se72, se80, se88]
+      xperm_hyp hp)
+    (fun _ hq => hq)
+    (evm_mulmod_dispatch_all_evm_mulmod_spec_within sp base a b n v5Old v6Old
+      p0 p1 p2 p3 p4 p5 p6 p7 x7Old x8Old x9Old x10Old x11Old x13Old x14Old
+      v16Old v18Old r0 r1 r2 r3)
+
+end EvmAsm.Evm64.MulMod.Compose

--- a/EvmAsm/Evm64/MulMod/Compose/ZeroPathTail.lean
+++ b/EvmAsm/Evm64/MulMod/Compose/ZeroPathTail.lean
@@ -3,7 +3,7 @@
 
   The complete N = 0 path from the zero-store through the skip jump:
   `reduce_zero_path ;; epilogue ;; zero_path_skip_nonzero`, composed over
-  `evm_mulmod_program_code` (`base + 32` → `base + 2152`, the program exit). The
+  `evm_mulmod_program_code` (`base + 32` → `base + 2160`, the program exit). The
   zero-path body (`ZeroPathBody`) zeroes the result window and advances `x12`;
   the final `JAL` (`zero_path_skip_nonzero`) jumps over the N ≠ 0 path to the
   program exit while owning nothing, so it is framed with the (untouched)
@@ -21,7 +21,7 @@ open EvmAsm.Evm64
     program exit. -/
 theorem evm_mulmod_zero_path_tail_evm_mulmod_spec_within
     (sp m0 m1 m2 m3 base : Word) :
-    cpsTripleWithin (4 + 1 + 1) (base + 32) ((base + 52) + signExtend21 (2100 : BitVec 21))
+    cpsTripleWithin (4 + 1 + 1) (base + 32) ((base + 52) + signExtend21 (2108 : BitVec 21))
       (evm_mulmod_program_code base)
       ((.x12 ↦ᵣ sp) **
        ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ m0) **

--- a/EvmAsm/Evm64/MulMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/MulMod/LimbSpec.lean
@@ -101,14 +101,14 @@ abbrev evm_mulmod_zero_path_skip_nonzero_code (base : Word) : CodeReq :=
 theorem evm_mulmod_zero_path_skip_nonzero_spec_within
     (base : Word) :
     let code := evm_mulmod_zero_path_skip_nonzero_code base
-    cpsTripleWithin 1 base (base + signExtend21 (2100 : BitVec 21)) code
+    cpsTripleWithin 1 base (base + signExtend21 (2108 : BitVec 21)) code
       empAssertion
       empAssertion := by
-  show cpsTripleWithin 1 base (base + signExtend21 (2100 : BitVec 21))
+  show cpsTripleWithin 1 base (base + signExtend21 (2108 : BitVec 21))
     (CodeReq.ofProg base evm_mulmod_zero_path_skip_nonzero) _ _
   rw [show CodeReq.ofProg base evm_mulmod_zero_path_skip_nonzero =
-      CodeReq.singleton base (.JAL .x0 2100) from CodeReq.ofProg_singleton]
-  exact jal_x0_spec_gen_within 2100 base
+      CodeReq.singleton base (.JAL .x0 2108) from CodeReq.ofProg_singleton]
+  exact jal_x0_spec_gen_within 2108 base
 
 abbrev evm_mulmod_nonzero_or_zero_prefix_code (base : Word) : CodeReq :=
   CodeReq.ofProg base evm_mulmod_nonzero_or_zero_prefix

--- a/EvmAsm/Evm64/MulMod/ProductLimbsValue.lean
+++ b/EvmAsm/Evm64/MulMod/ProductLimbsValue.lean
@@ -59,4 +59,28 @@ theorem mulModLimbsValue_productLimb (a b : EvmWord) :
   rw [show 64 * (7 + 1) = 64 * 8 from rfl, Nat.mod_eq_of_lt hlt] at h
   exact h
 
+/-- Total MULMOD correctness of the carry-aware reducer: from the `r = 0`
+    initial state, the carry-aware outer fold of the product limbs computes
+    `(a·b) % n` for **every** positive modulus `n` (no `n ≤ 2^255`
+    restriction). -/
+theorem mulModReduceOuterFoldCarry_productLimb_eq_mod (a b n : EvmWord)
+    (hn0 : 0 < n.toNat) :
+    (mulModReduceOuterFoldCarry n (fun i => productLimb a b (7 - i)) 0 8).toNat
+      = a.toNat * b.toNat % n.toNat := by
+  rw [mulModReduceOuterFoldCarry_toNat_zero_start n _ 8 hn0, mulModLimbsValue_productLimb]
+
+/-- EvmWord form: for every positive modulus `n` the carry-aware reducer leaves
+    exactly the EVM `MULMOD` result word `((a·b) mod n)` truncated to 256 bits.
+    Total: no `n ≤ 2^255` hypothesis, since `(a·b) % n < n < 2^256` always. -/
+theorem mulModReduceOuterFoldCarry_productLimb_eq_evmWord (a b n : EvmWord)
+    (hn0 : 0 < n.toNat) :
+    mulModReduceOuterFoldCarry n (fun i => productLimb a b (7 - i)) 0 8
+      = BitVec.ofNat 256 (a.toNat * b.toNat % n.toNat) := by
+  have hlt256 : a.toNat * b.toNat % n.toNat < 2 ^ 256 := by
+    have h1 := Nat.mod_lt (a.toNat * b.toNat) hn0
+    have h2 : n.toNat < 2 ^ 256 := n.isLt
+    omega
+  rw [← BitVec.toNat_inj, mulModReduceOuterFoldCarry_productLimb_eq_mod a b n hn0,
+    BitVec.toNat_ofNat, Nat.mod_eq_of_lt hlt256]
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MulMod/Program.lean
+++ b/EvmAsm/Evm64/MulMod/Program.lean
@@ -356,7 +356,7 @@ def evm_mulmod_nonzero_or_zero_prefix : Program :=
 /-- Branch over the nonzero product/reduction path after the `N = 0` result.
     The target is the end of `evm_mulmod`. -/
 def evm_mulmod_zero_path_skip_nonzero : Program :=
-  JAL .x0 (2100 : BitVec 21)
+  JAL .x0 (2108 : BitVec 21)
 
 /-- Initialize the 256-bit remainder accumulator and loop cursors.
 
@@ -398,6 +398,8 @@ def evm_mulmod_reduce512_inner_step : Program :=
   SLLI .x6 .x5 1 ;;
   OR' .x6 .x6 .x20 ;;
   SD .x12 .x6 248 ;;
+  SRLI .x8 .x5 63 ;;
+  BNE .x8 .x0 (64 : BitVec 13) ;;
   LD .x6 .x12 248 ;;
   LD .x7 .x12 88 ;;
   BLTU .x7 .x6 (52 : BitVec 13) ;;
@@ -440,7 +442,7 @@ def evm_mulmod_reduce512_inner_step : Program :=
   SUB .x5 .x5 .x11 ;;
   SD .x12 .x5 248 ;;
   ADDI .x15 .x15 4095 ;;
-  BNE .x15 .x0 (-252 : BitVec 13)
+  BNE .x15 .x0 (-260 : BitVec 13)
 
 /-- Outer eight-limb reducer loop. -/
 def evm_mulmod_reduce512_loop : Program :=
@@ -493,29 +495,29 @@ theorem evm_mulmod_reduce512_init_length :
     evm_mulmod_reduce512_init.length = 6 := by rfl
 
 theorem evm_mulmod_reduce512_inner_step_length :
-    evm_mulmod_reduce512_inner_step.length = 64 := by set_option maxRecDepth 1000 in rfl
+    evm_mulmod_reduce512_inner_step.length = 66 := by set_option maxRecDepth 1000 in rfl
 
 theorem evm_mulmod_reduce512_loop_length :
-    evm_mulmod_reduce512_loop.length = 69 := by set_option maxRecDepth 1000 in rfl
+    evm_mulmod_reduce512_loop.length = 71 := by set_option maxRecDepth 1000 in rfl
 
 theorem evm_mulmod_reduce512_write_result_length :
     evm_mulmod_reduce512_write_result.length = 8 := by rfl
 
 theorem evm_mulmod_reduce512_length :
-    evm_mulmod_reduce512.length = 84 := by
+    evm_mulmod_reduce512.length = 86 := by
   unfold evm_mulmod_reduce512
   simp only [seq, Program.length_append, evm_mulmod_reduce512_init_length,
     evm_mulmod_reduce512_loop_length, evm_mulmod_reduce512_write_result_length,
     evm_mulmod_epilogue_length]
 
-theorem evm_mulmod_length : evm_mulmod.length = 538 := by
+theorem evm_mulmod_length : evm_mulmod.length = 540 := by
   unfold evm_mulmod
   simp only [seq, Program.length_append, evm_mulmod_nonzero_or_zero_prefix_length,
     evm_mulmod_reduce_zero_path_length, evm_mulmod_epilogue_length,
     evm_mulmod_zero_path_skip_nonzero_length, evm_mulmod_product_layout_length,
     evm_mulmod_reduce512_length]
 
-theorem evm_mulmod_byte_length : 4 * evm_mulmod.length = 2152 := by
+theorem evm_mulmod_byte_length : 4 * evm_mulmod.length = 2160 := by
   rw [evm_mulmod_length]
 
 theorem evm_mulmod_nonzero_path_start_byte :
@@ -527,12 +529,12 @@ theorem evm_mulmod_nonzero_path_start_byte :
 
 theorem evm_mulmod_bne_nonzero_target_byte : 28 + (28 : Nat) = 56 := by rfl
 
-theorem evm_mulmod_zero_skip_target_byte : 52 + (2100 : Nat) = 2152 := by rfl
+theorem evm_mulmod_zero_skip_target_byte : 52 + (2108 : Nat) = 2160 := by rfl
 
 theorem evm_mulmod_reduce512_start_byte : 56 + 4 * evm_mulmod_product_layout.length = 1816 := by
   rw [evm_mulmod_product_layout_length]
 
-theorem evm_mulmod_reduce512_end_byte : 1816 + 4 * evm_mulmod_reduce512.length = 2152 := by
+theorem evm_mulmod_reduce512_end_byte : 1816 + 4 * evm_mulmod_reduce512.length = 2160 := by
   rw [evm_mulmod_reduce512_length]
 
 -- ============================================================================

--- a/EvmAsm/Evm64/MulMod/Program.lean
+++ b/EvmAsm/Evm64/MulMod/Program.lean
@@ -451,7 +451,7 @@ def evm_mulmod_reduce512_loop : Program :=
   evm_mulmod_reduce512_inner_step ;;
   ADDI .x16 .x16 4088 ;;
   ADDI .x18 .x18 4095 ;;
-  BNE .x18 .x0 (-272 : BitVec 13)
+  BNE .x18 .x0 (-280 : BitVec 13)
 
 /-- Copy the finalized remainder into the EVM result slot `sp + 64..88`. -/
 def evm_mulmod_reduce512_write_result : Program :=

--- a/EvmAsm/Evm64/MulMod/ReduceBitLoop.lean
+++ b/EvmAsm/Evm64/MulMod/ReduceBitLoop.lean
@@ -2,12 +2,14 @@
   EvmAsm.Evm64.MulMod.ReduceBitLoop
 
   Loop-facing adapter for the MULMOD 512-bit reducer. The inner-step branch
-  spec clobbers and surrenders six scratch registers (`x5/x6/x7/x10/x11/x13`),
-  so the bit-loop invariant carries them as ownership. This file restates the
-  inner step over that loop-carried precondition.
+  spec clobbers and surrenders seven scratch registers
+  (`x5/x6/x7/x8/x10/x11/x13`, with `x8` the new carry register), so the
+  bit-loop invariant carries them as ownership. This file restates the inner
+  step over that loop-carried precondition.
 -/
 
 import EvmAsm.Evm64.MulMod.ReduceInnerStepSpecs
+import EvmAsm.Evm64.MulMod.ReduceFoldInvariant
 
 namespace EvmAsm.Evm64
 
@@ -31,91 +33,103 @@ def bitLoopCommon
   ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 3)
 
 /-- Loop-carried precondition for one reducer bit step: `bitLoopCommon` plus
-    ownership of the six clobbered scratch registers. -/
+    ownership of the seven clobbered scratch registers (including the new carry
+    register `x8`). -/
 @[irreducible]
 def mulModReduceBitLoopPre
     (sp x17Old x15 x19Old x20Old : Word) (r n : EvmWord) : Assertion :=
   bitLoopCommon sp x17Old x15 x19Old x20Old r n **
-  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x8 **
   regOwn .x10 ** regOwn .x11 ** regOwn .x13
 
 /-- One reducer bit step restated over the loop-carried precondition that owns
     the six clobbered scratch registers, ready for the bit-loop induction. -/
 theorem evm_mulmod_reduce512_bit_loop_step_spec_within
     (sp base x17Old x15 x19Old x20Old : Word) (r n : EvmWord) :
-    cpsBranchWithin 64 base
+    cpsBranchWithin 66 base
       (evm_mulmod_reduce512_inner_step_code base)
       (mulModReduceBitLoopPre sp x17Old x15 x19Old x20Old r n)
       base (mulModReduceInnerStepPost sp x17Old x15 r n false)
-      (base + 256) (mulModReduceInnerStepPost sp x17Old x15 r n true) := by
-  have h13 : cpsBranchWithin 64 base
+      (base + 264) (mulModReduceInnerStepPost sp x17Old x15 r n true) := by
+  have h13 : cpsBranchWithin 66 base
       (evm_mulmod_reduce512_inner_step_code base)
       ((bitLoopCommon sp x17Old x15 x19Old x20Old r n **
-          regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11) **
         regOwn .x13)
       base (mulModReduceInnerStepPost sp x17Old x15 r n false)
-      (base + 256) (mulModReduceInnerStepPost sp x17Old x15 r n true) := by
+      (base + 264) (mulModReduceInnerStepPost sp x17Old x15 r n true) := by
     refine cpsBranchWithin_of_forall_regIs_to_regOwn (r := .x13) ?_
     intro v13
-    have h11 : cpsBranchWithin 64 base
+    have h11 : cpsBranchWithin 66 base
         (evm_mulmod_reduce512_inner_step_code base)
         ((bitLoopCommon sp x17Old x15 x19Old x20Old r n ** (.x13 ↦ᵣ v13) **
-            regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10) **
+            regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10) **
           regOwn .x11)
         base (mulModReduceInnerStepPost sp x17Old x15 r n false)
-        (base + 256) (mulModReduceInnerStepPost sp x17Old x15 r n true) := by
+        (base + 264) (mulModReduceInnerStepPost sp x17Old x15 r n true) := by
       refine cpsBranchWithin_of_forall_regIs_to_regOwn (r := .x11) ?_
       intro v11
-      have h10 : cpsBranchWithin 64 base
+      have h10 : cpsBranchWithin 66 base
           (evm_mulmod_reduce512_inner_step_code base)
           ((bitLoopCommon sp x17Old x15 x19Old x20Old r n ** (.x13 ↦ᵣ v13) **
-              (.x11 ↦ᵣ v11) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7) **
+              (.x11 ↦ᵣ v11) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x8) **
             regOwn .x10)
           base (mulModReduceInnerStepPost sp x17Old x15 r n false)
-          (base + 256) (mulModReduceInnerStepPost sp x17Old x15 r n true) := by
+          (base + 264) (mulModReduceInnerStepPost sp x17Old x15 r n true) := by
         refine cpsBranchWithin_of_forall_regIs_to_regOwn (r := .x10) ?_
         intro v10
-        have h7 : cpsBranchWithin 64 base
+        have h8 : cpsBranchWithin 66 base
             (evm_mulmod_reduce512_inner_step_code base)
             ((bitLoopCommon sp x17Old x15 x19Old x20Old r n ** (.x13 ↦ᵣ v13) **
-                (.x11 ↦ᵣ v11) ** (.x10 ↦ᵣ v10) ** regOwn .x5 ** regOwn .x6) **
-              regOwn .x7)
+                (.x11 ↦ᵣ v11) ** (.x10 ↦ᵣ v10) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7) **
+              regOwn .x8)
             base (mulModReduceInnerStepPost sp x17Old x15 r n false)
-            (base + 256) (mulModReduceInnerStepPost sp x17Old x15 r n true) := by
-          refine cpsBranchWithin_of_forall_regIs_to_regOwn (r := .x7) ?_
-          intro v7
-          have h6 : cpsBranchWithin 64 base
+            (base + 264) (mulModReduceInnerStepPost sp x17Old x15 r n true) := by
+          refine cpsBranchWithin_of_forall_regIs_to_regOwn (r := .x8) ?_
+          intro v8
+          have h7 : cpsBranchWithin 66 base
               (evm_mulmod_reduce512_inner_step_code base)
               ((bitLoopCommon sp x17Old x15 x19Old x20Old r n ** (.x13 ↦ᵣ v13) **
-                  (.x11 ↦ᵣ v11) ** (.x10 ↦ᵣ v10) ** (.x7 ↦ᵣ v7) ** regOwn .x5) **
-                regOwn .x6)
+                  (.x11 ↦ᵣ v11) ** (.x10 ↦ᵣ v10) ** (.x8 ↦ᵣ v8) ** regOwn .x5 ** regOwn .x6) **
+                regOwn .x7)
               base (mulModReduceInnerStepPost sp x17Old x15 r n false)
-              (base + 256) (mulModReduceInnerStepPost sp x17Old x15 r n true) := by
-            refine cpsBranchWithin_of_forall_regIs_to_regOwn (r := .x6) ?_
-            intro v6
-            have h5 : cpsBranchWithin 64 base
+              (base + 264) (mulModReduceInnerStepPost sp x17Old x15 r n true) := by
+            refine cpsBranchWithin_of_forall_regIs_to_regOwn (r := .x7) ?_
+            intro v7
+            have h6 : cpsBranchWithin 66 base
                 (evm_mulmod_reduce512_inner_step_code base)
                 ((bitLoopCommon sp x17Old x15 x19Old x20Old r n ** (.x13 ↦ᵣ v13) **
-                    (.x11 ↦ᵣ v11) ** (.x10 ↦ᵣ v10) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6)) **
-                  regOwn .x5)
+                    (.x11 ↦ᵣ v11) ** (.x10 ↦ᵣ v10) ** (.x8 ↦ᵣ v8) ** (.x7 ↦ᵣ v7) ** regOwn .x5) **
+                  regOwn .x6)
                 base (mulModReduceInnerStepPost sp x17Old x15 r n false)
-                (base + 256) (mulModReduceInnerStepPost sp x17Old x15 r n true) := by
-              refine cpsBranchWithin_of_forall_regIs_to_regOwn (r := .x5) ?_
-              intro v5
-              refine cpsBranchWithin_weaken
-                (fun h hp => by
-                  unfold bitLoopCommon at hp
-                  unfold mulModReduceInnerStepPre mulModReduceInnerStepSubtractPre
-                  xperm_hyp hp)
-                (fun _ hp => hp) (fun _ hp => hp)
-                (evm_mulmod_reduce512_inner_step_spec_within
-                  sp base x17Old v5 v6 v7 v10 v11 v13 x15 x19Old x20Old r n)
+                (base + 264) (mulModReduceInnerStepPost sp x17Old x15 r n true) := by
+              refine cpsBranchWithin_of_forall_regIs_to_regOwn (r := .x6) ?_
+              intro v6
+              have h5 : cpsBranchWithin 66 base
+                  (evm_mulmod_reduce512_inner_step_code base)
+                  ((bitLoopCommon sp x17Old x15 x19Old x20Old r n ** (.x13 ↦ᵣ v13) **
+                      (.x11 ↦ᵣ v11) ** (.x10 ↦ᵣ v10) ** (.x8 ↦ᵣ v8) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6)) **
+                    regOwn .x5)
+                  base (mulModReduceInnerStepPost sp x17Old x15 r n false)
+                  (base + 264) (mulModReduceInnerStepPost sp x17Old x15 r n true) := by
+                refine cpsBranchWithin_of_forall_regIs_to_regOwn (r := .x5) ?_
+                intro v5
+                refine cpsBranchWithin_weaken
+                  (fun h hp => by
+                    unfold bitLoopCommon at hp
+                    unfold mulModReduceInnerStepPre mulModReduceInnerStepSubtractPre
+                    xperm_hyp hp)
+                  (fun _ hp => hp) (fun _ hp => hp)
+                  (evm_mulmod_reduce512_inner_step_spec_within
+                    sp base x17Old v5 v6 v7 v8 v10 v11 v13 x15 x19Old x20Old r n)
+              exact cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
+                (fun _ hp => hp) (fun _ hp => hp) h5
             exact cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
-              (fun _ hp => hp) (fun _ hp => hp) h5
+              (fun _ hp => hp) (fun _ hp => hp) h6
           exact cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
-            (fun _ hp => hp) (fun _ hp => hp) h6
+            (fun _ hp => hp) (fun _ hp => hp) h7
         exact cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
-          (fun _ hp => hp) (fun _ hp => hp) h7
+          (fun _ hp => hp) (fun _ hp => hp) h8
       exact cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
         (fun _ hp => hp) (fun _ hp => hp) h10
     exact cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
@@ -136,7 +150,7 @@ theorem mulModReduceInnerStepPost_false_to_bitLoopPre
       mulModReduceBitLoopPre sp (x17Old <<< 1)
         (x15 + signExtend12 (4095 : BitVec 12))
         (EvmWord.getLimbN r 1 >>> 63) (EvmWord.getLimbN r 2 >>> 63)
-        (mulModReduceStep r n (mulModReduceInputBit x17Old)) n h := by
+        (mulModReduceStepCarry r n (mulModReduceInputBit x17Old)) n h := by
   intro h hp
   unfold mulModReduceInnerStepPost mulModReduceTailPost mulModReduceCompareMem at hp
   simp only [Bool.false_eq_true, ↓reduceIte] at hp
@@ -150,7 +164,7 @@ theorem mulModReduceInnerStepPost_false_to_bitLoopPre
 theorem evm_mulmod_reduce512_bit_loop_step_loop_path
     (sp base x17Old x15 x19Old x20Old : Word) (r n : EvmWord)
     (hloop : x15 + signExtend12 (4095 : BitVec 12) ≠ 0) :
-    cpsTripleWithin 64 base base
+    cpsTripleWithin 66 base base
       (evm_mulmod_reduce512_inner_step_code base)
       (mulModReduceBitLoopPre sp x17Old x15 x19Old x20Old r n)
       (mulModReduceInnerStepPost sp x17Old x15 r n false) := by
@@ -168,7 +182,7 @@ theorem evm_mulmod_reduce512_bit_loop_step_loop_path
 theorem evm_mulmod_reduce512_bit_loop_step_done_path
     (sp base x17Old x15 x19Old x20Old : Word) (r n : EvmWord)
     (hdone : x15 + signExtend12 (4095 : BitVec 12) = 0) :
-    cpsTripleWithin 64 base (base + 256)
+    cpsTripleWithin 66 base (base + 264)
       (evm_mulmod_reduce512_inner_step_code base)
       (mulModReduceBitLoopPre sp x17Old x15 x19Old x20Old r n)
       (mulModReduceInnerStepPost sp x17Old x15 r n true) := by
@@ -187,7 +201,7 @@ theorem evm_mulmod_reduce512_bit_loop_step_done_path
 @[irreducible]
 def mulModReduceBitLoopPost (sp : Word) (result n : EvmWord) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x15 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
-  regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 **
   regOwn .x13 ** regOwn .x17 ** regOwn .x19 ** regOwn .x20 **
   mulModReduceCompareMem sp result n
 
@@ -207,7 +221,7 @@ theorem mulModReduceInnerStepPost_true_to_bitLoopPost
     (sp x17Old x15 : Word) (r n : EvmWord) :
     ∀ h, mulModReduceInnerStepPost sp x17Old x15 r n true h →
       mulModReduceBitLoopPost sp
-        (mulModReduceStep r n (mulModReduceInputBit x17Old)) n h := by
+        (mulModReduceStepCarry r n (mulModReduceInputBit x17Old)) n h := by
   intro h hp
   unfold mulModReduceInnerStepPost at hp
   have hp1 := sepConj_mono_left (tailPost_true_regs_zero x15) h hp
@@ -221,7 +235,7 @@ theorem mulModReduceInnerStepPost_true_to_bitLoopPost
       (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x20 _))) hh q2
   have hp2 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
     (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
-      (sepConj_mono_right (w3 _ _ _ _)))))))) h hp1
+      (sepConj_mono_right (sepConj_mono_right (w3 _ _ _ _))))))))) h hp1
   unfold mulModReduceBitLoopPost
   xperm_hyp hp2
 
@@ -232,10 +246,10 @@ theorem mulModReduceInnerStepPost_true_to_bitLoopPost
 private theorem bit_loop_aux (m : Nat) :
     1 ≤ m → m ≤ 64 →
     ∀ (sp base w x19v x20v : Word) (r n : EvmWord),
-    cpsTripleWithin (64 * m) base (base + 256)
+    cpsTripleWithin (66 * m) base (base + 264)
       (evm_mulmod_reduce512_inner_step_code base)
       (mulModReduceBitLoopPre sp w (BitVec.ofNat 64 m) x19v x20v r n)
-      (mulModReduceBitLoopPost sp (mulModReduceStepN r n w m) n) := by
+      (mulModReduceBitLoopPost sp (mulModReduceStepNCarry r n w m) n) := by
   induction m with
   | zero => intro h1 _; omega
   | succ k ih =>
@@ -260,7 +274,7 @@ private theorem bit_loop_aux (m : Nat) :
         sp base w (BitVec.ofNat 64 (k + 1)) x19v x20v r n hloop
       have hih := ih hkpos (by omega) sp base (w <<< 1)
         (EvmWord.getLimbN r 1 >>> 63) (EvmWord.getLimbN r 2 >>> 63)
-        (mulModReduceStep r n (mulModReduceInputBit w)) n
+        (mulModReduceStepCarry r n (mulModReduceInputBit w)) n
       have hcomp := cpsTripleWithin_seq_perm_same_cr
         (fun h hp => by
           have hb := mulModReduceInnerStepPost_false_to_bitLoopPre
@@ -268,18 +282,18 @@ private theorem bit_loop_aux (m : Nat) :
           rw [mulModReduceBitCounter_decr (k + 1) (by omega) h64] at hb
           exact hb)
         hstep hih
-      have hbound : 64 * (k + 1) = 64 + 64 * k := by ring
-      rw [hbound, mulModReduceStepN_succ]
+      have hbound : 66 * (k + 1) = 66 + 66 * k := by ring
+      rw [hbound, mulModReduceStepNCarry_succ]
       exact hcomp
 
 /-- The inner 64-bit reducer loop, instantiated at the full 64-iteration count
     used by `evm_mulmod_reduce512_loop`. -/
 theorem evm_mulmod_reduce512_bit_loop_spec_within
     (sp base w x19v x20v : Word) (r n : EvmWord) :
-    cpsTripleWithin (64 * 64) base (base + 256)
+    cpsTripleWithin (66 * 64) base (base + 264)
       (evm_mulmod_reduce512_inner_step_code base)
       (mulModReduceBitLoopPre sp w (BitVec.ofNat 64 64) x19v x20v r n)
-      (mulModReduceBitLoopPost sp (mulModReduceStepN r n w 64) n) :=
+      (mulModReduceBitLoopPost sp (mulModReduceStepNCarry r n w 64) n) :=
   bit_loop_aux 64 (by omega) (by omega) sp base w x19v x20v r n
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MulMod/ReduceInnerStepPrefix.lean
+++ b/EvmAsm/Evm64/MulMod/ReduceInnerStepPrefix.lean
@@ -4,6 +4,7 @@
   CPS spec for the shift-and-insert prefix of the MULMOD reducer inner step.
 -/
 
+import EvmAsm.Evm64.MulMod.Program
 import EvmAsm.Evm64.MulMod.ReduceCompare
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.RunBlock
@@ -168,5 +169,104 @@ theorem evm_mulmod_reduce512_inner_step_shift_prefix_spec_within
       sp base x17Old r0 r1 r2 r3 v5 v6 v19 v20
   rw [mulModReduceShiftPrefixRawPost_eq_folded] at hraw
   exact hraw
+
+/-- The shift prefix (instructions 0–20) is subsumed by the full inner-step
+    CodeReq. (Mirrors `evm_mulmod_reduce512_inner_step_shift_prefix_code_sub`
+    in `ReduceInnerStepSpecs`, which is downstream of this file.) -/
+private theorem inner_step_shift_prefix_code_sub (base : Word) :
+    ∀ a i, evm_mulmod_reduce512_inner_step_shift_prefix_code base a = some i →
+      CodeReq.ofProg base evm_mulmod_reduce512_inner_step a = some i := by
+  unfold evm_mulmod_reduce512_inner_step_shift_prefix_code
+  refine CodeReq.ofProg_mono_sub base base
+    evm_mulmod_reduce512_inner_step evm_mulmod_reduce512_inner_step_shift_prefix
+    0 ?_ ?_ ?_ ?_
+  · rw [show BitVec.ofNat 64 (4 * 0) = (0 : Word) by decide]
+    bv_omega
+  · rfl
+  · decide
+  · decide
+
+/-- The new `SRLI .x8 .x5 63` at byte offset 84 (program index 21) of
+    `evm_mulmod_reduce512_inner_step` is subsumed by the full-step CodeReq. -/
+private theorem inner_step_srli_carry_code_sub (base : Word) :
+    ∀ a i, CodeReq.singleton (base + 84) (.SRLI .x8 .x5 (63 : BitVec 6)) a = some i →
+      CodeReq.ofProg base evm_mulmod_reduce512_inner_step a = some i := by
+  rw [← CodeReq.ofProg_singleton]
+  refine CodeReq.ofProg_mono_sub base (base + 84)
+    evm_mulmod_reduce512_inner_step [.SRLI .x8 .x5 (63 : BitVec 6)]
+    21 ?_ ?_ ?_ ?_
+  · rw [show BitVec.ofNat 64 (4 * 21) = (84 : Word) by decide]
+  · rfl
+  · decide
+  · decide
+
+/-- Shift prefix spec extended by the new carry-capturing `SRLI .x8 .x5 63`
+    (program index 21, byte offset 84 → 88), over the full inner-step CodeReq.
+
+    After the 21-instruction shift cascade, `.x5 ↦ᵣ r3` holds the pre-shift high
+    limb (the 4th remainder limb), so `SRLI .x8 .x5 63` writes `x8 = r3 >>> 63`,
+    i.e. the remainder's bit 255 — the carry-out the old code discarded. -/
+theorem evm_mulmod_reduce512_inner_step_shift_prefix_carry_spec_within
+    (sp base x17Old r0 r1 r2 r3 v5 v6 v19 v20 x8Old : Word) :
+    cpsTripleWithin 22 base (base + 88)
+      (CodeReq.ofProg base evm_mulmod_reduce512_inner_step)
+      ((.x12 ↦ᵣ sp) ** (.x17 ↦ᵣ x17Old) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+       (.x19 ↦ᵣ v19) ** (.x20 ↦ᵣ v20) ** (.x8 ↦ᵣ x8Old) **
+       ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ r3))
+      (mulModReduceShiftPrefixPost sp x17Old r0 r1 r2 r3 ** (.x8 ↦ᵣ (r3 >>> 63))) := by
+  -- Prefix: 21 instructions, base → base+84, framed with `.x8 ↦ᵣ x8Old`.
+  have hprefix :=
+    cpsTripleWithin_frameR (.x8 ↦ᵣ x8Old) pcFree_regIs
+      (cpsTripleWithin_extend_code
+        (hmono := inner_step_shift_prefix_code_sub base)
+        (h := evm_mulmod_reduce512_inner_step_shift_prefix_spec_within
+          sp base x17Old r0 r1 r2 r3 v5 v6 v19 v20))
+  -- SRLI step: 1 instruction, base+84 → base+88, reads x5 = r3, writes x8.
+  have hsrli :=
+    cpsTripleWithin_extend_code
+      (hmono := inner_step_srli_carry_code_sub base)
+      (h := srli_spec_gen_within .x8 .x5 x8Old r3 (63 : BitVec 6) (base + 84) (by decide))
+  rw [show (63 : BitVec 6).toNat = 63 by decide] at hsrli
+  rw [show base + 84 + 4 = base + 88 by bv_omega] at hsrli
+  -- The frame for the SRLI: every atom of the folded prefix post except `.x5`.
+  set shifted :=
+    mulModReduceShiftInBit (mulModReduceRemWord r0 r1 r2 r3) (mulModReduceInputBit x17Old)
+    with hshifted
+  have hstep :
+      cpsTripleWithin 1 (base + 84) (base + 88)
+        (CodeReq.ofProg base evm_mulmod_reduce512_inner_step)
+        (mulModReduceShiftPrefixPost sp x17Old r0 r1 r2 r3 ** (.x8 ↦ᵣ x8Old))
+        (mulModReduceShiftPrefixPost sp x17Old r0 r1 r2 r3 ** (.x8 ↦ᵣ (r3 >>> 63))) := by
+    have hframed :=
+      cpsTripleWithin_frameR
+        ((.x12 ↦ᵣ sp) ** (.x17 ↦ᵣ (x17Old <<< 1)) ** (.x6 ↦ᵣ shifted.getLimbN 3) **
+         (.x19 ↦ᵣ (r1 >>> 63)) ** (.x20 ↦ᵣ (r2 >>> 63)) **
+         ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ shifted.getLimbN 0) **
+         ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ shifted.getLimbN 1) **
+         ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ shifted.getLimbN 2) **
+         ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ shifted.getLimbN 3))
+        (by
+          repeat first
+            | exact pcFree_regIs
+            | exact pcFree_memIs
+            | apply pcFree_sepConj)
+        hsrli
+    refine cpsTripleWithin_weaken ?_ ?_ hframed
+    · intro h hp
+      unfold mulModReduceShiftPrefixPost at hp
+      simp only [← hshifted] at hp
+      xperm_hyp hp
+    · intro h hp
+      unfold mulModReduceShiftPrefixPost
+      simp only [← hshifted]
+      xperm_hyp hp
+  -- Sequence prefix then SRLI step (same CodeReq), then fix entry/exit shape.
+  have hcomp := cpsTripleWithin_seq_same_cr hprefix hstep
+  refine cpsTripleWithin_weaken ?_ (fun _ hp => hp) hcomp
+  intro h hp
+  xperm_hyp hp
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MulMod/ReduceInnerStepSpecs.lean
+++ b/EvmAsm/Evm64/MulMod/ReduceInnerStepSpecs.lean
@@ -5,12 +5,14 @@
 -/
 
 import EvmAsm.Evm64.MulMod.Program
+import EvmAsm.Evm64.MulMod.ReduceCorrect
 import EvmAsm.Evm64.MulMod.ReduceInnerStepPrefix
 import EvmAsm.Evm64.MulMod.ReduceInnerStepCompare
 import EvmAsm.Evm64.MulMod.ReduceInnerStepTail
 import EvmAsm.Evm64.MulMod.ReduceInnerStepSubtract
 import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.XPermPure
+import EvmAsm.Rv64.BitAux
 
 namespace EvmAsm.Evm64
 
@@ -35,44 +37,127 @@ theorem evm_mulmod_reduce512_inner_step_shift_prefix_code_sub (base : Word) :
   · decide
   · decide
 
-theorem evm_mulmod_reduce512_inner_step_compare_code_sub (base : Word) :
-    ∀ a i, evm_mulmod_reduce512_inner_step_compare_code base a = some i →
+/-- The new `SRLI .x8 .x5 63` at byte 84 (program index 21) is subsumed by the
+    full inner-step CodeReq. -/
+theorem evm_mulmod_reduce512_inner_step_srli_carry_code_sub (base : Word) :
+    ∀ a i, CodeReq.singleton (base + 84) (.SRLI .x8 .x5 (63 : BitVec 6)) a = some i →
       evm_mulmod_reduce512_inner_step_code base a = some i := by
-  unfold evm_mulmod_reduce512_inner_step_compare_code
   unfold evm_mulmod_reduce512_inner_step_code
+  rw [← CodeReq.ofProg_singleton]
   refine CodeReq.ofProg_mono_sub base (base + 84)
-    evm_mulmod_reduce512_inner_step evm_mulmod_reduce512_inner_step_compare
+    evm_mulmod_reduce512_inner_step [.SRLI .x8 .x5 (63 : BitVec 6)]
     21 ?_ ?_ ?_ ?_
   · rw [show BitVec.ofNat 64 (4 * 21) = (84 : Word) by decide]
   · rfl
   · decide
   · decide
 
-theorem evm_mulmod_reduce512_inner_step_subtract_store_code_sub (base : Word) :
-    ∀ a i, evm_mulmod_reduce512_inner_step_subtract_store_code base a = some i →
+/-- The new `BNE .x8 .x0 (64)` carry branch at byte 88 (program index 22) is
+    subsumed by the full inner-step CodeReq. -/
+theorem evm_mulmod_reduce512_inner_step_bne_carry_code_sub (base : Word) :
+    ∀ a i, CodeReq.singleton (base + 88) (.BNE .x8 .x0 (64 : BitVec 13)) a = some i →
       evm_mulmod_reduce512_inner_step_code base a = some i := by
-  unfold evm_mulmod_reduce512_inner_step_subtract_store_code
   unfold evm_mulmod_reduce512_inner_step_code
-  refine CodeReq.ofProg_mono_sub base (base + 144)
-    evm_mulmod_reduce512_inner_step evm_mulmod_reduce512_inner_step_subtract_store
-    36 ?_ ?_ ?_ ?_
-  · rw [show BitVec.ofNat 64 (4 * 36) = (144 : Word) by decide]
+  rw [← CodeReq.ofProg_singleton]
+  refine CodeReq.ofProg_mono_sub base (base + 88)
+    evm_mulmod_reduce512_inner_step [.BNE .x8 .x0 (64 : BitVec 13)]
+    22 ?_ ?_ ?_ ?_
+  · rw [show BitVec.ofNat 64 (4 * 22) = (88 : Word) by decide]
   · rfl
   · decide
   · decide
 
-theorem evm_mulmod_reduce512_inner_step_tail_code_sub (base : Word) :
-    ∀ a i, evm_mulmod_reduce512_inner_step_tail_code base a = some i →
+theorem evm_mulmod_reduce512_inner_step_compare_code_sub (base : Word) :
+    ∀ a i, evm_mulmod_reduce512_inner_step_compare_code (base + 8) a = some i →
       evm_mulmod_reduce512_inner_step_code base a = some i := by
-  unfold evm_mulmod_reduce512_inner_step_tail_code
+  unfold evm_mulmod_reduce512_inner_step_compare_code
   unfold evm_mulmod_reduce512_inner_step_code
-  refine CodeReq.ofProg_mono_sub base (base + 248)
-    evm_mulmod_reduce512_inner_step evm_mulmod_reduce512_inner_step_tail
-    62 ?_ ?_ ?_ ?_
-  · rw [show BitVec.ofNat 64 (4 * 62) = (248 : Word) by decide]
+  rw [show (base + 8 : Word) + 84 = base + 92 by bv_omega]
+  refine CodeReq.ofProg_mono_sub base (base + 92)
+    evm_mulmod_reduce512_inner_step evm_mulmod_reduce512_inner_step_compare
+    23 ?_ ?_ ?_ ?_
+  · rw [show BitVec.ofNat 64 (4 * 23) = (92 : Word) by decide]
   · rfl
   · decide
   · decide
+
+theorem evm_mulmod_reduce512_inner_step_subtract_store_code_sub (base : Word) :
+    ∀ a i, evm_mulmod_reduce512_inner_step_subtract_store_code (base + 8) a = some i →
+      evm_mulmod_reduce512_inner_step_code base a = some i := by
+  unfold evm_mulmod_reduce512_inner_step_subtract_store_code
+  unfold evm_mulmod_reduce512_inner_step_code
+  rw [show (base + 8 : Word) + 144 = base + 152 by bv_omega]
+  refine CodeReq.ofProg_mono_sub base (base + 152)
+    evm_mulmod_reduce512_inner_step evm_mulmod_reduce512_inner_step_subtract_store
+    38 ?_ ?_ ?_ ?_
+  · rw [show BitVec.ofNat 64 (4 * 38) = (152 : Word) by decide]
+  · rfl
+  · decide
+  · decide
+
+/-- The loop-control tail of the (carry-aware) inner step now lives at byte 256
+    (program index 64) with the loop-back `BNE` offset `-260`. -/
+def evm_mulmod_reduce512_inner_step_tail_carry : Program :=
+  ADDI .x15 .x15 4095 ;;
+  BNE .x15 .x0 (-260 : BitVec 13)
+
+theorem evm_mulmod_reduce512_inner_step_tail_code_sub (base : Word) :
+    ∀ a i, CodeReq.ofProg (base + 256) evm_mulmod_reduce512_inner_step_tail_carry a = some i →
+      evm_mulmod_reduce512_inner_step_code base a = some i := by
+  unfold evm_mulmod_reduce512_inner_step_code
+  refine CodeReq.ofProg_mono_sub base (base + 256)
+    evm_mulmod_reduce512_inner_step evm_mulmod_reduce512_inner_step_tail_carry
+    64 ?_ ?_ ?_ ?_
+  · rw [show BitVec.ofNat 64 (4 * 64) = (256 : Word) by decide]
+  · rfl
+  · decide
+  · decide
+
+/-- Carry-aware loop-control tail branch spec at byte 256: decrement `x15`, then
+    `BNE` back to `base` (loop) or fall through to `base + 264` (done). Mirrors
+    `evm_mulmod_reduce512_inner_step_tail_spec_within` at the shifted offset with
+    the `-260` loop-back. -/
+theorem evm_mulmod_reduce512_inner_step_tail_carry_spec_within
+    (base x15 : Word) :
+    cpsBranchWithin 2 (base + 256)
+      (CodeReq.ofProg (base + 256) evm_mulmod_reduce512_inner_step_tail_carry)
+      ((.x15 ↦ᵣ x15) ** (.x0 ↦ᵣ (0 : Word)))
+      base (mulModReduceTailPost x15 false)
+      (base + 264) (mulModReduceTailPost x15 true) := by
+  rw [show CodeReq.ofProg (base + 256) evm_mulmod_reduce512_inner_step_tail_carry =
+      (CodeReq.singleton (base + 256) (.ADDI .x15 .x15 4095)).union
+        (CodeReq.singleton (base + 260) (.BNE .x15 .x0 (-260 : BitVec 13))) by
+    unfold evm_mulmod_reduce512_inner_step_tail_carry
+    show CodeReq.ofProg (base + 256)
+        [.ADDI .x15 .x15 4095, .BNE .x15 .x0 (-260 : BitVec 13)] = _
+    rw [CodeReq.ofProg_pair]
+    rw [show (base + 256 : Word) + 4 = base + 260 by bv_omega]]
+  unfold mulModReduceTailPost
+  simp only [Bool.false_eq_true, ↓reduceIte]
+  have hnext : (base + 256 : Word) + 4 = base + 260 := by bv_omega
+  have hfallthrough : (base + 260 : Word) + 4 = base + 264 := by bv_omega
+  have hse : signExtend13 ((-260 : BitVec 13)) = (18446744073709551356 : Word) := by
+    decide
+  have hloop : (base + 260 : Word) + signExtend13 ((-260 : BitVec 13)) = base := by
+    rw [hse]
+    bv_omega
+  have hdisjoint : CodeReq.Disjoint
+      (CodeReq.singleton (base + 256) (.ADDI .x15 .x15 4095))
+      (CodeReq.singleton (base + 260) (.BNE .x15 .x0 (-260 : BitVec 13))) :=
+    CodeReq.Disjoint.singleton (by bv_omega)
+  have haddi_raw := addi_spec_gen_same_within .x15 x15 4095 (base + 256) (by decide)
+  rw [hnext] at haddi_raw
+  have haddi : cpsTripleWithin 1 (base + 256) (base + 260)
+      (CodeReq.singleton (base + 256) (.ADDI .x15 .x15 4095))
+      ((.x15 ↦ᵣ x15) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x15 ↦ᵣ (x15 + signExtend12 (4095 : BitVec 12))) ** (.x0 ↦ᵣ (0 : Word))) :=
+    cpsTripleWithin_frameR (.x0 ↦ᵣ (0 : Word)) (by pcFree) haddi_raw
+  have hbne := bne_spec_gen_within .x15 .x0 (-260 : BitVec 13)
+    (x15 + signExtend12 (4095 : BitVec 12)) (0 : Word) (base + 260)
+  rw [hloop, hfallthrough] at hbne
+  simpa only [Nat.reduceAdd, sepConj_assoc'] using
+    (cpsTripleWithin_seq_cpsBranchWithin_with_perm hdisjoint
+      (fun _ hp => hp) haddi hbne)
 
 theorem evm_mulmod_reduce512_inner_step_shift_prefix_full_code_spec_within
     (sp base x17Old r0 r1 r2 r3 v5 v6 v19 v20 : Word) :
@@ -93,74 +178,167 @@ theorem evm_mulmod_reduce512_inner_step_shift_prefix_full_code_spec_within
 theorem evm_mulmod_reduce512_inner_step_compare_ge_full_code_spec_within
     (sp base x6Old x7Old : Word) (r n : EvmWord)
     (hge : mulModReduceRemGE r n) :
-    cpsTripleWithin 15 (base + 84) (base + 144)
+    cpsTripleWithin 15 (base + 92) (base + 152)
       (evm_mulmod_reduce512_inner_step_code base)
       (mulModReduceComparePre sp x6Old x7Old r n ** ⌜mulModReduceRemGE r n⌝)
-      (mulModReduceComparePost sp r n true) :=
-  cpsTripleWithin_extend_code
+      (mulModReduceComparePost sp r n true) := by
+  have h := cpsTripleWithin_extend_code
     (hmono := evm_mulmod_reduce512_inner_step_compare_code_sub base)
     (h := evm_mulmod_reduce512_inner_step_compare_ge_spec_within
-      sp base x6Old x7Old r n hge)
+      sp (base + 8) x6Old x7Old r n hge)
+  rwa [show (base + 8 : Word) + 84 = base + 92 by bv_omega,
+    show (base + 8 : Word) + 144 = base + 152 by bv_omega] at h
 
 theorem evm_mulmod_reduce512_inner_step_compare_lt_full_code_spec_within
     (sp base x6Old x7Old : Word) (r n : EvmWord)
     (hlt : mulModReduceRemLT r n) :
-    cpsTripleWithin 15 (base + 84) (base + 248)
+    cpsTripleWithin 15 (base + 92) (base + 256)
       (evm_mulmod_reduce512_inner_step_code base)
       (mulModReduceComparePre sp x6Old x7Old r n ** ⌜mulModReduceRemLT r n⌝)
-      (mulModReduceComparePost sp r n false) :=
-  cpsTripleWithin_extend_code
+      (mulModReduceComparePost sp r n false) := by
+  have h := cpsTripleWithin_extend_code
     (hmono := evm_mulmod_reduce512_inner_step_compare_code_sub base)
     (h := evm_mulmod_reduce512_inner_step_compare_lt_spec_within
-      sp base x6Old x7Old r n hlt)
+      sp (base + 8) x6Old x7Old r n hlt)
+  rwa [show (base + 8 : Word) + 84 = base + 92 by bv_omega,
+    show (base + 8 : Word) + 248 = base + 256 by bv_omega] at h
 
 theorem evm_mulmod_reduce512_inner_step_subtract_store_full_code_spec_within
     (sp base v5 v6 v7 v10 v11 v13 : Word) (r n : EvmWord) :
-    cpsTripleWithin 26 (base + 144) (base + 248)
+    cpsTripleWithin 26 (base + 152) (base + 256)
       (evm_mulmod_reduce512_inner_step_code base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x13 ↦ᵣ v13) **
        mulModReduceCompareMem sp r n)
-      (mulModReduceSubtractPost sp r n) :=
-  cpsTripleWithin_extend_code
+      (mulModReduceSubtractPost sp r n) := by
+  have h := cpsTripleWithin_extend_code
     (hmono := evm_mulmod_reduce512_inner_step_subtract_store_code_sub base)
     (h := evm_mulmod_reduce512_inner_step_subtract_store_spec_within
-      sp base v5 v6 v7 v10 v11 v13 r n)
+      sp (base + 8) v5 v6 v7 v10 v11 v13 r n)
+  rwa [show (base + 8 : Word) + 144 = base + 152 by bv_omega,
+    show (base + 8 : Word) + 248 = base + 256 by bv_omega] at h
 
 theorem evm_mulmod_reduce512_inner_step_tail_full_code_spec_within
     (base x15 : Word) :
-    cpsBranchWithin 2 (base + 248)
+    cpsBranchWithin 2 (base + 256)
       (evm_mulmod_reduce512_inner_step_code base)
       ((.x15 ↦ᵣ x15) ** (.x0 ↦ᵣ (0 : Word)))
       base (mulModReduceTailPost x15 false)
-      (base + 256) (mulModReduceTailPost x15 true) :=
+      (base + 264) (mulModReduceTailPost x15 true) :=
   cpsBranchWithin_extend_code
     (hmono := evm_mulmod_reduce512_inner_step_tail_code_sub base)
-    (h := evm_mulmod_reduce512_inner_step_tail_spec_within base x15)
+    (h := evm_mulmod_reduce512_inner_step_tail_carry_spec_within base x15)
+
+
+/-! ## Carry branch -/
+
+/-- Bit-255 of the remainder (the shift carry-out) is detected by the high limb's
+    top bit: `(r.getLimbN 3) >>> 63 ≠ 0 ↔ r.getLsbD 255 = true`. -/
+theorem getLimbN3_ushr63_ne_zero_iff_getLsbD255 (r : EvmWord) :
+    (EvmWord.getLimbN r 3 >>> 63 ≠ 0) ↔ r.getLsbD 255 = true := by
+  have hbit : (EvmWord.getLimbN r 3).getLsbD 63 = r.getLsbD 255 := by
+    rw [EvmWord.getLimbN_lt r 3 (by decide)]
+    unfold EvmWord.getLimb
+    rw [BitVec.getLsbD_extractLsb']
+    simp
+  rcases EvmAsm.Rv64.BitAux.ushr63_bool (EvmWord.getLimbN r 3) with h0 | h1
+  · rw [h0]
+    have hb : (EvmWord.getLimbN r 3).getLsbD 63 = false := by
+      have : (EvmWord.getLimbN r 3 >>> 63).getLsbD 0 = false := by rw [h0]; rfl
+      rwa [BitVec.getLsbD_ushiftRight, Nat.add_zero] at this
+    rw [hbit] at hb
+    rw [hb]; simp
+  · rw [h1]
+    have hb : (EvmWord.getLimbN r 3).getLsbD 63 = true := by
+      have : (EvmWord.getLimbN r 3 >>> 63).getLsbD 0 = true := by rw [h1]; rfl
+      rwa [BitVec.getLsbD_ushiftRight, Nat.add_zero] at this
+    rw [hbit] at hb
+    rw [hb]; simp
+
+/-- Carry-branch (`BNE .x8 .x0 (64)` at byte 88, program index 22) spec over the
+    full inner-step code. The carry bit `c = r3 >>> 63` (held in `x8`) selects:
+    when `c ≠ 0` (remainder bit 255 set) branch to the subtract entry `base+152`;
+    when `c = 0` fall through to the compare ladder at `base+92`. The exits carry
+    the `getLsbD 255` reading of the carry. -/
+theorem evm_mulmod_reduce512_inner_step_carry_branch_spec_within
+    (base : Word) (r : EvmWord) :
+    cpsBranchWithin 1 (base + 88)
+      (evm_mulmod_reduce512_inner_step_code base)
+      ((.x8 ↦ᵣ (EvmWord.getLimbN r 3 >>> 63)) ** (.x0 ↦ᵣ (0 : Word)))
+      (base + 152)
+        (((.x8 ↦ᵣ (EvmWord.getLimbN r 3 >>> 63)) ** (.x0 ↦ᵣ (0 : Word))) **
+          ⌜r.getLsbD 255 = true⌝)
+      (base + 92)
+        (((.x8 ↦ᵣ (EvmWord.getLimbN r 3 >>> 63)) ** (.x0 ↦ᵣ (0 : Word))) **
+          ⌜r.getLsbD 255 = false⌝) := by
+  have hbne := bne_spec_gen_within .x8 .x0 (64 : BitVec 13)
+    (EvmWord.getLimbN r 3 >>> 63) (0 : Word) (base + 88)
+  rw [show (base + 88 : Word) + signExtend13 (64 : BitVec 13) = base + 152 by
+      rw [show signExtend13 (64 : BitVec 13) = (64 : Word) by decide]; bv_omega,
+    show (base + 88 : Word) + 4 = base + 92 by bv_omega] at hbne
+  have hlift := cpsBranchWithin_extend_code
+    (hmono := evm_mulmod_reduce512_inner_step_bne_carry_code_sub base)
+    (h := hbne)
+  refine cpsBranchWithin_weaken (fun _ hp => hp) ?_ ?_ hlift
+  · intro h hp
+    rw [← sepConj_assoc'] at hp
+    refine (sepConj_pure_right h).2 ⟨((sepConj_pure_right h).1 hp).1, ?_⟩
+    exact (getLimbN3_ushr63_ne_zero_iff_getLsbD255 r).1 ((sepConj_pure_right h).1 hp).2
+  · intro h hp
+    rw [← sepConj_assoc'] at hp
+    refine (sepConj_pure_right h).2 ⟨((sepConj_pure_right h).1 hp).1, ?_⟩
+    have heq : EvmWord.getLimbN r 3 >>> 63 = 0 := ((sepConj_pure_right h).1 hp).2
+    rw [Bool.eq_false_iff]
+    intro hc
+    exact ((getLimbN3_ushr63_ne_zero_iff_getLsbD255 r).2 hc) heq
 
 theorem evm_mulmod_reduce512_inner_step_tail_done_full_code_spec_within
     (base x15 : Word)
     (h_done : x15 + signExtend12 (4095 : BitVec 12) = 0) :
-    cpsTripleWithin 2 (base + 248) (base + 256)
+    cpsTripleWithin 2 (base + 256) (base + 264)
       (evm_mulmod_reduce512_inner_step_code base)
       (((.x15 ↦ᵣ x15) ** (.x0 ↦ᵣ (0 : Word))) **
         ⌜x15 + signExtend12 (4095 : BitVec 12) = 0⌝)
-      (mulModReduceTailPost x15 true) :=
-  cpsTripleWithin_extend_code
-    (hmono := evm_mulmod_reduce512_inner_step_tail_code_sub base)
-    (h := evm_mulmod_reduce512_inner_step_tail_done_spec_within base x15 h_done)
+      (mulModReduceTailPost x15 true) := by
+  have hbr := evm_mulmod_reduce512_inner_step_tail_full_code_spec_within base x15
+  have hdone_pre : cpsBranchWithin 2 (base + 256)
+      (evm_mulmod_reduce512_inner_step_code base)
+      (((.x15 ↦ᵣ x15) ** (.x0 ↦ᵣ (0 : Word))) **
+        ⌜x15 + signExtend12 (4095 : BitVec 12) = 0⌝)
+      base (mulModReduceTailPost x15 false)
+      (base + 264) (mulModReduceTailPost x15 true) :=
+    cpsBranchWithin_weaken (fun h hp => ((sepConj_pure_right h).1 hp).1)
+      (fun _ hp => hp) (fun _ hp => hp) hbr
+  exact cpsBranchWithin_ntakenPath hdone_pre (by
+    intro h hp
+    unfold mulModReduceTailPost at hp
+    simp only [Bool.false_eq_true, ↓reduceIte] at hp
+    obtain ⟨hregs, h_ne⟩ := (sepConj_pure_right h).1 hp
+    exact h_ne h_done)
 
 theorem evm_mulmod_reduce512_inner_step_tail_loop_full_code_spec_within
     (base x15 : Word)
     (h_loop : x15 + signExtend12 (4095 : BitVec 12) ≠ 0) :
-    cpsTripleWithin 2 (base + 248) base
+    cpsTripleWithin 2 (base + 256) base
       (evm_mulmod_reduce512_inner_step_code base)
       (((.x15 ↦ᵣ x15) ** (.x0 ↦ᵣ (0 : Word))) **
         ⌜x15 + signExtend12 (4095 : BitVec 12) ≠ 0⌝)
-      (mulModReduceTailPost x15 false) :=
-  cpsTripleWithin_extend_code
-    (hmono := evm_mulmod_reduce512_inner_step_tail_code_sub base)
-    (h := evm_mulmod_reduce512_inner_step_tail_loop_spec_within base x15 h_loop)
+      (mulModReduceTailPost x15 false) := by
+  have hbr := evm_mulmod_reduce512_inner_step_tail_full_code_spec_within base x15
+  have hloop_pre : cpsBranchWithin 2 (base + 256)
+      (evm_mulmod_reduce512_inner_step_code base)
+      (((.x15 ↦ᵣ x15) ** (.x0 ↦ᵣ (0 : Word))) **
+        ⌜x15 + signExtend12 (4095 : BitVec 12) ≠ 0⌝)
+      base (mulModReduceTailPost x15 false)
+      (base + 264) (mulModReduceTailPost x15 true) :=
+    cpsBranchWithin_weaken (fun h hp => ((sepConj_pure_right h).1 hp).1)
+      (fun _ hp => hp) (fun _ hp => hp) hbr
+  exact cpsBranchWithin_takenPath hloop_pre (by
+    intro h hp
+    unfold mulModReduceTailPost at hp
+    simp only [ite_true] at hp
+    obtain ⟨hregs, h_eq⟩ := (sepConj_pure_right h).1 hp
+    exact h_loop h_eq)
 
 
 
@@ -174,11 +352,11 @@ def mulModReduceSubtractOwnPre
 
 theorem evm_mulmod_reduce512_inner_step_subtract_store_own_full_code_spec_within
     (sp base v5 v10 v11 v13 : Word) (r n : EvmWord) :
-    cpsTripleWithin 26 (base + 144) (base + 248)
+    cpsTripleWithin 26 (base + 152) (base + 256)
       (evm_mulmod_reduce512_inner_step_code base)
       (mulModReduceSubtractOwnPre sp v5 v10 v11 v13 r n)
       (mulModReduceSubtractPost sp r n) := by
-  have hown7 : cpsTripleWithin 26 (base + 144) (base + 248)
+  have hown7 : cpsTripleWithin 26 (base + 152) (base + 256)
       (evm_mulmod_reduce512_inner_step_code base)
       (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** regOwn .x6 **
         (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x13 ↦ᵣ v13) **
@@ -186,7 +364,7 @@ theorem evm_mulmod_reduce512_inner_step_subtract_store_own_full_code_spec_within
       (mulModReduceSubtractPost sp r n) := by
     refine cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x7) ?_
     intro v7
-    have hown6 : cpsTripleWithin 26 (base + 144) (base + 248)
+    have hown6 : cpsTripleWithin 26 (base + 152) (base + 256)
         (evm_mulmod_reduce512_inner_step_code base)
         (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) **
           (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x13 ↦ᵣ v13) **
@@ -210,10 +388,10 @@ theorem evm_mulmod_reduce512_inner_step_subtract_store_own_full_code_spec_within
 /-- Folded precondition for the reducer inner-step no-subtract path. -/
 @[irreducible]
 def mulModReduceInnerStepNoSubtractPre
-    (sp x17Old x5Old x6Old x7Old x15 x19Old x20Old : Word)
+    (sp x17Old x5Old x6Old x7Old x8Old x15 x19Old x20Old : Word)
     (r n : EvmWord) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x17 ↦ᵣ x17Old) ** (.x5 ↦ᵣ x5Old) ** (.x6 ↦ᵣ x6Old) **
-  (.x7 ↦ᵣ x7Old) ** (.x15 ↦ᵣ x15) ** (.x0 ↦ᵣ (0 : Word)) **
+  (.x7 ↦ᵣ x7Old) ** (.x8 ↦ᵣ x8Old) ** (.x15 ↦ᵣ x15) ** (.x0 ↦ᵣ (0 : Word)) **
   (.x19 ↦ᵣ x19Old) ** (.x20 ↦ᵣ x20Old) **
   ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 0) **
   ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 1) **
@@ -233,20 +411,24 @@ def mulModReduceInnerStepNoSubtractPost
   mulModReduceComparePost sp shifted n false **
   (.x17 ↦ᵣ (x17Old <<< 1)) **
   (.x5 ↦ᵣ EvmWord.getLimbN r 3) **
+  (.x8 ↦ᵣ (EvmWord.getLimbN r 3 >>> 63)) **
   (.x19 ↦ᵣ (EvmWord.getLimbN r 1 >>> 63)) **
   (.x20 ↦ᵣ (EvmWord.getLimbN r 2 >>> 63))
 
-/-- Compose prefix, compare-LT, and tail into the no-subtract reducer inner-step path. -/
+/-- Compose carry-prefix, carry-branch (not-taken), compare-LT, and tail into the
+    no-subtract reducer inner-step path. The no-subtract path additionally
+    requires the shift carry-out (remainder bit 255) to be FALSE. -/
 theorem evm_mulmod_reduce512_inner_step_no_subtract_path_spec_within
-    (sp base x17Old x5Old x6Old x7Old x15 x19Old x20Old : Word)
+    (sp base x17Old x5Old x6Old x7Old x8Old x15 x19Old x20Old : Word)
     (r n : EvmWord)
+    (hcarry : r.getLsbD 255 = false)
     (hlt : mulModReduceRemLT (mulModReduceShiftInBit r (mulModReduceInputBit x17Old)) n) :
-    cpsBranchWithin 38 base
+    cpsBranchWithin 40 base
       (evm_mulmod_reduce512_inner_step_code base)
-      (mulModReduceInnerStepNoSubtractPre sp x17Old x5Old x6Old x7Old x15 x19Old x20Old r n **
+      (mulModReduceInnerStepNoSubtractPre sp x17Old x5Old x6Old x7Old x8Old x15 x19Old x20Old r n **
         ⌜mulModReduceRemLT (mulModReduceShiftInBit r (mulModReduceInputBit x17Old)) n⌝)
       base (mulModReduceInnerStepNoSubtractPost sp x17Old x15 r n false)
-      (base + 256) (mulModReduceInnerStepNoSubtractPost sp x17Old x15 r n true) := by
+      (base + 264) (mulModReduceInnerStepNoSubtractPost sp x17Old x15 r n true) := by
   let shifted := mulModReduceShiftInBit r (mulModReduceInputBit x17Old)
   let prefixFrame : Assertion :=
     (.x7 ↦ᵣ x7Old) ** (.x15 ↦ᵣ x15) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -258,6 +440,7 @@ theorem evm_mulmod_reduce512_inner_step_no_subtract_path_spec_within
   let compareFrame : Assertion :=
     (.x17 ↦ᵣ (x17Old <<< 1)) **
     (.x5 ↦ᵣ EvmWord.getLimbN r 3) **
+    (.x8 ↦ᵣ (EvmWord.getLimbN r 3 >>> 63)) **
     (.x19 ↦ᵣ (EvmWord.getLimbN r 1 >>> 63)) **
     (.x20 ↦ᵣ (EvmWord.getLimbN r 2 >>> 63)) **
     (.x15 ↦ᵣ x15) ** (.x0 ↦ᵣ (0 : Word))
@@ -265,31 +448,61 @@ theorem evm_mulmod_reduce512_inner_step_no_subtract_path_spec_within
     mulModReduceComparePost sp shifted n false **
     (.x17 ↦ᵣ (x17Old <<< 1)) **
     (.x5 ↦ᵣ EvmWord.getLimbN r 3) **
+    (.x8 ↦ᵣ (EvmWord.getLimbN r 3 >>> 63)) **
     (.x19 ↦ᵣ (EvmWord.getLimbN r 1 >>> 63)) **
     (.x20 ↦ᵣ (EvmWord.getLimbN r 2 >>> 63))
-  have hprefix0 := evm_mulmod_reduce512_inner_step_shift_prefix_full_code_spec_within
+  -- Carry prefix (22 instructions, base → base+88), producing x8 = r3 >>> 63.
+  have hprefix0 := evm_mulmod_reduce512_inner_step_shift_prefix_carry_spec_within
     sp base x17Old (EvmWord.getLimbN r 0) (EvmWord.getLimbN r 1)
-    (EvmWord.getLimbN r 2) (EvmWord.getLimbN r 3) x5Old x6Old x19Old x20Old
+    (EvmWord.getLimbN r 2) (EvmWord.getLimbN r 3) x5Old x6Old x19Old x20Old x8Old
   have hprefix := cpsTripleWithin_frameR prefixFrame (by pcFree) hprefix0
-  have hprefixTop : cpsTripleWithin 21 base (base + 84)
+  have hprefixTop : cpsTripleWithin 22 base (base + 88)
       (evm_mulmod_reduce512_inner_step_code base)
-      (mulModReduceInnerStepNoSubtractPre sp x17Old x5Old x6Old x7Old x15 x19Old x20Old r n **
+      (mulModReduceInnerStepNoSubtractPre sp x17Old x5Old x6Old x7Old x8Old x15 x19Old x20Old r n **
         ⌜mulModReduceRemLT shifted n⌝)
-      (mulModReduceShiftPrefixPost sp x17Old (EvmWord.getLimbN r 0) (EvmWord.getLimbN r 1)
-        (EvmWord.getLimbN r 2) (EvmWord.getLimbN r 3) ** prefixFrame) :=
+      ((mulModReduceShiftPrefixPost sp x17Old (EvmWord.getLimbN r 0) (EvmWord.getLimbN r 1)
+        (EvmWord.getLimbN r 2) (EvmWord.getLimbN r 3) **
+        (.x8 ↦ᵣ (EvmWord.getLimbN r 3 >>> 63))) ** prefixFrame) :=
     cpsTripleWithin_weaken (fun h hp => by
       unfold mulModReduceInnerStepNoSubtractPre at hp
       dsimp only [prefixFrame, shifted] at hp ⊢
       xperm_hyp hp)
       (fun _ hp => hp) hprefix
-  have hcompare0 := evm_mulmod_reduce512_inner_step_compare_lt_full_code_spec_within
-    sp base (EvmWord.getLimbN shifted 3) x7Old shifted n hlt
-  have hcompare := cpsTripleWithin_frameR compareFrame (by pcFree) hcompare0
-  have hprefix_compare : cpsTripleWithin (21 + 15) base (base + 248)
+  -- Carry branch (1 instruction, base+88), not taken because the carry is FALSE.
+  have hcarry_branch := evm_mulmod_reduce512_inner_step_carry_branch_spec_within base r
+  have hcarry_ntaken : cpsTripleWithin 1 (base + 88) (base + 92)
       (evm_mulmod_reduce512_inner_step_code base)
-      (mulModReduceInnerStepNoSubtractPre sp x17Old x5Old x6Old x7Old x15 x19Old x20Old r n **
+      ((.x8 ↦ᵣ (EvmWord.getLimbN r 3 >>> 63)) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x8 ↦ᵣ (EvmWord.getLimbN r 3 >>> 63)) ** (.x0 ↦ᵣ (0 : Word))) :=
+    cpsTripleWithin_weaken (fun _ hp => hp)
+      (fun h hp => ((sepConj_pure_right h).1 hp).1)
+      (cpsBranchWithin_ntakenPath hcarry_branch (by
+        intro h hp
+        have h255 : r.getLsbD 255 = true := ((sepConj_pure_right h).1 hp).2
+        rw [hcarry] at h255; exact absurd h255 (by decide)))
+  -- Frame the carry-branch with everything except x8/x0.
+  let branchFrame : Assertion :=
+    (.x12 ↦ᵣ sp) ** (.x17 ↦ᵣ (x17Old <<< 1)) ** (.x5 ↦ᵣ EvmWord.getLimbN r 3) **
+    (.x6 ↦ᵣ EvmWord.getLimbN shifted 3) **
+    (.x19 ↦ᵣ (EvmWord.getLimbN r 1 >>> 63)) ** (.x20 ↦ᵣ (EvmWord.getLimbN r 2 >>> 63)) **
+    ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN shifted 0) **
+    ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN shifted 1) **
+    ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN shifted 2) **
+    ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ EvmWord.getLimbN shifted 3) **
+    (.x7 ↦ᵣ x7Old) ** (.x15 ↦ᵣ x15) **
+    ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 0) **
+    ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 1) **
+    ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 2) **
+    ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 3) **
+    ⌜mulModReduceRemLT shifted n⌝
+  have hcarry_framed := cpsTripleWithin_frameR branchFrame (by
+    dsimp only [branchFrame, prefixFrame]; pcFree) hcarry_ntaken
+  -- prefix then carry-branch: base → base+92.
+  have hprefix_carry : cpsTripleWithin (22 + 1) base (base + 92)
+      (evm_mulmod_reduce512_inner_step_code base)
+      (mulModReduceInnerStepNoSubtractPre sp x17Old x5Old x6Old x7Old x8Old x15 x19Old x20Old r n **
         ⌜mulModReduceRemLT shifted n⌝)
-      (mulModReduceComparePost sp shifted n false ** compareFrame) :=
+      (((.x8 ↦ᵣ (EvmWord.getLimbN r 3 >>> 63)) ** (.x0 ↦ᵣ (0 : Word))) ** branchFrame) :=
     cpsTripleWithin_seq_perm_same_cr (fun h hp => by
       unfold mulModReduceShiftPrefixPost at hp
       have hrem : mulModReduceRemWord (EvmWord.getLimbN r 0) (EvmWord.getLimbN r 1)
@@ -300,10 +513,23 @@ theorem evm_mulmod_reduce512_inner_step_no_subtract_path_spec_within
           EvmWord.getLimb_as_getLimbN_1, EvmWord.getLimb_as_getLimbN_2,
           EvmWord.getLimb_as_getLimbN_3]
       rw [hrem] at hp
-      unfold mulModReduceComparePre mulModReduceCompareMem
-      dsimp only [shifted, prefixFrame, compareFrame] at hp ⊢
+      dsimp only [shifted, prefixFrame, branchFrame] at hp ⊢
       xperm_hyp hp)
-      hprefixTop hcompare
+      hprefixTop hcarry_framed
+  -- Compare-LT (15 instructions, base+92 → base+256).
+  have hcompare0 := evm_mulmod_reduce512_inner_step_compare_lt_full_code_spec_within
+    sp base (EvmWord.getLimbN shifted 3) x7Old shifted n hlt
+  have hcompare := cpsTripleWithin_frameR compareFrame (by pcFree) hcompare0
+  have hprefix_compare : cpsTripleWithin (22 + 1 + 15) base (base + 256)
+      (evm_mulmod_reduce512_inner_step_code base)
+      (mulModReduceInnerStepNoSubtractPre sp x17Old x5Old x6Old x7Old x8Old x15 x19Old x20Old r n **
+        ⌜mulModReduceRemLT shifted n⌝)
+      (mulModReduceComparePost sp shifted n false ** compareFrame) :=
+    cpsTripleWithin_seq_perm_same_cr (fun h hp => by
+      unfold mulModReduceComparePre mulModReduceCompareMem
+      dsimp only [shifted, branchFrame, prefixFrame, compareFrame] at hp ⊢
+      xperm_hyp hp)
+      hprefix_carry hcompare
   have htail0 := evm_mulmod_reduce512_inner_step_tail_full_code_spec_within base x15
   have htail := cpsBranchWithin_frameR tailFrame (by
     dsimp only [tailFrame]
@@ -313,12 +539,12 @@ theorem evm_mulmod_reduce512_inner_step_no_subtract_path_spec_within
       dsimp only [compareFrame, tailFrame] at hp ⊢
       xperm_hyp hp)
     hprefix_compare htail
-  change cpsBranchWithin (21 + 15 + 2) base
+  change cpsBranchWithin (22 + 1 + 15 + 2) base
       (evm_mulmod_reduce512_inner_step_code base)
-      (mulModReduceInnerStepNoSubtractPre sp x17Old x5Old x6Old x7Old x15 x19Old x20Old r n **
+      (mulModReduceInnerStepNoSubtractPre sp x17Old x5Old x6Old x7Old x8Old x15 x19Old x20Old r n **
         ⌜mulModReduceRemLT shifted n⌝)
       base (mulModReduceInnerStepNoSubtractPost sp x17Old x15 r n false)
-      (base + 256) (mulModReduceInnerStepNoSubtractPost sp x17Old x15 r n true)
+      (base + 264) (mulModReduceInnerStepNoSubtractPost sp x17Old x15 r n true)
   exact cpsBranchWithin_weaken (fun _ hp => hp) (fun h hp => by
       unfold mulModReduceInnerStepNoSubtractPost
       dsimp only [shifted, tailFrame] at hp ⊢
@@ -330,13 +556,20 @@ theorem evm_mulmod_reduce512_inner_step_no_subtract_path_spec_within
     hbranch
 
 
+/-- The carry-aware subtract decision for one reducer step: subtract the modulus
+    when the shift overflowed (`r.getLsbD 255`) or the truncated shifted remainder
+    is already `≥ n`. Mirrors the condition in `mulModReduceStepCarry`. -/
+def mulModReduceSubtractDecision (r n : EvmWord) (x17Old : Word) : Prop :=
+  r.getLsbD 255 = true ∨
+    ¬ ((mulModReduceShiftInBit r (mulModReduceInputBit x17Old)).toNat < n.toNat)
+
 /-- Folded precondition for the reducer inner-step subtract path. -/
 @[irreducible]
 def mulModReduceInnerStepSubtractPre
-    (sp x17Old x5Old x6Old x7Old x10Old x11Old x13Old x15 x19Old x20Old : Word)
+    (sp x17Old x5Old x6Old x7Old x8Old x10Old x11Old x13Old x15 x19Old x20Old : Word)
     (r n : EvmWord) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x17 ↦ᵣ x17Old) ** (.x5 ↦ᵣ x5Old) ** (.x6 ↦ᵣ x6Old) **
-  (.x7 ↦ᵣ x7Old) ** (.x10 ↦ᵣ x10Old) ** (.x11 ↦ᵣ x11Old) **
+  (.x7 ↦ᵣ x7Old) ** (.x8 ↦ᵣ x8Old) ** (.x10 ↦ᵣ x10Old) ** (.x11 ↦ᵣ x11Old) **
   (.x13 ↦ᵣ x13Old) ** (.x15 ↦ᵣ x15) ** (.x0 ↦ᵣ (0 : Word)) **
   (.x19 ↦ᵣ x19Old) ** (.x20 ↦ᵣ x20Old) **
   ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 0) **
@@ -356,22 +589,51 @@ def mulModReduceInnerStepSubtractPost
   mulModReduceTailPost x15 done **
   mulModReduceSubtractPost sp shifted n **
   (.x17 ↦ᵣ (x17Old <<< 1)) **
+  (.x8 ↦ᵣ (EvmWord.getLimbN r 3 >>> 63)) **
   (.x19 ↦ᵣ (EvmWord.getLimbN r 1 >>> 63)) **
   (.x20 ↦ᵣ (EvmWord.getLimbN r 2 >>> 63)) **
-  ⌜mulModReduceRemGE shifted n⌝
+  ⌜mulModReduceSubtractDecision r n x17Old⌝
 
-/-- Compose prefix, compare-GE, subtract-store, and tail into the subtract reducer path. -/
+/-- Drop the path-selecting pure fact carried by the compare-ladder post. -/
+theorem mulModReduceComparePost_drop (sp : Word) (r n : EvmWord) (b : Bool) :
+    ∀ h, mulModReduceComparePost sp r n b h →
+      ((.x12 ↦ᵣ sp) ** regOwn .x6 ** regOwn .x7 ** mulModReduceCompareMem sp r n) h := by
+  intro h hp
+  unfold mulModReduceComparePost at hp
+  exact sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (fun _ hq => ((sepConj_pure_right _).1 hq).1))) h hp
+
+/-- Compose carry-prefix, the carry/compare merge into the subtract entry,
+    subtract-store, and tail into the subtract reducer path. The subtract path
+    triggers when the shift overflowed (`r.getLsbD 255`) OR the truncated shifted
+    remainder is `≥ n`. -/
 theorem evm_mulmod_reduce512_inner_step_subtract_path_spec_within
-    (sp base x17Old x5Old x6Old x7Old x10Old x11Old x13Old x15 x19Old x20Old : Word)
+    (sp base x17Old x5Old x6Old x7Old x8Old x10Old x11Old x13Old x15 x19Old x20Old : Word)
     (r n : EvmWord)
-    (hge : mulModReduceRemGE (mulModReduceShiftInBit r (mulModReduceInputBit x17Old)) n) :
-    cpsBranchWithin 64 base
+    (hdec : mulModReduceSubtractDecision r n x17Old) :
+    cpsBranchWithin 66 base
       (evm_mulmod_reduce512_inner_step_code base)
-      (mulModReduceInnerStepSubtractPre sp x17Old x5Old x6Old x7Old x10Old x11Old x13Old x15 x19Old x20Old r n **
-        ⌜mulModReduceRemGE (mulModReduceShiftInBit r (mulModReduceInputBit x17Old)) n⌝)
+      (mulModReduceInnerStepSubtractPre sp x17Old x5Old x6Old x7Old x8Old x10Old x11Old x13Old x15 x19Old x20Old r n **
+        ⌜mulModReduceSubtractDecision r n x17Old⌝)
       base (mulModReduceInnerStepSubtractPost sp x17Old x15 r n false)
-      (base + 256) (mulModReduceInnerStepSubtractPost sp x17Old x15 r n true) := by
+      (base + 264) (mulModReduceInnerStepSubtractPost sp x17Old x15 r n true) := by
   let shifted := mulModReduceShiftInBit r (mulModReduceInputBit x17Old)
+  -- Frame carried alongside the subtract-store (everything but its own footprint).
+  let subtractFrame : Assertion :=
+    (.x17 ↦ᵣ (x17Old <<< 1)) **
+    (.x8 ↦ᵣ (EvmWord.getLimbN r 3 >>> 63)) **
+    (.x19 ↦ᵣ (EvmWord.getLimbN r 1 >>> 63)) **
+    (.x20 ↦ᵣ (EvmWord.getLimbN r 2 >>> 63)) **
+    (.x15 ↦ᵣ x15) ** (.x0 ↦ᵣ (0 : Word)) **
+    ⌜mulModReduceSubtractDecision r n x17Old⌝
+  let tailFrame : Assertion :=
+    mulModReduceSubtractPost sp shifted n **
+    (.x17 ↦ᵣ (x17Old <<< 1)) **
+    (.x8 ↦ᵣ (EvmWord.getLimbN r 3 >>> 63)) **
+    (.x19 ↦ᵣ (EvmWord.getLimbN r 1 >>> 63)) **
+    (.x20 ↦ᵣ (EvmWord.getLimbN r 2 >>> 63)) **
+    ⌜mulModReduceSubtractDecision r n x17Old⌝
+  -- The carry prefix (22 instructions, base → base+88, exposing x8 = r3 >>> 63).
   let prefixFrame : Assertion :=
     (.x7 ↦ᵣ x7Old) ** (.x10 ↦ᵣ x10Old) ** (.x11 ↦ᵣ x11Old) **
     (.x13 ↦ᵣ x13Old) ** (.x15 ↦ᵣ x15) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -379,79 +641,210 @@ theorem evm_mulmod_reduce512_inner_step_subtract_path_spec_within
     ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 1) **
     ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 2) **
     ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 3) **
-    ⌜mulModReduceRemGE shifted n⌝
-  let compareFrame : Assertion :=
-    (.x17 ↦ᵣ (x17Old <<< 1)) **
-    (.x5 ↦ᵣ EvmWord.getLimbN r 3) **
-    (.x19 ↦ᵣ (EvmWord.getLimbN r 1 >>> 63)) **
-    (.x20 ↦ᵣ (EvmWord.getLimbN r 2 >>> 63)) **
-    (.x10 ↦ᵣ x10Old) ** (.x11 ↦ᵣ x11Old) ** (.x13 ↦ᵣ x13Old) **
-    (.x15 ↦ᵣ x15) ** (.x0 ↦ᵣ (0 : Word))
-  let subtractFrame : Assertion :=
-    (.x17 ↦ᵣ (x17Old <<< 1)) **
-    (.x19 ↦ᵣ (EvmWord.getLimbN r 1 >>> 63)) **
-    (.x20 ↦ᵣ (EvmWord.getLimbN r 2 >>> 63)) **
-    (.x15 ↦ᵣ x15) ** (.x0 ↦ᵣ (0 : Word)) **
-    ⌜mulModReduceRemGE shifted n⌝
-  let tailFrame : Assertion :=
-    mulModReduceSubtractPost sp shifted n **
-    (.x17 ↦ᵣ (x17Old <<< 1)) **
-    (.x19 ↦ᵣ (EvmWord.getLimbN r 1 >>> 63)) **
-    (.x20 ↦ᵣ (EvmWord.getLimbN r 2 >>> 63)) **
-    ⌜mulModReduceRemGE shifted n⌝
-  have hprefix0 := evm_mulmod_reduce512_inner_step_shift_prefix_full_code_spec_within
+    ⌜mulModReduceSubtractDecision r n x17Old⌝
+  have hprefix0 := evm_mulmod_reduce512_inner_step_shift_prefix_carry_spec_within
     sp base x17Old (EvmWord.getLimbN r 0) (EvmWord.getLimbN r 1)
-    (EvmWord.getLimbN r 2) (EvmWord.getLimbN r 3) x5Old x6Old x19Old x20Old
+    (EvmWord.getLimbN r 2) (EvmWord.getLimbN r 3) x5Old x6Old x19Old x20Old x8Old
   have hprefix := cpsTripleWithin_frameR prefixFrame (by pcFree) hprefix0
-  have hprefixTop : cpsTripleWithin 21 base (base + 84)
+  -- The post of the framed carry prefix, refolded over the subtract precondition.
+  let prefixPost : Assertion :=
+    (mulModReduceShiftPrefixPost sp x17Old (EvmWord.getLimbN r 0) (EvmWord.getLimbN r 1)
+      (EvmWord.getLimbN r 2) (EvmWord.getLimbN r 3) **
+      (.x8 ↦ᵣ (EvmWord.getLimbN r 3 >>> 63))) ** prefixFrame
+  have hprefixTop : cpsTripleWithin 22 base (base + 88)
       (evm_mulmod_reduce512_inner_step_code base)
-      (mulModReduceInnerStepSubtractPre sp x17Old x5Old x6Old x7Old x10Old x11Old x13Old x15 x19Old x20Old r n **
-        ⌜mulModReduceRemGE shifted n⌝)
-      (mulModReduceShiftPrefixPost sp x17Old (EvmWord.getLimbN r 0) (EvmWord.getLimbN r 1)
-        (EvmWord.getLimbN r 2) (EvmWord.getLimbN r 3) ** prefixFrame) :=
+      (mulModReduceInnerStepSubtractPre sp x17Old x5Old x6Old x7Old x8Old x10Old x11Old x13Old x15 x19Old x20Old r n **
+        ⌜mulModReduceSubtractDecision r n x17Old⌝)
+      prefixPost :=
     cpsTripleWithin_weaken (fun h hp => by
       unfold mulModReduceInnerStepSubtractPre at hp
-      dsimp only [prefixFrame, shifted] at hp ⊢
+      dsimp only [prefixFrame, prefixPost, shifted] at hp ⊢
       xperm_hyp hp)
       (fun _ hp => hp) hprefix
-  have hcompare0 := evm_mulmod_reduce512_inner_step_compare_ge_full_code_spec_within
-    sp base (EvmWord.getLimbN shifted 3) x7Old shifted n hge
-  have hcompare := cpsTripleWithin_frameR compareFrame (by pcFree) hcompare0
-  have hprefix_compare : cpsTripleWithin (21 + 15) base (base + 144)
+  -- The subtract-store-own precondition (at base+152) with its frame.
+  let subtractOwn : Assertion :=
+    mulModReduceSubtractOwnPre sp (EvmWord.getLimbN r 3) x10Old x11Old x13Old shifted n **
+    subtractFrame
+  -- Merge sub-paths: base+88 → base+152 (≤ 16 steps), reaching the subtract entry.
+  have hmerge : cpsTripleWithin 16 (base + 88) (base + 152)
+      (evm_mulmod_reduce512_inner_step_code base) prefixPost subtractOwn := by
+    have hcarry_branch := evm_mulmod_reduce512_inner_step_carry_branch_spec_within base r
+    by_cases hc : r.getLsbD 255 = true
+    · -- Carry set: branch TAKEN straight to the subtract entry (1 ≤ 16 steps).
+      let takenFrame : Assertion :=
+        (.x12 ↦ᵣ sp) ** (.x17 ↦ᵣ (x17Old <<< 1)) ** (.x5 ↦ᵣ EvmWord.getLimbN r 3) **
+        (.x6 ↦ᵣ EvmWord.getLimbN shifted 3) **
+        (.x19 ↦ᵣ (EvmWord.getLimbN r 1 >>> 63)) ** (.x20 ↦ᵣ (EvmWord.getLimbN r 2 >>> 63)) **
+        ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN shifted 0) **
+        ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN shifted 1) **
+        ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN shifted 2) **
+        ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ EvmWord.getLimbN shifted 3) **
+        (.x7 ↦ᵣ x7Old) ** (.x10 ↦ᵣ x10Old) ** (.x11 ↦ᵣ x11Old) ** (.x13 ↦ᵣ x13Old) **
+        (.x15 ↦ᵣ x15) **
+        ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 0) **
+        ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 1) **
+        ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 2) **
+        ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 3) **
+        ⌜mulModReduceSubtractDecision r n x17Old⌝
+      have htaken : cpsTripleWithin 1 (base + 88) (base + 152)
+          (evm_mulmod_reduce512_inner_step_code base)
+          ((.x8 ↦ᵣ (EvmWord.getLimbN r 3 >>> 63)) ** (.x0 ↦ᵣ (0 : Word)))
+          ((.x8 ↦ᵣ (EvmWord.getLimbN r 3 >>> 63)) ** (.x0 ↦ᵣ (0 : Word))) :=
+        cpsTripleWithin_weaken (fun _ hp => hp)
+          (fun h hp => ((sepConj_pure_right h).1 hp).1)
+          (cpsBranchWithin_takenPath hcarry_branch (by
+            intro h hp
+            have h255 : r.getLsbD 255 = false := ((sepConj_pure_right h).1 hp).2
+            rw [hc] at h255; exact absurd h255 (by decide)))
+      have htaken_framed := cpsTripleWithin_frameR takenFrame (by
+        dsimp only [takenFrame]; pcFree) htaken
+      refine cpsTripleWithin_mono_nSteps (show (1 : Nat) ≤ 16 by omega) ?_
+      refine cpsTripleWithin_weaken ?_ ?_ htaken_framed
+      · intro h hp
+        dsimp only [prefixPost, prefixFrame] at hp
+        unfold mulModReduceShiftPrefixPost at hp
+        have hrem : mulModReduceRemWord (EvmWord.getLimbN r 0) (EvmWord.getLimbN r 1)
+            (EvmWord.getLimbN r 2) (EvmWord.getLimbN r 3) = r := by
+          apply (EvmWord.eq_iff_limbs).2
+          intro i
+          fin_cases i <;> simp [EvmWord.getLimb_as_getLimbN_0,
+            EvmWord.getLimb_as_getLimbN_1, EvmWord.getLimb_as_getLimbN_2,
+            EvmWord.getLimb_as_getLimbN_3]
+        rw [hrem] at hp
+        dsimp only [takenFrame, shifted] at hp ⊢
+        xperm_hyp hp
+      · intro h hp
+        dsimp only [subtractOwn, subtractFrame] at ⊢
+        unfold mulModReduceSubtractOwnPre mulModReduceCompareMem
+        dsimp only [takenFrame, shifted] at hp ⊢
+        -- Convert the concrete x6 and x7 into ownership.
+        have hp6 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+          (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x6 _))))) h hp
+        have hp7 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+          (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+          (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+          (sepConj_mono_right (sepConj_mono_right
+          (sepConj_mono_left (regIs_to_regOwn .x7 _))))))))))))
+          h hp6
+        xperm_hyp hp7
+    · -- Carry clear: branch NOT-TAKEN to compare (1), then compare-GE (15) to base+152.
+      have hge : mulModReduceRemGE shifted n := by
+        rcases hdec with h | h
+        · exact absurd h hc
+        · unfold mulModReduceRemGE
+          dsimp only [shifted]
+          simpa only [BitVec.ult, Bool.not_eq_true, decide_eq_false_iff_not,
+            decide_eq_true_eq] using h
+      let compareFrame : Assertion :=
+        (.x17 ↦ᵣ (x17Old <<< 1)) **
+        (.x5 ↦ᵣ EvmWord.getLimbN r 3) **
+        (.x8 ↦ᵣ (EvmWord.getLimbN r 3 >>> 63)) **
+        (.x19 ↦ᵣ (EvmWord.getLimbN r 1 >>> 63)) **
+        (.x20 ↦ᵣ (EvmWord.getLimbN r 2 >>> 63)) **
+        (.x10 ↦ᵣ x10Old) ** (.x11 ↦ᵣ x11Old) ** (.x13 ↦ᵣ x13Old) **
+        (.x15 ↦ᵣ x15) ** (.x0 ↦ᵣ (0 : Word)) **
+        ⌜mulModReduceSubtractDecision r n x17Old⌝
+      -- Carry branch not taken: base+88 → base+92.
+      have hntaken : cpsTripleWithin 1 (base + 88) (base + 92)
+          (evm_mulmod_reduce512_inner_step_code base)
+          ((.x8 ↦ᵣ (EvmWord.getLimbN r 3 >>> 63)) ** (.x0 ↦ᵣ (0 : Word)))
+          ((.x8 ↦ᵣ (EvmWord.getLimbN r 3 >>> 63)) ** (.x0 ↦ᵣ (0 : Word))) :=
+        cpsTripleWithin_weaken (fun _ hp => hp)
+          (fun h hp => ((sepConj_pure_right h).1 hp).1)
+          (cpsBranchWithin_ntakenPath hcarry_branch (by
+            intro h hp
+            have h255 : r.getLsbD 255 = true := ((sepConj_pure_right h).1 hp).2
+            exact absurd h255 hc))
+      let ntakenFrame : Assertion :=
+        (.x12 ↦ᵣ sp) ** (.x17 ↦ᵣ (x17Old <<< 1)) ** (.x5 ↦ᵣ EvmWord.getLimbN r 3) **
+        (.x6 ↦ᵣ EvmWord.getLimbN shifted 3) **
+        (.x19 ↦ᵣ (EvmWord.getLimbN r 1 >>> 63)) ** (.x20 ↦ᵣ (EvmWord.getLimbN r 2 >>> 63)) **
+        ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN shifted 0) **
+        ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN shifted 1) **
+        ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN shifted 2) **
+        ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ EvmWord.getLimbN shifted 3) **
+        (.x7 ↦ᵣ x7Old) ** (.x10 ↦ᵣ x10Old) ** (.x11 ↦ᵣ x11Old) ** (.x13 ↦ᵣ x13Old) **
+        (.x15 ↦ᵣ x15) **
+        ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 0) **
+        ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 1) **
+        ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 2) **
+        ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 3) **
+        ⌜mulModReduceSubtractDecision r n x17Old⌝
+      have hntaken_framed := cpsTripleWithin_frameR ntakenFrame (by
+        dsimp only [ntakenFrame]; pcFree) hntaken
+      -- prefixPost → compare-GE precondition at base+92 (with compareFrame).
+      have hprefix_to_compare : cpsTripleWithin 1 (base + 88) (base + 92)
+          (evm_mulmod_reduce512_inner_step_code base) prefixPost
+          (mulModReduceComparePre sp (EvmWord.getLimbN shifted 3) x7Old shifted n **
+            compareFrame) :=
+        cpsTripleWithin_weaken
+          (fun h hp => by
+            dsimp only [prefixPost, prefixFrame] at hp
+            unfold mulModReduceShiftPrefixPost at hp
+            have hrem : mulModReduceRemWord (EvmWord.getLimbN r 0) (EvmWord.getLimbN r 1)
+                (EvmWord.getLimbN r 2) (EvmWord.getLimbN r 3) = r := by
+              apply (EvmWord.eq_iff_limbs).2
+              intro i
+              fin_cases i <;> simp [EvmWord.getLimb_as_getLimbN_0,
+                EvmWord.getLimb_as_getLimbN_1, EvmWord.getLimb_as_getLimbN_2,
+                EvmWord.getLimb_as_getLimbN_3]
+            rw [hrem] at hp
+            dsimp only [ntakenFrame, shifted] at hp ⊢
+            xperm_hyp hp)
+          (fun h hp => by
+            unfold mulModReduceComparePre mulModReduceCompareMem
+            dsimp only [ntakenFrame, compareFrame, shifted] at hp ⊢
+            xperm_hyp hp)
+          hntaken_framed
+      have hcompare0' := evm_mulmod_reduce512_inner_step_compare_ge_full_code_spec_within
+        sp base (EvmWord.getLimbN shifted 3) x7Old shifted n hge
+      have hcompare0 : cpsTripleWithin 15 (base + 92) (base + 152)
+          (evm_mulmod_reduce512_inner_step_code base)
+          (mulModReduceComparePre sp (EvmWord.getLimbN shifted 3) x7Old shifted n)
+          (mulModReduceComparePost sp shifted n true) :=
+        cpsTripleWithin_weaken
+          (fun h hp => (sepConj_pure_right h).2 ⟨hp, hge⟩)
+          (fun _ hp => hp) hcompare0'
+      have hcompare := cpsTripleWithin_frameR compareFrame (by
+        dsimp only [compareFrame]; pcFree) hcompare0
+      have hcompose : cpsTripleWithin (1 + 15) (base + 88) (base + 152)
+          (evm_mulmod_reduce512_inner_step_code base) prefixPost
+          (mulModReduceComparePost sp shifted n true ** compareFrame) :=
+        cpsTripleWithin_seq_perm_same_cr (fun h hp => by
+          dsimp only [compareFrame] at hp ⊢
+          xperm_hyp hp)
+          hprefix_to_compare hcompare
+      refine cpsTripleWithin_mono_nSteps (show (1 + 15 : Nat) ≤ 16 by omega) ?_
+      refine cpsTripleWithin_weaken (fun _ hp => hp) ?_ hcompose
+      intro h hp
+      -- Drop the redundant compare-ladder pure fact; the decision pure comes from
+      -- `compareFrame`.
+      have hp' := sepConj_mono_left (mulModReduceComparePost_drop sp shifted n true) h hp
+      dsimp only [subtractOwn, subtractFrame] at ⊢
+      unfold mulModReduceSubtractOwnPre mulModReduceCompareMem
+      unfold mulModReduceCompareMem at hp'
+      dsimp only [compareFrame, shifted] at hp' ⊢
+      xperm_hyp hp'
+  -- prefix-carry (22) then merge (16): base → base+152.
+  have hprefix_subtract : cpsTripleWithin (22 + 16) base (base + 152)
       (evm_mulmod_reduce512_inner_step_code base)
-      (mulModReduceInnerStepSubtractPre sp x17Old x5Old x6Old x7Old x10Old x11Old x13Old x15 x19Old x20Old r n **
-        ⌜mulModReduceRemGE shifted n⌝)
-      (mulModReduceComparePost sp shifted n true ** compareFrame) :=
-    cpsTripleWithin_seq_perm_same_cr (fun h hp => by
-      unfold mulModReduceShiftPrefixPost at hp
-      have hrem : mulModReduceRemWord (EvmWord.getLimbN r 0) (EvmWord.getLimbN r 1)
-          (EvmWord.getLimbN r 2) (EvmWord.getLimbN r 3) = r := by
-        apply (EvmWord.eq_iff_limbs).2
-        intro i
-        fin_cases i <;> simp [EvmWord.getLimb_as_getLimbN_0,
-          EvmWord.getLimb_as_getLimbN_1, EvmWord.getLimb_as_getLimbN_2,
-          EvmWord.getLimb_as_getLimbN_3]
-      rw [hrem] at hp
-      unfold mulModReduceComparePre mulModReduceCompareMem
-      dsimp only [shifted, prefixFrame, compareFrame] at hp ⊢
-      xperm_hyp hp)
-      hprefixTop hcompare
+      (mulModReduceInnerStepSubtractPre sp x17Old x5Old x6Old x7Old x8Old x10Old x11Old x13Old x15 x19Old x20Old r n **
+        ⌜mulModReduceSubtractDecision r n x17Old⌝)
+      subtractOwn :=
+    cpsTripleWithin_seq_same_cr hprefixTop hmerge
+  -- Subtract-store (26 instructions, base+152 → base+256).
   have hsubtract0 := evm_mulmod_reduce512_inner_step_subtract_store_own_full_code_spec_within
     sp base (EvmWord.getLimbN r 3) x10Old x11Old x13Old shifted n
   have hsubtract := cpsTripleWithin_frameR subtractFrame (by pcFree) hsubtract0
-  have hthrough_subtract : cpsTripleWithin (21 + 15 + 26) base (base + 248)
+  have hthrough_subtract : cpsTripleWithin (22 + 16 + 26) base (base + 256)
       (evm_mulmod_reduce512_inner_step_code base)
-      (mulModReduceInnerStepSubtractPre sp x17Old x5Old x6Old x7Old x10Old x11Old x13Old x15 x19Old x20Old r n **
-        ⌜mulModReduceRemGE shifted n⌝)
+      (mulModReduceInnerStepSubtractPre sp x17Old x5Old x6Old x7Old x8Old x10Old x11Old x13Old x15 x19Old x20Old r n **
+        ⌜mulModReduceSubtractDecision r n x17Old⌝)
       (mulModReduceSubtractPost sp shifted n ** subtractFrame) :=
     cpsTripleWithin_seq_perm_same_cr (fun h hp => by
-      unfold mulModReduceComparePost at hp
-      unfold mulModReduceSubtractOwnPre
-      unfold mulModReduceCompareMem at hp ⊢
-      simp only [ite_true] at hp
-      dsimp only [compareFrame, subtractFrame] at hp ⊢
+      dsimp only [subtractOwn, subtractFrame] at hp ⊢
       xperm_hyp hp)
-      hprefix_compare hsubtract
+      hprefix_subtract hsubtract
   have htail0 := evm_mulmod_reduce512_inner_step_tail_full_code_spec_within base x15
   have htail := cpsBranchWithin_frameR tailFrame (by
     dsimp only [tailFrame]
@@ -461,12 +854,12 @@ theorem evm_mulmod_reduce512_inner_step_subtract_path_spec_within
       dsimp only [subtractFrame, tailFrame] at hp ⊢
       xperm_hyp hp)
     hthrough_subtract htail
-  change cpsBranchWithin (21 + 15 + 26 + 2) base
+  change cpsBranchWithin (22 + 16 + 26 + 2) base
       (evm_mulmod_reduce512_inner_step_code base)
-      (mulModReduceInnerStepSubtractPre sp x17Old x5Old x6Old x7Old x10Old x11Old x13Old x15 x19Old x20Old r n **
-        ⌜mulModReduceRemGE shifted n⌝)
+      (mulModReduceInnerStepSubtractPre sp x17Old x5Old x6Old x7Old x8Old x10Old x11Old x13Old x15 x19Old x20Old r n **
+        ⌜mulModReduceSubtractDecision r n x17Old⌝)
       base (mulModReduceInnerStepSubtractPost sp x17Old x15 r n false)
-      (base + 256) (mulModReduceInnerStepSubtractPost sp x17Old x15 r n true)
+      (base + 264) (mulModReduceInnerStepSubtractPost sp x17Old x15 r n true)
   exact cpsBranchWithin_weaken (fun _ hp => hp) (fun h hp => by
       unfold mulModReduceInnerStepSubtractPost
       dsimp only [shifted, tailFrame] at hp ⊢
@@ -507,15 +900,40 @@ theorem mulModReduceStep_of_ge {r n : EvmWord} {bit : Bool}
   unfold mulModReduceStep
   simp only [hge', if_false]
 
+/-- When the carry-aware subtract decision holds, the carry-aware step subtracts
+    the modulus. -/
+theorem mulModReduceStepCarry_of_decision {r n : EvmWord} {x17Old : Word}
+    (hdec : mulModReduceSubtractDecision r n x17Old) :
+    mulModReduceStepCarry r n (mulModReduceInputBit x17Old)
+      = mulModReduceShiftInBit r (mulModReduceInputBit x17Old) - n := by
+  unfold mulModReduceStepCarry
+  simp only [mulModReduceSubtractDecision] at hdec
+  rw [if_pos hdec]
+
+/-- When the carry-aware subtract decision fails (carry clear and `<`), the
+    carry-aware step keeps the shifted-in remainder unchanged. -/
+theorem mulModReduceStepCarry_of_not_decision {r n : EvmWord} {x17Old : Word}
+    (hcarry : r.getLsbD 255 = false)
+    (hlt : mulModReduceRemLT (mulModReduceShiftInBit r (mulModReduceInputBit x17Old)) n) :
+    mulModReduceStepCarry r n (mulModReduceInputBit x17Old)
+      = mulModReduceShiftInBit r (mulModReduceInputBit x17Old) := by
+  have hlt' : (mulModReduceShiftInBit r (mulModReduceInputBit x17Old)).toNat < n.toNat := by
+    unfold mulModReduceRemLT at hlt
+    simpa only [BitVec.ult, decide_eq_true_eq] using hlt
+  unfold mulModReduceStepCarry
+  rw [if_neg]
+  rw [not_or]
+  exact ⟨by rw [hcarry]; exact (by decide), by rw [not_not]; exact hlt'⟩
+
 /-- Folded precondition for the full reducer inner step.
 
 It owns the loop-carried registers and the remainder/modulus memory window,
 agreeing with the subtract-path precondition so both branch paths share it. -/
 @[irreducible]
 def mulModReduceInnerStepPre
-    (sp x17Old x5Old x6Old x7Old x10Old x11Old x13Old x15 x19Old x20Old : Word)
+    (sp x17Old x5Old x6Old x7Old x8Old x10Old x11Old x13Old x15 x19Old x20Old : Word)
     (r n : EvmWord) : Assertion :=
-  mulModReduceInnerStepSubtractPre sp x17Old x5Old x6Old x7Old x10Old x11Old x13Old
+  mulModReduceInnerStepSubtractPre sp x17Old x5Old x6Old x7Old x8Old x10Old x11Old x13Old
     x15 x19Old x20Old r n
 
 /-- Folded postcondition for the full reducer inner step.
@@ -529,10 +947,10 @@ ownership. -/
 @[irreducible]
 def mulModReduceInnerStepPost
     (sp x17Old x15 : Word) (r n : EvmWord) (done : Bool) : Assertion :=
-  let stepped := mulModReduceStep r n (mulModReduceInputBit x17Old)
+  let stepped := mulModReduceStepCarry r n (mulModReduceInputBit x17Old)
   mulModReduceTailPost x15 done **
   (.x12 ↦ᵣ sp) **
-  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x8 **
   regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
   (.x17 ↦ᵣ (x17Old <<< 1)) **
   (.x19 ↦ᵣ (EvmWord.getLimbN r 1 >>> 63)) **
@@ -566,32 +984,28 @@ theorem mulModReduceSubtractPost_regOwn (sp : Word) (r n : EvmWord) :
 /-- Bridge the subtract-path post into the unified inner-step post. -/
 theorem mulModReduceInnerStepPost_of_subtractPost
     (sp x17Old x15 : Word) (r n : EvmWord) (done : Bool)
-    (hge : mulModReduceRemGE (mulModReduceShiftInBit r (mulModReduceInputBit x17Old)) n) :
+    (hdec : mulModReduceSubtractDecision r n x17Old) :
     ∀ h, mulModReduceInnerStepSubtractPost sp x17Old x15 r n done h →
       mulModReduceInnerStepPost sp x17Old x15 r n done h := by
   intro h hp
   unfold mulModReduceInnerStepSubtractPost at hp
+  -- Convert the subtract-store post's concrete scratch into ownership.
   have hp1 := sepConj_mono_right (sepConj_mono_left
     (mulModReduceSubtractPost_regOwn sp
       (mulModReduceShiftInBit r (mulModReduceInputBit x17Old)) n)) h hp
+  -- Surrender x8 ownership.
+  have hp2 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono_left (regIs_to_regOwn .x8 _)))) h hp1
   unfold mulModReduceInnerStepPost mulModReduceCompareMem
-  unfold mulModReduceSubtractMem at hp1
-  rw [mulModReduceStep_of_ge hge]
-  xperm_pure hp1
-
-/-- Drop the path-selecting pure fact carried by the compare-ladder post. -/
-theorem mulModReduceComparePost_drop (sp : Word) (r n : EvmWord) (b : Bool) :
-    ∀ h, mulModReduceComparePost sp r n b h →
-      ((.x12 ↦ᵣ sp) ** regOwn .x6 ** regOwn .x7 ** mulModReduceCompareMem sp r n) h := by
-  intro h hp
-  unfold mulModReduceComparePost at hp
-  exact sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
-    (fun _ hq => ((sepConj_pure_right _).1 hq).1))) h hp
+  unfold mulModReduceSubtractMem at hp2
+  rw [mulModReduceStepCarry_of_decision hdec]
+  xperm_pure hp2
 
 /-- Bridge the no-subtract-path post (with the frame-in scratch registers)
     into the unified inner-step post. -/
 theorem mulModReduceInnerStepPost_of_noSubtractPost
     (sp x17Old x10Old x11Old x13Old x15 : Word) (r n : EvmWord) (done : Bool)
+    (hcarry : r.getLsbD 255 = false)
     (hlt : mulModReduceRemLT (mulModReduceShiftInBit r (mulModReduceInputBit x17Old)) n) :
     ∀ h, (mulModReduceInnerStepNoSubtractPost sp x17Old x15 r n done **
             ((.x10 ↦ᵣ x10Old) ** (.x11 ↦ᵣ x11Old) ** (.x13 ↦ᵣ x13Old))) h →
@@ -603,54 +1017,64 @@ theorem mulModReduceInnerStepPost_of_noSubtractPost
       (mulModReduceShiftInBit r (mulModReduceInputBit x17Old)) n false))) h hp
   have hp2 := sepConj_mono_left (sepConj_mono_right (sepConj_mono_right
     (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x5 _))))) h hp1
-  have hp3 := sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x10 _)) h hp2
+  have hp2b := sepConj_mono_left (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono_right (sepConj_mono_right (sepConj_mono_left
+      (regIs_to_regOwn .x8 _)))))) h hp2
+  have hp3 := sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x10 _)) h hp2b
   have hp4 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_left
     (regIs_to_regOwn .x11 _))) h hp3
   have hp5 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
     (regIs_to_regOwn .x13 _))) h hp4
   unfold mulModReduceInnerStepPost
-  rw [mulModReduceStep_of_lt hlt]
+  rw [mulModReduceStepCarry_of_not_decision hcarry hlt]
   xperm_hyp hp5
 
 /-- Full reducer inner-step branch specification: one bit-serial step of the
     512-bit modular reduction, dispatching the subtract / no-subtract paths on
     the comparison of the shifted remainder against the modulus. -/
 theorem evm_mulmod_reduce512_inner_step_spec_within
-    (sp base x17Old x5Old x6Old x7Old x10Old x11Old x13Old x15 x19Old x20Old : Word)
+    (sp base x17Old x5Old x6Old x7Old x8Old x10Old x11Old x13Old x15 x19Old x20Old : Word)
     (r n : EvmWord) :
-    cpsBranchWithin 64 base
+    cpsBranchWithin 66 base
       (evm_mulmod_reduce512_inner_step_code base)
-      (mulModReduceInnerStepPre sp x17Old x5Old x6Old x7Old x10Old x11Old x13Old
+      (mulModReduceInnerStepPre sp x17Old x5Old x6Old x7Old x8Old x10Old x11Old x13Old
         x15 x19Old x20Old r n)
       base (mulModReduceInnerStepPost sp x17Old x15 r n false)
-      (base + 256) (mulModReduceInnerStepPost sp x17Old x15 r n true) := by
-  by_cases hge : mulModReduceRemGE (mulModReduceShiftInBit r (mulModReduceInputBit x17Old)) n
-  · have hsub := evm_mulmod_reduce512_inner_step_subtract_path_spec_within
-      sp base x17Old x5Old x6Old x7Old x10Old x11Old x13Old x15 x19Old x20Old r n hge
+      (base + 264) (mulModReduceInnerStepPost sp x17Old x15 r n true) := by
+  by_cases hdec : mulModReduceSubtractDecision r n x17Old
+  · -- Subtract path (66 steps): the shift overflowed or the truncated value ≥ n.
+    have hsub := evm_mulmod_reduce512_inner_step_subtract_path_spec_within
+      sp base x17Old x5Old x6Old x7Old x8Old x10Old x11Old x13Old x15 x19Old x20Old r n hdec
     exact cpsBranchWithin_weaken
       (fun h hp => by
         unfold mulModReduceInnerStepPre at hp
-        exact (sepConj_pure_right h).2 ⟨hp, hge⟩)
-      (mulModReduceInnerStepPost_of_subtractPost sp x17Old x15 r n false hge)
-      (mulModReduceInnerStepPost_of_subtractPost sp x17Old x15 r n true hge)
+        exact (sepConj_pure_right h).2 ⟨hp, hdec⟩)
+      (mulModReduceInnerStepPost_of_subtractPost sp x17Old x15 r n false hdec)
+      (mulModReduceInnerStepPost_of_subtractPost sp x17Old x15 r n true hdec)
       hsub
-  · have hlt : mulModReduceRemLT (mulModReduceShiftInBit r (mulModReduceInputBit x17Old)) n := by
-      unfold mulModReduceRemGE at hge
+  · -- No-subtract path: carry clear and truncated value < n.
+    have hcarry : r.getLsbD 255 = false := by
+      by_contra hc
+      exact hdec (Or.inl (by simpa using hc))
+    have hlt : mulModReduceRemLT (mulModReduceShiftInBit r (mulModReduceInputBit x17Old)) n := by
       unfold mulModReduceRemLT
-      exact not_not.mp hge
+      have hlt' : (mulModReduceShiftInBit r (mulModReduceInputBit x17Old)).toNat < n.toNat := by
+        by_contra h
+        exact hdec (Or.inr h)
+      simpa only [BitVec.ult, decide_eq_true_eq] using hlt'
     have hns0 := evm_mulmod_reduce512_inner_step_no_subtract_path_spec_within
-      sp base x17Old x5Old x6Old x7Old x15 x19Old x20Old r n hlt
+      sp base x17Old x5Old x6Old x7Old x8Old x15 x19Old x20Old r n hcarry hlt
     have hns1 := cpsBranchWithin_frameR
       ((.x10 ↦ᵣ x10Old) ** (.x11 ↦ᵣ x11Old) ** (.x13 ↦ᵣ x13Old)) (by pcFree) hns0
-    have hns := cpsBranchWithin_mono_nSteps (show (38 : Nat) ≤ 64 by omega) hns1
+    have hns := cpsBranchWithin_mono_nSteps (show (40 : Nat) ≤ 66 by omega) hns1
     exact cpsBranchWithin_weaken
       (fun h hp => by
         unfold mulModReduceInnerStepPre mulModReduceInnerStepSubtractPre at hp
         unfold mulModReduceInnerStepNoSubtractPre
         have hp2 := (sepConj_pure_right h).2 ⟨hp, hlt⟩
         xperm_hyp hp2)
-      (mulModReduceInnerStepPost_of_noSubtractPost sp x17Old x10Old x11Old x13Old x15 r n false hlt)
-      (mulModReduceInnerStepPost_of_noSubtractPost sp x17Old x10Old x11Old x13Old x15 r n true hlt)
+      (mulModReduceInnerStepPost_of_noSubtractPost sp x17Old x10Old x11Old x13Old x15 r n false hcarry hlt)
+      (mulModReduceInnerStepPost_of_noSubtractPost sp x17Old x10Old x11Old x13Old x15 r n true hcarry hlt)
       hns
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MulMod/ReduceOuterInduction.lean
+++ b/EvmAsm/Evm64/MulMod/ReduceOuterInduction.lean
@@ -60,7 +60,7 @@ theorem limbChain_pcFree (ptr : Word) (limbs : Nat → Word) (m : Nat) :
     `regOwn` body adapter consumes once the current product cell is split off. -/
 def outerEntryCore (sp ptr c : Word) (r n : EvmWord) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x16 ↦ᵣ ptr) ** (.x0 ↦ᵣ (0 : Word)) ** (.x18 ↦ᵣ c) **
-  regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
   regOwn .x17 ** regOwn .x15 ** regOwn .x19 ** regOwn .x20 **
   mulModReduceCompareMem sp r n
 
@@ -68,16 +68,16 @@ def outerEntryCore (sp ptr c : Word) (r n : EvmWord) : Assertion :=
     (1 ≤ m ≤ 8): starting with `m` in the limb counter `x18` and the current
     product limb at `x16 = ptr`, the loop folds the `m` product limbs (highest
     first, `limbChain ptr limbs m`) into the remainder and lands at the loop
-    exit `base + 276` with the remainder fully reduced over those limbs
-    (`mulModReduceOuterFold n limbs r m`). The window limbs are read-only, so
+    exit `base + 284` with the remainder fully reduced over those limbs
+    (`mulModReduceOuterFoldCarry n limbs r m`). The window limbs are read-only, so
     they are preserved in the postcondition. -/
 private theorem outer_aux (m : Nat) :
     1 ≤ m → m ≤ 8 →
     ∀ (sp base ptr : Word) (r n : EvmWord) (limbs : Nat → Word),
-    cpsTripleWithin ((2 + 64 * 64 + 2 + 1) * m) base (base + 276)
+    cpsTripleWithin ((2 + 66 * 64 + 2 + 1) * m) base (base + 284)
       (CodeReq.ofProg base evm_mulmod_reduce512_loop)
       (outerEntryCore sp ptr (BitVec.ofNat 64 m) r n ** limbChain ptr limbs m)
-      (mulModReduceBitLoopPost sp (mulModReduceOuterFold n limbs r m) n **
+      (mulModReduceBitLoopPost sp (mulModReduceOuterFoldCarry n limbs r m) n **
         regOwn .x16 ** regOwn .x18 ** limbChain ptr limbs m) := by
   induction m with
   | zero => intro h1 _; omega
@@ -90,9 +90,9 @@ private theorem outer_aux (m : Nat) :
         (mulModReduceBitCounter_eq_zero_iff 1 (by omega) (by omega)).mpr rfl
       have hstep := evm_mulmod_reduce512_loop_body_done_path
         sp base ptr (BitVec.ofNat 64 1) (limbs 0) r n hdone
-      rw [show (2 + 64 * 64 + 2 + 1) * 1 = 2 + 64 * 64 + 2 + 1 from by ring,
-        show mulModReduceOuterFold n limbs r 1 = mulModReduceStepN r n (limbs 0) 64 from by
-          rw [mulModReduceOuterFold_succ, mulModReduceOuterFold_zero]]
+      rw [show (2 + 66 * 64 + 2 + 1) * 1 = 2 + 66 * 64 + 2 + 1 from by ring,
+        show mulModReduceOuterFoldCarry n limbs r 1 = mulModReduceStepNCarry r n (limbs 0) 64 from by
+          rw [mulModReduceOuterFoldCarry_succ, mulModReduceOuterFoldCarry_zero]]
       refine cpsTripleWithin_weaken ?_ ?_ hstep
       · intro h hp
         rw [limbChain_succ, limbChain_zero, sepConj_emp_right'] at hp
@@ -120,12 +120,12 @@ private theorem outer_aux (m : Nat) :
         (limbChain (ptr + signExtend12 (4088 : BitVec 12)) (fun i => limbs (i + 1)) k)
         (limbChain_pcFree _ _ _) hstep
       have hih := ih hkpos (by omega) sp base (ptr + signExtend12 (4088 : BitVec 12))
-        (mulModReduceStepN r n (limbs 0) 64) n (fun i => limbs (i + 1))
+        (mulModReduceStepNCarry r n (limbs 0) 64) n (fun i => limbs (i + 1))
       have hIH' := cpsTripleWithin_frameR
         ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limbs 0) (by pcFree) hih
-      rw [show (2 + 64 * 64 + 2 + 1) * (k + 1)
-            = (2 + 64 * 64 + 2 + 1) + (2 + 64 * 64 + 2 + 1) * k from by ring,
-        mulModReduceOuterFold_succ]
+      rw [show (2 + 66 * 64 + 2 + 1) * (k + 1)
+            = (2 + 66 * 64 + 2 + 1) + (2 + 66 * 64 + 2 + 1) * k from by ring,
+        mulModReduceOuterFoldCarry_succ]
       refine cpsTripleWithin_weaken ?_ ?_
         (cpsTripleWithin_seq_perm_same_cr ?_ hframed_loop hIH')
       · -- pre(k+1) ⊢ framed loop-path precondition
@@ -158,10 +158,10 @@ private theorem outer_aux (m : Nat) :
     into the remainder. -/
 theorem evm_mulmod_reduce512_loop_spec_within
     (sp base ptr : Word) (r n : EvmWord) (limbs : Nat → Word) :
-    cpsTripleWithin ((2 + 64 * 64 + 2 + 1) * 8) base (base + 276)
+    cpsTripleWithin ((2 + 66 * 64 + 2 + 1) * 8) base (base + 284)
       (CodeReq.ofProg base evm_mulmod_reduce512_loop)
       (outerEntryCore sp ptr (BitVec.ofNat 64 8) r n ** limbChain ptr limbs 8)
-      (mulModReduceBitLoopPost sp (mulModReduceOuterFold n limbs r 8) n **
+      (mulModReduceBitLoopPost sp (mulModReduceOuterFoldCarry n limbs r 8) n **
         regOwn .x16 ** regOwn .x18 ** limbChain ptr limbs 8) :=
   outer_aux 8 (by omega) (by omega) sp base ptr r n limbs
 
@@ -182,13 +182,13 @@ theorem evm_mulmod_reduce512_loop_code_sub (base : Word) :
 
 /-- The full outer reducer loop, lifted into the total reducer program code:
     from byte offset 24 it folds all eight product limbs into the remainder,
-    landing at offset 300 (where `write_result` begins). -/
+    landing at offset 308 (where `write_result` begins). -/
 theorem evm_mulmod_reduce512_loop_total_spec_within
     (sp base ptr : Word) (r n : EvmWord) (limbs : Nat → Word) :
-    cpsTripleWithin ((2 + 64 * 64 + 2 + 1) * 8) (base + 24) (base + 24 + 276)
+    cpsTripleWithin ((2 + 66 * 64 + 2 + 1) * 8) (base + 24) (base + 24 + 284)
       (CodeReq.ofProg base evm_mulmod_reduce512)
       (outerEntryCore sp ptr (BitVec.ofNat 64 8) r n ** limbChain ptr limbs 8)
-      (mulModReduceBitLoopPost sp (mulModReduceOuterFold n limbs r 8) n **
+      (mulModReduceBitLoopPost sp (mulModReduceOuterFoldCarry n limbs r 8) n **
         regOwn .x16 ** regOwn .x18 ** limbChain ptr limbs 8) :=
   cpsTripleWithin_extend_code
     (hmono := evm_mulmod_reduce512_loop_code_sub base)
@@ -204,10 +204,10 @@ theorem evm_mulmod_reduce512_init_code_sub (base : Word) :
     (evm_mulmod_reduce512_loop ++
       (evm_mulmod_reduce512_write_result ++ evm_mulmod_epilogue)) a i h
 
-/-- `evm_mulmod_reduce512_write_result` sits at byte offset 300 (after `init`
-    and the 69-instruction `loop`) within the total reducer program. -/
+/-- `evm_mulmod_reduce512_write_result` sits at byte offset 308 (after `init`
+    and the 71-instruction `loop`) within the total reducer program. -/
 theorem evm_mulmod_reduce512_write_result_code_sub (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + BitVec.ofNat 64 300) evm_mulmod_reduce512_write_result) a = some i →
+    ∀ a i, (CodeReq.ofProg (base + BitVec.ofNat 64 308) evm_mulmod_reduce512_write_result) a = some i →
       (CodeReq.ofProg base evm_mulmod_reduce512) a = some i := by
   intro a i h
   refine CodeReq.ofProg_mono_append_right base evm_mulmod_reduce512_init
@@ -216,15 +216,15 @@ theorem evm_mulmod_reduce512_write_result_code_sub (base : Word) :
   refine CodeReq.ofProg_mono_append_right (base + BitVec.ofNat 64 24) evm_mulmod_reduce512_loop
     (evm_mulmod_reduce512_write_result ++ evm_mulmod_epilogue) (by decide) a i ?_
   rw [evm_mulmod_reduce512_loop_length,
-    show (base + BitVec.ofNat 64 24) + BitVec.ofNat 64 (4 * 69) = base + BitVec.ofNat 64 300 from by
+    show (base + BitVec.ofNat 64 24) + BitVec.ofNat 64 (4 * 71) = base + BitVec.ofNat 64 308 from by
       bv_omega]
-  exact CodeReq.ofProg_mono_append_left (base + BitVec.ofNat 64 300)
+  exact CodeReq.ofProg_mono_append_left (base + BitVec.ofNat 64 308)
     evm_mulmod_reduce512_write_result evm_mulmod_epilogue a i h
 
-/-- `evm_mulmod_epilogue` is the final instruction (byte offset 332) of the
+/-- `evm_mulmod_epilogue` is the final instruction (byte offset 340) of the
     total reducer program. -/
 theorem evm_mulmod_epilogue_code_sub (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + BitVec.ofNat 64 332) evm_mulmod_epilogue) a = some i →
+    ∀ a i, (CodeReq.ofProg (base + BitVec.ofNat 64 340) evm_mulmod_epilogue) a = some i →
       (CodeReq.ofProg base evm_mulmod_reduce512) a = some i := by
   intro a i h
   refine CodeReq.ofProg_mono_append_right base evm_mulmod_reduce512_init
@@ -233,12 +233,12 @@ theorem evm_mulmod_epilogue_code_sub (base : Word) :
   refine CodeReq.ofProg_mono_append_right (base + BitVec.ofNat 64 24) evm_mulmod_reduce512_loop
     (evm_mulmod_reduce512_write_result ++ evm_mulmod_epilogue) (by decide) a i ?_
   rw [evm_mulmod_reduce512_loop_length,
-    show (base + BitVec.ofNat 64 24) + BitVec.ofNat 64 (4 * 69) = base + BitVec.ofNat 64 300 from by
+    show (base + BitVec.ofNat 64 24) + BitVec.ofNat 64 (4 * 71) = base + BitVec.ofNat 64 308 from by
       bv_omega]
-  refine CodeReq.ofProg_mono_append_right (base + BitVec.ofNat 64 300) evm_mulmod_reduce512_write_result
+  refine CodeReq.ofProg_mono_append_right (base + BitVec.ofNat 64 308) evm_mulmod_reduce512_write_result
     evm_mulmod_epilogue (by decide) a i ?_
   rw [evm_mulmod_reduce512_write_result_length,
-    show (base + BitVec.ofNat 64 300) + BitVec.ofNat 64 (4 * 8) = base + BitVec.ofNat 64 332 from by
+    show (base + BitVec.ofNat 64 308) + BitVec.ofNat 64 (4 * 8) = base + BitVec.ofNat 64 340 from by
       bv_omega]
   exact h
 
@@ -263,10 +263,10 @@ theorem evm_mulmod_reduce512_init_total_spec_within (sp base : Word)
     (h := evm_mulmod_reduce512_init_spec_within sp base v16Old v18Old r0 r1 r2 r3)
 
 /-- `evm_mulmod_reduce512_write_result` lifted into the total reducer program
-    code (byte offset 300): copies the reduced remainder into the result slots. -/
+    code (byte offset 308): copies the reduced remainder into the result slots. -/
 theorem evm_mulmod_reduce512_write_result_total_spec_within (sp base : Word)
     (v5Old r0 r1 r2 r3 m0 m1 m2 m3 : Word) :
-    cpsTripleWithin 8 (base + 300) (base + 300 + 32) (CodeReq.ofProg base evm_mulmod_reduce512)
+    cpsTripleWithin 8 (base + 308) (base + 308 + 32) (CodeReq.ofProg base evm_mulmod_reduce512)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5Old) **
        ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ r0) **
        ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ r1) **
@@ -287,46 +287,46 @@ theorem evm_mulmod_reduce512_write_result_total_spec_within (sp base : Word)
        ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ r3)) :=
   cpsTripleWithin_extend_code
     (hmono := evm_mulmod_reduce512_write_result_code_sub base)
-    (h := evm_mulmod_reduce512_write_result_spec_within sp (base + BitVec.ofNat 64 300)
+    (h := evm_mulmod_reduce512_write_result_spec_within sp (base + BitVec.ofNat 64 308)
       v5Old r0 r1 r2 r3 m0 m1 m2 m3)
 
 /-- `evm_mulmod_epilogue` lifted into the total reducer program code (byte
-    offset 332): the final `ADDI x12, x12, 64` restoring the result base. -/
+    offset 340): the final `ADDI x12, x12, 64` restoring the result base. -/
 theorem evm_mulmod_epilogue_total_spec_within (sp base : Word) :
-    cpsTripleWithin 1 (base + 332) (base + 332 + 4) (CodeReq.ofProg base evm_mulmod_reduce512)
+    cpsTripleWithin 1 (base + 340) (base + 340 + 4) (CodeReq.ofProg base evm_mulmod_reduce512)
       (.x12 ↦ᵣ sp)
       (.x12 ↦ᵣ (sp + signExtend12 (64 : BitVec 12))) :=
   cpsTripleWithin_extend_code
     (hmono := evm_mulmod_epilogue_code_sub base)
-    (h := evm_mulmod_epilogue_spec_within sp (base + BitVec.ofNat 64 332))
+    (h := evm_mulmod_epilogue_spec_within sp (base + BitVec.ofNat 64 340))
 
 /-- The reducer prologue and main loop composed: `init` zeroes the accumulator
     and arms the pointer/counter (`x16 = sp + 152`, `x18 = 8`), then the
     eight-limb `loop` folds the product window `limbChain (sp + 152) limbs 8`
-    into the remainder, landing at byte offset 300 with the reduced value
-    `mulModReduceOuterFold n limbs 0 8` in the accumulator. The scratch
+    into the remainder, landing at byte offset 308 with the reduced value
+    `mulModReduceOuterFoldCarry n limbs 0 8` in the accumulator. The scratch
     registers, modulus, and product window are framed across `init`. -/
 theorem evm_mulmod_reduce512_init_loop_spec_within
     (sp base : Word) (v16Old v18Old r0 r1 r2 r3 : Word) (n : EvmWord) (limbs : Nat → Word) :
-    cpsTripleWithin (6 + (2 + 64 * 64 + 2 + 1) * 8) base (base + 24 + 276)
+    cpsTripleWithin (6 + (2 + 66 * 64 + 2 + 1) * 8) base (base + 24 + 284)
       (CodeReq.ofProg base evm_mulmod_reduce512)
       (((.x12 ↦ᵣ sp) ** (.x16 ↦ᵣ v16Old) ** (.x18 ↦ᵣ v18Old) ** (.x0 ↦ᵣ 0) **
         ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ r0) **
         ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ r1) **
         ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ r2) **
         ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ r3)) **
-       ((regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+       ((regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 **
          regOwn .x13 ** regOwn .x17 ** regOwn .x15 ** regOwn .x19 ** regOwn .x20 **
          ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 0) **
          ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 1) **
          ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 2) **
          ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 3)) **
         limbChain (sp + signExtend12 (152 : BitVec 12)) limbs 8))
-      (mulModReduceBitLoopPost sp (mulModReduceOuterFold n limbs (0 : EvmWord) 8) n **
+      (mulModReduceBitLoopPost sp (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) n **
         regOwn .x16 ** regOwn .x18 **
         limbChain (sp + signExtend12 (152 : BitVec 12)) limbs 8) := by
   have hframed_init := cpsTripleWithin_frameR
-    ((regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+    ((regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 **
       regOwn .x13 ** regOwn .x17 ** regOwn .x15 ** regOwn .x19 ** regOwn .x20 **
       ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 0) **
       ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 1) **
@@ -349,7 +349,7 @@ theorem evm_mulmod_reduce512_init_loop_spec_within
     regardless of its incoming value, so the loop's owned `x5` feeds straight in. -/
 theorem evm_mulmod_reduce512_write_result_regown_spec_within (sp base : Word)
     (r0 r1 r2 r3 m0 m1 m2 m3 : Word) :
-    cpsTripleWithin 8 (base + 300) (base + 300 + 32) (CodeReq.ofProg base evm_mulmod_reduce512)
+    cpsTripleWithin 8 (base + 308) (base + 308 + 32) (CodeReq.ofProg base evm_mulmod_reduce512)
       (((.x12 ↦ᵣ sp) **
         ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ r0) **
         ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ r1) **
@@ -374,21 +374,21 @@ theorem evm_mulmod_reduce512_write_result_regown_spec_within (sp base : Word)
     (evm_mulmod_reduce512_write_result_total_spec_within sp base v5 r0 r1 r2 r3 m0 m1 m2 m3)
 
 /-- Prologue, main loop, and result-writeback composed: after `init ;; loop`
-    leaves the reduced value `R = mulModReduceOuterFold n limbs 0 8` in the
+    leaves the reduced value `R = mulModReduceOuterFoldCarry n limbs 0 8` in the
     accumulator window, `write_result` copies its four limbs into the EVM result
-    slots `sp + 64 .. sp + 88`. Lands at byte offset 332 (where the epilogue
+    slots `sp + 64 .. sp + 88`. Lands at byte offset 340 (where the epilogue
     begins). The loop's owned scratch registers and the (now-spent) product
     window are framed across `write_result`. -/
 theorem evm_mulmod_reduce512_init_loop_wr_spec_within
     (sp base : Word) (v16Old v18Old r0 r1 r2 r3 : Word) (n : EvmWord) (limbs : Nat → Word) :
-    cpsTripleWithin (6 + (2 + 64 * 64 + 2 + 1) * 8 + 8) base (base + 300 + 32)
+    cpsTripleWithin (6 + (2 + 66 * 64 + 2 + 1) * 8 + 8) base (base + 308 + 32)
       (CodeReq.ofProg base evm_mulmod_reduce512)
       (((.x12 ↦ᵣ sp) ** (.x16 ↦ᵣ v16Old) ** (.x18 ↦ᵣ v18Old) ** (.x0 ↦ᵣ 0) **
         ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ r0) **
         ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ r1) **
         ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ r2) **
         ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ r3)) **
-       ((regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+       ((regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 **
          regOwn .x13 ** regOwn .x17 ** regOwn .x15 ** regOwn .x19 ** regOwn .x20 **
          ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 0) **
          ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 1) **
@@ -396,32 +396,32 @@ theorem evm_mulmod_reduce512_init_loop_wr_spec_within
          ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 3)) **
         limbChain (sp + signExtend12 (152 : BitVec 12)) limbs 8))
       (((.x12 ↦ᵣ sp) **
-        (.x5 ↦ᵣ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 3) **
-        ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 0) **
-        ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 1) **
-        ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 2) **
-        ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 3) **
-        ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 0) **
-        ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 1) **
-        ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 2) **
-        ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 3)) **
+        (.x5 ↦ᵣ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 3) **
+        ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 0) **
+        ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 1) **
+        ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 2) **
+        ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 3) **
+        ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 0) **
+        ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 1) **
+        ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 2) **
+        ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 3)) **
        (((.x15 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
-         regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
+         regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
          regOwn .x17 ** regOwn .x19 ** regOwn .x20 ** regOwn .x16 ** regOwn .x18) **
         limbChain (sp + signExtend12 (152 : BitVec 12)) limbs 8)) := by
   have hil := evm_mulmod_reduce512_init_loop_spec_within sp base v16Old v18Old r0 r1 r2 r3 n limbs
-  rw [show (base : Word) + 24 + 276 = base + 300 from by bv_omega] at hil
+  rw [show (base : Word) + 24 + 284 = base + 308 from by bv_omega] at hil
   have hwr := cpsTripleWithin_frameR
     (((.x15 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
-      regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
+      regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
       regOwn .x17 ** regOwn .x19 ** regOwn .x20 ** regOwn .x16 ** regOwn .x18) **
       limbChain (sp + signExtend12 (152 : BitVec 12)) limbs 8)
     (pcFree_sepConj (by pcFree) (limbChain_pcFree _ _ _))
     (evm_mulmod_reduce512_write_result_regown_spec_within sp base
-      (EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 0)
-      (EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 1)
-      (EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 2)
-      (EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 3)
+      (EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 0)
+      (EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 1)
+      (EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 2)
+      (EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 3)
       (EvmWord.getLimbN n 0) (EvmWord.getLimbN n 1)
       (EvmWord.getLimbN n 2) (EvmWord.getLimbN n 3))
   refine cpsTripleWithin_seq_perm_same_cr ?_ hil hwr
@@ -432,18 +432,18 @@ theorem evm_mulmod_reduce512_init_loop_wr_spec_within
 /-- The full 512-bit-by-256-bit MULMOD reducer, end to end. Given the 512-bit
     product as eight 64-bit limbs (`limbChain (sp + 152) limbs 8`) and the
     256-bit modulus `n` in its slots, `evm_mulmod_reduce512` leaves the reduced
-    value `R = mulModReduceOuterFold n limbs 0 8` in the EVM result slots
+    value `R = mulModReduceOuterFoldCarry n limbs 0 8` in the EVM result slots
     `sp + 64 .. sp + 88` and restores the result base pointer (`x12 = sp + 64`). -/
 theorem evm_mulmod_reduce512_spec_within
     (sp base : Word) (v16Old v18Old r0 r1 r2 r3 : Word) (n : EvmWord) (limbs : Nat → Word) :
-    cpsTripleWithin (6 + (2 + 64 * 64 + 2 + 1) * 8 + 8 + 1) base (base + 336)
+    cpsTripleWithin (6 + (2 + 66 * 64 + 2 + 1) * 8 + 8 + 1) base (base + 344)
       (CodeReq.ofProg base evm_mulmod_reduce512)
       (((.x12 ↦ᵣ sp) ** (.x16 ↦ᵣ v16Old) ** (.x18 ↦ᵣ v18Old) ** (.x0 ↦ᵣ 0) **
         ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ r0) **
         ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ r1) **
         ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ r2) **
         ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ r3)) **
-       ((regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+       ((regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 **
          regOwn .x13 ** regOwn .x17 ** regOwn .x15 ** regOwn .x19 ** regOwn .x20 **
          ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 0) **
          ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 1) **
@@ -451,38 +451,38 @@ theorem evm_mulmod_reduce512_spec_within
          ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 3)) **
         limbChain (sp + signExtend12 (152 : BitVec 12)) limbs 8))
       ((.x12 ↦ᵣ (sp + signExtend12 (64 : BitVec 12))) **
-       (((.x5 ↦ᵣ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 3) **
-         ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 0) **
-         ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 1) **
-         ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 2) **
-         ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 3) **
-         ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 0) **
-         ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 1) **
-         ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 2) **
-         ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 3)) **
+       (((.x5 ↦ᵣ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 3) **
+         ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 0) **
+         ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 1) **
+         ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 2) **
+         ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 3) **
+         ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 0) **
+         ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 1) **
+         ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 2) **
+         ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 3)) **
         (((.x15 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
-          regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
+          regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
           regOwn .x17 ** regOwn .x19 ** regOwn .x20 ** regOwn .x16 ** regOwn .x18) **
          limbChain (sp + signExtend12 (152 : BitVec 12)) limbs 8))) := by
   have hilwr := evm_mulmod_reduce512_init_loop_wr_spec_within sp base v16Old v18Old r0 r1 r2 r3 n limbs
-  rw [show (base : Word) + 300 + 32 = base + 332 from by bv_omega] at hilwr
+  rw [show (base : Word) + 308 + 32 = base + 340 from by bv_omega] at hilwr
   have hepi := cpsTripleWithin_frameR
-    (((.x5 ↦ᵣ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 3) **
-      ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 0) **
-      ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 1) **
-      ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 2) **
-      ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 3) **
-      ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 0) **
-      ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 1) **
-      ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 2) **
-      ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFold n limbs (0 : EvmWord) 8) 3)) **
+    (((.x5 ↦ᵣ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 3) **
+      ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 0) **
+      ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 1) **
+      ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 2) **
+      ((sp + signExtend12 (248 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 3) **
+      ((sp + signExtend12 (64 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 0) **
+      ((sp + signExtend12 (72 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 1) **
+      ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 2) **
+      ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN (mulModReduceOuterFoldCarry n limbs (0 : EvmWord) 8) 3)) **
      (((.x15 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
-       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
+       regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
        regOwn .x17 ** regOwn .x19 ** regOwn .x20 ** regOwn .x16 ** regOwn .x18) **
       limbChain (sp + signExtend12 (152 : BitVec 12)) limbs 8))
     (pcFree_sepConj (by pcFree) (pcFree_sepConj (by pcFree) (limbChain_pcFree _ _ _)))
     (evm_mulmod_epilogue_total_spec_within sp base)
-  rw [show (base : Word) + 332 + 4 = base + 336 from by bv_omega] at hepi
+  rw [show (base : Word) + 340 + 4 = base + 344 from by bv_omega] at hepi
   refine cpsTripleWithin_seq_perm_same_cr ?_ hilwr hepi
   intro h hp
   xperm_hyp hp

--- a/EvmAsm/Evm64/MulMod/ReduceOuterLoop.lean
+++ b/EvmAsm/Evm64/MulMod/ReduceOuterLoop.lean
@@ -27,21 +27,21 @@ theorem evm_mulmod_reduce512_loop_inner_code_sub (base : Word) :
     [Instr.LD .x17 .x16 0, Instr.ADDI .x15 .x0 64]
     evm_mulmod_reduce512_inner_step
     [Instr.ADDI .x16 .x16 4088, Instr.ADDI .x18 .x18 4095,
-      Instr.BNE .x18 .x0 (-272 : BitVec 13)]
+      Instr.BNE .x18 .x0 (-280 : BitVec 13)]
     ?_ a i ?_
   · decide
   · exact h
 
 /-- The inner 64-bit bit loop, lifted to the enclosing `reduce512_loop` code:
-    it runs from byte offset 8 to byte offset 264 (where the pointer-advance
+    it runs from byte offset 8 to byte offset 272 (where the pointer-advance
     instructions begin), folding the current product limb `w` into the
     remainder. -/
 theorem evm_mulmod_reduce512_loop_bit_loop_spec_within
     (sp base w x19v x20v : Word) (r n : EvmWord) :
-    cpsTripleWithin (64 * 64) (base + 8) (base + 8 + 256)
+    cpsTripleWithin (66 * 64) (base + 8) (base + 8 + 264)
       (CodeReq.ofProg base evm_mulmod_reduce512_loop)
       (mulModReduceBitLoopPre sp w (BitVec.ofNat 64 64) x19v x20v r n)
-      (mulModReduceBitLoopPost sp (mulModReduceStepN r n w 64) n) :=
+      (mulModReduceBitLoopPost sp (mulModReduceStepNCarry r n w 64) n) :=
   cpsTripleWithin_extend_code
     (hmono := evm_mulmod_reduce512_loop_inner_code_sub base)
     (h := evm_mulmod_reduce512_bit_loop_spec_within sp (base + 8) w x19v x20v r n)
@@ -89,15 +89,15 @@ theorem evm_mulmod_reduce512_loop_prefix_spec_within
     (cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hLDf hADDIf)
 
 /-- One outer-loop iteration up to the pointer-advance: load the product limb
-    at `x16`, run the inner 64-bit bit loop, and land at byte offset 264 with
-    that limb folded into the remainder (`mulModReduceStepN r n limb 64`). -/
+    at `x16`, run the inner 64-bit bit loop, and land at byte offset 272 with
+    that limb folded into the remainder (`mulModReduceStepNCarry r n limb 64`). -/
 theorem evm_mulmod_reduce512_loop_fold_one_limb_spec_within
     (sp base ptr oldX17 oldX15 x19v x20v limb : Word) (r n : EvmWord) :
-    cpsTripleWithin (2 + 64 * 64) base (base + 8 + 256)
+    cpsTripleWithin (2 + 66 * 64) base (base + 8 + 264)
       (CodeReq.ofProg base evm_mulmod_reduce512_loop)
       ((.x12 ↦ᵣ sp) ** (.x16 ↦ᵣ ptr) ** (.x17 ↦ᵣ oldX17) ** (.x15 ↦ᵣ oldX15) **
        (.x0 ↦ᵣ (0 : Word)) ** (.x19 ↦ᵣ x19v) ** (.x20 ↦ᵣ x20v) **
-       regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
        ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 0) **
        ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 1) **
        ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 2) **
@@ -107,11 +107,11 @@ theorem evm_mulmod_reduce512_loop_fold_one_limb_spec_within
        ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 2) **
        ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 3) **
        ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb))
-      (mulModReduceBitLoopPost sp (mulModReduceStepN r n limb 64) n **
+      (mulModReduceBitLoopPost sp (mulModReduceStepNCarry r n limb 64) n **
        (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb)) := by
   have hpf := cpsTripleWithin_frameR
     ((.x12 ↦ᵣ sp) ** (.x19 ↦ᵣ x19v) ** (.x20 ↦ᵣ x20v) **
-     regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
+     regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
      ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 0) **
      ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 1) **
      ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 2) **
@@ -135,60 +135,60 @@ theorem evm_mulmod_reduce512_loop_fold_one_limb_spec_within
       hpf hif)
 
 /-- The pointer-advance / loop-control suffix `[ADDI x16, ADDI x18, BNE]` sits at
-    byte offset 264 (instruction index 66) within `evm_mulmod_reduce512_loop`. -/
+    byte offset 272 (instruction index 68) within `evm_mulmod_reduce512_loop`. -/
 theorem evm_mulmod_reduce512_loop_suffix_code_sub (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + 264)
+    ∀ a i, (CodeReq.ofProg (base + 272)
         [Instr.ADDI .x16 .x16 4088, Instr.ADDI .x18 .x18 4095,
-          Instr.BNE .x18 .x0 (-272 : BitVec 13)]) a = some i →
+          Instr.BNE .x18 .x0 (-280 : BitVec 13)]) a = some i →
       (CodeReq.ofProg base evm_mulmod_reduce512_loop) a = some i := by
-  refine CodeReq.ofProg_mono_sub base (base + 264) evm_mulmod_reduce512_loop
+  refine CodeReq.ofProg_mono_sub base (base + 272) evm_mulmod_reduce512_loop
     [Instr.ADDI .x16 .x16 4088, Instr.ADDI .x18 .x18 4095,
-      Instr.BNE .x18 .x0 (-272 : BitVec 13)] 66 ?_ ?_ ?_ ?_
-  · rw [show BitVec.ofNat 64 (4 * 66) = (264 : Word) by decide]
+      Instr.BNE .x18 .x0 (-280 : BitVec 13)] 68 ?_ ?_ ?_ ?_
+  · rw [show BitVec.ofNat 64 (4 * 68) = (272 : Word) by decide]
   · rfl
   · rw [evm_mulmod_reduce512_loop_length]; decide
   · rw [evm_mulmod_reduce512_loop_length]; decide
 
 /-- Single instruction `ADDI x16, x16, -8` at index 66 lives in `reduce512_loop`. -/
 private theorem loop_addi16_code_sub (base : Word) :
-    ∀ a i, CodeReq.singleton (base + 264) (Instr.ADDI .x16 .x16 4088) a = some i →
+    ∀ a i, CodeReq.singleton (base + 272) (Instr.ADDI .x16 .x16 4088) a = some i →
       (CodeReq.ofProg base evm_mulmod_reduce512_loop) a = some i := by
   rw [← CodeReq.ofProg_singleton]
-  refine CodeReq.ofProg_mono_sub base (base + 264) evm_mulmod_reduce512_loop
-    [Instr.ADDI .x16 .x16 4088] 66 ?_ ?_ ?_ ?_
-  · rw [show BitVec.ofNat 64 (4 * 66) = (264 : Word) by decide]
+  refine CodeReq.ofProg_mono_sub base (base + 272) evm_mulmod_reduce512_loop
+    [Instr.ADDI .x16 .x16 4088] 68 ?_ ?_ ?_ ?_
+  · rw [show BitVec.ofNat 64 (4 * 68) = (272 : Word) by decide]
   · rfl
   · rw [evm_mulmod_reduce512_loop_length]; decide
   · rw [evm_mulmod_reduce512_loop_length]; decide
 
 /-- Single instruction `ADDI x18, x18, -1` at index 67 lives in `reduce512_loop`. -/
 private theorem loop_addi18_code_sub (base : Word) :
-    ∀ a i, CodeReq.singleton (base + 268) (Instr.ADDI .x18 .x18 4095) a = some i →
+    ∀ a i, CodeReq.singleton (base + 276) (Instr.ADDI .x18 .x18 4095) a = some i →
       (CodeReq.ofProg base evm_mulmod_reduce512_loop) a = some i := by
   rw [← CodeReq.ofProg_singleton]
-  refine CodeReq.ofProg_mono_sub base (base + 268) evm_mulmod_reduce512_loop
-    [Instr.ADDI .x18 .x18 4095] 67 ?_ ?_ ?_ ?_
-  · rw [show BitVec.ofNat 64 (4 * 67) = (268 : Word) by decide]
+  refine CodeReq.ofProg_mono_sub base (base + 276) evm_mulmod_reduce512_loop
+    [Instr.ADDI .x18 .x18 4095] 69 ?_ ?_ ?_ ?_
+  · rw [show BitVec.ofNat 64 (4 * 69) = (276 : Word) by decide]
   · rfl
   · rw [evm_mulmod_reduce512_loop_length]; decide
   · rw [evm_mulmod_reduce512_loop_length]; decide
 
 /-- Outer-loop pointer/counter advance: `ADDI x16, x16, -8 ; ADDI x18, x18, -1`. -/
 theorem evm_mulmod_reduce512_loop_advance_spec_within (base x16v x18v : Word) :
-    cpsTripleWithin 2 (base + 264) (base + 272)
+    cpsTripleWithin 2 (base + 272) (base + 280)
       (CodeReq.ofProg base evm_mulmod_reduce512_loop)
       ((.x16 ↦ᵣ x16v) ** (.x18 ↦ᵣ x18v))
       ((.x16 ↦ᵣ (x16v + signExtend12 (4088 : BitVec 12))) **
        (.x18 ↦ᵣ (x18v + signExtend12 (4095 : BitVec 12)))) := by
   have h16 := cpsTripleWithin_extend_code (hmono := loop_addi16_code_sub base)
-    (h := addi_spec_gen_same_within .x16 x16v (4088 : BitVec 12) (base + 264) (by decide))
+    (h := addi_spec_gen_same_within .x16 x16v (4088 : BitVec 12) (base + 272) (by decide))
   have h18 := cpsTripleWithin_extend_code (hmono := loop_addi18_code_sub base)
-    (h := addi_spec_gen_same_within .x18 x18v (4095 : BitVec 12) (base + 268) (by decide))
+    (h := addi_spec_gen_same_within .x18 x18v (4095 : BitVec 12) (base + 276) (by decide))
   have h16f := cpsTripleWithin_frameR ((.x18 ↦ᵣ x18v)) (by pcFree) h16
   have h18f := cpsTripleWithin_frameR
     ((.x16 ↦ᵣ (x16v + signExtend12 (4088 : BitVec 12)))) (by pcFree) h18
-  rw [show (base + 264 + 4 : Word) = base + 268 from by bv_omega] at h16f
-  rw [show (base + 272 : Word) = base + 268 + 4 from by bv_omega]
+  rw [show (base + 272 + 4 : Word) = base + 276 from by bv_omega] at h16f
+  rw [show (base + 280 : Word) = base + 276 + 4 from by bv_omega]
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hp => by xperm_hyp hp)
     (cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h16f h18f)
 
@@ -197,11 +197,11 @@ theorem evm_mulmod_reduce512_loop_advance_spec_within (base x16v x18v : Word) :
     limb pointer (`x16 -= 8`) and decrement the eight-limb counter (`x18`). -/
 theorem evm_mulmod_reduce512_loop_fold_advance_spec_within
     (sp base ptr oldX17 oldX15 x19v x20v x18v limb : Word) (r n : EvmWord) :
-    cpsTripleWithin (2 + 64 * 64 + 2) base (base + 272)
+    cpsTripleWithin (2 + 66 * 64 + 2) base (base + 280)
       (CodeReq.ofProg base evm_mulmod_reduce512_loop)
       ((.x12 ↦ᵣ sp) ** (.x16 ↦ᵣ ptr) ** (.x17 ↦ᵣ oldX17) ** (.x15 ↦ᵣ oldX15) **
        (.x0 ↦ᵣ (0 : Word)) ** (.x19 ↦ᵣ x19v) ** (.x20 ↦ᵣ x20v) ** (.x18 ↦ᵣ x18v) **
-       regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
        ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 0) **
        ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 1) **
        ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 2) **
@@ -211,7 +211,7 @@ theorem evm_mulmod_reduce512_loop_fold_advance_spec_within
        ((sp + signExtend12 (80 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 2) **
        ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 3) **
        ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb))
-      (mulModReduceBitLoopPost sp (mulModReduceStepN r n limb 64) n **
+      (mulModReduceBitLoopPost sp (mulModReduceStepNCarry r n limb 64) n **
        (.x16 ↦ᵣ (ptr + signExtend12 (4088 : BitVec 12))) **
        (.x18 ↦ᵣ (x18v + signExtend12 (4095 : BitVec 12))) **
        ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb)) := by
@@ -219,51 +219,51 @@ theorem evm_mulmod_reduce512_loop_fold_advance_spec_within
     (evm_mulmod_reduce512_loop_fold_one_limb_spec_within
       sp base ptr oldX17 oldX15 x19v x20v limb r n)
   have hadvf := cpsTripleWithin_frameR
-    (mulModReduceBitLoopPost sp (mulModReduceStepN r n limb 64) n **
+    (mulModReduceBitLoopPost sp (mulModReduceStepNCarry r n limb 64) n **
       ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb))
     (by unfold mulModReduceBitLoopPost mulModReduceCompareMem; pcFree)
     (evm_mulmod_reduce512_loop_advance_spec_within base ptr x18v)
-  rw [show (base + 8 + 256 : Word) = base + 264 from by bv_omega] at hfoldf
+  rw [show (base + 8 + 264 : Word) = base + 272 from by bv_omega] at hfoldf
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hp => by xperm_hyp hp)
     (cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hfoldf hadvf)
 
-/-- Outer-loop control `BNE x18, x0, -272` at byte offset 272: loops back to
+/-- Outer-loop control `BNE x18, x0, -280` at byte offset 280: loops back to
     `base` while the eight-limb counter `x18` is nonzero, falls through to
-    `base + 276` (the post-loop) when it reaches zero. -/
+    `base + 284` (the post-loop) when it reaches zero. -/
 theorem evm_mulmod_reduce512_loop_branch_spec_within (base x18v : Word) :
-    cpsBranchWithin 1 (base + 272)
+    cpsBranchWithin 1 (base + 280)
       (CodeReq.ofProg base evm_mulmod_reduce512_loop)
       ((.x18 ↦ᵣ x18v) ** (.x0 ↦ᵣ (0 : Word)))
       base ((.x18 ↦ᵣ x18v) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜x18v ≠ (0 : Word)⌝)
-      (base + 276) ((.x18 ↦ᵣ x18v) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜x18v = (0 : Word)⌝) := by
+      (base + 284) ((.x18 ↦ᵣ x18v) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜x18v = (0 : Word)⌝) := by
   have hsub : ∀ a i,
-      CodeReq.singleton (base + 272) (Instr.BNE .x18 .x0 (-272 : BitVec 13)) a = some i →
+      CodeReq.singleton (base + 280) (Instr.BNE .x18 .x0 (-280 : BitVec 13)) a = some i →
       (CodeReq.ofProg base evm_mulmod_reduce512_loop) a = some i := by
     rw [← CodeReq.ofProg_singleton]
-    refine CodeReq.ofProg_mono_sub base (base + 272) evm_mulmod_reduce512_loop
-      [Instr.BNE .x18 .x0 (-272 : BitVec 13)] 68 ?_ ?_ ?_ ?_
-    · rw [show BitVec.ofNat 64 (4 * 68) = (272 : Word) by decide]
+    refine CodeReq.ofProg_mono_sub base (base + 280) evm_mulmod_reduce512_loop
+      [Instr.BNE .x18 .x0 (-280 : BitVec 13)] 70 ?_ ?_ ?_ ?_
+    · rw [show BitVec.ofNat 64 (4 * 70) = (280 : Word) by decide]
     · rfl
     · rw [evm_mulmod_reduce512_loop_length]; decide
     · rw [evm_mulmod_reduce512_loop_length]; decide
-  have hbne := bne_spec_gen_within .x18 .x0 (-272 : BitVec 13) x18v (0 : Word) (base + 272)
-  have htaken : ((base + 272) + signExtend13 (-272 : BitVec 13) : Word) = base := by
-    rw [show signExtend13 (-272 : BitVec 13) = (-272 : Word) from by decide]; bv_omega
-  have hnt : ((base + 272) + 4 : Word) = base + 276 := by bv_omega
+  have hbne := bne_spec_gen_within .x18 .x0 (-280 : BitVec 13) x18v (0 : Word) (base + 280)
+  have htaken : ((base + 280) + signExtend13 (-280 : BitVec 13) : Word) = base := by
+    rw [show signExtend13 (-280 : BitVec 13) = (-280 : Word) from by decide]; bv_omega
+  have hnt : ((base + 280) + 4 : Word) = base + 284 := by bv_omega
   rw [htaken, hnt] at hbne
   exact cpsBranchWithin_extend_code (hmono := hsub) (h := hbne)
 
 /-- One full outer-loop body iteration as a two-exit branch: fold the current
     product limb, advance the pointer/counter, then branch on the eight-limb
     counter — loop back to `base` while `x18` stays nonzero, fall through to
-    `base + 276` when it reaches zero. -/
+    `base + 284` when it reaches zero. -/
 theorem evm_mulmod_reduce512_loop_body_spec_within
     (sp base ptr oldX17 oldX15 x19v x20v x18v limb : Word) (r n : EvmWord) :
-    cpsBranchWithin (2 + 64 * 64 + 2 + 1) base
+    cpsBranchWithin (2 + 66 * 64 + 2 + 1) base
       (CodeReq.ofProg base evm_mulmod_reduce512_loop)
       ((.x12 ↦ᵣ sp) ** (.x16 ↦ᵣ ptr) ** (.x17 ↦ᵣ oldX17) ** (.x15 ↦ᵣ oldX15) **
        (.x0 ↦ᵣ (0 : Word)) ** (.x19 ↦ᵣ x19v) ** (.x20 ↦ᵣ x20v) ** (.x18 ↦ᵣ x18v) **
-       regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
        ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 0) **
        ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 1) **
        ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 2) **
@@ -274,22 +274,22 @@ theorem evm_mulmod_reduce512_loop_body_spec_within
        ((sp + signExtend12 (88 : BitVec 12)) ↦ₘ EvmWord.getLimbN n 3) **
        ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb))
       base
-      (mulModReduceBitLoopPost sp (mulModReduceStepN r n limb 64) n **
+      (mulModReduceBitLoopPost sp (mulModReduceStepNCarry r n limb 64) n **
        (.x16 ↦ᵣ (ptr + signExtend12 (4088 : BitVec 12))) **
        (.x18 ↦ᵣ (x18v + signExtend12 (4095 : BitVec 12))) **
        ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb) **
        ⌜x18v + signExtend12 (4095 : BitVec 12) ≠ (0 : Word)⌝)
-      (base + 276)
-      (mulModReduceBitLoopPost sp (mulModReduceStepN r n limb 64) n **
+      (base + 284)
+      (mulModReduceBitLoopPost sp (mulModReduceStepNCarry r n limb 64) n **
        (.x16 ↦ᵣ (ptr + signExtend12 (4088 : BitVec 12))) **
        (.x18 ↦ᵣ (x18v + signExtend12 (4095 : BitVec 12))) **
        ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb) **
        ⌜x18v + signExtend12 (4095 : BitVec 12) = (0 : Word)⌝) := by
   have hbnef := cpsBranchWithin_frameR
     ((.x12 ↦ᵣ sp) ** (.x15 ↦ᵣ (0 : Word)) **
-     regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
+     regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
      regOwn .x17 ** regOwn .x19 ** regOwn .x20 **
-     mulModReduceCompareMem sp (mulModReduceStepN r n limb 64) n **
+     mulModReduceCompareMem sp (mulModReduceStepNCarry r n limb 64) n **
      (.x16 ↦ᵣ (ptr + signExtend12 (4088 : BitVec 12))) **
      ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb))
     (by unfold mulModReduceCompareMem; pcFree)
@@ -306,14 +306,14 @@ theorem evm_mulmod_reduce512_loop_body_spec_within
 
 /-- The part of the outer-loop body precondition that the eight-limb induction
     threads unchanged from iteration to iteration: the frame pointer, the limb
-    pointer, the zero register, the limb counter, the six inner-step scratch
+    pointer, the zero register, the limb counter, the seven inner-step scratch
     registers (owned), the four remainder limbs, the four modulus limbs, and the
     current product limb in memory. The four registers the body overwrites
     (`x17`, `x15`, `x19`, `x20`) are *not* part of this — they are carried as
     `regOwn` and re-introduced by `evm_mulmod_reduce512_loop_body_regown_spec_within`. -/
 def bodyLoopCommon (sp ptr x18v : Word) (r n : EvmWord) (limb : Word) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x16 ↦ᵣ ptr) ** (.x0 ↦ᵣ (0 : Word)) ** (.x18 ↦ᵣ x18v) **
-  regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x8 ** regOwn .x10 ** regOwn .x11 ** regOwn .x13 **
   ((sp + signExtend12 (224 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 0) **
   ((sp + signExtend12 (232 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 1) **
   ((sp + signExtend12 (240 : BitVec 12)) ↦ₘ EvmWord.getLimbN r 2) **
@@ -333,72 +333,72 @@ def bodyLoopCommon (sp ptr x18v : Word) (r n : EvmWord) (limb : Word) : Assertio
     this precondition for the next limb. -/
 theorem evm_mulmod_reduce512_loop_body_regown_spec_within
     (sp base ptr x18v limb : Word) (r n : EvmWord) :
-    cpsBranchWithin (2 + 64 * 64 + 2 + 1) base
+    cpsBranchWithin (2 + 66 * 64 + 2 + 1) base
       (CodeReq.ofProg base evm_mulmod_reduce512_loop)
       ((bodyLoopCommon sp ptr x18v r n limb **
         regOwn .x17 ** regOwn .x15 ** regOwn .x19) ** regOwn .x20)
       base
-      (mulModReduceBitLoopPost sp (mulModReduceStepN r n limb 64) n **
+      (mulModReduceBitLoopPost sp (mulModReduceStepNCarry r n limb 64) n **
        (.x16 ↦ᵣ (ptr + signExtend12 (4088 : BitVec 12))) **
        (.x18 ↦ᵣ (x18v + signExtend12 (4095 : BitVec 12))) **
        ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb) **
        ⌜x18v + signExtend12 (4095 : BitVec 12) ≠ (0 : Word)⌝)
-      (base + 276)
-      (mulModReduceBitLoopPost sp (mulModReduceStepN r n limb 64) n **
+      (base + 284)
+      (mulModReduceBitLoopPost sp (mulModReduceStepNCarry r n limb 64) n **
        (.x16 ↦ᵣ (ptr + signExtend12 (4088 : BitVec 12))) **
        (.x18 ↦ᵣ (x18v + signExtend12 (4095 : BitVec 12))) **
        ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb) **
        ⌜x18v + signExtend12 (4095 : BitVec 12) = (0 : Word)⌝) := by
   refine cpsBranchWithin_of_forall_regIs_to_regOwn (r := .x20) ?_
   intro v20
-  have h19 : cpsBranchWithin (2 + 64 * 64 + 2 + 1) base
+  have h19 : cpsBranchWithin (2 + 66 * 64 + 2 + 1) base
       (CodeReq.ofProg base evm_mulmod_reduce512_loop)
       ((bodyLoopCommon sp ptr x18v r n limb ** (.x20 ↦ᵣ v20) **
           regOwn .x17 ** regOwn .x15) ** regOwn .x19)
       base
-      (mulModReduceBitLoopPost sp (mulModReduceStepN r n limb 64) n **
+      (mulModReduceBitLoopPost sp (mulModReduceStepNCarry r n limb 64) n **
        (.x16 ↦ᵣ (ptr + signExtend12 (4088 : BitVec 12))) **
        (.x18 ↦ᵣ (x18v + signExtend12 (4095 : BitVec 12))) **
        ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb) **
        ⌜x18v + signExtend12 (4095 : BitVec 12) ≠ (0 : Word)⌝)
-      (base + 276)
-      (mulModReduceBitLoopPost sp (mulModReduceStepN r n limb 64) n **
+      (base + 284)
+      (mulModReduceBitLoopPost sp (mulModReduceStepNCarry r n limb 64) n **
        (.x16 ↦ᵣ (ptr + signExtend12 (4088 : BitVec 12))) **
        (.x18 ↦ᵣ (x18v + signExtend12 (4095 : BitVec 12))) **
        ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb) **
        ⌜x18v + signExtend12 (4095 : BitVec 12) = (0 : Word)⌝) := by
     refine cpsBranchWithin_of_forall_regIs_to_regOwn (r := .x19) ?_
     intro v19
-    have h15 : cpsBranchWithin (2 + 64 * 64 + 2 + 1) base
+    have h15 : cpsBranchWithin (2 + 66 * 64 + 2 + 1) base
         (CodeReq.ofProg base evm_mulmod_reduce512_loop)
         ((bodyLoopCommon sp ptr x18v r n limb ** (.x20 ↦ᵣ v20) **
             (.x19 ↦ᵣ v19) ** regOwn .x17) ** regOwn .x15)
         base
-        (mulModReduceBitLoopPost sp (mulModReduceStepN r n limb 64) n **
+        (mulModReduceBitLoopPost sp (mulModReduceStepNCarry r n limb 64) n **
          (.x16 ↦ᵣ (ptr + signExtend12 (4088 : BitVec 12))) **
          (.x18 ↦ᵣ (x18v + signExtend12 (4095 : BitVec 12))) **
          ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb) **
          ⌜x18v + signExtend12 (4095 : BitVec 12) ≠ (0 : Word)⌝)
-        (base + 276)
-        (mulModReduceBitLoopPost sp (mulModReduceStepN r n limb 64) n **
+        (base + 284)
+        (mulModReduceBitLoopPost sp (mulModReduceStepNCarry r n limb 64) n **
          (.x16 ↦ᵣ (ptr + signExtend12 (4088 : BitVec 12))) **
          (.x18 ↦ᵣ (x18v + signExtend12 (4095 : BitVec 12))) **
          ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb) **
          ⌜x18v + signExtend12 (4095 : BitVec 12) = (0 : Word)⌝) := by
       refine cpsBranchWithin_of_forall_regIs_to_regOwn (r := .x15) ?_
       intro v15
-      have h17 : cpsBranchWithin (2 + 64 * 64 + 2 + 1) base
+      have h17 : cpsBranchWithin (2 + 66 * 64 + 2 + 1) base
           (CodeReq.ofProg base evm_mulmod_reduce512_loop)
           ((bodyLoopCommon sp ptr x18v r n limb ** (.x20 ↦ᵣ v20) **
               (.x19 ↦ᵣ v19) ** (.x15 ↦ᵣ v15)) ** regOwn .x17)
           base
-          (mulModReduceBitLoopPost sp (mulModReduceStepN r n limb 64) n **
+          (mulModReduceBitLoopPost sp (mulModReduceStepNCarry r n limb 64) n **
            (.x16 ↦ᵣ (ptr + signExtend12 (4088 : BitVec 12))) **
            (.x18 ↦ᵣ (x18v + signExtend12 (4095 : BitVec 12))) **
            ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb) **
            ⌜x18v + signExtend12 (4095 : BitVec 12) ≠ (0 : Word)⌝)
-          (base + 276)
-          (mulModReduceBitLoopPost sp (mulModReduceStepN r n limb 64) n **
+          (base + 284)
+          (mulModReduceBitLoopPost sp (mulModReduceStepNCarry r n limb 64) n **
            (.x16 ↦ᵣ (ptr + signExtend12 (4088 : BitVec 12))) **
            (.x18 ↦ᵣ (x18v + signExtend12 (4095 : BitVec 12))) **
            ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb) **
@@ -422,11 +422,11 @@ theorem evm_mulmod_reduce512_loop_body_regown_spec_within
 theorem evm_mulmod_reduce512_loop_body_loop_path
     (sp base ptr x18v limb : Word) (r n : EvmWord)
     (hloop : x18v + signExtend12 (4095 : BitVec 12) ≠ (0 : Word)) :
-    cpsTripleWithin (2 + 64 * 64 + 2 + 1) base base
+    cpsTripleWithin (2 + 66 * 64 + 2 + 1) base base
       (CodeReq.ofProg base evm_mulmod_reduce512_loop)
       ((bodyLoopCommon sp ptr x18v r n limb **
         regOwn .x17 ** regOwn .x15 ** regOwn .x19) ** regOwn .x20)
-      (mulModReduceBitLoopPost sp (mulModReduceStepN r n limb 64) n **
+      (mulModReduceBitLoopPost sp (mulModReduceStepNCarry r n limb 64) n **
        (.x16 ↦ᵣ (ptr + signExtend12 (4088 : BitVec 12))) **
        (.x18 ↦ᵣ (x18v + signExtend12 (4095 : BitVec 12))) **
        ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb) **
@@ -440,16 +440,16 @@ theorem evm_mulmod_reduce512_loop_body_loop_path
   exact hloop ((sepConj_pure_right _).1 hq3).2
 
 /-- When the decremented limb counter `x18` reaches zero, the outer-loop body
-    takes the `BNE` fall-through exit: a `base → base + 276` triple landing in
+    takes the `BNE` fall-through exit: a `base → base + 284` triple landing in
     the loop-done post (the last limb folded into the remainder). -/
 theorem evm_mulmod_reduce512_loop_body_done_path
     (sp base ptr x18v limb : Word) (r n : EvmWord)
     (hdone : x18v + signExtend12 (4095 : BitVec 12) = (0 : Word)) :
-    cpsTripleWithin (2 + 64 * 64 + 2 + 1) base (base + 276)
+    cpsTripleWithin (2 + 66 * 64 + 2 + 1) base (base + 284)
       (CodeReq.ofProg base evm_mulmod_reduce512_loop)
       ((bodyLoopCommon sp ptr x18v r n limb **
         regOwn .x17 ** regOwn .x15 ** regOwn .x19) ** regOwn .x20)
-      (mulModReduceBitLoopPost sp (mulModReduceStepN r n limb 64) n **
+      (mulModReduceBitLoopPost sp (mulModReduceStepNCarry r n limb 64) n **
        (.x16 ↦ᵣ (ptr + signExtend12 (4088 : BitVec 12))) **
        (.x18 ↦ᵣ (x18v + signExtend12 (4095 : BitVec 12))) **
        ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ limb) **


### PR DESCRIPTION
## Summary
Makes the assembled `evm_mulmod` program correct for **all** moduli and proves the **total** stack-level spec — no `n ≤ 2^255` restriction.

**The bug:** the bit-serial reducer's inner step shifted the 256-bit remainder left and **discarded the carry-out** (bit 256 of `2r`). For `n > 2^255` a remainder can reach `≥ 2^255`, so that lost bit made the program compute the wrong value — it was genuinely incorrect, not just unproven, for large moduli.

**The fix (+2 instructions in `evm_mulmod_reduce512_inner_step`):**
- `SRLI .x8 .x5 63` — capture the pre-shift high-limb bit 63 (`= r.getLsbD 255`, the carry-out).
- `BNE .x8 .x0 (64)` — force the subtract path when the carry is set.

so the inner step realizes `mulModReduceStepCarry` (subtract iff `r.getLsbD 255 ∨ shifted ≥ n`). Consequent program offset updates: inner tail `BNE -252→-260`, **outer-loop `BNE -272→-280`**, zero-path-skip `JAL 2100→2108`; program length `538→540`, exit `2152→2160`.

**Headline result** (`evm_mulmod_stack_spec_within`, `Compose/StackSpecAll.lean`): hypothesis-free over all `n` —
`evmWordIs sp a ** evmWordIs (sp+32) b ** evmWordIs (sp+signExtend12 64) n  →  evmWordIs (sp+signExtend12 64) (EvmWord.mulmod a b n)` (with scratch framed as `regOwn`/`memOwn`). `EvmWord.mulmod` is `0` for `n=0`, `(a·b) mod n` otherwise — the official EVM `MULMOD` semantics.

## Re-proof chain (bottom-up, all kernel-clean)
- **U1** shift prefix + carry capture (`x8 = r.getLsbD 255`).
- **U2** inner step → `mulModReduceStepCarry` (new carry branch, offset shifts, local carry-aware tail).
- **U3** bit loop → outer loop → 8-limb induction → `evm_mulmod_reduce512_spec_within` leaves `mulModReduceOuterFoldCarry` (exit `base+344`). *(Also corrected the outer-loop `BNE` offset, a behavioral gap in the initial program edit.)*
- **U4** Compose → dispatch → stack re-lift; **drops `n ≤ 2^255`** via `mulModReduceOuterFoldCarry_toNat_zero_start` (all `n>0`) + `mulModLimbsValue_productLimb` + `mulmod_zero` (`n=0`).

Reuses the entire carry-aware semantic layer merged earlier (`mulModReduceStepCarry`, the carry folds, the Horner laws, the product↔`a·b` bridge).

Kernel-clean: `#print axioms` on the total spec = `{propext, Classical.choice, Quot.sound}`. No `native_decide`/`bv_decide`/`sorry`/`admit`, no heartbeat/recdepth bumps. **Full `lake build` (whole repo) passes** — the bytecode change breaks nothing elsewhere.

Refs #91. Bead: evm-asm-fhsxz.2.4.2.60.2.5.1.4 (units .20–.23).

Directed by @pirapira; implemented by Claude Code