### PR TITLE
feat(sasm): ghost statement node — ambient-assertion reshaping (stage 3a)

### DIFF
--- a/EvmAsm/Rv64/SAsm/Ast.lean
+++ b/EvmAsm/Rv64/SAsm/Ast.lean
@@ -112,6 +112,13 @@ inductive Stmt where
       every reachable register file satisfies `P`, and strengthens the
       reachable set with `P` downstream (a proof cut). -/
   | assert (label : String) (P : RegFile → List (BitVec 8) → Assertion → Prop)
+  /-- Ghost step: emits no code; replaces the ambient assertion `A` by
+      `f rf ws A`, justified by one VC demanding a pointwise entailment
+      (and pc-freedom of the result).  This is how recursive predicates
+      are folded/unfolded mid-body (open a tree node, push a zipper
+      frame, …). -/
+  | ghost  (label : String)
+           (f : RegFile → List (BitVec 8) → Assertion → Assertion)
   /-- Bounded loop: the body runs while `c` holds, at most `fuel` iterations.
       `inv i` must hold at the i-th evaluation of the header; the generator
       emits initialization, preservation, and fuel-exhaustion VCs. -/
@@ -136,6 +143,7 @@ def size : Stmt → Nat
   | ite _ _ t e       => t.size + e.size + 2
   | when _ _ b        => b.size + 1
   | assert _ _        => 0
+  | ghost _ _         => 0
   | «while» _ _ _ _ b   => b.size + 2
   | call _ _          => 1
 
@@ -151,6 +159,7 @@ def callFree : Stmt → Bool
   | ite _ _ t e       => t.callFree && e.callFree
   | when _ _ b        => b.callFree
   | assert _ _        => true
+  | ghost _ _         => true
   | «while» _ _ _ _ b => b.callFree
   | call _ _          => false
 

--- a/EvmAsm/Rv64/SAsm/ExamplesVc.lean
+++ b/EvmAsm/Rv64/SAsm/ExamplesVc.lean
@@ -832,6 +832,34 @@ theorem twoCellsFn_spec (v w : Word) :
     rintro rf ws A ⟨A₀, hA0pc, rfl, hx10, hA0eq⟩
     exact ⟨hx10, by rw [hA0eq]⟩
 
