### PR TITLE
feat(sail-equiv): monad-generic untilFuelM_one_pure for the SailME loop

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/MemMonad.lean
+++ b/EvmAsm/Rv64/SailEquiv/MemMonad.lean
@@ -27,6 +27,14 @@ theorem untilFuelM_one_pure {α : Type} (g : α → Bool) (init : α) (f : α �
   unfold untilFuelM
   simp [untilFuelM.go]
 
+/-- Monad-generic version of `untilFuelM_one_pure`, for the `SailME` (ExceptT) loop
+    in `vmem_write_addr`/`vmem_read_addr`. -/
+theorem untilFuelM_one_pure_gen {m : Type → Type} [Monad m] [LawfulMonad m] {α : Type}
+    (g : α → Bool) (init : α) (f : α → m α) :
+    untilFuelM 1 (fun x => (Pure.pure (g x) : m Bool)) init f = f init := by
+  unfold untilFuelM
+  simp [untilFuelM.go]
+
 /-- Sail's `writeBytes` stores byte `i` as `v.extractLsb' (8*i) 8`; our reassembly
     lemmas (`MemReduce`) are stated with `extractByte`. They coincide. -/
 theorem extractByte_eq_extractLsb' (v : Word) (i : Nat) :


### PR DESCRIPTION
Small prerequisite for the next store-path layer (`vmem_write_addr`), following the merged #9530.

`untilFuelM_one_pure_gen` generalises the existing `untilFuelM_one_pure` (which was `SailM`-specific) to any `[Monad m] [LawfulMonad m]`: with `fuel = 1` and a pure loop condition, the loop runs its body exactly once and returns the result. The `vmem_write_addr`/`vmem_read_addr` misaligned-split loop runs in the `SailME` (ExceptT) monad rather than `SailM`, so it needs this generic form.

(`Pure.pure` is written explicitly to avoid the sep-logic `⌜·⌝` coercion that captures unqualified `pure` inside `namespace EvmAsm.Rv64.SailEquiv`.)

Builds green; axiom-clean; no `sorry`, no `bv_decide`/`native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)