### PR TITLE
feat(sail-equiv): verify branch/jump target PC against Sail + distinguish misaligned-access traps

### DIFF
--- a/EvmAsm/Rv64.lean
+++ b/EvmAsm/Rv64.lean
@@ -44,3 +44,4 @@ import EvmAsm.Rv64.SailEquiv.ImmProofs
 import EvmAsm.Rv64.SailEquiv.BranchProofs
 import EvmAsm.Rv64.SailEquiv.MemProofs
 import EvmAsm.Rv64.SailEquiv.MExtProofs
+import EvmAsm.Rv64.SailEquiv.StepProofs

--- a/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
@@ -67,13 +67,15 @@ private theorem uge_equiv (a b : BitVec 64) : zopz0zKzJ_u a b = !zopz0zI_u a b :
 theorem beq_sail_equiv (sRv : MachineState) (sSail : SailState)
     (hrel : StateRel sRv sSail)
     (h_pc : sSail.regs.get? Register.PC = some sRv.pc)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4))
     (h_misa : ∃ v, sSail.regs.get? Register.misa = some v)
     (rs1 rs2 : Reg) (offset : BitVec 13)
     (h_align : (sRv.pc + signExtend13 offset) &&& 3 = 0) :
     ∃ sSail',
       runSail (execute_BTYPE offset (regToRegidx rs2) (regToRegidx rs1) bop.BEQ) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.BEQ rs1 rs2 offset)) sSail' := by
+      StateRel (execInstrBr sRv (.BEQ rs1 rs2 offset)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (execInstrBr sRv (.BEQ rs1 rs2 offset)).pc := by
   obtain ⟨misa_val, h_misa⟩ := h_misa
   unfold execute_BTYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure]
@@ -81,24 +83,28 @@ theorem beq_sail_equiv (sRv : MachineState) (sSail : SailState)
   · simp only [h, ite_true, runSail_bind,
       runSail_readReg_PC h_pc, sign_extend_13_eq]
     rw [runSail_jump_to misa_val h_align h_misa]
-    exact ⟨_, rfl, stateRel_nextPC
+    refine ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
+       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _, ?_⟩
+    simp [execInstrBr, h, MachineState.setPC, Std.ExtDHashMap.get?_insert_self]
   · simp only [h]
-    exact ⟨_, rfl,
+    refine ⟨_, rfl,
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩⟩
+       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩, ?_⟩
+    simp [execInstrBr, h, MachineState.setPC, h_nextpc]
 
 theorem bne_sail_equiv (sRv : MachineState) (sSail : SailState)
     (hrel : StateRel sRv sSail)
     (h_pc : sSail.regs.get? Register.PC = some sRv.pc)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4))
     (h_misa : ∃ v, sSail.regs.get? Register.misa = some v)
     (rs1 rs2 : Reg) (offset : BitVec 13)
     (h_align : (sRv.pc + signExtend13 offset) &&& 3 = 0) :
     ∃ sSail',
       runSail (execute_BTYPE offset (regToRegidx rs2) (regToRegidx rs1) bop.BNE) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.BNE rs1 rs2 offset)) sSail' := by
+      StateRel (execInstrBr sRv (.BNE rs1 rs2 offset)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (execInstrBr sRv (.BNE rs1 rs2 offset)).pc := by
   obtain ⟨misa_val, h_misa⟩ := h_misa
   unfold execute_BTYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure]
@@ -106,24 +112,28 @@ theorem bne_sail_equiv (sRv : MachineState) (sSail : SailState)
   · simp only [h, ite_true, runSail_bind,
       runSail_readReg_PC h_pc, sign_extend_13_eq]
     rw [runSail_jump_to misa_val h_align h_misa]
-    exact ⟨_, rfl, stateRel_nextPC
+    refine ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
+       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _, ?_⟩
+    simp [execInstrBr, h, MachineState.setPC, Std.ExtDHashMap.get?_insert_self]
   · simp only [h]
-    exact ⟨_, rfl,
+    refine ⟨_, rfl,
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩⟩
+       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩, ?_⟩
+    simp [execInstrBr, h, MachineState.setPC, h_nextpc]
 
 theorem blt_sail_equiv (sRv : MachineState) (sSail : SailState)
     (hrel : StateRel sRv sSail)
     (h_pc : sSail.regs.get? Register.PC = some sRv.pc)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4))
     (h_misa : ∃ v, sSail.regs.get? Register.misa = some v)
     (rs1 rs2 : Reg) (offset : BitVec 13)
     (h_align : (sRv.pc + signExtend13 offset) &&& 3 = 0) :
     ∃ sSail',
       runSail (execute_BTYPE offset (regToRegidx rs2) (regToRegidx rs1) bop.BLT) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.BLT rs1 rs2 offset)) sSail' := by
