### PR TITLE
feat(wp): add generated loop skeletons

### DIFF
--- a/EvmAsm/Rv64/WP/GeneratedCFG.lean
+++ b/EvmAsm/Rv64/WP/GeneratedCFG.lean
@@ -27,6 +27,25 @@ structure Branch2Spec where
   taken : ExitSpec
   fallthrough : ExitSpec
 
+/-- A generated bounded natural-number loop summary.
+
+    The generated shape records labels, step budgets, fuel, and the assertion
+    names used by the loop rule.  Runtime success/failure data still belongs in
+    `post`, `exitPost`, or the invariant assertions, not in the shape fields as
+    decoded values. -/
+structure LoopNatSpec where
+  header : Word
+  bodyEntry : Word
+  exitLabel : Word
+  nHeader : Nat
+  nBody : Nat
+  nExit : Nat
+  fuel : Nat
+  inv : Nat → Assertion
+  bodyPre : Nat → Assertion
+  exitPost : Nat → Assertion
+  post : Assertion
+
 namespace Branch2Spec
 
 /-- Exit list represented by a generated two-way branch summary. -/
@@ -310,6 +329,56 @@ def join4ResolveThird {entry : Word} {cr : CodeReq} {post : Assertion}
 
 end OpenCFG
 
+namespace LoopNatSpec
+
+/-- The generated precondition of a bounded loop shape. -/
+def pre (spec : LoopNatSpec) : Assertion :=
+  spec.inv 0
+
+/-- The generated step bound of a bounded loop shape. -/
+def bound (spec : LoopNatSpec) : Nat :=
+  loopBound spec.nHeader spec.nBody spec.nExit spec.fuel
+
+/-- Package a generated loop shape and the kernel-checked loop obligations as a
+    single-exit CFG certificate. -/
+def toCert (spec : LoopNatSpec) {cr : CodeReq}
+    (hcert : loopNatCert spec.nHeader spec.nBody spec.nExit
+      spec.header spec.bodyEntry spec.exitLabel cr
+      spec.inv spec.bodyPre spec.exitPost spec.post 0 spec.fuel) :
+    CFG.Cert spec.header spec.exitLabel cr spec.post :=
+  CFG.loopNat hcert
+
+/-- View a generated loop shape as an `OpenCFG` with one generated exit. -/
+def toOpenCFG (spec : LoopNatSpec) {cr : CodeReq}
+    (hcert : loopNatCert spec.nHeader spec.nBody spec.nExit
+      spec.header spec.bodyEntry spec.exitLabel cr
+      spec.inv spec.bodyPre spec.exitPost spec.post 0 spec.fuel) :
+    OpenCFG spec.header cr :=
+  OpenCFG.ofCert (spec.toCert hcert)
+
+@[simp] theorem toCert_pre (spec : LoopNatSpec) {cr : CodeReq}
+    (hcert : loopNatCert spec.nHeader spec.nBody spec.nExit
+      spec.header spec.bodyEntry spec.exitLabel cr
+      spec.inv spec.bodyPre spec.exitPost spec.post 0 spec.fuel) :
+    (spec.toCert hcert).pre = spec.pre :=
+  rfl
+
+@[simp] theorem toCert_nSteps (spec : LoopNatSpec) {cr : CodeReq}
+    (hcert : loopNatCert spec.nHeader spec.nBody spec.nExit
+      spec.header spec.bodyEntry spec.exitLabel cr
+      spec.inv spec.bodyPre spec.exitPost spec.post 0 spec.fuel) :
+    (spec.toCert hcert).nSteps = spec.bound :=
+  rfl
+
+@[simp] theorem toOpenCFG_exits (spec : LoopNatSpec) {cr : CodeReq}
+    (hcert : loopNatCert spec.nHeader spec.nBody spec.nExit
+      spec.header spec.bodyEntry spec.exitLabel cr
+      spec.inv spec.bodyPre spec.exitPost spec.post 0 spec.fuel) :
+    (spec.toOpenCFG hcert).exits = [(spec.exitLabel, spec.post)] :=
+  rfl
+
+end LoopNatSpec
+
 namespace Branch2Spec
 
 /-- Build an `OpenCFG` branch skeleton from a generated two-exit shape and a
