### PR TITLE
feat(divmod): n=4 MOD lane complete — evm_mod_n4_lane_of_shape_native (5th/last MOD lane)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -495,6 +495,9 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopMaxAddbackMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallSkipMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallAddbackMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDenormCallSkipMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDenormCallAddbackMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopFullCallSkipMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopFullCallAddbackMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallSkip
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallSkip

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -494,6 +494,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopMaxMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopMaxAddbackMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallSkipMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallAddbackMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDenormCallSkipMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallSkip
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallSkip

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -492,6 +492,8 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopCallMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopCallAddbackMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopMaxMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopMaxAddbackMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallSkipMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallAddbackMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallSkip
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallSkip

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -142,6 +142,7 @@ import EvmAsm.Evm64.DivMod.Spec.N4V5TrialQuotientV4Bridge
 import EvmAsm.Evm64.DivMod.Spec.N4V5CallAddbackWordLane
 import EvmAsm.Evm64.DivMod.Spec.N4V5CallSkipWordLane
 import EvmAsm.Evm64.DivMod.Spec.N4V5CallSkipModWordLane
+import EvmAsm.Evm64.DivMod.Spec.N4V5CallAddbackModWordLane
 import EvmAsm.Evm64.DivMod.Spec.N4V5CallSkipUpperBound
 import EvmAsm.Evm64.DivMod.Spec.N4V5CallSkipWordLaneNative
 import EvmAsm.Evm64.DivMod.Spec.N4Carry2OfNamed

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -501,6 +501,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopFullCallSkipMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopFullCallAddbackMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDispatchPostBridgeMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLaneCallSkipMod
+import EvmAsm.Evm64.DivMod.Spec.N4V5CallAddbackModRemainder
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallSkip
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallSkip

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -487,6 +487,11 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5FullShift0Mod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5LaneShift0Mod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5LaneMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopCallMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopCallAddbackMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopMaxMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopMaxAddbackMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallSkip
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallSkip

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -500,6 +500,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDenormCallAddbackMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopFullCallSkipMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopFullCallAddbackMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDispatchPostBridgeMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLaneCallSkipMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallSkip
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallSkip

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -498,6 +498,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDenormCallSkipMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDenormCallAddbackMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopFullCallSkipMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopFullCallAddbackMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDispatchPostBridgeMod
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5PreloopShift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5ToDenormShift0CallSkip
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallSkip

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -141,6 +141,7 @@ import EvmAsm.Evm64.DivMod.Spec.DivDispatchShift
 import EvmAsm.Evm64.DivMod.Spec.N4V5TrialQuotientV4Bridge
 import EvmAsm.Evm64.DivMod.Spec.N4V5CallAddbackWordLane
 import EvmAsm.Evm64.DivMod.Spec.N4V5CallSkipWordLane
