### PR TITLE
feat(spike): env-gated per-instruction commit log for EVM debugging

### DIFF
--- a/scripts/spike/README.md
+++ b/scripts/spike/README.md
@@ -60,6 +60,32 @@ Run one block: `scripts/spike/spike_run <guest.elf> <input> <output>`
 EEST backend: `EEST_BACKEND=spike scripts/codegen-eest-stateless-check.sh --limit 1000 --jobs 4 --max-jobs 4`
 Parity gate: `scripts/spike/parity-check.sh 8 1`
 
+## Debugging: per-instruction commit log
+
+`spike_run` supports an env-gated commit log for EVM-faithfulness / gas-model
+debugging. Set `SPIKE_COMMITLOG=<file>` and spike writes its standard per-instruction
+trace (RV64 `pc`, instruction word, register and memory writes) to that file.
+Unset, behavior is byte-identical to before (zero impact on parity/CI runs).
+
+```bash
+SPIKE_COMMITLOG=/tmp/cl.log scripts/spike/spike_run <guest.elf> <input> /tmp/out
+```
+
+The guest\'s EVM-bytecode interpreter has a single dispatch loop; its opcode
+fetch is the `lbu t0, 0(a0)` at the `.dispatch_loop` label (a0/x10 = EVM PC,
+t0/x5 = opcode byte). To extract the executed EVM bytecodes from the log, find
+that fetch instruction\'s address (e.g. via `riscv64-unknown-elf-objdump -d
+<guest.elf> | grep -A2 .dispatch_loop`) and filter:
+
+```bash
+rg "<fetch-addr> \(0x00054283\)" /tmp/cl.log \
+  | rg -o 'x5\s+0x([0-9a-f]+)\s+mem\s+0x([0-9a-f]+)' -r '$1 $2'
+# column 1 = opcode/operand byte, column 2 = EVM PC (memory address)
+```
+
+This gives the executed-EVM-byte sequence (count includes PUSH operand bytes),
+useful for diffing guest vs execution-specs per-opcode traces (`ethereum.trace`).
+
 ## The guest's runtime contract (see ../../../.claude/plans for full map)
 - Memory: header `0x7ffff000`, `.text 0x80000000`, `.data 0xa3000000`,
   `.sszscratch 0xbf500000`, input `0x40000000`, output `0xa0010000`.

--- a/scripts/spike/spike_run.cc
+++ b/scripts/spike/spike_run.cc
@@ -63,8 +63,12 @@ int main(int argc, char** argv) {
   for (auto& m : cfg.mem_layout) mems.push_back({m.get_base(), new mem_t(m.get_size())});
 
   std::vector<std::string> args = { argv[1] };
+  // Env-gated commit log: set SPIKE_COMMITLOG=<file> to get a per-instruction
+  // trace (pc, insn word, reg/mem writes) for EVM-faithfulness debugging.
+  const char* log_path = getenv("SPIKE_COMMITLOG");
   sim_t sim(&cfg, false, mems, {}, false, args, debug_module_config_t(),
-            nullptr, false, nullptr, false, nullptr, std::nullopt);
+            log_path, false, nullptr, false, nullptr, std::nullopt);
+  if (log_path) sim.configure_log(false, true);
   processor_t* p = sim.get_core(0);
   // register_extension() (called post-construction) does NOT invoke get_csrs(),
   // and the proc's init-time get_csrs sweep already ran, so add the accelerator


### PR DESCRIPTION
## What

Adds `SPIKE_COMMITLOG=<file>` env var to `scripts/spike/spike_run`. When set, enables spike's built-in per-instruction commit log (RV64 `pc`, instruction word, register and memory writes). When unset, behavior is **byte-identical to before** — no impact on parity checks, the EEST runner, or CI.

## Why

This is the debugging interface used to investigate EVM-faithfulness gaps (see #9505 / bead `coc3g.9.3.3`). The per-instruction RV64 trace lets you reconstruct the executed EVM-bytecode sequence and diff it against execution-specs per-opcode traces (`ethereum.trace`), which was the technique that pinned the create_preimage factory-loop truncation (guest executes 1 of 10 CREATEs).

It replaces ad-hoc in-guest instrumentation (repurposing verdict-prologue `.data` slots, throwaway counters) for many debugging tasks — the commit log requires no guest rebuild and captures the full execution unconditionally.

## How to use

```bash
SPIKE_COMMITLOG=/tmp/cl.log scripts/spike/spike_run <guest.elf> <input> /tmp/out
```

The guest's EVM interpreter has a single dispatch loop; its opcode fetch is `lbu t0, 0(a0)` at `.dispatch_loop` (a0/x10 = EVM PC, t0/x5 = opcode byte). README updated with the extraction recipe:

```bash
rg "<fetch-addr> (0x00054283)" /tmp/cl.log \
  | rg -o 'x5\s+0x([0-9a-f]+)\s+mem\s+0x([0-9a-f]+)' -r '$1 $2'
```

## Verification

- `scripts/spike/build.sh` rebuilds clean (with `SPIKE_SRC=/tmp/riscv-isa-sim`).
- Env-gate confirmed: with `SPIKE_COMMITLOG` unset, `spike_run` runs identically (no log file produced); with it set, a 5.1M-line commit log is produced for a real stateless-guest run.

## Files

- `scripts/spike/spike_run.cc` — read `SPIKE_COMMITLOG`, pass as `log_path` to `sim_t` ctor, call `sim.configure_log(false, true)` if set. ~4 lines.
- `scripts/spike/README.md` — new \"Debugging: per-instruction commit log\" section.

No guest / codegen / proof changes.