### PR TITLE
fix(blob-tx): correct EOA CALL value gas + restore staged sender balance

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -2867,13 +2867,25 @@ def emitRuntimeDispatcherDataSectionCore
   "  .zero 8\n" ++
   runtimeSameBlockDelegationCodeData ++
   ".balign 8\n" ++
-  -- lv44p.1: 32-byte zero-pad staging window for CALLDATALOAD (h_CALLDATALOAD
-  -- preBody). The verified mload body reads a raw 32-byte window with no
-  -- out-of-bounds guard; the handler stages a zero-padded copy here so reads
-  -- past env.callDataLen yield the EVM-mandated zero pad instead of adjacent
-  -- memory. Used transiently within one opcode dispatch (no re-entrancy: the
-  -- dispatcher runs one opcode at a time), so a single static buffer is sound.
-  "bv_cdl_stage:\n  .zero 32\n" ++
+   -- lv44p.1: 32-byte zero-pad staging window for CALLDATALOAD (h_CALLDATALOAD
+   -- preBody). The verified mload body reads a raw 32-byte window with no
+   -- out-of-bounds guard; the handler stages a zero-padded copy here so reads
+   -- past env.callDataLen yield the EVM-mandated zero pad instead of adjacent
+   -- memory. Used transiently within one opcode dispatch (no re-entrancy: the
+   -- dispatcher runs one opcode at a time), so a single static buffer is sound.
+   "bv_cdl_stage:\n  .zero 32\n" ++
+   -- coc3g.9.3 (#9458 follow-up, bv_fail=53): EMPTY_CODE_HASH (keccak "") for the
+   -- callDescendFallThrough empty-code-EOA routing fix. status 5 from
+   -- code_at_header_state_root means code_hash not in witness.codes; for an
+   -- EXISTING EOA that code_hash is EMPTY_CODE_HASH, so the call is a valid
+   -- empty-code callee (not a witness miss). ChildFrameHandlers.Lcd_callee_nocreate_
+   -- compares cahsr_acct_struct.code_hash against this constant.
+   ".balign 32\n" ++
+   "cd_empty_code_hash:\n" ++
+   "  .byte 0xc5, 0xd2, 0x46, 0x01, 0x86, 0xf7, 0x23, 0x3c\n" ++
+   "  .byte 0x92, 0x7e, 0x7d, 0xb2, 0xdc, 0xc7, 0x03, 0xc0\n" ++
+   "  .byte 0xe5, 0x00, 0xb6, 0x53, 0xca, 0x82, 0x27, 0x3b\n" ++
+   "  .byte 0x7b, 0xfa, 0xd8, 0x04, 0x5d, 0x85, 0xa4, 0x70\n" ++
   ".balign 8\n" ++
   "txal_type:\n  .zero 8\n" ++
   "txal_inner_off:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -834,35 +834,19 @@ def blockVerdictFunction : String :=
   -- dispatcher consumes this after its setup resets and records it in the live
   -- nonstorage log; it is one-shot and harmless for contracts that never query
   -- the sender balance.
-   "  la a0, bv_stx_sender_acct; addi a0, a0, 8; la a1, bv_upfront_cost; la a2, bv_pending_upfront_sender_post\n" ++
-   "  jal ra, u256_sub_be\n" ++
-   "  bnez a0, .Lbv_stx_pending_upfront_done\n" ++
-   -- bv_upfront_cost used max_fee*gas_limit + max_blob_fee*blob_gas, but the
-   -- actual deduction at tx start uses effective_gas_price*gas_limit +
-   -- blob_gas_price*blob_gas. Add back both differences so BALANCE(ORIGIN)
-   -- during execution sees the correct sender balance.
-   -- bv_upfront_blob_cost is scratch (freed after blob-cost accumulation).
-   -- Gas delta: (max_fee - effective_gas_price) * gas_limit
-   "  la a0, tefgp_max_fee; la a1, bv_fee_egp_scratch; la a2, bv_upfront_blob_cost\n" ++
-   "  jal ra, u256_sub_be\n" ++
-   "  bnez a0, .Lbv_stx_pending_upfront_done\n" ++
-   "  la a0, bv_upfront_blob_cost; la t0, bv_simple_transfer_tx; ld a1, 40(t0); la a2, bv_upfront_blob_cost\n" ++
-   "  jal ra, u256_mul_u64_be\n" ++
-   "  bnez a0, .Lbv_stx_pending_upfront_done\n" ++
-   "  la a0, bv_pending_upfront_sender_post; la a1, bv_upfront_blob_cost; la a2, bv_pending_upfront_sender_post\n" ++
-   "  jal ra, u256_add_be\n" ++
-   -- Blob delta: (max_fee_per_blob_gas - blob_gas_price) * blob_count * 131072
-   -- bsg_blob_price_be holds the actual blob_gas_price (set at line 338).
-   "  la a0, tcbg_blob_fee_be; la a1, bsg_blob_price_be; la a2, bv_upfront_blob_cost\n" ++
-   "  jal ra, u256_sub_be\n" ++
-   "  bnez a0, .Lbv_stx_pending_upfront_blob_delta_done\n" ++
-   "  la a0, bv_upfront_blob_cost; la t0, bv_upfront_blob_count; ld a1, 0(t0); slli a1, a1, 17; la a2, bv_upfront_blob_cost\n" ++
-   "  jal ra, u256_mul_u64_be\n" ++
-   "  bnez a0, .Lbv_stx_pending_upfront_blob_delta_done\n" ++
-   "  la a0, bv_pending_upfront_sender_post; la a1, bv_upfront_blob_cost; la a2, bv_pending_upfront_sender_post\n" ++
-   "  jal ra, u256_add_be\n" ++
-   ".Lbv_stx_pending_upfront_blob_delta_done:\n" ++
-   "  la t0, bv_stx_sender_addr; la t1, bv_pending_upfront_sender_addr\n" ++
+    "  la a0, bv_stx_sender_acct; addi a0, a0, 8; la a1, bv_upfront_cost; la a2, bv_pending_upfront_sender_post\n" ++
+    "  jal ra, u256_sub_be\n" ++
+    "  bnez a0, .Lbv_stx_pending_upfront_done\n" ++
+    -- bv_upfront_cost already holds effective_gas_price*gas_limit +
+    -- blob_gas_price*blob_gas + value (recomputed @807-831, PR #9482), so
+    -- bv_pending_upfront_sender_post is now the correct execution-start sender
+    -- balance. The (max_fee-eff_price) and (max_blob-blob_gas_price) refund
+    -- deltas that previously followed here were a double-correction: they assumed
+    -- bv_upfront_cost was still max-fee-based, but the recompute above already
+    -- replaced it with the eff-price-based cost, so adding the deltas back made
+    -- BALANCE(ORIGIN) too high by ~max_fee_gap*gas_limit -> bv_fail=34
+    -- (bal_storage_mismatch) on the gasUsed=195840 blob_gas_subtraction_tx cases.
+    "  la t0, bv_stx_sender_addr; la t1, bv_pending_upfront_sender_addr\n" ++
   "  ld t2, 0(t0); sd t2, 0(t1); ld t2, 8(t0); sd t2, 8(t1); ld t2, 16(t0); sd t2, 16(t1); sd zero, 24(t1)\n" ++
   "  la t0, bv_stx_sender_acct; addi t0, t0, 8; la t1, bv_pending_upfront_sender_pre\n" ++
   "  ld t2, 0(t0); sd t2, 0(t1); ld t2, 8(t0); sd t2, 8(t1); ld t2, 16(t0); sd t2, 16(t1); ld t2, 24(t0); sd t2, 24(t1)\n" ++

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -787,7 +787,27 @@ def callDescendFallThrough
   ".Lcd_callee_nocreate_" ++ tag ++ ":\n" ++
   "  li t3, 1\n" ++
   "  beq t2, t3, .Lcd_empty_" ++ tag ++ "\n" ++
-  -- fail (status 2/3/4/5): pop args, push 0
+  -- coc3g.9.3 (#9458 follow-up, bv_fail=53): status 5 = code_hash not found in
+  -- witness.codes. An EXISTING EOA is in the state trie (step 2 ok) but its
+  -- code_hash is EMPTY_CODE_HASH (keccak ""), which is never stored in the codes
+  -- section -> status 5. A value-CALL to such an existing EOA is a VALID
+  -- empty-code callee: the spec runs no code, transfers value, and bills the net
+  -- 6700 value gas (9000 - 2300 stipend) -- exactly .Lcd_empty_. Without this the
+  -- call routed to .Lcd_fail_ (push 0), skipping the value gas -> receipt
+  -- cumulative under-counted by 6700 -> receipts-root mismatch (bv_fail=53 on the
+  -- 48 non-allowlisted blob_gas_subtraction_tx cases). Distinguish a genuine
+  -- witness-miss (non-empty code hash absent from codes -> fail) from a legitimate
+  -- empty-code EOA by checking cahsr_acct_struct.code_hash == EMPTY_CODE_HASH.
+  "  li t3, 5\n" ++
+  "  bne t2, t3, .Lcd_fail_" ++ tag ++ "\n" ++
+  "  la t3, cd_empty_code_hash\n" ++
+  "  la t4, cahsr_acct_struct\n" ++
+  "  ld t5,  0(t3); ld t6,  72(t4); bne t5, t6, .Lcd_fail_" ++ tag ++ "\n" ++
+  "  ld t5,  8(t3); ld t6,  80(t4); bne t5, t6, .Lcd_fail_" ++ tag ++ "\n" ++
+  "  ld t5, 16(t3); ld t6,  88(t4); bne t5, t6, .Lcd_fail_" ++ tag ++ "\n" ++
+  "  ld t5, 24(t3); ld t6,  96(t4); bne t5, t6, .Lcd_fail_" ++ tag ++ "\n" ++
+  "  j .Lcd_empty_" ++ tag ++ "\n" ++
+  -- fail (status 2/3/4): pop args, push 0
   ".Lcd_fail_" ++ tag ++ ":\n" ++
   "  addi x12, x12, " ++ np ++ "\n" ++
   "  sd x0, 0(x12); sd x0, 8(x12); sd x0, 16(x12); sd x0, 24(x12)\n" ++


### PR DESCRIPTION
## Summary

Restores **128/128** on `blob_gas_subtraction_tx` (was 80/128 via gasUsed-allowlist + 48 `bv_fail=53`). Two independent fixes; follow-up to #9482 / closes the 48 `bv_fail=53` (bead `evm-asm-coc3g.9.3`).

### Commit 2 — route existing-EOA callees to the empty-callee path (`fix(call)`)
A value-bearing `CALL` to an **existing EOA** (the test contract's `CALL(GAS, ORIGIN, SELFBALANCE-CALLVALUE, ...)`) routed to `.Lcd_fail_` instead of `.Lcd_empty_`, **skipping the net 6700 value-transfer gas** (9000 `GAS_CALL_VALUE` − 2300 stipend). The receipt cumulative was under-counted by 6700 → receipts-root mismatch → `bv_fail=53` on the 48 cases whose `header.gasUsed=97920` is absent from the gasUsed allowlist.

Root cause: `code_at_header_state_root` returns **status 5** ("code_hash not in witness.codes") for an EOA, because its `code_hash` is `EMPTY_CODE_HASH` (keccak ""), which is never stored in the codes section. `.Lcd_callee_nocreate_` only routed `status==1` (account not in trie) → `.Lcd_empty_`; status 2/3/4/5 fell to `.Lcd_fail_`. An EOA is a legitimate empty-code callee. The fix distinguishes a genuine witness-miss (non-empty code hash absent) from a real empty-code EOA by checking `code_hash == EMPTY_CODE_HASH` and routing the latter to `.Lcd_empty_` (mirrors existing `status==1` handling). The value transfer was already committed at the balance gate, so this only corrects the gas + the success flag. Also fixes STATICCALL/CALLCODE/DELEGATECALL to EOAs (now push success).

`cd_empty_code_hash` is added to the shared `emitRuntimeDispatcherDataSectionCore` so every dispatch build unit defines it.

### Commit 1 — drop double-applied sender-balance refund deltas (`fix(block-verdict)`)
After #9482 merged (which **recomputes** `bv_upfront_cost` as `effective_gas_price*gas + blob_gas_price*blob + value`), sibling fix c60e4feb1 landed on top **appending** `(max_fee−eff_price)*gas` and `(max_blob−blob_gas_price)*blob` refund deltas. Those deltas assume a max-fee-based cost, but the #9482 recompute already replaced it with the eff-price-based cost, so they **double-corrected**: `BALANCE(ORIGIN)` came back too high by `~max_fee_gap*gas_limit`, SSTOREs diverged from the BAL witness, and the `gasUsed=195840` cases regressed to `bv_fail=34` (bal_storage_mismatch). Removing the redundant deltas restores the correct #9482 behavior.

## Verification
- `lake build` clean (3518 jobs).
- Architecture gates green: check-no-warnings, check-file-size, check-layering, check-forbidden-tactics, check-opcode-structure, check-axioms. (No heartbeat overrides; the CALL/balance edits add none.)
- Probe (`zisk_stateless_verdict_v2`) on case2 (`gasUsed=97920`): `receipt_inc = 144732 = execution-specs truth`; case0 (`gasUsed=195840`): `bv_fail=0` (was 34).
- Spike reproduction, 128 cases: **128/128 full match, 0 fail** (`scripts/codegen-eest-stateless-check.sh --filter blob_gas_subtraction_tx --limit 200 --backend spike --jobs auto --quiet-passes`).

## Scope notes
- The 48 `gasUsed=97920` cases now pass **honestly** (validator status 0). The 80 `gasUsed=195840` cases remain gasUsed-allowlist-masked (their receipt cumulative still carries a deeper ~85680/2-SSTORE residual — separate amsterdam gas-model debt, tracked under `evm-asm-coc3g.9.3`); this PR does **not** retire the allowlist.

## Test plan
- [x] `lake build`
- [x] architecture gates
- [x] spike `blob_gas_subtraction_tx` 128/128
- [ ] ziskemu parity (105-byte SSZ result; same backend class)

🤖 Generated with [opencode](https://opencode.ai); diagnosis + fixes by GLM-5.2.