### PR TITLE
SAsm M5b-1: wider read-only loads (LW/LWU/LD) — SSZ-shaped u32/u64 reads

### DIFF
--- a/EvmAsm/Rv64/SAsm/BlockSound.lean
+++ b/EvmAsm/Rv64/SAsm/BlockSound.lean
@@ -90,9 +90,7 @@ theorem execInstrRF_sound {i : Instr} (reg : Region) (hreg : reg.wf)
     (hok : instrOk i = true)
     (rf : RegFile) (base : Word)
     (hvc : match loadSem i with
-      | some l =>
-          ((rf.get l.rs1 + signExtend12 l.ofs) - reg.base).toNat
-            < reg.bytes.length
+      | some l => reg.loadOk (rf.get l.rs1 + signExtend12 l.ofs) l.nbytes
       | none => True) :
     cpsTripleWithin 1 base (base + 4) (CodeReq.singleton base i)
       ((regFileIs rf) ** bytesRegion reg.base reg.bytes)

--- a/EvmAsm/Rv64/SAsm/ExamplesVc.lean
+++ b/EvmAsm/Rv64/SAsm/ExamplesVc.lean
@@ -179,13 +179,12 @@ theorem rlpIsListFn_spec (inBase : Word) (bs : List (BitVec 8))
   case region => exact hwf
   case rlpIsList.load.mem =>
     rintro rf ⟨hx10, hne⟩
-    refine ⟨?_, trivial, trivial⟩
-    show ((rf.get .x10 + signExtend12 (0 : BitVec 12))
-      - (rlpIsListFn inBase bs).region.base).toNat
-      < (rlpIsListFn inBase bs).region.bytes.length
-    rw [show (rlpIsListFn inBase bs).region = Region.mk inBase bs from rfl]
+    refine ⟨⟨one_dvd _, ?_⟩, trivial, trivial⟩
+    show ((rf.get .x10 + signExtend12 (0 : BitVec 12)) - inBase).toNat + 1
+      ≤ bs.length
     rw [haddr rf hx10]
-    exact List.length_pos_iff.mpr hne
+    have := List.length_pos_iff.mpr hne
+    omega
   case rlpIsList.post =>
     intro rf' h
     show rf'.get .x10 = (if (bs.headD 0).toNat < 0xc0 then 0 else 1)
@@ -230,6 +229,54 @@ theorem rlpIsListFn_spec (inBase : Word) (bs : List (BitVec 8))
         RegFile.get_set_self _ .x6 _ (by decide),
         hbyte rf₁ hx10] at hcond
       rw [if_neg (fun hlt => hcond (hult.mpr hlt))]
+
+-- ============================================================================
+-- Wider loads (Milestone M5b): SSZ-style u32 offset read
+-- ============================================================================
+
+/-- Read the little-endian u32 at byte offset 4 of an SSZ-style input into
+    a1 — the shape of an SSZ offset-table walk (`decode_validation_bit`). -/
+def sszReadOffsetFn (inBase : Word) (bs : List (BitVec 8)) : Fn where
+  name := "sszReadOffset"
+  region := ⟨inBase, bs⟩
+  pre := fun rf => rf.get .x10 = inBase ∧ 8 ≤ bs.length
+  post := fun rf => rf.get .x11
+    = BitVec.zeroExtend 64
+        (bs.getD 7 0 ++ bs.getD 6 0 ++ bs.getD 5 0 ++ bs.getD 4 0)
+  body := .block "load" [.LWU .x11 .x10 4]
+
+theorem sszReadOffsetFn_spec (inBase : Word) (bs : List (BitVec 8))
+    (hwf : (Region.mk inBase bs).wf) (base : Word) :
+    (sszReadOffsetFn inBase bs).Spec base := by
+  have haddr : ∀ rf : RegFile, rf.get .x10 = inBase →
+      ((rf.get .x10 + signExtend12 (4 : BitVec 12)) - inBase).toNat = 4 := by
+    intro rf h
+    rw [h, show signExtend12 (4 : BitVec 12) = (4 : Word) from by decide]
+    bv_omega
+  vcgen
+  case region => exact hwf
+  case sszReadOffset.load.mem =>
+    rintro rf ⟨hx10, hlen⟩
+    refine ⟨⟨?_, ?_⟩, trivial⟩
+    · show (4 : Nat) ∣ ((rf.get .x10 + signExtend12 (4 : BitVec 12)) - inBase).toNat
+      rw [haddr rf hx10]
+    · show ((rf.get .x10 + signExtend12 (4 : BitVec 12)) - inBase).toNat + 4
+        ≤ bs.length
+      rw [haddr rf hx10]
+      omega
+  case sszReadOffset.post =>
+    rintro rf' ⟨rf₀, ⟨hx10, hlen⟩, rfl⟩
+    show RegFile.get _ .x11 = _
+    simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem, loadSem]
+    rw [RegFile.get_set_self _ .x11 _ (by decide)]
+    rw [hx10, show signExtend12 (4 : BitVec 12) = (4 : Word) from by decide]
+    show BitVec.zeroExtend 64 (Region.word32At ⟨inBase, bs⟩ (inBase + 4)) = _
+    unfold Region.word32At Region.byteAt
+    rw [show inBase + 4 + 3 - inBase = (7 : Word) from by bv_omega,
+      show inBase + 4 + 2 - inBase = (6 : Word) from by bv_omega,
+      show inBase + 4 + 1 - inBase = (5 : Word) from by bv_omega,
+      show inBase + 4 - inBase = (4 : Word) from by bv_omega]
+    rfl
 
 end ExamplesVc
 end SAsm

