### PR TITLE
perf(codegen): walk selected RLP account and header fields

### DIFF
--- a/EvmAsm/Codegen/Programs/Account.lean
+++ b/EvmAsm/Codegen/Programs/Account.lean
@@ -8,9 +8,9 @@
     K120  account_extract_balance  (field 1, u256 BE)
     K123  account_is_empty         (EIP-161 emptiness)
 
-  All three compose `rlp_field_to_u64` (K34), `rlp_field_to_u256_be`
-  (K35), and `rlp_list_nth_item` (K20) — which remain in
-  `Programs/Tx.lean` and `Programs/RlpRead.lean`.
+  `account_is_empty` uses the cursor-walk helpers from `Programs/RlpWalk.lean`.
+  The remaining standalone field predicates in this file still use indexed RLP
+  access through `rlp_list_nth_item` where they perform one-off lookups.
 
   No proofs yet -- these are codegen `String` defs only.
 -/
@@ -18,6 +18,7 @@
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.RlpWalk
 import EvmAsm.Codegen.Programs.Tx
 import EvmAsm.Codegen.Programs.TxExtract
 import EvmAsm.Codegen.Programs.U256
@@ -54,10 +55,10 @@ open EvmAsm.Rv64.Program
 
       0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
 
-    Composes:
-      - PR-K20 `rlp_list_nth_item`         — field bounds
-      - existing `rlp_field_to_u64`        — nonce
-      - existing `rlp_field_to_u256_be`    — balance
+    Composes a single RLP cursor walk over the four account fields:
+      - field 0 content decoded by rlp_content_to_u64 for nonce
+      - field 1 content decoded by rlp_content_to_u256_be for balance
+      - field 3 content copied/compared directly for code_hash
 
     Calling convention:
       a0 (input)  : account_rlp ptr
@@ -68,47 +69,51 @@ open EvmAsm.Rv64.Program
         0 : success — predicate written to *out
         1 : RLP parse failure / field missing / wrong width
 
-    Uses 8 + 32 + 8 + 8 + 32 = 88 bytes of `.data` scratch
-    (`aie_nonce` u64, `aie_balance` 32 B, `aie_offset` + `aie_length`,
-    `aie_empty_code_hash` constant). -/
+    Uses `.data` scratch for `aie_nonce` (u64), `aie_balance` (32 B), and the
+    `aie_empty_code_hash` constant. The probe data section also carries legacy
+    offset/length cells for sibling indexed helpers. -/
 def accountIsEmptyFunction : String :=
   "account_is_empty:\n" ++
-  "  addi sp, sp, -32\n" ++
+  "  addi sp, sp, -48\n" ++
   "  sd ra,  0(sp)\n" ++
   "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  sd s3, 32(sp); sd s4, 40(sp)\n" ++
   "  mv s0, a0                   # account_ptr\n" ++
   "  mv s1, a1                   # account_len\n" ++
   "  mv s2, a2                   # out u64 ptr\n" ++
   "  sd zero, 0(s2)\n" ++
-  "  # Step 1: nonce (field 0) → aie_nonce.\n" ++
+  "  # Step 1: initialize the account field cursor.\n" ++
   "  mv a0, s0; mv a1, s1\n" ++
-  "  li a2, 0\n" ++
-  "  la a3, aie_nonce\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
-  "  bnez a0, .Laie_parse_fail\n" ++
-  "  la t0, aie_nonce; ld t1, 0(t0)\n" ++
+  "  jal ra, rlp_walk_init\n" ++
+  "  bnez a2, .Laie_parse_fail\n" ++
+  "  mv s3, a0                   # cursor\n" ++
+  "  mv s4, a1                   # end\n" ++
+  "  # Step 2: nonce (field 0) -> aie_nonce.\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Laie_parse_fail\n" ++
+  "  sub t0, a0, a2; mv s3, a0; mv a0, t0; mv a1, a2\n" ++
+  "  jal ra, rlp_content_to_u64\n" ++
+  "  bnez a1, .Laie_parse_fail\n" ++
+  "  la t0, aie_nonce; sd a0, 0(t0)\n" ++
+  "  mv t1, a0\n" ++
   "  bnez t1, .Laie_not_empty\n" ++
