### PR TITLE
exp: glue loop-body results to expSqMulStep (6snn.4 bridge)

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -116,6 +116,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitIterMerge
 import EvmAsm.Evm64.Exp.Compose.SavedBitIterBridges
 import EvmAsm.Evm64.Exp.Compose.SavedBitIterExitBridge
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopBodyInd
+import EvmAsm.Evm64.Exp.Compose.SavedBitSemanticStep
 import EvmAsm.Evm64.Exp.Layout
 import EvmAsm.Evm64.Exp.Spec
 import EvmAsm.Evm64.Exp.StackExecutionBridge

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitSemanticStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitSemanticStep.lean
@@ -1,0 +1,50 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitSemanticStep
+
+  Glue between the EXP loop body's structural per-iteration result definitions
+  (`expTwoMulSquareW`, `expTwoMulIterRw`) and the pure semantic
+  square-and-multiply step `EvmWord.expSqMulStep`.
+
+  The skip path squares the accumulator (`acc * acc`); the cond-mul path
+  squares then multiplies by the base (`acc * acc * base`).  Both are exactly
+  one `expSqMulStep` on the accumulator word, modulo commutativity of EvmWord
+  multiplication.  These lemmas are the connective tissue for threading the
+  semantic accumulator invariant `acc = EvmWord.exp base prefix` through the
+  256-iteration loop induction.
+
+  Bead evm-asm-6snn.4.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitBaseDefs
+import EvmAsm.Evm64.EvmWordArith.Exp
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+open EvmAsm.Evm64.EvmWord
+
+/-- The loop body's squaring result `expTwoMulSquareW` (the skip path: `acc²`)
+    is the `bit = false` square-and-multiply step on the accumulator word
+    `expResultWord r0 r1 r2 r3`. The base argument is irrelevant on this path. -/
+theorem expTwoMulSquareW_eq_expSqMulStep_false
+    (r0 r1 r2 r3 : Word) (base : EvmWord) :
+    expTwoMulSquareW r0 r1 r2 r3 =
+      expSqMulStep base (expResultWord r0 r1 r2 r3) false := by
+  unfold expTwoMulSquareW expTwoMulIterW expSqMulStep
+  rfl
+
+/-- The loop body's cond-mul result `expTwoMulIterRw` (the cond path:
+    `acc² · base`) is the `bit = true` square-and-multiply step on the
+    accumulator word `expResultWord r0 r1 r2 r3` with base
+    `expResultWord a0 a1 a2 a3` (modulo commutativity). -/
+theorem expTwoMulIterRw_eq_expSqMulStep_true
+    (r0 r1 r2 r3 a0 a1 a2 a3 : Word) :
+    expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3 =
+      expSqMulStep (expResultWord a0 a1 a2 a3)
+        (expResultWord r0 r1 r2 r3) true := by
+  unfold expTwoMulIterRw expTwoMulSquareW expTwoMulIterW expTwoMulIterAw
+    expSqMulStep
+  simp only [if_true]
+  rw [BitVec.mul_comm]
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- Adds `expTwoMulSquareW_eq_expSqMulStep_false` and `expTwoMulIterRw_eq_expSqMulStep_true`: the EXP loop body's structural per-iteration result definitions equal one semantic square-and-multiply step on the accumulator word.
  - skip path: `expTwoMulSquareW r0..r3 = acc*acc = expSqMulStep _ acc false` (acc = `expResultWord r0..r3`)
  - cond path: `expTwoMulIterRw r0..r3 a0..a3 = acc*acc*base = expSqMulStep base acc true` (base = `expResultWord a0..a3`), modulo `BitVec.mul_comm`
- These connect the **structural** loop specs (whose squaring/cond-mul results were proven as `acc²` / `acc²·base`) to the proven **semantic** chain (`expSqMulStep_correct` → `expSqMulFold_exp` → `expSqMulFold_one`) — the connective tissue for threading `acc = EvmWord.exp base prefix` through the 256-iteration induction.
- Axiom-clean (`propext`, `Quot.sound`); no `sorry`.

**Stacked on `feat/exp-semantic-fold-one` (PR #9480).**

Refs #92. Bead: evm-asm-6snn.4.

Directed by @pirapira; implemented by Claude Code