+import EvmAsm.Evm64.DivMod.Spec.N4V5CallSkipModWordLane
 import EvmAsm.Evm64.DivMod.Spec.N4V5CallSkipUpperBound
 import EvmAsm.Evm64.DivMod.Spec.N4V5CallSkipWordLaneNative
 import EvmAsm.Evm64.DivMod.Spec.N4Carry2OfNamed

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopCallAddbackMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopCallAddbackMod.lean
@@ -1,0 +1,57 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopCallAddbackMod
+
+  MOD mirror of `FullPathN4V5NoNopCallAddback`: the n=4 loop body lifted to `modCode_noNop_v5`
+  via `sharedDivModCodeNoNop_v5_sub_modCode_noNop_v5` (raw shared-code body reused).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopCallAddback
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+theorem divK_loop_body_n4_call_addback_j0_beq_norm_v5_noNop_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult uTop v3)
+    (hborrow : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV5QHat uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word))
+    (hcarry2_nz :
+      let qHat := divKTrialCallV5QHat uTop u3 v3
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 234 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopBodyN4CallJ0NormPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 **
+       (sp + signExtend12 3936 ↦ₘ scratchMem))
+      (loopBodyN4CallAddbackBeqJ0PostV5 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  have raw := divK_loop_body_n4_call_addback_j0_beq_v5_spec_within_noNop
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+    retMem dMem dloMem scratchUn0 scratchMem base
+    halign hbltu hborrow hcarry2_nz
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v5_sub_modCode_noNop_v5) raw
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      rw [loopBodyN4CallJ0NormPre_unfold] at hp
+      rw [loopBodyN4CallSkipJ0PreV4_unfold]
+      rw [loopBodyN4CallSkipJ0Pre_unfold]
+      simp only [se12_32, se12_40, se12_48, se12_56,
+                 u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+                 u_base_off4072_j0, u_base_off4064_j0, q_addr_j0]
+      xperm_hyp hp)
+    (fun _ hp => hp)
+    raw'
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopCallMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopCallMod.lean
@@ -1,0 +1,48 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopCallMod
+
+  MOD mirror of `FullPathN4V5NoNopCall`: the n=4 loop body lifted to `modCode_noNop_v5`
+  via `sharedDivModCodeNoNop_v5_sub_modCode_noNop_v5` (raw shared-code body reused).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopCall
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+theorem divK_loop_body_n4_call_skip_j0_norm_v5_noNop_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult uTop v3)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV5QHat uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 158 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      (loopBodyN4CallJ0NormPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 **
+       (sp + signExtend12 3936 ↦ₘ scratchMem))
+      (loopBodyN4CallSkipJ0PostV5 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  have raw := divK_loop_body_n4_call_skip_j0_v5_spec_within_noNop
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+    retMem dMem dloMem scratchUn0 scratchMem base
+    halign hbltu hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v5_sub_modCode_noNop_v5) raw
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      rw [loopBodyN4CallJ0NormPre_unfold] at hp
+      rw [loopBodyN4CallSkipJ0PreV4_unfold]
+      rw [loopBodyN4CallSkipJ0Pre_unfold]
+      simp only [se12_32, se12_40, se12_48, se12_56,
+                 u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+                 u_base_off4072_j0, u_base_off4064_j0, q_addr_j0]
+      xperm_hyp hp)
+    (fun _ hp => hp)
+    raw'
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopDenormCallAddbackMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopDenormCallAddbackMod.lean
@@ -1,0 +1,152 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDenormCallAddbackMod
+
+  n=4 v5 MOD call+addback-beq denorm/epilogue: denormOff → nopOff over
+  `modCode_noNop_v5`.  MOD mirror of `evm_div_n4_call_addback_beq_denorm_epilogue_spec_v5_noNop`
+  (FullPathN4V5NoNopDenormCallAddback): same shared addback loop-exit state
+  (`preloopCallAddbackPostN4V5`), but the MOD denorm epilogue
+  (`evm_mod_preamble_denorm_epilogue_spec_v5_noNop`, post `denormModPost`) reads out
+  the un-normalized REMAINDER (the post-addback `un*Out`) where DIV reads the
+  corrected quotient.  The quotient output cells (sp+4088/4080/4072/4064, holding
+  `q_out`/0/0/0), unread by MOD, are framed through.  Step of the n=4 MOD lane.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallAddbackMod
+import EvmAsm.Evm64.DivMod.Compose.DenormEpilogueV5Mod
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- Final post for the n=4 v5 MOD call+addback-beq full path: the denormalized MOD
+    remainder (`denormModPost` of the post-addback `un*Out`) plus the residual
+    scratch cells (incl. the framed, unread quotient cells).  MOD mirror of
+    `fullDivN4CallAddbackBeqPostV5`. -/
+def fullModN4CallAddbackPostV5 (sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem : Word) : Assertion :=
+  let shift := (clzResult b3).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  let qHat := divKTrialCallV5QHat u4 u3 b3'
+  let dLo := divKTrialCallV5DLo b3'
+  let div_un0 := divKTrialCallV5Un0 u3
+  let scratchOut := divKTrialCallV5ScratchOut u4 u3 b3' scratchMem
+  let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  let u4_new := u4 - c3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 u4_new b0' b1' b2' b3'
+  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 b0' b1' b2' b3'
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 b0' b1' b2' b3'
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let u4_out  := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
+  denormModPost sp shift un0Out un1Out un2Out un3Out **
+  ((sp + signExtend12 3992) ↦ₘ shift) **
+  ((sp + signExtend12 4088) ↦ₘ q_out) **
+  ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4024) ↦ₘ u4_out) **
+  ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+  (.x9 ↦ᵣ (0 : Word) + signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ b3') **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1
+
+/-- n=4 v5 MOD call+addback-beq denorm/epilogue: denormOff → nopOff over `modCode_noNop_v5`. -/
+theorem evm_mod_n4_call_addback_denorm_epilogue_spec_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 scratchMem : Word)
+    (hshift_nz : (clzResult b3).1 ≠ 0) :
+    cpsTripleWithin (2 + 23 + 10) (base + denormOff) (base + nopOff) (modCode_noNop_v5 base)
+      (preloopCallAddbackPostN4V5 sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)
+      (fullModN4CallAddbackPostV5 sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) := by
+  let shift := (clzResult b3).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  let qHat := divKTrialCallV5QHat u4 u3 b3'
+  let dLo := divKTrialCallV5DLo b3'
+  let div_un0 := divKTrialCallV5Un0 u3
+  let scratchOut := divKTrialCallV5ScratchOut u4 u3 b3' scratchMem
+  let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  let u4_new := u4 - c3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 u4_new b0' b1' b2' b3'
+  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 b0' b1' b2' b3'
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 b0' b1' b2' b3'
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let u4_out  := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
+  have hB := evm_mod_preamble_denorm_epilogue_spec_v5_noNop sp base
+    un0Out un1Out un2Out un3Out shift
+    un3Out ((0 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088) c3
+    b0' b1' b2' b3'
+    hshift_nz
+  have hBF := cpsTripleWithin_frameR
+    (((sp + signExtend12 4088) ↦ₘ q_out) **
+     ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ u4_out) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     (.x9 ↦ᵣ (0 : Word) + signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ b3') **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ div_un0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) hB
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      simp only [preloopCallAddbackPostN4V5, loopBodyN4CallAddbackBeqJ0PostV5,
+        loopBodyAddbackBeqPost, loopExitPost,
+        se12_32, se12_40, se12_48, se12_56,
+        u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+        u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at hp
+      xperm_hyp hp)
+    (fun h hq => by
+      delta fullModN4CallAddbackPostV5
+      simp only [denormModPost_unfold] at hq ⊢
+      xperm_chunked hq)
+    hBF
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopDenormCallSkipMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopDenormCallSkipMod.lean
@@ -1,0 +1,128 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDenormCallSkipMod
+
+  n=4 v5 MOD call+skip denorm/epilogue: denormOff → nopOff over `modCode_noNop_v5`.
+  MOD mirror of `evm_div_n4_call_skip_denorm_epilogue_spec_v5_noNop`
+  (FullPathN4V5NoNopDenormCallSkip): same shared pre `preloopCallSkipPostN4V5`
+  (op-agnostic loop-exit state), but the MOD denorm epilogue
+  (`evm_mod_preamble_denorm_epilogue_spec_v5_noNop`, post `denormModPost`) reads out
+  the un-normalized REMAINDER (the mulsub result `ms`) where DIV reads the quotient.
+  The quotient output cells (sp+4088/4080/4072/4064), unread by MOD, are framed
+  through.  Step of the n=4 MOD lane.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallSkipMod
+import EvmAsm.Evm64.DivMod.Compose.DenormEpilogueV5Mod
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- Final post for the n=4 v5 MOD call+skip full path: the denormalized MOD
+    remainder (`denormModPost` of the mulsub result `ms`) plus the residual scratch
+    cells (incl. the framed, unread quotient cells).  MOD mirror of
+    `fullDivN4CallSkipPostV5`. -/
+def fullModN4CallSkipPostV5 (sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem : Word) : Assertion :=
+  let shift := (clzResult b3).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  let qHat := divKTrialCallV5QHat u4 u3 b3'
+  let dLo := divKTrialCallV5DLo b3'
+  let div_un0 := divKTrialCallV5Un0 u3
+  let scratchOut := divKTrialCallV5ScratchOut u4 u3 b3' scratchMem
+  let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
+  denormModPost sp shift ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 **
+  ((sp + signExtend12 3992) ↦ₘ shift) **
+  ((sp + signExtend12 4088) ↦ₘ qHat) **
+  ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4024) ↦ₘ u4 - ms.2.2.2.2) **
+  (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+  (.x9 ↦ᵣ (0 : Word) + signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ b3') **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1
+
+/-- n=4 v5 MOD call+skip denorm/epilogue: denormOff → nopOff over `modCode_noNop_v5`. -/
+theorem evm_mod_n4_call_skip_denorm_epilogue_spec_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 scratchMem : Word)
+    (hshift_nz : (clzResult b3).1 ≠ 0) :
+    cpsTripleWithin (2 + 23 + 10) (base + denormOff) (base + nopOff) (modCode_noNop_v5 base)
+      (preloopCallSkipPostN4V5 sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)
+      (fullModN4CallSkipPostV5 sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) := by
+  let shift := (clzResult b3).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  let qHat := divKTrialCallV5QHat u4 u3 b3'
+  let dLo := divKTrialCallV5DLo b3'
+  let div_un0 := divKTrialCallV5Un0 u3
+  let scratchOut := divKTrialCallV5ScratchOut u4 u3 b3' scratchMem
+  let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
+  have hB := evm_mod_preamble_denorm_epilogue_spec_v5_noNop sp base
+    ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 shift
+    ms.2.2.2.1 ((0 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088) ms.2.2.2.2
+    b0' b1' b2' b3'
+    hshift_nz
+  have hBF := cpsTripleWithin_frameR
+    (((sp + signExtend12 4088) ↦ₘ qHat) **
+     ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ u4 - ms.2.2.2.2) **
+     (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     (.x9 ↦ᵣ (0 : Word) + signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ b3') **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ div_un0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) hB
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      simp only [preloopCallSkipPostN4V5, loopBodyN4CallSkipJ0PostV5,
+        loopBodyN4SkipPost, loopBodySkipPost, loopExitPost,
+        se12_32, se12_40, se12_48, se12_56,
+        u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+        u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at hp
+      xperm_hyp hp)
+    (fun h hq => by
+      delta fullModN4CallSkipPostV5
+      simp only [denormModPost_unfold] at hq ⊢
+      xperm_chunked hq)
+    hBF
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopDispatchPostBridgeMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopDispatchPostBridgeMod.lean
@@ -1,0 +1,70 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDispatchPostBridgeMod
+
+  n=4 v5 MOD post bridge: the `denormModPost`-form full-path post (remainder
+  readout) + residual scratch frame implies `modStackDispatchPostV5`, given the
+  four per-limb `(EvmWord.mod a b).getLimbN` facts.  MOD mirror of
+  `n4_denormDivPost_frame_to_divStackDispatchPost_v5`
+  (FullPathN4V5NoNopDispatchPostBridge): `denormModPost` (remainder in the output
+  cells) where DIV has `denormDivPost` (quotient), and the `mod`-limb facts where
+  DIV threads `div`-limb facts.  The frame is generalized (branch-independent) so
+  both the call-skip and call-addback lanes reuse it.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.DenormEpilogueV5Mod
+import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Mod
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_add_zero)
+
+/-- n=4 v5 MOD post bridge: `denormModPost` full-path post + residual frame implies
+    `modStackDispatchPostV5`, given the four `(EvmWord.mod a b).getLimbN` facts. -/
+theorem n4_denormModPost_frame_to_modStackDispatchPost_v5
+    (sp base : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 : Word)
+    (shift u0 u1 u2 u3 u4f qHatV x9Val dMemV dloMemV scratchUn0V scratchOutV : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hmod0 : (EvmWord.mod a b).getLimbN 0 =
+      (u0 >>> (shift.toNat % 64)) ||| (u1 <<< ((signExtend12 (0 : BitVec 12) - shift).toNat % 64)))
+    (hmod1 : (EvmWord.mod a b).getLimbN 1 =
+      (u1 >>> (shift.toNat % 64)) ||| (u2 <<< ((signExtend12 (0 : BitVec 12) - shift).toNat % 64)))
+    (hmod2 : (EvmWord.mod a b).getLimbN 2 =
+      (u2 >>> (shift.toNat % 64)) ||| (u3 <<< ((signExtend12 (0 : BitVec 12) - shift).toNat % 64)))
+    (hmod3 : (EvmWord.mod a b).getLimbN 3 = u3 >>> (shift.toNat % 64)) :
+    ∀ h,
+      (denormModPost sp shift u0 u1 u2 u3 **
+       ((sp + signExtend12 3992) ↦ₘ shift) **
+       ((sp + signExtend12 4088) ↦ₘ qHatV) **
+       ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ u4f) **
+       (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+       (.x9 ↦ᵣ x9Val) ** (.x11 ↦ᵣ qHatV) **
+       (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+       (sp + signExtend12 3960 ↦ₘ dMemV) **
+       (sp + signExtend12 3952 ↦ₘ dloMemV) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0V) **
+       (sp + signExtend12 3936 ↦ₘ scratchOutV) ** regOwn .x1) h →
+      modStackDispatchPostV5 sp a b h := by
+  intro h hp
+  rw [modStackDispatchPostV5]
+  delta denormModPost at hp
+  rw [word_add_zero] at hp
+  apply sepConj_mono_right (P := modStackDispatchPost sp a b) memIs_implies_memOwn h
+  apply sepConj_mono_left (modStackDispatchPost_weaken sp a b) h
+  rw [evmWordIs_sp_limbs_eq sp a a0 a1 a2 a3 ha0 ha1 ha2 ha3,
+      evmWordIs_sp32_limbs_eq sp (EvmWord.mod a b) _ _ _ _ hmod0 hmod1 hmod2 hmod3,
+      divScratchValuesCall_unfold, divScratchValues_unfold]
+  xperm_hyp hp
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopFullCallAddbackMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopFullCallAddbackMod.lean
@@ -1,0 +1,63 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopFullCallAddbackMod
+
+  Full n=4 v5 MOD call+addback-beq path: base → nopOff over `modCode_noNop_v5`
+  (shift ≠ 0, call+addback).  MOD mirror of `evm_div_n4_full_call_addback_spec_v5_noNop`:
+  composes the preloop+body (`evm_mod_n4_preloop_call_addback_spec_v5_noNop`,
+  base→denormOff) with the MOD denorm/epilogue
+  (`evm_mod_n4_call_addback_denorm_epilogue_spec_v5_noNop`, denormOff→nopOff).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDenormCallAddbackMod
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Full n=4 v5 MOD call+addback-beq path: base → nopOff (shift ≠ 0). -/
+theorem evm_mod_n4_full_call_addback_spec_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : isCallTrialN4 a3 b2 b3)
+    (hborrow : isAddbackBorrowN4CallV5 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hcarry2_nz : isAddbackCarry2NzN4CallV5 a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 234 + (2 + 23 + 10))
+      base (base + nopOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1)
+      (fullModN4CallAddbackPostV5 sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) := by
+  have hA := evm_mod_n4_preloop_call_addback_spec_v5_noNop sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratchUn0 scratchMem
+    hbnz hb3nz hshift_nz halign hbltu hborrow hcarry2_nz
+  have hB := evm_mod_n4_call_addback_denorm_epilogue_spec_v5_noNop sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 scratchMem hshift_nz
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hA hB
+  exact cpsTripleWithin_mono_nSteps (by decide) hFull
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopFullCallSkipMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopFullCallSkipMod.lean
@@ -1,0 +1,62 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopFullCallSkipMod
+
+  Full n=4 v5 MOD call+skip path: base → nopOff over `modCode_noNop_v5`
+  (shift ≠ 0, call+skip).  MOD mirror of `evm_div_n4_full_call_skip_spec_v5_noNop`:
+  composes the preloop+body (`evm_mod_n4_preloop_call_skip_spec_v5_noNop`,
+  base→denormOff) with the MOD denorm/epilogue
+  (`evm_mod_n4_call_skip_denorm_epilogue_spec_v5_noNop`, denormOff→nopOff).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDenormCallSkipMod
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Full n=4 v5 MOD call+skip path: base → nopOff (shift ≠ 0). -/
+theorem evm_mod_n4_full_call_skip_spec_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : isCallTrialN4 a3 b2 b3)
+    (hborrow : isSkipBorrowN4CallV5 a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 158 + (2 + 23 + 10))
+      base (base + nopOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1)
+      (fullModN4CallSkipPostV5 sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) := by
+  have hA := evm_mod_n4_preloop_call_skip_spec_v5_noNop sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratchUn0 scratchMem
+    hbnz hb3nz hshift_nz halign hbltu hborrow
+  have hB := evm_mod_n4_call_skip_denorm_epilogue_spec_v5_noNop sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 scratchMem hshift_nz
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hA hB
+  exact cpsTripleWithin_mono_nSteps (by decide) hFull
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopLaneCallSkipMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopLaneCallSkipMod.lean
@@ -1,0 +1,94 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopLaneCallSkipMod
+
+  The n=4 v5 MOD lane, call+skip branch, from the dispatch precondition to
+  `modStackDispatchPostV5` over `modCode_noNop_v5`, given the call-skip conditions.
+  MOD mirror of `evm_div_n4_lane_callSkip_of_conds`: derives the four
+  `(EvmWord.mod a b).getLimbN i` remainder facts via `n4_call_skip_mod_getLimbN_v5`
+  (hoisted to top-level context to avoid the whnf blowup of inline derivation),
+  then composes the pre-bridge (`n4_dispatchPre_to_pathEntry_v5`), the full
+  call+skip path (`evm_mod_n4_full_call_skip_spec_v5_noNop`), and the MOD post
+  bridge (`n4_denormModPost_frame_to_modStackDispatchPost_v5`).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopFullCallSkipMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDispatchPre
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopDispatchPostBridgeMod
+import EvmAsm.Evm64.DivMod.Spec.N4V5CallSkipModWordLane
+import EvmAsm.Evm64.DivMod.Spec.UnconditionalScaffoldV5Mod
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- n=4 v5 MOD lane (call+skip branch), from the dispatch pre to
+    `modStackDispatchPostV5`, given the call-skip conditions. -/
+theorem evm_mod_n4_lane_callSkip_of_conds (sp base : Word) (a b : EvmWord)
+    (x1Val v5 v6 v7 v10 v11Old : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : isCallTrialN4 a3 b2 b3)
+    (hborrowV5 : isSkipBorrowN4CallV5 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hborrowV4 : isSkipBorrowN4CallV4Evm a b)
+    (hsem : n4CallSkipSemanticHoldsV4 a b)
+    (hbridge :
+      divKTrialCallV5QHat
+        ((a.getLimbN 3) >>> ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64))
+        (((a.getLimbN 3) <<< ((clzResult (b.getLimbN 3)).1.toNat % 64)) |||
+          ((a.getLimbN 2) >>> ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64)))
+        (((b.getLimbN 3) <<< ((clzResult (b.getLimbN 3)).1.toNat % 64)) |||
+          ((b.getLimbN 2) >>> ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64))) =
+      div128Quot_v4
+        ((a.getLimbN 3) >>> ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64))
+        (((a.getLimbN 3) <<< ((clzResult (b.getLimbN 3)).1.toNat % 64)) |||
+          ((a.getLimbN 2) >>> ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64)))
+        (((b.getLimbN 3) <<< ((clzResult (b.getLimbN 3)).1.toNat % 64)) |||
+          ((b.getLimbN 2) >>> ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64)))) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v5 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) x1Val
+        ((clzResult b3).2 >>> (63 : Nat)) v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostV5 sp a b) := by
+  have hb3nz' : b.getLimbN 3 ≠ 0 := by rw [hb3]; exact hb3nz
+  have hb_ne : b ≠ 0 := by
+    intro h; exact hb3nz' (by rw [h]; exact EvmWord.getLimbN_zero 3)
+  have hshift_nz' : (clzResult (b.getLimbN 3)).1 ≠ 0 := by rw [hb3]; exact hshift_nz
+  have hbnz_lor : b0 ||| b1 ||| b2 ||| b3 ≠ 0 := fun h => hb3nz (BitVec.or_eq_zero_iff.mp h).2
+  -- Convert the borrow-skip cert to the getLimbN form the getLimbN lemma expects
+  -- (else `a0 =?= a.getLimbN 0` whnf-loops on the huge application).
+  have hborrowV5' : isSkipBorrowN4CallV5 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2)
+      (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := by
+    rw [ha0, ha1, ha2, ha3, hb0, hb1, hb2, hb3]; exact hborrowV5
+  obtain ⟨hmod0, hmod1, hmod2, hmod3⟩ :=
+    n4_call_skip_mod_getLimbN_v5 a b hb_ne hshift_nz' hb3nz' hborrowV4 hborrowV5' hsem hbridge
+  simp only [ha0, ha1, ha2, ha3, hb0, hb1, hb2, hb3] at hmod0 hmod1 hmod2 hmod3
+  have hpath := evm_mod_n4_full_call_skip_spec_v5_noNop sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratchUn0 scratchMem
+    hbnz_lor hb3nz hshift_nz halign hbltu hborrowV5
+  refine cpsTripleWithin_mono_nSteps (by have h : unifiedDivBound = 946 := rfl; omega) <|
+    cpsTripleWithin_weaken ?_ ?_ hpath
+  · intro h hp
+    exact n4_dispatchPre_to_pathEntry_v5 sp a b x1Val ((clzResult b3).2 >>> (63 : Nat))
+      v5 v6 v7 v10 v11Old a0 a1 a2 a3 b0 b1 b2 b3
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem retMem dMem dloMem
+      scratchUn0 scratchMem ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 h hp
+  · intro h hq
+    delta modStackDispatchPostV5
+    unfold fullModN4CallSkipPostV5 at hq
+    exact n4_denormModPost_frame_to_modStackDispatchPost_v5 sp base a b a0 a1 a2 a3
+      _ _ _ _ _ _ _ _ _ _ _ _ ha0 ha1 ha2 ha3 hmod0 hmod1 hmod2 hmod3 h hq
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopMaxAddbackMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopMaxAddbackMod.lean
@@ -1,0 +1,50 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopMaxAddbackMod
+
+  MOD mirror of `FullPathN4V5NoNopMaxAddback`: the n=4 loop body lifted to `modCode_noNop_v5`
+  via `sharedDivModCodeNoNop_v5_sub_modCode_noNop_v5` (raw shared-code body reused).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopMaxAddback
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+theorem divK_loop_body_n4_max_addback_j0_beq_norm_v5_noNop_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult uTop v3)
+    (hcarry2_nz : isAddbackCarry2NzN4Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+       ((sp + 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ u0) **
+       ((sp + 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ u2) **
+       ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + signExtend12 4024) ↦ₘ uTop) **
+       ((sp + signExtend12 4088) ↦ₘ qOld))
+      (loopBodyN4AddbackBeqPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n4_max_addback_j0_beq_v5_spec_within_noNop
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hcarry2_nz hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v5_sub_modCode_noNop_v5) raw
+  rw [loopBodyN4MaxSkipJ0Pre_unfold] at raw'
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw'
+  exact raw'
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopMaxMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopMaxMod.lean
@@ -1,0 +1,50 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopMaxMod
+
+  MOD mirror of `FullPathN4V5NoNopMax`: the n=4 loop body lifted to `modCode_noNop_v5`
+  via `sharedDivModCodeNoNop_v5_sub_modCode_noNop_v5` (raw shared-code body reused).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopMax
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+theorem divK_loop_body_n4_max_skip_j0_norm_v5_noNop_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult uTop v3) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) = (0 : Word) →
+    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+       ((sp + 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ u0) **
+       ((sp + 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ u2) **
+       ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + signExtend12 4024) ↦ₘ uTop) **
+       ((sp + signExtend12 4088) ↦ₘ qOld))
+      (loopBodyN4SkipPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n4_max_skip_j0_v5_spec_within_noNop
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v5_sub_modCode_noNop_v5) raw
+  rw [loopBodyN4MaxSkipJ0Pre_unfold] at raw'
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw'
+  rw [loopBodyN4MaxSkipJ0Post_unfold] at raw'
+  exact raw'
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopPreloopCallAddbackMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopPreloopCallAddbackMod.lean
@@ -1,0 +1,106 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallAddbackMod
+
+  n=4 v5 MOD preloop + call+addback loop body composition: base → denormOff over
+  `modCode_noNop_v5`.  MOD mirror of `evm_div_n4_preloop_call_addback_spec_v5_noNop`
+  (FullPathN4V5NoNopPreloopCallAddback): the preloop
+  (`evm_mod_n4_to_loopSetup_spec_within_v5_noNop`) ;; the call+addback j=0 loop body
+  (`divK_loop_body_n4_call_addback_j0_beq_norm_v5_noNop_modCode`), via
+  `cpsTripleWithin_seq_perm_same_cr`.  Post `preloopCallAddbackPostN4V5` + the shape
+  predicates are op-agnostic and reused verbatim.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopCallAddbackMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallAddback
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- n=4 v5 MOD preloop + call+addback loop body: base → denormOff over
+    `modCode_noNop_v5`. -/
+theorem evm_mod_n4_preloop_call_addback_spec_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : isCallTrialN4 a3 b2 b3)
+    (hborrow : isAddbackBorrowN4CallV5 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hcarry2_nz : isAddbackCarry2NzN4CallV5 a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 234) base (base + denormOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1)
+      (preloopCallAddbackPostN4V5 sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) := by
+  unfold isCallTrialN4 at hbltu
+  unfold isAddbackBorrowN4CallV5 at hborrow
+  unfold isAddbackCarry2NzN4CallV5 at hcarry2_nz
+  let shift := (clzResult b3).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  have hPre := evm_mod_n4_to_loopSetup_spec_within_v5_noNop sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    hbnz hb3nz hshift_nz
+  have hPreF := cpsTripleWithin_frameR
+    ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+     (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+     (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1)
+    (by pcFree) hPre
+  have hLoop := divK_loop_body_n4_call_addback_j0_beq_norm_v5_noNop_modCode sp base
+    jMem (4 : Word) shift u0 (a0 >>> (antiShift.toNat % 64)) v11Old antiShift
+    b0' b1' b2' b3' u0 u1 u2 u3 u4 (0 : Word)
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow hcarry2_nz
+  have hLoopF := cpsTripleWithin_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hLoop
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      delta loopSetupPost at hp
+      simp only [x1_val_n4] at hp
+      rw [loopBodyN4CallJ0NormPre_unfold]
+      xperm_hyp hp) hPreF hLoopF
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta preloopCallAddbackPostN4V5; xperm_hyp hq)
+    hFull
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopPreloopCallSkipMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopPreloopCallSkipMod.lean
@@ -1,0 +1,105 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallSkipMod
+
+  n=4 v5 MOD preloop + call+skip loop body composition: base → denormOff over
+  `modCode_noNop_v5`.  MOD mirror of `evm_div_n4_preloop_call_skip_spec_v5_noNop`
+  (FullPathN4V5NoNopPreloopCallSkip): the preloop
+  (`evm_mod_n4_to_loopSetup_spec_within_v5_noNop`) ;; the call+skip j=0 loop body
+  (`divK_loop_body_n4_call_skip_j0_norm_v5_noNop_modCode`), via
+  `cpsTripleWithin_seq_perm_same_cr`.  The loop output post `preloopCallSkipPostN4V5`
+  and the shape predicates (`isCallTrialN4`, `isSkipBorrowN4CallV5`) are op-agnostic
+  and reused verbatim.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopCallMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopMod
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopCallSkip
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- n=4 v5 MOD preloop + call+skip loop body: base → denormOff over
+    `modCode_noNop_v5`. -/
+theorem evm_mod_n4_preloop_call_skip_spec_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : isCallTrialN4 a3 b2 b3)
+    (hborrow : isSkipBorrowN4CallV5 a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 158) base (base + denormOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1)
+      (preloopCallSkipPostN4V5 sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) := by
+  unfold isCallTrialN4 at hbltu
+  unfold isSkipBorrowN4CallV5 at hborrow
+  let shift := (clzResult b3).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  have hPre := evm_mod_n4_to_loopSetup_spec_within_v5_noNop sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    hbnz hb3nz hshift_nz
+  have hPreF := cpsTripleWithin_frameR
+    ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+     (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+     (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1)
+    (by pcFree) hPre
+  have hLoop := divK_loop_body_n4_call_skip_j0_norm_v5_noNop_modCode sp base
+    jMem (4 : Word) shift u0 (a0 >>> (antiShift.toNat % 64)) v11Old antiShift
+    b0' b1' b2' b3' u0 u1 u2 u3 u4 (0 : Word)
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow
+  have hLoopF := cpsTripleWithin_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hLoop
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      delta loopSetupPost at hp
+      simp only [x1_val_n4] at hp
+      rw [loopBodyN4CallJ0NormPre_unfold]
+      xperm_hyp hp) hPreF hLoopF
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta preloopCallSkipPostN4V5; xperm_hyp hq)
+    hFull
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopPreloopMod.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V5NoNopPreloopMod.lean
@@ -1,0 +1,296 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloopMod
+
+  The n=4 MOD preloop pieces over `modCode_noNop_v5`, the MOD mirror of the DIV
+  n=4 preloop (`FullPathN4V5NoNopPreloop`): PhaseB(n=4) `b3 ≠ 0` dispatch +
+  AB/CLZ/PhaseC2/NormB/NormA/LoopSetup over `modCode_noNop_v5`.  Div→mod swaps:
+  code surface `divCode_noNop_v5` → `modCode_noNop_v5`, the phaseB block-subsumption
+  lemmas `_sub_divCode` → `_sub_modCode`, and the phase bricks div → `_mod`.
+  Mechanical mirror; the n=3 MOD preloop (`FullPathN3V5NoNopPreloopMod`) is the
+  structural template.  Foundation of the n=4 MOD lane.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V5NoNopPreloop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V5NoNopPreloopMod
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- PhaseB(n=4) over `modCode_noNop_v5`: the `b3 ≠ 0` dispatch branch (n = 4). -/
+theorem evm_mod_phaseB_n4_spec_within_v5_noNop (sp base : Word)
+    (b1 b2 b3 : Word) (v5 v6 v7 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
+    (hb3nz : b3 ≠ 0) :
+    cpsTripleWithin 21 (base + phaseBOff) (base + clzOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) **
+       ((sp + signExtend12 3984) ↦ₘ nMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b3) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+       ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 3984) ↦ₘ (4 : Word))) := by
+  -- Local copies of the (private) PhaseB offset/arith helpers.
+  have phB_i2_8 : (base + phaseBInit2Off : Word) + 8 = base + phaseBStep0Off := by bv_addr
+  have phB_addi_4 : (base + phaseBStep0Off : Word) + 4 = base + phaseBBneOff := by bv_addr
+  have phB_bne_4 : (base + phaseBBneOff : Word) + 4 = base + phaseBStep1Off := by bv_addr
+  have phB_t_20 : (base + phaseBTailOff : Word) + 20 = base + clzOff := by bv_addr
+  have phB_sp24_32 : (sp + (24 : Word) + (32 : Word)) = sp + 56 := by bv_addr
+  have divK_phaseB_n4_nm1_x8 :
+      ((4 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat = (24 : Word) := by
+    decide
+  have hinit1_raw := divK_phaseB_init1_spec_within sp (base + phaseBOff) q0 q1 q2 q3 u5 u6 u7
+  simp only [phB_off_28] at hinit1_raw
+  have hinit1 := cpsTripleWithin_extend_code divK_phaseB_init1_code_sub_modCode_noNop_v5 hinit1_raw
+  have hinit1f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hinit1
+  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + phaseBInit2Off) b1 b2 v6 v7
+  simp only [phB_i2_8] at hinit2_raw
+  have hinit2 := cpsTripleWithin_extend_code divK_phaseB_init2_code_sub_modCode_noNop_v5 hinit2_raw
+  seqFrame hinit1f hinit2
+  have haddi_raw := addi_x0_spec_gen_within .x5 v5 4 (base + phaseBStep0Off) (by nofun)
+  simp only [phB_addi_4, signExtend12_4] at haddi_raw
+  have haddi := cpsTripleWithin_extend_code addi_x5_singleton_sub_modCode_noNop_v5 haddi_raw
+  seqFrame hinit1fhinit2 haddi
+  have hbne_raw := bne_spec_gen_within .x10 .x0 24 b3 (0 : Word) (base + phaseBBneOff)
+  rw [show (base + phaseBBneOff : Word) + signExtend13 24 = base + phaseBTailOff from by
+        rv64_addr, phB_bne_4] at hbne_raw
+  have hbne_clean := cpsBranchWithin_takenStripPure2 hbne_raw
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hb3nz)
+  have hbne := cpsTripleWithin_extend_code bne_x10_singleton_sub_modCode_noNop_v5 hbne_clean
+  seqFrame hinit1fhinit2haddi hbne
+  have htail_raw := divK_phaseB_tail_spec_within sp (4 : Word) b3 nMem (base + phaseBTailOff)
+  simp only [divK_phaseB_tail_pre_unfold, divK_phaseB_tail_post_unfold,
+             phB_t_20, divK_phaseB_n4_nm1_x8, signExtend12_32, phB_sp24_32] at htail_raw
+  have htail := cpsTripleWithin_extend_code divK_phaseB_tail_code_sub_modCode_noNop_v5 htail_raw
+  seqFrame hinit1fhinit2haddihbne htail
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_chunked hp)
+    (fun h hq => by xperm_chunked hq)
+    hinit1fhinit2haddihbnehtail
+
+/-- PhaseAB(n=4) + CLZ(b3) over `modCode_noNop_v5`: dispatch to n=4 and compute the
+    normalization shift of the top limb `b3`.  n=4 analog of
+    `evm_div_phaseAB_n3_clz_spec_within_v5_noNop`. -/
+theorem evm_mod_phaseAB_n4_clz_spec_within_v5_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24) base (base + phaseC2Off) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b3).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ (clzResult b3).1) ** (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word))) := by
+  have hA := evm_mod_phaseA_ntaken_spec_within_v5_noNop sp base b0 b1 b2 b3 v5 v10 hbnz
+  have hAf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+     ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+     ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hA
+  have hB := evm_mod_phaseB_n4_spec_within_v5_noNop sp base b1 b2 b3
+    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 nMem hb3nz
+  have hBf := cpsTripleWithin_frameR
+    (((sp + 32) ↦ₘ b0))
+    (by pcFree) hB
+  have hAB := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hAf hBf
+  have hCLZ := divK_clz_spec_within_v5_noNop_mod b3 b1 b2 base
+  have hCLZf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)))
+    (by pcFree) hCLZ
+  have hABCLZ := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hAB hCLZf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hABCLZ
+
+/-- PhaseAB(n=4) + CLZ(b3) + PhaseC2(ntaken) + NormB over `modCode_noNop_v5`:
+    normalize the 4-limb divisor by `clz b3`.  n=4 analog of
+    `evm_div_n3_to_normB_spec_within_v5_noNop`. -/
+theorem evm_mod_n4_to_normB_spec_within_v5_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21) base (base + normAOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (normBPost sp (4 : Word) (clzResult b3).1 b0 b1 b2 b3) := by
+  let shift := (clzResult b3).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  have hABCLZ := evm_mod_phaseAB_n4_clz_spec_within_v5_noNop sp base b0 b1 b2 b3
+    v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3nz
+  have hABCLZf := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
+    (by pcFree) hABCLZ
+  have hC2 := divK_phaseC2_ntaken_spec_within_v5_noNop_mod sp shift ((clzResult b3).2 >>> (63 : Nat))
+    shiftMem base hshift_nz
+  have hC2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ (clzResult b3).2) ** (.x10 ↦ᵣ b3) **
+     (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)))
+    (by pcFree) hC2
+  have hABC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABCLZf hC2f
+  have hNB := divK_normB_full_spec_within_v5_noNop_mod sp b0 b1 b2 b3
+    (clzResult b3).2 ((clzResult b3).2 >>> (63 : Nat))
+    shift antiShift base
+  simp only [normBFullPost_unfold] at hNB
+  have hNBf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNB
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABC2 hNBf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta normBPost; xperm_hyp hq)
+    hFull
+
+/-- n=4 preloop entry→loopSetup over `modCode_noNop_v5`.  base → base+loopBodyOff.
+    n=4 analog of `evm_div_n3_to_loopSetup_spec_within_v5_noNop`. -/
+theorem evm_mod_n4_to_loopSetup_spec_within_v5_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (modCode_noNop_v5 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (loopSetupPost sp (4 : Word) (clzResult b3).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := (clzResult b3).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  have hNB := evm_mod_n4_to_normB_spec_within_v5_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u5 u6 u7 nMem shiftMem hbnz hb3nz hshift_nz
+  have hNBf := cpsTripleWithin_frameR
+    ((.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+     ((sp + signExtend12 4024) ↦ₘ u4Old))
+    (by pcFree) hNB
+  have hNormA := divK_normA_full_spec_within_v5_noNop_mod sp a0 a1 a2 a3
+    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
+    u0Old u1Old u2Old u3Old u4Old base
+  rw [divKNormAFullPreNoNop_unfold] at hNormA
+  simp only [normAFullPost_unfold] at hNormA
+  have hNormAf := cpsTripleWithin_frameR
+    ((.x0 ↦ᵣ (0 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ ((b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)))) **
+     ((sp + 56) ↦ₘ ((b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)))) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNormA
+  have hNA := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by delta normBPost at hp; xperm_hyp hp) hNBf hNormAf
+  have hLS := divK_loopSetup_ntaken_spec_within_v5_noNop_mod sp (4 : Word)
+    (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
+    (by decide)
+  simp only [divKLoopSetupNtakenPreNoNop_unfold,
+      divKLoopSetupNtakenPostNoNop_unfold] at hLS
+  have hLSf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ ((b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)))) **
+     ((sp + 56) ↦ₘ ((b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)))) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+     ((sp + signExtend12 4040) ↦ₘ u2) **
+     ((sp + signExtend12 4032) ↦ₘ (a3 <<< (shift.toNat % 64) ||| a2 >>> (antiShift.toNat % 64))) **
+     ((sp + signExtend12 4024) ↦ₘ (a3 >>> (antiShift.toNat % 64))) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hLS
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hNA hLSf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta loopSetupPost; xperm_hyp hq)
+    hFull
+