--- a/EvmAsm/Rv64/SAsm/RegionSound.lean
+++ b/EvmAsm/Rv64/SAsm/RegionSound.lean
@@ -49,21 +49,120 @@ theorem holdsFor_bytesRegion_getByte {b : Word} {bs : List (BitVec 8)}
   congr 1
   omega
 
-/-- Byte-load spec at register-file granularity: one step, the destination
-    receives the extended region byte at the effective address, the region
-    itself is untouched. -/
+/-- `extractWord32` is the little-endian append of its four bytes. -/
+theorem extractWord32_eq_append (w : Word) (p : Nat) (hp : p < 2) :
+    extractWord32 w p
+      = extractByte w (4 * p + 3) ++ extractByte w (4 * p + 2)
+        ++ extractByte w (4 * p + 1) ++ extractByte w (4 * p) := by
+  interval_cases p <;>
+    (apply BitVec.eq_of_getLsbD_eq
+     intro i hi
+     simp only [extractWord32, extractByte, BitVec.getLsbD_append,
+       BitVec.truncate, BitVec.getLsbD_setWidth, BitVec.getLsbD_ushiftRight]
+     interval_cases i <;> simp)
+
+/-- Extract the packed cell containing region index `i` from a framed
+    `bytesRegion`. -/
+theorem holdsFor_bytesRegion_cell {b : Word} {bs : List (BitVec 8)}
+    {R : Assertion} {s : MachineState}
+    (hPR : ((bytesRegion b bs) ** R).holdsFor s)
+    {i : Nat} (hi : i < bs.length) :
+    s.getMem (b + BitVec.ofNat 64 (8 * (i / 8)))
+      = packBytes ((bs.drop (8 * (i / 8))).take 8) := by
+  obtain ⟨front, rest, -, -, heq⟩ :=
+    bytesRegion_dword_at b bs (i / 8) (by omega)
+  rw [heq] at hPR
+  exact (holdsFor_memIs.mp (holdsFor_sepConj_elim_left
+    (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR)))).1
+
+/-- Read the aligned dword at region index `i` from a framed `bytesRegion`. -/
+theorem holdsFor_bytesRegion_getMem {b : Word} {bs : List (BitVec 8)}
+    {R : Assertion} {s : MachineState}
+    (hPR : ((bytesRegion b bs) ** R).holdsFor s)
+    {i : Nat} (h8 : 8 ∣ i) (hlen : i < bs.length) :
+    s.getMem (b + BitVec.ofNat 64 i) = packBytes ((bs.drop i).take 8) := by
+  have h := holdsFor_bytesRegion_cell hPR hlen
+  rw [show 8 * (i / 8) = i from by omega] at h
+  exact h
+
+/-- Read the aligned little-endian 32-bit word at region index `i` from a
+    framed `bytesRegion`. -/
+theorem holdsFor_bytesRegion_getWord32 {b : Word} {bs : List (BitVec 8)}
+    {R : Assertion} {s : MachineState}
+    (hPR : ((bytesRegion b bs) ** R).holdsFor s)
+    {i : Nat} (halign : b.toNat % 8 = 0) (h4 : 4 ∣ i)
+    (hlen : i + 4 ≤ bs.length) (hover : b.toNat + i < 2 ^ 64) :
+    s.getWord32 (b + BitVec.ofNat 64 i)
+      = (bs[i + 3]'(by omega) ++ bs[i + 2]'(by omega)
+          ++ bs[i + 1]'(by omega) ++ bs[i]'(by omega) : BitVec 32) := by
+  have hcell := holdsFor_bytesRegion_cell hPR (show i < bs.length by omega)
+  show extractWord32 (s.getMem (alignToDword (b + BitVec.ofNat 64 i)))
+    (byteOffset (b + BitVec.ofNat 64 i) / 4) = _
+  rw [alignToDword_add_ofNat_of_aligned halign hover,
+    byteOffset_add_ofNat_of_aligned halign hover, hcell,
+    extractWord32_eq_append _ _ (by omega)]
+  have hchunk : ∀ j, j < 4 →
+      4 * (i % 8 / 4) + j < ((bs.drop (8 * (i / 8))).take 8).length := by
+    intro j hj
+    simp only [List.length_take, List.length_drop]
+    omega
+  rw [extractByte_packBytes _ _ (by omega) (hchunk 3 (by omega)),
+    extractByte_packBytes _ _ (by omega) (hchunk 2 (by omega)),
+    extractByte_packBytes _ _ (by omega) (hchunk 1 (by omega)),
+    extractByte_packBytes _ (4 * (i % 8 / 4)) (by omega)
+      (by simpa using hchunk 0 (by omega))]
+  simp only [List.getElem_take, List.getElem_drop]
+  rw [getElem_congr_idx
+      (show 8 * (i / 8) + (4 * (i % 8 / 4) + 3) = i + 3 from by omega),
+    getElem_congr_idx
+      (show 8 * (i / 8) + (4 * (i % 8 / 4) + 2) = i + 2 from by omega),
+    getElem_congr_idx
+      (show 8 * (i / 8) + (4 * (i % 8 / 4) + 1) = i + 1 from by omega),
+    getElem_congr_idx
+      (show 8 * (i / 8) + 4 * (i % 8 / 4) = i from by omega)]
+
+/-- `Region.word32At` at `base + i`, as list elements. -/
+theorem word32At_index (reg : Region) {i : Nat}
+    (hlen : i + 4 ≤ reg.bytes.length)
+    (hover : reg.base.toNat + i + 4 ≤ 2 ^ 64) :
+    reg.word32At (reg.base + BitVec.ofNat 64 i)
+      = (reg.bytes[i + 3]'(by omega) ++ reg.bytes[i + 2]'(by omega)
+          ++ reg.bytes[i + 1]'(by omega) ++ reg.bytes[i]'(by omega) : BitVec 32) := by
+  have hb : ∀ j : Nat, (hj : j < 4) →
+      reg.byteAt (reg.base + BitVec.ofNat 64 i + BitVec.ofNat 64 j)
+        = reg.bytes[i + j]'(by omega) := by
+    intro j hj
+    unfold Region.byteAt
+    rw [show (reg.base + BitVec.ofNat 64 i + BitVec.ofNat 64 j) - reg.base
+        = BitVec.ofNat 64 (i + j) from by bv_omega]
+    rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt (by omega)]
+    rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem (by omega)]
+    rfl
+  unfold Region.word32At
+  rw [show (3 : Word) = BitVec.ofNat 64 3 from rfl,
+    show (2 : Word) = BitVec.ofNat 64 2 from rfl,
+    show (1 : Word) = BitVec.ofNat 64 1 from rfl]
+  rw [hb 3 (by omega), hb 2 (by omega), hb 1 (by omega)]
+  congr 1
+  have := hb 0 (by omega)
+  rw [show reg.base + BitVec.ofNat 64 i + BitVec.ofNat 64 0
+      = reg.base + BitVec.ofNat 64 i from by bv_omega] at this
+  exact this
+
+/-- Load spec at register-file granularity: one step, the destination
+    receives the value the pure engine computes (`LoadOp.val`), the region
+    itself untouched. -/
 theorem regFile_load_spec_within (i : Instr) (l : LoadOp) (reg : Region)
     (rf : RegFile) (base : Word)
     (hsem : loadSem i = some l)
     (hreg : reg.wf)
     (hrd : (Reg.isExposed l.rd || l.rd == .x0) = true)
     (hrs1 : (Reg.isExposed l.rs1 || l.rs1 == .x0) = true)
