### PR TITLE
feat(wp): improve branch proof ergonomics

### DIFF
--- a/EvmAsm/Rv64/Tactics/ExtractPure.lean
+++ b/EvmAsm/Rv64/Tactics/ExtractPure.lean
@@ -1,27 +1,25 @@
 /-
-# `extract_pure` — slice 2 of #1432 (beads evm-asm-455)
+# `extract_pure` / `extract_pure_deep` — slice 2 of #1432
 
 Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
 
-This file implements the `extract_pure` tactic designed in slice 1
-(beads evm-asm-bx7). Slice 3 (beads evm-asm-8f5) will rewrite the call
-sites listed in the slice-1 design notes to use this tactic.
+This file implements the pure-extraction tactics designed in slice 1
+(beads evm-asm-bx7).
 
 ## Overview
 
-`extract_pure h` rewrites a hypothesis `h : (… ** ⌜P⌝ ** … ** ⌜Q⌝ ** …) s`
+`extract_pure_deep h` rewrites a hypothesis `h : (… ** ⌜P⌝ ** … ** ⌜Q⌝ ** …) s`
 into a chain of `∧` applications by AC-normalising the `sepConj` chain and
 applying `sepConj_pure_left` / `sepConj_pure_right` to bubble pure atoms
 out. After the rewrite, the user can `obtain` directly without manually
 walking the chain.
 
-The implementation is a one-liner `simp only [...]` macro: it relies on
-the AC equalities `sepConj_assoc'`, `sepConj_comm'`, `sepConj_left_comm'`
-already used by `sep_perm`, plus the two pure-extraction biconditionals
-`sepConj_pure_left` and `sepConj_pure_right` (proved in `SepLogic.lean`),
-plus the `empAssertion` collapse rules.
+`extract_pure h` is retained as the shallow compatibility tactic. It performs
+the original one-pass rewrite only, which lets existing proofs continue to
+rely on their old local conjunction shape. New automation should prefer
+`extract_pure_deep`.
 
-We deliberately keep the surface small: callers say `extract_pure h`,
+We deliberately keep the surface small: callers say `extract_pure_deep h`,
 then use plain `obtain ⟨hP, hQ, …, hRest⟩ := h` to name the extracted
 purities. The richer `with ⟨…⟩` / `using P` forms sketched in slice 1
 are not needed in practice — `obtain` already provides them.
@@ -72,22 +70,47 @@ fires at the outer `s` and converts it to a `∧`.
 Tracked under beads `evm-asm-22a` / GH #1435.
 -/
 
-/-- `extract_pure h` rewrites a separation-logic hypothesis
-    `h : (A₁ ** … ** Aₙ) s` into a `∧`-chain whose left conjuncts are
-    the pure atoms (`⌜P⌝`) extracted from the chain and whose tail is
-    the remaining resource assertion applied to `s`.
+theorem sepConj_pure_pure_eq {P Q : Prop} :
+    (⌜P⌝ ** ⌜Q⌝) = ⌜P ∧ Q⌝ := by
+  funext h
+  rw [EvmAsm.Rv64.sepConj_pure_left]
+  unfold EvmAsm.Rv64.pure
+  apply propext
+  constructor
+  · intro h_pq
+    exact ⟨h_pq.2.1, h_pq.1, h_pq.2.2⟩
+  · intro h_pq
+    exact ⟨h_pq.2.1, h_pq.1, h_pq.2.2⟩
 
