### PR TITLE
feat(exp): fixed EXP loop body — Nat-induction (conditional) + scaffolding (20z6.13.7)

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -99,6 +99,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoopReloadTailFrames
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoopDirect
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedInductionFrameLoopDirect
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoopPreReload
+import EvmAsm.Evm64.Exp.Compose.FixedLoopInd
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEpilogueBase
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry

--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -118,6 +118,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitIterBridges
 import EvmAsm.Evm64.Exp.Compose.SavedBitIterExitBridge
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopBodyInd
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopBodyFromLoopPost
+import EvmAsm.Evm64.Exp.Compose.MergedLoopInd
 import EvmAsm.Evm64.Exp.Layout
 import EvmAsm.Evm64.Exp.Spec
 import EvmAsm.Evm64.Exp.StackExecutionBridge

--- a/EvmAsm/Evm64/Exp/Compose/FixedLoopInd.lean
+++ b/EvmAsm/Evm64/Exp/Compose/FixedLoopInd.lean
@@ -211,4 +211,30 @@ theorem cpsTripleWithin_expReloadDirectTruePre_preReload_vacuous
   have h3 := holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_right h2)
   exact hC6 (holdsFor_pure.mp h3)
 
+/-- Deep-ordinary input-frame chaining: when the *next* iteration `k+1` is
+    itself ordinary (its control decrement is neither a reload nor a pre-reload)
+    and the current iteration is not at a 64-bit limb boundary, the ordinary
+    head step's `hBranch` continuation frame `expReloadLimbDirectTailFrame`
+    coincides with the next iteration's induction-frame
+    `InductionFrameN (k+1) (controlC6-1) ptr`.  This is the input-frame side of
+    the deep-ordinary `hBranch` discharge in the fixed-loop induction (the
+    boundary cases — pre-reload/reload of `k+1` — are handled separately). -/
+theorem expReloadLimbDirectTailFrame_eq_inductionFrameN_succ_ordinary
+    {exponentWord : EvmWord} {k : Nat} {controlC6 ptr nextNextLimb : Word}
+    (hC6' :
+      (controlC6 + signExtend12 (-1 : BitVec 12)) + signExtend12 (-1 : BitVec 12)
+        ≠ 0)
+    (hNotPre' :
+      ((controlC6 + signExtend12 (-1 : BitVec 12)) +
+        signExtend12 (-1 : BitVec 12)).toNat ≠ 1)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hMod : k % 64 < 62) :
+    expReloadLimbDirectTailFrame ptr nextNextLimb =
+      expTwoMulFixedInductionFrameN exponentWord (k + 1)
+        (controlC6 + signExtend12 (-1 : BitVec 12)) ptr := by
+  rw [expReloadLimbDirectTailFrame_eq_savedNextLimbFrameN hNextNext,
+    expTwoMulFixedSavedNextLimbFrameN_succ_no_reload hMod,
+    expTwoMulFixedInductionFrameN_ordinary_of_control hC6' hNotPre']
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/FixedLoopInd.lean
+++ b/EvmAsm/Evm64/Exp/Compose/FixedLoopInd.lean
@@ -152,4 +152,63 @@ theorem cpsTripleWithin_expReloadDirectTruePre_ordinary_vacuous
   have h3 := holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_right h2)
   exact hC6 (holdsFor_pure.mp h3)
 
