### PR TITLE
feat(sasm): LH/LHU halfword loads from read-only regions

### DIFF
--- a/EvmAsm/Rv64/SAsm/ExamplesVc.lean
+++ b/EvmAsm/Rv64/SAsm/ExamplesVc.lean
@@ -278,6 +278,47 @@ theorem sszReadOffsetFn_spec (inBase : Word) (bs : List (BitVec 8))
       show inBase + 4 - inBase = (4 : Word) from by bv_omega]
     rfl
 
+/-- Read the little-endian u16 at byte offset 2 of the input into a1 —
+    exercises the LHU block leaf. -/
+def readU16Fn (inBase : Word) (bs : List (BitVec 8)) : Fn where
+  name := "readU16"
+  region := ⟨inBase, bs⟩
+  pre := fun rf => rf.get .x10 = inBase ∧ 4 ≤ bs.length
+  post := fun rf => rf.get .x11
+    = BitVec.zeroExtend 64 (bs.getD 3 0 ++ bs.getD 2 0)
+  body := .block "load" [.LHU .x11 .x10 2]
+
+theorem readU16Fn_spec (inBase : Word) (bs : List (BitVec 8))
+    (hwf : (Region.mk inBase bs).wf) (base : Word) :
+    (readU16Fn inBase bs).Spec base := by
+  have haddr : ∀ rf : RegFile, rf.get .x10 = inBase →
+      ((rf.get .x10 + signExtend12 (2 : BitVec 12)) - inBase).toNat = 2 := by
+    intro rf h
+    rw [h, show signExtend12 (2 : BitVec 12) = (2 : Word) from by decide]
+    bv_omega
+  vcgen
+  case region => exact hwf
+  case readU16.load.mem =>
+    rintro rf ⟨hx10, hlen⟩
+    refine ⟨⟨?_, ?_⟩, trivial⟩
+    · show (2 : Nat) ∣ ((rf.get .x10 + signExtend12 (2 : BitVec 12)) - inBase).toNat
+      rw [haddr rf hx10]
+    · show ((rf.get .x10 + signExtend12 (2 : BitVec 12)) - inBase).toNat + 2
+        ≤ bs.length
+      rw [haddr rf hx10]
+      omega
+  case readU16.post =>
+    rintro rf' ⟨rf₀, ⟨hx10, hlen⟩, rfl⟩
+    show RegFile.get _ .x11 = _
+    simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem, loadSem]
+    rw [RegFile.get_set_self _ .x11 _ (by decide)]
+    rw [hx10, show signExtend12 (2 : BitVec 12) = (2 : Word) from by decide]
+    show BitVec.zeroExtend 64 (Region.half16At ⟨inBase, bs⟩ (inBase + 2)) = _
+    unfold Region.half16At Region.byteAt
+    rw [show inBase + 2 + 1 - inBase = (3 : Word) from by bv_omega,
+      show inBase + 2 - inBase = (2 : Word) from by bv_omega]
+    rfl
+
 end ExamplesVc
 end SAsm
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/RegionSound.lean
+++ b/EvmAsm/Rv64/SAsm/RegionSound.lean
@@ -121,6 +121,71 @@ theorem holdsFor_bytesRegion_getWord32 {b : Word} {bs : List (BitVec 8)}
     getElem_congr_idx
       (show 8 * (i / 8) + 4 * (i % 8 / 4) = i from by omega)]
 
