### PR TITLE
feat(sasm): ra-spill packaging — callers as callees (Fn.toHandleR)

### DIFF
--- a/EvmAsm/Rv64/SAsm.lean
+++ b/EvmAsm/Rv64/SAsm.lean
@@ -18,6 +18,7 @@ import EvmAsm.Rv64.SAsm.StmtSound
 import EvmAsm.Rv64.SAsm.Handle
 import EvmAsm.Rv64.SAsm.StmtSoundCall
 import EvmAsm.Rv64.SAsm.Fn
+import EvmAsm.Rv64.SAsm.RaSpill
 import EvmAsm.Rv64.SAsm.Tactic
 import EvmAsm.Rv64.SAsm.Examples
 import EvmAsm.Rv64.SAsm.ExamplesVc

--- a/EvmAsm/Rv64/SAsm/ExamplesVc.lean
+++ b/EvmAsm/Rv64/SAsm/ExamplesVc.lean
@@ -6,6 +6,7 @@
   goals.  These double as regression tests for the tactic.
 -/
 
+import EvmAsm.Rv64.SAsm.RaSpill
 import EvmAsm.Rv64.SAsm.Tactic
 
 namespace EvmAsm.Rv64
@@ -385,6 +386,206 @@ theorem spillFn_spec (scratch x base : Word)
     rw [List.take_of_length_le (by rw [length_setBytes]; omega)]
     rw [hx10]
     exact (packBytes_setBytes_dword ws₀ x (by omega)).symm
