### PR TITLE
feat(wp): synthesize leaf preconditions from posts

### DIFF
--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -303,6 +303,15 @@ theorem cpsTripleWithin_of_forall_memIs_to_memOwn
   exact h vOld R hR s hcr
     ⟨hp, hcompat, h1, h2, hd12, hunion12, ⟨h3, h4, hd34, hunion34, hP3, hv4⟩, hR2⟩ hpc
 
+/-- Single-atom bounded variant of `cpsTripleWithin_of_forall_memIs_to_memOwn`. -/
+theorem cpsTripleWithin_of_forall_memIs_to_memOwn_single
+    {nSteps : Nat} {entry exit_ a Q} {cr : CodeReq}
+    (h : ∀ vOld, cpsTripleWithin nSteps entry exit_ cr (a ↦ₘ vOld) Q) :
+    cpsTripleWithin nSteps entry exit_ cr (memOwn a) Q := by
+  intro R hR s hcr hPR hpc
+  obtain ⟨hp, hcompat, h1, h2, hd, hunion, ⟨vOld, hv⟩, hR2⟩ := hPR
+  exact h vOld R hR s hcr ⟨hp, hcompat, h1, h2, hd, hunion, hv, hR2⟩ hpc
+
 /-- Branch elimination: if both branch exits lead to the same
     continuation exit with R, merge back into a single cpsTripleWithin.
     All position/code/assertion arguments are implicit — inferred from `hbr`/`h_t`/`h_f`. -/

