### PR TITLE
feat(sail-equiv): finish PC equivalence + start the memory-equivalence reduction

### DIFF
--- a/EvmAsm/Rv64.lean
+++ b/EvmAsm/Rv64.lean
@@ -46,3 +46,4 @@ import EvmAsm.Rv64.SailEquiv.MemProofs
 import EvmAsm.Rv64.SailEquiv.MExtProofs
 import EvmAsm.Rv64.SailEquiv.StepProofs
 import EvmAsm.Rv64.SailEquiv.MemReduce
+import EvmAsm.Rv64.SailEquiv.MemMonad

--- a/EvmAsm/Rv64.lean
+++ b/EvmAsm/Rv64.lean
@@ -45,3 +45,4 @@ import EvmAsm.Rv64.SailEquiv.BranchProofs
 import EvmAsm.Rv64.SailEquiv.MemProofs
 import EvmAsm.Rv64.SailEquiv.MExtProofs
 import EvmAsm.Rv64.SailEquiv.StepProofs
+import EvmAsm.Rv64.SailEquiv.MemReduce

--- a/EvmAsm/Rv64/Execution.lean
+++ b/EvmAsm/Rv64/Execution.lean
@@ -419,6 +419,98 @@ def step (s : MachineState) : Option MachineState :=
     else some (execInstrBr s .ECALL)  -- other ecalls continue
   | some i => some (execInstrBr s i)
 
+-- ============================================================================
+-- Trap-aware step result (distinguishing misaligned access)
+--
+-- `step` collapses every trap to `none`. For stating equivalence/soundness
+-- results cleanly ("unless a misaligned access happens, …") we surface a
+-- misaligned-access trap as a distinct value via `stepResult`, WITHOUT touching
+-- `step`/`stepN` (which underpin the CPS Hoare-triple framework and ~all proofs).
+-- `stepResult` is connected back to `step` by `step_eq_stepResult_toOption`.
+-- ============================================================================
+
+/-- Kinds of trap an interpreter step can raise.
+
+    Deliberately coarse for now: only `misalignedAccess` is distinguished; every
+    other `step`-trap (HALT/EBREAK, decode failure, out-of-range access, bad
+    syscall pointer) is lumped into `other`. **Extensible:** to surface a further
+    kind (e.g. `outOfRange`, `halt`, `decodeFail`) add a constructor here and a
+    corresponding classifier branch in `stepResult` (mirroring `isMisalignedAccess`);
+    `StepResult.toOption` and the `step` bridge are unaffected since they only
+    distinguish `ok` from "any trap". -/
+inductive TrapKind where
+  | misalignedAccess
+  | other
+  deriving DecidableEq, Repr
+
+/-- Outcome of one interpreter step: a successful next state, or a trap. -/
+inductive StepResult where
+  | ok (s : MachineState)
+  | trap (k : TrapKind)
+
+/-- Forget the trap kind, recovering the `Option`-based view used by `step`. -/
+def StepResult.toOption : StepResult → Option MachineState
+  | .ok s   => some s
+  | .trap _ => none
+
+/-- Lift an `Option`-step into a `StepResult`, attributing a `none` to `other`. -/
+def stepResultOfOption : Option MachineState → StepResult
+  | some s => .ok s
+  | none   => .trap .other
+
+@[simp] theorem stepResultOfOption_toOption (o : Option MachineState) :
+    (stepResultOfOption o).toOption = o := by
+  cases o <;> rfl
+
+/-- The current instruction is a memory access that is **in range but misaligned**
+    (the one way a memory `step` can trap that the Sail golden model handles
+    specially). Byte accesses never misalign. -/
+def isMisalignedAccess (s : MachineState) : Bool :=
+  match s.code s.pc with
+  | some (.LD _ rs1 off)  => let a := s.getReg rs1 + signExtend12 off; isValidMemAddr a && !isAligned8 a
+  | some (.SD rs1 _ off)  => let a := s.getReg rs1 + signExtend12 off; isValidMemAddr a && !isAligned8 a
+  | some (.LW _ rs1 off)  => let a := s.getReg rs1 + signExtend12 off; isValidMemAddr a && !isAligned4 a
+  | some (.LWU _ rs1 off) => let a := s.getReg rs1 + signExtend12 off; isValidMemAddr a && !isAligned4 a
+  | some (.SW rs1 _ off)  => let a := s.getReg rs1 + signExtend12 off; isValidMemAddr a && !isAligned4 a
+  | some (.LH _ rs1 off)  => let a := s.getReg rs1 + signExtend12 off; isValidMemAddr a && !isAligned2 a
+  | some (.LHU _ rs1 off) => let a := s.getReg rs1 + signExtend12 off; isValidMemAddr a && !isAligned2 a
+  | some (.SH rs1 _ off)  => let a := s.getReg rs1 + signExtend12 off; isValidMemAddr a && !isAligned2 a
+  | _ => false
+
+/-- Trap-aware single step: identical to `step`, except an in-range-but-misaligned
+    memory access yields `.trap .misalignedAccess` rather than being collapsed to
+    `none`. All other outcomes match `step` (success → `.ok`, any other trap →
+    `.trap .other`). See `step_eq_stepResult_toOption` for the precise bridge. -/
+def stepResult (s : MachineState) : StepResult :=
+  if isMisalignedAccess s then .trap .misalignedAccess
+  else stepResultOfOption (step s)
+
+/-- A misaligned access makes `step` trap (return `none`): the access is in range
+    but fails the alignment half of the `isValid*Access` guard. -/
+theorem isMisalignedAccess_imp_step_none {s : MachineState}
+    (h : isMisalignedAccess s = true) : step s = none := by
+  unfold isMisalignedAccess at h
+  unfold step
+  split at h <;>
+    simp_all [isValidDwordAccess, isValidMemAccess, isValidHalfwordAccess,
+      Bool.and_eq_true]
+
+/-- **Bridge.** `stepResult` refines `step`: forgetting the trap kind recovers
+    `step` exactly. Lets results proved with the misaligned distinction transfer to
+    the `step`/`stepN`-based corpus (and vice versa). -/
+theorem step_eq_stepResult_toOption (s : MachineState) :
+    step s = (stepResult s).toOption := by
+  unfold stepResult
+  by_cases h : isMisalignedAccess s
+  · simp [h, StepResult.toOption, isMisalignedAccess_imp_step_none h]
+  · simp [h, stepResultOfOption_toOption]
+
+/-- `stepResult` succeeds exactly when `step` does. -/
+theorem stepResult_ok_iff {s s' : MachineState} :
+    stepResult s = .ok s' ↔ step s = some s' := by
+  rw [step_eq_stepResult_toOption]
+  cases hs : stepResult s <;> simp [StepResult.toOption]
+
 /-- step for non-ECALL, non-EBREAK, non-memory instructions. -/
 @[simp] theorem step_non_ecall_non_mem {s : MachineState} {i : Instr}
     (hfetch : s.code s.pc = some i) (hne : i ≠ .ECALL) (hnb : i ≠ .EBREAK)
@@ -771,5 +863,27 @@ theorem code_stepN {k : Nat} {s s' : MachineState} (h : stepN k s = some s') :
       have h1 := code_step hs
       have h2 := ih h
       rw [h2, h1]
+
+-- ============================================================================
+-- Sanity checks for the trap-aware step result
+-- ============================================================================
+
+/-- An aligned, in-range dword access steps successfully (`.ok`). -/
+example (s : MachineState) (rd rs1 : Reg) (off : BitVec 12)
+    (hcode : s.code s.pc = some (.LD rd rs1 off))
+    (hvalid : isValidDwordAccess (s.getReg rs1 + signExtend12 off) = true) :
+    stepResult s = .ok (execInstrBr s (.LD rd rs1 off)) := by
+  rw [stepResult_ok_iff]; exact step_ld hcode hvalid
+
+/-- An in-range but misaligned dword access surfaces a distinguished
+    `.trap .misalignedAccess` — while plain `step` only sees `none`. -/
+example (s : MachineState) (rd rs1 : Reg) (off : BitVec 12)
+    (hcode : s.code s.pc = some (.LD rd rs1 off))
+    (hrange : isValidMemAddr (s.getReg rs1 + signExtend12 off) = true)
+    (hmis : isAligned8 (s.getReg rs1 + signExtend12 off) = false) :
+    stepResult s = .trap .misalignedAccess ∧ step s = none := by
+  have hm : isMisalignedAccess s = true := by
+    simp only [isMisalignedAccess, hcode]; rw [hrange, hmis]; decide
+  exact ⟨by unfold stepResult; simp [hm], isMisalignedAccess_imp_step_none hm⟩
 
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SailEquiv/ALUProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/ALUProofs.lean
@@ -69,11 +69,13 @@ theorem reg_agree_after_insert (sSail : SailState) (sRv : MachineState)
 -- for wX_bits, witness state, build StateRel (reg_agree from bridge + mem_agree trivial).
 
 theorem add_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 rs2 : Reg) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 rs2 : Reg) :
     ∃ sSail',
       runSail (execute_RTYPE (regToRegidx rs2) (regToRegidx rs1) (regToRegidx rd) rop.ADD) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.ADD rd rs1 rs2)) sSail' := by
