### PR TITLE
feat(wp): support partial leaf synthesis hints

### DIFF
--- a/EvmAsm/Rv64/Tactics/RunBlock.lean
+++ b/EvmAsm/Rv64/Tactics/RunBlock.lean
@@ -1108,6 +1108,85 @@ private def countSingleInstrSpecs? (specs : Array Expr) : MetaM (Option Nat) := 
     count := count + 1
   return some count
 
+private structure SingleInstrHint where
+  proof : Expr
+  addr : Expr
+  instr : Expr
+
+private def singleInstrHint? (spec : Expr) : MetaM (Option SingleInstrHint) := do
+  let specType ← instantiateMVars (← inferType spec)
+  let some (_, _, _, specCr, _, _) ← parseCpsTripleWithin? specType
+    | return none
+  match ← extractCrEntries specCr with
+  | [(addr, instr)] => return some { proof := spec, addr := addr, instr := instr }
+  | _ => return none
+
+private def findHintIdxForInstr (hints : Array (SingleInstrHint × Bool))
+    (addr instr : Expr) : MetaM (Option Nat) := do
+  for i in [:hints.size] do
+    if let some entry := hints[i]? then
+      if entry.2 then
+        let hint := entry.1
+        let isMatch ← withoutModifyingState do
+          withReducible do
+            let addrOk ← isDefEq hint.addr addr
+            if !addrOk then
+              return false
+            isDefEq hint.instr instr
+        if isMatch then
+          return some i
+  return none
+
+private def mkSingleInstrHints (specs : Array Expr) : MetaM (Array (SingleInstrHint × Bool)) := do
+  let mut hints := #[]
+  for spec in specs do
+    let some hint ← singleInstrHint? spec
+      | throwError "runBlockFromPost: partial-hint mode only accepts single-instruction specs.
+          Hint: pass a complete explicit spec list/composite spec, or give only single-instruction hints and let auto mode resolve the rest."
+    hints := hints.push (hint, true)
+  return hints
+
+private def synthesizeSpecsAndPreFromPostWithHints
+    (goalPost goalCr : Expr) (hintSpecs : Array Expr) : MetaM (Array Expr × Expr) := do
+  let instrAtoms ← extractCrEntries goalCr
+  if instrAtoms.isEmpty then
+    throwError "runBlockFromPost: no instructions found in the goal's CodeReq.
+        The CodeReq must contain CodeReq.singleton/union/ofProg entries."
+  let mut hints ← mkSingleInstrHints hintSpecs
+  let mut currentAtoms ← flattenSepConj goalPost
+  let mut specsForward : List Expr := []
+  let mut resolvedCount : Nat := 0
+  let totalCount := instrAtoms.length
+  for (addr, instr) in instrAtoms.reverse do
+    try
+      let spec ←
+        match ← findHintIdxForInstr hints addr instr with
+        | some hintIdx =>
+            let some entry := hints[hintIdx]?
+              | throwError "runBlockFromPost: internal error - selected hint index is out of bounds"
+            let hint := entry.1
+            hints := hints.set! hintIdx (hint, false)
+            trace[runBlock] "post-driven using explicit hint for {instr} at {addr}"
+            Pure.pure hint.proof
+        | none =>
+            resolveSpecForInstrFromPost instr addr currentAtoms
+      currentAtoms ← retreatState currentAtoms spec
+      specsForward := spec :: specsForward
+      resolvedCount := resolvedCount + 1
+    catch e =>
+      let eMsg ← e.toMessageData.format
+      throwError "{eMsg}
+  Progress: resolved {resolvedCount} of {totalCount} bounded instruction spec(s) backwards before failure."
+  for i in [:hints.size] do
+    if let some entry := hints[i]? then
+      if entry.2 then
+        let hint := entry.1
+        throwError "runBlockFromPost: explicit single-instruction hint was not used.
+          Hint CodeReq entry: {hint.addr} ↦ {hint.instr}
+          Hint: make sure the hint's address/instruction appears in the goal CodeReq, or use a complete manual spec list."
+  let pre ← buildSepConjChain currentAtoms
+  return (specsForward.toArray, pre)
+
 private def synthesizeSpecsAndPreFromPost (goalPost goalCr : Expr) : MetaM (Array Expr × Expr) := do
   let instrAtoms ← extractCrEntries goalCr
   if instrAtoms.isEmpty then
@@ -1138,14 +1217,18 @@ private def runBlockFromPostCore (specs : Array Expr) (goalPost goalCr : Expr) :
         try normalizeSpecWithinAddresses spec
         catch _ => Pure.pure spec
       let goalEntries ← extractCrEntries goalCr
