### PR TITLE
feat(wp): add generated branch skeletons

### DIFF
--- a/EvmAsm/Rv64/WP/GeneratedCFG.lean
+++ b/EvmAsm/Rv64/WP/GeneratedCFG.lean
@@ -13,6 +13,42 @@ namespace EvmAsm.Rv64
 namespace WP
 namespace GeneratedCFG
 
+/-- One generated CFG exit as supplied by a control-flow description.  This is
+    intentionally just a label plus the local postcondition at that label; it
+    does not carry decoded runtime result values. -/
+structure ExitSpec where
+  label : Word
+  post : Assertion
+
+/-- A generated two-way branch summary.  `taken` and `fallthrough` are the
+    expected successors and local posts; runtime success/failure information
+    belongs in those posts, not in this shape. -/
+structure Branch2Spec where
+  taken : ExitSpec
+  fallthrough : ExitSpec
+
+namespace Branch2Spec
+
+/-- Exit list represented by a generated two-way branch summary. -/
+def exits (spec : Branch2Spec) : List (Word × Assertion) :=
+  [(spec.taken.label, spec.taken.post),
+    (spec.fallthrough.label, spec.fallthrough.post)]
+
+/-- The kernel branch agrees with the generated two-exit shape. -/
+def Matches {entry : Word} {cr : CodeReq}
+    (spec : Branch2Spec) (br : Branch entry cr) : Prop :=
+  br.exit_t = spec.taken.label ∧ br.post_t = spec.taken.post ∧
+    br.exit_f = spec.fallthrough.label ∧ br.post_f = spec.fallthrough.post
+
+theorem exits_eq_of_matches {entry : Word} {cr : CodeReq}
+    {spec : Branch2Spec} {br : Branch entry cr}
+    (hshape : spec.Matches br) :
+    [(br.exit_t, br.post_t), (br.exit_f, br.post_f)] = spec.exits := by
+  rcases hshape with ⟨h_taken_label, h_taken_post, h_fall_label, h_fall_post⟩
+  simp [exits, h_taken_label, h_taken_post, h_fall_label, h_fall_post]
+
+end Branch2Spec
+
 /-- A generated multi-exit CFG with the expected exit list kept as data.
 
     `cfg` is the kernel-checked certificate. `exits` is the generated
@@ -63,6 +99,17 @@ def ofBranch {entry : Word} {cr : CodeReq} (br : Branch entry cr) :
   cfg := NBranch.ofBranch br
   exits := [(br.exit_t, br.post_t), (br.exit_f, br.post_f)]
   exits_eq := rfl
+
+/-- View a two-way branch through a generated two-exit shape.  The proof only
+    checks that the kernel branch labels/posts match the generated shape; the
+    shape itself carries no decoded result values. -/
+def ofBranchSpec {entry : Word} {cr : CodeReq}
+    (spec : Branch2Spec) (br : Branch entry cr)
+    (hshape : spec.Matches br) : OpenCFG entry cr where
+  cfg := NBranch.ofBranch br
+  exits := spec.exits
+  exits_eq := by
+    exact Branch2Spec.exits_eq_of_matches hshape
 
 @[simp] theorem ofCert_exits {entry exit_ : Word} {cr : CodeReq}
     {post : Assertion} (cfg : CFG.Cert entry exit_ cr post) :
@@ -261,6 +308,41 @@ def join4ResolveThird {entry : Word} {cr : CodeReq} {post : Assertion}
     (Q1 := Q1) (Q2 := Q2) (Q3 := Q3) (Q4 := Q4) g.cfg
     (by simp [g.exits_eq, hexits]) hdead1 hdead2 hlink3 hdead4
 