-  "  # Step 2: balance (field 1, u256 BE) → aie_balance.\n" ++
-  "  mv a0, s0; mv a1, s1\n" ++
-  "  li a2, 1\n" ++
-  "  la a3, aie_balance\n" ++
-  "  jal ra, rlp_field_to_u256_be\n" ++
+  "  # Step 3: balance (field 1, u256 BE) -> aie_balance.\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Laie_parse_fail\n" ++
+  "  sub t0, a0, a2; mv s3, a0; mv a0, t0; mv a1, a2; la a2, aie_balance\n" ++
+  "  jal ra, rlp_content_to_u256_be\n" ++
   "  bnez a0, .Laie_parse_fail\n" ++
   "  la t0, aie_balance\n" ++
   "  ld t1,  0(t0); bnez t1, .Laie_not_empty\n" ++
   "  ld t1,  8(t0); bnez t1, .Laie_not_empty\n" ++
   "  ld t1, 16(t0); bnez t1, .Laie_not_empty\n" ++
   "  ld t1, 24(t0); bnez t1, .Laie_not_empty\n" ++
-  "  # Step 3: code_hash (field 3) compared against EMPTY_CODE_HASH.\n" ++
-  "  mv a0, s0; mv a1, s1\n" ++
-  "  li a2, 3\n" ++
-  "  la a3, aie_offset; la a4, aie_length\n" ++
-  "  jal ra, rlp_list_nth_item\n" ++
-  "  bnez a0, .Laie_parse_fail\n" ++
-  "  la t0, aie_length; ld t1, 0(t0)\n" ++
+  "  # Step 4: skip storage_root (field 2).\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Laie_parse_fail; mv s3, a0\n" ++
+  "  # Step 5: code_hash (field 3) compared against EMPTY_CODE_HASH.\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Laie_parse_fail\n" ++
+  "  mv t1, a2\n" ++
   "  li t2, 32\n" ++
   "  bne t1, t2, .Laie_parse_fail\n" ++
-  "  la t0, aie_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  sub t3, a0, a2\n" ++
   "  la t4, aie_empty_code_hash\n" ++
   "  ld t5,  0(t3); ld t6,  0(t4); bne t5, t6, .Laie_not_empty\n" ++
   "  ld t5,  8(t3); ld t6,  8(t4); bne t5, t6, .Laie_not_empty\n" ++
@@ -129,7 +134,8 @@ def accountIsEmptyFunction : String :=
   ".Laie_ret:\n" ++
   "  ld ra,  0(sp)\n" ++
   "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
-  "  addi sp, sp, 32\n" ++
+  "  ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
   "  ret"
 
 /-- `zisk_account_is_empty`: probe BuildUnit. Reads
@@ -145,9 +151,7 @@ def ziskAccountIsEmptyPrologue : String :=
   "  li t0, 0xa0010000\n" ++
   "  sd a0, 0(t0)\n" ++
   "  j .Laie_pdone\n" ++
-  rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
-  rlpFieldToU256BeFunction ++ "\n" ++
+  rlpWalkHelpersClosure ++ "\n" ++
   accountIsEmptyFunction ++ "\n" ++
   ".Laie_pdone:"
 

--- a/EvmAsm/Codegen/Programs/HeaderSummaryStruct.lean
+++ b/EvmAsm/Codegen/Programs/HeaderSummaryStruct.lean
@@ -10,6 +10,7 @@ import EvmAsm.Codegen.Programs.HashBridge
 import EvmAsm.Codegen.Programs.Header
 import EvmAsm.Codegen.Programs.HeaderFields
 import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.RlpWalk
 import EvmAsm.Codegen.Programs.Tx
 import EvmAsm.Rv64.Program
 
@@ -34,10 +35,10 @@ open EvmAsm.Rv64
     "what is this block" tuple in one shot, ready to dump as a
     fixed-size record.
 
-    Composes K172 (block_hash) + K201 (state_root) +
-    rlp_field_to_u64 ×4. The integer fields use the same shape
-    as K198 / K210 / K211 / K38; the state_root copy uses the
-    same 4 × 8B pattern as K201.
+    Composes K172 (block_hash) + a single RLP cursor walk over the
+    header fields. The walk directly copies field 3 (state_root) and
+    decodes fields 8, 10, 11, and 15 with rlp_content_to_u64, avoiding
+    four full rlp_field_to_u64 rescans of the same header.
 
     Calling convention:
       a0 (input)  : header_rlp ptr