+/-- `extractHalfword` is the little-endian append of its two bytes. -/
+theorem extractHalfword_eq_append (w : Word) (p : Nat) (hp : p < 4) :
+    extractHalfword w p
+      = extractByte w (2 * p + 1) ++ extractByte w (2 * p) := by
+  interval_cases p <;>
+    (apply BitVec.eq_of_getLsbD_eq
+     intro i hi
+     simp only [extractHalfword, extractByte, BitVec.getLsbD_append,
+       BitVec.truncate, BitVec.getLsbD_setWidth, BitVec.getLsbD_ushiftRight]
+     interval_cases i <;> simp)
+
+/-- Read the aligned little-endian halfword at region index `i` from a
+    framed `bytesRegion`. -/
+theorem holdsFor_bytesRegion_getHalfword {b : Word} {bs : List (BitVec 8)}
+    {R : Assertion} {s : MachineState}
+    (hPR : ((bytesRegion b bs) ** R).holdsFor s)
+    {i : Nat} (halign : b.toNat % 8 = 0) (h2 : 2 ∣ i)
+    (hlen : i + 2 ≤ bs.length) (hover : b.toNat + i < 2 ^ 64) :
+    s.getHalfword (b + BitVec.ofNat 64 i)
+      = (bs[i + 1]'(by omega) ++ bs[i]'(by omega) : BitVec 16) := by
+  have hcell := holdsFor_bytesRegion_cell hPR (show i < bs.length by omega)
+  show extractHalfword (s.getMem (alignToDword (b + BitVec.ofNat 64 i)))
+    (byteOffset (b + BitVec.ofNat 64 i) / 2) = _
+  rw [alignToDword_add_ofNat_of_aligned halign hover,
+    byteOffset_add_ofNat_of_aligned halign hover, hcell,
+    extractHalfword_eq_append _ _ (by omega)]
+  have hchunk : ∀ j, j < 2 →
+      2 * (i % 8 / 2) + j < ((bs.drop (8 * (i / 8))).take 8).length := by
+    intro j hj
+    simp only [List.length_take, List.length_drop]
+    omega
+  rw [extractByte_packBytes _ _ (by omega) (hchunk 1 (by omega)),
+    extractByte_packBytes _ (2 * (i % 8 / 2)) (by omega)
+      (by simpa using hchunk 0 (by omega))]
+  simp only [List.getElem_take, List.getElem_drop]
+  rw [getElem_congr_idx
+      (show 8 * (i / 8) + (2 * (i % 8 / 2) + 1) = i + 1 from by omega),
+    getElem_congr_idx
+      (show 8 * (i / 8) + 2 * (i % 8 / 2) = i from by omega)]
+
+/-- `Region.half16At` at `base + i`, as list elements. -/
+theorem half16At_index (reg : Region) {i : Nat}
+    (hlen : i + 2 ≤ reg.bytes.length)
+    (hover : reg.base.toNat + i + 2 ≤ 2 ^ 64) :
+    reg.half16At (reg.base + BitVec.ofNat 64 i)
+      = (reg.bytes[i + 1]'(by omega) ++ reg.bytes[i]'(by omega) : BitVec 16) := by
+  have hb : ∀ j : Nat, (hj : j < 2) →
+      reg.byteAt (reg.base + BitVec.ofNat 64 i + BitVec.ofNat 64 j)
+        = reg.bytes[i + j]'(by omega) := by
+    intro j hj
+    unfold Region.byteAt
+    rw [show (reg.base + BitVec.ofNat 64 i + BitVec.ofNat 64 j) - reg.base
+        = BitVec.ofNat 64 (i + j) from by bv_omega]
+    rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt (by omega)]
+    rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem (by omega)]
+    rfl
+  unfold Region.half16At
+  rw [show (1 : Word) = BitVec.ofNat 64 1 from rfl]
+  rw [hb 1 (by omega)]
+  congr 1
+  have := hb 0 (by omega)
+  rw [show reg.base + BitVec.ofNat 64 i + BitVec.ofNat 64 0
+      = reg.base + BitVec.ofNat 64 i from by bv_omega] at this
+  exact this
+
 /-- `Region.word32At` at `base + i`, as list elements. -/
 theorem word32At_index (reg : Region) {i : Nat}
     (hlen : i + 4 ≤ reg.bytes.length)
