### PR TITLE
SAsm M4: verified calls — FnHandle, caller-shaped soundness, leaf-handle packaging

### DIFF
--- a/EvmAsm/Rv64/SAsm.lean
+++ b/EvmAsm/Rv64/SAsm.lean
@@ -14,6 +14,8 @@ import EvmAsm.Rv64.SAsm.BlockSound
 import EvmAsm.Rv64.SAsm.Vc
 import EvmAsm.Rv64.SAsm.CtrlSpecs
 import EvmAsm.Rv64.SAsm.StmtSound
+import EvmAsm.Rv64.SAsm.Handle
+import EvmAsm.Rv64.SAsm.StmtSoundCall
 import EvmAsm.Rv64.SAsm.Fn
 import EvmAsm.Rv64.SAsm.Tactic
 import EvmAsm.Rv64.SAsm.Examples

--- a/EvmAsm/Rv64/SAsm/Ast.lean
+++ b/EvmAsm/Rv64/SAsm/Ast.lean
@@ -16,6 +16,7 @@
 
 import EvmAsm.Rv64.Instructions
 import EvmAsm.Rv64.SAsm.RegFile
+import EvmAsm.Rv64.SAsm.Handle
 
 namespace EvmAsm.Rv64
 namespace SAsm
@@ -116,10 +117,11 @@ inductive Stmt where
       emits initialization, preservation, and fuel-exhaustion VCs. -/
   | «while»  (label : String) (c : Cond) (fuel : Nat)
            (inv : Nat → RegFile → Prop) (body : Stmt)
-  /-- Direct call (`jal ra, callee`) to a routine at a fixed entry address.
-      The callee's interface (pre/post in the C-like ABI) is looked up at
-      verification time; see docs/sasm-design.md §3.6. -/
-  | call   (label : String) (callee : Word)
+  /-- Direct call (`jal ra, f.entry`) to a routine with a verified caller
+      interface (docs/sasm-design.md §3.6).  The handle carries the callee's
+      pre/post in the C-like ABI; the VC generator emits one `.pre`
+      obligation per call site. -/
+  | call   (label : String) (f : FnHandle)
 
 namespace Stmt
 
@@ -139,6 +141,18 @@ def size : Stmt → Nat
 
 /-- All statement sizes are meaningful; `assert` is the only zero-size node. -/
 @[simp] theorem size_seq (a b : Stmt) : (seq a b).size = a.size + b.size := rfl
+
+/-- A statement makes no calls.  Call-free bodies get the stronger leaf
+    soundness theorem (every non-exposed register, including `ra`, is left
+    untouched and framed), which is what `Fn.toHandle` packages. -/
+def callFree : Stmt → Bool
+  | block _ _         => true
+  | seq a b           => a.callFree && b.callFree
+  | ite _ _ t e       => t.callFree && e.callFree
+  | when _ _ b        => b.callFree
+  | assert _ _        => true
+  | «while» _ _ _ _ b => b.callFree
+  | call _ _          => false
 
 end Stmt
 

--- a/EvmAsm/Rv64/SAsm/Examples.lean
+++ b/EvmAsm/Rv64/SAsm/Examples.lean
@@ -62,9 +62,9 @@ private def demoIte : Stmt :=
    .JAL .x0 (8 : BitVec 21),
    .MV .x12 .x11]
 
-/- A call resolves to a pc-relative JAL. -/
+/- A call resolves to a pc-relative JAL (stub handle: layout-only demo). -/
 private def demoCall : Stmt :=
-  .block "arg" [.LI .x10 42] ;;; .call "helper" 0x2000
+  .block "arg" [.LI .x10 42] ;;; .call "helper" (.stub 0x2000)
 
 #guard demoCall.size = 2
 #guard demoCall.flatten 0x1800 =

--- a/EvmAsm/Rv64/SAsm/ExamplesVc.lean
+++ b/EvmAsm/Rv64/SAsm/ExamplesVc.lean
@@ -91,6 +91,63 @@ theorem countFn_spec (base : Word) : countFn.Spec base := by
     subst this
     decide
 
+-- ============================================================================
+-- Calls (Milestone M4): package a verified leaf as a handle, call it
+-- ============================================================================
+
+/-- The clamp routine as a callee at `0x2000`, instantiated at the ghost
+    arguments `x := 5`, `y := 7`. -/
+def clampHandle : FnHandle :=
+  (clampFn 5 7).toHandle 0x2000 (clampFn_spec 5 7 0x2000) (by decide)
+
+/-- Load arguments and call clamp: afterwards `a0 = min(5, 7) = 5`. -/
+def callerFn : Fn where
+  name := "caller"
+  pre := fun _ => True
+  post := fun rf => rf.get .x10 = 5
+  body :=
+    .block "args" [.LI .x10 5, .LI .x11 7] ;;;
+    .call "clamp" clampHandle
+
+/-- The canonical ambient code requirement: the caller's own code plus the
+    callee's. -/
+def callerCr : CodeReq :=
+  (CodeReq.ofProg 0x1000 (callerFn.body.flatten 0x1000)).union clampHandle.code
+
+theorem callerFn_spec : callerFn.SpecR 0x1000 callerCr := by
+  vcgen
+  case code =>
+    intro a i h
+    simp only [callerCr, CodeReq.union, h]
+  case callees =>
+    refine ⟨trivial, ?_⟩
+    intro a i h
+    obtain ⟨k, hk, rfl⟩ := ofProg_some_range h
+    have hlen : ((clampFn 5 7).programRet 0x2000).length = 3 := by decide
+    rw [hlen] at hk
+    simp only [callerCr, CodeReq.union]
+    rw [CodeReq.ofProg_none_range 0x1000 (callerFn.body.flatten 0x1000)
+      (fun k' hk' heq => ?_)]
+    · exact h
+    · have hlen' : (callerFn.body.flatten 0x1000).length = 3 := by decide
+      rw [hlen'] at hk'
+      bv_omega
+  case calls =>
+    exact ⟨trivial, by decide, by decide, by decide⟩
+  case caller.clamp.pre =>
+    rintro rf ⟨rf₀, -, rfl⟩
+    show (clampFn 5 7).pre _
+    simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem, clampFn]
+    constructor
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_self _ _ _ (by decide)]
+    · rw [RegFile.get_set_self _ _ _ (by decide)]
+  case caller.post =>
+    intro rf h
+    show rf.get .x10 = 5
+    have h' : rf.get .x10 = (if BitVec.ult 5 7 then (5 : Word) else 7) := h.1
+    rw [h', if_pos (by decide)]
+
 end ExamplesVc
 end SAsm
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/Flatten.lean
+++ b/EvmAsm/Rv64/SAsm/Flatten.lean
@@ -57,8 +57,8 @@ def flatten (addr : Word) : Stmt → List Instr
   | «while» _ c _ _ b =>
       c.neg.toInstr (brOfs (b.size + 2))
         :: (b.flatten (addr + 4) ++ [.JAL .x0 (jBack (b.size + 1))])
-  | call _ callee =>
-      [.JAL .x1 (BitVec.setWidth 21 (callee - addr))]
+  | call _ f =>
+      [.JAL .x1 (BitVec.setWidth 21 (f.entry - addr))]
 
 /-- The flattened code of a statement occupies exactly `size` slots. -/
 theorem flatten_length (s : Stmt) (addr : Word) :
@@ -97,6 +97,25 @@ def offsetsOk : Stmt → Bool
            && decide (4 * (b.size + 1) ≤ 2^20)
            && b.offsetsOk
   | call _ _ => true
+
+/-- Address-aware side conditions of the call sites of a statement placed at
+    `addr`: each `jal` offset round-trips through its 21-bit immediate, the
+    return address is aligned, and the callee's code does not sit on the
+    call instruction itself.  Decidable for concrete layouts (`decide`),
+    `bv_omega` for relative ones. -/
+def callsOk : Stmt → Word → Prop
+  | block _ _, _ => True
+  | seq a b, addr =>
+      a.callsOk addr ∧ b.callsOk (addr + BitVec.ofNat 64 (4 * a.size))
+  | ite _ _ t e, addr =>
+      t.callsOk (addr + 4) ∧ e.callsOk (addr + BitVec.ofNat 64 (4 * (t.size + 2)))
+  | when _ _ b, addr => b.callsOk (addr + 4)
+  | assert _ _, _ => True
+  | «while» _ _ _ _ b, addr => b.callsOk (addr + 4)
+  | call _ f, addr =>
+      addr + signExtend21 (BitVec.setWidth 21 (f.entry - addr)) = f.entry
+      ∧ ((addr + 4) &&& ~~~(1 : Word)) = addr + 4
+      ∧ f.code addr = none
 
 end Stmt
 end SAsm

--- a/EvmAsm/Rv64/SAsm/Fn.lean
+++ b/EvmAsm/Rv64/SAsm/Fn.lean
@@ -9,11 +9,13 @@
   `Fn.sound` reduces it to the labeled pure VCs, which the `vcgen` tactic
   (Tactic.lean) splits into named goals.
 
-  Design: docs/sasm-design.md §3.6 (the `FnHandle` caller interface and the
-  `ret` epilogue land with calls in Milestone M4).
+  Design: docs/sasm-design.md §3.6.  `Fn.SpecR`/`Fn.soundR` are the
+  caller-shaped variants for bodies containing calls; `Fn.toHandle` packages
+  a verified call-free function (plus the `jalr` return epilogue) as a
+  callee `FnHandle`.
 -/
 
-import EvmAsm.Rv64.SAsm.StmtSound
+import EvmAsm.Rv64.SAsm.StmtSoundCall
 
 namespace EvmAsm.Rv64
 namespace SAsm
@@ -66,6 +68,112 @@ theorem sound (f : Fn) (base : Word) (h : VCs.Hold f.vcs) : f.Spec base := by
       obtain ⟨rf, hrf, hsp⟩ := hh
       exact ⟨rf, hrf, hpost rf hsp⟩)
     hbody
