### PR TITLE
feat(divmod): complete n=3 MOD lane — evm_mod_n3_lane_v5 (both shift arms)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -463,6 +463,16 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxAddbackNormMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxExactX1Mod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallCombosMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxCombosMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallExactBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxExactBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallCombosBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopRestCombosBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnifiedMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallCombosBorrowCarryNamedMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopRestCombosBorrowCarryNamedMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnifiedBorrowCarryCasesMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnifiedBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopLoopSelectedBorrowCarryMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallSkip

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -483,6 +483,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5FamiliesMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopFullToNopOffMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5PreloopShift0Mod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5PathShift0Mod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5FullShift0Mod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallSkip

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -457,6 +457,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5FullShift0Mod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5LaneShift0Mod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloopMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallExactX1Mod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallSkip

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -458,6 +458,11 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5LaneShift0Mod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloopMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallExactX1Mod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxAddbackNormMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxExactX1Mod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallCombosMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxCombosMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallSkip

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -484,6 +484,8 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopFullToNopOffMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5PreloopShift0Mod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5PathShift0Mod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5FullShift0Mod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5LaneShift0Mod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5LaneMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallSkip

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -349,6 +349,9 @@ import EvmAsm.Evm64.DivMod.Spec.N3V5QuotientShape
 import EvmAsm.Evm64.DivMod.Spec.N3V5QuotientLaneShape
 import EvmAsm.Evm64.DivMod.Spec.N3V5ModRemainder
 import EvmAsm.Evm64.DivMod.Spec.N3V5QuotientLaneShapeMod
+import EvmAsm.Evm64.DivMod.Spec.N3V5ConcretePostBridgeMod
+import EvmAsm.Evm64.DivMod.Spec.N3V5PostToDispatchPostV5Mod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5LaneShiftNzMod
 import EvmAsm.Evm64.DivMod.Spec.N2V5NormScaled
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientShape
 import EvmAsm.Evm64.DivMod.Spec.N2V5QuotientLaneShape

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -481,6 +481,8 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloopBorrowCarryMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopFromShapeMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5FamiliesMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopFullToNopOffMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5PreloopShift0Mod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5PathShift0Mod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallSkip

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -475,6 +475,8 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnifiedBorrowCarryMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopLoopSelectedBorrowCarryMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloopBorrowCarryMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopFromShapeMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5FamiliesMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopFullToNopOffMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallSkip

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -344,6 +344,7 @@ import EvmAsm.Evm64.DivMod.Spec.N3V5NormVShapeFacts
 import EvmAsm.Evm64.DivMod.Spec.N3V5DigitStepIter
 import EvmAsm.Evm64.DivMod.Spec.N3V5AccQuot
 import EvmAsm.Evm64.DivMod.Spec.N3V5Shift0Quotient