-    After `extract_pure h`, follow up with `obtain ⟨hP₁, …, hPₖ, hRest⟩ := h`
-    to name the extracted purities and the resource tail.
+theorem sepConj_pure_pure_left_eq {P Q : Prop} {R : Assertion} :
+    (⌜P⌝ ** ⌜Q⌝ ** R) = (⌜P ∧ Q⌝ ** R) := by
+  rw [← EvmAsm.Rv64.sepConj_assoc', sepConj_pure_pure_eq]
 
-    Example:
-    ```
-    example (s : PartialState) (R : Assertion) (P Q : Prop)
-        (h : (R ** ⌜P⌝ ** ⌜Q⌝) s) : P ∧ Q := by
-      extract_pure h
-      exact ⟨h.1, h.2.1⟩
-    ```
-    -/
+theorem sepConj_pure_mid_left_eq {P : Assertion} {Q : Prop} {R : Assertion} :
+    (P ** ⌜Q⌝ ** R) = (⌜Q⌝ ** P ** R) := by
+  rw [← EvmAsm.Rv64.sepConj_assoc', ← EvmAsm.Rv64.sepConj_assoc',
+    EvmAsm.Rv64.sepConj_comm' P (⌜Q⌝)]
+
+theorem sepConj_pure_mid_right_eq {P R : Assertion} {Q : Prop} :
+    (P ** R ** ⌜Q⌝) = (⌜Q⌝ ** P ** R) := by
+  rw [EvmAsm.Rv64.sepConj_comm' R (⌜Q⌝), ← EvmAsm.Rv64.sepConj_assoc',
+    EvmAsm.Rv64.sepConj_comm' P (⌜Q⌝), EvmAsm.Rv64.sepConj_assoc']
+
+theorem sepConj_pure_mid_assoc_eq {P R : Assertion} {Q : Prop} :
+    ((P ** ⌜Q⌝) ** R) = (⌜Q⌝ ** P ** R) := by
+  rw [EvmAsm.Rv64.sepConj_assoc']
+  exact sepConj_pure_mid_left_eq
+
+theorem sepConj_pure_head_assoc_eq {P : Prop} {Q R : Assertion} :
+    ((⌜P⌝ ** Q) ** R) = (⌜P⌝ ** (Q ** R)) := by
+  exact EvmAsm.Rv64.sepConj_assoc' (⌜P⌝) Q R
+
+/-- Compatibility tactic with the original shallow extraction behavior.
+
+    `extract_pure h` extracts pure atoms reachable by the state-applied `↔`
+    lemmas, but it does not recursively rewrite nested assertion subterms.
+    This preserves the old local shape expected by existing downstream proofs.
+    New automation should generally use `extract_pure_deep`. -/
 macro "extract_pure" h:ident : tactic =>
   `(tactic|
       simp only
@@ -99,6 +122,42 @@ macro "extract_pure" h:ident : tactic =>
         , EvmAsm.Rv64.sepConj_emp_left'
         , EvmAsm.Rv64.sepConj_emp_right'
         ] at $h:ident)
+
+/-- `extract_pure_deep h` rewrites a separation-logic hypothesis
+    `h : (A₁ ** … ** Aₙ) s` into a `∧`-chain whose left conjuncts are
+    the pure atoms (`⌜P⌝`) extracted from the chain and whose tail is
+    the remaining resource assertion applied to `s`.
+
+    Unlike `extract_pure`, this tactic also rewrites nested assertion
+    subterms, so it can reach pure atoms buried under long framed `**` chains.
+
+    After `extract_pure_deep h`, follow up with
+    `obtain ⟨hP₁, …, hPₖ, hRest⟩ := h` to name the extracted purities and
+    the resource tail.
+
+    Example:
+    ```
+    example (s : PartialState) (R : Assertion) (P Q : Prop)
+        (h : (R ** ⌜P⌝ ** ⌜Q⌝) s) : P ∧ Q := by
+      extract_pure_deep h
+      exact ⟨h.1, h.2.1⟩
+    ``` -/
+macro "extract_pure_deep" h:ident : tactic =>
+  `(tactic|
+      extract_pure $h:ident <;>
+      try simp only
+        [ EvmAsm.Rv64.Tactics.sepConj_pure_pure_left_eq
+        , EvmAsm.Rv64.Tactics.sepConj_pure_pure_eq
+        , EvmAsm.Rv64.Tactics.sepConj_pure_mid_assoc_eq
+        , EvmAsm.Rv64.Tactics.sepConj_pure_head_assoc_eq
+        , EvmAsm.Rv64.sepConj_pure_right
+        , EvmAsm.Rv64.sepConj_pure_left
+        , EvmAsm.Rv64.Tactics.sepConj_pure_mid_left
+        , EvmAsm.Rv64.Tactics.sepConj_pure_mid_right
+        , EvmAsm.Rv64.sepConj_emp_left'
+        , EvmAsm.Rv64.sepConj_emp_right'
+        ] at $h:ident)
+
 
 end EvmAsm.Rv64.Tactics
 
@@ -144,5 +203,23 @@ example (s : PartialState) (P Q R : Prop) (A : Assertion)
     (h : ((⌜P⌝ ** A) ** (⌜Q⌝ ** ⌜R⌝)) s) : P ∧ Q ∧ R := by
   extract_pure h
   refine ⟨?_, ?_, ?_⟩ <;> simp_all
+
+/-- Pure atom buried under a long framed chain. -/
+example (s : PartialState) (P : Prop) (A B C D : Assertion)
+    (h : (A ** (B ** (C ** (⌜P⌝ ** D)))) s) : P := by
+  extract_pure_deep h
+  exact h.1
+
+/-- Pure atom behind the frame shape produced by branch framing. -/
+example (s : PartialState) (P : Prop) (A B C D : Assertion)
+    (h : ((A ** B ** ⌜P⌝) ** (C ** D)) s) : P := by
+  extract_pure_deep h
+  simp_all
+
+/-- Multiple pure atoms interleaved with resources. -/
+example (s : PartialState) (P Q : Prop) (R₁ R₂ : Assertion)
+    (h : (R₁ ** ⌜P⌝ ** R₂ ** ⌜Q⌝) s) : P ∧ Q := by
+  extract_pure_deep h
+  simp_all
 
 end EvmAsm.Rv64.Tactics.ExtractPureTests

--- a/EvmAsm/Rv64/Tactics/RunBlock.lean
+++ b/EvmAsm/Rv64/Tactics/RunBlock.lean
@@ -1096,6 +1096,18 @@ private partial def extractCrEntries (cr : Expr) : MetaM (List (Expr × Expr)) :
   if cr' == cr then return []  -- No progress, give up
   extractCrEntries cr'
 
+private def countSingleInstrSpecs? (specs : Array Expr) : MetaM (Option Nat) := do
+  let mut count := 0
+  for spec in specs do
+    let specType ← inferType spec
+    let some (_, _, _, specCr, _, _) ← parseCpsTripleWithin? specType
+      | return none
+    let entries ← extractCrEntries specCr
+    if entries.length != 1 then
+      return none
+    count := count + 1
+  return some count
+
 private def synthesizeSpecsAndPreFromPost (goalPost goalCr : Expr) : MetaM (Array Expr × Expr) := do
   let instrAtoms ← extractCrEntries goalCr
   if instrAtoms.isEmpty then
@@ -1125,6 +1137,13 @@ private def runBlockFromPostCore (specs : Array Expr) (goalPost goalCr : Expr) :
       let processedSpecs ← specs.mapM fun spec => do
         try normalizeSpecWithinAddresses spec
         catch _ => Pure.pure spec
+      let goalEntries ← extractCrEntries goalCr
+      unless goalEntries.isEmpty do
+        if let some singleInstrCount ← countSingleInstrSpecs? processedSpecs then
+          if singleInstrCount != goalEntries.length then
+            throwError "runBlockFromPost: manual mode received {singleInstrCount} single-instruction spec(s) for {goalEntries.length} instruction(s) in the goal CodeReq.
+              Explicit manual specs are treated as the complete block, not as partial hints.
+              Pass one spec for every instruction in forward execution order, use a composite spec whose CodeReq covers the whole block, or omit all specs to use post-driven auto mode."
       let synthPre ← synthesizePreFromResolvedSpecs processedSpecs goalPost
       Pure.pure (processedSpecs, synthPre)
   runBlockWithinCore resolvedSpecs synthPre (goalCr := some goalCr)

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -234,6 +234,55 @@ elab "wp_rv64_cert" : tactic => withMainContext do
   Hint: try the intended constructor directly once to expose missing static
   facts, or tag a reusable constructor with @[rv64_wp_cert]."
 
+attribute [rv64_wp]
+  EvmAsm.Rv64.WP.Triple.refl_pre
+  EvmAsm.Rv64.WP.Triple.unreachable_pre
+  EvmAsm.Rv64.WP.Triple.ofSpec_pre
+  EvmAsm.Rv64.WP.Triple.weakenPre_pre
+  EvmAsm.Rv64.WP.Triple.weakenPost_pre
+  EvmAsm.Rv64.WP.Triple.monoSteps_pre
+  EvmAsm.Rv64.WP.Triple.extendCode_pre
+  EvmAsm.Rv64.WP.Triple.frameR_pre
+  EvmAsm.Rv64.WP.Triple.changeEntry_pre
+  EvmAsm.Rv64.WP.Triple.changeExit_pre
+  EvmAsm.Rv64.WP.Triple.seq_pre
+  EvmAsm.Rv64.WP.Triple.seqDisjoint_pre
+  EvmAsm.Rv64.WP.CFG.exitRefl_pre
+  EvmAsm.Rv64.WP.CFG.block_pre
+  EvmAsm.Rv64.WP.CFG.leaf_pre
+  EvmAsm.Rv64.WP.CFG.frameR_pre
+  EvmAsm.Rv64.WP.CFG.weakenPre_pre
+  EvmAsm.Rv64.WP.CFG.weakenPost_pre
+  EvmAsm.Rv64.WP.CFG.monoSteps_pre
+  EvmAsm.Rv64.WP.CFG.extendCode_pre
+  EvmAsm.Rv64.WP.CFG.changeEntry_pre
+  EvmAsm.Rv64.WP.CFG.changeExit_pre
+  EvmAsm.Rv64.WP.Branch.ofSpec_pre
+  EvmAsm.Rv64.WP.Branch.ofSpec_exit_t
+  EvmAsm.Rv64.WP.Branch.ofSpec_post_t
+  EvmAsm.Rv64.WP.Branch.ofSpec_exit_f
+  EvmAsm.Rv64.WP.Branch.ofSpec_post_f
+  EvmAsm.Rv64.WP.Branch.frameR_pre
+  EvmAsm.Rv64.WP.Branch.frameR_exit_t
+  EvmAsm.Rv64.WP.Branch.frameR_post_t
+  EvmAsm.Rv64.WP.Branch.frameR_exit_f
+  EvmAsm.Rv64.WP.Branch.frameR_post_f
+  EvmAsm.Rv64.WP.Branch.join_pre
+  EvmAsm.Rv64.WP.Branch.seqTakenDisjoint_pre
+  EvmAsm.Rv64.WP.Branch.seqNotTakenDisjoint_pre
+  EvmAsm.Rv64.WP.Branch.seqTakenBranchConvergeDisjoint_pre
+
+/-- Expose small WP certificate projections before using separation-logic
+    permutation or pure-extraction tactics. -/
+syntax (name := wpRv64NormTac) "wp_rv64_norm" : tactic
+syntax (name := wpRv64NormAtTac) "wp_rv64_norm" " at " ident : tactic
+
+macro_rules
+  | `(tactic| wp_rv64_norm) =>
+      `(tactic| try dsimp; try simp only [rv64_wp])
+  | `(tactic| wp_rv64_norm at $h:ident) =>
+      `(tactic| try dsimp at $h:ident; try simp only [rv64_wp] at $h:ident)
+
 /-- Close the midpoint entailment between adjacent WP fragments.  The common
     case is definitional equality of the head postcondition and tail WP; semantic
     bridge lemmas tagged `@[rv64_wp_entails]` handle generated handoff shapes,
@@ -242,21 +291,22 @@ syntax (name := wpRv64LinkTac) "wp_rv64_link" : tactic
 
 macro_rules
   | `(tactic| wp_rv64_link) =>
-      `(tactic| first
+      `(tactic| solve
         | exact EvmAsm.Rv64.WP.Entails.refl _
         | assumption
-        | wp_rv64_entails
-        | simp only [rv64_wp]; wp_rv64_entails
-        | dsimp; wp_rv64_entails
-        | dsimp; simp only [rv64_wp]; wp_rv64_entails
-        | intro _ _hp; xperm_hyp _hp
         | intro _ _hp; xperm_pure _hp
-        | intro _ _hp; simp only [rv64_wp] at _hp ⊢; xperm_hyp _hp
+        | intro _ _hp; try rw [EvmAsm.Rv64.WP.Branch.frameR_post_t, EvmAsm.Rv64.WP.Branch.ofSpec_post_t] at _hp; try rw [EvmAsm.Rv64.WP.Branch.frameR_post_f, EvmAsm.Rv64.WP.Branch.ofSpec_post_f] at _hp; try rw [EvmAsm.Rv64.WP.CFG.extendCode_pre]; try rw [EvmAsm.Rv64.WP.CFG.weakenPost_pre]; try rw [EvmAsm.Rv64.WP.CFG.frameR_pre]; try rw [EvmAsm.Rv64.WP.CFG.leaf_pre]; try rw [EvmAsm.Rv64.WP.CFG.block_pre]; xperm_pure _hp
+        | intro _ _hp; dsimp at _hp ⊢; simp only [rv64_wp] at _hp ⊢; xperm_pure _hp
+        | intro _ _hp; wp_rv64_norm at _hp; wp_rv64_norm; xperm_pure _hp
+        | intro _ _hp; try dsimp at _hp ⊢; try simp only [rv64_wp] at _hp ⊢; xperm_pure _hp
         | intro _ _hp; simp only [rv64_wp] at _hp ⊢; xperm_pure _hp
-        | intro _ _hp; dsimp at _hp ⊢; xperm_hyp _hp
-        | intro _ _hp; dsimp at _hp ⊢; xperm_pure _hp
-        | intro _ _hp; dsimp at _hp ⊢; simp only [rv64_wp] at _hp ⊢; xperm_hyp _hp
-        | intro _ _hp; dsimp at _hp ⊢; simp only [rv64_wp] at _hp ⊢; xperm_pure _hp)
+        | intro _ _hp; try dsimp at _hp ⊢; xperm_pure _hp
+        | wp_rv64_entails
+        | wp_rv64_norm; wp_rv64_entails
+        | simp only [rv64_wp]; wp_rv64_entails
+        | try dsimp; wp_rv64_entails
+        | try dsimp; try simp only [rv64_wp]; wp_rv64_entails)
+
 
 private def closeDisjointWithLocal (goal : MVarId) (goalType : Expr) : TacticM Bool := do
   for localDecl in ← getLCtx do

--- a/EvmAsm/Rv64/Tactics/XPermPure.lean
+++ b/EvmAsm/Rv64/Tactics/XPermPure.lean
@@ -5,7 +5,7 @@ Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
 
 `xperm_pure h` is a sibling of `xperm_hyp` that tolerates pure (`⌜·⌝`)
 atoms in the source hypothesis and/or the goal. It composes the
-`extract_pure` machinery (#1432, `EvmAsm/Rv64/Tactics/ExtractPure.lean`)
+`extract_pure_deep` machinery (#1432, `EvmAsm/Rv64/Tactics/ExtractPure.lean`)
 with `xperm_hyp` (`EvmAsm/Rv64/Tactics/XSimp.lean`).
 
 ## Semantics
@@ -17,7 +17,7 @@ hypothesis side, `xperm_pure h` closes the goal.
 
 Concretely, `xperm_pure h`:
 
-1. Runs `extract_pure` on the hypothesis, peeling every `⌜P_i⌝` atom
+1. Runs `extract_pure_deep` on the hypothesis, peeling every `⌜P_i⌝` atom
    into a `∧`-chain. After this `h : P₁ ∧ … ∧ Pₖ ∧ Hr s` where `Hr`
    is the resource-only tail.
 2. Runs the same `simp only` lemma set on the goal, peeling every
@@ -90,12 +90,26 @@ def evalXpermPure : Tactic := fun stx => do
       -- Step 1: peel pures from the hypothesis. Use `try` so that a
       -- bare resource hypothesis (no pures, no `**`) is left
       -- untouched.
-      evalTactic (← `(tactic| try extract_pure $h:ident))
-      -- Step 2: peel pures from the goal via the same simp lemma set.
+      evalTactic (← `(tactic| try extract_pure_deep $h:ident))
+      -- Step 2: peel pures from the goal via the same two-phase simp lemma set.
       evalTactic (← `(tactic|
         try
           simp only
             [ ← EvmAsm.Rv64.sepConj_assoc'
+            , EvmAsm.Rv64.sepConj_pure_right
+            , EvmAsm.Rv64.sepConj_pure_left
+            , EvmAsm.Rv64.Tactics.sepConj_pure_mid_left
+            , EvmAsm.Rv64.Tactics.sepConj_pure_mid_right
+            , EvmAsm.Rv64.sepConj_emp_left'
+            , EvmAsm.Rv64.sepConj_emp_right'
+            ]))
+      evalTactic (← `(tactic|
+        try
+          simp only
+            [ EvmAsm.Rv64.Tactics.sepConj_pure_pure_left_eq
+            , EvmAsm.Rv64.Tactics.sepConj_pure_pure_eq
+            , EvmAsm.Rv64.Tactics.sepConj_pure_mid_assoc_eq
+            , EvmAsm.Rv64.Tactics.sepConj_pure_head_assoc_eq
             , EvmAsm.Rv64.sepConj_pure_right
             , EvmAsm.Rv64.sepConj_pure_left
             , EvmAsm.Rv64.Tactics.sepConj_pure_mid_left

--- a/EvmAsm/Rv64/WP/CFG.lean
+++ b/EvmAsm/Rv64/WP/CFG.lean
@@ -101,11 +101,25 @@ theorem exitRefl_pre (addr : Word) (cr : CodeReq) (post : Assertion) :
     (exitRefl addr cr post).pre = post :=
   rfl
 
+/-- `block` exposes exactly the source precondition of the CPS proof. -/
+theorem block_pre {nSteps : Nat} {entry exit_ : Word} {cr : CodeReq}
+    {pre post post' : Assertion}
+    (hpost : Entails post post')
+    (h : cpsTripleWithin nSteps entry exit_ cr pre post) :
+    (block hpost h).pre = pre :=
+  rfl
+
 /-- `leaf` exposes exactly the source precondition of the CPS proof. -/
 theorem leaf_pre {nSteps : Nat} {entry exit_ : Word} {cr : CodeReq}
     {pre post : Assertion}
     (h : cpsTripleWithin nSteps entry exit_ cr pre post) :
     (leaf h).pre = pre :=
+  rfl
+
+/-- `frameR` appends exactly the supplied frame to the generated precondition. -/
+theorem frameR_pre {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
+    (cfg : Cert entry exit_ cr post) (F : Assertion) (hF : F.pcFree) :
+    (frameR cfg F hF).pre = (cfg.pre ** F) :=
   rfl
 
 /-- `weakenPre` exposes exactly the supplied precondition. -/

--- a/EvmAsm/Rv64/WP/Core.lean
+++ b/EvmAsm/Rv64/WP/Core.lean
@@ -169,6 +169,77 @@ def seqDisjoint {nSteps : Nat} {entry mid exit_ : Word} {cr1 cr2 : CodeReq}
   pre := pre
   sound := cpsTripleWithin_seq_with_perm hd hlink head tail.sound
 
+/-- Projection lemmas used by WP link normalization. -/
+theorem refl_pre (addr : Word) (cr : CodeReq) {pre post : Assertion}
+    (h : Entails pre post) :
+    (refl addr cr h).pre = pre :=
+  rfl
+
+theorem unreachable_pre (entry exit_ : Word) (cr : CodeReq) {pre post : Assertion}
+    (hpre : ∀ h, pre h → False) :
+    (@unreachable entry exit_ cr pre post hpre).pre = pre :=
+  rfl
+
+theorem ofSpec_pre {nSteps : Nat} {entry exit_ : Word} {cr : CodeReq}
+    {pre post post' : Assertion}
+    (hpost : Entails post post')
+    (h : cpsTripleWithin nSteps entry exit_ cr pre post) :
+    (ofSpec hpost h).pre = pre :=
+  rfl
+
+theorem weakenPre_pre {entry exit_ : Word} {cr : CodeReq} {post pre' : Assertion}
+    (t : Triple entry exit_ cr post) (hpre : Entails pre' t.pre) :
+    (weakenPre t hpre).pre = pre' :=
+  rfl
+
+theorem weakenPost_pre {entry exit_ : Word} {cr : CodeReq} {post post' : Assertion}
+    (t : Triple entry exit_ cr post) (hpost : Entails post post') :
+    (weakenPost t hpost).pre = t.pre :=
+  rfl
+
+theorem monoSteps_pre {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
+    (t : Triple entry exit_ cr post) {nSteps' : Nat} (hle : t.nSteps ≤ nSteps') :
+    (monoSteps t hle).pre = t.pre :=
+  rfl
+
+theorem extendCode_pre {entry exit_ : Word} {cr cr' : CodeReq} {post : Assertion}
+    (t : Triple entry exit_ cr post)
+    (hmono : ∀ a i, cr a = some i → cr' a = some i) :
+    (extendCode t hmono).pre = t.pre :=
+  rfl
+
+theorem frameR_pre {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
+    (t : Triple entry exit_ cr post) (F : Assertion) (hF : F.pcFree) :
+    (frameR t F hF).pre = (t.pre ** F) :=
+  rfl
+
+theorem changeEntry_pre {entry entry' exit_ : Word} {cr : CodeReq} {post : Assertion}
+    (t : Triple entry exit_ cr post) (hentry : entry' = entry) :
+    (changeEntry t hentry).pre = t.pre :=
+  rfl
+
+theorem changeExit_pre {entry exit_ exit_' : Word} {cr : CodeReq} {post : Assertion}
+    (t : Triple entry exit_ cr post) (hexit : exit_ = exit_') :
+    (changeExit t hexit).pre = t.pre :=
+  rfl
+
+theorem seq_pre {nSteps : Nat} {entry mid exit_ : Word} {cr : CodeReq}
+    {pre midPost post : Assertion}
+    (head : cpsTripleWithin nSteps entry mid cr pre midPost)
+    (tail : Triple mid exit_ cr post)
+    (hlink : Entails midPost tail.pre) :
+    (seq head tail hlink).pre = pre :=
+  rfl
+
+theorem seqDisjoint_pre {nSteps : Nat} {entry mid exit_ : Word} {cr1 cr2 : CodeReq}
+    {pre midPost post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (head : cpsTripleWithin nSteps entry mid cr1 pre midPost)
+    (tail : Triple mid exit_ cr2 post)
+    (hlink : Entails midPost tail.pre) :
+    (seqDisjoint hd head tail hlink).pre = pre :=
+  rfl
+
 end Triple
 
 /-- A two-exit branch summary consumable by the WP join rule. -/
@@ -283,6 +354,104 @@ def seqTakenBranchConvergeDisjoint {entry : Word} {cr1 cr2 : CodeReq}
     exact cpsBranchWithin_seq_cpsBranchWithin_taken_converge hd br.sound
       (cpsBranchWithin_weaken hlink (fun _ hp => hp) (fun _ hp => hp) htail)
       hf1 hf2
+
+/-- Projection lemmas used by WP link normalization. -/
+theorem ofSpec_pre {nSteps : Nat} {entry : Word} {cr : CodeReq}
+    {pre : Assertion} {exit_t : Word} {post_t : Assertion}
+    {exit_f : Word} {post_f : Assertion}
+    (h : cpsBranchWithin nSteps entry cr pre exit_t post_t exit_f post_f) :
+    (ofSpec h).pre = pre :=
+  rfl
+
+theorem ofSpec_exit_t {nSteps : Nat} {entry : Word} {cr : CodeReq}
+    {pre : Assertion} {exit_t : Word} {post_t : Assertion}
+    {exit_f : Word} {post_f : Assertion}
+    (h : cpsBranchWithin nSteps entry cr pre exit_t post_t exit_f post_f) :
+    (ofSpec h).exit_t = exit_t :=
+  rfl
+
+theorem ofSpec_post_t {nSteps : Nat} {entry : Word} {cr : CodeReq}
+    {pre : Assertion} {exit_t : Word} {post_t : Assertion}
+    {exit_f : Word} {post_f : Assertion}
+    (h : cpsBranchWithin nSteps entry cr pre exit_t post_t exit_f post_f) :
+    (ofSpec h).post_t = post_t :=
+  rfl
+
+theorem ofSpec_exit_f {nSteps : Nat} {entry : Word} {cr : CodeReq}
+    {pre : Assertion} {exit_t : Word} {post_t : Assertion}
+    {exit_f : Word} {post_f : Assertion}
+    (h : cpsBranchWithin nSteps entry cr pre exit_t post_t exit_f post_f) :
+    (ofSpec h).exit_f = exit_f :=
+  rfl
+
+theorem ofSpec_post_f {nSteps : Nat} {entry : Word} {cr : CodeReq}
+    {pre : Assertion} {exit_t : Word} {post_t : Assertion}
+    {exit_f : Word} {post_f : Assertion}
+    (h : cpsBranchWithin nSteps entry cr pre exit_t post_t exit_f post_f) :
+    (ofSpec h).post_f = post_f :=
+  rfl
+
+theorem frameR_pre {entry : Word} {cr : CodeReq}
+    (br : Branch entry cr) (F : Assertion) (hF : F.pcFree) :
+    (frameR br F hF).pre = (br.pre ** F) :=
+  rfl
+
+theorem frameR_exit_t {entry : Word} {cr : CodeReq}
+    (br : Branch entry cr) (F : Assertion) (hF : F.pcFree) :
+    (frameR br F hF).exit_t = br.exit_t :=
+  rfl
+
+theorem frameR_post_t {entry : Word} {cr : CodeReq}
+    (br : Branch entry cr) (F : Assertion) (hF : F.pcFree) :
+    (frameR br F hF).post_t = (br.post_t ** F) :=
+  rfl
+
+theorem frameR_exit_f {entry : Word} {cr : CodeReq}
+    (br : Branch entry cr) (F : Assertion) (hF : F.pcFree) :
+    (frameR br F hF).exit_f = br.exit_f :=
+  rfl
+
+theorem frameR_post_f {entry : Word} {cr : CodeReq}
+    (br : Branch entry cr) (F : Assertion) (hF : F.pcFree) :
+    (frameR br F hF).post_f = (br.post_f ** F) :=
+  rfl
+
+theorem join_pre {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
+    (br : Branch entry cr)
+    (t : Triple br.exit_t exit_ cr post)
+    (f : Triple br.exit_f exit_ cr post)
+    (ht : Entails br.post_t t.pre)
+    (hf : Entails br.post_f f.pre) :
+    (join br t f ht hf).pre = br.pre :=
+  rfl
+
+theorem seqTakenDisjoint_pre {entry target : Word} {cr1 cr2 : CodeReq} {post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : Branch entry cr1)
+    (tail : Triple br.exit_t target cr2 post)
+    (hlink : Entails br.post_t tail.pre) :
+    (seqTakenDisjoint hd br tail hlink).pre = br.pre :=
+  rfl
+
+theorem seqNotTakenDisjoint_pre {entry target : Word} {cr1 cr2 : CodeReq} {post : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : Branch entry cr1)
+    (tail : Triple br.exit_f target cr2 post)
+    (hlink : Entails br.post_f tail.pre) :
+    (seqNotTakenDisjoint hd br tail hlink).pre = br.pre :=
+  rfl
+
+theorem seqTakenBranchConvergeDisjoint_pre {entry : Word} {cr1 cr2 : CodeReq}
+    {failPost : Assertion}
+    (hd : cr1.Disjoint cr2)
+    (br : Branch entry cr1)
+    (tail : Branch br.exit_t cr2)
+    (hfail : tail.exit_t = br.exit_f)
+    (hlink : Entails br.post_t tail.pre)
+    (hf1 : Entails br.post_f failPost)
+    (hf2 : Entails tail.post_t failPost) :
+    (seqTakenBranchConvergeDisjoint hd br tail hfail hlink hf1 hf2).pre = br.pre :=
+  rfl
 
 end Branch
 

--- a/EvmAsm/Rv64/WP/Examples.lean
+++ b/EvmAsm/Rv64/WP/Examples.lean
@@ -6,6 +6,7 @@
 
 import EvmAsm.Rv64.InstructionSpecs
 import EvmAsm.Rv64.WP.CFG
+import EvmAsm.Rv64.Tactics.WP
 
 namespace EvmAsm.Rv64
 namespace WP
@@ -59,6 +60,36 @@ example {entry exit_ : Word} {cr : CodeReq} {post : Assertion}
     cpsTripleWithin (br.nSteps + Nat.max taken.nSteps notTaken.nSteps)
       entry exit_ cr br.pre post :=
   (CFG.branch br taken notTaken ht hf).sound
+
+/-- Branch links may need to unfold certificate projections and permute framed
+    resources. This models composing an independently-stated continuation whose
+    precondition has the same atoms as the branch post in a different order. -/
+example {nBranch nTaken nFail : Nat}
+    {entry takenExit failExit exit_ : Word} {cr : CodeReq}
+    {branchPre takenPost failPost finalPost frame : Assertion}
+    (h_frame : frame.pcFree)
+    (hBranch : cpsBranchWithin nBranch entry cr branchPre
+      takenExit takenPost failExit failPost)
+    (hTaken : cpsTripleWithin nTaken takenExit exit_ cr
+      (frame ** takenPost) finalPost)
+    (hFail : cpsTripleWithin nFail failExit exit_ cr
+      (frame ** failPost) finalPost) :
+    CFG.Cert entry exit_ cr finalPost := by
+  let br0 := Branch.ofSpec hBranch
+  let br := Branch.frameR br0 frame h_frame
+  let takenCert : CFG.Cert br.exit_t exit_ cr finalPost := CFG.leaf hTaken
+  let failCert : CFG.Cert br.exit_f exit_ cr finalPost := CFG.leaf hFail
+  have h_taken_link : Entails br.post_t takenCert.pre := by
+    intro h hp
+    rw [Branch.frameR_post_t, Branch.ofSpec_post_t] at hp
+    rw [CFG.leaf_pre]
+    xperm_pure hp
+  have h_fail_link : Entails br.post_f failCert.pre := by
+    intro h hp
+    rw [Branch.frameR_post_f, Branch.ofSpec_post_f] at hp
+    rw [CFG.leaf_pre]
+    xperm_pure hp
+  exact CFG.branch br takenCert failCert h_taken_link h_fail_link
 
 /-- Loop shape: a supplied indexed invariant and finite variant produce a
     regular CPS triple whose precondition is `inv 0`. -/

--- a/TACTICS.md
+++ b/TACTICS.md
@@ -111,12 +111,18 @@ register or memory cells, unresolved old values are generalized to `regOwn` or
 `memOwn` precondition atoms. Most users should call `wp_rv64_leaf_synth` on a
 `WP.CFG.Cert` goal instead.
 
+With explicit specs, manual mode treats the arguments as the complete block in
+forward execution order. Do not pass only the hard instructions as hints. If the
+`CodeReq` is concrete and all supplied specs are single-instruction specs,
+`runBlockFromPost` reports a count mismatch when the manual list is shorter or
+longer than the block.
+
 ### Requirements
 
 - Goal must be a `cpsTriple entry exit pre post`
 - **Auto mode**: precondition must contain `instrAt` (`↦ᵢ`) atoms with concrete
   instruction constructors (e.g., `.ADD .x7 .x7 .x6`)
-- **Manual mode**: each argument must be a `cpsTriple` proof
+- **Manual mode**: each argument must be a `cpsTriple` proof, and the argument list covers the complete block unless a composite spec covers multiple instructions
 
 ### Debugging
 
@@ -191,31 +197,32 @@ The current implementation deliberately routes through the existing proved
 remain source-compatible as the chunk partitioning backend evolves; keep using
 plain `xperm_hyp` for ordinary small permutations.
 
-## extract_pure
+## extract_pure_deep and extract_pure
 
-Drains pure (`⌜P⌝`) atoms out of a separation-logic hypothesis so they
-can be obtained directly. Replaces the long `obtain ⟨_, _, _, _, _, h⟩ := h`
-chain that was previously needed to walk past every resource atom to reach
-a buried pure assertion.
+`extract_pure_deep h` drains pure (`⌜P⌝`) atoms out of a separation-logic
+hypothesis so they can be obtained directly. It reaches pure atoms buried
+inside long framed `**` chains, replacing the old hand-written
+`obtain ⟨_, _, _, _, _, h⟩ := h` walks.
 
 ```lean
 example (s : PartialState) (R : Assertion) (P Q : Prop)
     (h : (R ** ⌜P⌝ ** ⌜Q⌝) s) : P ∧ Q := by
-  extract_pure h
+  extract_pure_deep h
   exact ⟨h.1, h.2.1⟩
 ```
 
-After `extract_pure h`, `h` has type `P₁ ∧ … ∧ Pₖ ∧ (resourceTail s)` —
-the pure atoms are exposed as the leading conjuncts. Defined in
-`EvmAsm/Rv64/Tactics/ExtractPure.lean`. Implemented as a `simp only`
-macro using left-associativity normalisation plus the
-`sepConj_pure_left/right/mid_*` iff lemmas.
+After `extract_pure_deep h`, `h` has type
+`P₁ ∧ … ∧ Pₖ ∧ (resourceTail s)`: the pure atoms are exposed as leading
+conjuncts. `extract_pure h` remains available as the shallow compatibility
+pass with the original local shape; use it when maintaining older proofs that
+expect that shape. New WP and CFG automation should use `extract_pure_deep`.
+Both are defined in `EvmAsm/Rv64/Tactics/ExtractPure.lean`.
 
 ## drop_pure
 
-Sibling of `extract_pure` that *discards* the pure atoms instead of
+Sibling of the pure-extraction tactics that *discards* the pure atoms instead of
 exposing them, rebinding the hypothesis to the bare resource tail.
-Useful when the goal has no pure atoms (so neither `extract_pure` +
+Useful when the goal has no pure atoms (so neither `extract_pure_deep` +
 `obtain` nor `xperm_pure` compose cleanly): after `drop_pure h`, a
 follow-up `xperm_hyp h` works directly with no destructuring.
 
@@ -227,7 +234,7 @@ example (s : PartialState) (P : Prop) (R₁ R₂ : Assertion)
 ```
 
 Defined in `EvmAsm/Rv64/Tactics/DropPure.lean`. Reuses
-`extract_pure`'s normalisation lemmas plus a small projection loop
+the pure-extraction normalisation lemmas plus a small projection loop
 that peels `.2` off `h` until no `And` remains.
 
 ## @[spec_gen] and #spec_db

--- a/docs/agents/wp-framework.md
+++ b/docs/agents/wp-framework.md
@@ -86,7 +86,9 @@ theorem spec :
 
    When auto-resolution cannot pick the right instruction specs, pass the same
    already-instantiated specs you would have passed to `runBlock`, in forward
-   execution order:
+   execution order. Supplying any explicit specs switches to manual mode for the
+   whole leaf, so the list must cover the complete block unless one argument is
+   a composite spec for the complete block:
 
    ```lean
    let hAddi := addi_spec_same_within .x5 v imm base (by decide)
@@ -94,7 +96,10 @@ theorem spec :
    ```
 
    Current matching is intentionally conservative: the requested postcondition
-   should expose the atoms produced by the instruction specs. When a registered
+   should expose the atoms produced by the instruction specs. If a concrete
+   leaf has four instructions and you pass three single-instruction specs,
+   `runBlockFromPost` reports that manual mode received the wrong number of
+   specs instead of failing later at the computed exit address. When a registered
    spec has one unresolved old-value atom such as `rd ↦ᵣ vOld` or
    `addr ↦ₘ memOld`, `wp_rv64_leaf_synth` turns it into `regOwn rd` or
    `memOwn addr` automatically. If an unresolved data parameter appears in a
@@ -211,6 +216,7 @@ theorem spec :
 | Need | Constructor or tactic |
 |------|-----------------------|
 | Synthesize a straight-line leaf from postcondition | `wp_rv64_leaf_synth`, `runBlockFromPost` |
+| Expose WP certificate projections in a link goal | `wp_rv64_norm`, projection rewrites such as `WP.Branch.frameR_post_t` and `WP.CFG.leaf_pre` |
 | Lift an exact single-exit CPS proof | `WP.CFG.leaf h`, `wp_rv64_leaf h` |
 | Lift and weaken a CPS proof's postcondition | `WP.CFG.block hpost h` |
 | Empty/reflexive exit certificate | `WP.CFG.exitRefl`, `wp_rv64_exit_refl` |
@@ -435,7 +441,17 @@ caller needs to distinguish it.
   goals usually show which entry, exit, code requirement, or postcondition did
   not infer.
 - If `wp_rv64_link` fails, normalize only the relevant helper definitions with
-  `simp only [rv64_wp]`, then use `xperm` or a small named entailment lemma.
+  `simp only [rv64_wp]`, then use `xperm_pure` or a small named entailment lemma.
+  When the goal contains local projections like `br.post_t h` or `tail.pre h`,
+  rewrite the projection explicitly before permutation. The checked branch-link
+  example in `EvmAsm/Rv64/WP/Examples.lean` uses
+  `rw [WP.Branch.frameR_post_t, WP.Branch.ofSpec_post_t] at hp`, then
+  `rw [WP.CFG.leaf_pre]`, then `xperm_pure hp`.
+- `extract_pure_deep` and `xperm_pure` use a two-phase pure extraction pass.
+  They handle pure facts buried behind framed `**` chains, and `xperm_pure`
+  remains the preferred link tactic when either side contains `⌜...⌝` atoms.
+  `extract_pure` is the shallow compatibility pass for older proofs; do not
+  use it in new WP automation unless preserving that older shape is the point.
 - If a branch join expands a large postcondition, fold it behind an
   `@[irreducible]` helper before asking `xperm` or `wp_rv64_link` to solve it.
 - If a disjointness goal is recurring, add a small `@[rv64_wp_disjoint]` lemma.


### PR DESCRIPTION
Follow-up to merged PR #9562. This branch is now rebased onto current main because #9562 merged and its source branch was removed.\n\n## Summary\n- Split pure extraction into shallow-compatible extract_pure and automation-oriented extract_pure_deep.\n- Route xperm_pure through extract_pure_deep so WP/CFG automation can handle deeply framed pure atoms without forcing downstream extract_pure migrations.\n- Add WP projection normalization lemmas and wp_rv64_norm, plus a branch-link example documenting the current explicit projection rewrite path.\n- Improve runBlockFromPost manual-mode diagnostics for wrong single-instruction spec counts.\n- Update TACTICS.md and docs/agents/wp-framework.md with the new workflow.\n\n## P0 follow-ups\n- Created evm-asm-iigpl.2 for automating Branch/CFG projection links inside wp_rv64_link.\n- Commented remaining work on evm-asm-iigpl, evm-asm-iigpl.1, and evm-asm-39guo.\n\n## Verification\n- rtk lake build EvmAsm.Rv64.Tactics.ExtractPure EvmAsm.Rv64.Tactics.XPermPure EvmAsm.Rv64.Tactics.WP EvmAsm.Rv64.WP.Examples EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1FullV5 EvmAsm.Evm64.DivMod.LimbSpec.Div128Step2FullV5\n- rtk lake build\n- rtk rg -n "sorry|admit|native_decide|bv_decide|set_option maxHeartbeats|set_option maxRecDepth" <modified Lean files>\n\nNote: full build replays an existing LeanRV64D/RiscvExtras deprecation warning unrelated to this branch.