### PR TITLE
feat(sail-equiv): mem_write_value fully reduced to the writeBytes state

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/MemMonad.lean
+++ b/EvmAsm/Rv64/SailEquiv/MemMonad.lean
@@ -105,4 +105,25 @@ theorem runSail_mem_write_value_to_checked (paddr : physaddr) (data : BitVec 64)
   cases checked_mem_write paddr 8 data (MemoryAccessType.Store mem_payload.Data)
     page_based_mem_type.PBMT_PMA Privilege.Machine default_meta false false false s <;> rfl
 
+/-- `runSail` commutes with `Functor.map`. -/
+theorem runSail_map {α β : Type} (f : α → β) (m : SailM α) (s : SailState) :
+    runSail (f <$> m) s = (runSail m s).map (fun p => (f p.1, p.2)) := by
+  simp only [runSail, Functor.map, EStateM.map]
+  cases m s <;> rfl
+
+/-- `checked_mem_write` under the assumed bare-Machine platform context: the
+    access passes the PMP/PMA check (`phys_access_check = none`) and is plain RAM
+    (`within_mmio_writable = false`), so it performs the plain `write_ram` and
+    reports `Ok`. `h_wr` supplies `write_ram`'s reduced result (state `s'`). -/
+theorem runSail_checked_mem_write_bare (paddr : physaddr) (data : BitVec 64) (s s' : SailState)
+    (h_pac : runSail (phys_access_check (MemoryAccessType.Store mem_payload.Data)
+        page_based_mem_type.PBMT_PMA Privilege.Machine paddr 8 false) s = some (Option.none, s))
+    (h_mmio : runSail (within_mmio_writable paddr 8) s = some (false, s))
+    (h_wr : runSail (write_ram write_kind.Write_plain paddr 8 data default_meta) s = some (true, s')) :
+    runSail (checked_mem_write paddr 8 data (MemoryAccessType.Store mem_payload.Data)
+        page_based_mem_type.PBMT_PMA Privilege.Machine default_meta false false false) s =
+      some (Result.Ok true, s') := by
+  unfold checked_mem_write
+  simp [runSail_bind, h_pac, h_mmio, write_kind_of_flags, runSail_map, h_wr]
+
 end EvmAsm.Rv64.SailEquiv

--- a/EvmAsm/Rv64/SailEquiv/MemMonad.lean
+++ b/EvmAsm/Rv64/SailEquiv/MemMonad.lean
@@ -126,4 +126,30 @@ theorem runSail_checked_mem_write_bare (paddr : physaddr) (data : BitVec 64) (s 
   unfold checked_mem_write
   simp [runSail_bind, h_pac, h_mmio, write_kind_of_flags, runSail_map, h_wr]
 
+/-- **`mem_write_value` fully reduced** (bare-Machine, plain doubleword store): it
+    succeeds (`Ok true`) and produces exactly the `writeBytes` state — the eight
+    little-endian byte slices of `data` written at `addr.toNat … +7`. Composes
+    `mem_write_value → checked_mem_write → write_ram → writeBytes`. -/
+theorem runSail_mem_write_value_bare (addr : physaddrbits) (data : BitVec 64)
+    (s : SailState) (m : BitVec 64)
+    (h_priv : s.regs.get? Register.cur_privilege = some Privilege.Machine)
+    (h_mstatus : s.regs.get? Register.mstatus = some m)
+    (h_mprv : _get_Mstatus_MPRV m = 0#1)
+    (h_pac : runSail (phys_access_check (MemoryAccessType.Store mem_payload.Data)
+        page_based_mem_type.PBMT_PMA Privilege.Machine (physaddr.Physaddr addr) 8 false) s
+        = some (Option.none, s))
+    (h_mmio : runSail (within_mmio_writable (physaddr.Physaddr addr) 8) s = some (false, s)) :
+    runSail (mem_write_value (physaddr.Physaddr addr) 8 data
+        (MemoryAccessType.Store mem_payload.Data) page_based_mem_type.PBMT_PMA false false false) s
+      = some (Result.Ok true,
+        { s with mem :=
+          (((((((s.mem.insert addr.toNat (data.extractLsb' 0 8)).insert
+            (addr.toNat + 1) (data.extractLsb' 8 8)).insert
+            (addr.toNat + 2) (data.extractLsb' 16 8)).insert (addr.toNat + 3) (data.extractLsb' 24 8)).insert
+            (addr.toNat + 4) (data.extractLsb' 32 8)).insert (addr.toNat + 5) (data.extractLsb' 40 8)).insert
+            (addr.toNat + 6) (data.extractLsb' 48 8)).insert (addr.toNat + 7) (data.extractLsb' 56 8) }) := by
+  rw [runSail_mem_write_value_to_checked _ _ _ _ h_priv h_mstatus h_mprv]
+  exact runSail_checked_mem_write_bare (physaddr.Physaddr addr) data s _ h_pac h_mmio
+    ((runSail_write_ram addr data s).trans (writeBytes_effect addr.toNat data s))
+
 end EvmAsm.Rv64.SailEquiv


### PR DESCRIPTION
Continues the Sail store-path reduction (follow-up to #9529). Reaches a milestone: **`mem_write_value` is reduced end-to-end** to the concrete byte-write state.

- **`runSail_checked_mem_write_bare`** — under the assumed bare-Machine platform context (`phys_access_check = none`, `within_mmio_writable = false`), `checked_mem_write` performs the plain `write_ram` and reports `Ok true`. (Re-landed: it was pushed to #9529's branch just after that PR merged.)
- **`runSail_map`** — `runSail` commutes with `Functor.map` (for the `Ok <$> write_ram` tail).
- **`runSail_mem_write_value_bare`** — the milestone: a plain doubleword store in bare Machine mode (`cur_privilege = Machine`, `mstatus.MPRV = 0`) makes `mem_write_value` succeed (`Ok true`) and produce exactly the `writeBytes` state (the eight little-endian byte slices of `data` at `addr.toNat … +7`). Composes `mem_write_value → checked_mem_write → write_ram → writeBytes`.

The resulting byte state is read back by the already-merged `reconstructDword_of_bytes`/`_congr`.

**Next** (subsequent PR): `vmem_write_addr` — the outer layer that wraps `translateAddr` + `mem_write_ea` + `mem_write_value` in the misaligned-split loop. Note: that loop runs in the `SailME` (ExceptT) monad, so it needs a `SailME`-level single-iteration lemma (the existing `untilFuelM_one_pure` is `SailM`-specific). Then `execute_STORE` and dropping `h_exec` from the LD/SD stubs. Forward (evm-asm ⇒ Sail) direction, under the no-misaligned-access precondition.

Builds green (`lake build EvmAsm.Rv64`, 1241 jobs); no `sorry`, no `bv_decide`/`native_decide`; axiom-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)