### PR TITLE
refactor(sdiv/smod): factor duplicated two's-complement ripple-negation (#266)

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DispatchPrefix.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DispatchPrefix.lean
@@ -51,7 +51,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_dispatchReady_spec_in_sdivCode
     rw [saveRaDivCallDispatchReadyPost_unfold]
     dsimp only at hq ⊢
     rw [divModStackDispatchPreNoX1_unfold_explicit_sdiv]
-    simp [sdivAbsDividendWord, sdivAbsDivisorWord, EvmWord.getLimbN,
+    simp [sdivAbsDividendWord, sdivAbsDivisorWord, rippleNegWord, EvmWord.getLimbN,
       EvmWord.getLimb_fromLimbs] at hq ⊢
     xperm_hyp hq) hPrefix
 
@@ -150,7 +150,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_dispatchReady_spec_in_sdivCodeV4
     rw [saveRaDivCallDispatchReadyPost_unfold]
     dsimp only at hq ⊢
     rw [divModStackDispatchPreNoX1_unfold_explicit_sdiv]
-    simp [sdivAbsDividendWord, sdivAbsDivisorWord, EvmWord.getLimbN,
+    simp [sdivAbsDividendWord, sdivAbsDivisorWord, rippleNegWord, EvmWord.getLimbN,
       EvmWord.getLimb_fromLimbs] at hq ⊢
     xperm_hyp hq) hPrefix
 

--- a/EvmAsm/Evm64/SDiv/Compose/DispatchViews.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DispatchViews.lean
@@ -30,7 +30,7 @@ theorem resultSignFixPost_evmWordIs
         (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
         evmWordIs sp (sdivSignFixedWord sign limb0 limb1 limb2 limb3))) := by
   rw [resultSignFixPost_unfold]
-  dsimp only [sdivSignFixedWord]
+  dsimp only [sdivSignFixedWord, rippleNegWord]
   let mask := (0 : Word) - sign
   let sum0 := (limb0 ^^^ mask) + sign
   let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0

--- a/EvmAsm/Evm64/SDiv/Compose/ResultSignFixZeroWordView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/ResultSignFixZeroWordView.lean
@@ -33,7 +33,7 @@ theorem resultSignFixPost_sdivResultSign_word
         (sdivResultSignFixedWord dividendTop divisorTop limb0 limb1 limb2 limb3)) := by
   dsimp only
   rw [resultSignFixPost_unfold, evmWordIs_sp_unfold]