+      StateRel (execInstrBr sRv (.ADD rd rs1 rs2)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_RTYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     runSail_wX_bits_of_reg]
@@ -81,14 +83,17 @@ theorem add_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 theorem sub_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 rs2 : Reg) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 rs2 : Reg) :
     ∃ sSail',
       runSail (execute_RTYPE (regToRegidx rs2) (regToRegidx rs1) (regToRegidx rd) rop.SUB) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.SUB rd rs1 rs2)) sSail' := by
+      StateRel (execInstrBr sRv (.SUB rd rs1 rs2)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_RTYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure]
   simp only [runSail_wX_bits_of_reg]
@@ -96,14 +101,17 @@ theorem sub_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 theorem and_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 rs2 : Reg) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 rs2 : Reg) :
     ∃ sSail',
       runSail (execute_RTYPE (regToRegidx rs2) (regToRegidx rs1) (regToRegidx rd) rop.AND) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.AND rd rs1 rs2)) sSail' := by
+      StateRel (execInstrBr sRv (.AND rd rs1 rs2)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_RTYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure]
   simp only [runSail_wX_bits_of_reg]
@@ -111,14 +119,17 @@ theorem and_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 theorem or_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 rs2 : Reg) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 rs2 : Reg) :
     ∃ sSail',
       runSail (execute_RTYPE (regToRegidx rs2) (regToRegidx rs1) (regToRegidx rd) rop.OR) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.OR rd rs1 rs2)) sSail' := by
+      StateRel (execInstrBr sRv (.OR rd rs1 rs2)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_RTYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure]
   simp only [runSail_wX_bits_of_reg]
@@ -126,14 +137,17 @@ theorem or_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 theorem xor_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 rs2 : Reg) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 rs2 : Reg) :
     ∃ sSail',
       runSail (execute_RTYPE (regToRegidx rs2) (regToRegidx rs1) (regToRegidx rd) rop.XOR) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.XOR rd rs1 rs2)) sSail' := by
+      StateRel (execInstrBr sRv (.XOR rd rs1 rs2)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_RTYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure]
   simp only [runSail_wX_bits_of_reg]
@@ -141,7 +155,8 @@ theorem xor_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 -- ============================================================================
 -- Comparison helper equivalences
@@ -166,11 +181,13 @@ theorem sltu_value_equiv (a b : BitVec 64) :
 -- ============================================================================
 
 theorem slt_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 rs2 : Reg) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 rs2 : Reg) :
     ∃ sSail',
       runSail (execute_RTYPE (regToRegidx rs2) (regToRegidx rs1) (regToRegidx rd) rop.SLT) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.SLT rd rs1 rs2)) sSail' := by
+      StateRel (execInstrBr sRv (.SLT rd rs1 rs2)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_RTYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     slt_value_equiv]
@@ -179,14 +196,17 @@ theorem slt_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 theorem sltu_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 rs2 : Reg) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 rs2 : Reg) :
     ∃ sSail',
       runSail (execute_RTYPE (regToRegidx rs2) (regToRegidx rs1) (regToRegidx rd) rop.SLTU) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.SLTU rd rs1 rs2)) sSail' := by
+      StateRel (execInstrBr sRv (.SLTU rd rs1 rs2)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_RTYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sltu_value_equiv]
@@ -195,7 +215,8 @@ theorem sltu_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 -- ============================================================================
 -- SLL, SRL, SRA (register shifts)
@@ -207,11 +228,13 @@ theorem sltu_sail_equiv (sRv : MachineState) (sSail : SailState)
 -- ============================================================================
 
 theorem sll_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 rs2 : Reg) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 rs2 : Reg) :
     ∃ sSail',
       runSail (execute_RTYPE (regToRegidx rs2) (regToRegidx rs1) (regToRegidx rd) rop.SLL) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.SLL rd rs1 rs2)) sSail' := by
+      StateRel (execInstrBr sRv (.SLL rd rs1 rs2)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_RTYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     shift_bits_left, Sail.BitVec.extractLsb]
@@ -220,14 +243,17 @@ theorem sll_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 theorem srl_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 rs2 : Reg) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 rs2 : Reg) :
     ∃ sSail',
       runSail (execute_RTYPE (regToRegidx rs2) (regToRegidx rs1) (regToRegidx rd) rop.SRL) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.SRL rd rs1 rs2)) sSail' := by
+      StateRel (execInstrBr sRv (.SRL rd rs1 rs2)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_RTYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     shift_bits_right, Sail.BitVec.extractLsb]
@@ -236,14 +262,17 @@ theorem srl_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 theorem sra_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 rs2 : Reg) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 rs2 : Reg) :
     ∃ sSail',
       runSail (execute_RTYPE (regToRegidx rs2) (regToRegidx rs1) (regToRegidx rd) rop.SRA) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.SRA rd rs1 rs2)) sSail' := by
+      StateRel (execInstrBr sRv (.SRA rd rs1 rs2)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_RTYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     shift_bits_right_arith, Sail.BitVec.extractLsb, BitVec.toNatInt]
@@ -252,7 +281,8 @@ theorem sra_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 -- ============================================================================
 -- LUI helper + proof
@@ -270,11 +300,13 @@ theorem lui_equiv (imm : BitVec 20) :
   simp only [sign_extend, Sail.BitVec.signExtend]; rw [lui_inner]
 
 theorem lui_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd : Reg) (imm : BitVec 20) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd : Reg) (imm : BitVec 20) :
     ∃ sSail',
       runSail (execute_UTYPE imm (regToRegidx rd) uop.LUI) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.LUI rd imm)) sSail' := by
