### PR TITLE
feat(sasm): focus blocks (.blockAt) — pointer-owned memory with pure VCs (stage 3b)

### DIFF
--- a/EvmAsm/Rv64/SAsm/Ast.lean
+++ b/EvmAsm/Rv64/SAsm/Ast.lean
@@ -112,6 +112,23 @@ inductive Stmt where
       every reachable register file satisfies `P`, and strengthens the
       reachable set with `P` downstream (a proof cut). -/
   | assert (label : String) (P : RegFile → List (BitVec 8) → Assertion → Prop)
+  /-- Focus block: a straight-line block whose *writable window* is a
+      `bytesRegion` at the address held in register `ptr`, opened out of
+      the ambient assertion for the block's duration.  The annotation
+      `win` names the decomposition (window bytes, remainder assertion) as
+      a function of the entry state — like loop invariants, the
+      factorization of a destructed assertion is user-supplied, so `sp`
+      stays fully determined and post-state VCs compute.  The generator
+      emits a `.focus` VC demanding the ambient assertion equal
+      `bytesRegion (rf.get ptr) (win …).1 ** (win …).2`.  The function's
+      flat rw window is framed — inaccessible inside the block; the
+      read-only region stays readable.  This is how SAsm code reads and
+      writes pointer-owned memory (tree nodes, list cells) with pure
+      VCs. -/
+  | blockAt (label : String) (ptr : Reg)
+            (win : RegFile → List (BitVec 8) → Assertion →
+              List (BitVec 8) × Assertion)
+            (instrs : List Instr)
   /-- Ghost step: emits no code; replaces the ambient assertion `A` by
       `f rf ws A`, justified by one VC demanding a pointwise entailment
       (and pc-freedom of the result).  This is how recursive predicates
@@ -144,6 +161,7 @@ def size : Stmt → Nat
   | when _ _ b        => b.size + 1
   | assert _ _        => 0
   | ghost _ _         => 0
+  | blockAt _ _ _ is  => is.length
   | «while» _ _ _ _ b   => b.size + 2
   | call _ _          => 1
 
@@ -160,6 +178,7 @@ def callFree : Stmt → Bool
   | when _ _ b        => b.callFree
   | assert _ _        => true
   | ghost _ _         => true
+  | blockAt _ _ _ _   => true
   | «while» _ _ _ _ b => b.callFree
   | call _ _          => false
 

--- a/EvmAsm/Rv64/SAsm/ExamplesVc.lean
+++ b/EvmAsm/Rv64/SAsm/ExamplesVc.lean
@@ -860,6 +860,70 @@ theorem swapCellsFn_spec (v w base : Word) : (swapCellsFn v w).Spec base := by
     rintro rf ws A' ⟨A, hA, rfl⟩
     rfl
 
