### PR TITLE
feat(sasm): thread an ambient Assertion through the symbolic state (stage 1)

### DIFF
--- a/EvmAsm/Rv64/SAsm/Ast.lean
+++ b/EvmAsm/Rv64/SAsm/Ast.lean
@@ -111,12 +111,12 @@ inductive Stmt where
   /-- Optional mid-condition: emits no code; generates one VC stating that
       every reachable register file satisfies `P`, and strengthens the
       reachable set with `P` downstream (a proof cut). -/
-  | assert (label : String) (P : RegFile → List (BitVec 8) → Prop)
+  | assert (label : String) (P : RegFile → List (BitVec 8) → Assertion → Prop)
   /-- Bounded loop: the body runs while `c` holds, at most `fuel` iterations.
       `inv i` must hold at the i-th evaluation of the header; the generator
       emits initialization, preservation, and fuel-exhaustion VCs. -/
   | «while»  (label : String) (c : Cond) (fuel : Nat)
-           (inv : Nat → RegFile → List (BitVec 8) → Prop) (body : Stmt)
+           (inv : Nat → RegFile → List (BitVec 8) → Assertion → Prop) (body : Stmt)
   /-- Direct call (`jal ra, f.entry`) to a routine with a verified caller
       interface (docs/sasm-design.md §3.6).  The handle carries the callee's
       pre/post in the C-like ABI; the VC generator emits one `.pre`

--- a/EvmAsm/Rv64/SAsm/CtrlSpecs.lean
+++ b/EvmAsm/Rv64/SAsm/CtrlSpecs.lean
@@ -74,26 +74,27 @@ theorem branch_spec_asrt (c : Cond) (ofs : BitVec 13) (rw : RwRegion)
     cpsBranchWithin 1 base (CodeReq.singleton base (c.toInstr ofs))
       (asrtOf rw reach)
       (base + signExtend13 ofs)
-        (asrtOf rw fun rf ws => reach rf ws ∧ c.holds rf)
-      (base + 4) (asrtOf rw fun rf ws => reach rf ws ∧ ¬ c.holds rf) := by
+        (asrtOf rw fun rf ws A => reach rf ws A ∧ c.holds rf)
+      (base + 4) (asrtOf rw fun rf ws A => reach rf ws A ∧ ¬ c.holds rf) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (c.toInstr ofs) :=
     CodeReq.singleton_satisfiedBy.mp hcr
   obtain ⟨hnec, hneb, hnm⟩ := Cond.toInstr_not_special c ofs
   have hstep' : step s = some (execInstrBr s (c.toInstr ofs)) :=
     step_non_ecall_non_mem hfetch hnec hneb hnm
-  obtain ⟨hp, hcompat, h1, h2, hd, hu, ⟨rf, ws, hlen, hreach, hsts⟩, hR2⟩ := hPR
-  have hPR' : ((regFileIs rf) ** (bytesRegion rw.base ws ** R)).holdsFor s := by
-    have h0 : (((regFileIs rf) ** bytesRegion rw.base ws) ** R).holdsFor s :=
+  obtain ⟨hp, hcompat, h1, h2, hd, hu, ⟨rf, ws, A, hlen, hApc, hreach, hsts⟩, hR2⟩ := hPR
+  have hPR' : ((regFileIs rf) ** (bytesRegion rw.base ws ** (A ** R))).holdsFor s := by
+    have h0 : ((((regFileIs rf) ** bytesRegion rw.base ws) ** A) ** R).holdsFor s :=
       ⟨hp, hcompat, h1, h2, hd, hu, hsts, hR2⟩
