### PR TITLE
feat(wp): add exact composition helpers

### DIFF
--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -150,7 +150,12 @@ elab "wp_rv64_entails" : tactic => withMainContext do
     catch _ =>
       restoreState saved
       continue
-  throwError "wp_rv64_entails: no @[rv64_wp_entails] theorem closed the goal"
+  let goalType ← instantiateMVars (← goal.getType)
+  throwError m!"wp_rv64_entails: no @[rv64_wp_entails] theorem closed the goal.
+  Tried {entries.size} registered theorem(s).
+  Goal: {goalType}
+  Hint: add a small @[rv64_wp_entails] lemma, or expose the assertion shape
+  with `simp only [rv64_wp]`."
 
 /-- Try declarations tagged with `@[rv64_wp_dead]` against the current
     unreachable-exit goal.  Tagged lemmas may have explicit proof arguments;
@@ -178,7 +183,12 @@ elab "wp_rv64_dead_hint" : tactic => withMainContext do
       catch _ =>
         restoreState saved
         continue
-  throwError "wp_rv64_dead_hint: no @[rv64_wp_dead] theorem closed the goal"
+  let goalType ← instantiateMVars (← goal.getType)
+  throwError m!"wp_rv64_dead_hint: no @[rv64_wp_dead] theorem closed the goal.
+  Tried {entries.size} registered theorem(s).
+  Goal: {goalType}
+  Hint: add a contradiction lemma tagged @[rv64_wp_dead], or pass the
+  unreachable proof directly to WP.CFG.unreachable."
 
 /-- Close an unreachable-exit goal, after exposing small WP definitions if
     needed, using declarations tagged with `@[rv64_wp_dead]`. -/
@@ -216,7 +226,11 @@ elab "wp_rv64_cert" : tactic => withMainContext do
     catch _ =>
       restoreState saved
       continue
-  throwError "wp_rv64_cert: no @[rv64_wp_cert] declaration closed the goal"
+  throwError m!"wp_rv64_cert: no @[rv64_wp_cert] declaration closed the goal.
+  Tried {entries.size} registered declaration(s).
+  Goal: {goalType}
+  Hint: try the intended constructor directly once to expose missing static
+  facts, or tag a reusable constructor with @[rv64_wp_cert]."
 
 /-- Close the midpoint entailment between adjacent WP fragments.  The common
     case is definitional equality of the head postcondition and tail WP; semantic
@@ -262,7 +276,12 @@ private def closeDisjointWithHint (goal : MVarId) : TacticM Unit := do
     catch _ =>
       restoreState saved
       continue
-  throwError "wp_rv64_disjoint: no @[rv64_wp_disjoint] theorem closed the goal"
+  let goalType ← instantiateMVars (← goal.getType)
+  throwError m!"wp_rv64_disjoint: no @[rv64_wp_disjoint] theorem closed the goal.
+  Tried {entries.size} registered theorem(s).
+  Goal: {goalType}
+  Hint: add a local disjointness hypothesis or tag a semantic disjointness
+  lemma with @[rv64_wp_disjoint]."
 
 /-- Close a `CodeReq.Disjoint` goal using local hypotheses, declarations
     tagged with `@[rv64_wp_disjoint]`, or the structural prover shared with
@@ -284,9 +303,82 @@ elab "wp_rv64_disjoint" : tactic => withMainContext do
     restoreState savedHint
     let cr1 := goalType.getAppArgs[0]!
     let cr2 := goalType.getAppArgs[1]!
