### PR TITLE
fix(bv): stage effective_gas_price + blob_gas_price for BALANCE(ORIGIN)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -784,6 +784,52 @@ def blockVerdictFunction : String :=
   ".Lbv_stx_upfront_blob_done:\n" ++
   "  la a0, bv_stx_sender_acct; addi a0, a0, 8\n  la a1, bv_upfront_cost\n  la a2, bv_upfront_islt\n  jal ra, u256_lt_be\n" ++
   "  la t0, bv_upfront_islt; ld t0, 0(t0)\n  bnez t0, .Lbv_sender_upfront_fail\n" ++
+  -- #9458: recompute bv_upfront_cost for the runtime BALANCE(ORIGIN) staging
+  -- using the SAME terms execution-specs actually debits before EVM execution,
+  -- not the (larger) worst-case terms the sufficiency CHECK above uses. The
+  -- CHECK (@761-786) correctly uses max_fee_per_gas / max_fee_per_blob_gas per
+  -- execution-specs check_transaction (amsterdam/fork.py:630,657,677), but the
+  -- DEBIT (amsterdam/fork.py:1065,1069,1080-1083) charges:
+  --   effective_gas_price * gas_limit + blob_gas_price * BLOB_GAS * nblobs + value
+  -- where blob_gas_price = calculate_blob_gas_price(excess_blob_gas) and value is
+  -- moved out of the sender before the recipient code runs. Staging the
+  -- max-fee-based cost over-charges whenever max_fee > base_fee (gas term) or
+  -- max_fee_per_blob_gas > blob_gas_price (blob term), so BALANCE(ORIGIN)
+  -- returns a balance that is too low, producing SSTORE values that disagree
+  -- with the BAL -> bv_fail=34. Mirrors @761-783 with two swaps: the gas term
+  -- tefgp_max_fee -> bv_fee_egp_scratch (effective_gas_price, written by
+  -- tx_effective_gas_pricing @438) and the blob term tcbg_blob_fee_be
+  -- (max_fee_per_blob_gas) -> bsg_blob_price_be (blob_gas_price, written by
+  -- amsterdam_blob_gas_price_u256 @338). Both staged terms are <= their checked
+  -- counterparts, so once the max-based check passed these cannot overflow; any
+  -- unreachable decode/count miss skips the staging rather than rejecting a
+  -- valid block.
+  "  la a0, bv_fee_egp_scratch\n" ++
+  "  la t0, bv_simple_transfer_tx; ld a1, 40(t0)\n" ++
+  "  la a2, bv_upfront_cost\n" ++
+  "  jal ra, u256_mul_u64_be\n" ++
+  "  bnez a0, .Lbv_stx_pending_upfront_done\n" ++
+  "  la a0, bv_upfront_cost; la t0, bv_simple_transfer_tx; addi a1, t0, 96; la a2, bv_upfront_cost\n" ++
+  "  jal ra, u256_add_be\n" ++
+  "  bnez a0, .Lbv_stx_pending_upfront_done\n" ++
+  "  la t0, bv_simple_transfer_tx; ld t1, 160(t0); li t2, 3; bne t1, t2, .Lbv_stx_restage_blob_done\n" ++
+  "  ld a0, 176(t0); ld a1, 184(t0); la a2, tcbg_struct\n" ++
+  "  jal ra, tx_eip4844_decode\n" ++
+  "  bnez a0, .Lbv_stx_pending_upfront_done\n" ++
+  "  la t0, tcbg_struct; lwu t1, 168(t0); lwu t2, 172(t0)\n" ++
+  "  la t3, bv_simple_transfer_tx; ld t3, 176(t3); add a0, t3, t1; mv a1, t2; la a2, bv_upfront_blob_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lbv_stx_pending_upfront_done\n" ++
+  "  la t0, bv_upfront_blob_count; ld a1, 0(t0); beqz a1, .Lbv_stx_pending_upfront_done\n" ++
+  "  li t2, 6; bgtu a1, t2, .Lbv_stx_pending_upfront_done\n" ++
+  "  slli a1, a1, 17\n" ++
+  "  la a0, bsg_blob_price_be; la a2, bv_upfront_blob_cost\n" ++
+  "  jal ra, u256_mul_u64_be\n" ++
+  "  bnez a0, .Lbv_stx_pending_upfront_done\n" ++
+  "  la a0, bv_upfront_cost; la a1, bv_upfront_blob_cost; la a2, bv_upfront_cost\n" ++
+  "  jal ra, u256_add_be\n" ++
+  "  bnez a0, .Lbv_stx_pending_upfront_done\n" ++
+  ".Lbv_stx_restage_blob_done:\n" ++
   -- Stage sender.balance at execution start for runtime BALANCE(ORIGIN). The
   -- dispatcher consumes this after its setup resets and records it in the live
   -- nonstorage log; it is one-shot and harmless for contracts that never query


