### PR TITLE
feat(exp): EXP loop-body induction infrastructure (post-#9495 — reshuffles, assemblers, ExpResidual, exit bridge)

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -103,6 +103,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFixedInductionFrameLoopDirect
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoopPreReload
 import EvmAsm.Evm64.Exp.Compose.FixedLoopInd
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedReloadReshuffle
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedExpResidual
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEpilogueBase
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry

--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -67,6 +67,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFixedWithMul
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEntryFixedIterPre
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePosts
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterExits
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedMergedFramedStep
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostBridge
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostCountBridge
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostStateBridge

--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -75,6 +75,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostCases
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostFramedCases
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterReloadPointerPures
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostIterPreCases
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedExitBridge
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixed
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixedEntryExists
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixedIterSpBounds
@@ -100,6 +101,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoopDirect
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedInductionFrameLoopDirect
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoopPreReload
 import EvmAsm.Evm64.Exp.Compose.FixedLoopInd
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedReloadReshuffle
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEpilogueBase
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry

--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -104,6 +104,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoopPreReload
 import EvmAsm.Evm64.Exp.Compose.FixedLoopInd
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedReloadReshuffle
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedExpResidual
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedReloadResidualRepartition
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEpilogueBase
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry

--- a/EvmAsm/Evm64/Exp/Compose/FixedLoopInd.lean
+++ b/EvmAsm/Evm64/Exp/Compose/FixedLoopInd.lean
@@ -296,4 +296,20 @@ theorem directHeadTailOrSuccessorFrameN_succ_ordinary_eq_reloadLimbTail
     expTwoMulFixedSavedNextLimbFrameN_succ_no_reload hMod,
     expTwoMulFixedSavedNextLimbFrameN_succ_no_reload hMod1]
 
+/-- Pre-reload output-frame split: the two-cell pre-reload tail frame
+    `expPreReloadDirectTailFrameN` decomposes definitionally into the ordinary
+    one-cell tail `expReloadLimbDirectTailFrame` (at `ptr-8`) and the look-ahead
+    reload cell (at `ptr-16`).  This is the output-frame side of the
+    ordinary→pre-reload discharge: after applying the IH (whose output carries
+    the two-cell pre-reload frame), the look-ahead cell is returned to the
+    induction residual and the ordinary continuation's required one-cell tail
+    remains. -/
+theorem expPreReloadDirectTailFrameN_eq_tail_lookahead
+    {exponentWord : EvmWord} {k : Nat} {ptr nextNextLimb : Word} :
+    expPreReloadDirectTailFrameN exponentWord k ptr nextNextLimb =
+      (expReloadLimbDirectTailFrame ptr nextNextLimb **
+       expTwoMulFixedReloadLimbFrameN exponentWord (k + 1)
+         (ptr + signExtend12 (-8 : BitVec 12))) := by
+  rw [expPreReloadDirectTailFrameN_unfold, expReloadLimbDirectTailFrame_unfold]
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/FixedLoopInd.lean
+++ b/EvmAsm/Evm64/Exp/Compose/FixedLoopInd.lean
@@ -237,6 +237,34 @@ theorem expReloadLimbDirectTailFrame_eq_inductionFrameN_succ_ordinary
     expTwoMulFixedSavedNextLimbFrameN_succ_no_reload hMod,
     expTwoMulFixedInductionFrameN_ordinary_of_control hC6' hNotPre']
 
+/-- Ordinary→pre-reload input-frame re-partition.  When the next iteration
+    `k+1` is a *pre-reload* step (its control decrement has `toNat = 1`) and the
+    current iteration is not at a 64-bit limb boundary, the ordinary head step's
+    `hBranch` continuation tail `expReloadLimbDirectTailFrame` (one cell at
+    `ptr-8`) together with the look-ahead exponent cell at `ptr-16` (supplied
+    from the induction residual `R_k`) forms exactly the next iteration's
+    two-cell pre-reload induction frame `InductionFrameN (k+1) (controlC6-1)`.
+    This is the input-frame side of the ordinary→pre-reload `hBranch` discharge
+    in the fixed-loop induction; the look-ahead cell is the one re-partitioned
+    out of the residual at this boundary. -/
+theorem expReloadLimbDirectTailFrame_lookahead_eq_inductionFrameN_succ_preReload
+    {exponentWord : EvmWord} {k : Nat} {controlC6 ptr nextNextLimb : Word}
+    (hC6' :
+      ((controlC6 + signExtend12 (-1 : BitVec 12)) +
+        signExtend12 (-1 : BitVec 12)).toNat = 1)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hMod : k % 64 < 62) :
+    (expReloadLimbDirectTailFrame ptr nextNextLimb **
+      expTwoMulFixedSavedNextLimbFrameN exponentWord (k + 2)
+        (ptr + signExtend12 (-8 : BitVec 12))) =
+      expTwoMulFixedInductionFrameN exponentWord (k + 1)
+        (controlC6 + signExtend12 (-1 : BitVec 12)) ptr := by
+  rw [expReloadLimbDirectTailFrame_eq_savedNextLimbFrameN hNextNext,
+    expTwoMulFixedSavedNextLimbFrameN_succ_no_reload hMod,
+    expTwoMulFixedInductionFrameN_pre_reload_of_control hC6',
+    expTwoMulFixedPreReloadFrameN_unfold]
+
 /-- Deep-ordinary output-frame chaining (companion to
     `expReloadLimbDirectTailFrame_eq_inductionFrameN_succ_ordinary`): when the
     next iteration `k+1` is ordinary and neither `k` nor `k+1` is at a 64-bit

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedControlFrame.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedControlFrame.lean
@@ -232,13 +232,15 @@ theorem expTwoMulFixedSavedNextLimbFrameN_eq_succ_reload_limb_of_control_pre_rel
 def expTwoMulFixedPreReloadFrameN
     (exponentWord : EvmWord) (k : Nat) (ptr : Word) : Assertion :=
   expTwoMulFixedSavedNextLimbFrameN exponentWord k ptr **
-  expTwoMulFixedSavedNextLimbFrameN exponentWord (k + 1) ptr
+  expTwoMulFixedSavedNextLimbFrameN exponentWord (k + 1)
+    (ptr + signExtend12 (-8 : BitVec 12))
 
 theorem expTwoMulFixedPreReloadFrameN_unfold
     {exponentWord : EvmWord} {k : Nat} {ptr : Word} :
     expTwoMulFixedPreReloadFrameN exponentWord k ptr =
       (expTwoMulFixedSavedNextLimbFrameN exponentWord k ptr **
-      expTwoMulFixedSavedNextLimbFrameN exponentWord (k + 1) ptr) := by
+      expTwoMulFixedSavedNextLimbFrameN exponentWord (k + 1)
+        (ptr + signExtend12 (-8 : BitVec 12))) := by
   delta expTwoMulFixedPreReloadFrameN
   rfl
 
@@ -266,10 +268,16 @@ theorem expTwoMulFixedPreReloadFrameN_handoff_of_control
     (hC6 : (c6 + signExtend12 (-1 : BitVec 12)).toNat = 1) :
     expTwoMulFixedPreReloadFrameN exponentWord k ptr =
       (expTwoMulFixedSavedNextLimbFrameN exponentWord k ptr **
-        expTwoMulFixedReloadLimbFrameN exponentWord (k + 1) ptr) := by
+        expTwoMulFixedReloadLimbFrameN exponentWord (k + 1)
+          (ptr + signExtend12 (-8 : BitVec 12))) := by
+  -- Use the address-parametric value lemma keyed on `k % 64 = 62`, extracted
+  -- from the control invariant — avoids juggling `hControl`'s pointer argument
+  -- (which would trigger a non-matching-atom def-eq blowup).
+  have hMod : k % 64 = 62 :=
+    expTwoMulFixedControlInvariant_pre_reload_mod hControl hC6
   rw [expTwoMulFixedPreReloadFrameN_unfold,
-    expTwoMulFixedSavedNextLimbFrameN_eq_succ_reload_limb_of_control_pre_reload
-      hControl hC6]
+    expTwoMulFixedSavedNextLimbFrameN_eq_succ_reload_limb_of_pre_reload
+      (ptr := ptr + signExtend12 (-8 : BitVec 12)) hMod]
 
 theorem expTwoMulFixedReloadLimbFrameN_eq_of_reload_nextNext
     {exponentWord : EvmWord} {k : Nat} {ptr nextNextLimb : Word}

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedExitBridge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedExitBridge.lean
@@ -531,3 +531,174 @@ theorem expTwoMulFixedIterReloadCondCountPost_to_FullStackPreFrame
         ⟨ps_x1e, ps_ef2, hdx1, hux1, h_x1e,
           ⟨ps_x2e, ps_x3e, hdx23, hux23, h_x2e, h_x3e⟩⟩⟩
   sep_perm h_full
