### PR TITLE
feat(sail-equiv): write_ram/writeBytes reduction (toward LD/SD memory equivalence)

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/MemMonad.lean
+++ b/EvmAsm/Rv64/SailEquiv/MemMonad.lean
@@ -84,4 +84,25 @@ theorem runSail_write_ram (addr : physaddrbits) (data : BitVec 64) (s : SailStat
     MonadStateOf.modifyGet, MonadState.modifyGet, EStateM.modifyGet,
     Bind.bind, bind, EStateM.bind, Pure.pure, EStateM.pure, Fin.succ]
 
+/-- In Machine privilege with `MPRV = 0`, `mem_write_value` for a plain store
+    (`aq=rl=con=false`) reduces to `checked_mem_write` at `Machine` privilege:
+    `effectivePrivilege` returns `Machine`, the release/conditional alignment guard
+    is skipped, and the post-write callbacks are no-ops. -/
+theorem runSail_mem_write_value_to_checked (paddr : physaddr) (data : BitVec 64)
+    (s : SailState) (m : BitVec 64)
+    (h_priv : s.regs.get? Register.cur_privilege = some Privilege.Machine)
+    (h_mstatus : s.regs.get? Register.mstatus = some m)
+    (h_mprv : _get_Mstatus_MPRV m = 0#1) :
+    runSail (mem_write_value paddr 8 data (MemoryAccessType.Store mem_payload.Data)
+        page_based_mem_type.PBMT_PMA false false false) s =
+      runSail (checked_mem_write paddr 8 data (MemoryAccessType.Store mem_payload.Data)
+        page_based_mem_type.PBMT_PMA Privilege.Machine default_meta false false false) s := by
+  unfold mem_write_value mem_write_value_meta mem_write_value_priv_meta
+  simp (config := { decide := true }) [runSail, effectivePrivilege, h_mprv,
+    PreSail.readReg, h_priv, h_mstatus,
+    Pure.pure, EStateM.pure, Bind.bind, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get, bne]
+  cases checked_mem_write paddr 8 data (MemoryAccessType.Store mem_payload.Data)
+    page_based_mem_type.PBMT_PMA Privilege.Machine default_meta false false false s <;> rfl
+
 end EvmAsm.Rv64.SailEquiv

--- a/EvmAsm/Rv64/SailEquiv/MemMonad.lean
+++ b/EvmAsm/Rv64/SailEquiv/MemMonad.lean
@@ -70,4 +70,18 @@ theorem runSail_translateAddr_bare (vAddr : virtaddr) (access : MemoryAccessType
     Pure.pure, EStateM.pure, Bind.bind, bind, EStateM.bind, EStateM.map, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get, bne]
 
+/-- `write_ram` (plain write of a doubleword) reduces to its underlying
+    `writeBytes`: the physical-memory interface decomposes the value into
+    little-endian bytes and returns success. -/
+theorem runSail_write_ram (addr : physaddrbits) (data : BitVec 64) (s : SailState) :
+    runSail (write_ram write_kind.Write_plain (physaddr.Physaddr addr) 8 data ()) s =
+      runSail (PreSail.writeBytes (n := 8) addr.toNat data) s := by
+  rw [writeBytes_effect]
+  unfold write_ram
+  simp [runSail, PreSail.ConcurrencyInterfaceV1.sail_mem_write, PreSail.writeBytes,
+    List.ofFn_succ, List.ofFn_zero,
+    List.forM_cons, List.forM_nil, PreSail.writeByte, modify, modifyGet,
+    MonadStateOf.modifyGet, MonadState.modifyGet, EStateM.modifyGet,
+    Bind.bind, bind, EStateM.bind, Pure.pure, EStateM.pure, Fin.succ]
+
 end EvmAsm.Rv64.SailEquiv

--- a/EvmAsm/Rv64/SailEquiv/MemMonad.lean
+++ b/EvmAsm/Rv64/SailEquiv/MemMonad.lean
@@ -35,6 +35,20 @@ theorem extractByte_eq_extractLsb' (v : Word) (i : Nat) :
   apply BitVec.eq_of_toNat_eq
   simp [BitVec.toNat_setWidth, BitVec.toNat_ushiftRight, BitVec.toNat_ofNat]
 
+/-- State effect of an 8-byte `writeBytes`: registers unchanged; the doubleword's
+    eight little-endian byte slices are written at `addr … addr+7`, everything else
+    left alone. -/
+theorem writeBytes_effect (addr : Nat) (v : BitVec 64) (s : SailState) :
+    runSail (PreSail.writeBytes (n := 8) addr v) s = some (true,
+      { s with mem :=
+        (((((((s.mem.insert addr (v.extractLsb' 0 8)).insert (addr + 1) (v.extractLsb' 8 8)).insert
+          (addr + 2) (v.extractLsb' 16 8)).insert (addr + 3) (v.extractLsb' 24 8)).insert
+          (addr + 4) (v.extractLsb' 32 8)).insert (addr + 5) (v.extractLsb' 40 8)).insert
+          (addr + 6) (v.extractLsb' 48 8)).insert (addr + 7) (v.extractLsb' 56 8) }) := by
+  simp [runSail, PreSail.writeBytes, List.ofFn_succ, List.ofFn_zero, List.forM_cons, List.forM_nil,
+    PreSail.writeByte, modify, modifyGet, MonadStateOf.modifyGet, MonadState.modifyGet,
+    EStateM.modifyGet, Bind.bind, bind, EStateM.bind, Pure.pure, EStateM.pure, Fin.succ]
+
 /-- **Bare-mode address translation.** In Machine privilege with `MPRV = 0` and a
     non-shadow-stack access, `translateAddr` is the identity: it returns
     `Ok (Physaddr vaddr, PBMT_PMA, ())` and leaves the state unchanged. -/


### PR DESCRIPTION
Continues the Sail memory-equivalence reduction (follow-up to #9528). Two more bottom-up layers of the store path:

- **`writeBytes_effect`** — running Sail's `writeBytes` for a 64-bit value reduces to the concrete state in which the eight little-endian byte slices `v.extractLsb' (8*i) 8` are inserted at `addr … addr+7`, registers unchanged. (Re-landed: it was pushed to #9528's branch just after that PR merged, so it didn't make it in.)
- **`runSail_write_ram`** — a plain `write_ram` of a doubleword reduces to that `writeBytes` (the physical-memory interface decomposes the value into bytes and reports success).

Together with the already-merged `runSail_translateAddr_bare`, `untilFuelM_one_pure`, and the `MemReduce` reassembly lemmas (`reconstructDword_of_bytes`/`_congr`), these are the leaves of the eventual LD/SD `*_sail_equiv` discharge.

**Next** (subsequent PRs): `checked_mem_write`/`mem_write_value` (under an assumed bare-Machine platform context — PMP permits, address not MMIO), `runSail_vmem_write_bare`, `execute_STORE`, then dropping `h_exec` from the LD/SD stubs in `MemProofs.lean`. Forward (evm-asm ⇒ Sail) direction only, under the no-misaligned-access precondition.

Builds green (`lake build EvmAsm.Rv64`, 1241 jobs); no `sorry`, no `bv_decide`/`native_decide`; axiom-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)