-    rwa [sepConj_assoc'] at h0
+    rwa [sepConj_assoc' ((regFileIs rf) ** bytesRegion rw.base ws) A R,
+      sepConj_assoc'] at h0
   have hgeq : c.holdsG s.getReg ↔ c.holds rf := by
     rw [Cond.holds_iff_holdsG]
     exact Cond.holdsG_agree hwf
       (fun r hr => holdsFor_regFileIs_agree hPR' hr)
-  have hpcfree_t : ((asrtOf rw fun rf ws => reach rf ws ∧ c.holds rf) ** R).pcFree :=
+  have hpcfree_t : ((asrtOf rw fun rf ws A => reach rf ws A ∧ c.holds rf) ** R).pcFree :=
     pcFree_sepConj (pcFree_asrtOf _ _) hR
-  have hpcfree_f : ((asrtOf rw fun rf ws => reach rf ws ∧ ¬ c.holds rf) ** R).pcFree :=
+  have hpcfree_f : ((asrtOf rw fun rf ws A => reach rf ws A ∧ ¬ c.holds rf) ** R).pcFree :=
     pcFree_sepConj (pcFree_asrtOf _ _) hR
   by_cases hc : c.holds rf
   · have hexec : execInstrBr s (c.toInstr ofs) = s.setPC (s.pc + signExtend13 ofs) := by
@@ -102,14 +103,14 @@ theorem branch_spec_asrt (c : Cond) (ofs : BitVec 13) (rw : RwRegion)
     · show (step s).bind (stepN 0) = some _
       rw [hstep', hexec]; rfl
     · exact holdsFor_pcFree_setPC hpcfree_t
-        ⟨hp, hcompat, h1, h2, hd, hu, ⟨rf, ws, hlen, ⟨hreach, hc⟩, hsts⟩, hR2⟩
+        ⟨hp, hcompat, h1, h2, hd, hu, ⟨rf, ws, A, hlen, hApc, ⟨hreach, hc⟩, hsts⟩, hR2⟩
   · have hexec : execInstrBr s (c.toInstr ofs) = s.setPC (s.pc + 4) := by
       rw [Cond.execInstrBr_cond, if_neg (fun h => hc (hgeq.mp h))]
     refine ⟨1, Nat.le_refl 1, s.setPC (s.pc + 4), ?_, Or.inr ⟨rfl, ?_⟩⟩
     · show (step s).bind (stepN 0) = some _
       rw [hstep', hexec]; rfl
     · exact holdsFor_pcFree_setPC hpcfree_f
-        ⟨hp, hcompat, h1, h2, hd, hu, ⟨rf, ws, hlen, ⟨hreach, hc⟩, hsts⟩, hR2⟩
+        ⟨hp, hcompat, h1, h2, hd, hu, ⟨rf, ws, A, hlen, hApc, ⟨hreach, hc⟩, hsts⟩, hR2⟩
 
 /-- `JAL x0` at pc-free-assertion granularity: a pure PC move. -/
 theorem jal0_spec_pcFree (ofs : BitVec 21) (base : Word) {P : Assertion}

--- a/EvmAsm/Rv64/SAsm/Examples.lean
+++ b/EvmAsm/Rv64/SAsm/Examples.lean
@@ -18,9 +18,9 @@ open Stmt
 private def demoLoop : Stmt :=
   .block "init" [.LI .x5 0, .LI .x6 10] ;;;
   .«while» "count" (.bltu .x5 .x6) 10
-      (fun i rf _ => rf.get .x5 = BitVec.ofNat 64 i)
+      (fun i rf _ _ => rf.get .x5 = BitVec.ofNat 64 i)
       (.block "step" [.ADDI .x5 .x5 1]) ;;;
-  .assert "counted" (fun rf _ => rf.get .x5 = 10) ;;;
+  .assert "counted" (fun rf _ _ => rf.get .x5 = 10) ;;;
   .when "nonzero" (.bne .x5 .x0) (.block "mv" [.MV .x10 .x5])
 
 #guard demoLoop.size = 7
@@ -71,8 +71,8 @@ private def demoCall : Stmt :=
   [.LI .x10 42, .JAL .x1 (0x7FC : BitVec 21)]  -- 0x2000 - 0x1804
 
 /- `assert` emits no code and does not perturb downstream addresses. -/
-#guard (Stmt.assert "mid" (fun rf _ => rf.get .x5 = 0)).size = 0
-#guard (Stmt.assert "mid" (fun rf _ => rf.get .x5 = 0)).flatten 0x1000 = []
+#guard (Stmt.assert "mid" (fun rf _ _ => rf.get .x5 = 0)).size = 0
+#guard (Stmt.assert "mid" (fun rf _ _ => rf.get .x5 = 0)).flatten 0x1000 = []
 
 end Examples
 end SAsm

--- a/EvmAsm/Rv64/SAsm/ExamplesVc.lean
+++ b/EvmAsm/Rv64/SAsm/ExamplesVc.lean
@@ -18,15 +18,15 @@ open Stmt
 /-- `min(a0, a1)` into a0: if a0 ≥u a1 then a0 := a1. -/
 def clampFn (x y : Word) : Fn where
   name := "clamp"
-  pre := fun rf _ => rf.get .x10 = x ∧ rf.get .x11 = y
-  post := fun rf _ =>
+  pre := fun rf _ _ => rf.get .x10 = x ∧ rf.get .x11 = y
+  post := fun rf _ _ =>
     rf.get .x10 = (if BitVec.ult x y then x else y) ∧ rf.get .x11 = y
   body := .when "cap" (.bgeu .x10 .x11) (.block "set" [.MV .x10 .x11])
 
 theorem clampFn_spec (x y base : Word) : (clampFn x y).Spec base := by
   vcgen
   case clamp.post =>
-    intro rf ws h
+    intro rf ws A h
     show rf.get .x10 = (if BitVec.ult x y then x else y) ∧ rf.get .x11 = y
     rcases h with ⟨rf₀, ws₀, -, ⟨⟨hx, hy⟩, hge⟩, rfl, rfl⟩ | ⟨⟨hx, hy⟩, hlt⟩
     · -- took the branch: ¬ x <u y, a0 := a1
@@ -46,18 +46,18 @@ theorem clampFn_spec (x y base : Word) : (clampFn x y).Spec base := by
 /-- Count up from 0 to 10 in t0: init; while (t0 <u t1) t0 += 1. -/
 def countFn : Fn where
   name := "count"
-  pre := fun _ _ => True
-  post := fun rf _ => rf.get .x5 = 10
+  pre := fun _ _ _ => True
+  post := fun rf _ _ => rf.get .x5 = 10
   body :=
     .block "init" [.LI .x5 0, .LI .x6 10] ;;;
     .«while» "loop" (.bltu .x5 .x6) 10
-      (fun i rf _ => rf.get .x5 = BitVec.ofNat 64 i ∧ rf.get .x6 = 10 ∧ i ≤ 10)
+      (fun i rf _ _ => rf.get .x5 = BitVec.ofNat 64 i ∧ rf.get .x6 = 10 ∧ i ≤ 10)
       (.block "step" [.ADDI .x5 .x5 1])
 
 theorem countFn_spec (base : Word) : countFn.Spec base := by
   vcgen
   case count.loop.inv_init =>
-    rintro rf ws ⟨rf₀, ws₀, -, -, rfl, rfl⟩
+    rintro rf ws A ⟨rf₀, ws₀, -, -, rfl, rfl⟩
     simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem]
     refine ⟨?_, ?_, by omega⟩
     · rw [RegFile.get_set_ne _ _ _ _ (by decide),
@@ -65,7 +65,7 @@ theorem countFn_spec (base : Word) : countFn.Spec base := by
       rfl
     · rw [RegFile.get_set_self _ _ _ (by decide)]
   case count.loop.inv_step =>
-    rintro i hi rf' ws' ⟨rf₀, ws₀, -, ⟨⟨hx5, hx6, hle⟩, hlt⟩, rfl, rfl⟩
+    rintro i hi rf' ws' A' ⟨rf₀, ws₀, -, ⟨⟨hx5, hx6, hle⟩, hlt⟩, rfl, rfl⟩
     simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem]
     refine ⟨?_, ?_, by omega⟩
     · rw [RegFile.get_set_self _ _ _ (by decide), hx5,
@@ -74,12 +74,12 @@ theorem countFn_spec (base : Word) : countFn.Spec base := by
     · rw [RegFile.get_set_ne _ _ _ _ (by decide)]
       exact hx6
   case count.loop.exhausted =>
-    rintro rf ws ⟨hx5, hx6, -⟩
+    rintro rf ws A ⟨hx5, hx6, -⟩
     simp only [Cond.holds]
     rw [hx5, hx6]
     decide
   case count.post =>
-    intro rf ws h
+    intro rf ws A h
     show rf.get .x5 = 10
     obtain ⟨⟨i, hle, hx5, hx6, -⟩, hnc⟩ := h
     simp only [Cond.holds] at hnc
@@ -104,8 +104,8 @@ def clampHandle : FnHandle :=
 /-- Load arguments and call clamp: afterwards `a0 = min(5, 7) = 5`. -/
 def callerFn : Fn where
   name := "caller"
-  pre := fun _ _ => True
-  post := fun rf _ => rf.get .x10 = 5
+  pre := fun _ _ _ => True
+  post := fun rf _ _ => rf.get .x10 = 5
   body :=
     .block "args" [.LI .x10 5, .LI .x11 7] ;;;
     .call "clamp" clampHandle
@@ -136,14 +136,14 @@ theorem callerFn_spec : callerFn.SpecR 0x1000 callerCr := by
   case calls =>
     exact ⟨trivial, by decide, by decide, by decide⟩
   case caller.clamp.pre =>
-    rintro rf ws ⟨rf₀, ws₀, -, -, rfl, rfl⟩
+    rintro rf ws A ⟨rf₀, ws₀, -, -, rfl, rfl⟩
     simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem]
     constructor
     · rw [RegFile.get_set_ne _ _ _ _ (by decide),
         RegFile.get_set_self _ _ _ (by decide)]
     · rw [RegFile.get_set_self _ _ _ (by decide)]
   case caller.post =>
-    intro rf ws h
+    intro rf ws A h
     show rf.get .x10 = 5
     have h' : rf.get .x10 = (if BitVec.ult 5 7 then (5 : Word) else 7) := h.1
     rw [h', if_pos (by decide)]
@@ -158,8 +158,8 @@ theorem callerFn_spec : callerFn.SpecR 0x1000 callerCr := by
 def rlpIsListFn (inBase : Word) (bs : List (BitVec 8)) : Fn where
   name := "rlpIsList"
   region := ⟨inBase, bs⟩
-  pre := fun rf _ => rf.get .x10 = inBase ∧ bs ≠ []
-  post := fun rf _ =>
+  pre := fun rf _ _ => rf.get .x10 = inBase ∧ bs ≠ []
+  post := fun rf _ _ =>
     rf.get .x10 = (if (bs.headD 0).toNat < 0xc0 then 0 else 1)
   body :=
     .block "load" [.LBU .x5 .x10 0, .LI .x6 0xc0] ;;;
@@ -178,7 +178,7 @@ theorem rlpIsListFn_spec (inBase : Word) (bs : List (BitVec 8))
   vcgen
   case region => exact ⟨hwf, RwRegion.empty_wf⟩
   case rlpIsList.load.mem =>
-    rintro rf ws hws ⟨hx10, hne⟩
+    rintro rf ws A hws ⟨hx10, hne⟩
     obtain rfl : ws = [] := List.eq_nil_of_length_eq_zero hws
     simp only [blockVCs, loadSem]
     refine ⟨⟨one_dvd _, ?_⟩, trivial, trivial⟩
@@ -188,7 +188,7 @@ theorem rlpIsListFn_spec (inBase : Word) (bs : List (BitVec 8))
     have := List.length_pos_iff.mpr hne
     omega
   case rlpIsList.post =>
-    intro rf' ws' h
+    intro rf' ws' A' h
     show rf'.get .x10 = (if (bs.headD 0).toNat < 0xc0 then 0 else 1)
     obtain ⟨b, tl, rfl⟩ : ∃ b tl, bs = b :: tl := by
       rcases h with ⟨rf₀, ws₀, -, ⟨⟨rf₁, ws₁, -, ⟨-, hne⟩, -⟩, -⟩, -⟩
@@ -243,8 +243,8 @@ theorem rlpIsListFn_spec (inBase : Word) (bs : List (BitVec 8))
 def sszReadOffsetFn (inBase : Word) (bs : List (BitVec 8)) : Fn where
   name := "sszReadOffset"
   region := ⟨inBase, bs⟩
-  pre := fun rf _ => rf.get .x10 = inBase ∧ 8 ≤ bs.length
-  post := fun rf _ => rf.get .x11
+  pre := fun rf _ _ => rf.get .x10 = inBase ∧ 8 ≤ bs.length
+  post := fun rf _ _ => rf.get .x11
     = BitVec.zeroExtend 64
         (bs.getD 7 0 ++ bs.getD 6 0 ++ bs.getD 5 0 ++ bs.getD 4 0)
   body := .block "load" [.LWU .x11 .x10 4]
@@ -260,7 +260,7 @@ theorem sszReadOffsetFn_spec (inBase : Word) (bs : List (BitVec 8))
   vcgen
   case region => exact ⟨hwf, RwRegion.empty_wf⟩
   case sszReadOffset.load.mem =>
-    rintro rf ws hws ⟨hx10, hlen⟩
+    rintro rf ws A hws ⟨hx10, hlen⟩
     obtain rfl : ws = [] := List.eq_nil_of_length_eq_zero hws
     simp only [blockVCs, loadSem]
     refine ⟨⟨?_, ?_⟩, trivial⟩
@@ -271,7 +271,7 @@ theorem sszReadOffsetFn_spec (inBase : Word) (bs : List (BitVec 8))
       rw [haddr rf hx10]
       omega
   case sszReadOffset.post =>
-    rintro rf' ws' ⟨rf₀, ws₀, hws₀, ⟨hx10, hlen⟩, rfl, rfl⟩
+    rintro rf' ws' A' ⟨rf₀, ws₀, hws₀, ⟨hx10, hlen⟩, rfl, rfl⟩
     obtain rfl : ws' = [] := List.eq_nil_of_length_eq_zero hws₀
     show RegFile.get _ .x11 = _
     simp only [execBlock_cons, execBlock_nil, execInstrRF_nil, aluSem, loadSem]
@@ -290,8 +290,8 @@ theorem sszReadOffsetFn_spec (inBase : Word) (bs : List (BitVec 8))
 def readU16Fn (inBase : Word) (bs : List (BitVec 8)) : Fn where
   name := "readU16"
   region := ⟨inBase, bs⟩
-  pre := fun rf _ => rf.get .x10 = inBase ∧ 4 ≤ bs.length
-  post := fun rf _ => rf.get .x11
+  pre := fun rf _ _ => rf.get .x10 = inBase ∧ 4 ≤ bs.length
+  post := fun rf _ _ => rf.get .x11
     = BitVec.zeroExtend 64 (bs.getD 3 0 ++ bs.getD 2 0)
   body := .block "load" [.LHU .x11 .x10 2]
 
@@ -306,7 +306,7 @@ theorem readU16Fn_spec (inBase : Word) (bs : List (BitVec 8))
   vcgen
   case region => exact ⟨hwf, RwRegion.empty_wf⟩
   case readU16.load.mem =>
-    rintro rf ws hws ⟨hx10, hlen⟩
+    rintro rf ws A hws ⟨hx10, hlen⟩
     obtain rfl : ws = [] := List.eq_nil_of_length_eq_zero hws
     simp only [blockVCs, loadSem]
     refine ⟨⟨?_, ?_⟩, trivial⟩
@@ -317,7 +317,7 @@ theorem readU16Fn_spec (inBase : Word) (bs : List (BitVec 8))
       rw [haddr rf hx10]
       omega
   case readU16.post =>
-    rintro rf' ws' ⟨rf₀, ws₀, hws₀, ⟨hx10, hlen⟩, rfl, rfl⟩
+    rintro rf' ws' A' ⟨rf₀, ws₀, hws₀, ⟨hx10, hlen⟩, rfl, rfl⟩
     obtain rfl : ws' = [] := List.eq_nil_of_length_eq_zero hws₀
     show RegFile.get _ .x11 = _
     simp only [execBlock_cons, execBlock_nil, execInstrRF_nil, aluSem, loadSem]
@@ -338,8 +338,8 @@ theorem readU16Fn_spec (inBase : Word) (bs : List (BitVec 8))
 def spillFn (scratch x : Word) : Fn where
   name := "spill"
   rw := ⟨scratch, 8⟩
-  pre := fun rf _ => rf.get .x10 = x ∧ rf.get .x11 = scratch
-  post := fun rf _ => rf.get .x10 = x
+  pre := fun rf _ _ => rf.get .x10 = x ∧ rf.get .x11 = scratch
+  post := fun rf _ _ => rf.get .x10 = x
   body := .block "roundtrip" [.SD .x11 .x10 0, .LI .x10 0, .LD .x10 .x11 0]
 
 theorem spillFn_spec (scratch x base : Word)
@@ -353,7 +353,7 @@ theorem spillFn_spec (scratch x base : Word)
   vcgen
   case region => exact ⟨Region.empty_wf, hwf⟩
   case spill.roundtrip.mem =>
-    rintro rf ws hws ⟨hx10, hx11⟩
+    rintro rf ws A hws ⟨hx10, hx11⟩
     have hws8 : ws.length = 8 := hws
     simp only [blockVCs, loadSem, storeSem, aluSem, execInstrRF, spillFn,
       inRw, Region.loadOk, length_setBytes, hidx rf hx11,
@@ -361,7 +361,7 @@ theorem spillFn_spec (scratch x base : Word)
     rw [if_pos (show 0 + 8 ≤ ws.length from by omega)]
     exact ⟨⟨by omega, by decide⟩, trivial, ⟨by decide, by omega⟩, trivial⟩
   case spill.post =>
-    rintro rf' ws' ⟨rf₀, ws₀, hws₀, ⟨hx10, hx11⟩, rfl, rfl⟩
+    rintro rf' ws' A' ⟨rf₀, ws₀, hws₀, ⟨hx10, hx11⟩, rfl, rfl⟩
     have hws8 : ws₀.length = 8 := hws₀
     show RegFile.get _ .x10 = x
     simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem, loadSem,
@@ -402,8 +402,8 @@ def spillRw : RwRegion := ⟨0x10000, 8⟩
 def leafFn (v : Word) : Fn where
   name := "leaf"
   rw := spillRw
-  pre := fun rf ws => rf.get .x12 = 0x10000 ∧ ws = dwordBytes v
-  post := fun rf ws => rf.get .x10 = 5 ∧ rf.get .x12 = 0x10000
+  pre := fun rf ws _ => rf.get .x12 = 0x10000 ∧ ws = dwordBytes v
+  post := fun rf ws _ => rf.get .x10 = 5 ∧ rf.get .x12 = 0x10000
     ∧ ws = dwordBytes v
   body := .block "set" [.LI .x10 5]
 
@@ -411,7 +411,7 @@ theorem leafFn_spec (v base : Word) : (leafFn v).Spec base := by
   vcgen
   case region => exact ⟨Region.empty_wf, (by decide : spillRw.wf)⟩
   case leaf.post =>
-    rintro rf' ws' ⟨rf₀, ws₀, hws₀, ⟨hx12, hslot⟩, rfl, rfl⟩
+    rintro rf' ws' A' ⟨rf₀, ws₀, hws₀, ⟨hx12, hslot⟩, rfl, rfl⟩
     simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem]
     refine ⟨?_, ?_, hslot⟩
     · rw [RegFile.get_set_self _ _ _ (by decide)]
@@ -429,8 +429,8 @@ def leafHandle (v : Word) : FnHandle :=
 def callerRVFn (v : Word) : Fn where
   name := "callerR"
   rw := spillRw
-  pre := fun rf ws => rf.get .x12 = 0x10000 ∧ ws = dwordBytes v
-  post := fun rf ws => rf.get .x10 = 5 ∧ rf.get .x12 = 0x10000
+  pre := fun rf ws _ => rf.get .x12 = 0x10000 ∧ ws = dwordBytes v
+  post := fun rf ws _ => rf.get .x10 = 5 ∧ rf.get .x12 = 0x10000
     ∧ ws = dwordBytes v
   body := .call "leaf" (leafHandle v)
 
@@ -438,8 +438,8 @@ def callerRVFn (v : Word) : Fn where
     nobody's business outside the wrapper. -/
 def callerRFn : Fn :=
   { callerRVFn 0 with
-    pre := fun rf _ => rf.get .x12 = 0x10000
-    post := fun rf _ => rf.get .x10 = 5 ∧ rf.get .x12 = 0x10000 }
+    pre := fun rf _ _ => rf.get .x12 = 0x10000
+    post := fun rf _ _ => rf.get .x10 = 5 ∧ rf.get .x12 = 0x10000 }
 
 /-- Ambient code: the caller's spill-wrapped code at `0x1000` plus the
     leaf's. -/
@@ -484,9 +484,9 @@ theorem callerRVFn_spec (v : Word) :
       ⟨by decide, by decide, by decide⟩
     exact h0
   case callerR.leaf.pre =>
-    exact fun rf ws h => h
+    exact fun rf ws A h => h
   case callerR.post =>
-    exact fun rf ws h => h
+    exact fun rf ws A h => h
 
 private theorem callerR_hcode : ∀ a i,
     CodeReq.ofProg 0x1000 (callerRFn.programRetR .x12 0 0x1000) a = some i →
@@ -494,23 +494,23 @@ private theorem callerR_hcode : ∀ a i,
   intro a i h
   simp only [callerRCr, CodeReq.union, h]
 
-private theorem callerR_haddr : ∀ rf ws, callerRFn.pre rf ws →
+private theorem callerR_haddr : ∀ rf ws A, callerRFn.pre rf ws A →
     rf.get .x12 + signExtend12 0 = callerRFn.rw.base + BitVec.ofNat 64 0 := by
-  intro rf ws h
+  intro rf ws A h
   rw [show rf.get .x12 = 0x10000 from h]
   decide
 
-private theorem callerR_haddrPost : ∀ (v : Word) rf ws,
-    (callerRVFn v).post rf ws →
+private theorem callerR_haddrPost : ∀ (v : Word) rf ws A,
+    (callerRVFn v).post rf ws A →
     rf.get .x12 + signExtend12 0 = callerRFn.rw.base + BitVec.ofNat 64 0 := by
-  intro v rf ws h
+  intro v rf ws A h
   rw [show rf.get .x12 = 0x10000 from h.2.1]
   decide
 
-private theorem callerR_hspre : ∀ (v : Word) rf ws, callerRFn.pre rf ws →
+private theorem callerR_hspre : ∀ (v : Word) rf ws A, callerRFn.pre rf ws A →
     ws.length = callerRFn.rw.len →
-    (callerRVFn v).pre rf (setBytes ws 0 (dwordBytes v)) := by
-  intro v rf ws h hlen
+    (callerRVFn v).pre rf (setBytes ws 0 (dwordBytes v)) A := by
+  intro v rf ws A h hlen
   refine ⟨h, ?_⟩
   have hlen8 : ws.length = 8 := hlen
   have h1 := setBytes_slot ws (dwordBytes v) 0
@@ -519,14 +519,14 @@ private theorem callerR_hspre : ∀ (v : Word) rf ws, callerRFn.pre rf ws →
     List.take_of_length_le (by rw [length_setBytes]; omega)] at h1
   exact h1
 
-private theorem callerR_hspost : ∀ (v : Word) rf ws,
-    (callerRVFn v).post rf ws → callerRFn.post rf ws :=
-  fun _ _ _ h => ⟨h.1, h.2.1⟩
+private theorem callerR_hspost : ∀ (v : Word) rf ws A,
+    (callerRVFn v).post rf ws A → callerRFn.post rf ws A :=
+  fun _ _ _ _ h => ⟨h.1, h.2.1⟩
 
-private theorem callerR_hslot : ∀ (v : Word) rf ws,
-    (callerRVFn v).post rf ws → ws.length = callerRFn.rw.len →
+private theorem callerR_hslot : ∀ (v : Word) rf ws A,
+    (callerRVFn v).post rf ws A → ws.length = callerRFn.rw.len →
     (ws.drop 0).take 8 = dwordBytes v := by
-  intro v rf ws h hlen
+  intro v rf ws A h hlen
   rw [h.2.2, List.drop_zero,
     List.take_of_length_le (by rw [length_dwordBytes])]
 
@@ -549,8 +549,8 @@ def callerRHandle : FnHandle :=
 def topFn : Fn where
   name := "top"
   rw := spillRw
-  pre := fun rf _ => rf.get .x12 = 0x10000
-  post := fun rf _ => rf.get .x10 = 5 ∧ rf.get .x12 = 0x10000
+  pre := fun rf _ _ => rf.get .x12 = 0x10000
+  post := fun rf _ _ => rf.get .x10 = 5 ∧ rf.get .x12 = 0x10000
   body := .call "callerR" callerRHandle
 
 /-- Ambient code of the top-level caller at `0x3000`. -/
@@ -583,9 +583,9 @@ theorem topFn_spec : topFn.SpecR 0x3000 topCr := by
   case calls =>
     exact ⟨by decide, by decide, by decide⟩
   case top.callerR.pre =>
-    exact fun rf ws h => h
+    exact fun rf ws A h => h
   case top.post =>
-    exact fun rf ws h => h
+    exact fun rf ws A h => h
 
 end ExamplesVc
 end SAsm

--- a/EvmAsm/Rv64/SAsm/Fn.lean
+++ b/EvmAsm/Rv64/SAsm/Fn.lean
@@ -62,7 +62,7 @@ def vcs (f : Fn) : List VC :=
       ∧ 4 * f.body.size < 2 ^ 64⟩ ::
   (Stmt.vcs f.region f.rw f.body (f.name ++ ".") f.pre ++
    [⟨f.name ++ ".post",
-      ∀ rf ws, Stmt.sp f.region f.rw f.body f.pre rf ws → f.post rf ws⟩])
+      ∀ rf ws A, Stmt.sp f.region f.rw f.body f.pre rf ws A → f.post rf ws A⟩])
 
 /-- Soundness: the labeled pure VCs imply the CPS triple. -/
 theorem sound (f : Fn) (base : Word) (hreg : f.region.wf ∧ f.rw.wf)
@@ -72,7 +72,7 @@ theorem sound (f : Fn) (base : Word) (hreg : f.region.wf ∧ f.rw.wf)
     hreg.1 hreg.2 hflat.1 hflat.2.1 hflat.2.2 (fun _ _ hc => hc) h.tail.left
   have hpost := h.tail.right.head
   exact cpsTripleWithin_weaken (fun _ hp => hp)
-    (asrtM_mono (fun rf ws hsp => hpost rf ws hsp))
+    (asrtM_mono (fun rf ws A hsp => hpost rf ws A hsp))
     hbody
 
 -- ============================================================================
@@ -91,7 +91,7 @@ def vcsR (f : Fn) : List VC :=
   ⟨f.name ++ ".flat", f.body.offsetsOk = true ∧ 4 * f.body.size < 2 ^ 64⟩ ::
   (Stmt.vcs f.region f.rw f.body (f.name ++ ".") f.pre ++
    [⟨f.name ++ ".post",
-      ∀ rf ws, Stmt.sp f.region f.rw f.body f.pre rf ws → f.post rf ws⟩])
+      ∀ rf ws A, Stmt.sp f.region f.rw f.body f.pre rf ws A → f.post rf ws A⟩])
 
 /-- Caller-shaped soundness.  `hcode`/`hcallees` locate the body's and the
     callees' code inside `cr`; `hcalls` are the call sites' address side