-    (hin : ((rf.get l.rs1 + signExtend12 l.ofs) - reg.base).toNat
-      < reg.bytes.length) :
+    (hin : reg.loadOk (rf.get l.rs1 + signExtend12 l.ofs) l.nbytes) :
     cpsTripleWithin 1 base (base + 4) (CodeReq.singleton base i)
       ((regFileIs rf) ** bytesRegion reg.base reg.bytes)
       ((regFileIs (rf.set l.rd
-          (l.ext (reg.byteAt (rf.get l.rs1 + signExtend12 l.ofs))))) **
+          (l.val reg (rf.get l.rs1 + signExtend12 l.ofs)))) **
         bytesRegion reg.base reg.bytes) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some i := CodeReq.singleton_satisfiedBy.mp hcr
@@ -71,63 +170,138 @@ theorem regFile_load_spec_within (i : Instr) (l : LoadOp) (reg : Region)
   -- hPR : (regFileIs rf ** (bytesRegion ** R)).holdsFor s
   have hrs1v : s.getReg l.rs1 = rf.get l.rs1 :=
     holdsFor_regFileIs_agree hPR hrs1
-  have haddr_eq : rf.get l.rs1 + signExtend12 l.ofs
-      = reg.base + BitVec.ofNat 64
-          ((rf.get l.rs1 + signExtend12 l.ofs) - reg.base).toNat := by
-    bv_omega
-  have hover : reg.base.toNat
-      + ((rf.get l.rs1 + signExtend12 l.ofs) - reg.base).toNat < 2 ^ 64 := by
-    have := hreg.2.1
-    omega
-  have hvalidmem : isValidMemAddr (rf.get l.rs1 + signExtend12 l.ofs) = true := by
-    rw [haddr_eq]
-    exact hreg.2.2 _ hin
-  have hvalid : isValidByteAccess (s.getReg l.rs1 + signExtend12 l.ofs) = true := by
-    rw [isValidByteAccess_eq, hrs1v]
-    exact hvalidmem
-  -- the loaded byte
   have hPR2 : ((bytesRegion reg.base reg.bytes) ** (regFileIs rf ** R)).holdsFor s := by
     rw [sepConj_left_comm] at hPR
     exact hPR
