### PR TITLE
fix(wp): report unresolved link entailments

### DIFF
--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -220,19 +220,28 @@ elab "wp_rv64_cert" : tactic => withMainContext do
   unless ← isWpCertLikeGoal goalType do
     throwError "wp_rv64_cert: expected WP.Triple/WP.CFG.Cert, WP.Branch, or WP.NBranch goal"
   let entries := rv64WpCertExt.getState (← getEnv)
+  let mut errors : Array (Name × String) := #[]
   for declName in entries do
     let saved ← saveState
     try
       closeWithWpHint goal declName
       return
-    catch _ =>
+    catch e =>
       restoreState saved
+      let msg ← e.toMessageData.toString
+      errors := errors.push (declName, msg)
       continue
-  throwError m!"wp_rv64_cert: no @[rv64_wp_cert] declaration closed the goal.
+  let mut errMsg := m!"wp_rv64_cert: no @[rv64_wp_cert] declaration closed the goal.
   Tried {entries.size} registered declaration(s).
-  Goal: {goalType}
+  Goal: {goalType}"
+  unless errors.isEmpty do
+    errMsg := errMsg ++ m!"\n  Candidate failures:"
+    for (declName, msg) in errors do
+      errMsg := errMsg ++ m!"\n    {declName}: {msg}"
+  errMsg := errMsg ++ m!"
   Hint: try the intended constructor directly once to expose missing static
   facts, or tag a reusable constructor with @[rv64_wp_cert]."
+  throwError errMsg
 
 attribute [rv64_wp]
   EvmAsm.Rv64.WP.Triple.refl_pre
@@ -1375,6 +1384,18 @@ error: wp_rv64_link: could not close the remaining WP.Entails goal.
 #guard_msgs in
 example {P Q : Assertion} : EvmAsm.Rv64.WP.Entails P Q := by
   wp_rv64_link
+
+/--
+error: wp_rv64_cert: no @[rv64_wp_cert] declaration closed the goal.
+  Tried 0 registered declaration(s).
+  Goal: WP.Triple entry exit_ cr post
+  Hint: try the intended constructor directly once to expose missing static
+  facts, or tag a reusable constructor with @[rv64_wp_cert].
+-/
+#guard_msgs in
+example {entry exit_ : Word} {cr : CodeReq} {post : Assertion} :
+    EvmAsm.Rv64.WP.Triple entry exit_ cr post := by
+  wp_rv64_cert
 
 theorem wp_rv64_dead_test_hint {P : Assertion} (hdead : ∀ h, P h → False) :
     ∀ h, P h → False :=

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -134,6 +134,29 @@ private def closeWithWpHint (goal : MVarId) (declName : Name) : TacticM Unit := 
   goal.assign proof
   replaceMainGoal []
 
+private def appendWpHintFailures (errMsg : MessageData)
+    (errors : Array (Name × String)) : MessageData :=
+  if errors.isEmpty then
+    errMsg
+  else
+    errors.foldl
+      (fun errMsg error => errMsg ++ m!"\n    {error.fst}: {error.snd}")
+      (errMsg ++ m!"\n  Candidate failures:")
+
+private def collectWpHintFailures (goal : MVarId) (entries : Array Name) :
+    TacticM (Array (Name × String)) := do
+  let mut errors : Array (Name × String) := #[]
+  for declName in entries do
+    let saved ← saveState
+    try
+      closeWithWpHint goal declName
+      restoreState saved
+    catch e =>
+      restoreState saved
+      let msg ← e.toMessageData.toString
+      errors := errors.push (declName, msg)
+  return errors
+
 /-- Close a `WP.Entails` goal using declarations tagged with
     `@[rv64_wp_entails]`.  This is deliberately separate from the `rv64_wp` simp
     set: simp exposes the assertion shape, then this tactic applies named
@@ -144,20 +167,24 @@ elab "wp_rv64_entails" : tactic => withMainContext do
   unless goalType.isAppOfArity ``EvmAsm.Rv64.WP.Entails 2 do
     throwError "wp_rv64_entails: expected WP.Entails goal"
   let entries := rv64WpEntailsExt.getState (← getEnv)
+  let mut errors : Array (Name × String) := #[]
   for declName in entries do
     let saved ← saveState
     try
       closeWithWpHint goal declName
       return
-    catch _ =>
+    catch e =>
       restoreState saved