--- a/EvmAsm/Rv64/Tactics/RunBlock.lean
+++ b/EvmAsm/Rv64/Tactics/RunBlock.lean
@@ -824,10 +824,135 @@ private def consumePostAtoms (neededAtoms : List Expr) (currentAtoms : List Expr
     rest := eraseAtomIdx rest idx
   return rest.toList
 
+private inductive OwnershipKind where
+  | reg (r : Expr)
+  | mem (addr : Expr)
+
+private def OwnershipKind.ruleConst (single : Bool) : OwnershipKind → Name
+  | .reg _ =>
+      if single then
+        ``EvmAsm.Rv64.cpsTripleWithin_of_forall_regIs_to_regOwn_single
+      else
+        ``EvmAsm.Rv64.cpsTripleWithin_of_forall_regIs_to_regOwn
+  | .mem _ =>
+      if single then
+        ``EvmAsm.Rv64.cpsTripleWithin_of_forall_memIs_to_memOwn_single
+      else
+        ``EvmAsm.Rv64.cpsTripleWithin_of_forall_memIs_to_memOwn
+
+private def OwnershipKind.key : OwnershipKind → Expr
+  | .reg r => r
+  | .mem addr => addr
+
+private def isExactMVar (mvarId : MVarId) (e : Expr) : Bool :=
+  let e := e.consumeMData
+  e.isMVar && e.mvarId! == mvarId
+
+private def exprContainsMVar (mvarId : MVarId) (e : Expr) : Bool :=
+  (e.find? fun e => isExactMVar mvarId e).isSome
+
+private def replaceMVar (mvarId : MVarId) (replacement : Expr) (e : Expr) : Expr :=
+  e.replace fun e =>
+    if isExactMVar mvarId e then some replacement else none
+
+private def ownershipKindForOldValueAtom? (mvarId : MVarId) (atom : Expr) : Option OwnershipKind :=
+  if atom.isAppOfArity ``EvmAsm.Rv64.regIs 2 then
+    let r := atom.getAppArgs[0]!
+    let v := atom.getAppArgs[1]!
+    if isExactMVar mvarId v && !exprContainsMVar mvarId r then
+      some (.reg r)
+    else
+      none
+  else if atom.isAppOfArity ``EvmAsm.Rv64.memIs 2 then
+    let addr := atom.getAppArgs[0]!
+    let v := atom.getAppArgs[1]!
+    if isExactMVar mvarId v && !exprContainsMVar mvarId addr then
+      some (.mem addr)
+    else
+      none
+  else
+    none
+
+private def findOwnershipGeneralization? (mvarId : MVarId) (preAtoms : List Expr)
+    (post : Expr) : MetaM (Option (Nat × OwnershipKind)) := do
+  if exprContainsMVar mvarId post then
+    return none
+  let mut found : Option (Nat × OwnershipKind) := none
+  for h : i in [:preAtoms.length] do
+    let atom := preAtoms[i]
+    if let some kind := ownershipKindForOldValueAtom? mvarId atom then
+      if found.isSome then
+        throwError "runBlockFromPost: data parameter occurs as more than one old-value ownership candidate: {← mvarId.getType}"
+      found := some (i, kind)
+    else if exprContainsMVar mvarId atom then
+      return none
+  return found
+
+private def orderPreForOwnership (preAtoms : List Expr) (idx : Nat) : MetaM (Expr × Expr × Bool) := do
+  let oldAtom := preAtoms[idx]!
+  let frameAtoms := eraseAtomIdx preAtoms.toArray idx |>.toList
+  let frame ← buildSepConjChain frameAtoms
+  let orderedPre ←
+    if frameAtoms.isEmpty then
+      Pure.pure oldAtom
+    else
+      Pure.pure (mkApp2 (mkConst ``EvmAsm.Rv64.sepConj) frame oldAtom)
+  return (frame, orderedPre, frameAtoms.isEmpty)
+
+private def reorderPreForOwnership (proof : Expr) (orderedPre : Expr) : MetaM Expr := do
+  let proofType ← instantiateMVars (← inferType proof)
+  let some (nSteps, entry, exit_, cr, pre, post) ← parseCpsTripleWithin? proofType
+    | throwError "runBlockFromPost: internal error - ownership candidate is not a cpsTripleWithin"
+  if ← withoutModifyingState (isDefEq pre orderedPre) then
+    return proof
+  let hpre ← mkPermLambda orderedPre pre
+  let hpost ← mkIdLambda post
+  return mkAppN (mkConst ``EvmAsm.Rv64.cpsTripleWithin_weaken)
+    #[nSteps, entry, exit_, cr, pre, orderedPre, post, post, hpre, hpost, proof]
+
+private def applyOwnershipGeneralization (proof : Expr) (mvarId : MVarId)
+    (kind : OwnershipKind) (frame : Expr) (single : Bool) : MetaM Expr := do
+  let proofType ← instantiateMVars (← inferType proof)
+  let some (nSteps, entry, exit_, cr, _pre, post) ← parseCpsTripleWithin? proofType
+    | throwError "runBlockFromPost: internal error - ownership candidate is not a cpsTripleWithin"
+  let valueType ← instantiateMVars (← mvarId.getType)
+  withLocalDeclD `vOld valueType fun vOld => do
+    let body := replaceMVar mvarId vOld proof
+    let h ← mkLambdaFVars #[vOld] body
+    let rule := mkConst (kind.ruleConst single)
+    let result :=
+      if single then
+        mkAppN rule #[nSteps, entry, exit_, kind.key, post, cr, h]
+      else
+        mkAppN rule #[nSteps, entry, exit_, kind.key, frame, post, cr, h]
+    instantiateMVars result
+
+private partial def generalizeOwnershipParams (proof : Expr) (params : Array Expr) : MetaM Expr := do
+  let mut result := proof
+  for param in params do
+    if !param.isMVar then continue
+    let mvarId := param.mvarId!
+    if ← mvarId.isAssigned then continue
+    let paramType ← instantiateMVars (← mvarId.getType)
+    if ← isProp paramType then
+      continue
+    let resultType ← instantiateMVars (← inferType result)
+    let some (_, _, _, _, pre, post) ← parseCpsTripleWithin? resultType
+      | throwError "runBlockFromPost: internal error - synthesized spec is not a cpsTripleWithin"
+    let preAtoms ← flattenSepConj pre
+    let some (idx, kind) ← findOwnershipGeneralization? mvarId preAtoms post
+      | throwError "post matched but left data parameter unconstrained: {paramType}
+          Hint: unsupported unresolved data parameters must occur exactly as one old `regIs`/`memIs` value in the precondition and nowhere in the postcondition; otherwise pass an explicit spec."
+    let (frame, orderedPre, single) ← orderPreForOwnership preAtoms idx
+    let reordered ← reorderPreForOwnership result orderedPre
+    result ← applyOwnershipGeneralization reordered mvarId kind frame single
+  return result
+
 /-- Instantiate a registered single-instruction spec by matching its
     postcondition against the current desired postcondition.  Unlike forward
-    `runBlock`, this starts from the post and rejects candidates that would
-    leave data parameters, such as an old destination value, unconstrained. -/
+    `runBlock`, this starts from the post and turns unconstrained old register
+    or memory values into `regOwn`/`memOwn` preconditions when the spec shape is
+    unambiguous. -/
 private def tryInstantiateSpecFromPost (specName : Name) (instrExpr instrAddr : Expr)
     (currentAtoms : List Expr) : MetaM Expr := do
   let specConst := mkConst specName
@@ -852,12 +977,11 @@ private def tryInstantiateSpecFromPost (specName : Name) (instrExpr instrAddr : 
     if ← isProp paramType then
       let solved ← solveObligation mvarId
       unless solved do
-        throwError "cannot solve proof obligation: {paramType}\n\
+        throwError "cannot solve proof obligation: {paramType}
           Hint: Add the obligation as a hypothesis, or pass an already-instantiated spec."
-    else
-      throwError "post matched but left data parameter unconstrained: {paramType}\n\
-          Hint: use an ownership-style spec such as `regOwn`/`memOwn`, or pass an explicit spec."
   let proof ← instantiateMVars (mkAppN specConst params)
+  let proof ← generalizeOwnershipParams proof params
+  let proof ← instantiateMVars proof
   if proof.hasExprMVar then
     throwError "post matched but the instantiated proof still contains metavariables"
   let proofType ← instantiateMVars (← inferType proof)

--- a/EvmAsm/Rv64/Tactics/RunBlock.lean
+++ b/EvmAsm/Rv64/Tactics/RunBlock.lean
@@ -787,6 +787,134 @@ private def advanceState (currentAtoms : List Expr) (specExpr : Expr) : MetaM (L
   let frame := available.filter (·.2) |>.map (·.1) |>.toList
   return postAtoms ++ frame
 
+
+/-- Remove one atom from an array while preserving the order of all other atoms. -/
+private def eraseAtomIdx (atoms : Array Expr) (idx : Nat) : Array Expr := Id.run do
+  let mut result := Array.mkEmpty (atoms.size - 1)
+  for i in [:atoms.size] do
+    if i != idx then
+      result := result.push atoms[i]!
+  return result
+
+/-- Find a matching assertion atom, keeping successful metavariable assignments
+    and rolling back failed candidates.  This is the post-driven counterpart of
+    `findAtomIdx`: spec postconditions contain metavariables that should be
+    instantiated from the requested postcondition. -/
+private def findAtomIdxAssigning (target : Expr) (atoms : Array Expr) : MetaM (Option Nat) := do
+  for i in [:atoms.size] do
+    let saved ← saveState
+    try
+      if ← withReducible (isDefEq target atoms[i]!) then
+        return some i
+      restoreState saved
+    catch _ =>
+      restoreState saved
+  return none
+
+/-- Consume every atom required by a resolved spec postcondition from the
+    current desired postcondition.  The leftovers are the frame that should be
+    preserved while running the instruction backwards. -/
+private def consumePostAtoms (neededAtoms : List Expr) (currentAtoms : List Expr)
+    (ctx : MessageData) : MetaM (List Expr) := do
+  let mut rest := currentAtoms.toArray
+  for needed in neededAtoms do
+    let needed ← instantiateMVars needed
+    let some idx ← findAtomIdxAssigning needed rest
+      | throwError "runBlockFromPost: could not match postcondition atom while resolving {ctx}:\n  {needed}"
+    rest := eraseAtomIdx rest idx
+  return rest.toList
+
+/-- Instantiate a registered single-instruction spec by matching its
+    postcondition against the current desired postcondition.  Unlike forward
+    `runBlock`, this starts from the post and rejects candidates that would
+    leave data parameters, such as an old destination value, unconstrained. -/
+private def tryInstantiateSpecFromPost (specName : Name) (instrExpr instrAddr : Expr)
+    (currentAtoms : List Expr) : MetaM Expr := do
+  let specConst := mkConst specName
+  let specType ← inferType specConst
+  let (params, _, body) ← forallMetaTelescope specType
+  let some (_, specEntry, _, specCr, _, specPost) ← parseCpsTripleWithin? body
+    | throwError "tryInstantiateSpecFromPost: {specName} is not a cpsTripleWithin"
+  unless ← isDefEq specEntry instrAddr do
+    throwError "address mismatch"
+  let specCrWhnf ← whnfR specCr
+  if specCrWhnf.isAppOfArity ``EvmAsm.Rv64.CodeReq.singleton 2 then
+    let specInstr := specCrWhnf.getAppArgs[1]!
+    unless ← isDefEq specInstr instrExpr do
+      throwError "instruction mismatch in cr"
+  let specAtoms ← flattenSepConj specPost
+  let _ ← consumePostAtoms specAtoms currentAtoms m!"{specName}"
+  for param in params do
+    if !param.isMVar then continue
+    let mvarId := param.mvarId!
+    if ← mvarId.isAssigned then continue
+    let paramType ← instantiateMVars (← mvarId.getType)
+    if ← isProp paramType then
+      let solved ← solveObligation mvarId
+      unless solved do
+        throwError "cannot solve proof obligation: {paramType}\n\
+          Hint: Add the obligation as a hypothesis, or pass an already-instantiated spec."
+    else
+      throwError "post matched but left data parameter unconstrained: {paramType}\n\
+          Hint: use an ownership-style spec such as `regOwn`/`memOwn`, or pass an explicit spec."
+  let proof ← instantiateMVars (mkAppN specConst params)
+  if proof.hasExprMVar then
+    throwError "post matched but the instantiated proof still contains metavariables"
+  let proofType ← instantiateMVars (← inferType proof)
+  if proofType.hasExprMVar then
+    throwError "post matched but the instantiated spec type still contains metavariables"
+  return proof
+
+/-- Resolve one instruction by matching registered specs against the current
+    desired postcondition. -/
+private def resolveSpecForInstrFromPost (instrExpr instrAddr : Expr)
+    (currentAtoms : List Expr) : MetaM Expr := do
+  let instrHead := instrExpr.getAppFn
+  let .const instrName _ := instrHead
+    | throwError "runBlockFromPost: instruction is not a constructor application: {instrExpr}\n\
+        Hint: CodeReq entries must contain concrete instructions."
+  let env ← getEnv
+  let specs := findSpecsForInstr env instrName
+  if specs.isEmpty then
+    throwError "runBlockFromPost: no @[spec_gen_rv64] specs registered for `{instrName}`.\n\
+        Hint: import EvmAsm.Rv64.SyscallSpecs, register a spec, or pass an explicit spec."
+  trace[runBlock] "post-driven resolving {instrName} at {instrAddr} - {specs.size} candidate(s)"
+  let mut errors : Array (Name × String) := #[]
+  for entry in specs do
+    let saved ← saveState
+    try
+      let result ← tryInstantiateSpecFromPost entry.specName instrExpr instrAddr currentAtoms
+      trace[runBlock] "  post-driven resolved with {entry.specName}"
+      return result
+    catch e =>
+      restoreState saved
+      let msg := toString (← e.toMessageData.format)
+      errors := errors.push (entry.specName, msg)
+      continue
+  let mut errMsg := m!"runBlockFromPost: no spec could be instantiated backwards for `{instrName}` at {instrAddr}."
+  errMsg := errMsg ++ m!"\n  Tried {errors.size} candidate(s):"
+  for (name, msg) in errors do
+    errMsg := errMsg ++ m!"\n    {name}: {msg}"
+  errMsg := errMsg ++ m!"\n  Hint: strengthen the requested postcondition with the atoms produced by this instruction,\n    use an ownership-style spec for overwritten resources, or pass explicit spec hypotheses."
+  throwError errMsg
+
+/-- Compute the desired predecessor assertion for one already-instantiated spec
+    by replacing the spec's postcondition atoms with its precondition atoms. -/
+private def retreatState (currentAtoms : List Expr) (specExpr : Expr) : MetaM (List Expr) := do
+  let specType ← instantiateMVars (← inferType specExpr)
+  let some (_, _, _, _, specPre, specPost) ← parseCpsTripleWithin? specType
+    | throwError "retreatState: not a cpsTripleWithin"
+  let postAtoms ← flattenSepConj specPost
+  let frame ← consumePostAtoms postAtoms currentAtoms m!"{specType}"
+  let preAtoms ← flattenSepConj specPre
+  return preAtoms ++ frame
+
+private def synthesizePreFromResolvedSpecs (specsForward : Array Expr) (goalPost : Expr) : MetaM Expr := do
+  let mut currentAtoms ← flattenSepConj goalPost
+  for spec in specsForward.toList.reverse do
+    currentAtoms ← retreatState currentAtoms spec
+  buildSepConjChain currentAtoms
+
 /-- Extract instruction atoms `(addr, instrExpr)` from assertion atoms,
     preserving the order they appear in the precondition. -/
 private def extractInstrAtoms (atoms : List Expr) : List (Expr × Expr) :=
@@ -843,6 +971,39 @@ private partial def extractCrEntries (cr : Expr) : MetaM (List (Expr × Expr)) :
   let cr' ← Lean.Meta.whnfR cr
   if cr' == cr then return []  -- No progress, give up
   extractCrEntries cr'
+
+private def synthesizeSpecsAndPreFromPost (goalPost goalCr : Expr) : MetaM (Array Expr × Expr) := do
+  let instrAtoms ← extractCrEntries goalCr
+  if instrAtoms.isEmpty then
+    throwError "runBlockFromPost: no instructions found in the goal's CodeReq.\n\
+        The CodeReq must contain CodeReq.singleton/union/ofProg entries."
+  let mut currentAtoms ← flattenSepConj goalPost
+  let mut specsForward : List Expr := []
+  let mut resolvedCount : Nat := 0
+  let totalCount := instrAtoms.length
+  for (addr, instr) in instrAtoms.reverse do
+    try
+      let spec ← resolveSpecForInstrFromPost instr addr currentAtoms
+      currentAtoms ← retreatState currentAtoms spec
+      specsForward := spec :: specsForward
+      resolvedCount := resolvedCount + 1
+    catch e =>
+      let eMsg ← e.toMessageData.format
+      throwError "{eMsg}\n  Progress: resolved {resolvedCount} of {totalCount} bounded instruction spec(s) backwards before failure."
+  let pre ← buildSepConjChain currentAtoms
+  return (specsForward.toArray, pre)
+
+private def runBlockFromPostCore (specs : Array Expr) (goalPost goalCr : Expr) : MetaM Expr := do
+  let (resolvedSpecs, synthPre) ←
+    if specs.isEmpty then
+      synthesizeSpecsAndPreFromPost goalPost goalCr
+    else do
+      let processedSpecs ← specs.mapM fun spec => do
+        try normalizeSpecWithinAddresses spec
+        catch _ => Pure.pure spec
+      let synthPre ← synthesizePreFromResolvedSpecs processedSpecs goalPost
+      Pure.pure (processedSpecs, synthPre)
+  runBlockWithinCore resolvedSpecs synthPre (goalCr := some goalCr)
 
 private def autoResolveAndComposeWithin (goalPre : Expr) (goalCr : Expr) : MetaM Expr :=
   withTraceNode `runBlock.perf (fun _ => return m!"autoResolveAndComposeWithin") do
@@ -951,6 +1112,63 @@ elab "runBlock" specs:ident* : tactic => withMainContext do
     let permuted := mkAppN (mkConst ``EvmAsm.Rv64.cpsTripleWithin_weaken)
       #[gSteps, gEntry, gExit, gCr, gPre, gPre, resultPost, goalPost, idPre, postPerm, finalResult]
     workingGoal.assign permuted
+    replaceMainGoal []
+
+/-- Verify a straight-line leaf block by working backwards from the requested
+    postcondition.  With no arguments, the tactic resolves registered
+    `@[spec_gen_rv64]` instruction specs from the goal's `CodeReq`; with
+    arguments, it treats them as already-instantiated bounded specs in forward
+    execution order.  The goal may leave the precondition and step bound as
+    metavariables, which lets `WP.CFG.leaf` expose the synthesized precondition
+    as `cfg.pre`. -/
+elab "runBlockFromPost" specs:ident* : tactic => withMainContext do
+  withTraceNode `runBlock.perf (fun _ => return m!"runBlockFromPost") do
+    let mvarGoal ← getMainGoal
+    let goalType := inlineLets (← instantiateMVars (← mvarGoal.getType))
+    let some (gSteps, gEntry, gExit, gCr, gPre, goalPost) ← parseCpsTripleWithin? goalType
+      | throwError "runBlockFromPost: goal is not a `cpsTripleWithin`.\n\
+          Expected a goal such as `cpsTripleWithin ?n entry exit cr ?pre post`."
+    let specExprs ← specs.mapM fun s => elabTerm s none
+    let composed ← runBlockFromPostCore specExprs goalPost gCr
+    let finalResult ← normalizeWithinToGoal composed goalType
+    let resultType ← instantiateMVars (← inferType finalResult)
+    let some (rSteps, _, _, _, rPre, resultPost) ← parseCpsTripleWithin? resultType
+      | throwError "runBlockFromPost: internal error - synthesized result is not a cpsTripleWithin"
+    let finalResult ←
+      if gSteps.isMVar && !(← gSteps.mvarId!.isAssigned) then
+        gSteps.mvarId!.assign rSteps
+        Pure.pure finalResult
+      else if ← isDefEq rSteps gSteps then
+        Pure.pure finalResult
+      else
+        let hleType ← mkAppM ``LE.le #[rSteps, gSteps]
+        let hle ← mkFreshExprMVar hleType
+        let stx ← `(tactic| omega)
+        runTacticSilent hle.mvarId! stx
+        Pure.pure (mkAppN (mkConst ``EvmAsm.Rv64.cpsTripleWithin_mono_nSteps)
+          #[rSteps, gSteps, gEntry, gExit, gCr, rPre, resultPost, (← instantiateMVars hle), finalResult])
+    let resultType ← instantiateMVars (← inferType finalResult)
+    let some (rSteps, _, _, _, rPre, resultPost) ← parseCpsTripleWithin? resultType
+      | throwError "runBlockFromPost: internal error - step-adjusted result is not a cpsTripleWithin"
+    let prePerm ← do
+      if gPre.isMVar && !(← gPre.mvarId!.isAssigned) then
+        gPre.mvarId!.assign rPre
+        mkIdLambda rPre
+      else
+        let saved ← saveState
+        if ← isDefEq gPre rPre then
+          let goalPre ← instantiateMVars gPre
+          mkIdLambda goalPre
+        else
+          restoreState saved
+          let goalPre ← instantiateMVars gPre
+          mkPermLambda goalPre rPre
+    let goalPre ← instantiateMVars gPre
+    let postPerm ← mkPermLambda resultPost goalPost
+    let permuted := mkAppN (mkConst ``EvmAsm.Rv64.cpsTripleWithin_weaken)
+      #[rSteps, gEntry, gExit, gCr, rPre, goalPre, resultPost, goalPost,
+        prePerm, postPerm, finalResult]
+    mvarGoal.assign permuted
     replaceMainGoal []
 
 end EvmAsm.Rv64.Tactics

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -7,9 +7,11 @@
 -/
 
 import Lean
+import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.WPAttr
 import EvmAsm.Rv64.WP.CFG
 import EvmAsm.Rv64.WP.Call
+import EvmAsm.Rv64.Tactics.RunBlock
 import EvmAsm.Rv64.Tactics.SeqFrame
 import EvmAsm.Rv64.Tactics.XPermPure
 
@@ -322,6 +324,17 @@ syntax (name := wpRv64LeafTac) "wp_rv64_leaf " term : tactic
 macro_rules
   | `(tactic| wp_rv64_leaf $h:term) =>
       `(tactic| exact EvmAsm.Rv64.WP.CFG.leaf $h)
+
+/-- Build a leaf CFG certificate by working backwards from the requested
+    postcondition.  With no arguments, `runBlockFromPost` resolves registered
+    `@[spec_gen_rv64]` specs from the goal's `CodeReq`; with arguments, it uses
+    the supplied bounded specs in forward execution order. -/
+syntax (name := wpRv64LeafSynthTac) "wp_rv64_leaf_synth" ident* : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_leaf_synth $specs:ident*) =>
+      `(tactic| exact @EvmAsm.Rv64.WP.CFG.leaf ?_ _ _ _ ?_ _
+        (by runBlockFromPost $specs*))
 
 /-- Build an empty CFG at a join point with identical pre/post assertion. -/
 syntax (name := wpRv64ExitReflTac)
@@ -1201,6 +1214,25 @@ example {nSteps : Nat} {entry exit_ : Word} {cr : CodeReq} {pre post : Assertion
     (h : cpsTripleWithin nSteps entry exit_ cr pre post) :
     EvmAsm.Rv64.WP.CFG.Cert entry exit_ cr post := by
   wp_rv64_leaf h
+
+def wp_rv64_leaf_synth_li_cfg (base imm : Word) :
+    EvmAsm.Rv64.WP.CFG.Cert base (base + 4)
+      (CodeReq.singleton base (.LI .x5 imm))
+      (.x5 ↦ᵣ imm) := by
+  wp_rv64_leaf_synth
+
+example (base imm : Word) :
+    (wp_rv64_leaf_synth_li_cfg base imm).pre = regOwn .x5 := rfl
+
+def wp_rv64_leaf_synth_addi_manual_cfg (base v : Word) (imm : BitVec 12) :
+    EvmAsm.Rv64.WP.CFG.Cert base (base + 4)
+      (CodeReq.singleton base (.ADDI .x5 .x5 imm))
+      (.x5 ↦ᵣ (v + signExtend12 imm)) := by
+  let hAddi := addi_spec_same_within .x5 v imm base (by decide)
+  wp_rv64_leaf_synth hAddi
+
+example (base v : Word) (imm : BitVec 12) :
+    (wp_rv64_leaf_synth_addi_manual_cfg base v imm).pre = (.x5 ↦ᵣ v) := rfl
 
 example {entry : Word} {cr : CodeReq} {post : Assertion} :
     EvmAsm.Rv64.WP.CFG.Cert entry entry cr post := by

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -1234,6 +1234,28 @@ def wp_rv64_leaf_synth_addi_manual_cfg (base v : Word) (imm : BitVec 12) :
 example (base v : Word) (imm : BitVec 12) :
     (wp_rv64_leaf_synth_addi_manual_cfg base v imm).pre = (.x5 ↦ᵣ v) := rfl
 
+def wp_rv64_leaf_synth_addi_own_cfg (base v : Word) (imm : BitVec 12) :
+    EvmAsm.Rv64.WP.CFG.Cert base (base + 4)
+      (CodeReq.singleton base (.ADDI .x6 .x5 imm))
+      ((.x5 ↦ᵣ v) ** (.x6 ↦ᵣ (v + signExtend12 imm))) := by
+  wp_rv64_leaf_synth
+
+example (base v : Word) (imm : BitVec 12) :
+    (wp_rv64_leaf_synth_addi_own_cfg base v imm).pre =
+      ((.x5 ↦ᵣ v) ** regOwn .x6) := rfl
+
+def wp_rv64_leaf_synth_sd_own_cfg (base addr data : Word) (offset : BitVec 12) :
+    EvmAsm.Rv64.WP.CFG.Cert base (base + 4)
+      (CodeReq.singleton base (.SD .x5 .x6 offset))
+      ((.x5 ↦ᵣ addr) ** (.x6 ↦ᵣ data) **
+        ((addr + signExtend12 offset) ↦ₘ data)) := by
+  wp_rv64_leaf_synth
+
+example (base addr data : Word) (offset : BitVec 12) :
+    (wp_rv64_leaf_synth_sd_own_cfg base addr data offset).pre =
+      ((.x5 ↦ᵣ addr) ** (.x6 ↦ᵣ data) **
+        memOwn (addr + signExtend12 offset)) := rfl
+
 example {entry : Word} {cr : CodeReq} {post : Assertion} :
     EvmAsm.Rv64.WP.CFG.Cert entry entry cr post := by
   wp_rv64_exit_refl entry, cr, post

--- a/TACTICS.md
+++ b/TACTICS.md
@@ -18,9 +18,11 @@ User guide for the frame automation tactics in `EvmAsm/Tactics/`.
 The WP/CFG tactics are documented in
 [`docs/agents/wp-framework.md`](docs/agents/wp-framework.md). Start there when
 a proof should derive the precondition from a program, postcondition, and known
-control-flow shape. Common exact-midpoint helpers include `wp_rv64_leaf`,
-`wp_rv64_seq_exact`, and `wp_rv64_seq_block_exact`; bounded loop helpers include
-`wp_rv64_loop_nat` and `wp_rv64_loop_nat_sound`.
+control-flow shape. For straight-line leaves, start with `wp_rv64_leaf_synth`;
+it works backwards from the requested postcondition and exposes the computed
+precondition as `cfg.pre`. Common exact-midpoint helpers include
+`wp_rv64_leaf`, `wp_rv64_seq_exact`, and `wp_rv64_seq_block_exact`; bounded
+loop helpers include `wp_rv64_loop_nat` and `wp_rv64_loop_nat_sound`.
 
 **For closing arithmetic / address equality goals**, see the grindsets
 documented in [`GRIND.md`](GRIND.md):
@@ -98,6 +100,14 @@ theorem add_limb_carry_spec ... := by
   have s2 := add_limb_carry_spec_phase2 ...
   runBlock s1 s2
 ```