@@ -379,6 +448,27 @@ example {entry l : Word} {cr1 cr2 : CodeReq}
     (hlink : Entails headPost tail.pre) :
     ((g.seqHeadNBranchDisjoint hd hexits tail hlink).exits =
       tail.exits ++ others) :=
+  rfl
+
+example (spec : LoopNatSpec) {cr : CodeReq}
+    (hcert : loopNatCert spec.nHeader spec.nBody spec.nExit
+      spec.header spec.bodyEntry spec.exitLabel cr
+      spec.inv spec.bodyPre spec.exitPost spec.post 0 spec.fuel) :
+    (spec.toCert hcert).pre = spec.pre :=
+  rfl
+
+example (spec : LoopNatSpec) {cr : CodeReq}
+    (hcert : loopNatCert spec.nHeader spec.nBody spec.nExit
+      spec.header spec.bodyEntry spec.exitLabel cr
+      spec.inv spec.bodyPre spec.exitPost spec.post 0 spec.fuel) :
+    (spec.toCert hcert).nSteps = spec.bound :=
+  rfl
+
+example (spec : LoopNatSpec) {cr : CodeReq}
+    (hcert : loopNatCert spec.nHeader spec.nBody spec.nExit
+      spec.header spec.bodyEntry spec.exitLabel cr
+      spec.inv spec.bodyPre spec.exitPost spec.post 0 spec.fuel) :
+    (spec.toOpenCFG hcert).exits = [(spec.exitLabel, spec.post)] :=
   rfl
 
 end OpenCFG

--- a/docs/agents/wp-framework.md
+++ b/docs/agents/wp-framework.md
@@ -445,6 +445,45 @@ let topTaken : WP.CFG.Cert entry shape.taken.label cr finalPost :=
 not add decoded values, success booleans, or failure reasons to it. Put runtime
 outcomes inside `takenPost`, `failPost`, or the final disjunctive postcondition.
 
+For a generated bounded loop, use `LoopNatSpec` to keep the generated labels,
+budgets, fuel, invariant names, and local posts together. The actual loop proof
+is still the explicit kernel-checked `WP.loopNatCert`; the generated wrapper
+only packages that proof as a `WP.CFG.Cert` or one-exit `OpenCFG` and exposes
+the computed precondition and bound:
+
+```lean
+let loopShape : LoopNatSpec := {
+  header := headerLabel,
+  bodyEntry := bodyLabel,
+  exitLabel := exitLabel,
+  nHeader := nHeader,
+  nBody := nBody,
+  nExit := nExit,
+  fuel := fuel,
+  inv := inv,
+  bodyPre := bodyPre,
+  exitPost := exitPost,
+  post := finalPost
+}
+
+have hLoop :
+    WP.loopNatCert loopShape.nHeader loopShape.nBody loopShape.nExit
+      loopShape.header loopShape.bodyEntry loopShape.exitLabel cr
+      loopShape.inv loopShape.bodyPre loopShape.exitPost loopShape.post
+      0 loopShape.fuel := by
+  -- prove the header branch, body progress, exit-post handoff, and tail
+  ...
+
+let loopCfg : WP.CFG.Cert loopShape.header loopShape.exitLabel cr loopShape.post :=
+  loopShape.toCert hLoop
+
+example : loopCfg.pre = loopShape.pre := rfl
+```
+
+`LoopNatSpec` does not infer invariants or decide which runtime exit occurs.
+It is a generated-control-flow record for the labels and assertion families the
+proof producer already chose.
+
 Bad inputs:
 
 - decoded result values in the schema


### PR DESCRIPTION
Stacked on #9569.

## Summary
- add `WP.GeneratedCFG.LoopNatSpec` for generated bounded-loop control-flow shapes
- package explicit kernel-checked `WP.loopNatCert` proofs as `WP.CFG.Cert` or one-exit `OpenCFG` values
- expose generated loop `pre` and `bound` projections with checked examples
- document how proof-producing agents should supply loop labels, budgets, fuel, and assertion families without putting decoded runtime outcomes in the schema

## Verification
- `rtk lake build EvmAsm.Rv64.WP.GeneratedCFG`
- `rtk lake build`
- `rtk rg -n "sorry|admit|native_decide|bv_decide|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Rv64/WP/GeneratedCFG.lean docs/agents/wp-framework.md` (no matches)
- `rtk git diff --check`
