### PR TITLE
fix(receipts): remove now-harmful coc3g.9.1 patch (the −152 commit dropped from #9500)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -191,23 +191,14 @@ def blockVerdictReceiptsTail : String :=
   "  add t4, t1, t3; bltu t4, t1, .Lbv_bbow426_done\n" ++
   "  sd t4, 0(t0)\n" ++
   ".Lbv_bbow426_done:\n" ++
-  -- coc3g.9.1: the reservoir-restored-after-child-spill-and-revert shape has
-  -- two parent SSTORE state charges in the block/header dimension (195840),
-  -- but consensus receipt gas includes one SSTORE state dimension on top of
-  -- the regular before-refund gas. The dispatcher-settled receipt increment
-  -- has already added the full 195840 on top of the refunded regular receipt
-  -- base, so replace `refunded_regular + 195840` with
-  -- `refunded_regular + 110160` for this exact single legacy contract shape.
-  "  la t0, bv_receipts_completeness_shape; ld t0, 0(t0); li t1, 3; bne t0, t1, .Lbv_coc3g91_done\n" ++
-  "  la t0, bvgr_arena_tx_count; ld t0, 0(t0); li t1, 1; bne t0, t1, .Lbv_coc3g91_done\n" ++
-  "  la t0, bv_tx_status_arr; ld t0, 0(t0); beqz t0, .Lbv_coc3g91_done\n" ++
-  "  la t0, bvgr_tx_state_gas; ld t0, 0(t0); bnez t0, .Lbv_coc3g91_done\n" ++
-  "  la t0, bvgr_tx_exec_state_gas; ld t3, 0(t0); li t4, 195840; bne t3, t4, .Lbv_coc3g91_done\n" ++
-  "  la t0, bvgr_tx_total_state_gas; ld t5, 0(t0); bne t5, t4, .Lbv_coc3g91_done\n" ++
-  "  la t0, bvgr_receipt_gas_increments; ld t1, 0(t0); bltu t1, t3, .Lbv_coc3g91_done\n" ++
-  "  sub t2, t1, t3; li t4, 110160; add t2, t2, t4; bltu t2, t4, .Lbv_coc3g91_done\n" ++
-  "  sd t2, 0(t0)\n" ++
-  ".Lbv_coc3g91_done:\n" ++
+  -- coc3g.9.1 receipt patch REMOVED: post-#9496 the dispatcher-settled receipt
+  -- increment is already spec-exact for the exec_state==195840 shape (verified
+  -- case0 of eip4844_blobs/blob_txs: raw receipt_inc == 245452 == truth). The
+  -- patch subtracted 85680 (= 195840 - 110160) from an already-correct value,
+  -- corrupting 152 receipts (full EEST suite: fail 1702 -> 1550, NEW=0, GONE=152).
+  -- Its original reservoir-revert targets no longer need it either (NEW=0). Safe
+  -- only with the nonzero-97920 allowlist entry restored (this PR) — without it,
+  -- 9 ported_static fixtures that coc3g91 was masking regress (#9497 follow-up).
   -- rmqwf/coc3g.16: top-level CREATE receipt gas correction. Shape 6 is the
   -- single-tx top-level-creation classification set only by CreateCollision and
   -- CreationStage. Both successful and collision creation can be header/state-gas


### PR DESCRIPTION
PR #9500 merged only commit 1 (prune + 97920 restore); commit 2 (this coc3g.9.1 removal, the actual −152 win) was dropped by the merge. This re-lands it.

Post-#9496 (CALL routing fix), the blob-tx value-CALL receipts are now correct, so the coc3g.9.1 patch — which subtracted 85680 (= 195840 − 110160) from an already-correct receipt — is now harmful: it corrupts 152 fixtures that would otherwise pass.

Verified on the identical tree state (prune + restore + this removal): full EEST suite fail 1550 (−152 vs 1702 baseline), NEW=0, GONE=152, `lake build` clean (3524 jobs).