+-- ============================================================================
+-- Focus blocks: reading pointer-owned memory through the ambient assertion
+-- ============================================================================
+
+/-- Load the dword that the ambient assertion owns at the address in `a1`:
+    the focus block opens the cell as the block's writable window (the
+    annotation names the decomposition), the load routes into it, and a
+    ghost step reseals the ambient assertion. -/
+def focusReadFn (q v : Word) : Fn where
+  name := "focusRead"
+  pre := fun rf _ A => rf.get .x11 = q ∧ A = bytesRegion q (dwordBytes v)
+  post := fun rf _ A => rf.get .x10 = v ∧ A = bytesRegion q (dwordBytes v)
+  body :=
+    .blockAt "win" .x11 (fun _ _ _ => (dwordBytes v, empAssertion))
+      [.LD .x10 .x11 0] ;;;
+    .ghost "seal" (fun _ _ _ => bytesRegion q (dwordBytes v))
+
+theorem focusReadFn_spec (q v base : Word) (hwf : RwRegion.wf ⟨q, 8⟩) :
+    (focusReadFn q v).Spec base := by
+  have hidx : ∀ rf : RegFile, rf.get .x11 = q →
+      ((rf.get .x11 + signExtend12 (0 : BitVec 12)) - rf.get .x11).toNat = 0 := by
+    intro rf _
+    rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]
+    bv_omega
+  vcgen
+  case focusRead.win.focus =>
+    rintro rf ws A ⟨hx11, hA⟩
+    refine ⟨?_, pcFree_emp, ?_⟩
+    · rw [sepConj_emp_right', hx11]
+      exact hA
+    · rw [hx11, length_dwordBytes]
+      exact hwf
+  case focusRead.win.mem =>
+    rintro rf ws A hws ⟨hx11, hA⟩
+    simp only [blockVCs, loadSem, inRw, Region.loadOk,
+      hidx rf hx11, length_dwordBytes]
+    rw [if_pos (by omega)]
+    exact ⟨⟨by omega, by omega⟩, trivial⟩
+  case focusRead.seal =>
+    rintro rf ws A ⟨rf₀, A₀, hlen, ⟨hx11, hA₀⟩, hAeq, rfl, rfl⟩ hApc
+    refine ⟨?_, bytesRegion_pcFree _ _⟩
+    intro hp hh
+    rw [sepConj_emp_right'] at hh
+    rw [← hx11]
+    -- the window after a pure load is definitionally unchanged
+    exact hh
+  case focusRead.post =>
+    rintro rf' ws' A' ⟨A1, ⟨rf₀, A₀, hlen, ⟨hx11, hA₀⟩, hAeq, rfl, rfl⟩, rfl⟩
+    refine ⟨?_, rfl⟩
+    simp only [execBlock_cons, execBlock_nil, execInstrRF, loadSem, aluSem]
+    rw [if_pos (show inRw (rf₀.get .x11) (dwordBytes v)
+        (rf₀.get .x11 + signExtend12 0) 8 from by
+      unfold inRw
+      rw [hidx rf₀ hx11, length_dwordBytes])]
+    rw [RegFile.get_set_self _ _ _ (by decide)]
+    show Region.dwordAt ⟨rf₀.get .x11, dwordBytes v⟩
+      (rf₀.get .x11 + signExtend12 0) = v
+    unfold Region.dwordAt
+    rw [show ((rf₀.get .x11 + signExtend12 0)
+        - (⟨rf₀.get .x11, dwordBytes v⟩ : Region).base).toNat = 0 from
+      hidx rf₀ hx11]
+    rw [List.drop_zero, List.take_of_length_le (by rw [length_dwordBytes])]
+    exact packBytes_dwordBytes v
+
 end ExamplesVc
 end SAsm
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/Flatten.lean
+++ b/EvmAsm/Rv64/SAsm/Flatten.lean
@@ -56,6 +56,8 @@ def flatten (addr : Word) : Stmt → List Instr
       []
   | ghost _ _ =>
       []
+  | blockAt _ _ _ is =>
+      is
   | «while» _ c _ _ b =>
       c.neg.toInstr (brOfs (b.size + 2))
         :: (b.flatten (addr + 4) ++ [.JAL .x0 (jBack (b.size + 1))])
@@ -75,6 +77,7 @@ theorem flatten_length (s : Stmt) (addr : Word) :
       simp [flatten, size, ihb]
   | assert _ _ => rfl
   | ghost _ _ => rfl
+  | blockAt _ _ _ _ => rfl
   | «while» _ c fuel inv b ihb =>
       simp [flatten, size, ihb]
   | call _ callee => rfl
@@ -96,6 +99,7 @@ def offsetsOk : Stmt → Bool
       c.wf && decide (4 * (b.size + 1) < 2^12) && b.offsetsOk
   | assert _ _ => true
   | ghost _ _ => true
+  | blockAt _ _ _ _ => true
   | «while» _ c _ _ b =>
       c.wf && decide (4 * (b.size + 2) < 2^12)
            && decide (4 * (b.size + 1) ≤ 2^20)
@@ -116,6 +120,7 @@ def callsOk : Stmt → Word → Prop
   | when _ _ b, addr => b.callsOk (addr + 4)
   | assert _ _, _ => True
   | ghost _ _, _ => True
+  | blockAt _ _ _ _, _ => True
   | «while» _ _ _ _ b, addr => b.callsOk (addr + 4)
   | call _ f, addr =>
       addr + signExtend21 (BitVec.setWidth 21 (f.entry - addr)) = f.entry

--- a/EvmAsm/Rv64/SAsm/StmtSound.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSound.lean
@@ -378,6 +378,50 @@ theorem Stmt.sound (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
       simp only [Stmt.steps]
       rw [hz]
       exact h
+  | blockAt lbl p winF is =>
+      have hok : blockOk is = true := hvcs.head
+      have hfocus : ∀ rf ws A, reach rf ws A →
+          A = (bytesRegion (rf.get p) (winF rf ws A).1 ** (winF rf ws A).2)
+          ∧ (winF rf ws A).2.pcFree
+          ∧ RwRegion.wf ⟨rf.get p, (winF rf ws A).1.length⟩ := hvcs.tail.head
+      have hmem : ∀ rf ws A, ws.length = rw.len → reach rf ws A →
+          blockVCs reg (rf.get p) rf (winF rf ws A).1 is := by
+        by_cases hl : hasLoad is
+        · have ht := hvcs.tail.tail
+          simp only [hl, if_true] at ht
+          exact ht.head
+        · exact fun rf ws A _ _ =>
+            blockVCs_of_not_hasLoad reg (rf.get p) rf (winF rf ws A).1 is
+              (by simpa using hl)
+      apply cpsTripleWithin_exists_pre_M
+      intro rf ws A hlen hApc hreach
+      obtain ⟨hAeq, hArpc, hwf⟩ := hfocus rf ws A hreach
+      have h := execBlock_sound reg ⟨rf.get p, (winF rf ws A).1.length⟩ is rf
+        (winF rf ws A).1 base hreg hwf rfl hok (hmem rf ws A hlen hreach)
+        (by simpa [Stmt.size] using hsz)
+      have hA2 := cpsTripleWithin_frameR
+        (bytesRegion rw.base ws ** (winF rf ws A).2)
+        (pcFree_sepConj (bytesRegion_pcFree _ _) hArpc) h
+      have h' := cpsTripleWithin_extend_code hcode hA2
+      refine cpsTripleWithin_weaken ?_ ?_ h'
+      · intro hp hh
+        rw [hAeq] at hh
+        xperm_hyp hh
+      · intro hp hh
+        have hh2 : ((((regFileIs
+              (execBlock reg (rf.get p) rf (winF rf ws A).1 is).1) **
+            bytesRegion rw.base ws) **
+            (bytesRegion (rf.get p)
+              (execBlock reg (rf.get p) rf (winF rf ws A).1 is).2
+              ** (winF rf ws A).2)) **
+            bytesRegion reg.base reg.bytes) hp := by xperm_hyp hh
+        exact sepConj_mono_left (fun hq hx =>
+          ⟨(execBlock reg (rf.get p) rf (winF rf ws A).1 is).1, ws,
+            (bytesRegion (rf.get p)
+              (execBlock reg (rf.get p) rf (winF rf ws A).1 is).2
+              ** (winF rf ws A).2),
+            hlen, pcFree_sepConj (bytesRegion_pcFree _ _) hArpc,
+            ⟨rf, A, hlen, hreach, hAeq, rfl, rfl⟩, hx⟩) hp hh2
   | ghost lbl f =>
       have hvc := hvcs _ (List.mem_singleton_self _)
       have h : cpsTripleWithin 0 base base cr (asrtM reg rw reach)

--- a/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
@@ -78,6 +78,10 @@ theorem Stmt.soundR (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
   | ghost lbl f =>
       exact cpsTripleWithin_frameR (regOwn .x1) pcFree_regOwn
         (Stmt.sound reg rw (.ghost lbl f) base pfx reach hreg hrw rfl hofs hsz hcode hvcs)
+  | blockAt lbl p winF is =>
+      exact cpsTripleWithin_frameR (regOwn .x1) pcFree_regOwn
+        (Stmt.sound reg rw (.blockAt lbl p winF is) base pfx reach hreg hrw rfl hofs hsz
+          hcode hvcs)
   | seq a b iha ihb =>
       simp only [Stmt.offsetsOk, Bool.and_eq_true] at hofs
       simp only [Stmt.size] at hsz

--- a/EvmAsm/Rv64/SAsm/Vc.lean
+++ b/EvmAsm/Rv64/SAsm/Vc.lean
@@ -98,6 +98,13 @@ def sp (reg : Region) (rw : RwRegion) : Stmt → Reach → Reach
         ∨ (reach rf' ws' A' ∧ ¬ c.holds rf')
   | assert _ P, reach => fun rf ws A => reach rf ws A ∧ P rf ws A
   | ghost _ f, reach => fun rf ws A' => ∃ A, reach rf ws A ∧ A' = f rf ws A
+  | blockAt _ p winF is, reach => fun rf' ws' A'' => ∃ rf A,
+      ws'.length = rw.len ∧ reach rf ws' A
+      ∧ A = (bytesRegion (rf.get p) (winF rf ws' A).1 ** (winF rf ws' A).2)
+      ∧ rf' = (execBlock reg (rf.get p) rf (winF rf ws' A).1 is).1
+      ∧ A'' = (bytesRegion (rf.get p)
+            (execBlock reg (rf.get p) rf (winF rf ws' A).1 is).2
+          ** (winF rf ws' A).2)
   | «while» _ c fuel inv _, _ =>
       fun rf ws A => (∃ i, i ≤ fuel ∧ inv i rf ws A) ∧ ¬ c.holds rf
   | call _ f, _ => fun rf ws A => f.post rf ws A
@@ -123,6 +130,16 @@ def vcs (reg : Region) (rw : RwRegion) : Stmt → String → Reach → List VC
   | ghost lbl f, pfx, reach =>
       [⟨pfx ++ lbl, ∀ rf ws A, reach rf ws A → A.pcFree →
           (∀ hp, A hp → f rf ws A hp) ∧ (f rf ws A).pcFree⟩]
+  | blockAt lbl p winF is, pfx, reach =>
+      ⟨pfx ++ lbl ++ ".ok", blockOk is = true⟩ ::
+      ⟨pfx ++ lbl ++ ".focus", ∀ rf ws A, reach rf ws A →
+          A = (bytesRegion (rf.get p) (winF rf ws A).1 ** (winF rf ws A).2)
+          ∧ (winF rf ws A).2.pcFree
+          ∧ RwRegion.wf ⟨rf.get p, (winF rf ws A).1.length⟩⟩ ::
+      (if hasLoad is then
+        [⟨pfx ++ lbl ++ ".mem", ∀ rf ws A, ws.length = rw.len →
+            reach rf ws A → blockVCs reg (rf.get p) rf (winF rf ws A).1 is⟩]
+      else [])
   | «while» lbl c fuel inv b, pfx, reach =>
       ⟨pfx ++ lbl ++ ".inv_init", ∀ rf ws A, reach rf ws A → inv 0 rf ws A⟩ ::
       ⟨pfx ++ lbl ++ ".inv_step", ∀ i, i < fuel →
@@ -143,6 +160,7 @@ def steps : Stmt → Nat
   | when _ _ b => 1 + b.steps
   | assert _ _ => 0
   | ghost _ _ => 0
+  | blockAt _ _ _ is => is.length
   | «while» _ _ fuel _ b => WP.loopBound 1 (b.steps + 1) 1 fuel
   | call _ f => 1 + f.nSteps
 
@@ -169,6 +187,9 @@ theorem sp_mono (reg : Region) (rw : RwRegion) (s : Stmt) {r₁ r₂ : Reach}
   | ghost lbl f =>
       rintro rf ws A' ⟨A, hr, rfl⟩
       exact ⟨A, h rf ws A hr, rfl⟩
+  | blockAt lbl p winF is =>
+      rintro rf' ws' A'' ⟨rf, A, hlen, hr, hAeq, hrf, hA⟩
+      exact ⟨rf, A, hlen, h rf ws' A hr, hAeq, hrf, hA⟩
   | «while» lbl c fuel inv b ihb =>
       exact fun rf ws A hr => hr
   | call lbl f =>
@@ -225,6 +246,31 @@ theorem vcs_antitone (reg : Region) (rw : RwRegion) (s : Stmt) (pfx : String)
       simp only [vcs, List.mem_singleton] at hvc
       subst hvc
       exact fun rf ws A hr hApc => hvcs.head rf ws A (h rf ws A hr) hApc
+  | blockAt lbl p winF is =>
+      intro vc hvc
+      simp only [vcs, List.mem_cons] at hvc
+      rcases hvc with rfl | rfl | hvc
+      · exact hvcs.head
+      · exact fun rf ws A hr => hvcs.tail.head rf ws A (h rf ws A hr)
+      · by_cases hl : hasLoad is
+        · rw [if_pos hl] at hvc
+          rw [show vcs reg rw (.blockAt lbl p winF is) pfx r₂
+              = ⟨pfx ++ lbl ++ ".ok", blockOk is = true⟩ ::
+                ⟨pfx ++ lbl ++ ".focus", ∀ rf ws A, r₂ rf ws A →
+                    A = (bytesRegion (rf.get p) (winF rf ws A).1
+                      ** (winF rf ws A).2)
+                    ∧ (winF rf ws A).2.pcFree
+                    ∧ RwRegion.wf ⟨rf.get p, (winF rf ws A).1.length⟩⟩ ::
+                [⟨pfx ++ lbl ++ ".mem", ∀ rf ws A, ws.length = rw.len →
+                    r₂ rf ws A →
+                    blockVCs reg (rf.get p) rf (winF rf ws A).1 is⟩]
+            from by simp [vcs, hl]] at hvcs
+          simp only [List.mem_singleton] at hvc
+          subst hvc
+          exact fun rf ws A hlen hr =>
+            hvcs.tail.tail.head rf ws A hlen (h rf ws A hr)
+        · rw [if_neg hl] at hvc
+          exact absurd hvc (List.not_mem_nil)
   | «while» lbl c fuel inv b ihb =>
       intro vc hvc
       simp only [vcs, List.mem_cons] at hvc
@@ -251,6 +297,7 @@ def CalleesIn (s : Stmt) (reg : Region) (rw : RwRegion) (cr : CodeReq) : Prop :=
   | when _ _ b => b.CalleesIn reg rw cr
   | assert _ _ => True
   | ghost _ _ => True
+  | blockAt _ _ _ _ => True
   | «while» _ _ _ _ b => b.CalleesIn reg rw cr
   | call _ f => (∀ a i, f.code a = some i → cr a = some i)
       ∧ f.region = reg ∧ f.rw = rw

--- a/PLAN.md
+++ b/PLAN.md
@@ -2511,7 +2511,13 @@ contract, published via SpecA) called by twoCellsFn through frameA.
 Stage 3a landed: `.ghost` statement node —
 zero-code reshaping of the ambient assertion by a pointwise entailment
 (one VC: entailment + pcFree of the result); the fold/unfold vehicle
-for recursive predicates. Next stages: focus blocks (.blockAt),
+for recursive predicates. Stage 3b landed: focus blocks (`.blockAt ptr winF is`) — a block whose
+writable window is a bytesRegion at the register-held `ptr`, opened out
+of the ambient assertion for the block; the decomposition (window bytes,
+remainder) is a user annotation on the node, so sp stays fully
+determined and post-VCs compute. VCs: .ok, .focus (decomposition eq +
+remainder pcFree + window RwRegion.wf), .mem (window-routed blockVCs).
+Next stages:
 tree library + sorted-BST insertion demo, docs/sasm-howto.md.
 read_active_fork ported (ActiveForkSAsm.lean:
 byte-wise u32-at-cfg+8 + u64 fork read, drop-in read_active_fork_verified


### PR DESCRIPTION
Stage 3b of the Assertion-state milestone: the last framework piece before the tree library — SAsm code can now read/write **pointer-owned memory** (tree nodes, list cells) with pure VCs.

## `.blockAt lbl ptr winF is`

A straight-line block whose *writable window* is the `bytesRegion` at the address held in register `ptr`, opened out of the ambient assertion for the block's duration:

- The **decomposition is a user annotation** on the node: `winF : RegFile → List Byte → Assertion → List Byte × Assertion` names (window bytes, remainder assertion) as a function of the entry state. Like loop invariants, factorizations of destructed assertions are supplied rather than searched — so `sp` stays fully determined and post-state VCs *compute* through the pure block engine. (A first design with the decomposition existentially quantified in `sp` was scrapped: it pushed assertion-equality inversion onto every post-VC.)
- The function's flat rw window is **framed** (inaccessible inside the block); the read-only region stays readable; loads/stores route by address against the focused window — the block engine was already base-parametric, so no engine changes.
- VCs: `.ok` (block support), `.focus` (ambient = `bytesRegion (rf.get ptr) win ** rest`, `rest` pc-free, window-as-`RwRegion` well-formed), `.mem` (window-routed `blockVCs`, only when the block touches memory).
- Soundness: `execBlock_sound` at `rw := ⟨rf.get ptr, |win|⟩` with the flat window + remainder framed; `xperm` handles the atom permutations. Caller-shaped induction delegates like `block`; `vcgen` unchanged.

## Demo

`focusReadFn q v`: pre `{a1 = q, A = bytesRegion q (dwordBytes v)}` — focus-open the cell, `LD a0, 0(a1)` routed into it, ghost-reseal — post `{a0 = v, A intact}`. The `.post` VC computes the loaded value through the engine down to `packBytes_dwordBytes`.

Together with `.ghost` (#9683) and `frameA` (#9682), this completes the mechanism set for the sorted-BST insertion demo: unfold `treeAt` (ghost) → focus the node (blockAt) → compare/descend (pure engine) → reseal/fold (ghost), with callee framing at calls.

Kernel-clean; zero warnings; forbidden-tactics OK; no emitted-code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