@@ -50,51 +51,76 @@ open EvmAsm.Rv64
         2 : some integer field exceeds 8 bytes BE / state_root != 32 -/
 def headerComputeSummaryStructFunction : String :=
   "header_compute_summary_struct:\n" ++
-  "  addi sp, sp, -32\n" ++
+  "  addi sp, sp, -56\n" ++
   "  sd ra,  0(sp)\n" ++
   "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  sd s5, 48(sp)\n" ++
   "  mv s0, a0; mv s1, a1                # header\n" ++
   "  mv s2, a2                            # output struct\n" ++
   "  # 1. block_hash -> out[0..32]\n" ++
   "  mv a0, s0; mv a1, s1; mv a2, s2\n" ++
   "  jal ra, block_hash_from_header\n" ++
-  "  # 2. state_root -> out[32..64]\n" ++
+  "  # 2. Initialize one cursor walk over the header RLP.\n" ++
   "  mv a0, s0; mv a1, s1\n" ++
-  "  addi a2, s2, 32\n" ++
-  "  jal ra, header_extract_state_root\n" ++
-  "  bnez a0, .Lhcss_propagate_size\n" ++
-  "  # 3. number -> out[64..72] (field 8)\n" ++
-  "  mv a0, s0; mv a1, s1; li a2, 8\n" ++
-  "  addi a3, s2, 64\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
-  "  bnez a0, .Lhcss_propagate_int\n" ++
-  "  # 4. timestamp -> out[72..80] (field 11)\n" ++
-  "  mv a0, s0; mv a1, s1; li a2, 11\n" ++
-  "  addi a3, s2, 72\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
-  "  bnez a0, .Lhcss_propagate_int\n" ++
-  "  # 5. gas_used -> out[80..88] (field 10)\n" ++
-  "  mv a0, s0; mv a1, s1; li a2, 10\n" ++
-  "  addi a3, s2, 80\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
-  "  bnez a0, .Lhcss_propagate_int\n" ++
-  "  # 6. base_fee_per_gas -> out[88..96] (field 15)\n" ++
-  "  mv a0, s0; mv a1, s1; li a2, 15\n" ++
-  "  addi a3, s2, 88\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
-  "  bnez a0, .Lhcss_propagate_int\n" ++
+  "  jal ra, rlp_walk_init\n" ++
+  "  bnez a2, .Lhcss_parse_fail\n" ++
+  "  mv s3, a0                            # cursor\n" ++
+  "  mv s4, a1                            # end\n" ++
+  "  # Skip fields 0, 1, 2.\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Lhcss_parse_fail; mv s3, a0\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Lhcss_parse_fail; mv s3, a0\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Lhcss_parse_fail; mv s3, a0\n" ++
+  "  # Field 3: state_root -> out[32..64].\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Lhcss_parse_fail\n" ++
+  "  li t0, 32; bne a2, t0, .Lhcss_size_fail\n" ++
+  "  sub t1, a0, a2                       # content ptr\n" ++
+  "  ld t2,  0(t1); sd t2, 32(s2)\n" ++
+  "  ld t2,  8(t1); sd t2, 40(s2)\n" ++
+  "  ld t2, 16(t1); sd t2, 48(s2)\n" ++
+  "  ld t2, 24(t1); sd t2, 56(s2)\n" ++
+  "  mv s3, a0\n" ++
+  "  # Skip fields 4, 5, 6, 7.\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Lhcss_parse_fail; mv s3, a0\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Lhcss_parse_fail; mv s3, a0\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Lhcss_parse_fail; mv s3, a0\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Lhcss_parse_fail; mv s3, a0\n" ++
+  "  # Field 8: number -> out[64..72].\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Lhcss_parse_fail\n" ++
+  "  sub t0, a0, a2; mv s5, a0; mv a0, t0; mv a1, a2; jal ra, rlp_content_to_u64; bnez a1, .Lhcss_int_fail\n" ++
+  "  sd a0, 64(s2); mv s3, s5\n" ++
+  "  # Skip field 9.\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Lhcss_parse_fail; mv s3, a0\n" ++
+  "  # Field 10: gas_used -> out[80..88].\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Lhcss_parse_fail\n" ++
+  "  sub t0, a0, a2; mv s3, a0; mv a0, t0; mv a1, a2; jal ra, rlp_content_to_u64; bnez a1, .Lhcss_int_fail\n" ++
+  "  sd a0, 80(s2)\n" ++
+  "  # Field 11: timestamp -> out[72..80].\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Lhcss_parse_fail\n" ++
+  "  sub t0, a0, a2; mv s3, a0; mv a0, t0; mv a1, a2; jal ra, rlp_content_to_u64; bnez a1, .Lhcss_int_fail\n" ++
+  "  sd a0, 72(s2)\n" ++
+  "  # Skip fields 12, 13, 14.\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Lhcss_parse_fail; mv s3, a0\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Lhcss_parse_fail; mv s3, a0\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Lhcss_parse_fail; mv s3, a0\n" ++
+  "  # Field 15: base_fee_per_gas -> out[88..96].\n" ++
+  "  mv a0, s3; mv a1, s4; jal ra, rlp_walk_next; bnez a1, .Lhcss_parse_fail\n" ++
+  "  sub t0, a0, a2; mv a0, t0; mv a1, a2; jal ra, rlp_content_to_u64; bnez a1, .Lhcss_int_fail\n" ++
+  "  sd a0, 88(s2)\n" ++
   "  li a0, 0\n" ++
   "  j .Lhcss_ret\n" ++