+/-- Pre-reload-family analogue of
+    `cpsTripleWithin_expReloadDirectFalsePre_ordinary_vacuous`: when
+    `controlC6 - 1 ≠ 0` (which holds in both the ordinary and pre-reload
+    control sub-cases, since pre-reload has `(controlC6-1).toNat = 1`), the
+    pre-reload reload-false continuation is vacuous.  Its tail frame
+    `expPreReloadDirectFalseFrameN` carries the same contradicting pure
+    `⌜controlC6 - 1 = 0⌝` ahead of the extra reload-limb cell. -/
+theorem cpsTripleWithin_expReloadDirectFalsePre_preReload_vacuous
+    {n : Nat} {entry exit_ : Word} {code : CodeReq} {Q : Assertion}
+    {k kf : Nat} {baseWord exponentWord : EvmWord}
+    {controlC6 e iterCount nextLimb ptr nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 v6' v7' v10' v11' d0' d1' d2' d3' base : Word}
+    (hC6 : controlC6 + signExtend12 (-1 : BitVec 12) ≠ 0) :
+    cpsTripleWithin n entry exit_ code
+      (expReloadDirectFalsePre k baseWord exponentWord e iterCount nextLimb ptr
+        nextNextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3
+        v6' v7' v10' v11' d0' d1' d2' d3' base
+        (expPreReloadDirectFalseFrameN exponentWord kf controlC6 e iterCount
+          ptr nextLimb))
+      Q := by
+  intro R _ s _ hPR _
+  exfalso
+  delta expReloadDirectFalsePre at hPR
+  simp only [] at hPR
+  rw [expTwoMulFixedIterPreNWithStateFrame_unfold] at hPR
+  have hFrame :=
+    holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR)
+  rw [expPreReloadDirectFalseFrameN_unfold] at hFrame
+  have h2 := holdsFor_sepConj_elim_right hFrame
+  have h3 := holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_right h2)
+  exact hC6 (holdsFor_pure.mp h3)
+
+/-- Pre-reload-family true-branch analogue of
+    `cpsTripleWithin_expReloadDirectTruePre_ordinary_vacuous`. -/
+theorem cpsTripleWithin_expReloadDirectTruePre_preReload_vacuous
+    {n : Nat} {entry exit_ : Word} {code : CodeReq} {Q : Assertion}
+    {k kf : Nat} {baseWord exponentWord : EvmWord}
+    {controlC6 e iterCount nextLimb ptr nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 v6' v7' v10' v11' d0' d1' d2' d3' base : Word}
+    (hC6 : controlC6 + signExtend12 (-1 : BitVec 12) ≠ 0) :
+    cpsTripleWithin n entry exit_ code
+      (expReloadDirectTruePre k baseWord exponentWord e iterCount nextLimb ptr
+        nextNextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3
+        v6' v7' v10' v11' d0' d1' d2' d3' base
+        (expPreReloadDirectTrueFrameN exponentWord kf controlC6 e iterCount
+          ptr nextLimb))
+      Q := by
+  intro R _ s _ hPR _
+  exfalso
+  delta expReloadDirectTruePre at hPR
+  simp only [] at hPR
+  rw [expTwoMulFixedIterPreNWithStateFrame_unfold] at hPR
+  have hFrame :=
+    holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR)
+  rw [expPreReloadDirectTrueFrameN_unfold] at hFrame
+  have h2 := holdsFor_sepConj_elim_right hFrame
+  have h3 := holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_right h2)
+  exact hC6 (holdsFor_pure.mp h3)
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/FixedLoopInd.lean
+++ b/EvmAsm/Evm64/Exp/Compose/FixedLoopInd.lean
@@ -237,4 +237,35 @@ theorem expReloadLimbDirectTailFrame_eq_inductionFrameN_succ_ordinary
     expTwoMulFixedSavedNextLimbFrameN_succ_no_reload hMod,
     expTwoMulFixedInductionFrameN_ordinary_of_control hC6' hNotPre']
 