+      StateRel (execInstrBr sRv (.LUI rd imm)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_UTYPE
   simp only [runSail_bind, runSail_pure]
   simp only [runSail_wX_bits_of_reg]
@@ -282,7 +314,8 @@ theorem lui_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC, ← lui_equiv]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 -- ============================================================================
 -- ADDIW helper + proof
@@ -297,11 +330,13 @@ theorem addiw_equiv (rs1 : BitVec 64) (imm : BitVec 12) :
   congr 1; apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_setWidth]
 
 theorem addiw_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 : Reg) (imm : BitVec 12) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 : Reg) (imm : BitVec 12) :
     ∃ sSail',
       runSail (execute_ADDIW imm (regToRegidx rs1) (regToRegidx rd)) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.ADDIW rd rs1 imm)) sSail' := by
+      StateRel (execInstrBr sRv (.ADDIW rd rs1 imm)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_ADDIW
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure]
   simp only [runSail_wX_bits_of_reg]
@@ -309,7 +344,8 @@ theorem addiw_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC, signExtend12, ← addiw_equiv]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 -- ============================================================================
 -- AUIPC
@@ -321,12 +357,14 @@ theorem addiw_sail_equiv (sRv : MachineState) (sSail : SailState)
 
 theorem auipc_sail_equiv (sRv : MachineState) (sSail : SailState)
     (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4))
     (h_pc : sSail.regs.get? Register.PC = some sRv.pc)
     (rd : Reg) (imm : BitVec 20) :
     ∃ sSail',
       runSail (execute_UTYPE imm (regToRegidx rd) uop.AUIPC) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.AUIPC rd imm)) sSail' := by
+      StateRel (execInstrBr sRv (.AUIPC rd imm)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_UTYPE
   simp only [runSail_bind, runSail_pure, runSail_get_arch_pc h_pc]
   simp only [runSail_wX_bits_of_reg]
@@ -334,7 +372,8 @@ theorem auipc_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC, ← lui_equiv]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 -- ============================================================================
 -- MUL (M-extension, low 64 bits)
@@ -359,13 +398,15 @@ theorem mul_low_equiv (a b : BitVec 64) :
   exact_mod_cast rfl
 
 theorem mul_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 rs2 : Reg) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 rs2 : Reg) :
     ∃ sSail',
       runSail (execute_MUL (regToRegidx rs2) (regToRegidx rs1) (regToRegidx rd)
         { result_part := VectorHalf.Low, signed_rs1 := Signedness.Signed,
           signed_rs2 := Signedness.Signed }) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.MUL rd rs1 rs2)) sSail' := by
+      StateRel (execInstrBr sRv (.MUL rd rs1 rs2)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_MUL
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     mul_low_equiv, LeanRV64D.Functions.xlen]
@@ -374,6 +415,7 @@ theorem mul_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 end EvmAsm.Rv64.SailEquiv

--- a/EvmAsm/Rv64/SailEquiv/ALUProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/ALUProofs.lean
@@ -82,8 +82,8 @@ theorem add_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 theorem sub_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -100,8 +100,8 @@ theorem sub_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 theorem and_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -118,8 +118,8 @@ theorem and_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 theorem or_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -136,8 +136,8 @@ theorem or_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 theorem xor_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -154,8 +154,8 @@ theorem xor_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 -- ============================================================================
@@ -195,8 +195,8 @@ theorem slt_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 theorem sltu_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -214,8 +214,8 @@ theorem sltu_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 -- ============================================================================
@@ -242,8 +242,8 @@ theorem sll_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 theorem srl_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -261,8 +261,8 @@ theorem srl_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 theorem sra_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -280,8 +280,8 @@ theorem sra_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 -- ============================================================================
@@ -313,8 +313,8 @@ theorem lui_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC, ← lui_equiv]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 -- ============================================================================
@@ -343,8 +343,8 @@ theorem addiw_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC, signExtend12, ← addiw_equiv]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 -- ============================================================================
@@ -371,8 +371,8 @@ theorem auipc_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC, ← lui_equiv]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 -- ============================================================================
@@ -414,8 +414,8 @@ theorem mul_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 end EvmAsm.Rv64.SailEquiv

--- a/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
@@ -34,7 +34,7 @@ theorem stateRel_nextPC {sRv : MachineState} {sSail : SailState}
   ⟨fun r => by
     have ha := hrel.reg_agree r
     cases r <;> simpa [sailRegVal, Std.ExtDHashMap.get?_insert] using ha,
-   fun a => hrel.mem_agree a⟩
+   fun a ha => hrel.mem_agree a ha⟩
 
 -- Comparison operator equivalences (definitional: SAIL and Lean use the same operations)
 private theorem slt_equiv (a b : BitVec 64) : zopz0zI_s a b = BitVec.slt a b := by
@@ -85,12 +85,12 @@ theorem beq_sail_equiv (sRv : MachineState) (sSail : SailState)
     rw [runSail_jump_to misa_val h_align h_misa]
     refine ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _, ?_⟩
+       fun a ha => by simp [execInstrBr, h]; exact hrel.mem_agree a ha⟩ _, ?_⟩
     simp [execInstrBr, h, MachineState.setPC, Std.ExtDHashMap.get?_insert_self]
   · simp only [h]
     refine ⟨_, rfl,
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩, ?_⟩
+       fun a ha => by simp [execInstrBr, h]; exact hrel.mem_agree a ha⟩, ?_⟩
     simp [execInstrBr, h, MachineState.setPC, h_nextpc]
 
 theorem bne_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -114,12 +114,12 @@ theorem bne_sail_equiv (sRv : MachineState) (sSail : SailState)
     rw [runSail_jump_to misa_val h_align h_misa]
     refine ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _, ?_⟩
+       fun a ha => by simp [execInstrBr, h]; exact hrel.mem_agree a ha⟩ _, ?_⟩
     simp [execInstrBr, h, MachineState.setPC, Std.ExtDHashMap.get?_insert_self]
   · simp only [h]
     refine ⟨_, rfl,
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩, ?_⟩
+       fun a ha => by simp [execInstrBr, h]; exact hrel.mem_agree a ha⟩, ?_⟩
     simp [execInstrBr, h, MachineState.setPC, h_nextpc]
 
 theorem blt_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -143,12 +143,12 @@ theorem blt_sail_equiv (sRv : MachineState) (sSail : SailState)
     rw [runSail_jump_to misa_val h_align h_misa]
     refine ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _, ?_⟩
+       fun a ha => by simp [execInstrBr, h]; exact hrel.mem_agree a ha⟩ _, ?_⟩
     simp [execInstrBr, h, MachineState.setPC, Std.ExtDHashMap.get?_insert_self]
   · simp only [h]
     refine ⟨_, rfl,
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩, ?_⟩
+       fun a ha => by simp [execInstrBr, h]; exact hrel.mem_agree a ha⟩, ?_⟩
     simp [execInstrBr, h, MachineState.setPC, h_nextpc]
 
 theorem bge_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -172,7 +172,7 @@ theorem bge_sail_equiv (sRv : MachineState) (sSail : SailState)
     simp only [h, Bool.not_true]
     refine ⟨_, rfl,
       ⟨fun r => by simp [execInstrBr, show ¬¬BitVec.slt _ _ from fun h' => absurd h h']; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, show ¬¬BitVec.slt _ _ from fun h' => absurd h h']; exact hrel.mem_agree a⟩, ?_⟩
