### PR TITLE
feat(sasm): regFileIs↔atoms bridge, consequence rules, hand-triple packaging (stage 2a)

### DIFF
--- a/EvmAsm/Rv64/SAsm.lean
+++ b/EvmAsm/Rv64/SAsm.lean
@@ -18,6 +18,7 @@ import EvmAsm.Rv64.SAsm.StmtSound
 import EvmAsm.Rv64.SAsm.Handle
 import EvmAsm.Rv64.SAsm.StmtSoundCall
 import EvmAsm.Rv64.SAsm.Fn
+import EvmAsm.Rv64.SAsm.AssertionSpec
 import EvmAsm.Rv64.SAsm.RaSpill
 import EvmAsm.Rv64.SAsm.Tactic
 import EvmAsm.Rv64.SAsm.Examples

--- a/EvmAsm/Rv64/SAsm/AssertionSpec.lean
+++ b/EvmAsm/Rv64/SAsm/AssertionSpec.lean
@@ -1,0 +1,198 @@
+/-
+  EvmAsm.Rv64.SAsm.AssertionSpec
+
+  Bridges between the SAsm state atoms and plain separation-logic
+  assertions, plus consequence rules at the `Fn`/`FnHandle` level.
+
+  - `regFileOn`/`regFileIs_eq_atoms`: the single `regFileIs` atom equals
+    the separating conjunction of the 15 per-register atoms.  This is the
+    keystone for packaging existing hand-verified `cpsTripleWithin`
+    routines (stated over `↦ᵣ` chains) as SAsm callees, and for exporting
+    SAsm specs in atom form.
+  - `FnHandle.weaken` / `Fn.spec_conseq`: strengthen preconditions and
+    weaken postconditions of packaged handles and function specs.  The
+    frame rule needs no counterpart here: everything outside a handle's
+    footprint is framed by `cpsTripleWithin` itself
+    (`cpsTripleWithin_frameR` for hand proofs).
+-/
+
+import EvmAsm.Rv64.SAsm.Fn
+
+namespace EvmAsm.Rv64
+namespace SAsm
+
+-- ============================================================================
+-- The register file as per-register atoms
+-- ============================================================================
+
+/-- The partial state owning exactly the registers in `rs`, valued by `rf`. -/
+def _root_.EvmAsm.Rv64.PartialState.onRegs (rs : List Reg) (rf : RegFile) :
+    PartialState where
+  regs := fun r => if r ∈ rs then some (rf.get r) else none
+  mem  := fun _ => none
+  code := fun _ => none
+  pc   := none
+
+/-- Ownership of exactly the registers in `rs`, valued by `rf`. -/
+def regFileOn (rs : List Reg) (rf : RegFile) : Assertion :=
+  fun h => h = PartialState.onRegs rs rf
+
+theorem regFileOn_nil (rf : RegFile) : regFileOn [] rf = empAssertion := by
+  have hX : PartialState.onRegs [] rf = PartialState.empty := by
+    unfold PartialState.onRegs PartialState.empty
+    congr 1
+  funext h
+  show (h = PartialState.onRegs [] rf) = (h = PartialState.empty)
+  rw [hX]
+
+private theorem union_singleton_onRegs (r : Reg) (rs : List Reg) (rf : RegFile) :
+    (PartialState.singletonReg r (rf.get r)).union (PartialState.onRegs rs rf)
+      = PartialState.onRegs (r :: rs) rf := by
+  unfold PartialState.union PartialState.onRegs PartialState.singletonReg
+  congr 1
+  funext r'
+  by_cases hr : r' = r
+  · subst hr
+    simp
+  · simp [hr]
+
+/-- Peel one register off a duplicate-free register-set atom. -/
+theorem regFileOn_cons (r : Reg) (rs : List Reg) (rf : RegFile)
+    (hnd : r ∉ rs) :
+    regFileOn (r :: rs) rf = ((r ↦ᵣ rf.get r) ** regFileOn rs rf) := by
+  funext h
+  apply propext
+  constructor
+  · intro hh
+    refine ⟨PartialState.singletonReg r (rf.get r), PartialState.onRegs rs rf,
+      ?_, ?_, rfl, rfl⟩
+    · refine ⟨fun r' => ?_, fun a => Or.inl rfl, fun a => Or.inl rfl,
+        Or.inl rfl, Or.inl rfl, Or.inl rfl, Or.inl rfl⟩
+      by_cases hr : r' = r
+      · subst hr
+        right
+        simp [PartialState.onRegs, hnd]
+      · left
+        simp [PartialState.singletonReg, hr]
+    · rw [hh, union_singleton_onRegs]
+  · rintro ⟨h1, h2, hd, hu, hh1, hh2⟩
+    have hh1' : h1 = PartialState.singletonReg r (rf.get r) := hh1
+    have hh2' : h2 = PartialState.onRegs rs rf := hh2
+    show h = PartialState.onRegs (r :: rs) rf
+    rw [← hu, hh1', hh2', union_singleton_onRegs]
+
+theorem pcFree_regFileOn (rs : List Reg) (rf : RegFile) :
+    (regFileOn rs rf).pcFree := by
+  intro h hp
+  rw [hp]
+  rfl
+
+/-- `regFileOn` is a set: any membership-equivalent register list names the
+    same atom.  Use to bring the registers a routine touches to the front
+    before peeling with `regFileOn_cons`. -/
+theorem regFileOn_perm (rs₁ rs₂ : List Reg) (rf : RegFile)
+    (h : ∀ r, r ∈ rs₁ ↔ r ∈ rs₂) :
+    regFileOn rs₁ rf = regFileOn rs₂ rf := by
+  have hX : PartialState.onRegs rs₁ rf = PartialState.onRegs rs₂ rf := by
+    unfold PartialState.onRegs
+    congr 1
+    funext r
+    by_cases hr : r ∈ rs₁
+    · rw [if_pos hr, if_pos ((h r).mp hr)]
+    · rw [if_neg hr, if_neg (fun hm => hr ((h r).mpr hm))]
+  funext hp
+  show (hp = _) = (hp = _)
+  rw [hX]
+
+/-- `regFileOn` only reads the listed registers: valuations agreeing there
+    name the same atom.  Use to re-fold the untouched remainder after a
+    hand-verified routine updates some registers. -/
+theorem regFileOn_congr (rs : List Reg) (rf rf' : RegFile)
+    (h : ∀ r ∈ rs, rf.get r = rf'.get r) :
+    regFileOn rs rf = regFileOn rs rf' := by
+  have hX : PartialState.onRegs rs rf = PartialState.onRegs rs rf' := by
+    unfold PartialState.onRegs
+    congr 1
+    funext r
+    by_cases hr : r ∈ rs
+    · rw [if_pos hr, if_pos hr, h r hr]
+    · rw [if_neg hr, if_neg hr]
+  funext hp
+  show (hp = _) = (hp = _)
+  rw [hX]
+
+/-- `regFileIs` is the register-set atom over the exposed registers. -/
+theorem regFileIs_eq_regFileOn (rf : RegFile) :
+    regFileIs rf = regFileOn exposedRegs rf := by
+  have hX : PartialState.ofRegFile rf = PartialState.onRegs exposedRegs rf := by
+    unfold PartialState.ofRegFile PartialState.onRegs
+    congr 1
+    funext r
+    by_cases hr : Reg.isExposed r = true
+    · rw [if_pos hr, if_pos ((Reg.isExposed_iff_mem r).mp hr)]
+    · rw [if_neg hr, if_neg (fun hm => hr ((Reg.isExposed_iff_mem r).mpr hm))]
+  funext h
+  show (h = PartialState.ofRegFile rf) = (h = PartialState.onRegs exposedRegs rf)
+  rw [hX]
+
+/-- **The keystone bridge**: the register-file atom is the separating
+    conjunction of the 15 per-register atoms (t0–t6, a0–a7).  Rewrite left
+    to right to hand individual registers to a hand-verified routine's
+    atom-form triple; right to left to rebuild the SAsm state from a
+    routine's atom-form postcondition. -/
+theorem regFileIs_eq_atoms (rf : RegFile) :
+    regFileIs rf
+      = ((.x5 ↦ᵣ rf.get .x5) ** ((.x6 ↦ᵣ rf.get .x6) ** ((.x7 ↦ᵣ rf.get .x7) **
+        ((.x28 ↦ᵣ rf.get .x28) ** ((.x29 ↦ᵣ rf.get .x29) **
+        ((.x30 ↦ᵣ rf.get .x30) ** ((.x31 ↦ᵣ rf.get .x31) **
+        ((.x10 ↦ᵣ rf.get .x10) ** ((.x11 ↦ᵣ rf.get .x11) **
+        ((.x12 ↦ᵣ rf.get .x12) ** ((.x13 ↦ᵣ rf.get .x13) **
+        ((.x14 ↦ᵣ rf.get .x14) ** ((.x15 ↦ᵣ rf.get .x15) **
+        ((.x16 ↦ᵣ rf.get .x16) ** (.x17 ↦ᵣ rf.get .x17))))))))))))))) := by
+  rw [regFileIs_eq_regFileOn,
+    show exposedRegs = [.x5, .x6, .x7, .x28, .x29, .x30, .x31,
+      .x10, .x11, .x12, .x13, .x14, .x15, .x16, .x17] from rfl,
+    regFileOn_cons _ _ _ (by decide), regFileOn_cons _ _ _ (by decide),
+    regFileOn_cons _ _ _ (by decide), regFileOn_cons _ _ _ (by decide),
+    regFileOn_cons _ _ _ (by decide), regFileOn_cons _ _ _ (by decide),
+    regFileOn_cons _ _ _ (by decide), regFileOn_cons _ _ _ (by decide),
+    regFileOn_cons _ _ _ (by decide), regFileOn_cons _ _ _ (by decide),
+    regFileOn_cons _ _ _ (by decide), regFileOn_cons _ _ _ (by decide),
+    regFileOn_cons _ _ _ (by decide), regFileOn_cons _ _ _ (by decide),
+    regFileOn_cons _ _ _ (by decide), regFileOn_nil,
+    sepConj_emp_right']
+
+-- ============================================================================
+-- Consequence rules
+-- ============================================================================
+
+/-- Consequence at the handle level: a packaged routine may be re-published
+    with a stronger precondition and a weaker postcondition (e.g. to
+    specialize ghost data at a particular call site). -/
+def FnHandle.weaken (f : FnHandle) (pre' post' : Reach)
+    (hpre : ∀ rf ws A, pre' rf ws A → f.pre rf ws A)
+    (hpost : ∀ rf ws A, f.post rf ws A → post' rf ws A) : FnHandle where
+  entry := f.entry
+  code := f.code
+  nSteps := f.nSteps
+  region := f.region
+  rw := f.rw
+  pre := pre'
+  post := post'
+  sound := fun ret halign =>
+    cpsTripleWithin_weaken
+      (fun hp => sepConj_mono_right (asrtM_mono hpre) hp)
+      (fun hp => sepConj_mono_right (asrtM_mono hpost) hp)
+      (f.sound ret halign)
+
+/-- Consequence at the function-spec level: a proved `Fn.Spec` transports to
+    the same function with a stronger pre and weaker post. -/
+theorem Fn.spec_conseq (f : Fn) (base : Word) {pre' post' : Reach}
+    (hspec : f.Spec base)
+    (hpre : ∀ rf ws A, pre' rf ws A → f.pre rf ws A)
+    (hpost : ∀ rf ws A, f.post rf ws A → post' rf ws A) :
+    ({ f with pre := pre', post := post' } : Fn).Spec base :=
+  cpsTripleWithin_weaken (asrtM_mono hpre) (asrtM_mono hpost) hspec
+
+end SAsm
+end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/ExamplesVc.lean
+++ b/EvmAsm/Rv64/SAsm/ExamplesVc.lean
@@ -6,6 +6,8 @@
   goals.  These double as regression tests for the tactic.
 -/
 
+import EvmAsm.Rv64.InstructionSpecs
+import EvmAsm.Rv64.SAsm.AssertionSpec
 import EvmAsm.Rv64.SAsm.RaSpill
 import EvmAsm.Rv64.SAsm.Tactic
 
@@ -586,6 +588,165 @@ theorem topFn_spec : topFn.SpecR 0x3000 topCr := by
     exact fun rf ws A h => h
   case top.post =>
     exact fun rf ws A h => h
+
+-- ============================================================================
+-- Packaging a hand-verified routine (atom-form triple) as a callee
+-- ============================================================================
+
+/-- A hand-written (non-SAsm) routine: `a0 := a0 + a1; ret`. -/
+def handAddProg : Program := [.ADD .x10 .x10 .x11, .JALR .x0 .x1 0]
+
+/-- The exposed registers `handAddProg` does not touch. -/
+private def handAddRest : List Reg :=
+  [.x5, .x6, .x7, .x28, .x29, .x30, .x31, .x12, .x13, .x14, .x15, .x16, .x17]
+
+/-- The handle contract for `handAddProg`, proved from the routine's
+    atom-form per-instruction specs — the template for packaging any
+    existing hand-verified `cpsTripleWithin` as an SAsm callee: peel the
+    touched registers off `regFileIs` (`regFileOn_perm` + `regFileOn_cons`),
+    frame the rest, run the atom-form steps, and re-fold with
+    `regFileOn_congr`. -/
+theorem handAdd_sound (a b : Word) : ∀ ret : Word, (ret &&& ~~~(1 : Word)) = ret →
+    cpsTripleWithin 2 0x4000 ret (CodeReq.ofProg 0x4000 handAddProg)
+      (((.x1 : Reg) ↦ᵣ ret) ** asrtM Region.empty RwRegion.empty
+        (fun rf _ _ => rf.get .x10 = a ∧ rf.get .x11 = b))
+      (((.x1 : Reg) ↦ᵣ ret) ** asrtM Region.empty RwRegion.empty
+        (fun rf _ _ => rf.get .x10 = a + b)) := by
+  intro ret halign
+  rw [sepConj_comm' ((.x1 : Reg) ↦ᵣ ret) (asrtM Region.empty RwRegion.empty
+    (fun rf _ _ => rf.get .x10 = a ∧ rf.get .x11 = b))]
+  apply cpsTripleWithin_exists_pre_M_frame
+  intro rf ws A hlen hApc hpre
+  obtain rfl : ws = [] := List.eq_nil_of_length_eq_zero hlen
+  obtain ⟨hx10, hx11⟩ := hpre
+  -- peel a0/a1 off the register-file atom
+  have hsplit : ∀ rf' : RegFile, regFileIs rf'
+      = (((.x10 : Reg) ↦ᵣ rf'.get .x10) ** (((.x11 : Reg) ↦ᵣ rf'.get .x11) **
+          regFileOn handAddRest rf')) := by
+    intro rf'
+    rw [regFileIs_eq_regFileOn,
+      regFileOn_perm exposedRegs (.x10 :: .x11 :: handAddRest) rf'
+        (by intro r; cases r <;> simp [exposedRegs, handAddRest]),
+      regFileOn_cons _ _ _ (by decide), regFileOn_cons _ _ _ (by decide)]
+  -- the updated valuation (definitionally: a0 the sum, everything else rf)
+  set rf' : RegFile := fun r => if r = .x10 then rf.get .x10 + rf.get .x11 else rf r
+    with hrf'
+  have hrest : regFileOn handAddRest rf = regFileOn handAddRest rf' :=
+    regFileOn_congr _ _ _ (by intro r hr; fin_cases hr <;> rfl)
+  -- ADD step, framed with the untouched remainder + ambient A + ra
+  have hadd := add_spec_rd_eq_rs1_within .x10 .x11 (rf.get .x10) (rf.get .x11)
+    0x4000 (by decide)
+  have haddC := cpsTripleWithin_extend_code
+    (fun a' i h => show CodeReq.ofProg 0x4000
+        [Instr.ADD .x10 .x10 .x11, Instr.JALR .x0 .x1 0] a' = some i from
+      ofProg_head a' i h) hadd
+  have hFpc : (regFileOn handAddRest rf ** (A ** ((.x1 : Reg) ↦ᵣ ret))).pcFree :=
+    pcFree_sepConj (pcFree_regFileOn _ _) (pcFree_sepConj hApc (by pcFree))
+  have haddF := cpsTripleWithin_frameR
+    (regFileOn handAddRest rf ** (A ** ((.x1 : Reg) ↦ᵣ ret))) hFpc haddC
+  -- return step over the post-state atoms
+  have hjal := Fn.jalr_ret_spec (0x4000 + 4) ret halign
+    (P := ((.x10 : Reg) ↦ᵣ rf.get .x10 + rf.get .x11) **
+      (((.x11 : Reg) ↦ᵣ rf.get .x11) ** (regFileOn handAddRest rf ** A)))
+    (pcFree_sepConj (by pcFree) (pcFree_sepConj (by pcFree)
+      (pcFree_sepConj (pcFree_regFileOn _ _) hApc)))
+  have hjalC := cpsTripleWithin_extend_code
+    (fun a' i h => by
+      show CodeReq.ofProg 0x4000
+        [Instr.ADD .x10 .x10 .x11, Instr.JALR .x0 .x1 0] a' = some i
+      apply ofProg_cons_tail (by decide)
+      rw [CodeReq.ofProg_singleton]
+      exact h) hjal
+  -- assemble
+  have hseq := cpsTripleWithin_seq_same_cr
+    (cpsTripleWithin_weaken
+      (P' := (((regFileIs rf) ** bytesRegion RwRegion.empty.base []) ** A) **
+        (bytesRegion Region.empty.base Region.empty.bytes ** ((.x1 : Reg) ↦ᵣ ret)))
+      (Q' := ((.x1 : Reg) ↦ᵣ ret) **
+        (((.x10 : Reg) ↦ᵣ rf.get .x10 + rf.get .x11) **
+          (((.x11 : Reg) ↦ᵣ rf.get .x11) ** (regFileOn handAddRest rf ** A))))
+      (fun hp hh => by
+        rw [show bytesRegion RwRegion.empty.base [] = empAssertion from rfl,
+          show bytesRegion Region.empty.base Region.empty.bytes = empAssertion
+            from rfl,
+          sepConj_emp_right', sepConj_emp_left', hsplit rf] at hh
+        xperm_hyp hh)
+      (fun hp hh => by xperm_hyp hh)
+      haddF)
+    hjalC
+  refine cpsTripleWithin_weaken (fun hp hh => hh) ?_ hseq
+  intro hp hh
+  refine sepConj_mono_right (fun hq hx => ?_) hp hh
+  show (asrtOf RwRegion.empty (fun rf _ _ => rf.get .x10 = a + b) **
+    bytesRegion Region.empty.base Region.empty.bytes) hq
+  rw [show bytesRegion Region.empty.base Region.empty.bytes = empAssertion from rfl,
+    sepConj_emp_right']
+  refine ⟨rf', [], A, rfl, hApc, ?_, ?_⟩
+  · show rf.get .x10 + rf.get .x11 = a + b
+    rw [hx10, hx11]
+  · have hv10 : rf'.get .x10 = rf.get .x10 + rf.get .x11 := by rw [hrf']; rfl
+    have hv11 : rf'.get .x11 = rf.get .x11 := by rw [hrf']; rfl
+    rw [show bytesRegion RwRegion.empty.base [] = empAssertion from rfl,
+      sepConj_emp_right', hsplit rf', hv10, hv11, ← hrest]
+    xperm_hyp hx
+
+/-- The packaged hand routine at `0x4000`. -/
+def handAddHandle (a b : Word) : FnHandle where
+  entry := 0x4000
+  code := CodeReq.ofProg 0x4000 handAddProg
+  nSteps := 2
+  region := Region.empty
+  rw := RwRegion.empty
+  pre := fun rf _ _ => rf.get .x10 = a ∧ rf.get .x11 = b
+  post := fun rf _ _ => rf.get .x10 = a + b
+  sound := handAdd_sound a b
+
+/-- An SAsm caller of the hand-verified routine. -/
+def callerHFn : Fn where
+  name := "callerH"
+  pre := fun _ _ _ => True
+  post := fun rf _ _ => rf.get .x10 = 12
+  body :=
+    .block "args" [.LI .x10 5, .LI .x11 7] ;;;
+    .call "handAdd" (handAddHandle 5 7)
+
+def callerHCr : CodeReq :=
+  (CodeReq.ofProg 0x1000 (callerHFn.body.flatten 0x1000)).union
+    (handAddHandle 5 7).code
+
+theorem callerHFn_spec : callerHFn.SpecR 0x1000 callerHCr := by
+  vcgen
+  case code =>
+    intro a i h
+    simp only [callerHCr, CodeReq.union, h]
+  case callees =>
+    refine ⟨trivial, ?_, rfl, rfl⟩
+    intro a i h
+    obtain ⟨k, hk, rfl⟩ := ofProg_some_range h
+    have hlen : (handAddProg : List Instr).length = 2 := by decide
+    rw [hlen] at hk
+    simp only [callerHCr, CodeReq.union]
+    rw [CodeReq.ofProg_none_range 0x1000 (callerHFn.body.flatten 0x1000)
+      (fun k' hk' heq => ?_)]
+    · exact h
+    · have hlen' : (callerHFn.body.flatten 0x1000).length = 3 := by decide
+      rw [hlen'] at hk'
+      bv_omega
+  case calls =>
+    exact ⟨trivial, by decide, by decide, by decide⟩
+  case callerH.handAdd.pre =>
+    rintro rf ws A ⟨rf₀, ws₀, -, -, rfl, rfl⟩
+    simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem]
+    constructor
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_self _ _ _ (by decide)]
+    · rw [RegFile.get_set_self _ _ _ (by decide)]
+  case callerH.post =>
+    intro rf ws A h
+    show rf.get .x10 = 12
+    have h' : rf.get .x10 = 5 + 7 := h
+    rw [h']
+    decide
 
 end ExamplesVc
 end SAsm

--- a/PLAN.md
+++ b/PLAN.md
@@ -2493,11 +2493,15 @@ body-spec family pins the slot), with a two-level call-tree demo
 (CalleesIn currently forces one shared rw across the tree), then more
 Stateless/SSZ ports. Assertion-state milestone started (approved plan
 ~/.claude/plans/federated-wandering-pudding.md; epic evm-asm-6dt3v):
-Stage 1 landed — `Reach := RegFile → List Byte → Assertion → Prop`
+Stages 1+2a landed — `Reach := RegFile → List Byte → Assertion → Prop`
 threads an ambient (pc-free) separation-logic assertion through the
 symbolic state, inert through blocks/branches/loops/calls; asrtOf
-bundles it existentially. Next stages: regFileIs↔atoms bridge +
-Assertion-shaped FnHandle contracts + ofTriple, ghost/focus nodes,
+bundles it existentially. AssertionSpec.lean: regFileIs↔atoms bridge
+(regFileOn set-atoms + perm/congr/cons peeling, regFileIs_eq_atoms),
+FnHandle.weaken + Fn.spec_conseq consequence rules, handAdd demo
+(hand-verified atom-form triple packaged as an SAsm callee and called
+through the standard machinery). Next stages: Assertion-shaped FnHandle
+contracts + SState combinators, ghost/focus nodes,
 tree library + sorted-BST insertion demo, docs/sasm-howto.md.
 read_active_fork ported (ActiveForkSAsm.lean:
 byte-wise u32-at-cfg+8 + u64 fork read, drop-in read_active_fork_verified


### PR DESCRIPTION
Stage 2a of the Assertion-state milestone, stacked on #9680.

## `EvmAsm/Rv64/SAsm/AssertionSpec.lean`

- **`regFileOn rs rf`** — ownership of a register *set* (membership-based, so list order is irrelevant), with the toolkit: `regFileOn_perm` (reorder to bring touched registers to the front), `regFileOn_cons` (peel one register off as a `↦ᵣ` atom), `regFileOn_congr` (re-fold the untouched remainder after updates), `regFileOn_nil`, `pcFree_regFileOn`.
- **`regFileIs_eq_regFileOn` / `regFileIs_eq_atoms`** — the keystone bridge: the single `regFileIs` atom equals the separating conjunction of the 15 per-register atoms. In practice the peeling form is what you use: expose exactly the registers a routine touches, keep the other 13 as one opaque `regFileOn` atom (no 15-atom xperm blowup).
- **`FnHandle.weaken`** and **`Fn.spec_conseq`** — consequence rules (strengthen pre / weaken post) at the handle and function-spec levels. The frame rule needs no new counterpart: everything outside a footprint is framed by `cpsTripleWithin` itself (`cpsTripleWithin_frameR` for hand proofs).

## Demo: calling an existing hand-verified routine from SAsm

`handAddProg` (`ADD a0,a0,a1; ret`) is proved **outside** SAsm from atom-form per-instruction specs (`add_spec_rd_eq_rs1_within` + `Fn.jalr_ret_spec`), bridged into the `FnHandle` contract (peel a0/a1 off `regFileIs`, frame the rest + the ambient Assertion + `ra`, run the steps, re-fold with `regFileOn_congr` at the updated valuation), packaged as `handAddHandle`, and consumed by an SAsm caller through the standard `call` machinery — the template for packaging any existing hand-verified `cpsTripleWithin`.

Kernel-clean (the bridge lemmas need only `propext`/`Quot.sound`); zero warnings; no emitted-code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