+/-- Deep-ordinary output-frame chaining (companion to
+    `expReloadLimbDirectTailFrame_eq_inductionFrameN_succ_ordinary`): when the
+    next iteration `k+1` is ordinary and neither `k` nor `k+1` is at a 64-bit
+    limb boundary, the induction-hypothesis output frame
+    `DirectHeadTailOrSuccessorFrameN (k+1) (controlC6-1) ptr` coincides with the
+    ordinary head step's `hBranch` continuation tail
+    `expReloadLimbDirectTailFrame ptr nextNextLimb`.  With the input-frame lemma
+    this completes the deep-ordinary `hBranch` discharge: rewrite the pre, apply
+    the IH, rewrite the post. -/
+theorem directHeadTailOrSuccessorFrameN_succ_ordinary_eq_reloadLimbTail
+    {exponentWord : EvmWord} {k : Nat}
+    {controlC6 ptr nextNextLimb nextNextLimb' : Word}
+    (hC6' :
+      (controlC6 + signExtend12 (-1 : BitVec 12)) + signExtend12 (-1 : BitVec 12)
+        ≠ 0)
+    (hNotPre' :
+      ((controlC6 + signExtend12 (-1 : BitVec 12)) +
+        signExtend12 (-1 : BitVec 12)).toNat ≠ 1)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hMod : k % 64 < 62)
+    (hMod1 : (k + 1) % 64 < 62) :
+    expTwoMulFixedDirectHeadTailOrSuccessorFrameN exponentWord (k + 1)
+        (controlC6 + signExtend12 (-1 : BitVec 12)) ptr nextNextLimb' =
+      expReloadLimbDirectTailFrame ptr nextNextLimb := by
+  rw [expTwoMulFixedDirectHeadTailOrSuccessorFrameN_ordinary_of_control
+    hC6' hNotPre',
+    expReloadLimbDirectTailFrame_eq_savedNextLimbFrameN hNextNext,
+    expTwoMulFixedSavedNextLimbFrameN_succ_no_reload hMod,
+    expTwoMulFixedSavedNextLimbFrameN_succ_no_reload hMod1]
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/FixedLoopInd.lean
+++ b/EvmAsm/Evm64/Exp/Compose/FixedLoopInd.lean
@@ -1,0 +1,74 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.FixedLoopInd
+
+  Nat-indexed induction for the fixed-x19 EXP square-and-multiply loop body.
+
+  The fixed loop body is assembled from the per-iteration direct head step
+  `cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDirect_tailOrSuccessorFrameN_of_pre`
+  (see `SavedBitFixedInductionFrameLoopDirect`), mirroring the proven
+  non-fixed template `exp_loop_from_looppost_induction_general`
+  (`SavedBitLoopBodyInd`).
+
+  This module collects the arithmetic and structural glue that the
+  256-iteration assembly consumes.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedInductionFrameLoopDirect
+import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixedEntryExists
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+/-- The conservative fixed-x19 256-iteration full-body bound is exactly the
+    256-fold iteration-body bound.  This is the closed form consumed by the
+    Nat induction over the fixed loop, which counts iterations rather than
+    peeling a named first iteration. -/
+theorem expTwoMulFixedFullLoopBodyBound_eq_iterationsBodyBound_256 :
+    expTwoMulFixedFullLoopBodyBound = expTwoMulFixedIterationsBodyBound 256 := by
+  rw [expTwoMulFixedFullLoopBodyBound_eq, expTwoMulFixedIterationsBodyBound_eq]
+
+/-- Base case of the fixed-loop induction: the final iteration `k = 255`.
+
+    At `k = 255` every `k < 255` head-step continuation is vacuous, so the
+    direct head step
+    `cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDirect_tailOrSuccessorFrameN_of_pre`
+    collapses to requiring only the loop-exit bridge `hExit`. -/
+theorem exp_two_mul_fixed_loop_final_iteration_spec
+    {baseWord exponentWord : EvmWord} {iterations : Nat}
+    (controlC6 e machineC6 iterCount v10 v18 ptr nextLimb
+      nextNextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 : Word)
+    (base : Word)
+    (Q : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hControlMachine : controlC6 = machineC6)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (255 + 1) / 64))
+    (hExit :
+      ∀ ps,
+        expTwoMulFixedIterCaseExitPost iterCount e machineC6 ptr nextLimb
+          sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+        Q ps) :
+    cpsTripleWithin (expTwoMulFixedIterationsBodyBound (iterations + 1))
+      (base + 44) (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPreNWithInductionFrame 255 baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11)
+      (Q ** expTwoMulFixedDirectHeadTailOrSuccessorFrameN exponentWord 255
+        controlC6 ptr nextNextLimb) :=
+  cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDirect_tailOrSuccessorFrameN_of_pre
+    controlC6 e machineC6 iterCount v10 v18 ptr nextLimb
+    nextNextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+    e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 base Q hbase
+    hControlMachine (by decide) hBase hNextNext
+    (fun h => absurd h (by decide)) (fun h => absurd h (by decide))
+    (fun h => absurd h (by decide)) (fun h => absurd h (by decide))
+    (fun h => absurd h (by decide)) (fun h => absurd h (by decide))
+    (fun h => absurd h (by decide)) (fun h => absurd h (by decide))
+    (fun h => absurd h (by decide)) (fun _ => hExit)
+
+end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/FixedLoopInd.lean
+++ b/EvmAsm/Evm64/Exp/Compose/FixedLoopInd.lean
@@ -96,4 +96,60 @@ theorem expReloadLimbDirectTailFrame_eq_savedNextLimbFrameN
   rw [expReloadLimbDirectTailFrame_eq_savedNextLimbFrame,
     expTwoMulFixedSavedNextLimbFrameN_eq_of_nextNext hNextNext]
 