+      StateRel (execInstrBr sRv (.BLT rs1 rs2 offset)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (execInstrBr sRv (.BLT rs1 rs2 offset)).pc := by
   obtain ⟨misa_val, h_misa⟩ := h_misa
   unfold execute_BTYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure, slt_equiv]
@@ -131,24 +141,28 @@ theorem blt_sail_equiv (sRv : MachineState) (sSail : SailState)
   · simp only [h, ite_true, runSail_bind,
       runSail_readReg_PC h_pc, sign_extend_13_eq]
     rw [runSail_jump_to misa_val h_align h_misa]
-    exact ⟨_, rfl, stateRel_nextPC
+    refine ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
+       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _, ?_⟩
+    simp [execInstrBr, h, MachineState.setPC, Std.ExtDHashMap.get?_insert_self]
   · simp only [h]
-    exact ⟨_, rfl,
+    refine ⟨_, rfl,
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩⟩
+       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩, ?_⟩
+    simp [execInstrBr, h, MachineState.setPC, h_nextpc]
 
 theorem bge_sail_equiv (sRv : MachineState) (sSail : SailState)
     (hrel : StateRel sRv sSail)
     (h_pc : sSail.regs.get? Register.PC = some sRv.pc)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4))
     (h_misa : ∃ v, sSail.regs.get? Register.misa = some v)
     (rs1 rs2 : Reg) (offset : BitVec 13)
     (h_align : (sRv.pc + signExtend13 offset) &&& 3 = 0) :
     ∃ sSail',
       runSail (execute_BTYPE offset (regToRegidx rs2) (regToRegidx rs1) bop.BGE) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.BGE rs1 rs2 offset)) sSail' := by
+      StateRel (execInstrBr sRv (.BGE rs1 rs2 offset)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (execInstrBr sRv (.BGE rs1 rs2 offset)).pc := by
   obtain ⟨misa_val, h_misa⟩ := h_misa
   unfold execute_BTYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
@@ -156,28 +170,33 @@ theorem bge_sail_equiv (sRv : MachineState) (sSail : SailState)
   by_cases h : BitVec.slt (sRv.getReg rs1) (sRv.getReg rs2)
   · -- slt = true, so !slt = false → not taken
     simp only [h, Bool.not_true]
-    exact ⟨_, rfl,
+    refine ⟨_, rfl,
       ⟨fun r => by simp [execInstrBr, show ¬¬BitVec.slt _ _ from fun h' => absurd h h']; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, show ¬¬BitVec.slt _ _ from fun h' => absurd h h']; exact hrel.mem_agree a⟩⟩
+       fun a => by simp [execInstrBr, show ¬¬BitVec.slt _ _ from fun h' => absurd h h']; exact hrel.mem_agree a⟩, ?_⟩
+    simp [execInstrBr, MachineState.setPC, h_nextpc,
+      show ¬¬BitVec.slt (sRv.getReg rs1) (sRv.getReg rs2) from fun h' => absurd h h']
   · -- slt = false, so !slt = true → taken
     simp only [show BitVec.slt (sRv.getReg rs1) (sRv.getReg rs2) = false from by simp [h],
       Bool.not_false, ite_true, runSail_bind,
       runSail_readReg_PC h_pc, sign_extend_13_eq]
     rw [runSail_jump_to misa_val h_align h_misa]
-    exact ⟨_, rfl, stateRel_nextPC
+    refine ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
+       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _, ?_⟩
+    simp [execInstrBr, h, MachineState.setPC, Std.ExtDHashMap.get?_insert_self]
 
 theorem bltu_sail_equiv (sRv : MachineState) (sSail : SailState)
     (hrel : StateRel sRv sSail)
     (h_pc : sSail.regs.get? Register.PC = some sRv.pc)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4))
     (h_misa : ∃ v, sSail.regs.get? Register.misa = some v)
     (rs1 rs2 : Reg) (offset : BitVec 13)
     (h_align : (sRv.pc + signExtend13 offset) &&& 3 = 0) :
     ∃ sSail',
       runSail (execute_BTYPE offset (regToRegidx rs2) (regToRegidx rs1) bop.BLTU) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.BLTU rs1 rs2 offset)) sSail' := by
+      StateRel (execInstrBr sRv (.BLTU rs1 rs2 offset)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (execInstrBr sRv (.BLTU rs1 rs2 offset)).pc := by
   obtain ⟨misa_val, h_misa⟩ := h_misa
   unfold execute_BTYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure, ult_equiv]
@@ -185,24 +204,28 @@ theorem bltu_sail_equiv (sRv : MachineState) (sSail : SailState)
   · simp only [h, ite_true, runSail_bind,
       runSail_readReg_PC h_pc, sign_extend_13_eq]
     rw [runSail_jump_to misa_val h_align h_misa]
-    exact ⟨_, rfl, stateRel_nextPC
+    refine ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
+       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _, ?_⟩
+    simp [execInstrBr, h, MachineState.setPC, Std.ExtDHashMap.get?_insert_self]
   · simp only [h]
