### PR TITLE
feat(rv64/rlp): per-field x15 recompute from saved list-end pointer (#9373 F1)

### DIFF
--- a/EvmAsm/Rv64/RLP/ValidatingFieldStep.lean
+++ b/EvmAsm/Rv64/RLP/ValidatingFieldStep.lean
@@ -77,4 +77,30 @@ theorem rv64_x15_minus_x11_minus_one (b : Word) (w pl : Word) :
   rw [show (b + 4 + 4 : Word) = b + 8 from by bv_omega] at hseq
   exact hseq
 
+/-- Pointer subtraction: `(regionBase + a) − (regionBase + b) = a − b` for `b ≤ a < 2^64`
+    (the `regionBase` base cancels). -/
+theorem ptr_sub_ofNat (regionBase : Word) (a b : Nat) (hba : b ≤ a) (ha : a < 2 ^ 64) :
+    (regionBase + BitVec.ofNat 64 a) - (regionBase + BitVec.ofNat 64 b) = BitVec.ofNat 64 (a - b) := by
+  have hc : (regionBase + BitVec.ofNat 64 a) - (regionBase + BitVec.ofNat 64 b)
+      = BitVec.ofNat 64 a - BitVec.ofNat 64 b := by bv_omega
+  rw [hc, ofNat_sub_ofNat a b hba ha]
+
+/-- **Per-field `x15` recompute from a saved list-end pointer** (the walk's remaining-bytes setup,
+    avoiding the `x11` ordering hazard of the in-place decrement): `SUB x15, rEnd, x13` sets `x15` to
+    the bytes left to the list end, `listEnd − cursor`, where `rEnd` holds the list-end pointer
+    `regionBase + listEnd` and `x13` the cursor `regionBase + cursor`. `rEnd` is a callee-saved
+    register the field walk never touches (set once by the list descend). -/
+theorem rv64_x15_recompute (b regionBase : Word) (rEnd : Reg) (cursor listEnd : Nat) (v15Old : Word)
+    (hba : cursor ≤ listEnd) (hL : listEnd < 2 ^ 64) :
+    cpsTripleWithin 1 b (b + 4) (CodeReq.singleton b (.SUB .x15 rEnd .x13))
+      ((rEnd ↦ᵣ (regionBase + BitVec.ofNat 64 listEnd)) **
+       (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 cursor)) ** (.x15 ↦ᵣ v15Old))
+      ((rEnd ↦ᵣ (regionBase + BitVec.ofNat 64 listEnd)) **
+       (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 cursor)) **
+       (.x15 ↦ᵣ (BitVec.ofNat 64 (listEnd - cursor)))) := by
+  have raw := sub_spec_within .x15 rEnd .x13 (regionBase + BitVec.ofNat 64 listEnd)
+    (regionBase + BitVec.ofNat 64 cursor) v15Old b (by nofun)
+  rw [ptr_sub_ofNat regionBase listEnd cursor hba hL] at raw
+  exact raw
+
 end EvmAsm.Rv64.RLP


### PR DESCRIPTION
## Summary

The field walk's per-field **remaining-bytes setup**, completing the inter-field glue toolkit alongside the in-place decrement (#9477). It avoids an ordering hazard: the in-place `x15 -= payloadLen + 1` needs `payloadLen` in `x11`, but the scalar value-read overwrites `x11` with the decoded value before that could run. Recomputing from a saved list-end pointer sidesteps this.

`rv64_x15_recompute`: `SUB x15, rEnd, x13` sets `x15 := listEnd − cursor` (bytes left to the list end), where `rEnd` is a callee-saved register holding the list-end pointer `regionBase + listEnd` (set once by the list descend, #9489, and never touched by the walk) and `x13` is the cursor. Plus `ptr_sub_ofNat` — base-cancelling pointer subtraction (`(regionBase + a) − (regionBase + b) = a − b` for `b ≤ a < 2^64`).

## Verification
- `lake build` clean; 0 sorry / 0 warnings.
- `#print axioms`: only `propext`, `Classical.choice`, `Quot.sound`.
- forbidden-tactics scan green; no `set_option maxRecDepth`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)