### PR TITLE
SAsm M5a: read-only byte regions — loads in the block engine, region-carrying soundness, RLP demo

### DIFF
--- a/EvmAsm/Rv64/SAsm.lean
+++ b/EvmAsm/Rv64/SAsm.lean
@@ -10,6 +10,7 @@ import EvmAsm.Rv64.SAsm.Ast
 import EvmAsm.Rv64.SAsm.Flatten
 import EvmAsm.Rv64.SAsm.Sym
 import EvmAsm.Rv64.SAsm.RegFileSep
+import EvmAsm.Rv64.SAsm.RegionSound
 import EvmAsm.Rv64.SAsm.BlockSound
 import EvmAsm.Rv64.SAsm.Vc
 import EvmAsm.Rv64.SAsm.CtrlSpecs

--- a/EvmAsm/Rv64/SAsm/BlockSound.lean
+++ b/EvmAsm/Rv64/SAsm/BlockSound.lean
@@ -39,10 +39,10 @@ theorem aluSem_agree {i : Instr} {op : AluOp} (h : aluSem i = some op) :
   cases i <;> simp only [aluSem, reduceCtorEq] at h <;>
     (injection h with h; subst h; intro g g' hgg;
      simp only [List.forall_mem_cons] at hgg;
-     dsimp only;
-     (try rw [hgg.1]);
-     (try rw [hgg.2.1]);
-     all_goals rfl)
+     first
+       | (dsimp only; rw [hgg.1, hgg.2.1])
+       | (dsimp only; rw [hgg.1])
+       | dsimp only)
 
 /-- Classified instructions are not ECALL/EBREAK and touch no memory, so they
     step via `execInstrBr`. -/

--- a/EvmAsm/Rv64/SAsm/BlockSound.lean
+++ b/EvmAsm/Rv64/SAsm/BlockSound.lean
@@ -17,6 +17,7 @@
 import EvmAsm.Rv64.CPSSpec
 import EvmAsm.Rv64.SAsm.Sym
 import EvmAsm.Rv64.SAsm.RegFileSep
+import EvmAsm.Rv64.SAsm.RegionSound
 
 namespace EvmAsm.Rv64
 namespace SAsm
@@ -83,31 +84,53 @@ theorem regFile_alu_spec_within (i : Instr) (op : AluOp) (rf : RegFile) (base : 
       rw [hx0', RegFile.set_x0]
       exact holdsFor_pcFree_setPC (pcFree_sepConj (pcFree_regFileIs rf) hR) hPR
 
-/-- Single-instruction spec, dispatched through `instrOk`/`execInstrRF`. -/
-theorem execInstrRF_sound {i : Instr} (hok : instrOk i = true)
-    (rf : RegFile) (base : Word) :
+/-- Single-instruction spec, dispatched through `instrOk`/`execInstrRF`:
+    ALU instructions leave the region framed; loads read from it. -/
+theorem execInstrRF_sound {i : Instr} (reg : Region) (hreg : reg.wf)
+    (hok : instrOk i = true)
+    (rf : RegFile) (base : Word)
+    (hvc : match loadSem i with
+      | some l =>
+          ((rf.get l.rs1 + signExtend12 l.ofs) - reg.base).toNat
+            < reg.bytes.length
+      | none => True) :
     cpsTripleWithin 1 base (base + 4) (CodeReq.singleton base i)
-      (regFileIs rf) (regFileIs (execInstrRF rf i)) := by
+      ((regFileIs rf) ** bytesRegion reg.base reg.bytes)
+      ((regFileIs (execInstrRF reg rf i)) ** bytesRegion reg.base reg.bytes) := by
   cases hsem : aluSem i with
-  | none => simp [instrOk, hsem] at hok
+  | none =>
+      cases hload : loadSem i with
+      | none => simp [instrOk, hsem, hload] at hok
+      | some l =>
+          simp only [instrOk, hsem, hload, Bool.and_eq_true] at hok
+          simp only [hload] at hvc
+          simp only [execInstrRF, hsem, hload]
+          exact regFile_load_spec_within i l reg rf base hload hreg
+            hok.1 hok.2 hvc
   | some op =>
       simp only [instrOk, hsem, Bool.and_eq_true] at hok
       obtain ⟨hrd, hsrcs⟩ := hok
       simp only [execInstrRF, hsem]
-      exact regFile_alu_spec_within i op rf base hsem hrd
-        (fun r hr => by
-          have := List.all_eq_true.mp hsrcs r hr
-          simpa using this)
+      exact cpsTripleWithin_frameR (bytesRegion reg.base reg.bytes)
+        (bytesRegion_pcFree _ _)
+        (regFile_alu_spec_within i op rf base hsem hrd
+          (fun r hr => by
+            have := List.all_eq_true.mp hsrcs r hr
+            simpa using this))
 
 /-- Block soundness: a supported straight-line block satisfies a bounded CPS
     triple under its own `CodeReq.ofProg`, moving the exposed register file
     to its symbolic image.  `hlen` rules out address wrap-around (any real
     block is vastly shorter). -/
-theorem execBlock_sound (instrs : List Instr) (rf : RegFile) (base : Word)
-    (hok : blockOk instrs = true) (hlen : 4 * instrs.length < 2 ^ 64) :
+theorem execBlock_sound (reg : Region) (instrs : List Instr) (rf : RegFile)
+    (base : Word)
+    (hreg : reg.wf) (hok : blockOk instrs = true)
+    (hvcs : blockVCs reg rf instrs)
+    (hlen : 4 * instrs.length < 2 ^ 64) :
     cpsTripleWithin instrs.length base (base + BitVec.ofNat 64 (4 * instrs.length))
       (CodeReq.ofProg base instrs)
-      (regFileIs rf) (regFileIs (execBlock rf instrs)) := by
+      ((regFileIs rf) ** bytesRegion reg.base reg.bytes)
+      ((regFileIs (execBlock reg rf instrs)) ** bytesRegion reg.base reg.bytes) := by
   induction instrs generalizing rf base with
   | nil =>
       intro R hR s hcr hPR hpc
@@ -116,10 +139,11 @@ theorem execBlock_sound (instrs : List Instr) (rf : RegFile) (base : Word)
   | cons i rest ih =>
       simp only [blockOk, List.all_cons, Bool.and_eq_true] at hok
       obtain ⟨hoki, hokr⟩ := hok
+      obtain ⟨hvc1, hvcr⟩ := hvcs
       have hlenr : 4 * rest.length < 2 ^ 64 := by
         simp only [List.length_cons] at hlen; omega
-      have h1 := execInstrRF_sound hoki rf base
-      have h2 := ih (execInstrRF rf i) (base + 4) hokr hlenr
+      have h1 := execInstrRF_sound reg hreg hoki rf base hvc1
+      have h2 := ih (execInstrRF reg rf i) (base + 4) hokr hvcr hlenr
       have hd : (CodeReq.singleton base i).Disjoint
           (CodeReq.ofProg (base + 4) rest) := by
         intro a

--- a/EvmAsm/Rv64/SAsm/ExamplesVc.lean
+++ b/EvmAsm/Rv64/SAsm/ExamplesVc.lean
@@ -120,7 +120,7 @@ theorem callerFn_spec : callerFn.SpecR 0x1000 callerCr := by
     intro a i h
     simp only [callerCr, CodeReq.union, h]
   case callees =>
-    refine ⟨trivial, ?_⟩
+    refine ⟨trivial, ?_, rfl⟩
     intro a i h
     obtain ⟨k, hk, rfl⟩ := ofProg_some_range h
     have hlen : ((clampFn 5 7).programRet 0x2000).length = 3 := by decide
@@ -147,6 +147,89 @@ theorem callerFn_spec : callerFn.SpecR 0x1000 callerCr := by
     show rf.get .x10 = 5
     have h' : rf.get .x10 = (if BitVec.ult 5 7 then (5 : Word) else 7) := h.1
     rw [h', if_pos (by decide)]
+
+-- ============================================================================
+-- Read-only regions (Milestone M5a): RLP prefix classification
+-- ============================================================================
+
+/-- Classify the first byte of an RLP input: `a0 := 0` if the item is not a
+    list (first byte `< 0xc0`), else `1`.  The input buffer is a *ghost*
+    byte list `bs` at `inBase` — the check-heavy RLP decoding shape. -/
+def rlpIsListFn (inBase : Word) (bs : List (BitVec 8)) : Fn where
+  name := "rlpIsList"
+  region := ⟨inBase, bs⟩
+  pre := fun rf => rf.get .x10 = inBase ∧ bs ≠ []
+  post := fun rf =>
+    rf.get .x10 = (if (bs.headD 0).toNat < 0xc0 then 0 else 1)
+  body :=
+    .block "load" [.LBU .x5 .x10 0, .LI .x6 0xc0] ;;;
+    .ite "classify" (.bltu .x5 .x6)
+      (.block "notList" [.LI .x10 0])
+      (.block "isList" [.LI .x10 1])
+
+theorem rlpIsListFn_spec (inBase : Word) (bs : List (BitVec 8))
+    (hwf : (Region.mk inBase bs).wf) (base : Word) :
+    (rlpIsListFn inBase bs).Spec base := by
+  have haddr : ∀ rf : RegFile, rf.get .x10 = inBase →
+      ((rf.get .x10 + signExtend12 (0 : BitVec 12)) - inBase).toNat = 0 := by
+    intro rf h
+    rw [h, show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]
+    bv_omega
+  vcgen
+  case region => exact hwf
+  case rlpIsList.load.mem =>
+    rintro rf ⟨hx10, hne⟩
+    refine ⟨?_, trivial, trivial⟩
+    show ((rf.get .x10 + signExtend12 (0 : BitVec 12))
+      - (rlpIsListFn inBase bs).region.base).toNat
+      < (rlpIsListFn inBase bs).region.bytes.length
+    rw [show (rlpIsListFn inBase bs).region = Region.mk inBase bs from rfl]
+    rw [haddr rf hx10]
+    exact List.length_pos_iff.mpr hne
+  case rlpIsList.post =>
+    intro rf' h
+    show rf'.get .x10 = (if (bs.headD 0).toNat < 0xc0 then 0 else 1)
+    obtain ⟨b, tl, rfl⟩ : ∃ b tl, bs = b :: tl := by
+      rcases h with ⟨rf₀, ⟨⟨rf₁, ⟨-, hne⟩, -⟩, -⟩, -⟩ | ⟨rf₀, ⟨⟨rf₁, ⟨-, hne⟩, -⟩, -⟩, -⟩ <;>
+        (cases bs with
+         | nil => exact absurd rfl hne
+         | cons b tl => exact ⟨b, tl, rfl⟩)
+    have hz : (BitVec.zeroExtend 64 b).toNat = b.toNat := by
+      have hb := b.isLt
+      rw [show BitVec.zeroExtend 64 b = BitVec.setWidth 64 b from rfl,
+        BitVec.toNat_setWidth]
+      omega
+    have hult : (BitVec.zeroExtend 64 b).ult (0xc0 : Word) = true ↔ b.toNat < 0xc0 := by
+      simp only [BitVec.ult, BitVec.ofNat_eq_ofNat, BitVec.toNat_ofNat,
+        decide_eq_true_eq, hz]
+    have hbyte : ∀ rf₀ : RegFile, rf₀.get .x10 = inBase →
+        (rlpIsListFn inBase (b :: tl)).region.byteAt
+          (rf₀.get .x10 + signExtend12 (0 : BitVec 12)) = b := by
+      intro rf₀ h₀
+      show Region.byteAt (Region.mk inBase (b :: tl)) _ = b
+      unfold Region.byteAt
+      rw [haddr rf₀ h₀]
+      rfl
+    rcases h with ⟨rf₀, ⟨⟨rf₁, ⟨hx10, -⟩, rfl⟩, hcond⟩, rfl⟩
+                | ⟨rf₀, ⟨⟨rf₁, ⟨hx10, -⟩, rfl⟩, hcond⟩, rfl⟩
+    · -- not a list: b <u 0xc0
+      simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem, loadSem,
+        Cond.holds, List.headD_cons] at hcond ⊢
+      rw [RegFile.get_set_self _ .x10 _ (by decide)]
+      rw [RegFile.get_set_ne _ .x6 .x5 _ (by decide),
+        RegFile.get_set_self _ .x5 _ (by decide),
+        RegFile.get_set_self _ .x6 _ (by decide),
+        hbyte rf₁ hx10] at hcond
+      rw [if_pos (hult.mp hcond)]
+    · -- a list: ¬ (b <u 0xc0)
+      simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem, loadSem,
+        Cond.holds, List.headD_cons] at hcond ⊢
+      rw [RegFile.get_set_self _ .x10 _ (by decide)]
+      rw [RegFile.get_set_ne _ .x6 .x5 _ (by decide),
+        RegFile.get_set_self _ .x5 _ (by decide),
+        RegFile.get_set_self _ .x6 _ (by decide),
+        hbyte rf₁ hx10] at hcond
+      rw [if_neg (fun hlt => hcond (hult.mpr hlt))]
 
 end ExamplesVc
 end SAsm

--- a/EvmAsm/Rv64/SAsm/Fn.lean
+++ b/EvmAsm/Rv64/SAsm/Fn.lean
@@ -27,6 +27,9 @@ structure Fn where
   pre : Reach
   post : Reach
   body : Stmt
+  /-- The function's read-only byte region (`Region.empty` when no memory
+      is touched). -/
+  region : Region := Region.empty
 
 namespace Fn
 