+-- ============================================================================
+-- Ghost steps: reshaping the ambient assertion mid-body
+-- ============================================================================
+
+/-- A ghost step commuting the two ambient cells: no code, one entailment
+    VC.  (The stand-in for fold/unfold of recursive predicates.) -/
+def swapCellsFn (v w : Word) : Fn where
+  name := "swapCells"
+  pre := fun _ _ A =>
+    A = (((0x10100 : Word) ↦ₘ v) ** ((0x10108 : Word) ↦ₘ w))
+  post := fun _ _ A =>
+    A = (((0x10108 : Word) ↦ₘ w) ** ((0x10100 : Word) ↦ₘ v))
+  body := .ghost "swap"
+    (fun _ _ _ => ((0x10108 : Word) ↦ₘ w) ** ((0x10100 : Word) ↦ₘ v))
+
+theorem swapCellsFn_spec (v w base : Word) : (swapCellsFn v w).Spec base := by
+  vcgen
+  case swapCells.swap =>
+    rintro rf ws A hA hApc
+    refine ⟨?_, pcFree_sepConj pcFree_memIs pcFree_memIs⟩
+    intro hp hh
+    rw [hA] at hh
+    rw [sepConj_comm']
+    exact hh
+  case swapCells.post =>
+    rintro rf ws A' ⟨A, hA, rfl⟩
+    rfl
+
 end ExamplesVc
 end SAsm
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/Flatten.lean
+++ b/EvmAsm/Rv64/SAsm/Flatten.lean
@@ -54,6 +54,8 @@ def flatten (addr : Word) : Stmt → List Instr
       c.neg.toInstr (brOfs (b.size + 1)) :: b.flatten (addr + 4)
   | assert _ _ =>
       []
+  | ghost _ _ =>
+      []
   | «while» _ c _ _ b =>
       c.neg.toInstr (brOfs (b.size + 2))
         :: (b.flatten (addr + 4) ++ [.JAL .x0 (jBack (b.size + 1))])
@@ -72,6 +74,7 @@ theorem flatten_length (s : Stmt) (addr : Word) :
   | «when» _ c b ihb =>
       simp [flatten, size, ihb]
   | assert _ _ => rfl
+  | ghost _ _ => rfl
   | «while» _ c fuel inv b ihb =>
       simp [flatten, size, ihb]
   | call _ callee => rfl
@@ -92,6 +95,7 @@ def offsetsOk : Stmt → Bool
   | when _ c b =>
       c.wf && decide (4 * (b.size + 1) < 2^12) && b.offsetsOk
   | assert _ _ => true
+  | ghost _ _ => true
   | «while» _ c _ _ b =>
       c.wf && decide (4 * (b.size + 2) < 2^12)
            && decide (4 * (b.size + 1) ≤ 2^20)
@@ -111,6 +115,7 @@ def callsOk : Stmt → Word → Prop
       t.callsOk (addr + 4) ∧ e.callsOk (addr + BitVec.ofNat 64 (4 * (t.size + 2)))
   | when _ _ b, addr => b.callsOk (addr + 4)
   | assert _ _, _ => True
+  | ghost _ _, _ => True
   | «while» _ _ _ _ b, addr => b.callsOk (addr + 4)
   | call _ f, addr =>
       addr + signExtend21 (BitVec.setWidth 21 (f.entry - addr)) = f.entry

--- a/EvmAsm/Rv64/SAsm/StmtSound.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSound.lean
@@ -378,6 +378,22 @@ theorem Stmt.sound (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
       simp only [Stmt.steps]
       rw [hz]
       exact h
+  | ghost lbl f =>
+      have hvc := hvcs _ (List.mem_singleton_self _)
+      have h : cpsTripleWithin 0 base base cr (asrtM reg rw reach)
+          (asrtM reg rw (Stmt.sp reg rw (.ghost lbl f) reach)) := by
+        apply cpsTripleWithin_entails
+        intro hp hh
+        refine sepConj_mono_left (fun hq hx => ?_) hp hh
+        obtain ⟨rf, ws, A, hlen, hApc, hr, hsts⟩ := hx
+        obtain ⟨hent, hpcf⟩ := hvc rf ws A hr hApc
+        exact ⟨rf, ws, f rf ws A, hlen, hpcf, ⟨A, hr, rfl⟩,
+          sepConj_mono_right hent hq hsts⟩
+      have hz : base + BitVec.ofNat 64 (4 * Stmt.size (.ghost lbl f)) = base := by
+        simp [Stmt.size]
+      simp only [Stmt.steps]
+      rw [hz]
+      exact h
   | «while» lbl c fuel inv b ihb =>
       simp only [Stmt.offsetsOk, Bool.and_eq_true, decide_eq_true_eq] at hofs
       obtain ⟨⟨⟨hwf, hofsHdr⟩, hofsBack⟩, hOB⟩ := hofs

--- a/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
@@ -75,6 +75,9 @@ theorem Stmt.soundR (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
   | assert lbl P =>
       exact cpsTripleWithin_frameR (regOwn .x1) pcFree_regOwn
         (Stmt.sound reg rw (.assert lbl P) base pfx reach hreg hrw rfl hofs hsz hcode hvcs)
+  | ghost lbl f =>
+      exact cpsTripleWithin_frameR (regOwn .x1) pcFree_regOwn
+        (Stmt.sound reg rw (.ghost lbl f) base pfx reach hreg hrw rfl hofs hsz hcode hvcs)
   | seq a b iha ihb =>
       simp only [Stmt.offsetsOk, Bool.and_eq_true] at hofs
       simp only [Stmt.size] at hsz

--- a/EvmAsm/Rv64/SAsm/Vc.lean
+++ b/EvmAsm/Rv64/SAsm/Vc.lean
@@ -97,6 +97,7 @@ def sp (reg : Region) (rw : RwRegion) : Stmt → Reach → Reach
       sp reg rw b (fun rf ws A => reach rf ws A ∧ c.holds rf) rf' ws' A'
         ∨ (reach rf' ws' A' ∧ ¬ c.holds rf')
   | assert _ P, reach => fun rf ws A => reach rf ws A ∧ P rf ws A
+  | ghost _ f, reach => fun rf ws A' => ∃ A, reach rf ws A ∧ A' = f rf ws A
   | «while» _ c fuel inv _, _ =>
       fun rf ws A => (∃ i, i ≤ fuel ∧ inv i rf ws A) ∧ ¬ c.holds rf
   | call _ f, _ => fun rf ws A => f.post rf ws A
@@ -119,6 +120,9 @@ def vcs (reg : Region) (rw : RwRegion) : Stmt → String → Reach → List VC
       vcs reg rw b (pfx ++ lbl ++ ".") (fun rf ws A => reach rf ws A ∧ c.holds rf)
   | assert lbl P, pfx, reach =>
       [⟨pfx ++ lbl, ∀ rf ws A, reach rf ws A → P rf ws A⟩]
+  | ghost lbl f, pfx, reach =>
+      [⟨pfx ++ lbl, ∀ rf ws A, reach rf ws A → A.pcFree →
+          (∀ hp, A hp → f rf ws A hp) ∧ (f rf ws A).pcFree⟩]
   | «while» lbl c fuel inv b, pfx, reach =>
       ⟨pfx ++ lbl ++ ".inv_init", ∀ rf ws A, reach rf ws A → inv 0 rf ws A⟩ ::
       ⟨pfx ++ lbl ++ ".inv_step", ∀ i, i < fuel →
@@ -138,6 +142,7 @@ def steps : Stmt → Nat
   | ite _ _ t e => 1 + max (t.steps + 1) e.steps
   | when _ _ b => 1 + b.steps
   | assert _ _ => 0
+  | ghost _ _ => 0
   | «while» _ _ fuel _ b => WP.loopBound 1 (b.steps + 1) 1 fuel
   | call _ f => 1 + f.nSteps
 
@@ -161,6 +166,9 @@ theorem sp_mono (reg : Region) (rw : RwRegion) (s : Stmt) {r₁ r₂ : Reach}
       · exact Or.inr ⟨h rf ws A hskip.1, hskip.2⟩
   | assert lbl P =>
       exact fun rf ws A hr => ⟨h rf ws A hr.1, hr.2⟩
+  | ghost lbl f =>
+      rintro rf ws A' ⟨A, hr, rfl⟩
+      exact ⟨A, h rf ws A hr, rfl⟩
   | «while» lbl c fuel inv b ihb =>
       exact fun rf ws A hr => hr
   | call lbl f =>
@@ -212,6 +220,11 @@ theorem vcs_antitone (reg : Region) (rw : RwRegion) (s : Stmt) (pfx : String)
       simp only [vcs, List.mem_singleton] at hvc
       subst hvc
       exact fun rf ws A hr => hvcs.head rf ws A (h rf ws A hr)
+  | ghost lbl f =>
+      intro vc hvc
+      simp only [vcs, List.mem_singleton] at hvc
+      subst hvc
+      exact fun rf ws A hr hApc => hvcs.head rf ws A (h rf ws A hr) hApc
   | «while» lbl c fuel inv b ihb =>
       intro vc hvc
       simp only [vcs, List.mem_cons] at hvc
@@ -237,6 +250,7 @@ def CalleesIn (s : Stmt) (reg : Region) (rw : RwRegion) (cr : CodeReq) : Prop :=
   | ite _ _ t e => t.CalleesIn reg rw cr ∧ e.CalleesIn reg rw cr
   | when _ _ b => b.CalleesIn reg rw cr
   | assert _ _ => True
+  | ghost _ _ => True
   | «while» _ _ _ _ b => b.CalleesIn reg rw cr
   | call _ f => (∀ a i, f.code a = some i → cr a = some i)
       ∧ f.region = reg ∧ f.rw = rw

--- a/PLAN.md
+++ b/PLAN.md
@@ -2508,7 +2508,10 @@ frame rule at call granularity (callee needing A₀ callable where the
 caller holds A₀ ** Fr), derived generically with NO soundness-induction
 change (asrtOf_frameA/asrtM_frameA). Demo: cellKeepFn (ambient-cell
 contract, published via SpecA) called by twoCellsFn through frameA.
-Next stages: ghost/focus nodes,
+Stage 3a landed: `.ghost` statement node —
+zero-code reshaping of the ambient assertion by a pointwise entailment
+(one VC: entailment + pcFree of the result); the fold/unfold vehicle
+for recursive predicates. Next stages: focus blocks (.blockAt),
 tree library + sorted-BST insertion demo, docs/sasm-howto.md.
 read_active_fork ported (ActiveForkSAsm.lean:
 byte-wise u32-at-cfg+8 + u64 fork read, drop-in read_active_fork_verified


### PR DESCRIPTION
Stage 3a of the Assertion-state milestone.

## `.ghost` — zero-code reshaping of the ambient assertion

New `Stmt` constructor `.ghost lbl f` with `f : RegFile → List (BitVec 8) → Assertion → Assertion`:

- **Emits no code** (`size`/`steps` = 0; mirrors `assert` through `flatten`/`offsetsOk`/`callsOk`/`CalleesIn`).
- **`sp`**: the ambient assertion `A` is replaced by `f rf ws A` (existentially recorded, so downstream reaches see the new shape).
- **One labeled VC**: `∀ rf ws A, reach rf ws A → A.pcFree → (∀ hp, A hp → f rf ws A hp) ∧ (f rf ws A).pcFree` — a pointwise entailment plus pc-freedom of the result. In practice `f` ignores the old `A`'s value (the reach pins its shape) and the entailment is a fold/unfold lemma of the user's predicate.

This is the vehicle for opening `treeAt p (node k l r)` into `nodeBytes ** treeAt pl l ** treeAt pr r`, pushing/popping zipper frames, etc., in the upcoming tree stages.

Soundness is a zero-step `cpsTripleWithin_entails`: `sepConj_mono_right` with the VC's entailment applied inside the `asrtOf` bundle; the caller-shaped induction delegates exactly like `assert`. `vcgen` needed no changes.

## Demo

`swapCellsFn` commutes two ambient memory cells purely via a ghost step — the entailment VC discharges with `sepConj_comm`, the `.post` VC is `rfl`.

Kernel-clean; zero warnings; forbidden-tactics OK; no emitted-code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