+
+-- ============================================================================
+-- Callers as callees (ra-spill packaging): a two-level call tree
+-- ============================================================================
+
+/-- The demo call tree's shared writable region: one dword spill slot at
+    `0x10000` (`CalleesIn` requires every function in the tree to declare
+    the same writable region). -/
+def spillRw : RwRegion := ⟨0x10000, 8⟩
+
+/-- Leaf callee: set a0 := 5.  Ghost `v` is the caller's spilled return
+    address: the leaf shares the writable region, so its contract records
+    that it leaves the slot alone (its own `.post` VC proves it). -/
+def leafFn (v : Word) : Fn where
+  name := "leaf"
+  rw := spillRw
+  pre := fun rf ws => rf.get .x12 = 0x10000 ∧ ws = dwordBytes v
+  post := fun rf ws => rf.get .x10 = 5 ∧ rf.get .x12 = 0x10000
+    ∧ ws = dwordBytes v
+  body := .block "set" [.LI .x10 5]
+
+theorem leafFn_spec (v base : Word) : (leafFn v).Spec base := by
+  vcgen
+  case region => exact ⟨Region.empty_wf, (by decide : spillRw.wf)⟩
+  case leaf.post =>
+    rintro rf' ws' ⟨rf₀, ws₀, hws₀, ⟨hx12, hslot⟩, rfl, rfl⟩
+    simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem]
+    refine ⟨?_, ?_, hslot⟩
+    · rw [RegFile.get_set_self _ _ _ (by decide)]
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide)]
+      exact hx12
+
+/-- The leaf as a callee at `0x2000`. -/
+def leafHandle (v : Word) : FnHandle :=
+  (leafFn v).toHandle 0x2000 (leafFn_spec v 0x2000)
+    ((by decide : 4 * ((leafFn 0).body.size + 1) ≤ 2 ^ 64))
+
+/-- The mid-level caller: call the leaf.  Ghost `v` is its own spilled
+    return address, threaded through the whole call so the packaging can
+    restore it. -/
+def callerRVFn (v : Word) : Fn where
+  name := "callerR"
+  rw := spillRw
+  pre := fun rf ws => rf.get .x12 = 0x10000 ∧ ws = dwordBytes v
+  post := fun rf ws => rf.get .x10 = 5 ∧ rf.get .x12 = 0x10000
+    ∧ ws = dwordBytes v
+  body := .call "leaf" (leafHandle v)
+
+/-- The handle-facing view of the caller: the spill slot's contents are
+    nobody's business outside the wrapper. -/
+def callerRFn : Fn :=
+  { callerRVFn 0 with
+    pre := fun rf _ => rf.get .x12 = 0x10000
+    post := fun rf _ => rf.get .x10 = 5 ∧ rf.get .x12 = 0x10000 }
+
+/-- Ambient code: the caller's spill-wrapped code at `0x1000` plus the
+    leaf's. -/
+def callerRCr : CodeReq :=
+  (CodeReq.ofProg 0x1000 (callerRFn.programRetR .x12 0 0x1000)).union
+    (leafHandle 0).code
+
+theorem callerRVFn_spec (v : Word) :
+    (callerRVFn v).SpecR (0x1000 + 4) callerRCr := by
+  vcgen
+  case region => exact ⟨Region.empty_wf, (by decide : spillRw.wf)⟩
+  case code =>
+    intro a i h
+    have h' : CodeReq.ofProg 0x1000 (callerRFn.programRetR .x12 0 0x1000)
+        a = some i := by
+      show CodeReq.ofProg 0x1000 (Instr.SD .x12 .x1 0 ::
+        (callerRFn.body.flatten (0x1000 + 4)
+          ++ [Instr.LD .x1 .x12 0, Instr.JALR .x0 .x1 0])) a = some i
+      apply ofProg_cons_tail
+        ((by decide : 4 * ((callerRFn.body.flatten (0x1000 + 4)
+          ++ [Instr.LD .x1 .x12 0, Instr.JALR .x0 .x1 0]).length + 1) ≤ 2 ^ 64))
+      apply ofProg_mono_left
+      exact h
+    simp only [callerRCr, CodeReq.union, h']
+  case callees =>
+    refine ⟨?_, rfl, rfl⟩
+    intro a i h
+    obtain ⟨kk, hk, rfl⟩ := ofProg_some_range h
+    have hlen0 : ((leafFn 0).programRet 0x2000).length = 2 := by decide
+    have hlen : ((leafFn v).programRet 0x2000).length = 2 := hlen0
+    rw [hlen] at hk
+    simp only [callerRCr, CodeReq.union]
+    rw [CodeReq.ofProg_none_range 0x1000 (callerRFn.programRetR .x12 0 0x1000)
+      (fun k' hk' heq => ?_)]
+    · exact h
+    · have hlen' : (callerRFn.programRetR .x12 0 0x1000).length = 4 := by
+        decide
+      rw [hlen'] at hk'
+      bv_omega
+  case calls =>
+    have h0 : (callerRVFn 0).body.callsOk (0x1000 + 4) :=
+      ⟨by decide, by decide, by decide⟩
+    exact h0
+  case callerR.leaf.pre =>
+    exact fun rf ws h => h
+  case callerR.post =>
+    exact fun rf ws h => h
+
+private theorem callerR_hcode : ∀ a i,
+    CodeReq.ofProg 0x1000 (callerRFn.programRetR .x12 0 0x1000) a = some i →
+    callerRCr a = some i := by
+  intro a i h
+  simp only [callerRCr, CodeReq.union, h]
+
+private theorem callerR_haddr : ∀ rf ws, callerRFn.pre rf ws →
+    rf.get .x12 + signExtend12 0 = callerRFn.rw.base + BitVec.ofNat 64 0 := by
+  intro rf ws h
+  rw [show rf.get .x12 = 0x10000 from h]
+  decide
+
+private theorem callerR_haddrPost : ∀ (v : Word) rf ws,
+    (callerRVFn v).post rf ws →
+    rf.get .x12 + signExtend12 0 = callerRFn.rw.base + BitVec.ofNat 64 0 := by
+  intro v rf ws h
+  rw [show rf.get .x12 = 0x10000 from h.2.1]
+  decide
+
+private theorem callerR_hspre : ∀ (v : Word) rf ws, callerRFn.pre rf ws →
+    ws.length = callerRFn.rw.len →
+    (callerRVFn v).pre rf (setBytes ws 0 (dwordBytes v)) := by
+  intro v rf ws h hlen
+  refine ⟨h, ?_⟩
+  have hlen8 : ws.length = 8 := hlen
+  have h1 := setBytes_slot ws (dwordBytes v) 0
+    (by rw [length_dwordBytes]; omega)
+  rw [List.drop_zero, length_dwordBytes,
+    List.take_of_length_le (by rw [length_setBytes]; omega)] at h1
+  exact h1
+
+private theorem callerR_hspost : ∀ (v : Word) rf ws,
+    (callerRVFn v).post rf ws → callerRFn.post rf ws :=
+  fun _ _ _ h => ⟨h.1, h.2.1⟩
+
+private theorem callerR_hslot : ∀ (v : Word) rf ws,
+    (callerRVFn v).post rf ws → ws.length = callerRFn.rw.len →
+    (ws.drop 0).take 8 = dwordBytes v := by
+  intro v rf ws h hlen
+  rw [h.2.2, List.drop_zero,
+    List.take_of_length_le (by rw [length_dwordBytes])]
+
+/-- The caller, packaged as a callee: its `ra` is spilled to the scratch
+    slot around the body.  This is the "callers as callees" milestone: the
+    packaged handle can itself be called. -/
+def callerRHandle : FnHandle :=
+  callerRFn.toHandleR 0x1000 callerRCr .x12 0 0
+    (fun v => (callerRVFn v).pre) (fun v => (callerRVFn v).post)
+    (by decide)
+    ((by decide : spillRw.wf))
+    (by decide) ((by decide : 0 + 8 ≤ spillRw.len))
+    ((by decide : 4 * (callerRFn.body.size + 3) ≤ 2 ^ 64))
+    (fun v => callerRVFn_spec v)
+    callerR_hcode callerR_haddr callerR_haddrPost
+    callerR_hspre callerR_hspost callerR_hslot
+
+/-- A top-level caller consuming the packaged handle: the mid-level caller
+    really is a callee. -/
+def topFn : Fn where
+  name := "top"
+  rw := spillRw
+  pre := fun rf _ => rf.get .x12 = 0x10000
+  post := fun rf _ => rf.get .x10 = 5 ∧ rf.get .x12 = 0x10000
+  body := .call "callerR" callerRHandle
+
+/-- Ambient code of the top-level caller at `0x3000`. -/
+def topCr : CodeReq :=
+  (CodeReq.ofProg 0x3000 (topFn.body.flatten 0x3000)).union callerRCr
+
+theorem topFn_spec : topFn.SpecR 0x3000 topCr := by
+  vcgen
+  case code =>
+    intro a i h
+    simp only [topCr, CodeReq.union, h]
+  case callees =>
+    refine ⟨?_, rfl, rfl⟩
+    intro a i h
+    -- callerRHandle.code = callerRCr: two ofProg ranges, both away from 0x3000
+    have h' : callerRCr a = some i := h
+    simp only [topCr, CodeReq.union]
+    rw [CodeReq.ofProg_none_range 0x3000 (topFn.body.flatten 0x3000)
+      (fun k' hk' heq => ?_)]
+    · exact h'
+    · have hlen' : (topFn.body.flatten 0x3000).length = 1 := by decide
+      rw [hlen'] at hk'
+      have hk1 : k' = 0 := by omega
+      subst hk1
+      -- the address 0x3000 carries no code in callerRCr
+      have hnone : callerRCr (0x3000 + BitVec.ofNat 64 (4 * 0)) = none := by
+        decide
+      rw [← heq, h'] at hnone
+      cases hnone
+  case calls =>
+    exact ⟨by decide, by decide, by decide⟩
+  case top.callerR.pre =>
+    exact fun rf ws h => h
+  case top.post =>
+    exact fun rf ws h => h
 
 end ExamplesVc
 end SAsm

--- a/EvmAsm/Rv64/SAsm/RaSpill.lean
+++ b/EvmAsm/Rv64/SAsm/RaSpill.lean
@@ -1,0 +1,524 @@
+/-
+  EvmAsm.Rv64.SAsm.RaSpill
+
+  Packaging a verified *caller* (a function whose body contains calls) as a
+  callee `FnHandle` (docs/sasm-design.md §3.6).  A caller clobbers `ra` at
+  its call sites, so the packaged code spills `ra` to a dword slot of the
+  function's writable region on entry and restores it before returning:
+
+      SD rs, x1, sofs ; <body> ; LD x1, rs, sofs ; JALR x0, x1, 0
+
+  `rs` is an exposed register that the pre- (and post-) condition pin to the
+  spill slot's address.  The return address is threaded through the body as
+  a ghost word: `Fn.retSpecR` consumes a *family* of caller-shaped body
+  specs indexed by the spilled value, whose pre/post state that the slot
+  holds it — slot preservation is exactly the caller's own `.post` VC.
+
+  The two one-step lemmas here are the `ra` analogues of
+  `regFile_store_spec_within` / `regFile_load_spec_within`: `x1` is not an
+  exposed register, so its value comes from (and goes to) the separate
+  `.x1 ↦ᵣ _` atom rather than the `regFileIs` atom.
+-/
+
+import EvmAsm.Rv64.SAsm.Fn
+
+namespace EvmAsm.Rv64
+namespace SAsm
+
+-- ============================================================================
+-- Byte-list helpers
+-- ============================================================================
+
+/-- Packing a dword's own little-endian bytes gives it back. -/
+theorem packBytes_dwordBytes (v : Word) : packBytes (dwordBytes v) = v := by
+  symm
+  apply eq_of_forall_extractByte
+  intro j hj
+  rw [extractByte_packBytes_total _ j hj]
+  interval_cases j <;> simp [dwordBytes, getByteAt]
+
+/-- The freshly spliced window holds exactly the payload. -/
+theorem setBytes_slot (ws ns : List (BitVec 8)) (k : Nat)
+    (h : k + ns.length ≤ ws.length) :
+    ((setBytes ws k ns).drop k).take ns.length = ns := by
+  apply List.ext_getElem
+  · simp only [List.length_take, List.length_drop, length_setBytes]
+    omega
+  · intro j hj1 hj2
+    rw [List.getElem_take, List.getElem_drop]
+    have hlt : k + j < (setBytes ws k ns).length := by
+      rw [length_setBytes]
+      omega
+    have hj : j < ns.length := by
+      simp only [List.length_take, List.length_drop, length_setBytes] at hj1
+      omega
+    have hb : getByteAt (setBytes ws k ns) (k + j) = getByteAt ns j := by
+      rw [getByteAt_setBytes ns ws k (k + j) h, if_pos ⟨by omega, by omega⟩,
+        show k + j - k = j from by omega]
+    unfold getByteAt at hb
+    rw [dif_pos hlt, dif_pos hj] at hb
+    exact hb
+
+/-- Transport `RwRegion.wf` to the current contents viewed as a region. -/
+theorem RwRegion.wf_toRegion {rw : RwRegion} {ws : List (BitVec 8)}
+    (hrw : rw.wf) (hlen : ws.length = rw.len) :
+    (Region.mk rw.base ws).wf := by
+  refine ⟨hrw.1, ?_, ?_⟩
+  · show rw.base.toNat + ws.length < 2 ^ 64
+    have := hrw.2.1
+    omega
+  · intro k hk
+    have hk' : k < ws.length := hk
+    exact hrw.2.2 k (by omega)
+
+-- ============================================================================
+-- Spill and restore: one-step triples for `ra` against the writable region
+-- ============================================================================
+
+/-- Spill `ra`: `SD rs, x1, sofs` writes the (separately owned) return
+    address into the writable region; the register file and `ra` itself are
+    untouched. -/
+theorem sd_ra_spec_within (rs : Reg) (sofs : BitVec 12) (rwBase : Word)
+    (rf : RegFile) (ws : List (BitVec 8)) (ret : Word) (base : Word)
+    (hrs : (Reg.isExposed rs || rs == .x0) = true)
+    (hwf : (Region.mk rwBase ws).wf)
+    (hin : inRw rwBase ws (rf.get rs + signExtend12 sofs) 8)
+    (hdvd : 8 ∣ ((rf.get rs + signExtend12 sofs) - rwBase).toNat) :
+    cpsTripleWithin 1 base (base + 4) (CodeReq.singleton base (.SD rs .x1 sofs))
+      (((.x1 : Reg) ↦ᵣ ret) ** ((regFileIs rf) ** bytesRegion rwBase ws))
+      (((.x1 : Reg) ↦ᵣ ret) ** ((regFileIs rf) ** bytesRegion rwBase
+        (setBytes ws ((rf.get rs + signExtend12 sofs) - rwBase).toNat
+          (dwordBytes ret)))) := by
+  intro R hR s hcr hPR hpc; subst hpc
+  have hfetch : s.code s.pc = some (.SD rs .x1 sofs) :=
+    CodeReq.singleton_satisfiedBy.mp hcr
+  rw [sepConj_assoc'] at hPR
+  -- hPR : ((.x1 ↦ᵣ ret) ** ((regFileIs ** bytesRegion) ** R))
+  have hx1 : s.getReg .x1 = ret :=
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left hPR)
+  rw [sepConj_left_comm, sepConj_assoc'] at hPR
+  -- hPR : (regFileIs ** (bytesRegion ** ((.x1) ** R)))
+  have hrsv : s.getReg rs = rf.get rs := holdsFor_regFileIs_agree hPR hrs
+  rw [sepConj_left_comm] at hPR
+  -- hPR : (bytesRegion ** (regFileIs ** ((.x1) ** R)))
+  set addr := rf.get rs + signExtend12 sofs with haddr_def
+  unfold inRw at hin
+  set i0 := (addr - rwBase).toNat with hi0_def
+  have hi0lt : i0 < ws.length := by omega
+  have haddr_eq : addr = rwBase + BitVec.ofNat 64 i0 := by
+    rw [hi0_def]
+    bv_omega
+  have hover : rwBase.toNat + i0 < 2 ^ 64 := by
+    have h1 : rwBase.toNat + ws.length < 2 ^ 64 := hwf.2.1
+    omega
+  have haddr_toNat : addr.toNat = rwBase.toNat + i0 := by
+    rw [haddr_eq, BitVec.toNat_add, BitVec.toNat_ofNat]
+    omega
+  have hvalidmem : isValidMemAddr addr = true := by
+    rw [haddr_eq]
+    exact hwf.2.2 _ hi0lt
+  have hb8 : rwBase.toNat % 8 = 0 := hwf.1
+  have h80 : i0 % 8 = 0 := by omega
+  have hi08 : 8 * (i0 / 8) = i0 := by omega
+  have hvalid : isValidDwordAccess (s.getReg rs + signExtend12 sofs) = true := by
+    rw [hrsv]
+    show isValidDwordAccess addr = true
+    simp only [isValidDwordAccess_eq, Bool.and_eq_true]
+    refine ⟨hvalidmem, ?_⟩
+    simp only [isAligned8, beq_iff_eq]
+    omega
+  have hstep' : step s = some (execInstrBr s (.SD rs .x1 sofs)) :=
+    step_sd hfetch hvalid
+  have hexec : execInstrBr s (.SD rs .x1 sofs)
+      = (s.setMem (rwBase + BitVec.ofNat 64 (8 * (i0 / 8)))
+          (packBytes (setBytes ((ws.drop (8 * (i0 / 8))).take 8) (i0 % 8)
+            (dwordBytes ret)))).setPC (s.pc + 4) := by
+    simp only [execInstrBr]
+    rw [hrsv, hx1]
+    show (s.setMem addr ret).setPC (s.pc + 4) = _
+    rw [h80,
+      show addr = rwBase + BitVec.ofNat 64 (8 * (i0 / 8)) from by
+        rw [haddr_eq, hi08],
+      ← packBytes_setBytes_dword ((ws.drop (8 * (i0 / 8))).take 8) ret (by
+        simp only [List.length_take, List.length_drop]
+        omega)]
+  have hupd := holdsFor_bytesRegion_setBytes
+    (i := i0) (ns := dwordBytes ret) hPR
+    (by simp [dwordBytes])
+    (by simp only [length_dwordBytes]; omega)
+    (by simp only [length_dwordBytes]; omega)
+  refine ⟨1, Nat.le_refl 1,
+    (s.setMem (rwBase + BitVec.ofNat 64 (8 * (i0 / 8)))
+      (packBytes (setBytes ((ws.drop (8 * (i0 / 8))).take 8) (i0 % 8)
+        (dwordBytes ret)))).setPC (s.pc + 4), ?_, rfl, ?_⟩
+  · show (step s).bind (stepN 0) = some _
+    rw [hstep', hexec]; rfl
+  · rw [sepConj_left_comm,
+      sepConj_left_comm (bytesRegion rwBase (setBytes ws i0 (dwordBytes ret)))
+        ((.x1 : Reg) ↦ᵣ ret) R,
+      sepConj_left_comm,
+      ← sepConj_assoc' (regFileIs rf)
+        (bytesRegion rwBase (setBytes ws i0 (dwordBytes ret))) R,
+      ← sepConj_assoc'] at hupd
+    exact holdsFor_pcFree_setPC
+      (pcFree_sepConj (pcFree_sepConj (by pcFree)
+        (pcFree_sepConj (pcFree_regFileIs _) (bytesRegion_pcFree _ _))) hR)
+      hupd
+
+/-- Restore `ra`: `LD x1, rs, sofs` loads the spill slot back into the
+    (separately owned) `ra`; everything else is untouched. -/
+theorem ld_ra_spec_within (rs : Reg) (sofs : BitVec 12) (rwBase : Word)
+    (rf : RegFile) (ws : List (BitVec 8)) (old : Word) (base : Word)
+    (hrs : (Reg.isExposed rs || rs == .x0) = true)
+    (hwf : (Region.mk rwBase ws).wf)
+    (hin : inRw rwBase ws (rf.get rs + signExtend12 sofs) 8)
+    (hdvd : 8 ∣ ((rf.get rs + signExtend12 sofs) - rwBase).toNat) :
+    cpsTripleWithin 1 base (base + 4) (CodeReq.singleton base (.LD .x1 rs sofs))
+      (((.x1 : Reg) ↦ᵣ old) ** ((regFileIs rf) ** bytesRegion rwBase ws))
+      (((.x1 : Reg) ↦ᵣ packBytes
+          ((ws.drop ((rf.get rs + signExtend12 sofs) - rwBase).toNat).take 8))
+        ** ((regFileIs rf) ** bytesRegion rwBase ws)) := by
+  intro R hR s hcr hPR hpc; subst hpc
+  have hfetch : s.code s.pc = some (.LD .x1 rs sofs) :=
+    CodeReq.singleton_satisfiedBy.mp hcr
+  rw [sepConj_assoc'] at hPR
+  -- hPR : ((.x1 ↦ᵣ old) ** ((regFileIs ** bytesRegion) ** R))
+  have hPR1 := hPR
+  rw [sepConj_left_comm, sepConj_assoc'] at hPR1
+  -- hPR1 : (regFileIs ** (bytesRegion ** ((.x1) ** R)))
+  have hrsv : s.getReg rs = rf.get rs := holdsFor_regFileIs_agree hPR1 hrs
+  have hPR2 := hPR1
+  rw [sepConj_left_comm] at hPR2
+  -- hPR2 : (bytesRegion ** (regFileIs ** ((.x1) ** R)))
+  set addr := rf.get rs + signExtend12 sofs with haddr_def
+  unfold inRw at hin
+  set i0 := (addr - rwBase).toNat with hi0_def
+  have hi0lt : i0 < ws.length := by omega
+  have haddr_eq : addr = rwBase + BitVec.ofNat 64 i0 := by
+    rw [hi0_def]
+    bv_omega
+  have hover : rwBase.toNat + i0 < 2 ^ 64 := by
+    have h1 : rwBase.toNat + ws.length < 2 ^ 64 := hwf.2.1
+    omega
+  have haddr_toNat : addr.toNat = rwBase.toNat + i0 := by
+    rw [haddr_eq, BitVec.toNat_add, BitVec.toNat_ofNat]
+    omega
+  have hvalidmem : isValidMemAddr addr = true := by
+    rw [haddr_eq]
+    exact hwf.2.2 _ hi0lt
+  have hb8 : rwBase.toNat % 8 = 0 := hwf.1
+  have h80 : i0 % 8 = 0 := by omega
+  have hvalid : isValidDwordAccess (s.getReg rs + signExtend12 sofs) = true := by
+    rw [hrsv]
+    show isValidDwordAccess addr = true
+    simp only [isValidDwordAccess_eq, Bool.and_eq_true]
+    refine ⟨hvalidmem, ?_⟩
+    simp only [isAligned8, beq_iff_eq]
+    omega
+  have hstep' : step s = some (execInstrBr s (.LD .x1 rs sofs)) :=
+    step_ld hfetch hvalid
+  have hexec : execInstrBr s (.LD .x1 rs sofs)
+      = (s.setReg .x1 (packBytes ((ws.drop i0).take 8))).setPC (s.pc + 4) := by
+    simp only [execInstrBr]
+    rw [hrsv]
+    show (s.setReg .x1 (s.getMem addr)).setPC (s.pc + 4) = _
+    rw [show s.getMem addr = packBytes ((ws.drop i0).take 8) from by
+      conv_lhs => rw [haddr_eq]
+      exact holdsFor_bytesRegion_getMem hPR2 hdvd hi0lt]
+  refine ⟨1, Nat.le_refl 1,
+    (s.setReg .x1 (packBytes ((ws.drop i0).take 8))).setPC (s.pc + 4),
+    ?_, rfl, ?_⟩
+  · show (step s).bind (stepN 0) = some _
+    rw [hstep', hexec]; rfl
+  · have h1 := holdsFor_sepConj_regIs_setReg
+      (v' := packBytes ((ws.drop i0).take 8))
+      (show (.x1 : Reg) ≠ .x0 from by decide) hPR
+    rw [← sepConj_assoc'] at h1
+    exact holdsFor_pcFree_setPC
+      (pcFree_sepConj (pcFree_sepConj (by pcFree)
+        (pcFree_sepConj (pcFree_regFileIs _) (bytesRegion_pcFree _ _))) hR)
+      h1
+
+-- ============================================================================
+-- Existential-precondition splitters with the `ra` atom alongside
+-- ============================================================================
+
+/-- Split `asrtM ** X` into a per-symbolic-state family (both regions and the
+    extra atom `X` alongside). -/
+theorem cpsTripleWithin_exists_pre_M_frame {n : Nat} {entry exit_ : Word}
+    {cr : CodeReq} {X : Assertion} {reg : Region} {rw : RwRegion}
+    {reach : Reach} {Q : Assertion}
+    (h : ∀ rf ws, ws.length = rw.len → reach rf ws →
+      cpsTripleWithin n entry exit_ cr
+        (((regFileIs rf) ** bytesRegion rw.base ws) **
+          (bytesRegion reg.base reg.bytes ** X)) Q) :
+    cpsTripleWithin n entry exit_ cr (asrtM reg rw reach ** X) Q := by
+  intro R hR s hcr hPR hpc
+  rw [show asrtM reg rw reach
+      = (asrtOf rw reach ** bytesRegion reg.base reg.bytes) from rfl,
+    sepConj_assoc', sepConj_assoc'] at hPR
+  -- hPR : (asrtOf ** (bytesRegion reg ** (X ** R)))
+  obtain ⟨hp, hcompat, h1, h2, hd, hu, ⟨rf, ws, hlen, hreach, hsts⟩, hR2⟩ := hPR
+  have hPR' : ((((regFileIs rf) ** bytesRegion rw.base ws) **
+      (bytesRegion reg.base reg.bytes ** (X ** R)))).holdsFor s :=
+    ⟨hp, hcompat, h1, h2, hd, hu, hsts, hR2⟩
+  rw [← sepConj_assoc' (bytesRegion reg.base reg.bytes) X R,
+    ← sepConj_assoc'] at hPR'
+  exact h rf ws hlen hreach R hR s hcr hPR' hpc
+
+/-- Split an `asrtR` precondition into a per-symbolic-state family, including
+    a concrete value for the owned `ra`. -/
+theorem cpsTripleWithin_exists_pre_R {n : Nat} {entry exit_ : Word}
+    {cr : CodeReq} {reg : Region} {rw : RwRegion} {reach : Reach}
+    {Q : Assertion}
+    (h : ∀ rf ws (v : Word), ws.length = rw.len → reach rf ws →
+      cpsTripleWithin n entry exit_ cr
+        (((regFileIs rf) ** bytesRegion rw.base ws) **
+          (bytesRegion reg.base reg.bytes ** ((.x1 : Reg) ↦ᵣ v))) Q) :
+    cpsTripleWithin n entry exit_ cr (asrtR reg rw reach) Q := by
+  show cpsTripleWithin n entry exit_ cr (asrtM reg rw reach ** regOwn .x1) Q
+  apply cpsTripleWithin_regOwn_right_pre
+  intro v
+  exact cpsTripleWithin_exists_pre_M_frame
+    (fun rf ws hlen hreach => h rf ws v hlen hreach)
+
+-- ============================================================================
+-- Packaging a verified caller as a callee handle
+-- ============================================================================
+
+namespace Fn
+
+/-- The caller's code wrapped with the `ra`-spill prologue and the
+    restore-and-return epilogue.  The body is flattened at `base + 4`. -/
+def programRetR (f : Fn) (rs : Reg) (sofs : BitVec 12) (base : Word) : Program :=
+  .SD rs .x1 sofs ::
+    (f.body.flatten (base + 4) ++ [.LD .x1 rs sofs, .JALR .x0 .x1 0])
+
+/-- A verified caller, wrapped with the `ra`-spill prologue/epilogue,
+    satisfies the `FnHandle` calling contract.
+
+    The spill slot is the dword at index `k` of the writable region; `rs` is
+    an exposed register that `pre` pins to its address (and that the body,
+    per the strengthened post, restores).  `spre`/`spost` are the
+    ghost-indexed body conditions: `spre v`/`spost v` additionally record
+    that the slot holds `v` (the caller's own `.post` VC proves the body
+    preserves it); `hbody` is the caller-shaped body spec at each ghost
+    value, obtained from `Fn.soundR` of the ghost-indexed function. -/
+theorem retSpecR (f : Fn) (base : Word) (cr : CodeReq)
+    (rs : Reg) (sofs : BitVec 12) (k : Nat)
+    (spre spost : Word → Reach)
+    (hrs : (Reg.isExposed rs || rs == .x0) = true)
+    (hrw : f.rw.wf)
+    (hk : 8 ∣ k) (hk8 : k + 8 ≤ f.rw.len)
+    (hsz : 4 * (f.body.size + 3) ≤ 2 ^ 64)
+    (hbody : ∀ v : Word, cpsTripleWithin f.body.steps (base + 4)
+        ((base + 4) + BitVec.ofNat 64 (4 * f.body.size)) cr
+        (asrtR f.region f.rw (spre v)) (asrtR f.region f.rw (spost v)))
+    (hcode : ∀ a i, CodeReq.ofProg base (f.programRetR rs sofs base) a = some i →
+        cr a = some i)
+    (haddr : ∀ rf ws, f.pre rf ws →
+        rf.get rs + signExtend12 sofs = f.rw.base + BitVec.ofNat 64 k)
+    (haddrPost : ∀ v rf ws, spost v rf ws →
+        rf.get rs + signExtend12 sofs = f.rw.base + BitVec.ofNat 64 k)
+    (hspre : ∀ v rf ws, f.pre rf ws → ws.length = f.rw.len →
+        spre v rf (setBytes ws k (dwordBytes v)))
+    (hspost : ∀ v rf ws, spost v rf ws → f.post rf ws)
+    (hslot : ∀ v rf ws, spost v rf ws → ws.length = f.rw.len →
+        (ws.drop k).take 8 = dwordBytes v) :
+    ∀ ret : Word, (ret &&& ~~~(1 : Word)) = ret →
+      cpsTripleWithin (1 + f.body.steps + 2) base ret cr
+        (((.x1 : Reg) ↦ᵣ ret) ** asrtM f.region f.rw f.pre)
+        (((.x1 : Reg) ↦ᵣ ret) ** asrtM f.region f.rw f.post) := by
+  intro ret halign
+  have hk64 : k < 2 ^ 64 := by
+    have := hrw.2.1
+    omega
+  have hlflat : (f.body.flatten (base + 4)).length = f.body.size :=
+    Stmt.flatten_length ..
+  -- code containment for the three wrapper instructions
+  have hcodeSD : ∀ a i, CodeReq.singleton base (.SD rs .x1 sofs) a = some i →
+      cr a = some i := by
+    intro a i h
+    apply hcode
+    show CodeReq.ofProg base (.SD rs .x1 sofs ::
+      (f.body.flatten (base + 4) ++ [.LD .x1 rs sofs, .JALR .x0 .x1 0]))
+      a = some i
+    exact ofProg_head a i h
+  have hcodeLD : ∀ a i, CodeReq.singleton
+      ((base + 4) + BitVec.ofNat 64 (4 * f.body.size)) (.LD .x1 rs sofs)
+      a = some i → cr a = some i := by
+    intro a i h
+    apply hcode
+    show CodeReq.ofProg base (.SD rs .x1 sofs ::
+      (f.body.flatten (base + 4) ++ [.LD .x1 rs sofs, .JALR .x0 .x1 0]))
+      a = some i
+    apply ofProg_cons_tail (by simp only [List.length_append, List.length_cons, List.length_nil, hlflat]; omega)
+    apply ofProg_mono_right
+      (p1 := f.body.flatten (base + 4))
+      (p2 := [.LD .x1 rs sofs, .JALR .x0 .x1 0])
+      (by simp only [List.length_cons, List.length_nil, hlflat]; omega)
+    rw [hlflat]
+    exact ofProg_head a i h
+  have hcodeJ : ∀ a i, CodeReq.singleton
+      (((base + 4) + BitVec.ofNat 64 (4 * f.body.size)) + 4) (.JALR .x0 .x1 0)
+      a = some i → cr a = some i := by
+    intro a i h
+    apply hcode
+    show CodeReq.ofProg base (.SD rs .x1 sofs ::
+      (f.body.flatten (base + 4) ++ [.LD .x1 rs sofs, .JALR .x0 .x1 0]))
+      a = some i
+    apply ofProg_cons_tail (by simp only [List.length_append, List.length_cons, List.length_nil, hlflat]; omega)
+    apply ofProg_mono_right
+      (p1 := f.body.flatten (base + 4))
+      (p2 := [.LD .x1 rs sofs, .JALR .x0 .x1 0])
+      (by simp only [List.length_cons, List.length_nil, hlflat]; omega)
+    rw [hlflat]
+    apply ofProg_mono_right (p1 := [.LD .x1 rs sofs]) (p2 := [.JALR .x0 .x1 0])
+      (by simp only [List.length_cons, List.length_nil]; omega)
+    rw [CodeReq.ofProg_singleton]
+    exact h
+  -- restore + return: from the ghost-indexed body post back to the contract
+  have hRest : cpsTripleWithin 2 ((base + 4) + BitVec.ofNat 64 (4 * f.body.size))
+      ret cr (asrtR f.region f.rw (spost ret))
+      (((.x1 : Reg) ↦ᵣ ret) ** asrtM f.region f.rw f.post) := by
+    apply cpsTripleWithin_exists_pre_R
+    intro rf ws v hlen hreach
+    have haddr' : rf.get rs + signExtend12 sofs
+        = f.rw.base + BitVec.ofNat 64 k := haddrPost ret rf ws hreach
+    have hidx : ((rf.get rs + signExtend12 sofs) - f.rw.base).toNat = k := by
+      rw [haddr']
+      bv_omega
+    have hwf' : (Region.mk f.rw.base ws).wf := RwRegion.wf_toRegion hrw hlen
+    have hin' : inRw f.rw.base ws (rf.get rs + signExtend12 sofs) 8 := by
+      unfold inRw
+      rw [hidx]
+      omega
+    have hld := ld_ra_spec_within rs sofs f.rw.base rf ws v
+      ((base + 4) + BitVec.ofNat 64 (4 * f.body.size)) hrs hwf' hin'
+      (by rw [hidx]; exact hk)
+    rw [hidx, hslot ret rf ws hreach hlen, packBytes_dwordBytes] at hld
+    have hld' := cpsTripleWithin_extend_code hcodeLD hld
+    have hld'' := cpsTripleWithin_frameR
+      (bytesRegion f.region.base f.region.bytes) (bytesRegion_pcFree _ _) hld'
+    -- JALR
+    have hjal := jalr_ret_spec (((base + 4) + BitVec.ofNat 64 (4 * f.body.size)) + 4)
+      ret halign
+      (P := ((regFileIs rf) ** bytesRegion f.rw.base ws) **
+        bytesRegion f.region.base f.region.bytes)
+      (pcFree_sepConj (pcFree_sepConj (pcFree_regFileIs _)
+        (bytesRegion_pcFree _ _)) (bytesRegion_pcFree _ _))
+    have hjal' := cpsTripleWithin_extend_code hcodeJ hjal
+    have hseq := cpsTripleWithin_seq_same_cr
+      (cpsTripleWithin_weaken
+        (P := (((.x1 : Reg) ↦ᵣ v) ** ((regFileIs rf) ** bytesRegion f.rw.base ws))
+          ** bytesRegion f.region.base f.region.bytes)
+        (P' := ((regFileIs rf) ** bytesRegion f.rw.base ws) **
+          (bytesRegion f.region.base f.region.bytes ** ((.x1 : Reg) ↦ᵣ v)))
+        (Q' := ((.x1 : Reg) ↦ᵣ ret) **
+          (((regFileIs rf) ** bytesRegion f.rw.base ws) **
+            bytesRegion f.region.base f.region.bytes))
+        (fun hp hh => by
+          have h1 := sc_to_swap hp hh
+          rw [sepConj_comm' ((regFileIs rf) ** bytesRegion f.rw.base ws)
+            ((.x1 : Reg) ↦ᵣ v)] at h1
+          exact h1)
+        (fun hp hh => sc_assoc_r hp hh)
+        hld'')
+      hjal'
+    refine cpsTripleWithin_weaken (fun hp hh => hh) ?_ hseq
+    -- ((.x1 ↦ ret) ** ((RF ** BW) ** RO)) → ((.x1 ↦ ret) ** asrtM post)
+    intro hp hh
+    refine sepConj_mono_right (fun hq hx => ?_) hp hh
+    show asrtM f.region f.rw f.post hq
+    exact sepConj_mono_left
+      (fun hv hy => ⟨rf, ws, hlen, hspost ret rf ws hreach, hy⟩) hq hx
+  -- spill + body
+  have hMain : cpsTripleWithin (1 + f.body.steps) base
+      ((base + 4) + BitVec.ofNat 64 (4 * f.body.size)) cr
+      (((.x1 : Reg) ↦ᵣ ret) ** asrtM f.region f.rw f.pre)
+      (asrtR f.region f.rw (spost ret)) := by
+    rw [sepConj_comm' ((.x1 : Reg) ↦ᵣ ret) (asrtM f.region f.rw f.pre)]
+    apply cpsTripleWithin_exists_pre_M_frame
+    intro rf ws hlen hreach
+    have haddr' : rf.get rs + signExtend12 sofs
+        = f.rw.base + BitVec.ofNat 64 k := haddr rf ws hreach
+    have hidx : ((rf.get rs + signExtend12 sofs) - f.rw.base).toNat = k := by
+      rw [haddr']
+      bv_omega
+    have hwf' : (Region.mk f.rw.base ws).wf := RwRegion.wf_toRegion hrw hlen
+    have hin' : inRw f.rw.base ws (rf.get rs + signExtend12 sofs) 8 := by
+      unfold inRw
+      rw [hidx]
+      omega
+    have hsd := sd_ra_spec_within rs sofs f.rw.base rf ws ret base hrs hwf' hin'
+      (by rw [hidx]; exact hk)
+    rw [hidx] at hsd
+    have hsd' := cpsTripleWithin_extend_code hcodeSD hsd
+    have hsd'' := cpsTripleWithin_frameR
+      (bytesRegion f.region.base f.region.bytes) (bytesRegion_pcFree _ _) hsd'
+    have hsdW := cpsTripleWithin_weaken
+      (P := (((.x1 : Reg) ↦ᵣ ret) ** ((regFileIs rf) ** bytesRegion f.rw.base ws))
+        ** bytesRegion f.region.base f.region.bytes)
+      (P' := ((regFileIs rf) ** bytesRegion f.rw.base ws) **
+        (bytesRegion f.region.base f.region.bytes ** ((.x1 : Reg) ↦ᵣ ret)))
+      (Q' := asrtR f.region f.rw (spre ret))
+      (fun hp hh => by
+        have h1 := sc_to_swap hp hh
+        rw [sepConj_comm' ((regFileIs rf) ** bytesRegion f.rw.base ws)
+          ((.x1 : Reg) ↦ᵣ ret)] at h1
+        exact h1)
+      (fun hp hh => by
+        have h1 := sepConj_mono_left
+          (fun hq hx => sepConj_mono_left
+            (fun hv (hy : ((.x1 : Reg) ↦ᵣ ret) hv) =>
+              (⟨ret, hy⟩ : regOwn .x1 hv)) hq hx) hp hh
+        have h2 := sepConj_mono_left
+          (fun hq hx => sepConj_mono_right
+            (fun hv hy =>
+              (⟨rf, setBytes ws k (dwordBytes ret),
+                by rw [length_setBytes]; exact hlen,
+                hspre ret rf ws hreach hlen, hy⟩ :
+                asrtOf f.rw (spre ret) hv)) hq hx) hp h1
+        rw [sepConj_assoc', sepConj_comm'] at h2
+        exact h2)
+      hsd''
+    exact cpsTripleWithin_seq_same_cr hsdW (hbody ret)
+  exact cpsTripleWithin_seq_same_cr hMain hRest
+
+/-- Package a verified caller as a callee handle: the handle's code is the
+    ambient `cr` (the wrapper's own code plus every callee's). -/
+def toHandleR (f : Fn) (base : Word) (cr : CodeReq)
+    (rs : Reg) (sofs : BitVec 12) (k : Nat)
+    (spre spost : Word → Reach)
+    (hrs : (Reg.isExposed rs || rs == .x0) = true)
+    (hrw : f.rw.wf)
+    (hk : 8 ∣ k) (hk8 : k + 8 ≤ f.rw.len)
+    (hsz : 4 * (f.body.size + 3) ≤ 2 ^ 64)
+    (hbody : ∀ v : Word, cpsTripleWithin f.body.steps (base + 4)
+        ((base + 4) + BitVec.ofNat 64 (4 * f.body.size)) cr
+        (asrtR f.region f.rw (spre v)) (asrtR f.region f.rw (spost v)))
+    (hcode : ∀ a i, CodeReq.ofProg base (f.programRetR rs sofs base) a = some i →
+        cr a = some i)
+    (haddr : ∀ rf ws, f.pre rf ws →
+        rf.get rs + signExtend12 sofs = f.rw.base + BitVec.ofNat 64 k)
+    (haddrPost : ∀ v rf ws, spost v rf ws →
+        rf.get rs + signExtend12 sofs = f.rw.base + BitVec.ofNat 64 k)
+    (hspre : ∀ v rf ws, f.pre rf ws → ws.length = f.rw.len →
+        spre v rf (setBytes ws k (dwordBytes v)))
+    (hspost : ∀ v rf ws, spost v rf ws → f.post rf ws)
+    (hslot : ∀ v rf ws, spost v rf ws → ws.length = f.rw.len →
+        (ws.drop k).take 8 = dwordBytes v) : FnHandle where
+  entry := base
+  code := cr
+  nSteps := 1 + f.body.steps + 2
+  region := f.region
+  rw := f.rw
+  pre := f.pre
+  post := f.post
+  sound := f.retSpecR base cr rs sofs k spre spost hrs hrw hk hk8 hsz hbody
+    hcode haddr haddrPost hspre hspost hslot
+
+end Fn
+
+end SAsm
+end EvmAsm.Rv64

--- a/PLAN.md
+++ b/PLAN.md
@@ -2485,8 +2485,13 @@ address-routed loads, both soundness inductions generalized; multi-byte
 bytesRegion write algebra in MemRegionWriteWide.lean). Stores landed: SB/SH/SW/SD block
 leaves (storeSem + regFile_store_spec_within via the MemRegionWriteWide
 splice algebra; per-store VC = in-rw ∧ n-aligned; spillFn SD/LD round-trip
-demo). Remaining: ra-spill prologue packaging for multi-level call trees,
-then more Stateless/SSZ ports.
+demo). ra-spill packaging landed (`SAsm/RaSpill.lean`): `Fn.toHandleR`
+wraps a `soundR`-verified caller as a callee (SD x1 prologue / LD x1 +
+JALR epilogue against a dword slot of the shared rw region; ghost-indexed
+body-spec family pins the slot), with a two-level call-tree demo
+(topFn → callerRHandle → leafHandle). Remaining: per-frame rw sub-regions
+(CalleesIn currently forces one shared rw across the tree), then more
+Stateless/SSZ ports.
 
 ## Stateless Guest (parallel STF track)
 

--- a/docs/sasm-design.md
+++ b/docs/sasm-design.md
@@ -352,11 +352,19 @@ structure FnHandle where
 - Hand-verified (non-SAsm) routines join the same ecosystem by packaging
   their existing `cpsTripleWithin` spec as a `FnHandle` (adapter lemmas
   bridge atom-form assertions to `regFileIs`, §3.1).
-- Non-leaf functions (bodies containing `call`) need `ra` saved. Milestones
-  1–2 restrict to leaf callees called from a top-level routine that owns
-  `ra`; Milestone 4 adds the standard prologue/epilogue (sp-frame spill of
-  `ra`, later s-registers) emitted by the flattener, with the stack cells
-  modeled as an `.rw` region.
+- Non-leaf functions (bodies containing `call`) need `ra` saved.
+  `Fn.toHandleR` (`SAsm/RaSpill.lean`) packages a caller verified via
+  `soundR` as a callee: the emitted code is
+  `SD rs, x1, sofs ; body ; LD x1, rs, sofs ; JALR x0, x1, 0`, where the
+  spill slot is a dword of the function's `.rw` region and `rs` is an
+  exposed register that the pre pins to its address.  The return address is
+  threaded through the body as a ghost word — the packaging consumes a
+  family of `SpecR`s indexed by the spilled value, whose pre/post record
+  that the slot holds it, so slot preservation is the caller's own `.post`
+  VC.  (`CalleesIn` currently makes the whole call tree share one `.rw`
+  region, so the slot is visible to callees as part of the symbolic state;
+  per-frame sub-regions are future work.)  The `ExamplesVc` two-level tree
+  (`topFn` → `callerRHandle` → `leafHandle`) exercises the full shape.
 
 ### 3.7 Flattening (`SAsm/Flatten.lean`)
 


### PR DESCRIPTION
Completes the M5b-2 milestone piece "ra-spill prologue packaging": a caller (an `Fn` whose body contains `call` nodes, verified via `Fn.soundR`) can now itself be packaged as a callee `FnHandle`.

## New: `EvmAsm/Rv64/SAsm/RaSpill.lean`

**Wrapper code** (`Fn.programRetR`):
```
SD rs, x1, sofs ; <body> ; LD x1, rs, sofs ; JALR x0, x1, 0
```
The spill slot is a dword at index `k` of the function's writable region; `rs` is an exposed register the precondition pins to its address.

**One-step spill/restore lemmas** — `sd_ra_spec_within` / `ld_ra_spec_within` mirror `regFile_store/load_spec_within`, but `x1` is not exposed, so its value is sourced from (SD) and written to (LD) the separate `.x1 ↦ᵣ _` atom rather than the `regFileIs` atom.

**Packaging** — `Fn.retSpecR` / `Fn.toHandleR`: the return address is threaded through the body as a *ghost word*. The packaging consumes a family of caller-shaped specs `hbody : ∀ v, … (asrtR (spre v)) (asrtR (spost v))` whose pre/post additionally record that the slot holds `v` — so slot preservation across the body is exactly the caller's own `.post` VC, and misuse of the slot makes the family unprovable. Side obligations (address pinning, slot algebra via the new `setBytes_slot` / `packBytes_dwordBytes`) are plain pure lemmas.

## Demo (`ExamplesVc`)

A two-level call tree over a shared one-dword scratch region at `0x10000`:
`topFn (0x3000)` → `callerRHandle (0x1000, packaged via toHandleR)` → `leafHandle (0x2000)`.
The packaged handle is consumed by the *standard* `call` machinery, closing the "callers as callees" loop.

## Notes

- `CalleesIn` currently requires the callee's `rw` to equal the caller's, so the whole call tree shares one writable region (the slot is part of every callee's symbolic state). Per-frame sub-regions are noted as future work in docs/sasm-design.md §3.6.
- All new theorems are kernel-clean (`propext`/`Classical.choice`/`Quot.sound` only); forbidden-tactics scan OK; zero warnings.
- No emitted-code changes (nothing in Codegen touched), so no EEST A/B run is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