-  ".Lhcss_propagate_size:\n" ++
-  "  # state_root status: 1=parse, 2=size. Pass through unchanged.\n" ++
-  "  j .Lhcss_ret\n" ++
-  ".Lhcss_propagate_int:\n" ++
-  "  # rlp_field_to_u64 returns 1=parse, 2=too_long. Map both to\n" ++
-  "  # the same code as the upper-level status.\n" ++
+  ".Lhcss_parse_fail:\n" ++
+  "  li a0, 1; j .Lhcss_ret\n" ++
+  ".Lhcss_size_fail:\n" ++
+  "  li a0, 2; j .Lhcss_ret\n" ++
+  ".Lhcss_int_fail:\n" ++
+  "  li a0, 2\n" ++
   ".Lhcss_ret:\n" ++
   "  ld ra,  0(sp)\n" ++
   "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
-  "  addi sp, sp, 32\n" ++
+  "  ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  ld s5, 48(sp)\n" ++
+  "  addi sp, sp, 56\n" ++
   "  ret"
 
 /-- `zisk_header_compute_summary_struct`: probe BuildUnit.
@@ -114,11 +140,9 @@ def ziskHeaderComputeSummaryStructPrologue : String :=
   "  li t0, 0xa0010000\n" ++
   "  sd a0, 0(t0)\n" ++
   "  j .Lhcss_pdone\n" ++
-  rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpWalkHelpersClosure ++ "\n" ++
   zkvmKeccak256Function ++ "\n" ++
   blockHashFromHeaderFunction ++ "\n" ++
-  headerExtractStateRootFunction ++ "\n" ++
   headerComputeSummaryStructFunction ++ "\n" ++
   ".Lhcss_pdone:"
 


### PR DESCRIPTION
## Summary
- migrate `header_compute_summary_struct` to one RLP cursor walk for state_root, number, gas_used, timestamp, and base_fee
- migrate `account_is_empty` to one account cursor walk for nonce, balance, storage_root skip, and code_hash comparison
- swap the affected probe closures to `rlpWalkHelpersClosure` instead of repeated indexed field helpers

## Verification
- `lake build EvmAsm.Codegen.Programs.HeaderSummaryStruct EvmAsm.Codegen.Programs.Account`
- `lake exe codegen --program zisk_header_compute_summary_struct --halt sp1 -o /tmp/hcss_probe`
- `lake exe codegen --program zisk_account_is_empty --halt sp1 -o /tmp/aie_probe`
- `lake build` (local build succeeded; one pre-existing dependency deprecation warning replayed from LeanRV64D/RiscvExtras.lean)
- 200 random EEST cases with spike backend, compared modified tree against clean HEAD worktree at /tmp/evm-asm-eest-baseline:
  - command shape: `scripts/codegen-eest-stateless-check.sh --filter random_statetest --limit 200 --random --seed 220 --backend spike --jobs 2 --quiet-passes`
  - both runs: selected=200, ran=200, full=177, root=200, succ=177, tail=200, fail=23, errored=0, budget=0
  - normalized summaries and manifests match; all per-case `.output` and `.result.tsv` files match

Beads: evm-asm-22pwv, evm-asm-22pwv.3, evm-asm-22pwv.4