+
+### Post-driven WP leaf mode
+
+`runBlockFromPost` is the lower-level tactic used by `wp_rv64_leaf_synth`. It
+expects a bounded CPS goal whose precondition and step bound may be metavariables,
+for example `cpsTripleWithin ?n entry exit cr ?pre post`, and computes `?pre`
+by matching registered specs backwards from `post`. Most users should call
+`wp_rv64_leaf_synth` on a `WP.CFG.Cert` goal instead.
 
 ### Requirements
 

--- a/TACTICS.md
+++ b/TACTICS.md
@@ -106,8 +106,10 @@ theorem add_limb_carry_spec ... := by
 `runBlockFromPost` is the lower-level tactic used by `wp_rv64_leaf_synth`. It
 expects a bounded CPS goal whose precondition and step bound may be metavariables,
 for example `cpsTripleWithin ?n entry exit cr ?pre post`, and computes `?pre`
-by matching registered specs backwards from `post`. Most users should call
-`wp_rv64_leaf_synth` on a `WP.CFG.Cert` goal instead.
+by matching registered specs backwards from `post`. For simple overwritten
+register or memory cells, unresolved old values are generalized to `regOwn` or
+`memOwn` precondition atoms. Most users should call `wp_rv64_leaf_synth` on a
+`WP.CFG.Cert` goal instead.
 
 ### Requirements
 

