### PR TITLE
feat(exp): residual-threaded merged loop-body induction (8-case) — toward evm_exp_stack_spec_within

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -105,6 +105,7 @@ import EvmAsm.Evm64.Exp.Compose.FixedLoopInd
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedReloadReshuffle
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedExpResidual
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedReloadResidualRepartition
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedResidualInduction
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEpilogueBase
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCount.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCount.lean
@@ -46,6 +46,24 @@ theorem expTwoMulFixedRemainingIterations_succ_final :
     expTwoMulFixedRemainingIterations (255 + 1) = 0 := by
   rfl
 
+/-- Block-bound at a non-final reload: a reload loop-back fires at a 64-bit
+    boundary (`k % 64 = 63`) and, when it is not the loop exit (`k < 255`),
+    the limb block index `k / 64` is strictly below 3.  This is the arithmetic
+    core of the `ExpResidual` block-bound used by the residual-threaded merged
+    induction: the look-ahead exponent cell is present (`ExpResidual` non-empty)
+    at every reload, because the only `k / 64 = 3` reload coincides with the
+    exit (`k = 255`), not a loop-back. -/
+theorem expTwoMulFixedReloadBlock_lt_three
+    {k : Nat} (hMod : k % 64 = 63) (hLt : k < 255) :
+    k / 64 < 3 := by
+  omega
+
+/-- The non-final reload block index is exactly one of `0, 1, 2`. -/
+theorem expTwoMulFixedReloadBlock_cases
+    {k : Nat} (hMod : k % 64 = 63) (hLt : k < 255) :
+    k / 64 = 0 ∨ k / 64 = 1 ∨ k / 64 = 2 := by
+  omega
+
 theorem expTwoMulFixedIterCountInvariant_zero :
     expTwoMulFixedIterCountInvariant 0 (256 : Word) := by
   unfold expTwoMulFixedIterCountInvariant

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedReloadResidualRepartition.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedReloadResidualRepartition.lean
@@ -361,4 +361,111 @@ theorem expTwoMulFixedIterReloadSkipCountPost_residual_repartition_two
     ⟨psA, psR, hdisj, hunion, hScratch, hR⟩
   xperm_hyp hCombined
 