-  unfold sdivResultSignFixedWord
+  unfold sdivResultSignFixedWord rippleNegWord
   dsimp only
   simp only [EvmAsm.Rv64.signExtend12_0, EvmAsm.Rv64.signExtend12_8,
     EvmAsm.Rv64.signExtend12_16, EvmAsm.Rv64.signExtend12_24,

--- a/EvmAsm/Evm64/SDiv/Compose/Words.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Words.lean
@@ -12,56 +12,17 @@ namespace EvmAsm.Evm64.SDiv.Compose
 
 open EvmAsm.Rv64.BitAux
 
-/-- Absolute-value word produced by the SDIV dividend sign/absolute-value
-    prefix, packaged as a named expression so downstream callable-composition
-    proofs do not duplicate the expanded `fromLimbs` term. -/
-def sdivAbsDividendWord
-    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop : Word) : EvmWord :=
-  let dividendSign := dividendTop >>> (63 : BitVec 6).toNat
-  let dividendMask := (0 : Word) - dividendSign
-  let dividendSum0 := (dividendLimb0 ^^^ dividendMask) + dividendSign
-  let dividendCarry0 :=
-    if BitVec.ult dividendSum0 dividendSign then (1 : Word) else 0
-  let dividendSum1 := (dividendLimb1 ^^^ dividendMask) + dividendCarry0
-  let dividendCarry1 :=
-    if BitVec.ult dividendSum1 dividendCarry0 then (1 : Word) else 0
-  let dividendSum2 := (dividendLimb2 ^^^ dividendMask) + dividendCarry1
-  let dividendCarry2 :=
-    if BitVec.ult dividendSum2 dividendCarry1 then (1 : Word) else 0
-  let dividendSum3 := (dividendTop ^^^ dividendMask) + dividendCarry2
-  EvmWord.fromLimbs fun i : Fin 4 =>
-    match i with
-    | 0 => dividendSum0 | 1 => dividendSum1 | 2 => dividendSum2 | 3 => dividendSum3
-
-/-- Absolute-value word produced by the SDIV divisor sign/absolute-value
-    prefix, paired with `sdivAbsDividendWord` for downstream composition
-    statements that consume `divModStackDispatchPre`. -/
-def sdivAbsDivisorWord
-    (divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : EvmWord :=
-  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
-  let divisorMask := (0 : Word) - divisorSign
-  let divisorSum0 := (divisorLimb0 ^^^ divisorMask) + divisorSign
-  let divisorCarry0 := if BitVec.ult divisorSum0 divisorSign then (1 : Word) else 0
-  let divisorSum1 := (divisorLimb1 ^^^ divisorMask) + divisorCarry0
-  let divisorCarry1 := if BitVec.ult divisorSum1 divisorCarry0 then (1 : Word) else 0
-  let divisorSum2 := (divisorLimb2 ^^^ divisorMask) + divisorCarry1
-  let divisorCarry2 := if BitVec.ult divisorSum2 divisorCarry1 then (1 : Word) else 0
-  let divisorSum3 := (divisorTop ^^^ divisorMask) + divisorCarry2
-  EvmWord.fromLimbs fun i : Fin 4 =>
-    match i with
-    | 0 => divisorSum0 | 1 => divisorSum1 | 2 => divisorSum2 | 3 => divisorSum3
-
-/-- Word produced by conditionally negating the unsigned quotient limbs by the
-    SDIV result sign. This names the memory-result word of the result-sign
-    fixup block before connecting it to the semantic `EvmWord.sdiv` result. -/
-def sdivResultSignFixedWord
-    (dividendTop divisorTop limb0 limb1 limb2 limb3 : Word) : EvmWord :=
-  let resultSign :=
-    (dividendTop >>> (63 : BitVec 6).toNat) ^^^
-      (divisorTop >>> (63 : BitVec 6).toNat)
-  let mask := (0 : Word) - resultSign
-  let sum0 := (limb0 ^^^ mask) + resultSign
-  let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
+/-- Conditional four-limb two's-complement negation by a Boolean `sign` word.
+    `mask = 0 - sign` is `0` when `sign = 0` and all-ones when `sign = 1`, so a
+    ripple-carry chain over `(limbᵢ ^^^ mask) + carryᵢ₋₁` (seeded with `sign`)
+    yields the source word when `sign = 0` and its two's-complement negation when
+    `sign = 1`. This is the shared kernel of every SDIV/SMOD sign/absolute-value
+    and result-sign-fixup block; the per-operand defs below are thin
+    specializations that only differ in how `sign` is computed. -/
+def rippleNegWord (limb0 limb1 limb2 limb3 sign : Word) : EvmWord :=
+  let mask := (0 : Word) - sign
+  let sum0 := (limb0 ^^^ mask) + sign
+  let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
   let sum1 := (limb1 ^^^ mask) + carry0
   let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
   let sum2 := (limb2 ^^^ mask) + carry1
@@ -70,6 +31,87 @@ def sdivResultSignFixedWord
   EvmWord.fromLimbs fun i : Fin 4 =>
     match i with
     | 0 => sum0 | 1 => sum1 | 2 => sum2 | 3 => sum3
+
+/-- Helper: `-v = ~~~v + 1` (two's complement for EvmWord). -/
+private theorem evmWord_neg_eq_not_add (v : EvmWord) : -v = ~~~v + 1 := by bv_omega
+
+/-- With `sign = 0` the ripple-negation is the identity: it returns the source
+    word assembled from the four limbs. -/
+theorem rippleNegWord_of_sign_zero
+    (limb0 limb1 limb2 limb3 sign : Word) (hSign : sign = 0) :
+    rippleNegWord limb0 limb1 limb2 limb3 sign =
+      EvmWord.fromLimbs fun i : Fin 4 =>
+        match i with
+        | 0 => limb0 | 1 => limb1 | 2 => limb2 | 3 => limb3 := by
+  subst hSign
+  unfold rippleNegWord
+  simp (config := { zeta := true }) only
+    [show (0 : Word) - 0 = 0 from rfl, ult_zero_false, word_xor_zero, word_add_zero,
+     word_if_false_eq_zero]
+
+/-- With `sign = 1` the ripple-negation computes the two's-complement negation of
+    the word assembled from the four limbs. This is the single proof shared by
+    every SDIV/SMOD `…_eq_neg_word_of_sign_one` wrapper. -/
+theorem rippleNegWord_of_sign_one
+    (limb0 limb1 limb2 limb3 sign : Word) (hSign : sign = 1) :
+    rippleNegWord limb0 limb1 limb2 limb3 sign =
+      -(EvmWord.fromLimbs fun i : Fin 4 =>
+          match i with
+          | 0 => limb0 | 1 => limb1 | 2 => limb2 | 3 => limb3) := by
+  set v := EvmWord.fromLimbs (fun i : Fin 4 =>
+    match i with | 0 => limb0 | 1 => limb1 | 2 => limb2 | 3 => limb3) with hv
+  have hv0 : v.getLimb 0 = limb0 := by rw [hv]; exact EvmWord.getLimb_fromLimbs
+  have hv1 : v.getLimb 1 = limb1 := by rw [hv]; exact EvmWord.getLimb_fromLimbs
+  have hv2 : v.getLimb 2 = limb2 := by rw [hv]; exact EvmWord.getLimb_fromLimbs
+  have hv3 : v.getLimb 3 = limb3 := by rw [hv]; exact EvmWord.getLimb_fromLimbs
+  have h1_0 : (1 : EvmWord).getLimb 0 = 1 := by decide
+  have h1_1 : (1 : EvmWord).getLimb 1 = 0 := by decide
+  have h1_2 : (1 : EvmWord).getLimb 2 = 0 := by decide
+  have h1_3 : (1 : EvmWord).getLimb 3 = 0 := by decide
+  have hNot : ∀ i : Fin 4, (~~~v).getLimb i = ~~~(v.getLimb i) :=
+    fun _ => EvmWord.getLimb_not
+  have hadd := EvmWord.add_carry_chain_correct (~~~v) 1
+  simp (config := { zeta := true }) only [hNot, h1_0, h1_1, h1_2, h1_3] at hadd
+  simp (config := { zeta := true }) only [ult_zero_false, word_if_false_eq_zero] at hadd
+  -- Rewrite the carry chain in terms of the raw limbs (not `v.getLimb _`).
+  simp only [hv0, hv1, hv2, hv3] at hadd
+  subst hSign
+  unfold rippleNegWord
+  simp (config := { zeta := true }) only [word_zero_sub_one, word_xor_allOnes]
+  rw [evmWord_neg_eq_not_add, ← EvmWord.fromLimbs_getLimb (~~~v + 1)]
+  apply EvmWord.eq_iff_limbs.mpr; intro ⟨i, hi⟩
+  rw [EvmWord.getLimb_fromLimbs, EvmWord.getLimb_fromLimbs]
+  rcases i with _ | _ | _ | _ | j <;> [skip; skip; skip; skip; omega]
+  all_goals dsimp only []
+  · exact hadd.1.symm
+  · have h := hadd.2.1; simp [BitVec.add_zero] at h; exact h.symm
+  · have h := hadd.2.2.1; simp [BitVec.add_zero] at h; exact h.symm
+  · have h := hadd.2.2.2; simp [BitVec.add_zero] at h; exact h.symm
+
+/-- Absolute-value word produced by the SDIV dividend sign/absolute-value
+    prefix, packaged as a named expression so downstream callable-composition
+    proofs do not duplicate the expanded `fromLimbs` term. -/
+def sdivAbsDividendWord
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop : Word) : EvmWord :=
+  rippleNegWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+    (dividendTop >>> (63 : BitVec 6).toNat)
+
+/-- Absolute-value word produced by the SDIV divisor sign/absolute-value
+    prefix, paired with `sdivAbsDividendWord` for downstream composition
+    statements that consume `divModStackDispatchPre`. -/
+def sdivAbsDivisorWord
+    (divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : EvmWord :=
+  rippleNegWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+    (divisorTop >>> (63 : BitVec 6).toNat)
+
+/-- Word produced by conditionally negating the unsigned quotient limbs by the
+    SDIV result sign. This names the memory-result word of the result-sign
+    fixup block before connecting it to the semantic `EvmWord.sdiv` result. -/
+def sdivResultSignFixedWord
+    (dividendTop divisorTop limb0 limb1 limb2 limb3 : Word) : EvmWord :=
+  rippleNegWord limb0 limb1 limb2 limb3
+    ((dividendTop >>> (63 : BitVec 6).toNat) ^^^
+      (divisorTop >>> (63 : BitVec 6).toNat))
 
 /-- The SDIV result sign is the XOR of two top-bit extractions, hence it is a
     Boolean word. This keeps later result-sign-fix zero-quotient rewrites from
@@ -185,11 +227,8 @@ theorem sdivAbsDividendWord_of_sign_zero
       EvmWord.fromLimbs fun i : Fin 4 =>
         match i with
         | 0 => limb0 | 1 => limb1 | 2 => limb2 | 3 => top := by
-  simp only [bv6_63_toNat] at hSign
   unfold sdivAbsDividendWord
-  simp (config := { zeta := true }) only
-    [bv6_63_toNat, hSign, show (0 : Word) - 0 = 0 from rfl, ult_zero_false, word_xor_zero,
-     word_add_zero, word_if_false_eq_zero]
+  exact rippleNegWord_of_sign_zero _ _ _ _ _ hSign
 
 /-- Four concrete `getLimbN` projections assemble back to their source word. -/
 theorem sdivWord_from_getLimbN (v : EvmWord) :
@@ -215,9 +254,6 @@ theorem sdivAbsDividendWord_eq_word_of_sign_zero
   rw [sdivAbsDividendWord_of_sign_zero _ _ _ _ hSign]
   exact sdivWord_from_getLimbN dividend
 
-/-- Helper: `-v = ~~~v + 1` (two's complement for EvmWord). -/
-private theorem evmWord_neg_eq_not_add (v : EvmWord) : -v = ~~~v + 1 := by bv_omega
-
 /-- If the dividend sign bit is one, the SDIV absolute-value helper returns the
     two's-complement negation of the dividend word. -/
 theorem sdivAbsDividendWord_eq_neg_word_of_sign_one
@@ -225,49 +261,8 @@ theorem sdivAbsDividendWord_eq_neg_word_of_sign_one
     (hSign : dividend.getLimbN 3 >>> (63 : BitVec 6).toNat = (1 : Word)) :
     sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
       (dividend.getLimbN 2) (dividend.getLimbN 3) = -dividend := by
-  -- getLimbN k = getLimb k for k < 4
-  have hl0 : dividend.getLimbN 0 = dividend.getLimb 0 :=
-    (EvmWord.getLimbN_lt dividend 0 (by omega)).symm
-  have hl1 : dividend.getLimbN 1 = dividend.getLimb 1 :=
-    (EvmWord.getLimbN_lt dividend 1 (by omega)).symm
-  have hl2 : dividend.getLimbN 2 = dividend.getLimb 2 :=
-    (EvmWord.getLimbN_lt dividend 2 (by omega)).symm
-  have hl3 : dividend.getLimbN 3 = dividend.getLimb 3 :=
-    (EvmWord.getLimbN_lt dividend 3 (by omega)).symm
-  -- getLimb of (1 : EvmWord)
-  have h1_0 : (1 : EvmWord).getLimb 0 = 1 := by decide
-  have h1_1 : (1 : EvmWord).getLimb 1 = 0 := by decide
-  have h1_2 : (1 : EvmWord).getLimb 2 = 0 := by decide
-  have h1_3 : (1 : EvmWord).getLimb 3 = 0 := by decide
-  -- getLimb of ~~~dividend = ~~~(getLimb dividend)
-  have hNot : ∀ i : Fin 4, (~~~dividend).getLimb i = ~~~(dividend.getLimb i) :=
-    fun _ => EvmWord.getLimb_not
-  -- Add carry chain for (~~~dividend) + 1; b0=1, b1=b2=b3=0
-  have hadd := EvmWord.add_carry_chain_correct (~~~dividend) 1
-  -- Zeta-reduce the let bindings and substitute concrete limb values
-  -- hadd gives carry chain for (~~~dividend + 1)
-  -- Simplify hadd: substitute limbs, simplify + 0 and ult x 0 = false
-  simp (config := { zeta := true }) only [hNot, h1_0, h1_1, h1_2, h1_3] at hadd
-  -- Extra pass to clean up + 0 and carry_a = 0 terms
-  simp (config := { zeta := true }) only [ult_zero_false, word_if_false_eq_zero] at hadd
-  -- hadd now says (~~~dividend+1).getLimb k = <sdiv-sum-k> for k=0,1,2,3
-  -- Unfold sdivAbsDividendWord; substitute sign=1 → mask=allOnes; NOT the limbs
-  simp only [bv6_63_toNat] at hSign
-  -- Derive sign=1 in getLimb form for use after unfolding
-  have hSignL : dividend.getLimb 3 >>> 63 = 1 := hl3 ▸ hSign
   unfold sdivAbsDividendWord
-  simp (config := { zeta := true }) only [bv6_63_toNat, hSignL, word_zero_sub_one,
-    hl0, hl1, hl2, hl3, word_xor_allOnes]
-  -- Goal: fromLimbs (fun i => match i with | 0 => S0 | ... | 3 => S3) = -dividend
-  rw [evmWord_neg_eq_not_add, ← EvmWord.fromLimbs_getLimb (~~~dividend + 1)]
-  apply EvmWord.eq_iff_limbs.mpr; intro ⟨i, hi⟩
-  rw [EvmWord.getLimb_fromLimbs, EvmWord.getLimb_fromLimbs]
-  rcases i with _ | _ | _ | _ | j <;> [skip; skip; skip; skip; omega]
-  all_goals dsimp only []
-  · exact hadd.1.symm
-  · have h := hadd.2.1; simp [BitVec.add_zero] at h; exact h.symm
-  · have h := hadd.2.2.1; simp [BitVec.add_zero] at h; exact h.symm
-  · have h := hadd.2.2.2; simp [BitVec.add_zero] at h; exact h.symm
+  rw [rippleNegWord_of_sign_one _ _ _ _ _ hSign, sdivWord_from_getLimbN]
 
 /-- If the divisor sign bit is zero, the divisor absolute-value word is just the
     original four-limb word. -/
@@ -278,11 +273,8 @@ theorem sdivAbsDivisorWord_of_sign_zero
       EvmWord.fromLimbs fun i : Fin 4 =>
         match i with
         | 0 => limb0 | 1 => limb1 | 2 => limb2 | 3 => top := by
-  simp only [bv6_63_toNat] at hSign
   unfold sdivAbsDivisorWord
-  simp (config := { zeta := true }) only
-    [bv6_63_toNat, hSign, show (0 : Word) - 0 = 0 from rfl, ult_zero_false, word_xor_zero,
-     word_add_zero, word_if_false_eq_zero]
+  exact rippleNegWord_of_sign_zero _ _ _ _ _ hSign
 
 /-- Word-shaped variant of `sdivAbsDivisorWord_of_sign_zero`: if the divisor
     sign bit is zero, the SDIV absolute-value helper returns the divisor word. -/
@@ -301,40 +293,8 @@ theorem sdivAbsDivisorWord_eq_neg_word_of_sign_one
     (hSign : divisor.getLimbN 3 >>> (63 : BitVec 6).toNat = (1 : Word)) :
     sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
       (divisor.getLimbN 2) (divisor.getLimbN 3) = -divisor := by
-  have hl0 : divisor.getLimbN 0 = divisor.getLimb 0 :=
-    (EvmWord.getLimbN_lt divisor 0 (by omega)).symm
-  have hl1 : divisor.getLimbN 1 = divisor.getLimb 1 :=
-    (EvmWord.getLimbN_lt divisor 1 (by omega)).symm
-  have hl2 : divisor.getLimbN 2 = divisor.getLimb 2 :=
-    (EvmWord.getLimbN_lt divisor 2 (by omega)).symm
-  have hl3 : divisor.getLimbN 3 = divisor.getLimb 3 :=
-    (EvmWord.getLimbN_lt divisor 3 (by omega)).symm
-  have h1_0 : (1 : EvmWord).getLimb 0 = 1 := by decide
-  have h1_1 : (1 : EvmWord).getLimb 1 = 0 := by decide
-  have h1_2 : (1 : EvmWord).getLimb 2 = 0 := by decide
-  have h1_3 : (1 : EvmWord).getLimb 3 = 0 := by decide
-  have hNot : ∀ i : Fin 4, (~~~divisor).getLimb i = ~~~(divisor.getLimb i) :=
-    fun _ => EvmWord.getLimb_not
-  have hadd := EvmWord.add_carry_chain_correct (~~~divisor) 1
-  -- hadd gives carry chain for (~~~dividend + 1)
-  -- Simplify hadd: substitute limbs, simplify + 0 and ult x 0 = false
-  simp (config := { zeta := true }) only [hNot, h1_0, h1_1, h1_2, h1_3] at hadd
-  -- Extra pass to clean up + 0 and carry_a = 0 terms
-  simp (config := { zeta := true }) only [ult_zero_false, word_if_false_eq_zero] at hadd
-  simp only [bv6_63_toNat] at hSign
-  have hSignL : divisor.getLimb 3 >>> 63 = 1 := hl3 ▸ hSign
   unfold sdivAbsDivisorWord
-  simp (config := { zeta := true }) only [bv6_63_toNat, hSignL, word_zero_sub_one,
-    hl0, hl1, hl2, hl3, word_xor_allOnes]
-  rw [evmWord_neg_eq_not_add, ← EvmWord.fromLimbs_getLimb (~~~divisor + 1)]
-  apply EvmWord.eq_iff_limbs.mpr; intro ⟨i, hi⟩
-  rw [EvmWord.getLimb_fromLimbs, EvmWord.getLimb_fromLimbs]
-  rcases i with _ | _ | _ | _ | j <;> [skip; skip; skip; skip; omega]
-  all_goals dsimp only []
-  · exact hadd.1.symm
-  · have h := hadd.2.1; simp [BitVec.add_zero] at h; exact h.symm
-  · have h := hadd.2.2.1; simp [BitVec.add_zero] at h; exact h.symm
-  · have h := hadd.2.2.2; simp [BitVec.add_zero] at h; exact h.symm
+  rw [rippleNegWord_of_sign_one _ _ _ _ _ hSign, sdivWord_from_getLimbN]
 
 /-- If the SDIV result sign is zero, the result-sign-fix word is just the
     unsigned quotient word assembled from its four limbs. -/
@@ -347,11 +307,8 @@ theorem sdivResultSignFixedWord_of_result_sign_zero
       EvmWord.fromLimbs fun i : Fin 4 =>
         match i with
         | 0 => limb0 | 1 => limb1 | 2 => limb2 | 3 => limb3 := by
-  simp only [bv6_63_toNat] at hSign
   unfold sdivResultSignFixedWord
-  simp (config := { zeta := true }) only
-    [bv6_63_toNat, hSign, show (0 : Word) - 0 = 0 from rfl, ult_zero_false, word_xor_zero,
-     word_add_zero, word_if_false_eq_zero]
+  exact rippleNegWord_of_sign_zero _ _ _ _ _ hSign
 
 /-- Word-shaped variant of `sdivResultSignFixedWord_of_result_sign_zero`: if
     the result sign is zero, the result-sign-fix helper leaves the quotient word
@@ -377,39 +334,8 @@ theorem sdivResultSignFixedWord_eq_neg_word_of_result_sign_one
     sdivResultSignFixedWord dividendTop divisorTop
       (quotient.getLimbN 0) (quotient.getLimbN 1)
       (quotient.getLimbN 2) (quotient.getLimbN 3) = -quotient := by
-  have hl0 : quotient.getLimbN 0 = quotient.getLimb 0 :=
-    (EvmWord.getLimbN_lt quotient 0 (by omega)).symm
-  have hl1 : quotient.getLimbN 1 = quotient.getLimb 1 :=
-    (EvmWord.getLimbN_lt quotient 1 (by omega)).symm
-  have hl2 : quotient.getLimbN 2 = quotient.getLimb 2 :=
-    (EvmWord.getLimbN_lt quotient 2 (by omega)).symm
-  have hl3 : quotient.getLimbN 3 = quotient.getLimb 3 :=
-    (EvmWord.getLimbN_lt quotient 3 (by omega)).symm
-  have h1_0 : (1 : EvmWord).getLimb 0 = 1 := by decide
-  have h1_1 : (1 : EvmWord).getLimb 1 = 0 := by decide
-  have h1_2 : (1 : EvmWord).getLimb 2 = 0 := by decide
-  have h1_3 : (1 : EvmWord).getLimb 3 = 0 := by decide
-  have hNot : ∀ i : Fin 4, (~~~quotient).getLimb i = ~~~(quotient.getLimb i) :=
-    fun _ => EvmWord.getLimb_not
-  have hadd := EvmWord.add_carry_chain_correct (~~~quotient) 1
-  -- hadd gives carry chain for (~~~dividend + 1)
-  -- Simplify hadd: substitute limbs, simplify + 0 and ult x 0 = false
-  simp (config := { zeta := true }) only [hNot, h1_0, h1_1, h1_2, h1_3] at hadd
-  -- Extra pass to clean up + 0 and carry_a = 0 terms
-  simp (config := { zeta := true }) only [ult_zero_false, word_if_false_eq_zero] at hadd
-  simp only [bv6_63_toNat] at hSign
   unfold sdivResultSignFixedWord
-  simp (config := { zeta := true }) only [bv6_63_toNat, hSign, word_zero_sub_one,
-    hl0, hl1, hl2, hl3, word_xor_allOnes]
-  rw [evmWord_neg_eq_not_add, ← EvmWord.fromLimbs_getLimb (~~~quotient + 1)]
-  apply EvmWord.eq_iff_limbs.mpr; intro ⟨i, hi⟩
-  rw [EvmWord.getLimb_fromLimbs, EvmWord.getLimb_fromLimbs]
-  rcases i with _ | _ | _ | _ | j <;> [skip; skip; skip; skip; omega]
-  all_goals dsimp only []
-  · exact hadd.1.symm
-  · have h := hadd.2.1; simp [BitVec.add_zero] at h; exact h.symm
-  · have h := hadd.2.2.1; simp [BitVec.add_zero] at h; exact h.symm
-  · have h := hadd.2.2.2; simp [BitVec.add_zero] at h; exact h.symm
+  rw [rippleNegWord_of_sign_one _ _ _ _ _ hSign, sdivWord_from_getLimbN]
 
 /-- The SDIV divisor absolute-value word is zero when all divisor limbs are
     zero. This discharges the internal bzero-branch hypothesis for the
@@ -708,17 +634,7 @@ theorem sdivAbsDividendWord_limb_sign_split
     stack-level views can fold the four memory atoms into one `evmWordIs`. -/
 def sdivSignFixedWord
     (sign limb0 limb1 limb2 limb3 : Word) : EvmWord :=
-  let mask := (0 : Word) - sign
-  let sum0 := (limb0 ^^^ mask) + sign
-  let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
-  let sum1 := (limb1 ^^^ mask) + carry0
-  let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
-  let sum2 := (limb2 ^^^ mask) + carry1
-  let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
-  let sum3 := (limb3 ^^^ mask) + carry2
-  EvmWord.fromLimbs fun i : Fin 4 =>
-    match i with
-    | 0 => sum0 | 1 => sum1 | 2 => sum2 | 3 => sum3
+  rippleNegWord limb0 limb1 limb2 limb3 sign
 
 /-- If the SDIV result sign is zero, result-sign fixup leaves the quotient
     word unchanged. -/
@@ -727,10 +643,7 @@ theorem sdivSignFixedWord_zero_sign (word : EvmWord) :
       (word.getLimbN 0) (word.getLimbN 1) (word.getLimbN 2) (word.getLimbN 3) =
       word := by
   unfold sdivSignFixedWord
-  simp (config := { zeta := true }) only
-    [show (0 : Word) - 0 = 0 from rfl, ult_zero_false, word_xor_zero, word_add_zero,
-     word_if_false_eq_zero]
-  exact sdivWord_from_getLimbN word
+  rw [rippleNegWord_of_sign_zero _ _ _ _ _ rfl, sdivWord_from_getLimbN]
 
 /-- Conditional result-sign fixup maps a zero quotient to the zero word. -/
 theorem sdivSignFixedWord_zero_quotient
@@ -751,41 +664,9 @@ theorem sdivSignFixedWord_one_sign (word : EvmWord) :
     sdivSignFixedWord 1
       (word.getLimbN 0) (word.getLimbN 1) (word.getLimbN 2) (word.getLimbN 3) =
       ~~~word + 1 := by
-  -- sdivSignFixedWord 1 ... is identical to sdivResultSignFixedWord with resultSign=1
-  -- Use sdivResultSignFixedWord_eq_neg_word_of_result_sign_one + evmWord_neg_eq_not_add
-  -- But sdivSignFixedWord takes (sign, l0, l1, l2, l3) instead of (dTop, vTop, l0..l3)
-  -- They have the same carry chain; use the direct add_carry_chain approach
-  have hl0 : word.getLimbN 0 = word.getLimb 0 :=
-    (EvmWord.getLimbN_lt word 0 (by omega)).symm
-  have hl1 : word.getLimbN 1 = word.getLimb 1 :=
-    (EvmWord.getLimbN_lt word 1 (by omega)).symm
-  have hl2 : word.getLimbN 2 = word.getLimb 2 :=
-    (EvmWord.getLimbN_lt word 2 (by omega)).symm
-  have hl3 : word.getLimbN 3 = word.getLimb 3 :=
-    (EvmWord.getLimbN_lt word 3 (by omega)).symm
-  have h1_0 : (1 : EvmWord).getLimb 0 = 1 := by decide
-  have h1_1 : (1 : EvmWord).getLimb 1 = 0 := by decide
-  have h1_2 : (1 : EvmWord).getLimb 2 = 0 := by decide
-  have h1_3 : (1 : EvmWord).getLimb 3 = 0 := by decide
-  have hNot : ∀ i : Fin 4, (~~~word).getLimb i = ~~~(word.getLimb i) :=
-    fun _ => EvmWord.getLimb_not
-  have hadd := EvmWord.add_carry_chain_correct (~~~word) 1
-  -- hadd gives carry chain for (~~~dividend + 1)
-  -- Simplify hadd: substitute limbs, simplify + 0 and ult x 0 = false
-  simp (config := { zeta := true }) only [hNot, h1_0, h1_1, h1_2, h1_3] at hadd
-  -- Extra pass to clean up + 0 and carry_a = 0 terms
-  simp (config := { zeta := true }) only [ult_zero_false, word_if_false_eq_zero] at hadd
   unfold sdivSignFixedWord
-  simp (config := { zeta := true }) only [word_zero_sub_one, hl0, hl1, hl2, hl3, word_xor_allOnes]
-  rw [← EvmWord.fromLimbs_getLimb (~~~word + 1)]
-  apply EvmWord.eq_iff_limbs.mpr; intro ⟨i, hi⟩
-  rw [EvmWord.getLimb_fromLimbs, EvmWord.getLimb_fromLimbs]
-  rcases i with _ | _ | _ | _ | j <;> [skip; skip; skip; skip; omega]
-  all_goals dsimp only []
-  · exact hadd.1.symm
-  · have h := hadd.2.1; simp [BitVec.add_zero] at h; exact h.symm
-  · have h := hadd.2.2.1; simp [BitVec.add_zero] at h; exact h.symm
-  · have h := hadd.2.2.2; simp [BitVec.add_zero] at h; exact h.symm
+  rw [rippleNegWord_of_sign_one _ _ _ _ _ rfl, sdivWord_from_getLimbN,
+    evmWord_neg_eq_not_add]
 
 /-- Boolean result signs reduce result-sign fixup to either the original
     quotient word or its explicit two's-complement negation. -/

--- a/EvmAsm/Evm64/SMod/Compose/ResultSignFixView.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ResultSignFixView.lean
@@ -30,7 +30,7 @@ theorem smodResultSignFixPost_smodResultSign_word
        evmWordIs sp (smodResultSignFixedWord dividendTop limb0 limb1 limb2 limb3)) := by
   dsimp only
   rw [smodResultSignFixPost_unfold, evmWordIs_sp_unfold]
-  unfold smodResultSignFixedWord
+  unfold smodResultSignFixedWord EvmAsm.Evm64.SDiv.Compose.rippleNegWord
   dsimp only
   simp only [EvmAsm.Rv64.signExtend12_0, EvmAsm.Rv64.signExtend12_8,
     EvmAsm.Rv64.signExtend12_16, EvmAsm.Rv64.signExtend12_24,

--- a/EvmAsm/Evm64/SMod/Compose/Words.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Words.lean
@@ -10,8 +10,6 @@ namespace EvmAsm.Evm64.SMod.Compose
 
 open EvmAsm.Rv64.BitAux
 
-private theorem evmWord_neg_eq_not_add (v : EvmWord) : -v = ~~~v + 1 := by bv_omega
-
 /-- Absolute-value word produced by the SMOD dividend sign/absolute-value
     prefix. The computation matches SDIV; SMOD differs only in the final result
     sign, which follows the dividend sign. -/
@@ -31,18 +29,8 @@ def smodAbsDivisorWord
     SMOD result sign. For SMOD, the result sign is the dividend sign bit. -/
 def smodResultSignFixedWord
     (dividendTop limb0 limb1 limb2 limb3 : Word) : EvmWord :=
-  let resultSign := dividendTop >>> (63 : BitVec 6).toNat
-  let mask := (0 : Word) - resultSign
-  let sum0 := (limb0 ^^^ mask) + resultSign
-  let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
-  let sum1 := (limb1 ^^^ mask) + carry0
-  let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
-  let sum2 := (limb2 ^^^ mask) + carry1
-  let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
-  let sum3 := (limb3 ^^^ mask) + carry2
-  EvmWord.fromLimbs fun i : Fin 4 =>
-    match i with
-    | 0 => sum0 | 1 => sum1 | 2 => sum2 | 3 => sum3
+  EvmAsm.Evm64.SDiv.Compose.rippleNegWord limb0 limb1 limb2 limb3
+    (dividendTop >>> (63 : BitVec 6).toNat)
 
 /-- The SMOD result sign is the dividend top bit, hence it is a Boolean word. -/
 theorem smodResultSign_bool (dividendTop : Word) :
@@ -168,12 +156,9 @@ theorem smodResultSignFixedWord_eq_word_of_result_sign_zero
     smodResultSignFixedWord dividendTop
       (modulus.getLimbN 0) (modulus.getLimbN 1)
       (modulus.getLimbN 2) (modulus.getLimbN 3) = modulus := by
-  simp only [bv6_63_toNat] at hSign
   unfold smodResultSignFixedWord
-  simp (config := { zeta := true }) only
-    [bv6_63_toNat, hSign, show (0 : Word) - 0 = 0 from rfl, ult_zero_false, word_xor_zero,
-     word_add_zero, word_if_false_eq_zero]
-  exact EvmAsm.Evm64.SDiv.Compose.sdivWord_from_getLimbN modulus
+  rw [EvmAsm.Evm64.SDiv.Compose.rippleNegWord_of_sign_zero _ _ _ _ _ hSign,
+    EvmAsm.Evm64.SDiv.Compose.sdivWord_from_getLimbN]
 
 /-- If the SMOD result sign is one, the result-sign-fix helper returns the
     two's-complement negation of the unsigned modulo word. -/
@@ -183,37 +168,9 @@ theorem smodResultSignFixedWord_eq_neg_word_of_result_sign_one
     smodResultSignFixedWord dividendTop
       (modulus.getLimbN 0) (modulus.getLimbN 1)
       (modulus.getLimbN 2) (modulus.getLimbN 3) = -modulus := by
-  have hl0 : modulus.getLimbN 0 = modulus.getLimb 0 :=
-    (EvmWord.getLimbN_lt modulus 0 (by omega)).symm
-  have hl1 : modulus.getLimbN 1 = modulus.getLimb 1 :=
-    (EvmWord.getLimbN_lt modulus 1 (by omega)).symm
-  have hl2 : modulus.getLimbN 2 = modulus.getLimb 2 :=
-    (EvmWord.getLimbN_lt modulus 2 (by omega)).symm
-  have hl3 : modulus.getLimbN 3 = modulus.getLimb 3 :=
-    (EvmWord.getLimbN_lt modulus 3 (by omega)).symm
-  have h1_0 : (1 : EvmWord).getLimb 0 = 1 := by decide
-  have h1_1 : (1 : EvmWord).getLimb 1 = 0 := by decide
-  have h1_2 : (1 : EvmWord).getLimb 2 = 0 := by decide
-  have h1_3 : (1 : EvmWord).getLimb 3 = 0 := by decide
-  have hNot : ∀ i : Fin 4, (~~~modulus).getLimb i = ~~~(modulus.getLimb i) :=
-    fun _ => EvmWord.getLimb_not
-  have hadd := EvmWord.add_carry_chain_correct (~~~modulus) 1
-  simp (config := { zeta := true }) only [hNot, h1_0, h1_1, h1_2, h1_3] at hadd
-  simp (config := { zeta := true }) only [ult_zero_false, word_if_false_eq_zero] at hadd
-  simp only [bv6_63_toNat] at hSign
-  have hSignL : dividendTop >>> 63 = 1 := hSign
   unfold smodResultSignFixedWord
-  simp (config := { zeta := true }) only [bv6_63_toNat, hSignL, word_zero_sub_one,
-    hl0, hl1, hl2, hl3, word_xor_allOnes]
-  rw [evmWord_neg_eq_not_add, ← EvmWord.fromLimbs_getLimb (~~~modulus + 1)]
-  apply EvmWord.eq_iff_limbs.mpr; intro ⟨i, hi⟩
-  rw [EvmWord.getLimb_fromLimbs, EvmWord.getLimb_fromLimbs]
-  rcases i with _ | _ | _ | _ | j <;> [skip; skip; skip; skip; omega]
-  all_goals dsimp only []
-  · exact hadd.1.symm
-  · have h := hadd.2.1; simp [BitVec.add_zero] at h; exact h.symm
-  · have h := hadd.2.2.1; simp [BitVec.add_zero] at h; exact h.symm
-  · have h := hadd.2.2.2; simp [BitVec.add_zero] at h; exact h.symm
+  rw [EvmAsm.Evm64.SDiv.Compose.rippleNegWord_of_sign_one _ _ _ _ _ hSign,
+    EvmAsm.Evm64.SDiv.Compose.sdivWord_from_getLimbN]
 
 /-- The SMOD dividend absolute-value word is zero exactly for the zero
     dividend. -/

--- a/PLAN.md
+++ b/PLAN.md
@@ -440,11 +440,16 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
     two `@[grind →]`) that dedup the inline JALR-mask (`&&& ~~~1` / `&&& 1 = 0`)
     parity proofs; `Exp/AddrNorm.addrAligned` and the two `SDiv/Compose/Base`
     mask lemmas now delegate to them.
-  - **Deferred:** factoring the 4 near-identical multi-limb two's-complement
-    `…AbsWord …= -v` proofs (`SDiv`/`SMod` `Compose/Words.lean`) into one shared
-    lemma is blocked by their 4 separate underlying definitions — a clean DRY
-    needs unifying those defs into a shared `rippleNegWord` function (a larger
-    refactor; the 4 proofs are correct/kernel-checkable as-is).
+  - **DONE (PR #9536, issue #266):** the near-identical multi-limb
+    two's-complement `…= -v` proofs in `SDiv`/`SMod` `Compose/Words.lean` are now
+    factored behind one shared `rippleNegWord limb0 limb1 limb2 limb3 sign` kernel
+    + two generic lemmas (`rippleNegWord_of_sign_{one,zero}`). The five concrete
+    defs (`sdivAbsDividendWord`, `sdivAbsDivisorWord`, `sdivResultSignFixedWord`,
+    `sdivSignFixedWord`, `smodResultSignFixedWord`) became thin `rippleNegWord`
+    applications and the per-operand proofs collapsed to 2-line wrappers (net
+    −162 lines; def names/statements unchanged so name-level consumers were
+    untouched; axiom footprint unchanged). The DIV/MOD main-loop dedup half of
+    #266 remains a separate, larger `DivMod/LoopBody*` refactor.
 - **Execution Layer specs** (`EvmAsm/EL/`): Pure Lean specs for Ethereum
   data structures, independent of RISC-V. Currently:
   - `EL/RLP/` — RLP encoding/decoding with round-trip proofs (`decide`)


### PR DESCRIPTION
## What

The SDIV/SMOD sign/absolute-value and result-sign-fixup blocks each compute a 4-limb two's-complement negation via the *same* ripple-carry chain (`mask = 0 - sign`; `sumᵢ = (limbᵢ ^^^ mask) + carryᵢ₋₁`; `fromLimbs`). This was written out as **five** separate defs whose `= -v` / `= word` correctness proofs were copied **character-for-character** — the ~45-line `add_carry_chain_correct` ritual, repeated.

This PR introduces a single shared kernel and collapses the duplication:

- **`rippleNegWord limb0 limb1 limb2 limb3 sign`** — the shared conditional-negation def (`sign = 1` ⇒ two's-complement negate, `sign = 0` ⇒ identity).
- **`rippleNegWord_of_sign_one`** (`= -(fromLimbs …)`) and **`rippleNegWord_of_sign_zero`** (`= fromLimbs …`) — the two generic lemmas, each proved once.
- The five concrete defs (`sdivAbsDividendWord`, `sdivAbsDivisorWord`, `sdivResultSignFixedWord`, `sdivSignFixedWord`, `smodResultSignFixedWord`) become thin `rippleNegWord` applications differing only in how `sign` is computed.
- Every per-operand `…_eq_neg_word_of_sign_one` / `…_of_sign_zero` proof collapses to a 2-line wrapper (`unfold` → generic lemma → `sdivWord_from_getLimbN`).

## Scope / safety

- **Public def names and theorem statements are unchanged.** The new bodies are *definitionally equal* to the old ones, so the ~45 name-level consumers across `SDiv/`/`SMod/` compile untouched. Only the few sites that unfold a def *by its body* needed `rippleNegWord` added to their `unfold`/`simp` set (`DispatchPrefix`, `DispatchViews`, `ResultSignFixZeroWordView`, `ResultSignFixView`).
- **Net −162 lines** (266 deletions / 104 insertions).

## Verification

- Full `lake build` green (3541 jobs).
- Axiom footprint unchanged: the new lemmas + representative wrappers depend only on `propext` / `Classical.choice` / `Quot.sound` (verified via `#print axioms`).
- `scripts/check-forbidden-tactics.sh` OK — no `bv_decide`/`native_decide`.

## Out of scope

Issue #266 also gestures at factoring the **DIV/MOD main-loop** proof — that's a separate, larger `DivMod/LoopBody*` refactor and is left for follow-up. This PR closes the two's-complement ripple-negation half that `PLAN.md` had flagged as deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)