### PR TITLE
feat(stateless): verified SAsm port of read_active_fork (drop-in)

### DIFF
--- a/EvmAsm/Stateless/Entry.lean
+++ b/EvmAsm/Stateless/Entry.lean
@@ -74,6 +74,7 @@
 import EvmAsm.Rv64.Program
 import EvmAsm.Stateless.SSZ.Decode.Program
 import EvmAsm.Stateless.SSZ.Decode.ChainIdSAsm
+import EvmAsm.Stateless.SSZ.Decode.ActiveForkSAsm
 import EvmAsm.Stateless.SSZ.Encode.Program
 
 namespace EvmAsm.Stateless
@@ -93,7 +94,11 @@ def run_stateless_guest : Program :=
   -- EvmAsm/Stateless/SSZ/Decode/ChainIdSAsm.lean and beads evm-asm-iwzun).
   -- Same interface (a0 = chain_id, a3 = chain_config addr) plus a t0 clobber.
   EvmAsm.Stateless.SSZ.Decode.read_chain_id_verified ++
-  EvmAsm.Stateless.SSZ.Decode.read_active_fork ++
+  -- Verified SAsm replacement for `read_active_fork` (same misalignment
+  -- story: the u32 at chain_config+8 sits ≡ 2 (mod 4) and the u64 read is
+  -- host-data-dependent — see ActiveForkSAsm.lean).  Same interface
+  -- (a2 = fork index, a3 preserved) plus a t0 clobber.
+  EvmAsm.Stateless.SSZ.Decode.read_active_fork_verified ++
   EvmAsm.Stateless.SSZ.Decode.decode_validation_bit ++
   EvmAsm.Stateless.SSZ.Decode.decode_header_count ++
   EvmAsm.Stateless.SSZ.Encode.serialize_stateless_output