+/-- Non-reload (within-block) re-partition, cond branch: the loop-back
+    `SkipCondCountPost ** PointerPost` together with the (unchanged) exponent
+    residual produces the next iteration's `IterPre` (same pointer/block) framed
+    by the same residual.  The exponent residual rides untouched — only the
+    scratch/pointer cells are reshaped into the next `IterPre`. -/
+theorem expTwoMulFixedIterSkipCondCountPost_residual_repartition
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {b : Nat} {lookahead : Word} {exponentWord : EvmWord}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      ((expTwoMulFixedIterSkipCondCountPost iterCount e c6 sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond **
+        expTwoMulFixedIterPointerPost ptr nextLimb) **
+       (expTwoMulFixedExpResidual b ptr lookahead exponentWord ** frame)) ps) :
+    (∃ v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterPre
+        (e <<< (1 : BitVec 6).toNat)
+        (c6 + signExtend12 (-1 : BitVec 12))
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        ptr nextLimb sp evmSp
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+        (((base + 44) + 140) + 68)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+        d0 d1 d2 d3
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2)
+        ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+        a0 a1 a2 a3 v7 v11 **
+       (expTwoMulFixedExpResidual b ptr lookahead exponentWord ** frame)) ps) := by
+  obtain ⟨psA, psR, hdisj, hunion, hA, hR⟩ := h
+  obtain ⟨psC, psP, hdisjCP, hunionCP, hCount, hPtr⟩ := hA
+  obtain ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩ :=
+    expTwoMulFixedIterSkipCondCountPost_choose_scratch hCount
+  refine ⟨v7, v10, v11, d0, d1, d2, d3, ?_⟩
+  apply expTwoMulFixedIterSkipCondScratchFrame_to_iterPre_frame
+    (frame := expTwoMulFixedExpResidual b ptr lookahead exponentWord ** frame)
+  rw [expTwoMulFixedIterPointerFrame_unfold]
+  have hCombined :
+      (((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterSkipCondCountPostScratchSuffix e c6 base) **
+        expTwoMulFixedIterPointerPost ptr nextLimb) **
+       (expTwoMulFixedExpResidual b ptr lookahead exponentWord ** frame)) ps :=
+    ⟨psA, psR, hdisj, hunion,
+      ⟨psC, psP, hdisjCP, hunionCP, hScratch, hPtr⟩, hR⟩
+  xperm_hyp hCombined
+
+/-- Non-reload (within-block) re-partition, skip branch. -/
+theorem expTwoMulFixedIterSkipCountPost_residual_repartition
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {b : Nat} {lookahead : Word} {exponentWord : EvmWord}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      ((expTwoMulFixedIterSkipCountPost iterCount e c6 sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond **
+        expTwoMulFixedIterPointerPost ptr nextLimb) **
+       (expTwoMulFixedExpResidual b ptr lookahead exponentWord ** frame)) ps) :
+    (∃ v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterPre
+        (e <<< (1 : BitVec 6).toNat)
+        (c6 + signExtend12 (-1 : BitVec 12))
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        ptr nextLimb sp evmSp
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+        (((base + 44) + 32) + 68)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+        d0 d1 d2 d3
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2)
+        ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+        a0 a1 a2 a3 v7 v11 **
+       (expTwoMulFixedExpResidual b ptr lookahead exponentWord ** frame)) ps) := by
+  obtain ⟨psA, psR, hdisj, hunion, hA, hR⟩ := h
+  obtain ⟨psC, psP, hdisjCP, hunionCP, hCount, hPtr⟩ := hA
+  obtain ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩ :=
+    expTwoMulFixedIterSkipCountPost_choose_scratch hCount
+  refine ⟨v7, v10, v11, d0, d1, d2, d3, ?_⟩
+  apply expTwoMulFixedIterSkipScratchFrame_to_iterPre_frame
+    (frame := expTwoMulFixedExpResidual b ptr lookahead exponentWord ** frame)
+  rw [expTwoMulFixedIterPointerFrame_unfold]
+  have hCombined :
+      (((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+          r0 r1 r2 r3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterSkipCountPostScratchSuffix e c6 evmSp
+          a0 a1 a2 a3 base) **
+        expTwoMulFixedIterPointerPost ptr nextLimb) **
+       (expTwoMulFixedExpResidual b ptr lookahead exponentWord ** frame)) ps :=
+    ⟨psA, psR, hdisj, hunion,
+      ⟨psC, psP, hdisjCP, hunionCP, hScratch, hPtr⟩, hR⟩
+  xperm_hyp hCombined
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedResidualInduction.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedResidualInduction.lean
@@ -1,0 +1,100 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedResidualInduction
+
+  The `ExpResidual`-threaded merged fixed-x19 EXP loop-body induction.
+
+  STATUS: scaffold + validated plan (resumable WIP). The full induction proof is
+  the single remaining atomic piece for `evm_exp_stack_spec_within`; every
+  ingredient lemma it needs is already proven and committed (see below). This
+  file is intentionally NOT yet imported into `EvmAsm/Evm64/Exp.lean`, so the
+  umbrella build stays green while the proof is finished.
+
+  Unlike `exp_merged_loop_from_iterpre_induction` (parametric in `c6`, hence
+  needing the unprovable pure `MergedReloadReshuffle`), this induction threads
+  the exponent residual through the body via the framed step and carries the
+  control invariant as a pure side condition, making the reload boundary a pure
+  re-partition.
+
+  ── EXACT STATEMENT (validated to elaborate; copy this when filling the proof) ──
+
+  theorem exp_merged_loop_from_iterpre_residual_induction
+      (base sp evmSp a0 a1 a2 a3 : Word) (R : Assertion)
+      (exponentWord : EvmWord) (lookahead : Word)
+      (hbase : (base + 44 : Word) &&& 1 = 0)
+      (hExitU :
+        ∀ (e c6 iterCount ptr nextLimb r0 r1 r2 r3 : Word) (ps : PartialState),
+          (expTwoMulFixedIterMergedExitPost e c6 iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base **
+            expTwoMulFixedExpResidual 3 ptr lookahead exponentWord) ps →
+          R ps)
+      (n : Nat) :
+      ∀ (e c6 iterCount v10 v18 ptr nextLimb tOld vOld
+          r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 v7 v11 : Word),
+        iterCount.toNat = n + 1 →
+        expTwoMulFixedControlInvariant exponentWord (255 - n) c6 ptr nextLimb evmSp →
+        cpsTripleWithin ((n + 1) * 193) (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+            tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 **
+           expTwoMulFixedExpResidual ((255 - n) / 64) ptr lookahead exponentWord)
+          R
+
+  ── PROOF PLAN (all cited lemmas proven & committed) ──
+
+  induction n.
+  • zero (n=0, k=255, b=3, ExpResidual 3 = emp): apply
+    `exp_fixed_loop_body_final_succ_step_framed` with F := ExpResidual 3 ptr …
+    (= emp; `expTwoMulFixedExpResidual_ge_three`), hF via `_pcFree`,
+    hzero via `expTwoMulIterCountNew_eq_zero_of_toNat_one`, hExit := hExitU
+    instantiated.
+  • succ k (n=k+1, k_iter=255-(k+1)=254-k, b=(254-k)/64): apply
+    `exp_fixed_loop_body_succ_step_framed (k+1)` with F := ExpResidual b ptr …,
+    hExit = vacuous (count≠0) via the framed vacuous bridge, and hLoop built as:
+      intro the cpsTriple; obtain the `MergedLoopPost ** F ** Rframe` holdsFor;
+      rw [← expTwoMulFixedIterMergedLoopPost_eq_caseLoopPost]; unfold CaseLoopPost
+      into its 4 CountPost disjuncts (SkipCond/Skip[**PointerPost] ∨
+      ReloadCond/ReloadSkip):
+        - non-reload (SkipCond / Skip): apply
+          `expTwoMulFixedIterSkip{Cond,}CountPost_residual_repartition`
+          (input `(CountPost ** PointerPost) ** (ExpResidual b ptr ** Rframe)`,
+          output next IterPre ** (ExpResidual b ptr ** Rframe)); derive the next
+          control invariant via `expTwoMulFixedControlInvariant_succ_no_reload`
+          (b, ptr unchanged); apply IH at n=k.
+        - reload (ReloadCond / ReloadSkip): the disjunct pure gives
+          c6+signExtend12(-1)=0; with the carried control invariant,
+          `expTwoMulFixedControlInvariant_reload_mod` ⇒ k_iter%64=63, and
+          k_iter<255 ⇒ `expTwoMulFixedReloadBlock_cases` ⇒ b∈{0,1,2}; apply the
+          matching `expTwoMulFixedIterReload{Cond,Skip}CountPost_residual_repartition_{zero,one,two}`
+          (output next IterPre ** ((ptr↦nextLimb) ** ExpResidual (b+1)(ptr-8) ** Rframe));
+          the stale `(ptr↦nextLimb)` cell joins the ambient frame; derive next
+          control invariant via `expTwoMulFixedControlInvariant_succ_reload`;
+          apply IH at n=k (b+1, ptr-8). Use `xperm_hyp` for opaque-frame perms.
+
+  ── REMAINING SUBTLETY (the one open design point) ──
+  At exit (n=0, b=3) `ExpResidual 3 = emp`, so the exit-bridge disjuncts
+  (`SavedBitFixedExitBridge.lean`) — which need the read-only exponent frame
+  `evmWordIs (evmSp-32) exponentWord` — must source it from the *ambient*
+  universal frame (the passed exponent cells, above x16), not from `F`. So
+  `hExitU`'s eventual discharge (step C) reconciles the exit post against the
+  ambient exponent; this affects only the `hExitU` *discharge*, not this
+  induction's statement (which carries `ExpResidual 3 = emp` cleanly).
+
+  ── CHAIN after this induction (proven ingredients) ──
+  instantiate at n=255 (b=0; control invariant at k=0 is
+  `expTwoMulFixedControlInvariant_zero`; entry residual = ExpResidual 0 plus the
+  +24 look-ahead sourced from the ambient stack) → hBody; feed boundary
+  `exp_two_mul_fixed_full_loop_boundary_of_entry_iterpre_body_general_spec_within`
+  (`SavedBitBoundaryLoopFixedEntryExists.lean:1054`) + the proven semantic bridge
+  `expTwoMulFixedAccumulatorInvariant_full` → `evm_exp_stack_spec_within`.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.MergedLoopInd
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedMergedFramedStep
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedExpResidual
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedReloadResidualRepartition
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedResidualInduction.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedResidualInduction.lean
@@ -3,89 +3,14 @@
 
   The `ExpResidual`-threaded merged fixed-x19 EXP loop-body induction.
 