+
+/-- ReloadSkip (reload, bit=0) exit-post disjunct → full-stack exit pre-frame. -/
+theorem expTwoMulFixedIterReloadSkipCountPost_to_FullStackPreFrame
+    {iterCount e c6 ptr nextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exponentWord : EvmWord} {ps : PartialState}
+    (h : (expTwoMulFixedIterReloadSkipCountPost iterCount e c6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base (expTwoMulIterCountNew iterCount = 0) **
+          evmWordIs (evmSp + signExtend12 ((-32) : BitVec 12)) exponentWord) ps) :
+    ∃ w0 w1 w2 w3 : Word,
+      (expTwoMulLoopExitFullStackPreFrame sp (evmSp - 64)
+          (expTwoMulIterCountNew iterCount)
+          ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+          ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0)
+          ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1)
+          ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2)
+          ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+          (exponentWord.getLimbN 0) (exponentWord.getLimbN 1)
+          (exponentWord.getLimbN 2) (exponentWord.getLimbN 3)
+          (expResultWord a0 a1 a2 a3)
+          [expResultWord w0 w1 w2 w3, expSquaringCallSquareW r0 r1 r2 r3]
+          (expTwoMulIterCountNew iterCount = 0) **
+       (.x19 ↦ᵣ nextLimb) **
+       (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+       (.x18 ↦ᵣ (e >>> (63 : BitVec 6).toNat)) **
+       (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
+       ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+       (.x1 ↦ᵣ (((base + 44) + 32) + 68)) **
+       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11) ps := by
+  simp only [expTwoMulFixedIterReloadSkipCountPost, expTwoMulFixedIterReloadSkipRest,
+             expTwoMulFixedIterBaseFrame, evmWordIs] at h
+  simp only [signExtend12_0,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg64,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg56,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg48,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg40,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg32,
+             EvmAsm.Rv64.AddrNorm.word_add_zero,
+             BitVec.add_assoc,
+             show (32:Word) + 8 = 40 from by decide,
+             show (32:Word) + 16 = 48 from by decide,
+             show (32:Word) + 24 = 56 from by decide,
+             show (18446744073709551584:Word) + 8 = 18446744073709551592 from by decide,
+             show (18446744073709551584:Word) + 16 = 18446744073709551600 from by decide,
+             show (18446744073709551584:Word) + 24 = 18446744073709551608 from by decide] at h
+  obtain ⟨ps_LB, ps_ef, hd_ef, hu_ef, h_LB, h_ef⟩ := h
+  obtain ⟨ps_inner, ps_bf, hd_bf, hu_bf, h_inner, h_bf⟩ := h_LB
+  obtain ⟨ps_x9x0, ps_sr, hd_sr, hu_sr, h_x9x0, h_sr⟩ := h_inner
+  obtain ⟨ps_x2, ps_r1, hd1, hu1, h_x2, h_r1⟩ := h_sr
+  obtain ⟨ps_x12, ps_r2, hd2, hu2, h_x12, h_r2⟩ := h_r1
+  obtain ⟨ps_x5, ps_r3, hd3, hu3, h_x5, h_r3⟩ := h_r2
+  obtain ⟨ps_spG, ps_r4, hd4, hu4, h_spG, h_r4⟩ := h_r3
+  obtain ⟨ps_sp0, ps_spG1, hsd0, hsu0, h_sp0, h_spG1⟩ := h_spG
+  obtain ⟨ps_sp1, ps_spG2, hsd1, hsu1, h_sp1, h_spG2⟩ := h_spG1
+  obtain ⟨ps_sp2, ps_sp3, hsd2, hsu2, h_sp2, h_sp3⟩ := h_spG2
+  obtain ⟨ps_eG, ps_r5, hd5, hu5, h_eG, h_r5⟩ := h_r4
+  obtain ⟨ps_e32a, ps_eG1, hed0, heu0, h_e32a, h_eG1⟩ := h_eG
+  obtain ⟨ps_e32b, ps_eG2, hed1, heu1, h_e32b, h_eG2⟩ := h_eG1
+  obtain ⟨ps_e32c, ps_e32d, hed2, heu2, h_e32c, h_e32d⟩ := h_eG2
+  obtain ⟨ps_x6, ps_r12, hd12, hu12, h_x6, h_r12⟩ := h_r5
+  obtain ⟨ps_x7, ps_r13, hd13, hu13, h_x7, h_r13⟩ := h_r12
+  obtain ⟨ps_x10, ps_r14, hd14, hu14, h_x10, h_r14⟩ := h_r13
+  obtain ⟨ps_x11, ps_r15, hd15, hu15, h_x11, h_r15⟩ := h_r14
+  obtain ⟨w0, h_w0c⟩ := sepConj_choose_memOwn h_r15
+  obtain ⟨ps_w0, ps_r16, hdw0, huw0, h_w0, h_r16⟩ := h_w0c
+  obtain ⟨w1, h_w1c⟩ := sepConj_choose_memOwn h_r16
+  obtain ⟨ps_w1, ps_r17, hdw1, huw1, h_w1, h_r17⟩ := h_w1c
+  obtain ⟨w2, h_w2c⟩ := sepConj_choose_memOwn h_r17
+  obtain ⟨ps_w2, ps_r18, hdw2, huw2, h_w2, h_r18⟩ := h_w2c
+  obtain ⟨w3, h_w3c⟩ := sepConj_choose_memOwn h_r18
+  obtain ⟨ps_w3, ps_r19, hdw3, huw3, h_w3, h_r19⟩ := h_w3c
+  obtain ⟨ps_x1, ps_r20, hd20, hu20, h_x1, h_r20⟩ := h_r19
+  obtain ⟨ps_x19, ps_r21, hd21, hu21, h_x19, h_r21⟩ := h_r20
+  obtain ⟨ps_x20, ps_r22, hd22, hu22, h_x20, h_r22⟩ := h_r21
+  obtain ⟨ps_x18, ps_r23, hd23, hu23, h_x18, h_r23⟩ := h_r22
+  obtain ⟨_pc6, h_aft⟩ := (sepConj_pure_left _).mp h_r23
+  obtain ⟨ps_x16, ps_aft2, hd16, hu16, h_x16, h_aft2⟩ := h_aft
+  obtain ⟨ps_ptr, ps_bit, hdptr, huptr, h_ptr, h_bitpure⟩ := h_aft2
+  have hbit_emp : ps_bit = PartialState.empty := h_bitpure.1
+  obtain ⟨ps_a0, ps_bf1, hda0, hua0, h_a0, h_bf1⟩ := h_bf
+  obtain ⟨ps_a1, ps_bf2, hda1, hua1, h_a1, h_bf2⟩ := h_bf1
+  obtain ⟨ps_a2, ps_a3, hda23, hua23, h_a2, h_a3⟩ := h_bf2
+  obtain ⟨ps_x0, ps_ef1, hdx0, hux0, h_x0, h_ef1⟩ := h_ef
+  obtain ⟨ps_x1e, ps_ef2, hdx1, hux1, h_x1e, h_ef2⟩ := h_ef1
+  obtain ⟨ps_x2e, ps_x3e, hdx23, hux23, h_x2e, h_x3e⟩ := h_ef2
+  refine ⟨w0, w1, w2, w3, ?_⟩
+  rw [expTwoMulLoopExitFullStackPreFrame_unfold, expTwoMulLoopExitControl_unfold]
+  rw [show (evmSp - 64 : Word) = evmSp + 18446744073709551552 from by bv_omega]
+  simp only [evmWordIs, evmStackIs,
+             signExtend12_0, signExtend12_8, signExtend12_16, signExtend12_24,
+             signExtend12_64,
+             EvmAsm.Rv64.AddrNorm.word_add_zero,
+             BitVec.add_assoc,
+             expResultWord_getLimbN_0, expResultWord_getLimbN_1,
+             expResultWord_getLimbN_2, expResultWord_getLimbN_3,
+             show (18446744073709551552:Word) + 8 = 18446744073709551560 from by decide,
+             show (18446744073709551552:Word) + 16 = 18446744073709551568 from by decide,
+             show (18446744073709551552:Word) + 24 = 18446744073709551576 from by decide,
+             show (18446744073709551552:Word) + 32 = 18446744073709551584 from by decide,
+             show (18446744073709551552:Word) + 64 = 0 from by decide,
+             show (18446744073709551584:Word) + 8 = 18446744073709551592 from by decide,
+             show (18446744073709551584:Word) + 16 = 18446744073709551600 from by decide,
+             show (18446744073709551584:Word) + 24 = 18446744073709551608 from by decide,
+             show (18446744073709551584:Word) + 32 = 0 from by decide,
+             show (32:Word) + 8 = 40 from by decide,
+             show (32:Word) + 16 = 48 from by decide,
+             show (32:Word) + 24 = 56 from by decide]
+  have h_full :
+      (((((Reg.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (Reg.x0 ↦ᵣ 0) **
+          ⌜expTwoMulIterCountNew iterCount = 0⌝) **
+         (Reg.x2 ↦ᵣ sp) ** (Reg.x12 ↦ᵣ evmSp) **
+         (Reg.x5 ↦ᵣ (expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3) **
+         (((sp ↦ₘ (expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0) **
+            (sp + 8 ↦ₘ (expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1) **
+            (sp + 16 ↦ₘ (expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2) **
+            (sp + 24 ↦ₘ (expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3))) **
+         (((evmSp + 32 ↦ₘ (expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0) **
+            (evmSp + 40 ↦ₘ (expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1) **
+            (evmSp + 48 ↦ₘ (expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2) **
+            (evmSp + 56 ↦ₘ (expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3))) **
+         regOwn Reg.x6 ** regOwn Reg.x7 ** regOwn Reg.x10 ** regOwn Reg.x11 **
+         (evmSp ↦ₘ w0) ** (evmSp + 8 ↦ₘ w1) ** (evmSp + 16 ↦ₘ w2) **
+         (evmSp + 24 ↦ₘ w3) **
+         (Reg.x1 ↦ᵣ base + (44 + (32 + 68))) **
+         (Reg.x19 ↦ᵣ nextLimb) **
+         (Reg.x20 ↦ᵣ (0 : Word) + signExtend12 (64 : BitVec 12)) **
+         (Reg.x18 ↦ᵣ e >>> (63 : BitVec 6).toNat) **
+         (Reg.x16 ↦ᵣ ptr + signExtend12 (-8 : BitVec 12)) **
+         ((ptr ↦ₘ nextLimb) ** empAssertion)) **
+        ((evmSp + 18446744073709551552 ↦ₘ a0) **
+         (evmSp + 18446744073709551560 ↦ₘ a1) **
+         (evmSp + 18446744073709551568 ↦ₘ a2) **
+         (evmSp + 18446744073709551576 ↦ₘ a3))) **
+       ((evmSp + 18446744073709551584 ↦ₘ exponentWord.getLimbN 0) **
+        (evmSp + 18446744073709551592 ↦ₘ exponentWord.getLimbN 1) **
+        (evmSp + 18446744073709551600 ↦ₘ exponentWord.getLimbN 2) **
+        (evmSp + 18446744073709551608 ↦ₘ exponentWord.getLimbN 3))) ps := by
+    refine ⟨ps_LB, ps_ef, hd_ef, hu_ef, ?_, ?_⟩
+    · refine ⟨ps_inner, ps_bf, hd_bf, hu_bf, ?_, ?_⟩
+      · refine ⟨ps_x9x0, ps_sr, hd_sr, hu_sr, h_x9x0, ?_⟩
+        refine ⟨ps_x2, ps_r1, hd1, hu1, h_x2, ?_⟩
+        refine ⟨ps_x12, ps_r2, hd2, hu2, h_x12, ?_⟩
+        refine ⟨ps_x5, ps_r3, hd3, hu3, h_x5, ?_⟩
+        refine ⟨ps_spG, ps_r4, hd4, hu4, ?_, ?_⟩
+        · exact ⟨ps_sp0, ps_spG1, hsd0, hsu0, h_sp0,
+            ⟨ps_sp1, ps_spG2, hsd1, hsu1, h_sp1,
+              ⟨ps_sp2, ps_sp3, hsd2, hsu2, h_sp2, h_sp3⟩⟩⟩
+        refine ⟨ps_eG, ps_r5, hd5, hu5, ?_, ?_⟩
+        · exact ⟨ps_e32a, ps_eG1, hed0, heu0, h_e32a,
+            ⟨ps_e32b, ps_eG2, hed1, heu1, h_e32b,
+              ⟨ps_e32c, ps_e32d, hed2, heu2, h_e32c, h_e32d⟩⟩⟩
+        refine ⟨ps_x6, ps_r12, hd12, hu12, h_x6, ?_⟩
+        refine ⟨ps_x7, ps_r13, hd13, hu13, h_x7, ?_⟩
+        refine ⟨ps_x10, ps_r14, hd14, hu14, h_x10, ?_⟩
+        refine ⟨ps_x11, ps_r15, hd15, hu15, h_x11, ?_⟩
+        refine ⟨ps_w0, ps_r16, hdw0, huw0, h_w0, ?_⟩
+        refine ⟨ps_w1, ps_r17, hdw1, huw1, h_w1, ?_⟩
+        refine ⟨ps_w2, ps_r18, hdw2, huw2, h_w2, ?_⟩
+        refine ⟨ps_w3, ps_r19, hdw3, huw3, h_w3, ?_⟩
+        refine ⟨ps_x1, ps_r20, hd20, hu20, h_x1, ?_⟩
+        refine ⟨ps_x19, ps_r21, hd21, hu21, h_x19, ?_⟩
+        refine ⟨ps_x20, ps_r22, hd22, hu22, h_x20, ?_⟩
+        refine ⟨ps_x18, ps_r23, hd23, hu23, h_x18, ?_⟩
+        refine ⟨ps_x16, ps_aft2, hd16, hu16, h_x16, ?_⟩
+        exact ⟨ps_ptr, ps_bit, hdptr, huptr, h_ptr, hbit_emp⟩
+      · exact ⟨ps_a0, ps_bf1, hda0, hua0, h_a0,
+          ⟨ps_a1, ps_bf2, hda1, hua1, h_a1,
+            ⟨ps_a2, ps_a3, hda23, hua23, h_a2, h_a3⟩⟩⟩
+    · exact ⟨ps_x0, ps_ef1, hdx0, hux0, h_x0,
+        ⟨ps_x1e, ps_ef2, hdx1, hux1, h_x1e,
+          ⟨ps_x2e, ps_x3e, hdx23, hux23, h_x2e, h_x3e⟩⟩⟩
+  sep_perm h_full

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedExitBridge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedExitBridge.lean
@@ -357,3 +357,177 @@ theorem expTwoMulFixedIterSkipCondCountPost_to_FullStackPreFrame
         ⟨ps_x1e, ps_ef2, hdx1, hux1, h_x1e,
           ⟨ps_x2e, ps_x3e, hdx23, hux23, h_x2e, h_x3e⟩⟩⟩
   sep_perm h_full
+
+/-- ReloadCond (reload, bit≠0) exit-post disjunct → full-stack exit pre-frame. -/
+theorem expTwoMulFixedIterReloadCondCountPost_to_FullStackPreFrame
+    {iterCount e c6 ptr nextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exponentWord : EvmWord} {ps : PartialState}
+    (h : (expTwoMulFixedIterReloadCondCountPost iterCount e c6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base (expTwoMulIterCountNew iterCount = 0) **
+          evmWordIs (evmSp + signExtend12 ((-32) : BitVec 12)) exponentWord) ps) :
+    ∃ w0 w1 w2 w3 : Word,
+      (expTwoMulLoopExitFullStackPreFrame sp (evmSp - 64)
+          (expTwoMulIterCountNew iterCount)
+          ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+          ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0)
+          ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1)
+          ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2)
+          ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+          (exponentWord.getLimbN 0) (exponentWord.getLimbN 1)
+          (exponentWord.getLimbN 2) (exponentWord.getLimbN 3)
+          (expResultWord a0 a1 a2 a3)
+          [expResultWord w0 w1 w2 w3,
+            expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3]
+          (expTwoMulIterCountNew iterCount = 0) **
+       (.x19 ↦ᵣ nextLimb) **
+       (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+       (.x18 ↦ᵣ (e >>> (63 : BitVec 6).toNat)) **
+       (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
+       ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+       (.x1 ↦ᵣ (((base + 44) + 140) + 68)) **
+       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11) ps := by
+  simp only [expTwoMulFixedIterReloadCondCountPost, expTwoMulFixedIterSkipCondRest,
+             expTwoMulFixedIterReloadCondFrame, evmWordIs] at h
+  simp only [signExtend12_0,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg64,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg56,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg48,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg40,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg32,
+             EvmAsm.Rv64.AddrNorm.word_add_zero,
+             BitVec.add_assoc,
+             show (32:Word) + 8 = 40 from by decide,
+             show (32:Word) + 16 = 48 from by decide,
+             show (32:Word) + 24 = 56 from by decide,
+             show (18446744073709551584:Word) + 8 = 18446744073709551592 from by decide,
+             show (18446744073709551584:Word) + 16 = 18446744073709551600 from by decide,
+             show (18446744073709551584:Word) + 24 = 18446744073709551608 from by decide] at h
+  obtain ⟨ps_LB, ps_ef, hd_ef, hu_ef, h_LB, h_ef⟩ := h
+  obtain ⟨ps_inner, ps_scf, hd_scf, hu_scf, h_inner, h_scf⟩ := h_LB
+  obtain ⟨ps_x9x0, ps_sr, hd_sr, hu_sr, h_x9x0, h_sr⟩ := h_inner
+  obtain ⟨ps_x2, ps_r1, hd1, hu1, h_x2, h_r1⟩ := h_sr
+  obtain ⟨ps_x12, ps_r2, hd2, hu2, h_x12, h_r2⟩ := h_r1
+  obtain ⟨ps_x5, ps_r3, hd3, hu3, h_x5, h_r3⟩ := h_r2
+  obtain ⟨ps_a0, ps_ra0, hda0, hua0, h_a0, h_ra0⟩ := h_r3
+  obtain ⟨ps_a1, ps_ra1, hda1, hua1, h_a1, h_ra1⟩ := h_ra0
+  obtain ⟨ps_a2, ps_ra2, hda2, hua2, h_a2, h_ra2⟩ := h_ra1
+  obtain ⟨ps_a3, ps_r3b, hda3, hua3, h_a3, h_r3b⟩ := h_ra2
+  obtain ⟨ps_spG, ps_r4, hd4, hu4, h_spG, h_r4⟩ := h_r3b
+  obtain ⟨ps_sp0, ps_spG1, hsd0, hsu0, h_sp0, h_spG1⟩ := h_spG
+  obtain ⟨ps_sp1, ps_spG2, hsd1, hsu1, h_sp1, h_spG2⟩ := h_spG1
+  obtain ⟨ps_sp2, ps_sp3, hsd2, hsu2, h_sp2, h_sp3⟩ := h_spG2
+  obtain ⟨ps_eG, ps_r5, hd5, hu5, h_eG, h_r5⟩ := h_r4
+  obtain ⟨ps_e32a, ps_eG1, hed0, heu0, h_e32a, h_eG1⟩ := h_eG
+  obtain ⟨ps_e32b, ps_eG2, hed1, heu1, h_e32b, h_eG2⟩ := h_eG1
+  obtain ⟨ps_e32c, ps_e32d, hed2, heu2, h_e32c, h_e32d⟩ := h_eG2
+  obtain ⟨ps_x6, ps_r12, hd12, hu12, h_x6, h_r12⟩ := h_r5
+  obtain ⟨ps_x7, ps_r13, hd13, hu13, h_x7, h_r13⟩ := h_r12
+  obtain ⟨ps_x10, ps_r14, hd14, hu14, h_x10, h_r14⟩ := h_r13
+  obtain ⟨ps_x11, ps_r15, hd15, hu15, h_x11, h_r15⟩ := h_r14
+  obtain ⟨w0, h_w0c⟩ := sepConj_choose_memOwn h_r15
+  obtain ⟨ps_w0, ps_r16, hdw0, huw0, h_w0, h_r16⟩ := h_w0c
+  obtain ⟨w1, h_w1c⟩ := sepConj_choose_memOwn h_r16
+  obtain ⟨ps_w1, ps_r17, hdw1, huw1, h_w1, h_r17⟩ := h_w1c
+  obtain ⟨w2, h_w2c⟩ := sepConj_choose_memOwn h_r17
+  obtain ⟨ps_w2, ps_r18, hdw2, huw2, h_w2, h_r18⟩ := h_w2c
+  obtain ⟨w3, h_w3c⟩ := sepConj_choose_memOwn h_r18
+  obtain ⟨ps_w3, ps_x1, hdw3, huw3, h_w3, h_x1⟩ := h_w3c
+  -- ReloadCondFrame: x19, x20, x18, ⌜c6New=0⌝ (absorbed), x16, ptr-cell, ⌜bit≠0⌝ (→emp)
+  obtain ⟨ps_x19, ps_scf1, hd19, hu19, h_x19, h_scf1⟩ := h_scf
+  obtain ⟨ps_x20, ps_scf2, hd20, hu20, h_x20, h_scf2⟩ := h_scf1
+  obtain ⟨ps_x18, ps_scf3, hd18, hu18, h_x18, h_scf3⟩ := h_scf2
+  obtain ⟨_pc6, h_aft⟩ := (sepConj_pure_left _).mp h_scf3
+  obtain ⟨ps_x16, ps_aft2, hd16, hu16, h_x16, h_aft2⟩ := h_aft
+  obtain ⟨ps_ptr, ps_bit, hdptr, huptr, h_ptr, h_bitpure⟩ := h_aft2
+  have hbit_emp : ps_bit = PartialState.empty := h_bitpure.1
+  -- exponent frame: 4 atoms
+  obtain ⟨ps_x0e, ps_ef1, hdx0, hux0, h_x0e, h_ef1⟩ := h_ef
+  obtain ⟨ps_x1e, ps_ef2, hdx1, hux1, h_x1e, h_ef2⟩ := h_ef1
+  obtain ⟨ps_x2e, ps_x3e, hdx23, hux23, h_x2e, h_x3e⟩ := h_ef2
+  refine ⟨w0, w1, w2, w3, ?_⟩
+  rw [expTwoMulLoopExitFullStackPreFrame_unfold, expTwoMulLoopExitControl_unfold]
+  rw [show (evmSp - 64 : Word) = evmSp + 18446744073709551552 from by bv_omega]
+  simp only [evmWordIs, evmStackIs,
+             signExtend12_0, signExtend12_8, signExtend12_16, signExtend12_24,
+             signExtend12_64,
+             EvmAsm.Rv64.AddrNorm.word_add_zero,
+             BitVec.add_assoc,
+             expResultWord_getLimbN_0, expResultWord_getLimbN_1,
+             expResultWord_getLimbN_2, expResultWord_getLimbN_3,
+             show (18446744073709551552:Word) + 8 = 18446744073709551560 from by decide,
+             show (18446744073709551552:Word) + 16 = 18446744073709551568 from by decide,
+             show (18446744073709551552:Word) + 24 = 18446744073709551576 from by decide,
+             show (18446744073709551552:Word) + 32 = 18446744073709551584 from by decide,
+             show (18446744073709551552:Word) + 64 = 0 from by decide,
+             show (18446744073709551584:Word) + 8 = 18446744073709551592 from by decide,
+             show (18446744073709551584:Word) + 16 = 18446744073709551600 from by decide,
+             show (18446744073709551584:Word) + 24 = 18446744073709551608 from by decide,
+             show (18446744073709551584:Word) + 32 = 0 from by decide,
+             show (32:Word) + 8 = 40 from by decide,
+             show (32:Word) + 16 = 48 from by decide,
+             show (32:Word) + 24 = 56 from by decide]
+  have h_full :
+      (((((Reg.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (Reg.x0 ↦ᵣ 0) **
+          ⌜expTwoMulIterCountNew iterCount = 0⌝) **
+         (Reg.x2 ↦ᵣ sp) ** (Reg.x12 ↦ᵣ evmSp) **
+         (Reg.x5 ↦ᵣ (expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3) **
+         (evmSp + 18446744073709551552 ↦ₘ a0) **
+         (evmSp + 18446744073709551560 ↦ₘ a1) **
+         (evmSp + 18446744073709551568 ↦ₘ a2) **
+         (evmSp + 18446744073709551576 ↦ₘ a3) **
+         (((sp ↦ₘ (expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0) **
+            (sp + 8 ↦ₘ (expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1) **
+            (sp + 16 ↦ₘ (expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2) **
+            (sp + 24 ↦ₘ (expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3))) **
+         (((evmSp + 32 ↦ₘ (expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0) **
+            (evmSp + 40 ↦ₘ (expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1) **
+            (evmSp + 48 ↦ₘ (expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2) **
+            (evmSp + 56 ↦ₘ (expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3))) **
+         regOwn Reg.x6 ** regOwn Reg.x7 ** regOwn Reg.x10 ** regOwn Reg.x11 **
+         (evmSp ↦ₘ w0) ** (evmSp + 8 ↦ₘ w1) ** (evmSp + 16 ↦ₘ w2) **
+         (evmSp + 24 ↦ₘ w3) **
+         (Reg.x1 ↦ᵣ base + (44 + (140 + 68)))) **
+        ((Reg.x19 ↦ᵣ nextLimb) **
+         (Reg.x20 ↦ᵣ (0 : Word) + signExtend12 (64 : BitVec 12)) **
+         (Reg.x18 ↦ᵣ e >>> (63 : BitVec 6).toNat) **
+         (Reg.x16 ↦ᵣ ptr + signExtend12 (-8 : BitVec 12)) **
+         (ptr ↦ₘ nextLimb) ** empAssertion)) **
+       ((evmSp + 18446744073709551584 ↦ₘ exponentWord.getLimbN 0) **
+        (evmSp + 18446744073709551592 ↦ₘ exponentWord.getLimbN 1) **
+        (evmSp + 18446744073709551600 ↦ₘ exponentWord.getLimbN 2) **
+        (evmSp + 18446744073709551608 ↦ₘ exponentWord.getLimbN 3))) ps := by
+    refine ⟨ps_LB, ps_ef, hd_ef, hu_ef, ?_, ?_⟩
+    · refine ⟨ps_inner, ps_scf, hd_scf, hu_scf, ?_, ?_⟩
+      · refine ⟨ps_x9x0, ps_sr, hd_sr, hu_sr, h_x9x0, ?_⟩
+        refine ⟨ps_x2, ps_r1, hd1, hu1, h_x2, ?_⟩
+        refine ⟨ps_x12, ps_r2, hd2, hu2, h_x12, ?_⟩
+        refine ⟨ps_x5, ps_r3, hd3, hu3, h_x5, ?_⟩
+        refine ⟨ps_a0, ps_ra0, hda0, hua0, h_a0, ?_⟩
+        refine ⟨ps_a1, ps_ra1, hda1, hua1, h_a1, ?_⟩
+        refine ⟨ps_a2, ps_ra2, hda2, hua2, h_a2, ?_⟩
+        refine ⟨ps_a3, ps_r3b, hda3, hua3, h_a3, ?_⟩
+        refine ⟨ps_spG, ps_r4, hd4, hu4, ?_, ?_⟩
+        · exact ⟨ps_sp0, ps_spG1, hsd0, hsu0, h_sp0,
+            ⟨ps_sp1, ps_spG2, hsd1, hsu1, h_sp1,
+              ⟨ps_sp2, ps_sp3, hsd2, hsu2, h_sp2, h_sp3⟩⟩⟩
+        refine ⟨ps_eG, ps_r5, hd5, hu5, ?_, ?_⟩
+        · exact ⟨ps_e32a, ps_eG1, hed0, heu0, h_e32a,
+            ⟨ps_e32b, ps_eG2, hed1, heu1, h_e32b,
+              ⟨ps_e32c, ps_e32d, hed2, heu2, h_e32c, h_e32d⟩⟩⟩
+        refine ⟨ps_x6, ps_r12, hd12, hu12, h_x6, ?_⟩
+        refine ⟨ps_x7, ps_r13, hd13, hu13, h_x7, ?_⟩
+        refine ⟨ps_x10, ps_r14, hd14, hu14, h_x10, ?_⟩
+        refine ⟨ps_x11, ps_r15, hd15, hu15, h_x11, ?_⟩
+        refine ⟨ps_w0, ps_r16, hdw0, huw0, h_w0, ?_⟩
+        refine ⟨ps_w1, ps_r17, hdw1, huw1, h_w1, ?_⟩
+        refine ⟨ps_w2, ps_r18, hdw2, huw2, h_w2, ?_⟩
+        refine ⟨ps_w3, ps_x1, hdw3, huw3, h_w3, h_x1⟩
+      · refine ⟨ps_x19, ps_scf1, hd19, hu19, h_x19, ?_⟩
+        refine ⟨ps_x20, ps_scf2, hd20, hu20, h_x20, ?_⟩
+        refine ⟨ps_x18, ps_scf3, hd18, hu18, h_x18, ?_⟩
+        refine ⟨ps_x16, ps_aft2, hd16, hu16, h_x16, ?_⟩
+        exact ⟨ps_ptr, ps_bit, hdptr, huptr, h_ptr, hbit_emp⟩
+    · exact ⟨ps_x0e, ps_ef1, hdx0, hux0, h_x0e,
+        ⟨ps_x1e, ps_ef2, hdx1, hux1, h_x1e,
+          ⟨ps_x2e, ps_x3e, hdx23, hux23, h_x2e, h_x3e⟩⟩⟩
+  sep_perm h_full

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedExitBridge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedExitBridge.lean
@@ -188,3 +188,172 @@ theorem expTwoMulFixedIterSkipCountPost_to_FullStackPreFrame
         ⟨ps_x1e, ps_ef2, hdx1, hux1, h_x1e,
           ⟨ps_x2e, ps_x3e, hdx23, hux23, h_x2e, h_x3e⟩⟩⟩
   sep_perm h_full
+
+/-- SkipCond (no-reload, bit≠0) exit-post disjunct → full-stack exit pre-frame. -/
+theorem expTwoMulFixedIterSkipCondCountPost_to_FullStackPreFrame
+    {iterCount e c6 sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exponentWord : EvmWord} {ps : PartialState}
+    (h : (expTwoMulFixedIterSkipCondCountPost iterCount e c6 sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base (expTwoMulIterCountNew iterCount = 0) **
+          evmWordIs (evmSp + signExtend12 ((-32) : BitVec 12)) exponentWord) ps) :
+    ∃ w0 w1 w2 w3 : Word,
+      (expTwoMulLoopExitFullStackPreFrame sp (evmSp - 64)
+          (expTwoMulIterCountNew iterCount)
+          ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+          ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0)
+          ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1)
+          ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2)
+          ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+          (exponentWord.getLimbN 0) (exponentWord.getLimbN 1)
+          (exponentWord.getLimbN 2) (exponentWord.getLimbN 3)
+          (expResultWord a0 a1 a2 a3)
+          [expResultWord w0 w1 w2 w3,
+            expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3]
+          (expTwoMulIterCountNew iterCount = 0) **
+       (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+       (.x20 ↦ᵣ (c6 + signExtend12 (-1 : BitVec 12))) **
+       (.x18 ↦ᵣ (e >>> (63 : BitVec 6).toNat)) **
+       (.x1 ↦ᵣ (((base + 44) + 140) + 68)) **
+       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11) ps := by
+  simp only [expTwoMulFixedIterSkipCondCountPost, expTwoMulFixedIterSkipCondRest,
+             expTwoMulFixedIterSkipCondFrame, evmWordIs] at h
+  simp only [signExtend12_0,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg64,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg56,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg48,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg40,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg32,
+             EvmAsm.Rv64.AddrNorm.word_add_zero,
+             BitVec.add_assoc,
+             show (32:Word) + 8 = 40 from by decide,
+             show (32:Word) + 16 = 48 from by decide,
+             show (32:Word) + 24 = 56 from by decide,
+             show (18446744073709551584:Word) + 8 = 18446744073709551592 from by decide,
+             show (18446744073709551584:Word) + 16 = 18446744073709551600 from by decide,
+             show (18446744073709551584:Word) + 24 = 18446744073709551608 from by decide] at h
+  -- Navigate: (((x9x0pure ** SkipCondRest) ** SkipCondFrame) ** expFrame)
+  obtain ⟨ps_LB, ps_ef, hd_ef, hu_ef, h_LB, h_ef⟩ := h
+  obtain ⟨ps_inner, ps_scf, hd_scf, hu_scf, h_inner, h_scf⟩ := h_LB
+  obtain ⟨ps_x9x0, ps_sr, hd_sr, hu_sr, h_x9x0, h_sr⟩ := h_inner
+  obtain ⟨ps_x2, ps_r1, hd1, hu1, h_x2, h_r1⟩ := h_sr
+  obtain ⟨ps_x12, ps_r2, hd2, hu2, h_x12, h_r2⟩ := h_r1
+  obtain ⟨ps_x5, ps_r3, hd3, hu3, h_x5, h_r3⟩ := h_r2
+  obtain ⟨ps_a0, ps_ra0, hda0, hua0, h_a0, h_ra0⟩ := h_r3
+  obtain ⟨ps_a1, ps_ra1, hda1, hua1, h_a1, h_ra1⟩ := h_ra0
+  obtain ⟨ps_a2, ps_ra2, hda2, hua2, h_a2, h_ra2⟩ := h_ra1
+  obtain ⟨ps_a3, ps_r3b, hda3, hua3, h_a3, h_r3b⟩ := h_ra2
+  -- evmWordIs sp rw (4-atom group)
+  obtain ⟨ps_spG, ps_r4, hd4, hu4, h_spG, h_r4⟩ := h_r3b
+  obtain ⟨ps_sp0, ps_spG1, hsd0, hsu0, h_sp0, h_spG1⟩ := h_spG
+  obtain ⟨ps_sp1, ps_spG2, hsd1, hsu1, h_sp1, h_spG2⟩ := h_spG1
+  obtain ⟨ps_sp2, ps_sp3, hsd2, hsu2, h_sp2, h_sp3⟩ := h_spG2
+  -- evmWordIs (evmSp+32) rw (4-atom group)
+  obtain ⟨ps_eG, ps_r5, hd5, hu5, h_eG, h_r5⟩ := h_r4
+  obtain ⟨ps_e32a, ps_eG1, hed0, heu0, h_e32a, h_eG1⟩ := h_eG
+  obtain ⟨ps_e32b, ps_eG2, hed1, heu1, h_e32b, h_eG2⟩ := h_eG1
+  obtain ⟨ps_e32c, ps_e32d, hed2, heu2, h_e32c, h_e32d⟩ := h_eG2
+  obtain ⟨ps_x6, ps_r12, hd12, hu12, h_x6, h_r12⟩ := h_r5
+  obtain ⟨ps_x7, ps_r13, hd13, hu13, h_x7, h_r13⟩ := h_r12
+  obtain ⟨ps_x10, ps_r14, hd14, hu14, h_x10, h_r14⟩ := h_r13
+  obtain ⟨ps_x11, ps_r15, hd15, hu15, h_x11, h_r15⟩ := h_r14
+  obtain ⟨w0, h_w0c⟩ := sepConj_choose_memOwn h_r15
+  obtain ⟨ps_w0, ps_r16, hdw0, huw0, h_w0, h_r16⟩ := h_w0c
+  obtain ⟨w1, h_w1c⟩ := sepConj_choose_memOwn h_r16
+  obtain ⟨ps_w1, ps_r17, hdw1, huw1, h_w1, h_r17⟩ := h_w1c
+  obtain ⟨w2, h_w2c⟩ := sepConj_choose_memOwn h_r17
+  obtain ⟨ps_w2, ps_r18, hdw2, huw2, h_w2, h_r18⟩ := h_w2c
+  obtain ⟨w3, h_w3c⟩ := sepConj_choose_memOwn h_r18
+  obtain ⟨ps_w3, ps_x1, hdw3, huw3, h_w3, h_x1⟩ := h_w3c
+  -- SkipCondFrame: x19, x20, x18, then two pure facts (drop → one emp)
+  obtain ⟨ps_x19, ps_scf1, hd19, hu19, h_x19, h_scf1⟩ := h_scf
+  obtain ⟨ps_x20, ps_scf2, hd20, hu20, h_x20, h_scf2⟩ := h_scf1
+  obtain ⟨ps_x18, ps_pures, hd18, hu18, h_x18, h_pures⟩ := h_scf2
+  obtain ⟨_pc6, h_bit⟩ := (sepConj_pure_left _).mp h_pures
+  have hpures_emp : ps_pures = PartialState.empty := h_bit.1
+  -- exponent frame: 4 atoms
+  obtain ⟨ps_x0e, ps_ef1, hdx0, hux0, h_x0e, h_ef1⟩ := h_ef
+  obtain ⟨ps_x1e, ps_ef2, hdx1, hux1, h_x1e, h_ef2⟩ := h_ef1
+  obtain ⟨ps_x2e, ps_x3e, hdx23, hux23, h_x2e, h_x3e⟩ := h_ef2
+  refine ⟨w0, w1, w2, w3, ?_⟩
+  rw [expTwoMulLoopExitFullStackPreFrame_unfold, expTwoMulLoopExitControl_unfold]
+  rw [show (evmSp - 64 : Word) = evmSp + 18446744073709551552 from by bv_omega]
+  simp only [evmWordIs, evmStackIs,
+             signExtend12_0, signExtend12_8, signExtend12_16, signExtend12_24,
+             signExtend12_64,
+             EvmAsm.Rv64.AddrNorm.word_add_zero,
+             BitVec.add_assoc,
+             expResultWord_getLimbN_0, expResultWord_getLimbN_1,
+             expResultWord_getLimbN_2, expResultWord_getLimbN_3,
+             show (18446744073709551552:Word) + 8 = 18446744073709551560 from by decide,
+             show (18446744073709551552:Word) + 16 = 18446744073709551568 from by decide,
+             show (18446744073709551552:Word) + 24 = 18446744073709551576 from by decide,
+             show (18446744073709551552:Word) + 32 = 18446744073709551584 from by decide,
+             show (18446744073709551552:Word) + 64 = 0 from by decide,
+             show (18446744073709551584:Word) + 8 = 18446744073709551592 from by decide,
+             show (18446744073709551584:Word) + 16 = 18446744073709551600 from by decide,
+             show (18446744073709551584:Word) + 24 = 18446744073709551608 from by decide,
+             show (18446744073709551584:Word) + 32 = 0 from by decide,
+             show (32:Word) + 8 = 40 from by decide,
+             show (32:Word) + 16 = 48 from by decide,
+             show (32:Word) + 24 = 56 from by decide]
+  have h_full :
+      (((((Reg.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (Reg.x0 ↦ᵣ 0) **
+          ⌜expTwoMulIterCountNew iterCount = 0⌝) **
+         (Reg.x2 ↦ᵣ sp) ** (Reg.x12 ↦ᵣ evmSp) **
+         (Reg.x5 ↦ᵣ (expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3) **
+         (evmSp + 18446744073709551552 ↦ₘ a0) **
+         (evmSp + 18446744073709551560 ↦ₘ a1) **
+         (evmSp + 18446744073709551568 ↦ₘ a2) **
+         (evmSp + 18446744073709551576 ↦ₘ a3) **
+         (((sp ↦ₘ (expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0) **
+            (sp + 8 ↦ₘ (expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1) **
+            (sp + 16 ↦ₘ (expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2) **
+            (sp + 24 ↦ₘ (expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3))) **
+         (((evmSp + 32 ↦ₘ (expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0) **
+            (evmSp + 40 ↦ₘ (expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1) **
+            (evmSp + 48 ↦ₘ (expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2) **
+            (evmSp + 56 ↦ₘ (expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3))) **
+         regOwn Reg.x6 ** regOwn Reg.x7 ** regOwn Reg.x10 ** regOwn Reg.x11 **
+         (evmSp ↦ₘ w0) ** (evmSp + 8 ↦ₘ w1) ** (evmSp + 16 ↦ₘ w2) **
+         (evmSp + 24 ↦ₘ w3) **
+         (Reg.x1 ↦ᵣ base + (44 + (140 + 68)))) **
+        ((Reg.x19 ↦ᵣ e <<< (1 : BitVec 6).toNat) **
+         (Reg.x20 ↦ᵣ c6 + signExtend12 (-1 : BitVec 12)) **
+         ((Reg.x18 ↦ᵣ e >>> (63 : BitVec 6).toNat) ** empAssertion))) **
+       ((evmSp + 18446744073709551584 ↦ₘ exponentWord.getLimbN 0) **
+        (evmSp + 18446744073709551592 ↦ₘ exponentWord.getLimbN 1) **
+        (evmSp + 18446744073709551600 ↦ₘ exponentWord.getLimbN 2) **
+        (evmSp + 18446744073709551608 ↦ₘ exponentWord.getLimbN 3))) ps := by
+    refine ⟨ps_LB, ps_ef, hd_ef, hu_ef, ?_, ?_⟩
+    · refine ⟨ps_inner, ps_scf, hd_scf, hu_scf, ?_, ?_⟩
+      · refine ⟨ps_x9x0, ps_sr, hd_sr, hu_sr, h_x9x0, ?_⟩
+        refine ⟨ps_x2, ps_r1, hd1, hu1, h_x2, ?_⟩
+        refine ⟨ps_x12, ps_r2, hd2, hu2, h_x12, ?_⟩
+        refine ⟨ps_x5, ps_r3, hd3, hu3, h_x5, ?_⟩
+        refine ⟨ps_a0, ps_ra0, hda0, hua0, h_a0, ?_⟩
+        refine ⟨ps_a1, ps_ra1, hda1, hua1, h_a1, ?_⟩
+        refine ⟨ps_a2, ps_ra2, hda2, hua2, h_a2, ?_⟩
+        refine ⟨ps_a3, ps_r3b, hda3, hua3, h_a3, ?_⟩
+        refine ⟨ps_spG, ps_r4, hd4, hu4, ?_, ?_⟩
+        · exact ⟨ps_sp0, ps_spG1, hsd0, hsu0, h_sp0,
+            ⟨ps_sp1, ps_spG2, hsd1, hsu1, h_sp1,
+              ⟨ps_sp2, ps_sp3, hsd2, hsu2, h_sp2, h_sp3⟩⟩⟩
+        refine ⟨ps_eG, ps_r5, hd5, hu5, ?_, ?_⟩
+        · exact ⟨ps_e32a, ps_eG1, hed0, heu0, h_e32a,
+            ⟨ps_e32b, ps_eG2, hed1, heu1, h_e32b,
+              ⟨ps_e32c, ps_e32d, hed2, heu2, h_e32c, h_e32d⟩⟩⟩
+        refine ⟨ps_x6, ps_r12, hd12, hu12, h_x6, ?_⟩
+        refine ⟨ps_x7, ps_r13, hd13, hu13, h_x7, ?_⟩
+        refine ⟨ps_x10, ps_r14, hd14, hu14, h_x10, ?_⟩
+        refine ⟨ps_x11, ps_r15, hd15, hu15, h_x11, ?_⟩
+        refine ⟨ps_w0, ps_r16, hdw0, huw0, h_w0, ?_⟩
+        refine ⟨ps_w1, ps_r17, hdw1, huw1, h_w1, ?_⟩
+        refine ⟨ps_w2, ps_r18, hdw2, huw2, h_w2, ?_⟩
+        refine ⟨ps_w3, ps_x1, hdw3, huw3, h_w3, h_x1⟩
+      · refine ⟨ps_x19, ps_scf1, hd19, hu19, h_x19, ?_⟩
+        refine ⟨ps_x20, ps_scf2, hd20, hu20, h_x20, ?_⟩
+        exact ⟨ps_x18, ps_pures, hd18, hu18, h_x18, hpures_emp⟩
+    · exact ⟨ps_x0e, ps_ef1, hdx0, hux0, h_x0e,
+        ⟨ps_x1e, ps_ef2, hdx1, hux1, h_x1e,
+          ⟨ps_x2e, ps_x3e, hdx23, hux23, h_x2e, h_x3e⟩⟩⟩
+  sep_perm h_full

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedExitBridge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedExitBridge.lean
@@ -1,0 +1,190 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedExitBridge
+
+  Exit bridge for the fixed-x20 EXP loop body: from a final-iteration exit
+  post-condition disjunct (`expTwoMulFixedIter*CountPost … (IterCountNew = 0)`)
+  plus the exponent frame `evmWordIs (evmSp + signExtend12 (-32)) exponentWord`,
+  prove `(expTwoMulLoopExitFullStackPreFrame sp (evmSp - 64) … ** leftover) ps`.
+
+  Mirrors `SavedBitIterExitBridge.lean`, adapted for the fixed per-limb counter
+  in `x20` (carried into the leftover; irrelevant at loop exit) and the fixed
+  rest-structures.  The iteration runs at `evmSp_iter = evmSp + 64`, so the
+  bridge maps `…(evmSp_iter)… → LoopExitFullStackPreFrame sp (evmSp_iter − 64)`.
+
+  Bead: evm-asm-20z6.13.7 (exit bridge / step 3).
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoop
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePosts
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+/-- Skip (no-reload, bit=0) exit-post disjunct → full-stack exit pre-frame. -/
+theorem expTwoMulFixedIterSkipCountPost_to_FullStackPreFrame
+    {iterCount e c6 sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exponentWord : EvmWord} {ps : PartialState}
+    (h : (expTwoMulFixedIterSkipCountPost iterCount e c6 sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base (expTwoMulIterCountNew iterCount = 0) **
+          evmWordIs (evmSp + signExtend12 ((-32) : BitVec 12)) exponentWord) ps) :
+    ∃ w0 w1 w2 w3 : Word,
+      (expTwoMulLoopExitFullStackPreFrame sp (evmSp - 64)
+          (expTwoMulIterCountNew iterCount)
+          ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+          ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0)
+          ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1)
+          ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2)
+          ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+          (exponentWord.getLimbN 0) (exponentWord.getLimbN 1)
+          (exponentWord.getLimbN 2) (exponentWord.getLimbN 3)
+          (expResultWord a0 a1 a2 a3)
+          [expResultWord w0 w1 w2 w3, expSquaringCallSquareW r0 r1 r2 r3]
+          (expTwoMulIterCountNew iterCount = 0) **
+       (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+       (.x20 ↦ᵣ (c6 + signExtend12 (-1 : BitVec 12))) **
+       (.x18 ↦ᵣ (e >>> (63 : BitVec 6).toNat)) **
+       (.x1 ↦ᵣ (((base + 44) + 32) + 68)) **
+       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11) ps := by
+  simp only [expTwoMulFixedIterSkipCountPost, expTwoMulFixedIterSkipRest,
+             expTwoMulFixedIterBaseFrame, evmWordIs] at h
+  simp only [signExtend12_0,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg64,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg56,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg48,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg40,
+             EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg32,
+             EvmAsm.Rv64.AddrNorm.word_add_zero,
+             BitVec.add_assoc,
+             show (32:Word) + 8 = 40 from by decide,
+             show (32:Word) + 16 = 48 from by decide,
+             show (32:Word) + 24 = 56 from by decide,
+             show (18446744073709551584:Word) + 8 = 18446744073709551592 from by decide,
+             show (18446744073709551584:Word) + 16 = 18446744073709551600 from by decide,
+             show (18446744073709551584:Word) + 24 = 18446744073709551608 from by decide] at h
+  -- Navigate the source tree: ((Inner ** BaseFrame) ** exponentFrame)
+  obtain ⟨ps_LB, ps_ef, hd_ef, hu_ef, h_LB, h_ef⟩ := h
+  obtain ⟨ps_inner, ps_bf, hd_bf, hu_bf, h_inner, h_bf⟩ := h_LB
+  obtain ⟨ps_x9x0, ps_sr, hd_sr, hu_sr, h_x9x0, h_sr⟩ := h_inner
+  obtain ⟨ps_x2, ps_r1, hd1, hu1, h_x2, h_r1⟩ := h_sr
+  obtain ⟨ps_x12, ps_r2, hd2, hu2, h_x12, h_r2⟩ := h_r1
+  obtain ⟨ps_x5, ps_r3, hd3, hu3, h_x5, h_r3⟩ := h_r2
+  -- evmWordIs sp squareW (4-atom group)
+  obtain ⟨ps_spG, ps_r4, hd4, hu4, h_spG, h_r4⟩ := h_r3
+  obtain ⟨ps_sp0, ps_spG1, hsd0, hsu0, h_sp0, h_spG1⟩ := h_spG
+  obtain ⟨ps_sp1, ps_spG2, hsd1, hsu1, h_sp1, h_spG2⟩ := h_spG1
+  obtain ⟨ps_sp2, ps_sp3, hsd2, hsu2, h_sp2, h_sp3⟩ := h_spG2
+  -- evmWordIs (evmSp+32) squareW (4-atom group)
+  obtain ⟨ps_eG, ps_r5, hd5, hu5, h_eG, h_r5⟩ := h_r4
+  obtain ⟨ps_e32a, ps_eG1, hed0, heu0, h_e32a, h_eG1⟩ := h_eG
+  obtain ⟨ps_e32b, ps_eG2, hed1, heu1, h_e32b, h_eG2⟩ := h_eG1
+  obtain ⟨ps_e32c, ps_e32d, hed2, heu2, h_e32c, h_e32d⟩ := h_eG2
+  obtain ⟨ps_x6, ps_r12, hd12, hu12, h_x6, h_r12⟩ := h_r5
+  obtain ⟨ps_x7, ps_r13, hd13, hu13, h_x7, h_r13⟩ := h_r12
+  obtain ⟨ps_x10, ps_r14, hd14, hu14, h_x10, h_r14⟩ := h_r13
+  obtain ⟨ps_x11, ps_r15, hd15, hu15, h_x11, h_r15⟩ := h_r14
+  obtain ⟨w0, h_w0c⟩ := sepConj_choose_memOwn h_r15
+  obtain ⟨ps_w0, ps_r16, hdw0, huw0, h_w0, h_r16⟩ := h_w0c
+  obtain ⟨w1, h_w1c⟩ := sepConj_choose_memOwn h_r16
+  obtain ⟨ps_w1, ps_r17, hdw1, huw1, h_w1, h_r17⟩ := h_w1c
+  obtain ⟨w2, h_w2c⟩ := sepConj_choose_memOwn h_r17
+  obtain ⟨ps_w2, ps_r18, hdw2, huw2, h_w2, h_r18⟩ := h_w2c
+  obtain ⟨w3, h_w3c⟩ := sepConj_choose_memOwn h_r18
+  obtain ⟨ps_w3, ps_r19, hdw3, huw3, h_w3, h_r19⟩ := h_w3c
+  obtain ⟨ps_x1, ps_r20, hd20, hu20, h_x1, h_r20⟩ := h_r19
+  obtain ⟨ps_x19, ps_r21, hd21, hu21, h_x19, h_r21⟩ := h_r20
+  obtain ⟨ps_x20, ps_r22, hd22, hu22, h_x20, h_r22⟩ := h_r21
+  obtain ⟨ps_x18, ps_r23, hd23, hu23, h_x18, h_r23⟩ := h_r22
+  obtain ⟨_pne, _pbit⟩ := (sepConj_pure_left _).mp h_r23
+  -- BaseFrame: 4 atoms
+  obtain ⟨ps_a0, ps_bf1, hda0, hua0, h_a0, h_bf1⟩ := h_bf
+  obtain ⟨ps_a1, ps_bf2, hda1, hua1, h_a1, h_bf2⟩ := h_bf1
+  obtain ⟨ps_a2, ps_a3, hda23, hua23, h_a2, h_a3⟩ := h_bf2
+  -- exponent frame: 4 atoms
+  obtain ⟨ps_x0, ps_ef1, hdx0, hux0, h_x0, h_ef1⟩ := h_ef
+  obtain ⟨ps_x1e, ps_ef2, hdx1, hux1, h_x1e, h_ef2⟩ := h_ef1
+  obtain ⟨ps_x2e, ps_x3e, hdx23, hux23, h_x2e, h_x3e⟩ := h_ef2
+  refine ⟨w0, w1, w2, w3, ?_⟩
+  rw [expTwoMulLoopExitFullStackPreFrame_unfold, expTwoMulLoopExitControl_unfold]
+  rw [show (evmSp - 64 : Word) = evmSp + 18446744073709551552 from by bv_omega]
+  simp only [evmWordIs, evmStackIs,
+             signExtend12_0, signExtend12_8, signExtend12_16, signExtend12_24,
+             signExtend12_64,
+             EvmAsm.Rv64.AddrNorm.word_add_zero,
+             BitVec.add_assoc,
+             expResultWord_getLimbN_0, expResultWord_getLimbN_1,
+             expResultWord_getLimbN_2, expResultWord_getLimbN_3,
+             show (18446744073709551552:Word) + 8 = 18446744073709551560 from by decide,
+             show (18446744073709551552:Word) + 16 = 18446744073709551568 from by decide,
+             show (18446744073709551552:Word) + 24 = 18446744073709551576 from by decide,
+             show (18446744073709551552:Word) + 32 = 18446744073709551584 from by decide,
+             show (18446744073709551552:Word) + 64 = 0 from by decide,
+             show (18446744073709551584:Word) + 8 = 18446744073709551592 from by decide,
+             show (18446744073709551584:Word) + 16 = 18446744073709551600 from by decide,
+             show (18446744073709551584:Word) + 24 = 18446744073709551608 from by decide,
+             show (18446744073709551584:Word) + 32 = 0 from by decide,
+             show (32:Word) + 8 = 40 from by decide,
+             show (32:Word) + 16 = 48 from by decide,
+             show (32:Word) + 24 = 56 from by decide]
+  have hr23emp : ps_r23 = PartialState.empty := _pbit.1
+  have h_full :
+      (((((Reg.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (Reg.x0 ↦ᵣ 0) **
+          ⌜expTwoMulIterCountNew iterCount = 0⌝) **
+         (Reg.x2 ↦ᵣ sp) ** (Reg.x12 ↦ᵣ evmSp) **
+         (Reg.x5 ↦ᵣ (expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3) **
+         (((sp ↦ₘ (expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0) **
+            (sp + 8 ↦ₘ (expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1) **
+            (sp + 16 ↦ₘ (expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2) **
+            (sp + 24 ↦ₘ (expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3))) **
+         (((evmSp + 32 ↦ₘ (expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0) **
+            (evmSp + 40 ↦ₘ (expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1) **
+            (evmSp + 48 ↦ₘ (expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2) **
+            (evmSp + 56 ↦ₘ (expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3))) **
+         regOwn Reg.x6 ** regOwn Reg.x7 ** regOwn Reg.x10 ** regOwn Reg.x11 **
+         (evmSp ↦ₘ w0) ** (evmSp + 8 ↦ₘ w1) ** (evmSp + 16 ↦ₘ w2) **
+         (evmSp + 24 ↦ₘ w3) **
+         (Reg.x1 ↦ᵣ base + (44 + (32 + 68))) **
+         (Reg.x19 ↦ᵣ e <<< (1 : BitVec 6).toNat) **
+         (Reg.x20 ↦ᵣ c6 + signExtend12 (-1 : BitVec 12)) **
+         ((Reg.x18 ↦ᵣ e >>> (63 : BitVec 6).toNat) ** empAssertion)) **
+        ((evmSp + 18446744073709551552 ↦ₘ a0) **
+         (evmSp + 18446744073709551560 ↦ₘ a1) **
+         (evmSp + 18446744073709551568 ↦ₘ a2) **
+         (evmSp + 18446744073709551576 ↦ₘ a3))) **
+       ((evmSp + 18446744073709551584 ↦ₘ exponentWord.getLimbN 0) **
+        (evmSp + 18446744073709551592 ↦ₘ exponentWord.getLimbN 1) **
+        (evmSp + 18446744073709551600 ↦ₘ exponentWord.getLimbN 2) **
+        (evmSp + 18446744073709551608 ↦ₘ exponentWord.getLimbN 3))) ps := by
+    refine ⟨ps_LB, ps_ef, hd_ef, hu_ef, ?_, ?_⟩
+    · refine ⟨ps_inner, ps_bf, hd_bf, hu_bf, ?_, ?_⟩
+      · refine ⟨ps_x9x0, ps_sr, hd_sr, hu_sr, h_x9x0, ?_⟩
+        refine ⟨ps_x2, ps_r1, hd1, hu1, h_x2, ?_⟩
+        refine ⟨ps_x12, ps_r2, hd2, hu2, h_x12, ?_⟩
+        refine ⟨ps_x5, ps_r3, hd3, hu3, h_x5, ?_⟩
+        refine ⟨ps_spG, ps_r4, hd4, hu4, ?_, ?_⟩
+        · exact ⟨ps_sp0, ps_spG1, hsd0, hsu0, h_sp0,
+            ⟨ps_sp1, ps_spG2, hsd1, hsu1, h_sp1,
+              ⟨ps_sp2, ps_sp3, hsd2, hsu2, h_sp2, h_sp3⟩⟩⟩
+        refine ⟨ps_eG, ps_r5, hd5, hu5, ?_, ?_⟩
+        · exact ⟨ps_e32a, ps_eG1, hed0, heu0, h_e32a,
+            ⟨ps_e32b, ps_eG2, hed1, heu1, h_e32b,
+              ⟨ps_e32c, ps_e32d, hed2, heu2, h_e32c, h_e32d⟩⟩⟩
+        refine ⟨ps_x6, ps_r12, hd12, hu12, h_x6, ?_⟩
+        refine ⟨ps_x7, ps_r13, hd13, hu13, h_x7, ?_⟩
+        refine ⟨ps_x10, ps_r14, hd14, hu14, h_x10, ?_⟩
+        refine ⟨ps_x11, ps_r15, hd15, hu15, h_x11, ?_⟩
+        refine ⟨ps_w0, ps_r16, hdw0, huw0, h_w0, ?_⟩
+        refine ⟨ps_w1, ps_r17, hdw1, huw1, h_w1, ?_⟩
+        refine ⟨ps_w2, ps_r18, hdw2, huw2, h_w2, ?_⟩
+        refine ⟨ps_w3, ps_r19, hdw3, huw3, h_w3, ?_⟩
+        refine ⟨ps_x1, ps_r20, hd20, hu20, h_x1, ?_⟩
+        refine ⟨ps_x19, ps_r21, hd21, hu21, h_x19, ?_⟩
+        refine ⟨ps_x20, ps_r22, hd22, hu22, h_x20, ?_⟩
+        exact ⟨ps_x18, ps_r23, hd23, hu23, h_x18, hr23emp⟩
+      · exact ⟨ps_a0, ps_bf1, hda0, hua0, h_a0,
+          ⟨ps_a1, ps_bf2, hda1, hua1, h_a1,
+            ⟨ps_a2, ps_a3, hda23, hua23, h_a2, h_a3⟩⟩⟩
+    · exact ⟨ps_x0, ps_ef1, hdx0, hux0, h_x0,
+        ⟨ps_x1e, ps_ef2, hdx1, hux1, h_x1e,
+          ⟨ps_x2e, ps_x3e, hdx23, hux23, h_x2e, h_x3e⟩⟩⟩
+  sep_perm h_full

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedExpResidual.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedExpResidual.lean
@@ -1,0 +1,116 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedExpResidual
+
+  The exponent residual `ExpResidual` carried (as a framed pcFree assertion)
+  by the merged-loop induction: the not-yet-loaded exponent limb cells strictly
+  below the loop pointer `x16 = ptr`, organized by block `b = k / 64`.
+
+  Within a block the pointer `x16` is constant, so `ExpResidual` is constant
+  (it depends only on the block `b` and `ptr`).  At each of the three 64-bit
+  reload boundaries the pointer advances by `-8`, the top residual cell becomes
+  the next iteration's `IterPre` pointer cell (consumed by the proven reload
+  assemblers), and the (now stale) old pointer cell drops into the read-only
+  ambient frame.  The residual therefore shrinks by one cell per reload:
+  block 0 = 2 cells, block 1 = 1 cell, blocks 2-3 = 0 cells.
+
+  This file provides the definition together with the two reload-boundary
+  split identities `..._succ_zero` / `..._succ_one` and the empty-tail fact
+  `..._ge_two`, which the induction uses to re-partition the residual at a
+  reload before applying the IH.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedReloadReshuffle
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+/-- Exponent residual for block `b` at pointer `ptr`: the not-yet-loaded
+    exponent limb cells strictly below `x16 = ptr`.  Block 0 carries the two
+    cells at `ptr-8` (`getLimbN 1`) and `ptr-16` (`getLimbN 0`); block 1 carries
+    the single cell at `ptr-8` (`getLimbN 0`); blocks `≥ 2` carry nothing. -/
+@[irreducible]
+def expTwoMulFixedExpResidual (b : Nat) (ptr : Word)
+    (exponentWord : EvmWord) : Assertion :=
+  match b with
+  | 0 =>
+    (((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
+        exponentWord.getLimbN 1) **
+    ((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (-8 : BitVec 12)) +
+        signExtend12 (0 : BitVec 12)) ↦ₘ exponentWord.getLimbN 0)
+  | 1 =>
+    (((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
+        exponentWord.getLimbN 0)
+  | _ => empAssertion
+
+theorem expTwoMulFixedExpResidual_zero_unfold
+    {ptr : Word} {exponentWord : EvmWord} :
+    expTwoMulFixedExpResidual 0 ptr exponentWord =
+      ((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
+          exponentWord.getLimbN 1) **
+       ((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (-8 : BitVec 12)) +
+          signExtend12 (0 : BitVec 12)) ↦ₘ exponentWord.getLimbN 0)) := by
+  delta expTwoMulFixedExpResidual
+  rfl
+
+theorem expTwoMulFixedExpResidual_one_unfold
+    {ptr : Word} {exponentWord : EvmWord} :
+    expTwoMulFixedExpResidual 1 ptr exponentWord =
+      (((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
+        exponentWord.getLimbN 0) := by
+  delta expTwoMulFixedExpResidual
+  rfl
+
+theorem expTwoMulFixedExpResidual_ge_two
+    {b : Nat} {ptr : Word} {exponentWord : EvmWord} (hb : 2 ≤ b) :
+    expTwoMulFixedExpResidual b ptr exponentWord = empAssertion := by
+  delta expTwoMulFixedExpResidual
+  match b, hb with
+  | (n + 2), _ => rfl
+
+theorem expTwoMulFixedExpResidual_pcFree
+    {b : Nat} {ptr : Word} {exponentWord : EvmWord} :
+    (expTwoMulFixedExpResidual b ptr exponentWord).pcFree := by
+  match b with
+  | 0 =>
+    rw [expTwoMulFixedExpResidual_zero_unfold]; pcFree
+  | 1 =>
+    rw [expTwoMulFixedExpResidual_one_unfold]; pcFree
+  | (n + 2) =>
+    rw [expTwoMulFixedExpResidual_ge_two (by omega)]; pcFree
+
+instance pcFreeInst_expTwoMulFixedExpResidual
+    (b : Nat) (ptr : Word) (exponentWord : EvmWord) :
+    Assertion.PCFree (expTwoMulFixedExpResidual b ptr exponentWord) :=
+  ⟨expTwoMulFixedExpResidual_pcFree⟩
+
+/-- Reload-boundary split at block 0: the block-0 residual is the top cell at
+    `ptr-8` (carrying `getLimbN 1`, the next iteration's pointer-cell value)
+    separating-conjoined with the block-1 residual at the advanced pointer
+    `ptr-8`.  The induction consumes the top cell into the next `IterPre` via the
+    reload assembler and continues with `ExpResidual 1 (ptr-8)`. -/
+theorem expTwoMulFixedExpResidual_succ_zero
+    {ptr : Word} {exponentWord : EvmWord} :
+    expTwoMulFixedExpResidual 0 ptr exponentWord =
+      ((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
+          exponentWord.getLimbN 1) **
+       expTwoMulFixedExpResidual 1 (ptr + signExtend12 (-8 : BitVec 12))
+         exponentWord) := by
+  rw [expTwoMulFixedExpResidual_zero_unfold,
+    expTwoMulFixedExpResidual_one_unfold]
+
+/-- Reload-boundary split at block 1: the block-1 residual is its single top
+    cell at `ptr-8` (carrying `getLimbN 0`) separating-conjoined with the empty
+    block-2 residual at the advanced pointer. -/
+theorem expTwoMulFixedExpResidual_succ_one
+    {ptr : Word} {exponentWord : EvmWord} :
+    expTwoMulFixedExpResidual 1 ptr exponentWord =
+      ((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
+          exponentWord.getLimbN 0) **
+       expTwoMulFixedExpResidual 2 (ptr + signExtend12 (-8 : BitVec 12))
+         exponentWord) := by
+  rw [expTwoMulFixedExpResidual_one_unfold,
+    expTwoMulFixedExpResidual_ge_two (b := 2) (by omega),
+    sepConj_emp_right']
+
+end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedExpResidual.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedExpResidual.lean
@@ -2,21 +2,29 @@
   EvmAsm.Evm64.Exp.Compose.SavedBitFixedExpResidual
 
   The exponent residual `ExpResidual` carried (as a framed pcFree assertion)
-  by the merged-loop induction: the not-yet-loaded exponent limb cells strictly
-  below the loop pointer `x16 = ptr`, organized by block `b = k / 64`.
+  by the merged-loop induction: the not-yet-loaded limb cells strictly below
+  the loop pointer `x16 = ptr`, organized by block `b = k / 64`.
 
   Within a block the pointer `x16` is constant, so `ExpResidual` is constant
-  (it depends only on the block `b` and `ptr`).  At each of the three 64-bit
-  reload boundaries the pointer advances by `-8`, the top residual cell becomes
-  the next iteration's `IterPre` pointer cell (consumed by the proven reload
-  assemblers), and the (now stale) old pointer cell drops into the read-only
-  ambient frame.  The residual therefore shrinks by one cell per reload:
-  block 0 = 2 cells, block 1 = 1 cell, blocks 2-3 = 0 cells.
+  (it depends only on the block `b`, `ptr`, and a `lookahead` value).  At each
+  of the three 64-bit reload boundaries the pointer advances by `-8`, the top
+  residual cell becomes the next iteration's `IterPre` pointer cell (consumed
+  by the proven reload assemblers), and the (now stale) old pointer cell drops
+  into the read-only ambient frame.  The residual therefore shrinks by one cell
+  per reload.
 
-  This file provides the definition together with the two reload-boundary
-  split identities `..._succ_zero` / `..._succ_one` and the empty-tail fact
-  `..._ge_two`, which the induction uses to re-partition the residual at a
-  reload before applying the IH.
+  Cell counts are `3 / 2 / 1 / 0` by block.  Block 0 (`x16 = OUTER+48`) carries
+  the three cells strictly below `x16` that the three remaining reloads will
+  consume: `OUTER+40` (`getLimbN 1`), `OUTER+32` (`getLimbN 0`), and `OUTER+24`
+  (the `lookahead` cell — physically the high limb of the operand word just
+  below the exponent, never read since block 3 performs no reload).  Block 1
+  drops the top cell, block 2 carries only the `lookahead` cell, and block 3
+  (`x16 = OUTER+24`) carries nothing.
+
+  This file provides the definition together with the three reload-boundary
+  split identities `..._succ_zero` / `..._succ_one` / `..._succ_two` and the
+  empty-tail fact `..._ge_three`, which the induction uses to re-partition the
+  residual at a reload before applying the IH.
 -/
 
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedReloadReshuffle
@@ -25,63 +33,85 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
-/-- Exponent residual for block `b` at pointer `ptr`: the not-yet-loaded
-    exponent limb cells strictly below `x16 = ptr`.  Block 0 carries the two
-    cells at `ptr-8` (`getLimbN 1`) and `ptr-16` (`getLimbN 0`); block 1 carries
-    the single cell at `ptr-8` (`getLimbN 0`); blocks `≥ 2` carry nothing. -/
+/-- Exponent residual for block `b` at pointer `ptr` with bottom look-ahead
+    value `lookahead`: the not-yet-loaded limb cells strictly below `x16 = ptr`.
+    Counts are `3 / 2 / 1 / 0` by block; the cell addresses descend by `-8`. -/
 @[irreducible]
-def expTwoMulFixedExpResidual (b : Nat) (ptr : Word)
+def expTwoMulFixedExpResidual (b : Nat) (ptr lookahead : Word)
     (exponentWord : EvmWord) : Assertion :=
   match b with
   | 0 =>
     (((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
         exponentWord.getLimbN 1) **
     ((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (-8 : BitVec 12)) +
-        signExtend12 (0 : BitVec 12)) ↦ₘ exponentWord.getLimbN 0)
+        signExtend12 (0 : BitVec 12)) ↦ₘ exponentWord.getLimbN 0) **
+    (((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (-8 : BitVec 12)) +
+        signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
+        lookahead)
   | 1 =>
     (((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
-        exponentWord.getLimbN 0)
+        exponentWord.getLimbN 0) **
+    ((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (-8 : BitVec 12)) +
+        signExtend12 (0 : BitVec 12)) ↦ₘ lookahead)
+  | 2 =>
+    (((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
+        lookahead)
   | _ => empAssertion
 
 theorem expTwoMulFixedExpResidual_zero_unfold
-    {ptr : Word} {exponentWord : EvmWord} :
-    expTwoMulFixedExpResidual 0 ptr exponentWord =
+    {ptr lookahead : Word} {exponentWord : EvmWord} :
+    expTwoMulFixedExpResidual 0 ptr lookahead exponentWord =
       ((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
           exponentWord.getLimbN 1) **
        ((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (-8 : BitVec 12)) +
-          signExtend12 (0 : BitVec 12)) ↦ₘ exponentWord.getLimbN 0)) := by
+          signExtend12 (0 : BitVec 12)) ↦ₘ exponentWord.getLimbN 0) **
+       (((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (-8 : BitVec 12)) +
+          signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
+          lookahead)) := by
   delta expTwoMulFixedExpResidual
   rfl
 
 theorem expTwoMulFixedExpResidual_one_unfold
-    {ptr : Word} {exponentWord : EvmWord} :
-    expTwoMulFixedExpResidual 1 ptr exponentWord =
-      (((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
-        exponentWord.getLimbN 0) := by
+    {ptr lookahead : Word} {exponentWord : EvmWord} :
+    expTwoMulFixedExpResidual 1 ptr lookahead exponentWord =
+      ((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
+          exponentWord.getLimbN 0) **
+       ((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (-8 : BitVec 12)) +
+          signExtend12 (0 : BitVec 12)) ↦ₘ lookahead)) := by
   delta expTwoMulFixedExpResidual
   rfl
 
-theorem expTwoMulFixedExpResidual_ge_two
-    {b : Nat} {ptr : Word} {exponentWord : EvmWord} (hb : 2 ≤ b) :
-    expTwoMulFixedExpResidual b ptr exponentWord = empAssertion := by
+theorem expTwoMulFixedExpResidual_two_unfold
+    {ptr lookahead : Word} {exponentWord : EvmWord} :
+    expTwoMulFixedExpResidual 2 ptr lookahead exponentWord =
+      (((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
+          lookahead) := by
+  delta expTwoMulFixedExpResidual
+  rfl
+
+theorem expTwoMulFixedExpResidual_ge_three
+    {b : Nat} {ptr lookahead : Word} {exponentWord : EvmWord} (hb : 3 ≤ b) :
+    expTwoMulFixedExpResidual b ptr lookahead exponentWord = empAssertion := by
   delta expTwoMulFixedExpResidual
   match b, hb with
-  | (n + 2), _ => rfl
+  | (n + 3), _ => rfl
 
 theorem expTwoMulFixedExpResidual_pcFree
-    {b : Nat} {ptr : Word} {exponentWord : EvmWord} :
-    (expTwoMulFixedExpResidual b ptr exponentWord).pcFree := by
+    {b : Nat} {ptr lookahead : Word} {exponentWord : EvmWord} :
+    (expTwoMulFixedExpResidual b ptr lookahead exponentWord).pcFree := by
   match b with
   | 0 =>
     rw [expTwoMulFixedExpResidual_zero_unfold]; pcFree
   | 1 =>
     rw [expTwoMulFixedExpResidual_one_unfold]; pcFree
-  | (n + 2) =>
-    rw [expTwoMulFixedExpResidual_ge_two (by omega)]; pcFree
+  | 2 =>
+    rw [expTwoMulFixedExpResidual_two_unfold]; pcFree
+  | (n + 3) =>
+    rw [expTwoMulFixedExpResidual_ge_three (by omega)]; pcFree
 
 instance pcFreeInst_expTwoMulFixedExpResidual
-    (b : Nat) (ptr : Word) (exponentWord : EvmWord) :
-    Assertion.PCFree (expTwoMulFixedExpResidual b ptr exponentWord) :=
+    (b : Nat) (ptr lookahead : Word) (exponentWord : EvmWord) :
+    Assertion.PCFree (expTwoMulFixedExpResidual b ptr lookahead exponentWord) :=
   ⟨expTwoMulFixedExpResidual_pcFree⟩
 
 /-- Reload-boundary split at block 0: the block-0 residual is the top cell at
@@ -90,27 +120,38 @@ instance pcFreeInst_expTwoMulFixedExpResidual
     `ptr-8`.  The induction consumes the top cell into the next `IterPre` via the
     reload assembler and continues with `ExpResidual 1 (ptr-8)`. -/
 theorem expTwoMulFixedExpResidual_succ_zero
-    {ptr : Word} {exponentWord : EvmWord} :
-    expTwoMulFixedExpResidual 0 ptr exponentWord =
+    {ptr lookahead : Word} {exponentWord : EvmWord} :
+    expTwoMulFixedExpResidual 0 ptr lookahead exponentWord =
       ((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
           exponentWord.getLimbN 1) **
        expTwoMulFixedExpResidual 1 (ptr + signExtend12 (-8 : BitVec 12))
-         exponentWord) := by
+         lookahead exponentWord) := by
   rw [expTwoMulFixedExpResidual_zero_unfold,
     expTwoMulFixedExpResidual_one_unfold]
 
-/-- Reload-boundary split at block 1: the block-1 residual is its single top
-    cell at `ptr-8` (carrying `getLimbN 0`) separating-conjoined with the empty
-    block-2 residual at the advanced pointer. -/
+/-- Reload-boundary split at block 1: top cell at `ptr-8` (`getLimbN 0`)
+    conjoined with the block-2 residual at the advanced pointer. -/
 theorem expTwoMulFixedExpResidual_succ_one
-    {ptr : Word} {exponentWord : EvmWord} :
-    expTwoMulFixedExpResidual 1 ptr exponentWord =
+    {ptr lookahead : Word} {exponentWord : EvmWord} :
+    expTwoMulFixedExpResidual 1 ptr lookahead exponentWord =
       ((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
           exponentWord.getLimbN 0) **
        expTwoMulFixedExpResidual 2 (ptr + signExtend12 (-8 : BitVec 12))
-         exponentWord) := by
+         lookahead exponentWord) := by
   rw [expTwoMulFixedExpResidual_one_unfold,
-    expTwoMulFixedExpResidual_ge_two (b := 2) (by omega),
+    expTwoMulFixedExpResidual_two_unfold]
+
+/-- Reload-boundary split at block 2: the single top cell at `ptr-8` (the
+    `lookahead` cell) conjoined with the empty block-3 residual. -/
+theorem expTwoMulFixedExpResidual_succ_two
+    {ptr lookahead : Word} {exponentWord : EvmWord} :
+    expTwoMulFixedExpResidual 2 ptr lookahead exponentWord =
+      ((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
+          lookahead) **
+       expTwoMulFixedExpResidual 3 (ptr + signExtend12 (-8 : BitVec 12))
+         lookahead exponentWord) := by
+  rw [expTwoMulFixedExpResidual_two_unfold,
+    expTwoMulFixedExpResidual_ge_three (b := 3) (by omega),
     sepConj_emp_right']
 
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFrameLoopDirect.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFrameLoopDirect.lean
@@ -722,11 +722,15 @@ theorem expTwoMulFixedPreReloadFrameN_eq_direct_tail_of_control
       expTwoMulFixedSavedNextLimbFrame ptr nextNextLimb =
         expTwoMulFixedSavedNextLimbFrameN exponentWord k ptr :=
     expTwoMulFixedSavedNextLimbFrameN_eq_of_nextNext hNextNext
+  have hMod : k % 64 = 62 :=
+    expTwoMulFixedControlInvariant_pre_reload_mod hControl hC6
   have hSecondEq :
-      expTwoMulFixedSavedNextLimbFrameN exponentWord (k + 1) ptr =
-        expTwoMulFixedReloadLimbFrameN exponentWord (k + 1) ptr :=
-    expTwoMulFixedSavedNextLimbFrameN_eq_succ_reload_limb_of_control_pre_reload
-      hControl hC6
+      expTwoMulFixedSavedNextLimbFrameN exponentWord (k + 1)
+          (ptr + signExtend12 (-8 : BitVec 12)) =
+        expTwoMulFixedReloadLimbFrameN exponentWord (k + 1)
+          (ptr + signExtend12 (-8 : BitVec 12)) :=
+    expTwoMulFixedSavedNextLimbFrameN_eq_succ_reload_limb_of_pre_reload
+      (ptr := ptr + signExtend12 (-8 : BitVec 12)) hMod
   rw [expTwoMulFixedPreReloadFrameN_unfold, hSecondEq, ← hFrameEq,
     expTwoMulFixedSavedNextLimbFrame_unfold,
     expPreReloadDirectTailFrameN_unfold]

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
@@ -648,7 +648,7 @@ theorem expTwoMulFixedIterReloadSkipScratchFrame_pures
 /-- Weaken the per-iteration scratch frame's `x6` value slot to ownership.
     After the counter moved to `x20`, the next `IterPre` keeps `x6` only as
     `regOwn` scratch, so the loop-back post's concrete `x6` value is dropped. -/
-private theorem expTwoMulFixedIterScratchIs_x6_to_regOwn
+theorem expTwoMulFixedIterScratchIs_x6_to_regOwn
     {evmSp v6 v7 v10 v11 d0 d1 d2 d3 : Word} :
     ∀ ps, expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 ps →
       (regOwn .x6 ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopPreReload.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopPreReload.lean
@@ -15,14 +15,16 @@ def expPreReloadDirectTailFrameN
     (exponentWord : EvmWord) (k : Nat) (ptr nextNextLimb : Word) :
     Assertion :=
   expReloadDirectTailFrame ptr nextNextLimb
-    (expTwoMulFixedReloadLimbFrameN exponentWord (k + 1) ptr)
+    (expTwoMulFixedReloadLimbFrameN exponentWord (k + 1)
+      (ptr + signExtend12 (-8 : BitVec 12)))
 
 theorem expPreReloadDirectTailFrameN_unfold
     {exponentWord : EvmWord} {k : Nat} {ptr nextNextLimb : Word} :
     expPreReloadDirectTailFrameN exponentWord k ptr nextNextLimb =
       (((((ptr + signExtend12 (-8 : BitVec 12)) +
         signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) **
-        expTwoMulFixedReloadLimbFrameN exponentWord (k + 1) ptr)) := by
+        expTwoMulFixedReloadLimbFrameN exponentWord (k + 1)
+      (ptr + signExtend12 (-8 : BitVec 12)))) := by
   rw [expPreReloadDirectTailFrameN, expReloadDirectTailFrame_unfold]
 
 @[irreducible]
@@ -30,7 +32,8 @@ def expPreReloadDirectFalseFrameN
     (exponentWord : EvmWord) (k : Nat)
     (controlC6 e iterCount ptr nextLimb : Word) : Assertion :=
   expReloadDirectFalseFrame controlC6 e iterCount ptr nextLimb
-    (expTwoMulFixedReloadLimbFrameN exponentWord (k + 1) ptr)
+    (expTwoMulFixedReloadLimbFrameN exponentWord (k + 1)
+      (ptr + signExtend12 (-8 : BitVec 12)))
 
 theorem expPreReloadDirectFalseFrameN_unfold
     {exponentWord : EvmWord} {k : Nat}
@@ -42,7 +45,8 @@ theorem expPreReloadDirectFalseFrameN_unfold
         ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
         ⌜(e >>> (63 : BitVec 6).toNat) +
           signExtend12 (0 : BitVec 12) = 0⌝ **
-        expTwoMulFixedReloadLimbFrameN exponentWord (k + 1) ptr) := by
+        expTwoMulFixedReloadLimbFrameN exponentWord (k + 1)
+      (ptr + signExtend12 (-8 : BitVec 12))) := by
   rw [expPreReloadDirectFalseFrameN, expReloadDirectFalseFrame_unfold]
 
 @[irreducible]
@@ -50,7 +54,8 @@ def expPreReloadDirectTrueFrameN
     (exponentWord : EvmWord) (k : Nat)
     (controlC6 e iterCount ptr nextLimb : Word) : Assertion :=
   expReloadDirectTrueFrame controlC6 e iterCount ptr nextLimb
-    (expTwoMulFixedReloadLimbFrameN exponentWord (k + 1) ptr)
+    (expTwoMulFixedReloadLimbFrameN exponentWord (k + 1)
+      (ptr + signExtend12 (-8 : BitVec 12)))
 
 theorem expPreReloadDirectTrueFrameN_unfold
     {exponentWord : EvmWord} {k : Nat}
@@ -62,7 +67,8 @@ theorem expPreReloadDirectTrueFrameN_unfold
         ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
         ⌜(e >>> (63 : BitVec 6).toNat) +
           signExtend12 (0 : BitVec 12) ≠ 0⌝ **
-        expTwoMulFixedReloadLimbFrameN exponentWord (k + 1) ptr) := by
+        expTwoMulFixedReloadLimbFrameN exponentWord (k + 1)
+      (ptr + signExtend12 (-8 : BitVec 12))) := by
   rw [expPreReloadDirectTrueFrameN, expReloadDirectTrueFrame_unfold]
 
 /-- Pre-reload direct head step over the two-cell lookahead frame.
@@ -152,7 +158,8 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_p
   have hPreReloadEq :
       expTwoMulFixedPreReloadFrameN exponentWord k ptr =
         (expTwoMulFixedSavedNextLimbFrameN exponentWord k ptr **
-          expTwoMulFixedReloadLimbFrameN exponentWord (k + 1) ptr) :=
+          expTwoMulFixedReloadLimbFrameN exponentWord (k + 1)
+      (ptr + signExtend12 (-8 : BitVec 12))) :=
     expTwoMulFixedPreReloadFrameN_handoff_of_control hControl hC6
   exact
     cpsTripleWithin_weaken
@@ -167,7 +174,8 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_p
         controlC6 e machineC6 iterCount v10 v18 ptr nextLimb nextNextLimb
         sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
         a0 a1 a2 a3 v7 v11 base
-        (expTwoMulFixedReloadLimbFrameN exponentWord (k + 1) ptr)
+        (expTwoMulFixedReloadLimbFrameN exponentWord (k + 1)
+      (ptr + signExtend12 (-8 : BitVec 12)))
         Q
         (by
           rw [expTwoMulFixedReloadLimbFrameN_unfold,

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedMergedFramedStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedMergedFramedStep.lean
@@ -1,0 +1,219 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedMergedFramedStep
+
+  Framed variant of the merged fixed-x19 EXP per-iteration step.  The exponent
+  is read-only across the loop body, so an arbitrary pcFree frame `F` (used by
+  the residual induction to carry the not-yet-loaded exponent limb cells) can be
+  threaded through one iteration: it rides untouched from the iteration pre to
+  both the loop-back and loop-exit posts.  This is the enabler that makes the
+  reload-boundary cell available to the loop-back continuation (where the
+  proven reshuffle lemmas can re-partition it), discharging the old pure
+  `MergedReloadReshuffle` hypothesis.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterExits
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+/-- Merge one fixed x19 canonical appended-MUL EXP iteration with externally
+    supplied continuations, with a pcFree frame `F` threaded through the body
+    (read-only exponent), so the continuations see `… ** F`. -/
+theorem exp_two_mul_fixed_iter_merged_with_continuations_framed_spec_within
+    {nCont : Nat} {exit_ : Word} {R F : Assertion}
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hF : F.pcFree) :
+    (cpsTripleWithin nCont (base + 44) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterMergedLoopPost e c6 iterCount ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ** F)
+      R) →
+    (cpsTripleWithin nCont (base + 296) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterMergedExitPost e c6 iterCount ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ** F)
+      R) →
+    cpsTripleWithin
+      (expTwoMulFixedReloadIterStepBound + nCont)
+      (base + 44)
+      exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11 ** F)
+      R := by
+  intro hLoop hExit
+  have hbr :=
+    exp_msb_bit_test_fixed_full_iter_merged_named_exits_evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode_spec_within
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base hbase
+  have hbrF := cpsNBranchWithin_frameR hF hbr
+  refine cpsNBranchWithin_merge hbrF ?_
+  intro ex hmem
+  simp only [List.map] at hmem
+  cases hmem with
+  | head => exact hLoop
+  | tail _ htail =>
+      cases htail with
+      | head => exact hExit
+      | tail _ hnil => cases hnil
+
+/-- Bounded framed merge (max of loop/exit bounds). -/
+theorem exp_two_mul_fixed_iter_merged_with_continuations_bounded_framed_spec_within
+    {nLoop nExit nBound : Nat} {exit_ : Word} {R F : Assertion}
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hF : F.pcFree)
+    (hBound :
+      expTwoMulFixedReloadIterStepBound + max nLoop nExit ≤ nBound) :
+    (cpsTripleWithin nLoop (base + 44) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterMergedLoopPost e c6 iterCount ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ** F)
+      R) →
+    (cpsTripleWithin nExit (base + 296) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterMergedExitPost e c6 iterCount ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ** F)
+      R) →
+    cpsTripleWithin nBound
+      (base + 44)
+      exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11 ** F)
+      R := by
+  intro hLoop hExit
+  exact
+    cpsTripleWithin_mono_nSteps hBound
+      (exp_two_mul_fixed_iter_merged_with_continuations_framed_spec_within
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11 base hbase hF
+        (cpsTripleWithin_mono_nSteps (Nat.le_max_left nLoop nExit) hLoop)
+        (cpsTripleWithin_mono_nSteps (Nat.le_max_right nLoop nExit) hExit))
+
+/-- Framed peel of one fixed x19 merged iteration (closed `193`-per-iteration
+    bound). -/
+theorem exp_two_mul_fixed_iterations_body_peel_with_continuations_closed_bound_framed_spec_within
+    (iterations : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base exit_ : Word) (R F : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hF : F.pcFree) :
+    (cpsTripleWithin (iterations * 193)
+      (base + 44) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterMergedLoopPost e c6 iterCount ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ** F)
+      R) →
+    (cpsTripleWithin (iterations * 193)
+      (base + 296) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterMergedExitPost e c6 iterCount ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ** F)
+      R) →
+    cpsTripleWithin ((iterations + 1) * 193)
+      (base + 44)
+      exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11 ** F)
+      R := by
+  intro hLoop hExit
+  rw [← expTwoMulFixedIterationsBodyBound_eq iterations] at hLoop hExit
+  rw [← expTwoMulFixedIterationsBodyBound_eq (iterations + 1)]
+  exact
+    exp_two_mul_fixed_iter_merged_with_continuations_bounded_framed_spec_within
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base hbase hF
+      (expTwoMulFixedReloadIterStepBound_add_max_fixedIterationsBodyBound_le_succ
+        iterations)
+      hLoop hExit
+
+/-- Framed merged-loop induction step: thread a pcFree frame `F` (the exponent
+    residual) through one iteration.  The loop-back continuation receives the
+    `ptr-8` next-limb cell carried in `F`. -/
+theorem exp_fixed_loop_body_succ_step_framed
+    (n : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word) (R F : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hF : F.pcFree)
+    (hExit :
+      ∀ ps,
+        (expTwoMulFixedIterMergedExitPost e c6 iterCount ptr nextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base ** F) ps →
+        R ps)
+    (hLoop :
+      cpsTripleWithin (n * 193) (base + 44) (base + 296)
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulFixedIterMergedLoopPost e c6 iterCount ptr nextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base ** F)
+        R) :
+    cpsTripleWithin ((n + 1) * 193) (base + 44) (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11 ** F)
+      R :=
+  exp_two_mul_fixed_iterations_body_peel_with_continuations_closed_bound_framed_spec_within
+    n
+    e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+    r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+    v7 v11 base (base + 296) R F hbase hF hLoop
+    (cpsTripleWithin_mono_nSteps (Nat.zero_le _)
+      (cpsTripleWithin_extend_code
+        (hmono := by
+          intro a i h
+          cases h)
+        (cpsTripleWithin_refl hExit)))
+
+/-- Framed final merged-loop induction step (the loop-back edge is vacuous). -/
+theorem exp_fixed_loop_body_final_succ_step_framed
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word) (R F : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hF : F.pcFree)
+    (hzero : expTwoMulIterCountNew iterCount = 0)
+    (hExit :
+      ∀ ps,
+        (expTwoMulFixedIterMergedExitPost e c6 iterCount ptr nextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base ** F) ps →
+        R ps) :
+    cpsTripleWithin ((0 + 1) * 193) (base + 44) (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11 ** F)
+      R :=
+  exp_fixed_loop_body_succ_step_framed
+    0 e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+    r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+    base R F hbase hF hExit
+    (by
+      intro Rf _ s _ hPR _
+      exfalso
+      have hP := holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_left hPR)
+      obtain ⟨_, _, h_looppost⟩ := hP
+      exact expTwoMulFixedIterMergedLoopPost_zero_count_false hzero h_looppost)
+
+end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedReloadReshuffle.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedReloadReshuffle.lean
@@ -68,4 +68,64 @@ theorem expTwoMulFixedIterPointerFrame_reshuffle_to_reloadPointerFrame
   rw [expTwoMulFixedIterReloadPointerFrame_unfold]
   sep_perm h
 
+/-- Suffix-level reload reshuffle (conditional-multiply branch).
+
+    Lifts the pointer-cell reshuffle to the full reload-cond scratch suffix
+    frame that appears in the merged loop-back reload disjunct: given that
+    suffix together with the next-limb cell at `ptr-8` (from the induction
+    residual), regroup the `reloadPointerFrame` into the next iteration's
+    `IterPointerFrame (ptr-8)` and return the stale `ptr` cell.  All other
+    suffix atoms (the cursor `x19`, reset counter `x20`, saved bit `x18`, the
+    `c6New = 0` / `bit ≠ 0` pures, the `SkipCondRestScratchSuffix`) are
+    unchanged — this is a pure `sep_perm` once the pointer frames unfold. -/
+theorem expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame_reshuffle
+    {e c6 ptr nextLimb nextNextLimb base : Word} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
+          e c6 ptr nextLimb base **
+        (((ptr + signExtend12 (-8 : BitVec 12)) +
+          signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb)) ps) :
+    (expTwoMulFixedIterSkipCondRestScratchSuffix base **
+      (.x19 ↦ᵣ nextLimb) **
+      (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+      (.x18 ↦ᵣ ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))) **
+      ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+      expTwoMulFixedIterPointerFrame (ptr + signExtend12 (-8 : BitVec 12))
+        nextNextLimb **
+      ⌜(e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) ≠ 0⌝ **
+      ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb)) ps := by
+  simp only [expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame,
+    expTwoMulFixedIterReloadPointerFrame_unfold] at h
+  rw [expTwoMulFixedIterPointerFrame_unfold]
+  sep_perm h
+
+/-- Suffix-level reload reshuffle (skip / no-conditional-multiply branch).
+    The skip variant of
+    `expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame_reshuffle`: the
+    suffix carries the `x1` return slot and the `IterBaseFrame` instead of the
+    `SkipCondRestScratchSuffix`, and the `bit = 0` pure; the reshuffle is again
+    a pure `sep_perm`. -/
+theorem expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame_reshuffle
+    {e c6 ptr nextLimb nextNextLimb evmSp a0 a1 a2 a3 base : Word}
+    {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base **
+        (((ptr + signExtend12 (-8 : BitVec 12)) +
+          signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb)) ps) :
+    ((.x1 ↦ᵣ (((base + 44) + 32) + 68)) **
+      (.x19 ↦ᵣ nextLimb) **
+      (.x20 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+      (.x18 ↦ᵣ ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))) **
+      ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+      expTwoMulFixedIterPointerFrame (ptr + signExtend12 (-8 : BitVec 12))
+        nextNextLimb **
+      ⌜(e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0⌝ **
+      expTwoMulFixedIterBaseFrame evmSp a0 a1 a2 a3 **
+      ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb)) ps := by
+  simp only [expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame,
+    expTwoMulFixedIterReloadPointerFrame_unfold] at h
+  rw [expTwoMulFixedIterPointerFrame_unfold]
+  sep_perm h
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedReloadReshuffle.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedReloadReshuffle.lean
@@ -1,0 +1,71 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedReloadReshuffle
+
+  The reload-boundary pointer reshuffle for the fixed-x19 EXP loop.
+
+  At a 64-bit limb boundary the loop body has already executed the reload
+  (`LD x19 ← [x16]; ADDI x16 x16 -8`), so the loop-back post carries
+  `expTwoMulFixedIterReloadPointerFrame ptr nextLimb = (x16 ↦ ptr-8) **
+  (ptr ↦ nextLimb)`: the pointer register `x16` has advanced to `ptr-8`,
+  but the live memory cell is still at the now-stale address `ptr`.
+
+  The next iteration's `expTwoMulFixedIterPointerFrame (ptr-8) nextNextLimb`
+  instead needs the cell at the *new* pointer `ptr-8`.  That cell is the next
+  exponent limb, which lives in the induction residual `R` (the entry residual
+  `expTwoMulFixedFirstIterEntryResidual` stages exactly the not-yet-loaded
+  lower limbs).  So the reshuffle is a *pure* separation-logic re-partition:
+  pull the `ptr-8` cell out of `R` into the pointer frame and push the stale
+  `ptr` cell back into `R`.  No code step is required — the reload instructions
+  already ran inside the finished iteration body.
+
+  This lemma isolates that re-partition at the pointer-frame level; the
+  256-iteration merged loop induction threads the exponent residual `R` so the
+  `ptr-8` cell is in scope at each of the three limb boundaries.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostFramedCases
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+/-- Reload-boundary pointer reshuffle (pure re-partition).
+
+    Given the post-reload pointer frame `(x16 ↦ ptr-8) ** (ptr ↦ nextLimb)`
+    together with the next-limb cell at `ptr-8` (supplied from the induction
+    residual), regroup into the next iteration's pointer frame
+    `(x16 ↦ ptr-8) ** (ptr-8 ↦ nextNextLimb)` plus the stale `ptr` cell
+    (returned to the residual).  This is the entire content of the reload
+    transition once the residual cell is in scope: a `sep_perm`. -/
+theorem expTwoMulFixedIterReloadPointerFrame_reshuffle_to_pointerFrame
+    {ptr nextLimb nextNextLimb : Word} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterReloadPointerFrame ptr nextLimb **
+        (((ptr + signExtend12 (-8 : BitVec 12)) +
+          signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb)) ps) :
+    (expTwoMulFixedIterPointerFrame (ptr + signExtend12 (-8 : BitVec 12))
+        nextNextLimb **
+      ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb)) ps := by
+  rw [expTwoMulFixedIterReloadPointerFrame_unfold] at h
+  rw [expTwoMulFixedIterPointerFrame_unfold]
+  sep_perm h
+
+/-- The reverse re-partition: the next pointer frame plus the stale `ptr` cell
+    regroup back into the post-reload reload-pointer frame plus the `ptr-8`
+    cell.  Records that the reshuffle is an honest bijection on the heap
+    (no cell is created or destroyed), useful when threading the residual in
+    either direction. -/
+theorem expTwoMulFixedIterPointerFrame_reshuffle_to_reloadPointerFrame
+    {ptr nextLimb nextNextLimb : Word} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterPointerFrame (ptr + signExtend12 (-8 : BitVec 12))
+          nextNextLimb **
+        ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb)) ps) :
+    (expTwoMulFixedIterReloadPointerFrame ptr nextLimb **
+        (((ptr + signExtend12 (-8 : BitVec 12)) +
+          signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb)) ps := by
+  rw [expTwoMulFixedIterPointerFrame_unfold] at h
+  rw [expTwoMulFixedIterReloadPointerFrame_unfold]
+  sep_perm h
+
+end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedReloadReshuffle.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedReloadReshuffle.lean
@@ -232,4 +232,100 @@ theorem expTwoMulFixedIterReloadCondScratchFrame_to_iterPre_frame
     BitVec.add_assoc] at h ⊢
   xperm_hyp h
 
+/-- Reload→`IterPre` assembler (skip / no-conditional-multiply branch).
+
+    The skip analogue of `expTwoMulFixedIterReloadCondScratchFrame_to_iterPre_frame`:
+    the merged loop-back reload-skip disjunct's residual together with the next-limb
+    cell at `ptr-8` assembles into the next iteration's `expTwoMulFixedIterPre` at
+    `ptr-8` with the squaring result (`squareW`, since the conditional multiply is
+    skipped), reloaded cursor and reset counter, returning the stale `ptr` cell. -/
+theorem expTwoMulFixedIterReloadSkipScratchFrame_to_iterPre_frame
+    {iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterReloadSkipCountPostScratchSuffix
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base **
+          (((ptr + signExtend12 (-8 : BitVec 12)) +
+            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb))) **
+        frame) ps) :
+    ((expTwoMulFixedIterPre
+      nextLimb
+      ((0 : Word) + signExtend12 (64 : BitVec 12))
+      (expTwoMulIterCountNew iterCount)
+      v10
+      ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+      (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+      ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+      (((base + 44) + 32) + 68)
+      ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0)
+      ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1)
+      ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2)
+      ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+      d0 d1 d2 d3
+      ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0)
+      ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1)
+      ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2)
+      ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+      a0 a1 a2 a3 v7 v11) **
+      (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+        frame)) ps := by
+  obtain ⟨h_exit, h_c6, h_bit⟩ :=
+    expTwoMulFixedIterReloadSkipScratchFrame_pures
+      (show ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+          r0 r1 r2 r3 exitCond **
+          expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+          expTwoMulFixedIterReloadSkipCountPostScratchSuffix
+            e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) **
+          ((((ptr + signExtend12 (-8 : BitVec 12)) +
+            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) ** frame)) ps
+        from by sep_perm h)
+  replace h := sepConj_mono_left
+    (sepConj_mono_right (sepConj_mono_right
+      (sepConj_mono_left
+        (fun ps' hh =>
+          expTwoMulFixedIterReloadSkipCountPostScratchSuffix_frame hh)))) _ h
+  replace h := sepConj_mono_left
+    (sepConj_mono_right (sepConj_mono_right
+      (fun ps' hh =>
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame_reshuffle hh))) _ h
+  replace h := sepConj_mono_left
+    (sepConj_mono_right (sepConj_mono_left
+      expTwoMulFixedIterScratchIs_x6_to_regOwn)) _ h
+  unfold expTwoMulFixedIterSkipCountPostScratchPrefix
+    expTwoMulFixedIterSkipRestScratchPrefix at h
+  rw [expTwoMulFixedIterPointerFrame_unfold] at h
+  rw [show (⌜exitCond⌝ : Assertion) = empAssertion from
+      funext fun ps' => propext ⟨fun h' => h'.1, fun h' => ⟨h', h_exit⟩⟩] at h
+  rw [show (⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ : Assertion) =
+      empAssertion from
+      funext fun ps' => propext ⟨fun h' => h'.1, fun h' => ⟨h', h_c6⟩⟩] at h
+  rw [show
+      (⌜(e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0⌝ :
+        Assertion) = empAssertion from
+      funext fun ps' => propext ⟨fun h' => h'.1, fun h' => ⟨h', h_bit⟩⟩] at h
+  simp only [sepConj_emp_left', sepConj_emp_right'] at h
+  rw [expTwoMulFixedIterPre_unfold, expTwoMulIterBaseFrame_unfold,
+    expTwoMulFixedIterPointerFrame_unfold]
+  simp only [expTwoMulFixedIterBaseFrame,
+    evmWordIs, signExtend12_0, signExtend12_8, signExtend12_16,
+    signExtend12_24, signExtend12_32, signExtend12_40, signExtend12_48,
+    signExtend12_56,
+    EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg64,
+    EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg56,
+    EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg48,
+    EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg40,
+    EvmAsm.Rv64.AddrNorm.word_add_zero,
+    show (32 : Word) + 8 = 40 from by decide,
+    show (32 : Word) + 16 = 48 from by decide,
+    show (32 : Word) + 24 = 56 from by decide,
+    show (32 : Word) + 68 = 100 from by decide,
+    show (44 : Word) + 100 = 144 from by decide,
+    BitVec.add_assoc] at h ⊢
+  xperm_hyp h
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedReloadReshuffle.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedReloadReshuffle.lean
@@ -128,4 +128,108 @@ theorem expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame_reshuffle
   rw [expTwoMulFixedIterPointerFrame_unfold]
   sep_perm h
 
+/-- Reload→`IterPre` assembler (conditional-multiply branch).
+
+    The merged loop-back reload-cond disjunct's residual
+    (`SkipCondCountPostScratchPrefix ** ScratchIs ** ReloadCondCountPostScratchSuffix`)
+    together with the next-limb cell at `ptr-8` (from the induction residual)
+    assembles into the *next* iteration's `expTwoMulFixedIterPre` at the advanced
+    pointer `ptr-8`, with the reloaded cursor `x19 = nextLimb`, the reset counter
+    `x20 = 64`, and the stale `ptr` cell returned to the residual.  This is the
+    reload analogue of `expTwoMulFixedIterSkipCondScratchFrame_to_iterPre_frame`,
+    with the committed suffix reshuffle applied first to fix the pointer cell. -/
+theorem expTwoMulFixedIterReloadCondScratchFrame_to_iterPre_frame
+    {iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterReloadCondCountPostScratchSuffix e c6 ptr nextLimb base **
+          (((ptr + signExtend12 (-8 : BitVec 12)) +
+            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb))) **
+        frame) ps) :
+    ((expTwoMulFixedIterPre
+      nextLimb
+      ((0 : Word) + signExtend12 (64 : BitVec 12))
+      (expTwoMulIterCountNew iterCount)
+      v10
+      ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+      (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+      ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+      (((base + 44) + 140) + 68)
+      ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0)
+      ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1)
+      ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2)
+      ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+      d0 d1 d2 d3
+      ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0)
+      ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1)
+      ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2)
+      ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+      a0 a1 a2 a3 v7 v11) **
+      (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+        frame)) ps := by
+  -- Extract the pure facts (exit condition, reload `c6New = 0`, branch taken)
+  -- from the original residual before reshaping.
+  obtain ⟨h_exit, h_c6, h_bit⟩ :=
+    expTwoMulFixedIterReloadCondScratchFrame_pures
+      (show ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+          expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+          expTwoMulFixedIterReloadCondCountPostScratchSuffix e c6 ptr nextLimb base) **
+          ((((ptr + signExtend12 (-8 : BitVec 12)) +
+            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) ** frame)) ps
+        from by sep_perm h)
+  -- Convert the reload-cond suffix to its frame form, then reshuffle the
+  -- pointer cell using the committed suffix reshuffle.
+  replace h := sepConj_mono_left
+    (sepConj_mono_right (sepConj_mono_right
+      (sepConj_mono_left
+        (fun ps' hh =>
+          expTwoMulFixedIterReloadCondCountPostScratchSuffix_frame hh)))) _ h
+  replace h := sepConj_mono_left
+    (sepConj_mono_right (sepConj_mono_right
+      (fun ps' hh =>
+        expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame_reshuffle hh))) _ h
+  -- Weaken the surrendered `x6` scratch value to ownership.
+  replace h := sepConj_mono_left
+    (sepConj_mono_right (sepConj_mono_left
+      expTwoMulFixedIterScratchIs_x6_to_regOwn)) _ h
+  -- Strip the pure facts produced by the reshuffle.
+  unfold expTwoMulFixedIterSkipCondCountPostScratchPrefix
+    expTwoMulFixedIterSkipCondRestScratchPrefix
+    expTwoMulFixedIterSkipCondRestScratchSuffix at h
+  rw [expTwoMulFixedIterPointerFrame_unfold] at h
+  -- Strip the pure facts now that they are known true.
+  rw [show (⌜exitCond⌝ : Assertion) = empAssertion from
+      funext fun ps' => propext ⟨fun h' => h'.1, fun h' => ⟨h', h_exit⟩⟩] at h
+  rw [show (⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ : Assertion) =
+      empAssertion from
+      funext fun ps' => propext ⟨fun h' => h'.1, fun h' => ⟨h', h_c6⟩⟩] at h
+  rw [show
+      (⌜(e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) ≠ 0⌝ :
+        Assertion) = empAssertion from
+      funext fun ps' => propext ⟨fun h' => h'.1, fun h' => ⟨h', h_bit⟩⟩] at h
+  simp only [sepConj_emp_left', sepConj_emp_right'] at h
+  rw [expTwoMulFixedIterPre_unfold, expTwoMulIterBaseFrame_unfold,
+    expTwoMulFixedIterPointerFrame_unfold]
+  simp only [evmWordIs, signExtend12_0, signExtend12_8, signExtend12_16,
+    signExtend12_24, signExtend12_32, signExtend12_40, signExtend12_48,
+    signExtend12_56,
+    EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg64,
+    EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg56,
+    EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg48,
+    EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg40,
+    EvmAsm.Rv64.AddrNorm.word_add_zero,
+    show (32 : Word) + 8 = 40 from by decide,
+    show (32 : Word) + 16 = 48 from by decide,
+    show (32 : Word) + 24 = 56 from by decide,
+    show (140 : Word) + 68 = 208 from by decide,
+    show (44 : Word) + 208 = 252 from by decide,
+    BitVec.add_assoc] at h ⊢
+  xperm_hyp h
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedReloadResidualRepartition.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedReloadResidualRepartition.lean
@@ -76,3 +76,63 @@ theorem expTwoMulFixedIterReloadCondCountPost_residual_repartition_zero
         frame)) ps :=
     ⟨psA, psR, hdisj, hunion, hScratch, hR⟩
   xperm_hyp hCombined
+
+/-- Reload-boundary re-partition (skip branch, block 0): the skip analogue of
+    `expTwoMulFixedIterReloadCondCountPost_residual_repartition_zero`. -/
+theorem expTwoMulFixedIterReloadSkipCountPost_residual_repartition_zero
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {lookahead : Word} {exponentWord : EvmWord}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterReloadSkipCountPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond **
+       (expTwoMulFixedExpResidual 0 ptr lookahead exponentWord ** frame)) ps) :
+    (∃ v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterPre
+        nextLimb
+        ((0 : Word) + signExtend12 (64 : BitVec 12))
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        (ptr + signExtend12 (-8 : BitVec 12)) (exponentWord.getLimbN 1) sp evmSp
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+        (((base + 44) + 32) + 68)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+        d0 d1 d2 d3
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+        a0 a1 a2 a3 v7 v11 **
+       (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+        (expTwoMulFixedExpResidual 1 (ptr + signExtend12 (-8 : BitVec 12))
+          lookahead exponentWord **
+         frame))) ps) := by
+  obtain ⟨psA, psR, hdisj, hunion, hA, hR⟩ := h
+  obtain ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩ :=
+    expTwoMulFixedIterReloadSkipCountPost_choose_scratch hA
+  rw [expTwoMulFixedExpResidual_succ_zero] at hR
+  refine ⟨v7, v10, v11, d0, d1, d2, d3, ?_⟩
+  apply expTwoMulFixedIterReloadSkipScratchFrame_to_iterPre_frame
+    (nextNextLimb := exponentWord.getLimbN 1)
+    (frame := expTwoMulFixedExpResidual 1 (ptr + signExtend12 (-8 : BitVec 12))
+      lookahead exponentWord ** frame)
+  have hCombined :
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+          r0 r1 r2 r3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffix e c6 ptr nextLimb
+          evmSp a0 a1 a2 a3 base) **
+       (((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
+          exponentWord.getLimbN 1) **
+        expTwoMulFixedExpResidual 1 (ptr + signExtend12 (-8 : BitVec 12))
+          lookahead exponentWord) **
+        frame)) ps :=
+    ⟨psA, psR, hdisj, hunion, hScratch, hR⟩
+  xperm_hyp hCombined
+
+end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedReloadResidualRepartition.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedReloadResidualRepartition.lean
@@ -135,4 +135,230 @@ theorem expTwoMulFixedIterReloadSkipCountPost_residual_repartition_zero
     ⟨psA, psR, hdisj, hunion, hScratch, hR⟩
   xperm_hyp hCombined
 