+
+-- ============================================================================
+-- Caller-shaped specs (bodies that may contain calls) — Milestone M4
+-- ============================================================================
+
+/-- Caller-shaped correctness: like `Spec` but at `asrtR` granularity
+    (`ra` owned, its value forgotten across calls), against an ambient `cr`
+    that must contain the body's code and every callee's code. -/
+def SpecR (f : Fn) (base : Word) (cr : CodeReq) : Prop :=
+  cpsTripleWithin f.body.steps base (base + BitVec.ofNat 64 (4 * f.body.size))
+    cr (asrtR f.pre) (asrtR f.post)
+
+/-- VCs of a caller-shaped function (no `callFree` requirement). -/
+def vcsR (f : Fn) : List VC :=
+  ⟨f.name ++ ".flat", f.body.offsetsOk = true ∧ 4 * f.body.size < 2 ^ 64⟩ ::
+  (f.body.vcs (f.name ++ ".") f.pre ++
+   [⟨f.name ++ ".post", ∀ rf, f.body.sp f.pre rf → f.post rf⟩])
+
+/-- Caller-shaped soundness.  `hcode`/`hcallees` locate the body's and the
+    callees' code inside `cr`; `hcalls` are the call sites' address side
+    conditions (`decide`/`bv_omega` for concrete or relative layouts). -/
+theorem soundR (f : Fn) (base : Word) (cr : CodeReq)
+    (hcode : ∀ a i, CodeReq.ofProg base (f.body.flatten base) a = some i →
+      cr a = some i)
+    (hcallees : f.body.CalleesIn cr)
+    (hcalls : f.body.callsOk base)
+    (h : VCs.Hold f.vcsR) : f.SpecR base cr := by
+  have hflat := h.head
+  have hbody := Stmt.soundR f.body base (f.name ++ ".") f.pre
+    hflat.1 hflat.2 hcode hcallees hcalls h.tail.left
+  have hpost := h.tail.right.head
+  exact cpsTripleWithin_weaken (fun _ hp => hp)
+    (asrtR_mono (fun rf hsp => hpost rf hsp))
+    hbody
+
+-- ============================================================================
+-- Packaging a verified (call-free) function as a callee handle
+-- ============================================================================
+
+/-- The function's code with the C-ABI return epilogue. -/
+def programRet (f : Fn) (base : Word) : Program :=
+  f.body.flatten base ++ [.JALR .x0 .x1 0]
+
+/-- `jalr x0, ra, 0`: return to the (aligned) address held in `ra`,
+    changing nothing else. -/
+theorem jalr_ret_spec (base ret : Word) (halign : (ret &&& ~~~(1 : Word)) = ret)
+    {P : Assertion} (hP : P.pcFree) :
+    cpsTripleWithin 1 base ret (CodeReq.singleton base (.JALR .x0 .x1 0))
+      ((.x1 ↦ᵣ ret) ** P) ((.x1 ↦ᵣ ret) ** P) := by
+  intro R hR s hcr hPR hpc; subst hpc
+  have hfetch : s.code s.pc = some (.JALR .x0 .x1 0) :=
+    CodeReq.singleton_satisfiedBy.mp hcr
+  have hstep' : step s = some (execInstrBr s (.JALR .x0 .x1 0)) :=
+    step_non_ecall_non_mem hfetch (by nofun) (by nofun) rfl
+  have hx1 : s.getReg .x1 = ret :=
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
+      (holdsFor_sepConj_elim_left hPR))
+  have hexec : execInstrBr s (.JALR .x0 .x1 0) = s.setPC ret := by
+    rw [execInstrBr_jalr_x0, hx1]
+    congr 1
+    rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+      show ret + (0 : Word) = ret from by bv_omega]
+    exact halign
+  refine ⟨1, Nat.le_refl 1, s.setPC ret, ?_, rfl, ?_⟩
+  · show (step s).bind (stepN 0) = some _
+    rw [hstep', hexec]; rfl
+  · exact holdsFor_pcFree_setPC
+      (pcFree_sepConj (pcFree_sepConj (by pcFree) hP) hR) hPR
+
+/-- A verified call-free function, with the return epilogue, satisfies the
+    `FnHandle` calling contract: enter with any aligned return address in
+    `ra`, come back to it with `post` and `ra` intact. -/
+theorem retSpec (f : Fn) (base : Word) (hspec : f.Spec base)
+    (hsz : 4 * (f.body.size + 1) ≤ 2 ^ 64) :
+    ∀ ret : Word, (ret &&& ~~~(1 : Word)) = ret →
+      cpsTripleWithin (f.body.steps + 1) base ret
+        (CodeReq.ofProg base (f.programRet base))
+        ((.x1 ↦ᵣ ret) ** asrtOf f.pre)
+        ((.x1 ↦ᵣ ret) ** asrtOf f.post) := by
+  intro ret halign
+  have hla : (f.body.flatten base).length = f.body.size := Stmt.flatten_length ..
+  -- body triple, framed with the untouched return address
+  have h1 := cpsTripleWithin_frameR (.x1 ↦ᵣ ret) (by pcFree) hspec
+  rw [sepConj_comm' (asrtOf f.pre), sepConj_comm' (asrtOf f.post)] at h1
+  have h1' := cpsTripleWithin_extend_code
+    (ofProg_mono_left (p2 := [.JALR .x0 .x1 0])) h1
+  -- return epilogue
+  have h2 := jalr_ret_spec (base + BitVec.ofNat 64 (4 * f.body.size)) ret halign
+    (pcFree_asrtOf f.post)
+  have h2' := cpsTripleWithin_extend_code
+    (fun a i h => ofProg_mono_right (p1 := f.body.flatten base)
+      (p2 := [.JALR .x0 .x1 0])
+      (by simp [hla]; omega)
+      a i (by rw [hla, CodeReq.ofProg_singleton]; exact h)) h2
+  exact cpsTripleWithin_seq_same_cr h1' h2'
+
+/-- Package a verified call-free function as a callee handle
+    (docs/sasm-design.md §3.6). -/
+def toHandle (f : Fn) (base : Word) (hspec : f.Spec base)
+    (hsz : 4 * (f.body.size + 1) ≤ 2 ^ 64) : FnHandle where
+  entry := base
+  code := CodeReq.ofProg base (f.programRet base)
+  nSteps := f.body.steps + 1
+  pre := f.pre
+  post := f.post
+  sound := f.retSpec base hspec hsz
 
 end Fn
 

--- a/EvmAsm/Rv64/SAsm/Fn.lean
+++ b/EvmAsm/Rv64/SAsm/Fn.lean
@@ -50,7 +50,8 @@ def Spec (f : Fn) (base : Word) : Prop :=
     - the body's VCs;
     - `<name>.post`: the strongest postcondition entails the stated one. -/
 def vcs (f : Fn) : List VC :=
-  ⟨f.name ++ ".flat", f.body.offsetsOk = true ∧ 4 * f.body.size < 2 ^ 64⟩ ::
+  ⟨f.name ++ ".flat", f.body.callFree = true ∧ f.body.offsetsOk = true
+      ∧ 4 * f.body.size < 2 ^ 64⟩ ::
   (f.body.vcs (f.name ++ ".") f.pre ++
    [⟨f.name ++ ".post", ∀ rf, f.body.sp f.pre rf → f.post rf⟩])
 
@@ -58,7 +59,7 @@ def vcs (f : Fn) : List VC :=
 theorem sound (f : Fn) (base : Word) (h : VCs.Hold f.vcs) : f.Spec base := by
   have hflat := h.head
   have hbody := Stmt.sound f.body base (f.name ++ ".") f.pre
-    hflat.1 hflat.2 (fun _ _ hc => hc) h.tail.left
+    hflat.1 hflat.2.1 hflat.2.2 (fun _ _ hc => hc) h.tail.left
   have hpost := h.tail.right.head
   exact cpsTripleWithin_weaken (fun _ hp => hp)
     (fun hp hh => by

--- a/EvmAsm/Rv64/SAsm/Handle.lean
+++ b/EvmAsm/Rv64/SAsm/Handle.lean
@@ -1,0 +1,54 @@
+/-
+  EvmAsm.Rv64.SAsm.Handle
+
+  The C-like caller interface of a verified routine (docs/sasm-design.md
+  §3.6): everything a call site needs, deliberately forgetting the body.
+
+  A handle's `sound` field says: called with any aligned return address in
+  `ra` and the exposed register file satisfying `pre`, the routine returns
+  to that address within `nSteps` steps with the register file satisfying
+  `post` (ghost data is baked in through the ambient binders used when the
+  handle is constructed).  `Fn.toHandle` (Fn.lean) packages a verified
+  call-free SAsm function this way; hand-verified routines can be packaged
+  by proving the same shape directly.
+-/
+
+import EvmAsm.Rv64.CPSSpec
+import EvmAsm.Rv64.SAsm.RegFileSep
+
+namespace EvmAsm.Rv64
+namespace SAsm
+
+/-- Caller-facing interface of a verified routine in the project's C-like
+    ABI: arguments/results in the exposed a-registers (constrained by
+    `pre`/`post`), `ra` respected, everything outside the exposed register
+    file and `code` framed. -/
+structure FnHandle where
+  entry : Word
+  code : CodeReq
+  nSteps : Nat
+  pre : Reach
+  post : Reach
+  sound : ∀ ret : Word, (ret &&& ~~~(1 : Word)) = ret →
+    cpsTripleWithin nSteps entry ret code
+      ((.x1 ↦ᵣ ret) ** asrtOf pre)
+      ((.x1 ↦ᵣ ret) ** asrtOf post)
+
+/-- A stub handle with an unsatisfiable precondition: lets `Stmt` values
+    mention a routine that is not verified yet.  Any call to it generates
+    an unprovable `.pre` VC, so nothing can be concluded past it. -/
+def FnHandle.stub (entry : Word) : FnHandle where
+  entry := entry
+  code := CodeReq.empty
+  nSteps := 0
+  pre := fun _ => False
+  post := fun _ => True
+  sound := by
+    intro ret _ R hR s hcr hPR hpc
+    exact absurd hPR (by
+      rintro ⟨hp, -, h1, -, -, -, hP1, -⟩
+      obtain ⟨-, -, -, -, -, ⟨rf, -, hfalse⟩⟩ := hP1
+      exact hfalse)
+
+end SAsm
+end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/RegFileSep.lean
+++ b/EvmAsm/Rv64/SAsm/RegFileSep.lean
@@ -36,6 +36,21 @@ theorem pcFree_regFileIs (rf : RegFile) : (regFileIs rf).pcFree := by
   rw [hp]
   rfl
 
+/-- A set of register files: the pure abstraction of the machine state
+    between SAsm nodes. -/
+def Reach := RegFile → Prop
+
+/-- Embed a reachable set as an assertion: some register file in the set
+    owns the exposed registers. -/
+def asrtOf (reach : Reach) : Assertion :=
+  fun h => ∃ rf, regFileIs rf h ∧ reach rf
+
+theorem pcFree_asrtOf (reach : Reach) : (asrtOf reach).pcFree := by
+  intro h hp
+  obtain ⟨rf, hrf, -⟩ := hp
+  rw [hrf]
+  rfl
+
 /-- Extract exposed-register values from a framed `regFileIs`. -/
 theorem holdsFor_regFileIs_getReg {rf : RegFile} {R : Assertion} {s : MachineState}
     (hPR : ((regFileIs rf) ** R).holdsFor s)

--- a/EvmAsm/Rv64/SAsm/StmtSound.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSound.lean
@@ -134,6 +134,7 @@ theorem Cond.wf_neg (c : Cond) : c.neg.wf = c.wf := by
     discharges them by `decide`. -/
 theorem Stmt.sound (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
     {cr : CodeReq}
+    (hleaf : s.callFree = true)
     (hofs : s.offsetsOk = true)
     (hsz : 4 * s.size < 2 ^ 64)
     (hcode : ∀ a i, CodeReq.ofProg base (s.flatten base) a = some i → cr a = some i)
@@ -150,6 +151,7 @@ theorem Stmt.sound (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
       exact cpsTripleWithin_weaken (fun _ hp => hp)
         (fun hp hh => ⟨execBlock rf is, hh, rf, hreach, rfl⟩) h'
   | seq a b iha ihb =>
+      simp only [Stmt.callFree, Bool.and_eq_true] at hleaf
       simp only [Stmt.offsetsOk, Bool.and_eq_true] at hofs
       simp only [Stmt.size] at hsz
       have hsza : 4 * a.size < 2 ^ 64 := by omega
@@ -168,15 +170,16 @@ theorem Stmt.sound (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
           (by rw [hla, Stmt.flatten_length]; omega)
         rw [hla]
         exact h
-      have h1 := iha base pfx reach hofs.1 hsza hcode_a hvcs.left
+      have h1 := iha base pfx reach hleaf.1 hofs.1 hsza hcode_a hvcs.left
       have h2 := ihb (base + BitVec.ofNat 64 (4 * a.size)) pfx (a.sp reach)
-        hofs.2 hszb hcode_b hvcs.right
+        hleaf.2 hofs.2 hszb hcode_b hvcs.right
       have h3 := cpsTripleWithin_seq_same_cr h1 h2
       rw [addr_shift] at h3
       have : 4 * a.size + 4 * b.size = 4 * (a.size + b.size) := by omega
       rw [this] at h3
       exact h3
   | ite lbl c t e iht ihe =>
+      simp only [Stmt.callFree, Bool.and_eq_true] at hleaf
       simp only [Stmt.offsetsOk, Bool.and_eq_true, decide_eq_true_eq] at hofs
       obtain ⟨⟨⟨⟨hwf, hofsT⟩, hofsJ⟩, hOT⟩, hOE⟩ := hofs
       simp only [Stmt.size] at hsz
@@ -248,7 +251,7 @@ theorem Stmt.sound (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
       have hbr' := cpsBranchWithin_extend_code hcode_br hbr
       -- Then-arm: t's code then the skip jump
       have ht := iht (base + 4) (pfx ++ lbl ++ ".t.")
-        (fun rf => reach rf ∧ c.holds rf) hOT (by omega) hcode_t hvcs.left
+        (fun rf => reach rf ∧ c.holds rf) hleaf.1 hOT (by omega) hcode_t hvcs.left
       rw [haddr1] at ht
       have hjal := jal0_spec_pcFree (Stmt.jFwd (e.size + 1))
         (base + BitVec.ofNat 64 (4 * (t.size + 1)))
@@ -258,7 +261,7 @@ theorem Stmt.sound (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
       have htj := cpsTripleWithin_seq_same_cr ht hjal'
       -- Else-arm
       have he := ihe (base + BitVec.ofNat 64 (4 * (t.size + 2))) (pfx ++ lbl ++ ".e.")
-        (fun rf => reach rf ∧ ¬ c.holds rf) hOE (by omega) hcode_e hvcs.right
+        (fun rf => reach rf ∧ ¬ c.holds rf) hleaf.2 hOE (by omega) hcode_e hvcs.right
       rw [haddr3] at he
       -- Weaken branch posts: neg-condition denotations and arm preconditions
       have hbr'' : cpsBranchWithin 1 base cr (asrtOf reach)
@@ -312,7 +315,8 @@ theorem Stmt.sound (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
       rw [signExtend13_brOfs hofsB] at hbr
       have hbr' := cpsBranchWithin_extend_code hcode_br hbr
       have hb := ihb (base + 4) (pfx ++ lbl ++ ".")
-        (fun rf => reach rf ∧ c.holds rf) hOB (by omega) hcode_b hvcs
+        (fun rf => reach rf ∧ c.holds rf) (by simpa [Stmt.callFree] using hleaf)
+        hOB (by omega) hcode_b hvcs
       rw [show (base + 4) + BitVec.ofNat 64 (4 * b.size)
           = base + BitVec.ofNat 64 (4 * (b.size + 1)) from by bv_omega] at hb
       -- taken (¬c): skip directly to the exit
@@ -420,7 +424,8 @@ theorem Stmt.sound (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
             (asrtOf fun rf => inv (i + 1) rf) := by
         intro i hi
         have hb := ihb (base + 4) (pfx ++ lbl ++ ".body.")
-          (fun rf => inv i rf ∧ c.holds rf) hOB (by omega) hcode_b
+          (fun rf => inv i rf ∧ c.holds rf) (by simpa [Stmt.callFree] using hleaf)
+          hOB (by omega) hcode_b
           (Stmt.vcs_antitone b _ (fun rf hr => ⟨i, hi, hr.1, hr.2⟩) hBodyVcs)
         have hjal := jal0_spec_pcFree (Stmt.jBack (b.size + 1))
           ((base + 4) + BitVec.ofNat 64 (4 * b.size))
@@ -480,8 +485,8 @@ theorem Stmt.sound (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
           exact ⟨rf, hrf, hInvInit rf hr⟩)
         (fun _ hp => hp)
         hsound
-  | call lbl callee =>
-      exact (hvcs _ (List.mem_singleton_self _)).elim
+  | call lbl f =>
+      exact absurd hleaf (by simp [Stmt.callFree])
 
 end SAsm
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
@@ -1,0 +1,445 @@
+/-
+  EvmAsm.Rv64.SAsm.StmtSoundCall
+
+  Caller-shaped soundness of the SAsm VC generator: like `Stmt.sound`, but
+  the triple carries ownership of `ra` (`regOwn .x1`) so that `call` nodes
+  can be verified via `WP.cpsCallWithin` against the callee's `FnHandle`.
+
+  Compared to the leaf theorem, the pre/postcondition is
+  `asrtR reach := asrtOf reach ** regOwn .x1`: `ra` is owned throughout but
+  its *value* is only tracked across call-free segments internally — after a
+  call it holds the call's return address, which the shape deliberately
+  forgets.  Call-free bodies should keep using `Stmt.sound` (via `Fn.sound`)
+  so they can be packaged as `FnHandle`s (`Fn.toHandle`), where `ra`
+  invariance matters.
+
+  Design: docs/sasm-design.md §3.6 (Milestone M4).
+-/
+
+import EvmAsm.Rv64.SAsm.StmtSound
+import EvmAsm.Rv64.WP.Call
+
+namespace EvmAsm.Rv64
+namespace SAsm
+
+/-- Caller-shaped embedding of a reachable set: the exposed register file
+    plus ownership of `ra`. -/
+def asrtR (reach : Reach) : Assertion :=
+  asrtOf reach ** regOwn .x1
+
+theorem pcFree_asrtR (reach : Reach) : (asrtR reach).pcFree :=
+  pcFree_sepConj (pcFree_asrtOf _) pcFree_regOwn
+
+theorem asrtR_mono {r₁ r₂ : Reach} (h : ∀ rf, r₁ rf → r₂ rf) :
+    ∀ hp, asrtR r₁ hp → asrtR r₂ hp :=
+  fun hp => sepConj_mono_left (fun hq hh => by
+    obtain ⟨rf, hrf, hr⟩ := hh
+    exact ⟨rf, hrf, h rf hr⟩) hp
+
+theorem asrtR_unsat {r : Reach} (h : ∀ rf, r rf → False) :
+    ∀ hp, asrtR r hp → False := by
+  rintro hp ⟨h1, h2, -, -, ⟨rf, -, hr⟩, -⟩
+  exact h rf hr
+
+/-- Eliminate the unknown `ra` value of an `asrtR`-shaped precondition. -/
+theorem cpsTripleWithin_regOwn_right_pre {n : Nat} {entry exit_ : Word}
+    {cr : CodeReq} {P Q : Assertion} {r : Reg}
+    (h : ∀ v : Word, cpsTripleWithin n entry exit_ cr (P ** (r ↦ᵣ v)) Q) :
+    cpsTripleWithin n entry exit_ cr (P ** regOwn r) Q := by
+  intro R hR s hcr hPR hpc
+  obtain ⟨hp, hcompat, h1, h2, hd, hu, hP1, hR2⟩ := hPR
+  obtain ⟨h1a, h1b, hd1, hu1, hPa, ⟨v, hv⟩⟩ := hP1
+  exact h v R hR s hcr
+    ⟨hp, hcompat, h1, h2, hd, hu, ⟨h1a, h1b, hd1, hu1, hPa, hv⟩, hR2⟩ hpc
+
+/-- Caller-shaped soundness (Milestone M4): the flattened code of `s`
+    satisfies a bounded CPS triple at `asrtR` granularity, provided the
+    ambient `cr` also contains every callee's code (`hcallees`) and the call
+    sites' address side-conditions hold (`hcalls`). -/
+theorem Stmt.soundR (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
+    {cr : CodeReq}
+    (hofs : s.offsetsOk = true)
+    (hsz : 4 * s.size < 2 ^ 64)
+    (hcode : ∀ a i, CodeReq.ofProg base (s.flatten base) a = some i → cr a = some i)
+    (hcallees : s.CalleesIn cr)
+    (hcalls : s.callsOk base)
+    (hvcs : VCs.Hold (s.vcs pfx reach)) :
+    cpsTripleWithin s.steps base (base + BitVec.ofNat 64 (4 * s.size)) cr
+      (asrtR reach) (asrtR (s.sp reach)) := by
+  induction s generalizing base pfx reach cr with
+  | block lbl is =>
+      exact cpsTripleWithin_frameR (regOwn .x1) pcFree_regOwn
+        (Stmt.sound (.block lbl is) base pfx reach rfl hofs hsz hcode hvcs)
+  | assert lbl P =>
+      exact cpsTripleWithin_frameR (regOwn .x1) pcFree_regOwn
+        (Stmt.sound (.assert lbl P) base pfx reach rfl hofs hsz hcode hvcs)
+  | seq a b iha ihb =>
+      simp only [Stmt.offsetsOk, Bool.and_eq_true] at hofs
+      simp only [Stmt.size] at hsz
+      obtain ⟨hcallees_a, hcallees_b⟩ := hcallees
+      obtain ⟨hcalls_a, hcalls_b⟩ := hcalls
+      have hsza : 4 * a.size < 2 ^ 64 := by omega
+      have hszb : 4 * b.size < 2 ^ 64 := by omega
+      have hla : (a.flatten base).length = a.size := Stmt.flatten_length a base
+      have hcode_a : ∀ a' i,
+          CodeReq.ofProg base (a.flatten base) a' = some i → cr a' = some i :=
+        fun a' i h => hcode a' i (ofProg_mono_left a' i h)
+      have hcode_b : ∀ a' i,
+          CodeReq.ofProg (base + BitVec.ofNat 64 (4 * a.size))
+            (b.flatten (base + BitVec.ofNat 64 (4 * a.size))) a' = some i →
+          cr a' = some i := by
+        intro a' i h
+        apply hcode
+        apply ofProg_mono_right
+          (by rw [hla, Stmt.flatten_length]; omega)
+        rw [hla]
+        exact h
+      have h1 := iha base pfx reach hofs.1 hsza hcode_a hcallees_a hcalls_a hvcs.left
+      have h2 := ihb (base + BitVec.ofNat 64 (4 * a.size)) pfx (a.sp reach)
+        hofs.2 hszb hcode_b hcallees_b hcalls_b hvcs.right
+      have h3 := cpsTripleWithin_seq_same_cr h1 h2
+      rw [addr_shift] at h3
+      have : 4 * a.size + 4 * b.size = 4 * (a.size + b.size) := by omega
+      rw [this] at h3
+      exact h3
+  | ite lbl c t e iht ihe =>
+      simp only [Stmt.offsetsOk, Bool.and_eq_true, decide_eq_true_eq] at hofs
+      obtain ⟨⟨⟨⟨hwf, hofsT⟩, hofsJ⟩, hOT⟩, hOE⟩ := hofs
+      obtain ⟨hcallees_t, hcallees_e⟩ := hcallees
+      obtain ⟨hcalls_t, hcalls_e⟩ := hcalls
+      simp only [Stmt.size] at hsz
+      have hlt : (t.flatten (base + 4)).length = t.size := Stmt.flatten_length ..
+      have haddr1 : (base + 4) + BitVec.ofNat 64 (4 * t.size)
+          = base + BitVec.ofNat 64 (4 * (t.size + 1)) := by bv_omega
+      have haddr2 : (base + BitVec.ofNat 64 (4 * (t.size + 1)))
+            + BitVec.ofNat 64 (4 * (e.size + 1))
+          = base + BitVec.ofNat 64 (4 * (t.size + e.size + 2)) := by bv_omega
+      have haddr3 : (base + BitVec.ofNat 64 (4 * (t.size + 2)))
+            + BitVec.ofNat 64 (4 * e.size)
+          = base + BitVec.ofNat 64 (4 * (t.size + e.size + 2)) := by bv_omega
+      have haddr4 : (base + BitVec.ofNat 64 (4 * (t.size + 1))) + 4
+          = base + BitVec.ofNat 64 (4 * (t.size + 2)) := by bv_omega
+      have hflat : Stmt.flatten base (.ite lbl c t e)
+          = (c.neg.toInstr (Stmt.brOfs (t.size + 2)))
+            :: (t.flatten (base + 4)
+                ++ .JAL .x0 (Stmt.jFwd (e.size + 1))
+                :: e.flatten (base + BitVec.ofNat 64 (4 * (t.size + 2)))) := rfl
+      have hlenAll : 4 * ((t.flatten (base + 4)
+          ++ .JAL .x0 (Stmt.jFwd (e.size + 1))
+          :: e.flatten (base + BitVec.ofNat 64 (4 * (t.size + 2)))).length + 1)
+          ≤ 2 ^ 64 := by
+        simp only [List.length_append, List.length_cons, hlt, Stmt.flatten_length]
+        omega
+      have hcode_br : ∀ a' i,
+          CodeReq.singleton base (c.neg.toInstr (Stmt.brOfs (t.size + 2))) a' = some i →
+          cr a' = some i := by
+        intro a' i h
+        exact hcode a' i (hflat ▸ ofProg_head a' i h)
+      have hcode_t : ∀ a' i,
+          CodeReq.ofProg (base + 4) (t.flatten (base + 4)) a' = some i →
+          cr a' = some i := by
+        intro a' i h
+        exact hcode a' i (hflat ▸ ofProg_cons_tail hlenAll a' i (ofProg_mono_left a' i h))
+      have hcode_jal : ∀ a' i,
+          CodeReq.singleton (base + BitVec.ofNat 64 (4 * (t.size + 1)))
+            (.JAL .x0 (Stmt.jFwd (e.size + 1))) a' = some i →
+          cr a' = some i := by
+        intro a' i h
+        apply hcode a' i
+        rw [hflat]
+        apply ofProg_cons_tail hlenAll
+        apply ofProg_mono_right (p1 := t.flatten (base + 4))
+          (by simp only [List.length_cons, hlt, Stmt.flatten_length]; omega)
+        rw [hlt, haddr1]
+        exact ofProg_head a' i h
+      have hcode_e : ∀ a' i,
+          CodeReq.ofProg (base + BitVec.ofNat 64 (4 * (t.size + 2)))
+            (e.flatten (base + BitVec.ofNat 64 (4 * (t.size + 2)))) a' = some i →
+          cr a' = some i := by
+        intro a' i h
+        apply hcode a' i
+        rw [hflat]
+        apply ofProg_cons_tail hlenAll
+        apply ofProg_mono_right (p1 := t.flatten (base + 4))
+          (by simp only [List.length_cons, hlt, Stmt.flatten_length]; omega)
+        rw [hlt, haddr1]
+        apply ofProg_cons_tail
+          (by rw [Stmt.flatten_length]; omega)
+        rw [haddr4]
+        exact h
+      have hbr := branch_spec_asrt c.neg (Stmt.brOfs (t.size + 2)) reach base
+        (by rw [Cond.wf_neg]; exact hwf)
+      rw [signExtend13_brOfs hofsT] at hbr
+      have hbr' := cpsBranchWithin_frameR (regOwn .x1) pcFree_regOwn
+        (cpsBranchWithin_extend_code hcode_br hbr)
+      have ht := iht (base + 4) (pfx ++ lbl ++ ".t.")
+        (fun rf => reach rf ∧ c.holds rf) hOT (by omega) hcode_t
+        hcallees_t hcalls_t hvcs.left
+      rw [haddr1] at ht
+      have hjal := jal0_spec_pcFree (Stmt.jFwd (e.size + 1))
+        (base + BitVec.ofNat 64 (4 * (t.size + 1)))
+        (pcFree_asrtR (t.sp fun rf => reach rf ∧ c.holds rf))
+      rw [signExtend21_jFwd hofsJ, haddr2] at hjal
+      have hjal' := cpsTripleWithin_extend_code hcode_jal hjal
+      have htj := cpsTripleWithin_seq_same_cr ht hjal'
+      have he := ihe (base + BitVec.ofNat 64 (4 * (t.size + 2))) (pfx ++ lbl ++ ".e.")
+        (fun rf => reach rf ∧ ¬ c.holds rf) hOE (by omega) hcode_e
+        hcallees_e hcalls_e hvcs.right
+      rw [haddr3] at he
+      have hbr'' : cpsBranchWithin 1 base cr (asrtR reach)
+          (base + BitVec.ofNat 64 (4 * (t.size + 2)))
+            (asrtR fun rf => reach rf ∧ ¬ c.holds rf)
+          (base + 4) (asrtR fun rf => reach rf ∧ c.holds rf) := by
+        refine cpsBranchWithin_weaken (fun _ hp => hp) ?_ ?_ hbr'
+        · exact asrtR_mono (fun rf hh =>
+            ⟨hh.1, (Cond.holds_neg c rf).mp hh.2⟩)
+        · exact asrtR_mono (fun rf hh =>
+            ⟨hh.1, Decidable.of_not_not
+              (fun hcc => hh.2 ((Cond.holds_neg c rf).mpr hcc))⟩)
+      have harmE : cpsTripleWithin (max (t.steps + 1) e.steps)
+          (base + BitVec.ofNat 64 (4 * (t.size + 2)))
+          (base + BitVec.ofNat 64 (4 * (t.size + e.size + 2))) cr
+          (asrtR fun rf => reach rf ∧ ¬ c.holds rf)
+          (asrtR (Stmt.sp (.ite lbl c t e) reach)) := by
+        refine cpsTripleWithin_mono_nSteps (Nat.le_max_right _ _)
+          (cpsTripleWithin_weaken (fun _ hp => hp) ?_ he)
+        exact asrtR_mono (fun rf hsp => Or.inr hsp)
+      have harmT : cpsTripleWithin (max (t.steps + 1) e.steps)
+          (base + 4)
+          (base + BitVec.ofNat 64 (4 * (t.size + e.size + 2))) cr
+          (asrtR fun rf => reach rf ∧ c.holds rf)
+          (asrtR (Stmt.sp (.ite lbl c t e) reach)) := by
+        refine cpsTripleWithin_mono_nSteps (Nat.le_max_left _ _)
+          (cpsTripleWithin_weaken (fun _ hp => hp) ?_ htj)
+        exact asrtR_mono (fun rf hsp => Or.inl hsp)
+      exact cpsBranchWithin_merge_same_cr hbr'' harmE harmT
+  | «when» lbl c b ihb =>
+      simp only [Stmt.offsetsOk, Bool.and_eq_true, decide_eq_true_eq] at hofs
+      obtain ⟨⟨hwf, hofsB⟩, hOB⟩ := hofs
+      simp only [Stmt.size] at hsz
+      have hlenAll : 4 * ((b.flatten (base + 4)).length + 1) ≤ 2 ^ 64 := by
+        rw [Stmt.flatten_length]; omega
+      have hflat : Stmt.flatten base (.when lbl c b)
+          = (c.neg.toInstr (Stmt.brOfs (b.size + 1))) :: b.flatten (base + 4) := rfl
+      have hcode_br : ∀ a' i,
+          CodeReq.singleton base (c.neg.toInstr (Stmt.brOfs (b.size + 1))) a' = some i →
+          cr a' = some i :=
+        fun a' i h => hcode a' i (hflat ▸ ofProg_head a' i h)
+      have hcode_b : ∀ a' i,
+          CodeReq.ofProg (base + 4) (b.flatten (base + 4)) a' = some i →
+          cr a' = some i :=
+        fun a' i h => hcode a' i (hflat ▸ ofProg_cons_tail hlenAll a' i h)
+      have hbr := branch_spec_asrt c.neg (Stmt.brOfs (b.size + 1)) reach base
+        (by rw [Cond.wf_neg]; exact hwf)
+      rw [signExtend13_brOfs hofsB] at hbr
+      have hbr' := cpsBranchWithin_frameR (regOwn .x1) pcFree_regOwn
+        (cpsBranchWithin_extend_code hcode_br hbr)
+      have hb := ihb (base + 4) (pfx ++ lbl ++ ".")
+        (fun rf => reach rf ∧ c.holds rf)
+        hOB (by omega) hcode_b hcallees hcalls hvcs
+      rw [show (base + 4) + BitVec.ofNat 64 (4 * b.size)
+          = base + BitVec.ofNat 64 (4 * (b.size + 1)) from by bv_omega] at hb
+      have hskip : cpsTripleWithin b.steps
+          (base + BitVec.ofNat 64 (4 * (b.size + 1)))
+          (base + BitVec.ofNat 64 (4 * (b.size + 1))) cr
+          (asrtR fun rf => reach rf ∧ c.neg.holds rf)
+          (asrtR (Stmt.sp (.when lbl c b) reach)) := by
+        apply cpsTripleWithin_mono_nSteps (Nat.zero_le _)
+        apply cpsTripleWithin_entails
+        exact asrtR_mono (fun rf hh =>
+          Or.inr ⟨hh.1, (Cond.holds_neg c rf).mp hh.2⟩)
+      have hbody : cpsTripleWithin b.steps (base + 4)
+          (base + BitVec.ofNat 64 (4 * (b.size + 1))) cr
+          (asrtR fun rf => reach rf ∧ ¬ c.neg.holds rf)
+          (asrtR (Stmt.sp (.when lbl c b) reach)) := by
+        refine cpsTripleWithin_weaken ?_ ?_ hb
+        · exact asrtR_mono (fun rf hh =>
+            ⟨hh.1, Decidable.of_not_not
+              (fun hcc => hh.2 ((Cond.holds_neg c rf).mpr hcc))⟩)
+        · exact asrtR_mono (fun rf hsp => Or.inl hsp)
+      exact cpsBranchWithin_merge_same_cr hbr' hskip hbody
+  | «while» lbl c fuel inv b ihb =>
+      simp only [Stmt.offsetsOk, Bool.and_eq_true, decide_eq_true_eq] at hofs
+      obtain ⟨⟨⟨hwf, hofsHdr⟩, hofsBack⟩, hOB⟩ := hofs
+      simp only [Stmt.size] at hsz
+      have hInvInit : ∀ rf, reach rf → inv 0 rf := hvcs.head
+      have hInvStep : ∀ i, i < fuel →
+          ∀ rf', b.sp (fun rf => inv i rf ∧ c.holds rf) rf' → inv (i + 1) rf' :=
+        hvcs.tail.head
+      have hExhausted : ∀ rf, inv fuel rf → ¬ c.holds rf := hvcs.tail.tail.head
+      have hBodyVcs := hvcs.tail.tail.tail
+      have hlenAll : 4 * ((b.flatten (base + 4)
+          ++ [Instr.JAL Reg.x0 (Stmt.jBack (b.size + 1))]).length + 1) ≤ 2 ^ 64 := by
+        simp only [List.length_append, List.length_cons, List.length_nil,
+          Stmt.flatten_length]
+        omega
+      have hflat : Stmt.flatten base (.while lbl c fuel inv b)
+          = (c.neg.toInstr (Stmt.brOfs (b.size + 2)))
+            :: (b.flatten (base + 4) ++ [.JAL .x0 (Stmt.jBack (b.size + 1))]) := rfl
+      have hcode_br : ∀ a' i,
+          CodeReq.singleton base (c.neg.toInstr (Stmt.brOfs (b.size + 2))) a' = some i →
+          cr a' = some i :=
+        fun a' i h => hcode a' i (hflat ▸ ofProg_head a' i h)
+      have hcode_b : ∀ a' i,
+          CodeReq.ofProg (base + 4) (b.flatten (base + 4)) a' = some i →
+          cr a' = some i :=
+        fun a' i h => hcode a' i
+          (hflat ▸ ofProg_cons_tail hlenAll a' i (ofProg_mono_left a' i h))
+      have hcode_jal : ∀ a' i,
+          CodeReq.singleton ((base + 4) + BitVec.ofNat 64 (4 * b.size))
+            (.JAL .x0 (Stmt.jBack (b.size + 1))) a' = some i →
+          cr a' = some i := by
+        intro a' i h
+        apply hcode a' i
+        rw [hflat]
+        apply ofProg_cons_tail hlenAll
+        apply ofProg_mono_right (p1 := b.flatten (base + 4))
+          (by simp only [List.length_cons, List.length_nil, Stmt.flatten_length]; omega)
+        rw [Stmt.flatten_length]
+        exact ofProg_head a' i h
+      have hbodyEnd : (base + 4) + BitVec.ofNat 64 (4 * b.size)
+          = base + BitVec.ofNat 64 (4 * (b.size + 1)) := by bv_omega
+      have hheader : ∀ (r : Reach),
+          cpsBranchWithin 1 base cr (asrtR r)
+            (base + BitVec.ofNat 64 (4 * (b.size + 2)))
+              (asrtR fun rf => r rf ∧ ¬ c.holds rf)
+            (base + 4) (asrtR fun rf => r rf ∧ c.holds rf) := by
+        intro r
+        have hbr := branch_spec_asrt c.neg (Stmt.brOfs (b.size + 2)) r base
+          (by rw [Cond.wf_neg]; exact hwf)
+        rw [signExtend13_brOfs hofsHdr] at hbr
+        have hbr' := cpsBranchWithin_frameR (regOwn .x1) pcFree_regOwn
+          (cpsBranchWithin_extend_code hcode_br hbr)
+        refine cpsBranchWithin_weaken (fun _ hp => hp) ?_ ?_ hbr'
+        · exact asrtR_mono (fun rf hh =>
+            ⟨hh.1, (Cond.holds_neg c rf).mp hh.2⟩)
+        · exact asrtR_mono (fun rf hh =>
+            ⟨hh.1, Decidable.of_not_not
+              (fun hcc => hh.2 ((Cond.holds_neg c rf).mpr hcc))⟩)
+      have hbodyStep : ∀ i, i < fuel →
+          cpsTripleWithin (b.steps + 1) (base + 4) base cr
+            (asrtR fun rf => inv i rf ∧ c.holds rf)
+            (asrtR fun rf => inv (i + 1) rf) := by
+        intro i hi
+        have hb := ihb (base + 4) (pfx ++ lbl ++ ".body.")
+          (fun rf => inv i rf ∧ c.holds rf)
+          hOB (by omega) hcode_b hcallees hcalls
+          (Stmt.vcs_antitone b _ (fun rf hr => ⟨i, hi, hr.1, hr.2⟩) hBodyVcs)
+        have hjal := jal0_spec_pcFree (Stmt.jBack (b.size + 1))
+          ((base + 4) + BitVec.ofNat 64 (4 * b.size))
+          (pcFree_asrtR (b.sp fun rf => inv i rf ∧ c.holds rf))
+        rw [hbodyEnd, add_jBack base (b.size + 1) (by omega) hofsBack] at hjal
+        rw [← hbodyEnd] at hjal
+        have hjal' := cpsTripleWithin_extend_code hcode_jal hjal
+        have hseq := cpsTripleWithin_seq_same_cr hb hjal'
+        exact cpsTripleWithin_weaken (fun _ hp => hp)
+          (asrtR_mono (fun rf hsp => hInvStep i hi rf hsp)) hseq
+      have hcert : ∀ fuel' start, start + fuel' = fuel →
+          WP.loopNatCert 1 (b.steps + 1) 1 base (base + 4)
+            (base + BitVec.ofNat 64 (4 * (b.size + 2))) cr
+            (fun i => asrtR fun rf => inv i rf)
+            (fun i => asrtR fun rf => inv i rf ∧ c.holds rf)
+            (fun i => asrtR fun rf => inv i rf ∧ ¬ c.holds rf)
+            (asrtR fun rf => (∃ i, i ≤ fuel ∧ inv i rf) ∧ ¬ c.holds rf)
+            start fuel' := by
+        intro fuel'
+        induction fuel' with
+        | zero =>
+            intro start hstart
+            simp only [WP.loopNatCert]
+            have hexit : cpsTripleWithin 0
+                (base + BitVec.ofNat 64 (4 * (b.size + 2)))
+                (base + BitVec.ofNat 64 (4 * (b.size + 2))) cr
+                (asrtR fun rf => inv start rf ∧ ¬ c.holds rf)
+                (asrtR fun rf => (∃ i, i ≤ fuel ∧ inv i rf) ∧ ¬ c.holds rf) :=
+              cpsTripleWithin_entails (asrtR_mono (fun rf hh =>
+                ⟨⟨start, by omega, hh.1⟩, hh.2⟩))
+            have hsf : start = fuel := by omega
+            have hdead : cpsTripleWithin 0 (base + 4)
+                (base + BitVec.ofNat 64 (4 * (b.size + 2))) cr
+                (asrtR fun rf => inv start rf ∧ c.holds rf)
+                (asrtR fun rf => (∃ i, i ≤ fuel ∧ inv i rf) ∧ ¬ c.holds rf) :=
+              cpsTripleWithin_unreachable (asrtR_unsat (fun rf hh =>
+                hExhausted rf (hsf ▸ hh.1) hh.2))
+            exact cpsBranchWithin_merge_same_cr
+              (cpsBranchWithin_swap (hheader (fun rf => inv start rf))) hdead hexit
+        | succ fuel' ih =>
+            intro start hstart
+            refine ⟨cpsBranchWithin_swap (hheader (fun rf => inv start rf)),
+              hbodyStep start (by omega), ?_, ih (start + 1) (by omega)⟩
+            exact asrtR_mono (fun rf hh => ⟨⟨start, by omega, hh.1⟩, hh.2⟩)
+      have hsound := WP.loopNatCert_sound (hcert fuel 0 (by omega))
+      exact cpsTripleWithin_weaken
+        (asrtR_mono (fun rf hr => hInvInit rf hr))
+        (fun _ hp => hp)
+        hsound
+  | call lbl f =>
+      obtain ⟨hoffset, halign, hnotself⟩ := hcalls
+      have hpreVC : ∀ rf, reach rf → f.pre rf := hvcs _ (List.mem_singleton_self _)
+      -- callee triple, retargeted at the aligned return address
+      have hret' : cpsTripleWithin f.nSteps f.entry ((base + 4) &&& ~~~(1 : Word))
+          f.code
+          ((.x1 ↦ᵣ (base + 4)) ** asrtOf f.pre)
+          ((.x1 ↦ᵣ (base + 4)) ** asrtOf f.post) := by
+        rw [halign]
+        exact f.sound (base + 4) halign
+      have hdisj : (CodeReq.singleton base
+          (.JAL .x1 (BitVec.setWidth 21 (f.entry - base)))).Disjoint f.code := by
+        intro a
+        by_cases ha : a = base
+        · subst ha
+          exact Or.inr hnotself
+        · left
+          simp [CodeReq.singleton, ha]
+      have hmono : ∀ a i,
+          ((CodeReq.singleton base
+            (.JAL .x1 (BitVec.setWidth 21 (f.entry - base)))).union f.code) a = some i →
+          cr a = some i := by
+        intro a i h
+        simp only [CodeReq.union] at h
+        cases hs : CodeReq.singleton base
+            (.JAL .x1 (BitVec.setWidth 21 (f.entry - base))) a with
+        | none =>
+            rw [hs] at h
+            exact hcallees a i h
+        | some j =>
+            rw [hs] at h
+            apply hcode a i
+            rw [show Stmt.flatten base (.call lbl f)
+              = [.JAL .x1 (BitVec.setWidth 21 (f.entry - base))] from rfl,
+              CodeReq.ofProg_singleton]
+            rw [hs]
+            exact h
+      -- the framed call triple, for each old value of ra
+      have hcall : ∀ vOld : Word,
+          cpsTripleWithin (1 + f.nSteps) base (base + 4) cr
+            ((asrtOf f.pre) ** (.x1 ↦ᵣ vOld))
+            ((asrtOf (Stmt.sp (.call lbl f) reach)) ** regOwn .x1) := by
+        intro vOld
+        have h := WP.cpsCallWithin (vOld := vOld)
+          (BitVec.setWidth 21 (f.entry - base)) hoffset halign
+          (pcFree_asrtOf f.pre) hdisj hret'
+        have h' := cpsTripleWithin_extend_code hmono h
+        refine cpsTripleWithin_weaken ?_ ?_ h'
+        · intro hp hh
+          rw [sepConj_comm'] at hh
+          exact hh
+        · intro hp hh
+          rw [sepConj_comm' (.x1 ↦ᵣ (base + 4))] at hh
+          exact sepConj_mono_right (fun hq hx => ⟨base + 4, hx⟩) hp hh
+      -- assemble: eliminate the unknown ra value, weaken the entry reach
+      have hfinal : cpsTripleWithin (1 + f.nSteps) base (base + 4) cr
+          (asrtR reach) (asrtR (Stmt.sp (.call lbl f) reach)) := by
+        refine cpsTripleWithin_weaken
+          (sepConj_mono_left (fun hq hh => by
+            obtain ⟨rf, hrf, hr⟩ := hh
+            exact ⟨rf, hrf, hpreVC rf hr⟩))
+          (fun _ hp => hp)
+          (cpsTripleWithin_regOwn_right_pre hcall)
+      simp only [Stmt.steps, Stmt.size, Nat.mul_one]
+      have h4 : base + BitVec.ofNat 64 4 = base + 4 := rfl
+      rw [h4]
+      exact hfinal
+
+end SAsm
+end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/Tactic.lean
+++ b/EvmAsm/Rv64/SAsm/Tactic.lean
@@ -99,23 +99,34 @@ private partial def vcCases (g : MVarId) : MetaM (List MVarId) := do
     verification condition.  Decidable bookkeeping VCs are closed with
     `decide`; the remaining goals carry their path labels as case names. -/
 elab "vcgen" : tactic => do
-  evalTactic (← `(tactic| refine EvmAsm.Rv64.SAsm.Fn.sound _ _ ?_))
-  let g ← getMainGoal
-  let gs ← vcCases g
-  -- Auto-discharge decidable bookkeeping goals (kernel `decide`; free
-  -- variables are fine because the checked terms reduce them away).
-  let mut remaining : List MVarId := []
+  let tgt ← getMainTarget
+  if tgt.isAppOf ``Fn.SpecR then
+    -- Caller-shaped goal: code/callee containment and call-site address
+    -- side conditions become their own named goals.
+    evalTactic (← `(tactic|
+      refine EvmAsm.Rv64.SAsm.Fn.soundR _ _ _ ?code ?callees ?calls ?_))
+  else
+    evalTactic (← `(tactic| refine EvmAsm.Rv64.SAsm.Fn.sound _ _ ?_))
+  let gs ← getGoals
+  let mut out : List MVarId := []
   for g in gs do
-    let closed ← g.withContext do
-      try
-        let prf ← mkDecideProof (← g.getType)
-        g.assign prf
-        Pure.pure true
-      catch _ =>
-        Pure.pure false
-    unless closed do
-      remaining := remaining ++ [g]
-  replaceMainGoal remaining
+    if (← g.getType).isAppOfArity ``VCs.Hold 1 then
+      -- Split the VC list; auto-discharge decidable bookkeeping goals
+      -- (kernel `decide`; free variables are fine because the checked
+      -- terms reduce them away).
+      for g' in ← vcCases g do
+        let closed ← g'.withContext do
+          try
+            let prf ← mkDecideProof (← g'.getType)
+            g'.assign prf
+            Pure.pure true
+          catch _ =>
+            Pure.pure false
+        unless closed do
+          out := out ++ [g']
+    else
+      out := out ++ [g]
+  replaceMainGoal out
 
 end SAsm
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/Vc.lean
+++ b/EvmAsm/Rv64/SAsm/Vc.lean
@@ -73,33 +73,14 @@ theorem Hold.append_intro {v₁ v₂ : List VC}
 end VCs
 
 -- ============================================================================
--- Reachable sets and their assertion embedding
--- ============================================================================
-
-/-- A set of register files: the pure abstraction of the machine state
-    between SAsm nodes. -/
-def Reach := RegFile → Prop
-
-/-- Embed a reachable set as an assertion: some register file in the set
-    owns the exposed registers. -/
-def asrtOf (reach : Reach) : Assertion :=
-  fun h => ∃ rf, regFileIs rf h ∧ reach rf
-
-theorem pcFree_asrtOf (reach : Reach) : (asrtOf reach).pcFree := by
-  intro h hp
-  obtain ⟨rf, hrf, -⟩ := hp
-  rw [hrf]
-  rfl
-
--- ============================================================================
 -- The reachable-set transformer
 -- ============================================================================
 
 namespace Stmt
 
 /-- Strongest-postcondition transformer over the exposed register file.
-    `call` is completed in Milestone M4; until then its `vcs` emit an
-    unprovable labeled goal, so the transformer's value is irrelevant. -/
+    A `call` replaces the reachable set by the callee's postcondition (the
+    callee owns the whole exposed file; ghost data relates them). -/
 def sp : Stmt → Reach → Reach
   | block _ is, reach => fun rf' => ∃ rf, reach rf ∧ rf' = execBlock rf is
   | seq a b, reach => b.sp (a.sp reach)
@@ -111,7 +92,7 @@ def sp : Stmt → Reach → Reach
   | assert _ P, reach => fun rf => reach rf ∧ P rf
   | «while» _ c fuel inv _, _ =>
       fun rf => (∃ i, i ≤ fuel ∧ inv i rf) ∧ ¬ c.holds rf
-  | call _ _, _ => fun _ => False
+  | call _ f, _ => fun rf => f.post rf
 
 /-- Labeled verification conditions of a statement, given the reachable set
     at its entry.  `pfx` is the path prefix for labels. -/
@@ -134,8 +115,8 @@ def vcs : Stmt → String → Reach → List VC
       ⟨pfx ++ lbl ++ ".exhausted", ∀ rf, inv fuel rf → ¬ c.holds rf⟩ ::
       b.vcs (pfx ++ lbl ++ ".body.")
         (fun rf => ∃ i, i < fuel ∧ inv i rf ∧ c.holds rf)
-  | call lbl _, pfx, _ =>
-      [⟨pfx ++ lbl ++ ".call_unsupported_until_M4", False⟩]
+  | call lbl f, pfx, reach =>
+      [⟨pfx ++ lbl ++ ".pre", ∀ rf, reach rf → f.pre rf⟩]
 
 /-- Exact step bound of a statement (docs/sasm-design.md §3.5; the loop bound
     is `WP.loopBound`). -/
@@ -146,7 +127,7 @@ def steps : Stmt → Nat
   | when _ _ b => 1 + b.steps
   | assert _ _ => 0
   | «while» _ _ fuel _ b => WP.loopBound 1 (b.steps + 1) 1 fuel
-  | call _ _ => 0
+  | call _ f => 1 + f.nSteps
 
 /-- `sp` is monotone in the reachable set. -/
 theorem sp_mono (s : Stmt) {r₁ r₂ : Reach} (h : ∀ rf, r₁ rf → r₂ rf) :
@@ -169,8 +150,8 @@ theorem sp_mono (s : Stmt) {r₁ r₂ : Reach} (h : ∀ rf, r₁ rf → r₂ rf)
       exact fun rf hr => ⟨h rf hr.1, hr.2⟩
   | «while» lbl c fuel inv b ihb =>
       exact fun rf hr => hr
-  | call lbl callee =>
-      exact fun rf hr => hr.elim
+  | call lbl f =>
+      exact fun rf hr => hr
 
 /-- `vcs` is antitone in the reachable set: obligations proven for a larger
     reachable set cover any smaller one.  Used to specialize loop-body VCs
@@ -209,8 +190,24 @@ theorem vcs_antitone (s : Stmt) (pfx : String) {r₁ r₂ : Reach}
       · exact hvcs.tail.head
       · exact hvcs.tail.tail.head
       · exact hvcs.tail.tail.tail vc hvc
-  | call lbl callee =>
-      exact fun vc hvc => hvcs vc (by simpa [vcs] using hvc)
+  | call lbl f =>
+      intro vc hvc
+      simp only [vcs, List.mem_singleton] at hvc
+      subst hvc
+      exact fun rf hr => hvcs.head rf (h rf hr)
+
+/-- The callee code of every call site is contained in `cr`.  Stated
+    structurally (rather than as a union of `CodeReq`s) so sub-statement
+    obligations project out without overlap side conditions. -/
+def CalleesIn (s : Stmt) (cr : CodeReq) : Prop :=
+  match s with
+  | block _ _ => True
+  | seq a b => a.CalleesIn cr ∧ b.CalleesIn cr
+  | ite _ _ t e => t.CalleesIn cr ∧ e.CalleesIn cr
+  | when _ _ b => b.CalleesIn cr
+  | assert _ _ => True
+  | «while» _ _ _ _ b => b.CalleesIn cr
+  | call _ f => ∀ a i, f.code a = some i → cr a = some i
 
 end Stmt
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2467,9 +2467,12 @@ and a `vcgen` tactic that reduces a function spec to labeled *pure* VCs via a
 structurally-recursive generator + one generic soundness theorem (recursion-
 safe by construction). Milestones M1–M5 in the design doc; M1 = AST +
 flattener, M2 = block symbolic engine + soundness, M3 = structural soundness
-+ `vcgen`, M4 = calls, M5 = mutable regions + RLP-style demo. **M1–M3 done**
-(2026-07-01): AST/flattener, block engine + soundness, generic Stmt.sound,
-Fn + vcgen, end-to-end demos (clampFn, countFn) axiom-clean.
++ `vcgen`, M4 = calls, M5 = mutable regions + RLP-style demo. **M1–M4 done**
+(M1–M3 2026-07-01, M4 2026-07-02): AST/flattener, block engine + soundness,
+generic Stmt.sound, Fn + vcgen, verified calls (FnHandle in the AST,
+caller-shaped Stmt.soundR/Fn.SpecR via cpsCallWithin, Fn.toHandle leaf
+packaging, caller demo). Remaining: M5 (.ro loads → .rw regions, RLP demo);
+multi-level call trees need the ra-spill prologue (M5 stack memory).
 
 ## Stateless Guest (parallel STF track)
 


### PR DESCRIPTION
## Summary

Milestone M4 of the SAsm DSL ([design](docs/sasm-design.md) §3.6, follow-up to #9636): **verified calls in the C-like ABI**.

- **`FnHandle`** — the caller-facing interface of a verified routine (entry, code, step bound, pre/post over the exposed register file, and a ∀-return-address soundness field). Carried directly in the `Stmt.call` node, so `sp`/`vcs`/`steps` stay self-contained; a call site generates exactly one labeled `.pre` VC and continues with the callee's postcondition.
- **`Stmt.soundR`** — caller-shaped soundness: the triple carries `regOwn x1` (`asrtR reach := asrtOf reach ** regOwn .x1`), so the `call` case composes via the existing `WP.cpsCallWithin`. Leaf cases delegate to the M3 theorem plus framing; JAL-offset/alignment/self-overlap side conditions are collected by the address-aware `callsOk`, callee-code containment by the structural `CalleesIn` — still zero manual disjointness anywhere.
- **`Fn.SpecR`/`Fn.soundR`** — caller-shaped function specs; `vcgen` dispatches on the goal head and names the `code`/`callees`/`calls` side goals alongside the per-VC goals.
- **`Fn.toHandle`** — packages a verified *call-free* function (its `Spec` + the `jalr x0, ra, 0` epilogue via `jalr_ret_spec`) as a callee handle. The M3 leaf theorem now takes `callFree` (surfaced through the auto-discharged `.flat` VC), which is what makes the ra-invariance of leaves available for packaging.
- **Demo** (`ExamplesVc.lean`): `clampFn` verified, packaged as a handle at `0x2000`, called from `callerFn` at `0x1000`; `a0 = min(5,7)` proven end to end through `vcgen`.

Multi-level call trees (callers that are themselves callees) need the ra-spill prologue, which arrives with `.rw` stack memory in M5, as documented in the design.

## Test plan
- `lake build EvmAsm.Rv64` green (1281 jobs)
- `#print axioms` on `Stmt.soundR`, `callerFn_spec` → `propext, Classical.choice, Quot.sound` only
- `scripts/check-forbidden-tactics.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)