+/-- In the ordinary control sub-case (`controlC6 - 1 ≠ 0`), the direct head
+    step's reload-false continuation is vacuous: its precondition carries the
+    pure fact `⌜controlC6 - 1 = 0⌝` (inside `expReloadLimbDirectFalseFrame`),
+    contradicting the ordinary condition.  This discharges one of the
+    `_ordinary_of_pre` continuations in the fixed-loop inductive step. -/
+theorem cpsTripleWithin_expReloadDirectFalsePre_ordinary_vacuous
+    {n : Nat} {entry exit_ : Word} {code : CodeReq} {Q : Assertion}
+    {k : Nat} {baseWord exponentWord : EvmWord}
+    {controlC6 e iterCount nextLimb ptr nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 v6' v7' v10' v11' d0' d1' d2' d3' base : Word}
+    (hC6 : controlC6 + signExtend12 (-1 : BitVec 12) ≠ 0) :
+    cpsTripleWithin n entry exit_ code
+      (expReloadDirectFalsePre k baseWord exponentWord e iterCount nextLimb ptr
+        nextNextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3
+        v6' v7' v10' v11' d0' d1' d2' d3' base
+        (expReloadLimbDirectFalseFrame controlC6 e iterCount ptr nextLimb))
+      Q := by
+  intro R _ s _ hPR _
+  exfalso
+  delta expReloadDirectFalsePre at hPR
+  simp only [] at hPR
+  rw [expTwoMulFixedIterPreNWithStateFrame_unfold] at hPR
+  have hFrame :=
+    holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR)
+  rw [expReloadLimbDirectFalseFrame_unfold] at hFrame
+  have h2 := holdsFor_sepConj_elim_right hFrame
+  have h3 := holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_right h2)
+  exact hC6 (holdsFor_pure.mp h3)
+
+/-- In the ordinary control sub-case (`controlC6 - 1 ≠ 0`), the direct head
+    step's reload-true continuation is vacuous, by the same pure contradiction
+    carried in `expReloadLimbDirectTrueFrame`. -/
+theorem cpsTripleWithin_expReloadDirectTruePre_ordinary_vacuous
+    {n : Nat} {entry exit_ : Word} {code : CodeReq} {Q : Assertion}
+    {k : Nat} {baseWord exponentWord : EvmWord}
+    {controlC6 e iterCount nextLimb ptr nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 v6' v7' v10' v11' d0' d1' d2' d3' base : Word}
+    (hC6 : controlC6 + signExtend12 (-1 : BitVec 12) ≠ 0) :
+    cpsTripleWithin n entry exit_ code
+      (expReloadDirectTruePre k baseWord exponentWord e iterCount nextLimb ptr
+        nextNextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3
+        v6' v7' v10' v11' d0' d1' d2' d3' base
+        (expReloadLimbDirectTrueFrame controlC6 e iterCount ptr nextLimb))
+      Q := by
+  intro R _ s _ hPR _
+  exfalso
+  delta expReloadDirectTruePre at hPR
+  simp only [] at hPR
+  rw [expTwoMulFixedIterPreNWithStateFrame_unfold] at hPR
+  have hFrame :=
+    holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR)
+  rw [expReloadLimbDirectTrueFrame_unfold] at hFrame
+  have h2 := holdsFor_sepConj_elim_right hFrame
+  have h3 := holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_right h2)
+  exact hC6 (holdsFor_pure.mp h3)
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/FixedLoopInd.lean
+++ b/EvmAsm/Evm64/Exp/Compose/FixedLoopInd.lean
@@ -71,4 +71,29 @@ theorem exp_two_mul_fixed_loop_final_iteration_spec
     (fun h => absurd h (by decide)) (fun h => absurd h (by decide))
     (fun h => absurd h (by decide)) (fun _ => hExit)
 
