### PR TITLE
fix(gas): credit CREATE state gas on failure (coc3g.9.3.4)

### DIFF
--- a/EvmAsm/Codegen/Programs/CallFrameReturn.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameReturn.lean
@@ -113,6 +113,25 @@ def frameReturnFunction : String :=
   ".Lfr_sgas_restore_left:\n" ++
   "  la t1, evm_state_gas_left; sd t3, 0(t1)\n" ++
   "  ld t0, 632(x20); la t1, evm_state_gas_used; sd t0, 0(t1)\n" ++
+  -- coc3g.9.3.4: CREATE-specific state gas credit on child failure. The CREATE charge
+  -- (amsterdamStateBytesPerNewAccountV2 = 120*1530 = 183600) is refunded to
+  -- state_gas_left and subtracted from state_gas_used, matching execution-specs
+  -- credit_state_gas_refund(evm, create_account_state_gas). This MUST NOT touch
+  -- gas_left — the spec credits state_gas_left ONLY. frame_return's spill restore
+  -- (above) already excluded the CREATE charge from s7 because the snapshot holds
+  -- POST-charge values (used_delta excludes the CREATE charge), so gas_left is not
+  -- inflated. Check create_frame_flag[child_depth] (set by create_frame_descend).
+  "  la t0, evm_call_depth; ld t1, 0(t0)\n" ++
+  "  la t0, create_frame_flag; slli t1, t1, 3; add t0, t0, t1\n" ++
+  "  ld t0, 0(t0)\n" ++
+  "  beqz t0, .Lfr_create_credit_done\n" ++
+  "  la t0, evm_state_gas_left; ld t1, 0(t0)\n" ++
+  "  li t2, 183600\n" ++
+  "  add t1, t1, t2; sd t1, 0(t0)\n" ++
+  "  la t0, evm_state_gas_used; ld t1, 0(t0)\n" ++
+  "  bltu t1, t2, .Lfr_create_credit_done\n" ++
+  "  sub t1, t1, t2; sd t1, 0(t0)\n" ++
+  ".Lfr_create_credit_done:\n" ++
   -- nxio8.4.2: discard the reverted child's EIP-3529 refund additions by restoring
   -- evm_refund_acc to the pre-child snapshot (incorporate_child_on_error does not
   -- add child.refund_counter). Success leaves it (the SSTORE refunds stay).

--- a/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
@@ -356,16 +356,16 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     -- create_frame_descend so recursive constructors at depth 1024 push zero instead of
     -- attempting to enter a non-protocol child frame.
     "  la t1, evm_call_depth\n  ld t2, 0(t1)\n  li t3, 1024\n  bgeu t2, t3, 7f\n" ++
-    "  addi sp, sp, -16\n  sd t4, 0(sp)\n" ++
     "  li a1, " ++ toString netPopBytes ++ "\n" ++
     "  jal x1, create_frame_descend\n" ++
-    "  ld t4, 0(sp)\n  addi sp, sp, 16\n" ++
-    -- nxio8.8 refund-on-failure: the descent snapshotted state-gas POST-charge into child_env+624/632;
-    -- rewrite the snapshot to the PRE-charge reservoir/used values. On child error/revert,
-    -- frame_return restores those globals and restores any regular-gas spill to the parent;
-    -- on child success the snapshot is unused and the charge stands.
-    "  sd t4, 624(x20)\n" ++
-    "  ld t0, 632(x20)\n" ++ liStateGasRuntime "t1" amsterdamStateBytesPerNewAccountV2 ++ "  sub t0, t0, t1\n  sd t0, 632(x20)\n" ++   -- refund = same 120*1530
+    -- coc3g.9.3.4: the descent snapshotted state-gas POST-charge into child_env+624/632.
+    -- We do NOT rewrite the snapshot to PRE-charge values. Previously the rewrite made
+    -- frame_return compute used_delta = full CREATE charge (183600), inflating s7 (child
+    -- leftover gas) by 183600 → gas_left got the CREATE spill back via EIP-150 (double
+    -- refund: gas_left AND state_gas_left). With POST-charge values, used_delta excludes
+    -- the CREATE charge (s7 not inflated). frame_return's CREATE-specific credit path
+    -- (create_frame_flag check) credits state_gas_left += 183600 on child failure,
+    -- matching execution-specs credit_state_gas_refund without touching gas_left.
 
     -- drj99.1 part 2: credit child C's env+32 selfBalance with the endowment so the initcode's
     -- SELFBALANCE and its outgoing value-CALL debits operate on the real balance. call_frame_descend

--- a/EvmAsm/Codegen/Programs/NoopHalt.lean
+++ b/EvmAsm/Codegen/Programs/NoopHalt.lean
@@ -48,6 +48,14 @@ private def returnRevertTail (kind : Nat) (rollbackAsm : String := "")
       -- REVERT: CREATE failed -> push 0 (rollback already ran above).
       "  li a0, 0\n  li a1, 0\n  li a2, 0\n" ++
       "  jal ra, frame_return\n" ++