--- a/docs/agents/wp-framework.md
+++ b/docs/agents/wp-framework.md
@@ -65,12 +65,45 @@ theorem spec :
    usually expose a disjunction such as "success with value" or "failure with
    status", with static guards carried inside the relevant disjuncts.
 
-2. Prove leaf blocks with existing tools.
+2. Synthesize straight-line leaf blocks from the postcondition when possible.
 
-   A leaf proof can be a normal `cpsTripleWithin` from `runBlock`, an existing
-   instruction/block spec, or a hand-written CPS theorem.
+   For a single-exit leaf whose `CodeReq` is a concrete `CodeReq.singleton`,
+   `CodeReq.union`, or `CodeReq.ofProg` tree, prefer `wp_rv64_leaf_synth`.
+   The tactic works backwards from the requested postcondition, resolves
+   registered `@[spec_gen_rv64]` instruction specs, and leaves the computed
+   assertion as `cfg.pre`.
 
-3. Lift leaves into WP certificates.
+   ```lean
+   def loadConstCfg (base imm : Word) :
+       WP.CFG.Cert base (base + 4)
+         (CodeReq.singleton base (.LI .x5 imm))
+         (.x5 ↦ᵣ imm) := by
+     wp_rv64_leaf_synth
+
+   example (base imm : Word) :
+       (loadConstCfg base imm).pre = regOwn .x5 := rfl
+   ```
+
+   When auto-resolution cannot pick the right instruction specs, pass the same
+   already-instantiated specs you would have passed to `runBlock`, in forward
+   execution order:
+
+   ```lean
+   let hAddi := addi_spec_same_within .x5 v imm base (by decide)
+   wp_rv64_leaf_synth hAddi
+   ```
+
+   Current matching is intentionally conservative: the requested postcondition
+   should expose the atoms produced by the instruction specs. If an instruction
+   overwrites a resource whose old value is not mentioned in the postcondition,
+   use an ownership-style spec (`regOwn`/`memOwn`) or pass an explicit spec.
+
+3. Prove remaining leaf blocks with existing tools.
+
+   A leaf proof can still be a normal `cpsTripleWithin` from `runBlock`, an
+   existing instruction/block spec, or a hand-written CPS theorem.
+
+4. Lift manually proven leaves into WP certificates.
 
    Use `WP.CFG.leaf` when the CPS postcondition already matches the
    certificate postcondition. Use `WP.CFG.block hpost` when the leaf needs a
