### PR TITLE
fix(rlp): make decodeWithdrawal strict (consensus-canonical scalar fields)

### DIFF
--- a/EvmAsm/EL/Withdrawal.lean
+++ b/EvmAsm/EL/Withdrawal.lean
@@ -36,11 +36,18 @@ structure Withdrawal where
 
 /-- Decode the full RLP encoding of an EIP-4895 withdrawal: a 4-element list whose elements are
     `[index, validator_index, address (20 bytes), amount]`. Returns `none` on any structural
-    deviation or trailing bytes. -/
+    deviation or trailing bytes.
+
+    **Strict** (consensus-canonical): the three scalar fields (`index`, `validator_index`,
+    `amount`) must be canonical minimal big-endian `uint64` encodings — no leading zero byte
+    (`d.headD 1 ≠ 0`, matching `decodeScalar` / execution-specs `_deserialize_to_uint`) and at
+    most 8 bytes (the value fits `u64`). A non-canonical scalar (e.g. `0x0005`, the bare `0x00`,
+    or a 9+-byte value) yields `none`. The address (element 2) must be exactly 20 bytes. -/
 def decodeWithdrawal (bs : List Byte) : Option Withdrawal :=
   match decodeFully bs with
   | some (.list [.bytes d0, .bytes d1, .bytes d2, .bytes d3]) =>
-      if d2.length = 20 then
+      if d0.headD 1 ≠ 0 ∧ d0.length ≤ 8 ∧ d1.headD 1 ≠ 0 ∧ d1.length ≤ 8
+         ∧ d2.length = 20 ∧ d3.headD 1 ≠ 0 ∧ d3.length ≤ 8 then
         some { index := Nat.fromBytesBE d0,
                validatorIndex := Nat.fromBytesBE d1,
                address := BitVec.ofNat 160 (Nat.fromBytesBE d2),
@@ -48,14 +55,19 @@ def decodeWithdrawal (bs : List Byte) : Option Withdrawal :=
       else none
   | _ => none
 
-/-- `decodeWithdrawal` succeeds exactly when the input fully decodes to a 4-element byte-list with a
-    20-byte address; in that case the fields are the big-endian scalars / raw address of the
-    elements. The defining unfolding, stated for the verified drop-in's coincidence proof. -/
+/-- `decodeWithdrawal` succeeds exactly when the input fully decodes to a 4-element byte-list whose
+    three scalar elements are canonical minimal big-endian `uint64`s (no leading zero, `≤ 8`
+    bytes) and whose address element is exactly 20 bytes; in that case the fields are the
+    big-endian scalars / raw address of the elements. The defining unfolding, stated for the
+    verified drop-in's coincidence proof. -/
 theorem decodeWithdrawal_eq_some_iff (bs : List Byte) (w : Withdrawal) :
     decodeWithdrawal bs = some w ↔
       ∃ d0 d1 d2 d3 : List Byte,
         decodeFully bs = some (.list [.bytes d0, .bytes d1, .bytes d2, .bytes d3])
+        ∧ d0.headD 1 ≠ 0 ∧ d0.length ≤ 8
+        ∧ d1.headD 1 ≠ 0 ∧ d1.length ≤ 8
         ∧ d2.length = 20
+        ∧ d3.headD 1 ≠ 0 ∧ d3.length ≤ 8
         ∧ w.index = Nat.fromBytesBE d0
         ∧ w.validatorIndex = Nat.fromBytesBE d1
         ∧ w.address = BitVec.ofNat 160 (Nat.fromBytesBE d2)
@@ -67,17 +79,18 @@ theorem decodeWithdrawal_eq_some_iff (bs : List Byte) (w : Withdrawal) :
     · -- the matching arm: `decodeFully bs = some (.list [4 bytes])`
       rename_i d0 d1 d2 d3 heq
       split at h
-      · rename_i h20
+      · rename_i hcond
+        obtain ⟨hc0, hl0, hc1, hl1, h20, hc3, hl3⟩ := hcond
         simp only [Option.some.injEq] at h
         subst h
-        exact ⟨d0, d1, d2, d3, heq, h20, rfl, rfl, rfl, rfl⟩
+        exact ⟨d0, d1, d2, d3, heq, hc0, hl0, hc1, hl1, h20, hc3, hl3, rfl, rfl, rfl, rfl⟩
       · simp at h
     · simp at h
-  · rintro ⟨d0, d1, d2, d3, hf, h20, hi, hv, ha, hamt⟩
+  · rintro ⟨d0, d1, d2, d3, hf, hc0, hl0, hc1, hl1, h20, hc3, hl3, hi, hv, ha, hamt⟩
     unfold decodeWithdrawal
     cases w
     subst hi hv ha hamt
     rw [hf]
-    simp [h20]
+    simp only [hc0, hl0, hc1, hl1, h20, hc3, hl3, ne_eq, not_false_eq_true, and_self, if_true]
 
 end EvmAsm.EL


### PR DESCRIPTION
## Make the pure `decodeWithdrawal` spec strict

`decodeWithdrawal` (`EvmAsm/EL/Withdrawal.lean`) — the pure decode spec that the upcoming
verified `withdrawal_decode` drop-in will be proved against — decoded the three scalar fields
(`index`, `validator_index`, `amount`) with bare `Nat.fromBytesBE`, so it **accepted
non-canonical encodings**: leading-zero scalars (`0x0005`), the bare non-canonical zero
`0x00`, and unbounded width (`> 8` bytes). That is a **specification bug** — Ethereum
consensus requires these fields to be canonical minimal big-endian `uint64`s, and a verified
decoder must be anchored on a spec that rejects exactly what the implementation rejects.

### Change
`decodeWithdrawal` now requires, for each scalar element `d`:
- **canonical minimal** big-endian: `d.headD 1 ≠ 0` (matches `decodeScalar` and
  execution-specs `_deserialize_to_uint`: `len > 0 ∧ d[0] = 0 ⇒` non-canonical), and
- **u64 width**: `d.length ≤ 8`.

This is exactly the acceptance set of the strict verified `rlp_content_to_u64`
(`EvmAsm/Rv64/RLP/ContentToU64.lean`), so the future coincidence proof lines up directly. The
address element is still required to be exactly 20 bytes. `decodeWithdrawal_eq_some_iff` is
restated with the added conditions and re-proven.

### Scope / safety
- `decodeWithdrawal` has **no current dependants** (a not-yet-consumed spec), so this is a
  self-contained spec fix with no downstream impact. Scalar fields kept as `Nat` (now
  guaranteed `< 2^64` by the width guard); minimal diff.
- `lake build EvmAsm.EL` clean, 0 `sorry`; `#print axioms decodeWithdrawal_eq_some_iff` =
  `propext` only.

Anchor for the follow-up: a verified, strict, **single-pass** walk-based `withdrawal_decode`
(replacing the current `rlp_list_nth_item`-per-field O(n²) rescan). Related: `rlp_field_to_u64`
has the same missing-canonicity gap (tracked in beads `evm-asm-vd5vr`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