+      -- coc3g.9.3.4: refund CREATE new-account state gas (183600) after frame_return.
+      -- Flag was cleared above so CallFrameReturn's credit doesn't fire; apply here.
+      "  la t0, evm_state_gas_left\n  ld t1, 0(t0)\n  li t2, 183600\n" ++
+      "  add t1, t1, t2\n  sd t1, 0(t0)\n" ++
+      "  la t0, evm_state_gas_used\n  ld t1, 0(t0)\n" ++
+      "  bltu t1, t2, .Lrr_crrev_cr_" ++ toString kind ++ "\n" ++
+      "  sub t1, t1, t2\n  sd t1, 0(t0)\n" ++
+      ".Lrr_crrev_cr_" ++ toString kind ++ ":\n" ++
       "  j .dispatch_loop\n"
      else
       -- RETURN: validity-gate child mem[x14..x14+x15] (the deployed code), record the
@@ -159,6 +167,13 @@ private def returnRevertTail (kind : Nat) (rollbackAsm : String := "")
       "  sd x0, 568(x20)\n" ++
       "  li a0, 0\n  li a1, 0\n  li a2, 0\n" ++
       "  jal ra, frame_return\n" ++
+      -- coc3g.9.3.4: refund CREATE state gas (same as REVERT path above).
+      "  la t0, evm_state_gas_left\n  ld t1, 0(t0)\n  li t2, 183600\n" ++
+      "  add t1, t1, t2\n  sd t1, 0(t0)\n" ++
+      "  la t0, evm_state_gas_used\n  ld t1, 0(t0)\n" ++
+      "  bltu t1, t2, .Lrr_crinv_cr_" ++ toString kind ++ "\n" ++
+      "  sub t1, t1, t2\n  sd t1, 0(t0)\n" ++
+      ".Lrr_crinv_cr_" ++ toString kind ++ ":\n" ++
       "  j .dispatch_loop\n") ++
     ".Lrr_call_" ++ toString kind ++ ":\n" ++
     "  li a0, " ++ (if kind == 2 then "0" else "1") ++ "\n" ++


### PR DESCRIPTION
## Summary

Fixes the amsterdam EIP-8037 two-dimensional gas reservoir receipt bug (bead coc3g.9.3.4). The guest's `frame_return` double-refunded the CREATE new-account state gas charge: it was added to the child leftover (s7) and refunded to parent `gas_left` via EIP-150, AND also credited to `state_gas_left`. The spec only credits `state_gas_left` — the `gas_left` spill persists.

## Changes (3 files, +42/−8)

1. **`ChildFrameCreateTail.lean`**: Removed the snapshot rewrite that set child env `+624/+632` to PRE-CHARGE values. Now keeps POST-CHARGE snapshot from `call_frame_descend`, so `frame_return`'s spill restore excludes the CREATE charge from `s7`.

2. **`CallFrameReturn.lean`**: On CREATE child FAILURE via OOG/exceptional exit (where `create_frame_flag` is still set), credit `state_gas_left += 183600` and `state_gas_used -= 183600` (matching spec `credit_state_gas_refund`).

3. **`NoopHalt.lean`**: On CREATE REVERT and deposit-failure paths (where the flag is cleared before `frame_return`), apply the same credit after `frame_return`.

## Verification

- `lake build` clean (3522 jobs)
- Full EEST suite (23219 fixtures, spike): **1130 → 1101 fail** (GONE=32, NEW=3, net −29)
- GONE: 29 `clear_return_buffer` + 3 CREATE deposit-failure fixtures
- NEW (3, documented below): 2 `init_collision_create_opcode` + 1 `parent_state_gas_after_child_failure`

## The 3 new failures

These are entangled with the exact-gas fallback tower (calibrated for the un-fixed gas model) and the missing SSTORE clear-state-gas refund (`credit_state_gas_refund` for storage clears). Filed as follow-up; not blocking this PR's net improvement.

- **Rows 13972, 13981** (`init_collision_create_opcode`): CREATE collision, small receipt diff (~4796). The exact-gas tower overwrites the receipt; the credit changes the arena receipt, creating a mismatch.
- **Row 2596** (`parent_state_gas_after_child_failure`): Spec has `state_gas_left=183600` (CREATE credit + SSTORE clear refund), guest has `state_gas_left=85680` (CREATE credit but no SSTORE clear refund). Diff = 97920 = state_gas_used.

## Baseline history

2780 → 1702 → 1550 (#9501) → 1285 (#9507 EXP) → 1234 (#9509 MULMOD) → 1218 (#9520 MODEXP a0) → 1130 (#9523 EIP-7702) → **1101** (this PR)

Co-Authored-By: GLM-5.2 <noreply@anthropic.com>