@@ -108,7 +108,7 @@ theorem soundR (f : Fn) (base : Word) (cr : CodeReq)
     hreg.1 hreg.2 hflat.1 hflat.2 hcode hcallees hcalls h.tail.left
   have hpost := h.tail.right.head
   exact cpsTripleWithin_weaken (fun _ hp => hp)
-    (asrtR_mono (fun rf ws hsp => hpost rf ws hsp))
+    (asrtR_mono (fun rf ws A hsp => hpost rf ws A hsp))
     hbody
 
 -- ============================================================================

--- a/EvmAsm/Rv64/SAsm/Handle.lean
+++ b/EvmAsm/Rv64/SAsm/Handle.lean
@@ -45,13 +45,13 @@ def FnHandle.stub (entry : Word) : FnHandle where
   nSteps := 0
   region := Region.empty
   rw := RwRegion.empty
-  pre := fun _ _ => False
-  post := fun _ _ => True
+  pre := fun _ _ _ => False
+  post := fun _ _ _ => True
   sound := by
     intro ret _ R hR s hcr hPR hpc
     obtain ⟨hp, hcompat, h1, h2, hd, hu, hP1, hR2⟩ := hPR
     obtain ⟨h1a, h1b, hd1, hu1, hx1, hM⟩ := hP1
-    exact (asrtM_unsat (fun _ _ hf => hf) h1b hM).elim
+    exact (asrtM_unsat (fun _ _ _ hf => hf) h1b hM).elim
 
 end SAsm
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/RaSpill.lean
+++ b/EvmAsm/Rv64/SAsm/RaSpill.lean
@@ -248,9 +248,9 @@ theorem ld_ra_spec_within (rs : Reg) (sofs : BitVec 12) (rwBase : Word)
 theorem cpsTripleWithin_exists_pre_M_frame {n : Nat} {entry exit_ : Word}
     {cr : CodeReq} {X : Assertion} {reg : Region} {rw : RwRegion}
     {reach : Reach} {Q : Assertion}