+       fun a ha => by simp [execInstrBr, show ¬¬BitVec.slt _ _ from fun h' => absurd h h']; exact hrel.mem_agree a ha⟩, ?_⟩
     simp [execInstrBr, MachineState.setPC, h_nextpc,
       show ¬¬BitVec.slt (sRv.getReg rs1) (sRv.getReg rs2) from fun h' => absurd h h']
   · -- slt = false, so !slt = true → taken
@@ -182,7 +182,7 @@ theorem bge_sail_equiv (sRv : MachineState) (sSail : SailState)
     rw [runSail_jump_to misa_val h_align h_misa]
     refine ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _, ?_⟩
+       fun a ha => by simp [execInstrBr, h]; exact hrel.mem_agree a ha⟩ _, ?_⟩
     simp [execInstrBr, h, MachineState.setPC, Std.ExtDHashMap.get?_insert_self]
 
 theorem bltu_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -206,12 +206,12 @@ theorem bltu_sail_equiv (sRv : MachineState) (sSail : SailState)
     rw [runSail_jump_to misa_val h_align h_misa]
     refine ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _, ?_⟩
+       fun a ha => by simp [execInstrBr, h]; exact hrel.mem_agree a ha⟩ _, ?_⟩
     simp [execInstrBr, h, MachineState.setPC, Std.ExtDHashMap.get?_insert_self]
   · simp only [h]
     refine ⟨_, rfl,
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩, ?_⟩
+       fun a ha => by simp [execInstrBr, h]; exact hrel.mem_agree a ha⟩, ?_⟩
     simp [execInstrBr, h, MachineState.setPC, h_nextpc]
 
 theorem bgeu_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -235,7 +235,7 @@ theorem bgeu_sail_equiv (sRv : MachineState) (sSail : SailState)
     simp only [h, Bool.not_true]
     refine ⟨_, rfl,
       ⟨fun r => by simp [execInstrBr, show ¬¬BitVec.ult _ _ from fun h' => absurd h h']; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, show ¬¬BitVec.ult _ _ from fun h' => absurd h h']; exact hrel.mem_agree a⟩, ?_⟩
+       fun a ha => by simp [execInstrBr, show ¬¬BitVec.ult _ _ from fun h' => absurd h h']; exact hrel.mem_agree a ha⟩, ?_⟩
     simp [execInstrBr, MachineState.setPC, h_nextpc,
       show ¬¬BitVec.ult (sRv.getReg rs1) (sRv.getReg rs2) from fun h' => absurd h h']
   · -- ult = false, so !ult = true → taken
@@ -245,7 +245,7 @@ theorem bgeu_sail_equiv (sRv : MachineState) (sSail : SailState)
     rw [runSail_jump_to misa_val h_align h_misa]
     refine ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
-       fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _, ?_⟩
+       fun a ha => by simp [execInstrBr, h]; exact hrel.mem_agree a ha⟩ _, ?_⟩
     simp [execInstrBr, h, MachineState.setPC, Std.ExtDHashMap.get?_insert_self]
 
 -- ============================================================================
@@ -281,9 +281,9 @@ theorem jal_sail_equiv (sRv : MachineState) (sSail : SailState)
   · intro r
     simpa [execInstrBr, MachineState.setPC]
       using reg_agree_after_insert _ _ (stateRel_nextPC hrel _) rd _ r
-  · intro a
+  · intro a ha
     simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-      using hrel.mem_agree a
+      using hrel.mem_agree a ha
   · simp [execInstrBr, MachineState.setPC, Std.ExtDHashMap.get?_insert_self]
 
 private theorem sign_extend_12_eq (imm : BitVec 12) :
@@ -334,9 +334,9 @@ theorem jalr_sail_equiv (sRv : MachineState) (sSail : SailState)
   · intro r
     simpa [execInstrBr, MachineState.setPC]
       using reg_agree_after_insert _ _ (stateRel_nextPC hrel_mid _) rd _ r
-  · intro a
+  · intro a ha
     simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-      using hrel_mid.mem_agree a
+      using hrel_mid.mem_agree a ha
   · simp [execInstrBr, MachineState.setPC, Std.ExtDHashMap.get?_insert_self]
 
 end EvmAsm.Rv64.SailEquiv

--- a/EvmAsm/Rv64/SailEquiv/ImmProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/ImmProofs.lean
@@ -23,11 +23,13 @@ namespace EvmAsm.Rv64.SailEquiv
 -- ============================================================================
 
 theorem addi_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 : Reg) (imm : BitVec 12) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 : Reg) (imm : BitVec 12) :
     ∃ sSail',
       runSail (execute_ITYPE imm (regToRegidx rs1) (regToRegidx rd) iop.ADDI) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.ADDI rd rs1 imm)) sSail' := by
+      StateRel (execInstrBr sRv (.ADDI rd rs1 imm)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_ITYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sign_extend, Sail.BitVec.signExtend]
@@ -36,14 +38,17 @@ theorem addi_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC, signExtend12]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 theorem andi_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 : Reg) (imm : BitVec 12) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 : Reg) (imm : BitVec 12) :
     ∃ sSail',
       runSail (execute_ITYPE imm (regToRegidx rs1) (regToRegidx rd) iop.ANDI) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.ANDI rd rs1 imm)) sSail' := by
+      StateRel (execInstrBr sRv (.ANDI rd rs1 imm)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_ITYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sign_extend, Sail.BitVec.signExtend]
@@ -52,14 +57,17 @@ theorem andi_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC, signExtend12]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 theorem ori_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 : Reg) (imm : BitVec 12) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 : Reg) (imm : BitVec 12) :
     ∃ sSail',
       runSail (execute_ITYPE imm (regToRegidx rs1) (regToRegidx rd) iop.ORI) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.ORI rd rs1 imm)) sSail' := by
+      StateRel (execInstrBr sRv (.ORI rd rs1 imm)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_ITYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sign_extend, Sail.BitVec.signExtend]
@@ -68,14 +76,17 @@ theorem ori_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC, signExtend12]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 theorem xori_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 : Reg) (imm : BitVec 12) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 : Reg) (imm : BitVec 12) :
     ∃ sSail',
       runSail (execute_ITYPE imm (regToRegidx rs1) (regToRegidx rd) iop.XORI) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.XORI rd rs1 imm)) sSail' := by
+      StateRel (execInstrBr sRv (.XORI rd rs1 imm)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_ITYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sign_extend, Sail.BitVec.signExtend]
@@ -84,18 +95,21 @@ theorem xori_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC, signExtend12]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 -- ============================================================================
 -- SLTI, SLTIU (immediate comparisons)
 -- ============================================================================
 
 theorem slti_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 : Reg) (imm : BitVec 12) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 : Reg) (imm : BitVec 12) :
     ∃ sSail',
       runSail (execute_ITYPE imm (regToRegidx rs1) (regToRegidx rd) iop.SLTI) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.SLTI rd rs1 imm)) sSail' := by
