### PR TITLE
feat(rlp): add WP withdrawal decode facade

### DIFF
--- a/EvmAsm/Rv64.lean
+++ b/EvmAsm/Rv64.lean
@@ -12,6 +12,7 @@ import EvmAsm.Rv64.HintSpecs
 import EvmAsm.Rv64.ControlFlow
 -- WP: backward, soundness-first calculators over bounded CPS triples.
 import EvmAsm.Rv64.WP
+import EvmAsm.Rv64.CPSCall
 -- RunBlock → SeqFrame → {XCancel → XPerm, PerfTrace, InstructionSpecs} + SpecDb.
 -- LiftSpec → XSimp → XPerm.
 import EvmAsm.Rv64.Tactics.RunBlock

--- a/EvmAsm/Rv64/CPSCall.lean
+++ b/EvmAsm/Rv64/CPSCall.lean
@@ -1,0 +1,27 @@
+/-
+  EvmAsm.Rv64.CPSCall
+
+  Compatibility import for direct-call composition.  New proof scripts should
+  prefer `EvmAsm.Rv64.WP.Call`, but this root-level theorem keeps older
+  #9522-style CPS scripts easy to adapt.
+-/
+
+import EvmAsm.Rv64.WP.Call
+
+namespace EvmAsm.Rv64
+
+/-- Root-namespace compatibility alias for `WP.cpsCallWithin`. -/
+theorem cpsCallWithin {nSteps : Nat} {callerPC calleeEntry vOld : Word}
+    {calleeCode : CodeReq} {Prest Q : Assertion} (offset : BitVec 21)
+    (hoffset : callerPC + signExtend21 offset = calleeEntry)
+    (halign : (callerPC + 4) &&& ~~~(1 : Word) = callerPC + 4)
+    (hPrest : Prest.pcFree)
+    (hdisj : (CodeReq.singleton callerPC (.JAL .x1 offset)).Disjoint calleeCode)
+    (hcallee : cpsTripleWithin nSteps calleeEntry ((callerPC + 4) &&& ~~~(1 : Word))
+      calleeCode ((.x1 ↦ᵣ (callerPC + 4)) ** Prest) Q) :
+    cpsTripleWithin (1 + nSteps) callerPC (callerPC + 4)
+      ((CodeReq.singleton callerPC (.JAL .x1 offset)).union calleeCode)
+      ((.x1 ↦ᵣ vOld) ** Prest) Q :=
+  WP.cpsCallWithin offset hoffset halign hPrest hdisj hcallee
+
+end EvmAsm.Rv64

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -1143,4 +1143,27 @@ theorem cpsBranchWithin_seq_cpsTripleWithin_taken {nSteps1 nSteps2 : Nat}
     exact ⟨k1, Nat.le_trans hk1 (Nat.le_add_right nSteps1 nSteps2), s1, hstep1,
       Or.inr ⟨hpc_f1, hQ_f1R⟩⟩
 
+/-- Sequence a triple onto the **not-taken** (fall-through) exit of a branch,
+    keeping the taken exit open.  Bounds add and code requirements are unioned. -/
+theorem cpsBranchWithin_seq_cpsTripleWithin_notTaken {nSteps1 nSteps2 : Nat}
+    {entry mid target exit_t : Word} {cr1 cr2 : CodeReq}
+    (hd : cr1.Disjoint cr2)
+    {P Q_t1 Q_f1 Q_f2 : Assertion}
+    (h1 : cpsBranchWithin nSteps1 entry cr1 P exit_t Q_t1 mid Q_f1)
+    (h2 : cpsTripleWithin nSteps2 mid target cr2 Q_f1 Q_f2) :
+    cpsBranchWithin (nSteps1 + nSteps2) entry (cr1.union cr2) P exit_t Q_t1 target Q_f2 := by
+  intro R hR s hcr hPR hpc
+  rw [CodeReq.union_satisfiedBy hd] at hcr
+  obtain ⟨hcr1, hcr2⟩ := hcr
+  obtain ⟨k1, hk1, s1, hstep1, hbranch1⟩ := h1 R hR s hcr1 hPR hpc
+  rcases hbranch1 with ⟨hpc_t1, hQ_t1R⟩ | ⟨hpc_f1, hQ_f1R⟩
+  · -- taken: keep the taken exit open.
+    exact ⟨k1, Nat.le_trans hk1 (Nat.le_add_right nSteps1 nSteps2), s1, hstep1,
+      Or.inl ⟨hpc_t1, hQ_t1R⟩⟩
+  · -- not-taken: continue into the follow-on triple.
+    have hcr2' := CodeReq.SatisfiedBy_preserved hstep1 hcr2
+    obtain ⟨k2, hk2, s2, hstep2, hpc2, hQ_f2R⟩ := h2 R hR s1 hcr2' hQ_f1R hpc_f1
+    exact ⟨k1 + k2, Nat.add_le_add hk1 hk2, s2, stepN_add_eq hstep1 hstep2,
+      Or.inr ⟨hpc2, hQ_f2R⟩⟩
+
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -688,6 +688,40 @@ theorem cpsNBranchWithin_extend_head_nbranch_disjoint {nSteps1 nSteps2 : Nat}
       exact ⟨k1, Nat.le_trans hk1 (Nat.le_add_right nSteps1 nSteps2), s1, hstep1,
         ex, List.mem_append_right exits htail, hpc1, hQF⟩
 
+/-- Extend the second exit of a bounded N-branch with another bounded N-branch
+    over disjoint tail code, preserving the first exit. This supports generated
+    left-to-right CFG proofs that classify one early exit and continue the
+    fall-through arm. -/
+theorem cpsNBranchWithin_extend_second_nbranch_disjoint {nSteps1 nSteps2 : Nat}
+    {entry head l : Word} {cr1 cr2 : CodeReq}
+    {P H Q : Assertion}
+    {exits others : List (Word × Assertion)}
+    (hd : cr1.Disjoint cr2)
+    (hbr : cpsNBranchWithin nSteps1 entry cr1 P ((head, H) :: (l, Q) :: others))
+    (hseq : cpsNBranchWithin nSteps2 l cr2 Q exits) :
+    cpsNBranchWithin (nSteps1 + nSteps2) entry (cr1.union cr2) P
+      ((head, H) :: (exits ++ others)) := by
+  intro F hF s hcr hPF hpc
+  rw [CodeReq.union_satisfiedBy hd] at hcr
+  obtain ⟨hcr1, hcr2⟩ := hcr
+  obtain ⟨k1, hk1, s1, hstep1, ex, hmem, hpc1, hQF⟩ :=
+    hbr F hF s hcr1 hPF hpc
+  cases hmem with
+  | head =>
+      exact ⟨k1, Nat.le_trans hk1 (Nat.le_add_right nSteps1 nSteps2), s1, hstep1,
+        (head, H), List.Mem.head _, hpc1, hQF⟩
+  | tail _ htail =>
+      cases htail with
+      | head =>
+          have hcr2' := CodeReq.SatisfiedBy_preserved hstep1 hcr2
+          obtain ⟨k2, hk2, s2, hstep2, ex2, hmem2, hpc2, hRF⟩ :=
+            hseq F hF s1 hcr2' hQF hpc1
+          exact ⟨k1 + k2, Nat.add_le_add hk1 hk2, s2, stepN_add_eq hstep1 hstep2,
+            ex2, List.Mem.tail _ (List.mem_append_left others hmem2), hpc2, hRF⟩
+      | tail _ htailRest =>
+          exact ⟨k1, Nat.le_trans hk1 (Nat.le_add_right nSteps1 nSteps2), s1, hstep1,
+            ex, List.Mem.tail _ (List.mem_append_right exits htailRest), hpc1, hQF⟩
+
 /-- Bounded sequence with the same CodeReq: a triple followed by an N-branch. -/
 theorem cpsTripleWithin_seq_cpsNBranchWithin_same_cr {nSteps1 nSteps2 : Nat}
     {entry mid : Word} {cr : CodeReq}

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -635,6 +635,59 @@ theorem cpsNBranchWithin_extend_head_nbranch {nSteps1 nSteps2 : Nat}
     exact ⟨k1, Nat.le_trans hk1 (Nat.le_add_right nSteps1 nSteps2), s1, hstep1,
       ex, List.mem_append_right exits htail, hpc1, hQF⟩
 
+/-- Extend the head exit of a bounded N-branch with a bounded triple over disjoint
+    tail code. The continued head path uses the tail code; non-head paths only
+    use the original branch code and are lifted into the summed bound. -/
+theorem cpsNBranchWithin_extend_head_disjoint {nSteps1 nSteps2 : Nat}
+    {entry l l' : Word} {cr1 cr2 : CodeReq}
+    {P Q R : Assertion}
+    {others : List (Word × Assertion)}
+    (hd : cr1.Disjoint cr2)
+    (hbr : cpsNBranchWithin nSteps1 entry cr1 P ((l, Q) :: others))
+    (hseq : cpsTripleWithin nSteps2 l l' cr2 Q R) :
+    cpsNBranchWithin (nSteps1 + nSteps2) entry (cr1.union cr2) P ((l', R) :: others) := by
+  intro F hF s hcr hPF hpc
+  rw [CodeReq.union_satisfiedBy hd] at hcr
+  obtain ⟨hcr1, hcr2⟩ := hcr
+  obtain ⟨k1, hk1, s1, hstep1, ex, hmem, hpc1, hQF⟩ :=
+    hbr F hF s hcr1 hPF hpc
+  cases hmem with
+  | head =>
+      have hcr2' := CodeReq.SatisfiedBy_preserved hstep1 hcr2
+      obtain ⟨k2, hk2, s2, hstep2, hpc2, hRF⟩ := hseq F hF s1 hcr2' hQF hpc1
+      exact ⟨k1 + k2, Nat.add_le_add hk1 hk2, s2, stepN_add_eq hstep1 hstep2,
+        (l', R), List.Mem.head _, hpc2, hRF⟩
+  | tail _ htail =>
+      exact ⟨k1, Nat.le_trans hk1 (Nat.le_add_right nSteps1 nSteps2), s1, hstep1,
+        ex, List.Mem.tail _ htail, hpc1, hQF⟩
+
+/-- Extend the head exit of a bounded N-branch with another bounded N-branch over
+    disjoint tail code. Continued head exits are prepended before the untouched
+    non-head exits. -/
+theorem cpsNBranchWithin_extend_head_nbranch_disjoint {nSteps1 nSteps2 : Nat}
+    {entry l : Word} {cr1 cr2 : CodeReq}
+    {P Q : Assertion}
+    {exits others : List (Word × Assertion)}
+    (hd : cr1.Disjoint cr2)
+    (hbr : cpsNBranchWithin nSteps1 entry cr1 P ((l, Q) :: others))
+    (hseq : cpsNBranchWithin nSteps2 l cr2 Q exits) :
+    cpsNBranchWithin (nSteps1 + nSteps2) entry (cr1.union cr2) P (exits ++ others) := by
+  intro F hF s hcr hPF hpc
+  rw [CodeReq.union_satisfiedBy hd] at hcr
+  obtain ⟨hcr1, hcr2⟩ := hcr
+  obtain ⟨k1, hk1, s1, hstep1, ex, hmem, hpc1, hQF⟩ :=
+    hbr F hF s hcr1 hPF hpc
+  cases hmem with
+  | head =>
+      have hcr2' := CodeReq.SatisfiedBy_preserved hstep1 hcr2
+      obtain ⟨k2, hk2, s2, hstep2, ex2, hmem2, hpc2, hRF⟩ :=
+        hseq F hF s1 hcr2' hQF hpc1
+      exact ⟨k1 + k2, Nat.add_le_add hk1 hk2, s2, stepN_add_eq hstep1 hstep2,
+        ex2, List.mem_append_left others hmem2, hpc2, hRF⟩
+  | tail _ htail =>
+      exact ⟨k1, Nat.le_trans hk1 (Nat.le_add_right nSteps1 nSteps2), s1, hstep1,
+        ex, List.mem_append_right exits htail, hpc1, hQF⟩
+
 /-- Bounded sequence with the same CodeReq: a triple followed by an N-branch. -/
 theorem cpsTripleWithin_seq_cpsNBranchWithin_same_cr {nSteps1 nSteps2 : Nat}
     {entry mid : Word} {cr : CodeReq}

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -688,6 +688,40 @@ theorem cpsNBranchWithin_extend_head_nbranch_disjoint {nSteps1 nSteps2 : Nat}
       exact ⟨k1, Nat.le_trans hk1 (Nat.le_add_right nSteps1 nSteps2), s1, hstep1,
         ex, List.mem_append_right exits htail, hpc1, hQF⟩
 
+/-- Extend an arbitrary exit of a bounded N-branch with another bounded N-branch
+    over disjoint tail code. Exits before the selected one are preserved as a
+    prefix, and exits after it are preserved as a suffix. -/
+theorem cpsNBranchWithin_extend_prefixed_nbranch_disjoint {nSteps1 nSteps2 : Nat}
+    {entry l : Word} {cr1 cr2 : CodeReq}
+    {P Q : Assertion}
+    {preExits exits others : List (Word × Assertion)}
+    (hd : cr1.Disjoint cr2)
+    (hbr : cpsNBranchWithin nSteps1 entry cr1 P (preExits ++ (l, Q) :: others))
+    (hseq : cpsNBranchWithin nSteps2 l cr2 Q exits) :
+    cpsNBranchWithin (nSteps1 + nSteps2) entry (cr1.union cr2) P
+      ((preExits ++ exits) ++ others) := by
+  intro F hF s hcr hPF hpc
+  rw [CodeReq.union_satisfiedBy hd] at hcr
+  obtain ⟨hcr1, hcr2⟩ := hcr
+  obtain ⟨k1, hk1, s1, hstep1, ex, hmem, hpc1, hQF⟩ :=
+    hbr F hF s hcr1 hPF hpc
+  rw [List.mem_append] at hmem
+  cases hmem with
+  | inl hprefix =>
+      exact ⟨k1, Nat.le_trans hk1 (Nat.le_add_right nSteps1 nSteps2), s1, hstep1,
+        ex, List.mem_append_left others (List.mem_append_left exits hprefix), hpc1, hQF⟩
+  | inr htail =>
+      cases htail with
+      | head =>
+          have hcr2p := CodeReq.SatisfiedBy_preserved hstep1 hcr2
+          obtain ⟨k2, hk2, s2, hstep2, ex2, hmem2, hpc2, hRF⟩ :=
+            hseq F hF s1 hcr2p hQF hpc1
+          exact ⟨k1 + k2, Nat.add_le_add hk1 hk2, s2, stepN_add_eq hstep1 hstep2,
+            ex2, List.mem_append_left others (List.mem_append_right preExits hmem2), hpc2, hRF⟩
+      | tail _ htailRest =>
+          exact ⟨k1, Nat.le_trans hk1 (Nat.le_add_right nSteps1 nSteps2), s1, hstep1,
+            ex, List.mem_append_right (preExits ++ exits) htailRest, hpc1, hQF⟩
+
 /-- Extend the second exit of a bounded N-branch with another bounded N-branch
     over disjoint tail code, preserving the first exit. This supports generated
     left-to-right CFG proofs that classify one early exit and continue the

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -1264,6 +1264,39 @@ theorem cpsBranchWithin_seq_cpsTripleWithin_taken {nSteps1 nSteps2 : Nat}
     exact ⟨k1, Nat.le_trans hk1 (Nat.le_add_right nSteps1 nSteps2), s1, hstep1,
       Or.inr ⟨hpc_f1, hQ_f1R⟩⟩
 
+/-- Sequence a branch onto the taken exit of a branch, converging the first branch
+    fall exit and the second branch taken exit onto one shared failure exit. The
+    second branch fall exit is the resulting success exit. This is the standard
+    decoder shape for parse-success followed by a validating check where malformed
+    input and check failure are one postcondition case. -/
+theorem cpsBranchWithin_seq_cpsBranchWithin_taken_converge {nSteps1 nSteps2 : Nat}
+    {entry mid succ fail : Word} {cr1 cr2 : CodeReq}
+    (hd : cr1.Disjoint cr2)
+    {P Q_t1 Q_f1 Q_t2 Q_succ Q_fail : Assertion}
+    (h1 : cpsBranchWithin nSteps1 entry cr1 P mid Q_t1 fail Q_f1)
+    (h2 : cpsBranchWithin nSteps2 mid cr2 Q_t1 fail Q_t2 succ Q_succ)
+    (hf1 : ∀ h, Q_f1 h → Q_fail h)
+    (hf2 : ∀ h, Q_t2 h → Q_fail h) :
+    cpsBranchWithin (nSteps1 + nSteps2) entry (cr1.union cr2) P succ Q_succ fail Q_fail := by
+  intro R hR s hcr hPR hpc
+  rw [CodeReq.union_satisfiedBy hd] at hcr
+  obtain ⟨hcr1, hcr2⟩ := hcr
+  obtain ⟨k1, hk1, s1, hstep1, hbranch1⟩ := h1 R hR s hcr1 hPR hpc
+  rcases hbranch1 with ⟨hpc_t1, hQ_t1R⟩ | ⟨hpc_f1, hQ_f1R⟩
+  · have hcr2Next := CodeReq.SatisfiedBy_preserved hstep1 hcr2
+    obtain ⟨k2, hk2, s2, hstep2, hbranch2⟩ := h2 R hR s1 hcr2Next hQ_t1R hpc_t1
+    rcases hbranch2 with ⟨hpc_t2, hQ_t2R⟩ | ⟨hpc_f2, hQ_succR⟩
+    · exact ⟨k1 + k2, Nat.add_le_add hk1 hk2, s2, stepN_add_eq hstep1 hstep2,
+        Or.inr ⟨hpc_t2, by
+          obtain ⟨hp, hcompat, hpq⟩ := hQ_t2R
+          exact ⟨hp, hcompat, sepConj_mono_left hf2 hp hpq⟩⟩⟩
+    · exact ⟨k1 + k2, Nat.add_le_add hk1 hk2, s2, stepN_add_eq hstep1 hstep2,
+        Or.inl ⟨hpc_f2, hQ_succR⟩⟩
+  · exact ⟨k1, Nat.le_trans hk1 (Nat.le_add_right nSteps1 nSteps2), s1, hstep1,
+      Or.inr ⟨hpc_f1, by
+        obtain ⟨hp, hcompat, hpq⟩ := hQ_f1R
+        exact ⟨hp, hcompat, sepConj_mono_left hf1 hp hpq⟩⟩⟩
+
 /-- Sequence a triple onto the **not-taken** (fall-through) exit of a branch,
     keeping the taken exit open.  Bounds add and code requirements are unioned. -/
 theorem cpsBranchWithin_seq_cpsTripleWithin_notTaken {nSteps1 nSteps2 : Nat}

--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -132,6 +132,7 @@ import EvmAsm.Rv64.RLP.UnifiedDecodeItemShortListValidated
 import EvmAsm.Rv64.RLP.ContentToU256Be
 import EvmAsm.Rv64.RLP.ContentToU64
 import EvmAsm.Rv64.RLP.WalkInit
+import EvmAsm.Rv64.RLP.WalkInitWP
 import EvmAsm.Rv64.RLP.WalkNext
 import EvmAsm.Rv64.RLP.WalkDecodeBridge
 import EvmAsm.Rv64.RLP.WithdrawalDecode

--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -99,6 +99,7 @@ import EvmAsm.Rv64.RLP.UnifiedHeteroFieldWalk
 import EvmAsm.Rv64.RLP.UnifiedScalarFieldRegionCanonical
 import EvmAsm.Rv64.RLP.UnifiedFieldUnitFullyCanonical
 import EvmAsm.Rv64.RLP.SchemaFold
+import EvmAsm.Rv64.RLP.SchemaWP
 import EvmAsm.Rv64.RLP.SchemaScalarValues
 import EvmAsm.Rv64.RLP.SchemaFoldConcat
 import EvmAsm.Rv64.RLP.SchemaListEncode

--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -140,3 +140,4 @@ import EvmAsm.Rv64.RLP.WithdrawalDecode
 import EvmAsm.Rv64.RLP.WithdrawalSchemaWP
 import EvmAsm.Rv64.RLP.WithdrawalDecodeFailureWP
 import EvmAsm.Rv64.RLP.WithdrawalDecodeShortWP
+import EvmAsm.Rv64.RLP.WithdrawalDecodeSemanticWP

--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -138,4 +138,5 @@ import EvmAsm.Rv64.RLP.WalkNext
 import EvmAsm.Rv64.RLP.WalkDecodeBridge
 import EvmAsm.Rv64.RLP.WithdrawalDecode
 import EvmAsm.Rv64.RLP.WithdrawalSchemaWP
+import EvmAsm.Rv64.RLP.WithdrawalDecodeFailureWP
 import EvmAsm.Rv64.RLP.WithdrawalDecodeShortWP

--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -138,3 +138,4 @@ import EvmAsm.Rv64.RLP.WalkNext
 import EvmAsm.Rv64.RLP.WalkDecodeBridge
 import EvmAsm.Rv64.RLP.WithdrawalDecode
 import EvmAsm.Rv64.RLP.WithdrawalSchemaWP
+import EvmAsm.Rv64.RLP.WithdrawalDecodeShortWP

--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -141,3 +141,4 @@ import EvmAsm.Rv64.RLP.WithdrawalSchemaWP
 import EvmAsm.Rv64.RLP.WithdrawalDecodeFailureWP
 import EvmAsm.Rv64.RLP.WithdrawalDecodeShortWP
 import EvmAsm.Rv64.RLP.WithdrawalDecodeSemanticWP
+import EvmAsm.Rv64.RLP.WithdrawalDecodeAutoWP

--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -133,3 +133,4 @@ import EvmAsm.Rv64.RLP.ContentToU256Be
 import EvmAsm.Rv64.RLP.ContentToU64
 import EvmAsm.Rv64.RLP.WalkInit
 import EvmAsm.Rv64.RLP.WalkNext
+import EvmAsm.Rv64.RLP.WithdrawalDecode

--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -137,3 +137,4 @@ import EvmAsm.Rv64.RLP.WalkInitWP
 import EvmAsm.Rv64.RLP.WalkNext
 import EvmAsm.Rv64.RLP.WalkDecodeBridge
 import EvmAsm.Rv64.RLP.WithdrawalDecode
+import EvmAsm.Rv64.RLP.WithdrawalSchemaWP

--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -142,3 +142,4 @@ import EvmAsm.Rv64.RLP.WithdrawalDecodeFailureWP
 import EvmAsm.Rv64.RLP.WithdrawalDecodeShortWP
 import EvmAsm.Rv64.RLP.WithdrawalDecodeSemanticWP
 import EvmAsm.Rv64.RLP.WithdrawalDecodeAutoWP
+import EvmAsm.Rv64.RLP.WithdrawalDecodeChainWP

--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -133,4 +133,5 @@ import EvmAsm.Rv64.RLP.ContentToU256Be
 import EvmAsm.Rv64.RLP.ContentToU64
 import EvmAsm.Rv64.RLP.WalkInit
 import EvmAsm.Rv64.RLP.WalkNext
+import EvmAsm.Rv64.RLP.WalkDecodeBridge
 import EvmAsm.Rv64.RLP.WithdrawalDecode

--- a/EvmAsm/Rv64/RLP/SchemaListEncode.lean
+++ b/EvmAsm/Rv64/RLP/SchemaListEncode.lean
@@ -52,4 +52,16 @@ theorem schemaConcat_of_encode_list_short (bs : List Byte) (specs : List FieldSp
   rw [← List.drop_drop, hbs, encode_list_schemaItems_short specs hlen]
   simp
 
+/-- **Payload slice from a complete short-list input.** A caller carrying the full
+    encoded-list equality can expose the schema payload at offset `1` without
+    manually inventing a concat witness. -/
+theorem schemaConcat_of_encoded_list_short (bs : List Byte) (specs : List FieldSpec)
+    (hlen : (schemaEncBytes specs).length ≤ 55)
+    (hinput : bs = encode (.list (schemaItems specs))) :
+    bs.drop 1 = schemaEncBytes specs ++ ([] : List Byte) := by
+  have hbs : bs.drop 0 = encode (.list (schemaItems specs)) ++ ([] : List Byte) := by
+    rw [hinput]
+    simp
+  simpa using schemaConcat_of_encode_list_short bs specs 0 ([] : List Byte) hlen hbs
+
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/SchemaWP.lean
+++ b/EvmAsm/Rv64/RLP/SchemaWP.lean
@@ -437,6 +437,65 @@ def SchemaCanonical : List FieldSpec → Prop
   | [] => True
   | f :: rest => (f.isScalar = true → f.data = [] ∨ f.data.headD 1 ≠ 0) ∧ SchemaCanonical rest
 
+/-- A field descriptor with its validity/drop evidence determines the pure decode fact for that
+    field.  This is machine-independent: the static layout evidence is separate from the decoded
+    payload witness, and scalar canonicality is used only on the scalar success path. -/
+theorem fieldSpecStep_decode_of_valid
+    (bs : List Byte) (O : Nat) (f : FieldSpec)
+    (hsize : (if f.isScalar then f.data.length ≤ 8
+      else (encode (.bytes f.data)).length < 256 ^ 8))
+    (hcanon : f.isScalar = true → f.data = [] ∨ f.data.headD 1 ≠ 0)
+    (hdrop : bs.drop O = encode (.bytes f.data) ++ bs.drop (O + fieldEnc f)) :
+    (if f.isScalar then
+      decodeScalar (bs.drop O) = some (Nat.fromBytesBE f.data, bs.drop (O + fieldEnc f))
+     else
+      decode (bs.drop O) = some (.bytes f.data, bs.drop (O + fieldEnc f))) := by
+  by_cases hscalar : f.isScalar = true
+  · have henc : (encode (.bytes f.data)).length < 256 ^ 8 :=
+      scalarField_encode_size_of_len_le_8 f.data (by simpa [hscalar] using hsize)
+    have hdec : decode (bs.drop O) = some (.bytes f.data, bs.drop (O + fieldEnc f)) := by
+      rw [hdrop]
+      exact decode_encode_append (.bytes f.data) (bs.drop (O + fieldEnc f)) henc
+    have hheadD : f.data.headD (1 : Byte) ≠ (0 : Byte) := by
+      cases hcanon hscalar with
+      | inl hnil => simp [hnil]
+      | inr h => simpa using h
+    have hhead : ¬ f.data.head?.getD (BitVec.ofNat 8 1) = BitVec.ofNat 8 0 := by
+      cases hd : f.data with
+      | nil => simp
+      | cons b _ =>
+          have hb : b ≠ (0 : Byte) := by simpa [hd] using hheadD
+          simpa [hd] using hb
+    simp [hscalar, decodeScalar, hdec, hhead]
+  · have hbyte : f.isScalar = false := by
+      cases hs : f.isScalar with
+      | false => rfl
+      | true => exact False.elim (hscalar hs)
+    have henc : (encode (.bytes f.data)).length < 256 ^ 8 := by
+      simpa [hbyte] using hsize
+    have hdec : decode (bs.drop O) = some (.bytes f.data, bs.drop (O + fieldEnc f)) := by
+      rw [hdrop]
+      exact decode_encode_append (.bytes f.data) (bs.drop (O + fieldEnc f)) henc
+    simpa [hbyte] using hdec
+
+/-- Fold the pure decode facts over a whole successful schema witness.  This mirrors
+    `schemaStep_spec_within`, but it has no machine-side premises and can be used
+    by semantic bridges such as withdrawal decoding. -/
+theorem schemaDecodes_of_valid_canonical
+    (bs : List Byte) :
+    ∀ (specs : List FieldSpec) (O outLen : Nat),
+      SchemaValid bs outLen O specs → SchemaCanonical specs → schemaDecodes bs O specs := by
+  intro specs
+  induction specs with
+  | nil => intro O outLen _ _; simp [schemaDecodes]
+  | cons f rest ih =>
+      intro O outLen hvalid hcanon
+      obtain ⟨hsize, _hImm, _hdst, hdrop, hvalid_tail⟩ := hvalid
+      obtain ⟨hcanon_head, hcanon_tail⟩ := hcanon
+      constructor
+      · exact fieldSpecStep_decode_of_valid bs O f hsize hcanon_head hdrop
+      · exact ih (O + fieldEnc f) outLen hvalid_tail hcanon_tail
+
 /-- Soundness view of `fieldSpecStepCert` with the precondition exposed as `schemaINV`. -/
 theorem fieldSpecStep_spec_within
     (base regionBase outBase : Word) (rOut : Reg)

--- a/EvmAsm/Rv64/RLP/SchemaWP.lean
+++ b/EvmAsm/Rv64/RLP/SchemaWP.lean
@@ -431,6 +431,226 @@ def fieldSpecStepCert
     exact byteFieldSpecStepCert base regionBase outBase rOut bs O outBytes f hbyte hsize hImm hdst
       halign hdalign hover hwin hdov hdval hcode hdrop
 
+/-- Scalar canonicality side conditions for a successful schema witness.  This is deliberately
+    separate from the static layout: it talks about the field bytes being proved on a success path. -/
+def SchemaCanonical : List FieldSpec → Prop
+  | [] => True
+  | f :: rest => (f.isScalar = true → f.data = [] ∨ f.data.headD 1 ≠ 0) ∧ SchemaCanonical rest
+
+/-- Soundness view of `fieldSpecStepCert` with the precondition exposed as `schemaINV`. -/
+theorem fieldSpecStep_spec_within
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs : List Byte) (O : Nat) (outBytes : List Byte) (f : FieldSpec)
+    (hsize : (if f.isScalar then f.data.length ≤ 8
+      else (encode (.bytes f.data)).length < 256 ^ 8))
+    (hcanon : f.isScalar = true → f.data = [] ∨ f.data.headD 1 ≠ 0)
+    (hImm : signExtend12 f.imm = BitVec.ofNat 64 f.di)
+    (hdst : f.di + fieldWriteLen f ≤ outBytes.length)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + fieldSize f < 2 ^ 64)
+    (hdrop : bs.drop O = encode (.bytes f.data) ++ bs.drop (O + fieldEnc f)) :
+    cpsTripleWithin (fieldSteps f) base (base + BitVec.ofNat 64 (fieldSize f))
+      (fieldCR base rOut f)
+      (schemaINV regionBase outBase rOut bs O outBytes)
+      (schemaINV regionBase outBase rOut bs (O + fieldEnc f) (fieldUpdate outBytes f)) := by
+  by_cases hscalar : f.isScalar = true
+  · have hlen8 : f.data.length ≤ 8 := by
+      simpa [hscalar] using hsize
+    have hdst8 : f.di + 8 ≤ outBytes.length := by
+      simpa [fieldWriteLen, hscalar] using hdst
+    have hcode_scalar : base.toNat + (if f.data = [] then 248 else 280) < 2 ^ 64 := by
+      simpa [fieldSize, hscalar] using hcode
+    by_cases hnil : f.data = []
+    · have hexit : base + 148 + 4 + BitVec.ofNat 64 (12 * 8) = base + BitVec.ofNat 64 248 := by
+        bv_omega
+      have hcode_empty : base.toNat + (148 + 4 + 12 * 8) < 2 ^ 64 := by
+        simpa [hnil] using hcode_scalar
+      have hdrop_empty : bs.drop O = encode (.bytes ([] : List Byte)) ++ bs.drop (O + fieldEnc f) := by
+        simpa [hnil] using hdrop
+      have hspec := (((WP.CFG.block
+        (scalarFieldPost_entails_schemaINV regionBase outBase rOut bs O ([] : List Byte) outBytes f.di)
+        (unified_empty_scalar_field_decode_and_store_region_fully_canonical base regionBase rOut
+          outBase f.imm bs O (bs.drop (O + fieldEnc f)) outBytes f.di halign hover hwin hdrop_empty
+          hdalign hdst8 hdov hdval hImm hcode_empty).1).changeExit hexit).weakenPre
+        (schemaINV_entails_byteFieldPre regionBase outBase rOut bs O outBytes)).sound
+      simpa [fieldSteps, fieldSize, fieldCR, fieldEnc, fieldUpdate, hscalar, hnil] using hspec
+    · have hlen1 : 1 ≤ f.data.length := by
+        cases hd : f.data with
+        | nil => exact False.elim (hnil hd)
+        | cons _ _ => simp
+      have hhead : f.data.headD 1 ≠ 0 := by
+        cases hcanon hscalar with
+        | inl h => exact False.elim (hnil h)
+        | inr h => exact h
+      have henc : (encode (.bytes f.data)).length < 256 ^ 8 :=
+        scalarField_encode_size_of_len_le_8 f.data hlen8
+      have hcode_data : base.toNat + 280 < 2 ^ 64 := by
+        simpa [hnil] using hcode_scalar
+      have hexit : base + 180 + 4 + BitVec.ofNat 64 (12 * 8) = base + BitVec.ofNat 64 280 := by
+        bv_omega
+      have hspec := (((WP.CFG.block
+        (scalarFieldPost_entails_schemaINV regionBase outBase rOut bs O f.data outBytes f.di)
+        (unified_scalar_field_decode_and_store_region_fully_canonical base regionBase rOut outBase
+          f.imm bs O f.data (bs.drop (O + fieldEnc f)) outBytes f.di hlen1 hlen8 hhead henc
+          halign hdalign hover hwin hImm hdst8 hdov hdval hcode_data hdrop).1).changeExit hexit).weakenPre
+        (schemaINV_entails_byteFieldPre regionBase outBase rOut bs O outBytes)).sound
+      simpa [fieldSteps, fieldSize, fieldCR, fieldEnc, fieldUpdate, hscalar, hnil] using hspec
+  · have hbyte : f.isScalar = false := by
+      cases hs : f.isScalar with
+      | false => rfl
+      | true => exact False.elim (hscalar hs)
+    have hsize_data : (encode (.bytes f.data)).length < 256 ^ 8 := by
+      simpa [hbyte] using hsize
+    have hdst_data : f.di + f.data.length ≤ outBytes.length := by
+      simpa [fieldWriteLen, hbyte] using hdst
+    have hcode_data : base.toNat + (148 + 4 + 20 * f.data.length) < 2 ^ 64 := by
+      simpa [fieldSize, hbyte] using hcode
+    have hexit : base + 148 + 4 + BitVec.ofNat 64 (20 * f.data.length)
+        = base + BitVec.ofNat 64 (fieldSize f) := by
+      simp [fieldSize, hbyte]
+      bv_omega
+    by_cases hnil : f.data = []
+    · have hdrop_empty : bs.drop O = encode (.bytes ([] : List Byte)) ++ bs.drop (O + fieldEnc f) := by
+        simpa [hnil] using hdrop
+      have hdst_empty : f.di + ([] : List Byte).length ≤ outBytes.length := by
+        simpa [hnil] using hdst_data
+      have hcode_empty : base.toNat + (148 + 4 + 20 * ([] : List Byte).length) < 2 ^ 64 := by
+        simpa [hnil] using hcode_data
+      have hexit_empty : base + 148 + 4 + BitVec.ofNat 64 (20 * ([] : List Byte).length)
+          = base + BitVec.ofNat 64 (fieldSize f) := by
+        simpa [hnil] using hexit
+      have hspec := (((WP.CFG.block
+        (byteFieldPost_entails_schemaINV regionBase outBase rOut bs O ([] : List Byte) outBytes f.di)
+        (unified_empty_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase
+          f.imm bs O (bs.drop (O + fieldEnc f)) outBytes f.di halign hdalign hover hwin hImm hdst_empty
+          hdov hdval hcode_empty hdrop_empty).1).changeExit hexit_empty).weakenPre
+        (schemaINV_entails_byteFieldPre regionBase outBase rOut bs O outBytes)).sound
+      simpa [fieldSteps, fieldSize, fieldCR, fieldEnc, fieldUpdate, hbyte, hnil] using hspec
+    · by_cases hshort : f.data.length ≤ 55
+      · have hlen1 : 1 ≤ f.data.length := by
+          cases hd : f.data with
+          | nil => exact False.elim (hnil hd)
+          | cons _ _ => simp
+        have hspec := (((WP.CFG.block
+          (byteFieldPost_entails_schemaINV regionBase outBase rOut bs O f.data outBytes f.di)
+          (unified_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase f.imm
+            bs O f.data (bs.drop (O + fieldEnc f)) outBytes f.di hlen1 hshort hsize_data halign
+            hdalign hover hwin hImm hdst_data hdov hdval hcode_data hdrop).1).changeExit hexit).weakenPre
+          (schemaINV_entails_byteFieldPre regionBase outBase rOut bs O outBytes)).sound
+        simpa [fieldSteps, fieldSize, fieldCR, fieldEnc, fieldUpdate, hbyte, hnil] using hspec
+      · have hlong : 55 < f.data.length := by omega
+        have hspec := (((WP.CFG.block
+          (byteFieldPost_entails_schemaINV regionBase outBase rOut bs O f.data outBytes f.di)
+          (unified_long_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase
+            f.imm bs O f.data (bs.drop (O + fieldEnc f)) outBytes f.di hlong hsize_data halign
+            hdalign hover hwin hImm hdst_data hdov hdval hcode_data hdrop).1).changeExit hexit).weakenPre
+          (schemaINV_entails_byteFieldPre regionBase outBase rOut bs O outBytes)).sound
+        simpa [fieldSteps, fieldSize, fieldCR, fieldEnc, fieldUpdate, hbyte, hnil] using hspec
+
+
+/-- CPS theorem for a whole schema: the program/post pair reduces to the initial schema invariant. -/
+theorem schemaStep_spec_within
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs : List Byte) (O : Nat) (outBytes : List Byte) (specs : List FieldSpec)
+    (hvalid : SchemaValid bs outBytes.length O specs)
+    (hcanon : SchemaCanonical specs)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + schemaSize specs < 2 ^ 64) :
+    cpsTripleWithin (schemaSteps specs) base (base + BitVec.ofNat 64 (schemaSize specs))
+      (schemaCR base rOut specs)
+      (schemaINV regionBase outBase rOut bs O outBytes)
+      (schemaINV regionBase outBase rOut bs (O + schemaEnc specs) (schemaOut outBytes specs)) := by
+  induction specs generalizing base O outBytes with
+  | nil =>
+      simpa [schemaSteps, schemaSize, schemaCR, schemaEnc, schemaOut] using
+        (cpsTripleWithin_refl (addr := base)
+          (P := schemaINV regionBase outBase rOut bs O outBytes)
+          (Q := schemaINV regionBase outBase rOut bs O outBytes)
+          (fun h hp => hp))
+  | cons f rest ih =>
+      obtain ⟨hsize, hImm, hdst, hdrop, hvalid_tail⟩ := hvalid
+      obtain ⟨hcanon_head, hcanon_tail⟩ := hcanon
+      have hfield_code : base.toNat + fieldSize f < 2 ^ 64 := by
+        have hsz : schemaSize (f :: rest) = fieldSize f + schemaSize rest := rfl
+        omega
+      have hfield := fieldSpecStep_spec_within base regionBase outBase rOut bs O outBytes f hsize
+        hcanon_head hImm hdst halign hdalign hover hwin hdov hdval hfield_code hdrop
+      have hbase_tail : (base + BitVec.ofNat 64 (fieldSize f)).toNat = base.toNat + fieldSize f := by
+        bv_omega
+      have hcode_tail : (base + BitVec.ofNat 64 (fieldSize f)).toNat + schemaSize rest < 2 ^ 64 := by
+        rw [hbase_tail]
+        have hsz : schemaSize (f :: rest) = fieldSize f + schemaSize rest := rfl
+        omega
+      have hvalid_tail_step : SchemaValid bs (fieldUpdate outBytes f).length (O + fieldEnc f) rest := by
+        simpa [fieldUpdate_length] using hvalid_tail
+      have hdov_tail : outBase.toNat + (fieldUpdate outBytes f).length < 2 ^ 64 := by
+        simpa [fieldUpdate_length] using hdov
+      have hdval_tail : ∀ i, i < (fieldUpdate outBytes f).length →
+          isValidByteAccess (outBase + BitVec.ofNat 64 i) = true := by
+        intro i hi
+        exact hdval i (by simpa [fieldUpdate_length] using hi)
+      have htail := ih (base := base + BitVec.ofNat 64 (fieldSize f))
+        (O := O + fieldEnc f) (outBytes := fieldUpdate outBytes f)
+        hvalid_tail_step hcanon_tail hdov_tail hdval_tail hcode_tail
+      have hd : (fieldCR base rOut f).Disjoint
+          (schemaCR (base + BitVec.ofNat 64 (fieldSize f)) rOut rest) := by
+        refine codeReq_disjoint_of_ranges _ _ (base.toNat + fieldSize f) ?_ ?_
+        · intro a ha
+          exact fieldCR_none_above base rOut f a hfield_code ha
+        · intro a ha
+          exact schemaCR_none_below rOut rest (base + BitVec.ofNat 64 (fieldSize f)) a
+            hcode_tail (by rw [hbase_tail]; exact ha)
+      have hseq := cpsTripleWithin_seq hd hfield htail
+      have hexit : base + BitVec.ofNat 64 (fieldSize f) + BitVec.ofNat 64 (schemaSize rest) =
+          base + BitVec.ofNat 64 (fieldSize f + schemaSize rest) := by
+        bv_omega
+      rw [hexit] at hseq
+      simpa [schemaSteps, schemaSize, schemaCR, schemaEnc, schemaOut, Nat.add_assoc] using hseq
+
+/-- WP certificate for a whole schema, exposing the reduced precondition as the certificate pre. -/
+def schemaStepCert
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs : List Byte) (O : Nat) (outBytes : List Byte) (specs : List FieldSpec)
+    (hvalid : SchemaValid bs outBytes.length O specs)
+    (hcanon : SchemaCanonical specs)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + schemaSize specs < 2 ^ 64) :
+    WP.CFG.Cert base (base + BitVec.ofNat 64 (schemaSize specs))
+      (schemaCR base rOut specs)
+      (schemaINV regionBase outBase rOut bs (O + schemaEnc specs) (schemaOut outBytes specs)) :=
+  WP.CFG.block (WP.Entails.refl _)
+    (schemaStep_spec_within base regionBase outBase rOut bs O outBytes specs hvalid hcanon
+      halign hdalign hover hwin hdov hdval hcode)
+
+/-- The computed WP precondition of schemaStepCert is the schema invariant before the schema. -/
+theorem schemaStepCert_pre
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs : List Byte) (O : Nat) (outBytes : List Byte) (specs : List FieldSpec)
+    (hvalid : SchemaValid bs outBytes.length O specs)
+    (hcanon : SchemaCanonical specs)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + schemaSize specs < 2 ^ 64) :
+    (schemaStepCert base regionBase outBase rOut bs O outBytes specs hvalid hcanon halign hdalign
+      hover hwin hdov hdval hcode).pre = schemaINV regionBase outBase rOut bs O outBytes :=
+  rfl
+
+
 /-- Pure decode fact paired with `fieldSpecStepCert`. -/
 theorem fieldSpecStep_decode
     (base regionBase outBase : Word) (rOut : Reg)

--- a/EvmAsm/Rv64/RLP/SchemaWP.lean
+++ b/EvmAsm/Rv64/RLP/SchemaWP.lean
@@ -1,0 +1,219 @@
+/-
+  EvmAsm.Rv64.RLP.SchemaWP
+
+  WP-facing adapters for fixed-schema RLP field units.  The canonical field
+  proofs expose the right machine behavior but their postconditions are ordered
+  for local composition; this file normalizes them to `schemaINV`, so callers can
+  use a field as a one-step weakest-precondition certificate.
+-/
+
+import EvmAsm.Rv64.RLP.SchemaFold
+import EvmAsm.Rv64.WP.CFG
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL.RLP
+open EvmAsm.Rv64.Tactics
+
+namespace SchemaWP
+
+/-- The schema invariant entails the canonical byte-field precondition. -/
+theorem schemaINV_entails_byteFieldPre
+    (regionBase outBase : Word) (rOut : Reg) (bs : List Byte) (O : Nat)
+    (outBytes : List Byte) :
+    WP.Entails (schemaINV regionBase outBase rOut bs O outBytes)
+      (((regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) ** (regOwn .x11) **
+        (regOwn .x12) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (regOwn .x14) **
+        (regOwn .x15) ** bytesRegion regionBase bs) **
+       ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes)) := by
+  intro h hp
+  unfold schemaINV at hp
+  xperm_hyp hp
+
+/-- The canonical byte-field postcondition entails the schema invariant. -/
+theorem byteFieldPost_entails_schemaINV
+    (regionBase outBase : Word) (rOut : Reg) (bs : List Byte) (O : Nat)
+    (data outBytes : List Byte) (di0 : Nat) :
+    WP.Entails
+      (((regOwn .x12) **
+          (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 (O + (encode (.bytes data)).length))) **
+          (regOwn .x14) ** (regOwn .x15) **
+          (rOut ↦ᵣ outBase) ** bytesRegion regionBase bs **
+          bytesRegion outBase (copyRangeGen outBytes data 0 di0 data.length)) **
+        (regOwn .x5 ** (.x0 ↦ᵣ (0 : Word)) ** regOwn .x10 ** regOwn .x11))
+      (schemaINV regionBase outBase rOut bs (O + (encode (.bytes data)).length)
+        (copyRangeGen outBytes data 0 di0 data.length)) := by
+  intro h hp
+  unfold schemaINV
+  xperm_hyp hp
+
+/-- Normalize a canonical byte-field unit into the schema fold invariant.
+    The returned certificate computes the precondition for the requested
+    postcondition `schemaINV ... (O + enc(data)) (copyRangeGen ...)`. -/
+def byteFieldStepCert
+    (base regionBase outBase : Word) (rOut : Reg) (fieldImm : BitVec 12)
+    (bs : List Byte) (O : Nat) (data tail outBytes : List Byte) (di0 : Nat)
+    (hsize : (encode (.bytes data)).length < 256 ^ 8)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hImm : signExtend12 fieldImm = BitVec.ofNat 64 di0)
+    (hdst : di0 + data.length ≤ outBytes.length)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + (148 + 4 + 20 * data.length) < 2 ^ 64)
+    (hdrop : bs.drop O = encode (.bytes data) ++ tail) :
+    WP.CFG.Cert base (base + 148 + 4 + BitVec.ofNat 64 (20 * data.length))
+      (bytesUnitCR base rOut fieldImm data.length)
+      (schemaINV regionBase outBase rOut bs (O + (encode (.bytes data)).length)
+        (copyRangeGen outBytes data 0 di0 data.length)) := by
+  by_cases hnil : data = []
+  · subst data
+    exact (WP.CFG.block
+      (byteFieldPost_entails_schemaINV regionBase outBase rOut bs O ([] : List Byte) outBytes di0)
+      (unified_empty_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase
+        fieldImm bs O tail outBytes di0 halign hdalign hover hwin hImm hdst hdov hdval hcode
+        hdrop).1).weakenPre
+      (schemaINV_entails_byteFieldPre regionBase outBase rOut bs O outBytes)
+  · by_cases hshort : data.length ≤ 55
+    · have hlen1 : 1 ≤ data.length := by
+        cases data with
+        | nil => contradiction
+        | cons _ _ => simp
+      exact (WP.CFG.block
+        (byteFieldPost_entails_schemaINV regionBase outBase rOut bs O data outBytes di0)
+        (unified_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase fieldImm
+          bs O data tail outBytes di0 hlen1 hshort hsize halign hdalign hover hwin hImm hdst hdov
+          hdval hcode hdrop).1).weakenPre
+        (schemaINV_entails_byteFieldPre regionBase outBase rOut bs O outBytes)
+    · have hlong : 55 < data.length := by omega
+      exact (WP.CFG.block
+        (byteFieldPost_entails_schemaINV regionBase outBase rOut bs O data outBytes di0)
+        (unified_long_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase
+          fieldImm bs O data tail outBytes di0 hlong hsize halign hdalign hover hwin hImm hdst hdov
+          hdval hcode hdrop).1).weakenPre
+        (schemaINV_entails_byteFieldPre regionBase outBase rOut bs O outBytes)
+
+/-- The computed WP precondition of `byteFieldStepCert` is the schema invariant before the field. -/
+theorem byteFieldStepCert_pre
+    (base regionBase outBase : Word) (rOut : Reg) (fieldImm : BitVec 12)
+    (bs : List Byte) (O : Nat) (data tail outBytes : List Byte) (di0 : Nat)
+    (hsize : (encode (.bytes data)).length < 256 ^ 8)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hImm : signExtend12 fieldImm = BitVec.ofNat 64 di0)
+    (hdst : di0 + data.length ≤ outBytes.length)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + (148 + 4 + 20 * data.length) < 2 ^ 64)
+    (hdrop : bs.drop O = encode (.bytes data) ++ tail) :
+    (byteFieldStepCert base regionBase outBase rOut fieldImm bs O data tail outBytes di0
+      hsize halign hdalign hover hwin hImm hdst hdov hdval hcode hdrop).pre =
+      schemaINV regionBase outBase rOut bs O outBytes := by
+  by_cases hnil : data = []
+  · subst data
+    simp [byteFieldStepCert, WP.Triple.weakenPre]
+  · unfold byteFieldStepCert
+    simp [hnil]
+    split <;> rfl
+
+/-- Pure decode coincidence paired with `byteFieldStepCert`. -/
+theorem byteFieldStep_decode
+    (base regionBase outBase : Word) (rOut : Reg) (fieldImm : BitVec 12)
+    (bs : List Byte) (O : Nat) (data tail outBytes : List Byte) (di0 : Nat)
+    (hsize : (encode (.bytes data)).length < 256 ^ 8)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hImm : signExtend12 fieldImm = BitVec.ofNat 64 di0)
+    (hdst : di0 + data.length ≤ outBytes.length)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + (148 + 4 + 20 * data.length) < 2 ^ 64)
+    (hdrop : bs.drop O = encode (.bytes data) ++ tail) :
+    decode (bs.drop O) = some (.bytes data, tail) := by
+  by_cases hnil : data = []
+  · subst data
+    exact (unified_empty_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase
+      fieldImm bs O tail outBytes di0 halign hdalign hover hwin hImm hdst hdov hdval hcode hdrop).2
+  · by_cases hshort : data.length ≤ 55
+    · have hlen1 : 1 ≤ data.length := by
+        cases data with
+        | nil => contradiction
+        | cons _ _ => simp
+      exact (unified_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase
+        fieldImm bs O data tail outBytes di0 hlen1 hshort hsize halign hdalign hover hwin hImm hdst
+        hdov hdval hcode hdrop).2
+    · have hlong : 55 < data.length := by omega
+      exact (unified_long_bytes_field_decode_and_copy_fully_canonical base regionBase rOut outBase
+        fieldImm bs O data tail outBytes di0 hlong hsize halign hdalign hover hwin hImm hdst hdov
+        hdval hcode hdrop).2
+
+/-- Schema-facing byte field step.  The static field record supplies the output
+    offset and immediate; the postcondition is expressed with `fieldEnc` and
+    `fieldUpdate`, so this is the adapter consumed by a schema fold. -/
+def byteFieldSpecStepCert
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs : List Byte) (O : Nat) (outBytes : List Byte) (f : FieldSpec)
+    (hbyte : f.isScalar = false)
+    (hsize : (if f.isScalar then f.data.length ≤ 8
+      else (encode (.bytes f.data)).length < 256 ^ 8))
+    (hImm : signExtend12 f.imm = BitVec.ofNat 64 f.di)
+    (hdst : f.di + fieldWriteLen f ≤ outBytes.length)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + fieldSize f < 2 ^ 64)
+    (hdrop : bs.drop O = encode (.bytes f.data) ++ bs.drop (O + fieldEnc f)) :
+    WP.CFG.Cert base (base + BitVec.ofNat 64 (fieldSize f))
+      (fieldCR base rOut f)
+      (schemaINV regionBase outBase rOut bs (O + fieldEnc f) (fieldUpdate outBytes f)) := by
+  have hsize_data : (encode (.bytes f.data)).length < 256 ^ 8 := by
+    simpa [hbyte] using hsize
+  have hdst_data : f.di + f.data.length ≤ outBytes.length := by
+    simpa [fieldWriteLen, hbyte] using hdst
+  have hcode_data : base.toNat + (148 + 4 + 20 * f.data.length) < 2 ^ 64 := by
+    simpa [fieldSize, hbyte] using hcode
+  have hexit : base + 148 + 4 + BitVec.ofNat 64 (20 * f.data.length)
+      = base + BitVec.ofNat 64 (fieldSize f) := by
+    simp [fieldSize, hbyte]
+    bv_omega
+  have cert := byteFieldStepCert base regionBase outBase rOut f.imm bs O f.data
+    (bs.drop (O + fieldEnc f)) outBytes f.di hsize_data halign hdalign hover hwin hImm hdst_data
+    hdov hdval hcode_data hdrop
+  simpa [fieldCR, fieldEnc, fieldUpdate, hbyte] using cert.changeExit hexit
+
+/-- Pure decode fact produced by `byteFieldSpecStepCert`. -/
+theorem byteFieldSpecStep_decode
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs : List Byte) (O : Nat) (outBytes : List Byte) (f : FieldSpec)
+    (hbyte : f.isScalar = false)
+    (hsize : (if f.isScalar then f.data.length ≤ 8
+      else (encode (.bytes f.data)).length < 256 ^ 8))
+    (hImm : signExtend12 f.imm = BitVec.ofNat 64 f.di)
+    (hdst : f.di + fieldWriteLen f ≤ outBytes.length)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + fieldSize f < 2 ^ 64)
+    (hdrop : bs.drop O = encode (.bytes f.data) ++ bs.drop (O + fieldEnc f)) :
+    decode (bs.drop O) = some (.bytes f.data, bs.drop (O + fieldEnc f)) := by
+  have hsize_data : (encode (.bytes f.data)).length < 256 ^ 8 := by
+    simpa [hbyte] using hsize
+  have hdst_data : f.di + f.data.length ≤ outBytes.length := by
+    simpa [fieldWriteLen, hbyte] using hdst
+  have hcode_data : base.toNat + (148 + 4 + 20 * f.data.length) < 2 ^ 64 := by
+    simpa [fieldSize, hbyte] using hcode
+  exact byteFieldStep_decode base regionBase outBase rOut f.imm bs O f.data
+    (bs.drop (O + fieldEnc f)) outBytes f.di hsize_data halign hdalign hover hwin hImm hdst_data
+    hdov hdval hcode_data hdrop
+
+end SchemaWP
+
+end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/SchemaWP.lean
+++ b/EvmAsm/Rv64/RLP/SchemaWP.lean
@@ -8,6 +8,7 @@
 -/
 
 import EvmAsm.Rv64.RLP.SchemaFold
+import EvmAsm.Rv64.RLP.SchemaListEncode
 import EvmAsm.Rv64.WP.CFG
 
 namespace EvmAsm.Rv64.RLP
@@ -707,6 +708,59 @@ theorem schemaStepCert_pre
     (hcode : base.toNat + schemaSize specs < 2 ^ 64) :
     (schemaStepCert base regionBase outBase rOut bs O outBytes specs hvalid hcanon halign hdalign
       hover hwin hdov hdval hcode).pre = schemaINV regionBase outBase rOut bs O outBytes :=
+  rfl
+
+/-- Build `SchemaValid` for a complete short-list-encoded schema input.
+    The schema payload starts after the one-byte list header, so the WP offset is `1`. -/
+theorem schemaValid_of_encoded_list_short
+    (bs : List Byte) (outLen : Nat) (specs : List FieldSpec)
+    (hcore : ∀ f, f ∈ specs → fieldCoreValid outLen f)
+    (hlen : (schemaEncBytes specs).length ≤ 55)
+    (hinput : bs = encode (.list (schemaItems specs))) :
+    SchemaValid bs outLen 1 specs :=
+  schemaValid_of_concat bs outLen ([] : List Byte) specs 1 hcore
+    (schemaConcat_of_encoded_list_short bs specs hlen hinput)
+
+/-- WP certificate for a whole schema whose input is the complete short-list
+    encoding of the field items.  This removes the caller-side payload concat
+    proof and exposes the reduced precondition at offset `1`. -/
+def schemaStepCertOfEncodedListShort
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs outBytes : List Byte) (specs : List FieldSpec)
+    (hcore : ∀ f, f ∈ specs → fieldCoreValid outBytes.length f)
+    (hcanon : SchemaCanonical specs)
+    (hlen : (schemaEncBytes specs).length ≤ 55)
+    (hinput : bs = encode (.list (schemaItems specs)))
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + schemaSize specs < 2 ^ 64) :
+    WP.CFG.Cert base (base + BitVec.ofNat 64 (schemaSize specs))
+      (schemaCR base rOut specs)
+      (schemaINV regionBase outBase rOut bs (1 + schemaEnc specs) (schemaOut outBytes specs)) :=
+  schemaStepCert base regionBase outBase rOut bs 1 outBytes specs
+    (schemaValid_of_encoded_list_short bs outBytes.length specs hcore hlen hinput)
+    hcanon halign hdalign hover hwin hdov hdval hcode
+
+/-- The encoded-list schema certificate computes the schema invariant at payload offset `1`. -/
+theorem schemaStepCertOfEncodedListShort_pre
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs outBytes : List Byte) (specs : List FieldSpec)
+    (hcore : ∀ f, f ∈ specs → fieldCoreValid outBytes.length f)
+    (hcanon : SchemaCanonical specs)
+    (hlen : (schemaEncBytes specs).length ≤ 55)
+    (hinput : bs = encode (.list (schemaItems specs)))
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + schemaSize specs < 2 ^ 64) :
+    (schemaStepCertOfEncodedListShort base regionBase outBase rOut bs outBytes specs hcore hcanon
+      hlen hinput halign hdalign hover hwin hdov hdval hcode).pre =
+      schemaINV regionBase outBase rOut bs 1 outBytes :=
   rfl
 
 

--- a/EvmAsm/Rv64/RLP/SchemaWP.lean
+++ b/EvmAsm/Rv64/RLP/SchemaWP.lean
@@ -18,6 +18,24 @@ open EvmAsm.Rv64.Tactics
 
 namespace SchemaWP
 
+
+/-- Scalar fields bounded to eight payload bytes always have an RLP encoding within the
+    decoder length bound used by the field endpoint. -/
+theorem scalarField_encode_size_of_len_le_8 (data : List Byte) (hlen8 : data.length ≤ 8) :
+    (encode (.bytes data)).length < 256 ^ 8 := by
+  unfold encode encodeBytes
+  cases data with
+  | nil => simp
+  | cons b tail =>
+      cases tail with
+      | nil =>
+          by_cases hb : b.toNat < 0x80 <;> simp [hb]
+      | cons c tail =>
+          have hlen8_tail : tail.length + 2 ≤ 8 := by simpa using hlen8
+          have h55 : tail.length + 1 + 1 ≤ 55 := by omega
+          simp [h55]
+          omega
+
 /-- The schema invariant entails the canonical byte-field precondition. -/
 theorem schemaINV_entails_byteFieldPre
     (regionBase outBase : Word) (rOut : Reg) (bs : List Byte) (O : Nat)
@@ -44,6 +62,24 @@ theorem byteFieldPost_entails_schemaINV
         (regOwn .x5 ** (.x0 ↦ᵣ (0 : Word)) ** regOwn .x10 ** regOwn .x11))
       (schemaINV regionBase outBase rOut bs (O + (encode (.bytes data)).length)
         (copyRangeGen outBytes data 0 di0 data.length)) := by
+  intro h hp
+  unfold schemaINV
+  xperm_hyp hp
+
+
+/-- The canonical scalar-field postcondition entails the schema invariant. -/
+theorem scalarFieldPost_entails_schemaINV
+    (regionBase outBase : Word) (rOut : Reg) (bs : List Byte) (O : Nat)
+    (data outBytes : List Byte) (di0 : Nat) :
+    WP.Entails
+      (((regOwn .x11) ** (regOwn .x14) ** (rOut ↦ᵣ outBase) **
+          bytesRegion outBase
+            (spillRange outBytes (BitVec.ofNat 64 (Nat.fromBytesBE data)) di0 8)) **
+        ((.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 (O + (encode (.bytes data)).length))) **
+          regOwn .x12 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs **
+          regOwn .x5 ** regOwn .x10 ** regOwn .x15))
+      (schemaINV regionBase outBase rOut bs (O + (encode (.bytes data)).length)
+        (spillRange outBytes (BitVec.ofNat 64 (Nat.fromBytesBE data)) di0 8)) := by
   intro h hp
   unfold schemaINV
   xperm_hyp hp
@@ -151,6 +187,98 @@ theorem byteFieldStep_decode
         fieldImm bs O data tail outBytes di0 hlong hsize halign hdalign hover hwin hImm hdst hdov
         hdval hcode hdrop).2
 
+
+/-- Normalize a canonical scalar field unit into the schema fold invariant.  The certificate covers
+    the empty zero scalar and the non-empty canonical scalar path. -/
+def scalarFieldStepCert
+    (base regionBase outBase : Word) (rOut : Reg) (fieldImm : BitVec 12)
+    (bs : List Byte) (O : Nat) (data tail outBytes : List Byte) (di0 : Nat)
+    (hlen8 : data.length ≤ 8) (hcanon : data = [] ∨ data.headD 1 ≠ 0)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hImm : signExtend12 fieldImm = BitVec.ofNat 64 di0)
+    (hdst : di0 + 8 ≤ outBytes.length)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + (if data = [] then 248 else 280) < 2 ^ 64)
+    (hdrop : bs.drop O = encode (.bytes data) ++ tail) :
+    WP.CFG.Cert base (base + BitVec.ofNat 64 (if data = [] then 248 else 280))
+      (if data = [] then emptyScalarUnitCR base rOut fieldImm
+       else scalarRegionUnitCR base rOut fieldImm)
+      (schemaINV regionBase outBase rOut bs (O + (encode (.bytes data)).length)
+        (spillRange outBytes (BitVec.ofNat 64 (Nat.fromBytesBE data)) di0 8)) := by
+  by_cases hnil : data = []
+  · subst data
+    have hexit : base + 148 + 4 + BitVec.ofNat 64 (12 * 8) = base + BitVec.ofNat 64 248 := by
+      bv_omega
+    have hcode_empty : base.toNat + (148 + 4 + 12 * 8) < 2 ^ 64 := by
+      simpa using hcode
+    exact ((WP.CFG.block
+      (scalarFieldPost_entails_schemaINV regionBase outBase rOut bs O ([] : List Byte) outBytes di0)
+      (unified_empty_scalar_field_decode_and_store_region_fully_canonical base regionBase rOut
+        outBase fieldImm bs O tail outBytes di0 halign hover hwin hdrop hdalign hdst hdov hdval hImm
+        hcode_empty).1).changeExit hexit).weakenPre
+      (schemaINV_entails_byteFieldPre regionBase outBase rOut bs O outBytes)
+  · have hlen1 : 1 ≤ data.length := by
+      cases data with
+      | nil => contradiction
+      | cons _ _ => simp
+    have hhead : data.headD 1 ≠ 0 := by
+      cases hcanon with
+      | inl h => exact False.elim (hnil h)
+      | inr h => exact h
+    have hsize : (encode (.bytes data)).length < 256 ^ 8 :=
+      scalarField_encode_size_of_len_le_8 data hlen8
+    have hcode_data : base.toNat + 280 < 2 ^ 64 := by
+      simpa [hnil] using hcode
+    have hexit : base + 180 + 4 + BitVec.ofNat 64 (12 * 8) = base + BitVec.ofNat 64 280 := by
+      bv_omega
+    simpa [hnil] using (((WP.CFG.block
+      (scalarFieldPost_entails_schemaINV regionBase outBase rOut bs O data outBytes di0)
+      (unified_scalar_field_decode_and_store_region_fully_canonical base regionBase rOut outBase
+        fieldImm bs O data tail outBytes di0 hlen1 hlen8 hhead hsize halign hdalign hover hwin hImm
+        hdst hdov hdval hcode_data hdrop).1).changeExit hexit).weakenPre
+      (schemaINV_entails_byteFieldPre regionBase outBase rOut bs O outBytes))
+
+/-- Pure decode coincidence paired with `scalarFieldStepCert`. -/
+theorem scalarFieldStep_decode
+    (base regionBase outBase : Word) (rOut : Reg) (fieldImm : BitVec 12)
+    (bs : List Byte) (O : Nat) (data tail outBytes : List Byte) (di0 : Nat)
+    (hlen8 : data.length ≤ 8) (hcanon : data = [] ∨ data.headD 1 ≠ 0)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hImm : signExtend12 fieldImm = BitVec.ofNat 64 di0)
+    (hdst : di0 + 8 ≤ outBytes.length)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + (if data = [] then 248 else 280) < 2 ^ 64)
+    (hdrop : bs.drop O = encode (.bytes data) ++ tail) :
+    decodeScalar (bs.drop O) = some (Nat.fromBytesBE data, tail) := by
+  by_cases hnil : data = []
+  · subst data
+    have hcode_empty : base.toNat + (148 + 4 + 12 * 8) < 2 ^ 64 := by
+      simpa using hcode
+    simpa using (unified_empty_scalar_field_decode_and_store_region_fully_canonical base
+      regionBase rOut outBase fieldImm bs O tail outBytes di0 halign hover hwin hdrop hdalign hdst
+      hdov hdval hImm hcode_empty).2
+  · have hlen1 : 1 ≤ data.length := by
+      cases data with
+      | nil => contradiction
+      | cons _ _ => simp
+    have hhead : data.headD 1 ≠ 0 := by
+      cases hcanon with
+      | inl h => exact False.elim (hnil h)
+      | inr h => exact h
+    have hsize : (encode (.bytes data)).length < 256 ^ 8 :=
+      scalarField_encode_size_of_len_le_8 data hlen8
+    have hcode_data : base.toNat + 280 < 2 ^ 64 := by
+      simpa [hnil] using hcode
+    exact (unified_scalar_field_decode_and_store_region_fully_canonical base regionBase rOut outBase
+      fieldImm bs O data tail outBytes di0 hlen1 hlen8 hhead hsize halign hdalign hover hwin hImm hdst
+      hdov hdval hcode_data hdrop).2
+
 /-- Schema-facing byte field step.  The static field record supplies the output
     offset and immediate; the postcondition is expressed with `fieldEnc` and
     `fieldUpdate`, so this is the adapter consumed by a schema fold. -/
@@ -213,6 +341,126 @@ theorem byteFieldSpecStep_decode
   exact byteFieldStep_decode base regionBase outBase rOut f.imm bs O f.data
     (bs.drop (O + fieldEnc f)) outBytes f.di hsize_data halign hdalign hover hwin hImm hdst_data
     hdov hdval hcode_data hdrop
+
+/-- Schema-facing scalar field step.  The scalar guard is only the static canonicality condition
+    needed by the success path, while the produced postcondition is still `fieldUpdate`. -/
+def scalarFieldSpecStepCert
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs : List Byte) (O : Nat) (outBytes : List Byte) (f : FieldSpec)
+    (hscalar : f.isScalar = true)
+    (hsize : (if f.isScalar then f.data.length ≤ 8
+      else (encode (.bytes f.data)).length < 256 ^ 8))
+    (hcanon : f.data = [] ∨ f.data.headD 1 ≠ 0)
+    (hImm : signExtend12 f.imm = BitVec.ofNat 64 f.di)
+    (hdst : f.di + fieldWriteLen f ≤ outBytes.length)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + fieldSize f < 2 ^ 64)
+    (hdrop : bs.drop O = encode (.bytes f.data) ++ bs.drop (O + fieldEnc f)) :
+    WP.CFG.Cert base (base + BitVec.ofNat 64 (fieldSize f))
+      (fieldCR base rOut f)
+      (schemaINV regionBase outBase rOut bs (O + fieldEnc f) (fieldUpdate outBytes f)) := by
+  have hlen8 : f.data.length ≤ 8 := by
+    simpa [hscalar] using hsize
+  have hdst8 : f.di + 8 ≤ outBytes.length := by
+    simpa [fieldWriteLen, hscalar] using hdst
+  have hcode_scalar : base.toNat + (if f.data = [] then 248 else 280) < 2 ^ 64 := by
+    simpa [fieldSize, hscalar] using hcode
+  have cert := scalarFieldStepCert base regionBase outBase rOut f.imm bs O f.data
+    (bs.drop (O + fieldEnc f)) outBytes f.di hlen8 hcanon halign hdalign hover hwin hImm hdst8
+    hdov hdval hcode_scalar hdrop
+  simpa [fieldCR, fieldEnc, fieldUpdate, fieldSize, hscalar] using cert
+
+/-- Pure scalar decode fact produced by `scalarFieldSpecStepCert`. -/
+theorem scalarFieldSpecStep_decode
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs : List Byte) (O : Nat) (outBytes : List Byte) (f : FieldSpec)
+    (hscalar : f.isScalar = true)
+    (hsize : (if f.isScalar then f.data.length ≤ 8
+      else (encode (.bytes f.data)).length < 256 ^ 8))
+    (hcanon : f.data = [] ∨ f.data.headD 1 ≠ 0)
+    (hImm : signExtend12 f.imm = BitVec.ofNat 64 f.di)
+    (hdst : f.di + fieldWriteLen f ≤ outBytes.length)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + fieldSize f < 2 ^ 64)
+    (hdrop : bs.drop O = encode (.bytes f.data) ++ bs.drop (O + fieldEnc f)) :
+    decodeScalar (bs.drop O) = some (Nat.fromBytesBE f.data, bs.drop (O + fieldEnc f)) := by
+  have hlen8 : f.data.length ≤ 8 := by
+    simpa [hscalar] using hsize
+  have hdst8 : f.di + 8 ≤ outBytes.length := by
+    simpa [fieldWriteLen, hscalar] using hdst
+  have hcode_scalar : base.toNat + (if f.data = [] then 248 else 280) < 2 ^ 64 := by
+    simpa [fieldSize, hscalar] using hcode
+  exact scalarFieldStep_decode base regionBase outBase rOut f.imm bs O f.data
+    (bs.drop (O + fieldEnc f)) outBytes f.di hlen8 hcanon halign hdalign hover hwin hImm hdst8
+    hdov hdval hcode_scalar hdrop
+
+/-- Field-step automation: choose the scalar or byte WP certificate from the field descriptor. -/
+def fieldSpecStepCert
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs : List Byte) (O : Nat) (outBytes : List Byte) (f : FieldSpec)
+    (hsize : (if f.isScalar then f.data.length ≤ 8
+      else (encode (.bytes f.data)).length < 256 ^ 8))
+    (hcanon : f.isScalar = true → f.data = [] ∨ f.data.headD 1 ≠ 0)
+    (hImm : signExtend12 f.imm = BitVec.ofNat 64 f.di)
+    (hdst : f.di + fieldWriteLen f ≤ outBytes.length)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + fieldSize f < 2 ^ 64)
+    (hdrop : bs.drop O = encode (.bytes f.data) ++ bs.drop (O + fieldEnc f)) :
+    WP.CFG.Cert base (base + BitVec.ofNat 64 (fieldSize f))
+      (fieldCR base rOut f)
+      (schemaINV regionBase outBase rOut bs (O + fieldEnc f) (fieldUpdate outBytes f)) := by
+  by_cases hscalar : f.isScalar = true
+  · exact scalarFieldSpecStepCert base regionBase outBase rOut bs O outBytes f hscalar hsize
+      (hcanon hscalar) hImm hdst halign hdalign hover hwin hdov hdval hcode hdrop
+  · have hbyte : f.isScalar = false := by
+      cases hs : f.isScalar with
+      | false => rfl
+      | true => exact False.elim (hscalar hs)
+    exact byteFieldSpecStepCert base regionBase outBase rOut bs O outBytes f hbyte hsize hImm hdst
+      halign hdalign hover hwin hdov hdval hcode hdrop
+
+/-- Pure decode fact paired with `fieldSpecStepCert`. -/
+theorem fieldSpecStep_decode
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs : List Byte) (O : Nat) (outBytes : List Byte) (f : FieldSpec)
+    (hsize : (if f.isScalar then f.data.length ≤ 8
+      else (encode (.bytes f.data)).length < 256 ^ 8))
+    (hcanon : f.isScalar = true → f.data = [] ∨ f.data.headD 1 ≠ 0)
+    (hImm : signExtend12 f.imm = BitVec.ofNat 64 f.di)
+    (hdst : f.di + fieldWriteLen f ≤ outBytes.length)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + fieldSize f < 2 ^ 64)
+    (hdrop : bs.drop O = encode (.bytes f.data) ++ bs.drop (O + fieldEnc f)) :
+    (if f.isScalar then
+      decodeScalar (bs.drop O) = some (Nat.fromBytesBE f.data, bs.drop (O + fieldEnc f))
+     else
+      decode (bs.drop O) = some (.bytes f.data, bs.drop (O + fieldEnc f))) := by
+  by_cases hscalar : f.isScalar = true
+  · simpa [hscalar] using scalarFieldSpecStep_decode base regionBase outBase rOut bs O outBytes f
+      hscalar hsize (hcanon hscalar) hImm hdst halign hdalign hover hwin hdov hdval hcode hdrop
+  · have hbyte : f.isScalar = false := by
+      cases hs : f.isScalar with
+      | false => rfl
+      | true => exact False.elim (hscalar hs)
+    simpa [hbyte] using byteFieldSpecStep_decode base regionBase outBase rOut bs O outBytes f hbyte
+      hsize hImm hdst halign hdalign hover hwin hdov hdval hcode hdrop
+
 
 end SchemaWP
 

--- a/EvmAsm/Rv64/RLP/UnifiedFieldUnitFullyCanonical.lean
+++ b/EvmAsm/Rv64/RLP/UnifiedFieldUnitFullyCanonical.lean
@@ -69,4 +69,50 @@ theorem unified_bytes_field_decode_and_copy_fully_canonical
       data tail outBytes di0 0 hlen1 hlen55 hsize halign hdalign hover hwin hImm hdst hdov hdval
       hcode hdrop).2
 
+/-- **Fully-canonical non-empty scalar field unit.** As `…_canonical` but `x14` is also
+    `regOwn` in both precondition and postcondition, matching `schemaINV`. -/
+theorem unified_scalar_field_decode_and_store_region_fully_canonical
+    (base regionBase : Word) (rOut : Reg) (outBase : Word) (fieldImm : BitVec 12)
+    (bs : List Byte) (O : Nat) (data tail : List Byte) (outBytes : List Byte) (di0 : Nat)
+    (hlen1 : 1 ≤ data.length) (hlen8 : data.length ≤ 8) (hhead : data.headD 1 ≠ 0)
+    (hsize : (encode (.bytes data)).length < 256 ^ 8)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hImm : signExtend12 fieldImm = BitVec.ofNat 64 di0)
+    (hdst : di0 + 8 ≤ outBytes.length)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + 280 < 2 ^ 64)
+    (hdrop : bs.drop O = encode (.bytes data) ++ tail) :
+    cpsTripleWithin ((61 + (2 + 6 * data.length)) + (1 + 3 * 8)) base
+      (base + 180 + 4 + BitVec.ofNat 64 (12 * 8))
+      (scalarRegionUnitCR base rOut fieldImm)
+      (((regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) ** (regOwn .x11) **
+        (regOwn .x12) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (regOwn .x14) **
+        (regOwn .x15) ** bytesRegion regionBase bs) **
+       ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes))
+      (((regOwn .x11) ** (regOwn .x14) ** (rOut ↦ᵣ outBase) **
+        bytesRegion outBase
+          (spillRange outBytes (BitVec.ofNat 64 (Nat.fromBytesBE data)) di0 8)) **
+       ((.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 (O + (encode (.bytes data)).length))) **
+        regOwn .x12 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs **
+        regOwn .x5 ** regOwn .x10 ** (regOwn .x15)))
+    ∧ decodeScalar (bs.drop O) = some (Nat.fromBytesBE data, tail) := by
+  refine ⟨?_, ?_⟩
+  · refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x14)
+        (P := (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) ** (regOwn .x11) **
+          (regOwn .x12) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+          (regOwn .x15) ** bytesRegion regionBase bs ** ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes))
+        (fun v14 => ?_))
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (sepConj_mono_left (sepConj_mono_right (sepConj_mono_left (regIs_implies_regOwn .x14))))
+      (unified_scalar_field_decode_and_store_region_canonical base regionBase rOut outBase
+        fieldImm bs O data tail outBytes di0 v14 hlen1 hlen8 hhead hsize halign hdalign hover hwin
+        hImm hdst hdov hdval hcode hdrop).1
+  · exact (unified_scalar_field_decode_and_store_region_canonical base regionBase rOut outBase
+      fieldImm bs O data tail outBytes di0 0 hlen1 hlen8 hhead hsize halign hdalign hover hwin hImm
+      hdst hdov hdval hcode hdrop).2
+
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/UnifiedScalarFieldRegion.lean
+++ b/EvmAsm/Rv64/RLP/UnifiedScalarFieldRegion.lean
@@ -36,4 +36,253 @@ theorem spillChainCR_none (bw a : Word) (N : Nat)
         from by bv_omega] at this)
     simp only [spillChainCR, CodeReq.union, h1, h2]
 
+/-- Full non-empty scalar field decode-and-store into region. Decode the byte-string scalar at
+    x13 = regionBase + ofNat O, read its non-empty big-endian payload into x11, and spill that
+    u64 value little-endian into the output struct region at byte offset di0. The guard
+    data.headD 1 != 0 is the scalar canonicality condition enforced by decodeScalar. -/
+theorem unified_scalar_field_decode_and_store_region
+    (base regionBase : Word) (rOut : Reg) (outBase : Word) (fieldImm : BitVec 12)
+    (bs : List Byte) (O : Nat) (data tail : List Byte) (outBytes : List Byte) (di0 : Nat)
+    (v5Old v10 v11Old v12Old v14Old v15Old : Word)
+    (hlen1 : 1 ≤ data.length) (hlen8 : data.length ≤ 8) (hhead : data.headD 1 ≠ 0)
+    (hsize : (encode (.bytes data)).length < 256 ^ 8)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hImm : signExtend12 fieldImm = BitVec.ofNat 64 di0)
+    (hdst : di0 + 8 ≤ outBytes.length)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + 280 < 2 ^ 64)
+    (hdrop : bs.drop O = encode (.bytes data) ++ tail) :
+    cpsTripleWithin ((61 + (2 + 6 * data.length)) + (1 + 3 * 8)) base
+      (base + 180 + 4 + BitVec.ofNat 64 (12 * 8))
+      (((CodeReq.singleton base (.LBU .x5 .x13 0)).union
+          (CodeReq.ofProg (base + 4) unified_decoder_prog)).union
+        ((((CodeReq.singleton (base + 148) (.ADDI .x14 .x11 0)).union
+            (CodeReq.singleton (base + 152) (.ADDI .x11 .x0 0))).union
+            (CodeReq.ofProg (base + 156) (rlp_phase2_long_loop_body_prog (-20)))).union
+          ((CodeReq.singleton (base + 180) (.ADDI .x14 rOut fieldImm)).union
+            (spillChainCR (base + 180 + 4) 8))))
+      (((.x5 ↦ᵣ v5Old) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
+        (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (.x14 ↦ᵣ v14Old) **
+        (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs) **
+       ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes))
+      (((regOwn .x11) ** (.x14 ↦ᵣ (outBase + BitVec.ofNat 64 (di0 + 8))) ** (rOut ↦ᵣ outBase) **
+        bytesRegion outBase
+          (spillRange outBytes (BitVec.ofNat 64 (Nat.fromBytesBE data)) di0 8)) **
+       ((.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 (O + (encode (.bytes data)).length))) **
+        regOwn .x12 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs **
+        regOwn .x5 ** regOwn .x10 ** (.x15 ↦ᵣ v15Old)))
+    ∧ decodeScalar (bs.drop O) = some (Nat.fromBytesBE data, tail) := by
+  have hlen55 : data.length ≤ 55 := by omega
+  have hbs0 : O < bs.length := by
+    have h := congrArg List.length hdrop
+    rw [List.length_drop, List.length_append] at h
+    have := encode_nonempty (RLPItem.bytes data); omega
+  have hbs_head : bs[O]'hbs0 = (encode (.bytes data))[0]'(encode_nonempty (RLPItem.bytes data)) := by
+    have key : (bs.drop O)[0]'(by rw [List.length_drop]; omega)
+        = (encode (.bytes data))[0]'(encode_nonempty (RLPItem.bytes data)) :=
+      (List.getElem_of_eq hdrop _).trans (List.getElem_append_left (encode_nonempty _))
+    rw [← key]; simp
+  obtain ⟨payloadOff, hptr, hlen, hpay⟩ :=
+    bytes_item_payload_window data tail regionBase O bs hdrop hlen55
+  rw [show ((encode (.bytes data))[0]'(encode_nonempty (RLPItem.bytes data)))
+        = (bs[O]'hbs0) from hbs_head.symm] at hptr hlen
+  have hpaylen : payloadOff + data.length ≤ bs.length := by
+    have e1 := congrArg List.length hpay
+    rw [List.length_drop, List.length_append] at e1
+    omega
+  have hstride : payloadOff + data.length = O + (encode (.bytes data)).length := by
+    have e1 := congrArg List.length hpay
+    have e2 := congrArg List.length hdrop
+    simp only [List.length_drop, List.length_append] at e1 e2; omega
+  have htake : (bs.drop payloadOff).take data.length = data := by
+    rw [hpay, List.take_left' rfl]
+  have hwindow0 : regionLongWindow regionBase bs O hbs0 :=
+    regionLongWindow_of_split regionBase bs (.bytes data) tail O hbs0 hbs_head hdrop
+      (by simpa [itemPayloadCount] using (show data.length < 256 ^ 8 by omega)) hwin
+  have hdesc := unified_list_header_descend base regionBase bs O hbs0 v5Old v10 v11Old v12Old
+    v14Old v15Old halign hover (hwin O hbs0) hwindow0
+  rw [hptr, hlen] at hdesc
+  have hread := unified_field_scalar_read (base + 148) regionBase bs payloadOff data.length
+    (itemX12Region (bs[O]'hbs0) bs O v12Old) (itemX14 (bs[O]'hbs0) v14Old)
+    hlen1 hlen8 halign hover
+    (fun i hi => ⟨by omega, hwin (payloadOff + i) (by omega)⟩)
+  rw [show (base + 148) + 32 = base + 180 from by bv_omega,
+      show (base + 148) + 4 = base + 152 from by bv_omega,
+      show (base + 148) + 8 = base + 156 from by bv_omega, htake] at hread
+  have hreadF := cpsTripleWithin_frameR
+    (regOwn .x5 ** regOwn .x10 ** (.x15 ↦ᵣ v15Old) **
+      ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes))
+    (by pcFree) hread
+  have hstore := unified_field_scalar_store_region (base + 180) rOut outBase fieldImm outBytes di0 8
+    (BitVec.ofNat 64 (Nat.fromBytesBE data)) (0 : Word)
+    hdalign hdst hdov hdval
+    (by have h180 : (base + 180).toNat = base.toNat + 180 := by bv_omega
+        omega) hImm
+  have hstoreF := cpsTripleWithin_frameR
+    ((.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 (payloadOff + data.length))) **
+      regOwn .x12 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs **
+      regOwn .x5 ** regOwn .x10 ** (.x15 ↦ᵣ v15Old))
+    (by pcFree) hstore
+  have hd_desc_read : ((CodeReq.singleton base (.LBU .x5 .x13 0)).union
+        (CodeReq.ofProg (base + 4) unified_decoder_prog)).Disjoint
+      (((CodeReq.singleton (base + 148) (.ADDI .x14 .x11 0)).union
+          (CodeReq.singleton (base + 152) (.ADDI .x11 .x0 0))).union
+          (CodeReq.ofProg (base + 156) (rlp_phase2_long_loop_body_prog (-20)))) := by
+    refine CodeReq.Disjoint.union_left ?_ ?_
+    · refine CodeReq.Disjoint.union_right ?_ ?_
+      · refine CodeReq.Disjoint.union_right (CodeReq.Disjoint.singleton (by bv_omega)) ?_
+        exact CodeReq.Disjoint.singleton (by bv_omega)
+      · exact CodeReq.Disjoint.singleton_ofProg
+          (CodeReq.ofProg_none_range_len (base + 156) (rlp_phase2_long_loop_body_prog (-20)) 6 base
+            (by rfl) (by intro k hk; bv_omega))
+    · refine CodeReq.Disjoint.union_right ?_ ?_
+      · refine CodeReq.Disjoint.union_right ?_ ?_
+        · exact CodeReq.Disjoint.ofProg_singleton
+            (CodeReq.ofProg_none_range_len (base + 4) unified_decoder_prog 36 (base + 148)
+              unified_decoder_prog_length (by intro k hk; bv_omega))
+        · exact CodeReq.Disjoint.ofProg_singleton
+            (CodeReq.ofProg_none_range_len (base + 4) unified_decoder_prog 36 (base + 152)
+              unified_decoder_prog_length (by intro k hk; bv_omega))
+      · intro a
+        by_cases hdec : ∀ k, k < 36 → a ≠ (base + 4) + BitVec.ofNat 64 (4 * k)
+        · exact Or.inl (CodeReq.ofProg_none_range_len (base + 4) unified_decoder_prog 36 a
+            unified_decoder_prog_length hdec)
+        · push Not at hdec
+          obtain ⟨k, hk, rfl⟩ := hdec
+          exact Or.inr (CodeReq.ofProg_none_range_len (base + 156)
+            (rlp_phase2_long_loop_body_prog (-20)) 6 _ (by rfl) (by intro j hj; bv_omega))
+  have hd_read_store : (((CodeReq.singleton (base + 148) (.ADDI .x14 .x11 0)).union
+          (CodeReq.singleton (base + 152) (.ADDI .x11 .x0 0))).union
+          (CodeReq.ofProg (base + 156) (rlp_phase2_long_loop_body_prog (-20)))).Disjoint
+      ((CodeReq.singleton (base + 180) (.ADDI .x14 rOut fieldImm)).union
+        (spillChainCR (base + 180 + 4) 8)) := by
+    refine CodeReq.Disjoint.union_left ?_ ?_
+    · refine CodeReq.Disjoint.union_left ?_ ?_
+      · refine CodeReq.Disjoint.union_right (CodeReq.Disjoint.singleton (by bv_omega)) ?_
+        exact singleton_disjoint_spillChainCR (base + 148) (base + 180 + 4)
+          (.ADDI .x14 .x11 0) 8 (by bv_omega) (by bv_omega)
+      · refine CodeReq.Disjoint.union_right (CodeReq.Disjoint.singleton (by bv_omega)) ?_
+        exact singleton_disjoint_spillChainCR (base + 152) (base + 180 + 4)
+          (.ADDI .x11 .x0 0) 8 (by bv_omega) (by bv_omega)
+    · refine CodeReq.Disjoint.union_right ?_ ?_
+      · exact CodeReq.Disjoint.ofProg_singleton
+          (CodeReq.ofProg_none_range_len (base + 156) (rlp_phase2_long_loop_body_prog (-20)) 6
+            (base + 180) (by rfl) (by intro k hk; bv_omega))
+      · intro a
+        by_cases hloop : ∀ k, k < 6 → a ≠ (base + 156) + BitVec.ofNat 64 (4 * k)
+        · exact Or.inl (CodeReq.ofProg_none_range_len (base + 156)
+            (rlp_phase2_long_loop_body_prog (-20)) 6 a (by rfl) hloop)
+        · push Not at hloop
+          obtain ⟨k, hk, rfl⟩ := hloop
+          exact Or.inr (spillChainCR_none (base + 180 + 4) _ 8 (fun j hj => by bv_omega))
+  have hd_desc_store : ((CodeReq.singleton base (.LBU .x5 .x13 0)).union
+        (CodeReq.ofProg (base + 4) unified_decoder_prog)).Disjoint
+      ((CodeReq.singleton (base + 180) (.ADDI .x14 rOut fieldImm)).union
+        (spillChainCR (base + 180 + 4) 8)) := by
+    refine CodeReq.Disjoint.union_left ?_ ?_
+    · refine CodeReq.Disjoint.union_right (CodeReq.Disjoint.singleton (by bv_omega)) ?_
+      exact singleton_disjoint_spillChainCR base (base + 180 + 4) (.LBU .x5 .x13 0) 8
+        (by bv_omega) (by bv_omega)
+    · refine CodeReq.Disjoint.union_right ?_ ?_
+      · exact CodeReq.Disjoint.ofProg_singleton
+          (CodeReq.ofProg_none_range_len (base + 4) unified_decoder_prog 36 (base + 180)
+            unified_decoder_prog_length (by intro k hk; bv_omega))
+      · intro a
+        by_cases hdec : ∀ k, k < 36 → a ≠ (base + 4) + BitVec.ofNat 64 (4 * k)
+        · exact Or.inl (CodeReq.ofProg_none_range_len (base + 4) unified_decoder_prog 36 a
+            unified_decoder_prog_length hdec)
+        · push Not at hdec
+          obtain ⟨k, hk, rfl⟩ := hdec
+          exact Or.inr (spillChainCR_none (base + 180 + 4) _ 8 (fun j hj => by bv_omega))
+  have hd_desc_tail : ((CodeReq.singleton base (.LBU .x5 .x13 0)).union
+        (CodeReq.ofProg (base + 4) unified_decoder_prog)).Disjoint
+      ((((CodeReq.singleton (base + 148) (.ADDI .x14 .x11 0)).union
+          (CodeReq.singleton (base + 152) (.ADDI .x11 .x0 0))).union
+          (CodeReq.ofProg (base + 156) (rlp_phase2_long_loop_body_prog (-20)))).union
+        ((CodeReq.singleton (base + 180) (.ADDI .x14 rOut fieldImm)).union
+          (spillChainCR (base + 180 + 4) 8))) :=
+    CodeReq.Disjoint.union_right hd_desc_read hd_desc_store
+  have hreadForStore : cpsTripleWithin (2 + 6 * data.length) (base + 148) (base + 180)
+      (((CodeReq.singleton (base + 148) (.ADDI .x14 .x11 0)).union
+          (CodeReq.singleton (base + 152) (.ADDI .x11 .x0 0))).union
+        (CodeReq.ofProg (base + 156) (rlp_phase2_long_loop_body_prog (-20))))
+      (((.x11 ↦ᵣ BitVec.ofNat 64 data.length) **
+          (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 payloadOff)) **
+          (.x14 ↦ᵣ itemX14 (bs[O]'hbs0) v14Old) **
+          (.x12 ↦ᵣ itemX12Region (bs[O]'hbs0) bs O v12Old) **
+          (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs) **
+        regOwn .x5 ** regOwn .x10 ** (.x15 ↦ᵣ v15Old) **
+        (rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes)
+      (((.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE data)) **
+          (.x14 ↦ᵣ (0 : Word)) ** (rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes) **
+        (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 (payloadOff + data.length))) **
+        regOwn .x12 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs **
+        regOwn .x5 ** regOwn .x10 ** (.x15 ↦ᵣ v15Old)) := by
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun h hp => by
+      have htmp : ((.x12 ↦ᵣ (bs.getD (payloadOff + (data.length - 1)) 0).zeroExtend 64) **
+          ((.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE data)) **
+           (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 (payloadOff + data.length))) **
+           (.x14 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs **
+           regOwn .x5 ** regOwn .x10 ** (.x15 ↦ᵣ v15Old) **
+           ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes))) h := by
+        xperm_hyp hp
+      have hx12 : (regOwn .x12 **
+          ((.x11 ↦ᵣ BitVec.ofNat 64 (Nat.fromBytesBE data)) **
+           (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 (payloadOff + data.length))) **
+           (.x14 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs **
+           regOwn .x5 ** regOwn .x10 ** (.x15 ↦ᵣ v15Old) **
+           ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes))) h :=
+        sepConj_mono_left (regIs_implies_regOwn .x12) h htmp
+      xperm_hyp hx12) hreadF
+  have hread_then_store := cpsTripleWithin_seq hd_read_store hreadForStore hstoreF
+  have hdescForRead : cpsTripleWithin 61 base (base + 148)
+      ((CodeReq.singleton base (.LBU .x5 .x13 0)).union
+        (CodeReq.ofProg (base + 4) unified_decoder_prog))
+      (((.x5 ↦ᵣ v5Old) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) **
+        (.x12 ↦ᵣ v12Old) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (.x14 ↦ᵣ v14Old) **
+        (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs) **
+       ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes))
+      (((.x11 ↦ᵣ BitVec.ofNat 64 data.length) **
+          (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 payloadOff)) **
+          (.x14 ↦ᵣ itemX14 (bs[O]'hbs0) v14Old) **
+          (.x12 ↦ᵣ itemX12Region (bs[O]'hbs0) bs O v12Old) **
+          (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs) **
+        regOwn .x5 ** regOwn .x10 ** (.x15 ↦ᵣ v15Old) **
+        (rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes) := by
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun h hp => by
+      have htmp : (((.x5 ↦ᵣ (bs[O]'hbs0).zeroExtend 64) ** (.x10 ↦ᵣ itemResidue (bs[O]'hbs0))) **
+          ((.x11 ↦ᵣ BitVec.ofNat 64 data.length) **
+           (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 payloadOff)) **
+           (.x14 ↦ᵣ itemX14 (bs[O]'hbs0) v14Old) **
+           (.x12 ↦ᵣ itemX12Region (bs[O]'hbs0) bs O v12Old) **
+           (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs **
+           (.x15 ↦ᵣ v15Old) ** ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes))) h := by
+        xperm_hyp hp
+      have htmp' : ((regOwn .x5 ** regOwn .x10) **
+          ((.x11 ↦ᵣ BitVec.ofNat 64 data.length) **
+           (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 payloadOff)) **
+           (.x14 ↦ᵣ itemX14 (bs[O]'hbs0) v14Old) **
+           (.x12 ↦ᵣ itemX12Region (bs[O]'hbs0) bs O v12Old) **
+           (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs **
+           (.x15 ↦ᵣ v15Old) ** ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes))) h :=
+        sepConj_mono_left
+          (sepConj_mono (regIs_implies_regOwn .x5) (regIs_implies_regOwn .x10)) h htmp
+      xperm_hyp htmp')
+      (cpsTripleWithin_frameR ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes)
+        (by exact pcFree_sepConj pcFree_regIs (bytesRegion_pcFree _ _)) hdesc)
+  have all := cpsTripleWithin_seq hd_desc_tail hdescForRead hread_then_store
+  refine ⟨?_, ?_⟩
+  · rw [show O + (encode (.bytes data)).length = payloadOff + data.length from hstride.symm]
+    rw [show (61 + (2 + 6 * data.length)) + (1 + 3 * 8)
+        = 61 + (2 + 6 * data.length) + (1 + 3 * 8) by ring]
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp) all
+  · unfold decodeScalar
+    have hpure : decode (bs.drop O) = some (.bytes data, tail) := by
+      rw [hdrop]; exact decode_encode_append (.bytes data) tail hsize
+    rw [hpure]
+    simp only [Option.bind_eq_bind, Option.bind_some, hhead, ↓reduceIte]
+
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/UnifiedScalarFieldRegionCanonical.lean
+++ b/EvmAsm/Rv64/RLP/UnifiedScalarFieldRegionCanonical.lean
@@ -24,6 +24,127 @@ open EvmAsm.Rv64
 open EvmAsm.EL.RLP
 open EvmAsm.Rv64.Tactics
 
+
+/-- **`regOwn`-re-entry non-empty scalar field.** As
+    `unified_scalar_field_decode_and_store_region` but `x5, x10, x11, x12` are `regOwn` in the
+    precondition, so it can be called after a previous field unit. -/
+theorem unified_scalar_field_decode_and_store_region_at_regOwn
+    (base regionBase : Word) (rOut : Reg) (outBase : Word) (fieldImm : BitVec 12)
+    (bs : List Byte) (O : Nat) (data tail : List Byte) (outBytes : List Byte) (di0 : Nat)
+    (v14Old v15Old : Word)
+    (hlen1 : 1 ≤ data.length) (hlen8 : data.length ≤ 8) (hhead : data.headD 1 ≠ 0)
+    (hsize : (encode (.bytes data)).length < 256 ^ 8)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hImm : signExtend12 fieldImm = BitVec.ofNat 64 di0)
+    (hdst : di0 + 8 ≤ outBytes.length)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + 280 < 2 ^ 64)
+    (hdrop : bs.drop O = encode (.bytes data) ++ tail) :
+    cpsTripleWithin ((61 + (2 + 6 * data.length)) + (1 + 3 * 8)) base
+      (base + 180 + 4 + BitVec.ofNat 64 (12 * 8))
+      (scalarRegionUnitCR base rOut fieldImm)
+      (((regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) ** (regOwn .x11) **
+        (regOwn .x12) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (.x14 ↦ᵣ v14Old) **
+        (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs) **
+       ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes))
+      (((regOwn .x11) ** (.x14 ↦ᵣ (outBase + BitVec.ofNat 64 (di0 + 8))) ** (rOut ↦ᵣ outBase) **
+        bytesRegion outBase
+          (spillRange outBytes (BitVec.ofNat 64 (Nat.fromBytesBE data)) di0 8)) **
+       ((.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 (O + (encode (.bytes data)).length))) **
+        regOwn .x12 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs **
+        regOwn .x5 ** regOwn .x10 ** (.x15 ↦ᵣ v15Old)))
+    ∧ decodeScalar (bs.drop O) = some (Nat.fromBytesBE data, tail) := by
+  refine ⟨?_, ?_⟩
+  · refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x5)
+        (P := (.x0 ↦ᵣ (0 : Word)) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+          (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs **
+          ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes) **
+          regOwn .x10 ** regOwn .x11 ** regOwn .x12)
+        (fun v5 => ?_))
+    refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x10)
+        (P := (.x0 ↦ᵣ (0 : Word)) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+          (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs **
+          ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes) **
+          (.x5 ↦ᵣ v5) ** regOwn .x11 ** regOwn .x12)
+        (fun v10 => ?_))
+    refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x11)
+        (P := (.x0 ↦ᵣ (0 : Word)) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+          (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs **
+          ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes) **
+          (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** regOwn .x12)
+        (fun v11 => ?_))
+    refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x12)
+        (P := (.x0 ↦ᵣ (0 : Word)) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+          (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ v15Old) ** bytesRegion regionBase bs **
+          ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes) **
+          (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11))
+        (fun v12 => ?_))
+    unfold scalarRegionUnitCR
+    rw [CodeReq.union_assoc]
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (unified_scalar_field_decode_and_store_region base regionBase rOut outBase fieldImm bs O
+        data tail outBytes di0 v5 v10 v11 v12 v14Old v15Old hlen1 hlen8 hhead hsize
+        halign hdalign hover hwin hImm hdst hdov hdval hcode hdrop).1
+  · exact (unified_scalar_field_decode_and_store_region base regionBase rOut outBase fieldImm bs O
+      data tail outBytes di0 0 0 0 0 v14Old v15Old hlen1 hlen8 hhead hsize halign hdalign hover
+      hwin hImm hdst hdov hdval hcode hdrop).2
+
+/-- **Canonical non-empty scalar field.** As `…_at_regOwn` but `x15` is also `regOwn` in the
+    precondition and postcondition. -/
+theorem unified_scalar_field_decode_and_store_region_canonical
+    (base regionBase : Word) (rOut : Reg) (outBase : Word) (fieldImm : BitVec 12)
+    (bs : List Byte) (O : Nat) (data tail : List Byte) (outBytes : List Byte) (di0 : Nat)
+    (v14Old : Word)
+    (hlen1 : 1 ≤ data.length) (hlen8 : data.length ≤ 8) (hhead : data.headD 1 ≠ 0)
+    (hsize : (encode (.bytes data)).length < 256 ^ 8)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hImm : signExtend12 fieldImm = BitVec.ofNat 64 di0)
+    (hdst : di0 + 8 ≤ outBytes.length)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + 280 < 2 ^ 64)
+    (hdrop : bs.drop O = encode (.bytes data) ++ tail) :
+    cpsTripleWithin ((61 + (2 + 6 * data.length)) + (1 + 3 * 8)) base
+      (base + 180 + 4 + BitVec.ofNat 64 (12 * 8))
+      (scalarRegionUnitCR base rOut fieldImm)
+      (((regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) ** (regOwn .x11) **
+        (regOwn .x12) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (.x14 ↦ᵣ v14Old) **
+        (regOwn .x15) ** bytesRegion regionBase bs) **
+       ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes))
+      (((regOwn .x11) ** (.x14 ↦ᵣ (outBase + BitVec.ofNat 64 (di0 + 8))) ** (rOut ↦ᵣ outBase) **
+        bytesRegion outBase
+          (spillRange outBytes (BitVec.ofNat 64 (Nat.fromBytesBE data)) di0 8)) **
+       ((.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 (O + (encode (.bytes data)).length))) **
+        regOwn .x12 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion regionBase bs **
+        regOwn .x5 ** regOwn .x10 ** (regOwn .x15)))
+    ∧ decodeScalar (bs.drop O) = some (Nat.fromBytesBE data, tail) := by
+  refine ⟨?_, ?_⟩
+  · refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ h => h)
+      (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x15)
+        (P := (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) ** (regOwn .x11) **
+          (regOwn .x12) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (.x14 ↦ᵣ v14Old) **
+          bytesRegion regionBase bs ** ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes))
+        (fun v15 => ?_))
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+        (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+          (regIs_implies_regOwn .x15))))))))
+      (unified_scalar_field_decode_and_store_region_at_regOwn base regionBase rOut outBase
+        fieldImm bs O data tail outBytes di0 v14Old v15 hlen1 hlen8 hhead hsize halign hdalign
+        hover hwin hImm hdst hdov hdval hcode hdrop).1
+  · exact (unified_scalar_field_decode_and_store_region_at_regOwn base regionBase rOut outBase
+      fieldImm bs O data tail outBytes di0 v14Old 0 hlen1 hlen8 hhead hsize halign hdalign hover
+      hwin hImm hdst hdov hdval hcode hdrop).2
+
 set_option maxRecDepth 8000 in
 /-- **Canonical byte-array field decode-and-copy into region.** As
     `unified_bytes_field_decode_and_copy_at_regOwn` but `x15` is also owned abstractly (`regOwn`)

--- a/EvmAsm/Rv64/RLP/ValidatingBytesCopy.lean
+++ b/EvmAsm/Rv64/RLP/ValidatingBytesCopy.lean
@@ -19,6 +19,7 @@
 import EvmAsm.Rv64.RLP.UnifiedDecodeItemShortBytesValidatedAt
 import EvmAsm.Rv64.RLP.UnifiedFieldBytesCopy
 import EvmAsm.Rv64.RLP.ValidatingFieldWalk
+import EvmAsm.Rv64.WP.CFG
 
 namespace EvmAsm.Rv64.RLP
 
@@ -33,36 +34,6 @@ private theorem bytescopy_ptr_eq (regionBase : Word) (O : Nat) :
     = regionBase + BitVec.ofNat 64 (O + 1) := by
   rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide,
       show (1 : Word) = BitVec.ofNat 64 1 from rfl, BitVec.add_assoc, ← BitVec.ofNat_add]
-
-/-- Sequence a branch onto the TAKEN exit of a branch, converging the follow-on branch's TAKEN exit
-    with the first branch's fall exit onto a shared fail exit `exitF`. Used to bolt a length-equality
-    check onto a validating decode's success so that *both* a malformed field (the decoder's bound
-    failure) and a wrong-length field converge on the one `a0 ≠ 0` exit. -/
-theorem cpsBranchWithin_seq_cpsBranchWithin_taken_conv {n1 n2 : Nat}
-    {entry mid succ exitF : Word} {cr1 cr2 : CodeReq} (hd : cr1.Disjoint cr2)
-    {P Q_t1 Q_f1 Q_t2 Q_succ Q_f : Assertion}
-    (h1 : cpsBranchWithin n1 entry cr1 P mid Q_t1 exitF Q_f1)
-    (h2 : cpsBranchWithin n2 mid cr2 Q_t1 exitF Q_t2 succ Q_succ)
-    (hf1 : ∀ h, Q_f1 h → Q_f h) (hf2 : ∀ h, Q_t2 h → Q_f h) :
-    cpsBranchWithin (n1 + n2) entry (cr1.union cr2) P succ Q_succ exitF Q_f := by
-  intro R hR s hcr hPR hpc
-  rw [CodeReq.union_satisfiedBy hd] at hcr
-  obtain ⟨hcr1, hcr2⟩ := hcr
-  obtain ⟨k1, hk1, s1, hstep1, hbranch1⟩ := h1 R hR s hcr1 hPR hpc
-  rcases hbranch1 with ⟨hpc_t1, hQ_t1R⟩ | ⟨hpc_f1, hQ_f1R⟩
-  · have hcr2' := CodeReq.SatisfiedBy_preserved hstep1 hcr2
-    obtain ⟨k2, hk2, s2, hstep2, hbranch2⟩ := h2 R hR s1 hcr2' hQ_t1R hpc_t1
-    rcases hbranch2 with ⟨hpc_t2, hQ_t2R⟩ | ⟨hpc_f2, hQ_succR⟩
-    · exact ⟨k1 + k2, Nat.add_le_add hk1 hk2, s2, stepN_add_eq hstep1 hstep2,
-        Or.inr ⟨hpc_t2, by
-          obtain ⟨hp, hcompat, hpq⟩ := hQ_t2R
-          exact ⟨hp, hcompat, sepConj_mono_left hf2 hp hpq⟩⟩⟩
-    · exact ⟨k1 + k2, Nat.add_le_add hk1 hk2, s2, stepN_add_eq hstep1 hstep2,
-        Or.inl ⟨hpc_f2, hQ_succR⟩⟩
-  · exact ⟨k1, Nat.le_trans hk1 (Nat.le_add_right n1 n2), s1, hstep1,
-      Or.inr ⟨hpc_f1, by
-        obtain ⟨hp, hcompat, hpq⟩ := hQ_f1R
-        exact ⟨hp, hcompat, sepConj_mono_left hf1 hp hpq⟩⟩⟩
 
 /-- Merge two pure facts carried in the two top-level operands of a separating conjunction into a
     single conjunctive pure: `(R1 ** ⌜P⌝) ** (R2 ** ⌜Q⌝) ⟹ (R1 ** R2) ** ⌜P ∧ Q⌝`. General in
@@ -326,40 +297,68 @@ theorem rlp_decode_shortBytes_bytescopy_at
   -- The length check on the success exit.
   have lenCheck := rlp_shortBytes_length_check pfx rest bs O expectedN v12Old v14Old regionBase
     succPC lenFailOff (e2_target + 12) hlenfail hexp11 (by omega) hpl64 hd_addibne
-  -- Converge: arm fall (decode = none) and length-check fail (payloadLen ≠ expectedN).
-  have armWithLen := cpsBranchWithin_seq_cpsBranchWithin_taken_conv hd_lencheck decAt lenCheck
-      (fun h hp => by
-        show ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) ** regOwn .x10 **
-            (.x11 ↦ᵣ (BitVec.ofNat 64 (rlpPrefixShortBytesPayloadLen pfx))) ** (.x12 ↦ᵣ v12Old) **
-            (.x13 ↦ᵣ ((regionBase + BitVec.ofNat 64 O) + signExtend12 (1 : BitVec 12))) **
-            (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ (BitVec.ofNat 64 (pfx :: rest).length)) **
-            bytesRegion regionBase bs **
-            ⌜decode (pfx :: rest) = none ∨ rlpPrefixShortBytesPayloadLen pfx ≠ expectedN⌝) h
-        extract_pure hp
-        obtain ⟨hnone, hst⟩ := hp
-        have hst' := sepConj_mono_left (sepConj_mono_left (sepConj_mono_left (sepConj_mono_left
-          (sepConj_mono_left (sepConj_mono_left
-            (sepConj_mono_right (regIs_implies_regOwn .x10))))))) h hst
-        have hg := (sepConj_pure_right h).2 ⟨hst',
-          (Or.inl hnone : decode (pfx :: rest) = none
-            ∨ rlpPrefixShortBytesPayloadLen pfx ≠ expectedN)⟩
-        xperm_hyp hg)
-      (fun h hp => by
-        show ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) ** regOwn .x10 **
-            (.x11 ↦ᵣ (BitVec.ofNat 64 (rlpPrefixShortBytesPayloadLen pfx))) ** (.x12 ↦ᵣ v12Old) **
-            (.x13 ↦ᵣ ((regionBase + BitVec.ofNat 64 O) + signExtend12 (1 : BitVec 12))) **
-            (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ (BitVec.ofNat 64 (pfx :: rest).length)) **
-            bytesRegion regionBase bs **
-            ⌜decode (pfx :: rest) = none ∨ rlpPrefixShortBytesPayloadLen pfx ≠ expectedN⌝) h
-        extract_pure hp
-        obtain ⟨hne, hst⟩ := hp
-        have hst' := sepConj_mono_left (sepConj_mono_left (sepConj_mono_left (sepConj_mono_left
-          (sepConj_mono_left (sepConj_mono_left
-            (sepConj_mono_right (regIs_implies_regOwn .x10))))))) h hst
-        have hg := (sepConj_pure_right h).2 ⟨hst',
-          (Or.inr hne : decode (pfx :: rest) = none
-            ∨ rlpPrefixShortBytesPayloadLen pfx ≠ expectedN)⟩
-        xperm_hyp hg)
+  -- Converge: arm fall (decode = none) and length-check fail (payloadLen != expectedN).
+  let failPost : Assertion :=
+    ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) ** regOwn .x10 **
+      (.x11 ↦ᵣ (BitVec.ofNat 64 (rlpPrefixShortBytesPayloadLen pfx))) ** (.x12 ↦ᵣ v12Old) **
+      (.x13 ↦ᵣ ((regionBase + BitVec.ofNat 64 O) + signExtend12 (1 : BitVec 12))) **
+      (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ (BitVec.ofNat 64 (pfx :: rest).length)) **
+      bytesRegion regionBase bs **
+      ⌜decode (pfx :: rest) = none ∨ rlpPrefixShortBytesPayloadLen pfx ≠ expectedN⌝)
+  have decodeFailToShared : EvmAsm.Rv64.WP.Entails
+      (((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xB8 : BitVec 12))) **
+        (.x11 ↦ᵣ (BitVec.ofNat 64 (rlpPrefixShortBytesPayloadLen pfx))) ** (.x12 ↦ᵣ v12Old) **
+        (.x13 ↦ᵣ ((regionBase + BitVec.ofNat 64 O) + signExtend12 (1 : BitVec 12))) **
+        (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ (BitVec.ofNat 64 (pfx :: rest).length)) **
+        bytesRegion regionBase bs ** ⌜decode (pfx :: rest) = none⌝)) failPost := by
+    intro h hp
+    show ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) ** regOwn .x10 **
+        (.x11 ↦ᵣ (BitVec.ofNat 64 (rlpPrefixShortBytesPayloadLen pfx))) ** (.x12 ↦ᵣ v12Old) **
+        (.x13 ↦ᵣ ((regionBase + BitVec.ofNat 64 O) + signExtend12 (1 : BitVec 12))) **
+        (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ (BitVec.ofNat 64 (pfx :: rest).length)) **
+        bytesRegion regionBase bs **
+        ⌜decode (pfx :: rest) = none ∨ rlpPrefixShortBytesPayloadLen pfx ≠ expectedN⌝) h
+    extract_pure hp
+    obtain ⟨hnone, hst⟩ := hp
+    have hstNext := sepConj_mono_left (sepConj_mono_left (sepConj_mono_left (sepConj_mono_left
+      (sepConj_mono_left (sepConj_mono_left
+        (sepConj_mono_right (regIs_implies_regOwn .x10))))))) h hst
+    have hg := (sepConj_pure_right h).2 ⟨hstNext,
+      (Or.inl hnone : decode (pfx :: rest) = none
+        ∨ rlpPrefixShortBytesPayloadLen pfx ≠ expectedN)⟩
+    xperm_hyp hg
+  have lenFailToShared : EvmAsm.Rv64.WP.Entails
+      (((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x10 ↦ᵣ (BitVec.ofNat 64 expectedN)) **
+        (.x11 ↦ᵣ (BitVec.ofNat 64 (rlpPrefixShortBytesPayloadLen pfx))) ** (.x12 ↦ᵣ v12Old) **
+        (.x13 ↦ᵣ ((regionBase + BitVec.ofNat 64 O) + signExtend12 (1 : BitVec 12))) **
+        (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ (BitVec.ofNat 64 (pfx :: rest).length)) **
+        bytesRegion regionBase bs ** ⌜rlpPrefixShortBytesPayloadLen pfx ≠ expectedN⌝)) failPost := by
+    intro h hp
+    show ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) ** regOwn .x10 **
+        (.x11 ↦ᵣ (BitVec.ofNat 64 (rlpPrefixShortBytesPayloadLen pfx))) ** (.x12 ↦ᵣ v12Old) **
+        (.x13 ↦ᵣ ((regionBase + BitVec.ofNat 64 O) + signExtend12 (1 : BitVec 12))) **
+        (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ (BitVec.ofNat 64 (pfx :: rest).length)) **
+        bytesRegion regionBase bs **
+        ⌜decode (pfx :: rest) = none ∨ rlpPrefixShortBytesPayloadLen pfx ≠ expectedN⌝) h
+    extract_pure hp
+    obtain ⟨hne, hst⟩ := hp
+    have hstNext := sepConj_mono_left (sepConj_mono_left (sepConj_mono_left (sepConj_mono_left
+      (sepConj_mono_left (sepConj_mono_left
+        (sepConj_mono_right (regIs_implies_regOwn .x10))))))) h hst
+    have hg := (sepConj_pure_right h).2 ⟨hstNext,
+      (Or.inr hne : decode (pfx :: rest) = none
+        ∨ rlpPrefixShortBytesPayloadLen pfx ≠ expectedN)⟩
+    xperm_hyp hg
+  have armWithLen : cpsBranchWithin (7 + 2) base _ _
+      (succPC + 8) _ (e2_target + 12) failPost :=
+    (EvmAsm.Rv64.WP.CFG.branchSeqTakenBranchConvergeDisjoint
+      (failPost := failPost) hd_lencheck
+      (EvmAsm.Rv64.WP.Branch.ofSpec decAt)
+      (EvmAsm.Rv64.WP.Branch.ofSpec lenCheck)
+      (by rfl) (EvmAsm.Rv64.WP.Entails.refl _)
+      decodeFailToShared lenFailToShared).sound
   -- Frame the output pointer + region onto both exits of armWithLen.
   have armWithLenF := cpsBranchWithin_frameR
     ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes)

--- a/EvmAsm/Rv64/RLP/ValidatingBytesCopy.lean
+++ b/EvmAsm/Rv64/RLP/ValidatingBytesCopy.lean
@@ -20,6 +20,7 @@ import EvmAsm.Rv64.RLP.UnifiedDecodeItemShortBytesValidatedAt
 import EvmAsm.Rv64.RLP.UnifiedFieldBytesCopy
 import EvmAsm.Rv64.RLP.ValidatingFieldWalk
 import EvmAsm.Rv64.WP.CFG
+import EvmAsm.Rv64.Tactics.WPAttr
 
 namespace EvmAsm.Rv64.RLP
 
@@ -398,5 +399,305 @@ theorem rlp_decode_shortBytes_bytescopy_at
           (pcFree_sepConj pcFree_regIs pcFree_pure))))
         copyRaw)
   exact cpsBranchWithin_seq_cpsTripleWithin_taken hd_copy armWithLenF copyF
+
+/-! ## WP certificate wrapper -/
+
+/-- Code requirement for the validating fixed-length short-bytes copy unit. -/
+def validatingShortBytesCopyCR
+    (base e2Target succPC : Word) (expectedN : Nat) (rOut : Reg) (fieldImm : BitVec 12)
+    (off1 off2 succOff lenFailOff : BitVec 13) : CodeReq :=
+  ((((((rlp_phase1_step_code 0x80 off1 base).union
+      (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+     (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).union
+    (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff))).union
+    ((CodeReq.singleton succPC (.ADDI .x10 .x0 (BitVec.ofNat 12 expectedN))).union
+      (CodeReq.singleton (succPC + 4) (.BNE .x11 .x10 lenFailOff)))).union
+    ((CodeReq.singleton (succPC + 8) (.ADDI .x14 rOut fieldImm)).union
+      (byteCopyChainCR (succPC + 8 + 4) expectedN)))
+
+/-- Computed precondition for the validating fixed-length short-bytes copy unit. -/
+def validatingShortBytesCopyPre
+    (pfx : Byte) (rest bs : List Byte) (O : Nat)
+    (v10 v11Old v12Old v14Old regionBase : Word)
+    (rOut : Reg) (outBase : Word) (outBytes : List Byte) : Assertion :=
+  (((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) **
+    (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) **
+    (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (.x14 ↦ᵣ v14Old) **
+    (.x15 ↦ᵣ (BitVec.ofNat 64 (pfx :: rest).length)) ** bytesRegion regionBase bs) **
+   ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes))
+
+/-- Success postcondition for the validating fixed-length short-bytes copy unit. -/
+def validatingShortBytesCopySuccessPost
+    (pfx : Byte) (_rest bs : List Byte) (O expectedN : Nat)
+    (regionBase : Word) (rOut : Reg) (outBase : Word) (outBytes : List Byte) (di0 : Nat) :
+    Assertion :=
+  ((((regOwn .x12) **
+      (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 ((O + 1) + expectedN))) **
+      (.x14 ↦ᵣ (outBase + BitVec.ofNat 64 (di0 + expectedN))) **
+      (regOwn .x15) ** (rOut ↦ᵣ outBase) ** bytesRegion regionBase bs **
+      bytesRegion outBase (copyRangeGen outBytes bs (O + 1) di0 expectedN)) **
+    ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x10 ↦ᵣ (BitVec.ofNat 64 expectedN)) **
+      (.x11 ↦ᵣ (BitVec.ofNat 64 (rlpPrefixShortBytesPayloadLen pfx))) **
+      ⌜rlpPrefixShortBytesPayloadLen pfx = expectedN⌝)))
+
+/-- Failure postcondition for the validating fixed-length short-bytes copy unit. -/
+def validatingShortBytesCopyFailurePost
+    (pfx : Byte) (rest bs : List Byte) (O expectedN : Nat)
+    (v12Old v14Old regionBase : Word) (rOut : Reg) (outBase : Word)
+    (outBytes : List Byte) : Assertion :=
+  (((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) ** regOwn .x10 **
+    (.x11 ↦ᵣ (BitVec.ofNat 64 (rlpPrefixShortBytesPayloadLen pfx))) **
+    (.x12 ↦ᵣ v12Old) **
+    (.x13 ↦ᵣ ((regionBase + BitVec.ofNat 64 O) + signExtend12 (1 : BitVec 12))) **
+    (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ (BitVec.ofNat 64 (pfx :: rest).length)) **
+    bytesRegion regionBase bs **
+    ⌜decode (pfx :: rest) = none ∨ rlpPrefixShortBytesPayloadLen pfx ≠ expectedN⌝) **
+   ((rOut ↦ᵣ outBase) ** bytesRegion outBase outBytes))
+
+/-- WP branch certificate for the validating fixed-length short-bytes copy unit.
+    This packages the raw `cpsBranchWithin` theorem as a calculator object, so a
+    generated schema fold can compose the unit through `wp_rv64_cert`. -/
+def validatingShortBytesCopyBranch
+    (pfx : Byte) (rest bs : List Byte) (O expectedN : Nat)
+    (v10 v11Old v12Old v14Old : Word)
+    (regionBase : Word) (rOut : Reg) (outBase : Word) (fieldImm : BitVec 12)
+    (outBytes : List Byte) (di0 : Nat)
+    (off1 off2 succOff lenFailOff : BitVec 13) (base e2Target : Word)
+    (h_class : classifyPrefix pfx = .shortBytes)
+    (hns : rlpPrefixShortBytesPayloadLen pfx ≠ 1)
+    (h_lfit : (pfx :: rest).length < 2 ^ 64)
+    (h_target : (base + 8 + 4) + signExtend13 off2 = e2Target)
+    (h_exp11 : expectedN < 2 ^ 11)
+    (h_pl64 : rlpPrefixShortBytesPayloadLen pfx < 2 ^ 64)
+    (h_phase3 : ((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).Disjoint
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog))
+    (h_bltu : (((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).Disjoint
+               (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff)))
+    (succPC : Word)
+    (h_succ_pc : (e2Target + 8) + signExtend13 succOff = succPC)
+    (h_len_fail : (succPC + 4) + signExtend13 lenFailOff = e2Target + 12)
+    (h_salign : regionBase.toNat % 8 = 0) (h_dalign : outBase.toNat % 8 = 0)
+    (h_sover : regionBase.toNat + bs.length < 2 ^ 64)
+    (h_svalid : ∀ i, i < bs.length →
+      isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (h_src : (O + 1) + expectedN ≤ bs.length)
+    (h_dst : di0 + expectedN ≤ outBytes.length)
+    (h_dov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (h_dval : ∀ i, i < outBytes.length →
+      isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_code : (succPC + 8).toNat + (4 + 20 * expectedN) < 2 ^ 64)
+    (h_imm : signExtend12 fieldImm = BitVec.ofNat 64 di0)
+    (h_addibne : (CodeReq.singleton succPC (.ADDI .x10 .x0 (BitVec.ofNat 12 expectedN))).Disjoint
+                  (CodeReq.singleton (succPC + 4) (.BNE .x11 .x10 lenFailOff)))
+    (h_lencheck : ((((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).union
+                 (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff))).Disjoint
+               ((CodeReq.singleton succPC (.ADDI .x10 .x0 (BitVec.ofNat 12 expectedN))).union
+                 (CodeReq.singleton (succPC + 4) (.BNE .x11 .x10 lenFailOff))))
+    (h_copy : (((((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).union
+                 (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff))).union
+                 ((CodeReq.singleton succPC (.ADDI .x10 .x0 (BitVec.ofNat 12 expectedN))).union
+                   (CodeReq.singleton (succPC + 4) (.BNE .x11 .x10 lenFailOff)))).Disjoint
+               ((CodeReq.singleton (succPC + 8) (.ADDI .x14 rOut fieldImm)).union
+                 (byteCopyChainCR (succPC + 8 + 4) expectedN))) :
+    WP.Branch base
+      (validatingShortBytesCopyCR base e2Target succPC expectedN rOut fieldImm
+        off1 off2 succOff lenFailOff) :=
+  WP.Branch.ofSpec
+    (rlp_decode_shortBytes_bytescopy_at pfx rest bs O expectedN v10 v11Old v12Old v14Old
+      regionBase rOut outBase fieldImm outBytes di0 off1 off2 succOff lenFailOff base e2Target
+      h_class hns h_lfit h_target h_exp11 h_pl64 h_phase3 h_bltu succPC h_succ_pc h_len_fail
+      h_salign h_dalign h_sover h_svalid h_src h_dst h_dov h_dval h_code h_imm h_addibne
+      h_lencheck h_copy)
+
+/-- The validating-copy branch computes the named precondition. -/
+theorem validatingShortBytesCopyBranch_pre
+    (pfx : Byte) (rest bs : List Byte) (O expectedN : Nat)
+    (v10 v11Old v12Old v14Old : Word)
+    (regionBase : Word) (rOut : Reg) (outBase : Word) (fieldImm : BitVec 12)
+    (outBytes : List Byte) (di0 : Nat)
+    (off1 off2 succOff lenFailOff : BitVec 13) (base e2Target : Word)
+    (h_class : classifyPrefix pfx = .shortBytes)
+    (hns : rlpPrefixShortBytesPayloadLen pfx ≠ 1)
+    (h_lfit : (pfx :: rest).length < 2 ^ 64)
+    (h_target : (base + 8 + 4) + signExtend13 off2 = e2Target)
+    (h_exp11 : expectedN < 2 ^ 11)
+    (h_pl64 : rlpPrefixShortBytesPayloadLen pfx < 2 ^ 64)
+    (h_phase3 : ((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).Disjoint
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog))
+    (h_bltu : (((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).Disjoint
+               (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff)))
+    (succPC : Word)
+    (h_succ_pc : (e2Target + 8) + signExtend13 succOff = succPC)
+    (h_len_fail : (succPC + 4) + signExtend13 lenFailOff = e2Target + 12)
+    (h_salign : regionBase.toNat % 8 = 0) (h_dalign : outBase.toNat % 8 = 0)
+    (h_sover : regionBase.toNat + bs.length < 2 ^ 64)
+    (h_svalid : ∀ i, i < bs.length →
+      isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (h_src : (O + 1) + expectedN ≤ bs.length)
+    (h_dst : di0 + expectedN ≤ outBytes.length)
+    (h_dov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (h_dval : ∀ i, i < outBytes.length →
+      isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_code : (succPC + 8).toNat + (4 + 20 * expectedN) < 2 ^ 64)
+    (h_imm : signExtend12 fieldImm = BitVec.ofNat 64 di0)
+    (h_addibne : (CodeReq.singleton succPC (.ADDI .x10 .x0 (BitVec.ofNat 12 expectedN))).Disjoint
+                  (CodeReq.singleton (succPC + 4) (.BNE .x11 .x10 lenFailOff)))
+    (h_lencheck : ((((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).union
+                 (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff))).Disjoint
+               ((CodeReq.singleton succPC (.ADDI .x10 .x0 (BitVec.ofNat 12 expectedN))).union
+                 (CodeReq.singleton (succPC + 4) (.BNE .x11 .x10 lenFailOff))))
+    (h_copy : (((((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).union
+                 (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff))).union
+                 ((CodeReq.singleton succPC (.ADDI .x10 .x0 (BitVec.ofNat 12 expectedN))).union
+                   (CodeReq.singleton (succPC + 4) (.BNE .x11 .x10 lenFailOff)))).Disjoint
+               ((CodeReq.singleton (succPC + 8) (.ADDI .x14 rOut fieldImm)).union
+                 (byteCopyChainCR (succPC + 8 + 4) expectedN))) :
+    (validatingShortBytesCopyBranch pfx rest bs O expectedN v10 v11Old v12Old v14Old
+      regionBase rOut outBase fieldImm outBytes di0 off1 off2 succOff lenFailOff base e2Target
+      h_class hns h_lfit h_target h_exp11 h_pl64 h_phase3 h_bltu succPC h_succ_pc h_len_fail
+      h_salign h_dalign h_sover h_svalid h_src h_dst h_dov h_dval h_code h_imm h_addibne
+      h_lencheck h_copy).pre =
+      validatingShortBytesCopyPre pfx rest bs O v10 v11Old v12Old v14Old regionBase rOut
+        outBase outBytes := by
+  rfl
+
+/-- The validating-copy branch's taken exit is the copied-success path. -/
+theorem validatingShortBytesCopyBranch_exit_t
+    (pfx : Byte) (rest bs : List Byte) (O expectedN : Nat)
+    (v10 v11Old v12Old v14Old : Word)
+    (regionBase : Word) (rOut : Reg) (outBase : Word) (fieldImm : BitVec 12)
+    (outBytes : List Byte) (di0 : Nat)
+    (off1 off2 succOff lenFailOff : BitVec 13) (base e2Target : Word)
+    (h_class : classifyPrefix pfx = .shortBytes)
+    (hns : rlpPrefixShortBytesPayloadLen pfx ≠ 1)
+    (h_lfit : (pfx :: rest).length < 2 ^ 64)
+    (h_target : (base + 8 + 4) + signExtend13 off2 = e2Target)
+    (h_exp11 : expectedN < 2 ^ 11)
+    (h_pl64 : rlpPrefixShortBytesPayloadLen pfx < 2 ^ 64)
+    (h_phase3 : ((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).Disjoint
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog))
+    (h_bltu : (((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).Disjoint
+               (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff)))
+    (succPC : Word)
+    (h_succ_pc : (e2Target + 8) + signExtend13 succOff = succPC)
+    (h_len_fail : (succPC + 4) + signExtend13 lenFailOff = e2Target + 12)
+    (h_salign : regionBase.toNat % 8 = 0) (h_dalign : outBase.toNat % 8 = 0)
+    (h_sover : regionBase.toNat + bs.length < 2 ^ 64)
+    (h_svalid : ∀ i, i < bs.length →
+      isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (h_src : (O + 1) + expectedN ≤ bs.length)
+    (h_dst : di0 + expectedN ≤ outBytes.length)
+    (h_dov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (h_dval : ∀ i, i < outBytes.length →
+      isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_code : (succPC + 8).toNat + (4 + 20 * expectedN) < 2 ^ 64)
+    (h_imm : signExtend12 fieldImm = BitVec.ofNat 64 di0)
+    (h_addibne : (CodeReq.singleton succPC (.ADDI .x10 .x0 (BitVec.ofNat 12 expectedN))).Disjoint
+                  (CodeReq.singleton (succPC + 4) (.BNE .x11 .x10 lenFailOff)))
+    (h_lencheck : ((((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).union
+                 (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff))).Disjoint
+               ((CodeReq.singleton succPC (.ADDI .x10 .x0 (BitVec.ofNat 12 expectedN))).union
+                 (CodeReq.singleton (succPC + 4) (.BNE .x11 .x10 lenFailOff))))
+    (h_copy : (((((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).union
+                 (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff))).union
+                 ((CodeReq.singleton succPC (.ADDI .x10 .x0 (BitVec.ofNat 12 expectedN))).union
+                   (CodeReq.singleton (succPC + 4) (.BNE .x11 .x10 lenFailOff)))).Disjoint
+               ((CodeReq.singleton (succPC + 8) (.ADDI .x14 rOut fieldImm)).union
+                 (byteCopyChainCR (succPC + 8 + 4) expectedN))) :
+    (validatingShortBytesCopyBranch pfx rest bs O expectedN v10 v11Old v12Old v14Old
+      regionBase rOut outBase fieldImm outBytes di0 off1 off2 succOff lenFailOff base e2Target
+      h_class hns h_lfit h_target h_exp11 h_pl64 h_phase3 h_bltu succPC h_succ_pc h_len_fail
+      h_salign h_dalign h_sover h_svalid h_src h_dst h_dov h_dval h_code h_imm h_addibne
+      h_lencheck h_copy).exit_t =
+      succPC + 8 + 4 + BitVec.ofNat 64 (20 * expectedN) := by
+  rfl
+
+/-- The validating-copy branch's not-taken exit is the shared validation-failure path. -/
+theorem validatingShortBytesCopyBranch_exit_f
+    (pfx : Byte) (rest bs : List Byte) (O expectedN : Nat)
+    (v10 v11Old v12Old v14Old : Word)
+    (regionBase : Word) (rOut : Reg) (outBase : Word) (fieldImm : BitVec 12)
+    (outBytes : List Byte) (di0 : Nat)
+    (off1 off2 succOff lenFailOff : BitVec 13) (base e2Target : Word)
+    (h_class : classifyPrefix pfx = .shortBytes)
+    (hns : rlpPrefixShortBytesPayloadLen pfx ≠ 1)
+    (h_lfit : (pfx :: rest).length < 2 ^ 64)
+    (h_target : (base + 8 + 4) + signExtend13 off2 = e2Target)
+    (h_exp11 : expectedN < 2 ^ 11)
+    (h_pl64 : rlpPrefixShortBytesPayloadLen pfx < 2 ^ 64)
+    (h_phase3 : ((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).Disjoint
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog))
+    (h_bltu : (((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).Disjoint
+               (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff)))
+    (succPC : Word)
+    (h_succ_pc : (e2Target + 8) + signExtend13 succOff = succPC)
+    (h_len_fail : (succPC + 4) + signExtend13 lenFailOff = e2Target + 12)
+    (h_salign : regionBase.toNat % 8 = 0) (h_dalign : outBase.toNat % 8 = 0)
+    (h_sover : regionBase.toNat + bs.length < 2 ^ 64)
+    (h_svalid : ∀ i, i < bs.length →
+      isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (h_src : (O + 1) + expectedN ≤ bs.length)
+    (h_dst : di0 + expectedN ≤ outBytes.length)
+    (h_dov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (h_dval : ∀ i, i < outBytes.length →
+      isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_code : (succPC + 8).toNat + (4 + 20 * expectedN) < 2 ^ 64)
+    (h_imm : signExtend12 fieldImm = BitVec.ofNat 64 di0)
+    (h_addibne : (CodeReq.singleton succPC (.ADDI .x10 .x0 (BitVec.ofNat 12 expectedN))).Disjoint
+                  (CodeReq.singleton (succPC + 4) (.BNE .x11 .x10 lenFailOff)))
+    (h_lencheck : ((((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).union
+                 (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff))).Disjoint
+               ((CodeReq.singleton succPC (.ADDI .x10 .x0 (BitVec.ofNat 12 expectedN))).union
+                 (CodeReq.singleton (succPC + 4) (.BNE .x11 .x10 lenFailOff))))
+    (h_copy : (((((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).union
+                 (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff))).union
+                 ((CodeReq.singleton succPC (.ADDI .x10 .x0 (BitVec.ofNat 12 expectedN))).union
+                   (CodeReq.singleton (succPC + 4) (.BNE .x11 .x10 lenFailOff)))).Disjoint
+               ((CodeReq.singleton (succPC + 8) (.ADDI .x14 rOut fieldImm)).union
+                 (byteCopyChainCR (succPC + 8 + 4) expectedN))) :
+    (validatingShortBytesCopyBranch pfx rest bs O expectedN v10 v11Old v12Old v14Old
+      regionBase rOut outBase fieldImm outBytes di0 off1 off2 succOff lenFailOff base e2Target
+      h_class hns h_lfit h_target h_exp11 h_pl64 h_phase3 h_bltu succPC h_succ_pc h_len_fail
+      h_salign h_dalign h_sover h_svalid h_src h_dst h_dov h_dval h_code h_imm h_addibne
+      h_lencheck h_copy).exit_f = e2Target + 12 := by
+  rfl
+
+attribute [rv64_wp]
+  validatingShortBytesCopyBranch_pre
+  validatingShortBytesCopyBranch_exit_t
+  validatingShortBytesCopyBranch_exit_f
+
+attribute [rv64_wp_cert]
+  validatingShortBytesCopyBranch
+
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/ValidatingExactArity.lean
+++ b/EvmAsm/Rv64/RLP/ValidatingExactArity.lean
@@ -16,6 +16,8 @@
 
 import EvmAsm.Rv64.MemRegion
 import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.WPAttr
+import EvmAsm.Rv64.WP.CFG
 
 namespace EvmAsm.Rv64.RLP
 
@@ -65,5 +67,59 @@ theorem rlp_exact_arity_check (b regionBase : Word) (rEnd : Reg) (cursor listEnd
     rw [show ((regionBase + BitVec.ofNat 64 cursor = regionBase + BitVec.ofNat 64 listEnd))
           = (cursor = listEnd) from propext (ptr_eq_iff_ofNat regionBase cursor listEnd hc hl)] at hp
     exact hp
+
+/-! ## WP certificate wrapper -/
+
+/-- Code requirement for the exact-arity list-end check. -/
+def exactArityCR (base : Word) (rEnd : Reg) (failOff : BitVec 13) : CodeReq :=
+  CodeReq.singleton base (.BNE .x13 rEnd failOff)
+
+/-- Computed precondition for the exact-arity list-end check. -/
+def exactArityPre (regionBase : Word) (rEnd : Reg) (cursor listEnd : Nat) : Assertion :=
+  ((.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 cursor)) **
+    (rEnd ↦ᵣ (regionBase + BitVec.ofNat 64 listEnd)))
+
+/-- Failure postcondition for the exact-arity list-end check. -/
+def exactArityFailurePost (regionBase : Word) (rEnd : Reg) (cursor listEnd : Nat) : Assertion :=
+  (exactArityPre regionBase rEnd cursor listEnd ** ⌜cursor ≠ listEnd⌝)
+
+/-- Success postcondition for the exact-arity list-end check. -/
+def exactAritySuccessPost (regionBase : Word) (rEnd : Reg) (cursor listEnd : Nat) : Assertion :=
+  (exactArityPre regionBase rEnd cursor listEnd ** ⌜cursor = listEnd⌝)
+
+/-- WP branch certificate for the exact-arity list-end check.
+    The taken exit is failure (`cursor ≠ listEnd`); the fall-through exit is success. -/
+def exactArityBranch (base regionBase : Word) (rEnd : Reg) (cursor listEnd : Nat)
+    (failOff : BitVec 13) (hc : cursor < 2 ^ 64) (hl : listEnd < 2 ^ 64) :
+    WP.Branch base (exactArityCR base rEnd failOff) :=
+  WP.Branch.ofSpec (rlp_exact_arity_check base regionBase rEnd cursor listEnd failOff hc hl)
+
+/-- The exact-arity branch computes the named precondition. -/
+theorem exactArityBranch_pre (base regionBase : Word) (rEnd : Reg) (cursor listEnd : Nat)
+    (failOff : BitVec 13) (hc : cursor < 2 ^ 64) (hl : listEnd < 2 ^ 64) :
+    (exactArityBranch base regionBase rEnd cursor listEnd failOff hc hl).pre =
+      exactArityPre regionBase rEnd cursor listEnd := by
+  rfl
+
+/-- The exact-arity branch's taken exit is the failure target. -/
+theorem exactArityBranch_exit_t (base regionBase : Word) (rEnd : Reg) (cursor listEnd : Nat)
+    (failOff : BitVec 13) (hc : cursor < 2 ^ 64) (hl : listEnd < 2 ^ 64) :
+    (exactArityBranch base regionBase rEnd cursor listEnd failOff hc hl).exit_t =
+      base + signExtend13 failOff := by
+  rfl
+
+/-- The exact-arity branch's fall-through exit is success. -/
+theorem exactArityBranch_exit_f (base regionBase : Word) (rEnd : Reg) (cursor listEnd : Nat)
+    (failOff : BitVec 13) (hc : cursor < 2 ^ 64) (hl : listEnd < 2 ^ 64) :
+    (exactArityBranch base regionBase rEnd cursor listEnd failOff hc hl).exit_f = base + 4 := by
+  rfl
+
+attribute [rv64_wp]
+  exactArityBranch_pre
+  exactArityBranch_exit_t
+  exactArityBranch_exit_f
+
+attribute [rv64_wp_cert]
+  exactArityBranch
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/ValidatingFieldWalk.lean
+++ b/EvmAsm/Rv64/RLP/ValidatingFieldWalk.lean
@@ -11,6 +11,8 @@
 import EvmAsm.Rv64.CPSSpec
 import EvmAsm.Rv64.RLP.UnifiedDecodeItemShortBytesValidatedAt
 import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.WPAttr
+import EvmAsm.Rv64.WP.CFG
 
 namespace EvmAsm.Rv64
 
@@ -202,6 +204,176 @@ theorem rlp_decode_shortBytes_advance_at_clean
     off1 off2 succOff base e2_target h_class hns hLfit htarget hd_phase3 hd_bltu succPC hsuccPC hd_add
   rw [advance_cursor_clean regionBase O (rlpPrefixShortBytesPayloadLen pfx)] at h
   exact h
+
+/-! ## WP certificate wrapper -/
+
+/-- Code requirement for validating shortBytes decode-and-advance. -/
+def validatingShortBytesAdvanceCR
+    (base e2Target succPC : Word) (off1 off2 succOff : BitVec 13) : CodeReq :=
+  (((((rlp_phase1_step_code 0x80 off1 base).union
+      (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+     (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).union
+    (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff))).union
+    (CodeReq.singleton succPC (.ADD .x13 .x13 .x11)))
+
+/-- Computed precondition for validating shortBytes decode-and-advance. -/
+def validatingShortBytesAdvancePre
+    (pfx : Byte) (rest bs : List Byte) (O : Nat)
+    (v10 v11Old v12Old v14Old regionBase : Word) : Assertion :=
+  ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) **
+    (.x11 ↦ᵣ v11Old) ** (.x12 ↦ᵣ v12Old) **
+    (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (.x14 ↦ᵣ v14Old) **
+    (.x15 ↦ᵣ (BitVec.ofNat 64 (pfx :: rest).length)) ** bytesRegion regionBase bs)
+
+/-- Success postcondition for validating shortBytes decode-and-advance. -/
+def validatingShortBytesAdvanceSuccessPost
+    (pfx : Byte) (rest bs : List Byte) (O : Nat)
+    (v12Old v14Old regionBase : Word) : Assertion :=
+  ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+    (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xB8 : BitVec 12))) **
+    (.x11 ↦ᵣ (BitVec.ofNat 64 (rlpPrefixShortBytesPayloadLen pfx))) **
+    (.x12 ↦ᵣ v12Old) **
+    (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 (O + 1 + rlpPrefixShortBytesPayloadLen pfx))) **
+    (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ (BitVec.ofNat 64 (pfx :: rest).length)) **
+    bytesRegion regionBase bs **
+    ⌜decode (pfx :: rest)
+      = some (.bytes (rest.take (rlpPrefixShortBytesPayloadLen pfx)),
+              rest.drop (rlpPrefixShortBytesPayloadLen pfx))⌝)
+
+/-- Failure postcondition for validating shortBytes decode-and-advance. -/
+def validatingShortBytesAdvanceFailurePost
+    (pfx : Byte) (rest bs : List Byte) (O : Nat)
+    (v12Old v14Old regionBase : Word) : Assertion :=
+  ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x0 ↦ᵣ (0 : Word)) **
+    (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xB8 : BitVec 12))) **
+    (.x11 ↦ᵣ (BitVec.ofNat 64 (rlpPrefixShortBytesPayloadLen pfx))) **
+    (.x12 ↦ᵣ v12Old) **
+    (.x13 ↦ᵣ ((regionBase + BitVec.ofNat 64 O) + signExtend12 (1 : BitVec 12))) **
+    (.x14 ↦ᵣ v14Old) ** (.x15 ↦ᵣ (BitVec.ofNat 64 (pfx :: rest).length)) **
+    bytesRegion regionBase bs ** ⌜decode (pfx :: rest) = none⌝)
+
+/-- WP branch certificate for validating shortBytes decode-and-advance.
+    The taken exit is success; the fall-through exit is failure. -/
+def validatingShortBytesAdvanceBranch
+    (pfx : Byte) (rest bs : List Byte) (O : Nat)
+    (v10 v11Old v12Old v14Old regionBase : Word)
+    (off1 off2 succOff : BitVec 13) (base e2Target : Word)
+    (h_class : classifyPrefix pfx = .shortBytes)
+    (hns : rlpPrefixShortBytesPayloadLen pfx ≠ 1)
+    (h_lfit : (pfx :: rest).length < 2 ^ 64)
+    (h_target : (base + 8 + 4) + signExtend13 off2 = e2Target)
+    (h_phase3 : ((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).Disjoint
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog))
+    (h_bltu : (((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).Disjoint
+               (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff)))
+    (succPC : Word)
+    (h_succ_pc : (e2Target + 8) + signExtend13 succOff = succPC)
+    (h_add : ((((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).union
+                 (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff))).Disjoint
+               (CodeReq.singleton succPC (.ADD .x13 .x13 .x11))) :
+    WP.Branch base (validatingShortBytesAdvanceCR base e2Target succPC off1 off2 succOff) :=
+  WP.Branch.ofSpec
+    (rlp_decode_shortBytes_advance_at_clean pfx rest bs O v10 v11Old v12Old v14Old regionBase
+      off1 off2 succOff base e2Target h_class hns h_lfit h_target h_phase3 h_bltu succPC
+      h_succ_pc h_add)
+
+/-- The validating advance branch computes the named precondition. -/
+theorem validatingShortBytesAdvanceBranch_pre
+    (pfx : Byte) (rest bs : List Byte) (O : Nat)
+    (v10 v11Old v12Old v14Old regionBase : Word)
+    (off1 off2 succOff : BitVec 13) (base e2Target : Word)
+    (h_class : classifyPrefix pfx = .shortBytes)
+    (hns : rlpPrefixShortBytesPayloadLen pfx ≠ 1)
+    (h_lfit : (pfx :: rest).length < 2 ^ 64)
+    (h_target : (base + 8 + 4) + signExtend13 off2 = e2Target)
+    (h_phase3 : ((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).Disjoint
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog))
+    (h_bltu : (((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).Disjoint
+               (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff)))
+    (succPC : Word)
+    (h_succ_pc : (e2Target + 8) + signExtend13 succOff = succPC)
+    (h_add : ((((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).union
+                 (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff))).Disjoint
+               (CodeReq.singleton succPC (.ADD .x13 .x13 .x11))) :
+    (validatingShortBytesAdvanceBranch pfx rest bs O v10 v11Old v12Old v14Old regionBase
+      off1 off2 succOff base e2Target h_class hns h_lfit h_target h_phase3 h_bltu succPC
+      h_succ_pc h_add).pre =
+      validatingShortBytesAdvancePre pfx rest bs O v10 v11Old v12Old v14Old regionBase := by
+  rfl
+
+/-- The validating advance branch's taken exit is success. -/
+theorem validatingShortBytesAdvanceBranch_exit_t
+    (pfx : Byte) (rest bs : List Byte) (O : Nat)
+    (v10 v11Old v12Old v14Old regionBase : Word)
+    (off1 off2 succOff : BitVec 13) (base e2Target : Word)
+    (h_class : classifyPrefix pfx = .shortBytes)
+    (hns : rlpPrefixShortBytesPayloadLen pfx ≠ 1)
+    (h_lfit : (pfx :: rest).length < 2 ^ 64)
+    (h_target : (base + 8 + 4) + signExtend13 off2 = e2Target)
+    (h_phase3 : ((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).Disjoint
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog))
+    (h_bltu : (((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).Disjoint
+               (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff)))
+    (succPC : Word)
+    (h_succ_pc : (e2Target + 8) + signExtend13 succOff = succPC)
+    (h_add : ((((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).union
+                 (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff))).Disjoint
+               (CodeReq.singleton succPC (.ADD .x13 .x13 .x11))) :
+    (validatingShortBytesAdvanceBranch pfx rest bs O v10 v11Old v12Old v14Old regionBase
+      off1 off2 succOff base e2Target h_class hns h_lfit h_target h_phase3 h_bltu succPC
+      h_succ_pc h_add).exit_t = succPC + 4 := by
+  rfl
+
+/-- The validating advance branch's fall-through exit is failure. -/
+theorem validatingShortBytesAdvanceBranch_exit_f
+    (pfx : Byte) (rest bs : List Byte) (O : Nat)
+    (v10 v11Old v12Old v14Old regionBase : Word)
+    (off1 off2 succOff : BitVec 13) (base e2Target : Word)
+    (h_class : classifyPrefix pfx = .shortBytes)
+    (hns : rlpPrefixShortBytesPayloadLen pfx ≠ 1)
+    (h_lfit : (pfx :: rest).length < 2 ^ 64)
+    (h_target : (base + 8 + 4) + signExtend13 off2 = e2Target)
+    (h_phase3 : ((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).Disjoint
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog))
+    (h_bltu : (((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).Disjoint
+               (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff)))
+    (succPC : Word)
+    (h_succ_pc : (e2Target + 8) + signExtend13 succOff = succPC)
+    (h_add : ((((rlp_phase1_step_code 0x80 off1 base).union
+                    (rlp_phase1_step_code 0xB8 off2 (base + 8))).union
+                 (CodeReq.ofProg e2Target rlp_phase3_short_string_prog)).union
+                 (CodeReq.singleton (e2Target + 8) (.BLTU .x11 .x15 succOff))).Disjoint
+               (CodeReq.singleton succPC (.ADD .x13 .x13 .x11))) :
+    (validatingShortBytesAdvanceBranch pfx rest bs O v10 v11Old v12Old v14Old regionBase
+      off1 off2 succOff base e2Target h_class hns h_lfit h_target h_phase3 h_bltu succPC
+      h_succ_pc h_add).exit_f = e2Target + 12 := by
+  rfl
+
+attribute [rv64_wp]
+  validatingShortBytesAdvanceBranch_pre
+  validatingShortBytesAdvanceBranch_exit_t
+  validatingShortBytesAdvanceBranch_exit_f
+
+attribute [rv64_wp_cert]
+  validatingShortBytesAdvanceBranch
 
 end RLP
 

--- a/EvmAsm/Rv64/RLP/WalkDecodeBridge.lean
+++ b/EvmAsm/Rv64/RLP/WalkDecodeBridge.lean
@@ -1,0 +1,214 @@
+/-
+  EvmAsm.Rv64.RLP.WalkDecodeBridge
+
+  Reusable pure bridge from the cursor-walk view used by `rlp_walk_next`
+  to the EL RLP decoder.  The walk routines expose offsets into one byte
+  buffer; these lemmas turn per-item offset facts into `decodeAux`,
+  `decodeItems`, and finally `decodeFully` facts.
+-/
+
+import EvmAsm.EL.RLP.ByteStringDecodeBridge
+import EvmAsm.EL.RLP.FullDecode
+import EvmAsm.EL.RLP.ListDecodeBridge
+import EvmAsm.EL.RLP.Properties
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.EL.RLP
+
+/-- A byte present at offset `off` peels off the front of `drop off`. -/
+theorem drop_eq_cons_of_getElem? {bytes : List Byte} {off : Nat} {b : Byte}
+    (hget : bytes[off]? = some b) :
+    bytes.drop off = b :: bytes.drop (off + 1) := by
+  have hlt : off < bytes.length := by
+    rw [List.getElem?_eq_some_iff] at hget
+    exact hget.1
+  have hb : bytes[off] = b := by
+    rw [List.getElem?_eq_getElem hlt] at hget
+    exact Option.some.inj hget
+  rw [List.drop_eq_getElem_cons hlt, hb]
+
+/-- Single-byte bridge from offset facts to the pure decoder. -/
+theorem decodeAux_singleByte_bridge (bytes : List Byte) (off : Nat) (b : Byte)
+    (hget : bytes[off]? = some b) (hsingle : b.toNat < 0x80) (n : Nat) :
+    decodeAux (n + 1) (bytes.drop off) = some (.bytes [b], bytes.drop (off + 1)) := by
+  rw [drop_eq_cons_of_getElem? hget]
+  exact decodeAux_cons_singleByte_of_classifyPrefix n b (bytes.drop (off + 1))
+    ((classifyPrefix_singleByte_iff b).mpr hsingle)
+
+/-- Short-byte-string bridge from offset facts to the pure decoder. -/
+theorem decodeAux_shortBytes_bridge (bytes : List Byte) (off : Nat) (b : Byte)
+    (hget : bytes[off]? = some b) (hlo : 0x80 ≤ b.toNat) (hhi : b.toNat ≤ 0xB7)
+    (hlen : off + 1 + (b.toNat - 0x80) ≤ bytes.length)
+    (hcanon : b.toNat - 0x80 = 1 →
+      ∃ c : Byte, bytes[off + 1]? = some c ∧ ¬ c.toNat < 0x80)
+    (n : Nat) :
+    decodeAux (n + 1) (bytes.drop off) =
+      some (.bytes ((bytes.drop (off + 1)).take (b.toNat - 0x80)),
+        bytes.drop (off + 1 + (b.toNat - 0x80))) := by
+  rw [drop_eq_cons_of_getElem? hget]
+  let len := b.toNat - 0x80
+  have hclass : classifyPrefix b = .shortBytes :=
+    (classifyPrefix_shortBytes_iff b).mpr ⟨hlo, hhi⟩
+  have hpayloadLen : rlpPrefixShortBytesPayloadLen b = len := rfl
+  have htake : takeBytes (bytes.drop (off + 1)) len =
+      some ((bytes.drop (off + 1)).take len, bytes.drop (off + 1 + len)) := by
+    have hge : len ≤ (bytes.drop (off + 1)).length := by
+      rw [List.length_drop]
+      omega
+    rw [takeBytes_length_ge hge, List.drop_drop]
+  refine (ByteStringDecodeBridge.decodeAux_cons_shortBytes_eq_some_iff
+    n b (bytes.drop (off + 1)) hclass
+    ((bytes.drop (off + 1)).take len) (bytes.drop (off + 1 + len))).mpr ?_
+  refine ⟨(bytes.drop (off + 1)).take len, ?_, rfl, ?_⟩
+  · simpa [len, hpayloadLen] using htake
+  · cases hC : (bytes.drop (off + 1)).take len with
+    | nil => trivial
+    | cons b0 tail =>
+        cases tail with
+        | nil =>
+            have hlen1 : len = 1 := by
+              have hl := congrArg List.length hC
+              simp only [List.length_take, List.length_drop, List.length_cons, List.length_nil] at hl
+              omega
+            obtain ⟨c, hcget, hcge⟩ := hcanon hlen1
+            have hcc : (bytes.drop (off + 1)).take len = [c] := by
+              rw [hlen1, drop_eq_cons_of_getElem? hcget]
+              rfl
+            rw [hC] at hcc
+            have hb0c : b0 = c := by
+              simpa using hcc
+            simpa [hb0c] using hcge
+        | cons _ _ => trivial
+
+/-! ## `decodeItems` composition -/
+
+/-- Prepend one decoded item to a recursive `decodeItems` run. -/
+theorem decodeItems_cons_of_decodeAux (bytes : List Byte) (off nextOff : Nat) (item : RLPItem)
+    (items : List RLPItem) (rest' : List Byte) (n : Nat)
+    (hne : bytes.drop off ≠ [])
+    (hitem : decodeAux (n + 1) (bytes.drop off) = some (item, bytes.drop nextOff))
+    (hrest : decodeItems (n + 1) (bytes.drop nextOff) = some (items, rest')) :
+    decodeItems (n + 2) (bytes.drop off) = some (item :: items, rest') := by
+  rw [decodeItems_succ_of_ne_nil (n + 1) (bytes.drop off) hne, hitem]
+  simp only [Option.bind_eq_bind, Option.bind_some, hrest]
+
+/-- A successful nonempty `decodeItems` run decomposes into one `decodeAux` step and the tail. -/
+theorem decodeItems_cons_inv (bs : List Byte) (item : RLPItem) (items : List RLPItem)
+    (rest' : List Byte) (n : Nat) (hne : bs ≠ [])
+    (h : decodeItems (n + 1) bs = some (item :: items, rest')) :
+    ∃ r, decodeAux n bs = some (item, r) ∧ decodeItems n r = some (items, rest') := by
+  rw [decodeItems_succ_of_ne_nil n bs hne] at h
+  rcases hd : decodeAux n bs with _ | ⟨i, r⟩
+  · simp [hd] at h
+  · simp only [hd, Option.bind_eq_bind, Option.bind_some] at h
+    rcases hr : decodeItems n r with _ | ⟨is, r''⟩
+    · simp [hr] at h
+    · simp only [hr, Option.bind_some, Option.some.injEq, Prod.mk.injEq,
+        List.cons.injEq] at h
+      obtain ⟨⟨hi, his⟩, hr'⟩ := h
+      subst hi
+      subst his
+      subst hr'
+      exact ⟨r, rfl, hr⟩
+
+/-- Four byte-string item decodes compose to a four-item list payload. -/
+theorem decodeItems_four_of_decodeAux (bytes : List Byte)
+    (off0 off1 off2 off3 off4 : Nat) (item0 item1 item2 item3 : RLPItem) (k : Nat)
+    (h0 : ∀ m, decodeAux (m + 1) (bytes.drop off0) = some (item0, bytes.drop off1))
+    (h1 : ∀ m, decodeAux (m + 1) (bytes.drop off1) = some (item1, bytes.drop off2))
+    (h2 : ∀ m, decodeAux (m + 1) (bytes.drop off2) = some (item2, bytes.drop off3))
+    (h3 : ∀ m, decodeAux (m + 1) (bytes.drop off3) = some (item3, bytes.drop off4))
+    (hend : bytes.drop off4 = []) :
+    decodeItems (k + 5) (bytes.drop off0) = some ([item0, item1, item2, item3], []) := by
+  have hne : ∀ {o item r}, decodeAux 1 (bytes.drop o) = some (item, r) → bytes.drop o ≠ [] := by
+    intro o item r h hnil
+    rw [hnil, decodeAux_nil] at h
+    simp at h
+  have base : decodeItems (k + 1) (bytes.drop off4) = some ([], []) := by
+    rw [hend]
+    rfl
+  have s3 := decodeItems_cons_of_decodeAux bytes off3 off4 item3 [] [] k
+    (hne (h3 0)) (h3 k) base
+  have s2 := decodeItems_cons_of_decodeAux bytes off2 off3 item2 _ [] (k + 1)
+    (hne (h2 0)) (h2 (k + 1)) s3
+  have s1 := decodeItems_cons_of_decodeAux bytes off1 off2 item1 _ [] (k + 2)
+    (hne (h1 0)) (h1 (k + 2)) s2
+  exact decodeItems_cons_of_decodeAux bytes off0 off1 item0 _ [] (k + 3)
+    (hne (h0 0)) (h0 (k + 3)) s1
+
+/-- One `decodeItems` step over a single-byte item at offset `off`. -/
+theorem decodeItems_cons_singleByte (bytes : List Byte) (off : Nat) (b : Byte)
+    (items : List RLPItem) (rest' : List Byte) (n : Nat)
+    (hget : bytes[off]? = some b) (hsingle : b.toNat < 0x80)
+    (hrest : decodeItems (n + 1) (bytes.drop (off + 1)) = some (items, rest')) :
+    decodeItems (n + 2) (bytes.drop off) = some (.bytes [b] :: items, rest') := by
+  have hne : bytes.drop off ≠ [] := by
+    rw [drop_eq_cons_of_getElem? hget]
+    simp
+  rw [decodeItems_succ_of_ne_nil (n + 1) (bytes.drop off) hne,
+    decodeAux_singleByte_bridge bytes off b hget hsingle n]
+  simp only [Option.bind_eq_bind, Option.bind_some, hrest]
+
+/-- One `decodeItems` step over a short-byte-string item at offset `off`. -/
+theorem decodeItems_cons_shortBytes (bytes : List Byte) (off : Nat) (b : Byte)
+    (items : List RLPItem) (rest' : List Byte) (n : Nat)
+    (hget : bytes[off]? = some b) (hlo : 0x80 ≤ b.toNat) (hhi : b.toNat ≤ 0xB7)
+    (hlen : off + 1 + (b.toNat - 0x80) ≤ bytes.length)
+    (hcanon : b.toNat - 0x80 = 1 →
+      ∃ c : Byte, bytes[off + 1]? = some c ∧ ¬ c.toNat < 0x80)
+    (hrest : decodeItems (n + 1) (bytes.drop (off + 1 + (b.toNat - 0x80))) =
+      some (items, rest')) :
+    decodeItems (n + 2) (bytes.drop off) =
+      some (.bytes ((bytes.drop (off + 1)).take (b.toNat - 0x80)) :: items, rest') := by
+  have hne : bytes.drop off ≠ [] := by
+    rw [drop_eq_cons_of_getElem? hget]
+    simp
+  rw [decodeItems_succ_of_ne_nil (n + 1) (bytes.drop off) hne,
+    decodeAux_shortBytes_bridge bytes off b hget hlo hhi hlen hcanon n]
+  change Option.bind
+      (some (RLPItem.bytes (List.take (BitVec.toNat b - 128) (List.drop (off + 1) bytes)),
+        List.drop (off + 1 + (BitVec.toNat b - 128)) bytes))
+      (fun p => Option.bind (decodeItems (n + 1) p.2)
+        (fun q => some (p.1 :: q.1, q.2))) =
+    some (RLPItem.bytes (List.take (BitVec.toNat b - 128) (List.drop (off + 1) bytes)) ::
+      items, rest')
+  rw [Option.bind_some]
+  rw [hrest]
+  rfl
+
+/-! ## Capstone: outer short list of four byte-string items -/
+
+/-- A short-list payload made of four decoded items is a full four-item RLP list. -/
+theorem decodeFully_shortList_four (pfx : Byte) (payload : List Byte)
+    (off1 off2 off3 off4 : Nat) (item0 item1 item2 item3 : RLPItem)
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (h0 : ∀ m, decodeAux (m + 1) payload = some (item0, payload.drop off1))
+    (h1 : ∀ m, decodeAux (m + 1) (payload.drop off1) = some (item1, payload.drop off2))
+    (h2 : ∀ m, decodeAux (m + 1) (payload.drop off2) = some (item2, payload.drop off3))
+    (h3 : ∀ m, decodeAux (m + 1) (payload.drop off3) = some (item3, payload.drop off4))
+    (hend : payload.drop off4 = [])
+    (h_min : 2 ≤ payload.length) :
+    decodeFully (pfx :: payload) = some (.list [item0, item1, item2, item3]) := by
+  have hdec : decode (pfx :: payload) = some (.list [item0, item1, item2, item3], []) := by
+    rw [decode_cons_eq_decodeAux_fuel,
+      show 2 * payload.length + 2 = (2 * payload.length + 1) + 1 from by omega]
+    refine (ListDecodeBridge.decodeAux_cons_shortList_eq_some_iff
+      (2 * payload.length + 1) pfx payload h_class
+      [item0, item1, item2, item3] []).mpr ?_
+    refine ⟨payload, ?_, ?_⟩
+    · rw [h_len, takeBytes_length_ge (le_refl payload.length), List.take_length, List.drop_length]
+    · apply ListDecodeBridge.decodeListPayload_eq_some_of_decodeItems_empty
+      obtain ⟨k, hk⟩ : ∃ k, 2 * payload.length + 1 = k + 5 := ⟨2 * payload.length - 4, by omega⟩
+      rw [hk]
+      have h0' : ∀ m, decodeAux (m + 1) (payload.drop 0) =
+          some (item0, payload.drop off1) := by
+        simp only [List.drop_zero]
+        exact h0
+      have hfour := decodeItems_four_of_decodeAux payload 0 off1 off2 off3 off4
+        item0 item1 item2 item3 k h0' h1 h2 h3 hend
+      rwa [List.drop_zero] at hfour
+  simp [decodeFully, hdec]
+
+end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/WalkDecodeBridge.lean
+++ b/EvmAsm/Rv64/RLP/WalkDecodeBridge.lean
@@ -317,6 +317,19 @@ theorem decodeAux_bytes_all_fuel_of_decode
                         rcases decoded with ⟨items, leftover⟩
                         cases h_empty : List.isEmpty leftover <;> simp [hitems] at hdecode
 
+/-- List-shaped facade for `decodeAux_bytes_all_fuel_of_decode`.  Generated
+    chain witnesses usually expose the current remainder as one list, not as a
+    syntactic `pfx :: rest`; this theorem hides the nonempty decomposition. -/
+theorem decodeAux_bytes_all_fuel_of_decode_list
+    (bs data rest' : List Byte)
+    (hdecode : decode bs = some (.bytes data, rest')) :
+    ∀ m, decodeAux (m + 1) bs = some (.bytes data, rest') := by
+  cases bs with
+  | nil =>
+      simp [decode, decodeAux] at hdecode
+  | cons pfx rest =>
+      exact decodeAux_bytes_all_fuel_of_decode pfx rest data rest' hdecode
+
 /-! ## Capstone: outer short list of four byte-string items -/
 
 /-- A short-list payload made of four decoded items is a full four-item RLP list. -/

--- a/EvmAsm/Rv64/RLP/WalkDecodeBridge.lean
+++ b/EvmAsm/Rv64/RLP/WalkDecodeBridge.lean
@@ -137,6 +137,46 @@ theorem decodeItems_four_of_decodeAux (bytes : List Byte)
   exact decodeItems_cons_of_decodeAux bytes off0 off1 item0 _ [] (k + 3)
     (hne (h0 0)) (h0 (k + 3)) s1
 
+/-- Prepend one decoded item to a recursive `decodeItems` run, phrased as a
+    direct remainder chain instead of byte-offset drops.  This is the shape
+    produced by validating WP field posts. -/
+theorem decodeItems_cons_of_decodeAux_chain (bs bsNext : List Byte)
+    (item : RLPItem) (items : List RLPItem) (rest' : List Byte) (n : Nat)
+    (hne : bs ≠ [])
+    (hitem : decodeAux (n + 1) bs = some (item, bsNext))
+    (hrest : decodeItems (n + 1) bsNext = some (items, rest')) :
+    decodeItems (n + 2) bs = some (item :: items, rest') := by
+  rw [decodeItems_succ_of_ne_nil (n + 1) bs hne, hitem]
+  simp only [Option.bind_eq_bind, Option.bind_some, hrest]
+
+/-- Four byte-string item decodes compose to a four-item list payload, using
+    only the successor remainders.  This avoids exposing synthetic offsets in
+    generated WP proofs. -/
+theorem decodeItems_four_of_decodeAux_chain
+    (bs0 bs1 bs2 bs3 bs4 : List Byte)
+    (item0 item1 item2 item3 : RLPItem) (k : Nat)
+    (h0 : ∀ m, decodeAux (m + 1) bs0 = some (item0, bs1))
+    (h1 : ∀ m, decodeAux (m + 1) bs1 = some (item1, bs2))
+    (h2 : ∀ m, decodeAux (m + 1) bs2 = some (item2, bs3))
+    (h3 : ∀ m, decodeAux (m + 1) bs3 = some (item3, bs4))
+    (hend : bs4 = []) :
+    decodeItems (k + 5) bs0 = some ([item0, item1, item2, item3], []) := by
+  have hne : ∀ {bs item r}, decodeAux 1 bs = some (item, r) → bs ≠ [] := by
+    intro bs item r h hnil
+    rw [hnil, decodeAux_nil] at h
+    simp at h
+  have base : decodeItems (k + 1) bs4 = some ([], []) := by
+    rw [hend]
+    rfl
+  have s3 := decodeItems_cons_of_decodeAux_chain bs3 bs4 item3 [] [] k
+    (hne (h3 0)) (h3 k) base
+  have s2 := decodeItems_cons_of_decodeAux_chain bs2 bs3 item2 _ [] (k + 1)
+    (hne (h2 0)) (h2 (k + 1)) s3
+  have s1 := decodeItems_cons_of_decodeAux_chain bs1 bs2 item1 _ [] (k + 2)
+    (hne (h1 0)) (h1 (k + 2)) s2
+  exact decodeItems_cons_of_decodeAux_chain bs0 bs1 item0 _ [] (k + 3)
+    (hne (h0 0)) (h0 (k + 3)) s1
+
 /-- One `decodeItems` step over a single-byte item at offset `off`. -/
 theorem decodeItems_cons_singleByte (bytes : List Byte) (off : Nat) (b : Byte)
     (items : List RLPItem) (rest' : List Byte) (n : Nat)
@@ -177,6 +217,106 @@ theorem decodeItems_cons_shortBytes (bytes : List Byte) (off : Nat) (b : Byte)
   rw [hrest]
   rfl
 
+
+/-! ## Bridges from WP field posts -/
+
+/-- A successful single-byte `decode` result can be reused at any positive
+    `decodeAux` fuel.  Validating WP field posts often expose `decode`, while
+    the list-level bridge composes `decodeAux`; this theorem is the lossless
+    adapter between those views. -/
+theorem decodeAux_singleByte_all_fuel_of_decode
+    (pfx : Byte) (rest data rest' : List Byte)
+    (h_class : classifyPrefix pfx = .singleByte)
+    (hdecode : decode (pfx :: rest) = some (.bytes data, rest')) :
+    ∀ m, decodeAux (m + 1) (pfx :: rest) = some (.bytes data, rest') := by
+  rw [decode_cons_eq_decodeAux_fuel] at hdecode
+  have hdecode' :
+      decodeAux ((2 * rest.length + 1) + 1) (pfx :: rest) =
+        some (.bytes data, rest') := by
+    have hfuel : (2 * rest.length + 1) + 1 = 2 * rest.length + 2 := by omega
+    rw [hfuel]
+    exact hdecode
+  have hwitness :=
+    (ByteStringDecodeBridge.decodeAux_cons_singleByte_eq_some_iff
+      (2 * rest.length + 1) pfx rest h_class data rest').mp hdecode'
+  intro m
+  exact (ByteStringDecodeBridge.decodeAux_cons_singleByte_eq_some_iff
+    m pfx rest h_class data rest').mpr hwitness
+
+/-- A successful short-byte-string `decode` result can be reused at any
+    positive `decodeAux` fuel.  This lets generated WP proofs turn the pure
+    field-post fact from a validating branch into the shape consumed by
+    `decodeItems_four_of_decodeAux` and `decodeFully_shortList_four`. -/
+theorem decodeAux_shortBytes_all_fuel_of_decode
+    (pfx : Byte) (rest data rest' : List Byte)
+    (h_class : classifyPrefix pfx = .shortBytes)
+    (hdecode : decode (pfx :: rest) = some (.bytes data, rest')) :
+    ∀ m, decodeAux (m + 1) (pfx :: rest) = some (.bytes data, rest') := by
+  rw [decode_cons_eq_decodeAux_fuel] at hdecode
+  have hdecode' :
+      decodeAux ((2 * rest.length + 1) + 1) (pfx :: rest) =
+        some (.bytes data, rest') := by
+    have hfuel : (2 * rest.length + 1) + 1 = 2 * rest.length + 2 := by omega
+    rw [hfuel]
+    exact hdecode
+  have hwitness :=
+    (ByteStringDecodeBridge.decodeAux_cons_shortBytes_eq_some_iff
+      (2 * rest.length + 1) pfx rest h_class data rest').mp hdecode'
+  intro m
+  exact (ByteStringDecodeBridge.decodeAux_cons_shortBytes_eq_some_iff
+    m pfx rest h_class data rest').mpr hwitness
+
+/-- Any successful byte-string `decode` result is stable for every positive
+    `decodeAux` fuel. This is the field-post adapter used by WP-generated
+    validating walks; callers do not need to expose the precise byte prefix
+    class at semantic joins. -/
+theorem decodeAux_bytes_all_fuel_of_decode
+    (pfx : Byte) (rest data rest' : List Byte)
+    (hdecode : decode (pfx :: rest) = some (.bytes data, rest')) :
+    ∀ m, decodeAux (m + 1) (pfx :: rest) = some (.bytes data, rest') := by
+  intro m
+  unfold decode at hdecode
+  unfold decodeAux at hdecode ⊢
+  by_cases h80 : pfx.toNat < 0x80
+  · simp [h80] at hdecode ⊢
+    exact hdecode
+  · by_cases hB7 : pfx.toNat ≤ 0xB7
+    · simp [h80, hB7] at hdecode ⊢
+      exact hdecode
+    · by_cases hBF : pfx.toNat ≤ 0xBF
+      · simp [h80, hB7, hBF] at hdecode ⊢
+        exact hdecode
+      · by_cases hF7 : pfx.toNat ≤ 0xF7
+        · simp [h80, hB7, hBF, hF7] at hdecode ⊢
+          cases htake : takeBytes rest (pfx.toNat - 0xC0) with
+          | none => simp [htake] at hdecode
+          | some pair =>
+              rcases pair with ⟨payload, tail⟩
+              simp [htake] at hdecode
+              cases hitems : decodeItems (2 * rest.length + 1) payload with
+              | none => simp [hitems] at hdecode
+              | some decoded =>
+                  rcases decoded with ⟨items, leftover⟩
+                  cases h_empty : List.isEmpty leftover <;> simp [hitems] at hdecode
+        · simp [h80, hB7, hBF, hF7] at hdecode ⊢
+          cases hread : readLength rest (pfx.toNat - 0xF7) with
+          | none => simp [hread] at hdecode
+          | some pair =>
+              rcases pair with ⟨lenVal, rest1⟩
+              by_cases hcanon : lenVal ≤ 55
+              · simp [hread, hcanon] at hdecode
+              · simp [hread, hcanon] at hdecode
+                cases htake : takeBytes rest1 lenVal with
+                | none => simp [htake] at hdecode
+                | some pair2 =>
+                    rcases pair2 with ⟨payload, tail⟩
+                    simp [htake] at hdecode
+                    cases hitems : decodeItems (2 * rest.length + 1) payload with
+                    | none => simp [hitems] at hdecode
+                    | some decoded =>
+                        rcases decoded with ⟨items, leftover⟩
+                        cases h_empty : List.isEmpty leftover <;> simp [hitems] at hdecode
+
 /-! ## Capstone: outer short list of four byte-string items -/
 
 /-- A short-list payload made of four decoded items is a full four-item RLP list. -/
@@ -209,6 +349,34 @@ theorem decodeFully_shortList_four (pfx : Byte) (payload : List Byte)
       have hfour := decodeItems_four_of_decodeAux payload 0 off1 off2 off3 off4
         item0 item1 item2 item3 k h0' h1 h2 h3 hend
       rwa [List.drop_zero] at hfour
+  simp [decodeFully, hdec]
+
+/-- A short-list payload made of four decoded items is a full four-item RLP
+    list, phrased over a remainder chain rather than offset drops. -/
+theorem decodeFully_shortList_four_chain (pfx : Byte) (payload r1 r2 r3 r4 : List Byte)
+    (item0 item1 item2 item3 : RLPItem)
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (h0 : ∀ m, decodeAux (m + 1) payload = some (item0, r1))
+    (h1 : ∀ m, decodeAux (m + 1) r1 = some (item1, r2))
+    (h2 : ∀ m, decodeAux (m + 1) r2 = some (item2, r3))
+    (h3 : ∀ m, decodeAux (m + 1) r3 = some (item3, r4))
+    (hend : r4 = [])
+    (h_min : 2 ≤ payload.length) :
+    decodeFully (pfx :: payload) = some (.list [item0, item1, item2, item3]) := by
+  have hdec : decode (pfx :: payload) = some (.list [item0, item1, item2, item3], []) := by
+    rw [decode_cons_eq_decodeAux_fuel,
+      show 2 * payload.length + 2 = (2 * payload.length + 1) + 1 from by omega]
+    refine (ListDecodeBridge.decodeAux_cons_shortList_eq_some_iff
+      (2 * payload.length + 1) pfx payload h_class
+      [item0, item1, item2, item3] []).mpr ?_
+    refine ⟨payload, ?_, ?_⟩
+    · rw [h_len, takeBytes_length_ge (le_refl payload.length), List.take_length, List.drop_length]
+    · apply ListDecodeBridge.decodeListPayload_eq_some_of_decodeItems_empty
+      obtain ⟨k, hk⟩ : ∃ k, 2 * payload.length + 1 = k + 5 := ⟨2 * payload.length - 4, by omega⟩
+      rw [hk]
+      exact decodeItems_four_of_decodeAux_chain payload r1 r2 r3 r4
+        item0 item1 item2 item3 k h0 h1 h2 h3 hend
   simp [decodeFully, hdec]
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/WalkInitWP.lean
+++ b/EvmAsm/Rv64/RLP/WalkInitWP.lean
@@ -1,0 +1,62 @@
+/-
+  EvmAsm.Rv64.RLP.WalkInitWP
+
+  WP-facing control summaries for `rlp_walk_init`.  The detailed leaf spec has
+  nine outcomes; fixed-schema decoders often first need only the coarse split
+  on the head `BEQ`: empty input versus nonempty input.
+-/
+
+import EvmAsm.Rv64.WP
+import EvmAsm.Rv64.RLP.WalkInit
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+
+/-- First `rlp_walk_init` branch precondition: only the length and zero register
+    are needed to split empty input from the nonempty path. -/
+def walkInitZeroNonzeroPre (listLen : Word) : Assertion :=
+  ((.x11 ↦ᵣ listLen) ** (.x0 ↦ᵣ (0 : Word)))
+
+/-- Taken branch of the first `rlp_walk_init` instruction: `listLen = 0`. -/
+def walkInitZeroPost (listLen : Word) : Assertion :=
+  ((.x11 ↦ᵣ listLen) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜listLen = (0 : Word)⌝)
+
+/-- Fall-through branch of the first `rlp_walk_init` instruction: `listLen != 0`. -/
+def walkInitNonzeroPost (listLen : Word) : Assertion :=
+  ((.x11 ↦ᵣ listLen) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜listLen ≠ (0 : Word)⌝)
+
+/-- Coarse zero/nonzero split for the first instruction of `rlp_walk_init`, as a
+    standalone singleton-code branch. -/
+theorem walkInitZeroNonzeroBranch_singleton_spec (base listLen : Word) :
+    cpsBranchWithin 1 base (CodeReq.singleton base (.BEQ .x11 .x0 (156 : BitVec 13)))
+      (walkInitZeroNonzeroPre listLen)
+      (base + 156) (walkInitZeroPost listLen)
+      (base + 4) (walkInitNonzeroPost listLen) := by
+  unfold walkInitZeroNonzeroPre walkInitZeroPost walkInitNonzeroPost
+  have h := beq_spec_gen_within .x11 .x0 (156 : BitVec 13) listLen (0 : Word) base
+  rw [show base + signExtend13 (156 : BitVec 13) = base + 156 from by
+    rw [show signExtend13 (156 : BitVec 13) = (156 : Word) from by decide]] at h
+  exact h
+
+/-- Coarse zero/nonzero split for the first instruction of `rlp_walk_init`, lifted
+    to the full `rlp_walk_init_code base` requirement. -/
+theorem walkInitZeroNonzeroBranch_spec (base listLen : Word) :
+    cpsBranchWithin 1 base (rlp_walk_init_code base)
+      (walkInitZeroNonzeroPre listLen)
+      (base + 156) (walkInitZeroPost listLen)
+      (base + 4) (walkInitNonzeroPost listLen) := by
+  have hmono : ∀ a i,
+      CodeReq.singleton base (.BEQ .x11 .x0 (156 : BitVec 13)) a = some i →
+      rlp_walk_init_code base a = some i :=
+    CodeReq.singleton_mono (CodeReq.ofProg_lookup_addr base rlp_walk_init_prog 0 base
+      (by rw [rlp_walk_init_prog_length]; norm_num)
+      (by rw [rlp_walk_init_prog_length]; norm_num) (by bv_omega))
+  exact cpsBranchWithin_extend_code hmono (walkInitZeroNonzeroBranch_singleton_spec base listLen)
+
+/-- WP branch certificate for the zero/nonzero split at the head of `rlp_walk_init`. -/
+def walkInitZeroNonzeroBranch (base listLen : Word) :
+    WP.Branch base (rlp_walk_init_code base) :=
+  WP.Branch.ofSpec (walkInitZeroNonzeroBranch_spec base listLen)
+
+end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -314,6 +314,144 @@ theorem walkInitEmptyFailStatusBranch_notTaken_post
       walkInitNonzeroOpenStatusPost listLen raVal statusOld := by
   rfl
 
+/-- Fall-through prefix tail after the initial zero/nonzero split:
+    `ADD x11,x10,x11; LBU x5,x10,0; LI x6,0xc0`. -/
+def walkInitNonzeroPrefixTailCode (base : Word) : CodeReq :=
+  (CodeReq.singleton (base + 4) (.ADD .x11 .x10 .x11)).union
+    ((CodeReq.singleton (base + 8) (.LBU .x5 .x10 0)).union
+      (CodeReq.singleton (base + 12) (.LI .x6 (0xc0 : Word))))
+
+/-- Code for the empty-input failure arm plus the nonzero prefix tail. -/
+def walkInitEmptyFailOrPrefixCode (base : Word) : CodeReq :=
+  (walkInitEmptyFailStatusCode base).union (walkInitNonzeroPrefixTailCode base)
+
+/-- State after the nonzero walk-init prefix tail has loaded the RLP prefix byte
+    and initialized the `0xc0` list threshold. -/
+def walkInitPrefixLoadedPost
+    (listBase listLen raVal : Word) (listBytes : List Byte)
+    (listOff : Nat) (hoff : listOff < listBytes.length) : Assertion :=
+  ((.x11 ↦ᵣ ((listBase + BitVec.ofNat 64 listOff) + listLen)) **
+    (.x10 ↦ᵣ (listBase + BitVec.ofNat 64 listOff)) **
+    (.x5 ↦ᵣ ((listBytes[listOff]'hoff).zeroExtend 64)) **
+    (.x6 ↦ᵣ (0xc0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) ** (.x1 ↦ᵣ raVal) **
+    bytesRegion listBase listBytes ** ⌜listLen ≠ (0 : Word)⌝)
+
+theorem walkInitNonzeroPrefixTail_spec_within
+    (base listBase listLen raVal t0Old t1Old : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true) :
+    cpsTripleWithin 3 (base + 4) (base + 16) (walkInitNonzeroPrefixTailCode base)
+      ((walkInitNonzeroOpenStatusPost listLen raVal (listBase + BitVec.ofNat 64 listOff)) **
+        (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion listBase listBytes)
+      (walkInitPrefixLoadedPost listBase listLen raVal listBytes listOff hoff) := by
+  unfold walkInitNonzeroOpenStatusPost walkInitNonzeroPost failStatusReturnPre
+    statusReturnPre walkInitPrefixLoadedPost walkInitNonzeroPrefixTailCode
+  have hadd := add_spec_gen_rd_eq_rs2_within .x11 .x10
+    (listBase + BitVec.ofNat 64 listOff) listLen (base + 4) (by decide)
+  have hlbu := bytesRegion_lbu_within .x5 .x10 listBase t0Old (base + 8)
+    listBytes listOff (by decide) hsalign hoff hover hvalid
+  have hli := li_spec_gen_within .x6 t1Old (0xc0 : Word) (base + 12) (by decide)
+  have hblk : cpsTripleWithin 3 (base + 4) (base + 16)
+      ((CodeReq.singleton (base + 4) (.ADD .x11 .x10 .x11)).union
+        ((CodeReq.singleton (base + 8) (.LBU .x5 .x10 0)).union
+          (CodeReq.singleton (base + 12) (.LI .x6 (0xc0 : Word)))))
+      ((.x11 ↦ᵣ listLen) ** (.x10 ↦ᵣ (listBase + BitVec.ofNat 64 listOff)) **
+        (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x1 ↦ᵣ raVal) ** bytesRegion listBase listBytes)
+      ((.x11 ↦ᵣ ((listBase + BitVec.ofNat 64 listOff) + listLen)) **
+        (.x10 ↦ᵣ (listBase + BitVec.ofNat 64 listOff)) **
+        (.x5 ↦ᵣ ((listBytes[listOff]'hoff).zeroExtend 64)) **
+        (.x6 ↦ᵣ (0xc0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) ** (.x1 ↦ᵣ raVal) **
+        bytesRegion listBase listBytes) := by
+    runBlock hadd hlbu hli
+  have hframed := cpsTripleWithin_frameR (⌜listLen ≠ (0 : Word)⌝) (by pcFree) hblk
+  exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp) hframed
+
+theorem walkInitEmptyFailStatusCode_disjoint_prefixTail (base : Word) :
+    (walkInitEmptyFailStatusCode base).Disjoint (walkInitNonzeroPrefixTailCode base) := by
+  unfold walkInitEmptyFailStatusCode walkInitNonzeroPrefixTailCode failStatusReturnCode
+    statusReturnCode
+  refine CodeReq.Disjoint.union_left ?_ ?_
+  · refine CodeReq.Disjoint.union_right (CodeReq.Disjoint.singleton (by bv_omega)) ?_
+    refine CodeReq.Disjoint.union_right
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega))
+  · refine CodeReq.Disjoint.union_left ?_ ?_
+    · refine CodeReq.Disjoint.union_right (CodeReq.Disjoint.singleton (by bv_omega)) ?_
+      refine CodeReq.Disjoint.union_right
+        (CodeReq.Disjoint.singleton (by bv_omega))
+        (CodeReq.Disjoint.singleton (by bv_omega))
+    · refine CodeReq.Disjoint.union_right (CodeReq.Disjoint.singleton (by bv_omega)) ?_
+      refine CodeReq.Disjoint.union_right
+        (CodeReq.Disjoint.singleton (by bv_omega))
+        (CodeReq.Disjoint.singleton (by bv_omega))
+
+/-- WP branch certificate after the first walk-init split and the nonzero prefix
+    tail.  The taken arm is the already-serviced empty-input failure endpoint;
+    the not-taken arm has loaded the prefix and remains open for the classifier. -/
+def walkInitEmptyFailOrPrefixBranch
+    (base listBase listLen raVal t0Old t1Old : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true) :
+    WP.Branch base (walkInitEmptyFailOrPrefixCode base) := by
+  let listPtr := listBase + BitVec.ofNat 64 listOff
+  let br0 := walkInitEmptyFailStatusBranch base listLen raVal listPtr
+  let frame : Assertion := (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion listBase listBytes
+  let br := WP.CFG.branchFrameR br0 frame (by
+    dsimp [frame]
+    pcFree)
+  have htail := walkInitNonzeroPrefixTail_spec_within base listBase listLen raVal
+    t0Old t1Old listBytes listOff hsalign hoff hover hvalid
+  unfold walkInitEmptyFailOrPrefixCode
+  exact WP.CFG.branchSeqNotTakenBlockDisjoint
+    (walkInitEmptyFailStatusCode_disjoint_prefixTail base)
+    br
+    htail
+    (by
+      intro h hp
+      dsimp [br, frame, br0, listPtr, WP.CFG.branchFrameR, WP.Branch.frameR] at hp
+      simpa only [listPtr, frame] using hp)
+
+theorem walkInitEmptyFailOrPrefixBranch_pre
+    (base listBase listLen raVal t0Old t1Old : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true) :
+    (walkInitEmptyFailOrPrefixBranch base listBase listLen raVal t0Old t1Old
+      listBytes listOff hsalign hoff hover hvalid).pre =
+      (walkInitEmptyFailStatusPre listLen raVal (listBase + BitVec.ofNat 64 listOff) **
+        (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion listBase listBytes) := by
+  rfl
+
+theorem walkInitEmptyFailOrPrefixBranch_taken_post
+    (base listBase listLen raVal t0Old t1Old : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true) :
+    (walkInitEmptyFailOrPrefixBranch base listBase listLen raVal t0Old t1Old
+      listBytes listOff hsalign hoff hover hvalid).post_t =
+      (walkInitEmptyFailStatusPost listLen raVal **
+        (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion listBase listBytes) := by
+  rfl
+
+theorem walkInitEmptyFailOrPrefixBranch_notTaken_post
+    (base listBase listLen raVal t0Old t1Old : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true) :
+    (walkInitEmptyFailOrPrefixBranch base listBase listLen raVal t0Old t1Old
+      listBytes listOff hsalign hoff hover hvalid).post_f =
+      walkInitPrefixLoadedPost listBase listLen raVal listBytes listOff hoff := by
+  rfl
+
 /-! ## Pure decode bridge -/
 
 /-- The decoded withdrawal value described by four already-decoded field byte strings.

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -1009,6 +1009,10 @@ theorem decodeWithdrawal_shortList_four_of_decodeAux (pfx : Byte) (payload : Lis
     (.bytes d0) (.bytes d1) (.bytes d2) (.bytes d3) h_class h_len h0 h1 h2 h3 hend h_min
   exact decodeWithdrawal_eq_some_of_decodeFully_fields hfull hc0 hl0 hc1 hl1 haddr hc3 hl3
 
+/-- The pure withdrawal decoder rejects empty input. -/
+theorem decodeWithdrawal_nil : decodeWithdrawal ([] : List Byte) = none := by
+  rfl
+
 /-! ## Result bytes, derived from the pure decoder result -/
 
 /-- Eight little-endian bytes of a 64-bit word. -/
@@ -1078,6 +1082,36 @@ theorem bytesRegionAny_pcFree (base : Word) (n : Nat) :
 
 instance (base : Word) (n : Nat) : Assertion.PCFree (bytesRegionAny base n) :=
   ⟨bytesRegionAny_pcFree base n⟩
+
+/-- Zero/nonzero walk-init split with an arbitrary caller frame carried across both
+    exits. Unlike the deeper prefix classifier, this certificate needs no prefix
+    readability hypotheses, so it is usable for the empty-input ABI path. -/
+def walkInitEmptyFailOrNonzeroFramedNBranch
+    (base listLen raVal statusOld : Word) (F : Assertion) (hF : F.pcFree) :
+    WP.NBranch base (walkInitEmptyFailStatusCode base) := by
+  let br := WP.CFG.nbranchOfBranch (walkInitEmptyFailStatusBranch base listLen raVal statusOld)
+  wp_rv64_nbranch_frame br, F, hF
+
+theorem walkInitEmptyFailOrNonzeroFramedNBranch_pre
+    (base listLen raVal statusOld : Word) (F : Assertion) (hF : F.pcFree) :
+    (walkInitEmptyFailOrNonzeroFramedNBranch base listLen raVal statusOld F hF).pre =
+      (walkInitEmptyFailStatusPre listLen raVal statusOld ** F) := by
+  rfl
+
+/-- Zero/nonzero walk-init split carrying the ABI output buffer across both exits. -/
+def walkInitEmptyFailOrNonzeroOutputNBranch
+    (base listLen raVal statusOld outBase : Word) :
+    WP.NBranch base (walkInitEmptyFailStatusCode base) :=
+  walkInitEmptyFailOrNonzeroFramedNBranch base listLen raVal statusOld
+    (bytesRegionAny outBase outputSize) (bytesRegionAny_pcFree outBase outputSize)
+
+theorem walkInitEmptyFailOrNonzeroOutputNBranch_pre
+    (base listLen raVal statusOld outBase : Word) :
+    (walkInitEmptyFailOrNonzeroOutputNBranch base listLen raVal statusOld outBase).pre =
+      (walkInitEmptyFailStatusPre listLen raVal statusOld **
+        bytesRegionAny outBase outputSize) := by
+  rw [walkInitEmptyFailOrNonzeroOutputNBranch,
+    walkInitEmptyFailOrNonzeroFramedNBranch_pre]
 
 /-- Walk-init classifier with the ABI output buffer framed across every exit. -/
 def walkInitEmptyFailNotListFailShortLongOutputNBranch
@@ -1169,6 +1203,15 @@ theorem resultPost_failure {input : List Byte} {outBase : Word}
   unfold resultPost
   rw [hdec]
 
+/-- ABI resources carried by the zero/nonzero split for the empty input case. -/
+def emptyInputAbiFrame (inputBase outBase : Word) : Assertion :=
+  bytesRegion inputBase [] ** bytesRegionAny outBase outputSize
+
+theorem emptyInputAbiFrame_pcFree (inputBase outBase : Word) :
+    (emptyInputAbiFrame inputBase outBase).pcFree := by
+  unfold emptyInputAbiFrame
+  exact pcFree_sepConj (bytesRegion_pcFree _ _) (bytesRegionAny_pcFree _ _)
+
 /-- A minimal ABI precondition for a withdrawal decoder entry.  A concrete
     program proof may strengthen this with scratch registers, stack cells, or
     helper-code frames through the WP precondition. -/
@@ -1184,6 +1227,51 @@ def abiPre (inputBase outBase raVal : Word) (input : List Byte) : Assertion :=
 def abiPost (inputBase outBase raVal : Word) (input : List Byte) : Assertion :=
   ((.x1 ↦ᵣ raVal) ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion inputBase input **
     resultPost input outBase)
+
+/-- Empty-input resources plus the pure decoder failure fact. -/
+def emptyInputDecodeFrame (inputBase outBase : Word) : Assertion :=
+  emptyInputAbiFrame inputBase outBase ** ⌜decodeWithdrawal ([] : List Byte) = none⌝
+
+theorem emptyInputDecodeFrame_pcFree (inputBase outBase : Word) :
+    (emptyInputDecodeFrame inputBase outBase).pcFree := by
+  unfold emptyInputDecodeFrame
+  exact pcFree_sepConj (emptyInputAbiFrame_pcFree inputBase outBase) pcFree_pure
+
+/-- Strong post for the empty-input walk-init failure arm. It keeps the exact
+    resource spine produced by the shallow walk-init slice and adds the pure
+    Lean decoder failure fact. -/
+def emptyInputFailurePost (inputBase outBase raVal : Word) : Assertion :=
+  ((((.x1 ↦ᵣ raVal) ** (.x10 ↦ᵣ (1 : Word))) ** (.x11 ↦ᵣ (0 : Word)) **
+      (.x0 ↦ᵣ (0 : Word)) ** ⌜(0 : Word) = (0 : Word)⌝) **
+    (bytesRegion inputBase [] ** bytesRegionAny outBase outputSize) **
+    ⌜decodeWithdrawal ([] : List Byte) = none⌝)
+
+/-- The shallow walk-init WP split specialized to empty input, with its head exit
+    mapped to a semantic failure post carrying decodeWithdrawal_nil. The nonzero
+    exit remains open and impossible under the zero length value. -/
+def walkInitEmptyInputFailureNBranch
+    (base inputBase outBase raVal statusOld : Word) :
+    WP.NBranch base (walkInitEmptyFailStatusCode base) := by
+  let frame := emptyInputDecodeFrame inputBase outBase
+  let br := walkInitEmptyFailOrNonzeroFramedNBranch base (0 : Word) raVal statusOld
+    frame (emptyInputDecodeFrame_pcFree inputBase outBase)
+  have hhead : WP.Entails
+      (walkInitEmptyFailStatusPost (0 : Word) raVal ** frame)
+      (emptyInputFailurePost inputBase outBase raVal) := by
+    intro h hp
+    unfold emptyInputFailurePost
+    dsimp [frame] at hp
+    unfold emptyInputDecodeFrame emptyInputAbiFrame walkInitEmptyFailStatusPost
+      failStatusReturnPost statusReturnPost walkInitZeroPost at hp
+    exact hp
+  exact WP.CFG.nbranchWeakenHeadPost br (by rfl) hhead
+
+theorem walkInitEmptyInputFailureNBranch_pre
+    (base inputBase outBase raVal statusOld : Word) :
+    (walkInitEmptyInputFailureNBranch base inputBase outBase raVal statusOld).pre =
+      (walkInitEmptyFailStatusPre (0 : Word) raVal statusOld **
+        emptyInputDecodeFrame inputBase outBase) := by
+  rfl
 
 /-- ABI resources preserved by the reason-erased failure endpoint.  The pure
     failure fact is supplied by the path that selected this endpoint, not by the

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -919,6 +919,48 @@ theorem walkInitEmptyFailNotListFailShortLongNBranch_pre
         (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion listBase listBytes) := by
   rfl
 
+/-- Uniformly frame the symbolic walk-init classifier. Generated decoder proofs
+    use this after WP reduction to carry caller-owned resources, such as the ABI
+    output buffer, across every still-open exit. -/
+def walkInitEmptyFailNotListFailShortLongFramedNBranch
+    (base listBase listLen raVal t0Old t1Old : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true)
+    (F : Assertion) (hF : F.pcFree) :
+    WP.NBranch base (walkInitEmptyFailNotListFailShortLongCode base) := by
+  let br := walkInitEmptyFailNotListFailShortLongNBranch base listBase listLen raVal
+    t0Old t1Old listBytes listOff hsalign hoff hover hvalid
+  wp_rv64_nbranch_frame br, F, hF
+
+theorem walkInitEmptyFailNotListFailShortLongFramedNBranch_pre
+    (base listBase listLen raVal t0Old t1Old : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true)
+    (F : Assertion) (hF : F.pcFree) :
+    (walkInitEmptyFailNotListFailShortLongFramedNBranch base listBase listLen raVal t0Old t1Old
+      listBytes listOff hsalign hoff hover hvalid F hF).pre =
+      ((walkInitEmptyFailNotListFailShortLongNBranch base listBase listLen raVal t0Old t1Old
+        listBytes listOff hsalign hoff hover hvalid).pre ** F) := by
+  rfl
+
+theorem walkInitEmptyFailNotListFailShortLongFramedNBranch_pre_expanded
+    (base listBase listLen raVal t0Old t1Old : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true)
+    (F : Assertion) (hF : F.pcFree) :
+    (walkInitEmptyFailNotListFailShortLongFramedNBranch base listBase listLen raVal t0Old t1Old
+      listBytes listOff hsalign hoff hover hvalid F hF).pre =
+      ((walkInitEmptyFailStatusPre listLen raVal (listBase + BitVec.ofNat 64 listOff) **
+        (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion listBase listBytes) ** F) := by
+  rw [walkInitEmptyFailNotListFailShortLongFramedNBranch_pre,
+    walkInitEmptyFailNotListFailShortLongNBranch_pre]
+
 /-! ## Pure decode bridge -/
 
 /-- The decoded withdrawal value described by four already-decoded field byte strings.
@@ -1036,6 +1078,68 @@ theorem bytesRegionAny_pcFree (base : Word) (n : Nat) :
 
 instance (base : Word) (n : Nat) : Assertion.PCFree (bytesRegionAny base n) :=
   ⟨bytesRegionAny_pcFree base n⟩
+
+/-- Walk-init classifier with the ABI output buffer framed across every exit. -/
+def walkInitEmptyFailNotListFailShortLongOutputNBranch
+    (base listBase listLen raVal t0Old t1Old outBase : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true) :
+    WP.NBranch base (walkInitEmptyFailNotListFailShortLongCode base) :=
+  walkInitEmptyFailNotListFailShortLongFramedNBranch base listBase listLen raVal
+    t0Old t1Old listBytes listOff hsalign hoff hover hvalid
+    (bytesRegionAny outBase outputSize) (bytesRegionAny_pcFree outBase outputSize)
+
+theorem walkInitEmptyFailNotListFailShortLongOutputNBranch_pre
+    (base listBase listLen raVal t0Old t1Old outBase : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true) :
+    (walkInitEmptyFailNotListFailShortLongOutputNBranch base listBase listLen raVal t0Old t1Old
+      outBase listBytes listOff hsalign hoff hover hvalid).pre =
+      ((walkInitEmptyFailStatusPre listLen raVal (listBase + BitVec.ofNat 64 listOff) **
+        (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion listBase listBytes) **
+        bytesRegionAny outBase outputSize) := by
+  rw [walkInitEmptyFailNotListFailShortLongOutputNBranch,
+    walkInitEmptyFailNotListFailShortLongFramedNBranch_pre_expanded]
+
+/-- Turn raw walk-init exits into a caller-provided semantic exit list. The map
+    proof is the only remaining manual input: each raw exit must keep its PC and
+    entail the corresponding semantic postcondition. -/
+def walkInitEmptyFailNotListFailShortLongOutputMappedNBranch
+    (base listBase listLen raVal t0Old t1Old outBase : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true)
+    (exits : List (Word × Assertion))
+    (hmap : ∀ ex ∈
+      (walkInitEmptyFailNotListFailShortLongOutputNBranch base listBase listLen raVal t0Old t1Old
+        outBase listBytes listOff hsalign hoff hover hvalid).exits,
+      ∃ ex' ∈ exits, ex'.1 = ex.1 ∧ WP.Entails ex.2 ex'.2) :
+    WP.NBranch base (walkInitEmptyFailNotListFailShortLongCode base) := by
+  let br := walkInitEmptyFailNotListFailShortLongOutputNBranch base listBase listLen raVal
+    t0Old t1Old outBase listBytes listOff hsalign hoff hover hvalid
+  wp_rv64_nbranch_weaken_posts br, exits, hmap
+
+theorem walkInitEmptyFailNotListFailShortLongOutputMappedNBranch_pre
+    (base listBase listLen raVal t0Old t1Old outBase : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true)
+    (exits : List (Word × Assertion))
+    (hmap : ∀ ex ∈
+      (walkInitEmptyFailNotListFailShortLongOutputNBranch base listBase listLen raVal t0Old t1Old
+        outBase listBytes listOff hsalign hoff hover hvalid).exits,
+      ∃ ex' ∈ exits, ex'.1 = ex.1 ∧ WP.Entails ex.2 ex'.2) :
+    (walkInitEmptyFailNotListFailShortLongOutputMappedNBranch base listBase listLen raVal
+      t0Old t1Old outBase listBytes listOff hsalign hoff hover hvalid exits hmap).pre =
+      (walkInitEmptyFailNotListFailShortLongOutputNBranch base listBase listLen raVal t0Old t1Old
+        outBase listBytes listOff hsalign hoff hover hvalid).pre := by
+  rfl
 
 /-- Result portion of the ABI postcondition.  Success is exactly
     `decodeWithdrawal input = some w`; failure is exactly `decodeWithdrawal input = none`.

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -1300,9 +1300,183 @@ theorem walkInitEmptyFailNotListFailShortLongOutputNBranch_pre
   rw [walkInitEmptyFailNotListFailShortLongOutputNBranch,
     walkInitEmptyFailNotListFailShortLongFramedNBranch_pre_expanded]
 
+/-- Raw empty-input failure exit of the walk-init classifier, including the
+    scratch/input frame that was carried across the classifier. -/
+def walkInitEmptyFailOutputPost
+    (listBase listLen raVal t0Old t1Old outBase : Word)
+    (listBytes : List Byte) : Assertion :=
+  ((walkInitEmptyFailStatusPost listLen raVal **
+    ((.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion listBase listBytes)) **
+    bytesRegionAny outBase outputSize)
+
+/-- Raw not-list failure exit after the reason-erased failure endpoint. -/
+def walkInitNotListFailOutputPost
+    (listBase listLen raVal outBase : Word) (listBytes : List Byte)
+    (listOff : Nat) (hoff : listOff < listBytes.length) : Assertion :=
+  walkInitPrefixNotListFailStatusPost listBase listLen raVal listBytes listOff hoff **
+    bytesRegionAny outBase outputSize
+
+/-- Raw short-list candidate exit, with the ABI output buffer preserved. -/
+def walkInitShortListOutputPost
+    (listBase listLen raVal outBase : Word) (listBytes : List Byte)
+    (listOff : Nat) (hoff : listOff < listBytes.length) : Assertion :=
+  walkInitShortListCandidatePost listBase listLen raVal listBytes listOff hoff **
+    bytesRegionAny outBase outputSize
+
+/-- Raw long-list candidate exit, with the ABI output buffer preserved. -/
+def walkInitLongListOutputPost
+    (listBase listLen raVal outBase : Word) (listBytes : List Byte)
+    (listOff : Nat) (hoff : listOff < listBytes.length) : Assertion :=
+  walkInitLongListCandidatePost listBase listLen raVal listBytes listOff hoff **
+    bytesRegionAny outBase outputSize
+
+/-- The four raw exits of `walkInitEmptyFailNotListFailShortLongOutputNBranch`,
+    named so generated proof code can target cases rather than list membership. -/
+def walkInitEmptyFailNotListFailShortLongOutputExits
+    (base listBase listLen raVal t0Old t1Old outBase : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hoff : listOff < listBytes.length) : List (Word × Assertion) :=
+  [ (failStatusReturnExit raVal,
+      walkInitEmptyFailOutputPost listBase listLen raVal t0Old t1Old outBase listBytes)
+  , (failStatusReturnExit raVal,
+      walkInitNotListFailOutputPost listBase listLen raVal outBase listBytes listOff hoff)
+  , (base + 124,
+      walkInitShortListOutputPost listBase listLen raVal outBase listBytes listOff hoff)
+  , (base + 28,
+      walkInitLongListOutputPost listBase listLen raVal outBase listBytes listOff hoff)
+  ]
+
+theorem walkInitEmptyFailNotListFailShortLongOutputNBranch_exits
+    (base listBase listLen raVal t0Old t1Old outBase : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true) :
+    (walkInitEmptyFailNotListFailShortLongOutputNBranch base listBase listLen raVal t0Old t1Old
+      outBase listBytes listOff hsalign hoff hover hvalid).exits =
+      walkInitEmptyFailNotListFailShortLongOutputExits base listBase listLen raVal t0Old t1Old
+        outBase listBytes listOff hoff := by
+  simp [walkInitEmptyFailNotListFailShortLongOutputNBranch,
+    walkInitEmptyFailNotListFailShortLongFramedNBranch,
+    walkInitEmptyFailNotListFailShortLongNBranch,
+    walkInitEmptyFailOrPrefixBranch, walkInitPrefixListCheckOrNotListFailBranch,
+    walkInitEmptyFailStatusBranch, walkInitPrefixListCheckBranch,
+    walkInitShortLongCheckBranch, walkInitEmptyFailStatusPost,
+    walkInitEmptyFailNotListFailShortLongOutputExits, walkInitEmptyFailOutputPost,
+    walkInitNotListFailOutputPost, walkInitShortListOutputPost, walkInitLongListOutputPost,
+    failStatusReturnExit, statusReturnExit, WP.CFG.nbranchFrameR, WP.NBranch.frameR,
+    WP.CFG.branchFrameR, WP.Branch.frameR, WP.CFG.branchSeqNotTakenNBranchDisjoint,
+    WP.Branch.seqNotTakenNBranchDisjoint, WP.CFG.branchSeqNotTakenBlockDisjoint,
+    WP.CFG.branchSeqTakenBlockDisjoint, WP.CFG.branchSeqNotTakenDisjoint,
+    WP.CFG.branchSeqTakenDisjoint, WP.Branch.seqNotTakenDisjoint,
+    WP.Branch.seqTakenDisjoint, WP.CFG.nbranchOfBranch, WP.NBranch.ofBranch,
+    WP.Branch.ofSpec, WP.CFG.block, WP.Triple.ofSpec]
+
+/-- Case-oriented weakening for the four raw walk-init classifier exits. This is
+    the generated-proof entry point: callers provide one entailment per control
+    case, and the membership-map proof is built here. -/
+def walkInitEmptyFailNotListFailShortLongOutputCaseNBranch
+    (base listBase listLen raVal t0Old t1Old outBase : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true)
+    (emptyPost notListPost shortPost longPost : Assertion)
+    (hEmpty : WP.Entails
+      (walkInitEmptyFailOutputPost listBase listLen raVal t0Old t1Old outBase listBytes)
+      emptyPost)
+    (hNotList : WP.Entails
+      (walkInitNotListFailOutputPost listBase listLen raVal outBase listBytes listOff hoff)
+      notListPost)
+    (hShort : WP.Entails
+      (walkInitShortListOutputPost listBase listLen raVal outBase listBytes listOff hoff)
+      shortPost)
+    (hLong : WP.Entails
+      (walkInitLongListOutputPost listBase listLen raVal outBase listBytes listOff hoff)
+      longPost) :
+    WP.NBranch base (walkInitEmptyFailNotListFailShortLongCode base) := by
+  let br := walkInitEmptyFailNotListFailShortLongOutputNBranch base listBase listLen raVal
+    t0Old t1Old outBase listBytes listOff hsalign hoff hover hvalid
+  let exits : List (Word × Assertion) :=
+    [ (failStatusReturnExit raVal, emptyPost)
+    , (failStatusReturnExit raVal, notListPost)
+    , (base + 124, shortPost)
+    , (base + 28, longPost)
+    ]
+  exact WP.CFG.nbranchWeakenPosts br exits (by
+    intro ex hex
+    have hex' := hex
+    rw [walkInitEmptyFailNotListFailShortLongOutputNBranch_exits] at hex'
+    simp [walkInitEmptyFailNotListFailShortLongOutputExits] at hex'
+    rcases hex' with hcase | hcase | hcase | hcase
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(failStatusReturnExit raVal, emptyPost), by simp [exits], rfl, hEmpty⟩
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(failStatusReturnExit raVal, notListPost), by simp [exits], rfl, hNotList⟩
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(base + 124, shortPost), by simp [exits], rfl, hShort⟩
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(base + 28, longPost), by simp [exits], rfl, hLong⟩)
+
+theorem walkInitEmptyFailNotListFailShortLongOutputCaseNBranch_pre
+    (base listBase listLen raVal t0Old t1Old outBase : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true)
+    (emptyPost notListPost shortPost longPost : Assertion)
+    (hEmpty : WP.Entails
+      (walkInitEmptyFailOutputPost listBase listLen raVal t0Old t1Old outBase listBytes)
+      emptyPost)
+    (hNotList : WP.Entails
+      (walkInitNotListFailOutputPost listBase listLen raVal outBase listBytes listOff hoff)
+      notListPost)
+    (hShort : WP.Entails
+      (walkInitShortListOutputPost listBase listLen raVal outBase listBytes listOff hoff)
+      shortPost)
+    (hLong : WP.Entails
+      (walkInitLongListOutputPost listBase listLen raVal outBase listBytes listOff hoff)
+      longPost) :
+    (walkInitEmptyFailNotListFailShortLongOutputCaseNBranch base listBase listLen raVal
+      t0Old t1Old outBase listBytes listOff hsalign hoff hover hvalid emptyPost notListPost
+      shortPost longPost hEmpty hNotList hShort hLong).pre =
+      (walkInitEmptyFailNotListFailShortLongOutputNBranch base listBase listLen raVal t0Old t1Old
+        outBase listBytes listOff hsalign hoff hover hvalid).pre := by
+  rfl
+
+theorem walkInitEmptyFailNotListFailShortLongOutputCaseNBranch_exits
+    (base listBase listLen raVal t0Old t1Old outBase : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true)
+    (emptyPost notListPost shortPost longPost : Assertion)
+    (hEmpty : WP.Entails
+      (walkInitEmptyFailOutputPost listBase listLen raVal t0Old t1Old outBase listBytes)
+      emptyPost)
+    (hNotList : WP.Entails
+      (walkInitNotListFailOutputPost listBase listLen raVal outBase listBytes listOff hoff)
+      notListPost)
+    (hShort : WP.Entails
+      (walkInitShortListOutputPost listBase listLen raVal outBase listBytes listOff hoff)
+      shortPost)
+    (hLong : WP.Entails
+      (walkInitLongListOutputPost listBase listLen raVal outBase listBytes listOff hoff)
+      longPost) :
+    (walkInitEmptyFailNotListFailShortLongOutputCaseNBranch base listBase listLen raVal
+      t0Old t1Old outBase listBytes listOff hsalign hoff hover hvalid emptyPost notListPost
+      shortPost longPost hEmpty hNotList hShort hLong).exits =
+      [ (failStatusReturnExit raVal, emptyPost)
+      , (failStatusReturnExit raVal, notListPost)
+      , (base + 124, shortPost)
+      , (base + 28, longPost)
+      ] := by
+  rfl
+
 /-- Turn raw walk-init exits into a caller-provided semantic exit list. The map
-    proof is the only remaining manual input: each raw exit must keep its PC and
-    entail the corresponding semantic postcondition. -/
+    proof remains available for unusual generated control-flow shapes; prefer
+    `walkInitEmptyFailNotListFailShortLongOutputCaseNBranch` when mapping the
+    standard four classifier cases. -/
 def walkInitEmptyFailNotListFailShortLongOutputMappedNBranch
     (base listBase listLen raVal t0Old t1Old outBase : Word)
     (listBytes : List Byte) (listOff : Nat)

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -11,7 +11,9 @@ import EvmAsm.Rv64.WP
 import EvmAsm.Rv64.MemRegion
 import EvmAsm.Rv64.MemRegionStore
 import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.Tactics.RunBlock
+import EvmAsm.Rv64.Tactics.WP
 import EvmAsm.Rv64.RLP.WalkDecodeBridge
 import EvmAsm.EL.Withdrawal
 
@@ -126,6 +128,63 @@ def prologueCert (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word) :
       (prologuePost sp0 raVal s0Old s1Old s2Old outBase) :=
   WP.CFG.block (WP.Entails.refl _)
     (prologue_spec_within base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3)
+
+/-! ## Failure endpoint -/
+
+/-- Small reason-erased failure return block: set status `1` and return.  This
+    deliberately does not encode why decoding failed; the public postcondition only
+    observes failure as `decodeWithdrawal input = none`. -/
+def failStatusReturn : List Instr :=
+  [ .LI .x10 (1 : Word)
+  , .JALR .x0 .x1 (0 : BitVec 12)
+  ]
+
+theorem failStatusReturn_length : failStatusReturn.length = 2 := rfl
+
+/-- Code requirement for the reason-erased failure return block rooted at `base`.
+    WP certificates keep code as a disjoint union of instruction fetches;
+    `failStatusReturn` remains the executable list shape. -/
+def failStatusReturnCode (base : Word) : CodeReq :=
+  (CodeReq.singleton base (.LI .x10 (1 : Word))).union
+    (CodeReq.singleton (base + 4) (.JALR .x0 .x1 (0 : BitVec 12)))
+
+/-- Return PC used by the failure return block, exactly matching `JALR x0, ra, 0`. -/
+def failStatusReturnExit (raVal : Word) : Word :=
+  (raVal + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)
+
+/-- Internal precondition for the reason-erased failure return block. -/
+def failStatusReturnPre (raVal statusOld : Word) : Assertion :=
+  ((.x1 ↦ᵣ raVal) ** (.x10 ↦ᵣ statusOld))
+
+/-- Internal postcondition for the reason-erased failure return block. -/
+def failStatusReturnPost (raVal : Word) : Assertion :=
+  ((.x1 ↦ᵣ raVal) ** (.x10 ↦ᵣ (1 : Word)))
+
+/-- WP certificate for the reason-erased failure return block. -/
+def failStatusReturnCert (base raVal statusOld : Word) :
+    WP.CFG.Cert base (failStatusReturnExit raVal) (failStatusReturnCode base)
+      (failStatusReturnPost raVal) := by
+  unfold failStatusReturnPost failStatusReturnExit failStatusReturnCode
+  have hli0 := li_spec_gen_within .x10 statusOld (1 : Word) base (by decide)
+  have hli := cpsTripleWithin_frameL (.x1 ↦ᵣ raVal) (by pcFree) hli0
+  have hret0 := jalr_x0_spec_gen_within .x1 raVal (0 : BitVec 12) (base + 4)
+  have hret := cpsTripleWithin_frameR (.x10 ↦ᵣ (1 : Word)) (by pcFree) hret0
+  exact WP.CFG.seqDisjoint
+    (CodeReq.Disjoint.singleton (by bv_omega))
+    hli
+    (WP.CFG.block (WP.Entails.refl _) hret)
+    (by wp_rv64_link)
+
+/-- Verified reason-erased failure return block. -/
+theorem failStatusReturn_spec_within
+    (base raVal statusOld : Word) :
+    cpsTripleWithin (failStatusReturnCert base raVal statusOld).nSteps base
+      (failStatusReturnExit raVal) (failStatusReturnCode base)
+      (failStatusReturnPre raVal statusOld)
+      (failStatusReturnPost raVal) :=
+  by
+    unfold failStatusReturnPre
+    exact (failStatusReturnCert base raVal statusOld).sound
 
 /-! ## Pure decode bridge -/
 

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -130,51 +130,82 @@ def prologueCert (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word) :
   WP.CFG.block (WP.Entails.refl _)
     (prologue_spec_within base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3)
 
-/-! ## Failure endpoint -/
+/-! ## Status return endpoints -/
 
-/-- Small reason-erased failure return block: set status `1` and return.  This
-    deliberately does not encode why decoding failed; the public postcondition only
-    observes failure as `decodeWithdrawal input = none`. -/
-def failStatusReturn : List Instr :=
-  [ .LI .x10 (1 : Word)
+/-- Small status-return block: set `a0` to `status` and return through `ra`. -/
+def statusReturn (status : Word) : List Instr :=
+  [ .LI .x10 status
   , .JALR .x0 .x1 (0 : BitVec 12)
   ]
 
-theorem failStatusReturn_length : failStatusReturn.length = 2 := rfl
+theorem statusReturn_length (status : Word) : (statusReturn status).length = 2 := rfl
 
-/-- Code requirement for the reason-erased failure return block rooted at `base`.
-    WP certificates keep code as a disjoint union of instruction fetches;
-    `failStatusReturn` remains the executable list shape. -/
-def failStatusReturnCode (base : Word) : CodeReq :=
-  (CodeReq.singleton base (.LI .x10 (1 : Word))).union
+/-- Code requirement for a status-return block rooted at `base`.  WP certificates
+    keep code as a disjoint union of instruction fetches; `statusReturn` remains
+    the executable list shape. -/
+def statusReturnCode (base status : Word) : CodeReq :=
+  (CodeReq.singleton base (.LI .x10 status)).union
     (CodeReq.singleton (base + 4) (.JALR .x0 .x1 (0 : BitVec 12)))
 
-/-- Return PC used by the failure return block, exactly matching `JALR x0, ra, 0`. -/
-def failStatusReturnExit (raVal : Word) : Word :=
+/-- Return PC used by a status-return block, exactly matching `JALR x0, ra, 0`. -/
+def statusReturnExit (raVal : Word) : Word :=
   (raVal + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)
 
-/-- Internal precondition for the reason-erased failure return block. -/
-def failStatusReturnPre (raVal statusOld : Word) : Assertion :=
+/-- Internal precondition for a status-return block. -/
+def statusReturnPre (raVal statusOld : Word) : Assertion :=
   ((.x1 ↦ᵣ raVal) ** (.x10 ↦ᵣ statusOld))
 
-/-- Internal postcondition for the reason-erased failure return block. -/
-def failStatusReturnPost (raVal : Word) : Assertion :=
-  ((.x1 ↦ᵣ raVal) ** (.x10 ↦ᵣ (1 : Word)))
+/-- Internal postcondition for a status-return block. -/
+def statusReturnPost (raVal status : Word) : Assertion :=
+  ((.x1 ↦ᵣ raVal) ** (.x10 ↦ᵣ status))
 
-/-- WP certificate for the reason-erased failure return block. -/
-def failStatusReturnCert (base raVal statusOld : Word) :
-    WP.CFG.Cert base (failStatusReturnExit raVal) (failStatusReturnCode base)
-      (failStatusReturnPost raVal) := by
-  unfold failStatusReturnPost failStatusReturnExit failStatusReturnCode
-  have hli0 := li_spec_gen_within .x10 statusOld (1 : Word) base (by decide)
+/-- WP certificate for a status-return block. -/
+def statusReturnCert (base raVal statusOld status : Word) :
+    WP.CFG.Cert base (statusReturnExit raVal) (statusReturnCode base status)
+      (statusReturnPost raVal status) := by
+  unfold statusReturnPost statusReturnExit statusReturnCode
+  have hli0 := li_spec_gen_within .x10 statusOld status base (by decide)
   have hli := cpsTripleWithin_frameL (.x1 ↦ᵣ raVal) (by pcFree) hli0
   have hret0 := jalr_x0_spec_gen_within .x1 raVal (0 : BitVec 12) (base + 4)
-  have hret := cpsTripleWithin_frameR (.x10 ↦ᵣ (1 : Word)) (by pcFree) hret0
+  have hret := cpsTripleWithin_frameR (.x10 ↦ᵣ status) (by pcFree) hret0
   exact WP.CFG.seqBlockDisjoint
     (CodeReq.Disjoint.singleton (by bv_omega))
     hli
     hret
     (by wp_rv64_link)
+
+/-- Verified status-return block. -/
+theorem statusReturn_spec_within (base raVal statusOld status : Word) :
+    cpsTripleWithin (statusReturnCert base raVal statusOld status).nSteps base
+      (statusReturnExit raVal) (statusReturnCode base status)
+      (statusReturnPre raVal statusOld)
+      (statusReturnPost raVal status) :=
+  by
+    unfold statusReturnPre
+    exact (statusReturnCert base raVal statusOld status).sound
+
+/-- Reason-erased failure return block: set status `1` and return. -/
+def failStatusReturn : List Instr :=
+  statusReturn (1 : Word)
+
+theorem failStatusReturn_length : failStatusReturn.length = 2 := rfl
+
+def failStatusReturnCode (base : Word) : CodeReq :=
+  statusReturnCode base (1 : Word)
+
+def failStatusReturnExit (raVal : Word) : Word :=
+  statusReturnExit raVal
+
+def failStatusReturnPre (raVal statusOld : Word) : Assertion :=
+  statusReturnPre raVal statusOld
+
+def failStatusReturnPost (raVal : Word) : Assertion :=
+  statusReturnPost raVal (1 : Word)
+
+def failStatusReturnCert (base raVal statusOld : Word) :
+    WP.CFG.Cert base (failStatusReturnExit raVal) (failStatusReturnCode base)
+      (failStatusReturnPost raVal) :=
+  statusReturnCert base raVal statusOld (1 : Word)
 
 /-- Verified reason-erased failure return block. -/
 theorem failStatusReturn_spec_within
@@ -183,9 +214,39 @@ theorem failStatusReturn_spec_within
       (failStatusReturnExit raVal) (failStatusReturnCode base)
       (failStatusReturnPre raVal statusOld)
       (failStatusReturnPost raVal) :=
-  by
-    unfold failStatusReturnPre
-    exact (failStatusReturnCert base raVal statusOld).sound
+  statusReturn_spec_within base raVal statusOld (1 : Word)
+
+/-- Success return block: set status `0` and return. -/
+def successStatusReturn : List Instr :=
+  statusReturn (0 : Word)
+
+theorem successStatusReturn_length : successStatusReturn.length = 2 := rfl
+
+def successStatusReturnCode (base : Word) : CodeReq :=
+  statusReturnCode base (0 : Word)
+
+def successStatusReturnExit (raVal : Word) : Word :=
+  statusReturnExit raVal
+
+def successStatusReturnPre (raVal statusOld : Word) : Assertion :=
+  statusReturnPre raVal statusOld
+
+def successStatusReturnPost (raVal : Word) : Assertion :=
+  statusReturnPost raVal (0 : Word)
+
+def successStatusReturnCert (base raVal statusOld : Word) :
+    WP.CFG.Cert base (successStatusReturnExit raVal) (successStatusReturnCode base)
+      (successStatusReturnPost raVal) :=
+  statusReturnCert base raVal statusOld (0 : Word)
+
+/-- Verified success return block. -/
+theorem successStatusReturn_spec_within
+    (base raVal statusOld : Word) :
+    cpsTripleWithin (successStatusReturnCert base raVal statusOld).nSteps base
+      (successStatusReturnExit raVal) (successStatusReturnCode base)
+      (successStatusReturnPre raVal statusOld)
+      (successStatusReturnPost raVal) :=
+  statusReturn_spec_within base raVal statusOld (0 : Word)
 
 /-! ## Pure decode bridge -/
 
@@ -385,7 +446,7 @@ def failStatusReturnAbiCert
   exact WP.CFG.block (by
     intro h hp
     have hpCase := hp
-    unfold failStatusReturnPost failStatusReturnAbiFrame at hp hpCase
+    unfold failStatusReturnPost statusReturnPost failStatusReturnAbiFrame at hp hpCase
     extract_pure hpCase
     obtain ⟨hdec, _hpRest⟩ := hpCase
     unfold abiPost
@@ -402,6 +463,60 @@ theorem failStatusReturn_abiPost_spec_within
   by
     unfold failStatusReturnAbiPre
     exact (failStatusReturnAbiCert base inputBase outBase raVal statusOld input).sound
+
+/-- ABI resources preserved by the success endpoint after the field decoders have
+    populated the output struct with the pure decoder result bytes. -/
+def successStatusReturnAbiFrame
+    (inputBase outBase : Word) (input : List Byte) (w : Withdrawal) : Assertion :=
+  ((.x0 ↦ᵣ (0 : Word)) ** bytesRegion inputBase input **
+    bytesRegion outBase (successBytes w) ** ⌜decodeWithdrawal input = some w⌝)
+
+theorem successStatusReturnAbiFrame_pcFree
+    (inputBase outBase : Word) (input : List Byte) (w : Withdrawal) :
+    (successStatusReturnAbiFrame inputBase outBase input w).pcFree := by
+  unfold successStatusReturnAbiFrame
+  exact pcFree_sepConj pcFree_regIs
+    (pcFree_sepConj (bytesRegion_pcFree _ _)
+      (pcFree_sepConj (bytesRegion_pcFree _ _) pcFree_pure))
+
+/-- ABI-facing precondition for a success endpoint reached after a path has
+    established the decoded withdrawal and written its output bytes. -/
+def successStatusReturnAbiPre
+    (inputBase outBase raVal statusOld : Word) (input : List Byte)
+    (w : Withdrawal) : Assertion :=
+  successStatusReturnPre raVal statusOld ** successStatusReturnAbiFrame inputBase outBase input w
+
+/-- WP certificate adapting the success endpoint to the public ABI postcondition. -/
+def successStatusReturnAbiCert
+    (base inputBase outBase raVal statusOld : Word) (input : List Byte)
+    (w : Withdrawal) :
+    WP.CFG.Cert base (successStatusReturnExit raVal) (successStatusReturnCode base)
+      (abiPost inputBase outBase raVal input) := by
+  have hsuccess := successStatusReturn_spec_within base raVal statusOld
+  have hframed := cpsTripleWithin_frameR
+    (successStatusReturnAbiFrame inputBase outBase input w)
+    (successStatusReturnAbiFrame_pcFree inputBase outBase input w) hsuccess
+  exact WP.CFG.block (by
+    intro h hp
+    have hpCase := hp
+    unfold successStatusReturnPost statusReturnPost successStatusReturnAbiFrame at hp hpCase
+    extract_pure hpCase
+    obtain ⟨hdec, _hpRest⟩ := hpCase
+    unfold abiPost
+    rw [resultPost_success hdec]
+    xperm_hyp hp) hframed
+
+/-- Verified ABI-facing success endpoint. -/
+theorem successStatusReturn_abiPost_spec_within
+    (base inputBase outBase raVal statusOld : Word) (input : List Byte)
+    (w : Withdrawal) :
+    cpsTripleWithin (successStatusReturnAbiCert base inputBase outBase raVal statusOld input w).nSteps
+      base (successStatusReturnExit raVal) (successStatusReturnCode base)
+      (successStatusReturnAbiPre inputBase outBase raVal statusOld input w)
+      (abiPost inputBase outBase raVal input) :=
+  by
+    unfold successStatusReturnAbiPre
+    exact (successStatusReturnAbiCert base inputBase outBase raVal statusOld input w).sound
 
 /-- A WP-facing certificate that a concrete control-flow proof implements the
     withdrawal decoder ABI.  The computed precondition is `cfg.pre`, so generated

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -1014,15 +1014,17 @@ def walkInitEmptyFailThenNonzeroShortLongNBranch
     WP.NBranch base (walkInitEmptyFailThenNonzeroShortLongCode base) := by
   let listPtr := listBase + BitVec.ofNat 64 listOff
   let frame : Assertion := (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion listBase listBytes
-  let br0 := WP.CFG.nbranchOfBranch (walkInitEmptyFailStatusBranch base listLen raVal listPtr)
+  let statusBranch := walkInitEmptyFailStatusBranch base listLen raVal listPtr
+  let br0 := WP.CFG.nbranchOfBranch statusBranch
   let br := WP.CFG.nbranchFrameR br0 frame (by
     dsimp [frame]
     pcFree)
   let tail := walkInitNonzeroNotListFailShortLongNBranch base listBase listLen raVal
     t0Old t1Old listBytes listOff hsalign hoff hover hvalid
   unfold walkInitEmptyFailThenNonzeroShortLongCode
-  wp_rv64_nbranch_second_nbranch_disjoint
-    (walkInitEmptyFailStatusCode_disjoint_nonzeroNotListFailShortLong base), br, tail
+  wp_rv64_nbranch_exit_nbranch_disjoint
+    (walkInitEmptyFailStatusCode_disjoint_nonzeroNotListFailShortLong base), br,
+    [(statusBranch.exit_t, (statusBranch.post_t ** frame))], tail
 
 theorem walkInitEmptyFailThenNonzeroShortLongNBranch_pre
     (base listBase listLen raVal t0Old t1Old : Word)

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -16,6 +16,7 @@ import EvmAsm.Rv64.Tactics.RunBlock
 import EvmAsm.Rv64.Tactics.WP
 import EvmAsm.Rv64.Tactics.ExtractPure
 import EvmAsm.Rv64.RLP.WalkDecodeBridge
+import EvmAsm.Rv64.RLP.WalkInitWP
 import EvmAsm.EL.Withdrawal
 
 namespace EvmAsm.Rv64.RLP
@@ -247,6 +248,71 @@ theorem successStatusReturn_spec_within
       (successStatusReturnPre raVal statusOld)
       (successStatusReturnPost raVal) :=
   statusReturn_spec_within base raVal statusOld (0 : Word)
+
+/-! ## Walk-init branch endpoint composition -/
+
+/-- Code for the first `rlp_walk_init` branch plus the reason-erased failure
+    endpoint placed at the branch's empty-input target. -/
+def walkInitEmptyFailStatusCode (base : Word) : CodeReq :=
+  (CodeReq.singleton base (.BEQ .x11 .x0 (156 : BitVec 13))).union
+    (failStatusReturnCode (base + 156))
+
+/-- Precondition for the first walk-init branch while carrying just enough
+    status-return state to service the empty-input arm. -/
+def walkInitEmptyFailStatusPre (listLen raVal statusOld : Word) : Assertion :=
+  walkInitZeroNonzeroPre listLen ** failStatusReturnPre raVal statusOld
+
+/-- Empty-input arm after it has run the reason-erased failure status endpoint. -/
+def walkInitEmptyFailStatusPost (listLen raVal : Word) : Assertion :=
+  failStatusReturnPost raVal ** walkInitZeroPost listLen
+
+/-- Nonempty-input arm, left open for the real decoder continuation. -/
+def walkInitNonzeroOpenStatusPost (listLen raVal statusOld : Word) : Assertion :=
+  walkInitNonzeroPost listLen ** failStatusReturnPre raVal statusOld
+
+/-- WP branch certificate for the first `rlp_walk_init` split, with the
+    empty-input arm already continued through the shared failure-status endpoint
+    and the nonzero arm left as a branch exit. -/
+def walkInitEmptyFailStatusBranch (base listLen raVal statusOld : Word) :
+    WP.Branch base (walkInitEmptyFailStatusCode base) := by
+  let br0 : WP.Branch base (CodeReq.singleton base (.BEQ .x11 .x0 (156 : BitVec 13))) :=
+    WP.Branch.ofSpec (walkInitZeroNonzeroBranch_singleton_spec base listLen)
+  let br := WP.CFG.branchFrameR br0 (failStatusReturnPre raVal statusOld) (by
+    unfold failStatusReturnPre statusReturnPre
+    pcFree)
+  have htail0 := failStatusReturn_spec_within (base + 156) raVal statusOld
+  have htail := cpsTripleWithin_frameR (walkInitZeroPost listLen) (by
+    unfold walkInitZeroPost
+    pcFree) htail0
+  unfold walkInitEmptyFailStatusCode failStatusReturnCode
+  exact WP.CFG.branchSeqTakenBlockDisjoint
+    (CodeReq.Disjoint.union_right
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega)))
+    br
+    htail
+    (by
+      intro h hp
+      dsimp [br, WP.CFG.branchFrameR, WP.Branch.frameR] at hp
+      xperm_hyp hp)
+
+theorem walkInitEmptyFailStatusBranch_pre
+    (base listLen raVal statusOld : Word) :
+    (walkInitEmptyFailStatusBranch base listLen raVal statusOld).pre =
+      walkInitEmptyFailStatusPre listLen raVal statusOld := by
+  rfl
+
+theorem walkInitEmptyFailStatusBranch_taken_post
+    (base listLen raVal statusOld : Word) :
+    (walkInitEmptyFailStatusBranch base listLen raVal statusOld).post_t =
+      walkInitEmptyFailStatusPost listLen raVal := by
+  rfl
+
+theorem walkInitEmptyFailStatusBranch_notTaken_post
+    (base listLen raVal statusOld : Word) :
+    (walkInitEmptyFailStatusBranch base listLen raVal statusOld).post_f =
+      walkInitNonzeroOpenStatusPost listLen raVal statusOld := by
+  rfl
 
 /-! ## Pure decode bridge -/
 

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -567,6 +567,153 @@ theorem walkInitEmptyFailOrListCheckNBranch_pre
         (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion listBase listBytes) := by
   rfl
 
+/-- The reason-erased failure endpoint placed at the not-list target. -/
+def walkInitPrefixNotListFailStatusCode (base : Word) : CodeReq :=
+  failStatusReturnCode (base + 164)
+
+/-- Code for the prefix list-check branch with its not-list failure endpoint
+    already serviced. -/
+def walkInitPrefixListCheckOrNotListFailCode (base : Word) : CodeReq :=
+  (walkInitPrefixListCheckCode base).union (walkInitPrefixNotListFailStatusCode base)
+
+/-- Code through empty-input failure, prefix load, list-prefix classification,
+    and the not-list failure endpoint. The list-shaped arm remains open. -/
+def walkInitEmptyFailNotListFailOrListCode (base : Word) : CodeReq :=
+  (walkInitEmptyFailOrPrefixCode base).union
+    (walkInitPrefixListCheckOrNotListFailCode base)
+
+/-- Frame preserved by the not-list failure endpoint. -/
+def walkInitPrefixNotListFailStatusFrame
+    (listBase listLen : Word) (listBytes : List Byte)
+    (listOff : Nat) (hoff : listOff < listBytes.length) : Assertion :=
+  ((.x11 ↦ᵣ ((listBase + BitVec.ofNat 64 listOff) + listLen)) **
+    (.x5 ↦ᵣ walkInitPrefixWord listBytes listOff hoff) ** (.x6 ↦ᵣ (0xc0 : Word)) **
+    (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase listBytes **
+    ⌜listLen ≠ (0 : Word)⌝ **
+    ⌜BitVec.ult (walkInitPrefixWord listBytes listOff hoff) (0xc0 : Word)⌝)
+
+/-- Not-list arm after it has run the reason-erased failure status endpoint. -/
+def walkInitPrefixNotListFailStatusPost
+    (listBase listLen raVal : Word) (listBytes : List Byte)
+    (listOff : Nat) (hoff : listOff < listBytes.length) : Assertion :=
+  failStatusReturnPost raVal **
+    walkInitPrefixNotListFailStatusFrame listBase listLen listBytes listOff hoff
+
+theorem walkInitPrefixNotListFailStatusFrame_pcFree
+    (listBase listLen : Word) (listBytes : List Byte)
+    (listOff : Nat) (hoff : listOff < listBytes.length) :
+    (walkInitPrefixNotListFailStatusFrame listBase listLen listBytes listOff hoff).pcFree := by
+  unfold walkInitPrefixNotListFailStatusFrame
+  pcFree
+
+theorem walkInitPrefixNotListFailStatus_spec_within
+    (base listBase listLen raVal : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hoff : listOff < listBytes.length) :
+    cpsTripleWithin (failStatusReturnCert (base + 164) raVal
+        (listBase + BitVec.ofNat 64 listOff)).nSteps
+      (base + 164) (failStatusReturnExit raVal)
+      (walkInitPrefixNotListFailStatusCode base)
+      (walkInitPrefixNotListPost listBase listLen raVal listBytes listOff hoff)
+      (walkInitPrefixNotListFailStatusPost listBase listLen raVal listBytes listOff hoff) := by
+  unfold walkInitPrefixNotListFailStatusCode
+  have hfail := failStatusReturn_spec_within (base + 164) raVal
+    (listBase + BitVec.ofNat 64 listOff)
+  have hframed := cpsTripleWithin_frameR
+    (walkInitPrefixNotListFailStatusFrame listBase listLen listBytes listOff hoff)
+    (walkInitPrefixNotListFailStatusFrame_pcFree listBase listLen listBytes listOff hoff)
+    hfail
+  exact cpsTripleWithin_weaken (fun h hp => by
+      unfold walkInitPrefixNotListPost walkInitPrefixLoadedPost at hp
+      unfold failStatusReturnPre statusReturnPre walkInitPrefixNotListFailStatusFrame
+        walkInitPrefixWord
+      xperm_hyp hp)
+    (fun h hp => by
+      unfold walkInitPrefixNotListFailStatusPost
+      xperm_hyp hp) hframed
+
+theorem walkInitPrefixListCheckCode_disjoint_notListFailStatus (base : Word) :
+    (walkInitPrefixListCheckCode base).Disjoint
+      (walkInitPrefixNotListFailStatusCode base) := by
+  unfold walkInitPrefixListCheckCode walkInitPrefixNotListFailStatusCode
+    failStatusReturnCode statusReturnCode
+  refine CodeReq.Disjoint.union_right
+    (CodeReq.Disjoint.singleton (by bv_omega))
+    (CodeReq.Disjoint.singleton (by bv_omega))
+
+theorem walkInitEmptyFailOrPrefixCode_disjoint_notListFailStatus (base : Word) :
+    (walkInitEmptyFailOrPrefixCode base).Disjoint
+      (walkInitPrefixNotListFailStatusCode base) := by
+  unfold walkInitEmptyFailOrPrefixCode walkInitEmptyFailStatusCode failStatusReturnCode
+    statusReturnCode walkInitNonzeroPrefixTailCode walkInitPrefixNotListFailStatusCode
+  refine CodeReq.Disjoint.union_left ?_ ?_
+  · refine CodeReq.Disjoint.union_left ?_ ?_
+    · refine CodeReq.Disjoint.union_right
+        (CodeReq.Disjoint.singleton (by bv_omega))
+        (CodeReq.Disjoint.singleton (by bv_omega))
+    · refine CodeReq.Disjoint.union_left ?_ ?_
+      · refine CodeReq.Disjoint.union_right
+          (CodeReq.Disjoint.singleton (by bv_omega))
+          (CodeReq.Disjoint.singleton (by bv_omega))
+      · refine CodeReq.Disjoint.union_right
+          (CodeReq.Disjoint.singleton (by bv_omega))
+          (CodeReq.Disjoint.singleton (by bv_omega))
+  · refine CodeReq.Disjoint.union_left ?_ ?_
+    · refine CodeReq.Disjoint.union_right
+        (CodeReq.Disjoint.singleton (by bv_omega))
+        (CodeReq.Disjoint.singleton (by bv_omega))
+    · refine CodeReq.Disjoint.union_left ?_ ?_
+      · refine CodeReq.Disjoint.union_right
+          (CodeReq.Disjoint.singleton (by bv_omega))
+          (CodeReq.Disjoint.singleton (by bv_omega))
+      · refine CodeReq.Disjoint.union_right
+          (CodeReq.Disjoint.singleton (by bv_omega))
+          (CodeReq.Disjoint.singleton (by bv_omega))
+
+theorem walkInitEmptyFailOrPrefixCode_disjoint_listCheckOrNotListFail (base : Word) :
+    (walkInitEmptyFailOrPrefixCode base).Disjoint
+      (walkInitPrefixListCheckOrNotListFailCode base) := by
+  unfold walkInitPrefixListCheckOrNotListFailCode
+  exact CodeReq.Disjoint.union_right
+    (walkInitEmptyFailOrPrefixCode_disjoint_listCheck base)
+    (walkInitEmptyFailOrPrefixCode_disjoint_notListFailStatus base)
+
+/-- Multi-exit WP certificate after the first two failure cases have been
+    serviced. Exits are: empty failure returned, not-list failure returned, and
+    list-shaped fall-through. -/
+def walkInitEmptyFailNotListFailOrListNBranch
+    (base listBase listLen raVal t0Old t1Old : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true) :
+    WP.NBranch base (walkInitEmptyFailNotListFailOrListCode base) := by
+  let br := walkInitEmptyFailOrPrefixBranch base listBase listLen raVal t0Old t1Old
+    listBytes listOff hsalign hoff hover hvalid
+  let listBranch := walkInitPrefixListCheckBranch base listBase listLen raVal
+    listBytes listOff hoff
+  have hfail := walkInitPrefixNotListFailStatus_spec_within base listBase listLen raVal
+    listBytes listOff hoff
+  let tail : WP.NBranch (base + 16) (walkInitPrefixListCheckOrNotListFailCode base) := by
+    unfold walkInitPrefixListCheckOrNotListFailCode walkInitPrefixNotListFailStatusCode
+    wp_rv64_branch_taken_block_nbranch_disjoint
+      (walkInitPrefixListCheckCode_disjoint_notListFailStatus base), listBranch, hfail
+  unfold walkInitEmptyFailNotListFailOrListCode
+  wp_rv64_branch_not_taken_nbranch_disjoint
+    (walkInitEmptyFailOrPrefixCode_disjoint_listCheckOrNotListFail base), br, tail
+
+theorem walkInitEmptyFailNotListFailOrListNBranch_pre
+    (base listBase listLen raVal t0Old t1Old : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true) :
+    (walkInitEmptyFailNotListFailOrListNBranch base listBase listLen raVal t0Old t1Old
+      listBytes listOff hsalign hoff hover hvalid).pre =
+      (walkInitEmptyFailStatusPre listLen raVal (listBase + BitVec.ofNat 64 listOff) **
+        (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion listBase listBytes) := by
+  rfl
+
 /-! ## Pure decode bridge -/
 
 /-- The decoded withdrawal value described by four already-decoded field byte strings.

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -9,6 +9,9 @@
 
 import EvmAsm.Rv64.WP
 import EvmAsm.Rv64.MemRegion
+import EvmAsm.Rv64.MemRegionStore
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.RunBlock
 import EvmAsm.Rv64.RLP.WalkDecodeBridge
 import EvmAsm.EL.Withdrawal
 
@@ -51,6 +54,78 @@ def schema : List FieldLayout :=
   ]
 
 theorem schema_length : schema.length = 4 := rfl
+
+/-! ## Concrete program blocks -/
+
+/-- The 32-byte stack frame base after the withdrawal decoder prologue. -/
+def prologueFrameBase (sp0 : Word) : Word :=
+  sp0 + signExtend12 (-32 : BitVec 12)
+
+/-- Prologue block: allocate a 32-byte frame, save `ra`/`s0`/`s1`/`s2`,
+    and copy the output-struct pointer from `a2` to `s0`. -/
+def prologue : List Instr :=
+  [ .ADDI .x2 .x2 (-32 : BitVec 12)
+  , .SD .x2 .x1 (0 : BitVec 12)
+  , .SD .x2 .x8 (8 : BitVec 12)
+  , .SD .x2 .x9 (16 : BitVec 12)
+  , .SD .x2 .x18 (24 : BitVec 12)
+  , .MV .x8 .x12
+  ]
+
+theorem prologue_length : prologue.length = 6 := rfl
+
+/-- Code requirement for the withdrawal decoder prologue rooted at `base`. -/
+def prologueCode (base : Word) : CodeReq :=
+  CodeReq.ofProg base prologue
+
+/-- Machine precondition for the prologue. The four memory cells are the
+    caller-owned stack slots that become the saved frame. -/
+def prologuePre (sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word) : Assertion :=
+  ((.x2 ↦ᵣ sp0) ** (.x1 ↦ᵣ raVal) ** (.x8 ↦ᵣ s0Old) ** (.x9 ↦ᵣ s1Old) **
+    (.x18 ↦ᵣ s2Old) ** (.x12 ↦ᵣ outBase) **
+    (prologueFrameBase sp0 ↦ₘ m0) **
+    ((prologueFrameBase sp0 + 8) ↦ₘ m1) **
+    ((prologueFrameBase sp0 + 16) ↦ₘ m2) **
+    ((prologueFrameBase sp0 + 24) ↦ₘ m3))
+
+/-- Machine postcondition for the prologue. `s0` now owns the output pointer,
+    `sp` points at the new frame, and the caller-save values are spilled. -/
+def prologuePost (sp0 raVal s0Old s1Old s2Old outBase : Word) : Assertion :=
+  ((.x2 ↦ᵣ prologueFrameBase sp0) ** (.x1 ↦ᵣ raVal) **
+    (.x8 ↦ᵣ outBase) ** (.x9 ↦ᵣ s1Old) ** (.x18 ↦ᵣ s2Old) ** (.x12 ↦ᵣ outBase) **
+    (prologueFrameBase sp0 ↦ₘ raVal) **
+    ((prologueFrameBase sp0 + 8) ↦ₘ s0Old) **
+    ((prologueFrameBase sp0 + 16) ↦ₘ s1Old) **
+    ((prologueFrameBase sp0 + 24) ↦ₘ s2Old))
+
+/-- Verified prologue block, packaged in the same CPS contract as the rest of
+    the RV64 instruction specs. -/
+theorem prologue_spec_within
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word) :
+    cpsTripleWithin 6 base (base + 24) (prologueCode base)
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3)
+      (prologuePost sp0 raVal s0Old s1Old s2Old outBase) := by
+  unfold prologuePre prologuePost prologueFrameBase
+  have hadd := addi_spec_gen_same_within .x2 sp0 (-32 : BitVec 12) base (by decide)
+  have hsd0 := sd_spec_gen_within .x2 .x1 (sp0 + signExtend12 (-32 : BitVec 12)) raVal m0
+    (0 : BitVec 12) (base + 4)
+  have hsd1 := sd_spec_gen_within .x2 .x8 (sp0 + signExtend12 (-32 : BitVec 12)) s0Old m1
+    (8 : BitVec 12) (base + 8)
+  have hsd2 := sd_spec_gen_within .x2 .x9 (sp0 + signExtend12 (-32 : BitVec 12)) s1Old m2
+    (16 : BitVec 12) (base + 12)
+  have hsd3 := sd_spec_gen_within .x2 .x18 (sp0 + signExtend12 (-32 : BitVec 12)) s2Old m3
+    (24 : BitVec 12) (base + 16)
+  have hmv := mv_spec_gen_within .x8 .x12 outBase s0Old (base + 20) (by decide)
+  simp only [signExtend12_0] at hsd0
+  runBlock hadd hsd0 hsd1 hsd2 hsd3 hmv
+
+/-- WP certificate for the concrete prologue. Later proof-producing code can
+    compose this certificate directly instead of replaying the instruction proof. -/
+def prologueCert (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word) :
+    WP.CFG.Cert base (base + 24) (prologueCode base)
+      (prologuePost sp0 raVal s0Old s1Old s2Old outBase) :=
+  WP.CFG.block (WP.Entails.refl _)
+    (prologue_spec_within base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3)
 
 /-! ## Pure decode bridge -/
 

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -1587,25 +1587,35 @@ def emptyInputFailurePost (inputBase outBase raVal : Word) : Assertion :=
 def walkInitEmptyInputFailureNBranch
     (base inputBase outBase raVal statusOld : Word) :
     WP.NBranch base (walkInitEmptyFailStatusCode base) := by
-  let frame := emptyInputDecodeFrame inputBase outBase
+  let frame := emptyInputAbiFrame inputBase outBase
   let br := walkInitEmptyFailOrNonzeroFramedNBranch base (0 : Word) raVal statusOld
-    frame (emptyInputDecodeFrame_pcFree inputBase outBase)
+    frame (emptyInputAbiFrame_pcFree inputBase outBase)
   have hhead : WP.Entails
       (walkInitEmptyFailStatusPost (0 : Word) raVal ** frame)
       (emptyInputFailurePost inputBase outBase raVal) := by
     intro h hp
     unfold emptyInputFailurePost
     dsimp [frame] at hp
-    unfold emptyInputDecodeFrame emptyInputAbiFrame walkInitEmptyFailStatusPost
-      failStatusReturnPost statusReturnPost walkInitZeroPost at hp
-    exact hp
+    unfold emptyInputAbiFrame walkInitEmptyFailStatusPost failStatusReturnPost statusReturnPost
+      walkInitZeroPost at hp
+    rw [show (⌜decodeWithdrawal ([] : List Byte) = none⌝ : Assertion) = empAssertion by
+      funext h
+      unfold EvmAsm.Rv64.pure EvmAsm.Rv64.empAssertion
+      apply propext
+      constructor
+      · intro h_p
+        exact h_p.1
+      · intro h_empty
+        exact ⟨h_empty, decodeWithdrawal_nil⟩]
+    simp only [sepConj_emp_right']
+    simpa using hp
   exact WP.CFG.nbranchWeakenHeadPost br (by rfl) hhead
 
 theorem walkInitEmptyInputFailureNBranch_pre
     (base inputBase outBase raVal statusOld : Word) :
     (walkInitEmptyInputFailureNBranch base inputBase outBase raVal statusOld).pre =
       (walkInitEmptyFailStatusPre (0 : Word) raVal statusOld **
-        emptyInputDecodeFrame inputBase outBase) := by
+        emptyInputAbiFrame inputBase outBase) := by
   rfl
 
 /-- ABI resources preserved by the reason-erased failure endpoint.  The pure

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -1562,6 +1562,32 @@ theorem resultPost_failure {input : List Byte} {outBase : Word}
   unfold resultPost
   rw [hdec]
 
+/-- Disjunctive public view of the ABI result.  The success side carries a
+    decoded withdrawal witness and its output bytes; the failure side carries
+    only the reason-erased `decodeWithdrawal input = none` fact. -/
+def resultDisjPost (input : List Byte) (outBase : Word) : Assertion :=
+  fun h =>
+    (∃ w : Withdrawal,
+      ((.x10 ↦ᵣ (0 : Word)) ** bytesRegion outBase (successBytes w) **
+        ⌜decodeWithdrawal input = some w⌝) h) ∨
+    (((.x10 ↦ᵣ (1 : Word)) ** bytesRegionAny outBase outputSize **
+      ⌜decodeWithdrawal input = none⌝) h)
+
+/-- The stronger match-shaped result post implies the explicit disjunctive view. -/
+theorem resultPost_entails_resultDisjPost
+    (input : List Byte) (outBase : Word) :
+    WP.Entails (resultPost input outBase) (resultDisjPost input outBase) := by
+  intro h hp
+  unfold resultPost at hp
+  unfold resultDisjPost
+  cases hdec : decodeWithdrawal input with
+  | none =>
+      rw [hdec] at hp
+      exact Or.inr hp
+  | some w =>
+      rw [hdec] at hp
+      exact Or.inl ⟨w, hp⟩
+
 /-- ABI resources carried by the zero/nonzero split for the empty input case. -/
 def emptyInputAbiFrame (inputBase outBase : Word) : Assertion :=
   bytesRegion inputBase [] ** bytesRegionAny outBase outputSize
@@ -1586,6 +1612,26 @@ def abiPre (inputBase outBase raVal : Word) (input : List Byte) : Assertion :=
 def abiPost (inputBase outBase raVal : Word) (input : List Byte) : Assertion :=
   ((.x1 ↦ᵣ raVal) ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion inputBase input **
     resultPost input outBase)
+
+/-- ABI postcondition with an explicit success/failure disjunction over the Lean
+    decoder result.  This is the public characterization shape; `abiPost` above
+    is kept as the stronger match-shaped implementation post used by existing
+    proofs. -/
+def abiDisjPost (inputBase outBase raVal : Word) (input : List Byte) : Assertion :=
+  ((.x1 ↦ᵣ raVal) ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion inputBase input **
+    resultDisjPost input outBase)
+
+/-- The existing ABI postcondition implies the explicit disjunctive view. -/
+theorem abiPost_entails_abiDisjPost
+    (inputBase outBase raVal : Word) (input : List Byte) :
+    WP.Entails (abiPost inputBase outBase raVal input)
+      (abiDisjPost inputBase outBase raVal input) := by
+  intro h hp
+  unfold abiPost at hp
+  unfold abiDisjPost
+  exact sepConj_mono_right
+    (sepConj_mono_right
+      (sepConj_mono_right (resultPost_entails_resultDisjPost input outBase))) h hp
 
 /-- Empty-input resources plus the pure decoder failure fact. -/
 def emptyInputDecodeFrame (inputBase outBase : Word) : Assertion :=
@@ -1767,6 +1813,53 @@ theorem certSound {entry exit_ : Word} {cr : CodeReq}
     (cert : Cert entry exit_ cr inputBase outBase raVal input) :
     cpsTripleWithin cert.nSteps entry exit_ cr cert.pre
       (abiPost inputBase outBase raVal input) :=
+  cert.sound
+
+/-- ABI-facing certificate with the explicit disjunctive success/failure post. -/
+abbrev DisjCert (entry exit_ : Word) (cr : CodeReq)
+    (inputBase outBase raVal : Word) (input : List Byte) :=
+  WP.CFG.Cert entry exit_ cr (abiDisjPost inputBase outBase raVal input)
+
+/-- The computed precondition of a disjunctive withdrawal decoder certificate. -/
+def disjCertPre {entry exit_ : Word} {cr : CodeReq}
+    {inputBase outBase raVal : Word} {input : List Byte}
+    (cert : DisjCert entry exit_ cr inputBase outBase raVal input) : Assertion :=
+  cert.pre
+
+/-- Any existing ABI-facing certificate can be viewed through the explicit
+    disjunctive postcondition without changing its WP precondition. -/
+def toDisjCert {entry exit_ : Word} {cr : CodeReq}
+    {inputBase outBase raVal : Word} {input : List Byte}
+    (cert : Cert entry exit_ cr inputBase outBase raVal input) :
+    DisjCert entry exit_ cr inputBase outBase raVal input :=
+  WP.CFG.weakenPost cert (abiPost_entails_abiDisjPost inputBase outBase raVal input)
+
+/-- Viewing an existing certificate through the disjunctive post preserves the
+    computed weakest precondition. -/
+theorem toDisjCert_pre {entry exit_ : Word} {cr : CodeReq}
+    {inputBase outBase raVal : Word} {input : List Byte}
+    (cert : Cert entry exit_ cr inputBase outBase raVal input) :
+    (toDisjCert cert).pre = cert.pre :=
+  rfl
+
+/-- Top-level disjunctive characterization theorem: an implementation certified
+    against `abiPost` also proves the RISC-V code returns the same success/failure
+    case as the Lean `decodeWithdrawal` function. -/
+theorem certSound_disj {entry exit_ : Word} {cr : CodeReq}
+    {inputBase outBase raVal : Word} {input : List Byte}
+    (cert : Cert entry exit_ cr inputBase outBase raVal input) :
+    cpsTripleWithin cert.nSteps entry exit_ cr cert.pre
+      (abiDisjPost inputBase outBase raVal input) :=
+  cpsTripleWithin_weaken (fun _ hp => hp)
+    (abiPost_entails_abiDisjPost inputBase outBase raVal input) cert.sound
+
+/-- Soundness theorem for certificates that are built directly against the
+    explicit disjunctive post. -/
+theorem disjCertSound {entry exit_ : Word} {cr : CodeReq}
+    {inputBase outBase raVal : Word} {input : List Byte}
+    (cert : DisjCert entry exit_ cr inputBase outBase raVal input) :
+    cpsTripleWithin cert.nSteps entry exit_ cr cert.pre
+      (abiDisjPost inputBase outBase raVal input) :=
   cert.sound
 
 /-- Package an implementation triple as a withdrawal decoder certificate. -/

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -452,6 +452,121 @@ theorem walkInitEmptyFailOrPrefixBranch_notTaken_post
       walkInitPrefixLoadedPost listBase listLen raVal listBytes listOff hoff := by
   rfl
 
+/-- Loaded RLP list prefix byte as a 64-bit word. -/
+def walkInitPrefixWord (listBytes : List Byte) (listOff : Nat)
+    (hoff : listOff < listBytes.length) : Word :=
+  (listBytes[listOff]'hoff).zeroExtend 64
+
+/-- The next classifier instruction after the loaded prefix: `BLTU x5 x6 148`,
+    sending non-list prefixes to the failure target and list-shaped prefixes to
+    the fall-through decoder. -/
+def walkInitPrefixListCheckCode (base : Word) : CodeReq :=
+  CodeReq.singleton (base + 16) (.BLTU .x5 .x6 (148 : BitVec 13))
+
+/-- Code through the empty-input failure endpoint and the first list-prefix
+    classifier. -/
+def walkInitEmptyFailOrListCheckCode (base : Word) : CodeReq :=
+  (walkInitEmptyFailOrPrefixCode base).union (walkInitPrefixListCheckCode base)
+
+/-- Prefix-classifier taken arm: the loaded prefix is not an RLP list prefix. -/
+def walkInitPrefixNotListPost
+    (listBase listLen raVal : Word) (listBytes : List Byte)
+    (listOff : Nat) (hoff : listOff < listBytes.length) : Assertion :=
+  walkInitPrefixLoadedPost listBase listLen raVal listBytes listOff hoff **
+    ⌜BitVec.ult (walkInitPrefixWord listBytes listOff hoff) (0xc0 : Word)⌝
+
+/-- Prefix-classifier fall-through arm: the loaded prefix is list-shaped and is
+    ready for the short-list/long-list split. -/
+def walkInitPrefixListPost
+    (listBase listLen raVal : Word) (listBytes : List Byte)
+    (listOff : Nat) (hoff : listOff < listBytes.length) : Assertion :=
+  walkInitPrefixLoadedPost listBase listLen raVal listBytes listOff hoff **
+    ⌜¬ BitVec.ult (walkInitPrefixWord listBytes listOff hoff) (0xc0 : Word)⌝
+
+theorem walkInitPrefixListCheck_spec_within
+    (base listBase listLen raVal : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hoff : listOff < listBytes.length) :
+    cpsBranchWithin 1 (base + 16) (walkInitPrefixListCheckCode base)
+      (walkInitPrefixLoadedPost listBase listLen raVal listBytes listOff hoff)
+      (base + 164) (walkInitPrefixNotListPost listBase listLen raVal listBytes listOff hoff)
+      (base + 20) (walkInitPrefixListPost listBase listLen raVal listBytes listOff hoff) := by
+  unfold walkInitPrefixListCheckCode walkInitPrefixLoadedPost walkInitPrefixNotListPost
+    walkInitPrefixListPost walkInitPrefixWord
+  let pfx : Word := (listBytes[listOff]'hoff).zeroExtend 64
+  have hbr := bltu_spec_gen_within .x5 .x6 (148 : BitVec 13) pfx (0xc0 : Word) (base + 16)
+  rw [show (base + 16) + signExtend13 (148 : BitVec 13) = base + 164 from by
+        rw [show signExtend13 (148 : BitVec 13) = (148 : Word) from by decide]
+        bv_omega,
+      show (base + 16 : Word) + 4 = base + 20 from by bv_omega] at hbr
+  have hframed := cpsBranchWithin_frameR
+    (((.x11 ↦ᵣ ((listBase + BitVec.ofNat 64 listOff) + listLen)) **
+      (.x10 ↦ᵣ (listBase + BitVec.ofNat 64 listOff)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x1 ↦ᵣ raVal) ** bytesRegion listBase listBytes ** ⌜listLen ≠ (0 : Word)⌝))
+    (by pcFree) hbr
+  exact cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      unfold walkInitPrefixLoadedPost
+      xperm_hyp hp)
+    (fun h hp => by
+      unfold walkInitPrefixLoadedPost
+      xperm_hyp hp) hframed
+
+/-- WP branch certificate for the list-prefix classifier. -/
+def walkInitPrefixListCheckBranch
+    (base listBase listLen raVal : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hoff : listOff < listBytes.length) :
+    WP.Branch (base + 16) (walkInitPrefixListCheckCode base) :=
+  WP.Branch.ofSpec
+    (walkInitPrefixListCheck_spec_within base listBase listLen raVal listBytes listOff hoff)
+
+theorem walkInitEmptyFailOrPrefixCode_disjoint_listCheck (base : Word) :
+    (walkInitEmptyFailOrPrefixCode base).Disjoint (walkInitPrefixListCheckCode base) := by
+  unfold walkInitEmptyFailOrPrefixCode walkInitEmptyFailStatusCode failStatusReturnCode
+    statusReturnCode walkInitNonzeroPrefixTailCode walkInitPrefixListCheckCode
+  refine CodeReq.Disjoint.union_left ?_ ?_
+  · refine CodeReq.Disjoint.union_left ?_ ?_
+    · exact CodeReq.Disjoint.singleton (by bv_omega)
+    · refine CodeReq.Disjoint.union_left ?_ ?_
+      · exact CodeReq.Disjoint.singleton (by bv_omega)
+      · exact CodeReq.Disjoint.singleton (by bv_omega)
+  · refine CodeReq.Disjoint.union_left ?_ ?_
+    · exact CodeReq.Disjoint.singleton (by bv_omega)
+    · refine CodeReq.Disjoint.union_left ?_ ?_
+      · exact CodeReq.Disjoint.singleton (by bv_omega)
+      · exact CodeReq.Disjoint.singleton (by bv_omega)
+
+/-- Multi-exit WP certificate after the empty-input split, prefix load, and first
+    prefix classifier. Exits are: empty failure already returned, non-list
+    failure target, and list-shaped fall-through. -/
+def walkInitEmptyFailOrListCheckNBranch
+    (base listBase listLen raVal t0Old t1Old : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true) :
+    WP.NBranch base (walkInitEmptyFailOrListCheckCode base) := by
+  let br := walkInitEmptyFailOrPrefixBranch base listBase listLen raVal t0Old t1Old
+    listBytes listOff hsalign hoff hover hvalid
+  let tail := WP.CFG.nbranchOfBranch
+    (walkInitPrefixListCheckBranch base listBase listLen raVal listBytes listOff hoff)
+  unfold walkInitEmptyFailOrListCheckCode
+  wp_rv64_branch_not_taken_nbranch_disjoint
+    (walkInitEmptyFailOrPrefixCode_disjoint_listCheck base), br, tail
+
+theorem walkInitEmptyFailOrListCheckNBranch_pre
+    (base listBase listLen raVal t0Old t1Old : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true) :
+    (walkInitEmptyFailOrListCheckNBranch base listBase listLen raVal t0Old t1Old
+      listBytes listOff hsalign hoff hover hvalid).pre =
+      (walkInitEmptyFailStatusPre listLen raVal (listBase + BitVec.ofNat 64 listOff) **
+        (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion listBase listBytes) := by
+  rfl
+
 /-! ## Pure decode bridge -/
 
 /-- The decoded withdrawal value described by four already-decoded field byte strings.

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -1191,6 +1191,25 @@ theorem decodeWithdrawal_shortList_four_of_decodeAux_chain
     (.bytes d0) (.bytes d1) (.bytes d2) (.bytes d3) h_class h_len h0 h1 h2 h3 hend h_min
   exact decodeWithdrawal_eq_some_of_decodeFully_fields hfull hc0 hl0 hc1 hl1 haddr hc3 hl3
 
+/-- Implicit-argument facade for tactic use of the chain-shaped success bridge. -/
+theorem decodeWithdrawal_shortList_four_of_decodeAux_chain_auto
+    {pfx : Byte} {payload r1 r2 r3 r4 d0 d1 d2 d3 : List Byte}
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (h0 : ∀ m, decodeAux (m + 1) payload = some (.bytes d0, r1))
+    (h1 : ∀ m, decodeAux (m + 1) r1 = some (.bytes d1, r2))
+    (h2 : ∀ m, decodeAux (m + 1) r2 = some (.bytes d2, r3))
+    (h3 : ∀ m, decodeAux (m + 1) r3 = some (.bytes d3, r4))
+    (hend : r4 = [])
+    (h_min : 2 ≤ payload.length)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8) :
+    decodeWithdrawal (pfx :: payload) = some (fromFieldBytes d0 d1 d2 d3) :=
+  decodeWithdrawal_shortList_four_of_decodeAux_chain pfx payload r1 r2 r3 r4 d0 d1 d2 d3
+    h_class h_len h0 h1 h2 h3 hend h_min hc0 hl0 hc1 hl1 haddr hc3 hl3
+
 /-- The pure withdrawal decoder rejects empty input. -/
 theorem decodeWithdrawal_nil : decodeWithdrawal ([] : List Byte) = none := by
   rfl

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -389,6 +389,29 @@ theorem walkInitEmptyFailStatusCode_disjoint_prefixTail (base : Word) :
         (CodeReq.Disjoint.singleton (by bv_omega))
         (CodeReq.Disjoint.singleton (by bv_omega))
 
+theorem walkInitEmptyFailStatusCode_disjoint_singleton
+    (base a : Word) (i : Instr)
+    (h0 : base ≠ a) (h156 : base + 156 ≠ a) (h160 : base + 160 ≠ a) :
+    (walkInitEmptyFailStatusCode base).Disjoint (CodeReq.singleton a i) := by
+  unfold walkInitEmptyFailStatusCode failStatusReturnCode statusReturnCode
+  refine CodeReq.Disjoint.union_left ?_ ?_
+  · exact CodeReq.Disjoint.singleton h0
+  · refine CodeReq.Disjoint.union_left ?_ ?_
+    · exact CodeReq.Disjoint.singleton h156
+    · rw [show base + 156 + 4 = base + 160 from by bv_omega]
+      exact CodeReq.Disjoint.singleton h160
+
+theorem walkInitNonzeroPrefixTailCode_disjoint_singleton
+    (base a : Word) (i : Instr)
+    (h4 : base + 4 ≠ a) (h8 : base + 8 ≠ a) (h12 : base + 12 ≠ a) :
+    (walkInitNonzeroPrefixTailCode base).Disjoint (CodeReq.singleton a i) := by
+  unfold walkInitNonzeroPrefixTailCode
+  refine CodeReq.Disjoint.union_left ?_ ?_
+  · exact CodeReq.Disjoint.singleton h4
+  · refine CodeReq.Disjoint.union_left ?_ ?_
+    · exact CodeReq.Disjoint.singleton h8
+    · exact CodeReq.Disjoint.singleton h12
+
 /-- WP branch certificate after the first walk-init split and the nonzero prefix
     tail.  The taken arm is the already-serviced empty-input failure endpoint;
     the not-taken arm has loaded the prefix and remains open for the classifier. -/
@@ -744,6 +767,12 @@ def walkInitPrefixShortLongTailCode (base : Word) : CodeReq :=
 def walkInitEmptyFailNotListFailShortLongCode (base : Word) : CodeReq :=
   (walkInitEmptyFailOrPrefixCode base).union (walkInitPrefixShortLongTailCode base)
 
+def walkInitNonzeroNotListFailShortLongCode (base : Word) : CodeReq :=
+  (walkInitNonzeroPrefixTailCode base).union (walkInitPrefixShortLongTailCode base)
+
+def walkInitEmptyFailThenNonzeroShortLongCode (base : Word) : CodeReq :=
+  (walkInitEmptyFailStatusCode base).union (walkInitNonzeroNotListFailShortLongCode base)
+
 /-- State after the list-shaped fall-through has prepared the `0xf8` short/long
     list threshold. -/
 def walkInitPrefixF8Post
@@ -876,6 +905,136 @@ theorem walkInitEmptyFailOrPrefixCode_disjoint_shortLongTail (base : Word) :
       (walkInitEmptyFailOrPrefixCode_disjoint_listCheckOrNotListFail base)
       (walkInitEmptyFailOrPrefixCode_disjoint_listF8 base))
     (walkInitEmptyFailOrPrefixCode_disjoint_shortLong base)
+
+theorem walkInitNonzeroPrefixTailCode_disjoint_prefixShortLongTail (base : Word) :
+    (walkInitNonzeroPrefixTailCode base).Disjoint (walkInitPrefixShortLongTailCode base) := by
+  unfold walkInitPrefixShortLongTailCode walkInitPrefixListCheckNotListFailF8Code
+    walkInitPrefixListCheckOrNotListFailCode walkInitPrefixListCheckCode
+    walkInitPrefixNotListFailStatusCode failStatusReturnCode statusReturnCode
+    walkInitListF8Code walkInitShortLongCheckCode
+  have d16 := walkInitNonzeroPrefixTailCode_disjoint_singleton base (base + 16) (.BLTU .x5 .x6 (148 : BitVec 13))
+    (by bv_omega) (by bv_omega) (by bv_omega)
+  have d164 := walkInitNonzeroPrefixTailCode_disjoint_singleton base (base + 164) (.LI .x10 (1 : Word))
+    (by bv_omega) (by bv_omega) (by bv_omega)
+  have d168 := walkInitNonzeroPrefixTailCode_disjoint_singleton base (base + 164 + 4) (.JALR .x0 .x1 (0 : BitVec 12))
+    (by bv_omega) (by bv_omega) (by bv_omega)
+  have d20 := walkInitNonzeroPrefixTailCode_disjoint_singleton base (base + 20) (.LI .x6 (0xf8 : Word))
+    (by bv_omega) (by bv_omega) (by bv_omega)
+  have d24 := walkInitNonzeroPrefixTailCode_disjoint_singleton base (base + 24) (.BLTU .x5 .x6 (100 : BitVec 13))
+    (by bv_omega) (by bv_omega) (by bv_omega)
+  exact CodeReq.Disjoint.union_right
+    (CodeReq.Disjoint.union_right
+      (CodeReq.Disjoint.union_right d16 (CodeReq.Disjoint.union_right d164 d168)) d20) d24
+
+theorem walkInitEmptyFailStatusCode_disjoint_prefixShortLongTail (base : Word) :
+    (walkInitEmptyFailStatusCode base).Disjoint (walkInitPrefixShortLongTailCode base) := by
+  unfold walkInitPrefixShortLongTailCode walkInitPrefixListCheckNotListFailF8Code
+    walkInitPrefixListCheckOrNotListFailCode walkInitPrefixListCheckCode
+    walkInitPrefixNotListFailStatusCode failStatusReturnCode statusReturnCode
+    walkInitListF8Code walkInitShortLongCheckCode
+  have d16 := walkInitEmptyFailStatusCode_disjoint_singleton base (base + 16) (.BLTU .x5 .x6 (148 : BitVec 13))
+    (by bv_omega) (by bv_omega) (by bv_omega)
+  have d164 := walkInitEmptyFailStatusCode_disjoint_singleton base (base + 164) (.LI .x10 (1 : Word))
+    (by bv_omega) (by bv_omega) (by bv_omega)
+  have d168 := walkInitEmptyFailStatusCode_disjoint_singleton base (base + 164 + 4) (.JALR .x0 .x1 (0 : BitVec 12))
+    (by bv_omega) (by bv_omega) (by bv_omega)
+  have d20 := walkInitEmptyFailStatusCode_disjoint_singleton base (base + 20) (.LI .x6 (0xf8 : Word))
+    (by bv_omega) (by bv_omega) (by bv_omega)
+  have d24 := walkInitEmptyFailStatusCode_disjoint_singleton base (base + 24) (.BLTU .x5 .x6 (100 : BitVec 13))
+    (by bv_omega) (by bv_omega) (by bv_omega)
+  exact CodeReq.Disjoint.union_right
+    (CodeReq.Disjoint.union_right
+      (CodeReq.Disjoint.union_right d16 (CodeReq.Disjoint.union_right d164 d168)) d20) d24
+
+theorem walkInitEmptyFailStatusCode_disjoint_nonzeroNotListFailShortLong (base : Word) :
+    (walkInitEmptyFailStatusCode base).Disjoint
+      (walkInitNonzeroNotListFailShortLongCode base) := by
+  unfold walkInitNonzeroNotListFailShortLongCode
+  exact CodeReq.Disjoint.union_right
+    (walkInitEmptyFailStatusCode_disjoint_prefixTail base)
+    (walkInitEmptyFailStatusCode_disjoint_prefixShortLongTail base)
+
+/-- Tail classifier from the already-loaded prefix at base + 16 through the
+    not-list failure endpoint and the short-list/long-list split. -/
+def walkInitPrefixShortLongTailNBranch
+    (base listBase listLen raVal : Word) (listBytes : List Byte)
+    (listOff : Nat) (hoff : listOff < listBytes.length) :
+    WP.NBranch (base + 16) (walkInitPrefixShortLongTailCode base) := by
+  let listBranch := walkInitPrefixListCheckOrNotListFailBranch base listBase listLen raVal
+    listBytes listOff hoff
+  have hf8 := walkInitPrefixSetF8_spec_within base listBase listLen raVal
+    listBytes listOff hoff
+  let f8Branch : WP.Branch (base + 16) (walkInitPrefixListCheckNotListFailF8Code base) := by
+    unfold walkInitPrefixListCheckNotListFailF8Code
+    wp_rv64_branch_not_taken_block_disjoint
+      (walkInitPrefixListCheckOrNotListFailCode_disjoint_listF8 base), listBranch, hf8
+  let shortLong := WP.CFG.nbranchOfBranch
+    (walkInitShortLongCheckBranch base listBase listLen raVal listBytes listOff hoff)
+  unfold walkInitPrefixShortLongTailCode
+  wp_rv64_branch_not_taken_nbranch_disjoint
+    (walkInitPrefixListCheckNotListFailF8Code_disjoint_shortLong base), f8Branch, shortLong
+
+/-- Nonzero walk-init tail: load the first prefix byte, service the not-list
+    failure endpoint, and expose short-list/long-list candidates. -/
+def walkInitNonzeroNotListFailShortLongNBranch
+    (base listBase listLen raVal t0Old t1Old : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true) :
+    WP.NBranch (base + 4) (walkInitNonzeroNotListFailShortLongCode base) := by
+  have hprefix := walkInitNonzeroPrefixTail_spec_within base listBase listLen raVal
+    t0Old t1Old listBytes listOff hsalign hoff hover hvalid
+  let tail := walkInitPrefixShortLongTailNBranch base listBase listLen raVal
+    listBytes listOff hoff
+  unfold walkInitNonzeroNotListFailShortLongCode
+  wp_rv64_seq_block_nbranch_disjoint
+    (walkInitNonzeroPrefixTailCode_disjoint_prefixShortLongTail base), hprefix, tail
+
+theorem walkInitNonzeroNotListFailShortLongNBranch_pre
+    (base listBase listLen raVal t0Old t1Old : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true) :
+    (walkInitNonzeroNotListFailShortLongNBranch base listBase listLen raVal t0Old t1Old
+      listBytes listOff hsalign hoff hover hvalid).pre =
+      ((walkInitNonzeroOpenStatusPost listLen raVal (listBase + BitVec.ofNat 64 listOff)) **
+        (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion listBase listBytes) := by
+  rfl
+
+/-- Same classifier as walkInitEmptyFailNotListFailShortLongNBranch, but built
+    by preserving the empty-input head exit and continuing the nonzero second exit. -/
+def walkInitEmptyFailThenNonzeroShortLongNBranch
+    (base listBase listLen raVal t0Old t1Old : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true) :
+    WP.NBranch base (walkInitEmptyFailThenNonzeroShortLongCode base) := by
+  let listPtr := listBase + BitVec.ofNat 64 listOff
+  let frame : Assertion := (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion listBase listBytes
+  let br0 := WP.CFG.nbranchOfBranch (walkInitEmptyFailStatusBranch base listLen raVal listPtr)
+  let br := WP.CFG.nbranchFrameR br0 frame (by
+    dsimp [frame]
+    pcFree)
+  let tail := walkInitNonzeroNotListFailShortLongNBranch base listBase listLen raVal
+    t0Old t1Old listBytes listOff hsalign hoff hover hvalid
+  unfold walkInitEmptyFailThenNonzeroShortLongCode
+  wp_rv64_nbranch_second_nbranch_disjoint
+    (walkInitEmptyFailStatusCode_disjoint_nonzeroNotListFailShortLong base), br, tail
+
+theorem walkInitEmptyFailThenNonzeroShortLongNBranch_pre
+    (base listBase listLen raVal t0Old t1Old : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true) :
+    (walkInitEmptyFailThenNonzeroShortLongNBranch base listBase listLen raVal t0Old t1Old
+      listBytes listOff hsalign hoff hover hvalid).pre =
+      (walkInitEmptyFailStatusPre listLen raVal (listBase + BitVec.ofNat 64 listOff) **
+        (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion listBase listBytes) := by
+  rfl
 
 /-- Multi-exit WP certificate after the first list-prefix classifier has reached
     the short-list versus long-list split. Exits are empty failure, not-list

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -14,6 +14,7 @@ import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.Tactics.RunBlock
 import EvmAsm.Rv64.Tactics.WP
+import EvmAsm.Rv64.Tactics.ExtractPure
 import EvmAsm.Rv64.RLP.WalkDecodeBridge
 import EvmAsm.EL.Withdrawal
 
@@ -169,10 +170,10 @@ def failStatusReturnCert (base raVal statusOld : Word) :
   have hli := cpsTripleWithin_frameL (.x1 ↦ᵣ raVal) (by pcFree) hli0
   have hret0 := jalr_x0_spec_gen_within .x1 raVal (0 : BitVec 12) (base + 4)
   have hret := cpsTripleWithin_frameR (.x10 ↦ᵣ (1 : Word)) (by pcFree) hret0
-  exact WP.CFG.seqDisjoint
+  exact WP.CFG.seqBlockDisjoint
     (CodeReq.Disjoint.singleton (by bv_omega))
     hli
-    (WP.CFG.block (WP.Entails.refl _) hret)
+    hret
     (by wp_rv64_link)
 
 /-- Verified reason-erased failure return block. -/
@@ -347,6 +348,60 @@ def abiPre (inputBase outBase raVal : Word) (input : List Byte) : Assertion :=
 def abiPost (inputBase outBase raVal : Word) (input : List Byte) : Assertion :=
   ((.x1 ↦ᵣ raVal) ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion inputBase input **
     resultPost input outBase)
+
+/-- ABI resources preserved by the reason-erased failure endpoint.  The pure
+    failure fact is supplied by the path that selected this endpoint, not by the
+    static schema. -/
+def failStatusReturnAbiFrame (inputBase outBase : Word) (input : List Byte) : Assertion :=
+  ((.x0 ↦ᵣ (0 : Word)) ** bytesRegion inputBase input **
+    bytesRegionAny outBase outputSize ** ⌜decodeWithdrawal input = none⌝)
+
+theorem failStatusReturnAbiFrame_pcFree
+    (inputBase outBase : Word) (input : List Byte) :
+    (failStatusReturnAbiFrame inputBase outBase input).pcFree := by
+  unfold failStatusReturnAbiFrame
+  exact pcFree_sepConj pcFree_regIs
+    (pcFree_sepConj (bytesRegion_pcFree _ _)
+      (pcFree_sepConj (bytesRegionAny_pcFree _ _) pcFree_pure))
+
+/-- ABI-facing precondition for a failure endpoint reached after a path has
+    established that the pure withdrawal decoder fails. -/
+def failStatusReturnAbiPre
+    (inputBase outBase raVal statusOld : Word) (input : List Byte) : Assertion :=
+  failStatusReturnPre raVal statusOld ** failStatusReturnAbiFrame inputBase outBase input
+
+/-- WP certificate adapting the reason-erased failure endpoint to the public ABI
+    postcondition.  The exact failure reason is intentionally absent; only the
+    pure `decodeWithdrawal input = none` case fact is used to expose the unified
+    postcondition's failure disjunct. -/
+def failStatusReturnAbiCert
+    (base inputBase outBase raVal statusOld : Word) (input : List Byte) :
+    WP.CFG.Cert base (failStatusReturnExit raVal) (failStatusReturnCode base)
+      (abiPost inputBase outBase raVal input) := by
+  have hfail := failStatusReturn_spec_within base raVal statusOld
+  have hframed := cpsTripleWithin_frameR
+    (failStatusReturnAbiFrame inputBase outBase input)
+    (failStatusReturnAbiFrame_pcFree inputBase outBase input) hfail
+  exact WP.CFG.block (by
+    intro h hp
+    have hpCase := hp
+    unfold failStatusReturnPost failStatusReturnAbiFrame at hp hpCase
+    extract_pure hpCase
+    obtain ⟨hdec, _hpRest⟩ := hpCase
+    unfold abiPost
+    rw [resultPost_failure hdec]
+    xperm_hyp hp) hframed
+
+/-- Verified ABI-facing failure endpoint. -/
+theorem failStatusReturn_abiPost_spec_within
+    (base inputBase outBase raVal statusOld : Word) (input : List Byte) :
+    cpsTripleWithin (failStatusReturnAbiCert base inputBase outBase raVal statusOld input).nSteps
+      base (failStatusReturnExit raVal) (failStatusReturnCode base)
+      (failStatusReturnAbiPre inputBase outBase raVal statusOld input)
+      (abiPost inputBase outBase raVal input) :=
+  by
+    unfold failStatusReturnAbiPre
+    exact (failStatusReturnAbiCert base inputBase outBase raVal statusOld input).sound
 
 /-- A WP-facing certificate that a concrete control-flow proof implements the
     withdrawal decoder ABI.  The computed precondition is `cfg.pre`, so generated

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -694,10 +694,11 @@ def walkInitEmptyFailNotListFailOrListNBranch
     listBytes listOff hoff
   have hfail := walkInitPrefixNotListFailStatus_spec_within base listBase listLen raVal
     listBytes listOff hoff
+  let listTail0 := WP.CFG.nbranchOfBranch listBranch
   let tail : WP.NBranch (base + 16) (walkInitPrefixListCheckOrNotListFailCode base) := by
     unfold walkInitPrefixListCheckOrNotListFailCode walkInitPrefixNotListFailStatusCode
-    wp_rv64_branch_taken_block_nbranch_disjoint
-      (walkInitPrefixListCheckCode_disjoint_notListFailStatus base), listBranch, hfail
+    wp_rv64_nbranch_head_block_disjoint
+      (walkInitPrefixListCheckCode_disjoint_notListFailStatus base), listTail0, hfail
   unfold walkInitEmptyFailNotListFailOrListCode
   wp_rv64_branch_not_taken_nbranch_disjoint
     (walkInitEmptyFailOrPrefixCode_disjoint_listCheckOrNotListFail base), br, tail

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -9,6 +9,7 @@
 
 import EvmAsm.Rv64.WP
 import EvmAsm.Rv64.MemRegion
+import EvmAsm.Rv64.RLP.WalkDecodeBridge
 import EvmAsm.EL.Withdrawal
 
 namespace EvmAsm.Rv64.RLP
@@ -50,6 +51,54 @@ def schema : List FieldLayout :=
   ]
 
 theorem schema_length : schema.length = 4 := rfl
+
+/-! ## Pure decode bridge -/
+
+/-- The decoded withdrawal value described by four already-decoded field byte strings.
+    This is a postcondition/result helper, not part of the static schema. -/
+def fromFieldBytes (d0 d1 d2 d3 : List Byte) : Withdrawal where
+  index := Nat.fromBytesBE d0
+  validatorIndex := Nat.fromBytesBE d1
+  address := BitVec.ofNat 160 (Nat.fromBytesBE d2)
+  amount := Nat.fromBytesBE d3
+
+/-- If the pure RLP decoder sees exactly the four withdrawal byte fields and the
+    field guards match `decodeWithdrawal`'s strict scalar/address contract, then
+    `decodeWithdrawal` succeeds with the value derived from those bytes. -/
+theorem decodeWithdrawal_eq_some_of_decodeFully_fields
+    {input d0 d1 d2 d3 : List Byte}
+    (hfull : decodeFully input = some (.list [.bytes d0, .bytes d1, .bytes d2, .bytes d3]))
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8) :
+    decodeWithdrawal input = some (fromFieldBytes d0 d1 d2 d3) := by
+  unfold decodeWithdrawal fromFieldBytes
+  rw [hfull]
+  simp only [hc0, hl0, hc1, hl1, haddr, hc3, hl3, ne_eq, not_false_eq_true,
+    and_self, if_true]
+
+/-- Short-list walk capstone specialized to withdrawal fields. The hypotheses are
+    exactly the reusable walk/decode bridge facts for four byte-string items plus
+    the strict field guards. -/
+theorem decodeWithdrawal_shortList_four_of_decodeAux (pfx : Byte) (payload : List Byte)
+    (off1 off2 off3 off4 : Nat) (d0 d1 d2 d3 : List Byte)
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (h0 : ∀ m, decodeAux (m + 1) payload = some (.bytes d0, payload.drop off1))
+    (h1 : ∀ m, decodeAux (m + 1) (payload.drop off1) = some (.bytes d1, payload.drop off2))
+    (h2 : ∀ m, decodeAux (m + 1) (payload.drop off2) = some (.bytes d2, payload.drop off3))
+    (h3 : ∀ m, decodeAux (m + 1) (payload.drop off3) = some (.bytes d3, payload.drop off4))
+    (hend : payload.drop off4 = [])
+    (h_min : 2 ≤ payload.length)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8) :
+    decodeWithdrawal (pfx :: payload) = some (fromFieldBytes d0 d1 d2 d3) := by
+  have hfull := decodeFully_shortList_four pfx payload off1 off2 off3 off4
+    (.bytes d0) (.bytes d1) (.bytes d2) (.bytes d3) h_class h_len h0 h1 h2 h3 hend h_min
+  exact decodeWithdrawal_eq_some_of_decodeFully_fields hfull hc0 hl0 hc1 hl1 haddr hc3 hl3
 
 /-! ## Result bytes, derived from the pure decoder result -/
 

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -1170,6 +1170,27 @@ theorem decodeWithdrawal_shortList_four_of_decodeAux (pfx : Byte) (payload : Lis
     (.bytes d0) (.bytes d1) (.bytes d2) (.bytes d3) h_class h_len h0 h1 h2 h3 hend h_min
   exact decodeWithdrawal_eq_some_of_decodeFully_fields hfull hc0 hl0 hc1 hl1 haddr hc3 hl3
 
+/-- Short-list walk capstone specialized to withdrawal fields, phrased over the
+    remainder chain exposed by validating WP field posts. -/
+theorem decodeWithdrawal_shortList_four_of_decodeAux_chain
+    (pfx : Byte) (payload r1 r2 r3 r4 : List Byte) (d0 d1 d2 d3 : List Byte)
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (h0 : ∀ m, decodeAux (m + 1) payload = some (.bytes d0, r1))
+    (h1 : ∀ m, decodeAux (m + 1) r1 = some (.bytes d1, r2))
+    (h2 : ∀ m, decodeAux (m + 1) r2 = some (.bytes d2, r3))
+    (h3 : ∀ m, decodeAux (m + 1) r3 = some (.bytes d3, r4))
+    (hend : r4 = [])
+    (h_min : 2 ≤ payload.length)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8) :
+    decodeWithdrawal (pfx :: payload) = some (fromFieldBytes d0 d1 d2 d3) := by
+  have hfull := decodeFully_shortList_four_chain pfx payload r1 r2 r3 r4
+    (.bytes d0) (.bytes d1) (.bytes d2) (.bytes d3) h_class h_len h0 h1 h2 h3 hend h_min
+  exact decodeWithdrawal_eq_some_of_decodeFully_fields hfull hc0 hl0 hc1 hl1 haddr hc3 hl3
+
 /-- The pure withdrawal decoder rejects empty input. -/
 theorem decodeWithdrawal_nil : decodeWithdrawal ([] : List Byte) = none := by
   rfl

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -1,0 +1,196 @@
+/-
+  EvmAsm.Rv64.RLP.WithdrawalDecode
+
+  WP-facing specification facade for an RV64 `withdrawal_decode` routine.
+  The static schema below intentionally contains only field positions and output
+  layout.  It does not contain decoded bytes or values; those are introduced only
+  by the postcondition, through the pure `EvmAsm.EL.decodeWithdrawal` function.
+-/
+
+import EvmAsm.Rv64.WP
+import EvmAsm.Rv64.MemRegion
+import EvmAsm.EL.Withdrawal
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL
+open EvmAsm.EL.RLP
+
+namespace WithdrawalDecode
+
+/-! ## Static ABI layout -/
+
+/-- Field kind for the fixed EIP-4895 withdrawal schema.  This is static
+    layout/control information, not a decoded value. -/
+inductive FieldKind where
+  | scalarU64
+  | address20
+  deriving DecidableEq, Repr
+
+/-- One static field of `rlp([index, validator_index, address, amount])`.
+    The schema records only where to read a field from and where to write it in
+    the ABI output struct. -/
+structure FieldLayout where
+  inputIndex : Nat
+  outputOffset : Nat
+  kind : FieldKind
+  deriving DecidableEq, Repr
+
+/-- Output struct size used by the codegen ABI: 48 bytes. -/
+def outputSize : Nat := 48
+
+/-- Static schema for the ABI output struct:
+    `index@0`, `validator_index@8`, `address@16`, `amount@40`. -/
+def schema : List FieldLayout :=
+  [ { inputIndex := 0, outputOffset := 0,  kind := .scalarU64 }
+  , { inputIndex := 1, outputOffset := 8,  kind := .scalarU64 }
+  , { inputIndex := 2, outputOffset := 16, kind := .address20 }
+  , { inputIndex := 3, outputOffset := 40, kind := .scalarU64 }
+  ]
+
+theorem schema_length : schema.length = 4 := rfl
+
+/-! ## Result bytes, derived from the pure decoder result -/
+
+/-- Eight little-endian bytes of a 64-bit word. -/
+def u64LEBytes (v : Word) : List Byte :=
+  [ v.truncate 8
+  , (v >>> 8).truncate 8
+  , (v >>> 16).truncate 8
+  , (v >>> 24).truncate 8
+  , (v >>> 32).truncate 8
+  , (v >>> 40).truncate 8
+  , (v >>> 48).truncate 8
+  , (v >>> 56).truncate 8
+  ]
+
+theorem u64LEBytes_length (v : Word) : (u64LEBytes v).length = 8 := rfl
+
+/-- Twenty big-endian bytes of a 160-bit address word. -/
+def addressBEBytes (v : BitVec 160) : List Byte :=
+  [ (v >>> 152).truncate 8
+  , (v >>> 144).truncate 8
+  , (v >>> 136).truncate 8
+  , (v >>> 128).truncate 8
+  , (v >>> 120).truncate 8
+  , (v >>> 112).truncate 8
+  , (v >>> 104).truncate 8
+  , (v >>> 96).truncate 8
+  , (v >>> 88).truncate 8
+  , (v >>> 80).truncate 8
+  , (v >>> 72).truncate 8
+  , (v >>> 64).truncate 8
+  , (v >>> 56).truncate 8
+  , (v >>> 48).truncate 8
+  , (v >>> 40).truncate 8
+  , (v >>> 32).truncate 8
+  , (v >>> 24).truncate 8
+  , (v >>> 16).truncate 8
+  , (v >>> 8).truncate 8
+  , v.truncate 8
+  ]
+
+theorem addressBEBytes_length (v : BitVec 160) : (addressBEBytes v).length = 20 := rfl
+
+/-- ABI struct bytes for a successful pure withdrawal decode. -/
+def successBytes (w : Withdrawal) : List Byte :=
+  u64LEBytes (BitVec.ofNat 64 w.index) ++
+  u64LEBytes (BitVec.ofNat 64 w.validatorIndex) ++
+  addressBEBytes w.address ++
+  List.replicate 4 (0 : Byte) ++
+  u64LEBytes (BitVec.ofNat 64 w.amount)
+
+theorem successBytes_length (w : Withdrawal) : (successBytes w).length = outputSize := by
+  simp [successBytes, outputSize, u64LEBytes, addressBEBytes]
+
+/-! ## ABI assertions -/
+
+/-- Own an arbitrary byte region of a fixed length.  Used on failure paths,
+    where the routine reports failure and the output buffer contents are not
+    part of the functional contract. -/
+def bytesRegionAny (base : Word) (n : Nat) : Assertion :=
+  fun h => ∃ bs : List Byte, bs.length = n ∧ bytesRegion base bs h
+
+theorem bytesRegionAny_pcFree (base : Word) (n : Nat) :
+    (bytesRegionAny base n).pcFree := by
+  intro h hp
+  obtain ⟨bs, _hlen, hbs⟩ := hp
+  exact bytesRegion_pcFree base bs h hbs
+
+instance (base : Word) (n : Nat) : Assertion.PCFree (bytesRegionAny base n) :=
+  ⟨bytesRegionAny_pcFree base n⟩
+
+/-- Result portion of the ABI postcondition.  Success is exactly
+    `decodeWithdrawal input = some w`; failure is exactly `decodeWithdrawal input = none`.
+    The static schema above is not consulted here except through the fixed output size. -/
+def resultPost (input : List Byte) (outBase : Word) : Assertion :=
+  match decodeWithdrawal input with
+  | some w =>
+      ((.x10 ↦ᵣ (0 : Word)) ** bytesRegion outBase (successBytes w) **
+        ⌜decodeWithdrawal input = some w⌝)
+  | none =>
+      ((.x10 ↦ᵣ (1 : Word)) ** bytesRegionAny outBase outputSize **
+        ⌜decodeWithdrawal input = none⌝)
+
+theorem resultPost_success {input : List Byte} {outBase : Word} {w : Withdrawal}
+    (hdec : decodeWithdrawal input = some w) :
+    resultPost input outBase =
+      ((.x10 ↦ᵣ (0 : Word)) ** bytesRegion outBase (successBytes w) **
+        ⌜decodeWithdrawal input = some w⌝) := by
+  unfold resultPost
+  rw [hdec]
+
+theorem resultPost_failure {input : List Byte} {outBase : Word}
+    (hdec : decodeWithdrawal input = none) :
+    resultPost input outBase =
+      ((.x10 ↦ᵣ (1 : Word)) ** bytesRegionAny outBase outputSize **
+        ⌜decodeWithdrawal input = none⌝) := by
+  unfold resultPost
+  rw [hdec]
+
+/-- A minimal ABI precondition for a withdrawal decoder entry.  A concrete
+    program proof may strengthen this with scratch registers, stack cells, or
+    helper-code frames through the WP precondition. -/
+def abiPre (inputBase outBase raVal : Word) (input : List Byte) : Assertion :=
+  ((.x10 ↦ᵣ inputBase) ** (.x11 ↦ᵣ BitVec.ofNat 64 input.length) **
+   (.x12 ↦ᵣ outBase) ** (.x1 ↦ᵣ raVal) ** (.x0 ↦ᵣ (0 : Word)) **
+   bytesRegion inputBase input ** bytesRegionAny outBase outputSize)
+
+/-- ABI postcondition common to any implementation of `withdrawal_decode`.
+    It preserves `ra`, preserves the input bytes, and reports the pure decoder
+    result through `resultPost`. Scratch and argument registers not mentioned
+    here may be described by a stronger implementation-specific postcondition. -/
+def abiPost (inputBase outBase raVal : Word) (input : List Byte) : Assertion :=
+  ((.x1 ↦ᵣ raVal) ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion inputBase input **
+    resultPost input outBase)
+
+/-- A WP-facing certificate that a concrete control-flow proof implements the
+    withdrawal decoder ABI.  The computed precondition is `cfg.pre`, so generated
+    proofs can add whatever scratch resources their chosen program needs. -/
+abbrev Cert (entry exit_ : Word) (cr : CodeReq)
+    (inputBase outBase raVal : Word) (input : List Byte) :=
+  WP.CFG.Cert entry exit_ cr (abiPost inputBase outBase raVal input)
+
+def certPre {entry exit_ : Word} {cr : CodeReq}
+    {inputBase outBase raVal : Word} {input : List Byte}
+    (cert : Cert entry exit_ cr inputBase outBase raVal input) : Assertion :=
+  cert.pre
+
+theorem certSound {entry exit_ : Word} {cr : CodeReq}
+    {inputBase outBase raVal : Word} {input : List Byte}
+    (cert : Cert entry exit_ cr inputBase outBase raVal input) :
+    cpsTripleWithin cert.nSteps entry exit_ cr cert.pre
+      (abiPost inputBase outBase raVal input) :=
+  cert.sound
+
+/-- Package an implementation triple as a withdrawal decoder certificate. -/
+def ofSpec {nSteps : Nat} {entry exit_ : Word} {cr : CodeReq}
+    {pre : Assertion} {inputBase outBase raVal : Word} {input : List Byte}
+    (h : cpsTripleWithin nSteps entry exit_ cr pre
+      (abiPost inputBase outBase raVal input)) :
+    Cert entry exit_ cr inputBase outBase raVal input :=
+  WP.CFG.block (WP.Entails.refl _) h
+
+end WithdrawalDecode
+end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -714,6 +714,210 @@ theorem walkInitEmptyFailNotListFailOrListNBranch_pre
         (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion listBase listBytes) := by
   rfl
 
+/-- Branch certificate for the prefix list-check with the not-list arm already
+    serviced by the reason-erased failure endpoint. -/
+def walkInitPrefixListCheckOrNotListFailBranch
+    (base listBase listLen raVal : Word) (listBytes : List Byte)
+    (listOff : Nat) (hoff : listOff < listBytes.length) :
+    WP.Branch (base + 16) (walkInitPrefixListCheckOrNotListFailCode base) := by
+  let br := walkInitPrefixListCheckBranch base listBase listLen raVal listBytes listOff hoff
+  have hfail := walkInitPrefixNotListFailStatus_spec_within base listBase listLen raVal
+    listBytes listOff hoff
+  unfold walkInitPrefixListCheckOrNotListFailCode walkInitPrefixNotListFailStatusCode
+  wp_rv64_branch_taken_block_disjoint
+    (walkInitPrefixListCheckCode_disjoint_notListFailStatus base), br, hfail
+
+/-- The list-shaped fall-through loads the next classifier threshold `0xf8`. -/
+def walkInitListF8Code (base : Word) : CodeReq :=
+  CodeReq.singleton (base + 20) (.LI .x6 (0xf8 : Word))
+
+def walkInitPrefixListCheckNotListFailF8Code (base : Word) : CodeReq :=
+  (walkInitPrefixListCheckOrNotListFailCode base).union (walkInitListF8Code base)
+
+def walkInitShortLongCheckCode (base : Word) : CodeReq :=
+  CodeReq.singleton (base + 24) (.BLTU .x5 .x6 (100 : BitVec 13))
+
+def walkInitPrefixShortLongTailCode (base : Word) : CodeReq :=
+  (walkInitPrefixListCheckNotListFailF8Code base).union (walkInitShortLongCheckCode base)
+
+def walkInitEmptyFailNotListFailShortLongCode (base : Word) : CodeReq :=
+  (walkInitEmptyFailOrPrefixCode base).union (walkInitPrefixShortLongTailCode base)
+
+/-- State after the list-shaped fall-through has prepared the `0xf8` short/long
+    list threshold. -/
+def walkInitPrefixF8Post
+    (listBase listLen raVal : Word) (listBytes : List Byte)
+    (listOff : Nat) (hoff : listOff < listBytes.length) : Assertion :=
+  ((.x11 ↦ᵣ ((listBase + BitVec.ofNat 64 listOff) + listLen)) **
+    (.x10 ↦ᵣ (listBase + BitVec.ofNat 64 listOff)) **
+    (.x5 ↦ᵣ walkInitPrefixWord listBytes listOff hoff) ** (.x6 ↦ᵣ (0xf8 : Word)) **
+    (.x0 ↦ᵣ (0 : Word)) ** (.x1 ↦ᵣ raVal) ** bytesRegion listBase listBytes **
+    ⌜listLen ≠ (0 : Word)⌝ **
+    ⌜¬ BitVec.ult (walkInitPrefixWord listBytes listOff hoff) (0xc0 : Word)⌝)
+
+def walkInitShortListCandidatePost
+    (listBase listLen raVal : Word) (listBytes : List Byte)
+    (listOff : Nat) (hoff : listOff < listBytes.length) : Assertion :=
+  walkInitPrefixF8Post listBase listLen raVal listBytes listOff hoff **
+    ⌜BitVec.ult (walkInitPrefixWord listBytes listOff hoff) (0xf8 : Word)⌝
+
+def walkInitLongListCandidatePost
+    (listBase listLen raVal : Word) (listBytes : List Byte)
+    (listOff : Nat) (hoff : listOff < listBytes.length) : Assertion :=
+  walkInitPrefixF8Post listBase listLen raVal listBytes listOff hoff **
+    ⌜¬ BitVec.ult (walkInitPrefixWord listBytes listOff hoff) (0xf8 : Word)⌝
+
+theorem walkInitPrefixSetF8_spec_within
+    (base listBase listLen raVal : Word) (listBytes : List Byte)
+    (listOff : Nat) (hoff : listOff < listBytes.length) :
+    cpsTripleWithin 1 (base + 20) (base + 24) (walkInitListF8Code base)
+      (walkInitPrefixListPost listBase listLen raVal listBytes listOff hoff)
+      (walkInitPrefixF8Post listBase listLen raVal listBytes listOff hoff) := by
+  unfold walkInitListF8Code walkInitPrefixListPost walkInitPrefixLoadedPost
+    walkInitPrefixF8Post walkInitPrefixWord
+  let pfx : Word := (listBytes[listOff]'hoff).zeroExtend 64
+  have hli := li_spec_gen_within .x6 (0xc0 : Word) (0xf8 : Word) (base + 20) (by decide)
+  have hframed := cpsTripleWithin_frameR
+    (((.x11 ↦ᵣ ((listBase + BitVec.ofNat 64 listOff) + listLen)) **
+      (.x10 ↦ᵣ (listBase + BitVec.ofNat 64 listOff)) ** (.x5 ↦ᵣ pfx) **
+      (.x0 ↦ᵣ (0 : Word)) ** (.x1 ↦ᵣ raVal) ** bytesRegion listBase listBytes **
+      ⌜listLen ≠ (0 : Word)⌝ ** ⌜¬ BitVec.ult pfx (0xc0 : Word)⌝))
+    (by pcFree) hli
+  rw [show (base + 20 : Word) + 4 = base + 24 from by bv_omega] at hframed
+  exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp) hframed
+
+theorem walkInitShortLongCheck_spec_within
+    (base listBase listLen raVal : Word) (listBytes : List Byte)
+    (listOff : Nat) (hoff : listOff < listBytes.length) :
+    cpsBranchWithin 1 (base + 24) (walkInitShortLongCheckCode base)
+      (walkInitPrefixF8Post listBase listLen raVal listBytes listOff hoff)
+      (base + 124) (walkInitShortListCandidatePost listBase listLen raVal listBytes listOff hoff)
+      (base + 28) (walkInitLongListCandidatePost listBase listLen raVal listBytes listOff hoff) := by
+  unfold walkInitShortLongCheckCode walkInitPrefixF8Post walkInitShortListCandidatePost
+    walkInitLongListCandidatePost walkInitPrefixWord
+  let pfx : Word := (listBytes[listOff]'hoff).zeroExtend 64
+  have hbr := bltu_spec_gen_within .x5 .x6 (100 : BitVec 13) pfx (0xf8 : Word) (base + 24)
+  rw [show (base + 24) + signExtend13 (100 : BitVec 13) = base + 124 from by
+        rw [show signExtend13 (100 : BitVec 13) = (100 : Word) from by decide]
+        bv_omega,
+      show (base + 24 : Word) + 4 = base + 28 from by bv_omega] at hbr
+  have hframed := cpsBranchWithin_frameR
+    (((.x11 ↦ᵣ ((listBase + BitVec.ofNat 64 listOff) + listLen)) **
+      (.x10 ↦ᵣ (listBase + BitVec.ofNat 64 listOff)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x1 ↦ᵣ raVal) ** bytesRegion listBase listBytes ** ⌜listLen ≠ (0 : Word)⌝ **
+      ⌜¬ BitVec.ult pfx (0xc0 : Word)⌝))
+    (by pcFree) hbr
+  exact cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun h hp => by unfold walkInitPrefixF8Post walkInitPrefixWord; xperm_hyp hp)
+    (fun h hp => by unfold walkInitPrefixF8Post walkInitPrefixWord; xperm_hyp hp) hframed
+
+def walkInitShortLongCheckBranch
+    (base listBase listLen raVal : Word) (listBytes : List Byte)
+    (listOff : Nat) (hoff : listOff < listBytes.length) :
+    WP.Branch (base + 24) (walkInitShortLongCheckCode base) :=
+  WP.Branch.ofSpec
+    (walkInitShortLongCheck_spec_within base listBase listLen raVal listBytes listOff hoff)
+
+theorem walkInitPrefixListCheckOrNotListFailCode_disjoint_listF8 (base : Word) :
+    (walkInitPrefixListCheckOrNotListFailCode base).Disjoint (walkInitListF8Code base) := by
+  unfold walkInitPrefixListCheckOrNotListFailCode walkInitPrefixListCheckCode
+    walkInitPrefixNotListFailStatusCode failStatusReturnCode statusReturnCode walkInitListF8Code
+  refine CodeReq.Disjoint.union_left (CodeReq.Disjoint.singleton (by bv_omega)) ?_
+  refine CodeReq.Disjoint.union_left
+    (CodeReq.Disjoint.singleton (by bv_omega))
+    (CodeReq.Disjoint.singleton (by bv_omega))
+
+theorem walkInitPrefixListCheckNotListFailF8Code_disjoint_shortLong (base : Word) :
+    (walkInitPrefixListCheckNotListFailF8Code base).Disjoint (walkInitShortLongCheckCode base) := by
+  unfold walkInitPrefixListCheckNotListFailF8Code walkInitPrefixListCheckOrNotListFailCode
+    walkInitPrefixListCheckCode walkInitPrefixNotListFailStatusCode failStatusReturnCode
+    statusReturnCode walkInitListF8Code walkInitShortLongCheckCode
+  refine CodeReq.Disjoint.union_left ?_ (CodeReq.Disjoint.singleton (by bv_omega))
+  refine CodeReq.Disjoint.union_left (CodeReq.Disjoint.singleton (by bv_omega)) ?_
+  refine CodeReq.Disjoint.union_left
+    (CodeReq.Disjoint.singleton (by bv_omega))
+    (CodeReq.Disjoint.singleton (by bv_omega))
+
+theorem walkInitEmptyFailOrPrefixCode_disjoint_listF8 (base : Word) :
+    (walkInitEmptyFailOrPrefixCode base).Disjoint (walkInitListF8Code base) := by
+  unfold walkInitEmptyFailOrPrefixCode walkInitEmptyFailStatusCode failStatusReturnCode
+    statusReturnCode walkInitNonzeroPrefixTailCode walkInitListF8Code
+  refine CodeReq.Disjoint.union_left ?_ ?_
+  · refine CodeReq.Disjoint.union_left (CodeReq.Disjoint.singleton (by bv_omega)) ?_
+    refine CodeReq.Disjoint.union_left
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega))
+  · refine CodeReq.Disjoint.union_left (CodeReq.Disjoint.singleton (by bv_omega)) ?_
+    refine CodeReq.Disjoint.union_left
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega))
+
+theorem walkInitEmptyFailOrPrefixCode_disjoint_shortLong (base : Word) :
+    (walkInitEmptyFailOrPrefixCode base).Disjoint (walkInitShortLongCheckCode base) := by
+  unfold walkInitEmptyFailOrPrefixCode walkInitEmptyFailStatusCode failStatusReturnCode
+    statusReturnCode walkInitNonzeroPrefixTailCode walkInitShortLongCheckCode
+  refine CodeReq.Disjoint.union_left ?_ ?_
+  · refine CodeReq.Disjoint.union_left (CodeReq.Disjoint.singleton (by bv_omega)) ?_
+    refine CodeReq.Disjoint.union_left
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega))
+  · refine CodeReq.Disjoint.union_left (CodeReq.Disjoint.singleton (by bv_omega)) ?_
+    refine CodeReq.Disjoint.union_left
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega))
+
+theorem walkInitEmptyFailOrPrefixCode_disjoint_shortLongTail (base : Word) :
+    (walkInitEmptyFailOrPrefixCode base).Disjoint (walkInitPrefixShortLongTailCode base) := by
+  unfold walkInitPrefixShortLongTailCode walkInitPrefixListCheckNotListFailF8Code
+  exact CodeReq.Disjoint.union_right
+    (CodeReq.Disjoint.union_right
+      (walkInitEmptyFailOrPrefixCode_disjoint_listCheckOrNotListFail base)
+      (walkInitEmptyFailOrPrefixCode_disjoint_listF8 base))
+    (walkInitEmptyFailOrPrefixCode_disjoint_shortLong base)
+
+/-- Multi-exit WP certificate after the first list-prefix classifier has reached
+    the short-list versus long-list split. Exits are empty failure, not-list
+    failure, short-list candidate, and long-list candidate. -/
+def walkInitEmptyFailNotListFailShortLongNBranch
+    (base listBase listLen raVal t0Old t1Old : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true) :
+    WP.NBranch base (walkInitEmptyFailNotListFailShortLongCode base) := by
+  let br := walkInitEmptyFailOrPrefixBranch base listBase listLen raVal t0Old t1Old
+    listBytes listOff hsalign hoff hover hvalid
+  let listBranch := walkInitPrefixListCheckOrNotListFailBranch base listBase listLen raVal
+    listBytes listOff hoff
+  have hf8 := walkInitPrefixSetF8_spec_within base listBase listLen raVal
+    listBytes listOff hoff
+  let f8Branch : WP.Branch (base + 16) (walkInitPrefixListCheckNotListFailF8Code base) := by
+    unfold walkInitPrefixListCheckNotListFailF8Code
+    wp_rv64_branch_not_taken_block_disjoint
+      (walkInitPrefixListCheckOrNotListFailCode_disjoint_listF8 base), listBranch, hf8
+  let shortLong := WP.CFG.nbranchOfBranch
+    (walkInitShortLongCheckBranch base listBase listLen raVal listBytes listOff hoff)
+  let tail : WP.NBranch (base + 16) (walkInitPrefixShortLongTailCode base) := by
+    unfold walkInitPrefixShortLongTailCode
+    wp_rv64_branch_not_taken_nbranch_disjoint
+      (walkInitPrefixListCheckNotListFailF8Code_disjoint_shortLong base), f8Branch, shortLong
+  unfold walkInitEmptyFailNotListFailShortLongCode
+  wp_rv64_branch_not_taken_nbranch_disjoint
+    (walkInitEmptyFailOrPrefixCode_disjoint_shortLongTail base), br, tail
+
+theorem walkInitEmptyFailNotListFailShortLongNBranch_pre
+    (base listBase listLen raVal t0Old t1Old : Word)
+    (listBytes : List Byte) (listOff : Nat)
+    (hsalign : listBase.toNat % 8 = 0) (hoff : listOff < listBytes.length)
+    (hover : listBase.toNat + listOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (listBase + BitVec.ofNat 64 listOff) = true) :
+    (walkInitEmptyFailNotListFailShortLongNBranch base listBase listLen raVal t0Old t1Old
+      listBytes listOff hsalign hoff hover hvalid).pre =
+      (walkInitEmptyFailStatusPre listLen raVal (listBase + BitVec.ofNat 64 listOff) **
+        (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion listBase listBytes) := by
+  rfl
+
 /-! ## Pure decode bridge -/
 
 /-- The decoded withdrawal value described by four already-decoded field byte strings.

--- a/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecode.lean
@@ -1397,26 +1397,10 @@ def walkInitEmptyFailNotListFailShortLongOutputCaseNBranch
     WP.NBranch base (walkInitEmptyFailNotListFailShortLongCode base) := by
   let br := walkInitEmptyFailNotListFailShortLongOutputNBranch base listBase listLen raVal
     t0Old t1Old outBase listBytes listOff hsalign hoff hover hvalid
-  let exits : List (Word × Assertion) :=
-    [ (failStatusReturnExit raVal, emptyPost)
-    , (failStatusReturnExit raVal, notListPost)
-    , (base + 124, shortPost)
-    , (base + 28, longPost)
-    ]
-  exact WP.CFG.nbranchWeakenPosts br exits (by
-    intro ex hex
-    have hex' := hex
-    rw [walkInitEmptyFailNotListFailShortLongOutputNBranch_exits] at hex'
-    simp [walkInitEmptyFailNotListFailShortLongOutputExits] at hex'
-    rcases hex' with hcase | hcase | hcase | hcase
-    · rcases hcase with ⟨rfl, rfl⟩
-      exact ⟨(failStatusReturnExit raVal, emptyPost), by simp [exits], rfl, hEmpty⟩
-    · rcases hcase with ⟨rfl, rfl⟩
-      exact ⟨(failStatusReturnExit raVal, notListPost), by simp [exits], rfl, hNotList⟩
-    · rcases hcase with ⟨rfl, rfl⟩
-      exact ⟨(base + 124, shortPost), by simp [exits], rfl, hShort⟩
-    · rcases hcase with ⟨rfl, rfl⟩
-      exact ⟨(base + 28, longPost), by simp [exits], rfl, hLong⟩)
+  wp_rv64_nbranch_weaken_posts4_with br,
+    (walkInitEmptyFailNotListFailShortLongOutputNBranch_exits base listBase listLen raVal
+      t0Old t1Old outBase listBytes listOff hsalign hoff hover hvalid),
+    hEmpty, hNotList, hShort, hLong
 
 theorem walkInitEmptyFailNotListFailShortLongOutputCaseNBranch_pre
     (base listBase listLen raVal t0Old t1Old outBase : Word)

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -704,13 +704,67 @@ theorem walkInitShortSuccessDecodedFailureNBranch_exits
     h_len h_prologue_code h_code_max).failureNBranch_exits hsalign hover hwin h_len h_prologue_code
     h_code_max
 
+/-- Decoded-result failure branch with the long-list exit already continued
+    through the reason-erased ABI failure return. -/
+noncomputable def walkInitShortSuccessDecodedLongFailureNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (w : Withdrawal)
+    (hdec : decodeWithdrawal input = some w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base
+      ((walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+        m3 inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov
+        hdval h_len h_prologue_code h_code_max).successCode.union
+        (failStatusReturnCode ((base + 24) + 28))) :=
+  (walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+    inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov hdval
+    h_len h_prologue_code h_code_max).failureLongNBranch hsalign hover hwin h_len
+    h_prologue_code h_code_max
+
+/-- The decoded-result long-failure branch has the same static prologue
+    precondition as the success certificate. -/
+theorem walkInitShortSuccessDecodedLongFailureNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (w : Withdrawal)
+    (hdec : decodeWithdrawal input = some w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    (walkInitShortSuccessDecodedLongFailureNBranch base sp0 raVal s0Old s1Old s2Old outBase
+      m0 m1 m2 m3 inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign
+      hdov hdval h_len h_prologue_code h_code_max).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  exact (walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+    m3 inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov hdval
+    h_len h_prologue_code h_code_max).failureLongNBranch_pre hsalign hover hwin h_len
+    h_prologue_code h_code_max
+
 attribute [rv64_wp]
   walkInitShortSuccessDecodedCert_pre
   walkInitShortSuccessDecodedFailureNBranch_pre
+  walkInitShortSuccessDecodedLongFailureNBranch_pre
 
 attribute [rv64_wp_cert]
   walkInitShortSuccessDecodedCert
   walkInitShortSuccessDecodedFailureNBranch
+  walkInitShortSuccessDecodedLongFailureNBranch
 
 noncomputable example
     (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
@@ -754,6 +808,27 @@ noncomputable example
         (walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
           m3 inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov
           hdval h_len h_prologue_code h_code_max).specs)) := by
+  wp_rv64_cert
+
+noncomputable example
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (w : Withdrawal)
+    (hdec : decodeWithdrawal input = some w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base
+      ((walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+        m3 inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov
+        hdval h_len h_prologue_code h_code_max).successCode.union
+        (failStatusReturnCode ((base + 24) + 28))) := by
   wp_rv64_cert
 
 /-- Result-free package projection from a successful schema-input predicate.
@@ -917,14 +992,68 @@ theorem walkInitShortSuccessSchemaInputFailureNBranch_exits
     h_len h_prologue_code h_code_max).failureNBranch_exits hsalign hover hwin h_len h_prologue_code
     h_code_max
 
+/-- Result-free schema-input failure branch with the long-list exit already
+    continued through the reason-erased ABI failure return. -/
+noncomputable def walkInitShortSuccessSchemaInputLongFailureNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (h_success : successFieldSpecsInput input)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base
+      ((walkInitShortSuccessSchemaInputPkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1
+        m2 m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov
+        hdval h_len h_prologue_code h_code_max).successCode.union
+        (failStatusReturnCode ((base + 24) + 28))) :=
+  (walkInitShortSuccessSchemaInputPkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+    m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov hdval
+    h_len h_prologue_code h_code_max).failureLongNBranch hsalign hover hwin h_len
+    h_prologue_code h_code_max
+
+/-- The result-free schema-input long-failure branch has the same static
+    prologue precondition as the success certificate. -/
+theorem walkInitShortSuccessSchemaInputLongFailureNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (h_success : successFieldSpecsInput input)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    (walkInitShortSuccessSchemaInputLongFailureNBranch base sp0 raVal s0Old s1Old s2Old
+      outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input h_success hsalign hover
+      hwin hdalign hdov hdval h_len h_prologue_code h_code_max).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  exact (walkInitShortSuccessSchemaInputPkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1
+    m2 m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov hdval
+    h_len h_prologue_code h_code_max).failureLongNBranch_pre hsalign hover hwin h_len
+    h_prologue_code h_code_max
+
 
 attribute [rv64_wp]
   walkInitShortSuccessSchemaInputCert_pre
   walkInitShortSuccessSchemaInputFailureNBranch_pre
+  walkInitShortSuccessSchemaInputLongFailureNBranch_pre
 
 attribute [rv64_wp_cert]
   walkInitShortSuccessSchemaInputCert
   walkInitShortSuccessSchemaInputFailureNBranch
+  walkInitShortSuccessSchemaInputLongFailureNBranch
 
 noncomputable example
     (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
@@ -968,6 +1097,27 @@ noncomputable example
         (walkInitShortSuccessSchemaInputPkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1
           m2 m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov
           hdval h_len h_prologue_code h_code_max).specs)) := by
+  wp_rv64_cert
+
+noncomputable example
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (h_success : successFieldSpecsInput input)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base
+      ((walkInitShortSuccessSchemaInputPkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1
+        m2 m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov
+        hdval h_len h_prologue_code h_code_max).successCode.union
+        (failStatusReturnCode ((base + 24) + 28))) := by
   wp_rv64_cert
 
 
@@ -1231,6 +1381,48 @@ noncomputable example
       (walkInitShortSuccessResolvedCode (base + 24) specs)).union
       (failStatusReturnCode ((base + 24) + 28))) := by
   wp_withdrawal_decode_auto
+
+noncomputable example
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (w : Withdrawal)
+    (hdec : decodeWithdrawal input = some w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base
+      ((walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+        m3 inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov
+        hdval h_len h_prologue_code h_code_max).successCode.union
+        (failStatusReturnCode ((base + 24) + 28))) := by
+  wp_withdrawal_decode_auto input
+
+noncomputable example
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (h_success : successFieldSpecsInput input)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base
+      ((walkInitShortSuccessSchemaInputPkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1
+        m2 m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov
+        hdval h_len h_prologue_code h_code_max).successCode.union
+        (failStatusReturnCode ((base + 24) + 28))) := by
+  wp_withdrawal_decode_auto input
 
 end WithdrawalDecode
 

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -952,6 +952,7 @@ macro "withdrawal_decode_failure" : tactic =>
     | exact decodeWithdrawal_none_of_decodeFully_bytes (by assumption)
     | exact decodeWithdrawal_none_of_decodeFully_list_length_ne_four (by assumption) (by assumption)
     | exact decodeWithdrawal_none_of_decodeFully_fields_not_canonical (by assumption) (by assumption)
+    | exact decodeWithdrawal_none_of_walkInitPrefixWord_not_lt_f8 _ (by assumption) (by assumption)
     | exact (decodeWithdrawal_eq_none_iff_not_successFieldSpecsInput _).2 (by assumption))
 
 /-- Exact-arity leftover failure automation for validated short-list paths.
@@ -1031,6 +1032,12 @@ example
 
 example
     (input : List Byte) (hfull : decodeFully input = none) :
+    decodeWithdrawal input = none := by
+  wp_withdrawal_decode_auto
+
+example
+    (input : List Byte) (hoff : 0 < input.length)
+    (hnot : ¬ BitVec.ult (walkInitPrefixWord input 0 hoff) (0xf8 : Word)) :
     decodeWithdrawal input = none := by
   wp_withdrawal_decode_auto
 
@@ -1142,6 +1149,23 @@ noncomputable example
     WP.NBranch base ((prologueCode base).union
       (walkInitShortSuccessResolvedCode (base + 24) specs)) := by
   wp_withdrawal_decode_auto input
+
+
+noncomputable example
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover0 : inputBase.toNat + 0 < 2 ^ 64)
+    (hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_bound : input.length < 2 ^ 64)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    WP.NBranch base (((prologueCode base).union
+      (walkInitShortSuccessResolvedCode (base + 24) specs)).union
+      (failStatusReturnCode ((base + 24) + 28))) := by
+  wp_withdrawal_decode_auto
 
 end WithdrawalDecode
 

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -172,6 +172,21 @@ theorem walkInitShortSuccessDecodedWP_cert_pre
 attribute [rv64_wp]
   walkInitShortSuccessDecodedWP_cert_pre
 
+/-- Nonempty inputs select the reason-erased classifier exits in the zero/nonzero
+    facade. This hides the empty-input singleton branch once a caller has any
+    static nonempty witness. -/
+theorem walkInitZeroNonzeroAbiFailureFromPrologueExits_of_pos
+    (base sp0 raVal s0Old s1Old s2Old outBase : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (hoff : 0 < input.length) :
+    walkInitZeroNonzeroAbiFailureFromPrologueExits base sp0 raVal s0Old s1Old s2Old outBase
+      inputBase listLen t0Old t1Old input =
+      walkInitAbiFailureReasonErasedFromPrologueExits base sp0 raVal s0Old s1Old s2Old outBase
+        inputBase listLen t0Old t1Old input hoff := by
+  cases input with
+  | nil => simp at hoff
+  | cons _ _ => rfl
+
 namespace WalkInitShortSuccessDecodedWP
 
 /-- Result-free schema witnesses extracted by a decoded-success WP package. -/
@@ -237,6 +252,30 @@ theorem failureNBranch_pre
         walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
   unfold failureNBranch
   rw [walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeSuccessFrameNBranch_pre]
+
+/-- Package-indexed classifier exits normalized to the nonempty, reason-erased
+    shape. The low-level empty/nonempty `match` is discharged by `pkg.hoff`. -/
+theorem failureNBranch_exits
+    {base sp0 raVal s0Old s1Old s2Old outBase : Word}
+    {m0 m1 m2 m3 inputBase listLen t0Old t1Old : Word}
+    {input : List Byte} {w : Withdrawal}
+    (pkg : WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old input w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    (pkg.failureNBranch hsalign hover hwin h_len h_prologue_code h_code_max).exits =
+      (walkInitAbiFailureReasonErasedFromPrologueExits base sp0 raVal s0Old s1Old s2Old
+        outBase inputBase listLen t0Old t1Old input pkg.hoff).map
+        (fun ex => (ex.1, ex.2 ** walkInitSchemaScratchFrame)) := by
+  unfold failureNBranch
+  rw [walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeSuccessFrameNBranch_exits]
+  unfold walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeSuccessFrameExits
+  rw [walkInitZeroNonzeroAbiFailureFromPrologueExits_of_pos base sp0 raVal s0Old s1Old
+    s2Old outBase inputBase listLen t0Old t1Old input pkg.hoff]
 
 attribute [rv64_wp]
   failureNBranch_pre

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -1170,23 +1170,75 @@ theorem successFieldSpecsInput_or_decodeWithdrawal_eq_none
       exact Or.inl
         ((successFieldSpecsInput_iff_exists_decodeWithdrawal_eq_some input).2 ⟨w, hdec⟩)
 
+/-- Result-free schema-success bridge for generated validating field walks.  The
+    decoded result is used only as an existential witness for the semantic
+    characterization of `successFieldSpecsInput`; the schema predicate itself
+    remains result-free. -/
+theorem successFieldSpecsInput_of_shortList_four_decode_chain
+    {pfx : Byte} {payload r1 r2 r3 r4 d0 d1 d2 d3 : List Byte}
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (h0 : ∀ m, decodeAux (m + 1) payload = some (.bytes d0, r1))
+    (h1 : ∀ m, decodeAux (m + 1) r1 = some (.bytes d1, r2))
+    (h2 : ∀ m, decodeAux (m + 1) r2 = some (.bytes d2, r3))
+    (h3 : ∀ m, decodeAux (m + 1) r3 = some (.bytes d3, r4))
+    (hend : r4 = [])
+    (h_min : 2 ≤ payload.length)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8) :
+    successFieldSpecsInput (pfx :: payload) :=
+  (successFieldSpecsInput_iff_exists_decodeWithdrawal_eq_some (pfx :: payload)).2
+    ⟨fromFieldBytes d0 d1 d2 d3,
+      decodeWithdrawal_shortList_four_of_decodeAux_chain_auto h_class h_len h0 h1 h2 h3 hend
+        h_min hc0 hl0 hc1 hl1 haddr hc3 hl3⟩
+
 /-- Convert a validating field-post `decode` fact into the fuel-polymorphic
     `decodeAux` continuation consumed by the short-list WP bridge. -/
 macro "wp_rlp_field_decode_aux " hDecode:term : tactic =>
   `(tactic| exact decodeAux_bytes_all_fuel_of_decode _ _ _ _ $hDecode)
 
+/-- Exact-arity success automation for WP-generated validating field walks.  It
+    derives the four `decodeAux` continuations from field-post `decode` facts and
+    applies the withdrawal success bridge. -/
+macro "withdrawal_decode_success_chain " hclass:term ", " hlen:term ", " hdec0:term ", "
+    hdec1:term ", " hdec2:term ", " hdec3:term ", " hend:term ", " hmin:term ", "
+    hc0:term ", " hl0:term ", " hc1:term ", " hl1:term ", " haddr:term ", "
+    hc3:term ", " hl3:term : tactic =>
+  `(tactic| exact decodeWithdrawal_shortList_four_of_decodeAux_chain_auto
+    $hclass $hlen
+    (by wp_rlp_field_decode_aux $hdec0)
+    (by wp_rlp_field_decode_aux $hdec1)
+    (by wp_rlp_field_decode_aux $hdec2)
+    (by wp_rlp_field_decode_aux $hdec3)
+    $hend $hmin $hc0 $hl0 $hc1 $hl1 $haddr $hc3 $hl3)
+
+/-- Result-free schema-success automation for WP-generated validating field walks. -/
+macro "withdrawal_schema_success_chain " hclass:term ", " hlen:term ", " hdec0:term ", "
+    hdec1:term ", " hdec2:term ", " hdec3:term ", " hend:term ", " hmin:term ", "
+    hc0:term ", " hl0:term ", " hc1:term ", " hl1:term ", " haddr:term ", "
+    hc3:term ", " hl3:term : tactic =>
+  `(tactic| exact successFieldSpecsInput_of_shortList_four_decode_chain
+    $hclass $hlen
+    (by wp_rlp_field_decode_aux $hdec0)
+    (by wp_rlp_field_decode_aux $hdec1)
+    (by wp_rlp_field_decode_aux $hdec2)
+    (by wp_rlp_field_decode_aux $hdec3)
+    $hend $hmin $hc0 $hl0 $hc1 $hl1 $haddr $hc3 $hl3)
+
 /-- Exact-arity leftover failure automation for WP-generated validating field
     walks.  It derives all four `decodeAux` continuations from local field-post
     `decode` facts, then applies the chain-shaped withdrawal failure bridge. -/
-macro "withdrawal_decode_failure_chain " hClass:term ", " hLen:term ", " hDec0:term ", "
-    hDec1:term ", " hDec2:term ", " hDec3:term ", " hLeftover:term ", " hMin:term : tactic =>
+macro "withdrawal_decode_failure_chain " hclass:term ", " hlen:term ", " hdec0:term ", "
+    hdec1:term ", " hdec2:term ", " hdec3:term ", " hleftover:term ", " hmin:term : tactic =>
   `(tactic| exact decodeWithdrawal_none_of_shortList_four_leftover_chain_auto
-    $hClass $hLen
-    (by wp_rlp_field_decode_aux $hDec0)
-    (by wp_rlp_field_decode_aux $hDec1)
-    (by wp_rlp_field_decode_aux $hDec2)
-    (by wp_rlp_field_decode_aux $hDec3)
-    $hLeftover $hMin)
+    $hclass $hlen
+    (by wp_rlp_field_decode_aux $hdec0)
+    (by wp_rlp_field_decode_aux $hdec1)
+    (by wp_rlp_field_decode_aux $hdec2)
+    (by wp_rlp_field_decode_aux $hdec3)
+    $hleftover $hmin)
 
 /-- Pure failure automation for the semantic side of withdrawal WP joins. It
     consumes the common facts produced by validating RLP blocks: failed complete
@@ -1207,18 +1259,18 @@ macro "withdrawal_decode_failure" : tactic =>
 
 /-- Exact-arity leftover failure automation for validated short-list paths.
     Generated proofs pass the static branch facts produced by the WP walk. -/
-macro "withdrawal_decode_failure " hClass:term ", " hLen:term ", " h0:term ", " h1:term ", "
-    h2:term ", " h3:term ", " hLeftover:term ", " hMin:term : tactic =>
+macro "withdrawal_decode_failure " hclass:term ", " hlen:term ", " h0:term ", " h1:term ", "
+    h2:term ", " h3:term ", " hleftover:term ", " hmin:term : tactic =>
   `(tactic| exact decodeWithdrawal_none_of_shortList_four_leftover_auto
-    $hClass $hLen $h0 $h1 $h2 $h3 $hLeftover $hMin)
+    $hclass $hlen $h0 $h1 $h2 $h3 $hleftover $hmin)
 
 /-- Schema-concat leftover failure automation for generated WP schema walks.
     The caller supplies only static field bounds, the schema payload split, and a
     nonempty leftover; the intermediate `decodeAux` facts are derived internally. -/
-macro "withdrawal_decode_failure " hClass:term ", " hLen:term ", " hl0:term ", " hl1:term ", "
-    haddr:term ", " hl3:term ", " hPayload:term ", " hTail:term ", " hMin:term : tactic =>
+macro "withdrawal_decode_failure " hclass:term ", " hlen:term ", " hl0:term ", " hl1:term ", "
+    haddr:term ", " hl3:term ", " hPayload:term ", " hTail:term ", " hmin:term : tactic =>
   `(tactic| exact decodeWithdrawal_none_of_shortList_successFieldSpecs_leftover_auto
-    $hClass $hLen $hl0 $hl1 $haddr $hl3 $hPayload $hTail $hMin)
+    $hclass $hlen $hl0 $hl1 $haddr $hl3 $hPayload $hTail $hmin)
 
 /-- Same automation, but returning the result-free schema failure predicate used
     by caller-facing WP wrappers. -/
@@ -1227,11 +1279,11 @@ macro "withdrawal_schema_failure" : tactic =>
     (by withdrawal_decode_failure))
 
 /-- Schema-concat leftover failure automation for result-free schema predicates. -/
-macro "withdrawal_schema_failure " hClass:term ", " hLen:term ", " hl0:term ", " hl1:term ", "
-    haddr:term ", " hl3:term ", " hPayload:term ", " hTail:term ", " hMin:term : tactic =>
+macro "withdrawal_schema_failure " hclass:term ", " hlen:term ", " hl0:term ", " hl1:term ", "
+    haddr:term ", " hl3:term ", " hPayload:term ", " hTail:term ", " hmin:term : tactic =>
   `(tactic| exact (decodeWithdrawal_eq_none_iff_not_successFieldSpecsInput _).1
-    (by withdrawal_decode_failure $hClass, $hLen, $hl0, $hl1, $haddr, $hl3, $hPayload,
-      $hTail, $hMin))
+    (by withdrawal_decode_failure $hclass, $hlen, $hl0, $hl1, $haddr, $hl3, $hPayload,
+      $hTail, $hmin))
 
 /-- Withdrawal-domain WP automation.  This is the tactic generated proofs should
     use at control-flow joins: it solves pure withdrawal failure/schema facts
@@ -1256,33 +1308,47 @@ macro "wp_withdrawal_decode_auto " input:term : tactic =>
     | wp_withdrawal_decode_cert $input
     | wp_withdrawal_decode_auto)
 
+/-- Chain-shaped exact-arity success overload for generated validating field walks.
+    It can close either the semantic `decodeWithdrawal = some ...` goal or the
+    result-free `successFieldSpecsInput` goal. -/
+macro "wp_withdrawal_decode_chain_auto " hclass:term ", " hlen:term ", " hdec0:term ", "
+    hdec1:term ", " hdec2:term ", " hdec3:term ", " hend:term ", " hmin:term ", "
+    hc0:term ", " hl0:term ", " hc1:term ", " hl1:term ", " haddr:term ", "
+    hc3:term ", " hl3:term : tactic =>
+  `(tactic| first
+    | withdrawal_schema_success_chain $hclass, $hlen, $hdec0, $hdec1, $hdec2, $hdec3,
+        $hend, $hmin, $hc0, $hl0, $hc1, $hl1, $haddr, $hc3, $hl3
+    | withdrawal_decode_success_chain $hclass, $hlen, $hdec0, $hdec1, $hdec2, $hdec3,
+        $hend, $hmin, $hc0, $hl0, $hc1, $hl1, $haddr, $hc3, $hl3
+    | wp_withdrawal_decode_auto)
+
 /-- Chain-shaped exact-arity leftover overload for generated validating field walks.
     The four field `decodeAux` continuations are built automatically from the
     WP field-post `decode` facts. -/
-macro "wp_withdrawal_decode_chain_auto " hClass:term ", " hLen:term ", " hDec0:term ", "
-    hDec1:term ", " hDec2:term ", " hDec3:term ", " hLeftover:term ", " hMin:term : tactic =>
+macro "wp_withdrawal_decode_chain_auto " hclass:term ", " hlen:term ", " hdec0:term ", "
+    hdec1:term ", " hdec2:term ", " hdec3:term ", " hleftover:term ", " hmin:term : tactic =>
   `(tactic| first
-    | withdrawal_decode_failure_chain $hClass, $hLen, $hDec0, $hDec1, $hDec2, $hDec3,
-        $hLeftover, $hMin
+    | withdrawal_decode_failure_chain $hclass, $hlen, $hdec0, $hdec1, $hdec2, $hdec3,
+        $hleftover, $hmin
     | wp_withdrawal_decode_auto)
 
 /-- Exact-arity leftover overload for generated short-list field walks. -/
-macro "wp_withdrawal_decode_auto " hClass:term ", " hLen:term ", " h0:term ", " h1:term ", "
-    h2:term ", " h3:term ", " hLeftover:term ", " hMin:term : tactic =>
+macro "wp_withdrawal_decode_auto " hclass:term ", " hlen:term ", " h0:term ", " h1:term ", "
+    h2:term ", " h3:term ", " hleftover:term ", " hmin:term : tactic =>
   `(tactic| first
-    | withdrawal_decode_failure $hClass, $hLen, $h0, $h1, $h2, $h3, $hLeftover, $hMin
+    | withdrawal_decode_failure $hclass, $hlen, $h0, $h1, $h2, $h3, $hleftover, $hmin
     | wp_withdrawal_decode_auto)
 
 /-- Schema-concat exact-arity leftover overload for generated withdrawal schema
     walks.  This keeps the schema result-free while deriving the semantic
     failure fact needed by ABI postconditions. -/
-macro "wp_withdrawal_decode_auto " hClass:term ", " hLen:term ", " hl0:term ", " hl1:term ", "
-    haddr:term ", " hl3:term ", " hPayload:term ", " hTail:term ", " hMin:term : tactic =>
+macro "wp_withdrawal_decode_auto " hclass:term ", " hlen:term ", " hl0:term ", " hl1:term ", "
+    haddr:term ", " hl3:term ", " hPayload:term ", " hTail:term ", " hmin:term : tactic =>
   `(tactic| first
-    | withdrawal_schema_failure $hClass, $hLen, $hl0, $hl1, $haddr, $hl3, $hPayload,
-        $hTail, $hMin
-    | withdrawal_decode_failure $hClass, $hLen, $hl0, $hl1, $haddr, $hl3, $hPayload,
-        $hTail, $hMin
+    | withdrawal_schema_failure $hclass, $hlen, $hl0, $hl1, $haddr, $hl3, $hPayload,
+        $hTail, $hmin
+    | withdrawal_decode_failure $hclass, $hlen, $hl0, $hl1, $haddr, $hl3, $hPayload,
+        $hTail, $hmin
     | wp_withdrawal_decode_auto)
 
 example
@@ -1348,6 +1414,42 @@ example
     (h_min : 2 ≤ (p0 :: r0).length) :
     decodeWithdrawal (pfx :: p0 :: r0) = none := by
   wp_withdrawal_decode_chain_auto h_class, h_len, hdec0, hdec1, hdec2, hdec3, h_leftover, h_min
+
+example
+    (pfx p0 p1 p2 p3 : Byte) (r0 r1 r2 r3 d0 d1 d2 d3 : List Byte)
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = (p0 :: r0).length)
+    (hdec0 : decode (p0 :: r0) = some (.bytes d0, p1 :: r1))
+    (hdec1 : decode (p1 :: r1) = some (.bytes d1, p2 :: r2))
+    (hdec2 : decode (p2 :: r2) = some (.bytes d2, p3 :: r3))
+    (hdec3 : decode (p3 :: r3) = some (.bytes d3, []))
+    (h_end : ([] : List Byte) = [])
+    (h_min : 2 ≤ (p0 :: r0).length)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8) :
+    decodeWithdrawal (pfx :: p0 :: r0) = some (fromFieldBytes d0 d1 d2 d3) := by
+  wp_withdrawal_decode_chain_auto h_class, h_len, hdec0, hdec1, hdec2, hdec3, h_end, h_min,
+    hc0, hl0, hc1, hl1, haddr, hc3, hl3
+
+example
+    (pfx p0 p1 p2 p3 : Byte) (r0 r1 r2 r3 d0 d1 d2 d3 : List Byte)
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = (p0 :: r0).length)
+    (hdec0 : decode (p0 :: r0) = some (.bytes d0, p1 :: r1))
+    (hdec1 : decode (p1 :: r1) = some (.bytes d1, p2 :: r2))
+    (hdec2 : decode (p2 :: r2) = some (.bytes d2, p3 :: r3))
+    (hdec3 : decode (p3 :: r3) = some (.bytes d3, []))
+    (h_end : ([] : List Byte) = [])
+    (h_min : 2 ≤ (p0 :: r0).length)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8) :
+    successFieldSpecsInput (pfx :: p0 :: r0) := by
+  wp_withdrawal_decode_chain_auto h_class, h_len, hdec0, hdec1, hdec2, hdec3, h_end, h_min,
+    hc0, hl0, hc1, hl1, haddr, hc3, hl3
 
 example
     (pfx : Byte) (payload d0 d1 d2 d3 : List Byte)

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -172,6 +172,101 @@ theorem walkInitShortSuccessDecodedWP_cert_pre
 attribute [rv64_wp]
   walkInitShortSuccessDecodedWP_cert_pre
 
+/-- Result-free success schemas are exactly the inputs for which the Lean
+    withdrawal decoder returns some value. This keeps the schema predicate free
+    of the decoded result while still characterizing `decodeWithdrawal`. -/
+theorem successFieldSpecsInput_iff_exists_decodeWithdrawal_eq_some
+    (input : List Byte) :
+    successFieldSpecsInput input ↔ ∃ w : Withdrawal, decodeWithdrawal input = some w := by
+  constructor
+  · rintro ⟨d0, d1, d2, d3, hinput, hc0, hl0, hc1, hl1, haddr, hc3, hl3⟩
+    exact ⟨fromFieldBytes d0 d1 d2 d3,
+      decodeWithdrawal_eq_some_of_successFieldSpecs_input input d0 d1 d2 d3
+        hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput⟩
+  · rintro ⟨w, hdec⟩
+    rcases successFieldSpecs_input_of_decodeWithdrawal_eq_some input w hdec with
+      ⟨d0, d1, d2, d3, hinput, hc0, hl0, hc1, hl1, haddr, hc3, hl3, _hw⟩
+    exact ⟨d0, d1, d2, d3, hinput, hc0, hl0, hc1, hl1, haddr, hc3, hl3⟩
+
+/-- A result-free success-schema input is enough to produce a decoded-success WP
+    package for some Lean withdrawal result. -/
+theorem walkInitShortSuccessDecodedWP_exists_of_successFieldSpecsInput
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (h_success : successFieldSpecsInput input)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    ∃ w : Withdrawal,
+      Nonempty (WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase
+        m0 m1 m2 m3 inputBase listLen t0Old t1Old input w) := by
+  rcases (successFieldSpecsInput_iff_exists_decodeWithdrawal_eq_some input).mp h_success with
+    ⟨w, hdec⟩
+  exact ⟨w, walkInitShortSuccessDecodedWP_nonempty base sp0 raVal s0Old s1Old s2Old outBase
+    m0 m1 m2 m3 inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign
+    hdov hdval h_len h_prologue_code h_code_max⟩
+
+/-- Direct package constructor from the result-free success-schema predicate.
+    The returned Sigma carries the Lean decoded value, but the caller does not
+    put that value into the schema or precondition. -/
+noncomputable def walkInitShortSuccessSchemaInputWP
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (h_success : successFieldSpecsInput input)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    Sigma (fun w : Withdrawal => WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old
+      s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input w) :=
+  let h_pkg := walkInitShortSuccessDecodedWP_exists_of_successFieldSpecsInput base sp0 raVal
+    s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input h_success
+    hsalign hover hwin hdalign hdov hdval h_len h_prologue_code h_code_max
+  Classical.choice (by
+    rcases h_pkg with ⟨w, hpkg⟩
+    exact ⟨⟨w, Classical.choice hpkg⟩⟩)
+
+/-- The result-free success-schema package has the same static prologue
+    precondition as the decoded-result package. -/
+theorem walkInitShortSuccessSchemaInputWP_cert_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (h_success : successFieldSpecsInput input)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    (walkInitShortSuccessSchemaInputWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov hdval
+      h_len h_prologue_code h_code_max).2.cert.pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input) :=
+  (walkInitShortSuccessSchemaInputWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+    inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov hdval h_len
+    h_prologue_code h_code_max).2.hpre
+
+attribute [rv64_wp]
+  walkInitShortSuccessSchemaInputWP_cert_pre
+
 /-- Nonempty inputs select the reason-erased classifier exits in the zero/nonzero
     facade. This hides the empty-input singleton branch once a caller has any
     static nonempty witness. -/

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -172,6 +172,77 @@ theorem walkInitShortSuccessDecodedWP_cert_pre
 attribute [rv64_wp]
   walkInitShortSuccessDecodedWP_cert_pre
 
+namespace WalkInitShortSuccessDecodedWP
+
+/-- Result-free schema witnesses extracted by a decoded-success WP package. -/
+def specs
+    {base sp0 raVal s0Old s1Old s2Old outBase : Word}
+    {m0 m1 m2 m3 inputBase listLen t0Old t1Old : Word}
+    {input : List Byte} {w : Withdrawal}
+    (pkg : WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old input w) : List FieldSpec :=
+  successFieldSpecs pkg.d0 pkg.d1 pkg.d2 pkg.d3
+
+/-- The decoded package's generated success schema fits under the public max-code
+    bound used by `walkInitShortSuccessDecodedWP`. -/
+theorem code_bound_of_max
+    {base sp0 raVal s0Old s1Old s2Old outBase : Word}
+    {m0 m1 m2 m3 inputBase listLen t0Old t1Old : Word}
+    {input : List Byte} {w : Withdrawal}
+    (pkg : WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old input w)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    (base + 24).toNat + 172 + 4 + schemaSize pkg.specs + 8 < 2 ^ 64 := by
+  have h_schema_size := pkg.h_schema_size
+  unfold specs
+  omega
+
+/-- Zero/nonzero classifier facade over the same generated code requirement as a
+    decoded-success package.  This removes the last need to reconstruct the
+    witness-specific `successFieldSpecs` when composing branch-level automation. -/
+def failureNBranch
+    {base sp0 raVal s0Old s1Old s2Old outBase : Word}
+    {m0 m1 m2 m3 inputBase listLen t0Old t1Old : Word}
+    {input : List Byte} {w : Withdrawal}
+    (pkg : WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old input w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base ((prologueCode base).union
+      (walkInitShortSuccessResolvedCode (base + 24) pkg.specs)) :=
+  walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeSuccessFrameNBranch base sp0 raVal
+    s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input pkg.specs
+    hsalign hover hwin h_len h_prologue_code (pkg.code_bound_of_max h_code_max)
+
+/-- The package-indexed zero/nonzero facade has the same static precondition as
+    the decoded success certificate. -/
+theorem failureNBranch_pre
+    {base sp0 raVal s0Old s1Old s2Old outBase : Word}
+    {m0 m1 m2 m3 inputBase listLen t0Old t1Old : Word}
+    {input : List Byte} {w : Withdrawal}
+    (pkg : WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old input w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    (pkg.failureNBranch hsalign hover hwin h_len h_prologue_code h_code_max).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  unfold failureNBranch
+  rw [walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeSuccessFrameNBranch_pre]
+
+attribute [rv64_wp]
+  failureNBranch_pre
+
+end WalkInitShortSuccessDecodedWP
+
 end WithdrawalDecode
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -486,6 +486,71 @@ attribute [rv64_wp]
 attribute [rv64_wp_cert]
   failureNBranch
 
+/-- Package-indexed failure branch with the long-list exit already continued
+    through the reason-erased failure return block. -/
+def failureLongNBranch
+    {base sp0 raVal s0Old s1Old s2Old outBase : Word}
+    {m0 m1 m2 m3 inputBase listLen t0Old t1Old : Word}
+    {input : List Byte} {w : Withdrawal}
+    (pkg : WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old input w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base (pkg.successCode.union (failStatusReturnCode ((base + 24) + 28))) := by
+  dsimp [successCode]
+  exact walkInitAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureSuccessFrameNBranch
+    base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old
+    input pkg.specs hsalign pkg.hoff (by omega) (hwin 0 pkg.hoff) h_len (by omega)
+    h_prologue_code (pkg.code_bound_of_max h_code_max)
+
+/-- The long-failure package branch keeps the same static success-shaped
+    precondition as the success certificate. -/
+theorem failureLongNBranch_pre
+    {base sp0 raVal s0Old s1Old s2Old outBase : Word}
+    {m0 m1 m2 m3 inputBase listLen t0Old t1Old : Word}
+    {input : List Byte} {w : Withdrawal}
+    (pkg : WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old input w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    (pkg.failureLongNBranch hsalign hover hwin h_len h_prologue_code h_code_max).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  simpa [failureLongNBranch] using
+    (walkInitAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureSuccessFrameNBranch_pre
+      base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old
+      input pkg.specs hsalign pkg.hoff (by omega) (hwin 0 pkg.hoff) h_len (by omega)
+      h_prologue_code (pkg.code_bound_of_max h_code_max))
+
+attribute [rv64_wp]
+  failureLongNBranch_pre
+
+attribute [rv64_wp_cert]
+  failureLongNBranch
+
+example
+    {base sp0 raVal s0Old s1Old s2Old outBase : Word}
+    {m0 m1 m2 m3 inputBase listLen t0Old t1Old : Word}
+    {input : List Byte} {w : Withdrawal}
+    (pkg : WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old input w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base (pkg.successCode.union (failStatusReturnCode ((base + 24) + 28))) := by
+  wp_rv64_cert
+
 example
     {base sp0 raVal s0Old s1Old s2Old outBase : Word}
     {m0 m1 m2 m3 inputBase listLen t0Old t1Old : Word}

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -938,24 +938,69 @@ theorem successFieldSpecsInput_or_decodeWithdrawal_eq_none
       exact Or.inl
         ((successFieldSpecsInput_iff_exists_decodeWithdrawal_eq_some input).2 ⟨w, hdec⟩)
 
+/-- Pure failure automation for the semantic side of withdrawal WP joins. It
+    consumes the common facts produced by validating RLP blocks: failed complete
+    decode, raw decode failure, raw decode with trailing bytes, non-list complete
+    decode, wrong list arity, bad canonical field guards, or a result-free schema
+    negation. -/
+macro "withdrawal_decode_failure" : tactic =>
+  `(tactic| first
+    | assumption
+    | exact decodeWithdrawal_none_of_decodeFully_none (by assumption)
+    | exact decodeWithdrawal_none_of_decode_none (by assumption)
+    | exact decodeWithdrawal_none_of_decode_leftover (by assumption) (by assumption)
+    | exact decodeWithdrawal_none_of_decodeFully_bytes (by assumption)
+    | exact decodeWithdrawal_none_of_decodeFully_list_length_ne_four (by assumption) (by assumption)
+    | exact decodeWithdrawal_none_of_decodeFully_fields_not_canonical (by assumption) (by assumption)
+    | exact (decodeWithdrawal_eq_none_iff_not_successFieldSpecsInput _).2 (by assumption))
+
+/-- Same automation, but returning the result-free schema failure predicate used
+    by caller-facing WP wrappers. -/
+macro "withdrawal_schema_failure" : tactic =>
+  `(tactic| exact (decodeWithdrawal_eq_none_iff_not_successFieldSpecsInput _).1
+    (by withdrawal_decode_failure))
+
 example
     (input : List Byte) (hfull : decodeFully input = none) :
     decodeWithdrawal input = none := by
-  exact decodeWithdrawal_none_of_decodeFully_none hfull
+  withdrawal_decode_failure
 
 example
     (input : List Byte) (item : RLPItem) (leftover : List Byte)
     (hdecode : decode input = some (item, leftover))
     (hleftover : leftover ≠ []) :
     decodeWithdrawal input = none := by
-  exact decodeWithdrawal_none_of_decode_leftover hdecode hleftover
+  withdrawal_decode_failure
 
 example
     (input : List Byte) (items : List RLPItem)
     (hfull : decodeFully input = some (.list items))
     (hlen : items.length ≠ 4) :
     decodeWithdrawal input = none := by
-  exact decodeWithdrawal_none_of_decodeFully_list_length_ne_four hfull hlen
+  withdrawal_decode_failure
+
+example
+    (input d0 d1 d2 d3 : List Byte)
+    (hfull : decodeFully input = some (.list [.bytes d0, .bytes d1, .bytes d2, .bytes d3]))
+    (hbad : ¬
+      (d0.headD 1 ≠ 0 ∧ d0.length ≤ 8 ∧
+        d1.headD 1 ≠ 0 ∧ d1.length ≤ 8 ∧
+        d2.length = 20 ∧
+        d3.headD 1 ≠ 0 ∧ d3.length ≤ 8)) :
+    decodeWithdrawal input = none := by
+  withdrawal_decode_failure
+
+example
+    (input : List Byte) (hfull : decodeFully input = none) :
+    ¬ successFieldSpecsInput input := by
+  withdrawal_schema_failure
+
+example
+    (input : List Byte) (items : List RLPItem)
+    (hfull : decodeFully input = some (.list items))
+    (hlen : items.length ≠ 4) :
+    ¬ successFieldSpecsInput input := by
+  withdrawal_schema_failure
 
 noncomputable example
     (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -1127,6 +1127,7 @@ noncomputable example
 -- size bound, without reconstructing the precise success witnesses.
 attribute [rv64_wp_cert]
   walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeSuccessFrameNBranch
+  walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureSuccessFrameNBranch
 
 noncomputable example
     (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
@@ -1141,6 +1142,22 @@ noncomputable example
     (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
     WP.NBranch base ((prologueCode base).union
       (walkInitShortSuccessResolvedCode (base + 24) specs)) := by
+  wp_rv64_cert
+
+noncomputable example
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_schema_size : schemaSize specs <= 1392)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base (((prologueCode base).union
+      (walkInitShortSuccessResolvedCode (base + 24) specs)).union
+      (failStatusReturnCode ((base + 24) + 28))) := by
   wp_rv64_cert
 
 theorem successFieldSpecsInput_or_decodeWithdrawal_eq_none
@@ -1363,6 +1380,22 @@ noncomputable example
     (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
     WP.NBranch base ((prologueCode base).union
       (walkInitShortSuccessResolvedCode (base + 24) specs)) := by
+  wp_withdrawal_decode_auto input
+
+noncomputable example
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_schema_size : schemaSize specs <= 1392)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base (((prologueCode base).union
+      (walkInitShortSuccessResolvedCode (base + 24) specs)).union
+      (failStatusReturnCode ((base + 24) + 28))) := by
   wp_withdrawal_decode_auto input
 
 

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -119,6 +119,59 @@ theorem walkInitShortSuccessDecodedWP_nonempty
       hpre := by
         rw [walkInitShortSuccessFromPrologueCert_pre] }⟩
 
+
+/-- Direct constructor for the decoded-success WP package.  This is the entry
+    point generated callers should use: bind the package once, then continue
+    with `pkg.cert` and `pkg.hpre` rather than manually destructing the pure
+    decoder characterization. -/
+noncomputable def walkInitShortSuccessDecodedWP
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (w : Withdrawal)
+    (hdec : decodeWithdrawal input = some w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old input w :=
+  Classical.choice (walkInitShortSuccessDecodedWP_nonempty base sp0 raVal s0Old s1Old s2Old
+    outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input w hdec hsalign hover hwin
+    hdalign hdov hdval h_len h_prologue_code h_code_max)
+
+/-- The decoded-success package exposes the same static prologue precondition as
+    the witness-heavy certificate. -/
+theorem walkInitShortSuccessDecodedWP_cert_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (w : Withdrawal)
+    (hdec : decodeWithdrawal input = some w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    (walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov hdval
+      h_len h_prologue_code h_code_max).cert.pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input) :=
+  (walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+    inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov hdval h_len
+    h_prologue_code h_code_max).hpre
+
+attribute [rv64_wp]
+  walkInitShortSuccessDecodedWP_cert_pre
+
 end WithdrawalDecode
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -307,6 +307,66 @@ theorem code_bound_of_max
   unfold specs
   omega
 
+
+/-- Code covered by the prologue-to-success certificate carried by a decoded WP
+    package.  Naming it lets generated proofs talk about the package, not the
+    extracted field witnesses. -/
+def successCode
+    {base sp0 raVal s0Old s1Old s2Old outBase : Word}
+    {m0 m1 m2 m3 inputBase listLen t0Old t1Old : Word}
+    {input : List Byte} {w : Withdrawal}
+    (pkg : WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old input w) : CodeReq :=
+  (prologueCode base).union (walkInitShortSuccessResolvedCode (base + 24) pkg.specs)
+
+/-- Postcondition of the package-carried success certificate. -/
+def successPost
+    {base sp0 raVal s0Old s1Old s2Old outBase : Word}
+    {m0 m1 m2 m3 inputBase listLen t0Old t1Old : Word}
+    {input : List Byte} {w : Withdrawal}
+    (pkg : WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old input w) : Assertion :=
+  walkInitShortSuccessAbiPost inputBase outBase raVal input pkg.d0 pkg.d1 pkg.d2 pkg.d3 **
+    walkInitShortSuccessPrologueSavedFrame sp0 raVal s0Old s1Old s2Old
+
+/-- Package projection as a WP certificate.  This is registered as a certificate
+    hint so `wp_rv64_cert` can close package-shaped success goals directly. -/
+def successCert
+    {base sp0 raVal s0Old s1Old s2Old outBase : Word}
+    {m0 m1 m2 m3 inputBase listLen t0Old t1Old : Word}
+    {input : List Byte} {w : Withdrawal}
+    (pkg : WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old input w) :
+    WP.CFG.Cert base (successStatusReturnExit raVal) pkg.successCode pkg.successPost := by
+  dsimp [successCode, successPost, specs]
+  exact pkg.cert
+
+/-- The package-shaped success certificate reduces to the static caller
+    precondition. -/
+theorem successCert_pre
+    {base sp0 raVal s0Old s1Old s2Old outBase : Word}
+    {m0 m1 m2 m3 inputBase listLen t0Old t1Old : Word}
+    {input : List Byte} {w : Withdrawal}
+    (pkg : WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old input w) :
+    pkg.successCert.pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  dsimp [successCert]
+  exact pkg.hpre
+
+attribute [rv64_wp] successCert_pre
+attribute [rv64_wp_cert] successCert
+
+example
+    {base sp0 raVal s0Old s1Old s2Old outBase : Word}
+    {m0 m1 m2 m3 inputBase listLen t0Old t1Old : Word}
+    {input : List Byte} {w : Withdrawal}
+    (pkg : WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old input w) :
+    WP.CFG.Cert base (successStatusReturnExit raVal) pkg.successCode pkg.successPost := by
+  wp_rv64_cert
+
 /-- Zero/nonzero classifier facade over the same generated code requirement as a
     decoded-success package.  This removes the last need to reconstruct the
     witness-specific `successFieldSpecs` when composing branch-level automation. -/
@@ -374,6 +434,25 @@ theorem failureNBranch_exits
 
 attribute [rv64_wp]
   failureNBranch_pre
+
+attribute [rv64_wp_cert]
+  failureNBranch
+
+example
+    {base sp0 raVal s0Old s1Old s2Old outBase : Word}
+    {m0 m1 m2 m3 inputBase listLen t0Old t1Old : Word}
+    {input : List Byte} {w : Withdrawal}
+    (pkg : WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old input w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base ((prologueCode base).union
+      (walkInitShortSuccessResolvedCode (base + 24) pkg.specs)) := by
+  wp_rv64_cert
 
 end WalkInitShortSuccessDecodedWP
 

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -1170,6 +1170,24 @@ theorem successFieldSpecsInput_or_decodeWithdrawal_eq_none
       exact Or.inl
         ((successFieldSpecsInput_iff_exists_decodeWithdrawal_eq_some input).2 ⟨w, hdec⟩)
 
+/-- Convert a validating field-post `decode` fact into the fuel-polymorphic
+    `decodeAux` continuation consumed by the short-list WP bridge. -/
+macro "wp_rlp_field_decode_aux " hDecode:term : tactic =>
+  `(tactic| exact decodeAux_bytes_all_fuel_of_decode _ _ _ _ $hDecode)
+
+/-- Exact-arity leftover failure automation for WP-generated validating field
+    walks.  It derives all four `decodeAux` continuations from local field-post
+    `decode` facts, then applies the chain-shaped withdrawal failure bridge. -/
+macro "withdrawal_decode_failure_chain " hClass:term ", " hLen:term ", " hDec0:term ", "
+    hDec1:term ", " hDec2:term ", " hDec3:term ", " hLeftover:term ", " hMin:term : tactic =>
+  `(tactic| exact decodeWithdrawal_none_of_shortList_four_leftover_chain_auto
+    $hClass $hLen
+    (by wp_rlp_field_decode_aux $hDec0)
+    (by wp_rlp_field_decode_aux $hDec1)
+    (by wp_rlp_field_decode_aux $hDec2)
+    (by wp_rlp_field_decode_aux $hDec3)
+    $hLeftover $hMin)
+
 /-- Pure failure automation for the semantic side of withdrawal WP joins. It
     consumes the common facts produced by validating RLP blocks: failed complete
     decode, raw decode failure, raw decode with trailing bytes, non-list complete
@@ -1238,6 +1256,16 @@ macro "wp_withdrawal_decode_auto " input:term : tactic =>
     | wp_withdrawal_decode_cert $input
     | wp_withdrawal_decode_auto)
 
+/-- Chain-shaped exact-arity leftover overload for generated validating field walks.
+    The four field `decodeAux` continuations are built automatically from the
+    WP field-post `decode` facts. -/
+macro "wp_withdrawal_decode_chain_auto " hClass:term ", " hLen:term ", " hDec0:term ", "
+    hDec1:term ", " hDec2:term ", " hDec3:term ", " hLeftover:term ", " hMin:term : tactic =>
+  `(tactic| first
+    | withdrawal_decode_failure_chain $hClass, $hLen, $hDec0, $hDec1, $hDec2, $hDec3,
+        $hLeftover, $hMin
+    | wp_withdrawal_decode_auto)
+
 /-- Exact-arity leftover overload for generated short-list field walks. -/
 macro "wp_withdrawal_decode_auto " hClass:term ", " hLen:term ", " h0:term ", " h1:term ", "
     h2:term ", " h3:term ", " hLeftover:term ", " hMin:term : tactic =>
@@ -1301,6 +1329,25 @@ example
         d3.headD 1 ≠ 0 ∧ d3.length ≤ 8)) :
     decodeWithdrawal input = none := by
   withdrawal_decode_failure
+
+example
+    (p0 : Byte) (r0 d0 r1 : List Byte)
+    (hdec0 : decode (p0 :: r0) = some (.bytes d0, r1)) :
+    ∀ m, decodeAux (m + 1) (p0 :: r0) = some (.bytes d0, r1) := by
+  wp_rlp_field_decode_aux hdec0
+
+example
+    (pfx p0 p1 p2 p3 : Byte) (r0 r1 r2 r3 r4 d0 d1 d2 d3 : List Byte)
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = (p0 :: r0).length)
+    (hdec0 : decode (p0 :: r0) = some (.bytes d0, p1 :: r1))
+    (hdec1 : decode (p1 :: r1) = some (.bytes d1, p2 :: r2))
+    (hdec2 : decode (p2 :: r2) = some (.bytes d2, p3 :: r3))
+    (hdec3 : decode (p3 :: r3) = some (.bytes d3, r4))
+    (h_leftover : r4 ≠ [])
+    (h_min : 2 ≤ (p0 :: r0).length) :
+    decodeWithdrawal (pfx :: p0 :: r0) = none := by
+  wp_withdrawal_decode_chain_auto h_class, h_len, hdec0, hdec1, hdec2, hdec3, h_leftover, h_min
 
 example
     (pfx : Byte) (payload d0 d1 d2 d3 : List Byte)

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -172,6 +172,38 @@ theorem walkInitShortSuccessDecodedWP_cert_pre
 attribute [rv64_wp]
   walkInitShortSuccessDecodedWP_cert_pre
 
+attribute [rv64_wp_cert]
+  walkInitShortSuccessFromPrologueCert
+
+-- Regression: `wp_rv64_cert` derives the exact generated-code bound from a
+-- uniform static schema-size cap and local arithmetic facts.
+example
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input d0 d1 d2 d3 : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hoff : 0 < input.length)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_schema_size : schemaSize (successFieldSpecs d0 d1 d2 d3) <= 1392)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.CFG.Cert base (successStatusReturnExit raVal)
+      ((prologueCode base).union
+        (walkInitShortSuccessResolvedCode (base + 24) (successFieldSpecs d0 d1 d2 d3)))
+      (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3 **
+        walkInitShortSuccessPrologueSavedFrame sp0 raVal s0Old s1Old s2Old) := by
+  wp_rv64_cert
+
 /-- Result-free success schemas are exactly the inputs for which the Lean
     withdrawal decoder returns some value. This keeps the schema predicate free
     of the decoded result while still characterizing `decodeWithdrawal`. -/

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -961,11 +961,26 @@ macro "withdrawal_decode_failure " hClass:term ", " hLen:term ", " h0:term ", " 
   `(tactic| exact decodeWithdrawal_none_of_shortList_four_leftover_auto
     $hClass $hLen $h0 $h1 $h2 $h3 $hLeftover $hMin)
 
+/-- Schema-concat leftover failure automation for generated WP schema walks.
+    The caller supplies only static field bounds, the schema payload split, and a
+    nonempty leftover; the intermediate `decodeAux` facts are derived internally. -/
+macro "withdrawal_decode_failure " hClass:term ", " hLen:term ", " hl0:term ", " hl1:term ", "
+    haddr:term ", " hl3:term ", " hPayload:term ", " hTail:term ", " hMin:term : tactic =>
+  `(tactic| exact decodeWithdrawal_none_of_shortList_successFieldSpecs_leftover_auto
+    $hClass $hLen $hl0 $hl1 $haddr $hl3 $hPayload $hTail $hMin)
+
 /-- Same automation, but returning the result-free schema failure predicate used
     by caller-facing WP wrappers. -/
 macro "withdrawal_schema_failure" : tactic =>
   `(tactic| exact (decodeWithdrawal_eq_none_iff_not_successFieldSpecsInput _).1
     (by withdrawal_decode_failure))
+
+/-- Schema-concat leftover failure automation for result-free schema predicates. -/
+macro "withdrawal_schema_failure " hClass:term ", " hLen:term ", " hl0:term ", " hl1:term ", "
+    haddr:term ", " hl3:term ", " hPayload:term ", " hTail:term ", " hMin:term : tactic =>
+  `(tactic| exact (decodeWithdrawal_eq_none_iff_not_successFieldSpecsInput _).1
+    (by withdrawal_decode_failure $hClass, $hLen, $hl0, $hl1, $haddr, $hl3, $hPayload,
+      $hTail, $hMin))
 
 example
     (input : List Byte) (hfull : decodeFully input = none) :
@@ -1015,6 +1030,18 @@ example
   withdrawal_decode_failure h_class, h_len, h0, h1, h2, h3, h_leftover, h_min
 
 example
+    (pfx : Byte) (payload tail d0 d1 d2 d3 : List Byte)
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (hl0 : d0.length ≤ 8) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20) (hl3 : d3.length ≤ 8)
+    (h_payload : payload = schemaEncBytes (successFieldSpecs d0 d1 d2 d3) ++ tail)
+    (h_tail : tail ≠ [])
+    (h_min : 2 ≤ payload.length) :
+    decodeWithdrawal (pfx :: payload) = none := by
+  withdrawal_decode_failure h_class, h_len, hl0, hl1, haddr, hl3, h_payload, h_tail, h_min
+
+example
     (input : List Byte) (hfull : decodeFully input = none) :
     ¬ successFieldSpecsInput input := by
   withdrawal_schema_failure
@@ -1025,6 +1052,18 @@ example
     (hlen : items.length ≠ 4) :
     ¬ successFieldSpecsInput input := by
   withdrawal_schema_failure
+
+example
+    (pfx : Byte) (payload tail d0 d1 d2 d3 : List Byte)
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (hl0 : d0.length ≤ 8) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20) (hl3 : d3.length ≤ 8)
+    (h_payload : payload = schemaEncBytes (successFieldSpecs d0 d1 d2 d3) ++ tail)
+    (h_tail : tail ≠ [])
+    (h_min : 2 ≤ payload.length) :
+    ¬ successFieldSpecsInput (pfx :: payload) := by
+  withdrawal_schema_failure h_class, h_len, hl0, hl1, haddr, hl3, h_payload, h_tail, h_min
 
 noncomputable example
     (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -454,8 +454,224 @@ example
       (walkInitShortSuccessResolvedCode (base + 24) pkg.specs)) := by
   wp_rv64_cert
 
+
 end WalkInitShortSuccessDecodedWP
 
+/-- Result-free package projection from a successful schema-input predicate.
+    Generated callers can keep the schema predicate free of decoded results and
+    still obtain the concrete decoded-success WP package when they need to name
+    its code or postcondition. -/
+noncomputable def walkInitShortSuccessSchemaInputPkg
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (h_success : successFieldSpecsInput input)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old input
+      (walkInitShortSuccessSchemaInputWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+        m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov
+        hdval h_len h_prologue_code h_code_max).1 :=
+  (walkInitShortSuccessSchemaInputWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+    m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov hdval
+    h_len h_prologue_code h_code_max).2
+
+/-- Success certificate projected directly from the result-free schema predicate. -/
+noncomputable def walkInitShortSuccessSchemaInputCert
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (h_success : successFieldSpecsInput input)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.CFG.Cert base (successStatusReturnExit raVal)
+      (walkInitShortSuccessSchemaInputPkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+        m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov
+        hdval h_len h_prologue_code h_code_max).successCode
+      (walkInitShortSuccessSchemaInputPkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+        m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov
+        hdval h_len h_prologue_code h_code_max).successPost :=
+  (walkInitShortSuccessSchemaInputPkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+    m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov hdval
+    h_len h_prologue_code h_code_max).successCert
+
+/-- The result-free schema-input success cert has the static prologue
+    precondition. -/
+theorem walkInitShortSuccessSchemaInputCert_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (h_success : successFieldSpecsInput input)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    (walkInitShortSuccessSchemaInputCert base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+      m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov hdval
+      h_len h_prologue_code h_code_max).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  exact (walkInitShortSuccessSchemaInputPkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1
+    m2 m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov hdval
+    h_len h_prologue_code h_code_max).successCert_pre
+
+/-- Failure classifier branch over the same resolved code as the result-free
+    schema-input success package.  This is useful when a generated proof keeps a
+    zero/nonzero disjunction in the CFG before selecting the success exit. -/
+noncomputable def walkInitShortSuccessSchemaInputFailureNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (h_success : successFieldSpecsInput input)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base ((prologueCode base).union
+      (walkInitShortSuccessResolvedCode (base + 24)
+        (walkInitShortSuccessSchemaInputPkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1
+          m2 m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov
+          hdval h_len h_prologue_code h_code_max).specs)) :=
+  (walkInitShortSuccessSchemaInputPkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+    m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov hdval
+    h_len h_prologue_code h_code_max).failureNBranch hsalign hover hwin h_len h_prologue_code
+    h_code_max
+
+/-- The result-free schema-input failure branch has the same static prologue
+    precondition as the success cert. -/
+theorem walkInitShortSuccessSchemaInputFailureNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (h_success : successFieldSpecsInput input)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    (walkInitShortSuccessSchemaInputFailureNBranch base sp0 raVal s0Old s1Old s2Old outBase
+      m0 m1 m2 m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign
+      hdov hdval h_len h_prologue_code h_code_max).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  exact (walkInitShortSuccessSchemaInputPkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1
+    m2 m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov hdval
+    h_len h_prologue_code h_code_max).failureNBranch_pre hsalign hover hwin h_len h_prologue_code
+    h_code_max
+
+/-- Result-free schema-input failure exits normalized to the nonempty,
+    reason-erased classifier shape. -/
+theorem walkInitShortSuccessSchemaInputFailureNBranch_exits
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (h_success : successFieldSpecsInput input)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    (walkInitShortSuccessSchemaInputFailureNBranch base sp0 raVal s0Old s1Old s2Old outBase
+      m0 m1 m2 m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign
+      hdov hdval h_len h_prologue_code h_code_max).exits =
+      (walkInitAbiFailureReasonErasedFromPrologueExits base sp0 raVal s0Old s1Old s2Old
+        outBase inputBase listLen t0Old t1Old input
+        (walkInitShortSuccessSchemaInputPkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1
+          m2 m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov
+          hdval h_len h_prologue_code h_code_max).hoff).map
+        (fun ex => (ex.1, ex.2 ** walkInitSchemaScratchFrame)) := by
+  exact (walkInitShortSuccessSchemaInputPkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1
+    m2 m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov hdval
+    h_len h_prologue_code h_code_max).failureNBranch_exits hsalign hover hwin h_len h_prologue_code
+    h_code_max
+
+
+attribute [rv64_wp]
+  walkInitShortSuccessSchemaInputCert_pre
+  walkInitShortSuccessSchemaInputFailureNBranch_pre
+
+attribute [rv64_wp_cert]
+  walkInitShortSuccessSchemaInputCert
+  walkInitShortSuccessSchemaInputFailureNBranch
+
+noncomputable example
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (h_success : successFieldSpecsInput input)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.CFG.Cert base (successStatusReturnExit raVal)
+      (walkInitShortSuccessSchemaInputPkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+        m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov
+        hdval h_len h_prologue_code h_code_max).successCode
+      (walkInitShortSuccessSchemaInputPkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+        m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov
+        hdval h_len h_prologue_code h_code_max).successPost := by
+  wp_rv64_cert
+
+noncomputable example
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (h_success : successFieldSpecsInput input)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base ((prologueCode base).union
+      (walkInitShortSuccessResolvedCode (base + 24)
+        (walkInitShortSuccessSchemaInputPkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1
+          m2 m3 inputBase listLen t0Old t1Old input h_success hsalign hover hwin hdalign hdov
+          hdval h_len h_prologue_code h_code_max).specs)) := by
+  wp_rv64_cert
+
 end WithdrawalDecode
+
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -982,10 +982,61 @@ macro "withdrawal_schema_failure " hClass:term ", " hLen:term ", " hl0:term ", "
     (by withdrawal_decode_failure $hClass, $hLen, $hl0, $hl1, $haddr, $hl3, $hPayload,
       $hTail, $hMin))
 
+/-- Withdrawal-domain WP automation.  This is the tactic generated proofs should
+    use at control-flow joins: it solves pure withdrawal failure/schema facts
+    first, then asks the WP certificate, entailment, and dead-exit databases. -/
+macro "wp_withdrawal_decode_auto" : tactic =>
+  `(tactic| first
+    | withdrawal_decode_failure
+    | withdrawal_schema_failure
+    | assumption
+    | omega
+    | bv_omega
+    | wp_rv64_cert
+    | wp_rv64_link
+    | wp_rv64_dead)
+
+/-- Outcome-splitting withdrawal WP automation.  When the goal is a WP
+    certificate, this first splits on the pure decoder result and exposes the
+    corresponding result-free schema fact before falling back to the generic
+    withdrawal WP driver. -/
+macro "wp_withdrawal_decode_auto " input:term : tactic =>
+  `(tactic| first
+    | wp_withdrawal_decode_cert $input
+    | wp_withdrawal_decode_auto)
+
+/-- Exact-arity leftover overload for generated short-list field walks. -/
+macro "wp_withdrawal_decode_auto " hClass:term ", " hLen:term ", " h0:term ", " h1:term ", "
+    h2:term ", " h3:term ", " hLeftover:term ", " hMin:term : tactic =>
+  `(tactic| first
+    | withdrawal_decode_failure $hClass, $hLen, $h0, $h1, $h2, $h3, $hLeftover, $hMin
+    | wp_withdrawal_decode_auto)
+
+/-- Schema-concat exact-arity leftover overload for generated withdrawal schema
+    walks.  This keeps the schema result-free while deriving the semantic
+    failure fact needed by ABI postconditions. -/
+macro "wp_withdrawal_decode_auto " hClass:term ", " hLen:term ", " hl0:term ", " hl1:term ", "
+    haddr:term ", " hl3:term ", " hPayload:term ", " hTail:term ", " hMin:term : tactic =>
+  `(tactic| first
+    | withdrawal_schema_failure $hClass, $hLen, $hl0, $hl1, $haddr, $hl3, $hPayload,
+        $hTail, $hMin
+    | withdrawal_decode_failure $hClass, $hLen, $hl0, $hl1, $haddr, $hl3, $hPayload,
+        $hTail, $hMin
+    | wp_withdrawal_decode_auto)
+
 example
     (input : List Byte) (hfull : decodeFully input = none) :
     decodeWithdrawal input = none := by
   withdrawal_decode_failure
+
+example
+    (input : List Byte) (hfull : decodeFully input = none) :
+    decodeWithdrawal input = none := by
+  wp_withdrawal_decode_auto
+
+example (P : Assertion) :
+    WP.Entails P P := by
+  wp_withdrawal_decode_auto
 
 example
     (input : List Byte) (item : RLPItem) (leftover : List Byte)
@@ -1065,6 +1116,18 @@ example
     ¬ successFieldSpecsInput (pfx :: payload) := by
   withdrawal_schema_failure h_class, h_len, hl0, hl1, haddr, hl3, h_payload, h_tail, h_min
 
+example
+    (pfx : Byte) (payload tail d0 d1 d2 d3 : List Byte)
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (hl0 : d0.length ≤ 8) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20) (hl3 : d3.length ≤ 8)
+    (h_payload : payload = schemaEncBytes (successFieldSpecs d0 d1 d2 d3) ++ tail)
+    (h_tail : tail ≠ [])
+    (h_min : 2 ≤ payload.length) :
+    ¬ successFieldSpecsInput (pfx :: payload) := by
+  wp_withdrawal_decode_auto h_class, h_len, hl0, hl1, haddr, hl3, h_payload, h_tail, h_min
+
 noncomputable example
     (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
     (inputBase listLen t0Old t1Old : Word)
@@ -1078,7 +1141,7 @@ noncomputable example
     (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
     WP.NBranch base ((prologueCode base).union
       (walkInitShortSuccessResolvedCode (base + 24) specs)) := by
-  wp_withdrawal_decode_cert input
+  wp_withdrawal_decode_auto input
 
 end WithdrawalDecode
 

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -954,6 +954,13 @@ macro "withdrawal_decode_failure" : tactic =>
     | exact decodeWithdrawal_none_of_decodeFully_fields_not_canonical (by assumption) (by assumption)
     | exact (decodeWithdrawal_eq_none_iff_not_successFieldSpecsInput _).2 (by assumption))
 
+/-- Exact-arity leftover failure automation for validated short-list paths.
+    Generated proofs pass the static branch facts produced by the WP walk. -/
+macro "withdrawal_decode_failure " hClass:term ", " hLen:term ", " h0:term ", " h1:term ", "
+    h2:term ", " h3:term ", " hLeftover:term ", " hMin:term : tactic =>
+  `(tactic| exact decodeWithdrawal_none_of_shortList_four_leftover_auto
+    $hClass $hLen $h0 $h1 $h2 $h3 $hLeftover $hMin)
+
 /-- Same automation, but returning the result-free schema failure predicate used
     by caller-facing WP wrappers. -/
 macro "withdrawal_schema_failure" : tactic =>
@@ -989,6 +996,23 @@ example
         d3.headD 1 ≠ 0 ∧ d3.length ≤ 8)) :
     decodeWithdrawal input = none := by
   withdrawal_decode_failure
+
+example
+    (pfx : Byte) (payload d0 d1 d2 d3 : List Byte)
+    (off1 off2 off3 off4 : Nat)
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (h0 : ∀ m, decodeAux (m + 1) payload = some (.bytes d0, payload.drop off1))
+    (h1 : ∀ m, decodeAux (m + 1) (payload.drop off1) =
+      some (.bytes d1, payload.drop off2))
+    (h2 : ∀ m, decodeAux (m + 1) (payload.drop off2) =
+      some (.bytes d2, payload.drop off3))
+    (h3 : ∀ m, decodeAux (m + 1) (payload.drop off3) =
+      some (.bytes d3, payload.drop off4))
+    (h_leftover : payload.drop off4 ≠ [])
+    (h_min : 2 ≤ payload.length) :
+    decodeWithdrawal (pfx :: payload) = none := by
+  withdrawal_decode_failure h_class, h_len, h0, h1, h2, h3, h_leftover, h_min
 
 example
     (input : List Byte) (hfull : decodeFully input = none) :

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -889,6 +889,29 @@ noncomputable example
           hdval h_len h_prologue_code h_code_max).specs)) := by
   wp_rv64_cert
 
+
+-- Register the generic reason-erased zero/nonzero classifier after the more
+-- specific decoded/schema-success facades. Generated proofs can then fall
+-- back to the coarse ABI failure branch when they only know a static schema
+-- size bound, without reconstructing the precise success witnesses.
+attribute [rv64_wp_cert]
+  walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeSuccessFrameNBranch
+
+noncomputable example
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_schema_size : schemaSize specs <= 1392)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base ((prologueCode base).union
+      (walkInitShortSuccessResolvedCode (base + 24) specs)) := by
+  wp_rv64_cert
+
 end WithdrawalDecode
 
 

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -220,6 +220,22 @@ theorem successFieldSpecsInput_iff_exists_decodeWithdrawal_eq_some
       ⟨d0, d1, d2, d3, hinput, hc0, hl0, hc1, hl1, haddr, hc3, hl3, _hw⟩
     exact ⟨d0, d1, d2, d3, hinput, hc0, hl0, hc1, hl1, haddr, hc3, hl3⟩
 
+/-- Solve a withdrawal WP certificate goal by first trying the certificate
+    database directly, then splitting on the pure decoder result and exposing
+    the corresponding result-free schema/failure facts to the same database. -/
+macro "wp_withdrawal_decode_cert " input:term : tactic =>
+  `(tactic| first
+    | wp_rv64_cert
+    | cases hdec : decodeWithdrawal $input with
+      | none =>
+          have h_failure : ¬ successFieldSpecsInput $input :=
+            (decodeWithdrawal_eq_none_iff_not_successFieldSpecsInput $input).1 hdec
+          wp_rv64_cert
+      | some w =>
+          have h_success : successFieldSpecsInput $input :=
+            (successFieldSpecsInput_iff_exists_decodeWithdrawal_eq_some $input).2 ⟨w, hdec⟩
+          wp_rv64_cert)
+
 /-- A result-free success-schema input is enough to produce a decoded-success WP
     package for some Lean withdrawal result. -/
 theorem walkInitShortSuccessDecodedWP_exists_of_successFieldSpecsInput
@@ -911,6 +927,50 @@ noncomputable example
     WP.NBranch base ((prologueCode base).union
       (walkInitShortSuccessResolvedCode (base + 24) specs)) := by
   wp_rv64_cert
+
+theorem successFieldSpecsInput_or_decodeWithdrawal_eq_none
+    (input : List Byte) :
+    successFieldSpecsInput input ∨ decodeWithdrawal input = none := by
+  cases hdec : decodeWithdrawal input with
+  | none =>
+      exact Or.inr rfl
+  | some w =>
+      exact Or.inl
+        ((successFieldSpecsInput_iff_exists_decodeWithdrawal_eq_some input).2 ⟨w, hdec⟩)
+
+example
+    (input : List Byte) (hfull : decodeFully input = none) :
+    decodeWithdrawal input = none := by
+  exact decodeWithdrawal_none_of_decodeFully_none hfull
+
+example
+    (input : List Byte) (item : RLPItem) (leftover : List Byte)
+    (hdecode : decode input = some (item, leftover))
+    (hleftover : leftover ≠ []) :
+    decodeWithdrawal input = none := by
+  exact decodeWithdrawal_none_of_decode_leftover hdecode hleftover
+
+example
+    (input : List Byte) (items : List RLPItem)
+    (hfull : decodeFully input = some (.list items))
+    (hlen : items.length ≠ 4) :
+    decodeWithdrawal input = none := by
+  exact decodeWithdrawal_none_of_decodeFully_list_length_ne_four hfull hlen
+
+noncomputable example
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_schema_size : schemaSize specs <= 1392)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base ((prologueCode base).union
+      (walkInitShortSuccessResolvedCode (base + 24) specs)) := by
+  wp_withdrawal_decode_cert input
 
 end WithdrawalDecode
 

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -1,0 +1,124 @@
+/-
+  EvmAsm.Rv64.RLP.WithdrawalDecodeAutoWP
+
+  Caller-facing WP automation for the withdrawal decoder success path.  The
+  generated schema code still depends on the field byte witnesses, but callers
+  only provide the pure `decodeWithdrawal` result; this module extracts the
+  witnesses and packages the resulting WP certificate.
+-/
+
+import EvmAsm.Rv64.RLP.WithdrawalDecodeSemanticWP
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL
+open EvmAsm.EL.RLP
+open EvmAsm.Rv64.Tactics
+
+namespace WithdrawalDecode
+
+theorem schemaSize_successFieldSpecs_le_1392
+    (d0 d1 d2 d3 : List Byte) (haddr : d2.length = 20) :
+    schemaSize (successFieldSpecs d0 d1 d2 d3) <= 1392 := by
+  simp [schemaSize, successFieldSpecs, fieldSize, haddr]
+  split <;> split <;> split <;> omega
+
+theorem successFieldSpecs_input_length_pos
+    (input d0 d1 d2 d3 : List Byte)
+    (hl0 : d0.length <= 8) (hl1 : d1.length <= 8)
+    (haddr : d2.length = 20) (hl3 : d3.length <= 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3)))) :
+    0 < input.length := by
+  have hpayload :=
+    schemaEncBytes_successFieldSpecs_length_le_48 d0 d1 d2 d3 hl0 hl1 haddr hl3
+  have hshort : (schemaEncBytes (successFieldSpecs d0 d1 d2 d3)).length <= 55 := by
+    omega
+  subst input
+  rw [encode_list_schemaItems_short (successFieldSpecs d0 d1 d2 d3) hshort]
+  simp
+
+/-- WP package produced from a pure successful withdrawal decode.  The schema
+    remains result-free: the decoded value is related to the postcondition only
+    through `hw`, while the generated code/cert fields are indexed by the byte
+    witnesses extracted from `decodeWithdrawal`. -/
+structure WalkInitShortSuccessDecodedWP
+    (base sp0 raVal s0Old s1Old s2Old outBase : Word)
+    (m0 m1 m2 m3 inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (w : Withdrawal) where
+  d0 : List Byte
+  d1 : List Byte
+  d2 : List Byte
+  d3 : List Byte
+  hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3)))
+  hc0 : Not (d0.headD 1 = 0)
+  hl0 : d0.length <= 8
+  hc1 : Not (d1.headD 1 = 0)
+  hl1 : d1.length <= 8
+  haddr : d2.length = 20
+  hc3 : Not (d3.headD 1 = 0)
+  hl3 : d3.length <= 8
+  hw : w = fromFieldBytes d0 d1 d2 d3
+  hoff : 0 < input.length
+  h_schema_size : schemaSize (successFieldSpecs d0 d1 d2 d3) <= 1392
+  cert : WP.CFG.Cert base (successStatusReturnExit raVal)
+    ((prologueCode base).union
+      (walkInitShortSuccessResolvedCode (base + 24) (successFieldSpecs d0 d1 d2 d3)))
+    (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3 **
+      walkInitShortSuccessPrologueSavedFrame sp0 raVal s0Old s1Old s2Old)
+  hpre : cert.pre =
+    (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+      walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input)
+
+/-- Decode-driven automation for the prologue-to-success WP slice.  It consumes
+    the pure decoder result and a uniform static code-size bound, then proves that
+    the same generated WP package as the witness-heavy constructor is available. -/
+theorem walkInitShortSuccessDecodedWP_nonempty
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (w : Withdrawal)
+    (hdec : decodeWithdrawal input = some w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    Nonempty (WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old input w) := by
+  rcases successFieldSpecs_input_of_decodeWithdrawal_eq_some input w hdec with
+    ⟨d0, d1, d2, d3, hinput, hc0, hl0, hc1, hl1, haddr, hc3, hl3, hw⟩
+  have hoff := successFieldSpecs_input_length_pos input d0 d1 d2 d3 hl0 hl1 haddr hl3 hinput
+  have h_schema_size := schemaSize_successFieldSpecs_le_1392 d0 d1 d2 d3 haddr
+  have hcode : (base + 24).toNat + 172 + 4 +
+      schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64 := by
+    omega
+  exact ⟨
+    { d0 := d0
+      d1 := d1
+      d2 := d2
+      d3 := d3
+      hinput := hinput
+      hc0 := hc0
+      hl0 := hl0
+      hc1 := hc1
+      hl1 := hl1
+      haddr := haddr
+      hc3 := hc3
+      hl3 := hl3
+      hw := hw
+      hoff := hoff
+      h_schema_size := h_schema_size
+      cert := walkInitShortSuccessFromPrologueCert base sp0 raVal s0Old s1Old s2Old outBase
+        m0 m1 m2 m3 inputBase listLen t0Old t1Old input d0 d1 d2 d3 hsalign hoff hover
+        hwin hdalign hdov hdval hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput h_len h_prologue_code
+        hcode
+      hpre := by
+        rw [walkInitShortSuccessFromPrologueCert_pre] }⟩
+
+end WithdrawalDecode
+
+end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -487,7 +487,193 @@ example
   wp_rv64_cert
 
 
+
 end WalkInitShortSuccessDecodedWP
+
+/-- Success certificate projected directly from a pure successful decode result.
+    Generated callers can provide `decodeWithdrawal input = some w` and static
+    memory/code facts; the field-byte witness package stays internal. -/
+noncomputable def walkInitShortSuccessDecodedCert
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (w : Withdrawal)
+    (hdec : decodeWithdrawal input = some w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.CFG.Cert base (successStatusReturnExit raVal)
+      (walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+        inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov hdval
+        h_len h_prologue_code h_code_max).successCode
+      (walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+        inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov hdval
+        h_len h_prologue_code h_code_max).successPost :=
+  (walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+    inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov hdval
+    h_len h_prologue_code h_code_max).successCert
+
+/-- The decoded-result success cert has the static prologue precondition. -/
+theorem walkInitShortSuccessDecodedCert_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (w : Withdrawal)
+    (hdec : decodeWithdrawal input = some w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    (walkInitShortSuccessDecodedCert base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+      m3 inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov hdval
+      h_len h_prologue_code h_code_max).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  exact (walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+    m3 inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov hdval
+    h_len h_prologue_code h_code_max).successCert_pre
+
+/-- Failure classifier branch over the same resolved code as the decoded-success
+    package, without exposing the package to generated callers. -/
+noncomputable def walkInitShortSuccessDecodedFailureNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (w : Withdrawal)
+    (hdec : decodeWithdrawal input = some w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base ((prologueCode base).union
+      (walkInitShortSuccessResolvedCode (base + 24)
+        (walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+          m3 inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov
+          hdval h_len h_prologue_code h_code_max).specs)) :=
+  (walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+    inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov hdval
+    h_len h_prologue_code h_code_max).failureNBranch hsalign hover hwin h_len h_prologue_code
+    h_code_max
+
+/-- The decoded-result failure branch has the same static prologue precondition
+    as the decoded success cert. -/
+theorem walkInitShortSuccessDecodedFailureNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (w : Withdrawal)
+    (hdec : decodeWithdrawal input = some w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    (walkInitShortSuccessDecodedFailureNBranch base sp0 raVal s0Old s1Old s2Old outBase
+      m0 m1 m2 m3 inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign
+      hdov hdval h_len h_prologue_code h_code_max).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  exact (walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+    m3 inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov hdval
+    h_len h_prologue_code h_code_max).failureNBranch_pre hsalign hover hwin h_len h_prologue_code
+    h_code_max
+
+/-- Decoded-result failure exits normalized to the nonempty, reason-erased shape. -/
+theorem walkInitShortSuccessDecodedFailureNBranch_exits
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (w : Withdrawal)
+    (hdec : decodeWithdrawal input = some w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    (walkInitShortSuccessDecodedFailureNBranch base sp0 raVal s0Old s1Old s2Old outBase
+      m0 m1 m2 m3 inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign
+      hdov hdval h_len h_prologue_code h_code_max).exits =
+      (walkInitAbiFailureReasonErasedFromPrologueExits base sp0 raVal s0Old s1Old s2Old
+        outBase inputBase listLen t0Old t1Old input
+        (walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+          m3 inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov
+          hdval h_len h_prologue_code h_code_max).hoff).map
+        (fun ex => (ex.1, ex.2 ** walkInitSchemaScratchFrame)) := by
+  exact (walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+    m3 inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov hdval
+    h_len h_prologue_code h_code_max).failureNBranch_exits hsalign hover hwin h_len h_prologue_code
+    h_code_max
+
+attribute [rv64_wp]
+  walkInitShortSuccessDecodedCert_pre
+  walkInitShortSuccessDecodedFailureNBranch_pre
+
+attribute [rv64_wp_cert]
+  walkInitShortSuccessDecodedCert
+  walkInitShortSuccessDecodedFailureNBranch
+
+noncomputable example
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (w : Withdrawal)
+    (hdec : decodeWithdrawal input = some w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.CFG.Cert base (successStatusReturnExit raVal)
+      (walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+        inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov hdval
+        h_len h_prologue_code h_code_max).successCode
+      (walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+        inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov hdval
+        h_len h_prologue_code h_code_max).successPost := by
+  wp_rv64_cert
+
+noncomputable example
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (w : Withdrawal)
+    (hdec : decodeWithdrawal input = some w)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : forall i, i < input.length -> isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : forall i, i < outputSize -> isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len : listLen = BitVec.ofNat 64 input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base ((prologueCode base).union
+      (walkInitShortSuccessResolvedCode (base + 24)
+        (walkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+          m3 inputBase listLen t0Old t1Old input w hdec hsalign hover hwin hdalign hdov
+          hdval h_len h_prologue_code h_code_max).specs)) := by
+  wp_rv64_cert
 
 /-- Result-free package projection from a successful schema-input predicate.
     Generated callers can keep the schema predicate free of decoded results and

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeAutoWP.lean
@@ -895,7 +895,7 @@ noncomputable example
 -- back to the coarse ABI failure branch when they only know a static schema
 -- size bound, without reconstructing the precise success witnesses.
 attribute [rv64_wp_cert]
-  walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeSuccessFrameNBranch
+  walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeSuccessFrameNBranch
 
 noncomputable example
     (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeChainWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeChainWP.lean
@@ -517,6 +517,39 @@ macro "withdrawal_leftover_decode_chain" : tactic => do
   `(tactic| exact LeftoverDecodeChain.ofLocalFacts $h_class_stx:ident $h_len_stx:ident $h_dec0_stx:ident
     $h_dec1_stx:ident $h_dec2_stx:ident $h_dec3_stx:ident $h_leftover_stx:ident $h_min_stx:ident)
 
+/-- Synthesize a success outcome from the generated local names. -/
+macro "withdrawal_success_decode_outcome" : tactic =>
+  `(tactic| exact DecodeChainOutcome.success (by withdrawal_success_decode_chain))
+
+/-- Synthesize an exact-arity leftover outcome from the generated local names. -/
+macro "withdrawal_leftover_decode_outcome" : tactic =>
+  `(tactic| exact DecodeChainOutcome.leftover (by withdrawal_leftover_decode_chain))
+
+/-- Synthesize whichever exact-arity withdrawal outcome is available in the
+    current generated branch context. -/
+macro "withdrawal_decode_outcome" : tactic =>
+  `(tactic| first
+    | withdrawal_success_decode_outcome
+    | withdrawal_leftover_decode_outcome)
+
+/-- Explicit success-outcome constructor for generated proofs with nonstandard
+    local names. -/
+macro "withdrawal_success_decode_outcome " hclass:term ", " hlen:term ", " hdec0:term ", "
+    hdec1:term ", " hdec2:term ", " hdec3:term ", " hend:term ", " hmin:term ", "
+    hc0:term ", " hl0:term ", " hc1:term ", " hl1:term ", " haddr:term ", "
+    hc3:term ", " hl3:term : tactic =>
+  `(tactic| exact DecodeChainOutcome.success (SuccessDecodeChain.ofLocalFacts
+    $hclass $hlen $hdec0 $hdec1 $hdec2 $hdec3 $hend $hmin $hc0 $hl0 $hc1 $hl1
+    $haddr $hc3 $hl3))
+
+/-- Explicit leftover-outcome constructor for generated proofs with nonstandard
+    local names. -/
+macro "withdrawal_leftover_decode_outcome " hclass:term ", " hlen:term ", " hdec0:term ", "
+    hdec1:term ", " hdec2:term ", " hdec3:term ", " hleftover:term ", "
+    hmin:term : tactic =>
+  `(tactic| exact DecodeChainOutcome.leftover (LeftoverDecodeChain.ofLocalFacts
+    $hclass $hlen $hdec0 $hdec1 $hdec2 $hdec3 $hleftover $hmin))
+
 /-- Context-driven WP automation for generated successful field-walk proofs.
     It derives semantic success or the result-free schema fact from the standard
     local names, then falls through to the WP certificate/link/dead-exit
@@ -689,10 +722,40 @@ example
     (hdec1 : decode r1 = some (.bytes d1, r2))
     (hdec2 : decode r2 = some (.bytes d2, r3))
     (hdec3 : decode r3 = some (.bytes d3, r4))
+    (hend : r4 = [])
+    (h_min : 2 ≤ payload.length)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8) :
+    DecodeChainOutcome pfx payload := by
+  withdrawal_decode_outcome
+
+example
+    {pfx : Byte} {payload r1 r2 r3 r4 d0 d1 d2 d3 : List Byte}
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (hdec0 : decode payload = some (.bytes d0, r1))
+    (hdec1 : decode r1 = some (.bytes d1, r2))
+    (hdec2 : decode r2 = some (.bytes d2, r3))
+    (hdec3 : decode r3 = some (.bytes d3, r4))
     (h_leftover : r4 ≠ [])
     (h_min : 2 ≤ payload.length) :
     decodeWithdrawal (pfx :: payload) = none := by
   wp_withdrawal_decode_leftover_chain
+
+example
+    {pfx : Byte} {payload r1 r2 r3 r4 d0 d1 d2 d3 : List Byte}
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (hdec0 : decode payload = some (.bytes d0, r1))
+    (hdec1 : decode r1 = some (.bytes d1, r2))
+    (hdec2 : decode r2 = some (.bytes d2, r3))
+    (hdec3 : decode r3 = some (.bytes d3, r4))
+    (h_leftover : r4 ≠ [])
+    (h_min : 2 ≤ payload.length) :
+    DecodeChainOutcome pfx payload := by
+  withdrawal_decode_outcome
 
 example
     {pfx : Byte} {payload : List Byte} (chain : SuccessDecodeChain pfx payload) :

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeChainWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeChainWP.lean
@@ -935,6 +935,63 @@ elab "wp_withdrawal_decode_walk" : tactic => withMainContext do
               restoreState saved
   throwError "wp_withdrawal_decode_walk: no four-field withdrawal decode walk closed the goal"
 
+
+private def successFieldSpecsInputArg? (e : Expr) : Option Expr :=
+  if e.isAppOfArity ``EvmAsm.Rv64.RLP.WithdrawalDecode.successFieldSpecsInput 1 then
+    some e.getAppArgs[0]!
+  else
+    none
+
+private def decodeWithdrawalNoneArg? (e : Expr) : Option Expr := do
+  let (lhs, rhs) ← eqSides? e
+  guard (lhs.isAppOfArity ``EvmAsm.EL.decodeWithdrawal 1)
+  guard (rhs.isAppOfArity ``Option.none 1)
+  some lhs.getAppArgs[0]!
+
+private def isResultFreeDecodeSplitLocalType (e : Expr) : TacticM Bool := do
+  unless e.isAppOfArity ``Or 2 do
+    return false
+  let args := e.getAppArgs
+  let some successInput := successFieldSpecsInputArg? args[0]! | return false
+  let some failureInput := decodeWithdrawalNoneArg? args[1]! | return false
+  sameExpr successInput failureInput
+
+/-- Consume a result-free branch join of the form
+    `successFieldSpecsInput input ∨ decodeWithdrawal input = none`.  The success
+    branch exposes the schema predicate, while the failure branch exposes only
+    the reason-erased semantic failure fact. -/
+elab "wp_withdrawal_decode_split" : tactic => withMainContext do
+  let lctx ← getLCtx
+  for localDecl in lctx do
+    if localDecl.isImplementationDetail then
+      continue
+    let localType ← whnfR (← instantiateMVars localDecl.type)
+    unless ← isResultFreeDecodeSplitLocalType localType do
+      continue
+    let id := Lean.mkIdent localDecl.userName
+    try
+      evalTactic (← `(tactic|
+        cases $id:ident with
+        | inl h_success =>
+            first
+            | exact h_success
+            | exact (successFieldSpecsInput_iff_exists_decodeWithdrawal_eq_some _).mp h_success
+            | left; exact h_success
+            | left; exact (successFieldSpecsInput_iff_exists_decodeWithdrawal_eq_some _).mp h_success
+            | wp_withdrawal_decode_auto
+        | inr h_failure =>
+            first
+            | exact h_failure
+            | exact (decodeWithdrawal_eq_none_iff_not_successFieldSpecsInput _).1 h_failure
+            | right; exact h_failure
+            | right; exact (decodeWithdrawal_eq_none_iff_not_successFieldSpecsInput _).1 h_failure
+            | wp_withdrawal_decode_auto
+        done))
+      return
+    catch _ =>
+      (Pure.pure PUnit.unit : TacticM PUnit)
+  throwError "wp_withdrawal_decode_split: no result-free schema/failure split closed the goal"
+
 private def isDecodeChainLocalType (e : Expr) : Bool :=
   e.isAppOfArity ``SuccessDecodeChain 2 ||
     e.isAppOfArity ``LeftoverDecodeChain 2 ||
@@ -957,6 +1014,11 @@ elab "wp_withdrawal_decode_chain" : tactic => withMainContext do
       return
     catch _ =>
       (Pure.pure PUnit.unit : TacticM PUnit)
+  try
+    evalTactic (← `(tactic| wp_withdrawal_decode_split; done))
+    return
+  catch _ =>
+    (Pure.pure PUnit.unit : TacticM PUnit)
   try
     evalTactic (← `(tactic| wp_withdrawal_decode_walk; done))
     return
@@ -1008,6 +1070,11 @@ elab "wp_withdrawal_decode_outcome" : tactic => withMainContext do
       return
     catch _ =>
       (Pure.pure PUnit.unit : TacticM PUnit)
+  try
+    evalTactic (← `(tactic| wp_withdrawal_decode_split; done))
+    return
+  catch _ =>
+    (Pure.pure PUnit.unit : TacticM PUnit)
   try
     evalTactic (← `(tactic| wp_withdrawal_decode_walk; done))
   catch _ =>
@@ -1103,6 +1170,17 @@ example
     (min_fact : 2 ≤ payload.length) :
     (∃ w : Withdrawal, decodeWithdrawal (pfx :: payload) = some w) ∨
       decodeWithdrawal (pfx :: payload) = none := by
+  wp_withdrawal_decode_outcome
+
+
+example (input : List Byte)
+    (h_split : successFieldSpecsInput input ∨ decodeWithdrawal input = none) :
+    (∃ w : Withdrawal, decodeWithdrawal input = some w) ∨ decodeWithdrawal input = none := by
+  wp_withdrawal_decode_split
+
+example (input : List Byte)
+    (h_split : successFieldSpecsInput input ∨ decodeWithdrawal input = none) :
+    successFieldSpecsInput input ∨ decodeWithdrawal input = none := by
   wp_withdrawal_decode_outcome
 
 example

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeChainWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeChainWP.lean
@@ -627,6 +627,314 @@ macro "wp_withdrawal_decode_chain " chain:term : tactic =>
 
 open Lean Meta Elab Tactic
 
+private def getNatLitVal? (e : Expr) : Option Nat :=
+  match e with
+  | .lit (.natVal n) => some n
+  | _ =>
+      if e.isAppOfArity ``OfNat.ofNat 3 then
+        match e.getAppArgs[1]! with
+        | .lit (.natVal n) => some n
+        | _ => none
+      else
+        none
+
+private def sameExpr (a b : Expr) : TacticM Bool :=
+  withoutModifyingState (isDefEq a b)
+
+private def eqSides? (e : Expr) : Option (Expr × Expr) :=
+  if e.isAppOfArity ``Eq 3 then
+    let args := e.getAppArgs
+    some (args[1]!, args[2]!)
+  else
+    none
+
+private def isConst (e : Expr) (name : Name) : Bool :=
+  match e.getAppFn with
+  | .const n _ => n == name
+  | _ => false
+
+private def listLengthArg? (e : Expr) : Option Expr :=
+  if e.isAppOfArity ``List.length 2 then
+    some e.getAppArgs[1]!
+  else
+    none
+
+private def listNil? (e : Expr) : Bool :=
+  e.isAppOfArity ``List.nil 1
+
+private structure NamedClassFact where
+  name : Name
+  pfx : Expr
+
+private structure NamedLenFact where
+  name : Name
+  pfx : Expr
+  payload : Expr
+
+private structure NamedDecodeFact where
+  name : Name
+  input : Expr
+  data : Expr
+  rest : Expr
+
+private structure NamedEndFact where
+  name : Name
+  rest : Expr
+
+private structure NamedMinFact where
+  name : Name
+  payload : Expr
+
+private structure NamedHeadNeZeroFact where
+  name : Name
+  data : Expr
+
+private structure NamedLenLeFact where
+  name : Name
+  data : Expr
+  bound : Nat
+
+private structure NamedLenEqFact where
+  name : Name
+  data : Expr
+  value : Nat
+
+private structure WalkFactDb where
+  classes : Array NamedClassFact := #[]
+  lens : Array NamedLenFact := #[]
+  decodes : Array NamedDecodeFact := #[]
+  ends : Array NamedEndFact := #[]
+  leftovers : Array NamedEndFact := #[]
+  mins : Array NamedMinFact := #[]
+  headNeZeros : Array NamedHeadNeZeroFact := #[]
+  lenLes : Array NamedLenLeFact := #[]
+  lenEqs : Array NamedLenEqFact := #[]
+
+private def parseClassFact? (name : Name) (type : Expr) : Option NamedClassFact := do
+  let (lhs, rhs) ← eqSides? type
+  guard (lhs.isAppOfArity ``EvmAsm.EL.RLP.classifyPrefix 1)
+  guard (isConst rhs ``EvmAsm.EL.RLP.PrefixClass.shortList)
+  some { name := name, pfx := lhs.getAppArgs[0]! }
+
+private def parseLenFact? (name : Name) (type : Expr) : Option NamedLenFact := do
+  let (lhs, rhs) ← eqSides? type
+  guard (lhs.isAppOfArity ``EvmAsm.EL.RLP.rlpPrefixShortListPayloadLen 1)
+  let payload ← listLengthArg? rhs
+  some { name := name, pfx := lhs.getAppArgs[0]!, payload := payload }
+
+private def parseDecodeFact? (name : Name) (type : Expr) : Option NamedDecodeFact := do
+  let (lhs, rhs) ← eqSides? type
+  guard (lhs.isAppOfArity ``EvmAsm.EL.RLP.decode 1)
+  guard (rhs.isAppOfArity ``Option.some 2)
+  let pair := rhs.getAppArgs[1]!
+  guard (pair.isAppOfArity ``Prod.mk 4)
+  let item := pair.getAppArgs[2]!
+  guard (item.isAppOfArity ``EvmAsm.EL.RLP.RLPItem.bytes 1)
+  some {
+    name := name
+    input := lhs.getAppArgs[0]!
+    data := item.getAppArgs[0]!
+    rest := pair.getAppArgs[3]!
+  }
+
+private def parseEndFact? (name : Name) (type : Expr) : Option NamedEndFact := do
+  let (lhs, rhs) ← eqSides? type
+  guard (listNil? rhs)
+  some { name := name, rest := lhs }
+
+private def parseLeftoverFact? (name : Name) (type : Expr) : Option NamedEndFact := do
+  guard (type.isAppOfArity ``Ne 3)
+  let args := type.getAppArgs
+  guard (listNil? args[2]!)
+  some { name := name, rest := args[1]! }
+
+private def parseMinFact? (name : Name) (type : Expr) : Option NamedMinFact := do
+  guard (type.isAppOfArity ``LE.le 4)
+  let args := type.getAppArgs
+  guard (getNatLitVal? args[2]! == some 2)
+  let payload ← listLengthArg? args[3]!
+  some { name := name, payload := payload }
+
+private def parseHeadNeZeroFact? (name : Name) (type : Expr) : Option NamedHeadNeZeroFact := do
+  guard (type.isAppOfArity ``Ne 3)
+  let args := type.getAppArgs
+  guard (args[1]!.isAppOfArity ``List.headD 3)
+  guard (getNatLitVal? args[1]!.getAppArgs[2]! == some 1)
+  guard (getNatLitVal? args[2]! == some 0)
+  some { name := name, data := args[1]!.getAppArgs[1]! }
+
+private def parseLenLeFact? (name : Name) (type : Expr) : Option NamedLenLeFact := do
+  guard (type.isAppOfArity ``LE.le 4)
+  let args := type.getAppArgs
+  let data ← listLengthArg? args[2]!
+  let bound ← getNatLitVal? args[3]!
+  some { name := name, data := data, bound := bound }
+
+private def parseLenEqFact? (name : Name) (type : Expr) : Option NamedLenEqFact := do
+  let (lhs, rhs) ← eqSides? type
+  let data ← listLengthArg? lhs
+  let value ← getNatLitVal? rhs
+  some { name := name, data := data, value := value }
+
+private def collectWalkFactDb : TacticM WalkFactDb := do
+  let mut db : WalkFactDb := {}
+  for localDecl in ← getLCtx do
+    if localDecl.isImplementationDetail then
+      continue
+    let type ← instantiateMVars localDecl.type
+    let name := localDecl.userName
+    if let some fact := parseClassFact? name type then
+      db := { db with classes := db.classes.push fact }
+    if let some fact := parseLenFact? name type then
+      db := { db with lens := db.lens.push fact }
+    if let some fact := parseDecodeFact? name type then
+      db := { db with decodes := db.decodes.push fact }
+    if let some fact := parseEndFact? name type then
+      db := { db with ends := db.ends.push fact }
+    if let some fact := parseLeftoverFact? name type then
+      db := { db with leftovers := db.leftovers.push fact }
+    if let some fact := parseMinFact? name type then
+      db := { db with mins := db.mins.push fact }
+    if let some fact := parseHeadNeZeroFact? name type then
+      db := { db with headNeZeros := db.headNeZeros.push fact }
+    if let some fact := parseLenLeFact? name type then
+      db := { db with lenLes := db.lenLes.push fact }
+    if let some fact := parseLenEqFact? name type then
+      db := { db with lenEqs := db.lenEqs.push fact }
+  return db
+
+private def findClassFact? (db : WalkFactDb) (pfx : Expr) : TacticM (Option Name) := do
+  for fact in db.classes do
+    if ← sameExpr fact.pfx pfx then
+      return some fact.name
+  return none
+
+private def findDecodeFrom? (db : WalkFactDb) (input : Expr) :
+    TacticM (Array NamedDecodeFact) := do
+  let mut out := #[]
+  for fact in db.decodes do
+    if ← sameExpr fact.input input then
+      out := out.push fact
+  return out
+
+private def findEndFact? (facts : Array NamedEndFact) (rest : Expr) :
+    TacticM (Option Name) := do
+  for fact in facts do
+    if ← sameExpr fact.rest rest then
+      return some fact.name
+  return none
+
+private def findMinFact? (db : WalkFactDb) (payload : Expr) : TacticM (Option Name) := do
+  for fact in db.mins do
+    if ← sameExpr fact.payload payload then
+      return some fact.name
+  return none
+
+private def findHeadNeZeroFact? (db : WalkFactDb) (data : Expr) :
+    TacticM (Option Name) := do
+  for fact in db.headNeZeros do
+    if ← sameExpr fact.data data then
+      return some fact.name
+  return none
+
+private def findLenLeFact? (db : WalkFactDb) (data : Expr) (bound : Nat) :
+    TacticM (Option Name) := do
+  for fact in db.lenLes do
+    if fact.bound == bound then
+      if ← sameExpr fact.data data then
+        return some fact.name
+  return none
+
+private def findLenEqFact? (db : WalkFactDb) (data : Expr) (value : Nat) :
+    TacticM (Option Name) := do
+  for fact in db.lenEqs do
+    if fact.value == value then
+      if ← sameExpr fact.data data then
+        return some fact.name
+  return none
+
+private def factIdent (name : Name) : TSyntax `term :=
+  ⟨mkIdent name⟩
+
+private def tryCloseWithSuccessWalk (className lenName dec0Name dec1Name dec2Name dec3Name endName minName
+    canon0Name len0Name canon1Name len1Name addrName canon3Name len3Name : Name) : TacticM Unit := do
+  let className := factIdent className
+  let lenName := factIdent lenName
+  let dec0Name := factIdent dec0Name
+  let dec1Name := factIdent dec1Name
+  let dec2Name := factIdent dec2Name
+  let dec3Name := factIdent dec3Name
+  let endName := factIdent endName
+  let minName := factIdent minName
+  let canon0Name := factIdent canon0Name
+  let len0Name := factIdent len0Name
+  let canon1Name := factIdent canon1Name
+  let len1Name := factIdent len1Name
+  let addrName := factIdent addrName
+  let canon3Name := factIdent canon3Name
+  let len3Name := factIdent len3Name
+  evalTactic (← `(tactic|
+    wp_withdrawal_decode_chain (SuccessDecodeChain.ofLocalFacts
+      $className $lenName $dec0Name $dec1Name $dec2Name $dec3Name $endName $minName $canon0Name $len0Name $canon1Name
+      $len1Name $addrName $canon3Name $len3Name); done))
+
+private def tryCloseWithLeftoverWalk (className lenName dec0Name dec1Name dec2Name dec3Name leftoverName
+    minName : Name) : TacticM Unit := do
+  let className := factIdent className
+  let lenName := factIdent lenName
+  let dec0Name := factIdent dec0Name
+  let dec1Name := factIdent dec1Name
+  let dec2Name := factIdent dec2Name
+  let dec3Name := factIdent dec3Name
+  let leftoverName := factIdent leftoverName
+  let minName := factIdent minName
+  evalTactic (← `(tactic|
+    wp_withdrawal_decode_chain (LeftoverDecodeChain.ofLocalFacts
+      $className $lenName $dec0Name $dec1Name $dec2Name $dec3Name $leftoverName $minName); done))
+
+/-- Type-directed WP automation for generated four-field withdrawal walks.
+    It finds the local classifier, short-list length, field `decode` chain, and
+    either the success guards or leftover fact, then delegates to the existing
+    chain-object WP driver.  This avoids threading a manual `DecodeChainOutcome`
+    through branch joins. -/
+elab "wp_withdrawal_decode_walk" : tactic => withMainContext do
+  let db ← collectWalkFactDb
+  for lenFact in db.lens do
+    let some className ← findClassFact? db lenFact.pfx | continue
+    let dec0s ← findDecodeFrom? db lenFact.payload
+    for dec0 in dec0s do
+      let dec1s ← findDecodeFrom? db dec0.rest
+      for dec1 in dec1s do
+        let dec2s ← findDecodeFrom? db dec1.rest
+        for dec2 in dec2s do
+          let dec3s ← findDecodeFrom? db dec2.rest
+          for dec3 in dec3s do
+            let some minName ← findMinFact? db lenFact.payload | continue
+            let saved ← saveState
+            try
+              let some endName ← findEndFact? db.ends dec3.rest | throwError "no end fact"
+              let some canon0Name ← findHeadNeZeroFact? db dec0.data | throwError "no field 0 canonicality fact"
+              let some len0Name ← findLenLeFact? db dec0.data 8 | throwError "no field 0 length fact"
+              let some canon1Name ← findHeadNeZeroFact? db dec1.data | throwError "no field 1 canonicality fact"
+              let some len1Name ← findLenLeFact? db dec1.data 8 | throwError "no field 1 length fact"
+              let some addrName ← findLenEqFact? db dec2.data 20 | throwError "no address length fact"
+              let some canon3Name ← findHeadNeZeroFact? db dec3.data | throwError "no field 3 canonicality fact"
+              let some len3Name ← findLenLeFact? db dec3.data 8 | throwError "no field 3 length fact"
+              tryCloseWithSuccessWalk className lenFact.name dec0.name dec1.name dec2.name dec3.name
+                endName minName canon0Name len0Name canon1Name len1Name addrName canon3Name len3Name
+              return
+            catch _ =>
+              restoreState saved
+            let saved ← saveState
+            try
+              let some leftoverName ← findEndFact? db.leftovers dec3.rest | throwError "no leftover fact"
+              tryCloseWithLeftoverWalk className lenFact.name dec0.name dec1.name dec2.name dec3.name
+                leftoverName minName
+              return
+            catch _ =>
+              restoreState saved
+  throwError "wp_withdrawal_decode_walk: no four-field withdrawal decode walk closed the goal"
+
 private def isDecodeChainLocalType (e : Expr) : Bool :=
   e.isAppOfArity ``SuccessDecodeChain 2 ||
     e.isAppOfArity ``LeftoverDecodeChain 2 ||
@@ -649,6 +957,11 @@ elab "wp_withdrawal_decode_chain" : tactic => withMainContext do
       return
     catch _ =>
       (Pure.pure PUnit.unit : TacticM PUnit)
+  try
+    evalTactic (← `(tactic| wp_withdrawal_decode_walk; done))
+    return
+  catch _ =>
+    (Pure.pure PUnit.unit : TacticM PUnit)
   try
     evalTactic (← `(tactic| wp_withdrawal_decode_auto; done))
   catch _ =>
@@ -695,7 +1008,10 @@ elab "wp_withdrawal_decode_outcome" : tactic => withMainContext do
       return
     catch _ =>
       (Pure.pure PUnit.unit : TacticM PUnit)
-  throwError "wp_withdrawal_decode_outcome: no local decode-chain outcome closed the goal"
+  try
+    evalTactic (← `(tactic| wp_withdrawal_decode_walk; done))
+  catch _ =>
+    throwError "wp_withdrawal_decode_outcome: no local decode-chain outcome closed the goal"
 
 example
     {pfx : Byte} {payload r1 r2 r3 r4 d0 d1 d2 d3 : List Byte}
@@ -756,6 +1072,38 @@ example
     (h_min : 2 ≤ payload.length) :
     DecodeChainOutcome pfx payload := by
   withdrawal_decode_outcome
+
+
+example
+    {pfx : Byte} {payload rem1 rem2 rem3 rem4 field0 field1 field2 field3 : List Byte}
+    (class_fact : classifyPrefix pfx = .shortList)
+    (len_fact : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (decode0_fact : decode payload = some (.bytes field0, rem1))
+    (decode1_fact : decode rem1 = some (.bytes field1, rem2))
+    (decode2_fact : decode rem2 = some (.bytes field2, rem3))
+    (decode3_fact : decode rem3 = some (.bytes field3, rem4))
+    (end_fact : rem4 = [])
+    (min_fact : 2 ≤ payload.length)
+    (canon0_fact : field0.headD 1 ≠ 0) (len0_fact : field0.length ≤ 8)
+    (canon1_fact : field1.headD 1 ≠ 0) (len1_fact : field1.length ≤ 8)
+    (addr_fact : field2.length = 20)
+    (canon3_fact : field3.headD 1 ≠ 0) (len3_fact : field3.length ≤ 8) :
+    successFieldSpecsInput (pfx :: payload) ∨ decodeWithdrawal (pfx :: payload) = none := by
+  wp_withdrawal_decode_walk
+
+example
+    {pfx : Byte} {payload rem1 rem2 rem3 rem4 field0 field1 field2 field3 : List Byte}
+    (class_fact : classifyPrefix pfx = .shortList)
+    (len_fact : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (decode0_fact : decode payload = some (.bytes field0, rem1))
+    (decode1_fact : decode rem1 = some (.bytes field1, rem2))
+    (decode2_fact : decode rem2 = some (.bytes field2, rem3))
+    (decode3_fact : decode rem3 = some (.bytes field3, rem4))
+    (leftover_fact : rem4 ≠ [])
+    (min_fact : 2 ≤ payload.length) :
+    (∃ w : Withdrawal, decodeWithdrawal (pfx :: payload) = some w) ∨
+      decodeWithdrawal (pfx :: payload) = none := by
+  wp_withdrawal_decode_outcome
 
 example
     {pfx : Byte} {payload : List Byte} (chain : SuccessDecodeChain pfx payload) :

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeChainWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeChainWP.lean
@@ -594,6 +594,11 @@ macro "wp_withdrawal_decode_chain " chain:term : tactic =>
 
 open Lean Meta Elab Tactic
 
+private def isDecodeChainLocalType (e : Expr) : Bool :=
+  e.isAppOfArity ``SuccessDecodeChain 2 ||
+    e.isAppOfArity ``LeftoverDecodeChain 2 ||
+    e.isAppOfArity ``DecodeChainOutcome 2
+
 /-- Context-driven chain WP automation.  It scans local hypotheses for already
     bundled success/leftover chain objects, projects the needed pure fact, and
     then falls back to the generic withdrawal WP driver. -/
@@ -601,6 +606,9 @@ elab "wp_withdrawal_decode_chain" : tactic => withMainContext do
   let lctx ← getLCtx
   for localDecl in lctx do
     if localDecl.isImplementationDetail then
+      continue
+    let localType ← whnfR (← instantiateMVars localDecl.type)
+    unless isDecodeChainLocalType localType do
       continue
     let id := Lean.mkIdent localDecl.userName
     try
@@ -710,6 +718,11 @@ example
     {pfx : Byte} {payload : List Byte} (outcome : DecodeChainOutcome pfx payload) :
     successFieldSpecsInput outcome.input ∨ decodeWithdrawal outcome.input = none := by
   wp_withdrawal_decode_outcome outcome
+
+example
+    {pfx : Byte} {payload : List Byte} (outcome : DecodeChainOutcome pfx payload) :
+    successFieldSpecsInput outcome.input ∨ decodeWithdrawal outcome.input = none := by
+  wp_withdrawal_decode_chain
 
 example
     {pfx : Byte} {payload : List Byte} (outcome : DecodeChainOutcome pfx payload) :

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeChainWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeChainWP.lean
@@ -592,7 +592,7 @@ macro "wp_withdrawal_decode_chain " chain:term : tactic =>
     | wp_rv64_cert
     | wp_withdrawal_decode_auto)
 
-open Lean Elab Tactic
+open Lean Meta Elab Tactic
 
 /-- Context-driven chain WP automation.  It scans local hypotheses for already
     bundled success/leftover chain objects, projects the needed pure fact, and
@@ -630,6 +630,31 @@ macro "wp_withdrawal_decode_outcome " outcome:term : tactic =>
       | inl chain => wp_withdrawal_decode_chain chain
       | inr chain => wp_withdrawal_decode_chain chain
     | wp_withdrawal_decode_auto)
+
+private def isDecodeChainOutcomeLocalType (e : Expr) : Bool :=
+  e.isAppOfArity ``DecodeChainOutcome 2 ||
+    (e.isAppOfArity ``Sum 2 &&
+      e.getAppArgs[0]!.isAppOfArity ``SuccessDecodeChain 2 &&
+      e.getAppArgs[1]!.isAppOfArity ``LeftoverDecodeChain 2)
+
+/-- Context-driven outcome WP automation.  Generated proofs that already bundled
+    a branch join as a `DecodeChainOutcome` or `Sum` can leave the term implicit;
+    the tactic finds the local outcome and delegates to `wp_withdrawal_decode_outcome outcome`. -/
+elab "wp_withdrawal_decode_outcome" : tactic => withMainContext do
+  let lctx ← getLCtx
+  for localDecl in lctx do
+    if localDecl.isImplementationDetail then
+      continue
+    let localType ← whnfR (← instantiateMVars localDecl.type)
+    unless isDecodeChainOutcomeLocalType localType do
+      continue
+    let id := Lean.mkIdent localDecl.userName
+    try
+      evalTactic (← `(tactic| wp_withdrawal_decode_outcome $id:ident; done))
+      return
+    catch _ =>
+      (Pure.pure PUnit.unit : TacticM PUnit)
+  throwError "wp_withdrawal_decode_outcome: no local decode-chain outcome closed the goal"
 
 example
     {pfx : Byte} {payload r1 r2 r3 r4 d0 d1 d2 d3 : List Byte}
@@ -687,11 +712,23 @@ example
   wp_withdrawal_decode_outcome outcome
 
 example
+    {pfx : Byte} {payload : List Byte} (outcome : DecodeChainOutcome pfx payload) :
+    successFieldSpecsInput outcome.input ∨ decodeWithdrawal outcome.input = none := by
+  wp_withdrawal_decode_outcome
+
+example
     {pfx : Byte} {payload : List Byte}
     (outcome : Sum (SuccessDecodeChain pfx payload) (LeftoverDecodeChain pfx payload)) :
     (∃ w : Withdrawal, decodeWithdrawal (pfx :: payload) = some w) ∨
       decodeWithdrawal (pfx :: payload) = none := by
   wp_withdrawal_decode_outcome outcome
+
+example
+    {pfx : Byte} {payload : List Byte}
+    (outcome : Sum (SuccessDecodeChain pfx payload) (LeftoverDecodeChain pfx payload)) :
+    (∃ w : Withdrawal, decodeWithdrawal (pfx :: payload) = some w) ∨
+      decodeWithdrawal (pfx :: payload) = none := by
+  wp_withdrawal_decode_outcome
 
 noncomputable example
     {pfx : Byte} {payload : List Byte} (chain : SuccessDecodeChain pfx payload)

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeChainWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeChainWP.lean
@@ -137,6 +137,27 @@ theorem decodeWithdrawal_eq_some {pfx : Byte} {payload : List Byte}
     chain.decodeAux0 chain.decodeAux1 chain.decodeAux2 chain.decodeAux3 chain.hend chain.h_min
     chain.hc0 chain.hl0 chain.hc1 chain.hl1 chain.haddr chain.hc3 chain.hl3
 
+/-- Success chains choose the success side of a result-free schema split. -/
+theorem successFieldSpecsInput_or_not {pfx : Byte} {payload : List Byte}
+    (chain : SuccessDecodeChain pfx payload) :
+    WithdrawalDecode.successFieldSpecsInput chain.input ∨
+      ¬ WithdrawalDecode.successFieldSpecsInput chain.input :=
+  Or.inl chain.successFieldSpecsInput
+
+/-- Success chains choose the decoded-success side of a reason-erased decode split. -/
+theorem decodeWithdrawal_some_or_none {pfx : Byte} {payload : List Byte}
+    (chain : SuccessDecodeChain pfx payload) :
+    (∃ w : Withdrawal, decodeWithdrawal chain.input = some w) ∨
+      decodeWithdrawal chain.input = none :=
+  Or.inl ⟨chain.value, chain.decodeWithdrawal_eq_some⟩
+
+/-- Success chains can also feed joins that only distinguish schema success from
+    semantic failure. -/
+theorem successFieldSpecsInput_or_decodeWithdrawal_none {pfx : Byte} {payload : List Byte}
+    (chain : SuccessDecodeChain pfx payload) :
+    WithdrawalDecode.successFieldSpecsInput chain.input ∨ decodeWithdrawal chain.input = none :=
+  Or.inl chain.successFieldSpecsInput
+
 /-- Result-free WP package projected from a success decode chain. -/
 noncomputable def wpPackage {pfx : Byte} {payload : List Byte}
     (chain : SuccessDecodeChain pfx payload)
@@ -388,7 +409,77 @@ theorem not_successFieldSpecsInput {pfx : Byte} {payload : List Byte}
   (decodeWithdrawal_eq_none_iff_not_successFieldSpecsInput chain.input).1
     chain.decodeWithdrawal_eq_none
 
+/-- Exact-arity leftover chains choose the failure side of a result-free schema split. -/
+theorem successFieldSpecsInput_or_not {pfx : Byte} {payload : List Byte}
+    (chain : LeftoverDecodeChain pfx payload) :
+    successFieldSpecsInput chain.input ∨ ¬ successFieldSpecsInput chain.input :=
+  Or.inr chain.not_successFieldSpecsInput
+
+/-- Exact-arity leftover chains choose the reason-erased failure side of a decode split. -/
+theorem decodeWithdrawal_some_or_none {pfx : Byte} {payload : List Byte}
+    (chain : LeftoverDecodeChain pfx payload) :
+    (∃ w : Withdrawal, decodeWithdrawal chain.input = some w) ∨
+      decodeWithdrawal chain.input = none :=
+  Or.inr chain.decodeWithdrawal_eq_none
+
+/-- Exact-arity leftover chains can feed joins that only distinguish schema
+    success from semantic failure. -/
+theorem successFieldSpecsInput_or_decodeWithdrawal_none {pfx : Byte} {payload : List Byte}
+    (chain : LeftoverDecodeChain pfx payload) :
+    successFieldSpecsInput chain.input ∨ decodeWithdrawal chain.input = none :=
+  Or.inr chain.decodeWithdrawal_eq_none
+
 end LeftoverDecodeChain
+
+/-- Branch-join outcome for generated exact-arity withdrawal walks.  The failure
+    case deliberately carries no precise failure reason: downstream WP code only
+    needs to distinguish schema success from reason-erased semantic failure. -/
+inductive DecodeChainOutcome (pfx : Byte) (payload : List Byte) where
+  | success (chain : SuccessDecodeChain pfx payload)
+  | leftover (chain : LeftoverDecodeChain pfx payload)
+
+namespace DecodeChainOutcome
+
+/-- Full RLP input represented by a chain outcome. -/
+def input {pfx : Byte} {payload : List Byte} (_outcome : DecodeChainOutcome pfx payload) :
+    List Byte :=
+  pfx :: payload
+
+/-- Project the result-free schema split needed by control-flow joins. -/
+theorem successFieldSpecsInput_or_not {pfx : Byte} {payload : List Byte}
+    (outcome : DecodeChainOutcome pfx payload) :
+    successFieldSpecsInput outcome.input ∨ ¬ successFieldSpecsInput outcome.input := by
+  cases outcome with
+  | success chain =>
+      simpa [input, SuccessDecodeChain.input] using chain.successFieldSpecsInput_or_not
+  | leftover chain =>
+      simpa [input, LeftoverDecodeChain.input] using chain.successFieldSpecsInput_or_not
+
+/-- Project the reason-erased semantic decode split needed by ABI-level joins. -/
+theorem decodeWithdrawal_some_or_none {pfx : Byte} {payload : List Byte}
+    (outcome : DecodeChainOutcome pfx payload) :
+    (∃ w : Withdrawal, decodeWithdrawal outcome.input = some w) ∨
+      decodeWithdrawal outcome.input = none := by
+  cases outcome with
+  | success chain =>
+      simpa [input, SuccessDecodeChain.input] using chain.decodeWithdrawal_some_or_none
+  | leftover chain =>
+      simpa [input, LeftoverDecodeChain.input] using chain.decodeWithdrawal_some_or_none
+
+/-- Project the join fact that keeps schema success result-free while erasing
+    the precise failure reason. -/
+theorem successFieldSpecsInput_or_decodeWithdrawal_none {pfx : Byte} {payload : List Byte}
+    (outcome : DecodeChainOutcome pfx payload) :
+    successFieldSpecsInput outcome.input ∨ decodeWithdrawal outcome.input = none := by
+  cases outcome with
+  | success chain =>
+      simpa [input, SuccessDecodeChain.input] using
+        chain.successFieldSpecsInput_or_decodeWithdrawal_none
+  | leftover chain =>
+      simpa [input, LeftoverDecodeChain.input] using
+        chain.successFieldSpecsInput_or_decodeWithdrawal_none
+
+end DecodeChainOutcome
 
 /-- Synthesize a successful withdrawal decode chain from the generated local
     `decode`, classifier, length, and field-guard facts. -/
@@ -491,7 +582,53 @@ macro "wp_withdrawal_decode_chain " chain:term : tactic =>
     | exact ($chain).decodeWithdrawal_eq_some
     | exact ($chain).not_successFieldSpecsInput
     | exact ($chain).decodeWithdrawal_eq_none
+    | exact ($chain).successFieldSpecsInput_or_not
+    | exact ($chain).decodeWithdrawal_some_or_none
+    | exact ($chain).successFieldSpecsInput_or_decodeWithdrawal_none
+    | left; exact ($chain).successFieldSpecsInput
+    | left; exact ⟨($chain).value, ($chain).decodeWithdrawal_eq_some⟩
+    | right; exact ($chain).not_successFieldSpecsInput
+    | right; exact ($chain).decodeWithdrawal_eq_none
     | wp_rv64_cert
+    | wp_withdrawal_decode_auto)
+
+open Lean Elab Tactic
+
+/-- Context-driven chain WP automation.  It scans local hypotheses for already
+    bundled success/leftover chain objects, projects the needed pure fact, and
+    then falls back to the generic withdrawal WP driver. -/
+elab "wp_withdrawal_decode_chain" : tactic => withMainContext do
+  let lctx ← getLCtx
+  for localDecl in lctx do
+    if localDecl.isImplementationDetail then
+      continue
+    let id := Lean.mkIdent localDecl.userName
+    try
+      evalTactic (← `(tactic| wp_withdrawal_decode_chain $id:ident; done))
+      return
+    catch _ =>
+      (Pure.pure PUnit.unit : TacticM PUnit)
+  try
+    evalTactic (← `(tactic| wp_withdrawal_decode_auto; done))
+  catch _ =>
+    throwError "wp_withdrawal_decode_chain: no local decode chain or withdrawal WP hint closed the goal"
+
+/-- Outcome-driven WP automation for a bundled `DecodeChainOutcome` or a `Sum`
+    of success/leftover chains.  The tactic splits the outcome once and delegates
+    each branch to the chain-object WP driver. -/
+macro "wp_withdrawal_decode_outcome " outcome:term : tactic =>
+  `(tactic| first
+    | exact ($outcome).successFieldSpecsInput_or_not
+    | exact ($outcome).decodeWithdrawal_some_or_none
+    | exact ($outcome).successFieldSpecsInput_or_decodeWithdrawal_none
+    | have h_outcome := $outcome
+      cases h_outcome with
+      | success chain => wp_withdrawal_decode_chain chain
+      | leftover chain => wp_withdrawal_decode_chain chain
+    | have h_outcome := $outcome
+      cases h_outcome with
+      | inl chain => wp_withdrawal_decode_chain chain
+      | inr chain => wp_withdrawal_decode_chain chain
     | wp_withdrawal_decode_auto)
 
 example
@@ -530,9 +667,31 @@ example
   wp_withdrawal_decode_chain chain
 
 example
+    {pfx : Byte} {payload : List Byte} (chain : SuccessDecodeChain pfx payload) :
+    successFieldSpecsInput chain.input := by
+  wp_withdrawal_decode_chain
+
+example
     {pfx : Byte} {payload : List Byte} (chain : LeftoverDecodeChain pfx payload) :
     decodeWithdrawal chain.input = none := by
   wp_withdrawal_decode_chain chain
+
+example
+    {pfx : Byte} {payload : List Byte} (chain : LeftoverDecodeChain pfx payload) :
+    successFieldSpecsInput chain.input ∨ ¬ successFieldSpecsInput chain.input := by
+  wp_withdrawal_decode_chain
+
+example
+    {pfx : Byte} {payload : List Byte} (outcome : DecodeChainOutcome pfx payload) :
+    successFieldSpecsInput outcome.input ∨ decodeWithdrawal outcome.input = none := by
+  wp_withdrawal_decode_outcome outcome
+
+example
+    {pfx : Byte} {payload : List Byte}
+    (outcome : Sum (SuccessDecodeChain pfx payload) (LeftoverDecodeChain pfx payload)) :
+    (∃ w : Withdrawal, decodeWithdrawal (pfx :: payload) = some w) ∨
+      decodeWithdrawal (pfx :: payload) = none := by
+  wp_withdrawal_decode_outcome outcome
 
 noncomputable example
     {pfx : Byte} {payload : List Byte} (chain : SuccessDecodeChain pfx payload)

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeChainWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeChainWP.lean
@@ -1,0 +1,559 @@
+/-
+  EvmAsm.Rv64.RLP.WithdrawalDecodeChainWP
+
+  Chain-shaped automation facade for generated withdrawal decode WP proofs.
+  The field walker exposes a sequence of pure `decode` facts over successive
+  payload remainders; this module bundles those facts once and projects the
+  existing result-free schema-input WP packages from that bundle.
+-/
+
+import EvmAsm.Rv64.RLP.WithdrawalDecodeAutoWP
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL
+open EvmAsm.EL.RLP
+open EvmAsm.Rv64.Tactics
+
+namespace WithdrawalDecode
+
+/-- Successful four-field short-list decode chain produced by a validating field
+    walk.  The decoded field bytes are postcondition witnesses; the schema input
+    predicate derived from this structure remains result-free. -/
+structure SuccessDecodeChain (pfx : Byte) (payload : List Byte) where
+  r1 : List Byte
+  r2 : List Byte
+  r3 : List Byte
+  r4 : List Byte
+  d0 : List Byte
+  d1 : List Byte
+  d2 : List Byte
+  d3 : List Byte
+  h_class : classifyPrefix pfx = .shortList
+  h_len : rlpPrefixShortListPayloadLen pfx = payload.length
+  hdec0 : decode payload = some (.bytes d0, r1)
+  hdec1 : decode r1 = some (.bytes d1, r2)
+  hdec2 : decode r2 = some (.bytes d2, r3)
+  hdec3 : decode r3 = some (.bytes d3, r4)
+  hend : r4 = []
+  h_min : 2 ≤ payload.length
+  hc0 : d0.headD 1 ≠ 0
+  hl0 : d0.length ≤ 8
+  hc1 : d1.headD 1 ≠ 0
+  hl1 : d1.length ≤ 8
+  haddr : d2.length = 20
+  hc3 : d3.headD 1 ≠ 0
+  hl3 : d3.length ≤ 8
+
+namespace SuccessDecodeChain
+
+/-- Build a success chain from the facts emitted by a generated field walk. -/
+def ofLocalFacts {pfx : Byte} {payload r1 r2 r3 r4 d0 d1 d2 d3 : List Byte}
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (hdec0 : decode payload = some (.bytes d0, r1))
+    (hdec1 : decode r1 = some (.bytes d1, r2))
+    (hdec2 : decode r2 = some (.bytes d2, r3))
+    (hdec3 : decode r3 = some (.bytes d3, r4))
+    (hend : r4 = [])
+    (h_min : 2 ≤ payload.length)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8) :
+    SuccessDecodeChain pfx payload where
+  r1 := r1
+  r2 := r2
+  r3 := r3
+  r4 := r4
+  d0 := d0
+  d1 := d1
+  d2 := d2
+  d3 := d3
+  h_class := h_class
+  h_len := h_len
+  hdec0 := hdec0
+  hdec1 := hdec1
+  hdec2 := hdec2
+  hdec3 := hdec3
+  hend := hend
+  h_min := h_min
+  hc0 := hc0
+  hl0 := hl0
+  hc1 := hc1
+  hl1 := hl1
+  haddr := haddr
+  hc3 := hc3
+  hl3 := hl3
+
+/-- Full RLP input represented by a short-list success chain. -/
+def input {pfx : Byte} {payload : List Byte} (_chain : SuccessDecodeChain pfx payload) :
+    List Byte :=
+  pfx :: payload
+
+/-- Withdrawal value characterized by the field bytes in a success chain. -/
+def value {pfx : Byte} {payload : List Byte} (chain : SuccessDecodeChain pfx payload) :
+    Withdrawal :=
+  fromFieldBytes chain.d0 chain.d1 chain.d2 chain.d3
+
+/-- First field decode as a fuel-polymorphic `decodeAux` continuation. -/
+theorem decodeAux0 {pfx : Byte} {payload : List Byte}
+    (chain : SuccessDecodeChain pfx payload) :
+    ∀ m, decodeAux (m + 1) payload = some (.bytes chain.d0, chain.r1) :=
+  decodeAux_bytes_all_fuel_of_decode_list payload chain.d0 chain.r1 chain.hdec0
+
+/-- Second field decode as a fuel-polymorphic `decodeAux` continuation. -/
+theorem decodeAux1 {pfx : Byte} {payload : List Byte}
+    (chain : SuccessDecodeChain pfx payload) :
+    ∀ m, decodeAux (m + 1) chain.r1 = some (.bytes chain.d1, chain.r2) :=
+  decodeAux_bytes_all_fuel_of_decode_list chain.r1 chain.d1 chain.r2 chain.hdec1
+
+/-- Third field decode as a fuel-polymorphic `decodeAux` continuation. -/
+theorem decodeAux2 {pfx : Byte} {payload : List Byte}
+    (chain : SuccessDecodeChain pfx payload) :
+    ∀ m, decodeAux (m + 1) chain.r2 = some (.bytes chain.d2, chain.r3) :=
+  decodeAux_bytes_all_fuel_of_decode_list chain.r2 chain.d2 chain.r3 chain.hdec2
+
+/-- Fourth field decode as a fuel-polymorphic `decodeAux` continuation. -/
+theorem decodeAux3 {pfx : Byte} {payload : List Byte}
+    (chain : SuccessDecodeChain pfx payload) :
+    ∀ m, decodeAux (m + 1) chain.r3 = some (.bytes chain.d3, chain.r4) :=
+  decodeAux_bytes_all_fuel_of_decode_list chain.r3 chain.d3 chain.r4 chain.hdec3
+
+/-- Result-free schema-success predicate derived from the decode chain. -/
+theorem successFieldSpecsInput {pfx : Byte} {payload : List Byte}
+    (chain : SuccessDecodeChain pfx payload) :
+    successFieldSpecsInput chain.input :=
+  successFieldSpecsInput_of_shortList_four_decode_chain chain.h_class chain.h_len
+    chain.decodeAux0 chain.decodeAux1 chain.decodeAux2 chain.decodeAux3 chain.hend chain.h_min
+    chain.hc0 chain.hl0 chain.hc1 chain.hl1 chain.haddr chain.hc3 chain.hl3
+
+/-- Semantic success characterized by the chain's field bytes. -/
+theorem decodeWithdrawal_eq_some {pfx : Byte} {payload : List Byte}
+    (chain : SuccessDecodeChain pfx payload) :
+    decodeWithdrawal chain.input = some chain.value :=
+  decodeWithdrawal_shortList_four_of_decodeAux_chain_auto chain.h_class chain.h_len
+    chain.decodeAux0 chain.decodeAux1 chain.decodeAux2 chain.decodeAux3 chain.hend chain.h_min
+    chain.hc0 chain.hl0 chain.hc1 chain.hl1 chain.haddr chain.hc3 chain.hl3
+
+/-- Result-free WP package projected from a success decode chain. -/
+noncomputable def wpPackage {pfx : Byte} {payload : List Byte}
+    (chain : SuccessDecodeChain pfx payload)
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + chain.input.length < 2 ^ 64)
+    (hwin : ∀ i, i < chain.input.length →
+      isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len_word : listLen = BitVec.ofNat 64 chain.input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    Sigma (fun w : Withdrawal => WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old
+      s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old chain.input w) :=
+  walkInitShortSuccessSchemaInputWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+    inputBase listLen t0Old t1Old chain.input chain.successFieldSpecsInput hsalign hover hwin
+    hdalign hdov hdval h_len_word h_prologue_code h_code_max
+
+/-- Decoded-success package carried by a success decode chain. -/
+noncomputable def pkg {pfx : Byte} {payload : List Byte}
+    (chain : SuccessDecodeChain pfx payload)
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + chain.input.length < 2 ^ 64)
+    (hwin : ∀ i, i < chain.input.length →
+      isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len_word : listLen = BitVec.ofNat 64 chain.input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WalkInitShortSuccessDecodedWP base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+      inputBase listLen t0Old t1Old chain.input
+      (chain.wpPackage base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase
+        listLen t0Old t1Old hsalign hover hwin hdalign hdov hdval h_len_word h_prologue_code
+        h_code_max).1 :=
+  (chain.wpPackage base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen
+    t0Old t1Old hsalign hover hwin hdalign hdov hdval h_len_word h_prologue_code
+    h_code_max).2
+
+/-- Success certificate projected from a success decode chain package. -/
+noncomputable def successCert {pfx : Byte} {payload : List Byte}
+    (chain : SuccessDecodeChain pfx payload)
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + chain.input.length < 2 ^ 64)
+    (hwin : ∀ i, i < chain.input.length →
+      isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len_word : listLen = BitVec.ofNat 64 chain.input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.CFG.Cert base (successStatusReturnExit raVal)
+      (chain.pkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen
+        t0Old t1Old hsalign hover hwin hdalign hdov hdval h_len_word h_prologue_code
+        h_code_max).successCode
+      (chain.pkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen
+        t0Old t1Old hsalign hover hwin hdalign hdov hdval h_len_word h_prologue_code
+        h_code_max).successPost :=
+  (chain.pkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen
+    t0Old t1Old hsalign hover hwin hdalign hdov hdval h_len_word h_prologue_code
+    h_code_max).successCert
+
+/-- Chain success certificate reduces to the static prologue precondition. -/
+theorem successCert_pre {pfx : Byte} {payload : List Byte}
+    (chain : SuccessDecodeChain pfx payload)
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + chain.input.length < 2 ^ 64)
+    (hwin : ∀ i, i < chain.input.length →
+      isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len_word : listLen = BitVec.ofNat 64 chain.input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    (chain.successCert base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen
+      t0Old t1Old hsalign hover hwin hdalign hdov hdval h_len_word h_prologue_code
+      h_code_max).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase
+          chain.input) := by
+  exact (chain.pkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen
+    t0Old t1Old hsalign hover hwin hdalign hdov hdval h_len_word h_prologue_code
+    h_code_max).successCert_pre
+
+/-- Reason-erased failure branch over the same generated code as the chain
+    success certificate. -/
+noncomputable def failureLongNBranch {pfx : Byte} {payload : List Byte}
+    (chain : SuccessDecodeChain pfx payload)
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + chain.input.length < 2 ^ 64)
+    (hwin : ∀ i, i < chain.input.length →
+      isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len_word : listLen = BitVec.ofNat 64 chain.input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base
+      ((chain.pkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen
+        t0Old t1Old hsalign hover hwin hdalign hdov hdval h_len_word h_prologue_code
+        h_code_max).successCode.union (failStatusReturnCode ((base + 24) + 28))) :=
+  (chain.pkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen
+    t0Old t1Old hsalign hover hwin hdalign hdov hdval h_len_word h_prologue_code
+    h_code_max).failureLongNBranch hsalign hover hwin h_len_word h_prologue_code h_code_max
+
+/-- Chain failure branch reduces to the same static prologue precondition as the
+    success certificate. -/
+theorem failureLongNBranch_pre {pfx : Byte} {payload : List Byte}
+    (chain : SuccessDecodeChain pfx payload)
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + chain.input.length < 2 ^ 64)
+    (hwin : ∀ i, i < chain.input.length →
+      isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len_word : listLen = BitVec.ofNat 64 chain.input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    (chain.failureLongNBranch base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase
+      listLen t0Old t1Old hsalign hover hwin hdalign hdov hdval h_len_word h_prologue_code
+      h_code_max).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase
+          chain.input) := by
+  exact (chain.pkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen
+    t0Old t1Old hsalign hover hwin hdalign hdov hdval h_len_word h_prologue_code
+    h_code_max).failureLongNBranch_pre hsalign hover hwin h_len_word h_prologue_code h_code_max
+
+attribute [rv64_wp]
+  successCert_pre
+  failureLongNBranch_pre
+
+attribute [rv64_wp_cert]
+  successCert
+  failureLongNBranch
+
+end SuccessDecodeChain
+
+/-- Exact-arity failure chain produced by a validating field walk after four
+    successful byte-field decodes but with a nonempty payload remainder. -/
+structure LeftoverDecodeChain (pfx : Byte) (payload : List Byte) where
+  r1 : List Byte
+  r2 : List Byte
+  r3 : List Byte
+  r4 : List Byte
+  d0 : List Byte
+  d1 : List Byte
+  d2 : List Byte
+  d3 : List Byte
+  h_class : classifyPrefix pfx = .shortList
+  h_len : rlpPrefixShortListPayloadLen pfx = payload.length
+  hdec0 : decode payload = some (.bytes d0, r1)
+  hdec1 : decode r1 = some (.bytes d1, r2)
+  hdec2 : decode r2 = some (.bytes d2, r3)
+  hdec3 : decode r3 = some (.bytes d3, r4)
+  h_leftover : r4 ≠ []
+  h_min : 2 ≤ payload.length
+
+namespace LeftoverDecodeChain
+
+/-- Build an exact-arity leftover chain from the facts emitted by a generated
+    field walk. -/
+def ofLocalFacts {pfx : Byte} {payload r1 r2 r3 r4 d0 d1 d2 d3 : List Byte}
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (hdec0 : decode payload = some (.bytes d0, r1))
+    (hdec1 : decode r1 = some (.bytes d1, r2))
+    (hdec2 : decode r2 = some (.bytes d2, r3))
+    (hdec3 : decode r3 = some (.bytes d3, r4))
+    (h_leftover : r4 ≠ [])
+    (h_min : 2 ≤ payload.length) :
+    LeftoverDecodeChain pfx payload where
+  r1 := r1
+  r2 := r2
+  r3 := r3
+  r4 := r4
+  d0 := d0
+  d1 := d1
+  d2 := d2
+  d3 := d3
+  h_class := h_class
+  h_len := h_len
+  hdec0 := hdec0
+  hdec1 := hdec1
+  hdec2 := hdec2
+  hdec3 := hdec3
+  h_leftover := h_leftover
+  h_min := h_min
+
+/-- Full RLP input represented by an exact-arity failure chain. -/
+def input {pfx : Byte} {payload : List Byte} (_chain : LeftoverDecodeChain pfx payload) :
+    List Byte :=
+  pfx :: payload
+
+/-- First field decode as a fuel-polymorphic `decodeAux` continuation. -/
+theorem decodeAux0 {pfx : Byte} {payload : List Byte}
+    (chain : LeftoverDecodeChain pfx payload) :
+    ∀ m, decodeAux (m + 1) payload = some (.bytes chain.d0, chain.r1) :=
+  decodeAux_bytes_all_fuel_of_decode_list payload chain.d0 chain.r1 chain.hdec0
+
+/-- Second field decode as a fuel-polymorphic `decodeAux` continuation. -/
+theorem decodeAux1 {pfx : Byte} {payload : List Byte}
+    (chain : LeftoverDecodeChain pfx payload) :
+    ∀ m, decodeAux (m + 1) chain.r1 = some (.bytes chain.d1, chain.r2) :=
+  decodeAux_bytes_all_fuel_of_decode_list chain.r1 chain.d1 chain.r2 chain.hdec1
+
+/-- Third field decode as a fuel-polymorphic `decodeAux` continuation. -/
+theorem decodeAux2 {pfx : Byte} {payload : List Byte}
+    (chain : LeftoverDecodeChain pfx payload) :
+    ∀ m, decodeAux (m + 1) chain.r2 = some (.bytes chain.d2, chain.r3) :=
+  decodeAux_bytes_all_fuel_of_decode_list chain.r2 chain.d2 chain.r3 chain.hdec2
+
+/-- Fourth field decode as a fuel-polymorphic `decodeAux` continuation. -/
+theorem decodeAux3 {pfx : Byte} {payload : List Byte}
+    (chain : LeftoverDecodeChain pfx payload) :
+    ∀ m, decodeAux (m + 1) chain.r3 = some (.bytes chain.d3, chain.r4) :=
+  decodeAux_bytes_all_fuel_of_decode_list chain.r3 chain.d3 chain.r4 chain.hdec3
+
+/-- Exact-arity leftover chains are reason-erased withdrawal failures. -/
+theorem decodeWithdrawal_eq_none {pfx : Byte} {payload : List Byte}
+    (chain : LeftoverDecodeChain pfx payload) :
+    decodeWithdrawal chain.input = none :=
+  decodeWithdrawal_none_of_shortList_four_leftover_chain_auto chain.h_class chain.h_len
+    chain.decodeAux0 chain.decodeAux1 chain.decodeAux2 chain.decodeAux3 chain.h_leftover
+    chain.h_min
+
+/-- Exact-arity leftover chains cannot satisfy the result-free success schema. -/
+theorem not_successFieldSpecsInput {pfx : Byte} {payload : List Byte}
+    (chain : LeftoverDecodeChain pfx payload) :
+    ¬ successFieldSpecsInput chain.input :=
+  (decodeWithdrawal_eq_none_iff_not_successFieldSpecsInput chain.input).1
+    chain.decodeWithdrawal_eq_none
+
+end LeftoverDecodeChain
+
+/-- Synthesize a successful withdrawal decode chain from the generated local
+    `decode`, classifier, length, and field-guard facts. -/
+macro "withdrawal_success_decode_chain" : tactic => do
+  let hClass := Lean.mkIdent `h_class
+  let hLen := Lean.mkIdent `h_len
+  let hDec0 := Lean.mkIdent `hdec0
+  let hDec1 := Lean.mkIdent `hdec1
+  let hDec2 := Lean.mkIdent `hdec2
+  let hDec3 := Lean.mkIdent `hdec3
+  let hEnd := Lean.mkIdent `hend
+  let hMin := Lean.mkIdent `h_min
+  let hC0 := Lean.mkIdent `hc0
+  let hL0 := Lean.mkIdent `hl0
+  let hC1 := Lean.mkIdent `hc1
+  let hL1 := Lean.mkIdent `hl1
+  let hAddr := Lean.mkIdent `haddr
+  let hC3 := Lean.mkIdent `hc3
+  let hL3 := Lean.mkIdent `hl3
+  `(tactic| exact SuccessDecodeChain.ofLocalFacts $hClass:ident $hLen:ident $hDec0:ident
+    $hDec1:ident $hDec2:ident $hDec3:ident $hEnd:ident $hMin:ident $hC0:ident
+    $hL0:ident $hC1:ident $hL1:ident $hAddr:ident $hC3:ident $hL3:ident)
+
+/-- Synthesize an exact-arity leftover failure chain from generated local
+    `decode`, classifier, length, and leftover facts. -/
+macro "withdrawal_leftover_decode_chain" : tactic => do
+  let hClass := Lean.mkIdent `h_class
+  let hLen := Lean.mkIdent `h_len
+  let hDec0 := Lean.mkIdent `hdec0
+  let hDec1 := Lean.mkIdent `hdec1
+  let hDec2 := Lean.mkIdent `hdec2
+  let hDec3 := Lean.mkIdent `hdec3
+  let hLeftover := Lean.mkIdent `h_leftover
+  let hMin := Lean.mkIdent `h_min
+  `(tactic| exact LeftoverDecodeChain.ofLocalFacts $hClass:ident $hLen:ident $hDec0:ident
+    $hDec1:ident $hDec2:ident $hDec3:ident $hLeftover:ident $hMin:ident)
+
+/-- Context-driven WP automation for generated successful field-walk proofs.
+    It derives semantic success or the result-free schema fact from the standard
+    local names, then falls through to the WP certificate/link/dead-exit
+    databases. Use the argument-taking `wp_withdrawal_decode_chain_auto` when a
+    generated proof uses nonstandard names. -/
+macro "wp_withdrawal_decode_success_chain" : tactic => do
+  let hClass := Lean.mkIdent `h_class
+  let hLen := Lean.mkIdent `h_len
+  let hDec0 := Lean.mkIdent `hdec0
+  let hDec1 := Lean.mkIdent `hdec1
+  let hDec2 := Lean.mkIdent `hdec2
+  let hDec3 := Lean.mkIdent `hdec3
+  let hEnd := Lean.mkIdent `hend
+  let hMin := Lean.mkIdent `h_min
+  let hC0 := Lean.mkIdent `hc0
+  let hL0 := Lean.mkIdent `hl0
+  let hC1 := Lean.mkIdent `hc1
+  let hL1 := Lean.mkIdent `hl1
+  let hAddr := Lean.mkIdent `haddr
+  let hC3 := Lean.mkIdent `hc3
+  let hL3 := Lean.mkIdent `hl3
+  `(tactic| first
+    | exact (SuccessDecodeChain.ofLocalFacts $hClass:ident $hLen:ident $hDec0:ident
+        $hDec1:ident $hDec2:ident $hDec3:ident $hEnd:ident $hMin:ident $hC0:ident
+        $hL0:ident $hC1:ident $hL1:ident $hAddr:ident $hC3:ident
+        $hL3:ident).successFieldSpecsInput
+    | exact (SuccessDecodeChain.ofLocalFacts $hClass:ident $hLen:ident $hDec0:ident
+        $hDec1:ident $hDec2:ident $hDec3:ident $hEnd:ident $hMin:ident $hC0:ident
+        $hL0:ident $hC1:ident $hL1:ident $hAddr:ident $hC3:ident
+        $hL3:ident).decodeWithdrawal_eq_some
+    | wp_rv64_cert
+    | wp_withdrawal_decode_auto)
+
+/-- Context-driven WP automation for generated exact-arity leftover field-walk
+    proofs. It derives the reason-erased semantic/schema failure facts from the
+    standard local names, then falls through to the WP databases. -/
+macro "wp_withdrawal_decode_leftover_chain" : tactic => do
+  let hClass := Lean.mkIdent `h_class
+  let hLen := Lean.mkIdent `h_len
+  let hDec0 := Lean.mkIdent `hdec0
+  let hDec1 := Lean.mkIdent `hdec1
+  let hDec2 := Lean.mkIdent `hdec2
+  let hDec3 := Lean.mkIdent `hdec3
+  let hLeftover := Lean.mkIdent `h_leftover
+  let hMin := Lean.mkIdent `h_min
+  `(tactic| first
+    | exact (LeftoverDecodeChain.ofLocalFacts $hClass:ident $hLen:ident $hDec0:ident
+        $hDec1:ident $hDec2:ident $hDec3:ident $hLeftover:ident
+        $hMin:ident).not_successFieldSpecsInput
+    | exact (LeftoverDecodeChain.ofLocalFacts $hClass:ident $hLen:ident $hDec0:ident
+        $hDec1:ident $hDec2:ident $hDec3:ident $hLeftover:ident
+        $hMin:ident).decodeWithdrawal_eq_none
+    | wp_rv64_cert
+    | wp_withdrawal_decode_auto)
+
+example
+    {pfx : Byte} {payload r1 r2 r3 r4 d0 d1 d2 d3 : List Byte}
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (hdec0 : decode payload = some (.bytes d0, r1))
+    (hdec1 : decode r1 = some (.bytes d1, r2))
+    (hdec2 : decode r2 = some (.bytes d2, r3))
+    (hdec3 : decode r3 = some (.bytes d3, r4))
+    (hend : r4 = [])
+    (h_min : 2 ≤ payload.length)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8) :
+    successFieldSpecsInput (pfx :: payload) := by
+  wp_withdrawal_decode_success_chain
+
+example
+    {pfx : Byte} {payload r1 r2 r3 r4 d0 d1 d2 d3 : List Byte}
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (hdec0 : decode payload = some (.bytes d0, r1))
+    (hdec1 : decode r1 = some (.bytes d1, r2))
+    (hdec2 : decode r2 = some (.bytes d2, r3))
+    (hdec3 : decode r3 = some (.bytes d3, r4))
+    (h_leftover : r4 ≠ [])
+    (h_min : 2 ≤ payload.length) :
+    decodeWithdrawal (pfx :: payload) = none := by
+  wp_withdrawal_decode_leftover_chain
+
+noncomputable example
+    {pfx : Byte} {payload : List Byte} (chain : SuccessDecodeChain pfx payload)
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + chain.input.length < 2 ^ 64)
+    (hwin : ∀ i, i < chain.input.length →
+      isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len_word : listLen = BitVec.ofNat 64 chain.input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.CFG.Cert base (successStatusReturnExit raVal)
+      (chain.pkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen
+        t0Old t1Old hsalign hover hwin hdalign hdov hdval h_len_word h_prologue_code
+        h_code_max).successCode
+      (chain.pkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen
+        t0Old t1Old hsalign hover hwin hdalign hdov hdval h_len_word h_prologue_code
+        h_code_max).successPost := by
+  wp_rv64_cert
+
+noncomputable example
+    {pfx : Byte} {payload : List Byte} (chain : SuccessDecodeChain pfx payload)
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + chain.input.length < 2 ^ 64)
+    (hwin : ∀ i, i < chain.input.length →
+      isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (h_len_word : listLen = BitVec.ofNat 64 chain.input.length)
+    (h_prologue_code : base.toNat + 24 < 2 ^ 64)
+    (h_code_max : (base + 24).toNat + 172 + 4 + 1392 + 8 < 2 ^ 64) :
+    WP.NBranch base
+      ((chain.pkg base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen
+        t0Old t1Old hsalign hover hwin hdalign hdov hdval h_len_word h_prologue_code
+        h_code_max).successCode.union (failStatusReturnCode ((base + 24) + 28))) := by
+  wp_rv64_cert
+
+end WithdrawalDecode
+
+end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeChainWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeChainWP.lean
@@ -393,38 +393,38 @@ end LeftoverDecodeChain
 /-- Synthesize a successful withdrawal decode chain from the generated local
     `decode`, classifier, length, and field-guard facts. -/
 macro "withdrawal_success_decode_chain" : tactic => do
-  let hClass := Lean.mkIdent `h_class
-  let hLen := Lean.mkIdent `h_len
-  let hDec0 := Lean.mkIdent `hdec0
-  let hDec1 := Lean.mkIdent `hdec1
-  let hDec2 := Lean.mkIdent `hdec2
-  let hDec3 := Lean.mkIdent `hdec3
-  let hEnd := Lean.mkIdent `hend
-  let hMin := Lean.mkIdent `h_min
-  let hC0 := Lean.mkIdent `hc0
-  let hL0 := Lean.mkIdent `hl0
-  let hC1 := Lean.mkIdent `hc1
-  let hL1 := Lean.mkIdent `hl1
-  let hAddr := Lean.mkIdent `haddr
-  let hC3 := Lean.mkIdent `hc3
-  let hL3 := Lean.mkIdent `hl3
-  `(tactic| exact SuccessDecodeChain.ofLocalFacts $hClass:ident $hLen:ident $hDec0:ident
-    $hDec1:ident $hDec2:ident $hDec3:ident $hEnd:ident $hMin:ident $hC0:ident
-    $hL0:ident $hC1:ident $hL1:ident $hAddr:ident $hC3:ident $hL3:ident)
+  let h_class_stx := Lean.mkIdent `h_class
+  let h_len_stx := Lean.mkIdent `h_len
+  let h_dec0_stx := Lean.mkIdent `hdec0
+  let h_dec1_stx := Lean.mkIdent `hdec1
+  let h_dec2_stx := Lean.mkIdent `hdec2
+  let h_dec3_stx := Lean.mkIdent `hdec3
+  let h_end_stx := Lean.mkIdent `hend
+  let h_min_stx := Lean.mkIdent `h_min
+  let h_c0_stx := Lean.mkIdent `hc0
+  let h_l0_stx := Lean.mkIdent `hl0
+  let h_c1_stx := Lean.mkIdent `hc1
+  let h_l1_stx := Lean.mkIdent `hl1
+  let h_addr_stx := Lean.mkIdent `haddr
+  let h_c3_stx := Lean.mkIdent `hc3
+  let h_l3_stx := Lean.mkIdent `hl3
+  `(tactic| exact SuccessDecodeChain.ofLocalFacts $h_class_stx:ident $h_len_stx:ident $h_dec0_stx:ident
+    $h_dec1_stx:ident $h_dec2_stx:ident $h_dec3_stx:ident $h_end_stx:ident $h_min_stx:ident $h_c0_stx:ident
+    $h_l0_stx:ident $h_c1_stx:ident $h_l1_stx:ident $h_addr_stx:ident $h_c3_stx:ident $h_l3_stx:ident)
 
 /-- Synthesize an exact-arity leftover failure chain from generated local
     `decode`, classifier, length, and leftover facts. -/
 macro "withdrawal_leftover_decode_chain" : tactic => do
-  let hClass := Lean.mkIdent `h_class
-  let hLen := Lean.mkIdent `h_len
-  let hDec0 := Lean.mkIdent `hdec0
-  let hDec1 := Lean.mkIdent `hdec1
-  let hDec2 := Lean.mkIdent `hdec2
-  let hDec3 := Lean.mkIdent `hdec3
-  let hLeftover := Lean.mkIdent `h_leftover
-  let hMin := Lean.mkIdent `h_min
-  `(tactic| exact LeftoverDecodeChain.ofLocalFacts $hClass:ident $hLen:ident $hDec0:ident
-    $hDec1:ident $hDec2:ident $hDec3:ident $hLeftover:ident $hMin:ident)
+  let h_class_stx := Lean.mkIdent `h_class
+  let h_len_stx := Lean.mkIdent `h_len
+  let h_dec0_stx := Lean.mkIdent `hdec0
+  let h_dec1_stx := Lean.mkIdent `hdec1
+  let h_dec2_stx := Lean.mkIdent `hdec2
+  let h_dec3_stx := Lean.mkIdent `hdec3
+  let h_leftover_stx := Lean.mkIdent `h_leftover
+  let h_min_stx := Lean.mkIdent `h_min
+  `(tactic| exact LeftoverDecodeChain.ofLocalFacts $h_class_stx:ident $h_len_stx:ident $h_dec0_stx:ident
+    $h_dec1_stx:ident $h_dec2_stx:ident $h_dec3_stx:ident $h_leftover_stx:ident $h_min_stx:ident)
 
 /-- Context-driven WP automation for generated successful field-walk proofs.
     It derives semantic success or the result-free schema fact from the standard
@@ -432,30 +432,30 @@ macro "withdrawal_leftover_decode_chain" : tactic => do
     databases. Use the argument-taking `wp_withdrawal_decode_chain_auto` when a
     generated proof uses nonstandard names. -/
 macro "wp_withdrawal_decode_success_chain" : tactic => do
-  let hClass := Lean.mkIdent `h_class
-  let hLen := Lean.mkIdent `h_len
-  let hDec0 := Lean.mkIdent `hdec0
-  let hDec1 := Lean.mkIdent `hdec1
-  let hDec2 := Lean.mkIdent `hdec2
-  let hDec3 := Lean.mkIdent `hdec3
-  let hEnd := Lean.mkIdent `hend
-  let hMin := Lean.mkIdent `h_min
-  let hC0 := Lean.mkIdent `hc0
-  let hL0 := Lean.mkIdent `hl0
-  let hC1 := Lean.mkIdent `hc1
-  let hL1 := Lean.mkIdent `hl1
-  let hAddr := Lean.mkIdent `haddr
-  let hC3 := Lean.mkIdent `hc3
-  let hL3 := Lean.mkIdent `hl3
+  let h_class_stx := Lean.mkIdent `h_class
+  let h_len_stx := Lean.mkIdent `h_len
+  let h_dec0_stx := Lean.mkIdent `hdec0
+  let h_dec1_stx := Lean.mkIdent `hdec1
+  let h_dec2_stx := Lean.mkIdent `hdec2
+  let h_dec3_stx := Lean.mkIdent `hdec3
+  let h_end_stx := Lean.mkIdent `hend
+  let h_min_stx := Lean.mkIdent `h_min
+  let h_c0_stx := Lean.mkIdent `hc0
+  let h_l0_stx := Lean.mkIdent `hl0
+  let h_c1_stx := Lean.mkIdent `hc1
+  let h_l1_stx := Lean.mkIdent `hl1
+  let h_addr_stx := Lean.mkIdent `haddr
+  let h_c3_stx := Lean.mkIdent `hc3
+  let h_l3_stx := Lean.mkIdent `hl3
   `(tactic| first
-    | exact (SuccessDecodeChain.ofLocalFacts $hClass:ident $hLen:ident $hDec0:ident
-        $hDec1:ident $hDec2:ident $hDec3:ident $hEnd:ident $hMin:ident $hC0:ident
-        $hL0:ident $hC1:ident $hL1:ident $hAddr:ident $hC3:ident
-        $hL3:ident).successFieldSpecsInput
-    | exact (SuccessDecodeChain.ofLocalFacts $hClass:ident $hLen:ident $hDec0:ident
-        $hDec1:ident $hDec2:ident $hDec3:ident $hEnd:ident $hMin:ident $hC0:ident
-        $hL0:ident $hC1:ident $hL1:ident $hAddr:ident $hC3:ident
-        $hL3:ident).decodeWithdrawal_eq_some
+    | exact (SuccessDecodeChain.ofLocalFacts $h_class_stx:ident $h_len_stx:ident $h_dec0_stx:ident
+        $h_dec1_stx:ident $h_dec2_stx:ident $h_dec3_stx:ident $h_end_stx:ident $h_min_stx:ident $h_c0_stx:ident
+        $h_l0_stx:ident $h_c1_stx:ident $h_l1_stx:ident $h_addr_stx:ident $h_c3_stx:ident
+        $h_l3_stx:ident).successFieldSpecsInput
+    | exact (SuccessDecodeChain.ofLocalFacts $h_class_stx:ident $h_len_stx:ident $h_dec0_stx:ident
+        $h_dec1_stx:ident $h_dec2_stx:ident $h_dec3_stx:ident $h_end_stx:ident $h_min_stx:ident $h_c0_stx:ident
+        $h_l0_stx:ident $h_c1_stx:ident $h_l1_stx:ident $h_addr_stx:ident $h_c3_stx:ident
+        $h_l3_stx:ident).decodeWithdrawal_eq_some
     | wp_rv64_cert
     | wp_withdrawal_decode_auto)
 
@@ -463,21 +463,34 @@ macro "wp_withdrawal_decode_success_chain" : tactic => do
     proofs. It derives the reason-erased semantic/schema failure facts from the
     standard local names, then falls through to the WP databases. -/
 macro "wp_withdrawal_decode_leftover_chain" : tactic => do
-  let hClass := Lean.mkIdent `h_class
-  let hLen := Lean.mkIdent `h_len
-  let hDec0 := Lean.mkIdent `hdec0
-  let hDec1 := Lean.mkIdent `hdec1
-  let hDec2 := Lean.mkIdent `hdec2
-  let hDec3 := Lean.mkIdent `hdec3
-  let hLeftover := Lean.mkIdent `h_leftover
-  let hMin := Lean.mkIdent `h_min
+  let h_class_stx := Lean.mkIdent `h_class
+  let h_len_stx := Lean.mkIdent `h_len
+  let h_dec0_stx := Lean.mkIdent `hdec0
+  let h_dec1_stx := Lean.mkIdent `hdec1
+  let h_dec2_stx := Lean.mkIdent `hdec2
+  let h_dec3_stx := Lean.mkIdent `hdec3
+  let h_leftover_stx := Lean.mkIdent `h_leftover
+  let h_min_stx := Lean.mkIdent `h_min
   `(tactic| first
-    | exact (LeftoverDecodeChain.ofLocalFacts $hClass:ident $hLen:ident $hDec0:ident
-        $hDec1:ident $hDec2:ident $hDec3:ident $hLeftover:ident
-        $hMin:ident).not_successFieldSpecsInput
-    | exact (LeftoverDecodeChain.ofLocalFacts $hClass:ident $hLen:ident $hDec0:ident
-        $hDec1:ident $hDec2:ident $hDec3:ident $hLeftover:ident
-        $hMin:ident).decodeWithdrawal_eq_none
+    | exact (LeftoverDecodeChain.ofLocalFacts $h_class_stx:ident $h_len_stx:ident $h_dec0_stx:ident
+        $h_dec1_stx:ident $h_dec2_stx:ident $h_dec3_stx:ident $h_leftover_stx:ident
+        $h_min_stx:ident).not_successFieldSpecsInput
+    | exact (LeftoverDecodeChain.ofLocalFacts $h_class_stx:ident $h_len_stx:ident $h_dec0_stx:ident
+        $h_dec1_stx:ident $h_dec2_stx:ident $h_dec3_stx:ident $h_leftover_stx:ident
+        $h_min_stx:ident).decodeWithdrawal_eq_none
+    | wp_rv64_cert
+    | wp_withdrawal_decode_auto)
+
+/-- Chain-object WP automation.  Generated proofs that already bundled the field
+    walk into a `SuccessDecodeChain` or `LeftoverDecodeChain` can pass the bundle
+    once; the tactic projects the semantic/schema fact or delegates to the WP
+    certificate database. -/
+macro "wp_withdrawal_decode_chain " chain:term : tactic =>
+  `(tactic| first
+    | exact ($chain).successFieldSpecsInput
+    | exact ($chain).decodeWithdrawal_eq_some
+    | exact ($chain).not_successFieldSpecsInput
+    | exact ($chain).decodeWithdrawal_eq_none
     | wp_rv64_cert
     | wp_withdrawal_decode_auto)
 
@@ -510,6 +523,16 @@ example
     (h_min : 2 ≤ payload.length) :
     decodeWithdrawal (pfx :: payload) = none := by
   wp_withdrawal_decode_leftover_chain
+
+example
+    {pfx : Byte} {payload : List Byte} (chain : SuccessDecodeChain pfx payload) :
+    successFieldSpecsInput chain.input := by
+  wp_withdrawal_decode_chain chain
+
+example
+    {pfx : Byte} {payload : List Byte} (chain : LeftoverDecodeChain pfx payload) :
+    decodeWithdrawal chain.input = none := by
+  wp_withdrawal_decode_chain chain
 
 noncomputable example
     {pfx : Byte} {payload : List Byte} (chain : SuccessDecodeChain pfx payload)

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeFailureWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeFailureWP.lean
@@ -1,0 +1,263 @@
+/-
+  EvmAsm.Rv64.RLP.WithdrawalDecodeFailureWP
+
+  Semantic failure adapters for the withdrawal decoder WP calculus.  The exact
+  control-flow reason remains in a scratch frame; the public ABI component only
+  states that the pure `decodeWithdrawal` result is failure.
+-/
+
+import EvmAsm.Rv64.RLP.WithdrawalDecode
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL
+open EvmAsm.EL.RLP
+open EvmAsm.Rv64.Tactics
+
+namespace WithdrawalDecode
+
+/-- A byte/string RLP prefix cannot decode as a list. -/
+theorem decodeAux_ne_list_of_head_lt_c0
+    (fuel : Nat) (pfx : Byte) (rest leftover : List Byte) (items : List RLPItem)
+    (h : BitVec.ult (pfx.zeroExtend 64) (0xc0 : Word) = true) :
+    decodeAux (fuel + 1) (pfx :: rest) ≠ some (.list items, leftover) := by
+  have hp : pfx.toNat < 192 := by
+    simp only [BitVec.ult, decide_eq_true_eq, show (0xc0 : Word).toNat = 192 from by decide,
+      BitVec.toNat_setWidth] at h
+    have hb : pfx.toNat < 2 ^ 64 := by
+      have := pfx.isLt
+      omega
+    rw [Nat.mod_eq_of_lt hb] at h
+    exact h
+  intro hdec
+  unfold decodeAux at hdec
+  by_cases h80 : pfx.toNat < 128
+  · simp [h80] at hdec
+  · by_cases hB7 : pfx.toNat ≤ 183
+    · simp [h80, hB7] at hdec
+      cases ht : takeBytes rest (pfx.toNat - 128) with
+      | none => simp [ht] at hdec
+      | some pair =>
+          cases pair with
+          | mk data rest' =>
+              simp [ht] at hdec
+              cases data with
+              | nil => simp at hdec
+              | cons b tail =>
+                  cases tail with
+                  | nil => by_cases hb : b.toNat < 128 <;> simp [hb] at hdec
+                  | cons _ _ => simp at hdec
+    · have hBF : pfx.toNat ≤ 191 := by omega
+      simp [h80, hB7, hBF] at hdec
+      cases hr : readLength rest (pfx.toNat - 183) with
+      | none => simp [hr] at hdec
+      | some pair =>
+          cases pair with
+          | mk lenVal rest' =>
+              by_cases hlen : lenVal ≤ 55
+              · simp [hr, hlen] at hdec
+              · simp [hr, hlen] at hdec
+                cases ht : takeBytes rest' lenVal with
+                | none => simp [ht] at hdec
+                | some pair2 =>
+                    cases pair2 with
+                    | mk _ _ => simp [ht] at hdec
+
+/-- A complete RLP decode whose first byte is below `0xc0` cannot be a list. -/
+theorem decodeFully_ne_list_of_head_lt_c0
+    (pfx : Byte) (rest : List Byte) (items : List RLPItem)
+    (h : BitVec.ult (pfx.zeroExtend 64) (0xc0 : Word) = true) :
+    decodeFully (pfx :: rest) ≠ some (.list items) := by
+  intro hfull
+  have hdecode : decode (pfx :: rest) = some (.list items, []) :=
+    (decodeFully_eq_some_iff (pfx :: rest) (.list items)).1 hfull
+  rw [decode_cons_eq_decodeAux_fuel] at hdecode
+  exact decodeAux_ne_list_of_head_lt_c0 (2 * rest.length + 1) pfx rest [] items h hdecode
+
+/-- A withdrawal is encoded as an RLP list, so any byte/string prefix is a
+    reason-erased semantic failure. -/
+theorem decodeWithdrawal_none_of_head_lt_c0
+    (pfx : Byte) (rest : List Byte)
+    (h : BitVec.ult (pfx.zeroExtend 64) (0xc0 : Word) = true) :
+    decodeWithdrawal (pfx :: rest) = none := by
+  unfold decodeWithdrawal
+  generalize hfull : decodeFully (pfx :: rest) = decoded
+  cases decoded with
+  | none => rfl
+  | some item =>
+      cases item with
+      | bytes _ => rfl
+      | list items =>
+          exfalso
+          exact decodeFully_ne_list_of_head_lt_c0 pfx rest items h hfull
+
+/-- Scratch facts preserved by the empty-input failure case after exposing the
+    public ABI failure component. -/
+def walkInitEmptyFailAbiFrame (listLen t0Old t1Old : Word) : Assertion :=
+  ((.x11 ↦ᵣ listLen) ** (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) **
+    ⌜listLen = (0 : Word)⌝)
+
+/-- Scratch facts preserved by the not-list failure case after exposing the
+    public ABI failure component. -/
+def walkInitNotListFailAbiFrame
+    (listBase listLen : Word) (listBytes : List Byte)
+    (listOff : Nat) (hoff : listOff < listBytes.length) : Assertion :=
+  ((.x11 ↦ᵣ ((listBase + BitVec.ofNat 64 listOff) + listLen)) **
+    (.x5 ↦ᵣ walkInitPrefixWord listBytes listOff hoff) **
+    (.x6 ↦ᵣ (0xc0 : Word)) **
+    ⌜listLen ≠ (0 : Word)⌝ **
+    ⌜BitVec.ult (walkInitPrefixWord listBytes listOff hoff) (0xc0 : Word)⌝)
+
+theorem walkInitEmptyFailOutputPost_entails_abiFailureFrame
+    (inputBase listLen raVal t0Old t1Old outBase : Word) (input : List Byte)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64) :
+    WP.Entails
+      (walkInitEmptyFailOutputPost inputBase listLen raVal t0Old t1Old outBase input)
+      (abiPost inputBase outBase raVal input ** walkInitEmptyFailAbiFrame listLen t0Old t1Old) := by
+  intro h hp
+  have hpCase := hp
+  unfold walkInitEmptyFailOutputPost walkInitEmptyFailStatusPost failStatusReturnPost
+    statusReturnPost walkInitZeroPost at hpCase
+  rcases hpCase with ⟨hA, _hOut, _hdOut, _hunionOut, hA_prop, _hOut_prop⟩
+  rcases hA_prop with ⟨hB, _hBytes, _hdBytes, _hunionBytes, hB_prop, _hBytes_prop⟩
+  rcases hB_prop with ⟨hC, _hX6, _hdX6, _hunionX6, hC_prop, _hX6_prop⟩
+  rcases hC_prop with ⟨_hX1, _hX10, _hdX10, _hunionX10, _hX1_prop, _hX10_prop⟩
+  have hX6Pure := _hX6_prop
+  extract_pure hX6Pure
+  have hzero : listLen = (0 : Word) := hX6Pure.1
+  have hLengthZero : input.length = 0 := by
+    have heq : BitVec.ofNat 64 input.length = (0 : Word) := by
+      rw [← hLen]
+      exact hzero
+    have htn := congrArg BitVec.toNat heq
+    simp only [BitVec.toNat_ofNat, show (0 : Word).toNat = 0 from by decide] at htn
+    rw [Nat.mod_eq_of_lt hBound] at htn
+    exact htn
+  have hnil : input = [] := by
+    cases input with
+    | nil => rfl
+    | cons _ _ => simp at hLengthZero
+  have hdec : decodeWithdrawal input = none := by
+    rw [hnil]
+    exact decodeWithdrawal_nil
+  unfold walkInitEmptyFailOutputPost walkInitEmptyFailStatusPost failStatusReturnPost
+    statusReturnPost walkInitZeroPost at hp
+  unfold abiPost walkInitEmptyFailAbiFrame
+  rw [resultPost_failure hdec]
+  rw [show (⌜decodeWithdrawal input = none⌝ : Assertion) = empAssertion by
+    funext h
+    unfold EvmAsm.Rv64.pure EvmAsm.Rv64.empAssertion
+    apply propext
+    constructor
+    · intro h_p
+      exact h_p.1
+    · intro h_empty
+      exact ⟨h_empty, hdec⟩]
+  simp only [sepConj_emp_right']
+  xperm_hyp hp
+
+theorem walkInitNotListFailOutputPost_entails_abiFailureFrame_zeroOff
+    (inputBase listLen raVal outBase : Word) (input : List Byte)
+    (hoff : 0 < input.length) :
+    WP.Entails
+      (walkInitNotListFailOutputPost inputBase listLen raVal outBase input 0 hoff)
+      (abiPost inputBase outBase raVal input **
+        walkInitNotListFailAbiFrame inputBase listLen input 0 hoff) := by
+  intro h hp
+  have hpCase := hp
+  unfold walkInitNotListFailOutputPost walkInitPrefixNotListFailStatusPost
+    walkInitPrefixNotListFailStatusFrame walkInitPrefixWord at hpCase
+  rcases hpCase with ⟨hMain, _hOut, _hdOut, _hunionOut, hMain_prop, _hOut_prop⟩
+  rcases hMain_prop with ⟨_hFail, hFrame, _hdFrame, _hunionFrame, _hFail_prop, hFrame_prop⟩
+  rcases hFrame_prop with ⟨_hFrameHead, hFrameTail, _hdFrameTail, _hunionFrameTail,
+    _hFrameHead_prop, hFrameTail_prop⟩
+  have hFrameTailPure := hFrameTail_prop
+  extract_pure hFrameTailPure
+  have hlt : BitVec.ult (walkInitPrefixWord input 0 hoff) (0xc0 : Word) = true :=
+    hFrameTailPure.1
+  have hdec : decodeWithdrawal input = none := by
+    cases input with
+    | nil => simp at hoff
+    | cons pfx rest =>
+        simpa using decodeWithdrawal_none_of_head_lt_c0 pfx rest hlt
+  unfold walkInitNotListFailOutputPost walkInitPrefixNotListFailStatusPost
+    walkInitPrefixNotListFailStatusFrame failStatusReturnPost statusReturnPost walkInitPrefixWord at hp
+  unfold abiPost walkInitNotListFailAbiFrame walkInitPrefixWord
+  rw [resultPost_failure hdec]
+  rw [show (⌜decodeWithdrawal input = none⌝ : Assertion) = empAssertion by
+    funext h
+    unfold EvmAsm.Rv64.pure EvmAsm.Rv64.empAssertion
+    apply propext
+    constructor
+    · intro h_p
+      exact h_p.1
+    · intro h_empty
+      exact ⟨h_empty, hdec⟩]
+  simp only [sepConj_emp_right']
+  xperm_hyp hp
+
+/-- Walk-init classifier whose empty and not-list exits expose the semantic ABI
+    failure post, while short-list and long-list candidates remain open. -/
+def walkInitEmptyNotListAbiFailureNBranch
+    (base inputBase listLen raVal t0Old t1Old outBase : Word)
+    (input : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover0 : inputBase.toNat + 0 < 2 ^ 64)
+    (hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64) :
+    WP.NBranch base (walkInitEmptyFailNotListFailShortLongCode base) :=
+  walkInitEmptyFailNotListFailShortLongOutputCaseNBranch base inputBase listLen raVal
+    t0Old t1Old outBase input 0 hsalign hoff hover0 hvalid0
+    (abiPost inputBase outBase raVal input ** walkInitEmptyFailAbiFrame listLen t0Old t1Old)
+    (abiPost inputBase outBase raVal input ** walkInitNotListFailAbiFrame inputBase listLen input 0 hoff)
+    (walkInitShortListOutputPost inputBase listLen raVal outBase input 0 hoff)
+    (walkInitLongListOutputPost inputBase listLen raVal outBase input 0 hoff)
+    (walkInitEmptyFailOutputPost_entails_abiFailureFrame inputBase listLen raVal t0Old t1Old
+      outBase input hLen hBound)
+    (walkInitNotListFailOutputPost_entails_abiFailureFrame_zeroOff inputBase listLen raVal
+      outBase input hoff)
+    (WP.Entails.refl _)
+    (WP.Entails.refl _)
+
+theorem walkInitEmptyNotListAbiFailureNBranch_pre
+    (base inputBase listLen raVal t0Old t1Old outBase : Word)
+    (input : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover0 : inputBase.toNat + 0 < 2 ^ 64)
+    (hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64) :
+    (walkInitEmptyNotListAbiFailureNBranch base inputBase listLen raVal t0Old t1Old outBase
+      input hsalign hoff hover0 hvalid0 hLen hBound).pre =
+      (walkInitEmptyFailNotListFailShortLongOutputNBranch base inputBase listLen raVal t0Old
+        t1Old outBase input 0 hsalign hoff hover0 hvalid0).pre := by
+  rfl
+
+theorem walkInitEmptyNotListAbiFailureNBranch_exits
+    (base inputBase listLen raVal t0Old t1Old outBase : Word)
+    (input : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover0 : inputBase.toNat + 0 < 2 ^ 64)
+    (hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64) :
+    (walkInitEmptyNotListAbiFailureNBranch base inputBase listLen raVal t0Old t1Old outBase
+      input hsalign hoff hover0 hvalid0 hLen hBound).exits =
+      [ (failStatusReturnExit raVal,
+          abiPost inputBase outBase raVal input ** walkInitEmptyFailAbiFrame listLen t0Old t1Old)
+      , (failStatusReturnExit raVal,
+          abiPost inputBase outBase raVal input **
+            walkInitNotListFailAbiFrame inputBase listLen input 0 hoff)
+      , (base + 124,
+          walkInitShortListOutputPost inputBase listLen raVal outBase input 0 hoff)
+      , (base + 28,
+          walkInitLongListOutputPost inputBase listLen raVal outBase input 0 hoff)
+      ] := by
+  rfl
+
+end WithdrawalDecode
+
+end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeFailureWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeFailureWP.lean
@@ -92,6 +92,54 @@ theorem decodeWithdrawal_none_of_head_lt_c0
           exfalso
           exact decodeFully_ne_list_of_head_lt_c0 pfx rest items h hfull
 
+/-- The shallow empty-input split has a semantic failure head exit and one
+    syntactic nonzero fall-through exit. -/
+theorem walkInitEmptyInputFailureNBranch_exits
+    (base inputBase outBase raVal statusOld : Word) :
+    (walkInitEmptyInputFailureNBranch base inputBase outBase raVal statusOld).exits =
+      [ (failStatusReturnExit raVal, emptyInputFailurePost inputBase outBase raVal)
+      , (base + 4,
+          walkInitNonzeroOpenStatusPost (0 : Word) raVal statusOld **
+            emptyInputAbiFrame inputBase outBase)
+      ] := by
+  rfl
+
+/-- The nonzero fall-through exit of the empty-input specialization is
+    contradictory because it carries `0 != 0`. -/
+theorem walkInitEmptyInputNonzeroExit_contradicts
+    (inputBase outBase raVal statusOld : Word) :
+    ∀ h,
+      (walkInitNonzeroOpenStatusPost (0 : Word) raVal statusOld **
+        emptyInputAbiFrame inputBase outBase) h → False := by
+  intro h hp
+  unfold walkInitNonzeroOpenStatusPost walkInitNonzeroPost at hp
+  rcases hp with ⟨hMain, _hFrame, _hdFrame, _hunionFrame, hMain_prop, _hFrame_prop⟩
+  rcases hMain_prop with ⟨hRegs, _hFail, _hdFail, _hunionFail, hRegs_prop, _hFail_prop⟩
+  rcases hRegs_prop with ⟨_hRegs, hTail, _hdTail, _hunionTail, _hRegs_prop, hTail_prop⟩
+  rcases hTail_prop with ⟨_hX0, _hPure, _hdPure, _hunionPure, _hX0_prop, hPure_prop⟩
+  unfold EvmAsm.Rv64.pure at hPure_prop
+  exact hPure_prop.2 rfl
+
+/-- Resolved empty-input certificate: the impossible nonzero exit is closed by
+    contradiction, leaving the semantic failure post as the only result. -/
+def walkInitEmptyInputFailureCert
+    (base inputBase outBase raVal statusOld : Word) :
+    WP.CFG.Cert base (failStatusReturnExit raVal) (walkInitEmptyFailStatusCode base)
+      (emptyInputFailurePost inputBase outBase raVal) := by
+  let br := walkInitEmptyInputFailureNBranch base inputBase outBase raVal statusOld
+  wp_rv64_nbranch_join2_resolve_first_auto br,
+    (walkInitEmptyInputFailureNBranch_exits base inputBase outBase raVal statusOld),
+    (emptyInputFailurePost inputBase outBase raVal),
+    (walkInitEmptyInputNonzeroExit_contradicts inputBase outBase raVal statusOld)
+
+/-- The resolved empty-input certificate reduces to the shallow walk-init
+    empty-input precondition. -/
+theorem walkInitEmptyInputFailureCert_pre
+    (base inputBase outBase raVal statusOld : Word) :
+    (walkInitEmptyInputFailureCert base inputBase outBase raVal statusOld).pre =
+      (walkInitEmptyInputFailureNBranch base inputBase outBase raVal statusOld).pre := by
+  rfl
+
 /-- Scratch facts preserved by the empty-input failure case after exposing the
     public ABI failure component. -/
 def walkInitEmptyFailAbiFrame (listLen t0Old t1Old : Word) : Assertion :=

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeFailureWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeFailureWP.lean
@@ -239,8 +239,8 @@ theorem decodeWithdrawal_none_of_shortList_four_leftover
         rw [show 2 * payload.length - 1 + 1 = 2 * payload.length by omega] at h
         exact h
       have hr0 : r0 = payload.drop off1 := by
-        have hEq := Option.some.inj (hitem0.symm.trans h0fuel)
-        exact congrArg Prod.snd hEq
+        have h_eq := Option.some.inj (hitem0.symm.trans h0fuel)
+        exact congrArg Prod.snd h_eq
       subst r0
       have htail0' : decodeItems ((2 * payload.length - 1) + 1) (payload.drop off1) =
           some ([.bytes e1, .bytes e2, .bytes e3], []) := by
@@ -260,8 +260,8 @@ theorem decodeWithdrawal_none_of_shortList_four_leftover
         rw [show 2 * payload.length - 2 + 1 = 2 * payload.length - 1 by omega] at h
         exact h
       have hr1 : r1 = payload.drop off2 := by
-        have hEq := Option.some.inj (hitem1.symm.trans h1fuel)
-        exact congrArg Prod.snd hEq
+        have h_eq := Option.some.inj (hitem1.symm.trans h1fuel)
+        exact congrArg Prod.snd h_eq
       subst r1
       have htail1' : decodeItems ((2 * payload.length - 2) + 1) (payload.drop off2) =
           some ([.bytes e2, .bytes e3], []) := by
@@ -281,8 +281,8 @@ theorem decodeWithdrawal_none_of_shortList_four_leftover
         rw [show 2 * payload.length - 3 + 1 = 2 * payload.length - 2 by omega] at h
         exact h
       have hr2 : r2 = payload.drop off3 := by
-        have hEq := Option.some.inj (hitem2.symm.trans h2fuel)
-        exact congrArg Prod.snd hEq
+        have h_eq := Option.some.inj (hitem2.symm.trans h2fuel)
+        exact congrArg Prod.snd h_eq
       subst r2
       have htail2' : decodeItems ((2 * payload.length - 3) + 1) (payload.drop off3) =
           some ([.bytes e3], []) := by
@@ -302,11 +302,137 @@ theorem decodeWithdrawal_none_of_shortList_four_leftover
         rw [show 2 * payload.length - 4 + 1 = 2 * payload.length - 3 by omega] at h
         exact h
       have hr3 : r3 = payload.drop off4 := by
-        have hEq := Option.some.inj (hitem3.symm.trans h3fuel)
-        exact congrArg Prod.snd hEq
+        have h_eq := Option.some.inj (hitem3.symm.trans h3fuel)
+        exact congrArg Prod.snd h_eq
       subst r3
       exact decodeItems_ne_empty_of_ne_nil (fuel := 2 * payload.length - 3)
         (bs := payload.drop off4) (by omega) h_leftover htail3
+
+/-- If four byte-string field decoders have succeeded inside a short-list
+    payload but the fourth remainder is nonempty, the withdrawal decode fails.
+    This chain form matches validating WP field posts and hides synthetic offsets. -/
+theorem decodeWithdrawal_none_of_shortList_four_leftover_chain
+    (pfx : Byte) (payload r1 r2 r3 r4 : List Byte) (d0 d1 d2 d3 : List Byte)
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (h0 : ∀ m, decodeAux (m + 1) payload = some (.bytes d0, r1))
+    (h1 : ∀ m, decodeAux (m + 1) r1 = some (.bytes d1, r2))
+    (h2 : ∀ m, decodeAux (m + 1) r2 = some (.bytes d2, r3))
+    (h3 : ∀ m, decodeAux (m + 1) r3 = some (.bytes d3, r4))
+    (h_leftover : r4 ≠ [])
+    (h_min : 2 ≤ payload.length) :
+    decodeWithdrawal (pfx :: payload) = none := by
+  cases hdec : decodeWithdrawal (pfx :: payload) with
+  | none => rfl
+  | some w =>
+      exfalso
+      rcases (decodeWithdrawal_eq_some_iff (pfx :: payload) w).mp hdec with
+        ⟨e0, e1, e2, e3, hfull, _hc0, _hl0, _hc1, _hl1, _haddr, _hc3, _hl3,
+          _hi, _hv, _ha, _hamt⟩
+      have hdecode : decode (pfx :: payload) =
+          some (.list [.bytes e0, .bytes e1, .bytes e2, .bytes e3], []) :=
+        (decodeFully_eq_some_iff (pfx :: payload)
+          (.list [.bytes e0, .bytes e1, .bytes e2, .bytes e3])).1 hfull
+      rw [decode_cons_eq_decodeAux_fuel,
+        show 2 * payload.length + 2 = (2 * payload.length + 1) + 1 by omega,
+        ListDecodeBridge.decodeAux_cons_shortList_eq_decodeListPayload
+          (2 * payload.length + 1) pfx payload h_class] at hdecode
+      have htake : takeBytes payload (rlpPrefixShortListPayloadLen pfx) =
+          some (payload, []) := by
+        rw [h_len, takeBytes_length_ge (le_refl payload.length), List.take_length,
+          List.drop_length]
+      rw [htake] at hdecode
+      change Option.bind (ListDecodeBridge.decodeListPayload (2 * payload.length + 1) payload)
+          (fun items => some (RLPItem.list items, ([] : List Byte))) =
+        some (RLPItem.list [.bytes e0, .bytes e1, .bytes e2, .bytes e3], []) at hdecode
+      have hpayload : ListDecodeBridge.decodeListPayload (2 * payload.length + 1) payload =
+          some [.bytes e0, .bytes e1, .bytes e2, .bytes e3] := by
+        cases hpayload :
+            ListDecodeBridge.decodeListPayload (2 * payload.length + 1) payload with
+        | none =>
+            simp [hpayload] at hdecode
+        | some items =>
+            simpa [hpayload] using hdecode
+      have hitems : decodeItems (2 * payload.length + 1) payload =
+          some ([.bytes e0, .bytes e1, .bytes e2, .bytes e3], []) :=
+        (ListDecodeBridge.decodeListPayload_eq_some_iff
+          (2 * payload.length + 1) payload
+          [.bytes e0, .bytes e1, .bytes e2, .bytes e3]).1 hpayload
+      have hne0 : payload ≠ [] := by
+        intro hnil
+        rw [hnil] at h_min
+        simp at h_min
+      rcases decodeItems_cons_inv payload (.bytes e0)
+          [.bytes e1, .bytes e2, .bytes e3] [] (2 * payload.length) hne0 hitems with
+        ⟨r0, hitem0, htail0⟩
+      have h0fuel : decodeAux (2 * payload.length) payload = some (.bytes d0, r1) := by
+        have h := h0 (2 * payload.length - 1)
+        rw [show 2 * payload.length - 1 + 1 = 2 * payload.length by omega] at h
+        exact h
+      have hr0 : r0 = r1 := by
+        have h_eq := Option.some.inj (hitem0.symm.trans h0fuel)
+        exact congrArg Prod.snd h_eq
+      subst r0
+      have htail0' : decodeItems ((2 * payload.length - 1) + 1) r1 =
+          some ([.bytes e1, .bytes e2, .bytes e3], []) := by
+        rw [show 2 * payload.length - 1 + 1 = 2 * payload.length by omega]
+        exact htail0
+      rcases decodeItems_cons_inv r1 (.bytes e1) [.bytes e2, .bytes e3] []
+          (2 * payload.length - 1)
+          (by
+            intro hnil
+            have hbad := h1 0
+            rw [hnil, decodeAux_nil] at hbad
+            simp at hbad) htail0' with
+        ⟨r1', hitem1, htail1⟩
+      have h1fuel : decodeAux (2 * payload.length - 1) r1 = some (.bytes d1, r2) := by
+        have h := h1 (2 * payload.length - 2)
+        rw [show 2 * payload.length - 2 + 1 = 2 * payload.length - 1 by omega] at h
+        exact h
+      have hr1 : r1' = r2 := by
+        have h_eq := Option.some.inj (hitem1.symm.trans h1fuel)
+        exact congrArg Prod.snd h_eq
+      subst r1'
+      have htail1' : decodeItems ((2 * payload.length - 2) + 1) r2 =
+          some ([.bytes e2, .bytes e3], []) := by
+        rw [show 2 * payload.length - 2 + 1 = 2 * payload.length - 1 by omega]
+        exact htail1
+      rcases decodeItems_cons_inv r2 (.bytes e2) [.bytes e3] [] (2 * payload.length - 2)
+          (by
+            intro hnil
+            have hbad := h2 0
+            rw [hnil, decodeAux_nil] at hbad
+            simp at hbad) htail1' with
+        ⟨r2', hitem2, htail2⟩
+      have h2fuel : decodeAux (2 * payload.length - 2) r2 = some (.bytes d2, r3) := by
+        have h := h2 (2 * payload.length - 3)
+        rw [show 2 * payload.length - 3 + 1 = 2 * payload.length - 2 by omega] at h
+        exact h
+      have hr2 : r2' = r3 := by
+        have h_eq := Option.some.inj (hitem2.symm.trans h2fuel)
+        exact congrArg Prod.snd h_eq
+      subst r2'
+      have htail2' : decodeItems ((2 * payload.length - 3) + 1) r3 =
+          some ([.bytes e3], []) := by
+        rw [show 2 * payload.length - 3 + 1 = 2 * payload.length - 2 by omega]
+        exact htail2
+      rcases decodeItems_cons_inv r3 (.bytes e3) [] [] (2 * payload.length - 3)
+          (by
+            intro hnil
+            have hbad := h3 0
+            rw [hnil, decodeAux_nil] at hbad
+            simp at hbad) htail2' with
+        ⟨r3', hitem3, htail3⟩
+      have h3fuel : decodeAux (2 * payload.length - 3) r3 = some (.bytes d3, r4) := by
+        have h := h3 (2 * payload.length - 4)
+        rw [show 2 * payload.length - 4 + 1 = 2 * payload.length - 3 by omega] at h
+        exact h
+      have hr3 : r3' = r4 := by
+        have h_eq := Option.some.inj (hitem3.symm.trans h3fuel)
+        exact congrArg Prod.snd h_eq
+      subst r3'
+      exact decodeItems_ne_empty_of_ne_nil (fuel := 2 * payload.length - 3)
+        (bs := r4) (by omega) h_leftover htail3
 
 /-- Implicit-argument facade for tactic use of
     `decodeWithdrawal_none_of_shortList_four_leftover`. -/
@@ -327,6 +453,22 @@ theorem decodeWithdrawal_none_of_shortList_four_leftover_auto
     decodeWithdrawal (pfx :: payload) = none :=
   decodeWithdrawal_none_of_shortList_four_leftover pfx payload off1 off2 off3 off4
     d0 d1 d2 d3 h_class h_len h0 h1 h2 h3 h_leftover h_min
+
+/-- Implicit-argument facade for tactic use of the chain-shaped exact-arity
+    failure bridge. -/
+theorem decodeWithdrawal_none_of_shortList_four_leftover_chain_auto
+    {pfx : Byte} {payload r1 r2 r3 r4 d0 d1 d2 d3 : List Byte}
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (h0 : ∀ m, decodeAux (m + 1) payload = some (.bytes d0, r1))
+    (h1 : ∀ m, decodeAux (m + 1) r1 = some (.bytes d1, r2))
+    (h2 : ∀ m, decodeAux (m + 1) r2 = some (.bytes d2, r3))
+    (h3 : ∀ m, decodeAux (m + 1) r3 = some (.bytes d3, r4))
+    (h_leftover : r4 ≠ [])
+    (h_min : 2 ≤ payload.length) :
+    decodeWithdrawal (pfx :: payload) = none :=
+  decodeWithdrawal_none_of_shortList_four_leftover_chain pfx payload r1 r2 r3 r4 d0 d1 d2 d3
+    h_class h_len h0 h1 h2 h3 h_leftover h_min
 
 /-- Exact-arity failure bridge for generated schema walks.  Once the four
     withdrawal fields have consumed a strict prefix of the short-list payload,

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeFailureWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeFailureWP.lean
@@ -146,6 +146,187 @@ theorem decodeWithdrawal_none_of_decodeFully_list_length_ne_four
       rw [hitems]
       rfl
 
+/-- A nonempty byte stream cannot decode as zero list-payload items with
+    positive fuel. -/
+theorem decodeItems_ne_empty_of_ne_nil
+    {fuel : Nat} {bs : List Byte}
+    (hfuel : 1 ≤ fuel) (hne : bs ≠ []) :
+    decodeItems fuel bs ≠ some ([], []) := by
+  intro hitems
+  obtain ⟨fuel', rfl⟩ : ∃ fuel', fuel = fuel' + 1 := by
+    cases fuel with
+    | zero => omega
+    | succ fuel' => exact ⟨fuel', rfl⟩
+  rw [decodeItems_succ_of_ne_nil fuel' bs hne] at hitems
+  cases haux : decodeAux fuel' bs with
+  | none =>
+      simp [haux] at hitems
+  | some decoded =>
+      rcases decoded with ⟨item, rest⟩
+      cases hrest : decodeItems fuel' rest with
+      | none =>
+          simp [haux, hrest] at hitems
+      | some decodedRest =>
+          rcases decodedRest with ⟨items, rest'⟩
+          simp [haux, hrest] at hitems
+
+/-- If four byte-string field decoders have succeeded inside a short-list
+    payload but the cursor has not reached the payload end, the withdrawal decode
+    is a reason-erased semantic failure. This is the pure bridge used by the
+    validating exact-arity failure path. -/
+theorem decodeWithdrawal_none_of_shortList_four_leftover
+    (pfx : Byte) (payload : List Byte)
+    (off1 off2 off3 off4 : Nat) (d0 d1 d2 d3 : List Byte)
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (h0 : ∀ m, decodeAux (m + 1) payload = some (.bytes d0, payload.drop off1))
+    (h1 : ∀ m, decodeAux (m + 1) (payload.drop off1) =
+      some (.bytes d1, payload.drop off2))
+    (h2 : ∀ m, decodeAux (m + 1) (payload.drop off2) =
+      some (.bytes d2, payload.drop off3))
+    (h3 : ∀ m, decodeAux (m + 1) (payload.drop off3) =
+      some (.bytes d3, payload.drop off4))
+    (h_leftover : payload.drop off4 ≠ [])
+    (h_min : 2 ≤ payload.length) :
+    decodeWithdrawal (pfx :: payload) = none := by
+  cases hdec : decodeWithdrawal (pfx :: payload) with
+  | none => rfl
+  | some w =>
+      exfalso
+      rcases (decodeWithdrawal_eq_some_iff (pfx :: payload) w).mp hdec with
+        ⟨e0, e1, e2, e3, hfull, _hc0, _hl0, _hc1, _hl1, _haddr, _hc3, _hl3,
+          _hi, _hv, _ha, _hamt⟩
+      have hdecode : decode (pfx :: payload) =
+          some (.list [.bytes e0, .bytes e1, .bytes e2, .bytes e3], []) :=
+        (decodeFully_eq_some_iff (pfx :: payload)
+          (.list [.bytes e0, .bytes e1, .bytes e2, .bytes e3])).1 hfull
+      rw [decode_cons_eq_decodeAux_fuel,
+        show 2 * payload.length + 2 = (2 * payload.length + 1) + 1 by omega,
+        ListDecodeBridge.decodeAux_cons_shortList_eq_decodeListPayload
+          (2 * payload.length + 1) pfx payload h_class] at hdecode
+      have htake : takeBytes payload (rlpPrefixShortListPayloadLen pfx) =
+          some (payload, []) := by
+        rw [h_len, takeBytes_length_ge (le_refl payload.length), List.take_length,
+          List.drop_length]
+      rw [htake] at hdecode
+      change Option.bind (ListDecodeBridge.decodeListPayload (2 * payload.length + 1) payload)
+          (fun items => some (RLPItem.list items, ([] : List Byte))) =
+        some (RLPItem.list [.bytes e0, .bytes e1, .bytes e2, .bytes e3], []) at hdecode
+      have hpayload : ListDecodeBridge.decodeListPayload (2 * payload.length + 1) payload =
+          some [.bytes e0, .bytes e1, .bytes e2, .bytes e3] := by
+        cases hpayload :
+            ListDecodeBridge.decodeListPayload (2 * payload.length + 1) payload with
+        | none =>
+            simp [hpayload] at hdecode
+        | some items =>
+            simpa [hpayload] using hdecode
+      have hitems : decodeItems (2 * payload.length + 1) payload =
+          some ([.bytes e0, .bytes e1, .bytes e2, .bytes e3], []) :=
+        (ListDecodeBridge.decodeListPayload_eq_some_iff
+          (2 * payload.length + 1) payload
+          [.bytes e0, .bytes e1, .bytes e2, .bytes e3]).1 hpayload
+      have hne0 : payload ≠ [] := by
+        intro hnil
+        rw [hnil] at h_min
+        simp at h_min
+      rcases decodeItems_cons_inv payload (.bytes e0)
+          [.bytes e1, .bytes e2, .bytes e3] [] (2 * payload.length) hne0 hitems with
+        ⟨r0, hitem0, htail0⟩
+      have h0fuel : decodeAux (2 * payload.length) payload =
+          some (.bytes d0, payload.drop off1) := by
+        have h := h0 (2 * payload.length - 1)
+        rw [show 2 * payload.length - 1 + 1 = 2 * payload.length by omega] at h
+        exact h
+      have hr0 : r0 = payload.drop off1 := by
+        have hEq := Option.some.inj (hitem0.symm.trans h0fuel)
+        exact congrArg Prod.snd hEq
+      subst r0
+      have htail0' : decodeItems ((2 * payload.length - 1) + 1) (payload.drop off1) =
+          some ([.bytes e1, .bytes e2, .bytes e3], []) := by
+        rw [show 2 * payload.length - 1 + 1 = 2 * payload.length by omega]
+        exact htail0
+      rcases decodeItems_cons_inv (payload.drop off1) (.bytes e1)
+          [.bytes e2, .bytes e3] [] (2 * payload.length - 1)
+          (by
+            intro hnil
+            have hbad := h1 0
+            rw [hnil, decodeAux_nil] at hbad
+            simp at hbad) htail0' with
+        ⟨r1, hitem1, htail1⟩
+      have h1fuel : decodeAux (2 * payload.length - 1) (payload.drop off1) =
+          some (.bytes d1, payload.drop off2) := by
+        have h := h1 (2 * payload.length - 2)
+        rw [show 2 * payload.length - 2 + 1 = 2 * payload.length - 1 by omega] at h
+        exact h
+      have hr1 : r1 = payload.drop off2 := by
+        have hEq := Option.some.inj (hitem1.symm.trans h1fuel)
+        exact congrArg Prod.snd hEq
+      subst r1
+      have htail1' : decodeItems ((2 * payload.length - 2) + 1) (payload.drop off2) =
+          some ([.bytes e2, .bytes e3], []) := by
+        rw [show 2 * payload.length - 2 + 1 = 2 * payload.length - 1 by omega]
+        exact htail1
+      rcases decodeItems_cons_inv (payload.drop off2) (.bytes e2)
+          [.bytes e3] [] (2 * payload.length - 2)
+          (by
+            intro hnil
+            have hbad := h2 0
+            rw [hnil, decodeAux_nil] at hbad
+            simp at hbad) htail1' with
+        ⟨r2, hitem2, htail2⟩
+      have h2fuel : decodeAux (2 * payload.length - 2) (payload.drop off2) =
+          some (.bytes d2, payload.drop off3) := by
+        have h := h2 (2 * payload.length - 3)
+        rw [show 2 * payload.length - 3 + 1 = 2 * payload.length - 2 by omega] at h
+        exact h
+      have hr2 : r2 = payload.drop off3 := by
+        have hEq := Option.some.inj (hitem2.symm.trans h2fuel)
+        exact congrArg Prod.snd hEq
+      subst r2
+      have htail2' : decodeItems ((2 * payload.length - 3) + 1) (payload.drop off3) =
+          some ([.bytes e3], []) := by
+        rw [show 2 * payload.length - 3 + 1 = 2 * payload.length - 2 by omega]
+        exact htail2
+      rcases decodeItems_cons_inv (payload.drop off3) (.bytes e3)
+          [] [] (2 * payload.length - 3)
+          (by
+            intro hnil
+            have hbad := h3 0
+            rw [hnil, decodeAux_nil] at hbad
+            simp at hbad) htail2' with
+        ⟨r3, hitem3, htail3⟩
+      have h3fuel : decodeAux (2 * payload.length - 3) (payload.drop off3) =
+          some (.bytes d3, payload.drop off4) := by
+        have h := h3 (2 * payload.length - 4)
+        rw [show 2 * payload.length - 4 + 1 = 2 * payload.length - 3 by omega] at h
+        exact h
+      have hr3 : r3 = payload.drop off4 := by
+        have hEq := Option.some.inj (hitem3.symm.trans h3fuel)
+        exact congrArg Prod.snd hEq
+      subst r3
+      exact decodeItems_ne_empty_of_ne_nil (fuel := 2 * payload.length - 3)
+        (bs := payload.drop off4) (by omega) h_leftover htail3
+
+/-- Implicit-argument facade for tactic use of
+    `decodeWithdrawal_none_of_shortList_four_leftover`. -/
+theorem decodeWithdrawal_none_of_shortList_four_leftover_auto
+    {pfx : Byte} {payload d0 d1 d2 d3 : List Byte}
+    {off1 off2 off3 off4 : Nat}
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (h0 : ∀ m, decodeAux (m + 1) payload = some (.bytes d0, payload.drop off1))
+    (h1 : ∀ m, decodeAux (m + 1) (payload.drop off1) =
+      some (.bytes d1, payload.drop off2))
+    (h2 : ∀ m, decodeAux (m + 1) (payload.drop off2) =
+      some (.bytes d2, payload.drop off3))
+    (h3 : ∀ m, decodeAux (m + 1) (payload.drop off3) =
+      some (.bytes d3, payload.drop off4))
+    (h_leftover : payload.drop off4 ≠ [])
+    (h_min : 2 ≤ payload.length) :
+    decodeWithdrawal (pfx :: payload) = none :=
+  decodeWithdrawal_none_of_shortList_four_leftover pfx payload off1 off2 off3 off4
+    d0 d1 d2 d3 h_class h_len h0 h1 h2 h3 h_leftover h_min
+
 /-- Four decoded byte fields that fail the withdrawal field contract are a
     semantic failure, independent of which guard failed. -/
 theorem decodeWithdrawal_none_of_decodeFully_fields_not_canonical

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeFailureWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeFailureWP.lean
@@ -120,6 +120,8 @@ theorem walkInitEmptyInputNonzeroExit_contradicts
   unfold EvmAsm.Rv64.pure at hPure_prop
   exact hPure_prop.2 rfl
 
+attribute [rv64_wp_dead] walkInitEmptyInputNonzeroExit_contradicts
+
 /-- Resolved empty-input certificate: the impossible nonzero exit is closed by
     contradiction, leaving the semantic failure post as the only result. -/
 def walkInitEmptyInputFailureCert
@@ -127,10 +129,9 @@ def walkInitEmptyInputFailureCert
     WP.CFG.Cert base (failStatusReturnExit raVal) (walkInitEmptyFailStatusCode base)
       (emptyInputFailurePost inputBase outBase raVal) := by
   let br := walkInitEmptyInputFailureNBranch base inputBase outBase raVal statusOld
-  wp_rv64_nbranch_join2_resolve_first_auto br,
+  wp_rv64_nbranch_join2_resolve_first_dead_auto br,
     (walkInitEmptyInputFailureNBranch_exits base inputBase outBase raVal statusOld),
-    (emptyInputFailurePost inputBase outBase raVal),
-    (walkInitEmptyInputNonzeroExit_contradicts inputBase outBase raVal statusOld)
+    (emptyInputFailurePost inputBase outBase raVal)
 
 /-- The resolved empty-input certificate reduces to the shallow walk-init
     empty-input precondition. -/

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeFailureWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeFailureWP.lean
@@ -7,6 +7,7 @@
 -/
 
 import EvmAsm.Rv64.RLP.WithdrawalDecode
+import EvmAsm.Rv64.RLP.WithdrawalSchemaWP
 
 namespace EvmAsm.Rv64.RLP
 
@@ -326,6 +327,100 @@ theorem decodeWithdrawal_none_of_shortList_four_leftover_auto
     decodeWithdrawal (pfx :: payload) = none :=
   decodeWithdrawal_none_of_shortList_four_leftover pfx payload off1 off2 off3 off4
     d0 d1 d2 d3 h_class h_len h0 h1 h2 h3 h_leftover h_min
+
+/-- Exact-arity failure bridge for generated schema walks.  Once the four
+    withdrawal fields have consumed a strict prefix of the short-list payload,
+    the public semantic result is failure; the exact failure reason remains
+    erased.  The schema itself stays result-free: the field bytes appear only as
+    postcondition witnesses. -/
+theorem decodeWithdrawal_none_of_shortList_successFieldSpecs_leftover
+    (pfx : Byte) (payload tail d0 d1 d2 d3 : List Byte)
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (hl0 : d0.length ≤ 8) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20) (hl3 : d3.length ≤ 8)
+    (h_payload : payload = schemaEncBytes (successFieldSpecs d0 d1 d2 d3) ++ tail)
+    (h_tail : tail ≠ [])
+    (h_min : 2 ≤ payload.length) :
+    decodeWithdrawal (pfx :: payload) = none := by
+  let off1 := (encodeBytes d0).length
+  let off2 := off1 + (encodeBytes d1).length
+  let off3 := off2 + (encodeBytes d2).length
+  let off4 := off3 + (encodeBytes d3).length
+  have h_payload_norm :
+      payload =
+        encodeBytes d0 ++ (encodeBytes d1 ++ (encodeBytes d2 ++ (encodeBytes d3 ++ tail))) := by
+    rw [h_payload]
+    simp [schemaEncBytes, successFieldSpecs, encode, List.append_assoc]
+  have hd0_lt : d0.length < 256 ^ 8 := by omega
+  have hd1_lt : d1.length < 256 ^ 8 := by omega
+  have hd2_lt : d2.length < 256 ^ 8 := by omega
+  have hd3_lt : d3.length < 256 ^ 8 := by omega
+  have hdrop1 :
+      payload.drop off1 = encodeBytes d1 ++ (encodeBytes d2 ++ (encodeBytes d3 ++ tail)) := by
+    rw [h_payload_norm]
+    dsimp [off1]
+    rw [List.drop_append_length]
+  have hdrop2 : payload.drop off2 = encodeBytes d2 ++ (encodeBytes d3 ++ tail) := by
+    rw [h_payload_norm]
+    dsimp [off1, off2]
+    rw [← List.drop_drop, List.drop_append_length, List.drop_append_length]
+  have hdrop3 : payload.drop off3 = encodeBytes d3 ++ tail := by
+    rw [h_payload_norm]
+    dsimp [off1, off2, off3]
+    rw [← List.drop_drop, ← List.drop_drop]
+    rw [List.drop_append_length, List.drop_append_length, List.drop_append_length]
+  have hdrop4 : payload.drop off4 = tail := by
+    rw [h_payload_norm]
+    dsimp [off1, off2, off3, off4]
+    rw [← List.drop_drop, ← List.drop_drop, ← List.drop_drop]
+    rw [List.drop_append_length, List.drop_append_length, List.drop_append_length,
+      List.drop_append_length]
+  have h0 : ∀ m, decodeAux (m + 1) payload = some (.bytes d0, payload.drop off1) := by
+    intro m
+    rw [h_payload_norm]
+    dsimp [off1]
+    rw [decodeAux_succ_encodeBytes_append m d0
+      (encodeBytes d1 ++ (encodeBytes d2 ++ (encodeBytes d3 ++ tail))) hd0_lt]
+    rw [List.drop_append_length]
+  have h1 : ∀ m, decodeAux (m + 1) (payload.drop off1) =
+      some (.bytes d1, payload.drop off2) := by
+    intro m
+    rw [hdrop1]
+    rw [decodeAux_succ_encodeBytes_append m d1 (encodeBytes d2 ++ (encodeBytes d3 ++ tail))
+      hd1_lt]
+    rw [hdrop2]
+  have h2 : ∀ m, decodeAux (m + 1) (payload.drop off2) =
+      some (.bytes d2, payload.drop off3) := by
+    intro m
+    rw [hdrop2]
+    rw [decodeAux_succ_encodeBytes_append m d2 (encodeBytes d3 ++ tail) hd2_lt]
+    rw [hdrop3]
+  have h3 : ∀ m, decodeAux (m + 1) (payload.drop off3) =
+      some (.bytes d3, payload.drop off4) := by
+    intro m
+    rw [hdrop3]
+    rw [decodeAux_succ_encodeBytes_append m d3 tail hd3_lt]
+    rw [hdrop4]
+  have h_leftover : payload.drop off4 ≠ [] := by
+    rw [hdrop4]
+    exact h_tail
+  exact decodeWithdrawal_none_of_shortList_four_leftover pfx payload off1 off2 off3 off4
+    d0 d1 d2 d3 h_class h_len h0 h1 h2 h3 h_leftover h_min
+
+/-- Implicit-argument facade for tactic use with a schema payload-concat fact. -/
+theorem decodeWithdrawal_none_of_shortList_successFieldSpecs_leftover_auto
+    {pfx : Byte} {payload tail d0 d1 d2 d3 : List Byte}
+    (h_class : classifyPrefix pfx = .shortList)
+    (h_len : rlpPrefixShortListPayloadLen pfx = payload.length)
+    (hl0 : d0.length ≤ 8) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20) (hl3 : d3.length ≤ 8)
+    (h_payload : payload = schemaEncBytes (successFieldSpecs d0 d1 d2 d3) ++ tail)
+    (h_tail : tail ≠ [])
+    (h_min : 2 ≤ payload.length) :
+    decodeWithdrawal (pfx :: payload) = none :=
+  decodeWithdrawal_none_of_shortList_successFieldSpecs_leftover pfx payload tail d0 d1 d2 d3
+    h_class h_len hl0 hl1 haddr hl3 h_payload h_tail h_min
 
 /-- Four decoded byte fields that fail the withdrawal field contract are a
     semantic failure, independent of which guard failed. -/

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeFailureWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeFailureWP.lean
@@ -92,6 +92,86 @@ theorem decodeWithdrawal_none_of_head_lt_c0
           exfalso
           exact decodeFully_ne_list_of_head_lt_c0 pfx rest items h hfull
 
+/-- A failed complete RLP decode is a reason-erased withdrawal failure. -/
+theorem decodeWithdrawal_none_of_decodeFully_none
+    {input : List Byte} (hfull : decodeFully input = none) :
+    decodeWithdrawal input = none := by
+  unfold decodeWithdrawal
+  rw [hfull]
+
+/-- A failed raw RLP decode is a reason-erased withdrawal failure. -/
+theorem decodeWithdrawal_none_of_decode_none
+    {input : List Byte} (hdecode : decode input = none) :
+    decodeWithdrawal input = none :=
+  decodeWithdrawal_none_of_decodeFully_none (decodeFully_eq_none_of_decode_none hdecode)
+
+/-- A raw RLP decode with trailing input is a reason-erased withdrawal failure. -/
+theorem decodeWithdrawal_none_of_decode_leftover
+    {input leftover : List Byte} {item : RLPItem}
+    (hdecode : decode input = some (item, leftover))
+    (hleftover : leftover ≠ []) :
+    decodeWithdrawal input = none :=
+  decodeWithdrawal_none_of_decodeFully_none
+    (decodeFully_eq_none_of_decode_leftover hdecode hleftover)
+
+/-- A complete RLP bytes item cannot be a withdrawal list. -/
+theorem decodeWithdrawal_none_of_decodeFully_bytes
+    {input data : List Byte} (hfull : decodeFully input = some (.bytes data)) :
+    decodeWithdrawal input = none := by
+  unfold decodeWithdrawal
+  rw [hfull]
+
+/-- A completely decoded list with the wrong arity is rejected by
+    `decodeWithdrawal`; the precise failure reason is intentionally erased. -/
+theorem decodeWithdrawal_none_of_decodeFully_list_length_ne_four
+    {input : List Byte} {items : List RLPItem}
+    (hfull : decodeFully input = some (.list items))
+    (hlen : items.length ≠ 4) :
+    decodeWithdrawal input = none := by
+  cases hdec : decodeWithdrawal input with
+  | none => rfl
+  | some w =>
+      exfalso
+      rcases (decodeWithdrawal_eq_some_iff input w).mp hdec with
+        ⟨d0, d1, d2, d3, hfull', _hc0, _hl0, _hc1, _hl1, _haddr, _hc3, _hl3,
+          _hi, _hv, _ha, _hamt⟩
+      have hsome : some (RLPItem.list items) =
+          some (RLPItem.list [RLPItem.bytes d0, RLPItem.bytes d1, RLPItem.bytes d2,
+            RLPItem.bytes d3]) :=
+        hfull.symm.trans hfull'
+      have hitems : items = [RLPItem.bytes d0, RLPItem.bytes d1, RLPItem.bytes d2,
+          RLPItem.bytes d3] := by
+        simpa using hsome
+      apply hlen
+      rw [hitems]
+      rfl
+
+/-- Four decoded byte fields that fail the withdrawal field contract are a
+    semantic failure, independent of which guard failed. -/
+theorem decodeWithdrawal_none_of_decodeFully_fields_not_canonical
+    {input d0 d1 d2 d3 : List Byte}
+    (hfull : decodeFully input = some (.list [.bytes d0, .bytes d1, .bytes d2, .bytes d3]))
+    (hbad : ¬
+      (d0.headD 1 ≠ 0 ∧ d0.length ≤ 8 ∧
+        d1.headD 1 ≠ 0 ∧ d1.length ≤ 8 ∧
+        d2.length = 20 ∧
+        d3.headD 1 ≠ 0 ∧ d3.length ≤ 8)) :
+    decodeWithdrawal input = none := by
+  cases hdec : decodeWithdrawal input with
+  | none => rfl
+  | some _w =>
+      exfalso
+      unfold decodeWithdrawal at hdec
+      rw [hfull] at hdec
+      simp at hdec
+      have hgood :
+          d0.headD 1 ≠ 0 ∧ d0.length ≤ 8 ∧
+            d1.headD 1 ≠ 0 ∧ d1.length ≤ 8 ∧
+            d2.length = 20 ∧
+            d3.headD 1 ≠ 0 ∧ d3.length ≤ 8 := by
+        simpa [List.headD_eq_head?] using hdec.1
+      exact hbad hgood
+
 /-- The shallow empty-input split has a semantic failure head exit and one
     syntactic nonzero fall-through exit. -/
 theorem walkInitEmptyInputFailureNBranch_exits

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -1631,9 +1631,9 @@ def walkInitZeroNonzeroAbiFailureFromPrologueNBranch
         hwin 0 hoff
       have hBound : (b :: rest).length < 2 ^ 64 := by
         omega
-      exact walkInitAbiFailureFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old
-        outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old (b :: rest) hsalign hoff
-        hover0 hvalid0 hLen hBound hprologueCode hcode
+      exact walkInitAbiFailureReasonErasedFromPrologueNBranch base sp0 raVal s0Old s1Old
+        s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old (b :: rest) hsalign
+        hoff hover0 hvalid0 hLen hBound hprologueCode hcode
 
 /-- Fully reduced precondition for the input-indexed empty/nonempty ABI-failure
     facade. It is static and contains no pre-decoded branch/result fact. -/
@@ -1666,7 +1666,7 @@ attribute [rv64_wp]
   walkInitZeroNonzeroAbiFailureFromPrologueNBranch_pre
 
 /-- Input-indexed exits for the zero/nonzero prologue facade. Empty input keeps
-    the two-way zero/nonzero split; nonempty input exposes the four semantic
+    the two-way zero/nonzero split; nonempty input exposes reason-erased
     classifier exits. -/
 def walkInitZeroNonzeroAbiFailureFromPrologueExits
     (base sp0 raVal s0Old s1Old s2Old outBase : Word)
@@ -1677,7 +1677,7 @@ def walkInitZeroNonzeroAbiFailureFromPrologueExits
       walkInitEmptyInputFailureFromPrologueSharedFrameExits base sp0 raVal s0Old s1Old
         s2Old outBase inputBase t0Old t1Old
   | b :: rest =>
-      walkInitAbiFailureFromPrologueExits base sp0 raVal s0Old s1Old s2Old outBase
+      walkInitAbiFailureReasonErasedFromPrologueExits base sp0 raVal s0Old s1Old s2Old outBase
         inputBase listLen t0Old t1Old (b :: rest) (by simp)
 
 theorem walkInitZeroNonzeroAbiFailureFromPrologueNBranch_exits

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -540,6 +540,76 @@ theorem walkInitShortSuccessResolvedCert_pre
   unfold walkInitShortSuccessResolvedCert
   rfl
 
+
+/-- Fully reduced WP precondition for the short-list success classifier.  The
+    precondition is still result-free: it contains the input bytes, the loaded
+    length, scratch registers, and the zeroed schema handoff frame, but no
+    decoded withdrawal value. -/
+theorem walkInitShortSuccessResolvedCert_pre_expanded
+    (base inputBase listLen raVal t0Old t1Old outBase : Word)
+    (input d0 d1 d2 d3 : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hcode : base.toNat + 172 + 4 + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    (walkInitShortSuccessResolvedCert base inputBase listLen raVal t0Old t1Old outBase input
+      d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval hc0 hl0 hc1 hl1 haddr hc3
+      hl3 hinput hLen hcode).pre =
+      ((walkInitEmptyFailStatusPre listLen raVal (inputBase + BitVec.ofNat 64 0) **
+        (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion inputBase input) **
+        schemaWalkInitFrame outBase) := by
+  rw [walkInitShortSuccessResolvedCert_pre,
+    walkInitShortSuccessSemanticNBranch_pre,
+    walkInitShortSuccessSchemaNBranch_pre]
+
+/-- Traditional CPS statement for the resolved short-list success slice, using
+    the fully reduced WP precondition. -/
+theorem walkInitShortSuccessResolved_spec_within
+    (base inputBase listLen raVal t0Old t1Old outBase : Word)
+    (input d0 d1 d2 d3 : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hcode : base.toNat + 172 + 4 + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    cpsTripleWithin
+      (walkInitShortSuccessResolvedCert base inputBase listLen raVal t0Old t1Old outBase input
+        d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval hc0 hl0 hc1 hl1 haddr hc3
+        hl3 hinput hLen hcode).nSteps
+      base (successStatusReturnExit raVal)
+      ((walkInitEmptyFailNotListFailShortLongCode base).union
+        ((walkInitShortSuccessJumpCode base).union
+          ((schemaCursorInitCode (base + 172)).union
+            ((schemaCR (base + 172 + 4) .x8 (successFieldSpecs d0 d1 d2 d3)).union
+              (successStatusReturnCode
+                ((base + 172 + 4) + BitVec.ofNat 64
+                  (schemaSize (successFieldSpecs d0 d1 d2 d3))))))))
+      (((walkInitEmptyFailStatusPre listLen raVal (inputBase + BitVec.ofNat 64 0) **
+        (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion inputBase input) **
+        schemaWalkInitFrame outBase))
+      (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3) := by
+  rw [← walkInitShortSuccessResolvedCert_pre_expanded]
+  exact (walkInitShortSuccessResolvedCert base inputBase listLen raVal t0Old t1Old outBase input
+    d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval hc0 hl0 hc1 hl1 haddr hc3
+    hl3 hinput hLen hcode).sound
+
 end WithdrawalDecode
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -506,29 +506,14 @@ def walkInitShortSuccessResolvedCert
         (base + 28,
           walkInitLongSchemaPost inputBase listLen raVal outBase input hoff)] := by
     simpa [walkInitShortSuccessSemanticExits] using hexits
-  let tailEmpty : WP.CFG.Cert (failStatusReturnExit raVal) (successStatusReturnExit raVal) cr
-      (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3) :=
-    WP.CFG.unreachable (failStatusReturnExit raVal) (successStatusReturnExit raVal) cr
-      (walkInitEmptyFailSchemaAbiPost_contradicts_successFieldSpecs_input inputBase listLen
-        raVal t0Old t1Old outBase input hoff hLen hBound)
-  let tailNotList : WP.CFG.Cert (failStatusReturnExit raVal) (successStatusReturnExit raVal) cr
-      (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3) :=
-    WP.CFG.unreachable (failStatusReturnExit raVal) (successStatusReturnExit raVal) cr
-      (walkInitNotListFailSchemaAbiPost_contradicts_successFieldSpecs_input inputBase
-        listLen raVal outBase input d0 d1 d2 d3 hoff hl0 hl1 haddr hl3 hinput)
-  let tailSuccess : WP.CFG.Cert (successStatusReturnExit raVal) (successStatusReturnExit raVal) cr
-      (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3) :=
-    WP.CFG.exit (successStatusReturnExit raVal) cr (WP.Entails.refl _)
-  let tailLong : WP.CFG.Cert (base + 28) (successStatusReturnExit raVal) cr
-      (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3) :=
-    walkInitLongSchemaUnreachableCert (base + 28) (successStatusReturnExit raVal)
-      cr inputBase listLen raVal outBase input d0 d1 d2 d3 hoff hl0 hl1 haddr hl3 hinput
-      (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3)
-  wp_rv64_nbranch_join4_with br, hexits4, 0,
-    tailEmpty, WP.Entails.refl _, by rfl,
-    tailNotList, WP.Entails.refl _, by rfl,
-    tailSuccess, WP.Entails.refl _, by rfl,
-    tailLong, WP.Entails.refl _, by rfl
+  wp_rv64_nbranch_join4_resolve_third br, hexits4,
+    (walkInitEmptyFailSchemaAbiPost_contradicts_successFieldSpecs_input inputBase listLen
+      raVal t0Old t1Old outBase input hoff hLen hBound),
+    (walkInitNotListFailSchemaAbiPost_contradicts_successFieldSpecs_input inputBase
+      listLen raVal outBase input d0 d1 d2 d3 hoff hl0 hl1 haddr hl3 hinput),
+    (WP.Entails.refl _),
+    (walkInitLongSchemaPost_contradicts_successFieldSpecs_input inputBase listLen raVal
+      outBase input d0 d1 d2 d3 hoff hl0 hl1 haddr hl3 hinput)
 
 theorem walkInitShortSuccessResolvedCert_pre
     (base inputBase listLen raVal t0Old t1Old outBase : Word)

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -93,6 +93,22 @@ theorem walkInitShortSuccessPrologueCarryFrame_pcFree
   unfold walkInitShortSuccessPrologueCarryFrame
   pcFree
 
+/-- Schema scratch registers carried by the success-shaped classifier frame and
+    preserved by failure-only facades. -/
+def walkInitSchemaScratchFrame : Assertion :=
+  (regOwn .x13 ** regOwn .x14 ** regOwn .x15)
+
+theorem walkInitSchemaScratchFrame_pcFree : walkInitSchemaScratchFrame.pcFree := by
+  unfold walkInitSchemaScratchFrame
+  pcFree
+
+theorem bytesRegion_replicate_output_entails_any (outBase : Word) :
+    WP.Entails
+      (bytesRegion outBase (List.replicate outputSize (0 : Byte)))
+      (bytesRegionAny outBase outputSize) := by
+  intro h hp
+  exact ⟨List.replicate outputSize (0 : Byte), by simp [outputSize], hp⟩
+
 /-- Exact midpoint precondition before weakening `x12 ↦ outBase` to
     `regOwn x12`. -/
 def walkInitShortSuccessResolvedPreFromPrologue
@@ -127,6 +143,36 @@ theorem walkInitAbiFailurePrologueCarryFrame_pcFree
     (walkInitAbiFailurePrologueCarryFrame inputBase listLen t0Old t1Old outBase input).pcFree := by
   unfold walkInitAbiFailurePrologueCarryFrame
   pcFree
+
+theorem walkInitShortSuccessPrologueCarryFrame_entails_abiFailureScratchPre
+    (inputBase listLen t0Old t1Old outBase : Word) (input : List Byte) :
+    WP.Entails
+      (walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input)
+      (walkInitAbiFailurePrologueCarryFrame inputBase listLen t0Old t1Old outBase input **
+        walkInitSchemaScratchFrame) := by
+  intro h hp
+  unfold walkInitShortSuccessPrologueCarryFrame at hp
+  unfold walkInitAbiFailurePrologueCarryFrame walkInitSchemaScratchFrame
+  have hpAny := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+      (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+        (bytesRegion_replicate_output_entails_any outBase))))))))) h hp
+  xperm_hyp hpAny
+
+theorem prologuePreShortSuccessCarry_entails_abiFailureScratchPre
+    (sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word) (input : List Byte) :
+    WP.Entails
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input)
+      ((prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitAbiFailurePrologueCarryFrame inputBase listLen t0Old t1Old outBase input) **
+        walkInitSchemaScratchFrame) := by
+  intro h hp
+  exact (sepConj_assoc h).mpr
+    (sepConj_mono_right
+      (walkInitShortSuccessPrologueCarryFrame_entails_abiFailureScratchPre inputBase listLen
+        t0Old t1Old outBase input) h hp)
 
 /-- Prologue-owned resources that the ABI-failure classifier does not consume. -/
 def walkInitAbiFailurePrologueSavedFrame
@@ -181,7 +227,8 @@ theorem walkInitEmptyInputPrologueScratchFrame_pcFree (t0Old t1Old : Word) :
 
 -- WP-link automation unfolds these small assertion-shape helpers before `xperm`.
 attribute [rv64_wp] schemaWalkInitFrameFromPrologue walkInitShortSuccessPrologueSavedFrame
-  walkInitShortSuccessPrologueCarryFrame walkInitShortSuccessResolvedPreFromPrologue
+  walkInitShortSuccessPrologueCarryFrame walkInitSchemaScratchFrame
+  walkInitShortSuccessResolvedPreFromPrologue
   walkInitAbiFailurePrologueCarryFrame walkInitAbiFailurePrologueSavedFrame
   walkInitAbiFailurePreFromPrologue walkInitEmptyInputPrologueCarryFrame
   walkInitEmptyInputPreFromPrologue walkInitEmptyInputPrologueScratchFrame emptyInputAbiFrame
@@ -1905,6 +1952,87 @@ theorem walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeNBranch_exits
   unfold walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeNBranch
   simp only [WP.NBranch.extendCode]
   rw [walkInitZeroNonzeroAbiFailureFromPrologueNBranch_exits]
+
+/-- Failure facade over the resolved short-success code, restated with the same
+    success-shaped static caller frame used by the schema-success path.  The
+    added scratch frame is preserved on every exit by WP framing; the local
+    precondition bridge keeps the global WP hint registry narrow. -/
+def walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeSuccessFrameNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    WP.NBranch base
+      ((prologueCode base).union
+        (walkInitShortSuccessResolvedCode (base + 24) specs)) := by
+  let br := walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeNBranch base sp0 raVal
+    s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input specs
+    hsalign hover hwin hLen hprologueCode hcode
+  have hpre : WP.Entails
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input)
+      (br.pre ** walkInitSchemaScratchFrame) := by
+    dsimp [br]
+    rw [walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeNBranch_pre]
+    exact prologuePreShortSuccessCarry_entails_abiFailureScratchPre sp0 raVal s0Old s1Old
+      s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input
+  wp_rv64_nbranch_frame_set_pre br, walkInitSchemaScratchFrame,
+    walkInitSchemaScratchFrame_pcFree,
+    (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+      walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input)
+
+theorem walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeSuccessFrameNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    (walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeSuccessFrameNBranch base sp0 raVal
+      s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input specs
+      hsalign hover hwin hLen hprologueCode hcode).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  rfl
+
+attribute [rv64_wp]
+  walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeSuccessFrameNBranch_pre
+
+def walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeSuccessFrameExits
+    (base sp0 raVal s0Old s1Old s2Old outBase : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) : List (Word × Assertion) :=
+  (walkInitZeroNonzeroAbiFailureFromPrologueExits base sp0 raVal s0Old s1Old s2Old
+    outBase inputBase listLen t0Old t1Old input).map
+    (fun ex => (ex.1, ex.2 ** walkInitSchemaScratchFrame))
+
+theorem walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeSuccessFrameNBranch_exits
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    (walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeSuccessFrameNBranch base sp0 raVal
+      s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input specs
+      hsalign hover hwin hLen hprologueCode hcode).exits =
+      walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeSuccessFrameExits base sp0 raVal
+        s0Old s1Old s2Old outBase inputBase listLen t0Old t1Old input := by
+  unfold walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeSuccessFrameNBranch
+  simp only [WP.NBranch.weakenPre, WP.CFG.nbranchFrameR, WP.NBranch.frameR]
+  rw [walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeNBranch_exits]
+  rfl
 
 /-- Prologue followed by the reduced short-list success WP slice.  The prologue
     carries the walk-init/schema resources to its exit; the tail consumes those

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -1120,6 +1120,8 @@ theorem walkInitEmptyInputFailureFromPrologueNonzeroExit_contradicts
   exact walkInitEmptyInputNonzeroExit_contradicts inputBase outBase raVal
     (inputBase + BitVec.ofNat 64 0) hMain hMain_prop
 
+attribute [rv64_wp_dead] walkInitEmptyInputFailureFromPrologueNonzeroExit_contradicts
+
 /-- Prologue followed by the empty-input failure path with the impossible
     nonzero fall-through closed. This is the single-exit form callers should use
     when the input bytes are known to be empty. -/
@@ -1133,13 +1135,11 @@ def walkInitEmptyInputFailureFromPrologueCert
         walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) := by
   let br := walkInitEmptyInputFailureFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old
     outBase m0 m1 m2 m3 inputBase hprologueCode hcode
-  wp_rv64_nbranch_join2_resolve_first_auto br,
+  wp_rv64_nbranch_join2_resolve_first_dead_auto br,
     (walkInitEmptyInputFailureFromPrologueNBranch_exits base sp0 raVal s0Old s1Old
       s2Old outBase m0 m1 m2 m3 inputBase hprologueCode hcode),
     (emptyInputFailurePost inputBase outBase raVal **
-      walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase),
-    (walkInitEmptyInputFailureFromPrologueNonzeroExit_contradicts sp0 raVal s0Old s1Old
-      s2Old outBase inputBase)
+      walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
 
 theorem walkInitEmptyInputFailureFromPrologueCert_pre
     (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -525,6 +525,110 @@ theorem walkInitPrefixWord_not_lt_c0_of_successFieldSpecs_input
   simp [walkInitPrefixWord, encode_list_schemaItems_short, hshort, BitVec.ult]
   omega
 
+/-- A long-list prefix at walk-init cannot be a canonical withdrawal success
+    encoding: successful withdrawal encodings are short-list encodings. -/
+theorem decodeWithdrawal_none_of_walkInitPrefixWord_not_lt_f8
+    (input : List Byte) (hoff : 0 < input.length)
+    (hnot : ¬ BitVec.ult (walkInitPrefixWord input 0 hoff) (0xf8 : Word)) :
+    decodeWithdrawal input = none := by
+  exact (decodeWithdrawal_eq_none_iff_not_successFieldSpecsInput input).2 (by
+    intro h_success
+    rcases h_success with
+      ⟨d0, d1, d2, d3, hinput, _hc0, hl0, _hc1, hl1, haddr, _hc3, hl3⟩
+    exact hnot
+      (walkInitPrefixWord_lt_f8_of_successFieldSpecs_input input d0 d1 d2 d3 hoff
+        hl0 hl1 haddr hl3 hinput))
+
+/-- Non-ABI resources left over when a long-list walk-init candidate is continued
+    through the reason-erased failure return block. -/
+def walkInitLongListFailFrame
+    (inputBase listLen : Word) (input : List Byte) (hoff : 0 < input.length) : Assertion :=
+  ((.x11 ↦ᵣ ((inputBase + BitVec.ofNat 64 0) + listLen)) **
+    (.x5 ↦ᵣ walkInitPrefixWord input 0 hoff) ** (.x6 ↦ᵣ (0xf8 : Word)) **
+    ⌜listLen ≠ (0 : Word)⌝ **
+    ⌜¬ BitVec.ult (walkInitPrefixWord input 0 hoff) (0xc0 : Word)⌝ **
+    ⌜¬ BitVec.ult (walkInitPrefixWord input 0 hoff) (0xf8 : Word)⌝)
+
+theorem walkInitLongListFailFrame_pcFree
+    (inputBase listLen : Word) (input : List Byte) (hoff : 0 < input.length) :
+    (walkInitLongListFailFrame inputBase listLen input hoff).pcFree := by
+  unfold walkInitLongListFailFrame
+  pcFree
+
+/-- Long-list classifier candidates imply pure decoder failure and therefore can
+    hand off to the generic ABI failure-return block. -/
+theorem walkInitLongListOutputPost_entails_failStatusReturnAbiPre
+    (inputBase listLen raVal outBase : Word) (input : List Byte)
+    (hoff : 0 < input.length) :
+    WP.Entails
+      (walkInitLongListOutputPost inputBase listLen raVal outBase input 0 hoff)
+      (failStatusReturnAbiPre inputBase outBase raVal (inputBase + BitVec.ofNat 64 0) input **
+        walkInitLongListFailFrame inputBase listLen input hoff) := by
+  intro h hp
+  have hpCase := hp
+  unfold walkInitLongListOutputPost walkInitLongListCandidatePost at hpCase
+  rcases hpCase with ⟨hLong, _hOut, _hdOut, _hunionOut, hLong_prop, _hOut_prop⟩
+  rcases hLong_prop with ⟨_hPrefix, _hPure, _hdPure, _hunionPure,
+    _hPrefix_prop, hPure_prop⟩
+  have hdec : decodeWithdrawal input = none :=
+    decodeWithdrawal_none_of_walkInitPrefixWord_not_lt_f8 input hoff hPure_prop.2
+  unfold walkInitLongListOutputPost walkInitLongListCandidatePost walkInitPrefixF8Post at hp
+  unfold failStatusReturnAbiPre failStatusReturnPre statusReturnPre failStatusReturnAbiFrame
+    walkInitLongListFailFrame
+  rw [show (⌜decodeWithdrawal input = none⌝ : Assertion) = empAssertion by
+    funext h
+    unfold EvmAsm.Rv64.pure EvmAsm.Rv64.empAssertion
+    apply propext
+    constructor
+    · intro h_p
+      exact h_p.1
+    · intro h_empty
+      exact ⟨h_empty, hdec⟩]
+  simp only [sepConj_emp_right']
+  xperm_hyp hp
+
+/-- Framed version used by generated CFG joins. -/
+theorem walkInitLongListOutputPost_frame_entails_failStatusReturnAbiPre
+    (inputBase listLen raVal outBase : Word) (input : List Byte)
+    (hoff : 0 < input.length) (F : Assertion) :
+    WP.Entails
+      (walkInitLongListOutputPost inputBase listLen raVal outBase input 0 hoff ** F)
+      ((failStatusReturnAbiPre inputBase outBase raVal (inputBase + BitVec.ofNat 64 0) input **
+        walkInitLongListFailFrame inputBase listLen input hoff) ** F) := by
+  intro h hp
+  exact sepConj_mono_left
+    (walkInitLongListOutputPost_entails_failStatusReturnAbiPre inputBase listLen raVal
+      outBase input hoff) h hp
+
+attribute [rv64_wp_entails]
+  walkInitLongListOutputPost_entails_failStatusReturnAbiPre
+  walkInitLongListOutputPost_frame_entails_failStatusReturnAbiPre
+
+/-- Failure-return certificate for the long-list candidate exit, preserving the
+    non-ABI candidate facts as a frame. -/
+def walkInitLongListFailReturnCert
+    (base inputBase listLen raVal outBase : Word) (input : List Byte)
+    (hoff : 0 < input.length) :
+    WP.CFG.Cert base (failStatusReturnExit raVal) (failStatusReturnCode base)
+      (abiPost inputBase outBase raVal input **
+        walkInitLongListFailFrame inputBase listLen input hoff) :=
+  WP.CFG.frameR
+    (failStatusReturnAbiCert base inputBase outBase raVal
+      (inputBase + BitVec.ofNat 64 0) input)
+    (walkInitLongListFailFrame inputBase listLen input hoff)
+    (walkInitLongListFailFrame_pcFree inputBase listLen input hoff)
+
+theorem walkInitLongListFailReturnCert_pre
+    (base inputBase listLen raVal outBase : Word) (input : List Byte)
+    (hoff : 0 < input.length) :
+    (walkInitLongListFailReturnCert base inputBase listLen raVal outBase input hoff).pre =
+      (failStatusReturnAbiPre inputBase outBase raVal (inputBase + BitVec.ofNat 64 0) input **
+        walkInitLongListFailFrame inputBase listLen input hoff) := by
+  rfl
+
+attribute [rv64_wp] walkInitLongListFailReturnCert_pre
+attribute [rv64_wp_cert] walkInitLongListFailReturnCert
+
 /-- The empty-input semantic failure exit is unreachable for a nonempty short-list
     success witness whose length was loaded into `listLen`. -/
 theorem walkInitEmptyFailSchemaAbiPost_contradicts_successFieldSpecs_input
@@ -969,6 +1073,155 @@ def walkInitShortSuccessResolvedCode (base : Word) (specs : List FieldSpec) : Co
 
 attribute [rv64_wp] walkInitShortSuccessResolvedCode
 
+/-- The walk-init classifier has no instruction at the long-list fall-through
+    where the reason-erased failure return block is placed. -/
+theorem walkInitEmptyFailNotListFailShortLongCode_none_at_longFailReturn0
+    (base : Word) :
+    walkInitEmptyFailNotListFailShortLongCode base (base + 28) = none := by
+  unfold walkInitEmptyFailNotListFailShortLongCode walkInitEmptyFailOrPrefixCode
+    walkInitEmptyFailStatusCode failStatusReturnCode statusReturnCode
+    walkInitNonzeroPrefixTailCode walkInitPrefixShortLongTailCode
+    walkInitPrefixListCheckNotListFailF8Code walkInitPrefixListCheckOrNotListFailCode
+    walkInitPrefixListCheckCode walkInitPrefixNotListFailStatusCode walkInitListF8Code
+    walkInitShortLongCheckCode
+  have h0 : CodeReq.singleton base (.BEQ .x11 .x0 (156 : BitVec 13)) (base + 28) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h156 : CodeReq.singleton (base + 156) (.LI .x10 (1 : Word)) (base + 28) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h160 : CodeReq.singleton (base + 156 + 4) (.JALR .x0 .x1 (0 : BitVec 12)) (base + 28) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h4 : CodeReq.singleton (base + 4) (.ADD .x11 .x10 .x11) (base + 28) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h8 : CodeReq.singleton (base + 8) (.LBU .x5 .x10 0) (base + 28) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h12 : CodeReq.singleton (base + 12) (.LI .x6 (0xc0 : Word)) (base + 28) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h16 : CodeReq.singleton (base + 16) (.BLTU .x5 .x6 (148 : BitVec 13)) (base + 28) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h164 : CodeReq.singleton (base + 164) (.LI .x10 (1 : Word)) (base + 28) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h168 : CodeReq.singleton (base + 164 + 4) (.JALR .x0 .x1 (0 : BitVec 12)) (base + 28) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have hFail164 : failStatusReturnCode (base + 164) (base + 28) = none := by
+    unfold failStatusReturnCode statusReturnCode
+    simp only [CodeReq.union, h164, h168]
+  have h20 : CodeReq.singleton (base + 20) (.LI .x6 (0xf8 : Word)) (base + 28) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h24 : CodeReq.singleton (base + 24) (.BLTU .x5 .x6 (100 : BitVec 13)) (base + 28) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  simp only [CodeReq.union, h0, h156, h160, h4, h8, h12, h16, hFail164, h20, h24]
+
+theorem walkInitEmptyFailNotListFailShortLongCode_none_at_longFailReturn1
+    (base : Word) :
+    walkInitEmptyFailNotListFailShortLongCode base (base + 32) = none := by
+  unfold walkInitEmptyFailNotListFailShortLongCode walkInitEmptyFailOrPrefixCode
+    walkInitEmptyFailStatusCode failStatusReturnCode statusReturnCode
+    walkInitNonzeroPrefixTailCode walkInitPrefixShortLongTailCode
+    walkInitPrefixListCheckNotListFailF8Code walkInitPrefixListCheckOrNotListFailCode
+    walkInitPrefixListCheckCode walkInitPrefixNotListFailStatusCode walkInitListF8Code
+    walkInitShortLongCheckCode
+  have h0 : CodeReq.singleton base (.BEQ .x11 .x0 (156 : BitVec 13)) (base + 32) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h156 : CodeReq.singleton (base + 156) (.LI .x10 (1 : Word)) (base + 32) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h160 : CodeReq.singleton (base + 156 + 4) (.JALR .x0 .x1 (0 : BitVec 12)) (base + 32) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h4 : CodeReq.singleton (base + 4) (.ADD .x11 .x10 .x11) (base + 32) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h8 : CodeReq.singleton (base + 8) (.LBU .x5 .x10 0) (base + 32) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h12 : CodeReq.singleton (base + 12) (.LI .x6 (0xc0 : Word)) (base + 32) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h16 : CodeReq.singleton (base + 16) (.BLTU .x5 .x6 (148 : BitVec 13)) (base + 32) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h164 : CodeReq.singleton (base + 164) (.LI .x10 (1 : Word)) (base + 32) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h168 : CodeReq.singleton (base + 164 + 4) (.JALR .x0 .x1 (0 : BitVec 12)) (base + 32) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have hFail164 : failStatusReturnCode (base + 164) (base + 32) = none := by
+    unfold failStatusReturnCode statusReturnCode
+    simp only [CodeReq.union, h164, h168]
+  have h20 : CodeReq.singleton (base + 20) (.LI .x6 (0xf8 : Word)) (base + 32) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h24 : CodeReq.singleton (base + 24) (.BLTU .x5 .x6 (100 : BitVec 13)) (base + 32) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  simp only [CodeReq.union, h0, h156, h160, h4, h8, h12, h16, hFail164, h20, h24]
+
+/-- The resolved short-success code also leaves the long-list failure return
+    landing pad free. -/
+theorem walkInitShortSuccessResolvedCode_none_at_longFailReturn0
+    (base : Word) (specs : List FieldSpec)
+    (hcode : base.toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    walkInitShortSuccessResolvedCode base specs (base + 28) = none := by
+  have hbase172 : (base + 172).toNat = base.toNat + 172 := by
+    bv_omega
+  have h0 := walkInitEmptyFailNotListFailShortLongCode_none_at_longFailReturn0 base
+  have h1 : walkInitShortSuccessJumpCode base (base + 28) = none := by
+    unfold walkInitShortSuccessJumpCode
+    exact CodeReq.singleton_miss (by bv_omega)
+  have h2 :
+      ((schemaCursorInitCode (base + 172)).union
+        ((schemaCR (base + 172 + 4) .x8 specs).union
+          (successStatusReturnCode
+            ((base + 172 + 4) + BitVec.ofNat 64 (schemaSize specs)))))
+        (base + 28) = none :=
+    schemaCursorInitSuccessReturnTail_none_below (base + 172) .x8 specs (base + 28)
+      (by rw [hbase172]; omega) (by rw [hbase172]; bv_omega)
+  unfold walkInitShortSuccessResolvedCode
+  simp only [CodeReq.union, h0, h1]
+  exact h2
+
+theorem walkInitShortSuccessResolvedCode_none_at_longFailReturn1
+    (base : Word) (specs : List FieldSpec)
+    (hcode : base.toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    walkInitShortSuccessResolvedCode base specs (base + 32) = none := by
+  have hbase172 : (base + 172).toNat = base.toNat + 172 := by
+    bv_omega
+  have h0 := walkInitEmptyFailNotListFailShortLongCode_none_at_longFailReturn1 base
+  have h1 : walkInitShortSuccessJumpCode base (base + 32) = none := by
+    unfold walkInitShortSuccessJumpCode
+    exact CodeReq.singleton_miss (by bv_omega)
+  have h2 :
+      ((schemaCursorInitCode (base + 172)).union
+        ((schemaCR (base + 172 + 4) .x8 specs).union
+          (successStatusReturnCode
+            ((base + 172 + 4) + BitVec.ofNat 64 (schemaSize specs)))))
+        (base + 32) = none :=
+    schemaCursorInitSuccessReturnTail_none_below (base + 172) .x8 specs (base + 32)
+      (by rw [hbase172]; omega) (by rw [hbase172]; bv_omega)
+  unfold walkInitShortSuccessResolvedCode
+  simp only [CodeReq.union, h0, h1]
+  exact h2
+
+theorem walkInitShortSuccessResolvedCode_disjoint_longFailReturn
+    (base : Word) (specs : List FieldSpec)
+    (hcode : base.toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    (walkInitShortSuccessResolvedCode base specs).Disjoint
+      (failStatusReturnCode (base + 28)) := by
+  intro a
+  by_cases h28 : a = base + 28
+  · left
+    subst a
+    exact walkInitShortSuccessResolvedCode_none_at_longFailReturn0 base specs hcode
+  · by_cases h32 : a = base + 32
+    · left
+      subst a
+      exact walkInitShortSuccessResolvedCode_none_at_longFailReturn1 base specs hcode
+    · right
+      unfold failStatusReturnCode statusReturnCode
+      have h0 : CodeReq.singleton (base + 28) (.LI .x10 (1 : Word)) a = none :=
+        CodeReq.singleton_miss h28
+      have h1 : CodeReq.singleton (base + 28 + 4) (.JALR .x0 .x1 (0 : BitVec 12)) a = none :=
+        CodeReq.singleton_miss (by
+          intro h_eq
+          apply h32
+          rw [h_eq]
+          bv_omega)
+      simp only [CodeReq.union, h0, h1]
+
+attribute [rv64_wp_disjoint]
+  walkInitShortSuccessResolvedCode_disjoint_longFailReturn
+
 /-- The base walk-init classifier code is a prefix of the resolved short-success
     code. This lets failure-only classifier facades be reused over the larger
     success-capable code requirement. -/
@@ -1081,6 +1334,32 @@ theorem prologueCode_disjoint_walkInitShortSuccessResolvedCode
 
 attribute [rv64_wp_disjoint]
   prologueCode_disjoint_walkInitShortSuccessResolvedCode
+
+/-- Prologue plus resolved short-success code is disjoint from the long-list
+    failure return block. -/
+theorem prologueShortSuccessResolvedCode_disjoint_longFailReturn
+    (base : Word) (specs : List FieldSpec)
+    (hprologue : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    ((prologueCode base).union
+      (walkInitShortSuccessResolvedCode (base + 24) specs)).Disjoint
+      (failStatusReturnCode ((base + 24) + 28)) := by
+  refine CodeReq.Disjoint.union_left ?h_prologue ?h_tail
+  · have hbase24 : (base + 24).toNat = base.toNat + 24 := by
+      bv_omega
+    have hfail : (((base + 24) + 28).toNat = (base + 24).toNat + 28) := by
+      bv_omega
+    refine codeReq_disjoint_of_ranges _ _ (base.toNat + 24) ?_ ?_
+    · intro a ha
+      exact prologueCode_none_above base a hprologue ha
+    · intro a ha
+      unfold failStatusReturnCode
+      exact statusReturnCode_none_below ((base + 24) + 28) (1 : Word) a
+        (by rw [hfail]; omega) (by rw [hfail, hbase24]; omega)
+  · exact walkInitShortSuccessResolvedCode_disjoint_longFailReturn (base + 24) specs hcode
+
+attribute [rv64_wp_disjoint]
+  prologueShortSuccessResolvedCode_disjoint_longFailReturn
 
 /-- Range split between the decoder prologue and the standalone walk-init
     classifier. -/
@@ -1808,6 +2087,98 @@ theorem walkInitAbiFailureReasonErasedFromPrologueNBranch_exits
       walkInitAbiFailureReasonErasedFromPrologueExits base sp0 raVal s0Old s1Old s2Old
         outBase inputBase listLen t0Old t1Old input hoff := by
   rfl
+
+
+/-- Nonempty reason-erased failure classifier over resolved short-success code,
+    with the long-list fall-through continued through the shared failure return
+    block. The short-list candidate remains open for schema validation. -/
+def walkInitAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover0 : inputBase.toNat + 0 < 2 ^ 64)
+    (hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    WP.NBranch base
+      (((prologueCode base).union
+        (walkInitShortSuccessResolvedCode (base + 24) specs)).union
+        (failStatusReturnCode ((base + 24) + 28))) := by
+  let br0 := walkInitAbiFailureReasonErasedFromPrologueNBranch base sp0 raVal s0Old s1Old
+    s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hoff hover0
+    hvalid0 hLen hBound hprologueCode (by omega)
+  let br := EvmAsm.Rv64.WP.NBranch.extendCode br0
+    (prologueWalkInitClassifierCode_mono_resolvedCode base specs)
+  let savedFrame := walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase
+  let tail0 := walkInitLongListFailReturnCert ((base + 24) + 28) inputBase listLen raVal
+    outBase input hoff
+  let tail := WP.CFG.frameR tail0 savedFrame
+    (walkInitAbiFailurePrologueSavedFrame_pcFree sp0 raVal s0Old s1Old s2Old outBase)
+  have hexits : br.exits =
+      [(failStatusReturnExit raVal,
+          walkInitAbiFailureReasonPostFromPrologue sp0 raVal s0Old s1Old s2Old outBase
+            inputBase listLen t0Old t1Old input hoff),
+        ((base + 24) + 124,
+          walkInitShortListOutputPost inputBase listLen raVal outBase input 0 hoff **
+            savedFrame),
+        ((base + 24) + 28,
+          walkInitLongListOutputPost inputBase listLen raVal outBase input 0 hoff **
+            savedFrame)] := by
+    change br0.exits =
+      [(failStatusReturnExit raVal,
+          walkInitAbiFailureReasonPostFromPrologue sp0 raVal s0Old s1Old s2Old outBase
+            inputBase listLen t0Old t1Old input hoff),
+        ((base + 24) + 124,
+          walkInitShortListOutputPost inputBase listLen raVal outBase input 0 hoff **
+            savedFrame),
+        ((base + 24) + 28,
+          walkInitLongListOutputPost inputBase listLen raVal outBase input 0 hoff **
+            savedFrame)]
+    dsimp [br0, savedFrame]
+    rw [walkInitAbiFailureReasonErasedFromPrologueNBranch_exits]
+    rfl
+  exact WP.CFG.nbranchSeqExitCertDisjoint
+    (preExits :=
+      [(failStatusReturnExit raVal,
+          walkInitAbiFailureReasonPostFromPrologue sp0 raVal s0Old s1Old s2Old outBase
+            inputBase listLen t0Old t1Old input hoff),
+        ((base + 24) + 124,
+          walkInitShortListOutputPost inputBase listLen raVal outBase input 0 hoff **
+            savedFrame)])
+    (prologueShortSuccessResolvedCode_disjoint_longFailReturn base specs hprologueCode hcode)
+    br hexits tail
+    (by
+      dsimp [tail, tail0, savedFrame, WP.CFG.frameR, WP.Triple.frameR]
+      exact walkInitLongListOutputPost_frame_entails_failStatusReturnAbiPre inputBase listLen
+        raVal outBase input hoff savedFrame)
+
+theorem walkInitAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover0 : inputBase.toNat + 0 < 2 ^ 64)
+    (hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    (walkInitAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureNBranch base sp0 raVal
+      s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input specs
+      hsalign hoff hover0 hvalid0 hLen hBound hprologueCode hcode).pre =
+      (walkInitAbiFailureReasonErasedFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old
+        outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hoff hover0 hvalid0
+        hLen hBound hprologueCode (by omega)).pre := by
+  rfl
+
+attribute [rv64_wp]
+  walkInitAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureNBranch_pre
+
+attribute [rv64_wp_cert]
+  walkInitAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureNBranch
 
 /-- Prologue followed by the ABI-failure classifier, with the empty/nonempty
     split selected from the concrete input bytes. Callers supply only static

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -1,0 +1,340 @@
+/-
+  EvmAsm.Rv64.RLP.WithdrawalDecodeSemanticWP
+
+  Composed semantic WP facade for the withdrawal decoder prefix classifier:
+  empty and not-list exits expose the public ABI post, the short-list success
+  exit is continued through the generated schema tail, and the long-list exit
+  remains open for the next layer.
+-/
+
+import EvmAsm.Rv64.RLP.WithdrawalDecodeFailureWP
+import EvmAsm.Rv64.RLP.WithdrawalDecodeShortWP
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL
+open EvmAsm.EL.RLP
+open EvmAsm.Rv64.Tactics
+
+namespace WithdrawalDecode
+
+/-- Schema scratch registers preserved on failure exits after the output bytes
+    have been consumed by the public ABI post. -/
+def schemaWalkInitRegsFrame (outBase : Word) : Assertion :=
+  ((.x8 ↦ᵣ outBase) ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x15)
+
+/-- `schemaWalkInitFrame` with its zeroed output buffer weakened to arbitrary
+    output ownership. This is the bridge from the success-oriented schema frame
+    to reason-erased ABI failure posts. -/
+def schemaWalkInitAnyFrame (outBase : Word) : Assertion :=
+  ((.x8 ↦ᵣ outBase) ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 **
+    regOwn .x15 ** bytesRegionAny outBase outputSize)
+
+theorem schemaWalkInitFrame_entails_anyFrame (outBase : Word) :
+    WP.Entails (schemaWalkInitFrame outBase) (schemaWalkInitAnyFrame outBase) := by
+  intro h hp
+  unfold schemaWalkInitFrame at hp
+  unfold schemaWalkInitAnyFrame
+  exact sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono_right (sepConj_mono_right (fun h hp =>
+      ⟨List.replicate outputSize (0 : Byte), by simp [outputSize], hp⟩))))) h hp
+
+def walkInitEmptyFailSchemaAbiFrame (listLen t0Old t1Old outBase : Word) : Assertion :=
+  walkInitEmptyFailAbiFrame listLen t0Old t1Old ** schemaWalkInitRegsFrame outBase
+
+def walkInitNotListFailSchemaAbiFrame
+    (inputBase listLen outBase : Word) (input : List Byte)
+    (hoff : 0 < input.length) : Assertion :=
+  walkInitNotListFailAbiFrame inputBase listLen input 0 hoff ** schemaWalkInitRegsFrame outBase
+
+/-- Empty-input branch, with the schema handoff frame weakened to the public ABI
+    failure post plus preserved scratch facts. -/
+theorem walkInitEmptyFailSchemaPost_entails_abiFailureFrame
+    (inputBase listLen raVal t0Old t1Old outBase : Word) (input : List Byte)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64) :
+    WP.Entails
+      ((walkInitEmptyFailStatusPost listLen raVal **
+        ((.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion inputBase input)) **
+        schemaWalkInitFrame outBase)
+      (abiPost inputBase outBase raVal input **
+        walkInitEmptyFailSchemaAbiFrame listLen t0Old t1Old outBase) := by
+  intro h hp
+  have hpCase := hp
+  unfold walkInitEmptyFailStatusPost failStatusReturnPost statusReturnPost walkInitZeroPost at hpCase
+  rcases hpCase with ⟨hA, _hSchema, _hdSchema, _hunionSchema, hA_prop, _hSchema_prop⟩
+  rcases hA_prop with ⟨hB, _hInputRegs, _hdInputRegs, _hunionInputRegs, hB_prop, _hInputRegs_prop⟩
+  rcases hB_prop with ⟨_hRegs, _hPureFrame, _hdPureFrame, _hunionPureFrame,
+    _hRegs_prop, hPureFrame_prop⟩
+  have hPureCopy := hPureFrame_prop
+  extract_pure hPureCopy
+  have hzero : listLen = (0 : Word) := hPureCopy.1
+  have hLengthZero : input.length = 0 := by
+    have heq : BitVec.ofNat 64 input.length = (0 : Word) := by
+      rw [← hLen]
+      exact hzero
+    have htn := congrArg BitVec.toNat heq
+    simp only [BitVec.toNat_ofNat, show (0 : Word).toNat = 0 from by decide] at htn
+    rw [Nat.mod_eq_of_lt hBound] at htn
+    exact htn
+  have hnil : input = [] := by
+    cases input with
+    | nil => rfl
+    | cons _ _ => simp at hLengthZero
+  have hdec : decodeWithdrawal input = none := by
+    rw [hnil]
+    exact decodeWithdrawal_nil
+  have hpAny :
+      ((walkInitEmptyFailStatusPost listLen raVal **
+        ((.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion inputBase input)) **
+        schemaWalkInitAnyFrame outBase) h := by
+    exact sepConj_mono_right (schemaWalkInitFrame_entails_anyFrame outBase) h hp
+  unfold walkInitEmptyFailStatusPost failStatusReturnPost statusReturnPost walkInitZeroPost at hpAny
+  unfold schemaWalkInitAnyFrame at hpAny
+  unfold abiPost walkInitEmptyFailSchemaAbiFrame walkInitEmptyFailAbiFrame schemaWalkInitRegsFrame
+  rw [resultPost_failure hdec]
+  rw [show (⌜decodeWithdrawal input = none⌝ : Assertion) = empAssertion by
+    funext h
+    unfold EvmAsm.Rv64.pure EvmAsm.Rv64.empAssertion
+    apply propext
+    constructor
+    · intro h_p
+      exact h_p.1
+    · intro h_empty
+      exact ⟨h_empty, hdec⟩]
+  simp only [sepConj_emp_right']
+  xperm_hyp hpAny
+
+/-- Not-list branch, with the schema handoff frame weakened to the public ABI
+    failure post plus preserved scratch facts. -/
+theorem walkInitNotListFailSchemaPost_entails_abiFailureFrame
+    (inputBase listLen raVal outBase : Word) (input : List Byte)
+    (hoff : 0 < input.length) :
+    WP.Entails
+      (walkInitPrefixNotListFailStatusPost inputBase listLen raVal input 0 hoff **
+        schemaWalkInitFrame outBase)
+      (abiPost inputBase outBase raVal input **
+        walkInitNotListFailSchemaAbiFrame inputBase listLen outBase input hoff) := by
+  intro h hp
+  have hpCase := hp
+  unfold walkInitPrefixNotListFailStatusPost walkInitPrefixNotListFailStatusFrame
+    walkInitPrefixWord at hpCase
+  rcases hpCase with ⟨hMain, _hSchema, _hdSchema, _hunionSchema, hMain_prop, _hSchema_prop⟩
+  rcases hMain_prop with ⟨_hFail, _hFrame, _hdFrame, _hunionFrame,
+    _hFail_prop, hFrame_prop⟩
+  rcases hFrame_prop with ⟨_hFrameHead, _hFrameTail, _hdFrameTail, _hunionFrameTail,
+    _hFrameHead_prop, hFrameTail_prop⟩
+  have hFrameTailPure := hFrameTail_prop
+  extract_pure hFrameTailPure
+  have hlt : BitVec.ult (walkInitPrefixWord input 0 hoff) (0xc0 : Word) = true :=
+    hFrameTailPure.1
+  have hdec : decodeWithdrawal input = none := by
+    cases input with
+    | nil => simp at hoff
+    | cons pfx rest =>
+        simpa using decodeWithdrawal_none_of_head_lt_c0 pfx rest hlt
+  have hpAny :
+      (walkInitPrefixNotListFailStatusPost inputBase listLen raVal input 0 hoff **
+        schemaWalkInitAnyFrame outBase) h := by
+    exact sepConj_mono_right (schemaWalkInitFrame_entails_anyFrame outBase) h hp
+  unfold walkInitPrefixNotListFailStatusPost walkInitPrefixNotListFailStatusFrame
+    failStatusReturnPost statusReturnPost walkInitPrefixWord at hpAny
+  unfold schemaWalkInitAnyFrame at hpAny
+  unfold abiPost walkInitNotListFailSchemaAbiFrame walkInitNotListFailAbiFrame
+    schemaWalkInitRegsFrame walkInitPrefixWord
+  rw [resultPost_failure hdec]
+  rw [show (⌜decodeWithdrawal input = none⌝ : Assertion) = empAssertion by
+    funext h
+    unfold EvmAsm.Rv64.pure EvmAsm.Rv64.empAssertion
+    apply propext
+    constructor
+    · intro h_p
+      exact h_p.1
+    · intro h_empty
+      exact ⟨h_empty, hdec⟩]
+  simp only [sepConj_emp_right']
+  xperm_hyp hpAny
+
+def walkInitShortSuccessAbiPost
+    (inputBase outBase raVal : Word) (input d0 d1 d2 d3 : List Byte) : Assertion :=
+  ((abiPost inputBase outBase raVal input **
+    successSchemaReturnFrame inputBase outBase
+      (1 + schemaEnc (successFieldSpecs d0 d1 d2 d3))) **
+    (.x6 ↦ᵣ (0xf8 : Word)))
+
+def walkInitLongSchemaPost
+    (inputBase listLen raVal outBase : Word) (input : List Byte)
+    (hoff : 0 < input.length) : Assertion :=
+  walkInitLongListCandidatePost inputBase listLen raVal input 0 hoff ** schemaWalkInitFrame outBase
+
+def walkInitShortSuccessSchemaExits
+    (base inputBase listLen raVal t0Old t1Old outBase : Word)
+    (input d0 d1 d2 d3 : List Byte) (hoff : 0 < input.length) :
+    List (Word × Assertion) :=
+  [ (failStatusReturnExit raVal,
+      (walkInitEmptyFailStatusPost listLen raVal **
+        ((.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion inputBase input)) **
+        schemaWalkInitFrame outBase)
+  , (failStatusReturnExit raVal,
+      walkInitPrefixNotListFailStatusPost inputBase listLen raVal input 0 hoff **
+        schemaWalkInitFrame outBase)
+  , (successStatusReturnExit raVal,
+      walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3)
+  , (base + 28,
+      walkInitLongSchemaPost inputBase listLen raVal outBase input hoff)
+  ]
+
+theorem walkInitShortSuccessSchemaNBranch_exits
+    (base inputBase listLen raVal t0Old t1Old outBase : Word)
+    (input d0 d1 d2 d3 : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (hcode : base.toNat + 172 + 4 + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    (walkInitShortSuccessSchemaNBranch base inputBase listLen raVal t0Old t1Old outBase input
+      d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval hc0 hl0 hc1 hl1 haddr hc3
+      hl3 hinput hcode).exits =
+      walkInitShortSuccessSchemaExits base inputBase listLen raVal t0Old t1Old outBase input
+        d0 d1 d2 d3 hoff := by
+  unfold walkInitShortSuccessSchemaNBranch walkInitShortSuccessSchemaExits
+    walkInitShortSuccessAbiPost walkInitLongSchemaPost
+  rfl
+
+def walkInitShortSuccessSemanticExits
+    (base inputBase listLen raVal t0Old t1Old outBase : Word)
+    (input d0 d1 d2 d3 : List Byte) (hoff : 0 < input.length) :
+    List (Word × Assertion) :=
+  [ (failStatusReturnExit raVal,
+      abiPost inputBase outBase raVal input **
+        walkInitEmptyFailSchemaAbiFrame listLen t0Old t1Old outBase)
+  , (failStatusReturnExit raVal,
+      abiPost inputBase outBase raVal input **
+        walkInitNotListFailSchemaAbiFrame inputBase listLen outBase input hoff)
+  , (successStatusReturnExit raVal,
+      walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3)
+  , (base + 28,
+      walkInitLongSchemaPost inputBase listLen raVal outBase input hoff)
+  ]
+
+/-- Prefix classifier with semantic failure exits and the short-list success path
+    continued through the generated result-free schema WP tail. The long-list
+    exit remains open. -/
+def walkInitShortSuccessSemanticNBranch
+    (base inputBase listLen raVal t0Old t1Old outBase : Word)
+    (input d0 d1 d2 d3 : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hcode : base.toNat + 172 + 4 + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    WP.NBranch base
+      ((walkInitEmptyFailNotListFailShortLongCode base).union
+        ((walkInitShortSuccessJumpCode base).union
+          ((schemaCursorInitCode (base + 172)).union
+            ((schemaCR (base + 172 + 4) .x8 (successFieldSpecs d0 d1 d2 d3)).union
+              (successStatusReturnCode
+                ((base + 172 + 4) + BitVec.ofNat 64
+                  (schemaSize (successFieldSpecs d0 d1 d2 d3)))))))) := by
+  let br := walkInitShortSuccessSchemaNBranch base inputBase listLen raVal t0Old t1Old outBase
+    input d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval hc0 hl0 hc1 hl1 haddr
+    hc3 hl3 hinput hcode
+  let exits := walkInitShortSuccessSemanticExits base inputBase listLen raVal t0Old t1Old outBase
+    input d0 d1 d2 d3 hoff
+  have hBound : input.length < 2 ^ 64 := by
+    omega
+  exact WP.CFG.nbranchWeakenPosts br exits (by
+    intro ex hex
+    have hex' := hex
+    rw [walkInitShortSuccessSchemaNBranch_exits] at hex'
+    simp [walkInitShortSuccessSchemaExits] at hex'
+    rcases hex' with hcase | hcase | hcase | hcase
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(failStatusReturnExit raVal,
+        abiPost inputBase outBase raVal input **
+          walkInitEmptyFailSchemaAbiFrame listLen t0Old t1Old outBase), by simp [exits,
+            walkInitShortSuccessSemanticExits], rfl,
+        walkInitEmptyFailSchemaPost_entails_abiFailureFrame inputBase listLen raVal t0Old
+          t1Old outBase input hLen hBound⟩
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(failStatusReturnExit raVal,
+        abiPost inputBase outBase raVal input **
+          walkInitNotListFailSchemaAbiFrame inputBase listLen outBase input hoff), by simp [exits,
+            walkInitShortSuccessSemanticExits], rfl,
+        walkInitNotListFailSchemaPost_entails_abiFailureFrame inputBase listLen raVal outBase
+          input hoff⟩
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(successStatusReturnExit raVal,
+        walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3), by simp [exits,
+          walkInitShortSuccessSemanticExits], rfl, WP.Entails.refl _⟩
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(base + 28,
+        walkInitLongSchemaPost inputBase listLen raVal outBase input hoff), by simp [exits,
+          walkInitShortSuccessSemanticExits], rfl, WP.Entails.refl _⟩)
+
+theorem walkInitShortSuccessSemanticNBranch_pre
+    (base inputBase listLen raVal t0Old t1Old outBase : Word)
+    (input d0 d1 d2 d3 : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hcode : base.toNat + 172 + 4 + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    (walkInitShortSuccessSemanticNBranch base inputBase listLen raVal t0Old t1Old outBase input
+      d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval hc0 hl0 hc1 hl1 haddr hc3
+      hl3 hinput hLen hcode).pre =
+      (walkInitShortSuccessSchemaNBranch base inputBase listLen raVal t0Old t1Old outBase input
+        d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval hc0 hl0 hc1 hl1 haddr hc3
+        hl3 hinput hcode).pre := by
+  rfl
+
+theorem walkInitShortSuccessSemanticNBranch_exits
+    (base inputBase listLen raVal t0Old t1Old outBase : Word)
+    (input d0 d1 d2 d3 : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hcode : base.toNat + 172 + 4 + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    (walkInitShortSuccessSemanticNBranch base inputBase listLen raVal t0Old t1Old outBase input
+      d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval hc0 hl0 hc1 hl1 haddr hc3
+      hl3 hinput hLen hcode).exits =
+      walkInitShortSuccessSemanticExits base inputBase listLen raVal t0Old t1Old outBase input
+        d0 d1 d2 d3 hoff := by
+  rfl
+
+end WithdrawalDecode
+
+end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -256,6 +256,15 @@ theorem prologuePostShortSuccessCarry_entails_resolvedPre
     (walkInitShortSuccessResolvedPreFromPrologue_entails_pre inputBase listLen raVal t0Old
       t1Old outBase input) h hpExact
 
+attribute [rv64_wp_entails]
+  schemaWalkInitFrameFromPrologue_entails_schemaWalkInitFrame
+  walkInitShortSuccessResolvedPreFromPrologue_entails_pre
+  prologuePostAbiFailureCarry_entails_preFromPrologue
+  prologuePostEmptyInputCarry_entails_preFromPrologue
+  prologuePreAbiFailureEmptyCarry_entails_emptyScratchPre
+  prologuePostShortSuccessCarry_entails_resolvedPreFromPrologue
+  prologuePostShortSuccessCarry_entails_resolvedPre
+
 def walkInitEmptyFailSchemaAbiFrame (listLen t0Old t1Old outBase : Word) : Assertion :=
   walkInitEmptyFailAbiFrame listLen t0Old t1Old ** schemaWalkInitRegsFrame outBase
 
@@ -1045,6 +1054,29 @@ theorem walkInitEmptyInputFailureFromPrologueFullCodeNBranch_pre
         walkInitEmptyInputPrologueCarryFrame inputBase outBase) := by
   rfl
 
+attribute [rv64_wp] walkInitEmptyInputFailureFromPrologueFullCodeNBranch_pre
+
+/-- Shared-frame precondition bridge for the empty-input full-code branch.  This
+    is the reusable WP hint that lets generated zero/nonzero wrappers set the
+    ABI-failure caller frame without spelling out the scratch-frame proof. -/
+theorem prologuePreAbiFailureEmptyCarry_entails_fullCodeScratchPre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
+    (t0Old t1Old : Word)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    WP.Entails
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitAbiFailurePrologueCarryFrame inputBase (0 : Word) t0Old t1Old outBase
+          ([] : List Byte))
+      ((walkInitEmptyInputFailureFromPrologueFullCodeNBranch base sp0 raVal s0Old s1Old
+        s2Old outBase m0 m1 m2 m3 inputBase hprologueCode hcode).pre **
+        walkInitEmptyInputPrologueScratchFrame t0Old t1Old) := by
+  rw [walkInitEmptyInputFailureFromPrologueFullCodeNBranch_pre]
+  exact prologuePreAbiFailureEmptyCarry_entails_emptyScratchPre sp0 raVal s0Old s1Old
+    s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old
+
+attribute [rv64_wp_entails] prologuePreAbiFailureEmptyCarry_entails_fullCodeScratchPre
+
 /-- Extending code preserves the empty-input branch exits definitionally. -/
 theorem walkInitEmptyInputFailureFromPrologueFullCodeNBranch_exits
     (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
@@ -1072,16 +1104,9 @@ def walkInitEmptyInputFailureFromPrologueSharedFrameNBranch
   let scratchFrame := walkInitEmptyInputPrologueScratchFrame t0Old t1Old
   let br := WP.CFG.nbranchFrameR br0 scratchFrame
     (walkInitEmptyInputPrologueScratchFrame_pcFree t0Old t1Old)
-  have hpre : WP.Entails
-      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
-        walkInitAbiFailurePrologueCarryFrame inputBase (0 : Word) t0Old t1Old outBase
-          ([] : List Byte))
-      br.pre := by
-    dsimp [br, br0, scratchFrame, WP.CFG.nbranchFrameR, WP.NBranch.frameR]
-    rw [walkInitEmptyInputFailureFromPrologueFullCodeNBranch_pre]
-    exact prologuePreAbiFailureEmptyCarry_entails_emptyScratchPre sp0 raVal s0Old s1Old
-      s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old
-  wp_rv64_nbranch_weaken_pre_with br, hpre
+  exact WP.NBranch.weakenPre br
+    (prologuePreAbiFailureEmptyCarry_entails_fullCodeScratchPre base sp0 raVal s0Old
+      s1Old s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old hprologueCode hcode)
 
 /-- Expanded shared-frame precondition for the empty-input full-code path. -/
 theorem walkInitEmptyInputFailureFromPrologueSharedFrameNBranch_pre
@@ -1095,6 +1120,8 @@ theorem walkInitEmptyInputFailureFromPrologueSharedFrameNBranch_pre
         walkInitAbiFailurePrologueCarryFrame inputBase (0 : Word) t0Old t1Old outBase
           ([] : List Byte)) := by
   rfl
+
+attribute [rv64_wp] walkInitEmptyInputFailureFromPrologueSharedFrameNBranch_pre
 
 /-- Prologue followed by the ABI-failure classifier. Empty and not-list exits
     expose reason-erased ABI failure posts; short-list and long-list candidates
@@ -1175,18 +1202,13 @@ def walkInitZeroNonzeroAbiFailureFromPrologueNBranch
   | nil =>
       let br0 := walkInitEmptyInputFailureFromPrologueSharedFrameNBranch base sp0 raVal
         s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old hprologueCode hcode
-      have hpre : WP.Entails
-          (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
-            walkInitAbiFailurePrologueCarryFrame inputBase listLen t0Old t1Old outBase
-              ([] : List Byte))
-          br0.pre := by
-        dsimp [br0]
-        rw [walkInitEmptyInputFailureFromPrologueSharedFrameNBranch_pre]
-        have hLen0 : listLen = (0 : Word) := by
-          simpa using hLen
-        subst listLen
-        wp_rv64_link
-      wp_rv64_nbranch_weaken_pre_with br0, hpre
+      have hLen0 : listLen = (0 : Word) := by
+        simpa using hLen
+      subst listLen
+      wp_rv64_nbranch_set_pre br0,
+        (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+          walkInitAbiFailurePrologueCarryFrame inputBase (0 : Word) t0Old t1Old outBase
+            ([] : List Byte))
   | cons b rest =>
       have hoff : 0 < (b :: rest).length := by simp
       have hover0 : inputBase.toNat + 0 < 2 ^ 64 := by
@@ -1217,8 +1239,16 @@ theorem walkInitZeroNonzeroAbiFailureFromPrologueNBranch_pre
       (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
         walkInitAbiFailurePrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
   cases input with
-  | nil => rfl
+  | nil =>
+      have hLen0 : listLen = (0 : Word) := by
+        simpa using hLen
+      subst listLen
+      rfl
   | cons b rest => rfl
+
+attribute [rv64_wp]
+  walkInitAbiFailureFromPrologueNBranch_pre
+  walkInitZeroNonzeroAbiFailureFromPrologueNBranch_pre
 
 /-- Prologue followed by the reduced short-list success WP slice.  The prologue
     carries the walk-init/schema resources to its exit; the tail consumes those

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -1328,6 +1328,35 @@ def walkInitEmptyInputFailureFromPrologueSharedFramePost
     walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) **
     walkInitEmptyInputPrologueScratchFrame t0Old t1Old
 
+/-- Empty-input failure post normalized to the same ABI-plus-reason-frame shape
+    as the nonempty reason-erased failure classifier. -/
+def walkInitEmptyInputFailureReasonPostFromPrologue
+    (sp0 raVal s0Old s1Old s2Old outBase inputBase : Word)
+    (t0Old t1Old : Word) : Assertion :=
+  (abiPost inputBase outBase raVal ([] : List Byte) **
+    walkInitEmptyFailAbiFrame (0 : Word) t0Old t1Old) **
+    walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase
+
+/-- The empty-input branch carries no relevant failure reason: expose only the
+    public ABI failure post plus the generic zero-case reason frame. -/
+theorem walkInitEmptyInputFailureFromPrologueSharedFramePost_entails_reasonPost
+    (sp0 raVal s0Old s1Old s2Old outBase inputBase : Word)
+    (t0Old t1Old : Word) :
+    WP.Entails
+      (walkInitEmptyInputFailureFromPrologueSharedFramePost sp0 raVal s0Old s1Old s2Old
+        outBase inputBase t0Old t1Old)
+      (walkInitEmptyInputFailureReasonPostFromPrologue sp0 raVal s0Old s1Old s2Old outBase
+        inputBase t0Old t1Old) := by
+  intro h hp
+  unfold walkInitEmptyInputFailureFromPrologueSharedFramePost emptyInputFailurePost
+    walkInitEmptyInputPrologueScratchFrame at hp
+  unfold walkInitEmptyInputFailureReasonPostFromPrologue walkInitEmptyFailAbiFrame abiPost
+  rw [resultPost_failure decodeWithdrawal_nil]
+  xperm_hyp hp
+
+attribute [rv64_wp_entails]
+  walkInitEmptyInputFailureFromPrologueSharedFramePost_entails_reasonPost
+
 /-- Resolved empty-input path over the full classifier code with the same
     scratch-register caller frame as the nonempty classifier. -/
 def walkInitEmptyInputFailureFromPrologueSharedFrameCert
@@ -1886,6 +1915,107 @@ theorem walkInitZeroNonzeroAbiFailureFromPrologueNBranch_exits
       rfl
   | cons b rest => rfl
 
+/-- Input-indexed exits with empty input normalized to the same
+    ABI-plus-reason-frame style as the nonempty reason-erased classifier. -/
+def walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueExits
+    (base sp0 raVal s0Old s1Old s2Old outBase : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) : List (Word × Assertion) :=
+  match input with
+  | [] =>
+      [ (failStatusReturnExit raVal,
+          walkInitEmptyInputFailureReasonPostFromPrologue sp0 raVal s0Old s1Old s2Old
+            outBase inputBase t0Old t1Old) ]
+  | b :: rest =>
+      walkInitAbiFailureReasonErasedFromPrologueExits base sp0 raVal s0Old s1Old s2Old
+        outBase inputBase listLen t0Old t1Old (b :: rest) (by simp)
+
+/-- Zero/nonzero failure facade with the empty-input exit reason-erased too.
+    This keeps the same static precondition and code as the classifier facade,
+    but avoids exposing the precise empty-failure post shape to generated joins. -/
+def walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    WP.NBranch base
+      ((prologueCode base).union
+        (walkInitEmptyFailNotListFailShortLongCode (base + 24))) := by
+  let br := walkInitZeroNonzeroAbiFailureFromPrologueNBranch base sp0 raVal s0Old s1Old
+    s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hover hwin hLen
+    hprologueCode hcode
+  cases input with
+  | nil =>
+      have hLen0 : listLen = (0 : Word) := by
+        simpa using hLen
+      subst listLen
+      exact WP.CFG.nbranchWeakenHeadPost br (by
+        dsimp [br]
+        rw [walkInitZeroNonzeroAbiFailureFromPrologueNBranch_exits]
+        rfl)
+        (walkInitEmptyInputFailureFromPrologueSharedFramePost_entails_reasonPost sp0 raVal
+          s0Old s1Old s2Old outBase inputBase t0Old t1Old)
+  | cons _ _ =>
+      exact br
+
+/-- The reason-erased zero/nonzero facade preserves the original static
+    precondition. -/
+theorem walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    (walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueNBranch base sp0 raVal s0Old
+      s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hover
+      hwin hLen hprologueCode hcode).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitAbiFailurePrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  cases input with
+  | nil =>
+      have hLen0 : listLen = (0 : Word) := by
+        simpa using hLen
+      subst listLen
+      rfl
+  | cons _ _ => rfl
+
+attribute [rv64_wp]
+  walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueNBranch_pre
+
+/-- The reason-erased zero/nonzero facade exposes normalized empty exits and
+    keeps the nonempty reason-erased classifier exits unchanged. -/
+theorem walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueNBranch_exits
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    (walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueNBranch base sp0 raVal s0Old
+      s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hover
+      hwin hLen hprologueCode hcode).exits =
+      walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueExits base sp0 raVal s0Old s1Old
+        s2Old outBase inputBase listLen t0Old t1Old input := by
+  cases input with
+  | nil =>
+      have hLen0 : listLen = (0 : Word) := by
+        simpa using hLen
+      subst listLen
+      rfl
+  | cons _ _ => rfl
+
 /-- The zero/nonzero ABI-failure facade lifted to the same code requirement as
     the resolved short-success slice. The precondition and exits are unchanged;
     only the persistent code requirement is enlarged. -/
@@ -1952,6 +2082,70 @@ theorem walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeNBranch_exits
   unfold walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeNBranch
   simp only [WP.NBranch.extendCode]
   rw [walkInitZeroNonzeroAbiFailureFromPrologueNBranch_exits]
+
+/-- The reason-erased zero/nonzero facade lifted to the resolved short-success
+    code requirement.  This is the preferred failure-side shape for generated
+    joins: empty input and nonempty classifier failures have the same
+    reason-erased ABI style, while short/long candidates stay open. -/
+def walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    WP.NBranch base
+      ((prologueCode base).union
+        (walkInitShortSuccessResolvedCode (base + 24) specs)) := by
+  let br := walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueNBranch base sp0 raVal
+    s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input
+    hsalign hover hwin hLen hprologueCode (by omega)
+  wp_rv64_nbranch_extend_code br,
+    (prologueWalkInitClassifierCode_mono_resolvedCode base specs)
+
+theorem walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    (walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeNBranch base sp0 raVal
+      s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input specs
+      hsalign hover hwin hLen hprologueCode hcode).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitAbiFailurePrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  unfold walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeNBranch
+  simp only [WP.NBranch.extendCode]
+  rw [walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueNBranch_pre]
+
+attribute [rv64_wp]
+  walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeNBranch_pre
+
+theorem walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeNBranch_exits
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    (walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeNBranch base sp0 raVal
+      s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input specs
+      hsalign hover hwin hLen hprologueCode hcode).exits =
+      walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueExits base sp0 raVal s0Old s1Old
+        s2Old outBase inputBase listLen t0Old t1Old input := by
+  unfold walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeNBranch
+  simp only [WP.NBranch.extendCode]
+  rw [walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueNBranch_exits]
 
 /-- Failure facade over the resolved short-success code, restated with the same
     success-shaped static caller frame used by the schema-success path.  The
@@ -2032,6 +2226,86 @@ theorem walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeSuccessFrameNBranch
   unfold walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeSuccessFrameNBranch
   simp only [WP.NBranch.weakenPre, WP.CFG.nbranchFrameR, WP.NBranch.frameR]
   rw [walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeNBranch_exits]
+  rfl
+
+/-- Reason-erased failure facade over the resolved short-success code, in the
+    same success-shaped caller frame as the schema-success path.  Prefer this
+    over the raw fallback when generated joins do not care why decoding failed. -/
+def walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeSuccessFrameNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    WP.NBranch base
+      ((prologueCode base).union
+        (walkInitShortSuccessResolvedCode (base + 24) specs)) := by
+  let br := walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeNBranch base
+    sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input
+    specs hsalign hover hwin hLen hprologueCode hcode
+  have hpre : WP.Entails
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input)
+      (br.pre ** walkInitSchemaScratchFrame) := by
+    dsimp [br]
+    rw [walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeNBranch_pre]
+    exact prologuePreShortSuccessCarry_entails_abiFailureScratchPre sp0 raVal s0Old s1Old
+      s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input
+  wp_rv64_nbranch_frame_set_pre br, walkInitSchemaScratchFrame,
+    walkInitSchemaScratchFrame_pcFree,
+    (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+      walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input)
+
+theorem walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeSuccessFrameNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    (walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeSuccessFrameNBranch
+      base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old
+      input specs hsalign hover hwin hLen hprologueCode hcode).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  rfl
+
+attribute [rv64_wp]
+  walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeSuccessFrameNBranch_pre
+
+def walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeSuccessFrameExits
+    (base sp0 raVal s0Old s1Old s2Old outBase : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) : List (Word × Assertion) :=
+  (walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueExits base sp0 raVal s0Old s1Old
+    s2Old outBase inputBase listLen t0Old t1Old input).map
+    (fun ex => (ex.1, ex.2 ** walkInitSchemaScratchFrame))
+
+theorem walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeSuccessFrameNBranch_exits
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    (walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeSuccessFrameNBranch
+      base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old
+      input specs hsalign hover hwin hLen hprologueCode hcode).exits =
+      walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeSuccessFrameExits base
+        sp0 raVal s0Old s1Old s2Old outBase inputBase listLen t0Old t1Old input := by
+  unfold walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeSuccessFrameNBranch
+  simp only [WP.NBranch.weakenPre, WP.CFG.nbranchFrameR, WP.NBranch.frameR]
+  rw [walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeNBranch_exits]
   rfl
 
 /-- Prologue followed by the reduced short-list success WP slice.  The prologue

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -154,27 +154,37 @@ def walkInitAbiFailurePreFromPrologue
 /-- Resources framed across the prologue for the `input = []` walk-init split. -/
 def walkInitEmptyInputPrologueCarryFrame (inputBase outBase : Word) : Assertion :=
   ((.x10 ↦ᵣ (inputBase + BitVec.ofNat 64 0)) ** (.x11 ↦ᵣ (0 : Word)) **
-    (.x0 ↦ᵣ (0 : Word)) ** emptyInputDecodeFrame inputBase outBase)
+    (.x0 ↦ᵣ (0 : Word)) ** emptyInputAbiFrame inputBase outBase)
 
 theorem walkInitEmptyInputPrologueCarryFrame_pcFree (inputBase outBase : Word) :
     (walkInitEmptyInputPrologueCarryFrame inputBase outBase).pcFree := by
   unfold walkInitEmptyInputPrologueCarryFrame
   exact pcFree_sepConj pcFree_regIs
     (pcFree_sepConj pcFree_regIs
-      (pcFree_sepConj pcFree_regIs (emptyInputDecodeFrame_pcFree inputBase outBase)))
+      (pcFree_sepConj pcFree_regIs (emptyInputAbiFrame_pcFree inputBase outBase)))
 
 /-- Exact empty-input walk-init precondition after the decoder prologue. -/
 def walkInitEmptyInputPreFromPrologue
     (inputBase outBase raVal : Word) : Assertion :=
   walkInitEmptyFailStatusPre (0 : Word) raVal (inputBase + BitVec.ofNat 64 0) **
-    emptyInputDecodeFrame inputBase outBase
+    emptyInputAbiFrame inputBase outBase
+
+/-- Scratch registers carried across the empty-input path to match the nonempty
+    classifier's static caller frame. -/
+def walkInitEmptyInputPrologueScratchFrame (t0Old t1Old : Word) : Assertion :=
+  ((.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old))
+
+theorem walkInitEmptyInputPrologueScratchFrame_pcFree (t0Old t1Old : Word) :
+    (walkInitEmptyInputPrologueScratchFrame t0Old t1Old).pcFree := by
+  unfold walkInitEmptyInputPrologueScratchFrame
+  pcFree
 
 -- WP-link automation unfolds these small assertion-shape helpers before `xperm`.
 attribute [rv64_wp] schemaWalkInitFrameFromPrologue walkInitShortSuccessPrologueSavedFrame
   walkInitShortSuccessPrologueCarryFrame walkInitShortSuccessResolvedPreFromPrologue
   walkInitAbiFailurePrologueCarryFrame walkInitAbiFailurePrologueSavedFrame
   walkInitAbiFailurePreFromPrologue walkInitEmptyInputPrologueCarryFrame
-  walkInitEmptyInputPreFromPrologue emptyInputDecodeFrame emptyInputAbiFrame
+  walkInitEmptyInputPreFromPrologue walkInitEmptyInputPrologueScratchFrame emptyInputAbiFrame
   walkInitEmptyNotListAbiFailureNBranch_pre walkInitEmptyInputFailureNBranch_pre
   walkInitEmptyFailNotListFailShortLongOutputNBranch_pre walkInitEmptyFailStatusPre
   walkInitZeroNonzeroPre failStatusReturnPre statusReturnPre
@@ -200,6 +210,19 @@ theorem prologuePostEmptyInputCarry_entails_preFromPrologue
         walkInitEmptyInputPrologueCarryFrame inputBase outBase)
       (walkInitEmptyInputPreFromPrologue inputBase outBase raVal **
         walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) := by
+  wp_rv64_link
+
+/-- The empty-input caller frame is the ABI-failure caller frame specialized to
+    zero length and empty bytes, with `x5`/`x6` preserved as scratch frame. -/
+theorem prologuePreAbiFailureEmptyCarry_entails_emptyScratchPre
+    (sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old : Word) :
+    WP.Entails
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitAbiFailurePrologueCarryFrame inputBase (0 : Word) t0Old t1Old outBase
+          ([] : List Byte))
+      ((prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitEmptyInputPrologueCarryFrame inputBase outBase) **
+        walkInitEmptyInputPrologueScratchFrame t0Old t1Old) := by
   wp_rv64_link
 
 /-- Link the concrete prologue post plus caller-framed walk-init resources to
@@ -1031,6 +1054,46 @@ theorem walkInitEmptyInputFailureFromPrologueFullCodeNBranch_exits
       outBase m0 m1 m2 m3 inputBase hprologueCode hcode).exits =
       (walkInitEmptyInputFailureFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old
         outBase m0 m1 m2 m3 inputBase hprologueCode (by omega)).exits := by
+  rfl
+
+/-- Empty-input path with the same scratch-register caller frame as the nonempty
+    ABI-failure classifier. The precondition is the nonempty classifier frame
+    specialized to `listLen = 0` and `input = []`. -/
+def walkInitEmptyInputFailureFromPrologueSharedFrameNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
+    (t0Old t1Old : Word)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    WP.NBranch base
+      ((prologueCode base).union
+        (walkInitEmptyFailNotListFailShortLongCode (base + 24))) := by
+  let br0 := walkInitEmptyInputFailureFromPrologueFullCodeNBranch base sp0 raVal s0Old s1Old
+    s2Old outBase m0 m1 m2 m3 inputBase hprologueCode hcode
+  let scratchFrame := walkInitEmptyInputPrologueScratchFrame t0Old t1Old
+  let br := WP.CFG.nbranchFrameR br0 scratchFrame
+    (walkInitEmptyInputPrologueScratchFrame_pcFree t0Old t1Old)
+  have hpre : WP.Entails
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitAbiFailurePrologueCarryFrame inputBase (0 : Word) t0Old t1Old outBase
+          ([] : List Byte))
+      br.pre := by
+    dsimp [br, br0, scratchFrame, WP.CFG.nbranchFrameR, WP.NBranch.frameR]
+    rw [walkInitEmptyInputFailureFromPrologueFullCodeNBranch_pre]
+    exact prologuePreAbiFailureEmptyCarry_entails_emptyScratchPre sp0 raVal s0Old s1Old
+      s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old
+  wp_rv64_nbranch_weaken_pre_with br, hpre
+
+/-- Expanded shared-frame precondition for the empty-input full-code path. -/
+theorem walkInitEmptyInputFailureFromPrologueSharedFrameNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
+    (t0Old t1Old : Word)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    (walkInitEmptyInputFailureFromPrologueSharedFrameNBranch base sp0 raVal s0Old s1Old
+      s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old hprologueCode hcode).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitAbiFailurePrologueCarryFrame inputBase (0 : Word) t0Old t1Old outBase
+          ([] : List Byte)) := by
   rfl
 
 /-- Prologue followed by the ABI-failure classifier. Empty and not-list exits

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -1123,6 +1123,33 @@ theorem walkInitEmptyInputFailureFromPrologueSharedFrameNBranch_pre
 
 attribute [rv64_wp] walkInitEmptyInputFailureFromPrologueSharedFrameNBranch_pre
 
+/-- Fully named exits for the empty-input prologue path with the scratch frame
+    aligned to the nonempty classifier caller frame. -/
+def walkInitEmptyInputFailureFromPrologueSharedFrameExits
+    (base sp0 raVal s0Old s1Old s2Old outBase inputBase : Word)
+    (t0Old t1Old : Word) : List (Word × Assertion) :=
+  [ (failStatusReturnExit raVal,
+      (emptyInputFailurePost inputBase outBase raVal **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) **
+        walkInitEmptyInputPrologueScratchFrame t0Old t1Old)
+  , ((base + 24) + 4,
+      ((walkInitNonzeroOpenStatusPost (0 : Word) raVal
+        (inputBase + BitVec.ofNat 64 0) ** emptyInputAbiFrame inputBase outBase) **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) **
+        walkInitEmptyInputPrologueScratchFrame t0Old t1Old)
+  ]
+
+theorem walkInitEmptyInputFailureFromPrologueSharedFrameNBranch_exits
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
+    (t0Old t1Old : Word)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    (walkInitEmptyInputFailureFromPrologueSharedFrameNBranch base sp0 raVal s0Old s1Old
+      s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old hprologueCode hcode).exits =
+      walkInitEmptyInputFailureFromPrologueSharedFrameExits base sp0 raVal s0Old s1Old
+        s2Old outBase inputBase t0Old t1Old := by
+  rfl
+
 /-- Prologue followed by the ABI-failure classifier. Empty and not-list exits
     expose reason-erased ABI failure posts; short-list and long-list candidates
     remain open for later resolution. -/
@@ -1179,6 +1206,45 @@ theorem walkInitAbiFailureFromPrologueNBranch_pre
       hBound hprologueCode hcode).pre =
       (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
         walkInitAbiFailurePrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  rfl
+
+/-- Fully named nonempty classifier exits after the decoder prologue. -/
+def walkInitAbiFailureFromPrologueExits
+    (base sp0 raVal s0Old s1Old s2Old outBase : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (hoff : 0 < input.length) : List (Word × Assertion) :=
+  [ (failStatusReturnExit raVal,
+      (abiPost inputBase outBase raVal input **
+        walkInitEmptyFailAbiFrame listLen t0Old t1Old) **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+  , (failStatusReturnExit raVal,
+      (abiPost inputBase outBase raVal input **
+        walkInitNotListFailAbiFrame inputBase listLen input 0 hoff) **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+  , ((base + 24) + 124,
+      walkInitShortListOutputPost inputBase listLen raVal outBase input 0 hoff **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+  , ((base + 24) + 28,
+      walkInitLongListOutputPost inputBase listLen raVal outBase input 0 hoff **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+  ]
+
+theorem walkInitAbiFailureFromPrologueNBranch_exits
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover0 : inputBase.toNat + 0 < 2 ^ 64)
+    (hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    (walkInitAbiFailureFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old outBase
+      m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hoff hover0 hvalid0 hLen
+      hBound hprologueCode hcode).exits =
+      walkInitAbiFailureFromPrologueExits base sp0 raVal s0Old s1Old s2Old outBase
+        inputBase listLen t0Old t1Old input hoff := by
   rfl
 
 /-- Prologue followed by the ABI-failure classifier, with the empty/nonempty
@@ -1249,6 +1315,44 @@ theorem walkInitZeroNonzeroAbiFailureFromPrologueNBranch_pre
 attribute [rv64_wp]
   walkInitAbiFailureFromPrologueNBranch_pre
   walkInitZeroNonzeroAbiFailureFromPrologueNBranch_pre
+
+/-- Input-indexed exits for the zero/nonzero prologue facade. Empty input keeps
+    the two-way zero/nonzero split; nonempty input exposes the four semantic
+    classifier exits. -/
+def walkInitZeroNonzeroAbiFailureFromPrologueExits
+    (base sp0 raVal s0Old s1Old s2Old outBase : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) : List (Word × Assertion) :=
+  match input with
+  | [] =>
+      walkInitEmptyInputFailureFromPrologueSharedFrameExits base sp0 raVal s0Old s1Old
+        s2Old outBase inputBase t0Old t1Old
+  | b :: rest =>
+      walkInitAbiFailureFromPrologueExits base sp0 raVal s0Old s1Old s2Old outBase
+        inputBase listLen t0Old t1Old (b :: rest) (by simp)
+
+theorem walkInitZeroNonzeroAbiFailureFromPrologueNBranch_exits
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    (walkInitZeroNonzeroAbiFailureFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old
+      outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hover hwin hLen
+      hprologueCode hcode).exits =
+      walkInitZeroNonzeroAbiFailureFromPrologueExits base sp0 raVal s0Old s1Old s2Old
+        outBase inputBase listLen t0Old t1Old input := by
+  cases input with
+  | nil =>
+      have hLen0 : listLen = (0 : Word) := by
+        simpa using hLen
+      subst listLen
+      rfl
+  | cons b rest => rfl
 
 /-- Prologue followed by the reduced short-list success WP slice.  The prologue
     carries the walk-init/schema resources to its exit; the tail consumes those

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -2736,6 +2736,71 @@ theorem walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeSuccess
   rw [walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeNBranch_exits]
   rfl
 
+/-- Input-indexed reason-erased failure facade over the resolved short-success
+    code with the long-list fall-through continued through the shared failure
+    return. Empty input uses the zero arm and simply extends the code
+    requirement with the unused long-failure block; nonempty input uses the
+    long-failure-resolving classifier. -/
+def walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureSuccessFrameNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    WP.NBranch base
+      (((prologueCode base).union
+        (walkInitShortSuccessResolvedCode (base + 24) specs)).union
+        (failStatusReturnCode ((base + 24) + 28))) := by
+  cases input with
+  | nil =>
+      let br := walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeSuccessFrameNBranch
+        base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old
+        t1Old [] specs hsalign hover hwin hLen hprologueCode hcode
+      exact EvmAsm.Rv64.WP.NBranch.extendCode br (by
+        intro a i h
+        exact CodeReq.union_mono_left a i h)
+  | cons b rest =>
+      have hoff : 0 < (b :: rest).length := by simp
+      exact walkInitAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureSuccessFrameNBranch
+        base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old
+        t1Old (b :: rest) specs hsalign hoff (by omega) (hwin 0 hoff) hLen (by omega)
+        hprologueCode hcode
+
+/-- The input-indexed long-failure facade has the same success-shaped static
+    caller precondition as the success certificate. -/
+theorem walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureSuccessFrameNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    (walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureSuccessFrameNBranch
+      base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old
+      input specs hsalign hover hwin hLen hprologueCode hcode).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  cases input with
+  | nil =>
+      unfold walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureSuccessFrameNBranch
+      simp only [WP.NBranch.extendCode]
+      rw [walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeSuccessFrameNBranch_pre]
+  | cons b rest =>
+      exact walkInitAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureSuccessFrameNBranch_pre
+        base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old
+        t1Old (b :: rest) specs hsalign (by simp) (by omega) (hwin 0 (by simp)) hLen
+        (by omega) hprologueCode hcode
+
+attribute [rv64_wp]
+  walkInitZeroNonzeroAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureSuccessFrameNBranch_pre
+
 /-- Prologue followed by the reduced short-list success WP slice.  The prologue
     carries the walk-init/schema resources to its exit; the tail consumes those
     resources and returns the ABI success post while preserving the saved frame. -/

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -381,6 +381,10 @@ theorem walkInitNotListFailSchemaPost_entails_abiFailureFrame
   simp only [sepConj_emp_right']
   xperm_hyp hpAny
 
+attribute [rv64_wp_entails]
+  walkInitEmptyFailSchemaPost_entails_abiFailureFrame
+  walkInitNotListFailSchemaPost_entails_abiFailureFrame
+
 def walkInitShortSuccessAbiPost
     (inputBase outBase raVal : Word) (input d0 d1 d2 d3 : List Byte) : Assertion :=
   ((abiPost inputBase outBase raVal input **
@@ -616,16 +620,16 @@ def walkInitShortSuccessSemanticNBranch
     hc3 hl3 hinput hcode
   have hBound : input.length < 2 ^ 64 := by
     omega
-  wp_rv64_nbranch_weaken_posts4_with br,
+  wp_rv64_nbranch_weaken_posts4_with_auto br,
     (walkInitShortSuccessSchemaNBranch_exits base inputBase listLen raVal t0Old t1Old
       outBase input d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval hc0 hl0 hc1 hl1
       haddr hc3 hl3 hinput hcode),
-    (walkInitEmptyFailSchemaPost_entails_abiFailureFrame inputBase listLen raVal t0Old
-      t1Old outBase input hLen hBound),
-    (walkInitNotListFailSchemaPost_entails_abiFailureFrame inputBase listLen raVal outBase
-      input hoff),
-    (WP.Entails.refl _),
-    (WP.Entails.refl _)
+    (abiPost inputBase outBase raVal input **
+      walkInitEmptyFailSchemaAbiFrame listLen t0Old t1Old outBase),
+    (abiPost inputBase outBase raVal input **
+      walkInitNotListFailSchemaAbiFrame inputBase listLen outBase input hoff),
+    (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3),
+    (walkInitLongSchemaPost inputBase listLen raVal outBase input hoff)
 
 theorem walkInitShortSuccessSemanticNBranch_pre
     (base inputBase listLen raVal t0Old t1Old outBase : Word)

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -1028,6 +1028,9 @@ theorem prologueCode_disjoint_walkInitEmptyFailNotListFailShortLongCode
     exact walkInitEmptyFailNotListFailShortLongCode_none_below (base + 24) a htail
       (by rw [hbase24]; exact ha)
 
+attribute [rv64_wp_disjoint]
+  prologueCode_disjoint_walkInitEmptyFailNotListFailShortLongCode
+
 /-- The empty-input walk-init status block has no code below its entry address. -/
 theorem walkInitEmptyFailStatusCode_none_below
     (base a : Word) (hcode : base.toNat + 164 < 2 ^ 64) (h : a.toNat < base.toNat) :
@@ -1056,6 +1059,9 @@ theorem prologueCode_disjoint_walkInitEmptyFailStatusCode
     exact walkInitEmptyFailStatusCode_none_below (base + 24) a htail
       (by rw [hbase24]; exact ha)
 
+attribute [rv64_wp_disjoint]
+  prologueCode_disjoint_walkInitEmptyFailStatusCode
+
 /-- Prologue followed by the empty-input walk-init failure split. The taken exit
     carries the semantic `decodeWithdrawal [] = none` failure fact, while the
     nonzero exit remains explicit and contradictory for `listLen = 0`. -/
@@ -1070,20 +1076,10 @@ def walkInitEmptyInputFailureFromPrologueNBranch
   let head := prologueCert base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
   let tail := walkInitEmptyInputFailureNBranch (base + 24) inputBase outBase raVal
     (inputBase + BitVec.ofNat 64 0)
-  have hlink : WP.Entails
-      (prologuePost sp0 raVal s0Old s1Old s2Old outBase ** carryFrame)
-      (tail.pre ** savedFrame) := by
-    dsimp [tail, carryFrame, savedFrame]
-    simp only [walkInitEmptyInputFailureNBranch_pre]
-    exact prologuePostEmptyInputCarry_entails_preFromPrologue sp0 raVal s0Old s1Old s2Old
-      inputBase outBase
-  wp_rv64_seq_block_nbranch_framed_disjoint_with
-    (prologueCode_disjoint_walkInitEmptyFailStatusCode base hprologueCode hcode),
-    head, carryFrame,
+  wp_rv64_seq_block_nbranch_framed_auto head, carryFrame,
     (walkInitEmptyInputPrologueCarryFrame_pcFree inputBase outBase),
     tail, savedFrame,
-    (walkInitAbiFailurePrologueSavedFrame_pcFree sp0 raVal s0Old s1Old s2Old outBase),
-    hlink
+    (walkInitAbiFailurePrologueSavedFrame_pcFree sp0 raVal s0Old s1Old s2Old outBase)
 
 /-- Expanded precondition for the prologue-to-empty-input failure split. -/
 theorem walkInitEmptyInputFailureFromPrologueNBranch_pre
@@ -1382,22 +1378,10 @@ def walkInitAbiFailureFromPrologueNBranch
   let head := prologueCert base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
   let tail := walkInitEmptyNotListAbiFailureNBranch (base + 24) inputBase listLen raVal
     t0Old t1Old outBase input hsalign hoff hover0 hvalid0 hLen hBound
-  have hlink : WP.Entails
-      (prologuePost sp0 raVal s0Old s1Old s2Old outBase ** carryFrame)
-      (tail.pre ** savedFrame) := by
-    dsimp [tail, carryFrame, savedFrame]
-    simp only [walkInitEmptyNotListAbiFailureNBranch_pre,
-      walkInitEmptyFailNotListFailShortLongOutputNBranch_pre]
-    exact prologuePostAbiFailureCarry_entails_preFromPrologue sp0 raVal s0Old s1Old
-      s2Old inputBase listLen t0Old t1Old outBase input
-  wp_rv64_seq_block_nbranch_framed_disjoint_with
-    (prologueCode_disjoint_walkInitEmptyFailNotListFailShortLongCode base
-      hprologueCode hcode),
-    head, carryFrame,
+  wp_rv64_seq_block_nbranch_framed_auto head, carryFrame,
     (walkInitAbiFailurePrologueCarryFrame_pcFree inputBase listLen t0Old t1Old outBase input),
     tail, savedFrame,
-    (walkInitAbiFailurePrologueSavedFrame_pcFree sp0 raVal s0Old s1Old s2Old outBase),
-    hlink
+    (walkInitAbiFailurePrologueSavedFrame_pcFree sp0 raVal s0Old s1Old s2Old outBase)
 
 /-- Expanded precondition for the prologue-to-ABI-failure classifier. -/
 theorem walkInitAbiFailureFromPrologueNBranch_pre

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -2180,6 +2180,63 @@ attribute [rv64_wp]
 attribute [rv64_wp_cert]
   walkInitAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureNBranch
 
+/-- Nonempty long-failure-resolving facade with the same success-shaped static
+    caller frame used by the schema-success path. -/
+def walkInitAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureSuccessFrameNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover0 : inputBase.toNat + 0 < 2 ^ 64)
+    (hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    WP.NBranch base
+      (((prologueCode base).union
+        (walkInitShortSuccessResolvedCode (base + 24) specs)).union
+        (failStatusReturnCode ((base + 24) + 28))) := by
+  let br := walkInitAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureNBranch base sp0
+    raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input
+    specs hsalign hoff hover0 hvalid0 hLen hBound hprologueCode hcode
+  have hpre : WP.Entails
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input)
+      (br.pre ** walkInitSchemaScratchFrame) := by
+    dsimp [br]
+    rw [walkInitAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureNBranch_pre,
+      walkInitAbiFailureReasonErasedFromPrologueNBranch_pre]
+    exact prologuePreShortSuccessCarry_entails_abiFailureScratchPre sp0 raVal s0Old s1Old
+      s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input
+  exact WP.NBranch.weakenPre
+    (WP.CFG.nbranchFrameR br walkInitSchemaScratchFrame walkInitSchemaScratchFrame_pcFree)
+    hpre
+
+theorem walkInitAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureSuccessFrameNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover0 : inputBase.toNat + 0 < 2 ^ 64)
+    (hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    (walkInitAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureSuccessFrameNBranch
+      base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old
+      input specs hsalign hoff hover0 hvalid0 hLen hBound hprologueCode hcode).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  rfl
+
+attribute [rv64_wp]
+  walkInitAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureSuccessFrameNBranch_pre
+
+attribute [rv64_wp_cert]
+  walkInitAbiFailureReasonErasedFromPrologueResolvedCodeLongFailureSuccessFrameNBranch
+
 /-- Prologue followed by the ABI-failure classifier, with the empty/nonempty
     split selected from the concrete input bytes. Callers supply only static
     length and memory-validity facts; the WP facade chooses the empty path for

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -1154,6 +1154,72 @@ theorem walkInitAbiFailureFromPrologueNBranch_pre
         walkInitAbiFailurePrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
   rfl
 
+/-- Prologue followed by the ABI-failure classifier, with the empty/nonempty
+    split selected from the concrete input bytes. Callers supply only static
+    length and memory-validity facts; the WP facade chooses the empty path for
+    `[]` and the classifier path for nonempty input. -/
+def walkInitZeroNonzeroAbiFailureFromPrologueNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    WP.NBranch base
+      ((prologueCode base).union
+        (walkInitEmptyFailNotListFailShortLongCode (base + 24))) := by
+  cases input with
+  | nil =>
+      let br0 := walkInitEmptyInputFailureFromPrologueSharedFrameNBranch base sp0 raVal
+        s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old hprologueCode hcode
+      have hpre : WP.Entails
+          (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+            walkInitAbiFailurePrologueCarryFrame inputBase listLen t0Old t1Old outBase
+              ([] : List Byte))
+          br0.pre := by
+        dsimp [br0]
+        rw [walkInitEmptyInputFailureFromPrologueSharedFrameNBranch_pre]
+        have hLen0 : listLen = (0 : Word) := by
+          simpa using hLen
+        subst listLen
+        wp_rv64_link
+      wp_rv64_nbranch_weaken_pre_with br0, hpre
+  | cons b rest =>
+      have hoff : 0 < (b :: rest).length := by simp
+      have hover0 : inputBase.toNat + 0 < 2 ^ 64 := by
+        omega
+      have hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true :=
+        hwin 0 hoff
+      have hBound : (b :: rest).length < 2 ^ 64 := by
+        omega
+      exact walkInitAbiFailureFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old
+        outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old (b :: rest) hsalign hoff
+        hover0 hvalid0 hLen hBound hprologueCode hcode
+
+/-- Fully reduced precondition for the input-indexed empty/nonempty ABI-failure
+    facade. It is static and contains no pre-decoded branch/result fact. -/
+theorem walkInitZeroNonzeroAbiFailureFromPrologueNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    (walkInitZeroNonzeroAbiFailureFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old
+      outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hover hwin hLen
+      hprologueCode hcode).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitAbiFailurePrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  cases input with
+  | nil => rfl
+  | cons b rest => rfl
+
 /-- Prologue followed by the reduced short-list success WP slice.  The prologue
     carries the walk-init/schema resources to its exit; the tail consumes those
     resources and returns the ABI success post while preserving the saved frame. -/

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -988,6 +988,51 @@ theorem walkInitEmptyInputFailureFromPrologueNBranch_pre
         walkInitEmptyInputPrologueCarryFrame inputBase outBase) := by
   rfl
 
+/-- Empty-input path stated over the full walk-init classifier code. This lets
+    later zero/nonzero wrappers use one code requirement for both empty and
+    nonempty inputs. -/
+def walkInitEmptyInputFailureFromPrologueFullCodeNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    WP.NBranch base
+      ((prologueCode base).union
+        (walkInitEmptyFailNotListFailShortLongCode (base + 24))) := by
+  let br := walkInitEmptyInputFailureFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old
+    outBase m0 m1 m2 m3 inputBase hprologueCode (by omega)
+  wp_rv64_nbranch_extend_code br, (by
+    intro a i h
+    cases hprologue : prologueCode base a with
+    | none =>
+        simp only [CodeReq.union, hprologue] at h ⊢
+        unfold walkInitEmptyFailNotListFailShortLongCode walkInitEmptyFailOrPrefixCode
+        exact CodeReq.union_mono_left a i (CodeReq.union_mono_left a i h)
+    | some instr =>
+        simp only [CodeReq.union, hprologue] at h ⊢
+        exact h)
+
+/-- Expanded precondition for the empty-input path over the full classifier code. -/
+theorem walkInitEmptyInputFailureFromPrologueFullCodeNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    (walkInitEmptyInputFailureFromPrologueFullCodeNBranch base sp0 raVal s0Old s1Old s2Old
+      outBase m0 m1 m2 m3 inputBase hprologueCode hcode).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitEmptyInputPrologueCarryFrame inputBase outBase) := by
+  rfl
+
+/-- Extending code preserves the empty-input branch exits definitionally. -/
+theorem walkInitEmptyInputFailureFromPrologueFullCodeNBranch_exits
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    (walkInitEmptyInputFailureFromPrologueFullCodeNBranch base sp0 raVal s0Old s1Old s2Old
+      outBase m0 m1 m2 m3 inputBase hprologueCode hcode).exits =
+      (walkInitEmptyInputFailureFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old
+        outBase m0 m1 m2 m3 inputBase hprologueCode (by omega)).exits := by
+  rfl
+
 /-- Prologue followed by the ABI-failure classifier. Empty and not-list exits
     expose reason-erased ABI failure posts; short-list and long-list candidates
     remain open for later resolution. -/

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -113,10 +113,63 @@ theorem walkInitShortSuccessResolvedPreFromPrologue_entails_pre
   unfold walkInitShortSuccessResolvedPreFromPrologue at hp
   exact sepConj_mono_right (schemaWalkInitFrameFromPrologue_entails_schemaWalkInitFrame outBase) h hp
 
+/-- Resources framed across the prologue so the ABI-failure walk-init classifier
+    can start directly at the prologue exit. The output buffer is arbitrary
+    because failure posts only report status, not decoded output bytes. -/
+def walkInitAbiFailurePrologueCarryFrame
+    (inputBase listLen t0Old t1Old outBase : Word) (input : List Byte) : Assertion :=
+  ((.x10 ↦ᵣ (inputBase + BitVec.ofNat 64 0)) ** (.x11 ↦ᵣ listLen) **
+    (.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) **
+    bytesRegion inputBase input ** bytesRegionAny outBase outputSize)
+
+theorem walkInitAbiFailurePrologueCarryFrame_pcFree
+    (inputBase listLen t0Old t1Old outBase : Word) (input : List Byte) :
+    (walkInitAbiFailurePrologueCarryFrame inputBase listLen t0Old t1Old outBase input).pcFree := by
+  unfold walkInitAbiFailurePrologueCarryFrame
+  pcFree
+
+/-- Prologue-owned resources that the ABI-failure classifier does not consume. -/
+def walkInitAbiFailurePrologueSavedFrame
+    (sp0 raVal s0Old s1Old s2Old outBase : Word) : Assertion :=
+  ((.x2 ↦ᵣ prologueFrameBase sp0) ** (.x8 ↦ᵣ outBase) ** (.x9 ↦ᵣ s1Old) **
+    (.x18 ↦ᵣ s2Old) ** (.x12 ↦ᵣ outBase) **
+    (prologueFrameBase sp0 ↦ₘ raVal) **
+    ((prologueFrameBase sp0 + 8) ↦ₘ s0Old) **
+    ((prologueFrameBase sp0 + 16) ↦ₘ s1Old) **
+    ((prologueFrameBase sp0 + 24) ↦ₘ s2Old))
+
+theorem walkInitAbiFailurePrologueSavedFrame_pcFree
+    (sp0 raVal s0Old s1Old s2Old outBase : Word) :
+    (walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase).pcFree := by
+  unfold walkInitAbiFailurePrologueSavedFrame
+  pcFree
+
+/-- Exact ABI-failure classifier precondition after the decoder prologue. -/
+def walkInitAbiFailurePreFromPrologue
+    (inputBase listLen raVal t0Old t1Old outBase : Word) (input : List Byte) : Assertion :=
+  ((walkInitEmptyFailStatusPre listLen raVal (inputBase + BitVec.ofNat 64 0) **
+    (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion inputBase input) **
+    bytesRegionAny outBase outputSize)
+
 -- WP-link automation unfolds these small assertion-shape helpers before `xperm`.
 attribute [rv64_wp] schemaWalkInitFrameFromPrologue walkInitShortSuccessPrologueSavedFrame
   walkInitShortSuccessPrologueCarryFrame walkInitShortSuccessResolvedPreFromPrologue
-  walkInitEmptyFailStatusPre walkInitZeroNonzeroPre failStatusReturnPre statusReturnPre
+  walkInitAbiFailurePrologueCarryFrame walkInitAbiFailurePrologueSavedFrame
+  walkInitAbiFailurePreFromPrologue walkInitEmptyNotListAbiFailureNBranch_pre
+  walkInitEmptyFailNotListFailShortLongOutputNBranch_pre walkInitEmptyFailStatusPre
+  walkInitZeroNonzeroPre failStatusReturnPre statusReturnPre
+
+/-- Link the concrete prologue post plus failure-classifier resources to the
+    exact walk-init ABI-failure precondition, preserving prologue-owned state. -/
+theorem prologuePostAbiFailureCarry_entails_preFromPrologue
+    (sp0 raVal s0Old s1Old s2Old inputBase listLen t0Old t1Old outBase : Word)
+    (input : List Byte) :
+    WP.Entails
+      (prologuePost sp0 raVal s0Old s1Old s2Old outBase **
+        walkInitAbiFailurePrologueCarryFrame inputBase listLen t0Old t1Old outBase input)
+      (walkInitAbiFailurePreFromPrologue inputBase listLen raVal t0Old t1Old outBase input **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) := by
+  wp_rv64_link
 
 /-- Link the concrete prologue post plus caller-framed walk-init resources to
     the exact resolved WP precondition, carrying the saved frame as a tail frame. -/
@@ -818,6 +871,81 @@ theorem prologueCode_disjoint_walkInitShortSuccessResolvedCode
   · intro a ha
     exact walkInitShortSuccessResolvedCode_none_below (base + 24) specs a htail
       (by rw [hbase24]; exact ha)
+
+/-- Range split between the decoder prologue and the standalone walk-init
+    classifier. -/
+theorem prologueCode_disjoint_walkInitEmptyFailNotListFailShortLongCode
+    (base : Word)
+    (hprologue : base.toNat + 24 < 2 ^ 64)
+    (htail : (base + 24).toNat + 172 < 2 ^ 64) :
+    (prologueCode base).Disjoint
+      (walkInitEmptyFailNotListFailShortLongCode (base + 24)) := by
+  have hbase24 : (base + 24).toNat = base.toNat + 24 := by
+    bv_omega
+  refine codeReq_disjoint_of_ranges _ _ (base.toNat + 24) ?_ ?_
+  · intro a ha
+    exact prologueCode_none_above base a hprologue ha
+  · intro a ha
+    exact walkInitEmptyFailNotListFailShortLongCode_none_below (base + 24) a htail
+      (by rw [hbase24]; exact ha)
+
+/-- Prologue followed by the ABI-failure classifier. Empty and not-list exits
+    expose reason-erased ABI failure posts; short-list and long-list candidates
+    remain open for later resolution. -/
+def walkInitAbiFailureFromPrologueNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover0 : inputBase.toNat + 0 < 2 ^ 64)
+    (hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    WP.NBranch base
+      ((prologueCode base).union (walkInitEmptyFailNotListFailShortLongCode (base + 24))) := by
+  let carryFrame := walkInitAbiFailurePrologueCarryFrame inputBase listLen t0Old t1Old
+    outBase input
+  let savedFrame := walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase
+  let head := prologueCert base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+  let tail := walkInitEmptyNotListAbiFailureNBranch (base + 24) inputBase listLen raVal
+    t0Old t1Old outBase input hsalign hoff hover0 hvalid0 hLen hBound
+  have hlink : WP.Entails
+      (prologuePost sp0 raVal s0Old s1Old s2Old outBase ** carryFrame)
+      (tail.pre ** savedFrame) := by
+    dsimp [tail, carryFrame, savedFrame]
+    simp only [walkInitEmptyNotListAbiFailureNBranch_pre,
+      walkInitEmptyFailNotListFailShortLongOutputNBranch_pre]
+    exact prologuePostAbiFailureCarry_entails_preFromPrologue sp0 raVal s0Old s1Old
+      s2Old inputBase listLen t0Old t1Old outBase input
+  wp_rv64_seq_block_nbranch_framed_disjoint_with
+    (prologueCode_disjoint_walkInitEmptyFailNotListFailShortLongCode base
+      hprologueCode hcode),
+    head, carryFrame,
+    (walkInitAbiFailurePrologueCarryFrame_pcFree inputBase listLen t0Old t1Old outBase input),
+    tail, savedFrame,
+    (walkInitAbiFailurePrologueSavedFrame_pcFree sp0 raVal s0Old s1Old s2Old outBase),
+    hlink
+
+/-- Expanded precondition for the prologue-to-ABI-failure classifier. -/
+theorem walkInitAbiFailureFromPrologueNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover0 : inputBase.toNat + 0 < 2 ^ 64)
+    (hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    (walkInitAbiFailureFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old outBase
+      m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hoff hover0 hvalid0 hLen
+      hBound hprologueCode hcode).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitAbiFailurePrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  rfl
 
 /-- Prologue followed by the reduced short-list success WP slice.  The prologue
     carries the walk-init/schema resources to its exit; the tail consumes those

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -1008,6 +1008,9 @@ theorem prologueCode_disjoint_walkInitShortSuccessResolvedCode
     exact walkInitShortSuccessResolvedCode_none_below (base + 24) specs a htail
       (by rw [hbase24]; exact ha)
 
+attribute [rv64_wp_disjoint]
+  prologueCode_disjoint_walkInitShortSuccessResolvedCode
+
 /-- Range split between the decoder prologue and the standalone walk-init
     classifier. -/
 theorem prologueCode_disjoint_walkInitEmptyFailNotListFailShortLongCode
@@ -1864,20 +1867,19 @@ def walkInitShortSuccessFromPrologueCert
     (walkInitShortSuccessPrologueCarryFrame_pcFree inputBase listLen t0Old t1Old outBase input)
   let tail0 : WP.CFG.Cert (base + 24) (successStatusReturnExit raVal)
       (walkInitShortSuccessResolvedCode (base + 24) (successFieldSpecs d0 d1 d2 d3))
-      (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3) :=
-    WP.CFG.block (WP.Entails.refl _) (by
-      simpa [walkInitShortSuccessResolvedCode] using
-        walkInitShortSuccessResolved_spec_within (base + 24) inputBase listLen raVal t0Old
-          t1Old outBase input d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval
-          hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput hLen hcode)
+      (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3) := by
+    dsimp [walkInitShortSuccessResolvedCode]
+    exact walkInitShortSuccessResolvedCert (base + 24) inputBase listLen raVal t0Old t1Old
+      outBase input d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval hc0 hl0 hc1
+      hl1 haddr hc3 hl3 hinput hLen hcode
   let tail := WP.CFG.frameR tail0 savedFrame
     (walkInitShortSuccessPrologueSavedFrame_pcFree sp0 raVal s0Old s1Old s2Old)
-  exact WP.CFG.seqDisjoint
+  wp_rv64_cfg_cert_seq_disjoint_with
     (prologueCode_disjoint_walkInitShortSuccessResolvedCode base
-      (successFieldSpecs d0 d1 d2 d3) hprologueCode hcode) head.sound tail
+      (successFieldSpecs d0 d1 d2 d3) hprologueCode hcode), head, tail,
     (by
-      dsimp [head, tail, tail0, carryFrame, savedFrame, WP.CFG.frameR, WP.CFG.block,
-        WP.Triple.frameR, WP.Triple.ofSpec]
+      dsimp [head, tail, tail0, carryFrame, savedFrame, WP.CFG.frameR, WP.Triple.frameR]
+      rw [walkInitShortSuccessResolvedCert_pre_expanded]
       simpa using prologuePostShortSuccessCarry_entails_resolvedPre sp0 raVal s0Old s1Old s2Old
         inputBase listLen t0Old t1Old outBase input)
 

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -1532,12 +1532,10 @@ def walkInitAbiFailureReasonErasedFromPrologueNBranch
   let br := walkInitAbiFailureFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old outBase
     m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hoff hover0 hvalid0 hLen
     hBound hprologueCode hcode
-  wp_rv64_nbranch_weaken_posts4_with_auto br,
+  wp_rv64_nbranch_weaken_posts4_merge_first_two_with_auto br,
     (walkInitAbiFailureFromPrologueNBranch_exits base sp0 raVal s0Old s1Old s2Old outBase
       m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hoff hover0 hvalid0 hLen
       hBound hprologueCode hcode),
-    (walkInitAbiFailureReasonPostFromPrologue sp0 raVal s0Old s1Old s2Old outBase
-      inputBase listLen t0Old t1Old input hoff),
     (walkInitAbiFailureReasonPostFromPrologue sp0 raVal s0Old s1Old s2Old outBase
       inputBase listLen t0Old t1Old input hoff),
     (walkInitShortListOutputPost inputBase listLen raVal outBase input 0 hoff **
@@ -1569,9 +1567,6 @@ def walkInitAbiFailureReasonErasedFromPrologueExits
     (inputBase listLen t0Old t1Old : Word)
     (input : List Byte) (hoff : 0 < input.length) : List (Word × Assertion) :=
   [ (failStatusReturnExit raVal,
-      walkInitAbiFailureReasonPostFromPrologue sp0 raVal s0Old s1Old s2Old outBase
-        inputBase listLen t0Old t1Old input hoff)
-  , (failStatusReturnExit raVal,
       walkInitAbiFailureReasonPostFromPrologue sp0 raVal s0Old s1Old s2Old outBase
         inputBase listLen t0Old t1Old input hoff)
   , ((base + 24) + 124,

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -1150,6 +1150,82 @@ theorem walkInitEmptyInputFailureFromPrologueSharedFrameNBranch_exits
         s2Old outBase inputBase t0Old t1Old := by
   rfl
 
+/-- Case-oriented weakening for the two empty-input prologue exits. Generated
+    callers provide one entailment per exit and get the membership-map proof for
+    free. -/
+def walkInitEmptyInputFailureFromPrologueSharedFrameCaseNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
+    (t0Old t1Old : Word)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64)
+    (emptyPost nonzeroPost : Assertion)
+    (hEmpty : WP.Entails
+      ((emptyInputFailurePost inputBase outBase raVal **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) **
+        walkInitEmptyInputPrologueScratchFrame t0Old t1Old)
+      emptyPost)
+    (hNonzero : WP.Entails
+      (((walkInitNonzeroOpenStatusPost (0 : Word) raVal
+        (inputBase + BitVec.ofNat 64 0) ** emptyInputAbiFrame inputBase outBase) **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) **
+        walkInitEmptyInputPrologueScratchFrame t0Old t1Old)
+      nonzeroPost) :
+    WP.NBranch base
+      ((prologueCode base).union
+        (walkInitEmptyFailNotListFailShortLongCode (base + 24))) := by
+  let br := walkInitEmptyInputFailureFromPrologueSharedFrameNBranch base sp0 raVal s0Old
+    s1Old s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old hprologueCode hcode
+  wp_rv64_nbranch_weaken_posts2 br, hEmpty, hNonzero
+
+theorem walkInitEmptyInputFailureFromPrologueSharedFrameCaseNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
+    (t0Old t1Old : Word)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64)
+    (emptyPost nonzeroPost : Assertion)
+    (hEmpty : WP.Entails
+      ((emptyInputFailurePost inputBase outBase raVal **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) **
+        walkInitEmptyInputPrologueScratchFrame t0Old t1Old)
+      emptyPost)
+    (hNonzero : WP.Entails
+      (((walkInitNonzeroOpenStatusPost (0 : Word) raVal
+        (inputBase + BitVec.ofNat 64 0) ** emptyInputAbiFrame inputBase outBase) **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) **
+        walkInitEmptyInputPrologueScratchFrame t0Old t1Old)
+      nonzeroPost) :
+    (walkInitEmptyInputFailureFromPrologueSharedFrameCaseNBranch base sp0 raVal s0Old
+      s1Old s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old hprologueCode hcode
+      emptyPost nonzeroPost hEmpty hNonzero).pre =
+      (walkInitEmptyInputFailureFromPrologueSharedFrameNBranch base sp0 raVal s0Old s1Old
+        s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old hprologueCode hcode).pre := by
+  rfl
+
+theorem walkInitEmptyInputFailureFromPrologueSharedFrameCaseNBranch_exits
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
+    (t0Old t1Old : Word)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64)
+    (emptyPost nonzeroPost : Assertion)
+    (hEmpty : WP.Entails
+      ((emptyInputFailurePost inputBase outBase raVal **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) **
+        walkInitEmptyInputPrologueScratchFrame t0Old t1Old)
+      emptyPost)
+    (hNonzero : WP.Entails
+      (((walkInitNonzeroOpenStatusPost (0 : Word) raVal
+        (inputBase + BitVec.ofNat 64 0) ** emptyInputAbiFrame inputBase outBase) **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) **
+        walkInitEmptyInputPrologueScratchFrame t0Old t1Old)
+      nonzeroPost) :
+    (walkInitEmptyInputFailureFromPrologueSharedFrameCaseNBranch base sp0 raVal s0Old
+      s1Old s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old hprologueCode hcode
+      emptyPost nonzeroPost hEmpty hNonzero).exits =
+      [ (failStatusReturnExit raVal, emptyPost)
+      , ((base + 24) + 4, nonzeroPost)
+      ] := by
+  rfl
+
 /-- Prologue followed by the ABI-failure classifier. Empty and not-list exits
     expose reason-erased ABI failure posts; short-list and long-list candidates
     remain open for later resolution. -/
@@ -1245,6 +1321,125 @@ theorem walkInitAbiFailureFromPrologueNBranch_exits
       hBound hprologueCode hcode).exits =
       walkInitAbiFailureFromPrologueExits base sp0 raVal s0Old s1Old s2Old outBase
         inputBase listLen t0Old t1Old input hoff := by
+  rfl
+
+/-- Case-oriented weakening for the four nonempty prologue classifier exits. This
+    is the prologue-level analogue of the raw walk-init case mapper. -/
+def walkInitAbiFailureFromPrologueCaseNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover0 : inputBase.toNat + 0 < 2 ^ 64)
+    (hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64)
+    (emptyPost notListPost shortPost longPost : Assertion)
+    (hEmpty : WP.Entails
+      ((abiPost inputBase outBase raVal input **
+        walkInitEmptyFailAbiFrame listLen t0Old t1Old) **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+      emptyPost)
+    (hNotList : WP.Entails
+      ((abiPost inputBase outBase raVal input **
+        walkInitNotListFailAbiFrame inputBase listLen input 0 hoff) **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+      notListPost)
+    (hShort : WP.Entails
+      (walkInitShortListOutputPost inputBase listLen raVal outBase input 0 hoff **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+      shortPost)
+    (hLong : WP.Entails
+      (walkInitLongListOutputPost inputBase listLen raVal outBase input 0 hoff **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+      longPost) :
+    WP.NBranch base
+      ((prologueCode base).union (walkInitEmptyFailNotListFailShortLongCode (base + 24))) := by
+  let br := walkInitAbiFailureFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old outBase
+    m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hoff hover0 hvalid0 hLen
+    hBound hprologueCode hcode
+  wp_rv64_nbranch_weaken_posts4 br, hEmpty, hNotList, hShort, hLong
+
+theorem walkInitAbiFailureFromPrologueCaseNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover0 : inputBase.toNat + 0 < 2 ^ 64)
+    (hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64)
+    (emptyPost notListPost shortPost longPost : Assertion)
+    (hEmpty : WP.Entails
+      ((abiPost inputBase outBase raVal input **
+        walkInitEmptyFailAbiFrame listLen t0Old t1Old) **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+      emptyPost)
+    (hNotList : WP.Entails
+      ((abiPost inputBase outBase raVal input **
+        walkInitNotListFailAbiFrame inputBase listLen input 0 hoff) **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+      notListPost)
+    (hShort : WP.Entails
+      (walkInitShortListOutputPost inputBase listLen raVal outBase input 0 hoff **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+      shortPost)
+    (hLong : WP.Entails
+      (walkInitLongListOutputPost inputBase listLen raVal outBase input 0 hoff **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+      longPost) :
+    (walkInitAbiFailureFromPrologueCaseNBranch base sp0 raVal s0Old s1Old s2Old outBase
+      m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hoff hover0 hvalid0 hLen
+      hBound hprologueCode hcode emptyPost notListPost shortPost longPost hEmpty hNotList
+      hShort hLong).pre =
+      (walkInitAbiFailureFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old outBase
+        m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hoff hover0 hvalid0 hLen
+        hBound hprologueCode hcode).pre := by
+  rfl
+
+theorem walkInitAbiFailureFromPrologueCaseNBranch_exits
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover0 : inputBase.toNat + 0 < 2 ^ 64)
+    (hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64)
+    (emptyPost notListPost shortPost longPost : Assertion)
+    (hEmpty : WP.Entails
+      ((abiPost inputBase outBase raVal input **
+        walkInitEmptyFailAbiFrame listLen t0Old t1Old) **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+      emptyPost)
+    (hNotList : WP.Entails
+      ((abiPost inputBase outBase raVal input **
+        walkInitNotListFailAbiFrame inputBase listLen input 0 hoff) **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+      notListPost)
+    (hShort : WP.Entails
+      (walkInitShortListOutputPost inputBase listLen raVal outBase input 0 hoff **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+      shortPost)
+    (hLong : WP.Entails
+      (walkInitLongListOutputPost inputBase listLen raVal outBase input 0 hoff **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+      longPost) :
+    (walkInitAbiFailureFromPrologueCaseNBranch base sp0 raVal s0Old s1Old s2Old outBase
+      m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hoff hover0 hvalid0 hLen
+      hBound hprologueCode hcode emptyPost notListPost shortPost longPost hEmpty hNotList
+      hShort hLong).exits =
+      [ (failStatusReturnExit raVal, emptyPost)
+      , (failStatusReturnExit raVal, notListPost)
+      , ((base + 24) + 124, shortPost)
+      , ((base + 24) + 28, longPost)
+      ] := by
   rfl
 
 /-- Prologue followed by the ABI-failure classifier, with the empty/nonempty

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -168,6 +168,66 @@ def walkInitLongSchemaPost
     (hoff : 0 < input.length) : Assertion :=
   walkInitLongListCandidatePost inputBase listLen raVal input 0 hoff ** schemaWalkInitFrame outBase
 
+theorem walkInitPrefixWord_lt_f8_of_successFieldSpecs_input
+    (input d0 d1 d2 d3 : List Byte) (hoff : 0 < input.length)
+    (hl0 : d0.length ≤ 8) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3)))) :
+    BitVec.ult (walkInitPrefixWord input 0 hoff) (0xf8 : Word) = true := by
+  have hpayload := schemaEncBytes_successFieldSpecs_length_le_48 d0 d1 d2 d3 hl0 hl1 haddr hl3
+  have hshort : (schemaEncBytes (successFieldSpecs d0 d1 d2 d3)).length ≤ 55 := by
+    omega
+  subst input
+  simp [walkInitPrefixWord, encode_list_schemaItems_short, hshort, BitVec.ult]
+  omega
+
+/-- The long-list exit is unreachable when the input is the short-list encoding
+    of successful withdrawal field witnesses. -/
+theorem walkInitLongSchemaPost_contradicts_successFieldSpecs_input
+    (inputBase listLen raVal outBase : Word) (input d0 d1 d2 d3 : List Byte)
+    (hoff : 0 < input.length)
+    (hl0 : d0.length ≤ 8) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3)))) :
+    ∀ h, walkInitLongSchemaPost inputBase listLen raVal outBase input hoff h → False := by
+  intro h hp
+  have hlt := walkInitPrefixWord_lt_f8_of_successFieldSpecs_input input d0 d1 d2 d3 hoff
+    hl0 hl1 haddr hl3 hinput
+  unfold walkInitLongSchemaPost walkInitLongListCandidatePost at hp
+  rcases hp with ⟨hLong, _hSchema, _hd, _hunion, hLong_prop, _hSchema_prop⟩
+  rcases hLong_prop with ⟨_hPrefix, _hPure, _hdPure, _hunionPure,
+    _hPrefix_prop, hPure_prop⟩
+  exact hPure_prop.2 hlt
+
+/-- WP continuation for the dead long-list exit under a short-list success witness.
+    The target and code requirement are parameters so generated joins can reuse
+    the certificate in whatever larger CFG they are constructing. -/
+def walkInitLongSchemaUnreachableCert
+    (entry target : Word) (cr : CodeReq)
+    (inputBase listLen raVal outBase : Word) (input d0 d1 d2 d3 : List Byte)
+    (hoff : 0 < input.length)
+    (hl0 : d0.length ≤ 8) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (post : Assertion) :
+    WP.CFG.Cert entry target cr post :=
+  WP.CFG.unreachable entry target cr
+    (walkInitLongSchemaPost_contradicts_successFieldSpecs_input inputBase listLen raVal outBase
+      input d0 d1 d2 d3 hoff hl0 hl1 haddr hl3 hinput)
+
+theorem walkInitLongSchemaUnreachableCert_pre
+    (entry target : Word) (cr : CodeReq)
+    (inputBase listLen raVal outBase : Word) (input d0 d1 d2 d3 : List Byte)
+    (hoff : 0 < input.length)
+    (hl0 : d0.length ≤ 8) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (post : Assertion) :
+    (walkInitLongSchemaUnreachableCert entry target cr inputBase listLen raVal outBase input
+      d0 d1 d2 d3 hoff hl0 hl1 haddr hl3 hinput post).pre =
+      walkInitLongSchemaPost inputBase listLen raVal outBase input hoff := by
+  rfl
+
 def walkInitShortSuccessSchemaExits
     (base inputBase listLen raVal t0Old t1Old outBase : Word)
     (input d0 d1 d2 d3 : List Byte) (hoff : 0 < input.length) :

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -151,11 +151,31 @@ def walkInitAbiFailurePreFromPrologue
     (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion inputBase input) **
     bytesRegionAny outBase outputSize)
 
+/-- Resources framed across the prologue for the `input = []` walk-init split. -/
+def walkInitEmptyInputPrologueCarryFrame (inputBase outBase : Word) : Assertion :=
+  ((.x10 ↦ᵣ (inputBase + BitVec.ofNat 64 0)) ** (.x11 ↦ᵣ (0 : Word)) **
+    (.x0 ↦ᵣ (0 : Word)) ** emptyInputDecodeFrame inputBase outBase)
+
+theorem walkInitEmptyInputPrologueCarryFrame_pcFree (inputBase outBase : Word) :
+    (walkInitEmptyInputPrologueCarryFrame inputBase outBase).pcFree := by
+  unfold walkInitEmptyInputPrologueCarryFrame
+  exact pcFree_sepConj pcFree_regIs
+    (pcFree_sepConj pcFree_regIs
+      (pcFree_sepConj pcFree_regIs (emptyInputDecodeFrame_pcFree inputBase outBase)))
+
+/-- Exact empty-input walk-init precondition after the decoder prologue. -/
+def walkInitEmptyInputPreFromPrologue
+    (inputBase outBase raVal : Word) : Assertion :=
+  walkInitEmptyFailStatusPre (0 : Word) raVal (inputBase + BitVec.ofNat 64 0) **
+    emptyInputDecodeFrame inputBase outBase
+
 -- WP-link automation unfolds these small assertion-shape helpers before `xperm`.
 attribute [rv64_wp] schemaWalkInitFrameFromPrologue walkInitShortSuccessPrologueSavedFrame
   walkInitShortSuccessPrologueCarryFrame walkInitShortSuccessResolvedPreFromPrologue
   walkInitAbiFailurePrologueCarryFrame walkInitAbiFailurePrologueSavedFrame
-  walkInitAbiFailurePreFromPrologue walkInitEmptyNotListAbiFailureNBranch_pre
+  walkInitAbiFailurePreFromPrologue walkInitEmptyInputPrologueCarryFrame
+  walkInitEmptyInputPreFromPrologue emptyInputDecodeFrame emptyInputAbiFrame
+  walkInitEmptyNotListAbiFailureNBranch_pre walkInitEmptyInputFailureNBranch_pre
   walkInitEmptyFailNotListFailShortLongOutputNBranch_pre walkInitEmptyFailStatusPre
   walkInitZeroNonzeroPre failStatusReturnPre statusReturnPre
 
@@ -168,6 +188,17 @@ theorem prologuePostAbiFailureCarry_entails_preFromPrologue
       (prologuePost sp0 raVal s0Old s1Old s2Old outBase **
         walkInitAbiFailurePrologueCarryFrame inputBase listLen t0Old t1Old outBase input)
       (walkInitAbiFailurePreFromPrologue inputBase listLen raVal t0Old t1Old outBase input **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) := by
+  wp_rv64_link
+
+/-- Link the concrete prologue post plus `input = []` resources to the exact
+    empty-input walk-init precondition, preserving prologue-owned state. -/
+theorem prologuePostEmptyInputCarry_entails_preFromPrologue
+    (sp0 raVal s0Old s1Old s2Old inputBase outBase : Word) :
+    WP.Entails
+      (prologuePost sp0 raVal s0Old s1Old s2Old outBase **
+        walkInitEmptyInputPrologueCarryFrame inputBase outBase)
+      (walkInitEmptyInputPreFromPrologue inputBase outBase raVal **
         walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) := by
   wp_rv64_link
 
@@ -888,6 +919,74 @@ theorem prologueCode_disjoint_walkInitEmptyFailNotListFailShortLongCode
   · intro a ha
     exact walkInitEmptyFailNotListFailShortLongCode_none_below (base + 24) a htail
       (by rw [hbase24]; exact ha)
+
+/-- The empty-input walk-init status block has no code below its entry address. -/
+theorem walkInitEmptyFailStatusCode_none_below
+    (base a : Word) (hcode : base.toNat + 164 < 2 ^ 64) (h : a.toNat < base.toNat) :
+    walkInitEmptyFailStatusCode base a = none := by
+  unfold walkInitEmptyFailStatusCode failStatusReturnCode statusReturnCode
+  have h0 : CodeReq.singleton base (.BEQ .x11 .x0 (156 : BitVec 13)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h156 : CodeReq.singleton (base + 156) (.LI .x10 (1 : Word)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h160 : CodeReq.singleton (base + 156 + 4) (.JALR .x0 .x1 (0 : BitVec 12)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  simp only [CodeReq.union, h0, h156, h160]
+
+/-- Range split between the decoder prologue and the empty-input status block. -/
+theorem prologueCode_disjoint_walkInitEmptyFailStatusCode
+    (base : Word)
+    (hprologue : base.toNat + 24 < 2 ^ 64)
+    (htail : (base + 24).toNat + 164 < 2 ^ 64) :
+    (prologueCode base).Disjoint (walkInitEmptyFailStatusCode (base + 24)) := by
+  have hbase24 : (base + 24).toNat = base.toNat + 24 := by
+    bv_omega
+  refine codeReq_disjoint_of_ranges _ _ (base.toNat + 24) ?_ ?_
+  · intro a ha
+    exact prologueCode_none_above base a hprologue ha
+  · intro a ha
+    exact walkInitEmptyFailStatusCode_none_below (base + 24) a htail
+      (by rw [hbase24]; exact ha)
+
+/-- Prologue followed by the empty-input walk-init failure split. The taken exit
+    carries the semantic `decodeWithdrawal [] = none` failure fact, while the
+    nonzero exit remains explicit and contradictory for `listLen = 0`. -/
+def walkInitEmptyInputFailureFromPrologueNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 164 < 2 ^ 64) :
+    WP.NBranch base
+      ((prologueCode base).union (walkInitEmptyFailStatusCode (base + 24))) := by
+  let carryFrame := walkInitEmptyInputPrologueCarryFrame inputBase outBase
+  let savedFrame := walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase
+  let head := prologueCert base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3
+  let tail := walkInitEmptyInputFailureNBranch (base + 24) inputBase outBase raVal
+    (inputBase + BitVec.ofNat 64 0)
+  have hlink : WP.Entails
+      (prologuePost sp0 raVal s0Old s1Old s2Old outBase ** carryFrame)
+      (tail.pre ** savedFrame) := by
+    dsimp [tail, carryFrame, savedFrame]
+    simp only [walkInitEmptyInputFailureNBranch_pre]
+    exact prologuePostEmptyInputCarry_entails_preFromPrologue sp0 raVal s0Old s1Old s2Old
+      inputBase outBase
+  wp_rv64_seq_block_nbranch_framed_disjoint_with
+    (prologueCode_disjoint_walkInitEmptyFailStatusCode base hprologueCode hcode),
+    head, carryFrame,
+    (walkInitEmptyInputPrologueCarryFrame_pcFree inputBase outBase),
+    tail, savedFrame,
+    (walkInitAbiFailurePrologueSavedFrame_pcFree sp0 raVal s0Old s1Old s2Old outBase),
+    hlink
+
+/-- Expanded precondition for the prologue-to-empty-input failure split. -/
+theorem walkInitEmptyInputFailureFromPrologueNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 164 < 2 ^ 64) :
+    (walkInitEmptyInputFailureFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old
+      outBase m0 m1 m2 m3 inputBase hprologueCode hcode).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitEmptyInputPrologueCarryFrame inputBase outBase) := by
+  rfl
 
 /-- Prologue followed by the ABI-failure classifier. Empty and not-list exits
     expose reason-erased ABI failure posts; short-list and long-list candidates

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -1093,6 +1093,64 @@ theorem walkInitEmptyInputFailureFromPrologueNBranch_pre
         walkInitEmptyInputPrologueCarryFrame inputBase outBase) := by
   rfl
 
+theorem walkInitEmptyInputFailureFromPrologueNBranch_exits
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 164 < 2 ^ 64) :
+    (walkInitEmptyInputFailureFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old
+      outBase m0 m1 m2 m3 inputBase hprologueCode hcode).exits =
+      [ (failStatusReturnExit raVal,
+          emptyInputFailurePost inputBase outBase raVal **
+            walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+      , ((base + 24) + 4,
+          (walkInitNonzeroOpenStatusPost (0 : Word) raVal
+            (inputBase + BitVec.ofNat 64 0) ** emptyInputAbiFrame inputBase outBase) **
+            walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+      ] := by
+  rfl
+
+theorem walkInitEmptyInputFailureFromPrologueNonzeroExit_contradicts
+    (sp0 raVal s0Old s1Old s2Old outBase inputBase : Word) :
+    ∀ h,
+      ((walkInitNonzeroOpenStatusPost (0 : Word) raVal
+        (inputBase + BitVec.ofNat 64 0) ** emptyInputAbiFrame inputBase outBase) **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) h → False := by
+  intro h hp
+  rcases hp with ⟨hMain, _hSaved, _hdSaved, _hunionSaved, hMain_prop, _hSaved_prop⟩
+  exact walkInitEmptyInputNonzeroExit_contradicts inputBase outBase raVal
+    (inputBase + BitVec.ofNat 64 0) hMain hMain_prop
+
+/-- Prologue followed by the empty-input failure path with the impossible
+    nonzero fall-through closed. This is the single-exit form callers should use
+    when the input bytes are known to be empty. -/
+def walkInitEmptyInputFailureFromPrologueCert
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 164 < 2 ^ 64) :
+    WP.CFG.Cert base (failStatusReturnExit raVal)
+      ((prologueCode base).union (walkInitEmptyFailStatusCode (base + 24)))
+      (emptyInputFailurePost inputBase outBase raVal **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) := by
+  let br := walkInitEmptyInputFailureFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old
+    outBase m0 m1 m2 m3 inputBase hprologueCode hcode
+  wp_rv64_nbranch_join2_resolve_first_auto br,
+    (walkInitEmptyInputFailureFromPrologueNBranch_exits base sp0 raVal s0Old s1Old
+      s2Old outBase m0 m1 m2 m3 inputBase hprologueCode hcode),
+    (emptyInputFailurePost inputBase outBase raVal **
+      walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase),
+    (walkInitEmptyInputFailureFromPrologueNonzeroExit_contradicts sp0 raVal s0Old s1Old
+      s2Old outBase inputBase)
+
+theorem walkInitEmptyInputFailureFromPrologueCert_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 164 < 2 ^ 64) :
+    (walkInitEmptyInputFailureFromPrologueCert base sp0 raVal s0Old s1Old s2Old
+      outBase m0 m1 m2 m3 inputBase hprologueCode hcode).pre =
+      (walkInitEmptyInputFailureFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old
+        outBase m0 m1 m2 m3 inputBase hprologueCode hcode).pre := by
+  rfl
+
 /-- Empty-input path stated over the full walk-init classifier code. This lets
     later zero/nonzero wrappers use one code requirement for both empty and
     nonempty inputs. -/
@@ -1161,6 +1219,82 @@ theorem walkInitEmptyInputFailureFromPrologueFullCodeNBranch_exits
         outBase m0 m1 m2 m3 inputBase hprologueCode (by omega)).exits := by
   rfl
 
+def walkInitEmptyInputFailureFromPrologueFullCodeCert
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    WP.CFG.Cert base (failStatusReturnExit raVal)
+      ((prologueCode base).union
+        (walkInitEmptyFailNotListFailShortLongCode (base + 24)))
+      (emptyInputFailurePost inputBase outBase raVal **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) := by
+  let cfg := walkInitEmptyInputFailureFromPrologueCert base sp0 raVal s0Old s1Old s2Old
+    outBase m0 m1 m2 m3 inputBase hprologueCode (by omega)
+  exact WP.Triple.extendCode cfg (by
+    intro a i h
+    cases hprologue : prologueCode base a with
+    | none =>
+        simp only [CodeReq.union, hprologue] at h ⊢
+        unfold walkInitEmptyFailNotListFailShortLongCode walkInitEmptyFailOrPrefixCode
+        exact CodeReq.union_mono_left a i (CodeReq.union_mono_left a i h)
+    | some instr =>
+        simp only [CodeReq.union, hprologue] at h ⊢
+        exact h)
+
+theorem walkInitEmptyInputFailureFromPrologueFullCodeCert_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    (walkInitEmptyInputFailureFromPrologueFullCodeCert base sp0 raVal s0Old s1Old s2Old
+      outBase m0 m1 m2 m3 inputBase hprologueCode hcode).pre =
+      (walkInitEmptyInputFailureFromPrologueFullCodeNBranch base sp0 raVal s0Old s1Old s2Old
+        outBase m0 m1 m2 m3 inputBase hprologueCode hcode).pre := by
+  rfl
+
+def walkInitEmptyInputFailureFromPrologueSharedFramePost
+    (sp0 raVal s0Old s1Old s2Old outBase inputBase : Word)
+    (t0Old t1Old : Word) : Assertion :=
+  (emptyInputFailurePost inputBase outBase raVal **
+    walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) **
+    walkInitEmptyInputPrologueScratchFrame t0Old t1Old
+
+/-- Resolved empty-input path over the full classifier code with the same
+    scratch-register caller frame as the nonempty classifier. -/
+def walkInitEmptyInputFailureFromPrologueSharedFrameCert
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
+    (t0Old t1Old : Word)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    WP.CFG.Cert base (failStatusReturnExit raVal)
+      ((prologueCode base).union
+        (walkInitEmptyFailNotListFailShortLongCode (base + 24)))
+      (walkInitEmptyInputFailureFromPrologueSharedFramePost sp0 raVal s0Old s1Old s2Old
+        outBase inputBase t0Old t1Old) := by
+  let cfg0 := walkInitEmptyInputFailureFromPrologueFullCodeCert base sp0 raVal s0Old s1Old
+    s2Old outBase m0 m1 m2 m3 inputBase hprologueCode hcode
+  let scratchFrame := walkInitEmptyInputPrologueScratchFrame t0Old t1Old
+  let cfg := WP.CFG.frameR cfg0 scratchFrame
+    (walkInitEmptyInputPrologueScratchFrame_pcFree t0Old t1Old)
+  exact WP.Triple.weakenPre cfg (by
+    dsimp [cfg, cfg0, scratchFrame, WP.CFG.frameR, WP.Triple.frameR]
+    rw [walkInitEmptyInputFailureFromPrologueFullCodeCert_pre]
+    exact prologuePreAbiFailureEmptyCarry_entails_emptyScratchPre sp0 raVal s0Old s1Old
+      s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old)
+
+theorem walkInitEmptyInputFailureFromPrologueSharedFrameCert_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
+    (t0Old t1Old : Word)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    (walkInitEmptyInputFailureFromPrologueSharedFrameCert base sp0 raVal s0Old s1Old
+      s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old hprologueCode hcode).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitAbiFailurePrologueCarryFrame inputBase (0 : Word) t0Old t1Old outBase
+          ([] : List Byte)) := by
+  rfl
+
+attribute [rv64_wp] walkInitEmptyInputFailureFromPrologueSharedFrameCert_pre
+
 /-- Empty-input path with the same scratch-register caller frame as the nonempty
     ABI-failure classifier. The precondition is the nonempty classifier frame
     specialized to `listLen = 0` and `input = []`. -/
@@ -1221,82 +1355,6 @@ theorem walkInitEmptyInputFailureFromPrologueSharedFrameNBranch_exits
       s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old hprologueCode hcode).exits =
       walkInitEmptyInputFailureFromPrologueSharedFrameExits base sp0 raVal s0Old s1Old
         s2Old outBase inputBase t0Old t1Old := by
-  rfl
-
-/-- Case-oriented weakening for the two empty-input prologue exits. Generated
-    callers provide one entailment per exit and get the membership-map proof for
-    free. -/
-def walkInitEmptyInputFailureFromPrologueSharedFrameCaseNBranch
-    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
-    (t0Old t1Old : Word)
-    (hprologueCode : base.toNat + 24 < 2 ^ 64)
-    (hcode : (base + 24).toNat + 172 < 2 ^ 64)
-    (emptyPost nonzeroPost : Assertion)
-    (hEmpty : WP.Entails
-      ((emptyInputFailurePost inputBase outBase raVal **
-        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) **
-        walkInitEmptyInputPrologueScratchFrame t0Old t1Old)
-      emptyPost)
-    (hNonzero : WP.Entails
-      (((walkInitNonzeroOpenStatusPost (0 : Word) raVal
-        (inputBase + BitVec.ofNat 64 0) ** emptyInputAbiFrame inputBase outBase) **
-        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) **
-        walkInitEmptyInputPrologueScratchFrame t0Old t1Old)
-      nonzeroPost) :
-    WP.NBranch base
-      ((prologueCode base).union
-        (walkInitEmptyFailNotListFailShortLongCode (base + 24))) := by
-  let br := walkInitEmptyInputFailureFromPrologueSharedFrameNBranch base sp0 raVal s0Old
-    s1Old s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old hprologueCode hcode
-  wp_rv64_nbranch_weaken_posts2 br, hEmpty, hNonzero
-
-theorem walkInitEmptyInputFailureFromPrologueSharedFrameCaseNBranch_pre
-    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
-    (t0Old t1Old : Word)
-    (hprologueCode : base.toNat + 24 < 2 ^ 64)
-    (hcode : (base + 24).toNat + 172 < 2 ^ 64)
-    (emptyPost nonzeroPost : Assertion)
-    (hEmpty : WP.Entails
-      ((emptyInputFailurePost inputBase outBase raVal **
-        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) **
-        walkInitEmptyInputPrologueScratchFrame t0Old t1Old)
-      emptyPost)
-    (hNonzero : WP.Entails
-      (((walkInitNonzeroOpenStatusPost (0 : Word) raVal
-        (inputBase + BitVec.ofNat 64 0) ** emptyInputAbiFrame inputBase outBase) **
-        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) **
-        walkInitEmptyInputPrologueScratchFrame t0Old t1Old)
-      nonzeroPost) :
-    (walkInitEmptyInputFailureFromPrologueSharedFrameCaseNBranch base sp0 raVal s0Old
-      s1Old s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old hprologueCode hcode
-      emptyPost nonzeroPost hEmpty hNonzero).pre =
-      (walkInitEmptyInputFailureFromPrologueSharedFrameNBranch base sp0 raVal s0Old s1Old
-        s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old hprologueCode hcode).pre := by
-  rfl
-
-theorem walkInitEmptyInputFailureFromPrologueSharedFrameCaseNBranch_exits
-    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase : Word)
-    (t0Old t1Old : Word)
-    (hprologueCode : base.toNat + 24 < 2 ^ 64)
-    (hcode : (base + 24).toNat + 172 < 2 ^ 64)
-    (emptyPost nonzeroPost : Assertion)
-    (hEmpty : WP.Entails
-      ((emptyInputFailurePost inputBase outBase raVal **
-        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) **
-        walkInitEmptyInputPrologueScratchFrame t0Old t1Old)
-      emptyPost)
-    (hNonzero : WP.Entails
-      (((walkInitNonzeroOpenStatusPost (0 : Word) raVal
-        (inputBase + BitVec.ofNat 64 0) ** emptyInputAbiFrame inputBase outBase) **
-        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase) **
-        walkInitEmptyInputPrologueScratchFrame t0Old t1Old)
-      nonzeroPost) :
-    (walkInitEmptyInputFailureFromPrologueSharedFrameCaseNBranch base sp0 raVal s0Old
-      s1Old s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old hprologueCode hcode
-      emptyPost nonzeroPost hEmpty hNonzero).exits =
-      [ (failStatusReturnExit raVal, emptyPost)
-      , ((base + 24) + 4, nonzeroPost)
-      ] := by
   rfl
 
 /-- Prologue followed by the ABI-failure classifier. Empty and not-list exits
@@ -1683,15 +1741,12 @@ def walkInitZeroNonzeroAbiFailureFromPrologueNBranch
         (walkInitEmptyFailNotListFailShortLongCode (base + 24))) := by
   cases input with
   | nil =>
-      let br0 := walkInitEmptyInputFailureFromPrologueSharedFrameNBranch base sp0 raVal
-        s0Old s1Old s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old hprologueCode hcode
       have hLen0 : listLen = (0 : Word) := by
         simpa using hLen
       subst listLen
-      wp_rv64_nbranch_set_pre br0,
-        (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
-          walkInitAbiFailurePrologueCarryFrame inputBase (0 : Word) t0Old t1Old outBase
-            ([] : List Byte))
+      exact WP.NBranch.ofTriple
+        (walkInitEmptyInputFailureFromPrologueSharedFrameCert base sp0 raVal s0Old
+          s1Old s2Old outBase m0 m1 m2 m3 inputBase t0Old t1Old hprologueCode hcode)
   | cons b rest =>
       have hoff : 0 < (b :: rest).length := by simp
       have hover0 : inputBase.toNat + 0 < 2 ^ 64 := by
@@ -1743,8 +1798,9 @@ def walkInitZeroNonzeroAbiFailureFromPrologueExits
     (input : List Byte) : List (Word × Assertion) :=
   match input with
   | [] =>
-      walkInitEmptyInputFailureFromPrologueSharedFrameExits base sp0 raVal s0Old s1Old
-        s2Old outBase inputBase t0Old t1Old
+      [ (failStatusReturnExit raVal,
+          walkInitEmptyInputFailureFromPrologueSharedFramePost sp0 raVal s0Old s1Old
+            s2Old outBase inputBase t0Old t1Old) ]
   | b :: rest =>
       walkInitAbiFailureReasonErasedFromPrologueExits base sp0 raVal s0Old s1Old s2Old outBase
         inputBase listLen t0Old t1Old (b :: rest) (by simp)

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -719,6 +719,186 @@ theorem walkInitShortSuccessResolved_spec_within
     d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval hc0 hl0 hc1 hl1 haddr hc3
     hl3 hinput hLen hcode).sound
 
+
+/-- Code covered by the resolved short-list success WP slice.  This aliases the
+    generated union so higher-level WP composition can name the tail as a unit. -/
+def walkInitShortSuccessResolvedCode (base : Word) (specs : List FieldSpec) : CodeReq :=
+  ((walkInitEmptyFailNotListFailShortLongCode base).union
+    ((walkInitShortSuccessJumpCode base).union
+      ((schemaCursorInitCode (base + 172)).union
+        ((schemaCR (base + 172 + 4) .x8 specs).union
+          (successStatusReturnCode
+            ((base + 172 + 4) + BitVec.ofNat 64 (schemaSize specs)))))))
+
+
+attribute [rv64_wp] walkInitShortSuccessResolvedCode
+
+/-- The decoder prologue occupies exactly the first six 4-byte instructions. -/
+theorem prologueCode_none_above (base a : Word)
+    (hbound : base.toNat + 24 < 2 ^ 64) (h : base.toNat + 24 ≤ a.toNat) :
+    prologueCode base a = none := by
+  unfold prologueCode
+  exact CodeReq.ofProg_none_range_len base prologue 6 a prologue_length (fun k hk => by
+    bv_omega)
+
+/-- The walk-init classifier prefix used by the short-success slice has no code
+    below its entry address, assuming its code range does not wrap. -/
+theorem walkInitEmptyFailNotListFailShortLongCode_none_below
+    (base a : Word) (hcode : base.toNat + 172 < 2 ^ 64) (h : a.toNat < base.toNat) :
+    walkInitEmptyFailNotListFailShortLongCode base a = none := by
+  unfold walkInitEmptyFailNotListFailShortLongCode walkInitEmptyFailOrPrefixCode
+    walkInitEmptyFailStatusCode failStatusReturnCode statusReturnCode
+    walkInitNonzeroPrefixTailCode walkInitPrefixShortLongTailCode
+    walkInitPrefixListCheckNotListFailF8Code walkInitPrefixListCheckOrNotListFailCode
+    walkInitPrefixListCheckCode walkInitPrefixNotListFailStatusCode walkInitListF8Code
+    walkInitShortLongCheckCode
+  have h0 : CodeReq.singleton base (.BEQ .x11 .x0 (156 : BitVec 13)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h156 : CodeReq.singleton (base + 156) (.LI .x10 (1 : Word)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h160 : CodeReq.singleton (base + 156 + 4) (.JALR .x0 .x1 (0 : BitVec 12)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h4 : CodeReq.singleton (base + 4) (.ADD .x11 .x10 .x11) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h8 : CodeReq.singleton (base + 8) (.LBU .x5 .x10 0) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h12 : CodeReq.singleton (base + 12) (.LI .x6 (0xc0 : Word)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h16 : CodeReq.singleton (base + 16) (.BLTU .x5 .x6 (148 : BitVec 13)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h164 : CodeReq.singleton (base + 164) (.LI .x10 (1 : Word)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h168 : CodeReq.singleton (base + 164 + 4) (.JALR .x0 .x1 (0 : BitVec 12)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h20 : CodeReq.singleton (base + 20) (.LI .x6 (0xf8 : Word)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h24 : CodeReq.singleton (base + 24) (.BLTU .x5 .x6 (100 : BitVec 13)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  simp only [failStatusReturnCode, statusReturnCode, CodeReq.union,
+    h0, h156, h160, h4, h8, h12, h16, h164, h168, h20, h24]
+
+/-- The resolved short-success tail has no code below its entry address. -/
+theorem walkInitShortSuccessResolvedCode_none_below
+    (base : Word) (specs : List FieldSpec) (a : Word)
+    (hcode : base.toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64)
+    (h : a.toNat < base.toNat) :
+    walkInitShortSuccessResolvedCode base specs a = none := by
+  have hbase172 : (base + 172).toNat = base.toNat + 172 := by
+    bv_omega
+  have h0 : walkInitEmptyFailNotListFailShortLongCode base a = none :=
+    walkInitEmptyFailNotListFailShortLongCode_none_below base a (by omega) h
+  have h1 : walkInitShortSuccessJumpCode base a = none := by
+    unfold walkInitShortSuccessJumpCode
+    exact CodeReq.singleton_miss (by
+      intro h_eq
+      have := congrArg BitVec.toNat h_eq
+      bv_omega)
+  have h2 :
+      ((schemaCursorInitCode (base + 172)).union
+        ((schemaCR (base + 172 + 4) .x8 specs).union
+          (successStatusReturnCode
+            ((base + 172 + 4) + BitVec.ofNat 64 (schemaSize specs))))) a = none :=
+    schemaCursorInitSuccessReturnTail_none_below (base + 172) .x8 specs a
+      (by rw [hbase172]; omega) (by rw [hbase172]; omega)
+  unfold walkInitShortSuccessResolvedCode
+  simp only [CodeReq.union, h0, h1]
+  exact h2
+
+/-- Range split between the prologue and the resolved short-success tail. -/
+theorem prologueCode_disjoint_walkInitShortSuccessResolvedCode
+    (base : Word) (specs : List FieldSpec)
+    (hprologue : base.toNat + 24 < 2 ^ 64)
+    (htail : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    (prologueCode base).Disjoint (walkInitShortSuccessResolvedCode (base + 24) specs) := by
+  have hbase24 : (base + 24).toNat = base.toNat + 24 := by
+    bv_omega
+  refine codeReq_disjoint_of_ranges _ _ (base.toNat + 24) ?_ ?_
+  · intro a ha
+    exact prologueCode_none_above base a hprologue ha
+  · intro a ha
+    exact walkInitShortSuccessResolvedCode_none_below (base + 24) specs a htail
+      (by rw [hbase24]; exact ha)
+
+/-- Prologue followed by the reduced short-list success WP slice.  The prologue
+    carries the walk-init/schema resources to its exit; the tail consumes those
+    resources and returns the ABI success post while preserving the saved frame. -/
+def walkInitShortSuccessFromPrologueCert
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input d0 d1 d2 d3 : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 +
+      schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    WP.CFG.Cert base (successStatusReturnExit raVal)
+      ((prologueCode base).union
+        (walkInitShortSuccessResolvedCode (base + 24) (successFieldSpecs d0 d1 d2 d3)))
+      (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3 **
+        walkInitShortSuccessPrologueSavedFrame sp0 raVal s0Old s1Old s2Old) := by
+  let carryFrame := walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old
+    outBase input
+  let savedFrame := walkInitShortSuccessPrologueSavedFrame sp0 raVal s0Old s1Old s2Old
+  let head := WP.CFG.frameR
+    (prologueCert base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3)
+    carryFrame
+    (walkInitShortSuccessPrologueCarryFrame_pcFree inputBase listLen t0Old t1Old outBase input)
+  let tail0 : WP.CFG.Cert (base + 24) (successStatusReturnExit raVal)
+      (walkInitShortSuccessResolvedCode (base + 24) (successFieldSpecs d0 d1 d2 d3))
+      (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3) :=
+    WP.CFG.block (WP.Entails.refl _) (by
+      simpa [walkInitShortSuccessResolvedCode] using
+        walkInitShortSuccessResolved_spec_within (base + 24) inputBase listLen raVal t0Old
+          t1Old outBase input d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval
+          hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput hLen hcode)
+  let tail := WP.CFG.frameR tail0 savedFrame
+    (walkInitShortSuccessPrologueSavedFrame_pcFree sp0 raVal s0Old s1Old s2Old)
+  exact WP.CFG.seqDisjoint
+    (prologueCode_disjoint_walkInitShortSuccessResolvedCode base
+      (successFieldSpecs d0 d1 d2 d3) hprologueCode hcode) head.sound tail
+    (by
+      dsimp [head, tail, tail0, carryFrame, savedFrame, WP.CFG.frameR, WP.CFG.block,
+        WP.Triple.frameR, WP.Triple.ofSpec]
+      simpa using prologuePostShortSuccessCarry_entails_resolvedPre sp0 raVal s0Old s1Old s2Old
+        inputBase listLen t0Old t1Old outBase input)
+
+/-- Expanded precondition for the prologue-to-short-success certificate. -/
+theorem walkInitShortSuccessFromPrologueCert_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input d0 d1 d2 d3 : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 +
+      schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    (walkInitShortSuccessFromPrologueCert base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2
+      m3 inputBase listLen t0Old t1Old input d0 d1 d2 d3 hsalign hoff hover hwin hdalign
+      hdov hdval hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput hLen hprologueCode hcode).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  rfl
+
 end WithdrawalDecode
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -922,6 +922,30 @@ def walkInitShortSuccessResolvedCode (base : Word) (specs : List FieldSpec) : Co
 
 attribute [rv64_wp] walkInitShortSuccessResolvedCode
 
+/-- The base walk-init classifier code is a prefix of the resolved short-success
+    code. This lets failure-only classifier facades be reused over the larger
+    success-capable code requirement. -/
+theorem walkInitEmptyFailNotListFailShortLongCode_mono_resolvedCode
+    (base : Word) (specs : List FieldSpec) :
+    ∀ a i,
+      walkInitEmptyFailNotListFailShortLongCode base a = some i →
+        walkInitShortSuccessResolvedCode base specs a = some i := by
+  intro a i h
+  unfold walkInitShortSuccessResolvedCode
+  exact CodeReq.union_mono_left a i h
+
+/-- Prologue plus the base walk-init classifier is a prefix of prologue plus the
+    resolved short-success code. -/
+theorem prologueWalkInitClassifierCode_mono_resolvedCode
+    (base : Word) (specs : List FieldSpec) :
+    ∀ a i,
+      ((prologueCode base).union
+        (walkInitEmptyFailNotListFailShortLongCode (base + 24))) a = some i →
+        ((prologueCode base).union
+          (walkInitShortSuccessResolvedCode (base + 24) specs)) a = some i :=
+  CodeReq.union_mono_tail
+    (walkInitEmptyFailNotListFailShortLongCode_mono_resolvedCode (base + 24) specs)
+
 /-- The decoder prologue occupies exactly the first six 4-byte instructions. -/
 theorem prologueCode_none_above (base a : Word)
     (hbound : base.toNat + 24 < 2 ^ 64) (h : base.toNat + 24 ≤ a.toNat) :
@@ -1814,6 +1838,73 @@ theorem walkInitZeroNonzeroAbiFailureFromPrologueNBranch_exits
       subst listLen
       rfl
   | cons b rest => rfl
+
+/-- The zero/nonzero ABI-failure facade lifted to the same code requirement as
+    the resolved short-success slice. The precondition and exits are unchanged;
+    only the persistent code requirement is enlarged. -/
+def walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    WP.NBranch base
+      ((prologueCode base).union
+        (walkInitShortSuccessResolvedCode (base + 24) specs)) := by
+  let br := walkInitZeroNonzeroAbiFailureFromPrologueNBranch base sp0 raVal s0Old s1Old
+    s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hover hwin hLen
+    hprologueCode (by omega)
+  wp_rv64_nbranch_extend_code br,
+    (prologueWalkInitClassifierCode_mono_resolvedCode base specs)
+
+/-- The resolved-code zero/nonzero facade has the same static precondition as
+    the classifier-code facade. -/
+theorem walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    (walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeNBranch base sp0 raVal s0Old s1Old
+      s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input specs hsalign hover hwin
+      hLen hprologueCode hcode).pre =
+      (prologuePre sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 **
+        walkInitAbiFailurePrologueCarryFrame inputBase listLen t0Old t1Old outBase input) := by
+  unfold walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeNBranch
+  simp only [WP.NBranch.extendCode]
+  rw [walkInitZeroNonzeroAbiFailureFromPrologueNBranch_pre]
+
+attribute [rv64_wp]
+  walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeNBranch_pre
+
+/-- Lifting the zero/nonzero facade to the resolved code requirement preserves
+    its input-indexed exits. -/
+theorem walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeNBranch_exits
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (specs : List FieldSpec)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    (walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeNBranch base sp0 raVal s0Old s1Old
+      s2Old outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input specs hsalign hover hwin
+      hLen hprologueCode hcode).exits =
+      walkInitZeroNonzeroAbiFailureFromPrologueExits base sp0 raVal s0Old s1Old s2Old
+        outBase inputBase listLen t0Old t1Old input := by
+  unfold walkInitZeroNonzeroAbiFailureFromPrologueResolvedCodeNBranch
+  simp only [WP.NBranch.extendCode]
+  rw [walkInitZeroNonzeroAbiFailureFromPrologueNBranch_exits]
 
 /-- Prologue followed by the reduced short-list success WP slice.  The prologue
     carries the walk-init/schema resources to its exit; the tail consumes those

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -19,6 +19,8 @@ open EvmAsm.Rv64.Tactics
 
 namespace WithdrawalDecode
 
+attribute [rv64_wp] prologuePost prologueFrameBase
+
 /-- Schema scratch registers preserved on failure exits after the output bytes
     have been consumed by the public ABI post. -/
 def schemaWalkInitRegsFrame (outBase : Word) : Assertion :=
@@ -39,6 +41,113 @@ theorem schemaWalkInitFrame_entails_anyFrame (outBase : Word) :
   exact sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
     (sepConj_mono_right (sepConj_mono_right (fun h hp =>
       ⟨List.replicate outputSize (0 : Byte), by simp [outputSize], hp⟩))))) h hp
+
+/-- Schema handoff frame in the exact shape produced after the decoder prologue:
+    `s0`/`x8` and `a2`/`x12` both hold the output pointer.  The public schema
+    handoff only needs `regOwn x12`, so this frame is an entry-composition
+    helper, not a separate schema requirement. -/
+def schemaWalkInitFrameFromPrologue (outBase : Word) : Assertion :=
+  ((.x8 ↦ᵣ outBase) ** (.x12 ↦ᵣ outBase) ** regOwn .x13 ** regOwn .x14 **
+    regOwn .x15 ** bytesRegion outBase (List.replicate outputSize (0 : Byte)))
+
+theorem schemaWalkInitFrameFromPrologue_pcFree (outBase : Word) :
+    (schemaWalkInitFrameFromPrologue outBase).pcFree := by
+  unfold schemaWalkInitFrameFromPrologue
+  pcFree
+
+theorem schemaWalkInitFrameFromPrologue_entails_schemaWalkInitFrame (outBase : Word) :
+    WP.Entails (schemaWalkInitFrameFromPrologue outBase) (schemaWalkInitFrame outBase) := by
+  intro h hp
+  unfold schemaWalkInitFrameFromPrologue at hp
+  unfold schemaWalkInitFrame
+  exact sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x12 outBase)) h hp
+
+/-- Callee-save and stack resources produced by the prologue and preserved through
+    the short-list success slice. -/
+def walkInitShortSuccessPrologueSavedFrame
+    (sp0 raVal s0Old s1Old s2Old : Word) : Assertion :=
+  ((.x2 ↦ᵣ prologueFrameBase sp0) ** (.x9 ↦ᵣ s1Old) ** (.x18 ↦ᵣ s2Old) **
+    (prologueFrameBase sp0 ↦ₘ raVal) **
+    ((prologueFrameBase sp0 + 8) ↦ₘ s0Old) **
+    ((prologueFrameBase sp0 + 16) ↦ₘ s1Old) **
+    ((prologueFrameBase sp0 + 24) ↦ₘ s2Old))
+
+theorem walkInitShortSuccessPrologueSavedFrame_pcFree
+    (sp0 raVal s0Old s1Old s2Old : Word) :
+    (walkInitShortSuccessPrologueSavedFrame sp0 raVal s0Old s1Old s2Old).pcFree := by
+  unfold walkInitShortSuccessPrologueSavedFrame
+  pcFree
+
+/-- Resources framed across the prologue so the walk-init/schema WP slice can
+    start immediately at the prologue exit. -/
+def walkInitShortSuccessPrologueCarryFrame
+    (inputBase listLen t0Old t1Old outBase : Word) (input : List Byte) : Assertion :=
+  ((.x10 ↦ᵣ (inputBase + BitVec.ofNat 64 0)) ** (.x11 ↦ᵣ listLen) **
+    (.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) **
+    regOwn .x13 ** regOwn .x14 ** regOwn .x15 ** bytesRegion inputBase input **
+    bytesRegion outBase (List.replicate outputSize (0 : Byte)))
+
+theorem walkInitShortSuccessPrologueCarryFrame_pcFree
+    (inputBase listLen t0Old t1Old outBase : Word) (input : List Byte) :
+    (walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input).pcFree := by
+  unfold walkInitShortSuccessPrologueCarryFrame
+  pcFree
+
+/-- Exact midpoint precondition before weakening `x12 ↦ outBase` to
+    `regOwn x12`. -/
+def walkInitShortSuccessResolvedPreFromPrologue
+    (inputBase listLen raVal t0Old t1Old outBase : Word) (input : List Byte) : Assertion :=
+  ((walkInitEmptyFailStatusPre listLen raVal (inputBase + BitVec.ofNat 64 0) **
+    (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion inputBase input) **
+    schemaWalkInitFrameFromPrologue outBase)
+
+theorem walkInitShortSuccessResolvedPreFromPrologue_entails_pre
+    (inputBase listLen raVal t0Old t1Old outBase : Word) (input : List Byte) :
+    WP.Entails
+      (walkInitShortSuccessResolvedPreFromPrologue inputBase listLen raVal t0Old t1Old
+        outBase input)
+      (((walkInitEmptyFailStatusPre listLen raVal (inputBase + BitVec.ofNat 64 0) **
+        (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion inputBase input) **
+        schemaWalkInitFrame outBase)) := by
+  intro h hp
+  unfold walkInitShortSuccessResolvedPreFromPrologue at hp
+  exact sepConj_mono_right (schemaWalkInitFrameFromPrologue_entails_schemaWalkInitFrame outBase) h hp
+
+-- WP-link automation unfolds these small assertion-shape helpers before `xperm`.
+attribute [rv64_wp] schemaWalkInitFrameFromPrologue walkInitShortSuccessPrologueSavedFrame
+  walkInitShortSuccessPrologueCarryFrame walkInitShortSuccessResolvedPreFromPrologue
+  walkInitEmptyFailStatusPre walkInitZeroNonzeroPre failStatusReturnPre statusReturnPre
+
+/-- Link the concrete prologue post plus caller-framed walk-init resources to
+    the exact resolved WP precondition, carrying the saved frame as a tail frame. -/
+theorem prologuePostShortSuccessCarry_entails_resolvedPreFromPrologue
+    (sp0 raVal s0Old s1Old s2Old inputBase listLen t0Old t1Old outBase : Word)
+    (input : List Byte) :
+    WP.Entails
+      (prologuePost sp0 raVal s0Old s1Old s2Old outBase **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input)
+      (walkInitShortSuccessResolvedPreFromPrologue inputBase listLen raVal t0Old t1Old outBase
+        input ** walkInitShortSuccessPrologueSavedFrame sp0 raVal s0Old s1Old s2Old) := by
+  wp_rv64_link
+
+/-- Public handoff link from the prologue post to the reduced resolved WP
+    precondition, with the prologue saved frame preserved for later epilogue work. -/
+theorem prologuePostShortSuccessCarry_entails_resolvedPre
+    (sp0 raVal s0Old s1Old s2Old inputBase listLen t0Old t1Old outBase : Word)
+    (input : List Byte) :
+    WP.Entails
+      (prologuePost sp0 raVal s0Old s1Old s2Old outBase **
+        walkInitShortSuccessPrologueCarryFrame inputBase listLen t0Old t1Old outBase input)
+      ((((walkInitEmptyFailStatusPre listLen raVal (inputBase + BitVec.ofNat 64 0) **
+        (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion inputBase input) **
+        schemaWalkInitFrame outBase) **
+        walkInitShortSuccessPrologueSavedFrame sp0 raVal s0Old s1Old s2Old)) := by
+  intro h hp
+  have hpExact := prologuePostShortSuccessCarry_entails_resolvedPreFromPrologue
+    sp0 raVal s0Old s1Old s2Old inputBase listLen t0Old t1Old outBase input h hp
+  exact sepConj_mono_left
+    (walkInitShortSuccessResolvedPreFromPrologue_entails_pre inputBase listLen raVal t0Old
+      t1Old outBase input) h hpExact
 
 def walkInitEmptyFailSchemaAbiFrame (listLen t0Old t1Old outBase : Word) : Assertion :=
   walkInitEmptyFailAbiFrame listLen t0Old t1Old ** schemaWalkInitRegsFrame outBase

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -1446,6 +1446,160 @@ theorem walkInitAbiFailureFromPrologueCaseNBranch_exits
       ] := by
   rfl
 
+/-- Reason-erased scratch facts preserved by either ABI-failure classifier arm.
+    This deliberately hides whether the failure was the empty-input arm or the
+    not-list arm, while keeping exact separation ownership. -/
+def walkInitAbiFailureReasonFrame
+    (inputBase listLen t0Old t1Old : Word) (input : List Byte)
+    (hoff : 0 < input.length) : Assertion :=
+  fun h =>
+    walkInitEmptyFailAbiFrame listLen t0Old t1Old h ∨
+      walkInitNotListFailAbiFrame inputBase listLen input 0 hoff h
+
+theorem walkInitAbiFailureReasonFrame_pcFree
+    (inputBase listLen t0Old t1Old : Word) (input : List Byte)
+    (hoff : 0 < input.length) :
+    (walkInitAbiFailureReasonFrame inputBase listLen t0Old t1Old input hoff).pcFree := by
+  intro h hp
+  rcases hp with hp | hp
+  · have hFrame : (walkInitEmptyFailAbiFrame listLen t0Old t1Old).pcFree := by
+      unfold walkInitEmptyFailAbiFrame
+      pcFree
+    exact hFrame h hp
+  · have hFrame : (walkInitNotListFailAbiFrame inputBase listLen input 0 hoff).pcFree := by
+      unfold walkInitNotListFailAbiFrame
+      pcFree
+    exact hFrame h hp
+
+def walkInitAbiFailureReasonPostFromPrologue
+    (sp0 raVal s0Old s1Old s2Old outBase : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (hoff : 0 < input.length) : Assertion :=
+  (abiPost inputBase outBase raVal input **
+    walkInitAbiFailureReasonFrame inputBase listLen t0Old t1Old input hoff) **
+    walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase
+
+theorem walkInitEmptyFailProloguePost_entails_reasonPost
+    (sp0 raVal s0Old s1Old s2Old outBase : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (hoff : 0 < input.length) :
+    WP.Entails
+      ((abiPost inputBase outBase raVal input **
+        walkInitEmptyFailAbiFrame listLen t0Old t1Old) **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+      (walkInitAbiFailureReasonPostFromPrologue sp0 raVal s0Old s1Old s2Old outBase
+        inputBase listLen t0Old t1Old input hoff) := by
+  intro h hp
+  unfold walkInitAbiFailureReasonPostFromPrologue
+  exact sepConj_mono_left
+    (sepConj_mono_right (fun h hp => Or.inl hp)) h hp
+
+theorem walkInitNotListFailProloguePost_entails_reasonPost
+    (sp0 raVal s0Old s1Old s2Old outBase : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (hoff : 0 < input.length) :
+    WP.Entails
+      ((abiPost inputBase outBase raVal input **
+        walkInitNotListFailAbiFrame inputBase listLen input 0 hoff) **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+      (walkInitAbiFailureReasonPostFromPrologue sp0 raVal s0Old s1Old s2Old outBase
+        inputBase listLen t0Old t1Old input hoff) := by
+  intro h hp
+  unfold walkInitAbiFailureReasonPostFromPrologue
+  exact sepConj_mono_left
+    (sepConj_mono_right (fun h hp => Or.inr hp)) h hp
+
+attribute [rv64_wp_entails]
+  walkInitEmptyFailProloguePost_entails_reasonPost
+  walkInitNotListFailProloguePost_entails_reasonPost
+
+/-- Prologue ABI-failure classifier with empty and not-list failure arms mapped
+    to one reason-erased postcondition. The two exits stay distinct in the CFG
+    list, but generated callers no longer inspect the failure reason. -/
+def walkInitAbiFailureReasonErasedFromPrologueNBranch
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover0 : inputBase.toNat + 0 < 2 ^ 64)
+    (hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    WP.NBranch base
+      ((prologueCode base).union (walkInitEmptyFailNotListFailShortLongCode (base + 24))) := by
+  let br := walkInitAbiFailureFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old outBase
+    m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hoff hover0 hvalid0 hLen
+    hBound hprologueCode hcode
+  wp_rv64_nbranch_weaken_posts4_with_auto br,
+    (walkInitAbiFailureFromPrologueNBranch_exits base sp0 raVal s0Old s1Old s2Old outBase
+      m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hoff hover0 hvalid0 hLen
+      hBound hprologueCode hcode),
+    (walkInitAbiFailureReasonPostFromPrologue sp0 raVal s0Old s1Old s2Old outBase
+      inputBase listLen t0Old t1Old input hoff),
+    (walkInitAbiFailureReasonPostFromPrologue sp0 raVal s0Old s1Old s2Old outBase
+      inputBase listLen t0Old t1Old input hoff),
+    (walkInitShortListOutputPost inputBase listLen raVal outBase input 0 hoff **
+      walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase),
+    (walkInitLongListOutputPost inputBase listLen raVal outBase input 0 hoff **
+      walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+
+theorem walkInitAbiFailureReasonErasedFromPrologueNBranch_pre
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover0 : inputBase.toNat + 0 < 2 ^ 64)
+    (hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    (walkInitAbiFailureReasonErasedFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old
+      outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hoff hover0 hvalid0
+      hLen hBound hprologueCode hcode).pre =
+      (walkInitAbiFailureFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old outBase
+        m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hoff hover0 hvalid0 hLen
+        hBound hprologueCode hcode).pre := by
+  rfl
+
+def walkInitAbiFailureReasonErasedFromPrologueExits
+    (base sp0 raVal s0Old s1Old s2Old outBase : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte) (hoff : 0 < input.length) : List (Word × Assertion) :=
+  [ (failStatusReturnExit raVal,
+      walkInitAbiFailureReasonPostFromPrologue sp0 raVal s0Old s1Old s2Old outBase
+        inputBase listLen t0Old t1Old input hoff)
+  , (failStatusReturnExit raVal,
+      walkInitAbiFailureReasonPostFromPrologue sp0 raVal s0Old s1Old s2Old outBase
+        inputBase listLen t0Old t1Old input hoff)
+  , ((base + 24) + 124,
+      walkInitShortListOutputPost inputBase listLen raVal outBase input 0 hoff **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+  , ((base + 24) + 28,
+      walkInitLongListOutputPost inputBase listLen raVal outBase input 0 hoff **
+        walkInitAbiFailurePrologueSavedFrame sp0 raVal s0Old s1Old s2Old outBase)
+  ]
+
+theorem walkInitAbiFailureReasonErasedFromPrologueNBranch_exits
+    (base sp0 raVal s0Old s1Old s2Old outBase m0 m1 m2 m3 : Word)
+    (inputBase listLen t0Old t1Old : Word)
+    (input : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover0 : inputBase.toNat + 0 < 2 ^ 64)
+    (hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64)
+    (hprologueCode : base.toNat + 24 < 2 ^ 64)
+    (hcode : (base + 24).toNat + 172 < 2 ^ 64) :
+    (walkInitAbiFailureReasonErasedFromPrologueNBranch base sp0 raVal s0Old s1Old s2Old
+      outBase m0 m1 m2 m3 inputBase listLen t0Old t1Old input hsalign hoff hover0 hvalid0
+      hLen hBound hprologueCode hcode).exits =
+      walkInitAbiFailureReasonErasedFromPrologueExits base sp0 raVal s0Old s1Old s2Old
+        outBase inputBase listLen t0Old t1Old input hoff := by
+  rfl
+
 /-- Prologue followed by the ABI-failure classifier, with the empty/nonempty
     split selected from the concrete input bytes. Callers supply only static
     length and memory-validity facts; the WP facade chooses the empty path for
@@ -1513,6 +1667,7 @@ theorem walkInitZeroNonzeroAbiFailureFromPrologueNBranch_pre
 
 attribute [rv64_wp]
   walkInitAbiFailureFromPrologueNBranch_pre
+  walkInitAbiFailureReasonErasedFromPrologueNBranch_pre
   walkInitZeroNonzeroAbiFailureFromPrologueNBranch_pre
 
 /-- Input-indexed exits for the zero/nonzero prologue facade. Empty input keeps

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -494,26 +494,41 @@ def walkInitShortSuccessResolvedCert
     rw [walkInitShortSuccessSemanticNBranch_exits]
   have hBound : input.length < 2 ^ 64 := by
     omega
-  exact WP.CFG.nbranch br 0 (by
-    intro ex hex
-    have hex' := hex
-    rw [hexits] at hex'
-    simp [walkInitShortSuccessSemanticExits] at hex'
-    rcases hex' with hcase | hcase | hcase | hcase
-    · rcases hcase with ⟨rfl, rfl⟩
-      exact (WP.CFG.unreachable (failStatusReturnExit raVal) (successStatusReturnExit raVal)
-        cr (walkInitEmptyFailSchemaAbiPost_contradicts_successFieldSpecs_input inputBase listLen
-          raVal t0Old t1Old outBase input hoff hLen hBound)).sound
-    · rcases hcase with ⟨rfl, rfl⟩
-      exact (WP.CFG.unreachable (failStatusReturnExit raVal) (successStatusReturnExit raVal)
-        cr (walkInitNotListFailSchemaAbiPost_contradicts_successFieldSpecs_input inputBase
-          listLen raVal outBase input d0 d1 d2 d3 hoff hl0 hl1 haddr hl3 hinput)).sound
-    · rcases hcase with ⟨rfl, rfl⟩
-      exact (WP.CFG.exit (successStatusReturnExit raVal) cr (WP.Entails.refl _)).sound
-    · rcases hcase with ⟨rfl, rfl⟩
-      exact (walkInitLongSchemaUnreachableCert (base + 28) (successStatusReturnExit raVal)
-        cr inputBase listLen raVal outBase input d0 d1 d2 d3 hoff hl0 hl1 haddr hl3 hinput
-        (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3)).sound)
+  have hexits4 : br.exits =
+      [(failStatusReturnExit raVal,
+          abiPost inputBase outBase raVal input **
+            walkInitEmptyFailSchemaAbiFrame listLen t0Old t1Old outBase),
+        (failStatusReturnExit raVal,
+          abiPost inputBase outBase raVal input **
+            walkInitNotListFailSchemaAbiFrame inputBase listLen outBase input hoff),
+        (successStatusReturnExit raVal,
+          walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3),
+        (base + 28,
+          walkInitLongSchemaPost inputBase listLen raVal outBase input hoff)] := by
+    simpa [walkInitShortSuccessSemanticExits] using hexits
+  let tailEmpty : WP.CFG.Cert (failStatusReturnExit raVal) (successStatusReturnExit raVal) cr
+      (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3) :=
+    WP.CFG.unreachable (failStatusReturnExit raVal) (successStatusReturnExit raVal) cr
+      (walkInitEmptyFailSchemaAbiPost_contradicts_successFieldSpecs_input inputBase listLen
+        raVal t0Old t1Old outBase input hoff hLen hBound)
+  let tailNotList : WP.CFG.Cert (failStatusReturnExit raVal) (successStatusReturnExit raVal) cr
+      (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3) :=
+    WP.CFG.unreachable (failStatusReturnExit raVal) (successStatusReturnExit raVal) cr
+      (walkInitNotListFailSchemaAbiPost_contradicts_successFieldSpecs_input inputBase
+        listLen raVal outBase input d0 d1 d2 d3 hoff hl0 hl1 haddr hl3 hinput)
+  let tailSuccess : WP.CFG.Cert (successStatusReturnExit raVal) (successStatusReturnExit raVal) cr
+      (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3) :=
+    WP.CFG.exit (successStatusReturnExit raVal) cr (WP.Entails.refl _)
+  let tailLong : WP.CFG.Cert (base + 28) (successStatusReturnExit raVal) cr
+      (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3) :=
+    walkInitLongSchemaUnreachableCert (base + 28) (successStatusReturnExit raVal)
+      cr inputBase listLen raVal outBase input d0 d1 d2 d3 hoff hl0 hl1 haddr hl3 hinput
+      (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3)
+  wp_rv64_nbranch_join4_with br, hexits4, 0,
+    tailEmpty, WP.Entails.refl _, by rfl,
+    tailNotList, WP.Entails.refl _, by rfl,
+    tailSuccess, WP.Entails.refl _, by rfl,
+    tailLong, WP.Entails.refl _, by rfl
 
 theorem walkInitShortSuccessResolvedCert_pre
     (base inputBase listLen raVal t0Old t1Old outBase : Word)

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -731,6 +731,64 @@ theorem walkInitLongSchemaPost_contradicts_successFieldSpecs_input
     _hPrefix_prop, hPure_prop⟩
   exact hPure_prop.2 hlt
 
+/-- Dead-exit hint for the empty-input failure case. The witness-free
+    `successFieldSpecsInput` hypothesis is generated once by the outcome splitter
+    and then consumed by `wp_rv64_dead`. -/
+theorem walkInitEmptyFailSchemaAbiPost_contradicts_successFieldSpecs
+    (inputBase listLen raVal t0Old t1Old outBase : Word) (input : List Byte)
+    (hoff : 0 < input.length) (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64) (_h_success : successFieldSpecsInput input) :
+    ∀ h,
+      (abiPost inputBase outBase raVal input **
+        walkInitEmptyFailSchemaAbiFrame listLen t0Old t1Old outBase) h → False :=
+  walkInitEmptyFailSchemaAbiPost_contradicts_successFieldSpecs_input inputBase listLen raVal
+    t0Old t1Old outBase input hoff hLen hBound
+
+/-- Dead-exit hint for the not-list failure case, parameterized by the
+    result-free success-schema predicate rather than explicit field witnesses. -/
+theorem walkInitNotListFailSchemaAbiPost_contradicts_successFieldSpecs
+    (inputBase listLen raVal outBase : Word) (input : List Byte)
+    (hoff : 0 < input.length) (h_success : successFieldSpecsInput input) :
+    ∀ h,
+      (abiPost inputBase outBase raVal input **
+        walkInitNotListFailSchemaAbiFrame inputBase listLen outBase input hoff) h → False := by
+  rcases h_success with
+    ⟨d0, d1, d2, d3, hinput, _hc0, hl0, _hc1, hl1, haddr, _hc3, hl3⟩
+  exact walkInitNotListFailSchemaAbiPost_contradicts_successFieldSpecs_input inputBase listLen
+    raVal outBase input d0 d1 d2 d3 hoff hl0 hl1 haddr hl3 hinput
+
+/-- Dead-exit hint for the merged reason-erased failure post under a known
+    success-schema input. -/
+theorem walkInitShortSuccessFailureReasonPost_contradicts_successFieldSpecs
+    (inputBase listLen raVal t0Old t1Old outBase : Word) (input : List Byte)
+    (hoff : 0 < input.length) (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64) (h_success : successFieldSpecsInput input) :
+    ∀ h,
+      walkInitShortSuccessFailureReasonPost inputBase listLen raVal t0Old t1Old outBase
+        input hoff h → False := by
+  rcases h_success with
+    ⟨d0, d1, d2, d3, hinput, _hc0, hl0, _hc1, hl1, haddr, _hc3, hl3⟩
+  exact walkInitShortSuccessFailureReasonPost_contradicts_successFieldSpecs_input inputBase
+    listLen raVal t0Old t1Old outBase input d0 d1 d2 d3 hoff hLen hBound hl0 hl1 haddr
+    hl3 hinput
+
+/-- Dead-exit hint for the long-list candidate under a known short-list
+    success-schema input. -/
+theorem walkInitLongSchemaPost_contradicts_successFieldSpecs
+    (inputBase listLen raVal outBase : Word) (input : List Byte)
+    (hoff : 0 < input.length) (h_success : successFieldSpecsInput input) :
+    ∀ h, walkInitLongSchemaPost inputBase listLen raVal outBase input hoff h → False := by
+  rcases h_success with
+    ⟨d0, d1, d2, d3, hinput, _hc0, hl0, _hc1, hl1, haddr, _hc3, hl3⟩
+  exact walkInitLongSchemaPost_contradicts_successFieldSpecs_input inputBase listLen raVal
+    outBase input d0 d1 d2 d3 hoff hl0 hl1 haddr hl3 hinput
+
+attribute [rv64_wp_dead]
+  walkInitEmptyFailSchemaAbiPost_contradicts_successFieldSpecs
+  walkInitNotListFailSchemaAbiPost_contradicts_successFieldSpecs
+  walkInitShortSuccessFailureReasonPost_contradicts_successFieldSpecs
+  walkInitLongSchemaPost_contradicts_successFieldSpecs
+
 /-- WP continuation for the dead long-list exit under a short-list success witness.
     The target and code requirement are parameters so generated joins can reuse
     the certificate in whatever larger CFG they are constructing. -/
@@ -947,6 +1005,8 @@ def walkInitShortSuccessResolvedCert
     rw [walkInitShortSuccessSemanticNBranch_exits]
   have hBound : input.length < 2 ^ 64 := by
     omega
+  have h_success : successFieldSpecsInput input :=
+    ⟨d0, d1, d2, d3, hinput, hc0, hl0, hc1, hl1, haddr, hc3, hl3⟩
   have hexits3 : br.exits =
       [(failStatusReturnExit raVal,
           walkInitShortSuccessFailureReasonPost inputBase listLen raVal t0Old t1Old outBase
@@ -956,13 +1016,8 @@ def walkInitShortSuccessResolvedCert
         (base + 28,
           walkInitLongSchemaPost inputBase listLen raVal outBase input hoff)] := by
     simpa [walkInitShortSuccessSemanticExits] using hexits
-  wp_rv64_nbranch_join3_resolve_second_auto br, hexits3,
-    (walkInitShortSuccessFailureReasonPost_contradicts_successFieldSpecs_input inputBase
-      listLen raVal t0Old t1Old outBase input d0 d1 d2 d3 hoff hLen hBound hl0 hl1 haddr
-      hl3 hinput),
-    (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3),
-    (walkInitLongSchemaPost_contradicts_successFieldSpecs_input inputBase listLen raVal
-      outBase input d0 d1 d2 d3 hoff hl0 hl1 haddr hl3 hinput)
+  wp_rv64_nbranch_join3_resolve_second_dead_auto br, hexits3,
+    (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3)
 
 theorem walkInitShortSuccessResolvedCert_pre
     (base inputBase listLen raVal t0Old t1Old outBase : Word)

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -181,6 +181,80 @@ theorem walkInitPrefixWord_lt_f8_of_successFieldSpecs_input
   simp [walkInitPrefixWord, encode_list_schemaItems_short, hshort, BitVec.ult]
   omega
 
+theorem walkInitPrefixWord_not_lt_c0_of_successFieldSpecs_input
+    (input d0 d1 d2 d3 : List Byte) (hoff : 0 < input.length)
+    (hl0 : d0.length ≤ 8) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3)))) :
+    BitVec.ult (walkInitPrefixWord input 0 hoff) (0xc0 : Word) = false := by
+  have hpayload := schemaEncBytes_successFieldSpecs_length_le_48 d0 d1 d2 d3 hl0 hl1 haddr hl3
+  have hshort : (schemaEncBytes (successFieldSpecs d0 d1 d2 d3)).length ≤ 55 := by
+    omega
+  subst input
+  simp [walkInitPrefixWord, encode_list_schemaItems_short, hshort, BitVec.ult]
+  omega
+
+/-- The empty-input semantic failure exit is unreachable for a nonempty short-list
+    success witness whose length was loaded into `listLen`. -/
+theorem walkInitEmptyFailSchemaAbiPost_contradicts_successFieldSpecs_input
+    (inputBase listLen raVal t0Old t1Old outBase : Word) (input : List Byte)
+    (hoff : 0 < input.length) (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64) :
+    ∀ h,
+      (abiPost inputBase outBase raVal input **
+        walkInitEmptyFailSchemaAbiFrame listLen t0Old t1Old outBase) h → False := by
+  intro h hp
+  unfold walkInitEmptyFailSchemaAbiFrame walkInitEmptyFailAbiFrame at hp
+  rcases hp with ⟨_hAbi, hFrame, _hdFrame, _hunionFrame, _hAbi_prop, hFrame_prop⟩
+  rcases hFrame_prop with ⟨hEmpty, _hSchema, _hdSchema, _hunionSchema,
+    hEmpty_prop, _hSchema_prop⟩
+  rcases hEmpty_prop with ⟨_hLenReg, hRest1, _hdRest1, _hunionRest1,
+    _hLenReg_prop, hRest1_prop⟩
+  rcases hRest1_prop with ⟨_hX5, hRest2, _hdRest2, _hunionRest2,
+    _hX5_prop, hRest2_prop⟩
+  rcases hRest2_prop with ⟨_hX6, hPure, _hdPure, _hunionPure,
+    _hX6_prop, hPure_prop⟩
+  have hzero : listLen = (0 : Word) := hPure_prop.2
+  have hLengthZero : input.length = 0 := by
+    have heq : BitVec.ofNat 64 input.length = (0 : Word) := by
+      rw [← hLen]
+      exact hzero
+    have htn := congrArg BitVec.toNat heq
+    simp only [BitVec.toNat_ofNat, show (0 : Word).toNat = 0 from by decide] at htn
+    rw [Nat.mod_eq_of_lt hBound] at htn
+    exact htn
+  omega
+
+/-- The not-list semantic failure exit is unreachable for a short-list success
+    witness, because its first byte is a list prefix. -/
+theorem walkInitNotListFailSchemaAbiPost_contradicts_successFieldSpecs_input
+    (inputBase listLen raVal outBase : Word) (input d0 d1 d2 d3 : List Byte)
+    (hoff : 0 < input.length)
+    (hl0 : d0.length ≤ 8) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3)))) :
+    ∀ h,
+      (abiPost inputBase outBase raVal input **
+        walkInitNotListFailSchemaAbiFrame inputBase listLen outBase input hoff) h → False := by
+  intro h hp
+  have hnlt := walkInitPrefixWord_not_lt_c0_of_successFieldSpecs_input input d0 d1 d2 d3 hoff
+    hl0 hl1 haddr hl3 hinput
+  unfold walkInitNotListFailSchemaAbiFrame walkInitNotListFailAbiFrame at hp
+  rcases hp with ⟨_hAbi, hFrame, _hdFrame, _hunionFrame, _hAbi_prop, hFrame_prop⟩
+  rcases hFrame_prop with ⟨hNotList, _hSchema, _hdSchema, _hunionSchema,
+    hNotList_prop, _hSchema_prop⟩
+  rcases hNotList_prop with ⟨_hX11, hRest1, _hdRest1, _hunionRest1,
+    _hX11_prop, hRest1_prop⟩
+  rcases hRest1_prop with ⟨_hX5, hRest2, _hdRest2, _hunionRest2,
+    _hX5_prop, hRest2_prop⟩
+  rcases hRest2_prop with ⟨_hX6, hRest3, _hdRest3, _hunionRest3,
+    _hX6_prop, hRest3_prop⟩
+  rcases hRest3_prop with ⟨_hNonzero, hLt, _hdLt, _hunionLt,
+    _hNonzero_prop, hLt_prop⟩
+  have hlt : BitVec.ult (walkInitPrefixWord input 0 hoff) (0xc0 : Word) = true := hLt_prop.2
+  rw [hnlt] at hlt
+  contradiction
+
 /-- The long-list exit is unreachable when the input is the short-list encoding
     of successful withdrawal field witnesses. -/
 theorem walkInitLongSchemaPost_contradicts_successFieldSpecs_input
@@ -373,6 +447,97 @@ theorem walkInitShortSuccessSemanticNBranch_exits
       hl3 hinput hLen hcode).exits =
       walkInitShortSuccessSemanticExits base inputBase listLen raVal t0Old t1Old outBase input
         d0 d1 d2 d3 hoff := by
+  rfl
+
+/-- The short-success semantic classifier joined to a single success post.  The
+    empty, not-list, and long-list exits are closed by contradiction from the
+    success witness; the only reachable exit is the schema success post. -/
+def walkInitShortSuccessResolvedCert
+    (base inputBase listLen raVal t0Old t1Old outBase : Word)
+    (input d0 d1 d2 d3 : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hcode : base.toNat + 172 + 4 + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    WP.CFG.Cert base (successStatusReturnExit raVal)
+      ((walkInitEmptyFailNotListFailShortLongCode base).union
+        ((walkInitShortSuccessJumpCode base).union
+          ((schemaCursorInitCode (base + 172)).union
+            ((schemaCR (base + 172 + 4) .x8 (successFieldSpecs d0 d1 d2 d3)).union
+              (successStatusReturnCode
+                ((base + 172 + 4) + BitVec.ofNat 64
+                  (schemaSize (successFieldSpecs d0 d1 d2 d3))))))))
+      (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3) := by
+  let cr := ((walkInitEmptyFailNotListFailShortLongCode base).union
+    ((walkInitShortSuccessJumpCode base).union
+      ((schemaCursorInitCode (base + 172)).union
+        ((schemaCR (base + 172 + 4) .x8 (successFieldSpecs d0 d1 d2 d3)).union
+          (successStatusReturnCode
+            ((base + 172 + 4) + BitVec.ofNat 64
+              (schemaSize (successFieldSpecs d0 d1 d2 d3))))))))
+  let br := walkInitShortSuccessSemanticNBranch base inputBase listLen raVal t0Old t1Old outBase
+    input d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval hc0 hl0 hc1 hl1 haddr
+    hc3 hl3 hinput hLen hcode
+  have hexits : br.exits =
+      walkInitShortSuccessSemanticExits base inputBase listLen raVal t0Old t1Old outBase input
+        d0 d1 d2 d3 hoff := by
+    dsimp [br]
+    rw [walkInitShortSuccessSemanticNBranch_exits]
+  have hBound : input.length < 2 ^ 64 := by
+    omega
+  exact WP.CFG.nbranch br 0 (by
+    intro ex hex
+    have hex' := hex
+    rw [hexits] at hex'
+    simp [walkInitShortSuccessSemanticExits] at hex'
+    rcases hex' with hcase | hcase | hcase | hcase
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact (WP.CFG.unreachable (failStatusReturnExit raVal) (successStatusReturnExit raVal)
+        cr (walkInitEmptyFailSchemaAbiPost_contradicts_successFieldSpecs_input inputBase listLen
+          raVal t0Old t1Old outBase input hoff hLen hBound)).sound
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact (WP.CFG.unreachable (failStatusReturnExit raVal) (successStatusReturnExit raVal)
+        cr (walkInitNotListFailSchemaAbiPost_contradicts_successFieldSpecs_input inputBase
+          listLen raVal outBase input d0 d1 d2 d3 hoff hl0 hl1 haddr hl3 hinput)).sound
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact (WP.CFG.exit (successStatusReturnExit raVal) cr (WP.Entails.refl _)).sound
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact (walkInitLongSchemaUnreachableCert (base + 28) (successStatusReturnExit raVal)
+        cr inputBase listLen raVal outBase input d0 d1 d2 d3 hoff hl0 hl1 haddr hl3 hinput
+        (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3)).sound)
+
+theorem walkInitShortSuccessResolvedCert_pre
+    (base inputBase listLen raVal t0Old t1Old outBase : Word)
+    (input d0 d1 d2 d3 : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hcode : base.toNat + 172 + 4 + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    (walkInitShortSuccessResolvedCert base inputBase listLen raVal t0Old t1Old outBase input
+      d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval hc0 hl0 hc1 hl1 haddr hc3
+      hl3 hinput hLen hcode).pre =
+      (walkInitShortSuccessSemanticNBranch base inputBase listLen raVal t0Old t1Old outBase input
+        d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval hc0 hl0 hc1 hl1 haddr hc3
+        hl3 hinput hLen hcode).pre := by
+  unfold walkInitShortSuccessResolvedCert
   rfl
 
 end WithdrawalDecode

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -273,6 +273,22 @@ def walkInitNotListFailSchemaAbiFrame
     (hoff : 0 < input.length) : Assertion :=
   walkInitNotListFailAbiFrame inputBase listLen input 0 hoff ** schemaWalkInitRegsFrame outBase
 
+/-- Scratch facts preserved by either short-success semantic failure arm. The
+    ABI component is already reason-erased; this hides whether the classifier
+    failed because the input was empty or because the prefix was not a list. -/
+def walkInitShortSuccessFailureReasonFrame
+    (inputBase listLen t0Old t1Old outBase : Word)
+    (input : List Byte) (hoff : 0 < input.length) : Assertion :=
+  fun h =>
+    walkInitEmptyFailSchemaAbiFrame listLen t0Old t1Old outBase h ∨
+      walkInitNotListFailSchemaAbiFrame inputBase listLen outBase input hoff h
+
+def walkInitShortSuccessFailureReasonPost
+    (inputBase listLen raVal t0Old t1Old outBase : Word)
+    (input : List Byte) (hoff : 0 < input.length) : Assertion :=
+  abiPost inputBase outBase raVal input **
+    walkInitShortSuccessFailureReasonFrame inputBase listLen t0Old t1Old outBase input hoff
+
 /-- Empty-input branch, with the schema handoff frame weakened to the public ABI
     failure post plus preserved scratch facts. -/
 theorem walkInitEmptyFailSchemaPost_entails_abiFailureFrame
@@ -385,6 +401,45 @@ attribute [rv64_wp_entails]
   walkInitEmptyFailSchemaPost_entails_abiFailureFrame
   walkInitNotListFailSchemaPost_entails_abiFailureFrame
 
+theorem walkInitEmptyFailSchemaPost_entails_reasonPost
+    (inputBase listLen raVal t0Old t1Old outBase : Word) (input : List Byte)
+    (hoff : 0 < input.length)
+    (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64) :
+    WP.Entails
+      ((walkInitEmptyFailStatusPost listLen raVal **
+        ((.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion inputBase input)) **
+        schemaWalkInitFrame outBase)
+      (walkInitShortSuccessFailureReasonPost inputBase listLen raVal t0Old t1Old outBase
+        input hoff) :=
+  WP.Entails.trans
+    (walkInitEmptyFailSchemaPost_entails_abiFailureFrame inputBase listLen raVal t0Old
+      t1Old outBase input hLen hBound)
+    (by
+      intro h hp
+      unfold walkInitShortSuccessFailureReasonPost walkInitShortSuccessFailureReasonFrame
+      exact sepConj_mono_right (fun h hp => Or.inl hp) h hp)
+
+theorem walkInitNotListFailSchemaPost_entails_reasonPost
+    (inputBase listLen raVal t0Old t1Old outBase : Word) (input : List Byte)
+    (hoff : 0 < input.length) :
+    WP.Entails
+      (walkInitPrefixNotListFailStatusPost inputBase listLen raVal input 0 hoff **
+        schemaWalkInitFrame outBase)
+      (walkInitShortSuccessFailureReasonPost inputBase listLen raVal t0Old t1Old outBase
+        input hoff) :=
+  WP.Entails.trans
+    (walkInitNotListFailSchemaPost_entails_abiFailureFrame inputBase listLen raVal
+      outBase input hoff)
+    (by
+      intro h hp
+      unfold walkInitShortSuccessFailureReasonPost walkInitShortSuccessFailureReasonFrame
+      exact sepConj_mono_right (fun h hp => Or.inr hp) h hp)
+
+attribute [rv64_wp_entails]
+  walkInitEmptyFailSchemaPost_entails_reasonPost
+  walkInitNotListFailSchemaPost_entails_reasonPost
+
 def walkInitShortSuccessAbiPost
     (inputBase outBase raVal : Word) (input d0 d1 d2 d3 : List Byte) : Assertion :=
   ((abiPost inputBase outBase raVal input **
@@ -484,6 +539,29 @@ theorem walkInitNotListFailSchemaAbiPost_contradicts_successFieldSpecs_input
   rw [hnlt] at hlt
   contradiction
 
+/-- The reason-erased semantic failure exit is unreachable for a short-list
+    success witness. -/
+theorem walkInitShortSuccessFailureReasonPost_contradicts_successFieldSpecs_input
+    (inputBase listLen raVal t0Old t1Old outBase : Word) (input d0 d1 d2 d3 : List Byte)
+    (hoff : 0 < input.length) (hLen : listLen = BitVec.ofNat 64 input.length)
+    (hBound : input.length < 2 ^ 64)
+    (hl0 : d0.length ≤ 8) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3)))) :
+    ∀ h,
+      walkInitShortSuccessFailureReasonPost inputBase listLen raVal t0Old t1Old outBase
+        input hoff h → False := by
+  intro h hp
+  unfold walkInitShortSuccessFailureReasonPost walkInitShortSuccessFailureReasonFrame at hp
+  rcases hp with ⟨hAbi, hFrame, hd, hunion, hAbi_prop, hFrame_prop⟩
+  rcases hFrame_prop with hEmpty | hNotList
+  · exact walkInitEmptyFailSchemaAbiPost_contradicts_successFieldSpecs_input inputBase
+      listLen raVal t0Old t1Old outBase input hoff hLen hBound h
+      ⟨hAbi, hFrame, hd, hunion, hAbi_prop, hEmpty⟩
+  · exact walkInitNotListFailSchemaAbiPost_contradicts_successFieldSpecs_input inputBase
+      listLen raVal outBase input d0 d1 d2 d3 hoff hl0 hl1 haddr hl3 hinput h
+      ⟨hAbi, hFrame, hd, hunion, hAbi_prop, hNotList⟩
+
 /-- The long-list exit is unreachable when the input is the short-list encoding
     of successful withdrawal field witnesses. -/
 theorem walkInitLongSchemaPost_contradicts_successFieldSpecs_input
@@ -577,20 +655,17 @@ def walkInitShortSuccessSemanticExits
     (input d0 d1 d2 d3 : List Byte) (hoff : 0 < input.length) :
     List (Word × Assertion) :=
   [ (failStatusReturnExit raVal,
-      abiPost inputBase outBase raVal input **
-        walkInitEmptyFailSchemaAbiFrame listLen t0Old t1Old outBase)
-  , (failStatusReturnExit raVal,
-      abiPost inputBase outBase raVal input **
-        walkInitNotListFailSchemaAbiFrame inputBase listLen outBase input hoff)
+      walkInitShortSuccessFailureReasonPost inputBase listLen raVal t0Old t1Old outBase
+        input hoff)
   , (successStatusReturnExit raVal,
       walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3)
   , (base + 28,
       walkInitLongSchemaPost inputBase listLen raVal outBase input hoff)
   ]
 
-/-- Prefix classifier with semantic failure exits and the short-list success path
-    continued through the generated result-free schema WP tail. The long-list
-    exit remains open. -/
+/-- Prefix classifier with reason-erased semantic failure exits and the short-list
+    success path continued through the generated result-free schema WP tail. The
+    long-list exit remains open. -/
 def walkInitShortSuccessSemanticNBranch
     (base inputBase listLen raVal t0Old t1Old outBase : Word)
     (input d0 d1 d2 d3 : List Byte)
@@ -620,14 +695,12 @@ def walkInitShortSuccessSemanticNBranch
     hc3 hl3 hinput hcode
   have hBound : input.length < 2 ^ 64 := by
     omega
-  wp_rv64_nbranch_weaken_posts4_with_auto br,
+  wp_rv64_nbranch_weaken_posts4_merge_first_two_with_auto br,
     (walkInitShortSuccessSchemaNBranch_exits base inputBase listLen raVal t0Old t1Old
       outBase input d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval hc0 hl0 hc1 hl1
       haddr hc3 hl3 hinput hcode),
-    (abiPost inputBase outBase raVal input **
-      walkInitEmptyFailSchemaAbiFrame listLen t0Old t1Old outBase),
-    (abiPost inputBase outBase raVal input **
-      walkInitNotListFailSchemaAbiFrame inputBase listLen outBase input hoff),
+    (walkInitShortSuccessFailureReasonPost inputBase listLen raVal t0Old t1Old outBase
+      input hoff),
     (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3),
     (walkInitLongSchemaPost inputBase listLen raVal outBase input hoff)
 
@@ -723,24 +796,20 @@ def walkInitShortSuccessResolvedCert
     rw [walkInitShortSuccessSemanticNBranch_exits]
   have hBound : input.length < 2 ^ 64 := by
     omega
-  have hexits4 : br.exits =
+  have hexits3 : br.exits =
       [(failStatusReturnExit raVal,
-          abiPost inputBase outBase raVal input **
-            walkInitEmptyFailSchemaAbiFrame listLen t0Old t1Old outBase),
-        (failStatusReturnExit raVal,
-          abiPost inputBase outBase raVal input **
-            walkInitNotListFailSchemaAbiFrame inputBase listLen outBase input hoff),
+          walkInitShortSuccessFailureReasonPost inputBase listLen raVal t0Old t1Old outBase
+            input hoff),
         (successStatusReturnExit raVal,
           walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3),
         (base + 28,
           walkInitLongSchemaPost inputBase listLen raVal outBase input hoff)] := by
     simpa [walkInitShortSuccessSemanticExits] using hexits
-  wp_rv64_nbranch_join4_resolve_third br, hexits4,
-    (walkInitEmptyFailSchemaAbiPost_contradicts_successFieldSpecs_input inputBase listLen
-      raVal t0Old t1Old outBase input hoff hLen hBound),
-    (walkInitNotListFailSchemaAbiPost_contradicts_successFieldSpecs_input inputBase
-      listLen raVal outBase input d0 d1 d2 d3 hoff hl0 hl1 haddr hl3 hinput),
-    (WP.Entails.refl _),
+  wp_rv64_nbranch_join3_resolve_second_auto br, hexits3,
+    (walkInitShortSuccessFailureReasonPost_contradicts_successFieldSpecs_input inputBase
+      listLen raVal t0Old t1Old outBase input d0 d1 d2 d3 hoff hLen hBound hl0 hl1 haddr
+      hl3 hinput),
+    (walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3),
     (walkInitLongSchemaPost_contradicts_successFieldSpecs_input inputBase listLen raVal
       outBase input d0 d1 d2 d3 hoff hl0 hl1 haddr hl3 hinput)
 

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeSemanticWP.lean
@@ -255,38 +255,18 @@ def walkInitShortSuccessSemanticNBranch
   let br := walkInitShortSuccessSchemaNBranch base inputBase listLen raVal t0Old t1Old outBase
     input d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval hc0 hl0 hc1 hl1 haddr
     hc3 hl3 hinput hcode
-  let exits := walkInitShortSuccessSemanticExits base inputBase listLen raVal t0Old t1Old outBase
-    input d0 d1 d2 d3 hoff
   have hBound : input.length < 2 ^ 64 := by
     omega
-  exact WP.CFG.nbranchWeakenPosts br exits (by
-    intro ex hex
-    have hex' := hex
-    rw [walkInitShortSuccessSchemaNBranch_exits] at hex'
-    simp [walkInitShortSuccessSchemaExits] at hex'
-    rcases hex' with hcase | hcase | hcase | hcase
-    · rcases hcase with ⟨rfl, rfl⟩
-      exact ⟨(failStatusReturnExit raVal,
-        abiPost inputBase outBase raVal input **
-          walkInitEmptyFailSchemaAbiFrame listLen t0Old t1Old outBase), by simp [exits,
-            walkInitShortSuccessSemanticExits], rfl,
-        walkInitEmptyFailSchemaPost_entails_abiFailureFrame inputBase listLen raVal t0Old
-          t1Old outBase input hLen hBound⟩
-    · rcases hcase with ⟨rfl, rfl⟩
-      exact ⟨(failStatusReturnExit raVal,
-        abiPost inputBase outBase raVal input **
-          walkInitNotListFailSchemaAbiFrame inputBase listLen outBase input hoff), by simp [exits,
-            walkInitShortSuccessSemanticExits], rfl,
-        walkInitNotListFailSchemaPost_entails_abiFailureFrame inputBase listLen raVal outBase
-          input hoff⟩
-    · rcases hcase with ⟨rfl, rfl⟩
-      exact ⟨(successStatusReturnExit raVal,
-        walkInitShortSuccessAbiPost inputBase outBase raVal input d0 d1 d2 d3), by simp [exits,
-          walkInitShortSuccessSemanticExits], rfl, WP.Entails.refl _⟩
-    · rcases hcase with ⟨rfl, rfl⟩
-      exact ⟨(base + 28,
-        walkInitLongSchemaPost inputBase listLen raVal outBase input hoff), by simp [exits,
-          walkInitShortSuccessSemanticExits], rfl, WP.Entails.refl _⟩)
+  wp_rv64_nbranch_weaken_posts4_with br,
+    (walkInitShortSuccessSchemaNBranch_exits base inputBase listLen raVal t0Old t1Old
+      outBase input d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval hc0 hl0 hc1 hl1
+      haddr hc3 hl3 hinput hcode),
+    (walkInitEmptyFailSchemaPost_entails_abiFailureFrame inputBase listLen raVal t0Old
+      t1Old outBase input hLen hBound),
+    (walkInitNotListFailSchemaPost_entails_abiFailureFrame inputBase listLen raVal outBase
+      input hoff),
+    (WP.Entails.refl _),
+    (WP.Entails.refl _)
 
 theorem walkInitShortSuccessSemanticNBranch_pre
     (base inputBase listLen raVal t0Old t1Old outBase : Word)

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeShortWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeShortWP.lean
@@ -1,0 +1,264 @@
+/-
+  EvmAsm.Rv64.RLP.WithdrawalDecodeShortWP
+
+  First composed withdrawal-decoder WP layer: run the walk-init classifier with
+  schema handoff resources, then continue the short-list success exit through
+  the generated withdrawal schema success tail.  Other exits stay open for the
+  failure/long-list layers.
+-/
+
+import EvmAsm.Rv64.RLP.WithdrawalSchemaWP
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL
+open EvmAsm.EL.RLP
+open EvmAsm.Rv64.Tactics
+
+namespace WithdrawalDecode
+
+theorem walkInitEmptyFailNotListFailShortLongCode_none_above
+    (base a : Word) (h : base.toNat + 172 ≤ a.toNat) :
+    walkInitEmptyFailNotListFailShortLongCode base a = none := by
+  unfold walkInitEmptyFailNotListFailShortLongCode walkInitEmptyFailOrPrefixCode
+    walkInitEmptyFailStatusCode failStatusReturnCode statusReturnCode
+    walkInitNonzeroPrefixTailCode walkInitPrefixShortLongTailCode
+    walkInitPrefixListCheckNotListFailF8Code walkInitPrefixListCheckOrNotListFailCode
+    walkInitPrefixListCheckCode walkInitPrefixNotListFailStatusCode walkInitListF8Code
+    walkInitShortLongCheckCode
+  have h0 : CodeReq.singleton base (.BEQ .x11 .x0 (156 : BitVec 13)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h156 : CodeReq.singleton (base + 156) (.LI .x10 (1 : Word)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h160 : CodeReq.singleton (base + 156 + 4) (.JALR .x0 .x1 (0 : BitVec 12)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h4 : CodeReq.singleton (base + 4) (.ADD .x11 .x10 .x11) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h8 : CodeReq.singleton (base + 8) (.LBU .x5 .x10 0) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h12 : CodeReq.singleton (base + 12) (.LI .x6 (0xc0 : Word)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h16 : CodeReq.singleton (base + 16) (.BLTU .x5 .x6 (148 : BitVec 13)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h164 : CodeReq.singleton (base + 164) (.LI .x10 (1 : Word)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h168 : CodeReq.singleton (base + 164 + 4) (.JALR .x0 .x1 (0 : BitVec 12)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h20 : CodeReq.singleton (base + 20) (.LI .x6 (0xf8 : Word)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h24 : CodeReq.singleton (base + 24) (.BLTU .x5 .x6 (100 : BitVec 13)) a = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  simp only [failStatusReturnCode, statusReturnCode, CodeReq.union,
+    h0, h156, h160, h4, h8, h12, h16, h164, h168, h20, h24]
+
+theorem walkInitEmptyFailNotListFailShortLongCode_none_at_shortSuccessJump
+    (base : Word) :
+    walkInitEmptyFailNotListFailShortLongCode base (base + 124) = none := by
+  unfold walkInitEmptyFailNotListFailShortLongCode walkInitEmptyFailOrPrefixCode
+    walkInitEmptyFailStatusCode failStatusReturnCode statusReturnCode
+    walkInitNonzeroPrefixTailCode walkInitPrefixShortLongTailCode
+    walkInitPrefixListCheckNotListFailF8Code walkInitPrefixListCheckOrNotListFailCode
+    walkInitPrefixListCheckCode walkInitPrefixNotListFailStatusCode walkInitListF8Code
+    walkInitShortLongCheckCode
+  have h0 : CodeReq.singleton base (.BEQ .x11 .x0 (156 : BitVec 13)) (base + 124) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h156 : CodeReq.singleton (base + 156) (.LI .x10 (1 : Word)) (base + 124) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h160 : CodeReq.singleton (base + 156 + 4) (.JALR .x0 .x1 (0 : BitVec 12)) (base + 124) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h4 : CodeReq.singleton (base + 4) (.ADD .x11 .x10 .x11) (base + 124) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h8 : CodeReq.singleton (base + 8) (.LBU .x5 .x10 0) (base + 124) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h12 : CodeReq.singleton (base + 12) (.LI .x6 (0xc0 : Word)) (base + 124) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h16 : CodeReq.singleton (base + 16) (.BLTU .x5 .x6 (148 : BitVec 13)) (base + 124) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h164 : CodeReq.singleton (base + 164) (.LI .x10 (1 : Word)) (base + 124) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h168 : CodeReq.singleton (base + 164 + 4) (.JALR .x0 .x1 (0 : BitVec 12)) (base + 124) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h20 : CodeReq.singleton (base + 20) (.LI .x6 (0xf8 : Word)) (base + 124) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  have h24 : CodeReq.singleton (base + 24) (.BLTU .x5 .x6 (100 : BitVec 13)) (base + 124) = none :=
+    CodeReq.singleton_miss (by bv_omega)
+  simp only [failStatusReturnCode, statusReturnCode, CodeReq.union,
+    h0, h156, h160, h4, h8, h12, h16, h164, h168, h20, h24]
+
+theorem walkInitEmptyFailNotListFailShortLongCode_disjoint_shortSuccessJump
+    (base : Word) :
+    (walkInitEmptyFailNotListFailShortLongCode base).Disjoint
+      (walkInitShortSuccessJumpCode base) := by
+  intro a
+  by_cases h_eq : a = base + 124
+  · left
+    subst h_eq
+    exact walkInitEmptyFailNotListFailShortLongCode_none_at_shortSuccessJump base
+  · right
+    unfold walkInitShortSuccessJumpCode
+    exact CodeReq.singleton_miss h_eq
+
+theorem walkInitEmptyFailNotListFailShortLongCode_disjoint_schemaTail
+    (base : Word) (specs : List FieldSpec)
+    (hcode : base.toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    (walkInitEmptyFailNotListFailShortLongCode base).Disjoint
+      ((schemaCursorInitCode (base + 172)).union
+        ((schemaCR (base + 172 + 4) .x8 specs).union
+          (successStatusReturnCode
+            ((base + 172 + 4) + BitVec.ofNat 64 (schemaSize specs))))) := by
+  have hbase172 : (base + 172).toNat = base.toNat + 172 := by
+    bv_omega
+  refine codeReq_disjoint_of_ranges _ _ (base.toNat + 172) ?_ ?_
+  · intro a ha
+    exact walkInitEmptyFailNotListFailShortLongCode_none_above base a ha
+  · intro a ha
+    exact schemaCursorInitSuccessReturnTail_none_below (base + 172) .x8 specs a
+      (by rw [hbase172]; omega) (by rw [hbase172]; exact ha)
+
+theorem walkInitEmptyFailNotListFailShortLongCode_disjoint_shortSuccessTail
+    (base : Word) (specs : List FieldSpec)
+    (hcode : base.toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    (walkInitEmptyFailNotListFailShortLongCode base).Disjoint
+      ((walkInitShortSuccessJumpCode base).union
+        ((schemaCursorInitCode (base + 172)).union
+          ((schemaCR (base + 172 + 4) .x8 specs).union
+            (successStatusReturnCode
+              ((base + 172 + 4) + BitVec.ofNat 64 (schemaSize specs)))))) := by
+  exact CodeReq.Disjoint.union_right
+    (walkInitEmptyFailNotListFailShortLongCode_disjoint_shortSuccessJump base)
+    (walkInitEmptyFailNotListFailShortLongCode_disjoint_schemaTail base specs hcode)
+
+theorem walkInitSchemaFrameNBranch_exits
+    (base inputBase listLen raVal t0Old t1Old outBase : Word)
+    (input : List Byte) (hoff : 0 < input.length)
+    (hsalign : inputBase.toNat % 8 = 0)
+    (hover0 : inputBase.toNat + 0 < 2 ^ 64)
+    (hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true) :
+    (walkInitEmptyFailNotListFailShortLongFramedNBranch base inputBase listLen raVal
+      t0Old t1Old input 0 hsalign hoff hover0 hvalid0
+      (schemaWalkInitFrame outBase) (schemaWalkInitFrame_pcFree outBase)).exits =
+      [ (failStatusReturnExit raVal,
+          (walkInitEmptyFailStatusPost listLen raVal **
+            ((.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion inputBase input)) **
+            schemaWalkInitFrame outBase)
+      , (failStatusReturnExit raVal,
+          walkInitPrefixNotListFailStatusPost inputBase listLen raVal input 0 hoff **
+            schemaWalkInitFrame outBase)
+      , (base + 124,
+          walkInitShortListCandidatePost inputBase listLen raVal input 0 hoff **
+            schemaWalkInitFrame outBase)
+      , (base + 28,
+          walkInitLongListCandidatePost inputBase listLen raVal input 0 hoff **
+            schemaWalkInitFrame outBase)
+      ] := by
+  simp [walkInitEmptyFailNotListFailShortLongFramedNBranch,
+    walkInitEmptyFailNotListFailShortLongNBranch,
+    walkInitEmptyFailOrPrefixBranch, walkInitPrefixListCheckOrNotListFailBranch,
+    walkInitEmptyFailStatusBranch, walkInitPrefixListCheckBranch,
+    walkInitShortLongCheckBranch, walkInitEmptyFailStatusPost,
+    failStatusReturnExit, statusReturnExit, WP.CFG.nbranchFrameR, WP.NBranch.frameR,
+    WP.CFG.branchFrameR, WP.Branch.frameR, WP.CFG.branchSeqNotTakenNBranchDisjoint,
+    WP.Branch.seqNotTakenNBranchDisjoint, WP.CFG.branchSeqNotTakenBlockDisjoint,
+    WP.CFG.branchSeqTakenBlockDisjoint, WP.CFG.branchSeqNotTakenDisjoint,
+    WP.CFG.branchSeqTakenDisjoint, WP.Branch.seqNotTakenDisjoint,
+    WP.Branch.seqTakenDisjoint, WP.CFG.nbranchOfBranch, WP.NBranch.ofBranch,
+    WP.Branch.ofSpec, WP.CFG.block, WP.Triple.ofSpec]
+
+/-- Walk-init classifier with the short-list success exit continued through the
+    generated withdrawal schema success tail. Empty, not-list, and long-list
+    exits remain explicit for later failure/long-list automation. -/
+def walkInitShortSuccessSchemaNBranch
+    (base inputBase listLen raVal t0Old t1Old outBase : Word)
+    (input d0 d1 d2 d3 : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (hcode : base.toNat + 172 + 4 + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    WP.NBranch base
+      ((walkInitEmptyFailNotListFailShortLongCode base).union
+        ((walkInitShortSuccessJumpCode base).union
+          ((schemaCursorInitCode (base + 172)).union
+            ((schemaCR (base + 172 + 4) .x8 (successFieldSpecs d0 d1 d2 d3)).union
+              (successStatusReturnCode
+                ((base + 172 + 4) + BitVec.ofNat 64
+                  (schemaSize (successFieldSpecs d0 d1 d2 d3)))))))) := by
+  have hover0 : inputBase.toNat + 0 < 2 ^ 64 := by
+    omega
+  have hvalid0 : isValidByteAccess (inputBase + BitVec.ofNat 64 0) = true :=
+    hwin 0 hoff
+  let br := walkInitEmptyFailNotListFailShortLongFramedNBranch base inputBase listLen raVal
+    t0Old t1Old input 0 hsalign hoff hover0 hvalid0
+    (schemaWalkInitFrame outBase) (schemaWalkInitFrame_pcFree outBase)
+  let tailCert := successFieldSpecsReturnAbiCertOfInputFromWalkShortExit base inputBase outBase
+    raVal input d0 d1 d2 d3 hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput hsalign hdalign hover
+    hwin hdov hdval hcode
+  have hd : (walkInitEmptyFailNotListFailShortLongCode base).Disjoint
+      ((walkInitShortSuccessJumpCode base).union
+        ((schemaCursorInitCode (base + 172)).union
+          ((schemaCR (base + 172 + 4) .x8 (successFieldSpecs d0 d1 d2 d3)).union
+            (successStatusReturnCode
+              ((base + 172 + 4) + BitVec.ofNat 64
+                (schemaSize (successFieldSpecs d0 d1 d2 d3))))))) := by
+    exact walkInitEmptyFailNotListFailShortLongCode_disjoint_shortSuccessTail base
+      (successFieldSpecs d0 d1 d2 d3) hcode
+  let F := schemaWalkInitFrame outBase
+  let emptyPost : Assertion :=
+    (walkInitEmptyFailStatusPost listLen raVal **
+      ((.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion inputBase input)) ** F
+  let notListPost : Assertion :=
+    walkInitPrefixNotListFailStatusPost inputBase listLen raVal input 0 hoff ** F
+  let shortPost : Assertion :=
+    walkInitShortListCandidatePost inputBase listLen raVal input 0 hoff ** F
+  let longPost : Assertion :=
+    walkInitLongListCandidatePost inputBase listLen raVal input 0 hoff ** F
+  have hexits : br.exits =
+      [(failStatusReturnExit raVal, emptyPost), (failStatusReturnExit raVal, notListPost)] ++
+        (base + 124, shortPost) :: [(base + 28, longPost)] := by
+    dsimp [br, F, emptyPost, notListPost, shortPost, longPost]
+    rw [walkInitSchemaFrameNBranch_exits]
+    rfl
+  have hlink : WP.Entails shortPost tailCert.pre := by
+    dsimp [tailCert]
+    exact walkInitShortListCandidatePost_schemaWalkInitFrame_entails_walkShortExitPre
+      base inputBase listLen raVal outBase input d0 d1 d2 d3 hoff hc0 hl0 hc1 hl1 haddr hc3
+      hl3 hinput hsalign hdalign hover hwin hdov hdval hcode
+  wp_rv64_nbranch_exit_cert_disjoint_with hd, br,
+    [(failStatusReturnExit raVal, emptyPost), (failStatusReturnExit raVal, notListPost)],
+    hexits, tailCert, hlink
+
+theorem walkInitShortSuccessSchemaNBranch_pre
+    (base inputBase listLen raVal t0Old t1Old outBase : Word)
+    (input d0 d1 d2 d3 : List Byte)
+    (hsalign : inputBase.toNat % 8 = 0) (hoff : 0 < input.length)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdalign : outBase.toNat % 8 = 0)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (hcode : base.toNat + 172 + 4 + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    (walkInitShortSuccessSchemaNBranch base inputBase listLen raVal t0Old t1Old outBase input
+      d0 d1 d2 d3 hsalign hoff hover hwin hdalign hdov hdval hc0 hl0 hc1 hl1 haddr hc3
+      hl3 hinput hcode).pre =
+      ((walkInitEmptyFailStatusPre listLen raVal (inputBase + BitVec.ofNat 64 0) **
+        (.x5 ↦ᵣ t0Old) ** (.x6 ↦ᵣ t1Old) ** bytesRegion inputBase input) **
+        schemaWalkInitFrame outBase) := by
+  unfold walkInitShortSuccessSchemaNBranch
+  rfl
+
+end WithdrawalDecode
+
+end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeShortWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeShortWP.lean
@@ -129,6 +129,9 @@ theorem walkInitEmptyFailNotListFailShortLongCode_disjoint_shortSuccessTail
     (walkInitEmptyFailNotListFailShortLongCode_disjoint_shortSuccessJump base)
     (walkInitEmptyFailNotListFailShortLongCode_disjoint_schemaTail base specs hcode)
 
+attribute [rv64_wp_disjoint]
+  walkInitEmptyFailNotListFailShortLongCode_disjoint_shortSuccessTail
+
 theorem walkInitSchemaFrameNBranch_exits
     (base inputBase listLen raVal t0Old t1Old outBase : Word)
     (input : List Byte) (hoff : 0 < input.length)
@@ -201,15 +204,6 @@ def walkInitShortSuccessSchemaNBranch
   let tailCert := successFieldSpecsReturnAbiCertOfInputFromWalkShortExit base inputBase outBase
     raVal input d0 d1 d2 d3 hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput hsalign hdalign hover
     hwin hdov hdval hcode
-  have hd : (walkInitEmptyFailNotListFailShortLongCode base).Disjoint
-      ((walkInitShortSuccessJumpCode base).union
-        ((schemaCursorInitCode (base + 172)).union
-          ((schemaCR (base + 172 + 4) .x8 (successFieldSpecs d0 d1 d2 d3)).union
-            (successStatusReturnCode
-              ((base + 172 + 4) + BitVec.ofNat 64
-                (schemaSize (successFieldSpecs d0 d1 d2 d3))))))) := by
-    exact walkInitEmptyFailNotListFailShortLongCode_disjoint_shortSuccessTail base
-      (successFieldSpecs d0 d1 d2 d3) hcode
   let F := schemaWalkInitFrame outBase
   let emptyPost : Assertion :=
     (walkInitEmptyFailStatusPost listLen raVal **
@@ -228,12 +222,7 @@ def walkInitShortSuccessSchemaNBranch
     dsimp [br, F, emptyPost, notListPost, shortPost, longPost]
     rw [walkInitSchemaFrameNBranch_exits]
     rfl
-  have hlink : WP.Entails shortPost tailCert.pre := by
-    dsimp [tailCert]
-    exact walkInitShortListCandidatePost_schemaWalkInitFrame_entails_walkShortExitPre
-      base inputBase listLen raVal outBase input d0 d1 d2 d3 hoff hc0 hl0 hc1 hl1 haddr hc3
-      hl3 hinput hsalign hdalign hover hwin hdov hdval hcode
-  wp_rv64_nbranch_third_cert_disjoint_with hd, br, hexits, tailCert, hlink
+  wp_rv64_nbranch_third_cert_auto br, hexits, tailCert
 
 theorem walkInitShortSuccessSchemaNBranch_pre
     (base inputBase listLen raVal t0Old t1Old outBase : Word)

--- a/EvmAsm/Rv64/RLP/WithdrawalDecodeShortWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalDecodeShortWP.lean
@@ -221,8 +221,10 @@ def walkInitShortSuccessSchemaNBranch
   let longPost : Assertion :=
     walkInitLongListCandidatePost inputBase listLen raVal input 0 hoff ** F
   have hexits : br.exits =
-      [(failStatusReturnExit raVal, emptyPost), (failStatusReturnExit raVal, notListPost)] ++
-        (base + 124, shortPost) :: [(base + 28, longPost)] := by
+      [(failStatusReturnExit raVal, emptyPost),
+        (failStatusReturnExit raVal, notListPost),
+        (base + 124, shortPost),
+        (base + 28, longPost)] := by
     dsimp [br, F, emptyPost, notListPost, shortPost, longPost]
     rw [walkInitSchemaFrameNBranch_exits]
     rfl
@@ -231,9 +233,7 @@ def walkInitShortSuccessSchemaNBranch
     exact walkInitShortListCandidatePost_schemaWalkInitFrame_entails_walkShortExitPre
       base inputBase listLen raVal outBase input d0 d1 d2 d3 hoff hc0 hl0 hc1 hl1 haddr hc3
       hl3 hinput hsalign hdalign hover hwin hdov hdval hcode
-  wp_rv64_nbranch_exit_cert_disjoint_with hd, br,
-    [(failStatusReturnExit raVal, emptyPost), (failStatusReturnExit raVal, notListPost)],
-    hexits, tailCert, hlink
+  wp_rv64_nbranch_third_cert_disjoint_with hd, br, hexits, tailCert, hlink
 
 theorem walkInitShortSuccessSchemaNBranch_pre
     (base inputBase listLen raVal t0Old t1Old outBase : Word)

--- a/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
@@ -204,6 +204,85 @@ theorem decodeWithdrawal_eq_some_of_successFieldSpecs_input
   rw [hinput]
   exact decodeWithdrawal_encode_successFieldSpecs d0 d1 d2 d3 hc0 hl0 hc1 hl1 haddr hc3 hl3
 
+/-- Result-free predicate saying that `input` is the canonical encoded withdrawal
+    success schema for some four field byte strings.  It intentionally carries no
+    decoded `Withdrawal` value. -/
+def successFieldSpecsInput (input : List Byte) : Prop :=
+  ∃ d0 d1 d2 d3 : List Byte,
+    input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3)))
+      ∧ d0.headD 1 ≠ 0 ∧ d0.length ≤ 8
+      ∧ d1.headD 1 ≠ 0 ∧ d1.length ≤ 8
+      ∧ d2.length = 20
+      ∧ d3.headD 1 ≠ 0 ∧ d3.length ≤ 8
+
+/-- Any successful pure withdrawal decode exposes exactly the result-free success
+    schema encoding for its four byte fields.  This is the reverse bridge needed
+    by WP callers that case-split on `decodeWithdrawal input`, without putting
+    the decoded value into the static schema. -/
+theorem successFieldSpecs_input_of_decodeWithdrawal_eq_some
+    (input : List Byte) (w : Withdrawal)
+    (hdec : decodeWithdrawal input = some w) :
+    ∃ d0 d1 d2 d3 : List Byte,
+      input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3)))
+        ∧ d0.headD 1 ≠ 0 ∧ d0.length ≤ 8
+        ∧ d1.headD 1 ≠ 0 ∧ d1.length ≤ 8
+        ∧ d2.length = 20
+        ∧ d3.headD 1 ≠ 0 ∧ d3.length ≤ 8
+        ∧ w = fromFieldBytes d0 d1 d2 d3 := by
+  rcases (decodeWithdrawal_eq_some_iff input w).mp hdec with
+    ⟨d0, d1, d2, d3, hfull, hc0, hl0, hc1, hl1, haddr, hc3, hl3, hi, hv, ha, hamt⟩
+  have hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))) := by
+    have hbound := encode_successFieldSpecs_length_lt_256_pow_8 d0 d1 d2 d3 hl0 hl1 haddr hl3
+    exact (decodeFully_eq_encode input (.list (schemaItems (successFieldSpecs d0 d1 d2 d3)))
+      hbound).mp (by simpa [schemaItems, successFieldSpecs] using hfull)
+  have hw : w = fromFieldBytes d0 d1 d2 d3 := by
+    cases w
+    simp [fromFieldBytes] at hi hv ha hamt ⊢
+    exact ⟨hi, hv, ha, hamt⟩
+  exact ⟨d0, d1, d2, d3, hinput, hc0, hl0, hc1, hl1, haddr, hc3, hl3, hw⟩
+
+/-- Success of the pure decoder is equivalent to the existence of canonical
+    field-byte witnesses whose result-free schema encoding is the input and
+    whose bytes compute the returned value. -/
+theorem decodeWithdrawal_eq_some_iff_successFieldSpecs_input
+    (input : List Byte) (w : Withdrawal) :
+    decodeWithdrawal input = some w ↔
+      ∃ d0 d1 d2 d3 : List Byte,
+        input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3)))
+          ∧ d0.headD 1 ≠ 0 ∧ d0.length ≤ 8
+          ∧ d1.headD 1 ≠ 0 ∧ d1.length ≤ 8
+          ∧ d2.length = 20
+          ∧ d3.headD 1 ≠ 0 ∧ d3.length ≤ 8
+          ∧ w = fromFieldBytes d0 d1 d2 d3 := by
+  constructor
+  · exact successFieldSpecs_input_of_decodeWithdrawal_eq_some input w
+  · rintro ⟨d0, d1, d2, d3, hinput, hc0, hl0, hc1, hl1, haddr, hc3, hl3, hw⟩
+    rw [hw]
+    exact decodeWithdrawal_eq_some_of_successFieldSpecs_input input d0 d1 d2 d3
+      hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput
+
+/-- Failure is reason-erased: the pure decoder fails exactly when the input is not
+    any canonical success-schema encoding. -/
+theorem decodeWithdrawal_eq_none_iff_not_successFieldSpecsInput
+    (input : List Byte) :
+    decodeWithdrawal input = none ↔ ¬ successFieldSpecsInput input := by
+  constructor
+  · intro hnone hsucc
+    rcases hsucc with
+      ⟨d0, d1, d2, d3, hinput, hc0, hl0, hc1, hl1, haddr, hc3, hl3⟩
+    have hsome := decodeWithdrawal_eq_some_of_successFieldSpecs_input input d0 d1 d2 d3
+      hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput
+    rw [hnone] at hsome
+    contradiction
+  · intro hnot
+    cases hdec : decodeWithdrawal input with
+    | none => rfl
+    | some w =>
+        exfalso
+        rcases successFieldSpecs_input_of_decodeWithdrawal_eq_some input w hdec with
+          ⟨d0, d1, d2, d3, hinput, hc0, hl0, hc1, hl1, haddr, hc3, hl3, _hw⟩
+        exact hnot ⟨d0, d1, d2, d3, hinput, hc0, hl0, hc1, hl1, haddr, hc3, hl3⟩
+
 private theorem exists_eq_list_of_length_eq_20 (d : List Byte) (h : d.length = 20) :
     ∃ b0 b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 : Byte,
       d = [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9,

--- a/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
@@ -189,6 +189,52 @@ theorem decodeWithdrawal_eq_some_of_successFieldSpecs_input
   rw [hinput]
   exact decodeWithdrawal_encode_successFieldSpecs d0 d1 d2 d3 hc0 hl0 hc1 hl1 haddr hc3 hl3
 
+private theorem exists_eq_list_of_length_eq_20 (d : List Byte) (h : d.length = 20) :
+    ∃ b0 b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 : Byte,
+      d = [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9,
+        b10, b11, b12, b13, b14, b15, b16, b17, b18, b19] := by
+  rcases d with _ | ⟨b0, d⟩; · simp at h
+  rcases d with _ | ⟨b1, d⟩; · simp at h
+  rcases d with _ | ⟨b2, d⟩; · simp at h
+  rcases d with _ | ⟨b3, d⟩; · simp at h
+  rcases d with _ | ⟨b4, d⟩; · simp at h
+  rcases d with _ | ⟨b5, d⟩; · simp at h
+  rcases d with _ | ⟨b6, d⟩; · simp at h
+  rcases d with _ | ⟨b7, d⟩; · simp at h
+  rcases d with _ | ⟨b8, d⟩; · simp at h
+  rcases d with _ | ⟨b9, d⟩; · simp at h
+  rcases d with _ | ⟨b10, d⟩; · simp at h
+  rcases d with _ | ⟨b11, d⟩; · simp at h
+  rcases d with _ | ⟨b12, d⟩; · simp at h
+  rcases d with _ | ⟨b13, d⟩; · simp at h
+  rcases d with _ | ⟨b14, d⟩; · simp at h
+  rcases d with _ | ⟨b15, d⟩; · simp at h
+  rcases d with _ | ⟨b16, d⟩; · simp at h
+  rcases d with _ | ⟨b17, d⟩; · simp at h
+  rcases d with _ | ⟨b18, d⟩; · simp at h
+  rcases d with _ | ⟨b19, d⟩; · simp at h
+  rcases d with _ | ⟨_b20, _d⟩
+  · exact ⟨b0, b1, b2, b3, b4, b5, b6, b7, b8, b9,
+      b10, b11, b12, b13, b14, b15, b16, b17, b18, b19, rfl⟩
+  · simp at h
+
+local macro "withdrawal_schema_output_norm" : tactic =>
+  `(tactic| (simp [schemaOut, fieldUpdate, successFieldSpecs, outputSize, successBytes,
+      fromFieldBytes, u64LEBytes, spillRange, copyRangeGen, getByteAt, addressBEBytes,
+      Nat.fromBytesBE] <;> bv_omega))
+
+/-- The successful schema field walk writes exactly the ABI success bytes when
+    started from a zeroed output struct.  This hides the field-update fold from
+    callers: generated WP proofs can target the semantic postcondition directly. -/
+theorem successFieldSpecs_schemaOut_zeroed_eq_successBytes
+    (d0 d1 d2 d3 : List Byte) (haddr : d2.length = 20) :
+    schemaOut (List.replicate outputSize (0 : Byte)) (successFieldSpecs d0 d1 d2 d3) =
+      successBytes (fromFieldBytes d0 d1 d2 d3) := by
+  obtain ⟨b0, b1, b2, b3, b4, b5, b6, b7, b8, b9,
+    b10, b11, b12, b13, b14, b15, b16, b17, b18, b19, rfl⟩ :=
+    exists_eq_list_of_length_eq_20 d2 haddr
+  withdrawal_schema_output_norm
+
 /-- WP certificate for the successful withdrawal field walk, built from the four
     field byte witnesses plus one payload concatenation fact.  This is the
     withdrawal-specialized entry point to the generic schema WP fold. -/
@@ -237,6 +283,65 @@ theorem successFieldSpecsStepCertOfConcat_pre
     (successFieldSpecsStepCertOfConcat base regionBase outBase rOut bs tail outBytes d0 d1 d2 d3 O
       hout hc0 hl0 hc1 hl1 haddr hc3 hl3 hconcat halign hdalign hover hwin hdov hdval hcode).pre =
       schemaINV regionBase outBase rOut bs O outBytes := by
+  rfl
+
+/-- Success-path schema WP certificate whose postcondition is already the
+    semantic ABI byte layout.  The only output-side precondition is the static
+    zeroed 48-byte output struct; the raw `schemaOut` fold is discharged by
+    `successFieldSpecs_schemaOut_zeroed_eq_successBytes`. -/
+def successFieldSpecsStepSuccessBytesCertOfConcat
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs tail d0 d1 d2 d3 : List Byte) (O : Nat)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hconcat : bs.drop O = schemaEncBytes (successFieldSpecs d0 d1 d2 d3) ++ tail)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + schemaSize (successFieldSpecs d0 d1 d2 d3) < 2 ^ 64) :
+    WP.CFG.Cert base (base + BitVec.ofNat 64 (schemaSize (successFieldSpecs d0 d1 d2 d3)))
+      (schemaCR base rOut (successFieldSpecs d0 d1 d2 d3))
+      (schemaINV regionBase outBase rOut bs (O + schemaEnc (successFieldSpecs d0 d1 d2 d3))
+        (successBytes (fromFieldBytes d0 d1 d2 d3))) := by
+  let outBytes := List.replicate outputSize (0 : Byte)
+  have hout : outBytes.length = outputSize := by
+    simp [outBytes]
+  have hdov' : outBase.toNat + outBytes.length < 2 ^ 64 := by
+    simpa [outBytes, outputSize] using hdov
+  have hdval' : ∀ i, i < outBytes.length →
+      isValidByteAccess (outBase + BitVec.ofNat 64 i) = true := by
+    intro i hi
+    exact hdval i (by simpa [outBytes, outputSize] using hi)
+  have cert := successFieldSpecsStepCertOfConcat base regionBase outBase rOut bs tail outBytes
+    d0 d1 d2 d3 O hout hc0 hl0 hc1 hl1 haddr hc3 hl3 hconcat halign hdalign hover hwin
+    hdov' hdval' hcode
+  exact cert.weakenPost (by
+    intro h hp
+    rw [← successFieldSpecs_schemaOut_zeroed_eq_successBytes d0 d1 d2 d3 haddr]
+    simpa [outBytes] using hp)
+
+/-- The success-bytes wrapper computes the zeroed-output schema invariant as its WP precondition. -/
+theorem successFieldSpecsStepSuccessBytesCertOfConcat_pre
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs tail d0 d1 d2 d3 : List Byte) (O : Nat)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hconcat : bs.drop O = schemaEncBytes (successFieldSpecs d0 d1 d2 d3) ++ tail)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + schemaSize (successFieldSpecs d0 d1 d2 d3) < 2 ^ 64) :
+    (successFieldSpecsStepSuccessBytesCertOfConcat base regionBase outBase rOut bs tail d0 d1 d2
+      d3 O hc0 hl0 hc1 hl1 haddr hc3 hl3 hconcat halign hdalign hover hwin hdov hdval hcode).pre =
+      schemaINV regionBase outBase rOut bs O (List.replicate outputSize (0 : Byte)) := by
   rfl
 
 end WithdrawalDecode

--- a/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
@@ -137,7 +137,7 @@ private theorem encode_bytes_length_le_21_of_length_eq_20 (d : List Byte) (h : d
           simp [htail]
           omega
 
-private theorem schemaEncBytes_successFieldSpecs_length_le_48
+theorem schemaEncBytes_successFieldSpecs_length_le_48
     (d0 d1 d2 d3 : List Byte)
     (hl0 : d0.length ≤ 8) (hl1 : d1.length ≤ 8)
     (haddr : d2.length = 20) (hl3 : d3.length ≤ 8) :

--- a/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
@@ -11,6 +11,7 @@ import EvmAsm.Rv64.RLP.WithdrawalDecode
 import EvmAsm.Rv64.RLP.SchemaWP
 import EvmAsm.Rv64.RLP.SchemaFoldConcat
 import EvmAsm.Rv64.RLP.SchemaListEncode
+import EvmAsm.Rv64.Tactics.DropPure
 
 namespace EvmAsm.Rv64.RLP
 
@@ -645,6 +646,15 @@ theorem schemaCursorInitCode_none_above (base a : Word)
     have := congrArg BitVec.toNat h_eq
     omega)
 
+theorem schemaCursorInitCode_none_below (base a : Word)
+    (h : a.toNat < base.toNat) :
+    schemaCursorInitCode base a = none := by
+  unfold schemaCursorInitCode
+  exact CodeReq.singleton_miss (by
+    intro h_eq
+    have := congrArg BitVec.toNat h_eq
+    omega)
+
 theorem schemaCursorInitCode_disjoint_schemaCR
     (base : Word) (rOut : Reg) (specs : List FieldSpec)
     (hcode : base.toNat + 4 + schemaSize specs < 2 ^ 64) :
@@ -688,6 +698,71 @@ theorem schemaCursorInitCode_disjoint_successReturnTail
   · exact schemaCursorInitCode_disjoint_successStatusReturnCode base
       ((base + 4) + BitVec.ofNat 64 (schemaSize specs)) (by rw [hret]; omega)
       (by rw [hret]; omega)
+
+theorem schemaCursorInitSuccessReturnTail_none_below
+    (base : Word) (rOut : Reg) (specs : List FieldSpec) (a : Word)
+    (hcode : base.toNat + 4 + schemaSize specs + 8 < 2 ^ 64)
+    (hlt : a.toNat < base.toNat) :
+    ((schemaCursorInitCode base).union
+      ((schemaCR (base + 4) rOut specs).union
+        (successStatusReturnCode
+          ((base + 4) + BitVec.ofNat 64 (schemaSize specs))))) a = none := by
+  have hbase4 : (base + 4).toNat = base.toNat + 4 := by
+    bv_omega
+  have hret : ((base + 4) + BitVec.ofNat 64 (schemaSize specs)).toNat =
+      base.toNat + 4 + schemaSize specs := by
+    bv_omega
+  have h0 : schemaCursorInitCode base a = none :=
+    schemaCursorInitCode_none_below base a hlt
+  have hschema : schemaCR (base + 4) rOut specs a = none :=
+    schemaCR_none_below rOut specs (base + 4) a (by rw [hbase4]; omega)
+      (by rw [hbase4]; omega)
+  have hstatus : successStatusReturnCode ((base + 4) + BitVec.ofNat 64 (schemaSize specs)) a = none := by
+    unfold successStatusReturnCode
+    exact statusReturnCode_none_below ((base + 4) + BitVec.ofNat 64 (schemaSize specs))
+      (0 : Word) a (by rw [hret]; omega) (by rw [hret]; omega)
+  simp only [CodeReq.union, h0]
+  rw [hschema]
+  exact hstatus
+
+/-- Free landing-pad jump used to move the walk-init short-list success exit out
+    of the classifier code range before running generated schema code. -/
+def walkInitShortSuccessJumpCode (base : Word) : CodeReq :=
+  CodeReq.singleton (base + 124) (.JAL .x0 (48 : BitVec 21))
+
+theorem walkInitShortSuccessJumpCode_disjoint_successReturnTail
+    (base : Word) (rOut : Reg) (specs : List FieldSpec)
+    (hcode : base.toNat + 172 + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    (walkInitShortSuccessJumpCode base).Disjoint
+      ((schemaCursorInitCode (base + 172)).union
+        ((schemaCR (base + 172 + 4) rOut specs).union
+          (successStatusReturnCode
+            ((base + 172 + 4) + BitVec.ofNat 64 (schemaSize specs))))) := by
+  have hbase172 : (base + 172).toNat = base.toNat + 172 := by
+    bv_omega
+  refine codeReq_disjoint_of_ranges _ _ (base.toNat + 172) ?_ ?_
+  · intro a ha
+    unfold walkInitShortSuccessJumpCode
+    exact CodeReq.singleton_miss (by
+      intro h_eq
+      have := congrArg BitVec.toNat h_eq
+      bv_omega)
+  · intro a ha
+    exact schemaCursorInitSuccessReturnTail_none_below (base + 172) rOut specs a
+      (by rw [hbase172]; omega) (by rw [hbase172]; exact ha)
+
+/-- Extra resources a walk-init success candidate must carry in order to hand off
+    to the generated schema WP code.  The output buffer is intentionally fixed
+    to zeros because the current schema certificate proves updates from a zeroed
+    ABI result struct. -/
+def schemaWalkInitFrame (outBase : Word) : Assertion :=
+  ((.x8 ↦ᵣ outBase) ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 **
+    regOwn .x15 ** bytesRegion outBase (List.replicate outputSize (0 : Byte)))
+
+theorem schemaWalkInitFrame_pcFree (outBase : Word) :
+    (schemaWalkInitFrame outBase).pcFree := by
+  unfold schemaWalkInitFrame
+  pcFree
 
 /-- Automated success-path WP certificate: a generated field-schema walk followed
     by the success return shim. The schema remains result-free; the decoded
@@ -902,6 +977,208 @@ theorem successFieldSpecsReturnAbiCertOfInputFromListStart_pre
         (List.replicate outputSize (0 : Byte)) := by
   unfold successFieldSpecsReturnAbiCertOfInputFromListStart
   rfl
+
+/-- The same list-start success cert, preserving the `x6 = 0xf8` scratch value
+    produced by the short-list classifier. This is the exact tail shape needed
+    when composing from `walkInitShortListCandidatePost`. -/
+def successFieldSpecsReturnAbiCertOfInputFromListStartF8
+    (base regionBase outBase raVal : Word)
+    (bs d0 d1 d2 d3 : List Byte)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : bs = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + 4 + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    WP.CFG.Cert base (successStatusReturnExit raVal)
+      ((schemaCursorInitCode base).union
+        ((schemaCR (base + 4) .x8 (successFieldSpecs d0 d1 d2 d3)).union
+          (successStatusReturnCode
+            ((base + 4) + BitVec.ofNat 64 (schemaSize (successFieldSpecs d0 d1 d2 d3))))))
+      ((abiPost regionBase outBase raVal bs **
+        successSchemaReturnFrame regionBase outBase
+          (1 + schemaEnc (successFieldSpecs d0 d1 d2 d3))) **
+        (.x6 ↦ᵣ (0xf8 : Word))) :=
+  (successFieldSpecsReturnAbiCertOfInputFromListStart base regionBase outBase raVal bs
+    d0 d1 d2 d3 hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput halign hdalign hover hwin hdov
+    hdval hcode).frameR (.x6 ↦ᵣ (0xf8 : Word)) (by pcFree)
+
+theorem successFieldSpecsReturnAbiCertOfInputFromListStartF8_pre
+    (base regionBase outBase raVal : Word)
+    (bs d0 d1 d2 d3 : List Byte)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : bs = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + 4 + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    (successFieldSpecsReturnAbiCertOfInputFromListStartF8 base regionBase outBase raVal bs
+      d0 d1 d2 d3 hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput halign hdalign hover hwin hdov
+      hdval hcode).pre =
+      (schemaCursorInitPre regionBase outBase raVal bs 0
+        (List.replicate outputSize (0 : Byte)) ** (.x6 ↦ᵣ (0xf8 : Word))) := by
+  unfold successFieldSpecsReturnAbiCertOfInputFromListStartF8
+  change ((successFieldSpecsReturnAbiCertOfInputFromListStart base regionBase outBase raVal bs
+      d0 d1 d2 d3 hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput halign hdalign hover hwin hdov
+      hdval hcode).pre ** (.x6 ↦ᵣ (0xf8 : Word))) =
+    (schemaCursorInitPre regionBase outBase raVal bs 0
+      (List.replicate outputSize (0 : Byte)) ** (.x6 ↦ᵣ (0xf8 : Word)))
+  rw [successFieldSpecsReturnAbiCertOfInputFromListStart_pre]
+
+/-- Short-list success continuation from the walk-init success label.  The label
+    at `base + 124` contains only a jump island; generated schema code starts at
+    `base + 172`, after the classifier/failure-return code range. -/
+def successFieldSpecsReturnAbiCertOfInputFromWalkShortExit
+    (base regionBase outBase raVal : Word)
+    (bs d0 d1 d2 d3 : List Byte)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : bs = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + 172 + 4 + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    WP.CFG.Cert (base + 124) (successStatusReturnExit raVal)
+      ((walkInitShortSuccessJumpCode base).union
+        ((schemaCursorInitCode (base + 172)).union
+          ((schemaCR (base + 172 + 4) .x8 (successFieldSpecs d0 d1 d2 d3)).union
+            (successStatusReturnCode
+              ((base + 172 + 4) + BitVec.ofNat 64
+                (schemaSize (successFieldSpecs d0 d1 d2 d3)))))))
+      ((abiPost regionBase outBase raVal bs **
+        successSchemaReturnFrame regionBase outBase
+          (1 + schemaEnc (successFieldSpecs d0 d1 d2 d3))) **
+        (.x6 ↦ᵣ (0xf8 : Word))) := by
+  let specs := successFieldSpecs d0 d1 d2 d3
+  let tailBase : Word := base + 172
+  let tailPre : Assertion :=
+    schemaCursorInitPre regionBase outBase raVal bs 0
+      (List.replicate outputSize (0 : Byte)) ** (.x6 ↦ᵣ (0xf8 : Word))
+  have htailCode : tailBase.toNat + 4 + schemaSize specs + 8 < 2 ^ 64 := by
+    have hbase172 : tailBase.toNat = base.toNat + 172 := by
+      dsimp [tailBase]
+      bv_omega
+    rw [hbase172]
+    dsimp [specs] at hcode ⊢
+    omega
+  let tail := successFieldSpecsReturnAbiCertOfInputFromListStartF8 tailBase regionBase outBase
+    raVal bs d0 d1 d2 d3 hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput halign hdalign hover hwin
+    hdov hdval htailCode
+  have hjal := jal_x0_spec_gen_within (48 : BitVec 21) (base + 124)
+  have htarget : (base + 124) + signExtend21 (48 : BitVec 21) = tailBase := by
+    dsimp [tailBase]
+    simp [signExtend21]
+    bv_omega
+  rw [htarget] at hjal
+  let jump := (WP.CFG.block (WP.Entails.refl _) hjal).frameR tailPre (by
+    dsimp [tailPre]
+    unfold schemaCursorInitPre schemaCursorInitRestNoX13
+    pcFree)
+  have hd : (walkInitShortSuccessJumpCode base).Disjoint
+      ((schemaCursorInitCode tailBase).union
+        ((schemaCR (tailBase + 4) .x8 specs).union
+          (successStatusReturnCode
+            ((tailBase + 4) + BitVec.ofNat 64 (schemaSize specs))))) := by
+    dsimp [tailBase, specs]
+    exact walkInitShortSuccessJumpCode_disjoint_successReturnTail base .x8
+      (successFieldSpecs d0 d1 d2 d3) (by simpa [Nat.add_assoc] using hcode)
+  exact WP.CFG.seqDisjoint hd jump.sound tail (by
+    intro h hp
+    dsimp [tailPre] at hp
+    rw [successFieldSpecsReturnAbiCertOfInputFromListStartF8_pre]
+    simpa [sepConj_emp_left'] using hp)
+
+theorem successFieldSpecsReturnAbiCertOfInputFromWalkShortExit_pre
+    (base regionBase outBase raVal : Word)
+    (bs d0 d1 d2 d3 : List Byte)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : bs = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + 172 + 4 + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    (successFieldSpecsReturnAbiCertOfInputFromWalkShortExit base regionBase outBase raVal bs
+      d0 d1 d2 d3 hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput halign hdalign hover hwin hdov
+      hdval hcode).pre =
+      (empAssertion **
+        (schemaCursorInitPre regionBase outBase raVal bs 0
+          (List.replicate outputSize (0 : Byte)) ** (.x6 ↦ᵣ (0xf8 : Word)))) := by
+  unfold successFieldSpecsReturnAbiCertOfInputFromWalkShortExit
+  rfl
+
+/-- Link proof from the raw short-list classifier post, framed with the schema
+    handoff resources, to the F8-framed generated success tail precondition. -/
+theorem walkInitShortListCandidatePost_schemaWalkInitFrame_entails_tailPre
+    (inputBase listLen raVal outBase : Word) (input : List Byte)
+    (hoff : 0 < input.length) :
+    WP.Entails
+      (walkInitShortListCandidatePost inputBase listLen raVal input 0 hoff **
+        schemaWalkInitFrame outBase)
+      (schemaCursorInitPre inputBase outBase raVal input 0
+        (List.replicate outputSize (0 : Byte)) ** (.x6 ↦ᵣ (0xf8 : Word))) := by
+  intro h hp
+  unfold walkInitShortListCandidatePost walkInitPrefixF8Post schemaWalkInitFrame at hp
+  unfold schemaCursorInitPre schemaCursorInitRestNoX13
+  drop_pure hp
+  let pfx : Word := walkInitPrefixWord input 0 hoff
+  let endPtr : Word := (inputBase + BitVec.ofNat 64 0) + listLen
+  change
+    (((((.x10 ↦ᵣ (inputBase + BitVec.ofNat 64 0)) **
+        (((regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x11) **
+          (regOwn .x12) ** (regOwn .x14) ** (regOwn .x15) ** bytesRegion inputBase input) **
+         ((.x8 ↦ᵣ outBase) ** bytesRegion outBase (List.replicate outputSize (0 : Byte))) **
+         (.x1 ↦ᵣ raVal))) ** regOwn .x13) ** (.x6 ↦ᵣ (0xf8 : Word))) h)
+  have w1 := sepConj_mono_left (regIs_to_regOwn .x11 endPtr) h hp
+  have w2 := sepConj_mono_right
+    (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x5 pfx))) h w1
+  xperm_hyp w2
+
+/-- The same link, targeting the computed precondition of the jump-island short
+    success continuation. -/
+theorem walkInitShortListCandidatePost_schemaWalkInitFrame_entails_walkShortExitPre
+    (base inputBase listLen raVal outBase : Word) (input d0 d1 d2 d3 : List Byte)
+    (hoff : 0 < input.length)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (halign : inputBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : inputBase.toNat + input.length < 2 ^ 64)
+    (hwin : ∀ i, i < input.length → isValidByteAccess (inputBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + 172 + 4 + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    WP.Entails
+      (walkInitShortListCandidatePost inputBase listLen raVal input 0 hoff **
+        schemaWalkInitFrame outBase)
+      (successFieldSpecsReturnAbiCertOfInputFromWalkShortExit base inputBase outBase raVal input
+        d0 d1 d2 d3 hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput halign hdalign hover hwin hdov
+        hdval hcode).pre := by
+  intro h hp
+  rw [successFieldSpecsReturnAbiCertOfInputFromWalkShortExit_pre]
+  have htail := walkInitShortListCandidatePost_schemaWalkInitFrame_entails_tailPre
+    inputBase listLen raVal outBase input hoff h hp
+  exact (sepConj_emp_left h).mpr htail
 
 end WithdrawalDecode
 

--- a/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
@@ -159,6 +159,19 @@ private theorem encode_successFieldSpecs_length_lt_256_pow_8
   simp
   omega
 
+/-- A complete encoded withdrawal success witness exposes the schema payload at
+    offset `1`.  This is the pure input-slicing automation used by the WP
+    wrappers below, so callers do not need to hand-write a concat premise. -/
+theorem successFieldSpecs_concat_of_input
+    (bs d0 d1 d2 d3 : List Byte)
+    (hl0 : d0.length ≤ 8) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20) (hl3 : d3.length ≤ 8)
+    (hinput : bs = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3)))) :
+    bs.drop 1 = schemaEncBytes (successFieldSpecs d0 d1 d2 d3) ++ ([] : List Byte) := by
+  have hpayload := schemaEncBytes_successFieldSpecs_length_le_48 d0 d1 d2 d3 hl0 hl1 haddr hl3
+  have hshort : (schemaEncBytes (successFieldSpecs d0 d1 d2 d3)).length ≤ 55 := by omega
+  exact schemaConcat_of_encoded_list_short bs (successFieldSpecs d0 d1 d2 d3) hshort hinput
+
 /-- The success witness list characterizes the pure withdrawal decoder.  This is
     the semantic bridge used by the ABI postcondition; the static schema still
     contains no decoded result. -/
@@ -286,6 +299,60 @@ theorem successFieldSpecsStepCertOfConcat_pre
       schemaINV regionBase outBase rOut bs O outBytes := by
   rfl
 
+/-- Success-path schema WP certificate for a complete short-list encoded
+    withdrawal input.  This uses the generic `SchemaWP` encoded-list constructor
+    and fixes the payload offset to `1`. -/
+def successFieldSpecsStepCertOfInput
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs outBytes d0 d1 d2 d3 : List Byte)
+    (hout : outBytes.length = outputSize)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : bs = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + schemaSize (successFieldSpecs d0 d1 d2 d3) < 2 ^ 64) :
+    WP.CFG.Cert base (base + BitVec.ofNat 64 (schemaSize (successFieldSpecs d0 d1 d2 d3)))
+      (schemaCR base rOut (successFieldSpecs d0 d1 d2 d3))
+      (schemaINV regionBase outBase rOut bs (1 + schemaEnc (successFieldSpecs d0 d1 d2 d3))
+        (schemaOut outBytes (successFieldSpecs d0 d1 d2 d3))) := by
+  have hcore : ∀ f, f ∈ successFieldSpecs d0 d1 d2 d3 → fieldCoreValid outBytes.length f := by
+    rw [hout]
+    exact successFieldSpecs_coreValid d0 d1 d2 d3 hl0 hl1 haddr hl3
+  have hcanon := successFieldSpecs_schemaCanonical d0 d1 d2 d3 hc0 hc1 hc3
+  have hpayload := schemaEncBytes_successFieldSpecs_length_le_48 d0 d1 d2 d3 hl0 hl1 haddr hl3
+  have hshort : (schemaEncBytes (successFieldSpecs d0 d1 d2 d3)).length ≤ 55 := by omega
+  exact SchemaWP.schemaStepCertOfEncodedListShort base regionBase outBase rOut bs outBytes
+    (successFieldSpecs d0 d1 d2 d3) hcore hcanon hshort hinput halign hdalign hover hwin
+    hdov hdval hcode
+
+/-- The encoded-input schema wrapper computes the initial schema invariant at payload offset `1`. -/
+theorem successFieldSpecsStepCertOfInput_pre
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs outBytes d0 d1 d2 d3 : List Byte)
+    (hout : outBytes.length = outputSize)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : bs = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + schemaSize (successFieldSpecs d0 d1 d2 d3) < 2 ^ 64) :
+    (successFieldSpecsStepCertOfInput base regionBase outBase rOut bs outBytes d0 d1 d2 d3
+      hout hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput halign hdalign hover hwin hdov hdval hcode).pre =
+      schemaINV regionBase outBase rOut bs 1 outBytes := by
+  unfold successFieldSpecsStepCertOfInput
+  rfl
+
 /-- Success-path schema WP certificate whose postcondition is already the
     semantic ABI byte layout.  The only output-side precondition is the static
     zeroed 48-byte output struct; the raw `schemaOut` fold is discharged by
@@ -343,6 +410,62 @@ theorem successFieldSpecsStepSuccessBytesCertOfConcat_pre
     (successFieldSpecsStepSuccessBytesCertOfConcat base regionBase outBase rOut bs tail d0 d1 d2
       d3 O hc0 hl0 hc1 hl1 haddr hc3 hl3 hconcat halign hdalign hover hwin hdov hdval hcode).pre =
       schemaINV regionBase outBase rOut bs O (List.replicate outputSize (0 : Byte)) := by
+  rfl
+
+/-- Encoded-input version of the success-bytes schema WP certificate. -/
+def successFieldSpecsStepSuccessBytesCertOfInput
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs d0 d1 d2 d3 : List Byte)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : bs = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + schemaSize (successFieldSpecs d0 d1 d2 d3) < 2 ^ 64) :
+    WP.CFG.Cert base (base + BitVec.ofNat 64 (schemaSize (successFieldSpecs d0 d1 d2 d3)))
+      (schemaCR base rOut (successFieldSpecs d0 d1 d2 d3))
+      (schemaINV regionBase outBase rOut bs (1 + schemaEnc (successFieldSpecs d0 d1 d2 d3))
+        (successBytes (fromFieldBytes d0 d1 d2 d3))) := by
+  let outBytes := List.replicate outputSize (0 : Byte)
+  have hout : outBytes.length = outputSize := by
+    simp [outBytes]
+  have hdov' : outBase.toNat + outBytes.length < 2 ^ 64 := by
+    simpa [outBytes, outputSize] using hdov
+  have hdval' : ∀ i, i < outBytes.length →
+      isValidByteAccess (outBase + BitVec.ofNat 64 i) = true := by
+    intro i hi
+    exact hdval i (by simpa [outBytes, outputSize] using hi)
+  have cert := successFieldSpecsStepCertOfInput base regionBase outBase rOut bs outBytes
+    d0 d1 d2 d3 hout hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput halign hdalign hover hwin
+    hdov' hdval' hcode
+  exact cert.weakenPost (by
+    intro h hp
+    rw [← successFieldSpecs_schemaOut_zeroed_eq_successBytes d0 d1 d2 d3 haddr]
+    simpa [outBytes] using hp)
+
+/-- The encoded-input success-bytes wrapper computes the zeroed-output schema invariant. -/
+theorem successFieldSpecsStepSuccessBytesCertOfInput_pre
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs d0 d1 d2 d3 : List Byte)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : bs = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + schemaSize (successFieldSpecs d0 d1 d2 d3) < 2 ^ 64) :
+    (successFieldSpecsStepSuccessBytesCertOfInput base regionBase outBase rOut bs d0 d1 d2
+      d3 hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput halign hdalign hover hwin hdov hdval hcode).pre =
+      schemaINV regionBase outBase rOut bs 1 (List.replicate outputSize (0 : Byte)) := by
   rfl
 
 /-- A status-return block rooted at `base` has no code requirements below `base`. -/
@@ -517,6 +640,58 @@ theorem successFieldSpecsReturnAbiCertOfConcat_pre
         (.x1 ↦ᵣ raVal)) := by
   unfold successFieldSpecsReturnAbiCertOfConcat
   rfl
+
+/-- Caller-facing success-path WP certificate for a full short-list-encoded
+    withdrawal.  The schema payload slice is derived from `hinput` internally,
+    leaving only static memory/code facts and the success witnesses as inputs. -/
+def successFieldSpecsReturnAbiCertOfInput
+    (base regionBase outBase raVal : Word)
+    (bs d0 d1 d2 d3 : List Byte)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : bs = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    WP.CFG.Cert base (successStatusReturnExit raVal)
+      ((schemaCR base .x8 (successFieldSpecs d0 d1 d2 d3)).union
+        (successStatusReturnCode
+          (base + BitVec.ofNat 64 (schemaSize (successFieldSpecs d0 d1 d2 d3)))))
+      (abiPost regionBase outBase raVal bs **
+        successSchemaReturnFrame regionBase outBase
+          (1 + schemaEnc (successFieldSpecs d0 d1 d2 d3))) :=
+  successFieldSpecsReturnAbiCertOfConcat base regionBase outBase raVal bs ([] : List Byte)
+    d0 d1 d2 d3 1 hc0 hl0 hc1 hl1 haddr hc3 hl3
+    (successFieldSpecs_concat_of_input bs d0 d1 d2 d3 hl0 hl1 haddr hl3 hinput)
+    hinput halign hdalign hover hwin hdov hdval hcode
+
+/-- The encoded-input success wrapper computes the expected initial precondition:
+    schema invariant at payload offset `1`, plus the preserved return address. -/
+theorem successFieldSpecsReturnAbiCertOfInput_pre
+    (base regionBase outBase raVal : Word)
+    (bs d0 d1 d2 d3 : List Byte)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : bs = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    (successFieldSpecsReturnAbiCertOfInput base regionBase outBase raVal bs d0 d1 d2 d3
+      hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput halign hdalign hover hwin hdov hdval hcode).pre =
+      (schemaINV regionBase outBase .x8 bs 1 (List.replicate outputSize (0 : Byte)) **
+        (.x1 ↦ᵣ raVal)) := by
+  unfold successFieldSpecsReturnAbiCertOfInput
+  rw [successFieldSpecsReturnAbiCertOfConcat_pre]
 
 end WithdrawalDecode
 

--- a/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
@@ -1180,6 +1180,9 @@ theorem walkInitShortListCandidatePost_schemaWalkInitFrame_entails_walkShortExit
     inputBase listLen raVal outBase input hoff h hp
   exact (sepConj_emp_left h).mpr htail
 
+attribute [rv64_wp_entails]
+  walkInitShortListCandidatePost_schemaWalkInitFrame_entails_walkShortExitPre
+
 end WithdrawalDecode
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
@@ -17,6 +17,7 @@ namespace EvmAsm.Rv64.RLP
 open EvmAsm.Rv64
 open EvmAsm.EL
 open EvmAsm.EL.RLP
+open EvmAsm.Rv64.Tactics
 
 namespace WithdrawalDecode
 
@@ -342,6 +343,179 @@ theorem successFieldSpecsStepSuccessBytesCertOfConcat_pre
     (successFieldSpecsStepSuccessBytesCertOfConcat base regionBase outBase rOut bs tail d0 d1 d2
       d3 O hc0 hl0 hc1 hl1 haddr hc3 hl3 hconcat halign hdalign hover hwin hdov hdval hcode).pre =
       schemaINV regionBase outBase rOut bs O (List.replicate outputSize (0 : Byte)) := by
+  rfl
+
+/-- A status-return block rooted at `base` has no code requirements below `base`. -/
+theorem statusReturnCode_none_below (base status a : Word)
+    (hcode : base.toNat + 8 < 2 ^ 64) (hlt : a.toNat < base.toNat) :
+    statusReturnCode base status a = none := by
+  have hne_base : a ≠ base := by
+    intro h
+    have := congrArg BitVec.toNat h
+    omega
+  have hbase_false : (a == base) = false := by
+    rw [Bool.eq_false_iff]
+    intro h
+    rw [beq_iff_eq] at h
+    exact hne_base h
+  have hnext_false : (a == base + 4#64) = false := by
+    rw [Bool.eq_false_iff]
+    intro h
+    rw [beq_iff_eq] at h
+    bv_omega
+  simp [statusReturnCode, CodeReq.union, CodeReq.singleton, hbase_false, hnext_false]
+
+/-- The schema walk code range is disjoint from a status-return block placed
+    immediately after it. -/
+theorem schemaCR_disjoint_statusReturnCode (rOut : Reg) (specs : List FieldSpec)
+    (base status : Word)
+    (hcode : base.toNat + schemaSize specs + 8 < 2 ^ 64) :
+    (schemaCR base rOut specs).Disjoint
+      (statusReturnCode (base + BitVec.ofNat 64 (schemaSize specs)) status) := by
+  have hbase : (base + BitVec.ofNat 64 (schemaSize specs)).toNat =
+      base.toNat + schemaSize specs := by
+    bv_omega
+  refine codeReq_disjoint_of_ranges _ _ (base.toNat + schemaSize specs) ?_ ?_
+  · intro a ha
+    exact schemaCR_none_above rOut specs base a (by omega) ha
+  · intro a ha
+    exact statusReturnCode_none_below (base + BitVec.ofNat 64 (schemaSize specs)) status a
+      (by rw [hbase]; omega) (by rw [hbase]; exact ha)
+
+/-- Success endpoint precondition with the incoming status register abstracted as
+    `regOwn`. Generated schema-walk callers should not need to provide the old
+    status value because the endpoint overwrites it. -/
+def successStatusReturnAbiRegOwnPre
+    (inputBase outBase raVal : Word) (input : List Byte) (w : Withdrawal) : Assertion :=
+  (((.x1 ↦ᵣ raVal) ** successStatusReturnAbiFrame inputBase outBase input w) ** regOwn .x10)
+
+/-- ABI-facing success endpoint that consumes `regOwn .x10` instead of a
+    concrete old status value. -/
+def successStatusReturnAbiRegOwnCert
+    (base inputBase outBase raVal : Word) (input : List Byte) (w : Withdrawal) :
+    WP.CFG.Cert base (successStatusReturnExit raVal) (successStatusReturnCode base)
+      (abiPost inputBase outBase raVal input) := by
+  exact WP.CFG.block (WP.Entails.refl _)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x10)
+      (P := (.x1 ↦ᵣ raVal) ** successStatusReturnAbiFrame inputBase outBase input w)
+      (by
+        intro statusOld
+        have hs := successStatusReturn_abiPost_spec_within base inputBase outBase raVal statusOld
+          input w
+        exact cpsTripleWithin_weaken (fun h hp => by
+          unfold successStatusReturnAbiPre successStatusReturnPre statusReturnPre
+          xperm_hyp hp) (fun _ hp => hp) hs))
+
+/-- The reg-own success endpoint computes the value-independent ABI precondition. -/
+theorem successStatusReturnAbiRegOwnCert_pre
+    (base inputBase outBase raVal : Word) (input : List Byte) (w : Withdrawal) :
+    (successStatusReturnAbiRegOwnCert base inputBase outBase raVal input w).pre =
+      successStatusReturnAbiRegOwnPre inputBase outBase raVal input w := by
+  rfl
+
+/-- Scratch resources left after the successful schema walk and framed through
+    the status-return endpoint. The output pointer is held in `s0` (`x8`), as
+    established by the withdrawal decoder prologue. -/
+def successSchemaReturnFrame (regionBase outBase : Word) (O : Nat) : Assertion :=
+  ((regOwn .x5) ** (regOwn .x11) ** (regOwn .x12) **
+    (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) ** (regOwn .x14) **
+    (regOwn .x15) ** (.x8 ↦ᵣ outBase))
+
+theorem successSchemaReturnFrame_pcFree
+    (regionBase outBase : Word) (O : Nat) :
+    (successSchemaReturnFrame regionBase outBase O).pcFree := by
+  unfold successSchemaReturnFrame
+  pcFree
+
+/-- Automated success-path WP certificate: a generated field-schema walk followed
+    by the success return shim. The schema remains result-free; the decoded
+    withdrawal appears only through the success witnesses and the ABI post. -/
+def successFieldSpecsReturnAbiCertOfConcat
+    (base regionBase outBase raVal : Word)
+    (bs tail d0 d1 d2 d3 : List Byte) (O : Nat)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hconcat : bs.drop O = schemaEncBytes (successFieldSpecs d0 d1 d2 d3) ++ tail)
+    (hinput : bs = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    WP.CFG.Cert base (successStatusReturnExit raVal)
+      ((schemaCR base .x8 (successFieldSpecs d0 d1 d2 d3)).union
+        (successStatusReturnCode
+          (base + BitVec.ofNat 64 (schemaSize (successFieldSpecs d0 d1 d2 d3)))))
+      (abiPost regionBase outBase raVal bs **
+        successSchemaReturnFrame regionBase outBase
+          (O + schemaEnc (successFieldSpecs d0 d1 d2 d3))) := by
+  let specs := successFieldSpecs d0 d1 d2 d3
+  let w := fromFieldBytes d0 d1 d2 d3
+  have hdec : decodeWithdrawal bs = some w := by
+    exact decodeWithdrawal_eq_some_of_successFieldSpecs_input bs d0 d1 d2 d3
+      hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput
+  have hschemaCode : base.toNat + schemaSize specs < 2 ^ 64 := by
+    dsimp [specs] at hcode ⊢
+    omega
+  have schemaCert := successFieldSpecsStepSuccessBytesCertOfConcat base regionBase outBase .x8
+    bs tail d0 d1 d2 d3 O hc0 hl0 hc1 hl1 haddr hc3 hl3 hconcat halign hdalign hover
+    hwin hdov hdval hschemaCode
+  let schemaWithRa := WP.CFG.frameR schemaCert (.x1 ↦ᵣ raVal) (by pcFree)
+  have schemaStrong :
+      WP.CFG.Cert base (base + BitVec.ofNat 64 (schemaSize specs)) (schemaCR base .x8 specs)
+        (successStatusReturnAbiRegOwnPre regionBase outBase raVal bs w **
+          successSchemaReturnFrame regionBase outBase (O + schemaEnc specs)) := by
+    exact schemaWithRa.weakenPost (by
+      intro h hp
+      unfold schemaINV at hp
+      unfold successStatusReturnAbiRegOwnPre successStatusReturnAbiFrame successSchemaReturnFrame
+      rw [show (⌜decodeWithdrawal bs = some w⌝ : Assertion) = empAssertion by
+        funext h
+        unfold EvmAsm.Rv64.pure EvmAsm.Rv64.empAssertion
+        apply propext
+        constructor
+        · intro h_p
+          exact h_p.1
+        · intro h_empty
+          exact ⟨h_empty, hdec⟩]
+      simp only [sepConj_emp_right']
+      xperm_hyp hp)
+  let retBase := base + BitVec.ofNat 64 (schemaSize specs)
+  let tailCert := (successStatusReturnAbiRegOwnCert retBase regionBase outBase raVal bs w).frameR
+    (successSchemaReturnFrame regionBase outBase (O + schemaEnc specs))
+    (successSchemaReturnFrame_pcFree regionBase outBase (O + schemaEnc specs))
+  have hd : (schemaCR base .x8 specs).Disjoint (successStatusReturnCode retBase) := by
+    dsimp [retBase, specs]
+    exact schemaCR_disjoint_statusReturnCode .x8 (successFieldSpecs d0 d1 d2 d3) base (0 : Word)
+      (by simpa [successStatusReturnCode] using hcode)
+  exact WP.CFG.seqDisjoint hd schemaStrong.sound tailCert (WP.Entails.refl _)
+
+/-- The composed success-path certificate reduces to the initial schema invariant
+    plus the preserved return address; no decoded result appears in the precondition. -/
+theorem successFieldSpecsReturnAbiCertOfConcat_pre
+    (base regionBase outBase raVal : Word)
+    (bs tail d0 d1 d2 d3 : List Byte) (O : Nat)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hconcat : bs.drop O = schemaEncBytes (successFieldSpecs d0 d1 d2 d3) ++ tail)
+    (hinput : bs = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    (successFieldSpecsReturnAbiCertOfConcat base regionBase outBase raVal bs tail d0 d1 d2 d3 O
+      hc0 hl0 hc1 hl1 haddr hc3 hl3 hconcat hinput halign hdalign hover hwin hdov hdval
+      hcode).pre =
+      (schemaINV regionBase outBase .x8 bs O (List.replicate outputSize (0 : Byte)) **
+        (.x1 ↦ᵣ raVal)) := by
+  unfold successFieldSpecsReturnAbiCertOfConcat
   rfl
 
 end WithdrawalDecode

--- a/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
@@ -10,6 +10,7 @@
 import EvmAsm.Rv64.RLP.WithdrawalDecode
 import EvmAsm.Rv64.RLP.SchemaWP
 import EvmAsm.Rv64.RLP.SchemaFoldConcat
+import EvmAsm.Rv64.RLP.SchemaListEncode
 
 namespace EvmAsm.Rv64.RLP
 
@@ -104,6 +105,89 @@ theorem successFieldSpecs_decodes_of_concat
   SchemaWP.schemaDecodes_of_valid_canonical bs (successFieldSpecs d0 d1 d2 d3) O outputSize
     (successFieldSpecs_schemaValid_of_concat bs tail d0 d1 d2 d3 O hl0 hl1 haddr hl3 hconcat)
     (successFieldSpecs_schemaCanonical d0 d1 d2 d3 hc0 hc1 hc3)
+
+private theorem encode_bytes_length_le_9_of_length_le_8 (d : List Byte) (h : d.length ≤ 8) :
+    (encode (.bytes d)).length ≤ 9 := by
+  unfold encode encodeBytes
+  cases d with
+  | nil => simp
+  | cons b tail =>
+      cases tail with
+      | nil =>
+          by_cases hb : b.toNat < 0x80 <;> simp [hb]
+      | cons c tail =>
+          have htail : tail.length ≤ 6 := by simpa using h
+          have hshort : tail.length + 1 + 1 ≤ 55 := by omega
+          simp [hshort]
+          omega
+
+private theorem encode_bytes_length_le_21_of_length_eq_20 (d : List Byte) (h : d.length = 20) :
+    (encode (.bytes d)).length ≤ 21 := by
+  cases d with
+  | nil => simp at h
+  | cons b tail =>
+      cases tail with
+      | nil => simp at h
+      | cons c tail =>
+          simp at h
+          unfold encode encodeBytes
+          have htail : tail.length ≤ 53 := by omega
+          simp [htail]
+          omega
+
+private theorem schemaEncBytes_successFieldSpecs_length_le_48
+    (d0 d1 d2 d3 : List Byte)
+    (hl0 : d0.length ≤ 8) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20) (hl3 : d3.length ≤ 8) :
+    (schemaEncBytes (successFieldSpecs d0 d1 d2 d3)).length ≤ 48 := by
+  have h0 := encode_bytes_length_le_9_of_length_le_8 d0 hl0
+  have h1 := encode_bytes_length_le_9_of_length_le_8 d1 hl1
+  have h2 := encode_bytes_length_le_21_of_length_eq_20 d2 haddr
+  have h3 := encode_bytes_length_le_9_of_length_le_8 d3 hl3
+  simp [schemaEncBytes, successFieldSpecs]
+  omega
+
+private theorem encode_successFieldSpecs_length_lt_256_pow_8
+    (d0 d1 d2 d3 : List Byte)
+    (hl0 : d0.length ≤ 8) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20) (hl3 : d3.length ≤ 8) :
+    (encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3)))).length < 256 ^ 8 := by
+  have hpayload := schemaEncBytes_successFieldSpecs_length_le_48 d0 d1 d2 d3 hl0 hl1 haddr hl3
+  have hshort : (schemaEncBytes (successFieldSpecs d0 d1 d2 d3)).length ≤ 55 := by omega
+  rw [encode_list_schemaItems_short (successFieldSpecs d0 d1 d2 d3) hshort]
+  simp
+  omega
+
+/-- The success witness list characterizes the pure withdrawal decoder.  This is
+    the semantic bridge used by the ABI postcondition; the static schema still
+    contains no decoded result. -/
+theorem decodeWithdrawal_encode_successFieldSpecs
+    (d0 d1 d2 d3 : List Byte)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8) :
+    decodeWithdrawal (encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3)))) =
+      some (fromFieldBytes d0 d1 d2 d3) := by
+  have hfull : decodeFully (encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3)))) =
+      some (.list [.bytes d0, .bytes d1, .bytes d2, .bytes d3]) := by
+    have hsize := encode_successFieldSpecs_length_lt_256_pow_8 d0 d1 d2 d3 hl0 hl1 haddr hl3
+    simpa [schemaItems, successFieldSpecs] using
+      (decodeFully_encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))) hsize)
+  exact decodeWithdrawal_eq_some_of_decodeFully_fields hfull hc0 hl0 hc1 hl1 haddr hc3 hl3
+
+/-- Same bridge as `decodeWithdrawal_encode_successFieldSpecs`, but for callers
+    that carry the encoded-list equality as a hypothesis. -/
+theorem decodeWithdrawal_eq_some_of_successFieldSpecs_input
+    (input d0 d1 d2 d3 : List Byte)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : input = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3)))) :
+    decodeWithdrawal input = some (fromFieldBytes d0 d1 d2 d3) := by
+  rw [hinput]
+  exact decodeWithdrawal_encode_successFieldSpecs d0 d1 d2 d3 hc0 hl0 hc1 hl1 haddr hc3 hl3
 
 /-- WP certificate for the successful withdrawal field walk, built from the four
     field byte witnesses plus one payload concatenation fact.  This is the

--- a/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
@@ -1,0 +1,160 @@
+/-
+  EvmAsm.Rv64.RLP.WithdrawalSchemaWP
+
+  Withdrawal-specific adapters for the generic schema WP calculus.  The static
+  ABI schema in `WithdrawalDecode` remains result-free; this file packages the
+  success-path field byte witnesses into generic `FieldSpec`s and proves the
+  validity/canonicality facts that generated WP proofs can reuse.
+-/
+
+import EvmAsm.Rv64.RLP.WithdrawalDecode
+import EvmAsm.Rv64.RLP.SchemaWP
+import EvmAsm.Rv64.RLP.SchemaFoldConcat
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.EL
+open EvmAsm.EL.RLP
+
+namespace WithdrawalDecode
+
+/-- Success-path field witnesses for `[index, validator_index, address, amount]`.
+    This is not the static schema: the byte lists are postcondition witnesses,
+    while the offsets and field kinds match the result-free ABI layout. -/
+def successFieldSpecs (d0 d1 d2 d3 : List Byte) : List FieldSpec :=
+  [ { isScalar := true, data := d0, di := 0, imm := (0 : BitVec 12) }
+  , { isScalar := true, data := d1, di := 8, imm := (8 : BitVec 12) }
+  , { isScalar := false, data := d2, di := 16, imm := (16 : BitVec 12) }
+  , { isScalar := true, data := d3, di := 40, imm := (40 : BitVec 12) }
+  ]
+
+private theorem headD_ne_zero_schema_guard (d : List Byte) (h : d.headD 1 ≠ 0) :
+    d = [] ∨ ¬ d.head?.getD (BitVec.ofNat 8 1) = BitVec.ofNat 8 0 := by
+  right
+  cases hd : d with
+  | nil => simp
+  | cons b _ =>
+      have hb : b ≠ (0 : Byte) := by simpa [hd] using h
+      simpa [hd] using hb
+
+/-- Canonicality side conditions for the three scalar witnesses. -/
+theorem successFieldSpecs_schemaCanonical
+    (d0 d1 d2 d3 : List Byte)
+    (hc0 : d0.headD 1 ≠ 0) (hc1 : d1.headD 1 ≠ 0) (hc3 : d3.headD 1 ≠ 0) :
+    SchemaWP.SchemaCanonical (successFieldSpecs d0 d1 d2 d3) := by
+  simp [SchemaWP.SchemaCanonical, successFieldSpecs]
+  exact ⟨headD_ne_zero_schema_guard d0 hc0,
+    headD_ne_zero_schema_guard d1 hc1, headD_ne_zero_schema_guard d3 hc3⟩
+
+private theorem encode_bytes_length_lt_256_pow_8_of_length_eq_20 (d : List Byte)
+    (h : d.length = 20) :
+    (encode (.bytes d)).length < 256 ^ 8 := by
+  cases d with
+  | nil => simp at h
+  | cons b tail =>
+      cases tail with
+      | nil => simp at h
+      | cons c tail =>
+          simp at h
+          unfold encode encodeBytes
+          have htail : tail.length ≤ 53 := by omega
+          simp [htail]
+          omega
+
+/-- Core validity for the fixed withdrawal success witness list. -/
+theorem successFieldSpecs_coreValid
+    (d0 d1 d2 d3 : List Byte)
+    (hl0 : d0.length ≤ 8) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20) (hl3 : d3.length ≤ 8) :
+    ∀ f, f ∈ successFieldSpecs d0 d1 d2 d3 → fieldCoreValid outputSize f := by
+  intro f hf
+  simp [successFieldSpecs] at hf
+  rcases hf with rfl | rfl | rfl | rfl
+  · simp [fieldCoreValid, outputSize, fieldWriteLen, hl0]
+    decide
+  · simp [fieldCoreValid, outputSize, fieldWriteLen, hl1]
+    decide
+  · have henc := encode_bytes_length_lt_256_pow_8_of_length_eq_20 d2 haddr
+    simp [fieldCoreValid, outputSize, fieldWriteLen, haddr]
+    exact ⟨henc, by decide⟩
+  · simp [fieldCoreValid, outputSize, fieldWriteLen, hl3]
+    decide
+
+/-- Build the generic `SchemaValid` evidence for a successful withdrawal witness
+    from one concatenation fact over the list payload. -/
+theorem successFieldSpecs_schemaValid_of_concat
+    (bs tail d0 d1 d2 d3 : List Byte) (O : Nat)
+    (hl0 : d0.length ≤ 8) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20) (hl3 : d3.length ≤ 8)
+    (hconcat : bs.drop O = schemaEncBytes (successFieldSpecs d0 d1 d2 d3) ++ tail) :
+    SchemaValid bs outputSize O (successFieldSpecs d0 d1 d2 d3) :=
+  schemaValid_of_concat bs outputSize tail (successFieldSpecs d0 d1 d2 d3) O
+    (successFieldSpecs_coreValid d0 d1 d2 d3 hl0 hl1 haddr hl3) hconcat
+
+/-- One-shot pure decode automation for the four success-path withdrawal fields. -/
+theorem successFieldSpecs_decodes_of_concat
+    (bs tail d0 d1 d2 d3 : List Byte) (O : Nat)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hconcat : bs.drop O = schemaEncBytes (successFieldSpecs d0 d1 d2 d3) ++ tail) :
+    schemaDecodes bs O (successFieldSpecs d0 d1 d2 d3) :=
+  SchemaWP.schemaDecodes_of_valid_canonical bs (successFieldSpecs d0 d1 d2 d3) O outputSize
+    (successFieldSpecs_schemaValid_of_concat bs tail d0 d1 d2 d3 O hl0 hl1 haddr hl3 hconcat)
+    (successFieldSpecs_schemaCanonical d0 d1 d2 d3 hc0 hc1 hc3)
+
+/-- WP certificate for the successful withdrawal field walk, built from the four
+    field byte witnesses plus one payload concatenation fact.  This is the
+    withdrawal-specialized entry point to the generic schema WP fold. -/
+def successFieldSpecsStepCertOfConcat
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs tail outBytes d0 d1 d2 d3 : List Byte) (O : Nat)
+    (hout : outBytes.length = outputSize)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hconcat : bs.drop O = schemaEncBytes (successFieldSpecs d0 d1 d2 d3) ++ tail)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + schemaSize (successFieldSpecs d0 d1 d2 d3) < 2 ^ 64) :
+    WP.CFG.Cert base (base + BitVec.ofNat 64 (schemaSize (successFieldSpecs d0 d1 d2 d3)))
+      (schemaCR base rOut (successFieldSpecs d0 d1 d2 d3))
+      (schemaINV regionBase outBase rOut bs (O + schemaEnc (successFieldSpecs d0 d1 d2 d3))
+        (schemaOut outBytes (successFieldSpecs d0 d1 d2 d3))) := by
+  have hvalid : SchemaValid bs outBytes.length O (successFieldSpecs d0 d1 d2 d3) := by
+    rw [hout]
+    exact successFieldSpecs_schemaValid_of_concat bs tail d0 d1 d2 d3 O hl0 hl1 haddr hl3 hconcat
+  have hcanon := successFieldSpecs_schemaCanonical d0 d1 d2 d3 hc0 hc1 hc3
+  exact SchemaWP.schemaStepCert base regionBase outBase rOut bs O outBytes
+    (successFieldSpecs d0 d1 d2 d3) hvalid hcanon halign hdalign hover hwin hdov hdval hcode
+
+/-- The wrapper above computes exactly the initial schema invariant as its WP precondition. -/
+theorem successFieldSpecsStepCertOfConcat_pre
+    (base regionBase outBase : Word) (rOut : Reg)
+    (bs tail outBytes d0 d1 d2 d3 : List Byte) (O : Nat)
+    (hout : outBytes.length = outputSize)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hconcat : bs.drop O = schemaEncBytes (successFieldSpecs d0 d1 d2 d3) ++ tail)
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outBytes.length < 2 ^ 64)
+    (hdval : ∀ i, i < outBytes.length → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + schemaSize (successFieldSpecs d0 d1 d2 d3) < 2 ^ 64) :
+    (successFieldSpecsStepCertOfConcat base regionBase outBase rOut bs tail outBytes d0 d1 d2 d3 O
+      hout hc0 hl0 hc1 hl1 haddr hc3 hl3 hconcat halign hdalign hover hwin hdov hdval hcode).pre =
+      schemaINV regionBase outBase rOut bs O outBytes := by
+  rfl
+
+end WithdrawalDecode
+
+end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
+++ b/EvmAsm/Rv64/RLP/WithdrawalSchemaWP.lean
@@ -550,6 +550,145 @@ theorem successSchemaReturnFrame_pcFree
   unfold successSchemaReturnFrame
   pcFree
 
+/-- One-instruction bridge from a list value pointer in `x10` to the schema
+    cursor convention (`x13 = inputBase + O + 1`). -/
+def schemaCursorInitCode (base : Word) : CodeReq :=
+  CodeReq.singleton base (.ADDI .x13 .x10 (1 : BitVec 12))
+
+def schemaCursorInitRestNoX13
+    (regionBase outBase raVal : Word) (bs outBytes : List Byte) : Assertion :=
+  (((regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x11) **
+    (regOwn .x12) ** (regOwn .x14) ** (regOwn .x15) ** bytesRegion regionBase bs) **
+   ((.x8 ↦ᵣ outBase) ** bytesRegion outBase outBytes) ** (.x1 ↦ᵣ raVal))
+
+/-- Precondition for `schemaCursorInitCode`: `x10` points at the RLP list value
+    start, `x13` is arbitrary, and the remaining schema resources are owned. -/
+def schemaCursorInitPre
+    (regionBase outBase raVal : Word) (bs : List Byte) (O : Nat)
+    (outBytes : List Byte) : Assertion :=
+  ((.x10 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+    schemaCursorInitRestNoX13 regionBase outBase raVal bs outBytes) ** regOwn .x13
+
+def schemaCursorInitPostRest
+    (regionBase outBase raVal : Word) (bs : List Byte) (O : Nat)
+    (outBytes : List Byte) : Assertion :=
+  (((regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x11) **
+    (regOwn .x12) ** (.x13 ↦ᵣ (regionBase + BitVec.ofNat 64 (O + 1))) **
+    (regOwn .x14) ** (regOwn .x15) ** bytesRegion regionBase bs) **
+   ((.x8 ↦ᵣ outBase) ** bytesRegion outBase outBytes) ** (.x1 ↦ᵣ raVal))
+
+theorem schemaCursorInitPostRest_entails_schemaINV
+    (regionBase outBase raVal : Word) (bs : List Byte) (O : Nat)
+    (outBytes : List Byte) :
+    WP.Entails
+      ((.x10 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+        schemaCursorInitPostRest regionBase outBase raVal bs O outBytes)
+      (schemaINV regionBase outBase .x8 bs (O + 1) outBytes ** (.x1 ↦ᵣ raVal)) := by
+  intro h hp
+  have hpOwn : (regOwn .x10 **
+      schemaCursorInitPostRest regionBase outBase raVal bs O outBytes) h :=
+    sepConj_mono_left (regIs_to_regOwn .x10 (regionBase + BitVec.ofNat 64 O)) h hp
+  unfold schemaCursorInitPostRest at hpOwn
+  unfold schemaINV
+  xperm_hyp hpOwn
+
+/-- WP bridge from `x10 = inputBase + O` to the schema cursor precondition at
+    payload offset `O + 1`.  This is the handoff from the outer-list classifier
+    to generated schema field code. -/
+def schemaCursorInitCert
+    (base regionBase outBase raVal : Word) (bs : List Byte) (O : Nat)
+    (outBytes : List Byte) :
+    WP.CFG.Cert base (base + 4) (schemaCursorInitCode base)
+      (schemaINV regionBase outBase .x8 bs (O + 1) outBytes ** (.x1 ↦ᵣ raVal)) := by
+  have hspec : cpsTripleWithin 1 base (base + 4) (schemaCursorInitCode base)
+      (schemaCursorInitPre regionBase outBase raVal bs O outBytes)
+      ((.x10 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+        schemaCursorInitPostRest regionBase outBase raVal bs O outBytes) := by
+    unfold schemaCursorInitPre schemaCursorInitCode
+    refine cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x13)
+      (P := (.x10 ↦ᵣ (regionBase + BitVec.ofNat 64 O)) **
+        schemaCursorInitRestNoX13 regionBase outBase raVal bs outBytes) ?_
+    intro oldX13
+    have hadd := addi_spec_gen_within .x13 .x10 oldX13
+      (regionBase + BitVec.ofNat 64 O) (1 : BitVec 12) base (by decide)
+    have hframed := cpsTripleWithin_frameR
+      (schemaCursorInitRestNoX13 regionBase outBase raVal bs outBytes)
+      (by unfold schemaCursorInitRestNoX13; pcFree) hadd
+    refine cpsTripleWithin_weaken ?_ ?_ hframed
+    · intro h hp
+      unfold schemaCursorInitRestNoX13 at hp ⊢
+      xperm_hyp hp
+    · intro h hp
+      unfold schemaCursorInitRestNoX13 at hp
+      unfold schemaCursorInitPostRest
+      rw [show (regionBase + BitVec.ofNat 64 O) + signExtend12 (1 : BitVec 12) =
+          regionBase + BitVec.ofNat 64 (O + 1) by
+            rw [show signExtend12 (1 : BitVec 12) = (1 : Word) by decide]
+            bv_omega] at hp
+      xperm_hyp hp
+  exact WP.CFG.block
+    (schemaCursorInitPostRest_entails_schemaINV regionBase outBase raVal bs O outBytes) hspec
+
+theorem schemaCursorInitCert_pre
+    (base regionBase outBase raVal : Word) (bs : List Byte) (O : Nat)
+    (outBytes : List Byte) :
+    (schemaCursorInitCert base regionBase outBase raVal bs O outBytes).pre =
+      schemaCursorInitPre regionBase outBase raVal bs O outBytes := by
+  rfl
+
+theorem schemaCursorInitCode_none_above (base a : Word)
+    (h : base.toNat + 4 ≤ a.toNat) :
+    schemaCursorInitCode base a = none := by
+  unfold schemaCursorInitCode
+  exact CodeReq.singleton_miss (by
+    intro h_eq
+    have := congrArg BitVec.toNat h_eq
+    omega)
+
+theorem schemaCursorInitCode_disjoint_schemaCR
+    (base : Word) (rOut : Reg) (specs : List FieldSpec)
+    (hcode : base.toNat + 4 + schemaSize specs < 2 ^ 64) :
+    (schemaCursorInitCode base).Disjoint (schemaCR (base + 4) rOut specs) := by
+  have hbase4 : (base + 4).toNat = base.toNat + 4 := by
+    bv_omega
+  refine codeReq_disjoint_of_ranges _ _ (base.toNat + 4) ?_ ?_
+  · intro a ha
+    exact schemaCursorInitCode_none_above base a ha
+  · intro a ha
+    exact schemaCR_none_below rOut specs (base + 4) a (by rw [hbase4]; omega)
+      (by rw [hbase4]; exact ha)
+
+theorem schemaCursorInitCode_disjoint_successStatusReturnCode
+    (base statusBase : Word) :
+    base.toNat + 4 ≤ statusBase.toNat →
+    statusBase.toNat + 8 < 2 ^ 64 →
+    (schemaCursorInitCode base).Disjoint (successStatusReturnCode statusBase) := by
+  intro hle hcode
+  refine codeReq_disjoint_of_ranges _ _ (base.toNat + 4) ?_ ?_
+  · intro a ha
+    exact schemaCursorInitCode_none_above base a ha
+  · intro a ha
+    unfold successStatusReturnCode
+    exact statusReturnCode_none_below statusBase (0 : Word) a hcode (by omega)
+
+theorem schemaCursorInitCode_disjoint_successReturnTail
+    (base : Word) (rOut : Reg) (specs : List FieldSpec)
+    (hcode : base.toNat + 4 + schemaSize specs + 8 < 2 ^ 64) :
+    (schemaCursorInitCode base).Disjoint
+      ((schemaCR (base + 4) rOut specs).union
+        (successStatusReturnCode
+          ((base + 4) + BitVec.ofNat 64 (schemaSize specs)))) := by
+  have hbase4 : (base + 4).toNat = base.toNat + 4 := by
+    bv_omega
+  have hret : ((base + 4) + BitVec.ofNat 64 (schemaSize specs)).toNat =
+      base.toNat + 4 + schemaSize specs := by
+    bv_omega
+  refine CodeReq.Disjoint.union_right ?h_schema ?h_return
+  · exact schemaCursorInitCode_disjoint_schemaCR base rOut specs (by omega)
+  · exact schemaCursorInitCode_disjoint_successStatusReturnCode base
+      ((base + 4) + BitVec.ofNat 64 (schemaSize specs)) (by rw [hret]; omega)
+      (by rw [hret]; omega)
+
 /-- Automated success-path WP certificate: a generated field-schema walk followed
     by the success return shim. The schema remains result-free; the decoded
     withdrawal appears only through the success witnesses and the ABI post. -/
@@ -692,6 +831,77 @@ theorem successFieldSpecsReturnAbiCertOfInput_pre
         (.x1 ↦ᵣ raVal)) := by
   unfold successFieldSpecsReturnAbiCertOfInput
   rw [successFieldSpecsReturnAbiCertOfConcat_pre]
+
+/-- Caller-facing success-path certificate for a walk-init success candidate:
+    `x10` points to the list value start, so the first instruction initializes
+    the schema cursor (`x13`) and then the generic generated schema/return
+    certificate takes over. -/
+def successFieldSpecsReturnAbiCertOfInputFromListStart
+    (base regionBase outBase raVal : Word)
+    (bs d0 d1 d2 d3 : List Byte)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : bs = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + 4 + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    WP.CFG.Cert base (successStatusReturnExit raVal)
+      ((schemaCursorInitCode base).union
+        ((schemaCR (base + 4) .x8 (successFieldSpecs d0 d1 d2 d3)).union
+          (successStatusReturnCode
+            ((base + 4) + BitVec.ofNat 64 (schemaSize (successFieldSpecs d0 d1 d2 d3))))))
+      (abiPost regionBase outBase raVal bs **
+        successSchemaReturnFrame regionBase outBase
+          (1 + schemaEnc (successFieldSpecs d0 d1 d2 d3))) := by
+  let specs := successFieldSpecs d0 d1 d2 d3
+  have htailCode : (base + 4).toNat + schemaSize specs + 8 < 2 ^ 64 := by
+    have hbase4 : (base + 4).toNat = base.toNat + 4 := by
+      bv_omega
+    rw [hbase4]
+    dsimp [specs] at hcode ⊢
+    omega
+  let head := schemaCursorInitCert base regionBase outBase raVal bs 0
+    (List.replicate outputSize (0 : Byte))
+  let tail := successFieldSpecsReturnAbiCertOfInput (base + 4) regionBase outBase raVal
+    bs d0 d1 d2 d3 hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput halign hdalign hover hwin hdov
+    hdval htailCode
+  have hd : (schemaCursorInitCode base).Disjoint
+      ((schemaCR (base + 4) .x8 specs).union
+        (successStatusReturnCode
+          ((base + 4) + BitVec.ofNat 64 (schemaSize specs)))) := by
+    exact schemaCursorInitCode_disjoint_successReturnTail base .x8 specs (by
+      dsimp [specs] at hcode ⊢
+      exact hcode)
+  exact WP.CFG.seqDisjoint hd head.sound tail (by
+    rw [successFieldSpecsReturnAbiCertOfInput_pre]
+    exact WP.Entails.refl _)
+
+theorem successFieldSpecsReturnAbiCertOfInputFromListStart_pre
+    (base regionBase outBase raVal : Word)
+    (bs d0 d1 d2 d3 : List Byte)
+    (hc0 : d0.headD 1 ≠ 0) (hl0 : d0.length ≤ 8)
+    (hc1 : d1.headD 1 ≠ 0) (hl1 : d1.length ≤ 8)
+    (haddr : d2.length = 20)
+    (hc3 : d3.headD 1 ≠ 0) (hl3 : d3.length ≤ 8)
+    (hinput : bs = encode (.list (schemaItems (successFieldSpecs d0 d1 d2 d3))))
+    (halign : regionBase.toNat % 8 = 0) (hdalign : outBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + bs.length < 2 ^ 64)
+    (hwin : ∀ i, i < bs.length → isValidByteAccess (regionBase + BitVec.ofNat 64 i) = true)
+    (hdov : outBase.toNat + outputSize < 2 ^ 64)
+    (hdval : ∀ i, i < outputSize → isValidByteAccess (outBase + BitVec.ofNat 64 i) = true)
+    (hcode : base.toNat + 4 + schemaSize (successFieldSpecs d0 d1 d2 d3) + 8 < 2 ^ 64) :
+    (successFieldSpecsReturnAbiCertOfInputFromListStart base regionBase outBase raVal bs
+      d0 d1 d2 d3 hc0 hl0 hc1 hl1 haddr hc3 hl3 hinput halign hdalign hover hwin hdov
+      hdval hcode).pre =
+      schemaCursorInitPre regionBase outBase raVal bs 0
+        (List.replicate outputSize (0 : Byte)) := by
+  unfold successFieldSpecsReturnAbiCertOfInputFromListStart
+  rfl
 
 end WithdrawalDecode
 

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -148,6 +148,22 @@ macro_rules
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchSeqHeadNBranchDisjoint $hd $br (by rfl) $tail
         (by wp_rv64_link))
 
+/-- Frame every exit of an N-way branch with a PC-free assertion. -/
+syntax (name := wpRv64NBranchFrameRTac)
+  "wp_rv64_nbranch_frame " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_frame $br:term, $F:term, $hF:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchFrameR $br $F $hF)
+
+/-- Weaken the exit postconditions of an N-way branch. -/
+syntax (name := wpRv64NBranchWeakenPostsTac)
+  "wp_rv64_nbranch_weaken_posts " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_weaken_posts $br:term, $exits:term, $hmap:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchWeakenPosts $br $exits $hmap)
+
 /-- Display the computed precondition field of a WP/CFG certificate. -/
 syntax (name := wpRv64Cmd) "#wp_rv64 " term : command
 
@@ -270,5 +286,17 @@ example {nTail : Nat} {entry : Word} {cr1 cr2 : CodeReq}
   let nb := EvmAsm.Rv64.WP.CFG.nbranchOfBranch br
   let tail := EvmAsm.Rv64.WP.NBranch.ofSpec tailSound
   wp_rv64_nbranch_head_nbranch_disjoint hd, nb, tail
+
+example {entry : Word} {cr : CodeReq} {F : Assertion}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr) (hF : F.pcFree) :
+    EvmAsm.Rv64.WP.NBranch entry cr := by
+  wp_rv64_nbranch_frame br, F, hF
+
+example {entry : Word} {cr : CodeReq} {exits' : List (Word × Assertion)}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr)
+    (hmap : ∀ ex ∈ br.exits, ∃ ex' ∈ exits',
+      ex'.1 = ex.1 ∧ EvmAsm.Rv64.WP.Entails ex.2 ex'.2) :
+    EvmAsm.Rv64.WP.NBranch entry cr := by
+  wp_rv64_nbranch_weaken_posts br, exits', hmap
 
 end EvmAsm.Rv64.Tactics.WPTests

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -34,6 +34,15 @@ private def solveMVarWithLocalHyp (mvarId : MVarId) : TacticM Bool := do
   if ← mvarId.isAssigned then
     return true
   let target ← instantiateMVars (← mvarId.getType)
+  let mvarDecl ← mvarId.getDecl
+  unless mvarDecl.userName.isAnonymous do
+    for localDecl in ← getLCtx do
+      unless localDecl.isImplementationDetail do
+        if localDecl.userName == mvarDecl.userName then
+          let localType ← instantiateMVars localDecl.type
+          if ← withoutModifyingState (isDefEq localType target) then
+            mvarId.assign (mkFVar localDecl.fvarId)
+            return true
   unless ← isProp target do
     return false
   for localDecl in ← getLCtx do
@@ -45,17 +54,53 @@ private def solveMVarWithLocalHyp (mvarId : MVarId) : TacticM Bool := do
         return true
   return false
 
-private def closeWithWpEntailsHint (goal : MVarId) (declName : Name) : TacticM Unit := do
+private def localCandidatesForMVar (mvarId : MVarId) : TacticM (Array Expr) := do
+  let target ← instantiateMVars (← mvarId.getType)
+  let mvarDecl ← mvarId.getDecl
+  let mut named : Array Expr := #[]
+  let mut typed : Array Expr := #[]
+  for localDecl in ← getLCtx do
+    unless localDecl.isImplementationDetail do
+      let localType ← instantiateMVars localDecl.type
+      if ← withoutModifyingState (isDefEq localType target) then
+        let localExpr := mkFVar localDecl.fvarId
+        typed := typed.push localExpr
+        if !mvarDecl.userName.isAnonymous && localDecl.userName == mvarDecl.userName then
+          named := named.push localExpr
+  if !named.isEmpty then
+    return named
+  return typed
+
+partial def solveParamMVarsWithLocals (params : Array Expr) (idx : Nat) : TacticM Bool := do
+  if hidx : idx < params.size then
+    let param ← instantiateMVars params[idx]
+    if param.isMVar then
+      let mvarId := param.mvarId!
+      if ← mvarId.isAssigned then
+        solveParamMVarsWithLocals params (idx + 1)
+      else
+        let candidates ← localCandidatesForMVar mvarId
+        for candidate in candidates do
+          let saved ← saveState
+          mvarId.assign candidate
+          if ← solveParamMVarsWithLocals params (idx + 1) then
+            return true
+          restoreState saved
+        return false
+    else
+      solveParamMVarsWithLocals params (idx + 1)
+  else
+    return true
+
+private def closeWithWpHint (goal : MVarId) (declName : Name) : TacticM Unit := do
   let goalType ← instantiateMVars (← goal.getType)
   let hintConst ← mkConstWithFreshMVarLevels declName
   let hintType ← inferType hintConst
   let (params, _, body) ← forallMetaTelescope hintType
   unless ← isDefEq body goalType do
     throwError "hint result does not match goal"
-  for param in params do
-    let param ← instantiateMVars param
-    if param.isMVar then
-      let _ ← solveMVarWithLocalHyp param.mvarId!
+  unless ← solveParamMVarsWithLocals params 0 do
+    throwError "hint parameters were not inferable from local context"
   let proof ← instantiateMVars (mkAppN hintConst params)
   if proof.hasExprMVar then
     throwError "hint left unresolved metavariables"
@@ -75,12 +120,52 @@ elab "wp_rv64_entails" : tactic => withMainContext do
   for declName in entries do
     let saved ← saveState
     try
-      closeWithWpEntailsHint goal declName
+      closeWithWpHint goal declName
       return
     catch _ =>
       restoreState saved
       continue
   throwError "wp_rv64_entails: no @[rv64_wp_entails] theorem closed the goal"
+
+/-- Try declarations tagged with `@[rv64_wp_dead]` against the current
+    unreachable-exit goal.  Tagged lemmas may have explicit proof arguments;
+    generated side goals are discharged from local hypotheses. -/
+elab "wp_rv64_dead_hint" : tactic => withMainContext do
+  let goal ← getMainGoal
+  let goalType ← instantiateMVars (← goal.getType)
+  unless ← isProp goalType do
+    throwError "wp_rv64_dead_hint: expected proposition goal"
+  let entries := rv64WpDeadExt.getState (← getEnv)
+  for declName in entries do
+    let saved ← saveState
+    try
+      closeWithWpHint goal declName
+      return
+    catch _ =>
+      restoreState saved
+      let saved ← saveState
+      try
+        let hint := mkIdent declName
+        evalTactic (← `(tactic| apply $hint:ident <;> assumption))
+        unless (← getGoals).isEmpty do
+          throwError "hint left open goals"
+        return
+      catch _ =>
+        restoreState saved
+        continue
+  throwError "wp_rv64_dead_hint: no @[rv64_wp_dead] theorem closed the goal"
+
+/-- Close an unreachable-exit goal, after exposing small WP definitions if
+    needed, using declarations tagged with `@[rv64_wp_dead]`. -/
+syntax (name := wpRv64DeadTac) "wp_rv64_dead" : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_dead) =>
+      `(tactic| first
+        | wp_rv64_dead_hint
+        | simp only [rv64_wp]; wp_rv64_dead_hint
+        | try dsimp; wp_rv64_dead_hint
+        | try dsimp; simp only [rv64_wp]; wp_rv64_dead_hint)
 
 /-- Close the midpoint entailment between adjacent WP fragments.  The common
     case is definitional equality of the head postcondition and tail WP; semantic
@@ -561,6 +646,17 @@ macro_rules
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchJoin2ResolveFirst $br $hexits
         (show EvmAsm.Rv64.WP.Entails _ $post by wp_rv64_link) $hdead2)
 
+/-- Join two known exits when the first exit is reachable, synthesizing both
+    the reachable-exit entailment and dead second exit. -/
+syntax (name := wpRv64NBranchJoin2ResolveFirstDeadAutoTac)
+  "wp_rv64_nbranch_join2_resolve_first_dead_auto " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_join2_resolve_first_dead_auto $br:term, $hexits:term, $post:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchJoin2ResolveFirst $br $hexits
+        (show EvmAsm.Rv64.WP.Entails _ $post by wp_rv64_link)
+        (by wp_rv64_dead))
+
 /-- Join exactly two known exits when the second exit is the only reachable one. -/
 syntax (name := wpRv64NBranchJoin2ResolveSecondTac)
   "wp_rv64_nbranch_join2_resolve_second " term ", " term ", " term ", " term : tactic
@@ -577,6 +673,17 @@ syntax (name := wpRv64NBranchJoin2ResolveSecondAutoTac)
 macro_rules
   | `(tactic| wp_rv64_nbranch_join2_resolve_second_auto $br:term, $hexits:term, $hdead1:term, $post:term) =>
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchJoin2ResolveSecond $br $hexits $hdead1
+        (show EvmAsm.Rv64.WP.Entails _ $post by wp_rv64_link))
+
+/-- Join two known exits when the second exit is reachable, synthesizing both
+    the dead first exit and reachable-exit entailment. -/
+syntax (name := wpRv64NBranchJoin2ResolveSecondDeadAutoTac)
+  "wp_rv64_nbranch_join2_resolve_second_dead_auto " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_join2_resolve_second_dead_auto $br:term, $hexits:term, $post:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchJoin2ResolveSecond $br $hexits
+        (by wp_rv64_dead)
         (show EvmAsm.Rv64.WP.Entails _ $post by wp_rv64_link))
 
 /-- Join exactly three known exits when the second exit is the only reachable one. -/
@@ -596,6 +703,18 @@ macro_rules
   | `(tactic| wp_rv64_nbranch_join3_resolve_second_auto $br:term, $hexits:term, $hdead1:term, $post:term, $hdead3:term) =>
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchJoin3ResolveSecond $br $hexits $hdead1
         (show EvmAsm.Rv64.WP.Entails _ $post by wp_rv64_link) $hdead3)
+
+/-- Join three known exits when the second exit is reachable, synthesizing the
+    dead outer exits and reachable-exit entailment. -/
+syntax (name := wpRv64NBranchJoin3ResolveSecondDeadAutoTac)
+  "wp_rv64_nbranch_join3_resolve_second_dead_auto " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_join3_resolve_second_dead_auto $br:term, $hexits:term, $post:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchJoin3ResolveSecond $br $hexits
+        (by wp_rv64_dead)
+        (show EvmAsm.Rv64.WP.Entails _ $post by wp_rv64_link)
+        (by wp_rv64_dead))
 
 /-- Join exactly four known exits of an N-way branch, supplying the generated
     exit-list proof and one continuation per exit. -/
@@ -626,6 +745,18 @@ macro_rules
   | `(tactic| wp_rv64_nbranch_join4_resolve_third $br:term, $hexits:term, $hdead1:term, $hdead2:term, $hlink3:term, $hdead4:term) =>
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchJoin4ResolveThird $br $hexits
         $hdead1 $hdead2 $hlink3 $hdead4)
+
+/-- Join four known exits when the third exit is reachable, synthesizing the
+    dead surrounding exits and reachable-exit entailment. -/
+syntax (name := wpRv64NBranchJoin4ResolveThirdDeadAutoTac)
+  "wp_rv64_nbranch_join4_resolve_third_dead_auto " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_join4_resolve_third_dead_auto $br:term, $hexits:term, $post:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchJoin4ResolveThird $br $hexits
+        (by wp_rv64_dead) (by wp_rv64_dead)
+        (show EvmAsm.Rv64.WP.Entails _ $post by wp_rv64_link)
+        (by wp_rv64_dead))
 
 /-- Display the computed precondition field of a WP/CFG certificate. -/
 syntax (name := wpRv64Cmd) "#wp_rv64 " term : command
@@ -658,6 +789,16 @@ example {entry exit_ : Word} {cr : CodeReq} {pre post : Assertion}
 example {P : Assertion} {A : Prop} (hA : A) :
     EvmAsm.Rv64.WP.Entails P (P ** ⌜A⌝) := by
   wp_rv64_link
+
+theorem wp_rv64_dead_test_hint {P : Assertion} (hdead : ∀ h, P h → False) :
+    ∀ h, P h → False :=
+  hdead
+
+attribute [rv64_wp_dead] wp_rv64_dead_test_hint
+
+example {P : Assertion} (hdead : ∀ h, P h → False) :
+    ∀ h, P h → False := by
+  wp_rv64_dead
 
 example {nSteps : Nat} {entry mid exit_ : Word} {cr : CodeReq}
     {pre post : Assertion}
@@ -860,6 +1001,13 @@ example {entry l1 l2 : Word} {cr : CodeReq} {Q1 Q2 : Assertion}
     EvmAsm.Rv64.WP.CFG.Cert entry l1 cr Q1 := by
   wp_rv64_nbranch_join2_resolve_first_auto br, hexits, Q1, hdead2
 
+example {entry l1 l2 : Word} {cr : CodeReq} {Q1 Q2 : Assertion}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2)])
+    (hdead2 : ∀ h, Q2 h → False) :
+    EvmAsm.Rv64.WP.CFG.Cert entry l1 cr Q1 := by
+  wp_rv64_nbranch_join2_resolve_first_dead_auto br, hexits, Q1
+
 example {entry l1 l2 : Word} {cr : CodeReq} {post Q1 Q2 : Assertion}
     (br : EvmAsm.Rv64.WP.NBranch entry cr)
     (hexits : br.exits = [(l1, Q1), (l2, Q2)])
@@ -874,6 +1022,13 @@ example {entry l1 l2 : Word} {cr : CodeReq} {Q1 Q2 : Assertion}
     (hdead1 : ∀ h, Q1 h → False) :
     EvmAsm.Rv64.WP.CFG.Cert entry l2 cr Q2 := by
   wp_rv64_nbranch_join2_resolve_second_auto br, hexits, hdead1, Q2
+
+example {entry l1 l2 : Word} {cr : CodeReq} {Q1 Q2 : Assertion}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2)])
+    (hdead1 : ∀ h, Q1 h → False) :
+    EvmAsm.Rv64.WP.CFG.Cert entry l2 cr Q2 := by
+  wp_rv64_nbranch_join2_resolve_second_dead_auto br, hexits, Q2
 
 example {entry l1 l2 l3 : Word} {cr : CodeReq} {post Q1 Q2 Q3 : Assertion}
     (br : EvmAsm.Rv64.WP.NBranch entry cr)
@@ -891,6 +1046,14 @@ example {entry l1 l2 l3 : Word} {cr : CodeReq} {Q1 Q2 Q3 : Assertion}
     (hdead3 : ∀ h, Q3 h → False) :
     EvmAsm.Rv64.WP.CFG.Cert entry l2 cr Q2 := by
   wp_rv64_nbranch_join3_resolve_second_auto br, hexits, hdead1, Q2, hdead3
+
+example {entry l1 l2 l3 : Word} {cr : CodeReq} {Q1 Q2 Q3 : Assertion}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3)])
+    (hdead1 : ∀ h, Q1 h → False)
+    (hdead3 : ∀ h, Q3 h → False) :
+    EvmAsm.Rv64.WP.CFG.Cert entry l2 cr Q2 := by
+  wp_rv64_nbranch_join3_resolve_second_dead_auto br, hexits, Q2
 
 example {entry exit_ l1 l2 l3 l4 : Word} {cr : CodeReq} {post Q1 Q2 Q3 Q4 : Assertion}
     (br : EvmAsm.Rv64.WP.NBranch entry cr)
@@ -934,6 +1097,15 @@ example {entry l1 l2 l3 l4 : Word} {cr : CodeReq} {post Q1 Q2 Q3 Q4 : Assertion}
     (hdead4 : ∀ h, Q4 h → False) :
     EvmAsm.Rv64.WP.CFG.Cert entry l3 cr post := by
   wp_rv64_nbranch_join4_resolve_third br, hexits, hdead1, hdead2, hlink3, hdead4
+
+example {entry l1 l2 l3 l4 : Word} {cr : CodeReq} {Q1 Q2 Q3 Q4 : Assertion}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)])
+    (hdead1 : ∀ h, Q1 h → False)
+    (hdead2 : ∀ h, Q2 h → False)
+    (hdead4 : ∀ h, Q4 h → False) :
+    EvmAsm.Rv64.WP.CFG.Cert entry l3 cr Q3 := by
+  wp_rv64_nbranch_join4_resolve_third_dead_auto br, hexits, Q3
 
 example {entry head l : Word} {cr1 cr2 : CodeReq}
     {headPost secondPost : Assertion} {others : List (Word × Assertion)}

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -115,6 +115,55 @@ macro_rules
       `(tactic| exact EvmAsm.Rv64.WP.CFG.seqBlockNBranchDisjoint $hd $head $tail
         (by wp_rv64_link))
 
+/-- Frame a single-exit head block and an N-way tail, then compose them over
+    disjoint code. This is the common WP handoff shape for generated assembly:
+    caller resources are framed across the head block, callee-save resources are
+    framed across every tail exit, and the midpoint entailment is solved by the
+    WP link automation. -/
+syntax (name := wpRv64SeqBlockNBranchFramedDisjointTac)
+  "wp_rv64_seq_block_nbranch_framed_disjoint " term ", " term ", " term ", " term
+    ", " term ", " term ", " term : tactic
+
+/-- Explicit-link variant of `wp_rv64_seq_block_nbranch_framed_disjoint`.
+    Use this when the generated tail precondition needs a local normalization
+    step before `wp_rv64_link` can see the assertion atoms. -/
+syntax (name := wpRv64SeqBlockNBranchFramedDisjointWithTac)
+  "wp_rv64_seq_block_nbranch_framed_disjoint_with " term ", " term ", " term ", " term
+    ", " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_seq_block_nbranch_framed_disjoint_with $hd:term, $head:term,
+        $headFrame:term, $hHeadFrame:term, $tail:term, $tailFrame:term,
+        $hTailFrame:term, $hlink:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.seqBlockNBranchDisjoint $hd
+        (EvmAsm.Rv64.WP.CFG.frameR $head $headFrame $hHeadFrame).sound
+        (EvmAsm.Rv64.WP.CFG.nbranchFrameR $tail $tailFrame $hTailFrame)
+        $hlink)
+
+macro_rules
+  | `(tactic| wp_rv64_seq_block_nbranch_framed_disjoint $hd:term, $head:term,
+        $headFrame:term, $hHeadFrame:term, $tail:term, $tailFrame:term,
+        $hTailFrame:term) =>
+      `(tactic| wp_rv64_seq_block_nbranch_framed_disjoint_with $hd, $head,
+        $headFrame, $hHeadFrame, $tail, $tailFrame, $hTailFrame,
+        (by
+          dsimp only [EvmAsm.Rv64.WP.CFG.frameR, EvmAsm.Rv64.WP.CFG.nbranchFrameR,
+            EvmAsm.Rv64.WP.Triple.frameR, EvmAsm.Rv64.WP.NBranch.frameR]
+          wp_rv64_link))
+
+/-- Same as `wp_rv64_seq_block_nbranch_framed_disjoint`, with the code
+    disjointness side condition discharged by `wp_rv64_disjoint`. -/
+syntax (name := wpRv64SeqBlockNBranchFramedAutoTac)
+  "wp_rv64_seq_block_nbranch_framed_auto " term ", " term ", " term ", " term
+    ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_seq_block_nbranch_framed_auto $head:term, $headFrame:term,
+        $hHeadFrame:term, $tail:term, $tailFrame:term, $hTailFrame:term) =>
+      `(tactic| wp_rv64_seq_block_nbranch_framed_disjoint
+        (by wp_rv64_disjoint), $head, $headFrame, $hHeadFrame, $tail, $tailFrame,
+        $hTailFrame)
+
 /-- Continue a branch's taken exit with a WP/CFG tail over disjoint code. -/
 syntax (name := wpRv64BranchSeqTakenDisjointTac)
   "wp_rv64_branch_taken_disjoint " term ", " term ", " term : tactic

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -579,6 +579,24 @@ macro_rules
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchJoin2ResolveSecond $br $hexits $hdead1
         (show EvmAsm.Rv64.WP.Entails _ $post by wp_rv64_link))
 
+/-- Join exactly three known exits when the second exit is the only reachable one. -/
+syntax (name := wpRv64NBranchJoin3ResolveSecondTac)
+  "wp_rv64_nbranch_join3_resolve_second " term ", " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_join3_resolve_second $br:term, $hexits:term, $hdead1:term, $hlink2:term, $hdead3:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchJoin3ResolveSecond $br $hexits $hdead1 $hlink2 $hdead3)
+
+/-- Join exactly three known exits when the second exit is the only reachable one,
+    synthesizing the reachable-exit entailment with `wp_rv64_link`. -/
+syntax (name := wpRv64NBranchJoin3ResolveSecondAutoTac)
+  "wp_rv64_nbranch_join3_resolve_second_auto " term ", " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_join3_resolve_second_auto $br:term, $hexits:term, $hdead1:term, $post:term, $hdead3:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchJoin3ResolveSecond $br $hexits $hdead1
+        (show EvmAsm.Rv64.WP.Entails _ $post by wp_rv64_link) $hdead3)
+
 /-- Join exactly four known exits of an N-way branch, supplying the generated
     exit-list proof and one continuation per exit. -/
 syntax (name := wpRv64NBranchJoin4WithTac)
@@ -856,6 +874,23 @@ example {entry l1 l2 : Word} {cr : CodeReq} {Q1 Q2 : Assertion}
     (hdead1 : ∀ h, Q1 h → False) :
     EvmAsm.Rv64.WP.CFG.Cert entry l2 cr Q2 := by
   wp_rv64_nbranch_join2_resolve_second_auto br, hexits, hdead1, Q2
+
+example {entry l1 l2 l3 : Word} {cr : CodeReq} {post Q1 Q2 Q3 : Assertion}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3)])
+    (hdead1 : ∀ h, Q1 h → False)
+    (hlink2 : EvmAsm.Rv64.WP.Entails Q2 post)
+    (hdead3 : ∀ h, Q3 h → False) :
+    EvmAsm.Rv64.WP.CFG.Cert entry l2 cr post := by
+  wp_rv64_nbranch_join3_resolve_second br, hexits, hdead1, hlink2, hdead3
+
+example {entry l1 l2 l3 : Word} {cr : CodeReq} {Q1 Q2 Q3 : Assertion}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3)])
+    (hdead1 : ∀ h, Q1 h → False)
+    (hdead3 : ∀ h, Q3 h → False) :
+    EvmAsm.Rv64.WP.CFG.Cert entry l2 cr Q2 := by
+  wp_rv64_nbranch_join3_resolve_second_auto br, hexits, hdead1, Q2, hdead3
 
 example {entry exit_ l1 l2 l3 l4 : Word} {cr : CodeReq} {post Q1 Q2 Q3 Q4 : Assertion}
     (br : EvmAsm.Rv64.WP.NBranch entry cr)

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -295,6 +295,78 @@ macro_rules
   | `(tactic| wp_rv64_frame $cfg:term, $F:term, $hF:term) =>
       `(tactic| exact EvmAsm.Rv64.WP.CFG.frameR $cfg $F $hF)
 
+/-- Weaken a single-exit CFG certificate's computed precondition. -/
+syntax (name := wpRv64WeakenPreTac) "wp_rv64_weaken_pre " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_weaken_pre $cfg:term, $hpre:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.weakenPre $cfg $hpre)
+
+/-- Weaken a single-exit CFG certificate to an explicitly supplied
+    precondition, synthesizing the entailment with `wp_rv64_link`. -/
+syntax (name := wpRv64SetPreTac) "wp_rv64_set_pre " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_set_pre $cfg:term, $pre:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.weakenPre $cfg
+        (show EvmAsm.Rv64.WP.Entails $pre ($cfg).pre by wp_rv64_link))
+
+/-- Weaken a single-exit CFG certificate's continuation postcondition. -/
+syntax (name := wpRv64WeakenPostTac) "wp_rv64_weaken_post " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_weaken_post $cfg:term, $hpost:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.weakenPost $cfg $hpost)
+
+/-- Weaken a single-exit CFG certificate to an explicitly supplied
+    postcondition, synthesizing the entailment with `wp_rv64_link`. -/
+syntax (name := wpRv64SetPostTac) "wp_rv64_set_post " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_set_post $cfg:term, $post:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.weakenPost $cfg
+        (show EvmAsm.Rv64.WP.Entails _ $post by wp_rv64_link))
+
+/-- Increase a single-exit CFG certificate's step budget. -/
+syntax (name := wpRv64MonoStepsTac) "wp_rv64_mono_steps " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_mono_steps $cfg:term, $hle:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.monoSteps $cfg $hle)
+
+/-- Extend a single-exit CFG certificate to a larger persistent code requirement. -/
+syntax (name := wpRv64ExtendCodeTac) "wp_rv64_extend_code " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_extend_code $cfg:term, $hmono:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.extendCode $cfg $hmono)
+
+/-- Extend a single-exit CFG certificate and set an explicit precondition in
+    one generated step. -/
+syntax (name := wpRv64ExtendSetPreTac)
+  "wp_rv64_extend_set_pre " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_extend_set_pre $cfg:term, $hmono:term, $pre:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.weakenPre
+        (EvmAsm.Rv64.WP.CFG.extendCode $cfg $hmono)
+        (show EvmAsm.Rv64.WP.Entails $pre
+          (EvmAsm.Rv64.WP.CFG.extendCode $cfg $hmono).pre by wp_rv64_link))
+
+/-- Rewrite a single-exit CFG certificate's entry address. -/
+syntax (name := wpRv64ChangeEntryTac) "wp_rv64_change_entry " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_change_entry $cfg:term, $hentry:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.changeEntry $cfg $hentry)
+
+/-- Rewrite a single-exit CFG certificate's exit address. -/
+syntax (name := wpRv64ChangeExitTac) "wp_rv64_change_exit " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_change_exit $cfg:term, $hexit:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.changeExit $cfg $hexit)
+
 /-- Build a certificate for an unreachable precondition. -/
 syntax (name := wpRv64UnreachableTac)
   "wp_rv64_unreachable " term ", " term ", " term ", " term : tactic
@@ -961,6 +1033,58 @@ example {entry exit_ : Word} {cr : CodeReq} {post F : Assertion}
     (cfg : EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post) (hF : F.pcFree) :
     EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr (post ** F) := by
   wp_rv64_frame cfg, F, hF
+
+example {entry exit_ : Word} {cr : CodeReq} {pre post : Assertion}
+    (cfg : EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post)
+    (hpre : EvmAsm.Rv64.WP.Entails pre cfg.pre) :
+    EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post := by
+  wp_rv64_weaken_pre cfg, hpre
+
+example {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
+    (cfg : EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post) :
+    EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post := by
+  wp_rv64_set_pre cfg, cfg.pre
+
+example {entry exit_ : Word} {cr : CodeReq} {post post' : Assertion}
+    (cfg : EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post)
+    (hpost : EvmAsm.Rv64.WP.Entails post post') :
+    EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post' := by
+  wp_rv64_weaken_post cfg, hpost
+
+example {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
+    (cfg : EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post) :
+    EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post := by
+  wp_rv64_set_post cfg, post
+
+example {entry exit_ : Word} {cr : CodeReq} {post : Assertion} {nSteps' : Nat}
+    (cfg : EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post)
+    (hle : cfg.nSteps ≤ nSteps') :
+    EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post := by
+  wp_rv64_mono_steps cfg, hle
+
+example {entry exit_ : Word} {cr cr' : CodeReq} {post : Assertion}
+    (cfg : EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post)
+    (hmono : ∀ a i, cr a = some i → cr' a = some i) :
+    EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr' post := by
+  wp_rv64_extend_code cfg, hmono
+
+example {entry exit_ : Word} {cr cr' : CodeReq} {post : Assertion}
+    (cfg : EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post)
+    (hmono : ∀ a i, cr a = some i → cr' a = some i) :
+    EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr' post := by
+  wp_rv64_extend_set_pre cfg, hmono, cfg.pre
+
+example {entry entry' exit_ : Word} {cr : CodeReq} {post : Assertion}
+    (cfg : EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post)
+    (hentry : entry' = entry) :
+    EvmAsm.Rv64.WP.CFG.Cert entry' exit_ cr post := by
+  wp_rv64_change_entry cfg, hentry
+
+example {entry exit_ exit_' : Word} {cr : CodeReq} {post : Assertion}
+    (cfg : EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post)
+    (hexit : exit_ = exit_') :
+    EvmAsm.Rv64.WP.CFG.Cert entry exit_' cr post := by
+  wp_rv64_change_exit cfg, hexit
 
 example {entry exit_ : Word} {cr : CodeReq} {pre post : Assertion}
     (hpre : ∀ h, pre h → False) :

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -530,6 +530,19 @@ macro_rules
         (show EvmAsm.Rv64.WP.Entails _ $p3 by wp_rv64_link)
         (show EvmAsm.Rv64.WP.Entails _ $p4 by wp_rv64_link))
 
+/-- Weaken four known exits into three by merging the first two same-target
+    exits, synthesizing the per-exit entailments with `wp_rv64_link`. -/
+syntax (name := wpRv64NBranchWeakenPosts4MergeFirstTwoWithAutoTac)
+  "wp_rv64_nbranch_weaken_posts4_merge_first_two_with_auto " term ", " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_weaken_posts4_merge_first_two_with_auto $br:term, $hexits:term, $p12:term, $p3:term, $p4:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchWeakenPosts4MergeFirstTwo $br $hexits
+        (show EvmAsm.Rv64.WP.Entails _ $p12 by wp_rv64_link)
+        (show EvmAsm.Rv64.WP.Entails _ $p12 by wp_rv64_link)
+        (show EvmAsm.Rv64.WP.Entails _ $p3 by wp_rv64_link)
+        (show EvmAsm.Rv64.WP.Entails _ $p4 by wp_rv64_link))
+
 /-- Join exactly four known exits of an N-way branch, supplying the generated
     exit-list proof and one continuation per exit. -/
 syntax (name := wpRv64NBranchJoin4WithTac)
@@ -770,6 +783,13 @@ example {entry l1 l2 l3 l4 : Word} {cr : CodeReq}
     (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)]) :
     EvmAsm.Rv64.WP.NBranch entry cr := by
   wp_rv64_nbranch_weaken_posts4_with_auto br, hexits, Q1, Q2, Q3, Q4
+
+example {entry l l3 l4 : Word} {cr : CodeReq}
+    {Q Q3 Q4 : Assertion}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr)
+    (hexits : br.exits = [(l, Q), (l, Q), (l3, Q3), (l4, Q4)]) :
+    EvmAsm.Rv64.WP.NBranch entry cr := by
+  wp_rv64_nbranch_weaken_posts4_merge_first_two_with_auto br, hexits, Q, Q3, Q4
 
 example {entry exit_ l1 l2 l3 l4 : Word} {cr : CodeReq} {post Q1 Q2 Q3 Q4 : Assertion}
     (br : EvmAsm.Rv64.WP.NBranch entry cr)

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -186,6 +186,28 @@ macro_rules
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchSeqExitNBranchDisjoint
         (preExits := $preExits) $hd $br (by rfl) $tail (by wp_rv64_link))
 
+/-- Continue an arbitrary exit with a single-exit CFG certificate over disjoint
+    code. The preExits argument is the list of exits to preserve before the
+    selected exit, and the exits field is expected to reduce definitionally. -/
+syntax (name := wpRv64NBranchSeqExitCertDisjointTac)
+  "wp_rv64_nbranch_exit_cert_disjoint " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_exit_cert_disjoint $hd:term, $br:term, $preExits:term, $tail:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchSeqExitCertDisjoint
+        (preExits := $preExits) $hd $br (by rfl) $tail (by wp_rv64_link))
+
+/-- Continue an arbitrary exit with a single-exit CFG certificate, supplying the
+    generated exit-list proof and link entailment explicitly. This is the useful
+    endpoint for proof-producing code that normalizes exits with a local lemma. -/
+syntax (name := wpRv64NBranchSeqExitCertDisjointWithTac)
+  "wp_rv64_nbranch_exit_cert_disjoint_with " term ", " term ", " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_exit_cert_disjoint_with $hd:term, $br:term, $preExits:term, $hexits:term, $tail:term, $hlink:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchSeqExitCertDisjoint
+        (preExits := $preExits) $hd $br $hexits $tail $hlink)
+
 /-- Preserve the first exit and continue the second exit with another N-way branch
     over disjoint code. The tactic expects the exits field to reduce to a two-cons prefix. -/
 syntax (name := wpRv64NBranchSeqSecondNBranchDisjointTac)
@@ -392,5 +414,20 @@ example {entry head l : Word} {cr1 cr2 : CodeReq}
     (hlink : EvmAsm.Rv64.WP.Entails secondPost tail.pre) :
     EvmAsm.Rv64.WP.NBranch entry (cr1.union cr2) := by
   exact EvmAsm.Rv64.WP.CFG.nbranchSeqSecondNBranchDisjoint hd br hexits tail hlink
+
+example {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
+    (cfg : EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post) :
+    EvmAsm.Rv64.WP.NBranch entry cr :=
+  EvmAsm.Rv64.WP.NBranch.ofTriple cfg
+
+example {entry l l' : Word} {cr1 cr2 : CodeReq}
+    {exitPost post : Assertion} {preExits others : List (Word × Assertion)}
+    (hd : cr1.Disjoint cr2)
+    (br : EvmAsm.Rv64.WP.NBranch entry cr1)
+    (hexits : br.exits = preExits ++ (l, exitPost) :: others)
+    (tail : EvmAsm.Rv64.WP.CFG.Cert l l' cr2 post)
+    (hlink : EvmAsm.Rv64.WP.Entails exitPost tail.pre) :
+    EvmAsm.Rv64.WP.NBranch entry (cr1.union cr2) := by
+  wp_rv64_nbranch_exit_cert_disjoint_with hd, br, preExits, hexits, tail, hlink
 
 end EvmAsm.Rv64.Tactics.WPTests

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -164,6 +164,15 @@ macro_rules
   | `(tactic| wp_rv64_nbranch_weaken_posts $br:term, $exits:term, $hmap:term) =>
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchWeakenPosts $br $exits $hmap)
 
+/-- Weaken the head exit of an N-way branch. The tactic expects the exits field
+    to reduce to a cons. -/
+syntax (name := wpRv64NBranchWeakenHeadPostTac)
+  "wp_rv64_nbranch_weaken_head " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_weaken_head $br:term, $hpost:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchWeakenHeadPost $br (by rfl) $hpost)
+
 /-- Display the computed precondition field of a WP/CFG certificate. -/
 syntax (name := wpRv64Cmd) "#wp_rv64 " term : command
 
@@ -298,5 +307,13 @@ example {entry : Word} {cr : CodeReq} {exits' : List (Word × Assertion)}
       ex'.1 = ex.1 ∧ EvmAsm.Rv64.WP.Entails ex.2 ex'.2) :
     EvmAsm.Rv64.WP.NBranch entry cr := by
   wp_rv64_nbranch_weaken_posts br, exits', hmap
+
+example {entry l : Word} {cr : CodeReq} {headPost headPost' : Assertion}
+    {others : List (Word × Assertion)}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr)
+    (hexits : br.exits = (l, headPost) :: others)
+    (hpost : EvmAsm.Rv64.WP.Entails headPost headPost') :
+    EvmAsm.Rv64.WP.NBranch entry cr := by
+  exact EvmAsm.Rv64.WP.CFG.nbranchWeakenHeadPost br hexits hpost
 
 end EvmAsm.Rv64.Tactics.WPTests

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -109,6 +109,16 @@ macro_rules
       `(tactic| exact EvmAsm.Rv64.WP.CFG.branchSeqNotTakenBlockDisjoint $hd $br $tail
         (by wp_rv64_link))
 
+/-- Continue a branch's taken exit with a CPS leaf over disjoint code and expose
+    the resulting branch as an N-way branch. -/
+syntax (name := wpRv64BranchSeqTakenBlockNBranchDisjointTac)
+  "wp_rv64_branch_taken_block_nbranch_disjoint " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_branch_taken_block_nbranch_disjoint $hd:term, $br:term, $tail:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.branchSeqTakenBlockNBranchDisjoint $hd $br $tail
+        (by wp_rv64_link))
+
 /-- Continue a branch's not-taken exit with an N-way branch over disjoint code. -/
 syntax (name := wpRv64BranchSeqNotTakenNBranchDisjointTac)
   "wp_rv64_branch_not_taken_nbranch_disjoint " term ", " term ", " term : tactic
@@ -191,6 +201,14 @@ example {nTail : Nat} {entry target : Word} {cr1 cr2 : CodeReq}
     (tail : cpsTripleWithin nTail br.exit_f target cr2 br.post_f post) :
     EvmAsm.Rv64.WP.Branch entry (cr1.union cr2) := by
   wp_rv64_branch_not_taken_block_disjoint hd, br, tail
+
+example {nTail : Nat} {entry target : Word} {cr1 cr2 : CodeReq}
+    {post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : EvmAsm.Rv64.WP.Branch entry cr1)
+    (tail : cpsTripleWithin nTail br.exit_t target cr2 br.post_t post) :
+    EvmAsm.Rv64.WP.NBranch entry (cr1.union cr2) := by
+  wp_rv64_branch_taken_block_nbranch_disjoint hd, br, tail
 
 example {entry : Word} {cr : CodeReq}
     (br : EvmAsm.Rv64.WP.Branch entry cr) :

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -243,6 +243,42 @@ macro_rules
   | `(tactic| wp_rv64_nbranch_weaken_head $br:term, $hpost:term) =>
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchWeakenHeadPost $br (by rfl) $hpost)
 
+/-- Weaken exactly two known exits of an N-way branch. The exits field is
+    expected to reduce definitionally to the two-exit list. -/
+syntax (name := wpRv64NBranchWeakenPosts2Tac)
+  "wp_rv64_nbranch_weaken_posts2 " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_weaken_posts2 $br:term, $h1:term, $h2:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchWeakenPosts2 $br (by rfl) $h1 $h2)
+
+/-- Weaken exactly three known exits of an N-way branch. The exits field is
+    expected to reduce definitionally to the three-exit list. -/
+syntax (name := wpRv64NBranchWeakenPosts3Tac)
+  "wp_rv64_nbranch_weaken_posts3 " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_weaken_posts3 $br:term, $h1:term, $h2:term, $h3:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchWeakenPosts3 $br (by rfl) $h1 $h2 $h3)
+
+/-- Weaken exactly four known exits of an N-way branch. The exits field is
+    expected to reduce definitionally to the four-exit list. -/
+syntax (name := wpRv64NBranchWeakenPosts4Tac)
+  "wp_rv64_nbranch_weaken_posts4 " term ", " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_weaken_posts4 $br:term, $h1:term, $h2:term, $h3:term, $h4:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchWeakenPosts4 $br (by rfl) $h1 $h2 $h3 $h4)
+
+/-- Weaken exactly four known exits of an N-way branch, supplying the generated
+    exit-list proof explicitly. -/
+syntax (name := wpRv64NBranchWeakenPosts4WithTac)
+  "wp_rv64_nbranch_weaken_posts4_with " term ", " term ", " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_weaken_posts4_with $br:term, $hexits:term, $h1:term, $h2:term, $h3:term, $h4:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchWeakenPosts4 $br $hexits $h1 $h2 $h3 $h4)
+
 /-- Display the computed precondition field of a WP/CFG certificate. -/
 syntax (name := wpRv64Cmd) "#wp_rv64 " term : command
 
@@ -404,6 +440,28 @@ example {entry l : Word} {cr : CodeReq} {headPost headPost' : Assertion}
     (hpost : EvmAsm.Rv64.WP.Entails headPost headPost') :
     EvmAsm.Rv64.WP.NBranch entry cr := by
   exact EvmAsm.Rv64.WP.CFG.nbranchWeakenHeadPost br hexits hpost
+
+example {entry l1 l2 l3 l4 : Word} {cr : CodeReq}
+    {Q1 Q2 Q3 Q4 Q1' Q2' Q3' Q4' : Assertion}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)])
+    (h1 : EvmAsm.Rv64.WP.Entails Q1 Q1')
+    (h2 : EvmAsm.Rv64.WP.Entails Q2 Q2')
+    (h3 : EvmAsm.Rv64.WP.Entails Q3 Q3')
+    (h4 : EvmAsm.Rv64.WP.Entails Q4 Q4') :
+    EvmAsm.Rv64.WP.NBranch entry cr := by
+  exact EvmAsm.Rv64.WP.CFG.nbranchWeakenPosts4 br hexits h1 h2 h3 h4
+
+example {entry l1 l2 l3 l4 : Word} {cr : CodeReq}
+    {Q1 Q2 Q3 Q4 Q1' Q2' Q3' Q4' : Assertion}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)])
+    (h1 : EvmAsm.Rv64.WP.Entails Q1 Q1')
+    (h2 : EvmAsm.Rv64.WP.Entails Q2 Q2')
+    (h3 : EvmAsm.Rv64.WP.Entails Q3 Q3')
+    (h4 : EvmAsm.Rv64.WP.Entails Q4 Q4') :
+    EvmAsm.Rv64.WP.NBranch entry cr := by
+  wp_rv64_nbranch_weaken_posts4_with br, hexits, h1, h2, h3, h4
 
 example {entry head l : Word} {cr1 cr2 : CodeReq}
     {headPost secondPost : Assertion} {others : List (Word × Assertion)}

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -47,6 +47,14 @@ macro_rules
   | `(tactic| wp_rv64_frame $cfg:term, $F:term, $hF:term) =>
       `(tactic| exact EvmAsm.Rv64.WP.CFG.frameR $cfg $F $hF)
 
+/-- Build a certificate for an unreachable precondition. -/
+syntax (name := wpRv64UnreachableTac)
+  "wp_rv64_unreachable " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_unreachable $entry:term, $exit:term, $cr:term, $hpre:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.unreachable $entry $exit $cr $hpre)
+
 /-- Compose a head CPS triple with a WP/CFG tail and close the midpoint
     entailment with `wp_rv64_link`. -/
 syntax (name := wpRv64SeqTac) "wp_rv64_seq " term ", " term : tactic
@@ -301,6 +309,11 @@ example {entry exit_ : Word} {cr : CodeReq} {post F : Assertion}
     (cfg : EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post) (hF : F.pcFree) :
     EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr (post ** F) := by
   wp_rv64_frame cfg, F, hF
+
+example {entry exit_ : Word} {cr : CodeReq} {pre post : Assertion}
+    (hpre : ∀ h, pre h → False) :
+    EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post := by
+  wp_rv64_unreachable entry, exit_, cr, hpre
 
 example {P : Assertion} {A : Prop} (hA : A) :
     EvmAsm.Rv64.WP.Entails P (P ** ⌜A⌝) := by

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -109,6 +109,15 @@ macro_rules
       `(tactic| exact EvmAsm.Rv64.WP.CFG.branchSeqNotTakenBlockDisjoint $hd $br $tail
         (by wp_rv64_link))
 
+/-- Continue a branch's not-taken exit with an N-way branch over disjoint code. -/
+syntax (name := wpRv64BranchSeqNotTakenNBranchDisjointTac)
+  "wp_rv64_branch_not_taken_nbranch_disjoint " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_branch_not_taken_nbranch_disjoint $hd:term, $br:term, $tail:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.branchSeqNotTakenNBranchDisjoint $hd $br $tail
+        (by wp_rv64_link))
+
 /-- Display the computed precondition field of a WP/CFG certificate. -/
 syntax (name := wpRv64Cmd) "#wp_rv64 " term : command
 
@@ -182,5 +191,27 @@ example {nTail : Nat} {entry target : Word} {cr1 cr2 : CodeReq}
     (tail : cpsTripleWithin nTail br.exit_f target cr2 br.post_f post) :
     EvmAsm.Rv64.WP.Branch entry (cr1.union cr2) := by
   wp_rv64_branch_not_taken_block_disjoint hd, br, tail
+
+example {entry : Word} {cr : CodeReq}
+    (br : EvmAsm.Rv64.WP.Branch entry cr) :
+    EvmAsm.Rv64.WP.NBranch entry cr :=
+  EvmAsm.Rv64.WP.CFG.nbranchOfBranch br
+
+example {entry : Word} {cr1 cr2 : CodeReq}
+    (hd : cr1.Disjoint cr2)
+    (br : EvmAsm.Rv64.WP.Branch entry cr1)
+    (tail : EvmAsm.Rv64.WP.NBranch br.exit_f cr2)
+    (hlink : EvmAsm.Rv64.WP.Entails br.post_f tail.pre) :
+    EvmAsm.Rv64.WP.NBranch entry (cr1.union cr2) :=
+  EvmAsm.Rv64.WP.CFG.branchSeqNotTakenNBranchDisjoint hd br tail hlink
+
+example {nTail : Nat} {entry : Word} {cr1 cr2 : CodeReq}
+    {exits : List (Word × Assertion)}
+    (hd : cr1.Disjoint cr2)
+    (br : EvmAsm.Rv64.WP.Branch entry cr1)
+    (tailSound : cpsNBranchWithin nTail br.exit_f cr2 br.post_f exits) :
+    EvmAsm.Rv64.WP.NBranch entry (cr1.union cr2) := by
+  let tail := EvmAsm.Rv64.WP.NBranch.ofSpec tailSound
+  wp_rv64_branch_not_taken_nbranch_disjoint hd, br, tail
 
 end EvmAsm.Rv64.Tactics.WPTests

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -190,18 +190,50 @@ macro_rules
         | intro _ _hp; dsimp at _hp ⊢; simp only [rv64_wp] at _hp ⊢; xperm_hyp _hp
         | intro _ _hp; dsimp at _hp ⊢; simp only [rv64_wp] at _hp ⊢; xperm_pure _hp)
 
-/-- Close a `CodeReq.Disjoint` goal using the structural prover shared with
-    `seqFrame`.  This keeps WP composition proofs from spelling out code-range
-    side conditions for generated straight-line fragments. -/
+private def closeDisjointWithLocal (goal : MVarId) (goalType : Expr) : TacticM Bool := do
+  for localDecl in ← getLCtx do
+    unless localDecl.isImplementationDetail do
+      let localType ← instantiateMVars localDecl.type
+      if ← withoutModifyingState (isDefEq localType goalType) then
+        goal.assign (mkFVar localDecl.fvarId)
+        replaceMainGoal []
+        return true
+  return false
+
+private def closeDisjointWithHint (goal : MVarId) : TacticM Unit := do
+  let entries := rv64WpDisjointExt.getState (← getEnv)
+  for declName in entries do
+    let saved ← saveState
+    try
+      closeWithWpHint goal declName
+      return
+    catch _ =>
+      restoreState saved
+      continue
+  throwError "wp_rv64_disjoint: no @[rv64_wp_disjoint] theorem closed the goal"
+
+/-- Close a `CodeReq.Disjoint` goal using local hypotheses, the structural prover
+    shared with `seqFrame`, or declarations tagged with `@[rv64_wp_disjoint]`.
+    This keeps WP composition proofs from spelling out code-range side
+    conditions for generated straight-line fragments and semantic code ranges. -/
 elab "wp_rv64_disjoint" : tactic => withMainContext do
   let goal ← getMainGoal
-  let goalType ← goal.getType
+  let goalType ← instantiateMVars (← goal.getType)
+  let goalType ← whnfR goalType
   unless goalType.isAppOfArity ``EvmAsm.Rv64.CodeReq.Disjoint 2 do
     throwError "wp_rv64_disjoint: expected CodeReq.Disjoint goal"
-  let cr1 := goalType.getAppArgs[0]!
-  let cr2 := goalType.getAppArgs[1]!
-  let proof ← withTransparency .all <| buildDisjointProof cr1 cr2
-  goal.assign proof
+  if ← closeDisjointWithLocal goal goalType then
+    return
+  let saved ← saveState
+  try
+    let cr1 := goalType.getAppArgs[0]!
+    let cr2 := goalType.getAppArgs[1]!
+    let proof ← withTransparency .all <| buildDisjointProof cr1 cr2
+    goal.assign proof
+    replaceMainGoal []
+  catch _ =>
+    restoreState saved
+    closeDisjointWithHint (← getMainGoal)
 
 /-- Frame a single-exit CFG certificate and return the framed certificate. -/
 syntax (name := wpRv64FrameRTac) "wp_rv64_frame " term ", " term ", " term : tactic
@@ -456,6 +488,28 @@ syntax (name := wpRv64NBranchSeqThirdCertDisjointWithTac)
 macro_rules
   | `(tactic| wp_rv64_nbranch_third_cert_disjoint_with $hd:term, $br:term, $hexits:term, $tail:term, $hlink:term) =>
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchSeqThirdCertDisjoint $hd $br $hexits $tail $hlink)
+
+/-- Continue the third exit of a four-way N-branch with a single-exit CFG,
+    supplying the normalized exit-list proof and synthesizing the midpoint
+    entailment with `wp_rv64_link`. -/
+syntax (name := wpRv64NBranchSeqThirdCertDisjointWithAutoTac)
+  "wp_rv64_nbranch_third_cert_disjoint_with_auto " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_third_cert_disjoint_with_auto $hd:term, $br:term, $hexits:term, $tail:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchSeqThirdCertDisjoint $hd $br $hexits $tail
+        (by wp_rv64_link))
+
+/-- Continue the third exit of a four-way N-branch with a single-exit CFG,
+    synthesizing both the code disjointness side condition and midpoint
+    entailment. -/
+syntax (name := wpRv64NBranchSeqThirdCertAutoTac)
+  "wp_rv64_nbranch_third_cert_auto " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_third_cert_auto $br:term, $hexits:term, $tail:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchSeqThirdCertDisjoint
+        (by wp_rv64_disjoint) $br $hexits $tail (by wp_rv64_link))
 
 /-- Frame every exit of an N-way branch with a PC-free assertion. -/
 syntax (name := wpRv64NBranchFrameRTac)
@@ -924,6 +978,24 @@ example {entry l1 l2 l3 l4 l3' : Word} {cr1 cr2 : CodeReq}
     (hlink : EvmAsm.Rv64.WP.Entails Q3 tail.pre) :
     EvmAsm.Rv64.WP.NBranch entry (cr1.union cr2) := by
   wp_rv64_nbranch_third_cert_disjoint_with hd, br, hexits, tail, hlink
+
+example {entry l1 l2 l3 l4 : Word} {cr1 cr2 : CodeReq}
+    {Q1 Q2 Q3 Q4 : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : EvmAsm.Rv64.WP.NBranch entry cr1)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)]) :
+    EvmAsm.Rv64.WP.NBranch entry (cr1.union cr2) := by
+  let tail := EvmAsm.Rv64.WP.CFG.exit l3 cr2 (EvmAsm.Rv64.WP.Entails.refl Q3)
+  wp_rv64_nbranch_third_cert_disjoint_with_auto hd, br, hexits, tail
+
+example {entry l1 l2 l3 l4 : Word} {cr1 cr2 : CodeReq}
+    {Q1 Q2 Q3 Q4 : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : EvmAsm.Rv64.WP.NBranch entry cr1)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)]) :
+    EvmAsm.Rv64.WP.NBranch entry (cr1.union cr2) := by
+  let tail := EvmAsm.Rv64.WP.CFG.exit l3 cr2 (EvmAsm.Rv64.WP.Entails.refl Q3)
+  wp_rv64_nbranch_third_cert_auto br, hexits, tail
 
 example {entry : Word} {cr : CodeReq} {F : Assertion}
     (br : EvmAsm.Rv64.WP.NBranch entry cr) (hF : F.pcFree) :

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -73,6 +73,15 @@ macro_rules
       `(tactic| exact (EvmAsm.Rv64.WP.CFG.seqBlockDisjoint $hd $head $tail
         (by wp_rv64_link)).sound)
 
+/-- Compose a CPS block with an N-way CFG over disjoint code. -/
+syntax (name := wpRv64SeqBlockNBranchDisjointTac)
+  "wp_rv64_seq_block_nbranch_disjoint " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_seq_block_nbranch_disjoint $hd:term, $head:term, $tail:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.seqBlockNBranchDisjoint $hd $head $tail
+        (by wp_rv64_link))
+
 /-- Continue a branch's taken exit with a WP/CFG tail over disjoint code. -/
 syntax (name := wpRv64BranchSeqTakenDisjointTac)
   "wp_rv64_branch_taken_disjoint " term ", " term ", " term : tactic
@@ -146,6 +155,16 @@ syntax (name := wpRv64NBranchSeqHeadNBranchDisjointTac)
 macro_rules
   | `(tactic| wp_rv64_nbranch_head_nbranch_disjoint $hd:term, $br:term, $tail:term) =>
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchSeqHeadNBranchDisjoint $hd $br (by rfl) $tail
+        (by wp_rv64_link))
+
+/-- Preserve the first exit and continue the second exit with another N-way branch
+    over disjoint code. The tactic expects the exits field to reduce to a two-cons prefix. -/
+syntax (name := wpRv64NBranchSeqSecondNBranchDisjointTac)
+  "wp_rv64_nbranch_second_nbranch_disjoint " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_second_nbranch_disjoint $hd:term, $br:term, $tail:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchSeqSecondNBranchDisjoint $hd $br (by rfl) $tail
         (by wp_rv64_link))
 
 /-- Frame every exit of an N-way branch with a PC-free assertion. -/
@@ -315,5 +334,15 @@ example {entry l : Word} {cr : CodeReq} {headPost headPost' : Assertion}
     (hpost : EvmAsm.Rv64.WP.Entails headPost headPost') :
     EvmAsm.Rv64.WP.NBranch entry cr := by
   exact EvmAsm.Rv64.WP.CFG.nbranchWeakenHeadPost br hexits hpost
+
+example {entry head l : Word} {cr1 cr2 : CodeReq}
+    {headPost secondPost : Assertion} {others : List (Word × Assertion)}
+    (hd : cr1.Disjoint cr2)
+    (br : EvmAsm.Rv64.WP.NBranch entry cr1)
+    (hexits : br.exits = (head, headPost) :: (l, secondPost) :: others)
+    (tail : EvmAsm.Rv64.WP.NBranch l cr2)
+    (hlink : EvmAsm.Rv64.WP.Entails secondPost tail.pre) :
+    EvmAsm.Rv64.WP.NBranch entry (cr1.union cr2) := by
+  exact EvmAsm.Rv64.WP.CFG.nbranchSeqSecondNBranchDisjoint hd br hexits tail hlink
 
 end EvmAsm.Rv64.Tactics.WPTests

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -30,6 +30,21 @@ macro_rules
   | `(tactic| wp_rv64 $cfg:term) =>
       `(tactic| exact ($cfg).sound)
 
+private def solveMVarWithLocalHyp (mvarId : MVarId) : TacticM Bool := do
+  if ← mvarId.isAssigned then
+    return true
+  let target ← instantiateMVars (← mvarId.getType)
+  unless ← isProp target do
+    return false
+  for localDecl in ← getLCtx do
+    unless localDecl.isImplementationDetail do
+      let hyp := mkFVar localDecl.fvarId
+      let hypType ← instantiateMVars localDecl.type
+      if ← withoutModifyingState (isDefEq hypType target) then
+        mvarId.assign hyp
+        return true
+  return false
+
 private def closeWithWpEntailsHint (goal : MVarId) (declName : Name) : TacticM Unit := do
   let goalType ← instantiateMVars (← goal.getType)
   let hintConst ← mkConstWithFreshMVarLevels declName
@@ -37,6 +52,10 @@ private def closeWithWpEntailsHint (goal : MVarId) (declName : Name) : TacticM U
   let (params, _, body) ← forallMetaTelescope hintType
   unless ← isDefEq body goalType do
     throwError "hint result does not match goal"
+  for param in params do
+    let param ← instantiateMVars param
+    if param.isMVar then
+      let _ ← solveMVarWithLocalHyp param.mvarId!
   let proof ← instantiateMVars (mkAppN hintConst params)
   if proof.hasExprMVar then
     throwError "hint left unresolved metavariables"
@@ -435,6 +454,17 @@ macro_rules
   | `(tactic| wp_rv64_nbranch_weaken_posts2 $br:term, $h1:term, $h2:term) =>
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchWeakenPosts2 $br (by rfl) $h1 $h2)
 
+/-- Weaken exactly two known exits, synthesizing the per-exit entailments with
+    `wp_rv64_link`.  The supplied terms are the replacement postconditions. -/
+syntax (name := wpRv64NBranchWeakenPosts2AutoTac)
+  "wp_rv64_nbranch_weaken_posts2_auto " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_weaken_posts2_auto $br:term, $p1:term, $p2:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchWeakenPosts2 $br (by rfl)
+        (show EvmAsm.Rv64.WP.Entails _ $p1 by wp_rv64_link)
+        (show EvmAsm.Rv64.WP.Entails _ $p2 by wp_rv64_link))
+
 /-- Weaken exactly three known exits of an N-way branch. The exits field is
     expected to reduce definitionally to the three-exit list. -/
 syntax (name := wpRv64NBranchWeakenPosts3Tac)
@@ -443,6 +473,18 @@ syntax (name := wpRv64NBranchWeakenPosts3Tac)
 macro_rules
   | `(tactic| wp_rv64_nbranch_weaken_posts3 $br:term, $h1:term, $h2:term, $h3:term) =>
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchWeakenPosts3 $br (by rfl) $h1 $h2 $h3)
+
+/-- Weaken exactly three known exits, synthesizing the per-exit entailments with
+    `wp_rv64_link`.  The supplied terms are the replacement postconditions. -/
+syntax (name := wpRv64NBranchWeakenPosts3AutoTac)
+  "wp_rv64_nbranch_weaken_posts3_auto " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_weaken_posts3_auto $br:term, $p1:term, $p2:term, $p3:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchWeakenPosts3 $br (by rfl)
+        (show EvmAsm.Rv64.WP.Entails _ $p1 by wp_rv64_link)
+        (show EvmAsm.Rv64.WP.Entails _ $p2 by wp_rv64_link)
+        (show EvmAsm.Rv64.WP.Entails _ $p3 by wp_rv64_link))
 
 /-- Weaken exactly four known exits of an N-way branch. The exits field is
     expected to reduce definitionally to the four-exit list. -/
@@ -453,6 +495,19 @@ macro_rules
   | `(tactic| wp_rv64_nbranch_weaken_posts4 $br:term, $h1:term, $h2:term, $h3:term, $h4:term) =>
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchWeakenPosts4 $br (by rfl) $h1 $h2 $h3 $h4)
 
+/-- Weaken exactly four known exits, synthesizing the per-exit entailments with
+    `wp_rv64_link`.  The supplied terms are the replacement postconditions. -/
+syntax (name := wpRv64NBranchWeakenPosts4AutoTac)
+  "wp_rv64_nbranch_weaken_posts4_auto " term ", " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_weaken_posts4_auto $br:term, $p1:term, $p2:term, $p3:term, $p4:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchWeakenPosts4 $br (by rfl)
+        (show EvmAsm.Rv64.WP.Entails _ $p1 by wp_rv64_link)
+        (show EvmAsm.Rv64.WP.Entails _ $p2 by wp_rv64_link)
+        (show EvmAsm.Rv64.WP.Entails _ $p3 by wp_rv64_link)
+        (show EvmAsm.Rv64.WP.Entails _ $p4 by wp_rv64_link))
+
 /-- Weaken exactly four known exits of an N-way branch, supplying the generated
     exit-list proof explicitly. -/
 syntax (name := wpRv64NBranchWeakenPosts4WithTac)
@@ -461,6 +516,19 @@ syntax (name := wpRv64NBranchWeakenPosts4WithTac)
 macro_rules
   | `(tactic| wp_rv64_nbranch_weaken_posts4_with $br:term, $hexits:term, $h1:term, $h2:term, $h3:term, $h4:term) =>
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchWeakenPosts4 $br $hexits $h1 $h2 $h3 $h4)
+
+/-- Weaken exactly four known exits with an explicit exit-list proof,
+    synthesizing the per-exit entailments with `wp_rv64_link`. -/
+syntax (name := wpRv64NBranchWeakenPosts4WithAutoTac)
+  "wp_rv64_nbranch_weaken_posts4_with_auto " term ", " term ", " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_weaken_posts4_with_auto $br:term, $hexits:term, $p1:term, $p2:term, $p3:term, $p4:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchWeakenPosts4 $br $hexits
+        (show EvmAsm.Rv64.WP.Entails _ $p1 by wp_rv64_link)
+        (show EvmAsm.Rv64.WP.Entails _ $p2 by wp_rv64_link)
+        (show EvmAsm.Rv64.WP.Entails _ $p3 by wp_rv64_link)
+        (show EvmAsm.Rv64.WP.Entails _ $p4 by wp_rv64_link))
 
 /-- Join exactly four known exits of an N-way branch, supplying the generated
     exit-list proof and one continuation per exit. -/
@@ -695,6 +763,13 @@ example {entry l1 l2 l3 l4 : Word} {cr : CodeReq}
     (h4 : EvmAsm.Rv64.WP.Entails Q4 Q4') :
     EvmAsm.Rv64.WP.NBranch entry cr := by
   wp_rv64_nbranch_weaken_posts4_with br, hexits, h1, h2, h3, h4
+
+example {entry l1 l2 l3 l4 : Word} {cr : CodeReq}
+    {Q1 Q2 Q3 Q4 : Assertion}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)]) :
+    EvmAsm.Rv64.WP.NBranch entry cr := by
+  wp_rv64_nbranch_weaken_posts4_with_auto br, hexits, Q1, Q2, Q3, Q4
 
 example {entry exit_ l1 l2 l3 l4 : Word} {cr : CodeReq} {post Q1 Q2 Q3 Q4 : Assertion}
     (br : EvmAsm.Rv64.WP.NBranch entry cr)

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -9,7 +9,7 @@
 import Lean
 import EvmAsm.Rv64.WP.CFG
 import EvmAsm.Rv64.WP.Call
-import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Rv64.Tactics.XPermPure
 
 namespace EvmAsm.Rv64.Tactics
 
@@ -37,7 +37,15 @@ macro_rules
   | `(tactic| wp_rv64_link) =>
       `(tactic| first
         | exact EvmAsm.Rv64.WP.Entails.refl _
-        | intro _ _hp; xperm_hyp _hp)
+        | intro _ _hp; xperm_hyp _hp
+        | intro _ _hp; xperm_pure _hp)
+
+/-- Frame a single-exit CFG certificate and return the framed certificate. -/
+syntax (name := wpRv64FrameRTac) "wp_rv64_frame " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_frame $cfg:term, $F:term, $hF:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.frameR $cfg $F $hF)
 
 /-- Compose a head CPS triple with a WP/CFG tail and close the midpoint
     entailment with `wp_rv64_link`. -/
@@ -230,6 +238,15 @@ example {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     (cfg : EvmAsm.Rv64.WP.Triple entry exit_ cr post) :
     cpsTripleWithin cfg.nSteps entry exit_ cr cfg.pre post := by
   wp_rv64 cfg
+
+example {entry exit_ : Word} {cr : CodeReq} {post F : Assertion}
+    (cfg : EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post) (hF : F.pcFree) :
+    EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr (post ** F) := by
+  wp_rv64_frame cfg, F, hF
+
+example {P : Assertion} {A : Prop} (hA : A) :
+    EvmAsm.Rv64.WP.Entails P (P ** ⌜A⌝) := by
+  wp_rv64_link
 
 example {nSteps : Nat} {entry mid exit_ : Word} {cr : CodeReq}
     {pre post : Assertion}

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -287,6 +287,16 @@ macro_rules
   | `(tactic| wp_rv64_nbranch_weaken_posts4_with $br:term, $hexits:term, $h1:term, $h2:term, $h3:term, $h4:term) =>
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchWeakenPosts4 $br $hexits $h1 $h2 $h3 $h4)
 
+/-- Join exactly four known exits of an N-way branch, supplying the generated
+    exit-list proof and one continuation per exit. -/
+syntax (name := wpRv64NBranchJoin4WithTac)
+  "wp_rv64_nbranch_join4_with " term ", " term ", " term ", " term ", " term ", " term ", " term ", " term ", " term ", " term ", " term ", " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_join4_with $br:term, $hexits:term, $tailBound:term, $t1:term, $hlink1:term, $h1:term, $t2:term, $hlink2:term, $h2:term, $t3:term, $hlink3:term, $h3:term, $t4:term, $hlink4:term, $h4:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchJoin4 $br $hexits $tailBound
+        $t1 $t2 $t3 $t4 $hlink1 $hlink2 $hlink3 $hlink4 $h1 $h2 $h3 $h4)
+
 /-- Display the computed precondition field of a WP/CFG certificate. -/
 syntax (name := wpRv64Cmd) "#wp_rv64 " term : command
 
@@ -475,6 +485,25 @@ example {entry l1 l2 l3 l4 : Word} {cr : CodeReq}
     (h4 : EvmAsm.Rv64.WP.Entails Q4 Q4') :
     EvmAsm.Rv64.WP.NBranch entry cr := by
   wp_rv64_nbranch_weaken_posts4_with br, hexits, h1, h2, h3, h4
+
+example {entry exit_ l1 l2 l3 l4 : Word} {cr : CodeReq} {post Q1 Q2 Q3 Q4 : Assertion}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)])
+    (t1 : EvmAsm.Rv64.WP.CFG.Cert l1 exit_ cr post)
+    (t2 : EvmAsm.Rv64.WP.CFG.Cert l2 exit_ cr post)
+    (t3 : EvmAsm.Rv64.WP.CFG.Cert l3 exit_ cr post)
+    (t4 : EvmAsm.Rv64.WP.CFG.Cert l4 exit_ cr post)
+    (hlink1 : EvmAsm.Rv64.WP.Entails Q1 t1.pre)
+    (hlink2 : EvmAsm.Rv64.WP.Entails Q2 t2.pre)
+    (hlink3 : EvmAsm.Rv64.WP.Entails Q3 t3.pre)
+    (hlink4 : EvmAsm.Rv64.WP.Entails Q4 t4.pre) :
+    EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post := by
+  wp_rv64_nbranch_join4_with br, hexits, Nat.max (Nat.max t1.nSteps t2.nSteps)
+    (Nat.max t3.nSteps t4.nSteps),
+    t1, hlink1, Nat.le_trans (Nat.le_max_left _ _) (Nat.le_max_left _ _),
+    t2, hlink2, Nat.le_trans (Nat.le_max_right _ _) (Nat.le_max_left _ _),
+    t3, hlink3, Nat.le_trans (Nat.le_max_left _ _) (Nat.le_max_right _ _),
+    t4, hlink4, Nat.le_trans (Nat.le_max_right _ _) (Nat.le_max_right _ _)
 
 example {entry head l : Word} {cr1 cr2 : CodeReq}
     {headPost secondPost : Assertion} {others : List (Word × Assertion)}

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -212,10 +212,11 @@ private def closeDisjointWithHint (goal : MVarId) : TacticM Unit := do
       continue
   throwError "wp_rv64_disjoint: no @[rv64_wp_disjoint] theorem closed the goal"
 
-/-- Close a `CodeReq.Disjoint` goal using local hypotheses, the structural prover
-    shared with `seqFrame`, or declarations tagged with `@[rv64_wp_disjoint]`.
-    This keeps WP composition proofs from spelling out code-range side
-    conditions for generated straight-line fragments and semantic code ranges. -/
+/-- Close a `CodeReq.Disjoint` goal using local hypotheses, declarations
+    tagged with `@[rv64_wp_disjoint]`, or the structural prover shared with
+    `seqFrame`. This keeps WP composition proofs from spelling out code-range
+    side conditions for generated straight-line fragments and semantic code
+    ranges. -/
 elab "wp_rv64_disjoint" : tactic => withMainContext do
   let goal ← getMainGoal
   let goalType ← instantiateMVars (← goal.getType)
@@ -224,16 +225,16 @@ elab "wp_rv64_disjoint" : tactic => withMainContext do
     throwError "wp_rv64_disjoint: expected CodeReq.Disjoint goal"
   if ← closeDisjointWithLocal goal goalType then
     return
-  let saved ← saveState
+  let savedHint ← saveState
   try
+    closeDisjointWithHint goal
+  catch _ =>
+    restoreState savedHint
     let cr1 := goalType.getAppArgs[0]!
     let cr2 := goalType.getAppArgs[1]!
     let proof ← withTransparency .all <| buildDisjointProof cr1 cr2
-    goal.assign proof
+    (← getMainGoal).assign proof
     replaceMainGoal []
-  catch _ =>
-    restoreState saved
-    closeDisjointWithHint (← getMainGoal)
 
 /-- Frame a single-exit CFG certificate and return the framed certificate. -/
 syntax (name := wpRv64FrameRTac) "wp_rv64_frame " term ", " term ", " term : tactic
@@ -266,6 +267,62 @@ macro_rules
   | `(tactic| wp_rv64_seq_disjoint $hd:term, $head:term, $tail:term) =>
       `(tactic| exact (EvmAsm.Rv64.WP.Triple.seqDisjoint $hd $head $tail
         (by wp_rv64_link)).sound)
+
+/-- Build a single-exit CFG certificate by composing a head CPS triple with a
+    tail certificate over disjoint code, supplying the midpoint entailment. -/
+syntax (name := wpRv64CfgSeqDisjointWithTac)
+  "wp_rv64_cfg_seq_disjoint_with " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_cfg_seq_disjoint_with $hd:term, $head:term, $tail:term, $hlink:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.seqDisjoint $hd $head $tail $hlink)
+
+/-- Build a single-exit CFG certificate by composing a head CPS triple with a
+    tail certificate over disjoint code, synthesizing the midpoint entailment. -/
+syntax (name := wpRv64CfgSeqDisjointWithAutoTac)
+  "wp_rv64_cfg_seq_disjoint_with_auto " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_cfg_seq_disjoint_with_auto $hd:term, $head:term, $tail:term) =>
+      `(tactic| wp_rv64_cfg_seq_disjoint_with $hd, $head, $tail, (by wp_rv64_link))
+
+/-- Build a single-exit CFG certificate by composing a head CPS triple with a
+    tail certificate over disjoint code, synthesizing disjointness and the
+    midpoint entailment. -/
+syntax (name := wpRv64CfgSeqDisjointAutoTac)
+  "wp_rv64_cfg_seq_disjoint_auto " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_cfg_seq_disjoint_auto $head:term, $tail:term) =>
+      `(tactic| wp_rv64_cfg_seq_disjoint_with_auto (by wp_rv64_disjoint), $head, $tail)
+
+/-- Build a single-exit CFG certificate by composing a head certificate with a
+    tail certificate over disjoint code, supplying the midpoint entailment. -/
+syntax (name := wpRv64CfgCertSeqDisjointWithTac)
+  "wp_rv64_cfg_cert_seq_disjoint_with " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_cfg_cert_seq_disjoint_with $hd:term, $head:term, $tail:term, $hlink:term) =>
+      `(tactic| wp_rv64_cfg_seq_disjoint_with $hd, ($head).sound, $tail, $hlink)
+
+/-- Build a single-exit CFG certificate by composing a head certificate with a
+    tail certificate over disjoint code, synthesizing the midpoint entailment. -/
+syntax (name := wpRv64CfgCertSeqDisjointWithAutoTac)
+  "wp_rv64_cfg_cert_seq_disjoint_with_auto " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_cfg_cert_seq_disjoint_with_auto $hd:term, $head:term, $tail:term) =>
+      `(tactic| wp_rv64_cfg_seq_disjoint_with_auto $hd, ($head).sound, $tail)
+
+/-- Build a single-exit CFG certificate by composing a head certificate with a
+    tail certificate over disjoint code, synthesizing disjointness and the
+    midpoint entailment. -/
+syntax (name := wpRv64CfgCertSeqDisjointAutoTac)
+  "wp_rv64_cfg_cert_seq_disjoint_auto " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_cfg_cert_seq_disjoint_auto $head:term, $tail:term) =>
+      `(tactic| wp_rv64_cfg_seq_disjoint_auto ($head).sound, $tail)
 
 /-- Compose two adjacent CPS blocks over one shared persistent code requirement. -/
 syntax (name := wpRv64SeqBlockTac) "wp_rv64_seq_block " term ", " term : tactic
@@ -875,6 +932,21 @@ example {nHead nTail : Nat} {entry mid exit_ : Word} {cr1 cr2 : CodeReq}
     (tail : cpsTripleWithin nTail mid exit_ cr2 midPost post) :
     cpsTripleWithin (nHead + nTail) entry exit_ (cr1.union cr2) pre post := by
   wp_rv64_seq_block_disjoint hd, head, tail
+
+example {nHead : Nat} {entry mid : Word} {cr1 cr2 : CodeReq}
+    {pre midPost : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (head : cpsTripleWithin nHead entry mid cr1 pre midPost) :
+    EvmAsm.Rv64.WP.CFG.Cert entry mid (cr1.union cr2) midPost := by
+  let tail := EvmAsm.Rv64.WP.CFG.exit mid cr2 (EvmAsm.Rv64.WP.Entails.refl midPost)
+  wp_rv64_cfg_seq_disjoint_auto head, tail
+
+example {entry mid : Word} {cr1 cr2 : CodeReq} {post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (head : EvmAsm.Rv64.WP.CFG.Cert entry mid cr1 post) :
+    EvmAsm.Rv64.WP.CFG.Cert entry mid (cr1.union cr2) post := by
+  let tail := EvmAsm.Rv64.WP.CFG.exit mid cr2 (EvmAsm.Rv64.WP.Entails.refl post)
+  wp_rv64_cfg_cert_seq_disjoint_auto head, tail
 
 example {nTail : Nat} {entry target : Word} {cr1 cr2 : CodeReq}
     {tailPre post : Assertion}

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -7,6 +7,7 @@
 -/
 
 import Lean
+import EvmAsm.Rv64.Tactics.WPAttr
 import EvmAsm.Rv64.WP.CFG
 import EvmAsm.Rv64.WP.Call
 import EvmAsm.Rv64.Tactics.XPermPure
@@ -38,7 +39,9 @@ macro_rules
       `(tactic| first
         | exact EvmAsm.Rv64.WP.Entails.refl _
         | intro _ _hp; xperm_hyp _hp
-        | intro _ _hp; xperm_pure _hp)
+        | intro _ _hp; xperm_pure _hp
+        | intro _ _hp; simp only [rv64_wp] at _hp ⊢; xperm_hyp _hp
+        | intro _ _hp; simp only [rv64_wp] at _hp ⊢; xperm_pure _hp)
 
 /-- Frame a single-exit CFG certificate and return the framed certificate. -/
 syntax (name := wpRv64FrameRTac) "wp_rv64_frame " term ", " term ", " term : tactic

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -10,11 +10,12 @@ import Lean
 import EvmAsm.Rv64.Tactics.WPAttr
 import EvmAsm.Rv64.WP.CFG
 import EvmAsm.Rv64.WP.Call
+import EvmAsm.Rv64.Tactics.SeqFrame
 import EvmAsm.Rv64.Tactics.XPermPure
 
 namespace EvmAsm.Rv64.Tactics
 
-open Lean Elab Tactic
+open Lean Meta Elab Tactic
 
 /-- Close a `cpsTripleWithin` goal with a `WP.Triple`/`WP.CFG.Cert`.
 
@@ -42,6 +43,19 @@ macro_rules
         | intro _ _hp; xperm_pure _hp
         | intro _ _hp; simp only [rv64_wp] at _hp ⊢; xperm_hyp _hp
         | intro _ _hp; simp only [rv64_wp] at _hp ⊢; xperm_pure _hp)
+
+/-- Close a `CodeReq.Disjoint` goal using the structural prover shared with
+    `seqFrame`.  This keeps WP composition proofs from spelling out code-range
+    side conditions for generated straight-line fragments. -/
+elab "wp_rv64_disjoint" : tactic => withMainContext do
+  let goal ← getMainGoal
+  let goalType ← goal.getType
+  unless goalType.isAppOfArity ``EvmAsm.Rv64.CodeReq.Disjoint 2 do
+    throwError "wp_rv64_disjoint: expected CodeReq.Disjoint goal"
+  let cr1 := goalType.getAppArgs[0]!
+  let cr2 := goalType.getAppArgs[1]!
+  let proof ← withTransparency .all <| buildDisjointProof cr1 cr2
+  goal.assign proof
 
 /-- Frame a single-exit CFG certificate and return the framed certificate. -/
 syntax (name := wpRv64FrameRTac) "wp_rv64_frame " term ", " term ", " term : tactic
@@ -605,5 +619,11 @@ example {entry l l' : Word} {cr1 cr2 : CodeReq}
     (hlink : EvmAsm.Rv64.WP.Entails exitPost tail.pre) :
     EvmAsm.Rv64.WP.NBranch entry (cr1.union cr2) := by
   wp_rv64_nbranch_exit_cert_disjoint_with hd, br, preExits, hexits, tail, hlink
+
+example :
+    EvmAsm.Rv64.CodeReq.Disjoint
+      (EvmAsm.Rv64.CodeReq.singleton (0 : Word) (.ADDI .x1 .x0 (0 : BitVec 12)))
+      (EvmAsm.Rv64.CodeReq.singleton (4 : Word) (.ADDI .x2 .x0 (0 : BitVec 12))) := by
+  wp_rv64_disjoint
 
 end EvmAsm.Rv64.Tactics.WPTests

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -28,14 +28,25 @@ macro_rules
   | `(tactic| wp_rv64 $cfg:term) =>
       `(tactic| exact ($cfg).sound)
 
+/-- Close the midpoint entailment between adjacent WP fragments.  The common
+    case is definitional equality of the head postcondition and tail WP; reordered
+    separation frames fall through to `xperm`. -/
+syntax (name := wpRv64LinkTac) "wp_rv64_link" : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_link) =>
+      `(tactic| first
+        | exact EvmAsm.Rv64.WP.Entails.refl _
+        | intro _ _hp; xperm_hyp _hp)
+
 /-- Compose a head CPS triple with a WP/CFG tail and close the midpoint
-    entailment by separation-conjunction permutation. -/
+    entailment with `wp_rv64_link`. -/
 syntax (name := wpRv64SeqTac) "wp_rv64_seq " term ", " term : tactic
 
 macro_rules
   | `(tactic| wp_rv64_seq $head:term, $tail:term) =>
       `(tactic| exact (EvmAsm.Rv64.WP.Triple.seq $head $tail
-        (by intro _ _hp; xperm_hyp _hp)).sound)
+        (by wp_rv64_link)).sound)
 
 /-- Disjoint-code version of `wp_rv64_seq`. -/
 syntax (name := wpRv64SeqDisjointTac) "wp_rv64_seq_disjoint " term ", " term ", " term : tactic
@@ -43,7 +54,7 @@ syntax (name := wpRv64SeqDisjointTac) "wp_rv64_seq_disjoint " term ", " term ", 
 macro_rules
   | `(tactic| wp_rv64_seq_disjoint $hd:term, $head:term, $tail:term) =>
       `(tactic| exact (EvmAsm.Rv64.WP.Triple.seqDisjoint $hd $head $tail
-        (by intro _ _hp; xperm_hyp _hp)).sound)
+        (by wp_rv64_link)).sound)
 
 /-- Display the computed precondition field of a WP/CFG certificate. -/
 syntax (name := wpRv64Cmd) "#wp_rv64 " term : command

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -543,6 +543,42 @@ macro_rules
         (show EvmAsm.Rv64.WP.Entails _ $p3 by wp_rv64_link)
         (show EvmAsm.Rv64.WP.Entails _ $p4 by wp_rv64_link))
 
+/-- Join exactly two known exits when the first exit is the only reachable one. -/
+syntax (name := wpRv64NBranchJoin2ResolveFirstTac)
+  "wp_rv64_nbranch_join2_resolve_first " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_join2_resolve_first $br:term, $hexits:term, $hlink1:term, $hdead2:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchJoin2ResolveFirst $br $hexits $hlink1 $hdead2)
+
+/-- Join exactly two known exits when the first exit is the only reachable one,
+    synthesizing the reachable-exit entailment with `wp_rv64_link`. -/
+syntax (name := wpRv64NBranchJoin2ResolveFirstAutoTac)
+  "wp_rv64_nbranch_join2_resolve_first_auto " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_join2_resolve_first_auto $br:term, $hexits:term, $post:term, $hdead2:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchJoin2ResolveFirst $br $hexits
+        (show EvmAsm.Rv64.WP.Entails _ $post by wp_rv64_link) $hdead2)
+
+/-- Join exactly two known exits when the second exit is the only reachable one. -/
+syntax (name := wpRv64NBranchJoin2ResolveSecondTac)
+  "wp_rv64_nbranch_join2_resolve_second " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_join2_resolve_second $br:term, $hexits:term, $hdead1:term, $hlink2:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchJoin2ResolveSecond $br $hexits $hdead1 $hlink2)
+
+/-- Join exactly two known exits when the second exit is the only reachable one,
+    synthesizing the reachable-exit entailment with `wp_rv64_link`. -/
+syntax (name := wpRv64NBranchJoin2ResolveSecondAutoTac)
+  "wp_rv64_nbranch_join2_resolve_second_auto " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_join2_resolve_second_auto $br:term, $hexits:term, $hdead1:term, $post:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchJoin2ResolveSecond $br $hexits $hdead1
+        (show EvmAsm.Rv64.WP.Entails _ $post by wp_rv64_link))
+
 /-- Join exactly four known exits of an N-way branch, supplying the generated
     exit-list proof and one continuation per exit. -/
 syntax (name := wpRv64NBranchJoin4WithTac)
@@ -790,6 +826,36 @@ example {entry l l3 l4 : Word} {cr : CodeReq}
     (hexits : br.exits = [(l, Q), (l, Q), (l3, Q3), (l4, Q4)]) :
     EvmAsm.Rv64.WP.NBranch entry cr := by
   wp_rv64_nbranch_weaken_posts4_merge_first_two_with_auto br, hexits, Q, Q3, Q4
+
+example {entry l1 l2 : Word} {cr : CodeReq} {post Q1 Q2 : Assertion}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2)])
+    (hlink1 : EvmAsm.Rv64.WP.Entails Q1 post)
+    (hdead2 : ∀ h, Q2 h → False) :
+    EvmAsm.Rv64.WP.CFG.Cert entry l1 cr post := by
+  wp_rv64_nbranch_join2_resolve_first br, hexits, hlink1, hdead2
+
+example {entry l1 l2 : Word} {cr : CodeReq} {Q1 Q2 : Assertion}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2)])
+    (hdead2 : ∀ h, Q2 h → False) :
+    EvmAsm.Rv64.WP.CFG.Cert entry l1 cr Q1 := by
+  wp_rv64_nbranch_join2_resolve_first_auto br, hexits, Q1, hdead2
+
+example {entry l1 l2 : Word} {cr : CodeReq} {post Q1 Q2 : Assertion}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2)])
+    (hdead1 : ∀ h, Q1 h → False)
+    (hlink2 : EvmAsm.Rv64.WP.Entails Q2 post) :
+    EvmAsm.Rv64.WP.CFG.Cert entry l2 cr post := by
+  wp_rv64_nbranch_join2_resolve_second br, hexits, hdead1, hlink2
+
+example {entry l1 l2 : Word} {cr : CodeReq} {Q1 Q2 : Assertion}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2)])
+    (hdead1 : ∀ h, Q1 h → False) :
+    EvmAsm.Rv64.WP.CFG.Cert entry l2 cr Q2 := by
+  wp_rv64_nbranch_join2_resolve_second_auto br, hexits, hdead1, Q2
 
 example {entry exit_ l1 l2 l3 l4 : Word} {cr : CodeReq} {post Q1 Q2 Q3 Q4 : Assertion}
     (br : EvmAsm.Rv64.WP.NBranch entry cr)

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -73,6 +73,24 @@ macro_rules
       `(tactic| exact (EvmAsm.Rv64.WP.CFG.seqBlockDisjoint $hd $head $tail
         (by wp_rv64_link)).sound)
 
+/-- Continue a branch's taken exit with a WP/CFG tail over disjoint code. -/
+syntax (name := wpRv64BranchSeqTakenDisjointTac)
+  "wp_rv64_branch_taken_disjoint " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_branch_taken_disjoint $hd:term, $br:term, $tail:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.branchSeqTakenDisjoint $hd $br $tail
+        (by wp_rv64_link))
+
+/-- Continue a branch's taken exit with a CPS leaf over disjoint code. -/
+syntax (name := wpRv64BranchSeqTakenBlockDisjointTac)
+  "wp_rv64_branch_taken_block_disjoint " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_branch_taken_block_disjoint $hd:term, $br:term, $tail:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.branchSeqTakenBlockDisjoint $hd $br $tail
+        (by wp_rv64_link))
+
 /-- Display the computed precondition field of a WP/CFG certificate. -/
 syntax (name := wpRv64Cmd) "#wp_rv64 " term : command
 
@@ -112,5 +130,22 @@ example {nHead nTail : Nat} {entry mid exit_ : Word} {cr1 cr2 : CodeReq}
     (tail : cpsTripleWithin nTail mid exit_ cr2 midPost post) :
     cpsTripleWithin (nHead + nTail) entry exit_ (cr1.union cr2) pre post := by
   wp_rv64_seq_block_disjoint hd, head, tail
+
+example {nTail : Nat} {entry target : Word} {cr1 cr2 : CodeReq}
+    {tailPre post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : EvmAsm.Rv64.WP.Branch entry cr1)
+    (tail : cpsTripleWithin nTail br.exit_t target cr2 tailPre post)
+    (hlink : EvmAsm.Rv64.WP.Entails br.post_t tailPre) :
+    EvmAsm.Rv64.WP.Branch entry (cr1.union cr2) := by
+  exact EvmAsm.Rv64.WP.CFG.branchSeqTakenBlockDisjoint hd br tail hlink
+
+example {nTail : Nat} {entry target : Word} {cr1 cr2 : CodeReq}
+    {post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : EvmAsm.Rv64.WP.Branch entry cr1)
+    (tail : cpsTripleWithin nTail br.exit_t target cr2 br.post_t post) :
+    EvmAsm.Rv64.WP.Branch entry (cr1.union cr2) := by
+  wp_rv64_branch_taken_block_disjoint hd, br, tail
 
 end EvmAsm.Rv64.Tactics.WPTests

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -157,6 +157,16 @@ macro_rules
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchSeqHeadNBranchDisjoint $hd $br (by rfl) $tail
         (by wp_rv64_link))
 
+/-- Continue an arbitrary exit with another N-way branch over disjoint code.
+    The preExits argument is the list of exits to preserve before the selected exit. -/
+syntax (name := wpRv64NBranchSeqExitNBranchDisjointTac)
+  "wp_rv64_nbranch_exit_nbranch_disjoint " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_exit_nbranch_disjoint $hd:term, $br:term, $preExits:term, $tail:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchSeqExitNBranchDisjoint
+        (preExits := $preExits) $hd $br (by rfl) $tail (by wp_rv64_link))
+
 /-- Preserve the first exit and continue the second exit with another N-way branch
     over disjoint code. The tactic expects the exits field to reduce to a two-cons prefix. -/
 syntax (name := wpRv64NBranchSeqSecondNBranchDisjointTac)

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -128,6 +128,26 @@ macro_rules
       `(tactic| exact EvmAsm.Rv64.WP.CFG.branchSeqNotTakenNBranchDisjoint $hd $br $tail
         (by wp_rv64_link))
 
+/-- Continue the head exit of an N-way branch with a CPS leaf over disjoint code.
+    The tactic expects the N-branch exits field to reduce to a cons. -/
+syntax (name := wpRv64NBranchSeqHeadBlockDisjointTac)
+  "wp_rv64_nbranch_head_block_disjoint " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_head_block_disjoint $hd:term, $br:term, $tail:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchSeqHeadBlockDisjoint $hd $br (by rfl) $tail
+        (by wp_rv64_link))
+
+/-- Continue the head exit of an N-way branch with another N-way branch over
+    disjoint code. The tactic expects the N-branch exits field to reduce to a cons. -/
+syntax (name := wpRv64NBranchSeqHeadNBranchDisjointTac)
+  "wp_rv64_nbranch_head_nbranch_disjoint " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_head_nbranch_disjoint $hd:term, $br:term, $tail:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchSeqHeadNBranchDisjoint $hd $br (by rfl) $tail
+        (by wp_rv64_link))
+
 /-- Display the computed precondition field of a WP/CFG certificate. -/
 syntax (name := wpRv64Cmd) "#wp_rv64 " term : command
 
@@ -231,5 +251,24 @@ example {nTail : Nat} {entry : Word} {cr1 cr2 : CodeReq}
     EvmAsm.Rv64.WP.NBranch entry (cr1.union cr2) := by
   let tail := EvmAsm.Rv64.WP.NBranch.ofSpec tailSound
   wp_rv64_branch_not_taken_nbranch_disjoint hd, br, tail
+
+example {nTail : Nat} {entry target : Word} {cr1 cr2 : CodeReq}
+    {post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : EvmAsm.Rv64.WP.Branch entry cr1)
+    (tail : cpsTripleWithin nTail br.exit_t target cr2 br.post_t post) :
+    EvmAsm.Rv64.WP.NBranch entry (cr1.union cr2) := by
+  let nb := EvmAsm.Rv64.WP.CFG.nbranchOfBranch br
+  wp_rv64_nbranch_head_block_disjoint hd, nb, tail
+
+example {nTail : Nat} {entry : Word} {cr1 cr2 : CodeReq}
+    {exits : List (Word × Assertion)}
+    (hd : cr1.Disjoint cr2)
+    (br : EvmAsm.Rv64.WP.Branch entry cr1)
+    (tailSound : cpsNBranchWithin nTail br.exit_t cr2 br.post_t exits) :
+    EvmAsm.Rv64.WP.NBranch entry (cr1.union cr2) := by
+  let nb := EvmAsm.Rv64.WP.CFG.nbranchOfBranch br
+  let tail := EvmAsm.Rv64.WP.NBranch.ofSpec tailSound
+  wp_rv64_nbranch_head_nbranch_disjoint hd, nb, tail
 
 end EvmAsm.Rv64.Tactics.WPTests

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -167,6 +167,32 @@ macro_rules
         | try dsimp; wp_rv64_dead_hint
         | try dsimp; simp only [rv64_wp]; wp_rv64_dead_hint)
 
+
+private def isWpCertLikeGoal (goalType : Expr) : TacticM Bool := do
+  let goalType ← whnfR goalType
+  return goalType.isAppOfArity ``EvmAsm.Rv64.WP.Triple 4 ||
+    goalType.isAppOfArity ``EvmAsm.Rv64.WP.Branch 2 ||
+    goalType.isAppOfArity ``EvmAsm.Rv64.WP.NBranch 2
+
+/-- Close a WP certificate goal using declarations tagged with `@[rv64_wp_cert]`.
+    The target fixes the program/control-flow shape; remaining proof arguments
+    are filled from local hypotheses by name or exact type. -/
+elab "wp_rv64_cert" : tactic => withMainContext do
+  let goal ← getMainGoal
+  let goalType ← instantiateMVars (← goal.getType)
+  unless ← isWpCertLikeGoal goalType do
+    throwError "wp_rv64_cert: expected WP.Triple/WP.CFG.Cert, WP.Branch, or WP.NBranch goal"
+  let entries := rv64WpCertExt.getState (← getEnv)
+  for declName in entries do
+    let saved ← saveState
+    try
+      closeWithWpHint goal declName
+      return
+    catch _ =>
+      restoreState saved
+      continue
+  throwError "wp_rv64_cert: no @[rv64_wp_cert] declaration closed the goal"
+
 /-- Close the midpoint entailment between adjacent WP fragments.  The common
     case is definitional equality of the head postcondition and tail WP; semantic
     bridge lemmas tagged `@[rv64_wp_entails]` handle generated handoff shapes,

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -71,6 +71,26 @@ private def localCandidatesForMVar (mvarId : MVarId) : TacticM (Array Expr) := d
     return named
   return typed
 
+private def solveMVarByWpParamTactics (mvarId : MVarId) : TacticM Bool := do
+  if ← mvarId.isAssigned then
+    return true
+  mvarId.withContext do
+    let target ← instantiateMVars (← mvarId.getType)
+    unless ← isProp target do
+      return false
+    let saved ← saveState
+    let originalGoals ← getGoals
+    try
+      replaceMainGoal [mvarId]
+      evalTactic (← `(tactic| first | assumption | omega | bv_omega))
+      unless (← getGoals).isEmpty do
+        throwError "wp parameter tactic left open goals"
+      setGoals originalGoals
+      return true
+    catch _ =>
+      restoreState saved
+      return false
+
 partial def solveParamMVarsWithLocals (params : Array Expr) (idx : Nat) : TacticM Bool := do
   if hidx : idx < params.size then
     let param ← instantiateMVars params[idx]
@@ -86,6 +106,11 @@ partial def solveParamMVarsWithLocals (params : Array Expr) (idx : Nat) : Tactic
           if ← solveParamMVarsWithLocals params (idx + 1) then
             return true
           restoreState saved
+        let saved ← saveState
+        if ← solveMVarByWpParamTactics mvarId then
+          if ← solveParamMVarsWithLocals params (idx + 1) then
+            return true
+        restoreState saved
         return false
     else
       solveParamMVarsWithLocals params (idx + 1)

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -91,6 +91,24 @@ macro_rules
       `(tactic| exact EvmAsm.Rv64.WP.CFG.branchSeqTakenBlockDisjoint $hd $br $tail
         (by wp_rv64_link))
 
+/-- Continue a branch's not-taken exit with a WP/CFG tail over disjoint code. -/
+syntax (name := wpRv64BranchSeqNotTakenDisjointTac)
+  "wp_rv64_branch_not_taken_disjoint " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_branch_not_taken_disjoint $hd:term, $br:term, $tail:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.branchSeqNotTakenDisjoint $hd $br $tail
+        (by wp_rv64_link))
+
+/-- Continue a branch's not-taken exit with a CPS leaf over disjoint code. -/
+syntax (name := wpRv64BranchSeqNotTakenBlockDisjointTac)
+  "wp_rv64_branch_not_taken_block_disjoint " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_branch_not_taken_block_disjoint $hd:term, $br:term, $tail:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.branchSeqNotTakenBlockDisjoint $hd $br $tail
+        (by wp_rv64_link))
+
 /-- Display the computed precondition field of a WP/CFG certificate. -/
 syntax (name := wpRv64Cmd) "#wp_rv64 " term : command
 
@@ -147,5 +165,22 @@ example {nTail : Nat} {entry target : Word} {cr1 cr2 : CodeReq}
     (tail : cpsTripleWithin nTail br.exit_t target cr2 br.post_t post) :
     EvmAsm.Rv64.WP.Branch entry (cr1.union cr2) := by
   wp_rv64_branch_taken_block_disjoint hd, br, tail
+
+example {nTail : Nat} {entry target : Word} {cr1 cr2 : CodeReq}
+    {tailPre post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : EvmAsm.Rv64.WP.Branch entry cr1)
+    (tail : cpsTripleWithin nTail br.exit_f target cr2 tailPre post)
+    (hlink : EvmAsm.Rv64.WP.Entails br.post_f tailPre) :
+    EvmAsm.Rv64.WP.Branch entry (cr1.union cr2) := by
+  exact EvmAsm.Rv64.WP.CFG.branchSeqNotTakenBlockDisjoint hd br tail hlink
+
+example {nTail : Nat} {entry target : Word} {cr1 cr2 : CodeReq}
+    {post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : EvmAsm.Rv64.WP.Branch entry cr1)
+    (tail : cpsTripleWithin nTail br.exit_f target cr2 br.post_f post) :
+    EvmAsm.Rv64.WP.Branch entry (cr1.union cr2) := by
+  wp_rv64_branch_not_taken_block_disjoint hd, br, tail
 
 end EvmAsm.Rv64.Tactics.WPTests

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -177,6 +177,7 @@ macro_rules
   | `(tactic| wp_rv64_link) =>
       `(tactic| first
         | exact EvmAsm.Rv64.WP.Entails.refl _
+        | assumption
         | wp_rv64_entails
         | simp only [rv64_wp]; wp_rv64_entails
         | dsimp; wp_rv64_entails
@@ -612,6 +613,23 @@ macro_rules
       `(tactic| exact EvmAsm.Rv64.WP.NBranch.weakenPre $br
         (show EvmAsm.Rv64.WP.Entails $pre ($br).pre by wp_rv64_link))
 
+/-- Frame every exit of an N-way branch and set an explicit precondition in one
+    generated step.  This is the common shape when a caller frame is preserved
+    across every branch exit, but the source precondition is more structured
+    than the raw framed WP precondition. -/
+syntax (name := wpRv64NBranchFrameSetPreTac)
+  "wp_rv64_nbranch_frame_set_pre " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_frame_set_pre $br:term, $frame:term, $hFrame:term, $pre:term) =>
+      `(tactic|
+        exact EvmAsm.Rv64.WP.NBranch.weakenPre
+          (EvmAsm.Rv64.WP.CFG.nbranchFrameR $br $frame $hFrame)
+          (show EvmAsm.Rv64.WP.Entails $pre
+            (EvmAsm.Rv64.WP.CFG.nbranchFrameR $br $frame $hFrame).pre by
+            dsimp only [EvmAsm.Rv64.WP.CFG.nbranchFrameR, EvmAsm.Rv64.WP.NBranch.frameR]
+            wp_rv64_link))
+
 /-- Extend an N-way branch to a larger code requirement and set an explicit
     precondition in one generated step. -/
 syntax (name := wpRv64NBranchExtendSetPreTac)
@@ -620,9 +638,10 @@ syntax (name := wpRv64NBranchExtendSetPreTac)
 macro_rules
   | `(tactic| wp_rv64_nbranch_extend_set_pre $br:term, $hmono:term, $pre:term) =>
       `(tactic|
-        let br' := EvmAsm.Rv64.WP.NBranch.extendCode $br $hmono
-        exact EvmAsm.Rv64.WP.NBranch.weakenPre br'
-          (show EvmAsm.Rv64.WP.Entails $pre br'.pre by wp_rv64_link))
+        exact EvmAsm.Rv64.WP.NBranch.weakenPre
+          (EvmAsm.Rv64.WP.NBranch.extendCode $br $hmono)
+          (show EvmAsm.Rv64.WP.Entails $pre
+            (EvmAsm.Rv64.WP.NBranch.extendCode $br $hmono).pre by wp_rv64_link))
 
 /-- Weaken the exit postconditions of an N-way branch. -/
 syntax (name := wpRv64NBranchWeakenPostsTac)
@@ -1078,6 +1097,12 @@ example {entry : Word} {cr : CodeReq}
     (br : EvmAsm.Rv64.WP.NBranch entry cr) :
     EvmAsm.Rv64.WP.NBranch entry cr := by
   wp_rv64_nbranch_set_pre br, br.pre
+
+example {entry : Word} {cr : CodeReq} {pre F : Assertion}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr) (hF : F.pcFree)
+    (hpre : EvmAsm.Rv64.WP.Entails pre (br.pre ** F)) :
+    EvmAsm.Rv64.WP.NBranch entry cr := by
+  wp_rv64_nbranch_frame_set_pre br, F, hF, pre
 
 example {entry : Word} {cr : CodeReq} {exits' : List (Word × Assertion)}
     (br : EvmAsm.Rv64.WP.NBranch entry cr)

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -327,6 +327,22 @@ macro_rules
   | `(tactic| wp_rv64_nbranch_extend_code $br:term, $hmono:term) =>
       `(tactic| exact EvmAsm.Rv64.WP.NBranch.extendCode $br $hmono)
 
+/-- Weaken an N-way branch precondition, solving the entailment with `wp_rv64_link`. -/
+syntax (name := wpRv64NBranchWeakenPreTac)
+  "wp_rv64_nbranch_weaken_pre " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_weaken_pre $br:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.NBranch.weakenPre $br (by wp_rv64_link))
+
+/-- Weaken an N-way branch precondition with an explicit entailment proof. -/
+syntax (name := wpRv64NBranchWeakenPreWithTac)
+  "wp_rv64_nbranch_weaken_pre_with " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_weaken_pre_with $br:term, $hpre:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.NBranch.weakenPre $br $hpre)
+
 /-- Weaken the exit postconditions of an N-way branch. -/
 syntax (name := wpRv64NBranchWeakenPostsTac)
   "wp_rv64_nbranch_weaken_posts " term ", " term ", " term : tactic

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -8,6 +8,8 @@
 
 import Lean
 import EvmAsm.Rv64.WP.CFG
+import EvmAsm.Rv64.WP.Call
+import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Rv64.Tactics
 
@@ -26,6 +28,23 @@ macro_rules
   | `(tactic| wp_rv64 $cfg:term) =>
       `(tactic| exact ($cfg).sound)
 
+/-- Compose a head CPS triple with a WP/CFG tail and close the midpoint
+    entailment by separation-conjunction permutation. -/
+syntax (name := wpRv64SeqTac) "wp_rv64_seq " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_seq $head:term, $tail:term) =>
+      `(tactic| exact (EvmAsm.Rv64.WP.Triple.seq $head $tail
+        (by intro _ _hp; xperm_hyp _hp)).sound)
+
+/-- Disjoint-code version of `wp_rv64_seq`. -/
+syntax (name := wpRv64SeqDisjointTac) "wp_rv64_seq_disjoint " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_seq_disjoint $hd:term, $head:term, $tail:term) =>
+      `(tactic| exact (EvmAsm.Rv64.WP.Triple.seqDisjoint $hd $head $tail
+        (by intro _ _hp; xperm_hyp _hp)).sound)
+
 /-- Display the computed precondition field of a WP/CFG certificate. -/
 syntax (name := wpRv64Cmd) "#wp_rv64 " term : command
 
@@ -43,5 +62,12 @@ example {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     (cfg : EvmAsm.Rv64.WP.Triple entry exit_ cr post) :
     cpsTripleWithin cfg.nSteps entry exit_ cr cfg.pre post := by
   wp_rv64 cfg
+
+example {nSteps : Nat} {entry mid exit_ : Word} {cr : CodeReq}
+    {pre post : Assertion}
+    (tail : EvmAsm.Rv64.WP.Triple mid exit_ cr post)
+    (head : cpsTripleWithin nSteps entry mid cr pre tail.pre) :
+    cpsTripleWithin (nSteps + tail.nSteps) entry exit_ cr pre post := by
+  wp_rv64_seq head, tail
 
 end EvmAsm.Rv64.Tactics.WPTests

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -100,7 +100,18 @@ macro_rules
       `(tactic| exact EvmAsm.Rv64.WP.CFG.branchSeqTakenBlockDisjoint $hd $br $tail
         (by wp_rv64_link))
 
-/-- Continue a branch's not-taken exit with a WP/CFG tail over disjoint code. -/
+/-- Continue a branch taken exit with another branch, merging both failure exits
+    into the explicit shared failure post. The exit equality is expected to be
+    definitional. -/
+syntax (name := wpRv64BranchSeqTakenBranchConvergeDisjointTac)
+  "wp_rv64_branch_taken_branch_converge_disjoint " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_branch_taken_branch_converge_disjoint $hd:term, $br:term, $tail:term, $failPost:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.branchSeqTakenBranchConvergeDisjoint
+        (failPost := $failPost) $hd $br $tail (by rfl)
+        (by wp_rv64_link) (by wp_rv64_link) (by wp_rv64_link))
+
 syntax (name := wpRv64BranchSeqNotTakenDisjointTac)
   "wp_rv64_branch_not_taken_disjoint " term ", " term ", " term : tactic
 
@@ -283,6 +294,16 @@ example {nTail : Nat} {entry target : Word} {cr1 cr2 : CodeReq}
     (tail : cpsTripleWithin nTail br.exit_t target cr2 br.post_t post) :
     EvmAsm.Rv64.WP.NBranch entry (cr1.union cr2) := by
   wp_rv64_branch_taken_block_nbranch_disjoint hd, br, tail
+
+example {nTail : Nat} {entry succ : Word} {cr1 cr2 : CodeReq}
+    {succPost : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : EvmAsm.Rv64.WP.Branch entry cr1)
+    (tailSound : cpsBranchWithin nTail br.exit_t cr2 br.post_t
+      br.exit_f br.post_f succ succPost) :
+    EvmAsm.Rv64.WP.Branch entry (cr1.union cr2) := by
+  let tail := EvmAsm.Rv64.WP.Branch.ofSpec tailSound
+  wp_rv64_branch_taken_branch_converge_disjoint hd, br, tail, br.post_f
 
 example {entry : Word} {cr : CodeReq}
     (br : EvmAsm.Rv64.WP.Branch entry cr) :

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -319,6 +319,14 @@ macro_rules
   | `(tactic| wp_rv64_nbranch_frame $br:term, $F:term, $hF:term) =>
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchFrameR $br $F $hF)
 
+/-- Extend an N-way branch to a larger persistent code requirement. -/
+syntax (name := wpRv64NBranchExtendCodeTac)
+  "wp_rv64_nbranch_extend_code " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_extend_code $br:term, $hmono:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.NBranch.extendCode $br $hmono)
+
 /-- Weaken the exit postconditions of an N-way branch. -/
 syntax (name := wpRv64NBranchWeakenPostsTac)
   "wp_rv64_nbranch_weaken_posts " term ", " term ", " term : tactic

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -30,19 +30,61 @@ macro_rules
   | `(tactic| wp_rv64 $cfg:term) =>
       `(tactic| exact ($cfg).sound)
 
+private def closeWithWpEntailsHint (goal : MVarId) (declName : Name) : TacticM Unit := do
+  let goalType ← instantiateMVars (← goal.getType)
+  let hintConst ← mkConstWithFreshMVarLevels declName
+  let hintType ← inferType hintConst
+  let (params, _, body) ← forallMetaTelescope hintType
+  unless ← isDefEq body goalType do
+    throwError "hint result does not match goal"
+  let proof ← instantiateMVars (mkAppN hintConst params)
+  if proof.hasExprMVar then
+    throwError "hint left unresolved metavariables"
+  goal.assign proof
+  replaceMainGoal []
+
+/-- Close a `WP.Entails` goal using declarations tagged with
+    `@[rv64_wp_entails]`.  This is deliberately separate from the `rv64_wp` simp
+    set: simp exposes the assertion shape, then this tactic applies named
+    semantic bridge lemmas whose statements are not rewrite rules. -/
+elab "wp_rv64_entails" : tactic => withMainContext do
+  let goal ← getMainGoal
+  let goalType ← goal.getType
+  unless goalType.isAppOfArity ``EvmAsm.Rv64.WP.Entails 2 do
+    throwError "wp_rv64_entails: expected WP.Entails goal"
+  let entries := rv64WpEntailsExt.getState (← getEnv)
+  for declName in entries do
+    let saved ← saveState
+    try
+      closeWithWpEntailsHint goal declName
+      return
+    catch _ =>
+      restoreState saved
+      continue
+  throwError "wp_rv64_entails: no @[rv64_wp_entails] theorem closed the goal"
+
 /-- Close the midpoint entailment between adjacent WP fragments.  The common
-    case is definitional equality of the head postcondition and tail WP; reordered
-    separation frames fall through to `xperm`. -/
+    case is definitional equality of the head postcondition and tail WP; semantic
+    bridge lemmas tagged `@[rv64_wp_entails]` handle generated handoff shapes,
+    and reordered separation frames fall through to `xperm`. -/
 syntax (name := wpRv64LinkTac) "wp_rv64_link" : tactic
 
 macro_rules
   | `(tactic| wp_rv64_link) =>
       `(tactic| first
         | exact EvmAsm.Rv64.WP.Entails.refl _
+        | wp_rv64_entails
+        | simp only [rv64_wp]; wp_rv64_entails
+        | dsimp; wp_rv64_entails
+        | dsimp; simp only [rv64_wp]; wp_rv64_entails
         | intro _ _hp; xperm_hyp _hp
         | intro _ _hp; xperm_pure _hp
         | intro _ _hp; simp only [rv64_wp] at _hp ⊢; xperm_hyp _hp
-        | intro _ _hp; simp only [rv64_wp] at _hp ⊢; xperm_pure _hp)
+        | intro _ _hp; simp only [rv64_wp] at _hp ⊢; xperm_pure _hp
+        | intro _ _hp; dsimp at _hp ⊢; xperm_hyp _hp
+        | intro _ _hp; dsimp at _hp ⊢; xperm_pure _hp
+        | intro _ _hp; dsimp at _hp ⊢; simp only [rv64_wp] at _hp ⊢; xperm_hyp _hp
+        | intro _ _hp; dsimp at _hp ⊢; simp only [rv64_wp] at _hp ⊢; xperm_pure _hp)
 
 /-- Close a `CodeReq.Disjoint` goal using the structural prover shared with
     `seqFrame`.  This keeps WP composition proofs from spelling out code-range
@@ -343,6 +385,30 @@ macro_rules
   | `(tactic| wp_rv64_nbranch_weaken_pre_with $br:term, $hpre:term) =>
       `(tactic| exact EvmAsm.Rv64.WP.NBranch.weakenPre $br $hpre)
 
+/-- Weaken an N-way branch to an explicitly supplied precondition, solving the
+    entailment through the WP link automation.  Supplying the precondition is
+    important because `WP.NBranch` stores `pre` as a field rather than an index,
+    so the surrounding result type does not determine it. -/
+syntax (name := wpRv64NBranchSetPreTac)
+  "wp_rv64_nbranch_set_pre " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_set_pre $br:term, $pre:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.NBranch.weakenPre $br
+        (show EvmAsm.Rv64.WP.Entails $pre ($br).pre by wp_rv64_link))
+
+/-- Extend an N-way branch to a larger code requirement and set an explicit
+    precondition in one generated step. -/
+syntax (name := wpRv64NBranchExtendSetPreTac)
+  "wp_rv64_nbranch_extend_set_pre " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_extend_set_pre $br:term, $hmono:term, $pre:term) =>
+      `(tactic|
+        let br' := EvmAsm.Rv64.WP.NBranch.extendCode $br $hmono
+        exact EvmAsm.Rv64.WP.NBranch.weakenPre br'
+          (show EvmAsm.Rv64.WP.Entails $pre br'.pre by wp_rv64_link))
+
 /-- Weaken the exit postconditions of an N-way branch. -/
 syntax (name := wpRv64NBranchWeakenPostsTac)
   "wp_rv64_nbranch_weaken_posts " term ", " term ", " term : tactic
@@ -587,6 +653,11 @@ example {entry : Word} {cr : CodeReq} {F : Assertion}
     (br : EvmAsm.Rv64.WP.NBranch entry cr) (hF : F.pcFree) :
     EvmAsm.Rv64.WP.NBranch entry cr := by
   wp_rv64_nbranch_frame br, F, hF
+
+example {entry : Word} {cr : CodeReq}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr) :
+    EvmAsm.Rv64.WP.NBranch entry cr := by
+  wp_rv64_nbranch_set_pre br, br.pre
 
 example {entry : Word} {cr : CodeReq} {exits' : List (Word × Assertion)}
     (br : EvmAsm.Rv64.WP.NBranch entry cr)

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -226,6 +226,25 @@ macro_rules
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchSeqSecondNBranchDisjoint $hd $br (by rfl) $tail
         (by wp_rv64_link))
 
+/-- Continue the third exit of a four-way N-branch with a single-exit CFG over
+    disjoint tail code. The exit-list proof is expected to be definitional. -/
+syntax (name := wpRv64NBranchSeqThirdCertDisjointTac)
+  "wp_rv64_nbranch_third_cert_disjoint " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_third_cert_disjoint $hd:term, $br:term, $tail:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchSeqThirdCertDisjoint $hd $br (by rfl) $tail
+        (by wp_rv64_link))
+
+/-- Continue the third exit of a four-way N-branch with a single-exit CFG,
+    supplying the normalized exit-list proof and link entailment explicitly. -/
+syntax (name := wpRv64NBranchSeqThirdCertDisjointWithTac)
+  "wp_rv64_nbranch_third_cert_disjoint_with " term ", " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_third_cert_disjoint_with $hd:term, $br:term, $hexits:term, $tail:term, $hlink:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchSeqThirdCertDisjoint $hd $br $hexits $tail $hlink)
+
 /-- Frame every exit of an N-way branch with a PC-free assertion. -/
 syntax (name := wpRv64NBranchFrameRTac)
   "wp_rv64_nbranch_frame " term ", " term ", " term : tactic
@@ -463,6 +482,16 @@ example {nTail : Nat} {entry : Word} {cr1 cr2 : CodeReq}
   let nb := EvmAsm.Rv64.WP.CFG.nbranchOfBranch br
   let tail := EvmAsm.Rv64.WP.NBranch.ofSpec tailSound
   wp_rv64_nbranch_head_nbranch_disjoint hd, nb, tail
+
+example {entry l1 l2 l3 l4 l3' : Word} {cr1 cr2 : CodeReq}
+    {Q1 Q2 Q3 Q4 R : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : EvmAsm.Rv64.WP.NBranch entry cr1)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)])
+    (tail : EvmAsm.Rv64.WP.CFG.Cert l3 l3' cr2 R)
+    (hlink : EvmAsm.Rv64.WP.Entails Q3 tail.pre) :
+    EvmAsm.Rv64.WP.NBranch entry (cr1.union cr2) := by
+  wp_rv64_nbranch_third_cert_disjoint_with hd, br, hexits, tail, hlink
 
 example {entry : Word} {cr : CodeReq} {F : Assertion}
     (br : EvmAsm.Rv64.WP.NBranch entry cr) (hF : F.pcFree) :

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -297,6 +297,26 @@ macro_rules
       `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchJoin4 $br $hexits $tailBound
         $t1 $t2 $t3 $t4 $hlink1 $hlink2 $hlink3 $hlink4 $h1 $h2 $h3 $h4)
 
+/-- Join exactly four known exits, computing the common continuation bound from
+    the supplied certificates. -/
+syntax (name := wpRv64NBranchJoin4MaxTac)
+  "wp_rv64_nbranch_join4 " term ", " term ", " term ", " term ", " term ", " term ", " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_join4 $br:term, $hexits:term, $t1:term, $hlink1:term, $t2:term, $hlink2:term, $t3:term, $hlink3:term, $t4:term, $hlink4:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchJoin4Max $br $hexits
+        $t1 $t2 $t3 $t4 $hlink1 $hlink2 $hlink3 $hlink4)
+
+/-- Join exactly four known exits when the third exit is the only reachable one.
+    The other exits are discharged from contradiction proofs. -/
+syntax (name := wpRv64NBranchJoin4ResolveThirdTac)
+  "wp_rv64_nbranch_join4_resolve_third " term ", " term ", " term ", " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_nbranch_join4_resolve_third $br:term, $hexits:term, $hdead1:term, $hdead2:term, $hlink3:term, $hdead4:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.nbranchJoin4ResolveThird $br $hexits
+        $hdead1 $hdead2 $hlink3 $hdead4)
+
 /-- Display the computed precondition field of a WP/CFG certificate. -/
 syntax (name := wpRv64Cmd) "#wp_rv64 " term : command
 
@@ -504,6 +524,30 @@ example {entry exit_ l1 l2 l3 l4 : Word} {cr : CodeReq} {post Q1 Q2 Q3 Q4 : Asse
     t2, hlink2, Nat.le_trans (Nat.le_max_right _ _) (Nat.le_max_left _ _),
     t3, hlink3, Nat.le_trans (Nat.le_max_left _ _) (Nat.le_max_right _ _),
     t4, hlink4, Nat.le_trans (Nat.le_max_right _ _) (Nat.le_max_right _ _)
+
+example {entry exit_ l1 l2 l3 l4 : Word} {cr : CodeReq} {post Q1 Q2 Q3 Q4 : Assertion}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)])
+    (t1 : EvmAsm.Rv64.WP.CFG.Cert l1 exit_ cr post)
+    (t2 : EvmAsm.Rv64.WP.CFG.Cert l2 exit_ cr post)
+    (t3 : EvmAsm.Rv64.WP.CFG.Cert l3 exit_ cr post)
+    (t4 : EvmAsm.Rv64.WP.CFG.Cert l4 exit_ cr post)
+    (hlink1 : EvmAsm.Rv64.WP.Entails Q1 t1.pre)
+    (hlink2 : EvmAsm.Rv64.WP.Entails Q2 t2.pre)
+    (hlink3 : EvmAsm.Rv64.WP.Entails Q3 t3.pre)
+    (hlink4 : EvmAsm.Rv64.WP.Entails Q4 t4.pre) :
+    EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post := by
+  wp_rv64_nbranch_join4 br, hexits, t1, hlink1, t2, hlink2, t3, hlink3, t4, hlink4
+
+example {entry l1 l2 l3 l4 : Word} {cr : CodeReq} {post Q1 Q2 Q3 Q4 : Assertion}
+    (br : EvmAsm.Rv64.WP.NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)])
+    (hdead1 : ∀ h, Q1 h → False)
+    (hdead2 : ∀ h, Q2 h → False)
+    (hlink3 : EvmAsm.Rv64.WP.Entails Q3 post)
+    (hdead4 : ∀ h, Q4 h → False) :
+    EvmAsm.Rv64.WP.CFG.Cert entry l3 cr post := by
+  wp_rv64_nbranch_join4_resolve_third br, hexits, hdead1, hdead2, hlink3, hdead4
 
 example {entry head l : Word} {cr1 cr2 : CodeReq}
     {headPost secondPost : Assertion} {others : List (Word × Assertion)}

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -56,6 +56,23 @@ macro_rules
       `(tactic| exact (EvmAsm.Rv64.WP.Triple.seqDisjoint $hd $head $tail
         (by wp_rv64_link)).sound)
 
+/-- Compose two adjacent CPS blocks over one shared persistent code requirement. -/
+syntax (name := wpRv64SeqBlockTac) "wp_rv64_seq_block " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_seq_block $head:term, $tail:term) =>
+      `(tactic| exact (EvmAsm.Rv64.WP.CFG.seqBlock $head $tail
+        (by wp_rv64_link)).sound)
+
+/-- Disjoint-code version of `wp_rv64_seq_block`. -/
+syntax (name := wpRv64SeqBlockDisjointTac)
+  "wp_rv64_seq_block_disjoint " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_seq_block_disjoint $hd:term, $head:term, $tail:term) =>
+      `(tactic| exact (EvmAsm.Rv64.WP.CFG.seqBlockDisjoint $hd $head $tail
+        (by wp_rv64_link)).sound)
+
 /-- Display the computed precondition field of a WP/CFG certificate. -/
 syntax (name := wpRv64Cmd) "#wp_rv64 " term : command
 
@@ -80,5 +97,20 @@ example {nSteps : Nat} {entry mid exit_ : Word} {cr : CodeReq}
     (head : cpsTripleWithin nSteps entry mid cr pre tail.pre) :
     cpsTripleWithin (nSteps + tail.nSteps) entry exit_ cr pre post := by
   wp_rv64_seq head, tail
+
+example {nHead nTail : Nat} {entry mid exit_ : Word} {cr : CodeReq}
+    {pre midPost post : Assertion}
+    (head : cpsTripleWithin nHead entry mid cr pre midPost)
+    (tail : cpsTripleWithin nTail mid exit_ cr midPost post) :
+    cpsTripleWithin (nHead + nTail) entry exit_ cr pre post := by
+  wp_rv64_seq_block head, tail
+
+example {nHead nTail : Nat} {entry mid exit_ : Word} {cr1 cr2 : CodeReq}
+    {pre midPost post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (head : cpsTripleWithin nHead entry mid cr1 pre midPost)
+    (tail : cpsTripleWithin nTail mid exit_ cr2 midPost post) :
+    cpsTripleWithin (nHead + nTail) entry exit_ (cr1.union cr2) pre post := by
+  wp_rv64_seq_block_disjoint hd, head, tail
 
 end EvmAsm.Rv64.Tactics.WPTests

--- a/EvmAsm/Rv64/Tactics/WPAttr.lean
+++ b/EvmAsm/Rv64/Tactics/WPAttr.lean
@@ -75,4 +75,26 @@ initialize Lean.registerBuiltinAttribute {
     Lean.modifyEnv fun env => rv64WpDeadExt.addEntry env declName
 }
 
+
+/-- Environment extension storing theorem/definition names tagged with
+    `@[rv64_wp_cert]`.  These are WP certificate constructors whose arguments
+    can be inferred from the target and local static facts. -/
+initialize rv64WpCertExt : Lean.SimplePersistentEnvExtension Lean.Name (Array Lean.Name) ←
+  Lean.registerSimplePersistentEnvExtension {
+    addEntryFn := fun state declName => state.push declName
+    addImportedFn := fun entries => entries.foldl (init := #[]) fun acc es => acc ++ es
+  }
+
+/-- Certificate hint database used by `wp_rv64_cert`.  Declarations tagged here
+    should return `WP.Triple`/`WP.CFG.Cert`, `WP.Branch`, or `WP.NBranch`, with
+    proof arguments inferable from local hypotheses. -/
+initialize Lean.registerBuiltinAttribute {
+  name := `rv64_wp_cert
+  descr := "WP certificate constructors used by wp_rv64_cert"
+  applicationTime := .afterTypeChecking
+  add := fun declName stx _attrKind => do
+    Lean.Attribute.Builtin.ensureNoArgs stx
+    Lean.modifyEnv fun env => rv64WpCertExt.addEntry env declName
+}
+
 end EvmAsm.Rv64.Tactics

--- a/EvmAsm/Rv64/Tactics/WPAttr.lean
+++ b/EvmAsm/Rv64/Tactics/WPAttr.lean
@@ -33,6 +33,28 @@ initialize Lean.registerBuiltinAttribute {
     Lean.modifyEnv fun env => rv64WpEntailsExt.addEntry env declName
 }
 
+/-- Environment extension storing theorem names tagged with
+    `@[rv64_wp_disjoint]`. These are code-range disjointness hints for WP
+    composition side conditions that are too semantic for the structural prover. -/
+initialize rv64WpDisjointExt : Lean.SimplePersistentEnvExtension Lean.Name (Array Lean.Name) ←
+  Lean.registerSimplePersistentEnvExtension {
+    addEntryFn := fun state declName => state.push declName
+    addImportedFn := fun entries => entries.foldl (init := #[]) fun acc es => acc ++ es
+  }
+
+/-- Disjointness hint database used by `wp_rv64_disjoint` after local hypotheses
+    and structural code-shape proving. Theorems tagged here should prove goals
+    of shape `CodeReq.Disjoint cr1 cr2`, with side conditions inferable from
+    the local context. -/
+initialize Lean.registerBuiltinAttribute {
+  name := `rv64_wp_disjoint
+  descr := "WP code disjointness hints used by wp_rv64_disjoint"
+  applicationTime := .afterTypeChecking
+  add := fun declName stx _attrKind => do
+    Lean.Attribute.Builtin.ensureNoArgs stx
+    Lean.modifyEnv fun env => rv64WpDisjointExt.addEntry env declName
+}
+
 /-- Environment extension storing theorem names tagged with `@[rv64_wp_dead]`.
     These are contradiction hints for unreachable WP exits. -/
 initialize rv64WpDeadExt : Lean.SimplePersistentEnvExtension Lean.Name (Array Lean.Name) ←

--- a/EvmAsm/Rv64/Tactics/WPAttr.lean
+++ b/EvmAsm/Rv64/Tactics/WPAttr.lean
@@ -7,6 +7,30 @@
 
 import Lean.Meta.Tactic.Simp.RegisterCommand
 
+namespace EvmAsm.Rv64.Tactics
+
 /-- Simp set for WP-generated handoff definitions.  Keep this focused on small
     assertion-shape definitions that make adjacent CFG fragments line up. -/
 register_simp_attr rv64_wp
+
+/-- Environment extension storing the theorem names tagged with
+    `@[rv64_wp_entails]`, in registration order. -/
+initialize rv64WpEntailsExt : Lean.SimplePersistentEnvExtension Lean.Name (Array Lean.Name) ←
+  Lean.registerSimplePersistentEnvExtension {
+    addEntryFn := fun state declName => state.push declName
+    addImportedFn := fun entries => entries.foldl (init := #[]) fun acc es => acc ++ es
+  }
+
+/-- Entailment hint database used by `wp_rv64_link` after WP preconditions have
+    been simplified with `rv64_wp`.  Theorems tagged here should have target
+    type `WP.Entails P Q`, with all arguments inferable from the goal. -/
+initialize Lean.registerBuiltinAttribute {
+  name := `rv64_wp_entails
+  descr := "WP entailment hints used by wp_rv64_link"
+  applicationTime := .afterTypeChecking
+  add := fun declName stx _attrKind => do
+    Lean.Attribute.Builtin.ensureNoArgs stx
+    Lean.modifyEnv fun env => rv64WpEntailsExt.addEntry env declName
+}
+
+end EvmAsm.Rv64.Tactics

--- a/EvmAsm/Rv64/Tactics/WPAttr.lean
+++ b/EvmAsm/Rv64/Tactics/WPAttr.lean
@@ -33,4 +33,24 @@ initialize Lean.registerBuiltinAttribute {
     Lean.modifyEnv fun env => rv64WpEntailsExt.addEntry env declName
 }
 
+/-- Environment extension storing theorem names tagged with `@[rv64_wp_dead]`.
+    These are contradiction hints for unreachable WP exits. -/
+initialize rv64WpDeadExt : Lean.SimplePersistentEnvExtension Lean.Name (Array Lean.Name) ←
+  Lean.registerSimplePersistentEnvExtension {
+    addEntryFn := fun state declName => state.push declName
+    addImportedFn := fun entries => entries.foldl (init := #[]) fun acc es => acc ++ es
+  }
+
+/-- Dead-exit hint database used by `wp_rv64_dead`. Theorems tagged here should
+    prove goals of shape `∀ h, P h → False`, with all non-target arguments
+    inferable from local hypotheses. -/
+initialize Lean.registerBuiltinAttribute {
+  name := `rv64_wp_dead
+  descr := "WP unreachable-exit hints used by wp_rv64_dead"
+  applicationTime := .afterTypeChecking
+  add := fun declName stx _attrKind => do
+    Lean.Attribute.Builtin.ensureNoArgs stx
+    Lean.modifyEnv fun env => rv64WpDeadExt.addEntry env declName
+}
+
 end EvmAsm.Rv64.Tactics

--- a/EvmAsm/Rv64/Tactics/WPAttr.lean
+++ b/EvmAsm/Rv64/Tactics/WPAttr.lean
@@ -1,0 +1,12 @@
+/-
+  EvmAsm.Rv64.Tactics.WPAttr
+
+  Declares the `rv64_wp` simp set used by `wp_rv64_link` to expose
+  WP-calculator handoff shapes before separation-frame permutation.
+-/
+
+import Lean.Meta.Tactic.Simp.RegisterCommand
+
+/-- Simp set for WP-generated handoff definitions.  Keep this focused on small
+    assertion-shape definitions that make adjacent CFG fragments line up. -/
+register_simp_attr rv64_wp

--- a/EvmAsm/Rv64/WP.lean
+++ b/EvmAsm/Rv64/WP.lean
@@ -7,4 +7,5 @@
 import EvmAsm.Rv64.WP.Core
 import EvmAsm.Rv64.WP.Loop
 import EvmAsm.Rv64.WP.CFG
+import EvmAsm.Rv64.WP.Call
 import EvmAsm.Rv64.WP.Examples

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -166,6 +166,73 @@ def branchSeqNotTakenNBranchDisjoint {entry : Word} {cr1 cr2 : CodeReq}
     NBranch entry (cr1.union cr2) :=
   br.seqNotTakenNBranchDisjoint hd tail hlink
 
+/-- Continue the head exit of an N-way CFG over the same code requirement. -/
+def nbranchSeqHead {entry l l' : Word} {cr : CodeReq}
+    {headPost post : Assertion} {others : List (Word × Assertion)}
+    (br : NBranch entry cr)
+    (hexits : br.exits = (l, headPost) :: others)
+    (tail : Cert l l' cr post)
+    (hlink : Entails headPost tail.pre) :
+    NBranch entry cr :=
+  br.seqHead hexits tail hlink
+
+/-- Continue the head exit of an N-way CFG with a CPS leaf over the same code
+    requirement. -/
+def nbranchSeqHeadBlock {nTail : Nat} {entry l l' : Word} {cr : CodeReq}
+    {headPost tailPre post : Assertion} {others : List (Word × Assertion)}
+    (br : NBranch entry cr)
+    (hexits : br.exits = (l, headPost) :: others)
+    (tail : cpsTripleWithin nTail l l' cr tailPre post)
+    (hlink : Entails headPost tailPre) :
+    NBranch entry cr :=
+  nbranchSeqHead br hexits (block (Entails.refl _) tail) hlink
+
+/-- Continue the head exit of an N-way CFG over disjoint tail code. -/
+def nbranchSeqHeadDisjoint {entry l l' : Word} {cr1 cr2 : CodeReq}
+    {headPost post : Assertion} {others : List (Word × Assertion)}
+    (hd : cr1.Disjoint cr2)
+    (br : NBranch entry cr1)
+    (hexits : br.exits = (l, headPost) :: others)
+    (tail : Cert l l' cr2 post)
+    (hlink : Entails headPost tail.pre) :
+    NBranch entry (cr1.union cr2) :=
+  br.seqHeadDisjoint hd hexits tail hlink
+
+/-- Continue the head exit of an N-way CFG with a CPS leaf over disjoint tail code. -/
+def nbranchSeqHeadBlockDisjoint {nTail : Nat} {entry l l' : Word}
+    {cr1 cr2 : CodeReq} {headPost tailPre post : Assertion}
+    {others : List (Word × Assertion)}
+    (hd : cr1.Disjoint cr2)
+    (br : NBranch entry cr1)
+    (hexits : br.exits = (l, headPost) :: others)
+    (tail : cpsTripleWithin nTail l l' cr2 tailPre post)
+    (hlink : Entails headPost tailPre) :
+    NBranch entry (cr1.union cr2) :=
+  nbranchSeqHeadDisjoint hd br hexits (block (Entails.refl _) tail) hlink
+
+/-- Continue the head exit of an N-way CFG with another N-way CFG over the same
+    code requirement. -/
+def nbranchSeqHeadNBranch {entry l : Word} {cr : CodeReq}
+    {headPost : Assertion} {others : List (Word × Assertion)}
+    (br : NBranch entry cr)
+    (hexits : br.exits = (l, headPost) :: others)
+    (tail : NBranch l cr)
+    (hlink : Entails headPost tail.pre) :
+    NBranch entry cr :=
+  br.seqHeadNBranch hexits tail hlink
+
+/-- Continue the head exit of an N-way CFG with another N-way CFG over disjoint
+    tail code. -/
+def nbranchSeqHeadNBranchDisjoint {entry l : Word} {cr1 cr2 : CodeReq}
+    {headPost : Assertion} {others : List (Word × Assertion)}
+    (hd : cr1.Disjoint cr2)
+    (br : NBranch entry cr1)
+    (hexits : br.exits = (l, headPost) :: others)
+    (tail : NBranch l cr2)
+    (hlink : Entails headPost tail.pre) :
+    NBranch entry (cr1.union cr2) :=
+  br.seqHeadNBranchDisjoint hd hexits tail hlink
+
 /-- Join an N-way branch with a uniform continuation bound. -/
 def nbranch {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     (br : NBranch entry cr) (tailBound : Nat)

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -109,6 +109,26 @@ def branchSeqTakenBlockDisjoint {nTail : Nat} {entry target : Word}
     Branch entry (cr1.union cr2) :=
   branchSeqTakenDisjoint hd br (block (Entails.refl _) tail) hlink
 
+/-- Continue only the not-taken exit of a branch with disjoint code, leaving the
+    taken exit open. -/
+def branchSeqNotTakenDisjoint {entry target : Word} {cr1 cr2 : CodeReq} {post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : Branch entry cr1)
+    (tail : Cert br.exit_f target cr2 post)
+    (hlink : Entails br.post_f tail.pre) :
+    Branch entry (cr1.union cr2) :=
+  br.seqNotTakenDisjoint hd tail hlink
+
+/-- Continue only the not-taken exit of a branch with a CPS leaf over disjoint code. -/
+def branchSeqNotTakenBlockDisjoint {nTail : Nat} {entry target : Word}
+    {cr1 cr2 : CodeReq} {tailPre post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : Branch entry cr1)
+    (tail : cpsTripleWithin nTail br.exit_f target cr2 tailPre post)
+    (hlink : Entails br.post_f tailPre) :
+    Branch entry (cr1.union cr2) :=
+  branchSeqNotTakenDisjoint hd br (block (Entails.refl _) tail) hlink
+
 /-- Join an N-way branch with a uniform continuation bound. -/
 def nbranch {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     (br : NBranch entry cr) (tailBound : Nat)

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -372,6 +372,30 @@ def nbranchSeqSecondNBranchDisjoint {entry head l : Word} {cr1 cr2 : CodeReq}
     NBranch entry (cr1.union cr2) :=
   br.seqSecondNBranchDisjoint hd hexits tail hlink
 
+/-- Continue the third exit of a four-way N-branch with another N-way CFG over
+    disjoint tail code. -/
+def nbranchSeqThirdNBranchDisjoint {entry l1 l2 l3 l4 : Word} {cr1 cr2 : CodeReq}
+    {Q1 Q2 Q3 Q4 : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : NBranch entry cr1)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)])
+    (tail : NBranch l3 cr2)
+    (hlink : Entails Q3 tail.pre) :
+    NBranch entry (cr1.union cr2) :=
+  br.seqThirdNBranchDisjoint hd hexits tail hlink
+
+/-- Continue the third exit of a four-way N-branch with a single-exit CFG over
+    disjoint tail code. -/
+def nbranchSeqThirdCertDisjoint {entry l1 l2 l3 l4 l3' : Word} {cr1 cr2 : CodeReq}
+    {Q1 Q2 Q3 Q4 R : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : NBranch entry cr1)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)])
+    (tail : Cert l3 l3' cr2 R)
+    (hlink : Entails Q3 tail.pre) :
+    NBranch entry (cr1.union cr2) :=
+  br.seqThirdCertDisjoint hd hexits tail hlink
+
 /-- Join an N-way branch with a uniform continuation bound. -/
 def nbranch {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     (br : NBranch entry cr) (tailBound : Nat)

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -45,6 +45,91 @@ def frameR {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     Cert entry exit_ cr (post ** F) :=
   cfg.frameR F hF
 
+/-- Weaken the computed precondition of a single-exit CFG certificate. -/
+def weakenPre {entry exit_ : Word} {cr : CodeReq} {post pre' : Assertion}
+    (cfg : Cert entry exit_ cr post) (hpre : Entails pre' cfg.pre) :
+    Cert entry exit_ cr post :=
+  cfg.weakenPre hpre
+
+/-- Weaken the continuation postcondition of a single-exit CFG certificate. -/
+def weakenPost {entry exit_ : Word} {cr : CodeReq} {post post' : Assertion}
+    (cfg : Cert entry exit_ cr post) (hpost : Entails post post') :
+    Cert entry exit_ cr post' :=
+  cfg.weakenPost hpost
+
+/-- Increase the step budget of a single-exit CFG certificate. -/
+def monoSteps {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
+    (cfg : Cert entry exit_ cr post) {nSteps' : Nat} (hle : cfg.nSteps ≤ nSteps') :
+    Cert entry exit_ cr post :=
+  cfg.monoSteps hle
+
+/-- Extend a single-exit CFG certificate to a larger persistent code requirement. -/
+def extendCode {entry exit_ : Word} {cr cr' : CodeReq} {post : Assertion}
+    (cfg : Cert entry exit_ cr post)
+    (hmono : ∀ a i, cr a = some i → cr' a = some i) :
+    Cert entry exit_ cr' post :=
+  cfg.extendCode hmono
+
+/-- Rewrite the entry address of a single-exit CFG certificate. -/
+def changeEntry {entry entry' exit_ : Word} {cr : CodeReq} {post : Assertion}
+    (cfg : Cert entry exit_ cr post) (hentry : entry' = entry) :
+    Cert entry' exit_ cr post :=
+  cfg.changeEntry hentry
+
+/-- Rewrite the exit address of a single-exit CFG certificate. -/
+def changeExit {entry exit_ exit_' : Word} {cr : CodeReq} {post : Assertion}
+    (cfg : Cert entry exit_ cr post) (hexit : exit_ = exit_') :
+    Cert entry exit_' cr post :=
+  cfg.changeExit hexit
+
+/-- `weakenPre` exposes exactly the supplied precondition. -/
+theorem weakenPre_pre {entry exit_ : Word} {cr : CodeReq} {post pre' : Assertion}
+    (cfg : Cert entry exit_ cr post) (hpre : Entails pre' cfg.pre) :
+    (weakenPre cfg hpre).pre = pre' :=
+  rfl
+
+/-- `weakenPost` preserves the computed precondition. -/
+theorem weakenPost_pre {entry exit_ : Word} {cr : CodeReq} {post post' : Assertion}
+    (cfg : Cert entry exit_ cr post) (hpost : Entails post post') :
+    (weakenPost cfg hpost).pre = cfg.pre :=
+  rfl
+
+/-- `monoSteps` preserves the computed precondition. -/
+theorem monoSteps_pre {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
+    (cfg : Cert entry exit_ cr post) {nSteps' : Nat} (hle : cfg.nSteps ≤ nSteps') :
+    (monoSteps cfg hle).pre = cfg.pre :=
+  rfl
+
+/-- `extendCode` preserves the computed precondition. -/
+theorem extendCode_pre {entry exit_ : Word} {cr cr' : CodeReq} {post : Assertion}
+    (cfg : Cert entry exit_ cr post)
+    (hmono : ∀ a i, cr a = some i → cr' a = some i) :
+    (extendCode cfg hmono).pre = cfg.pre :=
+  rfl
+
+/-- `changeEntry` preserves the computed precondition. -/
+theorem changeEntry_pre {entry entry' exit_ : Word} {cr : CodeReq} {post : Assertion}
+    (cfg : Cert entry exit_ cr post) (hentry : entry' = entry) :
+    (changeEntry cfg hentry).pre = cfg.pre :=
+  rfl
+
+/-- `changeExit` preserves the computed precondition. -/
+theorem changeExit_pre {entry exit_ exit_' : Word} {cr : CodeReq} {post : Assertion}
+    (cfg : Cert entry exit_ cr post) (hexit : exit_ = exit_') :
+    (changeExit cfg hexit).pre = cfg.pre :=
+  rfl
+
+example {entry exit_ : Word} {cr : CodeReq} {post post' : Assertion}
+    (cfg : Cert entry exit_ cr post) (hpost : Entails post post') :
+    Cert entry exit_ cr post' :=
+  weakenPost cfg hpost
+
+example {entry exit_ : Word} {cr cr' : CodeReq} {post : Assertion}
+    (cfg : Cert entry exit_ cr post)
+    (hmono : ∀ a i, cr a = some i → cr' a = some i) :
+    (extendCode cfg hmono).pre = cfg.pre :=
+  extendCode_pre cfg hmono
+
 /-- Sequential composition with one shared persistent code requirement. -/
 def seq {nSteps : Nat} {entry mid exit_ : Word} {cr : CodeReq}
     {pre midPost post : Assertion}

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -123,6 +123,21 @@ def branchSeqTakenBlockDisjoint {nTail : Nat} {entry target : Word}
     Branch entry (cr1.union cr2) :=
   branchSeqTakenDisjoint hd br (block (Entails.refl _) tail) hlink
 
+/-- Continue the taken exit with another branch and merge both failure exits into
+    one failure post. This is the WP form of a decoder parse followed by a
+    validation branch. -/
+def branchSeqTakenBranchConvergeDisjoint {entry : Word} {cr1 cr2 : CodeReq}
+    {failPost : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : Branch entry cr1)
+    (tail : Branch br.exit_t cr2)
+    (hfail : tail.exit_t = br.exit_f)
+    (hlink : Entails br.post_t tail.pre)
+    (hf1 : Entails br.post_f failPost)
+    (hf2 : Entails tail.post_t failPost) :
+    Branch entry (cr1.union cr2) :=
+  br.seqTakenBranchConvergeDisjoint hd tail hfail hlink hf1 hf2
+
 /-- Continue only the not-taken exit of a branch with disjoint code, leaving the
     taken exit open. -/
 def branchSeqNotTakenDisjoint {entry target : Word} {cr1 cr2 : CodeReq} {post : Assertion}

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -34,6 +34,12 @@ def block {nSteps : Nat} {entry exit_ : Word} {cr : CodeReq}
     Cert entry exit_ cr post' :=
   Triple.ofSpec hpost h
 
+/-- Frame a single-exit CFG certificate with a PC-free assertion. -/
+def frameR {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
+    (cfg : Cert entry exit_ cr post) (F : Assertion) (hF : F.pcFree) :
+    Cert entry exit_ cr (post ** F) :=
+  cfg.frameR F hF
+
 /-- Sequential composition with one shared persistent code requirement. -/
 def seq {nSteps : Nat} {entry mid exit_ : Word} {cr : CodeReq}
     {pre midPost post : Assertion}

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -379,6 +379,21 @@ def nbranch {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     Cert entry exit_ cr post :=
   br.join tailBound hall
 
+/-- Join exactly four known exits with single-exit continuations. -/
+def nbranchJoin4 {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
+    {l1 l2 l3 l4 : Word} {Q1 Q2 Q3 Q4 : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)])
+    (tailBound : Nat)
+    (t1 : Cert l1 exit_ cr post) (t2 : Cert l2 exit_ cr post)
+    (t3 : Cert l3 exit_ cr post) (t4 : Cert l4 exit_ cr post)
+    (hlink1 : Entails Q1 t1.pre) (hlink2 : Entails Q2 t2.pre)
+    (hlink3 : Entails Q3 t3.pre) (hlink4 : Entails Q4 t4.pre)
+    (h1 : t1.nSteps ≤ tailBound) (h2 : t2.nSteps ≤ tailBound)
+    (h3 : t3.nSteps ≤ tailBound) (h4 : t4.nSteps ≤ tailBound) :
+    Cert entry exit_ cr post :=
+  br.join4 hexits tailBound t1 t2 t3 t4 hlink1 hlink2 hlink3 hlink4 h1 h2 h3 h4
+
 /-- Package an indexed invariant/variant loop as a CFG certificate. -/
 def loopNat {nHeader nBody nExit : Nat}
     {header bodyEntry exit_ : Word} {cr : CodeReq}

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -74,6 +74,11 @@ def seqBlockDisjoint {nHead nTail : Nat} {entry mid exit_ : Word} {cr1 cr2 : Cod
     Cert entry exit_ (cr1.union cr2) post :=
   seqDisjoint hd head (block (Entails.refl _) tail) hlink
 
+/-- Frame both exits of a branch with a PC-free assertion. -/
+def branchFrameR {entry : Word} {cr : CodeReq}
+    (br : Branch entry cr) (F : Assertion) (hF : F.pcFree) : Branch entry cr :=
+  br.frameR F hF
+
 /-- Join a two-way branch with a continuation for each exit. -/
 def branch {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     (br : Branch entry cr)
@@ -83,6 +88,26 @@ def branch {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     (hf : Entails br.post_f notTaken.pre) :
     Cert entry exit_ cr post :=
   br.join taken notTaken ht hf
+
+/-- Continue only the taken exit of a branch with disjoint code, leaving the
+    not-taken exit open. -/
+def branchSeqTakenDisjoint {entry target : Word} {cr1 cr2 : CodeReq} {post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : Branch entry cr1)
+    (tail : Cert br.exit_t target cr2 post)
+    (hlink : Entails br.post_t tail.pre) :
+    Branch entry (cr1.union cr2) :=
+  br.seqTakenDisjoint hd tail hlink
+
+/-- Continue only the taken exit of a branch with a CPS leaf over disjoint code. -/
+def branchSeqTakenBlockDisjoint {nTail : Nat} {entry target : Word}
+    {cr1 cr2 : CodeReq} {tailPre post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : Branch entry cr1)
+    (tail : cpsTripleWithin nTail br.exit_t target cr2 tailPre post)
+    (hlink : Entails br.post_t tailPre) :
+    Branch entry (cr1.union cr2) :=
+  branchSeqTakenDisjoint hd br (block (Entails.refl _) tail) hlink
 
 /-- Join an N-way branch with a uniform continuation bound. -/
 def nbranch {entry exit_ : Word} {cr : CodeReq} {post : Assertion}

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -394,6 +394,31 @@ def nbranchJoin4 {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     Cert entry exit_ cr post :=
   br.join4 hexits tailBound t1 t2 t3 t4 hlink1 hlink2 hlink3 hlink4 h1 h2 h3 h4
 
+/-- Join exactly four known exits, computing the common continuation bound from
+    the supplied continuation certificates. -/
+def nbranchJoin4Max {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
+    {l1 l2 l3 l4 : Word} {Q1 Q2 Q3 Q4 : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)])
+    (t1 : Cert l1 exit_ cr post) (t2 : Cert l2 exit_ cr post)
+    (t3 : Cert l3 exit_ cr post) (t4 : Cert l4 exit_ cr post)
+    (hlink1 : Entails Q1 t1.pre) (hlink2 : Entails Q2 t2.pre)
+    (hlink3 : Entails Q3 t3.pre) (hlink4 : Entails Q4 t4.pre) :
+    Cert entry exit_ cr post :=
+  br.join4Max hexits t1 t2 t3 t4 hlink1 hlink2 hlink3 hlink4
+
+/-- Join exactly four known exits when the third exit is the only reachable one. -/
+def nbranchJoin4ResolveThird {entry : Word} {cr : CodeReq} {post : Assertion}
+    {l1 l2 l3 l4 : Word} {Q1 Q2 Q3 Q4 : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)])
+    (hdead1 : ∀ h, Q1 h → False)
+    (hdead2 : ∀ h, Q2 h → False)
+    (hlink3 : Entails Q3 post)
+    (hdead4 : ∀ h, Q4 h → False) :
+    Cert entry l3 cr post :=
+  br.join4ResolveThird hexits hdead1 hdead2 hlink3 hdead4
+
 /-- Package an indexed invariant/variant loop as a CFG certificate. -/
 def loopNat {nHeader nBody nExit : Nat}
     {header bodyEntry exit_ : Word} {cr : CodeReq}

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -414,6 +414,26 @@ def nbranch {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     Cert entry exit_ cr post :=
   br.join tailBound hall
 
+/-- Join exactly two known exits when the first exit is the only reachable one. -/
+def nbranchJoin2ResolveFirst {entry : Word} {cr : CodeReq} {post : Assertion}
+    {l1 l2 : Word} {Q1 Q2 : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2)])
+    (hlink1 : Entails Q1 post)
+    (hdead2 : ∀ h, Q2 h → False) :
+    Cert entry l1 cr post :=
+  br.join2ResolveFirst hexits hlink1 hdead2
+
+/-- Join exactly two known exits when the second exit is the only reachable one. -/
+def nbranchJoin2ResolveSecond {entry : Word} {cr : CodeReq} {post : Assertion}
+    {l1 l2 : Word} {Q1 Q2 : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2)])
+    (hdead1 : ∀ h, Q1 h → False)
+    (hlink2 : Entails Q2 post) :
+    Cert entry l2 cr post :=
+  br.join2ResolveSecond hexits hdead1 hlink2
+
 /-- Join exactly four known exits with single-exit continuations. -/
 def nbranchJoin4 {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     {l1 l2 l3 l4 : Word} {Q1 Q2 Q3 Q4 : Assertion}

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -226,6 +226,34 @@ def nbranchWeakenPostsCons {entry : Word} {cr : CodeReq}
     NBranch entry cr :=
   br.weakenPostsCons hexits hhead htail
 
+/-- Weaken exactly two known exits of an N-way CFG. -/
+def nbranchWeakenPosts2 {entry : Word} {cr : CodeReq}
+    {l1 l2 : Word} {Q1 Q2 Q1' Q2' : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2)])
+    (h1 : Entails Q1 Q1') (h2 : Entails Q2 Q2') :
+    NBranch entry cr :=
+  br.weakenPosts2 hexits h1 h2
+
+/-- Weaken exactly three known exits of an N-way CFG. -/
+def nbranchWeakenPosts3 {entry : Word} {cr : CodeReq}
+    {l1 l2 l3 : Word} {Q1 Q2 Q3 Q1' Q2' Q3' : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3)])
+    (h1 : Entails Q1 Q1') (h2 : Entails Q2 Q2') (h3 : Entails Q3 Q3') :
+    NBranch entry cr :=
+  br.weakenPosts3 hexits h1 h2 h3
+
+/-- Weaken exactly four known exits of an N-way CFG. -/
+def nbranchWeakenPosts4 {entry : Word} {cr : CodeReq}
+    {l1 l2 l3 l4 : Word} {Q1 Q2 Q3 Q4 Q1' Q2' Q3' Q4' : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)])
+    (h1 : Entails Q1 Q1') (h2 : Entails Q2 Q2') (h3 : Entails Q3 Q3')
+    (h4 : Entails Q4 Q4') :
+    NBranch entry cr :=
+  br.weakenPosts4 hexits h1 h2 h3 h4
+
 /-- Continue a branch's not-taken exit with an N-way CFG over disjoint code,
     preserving the taken exit as the first open exit. -/
 def branchSeqNotTakenNBranchDisjoint {entry : Word} {cr1 cr2 : CodeReq}

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -129,6 +129,28 @@ def branchSeqNotTakenBlockDisjoint {nTail : Nat} {entry target : Word}
     Branch entry (cr1.union cr2) :=
   branchSeqNotTakenDisjoint hd br (block (Entails.refl _) tail) hlink
 
+/-- Continue only the taken exit of a branch with disjoint code and expose the
+    resulting two exits as an N-way branch. -/
+def branchSeqTakenNBranchDisjoint {entry target : Word} {cr1 cr2 : CodeReq}
+    {post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : Branch entry cr1)
+    (tail : Cert br.exit_t target cr2 post)
+    (hlink : Entails br.post_t tail.pre) :
+    NBranch entry (cr1.union cr2) :=
+  br.seqTakenAsNBranchDisjoint hd tail hlink
+
+/-- Continue only the taken exit of a branch with a CPS leaf over disjoint code
+    and expose the resulting two exits as an N-way branch. -/
+def branchSeqTakenBlockNBranchDisjoint {nTail : Nat} {entry target : Word}
+    {cr1 cr2 : CodeReq} {tailPre post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : Branch entry cr1)
+    (tail : cpsTripleWithin nTail br.exit_t target cr2 tailPre post)
+    (hlink : Entails br.post_t tailPre) :
+    NBranch entry (cr1.union cr2) :=
+  branchSeqTakenNBranchDisjoint hd br (block (Entails.refl _) tail) hlink
+
 /-- View a two-way branch as an N-way branch. -/
 def nbranchOfBranch {entry : Word} {cr : CodeReq} (br : Branch entry cr) :
     NBranch entry cr :=

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -53,6 +53,27 @@ def seqDisjoint {nSteps : Nat} {entry mid exit_ : Word} {cr1 cr2 : CodeReq}
     Cert entry exit_ (cr1.union cr2) post :=
   Triple.seqDisjoint hd head tail hlink
 
+/-- Sequential composition where both adjacent regions are already available as
+    CPS triples over one shared persistent code requirement. -/
+def seqBlock {nHead nTail : Nat} {entry mid exit_ : Word} {cr : CodeReq}
+    {pre midPost tailPre post : Assertion}
+    (head : cpsTripleWithin nHead entry mid cr pre midPost)
+    (tail : cpsTripleWithin nTail mid exit_ cr tailPre post)
+    (hlink : Entails midPost tailPre) :
+    Cert entry exit_ cr post :=
+  seq head (block (Entails.refl _) tail) hlink
+
+/-- Sequential composition where both adjacent regions are already available as
+    CPS triples over disjoint code requirements. -/
+def seqBlockDisjoint {nHead nTail : Nat} {entry mid exit_ : Word} {cr1 cr2 : CodeReq}
+    {pre midPost tailPre post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (head : cpsTripleWithin nHead entry mid cr1 pre midPost)
+    (tail : cpsTripleWithin nTail mid exit_ cr2 tailPre post)
+    (hlink : Entails midPost tailPre) :
+    Cert entry exit_ (cr1.union cr2) post :=
+  seqDisjoint hd head (block (Entails.refl _) tail) hlink
+
 /-- Join a two-way branch with a continuation for each exit. -/
 def branch {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     (br : Branch entry cr)

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -26,6 +26,11 @@ def exit (addr : Word) (cr : CodeReq) {pre post : Assertion}
     (h : Entails pre post) : Cert addr addr cr post :=
   Triple.refl addr cr h
 
+/-- A CFG certificate for an unreachable precondition. -/
+def unreachable (entry exit_ : Word) (cr : CodeReq) {pre post : Assertion}
+    (hpre : ∀ h, pre h → False) : Cert entry exit_ cr post :=
+  Triple.unreachable entry exit_ cr hpre
+
 /-- A leaf block whose CPS spec is already available. -/
 def block {nSteps : Nat} {entry exit_ : Word} {cr : CodeReq}
     {pre post post' : Assertion}

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -259,6 +259,17 @@ def nbranchWeakenPosts4 {entry : Word} {cr : CodeReq}
     NBranch entry cr :=
   br.weakenPosts4 hexits h1 h2 h3 h4
 
+/-- Weaken four exits into three by mapping the first two same-target exits to
+    one replacement post. -/
+def nbranchWeakenPosts4MergeFirstTwo {entry : Word} {cr : CodeReq}
+    {l l3 l4 : Word} {Q1 Q2 Q3 Q4 Q12 Q3' Q4' : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l, Q1), (l, Q2), (l3, Q3), (l4, Q4)])
+    (h1 : Entails Q1 Q12) (h2 : Entails Q2 Q12) (h3 : Entails Q3 Q3')
+    (h4 : Entails Q4 Q4') :
+    NBranch entry cr :=
+  br.weakenPosts4MergeFirstTwo hexits h1 h2 h3 h4
+
 /-- Continue a branch's not-taken exit with an N-way CFG over disjoint code,
     preserving the taken exit as the first open exit. -/
 def branchSeqNotTakenNBranchDisjoint {entry : Word} {cr1 cr2 : CodeReq}

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -170,6 +170,27 @@ def nbranchWeakenPosts {entry : Word} {cr : CodeReq}
     NBranch entry cr :=
   br.weakenPosts exits' hmap
 
+/-- Weaken the head exit of an N-way CFG, preserving the tail exits. -/
+def nbranchWeakenHeadPost {entry : Word} {cr : CodeReq}
+    {l : Word} {headPost headPost' : Assertion} {others : List (Word × Assertion)}
+    (br : NBranch entry cr)
+    (hexits : br.exits = (l, headPost) :: others)
+    (hhead : Entails headPost headPost') :
+    NBranch entry cr :=
+  br.weakenHeadPost hexits hhead
+
+/-- Weaken the head exit and remap the tail exits of an N-way CFG. -/
+def nbranchWeakenPostsCons {entry : Word} {cr : CodeReq}
+    {l : Word} {headPost headPost' : Assertion}
+    {others others' : List (Word × Assertion)}
+    (br : NBranch entry cr)
+    (hexits : br.exits = (l, headPost) :: others)
+    (hhead : Entails headPost headPost')
+    (htail : ∀ ex ∈ others, ∃ ex' ∈ others',
+      ex'.1 = ex.1 ∧ Entails ex.2 ex'.2) :
+    NBranch entry cr :=
+  br.weakenPostsCons hexits hhead htail
+
 /-- Continue a branch's not-taken exit with an N-way CFG over disjoint code,
     preserving the taken exit as the first open exit. -/
 def branchSeqNotTakenNBranchDisjoint {entry : Word} {cr1 cr2 : CodeReq}

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -315,6 +315,18 @@ def nbranchSeqExitNBranchDisjoint {entry l : Word} {cr1 cr2 : CodeReq}
     NBranch entry (cr1.union cr2) :=
   br.seqExitNBranchDisjoint hd hexits tail hlink
 
+/-- Continue an arbitrary exit of an N-way CFG with a single-exit certificate
+    over disjoint tail code, preserving the exits before and after it. -/
+def nbranchSeqExitCertDisjoint {entry l l' : Word} {cr1 cr2 : CodeReq}
+    {exitPost post : Assertion} {preExits others : List (Word × Assertion)}
+    (hd : cr1.Disjoint cr2)
+    (br : NBranch entry cr1)
+    (hexits : br.exits = preExits ++ (l, exitPost) :: others)
+    (tail : Cert l l' cr2 post)
+    (hlink : Entails exitPost tail.pre) :
+    NBranch entry (cr1.union cr2) :=
+  nbranchSeqExitNBranchDisjoint hd br hexits (NBranch.ofTriple tail) hlink
+
 /-- Preserve the first exit and continue the second exit with another N-way CFG
     over disjoint tail code. -/
 def nbranchSeqSecondNBranchDisjoint {entry head l : Word} {cr1 cr2 : CodeReq}

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -156,6 +156,20 @@ def nbranchOfBranch {entry : Word} {cr : CodeReq} (br : Branch entry cr) :
     NBranch entry cr :=
   NBranch.ofBranch br
 
+/-- Frame every exit of an N-way CFG with a PC-free assertion. -/
+def nbranchFrameR {entry : Word} {cr : CodeReq}
+    (br : NBranch entry cr) (F : Assertion) (hF : F.pcFree) :
+    NBranch entry cr :=
+  br.frameR F hF
+
+/-- Weaken the exit postconditions of an N-way CFG. -/
+def nbranchWeakenPosts {entry : Word} {cr : CodeReq}
+    (br : NBranch entry cr) (exits' : List (Word × Assertion))
+    (hmap : ∀ ex ∈ br.exits, ∃ ex' ∈ exits',
+      ex'.1 = ex.1 ∧ Entails ex.2 ex'.2) :
+    NBranch entry cr :=
+  br.weakenPosts exits' hmap
+
 /-- Continue a branch's not-taken exit with an N-way CFG over disjoint code,
     preserving the taken exit as the first open exit. -/
 def branchSeqNotTakenNBranchDisjoint {entry : Word} {cr1 cr2 : CodeReq}

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -129,6 +129,21 @@ def branchSeqNotTakenBlockDisjoint {nTail : Nat} {entry target : Word}
     Branch entry (cr1.union cr2) :=
   branchSeqNotTakenDisjoint hd br (block (Entails.refl _) tail) hlink
 
+/-- View a two-way branch as an N-way branch. -/
+def nbranchOfBranch {entry : Word} {cr : CodeReq} (br : Branch entry cr) :
+    NBranch entry cr :=
+  NBranch.ofBranch br
+
+/-- Continue a branch's not-taken exit with an N-way CFG over disjoint code,
+    preserving the taken exit as the first open exit. -/
+def branchSeqNotTakenNBranchDisjoint {entry : Word} {cr1 cr2 : CodeReq}
+    (hd : cr1.Disjoint cr2)
+    (br : Branch entry cr1)
+    (tail : NBranch br.exit_f cr2)
+    (hlink : Entails br.post_f tail.pre) :
+    NBranch entry (cr1.union cr2) :=
+  br.seqNotTakenNBranchDisjoint hd tail hlink
+
 /-- Join an N-way branch with a uniform continuation bound. -/
 def nbranch {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     (br : NBranch entry cr) (tailBound : Nat)

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -282,6 +282,18 @@ def nbranchSeqHeadNBranchDisjoint {entry l : Word} {cr1 cr2 : CodeReq}
     NBranch entry (cr1.union cr2) :=
   br.seqHeadNBranchDisjoint hd hexits tail hlink
 
+/-- Continue an arbitrary exit of an N-way CFG with another N-way CFG over disjoint
+    tail code, preserving the exits before and after it. -/
+def nbranchSeqExitNBranchDisjoint {entry l : Word} {cr1 cr2 : CodeReq}
+    {exitPost : Assertion} {preExits others : List (Word × Assertion)}
+    (hd : cr1.Disjoint cr2)
+    (br : NBranch entry cr1)
+    (hexits : br.exits = preExits ++ (l, exitPost) :: others)
+    (tail : NBranch l cr2)
+    (hlink : Entails exitPost tail.pre) :
+    NBranch entry (cr1.union cr2) :=
+  br.seqExitNBranchDisjoint hd hexits tail hlink
+
 /-- Preserve the first exit and continue the second exit with another N-way CFG
     over disjoint tail code. -/
 def nbranchSeqSecondNBranchDisjoint {entry head l : Word} {cr1 cr2 : CodeReq}

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -74,6 +74,20 @@ def seqBlockDisjoint {nHead nTail : Nat} {entry mid exit_ : Word} {cr1 cr2 : Cod
     Cert entry exit_ (cr1.union cr2) post :=
   seqDisjoint hd head (block (Entails.refl _) tail) hlink
 
+/-- Sequential composition from a CPS block into an N-way CFG over disjoint code. -/
+def seqBlockNBranchDisjoint {nHead : Nat} {entry mid : Word} {cr1 cr2 : CodeReq}
+    {pre midPost : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (head : cpsTripleWithin nHead entry mid cr1 pre midPost)
+    (tail : NBranch mid cr2)
+    (hlink : Entails midPost tail.pre) :
+    NBranch entry (cr1.union cr2) where
+  nSteps := nHead + tail.nSteps
+  pre := pre
+  exits := tail.exits
+  sound := cpsTripleWithin_seq_cpsNBranchWithin hd
+    (cpsTripleWithin_weaken (fun _ hp => hp) hlink head) tail.sound
+
 /-- Frame both exits of a branch with a PC-free assertion. -/
 def branchFrameR {entry : Word} {cr : CodeReq}
     (br : Branch entry cr) (F : Assertion) (hF : F.pcFree) : Branch entry cr :=
@@ -267,6 +281,18 @@ def nbranchSeqHeadNBranchDisjoint {entry l : Word} {cr1 cr2 : CodeReq}
     (hlink : Entails headPost tail.pre) :
     NBranch entry (cr1.union cr2) :=
   br.seqHeadNBranchDisjoint hd hexits tail hlink
+
+/-- Preserve the first exit and continue the second exit with another N-way CFG
+    over disjoint tail code. -/
+def nbranchSeqSecondNBranchDisjoint {entry head l : Word} {cr1 cr2 : CodeReq}
+    {headPost secondPost : Assertion} {others : List (Word × Assertion)}
+    (hd : cr1.Disjoint cr2)
+    (br : NBranch entry cr1)
+    (hexits : br.exits = (head, headPost) :: (l, secondPost) :: others)
+    (tail : NBranch l cr2)
+    (hlink : Entails secondPost tail.pre) :
+    NBranch entry (cr1.union cr2) :=
+  br.seqSecondNBranchDisjoint hd hexits tail hlink
 
 /-- Join an N-way branch with a uniform continuation bound. -/
 def nbranch {entry exit_ : Word} {cr : CodeReq} {post : Assertion}

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -434,6 +434,17 @@ def nbranchJoin2ResolveSecond {entry : Word} {cr : CodeReq} {post : Assertion}
     Cert entry l2 cr post :=
   br.join2ResolveSecond hexits hdead1 hlink2
 
+/-- Join exactly three known exits when the second exit is the only reachable one. -/
+def nbranchJoin3ResolveSecond {entry : Word} {cr : CodeReq} {post : Assertion}
+    {l1 l2 l3 : Word} {Q1 Q2 Q3 : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3)])
+    (hdead1 : ∀ h, Q1 h → False)
+    (hlink2 : Entails Q2 post)
+    (hdead3 : ∀ h, Q3 h → False) :
+    Cert entry l2 cr post :=
+  br.join3ResolveSecond hexits hdead1 hlink2 hdead3
+
 /-- Join exactly four known exits with single-exit continuations. -/
 def nbranchJoin4 {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     {l1 l2 l3 l4 : Word} {Q1 Q2 Q3 Q4 : Assertion}

--- a/EvmAsm/Rv64/WP/Call.lean
+++ b/EvmAsm/Rv64/WP/Call.lean
@@ -1,0 +1,86 @@
+/-
+  EvmAsm.Rv64.WP.Call
+
+  Call/return combinators for the WP certificate layer.  This packages the
+  common `jal ra, callee` shape as a backward calculator step: after the JAL,
+  the callee sees `ra = callerPC + 4`, and a normal RISC-V return reaches the
+  aligned caller continuation.
+-/
+
+import EvmAsm.Rv64.WP.CFG
+import EvmAsm.Rv64.GenericSpecs
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Rv64
+namespace WP
+
+/-- Bounded CPS rule for a direct `jal ra, callee` call.
+
+The callee may be any separately proved code requirement.  The caller JAL and
+the callee code must be disjoint, and the continuation is the architectural
+return address `callerPC + 4`. -/
+theorem cpsCallWithin {nSteps : Nat} {callerPC calleeEntry vOld : Word}
+    {calleeCode : CodeReq} {Prest Q : Assertion} (offset : BitVec 21)
+    (hoffset : callerPC + signExtend21 offset = calleeEntry)
+    (halign : (callerPC + 4) &&& ~~~(1 : Word) = callerPC + 4)
+    (hPrest : Prest.pcFree)
+    (hdisj : (CodeReq.singleton callerPC (.JAL .x1 offset)).Disjoint calleeCode)
+    (hcallee : cpsTripleWithin nSteps calleeEntry ((callerPC + 4) &&& ~~~(1 : Word))
+      calleeCode ((.x1 ↦ᵣ (callerPC + 4)) ** Prest) Q) :
+    cpsTripleWithin (1 + nSteps) callerPC (callerPC + 4)
+      ((CodeReq.singleton callerPC (.JAL .x1 offset)).union calleeCode)
+      ((.x1 ↦ᵣ vOld) ** Prest) Q := by
+  have hjal0 := generic_jal_spec_within .x1 vOld offset callerPC (by decide)
+  rw [hoffset] at hjal0
+  have hjal : cpsTripleWithin 1 callerPC calleeEntry
+      (CodeReq.singleton callerPC (.JAL .x1 offset))
+      ((.x1 ↦ᵣ vOld) ** Prest)
+      ((.x1 ↦ᵣ (callerPC + 4)) ** Prest) :=
+    cpsTripleWithin_frameR Prest hPrest hjal0
+  have hcallee' : cpsTripleWithin nSteps calleeEntry (callerPC + 4) calleeCode
+      ((.x1 ↦ᵣ (callerPC + 4)) ** Prest) Q := by
+    rw [halign] at hcallee
+    exact hcallee
+  exact cpsTripleWithin_seq hdisj hjal hcallee'
+
+namespace Triple
+
+/-- Package a direct call as a WP triple.  The callee certificate may compute a
+    stronger precondition; `hlink` connects the post-JAL state to that computed
+    precondition. -/
+def callWithin {callerPC calleeEntry : Word} {calleeCode : CodeReq}
+    {Prest Q : Assertion} (offset : BitVec 21) (vOld : Word)
+    (callee : Triple calleeEntry ((callerPC + 4) &&& ~~~(1 : Word)) calleeCode Q)
+    (hoffset : callerPC + signExtend21 offset = calleeEntry)
+    (halign : (callerPC + 4) &&& ~~~(1 : Word) = callerPC + 4)
+    (hPrest : Prest.pcFree)
+    (hdisj : (CodeReq.singleton callerPC (.JAL .x1 offset)).Disjoint calleeCode)
+    (hlink : Entails ((.x1 ↦ᵣ (callerPC + 4)) ** Prest) callee.pre) :
+    Triple callerPC (callerPC + 4)
+      ((CodeReq.singleton callerPC (.JAL .x1 offset)).union calleeCode) Q where
+  nSteps := 1 + callee.nSteps
+  pre := (.x1 ↦ᵣ vOld) ** Prest
+  sound := cpsCallWithin offset hoffset halign hPrest hdisj
+    (callee.weakenPre hlink).sound
+
+end Triple
+
+namespace CFG
+
+/-- User-facing CFG constructor for a direct call. -/
+def callWithin {callerPC calleeEntry : Word} {calleeCode : CodeReq}
+    {Prest Q : Assertion} (offset : BitVec 21) (vOld : Word)
+    (callee : Cert calleeEntry ((callerPC + 4) &&& ~~~(1 : Word)) calleeCode Q)
+    (hoffset : callerPC + signExtend21 offset = calleeEntry)
+    (halign : (callerPC + 4) &&& ~~~(1 : Word) = callerPC + 4)
+    (hPrest : Prest.pcFree)
+    (hdisj : (CodeReq.singleton callerPC (.JAL .x1 offset)).Disjoint calleeCode)
+    (hlink : Entails ((.x1 ↦ᵣ (callerPC + 4)) ** Prest) callee.pre) :
+    Cert callerPC (callerPC + 4)
+      ((CodeReq.singleton callerPC (.JAL .x1 offset)).union calleeCode) Q :=
+  Triple.callWithin offset vOld callee hoffset halign hPrest hdisj hlink
+
+end CFG
+
+end WP
+end EvmAsm.Rv64

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -57,6 +57,20 @@ def refl (addr : Word) (cr : CodeReq) {pre post : Assertion}
       obtain ⟨hp, hcompat, hpq⟩ := hPR
       exact ⟨hp, hcompat, sepConj_mono_left h hp hpq⟩⟩
 
+/-- A WP continuation for an unreachable state. If the computed precondition is
+    contradictory, any exit/postcondition follows without executing code. This
+    is useful when generated control-flow keeps syntactic exits whose path
+    guards are inconsistent with the current input witness. -/
+def unreachable (entry exit_ : Word) (cr : CodeReq) {pre post : Assertion}
+    (hpre : ∀ h, pre h → False) : Triple entry exit_ cr post where
+  nSteps := 0
+  pre := pre
+  sound := by
+    intro R _hR s _hcr hPR _hpc
+    obtain ⟨hp, _hcompat, hpq⟩ := hPR
+    obtain ⟨hprePart, _hRPart, _hd, _hunion, hpreSat, _hRSat⟩ := hpq
+    exact False.elim (hpre hprePart hpreSat)
+
 /-- Lift an already-proved CPS triple into a WP result, weakening its
     postcondition to the requested continuation post. -/
 def ofSpec {nSteps : Nat} {entry exit_ : Word} {cr : CodeReq}

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -263,6 +263,84 @@ def ofBranch {entry : Word} {cr : CodeReq} (br : Branch entry cr) :
   exits := [(br.exit_t, br.post_t), (br.exit_f, br.post_f)]
   sound := cpsBranchWithin_as_cpsNBranchWithin br.sound
 
+/-- Weaken the computed precondition of an N-way branch. -/
+def weakenPre {entry : Word} {cr : CodeReq} {pre' : Assertion}
+    (br : NBranch entry cr) (hpre : Entails pre' br.pre) : NBranch entry cr where
+  nSteps := br.nSteps
+  pre := pre'
+  exits := br.exits
+  sound := cpsNBranchWithin_weaken_pre hpre br.sound
+
+/-- Continue the head exit of an N-way branch with a single-exit continuation
+    over the same code requirement. -/
+def seqHead {entry l l' : Word} {cr : CodeReq}
+    {Q R : Assertion} {others : List (Word × Assertion)}
+    (br : NBranch entry cr)
+    (hexits : br.exits = (l, Q) :: others)
+    (tail : Triple l l' cr R)
+    (hlink : Entails Q tail.pre) :
+    NBranch entry cr where
+  nSteps := br.nSteps + tail.nSteps
+  pre := br.pre
+  exits := (l', R) :: others
+  sound := by
+    have hbr : cpsNBranchWithin br.nSteps entry cr br.pre ((l, Q) :: others) := by
+      simpa [hexits] using br.sound
+    exact cpsNBranchWithin_extend_head hbr (tail.weakenPre hlink).sound
+
+/-- Continue the head exit of an N-way branch with a single-exit continuation
+    over disjoint tail code. -/
+def seqHeadDisjoint {entry l l' : Word} {cr1 cr2 : CodeReq}
+    {Q R : Assertion} {others : List (Word × Assertion)}
+    (hd : cr1.Disjoint cr2)
+    (br : NBranch entry cr1)
+    (hexits : br.exits = (l, Q) :: others)
+    (tail : Triple l l' cr2 R)
+    (hlink : Entails Q tail.pre) :
+    NBranch entry (cr1.union cr2) where
+  nSteps := br.nSteps + tail.nSteps
+  pre := br.pre
+  exits := (l', R) :: others
+  sound := by
+    have hbr : cpsNBranchWithin br.nSteps entry cr1 br.pre ((l, Q) :: others) := by
+      simpa [hexits] using br.sound
+    exact cpsNBranchWithin_extend_head_disjoint hd hbr (tail.weakenPre hlink).sound
+
+/-- Continue the head exit of an N-way branch with another N-way continuation
+    over the same code requirement. -/
+def seqHeadNBranch {entry l : Word} {cr : CodeReq}
+    {Q : Assertion} {others : List (Word × Assertion)}
+    (br : NBranch entry cr)
+    (hexits : br.exits = (l, Q) :: others)
+    (tail : NBranch l cr)
+    (hlink : Entails Q tail.pre) :
+    NBranch entry cr where
+  nSteps := br.nSteps + tail.nSteps
+  pre := br.pre
+  exits := tail.exits ++ others
+  sound := by
+    have hbr : cpsNBranchWithin br.nSteps entry cr br.pre ((l, Q) :: others) := by
+      simpa [hexits] using br.sound
+    exact cpsNBranchWithin_extend_head_nbranch hbr (tail.weakenPre hlink).sound
+
+/-- Continue the head exit of an N-way branch with another N-way continuation
+    over disjoint tail code. -/
+def seqHeadNBranchDisjoint {entry l : Word} {cr1 cr2 : CodeReq}
+    {Q : Assertion} {others : List (Word × Assertion)}
+    (hd : cr1.Disjoint cr2)
+    (br : NBranch entry cr1)
+    (hexits : br.exits = (l, Q) :: others)
+    (tail : NBranch l cr2)
+    (hlink : Entails Q tail.pre) :
+    NBranch entry (cr1.union cr2) where
+  nSteps := br.nSteps + tail.nSteps
+  pre := br.pre
+  exits := tail.exits ++ others
+  sound := by
+    have hbr : cpsNBranchWithin br.nSteps entry cr1 br.pre ((l, Q) :: others) := by
+      simpa [hexits] using br.sound
+    exact cpsNBranchWithin_extend_head_nbranch_disjoint hd hbr (tail.weakenPre hlink).sound
+
 /-- Join all exits with a uniform continuation bound. -/
 def join {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     (br : NBranch entry cr) (tailBound : Nat)

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -570,6 +570,36 @@ def join {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
   pre := br.pre
   sound := cpsNBranchWithin_merge br.sound hall
 
+/-- Join exactly four known exits with single-exit continuations. This is the
+    fixed-arity frontend generated CFG proofs use after normalizing an N-branch
+    exit list. -/
+def join4 {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
+    {l1 l2 l3 l4 : Word} {Q1 Q2 Q3 Q4 : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)])
+    (tailBound : Nat)
+    (t1 : Triple l1 exit_ cr post) (t2 : Triple l2 exit_ cr post)
+    (t3 : Triple l3 exit_ cr post) (t4 : Triple l4 exit_ cr post)
+    (hlink1 : Entails Q1 t1.pre) (hlink2 : Entails Q2 t2.pre)
+    (hlink3 : Entails Q3 t3.pre) (hlink4 : Entails Q4 t4.pre)
+    (h1 : t1.nSteps ≤ tailBound) (h2 : t2.nSteps ≤ tailBound)
+    (h3 : t3.nSteps ≤ tailBound) (h4 : t4.nSteps ≤ tailBound) :
+    Triple entry exit_ cr post :=
+  br.join tailBound (by
+    intro ex hmem
+    have hmem' : ex ∈ [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)] := by
+      simpa [hexits] using hmem
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at hmem'
+    rcases hmem' with hcase | hcase | hcase | hcase
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ((t1.weakenPre hlink1).monoSteps h1).sound
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ((t2.weakenPre hlink2).monoSteps h2).sound
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ((t3.weakenPre hlink3).monoSteps h3).sound
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ((t4.weakenPre hlink4).monoSteps h4).sound)
+
 end NBranch
 
 namespace Branch

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -672,6 +672,30 @@ def join2ResolveSecond {entry : Word} {cr : CodeReq} {post : Assertion}
     · rcases hcase with ⟨rfl, rfl⟩
       exact (Triple.refl l2 cr hlink2).sound)
 
+/-- Join exactly three known exits when the second exit is the only reachable one.
+    The first and third exits are closed by contradictory preconditions, and the
+    second exit is treated as the continuation post. -/
+def join3ResolveSecond {entry : Word} {cr : CodeReq} {post : Assertion}
+    {l1 l2 l3 : Word} {Q1 Q2 Q3 : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3)])
+    (hdead1 : ∀ h, Q1 h → False)
+    (hlink2 : Entails Q2 post)
+    (hdead3 : ∀ h, Q3 h → False) :
+    Triple entry l2 cr post :=
+  br.join 0 (by
+    intro ex hmem
+    have hmem' : ex ∈ [(l1, Q1), (l2, Q2), (l3, Q3)] := by
+      simpa [hexits] using hmem
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at hmem'
+    rcases hmem' with hcase | hcase | hcase
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact (Triple.unreachable l1 l2 cr (pre := Q1) (post := post) hdead1).sound
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact (Triple.refl l2 cr hlink2).sound
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact (Triple.unreachable l3 l2 cr (pre := Q3) (post := post) hdead3).sound)
+
 /-- Join exactly four known exits with single-exit continuations. This is the
     fixed-arity frontend generated CFG proofs use after normalizing an N-branch
     exit list. -/

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -101,6 +101,14 @@ def extendCode {entry exit_ : Word} {cr cr' : CodeReq} {post : Assertion}
   pre := t.pre
   sound := cpsTripleWithin_extend_code hmono t.sound
 
+/-- Frame a single-exit WP result with a PC-free assertion. -/
+def frameR {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
+    (t : Triple entry exit_ cr post) (F : Assertion) (hF : F.pcFree) :
+    Triple entry exit_ cr (post ** F) where
+  nSteps := t.nSteps
+  pre := t.pre ** F
+  sound := cpsTripleWithin_frameR F hF t.sound
+
 /-- Rewrite the entry address of a WP result. -/
 def changeEntry {entry entry' exit_ : Word} {cr : CodeReq} {post : Assertion}
     (t : Triple entry exit_ cr post) (hentry : entry' = entry) :

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -465,6 +465,30 @@ def weakenPosts4 {entry : Word} {cr : CodeReq}
     · rcases hcase with ⟨rfl, rfl⟩
       exact ⟨(l4, Q4'), by simp, rfl, h4⟩)
 
+/-- Weaken exactly four known exits while merging the first two exits into one
+    replacement exit. The first two original exits must share the same target. -/
+def weakenPosts4MergeFirstTwo {entry : Word} {cr : CodeReq}
+    {l l3 l4 : Word} {Q1 Q2 Q3 Q4 Q12 Q3' Q4' : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l, Q1), (l, Q2), (l3, Q3), (l4, Q4)])
+    (h1 : Entails Q1 Q12) (h2 : Entails Q2 Q12) (h3 : Entails Q3 Q3')
+    (h4 : Entails Q4 Q4') :
+    NBranch entry cr :=
+  br.weakenPosts [(l, Q12), (l3, Q3'), (l4, Q4')] (by
+    intro ex hmem
+    have hmem' : ex ∈ [(l, Q1), (l, Q2), (l3, Q3), (l4, Q4)] := by
+      simpa [hexits] using hmem
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at hmem'
+    rcases hmem' with hcase | hcase | hcase | hcase
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(l, Q12), by simp, rfl, h1⟩
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(l, Q12), by simp, rfl, h2⟩
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(l3, Q3'), by simp, rfl, h3⟩
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(l4, Q4'), by simp, rfl, h4⟩)
+
 /-- Continue the head exit of an N-way branch with a single-exit continuation
     over the same code requirement. -/
 def seqHead {entry l l' : Word} {cr : CodeReq}

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -336,6 +336,16 @@ def weakenPre {entry : Word} {cr : CodeReq} {pre' : Assertion}
   exits := br.exits
   sound := cpsNBranchWithin_weaken_pre hpre br.sound
 
+/-- Extend an N-way branch to a larger persistent code requirement. -/
+def extendCode {entry : Word} {cr cr' : CodeReq}
+    (br : NBranch entry cr)
+    (hmono : ∀ a i, cr a = some i → cr' a = some i) :
+    NBranch entry cr' where
+  nSteps := br.nSteps
+  pre := br.pre
+  exits := br.exits
+  sound := cpsNBranchWithin_extend_code hmono br.sound
+
 /-- Frame every exit of an N-way branch with a PC-free assertion. -/
 def frameR {entry : Word} {cr : CodeReq}
     (br : NBranch entry cr) (F : Assertion) (hF : F.pcFree) : NBranch entry cr where

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -561,6 +561,32 @@ def seqSecondNBranchDisjoint {entry head l : Word} {cr1 cr2 : CodeReq}
       simpa [hexits] using br.sound
     exact cpsNBranchWithin_extend_second_nbranch_disjoint hd hbr (tail.weakenPre hlink).sound
 
+/-- Continue the third exit of a four-way N-branch with another N-way
+    continuation over disjoint tail code, preserving the other three exits. -/
+def seqThirdNBranchDisjoint {entry l1 l2 l3 l4 : Word} {cr1 cr2 : CodeReq}
+    {Q1 Q2 Q3 Q4 : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : NBranch entry cr1)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)])
+    (tail : NBranch l3 cr2)
+    (hlink : Entails Q3 tail.pre) :
+    NBranch entry (cr1.union cr2) :=
+  br.seqExitNBranchDisjoint
+    (preExits := [(l1, Q1), (l2, Q2)]) (others := [(l4, Q4)])
+    hd (by simpa using hexits) tail hlink
+
+/-- Continue the third exit of a four-way N-branch with a single-exit
+    continuation over disjoint tail code. -/
+def seqThirdCertDisjoint {entry l1 l2 l3 l4 l3' : Word} {cr1 cr2 : CodeReq}
+    {Q1 Q2 Q3 Q4 R : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : NBranch entry cr1)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)])
+    (tail : Triple l3 l3' cr2 R)
+    (hlink : Entails Q3 tail.pre) :
+    NBranch entry (cr1.union cr2) :=
+  br.seqThirdNBranchDisjoint hd hexits (NBranch.ofTriple tail) hlink
+
 /-- Join all exits with a uniform continuation bound. -/
 def join {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     (br : NBranch entry cr) (tailBound : Nat)

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -393,6 +393,24 @@ def seqHeadNBranchDisjoint {entry l : Word} {cr1 cr2 : CodeReq}
       simpa [hexits] using br.sound
     exact cpsNBranchWithin_extend_head_nbranch_disjoint hd hbr (tail.weakenPre hlink).sound
 
+/-- Preserve the first exit of an N-way branch and continue the second exit with
+    another N-way continuation over disjoint tail code. -/
+def seqSecondNBranchDisjoint {entry head l : Word} {cr1 cr2 : CodeReq}
+    {H Q : Assertion} {others : List (Word × Assertion)}
+    (hd : cr1.Disjoint cr2)
+    (br : NBranch entry cr1)
+    (hexits : br.exits = (head, H) :: (l, Q) :: others)
+    (tail : NBranch l cr2)
+    (hlink : Entails Q tail.pre) :
+    NBranch entry (cr1.union cr2) where
+  nSteps := br.nSteps + tail.nSteps
+  pre := br.pre
+  exits := (head, H) :: (tail.exits ++ others)
+  sound := by
+    have hbr : cpsNBranchWithin br.nSteps entry cr1 br.pre ((head, H) :: (l, Q) :: others) := by
+      simpa [hexits] using br.sound
+    exact cpsNBranchWithin_extend_second_nbranch_disjoint hd hbr (tail.weakenPre hlink).sound
+
 /-- Join all exits with a uniform continuation bound. -/
 def join {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     (br : NBranch entry cr) (tailBound : Nat)

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -393,6 +393,24 @@ def seqHeadNBranchDisjoint {entry l : Word} {cr1 cr2 : CodeReq}
       simpa [hexits] using br.sound
     exact cpsNBranchWithin_extend_head_nbranch_disjoint hd hbr (tail.weakenPre hlink).sound
 
+/-- Continue an arbitrary exit of an N-way branch with another N-way continuation
+    over disjoint tail code, preserving the exits before and after it. -/
+def seqExitNBranchDisjoint {entry l : Word} {cr1 cr2 : CodeReq}
+    {Q : Assertion} {preExits others : List (Word × Assertion)}
+    (hd : cr1.Disjoint cr2)
+    (br : NBranch entry cr1)
+    (hexits : br.exits = preExits ++ (l, Q) :: others)
+    (tail : NBranch l cr2)
+    (hlink : Entails Q tail.pre) :
+    NBranch entry (cr1.union cr2) where
+  nSteps := br.nSteps + tail.nSteps
+  pre := br.pre
+  exits := (preExits ++ tail.exits) ++ others
+  sound := by
+    have hbr : cpsNBranchWithin br.nSteps entry cr1 br.pre (preExits ++ (l, Q) :: others) := by
+      simpa [hexits] using br.sound
+    exact cpsNBranchWithin_extend_prefixed_nbranch_disjoint hd hbr (tail.weakenPre hlink).sound
+
 /-- Preserve the first exit of an N-way branch and continue the second exit with
     another N-way continuation over disjoint tail code. -/
 def seqSecondNBranchDisjoint {entry head l : Word} {cr1 cr2 : CodeReq}

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -276,6 +276,18 @@ end NBranch
 
 namespace Branch
 
+/-- Continue the taken exit of a branch and expose the result as a multi-exit
+    branch. This is the endpoint shape for generated decoders: close one failure
+    arm while keeping the fall-through arm open for later CFG construction. -/
+def seqTakenAsNBranchDisjoint {entry target : Word} {cr1 cr2 : CodeReq}
+    {post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : Branch entry cr1)
+    (tail : Triple br.exit_t target cr2 post)
+    (hlink : Entails br.post_t tail.pre) :
+    NBranch entry (cr1.union cr2) :=
+  NBranch.ofBranch (br.seqTakenDisjoint hd tail hlink)
+
 /-- Continue the not-taken exit of a branch with a multi-exit CFG over disjoint
     code. The taken exit is preserved as the first open exit, followed by the
     tail's exits. This is the standard shape for generated decoders that peel

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -255,6 +255,14 @@ def ofSpec {nSteps : Nat} {entry : Word} {cr : CodeReq}
   exits := exits
   sound := h
 
+/-- View a two-exit branch as a multi-exit branch. -/
+def ofBranch {entry : Word} {cr : CodeReq} (br : Branch entry cr) :
+    NBranch entry cr where
+  nSteps := br.nSteps
+  pre := br.pre
+  exits := [(br.exit_t, br.post_t), (br.exit_f, br.post_f)]
+  sound := cpsBranchWithin_as_cpsNBranchWithin br.sound
+
 /-- Join all exits with a uniform continuation bound. -/
 def join {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     (br : NBranch entry cr) (tailBound : Nat)
@@ -265,6 +273,25 @@ def join {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
   sound := cpsNBranchWithin_merge br.sound hall
 
 end NBranch
+
+namespace Branch
+
+/-- Continue the not-taken exit of a branch with a multi-exit CFG over disjoint
+    code. The taken exit is preserved as the first open exit, followed by the
+    tail's exits. This is the standard shape for generated decoders that peel
+    off one failure branch and keep walking the fall-through CFG. -/
+def seqNotTakenNBranchDisjoint {entry : Word} {cr1 cr2 : CodeReq}
+    (hd : cr1.Disjoint cr2)
+    (br : Branch entry cr1)
+    (tail : NBranch br.exit_f cr2)
+    (hlink : Entails br.post_f tail.pre) :
+    NBranch entry (cr1.union cr2) where
+  nSteps := br.nSteps + tail.nSteps
+  pre := br.pre
+  exits := (br.exit_t, br.post_t) :: tail.exits
+  sound := cpsBranchWithin_cons_cpsNBranchWithin_with_perm hd hlink br.sound tail.sound
+
+end Branch
 
 end WP
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -600,6 +600,44 @@ def join4 {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     · rcases hcase with ⟨rfl, rfl⟩
       exact ((t4.weakenPre hlink4).monoSteps h4).sound)
 
+/-- Join exactly four known exits, computing the common continuation bound from
+    the supplied continuation certificates. -/
+def join4Max {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
+    {l1 l2 l3 l4 : Word} {Q1 Q2 Q3 Q4 : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)])
+    (t1 : Triple l1 exit_ cr post) (t2 : Triple l2 exit_ cr post)
+    (t3 : Triple l3 exit_ cr post) (t4 : Triple l4 exit_ cr post)
+    (hlink1 : Entails Q1 t1.pre) (hlink2 : Entails Q2 t2.pre)
+    (hlink3 : Entails Q3 t3.pre) (hlink4 : Entails Q4 t4.pre) :
+    Triple entry exit_ cr post :=
+  br.join4 hexits (Nat.max (Nat.max t1.nSteps t2.nSteps) (Nat.max t3.nSteps t4.nSteps))
+    t1 t2 t3 t4 hlink1 hlink2 hlink3 hlink4
+    (Nat.le_trans (Nat.le_max_left _ _) (Nat.le_max_left _ _))
+    (Nat.le_trans (Nat.le_max_right _ _) (Nat.le_max_left _ _))
+    (Nat.le_trans (Nat.le_max_left _ _) (Nat.le_max_right _ _))
+    (Nat.le_trans (Nat.le_max_right _ _) (Nat.le_max_right _ _))
+
+/-- Join exactly four known exits when the third exit is the only reachable one.
+    The other exits are closed by contradictory preconditions, and the third
+    exit is treated as the continuation post. -/
+def join4ResolveThird {entry : Word} {cr : CodeReq} {post : Assertion}
+    {l1 l2 l3 l4 : Word} {Q1 Q2 Q3 Q4 : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)])
+    (hdead1 : ∀ h, Q1 h → False)
+    (hdead2 : ∀ h, Q2 h → False)
+    (hlink3 : Entails Q3 post)
+    (hdead4 : ∀ h, Q4 h → False) :
+    Triple entry l3 cr post :=
+  br.join4 hexits 0
+    (Triple.unreachable l1 l3 cr (pre := Q1) (post := post) hdead1)
+    (Triple.unreachable l2 l3 cr (pre := Q2) (post := post) hdead2)
+    (Triple.refl l3 cr hlink3)
+    (Triple.unreachable l4 l3 cr (pre := Q4) (post := post) hdead4)
+    (Entails.refl _) (Entails.refl _) (Entails.refl _) (Entails.refl _)
+    (Nat.le_refl _) (Nat.le_refl _) (Nat.le_refl _) (Nat.le_refl _)
+
 end NBranch
 
 namespace Branch

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -293,6 +293,36 @@ def weakenPosts {entry : Word} {cr : CodeReq}
   exits := exits'
   sound := cpsNBranchWithin_weaken_posts br.sound hmap
 
+/-- Weaken the head exit and optionally remap the tail exits of an N-way branch.
+    This avoids rebuilding the low-level membership map when a generated proof
+    consumes exits from left to right. -/
+def weakenPostsCons {entry : Word} {cr : CodeReq}
+    {l : Word} {Q Q' : Assertion} {others others' : List (Word × Assertion)}
+    (br : NBranch entry cr) (hexits : br.exits = (l, Q) :: others)
+    (hhead : Entails Q Q')
+    (htail : ∀ ex ∈ others, ∃ ex' ∈ others',
+      ex'.1 = ex.1 ∧ Entails ex.2 ex'.2) :
+    NBranch entry cr :=
+  br.weakenPosts ((l, Q') :: others') (by
+    intro ex hmem
+    have hmem' : ex ∈ (l, Q) :: others := by
+      simpa [hexits] using hmem
+    cases hmem' with
+    | head =>
+        exact ⟨(l, Q'), by simp, rfl, hhead⟩
+    | tail _ htailmem =>
+        obtain ⟨ex', hmemEx', heq, hent⟩ := htail ex htailmem
+        exact ⟨ex', List.mem_cons_of_mem _ hmemEx', heq, hent⟩)
+
+/-- Weaken only the head exit of an N-way branch, preserving every tail exit. -/
+def weakenHeadPost {entry : Word} {cr : CodeReq}
+    {l : Word} {Q Q' : Assertion} {others : List (Word × Assertion)}
+    (br : NBranch entry cr) (hexits : br.exits = (l, Q) :: others)
+    (hhead : Entails Q Q') :
+    NBranch entry cr :=
+  br.weakenPostsCons hexits hhead (fun ex hmem =>
+    ⟨ex, hmem, rfl, Entails.refl ex.2⟩)
+
 /-- Continue the head exit of an N-way branch with a single-exit continuation
     over the same code requirement. -/
 def seqHead {entry l l' : Word} {cr : CodeReq}

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -630,6 +630,48 @@ def join {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
   pre := br.pre
   sound := cpsNBranchWithin_merge br.sound hall
 
+/-- Join exactly two known exits when the first exit is the only reachable one.
+    The second exit is closed by a contradictory precondition, and the first
+    exit is treated as the continuation post. -/
+def join2ResolveFirst {entry : Word} {cr : CodeReq} {post : Assertion}
+    {l1 l2 : Word} {Q1 Q2 : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2)])
+    (hlink1 : Entails Q1 post)
+    (hdead2 : ∀ h, Q2 h → False) :
+    Triple entry l1 cr post :=
+  br.join 0 (by
+    intro ex hmem
+    have hmem' : ex ∈ [(l1, Q1), (l2, Q2)] := by
+      simpa [hexits] using hmem
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at hmem'
+    rcases hmem' with hcase | hcase
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact (Triple.refl l1 cr hlink1).sound
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact (Triple.unreachable l2 l1 cr (pre := Q2) (post := post) hdead2).sound)
+
+/-- Join exactly two known exits when the second exit is the only reachable one.
+    The first exit is closed by a contradictory precondition, and the second
+    exit is treated as the continuation post. -/
+def join2ResolveSecond {entry : Word} {cr : CodeReq} {post : Assertion}
+    {l1 l2 : Word} {Q1 Q2 : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2)])
+    (hdead1 : ∀ h, Q1 h → False)
+    (hlink2 : Entails Q2 post) :
+    Triple entry l2 cr post :=
+  br.join 0 (by
+    intro ex hmem
+    have hmem' : ex ∈ [(l1, Q1), (l2, Q2)] := by
+      simpa [hexits] using hmem
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at hmem'
+    rcases hmem' with hcase | hcase
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact (Triple.unreachable l1 l2 cr (pre := Q1) (post := post) hdead1).sound
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact (Triple.refl l2 cr hlink2).sound)
+
 /-- Join exactly four known exits with single-exit continuations. This is the
     fixed-arity frontend generated CFG proofs use after normalizing an N-branch
     exit list. -/

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -271,6 +271,28 @@ def weakenPre {entry : Word} {cr : CodeReq} {pre' : Assertion}
   exits := br.exits
   sound := cpsNBranchWithin_weaken_pre hpre br.sound
 
+/-- Frame every exit of an N-way branch with a PC-free assertion. -/
+def frameR {entry : Word} {cr : CodeReq}
+    (br : NBranch entry cr) (F : Assertion) (hF : F.pcFree) : NBranch entry cr where
+  nSteps := br.nSteps
+  pre := br.pre ** F
+  exits := br.exits.map (fun ex => (ex.1, ex.2 ** F))
+  sound := cpsNBranchWithin_frameR hF br.sound
+
+/-- Weaken the postconditions of an N-way branch without changing its step
+    bound or computed precondition. This is the WP-facing form of
+    cpsNBranchWithin_weaken_posts, useful after symbolic control-flow
+    construction has reduced the remaining work to per-exit semantic facts. -/
+def weakenPosts {entry : Word} {cr : CodeReq}
+    (br : NBranch entry cr) (exits' : List (Word × Assertion))
+    (hmap : ∀ ex ∈ br.exits, ∃ ex' ∈ exits',
+      ex'.1 = ex.1 ∧ Entails ex.2 ex'.2) :
+    NBranch entry cr where
+  nSteps := br.nSteps
+  pre := br.pre
+  exits := exits'
+  sound := cpsNBranchWithin_weaken_posts br.sound hmap
+
 /-- Continue the head exit of an N-way branch with a single-exit continuation
     over the same code requirement. -/
 def seqHead {entry l l' : Word} {cr : CodeReq}

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -290,6 +290,22 @@ def ofSpec {nSteps : Nat} {entry : Word} {cr : CodeReq}
   exits := exits
   sound := h
 
+/-- View a single-exit WP triple as a singleton multi-exit branch. -/
+def ofTriple {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
+    (cfg : Triple entry exit_ cr post) :
+    NBranch entry cr :=
+  ofSpec (cpsTripleWithin_as_cpsNBranchWithin cfg.sound)
+
+theorem ofTriple_pre {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
+    (cfg : Triple entry exit_ cr post) :
+    (ofTriple cfg).pre = cfg.pre := by
+  rfl
+
+theorem ofTriple_exits {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
+    (cfg : Triple entry exit_ cr post) :
+    (ofTriple cfg).exits = [(exit_, post)] := by
+  rfl
+
 /-- View a two-exit branch as a multi-exit branch. -/
 def ofBranch {entry : Word} {cr : CodeReq} (br : Branch entry cr) :
     NBranch entry cr where

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -374,6 +374,73 @@ def weakenHeadPost {entry : Word} {cr : CodeReq}
   br.weakenPostsCons hexits hhead (fun ex hmem =>
     ⟨ex, hmem, rfl, Entails.refl ex.2⟩)
 
+/-- Weaken exactly two known exits. This is a small-list frontend for
+    `weakenPosts`, avoiding the recurring membership proof in generated CFG
+    adapters. -/
+def weakenPosts2 {entry : Word} {cr : CodeReq}
+    {l1 l2 : Word} {Q1 Q2 Q1' Q2' : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2)])
+    (h1 : Entails Q1 Q1') (h2 : Entails Q2 Q2') :
+    NBranch entry cr :=
+  br.weakenPosts [(l1, Q1'), (l2, Q2')] (by
+    intro ex hmem
+    have hmem' : ex ∈ [(l1, Q1), (l2, Q2)] := by
+      simpa [hexits] using hmem
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at hmem'
+    rcases hmem' with hcase | hcase
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(l1, Q1'), by simp, rfl, h1⟩
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(l2, Q2'), by simp, rfl, h2⟩)
+
+/-- Weaken exactly three known exits. This is a small-list frontend for
+    `weakenPosts`, avoiding the recurring membership proof in generated CFG
+    adapters. -/
+def weakenPosts3 {entry : Word} {cr : CodeReq}
+    {l1 l2 l3 : Word} {Q1 Q2 Q3 Q1' Q2' Q3' : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3)])
+    (h1 : Entails Q1 Q1') (h2 : Entails Q2 Q2') (h3 : Entails Q3 Q3') :
+    NBranch entry cr :=
+  br.weakenPosts [(l1, Q1'), (l2, Q2'), (l3, Q3')] (by
+    intro ex hmem
+    have hmem' : ex ∈ [(l1, Q1), (l2, Q2), (l3, Q3)] := by
+      simpa [hexits] using hmem
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at hmem'
+    rcases hmem' with hcase | hcase | hcase
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(l1, Q1'), by simp, rfl, h1⟩
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(l2, Q2'), by simp, rfl, h2⟩
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(l3, Q3'), by simp, rfl, h3⟩)
+
+/-- Weaken exactly four known exits. This is the common endpoint for generated
+    decoder classifiers: normalize the calculated exits once, then provide one
+    semantic entailment per arm. -/
+def weakenPosts4 {entry : Word} {cr : CodeReq}
+    {l1 l2 l3 l4 : Word} {Q1 Q2 Q3 Q4 Q1' Q2' Q3' Q4' : Assertion}
+    (br : NBranch entry cr)
+    (hexits : br.exits = [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)])
+    (h1 : Entails Q1 Q1') (h2 : Entails Q2 Q2') (h3 : Entails Q3 Q3')
+    (h4 : Entails Q4 Q4') :
+    NBranch entry cr :=
+  br.weakenPosts [(l1, Q1'), (l2, Q2'), (l3, Q3'), (l4, Q4')] (by
+    intro ex hmem
+    have hmem' : ex ∈ [(l1, Q1), (l2, Q2), (l3, Q3), (l4, Q4)] := by
+      simpa [hexits] using hmem
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at hmem'
+    rcases hmem' with hcase | hcase | hcase | hcase
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(l1, Q1'), by simp, rfl, h1⟩
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(l2, Q2'), by simp, rfl, h2⟩
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(l3, Q3'), by simp, rfl, h3⟩
+    · rcases hcase with ⟨rfl, rfl⟩
+      exact ⟨(l4, Q4'), by simp, rfl, h4⟩)
+
 /-- Continue the head exit of an N-way branch with a single-exit continuation
     over the same code requirement. -/
 def seqHead {entry l l' : Word} {cr : CodeReq}

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -219,6 +219,22 @@ def seqTakenDisjoint {entry target : Word} {cr1 cr2 : CodeReq} {post : Assertion
   post_f := br.post_f
   sound := cpsBranchWithin_seq_cpsTripleWithin_taken hd br.sound (tail.weakenPre hlink).sound
 
+/-- Continue only the not-taken exit of a branch with disjoint code, leaving the
+    taken exit open.  This is the usual shape for fall-through decoder logic. -/
+def seqNotTakenDisjoint {entry target : Word} {cr1 cr2 : CodeReq} {post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : Branch entry cr1)
+    (tail : Triple br.exit_f target cr2 post)
+    (hlink : Entails br.post_f tail.pre) :
+    Branch entry (cr1.union cr2) where
+  nSteps := br.nSteps + tail.nSteps
+  pre := br.pre
+  exit_t := br.exit_t
+  post_t := br.post_t
+  exit_f := target
+  post_f := post
+  sound := cpsBranchWithin_seq_cpsTripleWithin_notTaken hd br.sound (tail.weakenPre hlink).sound
+
 end Branch
 
 /-- A multi-exit branch summary. -/

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -235,6 +235,33 @@ def seqNotTakenDisjoint {entry target : Word} {cr1 cr2 : CodeReq} {post : Assert
   post_f := post
   sound := cpsBranchWithin_seq_cpsTripleWithin_notTaken hd br.sound (tail.weakenPre hlink).sound
 
+/-- Continue the taken exit with another branch whose taken exit converges with
+    the first branch fall exit as one shared failure case. The second branch fall
+    exit becomes the success exit of the composed branch. -/
+def seqTakenBranchConvergeDisjoint {entry : Word} {cr1 cr2 : CodeReq}
+    {failPost : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : Branch entry cr1)
+    (tail : Branch br.exit_t cr2)
+    (hfail : tail.exit_t = br.exit_f)
+    (hlink : Entails br.post_t tail.pre)
+    (hf1 : Entails br.post_f failPost)
+    (hf2 : Entails tail.post_t failPost) :
+    Branch entry (cr1.union cr2) where
+  nSteps := br.nSteps + tail.nSteps
+  pre := br.pre
+  exit_t := tail.exit_f
+  post_t := tail.post_f
+  exit_f := br.exit_f
+  post_f := failPost
+  sound := by
+    have htail : cpsBranchWithin tail.nSteps br.exit_t cr2 tail.pre
+        br.exit_f tail.post_t tail.exit_f tail.post_f := by
+      simpa [hfail] using tail.sound
+    exact cpsBranchWithin_seq_cpsBranchWithin_taken_converge hd br.sound
+      (cpsBranchWithin_weaken hlink (fun _ hp => hp) (fun _ hp => hp) htail)
+      hf1 hf2
+
 end Branch
 
 /-- A multi-exit branch summary. -/

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -174,6 +174,17 @@ def ofSpec {nSteps : Nat} {entry : Word} {cr : CodeReq}
   post_f := post_f
   sound := h
 
+/-- Frame both exits of a branch with a PC-free assertion. -/
+def frameR {entry : Word} {cr : CodeReq}
+    (br : Branch entry cr) (F : Assertion) (hF : F.pcFree) : Branch entry cr where
+  nSteps := br.nSteps
+  pre := br.pre ** F
+  exit_t := br.exit_t
+  post_t := br.post_t ** F
+  exit_f := br.exit_f
+  post_f := br.post_f ** F
+  sound := cpsBranchWithin_frameR F hF br.sound
+
 /-- Join a branch by providing a continuation for each exit.  The branch's
     posts only need to entail the corresponding continuation preconditions. -/
 def join {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
@@ -190,6 +201,23 @@ def join {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
       (cpsBranchWithin_weaken (fun _ hp => hp) ht hf br.sound)
       (cpsTripleWithin_mono_nSteps (Nat.le_max_left t.nSteps f.nSteps) t.sound)
       (cpsTripleWithin_mono_nSteps (Nat.le_max_right t.nSteps f.nSteps) f.sound)
+
+/-- Continue only the taken exit of a branch with disjoint code, leaving the
+    not-taken exit open.  This is useful for early failure/success endpoints in
+    generated CFGs. -/
+def seqTakenDisjoint {entry target : Word} {cr1 cr2 : CodeReq} {post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : Branch entry cr1)
+    (tail : Triple br.exit_t target cr2 post)
+    (hlink : Entails br.post_t tail.pre) :
+    Branch entry (cr1.union cr2) where
+  nSteps := br.nSteps + tail.nSteps
+  pre := br.pre
+  exit_t := target
+  post_t := post
+  exit_f := br.exit_f
+  post_f := br.post_f
+  sound := cpsBranchWithin_seq_cpsTripleWithin_taken hd br.sound (tail.weakenPre hlink).sound
 
 end Branch
 


### PR DESCRIPTION
## Summary
- add a WP direct-call combinator plus a root-level CPSCall compatibility wrapper for #9522-style call proofs
- add WP sequencing tactics for xperm-backed midpoint entailments
- add an RLP withdrawal decode WP facade whose static schema only describes field layout, while the postcondition characterizes decodeWithdrawal success and failure

## Verification
- lake build
- scripts/check-unimported.sh
- scripts/check-file-size.sh --report
- scripts/check-no-warnings.sh
- scripts/check-forbidden-tactics.sh

## Notes
- #9533 is merged, so this PR targets main.
- The withdrawal schema intentionally does not contain the decoded result; decoded values appear only in the result postcondition.