+/-- Reload-boundary re-partition (cond branch, block 1). -/
+theorem expTwoMulFixedIterReloadCondCountPost_residual_repartition_one
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {lookahead : Word} {exponentWord : EvmWord}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterReloadCondCountPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond **
+       (expTwoMulFixedExpResidual 1 ptr lookahead exponentWord ** frame)) ps) :
+    (∃ v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterPre
+        nextLimb
+        ((0 : Word) + signExtend12 (64 : BitVec 12))
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        (ptr + signExtend12 (-8 : BitVec 12)) (exponentWord.getLimbN 0) sp evmSp
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+        (((base + 44) + 140) + 68)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+        d0 d1 d2 d3
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+        a0 a1 a2 a3 v7 v11 **
+       (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+        (expTwoMulFixedExpResidual 2 (ptr + signExtend12 (-8 : BitVec 12))
+          lookahead exponentWord **
+         frame))) ps) := by
+  obtain ⟨psA, psR, hdisj, hunion, hA, hR⟩ := h
+  obtain ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩ :=
+    expTwoMulFixedIterReloadCondCountPost_choose_scratch hA
+  rw [expTwoMulFixedExpResidual_succ_one] at hR
+  refine ⟨v7, v10, v11, d0, d1, d2, d3, ?_⟩
+  apply expTwoMulFixedIterReloadCondScratchFrame_to_iterPre_frame
+    (nextNextLimb := exponentWord.getLimbN 0)
+    (frame := expTwoMulFixedExpResidual 2 (ptr + signExtend12 (-8 : BitVec 12))
+      lookahead exponentWord ** frame)
+  have hCombined :
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffix e c6 ptr nextLimb base) **
+       (((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
+          exponentWord.getLimbN 0) **
+        expTwoMulFixedExpResidual 2 (ptr + signExtend12 (-8 : BitVec 12))
+          lookahead exponentWord) **
+        frame)) ps :=
+    ⟨psA, psR, hdisj, hunion, hScratch, hR⟩
+  xperm_hyp hCombined
+
+/-- Reload-boundary re-partition (skip branch, block 1). -/
+theorem expTwoMulFixedIterReloadSkipCountPost_residual_repartition_one
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {lookahead : Word} {exponentWord : EvmWord}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterReloadSkipCountPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond **
+       (expTwoMulFixedExpResidual 1 ptr lookahead exponentWord ** frame)) ps) :
+    (∃ v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterPre
+        nextLimb
+        ((0 : Word) + signExtend12 (64 : BitVec 12))
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        (ptr + signExtend12 (-8 : BitVec 12)) (exponentWord.getLimbN 0) sp evmSp
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+        (((base + 44) + 32) + 68)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+        d0 d1 d2 d3
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+        a0 a1 a2 a3 v7 v11 **
+       (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+        (expTwoMulFixedExpResidual 2 (ptr + signExtend12 (-8 : BitVec 12))
+          lookahead exponentWord **
+         frame))) ps) := by
+  obtain ⟨psA, psR, hdisj, hunion, hA, hR⟩ := h
+  obtain ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩ :=
+    expTwoMulFixedIterReloadSkipCountPost_choose_scratch hA
+  rw [expTwoMulFixedExpResidual_succ_one] at hR
+  refine ⟨v7, v10, v11, d0, d1, d2, d3, ?_⟩
+  apply expTwoMulFixedIterReloadSkipScratchFrame_to_iterPre_frame
+    (nextNextLimb := exponentWord.getLimbN 0)
+    (frame := expTwoMulFixedExpResidual 2 (ptr + signExtend12 (-8 : BitVec 12))
+      lookahead exponentWord ** frame)
+  have hCombined :
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+          r0 r1 r2 r3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffix e c6 ptr nextLimb
+          evmSp a0 a1 a2 a3 base) **
+       (((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
+          exponentWord.getLimbN 0) **
+        expTwoMulFixedExpResidual 2 (ptr + signExtend12 (-8 : BitVec 12))
+          lookahead exponentWord) **
+        frame)) ps :=
+    ⟨psA, psR, hdisj, hunion, hScratch, hR⟩
+  xperm_hyp hCombined
+
+/-- Reload-boundary re-partition (cond branch, block 2). -/
+theorem expTwoMulFixedIterReloadCondCountPost_residual_repartition_two
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {lookahead : Word} {exponentWord : EvmWord}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterReloadCondCountPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond **
+       (expTwoMulFixedExpResidual 2 ptr lookahead exponentWord ** frame)) ps) :
+    (∃ v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterPre
+        nextLimb
+        ((0 : Word) + signExtend12 (64 : BitVec 12))
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        (ptr + signExtend12 (-8 : BitVec 12)) lookahead sp evmSp
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+        (((base + 44) + 140) + 68)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+        d0 d1 d2 d3
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+        a0 a1 a2 a3 v7 v11 **
+       (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+        (expTwoMulFixedExpResidual 3 (ptr + signExtend12 (-8 : BitVec 12))
+          lookahead exponentWord **
+         frame))) ps) := by
+  obtain ⟨psA, psR, hdisj, hunion, hA, hR⟩ := h
+  obtain ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩ :=
+    expTwoMulFixedIterReloadCondCountPost_choose_scratch hA
+  rw [expTwoMulFixedExpResidual_succ_two] at hR
+  refine ⟨v7, v10, v11, d0, d1, d2, d3, ?_⟩
+  apply expTwoMulFixedIterReloadCondScratchFrame_to_iterPre_frame
+    (nextNextLimb := lookahead)
+    (frame := expTwoMulFixedExpResidual 3 (ptr + signExtend12 (-8 : BitVec 12))
+      lookahead exponentWord ** frame)
+  have hCombined :
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffix e c6 ptr nextLimb base) **
+       (((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
+          lookahead) **
+        expTwoMulFixedExpResidual 3 (ptr + signExtend12 (-8 : BitVec 12))
+          lookahead exponentWord) **
+        frame)) ps :=
+    ⟨psA, psR, hdisj, hunion, hScratch, hR⟩
+  xperm_hyp hCombined
+
+/-- Reload-boundary re-partition (skip branch, block 2). -/
+theorem expTwoMulFixedIterReloadSkipCountPost_residual_repartition_two
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {lookahead : Word} {exponentWord : EvmWord}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterReloadSkipCountPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond **
+       (expTwoMulFixedExpResidual 2 ptr lookahead exponentWord ** frame)) ps) :
+    (∃ v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterPre
+        nextLimb
+        ((0 : Word) + signExtend12 (64 : BitVec 12))
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        (ptr + signExtend12 (-8 : BitVec 12)) lookahead sp evmSp
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+        (((base + 44) + 32) + 68)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+        d0 d1 d2 d3
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+        a0 a1 a2 a3 v7 v11 **
+       (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+        (expTwoMulFixedExpResidual 3 (ptr + signExtend12 (-8 : BitVec 12))
+          lookahead exponentWord **
+         frame))) ps) := by
+  obtain ⟨psA, psR, hdisj, hunion, hA, hR⟩ := h
+  obtain ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩ :=
+    expTwoMulFixedIterReloadSkipCountPost_choose_scratch hA
+  rw [expTwoMulFixedExpResidual_succ_two] at hR
+  refine ⟨v7, v10, v11, d0, d1, d2, d3, ?_⟩
+  apply expTwoMulFixedIterReloadSkipScratchFrame_to_iterPre_frame
+    (nextNextLimb := lookahead)
+    (frame := expTwoMulFixedExpResidual 3 (ptr + signExtend12 (-8 : BitVec 12))
+      lookahead exponentWord ** frame)
+  have hCombined :
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+          r0 r1 r2 r3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffix e c6 ptr nextLimb
+          evmSp a0 a1 a2 a3 base) **
+       (((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
+          lookahead) **
+        expTwoMulFixedExpResidual 3 (ptr + signExtend12 (-8 : BitVec 12))
+          lookahead exponentWord) **
+        frame)) ps :=
+    ⟨psA, psR, hdisj, hunion, hScratch, hR⟩
+  xperm_hyp hCombined
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedReloadResidualRepartition.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedReloadResidualRepartition.lean
@@ -1,0 +1,78 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedReloadResidualRepartition
+
+  Reload-boundary re-partition: combine the merged loop-back reload `CountPost`
+  with the exponent residual `expTwoMulFixedExpResidual` to produce the next
+  iteration's `expTwoMulFixedIterPre`, with the residual shrunk by one block.
+
+  This packages, for the `ExpResidual`-threaded merged induction's reload case:
+  `_choose_scratch` (expose the reload scratch) + the `_succ_zero` residual split
+  (expose the `ptr-8` look-ahead cell) + the proven reload→IterPre assembler.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedReloadReshuffle
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedExpResidual
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostCases
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+/-- Reload-boundary re-partition (cond branch, block 0): the reload `CountPost`
+    plus the block-0 exponent residual re-partition into the next iteration's
+    `IterPre` (cursor reloaded from the `ptr-8` cell, pointer advanced) framed by
+    the block-1 residual and the now-stale pointer cell. -/
+theorem expTwoMulFixedIterReloadCondCountPost_residual_repartition_zero
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {lookahead : Word} {exponentWord : EvmWord}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterReloadCondCountPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond **
+       (expTwoMulFixedExpResidual 0 ptr lookahead exponentWord ** frame)) ps) :
+    (∃ v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterPre
+        nextLimb
+        ((0 : Word) + signExtend12 (64 : BitVec 12))
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        (ptr + signExtend12 (-8 : BitVec 12)) (exponentWord.getLimbN 1) sp evmSp
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+        (((base + 44) + 140) + 68)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+        d0 d1 d2 d3
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+        a0 a1 a2 a3 v7 v11 **
+       (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+        (expTwoMulFixedExpResidual 1 (ptr + signExtend12 (-8 : BitVec 12))
+          lookahead exponentWord **
+         frame))) ps) := by
+  obtain ⟨psA, psR, hdisj, hunion, hA, hR⟩ := h
+  obtain ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩ :=
+    expTwoMulFixedIterReloadCondCountPost_choose_scratch hA
+  rw [expTwoMulFixedExpResidual_succ_zero] at hR
+  refine ⟨v7, v10, v11, d0, d1, d2, d3, ?_⟩
+  apply expTwoMulFixedIterReloadCondScratchFrame_to_iterPre_frame
+    (nextNextLimb := exponentWord.getLimbN 1)
+    (frame := expTwoMulFixedExpResidual 1 (ptr + signExtend12 (-8 : BitVec 12))
+      lookahead exponentWord ** frame)
+  have hCombined :
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffix e c6 ptr nextLimb base) **
+       (((((ptr + signExtend12 (-8 : BitVec 12)) + signExtend12 (0 : BitVec 12)) ↦ₘ
+          exponentWord.getLimbN 1) **
+        expTwoMulFixedExpResidual 1 (ptr + signExtend12 (-8 : BitVec 12))
+          lookahead exponentWord) **
+        frame)) ps :=
+    ⟨psA, psR, hdisj, hunion, hScratch, hR⟩
+  xperm_hyp hCombined