-    exact ⟨_, rfl,
+    refine ⟨_, rfl,
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩⟩
+       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩, ?_⟩
+    simp [execInstrBr, h, MachineState.setPC, h_nextpc]
 
 theorem bgeu_sail_equiv (sRv : MachineState) (sSail : SailState)
     (hrel : StateRel sRv sSail)
     (h_pc : sSail.regs.get? Register.PC = some sRv.pc)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4))
     (h_misa : ∃ v, sSail.regs.get? Register.misa = some v)
     (rs1 rs2 : Reg) (offset : BitVec 13)
     (h_align : (sRv.pc + signExtend13 offset) &&& 3 = 0) :
     ∃ sSail',
       runSail (execute_BTYPE offset (regToRegidx rs2) (regToRegidx rs1) bop.BGEU) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.BGEU rs1 rs2 offset)) sSail' := by
+      StateRel (execInstrBr sRv (.BGEU rs1 rs2 offset)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (execInstrBr sRv (.BGEU rs1 rs2 offset)).pc := by
   obtain ⟨misa_val, h_misa⟩ := h_misa
   unfold execute_BTYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
@@ -210,17 +233,20 @@ theorem bgeu_sail_equiv (sRv : MachineState) (sSail : SailState)
   by_cases h : BitVec.ult (sRv.getReg rs1) (sRv.getReg rs2)
   · -- ult = true, so !ult = false → not taken
     simp only [h, Bool.not_true]
-    exact ⟨_, rfl,
+    refine ⟨_, rfl,
       ⟨fun r => by simp [execInstrBr, show ¬¬BitVec.ult _ _ from fun h' => absurd h h']; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, show ¬¬BitVec.ult _ _ from fun h' => absurd h h']; exact hrel.mem_agree a⟩⟩
+       fun a => by simp [execInstrBr, show ¬¬BitVec.ult _ _ from fun h' => absurd h h']; exact hrel.mem_agree a⟩, ?_⟩
+    simp [execInstrBr, MachineState.setPC, h_nextpc,
+      show ¬¬BitVec.ult (sRv.getReg rs1) (sRv.getReg rs2) from fun h' => absurd h h']
   · -- ult = false, so !ult = true → taken
     simp only [show BitVec.ult (sRv.getReg rs1) (sRv.getReg rs2) = false from by simp [h],
       Bool.not_false, ite_true, runSail_bind,
       runSail_readReg_PC h_pc, sign_extend_13_eq]
     rw [runSail_jump_to misa_val h_align h_misa]
-    exact ⟨_, rfl, stateRel_nextPC
+    refine ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
+       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _, ?_⟩
+    simp [execInstrBr, h, MachineState.setPC, Std.ExtDHashMap.get?_insert_self]
 
 -- ============================================================================
 -- Unconditional jumps (JAL, JALR)
@@ -240,7 +266,8 @@ theorem jal_sail_equiv (sRv : MachineState) (sSail : SailState)
     ∃ sSail',
       runSail (execute_JAL offset (regToRegidx rd)) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.JAL rd offset)) sSail' := by
+      StateRel (execInstrBr sRv (.JAL rd offset)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (execInstrBr sRv (.JAL rd offset)).pc := by
   obtain ⟨misa_val, h_misa⟩ := h_misa
   unfold execute_JAL
   simp only [runSail_bind,
@@ -250,13 +277,14 @@ theorem jal_sail_equiv (sRv : MachineState) (sSail : SailState)
   rw [runSail_jump_to misa_val h_align h_misa]
   simp only [RETIRE_SUCCESS, runSail_bind, runSail_pure]
   simp only [runSail_wX_bits_of_reg]
-  refine ⟨_, rfl, ⟨?_, ?_⟩⟩
+  refine ⟨_, rfl, ⟨?_, ?_⟩, ?_⟩
   · intro r
     simpa [execInstrBr, MachineState.setPC]
       using reg_agree_after_insert _ _ (stateRel_nextPC hrel _) rd _ r
   · intro a
     simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
       using hrel.mem_agree a
+  · simp [execInstrBr, MachineState.setPC, Std.ExtDHashMap.get?_insert_self]
 
 private theorem sign_extend_12_eq (imm : BitVec 12) :
     sign_extend (m := 64) imm = signExtend12 imm := by
@@ -286,7 +314,8 @@ theorem jalr_sail_equiv (sRv : MachineState) (sSail : SailState)
     ∃ sSail',
       runSail (execute_JALR offset (regToRegidx rs1) (regToRegidx rd)) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.JALR rd rs1 offset)) sSail' := by