--- a/EvmAsm/Stateless/SSZ/Decode/ActiveForkSAsm.lean
+++ b/EvmAsm/Stateless/SSZ/Decode/ActiveForkSAsm.lean
@@ -1,0 +1,274 @@
+/-
+  EvmAsm.Stateless.SSZ.Decode.ActiveForkSAsm
+
+  A verified SAsm port of `read_active_fork` (Program.lean): read the
+  `active_fork` offset (u32) at `chain_config + 8` and load the u64 fork
+  index it points to.
+
+  **Why byte-wise reads**: the chain-config section sits at
+  `INPUT_BASE + 18 + offset` with a 4-aligned host offset, so the original
+  `LWU x14, x13, 8` reads at an address `≡ 2 (mod 4)` and the `LD` reads at
+  a host-data-dependent address; both fail the Lean RV64 model's alignment
+  gates (beads `evm-asm-iwzun`), exactly like `read_chain_id`.  The port
+  assembles both values from one-byte loads (ChainIdSAsm.lean recipe).
+
+  Interface (matching the original + the `readChainIdFn` post):
+    pre:  a3 = chain-config address (`0x40000012 + leU32 bs 26`), ghost
+          bounds putting the offset u32 and the fork u64 inside the buffer
+    post: a2 = fork index, a3 preserved.  Clobbers t0, a2, a4.
+-/
+
+import EvmAsm.Stateless.SSZ.Decode.ChainIdSAsm
+
+namespace EvmAsm.Stateless.SSZ.Decode
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.SAsm.Stmt
+
+/-- The structured body of the verified `read_active_fork` (ghost-free, so
+    it flattens to a concrete `Program`). -/
+def readActiveForkBody : Stmt :=
+    .block "offset32" [
+      .LBU .x14 .x13 8,
+      .LBU .x5 .x13 9,  .SLLI .x5 .x5 8,  .OR .x14 .x14 .x5,
+      .LBU .x5 .x13 10, .SLLI .x5 .x5 16, .OR .x14 .x14 .x5,
+      .LBU .x5 .x13 11, .SLLI .x5 .x5 24, .OR .x14 .x14 .x5,
+      .ADD .x14 .x13 .x14] ;;;
+    .block "fork64" [
+      .LBU .x12 .x14 0,
+      .LBU .x5 .x14 1, .SLLI .x5 .x5 8,  .OR .x12 .x12 .x5,
+      .LBU .x5 .x14 2, .SLLI .x5 .x5 16, .OR .x12 .x12 .x5,
+      .LBU .x5 .x14 3, .SLLI .x5 .x5 24, .OR .x12 .x12 .x5,
+      .LBU .x5 .x14 4, .SLLI .x5 .x5 32, .OR .x12 .x12 .x5,
+      .LBU .x5 .x14 5, .SLLI .x5 .x5 40, .OR .x12 .x12 .x5,
+      .LBU .x5 .x14 6, .SLLI .x5 .x5 48, .OR .x12 .x12 .x5,
+      .LBU .x5 .x14 7, .SLLI .x5 .x5 56, .OR .x12 .x12 .x5]
+
+/-- Verified port of `read_active_fork`: with `a3` holding the chain-config
+    address (as `read_chain_id` leaves it), `a2 := the u64 fork index` at
+    `chain_config + (u32 at chain_config+8)`, read byte-wise from the
+    (ghost) input buffer `bs` at `INPUT_BASE`.  `a3` is preserved.
+    Clobbers t0, a2, a4 — the original's interface plus `t0`. -/
+def readActiveForkFn (bs : List (BitVec 8)) : Fn where
+  name := "readActiveFork"
+  region := ⟨0x40000000, bs⟩
+  pre := fun rf _ =>
+    rf.get .x13 = (0x40000012 : Word) + leU32 bs 26 ∧
+    26 + (leU32 bs 26).toNat + 4 ≤ bs.length ∧
+    18 + (leU32 bs 26).toNat
+      + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat + 8 ≤ bs.length
+  post := fun rf _ =>
+    rf.get .x12 = leU64 bs (18 + (leU32 bs 26).toNat
+      + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat) ∧
+    rf.get .x13 = (0x40000012 : Word) + leU32 bs 26
+  body := readActiveForkBody
+
+/-- The emitted drop-in replacement for `read_active_fork`
+    (position-independent: no calls, all branches structured). -/
+def read_active_fork_verified : Program :=
+  readActiveForkBody.flatten 0
+
+#guard (read_active_fork_verified : List Instr).length = 33
+#guard readActiveForkBody.flatten 0 = readActiveForkBody.flatten 0x80000000
+
+theorem readActiveForkFn_spec (bs : List (BitVec 8))
+    (hlen : bs.length ≤ 0x2000) (base : Word) :
+    (readActiveForkFn bs).Spec base := by
+  have hoff32 := leU32_toNat_lt bs 26
+  have hoff32' := leU32_toNat_lt bs (26 + (leU32 bs 26).toNat)
+  vcgen
+  case region =>
+    exact ⟨inputRegion_wf bs hlen, RwRegion.empty_wf⟩
+  case readActiveFork.offset32.mem =>
+    rintro rf ws hws ⟨hx13, hb1, hb2⟩
+    obtain rfl : ws = [] := List.eq_nil_of_length_eq_zero hws
+    simp only [execInstrRF_nil, aluSem, loadSem,
+      storeSem, blockVCs, Region.loadOk, RegFile.get_set_self,
+      RegFile.get_set_ne, ne_eq, reduceCtorEq, not_false_eq_true]
+    simp only [hx13,
+      show signExtend12 (8 : BitVec 12) = (8 : Word) from by decide,
+      show signExtend12 (9 : BitVec 12) = (9 : Word) from by decide,
+      show signExtend12 (10 : BitVec 12) = (10 : Word) from by decide,
+      show signExtend12 (11 : BitVec 12) = (11 : Word) from by decide,
+      show (readActiveForkFn bs).region.base = (0x40000000 : Word) from rfl,
+      show (readActiveForkFn bs).region.bytes = bs from rfl,
+      show ((0x40000012 : Word) + leU32 bs 26 + 8
+          - 0x40000000).toNat = 26 + (leU32 bs 26).toNat from by bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + 9
+          - 0x40000000).toNat = 26 + (leU32 bs 26).toNat + 1 from by bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + 10
+          - 0x40000000).toNat = 26 + (leU32 bs 26).toNat + 2 from by bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + 11
+          - 0x40000000).toNat = 26 + (leU32 bs 26).toNat + 3 from by bv_omega]
+    and_intros <;> first
+      | trivial
+      | omega
+  case readActiveFork.fork64.mem =>
+    rintro rf ws hws ⟨rf₀, ws₀, hws₀, ⟨hx13, hb1, hb2⟩, rfl, rfl⟩
+    obtain rfl : ws = [] := List.eq_nil_of_length_eq_zero hws
+    simp only [execBlock_cons, execBlock_nil, execInstrRF_nil, aluSem, loadSem,
+      storeSem, blockVCs, Region.loadOk, RegFile.get_set_self,
+      RegFile.get_set_ne, ne_eq, reduceCtorEq, not_false_eq_true]
+    have hbyteAt : ∀ a : Word,
+        (readActiveForkFn bs).region.byteAt a
+          = bs.getD (a - 0x40000000).toNat 0 := fun _ => rfl
+    simp only [hbyteAt, hx13,
+      show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+      show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide,
+      show signExtend12 (2 : BitVec 12) = (2 : Word) from by decide,
+      show signExtend12 (3 : BitVec 12) = (3 : Word) from by decide,
+      show signExtend12 (4 : BitVec 12) = (4 : Word) from by decide,
+      show signExtend12 (5 : BitVec 12) = (5 : Word) from by decide,
+      show signExtend12 (6 : BitVec 12) = (6 : Word) from by decide,
+      show signExtend12 (7 : BitVec 12) = (7 : Word) from by decide,
+      show signExtend12 (8 : BitVec 12) = (8 : Word) from by decide,
+      show signExtend12 (9 : BitVec 12) = (9 : Word) from by decide,
+      show signExtend12 (10 : BitVec 12) = (10 : Word) from by decide,
+      show signExtend12 (11 : BitVec 12) = (11 : Word) from by decide,
+      show (readActiveForkFn bs).region.base = (0x40000000 : Word) from rfl,
+      show (readActiveForkFn bs).region.bytes = bs from rfl,
+      show ((0x40000012 : Word) + leU32 bs 26 + 8
+          - 0x40000000).toNat = 26 + (leU32 bs 26).toNat from by bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + 9
+          - 0x40000000).toNat = 26 + (leU32 bs 26).toNat + 1 from by bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + 10
+          - 0x40000000).toNat = 26 + (leU32 bs 26).toNat + 2 from by bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + 11
+          - 0x40000000).toNat = 26 + (leU32 bs 26).toNat + 3 from by bv_omega]
+    rw [show BitVec.zeroExtend 64 (bs.getD (26 + (leU32 bs 26).toNat) 0)
+        ||| BitVec.zeroExtend 64 (bs.getD (26 + (leU32 bs 26).toNat + 1) 0)
+            <<< BitVec.toNat (8 : BitVec 6)
+        ||| BitVec.zeroExtend 64 (bs.getD (26 + (leU32 bs 26).toNat + 2) 0)
+            <<< BitVec.toNat (16 : BitVec 6)
+        ||| BitVec.zeroExtend 64 (bs.getD (26 + (leU32 bs 26).toNat + 3) 0)
+            <<< BitVec.toNat (24 : BitVec 6)
+        = leU32 bs (26 + (leU32 bs 26).toNat) from rfl]
+    simp only [
+      show ((0x40000012 : Word) + leU32 bs 26 + leU32 bs (26 + (leU32 bs 26).toNat)
+          + 0 - 0x40000000).toNat
+        = 18 + (leU32 bs 26).toNat
+          + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat from by
+        bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + leU32 bs (26 + (leU32 bs 26).toNat)
+          + 1 - 0x40000000).toNat
+        = 18 + (leU32 bs 26).toNat
+          + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat + 1 from by
+        bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + leU32 bs (26 + (leU32 bs 26).toNat)
+          + 2 - 0x40000000).toNat
+        = 18 + (leU32 bs 26).toNat
+          + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat + 2 from by
+        bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + leU32 bs (26 + (leU32 bs 26).toNat)
+          + 3 - 0x40000000).toNat
+        = 18 + (leU32 bs 26).toNat
+          + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat + 3 from by
+        bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + leU32 bs (26 + (leU32 bs 26).toNat)
+          + 4 - 0x40000000).toNat
+        = 18 + (leU32 bs 26).toNat
+          + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat + 4 from by
+        bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + leU32 bs (26 + (leU32 bs 26).toNat)
+          + 5 - 0x40000000).toNat
+        = 18 + (leU32 bs 26).toNat
+          + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat + 5 from by
+        bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + leU32 bs (26 + (leU32 bs 26).toNat)
+          + 6 - 0x40000000).toNat
+        = 18 + (leU32 bs 26).toNat
+          + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat + 6 from by
+        bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + leU32 bs (26 + (leU32 bs 26).toNat)
+          + 7 - 0x40000000).toNat
+        = 18 + (leU32 bs 26).toNat
+          + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat + 7 from by
+        bv_omega]
+    and_intros <;> first
+      | trivial
+      | omega
+  case readActiveFork.post =>
+    intro rf' ws' h
+    show rf'.get .x12 = leU64 bs (18 + (leU32 bs 26).toNat
+        + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat) ∧
+      rf'.get .x13 = (0x40000012 : Word) + leU32 bs 26
+    obtain ⟨rf₁, ws₁, hws₁, ⟨rf₀, ws₀, hws₀, ⟨hx13, hb1, hb2⟩, rfl, rfl⟩, rfl, rfl⟩ := h
+    obtain rfl : ws' = [] := List.eq_nil_of_length_eq_zero hws₀
+    simp only [execBlock_cons, execBlock_nil, execInstrRF_nil, aluSem, loadSem,
+      RegFile.get_set_self, RegFile.get_set_ne, ne_eq, reduceCtorEq,
+      not_false_eq_true]
+    have hbyteAt : ∀ a : Word,
+        (readActiveForkFn bs).region.byteAt a
+          = bs.getD (a - 0x40000000).toNat 0 := fun _ => rfl
+    simp only [hbyteAt, hx13,
+      show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+      show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide,
+      show signExtend12 (2 : BitVec 12) = (2 : Word) from by decide,
+      show signExtend12 (3 : BitVec 12) = (3 : Word) from by decide,
+      show signExtend12 (4 : BitVec 12) = (4 : Word) from by decide,
+      show signExtend12 (5 : BitVec 12) = (5 : Word) from by decide,
+      show signExtend12 (6 : BitVec 12) = (6 : Word) from by decide,
+      show signExtend12 (7 : BitVec 12) = (7 : Word) from by decide,
+      show signExtend12 (8 : BitVec 12) = (8 : Word) from by decide,
+      show signExtend12 (9 : BitVec 12) = (9 : Word) from by decide,
+      show signExtend12 (10 : BitVec 12) = (10 : Word) from by decide,
+      show signExtend12 (11 : BitVec 12) = (11 : Word) from by decide,
+      show ((0x40000012 : Word) + leU32 bs 26 + 8
+          - 0x40000000).toNat = 26 + (leU32 bs 26).toNat from by bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + 9
+          - 0x40000000).toNat = 26 + (leU32 bs 26).toNat + 1 from by bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + 10
+          - 0x40000000).toNat = 26 + (leU32 bs 26).toNat + 2 from by bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + 11
+          - 0x40000000).toNat = 26 + (leU32 bs 26).toNat + 3 from by bv_omega]
+    rw [show BitVec.zeroExtend 64 (bs.getD (26 + (leU32 bs 26).toNat) 0)
+        ||| BitVec.zeroExtend 64 (bs.getD (26 + (leU32 bs 26).toNat + 1) 0)
+            <<< BitVec.toNat (8 : BitVec 6)
+        ||| BitVec.zeroExtend 64 (bs.getD (26 + (leU32 bs 26).toNat + 2) 0)
+            <<< BitVec.toNat (16 : BitVec 6)
+        ||| BitVec.zeroExtend 64 (bs.getD (26 + (leU32 bs 26).toNat + 3) 0)
+            <<< BitVec.toNat (24 : BitVec 6)
+        = leU32 bs (26 + (leU32 bs 26).toNat) from rfl]
+    simp only [
+      show ((0x40000012 : Word) + leU32 bs 26 + leU32 bs (26 + (leU32 bs 26).toNat)
+          + 0 - 0x40000000).toNat
+        = 18 + (leU32 bs 26).toNat
+          + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat from by
+        bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + leU32 bs (26 + (leU32 bs 26).toNat)
+          + 1 - 0x40000000).toNat
+        = 18 + (leU32 bs 26).toNat
+          + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat + 1 from by
+        bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + leU32 bs (26 + (leU32 bs 26).toNat)
+          + 2 - 0x40000000).toNat
+        = 18 + (leU32 bs 26).toNat
+          + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat + 2 from by
+        bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + leU32 bs (26 + (leU32 bs 26).toNat)
+          + 3 - 0x40000000).toNat
+        = 18 + (leU32 bs 26).toNat
+          + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat + 3 from by
+        bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + leU32 bs (26 + (leU32 bs 26).toNat)
+          + 4 - 0x40000000).toNat
+        = 18 + (leU32 bs 26).toNat
+          + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat + 4 from by
+        bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + leU32 bs (26 + (leU32 bs 26).toNat)
+          + 5 - 0x40000000).toNat
+        = 18 + (leU32 bs 26).toNat
+          + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat + 5 from by
+        bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + leU32 bs (26 + (leU32 bs 26).toNat)
+          + 6 - 0x40000000).toNat
+        = 18 + (leU32 bs 26).toNat
+          + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat + 6 from by
+        bv_omega,
+      show ((0x40000012 : Word) + leU32 bs 26 + leU32 bs (26 + (leU32 bs 26).toNat)
+          + 7 - 0x40000000).toNat
+        = 18 + (leU32 bs 26).toNat
+          + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat + 7 from by
+        bv_omega]
+    exact ⟨rfl, trivial⟩
+
+end EvmAsm.Stateless.SSZ.Decode