-  STATUS: scaffold + validated plan (resumable WIP). The full induction proof is
-  the single remaining atomic piece for `evm_exp_stack_spec_within`; every
-  ingredient lemma it needs is already proven and committed (see below). This
-  file is intentionally NOT yet imported into `EvmAsm/Evm64/Exp.lean`, so the
-  umbrella build stays green while the proof is finished.
-
   Unlike `exp_merged_loop_from_iterpre_induction` (parametric in `c6`, hence
   needing the unprovable pure `MergedReloadReshuffle`), this induction threads
   the exponent residual through the body via the framed step and carries the
   control invariant as a pure side condition, making the reload boundary a pure
-  re-partition.
+  re-partition (using the proven `..._residual_repartition[_*]` lemmas).
 
-  ── EXACT STATEMENT (validated to elaborate; copy this when filling the proof) ──
-
-  theorem exp_merged_loop_from_iterpre_residual_induction
-      (base sp evmSp a0 a1 a2 a3 : Word) (R : Assertion)
-      (exponentWord : EvmWord) (lookahead : Word)
-      (hbase : (base + 44 : Word) &&& 1 = 0)
-      (hExitU :
-        ∀ (e c6 iterCount ptr nextLimb r0 r1 r2 r3 : Word) (ps : PartialState),
-          (expTwoMulFixedIterMergedExitPost e c6 iterCount ptr nextLimb sp evmSp
-            r0 r1 r2 r3 a0 a1 a2 a3 base **
-            expTwoMulFixedExpResidual 3 ptr lookahead exponentWord) ps →
-          R ps)
-      (n : Nat) :
-      ∀ (e c6 iterCount v10 v18 ptr nextLimb tOld vOld
-          r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 v7 v11 : Word),
-        iterCount.toNat = n + 1 →
-        expTwoMulFixedControlInvariant exponentWord (255 - n) c6 ptr nextLimb evmSp →
-        cpsTripleWithin ((n + 1) * 193) (base + 44) (base + 296)
-          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
-            tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 **
-           expTwoMulFixedExpResidual ((255 - n) / 64) ptr lookahead exponentWord)
-          R
-
-  ── PROOF PLAN (all cited lemmas proven & committed) ──
-
-  induction n.
-  • zero (n=0, k=255, b=3, ExpResidual 3 = emp): apply
-    `exp_fixed_loop_body_final_succ_step_framed` with F := ExpResidual 3 ptr …
-    (= emp; `expTwoMulFixedExpResidual_ge_three`), hF via `_pcFree`,
-    hzero via `expTwoMulIterCountNew_eq_zero_of_toNat_one`, hExit := hExitU
-    instantiated.
-  • succ k (n=k+1, k_iter=255-(k+1)=254-k, b=(254-k)/64): apply
-    `exp_fixed_loop_body_succ_step_framed (k+1)` with F := ExpResidual b ptr …,
-    hExit = vacuous (count≠0) via the framed vacuous bridge, and hLoop built as:
-      intro the cpsTriple; obtain the `MergedLoopPost ** F ** Rframe` holdsFor;
-      rw [← expTwoMulFixedIterMergedLoopPost_eq_caseLoopPost]; unfold CaseLoopPost
-      into its 4 CountPost disjuncts (SkipCond/Skip[**PointerPost] ∨
-      ReloadCond/ReloadSkip):
-        - non-reload (SkipCond / Skip): apply
-          `expTwoMulFixedIterSkip{Cond,}CountPost_residual_repartition`
-          (input `(CountPost ** PointerPost) ** (ExpResidual b ptr ** Rframe)`,
-          output next IterPre ** (ExpResidual b ptr ** Rframe)); derive the next
-          control invariant via `expTwoMulFixedControlInvariant_succ_no_reload`
-          (b, ptr unchanged); apply IH at n=k.
-        - reload (ReloadCond / ReloadSkip): the disjunct pure gives
-          c6+signExtend12(-1)=0; with the carried control invariant,
-          `expTwoMulFixedControlInvariant_reload_mod` ⇒ k_iter%64=63, and
-          k_iter<255 ⇒ `expTwoMulFixedReloadBlock_cases` ⇒ b∈{0,1,2}; apply the
-          matching `expTwoMulFixedIterReload{Cond,Skip}CountPost_residual_repartition_{zero,one,two}`
-          (output next IterPre ** ((ptr↦nextLimb) ** ExpResidual (b+1)(ptr-8) ** Rframe));
-          the stale `(ptr↦nextLimb)` cell joins the ambient frame; derive next
-          control invariant via `expTwoMulFixedControlInvariant_succ_reload`;
-          apply IH at n=k (b+1, ptr-8). Use `xperm_hyp` for opaque-frame perms.
-
-  ── REMAINING SUBTLETY (the one open design point) ──
-  At exit (n=0, b=3) `ExpResidual 3 = emp`, so the exit-bridge disjuncts
-  (`SavedBitFixedExitBridge.lean`) — which need the read-only exponent frame
-  `evmWordIs (evmSp-32) exponentWord` — must source it from the *ambient*
-  universal frame (the passed exponent cells, above x16), not from `F`. So
-  `hExitU`'s eventual discharge (step C) reconciles the exit post against the
-  ambient exponent; this affects only the `hExitU` *discharge*, not this
-  induction's statement (which carries `ExpResidual 3 = emp` cleanly).
-
-  ── CHAIN after this induction (proven ingredients) ──
-  instantiate at n=255 (b=0; control invariant at k=0 is
-  `expTwoMulFixedControlInvariant_zero`; entry residual = ExpResidual 0 plus the
-  +24 look-ahead sourced from the ambient stack) → hBody; feed boundary
-  `exp_two_mul_fixed_full_loop_boundary_of_entry_iterpre_body_general_spec_within`
-  (`SavedBitBoundaryLoopFixedEntryExists.lean:1054`) + the proven semantic bridge
-  `expTwoMulFixedAccumulatorInvariant_full` → `evm_exp_stack_spec_within`.
+  Bounded by `n ≤ 255` so the Nat-subtraction index alignment
+  `255 - (k+1) + 1 = 255 - k` holds.
 -/
 
 import EvmAsm.Evm64.Exp.Compose.MergedLoopInd