-      unless goalEntries.isEmpty do
-        if let some singleInstrCount ← countSingleInstrSpecs? processedSpecs then
-          if singleInstrCount != goalEntries.length then
-            throwError "runBlockFromPost: manual mode received {singleInstrCount} single-instruction spec(s) for {goalEntries.length} instruction(s) in the goal CodeReq.
-              Explicit manual specs are treated as the complete block, not as partial hints.
-              Pass one spec for every instruction in forward execution order, use a composite spec whose CodeReq covers the whole block, or omit all specs to use post-driven auto mode."
-      let synthPre ← synthesizePreFromResolvedSpecs processedSpecs goalPost
-      Pure.pure (processedSpecs, synthPre)
+      if goalEntries.isEmpty then
+        let synthPre ← synthesizePreFromResolvedSpecs processedSpecs goalPost
+        Pure.pure (processedSpecs, synthPre)
+      else if let some singleInstrCount ← countSingleInstrSpecs? processedSpecs then
+        if singleInstrCount == goalEntries.length then
+          let synthPre ← synthesizePreFromResolvedSpecs processedSpecs goalPost
+          Pure.pure (processedSpecs, synthPre)
+        else
+          synthesizeSpecsAndPreFromPostWithHints goalPost goalCr processedSpecs
+      else
+        let synthPre ← synthesizePreFromResolvedSpecs processedSpecs goalPost
+        Pure.pure (processedSpecs, synthPre)
   runBlockWithinCore resolvedSpecs synthPre (goalCr := some goalCr)
 
 private def autoResolveAndComposeWithin (goalPre : Expr) (goalCr : Expr) : MetaM Expr :=
@@ -1259,11 +1342,12 @@ elab "runBlock" specs:ident* : tactic => withMainContext do
 
 /-- Verify a straight-line leaf block by working backwards from the requested
     postcondition.  With no arguments, the tactic resolves registered
-    `@[spec_gen_rv64]` instruction specs from the goal's `CodeReq`; with
-    arguments, it treats them as already-instantiated bounded specs in forward
-    execution order.  The goal may leave the precondition and step bound as
-    metavariables, which lets `WP.CFG.leaf` expose the synthesized precondition
-    as `cfg.pre`. -/
+    `@[spec_gen_rv64]` instruction specs from the goal's `CodeReq`. With a full
+    explicit spec list, it uses those specs in forward execution order. With a
+    shorter list of single-instruction specs, it treats them as hints and
+    resolves the remaining instructions automatically. The goal may leave the
+    precondition and step bound as metavariables, which lets `WP.CFG.leaf`
+    expose the synthesized precondition as `cfg.pre`. -/
 elab "runBlockFromPost" specs:ident* : tactic => withMainContext do
   withTraceNode `runBlock.perf (fun _ => return m!"runBlockFromPost") do
     let mvarGoal ← getMainGoal

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -386,8 +386,9 @@ macro_rules
 
 /-- Build a leaf CFG certificate by working backwards from the requested
     postcondition.  With no arguments, `runBlockFromPost` resolves registered
-    `@[spec_gen_rv64]` specs from the goal's `CodeReq`; with arguments, it uses
-    the supplied bounded specs in forward execution order. -/
+    `@[spec_gen_rv64]` specs from the goal's `CodeReq`; with arguments, a full
+    explicit spec list is manual mode and a shorter single-instruction list is
+    used as partial hints for otherwise automatic synthesis. -/
 syntax (name := wpRv64LeafSynthTac) "wp_rv64_leaf_synth" ident* : tactic
 
 macro_rules
@@ -1292,6 +1293,16 @@ def wp_rv64_leaf_synth_addi_manual_cfg (base v : Word) (imm : BitVec 12) :
 
 example (base v : Word) (imm : BitVec 12) :
     (wp_rv64_leaf_synth_addi_manual_cfg base v imm).pre = (.x5 ↦ᵣ v) := rfl
+
+def wp_rv64_leaf_synth_partial_hint_cfg (base v : Word) (imm : BitVec 12) :
+    EvmAsm.Rv64.WP.CFG.Cert base (base + 8)
+      (CodeReq.ofProg base [(.LI .x5 v), (.ADDI .x5 .x5 imm)])
+      (.x5 ↦ᵣ (v + signExtend12 imm)) := by
+  let hAddi := addi_spec_same_within .x5 v imm (base + 4) (by decide)
+  wp_rv64_leaf_synth hAddi
+
+example (base v : Word) (imm : BitVec 12) :
+    (wp_rv64_leaf_synth_partial_hint_cfg base v imm).pre = regOwn .x5 := rfl
 
 def wp_rv64_leaf_synth_addi_own_cfg (base v : Word) (imm : BitVec 12) :
     EvmAsm.Rv64.WP.CFG.Cert base (base + 4)

--- a/TACTICS.md
+++ b/TACTICS.md
@@ -111,18 +111,18 @@ register or memory cells, unresolved old values are generalized to `regOwn` or
 `memOwn` precondition atoms. Most users should call `wp_rv64_leaf_synth` on a
 `WP.CFG.Cert` goal instead.
 
-With explicit specs, manual mode treats the arguments as the complete block in
-forward execution order. Do not pass only the hard instructions as hints. If the
-`CodeReq` is concrete and all supplied specs are single-instruction specs,
-`runBlockFromPost` reports a count mismatch when the manual list is shorter or
-longer than the block.
+With explicit specs, a full single-instruction list is complete manual mode in
+forward execution order. A shorter list of single-instruction specs is treated as
+partial hints: each hint is matched by address and instruction, while the rest of
+the concrete `CodeReq` is resolved automatically. Composite specs still represent
+the complete block. Unmatched hints are reported with their CodeReq entry.
 
 ### Requirements
 
 - Goal must be a `cpsTriple entry exit pre post`
 - **Auto mode**: precondition must contain `instrAt` (`↦ᵢ`) atoms with concrete
   instruction constructors (e.g., `.ADD .x7 .x7 .x6`)
-- **Manual mode**: each argument must be a `cpsTriple` proof, and the argument list covers the complete block unless a composite spec covers multiple instructions
+- **Manual/hint mode**: each argument must be a `cpsTriple` proof; a full single-instruction list covers the complete block, a shorter single-instruction list gives partial hints, and a composite spec covers the complete block
 
 ### Debugging
 

--- a/docs/agents/wp-framework.md
+++ b/docs/agents/wp-framework.md
@@ -84,22 +84,26 @@ theorem spec :
        (loadConstCfg base imm).pre = regOwn .x5 := rfl
    ```
 
