### PR TITLE
feat(wp): trace leaf synthesis successes

### DIFF
--- a/EvmAsm/Rv64/Tactics/RunBlock.lean
+++ b/EvmAsm/Rv64/Tactics/RunBlock.lean
@@ -64,6 +64,7 @@ import EvmAsm.Rv64.Tactics.SpecDb
 open Lean Meta Elab Tactic
 
 initialize registerTraceClass `runBlock (inherited := true)
+initialize registerTraceClass `runBlock.leafSynth (inherited := true)
 
 namespace EvmAsm.Rv64.Tactics
 
@@ -844,6 +845,10 @@ private def OwnershipKind.key : OwnershipKind → Expr
   | .reg r => r
   | .mem addr => addr
 
+private def OwnershipKind.traceMsg : OwnershipKind → MetaM MessageData
+  | .reg r => return m!"regOwn {← instantiateMVars r}"
+  | .mem addr => return m!"memOwn {← instantiateMVars addr}"
+
 private def isExactMVar (mvarId : MVarId) (e : Expr) : Bool :=
   let e := e.consumeMData
   e.isMVar && e.mvarId! == mvarId
@@ -943,6 +948,7 @@ private partial def generalizeOwnershipParams (proof : Expr) (params : Array Exp
     let some (idx, kind) ← findOwnershipGeneralization? mvarId preAtoms post
       | throwError "post matched but left data parameter unconstrained: {paramType}
           Hint: unsupported unresolved data parameters must occur exactly as one old `regIs`/`memIs` value in the precondition and nowhere in the postcondition; otherwise pass an explicit spec."
+    trace[runBlock.leafSynth] "synthesized {← kind.traceMsg} for old-value parameter of type {paramType}"
     let (frame, orderedPre, single) ← orderPreForOwnership preAtoms idx
     let reordered ← reorderPreForOwnership result orderedPre
     result ← applyOwnershipGeneralization reordered mvarId kind frame single
@@ -1009,6 +1015,7 @@ private def resolveSpecForInstrFromPost (instrExpr instrAddr : Expr)
     try
       let result ← tryInstantiateSpecFromPost entry.specName instrExpr instrAddr currentAtoms
       trace[runBlock] "  post-driven resolved with {entry.specName}"
+      trace[runBlock.leafSynth] "matched {entry.specName} for {instrName} at {instrAddr}"
       return result
     catch e =>
       restoreState saved
@@ -1185,6 +1192,7 @@ private def synthesizeSpecsAndPreFromPostWithHints
           Hint CodeReq entry: {hint.addr} ↦ {hint.instr}
           Hint: make sure the hint's address/instruction appears in the goal CodeReq, or use a complete manual spec list."
   let pre ← buildSepConjChain currentAtoms
+  trace[runBlock.leafSynth] "synthesized predecessor assertion:\n  {pre}"
   return (specsForward.toArray, pre)
 
 private def synthesizeSpecsAndPreFromPost (goalPost goalCr : Expr) : MetaM (Array Expr × Expr) := do
@@ -1206,6 +1214,7 @@ private def synthesizeSpecsAndPreFromPost (goalPost goalCr : Expr) : MetaM (Arra
       let eMsg ← e.toMessageData.format
       throwError "{eMsg}\n  Progress: resolved {resolvedCount} of {totalCount} bounded instruction spec(s) backwards before failure."
   let pre ← buildSepConjChain currentAtoms
+  trace[runBlock.leafSynth] "synthesized predecessor assertion:\n  {pre}"
   return (specsForward.toArray, pre)
 
 private def runBlockFromPostCore (specs : Array Expr) (goalPost goalCr : Expr) : MetaM Expr := do

--- a/EvmAsm/Rv64/Tactics/WP.lean
+++ b/EvmAsm/Rv64/Tactics/WP.lean
@@ -1416,6 +1416,20 @@ example (base v : Word) (imm : BitVec 12) :
     (wp_rv64_leaf_synth_addi_own_cfg base v imm).pre =
       ((.x5 ↦ᵣ v) ** regOwn .x6) := rfl
 
+/--
+trace: [runBlock.leafSynth] synthesized regOwn Reg.x6 for old-value parameter of type Word
+[runBlock.leafSynth] matched EvmAsm.Rv64.addi_spec_gen_within for EvmAsm.Rv64.Instr.ADDI at base
+[runBlock.leafSynth] synthesized predecessor assertion:
+      (Reg.x5 ↦ᵣ v) ** regOwn Reg.x6
+-/
+#guard_msgs in
+set_option trace.runBlock.leafSynth true in
+example (base v : Word) :
+    EvmAsm.Rv64.WP.CFG.Cert base (base + 4)
+      (CodeReq.singleton base (.ADDI .x6 .x5 (1 : BitVec 12)))
+      ((.x5 ↦ᵣ v) ** (.x6 ↦ᵣ (v + signExtend12 (1 : BitVec 12)))) := by
+  wp_rv64_leaf_synth
+
 def wp_rv64_leaf_synth_add_own_cfg (base v1 v2 : Word) :
     EvmAsm.Rv64.WP.CFG.Cert base (base + 4)
       (CodeReq.singleton base (.ADD .x7 .x5 .x6))

--- a/TACTICS.md
+++ b/TACTICS.md
@@ -139,6 +139,19 @@ This shows:
 - Which spec was selected
 - Composition progress
 
+For post-driven leaf synthesis, use the narrower trace class when you want the
+success path without the full `runBlock` trace:
+
+```lean
+set_option trace.runBlock.leafSynth true in
+example ... := by
+  wp_rv64_leaf_synth
+```
+
+This is silent by default during `lake build`. When enabled locally, it reports
+the matched registered specs, any synthesized `regOwn`/`memOwn` atoms, and the
+final predecessor assertion.
+
 ### Common failure modes
 
 | Symptom | Cause | Fix |

--- a/docs/agents/wp-framework.md
+++ b/docs/agents/wp-framework.md
@@ -502,6 +502,18 @@ caller needs to distinguish it.
 ## Debugging
 
 - If a generated precondition is unclear, inspect `#wp_rv64 cfg`.
+- If a `wp_rv64_leaf_synth` success is surprising, enable the narrow success
+  trace locally:
+
+  ```lean
+  set_option trace.runBlock.leafSynth true in
+  example ... := by
+    wp_rv64_leaf_synth
+  ```
+
+  The trace is silent by default in normal builds. When enabled, it reports the
+  registered spec matched for each instruction, synthesized `regOwn`/`memOwn`
+  atoms, and the final predecessor assertion.
 - If `wp_rv64_cert`, `wp_rv64_link`, `wp_rv64_dead`, or `wp_rv64_disjoint`
   fails, read the diagnostic first. It reports the goal shape, how many
   registered hints were tried, and the usual next action. When registered


### PR DESCRIPTION
## Summary
- add a silent-by-default trace class, trace.runBlock.leafSynth, for post-driven WP leaf synthesis
- report matched specs, synthesized regOwn/memOwn atoms, and the final predecessor assertion when enabled
- add a guarded trace regression and document the local debugging workflow

## Test plan
- rtk lake build EvmAsm.Rv64.Tactics.RunBlock
- rtk lake build EvmAsm.Rv64.Tactics.WP
- rtk lake build
- rtk git diff --check
- rtk scripts/check-forbidden-tactics.sh