+/-- The ordinary-case continuation tail frame `expReloadLimbDirectTailFrame`
+    and the induction-frame's `expTwoMulFixedSavedNextLimbFrame` are the same
+    single saved-next-limb cell at `ptr - 8`.  This is the def-level bridge the
+    ordinary control sub-case of the inductive step uses to reconcile the
+    direct head step's continuation tail against `InductionFrameN (k+1)`. -/
+theorem expReloadLimbDirectTailFrame_eq_savedNextLimbFrame
+    {ptr nextNextLimb : Word} :
+    expReloadLimbDirectTailFrame ptr nextNextLimb =
+      expTwoMulFixedSavedNextLimbFrame ptr nextNextLimb := by
+  rw [expReloadLimbDirectTailFrame_unfold,
+    expTwoMulFixedSavedNextLimbFrame_unfold]
+
+/-- Restatement of `expReloadLimbDirectTailFrame_eq_savedNextLimbFrame` against
+    the `k`-indexed saved-next-limb frame, given the standard `nextNextLimb`
+    cursor equation.  Converts the ordinary continuation tail directly into the
+    `InductionFrameN`-ordinary frame `expTwoMulFixedSavedNextLimbFrameN`. -/
+theorem expReloadLimbDirectTailFrame_eq_savedNextLimbFrameN
+    {exponentWord : EvmWord} {k : Nat} {ptr nextNextLimb : Word}
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64)) :
+    expReloadLimbDirectTailFrame ptr nextNextLimb =
+      expTwoMulFixedSavedNextLimbFrameN exponentWord k ptr := by
+  rw [expReloadLimbDirectTailFrame_eq_savedNextLimbFrame,
+    expTwoMulFixedSavedNextLimbFrameN_eq_of_nextNext hNextNext]
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/MergedLoopInd.lean
+++ b/EvmAsm/Evm64/Exp/Compose/MergedLoopInd.lean
@@ -9,12 +9,25 @@
   threaded without a `control = machine` side condition.  This mirrors the
   proven non-fixed template `exp_loop_from_looppost_induction_general`.
 