@@ -233,6 +298,42 @@ theorem regFile_load_spec_within (i : Instr) (l : LoadOp) (reg : Region)
       rw [show s.getByte addr = reg.bytes[i0]'hi0lt from by
         conv_lhs => rw [haddr_eq]
         exact holdsFor_bytesRegion_getByte hPR2' hb8 hi0lt hover]
+    case LH rd rs1 ofs =>
+      injection hsem with hsem; subst hsem
+      simp only at hdvd hlen ⊢
+      have hvalid : isValidHalfwordAccess (s.getReg rs1 + signExtend12 ofs) = true := by
+        rw [hrs1v]
+        show isValidHalfwordAccess addr = true
+        simp only [isValidHalfwordAccess_eq, Bool.and_eq_true]
+        refine ⟨hvalidmem, ?_⟩
+        simp only [isAligned2_eq, beq_iff_eq]
+        omega
+      refine ⟨step_lh hfetch hvalid, ?_⟩
+      simp only [execInstrBr]
+      rw [hrs1v]
+      show _ = (s.setReg _ ((reg.half16At addr).signExtend 64)).setPC _
+      rw [show s.getHalfword addr = reg.half16At addr from by
+        conv_lhs => rw [haddr_eq]
+        rw [haddr_eq, half16At_index reg hlen (by have := hreg.2.1; omega)]
+        exact holdsFor_bytesRegion_getHalfword hPR2' hb8 hdvd hlen hover]
+    case LHU rd rs1 ofs =>
+      injection hsem with hsem; subst hsem
+      simp only at hdvd hlen ⊢
+      have hvalid : isValidHalfwordAccess (s.getReg rs1 + signExtend12 ofs) = true := by
+        rw [hrs1v]
+        show isValidHalfwordAccess addr = true
+        simp only [isValidHalfwordAccess_eq, Bool.and_eq_true]
+        refine ⟨hvalidmem, ?_⟩
+        simp only [isAligned2_eq, beq_iff_eq]
+        omega
+      refine ⟨step_lhu hfetch hvalid, ?_⟩
+      simp only [execInstrBr]
+      rw [hrs1v]
+      show _ = (s.setReg _ ((reg.half16At addr).zeroExtend 64)).setPC _
+      rw [show s.getHalfword addr = reg.half16At addr from by
+        conv_lhs => rw [haddr_eq]
+        rw [haddr_eq, half16At_index reg hlen (by have := hreg.2.1; omega)]
+        exact holdsFor_bytesRegion_getHalfword hPR2' hb8 hdvd hlen hover]
     case LW rd rs1 ofs =>
       injection hsem with hsem; subst hsem
       simp only at hdvd hlen ⊢

--- a/EvmAsm/Rv64/SAsm/Sym.lean
+++ b/EvmAsm/Rv64/SAsm/Sym.lean
@@ -43,6 +43,10 @@ def Region.empty : Region := ⟨0, []⟩
 def Region.byteAt (reg : Region) (addr : Word) : BitVec 8 :=
   reg.bytes.getD (addr - reg.base).toNat 0
 
+/-- Read the little-endian 16-bit halfword at a 2-aligned absolute address. -/
+def Region.half16At (reg : Region) (addr : Word) : BitVec 16 :=
+  reg.byteAt (addr + 1) ++ reg.byteAt addr
+
 /-- Read the little-endian 32-bit word at a 4-aligned absolute address. -/
 def Region.word32At (reg : Region) (addr : Word) : BitVec 32 :=
   reg.byteAt (addr + 3) ++ reg.byteAt (addr + 2)
@@ -139,11 +143,12 @@ structure LoadOp where
   nbytes : Nat
   val : Region → Word → Word
 
-/-- Classify a load.  Bytes, 32-bit words, and dwords; halfwords can be
-    added the same way when a user needs them. -/
+/-- Classify a load.  Bytes, halfwords, 32-bit words, and dwords. -/
 def loadSem : Instr → Option LoadOp
   | .LBU rd rs1 ofs => some ⟨rd, rs1, ofs, 1, fun reg a => (reg.byteAt a).zeroExtend 64⟩
   | .LB  rd rs1 ofs => some ⟨rd, rs1, ofs, 1, fun reg a => (reg.byteAt a).signExtend 64⟩
+  | .LHU rd rs1 ofs => some ⟨rd, rs1, ofs, 2, fun reg a => (reg.half16At a).zeroExtend 64⟩
+  | .LH  rd rs1 ofs => some ⟨rd, rs1, ofs, 2, fun reg a => (reg.half16At a).signExtend 64⟩
   | .LW  rd rs1 ofs => some ⟨rd, rs1, ofs, 4, fun reg a => (reg.word32At a).signExtend 64⟩
   | .LWU rd rs1 ofs => some ⟨rd, rs1, ofs, 4, fun reg a => (reg.word32At a).zeroExtend 64⟩
   | .LD  rd rs1 ofs => some ⟨rd, rs1, ofs, 8, fun reg a => reg.dwordAt a⟩

--- a/PLAN.md
+++ b/PLAN.md
@@ -2478,8 +2478,9 @@ read-only loads (LW/LWU/LD with aligned in-range VCs), and the **first
 real port**: `readChainIdFn` (Stateless/SSZ/Decode/ChainIdSAsm.lean), a
 fully verified `read_chain_id` reading byte-wise — the original's
 misaligned LWU/LD trap under the Lean model (bug bead evm-asm-iwzun).
-Remaining: M5b-2 (.rw regions + stores; ra-spill prologue for multi-level
-call trees; LH/LHU), then more Stateless/SSZ ports.
+LH/LHU halfword loads done (Region.half16At + getHalfword bridge, LHU
+demo). Remaining: M5b-2 (.rw regions + stores; ra-spill prologue for
+multi-level call trees), then more Stateless/SSZ ports.
 
 ## Stateless Guest (parallel STF track)
 


### PR DESCRIPTION
First slice of SAsm M5b-2 (bead evm-asm-hzg1w): halfword loads from the function's read-only region.

- `Region.half16At` — little-endian 2-byte read, mirroring `word32At`
- `loadSem` cases for `LH`/`LHU` (`nbytes = 2`), so they become supported block leaves with the usual per-block `.mem` VC (`2 ∣ index ∧ fits`)
- Bridges `extractHalfword_eq_append`, `holdsFor_bytesRegion_getHalfword`, `half16At_index` — the halfword analogue of the word32 chain
- Two new cases in `regFile_load_spec_within`: machine `isValidHalfwordAccess` (range ∧ 2-aligned) derived from `Region.wf` + `loadOk`
- Demo `readU16Fn` runs an LHU end to end through `vcgen`

No emitted-code changes (pure verification infrastructure), so no EEST run needed. Axiom-clean (propext/Classical.choice/Quot.sound only).

Next slices on this milestone: writable regions + stores, then the ra-spill prologue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)