+end OpenCFG
+
+namespace Branch2Spec
+
+/-- Build an `OpenCFG` branch skeleton from a generated two-exit shape and a
+    kernel-checked branch certificate. -/
+def toOpenCFG {entry : Word} {cr : CodeReq}
+    (spec : Branch2Spec) (br : Branch entry cr)
+    (hshape : spec.Matches br) : OpenCFG entry cr :=
+  OpenCFG.ofBranchSpec spec br hshape
+
+/-- Resolve a generated two-way branch when the taken exit is the reachable
+    join case. -/
+def joinTaken {entry : Word} {cr : CodeReq} {post : Assertion}
+    (spec : Branch2Spec) (br : Branch entry cr)
+    (hshape : spec.Matches br)
+    (hlink : Entails spec.taken.post post)
+    (hdead : ∀ h, spec.fallthrough.post h → False) :
+    CFG.Cert entry spec.taken.label cr post :=
+  (spec.toOpenCFG br hshape).join2ResolveFirst rfl hlink hdead
+
+/-- Resolve a generated two-way branch when the fall-through exit is the
+    reachable join case. -/
+def joinFallthrough {entry : Word} {cr : CodeReq} {post : Assertion}
+    (spec : Branch2Spec) (br : Branch entry cr)
+    (hshape : spec.Matches br)
+    (hdead : ∀ h, spec.taken.post h → False)
+    (hlink : Entails spec.fallthrough.post post) :
+    CFG.Cert entry spec.fallthrough.label cr post :=
+  (spec.toOpenCFG br hshape).join2ResolveSecond rfl hdead hlink
+
+end Branch2Spec
+
+namespace OpenCFG
+
 example {entry : Word} {cr : CodeReq} (br : Branch entry cr) :
     (OpenCFG.ofBranch br).labels = [br.exit_t, br.exit_f] :=
   rfl
@@ -271,6 +353,22 @@ example {entry : Word} {cr : CodeReq} {post : Assertion}
     (hdead : ∀ h, br.post_f h → False) :
     CFG.Cert entry br.exit_t cr post :=
   (OpenCFG.ofBranch br).join2ResolveFirst rfl hlink hdead
+
+example {entry : Word} {cr : CodeReq} {post : Assertion}
+    (spec : Branch2Spec) (br : Branch entry cr)
+    (hshape : spec.Matches br)
+    (hlink : Entails spec.taken.post post)
+    (hdead : ∀ h, spec.fallthrough.post h → False) :
+    CFG.Cert entry spec.taken.label cr post :=
+  spec.joinTaken br hshape hlink hdead
+
+example {entry : Word} {cr : CodeReq} {post : Assertion}
+    (spec : Branch2Spec) (br : Branch entry cr)
+    (hshape : spec.Matches br)
+    (hdead : ∀ h, spec.taken.post h → False)
+    (hlink : Entails spec.fallthrough.post post) :
+    CFG.Cert entry spec.fallthrough.label cr post :=
+  spec.joinFallthrough br hshape hdead hlink
 
 example {entry l : Word} {cr1 cr2 : CodeReq}
     {headPost : Assertion} {others : List (Word × Assertion)}

--- a/docs/agents/wp-framework.md
+++ b/docs/agents/wp-framework.md
@@ -423,6 +423,28 @@ certificate constructors change. The wrapper also provides small-list helpers
 such as `join2ResolveFirst`, `join3ResolveSecond`, and `join4ResolveThird` for
 common decoder joins where all but one exit is contradictory.
 
+For a generated two-way branch, use `Branch2Spec` to keep the expected labels
+and local posts in one typed value, then prove that the kernel branch certificate
+matches that generated shape. The helper can resolve either side as the join:
+
+```lean
+let shape : Branch2Spec := {
+  taken := { label := takenLabel, post := takenPost },
+  fallthrough := { label := failLabel, post := failPost }
+}
+
+have hshape : shape.Matches br := by
+  -- usually `simp [shape, ...projection lemmas...]`
+  ...
+
+let topTaken : WP.CFG.Cert entry shape.taken.label cr finalPost :=
+  shape.joinTaken br hshape hlinkTaken hdeadFail
+```
+
+`Branch2Spec` is still only control-flow shape: labels plus assertion names. Do
+not add decoded values, success booleans, or failure reasons to it. Put runtime
+outcomes inside `takenPost`, `failPost`, or the final disjunctive postcondition.
+
 Bad inputs:
 
 - decoded result values in the schema


### PR DESCRIPTION
Stacked on #9565.

## Summary
- add `Branch2Spec`/`ExitSpec` as typed generated-CFG shapes for two-way branches
- add helpers to wrap a kernel `WP.Branch` through a generated shape and resolve either branch successor as the reachable join
- add checked skeleton examples in `GeneratedCFG.lean`
- document that generated CFG shapes contain labels and assertion names only, with runtime outcomes kept in postconditions

## Verification
- `rtk lake build EvmAsm.Rv64.WP.GeneratedCFG EvmAsm.Rv64.WP EvmAsm.Rv64.Tactics.WP`
- `rtk lake build`
- `rtk rg -n "sorry|admit|native_decide|bv_decide|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Rv64/WP/GeneratedCFG.lean docs/agents/wp-framework.md` (no matches)
- `rtk git diff --check`
