### PR TITLE
chore(receipts): drop redundant gasUsed=97920 nonzero-state allowlist entry

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -791,7 +791,9 @@ def blockVerdictReceiptsTail : String :=
   "  li t1, 35190; beq t2, t1, .Lbv_receipts_accept\n" ++
   "  li t1, 351900; beq t2, t1, .Lbv_receipts_accept\n" ++
   "  li t1, 195840; beq t2, t1, .Lbv_receipts_accept\n" ++
-  "  li t1, 97920; beq t2, t1, .Lbv_receipts_accept\n" ++
+  -- 97920 (nonzero-state) removed post-#9496: the 48 blob_gas_subtraction_tx
+  -- cases with gasUsed=97920 now pass with validator status 0 (honest receipt
+  -- root) via the existing-EOA CALL-routing fix, so this allowlist entry is dead.
   "  li t1, 391680; beq t2, t1, .Lbv_receipts_accept\n" ++
   "  li t1, 364140; beq t2, t1, .Lbv_receipts_accept\n" ++
   "  li t1, 388620; beq t2, t1, .Lbv_receipts_accept\n" ++


### PR DESCRIPTION
## What

Removes the dead `gasUsed=97920` entry from the **nonzero-state** branch of the WIP receipts allowlist (`BlockVerdictReceiptsTail.lean`).

## Why

After #9496 (existing-EOA CALL-routing fix), the 48 `blob_gas_subtraction_tx` cases with `gasUsed=97920` pass with **validator status 0** (honest receipt root) — they no longer reach the allowlist at all. So this entry is dead code.

The zero-state `97920` entry (different fixtures, zero state gas) is left untouched.

## Verification
- `lake build` clean (3518 jobs)
- `blob_gas_subtraction_tx`: 128/128 full match
- full `eip4844` family: 400/400 full match (spike)

## Scope
First step of bead `evm-asm-coc3g.9.3.2` (retire the gasUsed magic-constant allowlist + exact-gas tower). Mask removals keep `lake build` green since EEST is not in the default CI gate; EEST regressions are the surfacing signal for remaining debt.