### PR TITLE
fix(mulmod): save x13 into x28, not x21 (code base)

### DIFF
--- a/EvmAsm/Codegen/Programs/EvmMulmodHandler.lean
+++ b/EvmAsm/Codegen/Programs/EvmMulmodHandler.lean
@@ -10,11 +10,19 @@ import EvmAsm.Evm64.MulMod.Program
 namespace EvmAsm.Codegen
 
 /-- MULMOD's verified body uses x10/x13/x20 internally, so the dispatcher
-    wrapper saves and restores those live runtime registers around it. -/
+    wrapper saves and restores those live runtime registers around it.
+
+    NB: x21 is the dispatcher's permanent code base (the dispatch loop reads
+    `sub x5, x10, x21` every iteration; s4/s5 = x20/x21 are env/code base and
+    must never be used as scratch). The earlier wrapper used x21 as the save
+    slot for x13, clobbering the code base so the codeSize guard ran on
+    garbage after MULMOD (bv_fail=37 on `vmArithmeticTest/mulmod`). Save x13
+    into x28 (t3) instead: it is neither dispatcher-live nor touched by
+    `evm_mulmod` (whose body is straight-line, no nested calls). -/
 private def mulmodTail : HandlerTail :=
   .custom <|
     "  mv x10, x23\n" ++
-    "  mv x13, x21\n" ++
+    "  mv x13, x28\n" ++
     "  mv x20, x22\n" ++
     "  addi x10, x10, 1\n" ++
     "  ret"
@@ -22,7 +30,7 @@ private def mulmodTail : HandlerTail :=
 def mulmodHandlers : List OpcodeHandlerSpec :=
   [ { label   := "h_MULMOD"
       opcodes := [0x09]
-      preBody := stackUnderflowGuardAsm 3 ++ "\n  mv x23, x10\n  mv x21, x13\n  mv x22, x20"
+      preBody := stackUnderflowGuardAsm 3 ++ "\n  mv x23, x10\n  mv x28, x13\n  mv x22, x20"
       body    := EvmAsm.Evm64.evm_mulmod
       tail    := mulmodTail } ]
 


### PR DESCRIPTION
## Summary

The MULMOD dispatcher wrapper (`EvmMulmodHandler.lean`) saved/restored the live runtime register `x13` into **`x21`**. But `x21` (s5) is the dispatcher's permanent **code base** — the dispatch loop reads `sub x5, x10, x21` (PC − codebase) every iteration, and `s4/s5 = x20/x21` is explicitly documented as *"env/code base — never use as scratch"*. The wrapper never restored the real code base, so after every MULMOD the `codeSize` guard ran on a corrupted base (`x21` held `x13`'s value), diverging execution → `bv_fail=37` (BAL all-accounts storage mismatch) on `vmArithmeticTest/mulmod` and beyond.

## Fix

Save `x13` into **`x28`** (t3) instead: it is neither dispatcher-live nor touched by `evm_mulmod` (whose body is straight-line with no nested calls). Mirrors the ADDMOD wrapper's isolation discipline (ADDMOD redirects `x12` to scratch; EXP was fixed via the headroom-body approach in #9507).

## Verification

- `lake build` clean
- 4 sampled `vmArithmeticTest/mulmod` rows: `verdict=1 / bv_fail=0` (was `verdict=0 / bv_fail=37`)
- **Full EEST suite** (`zkevm@v0.4.0`, 23219 stateless fixtures, spike): **1285 → 1234 fail** (`GONE=53, NEW=2`)
  - The 2 NEW (`stRandom/random_statetest350`, `stRandom2/random_statetest536`) are random statetests that exercised MULMOD: previously the clobber produced a wrong receipt whose gas happened to be allowlisted (false pass); now MULMOD is correct and the genuine receipt gas (35976 / 36744) is not allowlisted, exposing pre-existing receipt-gas debt (`bv_fail=53`, same class as the other 1234 fails) — i.e. **unmasked false passes, not regressions caused by this change**.

This is the same bug class as the EXP stack-clobber fixed by #9507 (`evm-asm-fjivz`): a self-calling handler corrupting dispatcher-live state.