### PR TITLE
Stateless: emit the verified SAsm read_chain_id drop-in

### DIFF
--- a/EvmAsm/Stateless/Entry.lean
+++ b/EvmAsm/Stateless/Entry.lean
@@ -73,6 +73,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Stateless.SSZ.Decode.Program
+import EvmAsm.Stateless.SSZ.Decode.ChainIdSAsm
 import EvmAsm.Stateless.SSZ.Encode.Program
 
 namespace EvmAsm.Stateless
@@ -87,7 +88,11 @@ open EvmAsm.Rv64
     Replaced in successor PRs by the full decode → validate →
     execute → encode pipeline. -/
 def run_stateless_guest : Program :=
-  EvmAsm.Stateless.SSZ.Decode.read_chain_id ++
+  -- Verified SAsm replacement for `read_chain_id` (byte-wise reads; the
+  -- original's misaligned LWU/LD trap under the Lean model — see
+  -- EvmAsm/Stateless/SSZ/Decode/ChainIdSAsm.lean and beads evm-asm-iwzun).
+  -- Same interface (a0 = chain_id, a3 = chain_config addr) plus a t0 clobber.
+  EvmAsm.Stateless.SSZ.Decode.read_chain_id_verified ++
   EvmAsm.Stateless.SSZ.Decode.read_active_fork ++
   EvmAsm.Stateless.SSZ.Decode.decode_validation_bit ++
   EvmAsm.Stateless.SSZ.Decode.decode_header_count ++

--- a/EvmAsm/Stateless/SSZ/Decode/ChainIdSAsm.lean
+++ b/EvmAsm/Stateless/SSZ/Decode/ChainIdSAsm.lean
@@ -85,16 +85,9 @@ theorem leU32_toNat_lt (bs : List (BitVec 8)) (i : Nat) :
 -- The port
 -- ============================================================================
 
-/-- Verified port of `read_chain_id`: `a0 := chain_config.chain_id`, read
-    byte-wise from the (ghost) input buffer `bs` at `INPUT_BASE`.
-    Clobbers t0, a1–a3 — the same interface as the original plus `t0`. -/
-def readChainIdFn (bs : List (BitVec 8)) : Fn where
-  name := "readChainId"
-  region := ⟨0x40000000, bs⟩
-  pre := fun _ =>
-    30 ≤ bs.length ∧ 18 + (leU32 bs 26).toNat + 8 ≤ bs.length
-  post := fun rf => rf.get .x10 = leU64 bs (18 + (leU32 bs 26).toNat)
-  body :=
+/-- The structured body of the verified `read_chain_id` (ghost-free, so it
+    flattens to a concrete `Program`). -/
+def readChainIdBody : Stmt :=
     .block "setup" [.LI .x11 0x40000000, .ADDI .x12 .x11 18] ;;;
     .block "offset32" [
       .LBU .x13 .x12 8,
@@ -111,6 +104,29 @@ def readChainIdFn (bs : List (BitVec 8)) : Fn where
       .LBU .x5 .x13 5, .SLLI .x5 .x5 40, .OR .x10 .x10 .x5,
       .LBU .x5 .x13 6, .SLLI .x5 .x5 48, .OR .x10 .x10 .x5,
       .LBU .x5 .x13 7, .SLLI .x5 .x5 56, .OR .x10 .x10 .x5]