-   When auto-resolution cannot pick the right instruction specs, pass the same
-   already-instantiated specs you would have passed to `runBlock`, in forward
-   execution order. Supplying any explicit specs switches to manual mode for the
-   whole leaf, so the list must cover the complete block unless one argument is
-   a composite spec for the complete block:
+   When auto-resolution cannot pick the right instruction specs, pass
+   already-instantiated single-instruction specs as partial hints. Hints are
+   matched by address and instruction, and the remaining instructions are still
+   resolved backwards from the postcondition. A full single-instruction list is
+   treated as complete manual mode in forward execution order; a composite spec
+   is also treated as the complete block.
 
    ```lean
-   let hAddi := addi_spec_same_within .x5 v imm base (by decide)
+   let hAddi := addi_spec_same_within .x5 v imm (base + 4) (by decide)
    wp_rv64_leaf_synth hAddi
    ```
 
+   In that shape, a two-instruction `CodeReq.ofProg base [LI x5 v, ADDI x5 x5 imm]`
+   can use `hAddi` for the second instruction while auto-resolution computes the
+   predecessor through the first instruction.
+
    Current matching is intentionally conservative: the requested postcondition
-   should expose the atoms produced by the instruction specs. If a concrete
-   leaf has four instructions and you pass three single-instruction specs,
-   `runBlockFromPost` reports that manual mode received the wrong number of
-   specs instead of failing later at the computed exit address. When a registered
+   should expose the atoms produced by the instruction specs. If an explicit
+   single-instruction hint does not match an address/instruction in the goal
+   `CodeReq`, `runBlockFromPost` reports the unused hint. When a registered
    spec has one unresolved old-value atom such as `rd ↦ᵣ vOld` or
    `addr ↦ₘ memOld`, `wp_rv64_leaf_synth` turns it into `regOwn rd` or
    `memOwn addr` automatically. If an unresolved data parameter appears in a


### PR DESCRIPTION
Stacked on #9564.\n\n## Summary\n- allow `runBlockFromPost` to treat shorter explicit single-instruction spec lists as partial hints\n- match hints by CodeReq address/instruction and auto-resolve the remaining leaf instructions from the postcondition\n- add a checked `wp_rv64_leaf_synth` example where an explicit ADDI hint is composed with an automatically resolved LI\n- update `TACTICS.md` and `docs/agents/wp-framework.md` for the new hint mode\n\n## Verification\n- `rtk lake build EvmAsm.Rv64.Tactics.RunBlock EvmAsm.Rv64.Tactics.WP EvmAsm.Rv64.WP.Examples`\n- `rtk lake build`\n- `rtk rg -n "sorry|admit|native_decide|bv_decide|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Rv64/Tactics/RunBlock.lean EvmAsm/Rv64/Tactics/WP.lean TACTICS.md docs/agents/wp-framework.md` (no matches)\n- `rtk git diff --check`