--- a/PLAN.md
+++ b/PLAN.md
@@ -2491,7 +2491,10 @@ JALR epilogue against a dword slot of the shared rw region; ghost-indexed
 body-spec family pins the slot), with a two-level call-tree demo
 (topFn → callerRHandle → leafHandle). Remaining: per-frame rw sub-regions
 (CalleesIn currently forces one shared rw across the tree), then more
-Stateless/SSZ ports.
+Stateless/SSZ ports. read_active_fork ported (ActiveForkSAsm.lean:
+byte-wise u32-at-cfg+8 + u64 fork read, drop-in read_active_fork_verified
+swapped into run_stateless_guest, EEST A/B validated). Next port:
+decode_validation_bit.
 
 ## Stateless Guest (parallel STF track)
 


### PR DESCRIPTION
Second Stateless/SSZ SAsm port (after `read_chain_id`, #9651/#9652): `read_active_fork` is now a verified routine, swapped into `run_stateless_guest`.

## The port (`EvmAsm/Stateless/SSZ/Decode/ActiveForkSAsm.lean`)

`readActiveForkFn` reads the `active_fork` u32 offset at `chain_config + 8` and the u64 fork index it points to, **byte-wise**: the original `LWU x14, x13, 8` reads at an address `≡ 2 (mod 4)` (the chain-config section sits at `INPUT_BASE + 18 + offset` with a 4-aligned host offset) and the `LD` reads at a host-data-dependent address — both trap under the Lean RV64 model's alignment gates (beads `evm-asm-iwzun`), exactly like `read_chain_id`.

- Interface: `a3` = chain-config address in (as `read_chain_id_verified` leaves it), `a2` = fork index out, `a3` preserved; clobbers t0, a2, a4 (the original's interface plus t0).
- Ghost precondition carries the assumption the unverified routine makes implicitly: the offset u32 and the fork u64 lie inside the input buffer.
- Proof follows the ChainIdSAsm recipe; new wrinkle handled: both block addresses are symbolic (`0x40000012 + leU32 bs 26`), so the address→index conversions are `bv_omega` shows (after rewriting `signExtend12` constants to word literals, which `bv_omega` treats as opaque otherwise).

## Drop-in

`read_active_fork_verified` (33 instructions, position-independent, `#guard`-pinned) replaces `read_active_fork` in `run_stateless_guest`. Emitted-assembly diff is exactly the two expected expansions (LWU → 10 instrs, LD → 22 instrs).

## EEST A/B (spike backend)

Baseline (main) vs candidate, 200 random fixtures, `--seed 4242`, `--jobs 8`:

| leg | ran | full match | fail | error | budget |
|---|---|---|---|---|---|
| baseline | 200 | 200 | 0 | 0 | 0 |
| candidate | 200 | 200 | 0 | 0 | 0 |

Per-case labels identical between legs.

`readActiveForkFn_spec` is kernel-clean (`propext`/`Classical.choice`/`Quot.sound` only); forbidden-tactics scan OK; zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
