### PR TITLE
fix(exp): per-limb counter clobbered by mul_callable — relocate x6→x20 (callee-saved)

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/FixedLoopInd.lean
+++ b/EvmAsm/Evm64/Exp/Compose/FixedLoopInd.lean
@@ -105,12 +105,12 @@ theorem cpsTripleWithin_expReloadDirectFalsePre_ordinary_vacuous
     {n : Nat} {entry exit_ : Word} {code : CodeReq} {Q : Assertion}
     {k : Nat} {baseWord exponentWord : EvmWord}
     {controlC6 e iterCount nextLimb ptr nextNextLimb sp evmSp
-      r0 r1 r2 r3 a0 a1 a2 a3 v6' v7' v10' v11' d0' d1' d2' d3' base : Word}
+      r0 r1 r2 r3 a0 a1 a2 a3 v7' v10' v11' d0' d1' d2' d3' base : Word}
     (hC6 : controlC6 + signExtend12 (-1 : BitVec 12) ≠ 0) :
     cpsTripleWithin n entry exit_ code
       (expReloadDirectFalsePre k baseWord exponentWord e iterCount nextLimb ptr
         nextNextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3
-        v6' v7' v10' v11' d0' d1' d2' d3' base
+        v7' v10' v11' d0' d1' d2' d3' base
         (expReloadLimbDirectFalseFrame controlC6 e iterCount ptr nextLimb))
       Q := by
   intro R _ s _ hPR _
@@ -132,12 +132,12 @@ theorem cpsTripleWithin_expReloadDirectTruePre_ordinary_vacuous
     {n : Nat} {entry exit_ : Word} {code : CodeReq} {Q : Assertion}
     {k : Nat} {baseWord exponentWord : EvmWord}
     {controlC6 e iterCount nextLimb ptr nextNextLimb sp evmSp
-      r0 r1 r2 r3 a0 a1 a2 a3 v6' v7' v10' v11' d0' d1' d2' d3' base : Word}
+      r0 r1 r2 r3 a0 a1 a2 a3 v7' v10' v11' d0' d1' d2' d3' base : Word}
     (hC6 : controlC6 + signExtend12 (-1 : BitVec 12) ≠ 0) :
     cpsTripleWithin n entry exit_ code
       (expReloadDirectTruePre k baseWord exponentWord e iterCount nextLimb ptr
         nextNextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3
-        v6' v7' v10' v11' d0' d1' d2' d3' base
+        v7' v10' v11' d0' d1' d2' d3' base
         (expReloadLimbDirectTrueFrame controlC6 e iterCount ptr nextLimb))
       Q := by
   intro R _ s _ hPR _
@@ -163,12 +163,12 @@ theorem cpsTripleWithin_expReloadDirectFalsePre_preReload_vacuous
     {n : Nat} {entry exit_ : Word} {code : CodeReq} {Q : Assertion}
     {k kf : Nat} {baseWord exponentWord : EvmWord}
     {controlC6 e iterCount nextLimb ptr nextNextLimb sp evmSp
-      r0 r1 r2 r3 a0 a1 a2 a3 v6' v7' v10' v11' d0' d1' d2' d3' base : Word}
+      r0 r1 r2 r3 a0 a1 a2 a3 v7' v10' v11' d0' d1' d2' d3' base : Word}
     (hC6 : controlC6 + signExtend12 (-1 : BitVec 12) ≠ 0) :
     cpsTripleWithin n entry exit_ code
       (expReloadDirectFalsePre k baseWord exponentWord e iterCount nextLimb ptr
         nextNextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3
-        v6' v7' v10' v11' d0' d1' d2' d3' base
+        v7' v10' v11' d0' d1' d2' d3' base
         (expPreReloadDirectFalseFrameN exponentWord kf controlC6 e iterCount
           ptr nextLimb))
       Q := by
@@ -190,12 +190,12 @@ theorem cpsTripleWithin_expReloadDirectTruePre_preReload_vacuous
     {n : Nat} {entry exit_ : Word} {code : CodeReq} {Q : Assertion}
     {k kf : Nat} {baseWord exponentWord : EvmWord}
     {controlC6 e iterCount nextLimb ptr nextNextLimb sp evmSp
-      r0 r1 r2 r3 a0 a1 a2 a3 v6' v7' v10' v11' d0' d1' d2' d3' base : Word}
+      r0 r1 r2 r3 a0 a1 a2 a3 v7' v10' v11' d0' d1' d2' d3' base : Word}
     (hC6 : controlC6 + signExtend12 (-1 : BitVec 12) ≠ 0) :
     cpsTripleWithin n entry exit_ code
       (expReloadDirectTruePre k baseWord exponentWord e iterCount nextLimb ptr
         nextNextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3
-        v6' v7' v10' v11' d0' d1' d2' d3' base
+        v7' v10' v11' d0' d1' d2' d3' base
         (expPreReloadDirectTrueFrameN exponentWord kf controlC6 e iterCount
           ptr nextLimb))
       Q := by

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulFixedIter.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulFixedIter.lean
@@ -250,8 +250,8 @@ theorem exp_msb_bit_test_block_fixed_skip_expIterBodyFullMsbSavedBitTwoMulFixedC
     cpsTripleWithin 4 base (base + 28)
       (expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff)