-    (h : ∀ rf ws, ws.length = rw.len → reach rf ws →
+    (h : ∀ rf ws (A : Assertion), ws.length = rw.len → A.pcFree → reach rf ws A →
       cpsTripleWithin n entry exit_ cr
-        (((regFileIs rf) ** bytesRegion rw.base ws) **
+        ((((regFileIs rf) ** bytesRegion rw.base ws) ** A) **
           (bytesRegion reg.base reg.bytes ** X)) Q) :
     cpsTripleWithin n entry exit_ cr (asrtM reg rw reach ** X) Q := by
   intro R hR s hcr hPR hpc
@@ -258,29 +258,30 @@ theorem cpsTripleWithin_exists_pre_M_frame {n : Nat} {entry exit_ : Word}
       = (asrtOf rw reach ** bytesRegion reg.base reg.bytes) from rfl,
     sepConj_assoc', sepConj_assoc'] at hPR
   -- hPR : (asrtOf ** (bytesRegion reg ** (X ** R)))
-  obtain ⟨hp, hcompat, h1, h2, hd, hu, ⟨rf, ws, hlen, hreach, hsts⟩, hR2⟩ := hPR
-  have hPR' : ((((regFileIs rf) ** bytesRegion rw.base ws) **
+  obtain ⟨hp, hcompat, h1, h2, hd, hu, ⟨rf, ws, A, hlen, hApc, hreach, hsts⟩, hR2⟩ := hPR
+  have hPR' : (((((regFileIs rf) ** bytesRegion rw.base ws) ** A) **
       (bytesRegion reg.base reg.bytes ** (X ** R)))).holdsFor s :=
     ⟨hp, hcompat, h1, h2, hd, hu, hsts, hR2⟩
   rw [← sepConj_assoc' (bytesRegion reg.base reg.bytes) X R,
     ← sepConj_assoc'] at hPR'
-  exact h rf ws hlen hreach R hR s hcr hPR' hpc
+  exact h rf ws A hlen hApc hreach R hR s hcr hPR' hpc
 
 /-- Split an `asrtR` precondition into a per-symbolic-state family, including
     a concrete value for the owned `ra`. -/
 theorem cpsTripleWithin_exists_pre_R {n : Nat} {entry exit_ : Word}
     {cr : CodeReq} {reg : Region} {rw : RwRegion} {reach : Reach}
     {Q : Assertion}
-    (h : ∀ rf ws (v : Word), ws.length = rw.len → reach rf ws →
+    (h : ∀ rf ws (A : Assertion) (v : Word), ws.length = rw.len → A.pcFree →
+      reach rf ws A →
       cpsTripleWithin n entry exit_ cr
-        (((regFileIs rf) ** bytesRegion rw.base ws) **
+        ((((regFileIs rf) ** bytesRegion rw.base ws) ** A) **
           (bytesRegion reg.base reg.bytes ** ((.x1 : Reg) ↦ᵣ v))) Q) :
     cpsTripleWithin n entry exit_ cr (asrtR reg rw reach) Q := by
   show cpsTripleWithin n entry exit_ cr (asrtM reg rw reach ** regOwn .x1) Q
   apply cpsTripleWithin_regOwn_right_pre
   intro v
   exact cpsTripleWithin_exists_pre_M_frame
-    (fun rf ws hlen hreach => h rf ws v hlen hreach)
+    (fun rf ws A hlen hApc hreach => h rf ws A v hlen hApc hreach)
 
 -- ============================================================================
 -- Packaging a verified caller as a callee handle
@@ -316,14 +317,14 @@ theorem retSpecR (f : Fn) (base : Word) (cr : CodeReq)
         (asrtR f.region f.rw (spre v)) (asrtR f.region f.rw (spost v)))
     (hcode : ∀ a i, CodeReq.ofProg base (f.programRetR rs sofs base) a = some i →
         cr a = some i)
-    (haddr : ∀ rf ws, f.pre rf ws →
+    (haddr : ∀ rf ws A, f.pre rf ws A →
         rf.get rs + signExtend12 sofs = f.rw.base + BitVec.ofNat 64 k)
-    (haddrPost : ∀ v rf ws, spost v rf ws →
+    (haddrPost : ∀ v rf ws A, spost v rf ws A →
         rf.get rs + signExtend12 sofs = f.rw.base + BitVec.ofNat 64 k)
-    (hspre : ∀ v rf ws, f.pre rf ws → ws.length = f.rw.len →
-        spre v rf (setBytes ws k (dwordBytes v)))
-    (hspost : ∀ v rf ws, spost v rf ws → f.post rf ws)
-    (hslot : ∀ v rf ws, spost v rf ws → ws.length = f.rw.len →
+    (hspre : ∀ v rf ws A, f.pre rf ws A → ws.length = f.rw.len →
+        spre v rf (setBytes ws k (dwordBytes v)) A)
+    (hspost : ∀ v rf ws A, spost v rf ws A → f.post rf ws A)
+    (hslot : ∀ v rf ws A, spost v rf ws A → ws.length = f.rw.len →
         (ws.drop k).take 8 = dwordBytes v) :
     ∀ ret : Word, (ret &&& ~~~(1 : Word)) = ret →
       cpsTripleWithin (1 + f.body.steps + 2) base ret cr
@@ -382,9 +383,9 @@ theorem retSpecR (f : Fn) (base : Word) (cr : CodeReq)
       ret cr (asrtR f.region f.rw (spost ret))
       (((.x1 : Reg) ↦ᵣ ret) ** asrtM f.region f.rw f.post) := by
     apply cpsTripleWithin_exists_pre_R
-    intro rf ws v hlen hreach
+    intro rf ws A v hlen hApc hreach
     have haddr' : rf.get rs + signExtend12 sofs
-        = f.rw.base + BitVec.ofNat 64 k := haddrPost ret rf ws hreach
+        = f.rw.base + BitVec.ofNat 64 k := haddrPost ret rf ws A hreach
     have hidx : ((rf.get rs + signExtend12 sofs) - f.rw.base).toNat = k := by
       rw [haddr']
       bv_omega
@@ -396,42 +397,56 @@ theorem retSpecR (f : Fn) (base : Word) (cr : CodeReq)
     have hld := ld_ra_spec_within rs sofs f.rw.base rf ws v
       ((base + 4) + BitVec.ofNat 64 (4 * f.body.size)) hrs hwf' hin'
       (by rw [hidx]; exact hk)
-    rw [hidx, hslot ret rf ws hreach hlen, packBytes_dwordBytes] at hld
+    rw [hidx, hslot ret rf ws A hreach hlen, packBytes_dwordBytes] at hld
     have hld' := cpsTripleWithin_extend_code hcodeLD hld
+    have hldA := cpsTripleWithin_frameR A hApc hld'
     have hld'' := cpsTripleWithin_frameR
-      (bytesRegion f.region.base f.region.bytes) (bytesRegion_pcFree _ _) hld'
+      (bytesRegion f.region.base f.region.bytes) (bytesRegion_pcFree _ _) hldA
     -- JALR
     have hjal := jalr_ret_spec (((base + 4) + BitVec.ofNat 64 (4 * f.body.size)) + 4)
       ret halign
-      (P := ((regFileIs rf) ** bytesRegion f.rw.base ws) **
+      (P := (((regFileIs rf) ** bytesRegion f.rw.base ws) ** A) **
         bytesRegion f.region.base f.region.bytes)
-      (pcFree_sepConj (pcFree_sepConj (pcFree_regFileIs _)
-        (bytesRegion_pcFree _ _)) (bytesRegion_pcFree _ _))
+      (pcFree_sepConj (pcFree_sepConj (pcFree_sepConj (pcFree_regFileIs _)
+        (bytesRegion_pcFree _ _)) hApc) (bytesRegion_pcFree _ _))
     have hjal' := cpsTripleWithin_extend_code hcodeJ hjal
     have hseq := cpsTripleWithin_seq_same_cr
       (cpsTripleWithin_weaken
-        (P := (((.x1 : Reg) ↦ᵣ v) ** ((regFileIs rf) ** bytesRegion f.rw.base ws))
-          ** bytesRegion f.region.base f.region.bytes)
-        (P' := ((regFileIs rf) ** bytesRegion f.rw.base ws) **
+        (P := ((((.x1 : Reg) ↦ᵣ v) ** ((regFileIs rf) ** bytesRegion f.rw.base ws))
+          ** A) ** bytesRegion f.region.base f.region.bytes)
+        (P' := (((regFileIs rf) ** bytesRegion f.rw.base ws) ** A) **
           (bytesRegion f.region.base f.region.bytes ** ((.x1 : Reg) ↦ᵣ v)))
         (Q' := ((.x1 : Reg) ↦ᵣ ret) **
-          (((regFileIs rf) ** bytesRegion f.rw.base ws) **
+          ((((regFileIs rf) ** bytesRegion f.rw.base ws) ** A) **
             bytesRegion f.region.base f.region.bytes))
         (fun hp hh => by
           have h1 := sc_to_swap hp hh
-          rw [sepConj_comm' ((regFileIs rf) ** bytesRegion f.rw.base ws)
-            ((.x1 : Reg) ↦ᵣ v)] at h1
+          rw [sepConj_assoc' ((regFileIs rf) ** bytesRegion f.rw.base ws) A
+              ((.x1 : Reg) ↦ᵣ v),
+            sepConj_comm' A ((.x1 : Reg) ↦ᵣ v),
+            sepConj_left_comm ((regFileIs rf) ** bytesRegion f.rw.base ws)
+              ((.x1 : Reg) ↦ᵣ v) A,
+            ← sepConj_assoc' ((.x1 : Reg) ↦ᵣ v)
+              ((regFileIs rf) ** bytesRegion f.rw.base ws) A] at h1
           exact h1)
-        (fun hp hh => sc_assoc_r hp hh)
+        (fun hp hh => by
+          rw [sepConj_assoc'
+              (((.x1 : Reg) ↦ᵣ ret) ** ((regFileIs rf) ** bytesRegion f.rw.base ws))
+              A (bytesRegion f.region.base f.region.bytes),
+            sepConj_assoc' ((.x1 : Reg) ↦ᵣ ret)
+              ((regFileIs rf) ** bytesRegion f.rw.base ws),
+            ← sepConj_assoc' ((regFileIs rf) ** bytesRegion f.rw.base ws) A
+              (bytesRegion f.region.base f.region.bytes)] at hh
+          exact hh)
         hld'')
       hjal'
     refine cpsTripleWithin_weaken (fun hp hh => hh) ?_ hseq
-    -- ((.x1 ↦ ret) ** ((RF ** BW) ** RO)) → ((.x1 ↦ ret) ** asrtM post)
+    -- ((.x1 ↦ ret) ** (((RF ** BW) ** A) ** RO)) → ((.x1 ↦ ret) ** asrtM post)
     intro hp hh
     refine sepConj_mono_right (fun hq hx => ?_) hp hh
     show asrtM f.region f.rw f.post hq
     exact sepConj_mono_left
-      (fun hv hy => ⟨rf, ws, hlen, hspost ret rf ws hreach, hy⟩) hq hx
+      (fun hv hy => ⟨rf, ws, A, hlen, hApc, hspost ret rf ws A hreach, hy⟩) hq hx
   -- spill + body
   have hMain : cpsTripleWithin (1 + f.body.steps) base
       ((base + 4) + BitVec.ofNat 64 (4 * f.body.size)) cr
@@ -439,9 +454,9 @@ theorem retSpecR (f : Fn) (base : Word) (cr : CodeReq)
       (asrtR f.region f.rw (spost ret)) := by
     rw [sepConj_comm' ((.x1 : Reg) ↦ᵣ ret) (asrtM f.region f.rw f.pre)]
     apply cpsTripleWithin_exists_pre_M_frame
-    intro rf ws hlen hreach
+    intro rf ws A hlen hApc hreach
     have haddr' : rf.get rs + signExtend12 sofs
-        = f.rw.base + BitVec.ofNat 64 k := haddr rf ws hreach
+        = f.rw.base + BitVec.ofNat 64 k := haddr rf ws A hreach
     have hidx : ((rf.get rs + signExtend12 sofs) - f.rw.base).toNat = k := by
       rw [haddr']
       bv_omega
@@ -454,20 +469,29 @@ theorem retSpecR (f : Fn) (base : Word) (cr : CodeReq)
       (by rw [hidx]; exact hk)
     rw [hidx] at hsd
     have hsd' := cpsTripleWithin_extend_code hcodeSD hsd
+    have hsdA := cpsTripleWithin_frameR A hApc hsd'
     have hsd'' := cpsTripleWithin_frameR
-      (bytesRegion f.region.base f.region.bytes) (bytesRegion_pcFree _ _) hsd'
+      (bytesRegion f.region.base f.region.bytes) (bytesRegion_pcFree _ _) hsdA
     have hsdW := cpsTripleWithin_weaken
-      (P := (((.x1 : Reg) ↦ᵣ ret) ** ((regFileIs rf) ** bytesRegion f.rw.base ws))
-        ** bytesRegion f.region.base f.region.bytes)
-      (P' := ((regFileIs rf) ** bytesRegion f.rw.base ws) **
+      (P := ((((.x1 : Reg) ↦ᵣ ret) ** ((regFileIs rf) ** bytesRegion f.rw.base ws))
+        ** A) ** bytesRegion f.region.base f.region.bytes)
+      (P' := (((regFileIs rf) ** bytesRegion f.rw.base ws) ** A) **
         (bytesRegion f.region.base f.region.bytes ** ((.x1 : Reg) ↦ᵣ ret)))
       (Q' := asrtR f.region f.rw (spre ret))
       (fun hp hh => by
         have h1 := sc_to_swap hp hh
-        rw [sepConj_comm' ((regFileIs rf) ** bytesRegion f.rw.base ws)
-          ((.x1 : Reg) ↦ᵣ ret)] at h1
+        rw [sepConj_assoc' ((regFileIs rf) ** bytesRegion f.rw.base ws) A
+            ((.x1 : Reg) ↦ᵣ ret),
+          sepConj_comm' A ((.x1 : Reg) ↦ᵣ ret),
+          sepConj_left_comm ((regFileIs rf) ** bytesRegion f.rw.base ws)
+            ((.x1 : Reg) ↦ᵣ ret) A,
+          ← sepConj_assoc' ((.x1 : Reg) ↦ᵣ ret)
+            ((regFileIs rf) ** bytesRegion f.rw.base ws) A] at h1
         exact h1)
       (fun hp hh => by
+        rw [sepConj_assoc' ((.x1 : Reg) ↦ᵣ ret)
+          ((regFileIs rf) ** bytesRegion f.rw.base (setBytes ws k (dwordBytes ret)))
+          A] at hh
         have h1 := sepConj_mono_left
           (fun hq hx => sepConj_mono_left
             (fun hv (hy : ((.x1 : Reg) ↦ᵣ ret) hv) =>
@@ -475,9 +499,9 @@ theorem retSpecR (f : Fn) (base : Word) (cr : CodeReq)
         have h2 := sepConj_mono_left
           (fun hq hx => sepConj_mono_right
             (fun hv hy =>
-              (⟨rf, setBytes ws k (dwordBytes ret),
-                by rw [length_setBytes]; exact hlen,
-                hspre ret rf ws hreach hlen, hy⟩ :
+              (⟨rf, setBytes ws k (dwordBytes ret), A,
+                by rw [length_setBytes]; exact hlen, hApc,
+                hspre ret rf ws A hreach hlen, hy⟩ :
                 asrtOf f.rw (spre ret) hv)) hq hx) hp h1
         rw [sepConj_assoc', sepConj_comm'] at h2
         exact h2)
@@ -499,14 +523,14 @@ def toHandleR (f : Fn) (base : Word) (cr : CodeReq)
         (asrtR f.region f.rw (spre v)) (asrtR f.region f.rw (spost v)))
     (hcode : ∀ a i, CodeReq.ofProg base (f.programRetR rs sofs base) a = some i →
         cr a = some i)
-    (haddr : ∀ rf ws, f.pre rf ws →
+    (haddr : ∀ rf ws A, f.pre rf ws A →
         rf.get rs + signExtend12 sofs = f.rw.base + BitVec.ofNat 64 k)
-    (haddrPost : ∀ v rf ws, spost v rf ws →
+    (haddrPost : ∀ v rf ws A, spost v rf ws A →
         rf.get rs + signExtend12 sofs = f.rw.base + BitVec.ofNat 64 k)
-    (hspre : ∀ v rf ws, f.pre rf ws → ws.length = f.rw.len →
-        spre v rf (setBytes ws k (dwordBytes v)))
-    (hspost : ∀ v rf ws, spost v rf ws → f.post rf ws)
-    (hslot : ∀ v rf ws, spost v rf ws → ws.length = f.rw.len →
+    (hspre : ∀ v rf ws A, f.pre rf ws A → ws.length = f.rw.len →
+        spre v rf (setBytes ws k (dwordBytes v)) A)
+    (hspost : ∀ v rf ws A, spost v rf ws A → f.post rf ws A)
+    (hslot : ∀ v rf ws A, spost v rf ws A → ws.length = f.rw.len →
         (ws.drop k).take 8 = dwordBytes v) : FnHandle where
   entry := base
   code := cr

--- a/EvmAsm/Rv64/SAsm/RegFileSep.lean
+++ b/EvmAsm/Rv64/SAsm/RegFileSep.lean
@@ -36,10 +36,13 @@ theorem pcFree_regFileIs (rf : RegFile) : (regFileIs rf).pcFree := by
   rw [hp]
   rfl
 
-/-- A set of symbolic states — exposed register file plus the current
-    contents of the function's writable region: the pure abstraction of the
-    machine state between SAsm nodes. -/
-def Reach := RegFile → List (BitVec 8) → Prop
+/-- A set of symbolic states — exposed register file, the current contents
+    of the function's writable region, plus the ambient separation-logic
+    assertion the function owns beyond its flat regions (pointer-shaped
+    data: trees, lists, borrowed windows).  The pure abstraction of the
+    machine state between SAsm nodes; ordinary blocks leave the assertion
+    component untouched. -/
+def Reach := RegFile → List (BitVec 8) → Assertion → Prop
 
 /-- Extract exposed-register values from a framed `regFileIs`. -/
 theorem holdsFor_regFileIs_getReg {rf : RegFile} {R : Assertion} {s : MachineState}

--- a/EvmAsm/Rv64/SAsm/RegionSound.lean
+++ b/EvmAsm/Rv64/SAsm/RegionSound.lean
@@ -643,17 +643,19 @@ theorem regFile_load_spec_within (i : Instr) (l : LoadOp) (reg : Region)
 -- ============================================================================
 
 /-- Embed a reachable set as an assertion: some symbolic state in the set
-    owns the exposed registers and the writable region's contents (whose
-    byte count is pinned to the region's length). -/
+    owns the exposed registers, the writable region's contents (whose byte
+    count is pinned to the region's length), and the ambient assertion
+    component (pinned pc-free). -/
 def asrtOf (rw : RwRegion) (reach : Reach) : Assertion :=
-  fun h => ∃ rf ws, ws.length = rw.len ∧ reach rf ws ∧
-    ((regFileIs rf) ** bytesRegion rw.base ws) h
+  fun h => ∃ rf ws A, ws.length = rw.len ∧ Assertion.pcFree A ∧ reach rf ws A ∧
+    (((regFileIs rf) ** bytesRegion rw.base ws) ** A) h
 
 theorem pcFree_asrtOf (rw : RwRegion) (reach : Reach) :
     (asrtOf rw reach).pcFree := by
   intro h hp
-  obtain ⟨rf, ws, -, -, hh⟩ := hp
-  exact pcFree_sepConj (pcFree_regFileIs _) (bytesRegion_pcFree _ _) h hh
+  obtain ⟨rf, ws, A, -, hApc, -, hh⟩ := hp
+  exact pcFree_sepConj
+    (pcFree_sepConj (pcFree_regFileIs _) (bytesRegion_pcFree _ _)) hApc h hh
 
 /-- Leaf-shaped embedding of a reachable set: the exposed register file, the
     writable region's contents, plus the function's read-only region. -/
@@ -665,40 +667,46 @@ theorem pcFree_asrtM (reg : Region) (rw : RwRegion) (reach : Reach) :
   pcFree_sepConj (pcFree_asrtOf _ _) (bytesRegion_pcFree _ _)
 
 theorem asrtM_mono {reg : Region} {rw : RwRegion} {r₁ r₂ : Reach}
-    (h : ∀ rf ws, r₁ rf ws → r₂ rf ws) :
+    (h : ∀ rf ws A, r₁ rf ws A → r₂ rf ws A) :
     ∀ hp, asrtM reg rw r₁ hp → asrtM reg rw r₂ hp :=
   fun hp => sepConj_mono_left (fun hq hh => by
-    obtain ⟨rf, ws, hlen, hr, hsts⟩ := hh
-    exact ⟨rf, ws, hlen, h rf ws hr, hsts⟩) hp
+    obtain ⟨rf, ws, A, hlen, hApc, hr, hsts⟩ := hh
+    exact ⟨rf, ws, A, hlen, hApc, h rf ws A hr, hsts⟩) hp
 
 theorem asrtM_unsat {reg : Region} {rw : RwRegion} {r : Reach}
-    (h : ∀ rf ws, r rf ws → False) :
+    (h : ∀ rf ws A, r rf ws A → False) :
     ∀ hp, asrtM reg rw r hp → False := by
-  rintro hp ⟨h1, h2, -, -, ⟨rf, ws, -, hr, -⟩, -⟩
-  exact h rf ws hr
+  rintro hp ⟨h1, h2, -, -, ⟨rf, ws, A, -, -, hr, -⟩, -⟩
+  exact h rf ws A hr
 
 /-- Split an `asrtM` precondition into a per-symbolic-state family with both
-    regions alongside. -/
+    regions and the (pc-free) ambient assertion alongside. -/
 theorem cpsTripleWithin_exists_pre_M {n : Nat} {entry exit_ : Word}
     {cr : CodeReq} {reg : Region} {rw : RwRegion} {reach : Reach} {Q : Assertion}
-    (h : ∀ rf ws, ws.length = rw.len → reach rf ws →
+    (h : ∀ rf ws (A : Assertion), ws.length = rw.len → A.pcFree →
+      reach rf ws A →
       cpsTripleWithin n entry exit_ cr
-        ((regFileIs rf) ** (bytesRegion reg.base reg.bytes **
-          bytesRegion rw.base ws)) Q) :
+        (((regFileIs rf) ** (bytesRegion reg.base reg.bytes **
+          bytesRegion rw.base ws)) ** A) Q) :
     cpsTripleWithin n entry exit_ cr (asrtM reg rw reach) Q := by
   intro R hR s hcr hPR hpc
   rw [show asrtM reg rw reach
     = (asrtOf rw reach ** bytesRegion reg.base reg.bytes) from rfl,
     sepConj_assoc'] at hPR
-  obtain ⟨hp, hcompat, h1, h2, hd, hu, ⟨rf, ws, hlen, hreach, hsts⟩, hR2⟩ := hPR
-  have hPR' : (((regFileIs rf) ** bytesRegion rw.base ws) **
+  obtain ⟨hp, hcompat, h1, h2, hd, hu, ⟨rf, ws, A, hlen, hApc, hreach, hsts⟩, hR2⟩ := hPR
+  have hPR' : ((((regFileIs rf) ** bytesRegion rw.base ws) ** A) **
       (bytesRegion reg.base reg.bytes ** R)).holdsFor s :=
     ⟨hp, hcompat, h1, h2, hd, hu, hsts, hR2⟩
-  rw [sepConj_assoc',
-    sepConj_left_comm (bytesRegion rw.base ws) (bytesRegion reg.base reg.bytes) R,
-    ← sepConj_assoc' (bytesRegion reg.base reg.bytes),
-    ← sepConj_assoc'] at hPR'
-  exact h rf ws hlen hreach R hR s hcr hPR' hpc
+  rw [sepConj_assoc' ((regFileIs rf) ** bytesRegion rw.base ws) A,
+    sepConj_left_comm A (bytesRegion reg.base reg.bytes) R,
+    sepConj_assoc' (regFileIs rf) (bytesRegion rw.base ws),
+    sepConj_left_comm (bytesRegion rw.base ws) (bytesRegion reg.base reg.bytes),
+    ← sepConj_assoc' (bytesRegion reg.base reg.bytes) (bytesRegion rw.base ws),
+    ← sepConj_assoc' (regFileIs rf),
+    ← sepConj_assoc'
+      ((regFileIs rf) ** (bytesRegion reg.base reg.bytes ** bytesRegion rw.base ws))
+      A R] at hPR'
+  exact h rf ws A hlen hApc hreach R hR s hcr hPR' hpc
 
 end SAsm
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/StmtSound.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSound.lean
@@ -98,12 +98,13 @@ theorem ofProg_cons_tail {base : Word} {i : Instr} {rest : List Instr}
 /-- Split an `asrtOf` precondition into a per-symbolic-state family. -/
 theorem cpsTripleWithin_exists_pre {n : Nat} {entry exit_ : Word} {cr : CodeReq}
     {rw : RwRegion} {reach : Reach} {Q : Assertion}
-    (h : ∀ rf ws, ws.length = rw.len → reach rf ws → cpsTripleWithin n entry exit_ cr
-      ((regFileIs rf) ** bytesRegion rw.base ws) Q) :
+    (h : ∀ rf ws (A : Assertion), ws.length = rw.len → A.pcFree → reach rf ws A →
+      cpsTripleWithin n entry exit_ cr
+        (((regFileIs rf) ** bytesRegion rw.base ws) ** A) Q) :
     cpsTripleWithin n entry exit_ cr (asrtOf rw reach) Q := by
   intro R hR s hcr hPR hpc
-  obtain ⟨hp, hcompat, h1, h2, hd, hu, ⟨rf, ws, hlen, hreach, hsts⟩, hR2⟩ := hPR
-  exact h rf ws hlen hreach R hR s hcr ⟨hp, hcompat, h1, h2, hd, hu, hsts, hR2⟩ hpc
+  obtain ⟨hp, hcompat, h1, h2, hd, hu, ⟨rf, ws, A, hlen, hApc, hreach, hsts⟩, hR2⟩ := hPR
+  exact h rf ws A hlen hApc hreach R hR s hcr ⟨hp, hcompat, h1, h2, hd, hu, hsts, hR2⟩ hpc
 
 /-- Zero-step triple from a pointwise entailment. -/
 theorem cpsTripleWithin_entails {entry : Word} {cr : CodeReq} {P Q : Assertion}
@@ -153,27 +154,30 @@ theorem Stmt.sound (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
   induction s generalizing base pfx reach cr with
   | block lbl is =>
       have hok : blockOk is = true := hvcs.head
-      have hmem : ∀ rf ws, ws.length = rw.len → reach rf ws →
+      have hmem : ∀ rf ws (A : Assertion), ws.length = rw.len → reach rf ws A →
           blockVCs reg rw.base rf ws is := by
         by_cases hl : hasLoad is
         · have ht := hvcs.tail
           simp only [hl, if_true] at ht
           exact ht.head
-        · exact fun rf ws _ _ =>
+        · exact fun rf ws _ _ _ =>
             blockVCs_of_not_hasLoad reg rw.base rf ws is (by simpa using hl)
       apply cpsTripleWithin_exists_pre_M
-      intro rf ws hlen hreach
+      intro rf ws A hlen hApc hreach
       have h := execBlock_sound reg rw is rf ws base hreg hrw hlen hok
-        (hmem rf ws hlen hreach) (by simpa [Stmt.size] using hsz)
-      have h' := cpsTripleWithin_extend_code hcode h
+        (hmem rf ws A hlen hreach) (by simpa [Stmt.size] using hsz)
+      have hA := cpsTripleWithin_frameR A hApc h
+      have h' := cpsTripleWithin_extend_code hcode hA
       refine cpsTripleWithin_weaken (fun _ hp => hp) ?_ h'
       intro hp hh
-      have hh' := sc_to_swap hp hh
+      rw [sepConj_assoc', sepConj_assoc',
+        sepConj_comm' (bytesRegion reg.base reg.bytes),
+        ← sepConj_assoc', ← sepConj_assoc'] at hh
       exact sepConj_mono_left
         (fun hq hr => ⟨(execBlock reg rw.base rf ws is).1,
-          (execBlock reg rw.base rf ws is).2,
-          by rw [execBlock_ws_length]; exact hlen,
-          ⟨rf, ws, hlen, hreach, rfl, rfl⟩, hr⟩) hp hh'
+          (execBlock reg rw.base rf ws is).2, A,
+          by rw [execBlock_ws_length]; exact hlen, hApc,
+          ⟨rf, ws, hlen, hreach, rfl, rfl⟩, hr⟩) hp hh
   | seq a b iha ihb =>
       simp only [Stmt.callFree, Bool.and_eq_true] at hleaf
       simp only [Stmt.offsetsOk, Bool.and_eq_true] at hofs
@@ -276,46 +280,46 @@ theorem Stmt.sound (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
         (bytesRegion_pcFree _ _) (cpsBranchWithin_extend_code hcode_br hbr)
       -- Then-arm: t's code then the skip jump
       have ht := iht (base + 4) (pfx ++ lbl ++ ".t.")
-        (fun rf ws => reach rf ws ∧ c.holds rf) hleaf.1 hOT (by omega) hcode_t hvcs.left
+        (fun rf ws A => reach rf ws A ∧ c.holds rf) hleaf.1 hOT (by omega) hcode_t hvcs.left
       rw [haddr1] at ht
       have hjal := jal0_spec_pcFree (Stmt.jFwd (e.size + 1))
         (base + BitVec.ofNat 64 (4 * (t.size + 1)))
-        (pcFree_asrtM reg rw (Stmt.sp reg rw t fun rf ws => reach rf ws ∧ c.holds rf))
+        (pcFree_asrtM reg rw (Stmt.sp reg rw t fun rf ws A => reach rf ws A ∧ c.holds rf))
       rw [signExtend21_jFwd hofsJ, haddr2] at hjal
       have hjal' := cpsTripleWithin_extend_code hcode_jal hjal
       have htj := cpsTripleWithin_seq_same_cr ht hjal'
       -- Else-arm
       have he := ihe (base + BitVec.ofNat 64 (4 * (t.size + 2))) (pfx ++ lbl ++ ".e.")
-        (fun rf ws => reach rf ws ∧ ¬ c.holds rf) hleaf.2 hOE (by omega) hcode_e hvcs.right
+        (fun rf ws A => reach rf ws A ∧ ¬ c.holds rf) hleaf.2 hOE (by omega) hcode_e hvcs.right
       rw [haddr3] at he
       -- Weaken branch posts: neg-condition denotations and arm preconditions
       have hbr'' : cpsBranchWithin 1 base cr (asrtM reg rw reach)
           (base + BitVec.ofNat 64 (4 * (t.size + 2)))
-            (asrtM reg rw fun rf ws => reach rf ws ∧ ¬ c.holds rf)
-          (base + 4) (asrtM reg rw fun rf ws => reach rf ws ∧ c.holds rf) := by
+            (asrtM reg rw fun rf ws A => reach rf ws A ∧ ¬ c.holds rf)
+          (base + 4) (asrtM reg rw fun rf ws A => reach rf ws A ∧ c.holds rf) := by
         refine cpsBranchWithin_weaken (fun _ hp => hp) ?_ ?_ hbr'
-        · exact asrtM_mono (fun rf ws hh =>
+        · exact asrtM_mono (fun rf ws A hh =>
             ⟨hh.1, (Cond.holds_neg c rf).mp hh.2⟩)
-        · exact asrtM_mono (fun rf ws hh =>
+        · exact asrtM_mono (fun rf ws A hh =>
             ⟨hh.1, Decidable.of_not_not
               (fun hcc => hh.2 ((Cond.holds_neg c rf).mpr hcc))⟩)
       -- Merge: taken exit is the else entry, not-taken is the then entry
       have harmE : cpsTripleWithin (max (t.steps + 1) e.steps)
           (base + BitVec.ofNat 64 (4 * (t.size + 2)))
           (base + BitVec.ofNat 64 (4 * (t.size + e.size + 2))) cr
-          (asrtM reg rw fun rf ws => reach rf ws ∧ ¬ c.holds rf)
+          (asrtM reg rw fun rf ws A => reach rf ws A ∧ ¬ c.holds rf)
           (asrtM reg rw (Stmt.sp reg rw (.ite lbl c t e) reach)) := by
         refine cpsTripleWithin_mono_nSteps (Nat.le_max_right _ _)
           (cpsTripleWithin_weaken (fun _ hp => hp) ?_ he)
-        exact asrtM_mono (fun rf ws hsp => Or.inr hsp)
+        exact asrtM_mono (fun rf ws A hsp => Or.inr hsp)
       have harmT : cpsTripleWithin (max (t.steps + 1) e.steps)
           (base + 4)
           (base + BitVec.ofNat 64 (4 * (t.size + e.size + 2))) cr
-          (asrtM reg rw fun rf ws => reach rf ws ∧ c.holds rf)
+          (asrtM reg rw fun rf ws A => reach rf ws A ∧ c.holds rf)
           (asrtM reg rw (Stmt.sp reg rw (.ite lbl c t e) reach)) := by
         refine cpsTripleWithin_mono_nSteps (Nat.le_max_left _ _)
           (cpsTripleWithin_weaken (fun _ hp => hp) ?_ htj)
-        exact asrtM_mono (fun rf ws hsp => Or.inl hsp)
+        exact asrtM_mono (fun rf ws A hsp => Or.inl hsp)
       exact cpsBranchWithin_merge_same_cr hbr'' harmE harmT
   | «when» lbl c b ihb =>
       simp only [Stmt.offsetsOk, Bool.and_eq_true, decide_eq_true_eq] at hofs
@@ -339,7 +343,7 @@ theorem Stmt.sound (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
       have hbr' := cpsBranchWithin_frameR (bytesRegion reg.base reg.bytes)
         (bytesRegion_pcFree _ _) (cpsBranchWithin_extend_code hcode_br hbr)
       have hb := ihb (base + 4) (pfx ++ lbl ++ ".")
-        (fun rf ws => reach rf ws ∧ c.holds rf) (by simpa [Stmt.callFree] using hleaf)
+        (fun rf ws A => reach rf ws A ∧ c.holds rf) (by simpa [Stmt.callFree] using hleaf)
         hOB (by omega) hcode_b hvcs
       rw [show (base + 4) + BitVec.ofNat 64 (4 * b.size)
           = base + BitVec.ofNat 64 (4 * (b.size + 1)) from by bv_omega] at hb
@@ -347,28 +351,28 @@ theorem Stmt.sound (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
       have hskip : cpsTripleWithin b.steps
           (base + BitVec.ofNat 64 (4 * (b.size + 1)))
           (base + BitVec.ofNat 64 (4 * (b.size + 1))) cr
-          (asrtM reg rw fun rf ws => reach rf ws ∧ c.neg.holds rf)
+          (asrtM reg rw fun rf ws A => reach rf ws A ∧ c.neg.holds rf)
           (asrtM reg rw (Stmt.sp reg rw (.when lbl c b) reach)) := by
         apply cpsTripleWithin_mono_nSteps (Nat.zero_le _)
         apply cpsTripleWithin_entails
-        exact asrtM_mono (fun rf ws hh =>
+        exact asrtM_mono (fun rf ws A hh =>
           Or.inr ⟨hh.1, (Cond.holds_neg c rf).mp hh.2⟩)
       -- not-taken (c): run the body
       have hbody : cpsTripleWithin b.steps (base + 4)
           (base + BitVec.ofNat 64 (4 * (b.size + 1))) cr
-          (asrtM reg rw fun rf ws => reach rf ws ∧ ¬ c.neg.holds rf)
+          (asrtM reg rw fun rf ws A => reach rf ws A ∧ ¬ c.neg.holds rf)
           (asrtM reg rw (Stmt.sp reg rw (.when lbl c b) reach)) := by
         refine cpsTripleWithin_weaken ?_ ?_ hb
-        · exact asrtM_mono (fun rf ws hh =>
+        · exact asrtM_mono (fun rf ws A hh =>
             ⟨hh.1, Decidable.of_not_not
               (fun hcc => hh.2 ((Cond.holds_neg c rf).mpr hcc))⟩)
-        · exact asrtM_mono (fun rf ws hsp => Or.inl hsp)
+        · exact asrtM_mono (fun rf ws A hsp => Or.inl hsp)
       exact cpsBranchWithin_merge_same_cr hbr' hskip hbody
   | assert lbl P =>
       have hvc := hvcs _ (List.mem_singleton_self _)
       have h : cpsTripleWithin 0 base base cr (asrtM reg rw reach)
           (asrtM reg rw (Stmt.sp reg rw (.assert lbl P) reach)) :=
-        cpsTripleWithin_entails (asrtM_mono (fun rf ws hr => ⟨hr, hvc rf ws hr⟩))
+        cpsTripleWithin_entails (asrtM_mono (fun rf ws A hr => ⟨hr, hvc rf ws A hr⟩))
       have hz : base + BitVec.ofNat 64 (4 * Stmt.size (.assert lbl P)) = base := by
         simp [Stmt.size]
       simp only [Stmt.steps]
@@ -379,12 +383,13 @@ theorem Stmt.sound (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
       obtain ⟨⟨⟨hwf, hofsHdr⟩, hofsBack⟩, hOB⟩ := hofs
       simp only [Stmt.size] at hsz
       -- VC pieces
-      have hInvInit : ∀ rf ws, reach rf ws → inv 0 rf ws := hvcs.head
+      have hInvInit : ∀ rf ws A, reach rf ws A → inv 0 rf ws A := hvcs.head
       have hInvStep : ∀ i, i < fuel →
-          ∀ rf' ws', Stmt.sp reg rw b (fun rf ws => inv i rf ws ∧ c.holds rf) rf' ws' →
-            inv (i + 1) rf' ws' :=
+          ∀ rf' ws' A', Stmt.sp reg rw b
+              (fun rf ws A => inv i rf ws A ∧ c.holds rf) rf' ws' A' →
+            inv (i + 1) rf' ws' A' :=
         hvcs.tail.head
-      have hExhausted : ∀ rf ws, inv fuel rf ws → ¬ c.holds rf := hvcs.tail.tail.head
+      have hExhausted : ∀ rf ws A, inv fuel rf ws A → ¬ c.holds rf := hvcs.tail.tail.head
       have hBodyVcs := hvcs.tail.tail.tail
       -- Code containment
       have hlenAll : 4 * ((b.flatten (base + 4)
@@ -423,8 +428,8 @@ theorem Stmt.sound (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
       have hheader : ∀ (r : Reach),
           cpsBranchWithin 1 base cr (asrtM reg rw r)
             (base + BitVec.ofNat 64 (4 * (b.size + 2)))
-              (asrtM reg rw fun rf ws => r rf ws ∧ ¬ c.holds rf)
-            (base + 4) (asrtM reg rw fun rf ws => r rf ws ∧ c.holds rf) := by
+              (asrtM reg rw fun rf ws A => r rf ws A ∧ ¬ c.holds rf)
+            (base + 4) (asrtM reg rw fun rf ws A => r rf ws A ∧ c.holds rf) := by
         intro r
         have hbr := branch_spec_asrt c.neg (Stmt.brOfs (b.size + 2)) rw r base
           (by rw [Cond.wf_neg]; exact hwf)
@@ -432,38 +437,38 @@ theorem Stmt.sound (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
         have hbr' := cpsBranchWithin_frameR (bytesRegion reg.base reg.bytes)
           (bytesRegion_pcFree _ _) (cpsBranchWithin_extend_code hcode_br hbr)
         refine cpsBranchWithin_weaken (fun _ hp => hp) ?_ ?_ hbr'
-        · exact asrtM_mono (fun rf ws hh =>
+        · exact asrtM_mono (fun rf ws A hh =>
             ⟨hh.1, (Cond.holds_neg c rf).mp hh.2⟩)
-        · exact asrtM_mono (fun rf ws hh =>
+        · exact asrtM_mono (fun rf ws A hh =>
             ⟨hh.1, Decidable.of_not_not
               (fun hcc => hh.2 ((Cond.holds_neg c rf).mpr hcc))⟩)
       -- Body + back-jump triple for each iteration index
       have hbodyStep : ∀ i, i < fuel →
           cpsTripleWithin (b.steps + 1) (base + 4) base cr
-            (asrtM reg rw fun rf ws => inv i rf ws ∧ c.holds rf)
-            (asrtM reg rw fun rf ws => inv (i + 1) rf ws) := by
+            (asrtM reg rw fun rf ws A => inv i rf ws A ∧ c.holds rf)
+            (asrtM reg rw fun rf ws A => inv (i + 1) rf ws A) := by
         intro i hi
         have hb := ihb (base + 4) (pfx ++ lbl ++ ".body.")
-          (fun rf ws => inv i rf ws ∧ c.holds rf) (by simpa [Stmt.callFree] using hleaf)
+          (fun rf ws A => inv i rf ws A ∧ c.holds rf) (by simpa [Stmt.callFree] using hleaf)
           hOB (by omega) hcode_b
-          (Stmt.vcs_antitone reg rw b _ (fun rf ws hr => ⟨i, hi, hr.1, hr.2⟩) hBodyVcs)
+          (Stmt.vcs_antitone reg rw b _ (fun rf ws A hr => ⟨i, hi, hr.1, hr.2⟩) hBodyVcs)
         have hjal := jal0_spec_pcFree (Stmt.jBack (b.size + 1))
           ((base + 4) + BitVec.ofNat 64 (4 * b.size))
-          (pcFree_asrtM reg rw (Stmt.sp reg rw b fun rf ws => inv i rf ws ∧ c.holds rf))
+          (pcFree_asrtM reg rw (Stmt.sp reg rw b fun rf ws A => inv i rf ws A ∧ c.holds rf))
         rw [hbodyEnd, add_jBack base (b.size + 1) (by omega) hofsBack] at hjal
         rw [← hbodyEnd] at hjal
         have hjal' := cpsTripleWithin_extend_code hcode_jal hjal
         have hseq := cpsTripleWithin_seq_same_cr hb hjal'
         exact cpsTripleWithin_weaken (fun _ hp => hp)
-          (asrtM_mono (fun rf ws hsp => hInvStep i hi rf ws hsp)) hseq
+          (asrtM_mono (fun rf ws A hsp => hInvStep i hi rf ws A hsp)) hseq
       -- The loop certificate, by downward recursion on the remaining fuel
       have hcert : ∀ fuel' start, start + fuel' = fuel →
           WP.loopNatCert 1 (b.steps + 1) 1 base (base + 4)
             (base + BitVec.ofNat 64 (4 * (b.size + 2))) cr
-            (fun i => asrtM reg rw fun rf ws => inv i rf ws)
-            (fun i => asrtM reg rw fun rf ws => inv i rf ws ∧ c.holds rf)
-            (fun i => asrtM reg rw fun rf ws => inv i rf ws ∧ ¬ c.holds rf)
-            (asrtM reg rw fun rf ws => (∃ i, i ≤ fuel ∧ inv i rf ws) ∧ ¬ c.holds rf)
+            (fun i => asrtM reg rw fun rf ws A => inv i rf ws A)
+            (fun i => asrtM reg rw fun rf ws A => inv i rf ws A ∧ c.holds rf)
+            (fun i => asrtM reg rw fun rf ws A => inv i rf ws A ∧ ¬ c.holds rf)
+            (asrtM reg rw fun rf ws A => (∃ i, i ≤ fuel ∧ inv i rf ws A) ∧ ¬ c.holds rf)
             start fuel' := by
         intro fuel'
         induction fuel' with
@@ -473,27 +478,27 @@ theorem Stmt.sound (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
             have hexit : cpsTripleWithin 0
                 (base + BitVec.ofNat 64 (4 * (b.size + 2)))
                 (base + BitVec.ofNat 64 (4 * (b.size + 2))) cr
-                (asrtM reg rw fun rf ws => inv start rf ws ∧ ¬ c.holds rf)
-                (asrtM reg rw fun rf ws => (∃ i, i ≤ fuel ∧ inv i rf ws) ∧ ¬ c.holds rf) :=
-              cpsTripleWithin_entails (asrtM_mono (fun rf ws hh =>
+                (asrtM reg rw fun rf ws A => inv start rf ws A ∧ ¬ c.holds rf)
+                (asrtM reg rw fun rf ws A => (∃ i, i ≤ fuel ∧ inv i rf ws A) ∧ ¬ c.holds rf) :=
+              cpsTripleWithin_entails (asrtM_mono (fun rf ws A hh =>
                 ⟨⟨start, by omega, hh.1⟩, hh.2⟩))
             have hsf : start = fuel := by omega
             have hdead : cpsTripleWithin 0 (base + 4)
                 (base + BitVec.ofNat 64 (4 * (b.size + 2))) cr
-                (asrtM reg rw fun rf ws => inv start rf ws ∧ c.holds rf)
-                (asrtM reg rw fun rf ws => (∃ i, i ≤ fuel ∧ inv i rf ws) ∧ ¬ c.holds rf) :=
-              cpsTripleWithin_unreachable (asrtM_unsat (fun rf ws hh =>
-                hExhausted rf ws (hsf ▸ hh.1) hh.2))
+                (asrtM reg rw fun rf ws A => inv start rf ws A ∧ c.holds rf)
+                (asrtM reg rw fun rf ws A => (∃ i, i ≤ fuel ∧ inv i rf ws A) ∧ ¬ c.holds rf) :=
+              cpsTripleWithin_unreachable (asrtM_unsat (fun rf ws A hh =>
+                hExhausted rf ws A (hsf ▸ hh.1) hh.2))
             exact cpsBranchWithin_merge_same_cr
-              (cpsBranchWithin_swap (hheader (fun rf ws => inv start rf ws))) hdead hexit
+              (cpsBranchWithin_swap (hheader (fun rf ws A => inv start rf ws A))) hdead hexit
         | succ fuel' ih =>
             intro start hstart
-            refine ⟨cpsBranchWithin_swap (hheader (fun rf ws => inv start rf ws)),
+            refine ⟨cpsBranchWithin_swap (hheader (fun rf ws A => inv start rf ws A)),
               hbodyStep start (by omega), ?_, ih (start + 1) (by omega)⟩
-            exact asrtM_mono (fun rf ws hh => ⟨⟨start, by omega, hh.1⟩, hh.2⟩)
+            exact asrtM_mono (fun rf ws A hh => ⟨⟨start, by omega, hh.1⟩, hh.2⟩)
       have hsound := WP.loopNatCert_sound (hcert fuel 0 (by omega))
       exact cpsTripleWithin_weaken
-        (asrtM_mono (fun rf ws hr => hInvInit rf ws hr))
+        (asrtM_mono (fun rf ws A hr => hInvInit rf ws A hr))
         (fun _ hp => hp)
         hsound
   | call lbl f =>

--- a/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
@@ -32,12 +32,12 @@ theorem pcFree_asrtR (reg : Region) (rw : RwRegion) (reach : Reach) :
   pcFree_sepConj (pcFree_asrtM _ _ _) pcFree_regOwn
 
 theorem asrtR_mono {reg : Region} {rw : RwRegion} {r₁ r₂ : Reach}
-    (h : ∀ rf ws, r₁ rf ws → r₂ rf ws) :
+    (h : ∀ rf ws A, r₁ rf ws A → r₂ rf ws A) :
     ∀ hp, asrtR reg rw r₁ hp → asrtR reg rw r₂ hp :=
   fun hp => sepConj_mono_left (asrtM_mono h) hp
 
 theorem asrtR_unsat {reg : Region} {rw : RwRegion} {r : Reach}
-    (h : ∀ rf ws, r rf ws → False) :
+    (h : ∀ rf ws A, r rf ws A → False) :
     ∀ hp, asrtR reg rw r hp → False := by
   rintro hp ⟨h1, h2, -, -, hM, -⟩
   exact asrtM_unsat h h1 hM
@@ -176,45 +176,45 @@ theorem Stmt.soundR (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
         (cpsBranchWithin_frameR (bytesRegion reg.base reg.bytes)
           (bytesRegion_pcFree _ _) (cpsBranchWithin_extend_code hcode_br hbr))
       have ht := iht (base + 4) (pfx ++ lbl ++ ".t.")
-        (fun rf ws => reach rf ws ∧ c.holds rf) hOT (by omega) hcode_t
+        (fun rf ws A => reach rf ws A ∧ c.holds rf) hOT (by omega) hcode_t
         hcallees_t hcalls_t hvcs.left
       rw [haddr1] at ht
       have hjal := jal0_spec_pcFree (Stmt.jFwd (e.size + 1))
         (base + BitVec.ofNat 64 (4 * (t.size + 1)))
-        (pcFree_asrtR reg rw (Stmt.sp reg rw t fun rf ws => reach rf ws ∧ c.holds rf))
+        (pcFree_asrtR reg rw (Stmt.sp reg rw t fun rf ws A => reach rf ws A ∧ c.holds rf))
       rw [signExtend21_jFwd hofsJ, haddr2] at hjal
       have hjal' := cpsTripleWithin_extend_code hcode_jal hjal
       have htj := cpsTripleWithin_seq_same_cr ht hjal'
       have he := ihe (base + BitVec.ofNat 64 (4 * (t.size + 2))) (pfx ++ lbl ++ ".e.")
-        (fun rf ws => reach rf ws ∧ ¬ c.holds rf) hOE (by omega) hcode_e
+        (fun rf ws A => reach rf ws A ∧ ¬ c.holds rf) hOE (by omega) hcode_e
         hcallees_e hcalls_e hvcs.right
       rw [haddr3] at he
       have hbr'' : cpsBranchWithin 1 base cr (asrtR reg rw reach)
           (base + BitVec.ofNat 64 (4 * (t.size + 2)))
-            (asrtR reg rw fun rf ws => reach rf ws ∧ ¬ c.holds rf)
-          (base + 4) (asrtR reg rw fun rf ws => reach rf ws ∧ c.holds rf) := by
+            (asrtR reg rw fun rf ws A => reach rf ws A ∧ ¬ c.holds rf)
+          (base + 4) (asrtR reg rw fun rf ws A => reach rf ws A ∧ c.holds rf) := by
         refine cpsBranchWithin_weaken (fun _ hp => hp) ?_ ?_ hbr'
-        · exact asrtR_mono (fun rf ws hh =>
+        · exact asrtR_mono (fun rf ws A hh =>
             ⟨hh.1, (Cond.holds_neg c rf).mp hh.2⟩)
-        · exact asrtR_mono (fun rf ws hh =>
+        · exact asrtR_mono (fun rf ws A hh =>
             ⟨hh.1, Decidable.of_not_not
               (fun hcc => hh.2 ((Cond.holds_neg c rf).mpr hcc))⟩)
       have harmE : cpsTripleWithin (max (t.steps + 1) e.steps)
           (base + BitVec.ofNat 64 (4 * (t.size + 2)))
           (base + BitVec.ofNat 64 (4 * (t.size + e.size + 2))) cr
-          (asrtR reg rw fun rf ws => reach rf ws ∧ ¬ c.holds rf)
+          (asrtR reg rw fun rf ws A => reach rf ws A ∧ ¬ c.holds rf)
           (asrtR reg rw (Stmt.sp reg rw (.ite lbl c t e) reach)) := by
         refine cpsTripleWithin_mono_nSteps (Nat.le_max_right _ _)
           (cpsTripleWithin_weaken (fun _ hp => hp) ?_ he)
-        exact asrtR_mono (fun rf ws hsp => Or.inr hsp)
+        exact asrtR_mono (fun rf ws A hsp => Or.inr hsp)
       have harmT : cpsTripleWithin (max (t.steps + 1) e.steps)
           (base + 4)
           (base + BitVec.ofNat 64 (4 * (t.size + e.size + 2))) cr
-          (asrtR reg rw fun rf ws => reach rf ws ∧ c.holds rf)
+          (asrtR reg rw fun rf ws A => reach rf ws A ∧ c.holds rf)
           (asrtR reg rw (Stmt.sp reg rw (.ite lbl c t e) reach)) := by
         refine cpsTripleWithin_mono_nSteps (Nat.le_max_left _ _)
           (cpsTripleWithin_weaken (fun _ hp => hp) ?_ htj)
-        exact asrtR_mono (fun rf ws hsp => Or.inl hsp)
+        exact asrtR_mono (fun rf ws A hsp => Or.inl hsp)
       exact cpsBranchWithin_merge_same_cr hbr'' harmE harmT
   | «when» lbl c b ihb =>
       simp only [Stmt.offsetsOk, Bool.and_eq_true, decide_eq_true_eq] at hofs
@@ -239,39 +239,40 @@ theorem Stmt.soundR (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
         (cpsBranchWithin_frameR (bytesRegion reg.base reg.bytes)
           (bytesRegion_pcFree _ _) (cpsBranchWithin_extend_code hcode_br hbr))
       have hb := ihb (base + 4) (pfx ++ lbl ++ ".")
-        (fun rf ws => reach rf ws ∧ c.holds rf)
+        (fun rf ws A => reach rf ws A ∧ c.holds rf)
         hOB (by omega) hcode_b hcallees hcalls hvcs
       rw [show (base + 4) + BitVec.ofNat 64 (4 * b.size)
           = base + BitVec.ofNat 64 (4 * (b.size + 1)) from by bv_omega] at hb
       have hskip : cpsTripleWithin b.steps
           (base + BitVec.ofNat 64 (4 * (b.size + 1)))
           (base + BitVec.ofNat 64 (4 * (b.size + 1))) cr
-          (asrtR reg rw fun rf ws => reach rf ws ∧ c.neg.holds rf)
+          (asrtR reg rw fun rf ws A => reach rf ws A ∧ c.neg.holds rf)
           (asrtR reg rw (Stmt.sp reg rw (.when lbl c b) reach)) := by
         apply cpsTripleWithin_mono_nSteps (Nat.zero_le _)
         apply cpsTripleWithin_entails
-        exact asrtR_mono (fun rf ws hh =>
+        exact asrtR_mono (fun rf ws A hh =>
           Or.inr ⟨hh.1, (Cond.holds_neg c rf).mp hh.2⟩)
       have hbody : cpsTripleWithin b.steps (base + 4)
           (base + BitVec.ofNat 64 (4 * (b.size + 1))) cr
-          (asrtR reg rw fun rf ws => reach rf ws ∧ ¬ c.neg.holds rf)
+          (asrtR reg rw fun rf ws A => reach rf ws A ∧ ¬ c.neg.holds rf)
           (asrtR reg rw (Stmt.sp reg rw (.when lbl c b) reach)) := by
         refine cpsTripleWithin_weaken ?_ ?_ hb
-        · exact asrtR_mono (fun rf ws hh =>
+        · exact asrtR_mono (fun rf ws A hh =>
             ⟨hh.1, Decidable.of_not_not
               (fun hcc => hh.2 ((Cond.holds_neg c rf).mpr hcc))⟩)
-        · exact asrtR_mono (fun rf ws hsp => Or.inl hsp)
+        · exact asrtR_mono (fun rf ws A hsp => Or.inl hsp)
       exact cpsBranchWithin_merge_same_cr hbr' hskip hbody
   | «while» lbl c fuel inv b ihb =>
       simp only [Stmt.offsetsOk, Bool.and_eq_true, decide_eq_true_eq] at hofs
       obtain ⟨⟨⟨hwf, hofsHdr⟩, hofsBack⟩, hOB⟩ := hofs
       simp only [Stmt.size] at hsz
-      have hInvInit : ∀ rf ws, reach rf ws → inv 0 rf ws := hvcs.head
+      have hInvInit : ∀ rf ws A, reach rf ws A → inv 0 rf ws A := hvcs.head
       have hInvStep : ∀ i, i < fuel →
-          ∀ rf' ws', Stmt.sp reg rw b (fun rf ws => inv i rf ws ∧ c.holds rf) rf' ws' →
-            inv (i + 1) rf' ws' :=
+          ∀ rf' ws' A', Stmt.sp reg rw b
+              (fun rf ws A => inv i rf ws A ∧ c.holds rf) rf' ws' A' →
+            inv (i + 1) rf' ws' A' :=
         hvcs.tail.head
-      have hExhausted : ∀ rf ws, inv fuel rf ws → ¬ c.holds rf := hvcs.tail.tail.head
+      have hExhausted : ∀ rf ws A, inv fuel rf ws A → ¬ c.holds rf := hvcs.tail.tail.head
       have hBodyVcs := hvcs.tail.tail.tail
       have hlenAll : 4 * ((b.flatten (base + 4)
           ++ [Instr.JAL Reg.x0 (Stmt.jBack (b.size + 1))]).length + 1) ≤ 2 ^ 64 := by
@@ -307,8 +308,8 @@ theorem Stmt.soundR (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
       have hheader : ∀ (r : Reach),
           cpsBranchWithin 1 base cr (asrtR reg rw r)
             (base + BitVec.ofNat 64 (4 * (b.size + 2)))
-              (asrtR reg rw fun rf ws => r rf ws ∧ ¬ c.holds rf)
-            (base + 4) (asrtR reg rw fun rf ws => r rf ws ∧ c.holds rf) := by
+              (asrtR reg rw fun rf ws A => r rf ws A ∧ ¬ c.holds rf)
+            (base + 4) (asrtR reg rw fun rf ws A => r rf ws A ∧ c.holds rf) := by
         intro r
         have hbr := branch_spec_asrt c.neg (Stmt.brOfs (b.size + 2)) rw r base
           (by rw [Cond.wf_neg]; exact hwf)
@@ -317,36 +318,36 @@ theorem Stmt.soundR (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
           (cpsBranchWithin_frameR (bytesRegion reg.base reg.bytes)
             (bytesRegion_pcFree _ _) (cpsBranchWithin_extend_code hcode_br hbr))
         refine cpsBranchWithin_weaken (fun _ hp => hp) ?_ ?_ hbr'
-        · exact asrtR_mono (fun rf ws hh =>
+        · exact asrtR_mono (fun rf ws A hh =>
             ⟨hh.1, (Cond.holds_neg c rf).mp hh.2⟩)
-        · exact asrtR_mono (fun rf ws hh =>
+        · exact asrtR_mono (fun rf ws A hh =>
             ⟨hh.1, Decidable.of_not_not
               (fun hcc => hh.2 ((Cond.holds_neg c rf).mpr hcc))⟩)
       have hbodyStep : ∀ i, i < fuel →
           cpsTripleWithin (b.steps + 1) (base + 4) base cr
-            (asrtR reg rw fun rf ws => inv i rf ws ∧ c.holds rf)
-            (asrtR reg rw fun rf ws => inv (i + 1) rf ws) := by
+            (asrtR reg rw fun rf ws A => inv i rf ws A ∧ c.holds rf)
+            (asrtR reg rw fun rf ws A => inv (i + 1) rf ws A) := by
         intro i hi
         have hb := ihb (base + 4) (pfx ++ lbl ++ ".body.")
-          (fun rf ws => inv i rf ws ∧ c.holds rf)
+          (fun rf ws A => inv i rf ws A ∧ c.holds rf)
           hOB (by omega) hcode_b hcallees hcalls
-          (Stmt.vcs_antitone reg rw b _ (fun rf ws hr => ⟨i, hi, hr.1, hr.2⟩) hBodyVcs)
+          (Stmt.vcs_antitone reg rw b _ (fun rf ws A hr => ⟨i, hi, hr.1, hr.2⟩) hBodyVcs)
         have hjal := jal0_spec_pcFree (Stmt.jBack (b.size + 1))
           ((base + 4) + BitVec.ofNat 64 (4 * b.size))
-          (pcFree_asrtR reg rw (Stmt.sp reg rw b fun rf ws => inv i rf ws ∧ c.holds rf))
+          (pcFree_asrtR reg rw (Stmt.sp reg rw b fun rf ws A => inv i rf ws A ∧ c.holds rf))
         rw [hbodyEnd, add_jBack base (b.size + 1) (by omega) hofsBack] at hjal
         rw [← hbodyEnd] at hjal
         have hjal' := cpsTripleWithin_extend_code hcode_jal hjal
         have hseq := cpsTripleWithin_seq_same_cr hb hjal'
         exact cpsTripleWithin_weaken (fun _ hp => hp)
-          (asrtR_mono (fun rf ws hsp => hInvStep i hi rf ws hsp)) hseq
+          (asrtR_mono (fun rf ws A hsp => hInvStep i hi rf ws A hsp)) hseq
       have hcert : ∀ fuel' start, start + fuel' = fuel →
           WP.loopNatCert 1 (b.steps + 1) 1 base (base + 4)
             (base + BitVec.ofNat 64 (4 * (b.size + 2))) cr
-            (fun i => asrtR reg rw fun rf ws => inv i rf ws)
-            (fun i => asrtR reg rw fun rf ws => inv i rf ws ∧ c.holds rf)
-            (fun i => asrtR reg rw fun rf ws => inv i rf ws ∧ ¬ c.holds rf)
-            (asrtR reg rw fun rf ws => (∃ i, i ≤ fuel ∧ inv i rf ws) ∧ ¬ c.holds rf)
+            (fun i => asrtR reg rw fun rf ws A => inv i rf ws A)
+            (fun i => asrtR reg rw fun rf ws A => inv i rf ws A ∧ c.holds rf)
+            (fun i => asrtR reg rw fun rf ws A => inv i rf ws A ∧ ¬ c.holds rf)
+            (asrtR reg rw fun rf ws A => (∃ i, i ≤ fuel ∧ inv i rf ws A) ∧ ¬ c.holds rf)
             start fuel' := by
         intro fuel'
         induction fuel' with
@@ -356,33 +357,33 @@ theorem Stmt.soundR (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
             have hexit : cpsTripleWithin 0
                 (base + BitVec.ofNat 64 (4 * (b.size + 2)))
                 (base + BitVec.ofNat 64 (4 * (b.size + 2))) cr
-                (asrtR reg rw fun rf ws => inv start rf ws ∧ ¬ c.holds rf)
-                (asrtR reg rw fun rf ws => (∃ i, i ≤ fuel ∧ inv i rf ws) ∧ ¬ c.holds rf) :=
-              cpsTripleWithin_entails (asrtR_mono (fun rf ws hh =>
+                (asrtR reg rw fun rf ws A => inv start rf ws A ∧ ¬ c.holds rf)
+                (asrtR reg rw fun rf ws A => (∃ i, i ≤ fuel ∧ inv i rf ws A) ∧ ¬ c.holds rf) :=
+              cpsTripleWithin_entails (asrtR_mono (fun rf ws A hh =>
                 ⟨⟨start, by omega, hh.1⟩, hh.2⟩))
             have hsf : start = fuel := by omega
             have hdead : cpsTripleWithin 0 (base + 4)
                 (base + BitVec.ofNat 64 (4 * (b.size + 2))) cr
-                (asrtR reg rw fun rf ws => inv start rf ws ∧ c.holds rf)
-                (asrtR reg rw fun rf ws => (∃ i, i ≤ fuel ∧ inv i rf ws) ∧ ¬ c.holds rf) :=
-              cpsTripleWithin_unreachable (asrtR_unsat (fun rf ws hh =>
-                hExhausted rf ws (hsf ▸ hh.1) hh.2))
+                (asrtR reg rw fun rf ws A => inv start rf ws A ∧ c.holds rf)
+                (asrtR reg rw fun rf ws A => (∃ i, i ≤ fuel ∧ inv i rf ws A) ∧ ¬ c.holds rf) :=
+              cpsTripleWithin_unreachable (asrtR_unsat (fun rf ws A hh =>
+                hExhausted rf ws A (hsf ▸ hh.1) hh.2))
             exact cpsBranchWithin_merge_same_cr
-              (cpsBranchWithin_swap (hheader (fun rf ws => inv start rf ws))) hdead hexit
+              (cpsBranchWithin_swap (hheader (fun rf ws A => inv start rf ws A))) hdead hexit
         | succ fuel' ih =>
             intro start hstart
-            refine ⟨cpsBranchWithin_swap (hheader (fun rf ws => inv start rf ws)),
+            refine ⟨cpsBranchWithin_swap (hheader (fun rf ws A => inv start rf ws A)),
               hbodyStep start (by omega), ?_, ih (start + 1) (by omega)⟩
-            exact asrtR_mono (fun rf ws hh => ⟨⟨start, by omega, hh.1⟩, hh.2⟩)
+            exact asrtR_mono (fun rf ws A hh => ⟨⟨start, by omega, hh.1⟩, hh.2⟩)
       have hsound := WP.loopNatCert_sound (hcert fuel 0 (by omega))
       exact cpsTripleWithin_weaken
-        (asrtR_mono (fun rf ws hr => hInvInit rf ws hr))
+        (asrtR_mono (fun rf ws A hr => hInvInit rf ws A hr))
         (fun _ hp => hp)
         hsound
   | call lbl f =>
       obtain ⟨hoffset, halign, hnotself⟩ := hcalls
       obtain ⟨hcalleeCode, hregeq, hrweq⟩ := hcallees
-      have hpreVC : ∀ rf ws, reach rf ws → f.pre rf ws := hvcs _ (List.mem_singleton_self _)
+      have hpreVC : ∀ rf ws A, reach rf ws A → f.pre rf ws A := hvcs _ (List.mem_singleton_self _)
       -- callee triple, retargeted at the aligned return address
       have hret' : cpsTripleWithin f.nSteps f.entry ((base + 4) &&& ~~~(1 : Word))
           f.code
@@ -438,7 +439,7 @@ theorem Stmt.soundR (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
       have hfinal : cpsTripleWithin (1 + f.nSteps) base (base + 4) cr
           (asrtR reg rw reach) (asrtR reg rw (Stmt.sp reg rw (.call lbl f) reach)) := by
         refine cpsTripleWithin_weaken
-          (sepConj_mono_left (asrtM_mono (fun rf ws hr => hpreVC rf ws hr)))
+          (sepConj_mono_left (asrtM_mono (fun rf ws A hr => hpreVC rf ws A hr)))
           (fun _ hp => hp)
           (cpsTripleWithin_regOwn_right_pre hcall)
       simp only [Stmt.steps, Stmt.size, Nat.mul_one]

--- a/EvmAsm/Rv64/SAsm/Vc.lean
+++ b/EvmAsm/Rv64/SAsm/Vc.lean
@@ -85,21 +85,21 @@ namespace Stmt
     callee owns the whole exposed file and the regions; ghost data relates
     them). -/
 def sp (reg : Region) (rw : RwRegion) : Stmt → Reach → Reach
-  | block _ is, reach => fun rf' ws' => ∃ rf ws, ws.length = rw.len
-      ∧ reach rf ws
+  | block _ is, reach => fun rf' ws' A' => ∃ rf ws, ws.length = rw.len
+      ∧ reach rf ws A'
       ∧ rf' = (execBlock reg rw.base rf ws is).1
       ∧ ws' = (execBlock reg rw.base rf ws is).2
   | seq a b, reach => sp reg rw b (sp reg rw a reach)
-  | ite _ c t e, reach => fun rf' ws' =>
-      sp reg rw t (fun rf ws => reach rf ws ∧ c.holds rf) rf' ws' ∨
-      sp reg rw e (fun rf ws => reach rf ws ∧ ¬ c.holds rf) rf' ws'
-  | when _ c b, reach => fun rf' ws' =>
-      sp reg rw b (fun rf ws => reach rf ws ∧ c.holds rf) rf' ws'
-        ∨ (reach rf' ws' ∧ ¬ c.holds rf')
-  | assert _ P, reach => fun rf ws => reach rf ws ∧ P rf ws
+  | ite _ c t e, reach => fun rf' ws' A' =>
+      sp reg rw t (fun rf ws A => reach rf ws A ∧ c.holds rf) rf' ws' A' ∨
+      sp reg rw e (fun rf ws A => reach rf ws A ∧ ¬ c.holds rf) rf' ws' A'
+  | when _ c b, reach => fun rf' ws' A' =>
+      sp reg rw b (fun rf ws A => reach rf ws A ∧ c.holds rf) rf' ws' A'
+        ∨ (reach rf' ws' A' ∧ ¬ c.holds rf')
+  | assert _ P, reach => fun rf ws A => reach rf ws A ∧ P rf ws A
   | «while» _ c fuel inv _, _ =>
-      fun rf ws => (∃ i, i ≤ fuel ∧ inv i rf ws) ∧ ¬ c.holds rf
-  | call _ f, _ => fun rf ws => f.post rf ws
+      fun rf ws A => (∃ i, i ≤ fuel ∧ inv i rf ws A) ∧ ¬ c.holds rf
+  | call _ f, _ => fun rf ws A => f.post rf ws A
 
 /-- Labeled verification conditions of a statement, given the reachable set
     at its entry.  `pfx` is the path prefix for labels. -/
@@ -107,28 +107,28 @@ def vcs (reg : Region) (rw : RwRegion) : Stmt → String → Reach → List VC
   | block lbl is, pfx, reach =>
       ⟨pfx ++ lbl ++ ".ok", blockOk is = true⟩ ::
       (if hasLoad is then
-        [⟨pfx ++ lbl ++ ".mem", ∀ rf ws, ws.length = rw.len → reach rf ws →
+        [⟨pfx ++ lbl ++ ".mem", ∀ rf ws A, ws.length = rw.len → reach rf ws A →
             blockVCs reg rw.base rf ws is⟩]
       else [])
   | seq a b, pfx, reach =>
       vcs reg rw a pfx reach ++ vcs reg rw b pfx (sp reg rw a reach)
   | ite lbl c t e, pfx, reach =>
-      vcs reg rw t (pfx ++ lbl ++ ".t.") (fun rf ws => reach rf ws ∧ c.holds rf) ++
-      vcs reg rw e (pfx ++ lbl ++ ".e.") (fun rf ws => reach rf ws ∧ ¬ c.holds rf)
+      vcs reg rw t (pfx ++ lbl ++ ".t.") (fun rf ws A => reach rf ws A ∧ c.holds rf) ++
+      vcs reg rw e (pfx ++ lbl ++ ".e.") (fun rf ws A => reach rf ws A ∧ ¬ c.holds rf)
   | when lbl c b, pfx, reach =>
-      vcs reg rw b (pfx ++ lbl ++ ".") (fun rf ws => reach rf ws ∧ c.holds rf)
+      vcs reg rw b (pfx ++ lbl ++ ".") (fun rf ws A => reach rf ws A ∧ c.holds rf)
   | assert lbl P, pfx, reach =>
-      [⟨pfx ++ lbl, ∀ rf ws, reach rf ws → P rf ws⟩]
+      [⟨pfx ++ lbl, ∀ rf ws A, reach rf ws A → P rf ws A⟩]
   | «while» lbl c fuel inv b, pfx, reach =>
-      ⟨pfx ++ lbl ++ ".inv_init", ∀ rf ws, reach rf ws → inv 0 rf ws⟩ ::
+      ⟨pfx ++ lbl ++ ".inv_init", ∀ rf ws A, reach rf ws A → inv 0 rf ws A⟩ ::
       ⟨pfx ++ lbl ++ ".inv_step", ∀ i, i < fuel →
-          ∀ rf' ws', sp reg rw b (fun rf ws => inv i rf ws ∧ c.holds rf) rf' ws' →
-            inv (i + 1) rf' ws'⟩ ::
-      ⟨pfx ++ lbl ++ ".exhausted", ∀ rf ws, inv fuel rf ws → ¬ c.holds rf⟩ ::
+          ∀ rf' ws' A', sp reg rw b (fun rf ws A => inv i rf ws A ∧ c.holds rf) rf' ws' A' →
+            inv (i + 1) rf' ws' A'⟩ ::
+      ⟨pfx ++ lbl ++ ".exhausted", ∀ rf ws A, inv fuel rf ws A → ¬ c.holds rf⟩ ::
       vcs reg rw b (pfx ++ lbl ++ ".body.")
-        (fun rf ws => ∃ i, i < fuel ∧ inv i rf ws ∧ c.holds rf)
+        (fun rf ws A => ∃ i, i < fuel ∧ inv i rf ws A ∧ c.holds rf)
   | call lbl f, pfx, reach =>
-      [⟨pfx ++ lbl ++ ".pre", ∀ rf ws, reach rf ws → f.pre rf ws⟩]
+      [⟨pfx ++ lbl ++ ".pre", ∀ rf ws A, reach rf ws A → f.pre rf ws A⟩]
 
 /-- Exact step bound of a statement (docs/sasm-design.md §3.5; the loop bound
     is `WP.loopBound`). -/
@@ -143,35 +143,35 @@ def steps : Stmt → Nat
 
 /-- `sp` is monotone in the reachable set. -/
 theorem sp_mono (reg : Region) (rw : RwRegion) (s : Stmt) {r₁ r₂ : Reach}
-    (h : ∀ rf ws, r₁ rf ws → r₂ rf ws) :
-    ∀ rf ws, sp reg rw s r₁ rf ws → sp reg rw s r₂ rf ws := by
+    (h : ∀ rf ws A, r₁ rf ws A → r₂ rf ws A) :
+    ∀ rf ws A, sp reg rw s r₁ rf ws A → sp reg rw s r₂ rf ws A := by
   induction s generalizing r₁ r₂ with
   | block lbl is =>
-      rintro rf ws ⟨rf₀, ws₀, hlen, hr, hrf, hws⟩
-      exact ⟨rf₀, ws₀, hlen, h rf₀ ws₀ hr, hrf, hws⟩
+      rintro rf ws A ⟨rf₀, ws₀, hlen, hr, hrf, hws⟩
+      exact ⟨rf₀, ws₀, hlen, h rf₀ ws₀ A hr, hrf, hws⟩
   | seq a b iha ihb =>
-      exact fun rf ws => ihb (iha h) rf ws
+      exact fun rf ws A => ihb (iha h) rf ws A
   | ite lbl c t e iht ihe =>
-      rintro rf ws (ht | he)
-      · exact Or.inl (iht (fun rf ws hr => ⟨h rf ws hr.1, hr.2⟩) rf ws ht)
-      · exact Or.inr (ihe (fun rf ws hr => ⟨h rf ws hr.1, hr.2⟩) rf ws he)
+      rintro rf ws A (ht | he)
+      · exact Or.inl (iht (fun rf ws A hr => ⟨h rf ws A hr.1, hr.2⟩) rf ws A ht)
+      · exact Or.inr (ihe (fun rf ws A hr => ⟨h rf ws A hr.1, hr.2⟩) rf ws A he)
   | «when» lbl c b ihb =>
-      rintro rf ws (hb | hskip)
-      · exact Or.inl (ihb (fun rf ws hr => ⟨h rf ws hr.1, hr.2⟩) rf ws hb)
-      · exact Or.inr ⟨h rf ws hskip.1, hskip.2⟩
+      rintro rf ws A (hb | hskip)
+      · exact Or.inl (ihb (fun rf ws A hr => ⟨h rf ws A hr.1, hr.2⟩) rf ws A hb)
+      · exact Or.inr ⟨h rf ws A hskip.1, hskip.2⟩
   | assert lbl P =>
-      exact fun rf ws hr => ⟨h rf ws hr.1, hr.2⟩
+      exact fun rf ws A hr => ⟨h rf ws A hr.1, hr.2⟩
   | «while» lbl c fuel inv b ihb =>
-      exact fun rf ws hr => hr
+      exact fun rf ws A hr => hr
   | call lbl f =>
-      exact fun rf ws hr => hr
+      exact fun rf ws A hr => hr
 
 /-- `vcs` is antitone in the reachable set: obligations proven for a larger
     reachable set cover any smaller one.  Used to specialize loop-body VCs
     (generated at the union over iterations) to a specific iteration. -/
 theorem vcs_antitone (reg : Region) (rw : RwRegion) (s : Stmt) (pfx : String)
     {r₁ r₂ : Reach}
-    (h : ∀ rf ws, r₁ rf ws → r₂ rf ws) (hvcs : VCs.Hold (vcs reg rw s pfx r₂)) :
+    (h : ∀ rf ws A, r₁ rf ws A → r₂ rf ws A) (hvcs : VCs.Hold (vcs reg rw s pfx r₂)) :
     VCs.Hold (vcs reg rw s pfx r₁) := by
   induction s generalizing r₁ r₂ pfx with
   | block lbl is =>
@@ -184,12 +184,12 @@ theorem vcs_antitone (reg : Region) (rw : RwRegion) (s : Stmt) (pfx : String)
           have hvcs2 := hvcs.tail
           rw [show vcs reg rw (.block lbl is) pfx r₂
               = ⟨pfx ++ lbl ++ ".ok", blockOk is = true⟩ ::
-                [⟨pfx ++ lbl ++ ".mem", ∀ rf ws, ws.length = rw.len → r₂ rf ws →
+                [⟨pfx ++ lbl ++ ".mem", ∀ rf ws A, ws.length = rw.len → r₂ rf ws A →
                     blockVCs reg rw.base rf ws is⟩]
             from by simp [vcs, hl]] at hvcs
           simp only [List.mem_singleton] at hvc
           subst hvc
-          exact fun rf ws hlen hr => hvcs.tail.head rf ws hlen (h rf ws hr)
+          exact fun rf ws A hlen hr => hvcs.tail.head rf ws A hlen (h rf ws A hr)
         · rw [if_neg hl] at hvc
           exact absurd hvc (List.not_mem_nil)
   | seq a b iha ihb =>
@@ -202,21 +202,21 @@ theorem vcs_antitone (reg : Region) (rw : RwRegion) (s : Stmt) (pfx : String)
       intro vc hvc
       simp only [vcs, List.mem_append] at hvc
       rcases hvc with hvc | hvc
-      · exact iht _ (fun rf ws hr => ⟨h rf ws hr.1, hr.2⟩) hvcs.left vc hvc
-      · exact ihe _ (fun rf ws hr => ⟨h rf ws hr.1, hr.2⟩) hvcs.right vc hvc
+      · exact iht _ (fun rf ws A hr => ⟨h rf ws A hr.1, hr.2⟩) hvcs.left vc hvc
+      · exact ihe _ (fun rf ws A hr => ⟨h rf ws A hr.1, hr.2⟩) hvcs.right vc hvc
   | «when» lbl c b ihb =>
       intro vc hvc
-      exact ihb _ (fun rf ws hr => ⟨h rf ws hr.1, hr.2⟩) hvcs vc hvc
+      exact ihb _ (fun rf ws A hr => ⟨h rf ws A hr.1, hr.2⟩) hvcs vc hvc
   | assert lbl P =>
       intro vc hvc
       simp only [vcs, List.mem_singleton] at hvc
       subst hvc
-      exact fun rf ws hr => hvcs.head rf ws (h rf ws hr)
+      exact fun rf ws A hr => hvcs.head rf ws A (h rf ws A hr)
   | «while» lbl c fuel inv b ihb =>
       intro vc hvc
       simp only [vcs, List.mem_cons] at hvc
       rcases hvc with rfl | rfl | rfl | hvc
-      · exact fun rf ws hr => hvcs.head rf ws (h rf ws hr)
+      · exact fun rf ws A hr => hvcs.head rf ws A (h rf ws A hr)
       · exact hvcs.tail.head
       · exact hvcs.tail.tail.head
       · exact hvcs.tail.tail.tail vc hvc
@@ -224,7 +224,7 @@ theorem vcs_antitone (reg : Region) (rw : RwRegion) (s : Stmt) (pfx : String)
       intro vc hvc
       simp only [vcs, List.mem_singleton] at hvc
       subst hvc
-      exact fun rf ws hr => hvcs.head rf ws (h rf ws hr)
+      exact fun rf ws A hr => hvcs.head rf ws A (h rf ws A hr)
 
 /-- Per call site: the callee's code is contained in `cr` and the callee
     shares the caller's regions.  Stated structurally (rather than as a union

--- a/EvmAsm/Stateless/SSZ/Decode/ActiveForkSAsm.lean
+++ b/EvmAsm/Stateless/SSZ/Decode/ActiveForkSAsm.lean
@@ -51,12 +51,12 @@ def readActiveForkBody : Stmt :=
 def readActiveForkFn (bs : List (BitVec 8)) : Fn where
   name := "readActiveFork"
   region := ⟨0x40000000, bs⟩
-  pre := fun rf _ =>
+  pre := fun rf _ _ =>
     rf.get .x13 = (0x40000012 : Word) + leU32 bs 26 ∧
     26 + (leU32 bs 26).toNat + 4 ≤ bs.length ∧
     18 + (leU32 bs 26).toNat
       + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat + 8 ≤ bs.length
-  post := fun rf _ =>
+  post := fun rf _ _ =>
     rf.get .x12 = leU64 bs (18 + (leU32 bs 26).toNat
       + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat) ∧
     rf.get .x13 = (0x40000012 : Word) + leU32 bs 26
@@ -79,7 +79,7 @@ theorem readActiveForkFn_spec (bs : List (BitVec 8))
   case region =>
     exact ⟨inputRegion_wf bs hlen, RwRegion.empty_wf⟩
   case readActiveFork.offset32.mem =>
-    rintro rf ws hws ⟨hx13, hb1, hb2⟩
+    rintro rf ws A hws ⟨hx13, hb1, hb2⟩
     obtain rfl : ws = [] := List.eq_nil_of_length_eq_zero hws
     simp only [execInstrRF_nil, aluSem, loadSem,
       storeSem, blockVCs, Region.loadOk, RegFile.get_set_self,
@@ -103,7 +103,7 @@ theorem readActiveForkFn_spec (bs : List (BitVec 8))
       | trivial
       | omega
   case readActiveFork.fork64.mem =>
-    rintro rf ws hws ⟨rf₀, ws₀, hws₀, ⟨hx13, hb1, hb2⟩, rfl, rfl⟩
+    rintro rf ws A hws ⟨rf₀, ws₀, hws₀, ⟨hx13, hb1, hb2⟩, rfl, rfl⟩
     obtain rfl : ws = [] := List.eq_nil_of_length_eq_zero hws
     simp only [execBlock_cons, execBlock_nil, execInstrRF_nil, aluSem, loadSem,
       storeSem, blockVCs, Region.loadOk, RegFile.get_set_self,
@@ -187,7 +187,7 @@ theorem readActiveForkFn_spec (bs : List (BitVec 8))
       | trivial
       | omega
   case readActiveFork.post =>
-    intro rf' ws' h
+    intro rf' ws' A' h
     show rf'.get .x12 = leU64 bs (18 + (leU32 bs 26).toNat
         + (leU32 bs (26 + (leU32 bs 26).toNat)).toNat) ∧
       rf'.get .x13 = (0x40000012 : Word) + leU32 bs 26

--- a/EvmAsm/Stateless/SSZ/Decode/ChainIdSAsm.lean
+++ b/EvmAsm/Stateless/SSZ/Decode/ChainIdSAsm.lean
@@ -113,9 +113,9 @@ def readChainIdBody : Stmt :=
 def readChainIdFn (bs : List (BitVec 8)) : Fn where
   name := "readChainId"
   region := ⟨0x40000000, bs⟩
-  pre := fun _ _ =>
+  pre := fun _ _ _ =>
     30 ≤ bs.length ∧ 18 + (leU32 bs 26).toNat + 8 ≤ bs.length
-  post := fun rf _ =>
+  post := fun rf _ _ =>
     rf.get .x10 = leU64 bs (18 + (leU32 bs 26).toNat) ∧
     rf.get .x13 = (0x40000012 : Word) + leU32 bs 26
   body := readChainIdBody
@@ -153,7 +153,7 @@ theorem readChainIdFn_spec (bs : List (BitVec 8))
   case region =>
     exact ⟨inputRegion_wf bs hlen, RwRegion.empty_wf⟩
   case readChainId.offset32.mem =>
-    rintro rf ws hws ⟨rf₀, ws₀, hws₀, ⟨hlen30, hoff⟩, rfl, rfl⟩
+    rintro rf ws A hws ⟨rf₀, ws₀, hws₀, ⟨hlen30, hoff⟩, rfl, rfl⟩
     obtain rfl : ws = [] := List.eq_nil_of_length_eq_zero hws
     simp only [execBlock_cons, execBlock_nil, execInstrRF_nil, aluSem, loadSem,
       storeSem, blockVCs, Region.loadOk]
@@ -169,7 +169,7 @@ theorem readChainIdFn_spec (bs : List (BitVec 8))
     have h11 : (signExtend12 (11#12)).toNat = 11 := by decide
     omega
   case readChainId.chainid.mem =>
-    rintro rf ws hws ⟨rf₁, ws₁, hws₁, ⟨rf₀, ws₀, hws₀, ⟨hlen30, hoff⟩, rfl, rfl⟩, rfl, rfl⟩
+    rintro rf ws A hws ⟨rf₁, ws₁, hws₁, ⟨rf₀, ws₀, hws₀, ⟨hlen30, hoff⟩, rfl, rfl⟩, rfl, rfl⟩
     obtain rfl : ws = [] := List.eq_nil_of_length_eq_zero hws
     simp only [execBlock_cons, execBlock_nil, execInstrRF_nil, aluSem, loadSem,
       storeSem, blockVCs, Region.loadOk, RegFile.get_set_self, RegFile.get_set_ne,
@@ -208,7 +208,7 @@ theorem readChainIdFn_spec (bs : List (BitVec 8))
       | omega
       | bv_omega
   case readChainId.post =>
-    intro rf' ws' h
+    intro rf' ws' A' h
     show rf'.get .x10 = leU64 bs (18 + (leU32 bs 26).toNat) ∧
       rf'.get .x13 = (0x40000012 : Word) + leU32 bs 26
     obtain ⟨rf₂, ws₂, hws₂, ⟨rf₁, ws₁, hws₁, ⟨rf₀, ws₀, hws₀, ⟨hlen30, hoff⟩, rfl, rfl⟩, rfl, rfl⟩, rfl, rfl⟩ := h

--- a/PLAN.md
+++ b/PLAN.md
@@ -2491,7 +2491,15 @@ JALR epilogue against a dword slot of the shared rw region; ghost-indexed
 body-spec family pins the slot), with a two-level call-tree demo
 (topFn → callerRHandle → leafHandle). Remaining: per-frame rw sub-regions
 (CalleesIn currently forces one shared rw across the tree), then more
-Stateless/SSZ ports. read_active_fork ported (ActiveForkSAsm.lean:
+Stateless/SSZ ports. Assertion-state milestone started (approved plan
+~/.claude/plans/federated-wandering-pudding.md; epic evm-asm-6dt3v):
+Stage 1 landed — `Reach := RegFile → List Byte → Assertion → Prop`
+threads an ambient (pc-free) separation-logic assertion through the
+symbolic state, inert through blocks/branches/loops/calls; asrtOf
+bundles it existentially. Next stages: regFileIs↔atoms bridge +
+Assertion-shaped FnHandle contracts + ofTriple, ghost/focus nodes,
+tree library + sorted-BST insertion demo, docs/sasm-howto.md.
+read_active_fork ported (ActiveForkSAsm.lean:
 byte-wise u32-at-cfg+8 + u64 fork read, drop-in read_active_fork_verified
 swapped into run_stateless_guest, EEST A/B validated). Next port:
 decode_validation_bit.


### PR DESCRIPTION
Stage 1 of the SAsm Assertion-state milestone (approved plan: Assertion-shaped specs + separation-logic state for pointer-heavy data; epic bead `evm-asm-6dt3v`).

## What changes

The symbolic state gains a third component:

```lean
Reach := RegFile → List (BitVec 8) → Assertion → Prop
```

`A` is the ambient separation-logic assertion a function owns beyond its flat regions — in later stages it will hold pointer-shaped data (`treeAt p t`, list segments, borrowed windows). In this stage it is **inert**: `asrtOf` bundles it existentially (with a pc-free pin) as `((regFileIs rf ** bytesRegion rw.base ws) ** A)`, ordinary blocks frame it (`cpsTripleWithin_frameR` in `Stmt.sound`'s block case), and branches/asserts/loops/calls pass it through unchanged.

- `sp`/`vcs`/`CalleesIn`, `sp_mono`/`vcs_antitone`: arity threading; VC shapes gain one `∀ A` binder.
- `Stmt.sound` / `Stmt.soundR`: threaded through all cases via `asrtM_mono`/`asrtR_mono`; the `while` certificate and `branch_spec_asrt` carry the component opaquely.
- `RaSpill` splitters and `Fn.retSpecR`: the `A` atom is framed through the SD/LD/JALR wrapper steps.
- All demos (`Examples`, `ExamplesVc` incl. the two-level ra-spill tree) and both SSZ ports updated mechanically (`fun rf ws => …` → `fun rf ws _ => …`).
- `vcgen` needed no changes (it only walks the VC list spine).

## Coming next (separate PRs per the plan)

`regFileIs` ↔ per-register-atoms bridge + Assertion-shaped `FnHandle` contracts + `FnHandle.ofTriple` (calling existing hand-verified `cpsTripleWithin`s), ghost/focus statement nodes, a tree library, sorted-BST insertion demo, and the agent-facing `docs/sasm-howto.md`.

## Checks

Kernel-clean (`propext`/`Classical.choice`/`Quot.sound` on `Stmt.sound`, `Stmt.soundR`, `Fn.retSpecR`, `topFn_spec`, both SSZ port specs); forbidden-tactics scan OK; zero warnings. **No emitted-code change** (the `#guard`s still pin `read_chain_id_verified` / `read_active_fork_verified`), so no EEST run is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