-    let proof ← withTransparency .all <| buildDisjointProof cr1 cr2
-    (← getMainGoal).assign proof
-    replaceMainGoal []
+    try
+      let proof ← withTransparency .all <| buildDisjointProof cr1 cr2
+      (← getMainGoal).assign proof
+      replaceMainGoal []
+    catch e =>
+      throwError m!"wp_rv64_disjoint: no local hypothesis, registered hint, or
+  structural proof closed the goal.
+  Goal: {goalType}
+  Hint: add a local disjointness hypothesis, or tag a semantic disjointness
+  lemma with @[rv64_wp_disjoint].
+  Structural prover error: {← e.toMessageData.toString}"
+
+/-- Lift a leaf CPS proof whose postcondition already matches the CFG
+    postcondition. -/
+syntax (name := wpRv64LeafTac) "wp_rv64_leaf " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_leaf $h:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.leaf $h)
+
+/-- Build an empty CFG at a join point with identical pre/post assertion. -/
+syntax (name := wpRv64ExitReflTac)
+  "wp_rv64_exit_refl " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_exit_refl $addr:term, $cr:term, $post:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.exitRefl $addr $cr $post)
+
+/-- Build a CFG certificate from a head CPS proof and tail certificate when the
+    head postcondition is definitionally the tail precondition. -/
+syntax (name := wpRv64CfgSeqExactTac)
+  "wp_rv64_cfg_seq_exact " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_cfg_seq_exact $head:term, $tail:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.seqExact $tail $head)
+
+/-- Disjoint-code version of `wp_rv64_cfg_seq_exact`. -/
+syntax (name := wpRv64CfgSeqDisjointExactTac)
+  "wp_rv64_cfg_seq_disjoint_exact " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_cfg_seq_disjoint_exact $hd:term, $head:term, $tail:term) =>
+      `(tactic| exact EvmAsm.Rv64.WP.CFG.seqDisjointExact $hd $tail $head)
+
+/-- Close a CPS goal from exact head/tail CFG sequencing. -/
+syntax (name := wpRv64SeqExactTac) "wp_rv64_seq_exact " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_seq_exact $head:term, $tail:term) =>
+      `(tactic| exact (EvmAsm.Rv64.WP.CFG.seqExact $tail $head).sound)
+
+/-- Disjoint-code version of `wp_rv64_seq_exact`. -/
+syntax (name := wpRv64SeqDisjointExactTac)
+  "wp_rv64_seq_disjoint_exact " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_seq_disjoint_exact $hd:term, $head:term, $tail:term) =>
+      `(tactic| exact (EvmAsm.Rv64.WP.CFG.seqDisjointExact $hd $tail $head).sound)
+
+/-- Close a CPS goal from two adjacent same-code CPS blocks with exact
+    midpoint. -/
+syntax (name := wpRv64SeqBlockExactTac)
+  "wp_rv64_seq_block_exact " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_seq_block_exact $head:term, $tail:term) =>
+      `(tactic| exact (EvmAsm.Rv64.WP.CFG.seqBlockExact $head $tail).sound)
+
+/-- Disjoint-code version of `wp_rv64_seq_block_exact`. -/
+syntax (name := wpRv64SeqBlockDisjointExactTac)
+  "wp_rv64_seq_block_disjoint_exact " term ", " term ", " term : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_seq_block_disjoint_exact $hd:term, $head:term, $tail:term) =>
+      `(tactic| exact (EvmAsm.Rv64.WP.CFG.seqBlockDisjointExact $hd $head $tail).sound)
 
 /-- Frame a single-exit CFG certificate and return the framed certificate. -/
 syntax (name := wpRv64FrameRTac) "wp_rv64_frame " term ", " term ", " term : tactic
@@ -1091,6 +1183,15 @@ example {entry exit_ : Word} {cr : CodeReq} {pre post : Assertion}
     EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post := by
   wp_rv64_unreachable entry, exit_, cr, hpre
 
+example {nSteps : Nat} {entry exit_ : Word} {cr : CodeReq} {pre post : Assertion}
+    (h : cpsTripleWithin nSteps entry exit_ cr pre post) :
+    EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post := by
+  wp_rv64_leaf h
+
+example {entry : Word} {cr : CodeReq} {post : Assertion} :
+    EvmAsm.Rv64.WP.CFG.Cert entry entry cr post := by
+  wp_rv64_exit_refl entry, cr, post
+
 example {P : Assertion} {A : Prop} (hA : A) :
     EvmAsm.Rv64.WP.Entails P (P ** ⌜A⌝) := by
   wp_rv64_link
@@ -1112,12 +1213,41 @@ example {nSteps : Nat} {entry mid exit_ : Word} {cr : CodeReq}
     cpsTripleWithin (nSteps + tail.nSteps) entry exit_ cr pre post := by
   wp_rv64_seq head, tail
 
+example {nSteps : Nat} {entry mid exit_ : Word} {cr : CodeReq}
+    {pre post : Assertion}
+    (tail : EvmAsm.Rv64.WP.CFG.Cert mid exit_ cr post)
+    (head : cpsTripleWithin nSteps entry mid cr pre tail.pre) :
+    EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post := by
+  wp_rv64_cfg_seq_exact head, tail
+
+example {nSteps : Nat} {entry mid exit_ : Word} {cr : CodeReq}
+    {pre post : Assertion}
+    (tail : EvmAsm.Rv64.WP.CFG.Cert mid exit_ cr post)
+    (head : cpsTripleWithin nSteps entry mid cr pre tail.pre) :
+    cpsTripleWithin (nSteps + tail.nSteps) entry exit_ cr pre post := by
+  wp_rv64_seq_exact head, tail
+
+example {nSteps : Nat} {entry mid exit_ : Word} {cr1 cr2 : CodeReq}
+    {pre post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (tail : EvmAsm.Rv64.WP.CFG.Cert mid exit_ cr2 post)
+    (head : cpsTripleWithin nSteps entry mid cr1 pre tail.pre) :
+    cpsTripleWithin (nSteps + tail.nSteps) entry exit_ (cr1.union cr2) pre post := by
+  wp_rv64_seq_disjoint_exact hd, head, tail
+
 example {nHead nTail : Nat} {entry mid exit_ : Word} {cr : CodeReq}
     {pre midPost post : Assertion}
     (head : cpsTripleWithin nHead entry mid cr pre midPost)
     (tail : cpsTripleWithin nTail mid exit_ cr midPost post) :
     cpsTripleWithin (nHead + nTail) entry exit_ cr pre post := by
   wp_rv64_seq_block head, tail
+
+example {nHead nTail : Nat} {entry mid exit_ : Word} {cr : CodeReq}
+    {pre midPost post : Assertion}
+    (head : cpsTripleWithin nHead entry mid cr pre midPost)
+    (tail : cpsTripleWithin nTail mid exit_ cr midPost post) :
+    cpsTripleWithin (nHead + nTail) entry exit_ cr pre post := by
+  wp_rv64_seq_block_exact head, tail
 
 example {nHead nTail : Nat} {entry mid exit_ : Word} {cr1 cr2 : CodeReq}
     {pre midPost post : Assertion}
@@ -1126,6 +1256,14 @@ example {nHead nTail : Nat} {entry mid exit_ : Word} {cr1 cr2 : CodeReq}
     (tail : cpsTripleWithin nTail mid exit_ cr2 midPost post) :
     cpsTripleWithin (nHead + nTail) entry exit_ (cr1.union cr2) pre post := by
   wp_rv64_seq_block_disjoint hd, head, tail
+
+example {nHead nTail : Nat} {entry mid exit_ : Word} {cr1 cr2 : CodeReq}
+    {pre midPost post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (head : cpsTripleWithin nHead entry mid cr1 pre midPost)
+    (tail : cpsTripleWithin nTail mid exit_ cr2 midPost post) :
+    cpsTripleWithin (nHead + nTail) entry exit_ (cr1.union cr2) pre post := by
+  wp_rv64_seq_block_disjoint_exact hd, head, tail
 
 example {nHead : Nat} {entry mid : Word} {cr1 cr2 : CodeReq}
     {pre midPost : Assertion}

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -26,6 +26,12 @@ def exit (addr : Word) (cr : CodeReq) {pre post : Assertion}
     (h : Entails pre post) : Cert addr addr cr post :=
   Triple.refl addr cr h
 
+/-- Empty CFG at a join point when the precondition already is the
+    postcondition. -/
+def exitRefl (addr : Word) (cr : CodeReq) (post : Assertion) :
+    Cert addr addr cr post :=
+  exit addr cr (Entails.refl post)
+
 /-- A CFG certificate for an unreachable precondition. -/
 def unreachable (entry exit_ : Word) (cr : CodeReq) {pre post : Assertion}
     (hpre : ∀ h, pre h → False) : Cert entry exit_ cr post :=
@@ -38,6 +44,14 @@ def block {nSteps : Nat} {entry exit_ : Word} {cr : CodeReq}
     (h : cpsTripleWithin nSteps entry exit_ cr pre post) :
     Cert entry exit_ cr post' :=
   Triple.ofSpec hpost h
+
+/-- A leaf block whose CPS postcondition already matches the
+    certificate postcondition. -/
+def leaf {nSteps : Nat} {entry exit_ : Word} {cr : CodeReq}
+    {pre post : Assertion}
+    (h : cpsTripleWithin nSteps entry exit_ cr pre post) :
+    Cert entry exit_ cr post :=
+  block (Entails.refl _) h
 
 /-- Frame a single-exit CFG certificate with a PC-free assertion. -/
 def frameR {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
@@ -81,6 +95,18 @@ def changeExit {entry exit_ exit_' : Word} {cr : CodeReq} {post : Assertion}
     (cfg : Cert entry exit_ cr post) (hexit : exit_ = exit_') :
     Cert entry exit_' cr post :=
   cfg.changeExit hexit
+
+/-- `exitRefl` exposes exactly the supplied postcondition as its precondition. -/
+theorem exitRefl_pre (addr : Word) (cr : CodeReq) (post : Assertion) :
+    (exitRefl addr cr post).pre = post :=
+  rfl
+
+/-- `leaf` exposes exactly the source precondition of the CPS proof. -/
+theorem leaf_pre {nSteps : Nat} {entry exit_ : Word} {cr : CodeReq}
+    {pre post : Assertion}
+    (h : cpsTripleWithin nSteps entry exit_ cr pre post) :
+    (leaf h).pre = pre :=
+  rfl
 
 /-- `weakenPre` exposes exactly the supplied precondition. -/
 theorem weakenPre_pre {entry exit_ : Word} {cr : CodeReq} {post pre' : Assertion}
@@ -139,6 +165,15 @@ def seq {nSteps : Nat} {entry mid exit_ : Word} {cr : CodeReq}
     Cert entry exit_ cr post :=
   Triple.seq head tail hlink
 
+/-- Sequential composition when the head postcondition is exactly the
+    tail precondition. -/
+def seqExact {nSteps : Nat} {entry mid exit_ : Word} {cr : CodeReq}
+    {pre post : Assertion}
+    (tail : Cert mid exit_ cr post)
+    (head : cpsTripleWithin nSteps entry mid cr pre tail.pre) :
+    Cert entry exit_ cr post :=
+  seq head tail (Entails.refl _)
+
 /-- Sequential composition for disjoint code requirements. -/
 def seqDisjoint {nSteps : Nat} {entry mid exit_ : Word} {cr1 cr2 : CodeReq}
     {pre midPost post : Assertion}
@@ -149,6 +184,16 @@ def seqDisjoint {nSteps : Nat} {entry mid exit_ : Word} {cr1 cr2 : CodeReq}
     Cert entry exit_ (cr1.union cr2) post :=
   Triple.seqDisjoint hd head tail hlink
 
+/-- Disjoint-code sequencing when the head postcondition is exactly the
+    tail precondition. -/
+def seqDisjointExact {nSteps : Nat} {entry mid exit_ : Word} {cr1 cr2 : CodeReq}
+    {pre post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (tail : Cert mid exit_ cr2 post)
+    (head : cpsTripleWithin nSteps entry mid cr1 pre tail.pre) :
+    Cert entry exit_ (cr1.union cr2) post :=
+  seqDisjoint hd head tail (Entails.refl _)
+
 /-- Sequential composition where both adjacent regions are already available as
     CPS triples over one shared persistent code requirement. -/
 def seqBlock {nHead nTail : Nat} {entry mid exit_ : Word} {cr : CodeReq}
@@ -157,7 +202,16 @@ def seqBlock {nHead nTail : Nat} {entry mid exit_ : Word} {cr : CodeReq}
     (tail : cpsTripleWithin nTail mid exit_ cr tailPre post)
     (hlink : Entails midPost tailPre) :
     Cert entry exit_ cr post :=
-  seq head (block (Entails.refl _) tail) hlink
+  seq head (leaf tail) hlink
+
+/-- Same-code block sequencing when the first postcondition exactly
+    matches the second precondition. -/
+def seqBlockExact {nHead nTail : Nat} {entry mid exit_ : Word} {cr : CodeReq}
+    {pre midPost post : Assertion}
+    (head : cpsTripleWithin nHead entry mid cr pre midPost)
+    (tail : cpsTripleWithin nTail mid exit_ cr midPost post) :
+    Cert entry exit_ cr post :=
+  seqBlock head tail (Entails.refl _)
 
 /-- Sequential composition where both adjacent regions are already available as
     CPS triples over disjoint code requirements. -/
@@ -168,7 +222,17 @@ def seqBlockDisjoint {nHead nTail : Nat} {entry mid exit_ : Word} {cr1 cr2 : Cod
     (tail : cpsTripleWithin nTail mid exit_ cr2 tailPre post)
     (hlink : Entails midPost tailPre) :
     Cert entry exit_ (cr1.union cr2) post :=
-  seqDisjoint hd head (block (Entails.refl _) tail) hlink
+  seqDisjoint hd head (leaf tail) hlink
+
+/-- Disjoint-code block sequencing when the first postcondition exactly
+    matches the second precondition. -/
+def seqBlockDisjointExact {nHead nTail : Nat} {entry mid exit_ : Word} {cr1 cr2 : CodeReq}
+    {pre midPost post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (head : cpsTripleWithin nHead entry mid cr1 pre midPost)
+    (tail : cpsTripleWithin nTail mid exit_ cr2 midPost post) :
+    Cert entry exit_ (cr1.union cr2) post :=
+  seqBlockDisjoint hd head tail (Entails.refl _)
 
 /-- Sequential composition from a CPS block into an N-way CFG over disjoint code. -/
 def seqBlockNBranchDisjoint {nHead : Nat} {entry mid : Word} {cr1 cr2 : CodeReq}

--- a/EvmAsm/Rv64/WP/Examples.lean
+++ b/EvmAsm/Rv64/WP/Examples.lean
@@ -25,11 +25,20 @@ def addiTwiceCfg (base v : Word) (imm1 imm2 : BitVec 12) :
   exact CFG.seqDisjoint
     (CodeReq.Disjoint.singleton (by bv_omega))
     head
-    (CFG.block (Entails.refl _) tailSpec)
+    (CFG.leaf tailSpec)
     (Entails.refl _)
 
 example (base v : Word) (imm1 imm2 : BitVec 12) :
     (addiTwiceCfg base v imm1 imm2).pre = (.x5 ↦ᵣ v) := rfl
+
+/-- Exact sequencing removes the midpoint entailment when the head postcondition
+    is definitionally the generated tail precondition. -/
+example {nSteps : Nat} {entry mid exit_ : Word} {cr : CodeReq}
+    {pre post : Assertion}
+    (tail : CFG.Cert mid exit_ cr post)
+    (head : cpsTripleWithin nSteps entry mid cr pre tail.pre) :
+    CFG.Cert entry exit_ cr post :=
+  CFG.seqExact tail head
 
 example (base v : Word) (imm1 imm2 : BitVec 12) :
     cpsTripleWithin 2 base ((base + 4) + 4)

--- a/TACTICS.md
+++ b/TACTICS.md
@@ -18,7 +18,8 @@ User guide for the frame automation tactics in `EvmAsm/Tactics/`.
 The WP/CFG tactics are documented in
 [`docs/agents/wp-framework.md`](docs/agents/wp-framework.md). Start there when
 a proof should derive the precondition from a program, postcondition, and known
-control-flow shape.
+control-flow shape. Common exact-midpoint helpers include `wp_rv64_leaf`,
+`wp_rv64_seq_exact`, and `wp_rv64_seq_block_exact`.
 
 **For closing arithmetic / address equality goals**, see the grindsets
 documented in [`GRIND.md`](GRIND.md):

--- a/docs/agents/wp-framework.md
+++ b/docs/agents/wp-framework.md
@@ -72,7 +72,9 @@ theorem spec :
 
 3. Lift leaves into WP certificates.
 
-   Use `WP.CFG.block` for a single-exit CPS proof:
+   Use `WP.CFG.leaf` when the CPS postcondition already matches the
+   certificate postcondition. Use `WP.CFG.block hpost` when the leaf needs a
+   final postcondition weakening.
 
    ```lean
    have hBlock :