@@ -44,7 +47,7 @@ def codeReq (f : Fn) (base : Word) : CodeReq :=
     `body.steps` machine steps. -/
 def Spec (f : Fn) (base : Word) : Prop :=
   cpsTripleWithin f.body.steps base (base + BitVec.ofNat 64 (4 * f.body.size))
-    (f.codeReq base) (asrtOf f.pre) (asrtOf f.post)
+    (f.codeReq base) (asrtM f.region f.pre) (asrtM f.region f.post)
 
 /-- The function's labeled verification conditions:
     - `<name>.flat`: offsets fit and the code does not wrap (decidable;
@@ -54,19 +57,19 @@ def Spec (f : Fn) (base : Word) : Prop :=
 def vcs (f : Fn) : List VC :=
   ⟨f.name ++ ".flat", f.body.callFree = true ∧ f.body.offsetsOk = true
       ∧ 4 * f.body.size < 2 ^ 64⟩ ::
-  (f.body.vcs (f.name ++ ".") f.pre ++
-   [⟨f.name ++ ".post", ∀ rf, f.body.sp f.pre rf → f.post rf⟩])
+  (Stmt.vcs f.region f.body (f.name ++ ".") f.pre ++
+   [⟨f.name ++ ".post",
+      ∀ rf, Stmt.sp f.region f.body f.pre rf → f.post rf⟩])
 
 /-- Soundness: the labeled pure VCs imply the CPS triple. -/
-theorem sound (f : Fn) (base : Word) (h : VCs.Hold f.vcs) : f.Spec base := by
+theorem sound (f : Fn) (base : Word) (hreg : f.region.wf)
+    (h : VCs.Hold f.vcs) : f.Spec base := by
   have hflat := h.head
-  have hbody := Stmt.sound f.body base (f.name ++ ".") f.pre
+  have hbody := Stmt.sound f.region f.body base (f.name ++ ".") f.pre hreg
     hflat.1 hflat.2.1 hflat.2.2 (fun _ _ hc => hc) h.tail.left
   have hpost := h.tail.right.head
   exact cpsTripleWithin_weaken (fun _ hp => hp)
-    (fun hp hh => by
-      obtain ⟨rf, hrf, hsp⟩ := hh
-      exact ⟨rf, hrf, hpost rf hsp⟩)
+    (asrtM_mono (fun rf hsp => hpost rf hsp))
     hbody
 
 -- ============================================================================
@@ -78,25 +81,27 @@ theorem sound (f : Fn) (base : Word) (h : VCs.Hold f.vcs) : f.Spec base := by
     that must contain the body's code and every callee's code. -/
 def SpecR (f : Fn) (base : Word) (cr : CodeReq) : Prop :=
   cpsTripleWithin f.body.steps base (base + BitVec.ofNat 64 (4 * f.body.size))
-    cr (asrtR f.pre) (asrtR f.post)
+    cr (asrtR f.region f.pre) (asrtR f.region f.post)
 
 /-- VCs of a caller-shaped function (no `callFree` requirement). -/
 def vcsR (f : Fn) : List VC :=
   ⟨f.name ++ ".flat", f.body.offsetsOk = true ∧ 4 * f.body.size < 2 ^ 64⟩ ::
-  (f.body.vcs (f.name ++ ".") f.pre ++
-   [⟨f.name ++ ".post", ∀ rf, f.body.sp f.pre rf → f.post rf⟩])
+  (Stmt.vcs f.region f.body (f.name ++ ".") f.pre ++
+   [⟨f.name ++ ".post",
+      ∀ rf, Stmt.sp f.region f.body f.pre rf → f.post rf⟩])
 
 /-- Caller-shaped soundness.  `hcode`/`hcallees` locate the body's and the
     callees' code inside `cr`; `hcalls` are the call sites' address side
     conditions (`decide`/`bv_omega` for concrete or relative layouts). -/
 theorem soundR (f : Fn) (base : Word) (cr : CodeReq)
+    (hreg : f.region.wf)
     (hcode : ∀ a i, CodeReq.ofProg base (f.body.flatten base) a = some i →
       cr a = some i)
-    (hcallees : f.body.CalleesIn cr)
+    (hcallees : f.body.CalleesIn f.region cr)
     (hcalls : f.body.callsOk base)
     (h : VCs.Hold f.vcsR) : f.SpecR base cr := by
   have hflat := h.head
-  have hbody := Stmt.soundR f.body base (f.name ++ ".") f.pre
+  have hbody := Stmt.soundR f.region f.body base (f.name ++ ".") f.pre hreg
     hflat.1 hflat.2 hcode hcallees hcalls h.tail.left
   have hpost := h.tail.right.head
   exact cpsTripleWithin_weaken (fun _ hp => hp)
@@ -145,18 +150,18 @@ theorem retSpec (f : Fn) (base : Word) (hspec : f.Spec base)
     ∀ ret : Word, (ret &&& ~~~(1 : Word)) = ret →
       cpsTripleWithin (f.body.steps + 1) base ret
         (CodeReq.ofProg base (f.programRet base))
-        ((.x1 ↦ᵣ ret) ** asrtOf f.pre)
-        ((.x1 ↦ᵣ ret) ** asrtOf f.post) := by
+        ((.x1 ↦ᵣ ret) ** asrtM f.region f.pre)
+        ((.x1 ↦ᵣ ret) ** asrtM f.region f.post) := by
   intro ret halign
   have hla : (f.body.flatten base).length = f.body.size := Stmt.flatten_length ..
   -- body triple, framed with the untouched return address
   have h1 := cpsTripleWithin_frameR (.x1 ↦ᵣ ret) (by pcFree) hspec
-  rw [sepConj_comm' (asrtOf f.pre), sepConj_comm' (asrtOf f.post)] at h1
+  rw [sepConj_comm' (asrtM f.region f.pre), sepConj_comm' (asrtM f.region f.post)] at h1
   have h1' := cpsTripleWithin_extend_code
     (ofProg_mono_left (p2 := [.JALR .x0 .x1 0])) h1
   -- return epilogue
   have h2 := jalr_ret_spec (base + BitVec.ofNat 64 (4 * f.body.size)) ret halign
-    (pcFree_asrtOf f.post)
+    (pcFree_asrtM f.region f.post)
   have h2' := cpsTripleWithin_extend_code
     (fun a i h => ofProg_mono_right (p1 := f.body.flatten base)
       (p2 := [.JALR .x0 .x1 0])
@@ -171,6 +176,7 @@ def toHandle (f : Fn) (base : Word) (hspec : f.Spec base)
   entry := base
   code := CodeReq.ofProg base (f.programRet base)
   nSteps := f.body.steps + 1
+  region := f.region
   pre := f.pre
   post := f.post
   sound := f.retSpec base hspec hsz

--- a/EvmAsm/Rv64/SAsm/Handle.lean
+++ b/EvmAsm/Rv64/SAsm/Handle.lean
@@ -14,7 +14,7 @@
 -/
 
 import EvmAsm.Rv64.CPSSpec
-import EvmAsm.Rv64.SAsm.RegFileSep
+import EvmAsm.Rv64.SAsm.RegionSound
 
 namespace EvmAsm.Rv64
 namespace SAsm
@@ -27,12 +27,13 @@ structure FnHandle where
   entry : Word
   code : CodeReq
   nSteps : Nat
+  region : Region
   pre : Reach
   post : Reach
   sound : ∀ ret : Word, (ret &&& ~~~(1 : Word)) = ret →
     cpsTripleWithin nSteps entry ret code
-      ((.x1 ↦ᵣ ret) ** asrtOf pre)
-      ((.x1 ↦ᵣ ret) ** asrtOf post)
+      ((.x1 ↦ᵣ ret) ** asrtM region pre)
+      ((.x1 ↦ᵣ ret) ** asrtM region post)
 
 /-- A stub handle with an unsatisfiable precondition: lets `Stmt` values
     mention a routine that is not verified yet.  Any call to it generates
@@ -41,14 +42,14 @@ def FnHandle.stub (entry : Word) : FnHandle where
   entry := entry
   code := CodeReq.empty
   nSteps := 0
+  region := Region.empty
   pre := fun _ => False
   post := fun _ => True
   sound := by
     intro ret _ R hR s hcr hPR hpc
-    exact absurd hPR (by
-      rintro ⟨hp, -, h1, -, -, -, hP1, -⟩
-      obtain ⟨-, -, -, -, -, ⟨rf, -, hfalse⟩⟩ := hP1
-      exact hfalse)
+    obtain ⟨hp, hcompat, h1, h2, hd, hu, hP1, hR2⟩ := hPR
+    obtain ⟨h1a, h1b, hd1, hu1, hx1, hM⟩ := hP1
+    exact (asrtM_unsat (fun _ hf => hf) h1b hM).elim
 
 end SAsm
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/RegionSound.lean
+++ b/EvmAsm/Rv64/SAsm/RegionSound.lean
@@ -1,0 +1,137 @@
+/-
+  EvmAsm.Rv64.SAsm.RegionSound
+
+  Soundness of byte loads from the SAsm read-only region: a supported load
+  (`LBU`/`LB`) at regFileIs granularity reads exactly the region byte the
+  pure engine (`Region.byteAt`) computes, leaving the `bytesRegion`
+  assertion untouched.
+
+  The bridge from the dword-packed memory model is
+  `holdsFor_bytesRegion_getByte`, built on `bytesRegion_dword_at` and the
+  `extractByte`/`packBytes` algebra (EvmAsm.Rv64.MemRegion / ByteOps).
+-/
+
+import EvmAsm.Rv64.MemRegion
+import EvmAsm.Rv64.SAsm.Sym
+import EvmAsm.Rv64.SAsm.RegFileSep
+
+namespace EvmAsm.Rv64
+namespace SAsm
+
+private theorem sepConj_left_comm (A B C : Assertion) :
+    (A ** (B ** C)) = (B ** (A ** C)) := by
+  rw [← sepConj_assoc', sepConj_comm' A B, sepConj_assoc']
+
+/-- Extract byte `i` of a framed `bytesRegion` from the machine state. -/
+theorem holdsFor_bytesRegion_getByte {b : Word} {bs : List (BitVec 8)}
+    {R : Assertion} {s : MachineState}
+    (hPR : ((bytesRegion b bs) ** R).holdsFor s)
+    {i : Nat} (halign : b.toNat % 8 = 0) (hi : i < bs.length)
+    (hover : b.toNat + i < 2 ^ 64) :
+    s.getByte (b + BitVec.ofNat 64 i) = bs[i]'hi := by
+  obtain ⟨front, rest, hfp, hrp, heq⟩ :=
+    bytesRegion_dword_at b bs (i / 8) (by omega)
+  rw [heq] at hPR
+  have hcell : (((b + BitVec.ofNat 64 (8 * (i / 8))) ↦ₘ
+      packBytes ((bs.drop (8 * (i / 8))).take 8))).holdsFor s :=
+    holdsFor_sepConj_elim_left
+      (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR))
+  have hmem := (holdsFor_memIs.mp hcell).1
+  show extractByte (s.getMem (alignToDword (b + BitVec.ofNat 64 i)))
+    (byteOffset (b + BitVec.ofNat 64 i)) = bs[i]'hi
+  rw [alignToDword_add_ofNat_of_aligned halign hover,
+    byteOffset_add_ofNat_of_aligned halign hover, hmem]
+  have hchunk : i % 8 < ((bs.drop (8 * (i / 8))).take 8).length := by
+    simp only [List.length_take, List.length_drop]
+    omega
+  rw [extractByte_packBytes _ (i % 8) (by omega) hchunk]
+  rw [List.getElem_take, List.getElem_drop]
+  congr 1
+  omega
+
+/-- Byte-load spec at register-file granularity: one step, the destination
+    receives the extended region byte at the effective address, the region
+    itself is untouched. -/
+theorem regFile_load_spec_within (i : Instr) (l : LoadOp) (reg : Region)
+    (rf : RegFile) (base : Word)
+    (hsem : loadSem i = some l)
+    (hreg : reg.wf)
+    (hrd : (Reg.isExposed l.rd || l.rd == .x0) = true)
+    (hrs1 : (Reg.isExposed l.rs1 || l.rs1 == .x0) = true)
+    (hin : ((rf.get l.rs1 + signExtend12 l.ofs) - reg.base).toNat
+      < reg.bytes.length) :
+    cpsTripleWithin 1 base (base + 4) (CodeReq.singleton base i)
+      ((regFileIs rf) ** bytesRegion reg.base reg.bytes)
+      ((regFileIs (rf.set l.rd
+          (l.ext (reg.byteAt (rf.get l.rs1 + signExtend12 l.ofs))))) **
+        bytesRegion reg.base reg.bytes) := by
+  intro R hR s hcr hPR hpc; subst hpc
+  have hfetch : s.code s.pc = some i := CodeReq.singleton_satisfiedBy.mp hcr
+  rw [sepConj_assoc'] at hPR
+  -- hPR : (regFileIs rf ** (bytesRegion ** R)).holdsFor s
+  have hrs1v : s.getReg l.rs1 = rf.get l.rs1 :=
+    holdsFor_regFileIs_agree hPR hrs1
+  have haddr_eq : rf.get l.rs1 + signExtend12 l.ofs
+      = reg.base + BitVec.ofNat 64
+          ((rf.get l.rs1 + signExtend12 l.ofs) - reg.base).toNat := by
+    bv_omega
+  have hover : reg.base.toNat
+      + ((rf.get l.rs1 + signExtend12 l.ofs) - reg.base).toNat < 2 ^ 64 := by
+    have := hreg.2.1
+    omega
+  have hvalidmem : isValidMemAddr (rf.get l.rs1 + signExtend12 l.ofs) = true := by
+    rw [haddr_eq]
+    exact hreg.2.2 _ hin
+  have hvalid : isValidByteAccess (s.getReg l.rs1 + signExtend12 l.ofs) = true := by
+    rw [isValidByteAccess_eq, hrs1v]
+    exact hvalidmem
+  -- the loaded byte
+  have hPR2 : ((bytesRegion reg.base reg.bytes) ** (regFileIs rf ** R)).holdsFor s := by
+    rw [sepConj_left_comm] at hPR
+    exact hPR
+  have hgb : s.getByte (rf.get l.rs1 + signExtend12 l.ofs) = reg.bytes[
+      ((rf.get l.rs1 + signExtend12 l.ofs) - reg.base).toNat]'hin := by
+    conv_lhs => rw [haddr_eq]
+    exact holdsFor_bytesRegion_getByte hPR2 hreg.1 hin hover
+  have hbyteAt : reg.byteAt (rf.get l.rs1 + signExtend12 l.ofs)
+      = reg.bytes[((rf.get l.rs1 + signExtend12 l.ofs) - reg.base).toNat]'hin := by
+    unfold Region.byteAt
+    rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem hin]
+    rfl
+  -- one machine step
+  have hstep' : step s = some (execInstrBr s i) := by
+    cases i <;> simp only [loadSem, reduceCtorEq] at hsem <;>
+      (injection hsem with hsem; subst hsem;
+       first
+         | exact step_lbu hfetch hvalid
+         | exact step_lb hfetch hvalid)
+  have hexec : execInstrBr s i
+      = (s.setReg l.rd (l.ext (s.getByte (rf.get l.rs1 + signExtend12 l.ofs)))).setPC
+          (s.pc + 4) := by
+    cases i <;> simp only [loadSem, reduceCtorEq] at hsem <;>
+      (injection hsem with hsem; subst hsem;
+       simp only [execInstrBr]; rw [hrs1v])
+  refine ⟨1, Nat.le_refl 1,
+    (s.setReg l.rd (l.ext (s.getByte (rf.get l.rs1 + signExtend12 l.ofs)))).setPC
+      (s.pc + 4), ?_, rfl, ?_⟩
+  · show (step s).bind (stepN 0) = some _
+    rw [hstep', hexec]; rfl
+  · rw [hgb, ← hbyteAt] at *
+    rcases Bool.or_eq_true_iff.mp hrd with hexp | hx0
+    · have h1 := holdsFor_sepConj_regFileIs_setReg
+        (v := l.ext (reg.byteAt (rf.get l.rs1 + signExtend12 l.ofs))) hexp hPR
+      rw [← sepConj_assoc'] at h1
+      exact holdsFor_pcFree_setPC
+        (pcFree_sepConj (pcFree_sepConj (pcFree_regFileIs _)
+          (bytesRegion_pcFree _ _)) hR) h1
+    · have hx0' : l.rd = .x0 := by simpa using hx0
+      rw [hx0', RegFile.set_x0]
+      rw [show s.setReg .x0
+        (l.ext (reg.byteAt (rf.get l.rs1 + signExtend12 l.ofs))) = s from rfl]
+      rw [← sepConj_assoc'] at hPR
+      exact holdsFor_pcFree_setPC
+        (pcFree_sepConj (pcFree_sepConj (pcFree_regFileIs _)
+          (bytesRegion_pcFree _ _)) hR) hPR
+
+end SAsm
+end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/RegionSound.lean
+++ b/EvmAsm/Rv64/SAsm/RegionSound.lean
@@ -133,5 +133,45 @@ theorem regFile_load_spec_within (i : Instr) (l : LoadOp) (reg : Region)
         (pcFree_sepConj (pcFree_sepConj (pcFree_regFileIs _)
           (bytesRegion_pcFree _ _)) hR) hPR
 
+-- ============================================================================
+-- The region-carrying reachable-set embedding
+-- ============================================================================
+
+/-- Leaf-shaped embedding of a reachable set: the exposed register file plus
+    the function's read-only region. -/
+def asrtM (reg : Region) (reach : Reach) : Assertion :=
+  asrtOf reach ** bytesRegion reg.base reg.bytes
+
+theorem pcFree_asrtM (reg : Region) (reach : Reach) : (asrtM reg reach).pcFree :=
+  pcFree_sepConj (pcFree_asrtOf _) (bytesRegion_pcFree _ _)
+
+theorem asrtM_mono {reg : Region} {r₁ r₂ : Reach} (h : ∀ rf, r₁ rf → r₂ rf) :
+    ∀ hp, asrtM reg r₁ hp → asrtM reg r₂ hp :=
+  fun hp => sepConj_mono_left (fun hq hh => by
+    obtain ⟨rf, hrf, hr⟩ := hh
+    exact ⟨rf, hrf, h rf hr⟩) hp
+
+theorem asrtM_unsat {reg : Region} {r : Reach} (h : ∀ rf, r rf → False) :
+    ∀ hp, asrtM reg r hp → False := by
+  rintro hp ⟨h1, h2, -, -, ⟨rf, -, hr⟩, -⟩
+  exact h rf hr
+
+/-- Split an `asrtM` precondition into a per-register-file family with the
+    region alongside. -/
+theorem cpsTripleWithin_exists_pre_M {n : Nat} {entry exit_ : Word}
+    {cr : CodeReq} {reg : Region} {reach : Reach} {Q : Assertion}
+    (h : ∀ rf, reach rf → cpsTripleWithin n entry exit_ cr
+      ((regFileIs rf) ** bytesRegion reg.base reg.bytes) Q) :
+    cpsTripleWithin n entry exit_ cr (asrtM reg reach) Q := by
+  intro R hR s hcr hPR hpc
+  rw [show asrtM reg reach
+    = (asrtOf reach ** bytesRegion reg.base reg.bytes) from rfl,
+    sepConj_assoc'] at hPR
+  obtain ⟨hp, hcompat, h1, h2, hd, hu, ⟨rf, hrf1, hreach⟩, hR2⟩ := hPR
+  have hPR' : ((regFileIs rf) ** (bytesRegion reg.base reg.bytes ** R)).holdsFor s :=
+    ⟨hp, hcompat, h1, h2, hd, hu, hrf1, hR2⟩
+  rw [← sepConj_assoc'] at hPR'
+  exact h rf hreach R hR s hcr hPR' hpc
+
 end SAsm
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/StmtSound.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSound.lean
@@ -3,13 +3,19 @@
 
   The generic soundness theorem of the SAsm VC generator: for every
   statement, if its labeled pure VCs hold then the flattened code satisfies
-  a bounded CPS triple from `asrtOf reach` to `asrtOf (s.sp reach)`.
+  a bounded CPS triple from `asrtM reg reach` to `asrtM reg (sp reg s reach)`
+  — the exposed register file plus the function's read-only byte region.
 
   Proven once, by structural induction on `Stmt`; each constructor maps onto
   an existing WP combinator (docs/sasm-design.md §3.5).  The whole statement
   runs against one ambient `cr` that merely *contains* the flattened code
   (`hcode`), so no disjointness obligation ever reaches a user: sequential
   splits use `cpsTripleWithin_seq_same_cr` plus `CodeReq.ofProg` containment.
+
+  This is the *leaf* theorem (`callFree` bodies): every non-exposed register
+  — in particular `ra` — is untouched and framed, which is what lets
+  `Fn.toHandle` package such functions as callees.  Bodies containing calls
+  use `Stmt.soundR` (StmtSoundCall.lean).
 -/
 
 import EvmAsm.Rv64.SAsm.BlockSound
@@ -123,33 +129,45 @@ theorem Cond.wf_neg (c : Cond) : c.neg.wf = c.wf := by
 -- The generic soundness theorem
 -- ============================================================================
 
-/-- Soundness of the SAsm VC generator (docs/sasm-design.md §3.5): if the
-    labeled VCs of `s` hold, the flattened code of `s` placed at `base`
-    satisfies a bounded CPS triple from `asrtOf reach` to
-    `asrtOf (s.sp reach)`, within `s.steps` machine steps, under any code
-    requirement `cr` containing the flattened code.
+/-- Soundness of the SAsm VC generator (docs/sasm-design.md §3.5) for
+    call-free statements: if the labeled VCs of `s` hold, the flattened code
+    of `s` placed at `base` satisfies a bounded CPS triple from
+    `asrtM reg reach` to `asrtM reg (sp reg s reach)`, within `s.steps`
+    machine steps, under any code requirement `cr` containing the flattened
+    code.
 
-    `hofs` (offsets fit their immediates) and `hsz` (the function does not
-    wrap the address space) are decidable per program; `Fn.sound` (M3)
-    discharges them by `decide`. -/
-theorem Stmt.sound (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
-    {cr : CodeReq}
+    `hofs`/`hsz` are decidable per program; `hreg` is the region's
+    well-formedness (decidable for concrete regions, `omega`-shaped for
+    symbolic ones). -/
+theorem Stmt.sound (reg : Region) (s : Stmt) (base : Word) (pfx : String)
+    (reach : Reach) {cr : CodeReq}
+    (hreg : reg.wf)
     (hleaf : s.callFree = true)
     (hofs : s.offsetsOk = true)
     (hsz : 4 * s.size < 2 ^ 64)
     (hcode : ∀ a i, CodeReq.ofProg base (s.flatten base) a = some i → cr a = some i)
-    (hvcs : VCs.Hold (s.vcs pfx reach)) :
+    (hvcs : VCs.Hold (Stmt.vcs reg s pfx reach)) :
     cpsTripleWithin s.steps base (base + BitVec.ofNat 64 (4 * s.size)) cr
-      (asrtOf reach) (asrtOf (s.sp reach)) := by
+      (asrtM reg reach) (asrtM reg (Stmt.sp reg s reach)) := by
   induction s generalizing base pfx reach cr with
   | block lbl is =>
-      have hok : blockOk is = true := hvcs _ (List.mem_singleton_self _)
-      apply cpsTripleWithin_exists_pre
+      have hok : blockOk is = true := hvcs.head
+      have hmem : ∀ rf, reach rf → blockVCs reg rf is := by
+        by_cases hl : hasLoad is
+        · have ht := hvcs.tail
+          simp only [Stmt.vcs, hl, if_true] at ht
+          exact ht.head
+        · exact fun rf _ =>
+            blockVCs_of_not_hasLoad reg rf is (by simpa using hl)
+      apply cpsTripleWithin_exists_pre_M
       intro rf hreach
-      have h := execBlock_sound is rf base hok (by simpa [Stmt.size] using hsz)
+      have h := execBlock_sound reg is rf base hreg hok (hmem rf hreach)
+        (by simpa [Stmt.size] using hsz)
       have h' := cpsTripleWithin_extend_code hcode h
-      exact cpsTripleWithin_weaken (fun _ hp => hp)
-        (fun hp hh => ⟨execBlock rf is, hh, rf, hreach, rfl⟩) h'
+      refine cpsTripleWithin_weaken (fun _ hp => hp) ?_ h'
+      intro hp hh
+      exact sepConj_mono_left
+        (fun hq hr => ⟨execBlock reg rf is, hr, rf, hreach, rfl⟩) hp hh
   | seq a b iha ihb =>
       simp only [Stmt.callFree, Bool.and_eq_true] at hleaf
       simp only [Stmt.offsetsOk, Bool.and_eq_true] at hofs
@@ -171,7 +189,7 @@ theorem Stmt.sound (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
         rw [hla]
         exact h
       have h1 := iha base pfx reach hleaf.1 hofs.1 hsza hcode_a hvcs.left
-      have h2 := ihb (base + BitVec.ofNat 64 (4 * a.size)) pfx (a.sp reach)
+      have h2 := ihb (base + BitVec.ofNat 64 (4 * a.size)) pfx (Stmt.sp reg a reach)
         hleaf.2 hofs.2 hszb hcode_b hvcs.right
       have h3 := cpsTripleWithin_seq_same_cr h1 h2
       rw [addr_shift] at h3
@@ -248,14 +266,15 @@ theorem Stmt.sound (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
       have hbr := branch_spec_asrt c.neg (Stmt.brOfs (t.size + 2)) reach base
         (by rw [Cond.wf_neg]; exact hwf)
       rw [signExtend13_brOfs hofsT] at hbr
-      have hbr' := cpsBranchWithin_extend_code hcode_br hbr
+      have hbr' := cpsBranchWithin_frameR (bytesRegion reg.base reg.bytes)
+        (bytesRegion_pcFree _ _) (cpsBranchWithin_extend_code hcode_br hbr)
       -- Then-arm: t's code then the skip jump
       have ht := iht (base + 4) (pfx ++ lbl ++ ".t.")
         (fun rf => reach rf ∧ c.holds rf) hleaf.1 hOT (by omega) hcode_t hvcs.left
       rw [haddr1] at ht
       have hjal := jal0_spec_pcFree (Stmt.jFwd (e.size + 1))
         (base + BitVec.ofNat 64 (4 * (t.size + 1)))
-        (pcFree_asrtOf (t.sp fun rf => reach rf ∧ c.holds rf))
+        (pcFree_asrtM reg (Stmt.sp reg t fun rf => reach rf ∧ c.holds rf))
       rw [signExtend21_jFwd hofsJ, haddr2] at hjal
       have hjal' := cpsTripleWithin_extend_code hcode_jal hjal
       have htj := cpsTripleWithin_seq_same_cr ht hjal'
@@ -264,35 +283,33 @@ theorem Stmt.sound (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
         (fun rf => reach rf ∧ ¬ c.holds rf) hleaf.2 hOE (by omega) hcode_e hvcs.right
       rw [haddr3] at he
       -- Weaken branch posts: neg-condition denotations and arm preconditions
-      have hbr'' : cpsBranchWithin 1 base cr (asrtOf reach)
+      have hbr'' : cpsBranchWithin 1 base cr (asrtM reg reach)
           (base + BitVec.ofNat 64 (4 * (t.size + 2)))
-            (asrtOf fun rf => reach rf ∧ ¬ c.holds rf)
-          (base + 4) (asrtOf fun rf => reach rf ∧ c.holds rf) := by
+            (asrtM reg fun rf => reach rf ∧ ¬ c.holds rf)
+          (base + 4) (asrtM reg fun rf => reach rf ∧ c.holds rf) := by
         refine cpsBranchWithin_weaken (fun _ hp => hp) ?_ ?_ hbr'
-        · rintro hp ⟨rf, hrf, hr, hnc⟩
-          exact ⟨rf, hrf, hr, (Cond.holds_neg c rf).mp hnc⟩
-        · rintro hp ⟨rf, hrf, hr, hnc⟩
-          exact ⟨rf, hrf, hr,
-            Decidable.of_not_not (fun hcc => hnc ((Cond.holds_neg c rf).mpr hcc))⟩
+        · exact asrtM_mono (fun rf hh =>
+            ⟨hh.1, (Cond.holds_neg c rf).mp hh.2⟩)
+        · exact asrtM_mono (fun rf hh =>
+            ⟨hh.1, Decidable.of_not_not
+              (fun hcc => hh.2 ((Cond.holds_neg c rf).mpr hcc))⟩)
       -- Merge: taken exit is the else entry, not-taken is the then entry
       have harmE : cpsTripleWithin (max (t.steps + 1) e.steps)
           (base + BitVec.ofNat 64 (4 * (t.size + 2)))
           (base + BitVec.ofNat 64 (4 * (t.size + e.size + 2))) cr
-          (asrtOf fun rf => reach rf ∧ ¬ c.holds rf)
-          (asrtOf (Stmt.sp (.ite lbl c t e) reach)) := by
+          (asrtM reg fun rf => reach rf ∧ ¬ c.holds rf)
+          (asrtM reg (Stmt.sp reg (.ite lbl c t e) reach)) := by
         refine cpsTripleWithin_mono_nSteps (Nat.le_max_right _ _)
           (cpsTripleWithin_weaken (fun _ hp => hp) ?_ he)
-        rintro hp ⟨rf, hrf, hsp⟩
-        exact ⟨rf, hrf, Or.inr hsp⟩
+        exact asrtM_mono (fun rf hsp => Or.inr hsp)
       have harmT : cpsTripleWithin (max (t.steps + 1) e.steps)
           (base + 4)
           (base + BitVec.ofNat 64 (4 * (t.size + e.size + 2))) cr
-          (asrtOf fun rf => reach rf ∧ c.holds rf)
-          (asrtOf (Stmt.sp (.ite lbl c t e) reach)) := by
+          (asrtM reg fun rf => reach rf ∧ c.holds rf)
+          (asrtM reg (Stmt.sp reg (.ite lbl c t e) reach)) := by
         refine cpsTripleWithin_mono_nSteps (Nat.le_max_left _ _)
           (cpsTripleWithin_weaken (fun _ hp => hp) ?_ htj)
-        rintro hp ⟨rf, hrf, hsp⟩
-        exact ⟨rf, hrf, Or.inl hsp⟩
+        exact asrtM_mono (fun rf hsp => Or.inl hsp)
       exact cpsBranchWithin_merge_same_cr hbr'' harmE harmT
   | «when» lbl c b ihb =>
       simp only [Stmt.offsetsOk, Bool.and_eq_true, decide_eq_true_eq] at hofs
@@ -313,7 +330,8 @@ theorem Stmt.sound (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
       have hbr := branch_spec_asrt c.neg (Stmt.brOfs (b.size + 1)) reach base
         (by rw [Cond.wf_neg]; exact hwf)
       rw [signExtend13_brOfs hofsB] at hbr
-      have hbr' := cpsBranchWithin_extend_code hcode_br hbr
+      have hbr' := cpsBranchWithin_frameR (bytesRegion reg.base reg.bytes)
+        (bytesRegion_pcFree _ _) (cpsBranchWithin_extend_code hcode_br hbr)
       have hb := ihb (base + 4) (pfx ++ lbl ++ ".")
         (fun rf => reach rf ∧ c.holds rf) (by simpa [Stmt.callFree] using hleaf)
         hOB (by omega) hcode_b hvcs
@@ -323,31 +341,28 @@ theorem Stmt.sound (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
       have hskip : cpsTripleWithin b.steps
           (base + BitVec.ofNat 64 (4 * (b.size + 1)))
           (base + BitVec.ofNat 64 (4 * (b.size + 1))) cr
-          (asrtOf fun rf => reach rf ∧ c.neg.holds rf)
-          (asrtOf (Stmt.sp (.when lbl c b) reach)) := by
+          (asrtM reg fun rf => reach rf ∧ c.neg.holds rf)
+          (asrtM reg (Stmt.sp reg (.when lbl c b) reach)) := by
         apply cpsTripleWithin_mono_nSteps (Nat.zero_le _)
         apply cpsTripleWithin_entails
-        rintro hp ⟨rf, hrf, hr, hnc⟩
-        exact ⟨rf, hrf, Or.inr ⟨hr, (Cond.holds_neg c rf).mp hnc⟩⟩
+        exact asrtM_mono (fun rf hh =>
+          Or.inr ⟨hh.1, (Cond.holds_neg c rf).mp hh.2⟩)
       -- not-taken (c): run the body
       have hbody : cpsTripleWithin b.steps (base + 4)
           (base + BitVec.ofNat 64 (4 * (b.size + 1))) cr
-          (asrtOf fun rf => reach rf ∧ ¬ c.neg.holds rf)
-          (asrtOf (Stmt.sp (.when lbl c b) reach)) := by
+          (asrtM reg fun rf => reach rf ∧ ¬ c.neg.holds rf)
+          (asrtM reg (Stmt.sp reg (.when lbl c b) reach)) := by
         refine cpsTripleWithin_weaken ?_ ?_ hb
-        · rintro hp ⟨rf, hrf, hr, hnc⟩
-          exact ⟨rf, hrf, hr,
-            Decidable.of_not_not (fun hcc => hnc ((Cond.holds_neg c rf).mpr hcc))⟩
-        · rintro hp ⟨rf, hrf, hsp⟩
-          exact ⟨rf, hrf, Or.inl hsp⟩
+        · exact asrtM_mono (fun rf hh =>
+            ⟨hh.1, Decidable.of_not_not
+              (fun hcc => hh.2 ((Cond.holds_neg c rf).mpr hcc))⟩)
+        · exact asrtM_mono (fun rf hsp => Or.inl hsp)
       exact cpsBranchWithin_merge_same_cr hbr' hskip hbody
   | assert lbl P =>
       have hvc := hvcs _ (List.mem_singleton_self _)
-      have h : cpsTripleWithin 0 base base cr (asrtOf reach)
-          (asrtOf (Stmt.sp (.assert lbl P) reach)) :=
-        cpsTripleWithin_entails (fun hp hh => by
-          obtain ⟨rf, hrf, hr⟩ := hh
-          exact ⟨rf, hrf, hr, hvc rf hr⟩)
+      have h : cpsTripleWithin 0 base base cr (asrtM reg reach)
+          (asrtM reg (Stmt.sp reg (.assert lbl P) reach)) :=
+        cpsTripleWithin_entails (asrtM_mono (fun rf hr => ⟨hr, hvc rf hr⟩))
       have hz : base + BitVec.ofNat 64 (4 * Stmt.size (.assert lbl P)) = base := by
         simp [Stmt.size]
       simp only [Stmt.steps]
@@ -360,7 +375,7 @@ theorem Stmt.sound (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
       -- VC pieces
       have hInvInit : ∀ rf, reach rf → inv 0 rf := hvcs.head
       have hInvStep : ∀ i, i < fuel →
-          ∀ rf', b.sp (fun rf => inv i rf ∧ c.holds rf) rf' → inv (i + 1) rf' :=
+          ∀ rf', Stmt.sp reg b (fun rf => inv i rf ∧ c.holds rf) rf' → inv (i + 1) rf' :=
         hvcs.tail.head
       have hExhausted : ∀ rf, inv fuel rf → ¬ c.holds rf := hvcs.tail.tail.head
       have hBodyVcs := hvcs.tail.tail.tail
@@ -399,90 +414,79 @@ theorem Stmt.sound (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
           = base + BitVec.ofNat 64 (4 * (b.size + 1)) := by bv_omega
       -- Header branch at any invariant index
       have hheader : ∀ (r : Reach),
-          cpsBranchWithin 1 base cr (asrtOf r)
+          cpsBranchWithin 1 base cr (asrtM reg r)
             (base + BitVec.ofNat 64 (4 * (b.size + 2)))
-              (asrtOf fun rf => r rf ∧ ¬ c.holds rf)
-            (base + 4) (asrtOf fun rf => r rf ∧ c.holds rf) := by
+              (asrtM reg fun rf => r rf ∧ ¬ c.holds rf)
+            (base + 4) (asrtM reg fun rf => r rf ∧ c.holds rf) := by
         intro r
         have hbr := branch_spec_asrt c.neg (Stmt.brOfs (b.size + 2)) r base
           (by rw [Cond.wf_neg]; exact hwf)
         rw [signExtend13_brOfs hofsHdr] at hbr
-        have hbr' := cpsBranchWithin_extend_code hcode_br hbr
-        exact cpsBranchWithin_weaken (fun _ hp => hp)
-          (fun hp hh => by
-            obtain ⟨rf, hrf, hr, hnc⟩ := hh
-            exact ⟨rf, hrf, hr, (Cond.holds_neg c rf).mp hnc⟩)
-          (fun hp hh => by
-            obtain ⟨rf, hrf, hr, hnc⟩ := hh
-            exact ⟨rf, hrf, hr,
-              Decidable.of_not_not (fun hcc => hnc ((Cond.holds_neg c rf).mpr hcc))⟩)
-          hbr'
+        have hbr' := cpsBranchWithin_frameR (bytesRegion reg.base reg.bytes)
+          (bytesRegion_pcFree _ _) (cpsBranchWithin_extend_code hcode_br hbr)
+        refine cpsBranchWithin_weaken (fun _ hp => hp) ?_ ?_ hbr'
+        · exact asrtM_mono (fun rf hh =>
+            ⟨hh.1, (Cond.holds_neg c rf).mp hh.2⟩)
+        · exact asrtM_mono (fun rf hh =>
+            ⟨hh.1, Decidable.of_not_not
+              (fun hcc => hh.2 ((Cond.holds_neg c rf).mpr hcc))⟩)
       -- Body + back-jump triple for each iteration index
       have hbodyStep : ∀ i, i < fuel →
           cpsTripleWithin (b.steps + 1) (base + 4) base cr
-            (asrtOf fun rf => inv i rf ∧ c.holds rf)
-            (asrtOf fun rf => inv (i + 1) rf) := by
+            (asrtM reg fun rf => inv i rf ∧ c.holds rf)
+            (asrtM reg fun rf => inv (i + 1) rf) := by
         intro i hi
         have hb := ihb (base + 4) (pfx ++ lbl ++ ".body.")
           (fun rf => inv i rf ∧ c.holds rf) (by simpa [Stmt.callFree] using hleaf)
           hOB (by omega) hcode_b
-          (Stmt.vcs_antitone b _ (fun rf hr => ⟨i, hi, hr.1, hr.2⟩) hBodyVcs)
+          (Stmt.vcs_antitone reg b _ (fun rf hr => ⟨i, hi, hr.1, hr.2⟩) hBodyVcs)
         have hjal := jal0_spec_pcFree (Stmt.jBack (b.size + 1))
           ((base + 4) + BitVec.ofNat 64 (4 * b.size))
-          (pcFree_asrtOf (b.sp fun rf => inv i rf ∧ c.holds rf))
+          (pcFree_asrtM reg (Stmt.sp reg b fun rf => inv i rf ∧ c.holds rf))
         rw [hbodyEnd, add_jBack base (b.size + 1) (by omega) hofsBack] at hjal
         rw [← hbodyEnd] at hjal
         have hjal' := cpsTripleWithin_extend_code hcode_jal hjal
         have hseq := cpsTripleWithin_seq_same_cr hb hjal'
         exact cpsTripleWithin_weaken (fun _ hp => hp)
-          (fun hp hh => by
-            obtain ⟨rf, hrf, hsp⟩ := hh
-            exact ⟨rf, hrf, hInvStep i hi rf hsp⟩) hseq
+          (asrtM_mono (fun rf hsp => hInvStep i hi rf hsp)) hseq
       -- The loop certificate, by downward recursion on the remaining fuel
       have hcert : ∀ fuel' start, start + fuel' = fuel →
           WP.loopNatCert 1 (b.steps + 1) 1 base (base + 4)
             (base + BitVec.ofNat 64 (4 * (b.size + 2))) cr
-            (fun i => asrtOf fun rf => inv i rf)
-            (fun i => asrtOf fun rf => inv i rf ∧ c.holds rf)
-            (fun i => asrtOf fun rf => inv i rf ∧ ¬ c.holds rf)
-            (asrtOf fun rf => (∃ i, i ≤ fuel ∧ inv i rf) ∧ ¬ c.holds rf)
+            (fun i => asrtM reg fun rf => inv i rf)
+            (fun i => asrtM reg fun rf => inv i rf ∧ c.holds rf)
+            (fun i => asrtM reg fun rf => inv i rf ∧ ¬ c.holds rf)
+            (asrtM reg fun rf => (∃ i, i ≤ fuel ∧ inv i rf) ∧ ¬ c.holds rf)
             start fuel' := by
         intro fuel'
         induction fuel' with
         | zero =>
             intro start hstart
-            -- Forced exit: the header must fall out (fuel exhausted)
             simp only [WP.loopNatCert]
             have hexit : cpsTripleWithin 0
                 (base + BitVec.ofNat 64 (4 * (b.size + 2)))
                 (base + BitVec.ofNat 64 (4 * (b.size + 2))) cr
-                (asrtOf fun rf => inv start rf ∧ ¬ c.holds rf)
-                (asrtOf fun rf => (∃ i, i ≤ fuel ∧ inv i rf) ∧ ¬ c.holds rf) :=
-              cpsTripleWithin_entails (fun hp hh => by
-                obtain ⟨rf, hrf, hr, hnc⟩ := hh
-                exact ⟨rf, hrf, ⟨start, by omega, hr⟩, hnc⟩)
+                (asrtM reg fun rf => inv start rf ∧ ¬ c.holds rf)
+                (asrtM reg fun rf => (∃ i, i ≤ fuel ∧ inv i rf) ∧ ¬ c.holds rf) :=
+              cpsTripleWithin_entails (asrtM_mono (fun rf hh =>
+                ⟨⟨start, by omega, hh.1⟩, hh.2⟩))
             have hsf : start = fuel := by omega
             have hdead : cpsTripleWithin 0 (base + 4)
                 (base + BitVec.ofNat 64 (4 * (b.size + 2))) cr
-                (asrtOf fun rf => inv start rf ∧ c.holds rf)
-                (asrtOf fun rf => (∃ i, i ≤ fuel ∧ inv i rf) ∧ ¬ c.holds rf) :=
-              cpsTripleWithin_unreachable (fun hp hh => by
-                obtain ⟨rf, hrf, hr, hc⟩ := hh
-                exact hExhausted rf (hsf ▸ hr) hc)
+                (asrtM reg fun rf => inv start rf ∧ c.holds rf)
+                (asrtM reg fun rf => (∃ i, i ≤ fuel ∧ inv i rf) ∧ ¬ c.holds rf) :=
+              cpsTripleWithin_unreachable (asrtM_unsat (fun rf hh =>
+                hExhausted rf (hsf ▸ hh.1) hh.2))
             exact cpsBranchWithin_merge_same_cr
               (cpsBranchWithin_swap (hheader (fun rf => inv start rf))) hdead hexit
         | succ fuel' ih =>
             intro start hstart
             refine ⟨cpsBranchWithin_swap (hheader (fun rf => inv start rf)),
               hbodyStep start (by omega), ?_, ih (start + 1) (by omega)⟩
-            intro hp hh
-            obtain ⟨rf, hrf, hr, hnc⟩ := hh
-            exact ⟨rf, hrf, ⟨start, by omega, hr⟩, hnc⟩
+            exact asrtM_mono (fun rf hh => ⟨⟨start, by omega, hh.1⟩, hh.2⟩)
       have hsound := WP.loopNatCert_sound (hcert fuel 0 (by omega))
       exact cpsTripleWithin_weaken
-        (fun hp hh => by
-          obtain ⟨rf, hrf, hr⟩ := hh
-          exact ⟨rf, hrf, hInvInit rf hr⟩)
+        (asrtM_mono (fun rf hr => hInvInit rf hr))
         (fun _ hp => hp)
         hsound
   | call lbl f =>

--- a/EvmAsm/Rv64/SAsm/StmtSound.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSound.lean
@@ -155,7 +155,7 @@ theorem Stmt.sound (reg : Region) (s : Stmt) (base : Word) (pfx : String)
       have hmem : ∀ rf, reach rf → blockVCs reg rf is := by
         by_cases hl : hasLoad is
         · have ht := hvcs.tail
-          simp only [Stmt.vcs, hl, if_true] at ht
+          simp only [hl, if_true] at ht
           exact ht.head
         · exact fun rf _ =>
             blockVCs_of_not_hasLoad reg rf is (by simpa using hl)

--- a/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
@@ -6,7 +6,7 @@
   can be verified via `WP.cpsCallWithin` against the callee's `FnHandle`.
 
   Compared to the leaf theorem, the pre/postcondition is
-  `asrtR reach := asrtOf reach ** regOwn .x1`: `ra` is owned throughout but
+  `asrtR reg reach := asrtOf reach ** regOwn .x1`: `ra` is owned throughout but
   its *value* is only tracked across call-free segments internally — after a
   call it holds the call's return address, which the shape deliberately
   forgets.  Call-free bodies should keep using `Stmt.sound` (via `Fn.sound`)
@@ -22,24 +22,22 @@ import EvmAsm.Rv64.WP.Call
 namespace EvmAsm.Rv64
 namespace SAsm
 
-/-- Caller-shaped embedding of a reachable set: the exposed register file
-    plus ownership of `ra`. -/
-def asrtR (reach : Reach) : Assertion :=
-  asrtOf reach ** regOwn .x1
+/-- Caller-shaped embedding of a reachable set: the exposed register file,
+    the function's read-only region, plus ownership of `ra`. -/
+def asrtR (reg : Region) (reach : Reach) : Assertion :=
+  asrtM reg reach ** regOwn .x1
 
-theorem pcFree_asrtR (reach : Reach) : (asrtR reach).pcFree :=
-  pcFree_sepConj (pcFree_asrtOf _) pcFree_regOwn
+theorem pcFree_asrtR (reg : Region) (reach : Reach) : (asrtR reg reach).pcFree :=
+  pcFree_sepConj (pcFree_asrtM _ _) pcFree_regOwn
 
-theorem asrtR_mono {r₁ r₂ : Reach} (h : ∀ rf, r₁ rf → r₂ rf) :
-    ∀ hp, asrtR r₁ hp → asrtR r₂ hp :=
-  fun hp => sepConj_mono_left (fun hq hh => by
-    obtain ⟨rf, hrf, hr⟩ := hh
-    exact ⟨rf, hrf, h rf hr⟩) hp
+theorem asrtR_mono {reg : Region} {r₁ r₂ : Reach} (h : ∀ rf, r₁ rf → r₂ rf) :
+    ∀ hp, asrtR reg r₁ hp → asrtR reg r₂ hp :=
+  fun hp => sepConj_mono_left (asrtM_mono h) hp
 
-theorem asrtR_unsat {r : Reach} (h : ∀ rf, r rf → False) :
-    ∀ hp, asrtR r hp → False := by
-  rintro hp ⟨h1, h2, -, -, ⟨rf, -, hr⟩, -⟩
-  exact h rf hr
+theorem asrtR_unsat {reg : Region} {r : Reach} (h : ∀ rf, r rf → False) :
+    ∀ hp, asrtR reg r hp → False := by
+  rintro hp ⟨h1, h2, -, -, hM, -⟩
+  exact asrtM_unsat h h1 hM
 
 /-- Eliminate the unknown `ra` value of an `asrtR`-shaped precondition. -/
 theorem cpsTripleWithin_regOwn_right_pre {n : Nat} {entry exit_ : Word}
@@ -56,23 +54,24 @@ theorem cpsTripleWithin_regOwn_right_pre {n : Nat} {entry exit_ : Word}
     satisfies a bounded CPS triple at `asrtR` granularity, provided the
     ambient `cr` also contains every callee's code (`hcallees`) and the call
     sites' address side-conditions hold (`hcalls`). -/
-theorem Stmt.soundR (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
-    {cr : CodeReq}
+theorem Stmt.soundR (reg : Region) (s : Stmt) (base : Word) (pfx : String)
+    (reach : Reach) {cr : CodeReq}
+    (hreg : reg.wf)
     (hofs : s.offsetsOk = true)
     (hsz : 4 * s.size < 2 ^ 64)
     (hcode : ∀ a i, CodeReq.ofProg base (s.flatten base) a = some i → cr a = some i)
-    (hcallees : s.CalleesIn cr)
+    (hcallees : s.CalleesIn reg cr)
     (hcalls : s.callsOk base)
-    (hvcs : VCs.Hold (s.vcs pfx reach)) :
+    (hvcs : VCs.Hold (Stmt.vcs reg s pfx reach)) :
     cpsTripleWithin s.steps base (base + BitVec.ofNat 64 (4 * s.size)) cr
-      (asrtR reach) (asrtR (s.sp reach)) := by
+      (asrtR reg reach) (asrtR reg (Stmt.sp reg s reach)) := by
   induction s generalizing base pfx reach cr with
   | block lbl is =>
       exact cpsTripleWithin_frameR (regOwn .x1) pcFree_regOwn
-        (Stmt.sound (.block lbl is) base pfx reach rfl hofs hsz hcode hvcs)
+        (Stmt.sound reg (.block lbl is) base pfx reach hreg rfl hofs hsz hcode hvcs)
   | assert lbl P =>
       exact cpsTripleWithin_frameR (regOwn .x1) pcFree_regOwn
-        (Stmt.sound (.assert lbl P) base pfx reach rfl hofs hsz hcode hvcs)
+        (Stmt.sound reg (.assert lbl P) base pfx reach hreg rfl hofs hsz hcode hvcs)
   | seq a b iha ihb =>
       simp only [Stmt.offsetsOk, Bool.and_eq_true] at hofs
       simp only [Stmt.size] at hsz
@@ -95,7 +94,7 @@ theorem Stmt.soundR (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
         rw [hla]
         exact h
       have h1 := iha base pfx reach hofs.1 hsza hcode_a hcallees_a hcalls_a hvcs.left
-      have h2 := ihb (base + BitVec.ofNat 64 (4 * a.size)) pfx (a.sp reach)
+      have h2 := ihb (base + BitVec.ofNat 64 (4 * a.size)) pfx (Stmt.sp reg a reach)
         hofs.2 hszb hcode_b hcallees_b hcalls_b hvcs.right
       have h3 := cpsTripleWithin_seq_same_cr h1 h2
       rw [addr_shift] at h3
@@ -171,14 +170,15 @@ theorem Stmt.soundR (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
         (by rw [Cond.wf_neg]; exact hwf)
       rw [signExtend13_brOfs hofsT] at hbr
       have hbr' := cpsBranchWithin_frameR (regOwn .x1) pcFree_regOwn
-        (cpsBranchWithin_extend_code hcode_br hbr)
+        (cpsBranchWithin_frameR (bytesRegion reg.base reg.bytes)
+          (bytesRegion_pcFree _ _) (cpsBranchWithin_extend_code hcode_br hbr))
       have ht := iht (base + 4) (pfx ++ lbl ++ ".t.")
         (fun rf => reach rf ∧ c.holds rf) hOT (by omega) hcode_t
         hcallees_t hcalls_t hvcs.left
       rw [haddr1] at ht
       have hjal := jal0_spec_pcFree (Stmt.jFwd (e.size + 1))
         (base + BitVec.ofNat 64 (4 * (t.size + 1)))
-        (pcFree_asrtR (t.sp fun rf => reach rf ∧ c.holds rf))
+        (pcFree_asrtR reg (Stmt.sp reg t fun rf => reach rf ∧ c.holds rf))
       rw [signExtend21_jFwd hofsJ, haddr2] at hjal
       have hjal' := cpsTripleWithin_extend_code hcode_jal hjal
       have htj := cpsTripleWithin_seq_same_cr ht hjal'
@@ -186,10 +186,10 @@ theorem Stmt.soundR (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
         (fun rf => reach rf ∧ ¬ c.holds rf) hOE (by omega) hcode_e
         hcallees_e hcalls_e hvcs.right
       rw [haddr3] at he
-      have hbr'' : cpsBranchWithin 1 base cr (asrtR reach)
+      have hbr'' : cpsBranchWithin 1 base cr (asrtR reg reach)
           (base + BitVec.ofNat 64 (4 * (t.size + 2)))
-            (asrtR fun rf => reach rf ∧ ¬ c.holds rf)
-          (base + 4) (asrtR fun rf => reach rf ∧ c.holds rf) := by
+            (asrtR reg fun rf => reach rf ∧ ¬ c.holds rf)
+          (base + 4) (asrtR reg fun rf => reach rf ∧ c.holds rf) := by
         refine cpsBranchWithin_weaken (fun _ hp => hp) ?_ ?_ hbr'
         · exact asrtR_mono (fun rf hh =>
             ⟨hh.1, (Cond.holds_neg c rf).mp hh.2⟩)
@@ -199,16 +199,16 @@ theorem Stmt.soundR (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
       have harmE : cpsTripleWithin (max (t.steps + 1) e.steps)
           (base + BitVec.ofNat 64 (4 * (t.size + 2)))
           (base + BitVec.ofNat 64 (4 * (t.size + e.size + 2))) cr
-          (asrtR fun rf => reach rf ∧ ¬ c.holds rf)
-          (asrtR (Stmt.sp (.ite lbl c t e) reach)) := by
+          (asrtR reg fun rf => reach rf ∧ ¬ c.holds rf)
+          (asrtR reg (Stmt.sp reg (.ite lbl c t e) reach)) := by
         refine cpsTripleWithin_mono_nSteps (Nat.le_max_right _ _)
           (cpsTripleWithin_weaken (fun _ hp => hp) ?_ he)
         exact asrtR_mono (fun rf hsp => Or.inr hsp)
       have harmT : cpsTripleWithin (max (t.steps + 1) e.steps)
           (base + 4)
           (base + BitVec.ofNat 64 (4 * (t.size + e.size + 2))) cr
-          (asrtR fun rf => reach rf ∧ c.holds rf)
-          (asrtR (Stmt.sp (.ite lbl c t e) reach)) := by
+          (asrtR reg fun rf => reach rf ∧ c.holds rf)
+          (asrtR reg (Stmt.sp reg (.ite lbl c t e) reach)) := by
         refine cpsTripleWithin_mono_nSteps (Nat.le_max_left _ _)
           (cpsTripleWithin_weaken (fun _ hp => hp) ?_ htj)
         exact asrtR_mono (fun rf hsp => Or.inl hsp)
@@ -233,7 +233,8 @@ theorem Stmt.soundR (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
         (by rw [Cond.wf_neg]; exact hwf)
       rw [signExtend13_brOfs hofsB] at hbr
       have hbr' := cpsBranchWithin_frameR (regOwn .x1) pcFree_regOwn
-        (cpsBranchWithin_extend_code hcode_br hbr)
+        (cpsBranchWithin_frameR (bytesRegion reg.base reg.bytes)
+          (bytesRegion_pcFree _ _) (cpsBranchWithin_extend_code hcode_br hbr))
       have hb := ihb (base + 4) (pfx ++ lbl ++ ".")
         (fun rf => reach rf ∧ c.holds rf)
         hOB (by omega) hcode_b hcallees hcalls hvcs
@@ -242,16 +243,16 @@ theorem Stmt.soundR (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
       have hskip : cpsTripleWithin b.steps
           (base + BitVec.ofNat 64 (4 * (b.size + 1)))
           (base + BitVec.ofNat 64 (4 * (b.size + 1))) cr
-          (asrtR fun rf => reach rf ∧ c.neg.holds rf)
-          (asrtR (Stmt.sp (.when lbl c b) reach)) := by
+          (asrtR reg fun rf => reach rf ∧ c.neg.holds rf)
+          (asrtR reg (Stmt.sp reg (.when lbl c b) reach)) := by
         apply cpsTripleWithin_mono_nSteps (Nat.zero_le _)
         apply cpsTripleWithin_entails
         exact asrtR_mono (fun rf hh =>
           Or.inr ⟨hh.1, (Cond.holds_neg c rf).mp hh.2⟩)
       have hbody : cpsTripleWithin b.steps (base + 4)
           (base + BitVec.ofNat 64 (4 * (b.size + 1))) cr
-          (asrtR fun rf => reach rf ∧ ¬ c.neg.holds rf)
-          (asrtR (Stmt.sp (.when lbl c b) reach)) := by
+          (asrtR reg fun rf => reach rf ∧ ¬ c.neg.holds rf)
+          (asrtR reg (Stmt.sp reg (.when lbl c b) reach)) := by
         refine cpsTripleWithin_weaken ?_ ?_ hb
         · exact asrtR_mono (fun rf hh =>
             ⟨hh.1, Decidable.of_not_not
@@ -264,7 +265,7 @@ theorem Stmt.soundR (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
       simp only [Stmt.size] at hsz
       have hInvInit : ∀ rf, reach rf → inv 0 rf := hvcs.head
       have hInvStep : ∀ i, i < fuel →
-          ∀ rf', b.sp (fun rf => inv i rf ∧ c.holds rf) rf' → inv (i + 1) rf' :=
+          ∀ rf', Stmt.sp reg b (fun rf => inv i rf ∧ c.holds rf) rf' → inv (i + 1) rf' :=
         hvcs.tail.head
       have hExhausted : ∀ rf, inv fuel rf → ¬ c.holds rf := hvcs.tail.tail.head
       have hBodyVcs := hvcs.tail.tail.tail
@@ -300,16 +301,17 @@ theorem Stmt.soundR (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
       have hbodyEnd : (base + 4) + BitVec.ofNat 64 (4 * b.size)
           = base + BitVec.ofNat 64 (4 * (b.size + 1)) := by bv_omega
       have hheader : ∀ (r : Reach),
-          cpsBranchWithin 1 base cr (asrtR r)
+          cpsBranchWithin 1 base cr (asrtR reg r)
             (base + BitVec.ofNat 64 (4 * (b.size + 2)))
-              (asrtR fun rf => r rf ∧ ¬ c.holds rf)
-            (base + 4) (asrtR fun rf => r rf ∧ c.holds rf) := by
+              (asrtR reg fun rf => r rf ∧ ¬ c.holds rf)
+            (base + 4) (asrtR reg fun rf => r rf ∧ c.holds rf) := by
         intro r
         have hbr := branch_spec_asrt c.neg (Stmt.brOfs (b.size + 2)) r base
           (by rw [Cond.wf_neg]; exact hwf)
         rw [signExtend13_brOfs hofsHdr] at hbr
         have hbr' := cpsBranchWithin_frameR (regOwn .x1) pcFree_regOwn
-          (cpsBranchWithin_extend_code hcode_br hbr)
+          (cpsBranchWithin_frameR (bytesRegion reg.base reg.bytes)
+            (bytesRegion_pcFree _ _) (cpsBranchWithin_extend_code hcode_br hbr))
         refine cpsBranchWithin_weaken (fun _ hp => hp) ?_ ?_ hbr'
         · exact asrtR_mono (fun rf hh =>
             ⟨hh.1, (Cond.holds_neg c rf).mp hh.2⟩)
@@ -318,16 +320,16 @@ theorem Stmt.soundR (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
               (fun hcc => hh.2 ((Cond.holds_neg c rf).mpr hcc))⟩)
       have hbodyStep : ∀ i, i < fuel →
           cpsTripleWithin (b.steps + 1) (base + 4) base cr
-            (asrtR fun rf => inv i rf ∧ c.holds rf)
-            (asrtR fun rf => inv (i + 1) rf) := by
+            (asrtR reg fun rf => inv i rf ∧ c.holds rf)
+            (asrtR reg fun rf => inv (i + 1) rf) := by
         intro i hi
         have hb := ihb (base + 4) (pfx ++ lbl ++ ".body.")
           (fun rf => inv i rf ∧ c.holds rf)
           hOB (by omega) hcode_b hcallees hcalls
-          (Stmt.vcs_antitone b _ (fun rf hr => ⟨i, hi, hr.1, hr.2⟩) hBodyVcs)
+          (Stmt.vcs_antitone reg b _ (fun rf hr => ⟨i, hi, hr.1, hr.2⟩) hBodyVcs)
         have hjal := jal0_spec_pcFree (Stmt.jBack (b.size + 1))
           ((base + 4) + BitVec.ofNat 64 (4 * b.size))
-          (pcFree_asrtR (b.sp fun rf => inv i rf ∧ c.holds rf))
+          (pcFree_asrtR reg (Stmt.sp reg b fun rf => inv i rf ∧ c.holds rf))
         rw [hbodyEnd, add_jBack base (b.size + 1) (by omega) hofsBack] at hjal
         rw [← hbodyEnd] at hjal
         have hjal' := cpsTripleWithin_extend_code hcode_jal hjal
@@ -337,10 +339,10 @@ theorem Stmt.soundR (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
       have hcert : ∀ fuel' start, start + fuel' = fuel →
           WP.loopNatCert 1 (b.steps + 1) 1 base (base + 4)
             (base + BitVec.ofNat 64 (4 * (b.size + 2))) cr
-            (fun i => asrtR fun rf => inv i rf)
-            (fun i => asrtR fun rf => inv i rf ∧ c.holds rf)
-            (fun i => asrtR fun rf => inv i rf ∧ ¬ c.holds rf)
-            (asrtR fun rf => (∃ i, i ≤ fuel ∧ inv i rf) ∧ ¬ c.holds rf)
+            (fun i => asrtR reg fun rf => inv i rf)
+            (fun i => asrtR reg fun rf => inv i rf ∧ c.holds rf)
+            (fun i => asrtR reg fun rf => inv i rf ∧ ¬ c.holds rf)
+            (asrtR reg fun rf => (∃ i, i ≤ fuel ∧ inv i rf) ∧ ¬ c.holds rf)
             start fuel' := by
         intro fuel'
         induction fuel' with
@@ -350,15 +352,15 @@ theorem Stmt.soundR (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
             have hexit : cpsTripleWithin 0
                 (base + BitVec.ofNat 64 (4 * (b.size + 2)))
                 (base + BitVec.ofNat 64 (4 * (b.size + 2))) cr
-                (asrtR fun rf => inv start rf ∧ ¬ c.holds rf)
-                (asrtR fun rf => (∃ i, i ≤ fuel ∧ inv i rf) ∧ ¬ c.holds rf) :=
+                (asrtR reg fun rf => inv start rf ∧ ¬ c.holds rf)
+                (asrtR reg fun rf => (∃ i, i ≤ fuel ∧ inv i rf) ∧ ¬ c.holds rf) :=
               cpsTripleWithin_entails (asrtR_mono (fun rf hh =>
                 ⟨⟨start, by omega, hh.1⟩, hh.2⟩))
             have hsf : start = fuel := by omega
             have hdead : cpsTripleWithin 0 (base + 4)
                 (base + BitVec.ofNat 64 (4 * (b.size + 2))) cr
-                (asrtR fun rf => inv start rf ∧ c.holds rf)
-                (asrtR fun rf => (∃ i, i ≤ fuel ∧ inv i rf) ∧ ¬ c.holds rf) :=
+                (asrtR reg fun rf => inv start rf ∧ c.holds rf)
+                (asrtR reg fun rf => (∃ i, i ≤ fuel ∧ inv i rf) ∧ ¬ c.holds rf) :=
               cpsTripleWithin_unreachable (asrtR_unsat (fun rf hh =>
                 hExhausted rf (hsf ▸ hh.1) hh.2))
             exact cpsBranchWithin_merge_same_cr
@@ -375,13 +377,14 @@ theorem Stmt.soundR (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
         hsound
   | call lbl f =>
       obtain ⟨hoffset, halign, hnotself⟩ := hcalls
+      obtain ⟨hcalleeCode, hregeq⟩ := hcallees
       have hpreVC : ∀ rf, reach rf → f.pre rf := hvcs _ (List.mem_singleton_self _)
       -- callee triple, retargeted at the aligned return address
       have hret' : cpsTripleWithin f.nSteps f.entry ((base + 4) &&& ~~~(1 : Word))
           f.code
-          ((.x1 ↦ᵣ (base + 4)) ** asrtOf f.pre)
-          ((.x1 ↦ᵣ (base + 4)) ** asrtOf f.post) := by
-        rw [halign]
+          ((.x1 ↦ᵣ (base + 4)) ** asrtM reg f.pre)
+          ((.x1 ↦ᵣ (base + 4)) ** asrtM reg f.post) := by
+        rw [halign, ← hregeq]
         exact f.sound (base + 4) halign
       have hdisj : (CodeReq.singleton base
           (.JAL .x1 (BitVec.setWidth 21 (f.entry - base)))).Disjoint f.code := by
@@ -401,7 +404,7 @@ theorem Stmt.soundR (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
             (.JAL .x1 (BitVec.setWidth 21 (f.entry - base))) a with
         | none =>
             rw [hs] at h
-            exact hcallees a i h
+            exact hcalleeCode a i h
         | some j =>
             rw [hs] at h
             apply hcode a i
@@ -413,12 +416,12 @@ theorem Stmt.soundR (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
       -- the framed call triple, for each old value of ra
       have hcall : ∀ vOld : Word,
           cpsTripleWithin (1 + f.nSteps) base (base + 4) cr
-            ((asrtOf f.pre) ** (.x1 ↦ᵣ vOld))
-            ((asrtOf (Stmt.sp (.call lbl f) reach)) ** regOwn .x1) := by
+            ((asrtM reg f.pre) ** (.x1 ↦ᵣ vOld))
+            ((asrtM reg (Stmt.sp reg (.call lbl f) reach)) ** regOwn .x1) := by
         intro vOld
         have h := WP.cpsCallWithin (vOld := vOld)
           (BitVec.setWidth 21 (f.entry - base)) hoffset halign
-          (pcFree_asrtOf f.pre) hdisj hret'
+          (pcFree_asrtM reg f.pre) hdisj hret'
         have h' := cpsTripleWithin_extend_code hmono h
         refine cpsTripleWithin_weaken ?_ ?_ h'
         · intro hp hh
@@ -429,11 +432,9 @@ theorem Stmt.soundR (s : Stmt) (base : Word) (pfx : String) (reach : Reach)
           exact sepConj_mono_right (fun hq hx => ⟨base + 4, hx⟩) hp hh
       -- assemble: eliminate the unknown ra value, weaken the entry reach
       have hfinal : cpsTripleWithin (1 + f.nSteps) base (base + 4) cr
-          (asrtR reach) (asrtR (Stmt.sp (.call lbl f) reach)) := by
+          (asrtR reg reach) (asrtR reg (Stmt.sp reg (.call lbl f) reach)) := by
         refine cpsTripleWithin_weaken
-          (sepConj_mono_left (fun hq hh => by
-            obtain ⟨rf, hrf, hr⟩ := hh
-            exact ⟨rf, hrf, hpreVC rf hr⟩))
+          (sepConj_mono_left (asrtM_mono (fun rf hr => hpreVC rf hr)))
           (fun _ hp => hp)
           (cpsTripleWithin_regOwn_right_pre hcall)
       simp only [Stmt.steps, Stmt.size, Nat.mul_one]

--- a/EvmAsm/Rv64/SAsm/Sym.lean
+++ b/EvmAsm/Rv64/SAsm/Sym.lean
@@ -23,6 +23,37 @@ import EvmAsm.Rv64.SAsm.RegFile
 namespace EvmAsm.Rv64
 namespace SAsm
 
+-- ============================================================================
+-- Read-only byte regions (docs/sasm-design.md §3.3)
+-- ============================================================================
+
+/-- A read-only byte buffer owned by an SAsm function: `bytes` live at the
+    dword-aligned `base`.  The degenerate `Region.empty` is the default for
+    functions that touch no memory. -/
+structure Region where
+  base : Word
+  bytes : List (BitVec 8)
+
+/-- The no-memory region (its assertion is `empAssertion`). -/
+def Region.empty : Region := ⟨0, []⟩
+
+/-- Read the byte at an absolute address (junk when out of range; the block
+    VCs rule that out). -/
+def Region.byteAt (reg : Region) (addr : Word) : BitVec 8 :=
+  reg.bytes.getD (addr - reg.base).toNat 0
+
+/-- Region well-formedness: dword-aligned base, no address wrap, and every
+    byte within the machine's valid memory range.  Decidable for concrete
+    regions (`decide`); `omega`/`bv_omega` for symbolic ones. -/
+def Region.wf (reg : Region) : Prop :=
+  reg.base.toNat % 8 = 0 ∧
+  reg.base.toNat + reg.bytes.length < 2 ^ 64 ∧
+  ∀ k, k < reg.bytes.length → isValidMemAddr (reg.base + BitVec.ofNat 64 k) = true
+
+instance (reg : Region) : Decidable reg.wf := by
+  unfold Region.wf
+  infer_instance
+
 /-- Classification of a supported straight-line instruction: destination,
     sources, and result as a function of the register valuation. -/
 structure AluOp where
@@ -82,13 +113,32 @@ def aluSem : Instr → Option AluOp
   -- Everything else (memory, control flow, system) is not a block leaf.
   | _ => none
 
-/-- Symbolic execution of one instruction over the register file.
-    Unsupported instructions are the identity; they are ruled out by
-    `instrOk`, which the VC generator enforces. -/
-def execInstrRF (rf : RegFile) (i : Instr) : RegFile :=
+/-- Classification of a byte load from the function's read-only region:
+    destination, address register, immediate offset, and how the byte
+    extends to a word. -/
+structure LoadOp where
+  rd : Reg
+  rs1 : Reg
+  ofs : BitVec 12
+  ext : BitVec 8 → Word
+
+/-- Classify a byte load.  `LBU`/`LB` only in M5a; wider loads arrive with
+    multi-byte region reads. -/
+def loadSem : Instr → Option LoadOp
+  | .LBU rd rs1 ofs => some ⟨rd, rs1, ofs, fun b => b.zeroExtend 64⟩
+  | .LB  rd rs1 ofs => some ⟨rd, rs1, ofs, fun b => b.signExtend 64⟩
+  | _ => none
+
+/-- Symbolic execution of one instruction over the register file, reading
+    byte loads from `reg`.  Unsupported instructions are the identity; they
+    are ruled out by `instrOk`, which the VC generator enforces. -/
+def execInstrRF (reg : Region) (rf : RegFile) (i : Instr) : RegFile :=
   match aluSem i with
   | some op => rf.set op.rd (op.f rf.get)
-  | none => rf
+  | none =>
+    match loadSem i with
+    | some l => rf.set l.rd (l.ext (reg.byteAt (rf.get l.rs1 + signExtend12 l.ofs)))
+    | none => rf
 
 /-- Supported-and-exposed check for a block leaf instruction: the instruction
     is in the supported subset, writes an exposed register (or x0), and reads
@@ -98,21 +148,58 @@ def instrOk (i : Instr) : Bool :=
   | some op =>
       (Reg.isExposed op.rd || op.rd == .x0)
         && op.srcs.all (fun r => Reg.isExposed r || r == .x0)
-  | none => false
+  | none =>
+    match loadSem i with
+    | some l =>
+        (Reg.isExposed l.rd || l.rd == .x0)
+          && (Reg.isExposed l.rs1 || l.rs1 == .x0)
+    | none => false
 
 /-- Forward symbolic execution of a straight-line block. -/
-def execBlock (rf : RegFile) : List Instr → RegFile
+def execBlock (reg : Region) (rf : RegFile) : List Instr → RegFile
   | [] => rf
-  | i :: is => execBlock (execInstrRF rf i) is
+  | i :: is => execBlock reg (execInstrRF reg rf i) is
 
 /-- Every instruction of the block is a supported, exposure-respecting leaf. -/
 def blockOk (instrs : List Instr) : Bool :=
   instrs.all instrOk
 
-@[simp] theorem execBlock_nil (rf : RegFile) : execBlock rf [] = rf := rfl
+/-- Address side conditions of a block's loads, threaded through the
+    symbolic execution: every load's effective address indexes into the
+    region. -/
+def blockVCs (reg : Region) (rf : RegFile) : List Instr → Prop
+  | [] => True
+  | i :: is =>
+      (match loadSem i with
+       | some l =>
+           ((rf.get l.rs1 + signExtend12 l.ofs) - reg.base).toNat < reg.bytes.length
+       | none => True)
+      ∧ blockVCs reg (execInstrRF reg rf i) is
 
-@[simp] theorem execBlock_cons (rf : RegFile) (i : Instr) (is : List Instr) :
-    execBlock rf (i :: is) = execBlock (execInstrRF rf i) is := rfl
+/-- Whether a block contains any load (decides whether a `.mem` VC is
+    emitted at all). -/
+def hasLoad (instrs : List Instr) : Bool :=
+  instrs.any (fun i => (loadSem i).isSome)
+
+/-- Blocks without loads have no memory side conditions. -/
+theorem blockVCs_of_not_hasLoad (reg : Region) (rf : RegFile)
+    (instrs : List Instr) (h : hasLoad instrs = false) :
+    blockVCs reg rf instrs := by
+  induction instrs generalizing rf with
+  | nil => trivial
+  | cons i is ih =>
+      simp only [hasLoad, List.any_cons, Bool.or_eq_false_iff] at h
+      refine ⟨?_, ih _ (by simp [hasLoad, h.2])⟩
+      cases hl : loadSem i with
+      | none => trivial
+      | some l => simp [hl] at h
+
+@[simp] theorem execBlock_nil (reg : Region) (rf : RegFile) :
+    execBlock reg rf [] = rf := rfl
+
+@[simp] theorem execBlock_cons (reg : Region) (rf : RegFile) (i : Instr)
+    (is : List Instr) :
+    execBlock reg rf (i :: is) = execBlock reg (execInstrRF reg rf i) is := rfl
 
 end SAsm
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/Tactic.lean
+++ b/EvmAsm/Rv64/SAsm/Tactic.lean
@@ -104,26 +104,41 @@ elab "vcgen" : tactic => do
     -- Caller-shaped goal: code/callee containment and call-site address
     -- side conditions become their own named goals.
     evalTactic (← `(tactic|
-      refine EvmAsm.Rv64.SAsm.Fn.soundR _ _ _ ?code ?callees ?calls ?_))
+      refine EvmAsm.Rv64.SAsm.Fn.soundR _ _ _ ?region ?code ?callees ?calls ?_))
   else
-    evalTactic (← `(tactic| refine EvmAsm.Rv64.SAsm.Fn.sound _ _ ?_))
+    evalTactic (← `(tactic| refine EvmAsm.Rv64.SAsm.Fn.sound _ _ ?region ?_))
   let gs ← getGoals
   let mut out : List MVarId := []
+  let tryDecide (g : MVarId) : TacticM Bool := g.withContext do
+    try
+      let t ← g.getType
+      -- Only accept when the decision procedure genuinely evaluates to
+      -- `true` (mkDecideProof alone can produce kernel-rejected proofs on
+      -- goals with free variables that do not reduce away).
+      let d ← mkDecide t
+      let r ← withDefault <| whnf d
+      unless r.isConstOf ``Bool.true do
+        return false
+      let prf ← mkDecideProof t
+      g.assign prf
+      Pure.pure true
+    catch _ =>
+      Pure.pure false
   for g in gs do
     if (← g.getType).isAppOfArity ``VCs.Hold 1 then
       -- Split the VC list; auto-discharge decidable bookkeeping goals
       -- (kernel `decide`; free variables are fine because the checked
       -- terms reduce them away).
       for g' in ← vcCases g do
-        let closed ← g'.withContext do
-          try
-            let prf ← mkDecideProof (← g'.getType)
-            g'.assign prf
-            Pure.pure true
-          catch _ =>
-            Pure.pure false
-        unless closed do
+        unless ← tryDecide g' do
           out := out ++ [g']
+    else if (← g.getTag).getRoot == `region then
+      -- Region well-formedness is decidable for concrete regions.  Do NOT
+      -- attempt `decide` on the other side goals: they quantify over full
+      -- `Word`s, which is "decidable" by 2^64-case analysis and would melt
+      -- the kernel.
+      unless ← tryDecide g do
+        out := out ++ [g]
     else
       out := out ++ [g]
   replaceMainGoal out

--- a/EvmAsm/Rv64/SAsm/Vc.lean
+++ b/EvmAsm/Rv64/SAsm/Vc.lean
@@ -78,17 +78,18 @@ end VCs
 
 namespace Stmt
 
-/-- Strongest-postcondition transformer over the exposed register file.
+/-- Strongest-postcondition transformer over the exposed register file,
+    reading loads from the function's region `reg`.
     A `call` replaces the reachable set by the callee's postcondition (the
     callee owns the whole exposed file; ghost data relates them). -/
-def sp : Stmt → Reach → Reach
-  | block _ is, reach => fun rf' => ∃ rf, reach rf ∧ rf' = execBlock rf is
-  | seq a b, reach => b.sp (a.sp reach)
+def sp (reg : Region) : Stmt → Reach → Reach
+  | block _ is, reach => fun rf' => ∃ rf, reach rf ∧ rf' = execBlock reg rf is
+  | seq a b, reach => sp reg b (sp reg a reach)
   | ite _ c t e, reach => fun rf' =>
-      t.sp (fun rf => reach rf ∧ c.holds rf) rf' ∨
-      e.sp (fun rf => reach rf ∧ ¬ c.holds rf) rf'
+      sp reg t (fun rf => reach rf ∧ c.holds rf) rf' ∨
+      sp reg e (fun rf => reach rf ∧ ¬ c.holds rf) rf'
   | when _ c b, reach => fun rf' =>
-      b.sp (fun rf => reach rf ∧ c.holds rf) rf' ∨ (reach rf' ∧ ¬ c.holds rf')
+      sp reg b (fun rf => reach rf ∧ c.holds rf) rf' ∨ (reach rf' ∧ ¬ c.holds rf')
   | assert _ P, reach => fun rf => reach rf ∧ P rf
   | «while» _ c fuel inv _, _ =>
       fun rf => (∃ i, i ≤ fuel ∧ inv i rf) ∧ ¬ c.holds rf
@@ -96,24 +97,27 @@ def sp : Stmt → Reach → Reach
 
 /-- Labeled verification conditions of a statement, given the reachable set
     at its entry.  `pfx` is the path prefix for labels. -/
-def vcs : Stmt → String → Reach → List VC
-  | block lbl is, pfx, _ =>
-      [⟨pfx ++ lbl ++ ".ok", blockOk is = true⟩]
+def vcs (reg : Region) : Stmt → String → Reach → List VC
+  | block lbl is, pfx, reach =>
+      ⟨pfx ++ lbl ++ ".ok", blockOk is = true⟩ ::
+      (if hasLoad is then
+        [⟨pfx ++ lbl ++ ".mem", ∀ rf, reach rf → blockVCs reg rf is⟩]
+      else [])
   | seq a b, pfx, reach =>
-      a.vcs pfx reach ++ b.vcs pfx (a.sp reach)
+      vcs reg a pfx reach ++ vcs reg b pfx (sp reg a reach)
   | ite lbl c t e, pfx, reach =>
-      t.vcs (pfx ++ lbl ++ ".t.") (fun rf => reach rf ∧ c.holds rf) ++
-      e.vcs (pfx ++ lbl ++ ".e.") (fun rf => reach rf ∧ ¬ c.holds rf)
+      vcs reg t (pfx ++ lbl ++ ".t.") (fun rf => reach rf ∧ c.holds rf) ++
+      vcs reg e (pfx ++ lbl ++ ".e.") (fun rf => reach rf ∧ ¬ c.holds rf)
   | when lbl c b, pfx, reach =>
-      b.vcs (pfx ++ lbl ++ ".") (fun rf => reach rf ∧ c.holds rf)
+      vcs reg b (pfx ++ lbl ++ ".") (fun rf => reach rf ∧ c.holds rf)
   | assert lbl P, pfx, reach =>
       [⟨pfx ++ lbl, ∀ rf, reach rf → P rf⟩]
   | «while» lbl c fuel inv b, pfx, reach =>
       ⟨pfx ++ lbl ++ ".inv_init", ∀ rf, reach rf → inv 0 rf⟩ ::
       ⟨pfx ++ lbl ++ ".inv_step", ∀ i, i < fuel →
-          ∀ rf', b.sp (fun rf => inv i rf ∧ c.holds rf) rf' → inv (i + 1) rf'⟩ ::
+          ∀ rf', sp reg b (fun rf => inv i rf ∧ c.holds rf) rf' → inv (i + 1) rf'⟩ ::
       ⟨pfx ++ lbl ++ ".exhausted", ∀ rf, inv fuel rf → ¬ c.holds rf⟩ ::
-      b.vcs (pfx ++ lbl ++ ".body.")
+      vcs reg b (pfx ++ lbl ++ ".body.")
         (fun rf => ∃ i, i < fuel ∧ inv i rf ∧ c.holds rf)
   | call lbl f, pfx, reach =>
       [⟨pfx ++ lbl ++ ".pre", ∀ rf, reach rf → f.pre rf⟩]
@@ -130,8 +134,8 @@ def steps : Stmt → Nat
   | call _ f => 1 + f.nSteps
 
 /-- `sp` is monotone in the reachable set. -/
-theorem sp_mono (s : Stmt) {r₁ r₂ : Reach} (h : ∀ rf, r₁ rf → r₂ rf) :
-    ∀ rf, s.sp r₁ rf → s.sp r₂ rf := by
+theorem sp_mono (reg : Region) (s : Stmt) {r₁ r₂ : Reach} (h : ∀ rf, r₁ rf → r₂ rf) :
+    ∀ rf, sp reg s r₁ rf → sp reg s r₂ rf := by
   induction s generalizing r₁ r₂ with
   | block lbl is =>
       rintro rf ⟨rf₀, hr, hrf⟩
@@ -156,18 +160,33 @@ theorem sp_mono (s : Stmt) {r₁ r₂ : Reach} (h : ∀ rf, r₁ rf → r₂ rf)
 /-- `vcs` is antitone in the reachable set: obligations proven for a larger
     reachable set cover any smaller one.  Used to specialize loop-body VCs
     (generated at the union over iterations) to a specific iteration. -/
-theorem vcs_antitone (s : Stmt) (pfx : String) {r₁ r₂ : Reach}
-    (h : ∀ rf, r₁ rf → r₂ rf) (hvcs : VCs.Hold (s.vcs pfx r₂)) :
-    VCs.Hold (s.vcs pfx r₁) := by
+theorem vcs_antitone (reg : Region) (s : Stmt) (pfx : String) {r₁ r₂ : Reach}
+    (h : ∀ rf, r₁ rf → r₂ rf) (hvcs : VCs.Hold (vcs reg s pfx r₂)) :
+    VCs.Hold (vcs reg s pfx r₁) := by
   induction s generalizing r₁ r₂ pfx with
   | block lbl is =>
-      exact fun vc hvc => hvcs vc (by simpa [vcs] using hvc)
+      intro vc hvc
+      simp only [vcs, List.mem_cons] at hvc
+      rcases hvc with rfl | hvc
+      · exact hvcs.head
+      · by_cases hl : hasLoad is
+        · rw [if_pos hl] at hvc
+          have hvcs2 := hvcs.tail
+          rw [show vcs reg (.block lbl is) pfx r₂
+              = ⟨pfx ++ lbl ++ ".ok", blockOk is = true⟩ ::
+                [⟨pfx ++ lbl ++ ".mem", ∀ rf, r₂ rf → blockVCs reg rf is⟩]
+            from by simp [vcs, hl]] at hvcs
+          simp only [List.mem_singleton] at hvc
+          subst hvc
+          exact fun rf hr => hvcs.tail.head rf (h rf hr)
+        · rw [if_neg hl] at hvc
+          exact absurd hvc (List.not_mem_nil)
   | seq a b iha ihb =>
       intro vc hvc
       simp only [vcs, List.mem_append] at hvc ⊢
       rcases hvc with hvc | hvc
       · exact iha pfx h hvcs.left vc hvc
-      · exact ihb pfx (sp_mono a h) hvcs.right vc hvc
+      · exact ihb pfx (sp_mono reg a h) hvcs.right vc hvc
   | ite lbl c t e iht ihe =>
       intro vc hvc
       simp only [vcs, List.mem_append] at hvc
@@ -196,18 +215,19 @@ theorem vcs_antitone (s : Stmt) (pfx : String) {r₁ r₂ : Reach}
       subst hvc
       exact fun rf hr => hvcs.head rf (h rf hr)
 
-/-- The callee code of every call site is contained in `cr`.  Stated
-    structurally (rather than as a union of `CodeReq`s) so sub-statement
-    obligations project out without overlap side conditions. -/
-def CalleesIn (s : Stmt) (cr : CodeReq) : Prop :=
+/-- Per call site: the callee's code is contained in `cr` and the callee
+    shares the caller's region.  Stated structurally (rather than as a union
+    of `CodeReq`s) so sub-statement obligations project out without overlap
+    side conditions. -/
+def CalleesIn (s : Stmt) (reg : Region) (cr : CodeReq) : Prop :=
   match s with
   | block _ _ => True
-  | seq a b => a.CalleesIn cr ∧ b.CalleesIn cr
-  | ite _ _ t e => t.CalleesIn cr ∧ e.CalleesIn cr
-  | when _ _ b => b.CalleesIn cr
+  | seq a b => a.CalleesIn reg cr ∧ b.CalleesIn reg cr
+  | ite _ _ t e => t.CalleesIn reg cr ∧ e.CalleesIn reg cr
+  | when _ _ b => b.CalleesIn reg cr
   | assert _ _ => True
-  | «while» _ _ _ _ b => b.CalleesIn cr
-  | call _ f => ∀ a i, f.code a = some i → cr a = some i
+  | «while» _ _ _ _ b => b.CalleesIn reg cr
+  | call _ f => (∀ a i, f.code a = some i → cr a = some i) ∧ f.region = reg
 
 end Stmt
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2467,12 +2467,15 @@ and a `vcgen` tactic that reduces a function spec to labeled *pure* VCs via a
 structurally-recursive generator + one generic soundness theorem (recursion-
 safe by construction). Milestones M1–M5 in the design doc; M1 = AST +
 flattener, M2 = block symbolic engine + soundness, M3 = structural soundness
-+ `vcgen`, M4 = calls, M5 = mutable regions + RLP-style demo. **M1–M4 done**
-(M1–M3 2026-07-01, M4 2026-07-02): AST/flattener, block engine + soundness,
++ `vcgen`, M4 = calls, M5 = regions. **M1–M4 + M5a done** (M1–M3
+2026-07-01, M4 + M5a 2026-07-02): AST/flattener, block engine + soundness,
 generic Stmt.sound, Fn + vcgen, verified calls (FnHandle in the AST,
 caller-shaped Stmt.soundR/Fn.SpecR via cpsCallWithin, Fn.toHandle leaf
-packaging, caller demo). Remaining: M5 (.ro loads → .rw regions, RLP demo);
-multi-level call trees need the ra-spill prologue (M5 stack memory).
+packaging), and read-only byte regions (Region in Fn/FnHandle, LBU/LB in
+the block engine with per-block .mem VCs, region-carrying asrtM triples,
+RLP-prefix-classification demo over a symbolic input buffer). Remaining:
+M5b (.rw regions + stores; ra-spill prologue for multi-level call trees;
+wider loads), then port an SSZ routine from Stateless/.
 
 ## Stateless Guest (parallel STF track)
 


### PR DESCRIPTION
## Summary

Milestone M5a of the SAsm DSL ([design](docs/sasm-design.md) §3.3–3.4, follow-up to #9636/#9644): **read-only memory**, the piece that makes check-heavy RLP/SSZ decoding expressible.

- **`Region`** — a dword-aligned ghost byte buffer (`base`, `bytes`) carried by `Fn`/`FnHandle` (default `Region.empty`). Decidable well-formedness (alignment, no wrap, all bytes in valid memory) surfaces as a named `region` side goal; `vcgen` auto-discharges it for concrete/empty regions.
- **Block engine** — `loadSem` classifies `LBU`/`LB`; `execInstrRF`/`execBlock` resolve loads against the region (`Region.byteAt`); `blockVCs` threads each load's in-range side condition through the symbolic execution, and blocks containing loads emit exactly one labeled `.mem` VC (`∀ rf, reach rf → blockVCs reg rf is`). Load soundness (`regFile_load_spec_within`) sits on a new `holdsFor_bytesRegion_getByte` bridge over the existing `bytesRegion_dword_at` + `extractByte`/`packBytes` algebra.
- **Soundness** — both inductions now run at region-carrying granularity: `asrtM reg reach := asrtOf reach ** bytesRegion …` (leaf) and `asrtR reg reach := asrtM … ** regOwn x1` (caller). The region is framed through branches/jumps and passed to callees, which must share it (`CalleesIn` gains the region-equality conjunct — ghost bytes flow caller→callee).
- **Tactic hardening** — `vcgen`'s auto-`decide` now verifies the decision procedure actually evaluates to `true` before assigning (raw `mkDecideProof` produced kernel-rejected proofs on symbolic goals), and never attempts `Word`-quantified side goals (`∀ a : BitVec 64, …` is "decidable" by 2^64-case analysis; the kernel melted).
- **Demo** (`ExamplesVc.lean`): `rlpIsListFn` — load the first byte of a ghost RLP input at symbolic `inBase`, classify list vs non-list (`< 0xc0`), verified for arbitrary buffers under one `Region.wf` hypothesis. All M3/M4 demos pass unchanged.

Remaining for M5b (documented in PLAN.md): `.rw` regions + stores, the ra-spill prologue for multi-level call trees, wider loads, then porting an SSZ routine from `Stateless/`.

## Test plan
- `lake build EvmAsm.Rv64` green
- `#print axioms` on `Stmt.sound`, `Stmt.soundR`, `rlpIsListFn_spec` → `propext, Classical.choice, Quot.sound` only
- `scripts/check-forbidden-tactics.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)