### PR TITLE
feat(sasm): SState spec surface, Fn.SpecA, whileA/assertA, FnHandle.frameA (stage 2b)

### DIFF
--- a/EvmAsm/Rv64/SAsm/AssertionSpec.lean
+++ b/EvmAsm/Rv64/SAsm/AssertionSpec.lean
@@ -194,5 +194,124 @@ theorem Fn.spec_conseq (f : Fn) (base : Word) {pre' post' : Reach}
     ({ f with pre := pre', post := post' } : Fn).Spec base :=
   cpsTripleWithin_weaken (asrtM_mono hpre) (asrtM_mono hpost) hspec
 
+-- ============================================================================
+-- The canonical Assertion-shaped spec surface
+-- ============================================================================
+
+/-- The canonical factored machine assertion of an SAsm symbolic state:
+    some register file and window contents satisfying the pure `φ`, with
+    the ambient assertion pinned to the family `Af`.  This is the shape in
+    which SAsm specs read as separation-logic pre/postconditions, e.g.
+
+      SState reg rw (fun rf _ => rf.get .x10 = p)
+        (fun rf _ => treeAt (rf.get .x10) t)
+
+    Internally it is `asrtM` of the `A`-pinning reach, so `vcgen` and the
+    call machinery consume it unchanged. -/
+def SState (reg : Region) (rw : RwRegion)
+    (φ : RegFile → List (BitVec 8) → Prop)
+    (Af : RegFile → List (BitVec 8) → Assertion) : Assertion :=
+  asrtM reg rw (fun rf ws A => φ rf ws ∧ A = Af rf ws)
+
+theorem pcFree_SState (reg : Region) (rw : RwRegion)
+    (φ : RegFile → List (BitVec 8) → Prop)
+    (Af : RegFile → List (BitVec 8) → Assertion) :
+    (SState reg rw φ Af).pcFree :=
+  pcFree_asrtM _ _ _
+
+/-- An Assertion-shaped bounded triple for an SAsm function's body. -/
+def Fn.SpecA (f : Fn) (base : Word) (P Q : Assertion) : Prop :=
+  cpsTripleWithin f.body.steps base (base + BitVec.ofNat 64 (4 * f.body.size))
+    (f.codeReq base) P Q
+
+/-- Publish a proved `Fn.Spec` as an Assertion triple: an entry entailment
+    into the internal state and an exit entailment out of it.  For
+    `SState`-shaped pre/posts both entailments are `asrtM_mono`-mechanical
+    (or `Eq`-rewrites when the reaches are literally `A`-pinning). -/
+theorem Fn.specA_of_spec (f : Fn) (base : Word) {P Q : Assertion}
+    (hspec : f.Spec base)
+    (hpre : ∀ h, P h → asrtM f.region f.rw f.pre h)
+    (hpost : ∀ h, asrtM f.region f.rw f.post h → Q h) :
+    f.SpecA base P Q :=
+  cpsTripleWithin_weaken hpre hpost hspec
+
+/-- `while` with a factored Assertion invariant: the pure part `invPure i`
+    plus the ambient assertion pinned to `invA i`. -/
+def Stmt.whileA (lbl : String) (c : Cond) (fuel : Nat)
+    (invPure : Nat → RegFile → List (BitVec 8) → Prop)
+    (invA : Nat → RegFile → List (BitVec 8) → Assertion)
+    (body : Stmt) : Stmt :=
+  .while lbl c fuel (fun i rf ws A => invPure i rf ws ∧ A = invA i rf ws) body
+
+/-- `assert` with a factored Assertion annotation. -/
+def Stmt.assertA (lbl : String)
+    (φ : RegFile → List (BitVec 8) → Prop)
+    (Af : RegFile → List (BitVec 8) → Assertion) : Stmt :=
+  .assert lbl (fun rf ws A => φ rf ws ∧ A = Af rf ws)
+
+-- ============================================================================
+-- The frame rule at call granularity
+-- ============================================================================
+
+/-- Reach transformer of `FnHandle.frameA`: demand the ambient assertion
+    split as `A₀ ** Fr` and constrain only the `A₀` part. -/
+def Reach.frameA (r : Reach) (Fr : Assertion) : Reach :=
+  fun rf ws A => ∃ A₀, A₀.pcFree ∧ A = (A₀ ** Fr) ∧ r rf ws A₀
+
+/-- Splitting the ambient assertion moves a fixed frame out of `asrtOf`. -/
+theorem asrtOf_frameA (rw : RwRegion) (r : Reach) (Fr : Assertion)
+    (hFr : Fr.pcFree) :
+    asrtOf rw (r.frameA Fr) = (asrtOf rw r ** Fr) := by
+  funext h
+  apply propext
+  constructor
+  · rintro ⟨rf, ws, A, hlen, hApc, ⟨A₀, hA0, rfl, hr⟩, hsts⟩
+    rw [← sepConj_assoc'] at hsts
+    obtain ⟨g1, g2, gd, gu, hin, hfr⟩ := hsts
+    exact ⟨g1, g2, gd, gu, ⟨rf, ws, A₀, hlen, hA0, hr, hin⟩, hfr⟩
+  · rintro ⟨g1, g2, gd, gu, ⟨rf, ws, A₀, hlen, hA0, hr, hin⟩, hfr⟩
+    have hsts : ((((regFileIs rf) ** bytesRegion rw.base ws) ** A₀) ** Fr) h :=
+      ⟨g1, g2, gd, gu, hin, hfr⟩
+    rw [sepConj_assoc'] at hsts
+    exact ⟨rf, ws, A₀ ** Fr, hlen, pcFree_sepConj hA0 hFr,
+      ⟨A₀, hA0, rfl, hr⟩, hsts⟩
+
+/-- Splitting the ambient assertion moves a fixed frame out of `asrtM`. -/
+theorem asrtM_frameA (reg : Region) (rw : RwRegion) (r : Reach)
+    (Fr : Assertion) (hFr : Fr.pcFree) :
+    asrtM reg rw (r.frameA Fr) = (asrtM reg rw r ** Fr) := by
+  show (asrtOf rw (r.frameA Fr) ** bytesRegion reg.base reg.bytes)
+    = ((asrtOf rw r ** bytesRegion reg.base reg.bytes) ** Fr)
+  rw [asrtOf_frameA rw r Fr hFr, sepConj_assoc',
+    sepConj_comm' Fr (bytesRegion reg.base reg.bytes), ← sepConj_assoc']
+
+/-- **The frame rule for calls**: a callee needing ambient assertion `A₀`
+    may be called where the caller holds `A₀ ** Fr` — the framed handle
+    hands `A₀` to the callee and returns its ambient conjoined back with
+    the untouched `Fr`.  `Fr` is fixed at the call site (ghost data enters
+    through the ambient binders as usual). -/
+def FnHandle.frameA (f : FnHandle) (Fr : Assertion) (hFr : Fr.pcFree) :
+    FnHandle where
+  entry := f.entry
+  code := f.code
+  nSteps := f.nSteps
+  region := f.region
+  rw := f.rw
+  pre := f.pre.frameA Fr
+  post := f.post.frameA Fr
+  sound := fun ret halign => by
+    have h1 := cpsTripleWithin_frameR Fr hFr (f.sound ret halign)
+    refine cpsTripleWithin_weaken ?_ ?_ h1
+    · intro hp hh
+      rw [show asrtM f.region f.rw (f.pre.frameA Fr)
+          = (asrtM f.region f.rw f.pre ** Fr) from
+        asrtM_frameA f.region f.rw f.pre Fr hFr] at hh
+      exact sc_assoc_l hp hh
+    · intro hp hh
+      rw [show asrtM f.region f.rw (f.post.frameA Fr)
+          = (asrtM f.region f.rw f.post ** Fr) from
+        asrtM_frameA f.region f.rw f.post Fr hFr]
+      exact sc_assoc_r hp hh
+
 end SAsm
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/ExamplesVc.lean
+++ b/EvmAsm/Rv64/SAsm/ExamplesVc.lean
@@ -748,6 +748,90 @@ theorem callerHFn_spec : callerHFn.SpecR 0x1000 callerHCr := by
     rw [h']
     decide
 
+-- ============================================================================
+-- Assertion contracts + the call-granularity frame rule (frameA)
+-- ============================================================================
+
+/-- A callee whose contract owns an ambient separation-logic cell (ghost
+    value `v`): the cell rides through the body untouched — blocks cannot
+    reach the ambient assertion. -/
+def cellKeepFn (v : Word) : Fn where
+  name := "cellKeep"
+  pre := fun _ _ A => A = ((0x10100 : Word) ↦ₘ v)
+  post := fun rf _ A => rf.get .x10 = 1 ∧ A = ((0x10100 : Word) ↦ₘ v)
+  body := .block "one" [.LI .x10 1]
+
+theorem cellKeepFn_spec (v base : Word) : (cellKeepFn v).Spec base := by
+  vcgen
+  case cellKeep.post =>
+    rintro rf ws A ⟨rf₀, ws₀, hws₀, hA, rfl, rfl⟩
+    refine ⟨?_, hA⟩
+    simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem]
+    rw [RegFile.get_set_self _ _ _ (by decide)]
+
+/-- The same contract published as a readable Assertion triple. -/
+theorem cellKeepFn_specA (v base : Word) :
+    (cellKeepFn v).SpecA base
+      (SState Region.empty RwRegion.empty (fun _ _ => True)
+        (fun _ _ => (0x10100 : Word) ↦ₘ v))
+      (SState Region.empty RwRegion.empty (fun rf _ => rf.get .x10 = 1)
+        (fun _ _ => (0x10100 : Word) ↦ₘ v)) := by
+  refine Fn.specA_of_spec _ _ (cellKeepFn_spec v base) ?_ ?_
+  · exact asrtM_mono (fun rf ws A h => h.2)
+  · exact asrtM_mono (fun rf ws A h => ⟨h.1, h.2⟩)
+
+/-- The cell-owning callee at `0x5000`. -/
+def cellKeepHandle (v : Word) : FnHandle :=
+  (cellKeepFn v).toHandle 0x5000 (cellKeepFn_spec v 0x5000)
+    ((by decide : 4 * ((cellKeepFn 0).body.size + 1) ≤ 2 ^ 64))
+
+/-- A caller owning TWO ambient cells: the callee needs only the first, so
+    the call site frames the second with `FnHandle.frameA`. -/
+def twoCellsFn (v w : Word) : Fn where
+  name := "twoCells"
+  pre := fun _ _ A =>
+    A = (((0x10100 : Word) ↦ₘ v) ** ((0x10108 : Word) ↦ₘ w))
+  post := fun rf _ A => rf.get .x10 = 1 ∧
+    A = (((0x10100 : Word) ↦ₘ v) ** ((0x10108 : Word) ↦ₘ w))
+  body := .call "cellKeep"
+    ((cellKeepHandle v).frameA ((0x10108 : Word) ↦ₘ w) pcFree_memIs)
+
+def twoCellsCr (v w : Word) : CodeReq :=
+  (CodeReq.ofProg 0x1000 ((twoCellsFn v w).body.flatten 0x1000)).union
+    (cellKeepHandle v).code
+
+theorem twoCellsFn_spec (v w : Word) :
+    (twoCellsFn v w).SpecR 0x1000 (twoCellsCr v w) := by
+  vcgen
+  case code =>
+    intro a i h
+    simp only [twoCellsCr, CodeReq.union, h]
+  case callees =>
+    refine ⟨?_, rfl, rfl⟩
+    intro a i h
+    obtain ⟨k, hk, rfl⟩ := ofProg_some_range h
+    have hlen0 : ((cellKeepFn 0).programRet 0x5000).length = 2 := by decide
+    have hlen : ((cellKeepFn v).programRet 0x5000).length = 2 := hlen0
+    rw [hlen] at hk
+    simp only [twoCellsCr, CodeReq.union]
+    rw [CodeReq.ofProg_none_range 0x1000 ((twoCellsFn v w).body.flatten 0x1000)
+      (fun k' hk' heq => ?_)]
+    · exact h
+    · have hlen0' : ((twoCellsFn 0 0).body.flatten 0x1000).length = 1 := by decide
+      have hlen' : ((twoCellsFn v w).body.flatten 0x1000).length = 1 := hlen0'
+      rw [hlen'] at hk'
+      bv_omega
+  case calls =>
+    have h0 : (twoCellsFn 0 0).body.callsOk 0x1000 :=
+      ⟨by decide, by decide, by decide⟩
+    exact h0
+  case twoCells.cellKeep.pre =>
+    rintro rf ws A hA
+    exact ⟨(0x10100 : Word) ↦ₘ v, pcFree_memIs, hA, rfl⟩
+  case twoCells.post =>
+    rintro rf ws A ⟨A₀, hA0pc, rfl, hx10, hA0eq⟩
+    exact ⟨hx10, by rw [hA0eq]⟩
+
 end ExamplesVc
 end SAsm
 end EvmAsm.Rv64

--- a/PLAN.md
+++ b/PLAN.md
@@ -2500,8 +2500,15 @@ bundles it existentially. AssertionSpec.lean: regFileIs↔atoms bridge
 (regFileOn set-atoms + perm/congr/cons peeling, regFileIs_eq_atoms),
 FnHandle.weaken + Fn.spec_conseq consequence rules, handAdd demo
 (hand-verified atom-form triple packaged as an SAsm callee and called
-through the standard machinery). Next stages: Assertion-shaped FnHandle
-contracts + SState combinators, ghost/focus nodes,
+through the standard machinery). Stage 2b landed: SState (canonical
+factored Assertion = asrtM of an A-pinning reach), Fn.SpecA +
+specA_of_spec (publish specs as Assertion triples), Stmt.whileA/assertA
+(factored Assertion invariants/annotations), and FnHandle.frameA — the
+frame rule at call granularity (callee needing A₀ callable where the
+caller holds A₀ ** Fr), derived generically with NO soundness-induction
+change (asrtOf_frameA/asrtM_frameA). Demo: cellKeepFn (ambient-cell
+contract, published via SpecA) called by twoCellsFn through frameA.
+Next stages: ghost/focus nodes,
 tree library + sorted-BST insertion demo, docs/sasm-howto.md.
 read_active_fork ported (ActiveForkSAsm.lean:
 byte-wise u32-at-cfg+8 + u64 fork read, drop-in read_active_fork_verified


### PR DESCRIPTION
Stage 2b of the Assertion-state milestone — with a significant simplification over the approved plan.

## The simplification

The plan called for re-basing `FnHandle` on Assertion contracts (factored post fields) and reworking the `call` soundness case — estimated as the biggest theory PR. During implementation it turned out **the stage-1 state threading already gives handles Assertion contracts for free**: a `Reach` that pins the ambient component by equality (`fun rf ws A => φ rf ws ∧ A = Af rf ws`) *is* an Assertion contract, and `asrtM` of it *is* the readable factored assertion. So no `FnHandle` field changes and no soundness-induction rework are needed; what was genuinely missing was only the **frame rule at call sites**.

## What this adds (`AssertionSpec.lean`)

- **`SState reg rw φ Af`** — the canonical factored machine assertion of an SAsm state (register file + windows + ambient assertion pinned to `Af`), the shape in which specs read as separation-logic pre/posts. Defined as `asrtM` of the A-pinning reach, so `vcgen` and the call machinery consume it unchanged.
- **`Fn.SpecA` + `Fn.specA_of_spec`** — publish a proved `Fn.Spec` as an Assertion triple `{P} body {Q}` via entry/exit entailments (mechanical for `SState`-shaped `P`/`Q`).
- **`Stmt.whileA` / `Stmt.assertA`** — loop invariants and assert annotations in factored Assertion form.
- **`FnHandle.frameA`** — the frame rule at call granularity: a callee whose contract needs ambient `A₀` is callable where the caller holds `A₀ ** Fr`; the framed handle hands `A₀` to the callee and returns its ambient conjoined back with the untouched `Fr`. Derived generically from two new equalities (`asrtOf_frameA`, `asrtM_frameA`) plus `cpsTripleWithin_frameR` — ~40 lines total, no induction changes. This supersedes the flat rw sub-region carving entirely.

## Demo (ExamplesVc)

`cellKeepFn v` owns an ambient memory cell `0x10100 ↦ₘ v` through its contract (also published via `SpecA` as a readable Assertion triple). `twoCellsFn v w` holds `(0x10100 ↦ₘ v) ** (0x10108 ↦ₘ w)` and calls it with the second cell framed: the call-site split VC is `⟨cell₁, pcFree_memIs, hA, rfl⟩` and the post-call reassembly is one rewrite — exactly the ergonomics the tree/list stages need.

Kernel-clean (`asrtM_frameA`/`frameA`/`specA_of_spec` need only `propext`/`Quot.sound`); zero warnings; forbidden-tactics OK; no emitted-code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
