### PR TITLE
exp: canonical 256-bit MSB decomposition computes EvmWord.exp (6snn.4)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Exp.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Exp.lean
@@ -256,6 +256,47 @@ theorem expSqMulFold_one (base exponent : EvmWord) (bits : List Bool)
   refine expSqMulFold_exp base bits 0 exponent exponent.isLt ?_
   simp [hval]
 
+/-- The MSB-first bit list of the low `k` bits of `v` (most significant of the
+    `k` bits first): position `k-1` down to position `0`. -/
+def natBitsMsb : Nat → Nat → List Bool
+  | 0, _ => []
+  | k + 1, v => decide (v / 2 ^ k % 2 = 1) :: natBitsMsb k v
+
+/-- `natBitsMsb k v` has exactly `k` bits. -/
+theorem natBitsMsb_length (k v : Nat) : (natBitsMsb k v).length = k := by
+  induction k generalizing v with
+  | zero => rfl
+  | succ k ih => simp [natBitsMsb, ih]
+
+/-- The MSB-first value of `natBitsMsb k v` is `v` reduced mod `2^k`. -/
+theorem bitsToNatMsb_natBitsMsb (k v : Nat) :
+    bitsToNatMsb (natBitsMsb k v) = v % 2 ^ k := by
+  induction k generalizing v with
+  | zero => simp [natBitsMsb, bitsToNatMsb, Nat.pow_zero, Nat.mod_one]
+  | succ k ih =>
+    simp only [natBitsMsb, bitsToNatMsb, natBitsMsb_length]
+    have hcoef :
+        (if decide (v / 2 ^ k % 2 = 1) then (1 : Nat) else 0) = v / 2 ^ k % 2 := by
+      rcases (show v / 2 ^ k % 2 = 0 ∨ v / 2 ^ k % 2 = 1 from by omega) with h | h <;>
+        rw [h] <;> decide
+    rw [hcoef, ih, Nat.pow_succ, Nat.mod_mul,
+      Nat.mul_comm (2 ^ k) (v / 2 ^ k % 2)]
+    omega
+
+/-- The canonical 256-bit MSB-first decomposition of an EvmWord has value equal
+    to the word itself (no reduction needed, since `w.toNat < 2^256`). -/
+theorem bitsToNatMsb_natBitsMsb_toNat (w : EvmWord) :
+    bitsToNatMsb (natBitsMsb 256 w.toNat) = w.toNat := by
+  rw [bitsToNatMsb_natBitsMsb, Nat.mod_eq_of_lt w.isLt]
+
+/-- Square-and-multiply over the canonical 256-bit MSB-first decomposition of the
+    exponent computes `EvmWord.exp`. This is the concrete bit-sequence instance
+    of `expSqMulFold_one`: the EXP loop consumes exactly these 256 bits (most
+    significant first), so its accumulator ends at `base ^ exponent mod 2^256`. -/
+theorem expSqMulFold_natBitsMsb (base exponent : EvmWord) :
+    expSqMulFold base 1 (natBitsMsb 256 exponent.toNat) = exp base exponent :=
+  expSqMulFold_one base exponent _ (bitsToNatMsb_natBitsMsb_toNat exponent)
+
 /-- The GH #92 cross-limb boundary case `EXP(2, 64)`. -/
 theorem exp_two_64 : exp (2 : EvmWord) (64 : EvmWord) =
     BitVec.ofNat 256 (2^64) := by


### PR DESCRIPTION
## Summary
- Adds `natBitsMsb` (MSB-first bit list of the low `k` bits of a Nat) with `natBitsMsb_length`, `bitsToNatMsb_natBitsMsb` (value `= v % 2^k`), `bitsToNatMsb_natBitsMsb_toNat` (the 256-bit decomposition of an EvmWord equals the word), and `expSqMulFold_natBitsMsb`: square-and-multiply from `acc=1` over the canonical 256-bit MSB decomposition of the exponent computes `exp base exponent`.
- This is the concrete bit-sequence instance of `expSqMulFold_one` — the EXP loop consumes exactly these 256 bits (most significant first), so the **semantic side now reduces to a single loop property**: "the loop's consumed bit sequence equals `natBitsMsb 256 exponent.toNat`."
- Pure Nat/BitVec (`Nat.mod_mul` for the bit-decomposition modulus). Axiom-clean; no `sorry`.

**Stacked on `feat/exp-iter-value-step` (PR #9484).**

Refs #92. Bead: evm-asm-6snn.4.

Directed by @pirapira; implemented by Claude Code