### PR TITLE
fix(wp): summarize certificate hint failures

### DIFF
--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -220,19 +220,28 @@ elab "wp_rv64_cert" : tactic => withMainContext do
   unless ← isWpCertLikeGoal goalType do
     throwError "wp_rv64_cert: expected WP.Triple/WP.CFG.Cert, WP.Branch, or WP.NBranch goal"
   let entries := rv64WpCertExt.getState (← getEnv)
+  let mut errors : Array (Name × String) := #[]
   for declName in entries do
     let saved ← saveState
     try
       closeWithWpHint goal declName
       return
-    catch _ =>
+    catch e =>
       restoreState saved
+      let msg ← e.toMessageData.toString
+      errors := errors.push (declName, msg)
       continue
-  throwError m!"wp_rv64_cert: no @[rv64_wp_cert] declaration closed the goal.
+  let mut errMsg := m!"wp_rv64_cert: no @[rv64_wp_cert] declaration closed the goal.
   Tried {entries.size} registered declaration(s).
-  Goal: {goalType}
+  Goal: {goalType}"
+  unless errors.isEmpty do
+    errMsg := errMsg ++ m!"\n  Candidate failures:"
+    for (declName, msg) in errors do
+      errMsg := errMsg ++ m!"\n    {declName}: {msg}"
+  errMsg := errMsg ++ m!"
   Hint: try the intended constructor directly once to expose missing static
   facts, or tag a reusable constructor with @[rv64_wp_cert]."
+  throwError errMsg
 
 attribute [rv64_wp]
   EvmAsm.Rv64.WP.Triple.refl_pre
@@ -1375,6 +1384,18 @@ error: wp_rv64_link: could not close the remaining WP.Entails goal.
 #guard_msgs in
 example {P Q : Assertion} : EvmAsm.Rv64.WP.Entails P Q := by
   wp_rv64_link
+
+/--
+error: wp_rv64_cert: no @[rv64_wp_cert] declaration closed the goal.
+  Tried 0 registered declaration(s).
+  Goal: WP.Triple entry exit_ cr post
+  Hint: try the intended constructor directly once to expose missing static
+  facts, or tag a reusable constructor with @[rv64_wp_cert].
+-/
+#guard_msgs in
+example {entry exit_ : Word} {cr : CodeReq} {post : Assertion} :
+    EvmAsm.Rv64.WP.Triple entry exit_ cr post := by
+  wp_rv64_cert
 
 theorem wp_rv64_dead_test_hint {P : Assertion} (hdead : ∀ h, P h → False) :
     ∀ h, P h → False :=

--- a/docs/agents/wp-framework.md
+++ b/docs/agents/wp-framework.md
@@ -462,7 +462,10 @@ caller needs to distinguish it.
 - If a generated precondition is unclear, inspect `#wp_rv64 cfg`.
 - If `wp_rv64_cert`, `wp_rv64_link`, `wp_rv64_dead`, or `wp_rv64_disjoint`
   fails, read the diagnostic first. It reports the goal shape, how many
-  registered hints were tried, and the usual next action.
+  registered hints were tried, and the usual next action. When registered
+  certificate constructors were tried, `wp_rv64_cert` also reports each
+  candidate failure, such as a result-shape mismatch or an uninferable static
+  side condition.
 - If a constructor still does not infer, try it directly once. The resulting
   goals usually show which entry, exit, code requirement, or postcondition did
   not infer.


### PR DESCRIPTION
Stacked on #9567.

## Summary
- collect and report per-candidate `wp_rv64_cert` hint failures instead of discarding them
- keep the existing goal shape, hint count, and next-action guidance in the final diagnostic
- add a checked `#guard_msgs` regression for the empty certificate database path
- update WP troubleshooting docs for the richer certificate diagnostic

## Verification
- `rtk lake build EvmAsm.Rv64.Tactics.WP`
- `rtk lake build`
- `rtk rg -n "sorry|admit|native_decide|bv_decide|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Rv64/Tactics/WP.lean docs/agents/wp-framework.md` (no matches)
- `rtk git diff --check`
- temporary `/tmp` probe with a deliberately wrong `[rv64_wp_cert]` hint confirmed `Candidate failures:` lists the declaration and reason