-      ((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ c10) ** (.x0 ↦ᵣ (0 : Word)))
-      ((.x6 ↦ᵣ c6 + signExtend12 (-1 : BitVec 12)) ** (.x0 ↦ᵣ (0 : Word)) **
+      ((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x10 ↦ᵣ c10) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x20 ↦ᵣ c6 + signExtend12 (-1 : BitVec 12)) ** (.x0 ↦ᵣ (0 : Word)) **
        ⌜c6 + signExtend12 (-1 : BitVec 12) ≠ 0⌝ **
        (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
        (.x10 ↦ᵣ (e >>> (63 : BitVec 6).toNat))) := by
@@ -269,10 +269,10 @@ theorem exp_msb_bit_test_block_fixed_reload_expIterBodyFullMsbSavedBitTwoMulFixe
     cpsTripleWithin 7 base (base + 28)
       (expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff)
-      ((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ c10) ** (.x0 ↦ᵣ (0 : Word)) **
+      ((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x10 ↦ᵣ c10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb))
       ((.x19 ↦ᵣ nextLimb) **
-       (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+       (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
        (.x10 ↦ᵣ (e >>> (63 : BitVec 6).toNat)) ** (.x0 ↦ᵣ (0 : Word)) **
        ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
        (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -310,9 +310,9 @@ theorem exp_msb_bit_test_fixed_skip_then_save_expIterBodyFullMsbSavedBitTwoMulFi
     cpsTripleWithin (4 + 1) base (base + 32)
       (expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff)
-      ((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      ((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
        (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)))
-      ((.x6 ↦ᵣ c6New) ** (.x0 ↦ᵣ (0 : Word)) **
+      ((.x20 ↦ᵣ c6New) ** (.x0 ↦ᵣ (0 : Word)) **
        ⌜c6New ≠ 0⌝ ** (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
        (.x10 ↦ᵣ bit) ** (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12)))) := by
   intro bit c6New
@@ -325,7 +325,7 @@ theorem exp_msb_bit_test_fixed_skip_then_save_expIterBodyFullMsbSavedBitTwoMulFi
     exp_save_bit_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
       bit v18 squaringMulOff condMulOff skipOff backOff base
   have hSaveFramed := cpsTripleWithin_frameL
-    ((.x6 ↦ᵣ c6New) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜c6New ≠ 0⌝ **
+    ((.x20 ↦ᵣ c6New) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜c6New ≠ 0⌝ **
      (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)))
     (by pcFree) hSave
   have hSeq := cpsTripleWithin_seq_perm_same_cr
@@ -348,9 +348,9 @@ theorem exp_msb_bit_test_fixed_skip_then_save_expIterBodyFullMsbSavedBitTwoMulFi
       ((expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff).union
         (mul_callable_code mulTarget))
-      ((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      ((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
        (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)))
-      ((.x6 ↦ᵣ c6New) ** (.x0 ↦ᵣ (0 : Word)) **
+      ((.x20 ↦ᵣ c6New) ** (.x0 ↦ᵣ (0 : Word)) **
        ⌜c6New ≠ 0⌝ ** (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
        (.x10 ↦ᵣ bit) ** (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12)))) := by
   exact cpsTripleWithin_extend_code
@@ -369,11 +369,11 @@ theorem exp_msb_bit_test_fixed_reload_then_save_expIterBodyFullMsbSavedBitTwoMul
     cpsTripleWithin (7 + 1) base (base + 32)
       (expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff)
-      ((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      ((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
        (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb))
       ((.x19 ↦ᵣ nextLimb) **
-       (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+       (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
        (.x10 ↦ᵣ bit) ** (.x0 ↦ᵣ (0 : Word)) **
        ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
        (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -390,7 +390,7 @@ theorem exp_msb_bit_test_fixed_reload_then_save_expIterBodyFullMsbSavedBitTwoMul
       bit v18 squaringMulOff condMulOff skipOff backOff base
   have hSaveFramed := cpsTripleWithin_frameL
     ((.x19 ↦ᵣ nextLimb) **
-     (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+     (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
      (.x0 ↦ᵣ (0 : Word)) **
      ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
      (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -415,11 +415,11 @@ theorem exp_msb_bit_test_fixed_reload_then_save_expIterBodyFullMsbSavedBitTwoMul
       ((expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff).union
         (mul_callable_code mulTarget))
-      ((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      ((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
        (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb))
       ((.x19 ↦ᵣ nextLimb) **
-       (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+       (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
        (.x10 ↦ᵣ bit) ** (.x0 ↦ᵣ (0 : Word)) **
        ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
        (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -519,7 +519,7 @@ theorem exp_squaring_call_block_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_w
 
 /-- Fixed x19 no-reload prefix followed by the squaring-side MUL call. -/
 theorem exp_msb_bit_test_fixed_skip_save_then_squaring_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-    (e c6 v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+    (e c6 v6 v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 v7 v11 mulTarget : Word)
     (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
     (base : Word)
@@ -537,7 +537,7 @@ theorem exp_msb_bit_test_fixed_skip_save_then_squaring_expIterBodyFullMsbSavedBi
       ((expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff).union
         (mul_callable_code mulTarget))
-      (((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      (((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x6 ↦ᵣ v6) ** (.x10 ↦ᵣ v10) **
         (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
         ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
@@ -562,6 +562,7 @@ theorem exp_msb_bit_test_fixed_skip_save_then_squaring_expIterBodyFullMsbSavedBi
         (.x1 ↦ᵣ ((base + 32) + 68)) **
         (.x0 ↦ᵣ (0 : Word)) **
         (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+        (.x20 ↦ᵣ c6New) **
         (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
         ⌜c6New ≠ 0⌝)) := by
   intro bit c6New squareW
@@ -569,7 +570,7 @@ theorem exp_msb_bit_test_fixed_skip_save_then_squaring_expIterBodyFullMsbSavedBi
     exp_msb_bit_test_fixed_skip_then_save_expIterBodyFullMsbSavedBitTwoMulFixedCode_union_mul_spec_within
       e c6 v10 v18 mulTarget squaringMulOff condMulOff skipOff backOff base hc6
   have hPrefixFramed := cpsTripleWithin_frameR
-    ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+    ((.x6 ↦ᵣ v6) ** (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
      ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
      ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
      ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
@@ -587,10 +588,11 @@ theorem exp_msb_bit_test_fixed_skip_save_then_squaring_expIterBodyFullMsbSavedBi
   have hSquare :=
     exp_squaring_call_block_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
       sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
-      c6New v7 bit v11 mulTarget squaringMulOff condMulOff skipOff backOff
+      v6 v7 bit v11 mulTarget squaringMulOff condMulOff skipOff backOff
       base hbase hmt hd
   have hSquareFramed := cpsTripleWithin_frameR
-    ((.x0 ↦ᵣ (0 : Word)) **
+    ((.x20 ↦ᵣ c6New) **
+     (.x0 ↦ᵣ (0 : Word)) **
      (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
      (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
      ⌜c6New ≠ 0⌝)
@@ -604,7 +606,7 @@ theorem exp_msb_bit_test_fixed_skip_save_then_squaring_expIterBodyFullMsbSavedBi
 
 /-- Fixed x19 reload prefix followed by the squaring-side MUL call. -/
 theorem exp_msb_bit_test_fixed_reload_save_then_squaring_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-    (e c6 v10 v18 ptr nextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+    (e c6 v6 v10 v18 ptr nextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 v7 v11 mulTarget : Word)
     (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
     (base : Word)
@@ -621,7 +623,7 @@ theorem exp_msb_bit_test_fixed_reload_save_then_squaring_expIterBodyFullMsbSaved
       ((expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff).union
         (mul_callable_code mulTarget))
-      (((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      (((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x6 ↦ᵣ v6) ** (.x10 ↦ᵣ v10) **
         (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
@@ -647,6 +649,7 @@ theorem exp_msb_bit_test_fixed_reload_save_then_squaring_expIterBodyFullMsbSaved
         (.x1 ↦ᵣ ((base + 32) + 68)) **
         (.x0 ↦ᵣ (0 : Word)) **
         (.x19 ↦ᵣ nextLimb) **
+        (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
         (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
         ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
         (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -657,7 +660,7 @@ theorem exp_msb_bit_test_fixed_reload_save_then_squaring_expIterBodyFullMsbSaved
       e c6 v10 v18 ptr nextLimb mulTarget
       squaringMulOff condMulOff skipOff backOff base hc6
   have hPrefixFramed := cpsTripleWithin_frameR
-    ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+    ((.x6 ↦ᵣ v6) ** (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
      ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
      ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
      ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
@@ -675,10 +678,11 @@ theorem exp_msb_bit_test_fixed_reload_save_then_squaring_expIterBodyFullMsbSaved
   have hSquare :=
     exp_squaring_call_block_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
       sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
-      ((0 : Word) + signExtend12 (64 : BitVec 12)) v7 bit v11
+      v6 v7 bit v11
       mulTarget squaringMulOff condMulOff skipOff backOff base hbase hmt hd
   have hSquareFramed := cpsTripleWithin_frameR
-    ((.x0 ↦ᵣ (0 : Word)) **
+    ((.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+     (.x0 ↦ᵣ (0 : Word)) **
      (.x19 ↦ᵣ nextLimb) **
      (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
      ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -844,7 +848,7 @@ theorem exp_cond_mul_saved_bit_beq_expIterBodyFullMsbSavedBitTwoMulFixedCode_uni
 /-- Fixed x19 no-reload prefix and squaring-side MUL call followed by the
     saved-bit conditional-multiply BEQ. -/
 theorem exp_msb_bit_test_fixed_skip_save_squaring_then_cond_mul_beq_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-    (e c6 v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+    (e c6 v6 v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 v7 v11 mulTarget target : Word)
     (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
     (base : Word)
@@ -863,7 +867,7 @@ theorem exp_msb_bit_test_fixed_skip_save_squaring_then_cond_mul_beq_expIterBodyF
       ((expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff).union
         (mul_callable_code mulTarget))
-      (((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      (((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x6 ↦ᵣ v6) ** (.x10 ↦ᵣ v10) **
         (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
         ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
@@ -889,6 +893,7 @@ theorem exp_msb_bit_test_fixed_skip_save_squaring_then_cond_mul_beq_expIterBodyF
         (.x1 ↦ᵣ ((base + 32) + 68)) **
         (.x0 ↦ᵣ (0 : Word)) **
         (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+        (.x20 ↦ᵣ c6New) **
         (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
         ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝))
       (base + 140)
@@ -901,6 +906,7 @@ theorem exp_msb_bit_test_fixed_skip_save_squaring_then_cond_mul_beq_expIterBodyF
         (.x1 ↦ᵣ ((base + 32) + 68)) **
         (.x0 ↦ᵣ (0 : Word)) **
         (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+        (.x20 ↦ᵣ c6New) **
         (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
         ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝)) := by
   intro bit c6New squareW
@@ -914,7 +920,7 @@ theorem exp_msb_bit_test_fixed_skip_save_squaring_then_cond_mul_beq_expIterBodyF
     (.x1 ↦ᵣ ((base + 32) + 68))
   have hPrefixSquare :=
     exp_msb_bit_test_fixed_skip_save_then_squaring_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-      e c6 v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e c6 v6 v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 v7 v11 mulTarget squaringMulOff condMulOff skipOff backOff
       base hc6 hbase hmt hd
   have hBeq :=
@@ -923,6 +929,7 @@ theorem exp_msb_bit_test_fixed_skip_save_squaring_then_cond_mul_beq_expIterBodyF
       (bit + signExtend12 (0 : BitVec 12)) base target mulTarget htarget
   have hBeqFramed := cpsBranchWithin_frameR
     (rest **
+     (.x20 ↦ᵣ c6New) **
      (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
      ⌜c6New ≠ 0⌝)
     (by
@@ -937,7 +944,7 @@ theorem exp_msb_bit_test_fixed_skip_save_squaring_then_cond_mul_beq_expIterBodyF
         _ target _ (base + 140) _ :=
     cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr
       (fun _ hp => by
-        dsimp [rest, bit] at hp ⊢
+        dsimp [rest, bit, c6New] at hp ⊢
         xperm_hyp hp)
       hPrefixSquare hBeqFramed
   exact cpsBranchWithin_weaken
@@ -953,7 +960,7 @@ theorem exp_msb_bit_test_fixed_skip_save_squaring_then_cond_mul_beq_expIterBodyF
 /-- Fixed x19 reload prefix and squaring-side MUL call followed by the
     saved-bit conditional-multiply BEQ. -/
 theorem exp_msb_bit_test_fixed_reload_save_squaring_then_cond_mul_beq_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-    (e c6 v10 v18 ptr nextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+    (e c6 v6 v10 v18 ptr nextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 v7 v11 mulTarget target : Word)
     (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
     (base : Word)
@@ -971,7 +978,7 @@ theorem exp_msb_bit_test_fixed_reload_save_squaring_then_cond_mul_beq_expIterBod
       ((expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff).union
         (mul_callable_code mulTarget))
-      (((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      (((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x6 ↦ᵣ v6) ** (.x10 ↦ᵣ v10) **
         (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
@@ -998,6 +1005,7 @@ theorem exp_msb_bit_test_fixed_reload_save_squaring_then_cond_mul_beq_expIterBod
         (.x1 ↦ᵣ ((base + 32) + 68)) **
         (.x0 ↦ᵣ (0 : Word)) **
         (.x19 ↦ᵣ nextLimb) **
+        (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
         (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
         ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
         (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -1013,6 +1021,7 @@ theorem exp_msb_bit_test_fixed_reload_save_squaring_then_cond_mul_beq_expIterBod
         (.x1 ↦ᵣ ((base + 32) + 68)) **
         (.x0 ↦ᵣ (0 : Word)) **
         (.x19 ↦ᵣ nextLimb) **
+        (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
         (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
         ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
         (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -1029,7 +1038,7 @@ theorem exp_msb_bit_test_fixed_reload_save_squaring_then_cond_mul_beq_expIterBod
     (.x1 ↦ᵣ ((base + 32) + 68))
   have hPrefixSquare :=
     exp_msb_bit_test_fixed_reload_save_then_squaring_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-      e c6 v10 v18 ptr nextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e c6 v6 v10 v18 ptr nextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 v7 v11 mulTarget squaringMulOff condMulOff skipOff backOff
       base hc6 hbase hmt hd
   have hBeq :=
@@ -1038,6 +1047,7 @@ theorem exp_msb_bit_test_fixed_reload_save_squaring_then_cond_mul_beq_expIterBod
       (bit + signExtend12 (0 : BitVec 12)) base target mulTarget htarget
   have hBeqFramed := cpsBranchWithin_frameR
     (rest **
+     (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
      (.x19 ↦ᵣ nextLimb) **
      ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
      (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulFixedIterLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulFixedIterLoop.lean
@@ -19,7 +19,7 @@ open EvmAsm.Rv64
     the loop-back counter update. The nonzero conditional-multiply path remains
     the first exit. -/
 theorem exp_msb_bit_test_fixed_skip_save_squaring_beq_skip_then_loop_back_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-    (e c6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+    (e c6 v6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 v7 v11 mulTarget loopTarget : Word)
     (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
     (base : Word)
@@ -44,13 +44,14 @@ theorem exp_msb_bit_test_fixed_skip_save_squaring_beq_skip_then_loop_back_expIte
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
       (.x1 ↦ᵣ ((base + 32) + 68)) **
       (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+      (.x20 ↦ᵣ c6New) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝
     cpsNBranchWithin ((((4 + 1) + (17 + 64 + 9)) + 1) + 2) base
       ((expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff).union
         (mul_callable_code mulTarget))
-      ((((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      ((((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x6 ↦ᵣ v6) ** (.x10 ↦ᵣ v10) **
         (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
         ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
@@ -77,6 +78,7 @@ theorem exp_msb_bit_test_fixed_skip_save_squaring_beq_skip_then_loop_back_expIte
             (.x1 ↦ᵣ ((base + 32) + 68)) **
             (.x0 ↦ᵣ (0 : Word)) **
             (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+            (.x20 ↦ᵣ c6New) **
             (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
             ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝) **
             (.x9 ↦ᵣ iterCount))),
@@ -89,7 +91,7 @@ theorem exp_msb_bit_test_fixed_skip_save_squaring_beq_skip_then_loop_back_expIte
   intro bit c6New squareW skipRest
   have hBranch :=
     exp_msb_bit_test_fixed_skip_save_squaring_then_cond_mul_beq_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-      e c6 v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e c6 v6 v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 v7 v11 mulTarget (base + 244) squaringMulOff condMulOff
       skipOff backOff base hc6 hbase hmt hskip hd
   have hBranchFramed := cpsBranchWithin_frameR (.x9 ↦ᵣ iterCount) (by pcFree) hBranch
@@ -118,7 +120,7 @@ theorem exp_msb_bit_test_fixed_skip_save_squaring_beq_skip_then_loop_back_expIte
     the loop-back counter update. The nonzero conditional-multiply path remains
     the first exit. -/
 theorem exp_msb_bit_test_fixed_reload_save_squaring_beq_skip_then_loop_back_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+    (e c6 v6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
       r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 v7 v11 mulTarget loopTarget : Word)
     (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
     (base : Word)
@@ -142,6 +144,7 @@ theorem exp_msb_bit_test_fixed_reload_save_squaring_beq_skip_then_loop_back_expI
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
       (.x1 ↦ᵣ ((base + 32) + 68)) **
       (.x19 ↦ᵣ nextLimb) **
+      (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
       (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -151,7 +154,7 @@ theorem exp_msb_bit_test_fixed_reload_save_squaring_beq_skip_then_loop_back_expI
       ((expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff).union
         (mul_callable_code mulTarget))
-      ((((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      ((((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x6 ↦ᵣ v6) ** (.x10 ↦ᵣ v10) **
         (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
@@ -179,6 +182,7 @@ theorem exp_msb_bit_test_fixed_reload_save_squaring_beq_skip_then_loop_back_expI
             (.x1 ↦ᵣ ((base + 32) + 68)) **
             (.x0 ↦ᵣ (0 : Word)) **
             (.x19 ↦ᵣ nextLimb) **
+            (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
             (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
             ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
             (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -194,7 +198,7 @@ theorem exp_msb_bit_test_fixed_reload_save_squaring_beq_skip_then_loop_back_expI
   intro bit squareW skipRest
   have hBranch :=
     exp_msb_bit_test_fixed_reload_save_squaring_then_cond_mul_beq_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-      e c6 v10 v18 ptr nextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e c6 v6 v10 v18 ptr nextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 v7 v11 mulTarget (base + 244) squaringMulOff condMulOff
       skipOff backOff base hc6 hbase hmt hskip hd
   have hBranchFramed := cpsBranchWithin_frameR (.x9 ↦ᵣ iterCount) (by pcFree) hBranch
@@ -654,7 +658,7 @@ theorem exp_cond_mul_call_then_loop_back_expIterBodyFullMsbSavedBitTwoMulFixedCo
     prefix through squaring and saved-bit BEQ with the folded conditional
     multiply continuation, leaving the reload entry branch for a later merge. -/
 theorem exp_msb_bit_test_fixed_skip_full_iter_four_exit_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-    (e c6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+    (e c6 v6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 mulTarget loopTarget : Word)
     (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
     (base : Word)
@@ -679,6 +683,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_four_exit_expIterBodyFullMsbSavedB
       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
     let condFrame : Assertion :=
       (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+      (.x20 ↦ᵣ c6New) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝
     let skipRest : Assertion :=
@@ -690,6 +695,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_four_exit_expIterBodyFullMsbSavedB
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
       (.x1 ↦ᵣ ((base + 32) + 68)) **
       (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+      (.x20 ↦ᵣ c6New) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝
     let condRest : Assertion :=
@@ -710,7 +716,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_four_exit_expIterBodyFullMsbSavedB
       ((expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff).union
         (mul_callable_code mulTarget))
-      (((((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      (((((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x6 ↦ᵣ v6) ** (.x10 ↦ᵣ v10) **
         (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
         ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
@@ -742,7 +748,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_four_exit_expIterBodyFullMsbSavedB
   intro bit c6New squareW rw baseFrame condFrame skipRest condRest
   have hSkipRaw :=
     exp_msb_bit_test_fixed_skip_save_squaring_beq_skip_then_loop_back_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-      e c6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e c6 v6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 v7 v11 mulTarget loopTarget squaringMulOff condMulOff
       skipOff backOff base hc6 hbase hsqmt hskip hback hd
   have hSkip := cpsNBranchWithin_frameR (F := baseFrame) (by
@@ -793,7 +799,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_four_exit_expIterBodyFullMsbSavedB
     the conditional-multiply and zero-bit skip outcomes that land at the same
     loop/exit PCs. -/
 theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-    (e c6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+    (e c6 v6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 mulTarget loopTarget : Word)
     (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
     (base : Word)
@@ -818,6 +824,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_expIterBodyFullMsbSave
       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
     let condFrame : Assertion :=
       (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+      (.x20 ↦ᵣ c6New) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝
     let skipRest : Assertion :=
@@ -829,6 +836,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_expIterBodyFullMsbSave
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
       (.x1 ↦ᵣ ((base + 32) + 68)) **
       (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+      (.x20 ↦ᵣ c6New) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝
     let condRest : Assertion :=
@@ -849,7 +857,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_expIterBodyFullMsbSave
       ((expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff).union
         (mul_callable_code mulTarget))
-      (((((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      (((((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x6 ↦ᵣ v6) ** (.x10 ↦ᵣ v10) **
         (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
         ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
@@ -881,7 +889,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_expIterBodyFullMsbSave
   intro bit c6New squareW rw baseFrame condFrame skipRest condRest
   have hFour :=
     exp_msb_bit_test_fixed_skip_full_iter_four_exit_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-      e c6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e c6 v6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 mulTarget loopTarget
       squaringMulOff condMulOff skipOff backOff base hc6 hbase hsqmt hcondmt
       hskip hback hd
@@ -934,7 +942,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_expIterBodyFullMsbSave
     while carrying the reloaded exponent limb and pointer state through the
     conditional-multiply continuation. -/
 theorem exp_msb_bit_test_fixed_reload_full_iter_four_exit_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+    (e c6 v6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
       r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
       v7 v11 mulTarget loopTarget : Word)
     (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
@@ -959,6 +967,7 @@ theorem exp_msb_bit_test_fixed_reload_full_iter_four_exit_expIterBodyFullMsbSave
       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
     let condFrame : Assertion :=
       (.x19 ↦ᵣ nextLimb) **
+      (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
       (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -973,6 +982,7 @@ theorem exp_msb_bit_test_fixed_reload_full_iter_four_exit_expIterBodyFullMsbSave
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
       (.x1 ↦ᵣ ((base + 32) + 68)) **
       (.x19 ↦ᵣ nextLimb) **
+      (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
       (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -996,7 +1006,7 @@ theorem exp_msb_bit_test_fixed_reload_full_iter_four_exit_expIterBodyFullMsbSave
       ((expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff).union
         (mul_callable_code mulTarget))
-      (((((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      (((((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x6 ↦ᵣ v6) ** (.x10 ↦ᵣ v10) **
         (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
@@ -1029,7 +1039,7 @@ theorem exp_msb_bit_test_fixed_reload_full_iter_four_exit_expIterBodyFullMsbSave
   intro bit squareW rw baseFrame condFrame skipRest condRest
   have hReloadRaw :=
     exp_msb_bit_test_fixed_reload_save_squaring_beq_skip_then_loop_back_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      e c6 v6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
       r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 v7 v11 mulTarget loopTarget
       squaringMulOff condMulOff skipOff backOff base hc6 hbase hsqmt hskip hback hd
   have hReload := cpsNBranchWithin_frameR (F := baseFrame) (by

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulFixedIterMerged.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulFixedIterMerged.lean
@@ -14,7 +14,7 @@ open EvmAsm.Rv64
 /-- Branch-interface view of the fixed x19 no-reload full-iteration
     merged-exit slice. -/
 theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-    (e c6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+    (e c6 v6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 mulTarget loopTarget : Word)
     (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
     (base : Word)
@@ -39,6 +39,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_expIterBodyFull
       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
     let condFrame : Assertion :=
       (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+      (.x20 ↦ᵣ c6New) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝
     let skipRest : Assertion :=
@@ -50,6 +51,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_expIterBodyFull
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
       (.x1 ↦ᵣ ((base + 32) + 68)) **
       (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+      (.x20 ↦ᵣ c6New) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝
     let condRest : Assertion :=
@@ -70,7 +72,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_expIterBodyFull
       ((expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff).union
         (mul_callable_code mulTarget))
-      (((((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      (((((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x6 ↦ᵣ v6) ** (.x10 ↦ᵣ v10) **
         (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
         ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
@@ -101,7 +103,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_expIterBodyFull
           ⌜expTwoMulIterCountNew iterCount = 0⌝) ** skipRest) ** baseFrame) h) := by
   exact cpsNBranchWithin_as_cpsBranchWithin
     (exp_msb_bit_test_fixed_skip_full_iter_merged_exit_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-      e c6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e c6 v6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 mulTarget loopTarget
       squaringMulOff condMulOff skipOff backOff base hc6 hbase hsqmt hcondmt
       hskip hback hd)
@@ -109,7 +111,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_expIterBodyFull
 /-- Fixed x19 no-reload merged branch at the reload-path bound. This gives
     the later skip/reload branch merge a uniform step budget. -/
 theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_reload_bound_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-    (e c6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+    (e c6 v6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 mulTarget loopTarget : Word)
     (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
     (base : Word)
@@ -134,6 +136,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_reload_bound_ex
       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
     let condFrame : Assertion :=
       (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+      (.x20 ↦ᵣ c6New) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝
     let skipRest : Assertion :=
@@ -145,6 +148,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_reload_bound_ex
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
       (.x1 ↦ᵣ ((base + 32) + 68)) **
       (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+      (.x20 ↦ᵣ c6New) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝
     let condRest : Assertion :=
@@ -165,7 +169,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_reload_bound_ex
       ((expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff).union
         (mul_callable_code mulTarget))
-      (((((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      (((((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x6 ↦ᵣ v6) ** (.x10 ↦ᵣ v10) **
         (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
         ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
@@ -197,7 +201,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_reload_bound_ex
   exact cpsBranchWithin_mono_nSteps
     expTwoMulFixedSkipIterStepBound_le_reload
     (exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-      e c6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e c6 v6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 mulTarget loopTarget
       squaringMulOff condMulOff skipOff backOff base hc6 hbase hsqmt hcondmt
       hskip hback hd)
@@ -205,7 +209,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_reload_bound_ex
 /-- Fixed x19 no-reload merged branch at the reload-path bound, preserving the
     exponent pointer state that the reload path consumes. -/
 theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_reload_bound_pointer_frame_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+    (e c6 v6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
       r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
       v7 v11 mulTarget loopTarget : Word)
     (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
@@ -231,6 +235,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_reload_bound_po
       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
     let condFrame : Assertion :=
       (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+      (.x20 ↦ᵣ c6New) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝
     let skipRest : Assertion :=
@@ -242,6 +247,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_reload_bound_po
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
       (.x1 ↦ᵣ ((base + 32) + 68)) **
       (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+      (.x20 ↦ᵣ c6New) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝
     let condRest : Assertion :=
@@ -264,7 +270,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_reload_bound_po
       ((expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff).union
         (mul_callable_code mulTarget))
-      ((((((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      ((((((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x6 ↦ᵣ v6) ** (.x10 ↦ᵣ v10) **
         (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
         ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
@@ -300,7 +306,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_reload_bound_po
     dsimp [ptrFrame]
     pcFree)
     (exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_reload_bound_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-      e c6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e c6 v6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 mulTarget loopTarget
       squaringMulOff condMulOff skipOff backOff base hc6 hbase hsqmt hcondmt
       hskip hback hd)
@@ -309,7 +315,7 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_reload_bound_po
     the conditional-multiply and zero-bit skip outcomes that land at the same
     loop/exit PCs. -/
 theorem exp_msb_bit_test_fixed_reload_full_iter_merged_exit_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+    (e c6 v6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
       r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
       v7 v11 mulTarget loopTarget : Word)
     (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
@@ -334,6 +340,7 @@ theorem exp_msb_bit_test_fixed_reload_full_iter_merged_exit_expIterBodyFullMsbSa
       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
     let condFrame : Assertion :=
       (.x19 ↦ᵣ nextLimb) **
+      (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
       (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -348,6 +355,7 @@ theorem exp_msb_bit_test_fixed_reload_full_iter_merged_exit_expIterBodyFullMsbSa
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
       (.x1 ↦ᵣ ((base + 32) + 68)) **
       (.x19 ↦ᵣ nextLimb) **
+      (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
       (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -371,7 +379,7 @@ theorem exp_msb_bit_test_fixed_reload_full_iter_merged_exit_expIterBodyFullMsbSa
       ((expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff).union
         (mul_callable_code mulTarget))
-      (((((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      (((((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x6 ↦ᵣ v6) ** (.x10 ↦ᵣ v10) **
         (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
@@ -404,7 +412,7 @@ theorem exp_msb_bit_test_fixed_reload_full_iter_merged_exit_expIterBodyFullMsbSa
   intro bit squareW rw baseFrame condFrame skipRest condRest
   have hFour :=
     exp_msb_bit_test_fixed_reload_full_iter_four_exit_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      e c6 v6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
       r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
       v7 v11 mulTarget loopTarget squaringMulOff condMulOff skipOff backOff
       base hc6 hbase hsqmt hcondmt hskip hback hd
@@ -456,7 +464,7 @@ theorem exp_msb_bit_test_fixed_reload_full_iter_merged_exit_expIterBodyFullMsbSa
 /-- Branch-interface view of the fixed x19 reload full-iteration merged-exit
     slice. -/
 theorem exp_msb_bit_test_fixed_reload_full_iter_merged_exit_branch_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+    (e c6 v6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
       r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
       v7 v11 mulTarget loopTarget : Word)
     (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
@@ -481,6 +489,7 @@ theorem exp_msb_bit_test_fixed_reload_full_iter_merged_exit_branch_expIterBodyFu
       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
     let condFrame : Assertion :=
       (.x19 ↦ᵣ nextLimb) **
+      (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
       (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -495,6 +504,7 @@ theorem exp_msb_bit_test_fixed_reload_full_iter_merged_exit_branch_expIterBodyFu
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
       (.x1 ↦ᵣ ((base + 32) + 68)) **
       (.x19 ↦ᵣ nextLimb) **
+      (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
       (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -518,7 +528,7 @@ theorem exp_msb_bit_test_fixed_reload_full_iter_merged_exit_branch_expIterBodyFu
       ((expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff).union
         (mul_callable_code mulTarget))
-      (((((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      (((((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x6 ↦ᵣ v6) ** (.x10 ↦ᵣ v10) **
         (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
@@ -550,7 +560,7 @@ theorem exp_msb_bit_test_fixed_reload_full_iter_merged_exit_branch_expIterBodyFu
           ⌜expTwoMulIterCountNew iterCount = 0⌝) ** skipRest) ** baseFrame) h) := by
   exact cpsNBranchWithin_as_cpsBranchWithin
     (exp_msb_bit_test_fixed_reload_full_iter_merged_exit_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      e c6 v6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
       r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
       v7 v11 mulTarget loopTarget squaringMulOff condMulOff skipOff backOff
       base hc6 hbase hsqmt hcondmt hskip hback hd)
@@ -558,7 +568,7 @@ theorem exp_msb_bit_test_fixed_reload_full_iter_merged_exit_branch_expIterBodyFu
 /-- Reload merged branch with the input exponent pointer state grouped in the
     same `ptrFrame` shape used by the no-reload framed skip wrapper. -/
 theorem exp_msb_bit_test_fixed_reload_full_iter_merged_exit_branch_pointer_frame_pre_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+    (e c6 v6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
       r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
       v7 v11 mulTarget loopTarget : Word)
     (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
@@ -583,6 +593,7 @@ theorem exp_msb_bit_test_fixed_reload_full_iter_merged_exit_branch_pointer_frame
       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
     let condFrame : Assertion :=
       (.x19 ↦ᵣ nextLimb) **
+      (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
       (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -597,6 +608,7 @@ theorem exp_msb_bit_test_fixed_reload_full_iter_merged_exit_branch_pointer_frame
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
       (.x1 ↦ᵣ ((base + 32) + 68)) **
       (.x19 ↦ᵣ nextLimb) **
+      (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
       (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -622,7 +634,7 @@ theorem exp_msb_bit_test_fixed_reload_full_iter_merged_exit_branch_pointer_frame
       ((expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff).union
         (mul_callable_code mulTarget))
-      ((((((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      ((((((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x6 ↦ᵣ v6) ** (.x10 ↦ᵣ v10) **
         (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
         ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
@@ -654,7 +666,7 @@ theorem exp_msb_bit_test_fixed_reload_full_iter_merged_exit_branch_pointer_frame
   intro bit squareW rw baseFrame condFrame skipRest condRest ptrFrame
   refine cpsBranchWithin_weaken ?_ (fun _ hp => hp) (fun _ hp => hp)
     (exp_msb_bit_test_fixed_reload_full_iter_merged_exit_branch_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      e c6 v6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
       r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
       v7 v11 mulTarget loopTarget squaringMulOff condMulOff skipOff backOff
       base hc6 hbase hsqmt hcondmt hskip hback hd)
@@ -665,7 +677,7 @@ theorem exp_msb_bit_test_fixed_reload_full_iter_merged_exit_branch_pointer_frame
 /-- Fixed x19 full-iteration branch with the no-reload and reload x6 cases
     merged under a shared pointer-frame precondition. -/
 theorem exp_msb_bit_test_fixed_full_iter_merged_exit_branch_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+    (e c6 v6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
       r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
       v7 v11 mulTarget loopTarget : Word)
     (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
@@ -692,6 +704,7 @@ theorem exp_msb_bit_test_fixed_full_iter_merged_exit_branch_expIterBodyFullMsbSa
       (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb)
     let skipCondFrame : Assertion :=
       (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+      (.x20 ↦ᵣ c6New) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝
     let skipRest : Assertion :=
@@ -703,6 +716,7 @@ theorem exp_msb_bit_test_fixed_full_iter_merged_exit_branch_expIterBodyFullMsbSa
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
       (.x1 ↦ᵣ ((base + 32) + 68)) **
       (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+      (.x20 ↦ᵣ c6New) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝
     let skipCondRest : Assertion :=
@@ -719,6 +733,7 @@ theorem exp_msb_bit_test_fixed_full_iter_merged_exit_branch_expIterBodyFullMsbSa
       (.x1 ↦ᵣ ((base + 140) + 68))
     let reloadCondFrame : Assertion :=
       (.x19 ↦ᵣ nextLimb) **
+      (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New = 0⌝ **
       (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -733,6 +748,7 @@ theorem exp_msb_bit_test_fixed_full_iter_merged_exit_branch_expIterBodyFullMsbSa
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
       (.x1 ↦ᵣ ((base + 32) + 68)) **
       (.x19 ↦ᵣ nextLimb) **
+      (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New = 0⌝ **
       (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -771,7 +787,7 @@ theorem exp_msb_bit_test_fixed_full_iter_merged_exit_branch_expIterBodyFullMsbSa
       ((expIterBodyFullMsbSavedBitTwoMulFixedCode
         base squaringMulOff condMulOff skipOff backOff).union
         (mul_callable_code mulTarget))
-      ((((((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      ((((((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x6 ↦ᵣ v6) ** (.x10 ↦ᵣ v10) **
         (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
         ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
@@ -798,7 +814,7 @@ theorem exp_msb_bit_test_fixed_full_iter_merged_exit_branch_expIterBodyFullMsbSa
   by_cases h_c6 : c6New = 0
   · have hReload :=
       exp_msb_bit_test_fixed_reload_full_iter_merged_exit_branch_pointer_frame_pre_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        e c6 v6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
         r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
         v7 v11 mulTarget loopTarget squaringMulOff condMulOff skipOff backOff
         base h_c6 hbase hsqmt hcondmt hskip hback hd
@@ -811,7 +827,7 @@ theorem exp_msb_bit_test_fixed_full_iter_merged_exit_branch_expIterBodyFullMsbSa
       exact hp
   · have hSkip :=
       exp_msb_bit_test_fixed_skip_full_iter_merged_exit_branch_reload_bound_pointer_frame_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        e c6 v6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
         r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
         v7 v11 mulTarget loopTarget squaringMulOff condMulOff skipOff backOff
         base h_c6 hbase hsqmt hcondmt hskip hback hd

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryEntryFixedIterPre.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryEntryFixedIterPre.lean
@@ -193,7 +193,7 @@ theorem expTwoMulFixedFirstIterPre_unfold_words
     expTwoMulFixedFirstIterPre sp evmSp v10 v18 vOld v7 v11
         baseWord exponentWord dWord eWord =
       (((((.x19 ↦ᵣ exponentWord.getLimbN 3) **
-        (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+        (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) ** regOwn .x6 **
         (.x10 ↦ᵣ v10) ** (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ (evmSp + signExtend12 (64 : BitVec 12))) **
         (.x5 ↦ᵣ (1 : Word)) **
@@ -240,7 +240,7 @@ def expTwoMulFixedFirstIterPreOwned
     (sp evmSp v18 vOld : Word)
     (baseWord exponentWord dWord eWord : EvmWord) : Assertion :=
   (((((.x19 ↦ᵣ exponentWord.getLimbN 3) **
-    (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+    (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) ** regOwn .x6 **
     regOwn .x10 ** (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
     (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ (evmSp + signExtend12 (64 : BitVec 12))) **
     (.x5 ↦ᵣ (1 : Word)) **
@@ -259,7 +259,7 @@ theorem expTwoMulFixedFirstIterPreOwned_unfold
     expTwoMulFixedFirstIterPreOwned sp evmSp v18 vOld
         baseWord exponentWord dWord eWord =
       (((((.x19 ↦ᵣ exponentWord.getLimbN 3) **
-        (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+        (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) ** regOwn .x6 **
         regOwn .x10 ** (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ (evmSp + signExtend12 (64 : BitVec 12))) **
         (.x5 ↦ᵣ (1 : Word)) **
@@ -351,7 +351,7 @@ theorem expTwoMulFixedFirstIterPreOwned_choose_frame
     (.x19 ↦ᵣ exponentWord.getLimbN 3) **
     (.x2 ↦ᵣ sp) **
     (.x5 ↦ᵣ (1 : Word)) **
-    (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+    (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) ** regOwn .x6 **
     (.x9 ↦ᵣ (256 : Word))
   have h_front : (expTwoMulFixedFirstIterScratchOwn ** restFrame) ps := by
     unfold expTwoMulFixedFirstIterScratchOwn
@@ -374,8 +374,7 @@ def expTwoMulFixedFirstIterEntryResidual
   ((evmSp + 32) ↦ₘ exponentWord.getLimbN 0) **
   ((evmSp + 40) ↦ₘ exponentWord.getLimbN 1) **
   ((evmSp + 56) ↦ₘ exponentWord.getLimbN 3) **
-  evmStackIs (evmSp + 128) rest **
-  regOwn .x6
+  evmStackIs (evmSp + 128) rest
 
 theorem expTwoMulFixedFirstIterEntryResidual_unfold
     {evmSp : Word} {exponentWord : EvmWord} {rest : List EvmWord} :
@@ -383,8 +382,7 @@ theorem expTwoMulFixedFirstIterEntryResidual_unfold
       (((evmSp + 32) ↦ₘ exponentWord.getLimbN 0) **
        ((evmSp + 40) ↦ₘ exponentWord.getLimbN 1) **
        ((evmSp + 56) ↦ₘ exponentWord.getLimbN 3) **
-       evmStackIs (evmSp + 128) rest **
-       regOwn .x6) := by
+       evmStackIs (evmSp + 128) rest) := by
   delta expTwoMulFixedFirstIterEntryResidual
   rfl
 

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixed.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixed.lean
@@ -21,7 +21,7 @@ def expTwoMulBoundaryPreFixed
     (baseWord exponentWord : EvmWord) (rest : List EvmWord) : Assertion :=
   ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
    (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
-   (.x6 ↦ᵣ c6Old) ** (.x16 ↦ᵣ c16Old) ** (.x19 ↦ᵣ c19Old) **
+   (.x20 ↦ᵣ c6Old) ** (.x16 ↦ᵣ c16Old) ** (.x19 ↦ᵣ c19Old) **
    ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
    ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
    ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
@@ -36,7 +36,7 @@ theorem expTwoMulBoundaryPreFixed_unfold
       m0 m1 m2 m3 vOld v18 baseWord exponentWord rest =
       ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
        (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
-       (.x6 ↦ᵣ c6Old) ** (.x16 ↦ᵣ c16Old) ** (.x19 ↦ᵣ c19Old) **
+       (.x20 ↦ᵣ c6Old) ** (.x16 ↦ᵣ c16Old) ** (.x19 ↦ᵣ c19Old) **
        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
@@ -53,7 +53,7 @@ theorem expTwoMulBoundaryPreFixed_unfold_scratch
       m0 m1 m2 m3 vOld v18 baseWord exponentWord rest =
       ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
        (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
-       (.x6 ↦ᵣ c6Old) ** (.x16 ↦ᵣ c16Old) ** (.x19 ↦ᵣ c19Old) **
+       (.x20 ↦ᵣ c6Old) ** (.x16 ↦ᵣ c16Old) ** (.x19 ↦ᵣ c19Old) **
        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologueFixed.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologueFixed.lean
@@ -38,7 +38,7 @@ def expTwoMulLoopEntryPostFixed
     (rest : List EvmWord) : Assertion :=
   (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
       (.x9 ↦ᵣ (256 : Word)) ** (.x5 ↦ᵣ (1 : Word)) **
-      (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+      (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
       (.x16 ↦ᵣ (evmSp + signExtend12 (56 : BitVec 12) + signExtend12 (-8 : BitVec 12))) **
       (.x19 ↦ᵣ exponentWord.getLimbN 3) **
       evmWordIs sp (1 : EvmWord)) **
@@ -52,7 +52,7 @@ theorem expTwoMulLoopEntryPostFixed_unfold
     expTwoMulLoopEntryPostFixed sp evmSp vOld v18 baseWord exponentWord rest =
       (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
           (.x9 ↦ᵣ (256 : Word)) ** (.x5 ↦ᵣ (1 : Word)) **
-          (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+          (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
           (.x16 ↦ᵣ (evmSp + signExtend12 (56 : BitVec 12) + signExtend12 (-8 : BitVec 12))) **
           (.x19 ↦ᵣ exponentWord.getLimbN 3) **
           evmWordIs sp (1 : EvmWord)) **
@@ -67,7 +67,7 @@ theorem expTwoMulLoopEntryPostFixed_unfold_scratch
     expTwoMulLoopEntryPostFixed sp evmSp vOld v18 baseWord exponentWord rest =
       (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
           (.x9 ↦ᵣ (256 : Word)) ** (.x5 ↦ᵣ (1 : Word)) **
-          (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+          (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
           (.x16 ↦ᵣ (evmSp + signExtend12 (56 : BitVec 12) + signExtend12 (-8 : BitVec 12))) **
           (.x19 ↦ᵣ exponentWord.getLimbN 3) **
           evmWordIs sp (1 : EvmWord)) **
@@ -87,7 +87,7 @@ theorem expTwoMulLoopEntryPostFixed_unfold_rest2
         baseWord exponentWord (dWord :: eWord :: rest) =
       (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
           (.x9 ↦ᵣ (256 : Word)) ** (.x5 ↦ᵣ (1 : Word)) **
-          (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+          (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
           (.x16 ↦ᵣ (evmSp + signExtend12 (56 : BitVec 12) + signExtend12 (-8 : BitVec 12))) **
           (.x19 ↦ᵣ exponentWord.getLimbN 3) **
           evmWordIs sp (1 : EvmWord)) **
@@ -112,7 +112,7 @@ theorem expTwoMulLoopEntryPostFixed_unfold_rest2_offsets
         baseWord exponentWord (dWord :: eWord :: rest) =
       (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
           (.x9 ↦ᵣ (256 : Word)) ** (.x5 ↦ᵣ (1 : Word)) **
-          (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+          (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
           (.x16 ↦ᵣ (evmSp + signExtend12 (56 : BitVec 12) + signExtend12 (-8 : BitVec 12))) **
           (.x19 ↦ᵣ exponentWord.getLimbN 3) **
           evmWordIs sp (1 : EvmWord)) **
@@ -294,7 +294,7 @@ private theorem exp_prologue_fixed_in_fixed_code_spec_within
       (expMsbSavedBitTwoMulFixedCode base squaringMulOff condMulOff skipOff backOff)
       ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
        (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
-       (.x6 ↦ᵣ c6Old) ** (.x16 ↦ᵣ c16Old) ** (.x19 ↦ᵣ c19Old) **
+       (.x20 ↦ᵣ c6Old) ** (.x16 ↦ᵣ c16Old) ** (.x19 ↦ᵣ c19Old) **
        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
@@ -304,7 +304,7 @@ private theorem exp_prologue_fixed_in_fixed_code_spec_within
        (.x9 ↦ᵣ ((0 : Word) + signExtend12 (256 : BitVec 12))) **
        (.x5 ↦ᵣ ((0 : Word) + signExtend12 (1 : BitVec 12))) **
        (.x12 ↦ᵣ evmSp) **
-       (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+       (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
        (.x16 ↦ᵣ evmSp + signExtend12 (56 : BitVec 12) + signExtend12 (-8 : BitVec 12)) **
        (.x19 ↦ᵣ expLimb3) **
        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ
@@ -373,7 +373,7 @@ theorem exp_prologue_fixed_then_pointer_advance_spec_within
       (expMsbSavedBitTwoMulFixedCode base squaringMulOff condMulOff skipOff backOff)
       ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
        (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
-       (.x6 ↦ᵣ c6Old) ** (.x16 ↦ᵣ c16Old) ** (.x19 ↦ᵣ c19Old) **
+       (.x20 ↦ᵣ c6Old) ** (.x16 ↦ᵣ c16Old) ** (.x19 ↦ᵣ c19Old) **
        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
@@ -383,7 +383,7 @@ theorem exp_prologue_fixed_then_pointer_advance_spec_within
       (((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x9 ↦ᵣ ((0 : Word) + signExtend12 (256 : BitVec 12))) **
         (.x5 ↦ᵣ ((0 : Word) + signExtend12 (1 : BitVec 12))) **
-        (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+        (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
         (.x16 ↦ᵣ evmSp + signExtend12 (56 : BitVec 12) + signExtend12 (-8 : BitVec 12)) **
         (.x19 ↦ᵣ expLimb3) **
         ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ ((0 : Word) + signExtend12 (1 : BitVec 12))) **
@@ -404,7 +404,7 @@ theorem exp_prologue_fixed_then_pointer_advance_spec_within
   have hAdvanceF := cpsTripleWithin_frameR
     ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
      (.x9 ↦ᵣ 0 + signExtend12 256) ** (.x5 ↦ᵣ 0 + signExtend12 1) **
-     (.x6 ↦ᵣ 0 + signExtend12 64) **
+     (.x20 ↦ᵣ 0 + signExtend12 64) **
      (.x16 ↦ᵣ evmSp + signExtend12 56 + signExtend12 (-8:BitVec 12)) **
      (.x19 ↦ᵣ expLimb3) **
      ((sp + signExtend12 0) ↦ₘ 0 + signExtend12 1) **
@@ -437,7 +437,7 @@ theorem exp_prologue_fixed_then_pointer_advance_full_stack_spec_within
       (expMsbSavedBitTwoMulFixedCode base squaringMulOff condMulOff skipOff backOff)
       ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
        (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
-       (.x6 ↦ᵣ c6Old) ** (.x16 ↦ᵣ c16Old) ** (.x19 ↦ᵣ c19Old) **
+       (.x20 ↦ᵣ c6Old) ** (.x16 ↦ᵣ c16Old) ** (.x19 ↦ᵣ c19Old) **
        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFrameLoopDirect.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFrameLoopDirect.lean
@@ -29,41 +29,41 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDire
     (hBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expReloadTailDirectTailFrameN exponentWord k ptr nextNextLimb))
           (Q ** expReloadTailDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hReloadFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadTailDirectFalseFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expReloadTailDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hReloadTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadTailDirectTrueFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expReloadTailDirectTailFrameN exponentWord k ptr
@@ -107,41 +107,41 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDire
     (hBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expPreReloadDirectTailFrameN exponentWord k ptr nextNextLimb))
           (Q ** expPreReloadDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hReloadFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expPreReloadDirectFalseFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expPreReloadDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hReloadTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expPreReloadDirectTrueFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expPreReloadDirectTailFrameN exponentWord k ptr
@@ -189,39 +189,39 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDire
     (hBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTailFrame ptr nextNextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hReloadFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectFalseFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hReloadTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTrueFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
@@ -268,39 +268,39 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDire
     (hBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTailFrame ptr nextNextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hReloadFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectFalseFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hReloadTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTrueFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
@@ -835,42 +835,42 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDire
     (hReloadBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expReloadTailDirectTailFrameN exponentWord k ptr
               nextNextLimb))
           (Q ** expReloadTailDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hReloadFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadTailDirectFalseFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expReloadTailDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hReloadTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadTailDirectTrueFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expReloadTailDirectTailFrameN exponentWord k ptr
@@ -878,42 +878,42 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDire
     (hPreBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expPreReloadDirectTailFrameN exponentWord k ptr
               nextNextLimb))
           (Q ** expPreReloadDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hPreFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expPreReloadDirectFalseFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expPreReloadDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hPreTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expPreReloadDirectTrueFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expPreReloadDirectTailFrameN exponentWord k ptr
@@ -921,39 +921,39 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDire
     (hOrdBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTailFrame ptr nextNextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hOrdFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectFalseFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hOrdTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTrueFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
@@ -1026,42 +1026,42 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDire
     (hReloadBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expReloadTailDirectTailFrameN exponentWord k ptr
               nextNextLimb))
           (Q ** expReloadTailDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hReloadFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadTailDirectFalseFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expReloadTailDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hReloadTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadTailDirectTrueFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expReloadTailDirectTailFrameN exponentWord k ptr
@@ -1069,42 +1069,42 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDire
     (hPreBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expPreReloadDirectTailFrameN exponentWord k ptr
               nextNextLimb))
           (Q ** expPreReloadDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hPreFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expPreReloadDirectFalseFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expPreReloadDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hPreTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expPreReloadDirectTrueFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expPreReloadDirectTailFrameN exponentWord k ptr
@@ -1112,39 +1112,39 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithInductionFrame_head_reloadDire
     (hOrdBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTailFrame ptr nextNextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hOrdFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectFalseFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hOrdTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTrueFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -151,6 +151,7 @@ abbrev expTwoMulFixedIterSkipRestScratchSuffix
   let c6New := c6 + signExtend12 (-1 : BitVec 12)
   (.x1 ↦ᵣ (((base + 44) + 32) + 68)) **
   (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+  (.x20 ↦ᵣ c6New) **
   (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
   ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝
 
@@ -174,6 +175,7 @@ abbrev expTwoMulFixedIterReloadSkipRestScratchSuffix
   let c6New := c6 + signExtend12 (-1 : BitVec 12)
   (.x1 ↦ᵣ (((base + 44) + 32) + 68)) **
   (.x19 ↦ᵣ nextLimb) **
+  (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
   (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
   ⌜c6New = 0⌝ **
   (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -808,7 +810,8 @@ theorem expTwoMulFixedIterSkipCondCountPost_pures
   obtain ⟨_, _, _, _, _, hCountTail⟩ := hCount
   have hExit : exitCond := ((sepConj_pure_right _).1 hCountTail).2
   obtain ⟨_, _, _, _, _, hFrameTail⟩ := hFrame
-  obtain ⟨_, _, _, _, _, hPureTail⟩ := hFrameTail
+  obtain ⟨_, _, _, _, _, hFrameTailB⟩ := hFrameTail
+  obtain ⟨_, _, _, _, _, hPureTail⟩ := hFrameTailB
   have hC6 : c6 + signExtend12 (-1 : BitVec 12) ≠ 0 :=
     ((sepConj_pure_left _).1 hPureTail).1
   obtain ⟨_, hBit⟩ := ((sepConj_pure_left _).1 hPureTail).2
@@ -844,7 +847,8 @@ theorem expTwoMulFixedIterSkipCountPost_pures
   obtain ⟨_, _, _, _, _, hRest13⟩ := hRest12
   obtain ⟨_, _, _, _, _, hRest14⟩ := hRest13
   obtain ⟨_, _, _, _, _, hRest15⟩ := hRest14
-  obtain ⟨_, _, _, _, _, hPureTail⟩ := hRest15
+  obtain ⟨_, _, _, _, _, hRest15b⟩ := hRest15
+  obtain ⟨_, _, _, _, _, hPureTail⟩ := hRest15b
   have hC6 : c6 + signExtend12 (-1 : BitVec 12) ≠ 0 :=
     ((sepConj_pure_left _).1 hPureTail).1
   obtain ⟨_, hBit⟩ := ((sepConj_pure_left _).1 hPureTail).2
@@ -867,7 +871,8 @@ theorem expTwoMulFixedIterReloadCondCountPost_pures
   obtain ⟨_, _, _, _, _, hCountTail⟩ := hCount
   have hExit : exitCond := ((sepConj_pure_right _).1 hCountTail).2
   obtain ⟨_, _, _, _, _, hFrame1⟩ := hFrame
-  obtain ⟨_, _, _, _, _, hFrame2⟩ := hFrame1
+  obtain ⟨_, _, _, _, _, hFrame1b⟩ := hFrame1
+  obtain ⟨_, _, _, _, _, hFrame2⟩ := hFrame1b
   have hC6 : c6 + signExtend12 (-1 : BitVec 12) = 0 :=
     ((sepConj_pure_left _).1 hFrame2).1
   have hAfterC6 := ((sepConj_pure_left _).1 hFrame2).2
@@ -908,9 +913,10 @@ theorem expTwoMulFixedIterReloadSkipCountPost_pures
   obtain ⟨_, _, _, _, _, hRest14⟩ := hRest13
   obtain ⟨_, _, _, _, _, hRest15⟩ := hRest14
   obtain ⟨_, _, _, _, _, hRest16⟩ := hRest15
+  obtain ⟨_, _, _, _, _, hRest16b⟩ := hRest16
   have hC6 : c6 + signExtend12 (-1 : BitVec 12) = 0 :=
-    ((sepConj_pure_left _).1 hRest16).1
-  have hAfterC6 := ((sepConj_pure_left _).1 hRest16).2
+    ((sepConj_pure_left _).1 hRest16b).1
+  have hAfterC6 := ((sepConj_pure_left _).1 hRest16b).2
   obtain ⟨_, _, _, _, _, hRest17⟩ := hAfterC6
   have hBit :
       (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0 :=

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
@@ -45,6 +45,7 @@ abbrev expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
   let c6New := c6 + signExtend12 (-1 : BitVec 12)
   expTwoMulFixedIterSkipCondRestScratchSuffix base **
   (.x19 ↦ᵣ nextLimb) **
+  (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
   (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
   ⌜c6New = 0⌝ **
   expTwoMulFixedIterReloadPointerFrame ptr nextLimb **
@@ -69,6 +70,7 @@ abbrev expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
   let c6New := c6 + signExtend12 (-1 : BitVec 12)
   (.x1 ↦ᵣ (((base + 44) + 32) + 68)) **
   (.x19 ↦ᵣ nextLimb) **
+  (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
   (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
   ⌜c6New = 0⌝ **
   expTwoMulFixedIterReloadPointerFrame ptr nextLimb **
@@ -501,7 +503,8 @@ theorem expTwoMulFixedIterSkipCondScratchFrame_pures
     hSuffix, _hPtr⟩ := hSuffixPtr
   obtain ⟨_psRet, _psSkipCondFrame, _hDisjointRet, _hUnionRet,
     _hRet, hSkipCondFrame⟩ := hSuffix
-  obtain ⟨_, _, _, _, _, hFrameTail⟩ := hSkipCondFrame
+  obtain ⟨_, _, _, _, _, hX20Tail⟩ := hSkipCondFrame
+  obtain ⟨_, _, _, _, _, hFrameTail⟩ := hX20Tail
   obtain ⟨_, _, _, _, _, hPureTail⟩ := hFrameTail
   have h_c6 : c6 + signExtend12 (-1 : BitVec 12) ≠ 0 :=
     ((sepConj_pure_left _).1 hPureTail).1
@@ -544,7 +547,8 @@ theorem expTwoMulFixedIterSkipScratchFrame_pures
   obtain ⟨_psSkipRest, _psBaseFrame, _hDisjointSkipRest, _hUnionSkipRest,
     hSkipRest, _hBaseFrame⟩ := hSuffix
   obtain ⟨_, _, _, _, _, hSkipRestTail⟩ := hSkipRest
-  obtain ⟨_, _, _, _, _, hX18Tail⟩ := hSkipRestTail
+  obtain ⟨_, _, _, _, _, hX20Tail⟩ := hSkipRestTail
+  obtain ⟨_, _, _, _, _, hX18Tail⟩ := hX20Tail
   obtain ⟨_, _, _, _, _, hPureTail⟩ := hX18Tail
   have h_c6 : c6 + signExtend12 (-1 : BitVec 12) ≠ 0 :=
     ((sepConj_pure_left _).1 hPureTail).1
@@ -583,7 +587,8 @@ theorem expTwoMulFixedIterReloadCondScratchFrame_pures
     _hScratch, hSuffix⟩ := hTail
   obtain ⟨_psRet, _psReloadCondFrame, _hDisjointRet, _hUnionRet,
     _hRet, hReloadCondFrame⟩ := hSuffix
-  obtain ⟨_, _, _, _, _, hReloadCondTail⟩ := hReloadCondFrame
+  obtain ⟨_, _, _, _, _, hX20Tail⟩ := hReloadCondFrame
+  obtain ⟨_, _, _, _, _, hReloadCondTail⟩ := hX20Tail
   obtain ⟨_, _, _, _, _, hPureTail⟩ := hReloadCondTail
   have hC6Tail := ((sepConj_pure_left _).1 hPureTail)
   have h_c6 : c6 + signExtend12 (-1 : BitVec 12) = 0 := hC6Tail.1
@@ -629,7 +634,8 @@ theorem expTwoMulFixedIterReloadSkipScratchFrame_pures
   obtain ⟨_, _, _, _, _, hReloadSkipTail1⟩ := hReloadSkip
   obtain ⟨_, _, _, _, _, hReloadSkipTail2⟩ := hReloadSkipTail1
   obtain ⟨_, _, _, _, _, hReloadSkipTail3⟩ := hReloadSkipTail2
-  obtain ⟨_, _, _, _, hC6Pure, hPtrMemBit⟩ := hReloadSkipTail3
+  obtain ⟨_, _, _, _, _, hReloadSkipTail4⟩ := hReloadSkipTail3
+  obtain ⟨_, _, _, _, hC6Pure, hPtrMemBit⟩ := hReloadSkipTail4
   have h_c6 : c6 + signExtend12 (-1 : BitVec 12) = 0 :=
     hC6Pure.2
   obtain ⟨_, _, _, _, _, hMemBit⟩ := hPtrMemBit
@@ -638,6 +644,19 @@ theorem expTwoMulFixedIterReloadSkipScratchFrame_pures
       (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0 :=
     hBitPure.2
   exact ⟨h_exit, h_c6, h_bit⟩
+
+/-- Weaken the per-iteration scratch frame's `x6` value slot to ownership.
+    After the counter moved to `x20`, the next `IterPre` keeps `x6` only as
+    `regOwn` scratch, so the loop-back post's concrete `x6` value is dropped. -/
+private theorem expTwoMulFixedIterScratchIs_x6_to_regOwn
+    {evmSp v6 v7 v10 v11 d0 d1 d2 d3 : Word} :
+    ∀ ps, expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 ps →
+      (regOwn .x6 ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
+       (evmSp ↦ₘ d0) ** ((evmSp + 8) ↦ₘ d1) ** ((evmSp + 16) ↦ₘ d2) **
+       ((evmSp + 24) ↦ₘ d3)) ps := by
+  intro ps h
+  unfold expTwoMulFixedIterScratchIs at h
+  exact sepConj_mono_left (regIs_implies_regOwn .x6) _ h
 
 theorem expTwoMulFixedIterSkipCondScratchFrame_to_iterPre_frame
     {iterCount e c6 ptr nextLimb sp evmSp
@@ -655,7 +674,7 @@ theorem expTwoMulFixedIterSkipCondScratchFrame_to_iterPre_frame
     let rw := expTwoMulCondRw squareW a0 a1 a2 a3
     ((expTwoMulFixedIterPre
       (e <<< (1 : BitVec 6).toNat)
-      v6
+      (c6 + signExtend12 (-1 : BitVec 12))
       (expTwoMulIterCountNew iterCount)
       v10
       ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -670,9 +689,11 @@ theorem expTwoMulFixedIterSkipCondScratchFrame_to_iterPre_frame
   intro squareW rw
   have h_pures := expTwoMulFixedIterSkipCondScratchFrame_pures h
   rcases h_pures with ⟨h_exit, h_c6, h_bit⟩
+  replace h := sepConj_mono_left
+    (sepConj_mono_right (sepConj_mono_left
+      expTwoMulFixedIterScratchIs_x6_to_regOwn)) _ h
   unfold expTwoMulFixedIterSkipCondCountPostScratchPrefix
     expTwoMulFixedIterSkipCondRestScratchPrefix
-    expTwoMulFixedIterScratchIs
     expTwoMulFixedIterSkipCondCountPostScratchSuffix
     expTwoMulFixedIterSkipCondRestScratchSuffix
     expTwoMulFixedIterSkipCondFrame at h
@@ -721,7 +742,7 @@ theorem expTwoMulFixedIterSkipScratchFrame_to_iterPre_frame
     let squareW := expSquaringCallSquareW r0 r1 r2 r3
     ((expTwoMulFixedIterPre
       (e <<< (1 : BitVec 6).toNat)
-      v6
+      (c6 + signExtend12 (-1 : BitVec 12))
       (expTwoMulIterCountNew iterCount)
       v10
       ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -738,9 +759,11 @@ theorem expTwoMulFixedIterSkipScratchFrame_to_iterPre_frame
   intro squareW
   have h_pures := expTwoMulFixedIterSkipScratchFrame_pures h
   rcases h_pures with ⟨h_exit, h_c6, h_bit⟩
+  replace h := sepConj_mono_left
+    (sepConj_mono_right (sepConj_mono_left
+      expTwoMulFixedIterScratchIs_x6_to_regOwn)) _ h
   unfold expTwoMulFixedIterSkipCountPostScratchPrefix
     expTwoMulFixedIterSkipRestScratchPrefix
-    expTwoMulFixedIterScratchIs
     expTwoMulFixedIterSkipCountPostScratchSuffix
     expTwoMulFixedIterSkipRestScratchSuffix
     expTwoMulFixedIterBaseFrame at h

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostIterPreCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostIterPreCases.lean
@@ -74,12 +74,12 @@ theorem expTwoMulFixedIterCaseLoopPost_iterPre_or_reloadPointerFrame
     hSkipCond | hRest
   · rcases hSkipCond with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
     exact Or.inl
-      ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+      ⟨(c6 + signExtend12 (-1 : BitVec 12)), v7, v10, v11, d0, d1, d2, d3,
         expTwoMulFixedIterSkipCondScratchFrame_to_iterPre_frame hScratch⟩
   · rcases hRest with hSkip | hRest
     · rcases hSkip with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
       exact Or.inr (Or.inl
-        ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+        ⟨(c6 + signExtend12 (-1 : BitVec 12)), v7, v10, v11, d0, d1, d2, d3,
           expTwoMulFixedIterSkipScratchFrame_to_iterPre_frame hScratch⟩)
     · rcases hRest with hReloadCond | hReloadSkip
       · exact Or.inr (Or.inr (Or.inl hReloadCond))
@@ -304,12 +304,12 @@ theorem expTwoMulFixedIterCaseExitPost_iterPre_or_reloadPointerFrame
     hSkipCond | hRest
   · rcases hSkipCond with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
     exact Or.inl
-      ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+      ⟨(c6 + signExtend12 (-1 : BitVec 12)), v7, v10, v11, d0, d1, d2, d3,
         expTwoMulFixedIterSkipCondScratchFrame_to_iterPre_frame hScratch⟩
   · rcases hRest with hSkip | hRest
     · rcases hSkip with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
       exact Or.inr (Or.inl
-        ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+        ⟨(c6 + signExtend12 (-1 : BitVec 12)), v7, v10, v11, d0, d1, d2, d3,
           expTwoMulFixedIterSkipScratchFrame_to_iterPre_frame hScratch⟩)
     · rcases hRest with hReloadCond | hReloadSkip
       · exact Or.inr (Or.inr (Or.inl hReloadCond))

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePosts.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePosts.lean
@@ -23,6 +23,7 @@ abbrev expTwoMulFixedIterSkipCondFrame (e c6 : Word) : Assertion :=
   let bit := e >>> (63 : BitVec 6).toNat
   let c6New := c6 + signExtend12 (-1 : BitVec 12)
   (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+  (.x20 ↦ᵣ c6New) **
   (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
   ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝
 
@@ -39,6 +40,7 @@ abbrev expTwoMulFixedIterSkipRest
   memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
   (.x1 ↦ᵣ (((base + 44) + 32) + 68)) **
   (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+  (.x20 ↦ᵣ c6New) **
   (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
   ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝
 
@@ -63,6 +65,7 @@ abbrev expTwoMulFixedIterReloadCondFrame
   let bit := e >>> (63 : BitVec 6).toNat
   let c6New := c6 + signExtend12 (-1 : BitVec 12)
   (.x19 ↦ᵣ nextLimb) **
+  (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
   (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
   ⌜c6New = 0⌝ **
   (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -82,6 +85,7 @@ abbrev expTwoMulFixedIterReloadSkipRest
   memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
   (.x1 ↦ᵣ (((base + 44) + 32) + 68)) **
   (.x19 ↦ᵣ nextLimb) **
+  (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
   (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
   ⌜c6New = 0⌝ **
   (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterExits.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterExits.lean
@@ -26,6 +26,7 @@ abbrev expTwoMulFixedIterMergedLoopPost
     (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb)
   let skipCondFrame : Assertion :=
     (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+    (.x20 ↦ᵣ c6New) **
     (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
     ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝
   let skipRest : Assertion :=
@@ -37,6 +38,7 @@ abbrev expTwoMulFixedIterMergedLoopPost
     memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
     (.x1 ↦ᵣ (((base + 44) + 32) + 68)) **
     (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+    (.x20 ↦ᵣ c6New) **
     (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
     ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝
   let skipCondRest : Assertion :=
@@ -53,6 +55,7 @@ abbrev expTwoMulFixedIterMergedLoopPost
     (.x1 ↦ᵣ (((base + 44) + 140) + 68))
   let reloadCondFrame : Assertion :=
     (.x19 ↦ᵣ nextLimb) **
+    (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
     (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
     ⌜c6New = 0⌝ **
     (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -67,6 +70,7 @@ abbrev expTwoMulFixedIterMergedLoopPost
     memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
     (.x1 ↦ᵣ (((base + 44) + 32) + 68)) **
     (.x19 ↦ᵣ nextLimb) **
+    (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
     (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
     ⌜c6New = 0⌝ **
     (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -104,6 +108,7 @@ abbrev expTwoMulFixedIterMergedExitPost
     (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb)
   let skipCondFrame : Assertion :=
     (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+    (.x20 ↦ᵣ c6New) **
     (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
     ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝
   let skipRest : Assertion :=
@@ -115,6 +120,7 @@ abbrev expTwoMulFixedIterMergedExitPost
     memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
     (.x1 ↦ᵣ (((base + 44) + 32) + 68)) **
     (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+    (.x20 ↦ᵣ c6New) **
     (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
     ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝
   let skipCondRest : Assertion :=
@@ -131,6 +137,7 @@ abbrev expTwoMulFixedIterMergedExitPost
     (.x1 ↦ᵣ (((base + 44) + 140) + 68))
   let reloadCondFrame : Assertion :=
     (.x19 ↦ᵣ nextLimb) **
+    (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
     (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
     ⌜c6New = 0⌝ **
     (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -145,6 +152,7 @@ abbrev expTwoMulFixedIterMergedExitPost
     memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
     (.x1 ↦ᵣ (((base + 44) + 32) + 68)) **
     (.x19 ↦ᵣ nextLimb) **
+    (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
     (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
     ⌜c6New = 0⌝ **
     (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterPreNPost.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterPreNPost.lean
@@ -536,13 +536,13 @@ theorem expTwoMulFixedIterCaseLoopPost_iterPreNWithControl_or_reloadPointerFrame
       (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
         r0 r1 r2 r3 a0 a1 a2 a3 base **
         frame) ps) :
-    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+    (∃ v7 v10 v11 d0 d1 d2 d3,
       let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
         a0 a1 a2 a3
       expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
         (c6 + signExtend12 (-1 : BitVec 12))
         (e <<< (1 : BitVec 6).toNat)
-        v6
+        (c6 + signExtend12 (-1 : BitVec 12))
         (expTwoMulIterCountNew iterCount)
         v10
         ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -556,12 +556,12 @@ theorem expTwoMulFixedIterCaseLoopPost_iterPreNWithControl_or_reloadPointerFrame
         (rw.getLimbN 3)
         a0 a1 a2 a3 v7 v11
         frame ps) ∨
-    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+    (∃ v7 v10 v11 d0 d1 d2 d3,
       let squareW := expSquaringCallSquareW r0 r1 r2 r3
       expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
         (c6 + signExtend12 (-1 : BitVec 12))
         (e <<< (1 : BitVec 6).toNat)
-        v6
+        (c6 + signExtend12 (-1 : BitVec 12))
         (expTwoMulIterCountNew iterCount)
         v10
         ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -595,13 +595,13 @@ theorem expTwoMulFixedIterCaseLoopPost_iterPreNWithControl_or_reloadPointerFrame
     hSkipCond | hRest
   · rcases hSkipCond with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
     exact Or.inl
-      ⟨(c6 + signExtend12 (-1 : BitVec 12)), v7, v10, v11, d0, d1, d2, d3,
+      ⟨v7, v10, v11, d0, d1, d2, d3,
         expTwoMulFixedIterSkipCondScratchFrame_to_iterPreNWithControl_frame
           hk hBase hCursor hControl hInv hScratch⟩
   · rcases hRest with hSkip | hRest
     · rcases hSkip with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
       exact Or.inr (Or.inl
-        ⟨(c6 + signExtend12 (-1 : BitVec 12)), v7, v10, v11, d0, d1, d2, d3,
+        ⟨v7, v10, v11, d0, d1, d2, d3,
           expTwoMulFixedIterSkipScratchFrame_to_iterPreNWithControl_frame
             hk hBase hCursor hControl hInv hScratch⟩)
     · rcases hRest with hReloadCond | hReloadSkip
@@ -755,13 +755,13 @@ theorem expTwoMulFixedIterCaseLoopPost_iterPreNWithControl_or_reloadWithControlF
       (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
         r0 r1 r2 r3 a0 a1 a2 a3 base **
         frame) ps) :
-    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+    (∃ v7 v10 v11 d0 d1 d2 d3,
       let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
         a0 a1 a2 a3
       expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
         (c6 + signExtend12 (-1 : BitVec 12))
         (e <<< (1 : BitVec 6).toNat)
-        v6
+        (c6 + signExtend12 (-1 : BitVec 12))
         (expTwoMulIterCountNew iterCount)
         v10
         ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -775,12 +775,12 @@ theorem expTwoMulFixedIterCaseLoopPost_iterPreNWithControl_or_reloadWithControlF
         (rw.getLimbN 3)
         a0 a1 a2 a3 v7 v11
         frame ps) ∨
-    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+    (∃ v7 v10 v11 d0 d1 d2 d3,
       let squareW := expSquaringCallSquareW r0 r1 r2 r3
       expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
         (c6 + signExtend12 (-1 : BitVec 12))
         (e <<< (1 : BitVec 6).toNat)
-        v6
+        (c6 + signExtend12 (-1 : BitVec 12))
         (expTwoMulIterCountNew iterCount)
         v10
         ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -865,13 +865,13 @@ theorem expTwoMulFixedIterCaseLoopPost_branchPreNWithControl_or_reloadWithContro
       (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
         r0 r1 r2 r3 a0 a1 a2 a3 base **
         frame) ps) :
-    (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
+    (∃ bit v7 v10 v11 d0 d1 d2 d3,
       let outW := expTwoMulFixedBranchResult bit
         a0 a1 a2 a3 r0 r1 r2 r3
       expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
         (c6 + signExtend12 (-1 : BitVec 12))
         (e <<< (1 : BitVec 6).toNat)
-        v6
+        (c6 + signExtend12 (-1 : BitVec 12))
         (expTwoMulIterCountNew iterCount)
         v10
         ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -920,15 +920,15 @@ theorem expTwoMulFixedIterCaseLoopPost_branchPreNWithControl_or_reloadWithContro
       expTwoMulFixedIterCaseLoopPost_iterPreNWithControl_or_reloadWithControlFrame
         hk hBase hCursor hControl hNextNext hInv h with
     hCond | hRest
-  · rcases hCond with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hPre⟩
+  · rcases hCond with ⟨v7, v10, v11, d0, d1, d2, d3, hPre⟩
     exact Or.inl
-      ⟨true, v6, v7, v10, v11, d0, d1, d2, d3, by
+      ⟨true, v7, v10, v11, d0, d1, d2, d3, by
         simpa [expTwoMulFixedBranchResult_true,
           expTwoMulFixedBranchReturnPc_true] using hPre⟩
   · rcases hRest with hSkip | hRest
-    · rcases hSkip with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hPre⟩
+    · rcases hSkip with ⟨v7, v10, v11, d0, d1, d2, d3, hPre⟩
       exact Or.inl
-        ⟨false, v6, v7, v10, v11, d0, d1, d2, d3, by
+        ⟨false, v7, v10, v11, d0, d1, d2, d3, by
           simpa [expTwoMulFixedBranchResult_false,
             expTwoMulFixedBranchReturnPc_false] using hPre⟩
     · exact Or.inr hRest
@@ -952,13 +952,13 @@ theorem expTwoMulFixedIterCaseLoopPost_branchPreNWithControl_or_branchReloadWith
       (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
         r0 r1 r2 r3 a0 a1 a2 a3 base **
         frame) ps) :
-    (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
+    (∃ bit v7 v10 v11 d0 d1 d2 d3,
       let outW := expTwoMulFixedBranchResult bit
         a0 a1 a2 a3 r0 r1 r2 r3
       expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
         (c6 + signExtend12 (-1 : BitVec 12))
         (e <<< (1 : BitVec 6).toNat)
-        v6
+        (c6 + signExtend12 (-1 : BitVec 12))
         (expTwoMulIterCountNew iterCount)
         v10
         ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterPreNPost.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterPreNPost.lean
@@ -213,6 +213,7 @@ theorem expTwoMulFixedIterSkipCondScratchFrame_to_iterPreN_frame
         (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2) (rw.getLimbN 3)
         a0 a1 a2 a3 v7 v11) **
         frame) ps := by
+    rw [hC6Reg]
     simpa [rw] using
       (expTwoMulFixedIterSkipCondScratchFrame_to_iterPre_frame h)
   rw [expTwoMulFixedIterPreNWithFrame_unfold,
@@ -312,6 +313,7 @@ theorem expTwoMulFixedIterSkipScratchFrame_to_iterPreN_frame
         (squareW.getLimbN 2) (squareW.getLimbN 3)
         a0 a1 a2 a3 v7 v11) **
         frame) ps := by
+    rw [hC6Reg]
     simpa [squareW] using
       (expTwoMulFixedIterSkipScratchFrame_to_iterPre_frame h)
   rw [expTwoMulFixedIterPreNWithFrame_unfold,
@@ -351,7 +353,7 @@ theorem expTwoMulFixedIterSkipCondScratchFrame_to_iterPreNWithControl_frame
     expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
       (c6 + signExtend12 (-1 : BitVec 12))
       (e <<< (1 : BitVec 6).toNat)
-      v6
+      (c6 + signExtend12 (-1 : BitVec 12))
       (expTwoMulIterCountNew iterCount)
       v10
       ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -394,7 +396,7 @@ theorem expTwoMulFixedIterSkipCondScratchFrame_to_iterPreNWithControl_frame
   have hPre :
       ((expTwoMulFixedIterPre
         (e <<< (1 : BitVec 6).toNat)
-        v6
+        (c6 + signExtend12 (-1 : BitVec 12))
         (expTwoMulIterCountNew iterCount)
         v10
         ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -445,7 +447,7 @@ theorem expTwoMulFixedIterSkipScratchFrame_to_iterPreNWithControl_frame
     expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
       (c6 + signExtend12 (-1 : BitVec 12))
       (e <<< (1 : BitVec 6).toNat)
-      v6
+      (c6 + signExtend12 (-1 : BitVec 12))
       (expTwoMulIterCountNew iterCount)
       v10
       ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -490,7 +492,7 @@ theorem expTwoMulFixedIterSkipScratchFrame_to_iterPreNWithControl_frame
   have hPre :
       ((expTwoMulFixedIterPre
         (e <<< (1 : BitVec 6).toNat)
-        v6
+        (c6 + signExtend12 (-1 : BitVec 12))
         (expTwoMulIterCountNew iterCount)
         v10
         ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -593,13 +595,13 @@ theorem expTwoMulFixedIterCaseLoopPost_iterPreNWithControl_or_reloadPointerFrame
     hSkipCond | hRest
   · rcases hSkipCond with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
     exact Or.inl
-      ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+      ⟨(c6 + signExtend12 (-1 : BitVec 12)), v7, v10, v11, d0, d1, d2, d3,
         expTwoMulFixedIterSkipCondScratchFrame_to_iterPreNWithControl_frame
           hk hBase hCursor hControl hInv hScratch⟩
   · rcases hRest with hSkip | hRest
     · rcases hSkip with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
       exact Or.inr (Or.inl
-        ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+        ⟨(c6 + signExtend12 (-1 : BitVec 12)), v7, v10, v11, d0, d1, d2, d3,
           expTwoMulFixedIterSkipScratchFrame_to_iterPreNWithControl_frame
             hk hBase hCursor hControl hInv hScratch⟩)
     · rcases hRest with hReloadCond | hReloadSkip

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterReloadPointerPures.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterReloadPointerPures.lean
@@ -46,7 +46,9 @@ theorem expTwoMulFixedIterReloadCondPointerScratchFrame_pures
   obtain ⟨_psRet, _psX19Tail, _hDisjointRet, _hUnionRet,
     _hRet, hX19Tail⟩ := hSuffix
   obtain ⟨_psX19, _psX18Tail, _hDisjointX19, _hUnionX19,
-    _hX19, hX18Tail⟩ := hX19Tail
+    _hX19, hX20Tail⟩ := hX19Tail
+  obtain ⟨_psX20, _psX18Tail2, _hDisjointX20, _hUnionX20,
+    _hX20, hX18Tail⟩ := hX20Tail
   obtain ⟨_psX18, _psC6Tail, _hDisjointX18, _hUnionX18,
     _hX18, hC6Tail⟩ := hX18Tail
   obtain ⟨_psC6, _psPtrTail, _hDisjointC6, _hUnionC6,
@@ -95,7 +97,9 @@ theorem expTwoMulFixedIterReloadSkipPointerScratchFrame_pures
   obtain ⟨_psRet, _psX19Tail, _hDisjointRet, _hUnionRet,
     _hRet, hX19Tail⟩ := hSuffix
   obtain ⟨_psX19, _psX18Tail, _hDisjointX19, _hUnionX19,
-    _hX19, hX18Tail⟩ := hX19Tail
+    _hX19, hX20Tail⟩ := hX19Tail
+  obtain ⟨_psX20, _psX18Tail2, _hDisjointX20, _hUnionX20,
+    _hX20, hX18Tail⟩ := hX20Tail
   obtain ⟨_psX18, _psC6Tail, _hDisjointX18, _hUnionX18,
     _hX18, hC6Tail⟩ := hX18Tail
   obtain ⟨_psC6, _psPtrTail, _hDisjointC6, _hUnionC6,

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
@@ -61,7 +61,7 @@ def expTwoMulFixedStateReloadFalsePre
     (base : Word) (frame : Assertion) : Assertion :=
   let squareW := expSquaringCallSquareW r0 r1 r2 r3
   expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-    64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
+    64 nextLimb (signExtend12 (64 : BitVec 12)) (expTwoMulIterCountNew iterCount) v10'
     ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
     (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
     (squareW.getLimbN 3) (((base + 44) + 32) + 68)
@@ -82,7 +82,7 @@ def expTwoMulFixedStateReloadTruePre
   let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
     a0 a1 a2 a3
   expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-    64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
+    64 nextLimb (signExtend12 (64 : BitVec 12)) (expTwoMulIterCountNew iterCount) v10'
     ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
     (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
     (rw.getLimbN 3) (((base + 44) + 140) + 68)

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
@@ -31,14 +31,14 @@ def expTwoMulFixedStateBranchPre
     (controlC6 e iterCount ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 : Word)
     (bit : Bool)
-    (v6' v7' v10' v11' d0' d1' d2' d3' : Word)
+    (v7' v10' v11' d0' d1' d2' d3' : Word)
     (base : Word) (frame : Assertion) : Assertion :=
   let outW := expTwoMulFixedBranchResult bit
     a0 a1 a2 a3 r0 r1 r2 r3
   expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
     (controlC6 + signExtend12 (-1 : BitVec 12))
     (e <<< (1 : BitVec 6).toNat)
-    v6'
+    (controlC6 + signExtend12 (-1 : BitVec 12))
     (expTwoMulIterCountNew iterCount)
     v10'
     ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -57,7 +57,7 @@ def expTwoMulFixedStateReloadFalsePre
     (k : Nat) (baseWord exponentWord : EvmWord)
     (e iterCount nextLimb ptr nextNextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 : Word)
-    (v6' v7' v10' v11' d0' d1' d2' d3' : Word)
+    (_v6' v7' v10' v11' d0' d1' d2' d3' : Word)
     (base : Word) (frame : Assertion) : Assertion :=
   let squareW := expSquaringCallSquareW r0 r1 r2 r3
   expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
@@ -77,7 +77,7 @@ def expTwoMulFixedStateReloadTruePre
     (k : Nat) (baseWord exponentWord : EvmWord)
     (e iterCount nextLimb ptr nextNextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 : Word)
-    (v6' v7' v10' v11' d0' d1' d2' d3' : Word)
+    (_v6' v7' v10' v11' d0' d1' d2' d3' : Word)
     (base : Word) (frame : Assertion) : Assertion :=
   let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
     a0 a1 a2 a3
@@ -119,12 +119,12 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_fixedBou
       nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
     (hBranch :
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit cr
           (expTwoMulFixedStateBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 bit
-            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
+            v7' v10' v11' d0' d1' d2' d3' base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -181,13 +181,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_sameCode
     (hBound : 193 ≤ nBound)
     (hBranch :
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStateBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 bit
-            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
+            v7' v10' v11' d0' d1' d2' d3' base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -239,13 +239,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_fixedBou
       nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
     (hBranch :
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStateBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 bit
-            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
+            v7' v10' v11' d0' d1' d2' d3' base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -298,13 +298,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_iteratio
       nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
     (hBranch :
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) exit cr
           (expTwoMulFixedStateBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 bit
-            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
+            v7' v10' v11' d0' d1' d2' d3' base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -354,14 +354,14 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_iteratio
       nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
     (hBranch :
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStateBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 bit
-            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
+            v7' v10' v11' d0' d1' d2' d3' base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -416,14 +416,14 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_reloadDi
       nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
     (hBranch :
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStateBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 bit
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadDirectTailFrame ptr nextNextLimb frame))
           Q)
     (hReloadFalse :
@@ -584,14 +584,14 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_iterationsBoun
     (hBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStateBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 bit
-            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
+            v7' v10' v11' d0' d1' d2' d3' base frame)
           (Q ** frame))
     (hReload :
       k < 255 →
@@ -660,14 +660,14 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_iterationsBoun
     (hBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStateBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 bit
-            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
+            v7' v10' v11' d0' d1' d2' d3' base frame)
           (Q ** frame))
     (hReload :
       k < 255 →
@@ -729,14 +729,14 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithState_head_iterationsBound_sam
     (hBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStateBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 bit
-            v6' v7' v10' v11' d0' d1' d2' d3' base empAssertion)
+            v7' v10' v11' d0' d1' d2' d3' base empAssertion)
           Q)
     (hReload :
       k < 255 →
@@ -777,13 +777,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithState_head_iterationsBound_sam
         sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
         a0 a1 a2 a3 v7 v11 base empAssertion Q (by pcFree) hbase
         hControlMachine hk hBase hNextNext
-        (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' =>
+        (fun hk_lt bit v7' v10' v11' d0' d1' d2' d3' =>
           cpsTripleWithin_weaken
             (fun _ h => h)
             (fun _ h => by
               rw [sepConj_emp_right']
               exact h)
-            (hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3'))
+            (hBranch hk_lt bit v7' v10' v11' d0' d1' d2' d3'))
         (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' =>
           cpsTripleWithin_weaken
             (fun _ h => h)

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
@@ -50,7 +50,7 @@ def expReloadDirectFalsePre
     (base : Word) (tail : Assertion) : Assertion :=
   let squareW := expSquaringCallSquareW r0 r1 r2 r3
   expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-    64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
+    64 nextLimb (signExtend12 (64 : BitVec 12)) (expTwoMulIterCountNew iterCount) v10'
     ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
     (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
     (squareW.getLimbN 3) (((base + 44) + 32) + 68)
@@ -71,7 +71,7 @@ def expReloadDirectTruePre
   let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
     a0 a1 a2 a3
   expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-    64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
+    64 nextLimb (signExtend12 (64 : BitVec 12)) (expTwoMulIterCountNew iterCount) v10'
     ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
     (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
     (rw.getLimbN 3) (((base + 44) + 140) + 68)

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
@@ -20,14 +20,14 @@ def expReloadDirectBranchPre
     (controlC6 e iterCount ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 : Word)
     (bit : Bool)
-    (v6' v7' v10' v11' d0' d1' d2' d3' : Word)
+    (v7' v10' v11' d0' d1' d2' d3' : Word)
     (base : Word) (tail : Assertion) : Assertion :=
   let outW := expTwoMulFixedBranchResult bit
     a0 a1 a2 a3 r0 r1 r2 r3
   expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
     (controlC6 + signExtend12 (-1 : BitVec 12))
     (e <<< (1 : BitVec 6).toNat)
-    v6'
+    (controlC6 + signExtend12 (-1 : BitVec 12))
     (expTwoMulIterCountNew iterCount)
     v10'
     ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -46,7 +46,7 @@ def expReloadDirectFalsePre
     (k : Nat) (baseWord exponentWord : EvmWord)
     (e iterCount nextLimb ptr nextNextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 : Word)
-    (v6' v7' v10' v11' d0' d1' d2' d3' : Word)
+    (v7' v10' v11' d0' d1' d2' d3' : Word)
     (base : Word) (tail : Assertion) : Assertion :=
   let squareW := expSquaringCallSquareW r0 r1 r2 r3
   expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
@@ -66,7 +66,7 @@ def expReloadDirectTruePre
     (k : Nat) (baseWord exponentWord : EvmWord)
     (e iterCount nextLimb ptr nextNextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 : Word)
-    (v6' v7' v10' v11' d0' d1' d2' d3' : Word)
+    (v7' v10' v11' d0' d1' d2' d3' : Word)
     (base : Word) (tail : Assertion) : Assertion :=
   let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
     a0 a1 a2 a3
@@ -105,39 +105,39 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
     (hBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expReloadDirectTailFrame ptr nextNextLimb frame))
           (Q ** expReloadDirectTailFrame ptr nextNextLimb frame))
     (hReloadFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadDirectFalseFrame controlC6 e iterCount ptr nextLimb
               frame))
           (Q ** expReloadDirectTailFrame ptr nextNextLimb frame))
     (hReloadTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadDirectTrueFrame controlC6 e iterCount ptr nextLimb
               frame))
           (Q ** expReloadDirectTailFrame ptr nextNextLimb frame))
@@ -169,10 +169,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
       (((ptr + signExtend12 (-8 : BitVec 12)) +
         signExtend12 (0 : BitVec 12) ↦ₘ nextNextLimb) ** frame)
       Q hFrameCurrent hbase hControlMachine hk hBase hNextNext
-      (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+      (fun hk_lt bit v7' v10' v11' d0' d1' d2' d3' => by
         simpa only [expReloadDirectBranchPre, expTwoMulFixedStateBranchPre,
           expReloadDirectTailFrame_unfold] using
-          hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
+          hBranch hk_lt bit v7' v10' v11' d0' d1' d2' d3')
       (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
         cases bit
         · exact
@@ -185,7 +185,7 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
                       expReloadDirectFalsePre,
                       expReloadDirectFalseFrame_unfold,
                       expReloadDirectTailFrame_unfold] using
-                      hReloadFalse hk_lt v6' v7' v10' v11' d0' d1' d2' d3'))
+                      hReloadFalse hk_lt v7' v10' v11' d0' d1' d2' d3'))
         · exact
             (by
               simpa only [expReloadDirectTailFrame_unfold] using
@@ -196,7 +196,7 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
                       expReloadDirectTruePre,
                       expReloadDirectTrueFrame_unfold,
                       expReloadDirectTailFrame_unfold] using
-                      hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3')))
+                      hReloadTrue hk_lt v7' v10' v11' d0' d1' d2' d3')))
       hExit
 
 /-- Convenience form of
@@ -219,39 +219,39 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_p
     (hBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTailFrame ptr nextNextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hReloadFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectFalseFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hReloadTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTrueFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
@@ -285,30 +285,30 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_p
         sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
         a0 a1 a2 a3 v7 v11 base empAssertion Q (by pcFree) hbase
         hControlMachine hk hBase hNextNext
-        (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' =>
+        (fun hk_lt bit v7' v10' v11' d0' d1' d2' d3' =>
           cpsTripleWithin_weaken
             (fun _ h => by
               simpa only [expReloadDirectBranchPre,
                 expReloadDirectTailFrame_emp] using h)
             (fun _ h => by
               simpa only [expReloadDirectTailFrame_emp] using h)
-            (hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3'))
-        (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' =>
+            (hBranch hk_lt bit v7' v10' v11' d0' d1' d2' d3'))
+        (fun hk_lt v7' v10' v11' d0' d1' d2' d3' =>
           cpsTripleWithin_weaken
             (fun _ h => by
               simpa only [expReloadDirectFalsePre,
                 expReloadDirectFalseFrame_emp] using h)
             (fun _ h => by
               simpa only [expReloadDirectTailFrame_emp] using h)
-            (hReloadFalse hk_lt v6' v7' v10' v11' d0' d1' d2' d3'))
-        (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' =>
+            (hReloadFalse hk_lt v7' v10' v11' d0' d1' d2' d3'))
+        (fun hk_lt v7' v10' v11' d0' d1' d2' d3' =>
           cpsTripleWithin_weaken
             (fun _ h => by
               simpa only [expReloadDirectTruePre,
                 expReloadDirectTrueFrame_emp] using h)
             (fun _ h => by
               simpa only [expReloadDirectTailFrame_emp] using h)
-            (hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3'))
+            (hReloadTrue hk_lt v7' v10' v11' d0' d1' d2' d3'))
         hExit)
 
 /-- Pointer-only direct head step with the current saved-limb cell expressed
@@ -329,39 +329,39 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
     (hBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTailFrame ptr nextNextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hReloadFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectFalseFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hReloadTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTrueFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
@@ -397,20 +397,20 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
         sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
         a0 a1 a2 a3 v7 v11 base Q hbase hControlMachine hk hBase
         hNextNext
-        (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+        (fun hk_lt bit v7' v10' v11' d0' d1' d2' d3' => by
           simpa only [expReloadDirectBranchPre,
             expReloadLimbDirectTailFrame_unfold] using
-            hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
-        (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
+            hBranch hk_lt bit v7' v10' v11' d0' d1' d2' d3')
+        (fun hk_lt v7' v10' v11' d0' d1' d2' d3' => by
           simpa only [expReloadDirectFalsePre,
             expReloadLimbDirectFalseFrame_unfold,
             expReloadLimbDirectTailFrame_unfold] using
-            hReloadFalse hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
-        (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
+            hReloadFalse hk_lt v7' v10' v11' d0' d1' d2' d3')
+        (fun hk_lt v7' v10' v11' d0' d1' d2' d3' => by
           simpa only [expReloadDirectTruePre,
             expReloadLimbDirectTrueFrame_unfold,
             expReloadLimbDirectTailFrame_unfold] using
-            hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
+            hReloadTrue hk_lt v7' v10' v11' d0' d1' d2' d3')
         hExit)
 
 /-- Ordinary no-reload direct head step with the saved-limb frame advanced to
@@ -432,39 +432,39 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
     (hBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTailFrame ptr nextNextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hReloadFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectFalseFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hReloadTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTrueFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
@@ -489,20 +489,20 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
       sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
       a0 a1 a2 a3 v7 v11 base Q hbase hControlMachine hk hBase
       hNextNext
-      (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+      (fun hk_lt bit v7' v10' v11' d0' d1' d2' d3' => by
         simpa only [expReloadDirectBranchPre,
           expReloadLimbDirectTailFrame_unfold] using
-          hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
-      (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
+          hBranch hk_lt bit v7' v10' v11' d0' d1' d2' d3')
+      (fun hk_lt v7' v10' v11' d0' d1' d2' d3' => by
         simpa only [expReloadDirectFalsePre,
           expReloadLimbDirectFalseFrame_unfold,
           expReloadLimbDirectTailFrame_unfold] using
-          hReloadFalse hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
-      (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
+          hReloadFalse hk_lt v7' v10' v11' d0' d1' d2' d3')
+      (fun hk_lt v7' v10' v11' d0' d1' d2' d3' => by
         simpa only [expReloadDirectTruePre,
           expReloadLimbDirectTrueFrame_unfold,
           expReloadLimbDirectTailFrame_unfold] using
-          hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
+          hReloadTrue hk_lt v7' v10' v11' d0' d1' d2' d3')
       hExit
   exact cpsTripleWithin_weaken
     (fun _ h => h)
@@ -531,39 +531,39 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
     (hBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTailFrame ptr nextNextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hReloadFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectFalseFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hReloadTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTrueFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
@@ -599,20 +599,20 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
         sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
         a0 a1 a2 a3 v7 v11 base Q hbase hControlMachine hk hBase
         hNextNext
-        (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+        (fun hk_lt bit v7' v10' v11' d0' d1' d2' d3' => by
           simpa only [expReloadDirectBranchPre,
             expReloadLimbDirectTailFrame_unfold] using
-            hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
-        (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
+            hBranch hk_lt bit v7' v10' v11' d0' d1' d2' d3')
+        (fun hk_lt v7' v10' v11' d0' d1' d2' d3' => by
           simpa only [expReloadDirectFalsePre,
             expReloadLimbDirectFalseFrame_unfold,
             expReloadLimbDirectTailFrame_unfold] using
-            hReloadFalse hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
-        (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
+            hReloadFalse hk_lt v7' v10' v11' d0' d1' d2' d3')
+        (fun hk_lt v7' v10' v11' d0' d1' d2' d3' => by
           simpa only [expReloadDirectTruePre,
             expReloadLimbDirectTrueFrame_unfold,
             expReloadLimbDirectTailFrame_unfold] using
-            hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
+            hReloadTrue hk_lt v7' v10' v11' d0' d1' d2' d3')
         hExit)
 
 /-- Control-invariant form of the reload-boundary direct head step.
@@ -640,39 +640,39 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
     (hBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTailFrame ptr nextNextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hReloadFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectFalseFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hReloadTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTrueFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
@@ -721,39 +721,39 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
     (hBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTailFrame ptr nextNextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hReloadFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectFalseFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
     (hReloadTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadLimbDirectTrueFrame controlC6 e iterCount ptr
               nextLimb))
           (Q ** expReloadLimbDirectTailFrame ptr nextNextLimb))
@@ -813,41 +813,41 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
     (hBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expReloadTailDirectTailFrameN exponentWord k ptr nextNextLimb))
           (Q ** expReloadTailDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hReloadFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadTailDirectFalseFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expReloadTailDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hReloadTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadTailDirectTrueFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expReloadTailDirectTailFrameN exponentWord k ptr
@@ -899,25 +899,25 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
             expTwoMulFixedSavedNextLimbFrame_unfold]
           pcFree)
         hbase hControlMachine hk hBase hNextNext
-        (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+        (fun hk_lt bit v7' v10' v11' d0' d1' d2' d3' => by
           simpa only [expReloadDirectBranchPre,
             expReloadDirectTailFrame_unfold,
             expReloadTailDirectTailFrameN_unfold] using
-            hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
-        (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
+            hBranch hk_lt bit v7' v10' v11' d0' d1' d2' d3')
+        (fun hk_lt v7' v10' v11' d0' d1' d2' d3' => by
           simpa only [expReloadDirectFalsePre,
             expReloadDirectFalseFrame_unfold,
             expReloadDirectTailFrame_unfold,
             expReloadTailDirectFalseFrameN_unfold,
             expReloadTailDirectTailFrameN_unfold] using
-            hReloadFalse hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
-      (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
+            hReloadFalse hk_lt v7' v10' v11' d0' d1' d2' d3')
+      (fun hk_lt v7' v10' v11' d0' d1' d2' d3' => by
           simpa only [expReloadDirectTruePre,
             expReloadDirectTrueFrame_unfold,
             expReloadDirectTailFrame_unfold,
             expReloadTailDirectTrueFrameN_unfold,
             expReloadTailDirectTailFrameN_unfold] using
-            hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
+            hReloadTrue hk_lt v7' v10' v11' d0' d1' d2' d3')
         hExit)
 
 /-- From-pre variant of
@@ -944,41 +944,41 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
     (hBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expReloadTailDirectTailFrameN exponentWord k ptr nextNextLimb))
           (Q ** expReloadTailDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hReloadFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadTailDirectFalseFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expReloadTailDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hReloadTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expReloadTailDirectTrueFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expReloadTailDirectTailFrameN exponentWord k ptr

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopPreReload.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopPreReload.lean
@@ -91,41 +91,41 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_p
     (hBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expPreReloadDirectTailFrameN exponentWord k ptr nextNextLimb))
           (Q ** expPreReloadDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hReloadFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expPreReloadDirectFalseFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expPreReloadDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hReloadTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expPreReloadDirectTrueFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expPreReloadDirectTailFrameN exponentWord k ptr
@@ -218,41 +218,41 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_p
     (hBranch :
       k < 255 →
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            bit v7' v10' v11' d0' d1' d2' d3' base
             (expPreReloadDirectTailFrameN exponentWord k ptr nextNextLimb))
           (Q ** expPreReloadDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hReloadFalse :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectFalsePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expPreReloadDirectFalseFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expPreReloadDirectTailFrameN exponentWord k ptr
             nextNextLimb))
     (hReloadTrue :
       k < 255 →
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expReloadDirectTruePre k baseWord exponentWord
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
-            v6' v7' v10' v11' d0' d1' d2' d3' base
+            v7' v10' v11' d0' d1' d2' d3' base
             (expPreReloadDirectTrueFrameN exponentWord k controlC6 e
               iterCount ptr nextLimb))
           (Q ** expPreReloadDirectTailFrameN exponentWord k ptr

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateResidualBridge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateResidualBridge.lean
@@ -30,7 +30,7 @@ def expTwoMulFixedReloadResidualFalseNextPre
     (k : Nat) (baseWord exponentWord : EvmWord)
     (iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base
-      v6 v7 v10 v11 d0 d1 d2 d3 : Word)
+      v7 v10 v11 d0 d1 d2 d3 : Word)
     (frame : Assertion) : Assertion :=
   let squareW := expSquaringCallSquareW r0 r1 r2 r3
   expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
@@ -51,7 +51,7 @@ def expTwoMulFixedReloadResidualTrueNextPre
     (k : Nat) (baseWord exponentWord : EvmWord)
     (iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base
-      v6 v7 v10 v11 d0 d1 d2 d3 : Word)
+      v7 v10 v11 d0 d1 d2 d3 : Word)
     (frame : Assertion) : Assertion :=
   let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
     a0 a1 a2 a3
@@ -111,7 +111,6 @@ theorem expTwoMulFixedReloadBranchResidualWithStateFrame_false_to_iterPreNWithSt
     expTwoMulFixedIterSkipRestScratchPrefix,
     expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame,
     expTwoMulFixedIterReloadPointerFrame_unfold,
-    expTwoMulFixedIterScratchIs,
     expTwoMulFixedIterBaseFrame,
     expTwoMulIterBaseFrame_unfold,
     signExtend12_0, signExtend12_8, signExtend12_16, signExtend12_24,
@@ -134,7 +133,7 @@ theorem cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_false_t
         (expTwoMulFixedReloadResidualFalseNextPre k baseWord exponentWord
           iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
           r0 r1 r2 r3 a0 a1 a2 a3 base
-          v6 v7 v10 v11 d0 d1 d2 d3 frame)
+          v7 v10 v11 d0 d1 d2 d3 frame)
         Q) :
     cpsTripleWithin nSteps entry exit cr
       (expTwoMulFixedReloadBranchResidualWithStateFrame false (k := k)
@@ -197,7 +196,6 @@ theorem expTwoMulFixedReloadBranchResidualWithStateFrame_true_to_iterPreNWithSta
     expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame,
     expTwoMulFixedIterSkipCondRestScratchSuffix,
     expTwoMulFixedIterReloadPointerFrame_unfold,
-    expTwoMulFixedIterScratchIs,
     expTwoMulIterBaseFrame_unfold,
     signExtend12_0, signExtend12_8, signExtend12_16, signExtend12_24,
     signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
@@ -219,7 +217,7 @@ theorem cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_true_to
         (expTwoMulFixedReloadResidualTrueNextPre k baseWord exponentWord
           iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
           r0 r1 r2 r3 a0 a1 a2 a3 base
-          v6 v7 v10 v11 d0 d1 d2 d3 frame)
+          v7 v10 v11 d0 d1 d2 d3 frame)
         Q) :
     cpsTripleWithin nSteps entry exit cr
       (expTwoMulFixedReloadBranchResidualWithStateFrame true (k := k)

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateResidualBridge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateResidualBridge.lean
@@ -12,6 +12,19 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
+/-- Weaken the per-iteration scratch frame's `x6` value slot to ownership.
+    After the counter moved to `x20`, the next `IterPre` keeps `x6` only as
+    `regOwn` scratch, so the reload residual's concrete `x6` value is dropped. -/
+private theorem expTwoMulFixedIterScratchIs_x6_to_regOwn_resid
+    {evmSp v6 v7 v10 v11 d0 d1 d2 d3 : Word} :
+    ∀ ps, expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 ps →
+      (regOwn .x6 ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
+       (evmSp ↦ₘ d0) ** ((evmSp + 8) ↦ₘ d1) ** ((evmSp + 16) ↦ₘ d2) **
+       ((evmSp + 24) ↦ₘ d3)) ps := by
+  intro ps h
+  unfold expTwoMulFixedIterScratchIs at h
+  exact sepConj_mono_left (regIs_implies_regOwn .x6) _ h
+
 @[irreducible]
 def expTwoMulFixedReloadResidualFalseNextPre
     (k : Nat) (baseWord exponentWord : EvmWord)
@@ -21,7 +34,7 @@ def expTwoMulFixedReloadResidualFalseNextPre
     (frame : Assertion) : Assertion :=
   let squareW := expSquaringCallSquareW r0 r1 r2 r3
   expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-    64 nextLimb v6 (expTwoMulIterCountNew iterCount) v10
+    64 nextLimb (signExtend12 (64 : BitVec 12)) (expTwoMulIterCountNew iterCount) v10
     ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
     (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
     (squareW.getLimbN 3) (((base + 44) + 32) + 68)
@@ -43,7 +56,7 @@ def expTwoMulFixedReloadResidualTrueNextPre
   let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
     a0 a1 a2 a3
   expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-    64 nextLimb v6 (expTwoMulIterCountNew iterCount) v10
+    64 nextLimb (signExtend12 (64 : BitVec 12)) (expTwoMulIterCountNew iterCount) v10
     ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
     (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
     (rw.getLimbN 3) (((base + 44) + 140) + 68)
@@ -72,7 +85,7 @@ theorem expTwoMulFixedReloadBranchResidualWithStateFrame_false_to_iterPreNWithSt
         (expReloadDirectTailFrame ptr nextNextLimb frame) ps) :
     let squareW := expSquaringCallSquareW r0 r1 r2 r3
     expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-      64 nextLimb v6 (expTwoMulIterCountNew iterCount) v10
+      64 nextLimb (signExtend12 (64 : BitVec 12)) (expTwoMulIterCountNew iterCount) v10
       ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
       (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
       (squareW.getLimbN 3) (((base + 44) + 32) + 68)
@@ -86,6 +99,9 @@ theorem expTwoMulFixedReloadBranchResidualWithStateFrame_false_to_iterPreNWithSt
   rw [expTwoMulFixedReloadBranchResidualWithStateFrame_false] at h
   dsimp
   rw [expReloadDirectTailFrame_unfold] at h
+  replace h := sepConj_mono_left
+    (sepConj_mono_right (sepConj_mono_left
+      expTwoMulFixedIterScratchIs_x6_to_regOwn_resid)) _ h
   rw [expTwoMulFixedIterPreNWithStateFrame_unfold,
     expTwoMulFixedIterPreNWithState_unfold,
     expTwoMulFixedIterPre_unfold,
@@ -154,7 +170,7 @@ theorem expTwoMulFixedReloadBranchResidualWithStateFrame_true_to_iterPreNWithSta
     let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
       a0 a1 a2 a3
     expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-      64 nextLimb v6 (expTwoMulIterCountNew iterCount) v10
+      64 nextLimb (signExtend12 (64 : BitVec 12)) (expTwoMulIterCountNew iterCount) v10
       ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
       (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
       (rw.getLimbN 3) (((base + 44) + 140) + 68)
@@ -168,6 +184,9 @@ theorem expTwoMulFixedReloadBranchResidualWithStateFrame_true_to_iterPreNWithSta
   rw [expTwoMulFixedReloadBranchResidualWithStateFrame_true] at h
   dsimp
   rw [expReloadDirectTailFrame_unfold] at h
+  replace h := sepConj_mono_left
+    (sepConj_mono_right (sepConj_mono_left
+      expTwoMulFixedIterScratchIs_x6_to_regOwn_resid)) _ h
   rw [expTwoMulFixedIterPreNWithStateFrame_unfold,
     expTwoMulFixedIterPreNWithState_unfold,
     expTwoMulFixedIterPre_unfold,

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateStep.lean
@@ -27,14 +27,14 @@ def expTwoMulFixedStateStepBranchPre
     (controlC6 e iterCount ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 : Word)
     (bit : Bool)
-    (v6 v7 v10 v11 d0 d1 d2 d3 : Word)
+    (v7 v10 v11 d0 d1 d2 d3 : Word)
     (base : Word) (frame : Assertion) : Assertion :=
   let outW := expTwoMulFixedBranchResult bit
     a0 a1 a2 a3 r0 r1 r2 r3
   expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
     (controlC6 + signExtend12 (-1 : BitVec 12))
     (e <<< (1 : BitVec 6).toNat)
-    v6
+    (controlC6 + signExtend12 (-1 : BitVec 12))
     (expTwoMulIterCountNew iterCount)
     v10
     ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -391,11 +391,11 @@ theorem expTwoMulFixedIterStepPostNWithControlFrame_branchState_or_reload
       expTwoMulFixedIterStepPostNWithControlFrame k baseWord exponentWord
         iterCount e controlC6 ptr nextLimb nextNextLimb sp evmSp
         r0 r1 r2 r3 a0 a1 a2 a3 base frame ps) :
-    (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
+    (∃ bit v7 v10 v11 d0 d1 d2 d3,
       expTwoMulFixedStateStepBranchPre k baseWord exponentWord
         controlC6 e iterCount ptr nextLimb sp evmSp
         r0 r1 r2 r3 a0 a1 a2 a3 bit
-        v6 v7 v10 v11 d0 d1 d2 d3 base frame ps) ∨
+        v7 v10 v11 d0 d1 d2 d3 base frame ps) ∨
     (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
       expTwoMulFixedReloadBranchResidualWithControlFrame bit (k := k)
         baseWord exponentWord iterCount e controlC6 ptr nextLimb
@@ -403,9 +403,9 @@ theorem expTwoMulFixedIterStepPostNWithControlFrame_branchState_or_reload
         v6 v7 v10 v11 d0 d1 d2 d3 frame ps) := by
   rcases expTwoMulFixedIterStepPostNWithControlFrame_cases h with
     hBranch | hReload
-  · rcases hBranch with ⟨bit, v6, v7, v10, v11, d0, d1, d2, d3, hPre⟩
+  · rcases hBranch with ⟨bit, v7, v10, v11, d0, d1, d2, d3, hPre⟩
     exact Or.inl
-      ⟨bit, v6, v7, v10, v11, d0, d1, d2, d3,
+      ⟨bit, v7, v10, v11, d0, d1, d2, d3,
         by
           simpa only [expTwoMulFixedStateStepBranchPre,
             expTwoMulFixedStepPostBranchPre] using
@@ -428,11 +428,11 @@ theorem expTwoMulFixedIterStepPostNWithControlFrame_branchState_or_reloadState
       expTwoMulFixedIterStepPostNWithControlFrame k baseWord exponentWord
         iterCount e controlC6 ptr nextLimb nextNextLimb sp evmSp
         r0 r1 r2 r3 a0 a1 a2 a3 base frame ps) :
-    (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
+    (∃ bit v7 v10 v11 d0 d1 d2 d3,
       expTwoMulFixedStateStepBranchPre k baseWord exponentWord
         controlC6 e iterCount ptr nextLimb sp evmSp
         r0 r1 r2 r3 a0 a1 a2 a3 bit
-        v6 v7 v10 v11 d0 d1 d2 d3 base frame ps) ∨
+        v7 v10 v11 d0 d1 d2 d3 base frame ps) ∨
     (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
       expTwoMulFixedReloadBranchResidualWithStateFrame bit (k := k)
         baseWord exponentWord iterCount e controlC6 ptr nextLimb
@@ -468,11 +468,11 @@ theorem expTwoMulFixedIterCaseLoopPost_branchState_or_reload
       (expTwoMulFixedIterCaseLoopPost iterCount e controlC6 ptr nextLimb sp evmSp
         r0 r1 r2 r3 a0 a1 a2 a3 base **
         frame) ps) :
-    (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
+    (∃ bit v7 v10 v11 d0 d1 d2 d3,
       expTwoMulFixedStateStepBranchPre k baseWord exponentWord
         controlC6 e iterCount ptr nextLimb sp evmSp
         r0 r1 r2 r3 a0 a1 a2 a3 bit
-        v6 v7 v10 v11 d0 d1 d2 d3 base frame ps) ∨
+        v7 v10 v11 d0 d1 d2 d3 base frame ps) ∨
     (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
       expTwoMulFixedReloadBranchResidualWithControlFrame bit (k := k)
         baseWord exponentWord iterCount e controlC6 ptr nextLimb
@@ -502,11 +502,11 @@ theorem expTwoMulFixedIterCaseLoopPost_branchState_or_reloadState
       (expTwoMulFixedIterCaseLoopPost iterCount e controlC6 ptr nextLimb sp evmSp
         r0 r1 r2 r3 a0 a1 a2 a3 base **
         frame) ps) :
-    (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
+    (∃ bit v7 v10 v11 d0 d1 d2 d3,
       expTwoMulFixedStateStepBranchPre k baseWord exponentWord
         controlC6 e iterCount ptr nextLimb sp evmSp
         r0 r1 r2 r3 a0 a1 a2 a3 bit
-        v6 v7 v10 v11 d0 d1 d2 d3 base frame ps) ∨
+        v7 v10 v11 d0 d1 d2 d3 base frame ps) ∨
     (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
       expTwoMulFixedReloadBranchResidualWithStateFrame bit (k := k)
         baseWord exponentWord iterCount e controlC6 ptr nextLimb
@@ -530,12 +530,12 @@ theorem cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_branchState_
     (hCount : expTwoMulFixedIterCountInvariant k iterCount)
     (hBranch :
       ∀ (bit : Bool)
-        (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
+        (v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
           (expTwoMulFixedStateStepBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 bit
-            v6 v7 v10 v11 d0 d1 d2 d3 base frame)
+            v7 v10 v11 d0 d1 d2 d3 base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -552,7 +552,7 @@ theorem cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_branchState_
         r0 r1 r2 r3 a0 a1 a2 a3 base frame)
       Q :=
   cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_elim
-    (fun bit v6 v7 v10 v11 d0 d1 d2 d3 =>
+    (fun bit v7 v10 v11 d0 d1 d2 d3 =>
       cpsTripleWithin_weaken
         (fun _ h =>
           expTwoMulFixedIterPreNWithControlFrame_to_iterPreNWithStateFrame
@@ -562,7 +562,7 @@ theorem cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_branchState_
         (fun _ h => h)
         (by
           simpa only [expTwoMulFixedStateStepBranchPre] using
-            hBranch bit v6 v7 v10 v11 d0 d1 d2 d3))
+            hBranch bit v7 v10 v11 d0 d1 d2 d3))
     hReload
 
 /-- CPS eliminator whose ordinary and reload continuations are both stated
@@ -577,12 +577,12 @@ theorem cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_state_elim
     (hCount : expTwoMulFixedIterCountInvariant k iterCount)
     (hBranch :
       ∀ (bit : Bool)
-        (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
+        (v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
           (expTwoMulFixedStateStepBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 bit
-            v6 v7 v10 v11 d0 d1 d2 d3 base frame)
+            v7 v10 v11 d0 d1 d2 d3 base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -626,12 +626,12 @@ theorem cpsTripleWithin_expTwoMulFixedIterCaseLoopPost_branchState_elim
         iterCount e controlC6 ptr nextLimb evmSp r0 r1 r2 r3)
     (hBranch :
       ∀ (bit : Bool)
-        (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
+        (v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
           (expTwoMulFixedStateStepBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 bit
-            v6 v7 v10 v11 d0 d1 d2 d3 base frame)
+            v7 v10 v11 d0 d1 d2 d3 base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -674,12 +674,12 @@ theorem cpsTripleWithin_expTwoMulFixedIterCaseLoopPost_state_elim
         iterCount e controlC6 ptr nextLimb evmSp r0 r1 r2 r3)
     (hBranch :
       ∀ (bit : Bool)
-        (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
+        (v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
           (expTwoMulFixedStateStepBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 bit
-            v6 v7 v10 v11 d0 d1 d2 d3 base frame)
+            v7 v10 v11 d0 d1 d2 d3 base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -765,12 +765,12 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step
     (hBound : 193 ≤ nBound)
     (hBranch :
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit cr
           (expTwoMulFixedStateStepBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 bit
-            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
+            v7' v10' v11' d0' d1' d2' d3' base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -826,12 +826,12 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithControlFrame_state_step_of_con
     (hBound : 193 ≤ nBound)
     (hBranch :
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit cr
           (expTwoMulFixedStateStepBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 bit
-            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
+            v7' v10' v11' d0' d1' d2' d3' base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -890,12 +890,12 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithState_state_step
     (hBound : 193 ≤ nBound)
     (hBranch :
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit cr
           (expTwoMulFixedStateStepBranchPre k baseWord exponentWord
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 bit
-            v6' v7' v10' v11' d0' d1' d2' d3' base empAssertion)
+            v7' v10' v11' d0' d1' d2' d3' base empAssertion)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -983,13 +983,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_stepPost_elim_of_co
     (hBound : 193 + nSteps ≤ nBound)
     (hBranch :
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e controlC6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base bit
-            v6' v7' v10' v11' d0' d1' d2' d3' frame)
+            v7' v10' v11' d0' d1' d2' d3' frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -1038,13 +1038,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithState_stepPost_elim_of_count_b
     (hBound : 193 + nSteps ≤ nBound)
     (hBranch :
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e controlC6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base bit
-            v6' v7' v10' v11' d0' d1' d2' d3' empAssertion)
+            v7' v10' v11' d0' d1' d2' d3' empAssertion)
           Q)
     (hReload :
       ∀ (bit : Bool)

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStep.lean
@@ -397,13 +397,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithControlFrame_stepPost_elim_of_
       nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
     (hBranch :
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e controlC6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base bit
-            v6' v7' v10' v11' d0' d1' d2' d3'
+            v7' v10' v11' d0' d1' d2' d3'
             frame)
           Q)
     (hReload :
@@ -450,23 +450,23 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithControlFrame_stepPost_bit_elim
     (hNextNext :
       nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
     (hBranchTrue :
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e controlC6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base true
-            v6' v7' v10' v11' d0' d1' d2' d3'
+            v7' v10' v11' d0' d1' d2' d3'
             frame)
           Q)
     (hBranchFalse :
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e controlC6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base false
-            v6' v7' v10' v11' d0' d1' d2' d3'
+            v7' v10' v11' d0' d1' d2' d3'
             frame)
           Q)
     (hReloadTrue :
@@ -528,13 +528,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_stepPost_elim
       nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
     (hBranch :
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e c6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base bit
-            v6' v7' v10' v11' d0' d1' d2' d3'
+            v7' v10' v11' d0' d1' d2' d3'
             frame)
           Q)
     (hReload :
@@ -579,23 +579,23 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_stepPost_bit_elim
     (hNextNext :
       nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
     (hBranchTrue :
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e c6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base true
-            v6' v7' v10' v11' d0' d1' d2' d3'
+            v7' v10' v11' d0' d1' d2' d3'
             frame)
           Q)
     (hBranchFalse :
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e c6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base false
-            v6' v7' v10' v11' d0' d1' d2' d3'
+            v7' v10' v11' d0' d1' d2' d3'
             frame)
           Q)
     (hReloadTrue :
@@ -736,13 +736,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPre_stepPostNWithControl_elim
         r0 r1 r2 r3)
     (hBranch :
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e c6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base bit
-            v6' v7' v10' v11' d0' d1' d2' d3'
+            v7' v10' v11' d0' d1' d2' d3'
             empAssertion)
           Q)
     (hReload :
@@ -794,13 +794,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPre_stepPostNWithControlFrame_elim
         r0 r1 r2 r3)
     (hBranch :
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e c6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base bit
-            v6' v7' v10' v11' d0' d1' d2' d3'
+            v7' v10' v11' d0' d1' d2' d3'
             frame)
           Q)
     (hReload :
@@ -851,23 +851,23 @@ theorem cpsTripleWithin_expTwoMulFixedIterPre_stepPostNWithControl_bit_elim
       expTwoMulFixedAccumulatorInvariant baseWord exponentWord k
         r0 r1 r2 r3)
     (hBranchTrue :
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e c6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base true
-            v6' v7' v10' v11' d0' d1' d2' d3'
+            v7' v10' v11' d0' d1' d2' d3'
             empAssertion)
           Q)
     (hBranchFalse :
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e c6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base false
-            v6' v7' v10' v11' d0' d1' d2' d3'
+            v7' v10' v11' d0' d1' d2' d3'
             empAssertion)
           Q)
     (hReloadTrue :
@@ -933,23 +933,23 @@ theorem cpsTripleWithin_expTwoMulFixedIterPre_stepPostNWithControlFrame_bit_elim
       expTwoMulFixedAccumulatorInvariant baseWord exponentWord k
         r0 r1 r2 r3)
     (hBranchTrue :
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e c6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base true
-            v6' v7' v10' v11' d0' d1' d2' d3'
+            v7' v10' v11' d0' d1' d2' d3'
             frame)
           Q)
     (hBranchFalse :
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e c6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base false
-            v6' v7' v10' v11' d0' d1' d2' d3'
+            v7' v10' v11' d0' d1' d2' d3'
             frame)
           Q)
     (hReloadTrue :

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStepBounds.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStepBounds.lean
@@ -250,13 +250,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithControlFrame_stepPost_elim_bou
     (hBound : 193 + nSteps ≤ nBound)
     (hBranch :
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e controlC6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base bit
-            v6' v7' v10' v11' d0' d1' d2' d3' frame)
+            v7' v10' v11' d0' d1' d2' d3' frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -304,13 +304,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_stepPost_elim_bound
     (hBound : 193 + nSteps ≤ nBound)
     (hBranch :
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e controlC6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base bit
-            v6' v7' v10' v11' d0' d1' d2' d3' frame)
+            v7' v10' v11' d0' d1' d2' d3' frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -356,22 +356,22 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithControlFrame_stepPost_bit_elim
       nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
     (hBound : 193 + nSteps ≤ nBound)
     (hBranchTrue :
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e controlC6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base true
-            v6' v7' v10' v11' d0' d1' d2' d3' frame)
+            v7' v10' v11' d0' d1' d2' d3' frame)
           Q)
     (hBranchFalse :
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e controlC6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base false
-            v6' v7' v10' v11' d0' d1' d2' d3' frame)
+            v7' v10' v11' d0' d1' d2' d3' frame)
           Q)
     (hReloadTrue :
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
@@ -431,22 +431,22 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_stepPost_bit_elim_b
       nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
     (hBound : 193 + nSteps ≤ nBound)
     (hBranchTrue :
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e controlC6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base true
-            v6' v7' v10' v11' d0' d1' d2' d3' frame)
+            v7' v10' v11' d0' d1' d2' d3' frame)
           Q)
     (hBranchFalse :
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e controlC6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base false
-            v6' v7' v10' v11' d0' d1' d2' d3' frame)
+            v7' v10' v11' d0' d1' d2' d3' frame)
           Q)
     (hReloadTrue :
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
@@ -501,13 +501,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_stepPost_elim_bounded
     (hBound : 193 + nSteps ≤ nBound)
     (hBranch :
       ∀ (bit : Bool)
-        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e c6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base bit
-            v6' v7' v10' v11' d0' d1' d2' d3' frame)
+            v7' v10' v11' d0' d1' d2' d3' frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -552,22 +552,22 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_stepPost_bit_elim_bounde
       nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
     (hBound : 193 + nSteps ≤ nBound)
     (hBranchTrue :
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e c6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base true
-            v6' v7' v10' v11' d0' d1' d2' d3' frame)
+            v7' v10' v11' d0' d1' d2' d3' frame)
           Q)
     (hBranchFalse :
-      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+      ∀ (v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e c6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base false
-            v6' v7' v10' v11' d0' d1' d2' d3' frame)
+            v7' v10' v11' d0' d1' d2' d3' frame)
           Q)
     (hReloadTrue :
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStepPost.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStepPost.lean
@@ -17,13 +17,13 @@ def expTwoMulFixedIterStepPostNWithControlFrame
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word)
     (frame : Assertion) : Assertion :=
   fun ps =>
-    (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
+    (∃ bit v7 v10 v11 d0 d1 d2 d3,
       let outW := expTwoMulFixedBranchResult bit
         a0 a1 a2 a3 r0 r1 r2 r3
       expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
         (c6 + signExtend12 (-1 : BitVec 12))
         (e <<< (1 : BitVec 6).toNat)
-        v6
+        (c6 + signExtend12 (-1 : BitVec 12))
         (expTwoMulIterCountNew iterCount)
         v10
         ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -52,13 +52,13 @@ theorem expTwoMulFixedIterStepPostNWithControlFrame_unfold
       iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base frame =
     (fun ps =>
-      (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
+      (∃ bit v7 v10 v11 d0 d1 d2 d3,
         let outW := expTwoMulFixedBranchResult bit
           a0 a1 a2 a3 r0 r1 r2 r3
         expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
           (c6 + signExtend12 (-1 : BitVec 12))
           (e <<< (1 : BitVec 6).toNat)
-          v6
+          (c6 + signExtend12 (-1 : BitVec 12))
           (expTwoMulIterCountNew iterCount)
           v10
           ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -86,14 +86,14 @@ def expTwoMulFixedStepPostBranchPre
     (iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word)
     (bit : Bool)
-    (v6 v7 v10 v11 d0 d1 d2 d3 : Word)
+    (v7 v10 v11 d0 d1 d2 d3 : Word)
     (frame : Assertion) : Assertion :=
   let outW := expTwoMulFixedBranchResult bit
     a0 a1 a2 a3 r0 r1 r2 r3
   expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
     (c6 + signExtend12 (-1 : BitVec 12))
     (e <<< (1 : BitVec 6).toNat)
-    v6
+    (c6 + signExtend12 (-1 : BitVec 12))
     (expTwoMulIterCountNew iterCount)
     v10
     ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -118,7 +118,7 @@ theorem expTwoMulFixedIterStepPostNWithControlFrame_pcFree
   intro ps hps
   rw [expTwoMulFixedIterStepPostNWithControlFrame_unfold] at hps
   rcases hps with hPre | hReload
-  · rcases hPre with ⟨bit, v6, v7, v10, v11, d0, d1, d2, d3, hPre⟩
+  · rcases hPre with ⟨bit, v7, v10, v11, d0, d1, d2, d3, hPre⟩
     exact
       (inferInstance :
         Assertion.PCFree
@@ -127,7 +127,7 @@ theorem expTwoMulFixedIterStepPostNWithControlFrame_pcFree
           expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
             (c6 + signExtend12 (-1 : BitVec 12))
             (e <<< (1 : BitVec 6).toNat)
-            v6
+            (c6 + signExtend12 (-1 : BitVec 12))
             (expTwoMulIterCountNew iterCount)
             v10
             ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -199,14 +199,14 @@ theorem expTwoMulFixedIterStepPostNWithControlFrame_branch
     {iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
     {frame : Assertion} {ps : PartialState}
-    (bit : Bool) {v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    (bit : Bool) {v7 v10 v11 d0 d1 d2 d3 : Word}
     (h :
       let outW := expTwoMulFixedBranchResult bit
         a0 a1 a2 a3 r0 r1 r2 r3
       expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
         (c6 + signExtend12 (-1 : BitVec 12))
         (e <<< (1 : BitVec 6).toNat)
-        v6
+        (c6 + signExtend12 (-1 : BitVec 12))
         (expTwoMulIterCountNew iterCount)
         v10
         ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -224,7 +224,7 @@ theorem expTwoMulFixedIterStepPostNWithControlFrame_branch
       iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base frame ps := by
   rw [expTwoMulFixedIterStepPostNWithControlFrame_unfold]
-  exact Or.inl ⟨bit, v6, v7, v10, v11, d0, d1, d2, d3, h⟩
+  exact Or.inl ⟨bit, v7, v10, v11, d0, d1, d2, d3, h⟩
 
 theorem expTwoMulFixedIterStepPostNWithControlFrame_reload
     {baseWord exponentWord : EvmWord} {k : Nat}
@@ -248,12 +248,12 @@ theorem expTwoMulFixedIterStepPostNWithControlFrame_branch_true
     {iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
     {frame : Assertion} {ps : PartialState}
-    {v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    {v7 v10 v11 d0 d1 d2 d3 : Word}
     (h :
       expTwoMulFixedStepPostBranchPre k baseWord exponentWord
         iterCount e c6 ptr nextLimb sp evmSp
         r0 r1 r2 r3 a0 a1 a2 a3 base true
-        v6 v7 v10 v11 d0 d1 d2 d3 frame ps) :
+        v7 v10 v11 d0 d1 d2 d3 frame ps) :
     expTwoMulFixedIterStepPostNWithControlFrame k baseWord exponentWord
       iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base frame ps := by
@@ -265,12 +265,12 @@ theorem expTwoMulFixedIterStepPostNWithControlFrame_branch_false
     {iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
     {frame : Assertion} {ps : PartialState}
-    {v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    {v7 v10 v11 d0 d1 d2 d3 : Word}
     (h :
       expTwoMulFixedStepPostBranchPre k baseWord exponentWord
         iterCount e c6 ptr nextLimb sp evmSp
         r0 r1 r2 r3 a0 a1 a2 a3 base false
-        v6 v7 v10 v11 d0 d1 d2 d3 frame ps) :
+        v7 v10 v11 d0 d1 d2 d3 frame ps) :
     expTwoMulFixedIterStepPostNWithControlFrame k baseWord exponentWord
       iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base frame ps := by
@@ -451,13 +451,13 @@ theorem expTwoMulFixedIterStepPostNWithControlFrame_cases
       expTwoMulFixedIterStepPostNWithControlFrame k baseWord exponentWord
         iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
         r0 r1 r2 r3 a0 a1 a2 a3 base frame ps) :
-    (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
+    (∃ bit v7 v10 v11 d0 d1 d2 d3,
       let outW := expTwoMulFixedBranchResult bit
         a0 a1 a2 a3 r0 r1 r2 r3
       expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
         (c6 + signExtend12 (-1 : BitVec 12))
         (e <<< (1 : BitVec 6).toNat)
-        v6
+        (c6 + signExtend12 (-1 : BitVec 12))
         (expTwoMulIterCountNew iterCount)
         v10
         ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -486,13 +486,13 @@ theorem expTwoMulFixedIterStepPostNWithControlFrame_elim
     {frame Q : Assertion} {ps : PartialState}
     (hBranch :
       ∀ (bit : Bool)
-        (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
+        (v7 v10 v11 d0 d1 d2 d3 : Word),
         (let outW := expTwoMulFixedBranchResult bit
           a0 a1 a2 a3 r0 r1 r2 r3
         expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
           (c6 + signExtend12 (-1 : BitVec 12))
           (e <<< (1 : BitVec 6).toNat)
-          v6
+          (c6 + signExtend12 (-1 : BitVec 12))
           (expTwoMulIterCountNew iterCount)
           v10
           ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
@@ -522,8 +522,8 @@ theorem expTwoMulFixedIterStepPostNWithControlFrame_elim
     Q ps := by
   rcases expTwoMulFixedIterStepPostNWithControlFrame_cases h with
     hNext | hReloadCase
-  · rcases hNext with ⟨bit, v6, v7, v10, v11, d0, d1, d2, d3, hNext⟩
-    exact hBranch bit v6 v7 v10 v11 d0 d1 d2 d3 hNext
+  · rcases hNext with ⟨bit, v7, v10, v11, d0, d1, d2, d3, hNext⟩
+    exact hBranch bit v7 v10 v11 d0 d1 d2 d3 hNext
   · rcases hReloadCase with
       ⟨bit, v6, v7, v10, v11, d0, d1, d2, d3, hResidual⟩
     exact hReload bit v6 v7 v10 v11 d0 d1 d2 d3 hResidual
@@ -548,7 +548,7 @@ theorem expTwoMulFixedIterStepPostNWithControlFrame_attach_frame
       expTwoMulFixedIterStepPostNWithControlFrame k baseWord exponentWord
         iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
         r0 r1 r2 r3 a0 a1 a2 a3 base frame ps)
-    (fun bit v6 v7 v10 v11 d0 d1 d2 d3 hNext _hEq => by
+    (fun bit v7 v10 v11 d0 d1 d2 d3 hNext _hEq => by
       apply expTwoMulFixedIterStepPostNWithControlFrame_branch (bit := bit)
       simp only [expTwoMulFixedIterPreNWithControlFrame_unfold] at hNext ⊢
       exact ⟨psStep, psFrame, hDisjoint, hUnion,
@@ -574,12 +574,12 @@ theorem cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_elim
     {frame Q : Assertion}
     (hBranch :
       ∀ (bit : Bool)
-        (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
+        (v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e c6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base bit
-            v6 v7 v10 v11 d0 d1 d2 d3 frame)
+            v7 v10 v11 d0 d1 d2 d3 frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -604,8 +604,8 @@ theorem cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_elim
         ∃ kExec, kExec ≤ nSteps ∧ ∃ s',
           stepN kExec s = some s' ∧ s'.pc = exit ∧
             (Q ** R).holdsFor s')
-      (fun bit v6 v7 v10 v11 d0 d1 d2 d3 hNext =>
-        hBranch bit v6 v7 v10 v11 d0 d1 d2 d3
+      (fun bit v7 v10 v11 d0 d1 d2 d3 hNext =>
+        hBranch bit v7 v10 v11 d0 d1 d2 d3
           R hR s hcr
           ⟨hp, hcompat,
             ⟨hStep, hFrame, hdisj, hunion,
@@ -628,20 +628,20 @@ theorem cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_bit_elim
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
     {frame Q : Assertion}
     (hBranchTrue :
-      ∀ (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
+      ∀ (v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e c6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base true
-            v6 v7 v10 v11 d0 d1 d2 d3 frame)
+            v7 v10 v11 d0 d1 d2 d3 frame)
           Q)
     (hBranchFalse :
-      ∀ (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
+      ∀ (v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e c6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base false
-            v6 v7 v10 v11 d0 d1 d2 d3 frame)
+            v7 v10 v11 d0 d1 d2 d3 frame)
           Q)
     (hReloadTrue :
       ∀ (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
@@ -801,12 +801,12 @@ theorem cpsTripleWithin_expTwoMulFixedIterCaseLoopPost_stepPostNWithControlFrame
         r0 r1 r2 r3)
     (hBranch :
       ∀ (bit : Bool)
-        (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
+        (v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e c6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base bit
-            v6 v7 v10 v11 d0 d1 d2 d3 frame)
+            v7 v10 v11 d0 d1 d2 d3 frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -847,20 +847,20 @@ theorem cpsTripleWithin_expTwoMulFixedIterCaseLoopPost_stepPostNWithControlFrame
       expTwoMulFixedAccumulatorInvariant baseWord exponentWord k
         r0 r1 r2 r3)
     (hBranchTrue :
-      ∀ (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
+      ∀ (v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e c6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base true
-            v6 v7 v10 v11 d0 d1 d2 d3 frame)
+            v7 v10 v11 d0 d1 d2 d3 frame)
           Q)
     (hBranchFalse :
-      ∀ (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
+      ∀ (v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
           (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
             iterCount e c6 ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3 base false
-            v6 v7 v10 v11 d0 d1 d2 d3 frame)
+            v7 v10 v11 d0 d1 d2 d3 frame)
           Q)
     (hReloadTrue :
       ∀ (v6 v7 v10 v11 d0 d1 d2 d3 : Word),

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedWithMul.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedWithMul.lean
@@ -101,7 +101,7 @@ theorem exp_prologue_fixed_then_pointer_advance_full_stack_evmExpMsbSavedBitTwoM
         base mulTarget squaringMulOff condMulOff skipOff backOff)
       ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
        (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
-       (.x6 ↦ᵣ c6Old) ** (.x16 ↦ᵣ c16Old) ** (.x19 ↦ᵣ c19Old) **
+       (.x20 ↦ᵣ c6Old) ** (.x16 ↦ᵣ c16Old) ** (.x19 ↦ᵣ c19Old) **
        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
@@ -608,7 +608,7 @@ def expTwoMulFixedIterPre
     (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
       r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
       v7 v11 : Word) : Assertion :=
-  ((((((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+  ((((((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** regOwn .x6 ** (.x10 ↦ᵣ v10) **
     (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
     (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
     ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
@@ -633,7 +633,7 @@ theorem expTwoMulFixedIterPre_unfold
       v7 v11 : Word} :
     expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld
       vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 =
-      ((((((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+      ((((((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** regOwn .x6 ** (.x10 ↦ᵣ v10) **
         (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
         ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
@@ -868,6 +868,7 @@ theorem exp_msb_bit_test_fixed_full_iter_merged_exit_branch_evmExpMsbSavedBitTwo
       (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb)
     let skipCondFrame : Assertion :=
       (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+      (.x20 ↦ᵣ c6New) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝
     let skipRest : Assertion :=
@@ -879,6 +880,7 @@ theorem exp_msb_bit_test_fixed_full_iter_merged_exit_branch_evmExpMsbSavedBitTwo
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
       (.x1 ↦ᵣ (((base + 44) + 32) + 68)) **
       (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+      (.x20 ↦ᵣ c6New) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝
     let skipCondRest : Assertion :=
@@ -895,6 +897,7 @@ theorem exp_msb_bit_test_fixed_full_iter_merged_exit_branch_evmExpMsbSavedBitTwo
       (.x1 ↦ᵣ (((base + 44) + 140) + 68))
     let reloadCondFrame : Assertion :=
       (.x19 ↦ᵣ nextLimb) **
+      (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New = 0⌝ **
       (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -909,6 +912,7 @@ theorem exp_msb_bit_test_fixed_full_iter_merged_exit_branch_evmExpMsbSavedBitTwo
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
       (.x1 ↦ᵣ (((base + 44) + 32) + 68)) **
       (.x19 ↦ᵣ nextLimb) **
+      (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New = 0⌝ **
       (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -956,28 +960,61 @@ theorem exp_msb_bit_test_fixed_full_iter_merged_exit_branch_evmExpMsbSavedBitTwo
     reloadCondFrame reloadSkipRest reloadCondRest skipLoopPost skipExitPost
     reloadLoopPost reloadExitPost
   have hExit : ((base + 44) + 252 : Word) = base + 296 := by bv_addr
-  have h :=
-    exp_msb_bit_test_fixed_full_iter_merged_exit_branch_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
-      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
-      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
-      v7 v11 (base + 336) (base + 44)
-      EvmAsm.Evm64.canonicalExpSquaringMulOff
-      EvmAsm.Evm64.canonicalExpCondMulOff
-      EvmAsm.Evm64.canonicalExpCondMulSkipOff
-      EvmAsm.Evm64.canonicalExpMsbSavedBitFixedLoopBackOff
-      (base + 44) hbase
-      (EvmAsm.Evm64.canonicalExpFixedSquaringMul_target base).symm
-      (EvmAsm.Evm64.canonicalExpFixedCondMul_target base).symm
-      (EvmAsm.Evm64.canonicalExpFixedCondMulSkip_target base)
-      (EvmAsm.Evm64.canonicalExpMsbSavedBitFixedLoopBack_target base)
-      (expIterBodyFullMsbSavedBitTwoMulFixedCanonicalCode_disjoint_appended_mul base)
-  rw [hExit] at h
-  rw [← expIterBodyFullMsbSavedBitTwoMulFixedCanonicalAppendedMulCode_eq base] at h
-  rw [expTwoMulFixedIterPre_unfold, expTwoMulIterBaseFrame_unfold,
-    expTwoMulFixedIterPointerFrame_unfold]
-  exact
-    cpsBranchWithin_extend_iter_body_union_evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode
-      h
+  refine cpsBranchWithin_weaken
+    (fun _ hp => by
+      rw [expTwoMulFixedIterPre_unfold, expTwoMulIterBaseFrame_unfold,
+        expTwoMulFixedIterPointerFrame_unfold] at hp
+      xperm_hyp hp)
+    (fun _ hp => hp) (fun _ hp => hp)
+    (cpsBranchWithin_of_forall_regIs_to_regOwn (r := .x6)
+      (P :=
+        (.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+        (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+        ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+        ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+        ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+        ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+        ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+        (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) ** (.x1 ↦ᵣ vOld) **
+        (.x9 ↦ᵣ iterCount) **
+        ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+        ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+        ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+        ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+        (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb))
+      (fun v6 => by
+        have h :=
+          exp_msb_bit_test_fixed_full_iter_merged_exit_branch_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
+            e c6 v6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+            r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+            v7 v11 (base + 336) (base + 44)
+            EvmAsm.Evm64.canonicalExpSquaringMulOff
+            EvmAsm.Evm64.canonicalExpCondMulOff
+            EvmAsm.Evm64.canonicalExpCondMulSkipOff
+            EvmAsm.Evm64.canonicalExpMsbSavedBitFixedLoopBackOff
+            (base + 44) hbase
+            (EvmAsm.Evm64.canonicalExpFixedSquaringMul_target base).symm
+            (EvmAsm.Evm64.canonicalExpFixedCondMul_target base).symm
+            (EvmAsm.Evm64.canonicalExpFixedCondMulSkip_target base)
+            (EvmAsm.Evm64.canonicalExpMsbSavedBitFixedLoopBack_target base)
+            (expIterBodyFullMsbSavedBitTwoMulFixedCanonicalCode_disjoint_appended_mul base)
+        rw [hExit] at h
+        rw [← expIterBodyFullMsbSavedBitTwoMulFixedCanonicalAppendedMulCode_eq base] at h
+        have h' :=
+          cpsBranchWithin_extend_iter_body_union_evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode
+            h
+        refine cpsBranchWithin_weaken ?_ (fun _ hp => hp) (fun _ hp => hp) h'
+        intro st hp
+        dsimp only [] at hp ⊢
+        xperm_hyp hp))
 
 /-- N-branch view of the canonical-appended whole-code fixed x19 merged
     full-iteration spec. -/
@@ -1000,6 +1037,7 @@ theorem exp_msb_bit_test_fixed_full_iter_merged_exit_nbranch_evmExpMsbSavedBitTw
       (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb)
     let skipCondFrame : Assertion :=
       (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+      (.x20 ↦ᵣ c6New) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝
     let skipRest : Assertion :=
@@ -1011,6 +1049,7 @@ theorem exp_msb_bit_test_fixed_full_iter_merged_exit_nbranch_evmExpMsbSavedBitTw
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
       (.x1 ↦ᵣ (((base + 44) + 32) + 68)) **
       (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+      (.x20 ↦ᵣ c6New) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝
     let skipCondRest : Assertion :=
@@ -1027,6 +1066,7 @@ theorem exp_msb_bit_test_fixed_full_iter_merged_exit_nbranch_evmExpMsbSavedBitTw
       (.x1 ↦ᵣ (((base + 44) + 140) + 68))
     let reloadCondFrame : Assertion :=
       (.x19 ↦ᵣ nextLimb) **
+      (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New = 0⌝ **
       (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
@@ -1041,6 +1081,7 @@ theorem exp_msb_bit_test_fixed_full_iter_merged_exit_nbranch_evmExpMsbSavedBitTw
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
       (.x1 ↦ᵣ (((base + 44) + 32) + 68)) **
       (.x19 ↦ᵣ nextLimb) **
+      (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜c6New = 0⌝ **
       (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **

--- a/EvmAsm/Evm64/Exp/LimbSpec.lean
+++ b/EvmAsm/Evm64/Exp/LimbSpec.lean
@@ -1142,7 +1142,7 @@ theorem exp_prologue_fixed_spec_within
     cpsTripleWithin 10 base (base + 40) (exp_prologue_fixed_code base)
       ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
        (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
-       (.x6 ↦ᵣ c6Old) ** (.x16 ↦ᵣ c16Old) ** (.x19 ↦ᵣ c19Old) **
+       (.x20 ↦ᵣ c6Old) ** (.x16 ↦ᵣ c16Old) ** (.x19 ↦ᵣ c19Old) **
        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
@@ -1152,7 +1152,7 @@ theorem exp_prologue_fixed_spec_within
        (.x9 ↦ᵣ ((0 : Word) + signExtend12 (256 : BitVec 12))) **
        (.x5 ↦ᵣ ((0 : Word) + signExtend12 (1 : BitVec 12))) **
        (.x12 ↦ᵣ evmSp) **
-       (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+       (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
        (.x16 ↦ᵣ evmSp + signExtend12 (56 : BitVec 12) + signExtend12 (-8 : BitVec 12)) **
        (.x19 ↦ᵣ expLimb3) **
        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ
@@ -1167,7 +1167,7 @@ theorem exp_prologue_fixed_spec_within
   have hSd1 := generic_sd_spec_within .x2 .x0 sp (0:Word) m1 (8:BitVec 12) (base+12)
   have hSd2 := generic_sd_spec_within .x2 .x0 sp (0:Word) m2 (16:BitVec 12) (base+16)
   have hSd3 := generic_sd_spec_within .x2 .x0 sp (0:Word) m3 (24:BitVec 12) (base+20)
-  have hC6 := addi_spec_gen_within .x6 .x0 c6Old (0:Word) (64:BitVec 12) (base+24) (by decide)
+  have hC6 := addi_spec_gen_within .x20 .x0 c6Old (0:Word) (64:BitVec 12) (base+24) (by decide)
   have hLP := addi_spec_gen_within .x16 .x12 c16Old evmSp (56:BitVec 12) (base+28) (by decide)
   have hLd := ld_spec_gen_within .x19 .x16 (evmSp+signExtend12 56) c19Old expLimb3 (0:BitVec 12) (base+32) (by decide)
   have hAP := addi_spec_gen_same_within .x16 (evmSp+signExtend12 56) (-8:BitVec 12) (base+36) (by decide)
@@ -1211,12 +1211,12 @@ theorem exp_msb_bit_test_block_fixed_slli_spec_within (e : Word) (base : Word) :
 theorem exp_msb_bit_test_block_fixed_decrement_spec_within (c6 : Word) (base : Word) :
     cpsTripleWithin 1 (base + 8) (base + 12)
       (exp_msb_bit_test_block_fixed_code base)
-      (.x6 ↦ᵣ c6)
-      (.x6 ↦ᵣ (c6 + signExtend12 (-1 : BitVec 12))) := by
-  have h := addi_spec_gen_same_within .x6 c6 (-1 : BitVec 12) (base + 8) (by decide)
+      (.x20 ↦ᵣ c6)
+      (.x20 ↦ᵣ (c6 + signExtend12 (-1 : BitVec 12))) := by
+  have h := addi_spec_gen_same_within .x20 c6 (-1 : BitVec 12) (base + 8) (by decide)
   have hext := cpsTripleWithin_extend_code (h := h)
     (hmono := CodeReq.ofProg_mono_sub base (base + 8) exp_msb_bit_test_block_fixed
-      [.ADDI .x6 .x6 (-1)] 2 (by bv_omega) (by decide) (by decide) (by decide))
+      [.ADDI .x20 .x20 (-1)] 2 (by bv_omega) (by decide) (by decide) (by decide))
   have haddr : (base + 8 : Word) + 4 = base + 12 := by bv_addr
   rw [haddr] at hext; exact hext
 
@@ -1229,15 +1229,15 @@ theorem exp_msb_bit_test_block_fixed_decrement_spec_within (c6 : Word) (base : W
 theorem exp_msb_bit_test_block_fixed_bne_spec_within (c6_new : Word) (base : Word) :
     cpsBranchWithin 1 (base + 12)
       (exp_msb_bit_test_block_fixed_code base)
-      ((.x6 ↦ᵣ c6_new) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x20 ↦ᵣ c6_new) ** (.x0 ↦ᵣ (0 : Word)))
       (base + 12 + signExtend13 (16 : BitVec 13))
-        ((.x6 ↦ᵣ c6_new) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜c6_new ≠ 0⌝)
+        ((.x20 ↦ᵣ c6_new) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜c6_new ≠ 0⌝)
       (base + 12 + 4)
-        ((.x6 ↦ᵣ c6_new) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜c6_new = 0⌝) :=
+        ((.x20 ↦ᵣ c6_new) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜c6_new = 0⌝) :=
   cpsBranchWithin_extend_code
-    (h := bne_spec_gen_within .x6 .x0 (16 : BitVec 13) c6_new (0 : Word) (base + 12))
+    (h := bne_spec_gen_within .x20 .x0 (16 : BitVec 13) c6_new (0 : Word) (base + 12))
     (hmono := CodeReq.ofProg_mono_sub base (base + 12) exp_msb_bit_test_block_fixed
-      [.BNE .x6 .x0 16] 3 (by bv_omega) (by decide) (by decide) (by decide))
+      [.BNE .x20 .x0 16] 3 (by bv_omega) (by decide) (by decide) (by decide))
 
 /-- Skip path of the fixed bit-test block: BNE is taken because x6-1 ≠ 0.
     Exits at base+28 after 4 instructions. x19 shifted, x10 = MSB of old x19,
@@ -1247,17 +1247,17 @@ theorem exp_msb_bit_test_block_fixed_skip_spec_within
     (hc6 : c6 + signExtend12 (-1 : BitVec 12) ≠ 0) :
     cpsTripleWithin 4 base (base + 28)
       (exp_msb_bit_test_block_fixed_code base)
-      ((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ c10) ** (.x0 ↦ᵣ (0 : Word)))
-      ((.x6 ↦ᵣ c6 + signExtend12 (-1 : BitVec 12)) ** (.x0 ↦ᵣ (0 : Word)) **
+      ((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x10 ↦ᵣ c10) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x20 ↦ᵣ c6 + signExtend12 (-1 : BitVec 12)) ** (.x0 ↦ᵣ (0 : Word)) **
        ⌜c6 + signExtend12 (-1 : BitVec 12) ≠ 0⌝ **
        (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
        (.x10 ↦ᵣ (e >>> (63 : BitVec 6).toNat))) := by
   let c6_new := c6 + signExtend12 (-1 : BitVec 12)
   -- Compose 3 instructions with explicit intermediate types
-  have hSR_f := cpsTripleWithin_frameR ((.x6 ↦ᵣ c6) ** (.x0 ↦ᵣ (0:Word)))
+  have hSR_f := cpsTripleWithin_frameR ((.x20 ↦ᵣ c6) ** (.x0 ↦ᵣ (0:Word)))
     (by pcFree) (exp_msb_bit_test_block_fixed_srli_spec_within c10 e base)
   have hSL_f := cpsTripleWithin_frameR
-    ((.x10 ↦ᵣ (e >>> (63:BitVec 6).toNat)) ** (.x6 ↦ᵣ c6) ** (.x0 ↦ᵣ (0:Word)))
+    ((.x10 ↦ᵣ (e >>> (63:BitVec 6).toNat)) ** (.x20 ↦ᵣ c6) ** (.x0 ↦ᵣ (0:Word)))
     (by pcFree) (exp_msb_bit_test_block_fixed_slli_spec_within e base)
   have hAD_f := cpsTripleWithin_frameR
     ((.x19 ↦ᵣ (e <<< (1:BitVec 6).toNat)) ** (.x10 ↦ᵣ (e >>> (63:BitVec 6).toNat)) **
@@ -1266,8 +1266,8 @@ theorem exp_msb_bit_test_block_fixed_skip_spec_within
   have h3_seq := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp)
     (cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hSR_f hSL_f) hAD_f
   have h3 : cpsTripleWithin 3 base (base + 12) (exp_msb_bit_test_block_fixed_code base)
-      ((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ c10) ** (.x0 ↦ᵣ (0 : Word)))
-      ((.x19 ↦ᵣ (e <<< (1:BitVec 6).toNat)) ** (.x6 ↦ᵣ c6_new) **
+      ((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x10 ↦ᵣ c10) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x19 ↦ᵣ (e <<< (1:BitVec 6).toNat)) ** (.x20 ↦ᵣ c6_new) **
        (.x10 ↦ᵣ (e >>> (63:BitVec 6).toNat)) ** (.x0 ↦ᵣ (0:Word))) :=
     cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp) h3_seq
   have hBNE_f := cpsBranchWithin_frameR
@@ -1293,21 +1293,21 @@ theorem exp_msb_bit_test_block_fixed_reload_spec_within
     (hc6 : c6 + signExtend12 (-1 : BitVec 12) = 0) :
     cpsTripleWithin 7 base (base + 28)
       (exp_msb_bit_test_block_fixed_code base)
-      ((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ c10) ** (.x0 ↦ᵣ (0 : Word)) **
+      ((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x10 ↦ᵣ c10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb))
       ((.x19 ↦ᵣ nextLimb) **
-       (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+       (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
        (.x10 ↦ᵣ (e >>> (63 : BitVec 6).toNat)) ** (.x0 ↦ᵣ (0 : Word)) **
        ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
        (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
        ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb)) := by
   let c6_new := c6 + signExtend12 (-1 : BitVec 12)
   have hSR_f := cpsTripleWithin_frameR
-    ((.x6 ↦ᵣ c6) ** (.x0 ↦ᵣ (0:Word)) ** (.x16 ↦ᵣ ptr) **
+    ((.x20 ↦ᵣ c6) ** (.x0 ↦ᵣ (0:Word)) ** (.x16 ↦ᵣ ptr) **
      ((ptr + signExtend12 0) ↦ₘ nextLimb))
     (by pcFree) (exp_msb_bit_test_block_fixed_srli_spec_within c10 e base)
   have hSL_f := cpsTripleWithin_frameR
-    ((.x10 ↦ᵣ (e >>> (63:BitVec 6).toNat)) ** (.x6 ↦ᵣ c6) ** (.x0 ↦ᵣ (0:Word)) **
+    ((.x10 ↦ᵣ (e >>> (63:BitVec 6).toNat)) ** (.x20 ↦ᵣ c6) ** (.x0 ↦ᵣ (0:Word)) **
      (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 0) ↦ₘ nextLimb))
     (by pcFree) (exp_msb_bit_test_block_fixed_slli_spec_within e base)
   have hAD_f := cpsTripleWithin_frameR
@@ -1317,9 +1317,9 @@ theorem exp_msb_bit_test_block_fixed_reload_spec_within
   have h3_seq := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp)
     (cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hSR_f hSL_f) hAD_f
   have h3 : cpsTripleWithin 3 base (base+12) (exp_msb_bit_test_block_fixed_code base)
-      ((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ c10) ** (.x0 ↦ᵣ (0:Word)) **
+      ((.x19 ↦ᵣ e) ** (.x20 ↦ᵣ c6) ** (.x10 ↦ᵣ c10) ** (.x0 ↦ᵣ (0:Word)) **
        (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 0) ↦ₘ nextLimb))
-      ((.x19 ↦ᵣ (e <<< (1:BitVec 6).toNat)) ** (.x6 ↦ᵣ c6_new) **
+      ((.x19 ↦ᵣ (e <<< (1:BitVec 6).toNat)) ** (.x20 ↦ᵣ c6_new) **
        (.x10 ↦ᵣ (e >>> (63:BitVec 6).toNat)) ** (.x0 ↦ᵣ (0:Word)) **
        (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 0) ↦ₘ nextLimb)) :=
     cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp) h3_seq
@@ -1345,9 +1345,9 @@ theorem exp_msb_bit_test_block_fixed_reload_spec_within
       [.ADDI .x16 .x16 (-8)] 5 (by bv_omega) (by decide) (by decide) (by decide))
   -- ADDI x6 x0 64 at base+24
   have hC6 := cpsTripleWithin_extend_code
-    (h := addi_spec_gen_within .x6 .x0 c6_new (0:Word) (64:BitVec 12) (base+24) (by decide))
+    (h := addi_spec_gen_within .x20 .x0 c6_new (0:Word) (64:BitVec 12) (base+24) (by decide))
     (hmono := CodeReq.ofProg_mono_sub base (base+24) exp_msb_bit_test_block_fixed
-      [.ADDI .x6 .x0 64] 6 (by bv_omega) (by decide) (by decide) (by decide))
+      [.ADDI .x20 .x0 64] 6 (by bv_omega) (by decide) (by decide) (by decide))
   have e1 : (base+16:Word)+4=base+20 := by bv_addr
   have e2 : (base+20:Word)+4=base+24 := by bv_addr
   have e3 : (base+24:Word)+4=base+28 := by bv_addr
@@ -1355,11 +1355,11 @@ theorem exp_msb_bit_test_block_fixed_reload_spec_within
   -- Compose last 3 instructions
   -- Build h3b with explicit type to force elaboration
   have hLd_f := cpsTripleWithin_frameR
-    ((.x10 ↦ᵣ (e >>> (63:BitVec 6).toNat)) ** (.x6 ↦ᵣ c6_new) ** (.x0 ↦ᵣ (0:Word)) **
+    ((.x10 ↦ᵣ (e >>> (63:BitVec 6).toNat)) ** (.x20 ↦ᵣ c6_new) ** (.x0 ↦ᵣ (0:Word)) **
      ⌜c6_new = 0⌝)
     (by pcFree) hLd
   have hAP_f := cpsTripleWithin_frameR
-    ((.x19 ↦ᵣ nextLimb) ** (.x10 ↦ᵣ (e >>> (63:BitVec 6).toNat)) ** (.x6 ↦ᵣ c6_new) **
+    ((.x19 ↦ᵣ nextLimb) ** (.x10 ↦ᵣ (e >>> (63:BitVec 6).toNat)) ** (.x20 ↦ᵣ c6_new) **
      (.x0 ↦ᵣ (0:Word)) ** ⌜c6_new = 0⌝ ** ((ptr + signExtend12 0) ↦ₘ nextLimb))
     (by pcFree) hAP
   have hC6_f := cpsTripleWithin_frameR
@@ -1370,11 +1370,11 @@ theorem exp_msb_bit_test_block_fixed_reload_spec_within
   have h3b_seq := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp)
     (cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hLd_f hAP_f) hC6_f
   have h3b : cpsTripleWithin 3 (base+16) (base+28) (exp_msb_bit_test_block_fixed_code base)
-      ((.x19 ↦ᵣ (e <<< (1:BitVec 6).toNat)) ** (.x6 ↦ᵣ c6_new) **
+      ((.x19 ↦ᵣ (e <<< (1:BitVec 6).toNat)) ** (.x20 ↦ᵣ c6_new) **
        (.x10 ↦ᵣ (e >>> (63:BitVec 6).toNat)) ** (.x0 ↦ᵣ (0:Word)) **
        (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 0) ↦ₘ nextLimb) ** ⌜c6_new = 0⌝)
       ((.x19 ↦ᵣ nextLimb) **
-       (.x6 ↦ᵣ ((0:Word) + signExtend12 (64:BitVec 12))) **
+       (.x20 ↦ᵣ ((0:Word) + signExtend12 (64:BitVec 12))) **
        (.x10 ↦ᵣ (e >>> (63:BitVec 6).toNat)) ** (.x0 ↦ᵣ (0:Word)) **
        ⌜c6_new = 0⌝ **
        (.x16 ↦ᵣ (ptr + signExtend12 (-8:BitVec 12))) **

--- a/EvmAsm/Evm64/Exp/Program.lean
+++ b/EvmAsm/Evm64/Exp/Program.lean
@@ -1261,7 +1261,10 @@ theorem evm_exp_msb_saved_bit_two_mul_canonical_byte_length
 -- FIX DESIGN:
 -- - Use x19 (callee-saved, preserved across mul_callable) as the
 --   exponent cursor, initialized to exponentWord.getLimbN 3.
--- - Use x6 as per-limb counter (counts down from 64 to 0).
+-- - Use x20 (callee-saved, preserved across mul_callable) as the per-limb
+--   counter (counts down from 64 to 0). NOTE: x6 (caller-saved t1) is in
+--   mul_callable's footprint and is clobbered by the squaring/cond-mul JALs,
+--   so the counter must live in a callee-saved register like the x19 cursor.
 -- - Use x16 as limb pointer (starts at &exponent.limb3, advances by -8
 --   after each 64-bit limb is exhausted).
 -- - Fixed prologue: load x19=exponent.limb3, x6=64, x16=&exponent.limb2.
@@ -1272,7 +1275,7 @@ theorem evm_exp_msb_saved_bit_two_mul_canonical_byte_length
 -- ============================================================================
 
 /-- Fixed EXP prologue: initialize accumulator to 1, master counter x9=256,
-    per-limb counter x6=64, exponent cursor x19=exponent.getLimbN 3
+    per-limb counter x20=64, exponent cursor x19=exponent.getLimbN 3
     (loaded from x12+56 = evmSp+56 since x12=evmSp before pointer_advance),
     and limb pointer x16 pointing at the NEXT limb to reload (evmSp+48).
     10 instructions, 40 bytes. -/
@@ -1283,7 +1286,7 @@ def exp_prologue_fixed : Program :=
   SD .x2 .x0 8 ;;
   SD .x2 .x0 16 ;;
   SD .x2 .x0 24 ;;
-  ADDI .x6 .x0 64 ;;
+  ADDI .x20 .x0 64 ;;
   ADDI .x16 .x12 56 ;;
   LD .x19 .x16 0 ;;
   ADDI .x16 .x16 (-8)
@@ -1294,18 +1297,18 @@ theorem exp_prologue_fixed_byte_length : 4 * exp_prologue_fixed.length = 40 := b
   rw [exp_prologue_fixed_length]
 
 /-- Fixed MSB-first bit-test block: extract MSB of x19 (exponent cursor),
-    advance cursor (SLLI x19 x19 1), decrement per-limb counter x6.
-    When x6 = 0 (limb exhausted), reload x19 from x16 and advance x16 by -8.
+    advance cursor (SLLI x19 x19 1), decrement per-limb counter x20.
+    When x20 = 0 (limb exhausted), reload x19 from x16 and advance x16 by -8.
     7 instructions (3 core + 4 reload). The reload branch skips 4 instructions
     (= 16 bytes) when x6 ≠ 0 after decrement. -/
 def exp_msb_bit_test_block_fixed : Program :=
   SRLI .x10 .x19 63 ;;
   SLLI .x19 .x19 1 ;;
-  ADDI .x6 .x6 (-1) ;;
-  single (.BNE .x6 .x0 16) ;;
+  ADDI .x20 .x20 (-1) ;;
+  single (.BNE .x20 .x0 16) ;;
   LD .x19 .x16 0 ;;
   ADDI .x16 .x16 (-8) ;;
-  ADDI .x6 .x0 64
+  ADDI .x20 .x0 64
 
 theorem exp_msb_bit_test_block_fixed_length :
     exp_msb_bit_test_block_fixed.length = 7 := by decide


### PR DESCRIPTION
## Root-cause bug

The EXP fixed square-and-multiply loop held its **per-limb counter** in `x6`
(RISC-V `t1`, **caller-saved**). The iteration body decrements `x6` in the
bit-test, then calls `mul_callable` twice (squaring + conditional multiply)
via `JAL`. `mul_callable`'s footprint is `{x5,x6,x7,x10,x11}` — it **clobbers
`x6`** and there is no save/restore. So from the second iteration onward the
`BNE .x6, x0` limb-reload decision branched on a leftover product limb, not
the counter.

Consequence for the proof: the loop invariant `x6.toNat = 64 - k % 64` was
**genuinely false** against the executable at each iteration entry — which is
why the 256-iteration loop-body induction (`evm_exp_stack_spec_within`) could
not be closed by any route. The cursor `x19` was already correctly placed in a
callee-saved register ("`x19` is callee-saved so it survives `mul_callable`");
the counter was simply left in a caller-saved one.

## Fix

Relocate the per-limb counter to **`x20`** (callee-saved, outside
`mul_callable`'s footprint, so preserved by the frame rule — exactly like the
`x19` cursor). In the program this is a pure register rename
(`exp_prologue_fixed`, `exp_msb_bit_test_block_fixed`), **offset-preserving**:
all instruction counts and branch offsets are unchanged.

The spec chain is updated to match (≈18 files): counter-role `x6` → `x20`;
`x6` becomes pure `mul_callable` scratch (`regOwn`); and crucially the loop /
iteration posts that previously released `regOwn .x6` (counter lost) now carry
`.x20 ↦ c6New` (counter **preserved**, threaded through the MUL frames). The
DEF-layer signatures (`expTwoMulFixedIterPre`, etc.) are kept stable, so the
~162 downstream uses are unaffected.

## Result

`lake build EvmAsm.Evm64.Exp` is green (1105 jobs); `check-forbidden-tactics`
passes; no `sorry`/`native_decide`/`bv_decide`. The loop invariant
`x20 = 64 - k % 64` is now provable at each iteration entry, which unblocks the
EXP loop-body induction and the eventual `evm_exp_stack_spec_within`
(follow-up; this PR is the correctness fix + spec realignment).

Directed by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)