### PR TITLE
test(wp): guard leaf synthesis diagnostics

### DIFF
--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -1364,6 +1364,28 @@ def wp_rv64_leaf_synth_li_cfg (base imm : Word) :
 example (base imm : Word) :
     (wp_rv64_leaf_synth_li_cfg base imm).pre = regOwn .x5 := rfl
 
+/--
+error: runBlockFromPost: no spec could be instantiated backwards for `EvmAsm.Rv64.Instr.LI` at base.
+  Tried 2 candidate(s):
+    EvmAsm.Rv64.li_spec_gen_within: runBlockFromPost: could not match postcondition atom while resolving EvmAsm.Rv64.li_spec_gen_within:
+  EvmAsm.Rv64.Reg.x5 ↦ᵣ imm
+    EvmAsm.Rv64.li_spec_gen_own_within: runBlockFromPost: could not match postcondition atom while resolving EvmAsm.Rv64.li_spec_gen_own_within:
+  EvmAsm.Rv64.Reg.x5 ↦ᵣ imm
+  Hint: strengthen the requested postcondition with the atoms produced by this instruction,
+    use an ownership-style spec for overwritten resources, or pass explicit spec hypotheses.
+  Progress: resolved 0 of 1 bounded instruction spec(s) backwards before failure.
+---
+error: unsolved goals
+base imm : Word
+⊢ WP.CFG.Cert base (base + 4) (CodeReq.singleton base (Instr.LI Reg.x5 imm)) (Reg.x6 ↦ᵣ imm)
+-/
+#guard_msgs in
+example {base imm : Word} :
+    EvmAsm.Rv64.WP.CFG.Cert base (base + 4)
+      (CodeReq.singleton base (.LI .x5 imm))
+      (.x6 ↦ᵣ imm) := by
+  wp_rv64_leaf_synth
+
 def wp_rv64_leaf_synth_addi_manual_cfg (base v : Word) (imm : BitVec 12) :
     EvmAsm.Rv64.WP.CFG.Cert base (base + 4)
       (CodeReq.singleton base (.ADDI .x5 .x5 imm))

--- a/docs/agents/wp-framework.md
+++ b/docs/agents/wp-framework.md
@@ -108,7 +108,9 @@ theorem spec :
    `addr ↦ₘ memOld`, `wp_rv64_leaf_synth` turns it into `regOwn rd` or
    `memOwn addr` automatically. If an unresolved data parameter appears in a
    computed address, in the postcondition, or in more than one atom, pass an
-   explicit spec.
+   explicit spec. When synthesis fails, the diagnostic names the instruction,
+   address, candidate specs, missing postcondition atom, and how many bounded
+   instructions were resolved before the failure.
 
    ```lean
    def addiOwnCfg (base v : Word) (imm : BitVec 12) :


### PR DESCRIPTION
Stacked on #9570.

## Summary
- add a checked `#guard_msgs` regression for a failing `wp_rv64_leaf_synth` postcondition
- lock in the diagnostic that names the instruction, address, candidate specs, missing postcondition atom, hint, and resolved-instruction progress
- document the leaf synthesis failure diagnostic in the WP framework guide

## Verification
- `rtk lake build EvmAsm.Rv64.Tactics.WP`
- `rtk lake build`
- `rtk rg -n "sorry|admit|native_decide|bv_decide|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Rv64/Tactics/WP.lean docs/agents/wp-framework.md` (no matches)
- `rtk git diff --check`