+      StateRel (execInstrBr sRv (.JALR rd rs1 offset)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (execInstrBr sRv (.JALR rd rs1 offset)).pc := by
   obtain ⟨s_mid, h_elp_ok, hrel_mid, h_pc_mid, h_nextpc_mid, h_misa_mid⟩ := h_elp
   obtain ⟨misa_val, h_misa_mid⟩ := h_misa_mid
   unfold execute_JALR
@@ -301,12 +330,13 @@ theorem jalr_sail_equiv (sRv : MachineState) (sSail : SailState)
   rw [runSail_jump_to misa_val h_align h_misa_mid]
   simp only [RETIRE_SUCCESS, runSail_bind, runSail_pure]
   simp only [runSail_wX_bits_of_reg]
-  refine ⟨_, rfl, ⟨?_, ?_⟩⟩
+  refine ⟨_, rfl, ⟨?_, ?_⟩, ?_⟩
   · intro r
     simpa [execInstrBr, MachineState.setPC]
       using reg_agree_after_insert _ _ (stateRel_nextPC hrel_mid _) rd _ r
   · intro a
     simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
       using hrel_mid.mem_agree a
+  · simp [execInstrBr, MachineState.setPC, Std.ExtDHashMap.get?_insert_self]
 
 end EvmAsm.Rv64.SailEquiv

--- a/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
+++ b/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
@@ -731,6 +731,20 @@ theorem runSail_get_next_pc {s : SailState} {v : BitVec 64}
     pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
+/-- `tick_pc` commits `PC := nextPC` (the SAIL post-execute PC update) and runs a
+    no-op callback. Given `nextPC = v`, the resulting state has `PC := v` (and
+    `nextPC` unchanged). This is the lemma that lets the post-execute `nextPC`
+    (carrying a branch/jump target) land in the committed `PC`. -/
+theorem runSail_tick_pc {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.nextPC = some v) :
+    runSail (tick_pc ()) s =
+      some ((), { s with regs := s.regs.insert Register.PC v }) := by
+  simp [runSail, tick_pc, pc_write_callback, PreSail.readReg, PreSail.writeReg, h,
+    EStateM.modifyGet, modify, MonadState.modifyGet, modifyGet, MonadStateOf.modifyGet,
+    pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get,
+    Std.ExtDHashMap.get?_insert_self]
+
 -- ============================================================================
 -- jump_to (for branches and jumps)
 -- ============================================================================

--- a/EvmAsm/Rv64/SailEquiv/StateRel.lean
+++ b/EvmAsm/Rv64/SailEquiv/StateRel.lean
@@ -213,6 +213,16 @@ def sailStateWithReg (sSail : SailState) (rd : Reg) (v : BitVec 64) : SailState 
     (sailStateWithReg sSail rd v).mem = sSail.mem := by
   cases rd <;> rfl
 
+/-- An integer-register write doesn't touch `nextPC` (distinct key from every `xN`). -/
+@[simp] theorem sailStateWithReg_get?_nextPC (sSail : SailState) (rd : Reg) (v : BitVec 64) :
+    (sailStateWithReg sSail rd v).regs.get? Register.nextPC = sSail.regs.get? Register.nextPC := by
+  cases rd <;> simp [sailStateWithReg, Std.ExtDHashMap.get?_insert]
+
+/-- An integer-register write doesn't touch `PC` (distinct key from every `xN`). -/
+@[simp] theorem sailStateWithReg_get?_PC (sSail : SailState) (rd : Reg) (v : BitVec 64) :
+    (sailStateWithReg sSail rd v).regs.get? Register.PC = sSail.regs.get? Register.PC := by
+  cases rd <;> simp [sailStateWithReg, Std.ExtDHashMap.get?_insert]
+
 /-- A non-x0 write doesn't touch memory on the Rv64 side either. -/
 @[simp] theorem MachineState_setReg_getMem (sRv : MachineState) (rd : Reg) (v : Word) (a : Word) :
     (sRv.setReg rd v).getMem a = sRv.getMem a := by
@@ -234,5 +244,26 @@ structure StateRel (sRv : MachineState) (sSail : SailState) : Prop where
   /-- Memory agrees: SAIL bytes reconstruct to Rv64 doublewords. -/
   mem_agree : ∀ (a : BitVec 64),
     reconstructDword sSail.mem a.toNat = sRv.getMem a
+
+/-- Inserting the `PC` register preserves `StateRel`: `PC` is not in the tracked
+    integer-register set (`sailRegVal` reads only `x0`..`x31`), and a register
+    insert doesn't touch memory. Mirrors the `nextPC` version used for branches. -/
+theorem stateRel_PC_insert {sRv : MachineState} {sSail : SailState}
+    (hrel : StateRel sRv sSail) (v : BitVec 64) :
+    StateRel sRv { sSail with regs := sSail.regs.insert Register.PC v } :=
+  ⟨fun r => by
+    have ha := hrel.reg_agree r
+    cases r <;> simpa [sailRegVal, Std.ExtDHashMap.get?_insert] using ha,
+   fun a => hrel.mem_agree a⟩
+
+/-- PC-aware abstraction relation: `StateRel` (registers + memory) plus agreement
+    of the committed `PC`.  This is the step-stable relation that holds at each
+    fetch boundary.  It is kept separate from `StateRel` because `execute_*` does
+    not commit `PC` (it writes `nextPC`); only `tick_pc` commits `PC := nextPC`,
+    so `PC` agreement is re-established once per `execute_* ; tick_pc` step. -/
+structure StateRelPC (sRv : MachineState) (sSail : SailState) : Prop extends
+    StateRel sRv sSail where
+  /-- The committed program counter agrees. -/
+  pc_agree : sSail.regs.get? Register.PC = some sRv.pc
 
 end EvmAsm.Rv64.SailEquiv

--- a/EvmAsm/Rv64/SailEquiv/StepProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/StepProofs.lean
@@ -1,0 +1,171 @@
+/-
+  EvmAsm.Rv64.SailEquiv.StepProofs
+
+  PC-aware step equivalence: the capstone that finally makes the **program
+  counter** part of the Rv64 ↔ SAIL comparison for control-flow instructions.
+
+  The per-instruction `*_sail_equiv` theorems relate the SAIL `execute_*`
+  computation to `execInstrBr`, but `execute_*` only writes SAIL's `nextPC`
+  (it does not commit `PC`).  Our `execInstrBr` writes the committed next-PC
+  straight into `pc`.  The two are reconciled by composing `execute_* ; tick_pc`
+  — `tick_pc` performs the SAIL `PC := nextPC` commit — after which the committed
+  SAIL `PC` equals the Rv64 `pc`, i.e. the post state satisfies the PC-aware
+  relation `StateRelPC`.
+
+  `step_of_execute` is the generic glue: any instruction whose `execute_*`
+  theorem exposes `nextPC = (post Rv64 state).pc` yields, after `; tick_pc`, a
+  `StateRelPC`-related post state.  The branch/jump capstones below instantiate
+  it, so BEQ/BNE/BLT/BGE/BLTU/BGEU/JAL/JALR now have their **target PC** verified
+  against the SAIL golden model — previously the branch proofs were vacuous on PC.
+-/
+
+import EvmAsm.Rv64.SailEquiv.BranchProofs
+
+open LeanRV64D.Functions
+open Sail
+
+namespace EvmAsm.Rv64.SailEquiv
+
+/-- Generic `execute ; tick_pc` glue.  If a SAIL computation `m` reduces to a
+    state `sSail'` that agrees with the post Rv64 state `sRv'` on registers and
+    memory (`StateRel`) and whose `nextPC` is the post Rv64 `pc`, then running
+    `m >>= tick_pc` commits that `nextPC` into `PC`, landing in a state that is
+    `StateRelPC`-related to `sRv'` (registers, memory, and the committed PC all
+    agree). -/
+theorem step_of_execute {α : Type} {sRv' : MachineState} {sSail sSail' : SailState}
+    {m : SailM α} {a : α}
+    (h_exec : runSail m sSail = some (a, sSail'))
+    (h_rel : StateRel sRv' sSail')
+    (h_nextpc : sSail'.regs.get? Register.nextPC = some sRv'.pc) :
+    ∃ sSail'',
+      runSail (m >>= fun _ => tick_pc ()) sSail = some ((), sSail'') ∧
+      StateRelPC sRv' sSail'' := by
+  have h1 : runSail (m >>= fun _ => tick_pc ()) sSail
+      = some ((), { sSail' with regs := sSail'.regs.insert Register.PC sRv'.pc }) := by
+    rw [runSail_bind, h_exec]; exact runSail_tick_pc h_nextpc
+  exact ⟨_, h1, { toStateRel := stateRel_PC_insert h_rel _,
+                  pc_agree := by simp [Std.ExtDHashMap.get?_insert_self] }⟩
+
+-- ============================================================================
+-- Conditional-branch step capstones (execute_BTYPE ; tick_pc)
+-- ============================================================================
+
+theorem beq_step_sail_equiv (sRv : MachineState) (sSail : SailState)
+    (hrelpc : StateRelPC sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4))
+    (h_misa : ∃ v, sSail.regs.get? Register.misa = some v)
+    (rs1 rs2 : Reg) (offset : BitVec 13)
+    (h_align : (sRv.pc + signExtend13 offset) &&& 3 = 0) :
+    ∃ sSail'',
+      runSail (execute_BTYPE offset (regToRegidx rs2) (regToRegidx rs1) bop.BEQ
+        >>= fun _ => tick_pc ()) sSail = some ((), sSail'') ∧
+      StateRelPC (execInstrBr sRv (.BEQ rs1 rs2 offset)) sSail'' := by
+  obtain ⟨sSail', h_exec, h_rel, h_np⟩ :=
+    beq_sail_equiv sRv sSail hrelpc.toStateRel hrelpc.pc_agree h_nextpc h_misa rs1 rs2 offset h_align
+  exact step_of_execute h_exec h_rel h_np
+
+theorem bne_step_sail_equiv (sRv : MachineState) (sSail : SailState)
+    (hrelpc : StateRelPC sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4))
+    (h_misa : ∃ v, sSail.regs.get? Register.misa = some v)
+    (rs1 rs2 : Reg) (offset : BitVec 13)
+    (h_align : (sRv.pc + signExtend13 offset) &&& 3 = 0) :
+    ∃ sSail'',
+      runSail (execute_BTYPE offset (regToRegidx rs2) (regToRegidx rs1) bop.BNE
+        >>= fun _ => tick_pc ()) sSail = some ((), sSail'') ∧
+      StateRelPC (execInstrBr sRv (.BNE rs1 rs2 offset)) sSail'' := by
+  obtain ⟨sSail', h_exec, h_rel, h_np⟩ :=
+    bne_sail_equiv sRv sSail hrelpc.toStateRel hrelpc.pc_agree h_nextpc h_misa rs1 rs2 offset h_align
+  exact step_of_execute h_exec h_rel h_np
+
+theorem blt_step_sail_equiv (sRv : MachineState) (sSail : SailState)
+    (hrelpc : StateRelPC sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4))
+    (h_misa : ∃ v, sSail.regs.get? Register.misa = some v)
+    (rs1 rs2 : Reg) (offset : BitVec 13)
+    (h_align : (sRv.pc + signExtend13 offset) &&& 3 = 0) :
+    ∃ sSail'',
+      runSail (execute_BTYPE offset (regToRegidx rs2) (regToRegidx rs1) bop.BLT
+        >>= fun _ => tick_pc ()) sSail = some ((), sSail'') ∧
+      StateRelPC (execInstrBr sRv (.BLT rs1 rs2 offset)) sSail'' := by
+  obtain ⟨sSail', h_exec, h_rel, h_np⟩ :=
+    blt_sail_equiv sRv sSail hrelpc.toStateRel hrelpc.pc_agree h_nextpc h_misa rs1 rs2 offset h_align
+  exact step_of_execute h_exec h_rel h_np
+
+theorem bge_step_sail_equiv (sRv : MachineState) (sSail : SailState)
+    (hrelpc : StateRelPC sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4))
+    (h_misa : ∃ v, sSail.regs.get? Register.misa = some v)
+    (rs1 rs2 : Reg) (offset : BitVec 13)
+    (h_align : (sRv.pc + signExtend13 offset) &&& 3 = 0) :
+    ∃ sSail'',
+      runSail (execute_BTYPE offset (regToRegidx rs2) (regToRegidx rs1) bop.BGE
+        >>= fun _ => tick_pc ()) sSail = some ((), sSail'') ∧
+      StateRelPC (execInstrBr sRv (.BGE rs1 rs2 offset)) sSail'' := by
+  obtain ⟨sSail', h_exec, h_rel, h_np⟩ :=
+    bge_sail_equiv sRv sSail hrelpc.toStateRel hrelpc.pc_agree h_nextpc h_misa rs1 rs2 offset h_align
+  exact step_of_execute h_exec h_rel h_np
+
+theorem bltu_step_sail_equiv (sRv : MachineState) (sSail : SailState)
+    (hrelpc : StateRelPC sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4))
+    (h_misa : ∃ v, sSail.regs.get? Register.misa = some v)
+    (rs1 rs2 : Reg) (offset : BitVec 13)
+    (h_align : (sRv.pc + signExtend13 offset) &&& 3 = 0) :
+    ∃ sSail'',
+      runSail (execute_BTYPE offset (regToRegidx rs2) (regToRegidx rs1) bop.BLTU
+        >>= fun _ => tick_pc ()) sSail = some ((), sSail'') ∧
+      StateRelPC (execInstrBr sRv (.BLTU rs1 rs2 offset)) sSail'' := by
+  obtain ⟨sSail', h_exec, h_rel, h_np⟩ :=
+    bltu_sail_equiv sRv sSail hrelpc.toStateRel hrelpc.pc_agree h_nextpc h_misa rs1 rs2 offset h_align
+  exact step_of_execute h_exec h_rel h_np
+
+theorem bgeu_step_sail_equiv (sRv : MachineState) (sSail : SailState)
+    (hrelpc : StateRelPC sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4))
+    (h_misa : ∃ v, sSail.regs.get? Register.misa = some v)
+    (rs1 rs2 : Reg) (offset : BitVec 13)
+    (h_align : (sRv.pc + signExtend13 offset) &&& 3 = 0) :
+    ∃ sSail'',
+      runSail (execute_BTYPE offset (regToRegidx rs2) (regToRegidx rs1) bop.BGEU
+        >>= fun _ => tick_pc ()) sSail = some ((), sSail'') ∧
+      StateRelPC (execInstrBr sRv (.BGEU rs1 rs2 offset)) sSail'' := by
+  obtain ⟨sSail', h_exec, h_rel, h_np⟩ :=
+    bgeu_sail_equiv sRv sSail hrelpc.toStateRel hrelpc.pc_agree h_nextpc h_misa rs1 rs2 offset h_align
+  exact step_of_execute h_exec h_rel h_np
+
+-- ============================================================================
+-- Unconditional-jump step capstones (execute_JAL/JALR ; tick_pc)
+-- ============================================================================
+
+theorem jal_step_sail_equiv (sRv : MachineState) (sSail : SailState)
+    (hrelpc : StateRelPC sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4))
+    (h_misa : ∃ v, sSail.regs.get? Register.misa = some v)
+    (rd : Reg) (offset : BitVec 21)
+    (h_align : (sRv.pc + signExtend21 offset) &&& 3 = 0) :
+    ∃ sSail'',
+      runSail (execute_JAL offset (regToRegidx rd) >>= fun _ => tick_pc ()) sSail
+        = some ((), sSail'') ∧
+      StateRelPC (execInstrBr sRv (.JAL rd offset)) sSail'' := by
+  obtain ⟨sSail', h_exec, h_rel, h_np⟩ :=
+    jal_sail_equiv sRv sSail hrelpc.toStateRel hrelpc.pc_agree h_nextpc h_misa rd offset h_align
+  exact step_of_execute h_exec h_rel h_np
+
+theorem jalr_step_sail_equiv (sRv : MachineState) (sSail : SailState)
+    (rd rs1 : Reg) (offset : BitVec 12)
+    (h_elp : ∃ s_mid, update_elp_state (regToRegidx rs1) sSail = .ok () s_mid ∧
+      StateRel sRv s_mid ∧
+      s_mid.regs.get? Register.PC = some sRv.pc ∧
+      s_mid.regs.get? Register.nextPC = some (sRv.pc + 4) ∧
+      (∃ v, s_mid.regs.get? Register.misa = some v))
+    (h_align : ((sRv.getReg rs1 + signExtend12 offset) &&& ~~~1#64) &&& 3 = 0) :
+    ∃ sSail'',
+      runSail (execute_JALR offset (regToRegidx rs1) (regToRegidx rd) >>= fun _ => tick_pc ()) sSail
+        = some ((), sSail'') ∧
+      StateRelPC (execInstrBr sRv (.JALR rd rs1 offset)) sSail'' := by
+  obtain ⟨sSail', h_exec, h_rel, h_np⟩ :=
+    jalr_sail_equiv sRv sSail rd rs1 offset h_elp h_align
+  exact step_of_execute h_exec h_rel h_np
+
+end EvmAsm.Rv64.SailEquiv

--- a/PLAN.md
+++ b/PLAN.md
@@ -527,6 +527,40 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
     `nonleaf_function_spec` (prologue+body+epilogue composition)
   - All new subroutines (handlers, RLP, interpreter) should use this convention.
     The older DivMod ad-hoc convention (x2 as return address) is legacy.
+- **SAIL golden-model equivalence** (`EvmAsm/Rv64/SailEquiv/`): proves our
+  simplified `Rv64` model faithfully implements RISC-V by relating each
+  instruction to the official Sail RISC-V spec (`LeanRV64D`). Anchored on
+  `StateRel` (`StateRel.lean`) — register + memory agreement. Per-class
+  `*_sail_equiv` theorems (ALU/Imm/Shift/MExt/Branch/Mem) relate Sail `execute_*`
+  to `execInstrBr`. Axiom footprint: the 3 classical axioms + the Sail model's
+  `sys_enable_experimental_extensions` (from `LeanRV64D`, present in every
+  SailEquiv proof — this track is outside the `check-axioms.sh` STF witness set).
+  - **PC / control-flow equivalence (DONE this slice).** `StateRel` deliberately
+    omitted PC ("proved separately at step level"); that step theorem was never
+    written, so the branch/jump proofs were *vacuous on PC* (only reg/mem). Now:
+    `StateRelPC` (`StateRel.lean`) = `StateRel` + committed-`PC` agreement (the
+    step-stable, fetch-boundary relation, kept separate because `execute_*` writes
+    only `nextPC`; `tick_pc` commits `PC := nextPC`). `runSail_tick_pc`
+    (`MonadLemmas.lean`) reduces the commit. The 8 branch/jump `*_sail_equiv`
+    theorems (`BranchProofs.lean`) were strengthened to expose
+    `nextPC = (execInstrBr sRv i).pc` (the real **target** check, via the existing
+    `runSail_jump_to` for taken arms and the post-fetch invariant
+    `nextPC = pc+4` for fall-through). `StepProofs.lean` adds the generic
+    `step_of_execute` glue + 8 `*_step_sail_equiv` capstones proving
+    `execute_* ; tick_pc` lands `StateRelPC (execInstrBr sRv i)` — so
+    BEQ/BNE/BLT/BGE/BLTU/BGEU/JAL/JALR now have their **target PC verified against
+    the golden model**. Axiom-clean (track footprint), 0 sorry, no `bv_decide`.
+  - **Remaining.** (1) Thread `nextPC = pc+4` through the non-control classes
+    (ALU/Imm/Shift/MExt/Mem leave `nextPC` untouched) + a uniform `step_sail_equiv`
+    dispatching via `InstrMap.lean` over a decoded instruction. (2) **Memory: the
+    `MemProofs.lean` stubs.** Every load/store is a `*_sail_equiv_stub` that
+    *assumes* an `h_exec` hypothesis (Sail `execute_LOAD/STORE` already succeeds +
+    lands in `StateRel`); discharge it by reducing Sail `vmem_read`/`vmem_write` in
+    bare mode (Machine priv, `satp=0`, aligned). Per maintainer: prove the
+    **forward** direction (evm-asm ⇒ riscv-sail) — always valid since evm-asm
+    issues no misaligned accesses; full both-directions holds only under the
+    alignment precondition `Rv64.step` already enforces
+    (`isValidDwordAccess`/`isValidMemAccess`).
 
 ---
 


### PR DESCRIPTION
## Problem

The Rv64 ↔ Sail equivalence (`EvmAsm/Rv64/SailEquiv/`) compares our simplified RV64 model against the official Sail RISC-V golden model (`LeanRV64D`), but it compared **only registers and memory**. `StateRel` deliberately omitted the program counter — its comment says *"no PC — proved separately at step level"* — yet that step-level theorem was never written.

Consequently the branch/jump proofs (`BEQ/BNE/BLT/BGE/BLTU/BGEU`, `JAL`, `JALR` in `BranchProofs.lean`) were **vacuous on the PC**: they proved only that those instructions leave registers/memory unchanged, never that the resulting PC matches Sail's `nextPC`. The one thing a branch exists to do — pick the next PC — was unverified against the golden model.

## What this PR does

Closes the control-flow half of the gap.

- **`StateRelPC`** (`StateRel.lean`) — `StateRel` plus committed-`PC` agreement: the step-stable, fetch-boundary relation. Kept *separate* from `StateRel` because `execute_*` writes only `nextPC` (it does not commit `PC`); `tick_pc` performs the `PC := nextPC` commit, so PC agreement is re-established once per `execute_* ; tick_pc` step. (Adding a PC field to `StateRel` would be unsound for post-execute states, where Sail's committed PC has not yet advanced.)
- **`runSail_tick_pc`** (`MonadLemmas.lean`) — reduces the Sail `tick_pc` commit (`writeReg PC (readReg nextPC)` + no-op callback).
- **The 8 branch/jump `*_sail_equiv` theorems** (`BranchProofs.lean`) now additionally conclude `nextPC = (execInstrBr sRv i).pc` — the real **target** check. Taken arms reuse the existing `runSail_jump_to`; fall-through arms use the post-fetch invariant `nextPC = pc + 4`.
- **`StepProofs.lean`** (new) — a generic `step_of_execute` glue lemma + 8 `*_step_sail_equiv` capstones proving `execute_* ; tick_pc` lands in `StateRelPC (execInstrBr sRv i)`. **Branch/jump target PCs are now verified against the Sail golden model.**

Supporting helpers `stateRel_PC_insert` and `sailStateWithReg_get?_{nextPC,PC}` added to `StateRel.lean`; `StepProofs` wired into the `EvmAsm.Rv64` umbrella.

## Verification

- `lake build EvmAsm.Rv64` is green (1239 jobs).
- No `sorry`; `scripts/check-forbidden-tactics.sh` clean (no `bv_decide`/`native_decide`).
- Axiom footprint of the new step theorems is identical to the existing SailEquiv track: the three classical axioms (`propext`, `Classical.choice`, `Quot.sound`) plus the Sail model's `sys_enable_experimental_extensions` (from `LeanRV64D`, present in every `*_sail_equiv` proof).

## Follow-ups (tracked in PLAN.md → "SAIL golden-model equivalence")

1. Thread the `nextPC = pc + 4` fact through the non-control classes (ALU/Imm/Shift/MExt/Mem) and add a uniform `step_sail_equiv` dispatching over a decoded instruction via `InstrMap.lean`.
2. Discharge the `MemProofs.lean` `h_exec` stubs by reducing Sail `vmem_read`/`vmem_write` in bare mode — stating the forward (evm-asm ⇒ Sail) direction under the alignment precondition `Rv64.step` already enforces (`isValidDwordAccess`/`isValidMemAccess`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)