### PR TITLE
feat(wp): automate branch projection links

### DIFF
--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -294,13 +294,22 @@ macro_rules
       `(tactic| solve
         | exact EvmAsm.Rv64.WP.Entails.refl _
         | assumption
-        | intro _ _hp; xperm_pure _hp
-        | intro _ _hp; try rw [EvmAsm.Rv64.WP.Branch.frameR_post_t, EvmAsm.Rv64.WP.Branch.ofSpec_post_t] at _hp; try rw [EvmAsm.Rv64.WP.Branch.frameR_post_f, EvmAsm.Rv64.WP.Branch.ofSpec_post_f] at _hp; try rw [EvmAsm.Rv64.WP.CFG.extendCode_pre]; try rw [EvmAsm.Rv64.WP.CFG.weakenPost_pre]; try rw [EvmAsm.Rv64.WP.CFG.frameR_pre]; try rw [EvmAsm.Rv64.WP.CFG.leaf_pre]; try rw [EvmAsm.Rv64.WP.CFG.block_pre]; xperm_pure _hp
-        | intro _ _hp; dsimp at _hp ⊢; simp only [rv64_wp] at _hp ⊢; xperm_pure _hp
-        | intro _ _hp; wp_rv64_norm at _hp; wp_rv64_norm; xperm_pure _hp
-        | intro _ _hp; try dsimp at _hp ⊢; try simp only [rv64_wp] at _hp ⊢; xperm_pure _hp
-        | intro _ _hp; simp only [rv64_wp] at _hp ⊢; xperm_pure _hp
-        | intro _ _hp; try dsimp at _hp ⊢; xperm_pure _hp
+        | intro h hp; rw [EvmAsm.Rv64.WP.Branch.frameR_post_t, EvmAsm.Rv64.WP.Branch.ofSpec_post_t] at hp; rw [EvmAsm.Rv64.WP.CFG.leaf_pre]; xperm_pure hp
+        | intro h hp; rw [EvmAsm.Rv64.WP.Branch.frameR_post_f, EvmAsm.Rv64.WP.Branch.ofSpec_post_f] at hp; rw [EvmAsm.Rv64.WP.CFG.leaf_pre]; xperm_pure hp
+        | intro h hp; rw [EvmAsm.Rv64.WP.Branch.frameR_post_t, EvmAsm.Rv64.WP.Branch.ofSpec_post_t] at hp; rw [EvmAsm.Rv64.WP.CFG.block_pre]; xperm_pure hp
+        | intro h hp; rw [EvmAsm.Rv64.WP.Branch.frameR_post_f, EvmAsm.Rv64.WP.Branch.ofSpec_post_f] at hp; rw [EvmAsm.Rv64.WP.CFG.block_pre]; xperm_pure hp
+        | intro h hp; rw [EvmAsm.Rv64.WP.Branch.frameR_post_t, EvmAsm.Rv64.WP.Branch.ofSpec_post_t] at hp; rw [EvmAsm.Rv64.WP.CFG.frameR_pre]; xperm_pure hp
+        | intro h hp; rw [EvmAsm.Rv64.WP.Branch.frameR_post_f, EvmAsm.Rv64.WP.Branch.ofSpec_post_f] at hp; rw [EvmAsm.Rv64.WP.CFG.frameR_pre]; xperm_pure hp
+        | intro h hp; rw [EvmAsm.Rv64.WP.Branch.frameR_post_t, EvmAsm.Rv64.WP.Branch.ofSpec_post_t] at hp; rw [EvmAsm.Rv64.WP.CFG.extendCode_pre]; xperm_pure hp
+        | intro h hp; rw [EvmAsm.Rv64.WP.Branch.frameR_post_f, EvmAsm.Rv64.WP.Branch.ofSpec_post_f] at hp; rw [EvmAsm.Rv64.WP.CFG.extendCode_pre]; xperm_pure hp
+        | intro h hp; rw [EvmAsm.Rv64.WP.Branch.frameR_post_t, EvmAsm.Rv64.WP.Branch.ofSpec_post_t] at hp; rw [EvmAsm.Rv64.WP.CFG.weakenPost_pre]; xperm_pure hp
+        | intro h hp; rw [EvmAsm.Rv64.WP.Branch.frameR_post_f, EvmAsm.Rv64.WP.Branch.ofSpec_post_f] at hp; rw [EvmAsm.Rv64.WP.CFG.weakenPost_pre]; xperm_pure hp
+        | intro h hp; dsimp at hp ⊢; simp only [rv64_wp] at hp ⊢; xperm_pure hp
+        | intro h hp; wp_rv64_norm at hp; wp_rv64_norm; xperm_pure hp
+        | intro h hp; try dsimp at hp ⊢; try simp only [rv64_wp] at hp ⊢; xperm_pure hp
+        | intro h hp; simp only [rv64_wp] at hp ⊢; xperm_pure hp
+        | intro h hp; try dsimp at hp ⊢; xperm_pure hp
+        | intro h hp; xperm_pure hp
         | wp_rv64_entails
         | wp_rv64_norm; wp_rv64_entails
         | simp only [rv64_wp]; wp_rv64_entails

--- a/EvmAsm/Rv64/WP/Examples.lean
+++ b/EvmAsm/Rv64/WP/Examples.lean
@@ -80,15 +80,9 @@ example {nBranch nTaken nFail : Nat}
   let takenCert : CFG.Cert br.exit_t exit_ cr finalPost := CFG.leaf hTaken
   let failCert : CFG.Cert br.exit_f exit_ cr finalPost := CFG.leaf hFail
   have h_taken_link : Entails br.post_t takenCert.pre := by
-    intro h hp
-    rw [Branch.frameR_post_t, Branch.ofSpec_post_t] at hp
-    rw [CFG.leaf_pre]
-    xperm_pure hp
+    wp_rv64_link
   have h_fail_link : Entails br.post_f failCert.pre := by
-    intro h hp
-    rw [Branch.frameR_post_f, Branch.ofSpec_post_f] at hp
-    rw [CFG.leaf_pre]
-    xperm_pure hp
+    wp_rv64_link
   exact CFG.branch br takenCert failCert h_taken_link h_fail_link
 
 /-- Loop shape: a supplied indexed invariant and finite variant produce a

--- a/docs/agents/wp-framework.md
+++ b/docs/agents/wp-framework.md
@@ -216,7 +216,7 @@ theorem spec :
 | Need | Constructor or tactic |
 |------|-----------------------|
 | Synthesize a straight-line leaf from postcondition | `wp_rv64_leaf_synth`, `runBlockFromPost` |
-| Expose WP certificate projections in a link goal | `wp_rv64_norm`, projection rewrites such as `WP.Branch.frameR_post_t` and `WP.CFG.leaf_pre` |
+| Close branch/CFG projection links | `wp_rv64_link`; it handles common `WP.Branch.frameR_*`/`WP.Branch.ofSpec_*` posts into CFG preconditions such as `WP.CFG.leaf_pre` |
 | Lift an exact single-exit CPS proof | `WP.CFG.leaf h`, `wp_rv64_leaf h` |
 | Lift and weaken a CPS proof's postcondition | `WP.CFG.block hpost h` |
 | Empty/reflexive exit certificate | `WP.CFG.exitRefl`, `wp_rv64_exit_refl` |
@@ -442,11 +442,11 @@ caller needs to distinguish it.
   not infer.
 - If `wp_rv64_link` fails, normalize only the relevant helper definitions with
   `simp only [rv64_wp]`, then use `xperm_pure` or a small named entailment lemma.
-  When the goal contains local projections like `br.post_t h` or `tail.pre h`,
-  rewrite the projection explicitly before permutation. The checked branch-link
-  example in `EvmAsm/Rv64/WP/Examples.lean` uses
-  `rw [WP.Branch.frameR_post_t, WP.Branch.ofSpec_post_t] at hp`, then
-  `rw [WP.CFG.leaf_pre]`, then `xperm_pure hp`.
+  It already handles the common branch-link projection shape from
+  `WP.Branch.frameR_*`/`WP.Branch.ofSpec_*` posts into CFG preconditions such as
+  `WP.CFG.leaf_pre`. As a debugging fallback, reproduce the projection manually:
+  rewrite the branch post at the hypothesis, rewrite the CFG precondition in the
+  target, then call `xperm_pure hp`.
 - `extract_pure_deep` and `xperm_pure` use a two-phase pure extraction pass.
   They handle pure facts buried behind framed `**` chains, and `xperm_pure`
   remains the preferred link tactic when either side contains `⌜...⌝` atoms.


### PR DESCRIPTION
Stacked on #9563.\n\n## Summary\n- teach `wp_rv64_link` to normalize common Branch.frameR/ofSpec post projections into CFG preconditions before `xperm_pure`\n- update the branch-link example so both taken and fall-through links close with `wp_rv64_link`\n- document the automatic path and keep the manual projection sequence as debugging fallback\n\n## Verification\n- `rtk lake build EvmAsm.Rv64.Tactics.WP EvmAsm.Rv64.WP.Examples`\n- `rtk lake build`\n- `rtk rg -n "sorry|admit|native_decide|bv_decide|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Rv64/Tactics/WP.lean EvmAsm/Rv64/WP/Examples.lean docs/agents/wp-framework.md` (no matches)\n- `rtk git diff --check`