-  The reload (64-bit-boundary) loop-back disjuncts are not yet reshuffled into
-  the next-iteration `IterPre` shape in the merged formulation, so they are
-  taken here as an explicit reshuffle hypothesis `MergedReloadReshuffle`,
-  isolating exactly that remaining pure-assertion lemma.  Everything else —
-  the non-reload loop-back, the exit, the count threading, and the Nat
-  induction — is proven.
+  The reload (64-bit-boundary) loop-back disjuncts are taken here as an
+  explicit hypothesis `MergedReloadReshuffle`.  Everything else — the
+  non-reload loop-back, the exit, the count threading, and the Nat induction —
+  is proven outright.
+
+  IMPORTANT (established 2026-06-26): `MergedReloadReshuffle` as stated — a
+  *pure* assertion entailment from `expTwoMulFixedIterMergedLoopPost` to the
+  next `IterPre` — is NOT dischargeable.  At a limb boundary the merged
+  loop-back post has `x16 ↦ ptr-8` but its only pointer memory cell is at
+  `ptr` (a now-stale cell), and the next-limb cell at `ptr-8` is absent, so no
+  `IterPre` witness (whose `expTwoMulFixedIterPointerFrame` puts the pointer
+  register and its cell at the *same* address) can be built by `sep_perm`.
+  The reload is genuinely a *code step* (the limb load), which is exactly why
+  the `WithStateFrame`/`InductionFrame` routes thread the `(ptr-8)` next-limb
+  cell through the loop-back frame (`DirectHeadTailOrSuccessorFrameN`) instead.
+  Consequently this theorem proves the merged loop's *non-reload* structure and
+  count threading, but the full `hBody` (all 256 iterations including reloads)
+  must come from the `InductionFrame` route, which carries the next-limb cell.
+  See bead `evm-asm-20z6.13.7`.
 -/
 
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterExits
@@ -26,11 +39,16 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
-/-- The reload-disjunct reshuffle: at a 64-bit limb boundary, the merged
-    loop-back post's reload residual re-enters the next iteration's `IterPre`
-    (with reloaded control, advanced pointer, and decremented count).  This is
-    a pure assertion entailment — the single remaining merged-route lemma —
-    taken here as a hypothesis. -/
+/-- The reload-disjunct reshuffle hypothesis: at a 64-bit limb boundary, the
+    merged loop-back post's reload residual re-enters the next iteration's
+    `IterPre` (with reloaded control, advanced pointer, and decremented count).
+
+    NOTE: this is NOT a pure assertion entailment and is NOT dischargeable as
+    stated — the merged loop-back post lacks the `(ptr-8)` next-limb cell the
+    `IterPre` pointer frame requires, so the reload is genuinely a code-step
+    (the limb load).  It is kept as a hypothesis to factor out exactly the
+    reload handling; the full loop body must instead use the `InductionFrame`
+    route, which threads the next-limb cell.  See the module docstring. -/
 abbrev MergedReloadReshuffle (base sp evmSp a0 a1 a2 a3 : Word) : Prop :=
   ∀ (e c6 iterCount ptr nextLimb r0 r1 r2 r3 : Word) (ps : PartialState),
     expTwoMulFixedIterMergedLoopPost e c6 iterCount ptr nextLimb sp evmSp