+      let msg ← e.toMessageData.toString
+      errors := errors.push (declName, msg)
       continue
   let goalType ← instantiateMVars (← goal.getType)
-  throwError m!"wp_rv64_entails: no @[rv64_wp_entails] theorem closed the goal.
+  let errMsg := appendWpHintFailures m!"wp_rv64_entails: no @[rv64_wp_entails] theorem closed the goal.
   Tried {entries.size} registered theorem(s).
-  Goal: {goalType}
+  Goal: {goalType}" errors
+  throwError (errMsg ++ m!"
   Hint: add a small @[rv64_wp_entails] lemma, or expose the assertion shape
-  with `simp only [rv64_wp]`."
+  with `simp only [rv64_wp]`.")
 
 /-- Try declarations tagged with `@[rv64_wp_dead]` against the current
     unreachable-exit goal.  Tagged lemmas may have explicit proof arguments;
@@ -168,13 +195,15 @@ elab "wp_rv64_dead_hint" : tactic => withMainContext do
   unless ← isProp goalType do
     throwError "wp_rv64_dead_hint: expected proposition goal"
   let entries := rv64WpDeadExt.getState (← getEnv)
+  let mut errors : Array (Name × String) := #[]
   for declName in entries do
     let saved ← saveState
     try
       closeWithWpHint goal declName
       return
-    catch _ =>
+    catch eHint =>
       restoreState saved
+      let hintMsg ← eHint.toMessageData.toString
       let saved ← saveState
       try
         let hint := mkIdent declName
@@ -182,15 +211,20 @@ elab "wp_rv64_dead_hint" : tactic => withMainContext do
         unless (← getGoals).isEmpty do
           throwError "hint left open goals"
         return
-      catch _ =>
+      catch eApply =>
         restoreState saved
+        let applyMsg ← eApply.toMessageData.toString
+        errors := errors.push
+          (declName, "closeWithWpHint: " ++ hintMsg ++
+            "\n      fallback apply: " ++ applyMsg)
         continue
   let goalType ← instantiateMVars (← goal.getType)
-  throwError m!"wp_rv64_dead_hint: no @[rv64_wp_dead] theorem closed the goal.
+  let errMsg := appendWpHintFailures m!"wp_rv64_dead_hint: no @[rv64_wp_dead] theorem closed the goal.
   Tried {entries.size} registered theorem(s).
-  Goal: {goalType}
+  Goal: {goalType}" errors
+  throwError (errMsg ++ m!"
   Hint: add a contradiction lemma tagged @[rv64_wp_dead], or pass the
-  unreachable proof directly to WP.CFG.unreachable."
+  unreachable proof directly to WP.CFG.unreachable.")
 
 /-- Close an unreachable-exit goal, after exposing small WP definitions if
     needed, using declarations tagged with `@[rv64_wp_dead]`. -/
@@ -234,10 +268,7 @@ elab "wp_rv64_cert" : tactic => withMainContext do
   let mut errMsg := m!"wp_rv64_cert: no @[rv64_wp_cert] declaration closed the goal.
   Tried {entries.size} registered declaration(s).
   Goal: {goalType}"
-  unless errors.isEmpty do
-    errMsg := errMsg ++ m!"\n  Candidate failures:"
-    for (declName, msg) in errors do
-      errMsg := errMsg ++ m!"\n    {declName}: {msg}"
+  errMsg := appendWpHintFailures errMsg errors
   errMsg := errMsg ++ m!"
   Hint: try the intended constructor directly once to expose missing static
   facts, or tag a reusable constructor with @[rv64_wp_cert]."
@@ -306,16 +337,18 @@ elab "wp_rv64_link_fail" : tactic => withMainContext do
   let lhs := goalTypeWhnf.getAppArgs[0]!
   let rhs := goalTypeWhnf.getAppArgs[1]!
   let entries := rv64WpEntailsExt.getState (← getEnv)
-  throwError m!"wp_rv64_link: could not close the remaining WP.Entails goal.
+  let errors ← collectWpHintFailures goal entries
+  let errMsg := appendWpHintFailures m!"wp_rv64_link: could not close the remaining WP.Entails goal.
   Tried reflexivity, local assumptions, Branch/CFG projection rewrites,
   rv64_wp normalization, xperm_pure, and {entries.size} registered
   @[rv64_wp_entails] theorem(s).
   Source: {lhs}
-  Target: {rhs}
+  Target: {rhs}" errors
+  throwError (errMsg ++ m!"
   Hint: inspect whether the source and target differ by a missing projection
   rewrite such as WP.CFG.leaf_pre, by a frame permutation that xperm_pure
   cannot see, or by a reusable semantic bridge that should be tagged
-  @[rv64_wp_entails]."
+  @[rv64_wp_entails].")
 
 /-- Close the midpoint entailment between adjacent WP fragments.  The common
     case is definitional equality of the head postcondition and tail WP; semantic
@@ -364,20 +397,24 @@ private def closeDisjointWithLocal (goal : MVarId) (goalType : Expr) : TacticM B
 
 private def closeDisjointWithHint (goal : MVarId) : TacticM Unit := do
   let entries := rv64WpDisjointExt.getState (← getEnv)
+  let mut errors : Array (Name × String) := #[]
   for declName in entries do
     let saved ← saveState
     try
       closeWithWpHint goal declName
       return
-    catch _ =>
+    catch e =>
       restoreState saved
+      let msg ← e.toMessageData.toString
+      errors := errors.push (declName, msg)
       continue
   let goalType ← instantiateMVars (← goal.getType)
-  throwError m!"wp_rv64_disjoint: no @[rv64_wp_disjoint] theorem closed the goal.
+  let errMsg := appendWpHintFailures m!"wp_rv64_disjoint: no @[rv64_wp_disjoint] theorem closed the goal.
   Tried {entries.size} registered theorem(s).
-  Goal: {goalType}
+  Goal: {goalType}" errors
+  throwError (errMsg ++ m!"
   Hint: add a local disjointness hypothesis or tag a semantic disjointness
-  lemma with @[rv64_wp_disjoint]."
+  lemma with @[rv64_wp_disjoint].")
 
 /-- Close a `CodeReq.Disjoint` goal using local hypotheses, declarations
     tagged with `@[rv64_wp_disjoint]`, or the structural prover shared with
@@ -392,10 +429,11 @@ elab "wp_rv64_disjoint" : tactic => withMainContext do
     throwError "wp_rv64_disjoint: expected CodeReq.Disjoint goal"
   if ← closeDisjointWithLocal goal goalType then
     return
+  let hintEntries := rv64WpDisjointExt.getState (← getEnv)
   let savedHint ← saveState
   try
     closeDisjointWithHint goal
-  catch _ =>
+  catch hintError =>
     restoreState savedHint
     let cr1 := goalType.getAppArgs[0]!
     let cr2 := goalType.getAppArgs[1]!
@@ -404,12 +442,19 @@ elab "wp_rv64_disjoint" : tactic => withMainContext do
       (← getMainGoal).assign proof
       replaceMainGoal []
     catch e =>
-      throwError m!"wp_rv64_disjoint: no local hypothesis, registered hint, or
+      let mut errMsg := m!"wp_rv64_disjoint: no local hypothesis, registered hint, or
   structural proof closed the goal.
   Goal: {goalType}
   Hint: add a local disjointness hypothesis, or tag a semantic disjointness
-  lemma with @[rv64_wp_disjoint].
+  lemma with @[rv64_wp_disjoint]."
+      unless hintEntries.isEmpty do
+        let hintMsg ← hintError.toMessageData.toString
+        errMsg := errMsg ++ m!"
+  Registered hint prover error:
+  {hintMsg}"
+      errMsg := errMsg ++ m!"
   Structural prover error: {← e.toMessageData.toString}"
+      throwError errMsg
 
 /-- Lift a leaf CPS proof whose postcondition already matches the CFG
     postcondition. -/

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -283,6 +283,31 @@ macro_rules
   | `(tactic| wp_rv64_norm at $h:ident) =>
       `(tactic| try dsimp at $h:ident; try simp only [rv64_wp] at $h:ident)
 
+/-- Final diagnostic fallback for `wp_rv64_link`.  It runs only after the
+    concrete link-closing alternatives have failed, so the message names the
+    exact remaining entailment rather than asking the user to rediscover it by
+    replaying constructors manually. -/
+elab "wp_rv64_link_fail" : tactic => withMainContext do
+  let goal ← getMainGoal
+  let goalType ← instantiateMVars (← goal.getType)
+  let goalTypeWhnf ← whnfR goalType
+  unless goalTypeWhnf.isAppOfArity ``EvmAsm.Rv64.WP.Entails 2 do
+    throwError m!"wp_rv64_link: expected WP.Entails goal.
+  Goal: {goalType}"
+  let lhs := goalTypeWhnf.getAppArgs[0]!
+  let rhs := goalTypeWhnf.getAppArgs[1]!
+  let entries := rv64WpEntailsExt.getState (← getEnv)
+  throwError m!"wp_rv64_link: could not close the remaining WP.Entails goal.
+  Tried reflexivity, local assumptions, Branch/CFG projection rewrites,
+  rv64_wp normalization, xperm_pure, and {entries.size} registered
+  @[rv64_wp_entails] theorem(s).
+  Source: {lhs}
+  Target: {rhs}
+  Hint: inspect whether the source and target differ by a missing projection
+  rewrite such as WP.CFG.leaf_pre, by a frame permutation that xperm_pure
+  cannot see, or by a reusable semantic bridge that should be tagged
+  @[rv64_wp_entails]."
+
 /-- Close the midpoint entailment between adjacent WP fragments.  The common
     case is definitional equality of the head postcondition and tail WP; semantic
     bridge lemmas tagged `@[rv64_wp_entails]` handle generated handoff shapes,
@@ -314,7 +339,8 @@ macro_rules
         | wp_rv64_norm; wp_rv64_entails
         | simp only [rv64_wp]; wp_rv64_entails
         | try dsimp; wp_rv64_entails
-        | try dsimp; try simp only [rv64_wp]; wp_rv64_entails)
+        | try dsimp; try simp only [rv64_wp]; wp_rv64_entails
+        | wp_rv64_link_fail)
 
 
 private def closeDisjointWithLocal (goal : MVarId) (goalType : Expr) : TacticM Bool := do
@@ -1332,6 +1358,22 @@ example {entry : Word} {cr : CodeReq} {post : Assertion} :
 
 example {P : Assertion} {A : Prop} (hA : A) :
     EvmAsm.Rv64.WP.Entails P (P ** ⌜A⌝) := by
+  wp_rv64_link
+
+/--
+error: wp_rv64_link: could not close the remaining WP.Entails goal.
+  Tried reflexivity, local assumptions, Branch/CFG projection rewrites,
+  rv64_wp normalization, xperm_pure, and 0 registered
+  @[rv64_wp_entails] theorem(s).
+  Source: P
+  Target: Q
+  Hint: inspect whether the source and target differ by a missing projection
+  rewrite such as WP.CFG.leaf_pre, by a frame permutation that xperm_pure
+  cannot see, or by a reusable semantic bridge that should be tagged
+  @[rv64_wp_entails].
+-/
+#guard_msgs in
+example {P Q : Assertion} : EvmAsm.Rv64.WP.Entails P Q := by
   wp_rv64_link
 
 theorem wp_rv64_dead_test_hint {P : Assertion} (hdead : ∀ h, P h → False) :

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -1364,6 +1364,28 @@ def wp_rv64_leaf_synth_li_cfg (base imm : Word) :
 example (base imm : Word) :
     (wp_rv64_leaf_synth_li_cfg base imm).pre = regOwn .x5 := rfl
 
+/--
+error: runBlockFromPost: no spec could be instantiated backwards for `EvmAsm.Rv64.Instr.LI` at base.
+  Tried 2 candidate(s):
+    EvmAsm.Rv64.li_spec_gen_within: runBlockFromPost: could not match postcondition atom while resolving EvmAsm.Rv64.li_spec_gen_within:
+  EvmAsm.Rv64.Reg.x5 ↦ᵣ imm
+    EvmAsm.Rv64.li_spec_gen_own_within: runBlockFromPost: could not match postcondition atom while resolving EvmAsm.Rv64.li_spec_gen_own_within:
+  EvmAsm.Rv64.Reg.x5 ↦ᵣ imm
+  Hint: strengthen the requested postcondition with the atoms produced by this instruction,
+    use an ownership-style spec for overwritten resources, or pass explicit spec hypotheses.
+  Progress: resolved 0 of 1 bounded instruction spec(s) backwards before failure.
+---
+error: unsolved goals
+base imm : Word
+⊢ WP.CFG.Cert base (base + 4) (CodeReq.singleton base (Instr.LI Reg.x5 imm)) (Reg.x6 ↦ᵣ imm)
+-/
+#guard_msgs in
+example {base imm : Word} :
+    EvmAsm.Rv64.WP.CFG.Cert base (base + 4)
+      (CodeReq.singleton base (.LI .x5 imm))
+      (.x6 ↦ᵣ imm) := by
+  wp_rv64_leaf_synth
+
 def wp_rv64_leaf_synth_addi_manual_cfg (base v : Word) (imm : BitVec 12) :
     EvmAsm.Rv64.WP.CFG.Cert base (base + 4)
       (CodeReq.singleton base (.ADDI .x5 .x5 imm))

--- a/EvmAsm/Rv64/WP/GeneratedCFG.lean
+++ b/EvmAsm/Rv64/WP/GeneratedCFG.lean
@@ -27,6 +27,25 @@ structure Branch2Spec where
   taken : ExitSpec
   fallthrough : ExitSpec
 
+/-- A generated bounded natural-number loop summary.
+
+    The generated shape records labels, step budgets, fuel, and the assertion
+    names used by the loop rule.  Runtime success/failure data still belongs in
+    `post`, `exitPost`, or the invariant assertions, not in the shape fields as
+    decoded values. -/
+structure LoopNatSpec where
+  header : Word
+  bodyEntry : Word
+  exitLabel : Word
+  nHeader : Nat
+  nBody : Nat
+  nExit : Nat
+  fuel : Nat
+  inv : Nat → Assertion
+  bodyPre : Nat → Assertion
+  exitPost : Nat → Assertion
+  post : Assertion
+
 namespace Branch2Spec
 
 /-- Exit list represented by a generated two-way branch summary. -/
@@ -310,6 +329,56 @@ def join4ResolveThird {entry : Word} {cr : CodeReq} {post : Assertion}
 
 end OpenCFG
 
+namespace LoopNatSpec
+
+/-- The generated precondition of a bounded loop shape. -/
+def pre (spec : LoopNatSpec) : Assertion :=
+  spec.inv 0
+
+/-- The generated step bound of a bounded loop shape. -/
+def bound (spec : LoopNatSpec) : Nat :=
+  loopBound spec.nHeader spec.nBody spec.nExit spec.fuel
+
+/-- Package a generated loop shape and the kernel-checked loop obligations as a
+    single-exit CFG certificate. -/
+def toCert (spec : LoopNatSpec) {cr : CodeReq}
+    (hcert : loopNatCert spec.nHeader spec.nBody spec.nExit
+      spec.header spec.bodyEntry spec.exitLabel cr
+      spec.inv spec.bodyPre spec.exitPost spec.post 0 spec.fuel) :
+    CFG.Cert spec.header spec.exitLabel cr spec.post :=
+  CFG.loopNat hcert
+
+/-- View a generated loop shape as an `OpenCFG` with one generated exit. -/
+def toOpenCFG (spec : LoopNatSpec) {cr : CodeReq}
+    (hcert : loopNatCert spec.nHeader spec.nBody spec.nExit
+      spec.header spec.bodyEntry spec.exitLabel cr
+      spec.inv spec.bodyPre spec.exitPost spec.post 0 spec.fuel) :
+    OpenCFG spec.header cr :=
+  OpenCFG.ofCert (spec.toCert hcert)
+
+@[simp] theorem toCert_pre (spec : LoopNatSpec) {cr : CodeReq}
+    (hcert : loopNatCert spec.nHeader spec.nBody spec.nExit
+      spec.header spec.bodyEntry spec.exitLabel cr
+      spec.inv spec.bodyPre spec.exitPost spec.post 0 spec.fuel) :
+    (spec.toCert hcert).pre = spec.pre :=
+  rfl
+
+@[simp] theorem toCert_nSteps (spec : LoopNatSpec) {cr : CodeReq}
+    (hcert : loopNatCert spec.nHeader spec.nBody spec.nExit
+      spec.header spec.bodyEntry spec.exitLabel cr
+      spec.inv spec.bodyPre spec.exitPost spec.post 0 spec.fuel) :
+    (spec.toCert hcert).nSteps = spec.bound :=
+  rfl
+
+@[simp] theorem toOpenCFG_exits (spec : LoopNatSpec) {cr : CodeReq}
+    (hcert : loopNatCert spec.nHeader spec.nBody spec.nExit
+      spec.header spec.bodyEntry spec.exitLabel cr
+      spec.inv spec.bodyPre spec.exitPost spec.post 0 spec.fuel) :
+    (spec.toOpenCFG hcert).exits = [(spec.exitLabel, spec.post)] :=
+  rfl
+
+end LoopNatSpec
+
 namespace Branch2Spec
 
 /-- Build an `OpenCFG` branch skeleton from a generated two-exit shape and a
@@ -379,6 +448,27 @@ example {entry l : Word} {cr1 cr2 : CodeReq}
     (hlink : Entails headPost tail.pre) :
     ((g.seqHeadNBranchDisjoint hd hexits tail hlink).exits =
       tail.exits ++ others) :=
+  rfl
+
+example (spec : LoopNatSpec) {cr : CodeReq}
+    (hcert : loopNatCert spec.nHeader spec.nBody spec.nExit
+      spec.header spec.bodyEntry spec.exitLabel cr
+      spec.inv spec.bodyPre spec.exitPost spec.post 0 spec.fuel) :
+    (spec.toCert hcert).pre = spec.pre :=
+  rfl
+
+example (spec : LoopNatSpec) {cr : CodeReq}
+    (hcert : loopNatCert spec.nHeader spec.nBody spec.nExit
+      spec.header spec.bodyEntry spec.exitLabel cr
+      spec.inv spec.bodyPre spec.exitPost spec.post 0 spec.fuel) :
+    (spec.toCert hcert).nSteps = spec.bound :=
+  rfl
+
+example (spec : LoopNatSpec) {cr : CodeReq}
+    (hcert : loopNatCert spec.nHeader spec.nBody spec.nExit
+      spec.header spec.bodyEntry spec.exitLabel cr
+      spec.inv spec.bodyPre spec.exitPost spec.post 0 spec.fuel) :
+    (spec.toOpenCFG hcert).exits = [(spec.exitLabel, spec.post)] :=
   rfl
 
 end OpenCFG

--- a/docs/agents/wp-framework.md
+++ b/docs/agents/wp-framework.md
@@ -466,13 +466,14 @@ caller needs to distinguish it.
 - If a constructor still does not infer, try it directly once. The resulting
   goals usually show which entry, exit, code requirement, or postcondition did
   not infer.
-- If `wp_rv64_link` fails, normalize only the relevant helper definitions with
-  `simp only [rv64_wp]`, then use `xperm_pure` or a small named entailment lemma.
-  It already handles the common branch-link projection shape from
-  `WP.Branch.frameR_*`/`WP.Branch.ofSpec_*` posts into CFG preconditions such as
-  `WP.CFG.leaf_pre`. As a debugging fallback, reproduce the projection manually:
-  rewrite the branch post at the hypothesis, rewrite the CFG precondition in the
-  target, then call `xperm_pure hp`.
+- If `wp_rv64_link` fails, read the `Source:` and `Target:` assertions in the
+  diagnostic before changing the proof. Normalize only the relevant helper
+  definitions with `simp only [rv64_wp]`, then use `xperm_pure` or a small named
+  entailment lemma. It already handles the common branch-link projection shape
+  from `WP.Branch.frameR_*`/`WP.Branch.ofSpec_*` posts into CFG preconditions
+  such as `WP.CFG.leaf_pre`. As a debugging fallback, reproduce the projection
+  manually: rewrite the branch post at the hypothesis, rewrite the CFG
+  precondition in the target, then call `xperm_pure hp`.
 - `extract_pure_deep` and `xperm_pure` use a two-phase pure extraction pass.
   They handle pure facts buried behind framed `**` chains, and `xperm_pure`
   remains the preferred link tactic when either side contains `⌜...⌝` atoms.

--- a/docs/agents/wp-framework.md
+++ b/docs/agents/wp-framework.md
@@ -462,7 +462,10 @@ caller needs to distinguish it.
 - If a generated precondition is unclear, inspect `#wp_rv64 cfg`.
 - If `wp_rv64_cert`, `wp_rv64_link`, `wp_rv64_dead`, or `wp_rv64_disjoint`
   fails, read the diagnostic first. It reports the goal shape, how many
-  registered hints were tried, and the usual next action.
+  registered hints were tried, and the usual next action. When registered
+  certificate constructors were tried, `wp_rv64_cert` also reports each
+  candidate failure, such as a result-shape mismatch or an uninferable static
+  side condition.
 - If a constructor still does not infer, try it directly once. The resulting
   goals usually show which entry, exit, code requirement, or postcondition did
   not infer.

--- a/docs/agents/wp-framework.md
+++ b/docs/agents/wp-framework.md
@@ -108,7 +108,9 @@ theorem spec :
    `addr ↦ₘ memOld`, `wp_rv64_leaf_synth` turns it into `regOwn rd` or
    `memOwn addr` automatically. If an unresolved data parameter appears in a
    computed address, in the postcondition, or in more than one atom, pass an
-   explicit spec.
+   explicit spec. When synthesis fails, the diagnostic names the instruction,
+   address, candidate specs, missing postcondition atom, and how many bounded
+   instructions were resolved before the failure.
 
    ```lean
    def addiOwnCfg (base v : Word) (imm : BitVec 12) :

--- a/docs/agents/wp-framework.md
+++ b/docs/agents/wp-framework.md
@@ -463,9 +463,10 @@ caller needs to distinguish it.
 - If `wp_rv64_cert`, `wp_rv64_link`, `wp_rv64_dead`, or `wp_rv64_disjoint`
   fails, read the diagnostic first. It reports the goal shape, how many
   registered hints were tried, and the usual next action. When registered
-  certificate constructors were tried, `wp_rv64_cert` also reports each
-  candidate failure, such as a result-shape mismatch or an uninferable static
-  side condition.
+  hints were tried, the final diagnostic reports each candidate failure, such
+  as a result-shape mismatch, unresolved metavariables, or an uninferable
+  static side condition. For `wp_rv64_disjoint`, the final failure also keeps
+  the structural prover error after the registered-hint summary.
 - If a constructor still does not infer, try it directly once. The resulting
   goals usually show which entry, exit, code requirement, or postcondition did
   not infer.

--- a/docs/agents/wp-framework.md
+++ b/docs/agents/wp-framework.md
@@ -445,6 +445,45 @@ let topTaken : WP.CFG.Cert entry shape.taken.label cr finalPost :=
 not add decoded values, success booleans, or failure reasons to it. Put runtime
 outcomes inside `takenPost`, `failPost`, or the final disjunctive postcondition.
 
+For a generated bounded loop, use `LoopNatSpec` to keep the generated labels,
+budgets, fuel, invariant names, and local posts together. The actual loop proof
+is still the explicit kernel-checked `WP.loopNatCert`; the generated wrapper
+only packages that proof as a `WP.CFG.Cert` or one-exit `OpenCFG` and exposes
+the computed precondition and bound:
+
+```lean
+let loopShape : LoopNatSpec := {
+  header := headerLabel,
+  bodyEntry := bodyLabel,
+  exitLabel := exitLabel,
+  nHeader := nHeader,
+  nBody := nBody,
+  nExit := nExit,
+  fuel := fuel,
+  inv := inv,
+  bodyPre := bodyPre,
+  exitPost := exitPost,
+  post := finalPost
+}
+
+have hLoop :
+    WP.loopNatCert loopShape.nHeader loopShape.nBody loopShape.nExit
+      loopShape.header loopShape.bodyEntry loopShape.exitLabel cr
+      loopShape.inv loopShape.bodyPre loopShape.exitPost loopShape.post
+      0 loopShape.fuel := by
+  -- prove the header branch, body progress, exit-post handoff, and tail
+  ...
+
+let loopCfg : WP.CFG.Cert loopShape.header loopShape.exitLabel cr loopShape.post :=
+  loopShape.toCert hLoop
+
+example : loopCfg.pre = loopShape.pre := rfl
+```
+
+`LoopNatSpec` does not infer invariants or decide which runtime exit occurs.
+It is a generated-control-flow record for the labels and assertion families the
+proof producer already chose.
+
 Bad inputs:
 
 - decoded result values in the schema


### PR DESCRIPTION
Stacked on #9566.

## Summary
- add a final `wp_rv64_link` diagnostic fallback that reports the unresolved `Source:` and `Target:` assertions
- include the tactics already tried: reflexivity, assumptions, Branch/CFG projection rewrites, `rv64_wp` normalization, `xperm_pure`, and registered `@[rv64_wp_entails]` lemmas
- add a checked `#guard_msgs` regression for the diagnostic
- update the WP troubleshooting docs to start from the printed source/target assertions

## Verification
- `rtk lake build EvmAsm.Rv64.Tactics.WP`
- `rtk lake build`
- `rtk rg -n "sorry|admit|native_decide|bv_decide|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Rv64/Tactics/WP.lean docs/agents/wp-framework.md` (no matches)
- `rtk git diff --check`