@@ -85,7 +118,7 @@ theorem spec :
      WP.CFG.leaf hBlock
    ```
 
-4. Compose certificates backwards.
+5. Compose certificates backwards.
 
    If the tail certificate has precondition `tailCfg.pre`, prove the preceding
    block with postcondition `tailCfg.pre`, then compose that head proof into
@@ -99,12 +132,12 @@ theorem spec :
    `hLink` is usually `WP.Entails tailActualPre tailCfg.pre`. The tactic
    `wp_rv64_link` can close many identity, registered, or `xperm`-style links.
 
-5. Inspect the generated precondition.
+6. Inspect the generated precondition.
 
    Use `cfg.pre` in the final theorem statement. For interactive debugging,
    `#wp_rv64 cfg` prints the certificate's generated precondition.
 
-6. Finish with the normal CPS theorem.
+7. Finish with the normal CPS theorem.
 
    ```lean
    theorem top_spec :
@@ -116,6 +149,7 @@ theorem spec :
 
 | Need | Constructor or tactic |
 |------|-----------------------|
+| Synthesize a straight-line leaf from postcondition | `wp_rv64_leaf_synth`, `runBlockFromPost` |
 | Lift an exact single-exit CPS proof | `WP.CFG.leaf h`, `wp_rv64_leaf h` |
 | Lift and weaken a CPS proof's postcondition | `WP.CFG.block hpost h` |
 | Empty/reflexive exit certificate | `WP.CFG.exitRefl`, `wp_rv64_exit_refl` |

--- a/docs/agents/wp-framework.md
+++ b/docs/agents/wp-framework.md
@@ -94,9 +94,26 @@ theorem spec :
    ```
 
    Current matching is intentionally conservative: the requested postcondition
