### PR TITLE
feat(divmod): MOD n=1 shiftNz lane → modStackDispatchPostV5 (n1 lane steps 4-6)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -447,6 +447,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopPreloopMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5NoNopPreloopMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5ToDenormMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5FullMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5LaneShiftNzMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V5LaneShiftNzMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V5LaneShiftNzMod.lean
@@ -1,0 +1,110 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN1V5LaneShiftNzMod
+
+  The v5 n=1 MOD lane, shift≠0 case: from the stack-dispatch precondition to
+  `modStackDispatchPostV5`, over `modCode_noNop_v5`.  MOD mirror of
+  `evm_div_n1_lane_shiftNz_v5` (FullPathN1V5LaneShiftNz): composes the op-agnostic
+  pre lift (`n1_dispatchPre_to_pathEntry_v5`), the full MOD code path
+  (`evm_mod_n1_full_spec_v5_noNop`), and a MOD post bridge
+  (`n1_denormModPost_to_modStackDispatchPost_v5`, with the remainder-limb facts
+  from `fullModN1RemainderWordV5_eq_mod_lane_of_shape`).  Step 6 of the n=1 MOD lane.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5FullMod
+import EvmAsm.Evm64.DivMod.Spec.N1V5ModRemainder
+import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Mod
+import EvmAsm.Evm64.DivMod.Spec.UnifiedBzero
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_add_zero)
+
+open EvmAsm.Rv64 in
+/-- The v5 n=1 MOD full-path post (`denormModPost`-form + quotient cells + frame)
+    implies the stack-dispatch MOD post, given the per-limb `mod` facts (supplied by
+    the lane from the remainder theorem) and the dividend limbs.  MOD mirror of
+    `n1_denormPost_to_divStackDispatchPost_v5`. -/
+theorem n1_denormModPost_to_modStackDispatchPost_v5
+    (sp base : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 scratchMem : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hmod0 : (EvmWord.mod a b).getLimbN 0 =
+        (((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>> ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))))
+    (hmod1 : (EvmWord.mod a b).getLimbN 1 =
+        (((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>> ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))))
+    (hmod2 : (EvmWord.mod a b).getLimbN 2 =
+        (((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>> ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))))
+    (hmod3 : (EvmWord.mod a b).getLimbN 3 =
+        ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>> ((fullDivN1Shift b0).toNat % 64))) :
+    ∀ h,
+      ((denormModPost sp (fullDivN1Shift b0)
+          (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.1
+          (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+          (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+          (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 **
+        ((sp + signExtend12 3992) ↦ₘ fullDivN1Shift b0)) **
+       (((sp + signExtend12 4088) ↦ₘ
+            (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).1) **
+         ((sp + signExtend12 4080) ↦ₘ
+            (fullDivN1R1V5 true true true a0 a1 a2 a3 b0 b1 b2 b3).1) **
+         ((sp + signExtend12 4072) ↦ₘ
+            (fullDivN1R2V5 true true a0 a1 a2 a3 b0 b1 b2 b3).1) **
+         ((sp + signExtend12 4064) ↦ₘ
+            (fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3).1)) **
+       fullDivN1FrameV5 sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) h →
+      (modStackDispatchPost sp a b ** memOwn (sp + signExtend12 3936)) h := by
+  intro h hp
+  delta denormModPost fullDivN1FrameV5 at hp
+  rw [word_add_zero] at hp
+  apply sepConj_mono_right (P := modStackDispatchPost sp a b) memIs_implies_memOwn h
+  apply sepConj_mono_left (modStackDispatchPost_weaken sp a b) h
+  rw [evmWordIs_sp_limbs_eq sp a a0 a1 a2 a3 ha0 ha1 ha2 ha3,
+      evmWordIs_sp32_limbs_eq sp (EvmWord.mod a b) _ _ _ _ hmod0 hmod1 hmod2 hmod3,
+      divScratchValuesCall_unfold, divScratchValues_unfold]
+  xperm_hyp hp
+
+/-- The v5 n=1 MOD lane, shift≠0: stack-dispatch precondition → `modStackDispatchPostV5`. -/
+theorem evm_mod_n1_lane_shiftNz_v5 (sp base : Word) (a b : EvmWord)
+    (x1Val v5 v6 v7 v10 v11Old : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) x1Val
+        ((clzResult b0).2 >>> (63 : Nat)) v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostV5 sp a b) := by
+  have hmodWord := fullModN1RemainderWordV5_eq_mod_lane_of_shape
+    ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hb1z hb2z hb3z hshift_nz
+  obtain ⟨hmod0, hmod1, hmod2, hmod3⟩ := fullModN1V5_hmods_of_word_eq a b a0 a1 a2 a3 b0 b1 b2 b3 hmodWord
+  have hpath := evm_mod_n1_full_spec_v5_noNop sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0 scratchMem hbnz hb3z hb2z hb1z hshift_nz halign
+  refine cpsTripleWithin_mono_nSteps (by have h : unifiedDivBound = 946 := rfl; omega) <|
+    cpsTripleWithin_weaken ?_ ?_ hpath
+  · intro h hp
+    exact n1_dispatchPre_to_pathEntry_v5 sp a b x1Val v5 v6 v7 v10 v11Old a0 a1 a2 a3 b0 b1 b2 b3
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem retMem dMem dloMem
+      scratch_un0 scratchMem ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 h hp
+  · intro h hq
+    delta modStackDispatchPostV5
+    exact n1_denormModPost_to_modStackDispatchPost_v5 sp base a b a0 a1 a2 a3 b0 b1 b2 b3 scratchMem
+      ha0 ha1 ha2 ha3 hmod0 hmod1 hmod2 hmod3 h hq
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N1V5ModRemainder.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1V5ModRemainder.lean
@@ -1,0 +1,121 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N1V5ModRemainder
+
+  **v5 n=1 MOD remainder correctness from shape (shift≠0):**
+  `fullModN1RemainderWordV5 = EvmWord.mod a b`.
+
+  The n=1 analog of `fullModN2RemainderWordV5_eq_mod_of_shape` (N2V5ModRemainder).
+  For the single-limb divisor case (b1=b2=b3=0) the normalized remainder collapses
+  to one limb (`val256_high_limbs_zero_of_lt_word` applied to the R0 remainder
+  bound), so the denormalized remainder word reduces to the single-limb form
+  `fromLimbs [R0.2.1 >>> shift, 0, 0, 0]` proven equal to `EvmWord.mod a b` by
+  `fullDivN1V5_remainder_eq_mod_of_shape` (N1V5Quotient).  Bead `evm-asm-wbc4i.9.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N1V5Quotient
+import EvmAsm.Evm64.DivMod.Spec.N1CarryZeroReducers
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- Pack the four denormalized v5 n=1 MOD remainder limbs (funnel-shift-down of
+    `fullDivN1R0V5`'s remainder by `fullDivN1Shift b0`) into a single `EvmWord`.
+    Matches the `denormModPost` limb formulas exactly. -/
+@[irreducible]
+def fullModN1RemainderWordV5 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : EvmWord :=
+  EvmWord.fromLimbs (fun i : Fin 4 =>
+    match i with
+    | 0 =>
+        ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>>
+            ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<<
+            ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))
+    | 1 =>
+        ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>>
+            ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<<
+            ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))
+    | 2 =>
+        ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>>
+            ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<<
+            ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))
+    | 3 =>
+        (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>>
+          ((fullDivN1Shift b0).toNat % 64))
+
+/-- **v5 n=1 MOD remainder correctness (shift≠0), from shape.**
+    `fullModN1RemainderWordV5 = EvmWord.mod a b`. -/
+theorem fullModN1RemainderWordV5_eq_mod_of_shape
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0) :
+    fullModN1RemainderWordV5 a0 a1 a2 a3 b0 b1 b2 b3 =
+      EvmWord.mod
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3)
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3) := by
+  -- single-limb collapse: the high remainder limbs are zero
+  have hlt := fullDivN1R0V5_remainder_lt_of_shape a0 a1 a2 a3 b0 b1 b2 b3
+    hbnz hb1z hb2z hb3z hshift_nz
+  obtain ⟨h1, h2, h3⟩ := val256_high_limbs_zero_of_lt_word
+    (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.1
+    (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+    (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+    (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1
+    (fullDivN1NormV b0 b1 b2 b3).1 hlt
+  -- shift < 64 so `% 64` is identity
+  have hslt : (fullDivN1Shift b0).toNat % 64 = (fullDivN1Shift b0).toNat := by
+    apply Nat.mod_eq_of_lt
+    have := clzResult_fst_toNat_le b0
+    unfold fullDivN1Shift; omega
+  refine Eq.trans ?_ (fullDivN1V5_remainder_eq_mod_of_shape a0 a1 a2 a3 b0 b1 b2 b3
+    hbnz hb1z hb2z hb3z hshift_nz)
+  unfold fullModN1RemainderWordV5
+  rw [h1, h2, h3, hslt]
+  congr 1
+  funext i
+  fin_cases i <;> simp
+
+/-- Per-limb projection of the n=1 MOD remainder word equality. -/
+theorem fullModN1V5_hmods_of_word_eq
+    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hmod : fullModN1RemainderWordV5 a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.mod a b) :
+    (EvmWord.mod a b).getLimbN 0 =
+        (((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>> ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))) ∧
+    (EvmWord.mod a b).getLimbN 1 =
+        (((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>> ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))) ∧
+    (EvmWord.mod a b).getLimbN 2 =
+        (((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>> ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))) ∧
+    (EvmWord.mod a b).getLimbN 3 =
+        ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>> ((fullDivN1Shift b0).toNat % 64)) := by
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [← hmod]; delta fullModN1RemainderWordV5; exact EvmWord.getLimbN_fromLimbs_0
+  · rw [← hmod]; delta fullModN1RemainderWordV5; exact EvmWord.getLimbN_fromLimbs_1
+  · rw [← hmod]; delta fullModN1RemainderWordV5; exact EvmWord.getLimbN_fromLimbs_2
+  · rw [← hmod]; delta fullModN1RemainderWordV5; exact EvmWord.getLimbN_fromLimbs_3
+
+/-- Lane form from shape: the assembled v5 n=1 remainder word equals `EvmWord.mod a b`. -/
+theorem fullModN1RemainderWordV5_eq_mod_lane_of_shape
+    {a b : EvmWord} {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0) :
+    fullModN1RemainderWordV5 a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.mod a b := by
+  have hraw := fullModN1RemainderWordV5_eq_mod_of_shape a0 a1 a2 a3 b0 b1 b2 b3
+    hbnz hb1z hb2z hb3z hshift_nz
+  subst a0; subst a1; subst a2; subst a3; subst b0; subst b1; subst b2; subst b3
+  refine hraw.trans ?_
+  congr 1
+  · exact EvmWord.fromLimbs_match_getLimbN_id a
+  · exact EvmWord.fromLimbs_match_getLimbN_id b
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Completes the **shift≠0 half of the n=1 MOD lane** over `modCode_noNop_v5`, building on the now-merged preloop (#9548) and entry→denorm + full-path (#9549). Toward `evm_mod_v6_stack_spec` → flipping MOD `.conditional → .proven` (Phase 0; unblocks SDIV/SMOD).

## New theorems

`EvmAsm/Evm64/DivMod/Spec/N1V5ModRemainder.lean`:
- `fullModN1RemainderWordV5` — packs the four `denormModPost` un-normalized remainder limbs into an `EvmWord`.
- `fullModN1RemainderWordV5_eq_mod_of_shape` — `= EvmWord.mod a b`. Proof: the n=1 single-limb remainder collapses (high limbs zero, via `val256_high_limbs_zero_of_lt_word ∘ fullDivN1R0V5_remainder_lt_of_shape`), reducing to the existing remainder core `fullDivN1V5_remainder_eq_mod_of_shape`.
- `fullModN1V5_hmods_of_word_eq` (per-limb projection) + `fullModN1RemainderWordV5_eq_mod_lane_of_shape` (`a b : EvmWord` bridge).

`EvmAsm/Evm64/DivMod/Compose/FullPathN1V5LaneShiftNzMod.lean`:
- `n1_denormModPost_to_modStackDispatchPost_v5` — post bridge `denormModPost → modStackDispatchPostV5` (MOD mirror of the DIV `n1_denormPost_to_divStackDispatchPost_v5`).
- `evm_mod_n1_lane_shiftNz_v5` — the lane: `divModStackDispatchPreNoX1 → modStackDispatchPostV5` over `unifiedDivBound` steps, reusing the op-agnostic pre-lift `n1_dispatchPre_to_pathEntry_v5`, the full path (#9549), and the remainder facts.

Mirrors DIV `FullPathN1V5LaneShiftNz` and n=2 MOD `FullPathN2V5LaneShiftNzMod`. Wired into the `DivMod` hub.

## Verification

- `lake build EvmAsm.Evm64.DivMod` — green (1872 jobs).
- Axiom-clean: `#print axioms` on `evm_mod_n1_lane_shiftNz_v5` / `fullModN1RemainderWordV5_eq_mod_of_shape` → `propext, Classical.choice, Quot.sound`.
- `scripts/check-forbidden-tactics.sh` — OK.

## Next

The n=1 `_shift0` arm + `evm_mod_n1_lane_v5` combiner (DIV keeps these in sibling files), then the n=3 and n=4 lanes and the v6 assembly links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)