--- a/EvmAsm/Evm64/DivMod/Spec/N4V5CallAddbackModRemainder.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V5CallAddbackModRemainder.lean
@@ -22,11 +22,16 @@
 import EvmAsm.Evm64.DivMod.Spec.CallAddbackPureNat
 import EvmAsm.Evm64.DivMod.LoopSemantic
 import EvmAsm.Evm64.EvmWordArith.DivN4SingleAddbackVal256
+import EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddbackVal256
+import EvmAsm.Evm64.EvmWordArith.DivN4SingleAddbackGen
+import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
 
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmWord
+
+set_option maxRecDepth 4000
 
 /-- Fully-abstract single-addback remainder identity over `Nat`: from the two
     conservation equations + the exact-quotient hypothesis, the corrected
@@ -138,5 +143,112 @@ theorem val256_addback_single_eq_amod_of_facts
     hq_pos hms hcons (add_signExtend12_4095_toNat q hq_pos)
     (by rw [htop0]; rfl) hqHat
     (val256_bound _ _ _ _) (Nat.pos_of_ne_zero hBnz) (val256_bound _ _ _ _)
+
+
+/-- Fully-abstract DOUBLE-addback remainder identity over `Nat` (carry = 0, second
+    addback carries).  `k` plays the role of `q.toNat`; the trial overshoots by 2. -/
+theorem amod_double_pure (Av Bv MSv ABv uTop k qseK2 abTop : Nat)
+    (hq_ge2 : 2 ≤ k)
+    (hms : Av + (uTop + 1) * 2 ^ 256 = MSv + k * Bv)
+    (hcons : Av + uTop * 2 ^ 256 = qseK2 * Bv + ABv + abTop * 2 ^ 256)
+    (hqse : qseK2 = k - 2) (habtop : abTop = 0)
+    (hqHat : k = (Av + uTop * 2 ^ 256) / Bv + 2)
+    (hAB : ABv < 2 ^ 256) (hBpos : 0 < Bv) (hBlt : Bv < 2 ^ 256) :
+    ABv = (Av + uTop * 2 ^ 256) % Bv := by
+  subst hqse habtop
+  simp only [Nat.zero_mul, Nat.add_zero] at hcons
+  have hqB : k * Bv = (k - 2) * Bv + 2 * Bv := by
+    have h1 : k - 2 + 2 = k := Nat.sub_add_cancel hq_ge2
+    calc k * Bv = (k - 2 + 2) * Bv := by rw [h1]
+      _ = (k - 2) * Bv + 2 * Bv := by rw [Nat.add_mul]
+  have h_mulsub :
+      (uTop + 1) * 2 ^ 256 + ((Av + uTop * 2 ^ 256) * 2 ^ 0 - uTop * 2 ^ 256) =
+        MSv + ((Av + uTop * 2 ^ 256) / Bv + 2) * (Bv * 2 ^ 0) := by
+    simp only [pow_zero, Nat.mul_one]; rw [← hqHat]; omega
+  have h_addback : ABv + 2 ^ 256 = MSv + 2 * (Bv * 2 ^ 0) := by
+    simp only [pow_zero, Nat.mul_one]; omega
+  have h_u4_le : uTop * 2 ^ 256 ≤ (Av + uTop * 2 ^ 256) * 2 ^ 0 := by
+    simp only [pow_zero, Nat.mul_one]; omega
+  have h_amod : (Av + uTop * 2 ^ 256) % Bv * 2 ^ 0 < 2 ^ 256 := by
+    simp only [pow_zero, Nat.mul_one]
+    exact lt_of_lt_of_le (Nat.mod_lt _ hBpos) (le_of_lt hBlt)
+  have hres := abPrime_val_eq_amod_pow_s_pure_nat ABv MSv (Av + uTop * 2 ^ 256) Bv 0
+    uTop (uTop + 1) h_mulsub h_addback h_u4_le hAB h_amod (by omega)
+  simpa only [pow_zero, Nat.mul_one] using hres
+
+/-- **Double-addback (carry = 0) MOD remainder = (a % b) (·2^0), from runtime facts.**
+    The doubly-corrected remainder `ab' := addbackN4 (addbackN4 (mulsub …) …) …`
+    equals the (unscaled) true remainder when the trial `qHat` overshoots by two. -/
+theorem val256_addback_double_eq_amod_of_facts
+    (q v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (huTop : uTop.toNat + 1 < 2 ^ 64)
+    (hc3 : (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = uTop + 1)
+    (hcarry_zero :
+      addbackN4_carry (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1 v0 v1 v2 v3 = 0)
+    (hcarry2_one :
+      addbackN4_carry
+        (addbackN4 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+          (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3).1
+        (addbackN4 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+          (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3).2.1
+        (addbackN4 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+          (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3).2.2.1
+        (addbackN4 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+          (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3).2.2.2.1
+        v0 v1 v2 v3 = 1)
+    (hq_ge2 : 2 ≤ q.toNat)
+    (hBnz : val256 v0 v1 v2 v3 ≠ 0)
+    (hqHat : q.toNat =
+      (val256 u0 u1 u2 u3 + uTop.toNat * 2 ^ 256) / val256 v0 v1 v2 v3 + 2) :
+    let ms := mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
+    let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
+    val256 ab'.1 ab'.2.1 ab'.2.2.1 ab'.2.2.2.1 =
+      (val256 u0 u1 u2 u3 + uTop.toNat * 2 ^ 256) % val256 v0 v1 v2 v3 := by
+  -- No `set`/`rw` folding of the doubly-nested `ab'` (that builds kernel-unreducible
+  -- casts → deep recursion).  Feed the raw conservation directly; the huge `ab'`
+  -- terms are inferred as OPAQUE args to the abstract helper (as in the single case).
+  have hms : val256 u0 u1 u2 u3 + (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat * 2 ^ 256 =
+      val256 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+        + q.toNat * val256 v0 v1 v2 v3 :=
+    mulsubN4_val256_eq q v0 v1 v2 v3 u0 u1 u2 u3
+  have hc3n : (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat = uTop.toNat + 1 := by
+    rw [hc3, BitVec.toNat_add]; simp only [show (1 : Word).toNat = 1 from rfl]; omega
+  rw [hc3n] at hms
+  have hcons0 := iterDoubleAddback_val256_conservation_gen q v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    huTop hc3 hcarry_zero hcarry2_one hq_ge2
+  have hqsub : (q + signExtend12 (4095 : BitVec 12) + signExtend12 (4095 : BitVec 12)).toNat
+      = q.toNat - 2 := add_signExtend12_4095_add_signExtend12_4095_toNat q hq_ge2
+  rw [hqsub] at hcons0
+  -- second-addback top limb = 0 (raw form; small `.toNat` motive only)
+  have hab_top : (addbackN4 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1 (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3).2.2.2.2 = uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 := by
+    have h := addbackN4_top_eq (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+      (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3
+    simp only [] at h; rw [h, hcarry_zero]; simp
+  have hab'_top0 :
+      (addbackN4 (addbackN4 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1 (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3).1 (addbackN4 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1 (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3).2.1 (addbackN4 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1 (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3).2.2.1 (addbackN4 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1 (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3).2.2.2.1 (addbackN4 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1 (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3).2.2.2.2 v0 v1 v2 v3).2.2.2.2 = 0 := by
+    have h := addbackN4_single_top_zero_of_c3_uTop_plus_one
+      (addbackN4 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1 (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3).1 (addbackN4 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1 (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3).2.1 (addbackN4 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1 (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3).2.2.1 (addbackN4 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1 (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3).2.2.2.1 v0 v1 v2 v3 uTop (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 hc3 hcarry2_one
+    rw [hab_top]; exact h
+  -- Discharge: hcons0/goal infer MSv, ABv (= val256 ab'.low4), qseK2 (= q_out), abTop.
+  refine amod_double_pure (val256 u0 u1 u2 u3) (val256 v0 v1 v2 v3) _ _ uTop.toNat q.toNat _ _
+    hq_ge2 hms hcons0 rfl ?_ hqHat (val256_bound _ _ _ _) (Nat.pos_of_ne_zero hBnz)
+    (val256_bound _ _ _ _)
+  rw [hab'_top0]; rfl
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4V5CallAddbackModRemainder.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V5CallAddbackModRemainder.lean
@@ -1,0 +1,142 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4V5CallAddbackModRemainder
+
+  n=4 MOD call+addback remainder arithmetic bridge (Step 1 of the n=4 MOD lane's
+  addback branch).  The pure-Nat kernel `post1_val_eq_amod_pow_s_pure_nat`
+  (single addback) in `Spec/CallAddbackPureNat.lean` proves `remainder_val = (a %
+  b) * 2^s`, but was UNUSED — nothing connected the addback EvmWord-level `val256`
+  conservation to its `h_mulsub`/`h_addback` hypotheses.  This file provides the
+  connection at the `val256` level, taking the runtime carry/c3/qHat facts as
+  hypotheses (`_of_facts`); the semantic derivation of those facts (from
+  `n4CallAddbackBeqSemanticHoldsV5`) is the follow-up.
+
+  Kernel note: the arithmetic is factored into a fully-abstract `Nat`-only helper
+  (`amod_single_pure`) so the kernel checks it with no huge `val256 (mulsubN4 …)`
+  terms; the concrete conservation equations (which DO carry those terms, proven
+  by the imported `iterSingleAddback_val256_conservation_gen` / `mulsubN4_val256_eq`)
+  are fed as opaque arguments at the end, avoiding kernel deep recursion.
+
+  Bead: n=4 MOD lane addback bridge.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.CallAddbackPureNat
+import EvmAsm.Evm64.DivMod.LoopSemantic
+import EvmAsm.Evm64.EvmWordArith.DivN4SingleAddbackVal256
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmWord
+
+/-- Fully-abstract single-addback remainder identity over `Nat`: from the two
+    conservation equations + the exact-quotient hypothesis, the corrected
+    remainder equals `a % b`.  No huge `val256` terms here, so the kernel checks
+    it without deep recursion.  `k` plays the role of `q.toNat`. -/
+theorem amod_single_pure (Av Bv MSv ABv uTop k qseK abTop : Nat)
+    (hq_pos : 1 ≤ k)
+    (hms : Av + (uTop + 1) * 2 ^ 256 = MSv + k * Bv)
+    (hcons : Av + uTop * 2 ^ 256 = qseK * Bv + ABv + abTop * 2 ^ 256)
+    (hqse : qseK = k - 1) (habtop : abTop = 0)
+    (hqHat : k = (Av + uTop * 2 ^ 256) / Bv + 1)
+    (hAB : ABv < 2 ^ 256) (hBpos : 0 < Bv) (hBlt : Bv < 2 ^ 256) :
+    ABv = (Av + uTop * 2 ^ 256) % Bv := by
+  -- Fold the raw conservation into the clean `(k-1)*Bv + ABv` shape (Nat vars only:
+  -- tiny motive, no huge-term rewrite proof).
+  subst hqse habtop
+  simp only [Nat.zero_mul, Nat.add_zero] at hcons
+  have hqB : k * Bv = (k - 1) * Bv + Bv := by
+    have h1 : k - 1 + 1 = k := Nat.sub_add_cancel hq_pos
+    calc k * Bv = (k - 1 + 1) * Bv := by rw [h1]
+      _ = (k - 1) * Bv + Bv := by rw [Nat.add_mul, Nat.one_mul]
+  have h_mulsub :
+      (uTop + 1) * 2 ^ 256 + ((Av + uTop * 2 ^ 256) * 2 ^ 0 - uTop * 2 ^ 256) =
+        MSv + ((Av + uTop * 2 ^ 256) / Bv + 1) * (Bv * 2 ^ 0) := by
+    simp only [pow_zero, Nat.mul_one]; rw [← hqHat]; omega
+  have h_addback : ABv + 2 ^ 256 = MSv + Bv * 2 ^ 0 := by
+    simp only [pow_zero, Nat.mul_one]; omega
+  have h_u4_le : uTop * 2 ^ 256 ≤ (Av + uTop * 2 ^ 256) * 2 ^ 0 := by
+    simp only [pow_zero, Nat.mul_one]; omega
+  have h_amod : (Av + uTop * 2 ^ 256) % Bv * 2 ^ 0 < 2 ^ 256 := by
+    simp only [pow_zero, Nat.mul_one]
+    exact lt_of_lt_of_le (Nat.mod_lt _ hBpos) (le_of_lt hBlt)
+  have hres := post1_val_eq_amod_pow_s_pure_nat ABv MSv (Av + uTop * 2 ^ 256) Bv 0
+    uTop (uTop + 1) h_mulsub h_addback h_u4_le hAB h_amod (by omega)
+  simpa only [pow_zero, Nat.mul_one] using hres
+
+/-- **Single-addback (carry ≠ 0) MOD remainder = (a % b) (·2^0), from runtime facts.**
+
+    The single-addback corrected remainder `ab := addbackN4 (mulsub …) (u4 - c3) v`
+    satisfies `val256(ab.low4) = (val256 a' + uTop·2^256) % val256 b'` where the
+    trial `qHat` overshoots the normalized quotient by exactly one (`hqHat`), the
+    mulsub top limb is `u4 + 1` (`hc3`), the addback carry is one (`hcarry_one`),
+    and standard bounds hold.  (The `·2^s` funnel to the true shift is applied by
+    the getLimbN caller, exactly as in the call-skip path.) -/
+theorem val256_addback_single_eq_amod_of_facts
+    (q v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (huTop : uTop.toNat + 1 < 2 ^ 64)
+    (hc3 : (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = uTop + 1)
+    (hcarry_one :
+      addbackN4_carry
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+        v0 v1 v2 v3 = 1)
+    (hq_pos : 1 ≤ q.toNat)
+    (hBnz : val256 v0 v1 v2 v3 ≠ 0)
+    (hqHat : q.toNat =
+      (val256 u0 u1 u2 u3 + uTop.toNat * 2 ^ 256) / val256 v0 v1 v2 v3 + 1) :
+    let ms := mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+      (uTop - ms.2.2.2.2) v0 v1 v2 v3
+    val256 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 =
+      (val256 u0 u1 u2 u3 + uTop.toNat * 2 ^ 256) % val256 v0 v1 v2 v3 := by
+  -- Everything is kept in the RAW `mulsubN4`/`addbackN4` form (matching the imported
+  -- lemmas EXACTLY) so the final `exact` needs only syntactic matching plus cheap
+  -- zeta on the goal's `let`s — no delta-unfolding of the huge defs (which is what
+  -- triggers kernel deep recursion).  We deliberately do NOT `intro ms ab`.
+  have hms : val256 u0 u1 u2 u3
+        + (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat * 2 ^ 256 =
+      val256 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+        + q.toNat * val256 v0 v1 v2 v3 :=
+    mulsubN4_val256_eq q v0 v1 v2 v3 u0 u1 u2 u3
+  have hcons := iterSingleAddback_val256_conservation_gen q v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    huTop hc3 hcarry_one hq_pos
+  have htop0 := addbackN4_single_top_zero_of_c3_uTop_plus_one
+    (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+    (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+    v0 v1 v2 v3 uTop (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 hc3 hcarry_one
+  have hc3n : (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat = uTop.toNat + 1 := by
+    rw [hc3, BitVec.toNat_add]; simp only [show (1 : Word).toNat = 1 from rfl]; omega
+  -- Only `hms` needs a (single, cheap) rewrite; `hcons` is fed RAW so no huge-term
+  -- rewrite motive is ever built.
+  rw [hc3n] at hms
+  -- Discharge via the abstract helper, feeding the huge `val256` terms as opaque args
+  -- in EXACTLY the raw form `hcons` carries (so no defeq blow-up on the ABv arg).
+  exact amod_single_pure (val256 u0 u1 u2 u3) (val256 v0 v1 v2 v3)
+    (val256 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1)
+    (val256
+      (addbackN4 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+          (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3).1
+      (addbackN4 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+          (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3).2.1
+      (addbackN4 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+          (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3).2.2.1
+      (addbackN4 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+          (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3).2.2.2.1)
+    uTop.toNat q.toNat
+    (q + signExtend12 (4095 : BitVec 12)).toNat
+    (addbackN4 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+        (uTop - (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) v0 v1 v2 v3).2.2.2.2.toNat
+    hq_pos hms hcons (add_signExtend12_4095_toNat q hq_pos)
+    (by rw [htop0]; rfl) hqHat
+    (val256_bound _ _ _ _) (Nat.pos_of_ne_zero hBnz) (val256_bound _ _ _ _)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4V5CallAddbackModWordLane.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V5CallAddbackModWordLane.lean
@@ -592,4 +592,351 @@ theorem n4_call_addback_beq_mod_getLimbN_v5_single (a b : EvmWord)
   simp only [shift, antiShift, hmodS, hanti_toNat_mod, hab0, hab1, hab2, hab3]
   exact h_limbs
 
+/-- **n=4 MOD call+addback-beq getLimbN, double-addback branch (carry = 0).**
+    Mirror of `n4_call_addback_beq_mod_getLimbN_v5_single` for the double-addback
+    branch: the four limbs of `EvmWord.mod a b` are the funnel-shift-down of the
+    twice-corrected remainder `ab'`.  Same composition — overestimate bridge with
+    `q_out = a/b` plus `ab' = mulsubN4 q_out …` by `val256` injectivity (both
+    `val256` equal `aD % aV`, from the committed double crux). -/
+theorem n4_call_addback_beq_mod_getLimbN_v5_double (a b : EvmWord)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hsem : n4CallAddbackBeqSemanticHoldsV5 a b)
+    (hcall : isCallTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3))
+    (hborrow_ult : BitVec.ult (n4CallAddbackBeqU4 a b)
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b)
+          (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+          (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.2)
+    (hcarry_zero :
+      addbackN4_carry
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+          (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).1
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+          (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.1
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+          (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.1
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+          (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.1
+        (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+        (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b) = 0)
+    (hcarry2_one :
+      addbackN4_carry
+        (addbackN4
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.1
+          (n4CallAddbackBeqU4 a b -
+            (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+              (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+              (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+              (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.2)
+          (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+          (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)).1
+        (addbackN4
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.1
+          (n4CallAddbackBeqU4 a b -
+            (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+              (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+              (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+              (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.2)
+          (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+          (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)).2.1
+        (addbackN4
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.1
+          (n4CallAddbackBeqU4 a b -
+            (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+              (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+              (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+              (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.2)
+          (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+          (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)).2.2.1
+        (addbackN4
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.1
+          (n4CallAddbackBeqU4 a b -
+            (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+              (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+              (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+              (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.2)
+          (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+          (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)).2.2.2.1
+        (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+        (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b) = 1)
+    (hq_ge2 : 2 ≤ (n4CallAddbackBeqQHatV5 a b).toNat)
+    (hBnz : aV b ≠ 0)
+    (huTop : (n4CallAddbackBeqU4 a b).toNat + 1 < 2 ^ 64)
+    (hqHat : (n4CallAddbackBeqQHatV5 a b).toNat = aD a b / aV b + 2) :
+    let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
+    let antiShift :=
+      (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
+    let ms := mulsubN4 (n4CallAddbackBeqQHatV5 a b)
+      (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+      (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+      (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+      (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+      (n4CallAddbackBeqU4 a b - ms.2.2.2.2)
+      (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+      (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+    let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2
+      (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+      (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+    (EvmWord.mod a b).getLimbN 0 = ((ab'.1 >>> shift) ||| (ab'.2.1 <<< antiShift)) ∧
+    (EvmWord.mod a b).getLimbN 1 = ((ab'.2.1 >>> shift) ||| (ab'.2.2.1 <<< antiShift)) ∧
+    (EvmWord.mod a b).getLimbN 2 = ((ab'.2.2.1 >>> shift) ||| (ab'.2.2.2.1 <<< antiShift)) ∧
+    (EvmWord.mod a b).getLimbN 3 = (ab'.2.2.2.1 >>> shift) := by
+  intro shift antiShift ms ab ab'
+  have hclz_le := clzResult_fst_toNat_le (b.getLimbN 3)
+  have hshift_pos : 0 < (clzResult (b.getLimbN 3)).1.toNat := by
+    by_contra h; apply hshift_nz; apply BitVec.eq_of_toNat_eq
+    rw [show (0 : Word).toNat = 0 from rfl]; omega
+  have hshift_lt_64 : (clzResult (b.getLimbN 3)).1.toNat < 64 := by omega
+  have hmod_eq : (clzResult (b.getLimbN 3)).1.toNat % 64 =
+      (clzResult (b.getLimbN 3)).1.toNat := by omega
+  have hanti_toNat_mod :
+      (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64 =
+      64 - (clzResult (b.getLimbN 3)).1.toNat := by
+    have h0se12 : signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1 =
+        -((clzResult (b.getLimbN 3)).1) := by rw [signExtend12_0]; simp
+    rw [h0se12, BitVec.toNat_neg]
+    have : ((clzResult (b.getLimbN 3)).1).toNat ≤ 2 ^ 64 := by
+      have := ((clzResult (b.getLimbN 3)).1).isLt; omega
+    omega
+  have hb3_bound : (b.getLimbN 3).toNat <
+      2 ^ (64 - (clzResult (b.getLimbN 3)).1.toNat) :=
+    clzResult_fst_top_bound (b.getLimbN 3)
+  have hval_ab' := n4_addback_un_val256_eq_amod_double a b hb3nz hshift_nz hcall
+    hborrow_ult hcarry_zero hcarry2_one hq_ge2 hBnz huTop hqHat
+  simp only at hval_ab'
+  have hqout := n4CallAddbackBeqQOutV5_toNat_eq_div a b hbnz hsem
+  obtain ⟨hmul_le, hge⟩ := n4CallAddbackBeqQOutV5_bridge_bounds a b hbnz hsem
+  have hscaleU := u_val256_eq_scaled_with_overflow (a.getLimbN 0) (a.getLimbN 1)
+    (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 3) hshift_nz
+  have hscaleB := b3_prime_val256_eq_scaled (b.getLimbN 0) (b.getLimbN 1)
+    (b.getLimbN 2) (b.getLimbN 3) hshift_nz
+  simp only [hmod_eq, hanti_toNat_mod] at hscaleU hscaleB
+  have ha_toNat : val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      = a.toNat := by
+    simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+               ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
+    exact EvmWord.val256_eq_toNat a
+  have hb_toNat : val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      = b.toNat := by
+    simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+               ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
+    exact EvmWord.val256_eq_toNat b
+  rw [ha_toNat] at hscaleU
+  rw [hb_toNat] at hscaleB
+  have hU0 := n4CallAddbackBeqU0_eq_direct (a := a) hshift_nz
+  have hU1 := n4CallAddbackBeqU1_eq_direct (a := a) hshift_nz
+  have hU2 := n4CallAddbackBeqU2_eq_direct (a := a) hshift_nz
+  have hU3 := n4CallAddbackBeqU3_eq_direct (a := a) hshift_nz
+  have hU4 := n4CallAddbackBeqU4_eq_direct (a := a) hshift_nz
+  have hB0 := n4CallAddbackBeqB0Prime_eq_direct hshift_nz
+  have hB1 := n4CallAddbackBeqB1Prime_eq_direct hshift_nz
+  have hB2 := n4CallAddbackBeqB2Prime_eq_direct hshift_nz
+  have hB3 := n4CallAddbackBeqB3Prime_eq_direct hshift_nz
+  set s := (clzResult (b.getLimbN 3)).1.toNat with hs_def
+  have hq_raw : (n4CallAddbackBeqQOutV5 a b).toNat =
+      (val256 ((a.getLimbN 0) <<< s)
+          (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+          (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+          (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))
+        + ((a.getLimbN 3) >>> (64 - s)).toNat * 2 ^ 256) /
+      val256 ((b.getLimbN 0) <<< s)
+          (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+          (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+          (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s))) := by
+    rw [hscaleU, hscaleB, hqout, Nat.mul_div_mul_right _ _ (Nat.two_pow_pos s)]
+  have hBnz_raw : val256 ((b.getLimbN 0) <<< s)
+      (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+      (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+      (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s))) ≠ 0 := by
+    rw [hscaleB]
+    have : 0 < b.toNat := by
+      rcases Nat.eq_zero_or_pos b.toNat with h | h
+      · exact absurd (BitVec.eq_of_toNat_eq (by rw [h]; rfl)) hbnz
+      · exact h
+    positivity
+  have hval_msN := mulsub_exact_val256_low4 (n4CallAddbackBeqQOutV5 a b)
+    ((b.getLimbN 0) <<< s)
+    (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+    (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+    (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s)))
+    ((a.getLimbN 0) <<< s)
+    (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+    (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+    (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))
+    ((a.getLimbN 3) >>> (64 - s))
+    hBnz_raw hq_raw
+  have haD : aD a b =
+      val256 ((a.getLimbN 0) <<< s)
+          (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+          (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+          (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))
+        + ((a.getLimbN 3) >>> (64 - s)).toNat * 2 ^ 256 := by
+    simp only [aD, hU0, hU1, hU2, hU3, hU4]
+  have haV : aV b =
+      val256 ((b.getLimbN 0) <<< s)
+          (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+          (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+          (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s))) := by
+    simp only [aV, hB0, hB1, hB2, hB3]
+  rw [haD, haV] at hval_ab'
+  have hval_eq : val256 ab'.1 ab'.2.1 ab'.2.2.1 ab'.2.2.2.1 =
+      val256
+        (mulsubN4 (n4CallAddbackBeqQOutV5 a b)
+          ((b.getLimbN 0) <<< s)
+          (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+          (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+          (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s)))
+          ((a.getLimbN 0) <<< s)
+          (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+          (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+          (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))).1
+        (mulsubN4 (n4CallAddbackBeqQOutV5 a b)
+          ((b.getLimbN 0) <<< s)
+          (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+          (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+          (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s)))
+          ((a.getLimbN 0) <<< s)
+          (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+          (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+          (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))).2.1
+        (mulsubN4 (n4CallAddbackBeqQOutV5 a b)
+          ((b.getLimbN 0) <<< s)
+          (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+          (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+          (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s)))
+          ((a.getLimbN 0) <<< s)
+          (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+          (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+          (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))).2.2.1
+        (mulsubN4 (n4CallAddbackBeqQOutV5 a b)
+          ((b.getLimbN 0) <<< s)
+          (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+          (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+          (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s)))
+          ((a.getLimbN 0) <<< s)
+          (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+          (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+          (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))).2.2.2.1 := by
+    rw [hval_ab', hval_msN]
+  obtain ⟨hab0, hab1, hab2, hab3⟩ := val256_inj hval_eq
+  have hc3 : (mulsubN4 (n4CallAddbackBeqQOutV5 a b)
+      ((b.getLimbN 0) <<< s)
+      (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+      (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+      (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s)))
+      ((a.getLimbN 0) <<< s)
+      (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+      (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+      (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))).2.2.2.2.toNat ≤
+      ((a.getLimbN 3) >>> (64 - s)).toNat := by
+    have hcons := mulsubN4_val256_eq (n4CallAddbackBeqQOutV5 a b)
+      ((b.getLimbN 0) <<< s)
+      (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+      (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+      (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s)))
+      ((a.getLimbN 0) <<< s)
+      (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+      (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+      (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))
+    simp only at hcons
+    have hqmod : (n4CallAddbackBeqQOutV5 a b).toNat *
+        val256 ((b.getLimbN 0) <<< s)
+          (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+          (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+          (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s))) +
+        (val256 ((a.getLimbN 0) <<< s)
+          (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+          (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+          (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))
+          + ((a.getLimbN 3) >>> (64 - s)).toNat * 2 ^ 256) %
+        val256 ((b.getLimbN 0) <<< s)
+          (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+          (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+          (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s))) =
+        val256 ((a.getLimbN 0) <<< s)
+          (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+          (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+          (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))
+          + ((a.getLimbN 3) >>> (64 - s)).toNat * 2 ^ 256 := by
+      rw [hq_raw, Nat.mul_comm]; exact Nat.div_add_mod _ _
+    omega
+  have h_limbs := denorm_limbN_eq_mod_of_overestimate_getLimbN (a := a) (b := b)
+    (qHat := n4CallAddbackBeqQOutV5 a b) (s := s)
+    hshift_pos hshift_lt_64 hb3_bound hmul_le hge hb3nz hc3
+  have hmodS : (clzResult (b.getLimbN 3)).1.toNat % 64 = s := by omega
+  simp only [shift, antiShift, hmodS, hanti_toNat_mod, hab0, hab1, hab2, hab3]
+  exact h_limbs
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4V5CallAddbackModWordLane.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V5CallAddbackModWordLane.lean
@@ -1,0 +1,52 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4V5CallAddbackModWordLane
+
+  n=4 MOD call+addback-beq remainder getLimbN facts (route ii): the four limbs of
+  `EvmWord.mod a b` equal the funnel-shift-down of the addback-corrected remainder
+  `un*Out`.  Uses the corrected quotient `q_out` with the complete overestimate
+  bridge `denorm_limbN_eq_mod_of_overestimate_getLimbN`, plus the per-limb identity
+  `un*Out = mulsubN4 q_out b' u` (from `val256` injectivity + the committed val256
+  cruxes + the mulsub conservation `mulsubN4_val256_eq`).
+-/
+import EvmAsm.Evm64.EvmWordArith.MultiLimb
+import EvmAsm.Evm64.DivMod.LoopSemantic
+
+namespace EvmAsm.Evm64
+open EvmAsm.Rv64 EvmWord
+
+/-- `val256` is injective on `Word⁴` (base-2⁶⁴ representation, each limb < 2⁶⁴). -/
+theorem val256_inj {x0 x1 x2 x3 y0 y1 y2 y3 : Word}
+    (h : val256 x0 x1 x2 x3 = val256 y0 y1 y2 y3) :
+    x0 = y0 ∧ x1 = y1 ∧ x2 = y2 ∧ x3 = y3 := by
+  have b0 := x0.isLt; have b1 := x1.isLt; have b2 := x2.isLt; have b3 := x3.isLt
+  have c0 := y0.isLt; have c1 := y1.isLt; have c2 := y2.isLt; have c3 := y3.isLt
+  simp only [val256] at h
+  refine ⟨BitVec.eq_of_toNat_eq ?_, BitVec.eq_of_toNat_eq ?_,
+          BitVec.eq_of_toNat_eq ?_, BitVec.eq_of_toNat_eq ?_⟩ <;> omega
+
+/-- Exact-quotient mulsub remainder: if `q = D / V` (D = val256 u + u4*2^256 the
+    normalized dividend, V = val256 v the normalized divisor), `V ≠ 0`, and the
+    mulsub top-borrow `c3 ≤ u4`, then `val256 (mulsub q v u).low4 = D % V`.
+    Via `mulsubN4_val256_eq` + Nat div/mod + `val256_bound` (omega). -/
+theorem mulsub_exact_val256_low4 (q v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
+    (hBnz : val256 v0 v1 v2 v3 ≠ 0)
+    (hq : q.toNat = (val256 u0 u1 u2 u3 + u4.toNat * 2 ^ 256) / val256 v0 v1 v2 v3) :
+    val256 (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1 =
+      (val256 u0 u1 u2 u3 + u4.toNat * 2 ^ 256) % val256 v0 v1 v2 v3 := by
+  have hcons := mulsubN4_val256_eq q v0 v1 v2 v3 u0 u1 u2 u3
+  simp only at hcons
+  set ms := mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3 with hms
+  have hlow_lt := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+  have hV_lt := val256_bound v0 v1 v2 v3
+  have hmod_lt : (val256 u0 u1 u2 u3 + u4.toNat * 2 ^ 256) % val256 v0 v1 v2 v3
+      < val256 v0 v1 v2 v3 := Nat.mod_lt _ (Nat.pos_of_ne_zero hBnz)
+  have hqV : q.toNat * val256 v0 v1 v2 v3 +
+      (val256 u0 u1 u2 u3 + u4.toNat * 2 ^ 256) % val256 v0 v1 v2 v3
+      = val256 u0 u1 u2 u3 + u4.toNat * 2 ^ 256 := by
+    rw [hq, Nat.mul_comm]; exact Nat.div_add_mod _ _
+  omega
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4V5CallAddbackModWordLane.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V5CallAddbackModWordLane.lean
@@ -49,4 +49,11 @@ theorem mulsub_exact_val256_low4 (q v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
     rw [hq, Nat.mul_comm]; exact Nat.div_add_mod _ _
   omega
 
+/-- Scaled modulo `(A·2ˢ) % (B·2ˢ) = (A % B)·2ˢ` — the normalization link from the
+    normalized remainder `D % V` to the scaled true remainder, used by the n=4
+    addback getLimbN composition. -/
+theorem scaled_nat_amod (A B s : Nat) :
+    (A * 2 ^ s) % (B * 2 ^ s) = (A % B) * 2 ^ s := by
+  rw [Nat.mul_comm A, Nat.mul_comm B, Nat.mul_comm (A % B), Nat.mul_mod_mul_left]
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4V5CallAddbackModWordLane.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V5CallAddbackModWordLane.lean
@@ -10,6 +10,9 @@
 -/
 import EvmAsm.Evm64.EvmWordArith.MultiLimb
 import EvmAsm.Evm64.DivMod.LoopSemantic
+import EvmAsm.Evm64.DivMod.Spec.N4V5CallAddbackModRemainder
+import EvmAsm.Evm64.DivMod.Spec.N4C3EqUTopPlusOne
+import EvmAsm.Evm64.DivMod.Spec.CallAddbackV5
 
 namespace EvmAsm.Evm64
 open EvmAsm.Rv64 EvmWord
@@ -55,5 +58,226 @@ theorem mulsub_exact_val256_low4 (q v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
 theorem scaled_nat_amod (A B s : Nat) :
     (A * 2 ^ s) % (B * 2 ^ s) = (A % B) * 2 ^ s := by
   rw [Nat.mul_comm A, Nat.mul_comm B, Nat.mul_comm (A % B), Nat.mul_mod_mul_left]
+
+/-- Accessor-form abbreviations for the n=4 addback normalized dividend/divisor. -/
+private noncomputable abbrev aD (a b : EvmWord) : Nat :=
+  val256 (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+    (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)
+    + (n4CallAddbackBeqU4 a b).toNat * 2 ^ 256
+
+private noncomputable abbrev aV (b : EvmWord) : Nat :=
+  val256 (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+    (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+
+/-- **PROBE (single/carry≠0 branch):** `val256(ab) = D % V` in accessor form, from the
+    branch conditions — the linchpin discharge feeding the committed single crux.
+    Building this surfaces the exact accessor↔crux gap for the parent to finish. -/
+theorem n4_addback_un_val256_eq_amod_single (a b : EvmWord)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3))
+    (hborrow_ult : BitVec.ult (n4CallAddbackBeqU4 a b)
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b)
+          (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+          (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.2)
+    (hcarry_one :
+      addbackN4_carry
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+          (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).1
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+          (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.1
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+          (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.1
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+          (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.1
+        (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+        (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b) = 1)
+    (hq_pos : 1 ≤ (n4CallAddbackBeqQHatV5 a b).toNat)
+    (hBnz : aV b ≠ 0)
+    (huTop : (n4CallAddbackBeqU4 a b).toNat + 1 < 2 ^ 64)
+    (hqHat : (n4CallAddbackBeqQHatV5 a b).toNat = aD a b / aV b + 1) :
+    let ms := mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+      (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+      (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+      (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+      (n4CallAddbackBeqU4 a b - ms.2.2.2.2)
+      (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+      (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+    val256 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 = aD a b % aV b := by
+  have hc3 := n4CallAddbackBeq_c3_eq_uTop_plus_one_of_borrow hb3nz hshift_nz hcall hborrow_ult
+  exact val256_addback_single_eq_amod_of_facts
+    (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+    (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+    (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+    (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b) (n4CallAddbackBeqU4 a b)
+    huTop hc3 hcarry_one hq_pos hBnz hqHat
+
+/-- **PROBE (double/carry=0∧carry2≠0 branch):** `val256(ab') = D % V` in accessor
+    form, from the branch conditions — the double-addback linchpin discharge feeding
+    the committed double crux. -/
+theorem n4_addback_un_val256_eq_amod_double (a b : EvmWord)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3))
+    (hborrow_ult : BitVec.ult (n4CallAddbackBeqU4 a b)
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b)
+          (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+          (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.2)
+    (hcarry_zero :
+      addbackN4_carry
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+          (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).1
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+          (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.1
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+          (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.1
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+          (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.1
+        (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+        (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b) = 0)
+    (hcarry2_one :
+      addbackN4_carry
+        (addbackN4
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.1
+          (n4CallAddbackBeqU4 a b -
+            (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+              (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+              (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+              (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.2)
+          (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+          (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)).1
+        (addbackN4
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.1
+          (n4CallAddbackBeqU4 a b -
+            (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+              (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+              (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+              (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.2)
+          (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+          (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)).2.1
+        (addbackN4
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.1
+          (n4CallAddbackBeqU4 a b -
+            (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+              (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+              (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+              (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.2)
+          (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+          (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)).2.2.1
+        (addbackN4
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.1
+          (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+            (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+            (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.1
+          (n4CallAddbackBeqU4 a b -
+            (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+              (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+              (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+              (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.2)
+          (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+          (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)).2.2.2.1
+        (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+        (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b) = 1)
+    (hq_ge2 : 2 ≤ (n4CallAddbackBeqQHatV5 a b).toNat)
+    (hBnz : aV b ≠ 0)
+    (huTop : (n4CallAddbackBeqU4 a b).toNat + 1 < 2 ^ 64)
+    (hqHat : (n4CallAddbackBeqQHatV5 a b).toNat = aD a b / aV b + 2) :
+    let ms := mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+      (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+      (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+      (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+      (n4CallAddbackBeqU4 a b - ms.2.2.2.2)
+      (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+      (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+    let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2
+      (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+      (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+    val256 ab'.1 ab'.2.1 ab'.2.2.1 ab'.2.2.2.1 = aD a b % aV b := by
+  have hc3 := n4CallAddbackBeq_c3_eq_uTop_plus_one_of_borrow hb3nz hshift_nz hcall hborrow_ult
+  exact val256_addback_double_eq_amod_of_facts
+    (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+    (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+    (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+    (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b) (n4CallAddbackBeqU4 a b)
+    huTop hc3 hcarry_zero hcarry2_one hq_ge2 hBnz hqHat
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4V5CallAddbackModWordLane.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V5CallAddbackModWordLane.lean
@@ -13,6 +13,9 @@ import EvmAsm.Evm64.DivMod.LoopSemantic
 import EvmAsm.Evm64.DivMod.Spec.N4V5CallAddbackModRemainder
 import EvmAsm.Evm64.DivMod.Spec.N4C3EqUTopPlusOne
 import EvmAsm.Evm64.DivMod.Spec.CallAddbackV5
+import EvmAsm.Evm64.DivMod.Spec.CallSkipOverestimateBridge
+import EvmAsm.Evm64.EvmWordArith.KnuthTheoremB
+import EvmAsm.Evm64.EvmWordArith.CLZLemmas
 
 namespace EvmAsm.Evm64
 open EvmAsm.Rv64 EvmWord
@@ -327,5 +330,266 @@ theorem n4CallAddbackBeqQOutV5_bridge_bounds (a b : EvmWord)
     exact EvmWord.val256_eq_toNat b
   rw [ha_val, hb_val, hq]
   exact ⟨Nat.div_mul_le_self a.toNat b.toNat, le_refl _⟩
+
+/-- **n=4 MOD call+addback-beq getLimbN, single-addback branch (carry ≠ 0).**
+    Under the single-addback branch conditions, the four limbs of `EvmWord.mod a b`
+    are the funnel-shift-down of the once-corrected remainder `ab`.  Composes the
+    complete overestimate bridge (`denorm_limbN_eq_mod_of_overestimate_getLimbN`,
+    instantiated with the corrected quotient `q_out = a/b`) with the per-limb
+    reconciliation `ab = mulsubN4 q_out …` (via `val256` injectivity: both sides'
+    `val256` equal the normalized remainder `aD % aV`, from the committed single
+    crux and the exact-quotient `mulsub_exact_val256_low4`).  The bridge's
+    top-borrow bound is discharged internally (exact quotient ⇒ `c3 = u4`). -/
+theorem n4_call_addback_beq_mod_getLimbN_v5_single (a b : EvmWord)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hsem : n4CallAddbackBeqSemanticHoldsV5 a b)
+    (hcall : isCallTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3))
+    (hborrow_ult : BitVec.ult (n4CallAddbackBeqU4 a b)
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b)
+          (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+          (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.2)
+    (hcarry_one :
+      addbackN4_carry
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+          (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).1
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+          (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.1
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+          (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.1
+        (mulsubN4 (n4CallAddbackBeqQHatV5 a b) (n4CallAddbackBeqB0Prime b)
+          (n4CallAddbackBeqB1Prime b) (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)).2.2.2.1
+        (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+        (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b) = 1)
+    (hq_pos : 1 ≤ (n4CallAddbackBeqQHatV5 a b).toNat)
+    (hBnz : aV b ≠ 0)
+    (huTop : (n4CallAddbackBeqU4 a b).toNat + 1 < 2 ^ 64)
+    (hqHat : (n4CallAddbackBeqQHatV5 a b).toNat = aD a b / aV b + 1) :
+    let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
+    let antiShift :=
+      (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
+    let ms := mulsubN4 (n4CallAddbackBeqQHatV5 a b)
+      (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+      (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+      (n4CallAddbackBeqU0 a b) (n4CallAddbackBeqU1 a b)
+      (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b)
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+      (n4CallAddbackBeqU4 a b - ms.2.2.2.2)
+      (n4CallAddbackBeqB0Prime b) (n4CallAddbackBeqB1Prime b)
+      (n4CallAddbackBeqB2Prime b) (n4CallAddbackBeqB3Prime b)
+    (EvmWord.mod a b).getLimbN 0 = ((ab.1 >>> shift) ||| (ab.2.1 <<< antiShift)) ∧
+    (EvmWord.mod a b).getLimbN 1 = ((ab.2.1 >>> shift) ||| (ab.2.2.1 <<< antiShift)) ∧
+    (EvmWord.mod a b).getLimbN 2 = ((ab.2.2.1 >>> shift) ||| (ab.2.2.2.1 <<< antiShift)) ∧
+    (EvmWord.mod a b).getLimbN 3 = (ab.2.2.2.1 >>> shift) := by
+  intro shift antiShift ms ab
+  -- (0) shift bounds (mirror the call-skip template).
+  have hclz_le := clzResult_fst_toNat_le (b.getLimbN 3)
+  have hshift_pos : 0 < (clzResult (b.getLimbN 3)).1.toNat := by
+    by_contra h; apply hshift_nz; apply BitVec.eq_of_toNat_eq
+    rw [show (0 : Word).toNat = 0 from rfl]; omega
+  have hshift_lt_64 : (clzResult (b.getLimbN 3)).1.toNat < 64 := by omega
+  have hmod_eq : (clzResult (b.getLimbN 3)).1.toNat % 64 =
+      (clzResult (b.getLimbN 3)).1.toNat := by omega
+  have hanti_toNat_mod :
+      (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64 =
+      64 - (clzResult (b.getLimbN 3)).1.toNat := by
+    have h0se12 : signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1 =
+        -((clzResult (b.getLimbN 3)).1) := by rw [signExtend12_0]; simp
+    rw [h0se12, BitVec.toNat_neg]
+    have : ((clzResult (b.getLimbN 3)).1).toNat ≤ 2 ^ 64 := by
+      have := ((clzResult (b.getLimbN 3)).1).isLt; omega
+    omega
+  have hb3_bound : (b.getLimbN 3).toNat <
+      2 ^ (64 - (clzResult (b.getLimbN 3)).1.toNat) :=
+    clzResult_fst_top_bound (b.getLimbN 3)
+  -- (1) val256(ab) = aD % aV  (committed single crux).
+  have hval_ab := n4_addback_un_val256_eq_amod_single a b hb3nz hshift_nz hcall
+    hborrow_ult hcarry_one hq_pos hBnz huTop hqHat
+  simp only at hval_ab
+  -- (2) q_out = a/b and the overestimate bridge bounds.
+  have hqout := n4CallAddbackBeqQOutV5_toNat_eq_div a b hbnz hsem
+  obtain ⟨hmul_le, hge⟩ := n4CallAddbackBeqQOutV5_bridge_bounds a b hbnz hsem
+  -- (3) Align the accessor normalized dividend/divisor to the raw `<<< s` form
+  -- (s := clz.toNat), and to the scaled values `a.toNat*2^s`, `b.toNat*2^s`.
+  have hscaleU := u_val256_eq_scaled_with_overflow (a.getLimbN 0) (a.getLimbN 1)
+    (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 3) hshift_nz
+  have hscaleB := b3_prime_val256_eq_scaled (b.getLimbN 0) (b.getLimbN 1)
+    (b.getLimbN 2) (b.getLimbN 3) hshift_nz
+  simp only [hmod_eq, hanti_toNat_mod] at hscaleU hscaleB
+  have ha_toNat : val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      = a.toNat := by
+    simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+               ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
+    exact EvmWord.val256_eq_toNat a
+  have hb_toNat : val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      = b.toNat := by
+    simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+               ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
+    exact EvmWord.val256_eq_toNat b
+  rw [ha_toNat] at hscaleU
+  rw [hb_toNat] at hscaleB
+  -- Accessor abbrevs unfolded to the raw `<<< s` form.
+  have hU0 := n4CallAddbackBeqU0_eq_direct (a := a) hshift_nz
+  have hU1 := n4CallAddbackBeqU1_eq_direct (a := a) hshift_nz
+  have hU2 := n4CallAddbackBeqU2_eq_direct (a := a) hshift_nz
+  have hU3 := n4CallAddbackBeqU3_eq_direct (a := a) hshift_nz
+  have hU4 := n4CallAddbackBeqU4_eq_direct (a := a) hshift_nz
+  have hB0 := n4CallAddbackBeqB0Prime_eq_direct hshift_nz
+  have hB1 := n4CallAddbackBeqB1Prime_eq_direct hshift_nz
+  have hB2 := n4CallAddbackBeqB2Prime_eq_direct hshift_nz
+  have hB3 := n4CallAddbackBeqB3Prime_eq_direct hshift_nz
+  -- aD/aV in raw `<<< s` form equal the scaled values.
+  set s := (clzResult (b.getLimbN 3)).1.toNat with hs_def
+  -- The raw normalized limb tuple (matches the bridge's `msN` args, s = clz.toNat).
+  have hq_raw : (n4CallAddbackBeqQOutV5 a b).toNat =
+      (val256 ((a.getLimbN 0) <<< s)
+          (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+          (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+          (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))
+        + ((a.getLimbN 3) >>> (64 - s)).toNat * 2 ^ 256) /
+      val256 ((b.getLimbN 0) <<< s)
+          (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+          (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+          (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s))) := by
+    rw [hscaleU, hscaleB, hqout, Nat.mul_div_mul_right _ _ (Nat.two_pow_pos s)]
+  have hBnz_raw : val256 ((b.getLimbN 0) <<< s)
+      (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+      (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+      (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s))) ≠ 0 := by
+    rw [hscaleB]
+    have : 0 < b.toNat := by
+      rcases Nat.eq_zero_or_pos b.toNat with h | h
+      · exact absurd (BitVec.eq_of_toNat_eq (by rw [h]; rfl)) hbnz
+      · exact h
+    positivity
+  -- (4) val256(msN.low4) = aD_raw % aV_raw, exact-quotient mulsub.
+  have hval_msN := mulsub_exact_val256_low4 (n4CallAddbackBeqQOutV5 a b)
+    ((b.getLimbN 0) <<< s)
+    (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+    (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+    (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s)))
+    ((a.getLimbN 0) <<< s)
+    (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+    (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+    (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))
+    ((a.getLimbN 3) >>> (64 - s))
+    hBnz_raw hq_raw
+  -- (5) aD a b = aD_raw and aV b = aV_raw (accessor = raw via `_eq_direct`).
+  have haD : aD a b =
+      val256 ((a.getLimbN 0) <<< s)
+          (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+          (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+          (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))
+        + ((a.getLimbN 3) >>> (64 - s)).toNat * 2 ^ 256 := by
+    simp only [aD, hU0, hU1, hU2, hU3, hU4]
+  have haV : aV b =
+      val256 ((b.getLimbN 0) <<< s)
+          (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+          (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+          (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s))) := by
+    simp only [aV, hB0, hB1, hB2, hB3]
+  -- (6) Per-limb: ab = msN via `val256` injectivity (both = aD % aV).
+  rw [haD, haV] at hval_ab
+  have hval_eq : val256 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 =
+      val256
+        (mulsubN4 (n4CallAddbackBeqQOutV5 a b)
+          ((b.getLimbN 0) <<< s)
+          (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+          (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+          (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s)))
+          ((a.getLimbN 0) <<< s)
+          (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+          (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+          (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))).1
+        (mulsubN4 (n4CallAddbackBeqQOutV5 a b)
+          ((b.getLimbN 0) <<< s)
+          (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+          (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+          (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s)))
+          ((a.getLimbN 0) <<< s)
+          (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+          (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+          (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))).2.1
+        (mulsubN4 (n4CallAddbackBeqQOutV5 a b)
+          ((b.getLimbN 0) <<< s)
+          (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+          (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+          (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s)))
+          ((a.getLimbN 0) <<< s)
+          (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+          (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+          (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))).2.2.1
+        (mulsubN4 (n4CallAddbackBeqQOutV5 a b)
+          ((b.getLimbN 0) <<< s)
+          (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+          (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+          (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s)))
+          ((a.getLimbN 0) <<< s)
+          (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+          (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+          (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))).2.2.2.1 := by
+    rw [hval_ab, hval_msN]
+  obtain ⟨hab0, hab1, hab2, hab3⟩ := val256_inj hval_eq
+  -- (7) Bridge top-borrow bound: exact quotient ⇒ c3 = u4.
+  have hc3 : (mulsubN4 (n4CallAddbackBeqQOutV5 a b)
+      ((b.getLimbN 0) <<< s)
+      (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+      (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+      (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s)))
+      ((a.getLimbN 0) <<< s)
+      (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+      (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+      (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))).2.2.2.2.toNat ≤
+      ((a.getLimbN 3) >>> (64 - s)).toNat := by
+    have hcons := mulsubN4_val256_eq (n4CallAddbackBeqQOutV5 a b)
+      ((b.getLimbN 0) <<< s)
+      (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+      (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+      (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s)))
+      ((a.getLimbN 0) <<< s)
+      (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+      (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+      (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))
+    simp only at hcons
+    have hqmod : (n4CallAddbackBeqQOutV5 a b).toNat *
+        val256 ((b.getLimbN 0) <<< s)
+          (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+          (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+          (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s))) +
+        (val256 ((a.getLimbN 0) <<< s)
+          (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+          (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+          (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))
+          + ((a.getLimbN 3) >>> (64 - s)).toNat * 2 ^ 256) %
+        val256 ((b.getLimbN 0) <<< s)
+          (((b.getLimbN 1) <<< s) ||| ((b.getLimbN 0) >>> (64 - s)))
+          (((b.getLimbN 2) <<< s) ||| ((b.getLimbN 1) >>> (64 - s)))
+          (((b.getLimbN 3) <<< s) ||| ((b.getLimbN 2) >>> (64 - s))) =
+        val256 ((a.getLimbN 0) <<< s)
+          (((a.getLimbN 1) <<< s) ||| ((a.getLimbN 0) >>> (64 - s)))
+          (((a.getLimbN 2) <<< s) ||| ((a.getLimbN 1) >>> (64 - s)))
+          (((a.getLimbN 3) <<< s) ||| ((a.getLimbN 2) >>> (64 - s)))
+          + ((a.getLimbN 3) >>> (64 - s)).toNat * 2 ^ 256 := by
+      rw [hq_raw, Nat.mul_comm]; exact Nat.div_add_mod _ _
+    omega
+  -- (8) Apply the per-limb overestimate bridge with qHat := q_out, s := clz.toNat.
+  have h_limbs := denorm_limbN_eq_mod_of_overestimate_getLimbN (a := a) (b := b)
+    (qHat := n4CallAddbackBeqQOutV5 a b) (s := s)
+    hshift_pos hshift_lt_64 hb3_bound hmul_le hge hb3nz hc3
+  -- (9) Rewrite ab → msN and align the funnel shifts.
+  have hmodS : (clzResult (b.getLimbN 3)).1.toNat % 64 = s := by omega
+  simp only [shift, antiShift, hmodS, hanti_toNat_mod, hab0, hab1, hab2, hab3]
+  exact h_limbs
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4V5CallAddbackModWordLane.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V5CallAddbackModWordLane.lean
@@ -280,4 +280,52 @@ theorem n4_addback_un_val256_eq_amod_double (a b : EvmWord)
     (n4CallAddbackBeqU2 a b) (n4CallAddbackBeqU3 a b) (n4CallAddbackBeqU4 a b)
     huTop hc3 hcarry_zero hcarry2_one hq_ge2 hBnz hqHat
 
+/-- From the addback semantic (`q_out = qTrue`), the corrected quotient's `toNat`
+    equals `a.toNat / b.toNat`.  Feeds the overestimate bridge's `hqHat_mul_le` /
+    `hqHat_ge` bounds for the MOD addback getLimbN composition. -/
+theorem n4CallAddbackBeqQOutV5_toNat_eq_div (a b : EvmWord)
+    (hbnz : b ≠ 0)
+    (hsem : n4CallAddbackBeqSemanticHoldsV5 a b) :
+    (n4CallAddbackBeqQOutV5 a b).toNat = a.toNat / b.toNat := by
+  unfold n4CallAddbackBeqSemanticHoldsV5 n4CallAddbackBeqQTrue at hsem
+  have ha_val : val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) = a.toNat := by
+    simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+               ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
+    exact EvmWord.val256_eq_toNat a
+  have hb_val : val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) = b.toNat := by
+    simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+               ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
+    exact EvmWord.val256_eq_toNat b
+  rw [ha_val, hb_val] at hsem
+  have hdiv_toNat : (EvmWord.div a b).toNat = a.toNat / b.toNat := by
+    unfold EvmWord.div; rw [if_neg hbnz]; exact BitVec.toNat_udiv
+  omega
+
+/-- The two overestimate-bridge bounds for the corrected quotient `q_out`, on the
+    original (un-normalized) `a`/`b` limbs.  Since `q_out` is the exact quotient
+    (`n4CallAddbackBeqQOutV5_toNat_eq_div`), the trial-multiplication bound and the
+    ge-bound both hold on the nose.  These are exactly the `hqHat_mul_le` /
+    `hqHat_ge` arguments of `denorm_limbN_eq_mod_of_overestimate_getLimbN` when it
+    is applied with `qHat := q_out` in the n=4 MOD addback getLimbN lane. -/
+theorem n4CallAddbackBeqQOutV5_bridge_bounds (a b : EvmWord)
+    (hbnz : b ≠ 0)
+    (hsem : n4CallAddbackBeqSemanticHoldsV5 a b) :
+    (n4CallAddbackBeqQOutV5 a b).toNat *
+        val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ≤
+      val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) ∧
+    val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) /
+        val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ≤
+      (n4CallAddbackBeqQOutV5 a b).toNat := by
+  have hq := n4CallAddbackBeqQOutV5_toNat_eq_div a b hbnz hsem
+  have ha_val : val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) = a.toNat := by
+    simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+               ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
+    exact EvmWord.val256_eq_toNat a
+  have hb_val : val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) = b.toNat := by
+    simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+               ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
+    exact EvmWord.val256_eq_toNat b
+  rw [ha_val, hb_val, hq]
+  exact ⟨Nat.div_mul_le_self a.toNat b.toNat, le_refl _⟩
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4V5CallSkipModWordLane.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V5CallSkipModWordLane.lean
@@ -28,7 +28,7 @@ open EvmAsm.Rv64 EvmWord
     conditions.  The four limbs of `EvmWord.mod a b` are the funnel-shift-down of
     the normalized mulsub result by the normalization shift. -/
 theorem n4_call_skip_mod_getLimbN_v5 (a b : EvmWord)
-    (hbnz : b ≠ 0)
+    (_hbnz : b ≠ 0)
     (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0)
     (hborrow : isSkipBorrowN4CallV4Evm a b)
@@ -72,7 +72,6 @@ theorem n4_call_skip_mod_getLimbN_v5 (a b : EvmWord)
   have hclz_le := clzResult_fst_toNat_le (b.getLimbN 3)
   have hshift_pos : 0 < (clzResult (b.getLimbN 3)).1.toNat := by
     by_contra h
-    push_neg at h
     apply hshift_nz
     apply BitVec.eq_of_toNat_eq
     rw [show (0 : Word).toNat = 0 from rfl]

--- a/EvmAsm/Evm64/DivMod/Spec/N4V5CallSkipModWordLane.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V5CallSkipModWordLane.lean
@@ -1,0 +1,120 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4V5CallSkipModWordLane
+
+  MOD counterpart of `n4_call_skip_div_mod_getLimbN_v5` (N4V5CallSkipWordLane):
+  under the n=4 call+skip conditions, the four limbs of `EvmWord.mod a b` equal
+  the denormalized (funnel-shift-down by the normalization shift) mulsub result
+  `mulsubN4 qHat b'… u…`.  Discharges the four overestimate bounds of
+  `denorm_limbN_eq_mod_of_overestimate_getLimbN` from the call-skip facts exactly
+  as the (old-modCode) `output_slot_to_evmWordIs_mod_n4_call_skip_denorm` does:
+  the T3 bound (`div128Quot_v4_call_skip_mul_val256_b_le_val256_a`, bridged to the
+  v5 qHat via `hbridge`), the Knuth-A bound (`n4CallSkipSemanticHoldsV4`), the
+  `hc3_n_le_u_top` carry bound (`c3_le_u4_of_skip_borrow_call_v5`), and the CLZ
+  top bound (`clzResult_fst_top_bound`).  The one missing link for the n=4 MOD
+  shiftNz `_of_conds` lane.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N4V5CallSkipWordLane
+import EvmAsm.Evm64.DivMod.Spec.N4V5CallSkipUpperBound
+import EvmAsm.Evm64.DivMod.Spec.CallSkipOverestimateBridge
+import EvmAsm.Evm64.EvmWordArith.Div128CallSkipCloseV4
+import EvmAsm.Evm64.EvmWordArith.CLZLemmas
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64 EvmWord
+
+/-- MOD limb facts for the n=4 call+skip path (v5), from the call-skip
+    conditions.  The four limbs of `EvmWord.mod a b` are the funnel-shift-down of
+    the normalized mulsub result by the normalization shift. -/
+theorem n4_call_skip_mod_getLimbN_v5 (a b : EvmWord)
+    (hbnz : b ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hborrow : isSkipBorrowN4CallV4Evm a b)
+    (hborrowV5 : isSkipBorrowN4CallV5 (a.getLimbN 0) (a.getLimbN 1)
+      (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0) (b.getLimbN 1)
+      (b.getLimbN 2) (b.getLimbN 3))
+    (hsem : n4CallSkipSemanticHoldsV4 a b)
+    (hbridge :
+      divKTrialCallV5QHat
+        ((a.getLimbN 3) >>> ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64))
+        (((a.getLimbN 3) <<< ((clzResult (b.getLimbN 3)).1.toNat % 64)) |||
+          ((a.getLimbN 2) >>> ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64)))
+        (((b.getLimbN 3) <<< ((clzResult (b.getLimbN 3)).1.toNat % 64)) |||
+          ((b.getLimbN 2) >>> ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64))) =
+      div128Quot_v4
+        ((a.getLimbN 3) >>> ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64))
+        (((a.getLimbN 3) <<< ((clzResult (b.getLimbN 3)).1.toNat % 64)) |||
+          ((a.getLimbN 2) >>> ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64)))
+        (((b.getLimbN 3) <<< ((clzResult (b.getLimbN 3)).1.toNat % 64)) |||
+          ((b.getLimbN 2) >>> ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64)))) :
+    let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
+    let antiShift :=
+      (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
+    let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
+    let b2' := ((b.getLimbN 2) <<< shift) ||| ((b.getLimbN 1) >>> antiShift)
+    let b1' := ((b.getLimbN 1) <<< shift) ||| ((b.getLimbN 0) >>> antiShift)
+    let b0' := (b.getLimbN 0) <<< shift
+    let u4 := (a.getLimbN 3) >>> antiShift
+    let u3 := ((a.getLimbN 3) <<< shift) ||| ((a.getLimbN 2) >>> antiShift)
+    let u2 := ((a.getLimbN 2) <<< shift) ||| ((a.getLimbN 1) >>> antiShift)
+    let u1 := ((a.getLimbN 1) <<< shift) ||| ((a.getLimbN 0) >>> antiShift)
+    let u0 := (a.getLimbN 0) <<< shift
+    let qHat := divKTrialCallV5QHat u4 u3 b3'
+    let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
+    (EvmWord.mod a b).getLimbN 0 = ((ms.1 >>> shift) ||| (ms.2.1 <<< antiShift)) ∧
+    (EvmWord.mod a b).getLimbN 1 = ((ms.2.1 >>> shift) ||| (ms.2.2.1 <<< antiShift)) ∧
+    (EvmWord.mod a b).getLimbN 2 = ((ms.2.2.1 >>> shift) ||| (ms.2.2.2.1 <<< antiShift)) ∧
+    (EvmWord.mod a b).getLimbN 3 = (ms.2.2.2.1 >>> shift) := by
+  intro shift antiShift b3' b2' b1' b0' u4 u3 u2 u1 u0 qHat ms
+  -- Shift bounds.
+  have hclz_le := clzResult_fst_toNat_le (b.getLimbN 3)
+  have hshift_pos : 0 < (clzResult (b.getLimbN 3)).1.toNat := by
+    by_contra h
+    push_neg at h
+    apply hshift_nz
+    apply BitVec.eq_of_toNat_eq
+    rw [show (0 : Word).toNat = 0 from rfl]
+    omega
+  have hshift_lt_64 : (clzResult (b.getLimbN 3)).1.toNat < 64 := by omega
+  have hmod_eq : (clzResult (b.getLimbN 3)).1.toNat % 64 =
+      (clzResult (b.getLimbN 3)).1.toNat := by omega
+  have hanti_toNat_mod :
+      (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64 =
+      64 - (clzResult (b.getLimbN 3)).1.toNat := by
+    have h0se12 : signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1 =
+        -((clzResult (b.getLimbN 3)).1) := by rw [signExtend12_0]; simp
+    rw [h0se12, BitVec.toNat_neg]
+    have : ((clzResult (b.getLimbN 3)).1).toNat ≤ 2 ^ 64 := by
+      have := ((clzResult (b.getLimbN 3)).1).isLt; omega
+    omega
+  -- b3 CLZ top bound.
+  have hb3_bound : (b.getLimbN 3).toNat <
+      2 ^ (64 - (clzResult (b.getLimbN 3)).1.toNat) :=
+    clzResult_fst_top_bound (b.getLimbN 3)
+  -- T3 bound (v4) + hsem (Knuth-A) + c3 carry bound (v5).
+  rw [isSkipBorrowN4CallV4Evm_def] at hborrow
+  have hT3 := div128Quot_v4_call_skip_mul_val256_b_le_val256_a
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      hshift_nz hborrow
+  rw [n4CallSkipSemanticHoldsV4_def] at hsem
+  have hc3_le := c3_le_u4_of_skip_borrow_call_v5 hborrowV5
+  simp only [hmod_eq, hanti_toNat_mod] at hT3 hsem hc3_le hbridge
+  -- Convert the T3 and Knuth-A bounds onto the v5 qHat via `hbridge`.
+  rw [← hbridge] at hT3 hsem
+  -- Apply the per-limb overestimate bridge with `s = clz.1.toNat`, v5 qHat.
+  have h_limbs := denorm_limbN_eq_mod_of_overestimate_getLimbN (a := a) (b := b)
+    (qHat := divKTrialCallV5QHat
+      ((a.getLimbN 3) >>> (64 - (clzResult (b.getLimbN 3)).1.toNat))
+      (((a.getLimbN 3) <<< (clzResult (b.getLimbN 3)).1.toNat) |||
+       ((a.getLimbN 2) >>> (64 - (clzResult (b.getLimbN 3)).1.toNat)))
+      (((b.getLimbN 3) <<< (clzResult (b.getLimbN 3)).1.toNat) |||
+       ((b.getLimbN 2) >>> (64 - (clzResult (b.getLimbN 3)).1.toNat))))
+    hshift_pos hshift_lt_64 hb3_bound hT3 hsem hb3nz hc3_le
+  simp only [shift, antiShift, b3', b2', b1', b0', u4, u3, u2, u1, u0, qHat, ms,
+    hmod_eq, hanti_toNat_mod]
+  exact h_limbs
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## What (draft — ~95% of the n=4 MOD lane, 6 commits, all green + axiom-clean)

The n=4 MOD lane (`b3 ≠ 0`, full Knuth-D with add-back) over `modCode_noNop_v5` — the **last of the 5 MOD lanes** toward `evm_mod_v6_stack_spec` → MOD `.proven`. This draft has everything built **except** the two blockers below (one tractable, one genuine new math in the div128 add-back semantics — hence the draft + questions, per the crowdsource valve).

Built & green (`lake build EvmAsm.Evm64.DivMod` → 1922 jobs; `#print axioms` on each → `propext/Classical.choice/Quot.sound`; forbidden-tactics OK):
- **Preloop + loop bodies** (`FullPathN4V5NoNopPreloopMod` + the 4 j=0 loop bodies) — `evm_mod_n4_to_loopSetup_spec_within_v5_noNop` and the shared-loop `_modCode` lifts.
- **Both call-branch full paths base→nopOff** (`evm_mod_n4_full_call_{skip,addback}_spec_v5_noNop`, posts `fullModN4Call{Skip,Addback}PostV5`), incl. the denorm-epilogue mirrors. (Fixed a recurring pre-mono `xperm` snag by framing the 3 high-normalization cells `sp+4016/4008/4000↦0`.)
- **Dispatch post-bridge** `n4_denormModPost_frame_to_modStackDispatchPost_v5` (`denormModPost` frame → `modStackDispatchPostV5`, given the four `(EvmWord.mod a b).getLimbN` facts).
- **The hardest kernel — call-skip MOD remainder facts** `n4_call_skip_mod_getLimbN_v5`: discharges the 4 overestimate bounds of `denorm_limbN_eq_mod_of_overestimate_getLimbN` from the call-skip semantic conditions (reusing `div128Quot_v4_call_skip_mul_val256_b_le_val256_a`, `n4CallSkipSemanticHoldsV4_def`, `c3_le_u4_of_skip_borrow_call_v5`) + the shift-form bridge.

## Remaining (2 blockers)

**Blocker 1 — call-skip `_of_conds` lane (tractable):** composing `n4_call_skip_mod_getLimbN_v5` + the full path + post-bridge into `evm_mod_n4_lane_callSkip_of_conds` hits a `whnf` heartbeat timeout (even at 1M) when the huge mulsub/funnel terms are rewritten in-proof. Fix (mirroring DIV's split): introduce `evm_mod_n4_lane_callSkip_of_hmod` taking the four `hmod` facts as **explicit** hypotheses (exact `denormModPost`-funnel form with `shift = (clzResult b3).1`) — the structure of DIV `evm_div_n4_lane_callSkip_of_hdiv` — then `_of_conds` just `obtain`s from `n4_call_skip_mod_getLimbN_v5` and feeds it. No huge in-proof inference → no whnf blowup.

**Blocker 2 — addback branch MOD remainder facts (genuine new math — QUESTION for @pirapira):** the add-back branch's trial `qHat` **overshoots by one `b`** (that's why it adds back), so `denorm_limbN_eq_mod_of_overestimate_getLimbN`'s no-overshoot precondition `qHat·val256(b) ≤ val256(a)` does **not** hold for the raw trial `qHat`. The DIV add-back lane instead uses `n4CallAddbackBeqSemanticHoldsV5` (the *corrected* quotient `q = a/b`; `n4_call_addback_beq_div_getLimbN_v5`). **What's the intended route for the MOD add-back *remainder* getLimbN facts?** Either (i) a new exact-case bridge `mod = denorm(corrected-ms)` from `n4CallAddbackBeqSemanticHoldsV5` (`q·b + r = a`, `r < b`), or (ii) reuse the overestimate bridge with `qHat := n4CallAddbackBeqQOutV5` (the corrected `q_out`, for which `q_out·b ≤ a` holds with equality) + `c3_le_u4_plus_one_from_identity` (`CallAddbackPureNat.lean:72`) for the carry bound. Guidance appreciated — this is the last kernel.

## After the blockers

`evm_mod_n4_lane_shiftNz_v5_of_cert` (combine both `_of_conds` under `n4ShiftNzLaneRuntimeCertV5`) → shift0 arm (max-branch full-paths + shift0 lane) → `evm_mod_n4_lane_v5_of_certs` + reuse the op-agnostic cert discharges (`evm_div_n4_shift0_cert_of_shape` + the shiftNz discharge) → `evm_mod_n4_lane_v5` in `N4ShapeIs` form → the (already-proven) 5-lane combinator `evm_mod_stack_spec_unconditional_of_lanes_v5_mod` → v6 links → `evm_mod_v6_stack_spec`.

(n=1 and n=3 MOD lanes already merged: #9554, #9590.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)