+      StateRel (execInstrBr sRv (.SLTI rd rs1 imm)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_ITYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sign_extend, Sail.BitVec.signExtend, slt_value_equiv]
@@ -104,14 +118,17 @@ theorem slti_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC, signExtend12]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 theorem sltiu_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 : Reg) (imm : BitVec 12) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 : Reg) (imm : BitVec 12) :
     ∃ sSail',
       runSail (execute_ITYPE imm (regToRegidx rs1) (regToRegidx rd) iop.SLTIU) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.SLTIU rd rs1 imm)) sSail' := by
+      StateRel (execInstrBr sRv (.SLTIU rd rs1 imm)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_ITYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sign_extend, Sail.BitVec.signExtend, sltu_value_equiv]
@@ -120,18 +137,21 @@ theorem sltiu_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC, signExtend12]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 -- ============================================================================
 -- MV (pseudo: ADDI rd rs 0), NOP (pseudo: ADDI x0 x0 0)
 -- ============================================================================
 
 theorem mv_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs : Reg) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs : Reg) :
     ∃ sSail',
       runSail (execute_ITYPE 0 (regToRegidx rs) (regToRegidx rd) iop.ADDI) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.MV rd rs)) sSail' := by
+      StateRel (execInstrBr sRv (.MV rd rs)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_ITYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sign_extend, Sail.BitVec.signExtend]
@@ -140,18 +160,22 @@ theorem mv_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 theorem nop_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) :
     ∃ sSail',
       runSail (execute_ITYPE 0 (regidx.Regidx 0) (regidx.Regidx 0) iop.ADDI) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv .NOP) sSail' := by
+      StateRel (execInstrBr sRv .NOP) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_ITYPE
   simp only [runSail_bind, runSail_rX_bits_x0, runSail_pure,
     sign_extend, Sail.BitVec.signExtend, runSail_wX_bits_x0]
   exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using hrel.reg_agree r,
-    fun a => by simpa [execInstrBr, MachineState.setPC] using hrel.mem_agree a⟩⟩
+    fun a => by simpa [execInstrBr, MachineState.setPC] using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 end EvmAsm.Rv64.SailEquiv

--- a/EvmAsm/Rv64/SailEquiv/ImmProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/ImmProofs.lean
@@ -37,8 +37,8 @@ theorem addi_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC, signExtend12]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 theorem andi_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -56,8 +56,8 @@ theorem andi_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC, signExtend12]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 theorem ori_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -75,8 +75,8 @@ theorem ori_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC, signExtend12]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 theorem xori_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -94,8 +94,8 @@ theorem xori_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC, signExtend12]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 -- ============================================================================
@@ -117,8 +117,8 @@ theorem slti_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC, signExtend12]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 theorem sltiu_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -136,8 +136,8 @@ theorem sltiu_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC, signExtend12]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 -- ============================================================================
@@ -159,8 +159,8 @@ theorem mv_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 theorem nop_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -175,7 +175,7 @@ theorem nop_sail_equiv (sRv : MachineState) (sSail : SailState)
   simp only [runSail_bind, runSail_rX_bits_x0, runSail_pure,
     sign_extend, Sail.BitVec.signExtend, runSail_wX_bits_x0]
   exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using hrel.reg_agree r,
-    fun a => by simpa [execInstrBr, MachineState.setPC] using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC] using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 end EvmAsm.Rv64.SailEquiv

--- a/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
@@ -259,8 +259,8 @@ theorem mulh_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 theorem mulhsu_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -282,8 +282,8 @@ theorem mulhsu_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 /-- MULHU value: SAIL's mult_to_bits_half Unsigned Unsigned High = rv64_mulhu. -/
@@ -316,8 +316,8 @@ theorem mulhu_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 theorem div_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -337,8 +337,8 @@ theorem div_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 theorem divu_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -358,8 +358,8 @@ theorem divu_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 theorem rem_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -378,8 +378,8 @@ theorem rem_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 theorem remu_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -397,8 +397,8 @@ theorem remu_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 end EvmAsm.Rv64.SailEquiv

--- a/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
@@ -241,13 +241,15 @@ theorem mulhsu_high_equiv (a b : BitVec 64) :
 -- ============================================================================
 
 theorem mulh_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 rs2 : Reg) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 rs2 : Reg) :
     ∃ sSail',
       runSail (execute_MUL (regToRegidx rs2) (regToRegidx rs1) (regToRegidx rd)
         { result_part := VectorHalf.High, signed_rs1 := Signedness.Signed,
           signed_rs2 := Signedness.Signed }) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.MULH rd rs1 rs2)) sSail' := by
+      StateRel (execInstrBr sRv (.MULH rd rs1 rs2)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_MUL
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     show ∀ x y : Word, mult_to_bits_half (l := LeanRV64D.Functions.xlen)
@@ -258,16 +260,19 @@ theorem mulh_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 theorem mulhsu_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 rs2 : Reg) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 rs2 : Reg) :
     ∃ sSail',
       runSail (execute_MUL (regToRegidx rs2) (regToRegidx rs1) (regToRegidx rd)
         { result_part := VectorHalf.High, signed_rs1 := Signedness.Signed,
           signed_rs2 := Signedness.Unsigned }) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.MULHSU rd rs1 rs2)) sSail' := by
+      StateRel (execInstrBr sRv (.MULHSU rd rs1 rs2)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_MUL
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     show ∀ x y : Word, mult_to_bits_half (l := LeanRV64D.Functions.xlen)
@@ -278,7 +283,8 @@ theorem mulhsu_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 /-- MULHU value: SAIL's mult_to_bits_half Unsigned Unsigned High = rv64_mulhu. -/
 theorem mulhu_high_equiv (a b : BitVec 64) :
@@ -292,13 +298,15 @@ theorem mulhu_high_equiv (a b : BitVec 64) :
   omega
 
 theorem mulhu_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 rs2 : Reg) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 rs2 : Reg) :
     ∃ sSail',
       runSail (execute_MUL (regToRegidx rs2) (regToRegidx rs1) (regToRegidx rd)
         { result_part := VectorHalf.High, signed_rs1 := Signedness.Unsigned,
           signed_rs2 := Signedness.Unsigned }) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.MULHU rd rs1 rs2)) sSail' := by
+      StateRel (execInstrBr sRv (.MULHU rd rs1 rs2)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_MUL
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     show ∀ x y : Word, mult_to_bits_half (l := LeanRV64D.Functions.xlen)
@@ -309,14 +317,17 @@ theorem mulhu_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 theorem div_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 rs2 : Reg) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 rs2 : Reg) :
     ∃ sSail',
       runSail (execute_DIV (regToRegidx rs2) (regToRegidx rs1) (regToRegidx rd) false) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.DIV rd rs1 rs2)) sSail' := by
+      StateRel (execInstrBr sRv (.DIV rd rs1 rs2)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_DIV
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     LeanRV64D.Functions.not,
@@ -327,14 +338,17 @@ theorem div_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 theorem divu_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 rs2 : Reg) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 rs2 : Reg) :
     ∃ sSail',
       runSail (execute_DIV (regToRegidx rs2) (regToRegidx rs1) (regToRegidx rd) true) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.DIVU rd rs1 rs2)) sSail' := by
+      StateRel (execInstrBr sRv (.DIVU rd rs1 rs2)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_DIV
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     LeanRV64D.Functions.xlen, LeanRV64D.Functions.not,
@@ -345,14 +359,17 @@ theorem divu_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 theorem rem_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 rs2 : Reg) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 rs2 : Reg) :
     ∃ sSail',
       runSail (execute_REM (regToRegidx rs2) (regToRegidx rs1) (regToRegidx rd) false) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.REM rd rs1 rs2)) sSail' := by
