### PR TITLE
perf(codegen): single-pass cursor-walk RLP decode for header decoders

### DIFF
--- a/EvmAsm/Codegen/Programs/HeaderDecode.lean
+++ b/EvmAsm/Codegen/Programs/HeaderDecode.lean
@@ -16,6 +16,7 @@
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.RlpWalk
 import EvmAsm.Codegen.Programs.Tx
 
 namespace EvmAsm.Codegen
@@ -37,71 +38,89 @@ open EvmAsm.Rv64.Program
     This decoder reads only the first 12 fields' indices, so
     it works on any post-Berlin header.
 
-    Calling convention:
-      a0 (input)  : header_rlp ptr
-      a1 (input)  : header_rlp byte length
-      a2 (input)  : 96-byte output struct ptr
-      ra (input)  : return
-      a0 (output) : 0 success / 1 parse fail (not an RLP list,
-                    parent_hash or state_root not 32 bytes,
-                    or timestamp > 8 bytes BE).
+     Calling convention:
+       a0 (input)  : header_rlp ptr
+       a1 (input)  : header_rlp byte length
+       a2 (input)  : 96-byte output struct ptr
+       ra (input)  : return
+       a0 (output) : 0 success / 1 parse fail (not an RLP list,
+                     parent_hash or state_root not 32 bytes,
+                     or timestamp > 8 bytes BE).
 
-    Composes PR-K20 `rlp_list_nth_item` + PR-K34
-    `rlp_field_to_u64`. The hash fields are copied via 4 ×
-    8-byte `ld`/`sd` (each 32-byte hash). -/
+     Composes the cursor walker (`rlp_walk_init` +
+     `rlp_walk_next` + `rlp_content_to_u64`). The four wanted
+     fields live at indices {0,3,8,11}; the walker visits the
+     first 12 items once (single O(N) pass), capturing the four
+     wanted fields and skipping the eight in between. The hash
+     fields are copied via 4 x 8-byte `ld`/`sd`. -/
 def headerMinimalDecodeFunction : String :=
   "header_minimal_decode:\n" ++
-  "  addi sp, sp, -32\n" ++
+  "  addi sp, sp, -64\n" ++
   "  sd ra,  0(sp)\n" ++
-  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
-  "  mv s0, a0                  # header_rlp ptr\n" ++
-  "  mv s1, a1                  # header_len\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  mv s0, a0                  # header_rlp ptr (base)\n" ++
   "  mv s2, a2                  # struct out\n" ++
-  "  # Field 0: parent_hash (32 bytes)\n" ++
-  "  mv a0, s0; mv a1, s1; li a2, 0\n" ++
-  "  la a3, hmd_offset; la a4, hmd_length\n" ++
-  "  jal ra, rlp_list_nth_item\n" ++
-  "  bnez a0, .Lhmd_fail\n" ++
-  "  la t0, hmd_length; ld t1, 0(t0)\n" ++
-  "  li t2, 32\n" ++
-  "  bne t1, t2, .Lhmd_fail\n" ++
-  "  la t0, hmd_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  jal ra, rlp_walk_init      # a0=ptr,a1=len -> cursor,end,status\n" ++
+  "  bnez a2, .Lhmd_fail\n" ++
+  "  mv s1, a1                  # end\n" ++
+  "  mv s3, a0                  # cursor\n" ++
+  "  # field 0: parent_hash (32 bytes @ struct+0)\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhmd_fail\n" ++
+  "  li t0, 32; bne a2, t0, .Lhmd_fail\n" ++
+  "  sub t3, a0, a2             # content_ptr = advanced - len\n" ++
   "  ld t4,  0(t3); sd t4,  0(s2)\n" ++
   "  ld t4,  8(t3); sd t4,  8(s2)\n" ++
   "  ld t4, 16(t3); sd t4, 16(s2)\n" ++
   "  ld t4, 24(t3); sd t4, 24(s2)\n" ++