@@ -80,7 +82,7 @@ theorem spec :
      runBlock
 
    let blockCfg : WP.CFG.Cert entry exit_ cr blockPost :=
-     WP.CFG.block (WP.Entails.refl _) hBlock
+     WP.CFG.leaf hBlock
    ```
 
 4. Compose certificates backwards.
@@ -114,8 +116,10 @@ theorem spec :
 
 | Need | Constructor or tactic |
 |------|-----------------------|
-| Lift an existing single-exit CPS proof | `WP.CFG.block (WP.Entails.refl _) h` |
-| Empty/reflexive exit certificate | `WP.CFG.exit` |
+| Lift an exact single-exit CPS proof | `WP.CFG.leaf h`, `wp_rv64_leaf h` |
+| Lift and weaken a CPS proof's postcondition | `WP.CFG.block hpost h` |
+| Empty/reflexive exit certificate | `WP.CFG.exitRefl`, `wp_rv64_exit_refl` |
+| Empty exit with postcondition weakening | `WP.CFG.exit` |
 | Impossible path | `WP.CFG.unreachable` |
 | Add a separation-logic frame | `WP.CFG.frameR` |
 | Weaken the generated precondition | `WP.CFG.weakenPre`, `wp_rv64_weaken_pre` |
@@ -124,8 +128,11 @@ theorem spec :
 | Enlarge the code requirement | `WP.CFG.extendCode`, `wp_rv64_extend_code` |
 | Change entry or exit addresses by equality | `WP.CFG.changeEntry`, `WP.CFG.changeExit` |
 | Compose a head CPS proof into a tail certificate | `WP.CFG.seq`, `wp_rv64_seq` |
+| Compose when the midpoint is exact | `WP.CFG.seqExact`, `wp_rv64_seq_exact` |
 | Compose with disjoint code reqs | `WP.CFG.seqDisjoint`, `wp_rv64_seq_disjoint` |
+| Disjoint exact midpoint | `WP.CFG.seqDisjointExact`, `wp_rv64_seq_disjoint_exact` |
 | Compose two raw CPS block proofs | `WP.CFG.seqBlock`, `WP.CFG.seqBlockDisjoint` |
+| Raw blocks with exact midpoint | `WP.CFG.seqBlockExact`, `WP.CFG.seqBlockDisjointExact` |
 
 The `wp_rv64_*` tactics are thin wrappers around the constructors. They are
 useful when Lean can infer most arguments from the goal, especially after the
@@ -225,6 +232,47 @@ Good inputs:
 - loop header, body, exit labels, invariant family, and fuel bound
 - static facts such as length bounds, pointer alignment, and code disjointness
 
+A useful generated-CFG sketch looks like this:
+
+```text
+routine: WithdrawalDecode
+entry: prologue
+exit: done
+blocks:
+  prologue:
+    start: base
+    end: walk_init
+    code: prologueCode
+    post: prologuePost
+    successors: [walk_init]
+  walk_init:
+    kind: nbranch
+    exits:
+      - label: empty_input_fail
+        post: walkInitEmptyPost
+      - label: long_list_fail
+        post: walkInitLongListPost
+      - label: fields_start
+        post: walkInitSuccessPost
+joins:
+  done:
+    post: withdrawalDecodeDisjPost
+loops:
+  field_walk:
+    header: fields_start
+    body: field_body
+    exit: fields_done
+    invariant: fieldWalkInv
+    fuel: 4
+static_facts:
+  - code_disjoint_prologue_walk
+  - input_len_bound
+```
+
+This is not a Lean syntax requirement. It is the information a proof-producing
+agent should have available before it emits WP code. `post` names refer to Lean
+assertion definitions or local hypotheses, not to decoded runtime values.
+
 Bad inputs:
 
 - decoded result values in the schema
@@ -240,7 +288,10 @@ caller needs to distinguish it.
 ## Debugging
 
 - If a generated precondition is unclear, inspect `#wp_rv64 cfg`.
-- If `wp_rv64_cert` fails, try the constructor directly once. The resulting
+- If `wp_rv64_cert`, `wp_rv64_link`, `wp_rv64_dead`, or `wp_rv64_disjoint`
+  fails, read the diagnostic first. It reports the goal shape, how many
+  registered hints were tried, and the usual next action.
+- If a constructor still does not infer, try it directly once. The resulting
   goals usually show which entry, exit, code requirement, or postcondition did
   not infer.
 - If `wp_rv64_link` fails, normalize only the relevant helper definitions with


### PR DESCRIPTION
Stacked on PR #9540. Summary: add WP.CFG exact helpers leaf, exitRefl, seqExact, seqDisjointExact, seqBlockExact, and seqBlockDisjointExact; add matching wp_rv64 tactic macros and examples; improve WP tactic failure diagnostics; document exact helpers and a generated-CFG input sketch that keeps decoded results out of the schema; promote follow-up beads evm-asm-qphtc, evm-asm-39guo, evm-asm-9d5rr, evm-asm-iigpl to P0. Verification: targeted WP module build, full lake build, git diff --check, forbidden tactic check, unimported check, and file-size check.