--- a/EvmAsm/Evm64/Exp/Compose/MergedLoopInd.lean
+++ b/EvmAsm/Evm64/Exp/Compose/MergedLoopInd.lean
@@ -1,0 +1,142 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.MergedLoopInd
+
+  Nat-indexed induction for the fixed-x19 EXP square-and-multiply loop body,
+  via the merged loop-back/exit continuation route.
+
+  The per-iteration step `exp_fixed_loop_body_succ_step` is parametric in the
+  within-limb control `c6`, so the loop-back's existential control value is
+  threaded without a `control = machine` side condition.  This mirrors the
+  proven non-fixed template `exp_loop_from_looppost_induction_general`.
+
+  The reload (64-bit-boundary) loop-back disjuncts are not yet reshuffled into
+  the next-iteration `IterPre` shape in the merged formulation, so they are
+  taken here as an explicit reshuffle hypothesis `MergedReloadReshuffle`,
+  isolating exactly that remaining pure-assertion lemma.  Everything else —
+  the non-reload loop-back, the exit, the count threading, and the Nat
+  induction — is proven.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterExits
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostBridge
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostIterPreCases
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCount
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+/-- The reload-disjunct reshuffle: at a 64-bit limb boundary, the merged
+    loop-back post's reload residual re-enters the next iteration's `IterPre`
+    (with reloaded control, advanced pointer, and decremented count).  This is
+    a pure assertion entailment — the single remaining merged-route lemma —
+    taken here as a hypothesis. -/
+abbrev MergedReloadReshuffle (base sp evmSp a0 a1 a2 a3 : Word) : Prop :=
+  ∀ (e c6 iterCount ptr nextLimb r0 r1 r2 r3 : Word) (ps : PartialState),
+    expTwoMulFixedIterMergedLoopPost e c6 iterCount ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+    c6 + signExtend12 (-1 : BitVec 12) = 0 →
+    ∃ (e' c6' iterCount' v10' v18' ptr' nextLimb' tOld' vOld'
+        r0' r1' r2' r3' d0' d1' d2' d3' e0' e1' e2' e3' v7' v11' : Word),
+      expTwoMulFixedIterPre e' c6' iterCount' v10' v18' ptr' nextLimb' sp evmSp
+        tOld' vOld' r0' r1' r2' r3' d0' d1' d2' d3' e0' e1' e2' e3'
+        a0 a1 a2 a3 v7' v11' ps ∧
+      iterCount' = expTwoMulIterCountNew iterCount
+
+/-- Fixed EXP loop body, by Nat induction over the outer iteration count, via
+    the merged continuation route.  Conditional on the reload reshuffle and a
+    universal exit bridge `hExitU`. -/
+theorem exp_merged_loop_from_iterpre_induction
+    (base sp evmSp a0 a1 a2 a3 : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hReload : MergedReloadReshuffle base sp evmSp a0 a1 a2 a3)
+    (hExitU :
+      ∀ (e c6 iterCount ptr nextLimb r0 r1 r2 r3 : Word) (ps : PartialState),
+        expTwoMulFixedIterMergedExitPost e c6 iterCount ptr nextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+        R ps)
+    (n : Nat) :
+    ∀ (e c6 iterCount v10 v18 ptr nextLimb tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 v7 v11 : Word),
+      iterCount.toNat = n + 1 →
+      cpsTripleWithin ((n + 1) * 193)
+        (base + 44) (base + 296)
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+          tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11)
+        R := by
+  induction n with
+  | zero =>
+    intro e c6 iterCount v10 v18 ptr nextLimb tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 v7 v11 hcount
+    have hzero : expTwoMulIterCountNew iterCount = 0 :=
+      expTwoMulIterCountNew_eq_zero_of_toNat_one hcount
+    exact
+      exp_fixed_loop_body_final_succ_step
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+        base R hbase hzero (hExitU e c6 iterCount ptr nextLimb r0 r1 r2 r3)
+  | succ k IH =>
+    intro e c6 iterCount v10 v18 ptr nextLimb tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 v7 v11 hcount
+    have hcountNew : (expTwoMulIterCountNew iterCount).toNat = k + 1 :=
+      expTwoMulIterCountNew_toNat_of_eq_succ hcount
+    have hne : expTwoMulIterCountNew iterCount ≠ 0 := by
+      intro h
+      rw [h] at hcountNew
+      simp at hcountNew
+    have hExit :
+        ∀ ps,
+          expTwoMulFixedIterMergedExitPost e c6 iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+          R ps :=
+      exp_fixed_iter_merged_exit_vacuous_bridge hne
+    have hLoop :
+        cpsTripleWithin ((k + 1) * 193)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expTwoMulFixedIterMergedLoopPost e c6 iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base)
+          R := by
+      intro Rframe hRframe s hcr hPR hpc
+      obtain ⟨hp, hcompat, ps1, ps2, hdisj, hunion, hLP, hR_ps⟩ := hPR
+      have hCase :
+          expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base ps1 := by
+        rw [← expTwoMulFixedIterMergedLoopPost_eq_caseLoopPost]
+        exact hLP
+      rcases
+          expTwoMulFixedIterCaseLoopPost_iterPre_or_reloadPointerFrame_pures_unframed
+            hCase
+        with hCond | hRest
+      · rcases hCond with ⟨v6, v7', v10', v11', d0', d1', d2', d3', hPre⟩
+        exact IH _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ hcountNew
+          Rframe hRframe s hcr ⟨hp, hcompat, ps1, ps2, hdisj, hunion, hPre, hR_ps⟩
+          hpc
+      · rcases hRest with hSkip | hRest
+        · rcases hSkip with ⟨v6, v7', v10', v11', d0', d1', d2', d3', hPre⟩
+          exact IH _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ hcountNew
+            Rframe hRframe s hcr
+            ⟨hp, hcompat, ps1, ps2, hdisj, hunion, hPre, hR_ps⟩ hpc
+        · have hc6 : c6 + signExtend12 (-1 : BitVec 12) = 0 := by
+            rcases hRest with hReloadCond | hReloadSkip
+            · obtain ⟨_, _, _, _, _, _, _, _, _, _, hc6, _⟩ := hReloadCond
+              exact hc6
+            · obtain ⟨_, _, _, _, _, _, _, _, _, _, hc6, _⟩ := hReloadSkip
+              exact hc6
+          obtain ⟨e', c6', iterCount', v10', v18', ptr', nextLimb', tOld',
+              vOld', r0', r1', r2', r3', d0', d1', d2', d3', e0', e1', e2',
+              e3', v7', v11', hPre, hcount'⟩ :=
+            hReload e c6 iterCount ptr nextLimb r0 r1 r2 r3 ps1 hLP hc6
+          subst hcount'
+          exact IH _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ hcountNew
+            Rframe hRframe s hcr
+            ⟨hp, hcompat, ps1, ps2, hdisj, hunion, hPre, hR_ps⟩ hpc
+    exact
+      exp_fixed_loop_body_succ_step
+        (k + 1)
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+        base R hbase hExit hLoop
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## What