+      StateRel (execInstrBr sRv (.REM rd rs1 rs2)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_REM
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     Bool.false_eq_true, ite_false]
@@ -362,14 +379,17 @@ theorem rem_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 theorem remu_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 rs2 : Reg) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 rs2 : Reg) :
     ∃ sSail',
       runSail (execute_REM (regToRegidx rs2) (regToRegidx rs1) (regToRegidx rd) true) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.REMU rd rs1 rs2)) sSail' := by
+      StateRel (execInstrBr sRv (.REMU rd rs1 rs2)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_REM
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure, ite_true]
   conv in to_bits_truncate _ => rw [remu_full_equiv]
@@ -378,6 +398,7 @@ theorem remu_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 end EvmAsm.Rv64.SailEquiv

--- a/EvmAsm/Rv64/SailEquiv/MemMonad.lean
+++ b/EvmAsm/Rv64/SailEquiv/MemMonad.lean
@@ -1,0 +1,37 @@
+/-
+  EvmAsm.Rv64.SailEquiv.MemMonad
+
+  The Sail monadic reduction (Phase 2, step #2): symbolically executing the Sail
+  golden model's `execute_STORE`/`execute_LOAD` to a closed-form state update, for
+  an aligned access in bare Machine mode.  Built bottom-up as per-layer `runSail_*`
+  lemmas (the `runSail_jump_to` pattern in `MonadLemmas.lean`).
+
+  This file starts with the generic loop lemma `untilFuelM_one` that the
+  single-chunk (aligned) `vmem_*_addr` loop needs.
+-/
+
+import EvmAsm.Rv64.SailEquiv.MonadLemmas
+import EvmAsm.Rv64.SailEquiv.MemReduce
+
+open Sail
+
+namespace EvmAsm.Rv64.SailEquiv
+
+/-- `untilFuelM` with fuel 1 and a **pure** loop condition runs the body exactly
+    once and returns its result (the condition is evaluated but has no effect).
+    For an aligned access `split_misaligned` gives `n = 1`, so the `vmem_*_addr`
+    loop is this single iteration. -/
+theorem untilFuelM_one_pure {α : Type} (g : α → Bool) (init : α) (f : α → SailM α) :
+    untilFuelM 1 (fun x => (Pure.pure (g x) : SailM Bool)) init f = f init := by
+  unfold untilFuelM
+  simp [untilFuelM.go]
+
+/-- Sail's `writeBytes` stores byte `i` as `v.extractLsb' (8*i) 8`; our reassembly
+    lemmas (`MemReduce`) are stated with `extractByte`. They coincide. -/
+theorem extractByte_eq_extractLsb' (v : Word) (i : Nat) :
+    extractByte v i = v.extractLsb' (8 * i) 8 := by
+  simp only [extractByte, BitVec.extractLsb', Nat.mul_comm i 8]
+  apply BitVec.eq_of_toNat_eq
+  simp [BitVec.toNat_setWidth, BitVec.toNat_ushiftRight, BitVec.toNat_ofNat]
+
+end EvmAsm.Rv64.SailEquiv

--- a/EvmAsm/Rv64/SailEquiv/MemMonad.lean
+++ b/EvmAsm/Rv64/SailEquiv/MemMonad.lean
@@ -14,6 +14,7 @@ import EvmAsm.Rv64.SailEquiv.MonadLemmas
 import EvmAsm.Rv64.SailEquiv.MemReduce
 
 open Sail
+open LeanRV64D.Functions
 
 namespace EvmAsm.Rv64.SailEquiv
 
@@ -33,5 +34,26 @@ theorem extractByte_eq_extractLsb' (v : Word) (i : Nat) :
   simp only [extractByte, BitVec.extractLsb', Nat.mul_comm i 8]
   apply BitVec.eq_of_toNat_eq
   simp [BitVec.toNat_setWidth, BitVec.toNat_ushiftRight, BitVec.toNat_ofNat]
+
+/-- **Bare-mode address translation.** In Machine privilege with `MPRV = 0` and a
+    non-shadow-stack access, `translateAddr` is the identity: it returns
+    `Ok (Physaddr vaddr, PBMT_PMA, ())` and leaves the state unchanged. -/
+theorem runSail_translateAddr_bare (vAddr : virtaddr) (access : MemoryAccessType mem_payload)
+    (s : SailState) (mstatusVal : BitVec 64)
+    (h_priv : s.regs.get? Register.cur_privilege = some Privilege.Machine)
+    (h_mstatus : s.regs.get? Register.mstatus = some mstatusVal)
+    (h_mprv : _get_Mstatus_MPRV mstatusVal = 0#1)
+    (h_ss : is_shadow_stack_access access = Pure.pure false) :
+    runSail (translateAddr vAddr access) s =
+      some (Ok (physaddr.Physaddr (zero_extend (m := 64) (bits_of_virtaddr vAddr)),
+        page_based_mem_type.PBMT_PMA, init_ext_ptw), s) := by
+  unfold translateAddr
+  simp (config := { decide := true }) [runSail, SailME.run, PreSail.PreSailME.run,
+    effectivePrivilege, translationMode, h_ss, h_mprv,
+    PreSail.readReg, h_priv, h_mstatus,
+    ExceptT.run, ExceptT.mk, ExceptT.pure, ExceptT.bind, ExceptT.bindCont, ExceptT.lift,
+    MonadLift.monadLift, monadLift, liftM, Functor.map,
+    Pure.pure, EStateM.pure, Bind.bind, bind, EStateM.bind, EStateM.map, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get, bne]
 
 end EvmAsm.Rv64.SailEquiv

--- a/EvmAsm/Rv64/SailEquiv/MemReduce.lean
+++ b/EvmAsm/Rv64/SailEquiv/MemReduce.lean
@@ -1,0 +1,75 @@
+/-
+  EvmAsm.Rv64.SailEquiv.MemReduce
+
+  Bare-mode memory reduction for the Sail golden-model equivalence (Phase 2).
+
+  Develops the lemmas to discharge the `MemProofs.lean` load/store stubs in the
+  **forward** (evm-asm ⇒ Sail) direction, under bare translation mode (Machine
+  privilege, `satp = 0`) and an aligned access — the regime evm-asm always
+  operates in (`stepResult s ≠ .trap .misalignedAccess`).
+
+  Built bottom-up. This file currently provides the pure little-endian reassembly
+  identity connecting Sail's byte memory to the dword view of `StateRel.mem_agree`.
+-/
+
+import EvmAsm.Rv64.SailEquiv.StateRel
+import EvmAsm.Rv64.ByteOps
+
+open Sail
+
+namespace EvmAsm.Rv64.SailEquiv
+
+open EvmAsm.Rv64
+
+/-- **Byte extensionality** for 64-bit words: two words agreeing on all eight
+    bytes are equal. -/
+theorem byte_ext {x y : Word} (h : ∀ i : Fin 8, extractByte x i.val = extractByte y i.val) :
+    x = y := by
+  apply BitVec.eq_of_getLsbD_eq
+  intro j hj
+  have hlt : j / 8 < 8 := by omega
+  have hb := congrArg (fun b : BitVec 8 => b.getLsbD (j % 8)) (h ⟨j / 8, hlt⟩)
+  have hidx : j / 8 * 8 + j % 8 = j := by omega
+  have hm : j % 8 < 8 := by omega
+  simpa [extractByte, hidx, hm] using hb
+
+/-- Packing a word's own bytes (little-endian) recovers the word. -/
+theorem packDword_extractByte (v : Word) :
+    packDword (fun i => extractByte v i.val) = v := by
+  apply byte_ext
+  intro i
+  exact extractByte_packDword
+
+/-- `reconstructDword` is `packDword` over the eight bytes read from the map. -/
+theorem reconstructDword_eq_packDword (mem : Std.ExtHashMap Nat (BitVec 8)) (addr : Nat) :
+    reconstructDword mem addr = packDword (fun i : Fin 8 => mem.getD (addr + i.val) 0) := rfl
+
+/-- **Little-endian reassembly.** If the eight bytes at `addr … addr+7` are the
+    byte slices of a 64-bit value `v` (byte `i` = `extractByte v i`), then
+    `reconstructDword` recovers `v`.  This bridges Sail's byte-level memory
+    (written little-endian by `writeBytes`) to the dword view of
+    `StateRel.mem_agree`. -/
+theorem reconstructDword_of_bytes
+    (mem : Std.ExtHashMap Nat (BitVec 8)) (addr : Nat) (v : Word)
+    (h : ∀ i, i < 8 → mem.getD (addr + i) 0 = extractByte v i) :
+    reconstructDword mem addr = v := by
+  rw [reconstructDword_eq_packDword]
+  have hfun : (fun i : Fin 8 => mem.getD (addr + i.val) 0)
+      = (fun i : Fin 8 => extractByte v i.val) := by
+    funext i; exact h i.val i.isLt
+  rw [hfun, packDword_extractByte]
+
+/-- `reconstructDword` reads only the eight bytes at `addr … addr+7`, so it is
+    invariant under changes elsewhere.  Combined with the 8-aligned disjointness of
+    distinct doublewords, this is how an aligned store leaves *other* dwords'
+    `mem_agree` untouched. -/
+theorem reconstructDword_congr
+    {mem mem' : Std.ExtHashMap Nat (BitVec 8)} {addr : Nat}
+    (h : ∀ i, i < 8 → mem'.getD (addr + i) 0 = mem.getD (addr + i) 0) :
+    reconstructDword mem' addr = reconstructDword mem addr := by
+  rw [reconstructDword_eq_packDword, reconstructDword_eq_packDword]
+  congr 1
+  funext i
+  exact h i.val i.isLt
+
+end EvmAsm.Rv64.SailEquiv

--- a/EvmAsm/Rv64/SailEquiv/ShiftProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/ShiftProofs.lean
@@ -64,8 +64,8 @@ theorem slli_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 theorem srli_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -83,8 +83,8 @@ theorem srli_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 theorem srai_sail_equiv (sRv : MachineState) (sSail : SailState)
@@ -102,8 +102,8 @@ theorem srai_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
-    fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩,
+    fun a ha => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
+                 using hrel.mem_agree a ha⟩,
     by simp [h_nextpc]⟩
 
 end EvmAsm.Rv64.SailEquiv

--- a/EvmAsm/Rv64/SailEquiv/ShiftProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/ShiftProofs.lean
@@ -50,11 +50,13 @@ private theorem sra_extractLsb_bv6 (v : BitVec 64) (shamt : BitVec 6) :
 -- ============================================================================
 
 theorem slli_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 : Reg) (shamt : BitVec 6) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 : Reg) (shamt : BitVec 6) :
     ∃ sSail',
       runSail (execute_SHIFTIOP shamt (regToRegidx rs1) (regToRegidx rd) sop.SLLI) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.SLLI rd rs1 shamt)) sSail' := by
+      StateRel (execInstrBr sRv (.SLLI rd rs1 shamt)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_SHIFTIOP
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sll_extractLsb_bv6]
@@ -63,14 +65,17 @@ theorem slli_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 theorem srli_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 : Reg) (shamt : BitVec 6) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 : Reg) (shamt : BitVec 6) :
     ∃ sSail',
       runSail (execute_SHIFTIOP shamt (regToRegidx rs1) (regToRegidx rd) sop.SRLI) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.SRLI rd rs1 shamt)) sSail' := by
+      StateRel (execInstrBr sRv (.SRLI rd rs1 shamt)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_SHIFTIOP
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     srl_extractLsb_bv6]
@@ -79,14 +84,17 @@ theorem srli_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 theorem srai_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 : Reg) (shamt : BitVec 6) :
+    (hrel : StateRel sRv sSail)
+    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4)) (rd rs1 : Reg) (shamt : BitVec 6) :
     ∃ sSail',
       runSail (execute_SHIFTIOP shamt (regToRegidx rs1) (regToRegidx rd) sop.SRAI) sSail
         = some (RETIRE_SUCCESS, sSail') ∧
-      StateRel (execInstrBr sRv (.SRAI rd rs1 shamt)) sSail' := by
+      StateRel (execInstrBr sRv (.SRAI rd rs1 shamt)) sSail' ∧
+      sSail'.regs.get? Register.nextPC = some (sRv.pc + 4) := by
   unfold execute_SHIFTIOP
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sra_extractLsb_bv6]
@@ -95,6 +103,7 @@ theorem srai_sail_equiv (sRv : MachineState) (sSail : SailState)
     fun r => by simpa [execInstrBr, MachineState.setPC]
                  using reg_agree_after_insert sSail sRv hrel rd _ r,
     fun a => by simpa [execInstrBr, MachineState.setPC, MachineState.getMem]
-                 using hrel.mem_agree a⟩⟩
+                 using hrel.mem_agree a⟩,
+    by simp [h_nextpc]⟩
 
 end EvmAsm.Rv64.SailEquiv

--- a/EvmAsm/Rv64/SailEquiv/StateRel.lean
+++ b/EvmAsm/Rv64/SailEquiv/StateRel.lean
@@ -241,8 +241,16 @@ def sailStateWithReg (sSail : SailState) (rd : Reg) (v : BitVec 64) : SailState 
 structure StateRel (sRv : MachineState) (sSail : SailState) : Prop where
   /-- Registers agree on all 32 integer registers. -/
   reg_agree : ∀ (r : Reg), sailRegVal sSail r = some (sRv.getReg r)
-  /-- Memory agrees: SAIL bytes reconstruct to Rv64 doublewords. -/
-  mem_agree : ∀ (a : BitVec 64),
+  /-- Memory agrees on **8-aligned doublewords**: the SAIL bytes at `a` reconstruct
+      to the Rv64 doubleword `getMem a`.
+
+      Restricted to 8-aligned `a` because Rv64 `mem` is dword-granular (a store is a
+      single-point `setMem`), so the unrestricted ∀-byte form (overlapping 8-byte
+      windows at every offset) cannot be preserved by a store — the byte write would
+      change the windows at the seven preceding offsets, which the dword-granular
+      `mem` does not track. Distinct 8-aligned dwords are disjoint, so an 8-aligned
+      store *does* preserve this form. -/
+  mem_agree : ∀ (a : BitVec 64), a.toNat % 8 = 0 →
     reconstructDword sSail.mem a.toNat = sRv.getMem a
 
 /-- Inserting the `PC` register preserves `StateRel`: `PC` is not in the tracked
@@ -254,7 +262,7 @@ theorem stateRel_PC_insert {sRv : MachineState} {sSail : SailState}
   ⟨fun r => by
     have ha := hrel.reg_agree r
     cases r <;> simpa [sailRegVal, Std.ExtDHashMap.get?_insert] using ha,
-   fun a => hrel.mem_agree a⟩
+   fun a ha => hrel.mem_agree a ha⟩
 
 /-- PC-aware abstraction relation: `StateRel` (registers + memory) plus agreement
     of the committed `PC`.  This is the step-stable relation that holds at each

--- a/PLAN.md
+++ b/PLAN.md
@@ -557,6 +557,18 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
     uniformly by the `@[simp] sailStateWithReg_get?_nextPC` helper + `h_nextpc`).
     So every non-memory instruction's equivalence theorem now pins the PC
     behaviour — the prerequisite the uniform step theorem consumes.
+  - **MisalignedAccess trap distinction (DONE).** So memory soundness can be
+    stated cleanly ("unless a misaligned access happens"), `Execution.lean` gains a
+    trap-aware companion to `step` — *without* touching `step`/`stepN` (which
+    underpin `cpsTriple` and ~all proofs). `TrapKind` (`misalignedAccess | other`,
+    extensible) + `StepResult` (`ok | trap`); `isMisalignedAccess` flags an
+    in-range-but-misaligned memory access (splitting the conflated
+    `isValidMemAddr && isAligned*` guard); `stepResult s := if isMisalignedAccess s
+    then .trap .misalignedAccess else stepResultOfOption (step s)`. Bridge
+    `step_eq_stepResult_toOption : step s = (stepResult s).toOption` (+
+    `stepResult_ok_iff`, `isMisalignedAccess_imp_step_none`) connects it to the
+    `step`/`stepN` corpus. Axiom-clean (`propext`/`Quot.sound`), 0 sorry, full
+    `EvmAsm.Rv64` builds untouched.
   - **Remaining.** (1) A uniform `step_sail_equiv` dispatching via `InstrMap.lean`
     over a decoded instruction (composes the per-class results via
     `step_of_execute`; blocked on the memory class below, since it must cover

--- a/PLAN.md
+++ b/PLAN.md
@@ -550,9 +550,17 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
     `execute_* ; tick_pc` lands `StateRelPC (execInstrBr sRv i)` — so
     BEQ/BNE/BLT/BGE/BLTU/BGEU/JAL/JALR now have their **target PC verified against
     the golden model**. Axiom-clean (track footprint), 0 sorry, no `bv_decide`.
-  - **Remaining.** (1) Thread `nextPC = pc+4` through the non-control classes
-    (ALU/Imm/Shift/MExt/Mem leave `nextPC` untouched) + a uniform `step_sail_equiv`
-    dispatching via `InstrMap.lean` over a decoded instruction. (2) **Memory: the
+  - **Non-control PC threading (DONE).** All 32 non-control `*_sail_equiv`
+    theorems (ALU/Imm/Shift/MExt — RTYPE/ITYPE/UTYPE/SHIFTIOP/ADDIW/MUL/DIV/REM)
+    now take `h_nextpc : nextPC = pc+4` and additionally conclude
+    `nextPC = pc+4` (these instructions leave `nextPC` untouched; discharged
+    uniformly by the `@[simp] sailStateWithReg_get?_nextPC` helper + `h_nextpc`).
+    So every non-memory instruction's equivalence theorem now pins the PC
+    behaviour — the prerequisite the uniform step theorem consumes.
+  - **Remaining.** (1) A uniform `step_sail_equiv` dispatching via `InstrMap.lean`
+    over a decoded instruction (composes the per-class results via
+    `step_of_execute`; blocked on the memory class below, since it must cover
+    LD/SD). (2) **Memory: the
     `MemProofs.lean` stubs.** Every load/store is a `*_sail_equiv_stub` that
     *assumes* an `h_exec` hypothesis (Sail `execute_LOAD/STORE` already succeeds +
     lands in `StateRel`); discharge it by reducing Sail `vmem_read`/`vmem_write` in


### PR DESCRIPTION
Follow-up to #9527 (which verified branch/jump **target PC** against the Sail golden model). That PR merged with only its first commit; this PR carries the rest of that work plus the start of the memory-equivalence reduction.

## Contents

**Finishing the PC / control-flow story**
- **Non-control `nextPC` threading** — all 32 non-control `*_sail_equiv` theorems (ALU/Imm/Shift/MExt) now additionally pin `nextPC = pc+4`, so every non-memory instruction's equivalence verifies the PC behaviour (the prerequisite a uniform step theorem will consume).
- **Trap-aware `stepResult`** (`Execution.lean`) — `step` collapses every trap to `none`; to state memory soundness cleanly ("unless a misaligned access happens") this adds a companion result type **without touching `step`/`stepN`** (which underpin `cpsTriple` and ~all proofs): `TrapKind` (`misalignedAccess | other`, extensible), `StepResult`, `isMisalignedAccess` (splits the conflated `isValidMemAddr && isAligned*` guard), and the bridge `step_eq_stepResult_toOption` (+ `stepResult_ok_iff`, `isMisalignedAccess_imp_step_none`).

**Memory-equivalence reduction (toward discharging the `MemProofs.lean` LD/SD stubs)**
- **`mem_agree` restricted to 8-aligned doublewords** (`StateRel.lean`) — the unrestricted ∀-byte form is unmaintainable across a store (Rv64 `mem` is dword-granular / single-point `setMem`); aligned dwords are disjoint, so an 8-aligned store preserves it. Mechanical ripple threaded through all `StateRel` constructions.
- **`MemReduce.lean`** — the pure little-endian reassembly core: `byte_ext`, `packDword_extractByte`, `reconstructDword_eq_packDword`, `reconstructDword_of_bytes` (Sail's `writeBytes` bytes reassemble to the value), `reconstructDword_congr` (an aligned store leaves other dwords untouched). Reuses `ByteOps.packDword`/`extractByte`.
- **`MemMonad.lean`** — the Sail monadic reduction, bottom-up: `untilFuelM_one_pure` (the aligned single-chunk loop), `extractByte_eq_extractLsb'`, and **`runSail_translateAddr_bare`** (Machine + `MPRV=0` + non-shadow-stack ⇒ `translateAddr` is the identity — the first deep per-layer `runSail_*` reduction, establishing the simp recipe).

## Status / next
The LD/SD stub discharge is **in progress**: remaining layers are `runSail_phys_access_check_ok` (under an assumed bare-Machine platform context — PMP permits / not-MMIO), `runSail_write_ram`/`_read_ram`, `writeBytes_effect`/`readBytes_effect`, then `runSail_vmem_{write,read}_bare` and the `MemProofs.lean` LD/SD discharge. Per the maintainer's note, only the forward (evm-asm ⇒ Sail) direction is proven, under the no-misaligned-access (alignment) precondition.

Builds green (`lake build EvmAsm.Rv64`, ~1241 jobs); no `sorry`, no `bv_decide`/`native_decide`; axiom-clean (the three classical axioms; SailEquiv lemmas additionally carry the Sail model's `sys_enable_experimental_extensions`, as the whole track does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)