-   should expose the atoms produced by the instruction specs. If an instruction
-   overwrites a resource whose old value is not mentioned in the postcondition,
-   use an ownership-style spec (`regOwn`/`memOwn`) or pass an explicit spec.
+   should expose the atoms produced by the instruction specs. When a registered
+   spec has one unresolved old-value atom such as `rd ↦ᵣ vOld` or
+   `addr ↦ₘ memOld`, `wp_rv64_leaf_synth` turns it into `regOwn rd` or
+   `memOwn addr` automatically. If an unresolved data parameter appears in a
+   computed address, in the postcondition, or in more than one atom, pass an
+   explicit spec.
+
+   ```lean
+   def addiOwnCfg (base v : Word) (imm : BitVec 12) :
+       WP.CFG.Cert base (base + 4)
+         (CodeReq.singleton base (.ADDI .x6 .x5 imm))
+         ((.x5 ↦ᵣ v) ** (.x6 ↦ᵣ (v + signExtend12 imm))) := by
+     wp_rv64_leaf_synth
+
+   example (base v : Word) (imm : BitVec 12) :
+       (addiOwnCfg base v imm).pre = ((.x5 ↦ᵣ v) ** regOwn .x6) := rfl
+   ```
+
+   The checked examples in `EvmAsm.Rv64.Tactics.WP` also include an `SD`
+   leaf whose old memory cell is synthesized as `memOwn`.
 
 3. Prove remaining leaf blocks with existing tools.
 


### PR DESCRIPTION
Codex-authored stacked PR on feat/wp-generated-cfg. Adds post-driven WP leaf synthesis via wp_rv64_leaf_synth and the lower-level runBlockFromPost tactic. Documents the workflow in TACTICS.md and docs/agents/wp-framework.md. Validation: lake build, lake build EvmAsm.Rv64.Tactics.WP, git diff --check, scripts/check-file-size.sh, scripts/check-forbidden-tactics.sh, scripts/check-unimported.sh. Follow-up bead evm-asm-iigpl.1.1 tracks generic overwritten-resource ownership synthesis.