-  have hgb : s.getByte (rf.get l.rs1 + signExtend12 l.ofs) = reg.bytes[
-      ((rf.get l.rs1 + signExtend12 l.ofs) - reg.base).toNat]'hin := by
-    conv_lhs => rw [haddr_eq]
-    exact holdsFor_bytesRegion_getByte hPR2 hreg.1 hin hover
-  have hbyteAt : reg.byteAt (rf.get l.rs1 + signExtend12 l.ofs)
-      = reg.bytes[((rf.get l.rs1 + signExtend12 l.ofs) - reg.base).toNat]'hin := by
-    unfold Region.byteAt
-    rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem hin]
-    rfl
-  -- one machine step
-  have hstep' : step s = some (execInstrBr s i) := by
+  rw [sepConj_left_comm] at hPR2
+  -- shared address facts
+  set addr := rf.get l.rs1 + signExtend12 l.ofs with haddr_def
+  obtain ⟨hdvd, hlen⟩ := hin
+  set i0 := (addr - reg.base).toNat with hi0_def
+  have hn : 1 ≤ l.nbytes := by
     cases i <;> simp only [loadSem, reduceCtorEq] at hsem <;>
-      (injection hsem with hsem; subst hsem;
-       first
-         | exact step_lbu hfetch hvalid
-         | exact step_lb hfetch hvalid)
-  have hexec : execInstrBr s i
-      = (s.setReg l.rd (l.ext (s.getByte (rf.get l.rs1 + signExtend12 l.ofs)))).setPC
-          (s.pc + 4) := by
-    cases i <;> simp only [loadSem, reduceCtorEq] at hsem <;>
-      (injection hsem with hsem; subst hsem;
-       simp only [execInstrBr]; rw [hrs1v])
+      (injection hsem with hsem; subst hsem; simp)
+  have hi0lt : i0 < reg.bytes.length := by omega
+  have haddr_eq : addr = reg.base + BitVec.ofNat 64 i0 := by
+    rw [hi0_def]
+    bv_omega
+  have hover : reg.base.toNat + i0 < 2 ^ 64 := by
+    have := hreg.2.1
+    omega
+  have haddr_toNat : addr.toNat = reg.base.toNat + i0 := by
+    rw [haddr_eq, BitVec.toNat_add, BitVec.toNat_ofNat]
+    omega
+  have hvalidmem : isValidMemAddr addr = true := by
+    rw [haddr_eq]
+    exact hreg.2.2 _ hi0lt
+  have hb8 : reg.base.toNat % 8 = 0 := hreg.1
+  -- one machine step, ending in the engine's value
+  have hkey : step s = some (execInstrBr s i)
+      ∧ execInstrBr s i
+        = (s.setReg l.rd (l.val reg addr)).setPC (s.pc + 4) := by
+    have hPR2' := hPR2
+    rw [sepConj_left_comm] at hPR2'
+    -- hPR2' : (bytesRegion ** (regFileIs ** R)).holdsFor s
+    cases i <;> simp only [loadSem, reduceCtorEq] at hsem
+    case LB rd rs1 ofs =>
+      injection hsem with hsem; subst hsem
+      simp only at hdvd hlen ⊢
+      refine ⟨step_lb hfetch (by rw [hrs1v]; simpa using hvalidmem), ?_⟩
+      simp only [execInstrBr]
+      rw [hrs1v]
+      show _ = (s.setReg _ ((reg.byteAt addr).signExtend 64)).setPC _
+      rw [show reg.byteAt addr = reg.bytes[i0]'hi0lt from by
+        unfold Region.byteAt
+        rw [← hi0_def, List.getD_eq_getElem?_getD,
+          List.getElem?_eq_getElem hi0lt]
+        rfl]
+      rw [show s.getByte addr = reg.bytes[i0]'hi0lt from by
+        conv_lhs => rw [haddr_eq]
+        exact holdsFor_bytesRegion_getByte hPR2' hb8 hi0lt hover]
+    case LBU rd rs1 ofs =>
+      injection hsem with hsem; subst hsem
+      simp only at hdvd hlen ⊢
+      refine ⟨step_lbu hfetch (by rw [hrs1v]; simpa using hvalidmem), ?_⟩
+      simp only [execInstrBr]
+      rw [hrs1v]
+      show _ = (s.setReg _ ((reg.byteAt addr).zeroExtend 64)).setPC _
+      rw [show reg.byteAt addr = reg.bytes[i0]'hi0lt from by
+        unfold Region.byteAt
+        rw [← hi0_def, List.getD_eq_getElem?_getD,
+          List.getElem?_eq_getElem hi0lt]
+        rfl]
+      rw [show s.getByte addr = reg.bytes[i0]'hi0lt from by
+        conv_lhs => rw [haddr_eq]
+        exact holdsFor_bytesRegion_getByte hPR2' hb8 hi0lt hover]
+    case LW rd rs1 ofs =>
+      injection hsem with hsem; subst hsem
+      simp only at hdvd hlen ⊢
+      have hvalid : isValidMemAccess (s.getReg rs1 + signExtend12 ofs) = true := by
+        rw [hrs1v]
+        show isValidMemAccess addr = true
+        simp only [isValidMemAccess_eq, Bool.and_eq_true]
+        refine ⟨hvalidmem, ?_⟩
+        simp only [isAligned4, beq_iff_eq]
+        omega
+      refine ⟨step_lw hfetch hvalid, ?_⟩
+      simp only [execInstrBr]
+      rw [hrs1v]
+      show _ = (s.setReg _ ((reg.word32At addr).signExtend 64)).setPC _
+      rw [show s.getWord32 addr = reg.word32At addr from by
+        conv_lhs => rw [haddr_eq]
+        rw [haddr_eq, word32At_index reg hlen (by have := hreg.2.1; omega)]
+        exact holdsFor_bytesRegion_getWord32 hPR2' hb8 hdvd hlen hover]
+    case LWU rd rs1 ofs =>
+      injection hsem with hsem; subst hsem
+      simp only at hdvd hlen ⊢
+      have hvalid : isValidMemAccess (s.getReg rs1 + signExtend12 ofs) = true := by
+        rw [hrs1v]
+        show isValidMemAccess addr = true
+        simp only [isValidMemAccess_eq, Bool.and_eq_true]
+        refine ⟨hvalidmem, ?_⟩
+        simp only [isAligned4, beq_iff_eq]
+        omega
+      refine ⟨step_lwu hfetch hvalid, ?_⟩
+      simp only [execInstrBr]
+      rw [hrs1v]
+      show _ = (s.setReg _ ((reg.word32At addr).zeroExtend 64)).setPC _
+      rw [show s.getWord32 addr = reg.word32At addr from by
+        conv_lhs => rw [haddr_eq]
+        rw [haddr_eq, word32At_index reg hlen (by have := hreg.2.1; omega)]
+        exact holdsFor_bytesRegion_getWord32 hPR2' hb8 hdvd hlen hover]
+    case LD rd rs1 ofs =>
+      injection hsem with hsem; subst hsem
+      simp only at hdvd hlen ⊢
+      have hvalid : isValidDwordAccess (s.getReg rs1 + signExtend12 ofs) = true := by
+        rw [hrs1v]
+        show isValidDwordAccess addr = true
+        simp only [isValidDwordAccess_eq, Bool.and_eq_true]
+        refine ⟨hvalidmem, ?_⟩
+        simp only [isAligned8, beq_iff_eq]
+        omega
+      refine ⟨step_ld hfetch hvalid, ?_⟩
+      simp only [execInstrBr]
+      rw [hrs1v]
+      show _ = (s.setReg _ (reg.dwordAt addr)).setPC _
+      rw [show reg.dwordAt addr = packBytes ((reg.bytes.drop i0).take 8) from rfl]
+      rw [show s.getMem addr = packBytes ((reg.bytes.drop i0).take 8) from by
+        conv_lhs => rw [haddr_eq]
+        exact holdsFor_bytesRegion_getMem hPR2' hdvd hi0lt]
+  obtain ⟨hstep', hexec⟩ := hkey
   refine ⟨1, Nat.le_refl 1,
-    (s.setReg l.rd (l.ext (s.getByte (rf.get l.rs1 + signExtend12 l.ofs)))).setPC
-      (s.pc + 4), ?_, rfl, ?_⟩
+    (s.setReg l.rd (l.val reg addr)).setPC (s.pc + 4), ?_, rfl, ?_⟩
   · show (step s).bind (stepN 0) = some _
     rw [hstep', hexec]; rfl
-  · rw [hgb, ← hbyteAt] at *
-    rcases Bool.or_eq_true_iff.mp hrd with hexp | hx0
+  · rcases Bool.or_eq_true_iff.mp hrd with hexp | hx0
     · have h1 := holdsFor_sepConj_regFileIs_setReg
-        (v := l.ext (reg.byteAt (rf.get l.rs1 + signExtend12 l.ofs))) hexp hPR
+        (v := l.val reg addr) hexp hPR
       rw [← sepConj_assoc'] at h1
       exact holdsFor_pcFree_setPC
         (pcFree_sepConj (pcFree_sepConj (pcFree_regFileIs _)
           (bytesRegion_pcFree _ _)) hR) h1
     · have hx0' : l.rd = .x0 := by simpa using hx0
       rw [hx0', RegFile.set_x0]
-      rw [show s.setReg .x0
-        (l.ext (reg.byteAt (rf.get l.rs1 + signExtend12 l.ofs))) = s from rfl]
+      rw [show s.setReg .x0 (l.val reg addr) = s from rfl]
       rw [← sepConj_assoc'] at hPR
       exact holdsFor_pcFree_setPC
         (pcFree_sepConj (pcFree_sepConj (pcFree_regFileIs _)

--- a/EvmAsm/Rv64/SAsm/Sym.lean
+++ b/EvmAsm/Rv64/SAsm/Sym.lean
@@ -18,6 +18,7 @@
 -/
 
 import EvmAsm.Rv64.Execution
+import EvmAsm.Rv64.ByteOps
 import EvmAsm.Rv64.SAsm.RegFile
 
 namespace EvmAsm.Rv64
@@ -41,6 +42,21 @@ def Region.empty : Region := ⟨0, []⟩
     VCs rule that out). -/
 def Region.byteAt (reg : Region) (addr : Word) : BitVec 8 :=
   reg.bytes.getD (addr - reg.base).toNat 0
+
+/-- Read the little-endian 32-bit word at a 4-aligned absolute address. -/
+def Region.word32At (reg : Region) (addr : Word) : BitVec 32 :=
+  reg.byteAt (addr + 3) ++ reg.byteAt (addr + 2)
+    ++ reg.byteAt (addr + 1) ++ reg.byteAt addr
+
+/-- Read the dword (as its packed cell) at an 8-aligned absolute address. -/
+def Region.dwordAt (reg : Region) (addr : Word) : Word :=
+  packBytes ((reg.bytes.drop (addr - reg.base).toNat).take 8)
+
+/-- Address side condition of an `n`-byte load: the index is `n`-aligned
+    within the region and the whole access fits. -/
+def Region.loadOk (reg : Region) (addr : Word) (n : Nat) : Prop :=
+  n ∣ (addr - reg.base).toNat
+    ∧ (addr - reg.base).toNat + n ≤ reg.bytes.length
 
 /-- Region well-formedness: dword-aligned base, no address wrap, and every
     byte within the machine's valid memory range.  Decidable for concrete
@@ -113,20 +129,24 @@ def aluSem : Instr → Option AluOp
   -- Everything else (memory, control flow, system) is not a block leaf.
   | _ => none
 
-/-- Classification of a byte load from the function's read-only region:
-    destination, address register, immediate offset, and how the byte
-    extends to a word. -/
+/-- Classification of a load from the function's read-only region:
+    destination, address register, immediate offset, access width in bytes,
+    and the loaded (extended) word as a function of region and address. -/
 structure LoadOp where
   rd : Reg
   rs1 : Reg
   ofs : BitVec 12
-  ext : BitVec 8 → Word
+  nbytes : Nat
+  val : Region → Word → Word
 
-/-- Classify a byte load.  `LBU`/`LB` only in M5a; wider loads arrive with
-    multi-byte region reads. -/
+/-- Classify a load.  Bytes, 32-bit words, and dwords; halfwords can be
+    added the same way when a user needs them. -/
 def loadSem : Instr → Option LoadOp
-  | .LBU rd rs1 ofs => some ⟨rd, rs1, ofs, fun b => b.zeroExtend 64⟩
-  | .LB  rd rs1 ofs => some ⟨rd, rs1, ofs, fun b => b.signExtend 64⟩
+  | .LBU rd rs1 ofs => some ⟨rd, rs1, ofs, 1, fun reg a => (reg.byteAt a).zeroExtend 64⟩
+  | .LB  rd rs1 ofs => some ⟨rd, rs1, ofs, 1, fun reg a => (reg.byteAt a).signExtend 64⟩
+  | .LW  rd rs1 ofs => some ⟨rd, rs1, ofs, 4, fun reg a => (reg.word32At a).signExtend 64⟩
+  | .LWU rd rs1 ofs => some ⟨rd, rs1, ofs, 4, fun reg a => (reg.word32At a).zeroExtend 64⟩
+  | .LD  rd rs1 ofs => some ⟨rd, rs1, ofs, 8, fun reg a => reg.dwordAt a⟩
   | _ => none
 
 /-- Symbolic execution of one instruction over the register file, reading
@@ -137,7 +157,7 @@ def execInstrRF (reg : Region) (rf : RegFile) (i : Instr) : RegFile :=
   | some op => rf.set op.rd (op.f rf.get)
   | none =>
     match loadSem i with
-    | some l => rf.set l.rd (l.ext (reg.byteAt (rf.get l.rs1 + signExtend12 l.ofs)))
+    | some l => rf.set l.rd (l.val reg (rf.get l.rs1 + signExtend12 l.ofs))
     | none => rf
 
 /-- Supported-and-exposed check for a block leaf instruction: the instruction
@@ -171,8 +191,7 @@ def blockVCs (reg : Region) (rf : RegFile) : List Instr → Prop
   | [] => True
   | i :: is =>
       (match loadSem i with
-       | some l =>
-           ((rf.get l.rs1 + signExtend12 l.ofs) - reg.base).toNat < reg.bytes.length
+       | some l => reg.loadOk (rf.get l.rs1 + signExtend12 l.ofs) l.nbytes
        | none => True)
       ∧ blockVCs reg (execInstrRF reg rf i) is
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2473,9 +2473,11 @@ generic Stmt.sound, Fn + vcgen, verified calls (FnHandle in the AST,
 caller-shaped Stmt.soundR/Fn.SpecR via cpsCallWithin, Fn.toHandle leaf
 packaging), and read-only byte regions (Region in Fn/FnHandle, LBU/LB in
 the block engine with per-block .mem VCs, region-carrying asrtM triples,
-RLP-prefix-classification demo over a symbolic input buffer). Remaining:
-M5b (.rw regions + stores; ra-spill prologue for multi-level call trees;
-wider loads), then port an SSZ routine from Stateless/.
+RLP-prefix-classification demo over a symbolic input buffer), and wider
+read-only loads (LW/LWU/LD with aligned in-range VCs; SSZ-style u32
+offset-read demo). Remaining: M5b-2 (.rw regions + stores; ra-spill
+prologue for multi-level call trees; LH/LHU), then port an SSZ routine
+from Stateless/.
 
 ## Stateless Guest (parallel STF track)
 


### PR DESCRIPTION
## Summary

Follow-up to #9647 ([design](docs/sasm-design.md) §3.4): the SAsm block engine now supports the loads the `Stateless/SSZ` routines actually use — `LW`/`LWU` (SSZ u32 offset tables) and `LD` (u64 fields) — alongside the existing `LBU`/`LB`.

- **Engine**: `LoadOp` generalizes to a width + value function. `Region.word32At` is the little-endian append of four region bytes; `Region.dwordAt` is the packed 8-byte cell. Per-load side conditions become `Region.loadOk` (index `n`-aligned within the region, access fits), still surfacing as one labeled `.mem` VC per block.
- **Soundness**: new bridges from the dword-packed memory model — `extractWord32_eq_append` (bit-level, per-position), `holdsFor_bytesRegion_cell`/`getMem`/`getWord32`, and `word32At_index`. `regFile_load_spec_within` dispatches all five load shapes, deriving the machine's `isValidMemAccess`/`isValidDwordAccess` (range + 4-/8-alignment) from `Region.wf` + `loadOk` — users never see an alignment obligation beyond the pure `.mem` VC.
- **Demo** (`ExamplesVc.lean`): `sszReadOffsetFn` — `LWU` of the little-endian u32 at byte offset 4 of a symbolic input buffer, the exact shape of the SSZ offset-table walks in `Stateless/SSZ/Decode`, verified end to end through `vcgen`.

`LH`/`LHU` slot in the same way when needed; `.rw` regions + stores (and with them the ra-spill prologue for multi-level call trees) remain for M5b-2, per PLAN.md.

## Test plan
- Full `lake build` green (3665 jobs); `scripts/check-no-warnings.sh` → 0 warnings under `EvmAsm/`
- `scripts/check-forbidden-tactics.sh` clean
- `#print axioms` on `regFile_load_spec_within`, `sszReadOffsetFn_spec` → `propext, Classical.choice, Quot.sound` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)