-  "  # Field 3: state_root (32 bytes at struct + 32)\n" ++
-  "  mv a0, s0; mv a1, s1; li a2, 3\n" ++
-  "  la a3, hmd_offset; la a4, hmd_length\n" ++
-  "  jal ra, rlp_list_nth_item\n" ++
-  "  bnez a0, .Lhmd_fail\n" ++
-  "  la t0, hmd_length; ld t1, 0(t0)\n" ++
-  "  li t2, 32\n" ++
-  "  bne t1, t2, .Lhmd_fail\n" ++
-  "  la t0, hmd_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
-  "  addi t4, s2, 32\n" ++
-  "  ld t5,  0(t3); sd t5,  0(t4)\n" ++
-  "  ld t5,  8(t3); sd t5,  8(t4)\n" ++
-  "  ld t5, 16(t3); sd t5, 16(t4)\n" ++
-  "  ld t5, 24(t3); sd t5, 24(t4)\n" ++
-  "  # Field 8: number (u64 at struct + 64)\n" ++
-  "  mv a0, s0; mv a1, s1; li a2, 8\n" ++
-  "  addi a3, s2, 64\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
-  "  bnez a0, .Lhmd_fail\n" ++
-  "  # Field 11: timestamp (u64 at struct + 72)\n" ++
-  "  mv a0, s0; mv a1, s1; li a2, 11\n" ++
-  "  addi a3, s2, 72\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
-  "  bnez a0, .Lhmd_fail\n" ++
+  "  # fields 1..2: skip (ommers_hash, beneficiary)\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhmd_fail\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhmd_fail\n" ++
+  "  # field 3: state_root (32 bytes @ struct+32)\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhmd_fail\n" ++
+  "  li t0, 32; bne a2, t0, .Lhmd_fail\n" ++
+  "  sub t3, a0, a2\n" ++
+  "  ld t4,  0(t3); sd t4, 32(s2)\n" ++
+  "  ld t4,  8(t3); sd t4, 40(s2)\n" ++
+  "  ld t4, 16(t3); sd t4, 48(s2)\n" ++
+  "  ld t4, 24(t3); sd t4, 56(s2)\n" ++
+  "  # fields 4..7: skip (state_root already read; roots/gas/etc)\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhmd_fail\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhmd_fail\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhmd_fail\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhmd_fail\n" ++
+  "  # field 8: number (u64 @ struct+64)\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhmd_fail\n" ++
+  "  sub a0, a0, a2; mv a1, a2; jal ra, rlp_content_to_u64\n" ++
+  "  bnez a1, .Lhmd_fail\n" ++
+  "  sd a0, 64(s2)\n" ++
+  "  # fields 9..10: skip (gas_limit, gas_used)\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhmd_fail\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhmd_fail\n" ++
+  "  # field 11: timestamp (u64 @ struct+72)\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhmd_fail\n" ++
+  "  sub a0, a0, a2; mv a1, a2; jal ra, rlp_content_to_u64\n" ++
+  "  bnez a1, .Lhmd_fail\n" ++
+  "  sd a0, 72(s2)\n" ++
   "  li a0, 0\n" ++
   "  j .Lhmd_ret\n" ++
   ".Lhmd_fail:\n" ++
   "  li a0, 1\n" ++
   ".Lhmd_ret:\n" ++
   "  ld ra,  0(sp)\n" ++
-  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
-  "  addi sp, sp, 32\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
   "  ret"
 
 /-- `zisk_header_minimal_decode`: probe BuildUnit. Reads
@@ -126,23 +145,13 @@ def ziskHeaderMinimalDecodePrologue : String :=
   "  li t0, 0xa0010000\n" ++
   "  sd a0, 0(t0)\n" ++
   "  j .Lhmd_pdone\n" ++
-  rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpWalkInitFunction ++ "\n" ++
+  rlpWalkNextFunction ++ "\n" ++
+  rlpContentToU64Function ++ "\n" ++
   headerMinimalDecodeFunction ++ "\n" ++
   ".Lhmd_pdone:"
 