### PR DESCRIPTION
## Summary

Fixes #9458 — `blob_gas_subtraction_tx` fixtures fail `bv_fail=34` (BAL storage mismatch).

The runtime `BALANCE(ORIGIN)` staging recomputed the sender's execution-start balance using the worst-case **CHECK** terms (`max_fee_per_gas`, `max_fee_per_blob_gas`). But execution-specs ([`amsterdam/fork.py:1065,1069,1080-1083`](https://github.com/ethereum/execution-specs)) actually **debits** from the sender, before the recipient code runs:

```
effective_gas_price * gas_limit  +  blob_gas_price * BLOB_GAS * nblobs  +  value
```

where `blob_gas_price = calculate_blob_gas_price(excess_blob_gas)`. Staging the max-fee-based cost over-charged whenever `max_fee > base_fee` (gas term) or `max_fee_per_blob_gas > blob_gas_price` (blob term), so `BALANCE(ORIGIN)` returned a balance that was too low. The test contract (`SSTORE(0, BALANCE(ORIGIN))`) then wrote values that disagreed with the BAL witness → `bv_fail=34`.

## Root cause

`EvmAsm/Codegen/Programs/BlockVerdictFunction.lean`, single-tx path:

- **CHECK** (`@761-786`): correctly uses `max_fee` terms per `check_transaction` (`amsterdam/fork.py:630,657,677`) — **unchanged**.
- **Staging** (after the check): recompute `bv_upfront_cost` mirroring `@761-783` with two swaps:
  - gas term: `tefgp_max_fee` → `bv_fee_egp_scratch` (`effective_gas_price`, written by `tx_effective_gas_pricing @438`)
  - blob term: `tcbg_blob_fee_be` (`max_fee_per_blob_gas`) → `bsg_blob_price_be` (`blob_gas_price`, written by `amsterdam_blob_gas_price_u256 @338`)

Both staged terms are `≤` their checked counterparts, so overflow is unreachable once the max-based check passed; any unreachable decode/count miss skips the staging rather than rejecting a valid block (strictly sound, no false-reject).

The formula was confirmed against execution-specs (`amsterdam/fork.py:process_transaction`) and against the fixture ground truth: a per-case sweep over all 128 cases showed `eff_gas + bgp_blob + val` matches every slot0-present case exactly.

## Verification

`scripts/codegen-eest-stateless-check.sh --filter blob_gas_subtraction_tx --backend spike` (128 cases):

| | pass | fail |
|---|---|---|
| `main` (b6ccc5c7b) | 0 | 128 (`bv_fail=34`) |
| **this PR** | **80** | 48 (`bv_fail=53`) |

`lake build` clean (3503 jobs); architecture gates (layering, file-size, heartbeats, no-warnings, forbidden-tactics) all green.

## Out of scope

The remaining 48 cases now fail at a **downstream** `receipts_root_mismatch` (`bv_fail=53`), with `recomputed_state_root == payload_state_root` (i.e. the balance/storage fix is fully correct for all 128 — the state root matches everywhere). That is a separate pre-existing receipts-root issue, masked on `main` by the `bv_fail=34` storage check firing first; it is not addressed here. The failure split is balanced across blob counts (24 `single_blob` + 24 `max_blobs`).

Closes #9458.