### PR TITLE
exp: per-iteration accumulator value preservation (6snn.4)

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitSemanticStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitSemanticStep.lean
@@ -47,4 +47,33 @@ theorem expTwoMulIterRw_eq_expSqMulStep_true
   simp only [if_true]
   rw [BitVec.mul_comm]
 
+/-- Per-iteration accumulator value preservation, skip path.
+
+    If the input accumulator limb-word equals `exp base e`, the loop body's
+    squaring result `expTwoMulSquareW` equals `exp base e'` for the doubled
+    prefix `e'` with `e'.toNat = 2 * e.toNat`. -/
+theorem expTwoMulSquareW_exp (base : EvmWord) (r0 r1 r2 r3 : Word) (e e' : EvmWord)
+    (hacc : expResultWord r0 r1 r2 r3 = exp base e)
+    (hnext : e'.toNat = 2 * e.toNat) :
+    expTwoMulSquareW r0 r1 r2 r3 = exp base e' := by
+  unfold expTwoMulSquareW expTwoMulIterW
+  rw [hacc]
+  exact (exp_double_right_of_toNat_eq base e e' hnext).symm
+
+/-- Per-iteration accumulator value preservation, cond-mul path.
+
+    If the input accumulator limb-word equals `exp base e` and the base
+    limb-word equals `base`, the loop body's cond-mul result `expTwoMulIterRw`
+    equals `exp base e'` for the doubled-plus-one prefix `e'` with
+    `e'.toNat = 2 * e.toNat + 1`. -/
+theorem expTwoMulIterRw_exp (base : EvmWord) (r0 r1 r2 r3 a0 a1 a2 a3 : Word)
+    (e e' : EvmWord)
+    (hacc : expResultWord r0 r1 r2 r3 = exp base e)
+    (hbase : expResultWord a0 a1 a2 a3 = base)
+    (hnext : e'.toNat = 2 * e.toNat + 1) :
+    expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3 = exp base e' := by
+  unfold expTwoMulIterRw expTwoMulSquareW expTwoMulIterW expTwoMulIterAw
+  rw [hacc, hbase, BitVec.mul_comm]
+  exact (exp_double_add_one_right_of_toNat_eq base e e' hnext).symm
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- Adds `expTwoMulSquareW_exp` and `expTwoMulIterRw_exp`: given the input accumulator limb-word `= exp base e`, the loop body's per-iteration result `= exp base e'` for the extended prefix `e'` (`= 2e` on the skip path, `= 2e+1` on the cond path).
- These lift the structural per-iteration results (`squareW = acc²`, `rw = acc²·base`, already proven in the loop specs) directly to the **semantic accumulator value** via the `exp_double` recurrences — the value content of the inductive step for threading `acc = EvmWord.exp base prefix` through the 256-iteration loop.
- Frame-free; the reusable core for the value-carrying loop induction. Axiom-clean (`propext`, `Quot.sound`); no `sorry`.

**Stacked on `feat/exp-struct-sem-glue` (PR #9481).**

Refs #92. Bead: evm-asm-6snn.4.

Directed by @pirapira; implemented by Claude Code