-def ziskHeaderMinimalDecodeDataSection : String :=
-  ".section .data\n" ++
-  ".balign 8\n" ++
-  "rfu_offset:\n" ++
-  "  .zero 8\n" ++
-  "rfu_length:\n" ++
-  "  .zero 8\n" ++
-  ".balign 8\n" ++
-  "hmd_offset:\n" ++
-  "  .zero 8\n" ++
-  "hmd_length:\n" ++
-  "  .zero 8"
+def ziskHeaderMinimalDecodeDataSection : String := ""
 
 def ziskHeaderMinimalDecodeProbeUnit : BuildUnit := {
   body        := NOP
@@ -177,82 +186,107 @@ def ziskHeaderMinimalDecodeProbeUnit : BuildUnit := {
       a0 (output) : 0 success / 1 parse fail. -/
 def headerExtendedDecodeFunction : String :=
   "header_extended_decode:\n" ++
-  "  addi sp, sp, -32\n" ++
+  "  addi sp, sp, -64\n" ++
   "  sd ra,  0(sp)\n" ++
-  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
-  "  mv s0, a0                  # header_rlp ptr\n" ++
-  "  mv s1, a1                  # header_len\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  mv s0, a0                  # header_rlp ptr (base)\n" ++
   "  mv s2, a2                  # struct out\n" ++
-  "  # Field 0: parent_hash\n" ++
-  "  mv a0, s0; mv a1, s1; li a2, 0\n" ++
-  "  la a3, hmd_offset; la a4, hmd_length\n" ++
-  "  jal ra, rlp_list_nth_item\n" ++
-  "  bnez a0, .Lhed_fail\n" ++
-  "  la t0, hmd_length; ld t1, 0(t0)\n" ++
-  "  li t2, 32\n" ++
-  "  bne t1, t2, .Lhed_fail\n" ++
-  "  la t0, hmd_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  jal ra, rlp_walk_init      # a0=ptr,a1=len -> cursor,end,status\n" ++
+  "  bnez a2, .Lhed_fail\n" ++
+  "  mv s1, a1                  # end\n" ++
+  "  mv s3, a0                  # cursor\n" ++
+  "  # field 0: parent_hash (32 bytes @ struct+0)\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhed_fail\n" ++
+  "  li t0, 32; bne a2, t0, .Lhed_fail\n" ++
+  "  sub t3, a0, a2\n" ++
   "  ld t4,  0(t3); sd t4,  0(s2)\n" ++
   "  ld t4,  8(t3); sd t4,  8(s2)\n" ++
   "  ld t4, 16(t3); sd t4, 16(s2)\n" ++
   "  ld t4, 24(t3); sd t4, 24(s2)\n" ++
-  "  # Field 3: state_root\n" ++
-  "  mv a0, s0; mv a1, s1; li a2, 3\n" ++
-  "  la a3, hmd_offset; la a4, hmd_length\n" ++
-  "  jal ra, rlp_list_nth_item\n" ++
+  "  # fields 1..2: skip\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhed_fail\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhed_fail\n" ++
+  "  # field 3: state_root (32 bytes @ struct+32)\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhed_fail\n" ++
+  "  li t0, 32; bne a2, t0, .Lhed_fail\n" ++
+  "  sub t3, a0, a2\n" ++
+  "  ld t4,  0(t3); sd t4, 32(s2)\n" ++
+  "  ld t4,  8(t3); sd t4, 40(s2)\n" ++
+  "  ld t4, 16(t3); sd t4, 48(s2)\n" ++
+  "  ld t4, 24(t3); sd t4, 56(s2)\n" ++
+  "  # fields 4..7: skip\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhed_fail\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhed_fail\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhed_fail\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhed_fail\n" ++
+  "  # field 8: number (u64 @ struct+64)\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhed_fail\n" ++
+  "  sub a0, a0, a2; mv a1, a2; jal ra, rlp_content_to_u64\n" ++
+  "  bnez a1, .Lhed_fail\n" ++
+  "  sd a0, 64(s2)\n" ++
+  "  # field 9: gas_limit (u64 @ struct+80)\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhed_fail\n" ++
+  "  sub a0, a0, a2; mv a1, a2; jal ra, rlp_content_to_u64\n" ++
+  "  bnez a1, .Lhed_fail\n" ++
+  "  sd a0, 80(s2)\n" ++
+  "  # field 10: gas_used (u64 @ struct+88)\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhed_fail\n" ++
+  "  sub a0, a0, a2; mv a1, a2; jal ra, rlp_content_to_u64\n" ++
+  "  bnez a1, .Lhed_fail\n" ++
+  "  sd a0, 88(s2)\n" ++
+  "  # field 11: timestamp (u64 @ struct+72)\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhed_fail\n" ++
+  "  sub a0, a0, a2; mv a1, a2; jal ra, rlp_content_to_u64\n" ++
+  "  bnez a1, .Lhed_fail\n" ++
+  "  sd a0, 72(s2)\n" ++
+  "  # fields 12..14: skip\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhed_fail\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhed_fail\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhed_fail\n" ++
+  "  # field 15: base_fee_per_gas (u256 @ struct+96)\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhed_fail\n" ++
+  "  sub a0, a0, a2; mv a1, a2; addi a2, s2, 96\n" ++
+  "  jal ra, rlp_content_to_u256_be\n" ++
   "  bnez a0, .Lhed_fail\n" ++
-  "  la t0, hmd_length; ld t1, 0(t0)\n" ++
-  "  li t2, 32\n" ++
-  "  bne t1, t2, .Lhed_fail\n" ++
-  "  la t0, hmd_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
-  "  addi t4, s2, 32\n" ++
-  "  ld t5,  0(t3); sd t5,  0(t4)\n" ++
-  "  ld t5,  8(t3); sd t5,  8(t4)\n" ++
-  "  ld t5, 16(t3); sd t5, 16(t4)\n" ++
-  "  ld t5, 24(t3); sd t5, 24(t4)\n" ++
-  "  # Field 8: number\n" ++
-  "  mv a0, s0; mv a1, s1; li a2, 8\n" ++
-  "  addi a3, s2, 64\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
-  "  bnez a0, .Lhed_fail\n" ++
-  "  # Field 11: timestamp\n" ++
-  "  mv a0, s0; mv a1, s1; li a2, 11\n" ++
-  "  addi a3, s2, 72\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
-  "  bnez a0, .Lhed_fail\n" ++
-  "  # Field 9: gas_limit\n" ++
-  "  mv a0, s0; mv a1, s1; li a2, 9\n" ++
-  "  addi a3, s2, 80\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
-  "  bnez a0, .Lhed_fail\n" ++
-  "  # Field 10: gas_used\n" ++
-  "  mv a0, s0; mv a1, s1; li a2, 10\n" ++
-  "  addi a3, s2, 88\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
-  "  bnez a0, .Lhed_fail\n" ++
-  "  # Field 15: base_fee_per_gas (u256)\n" ++
-  "  mv a0, s0; mv a1, s1; li a2, 15\n" ++
-  "  addi a3, s2, 96\n" ++
-  "  jal ra, rlp_field_to_u256_be\n" ++
-  "  bnez a0, .Lhed_fail\n" ++
-  "  # Field 17: blob_gas_used\n" ++
-  "  mv a0, s0; mv a1, s1; li a2, 17\n" ++
-  "  addi a3, s2, 128\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
-  "  bnez a0, .Lhed_fail\n" ++
-  "  # Field 18: excess_blob_gas\n" ++
-  "  mv a0, s0; mv a1, s1; li a2, 18\n" ++
-  "  addi a3, s2, 136\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
-  "  bnez a0, .Lhed_fail\n" ++
+  "  # field 16: skip\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhed_fail\n" ++
+  "  # field 17: blob_gas_used (u64 @ struct+128)\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhed_fail\n" ++
+  "  sub a0, a0, a2; mv a1, a2; jal ra, rlp_content_to_u64\n" ++
+  "  bnez a1, .Lhed_fail\n" ++
+  "  sd a0, 128(s2)\n" ++
+  "  # field 18: excess_blob_gas (u64 @ struct+136)\n" ++
+  "  mv a0, s3; mv a1, s1; jal ra, rlp_walk_next\n" ++
+  "  mv s3, a0; bnez a1, .Lhed_fail\n" ++
+  "  sub a0, a0, a2; mv a1, a2; jal ra, rlp_content_to_u64\n" ++
+  "  bnez a1, .Lhed_fail\n" ++
+  "  sd a0, 136(s2)\n" ++
   "  li a0, 0\n" ++
   "  j .Lhed_ret\n" ++
   ".Lhed_fail:\n" ++
   "  li a0, 1\n" ++
   ".Lhed_ret:\n" ++
   "  ld ra,  0(sp)\n" ++
-  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
-  "  addi sp, sp, 32\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
   "  ret"
 
 /-- `zisk_header_extended_decode`: probe BuildUnit. -/
@@ -275,24 +309,14 @@ def ziskHeaderExtendedDecodePrologue : String :=
   "  li t0, 0xa0010000\n" ++
   "  sd a0, 0(t0)\n" ++
   "  j .Lhed_pdone\n" ++
-  rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
-  rlpFieldToU256BeFunction ++ "\n" ++
+  rlpWalkInitFunction ++ "\n" ++
+  rlpWalkNextFunction ++ "\n" ++
+  rlpContentToU64Function ++ "\n" ++
+  rlpContentToU256BeFunction ++ "\n" ++
   headerExtendedDecodeFunction ++ "\n" ++
   ".Lhed_pdone:"
 
-def ziskHeaderExtendedDecodeDataSection : String :=
-  ".section .data\n" ++
-  ".balign 8\n" ++
-  "rfu_offset:\n" ++
-  "  .zero 8\n" ++
-  "rfu_length:\n" ++
-  "  .zero 8\n" ++
-  ".balign 8\n" ++
-  "hmd_offset:\n" ++
-  "  .zero 8\n" ++
-  "hmd_length:\n" ++
-  "  .zero 8"
+def ziskHeaderExtendedDecodeDataSection : String := ""
 
 def ziskHeaderExtendedDecodeProbeUnit : BuildUnit := {
   body        := NOP


### PR DESCRIPTION
## Summary

Phase 2 of the RLP cursor-walk optimization (follow-on to #9503). Applies the `RlpWalk` cursor primitives to the two multi-field **header** decoders, replacing the O(N²) index-based re-walks with a single O(N) forward pass.

The header decoders are **random-access** (unlike the purely sequential tx decoders), so this introduces the **cursor-walk-then-discard** pattern: walk every item `0..max_index` in list order, capture the wanted indices, skip the rest.

| Decoder | Fields | Before | After |
|---|---|---|---|
| `header_minimal_decode` (K38) | {0,3,8,11} | 22 walks | 12 |
| `header_extended_decode` (K39) | {0,3,8,9,10,11,15,17,18} | 91 walks | 19 |

## Changes

- `HeaderDecode.lean`: both decoders rewritten onto `rlp_walk_init` + `rlp_walk_next` + `rlp_content_to_u64` (+ `rlp_content_to_u256_be` for the base_fee field). Probe prologue concatenations swapped; probe data sections now empty (the walker is frameless).
- `coinbase_extract_from_header` (K55) is a single-field caller — **left untouched**.

## Verification

Codegen-only (no Lean proofs — matches prior status quo):
- `lake build` green.
- `scripts/codegen-zisk-header-minimal-decode-check.sh` → PASS (all synthetic cases).
- `scripts/codegen-zisk-header-extended-decode-check.sh` → PASS (Amsterdam header cases).
- `check-unimported.sh`: 0 orphans. `check-file-size.sh`: within cap.

## Notes

Stacked on #9503 (depends on `RlpWalk.lean`). Retarget to `main` once #9503 lands.