+
+/-- Verified port of `read_chain_id`: `a0 := chain_config.chain_id`, read
+    byte-wise from the (ghost) input buffer `bs` at `INPUT_BASE`; `a3` is
+    left holding the chain-config section address (the interface
+    `read_active_fork` documents).  Clobbers t0, a1–a3 — the original's
+    interface plus `t0`. -/
+def readChainIdFn (bs : List (BitVec 8)) : Fn where
+  name := "readChainId"
+  region := ⟨0x40000000, bs⟩
+  pre := fun _ =>
+    30 ≤ bs.length ∧ 18 + (leU32 bs 26).toNat + 8 ≤ bs.length
+  post := fun rf =>
+    rf.get .x10 = leU64 bs (18 + (leU32 bs 26).toNat) ∧
+    rf.get .x13 = (0x40000012 : Word) + leU32 bs 26
+  body := readChainIdBody
+
+/-- The emitted drop-in replacement for `read_chain_id`
+    (position-independent: no calls, all branches structured). -/
+def read_chain_id_verified : Program :=
+  readChainIdBody.flatten 0
+
+#guard (read_chain_id_verified : List Instr).length = 35
+#guard readChainIdBody.flatten 0 = readChainIdBody.flatten 0x80000000
 
 /-- The input buffer forms a well-formed SAsm region (dword-aligned base in
     the machine's input zone). -/
@@ -191,7 +207,8 @@ theorem readChainIdFn_spec (bs : List (BitVec 8))
       | bv_omega
   case readChainId.post =>
     intro rf' h
-    show rf'.get .x10 = leU64 bs (18 + (leU32 bs 26).toNat)
+    show rf'.get .x10 = leU64 bs (18 + (leU32 bs 26).toNat) ∧
+      rf'.get .x13 = (0x40000012 : Word) + leU32 bs 26
     obtain ⟨rf₂, ⟨rf₁, ⟨rf₀, ⟨hlen30, hoff⟩, rfl⟩, rfl⟩, rfl⟩ := h
     simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem, loadSem,
       RegFile.get_set_self, RegFile.get_set_ne, ne_eq, reduceCtorEq,
@@ -239,6 +256,7 @@ theorem readChainIdFn_spec (bs : List (BitVec 8))
           = 18 + (leU32 bs 26).toNat + 6 from by bv_omega,
       show ((1073741824 : Word) + 18 + leU32 bs 26 + 7 - 0x40000000).toNat
           = 18 + (leU32 bs 26).toNat + 7 from by bv_omega]
-    rfl
+    refine ⟨rfl, ?_⟩
+    rw [show (1073741824 : Word) + 18 = (0x40000012 : Word) from by decide]
 
 end EvmAsm.Stateless.SSZ.Decode


### PR DESCRIPTION
## Summary

`run_stateless_guest` now emits **`read_chain_id_verified`** — the flattened body of the machine-checked `readChainIdFn` (PR #9651) — in place of the original `read_chain_id`.

- **Why**: the original's `LWU` at `0x4000001A` (2 mod 4) and data-dependent `LD` are misaligned and trap under the Lean RV64 model (bug bead `evm-asm-iwzun`); the verified routine assembles the u32 offset and u64 chain-id from one-byte loads (35 instructions vs 5).
- **Interface**: preserved — `a0 = chain_id`, and `a3 = chain_config section address` (consumed by `read_active_fork`; now part of the *verified postcondition*, extended in this PR). One additional clobber (`t0`), which is write-before-read everywhere downstream (checked).
- The program is position-independent (`#guard flatten 0 = flatten 0x80000000`), so the swap shifts subsequent routines without any offset fixups.

## Validation: 200 random EEST cases, spike backend, baseline A/B

Per request: built `spike_run` from `riscv-isa-sim` (`scripts/spike/build.sh`), emitted two ELFs — `stateless_guest_baseline.elf` (pre-change tree) and `stateless_guest_sasm.elf` (this branch) — and ran the *same* randomly selected 200 stateless fixtures (seed `4242`, reproducible via `--random --seed 4242 --limit 200`) from the 23,219-fixture `zkevm@v0.4.0` corpus through `scripts/codegen-eest-stateless-check.sh --backend spike` against each ELF, pinned via `GUEST_ELF`/`--no-build`.

**Result: per-case classifications identical on all 200 fixtures — and all 200 are `PASS(full)` (complete 105-byte `SszStatelessValidationResult` parity) on both ELFs.** No new failures, no lost passes, no divergence of any kind.

## Test plan
- Full `lake build` green; `check-no-warnings.sh` 0; `check-unimported.sh` 0 orphans; forbidden-tactics clean
- `#print axioms readChainIdFn_spec` → classical axioms only
- EEST spike A/B as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)