### PR TITLE
feat(divmod): complete n=1 MOD lane — evm_mod_n1_lane_v5 (both shift arms)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -447,6 +447,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V5NoNopPreloopMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5NoNopPreloopMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5ToDenormMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5FullMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5LaneShiftNzMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -451,6 +451,8 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5FullMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5LaneShiftNzMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5PreloopShift0Mod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5ToDenormShift0Mod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5FullShift0Mod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5LaneShift0Mod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -102,6 +102,7 @@ import EvmAsm.Evm64.DivMod.Spec.N1V5CarryZero
 import EvmAsm.Evm64.DivMod.Spec.N1V5DigitSteps
 import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0Conservation
 import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0QuotientCorrect
+import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0ModRemainder
 import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0QuotientWordLane
 import EvmAsm.Evm64.DivMod.Spec.N1V5Quotient
 import EvmAsm.Evm64.DivMod.Spec.N1V5QuotientLimbs

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V5FullShift0Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V5FullShift0Mod.lean
@@ -1,0 +1,209 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN1V5FullShift0Mod
+
+  Full v5 n=1 MOD code path, shift=0 case (base → nopOff), over `modCode_noNop_v5`:
+  the shift=0 preloop+loop (`evm_mod_n1_to_denorm_shift0_spec_v5_noNop`) composed
+  with the shift=0 MOD epilogue (`evm_mod_shift0_epilogue_spec_v5_noNop`) via a
+  MOD-specific loop-post → epilogue-pre bridge.  MOD counterpart of
+  `evm_div_n1_full_shift0_spec_v5_noNop`: the MOD epilogue reads the un-normalized
+  remainder u-cells (sp+4056/4048/4040/4032 = `R0.2.{1,2.1,2.2.1,2.2.2.1}`), so the
+  bridge `loopN1UnifiedPostV5_shift0_to_modEpiloguePre` exposes those in the
+  epilogue's footprint (the DIV bridge buried them in its frame).  The quotient
+  digits (sp+4088/4080/4072/4064) are framed through, unread.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5BridgeShift0
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5ToDenormShift0Mod
+import EvmAsm.Evm64.DivMod.Compose.DenormEpilogueV5Mod
+
+namespace EvmAsm.Evm64
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56 word_add_zero)
+
+attribute [local irreducible] EvmWord.val256 div128Quot_v5 iterWithDoubleAddback mulsubN4 clzResult
+
+/-- The shift=0 loop-state frame WITHOUT the four remainder u-cells
+    (sp+4056/4048/4040/4032) and WITHOUT the quotient output cells
+    (sp+4088/4080/4072/4064) — those are split out for the MOD shift=0 epilogue. -/
+@[irreducible] def fullModN1FrameShift0V5Rest (sp base a0 a1 a2 a3 b0 scratchMem : Word) : Assertion :=
+  let R3 := iterN1Call_v5 b0 0 0 0 a3 0 0 0 0
+  let R2 := fullN1S2 b0 0 0 0 a3 0 0 0 0 a2
+  let R1 := fullN1S1 b0 0 0 0 a3 0 0 0 0 a2 a1
+  let R0 := fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ R0.1) **
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 3976) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)) **
+  ((sp + signExtend12 4024) ↦ₘ R0.2.2.2.2.2) ** ((sp + signExtend12 4016) ↦ₘ R1.2.2.2.2.2) **
+  ((sp + signExtend12 4008) ↦ₘ R2.2.2.2.2.2) ** ((sp + signExtend12 4000) ↦ₘ R3.2.2.2.2.2) **
+  ((sp + signExtend12 3968) ↦ₘ (base + div128CallRetOff)) ** ((sp + signExtend12 3960) ↦ₘ b0) **
+  ((sp + signExtend12 3952) ↦ₘ divKTrialCallV5DLo b0) **
+  ((sp + signExtend12 3944) ↦ₘ divKTrialCallV5Un0 a0) **
+  ((sp + signExtend12 3936) ↦ₘ
+    divKTrialCallV5ScratchOut R1.2.1 a0 b0
+      (divKTrialCallV5ScratchOut R2.2.1 a1 b0
+        (divKTrialCallV5ScratchOut R3.2.1 a2 b0
+          (divKTrialCallV5ScratchOut 0 a3 b0 scratchMem)))) **
+  regOwn .x1
+
+theorem fullModN1FrameShift0V5Rest_unfold {sp base a0 a1 a2 a3 b0 scratchMem : Word} :
+    fullModN1FrameShift0V5Rest sp base a0 a1 a2 a3 b0 scratchMem =
+    (let R3 := iterN1Call_v5 b0 0 0 0 a3 0 0 0 0
+     let R2 := fullN1S2 b0 0 0 0 a3 0 0 0 0 a2
+     let R1 := fullN1S1 b0 0 0 0 a3 0 0 0 0 a2 a1
+     let R0 := fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ R0.1) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 3976) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)) **
+     ((sp + signExtend12 4024) ↦ₘ R0.2.2.2.2.2) ** ((sp + signExtend12 4016) ↦ₘ R1.2.2.2.2.2) **
+     ((sp + signExtend12 4008) ↦ₘ R2.2.2.2.2.2) ** ((sp + signExtend12 4000) ↦ₘ R3.2.2.2.2.2) **
+     ((sp + signExtend12 3968) ↦ₘ (base + div128CallRetOff)) ** ((sp + signExtend12 3960) ↦ₘ b0) **
+     ((sp + signExtend12 3952) ↦ₘ divKTrialCallV5DLo b0) **
+     ((sp + signExtend12 3944) ↦ₘ divKTrialCallV5Un0 a0) **
+     ((sp + signExtend12 3936) ↦ₘ
+       divKTrialCallV5ScratchOut R1.2.1 a0 b0
+         (divKTrialCallV5ScratchOut R2.2.1 a1 b0
+           (divKTrialCallV5ScratchOut R3.2.1 a2 b0
+             (divKTrialCallV5ScratchOut 0 a3 b0 scratchMem)))) **
+     regOwn .x1) := by
+  delta fullModN1FrameShift0V5Rest; rfl
+
+/-- MOD shift=0 loop-post → epilogue-pre bridge.  Mirror of
+    `loopN1UnifiedPostV5_shift0_to_epiloguePre` (same proof), but the four
+    remainder u-cells (sp+4056/4048/4040/4032) are placed in the explicit
+    epilogue footprint (the MOD epilogue reads them) and the quotient output cells
+    are split out separately, leaving `fullModN1FrameShift0V5Rest`. -/
+theorem loopN1UnifiedPostV5_shift0_to_modEpiloguePre
+    (sp base a0 a1 a2 a3 b0 scratchMem : Word) (h : PartialState)
+    (hp : (loopN1UnifiedPostV5 sp base b0 0 0 0 a3 0 0 0 0 a2 a1 a0 scratchMem **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1)) h) :
+    (((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ (sp + signExtend12 4056)) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ (0 : Word)) ** (.x7 ↦ᵣ (sp + signExtend12 4088)) **
+       (.x2 ↦ᵣ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.2.1) **
+       (.x10 ↦ᵣ (mulsubN4
+            (div128Quot_v5 (fullN1S1 b0 0 0 0 a3 0 0 0 0 a2 a1).2.1 a0 b0)
+            b0 0 0 0 a0
+            (fullN1S1 b0 0 0 0 a3 0 0 0 0 a2 a1).2.1
+            (fullN1S1 b0 0 0 0 a3 0 0 0 0 a2 a1).2.2.1
+            (fullN1S1 b0 0 0 0 a3 0 0 0 0 a2 a1).2.2.2.1).2.2.2.2) **
+       ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1) **
+       ((sp + signExtend12 4056) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.1) **
+       ((sp + signExtend12 4048) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.1) **
+       ((sp + signExtend12 4040) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.1) **
+       ((sp + signExtend12 4032) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.2.1) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ (0 : Word)) **
+       ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word))) **
+     (((sp + signExtend12 4088) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).1) **
+       ((sp + signExtend12 4080) ↦ₘ (fullN1S1 b0 0 0 0 a3 0 0 0 0 a2 a1).1) **
+       ((sp + signExtend12 4072) ↦ₘ (fullN1S2 b0 0 0 0 a3 0 0 0 0 a2).1) **
+       ((sp + signExtend12 4064) ↦ₘ (iterN1Call_v5 b0 0 0 0 a3 0 0 0 0).1)) **
+     fullModN1FrameShift0V5Rest sp base a0 a1 a2 a3 b0 scratchMem) h := by
+  rw [fullModN1FrameShift0V5Rest_unfold]
+  delta loopN1UnifiedPostV5 loopN1Iter210PostV5 loopN1Iter10PostV5 loopIterPostN1V5
+    loopIterPostN1CallV5 at hp
+  dsimp only [] at hp
+  rw [loopExitPostN1_j0_eq] at hp
+  rw [← iterN1Call_v5_unfoldU'] at hp
+  delta fullN1S0 fullN1S1 fullN1S2
+  dsimp only []
+  simp only [n1_ub3_off4064, n1_qa3, n2_ub2_off4064, n2_qa2,
+      n3_ub1_off4064, n3_qa1, iterN1V5_true, if_true,
+      se12_32, se12_40, se12_48, se12_56, sepConj_emp_right'] at hp ⊢
+  set R3 := iterN1Call_v5 b0 0 0 0 a3 0 0 0 0 with hR3
+  set R2 := iterN1Call_v5 b0 0 0 0 a2 R3.2.1 R3.2.2.1 R3.2.2.2.1 R3.2.2.2.2.1 with hR2
+  set R1 := iterN1Call_v5 b0 0 0 0 a1 R2.2.1 R2.2.2.1 R2.2.2.2.1 R2.2.2.2.2.1 with hR1
+  set R0 := iterN1Call_v5 b0 0 0 0 a0 R1.2.1 R1.2.2.1 R1.2.2.2.1 R1.2.2.2.2.1 with hR0
+  xperm_chunked hp
+
+/-- Full n=1 MOD code path over `modCode_noNop_v5` (shift = 0): preloop + capped
+    loop + MOD remainder epilogue, `base → nopOff`.  The un-normalized remainder
+    limbs `R0.2.{1,2.1,2.2.1,2.2.2.1}` land in the output slots (sp+32/40/48/56). -/
+theorem evm_mod_n1_full_shift0_spec_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_z : (clzResult b0).1 = 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
+    cpsTripleWithin ((((8 + 21 + 24 + 4) + 13) + 632) + 12) base (base + nopOff)
+      (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+       ((sp + signExtend12 3960) ↦ₘ dMem) **
+       ((sp + signExtend12 3952) ↦ₘ dloMem) **
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem) ** regOwn .x1)
+      (((.x12 ↦ᵣ (sp + 32)) **
+         (.x5 ↦ᵣ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.1) **
+         (.x6 ↦ᵣ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.1) **
+         (.x7 ↦ᵣ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.1) **
+         (.x2 ↦ᵣ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.2.1) **
+         (.x0 ↦ᵣ (0 : Word)) **
+         (.x10 ↦ᵣ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.2.1) **
+         ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1) **
+         ((sp + signExtend12 4056) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.1) **
+         ((sp + signExtend12 4048) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.1) **
+         ((sp + signExtend12 4040) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.1) **
+         ((sp + signExtend12 4032) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.2.1) **
+         ((sp + 32) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.1) **
+         ((sp + 40) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.1) **
+         ((sp + 48) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.1) **
+         ((sp + 56) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.2.1)) **
+        (((sp + signExtend12 4088) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).1) **
+          ((sp + signExtend12 4080) ↦ₘ (fullN1S1 b0 0 0 0 a3 0 0 0 0 a2 a1).1) **
+          ((sp + signExtend12 4072) ↦ₘ (fullN1S2 b0 0 0 0 a3 0 0 0 0 a2).1) **
+          ((sp + signExtend12 4064) ↦ₘ (iterN1Call_v5 b0 0 0 0 a3 0 0 0 0).1)) **
+        fullModN1FrameShift0V5Rest sp base a0 a1 a2 a3 b0 scratchMem) := by
+  have hA := evm_mod_n1_to_denorm_shift0_spec_v5_noNop sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0 scratchMem hbnz hb3z hb2z hb1z hshift_z halign
+  have hB := evm_mod_shift0_epilogue_spec_v5_noNop sp base
+    (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.1
+    (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.1
+    (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.1
+    (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.2.1
+    (clzResult b0).1
+    (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.2.1
+    (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    (mulsubN4
+        (div128Quot_v5 (fullN1S1 b0 0 0 0 a3 0 0 0 0 a2 a1).2.1 a0 b0)
+        b0 0 0 0 a0
+        (fullN1S1 b0 0 0 0 a3 0 0 0 0 a2 a1).2.1
+        (fullN1S1 b0 0 0 0 a3 0 0 0 0 a2 a1).2.2.1
+        (fullN1S1 b0 0 0 0 a3 0 0 0 0 a2 a1).2.2.2.1).2.2.2.2
+    b0 (0 : Word) (0 : Word) (0 : Word) hshift_z
+  have hBf := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4088) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).1) **
+       ((sp + signExtend12 4080) ↦ₘ (fullN1S1 b0 0 0 0 a3 0 0 0 0 a2 a1).1) **
+       ((sp + signExtend12 4072) ↦ₘ (fullN1S2 b0 0 0 0 a3 0 0 0 0 a2).1) **
+       ((sp + signExtend12 4064) ↦ₘ (iterN1Call_v5 b0 0 0 0 a3 0 0 0 0).1)) **
+      fullModN1FrameShift0V5Rest sp base a0 a1 a2 a3 b0 scratchMem)
+    (by rw [fullModN1FrameShift0V5Rest_unfold]; pcFree) hB
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      have hbr := loopN1UnifiedPostV5_shift0_to_modEpiloguePre sp base a0 a1 a2 a3 b0 scratchMem h hp
+      xperm_hyp hbr) hA hBf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hFull
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V5LaneShift0Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V5LaneShift0Mod.lean
@@ -1,0 +1,154 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN1V5LaneShift0Mod
+
+  The v5 n=1 MOD lane, shift=0 case + the full `evm_mod_n1_lane_v5` combiner.
+  MOD mirror of `FullPathN1V5LaneShift0` (DIV).  Composes the op-agnostic pre lift
+  (`n1_dispatchPre_to_pathEntry_v5`), the full shift=0 MOD code path
+  (`evm_mod_n1_full_shift0_spec_v5_noNop`), and a shift=0 MOD post bridge
+  (with the remainder-limb facts from `fullModN1RemainderWordShift0V5_eq_mod_lane_of_shape`).
+  The combiner case-splits `(clzResult b0).1 = 0` to unify the shift0 and shift≠0
+  halves into one lane theorem over `modCode_noNop_v5` → `modStackDispatchPostV5`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5FullShift0Mod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5LaneShiftNzMod
+import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0ModRemainder
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_add_zero)
+
+/-- Project the shift=0 MOD remainder-word equality into the four per-limb
+    `getLimbN` facts (the values in the output cells sp+32/40/48/56). -/
+theorem fullModN1Shift0V5_hmods_of_word_eq
+    (a b : EvmWord) (a0 a1 a2 a3 b0 : Word)
+    (hword : fullModN1RemainderWordShift0V5 a0 a1 a2 a3 b0 = EvmWord.mod a b) :
+    (EvmWord.mod a b).getLimbN 0 = (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.1 ∧
+    (EvmWord.mod a b).getLimbN 1 = (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.1 ∧
+    (EvmWord.mod a b).getLimbN 2 = (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.1 ∧
+    (EvmWord.mod a b).getLimbN 3 = (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.2.1 := by
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [← hword]; delta fullModN1RemainderWordShift0V5; exact EvmWord.getLimbN_fromLimbs_0
+  · rw [← hword]; delta fullModN1RemainderWordShift0V5; exact EvmWord.getLimbN_fromLimbs_1
+  · rw [← hword]; delta fullModN1RemainderWordShift0V5; exact EvmWord.getLimbN_fromLimbs_2
+  · rw [← hword]; delta fullModN1RemainderWordShift0V5; exact EvmWord.getLimbN_fromLimbs_3
+
+open EvmAsm.Rv64 in
+/-- Shift=0 MOD post bridge: the shift=0 full-path post implies the stack-dispatch
+    MOD post (`modStackDispatchPostV5`), given the per-limb `mod` facts.  MOD mirror
+    of `n1_shift0_post_to_divStackDispatchPost_v5`. -/
+theorem n1_shift0_modPost_to_modStackDispatchPost_v5
+    (sp base : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 b0 scratchMem : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hmod0 : (EvmWord.mod a b).getLimbN 0 = (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.1)
+    (hmod1 : (EvmWord.mod a b).getLimbN 1 = (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.1)
+    (hmod2 : (EvmWord.mod a b).getLimbN 2 = (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.1)
+    (hmod3 : (EvmWord.mod a b).getLimbN 3 = (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.2.1) :
+    ∀ h,
+      (((.x12 ↦ᵣ (sp + 32)) **
+         (.x5 ↦ᵣ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.1) **
+         (.x6 ↦ᵣ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.1) **
+         (.x7 ↦ᵣ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.1) **
+         (.x2 ↦ᵣ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.2.1) **
+         (.x0 ↦ᵣ (0 : Word)) **
+         (.x10 ↦ᵣ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.2.1) **
+         ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1) **
+         ((sp + signExtend12 4056) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.1) **
+         ((sp + signExtend12 4048) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.1) **
+         ((sp + signExtend12 4040) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.1) **
+         ((sp + signExtend12 4032) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.2.1) **
+         ((sp + 32) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.1) **
+         ((sp + 40) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.1) **
+         ((sp + 48) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.1) **
+         ((sp + 56) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.2.1)) **
+        (((sp + signExtend12 4088) ↦ₘ (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).1) **
+          ((sp + signExtend12 4080) ↦ₘ (fullN1S1 b0 0 0 0 a3 0 0 0 0 a2 a1).1) **
+          ((sp + signExtend12 4072) ↦ₘ (fullN1S2 b0 0 0 0 a3 0 0 0 0 a2).1) **
+          ((sp + signExtend12 4064) ↦ₘ (iterN1Call_v5 b0 0 0 0 a3 0 0 0 0).1)) **
+        fullModN1FrameShift0V5Rest sp base a0 a1 a2 a3 b0 scratchMem) h →
+      (modStackDispatchPost sp a b ** memOwn (sp + signExtend12 3936)) h := by
+  intro h hp
+  rw [fullModN1FrameShift0V5Rest_unfold] at hp
+  rw [word_add_zero] at hp
+  apply sepConj_mono_right (P := modStackDispatchPost sp a b) memIs_implies_memOwn h
+  apply sepConj_mono_left (modStackDispatchPost_weaken sp a b) h
+  rw [evmWordIs_sp_limbs_eq sp a a0 a1 a2 a3 ha0 ha1 ha2 ha3,
+      evmWordIs_sp32_limbs_eq sp (EvmWord.mod a b) _ _ _ _ hmod0 hmod1 hmod2 hmod3,
+      divScratchValuesCall_unfold, divScratchValues_unfold]
+  xperm_hyp hp
+
+/-- The v5 n=1 MOD lane, shift=0: stack-dispatch precondition → `modStackDispatchPostV5`. -/
+theorem evm_mod_n1_lane_shift0_v5 (sp base : Word) (a b : EvmWord)
+    (x1Val v5 v6 v7 v10 v11Old : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_z : (clzResult b0).1 = 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) x1Val
+        ((clzResult b0).2 >>> (63 : Nat)) v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostV5 sp a b) := by
+  have hmodWord := fullModN1RemainderWordShift0V5_eq_mod_lane_of_shape
+    ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hb1z hb2z hb3z hshift_z
+  obtain ⟨hmod0, hmod1, hmod2, hmod3⟩ := fullModN1Shift0V5_hmods_of_word_eq a b a0 a1 a2 a3 b0 hmodWord
+  have hpath := evm_mod_n1_full_shift0_spec_v5_noNop sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0 scratchMem hbnz hb3z hb2z hb1z hshift_z halign
+  refine cpsTripleWithin_mono_nSteps (by have h : unifiedDivBound = 946 := rfl; omega) <|
+    cpsTripleWithin_weaken ?_ ?_ hpath
+  · intro h hp
+    exact n1_dispatchPre_to_pathEntry_v5 sp a b x1Val v5 v6 v7 v10 v11Old a0 a1 a2 a3 b0 b1 b2 b3
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem retMem dMem dloMem
+      scratch_un0 scratchMem ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 h hp
+  · intro h hq
+    delta modStackDispatchPostV5
+    exact n1_shift0_modPost_to_modStackDispatchPost_v5 sp base a b a0 a1 a2 a3 b0 scratchMem
+      ha0 ha1 ha2 ha3 hmod0 hmod1 hmod2 hmod3 h hq
+
+/-- The full v5 n=1 MOD lane: combines the shift≠0 and shift=0 halves by
+    `by_cases (clzResult b0).1 = 0`.  Mirror of `evm_div_n1_lane_v5`. -/
+theorem evm_mod_n1_lane_v5 (sp base : Word) (a b : EvmWord)
+    (x1Val v5 v6 v7 v10 v11Old : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) x1Val
+        ((clzResult b0).2 >>> (63 : Nat)) v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostV5 sp a b) := by
+  by_cases hsh : (clzResult b0).1 = 0
+  · exact evm_mod_n1_lane_shift0_v5 sp base a b x1Val v5 v6 v7 v10 v11Old
+      a0 a1 a2 a3 b0 b1 b2 b3 q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+      retMem dMem dloMem scratch_un0 scratchMem ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3
+      hbnz hb3z hb2z hb1z hsh halign
+  · exact evm_mod_n1_lane_shiftNz_v5 sp base a b x1Val v5 v6 v7 v10 v11Old
+      a0 a1 a2 a3 b0 b1 b2 b3 q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+      retMem dMem dloMem scratch_un0 scratchMem ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3
+      hbnz hb3z hb2z hb1z hsh halign
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V5LaneShiftNzMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V5LaneShiftNzMod.lean
@@ -1,0 +1,110 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN1V5LaneShiftNzMod
+
+  The v5 n=1 MOD lane, shift≠0 case: from the stack-dispatch precondition to
+  `modStackDispatchPostV5`, over `modCode_noNop_v5`.  MOD mirror of
+  `evm_div_n1_lane_shiftNz_v5` (FullPathN1V5LaneShiftNz): composes the op-agnostic
+  pre lift (`n1_dispatchPre_to_pathEntry_v5`), the full MOD code path
+  (`evm_mod_n1_full_spec_v5_noNop`), and a MOD post bridge
+  (`n1_denormModPost_to_modStackDispatchPost_v5`, with the remainder-limb facts
+  from `fullModN1RemainderWordV5_eq_mod_lane_of_shape`).  Step 6 of the n=1 MOD lane.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5FullMod
+import EvmAsm.Evm64.DivMod.Spec.N1V5ModRemainder
+import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Mod
+import EvmAsm.Evm64.DivMod.Spec.UnifiedBzero
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_add_zero)
+
+open EvmAsm.Rv64 in
+/-- The v5 n=1 MOD full-path post (`denormModPost`-form + quotient cells + frame)
+    implies the stack-dispatch MOD post, given the per-limb `mod` facts (supplied by
+    the lane from the remainder theorem) and the dividend limbs.  MOD mirror of
+    `n1_denormPost_to_divStackDispatchPost_v5`. -/
+theorem n1_denormModPost_to_modStackDispatchPost_v5
+    (sp base : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 scratchMem : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hmod0 : (EvmWord.mod a b).getLimbN 0 =
+        (((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>> ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))))
+    (hmod1 : (EvmWord.mod a b).getLimbN 1 =
+        (((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>> ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))))
+    (hmod2 : (EvmWord.mod a b).getLimbN 2 =
+        (((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>> ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))))
+    (hmod3 : (EvmWord.mod a b).getLimbN 3 =
+        ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>> ((fullDivN1Shift b0).toNat % 64))) :
+    ∀ h,
+      ((denormModPost sp (fullDivN1Shift b0)
+          (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.1
+          (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+          (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+          (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 **
+        ((sp + signExtend12 3992) ↦ₘ fullDivN1Shift b0)) **
+       (((sp + signExtend12 4088) ↦ₘ
+            (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).1) **
+         ((sp + signExtend12 4080) ↦ₘ
+            (fullDivN1R1V5 true true true a0 a1 a2 a3 b0 b1 b2 b3).1) **
+         ((sp + signExtend12 4072) ↦ₘ
+            (fullDivN1R2V5 true true a0 a1 a2 a3 b0 b1 b2 b3).1) **
+         ((sp + signExtend12 4064) ↦ₘ
+            (fullDivN1R3V5 true a0 a1 a2 a3 b0 b1 b2 b3).1)) **
+       fullDivN1FrameV5 sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) h →
+      (modStackDispatchPost sp a b ** memOwn (sp + signExtend12 3936)) h := by
+  intro h hp
+  delta denormModPost fullDivN1FrameV5 at hp
+  rw [word_add_zero] at hp
+  apply sepConj_mono_right (P := modStackDispatchPost sp a b) memIs_implies_memOwn h
+  apply sepConj_mono_left (modStackDispatchPost_weaken sp a b) h
+  rw [evmWordIs_sp_limbs_eq sp a a0 a1 a2 a3 ha0 ha1 ha2 ha3,
+      evmWordIs_sp32_limbs_eq sp (EvmWord.mod a b) _ _ _ _ hmod0 hmod1 hmod2 hmod3,
+      divScratchValuesCall_unfold, divScratchValues_unfold]
+  xperm_hyp hp
+
+/-- The v5 n=1 MOD lane, shift≠0: stack-dispatch precondition → `modStackDispatchPostV5`. -/
+theorem evm_mod_n1_lane_shiftNz_v5 (sp base : Word) (a b : EvmWord)
+    (x1Val v5 v6 v7 v10 v11Old : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) x1Val
+        ((clzResult b0).2 >>> (63 : Nat)) v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostV5 sp a b) := by
+  have hmodWord := fullModN1RemainderWordV5_eq_mod_lane_of_shape
+    ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hb1z hb2z hb3z hshift_nz
+  obtain ⟨hmod0, hmod1, hmod2, hmod3⟩ := fullModN1V5_hmods_of_word_eq a b a0 a1 a2 a3 b0 b1 b2 b3 hmodWord
+  have hpath := evm_mod_n1_full_spec_v5_noNop sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0 scratchMem hbnz hb3z hb2z hb1z hshift_nz halign
+  refine cpsTripleWithin_mono_nSteps (by have h : unifiedDivBound = 946 := rfl; omega) <|
+    cpsTripleWithin_weaken ?_ ?_ hpath
+  · intro h hp
+    exact n1_dispatchPre_to_pathEntry_v5 sp a b x1Val v5 v6 v7 v10 v11Old a0 a1 a2 a3 b0 b1 b2 b3
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem retMem dMem dloMem
+      scratch_un0 scratchMem ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 h hp
+  · intro h hq
+    delta modStackDispatchPostV5
+    exact n1_denormModPost_to_modStackDispatchPost_v5 sp base a b a0 a1 a2 a3 b0 b1 b2 b3 scratchMem
+      ha0 ha1 ha2 ha3 hmod0 hmod1 hmod2 hmod3 h hq
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N1V5ModRemainder.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1V5ModRemainder.lean
@@ -1,0 +1,121 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N1V5ModRemainder
+
+  **v5 n=1 MOD remainder correctness from shape (shift≠0):**
+  `fullModN1RemainderWordV5 = EvmWord.mod a b`.
+
+  The n=1 analog of `fullModN2RemainderWordV5_eq_mod_of_shape` (N2V5ModRemainder).
+  For the single-limb divisor case (b1=b2=b3=0) the normalized remainder collapses
+  to one limb (`val256_high_limbs_zero_of_lt_word` applied to the R0 remainder
+  bound), so the denormalized remainder word reduces to the single-limb form
+  `fromLimbs [R0.2.1 >>> shift, 0, 0, 0]` proven equal to `EvmWord.mod a b` by
+  `fullDivN1V5_remainder_eq_mod_of_shape` (N1V5Quotient).  Bead `evm-asm-wbc4i.9.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N1V5Quotient
+import EvmAsm.Evm64.DivMod.Spec.N1CarryZeroReducers
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- Pack the four denormalized v5 n=1 MOD remainder limbs (funnel-shift-down of
+    `fullDivN1R0V5`'s remainder by `fullDivN1Shift b0`) into a single `EvmWord`.
+    Matches the `denormModPost` limb formulas exactly. -/
+@[irreducible]
+def fullModN1RemainderWordV5 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : EvmWord :=
+  EvmWord.fromLimbs (fun i : Fin 4 =>
+    match i with
+    | 0 =>
+        ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>>
+            ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<<
+            ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))
+    | 1 =>
+        ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>>
+            ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<<
+            ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))
+    | 2 =>
+        ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>>
+            ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<<
+            ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))
+    | 3 =>
+        (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>>
+          ((fullDivN1Shift b0).toNat % 64))
+
+/-- **v5 n=1 MOD remainder correctness (shift≠0), from shape.**
+    `fullModN1RemainderWordV5 = EvmWord.mod a b`. -/
+theorem fullModN1RemainderWordV5_eq_mod_of_shape
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0) :
+    fullModN1RemainderWordV5 a0 a1 a2 a3 b0 b1 b2 b3 =
+      EvmWord.mod
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3)
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3) := by
+  -- single-limb collapse: the high remainder limbs are zero
+  have hlt := fullDivN1R0V5_remainder_lt_of_shape a0 a1 a2 a3 b0 b1 b2 b3
+    hbnz hb1z hb2z hb3z hshift_nz
+  obtain ⟨h1, h2, h3⟩ := val256_high_limbs_zero_of_lt_word
+    (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.1
+    (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+    (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+    (fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1
+    (fullDivN1NormV b0 b1 b2 b3).1 hlt
+  -- shift < 64 so `% 64` is identity
+  have hslt : (fullDivN1Shift b0).toNat % 64 = (fullDivN1Shift b0).toNat := by
+    apply Nat.mod_eq_of_lt
+    have := clzResult_fst_toNat_le b0
+    unfold fullDivN1Shift; omega
+  refine Eq.trans ?_ (fullDivN1V5_remainder_eq_mod_of_shape a0 a1 a2 a3 b0 b1 b2 b3
+    hbnz hb1z hb2z hb3z hshift_nz)
+  unfold fullModN1RemainderWordV5
+  rw [h1, h2, h3, hslt]
+  congr 1
+  funext i
+  fin_cases i <;> simp
+
+/-- Per-limb projection of the n=1 MOD remainder word equality. -/
+theorem fullModN1V5_hmods_of_word_eq
+    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hmod : fullModN1RemainderWordV5 a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.mod a b) :
+    (EvmWord.mod a b).getLimbN 0 =
+        (((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>> ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))) ∧
+    (EvmWord.mod a b).getLimbN 1 =
+        (((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>> ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))) ∧
+    (EvmWord.mod a b).getLimbN 2 =
+        (((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>> ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))) ∧
+    (EvmWord.mod a b).getLimbN 3 =
+        ((fullDivN1R0V5 true true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>> ((fullDivN1Shift b0).toNat % 64)) := by
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [← hmod]; delta fullModN1RemainderWordV5; exact EvmWord.getLimbN_fromLimbs_0
+  · rw [← hmod]; delta fullModN1RemainderWordV5; exact EvmWord.getLimbN_fromLimbs_1
+  · rw [← hmod]; delta fullModN1RemainderWordV5; exact EvmWord.getLimbN_fromLimbs_2
+  · rw [← hmod]; delta fullModN1RemainderWordV5; exact EvmWord.getLimbN_fromLimbs_3
+
+/-- Lane form from shape: the assembled v5 n=1 remainder word equals `EvmWord.mod a b`. -/
+theorem fullModN1RemainderWordV5_eq_mod_lane_of_shape
+    {a b : EvmWord} {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0) :
+    fullModN1RemainderWordV5 a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.mod a b := by
+  have hraw := fullModN1RemainderWordV5_eq_mod_of_shape a0 a1 a2 a3 b0 b1 b2 b3
+    hbnz hb1z hb2z hb3z hshift_nz
+  subst a0; subst a1; subst a2; subst a3; subst b0; subst b1; subst b2; subst b3
+  refine hraw.trans ?_
+  congr 1
+  · exact EvmWord.fromLimbs_match_getLimbN_id a
+  · exact EvmWord.fromLimbs_match_getLimbN_id b
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N1V5Shift0ModRemainder.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1V5Shift0ModRemainder.lean
@@ -1,0 +1,120 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N1V5Shift0ModRemainder
+
+  v5 n=1 **shift=0** MOD remainder correctness: the shift=0 schoolbook leaves the
+  exact remainder `EvmWord.mod a b` in the low u-cell, from the divisor shape
+  `(clzResult b0).1 = 0` (single-limb divisor, already top-bit aligned, no
+  normalization scaling).
+
+  MOD counterpart of `fullDivN1QuotientWordShift0V5_eq_div_of_shape`
+  (N1V5Shift0QuotientCorrect): same `fullDivN1V5_four_step_nat` Euclidean
+  accumulation, but `mod_remainder_of_normalized` (`s := 0`, so `r / 2^0 = a % b`)
+  + `mod_of_val256_eq_mod` instead of the quotient bridges.  The shift=0 MOD
+  epilogue (`evm_mod_shift0_epilogue_spec_v5_noNop`) loads the un-normalized
+  remainder u-cells directly, so the assembled remainder word packs
+  `(fullN1S0 …).2.{1,2.1,2.2.1,2.2.2.1}` with no funnel-shift.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0Quotient
+import EvmAsm.Evm64.DivMod.Spec.N1V5Shift0Conservation
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmWord
+
+private theorem val256_lo2_mod (x y : Word) :
+    val256 x y 0 0 = x.toNat + 2 ^ 64 * y.toNat := by
+  unfold val256
+  simp only [show (0 : Word).toNat = 0 from by decide]
+  ring
+
+/-- Pack the four shift=0 MOD remainder limbs (the loop's un-normalized u-cells,
+    read directly by the shift=0 MOD epilogue) into a single `EvmWord`. -/
+@[irreducible]
+def fullModN1RemainderWordShift0V5 (a0 a1 a2 a3 b0 : Word) : EvmWord :=
+  EvmWord.fromLimbs (fun i : Fin 4 => match i with
+    | 0 => (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.1
+    | 1 => (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.1
+    | 2 => (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.1
+    | 3 => (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.2.2.2.1)
+
+/-- **v5 n=1 shift=0 MOD remainder correctness, from shape.**
+    `fullModN1RemainderWordShift0V5 = EvmWord.mod a b`. -/
+theorem fullModN1RemainderWordShift0V5_eq_mod_of_shape
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hclz : (clzResult b0).1 = 0) :
+    fullModN1RemainderWordShift0V5 a0 a1 a2 a3 b0 =
+      EvmWord.mod
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3)
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3) := by
+  have hb0nz : b0 ≠ 0 := by
+    rw [hb1z, hb2z, hb3z] at hbnz; simpa using hbnz
+  have rem_eq : ∀ {x0 x1 x2 x3 : Word}, val256 x0 x1 x2 x3 < b0.toNat →
+      x1 = 0 ∧ x2 = 0 ∧ x3 = 0 := by
+    intro x0 x1 x2 x3 h
+    exact val256_high_limbs_zero_of_lt_word x0 x1 x2 x3 b0 h
+  have rem_val : ∀ {x0 x1 x2 x3 : Word}, val256 x0 x1 x2 x3 < b0.toNat →
+      val256 x0 x1 x2 x3 = x0.toNat := by
+    intro x0 x1 x2 x3 h
+    obtain ⟨h1, h2, h3⟩ := val256_high_limbs_zero_of_lt_word x0 x1 x2 x3 b0 h
+    rw [h1, h2, h3]; simp [val256]
+  have hr3 := rem_val (s3_rem_lt_shift0 a3 b0 hb0nz hclz)
+  have hr2 := rem_val (s2_rem_lt_shift0 a2 a3 b0 hb0nz hclz)
+  have hr1 := rem_val (s1_rem_lt_shift0 a1 a2 a3 b0 hb0nz hclz)
+  have hr0lt := s0_rem_lt_shift0 a0 a1 a2 a3 b0 hb0nz hclz
+  have hr0 := rem_val hr0lt
+  -- high remainder limbs collapse to zero (remainder < b0 < 2^64)
+  obtain ⟨hc1, hc2, hc3⟩ := rem_eq hr0lt
+  have hacc := fullDivN1V5_four_step_nat
+    (a := val256 a0 a1 a2 a3) (b := b0.toNat)
+    (q3 := (iterN1Call_v5 b0 0 0 0 a3 0 0 0 0).1.toNat)
+    (q2 := (fullN1S2 b0 0 0 0 a3 0 0 0 0 a2).1.toNat)
+    (q1 := (fullN1S1 b0 0 0 0 a3 0 0 0 0 a2 a1).1.toNat)
+    (q0 := (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).1.toNat)
+    (u0 := a0.toNat) (u1 := a1.toNat) (u2 := a2.toNat) (u3 := a3.toNat) (u4 := 0)
+    (r3 := (iterN1Call_v5 b0 0 0 0 a3 0 0 0 0).2.1.toNat)
+    (r2 := (fullN1S2 b0 0 0 0 a3 0 0 0 0 a2).2.1.toNat)
+    (r1 := (fullN1S1 b0 0 0 0 a3 0 0 0 0 a2 a1).2.1.toNat)
+    (r0 := (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.1.toNat)
+    (by simp [val256]; ring)
+    (by have h := s3_cons_shift0 a3 b0 hb0nz hclz; rw [hr3] at h; simp [val256] at h; omega)
+    (by have h := s2_cons_shift0 a2 a3 b0 hb0nz hclz; rw [hr2, val256_lo2_mod] at h; exact h)
+    (by have h := s1_cons_shift0 a1 a2 a3 b0 hb0nz hclz; rw [hr1, val256_lo2_mod] at h; exact h)
+    (by have h := s0_cons_shift0 a0 a1 a2 a3 b0 hb0nz hclz; rw [hr0, val256_lo2_mod] at h; exact h)
+  have hlt : (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.1.toNat < b0.toNat := by
+    rw [← hr0]; exact hr0lt
+  have hmod := mod_remainder_of_normalized (s := 0) (by simpa using hacc) (by simpa using hlt)
+  have hbval : val256 b0 b1 b2 b3 = b0.toNat := by rw [hb1z, hb2z, hb3z]; simp [val256]
+  have hrval : val256 (fullN1S0 b0 0 0 0 a3 0 0 0 0 a2 a1 a0).2.1 0 0 0 =
+      val256 a0 a1 a2 a3 % val256 b0 b1 b2 b3 := by
+    rw [hbval]
+    simp only [val256, show (0 : Word).toNat = 0 from by decide]
+    simpa using hmod
+  -- collapse the high limbs of the assembled word, then close via the single-limb value
+  unfold fullModN1RemainderWordShift0V5
+  rw [hc1, hc2, hc3]
+  exact mod_of_val256_eq_mod hbnz hrval
+
+/-- Lane (`a b : EvmWord`) form of the shift=0 MOD remainder word correctness. -/
+theorem fullModN1RemainderWordShift0V5_eq_mod_lane_of_shape
+    {a b : EvmWord} {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hclz : (clzResult b0).1 = 0) :
+    fullModN1RemainderWordShift0V5 a0 a1 a2 a3 b0 = EvmWord.mod a b := by
+  have hraw := fullModN1RemainderWordShift0V5_eq_mod_of_shape a0 a1 a2 a3 b0 b1 b2 b3
+    hbnz hb1z hb2z hb3z hclz
+  subst a0; subst a1; subst a2; subst a3; subst b0; subst b1; subst b2; subst b3
+  refine hraw.trans ?_
+  congr 1
+  · exact EvmWord.fromLimbs_match_getLimbN_id a
+  · exact EvmWord.fromLimbs_match_getLimbN_id b
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Completes the **entire n=1 MOD lane** over `modCode_noNop_v5`: `evm_mod_n1_lane_v5`, which case-splits on `(clzResult b0).1 = 0` and dispatches to the shift=0 or shift≠0 arm, landing in `modStackDispatchPostV5` (i.e. `evmWordIs (sp+32) (EvmWord.mod a b)`). This is **1 of the 5 MOD lanes** feeding `evm_mod_v6_stack_spec` → MOD `.proven`.

**Stacks on #9550 (shiftNz lane) and #9553 (shift0 remainder)** — both still open; this branch includes their commits, so the diff shrinks as they merge. (#9552, the shift0 foundation, is already merged.)

## New (the final assembly)

- `FullPathN1V5FullShift0Mod.lean` — `loopN1UnifiedPostV5_shift0_to_modEpiloguePre` (a dedicated MOD loop-post → shift0-epilogue-pre bridge exposing the remainder u-cells the MOD epilogue reads) + `evm_mod_n1_full_shift0_spec_v5_noNop` (full shift=0 path base→nopOff via `evm_mod_shift0_epilogue_spec_v5_noNop`).
- `FullPathN1V5LaneShift0Mod.lean` — `n1_shift0_modPost_to_modStackDispatchPost_v5` (post bridge, using `fullModN1RemainderWordShift0V5_eq_mod_lane_of_shape`), `evm_mod_n1_lane_shift0_v5`, and the combiner **`evm_mod_n1_lane_v5`**.

(Earlier slices on this branch: the shiftNz lane #9550, shift0 foundation #9552, shift0 remainder #9553.)

## Verification

- `lake build EvmAsm.Evm64.DivMod` — green (1877 jobs).
- Axiom-clean: `#print axioms evm_mod_n1_lane_v5` / `evm_mod_n1_lane_shift0_v5` → `propext, Classical.choice, Quot.sound`.
- `scripts/check-forbidden-tactics.sh` — OK.

## Next

The n=3 and n=4 MOD lanes, then the 5-lane combinator (`evm_mod_stack_spec_unconditional_of_lanes_v5_mod`, already exists) and the v6 assembly links → `evm_mod_v6_stack_spec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)