### PR DESCRIPTION
Follow-up to #9495 (merged). That PR landed the x6→x20 counter-clobber **executable bug fix** and the `∀v6'`-wall dissolution. This PR carries the EXP loop-body induction infrastructure built on top of it — committed to the same branch after #9495 merged, so currently on no open PR.

All new, self-contained files (no overlap with main); `lake build EvmAsm.Evm64.Exp` green, no `sorry`/`native_decide`/`bv_decide`, zero warnings:

- `SavedBitFixedExitBridge.lean` — the 4 exit-post → `LoopExitFullStackPreFrame` disjunct bridges.
- `SavedBitFixedReloadReshuffle.lean` — reload-boundary pointer/suffix reshuffles + both reload→`IterPre` assemblers (pure `sep_perm`; the reload is a re-partition, not a code step, given the residual carries the next-limb cell).
- `SavedBitFixedExpResidual.lean` — `ExpResidual` (the exponent residual carried through the loop, counts 3/2/1/0 by block) + block-boundary split lemmas.
- `SavedBitFixedMergedFramedStep.lean` — framed merged-iteration step (threads the exponent residual `F` through one iteration; exponent is read-only across the body).
- `SavedBitFixedReloadResidualRepartition.lean` — the 6 reload-boundary re-partitions (cond+skip × blocks 0/1/2).

These are the proven ingredients for the `ExpResidual`-threaded merged induction that produces `hBody`, which composes with the boundary lemma + the (already-proven) semantic bridge to land `evm_exp_stack_spec_within` (the final induction assembly is in progress).

Directed by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)