Adds `EvmAsm/Evm64/Exp/Compose/FixedLoopInd.lean` — the first two pieces of the Nat-indexed induction for the fixed EXP square-and-multiply 256-iteration loop body (bead `evm-asm-20z6.13.7`).

- **`expTwoMulFixedFullLoopBodyBound_eq_iterationsBodyBound_256`** — the closed bound `expTwoMulFixedFullLoopBodyBound = expTwoMulFixedIterationsBodyBound 256`, the form the iteration-counting induction needs.
- **`exp_two_mul_fixed_loop_final_iteration_spec`** — the induction **base case** (`k = 255`). All nine `k < 255` continuations of the direct head step `..._head_reloadDirect_tailOrSuccessorFrameN_of_pre` are vacuous (`255 < 255` is false), so the final iteration reduces to exactly the loop-exit bridge `hExit : expTwoMulFixedIterCaseExitPost … → Q`. This isolates the final-iteration obligation to that single exit bridge.

Mirrors the proven non-fixed template `exp_loop_from_looppost_induction_general`.

## Why

The fixed canonical loop body (`hBody`, consumed by `exp_two_mul_fixed_full_loop_boundary_of_entry_pren_exists_body_general_spec_within`) is the one remaining gap on the path to `evm_exp_stack_spec_within` — the last EVM-stack opcode without a kernel-checked stack-level spec. The per-iteration engine and head step already exist; this lands the base case and the bound glue. Remaining: the `k < 255` inductive step (frame-threading the `DirectHeadTailOrSuccessorFrameN` tails through the IH) and the exit bridge.

## Verification

- `lake build EvmAsm.Evm64.Exp.Compose.FixedLoopInd` ✔ and `lake build EvmAsm.Evm64.Exp` ✔
- `scripts/check-file-size.sh`, `scripts/check-unimported.sh` (0 orphans), `scripts/check-forbidden-tactics.sh` all pass
- `#print axioms`: both theorems depend only on `propext` / `Classical.choice` / `Quot.sound` — no `sorry`/`native_decide`/`bv_decide`

🤖 Generated with [Claude Code](https://claude.com/claude-code)