+import EvmAsm.Evm64.DivMod.Spec.N3V5Shift0ModRemainder
 import EvmAsm.Evm64.DivMod.Spec.N3V5Shift0DivLimb
 import EvmAsm.Evm64.DivMod.Spec.N3V5QuotientShape
 import EvmAsm.Evm64.DivMod.Spec.N3V5QuotientLaneShape

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -473,6 +473,8 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopRestCombosBorrowCarryNamedMo
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnifiedBorrowCarryCasesMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnifiedBorrowCarryMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopLoopSelectedBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloopBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopFromShapeMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallSkip

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5FamiliesMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5FamiliesMod.lean
@@ -1,0 +1,146 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5FamiliesMod
+
+  v5 MOD n=3 denorm + epilogue bundle (denormOff → nopOff), over `modCode_noNop_v5`.
+  The MOD mirror of the DIV n=3 denorm-epilogue families (`FullPathN3V5NoNopDenormDefs`):
+  it shares the DIV denorm PRE (`fullDivN3DenormPreV5`) and the loop frame
+  (`fullDivN3FrameNoX1V5` / `fullDivN3ScratchMemV5`) — the loop computes both quotient
+  and remainder — and swaps in the MOD epilogue (`evm_mod_preamble_denorm_epilogue_spec_v5_noNop`)
+  which loads the denormalized remainder.  Defines the MOD post bundles
+  `fullModN3DenormPostV5` / `fullModN3UnifiedPostNoX1V5`, mirroring the n=2 MOD
+  `FullPathN2V5FamiliesMod`.  First sub-unit of Milestone D of the n=3 MOD lane.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopDenormDefs
+import EvmAsm.Evm64.DivMod.Compose.DenormEpilogueV5Mod
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- v5 MOD n=3 denorm post: the denormalized remainder (`denormModPost`) plus the
+    untouched shift cell and the two quotient cells (framed, MOD never reads them). -/
+@[irreducible]
+def fullModN3DenormPostV5 (bltu_1 bltu_0 : Bool)
+    (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let shift := fullDivN3Shift b2
+  let r1 := fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  denormModPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 **
+  ((sp + signExtend12 3992) ↦ₘ shift) **
+  ((sp + signExtend12 4088) ↦ₘ r0.1) **
+  ((sp + signExtend12 4080) ↦ₘ r1.1) **
+  ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4064) ↦ₘ (0 : Word))
+
+/-- v5 MOD n=3 unified post (NoX1 form): MOD denorm post plus the shared loop
+    frame and the `sp+3936` div128 scratch cell.  Reuses the DIV n=3 frame. -/
+@[irreducible]
+def fullModN3UnifiedPostNoX1V5 (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem : Word) :
+    Assertion :=
+  fullModN3DenormPostV5 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 **
+  fullDivN3FrameNoX1V5 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+    retMem dMem dloMem scratchUn0 **
+  ((sp + signExtend12 3936) ↦ₘ
+    fullDivN3ScratchMemV5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)
+
+theorem fullModN3DenormPostV5_unfold {bltu_1 bltu_0 : Bool}
+    {sp a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
+    fullModN3DenormPostV5 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 =
+    (let shift := fullDivN3Shift b2
+     let r1 := fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+     let r0 := fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+     denormModPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 **
+     ((sp + signExtend12 3992) ↦ₘ shift) **
+     ((sp + signExtend12 4088) ↦ₘ r0.1) **
+     ((sp + signExtend12 4080) ↦ₘ r1.1) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word))) := by
+  delta fullModN3DenormPostV5; rfl
+
+theorem fullModN3UnifiedPostNoX1V5_unfold {bltu_1 bltu_0 : Bool}
+    {sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem : Word} :
+    fullModN3UnifiedPostNoX1V5 bltu_1 bltu_0 sp base
+      a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem =
+    (fullModN3DenormPostV5 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 **
+     fullDivN3FrameNoX1V5 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratchUn0 **
+     ((sp + signExtend12 3936) ↦ₘ
+       fullDivN3ScratchMemV5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)) := by
+  delta fullModN3UnifiedPostNoX1V5; rfl
+
+/-- v5 MOD n=3 denorm + epilogue (denormOff → nopOff): the SHARED DIV denorm pre
+    drives the MOD epilogue (loads the denormalized remainder), yielding the MOD
+    denorm post.  Mirror of `evm_mod_n2_denorm_epilogue_bundled_spec_noNop_v5Final`. -/
+theorem evm_mod_n3_denorm_epilogue_bundled_spec_noNop_v5Final
+    (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hshift_nz : fullDivN3Shift b2 ≠ 0) :
+    cpsTripleWithin (2 + 23 + 10) (base + denormOff) (base + nopOff) (modCode_noNop_v5 base)
+      (fullDivN3DenormPreV5 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3)
+      (fullModN3DenormPostV5 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := fullDivN3Shift b2
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let r1 := fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  let c3 := fullDivN3C3V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  have h := evm_mod_preamble_denorm_epilogue_spec_v5_noNop sp base
+    r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 shift
+    r0.2.2.2.2.1 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    c3 v.1 v.2.1 v.2.2.1 v.2.2.2 hshift_nz
+  have hF := cpsTripleWithin_frameR
+    (((sp + signExtend12 4088) ↦ₘ r0.1) **
+     ((sp + signExtend12 4080) ↦ₘ r1.1) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word)))
+    (by pcFree) h
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      subst shift; subst v; subst r1; subst r0; subst c3
+      delta fullDivN3DenormPreV5 at hp
+      simp only [se12_32, se12_40, se12_48, se12_56] at hp
+      xperm_hyp hp)
+    (fun h hq => by
+      subst shift; subst r1; subst r0
+      delta fullModN3DenormPostV5
+      xperm_hyp hq)
+    hF
+
+/-- v5 MOD n=3 denorm + epilogue, framed with the loop frame + scratch cell + x1
+    (the direct shape for the n=3 MOD path composition). -/
+theorem evm_mod_n3_denorm_epilogue_bundled_spec_noNop_v5Final_exact_x1_frame
+    (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hshift_nz : fullDivN3Shift b2 ≠ 0) :
+    cpsTripleWithin (2 + 23 + 10) (base + denormOff) (base + nopOff)
+      (modCode_noNop_v5 base)
+      (fullDivN3DenormPreV5 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 **
+       fullDivN3FrameNoX1V5 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+         retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ
+         fullDivN3ScratchMemV5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (fullModN3UnifiedPostNoX1V5 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem **
+       (.x1 ↦ᵣ raVal)) := by
+  have hDenorm := evm_mod_n3_denorm_epilogue_bundled_spec_noNop_v5Final
+    bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3 hshift_nz
+  have hFramed := cpsTripleWithin_frameR
+    (fullDivN3FrameNoX1V5 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratchUn0 **
+     ((sp + signExtend12 3936) ↦ₘ
+       fullDivN3ScratchMemV5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) **
+     (.x1 ↦ᵣ raVal))
+    (by
+      delta fullDivN3FrameNoX1V5 fullDivN3ScratchNoX1V5
+      pcFree) hDenorm
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by
+      delta fullModN3UnifiedPostNoX1V5
+      xperm_hyp hq)
+    hFramed
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5FullShift0Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5FullShift0Mod.lean
@@ -1,0 +1,220 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5FullShift0Mod
+
+  Full v5 n=3 MOD code path, shift=0 case (base → nopOff), over `modCode_noNop_v5`:
+  the shift=0 preloop+loop (`evm_mod_n3_to_denorm_shift0_param_v5_noNop`) composed
+  with the shift=0 MOD epilogue (`evm_mod_shift0_epilogue_spec_v5_noNop`) via a
+  MOD-specific loop-post → epilogue-pre bridge.  MOD counterpart of
+  `evm_div_n3_full_shift0_param_v5_noNop`: the MOD epilogue reads the un-normalized
+  remainder u-cells (sp+4056/4048/4040/4032 = `n3Shift0R0.2.{1,2.1,2.2.1,2.2.2.1}`),
+  so the bridge `loopN3UnifiedPostV5NoX1_shift0_to_modEpiloguePre` places those in
+  the epilogue's footprint (the DIV bridge buried them in its frame) — proven by
+  reusing the DIV bridge and re-partitioning.  The quotient digits
+  (sp+4088/4080/4072/4064) are framed through, unread.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5PathShift0Mod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5BridgeShift0
+import EvmAsm.Evm64.DivMod.Compose.DenormEpilogueV5Mod
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- The shift=0 n=3 loop-state frame WITHOUT the four remainder u-cells
+    (sp+4056/4048/4040/4032) — those are split out for the MOD shift=0 epilogue.
+    Equals `fullDivN3FrameShift0V5` minus those four cells. -/
+@[irreducible] def fullModN3FrameShift0V5Rest (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 retMem dMem dloMem scratchUn0 scratchMem raVal : Word) :
+    Assertion :=
+  let r1 := n3Shift0R1 bltu_1 a1 a2 a3 b0 b1 b2
+  let r0 := n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2
+  let scratch1 := if bltu_1 then divKTrialCallV5ScratchOut 0 a3 b2 scratchMem else scratchMem
+  let scratchMemF := if bltu_0 then divKTrialCallV5ScratchOut r1.2.2.2.1 r1.2.2.1 b2 scratch1 else scratch1
+  let scratchRet1 := if bltu_1 then (base + div128CallRetOff) else retMem
+  let scratchD1 := if bltu_1 then b2 else dMem
+  let scratchDLo1 := if bltu_1 then divKTrialCallV5DLo b2 else dloMem
+  let scratchUn01 := if bltu_1 then divKTrialCallV5Un0 a3 else scratchUn0
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 3976) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
+  ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) ** ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+  ((sp + signExtend12 4008) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  (sp + signExtend12 3968 ↦ₘ (if bltu_0 then (base + div128CallRetOff) else scratchRet1)) **
+  (sp + signExtend12 3960 ↦ₘ (if bltu_0 then b2 else scratchD1)) **
+  (sp + signExtend12 3952 ↦ₘ (if bltu_0 then divKTrialCallV5DLo b2 else scratchDLo1)) **
+  (sp + signExtend12 3944 ↦ₘ (if bltu_0 then divKTrialCallV5Un0 r1.2.2.1 else scratchUn01)) **
+  (sp + signExtend12 3936 ↦ₘ scratchMemF) **
+  (.x1 ↦ᵣ raVal)
+
+theorem fullModN3FrameShift0V5Rest_unfold {bltu_1 bltu_0 : Bool}
+    {sp base a0 a1 a2 a3 b0 b1 b2 retMem dMem dloMem scratchUn0 scratchMem raVal : Word} :
+    fullModN3FrameShift0V5Rest bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2
+      retMem dMem dloMem scratchUn0 scratchMem raVal =
+    (let r1 := n3Shift0R1 bltu_1 a1 a2 a3 b0 b1 b2
+     let r0 := n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2
+     let scratch1 := if bltu_1 then divKTrialCallV5ScratchOut 0 a3 b2 scratchMem else scratchMem
+     let scratchMemF := if bltu_0 then divKTrialCallV5ScratchOut r1.2.2.2.1 r1.2.2.1 b2 scratch1 else scratch1
+     let scratchRet1 := if bltu_1 then (base + div128CallRetOff) else retMem
+     let scratchD1 := if bltu_1 then b2 else dMem
+     let scratchDLo1 := if bltu_1 then divKTrialCallV5DLo b2 else dloMem
+     let scratchUn01 := if bltu_1 then divKTrialCallV5Un0 a3 else scratchUn0
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 3976) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
+     ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) ** ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (if bltu_0 then (base + div128CallRetOff) else scratchRet1)) **
+     (sp + signExtend12 3960 ↦ₘ (if bltu_0 then b2 else scratchD1)) **
+     (sp + signExtend12 3952 ↦ₘ (if bltu_0 then divKTrialCallV5DLo b2 else scratchDLo1)) **
+     (sp + signExtend12 3944 ↦ₘ (if bltu_0 then divKTrialCallV5Un0 r1.2.2.1 else scratchUn01)) **
+     (sp + signExtend12 3936 ↦ₘ scratchMemF) **
+     (.x1 ↦ᵣ raVal)) := by
+  delta fullModN3FrameShift0V5Rest; rfl
+
+theorem fullModN3FrameShift0V5Rest_pcFree {bltu_1 bltu_0 : Bool}
+    {sp base a0 a1 a2 a3 b0 b1 b2 retMem dMem dloMem scratchUn0 scratchMem raVal : Word} :
+    (fullModN3FrameShift0V5Rest bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2
+      retMem dMem dloMem scratchUn0 scratchMem raVal).pcFree := by
+  rw [fullModN3FrameShift0V5Rest_unfold]
+  cases bltu_1 <;> cases bltu_0 <;>
+    simp only [Bool.false_eq_true, if_true, if_false] <;> pcFree
+
+/-- MOD shift=0 loop-post → epilogue-pre bridge (n=3).  Reuses the DIV bridge
+    `loopN3UnifiedPostV5NoX1_shift0_to_epiloguePre` and re-partitions: the four
+    remainder u-cells (sp+4056/4048/4040/4032) move into the MOD epilogue footprint,
+    the quotient output cells split out, leaving `fullModN3FrameShift0V5Rest`. -/
+theorem loopN3UnifiedPostV5NoX1_shift0_to_modEpiloguePre
+    (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (h : PartialState)
+    (hp : ((loopN3UnifiedPostV5NoX1 bltu_1 bltu_0 sp base
+              b0 b1 b2 0 a1 a2 a3 0 0 a0
+              retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal)) **
+            (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+             ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+             ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+             ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+             ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+             ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+             ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))) h) :
+    (((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ (sp + signExtend12 4056)) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ (0 : Word)) ** (.x7 ↦ᵣ (sp + signExtend12 4088)) **
+       (.x2 ↦ᵣ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.2.1) **
+       (.x10 ↦ᵣ n3Shift0C3 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2) **
+       ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1) **
+       ((sp + signExtend12 4056) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.1) **
+       ((sp + signExtend12 4048) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.1) **
+       ((sp + signExtend12 4040) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.1) **
+       ((sp + signExtend12 4032) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.2.1) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ (0 : Word))) **
+     (((sp + signExtend12 4088) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).1) **
+       ((sp + signExtend12 4080) ↦ₘ (n3Shift0R1 bltu_1 a1 a2 a3 b0 b1 b2).1) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4064) ↦ₘ (0 : Word))) **
+     fullModN3FrameShift0V5Rest bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2
+       retMem dMem dloMem scratchUn0 scratchMem raVal) h := by
+  have hbr := loopN3UnifiedPostV5NoX1_shift0_to_epiloguePre bltu_1 bltu_0
+    sp base a0 a1 a2 a3 b0 b1 b2 retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+  rw [fullDivN3FrameShift0V5_unfold] at hbr
+  rw [fullModN3FrameShift0V5Rest_unfold]
+  xperm_hyp hbr
+
+/-- Full n=3 MOD code path over `modCode_noNop_v5` (shift = 0): preloop + capped
+    loop + MOD remainder epilogue, `base → nopOff`.  The un-normalized remainder
+    limbs `n3Shift0R0.2.{1,2.1,2.2.1,2.2.2.1}` land in the output slots
+    (sp+32/40/48/56). -/
+theorem evm_mod_n3_full_shift0_param_v5_noNop (bltu_1 bltu_0 : Bool)
+    (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 v2 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| (0 : Word) ≠ 0) (hb2nz : b2 ≠ 0)
+    (hshift_z : (clzResult b2).1 = 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 = BitVec.ult (0 : Word) b2)
+    (hbltu_0 : bltu_0 =
+      BitVec.ult (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 b2) :
+    cpsTripleWithin ((((8 + 21 + 24 + 4) + 13) + 468) + 12) base (base + nopOff)
+      (modCode_noNop_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        ((sp + signExtend12 3968) ↦ₘ retMem) ** ((sp + signExtend12 3960) ↦ₘ dMem) **
+        ((sp + signExtend12 3952) ↦ₘ dloMem) ** ((sp + signExtend12 3944) ↦ₘ scratchUn0) **
+        ((sp + signExtend12 3936) ↦ₘ scratchMem) ** (.x1 ↦ᵣ raVal)))
+      (((.x12 ↦ᵣ (sp + 32)) **
+        (.x5 ↦ᵣ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.1) **
+        (.x6 ↦ᵣ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.1) **
+        (.x7 ↦ᵣ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.1) **
+        (.x2 ↦ᵣ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.2.1) **
+        (.x0 ↦ᵣ (0 : Word)) **
+        (.x10 ↦ᵣ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.2.1) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1) **
+        ((sp + signExtend12 4056) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.1) **
+        ((sp + signExtend12 4048) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.1) **
+        ((sp + signExtend12 4040) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.1) **
+        ((sp + signExtend12 4032) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.2.1) **
+        ((sp + 32) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.1) **
+        ((sp + 40) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.1) **
+        ((sp + 48) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.1) **
+        ((sp + 56) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.2.1)) **
+       (((sp + signExtend12 4088) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).1) **
+         ((sp + signExtend12 4080) ↦ₘ (n3Shift0R1 bltu_1 a1 a2 a3 b0 b1 b2).1) **
+         ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+         ((sp + signExtend12 4064) ↦ₘ (0 : Word))) **
+       fullModN3FrameShift0V5Rest bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2
+         retMem dMem dloMem scratchUn0 scratchMem raVal) := by
+  have hA := evm_mod_n3_to_denorm_shift0_param_v5_noNop bltu_1 bltu_0
+    sp base a0 a1 a2 a3 b0 b1 b2 (0 : Word) v2 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratchUn0 scratchMem raVal hbnz rfl hb2nz hshift_z halign
+    hbltu_1 hbltu_0
+  have hB := evm_mod_shift0_epilogue_spec_v5_noNop sp base
+    (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.1
+    (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.1
+    (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.1
+    (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.2.1
+    (clzResult b2).1
+    (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.2.1
+    (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    (n3Shift0C3 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2)
+    b0 b1 b2 (0 : Word) hshift_z
+  have hBf := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4088) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).1) **
+       ((sp + signExtend12 4080) ↦ₘ (n3Shift0R1 bltu_1 a1 a2 a3 b0 b1 b2).1) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4064) ↦ₘ (0 : Word))) **
+      fullModN3FrameShift0V5Rest bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2
+        retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (by
+      rw [fullModN3FrameShift0V5Rest_unfold]
+      cases bltu_1 <;> cases bltu_0 <;>
+        simp only [Bool.false_eq_true, if_true, if_false] <;> pcFree) hB
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      have hbr := loopN3UnifiedPostV5NoX1_shift0_to_modEpiloguePre bltu_1 bltu_0
+        sp base a0 a1 a2 a3 b0 b1 b2 retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      xperm_hyp hbr) hA hBf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hFull
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5LaneMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5LaneMod.lean
@@ -1,0 +1,40 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5LaneMod
+
+  The full v5 n=3 MOD lane: combines the shift≠0 and shift=0 halves by
+  `by_cases (clzResult (b.getLimbN 2)).1 = 0`.  MOD mirror of `evm_div_n3_lane_v5`.
+  One lane theorem over `modCode_noNop_v5` → `modStackDispatchPostV5`, the n=3
+  entry in the 5-lane MOD dispatch.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5LaneShift0Mod
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The full v5 n=3 MOD lane (both shift arms). -/
+theorem evm_mod_n3_lane_v5 (sp base : Word) (a b : EvmWord)
+    (raVal v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat)) v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostV5 sp a b) := by
+  by_cases hsh : (clzResult (b.getLimbN 2)).1 = 0
+  · exact evm_mod_n3_lane_shift0_v5 sp base a b raVal v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+      retMem dMem dloMem scratch_un0 scratchMem hb3z hb2nz hsh halign
+  · exact evm_mod_n3_lane_shiftNz_v5 sp base a b raVal v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+      retMem dMem dloMem scratch_un0 scratchMem hb3z hb2nz hsh halign
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5LaneShift0Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5LaneShift0Mod.lean
@@ -1,0 +1,226 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5LaneShift0Mod
+
+  The v5 n=3 MOD lane, shift=0 case: from the stack-dispatch precondition
+  `divModStackDispatchPreNoX1` to `modStackDispatchPostV5`, over `modCode_noNop_v5`,
+  given the normalization shift is zero (`clz b2 = 0`).  MOD mirror of
+  `FullPathN3V5LaneShift0` (DIV): pins the two runtime borrow flags, composes the
+  flag-param full shift=0 MOD path (`evm_mod_n3_full_shift0_param_v5_noNop`), the
+  inline dispatch-pre adapter, and the shift=0 MOD post bridge — the latter routes
+  through `modConcretePostNoX1ExactRegsFrame` (as the DIV shift=0 bridge does) to
+  handle the `.x1 ↦ᵣ raVal` regIs → `regOwn .x1` weakening.  Fed the shift=0 MOD
+  remainder correctness (`n3_shift0_remainder_word_eq_mod_lane`).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5FullShift0Mod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5LaneShiftNzMod
+import EvmAsm.Evm64.DivMod.Spec.N3V5Shift0ModRemainder
+import EvmAsm.Evm64.DivMod.Spec.CallablePost
+import EvmAsm.Evm64.DivMod.Spec.StackPostBridgeMod
+import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Mod
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_add_zero)
+
+open EvmWord in
+/-- Project the shift=0 MOD remainder-word equality into the four per-limb
+    `getLimbN` facts (in the folded `n3Shift0R0` form). -/
+theorem n3_shift0_mod_getLimbN_threaded (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 : Word) (bltu_1 bltu_0 : Bool)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3z : b.getLimbN 3 = 0)
+    (hb2ge : b2.toNat ≥ 2 ^ 63)
+    (hc1 : bltu_1 = true → BitVec.ult (0 : Word) b2 = true)
+    (hm1 : bltu_1 = false → ¬ BitVec.ult (0 : Word) b2)
+    (hc0 : bltu_0 = true →
+      BitVec.ult (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 b2 = true)
+    (hm0 : bltu_0 = false →
+      ¬ BitVec.ult (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 b2) :
+    (EvmWord.mod a b).getLimbN 0 = (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.1 ∧
+    (EvmWord.mod a b).getLimbN 1 = (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.1 ∧
+    (EvmWord.mod a b).getLimbN 2 = (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.1 ∧
+    (EvmWord.mod a b).getLimbN 3 = (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.2.1 := by
+  have hword := n3_shift0_remainder_word_eq_mod_lane a b a0 a1 a2 a3 b0 b1 b2 bltu_1 bltu_0
+    ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3z hb2ge hc1 hm1 hc0 hm0
+  have h0 : (0 : Word).toNat = 0 := rfl
+  have hvpos : 2 ^ 191 ≤ val256 b0 b1 b2 0 := by simp only [EvmWord.val256, h0]; omega
+  have hfwv : val256 a1 a2 a3 0 < 2 ^ 64 * val256 b0 b1 b2 0 := by
+    have ha : val256 a1 a2 a3 0 < 2 ^ 192 := by
+      have := a1.isLt; have := a2.isLt; have := a3.isLt
+      simp only [EvmWord.val256, h0]; omega
+    calc val256 a1 a2 a3 0 < 2 ^ 192 := ha
+      _ ≤ 2 ^ 64 * 2 ^ 191 := by norm_num
+      _ ≤ 2 ^ 64 * val256 b0 b1 b2 0 := Nat.mul_le_mul_left _ hvpos
+  obtain ⟨hR1u4, _⟩ := iterN3V5_collapse bltu_1 b0 b1 b2 a1 a2 a3 0 hb2ge hfwv hc1 hm1
+  -- Per goal (no `<;>`/`first`): unfold the `n3Shift0R0` RHS + collapse the u4 slot,
+  -- then rewrite `mod a b` to the fromLimbs form and project. Mirrors the DIV
+  -- `n3_shift0_div_getLimbN_threaded` structure.
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · simp only [n3Shift0R0, n3Shift0R1]; rw [hR1u4, ← hword]; exact EvmWord.getLimbN_fromLimbs_0
+  · simp only [n3Shift0R0, n3Shift0R1]; rw [hR1u4, ← hword]; exact EvmWord.getLimbN_fromLimbs_1
+  · simp only [n3Shift0R0, n3Shift0R1]; rw [hR1u4, ← hword]; exact EvmWord.getLimbN_fromLimbs_2
+  · simp only [n3Shift0R0, n3Shift0R1]; rw [hR1u4, ← hword]; exact EvmWord.getLimbN_fromLimbs_3
+
+/-- Shift=0 MOD post bridge: the shift=0 full-path post implies `modStackDispatchPostV5`,
+    given the per-limb `mod` facts.  MOD mirror of `n3_shift0_fullPost_to_divStackDispatchPostV5`,
+    routing through `modConcretePostNoX1ExactRegsFrame`. -/
+theorem n3_shift0_modPost_to_modStackDispatchPost_v5
+    (bltu_1 bltu_0 : Bool) (sp base : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hmod0 : (EvmWord.mod a b).getLimbN 0 = (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.1)
+    (hmod1 : (EvmWord.mod a b).getLimbN 1 = (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.1)
+    (hmod2 : (EvmWord.mod a b).getLimbN 2 = (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.1)
+    (hmod3 : (EvmWord.mod a b).getLimbN 3 = (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.2.1) :
+    ∀ h,
+      (((.x12 ↦ᵣ (sp + 32)) **
+        (.x5 ↦ᵣ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.1) **
+        (.x6 ↦ᵣ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.1) **
+        (.x7 ↦ᵣ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.1) **
+        (.x2 ↦ᵣ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.2.1) **
+        (.x0 ↦ᵣ (0 : Word)) **
+        (.x10 ↦ᵣ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.2.1) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1) **
+        ((sp + signExtend12 4056) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.1) **
+        ((sp + signExtend12 4048) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.1) **
+        ((sp + signExtend12 4040) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.1) **
+        ((sp + signExtend12 4032) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.2.1) **
+        ((sp + 32) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.1) **
+        ((sp + 40) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.1) **
+        ((sp + 48) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.1) **
+        ((sp + 56) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.2.1)) **
+       (((sp + signExtend12 4088) ↦ₘ (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).1) **
+         ((sp + signExtend12 4080) ↦ₘ (n3Shift0R1 bltu_1 a1 a2 a3 b0 b1 b2).1) **
+         ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+         ((sp + signExtend12 4064) ↦ₘ (0 : Word))) **
+       fullModN3FrameShift0V5Rest bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2
+         retMem dMem dloMem scratchUn0 scratchMem raVal) h →
+      modStackDispatchPostV5 sp a b h := by
+  intro h hq
+  rw [fullModN3FrameShift0V5Rest_unfold] at hq
+  have hExact :
+      (modConcretePostNoX1ExactRegsFrame sp a b (signExtend12 4095) raVal
+        (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.2.1
+        (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.1
+        (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.1
+        (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.1
+        (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.2.1
+        (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).1
+        (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).1
+        (n3Shift0R1 bltu_1 a1 a2 a3 b0 b1 b2).1 (0 : Word) (0 : Word)
+        (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.1
+        (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.1
+        (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.1
+        (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.2.1
+        (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.2.2
+        (n3Shift0R1 bltu_1 a1 a2 a3 b0 b1 b2).2.2.2.2.2 (0 : Word) (0 : Word)
+        (clzResult b2).1 (3 : Word) (0 : Word)
+        (if bltu_0 then (base + div128CallRetOff)
+          else if bltu_1 then (base + div128CallRetOff) else retMem)
+        (if bltu_0 then b2 else if bltu_1 then b2 else dMem)
+        (if bltu_0 then divKTrialCallV5DLo b2
+          else if bltu_1 then divKTrialCallV5DLo b2 else dloMem)
+        (if bltu_0 then divKTrialCallV5Un0 (n3Shift0R1 bltu_1 a1 a2 a3 b0 b1 b2).2.2.1
+          else if bltu_1 then divKTrialCallV5Un0 a3 else scratchUn0) **
+       ((sp + signExtend12 3936) ↦ₘ
+        (if bltu_0 then divKTrialCallV5ScratchOut (n3Shift0R1 bltu_1 a1 a2 a3 b0 b1 b2).2.2.2.1
+            (n3Shift0R1 bltu_1 a1 a2 a3 b0 b1 b2).2.2.1 b2
+            (if bltu_1 then divKTrialCallV5ScratchOut 0 a3 b2 scratchMem else scratchMem)
+          else if bltu_1 then divKTrialCallV5ScratchOut 0 a3 b2 scratchMem else scratchMem))) h := by
+    rw [modConcretePostNoX1ExactRegsFrame_unfold,
+        evmWordIs_sp_limbs_eq sp a a0 a1 a2 a3 ha0 ha1 ha2 ha3,
+        evmWordIs_sp32_limbs_eq sp (EvmWord.mod a b)
+          (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.1
+          (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.1
+          (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.1
+          (n3Shift0R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2).2.2.2.2.1
+          hmod0 hmod1 hmod2 hmod3,
+        divScratchValuesCallNoX1_unfold, divScratchValues_unfold]
+    rw [word_add_zero] at hq
+    xperm_hyp hq
+  rw [modStackDispatchPostV5]
+  exact sepConj_mono
+    (fun h hp => modStackDispatchPostCallableExactFrame_weaken sp a b raVal (signExtend12 4095) h
+      (by rw [modStackDispatchPostCallableExactFrame_unfold]
+          exact modConcretePostNoX1ExactRegs_weaken_callable_frame sp a b h hp))
+    (fun h hp => memIs_implies_memOwn h hp)
+    h hExact
+
+/-- The v5 n=3 MOD lane, shift=0: stack-dispatch precondition → `modStackDispatchPostV5`. -/
+theorem evm_mod_n3_lane_shift0_v5 (sp base : Word) (a b : EvmWord)
+    (raVal v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_z : (clzResult (b.getLimbN 2)).1 = 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat)) v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostV5 sp a b) := by
+  have hb2ge : (b.getLimbN 2).toNat ≥ 2 ^ 63 := clz_zero_imp_msb hshift_z
+  obtain ⟨bltu_1, hbltu_1⟩ : ∃ x, x = BitVec.ult (0 : Word) (b.getLimbN 2) := ⟨_, rfl⟩
+  obtain ⟨bltu_0, hbltu_0⟩ :
+      ∃ x, x = BitVec.ult (iterN3V5 bltu_1 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) 0
+          (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) 0 0).2.2.2.1
+        (b.getLimbN 2) := ⟨_, rfl⟩
+  have hc1 : bltu_1 = true → BitVec.ult (0 : Word) (b.getLimbN 2) = true :=
+    fun h => by rw [← hbltu_1]; exact h
+  have hm1 : bltu_1 = false → ¬ BitVec.ult (0 : Word) (b.getLimbN 2) :=
+    fun h => by rw [← hbltu_1, h]; decide
+  have hc0 : bltu_0 = true →
+      BitVec.ult (iterN3V5 bltu_1 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) 0
+        (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) 0 0).2.2.2.1 (b.getLimbN 2) = true :=
+    fun h => by rw [← hbltu_0]; exact h
+  have hm0 : bltu_0 = false →
+      ¬ BitVec.ult (iterN3V5 bltu_1 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) 0
+        (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) 0 0).2.2.2.1 (b.getLimbN 2) :=
+    fun h => by rw [← hbltu_0, h]; decide
+  obtain ⟨hmod0, hmod1, hmod2, hmod3⟩ := n3_shift0_mod_getLimbN_threaded a b
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) bltu_1 bltu_0
+    rfl rfl rfl rfl rfl rfl rfl hb3z hb2ge hc1 hm1 hc0 hm0
+  have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| (0 : Word) ≠ 0 := by
+    intro h
+    have h2 := (BitVec.or_eq_zero_iff.mp h).1
+    exact hb2nz (BitVec.or_eq_zero_iff.mp h2).2
+  have hpath := evm_mod_n3_full_shift0_param_v5_noNop bltu_1 bltu_0 sp base
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+    ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat)) v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0 scratchMem raVal hbnz' hb2nz hshift_z halign
+    hbltu_1 hbltu_0
+  refine cpsTripleWithin_mono_nSteps (by have h : unifiedDivBound = 946 := rfl; omega) <|
+    cpsTripleWithin_weaken ?_ ?_ hpath
+  · intro h hp
+    rw [divModStackDispatchPreNoX1_unfold] at hp
+    rw [show evmWordIs sp a =
+        ((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
+         ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3))
+        from by rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ rfl rfl rfl rfl]] at hp
+    rw [show evmWordIs (sp + 32) b =
+        (((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
+         ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3))
+        from by rw [evmWordIs_sp32_limbs_eq sp b _ _ _ _ rfl rfl rfl rfl]] at hp
+    rw [divScratchValuesCallNoX1_unfold, divScratchValues_unfold] at hp
+    rw [hb3z] at hp
+    simp only [word_add_zero]
+    xperm_hyp hp
+  · intro h hq
+    exact n3_shift0_modPost_to_modStackDispatchPost_v5 bltu_1 bltu_0 sp base a b
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) retMem dMem dloMem scratch_un0 scratchMem raVal
+      rfl rfl rfl rfl hmod0 hmod1 hmod2 hmod3 h hq
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5LaneShiftNzMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5LaneShiftNzMod.lean
@@ -1,0 +1,113 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5LaneShiftNzMod
+
+  The v5 n=3 MOD lane, shift≠0 case: from the stack-dispatch precondition
+  `divModStackDispatchPreNoX1` to `modStackDispatchPostV5`, over `modCode_noNop_v5`.
+  MOD mirror of `FullPathN3V5LaneShiftNz` (DIV n=3): composes the full entry→nopOff
+  path with the carry discharged from shape
+  (`evm_mod_n3_preloop_loop_denorm_v5_noNop_fromShape`) — bridged at the pre from
+  `divModStackDispatchPreNoX1` (op-agnostic `evmWordIs`/`divScratchValuesCallNoX1`
+  unfolds) — with the post bridge (`fullModN3UnifiedPostNoX1V5_to_modStackDispatchPostV5`)
+  fed the shape-derived remainder correctness
+  (`fullModN3RemainderWordV5_eq_mod_lane_of_shape`), and step-count widening to
+  `unifiedDivBound`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopFullToNopOffMod
+import EvmAsm.Evm64.DivMod.Spec.N3V5PostToDispatchPostV5Mod
+import EvmAsm.Evm64.DivMod.Spec.N3V5QuotientLaneShapeMod
+import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Mod
+import EvmAsm.Evm64.DivMod.Spec.UnifiedBzero
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_add_zero)
+
+theorem evm_mod_n3_lane_shiftNz_v5 (sp base : Word) (a b : EvmWord)
+    (raVal v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat)) v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostV5 sp a b) := by
+  -- The two runtime borrow flags, in clean `ult (fullDivN3R1V5 …)` form.
+  obtain ⟨bltu_1, hbltu_1⟩ :
+      ∃ x, x = BitVec.ult (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1 := ⟨_, rfl⟩
+  obtain ⟨bltu_0, hbltu_0⟩ :
+      ∃ x, x = BitVec.ult (fullDivN3R1V5 bltu_1 (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1 := ⟨_, rfl⟩
+  -- The per-digit `bltu` path matches, from the clean flag definitions.
+  have hc1 : bltu_1 = true →
+      BitVec.ult (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.2.1 = true := fun h => by rw [← hbltu_1]; exact h
+  have hm1 : bltu_1 = false →
+      ¬ BitVec.ult (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.2.1 := fun h => by rw [← hbltu_1, h]; decide
+  have hc0 : bltu_0 = true →
+      BitVec.ult (fullDivN3R1V5 bltu_1 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.2.1 = true := fun h => by rw [← hbltu_0]; exact h
+  have hm0 : bltu_0 = false →
+      ¬ BitVec.ult (fullDivN3R1V5 bltu_1 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+        (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).2.2.1 := fun h => by rw [← hbltu_0, h]; decide
+  -- Remainder correctness from shape (lane form).
+  have hdivWord := fullModN3RemainderWordV5_eq_mod_lane_of_shape bltu_1 bltu_0
+    (a := a) (b := b) rfl rfl rfl rfl rfl rfl rfl rfl
+    hb3z hshift_nz hb2nz hc1 hm1 hc0 hm0
+  -- The limb-`or` form of `b ≠ 0`, derived from `b2 ≠ 0`.
+  have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 := by
+    intro h
+    have h2 := (BitVec.or_eq_zero_iff.mp h).1
+    exact hb2nz (BitVec.or_eq_zero_iff.mp h2).2
+  -- The full entry→nopOff path with carry discharged from shape.
+  have hpath := evm_mod_n3_preloop_loop_denorm_v5_noNop_fromShape bltu_1 bltu_0 sp base
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    v5 v6 v7 v10 v11Old q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0 scratchMem raVal
+    hbnz' hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0
+  refine cpsTripleWithin_mono_nSteps (by have h : unifiedDivBound = 946 := rfl; omega) <|
+    cpsTripleWithin_weaken ?_ ?_ hpath
+  · -- pre-adapter: the dispatch pre unfolds to the explicit stack pre-state.
+    intro h hp
+    rw [divModStackDispatchPreNoX1_unfold] at hp
+    rw [show evmWordIs sp a =
+        ((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
+         ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3))
+        from by rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ rfl rfl rfl rfl]] at hp
+    rw [show evmWordIs (sp + 32) b =
+        (((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
+         ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3))
+        from by rw [evmWordIs_sp32_limbs_eq sp b _ _ _ _ rfl rfl rfl rfl]] at hp
+    rw [divScratchValuesCallNoX1_unfold, divScratchValues_unfold] at hp
+    simp only [word_add_zero]
+    xperm_hyp hp
+  · -- post bridge.
+    intro h hq
+    exact fullModN3UnifiedPostNoX1V5_to_modStackDispatchPostV5 bltu_1 bltu_0 sp base a b
+      retMem dMem dloMem scratch_un0 scratchMem raVal hdivWord h hq
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopCallCombosBorrowCarryMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopCallCombosBorrowCarryMod.lean
@@ -1,0 +1,171 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallCombosBorrowCarryMod
+
+  Borrow-dispatched call-first n=3 v5 two-iteration loop combos: the j=1 first
+  call iteration from the loop source and the call×call full path, each taking the
+  per-iteration second-addback carry only CONDITIONALLY on that iteration's
+  runtime mulsub borrow.  Thin variants of `divK_loop_n3_call_{j1_from_source,call}_..._v5_noNop`
+  (FullPathN3V5NoNopCallCombos) composing the borrowCarry exact-jN bodies (#7529)
+  through the same version-agnostic source-pre / j1→j0 bridges.  The guarded carry
+  hypotheses match the `loopN3SelectedBorrowCarryV5` bundle obligations (#7526),
+  discharged from shape in #7527.  Bead `evm-asm-wbc4i.9.3.3.3.4`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallExactBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- First n=3 call iteration (j=1) from the loop source, carry required only on
+    the runtime borrow branch. -/
+theorem divK_loop_n3_call_j1_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hcarry2_borrow :
+      BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) →
+      (let qHat := divKTrialCallV5QHat u3 u2 v2
+       let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+       let c3 := ms.2.2.2.2
+       let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+       let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+       carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0)) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3CallScratchNoX1 sp base (1 : Word)
+        (divKTrialCallV5QHat u3 u2 v2)
+        (divKTrialCallV5DLo v2)
+        (divKTrialCallV5Un0 u2)
+        (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) **
+        (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old))) := by
+  have J1 := divK_loop_body_n3_call_j1_exact_loopIterScratch_v5_noNop_modCode_borrowCarry sp base
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu hcarry2_borrow
+  have J1f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J1
+  exact cpsTripleWithin_weaken
+    (loopN3PreWithScratchV4NoX1_to_call_j1_pre
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+      retMem dMem dloMem scratchUn0 scratchMem)
+    (fun h hp => hp)
+    J1f
+
+/-- Full n=3 call×call path from the loop source, carry required only on each
+    iteration's runtime borrow branch. -/
+theorem divK_loop_n3_call_call_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : BitVec.ult u3 v2)
+    (hcarry2_borrow_1 :
+      BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) →
+      (let qHat := divKTrialCallV5QHat u3 u2 v2
+       let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+       let c3 := ms.2.2.2.2
+       let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+       let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+       carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0))
+    (hbltu_0 :
+      BitVec.ult
+        (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
+    (hcarry2_borrow_0 :
+      let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r1.2.2.2.2.1
+        (mulsubN4_c3 (divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v2)
+          v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      (let qHat := divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v2
+       let ms := mulsubN4 qHat v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1
+       let c3 := ms.2.2.2.2
+       let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+       let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (r1.2.2.2.2.1 - c3) v0 v1 v2 v3
+       carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0)) :
+    let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (234 + 234) (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v2)
+        (divKTrialCallV5DLo v2)
+        (divKTrialCallV5Un0 r1.2.2.1)
+        (divKTrialCallV5ScratchOut r1.2.2.2.1 r1.2.2.1 v2
+          (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem))
+        v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) := by
+  intro r1 uBase1 qAddr1
+  have J1 := divK_loop_n3_call_j1_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu_1 hcarry2_borrow_1
+  subst r1
+  subst uBase1
+  subst qAddr1
+  have J0 := divK_loop_body_n3_call_j0_exact_loopIterScratch_v5_noNop_modCode_borrowCarry sp base
+    (1 : Word)
+    ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q0Old raVal
+    (base + div128CallRetOff) v2 (divKTrialCallV5DLo v2)
+    (divKTrialCallV5Un0 u2) (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+    halign hbltu_0 hcarry2_borrow_0
+  have J0f := cpsTripleWithin_frameR
+    (((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
+    (by pcFree) J0
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN3CallScratchNoX1_j1_to_call_j0_pre
+      sp base (divKTrialCallV5QHat u3 u2 v2) (divKTrialCallV5DLo v2)
+      (divKTrialCallV5Un0 u2) (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q0Old raVal)
+    J1 J0f
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopCallCombosBorrowCarryNamedMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopCallCombosBorrowCarryNamedMod.lean
@@ -1,0 +1,101 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallCombosBorrowCarryNamedMod
+
+  Named-carry restatements of the call-first n=3 borrowCarry combos: identical to
+  the inline-carry combos (FullPathN3V5NoNopCallCombosBorrowCarry, #7531) but with
+  the second-addback carry obligation written as the NAMED
+  `loopBodyN3CallAddbackCarry2NzV5` (defeq to the inline form, unfolded here where
+  `mulsubN4`/`addbackN4` are transparent).  These let the from-source borrowCarry
+  dispatch feed the bundle's named obligations to combos NAMED-to-NAMED, avoiding
+  the isDefEq explosion that arises when matching inline carry hypotheses with the
+  iteration windows held opaque.  Bead `evm-asm-wbc4i.9.3.3.3.4`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallCombosBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnifiedMod
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Named-carry restatement of `divK_loop_n3_call_j1_from_source_..._borrowCarry`. -/
+theorem divK_loop_n3_call_j1_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry_named
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hcarry2_borrow :
+      BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) →
+      loopBodyN3CallAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3CallScratchNoX1 sp base (1 : Word)
+        (divKTrialCallV5QHat u3 u2 v2)
+        (divKTrialCallV5DLo v2)
+        (divKTrialCallV5Un0 u2)
+        (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) **
+        (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old))) :=
+  divK_loop_n3_call_j1_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu hcarry2_borrow
+
+/-- Named-carry restatement of `divK_loop_n3_call_call_from_source_..._borrowCarry`. -/
+theorem divK_loop_n3_call_call_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry_named
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : BitVec.ult u3 v2)
+    (hcarry2_borrow_1 :
+      BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) →
+      loopBodyN3CallAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_0 :
+      BitVec.ult
+        (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
+    (hcarry2_borrow_0 :
+      let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r1.2.2.2.2.1
+        (mulsubN4_c3 (divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v2)
+          v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      loopBodyN3CallAddbackCarry2NzV5 v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (234 + 234) (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v2)
+        (divKTrialCallV5DLo v2)
+        (divKTrialCallV5Un0 r1.2.2.1)
+        (divKTrialCallV5ScratchOut r1.2.2.2.1 r1.2.2.1 v2
+          (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem))
+        v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) :=
+  divK_loop_n3_call_call_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu_1 hcarry2_borrow_1 hbltu_0 hcarry2_borrow_0
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopCallCombosMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopCallCombosMod.lean
@@ -1,0 +1,260 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallCombosMod  (MOD mirror of FullPathN3V5NoNopCallCombos)
+
+  v5/no-NOP n=3 two-iteration loop combos whose FIRST iteration is a call:
+  `divK_loop_n3_call_j1_from_source_exact_loopIterScratch_v5_noNop_modCode` (the j=1 first
+  call iteration from the callable-ready loop source) and the call×{call,max}
+  full-path combos (`divK_loop_n3_call_{call,max}_from_source_exact_loopIterScratch_v5_noNop_modCode`).
+  Mirror of the v4 analogs (`FullPathN3V4NoNop` :653/:734/:1087) over
+  `modCode_noNop_v5`, composing the v5 call/max exact-jN dispatch bodies (#7516
+  call, #7512 max) through the SHARED (version-agnostic) source-pre / j1→j0 post
+  bridges reused from the v4 file.  The v5 call dispatch consumes the inline
+  carry hypotheses (vs the v4 named props); the max dispatch keeps the shared
+  `isAddbackCarry2NzN3Max`.  Bead `evm-asm-wbc4i.9.3.3.2.3`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallExactX1Mod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxExactX1Mod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- First n=3 call iteration (j=1) from the callable-ready v5 loop source,
+    preserving concrete `x1` and carrying the j=0 source atoms as a frame. -/
+theorem divK_loop_n3_call_j1_from_source_exact_loopIterScratch_v5_noNop_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hcarry2_nz :
+      let qHat := divKTrialCallV5QHat u3 u2 v2
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3CallScratchNoX1 sp base (1 : Word)
+        (divKTrialCallV5QHat u3 u2 v2)
+        (divKTrialCallV5DLo v2)
+        (divKTrialCallV5Un0 u2)
+        (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) **
+        (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old))) := by
+  have J1 := divK_loop_body_n3_call_j1_exact_loopIterScratch_v5_noNop_modCode sp base
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu hcarry2_nz
+  have J1f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J1
+  exact cpsTripleWithin_weaken
+    (loopN3PreWithScratchV4NoX1_to_call_j1_pre
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+      retMem dMem dloMem scratchUn0 scratchMem)
+    (fun h hp => hp)
+    J1f
+
+/-- Full n=3 call×call path from the callable-ready v5 loop source, preserving
+    concrete `x1` and carrying the j=1 stored u4/q atoms. -/
+theorem divK_loop_n3_call_call_from_source_exact_loopIterScratch_v5_noNop_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : BitVec.ult u3 v2)
+    (hcarry2_nz_1 :
+      let qHat := divKTrialCallV5QHat u3 u2 v2
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0)
+    (hbltu_0 :
+      BitVec.ult
+        (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
+    (hcarry2_nz_0 :
+      let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      let qHat := divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v2
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (r1.2.2.2.2.1 - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (234 + 234) (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v2)
+        (divKTrialCallV5DLo v2)
+        (divKTrialCallV5Un0 r1.2.2.1)
+        (divKTrialCallV5ScratchOut r1.2.2.2.1 r1.2.2.1 v2
+          (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem))
+        v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) := by
+  intro r1 uBase1 qAddr1
+  have J1 := divK_loop_n3_call_j1_from_source_exact_loopIterScratch_v5_noNop_modCode
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu_1 hcarry2_nz_1
+  subst r1
+  subst uBase1
+  subst qAddr1
+  have J0 := divK_loop_body_n3_call_j0_exact_loopIterScratch_v5_noNop_modCode sp base
+    (1 : Word)
+    ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q0Old raVal
+    (base + div128CallRetOff) v2 (divKTrialCallV5DLo v2)
+    (divKTrialCallV5Un0 u2) (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+    halign hbltu_0 hcarry2_nz_0
+  have J0f := cpsTripleWithin_frameR
+    (((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
+    (by pcFree) J0
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN3CallScratchNoX1_j1_to_call_j0_pre
+      sp base (divKTrialCallV5QHat u3 u2 v2) (divKTrialCallV5DLo v2)
+      (divKTrialCallV5Un0 u2) (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q0Old raVal)
+    J1 J0f
+
+/-- Full n=3 call×max path from the callable-ready v5 loop source, preserving
+    concrete `x1` and carrying the j=1 stored u4/q atoms. -/
+theorem divK_loop_n3_call_max_from_source_exact_loopIterScratch_v5_noNop_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : BitVec.ult u3 v2)
+    (hcarry2_nz_1 :
+      let qHat := divKTrialCallV5QHat u3 u2 v2
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0)
+    (hbltu_0 :
+      let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      ¬BitVec.ult r1.2.2.2.1 v2)
+    (hcarry2_nz_0 :
+      let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      isAddbackCarry2NzN3Max v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (234 + 152) (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+        (sp + signExtend12 3960 ↦ₘ v2) **
+        (sp + signExtend12 3952 ↦ₘ (divKTrialCallV5DLo v2)) **
+        (sp + signExtend12 3944 ↦ₘ (divKTrialCallV5Un0 u2)) **
+        (sp + signExtend12 3936 ↦ₘ (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)) **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) := by
+  intro r1 uBase1 qAddr1
+  have J1 := divK_loop_n3_call_j1_from_source_exact_loopIterScratch_v5_noNop_modCode
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu_1 hcarry2_nz_1
+  subst r1
+  subst uBase1
+  subst qAddr1
+  have J0 := divK_loop_body_n3_max_j0_exact_loopIterScratch_v5_noNop_modCode sp base
+    (1 : Word)
+    ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q0Old raVal
+    (base + div128CallRetOff) v2 (divKTrialCallV5DLo v2)
+    (divKTrialCallV5Un0 u2) (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+    hbltu_0 hcarry2_nz_0
+  have J0f := cpsTripleWithin_frameR
+    (((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
+    (by pcFree) J0
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN3CallScratchNoX1_j1_to_max_j0_pre
+      sp base (divKTrialCallV5QHat u3 u2 v2) (divKTrialCallV5DLo v2)
+      (divKTrialCallV5Un0 u2) (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q0Old raVal)
+    J1 J0f
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopCallExactBorrowCarryMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopCallExactBorrowCarryMod.lean
@@ -1,0 +1,126 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallExactBorrowCarryMod
+
+  Borrow-dispatched variants of the n=3 v5 call exact-jN loop bodies: each takes
+  the second-addback carry obligation only CONDITIONALLY on that iteration's
+  runtime mulsub borrow (`borrow → carry`), instead of unconditionally.  Thin
+  variants of `divK_loop_body_n3_call_j{0,1}_exact_loopIterScratch_v5_noNop_modCode`
+  (FullPathN3V5NoNopCallExact) — the by_cases on the borrow is identical, and in
+  the addback (borrow) branch the unconditional carry is recovered as
+  `hcarry2_borrow hborrow`.  These are the per-digit bodies the n=3 borrowCarry
+  combos consume (the from-shape carry being borrow-conditional, #7527).
+  Bead `evm-asm-wbc4i.9.3.3.3.4`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallExactX1Mod
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Call exact-jN j=0, carry required only on the runtime borrow branch. -/
+theorem divK_loop_body_n3_call_j0_exact_loopIterScratch_v5_noNop_modCode_borrowCarry (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hcarry2_borrow :
+      BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) →
+      (let qHat := divKTrialCallV5QHat u3 u2 v2
+       let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+       let c3 := ms.2.2.2.2
+       let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+       let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+       carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0)) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopBodyN3CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV5QHat u3 u2 v2)
+        (divKTrialCallV5DLo v2)
+        (divKTrialCallV5Un0 u2)
+        (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  by_cases hborrow : BitVec.ult uTop
+      (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hcarry2_nz := hcarry2_borrow hborrow
+    have hborrow_nz : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word) := by
+      unfold mulsubN4_c3 at hborrow
+      rw [if_pos hborrow]; decide
+    exact divK_loop_body_n3_call_addback_j0_exact_loopIterScratch_v5_noNop_modCode
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow_nz hcarry2_nz
+  · have hborrow_zero :
+        mulsubN4NoBorrow (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold mulsubN4NoBorrow
+      dsimp only
+      unfold mulsubN4_c3 at hborrow
+      rw [if_neg hborrow]
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      divK_loop_body_n3_call_skip_j0_exact_loopIterScratch_v5_noNop_modCode
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow_zero
+
+/-- Call exact-jN j=1, carry required only on the runtime borrow branch. -/
+theorem divK_loop_body_n3_call_j1_exact_loopIterScratch_v5_noNop_modCode_borrowCarry (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hcarry2_borrow :
+      BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) →
+      (let qHat := divKTrialCallV5QHat u3 u2 v2
+       let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+       let c3 := ms.2.2.2.2
+       let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+       let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+       carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0)) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v5 base)
+      (loopBodyN3CallSkipJgt0PreV4NoX1 sp (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base (1 : Word)
+        (divKTrialCallV5QHat u3 u2 v2)
+        (divKTrialCallV5DLo v2)
+        (divKTrialCallV5Un0 u2)
+        (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  by_cases hborrow : BitVec.ult uTop
+      (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hcarry2_nz := hcarry2_borrow hborrow
+    have hborrow_nz : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word) := by
+      unfold mulsubN4_c3 at hborrow
+      rw [if_pos hborrow]; decide
+    exact divK_loop_body_n3_call_addback_jgt0_exact_loopIterScratch_v5_noNop_modCode
+      (1 : Word) sp base EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow_nz hcarry2_nz
+  · have hborrow_zero :
+        mulsubN4NoBorrow (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold mulsubN4NoBorrow
+      dsimp only
+      unfold mulsubN4_c3 at hborrow
+      rw [if_neg hborrow]
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      divK_loop_body_n3_call_skip_j1_exact_loopIterScratch_v5_noNop_modCode
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow_zero
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopCallExactX1Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopCallExactX1Mod.lean
@@ -1,0 +1,351 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallExactX1Mod
+
+  v5/no-NOP n=3 call-path exact-x1 loop-iteration wrappers over `modCode_noNop_v5`,
+  exposing the unified scratch loop-iteration post `loopIterPostN3CallScratchNoX1`
+  (with concrete `x1 = raVal`).  Lifts the four v5 call exact-x1 raws
+  (CallSkipExactX1V5NoNop #7513, CallAddbackBeqExactX1V5NoNop #7515) via
+  `cpsTripleWithin_extend_code`, converts each to the scratch post through the
+  shared `loopIterPostN3CallScratchNoX1_{skip,addback}` rewrites, then dispatches
+  on the computed mulsub borrow bit (`by_cases`) to give the call exact-jN bodies
+  (j=0 / j=1).  Mirror of the v4 analogs (`FullPathN3V4NoNop` :338/:390/:442/
+  :494/:547/:588); the only deviation is the v5 inline borrow/carry hypotheses
+  (vs the v4 named props) bridged through `mulsubN4_c3 = (mulsubN4 …).2.2.2.2`.
+  Bead `evm-asm-wbc4i.9.3.3.2.1`.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallSkipExactX1V5NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN3V5.CallAddbackBeqExactX1V5NoNop
+import EvmAsm.Evm64.DivMod.Compose.V5NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Loop body n=3, call+skip, j=0 over `modCode_noNop_v5`, preserving concrete
+    `x1` and exposing the scratch loop-iteration post. -/
+theorem divK_loop_body_n3_call_skip_j0_exact_loopIterScratch_v5_noNop_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 158 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopBodyN3CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV5QHat u3 u2 v2)
+        (divKTrialCallV5DLo v2)
+        (divKTrialCallV5Un0 u2)
+        (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  have hb :
+      ¬BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) := by
+    unfold mulsubN4NoBorrow at hborrow
+    dsimp only [] at hborrow
+    intro hlt
+    unfold mulsubN4_c3 at hlt
+    rw [if_pos hlt] at hborrow
+    exact (by decide : (1 : Word) ≠ (0 : Word)) hborrow
+  exact cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by
+      have hpost :
+          ((loopBodyN3CallSkipPostJScratchNoX1 sp base (0 : Word)
+            (divKTrialCallV5QHat u3 u2 v2)
+            (divKTrialCallV5DLo v2)
+            (divKTrialCallV5Un0 u2)
+            (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop) ** (.x1 ↦ᵣ raVal)) h := by
+        unfold loopBodyN3CallSkipJ0PostV5NoX1 at hp
+        unfold loopBodyN3CallSkipPostJScratchNoX1
+        simpa only [sepConj_assoc'] using hp
+      rw [loopIterPostN3CallScratchNoX1_skip hb] at hpost
+      exact hpost)
+    (cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v5_sub_modCode_noNop_v5)
+      (divK_loop_body_n3_call_skip_j0_v5_spec_within_noNop_exact_x1
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow))
+
+/-- Loop body n=3, call+skip, j=1 over `modCode_noNop_v5`, preserving concrete
+    `x1` and exposing the scratch loop-iteration post. -/
+theorem divK_loop_body_n3_call_skip_j1_exact_loopIterScratch_v5_noNop_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 158 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v5 base)
+      (loopBodyN3CallSkipJgt0PreV4NoX1 sp (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base (1 : Word)
+        (divKTrialCallV5QHat u3 u2 v2)
+        (divKTrialCallV5DLo v2)
+        (divKTrialCallV5Un0 u2)
+        (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  have hb :
+      ¬BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) := by
+    unfold mulsubN4NoBorrow at hborrow
+    dsimp only [] at hborrow
+    intro hlt
+    unfold mulsubN4_c3 at hlt
+    rw [if_pos hlt] at hborrow
+    exact (by decide : (1 : Word) ≠ (0 : Word)) hborrow
+  exact cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by
+      have hpost :
+          ((loopBodyN3CallSkipPostJScratchNoX1 sp base (1 : Word)
+            (divKTrialCallV5QHat u3 u2 v2)
+            (divKTrialCallV5DLo v2)
+            (divKTrialCallV5Un0 u2)
+            (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop) ** (.x1 ↦ᵣ raVal)) h := by
+        unfold loopBodyN3CallSkipJgt0PostV5NoX1 at hp
+        unfold loopBodyN3CallSkipPostJScratchNoX1
+        simpa only [sepConj_assoc'] using hp
+      rw [loopIterPostN3CallScratchNoX1_skip hb] at hpost
+      exact hpost)
+    (cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v5_sub_modCode_noNop_v5)
+      (divK_loop_body_n3_call_skip_j1_v5_spec_within_noNop_exact_x1
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow))
+
+/-- Loop body n=3, call+addback, j=0 over `modCode_noNop_v5`, preserving concrete
+    `x1` and exposing the scratch loop-iteration post. -/
+theorem divK_loop_body_n3_call_addback_j0_exact_loopIterScratch_v5_noNop_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word))
+    (hcarry2_nz :
+      let qHat := divKTrialCallV5QHat u3 u2 v2
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopBodyN3CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV5QHat u3 u2 v2)
+        (divKTrialCallV5DLo v2)
+        (divKTrialCallV5Un0 u2)
+        (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  have hb :
+      BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) := by
+    by_contra hlt
+    unfold mulsubN4_c3 at hlt
+    rw [if_neg hlt] at hborrow
+    exact hborrow rfl
+  exact cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by
+      have hpost :
+          ((loopBodyN3CallAddbackBeqPostJScratchNoX1 sp base (0 : Word)
+            (divKTrialCallV5QHat u3 u2 v2)
+            (divKTrialCallV5DLo v2)
+            (divKTrialCallV5Un0 u2)
+            (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop) ** (.x1 ↦ᵣ raVal)) h := by
+        unfold loopBodyN3CallAddbackJ0PostV5NoX1 at hp
+        unfold loopBodyN3CallAddbackBeqPostJScratchNoX1
+        simpa only [sepConj_assoc'] using hp
+      rw [loopIterPostN3CallScratchNoX1_addback hb] at hpost
+      exact hpost)
+    (cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v5_sub_modCode_noNop_v5)
+      (divK_loop_body_n3_call_addback_j0_beq_v5_spec_within_noNop_exact_x1
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz))
+
+/-- Loop body n=3, call+addback, j>0 over `modCode_noNop_v5`, preserving concrete
+    `x1` and exposing the scratch loop-iteration post. -/
+theorem divK_loop_body_n3_call_addback_jgt0_exact_loopIterScratch_v5_noNop_modCode (j sp base : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word))
+    (hcarry2_nz :
+      let qHat := divKTrialCallV5QHat u3 u2 v2
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v5 base)
+      (loopBodyN3CallSkipJgt0PreV4NoX1 sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base j
+        (divKTrialCallV5QHat u3 u2 v2)
+        (divKTrialCallV5DLo v2)
+        (divKTrialCallV5Un0 u2)
+        (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  have hb :
+      BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) := by
+    by_contra hlt
+    unfold mulsubN4_c3 at hlt
+    rw [if_neg hlt] at hborrow
+    exact hborrow rfl
+  exact cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by
+      have hpost :
+          ((loopBodyN3CallAddbackBeqPostJScratchNoX1 sp base j
+            (divKTrialCallV5QHat u3 u2 v2)
+            (divKTrialCallV5DLo v2)
+            (divKTrialCallV5Un0 u2)
+            (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop) ** (.x1 ↦ᵣ raVal)) h := by
+        unfold loopBodyN3CallAddbackJgt0PostV5NoX1 at hp
+        unfold loopBodyN3CallAddbackBeqPostJScratchNoX1
+        simpa only [sepConj_assoc'] using hp
+      rw [loopIterPostN3CallScratchNoX1_addback hb] at hpost
+      exact hpost)
+    (cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v5_sub_modCode_noNop_v5)
+      (divK_loop_body_n3_call_addback_jgt0_beq_v5_spec_within_noNop_exact_x1 j hpos
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz))
+
+/-- Loop body n=3, call path, j=0 over `modCode_noNop_v5`, selecting the skip or
+    addback correction from the computed mulsub borrow bit (call exact-jN). -/
+theorem divK_loop_body_n3_call_j0_exact_loopIterScratch_v5_noNop_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hcarry2_nz :
+      let qHat := divKTrialCallV5QHat u3 u2 v2
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopBodyN3CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV5QHat u3 u2 v2)
+        (divKTrialCallV5DLo v2)
+        (divKTrialCallV5Un0 u2)
+        (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  by_cases hborrow : BitVec.ult uTop
+      (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word) := by
+      unfold mulsubN4_c3 at hborrow
+      rw [if_pos hborrow]; decide
+    exact divK_loop_body_n3_call_addback_j0_exact_loopIterScratch_v5_noNop_modCode
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow_nz hcarry2_nz
+  · have hborrow_zero :
+        mulsubN4NoBorrow (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold mulsubN4NoBorrow
+      dsimp only
+      unfold mulsubN4_c3 at hborrow
+      rw [if_neg hborrow]
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      divK_loop_body_n3_call_skip_j0_exact_loopIterScratch_v5_noNop_modCode
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow_zero
+
+/-- Loop body n=3, call path, j=1 over `modCode_noNop_v5`, selecting the skip or
+    addback correction from the computed mulsub borrow bit (call exact-jN). -/
+theorem divK_loop_body_n3_call_j1_exact_loopIterScratch_v5_noNop_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hcarry2_nz :
+      let qHat := divKTrialCallV5QHat u3 u2 v2
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v5 base)
+      (loopBodyN3CallSkipJgt0PreV4NoX1 sp (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base (1 : Word)
+        (divKTrialCallV5QHat u3 u2 v2)
+        (divKTrialCallV5DLo v2)
+        (divKTrialCallV5Un0 u2)
+        (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  by_cases hborrow : BitVec.ult uTop
+      (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word) := by
+      unfold mulsubN4_c3 at hborrow
+      rw [if_pos hborrow]; decide
+    exact divK_loop_body_n3_call_addback_jgt0_exact_loopIterScratch_v5_noNop_modCode
+      (1 : Word) sp base EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow_nz hcarry2_nz
+  · have hborrow_zero :
+        mulsubN4NoBorrow (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold mulsubN4NoBorrow
+      dsimp only
+      unfold mulsubN4_c3 at hborrow
+      rw [if_neg hborrow]
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      divK_loop_body_n3_call_skip_j1_exact_loopIterScratch_v5_noNop_modCode
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow_zero
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopFromShapeMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopFromShapeMod.lean
@@ -1,0 +1,100 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopFromShapeMod
+
+  Full n=3 v5 stack-pre → unified-post path with the carry hypothesis DISCHARGED
+  FROM SHAPE.  Wraps `evm_mod_n3_preloop_loop_unified_exact_x1_scratch_v5_noNop_borrowCarry`
+  (#7540): instead of taking `loopN3SelectedBorrowCarryV5` as a hypothesis, it
+  discharges it via `loopN3SelectedBorrowCarryV5_of_shape` (#7527), and accepts the
+  borrow flags in the CLEAN `ult (fullDivN3R1V5 bltu_1 …).2.2.2.1 v2'` form (rather
+  than #7540's `iterN3Max`/`iterWithDoubleAddback` `match` form), bridged via the
+  dispatch-form equalities `fullDivN3R1V5_true`/`fullDivN3R1V5_false`.  This removes
+  the last shape-derived obligation from the n=3 loop path — the direct input to the
+  n=3 lane.  n3 mirror of `evm_div_n2_stack_pre_to_unified_post_v5_noNop_fromShape`.
+  Bead `evm-asm-wbc4i.9.3.3.3.4`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloopBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Spec.N3V5BundleOfShape
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Full n=3 v5 stack-pre → unified-post, with the borrow-carry bundle discharged
+    from shape; borrow flags in the clean `fullDivN3R1V5` form. -/
+theorem evm_mod_n3_stack_pre_to_unified_post_v5_noNop_fromShape
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1)
+    (hbltu_0 : bltu_0 =
+      BitVec.ult (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 468) base (base + denormOff)
+      (modCode_noNop_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      ((loopN3UnifiedPostV5NoX1 bltu_1 bltu_0 sp base
+        (fullDivN3NormV b0 b1 b2 b3).1
+        (fullDivN3NormV b0 b1 b2 b3).2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.2
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+        (0 : Word)
+        (fullDivN3NormU a0 a1 a2 a3 b2).1
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))) := by
+  apply evm_mod_n3_preloop_loop_unified_exact_x1_scratch_v5_noNop_borrowCarry
+    bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz halign hbltu_1
+  case hbltu_0 =>
+    cases bltu_1 <;> simpa [fullDivN3R1V5_true, fullDivN3R1V5_false] using hbltu_0
+  case hcarry =>
+    apply loopN3SelectedBorrowCarryV5_of_shape a0 a1 a2 a3 b0 b1 b2 b3
+      bltu_1 bltu_0 hb3z hb2nz hshift_nz
+    · intro h; rw [← hbltu_1]; exact h
+    · intro h; rw [← hbltu_1, h]; decide
+    · intro h; rw [← hbltu_0]; exact h
+    · intro h; rw [← hbltu_0, h]; decide
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopFullToNopOffMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopFullToNopOffMod.lean
@@ -1,0 +1,121 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopFullToNopOffMod
+
+  The full n=3 MOD v5 path from the stack pre-state to the unified post at
+  `base + nopOff`, carry discharged from shape, over `modCode_noNop_v5`.  MOD mirror
+  of `fullDivN3_preloop_loop_denorm_v5_noNop_fromShape` (`FullPathN3V5NoNopFullToNopOff`):
+  composes the MOD loop path (`evm_mod_n3_stack_pre_to_unified_post_v5_noNop_fromShape`,
+  base→denormOff) — bridged per-case through the op-agnostic
+  `loopN3UnifiedPostV5NoX1_to_fullDivN3DenormPreV5_frame_{FF,FT,TF,TT}` — with the MOD
+  denorm epilogue (`evm_mod_n3_denorm_epilogue_bundled_spec_noNop_v5Final_exact_x1_frame`),
+  landing `fullModN3UnifiedPostNoX1V5`.  Milestone D sub-unit of the n=3 MOD lane.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopFromShapeMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5FamiliesMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopDenormBridge
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Full n=3 MOD v5 stack-pre → `fullModN3UnifiedPostNoX1V5` at `base + nopOff`,
+    carry discharged from shape. -/
+theorem evm_mod_n3_preloop_loop_denorm_v5_noNop_fromShape
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1)
+    (hbltu_0 : bltu_0 =
+      BitVec.ult (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1) :
+    cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 468) + (2 + 23 + 10))
+      base (base + nopOff) (modCode_noNop_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      (fullModN3UnifiedPostNoX1V5 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem **
+       (.x1 ↦ᵣ raVal)) := by
+  have hShift : fullDivN3Shift b2 ≠ 0 := by delta fullDivN3Shift; exact hshift_nz
+  have hDenorm := evm_mod_n3_denorm_epilogue_bundled_spec_noNop_v5Final_exact_x1_frame
+    bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+    retMem dMem dloMem scratchUn0 scratchMem raVal hShift
+  have hLoop := evm_mod_n3_stack_pre_to_unified_post_v5_noNop_fromShape
+    bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0
+  have hLoop' :
+      cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 468) base (base + denormOff)
+        (modCode_noNop_v5 base)
+        (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+          (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+          ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+          ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+          ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+          ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+          ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+          ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+          ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+          ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+          ((sp + signExtend12 4024) ↦ₘ u4Old) **
+          ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+          ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+          ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+         ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+          (sp + signExtend12 3968 ↦ₘ retMem) **
+          (sp + signExtend12 3960 ↦ₘ dMem) **
+          (sp + signExtend12 3952 ↦ₘ dloMem) **
+          (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+          (sp + signExtend12 3936 ↦ₘ scratchMem) **
+          (.x1 ↦ᵣ raVal)))
+        (fullDivN3DenormPreV5 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 **
+         fullDivN3FrameNoX1V5 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+           retMem dMem dloMem scratchUn0 **
+         ((sp + signExtend12 3936) ↦ₘ
+           fullDivN3ScratchMemV5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) **
+         (.x1 ↦ᵣ raVal)) := by
+    refine cpsTripleWithin_weaken (fun h hp => hp) ?_ hLoop
+    intro h hq
+    cases bltu_1 <;> cases bltu_0
+    · exact loopN3UnifiedPostV5NoX1_to_fullDivN3DenormPreV5_frame_FF
+        sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem raVal h hq
+    · exact loopN3UnifiedPostV5NoX1_to_fullDivN3DenormPreV5_frame_FT
+        sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem raVal h hq
+    · exact loopN3UnifiedPostV5NoX1_to_fullDivN3DenormPreV5_frame_TF
+        sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem raVal h hq
+    · exact loopN3UnifiedPostV5NoX1_to_fullDivN3DenormPreV5_frame_TT
+        sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem raVal h hq
+  exact cpsTripleWithin_mono_nSteps (by decide) <|
+    cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hLoop' hDenorm
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopLoopSelectedBorrowCarryMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopLoopSelectedBorrowCarryMod.lean
@@ -1,0 +1,54 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopLoopSelectedBorrowCarry
+
+  Borrow-conditional instantiation of the v5 no-NOP exact-`x1` n=3 loop with
+  explicit normalized values: the `_borrowCarry` analog of
+  `evm_div_n3_loop_unified_inst_noNop_exact_x1_v5_selectedCarry` (#7521).  Plugs
+  the preloop's normalized divisor/window (`shift`/`antiShift`/`b0'..b3'`/`u1..u4`,
+  `j = 3`, `uTop = 0`) into the borrow-dispatched loop (#7538), taking the
+  satisfiable-from-shape `loopN3SelectedBorrowCarryV5` bundle in place of the
+  unconditional selected carries.  The bundle is discharged from shape later by the
+  from-shape composition.  Bead `evm-asm-wbc4i.9.3.3.3.4`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnifiedBorrowCarryMod
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Borrow-conditional instantiation of the v5 no-NOP exact-`x1` n=3 loop with
+    explicit normalized values (the form the preloop composition consumes), feeding
+    the `loopN3SelectedBorrowCarryV5` bundle. -/
+theorem evm_mod_n3_loop_unified_inst_noNop_exact_x1_v5_borrowCarry_modCode
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (shift antiShift b0' b1' b2' b3' u0 u1 u2 u3 u4 : Word)
+    (v10Old v11Old jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 = BitVec.ult u4 b2')
+    (hbltu_0 : bltu_0 =
+      match bltu_1 with
+      | false => BitVec.ult (iterN3Max b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)).2.2.2.1 b2'
+      | true =>
+        BitVec.ult
+          (iterWithDoubleAddback (divKTrialCallV5QHat u4 u3 b2')
+            b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)).2.2.2.1 b2')
+    (hcarry : loopN3SelectedBorrowCarryV5 bltu_1 bltu_0
+      b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0) :
+    cpsTripleWithin 468 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jMem (3 : Word) shift u0 v10Old v11Old antiShift
+        b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0 (0 : Word) (0 : Word)
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN3UnifiedPostV5NoX1 bltu_1 bltu_0 sp base
+        b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) :=
+  divK_loop_n3_unified_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry
+    bltu_1 bltu_0 sp base jMem (3 : Word) shift u0 v10Old v11Old antiShift
+    b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0 (0 : Word) (0 : Word) raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu_1 hbltu_0 hcarry
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopMaxAddbackNormMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopMaxAddbackNormMod.lean
@@ -1,0 +1,76 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxAddbackNormMod
+
+  MOD mirror of `FullPathN3V5NoNopMaxAddbackNorm`: v5/no-NOP norm-pre wrappers for
+  the n=3 max+addback-beq loop bodies over `modCode_noNop_v5`.  Byte-for-byte the
+  DIV wrappers, swapping ONLY the extend target
+  (`sharedDivModCodeNoNop_v5_sub_divCode_noNop_v5` →
+  `sharedDivModCodeNoNop_v5_sub_modCode_noNop_v5`).  Raw bodies (over the SHARED
+  `sharedDivModCodeNoNop_v5`) + code-agnostic NormPre/Post defs reused verbatim.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxAddbackNorm
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- Loop body n=3, max+addback-beq, j=0 over `modCode_noNop_v5`. -/
+theorem divK_loop_body_n3_max_addback_j0_beq_norm_v5_noNop_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult u3 v2)
+    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopBodyN3MaxSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN3AddbackBeqPost sp (0 : Word) (signExtend12 4095 : Word)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n3_max_addback_j0_beq_v5_spec_within_noNop
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hcarry2_nz hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v5_sub_modCode_noNop_v5) raw
+  rw [loopBodyN3MaxSkipPre_unfold] at raw'
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw'
+  delta loopBodyN3MaxSkipJ0NormPreV4
+  exact raw'
+
+/-- Loop body n=3, max+addback-beq, j>0 over `modCode_noNop_v5`. -/
+theorem divK_loop_body_n3_max_addback_jgt0_beq_norm_v5_noNop_modCode (j sp base : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult u3 v2)
+    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v5 base)
+      (loopBodyN3MaxAddbackJgt0NormPreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN3AddbackBeqPost sp j (signExtend12 4095 : Word)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n3_max_addback_jgt0_beq_v5_spec_within_noNop j hpos
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hcarry2_nz hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v5_sub_modCode_noNop_v5) raw
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopBodyN3MaxAddbackJgt0NormPreV4 at hp
+      xperm_hyp hp)
+    (fun h hp => hp)
+    raw'
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopMaxCombosMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopMaxCombosMod.lean
@@ -1,0 +1,194 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxCombosMod  (MOD mirror of FullPathN3V5NoNopMaxCombos)
+
+  v5/no-NOP n=3 two-iteration loop combos whose FIRST iteration is a max:
+  `divK_loop_n3_max_{max,call}_from_source_exact_loopIterScratch_v5_noNop_modCode`.
+  Mirror of the v4 analogs (`FullPathN3V4NoNopMaxCall` :131/:211) over
+  `modCode_noNop_v5`, composing the v5 max/call exact-jN dispatch bodies (#7512
+  max, #7516 call) through the SHARED version-agnostic source-pre / j1→j0 post
+  bridges reused from the v4 files (`loopN3PreWithScratchV4NoX1_to_max_j1_pre`,
+  `loopIterPostN3MaxScratchX1_j1_to_{max,call}_j0_pre`).  `max_max` is fully
+  version-agnostic (pure `iterN3Max`, shared `isAddbackCarry2NzN3Max`); `max_call`
+  feeds the v5 call-j0 dispatch its inline carry hypothesis.  Completes the 4
+  n=3 v5 loop combos (call_call/call_max in #7517 + max_max/max_call here).
+  Bead `evm-asm-wbc4i.9.3.3.2.3`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxExactX1Mod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallExactX1Mod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopMaxCall
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Full n=3 max×max path from the callable-ready v5 loop source, preserving
+    concrete `x1`, scratch, and the j=1 stored u4/q atoms. -/
+theorem divK_loop_n3_max_max_from_source_exact_loopIterScratch_v5_noNop_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu_1 : ¬BitVec.ult u3 v2)
+    (hcarry2_nz_1 : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      ¬BitVec.ult r1.2.2.2.1 v2)
+    (hcarry2_nz_0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      isAddbackCarry2NzN3Max v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (152 + 152) (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) := by
+  intro r1 uBase1 qAddr1
+  have J1 := divK_loop_body_n3_max_j1_exact_loopIterScratch_v5_noNop_modCode sp base
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem hbltu_1 hcarry2_nz_1
+  subst r1
+  subst uBase1
+  subst qAddr1
+  have J1f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J1
+  have J0 := divK_loop_body_n3_max_j0_exact_loopIterScratch_v5_noNop_modCode sp base
+    (1 : Word)
+    ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q0Old raVal retMem dMem dloMem scratchUn0 scratchMem hbltu_0 hcarry2_nz_0
+  have J0f := cpsTripleWithin_frameR
+    (((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
+    (by pcFree) J0
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN3MaxScratchX1_j1_to_max_j0_pre
+      sp retMem dMem dloMem scratchUn0 scratchMem
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q0Old raVal)
+    (cpsTripleWithin_weaken
+      (loopN3PreWithScratchV4NoX1_to_max_j1_pre
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem)
+      (fun h hp => hp)
+      J1f)
+    J0f
+
+/-- Full n=3 max×call path from the callable-ready v5 loop source, preserving
+    concrete `x1`, scratch, and the j=1 stored u4/q atoms. -/
+theorem divK_loop_n3_max_call_from_source_exact_loopIterScratch_v5_noNop_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : ¬BitVec.ult u3 v2)
+    (hcarry2_nz_1 : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r1.2.2.2.1 v2)
+    (hcarry2_nz_0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      let qHat := divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v2
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (r1.2.2.2.2.1 - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (152 + 234) (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v2)
+        (divKTrialCallV5DLo v2)
+        (divKTrialCallV5Un0 r1.2.2.1)
+        (divKTrialCallV5ScratchOut r1.2.2.2.1 r1.2.2.1 v2 scratchMem)
+        v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) := by
+  intro r1 uBase1 qAddr1
+  have J1 := divK_loop_body_n3_max_j1_exact_loopIterScratch_v5_noNop_modCode sp base
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem hbltu_1 hcarry2_nz_1
+  subst r1
+  subst uBase1
+  subst qAddr1
+  have J1f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J1
+  have J0 := divK_loop_body_n3_call_j0_exact_loopIterScratch_v5_noNop_modCode sp base
+    (1 : Word)
+    ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    halign hbltu_0 hcarry2_nz_0
+  have J0f := cpsTripleWithin_frameR
+    (((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
+    (by pcFree) J0
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN3MaxScratchX1_j1_to_call_j0_pre
+      sp retMem dMem dloMem scratchUn0 scratchMem
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q0Old raVal)
+    (cpsTripleWithin_weaken
+      (loopN3PreWithScratchV4NoX1_to_max_j1_pre
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem)
+      (fun h hp => hp)
+      J1f)
+    J0f
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopMaxExactBorrowCarryMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopMaxExactBorrowCarryMod.lean
@@ -1,0 +1,174 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxExactBorrowCarryMod
+
+  Borrow-dispatched variants of the n=3 v5 max exact-jN loop bodies: each takes
+  the second-addback carry obligation only CONDITIONALLY on that iteration's
+  runtime mulsub borrow (`borrow → isAddbackCarry2NzN3Max`), instead of
+  unconditionally.  Thin variants of
+  `divK_loop_body_n3_max_j{0,1}_exact_loopIterScratch_v5_noNop_modCode`
+  (FullPathN3V5NoNopMaxExact) — the by_cases on the borrow is identical, and in
+  the addback (borrow) branch the unconditional carry is recovered as
+  `hcarry2_borrow hborrow`.  The per-digit max bodies the n=3 borrowCarry combos
+  consume.  Bead `evm-asm-wbc4i.9.3.3.3.4`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxExactX1Mod
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Max exact-jN j=0, carry required only on the runtime borrow branch. -/
+theorem divK_loop_body_n3_max_j0_exact_loopIterScratch_v5_noNop_modCode_borrowCarry (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu : ¬BitVec.ult u3 v2)
+    (hcarry2_borrow :
+      BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) →
+      isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      ((loopBodyN3MaxSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      ((loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal))) := by
+  by_cases hborrow : BitVec.ult uTop
+      (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hcarry2_nz := hcarry2_borrow hborrow
+    have hborrow_nz :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) ≠ (0 : Word) := by
+      rw [if_pos hborrow]; decide
+    have J := divK_loop_body_n3_max_addback_j0_beq_norm_v5_noNop_modCode
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hcarry2_nz hborrow_nz
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by
+        rw [loopIterPostN3Max_addback hborrow] at hp
+        xperm_hyp hp)
+      Jf
+  · have hborrow_zero :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) = (0 : Word) := by
+      rw [if_neg hborrow]
+    have J := divK_loop_body_n3_max_skip_j0_norm_v5_noNop_modCode
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hborrow_zero
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => by xperm_hyp hp)
+        (fun h hp => by
+          rw [loopIterPostN3Max_skip hborrow] at hp
+          xperm_hyp hp)
+        Jf
+
+/-- Max exact-jN j=1, carry required only on the runtime borrow branch. -/
+theorem divK_loop_body_n3_max_j1_exact_loopIterScratch_v5_noNop_modCode_borrowCarry (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu : ¬BitVec.ult u3 v2)
+    (hcarry2_borrow :
+      BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) →
+      isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v5 base)
+      ((loopBodyN3MaxSkipJ1NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      ((loopIterPostN3Max sp (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal))) := by
+  by_cases hborrow : BitVec.ult uTop
+      (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hcarry2_nz := hcarry2_borrow hborrow
+    have hborrow_nz :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) ≠ (0 : Word) := by
+      rw [if_pos hborrow]; decide
+    have J := divK_loop_body_n3_max_addback_jgt0_beq_norm_v5_noNop_modCode
+      (1 : Word) sp base EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hcarry2_nz hborrow_nz
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_weaken
+      (fun h hp => by
+        delta loopBodyN3MaxSkipJ1NormPreV4 loopBodyN3MaxAddbackJgt0NormPreV4 at hp ⊢
+        xperm_hyp hp)
+      (fun h hp => by
+        rw [loopIterPostN3Max_addback hborrow] at hp
+        xperm_hyp hp)
+      Jf
+  · have hborrow_zero :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) = (0 : Word) := by
+      rw [if_neg hborrow]
+    have J := divK_loop_body_n3_max_skip_j1_norm_v5_noNop_modCode
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hborrow_zero
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => by xperm_hyp hp)
+        (fun h hp => by
+          rw [loopIterPostN3Max_skip hborrow] at hp
+          xperm_hyp hp)
+        Jf
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopMaxExactX1Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopMaxExactX1Mod.lean
@@ -1,0 +1,169 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxExactX1Mod
+
+  MOD mirror of `FullPathN3V5NoNopMaxExact`: v5/no-NOP n=3 max-path exact-jN
+  loop-body wrappers over `modCode_noNop_v5`.  `by_cases` on the mulsub borrow to
+  dispatch to the modCode max-skip / max-addback-beq norm wrappers
+  (`FullPathN3V5NoNopMaxMod` / `FullPathN3V5NoNopMaxAddbackNormMod`), exposing the
+  unified `loopIterPostN3Max` with the concrete `x1`/scratch frame.  Structurally
+  identical to the DIV file; only the norm-wrapper names carry the `_modCode`
+  suffix and the code surface is `modCode_noNop_v5`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxAddbackNormMod
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Loop body n=3, max path, j=0 over `modCode_noNop_v5`, preserving concrete
+    `x1` and callable scratch cells as frame. -/
+theorem divK_loop_body_n3_max_j0_exact_loopIterScratch_v5_noNop_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu : ¬BitVec.ult u3 v2)
+    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      ((loopBodyN3MaxSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      ((loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal))) := by
+  by_cases hborrow : BitVec.ult uTop
+      (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) ≠ (0 : Word) := by
+      rw [if_pos hborrow]; decide
+    have J := divK_loop_body_n3_max_addback_j0_beq_norm_v5_noNop_modCode
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hcarry2_nz hborrow_nz
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by
+        rw [loopIterPostN3Max_addback hborrow] at hp
+        xperm_hyp hp)
+      Jf
+  · have hborrow_zero :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) = (0 : Word) := by
+      rw [if_neg hborrow]
+    have J := divK_loop_body_n3_max_skip_j0_norm_v5_noNop_modCode
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hborrow_zero
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => by xperm_hyp hp)
+        (fun h hp => by
+          rw [loopIterPostN3Max_skip hborrow] at hp
+          xperm_hyp hp)
+        Jf
+
+/-- Loop body n=3, max path, j=1 over `modCode_noNop_v5`, preserving concrete
+    `x1` and callable scratch cells as frame. -/
+theorem divK_loop_body_n3_max_j1_exact_loopIterScratch_v5_noNop_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu : ¬BitVec.ult u3 v2)
+    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v5 base)
+      ((loopBodyN3MaxSkipJ1NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      ((loopIterPostN3Max sp (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal))) := by
+  by_cases hborrow : BitVec.ult uTop
+      (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) ≠ (0 : Word) := by
+      rw [if_pos hborrow]; decide
+    have J := divK_loop_body_n3_max_addback_jgt0_beq_norm_v5_noNop_modCode
+      (1 : Word) sp base EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hcarry2_nz hborrow_nz
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_weaken
+      (fun h hp => by
+        delta loopBodyN3MaxSkipJ1NormPreV4 loopBodyN3MaxAddbackJgt0NormPreV4 at hp ⊢
+        xperm_hyp hp)
+      (fun h hp => by
+        rw [loopIterPostN3Max_addback hborrow] at hp
+        xperm_hyp hp)
+      Jf
+  · have hborrow_zero :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) = (0 : Word) := by
+      rw [if_neg hborrow]
+    have J := divK_loop_body_n3_max_skip_j1_norm_v5_noNop_modCode
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hborrow_zero
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => by xperm_hyp hp)
+        (fun h hp => by
+          rw [loopIterPostN3Max_skip hborrow] at hp
+          xperm_hyp hp)
+        Jf
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopMaxMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopMaxMod.lean
@@ -1,0 +1,72 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxMod
+
+  MOD mirror of `FullPathN3V5NoNopMax`: v5/no-NOP norm-pre wrappers for the n=3
+  max+skip loop bodies over `modCode_noNop_v5`.  Byte-for-byte the DIV wrappers,
+  swapping ONLY the extend target (`sharedDivModCodeNoNop_v5_sub_divCode_noNop_v5`
+  → `sharedDivModCodeNoNop_v5_sub_modCode_noNop_v5`) — the raw bodies (over the
+  SHARED `sharedDivModCodeNoNop_v5`) and the code-agnostic NormPre/Post defs are
+  reused verbatim.  Mirror of `FullPathN2V5NoNopMaxMod`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMax
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- Loop body n=3, max+skip, j=0 over `modCode_noNop_v5`. -/
+theorem divK_loop_body_n3_max_skip_j0_norm_v5_noNop_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult u3 v2) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) = (0 : Word) →
+    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopBodyN3MaxSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN3SkipPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n3_max_skip_j0_v5_spec_within_noNop
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v5_sub_modCode_noNop_v5) raw
+  rw [loopBodyN3MaxSkipPre_unfold] at raw'
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw'
+  delta loopBodyN3MaxSkipJ0NormPreV4
+  exact raw'
+
+/-- Loop body n=3, max+skip, j=1 over `modCode_noNop_v5`. -/
+theorem divK_loop_body_n3_max_skip_j1_norm_v5_noNop_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult u3 v2) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) = (0 : Word) →
+    cpsTripleWithin 76 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v5 base)
+      (loopBodyN3MaxSkipJ1NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN3SkipPost sp (1 : Word) (signExtend12 4095 : Word)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n3_max_skip_j1_v5_spec_within_noNop
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v5_sub_modCode_noNop_v5) raw
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopBodyN3MaxSkipJ1NormPreV4 at hp
+      xperm_hyp hp)
+    (fun h hp => hp)
+    raw'
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopPreloopBorrowCarryMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopPreloopBorrowCarryMod.lean
@@ -1,0 +1,168 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloopBorrowCarryMod
+
+  Full n=3 v5 path from the stack pre-state to the unified loop post, borrow-carry
+  flavour: composes the preloop (`evm_div_n3_to_loopSetup_..._v5_noNop_exact_x1_scratch_frame`,
+  `base → loopBodyOff`) with the borrow-dispatched loop instantiation
+  (`evm_mod_n3_loop_unified_inst_noNop_exact_x1_v5_borrowCarry_modCode`, #7539,
+  `loopBodyOff → denormOff`), bridged through `loopSetupPost_to_loopN3PreWithScratchV4NoX1_framed`
+  (version-agnostic).  The carry is the satisfiable-from-shape
+  `loopN3SelectedBorrowCarryV5` bundle (still a hypothesis here; discharged from
+  shape in the next step).  v5 mirror of
+  `fullDivN3_preloop_loop_unified_exact_x1_scratch_v4_noNop_selectedCarry`.
+  Bead `evm-asm-wbc4i.9.3.3.3.4`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloopMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopLoopSelectedBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopMaxCall
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Full n=3 v5 stack-pre → unified-post, feeding the `loopN3SelectedBorrowCarryV5`
+    bundle through the preloop ∘ setup-bridge ∘ borrow-dispatched-loop chain. -/
+theorem evm_mod_n3_preloop_loop_unified_exact_x1_scratch_v5_noNop_borrowCarry
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_1 with
+      | false =>
+        BitVec.ult
+          (iterN3Max (fullDivN3NormV b0 b1 b2 b3).1
+            (fullDivN3NormV b0 b1 b2 b3).2.1
+            (fullDivN3NormV b0 b1 b2 b3).2.2.1
+            (fullDivN3NormV b0 b1 b2 b3).2.2.2
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.1
+      | true =>
+        BitVec.ult
+          (iterWithDoubleAddback
+            (divKTrialCallV5QHat
+              (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+              (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+              (fullDivN3NormV b0 b1 b2 b3).2.2.1)
+            (fullDivN3NormV b0 b1 b2 b3).1
+            (fullDivN3NormV b0 b1 b2 b3).2.1
+            (fullDivN3NormV b0 b1 b2 b3).2.2.1
+            (fullDivN3NormV b0 b1 b2 b3).2.2.2
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.1)
+    (hcarry : loopN3SelectedBorrowCarryV5 bltu_1 bltu_0
+      (fullDivN3NormV b0 b1 b2 b3).1
+      (fullDivN3NormV b0 b1 b2 b3).2.1
+      (fullDivN3NormV b0 b1 b2 b3).2.2.1
+      (fullDivN3NormV b0 b1 b2 b3).2.2.2
+      (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+      (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+      (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+      (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+      (0 : Word)
+      (fullDivN3NormU a0 a1 a2 a3 b2).1) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 468) base (base + denormOff)
+      (modCode_noNop_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      ((loopN3UnifiedPostV5NoX1 bltu_1 bltu_0 sp base
+        (fullDivN3NormV b0 b1 b2 b3).1
+        (fullDivN3NormV b0 b1 b2 b3).2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.2
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+        (0 : Word)
+        (fullDivN3NormU a0 a1 a2 a3 b2).1
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))) := by
+  have hPre := evm_mod_n3_to_loopSetup_spec_within_v5_noNop_exact_x1_scratch_frame
+    sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz
+  have hLoop := evm_mod_n3_loop_unified_inst_noNop_exact_x1_v5_borrowCarry_modCode
+    bltu_1 bltu_0 sp base
+    (fullDivN3Shift b2) (fullDivN3AntiShift b2)
+    (fullDivN3NormV b0 b1 b2 b3).1
+    (fullDivN3NormV b0 b1 b2 b3).2.1
+    (fullDivN3NormV b0 b1 b2 b3).2.2.1
+    (fullDivN3NormV b0 b1 b2 b3).2.2.2
+    (fullDivN3NormU a0 a1 a2 a3 b2).1
+    (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+    (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+    (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+    (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+    (a0 >>> ((fullDivN3AntiShift b2).toNat % 64)) v11Old jMem
+    retMem dMem dloMem scratchUn0 scratchMem raVal
+    halign hbltu_1 (by cases bltu_1 <;> simpa using hbltu_0) hcarry
+  have hLoopf := cpsTripleWithin_frameR
+    ((((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1)))
+    (by pcFree) hLoop
+  have hBridge := loopSetupPost_to_loopN3PreWithScratchV4NoX1_framed
+    sp a0 a1 a2 a3 b0 b1 b2 b3 v11Old
+    jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+  have hPre' := cpsTripleWithin_weaken
+    (fun h hp => hp)
+    hBridge
+    hPre
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hPre' hLoopf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hq => hq)
+    hFull
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopRestCombosBorrowCarryMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopRestCombosBorrowCarryMod.lean
@@ -1,0 +1,294 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopRestCombosBorrowCarryMod
+
+  Borrow-dispatched n=3 v5 two-iteration loop combos for the three remaining
+  shapes: call×max, max×max, max×call.  Each takes the per-iteration
+  second-addback carry only CONDITIONALLY on that iteration's runtime mulsub
+  borrow.  Thin variants of the selectedCarry combos (`FullPathN3V5NoNopCallCombos`
+  call_max, `FullPathN3V5NoNopMaxCombos` max_max/max_call) composing the
+  borrowCarry exact-jN bodies (#7529 call, #7530 max) through the same
+  version-agnostic source-pre / j1→j0 bridges.  The guarded carry hypotheses match
+  the `loopN3SelectedBorrowCarryV5` bundle obligations (#7526/#7527).  Completes
+  the 4 n=3 borrowCarry combos (call_call/call_j1 #7531 + these three).
+  Bead `evm-asm-wbc4i.9.3.3.3.4`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallCombosBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxExactBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopMaxCall
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Full n=3 call×max path, carry required only on each iteration's runtime
+    borrow branch. -/
+theorem divK_loop_n3_call_max_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : BitVec.ult u3 v2)
+    (hcarry2_borrow_1 :
+      BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) →
+      (let qHat := divKTrialCallV5QHat u3 u2 v2
+       let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+       let c3 := ms.2.2.2.2
+       let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+       let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+       carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0))
+    (hbltu_0 :
+      let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      ¬BitVec.ult r1.2.2.2.1 v2)
+    (hcarry2_borrow_0 :
+      let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r1.2.2.2.2.1
+        (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      isAddbackCarry2NzN3Max v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (234 + 152) (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+        (sp + signExtend12 3960 ↦ₘ v2) **
+        (sp + signExtend12 3952 ↦ₘ (divKTrialCallV5DLo v2)) **
+        (sp + signExtend12 3944 ↦ₘ (divKTrialCallV5Un0 u2)) **
+        (sp + signExtend12 3936 ↦ₘ (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)) **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) := by
+  intro r1 uBase1 qAddr1
+  have J1 := divK_loop_n3_call_j1_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu_1 hcarry2_borrow_1
+  subst r1
+  subst uBase1
+  subst qAddr1
+  have J0 := divK_loop_body_n3_max_j0_exact_loopIterScratch_v5_noNop_modCode_borrowCarry sp base
+    (1 : Word)
+    ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q0Old raVal
+    (base + div128CallRetOff) v2 (divKTrialCallV5DLo v2)
+    (divKTrialCallV5Un0 u2) (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+    hbltu_0 hcarry2_borrow_0
+  have J0f := cpsTripleWithin_frameR
+    (((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
+    (by pcFree) J0
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN3CallScratchNoX1_j1_to_max_j0_pre
+      sp base (divKTrialCallV5QHat u3 u2 v2) (divKTrialCallV5DLo v2)
+      (divKTrialCallV5Un0 u2) (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q0Old raVal)
+    J1 J0f
+
+/-- Full n=3 max×max path, carry required only on each iteration's runtime
+    borrow branch. -/
+theorem divK_loop_n3_max_max_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu_1 : ¬BitVec.ult u3 v2)
+    (hcarry2_borrow_1 :
+      BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) →
+      isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      ¬BitVec.ult r1.2.2.2.1 v2)
+    (hcarry2_borrow_0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r1.2.2.2.2.1
+        (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      isAddbackCarry2NzN3Max v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (152 + 152) (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) := by
+  intro r1 uBase1 qAddr1
+  have J1 := divK_loop_body_n3_max_j1_exact_loopIterScratch_v5_noNop_modCode_borrowCarry sp base
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem hbltu_1 hcarry2_borrow_1
+  subst r1
+  subst uBase1
+  subst qAddr1
+  have J1f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J1
+  have J0 := divK_loop_body_n3_max_j0_exact_loopIterScratch_v5_noNop_modCode_borrowCarry sp base
+    (1 : Word)
+    ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q0Old raVal retMem dMem dloMem scratchUn0 scratchMem hbltu_0 hcarry2_borrow_0
+  have J0f := cpsTripleWithin_frameR
+    (((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
+    (by pcFree) J0
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN3MaxScratchX1_j1_to_max_j0_pre
+      sp retMem dMem dloMem scratchUn0 scratchMem
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q0Old raVal)
+    (cpsTripleWithin_weaken
+      (loopN3PreWithScratchV4NoX1_to_max_j1_pre
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem)
+      (fun h hp => hp)
+      J1f)
+    J0f
+
+/-- Full n=3 max×call path, carry required only on each iteration's runtime
+    borrow branch. -/
+theorem divK_loop_n3_max_call_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : ¬BitVec.ult u3 v2)
+    (hcarry2_borrow_1 :
+      BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) →
+      isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r1.2.2.2.1 v2)
+    (hcarry2_borrow_0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r1.2.2.2.2.1
+        (mulsubN4_c3 (divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v2)
+          v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      (let qHat := divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v2
+       let ms := mulsubN4 qHat v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1
+       let c3 := ms.2.2.2.2
+       let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+       let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (r1.2.2.2.2.1 - c3) v0 v1 v2 v3
+       carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0)) :
+    let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (152 + 234) (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v2)
+        (divKTrialCallV5DLo v2)
+        (divKTrialCallV5Un0 r1.2.2.1)
+        (divKTrialCallV5ScratchOut r1.2.2.2.1 r1.2.2.1 v2 scratchMem)
+        v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) := by
+  intro r1 uBase1 qAddr1
+  have J1 := divK_loop_body_n3_max_j1_exact_loopIterScratch_v5_noNop_modCode_borrowCarry sp base
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem hbltu_1 hcarry2_borrow_1
+  subst r1
+  subst uBase1
+  subst qAddr1
+  have J1f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J1
+  have J0 := divK_loop_body_n3_call_j0_exact_loopIterScratch_v5_noNop_modCode_borrowCarry sp base
+    (1 : Word)
+    ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    halign hbltu_0 hcarry2_borrow_0
+  have J0f := cpsTripleWithin_frameR
+    (((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
+    (by pcFree) J0
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN3MaxScratchX1_j1_to_call_j0_pre
+      sp retMem dMem dloMem scratchUn0 scratchMem
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q0Old raVal)
+    (cpsTripleWithin_weaken
+      (loopN3PreWithScratchV4NoX1_to_max_j1_pre
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem)
+      (fun h hp => hp)
+      J1f)
+    J0f
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopRestCombosBorrowCarryNamedMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopRestCombosBorrowCarryNamedMod.lean
@@ -1,0 +1,111 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopRestCombosBorrowCarryNamedMod
+
+  Named-carry restatements of the call_max and max_call n=3 borrowCarry combos
+  (#7532): the CALL obligation's second-addback carry is written as the NAMED
+  `loopBodyN3CallAddbackCarry2NzV5` (defeq to inline, unfolded here where
+  `mulsubN4`/`addbackN4` are transparent).  Completes the named-carry combo set
+  (call_j1/call_call in #7534 + call_max/max_call here; max_max already takes the
+  named `isAddbackCarry2NzN3Max`) so the from-source borrowCarry dispatch can feed
+  the bundle's named obligations named-to-named without the isDefEq explosion.
+  Bead `evm-asm-wbc4i.9.3.3.3.4`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopRestCombosBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnifiedMod
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Named-carry restatement of `divK_loop_n3_call_max_from_source_..._borrowCarry`. -/
+theorem divK_loop_n3_call_max_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry_named
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : BitVec.ult u3 v2)
+    (hcarry2_borrow_1 :
+      BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) →
+      loopBodyN3CallAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_0 :
+      let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      ¬BitVec.ult r1.2.2.2.1 v2)
+    (hcarry2_borrow_0 :
+      let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r1.2.2.2.2.1
+        (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      isAddbackCarry2NzN3Max v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (234 + 152) (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+        (sp + signExtend12 3960 ↦ₘ v2) **
+        (sp + signExtend12 3952 ↦ₘ (divKTrialCallV5DLo v2)) **
+        (sp + signExtend12 3944 ↦ₘ (divKTrialCallV5Un0 u2)) **
+        (sp + signExtend12 3936 ↦ₘ (divKTrialCallV5ScratchOut u3 u2 v2 scratchMem)) **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) :=
+  divK_loop_n3_call_max_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu_1 hcarry2_borrow_1 hbltu_0 hcarry2_borrow_0
+
+/-- Named-carry restatement of `divK_loop_n3_max_call_from_source_..._borrowCarry`. -/
+theorem divK_loop_n3_max_call_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry_named
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : ¬BitVec.ult u3 v2)
+    (hcarry2_borrow_1 :
+      BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) →
+      isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r1.2.2.2.1 v2)
+    (hcarry2_borrow_0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r1.2.2.2.2.1
+        (mulsubN4_c3 (divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v2)
+          v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      loopBodyN3CallAddbackCarry2NzV5 v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (152 + 234) (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v2)
+        (divKTrialCallV5DLo v2)
+        (divKTrialCallV5Un0 r1.2.2.1)
+        (divKTrialCallV5ScratchOut r1.2.2.2.1 r1.2.2.1 v2 scratchMem)
+        v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) :=
+  divK_loop_n3_max_call_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu_1 hcarry2_borrow_1 hbltu_0 hcarry2_borrow_0
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopUnifiedBorrowCarryCasesMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopUnifiedBorrowCarryCasesMod.lean
@@ -1,0 +1,190 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnifiedBorrowCarryCasesMod
+
+  Per-case unified-post wrappers for the n=3 v5 borrowCarry dispatch: each takes
+  the per-iteration borrow flags and (named) carry obligations as FRESH inputs and
+  weakens the matching combo's per-shape post to `loopN3UnifiedPostV5NoX1`.  By
+  keeping the combo application in this clean context (fresh `hc0`, no
+  bundle-extraction `rw`), the combo isDefEq stays syntactic — the dispatch then
+  only feeds the (rewritten) bundle obligations to these wrappers' parameters,
+  avoiding the per-case isDefEq explosion seen when the combo was applied directly
+  to the rewritten `hc0`.  Bead `evm-asm-wbc4i.9.3.3.3.4`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopRestCombosBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallCombosBorrowCarryNamedMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopRestCombosBorrowCarryNamedMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnifiedMod
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- max×max case → unified post. -/
+theorem divK_loop_n3_unified_maxmax_borrowCarry_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb1 : ¬BitVec.ult u3 v2)
+    (hc1 :
+      BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) →
+      isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hb0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      ¬BitVec.ult r1.2.2.2.1 v2)
+    (hc0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r1.2.2.2.2.1
+        (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      isAddbackCarry2NzN3Max v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    cpsTripleWithin 468 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN3UnifiedPostV5NoX1 false false sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) :=
+  cpsTripleWithin_mono_nSteps (by decide) <|
+    cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by
+        unfold loopN3UnifiedPostV5NoX1
+        simp only at hp ⊢
+        xperm_hyp hp)
+      (divK_loop_n3_max_max_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem hb1 hc1 hb0 hc0)
+
+/-- max×call case → unified post. -/
+theorem divK_loop_n3_unified_maxcall_borrowCarry_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hb1 : ¬BitVec.ult u3 v2)
+    (hc1 :
+      BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) →
+      isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hb0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r1.2.2.2.1 v2)
+    (hc0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r1.2.2.2.2.1
+        (mulsubN4_c3 (divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v2)
+          v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      loopBodyN3CallAddbackCarry2NzV5 v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    cpsTripleWithin 468 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN3UnifiedPostV5NoX1 false true sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) :=
+  cpsTripleWithin_mono_nSteps (by decide) <|
+    cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by
+        unfold loopN3UnifiedPostV5NoX1
+        simp only at hp ⊢
+        xperm_hyp hp)
+      (divK_loop_n3_max_call_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry_named
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hb1 hc1 hb0 hc0)
+
+/-- call×max case → unified post. -/
+theorem divK_loop_n3_unified_callmax_borrowCarry_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hb1 : BitVec.ult u3 v2)
+    (hc1 :
+      BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) →
+      loopBodyN3CallAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hb0 :
+      let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      ¬BitVec.ult r1.2.2.2.1 v2)
+    (hc0 :
+      let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r1.2.2.2.2.1
+        (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      isAddbackCarry2NzN3Max v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    cpsTripleWithin 468 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN3UnifiedPostV5NoX1 true false sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) :=
+  cpsTripleWithin_mono_nSteps (by decide) <|
+    cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by
+        unfold loopN3UnifiedPostV5NoX1
+        simp only at hp ⊢
+        xperm_hyp hp)
+      (divK_loop_n3_call_max_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry_named
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hb1 hc1 hb0 hc0)
+
+/-- call×call case → unified post. -/
+theorem divK_loop_n3_unified_callcall_borrowCarry_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hb1 : BitVec.ult u3 v2)
+    (hc1 :
+      BitVec.ult uTop (mulsubN4_c3 (divKTrialCallV5QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) →
+      loopBodyN3CallAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hb0 :
+      BitVec.ult
+        (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
+    (hc0 :
+      let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r1.2.2.2.2.1
+        (mulsubN4_c3 (divKTrialCallV5QHat r1.2.2.2.1 r1.2.2.1 v2)
+          v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1) →
+      loopBodyN3CallAddbackCarry2NzV5 v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    cpsTripleWithin 468 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN3UnifiedPostV5NoX1 true true sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) :=
+  cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      unfold loopN3UnifiedPostV5NoX1
+      simp only at hp ⊢
+      xperm_hyp hp)
+    (divK_loop_n3_call_call_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry_named
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+      retMem dMem dloMem scratchUn0 scratchMem halign hb1 hc1 hb0 hc0)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopUnifiedBorrowCarryMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopUnifiedBorrowCarryMod.lean
@@ -1,0 +1,116 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnifiedBorrowCarry
+
+  Borrow-dispatched unified n=3 v5 loop: takes `loopN3SelectedBorrowCarryV5` (the
+  satisfiable-from-shape carry bundle, #7526) instead of the unsatisfiable
+  unconditional `loopN3SelectedCarryV5`, and dispatches the 4 `bltu²` cases to the
+  per-case unified-post `_borrowCarry` wrappers (#7536), extracting the two
+  per-digit borrow-conditional carries from the bundle in each arm.
+
+  The bundle's j=0 window is `iterN3V5 bltu_1 …` (`@[irreducible]`); the dispatch
+  rewrites it with `iterN3V5_true_eq` (→ `iterWithDoubleAddback (divKTrialCallV5QHat …)`)
+  and the NAMED `iterN3V5_false_eq_max` (→ `iterN3Max`, *not* the over-unfolded
+  `iterWithDoubleAddback (signExtend12 4095)`).  Matching the wrappers' named
+  `iterN3Max` window keeps the isDefEq syntactic — the over-unfold to the saturated
+  `iterWithDoubleAddback` is exactly what forced the explosive defeq through the
+  irreducible `iterN3Max` in earlier attempts.  n3 mirror of
+  `divK_loop_n2_unified_from_source_..._borrowCarry`.  Bead `evm-asm-wbc4i.9.3.3.3.4`.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopLoopDefsBorrowCarry
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnifiedBorrowCarryCasesMod
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Borrow-dispatched n=3 v5 unified loop: the carries come from the
+    satisfiable-from-shape `loopN3SelectedBorrowCarryV5` bundle (borrow-conditional
+    per digit), dispatched to the per-case unified-post `_borrowCarry` wrappers. -/
+theorem divK_loop_n3_unified_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 = BitVec.ult u3 v2)
+    (hbltu_0 : bltu_0 =
+      match bltu_1 with
+      | false => BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2
+      | true =>
+        BitVec.ult
+          (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
+    (hcarry : loopN3SelectedBorrowCarryV5 bltu_1 bltu_0
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig) :
+    cpsTripleWithin 468 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN3UnifiedPostV5NoX1 bltu_1 bltu_0 sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  cases bltu_1 <;> cases bltu_0
+  · -- max × max
+    have hb1 : ¬BitVec.ult u3 v2 := by rw [← hbltu_1]; decide
+    have hb0 :
+        let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        ¬BitVec.ult r1.2.2.2.1 v2 := by
+      simp only at hbltu_0 ⊢; rw [← hbltu_0]; decide
+    unfold loopN3SelectedBorrowCarryV5 at hcarry
+    simp only [iterN3V5_false_eq_max] at hcarry
+    rw [if_neg (by decide), if_neg (by decide)] at hcarry
+    obtain ⟨hc1, hc0⟩ := hcarry
+    exact divK_loop_n3_unified_maxmax_borrowCarry_modCode sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+      retMem dMem dloMem scratchUn0 scratchMem hb1 hc1 hb0 hc0
+  · -- max × call
+    have hb1 : ¬BitVec.ult u3 v2 := by rw [← hbltu_1]; decide
+    have hb0 :
+        let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        BitVec.ult r1.2.2.2.1 v2 := by
+      simp only at hbltu_0 ⊢; exact hbltu_0.symm
+    unfold loopN3SelectedBorrowCarryV5 at hcarry
+    simp only [iterN3V5_false_eq_max] at hcarry
+    rw [if_neg (by decide), if_pos (by decide)] at hcarry
+    obtain ⟨hc1, hc0⟩ := hcarry
+    exact divK_loop_n3_unified_maxcall_borrowCarry_modCode sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+      retMem dMem dloMem scratchUn0 scratchMem halign hb1 hc1 hb0 hc0
+  · -- call × max
+    have hb1 : BitVec.ult u3 v2 := hbltu_1.symm
+    have hb0 :
+        let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        ¬BitVec.ult r1.2.2.2.1 v2 := by
+      simp only at hbltu_0 ⊢; rw [← hbltu_0]; decide
+    unfold loopN3SelectedBorrowCarryV5 at hcarry
+    simp only [iterN3V5_true_eq] at hcarry
+    rw [if_pos (by decide), if_neg (by decide)] at hcarry
+    obtain ⟨hc1, hc0⟩ := hcarry
+    exact divK_loop_n3_unified_callmax_borrowCarry_modCode sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+      retMem dMem dloMem scratchUn0 scratchMem halign hb1 hc1 hb0 hc0
+  · -- call × call
+    have hb1 : BitVec.ult u3 v2 := hbltu_1.symm
+    have hb0 :
+        BitVec.ult
+          (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 := by
+      simp only at hbltu_0; exact hbltu_0.symm
+    unfold loopN3SelectedBorrowCarryV5 at hcarry
+    simp only [iterN3V5_true_eq] at hcarry
+    rw [if_pos (by decide), if_pos (by decide)] at hcarry
+    obtain ⟨hc1, hc0⟩ := hcarry
+    exact divK_loop_n3_unified_callcall_borrowCarry_modCode sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+      retMem dMem dloMem scratchUn0 scratchMem halign hb1 hc1 hb0 hc0
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopUnifiedMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5NoNopUnifiedMod.lean
@@ -1,0 +1,128 @@
+/- n=3 MOD unified loop dispatcher over modCode_noNop_v5. Reuses the code-agnostic
+   defs from FullPathN3V5NoNopUnified; only the modCode theorem differs. -/
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopUnified
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopCallCombosMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopMaxCombosMod
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem divK_loop_n3_unified_from_source_exact_loopIterScratch_v5_noNop_modCode_selectedCarry
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 = BitVec.ult u3 v2)
+    (hbltu_0 : bltu_0 =
+      match bltu_1 with
+      | false => BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2
+      | true =>
+        BitVec.ult
+          (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
+    (hcarry2_j1 :
+      if bltu_1 then
+        loopBodyN3CallAddbackCarry2NzV5 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      else
+        isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_j0 :
+      match bltu_1 with
+      | false =>
+        let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        if bltu_0 then
+          loopBodyN3CallAddbackCarry2NzV5 v0 v1 v2 v3
+            u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+        else
+          isAddbackCarry2NzN3Max v0 v1 v2 v3
+            u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+      | true =>
+        let r1 := iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        if bltu_0 then
+          loopBodyN3CallAddbackCarry2NzV5 v0 v1 v2 v3
+            u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+        else
+          isAddbackCarry2NzN3Max v0 v1 v2 v3
+            u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    cpsTripleWithin 468 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN3UnifiedPostV5NoX1 bltu_1 bltu_0 sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  cases bltu_1 <;> cases bltu_0
+  · have hb1 : ¬BitVec.ult u3 v2 := by rw [← hbltu_1]; decide
+    have hb0 : ¬BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 := by
+      simp only at hbltu_0; rw [← hbltu_0]; decide
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => hp)
+        (fun h hp => by
+          unfold loopN3UnifiedPostV5NoX1
+          simp only at hp ⊢
+          rw [sepConj_assoc'] at hp
+          xperm_hyp hp)
+        (divK_loop_n3_max_max_from_source_exact_loopIterScratch_v5_noNop_modCode
+          sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+          retMem dMem dloMem scratchUn0 scratchMem hb1 hcarry2_j1 hb0 hcarry2_j0)
+  · have hb1 : ¬BitVec.ult u3 v2 := by rw [← hbltu_1]; decide
+    have hb0 : BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 := by
+      simp only at hbltu_0; exact hbltu_0.symm
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => hp)
+        (fun h hp => by
+          unfold loopN3UnifiedPostV5NoX1
+          simp only at hp ⊢
+          rw [sepConj_assoc'] at hp
+          xperm_hyp hp)
+        (divK_loop_n3_max_call_from_source_exact_loopIterScratch_v5_noNop_modCode
+          sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+          retMem dMem dloMem scratchUn0 scratchMem halign hb1 hcarry2_j1 hb0 hcarry2_j0)
+  · have hb1 : BitVec.ult u3 v2 := hbltu_1.symm
+    have hb0 :
+        ¬BitVec.ult
+          (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 := by
+      simp only at hbltu_0; rw [← hbltu_0]; decide
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => hp)
+        (fun h hp => by
+          unfold loopN3UnifiedPostV5NoX1
+          simp only at hp ⊢
+          rw [sepConj_assoc'] at hp
+          xperm_hyp hp)
+        (divK_loop_n3_call_max_from_source_exact_loopIterScratch_v5_noNop_modCode
+          sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+          retMem dMem dloMem scratchUn0 scratchMem halign hb1 hcarry2_j1 hb0 hcarry2_j0)
+  · have hb1 : BitVec.ult u3 v2 := hbltu_1.symm
+    have hb0 :
+        BitVec.ult
+          (iterWithDoubleAddback (divKTrialCallV5QHat u3 u2 v2)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 := by
+      simp only at hbltu_0; exact hbltu_0.symm
+    exact cpsTripleWithin_weaken
+      (fun h hp => hp)
+      (fun h hp => by
+        unfold loopN3UnifiedPostV5NoX1
+        simp only at hp ⊢
+        rw [sepConj_assoc'] at hp
+        xperm_hyp hp)
+      (divK_loop_n3_call_call_from_source_exact_loopIterScratch_v5_noNop_modCode
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hb1 hcarry2_j1 hb0 hcarry2_j0)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5PathShift0Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5PathShift0Mod.lean
@@ -1,0 +1,137 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5PathShift0Mod
+
+  v5 n=3 shift=0 LOOP + PATH (base → denormOff) over `modCode_noNop_v5`.  MOD mirror
+  of `FullPathN3V5LoopShift0` + `FullPathN3V5PathShift0`: the shift=0 loop applies
+  the already-lifted modCode unified dispatcher
+  (`divK_loop_n3_unified_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry`);
+  the path composes the shift=0 preloop (`evm_mod_n3_to_loopSetup_shift0_spec_v5_noNop`)
+  ;; that loop via the op-agnostic loop-entry bridge.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5PreloopShift0Mod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopLoopSelectedBorrowCarryMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5PathShift0
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v5 n=3 shift=0 loop body (loopBodyOff → denormOff) over `modCode_noNop_v5`. -/
+theorem divK_loop_n3_shift0_param_v5_noNop_modCode (bltu_1 bltu_0 : Bool)
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (a0 a1 a2 a3 b0 b1 b2 q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hb2ge : b2.toNat ≥ 2 ^ 63)
+    (hbltu_1 : bltu_1 = BitVec.ult (0 : Word) b2)
+    (hbltu_0 : bltu_0 =
+      BitVec.ult (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 b2) :
+    cpsTripleWithin 468 (base + loopBodyOff) (base + denormOff)
+      (modCode_noNop_v5 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        b0 b1 b2 0 a1 a2 a3 0 0 a0 q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN3UnifiedPostV5NoX1 bltu_1 bltu_0 sp base
+        b0 b1 b2 0 a1 a2 a3 0 0 a0
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  apply divK_loop_n3_unified_from_source_exact_loopIterScratch_v5_noNop_modCode_borrowCarry
+    bltu_1 bltu_0 sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    b0 b1 b2 0 a1 a2 a3 0 0 a0 q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign
+  case hbltu_1 =>
+    exact hbltu_1
+  case hbltu_0 =>
+    cases bltu_1 <;>
+      simp only [iterN3V5_false_eq_max, iterN3V5_true_eq] at hbltu_0 ⊢ <;> exact hbltu_0
+  case hcarry =>
+    exact loopN3SelectedBorrowCarryV5_shift0_of_shape a0 a1 a2 a3 b0 b1 b2
+      bltu_1 bltu_0 hb2ge
+      (fun h => by rw [← hbltu_1]; exact h)
+      (fun h => by rw [← hbltu_1, h]; decide)
+      (fun h => by rw [← hbltu_0]; exact h)
+      (fun h => by rw [← hbltu_0, h]; decide)
+
+/-- Full n=3 shift=0 path, `base → denormOff`, over `modCode_noNop_v5`. -/
+theorem evm_mod_n3_to_denorm_shift0_param_v5_noNop (bltu_1 bltu_0 : Bool)
+    (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v2 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_z : (clzResult b2).1 = 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 = BitVec.ult (0 : Word) b2)
+    (hbltu_0 : bltu_0 =
+      BitVec.ult (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 b2) :
+    cpsTripleWithin (((8 + 21 + 24 + 4) + 13) + 468) base (base + denormOff)
+      (modCode_noNop_v5 base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        ((sp + signExtend12 3968) ↦ₘ retMem) ** ((sp + signExtend12 3960) ↦ₘ dMem) **
+        ((sp + signExtend12 3952) ↦ₘ dloMem) ** ((sp + signExtend12 3944) ↦ₘ scratchUn0) **
+        ((sp + signExtend12 3936) ↦ₘ scratchMem) ** (.x1 ↦ᵣ raVal)))
+      ((loopN3UnifiedPostV5NoX1 bltu_1 bltu_0 sp base
+        b0 b1 b2 0 a1 a2 a3 0 0 a0
+        retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))) := by
+  have hb2ge : b2.toNat ≥ 2 ^ 63 := clz_zero_imp_msb hshift_z
+  have hPre := evm_mod_n3_to_loopSetup_shift0_spec_v5_noNop sp base a0 a1 a2 a3 b0 b1 b2 b3
+    v2 v5 v6 v7 v10 q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    hbnz hb3z hb2nz hshift_z
+  have hPref := cpsTripleWithin_frameR
+    ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+     ((sp + signExtend12 3968) ↦ₘ retMem) ** ((sp + signExtend12 3960) ↦ₘ dMem) **
+     ((sp + signExtend12 3952) ↦ₘ dloMem) ** ((sp + signExtend12 3944) ↦ₘ scratchUn0) **
+     ((sp + signExtend12 3936) ↦ₘ scratchMem) ** (.x1 ↦ᵣ raVal))
+    (by pcFree) hPre
+  have hLoop := divK_loop_n3_shift0_param_v5_noNop_modCode bltu_1 bltu_0 sp base jMem (3 : Word)
+    (clzResult b2).1 ((clzResult b2).2 >>> (63 : Nat)) (0 : Word) v11Old
+    (signExtend12 (0 : BitVec 12) - (clzResult b2).1)
+    a0 a1 a2 a3 b0 b1 b2 (0 : Word) (0 : Word) raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hb2ge hbltu_1 hbltu_0
+  have hLoopf := cpsTripleWithin_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))
+    (by pcFree) hLoop
+  have hPre' := cpsTripleWithin_weaken (fun h hp => hp)
+    (n3_shift0_loopExit_to_loopN3PreWithScratch sp a0 a1 a2 a3 b0 b1 b2 b3 v11Old
+      jMem retMem dMem dloMem scratchUn0 scratchMem raVal hb3z)
+    hPref
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hPre' hLoopf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => hp) (fun h hq => hq) hFull
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5PreloopShift0Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V5PreloopShift0Mod.lean
@@ -1,0 +1,146 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V5PreloopShift0Mod
+
+  v5 n=3 shift=0 preloop pieces over `modCode_noNop_v5`.  MOD mirror of
+  `FullPathN3V5PreloopShift0`: on the shift=0 branch the divisor is already
+  top-bit-aligned (`(clzResult b2).1 = 0`), so phase-C2 takes the BEQ to copyAU
+  and the dividend is copied verbatim.  Reuses the merged n=3 MOD phaseAB-clz
+  (`evm_mod_phaseAB_n3_clz_spec_within_v5_noNop`) + the shift=0 phase-C2/copyAU MOD
+  bricks (`divK_phaseC2_taken_spec_within_v5_noNop_mod`,
+  `divK_copyAU_loopSetup_shift0_spec_v5_noNop_mod`).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloopMod
+import EvmAsm.Evm64.DivMod.Compose.PhaseC2V5Mod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1V5PreloopShift0Mod
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v5 n=3 phaseAB-clz + phaseC2(shift=0 taken), `base → copyAUOff`, over
+    `modCode_noNop_v5`.  Shift=0 branch (`(clzResult b2).1 = 0`). -/
+theorem evm_mod_phaseAB_n3_clz_c2taken_spec_v5_noNop (sp base : Word)
+    (b0 b1 b2 b3 v2 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_z : (clzResult b2).1 = 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4) base (base + copyAUOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b2).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ (clzResult b2).1) ** (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+       (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - (clzResult b2).1)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1)) := by
+  have hABCLZ := evm_mod_phaseAB_n3_clz_spec_within_v5_noNop sp base b0 b1 b2 b3
+    v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2nz
+  have hABCLZf := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ v2) ** ((sp + signExtend12 3992) ↦ₘ shiftMem))
+    (by pcFree) hABCLZ
+  have hC2 := divK_phaseC2_taken_spec_within_v5_noNop_mod sp (clzResult b2).1
+    v2 shiftMem base hshift_z
+  have hC2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ (clzResult b2).2) ** (.x10 ↦ᵣ b3) **
+     (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)))
+    (by pcFree) hC2
+  have hABC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABCLZf hC2f
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hABC2
+
+/-- Full n=3 shift=0 preloop, `base → loopBodyOff`, over `modCode_noNop_v5`. -/
+theorem evm_mod_n3_to_loopSetup_shift0_spec_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v2 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_z : (clzResult b2).1 = 0) :
+    cpsTripleWithin ((8 + 21 + 24 + 4) + 13) base (base + loopBodyOff)
+      (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) **
+       (.x9 ↦ᵣ (signExtend12 (4 : BitVec 12) - (3 : Word))) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ (clzResult b2).1) **
+       (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+       (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - (clzResult b2).1)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
+       ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1)) := by
+  have hC2 := evm_mod_phaseAB_n3_clz_c2taken_spec_v5_noNop sp base b0 b1 b2 b3
+    v2 v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem shiftMem hbnz hb3z hb2nz hshift_z
+  have hC2f := cpsTripleWithin_frameR
+    ((.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+     ((sp + signExtend12 4024) ↦ₘ u4Old))
+    (by pcFree) hC2
+  have hSeg := divK_copyAU_loopSetup_shift0_spec_v5_noNop_mod sp base
+    a0 a1 a2 a3 u0Old u1Old u2Old u3Old u4Old (clzResult b2).2
+    (signExtend12 (4 : BitVec 12) - (4 : Word)) (3 : Word) (by decide)
+  have hSegf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ (clzResult b2).1) **
+     (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+     (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - (clzResult b2).1)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))
+    (by pcFree) hSeg
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by simp only [signExtend12_0] at hp ⊢; xperm_hyp hp) hC2f hSegf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by simp only [signExtend12_0] at hq ⊢; xperm_hyp hq)
+    hFull
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3V5ConcretePostBridgeMod.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V5ConcretePostBridgeMod.lean
@@ -1,0 +1,190 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3V5ConcretePostBridgeMod
+
+  N=3 V5 MOD bridge from `fullModN3UnifiedPostNoX1V5` (with exact caller `x1`) to
+  the public concrete post `modConcretePostNoX1ExactRegsFrame` (then to the named
+  `modStackDispatchPostCallableExactFrame`), plus the v5 div128 scratch cell.
+  MOD mirror of `N3V5ConcretePostBridge` (DIV n=3), applying the div→mod
+  transformation of `N2V5ConcretePostBridgeMod`: the readout registers hold the
+  denormalized REMAINDER (`u_i'` funnel-shift of `fullDivN3R0V5`), the `sp+32`
+  result is `EvmWord.mod a b`, and the quotient cells (`r0.1`/`r1.1`/0/0) remain
+  framed.  Bead: n=3 MOD lane, Milestone D.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopDenormDefs
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5FamiliesMod
+import EvmAsm.Evm64.DivMod.Spec.N3V5ModRemainder
+import EvmAsm.Evm64.DivMod.Spec.CallablePost
+import EvmAsm.Evm64.DivMod.Spec.Dispatcher
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_add_zero)
+
+/-- N=3 v5 MOD bridge: `fullModN3UnifiedPostNoX1V5` + exact `x1` → the public
+    concrete `modConcretePostNoX1ExactRegsFrame` + the v5 scratch cell. -/
+theorem fullModN3UnifiedPostNoX1V5_frame_to_modConcretePostNoX1ExactRegsFrame_scratch
+    (bltu_1 bltu_0 : Bool)
+    (sp base : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hdiv0 : (EvmWord.mod a b).getLimbN 0 =
+        (((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>> ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64))))
+    (hdiv1 : (EvmWord.mod a b).getLimbN 1 =
+        (((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>> ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64))))
+    (hdiv2 : (EvmWord.mod a b).getLimbN 2 =
+        (((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>> ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64))))
+    (hdiv3 : (EvmWord.mod a b).getLimbN 3 =
+        ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>> ((fullDivN3Shift b2).toNat % 64))) :
+    ∀ h,
+      (fullModN3UnifiedPostNoX1V5 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) h →
+      (modConcretePostNoX1ExactRegsFrame sp a b
+        (signExtend12 4095) raVal
+        (signExtend12 (0 : BitVec 12) - fullDivN3Shift b2)
+        (((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>> ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64)))
+        (((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>> ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64)))
+        (((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>> ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64)))
+        ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>> ((fullDivN3Shift b2).toNat % 64))
+        (fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (0 : Word)
+        (0 : Word)
+        (((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>>
+            ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<<
+            (((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat) % 64)))
+        (((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>>
+            ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<<
+            (((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat) % 64)))
+        (((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>>
+            ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<<
+            (((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat) % 64)))
+        ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>>
+          ((fullDivN3Shift b2).toNat % 64))
+        (fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.2
+        (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.2
+        (0 : Word)
+        (0 : Word)
+        (fullDivN3Shift b2) (3 : Word) (0 : Word)
+        (if bltu_0 then (base + div128CallRetOff)
+          else if bltu_1 then (base + div128CallRetOff) else retMem)
+        (if bltu_0 then (fullDivN3NormV b0 b1 b2 b3).2.2.1
+          else if bltu_1 then (fullDivN3NormV b0 b1 b2 b3).2.2.1 else dMem)
+        (if bltu_0 then divKTrialCallV5DLo (fullDivN3NormV b0 b1 b2 b3).2.2.1
+          else if bltu_1 then divKTrialCallV5DLo (fullDivN3NormV b0 b1 b2 b3).2.2.1 else dloMem)
+        (if bltu_0 then divKTrialCallV5Un0
+            (fullDivN3R1V5 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+          else if bltu_1 then divKTrialCallV5Un0
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+          else scratchUn0) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV5 bltu_1 bltu_0
+          a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)) h := by
+  intro h hq
+  delta fullModN3UnifiedPostNoX1V5 fullModN3DenormPostV5 fullDivN3FrameNoX1V5
+    fullDivN3ScratchNoX1V5 at hq
+  simp (config := { zeta := true }) only [denormModPost_unfold] at hq
+  rw [word_add_zero] at hq
+  rw [modConcretePostNoX1ExactRegsFrame_unfold,
+      evmWordIs_sp_limbs_eq sp a a0 a1 a2 a3 ha0 ha1 ha2 ha3,
+      evmWordIs_sp32_limbs_eq sp (EvmWord.mod a b)
+        (((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>> ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64)))
+        (((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>> ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64)))
+        (((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>> ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64)))
+        ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>> ((fullDivN3Shift b2).toNat % 64))
+        hdiv0 hdiv1 hdiv2 hdiv3,
+      divScratchValuesCallNoX1_unfold, divScratchValues_unfold]
+  xperm_hyp hq
+
+/-- Named callable-frame version for n=3 MOD. -/
+theorem fullModN3UnifiedPostNoX1V5_frame_to_modStackDispatchPostCallableExactFrame_scratch
+    (bltu_1 bltu_0 : Bool)
+    (sp base : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hdiv0 : (EvmWord.mod a b).getLimbN 0 =
+        (((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>> ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64))))
+    (hdiv1 : (EvmWord.mod a b).getLimbN 1 =
+        (((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>> ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64))))
+    (hdiv2 : (EvmWord.mod a b).getLimbN 2 =
+        (((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>> ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<< ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64))))
+    (hdiv3 : (EvmWord.mod a b).getLimbN 3 =
+        ((fullDivN3R0V5 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>> ((fullDivN3Shift b2).toNat % 64))) :
+    ∀ h,
+      (fullModN3UnifiedPostNoX1V5 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) h →
+      (modStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV5 bltu_1 bltu_0
+          a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)) h := by
+  intro h hp
+  rw [modStackDispatchPostCallableExactFrame_unfold]
+  exact sepConj_mono_left
+    (fun h hp => modConcretePostNoX1ExactRegs_weaken_callable_frame sp a b h hp)
+    h
+    (fullModN3UnifiedPostNoX1V5_frame_to_modConcretePostNoX1ExactRegsFrame_scratch
+      bltu_1 bltu_0 sp base a b
+      a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem
+      raVal ha0 ha1 ha2 ha3 hdiv0 hdiv1 hdiv2 hdiv3 h hp)
+
+/-- Word-remainder form: from `hdivWord : fullModN3RemainderWordV5 ... = EvmWord.mod a b`. -/
+theorem fullModN3UnifiedPostNoX1V5_frame_to_modStackDispatchPostCallableExactFrame_scratch_word
+    (bltu_1 bltu_0 : Bool)
+    (sp base : Word) (a b : EvmWord)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hdivWord : fullModN3RemainderWordV5 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.mod a b) :
+    ∀ h,
+      (fullModN3UnifiedPostNoX1V5 bltu_1 bltu_0 sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) h →
+      (modStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV5 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          scratchMem)) h := by
+  obtain ⟨hdiv0, hdiv1, hdiv2, hdiv3⟩ :=
+    fullModN3V5_hmods_of_word_eq a b
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      bltu_1 bltu_0
+      hdivWord
+  exact fullModN3UnifiedPostNoX1V5_frame_to_modStackDispatchPostCallableExactFrame_scratch
+    bltu_1 bltu_0 sp base a b
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    retMem dMem dloMem scratchUn0 scratchMem raVal
+    rfl rfl rfl rfl hdiv0 hdiv1 hdiv2 hdiv3
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3V5PostToDispatchPostV5Mod.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V5PostToDispatchPostV5Mod.lean
@@ -1,0 +1,47 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3V5PostToDispatchPostV5Mod
+
+  N=3 V5 MOD: from `fullModN3UnifiedPostNoX1V5` (with exact caller `x1`) and the
+  remainder-word correctness, conclude the scaffold post `modStackDispatchPostV5`.
+  Thin mirror of `N2V5PostToDispatchPostV5Mod` over the n=3 callable-frame bridge
+  (`N3V5ConcretePostBridgeMod`).
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N3V5ConcretePostBridgeMod
+import EvmAsm.Evm64.DivMod.Spec.StackPostBridgeMod
+import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Mod
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- From the n=3 v5 MOD unified post (with exact caller `x1`) and remainder-word
+    correctness, conclude the scaffold post `modStackDispatchPostV5`. -/
+theorem fullModN3UnifiedPostNoX1V5_to_modStackDispatchPostV5
+    (bltu_1 bltu_0 : Bool)
+    (sp base : Word) (a b : EvmWord)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hdivWord : fullModN3RemainderWordV5 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.mod a b) :
+    ∀ h,
+      (fullModN3UnifiedPostNoX1V5 bltu_1 bltu_0 sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) h →
+      modStackDispatchPostV5 sp a b h := by
+  intro h hp
+  have h1 := fullModN3UnifiedPostNoX1V5_frame_to_modStackDispatchPostCallableExactFrame_scratch_word
+    bltu_1 bltu_0 sp base a b
+    retMem dMem dloMem scratchUn0 scratchMem raVal hdivWord h hp
+  simp only [modStackDispatchPostV5]
+  revert h1
+  apply sepConj_mono
+  · exact fun h hp =>
+      modStackDispatchPostCallableExactFrame_weaken sp a b raVal (signExtend12 4095) h hp
+  · exact fun h hp => memIs_implies_memOwn h hp
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3V5Shift0ModRemainder.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V5Shift0ModRemainder.lean
@@ -1,0 +1,173 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3V5Shift0ModRemainder
+
+  **v5 n=3 MOD remainder correctness for the shift=0 path.**
+  When the divisor's top limb `b2` is already normalized (`b2 ≥ 2^63`), the
+  schoolbook runs on the RAW 3-limb divisor `(b0,b1,b2,0)` with no denormalization,
+  so the final R0 remainder window (3 limbs, top limb collapsed to 0) equals
+  `EvmWord.mod a b` directly.
+
+  MOD counterpart of `n3_shift0_quotient_word_eq_div` (N3V5Shift0Quotient): same
+  `iterN3V5_step` telescope (reused via the two-step accumulation), but extracts
+  the remainder (`Nat.mul_add_mod` + the window bound) instead of the quotient, and
+  closes with `mod_of_val256_eq_mod`.  n=3 analog of `n2_shift0_remainder_eq_mod`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N3V5Shift0Quotient
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- **v5 n=3 remainder word = mod a b (shift=0).** The shift=0 final R0 remainder
+    window, packed into `fromLimbs(R0.2.1, R0.2.2.1, R0.2.2.2.1, R0.2.2.2.2.1)`,
+    equals `EvmWord.mod a b`. -/
+theorem n3_shift0_remainder_word_eq_mod
+    (a0 a1 a2 a3 b0 b1 b2 : Word) (hb2 : b2.toNat ≥ 2^63) (bltu_1 bltu_0 : Bool)
+    (hc1 : bltu_1 = true → BitVec.ult (0:Word) b2 = true)
+    (hm1 : bltu_1 = false → ¬ BitVec.ult (0:Word) b2)
+    (hc0 : bltu_0 = true →
+      BitVec.ult (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 b2 = true)
+    (hm0 : bltu_0 = false →
+      ¬ BitVec.ult (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 b2) :
+    EvmWord.fromLimbs (fun i : Fin 4 => match i with
+        | 0 => (iterN3V5 bltu_0 b0 b1 b2 0 a0
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 0).2.1
+        | 1 => (iterN3V5 bltu_0 b0 b1 b2 0 a0
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 0).2.2.1
+        | 2 => (iterN3V5 bltu_0 b0 b1 b2 0 a0
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 0).2.2.2.1
+        | 3 => (iterN3V5 bltu_0 b0 b1 b2 0 a0
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 0).2.2.2.2.1)
+      = EvmWord.mod
+          (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3)
+          (EvmWord.fromLimbs fun i : Fin 4 => match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => 0) := by
+  have h0 : (0:Word).toNat = 0 := rfl
+  have hbnz : b0 ||| b1 ||| b2 ||| (0:Word) ≠ 0 := by
+    intro h
+    have h2 := (BitVec.or_eq_zero_iff.mp h).1
+    have hz : b2 = 0 := (BitVec.or_eq_zero_iff.mp h2).2
+    rw [hz] at hb2; simp at hb2
+  have hvpos : 2^191 ≤ val256 b0 b1 b2 0 := by simp only [EvmWord.val256, h0]; omega
+  have hfwv : val256 a1 a2 a3 0 < 2^64 * val256 b0 b1 b2 0 := by
+    have ha : val256 a1 a2 a3 0 < 2^192 := by
+      have := a1.isLt; have := a2.isLt; have := a3.isLt
+      simp only [EvmWord.val256, h0]; omega
+    calc val256 a1 a2 a3 0 < 2^192 := ha
+      _ ≤ 2^64 * 2^191 := by norm_num
+      _ ≤ 2^64 * val256 b0 b1 b2 0 := Nat.mul_le_mul_left _ hvpos
+  have hR1 := iterN3V5_step bltu_1 b0 b1 b2 a1 a2 a3 0 hb2 hfwv hc1 hm1
+  have hR0valid := n3_next_window_lt a0
+    (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1
+    (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1
+    (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 _ hR1.2
+  have hR0 := iterN3V5_step bltu_0 b0 b1 b2 a0
+    (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1
+    (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1
+    (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 hb2 hR0valid hc0 hm0
+  have hR0c := iterN3V5_collapse bltu_0 b0 b1 b2 a0
+    (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1
+    (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1
+    (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 hb2 hR0valid hc0 hm0
+  have hfirst : val256 a0 a1 a2 a3 = a0.toNat + 2^64 * val256 a1 a2 a3 0 := by
+    simp only [EvmWord.val256, h0]; ring
+  have hWin0 : val256 a0
+      (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1
+      (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1
+      (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1
+      = a0.toNat + 2^64 * ((iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1.toNat
+          + 2^64 * (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1.toNat
+          + 2^128 * (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1.toNat) := by
+    simp only [EvmWord.val256]; ring
+  rw [hWin0] at hR0
+  have htele := fullDivN3V5_two_step_nat hfirst hR1.1 hR0.1
+  have hbpos : 0 < val256 b0 b1 b2 0 := by omega
+  have hmodeq : val256 a0 a1 a2 a3 % val256 b0 b1 b2 0
+      = (iterN3V5 bltu_0 b0 b1 b2 0 a0
+            (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1
+            (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1
+            (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 0).2.1.toNat
+        + 2^64 * (iterN3V5 bltu_0 b0 b1 b2 0 a0
+            (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1
+            (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1
+            (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 0).2.2.1.toNat
+        + 2^128 * (iterN3V5 bltu_0 b0 b1 b2 0 a0
+            (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1
+            (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1
+            (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 0).2.2.2.1.toNat := by
+    rw [htele, Nat.mul_comm _ (val256 b0 b1 b2 0), Nat.mul_add_mod, Nat.mod_eq_of_lt hR0.2]
+  have hr : val256
+      (iterN3V5 bltu_0 b0 b1 b2 0 a0
+        (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1
+        (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1
+        (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 0).2.1
+      (iterN3V5 bltu_0 b0 b1 b2 0 a0
+        (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1
+        (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1
+        (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 0).2.2.1
+      (iterN3V5 bltu_0 b0 b1 b2 0 a0
+        (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1
+        (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1
+        (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 0).2.2.2.1
+      (iterN3V5 bltu_0 b0 b1 b2 0 a0
+        (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1
+        (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1
+        (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 0).2.2.2.2.1
+      = val256 a0 a1 a2 a3 % val256 b0 b1 b2 0 := by
+    rw [hR0c.1, hmodeq]; simp only [EvmWord.val256, h0]; ring_nf
+  exact mod_of_val256_eq_mod hbnz hr
+
+/-- Lane (`a b : EvmWord`) form of the shift=0 n=3 MOD remainder-word correctness. -/
+theorem n3_shift0_remainder_word_eq_mod_lane (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 : Word) (bltu_1 bltu_0 : Bool)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3z : b.getLimbN 3 = 0)
+    (hb2ge : b2.toNat ≥ 2^63)
+    (hc1 : bltu_1 = true → BitVec.ult (0:Word) b2 = true)
+    (hm1 : bltu_1 = false → ¬ BitVec.ult (0:Word) b2)
+    (hc0 : bltu_0 = true →
+      BitVec.ult (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 b2 = true)
+    (hm0 : bltu_0 = false →
+      ¬ BitVec.ult (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 b2) :
+    EvmWord.fromLimbs (fun i : Fin 4 => match i with
+        | 0 => (iterN3V5 bltu_0 b0 b1 b2 0 a0
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 0).2.1
+        | 1 => (iterN3V5 bltu_0 b0 b1 b2 0 a0
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 0).2.2.1
+        | 2 => (iterN3V5 bltu_0 b0 b1 b2 0 a0
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 0).2.2.2.1
+        | 3 => (iterN3V5 bltu_0 b0 b1 b2 0 a0
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.1
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.1
+                  (iterN3V5 bltu_1 b0 b1 b2 0 a1 a2 a3 0 0).2.2.2.1 0).2.2.2.2.1)
+      = EvmWord.mod a b := by
+  have hbase := n3_shift0_remainder_word_eq_mod a0 a1 a2 a3 b0 b1 b2 hb2ge bltu_1 bltu_0
+    hc1 hm1 hc0 hm0
+  refine hbase.trans ?_
+  congr 1
+  · conv_rhs => rw [← EvmWord.fromLimbs_match_getLimbN_id a]
+    congr 1
+    funext i
+    fin_cases i <;> simp only [ha0, ha1, ha2, ha3]
+  · conv_rhs => rw [← EvmWord.fromLimbs_match_getLimbN_id b]
+    congr 1
+    funext i
+    fin_cases i <;> simp only [hb0, hb1, hb2, hb3z]
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What

Completes the **entire n=3 MOD lane** over `modCode_noNop_v5`: `evm_mod_n3_lane_v5` (`divModStackDispatchPreNoX1 → modStackDispatchPostV5`, case-split `(clzResult b2).1 = 0`). **Supersedes #9582** (which had the loop-body layer + shiftNz lane) — this branch contains all of it plus the shift0 arm + combiner, so #9582 can be closed in favor of this. Builds on the merged n=3 remainder spec (#9575) and preloop (#9577). This is **the 4th of 5 MOD lanes** (bzero ✅, n=1 ✅, n=2 ✅, n=3 ✅) toward `evm_mod_v6_stack_spec` → MOD `.proven`.

10 commits, ~30 files, all mechanical mirrors of the DIV n=3 lane + the completed n=2 MOD lane, except the two genuine-math pieces (both reusing pirapira's n=3 quotient telescope):
- **Loop-body (C1/C2)**: leaves → Combos → borrow-carry → Unified → loop-over-`modCode`.
- **FromShape (C3)**: `evm_mod_n3_stack_pre_to_unified_post_v5_noNop_fromShape`.
- **Full path (D)**: V5 families/epilogue, `evm_mod_n3_preloop_loop_denorm_v5_noNop_fromShape`, concrete post-bridge, `fullModN3UnifiedPostNoX1V5_to_modStackDispatchPostV5`.
- **shiftNz lane**: `evm_mod_n3_lane_shiftNz_v5`.
- **shift0 arm**: remainder correctness (`n3_shift0_remainder_word_eq_mod`), preloop/loop/to-denorm, full-path (u-cell bridge), `evm_mod_n3_lane_shift0_v5`.
- **combiner**: `evm_mod_n3_lane_v5`.

## Verification

- `lake build EvmAsm.Evm64.DivMod` — green (1909 jobs).
- Axiom-clean: `#print axioms evm_mod_n3_lane_v5` → `propext, Classical.choice, Quot.sound`.
- `scripts/check-forbidden-tactics.sh` — OK.

## Next

The n=4 lane (last, hardest), then the 5-lane combinator (`evm_mod_stack_spec_unconditional_of_lanes_v5_mod`, already exists) + the v6 assembly links → `evm_mod_v6_stack_spec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)