### PR TITLE
test(wp): cover ADD ownership synthesis

### DIFF
--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -1416,6 +1416,16 @@ example (base v : Word) (imm : BitVec 12) :
     (wp_rv64_leaf_synth_addi_own_cfg base v imm).pre =
       ((.x5 ↦ᵣ v) ** regOwn .x6) := rfl
 
+def wp_rv64_leaf_synth_add_own_cfg (base v1 v2 : Word) :
+    EvmAsm.Rv64.WP.CFG.Cert base (base + 4)
+      (CodeReq.singleton base (.ADD .x7 .x5 .x6))
+      ((.x5 ↦ᵣ v1) ** (.x6 ↦ᵣ v2) ** (.x7 ↦ᵣ (v1 + v2))) := by
+  wp_rv64_leaf_synth
+
+example (base v1 v2 : Word) :
+    (wp_rv64_leaf_synth_add_own_cfg base v1 v2).pre =
+      ((.x5 ↦ᵣ v1) ** (.x6 ↦ᵣ v2) ** regOwn .x7) := rfl
+
 def wp_rv64_leaf_synth_sd_own_cfg (base addr data : Word) (offset : BitVec 12) :
     EvmAsm.Rv64.WP.CFG.Cert base (base + 4)
       (CodeReq.singleton base (.SD .x5 .x6 offset))

--- a/docs/agents/wp-framework.md
+++ b/docs/agents/wp-framework.md
@@ -123,8 +123,9 @@ theorem spec :
        (addiOwnCfg base v imm).pre = ((.x5 ↦ᵣ v) ** regOwn .x6) := rfl
    ```
 
-   The checked examples in `EvmAsm.Rv64.Tactics.WP` also include an `SD`
-   leaf whose old memory cell is synthesized as `memOwn`.
+   The checked examples in `EvmAsm.Rv64.Tactics.WP` also include an all-distinct
+   `ADD` leaf whose clobbered destination is synthesized as `regOwn`, and an
+   `SD` leaf whose old memory cell is synthesized as `memOwn`.
 
 3. Prove remaining leaf blocks with existing tools.
 


### PR DESCRIPTION
Stacked on #9571.

## Summary
- add a checked all-distinct `ADD` leaf example for post-driven WP synthesis
- show the generic old-value ownership path turns the clobbered destination into `regOwn .x7`
- document that checked examples now cover ADD-style register clobbers as well as ADDI and stores

## Verification
- `rtk lake build EvmAsm.Rv64.Tactics.WP`
- `rtk lake build`
- `rtk rg -n "sorry|admit|native_decide|bv_decide|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Rv64/Tactics/WP.lean docs/agents/wp-framework.md` (no matches)
- `rtk git diff --check`