@@ -96,5 +21,462 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFixedReloadResidualRepartition
 namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
+
+theorem exp_merged_loop_from_iterpre_residual_induction
+    (base sp evmSp a0 a1 a2 a3 : Word) (R : Assertion)
+    (exponentWord : EvmWord) (lookahead : Word)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hExitU :
+      ∀ (e c6 iterCount ptr nextLimb r0 r1 r2 r3 : Word) (ps : PartialState),
+        (expTwoMulFixedIterMergedExitPost e c6 iterCount ptr nextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base **
+          expTwoMulFixedExpResidual 3 ptr lookahead exponentWord) ps →
+        R ps)
+    (n : Nat) :
+    n ≤ 255 →
+    ∀ (e c6 iterCount v10 v18 ptr nextLimb tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 v7 v11 : Word),
+      iterCount.toNat = n + 1 →
+      expTwoMulFixedControlInvariant exponentWord (255 - n) c6 ptr
+        (exponentWord.getLimbN (2 - (255 - n) / 64)) evmSp →
+      cpsTripleWithin ((n + 1) * 193) (base + 44) (base + 296)
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+          tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 **
+         expTwoMulFixedExpResidual ((255 - n) / 64) ptr lookahead exponentWord)
+        R := by
+  induction n with
+  | zero =>
+    intro _hn e c6 iterCount v10 v18 ptr nextLimb tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 v7 v11 hcount _hControl
+    have hzero : expTwoMulIterCountNew iterCount = 0 :=
+      expTwoMulIterCountNew_eq_zero_of_toNat_one hcount
+    have hb : (255 - 0) / 64 = 3 := by decide
+    rw [hb]
+    exact
+      exp_fixed_loop_body_final_succ_step_framed
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+        base R (expTwoMulFixedExpResidual 3 ptr lookahead exponentWord)
+        hbase expTwoMulFixedExpResidual_pcFree
+        hzero (hExitU e c6 iterCount ptr nextLimb r0 r1 r2 r3)
+  | succ k IH =>
+    intro hn e c6 iterCount v10 v18 ptr nextLimb tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 v7 v11 hcount hControl
+    have hn' : k ≤ 255 := by omega
+    have hcountNew : (expTwoMulIterCountNew iterCount).toNat = k + 1 :=
+      expTwoMulIterCountNew_toNat_of_eq_succ hcount
+    have hne : expTwoMulIterCountNew iterCount ≠ 0 := by
+      intro h; rw [h] at hcountNew; simp at hcountNew
+    have hExit :
+        ∀ ps,
+          (expTwoMulFixedIterMergedExitPost e c6 iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base **
+            expTwoMulFixedExpResidual ((255 - (k + 1)) / 64) ptr lookahead exponentWord) ps →
+          R ps := by
+      intro ps hps
+      obtain ⟨_, _, _, _, hE, _⟩ := hps
+      exact absurd hE (expTwoMulFixedIterMergedExitPost_nonzero_count_false hne)
+    have hLoop :
+        cpsTripleWithin ((k + 1) * 193) (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expTwoMulFixedIterMergedLoopPost e c6 iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base **
+            expTwoMulFixedExpResidual ((255 - (k + 1)) / 64) ptr lookahead exponentWord)
+          R := by
+      intro Rframe hRframe s hcr hPR hpc
+      obtain ⟨hp, hcompat, psMF, psR, hdisj, hunion, hMF, hRps⟩ := hPR
+      obtain ⟨psM, psF, hdMF, huMF, hLP, hFps⟩ := hMF
+      rw [expTwoMulFixedIterMergedLoopPost_eq_caseLoopPost] at hLP
+      have hEmp :
+          (expTwoMulFixedExpResidual ((255 - (k + 1)) / 64) ptr lookahead
+            exponentWord ** empAssertion) psF := by
+        rw [sepConj_emp_right']; exact hFps
+      rcases hLP with hSkip | hReload
+      · -- Skip (non-reload) loop-back: ((SkipCond ∨ Skip) ** PointerPost) psM
+        obtain ⟨psI, psP, hdIP, huIP, hInner, hPtr⟩ := hSkip
+        rcases hInner with hSC | hSk
+        · -- SkipCond branch
+          obtain ⟨_, hC6, _⟩ := expTwoMulFixedIterSkipCondCountPost_pures hSC
+          have hMod := expTwoMulFixedControlInvariant_no_reload_mod hControl hC6
+          have hbk : (255 - k) / 64 = (255 - (k + 1)) / 64 := by omega
+          have hControlNext :
+              expTwoMulFixedControlInvariant exponentWord (255 - k)
+                (c6 + signExtend12 (-1 : BitVec 12)) ptr
+                (exponentWord.getLimbN (2 - (255 - k) / 64)) evmSp := by
+            have h := expTwoMulFixedControlInvariant_succ_no_reload hControl hC6
+            rw [show 255 - (k + 1) + 1 = 255 - k from by omega,
+                show 2 - (255 - (k + 1)) / 64 = 2 - (255 - k) / 64 from by omega] at h
+            exact h
+          have hInput :
+              ((expTwoMulFixedIterSkipCondCountPost iterCount e c6 sp evmSp
+                  r0 r1 r2 r3 a0 a1 a2 a3 base
+                  (expTwoMulIterCountNew iterCount ≠ 0) **
+                expTwoMulFixedIterPointerPost ptr nextLimb) **
+               (expTwoMulFixedExpResidual ((255 - (k + 1)) / 64) ptr lookahead
+                  exponentWord ** empAssertion)) psMF :=
+            ⟨psM, psF, hdMF, huMF, ⟨psI, psP, hdIP, huIP, hSC, hPtr⟩, hEmp⟩
+          obtain ⟨v7', v10', v11', d0', d1', d2', d3', hOut⟩ :=
+            expTwoMulFixedIterSkipCondCountPost_residual_repartition hInput
+          rw [sepConj_emp_right'] at hOut
+          rw [← hbk] at hOut
+          exact IH hn' _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ hcountNew
+            hControlNext Rframe hRframe s hcr
+            ⟨hp, hcompat, psMF, psR, hdisj, hunion, hOut, hRps⟩ hpc
+        · -- Skip branch
+          obtain ⟨_, hC6, _⟩ := expTwoMulFixedIterSkipCountPost_pures hSk
+          have hMod := expTwoMulFixedControlInvariant_no_reload_mod hControl hC6
+          have hbk : (255 - k) / 64 = (255 - (k + 1)) / 64 := by omega
+          have hControlNext :
+              expTwoMulFixedControlInvariant exponentWord (255 - k)
+                (c6 + signExtend12 (-1 : BitVec 12)) ptr
+                (exponentWord.getLimbN (2 - (255 - k) / 64)) evmSp := by
+            have h := expTwoMulFixedControlInvariant_succ_no_reload hControl hC6
+            rw [show 255 - (k + 1) + 1 = 255 - k from by omega,
+                show 2 - (255 - (k + 1)) / 64 = 2 - (255 - k) / 64 from by omega] at h
+            exact h
+          have hInput :
+              ((expTwoMulFixedIterSkipCountPost iterCount e c6 sp evmSp
+                  r0 r1 r2 r3 a0 a1 a2 a3 base
+                  (expTwoMulIterCountNew iterCount ≠ 0) **
+                expTwoMulFixedIterPointerPost ptr nextLimb) **
+               (expTwoMulFixedExpResidual ((255 - (k + 1)) / 64) ptr lookahead
+                  exponentWord ** empAssertion)) psMF :=
+            ⟨psM, psF, hdMF, huMF, ⟨psI, psP, hdIP, huIP, hSk, hPtr⟩, hEmp⟩
+          obtain ⟨v7', v10', v11', d0', d1', d2', d3', hOut⟩ :=
+            expTwoMulFixedIterSkipCountPost_residual_repartition hInput
+          rw [sepConj_emp_right'] at hOut
+          rw [← hbk] at hOut
+          exact IH hn' _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ hcountNew
+            hControlNext Rframe hRframe s hcr
+            ⟨hp, hcompat, psMF, psR, hdisj, hunion, hOut, hRps⟩ hpc
+      · -- Reload loop-back: (ReloadCond ∨ ReloadSkip) psM  (no PointerPost wrapper)
+        rcases hReload with hRC | hRS
+        · -- ReloadCond branch
+          obtain ⟨_, hC6, _⟩ := expTwoMulFixedIterReloadCondCountPost_pures hRC
+          have hMod : (255 - (k + 1)) % 64 = 63 :=
+            expTwoMulFixedControlInvariant_reload_mod hControl hC6
+          rcases expTwoMulFixedReloadBlock_cases hMod (by omega) with hb0 | hb1 | hb2
+          · -- block 0 → 1
+            have hbk : (255 - k) / 64 = 1 := by omega
+            have hc64 : ((0 : Word) + signExtend12 (64 : BitVec 12)) = (64 : Word) := by
+              decide
+            have hControlNext :
+                expTwoMulFixedControlInvariant exponentWord (255 - k)
+                  ((0 : Word) + signExtend12 (64 : BitVec 12))
+                  (ptr + signExtend12 (-8 : BitVec 12))
+                  (exponentWord.getLimbN (2 - (255 - k) / 64)) evmSp := by
+              rw [hc64]
+              have h := expTwoMulFixedControlInvariant_succ_reload hControl hC6
+                (nextNextLimb := exponentWord.getLimbN (2 - (255 - k) / 64))
+                (by rw [show (255 - (k + 1)) + 1 = 255 - k from by omega])
+              have hidx : (255 - (k + 1)) + 1 = 255 - k := by omega
+              rwa [hidx] at h
+            rw [hb0] at hFps
+            have hEmp0 :
+                (expTwoMulFixedExpResidual 0 ptr lookahead exponentWord **
+                  empAssertion) psF := by rw [sepConj_emp_right']; exact hFps
+            have hInput :
+                (expTwoMulFixedIterReloadCondCountPost iterCount e c6 ptr nextLimb
+                    sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+                    (expTwoMulIterCountNew iterCount ≠ 0) **
+                 (expTwoMulFixedExpResidual 0 ptr lookahead exponentWord **
+                    empAssertion)) psMF :=
+              ⟨psM, psF, hdMF, huMF, hRC, hEmp0⟩
+            obtain ⟨v7', v10', v11', d0', d1', d2', d3', hOut⟩ :=
+              expTwoMulFixedIterReloadCondCountPost_residual_repartition_zero hInput
+            simp only [sepConj_emp_right'] at hOut
+            have hFull :
+                ((_ : Assertion) ** Rframe).holdsFor s :=
+              ⟨hp, hcompat, psMF, psR, hdisj, hunion, hOut, hRps⟩
+            obtain ⟨kk, hkk, s', hstep', hpc', hH⟩ :=
+              IH hn'
+                nextLimb ((0 : Word) + signExtend12 (64 : BitVec 12))
+                (expTwoMulIterCountNew iterCount) v10'
+                ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+                (ptr + signExtend12 (-8 : BitVec 12)) (exponentWord.getLimbN 1)
+                ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+                (((base + 44) + 140) + 68)
+                ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0)
+                ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1)
+                ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2)
+                ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+                d0' d1' d2' d3'
+                ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0)
+                ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1)
+                ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2)
+                ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+                v7' v11' hcountNew hControlNext
+                (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) ** Rframe)
+                (pcFree_sepConj pcFree_memIs hRframe) s hcr
+                (by
+                  rw [hbk,
+                    ← sepConj_assoc' _ ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) Rframe,
+                    sepConj_assoc' _
+                      (expTwoMulFixedExpResidual 1 (ptr + signExtend12 (-8 : BitVec 12))
+                        lookahead exponentWord)
+                      ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb),
+                    sepConj_comm'
+                      (expTwoMulFixedExpResidual 1 (ptr + signExtend12 (-8 : BitVec 12))
+                        lookahead exponentWord)
+                      ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb)]
+                  exact hFull) hpc
+            refine ⟨kk, hkk, s', hstep', hpc', ?_⟩
+            rw [sepConj_left_comm' R
+              ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) Rframe] at hH
+            exact holdsFor_sepConj_elim_right hH
+          · -- block 1 → 2
+            have hbk : (255 - k) / 64 = 2 := by omega
+            have hc64 : ((0 : Word) + signExtend12 (64 : BitVec 12)) = (64 : Word) := by decide
+            have hControlNext :
+                expTwoMulFixedControlInvariant exponentWord (255 - k)
+                  ((0 : Word) + signExtend12 (64 : BitVec 12))
+                  (ptr + signExtend12 (-8 : BitVec 12))
+                  (exponentWord.getLimbN (2 - (255 - k) / 64)) evmSp := by
+              rw [hc64]
+              have h := expTwoMulFixedControlInvariant_succ_reload hControl hC6
+                (nextNextLimb := exponentWord.getLimbN (2 - (255 - k) / 64))
+                (by rw [show (255 - (k + 1)) + 1 = 255 - k from by omega])
+              rwa [show (255 - (k + 1)) + 1 = 255 - k from by omega] at h
+            rw [hb1] at hFps
+            have hEmpB : (expTwoMulFixedExpResidual 1 ptr lookahead exponentWord ** empAssertion) psF := by
+              rw [sepConj_emp_right']; exact hFps
+            have hInput :
+                (expTwoMulFixedIterReloadCondCountPost iterCount e c6 ptr nextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+                    (expTwoMulIterCountNew iterCount ≠ 0) **
+                 (expTwoMulFixedExpResidual 1 ptr lookahead exponentWord ** empAssertion)) psMF :=
+              ⟨psM, psF, hdMF, huMF, hRC, hEmpB⟩
+            obtain ⟨v7', v10', v11', d0', d1', d2', d3', hOut⟩ :=
+              expTwoMulFixedIterReloadCondCountPost_residual_repartition_one hInput
+            simp only [sepConj_emp_right'] at hOut
+            have hFull : ((_ : Assertion) ** Rframe).holdsFor s :=
+              ⟨hp, hcompat, psMF, psR, hdisj, hunion, hOut, hRps⟩
+            obtain ⟨kk, hkk, s', hstep', hpc', hH⟩ :=
+              IH hn' nextLimb ((0 : Word) + signExtend12 (64 : BitVec 12))
+                (expTwoMulIterCountNew iterCount) v10'
+                ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+                (ptr + signExtend12 (-8 : BitVec 12)) (exponentWord.getLimbN 0)
+                ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3) (((base + 44) + 140) + 68)
+                ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0) ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1)
+                ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2) ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+                d0' d1' d2' d3'
+                ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0) ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1)
+                ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2) ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+                v7' v11' hcountNew hControlNext
+                (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) ** Rframe)
+                (pcFree_sepConj pcFree_memIs hRframe) s hcr
+                (by
+                  rw [hbk, ← sepConj_assoc' _ ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) Rframe,
+                    sepConj_assoc' _ (expTwoMulFixedExpResidual 2 (ptr + signExtend12 (-8 : BitVec 12)) lookahead exponentWord) ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb),
+                    sepConj_comm' (expTwoMulFixedExpResidual 2 (ptr + signExtend12 (-8 : BitVec 12)) lookahead exponentWord) ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb)]
+                  exact hFull) hpc
+            refine ⟨kk, hkk, s', hstep', hpc', ?_⟩
+            rw [sepConj_left_comm' R ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) Rframe] at hH
+            exact holdsFor_sepConj_elim_right hH
+          · -- block 2 → 3
+            have hbk : (255 - k) / 64 = 3 := by omega
+            have hc64 : ((0 : Word) + signExtend12 (64 : BitVec 12)) = (64 : Word) := by decide
+            have hControlNext :
+                expTwoMulFixedControlInvariant exponentWord (255 - k)
+                  ((0 : Word) + signExtend12 (64 : BitVec 12))
+                  (ptr + signExtend12 (-8 : BitVec 12))
+                  (exponentWord.getLimbN (2 - (255 - k) / 64)) evmSp := by
+              rw [hc64]
+              have h := expTwoMulFixedControlInvariant_succ_reload hControl hC6
+                (nextNextLimb := exponentWord.getLimbN (2 - (255 - k) / 64))
+                (by rw [show (255 - (k + 1)) + 1 = 255 - k from by omega])
+              rwa [show (255 - (k + 1)) + 1 = 255 - k from by omega] at h
+            rw [hb2] at hFps
+            have hEmpB : (expTwoMulFixedExpResidual 2 ptr lookahead exponentWord ** empAssertion) psF := by
+              rw [sepConj_emp_right']; exact hFps
+            have hInput :
+                (expTwoMulFixedIterReloadCondCountPost iterCount e c6 ptr nextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+                    (expTwoMulIterCountNew iterCount ≠ 0) **
+                 (expTwoMulFixedExpResidual 2 ptr lookahead exponentWord ** empAssertion)) psMF :=
+              ⟨psM, psF, hdMF, huMF, hRC, hEmpB⟩
+            obtain ⟨v7', v10', v11', d0', d1', d2', d3', hOut⟩ :=
+              expTwoMulFixedIterReloadCondCountPost_residual_repartition_two hInput
+            simp only [sepConj_emp_right'] at hOut
+            have hFull : ((_ : Assertion) ** Rframe).holdsFor s :=
+              ⟨hp, hcompat, psMF, psR, hdisj, hunion, hOut, hRps⟩
+            obtain ⟨kk, hkk, s', hstep', hpc', hH⟩ :=
+              IH hn' nextLimb ((0 : Word) + signExtend12 (64 : BitVec 12))
+                (expTwoMulIterCountNew iterCount) v10'
+                ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+                (ptr + signExtend12 (-8 : BitVec 12)) lookahead
+                ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3) (((base + 44) + 140) + 68)
+                ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0) ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1)
+                ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2) ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+                d0' d1' d2' d3'
+                ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 0) ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 1)
+                ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 2) ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3).getLimbN 3)
+                v7' v11' hcountNew hControlNext
+                (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) ** Rframe)
+                (pcFree_sepConj pcFree_memIs hRframe) s hcr
+                (by
+                  rw [hbk, ← sepConj_assoc' _ ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) Rframe,
+                    sepConj_assoc' _ (expTwoMulFixedExpResidual 3 (ptr + signExtend12 (-8 : BitVec 12)) lookahead exponentWord) ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb),
+                    sepConj_comm' (expTwoMulFixedExpResidual 3 (ptr + signExtend12 (-8 : BitVec 12)) lookahead exponentWord) ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb)]
+                  exact hFull) hpc
+            refine ⟨kk, hkk, s', hstep', hpc', ?_⟩
+            rw [sepConj_left_comm' R ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) Rframe] at hH
+            exact holdsFor_sepConj_elim_right hH
+        · -- ReloadSkip branch
+          obtain ⟨_, hC6, _⟩ := expTwoMulFixedIterReloadSkipCountPost_pures hRS
+          have hMod : (255 - (k + 1)) % 64 = 63 :=
+            expTwoMulFixedControlInvariant_reload_mod hControl hC6
+          rcases expTwoMulFixedReloadBlock_cases hMod (by omega) with hb0 | hb1 | hb2
+          · -- block 0 → 1
+            have hbk : (255 - k) / 64 = 1 := by omega
+            have hc64 : ((0 : Word) + signExtend12 (64 : BitVec 12)) = (64 : Word) := by decide
+            have hControlNext :
+                expTwoMulFixedControlInvariant exponentWord (255 - k)
+                  ((0 : Word) + signExtend12 (64 : BitVec 12))
+                  (ptr + signExtend12 (-8 : BitVec 12))
+                  (exponentWord.getLimbN (2 - (255 - k) / 64)) evmSp := by
+              rw [hc64]
+              have h := expTwoMulFixedControlInvariant_succ_reload hControl hC6
+                (nextNextLimb := exponentWord.getLimbN (2 - (255 - k) / 64))
+                (by rw [show (255 - (k + 1)) + 1 = 255 - k from by omega])
+              rwa [show (255 - (k + 1)) + 1 = 255 - k from by omega] at h
+            rw [hb0] at hFps
+            have hEmpB : (expTwoMulFixedExpResidual 0 ptr lookahead exponentWord ** empAssertion) psF := by
+              rw [sepConj_emp_right']; exact hFps
+            have hInput :
+                (expTwoMulFixedIterReloadSkipCountPost iterCount e c6 ptr nextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+                    (expTwoMulIterCountNew iterCount ≠ 0) **
+                 (expTwoMulFixedExpResidual 0 ptr lookahead exponentWord ** empAssertion)) psMF :=
+              ⟨psM, psF, hdMF, huMF, hRS, hEmpB⟩
+            obtain ⟨v7', v10', v11', d0', d1', d2', d3', hOut⟩ :=
+              expTwoMulFixedIterReloadSkipCountPost_residual_repartition_zero hInput
+            simp only [sepConj_emp_right'] at hOut
+            have hFull : ((_ : Assertion) ** Rframe).holdsFor s :=
+              ⟨hp, hcompat, psMF, psR, hdisj, hunion, hOut, hRps⟩
+            obtain ⟨kk, hkk, s', hstep', hpc', hH⟩ :=
+              IH hn' nextLimb ((0 : Word) + signExtend12 (64 : BitVec 12))
+                (expTwoMulIterCountNew iterCount) v10'
+                ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+                (ptr + signExtend12 (-8 : BitVec 12)) (exponentWord.getLimbN 1)
+                ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3) (((base + 44) + 32) + 68)
+                ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0) ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1)
+                ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2) ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+                d0' d1' d2' d3'
+                ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0) ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1)
+                ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2) ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+                v7' v11' hcountNew hControlNext
+                (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) ** Rframe)
+                (pcFree_sepConj pcFree_memIs hRframe) s hcr
+                (by
+                  rw [hbk, ← sepConj_assoc' _ ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) Rframe,
+                    sepConj_assoc' _ (expTwoMulFixedExpResidual 1 (ptr + signExtend12 (-8 : BitVec 12)) lookahead exponentWord) ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb),
+                    sepConj_comm' (expTwoMulFixedExpResidual 1 (ptr + signExtend12 (-8 : BitVec 12)) lookahead exponentWord) ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb)]
+                  exact hFull) hpc
+            refine ⟨kk, hkk, s', hstep', hpc', ?_⟩
+            rw [sepConj_left_comm' R ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) Rframe] at hH
+            exact holdsFor_sepConj_elim_right hH
+          · -- block 1 → 2
+            have hbk : (255 - k) / 64 = 2 := by omega
+            have hc64 : ((0 : Word) + signExtend12 (64 : BitVec 12)) = (64 : Word) := by decide
+            have hControlNext :
+                expTwoMulFixedControlInvariant exponentWord (255 - k)
+                  ((0 : Word) + signExtend12 (64 : BitVec 12))
+                  (ptr + signExtend12 (-8 : BitVec 12))
+                  (exponentWord.getLimbN (2 - (255 - k) / 64)) evmSp := by
+              rw [hc64]
+              have h := expTwoMulFixedControlInvariant_succ_reload hControl hC6
+                (nextNextLimb := exponentWord.getLimbN (2 - (255 - k) / 64))
+                (by rw [show (255 - (k + 1)) + 1 = 255 - k from by omega])
+              rwa [show (255 - (k + 1)) + 1 = 255 - k from by omega] at h
+            rw [hb1] at hFps
+            have hEmpB : (expTwoMulFixedExpResidual 1 ptr lookahead exponentWord ** empAssertion) psF := by
+              rw [sepConj_emp_right']; exact hFps
+            have hInput :
+                (expTwoMulFixedIterReloadSkipCountPost iterCount e c6 ptr nextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+                    (expTwoMulIterCountNew iterCount ≠ 0) **
+                 (expTwoMulFixedExpResidual 1 ptr lookahead exponentWord ** empAssertion)) psMF :=
+              ⟨psM, psF, hdMF, huMF, hRS, hEmpB⟩
+            obtain ⟨v7', v10', v11', d0', d1', d2', d3', hOut⟩ :=
+              expTwoMulFixedIterReloadSkipCountPost_residual_repartition_one hInput
+            simp only [sepConj_emp_right'] at hOut
+            have hFull : ((_ : Assertion) ** Rframe).holdsFor s :=
+              ⟨hp, hcompat, psMF, psR, hdisj, hunion, hOut, hRps⟩
+            obtain ⟨kk, hkk, s', hstep', hpc', hH⟩ :=
+              IH hn' nextLimb ((0 : Word) + signExtend12 (64 : BitVec 12))
+                (expTwoMulIterCountNew iterCount) v10'
+                ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+                (ptr + signExtend12 (-8 : BitVec 12)) (exponentWord.getLimbN 0)
+                ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3) (((base + 44) + 32) + 68)
+                ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0) ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1)
+                ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2) ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+                d0' d1' d2' d3'
+                ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0) ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1)
+                ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2) ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+                v7' v11' hcountNew hControlNext
+                (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) ** Rframe)
+                (pcFree_sepConj pcFree_memIs hRframe) s hcr
+                (by
+                  rw [hbk, ← sepConj_assoc' _ ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) Rframe,
+                    sepConj_assoc' _ (expTwoMulFixedExpResidual 2 (ptr + signExtend12 (-8 : BitVec 12)) lookahead exponentWord) ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb),
+                    sepConj_comm' (expTwoMulFixedExpResidual 2 (ptr + signExtend12 (-8 : BitVec 12)) lookahead exponentWord) ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb)]
+                  exact hFull) hpc
+            refine ⟨kk, hkk, s', hstep', hpc', ?_⟩
+            rw [sepConj_left_comm' R ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) Rframe] at hH
+            exact holdsFor_sepConj_elim_right hH
+          · -- block 2 → 3
+            have hbk : (255 - k) / 64 = 3 := by omega
+            have hc64 : ((0 : Word) + signExtend12 (64 : BitVec 12)) = (64 : Word) := by decide
+            have hControlNext :
+                expTwoMulFixedControlInvariant exponentWord (255 - k)
+                  ((0 : Word) + signExtend12 (64 : BitVec 12))
+                  (ptr + signExtend12 (-8 : BitVec 12))
+                  (exponentWord.getLimbN (2 - (255 - k) / 64)) evmSp := by
+              rw [hc64]
+              have h := expTwoMulFixedControlInvariant_succ_reload hControl hC6
+                (nextNextLimb := exponentWord.getLimbN (2 - (255 - k) / 64))
+                (by rw [show (255 - (k + 1)) + 1 = 255 - k from by omega])
+              rwa [show (255 - (k + 1)) + 1 = 255 - k from by omega] at h
+            rw [hb2] at hFps
+            have hEmpB : (expTwoMulFixedExpResidual 2 ptr lookahead exponentWord ** empAssertion) psF := by
+              rw [sepConj_emp_right']; exact hFps
+            have hInput :
+                (expTwoMulFixedIterReloadSkipCountPost iterCount e c6 ptr nextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+                    (expTwoMulIterCountNew iterCount ≠ 0) **
+                 (expTwoMulFixedExpResidual 2 ptr lookahead exponentWord ** empAssertion)) psMF :=
+              ⟨psM, psF, hdMF, huMF, hRS, hEmpB⟩
+            obtain ⟨v7', v10', v11', d0', d1', d2', d3', hOut⟩ :=
+              expTwoMulFixedIterReloadSkipCountPost_residual_repartition_two hInput
+            simp only [sepConj_emp_right'] at hOut
+            have hFull : ((_ : Assertion) ** Rframe).holdsFor s :=
+              ⟨hp, hcompat, psMF, psR, hdisj, hunion, hOut, hRps⟩
+            obtain ⟨kk, hkk, s', hstep', hpc', hH⟩ :=
+              IH hn' nextLimb ((0 : Word) + signExtend12 (64 : BitVec 12))
+                (expTwoMulIterCountNew iterCount) v10'
+                ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+                (ptr + signExtend12 (-8 : BitVec 12)) lookahead
+                ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3) (((base + 44) + 32) + 68)
+                ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0) ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1)
+                ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2) ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+                d0' d1' d2' d3'
+                ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0) ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1)
+                ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2) ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3)
+                v7' v11' hcountNew hControlNext
+                (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) ** Rframe)
+                (pcFree_sepConj pcFree_memIs hRframe) s hcr
+                (by
+                  rw [hbk, ← sepConj_assoc' _ ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) Rframe,
+                    sepConj_assoc' _ (expTwoMulFixedExpResidual 3 (ptr + signExtend12 (-8 : BitVec 12)) lookahead exponentWord) ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb),
+                    sepConj_comm' (expTwoMulFixedExpResidual 3 (ptr + signExtend12 (-8 : BitVec 12)) lookahead exponentWord) ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb)]
+                  exact hFull) hpc
+            refine ⟨kk, hkk, s', hstep', hpc', ?_⟩
+            rw [sepConj_left_comm' R ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) Rframe] at hH
+            exact holdsFor_sepConj_elim_right hH
+    exact
+      exp_fixed_loop_body_succ_step_framed
+        (k + 1)
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+        base R (expTwoMulFixedExpResidual ((255 - (k + 1)) / 64) ptr lookahead exponentWord)
+        hbase expTwoMulFixedExpResidual_pcFree
+        hExit hLoop
 
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
Continues the EXP work after #9495 (executable bug fix) and #9498 (induction infrastructure), both merged.

This PR lands the **atomic crux**: `exp_merged_loop_from_iterpre_residual_induction` — the full residual-threaded merged fixed-loop body induction, with **all 8 loop-back cases proven** (zero/base + 2 non-reload within-block + 6 reload sub-cases over blocks 0/1/2). The exponent residual `ExpResidual` (counts 3/2/1/0 by block) is threaded through the loop; the control invariant `c6 = 64 - k%64` is carried as a pure side condition to bound reloads to `b < 3` (so the proven reload re-partitions apply); the stale pointer cell routes to the ambient frame at each reload.

Also includes the remaining ingredient bricks from after #9498:
- `7aa40046c` — the 2 non-reload (within-block) residual re-partitions
- `a07cf7c9d` — the `b<3` reload block-bound arithmetic
- `9bdbb1b02` / `c073c2e84` — the residual-induction scaffold and the completed 8-case induction

`lake build EvmAsm.Evm64.Exp` green (1111 jobs); no `sorry`/`native_decide`/`bv_decide`; zero warnings; no orphan imports.

This is the hardest, longest-blocking piece. The remaining composition to `evm_exp_stack_spec_within` (hExitU discharge via the proven exit-bridge disjuncts, n=255 instantiation, entry surgery, boundary `:1054` + the proven semantic bridge) is a follow-up — all its ingredients are already proven.

Directed by @pirapira; implemented by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)