### PR TITLE
feat(sasm): relational ghost/focus annotations + satisfiability harvest (stage 4.5)

### DIFF
--- a/EvmAsm/Rv64/SAsm/Ast.lean
+++ b/EvmAsm/Rv64/SAsm/Ast.lean
@@ -115,27 +115,30 @@ inductive Stmt where
   /-- Focus block: a straight-line block whose *writable window* is a
       `bytesRegion` at the address held in register `ptr`, opened out of
       the ambient assertion for the block's duration.  The annotation
-      `win` names the decomposition (window bytes, remainder assertion) as
-      a function of the entry state — like loop invariants, the
-      factorization of a destructed assertion is user-supplied, so `sp`
-      stays fully determined and post-state VCs compute.  The generator
-      emits a `.focus` VC demanding the ambient assertion equal
-      `bytesRegion (rf.get ptr) (win …).1 ** (win …).2`.  The function's
-      flat rw window is framed — inaccessible inside the block; the
-      read-only region stays readable.  This is how SAsm code reads and
-      writes pointer-owned memory (tree nodes, list cells) with pure
-      VCs. -/
+      `winR` *relates* the entry state to the decomposition (window bytes,
+      remainder assertion) — relational rather than functional so it can
+      name existentially-quantified ghosts from the ambient invariant
+      (zipper contexts, subtrees).  The generator emits a `.focus` VC
+      demanding a related decomposition exist with
+      `A = bytesRegion (rf.get ptr) win ** rest`.  The function's flat rw
+      window is framed — inaccessible inside the block; the read-only
+      region stays readable.  This is how SAsm code reads and writes
+      pointer-owned memory (tree nodes, list cells) with pure VCs. -/
   | blockAt (label : String) (ptr : Reg)
-            (win : RegFile → List (BitVec 8) → Assertion →
-              List (BitVec 8) × Assertion)
+            (winR : RegFile → List (BitVec 8) → Assertion →
+              List (BitVec 8) → Assertion → Prop)
             (instrs : List Instr)
-  /-- Ghost step: emits no code; replaces the ambient assertion `A` by
-      `f rf ws A`, justified by one VC demanding a pointwise entailment
-      (and pc-freedom of the result).  This is how recursive predicates
-      are folded/unfolded mid-body (open a tree node, push a zipper
-      frame, …). -/
+  /-- Ghost step: emits no code; replaces the ambient assertion `A` by an
+      `R`-related `A'`, justified by one VC producing such an `A'` with a
+      pointwise entailment (and pc-freedom).  Relational rather than
+      functional so the new assertion can be built from
+      existentially-quantified ghosts.  The strongest postcondition also
+      records satisfiability of the old `A` — the *harvest* by which pure
+      facts trapped inside the assertion (`p = 0` at a leaf, …) reach the
+      pure VCs.  This is how recursive predicates are folded/unfolded
+      mid-body (open a tree node, push a zipper frame, …). -/
   | ghost  (label : String)
-           (f : RegFile → List (BitVec 8) → Assertion → Assertion)
+           (R : RegFile → List (BitVec 8) → Assertion → Assertion → Prop)
   /-- Bounded loop: the body runs while `c` holds, at most `fuel` iterations.
       `inv i` must hold at the i-th evaluation of the header; the generator
       emits initialization, preservation, and fuel-exhaustion VCs. -/

--- a/EvmAsm/Rv64/SAsm/ExamplesVc.lean
+++ b/EvmAsm/Rv64/SAsm/ExamplesVc.lean
@@ -845,19 +845,19 @@ def swapCellsFn (v w : Word) : Fn where
   post := fun _ _ A =>
     A = (((0x10108 : Word) ↦ₘ w) ** ((0x10100 : Word) ↦ₘ v))
   body := .ghost "swap"
-    (fun _ _ _ => ((0x10108 : Word) ↦ₘ w) ** ((0x10100 : Word) ↦ₘ v))
+    (fun _ _ _ A' => A' = (((0x10108 : Word) ↦ₘ w) ** ((0x10100 : Word) ↦ₘ v)))
 
 theorem swapCellsFn_spec (v w base : Word) : (swapCellsFn v w).Spec base := by
   vcgen
   case swapCells.swap =>
-    rintro rf ws A hA hApc
-    refine ⟨?_, pcFree_sepConj pcFree_memIs pcFree_memIs⟩
+    rintro rf ws A hA hApc hsat
+    refine ⟨_, rfl, ?_, pcFree_sepConj pcFree_memIs pcFree_memIs⟩
     intro hp hh
     rw [hA] at hh
     rw [sepConj_comm']
     exact hh
   case swapCells.post =>
-    rintro rf ws A' ⟨A, hA, rfl⟩
+    rintro rf ws A' ⟨A, hA, hsat, rfl⟩
     rfl
 
 -- ============================================================================
@@ -873,9 +873,10 @@ def focusReadFn (q v : Word) : Fn where
   pre := fun rf _ A => rf.get .x11 = q ∧ A = bytesRegion q (dwordBytes v)
   post := fun rf _ A => rf.get .x10 = v ∧ A = bytesRegion q (dwordBytes v)
   body :=
-    .blockAt "win" .x11 (fun _ _ _ => (dwordBytes v, empAssertion))
+    .blockAt "win" .x11
+      (fun _ _ _ win rest => win = dwordBytes v ∧ rest = empAssertion)
       [.LD .x10 .x11 0] ;;;
-    .ghost "seal" (fun _ _ _ => bytesRegion q (dwordBytes v))
+    .ghost "seal" (fun _ _ _ A' => A' = bytesRegion q (dwordBytes v))
 
 theorem focusReadFn_spec (q v base : Word) (hwf : RwRegion.wf ⟨q, 8⟩) :
     (focusReadFn q v).Spec base := by
@@ -886,28 +887,30 @@ theorem focusReadFn_spec (q v base : Word) (hwf : RwRegion.wf ⟨q, 8⟩) :
     bv_omega
   vcgen
   case focusRead.win.focus =>
-    rintro rf ws A ⟨hx11, hA⟩
-    refine ⟨?_, pcFree_emp, ?_⟩
+    rintro rf ws A ⟨hx11, hA⟩ hApc hsat
+    refine ⟨dwordBytes v, empAssertion, ⟨rfl, rfl⟩, ?_, pcFree_emp, ?_⟩
     · rw [sepConj_emp_right', hx11]
       exact hA
     · rw [hx11, length_dwordBytes]
       exact hwf
   case focusRead.win.mem =>
-    rintro rf ws A hws ⟨hx11, hA⟩
+    rintro rf ws A win rest hws ⟨hx11, hA⟩ ⟨rfl, rfl⟩ hAeq
     simp only [blockVCs, loadSem, inRw, Region.loadOk,
       hidx rf hx11, length_dwordBytes]
     rw [if_pos (by omega)]
     exact ⟨⟨by omega, by omega⟩, trivial⟩
   case focusRead.seal =>
-    rintro rf ws A ⟨rf₀, A₀, hlen, ⟨hx11, hA₀⟩, hAeq, rfl, rfl⟩ hApc
-    refine ⟨?_, bytesRegion_pcFree _ _⟩
+    rintro rf ws A ⟨rf₀, A₀, win, rest, hlen, ⟨hx11, hA₀⟩, hsat, ⟨rfl, rfl⟩,
+      hAeq, rfl, rfl⟩ hApc hsat'
+    refine ⟨_, rfl, ?_, bytesRegion_pcFree _ _⟩
     intro hp hh
     rw [sepConj_emp_right'] at hh
     rw [← hx11]
     -- the window after a pure load is definitionally unchanged
     exact hh
   case focusRead.post =>
-    rintro rf' ws' A' ⟨A1, ⟨rf₀, A₀, hlen, ⟨hx11, hA₀⟩, hAeq, rfl, rfl⟩, rfl⟩
+    rintro rf' ws' A' ⟨A1, ⟨rf₀, A₀, win, rest, hlen, ⟨hx11, hA₀⟩, hsat,
+      ⟨rfl, rfl⟩, hAeq, rfl, rfl⟩, hsat1, rfl⟩
     refine ⟨?_, rfl⟩
     simp only [execBlock_cons, execBlock_nil, execInstrRF, loadSem, aluSem]
     rw [if_pos (show inRw (rf₀.get .x11) (dwordBytes v)
@@ -923,6 +926,32 @@ theorem focusReadFn_spec (q v base : Word) (hwf : RwRegion.wf ⟨q, 8⟩) :
       hidx rf₀ hx11]
     rw [List.drop_zero, List.take_of_length_le (by rw [length_dwordBytes])]
     exact packBytes_dwordBytes v
+
+/-- Harvesting a pure fact trapped inside the ambient assertion: ghost
+    steps receive satisfiability of the current `A`, so facts baked into
+    predicates (`⌜…⌝` conjuncts: nil-pointers, node well-formedness) reach
+    the pure VCs through the ghost relation. -/
+def harvestFn (n : Word) : Fn where
+  name := "harvest"
+  pre := fun _ _ A => A = (⌜n = 7⌝ ** empAssertion)
+  post := fun _ _ A => A = empAssertion ∧ n = 7
+  body := .ghost "get" (fun _ _ _ A' => A' = empAssertion ∧ n = 7)
+
+theorem harvestFn_spec (n base : Word) : (harvestFn n).Spec base := by
+  vcgen
+  case harvest.get =>
+    rintro rf ws A hA hApc hsat
+    have h7 : n = 7 := by
+      obtain ⟨hp, hhp⟩ := hsat
+      rw [hA] at hhp
+      exact ((sepConj_pure_left hp).mp hhp).1
+    refine ⟨empAssertion, ⟨rfl, h7⟩, ?_, pcFree_emp⟩
+    intro hp hh
+    rw [hA] at hh
+    exact ((sepConj_pure_left hp).mp hh).2
+  case harvest.post =>
+    rintro rf ws A' ⟨A, hA, hsat, rfl, h7⟩
+    exact ⟨rfl, h7⟩
 
 end ExamplesVc
 end SAsm

--- a/EvmAsm/Rv64/SAsm/StmtSound.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSound.lean
@@ -378,62 +378,65 @@ theorem Stmt.sound (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
       simp only [Stmt.steps]
       rw [hz]
       exact h
-  | blockAt lbl p winF is =>
+  | blockAt lbl p winR is =>
       have hok : blockOk is = true := hvcs.head
-      have hfocus : ∀ rf ws A, reach rf ws A →
-          A = (bytesRegion (rf.get p) (winF rf ws A).1 ** (winF rf ws A).2)
-          ∧ (winF rf ws A).2.pcFree
-          ∧ RwRegion.wf ⟨rf.get p, (winF rf ws A).1.length⟩ := hvcs.tail.head
-      have hmem : ∀ rf ws A, ws.length = rw.len → reach rf ws A →
-          blockVCs reg (rf.get p) rf (winF rf ws A).1 is := by
+      have hfocus : ∀ rf ws A, reach rf ws A → A.pcFree → (∃ hp, A hp) →
+          ∃ win rest, winR rf ws A win rest
+            ∧ A = (bytesRegion (rf.get p) win ** rest)
+            ∧ rest.pcFree ∧ RwRegion.wf ⟨rf.get p, win.length⟩ := hvcs.tail.head
+      have hmem : ∀ rf ws A win rest, ws.length = rw.len → reach rf ws A →
+          winR rf ws A win rest → A = (bytesRegion (rf.get p) win ** rest) →
+          blockVCs reg (rf.get p) rf win is := by
         by_cases hl : hasLoad is
         · have ht := hvcs.tail.tail
           simp only [hl, if_true] at ht
           exact ht.head
-        · exact fun rf ws A _ _ =>
-            blockVCs_of_not_hasLoad reg (rf.get p) rf (winF rf ws A).1 is
-              (by simpa using hl)
+        · exact fun rf ws A win rest _ _ _ _ =>
+            blockVCs_of_not_hasLoad reg (rf.get p) rf win is (by simpa using hl)
       apply cpsTripleWithin_exists_pre_M
-      intro rf ws A hlen hApc hreach
-      obtain ⟨hAeq, hArpc, hwf⟩ := hfocus rf ws A hreach
-      have h := execBlock_sound reg ⟨rf.get p, (winF rf ws A).1.length⟩ is rf
-        (winF rf ws A).1 base hreg hwf rfl hok (hmem rf ws A hlen hreach)
+      intro rf ws A hlen hApc hreach R hR s hcr hPR hpc
+      have hsat : ∃ hp, A hp := by
+        obtain ⟨h0, hcompat, h1, h2, hd, hu, hP1, hR2⟩ := hPR
+        obtain ⟨h3, h4, hd2, hu2, hP3, hA4⟩ := hP1
+        exact ⟨h4, hA4⟩
+      obtain ⟨win, rest, hRw, hAeq, hrestpc, hwf⟩ :=
+        hfocus rf ws A hreach hApc hsat
+      have h := execBlock_sound reg ⟨rf.get p, win.length⟩ is rf win base hreg
+        hwf rfl hok (hmem rf ws A win rest hlen hreach hRw hAeq)
         (by simpa [Stmt.size] using hsz)
-      have hA2 := cpsTripleWithin_frameR
-        (bytesRegion rw.base ws ** (winF rf ws A).2)
-        (pcFree_sepConj (bytesRegion_pcFree _ _) hArpc) h
+      have hA2 := cpsTripleWithin_frameR (bytesRegion rw.base ws ** rest)
+        (pcFree_sepConj (bytesRegion_pcFree _ _) hrestpc) h
       have h' := cpsTripleWithin_extend_code hcode hA2
-      refine cpsTripleWithin_weaken ?_ ?_ h'
+      refine cpsTripleWithin_weaken ?_ ?_ h' R hR s hcr hPR hpc
       · intro hp hh
         rw [hAeq] at hh
         xperm_hyp hh
       · intro hp hh
-        have hh2 : ((((regFileIs
-              (execBlock reg (rf.get p) rf (winF rf ws A).1 is).1) **
+        have hh2 : ((((regFileIs (execBlock reg (rf.get p) rf win is).1) **
             bytesRegion rw.base ws) **
-            (bytesRegion (rf.get p)
-              (execBlock reg (rf.get p) rf (winF rf ws A).1 is).2
-              ** (winF rf ws A).2)) **
+            (bytesRegion (rf.get p) (execBlock reg (rf.get p) rf win is).2
+              ** rest)) **
             bytesRegion reg.base reg.bytes) hp := by xperm_hyp hh
         exact sepConj_mono_left (fun hq hx =>
-          ⟨(execBlock reg (rf.get p) rf (winF rf ws A).1 is).1, ws,
-            (bytesRegion (rf.get p)
-              (execBlock reg (rf.get p) rf (winF rf ws A).1 is).2
-              ** (winF rf ws A).2),
-            hlen, pcFree_sepConj (bytesRegion_pcFree _ _) hArpc,
-            ⟨rf, A, hlen, hreach, hAeq, rfl, rfl⟩, hx⟩) hp hh2
-  | ghost lbl f =>
+          ⟨(execBlock reg (rf.get p) rf win is).1, ws,
+            (bytesRegion (rf.get p) (execBlock reg (rf.get p) rf win is).2
+              ** rest),
+            hlen, pcFree_sepConj (bytesRegion_pcFree _ _) hrestpc,
+            ⟨rf, A, win, rest, hlen, hreach, hsat, hRw, hAeq, rfl, rfl⟩,
+            hx⟩) hp hh2
+  | ghost lbl R =>
       have hvc := hvcs _ (List.mem_singleton_self _)
       have h : cpsTripleWithin 0 base base cr (asrtM reg rw reach)
-          (asrtM reg rw (Stmt.sp reg rw (.ghost lbl f) reach)) := by
+          (asrtM reg rw (Stmt.sp reg rw (.ghost lbl R) reach)) := by
         apply cpsTripleWithin_entails
         intro hp hh
         refine sepConj_mono_left (fun hq hx => ?_) hp hh
         obtain ⟨rf, ws, A, hlen, hApc, hr, hsts⟩ := hx
-        obtain ⟨hent, hpcf⟩ := hvc rf ws A hr hApc
-        exact ⟨rf, ws, f rf ws A, hlen, hpcf, ⟨A, hr, rfl⟩,
-          sepConj_mono_right hent hq hsts⟩
-      have hz : base + BitVec.ofNat 64 (4 * Stmt.size (.ghost lbl f)) = base := by
+        obtain ⟨g1, g2, gd, gu, hin, hA⟩ := hsts
+        obtain ⟨A', hRw, hent, hpcf⟩ := hvc rf ws A hr hApc ⟨g2, hA⟩
+        exact ⟨rf, ws, A', hlen, hpcf, ⟨A, hr, ⟨g2, hA⟩, hRw⟩,
+          ⟨g1, g2, gd, gu, hin, hent g2 hA⟩⟩
+      have hz : base + BitVec.ofNat 64 (4 * Stmt.size (.ghost lbl R)) = base := by
         simp [Stmt.size]
       simp only [Stmt.steps]
       rw [hz]

--- a/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
@@ -75,12 +75,12 @@ theorem Stmt.soundR (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
   | assert lbl P =>
       exact cpsTripleWithin_frameR (regOwn .x1) pcFree_regOwn
         (Stmt.sound reg rw (.assert lbl P) base pfx reach hreg hrw rfl hofs hsz hcode hvcs)
-  | ghost lbl f =>
+  | ghost lbl R =>
       exact cpsTripleWithin_frameR (regOwn .x1) pcFree_regOwn
-        (Stmt.sound reg rw (.ghost lbl f) base pfx reach hreg hrw rfl hofs hsz hcode hvcs)
-  | blockAt lbl p winF is =>
+        (Stmt.sound reg rw (.ghost lbl R) base pfx reach hreg hrw rfl hofs hsz hcode hvcs)
+  | blockAt lbl p winR is =>
       exact cpsTripleWithin_frameR (regOwn .x1) pcFree_regOwn
-        (Stmt.sound reg rw (.blockAt lbl p winF is) base pfx reach hreg hrw rfl hofs hsz
+        (Stmt.sound reg rw (.blockAt lbl p winR is) base pfx reach hreg hrw rfl hofs hsz
           hcode hvcs)
   | seq a b iha ihb =>
       simp only [Stmt.offsetsOk, Bool.and_eq_true] at hofs

--- a/EvmAsm/Rv64/SAsm/Vc.lean
+++ b/EvmAsm/Rv64/SAsm/Vc.lean
@@ -97,14 +97,15 @@ def sp (reg : Region) (rw : RwRegion) : Stmt → Reach → Reach
       sp reg rw b (fun rf ws A => reach rf ws A ∧ c.holds rf) rf' ws' A'
         ∨ (reach rf' ws' A' ∧ ¬ c.holds rf')
   | assert _ P, reach => fun rf ws A => reach rf ws A ∧ P rf ws A
-  | ghost _ f, reach => fun rf ws A' => ∃ A, reach rf ws A ∧ A' = f rf ws A
-  | blockAt _ p winF is, reach => fun rf' ws' A'' => ∃ rf A,
-      ws'.length = rw.len ∧ reach rf ws' A
-      ∧ A = (bytesRegion (rf.get p) (winF rf ws' A).1 ** (winF rf ws' A).2)
-      ∧ rf' = (execBlock reg (rf.get p) rf (winF rf ws' A).1 is).1
-      ∧ A'' = (bytesRegion (rf.get p)
-            (execBlock reg (rf.get p) rf (winF rf ws' A).1 is).2
-          ** (winF rf ws' A).2)
+  | ghost _ R, reach => fun rf ws A' => ∃ A, reach rf ws A
+      ∧ (∃ hp, A hp) ∧ R rf ws A A'
+  | blockAt _ p winR is, reach => fun rf' ws' A'' => ∃ rf A win rest,
+      ws'.length = rw.len ∧ reach rf ws' A ∧ (∃ hp, A hp)
+      ∧ winR rf ws' A win rest
+      ∧ A = (bytesRegion (rf.get p) win ** rest)
+      ∧ rf' = (execBlock reg (rf.get p) rf win is).1
+      ∧ A'' = (bytesRegion (rf.get p) (execBlock reg (rf.get p) rf win is).2
+          ** rest)
   | «while» _ c fuel inv _, _ =>
       fun rf ws A => (∃ i, i ≤ fuel ∧ inv i rf ws A) ∧ ¬ c.holds rf
   | call _ f, _ => fun rf ws A => f.post rf ws A
@@ -127,18 +128,21 @@ def vcs (reg : Region) (rw : RwRegion) : Stmt → String → Reach → List VC
       vcs reg rw b (pfx ++ lbl ++ ".") (fun rf ws A => reach rf ws A ∧ c.holds rf)
   | assert lbl P, pfx, reach =>
       [⟨pfx ++ lbl, ∀ rf ws A, reach rf ws A → P rf ws A⟩]
-  | ghost lbl f, pfx, reach =>
-      [⟨pfx ++ lbl, ∀ rf ws A, reach rf ws A → A.pcFree →
-          (∀ hp, A hp → f rf ws A hp) ∧ (f rf ws A).pcFree⟩]
-  | blockAt lbl p winF is, pfx, reach =>
+  | ghost lbl R, pfx, reach =>
+      [⟨pfx ++ lbl, ∀ rf ws A, reach rf ws A → A.pcFree → (∃ hp, A hp) →
+          ∃ A', R rf ws A A' ∧ (∀ hp, A hp → A' hp) ∧ A'.pcFree⟩]
+  | blockAt lbl p winR is, pfx, reach =>
       ⟨pfx ++ lbl ++ ".ok", blockOk is = true⟩ ::
-      ⟨pfx ++ lbl ++ ".focus", ∀ rf ws A, reach rf ws A →
-          A = (bytesRegion (rf.get p) (winF rf ws A).1 ** (winF rf ws A).2)
-          ∧ (winF rf ws A).2.pcFree
-          ∧ RwRegion.wf ⟨rf.get p, (winF rf ws A).1.length⟩⟩ ::
+      ⟨pfx ++ lbl ++ ".focus", ∀ rf ws A, reach rf ws A → A.pcFree →
+          (∃ hp, A hp) →
+          ∃ win rest, winR rf ws A win rest
+            ∧ A = (bytesRegion (rf.get p) win ** rest)
+            ∧ rest.pcFree ∧ RwRegion.wf ⟨rf.get p, win.length⟩⟩ ::
       (if hasLoad is then
-        [⟨pfx ++ lbl ++ ".mem", ∀ rf ws A, ws.length = rw.len →
-            reach rf ws A → blockVCs reg (rf.get p) rf (winF rf ws A).1 is⟩]
+        [⟨pfx ++ lbl ++ ".mem", ∀ rf ws A win rest, ws.length = rw.len →
+            reach rf ws A → winR rf ws A win rest →
+            A = (bytesRegion (rf.get p) win ** rest) →
+            blockVCs reg (rf.get p) rf win is⟩]
       else [])
   | «while» lbl c fuel inv b, pfx, reach =>
       ⟨pfx ++ lbl ++ ".inv_init", ∀ rf ws A, reach rf ws A → inv 0 rf ws A⟩ ::
@@ -184,12 +188,12 @@ theorem sp_mono (reg : Region) (rw : RwRegion) (s : Stmt) {r₁ r₂ : Reach}
       · exact Or.inr ⟨h rf ws A hskip.1, hskip.2⟩
   | assert lbl P =>
       exact fun rf ws A hr => ⟨h rf ws A hr.1, hr.2⟩
-  | ghost lbl f =>
-      rintro rf ws A' ⟨A, hr, rfl⟩
-      exact ⟨A, h rf ws A hr, rfl⟩
-  | blockAt lbl p winF is =>
-      rintro rf' ws' A'' ⟨rf, A, hlen, hr, hAeq, hrf, hA⟩
-      exact ⟨rf, A, hlen, h rf ws' A hr, hAeq, hrf, hA⟩
+  | ghost lbl R =>
+      rintro rf ws A' ⟨A, hr, hsat, hR⟩
+      exact ⟨A, h rf ws A hr, hsat, hR⟩
+  | blockAt lbl p winR is =>
+      rintro rf' ws' A'' ⟨rf, A, win, rest, hlen, hr, hsat, hR, hAeq, hrf, hA⟩
+      exact ⟨rf, A, win, rest, hlen, h rf ws' A hr, hsat, hR, hAeq, hrf, hA⟩
   | «while» lbl c fuel inv b ihb =>
       exact fun rf ws A hr => hr
   | call lbl f =>
@@ -241,12 +245,12 @@ theorem vcs_antitone (reg : Region) (rw : RwRegion) (s : Stmt) (pfx : String)
       simp only [vcs, List.mem_singleton] at hvc
       subst hvc
       exact fun rf ws A hr => hvcs.head rf ws A (h rf ws A hr)
-  | ghost lbl f =>
+  | ghost lbl R =>
       intro vc hvc
       simp only [vcs, List.mem_singleton] at hvc
       subst hvc
-      exact fun rf ws A hr hApc => hvcs.head rf ws A (h rf ws A hr) hApc
-  | blockAt lbl p winF is =>
+      exact fun rf ws A hr hApc hsat => hvcs.head rf ws A (h rf ws A hr) hApc hsat
+  | blockAt lbl p winR is =>
       intro vc hvc
       simp only [vcs, List.mem_cons] at hvc
       rcases hvc with rfl | rfl | hvc
@@ -254,21 +258,22 @@ theorem vcs_antitone (reg : Region) (rw : RwRegion) (s : Stmt) (pfx : String)
       · exact fun rf ws A hr => hvcs.tail.head rf ws A (h rf ws A hr)
       · by_cases hl : hasLoad is
         · rw [if_pos hl] at hvc
-          rw [show vcs reg rw (.blockAt lbl p winF is) pfx r₂
+          rw [show vcs reg rw (.blockAt lbl p winR is) pfx r₂
               = ⟨pfx ++ lbl ++ ".ok", blockOk is = true⟩ ::
-                ⟨pfx ++ lbl ++ ".focus", ∀ rf ws A, r₂ rf ws A →
-                    A = (bytesRegion (rf.get p) (winF rf ws A).1
-                      ** (winF rf ws A).2)
-                    ∧ (winF rf ws A).2.pcFree
-                    ∧ RwRegion.wf ⟨rf.get p, (winF rf ws A).1.length⟩⟩ ::
-                [⟨pfx ++ lbl ++ ".mem", ∀ rf ws A, ws.length = rw.len →
-                    r₂ rf ws A →
-                    blockVCs reg (rf.get p) rf (winF rf ws A).1 is⟩]
+                ⟨pfx ++ lbl ++ ".focus", ∀ rf ws A, r₂ rf ws A → A.pcFree →
+                    (∃ hp, A hp) →
+                    ∃ win rest, winR rf ws A win rest
+                      ∧ A = (bytesRegion (rf.get p) win ** rest)
+                      ∧ rest.pcFree ∧ RwRegion.wf ⟨rf.get p, win.length⟩⟩ ::
+                [⟨pfx ++ lbl ++ ".mem", ∀ rf ws A win rest, ws.length = rw.len →
+                    r₂ rf ws A → winR rf ws A win rest →
+                    A = (bytesRegion (rf.get p) win ** rest) →
+                    blockVCs reg (rf.get p) rf win is⟩]
             from by simp [vcs, hl]] at hvcs
           simp only [List.mem_singleton] at hvc
           subst hvc
-          exact fun rf ws A hlen hr =>
-            hvcs.tail.tail.head rf ws A hlen (h rf ws A hr)
+          exact fun rf ws A win rest hlen hr hR hAeq =>
+            hvcs.tail.tail.head rf ws A win rest hlen (h rf ws A hr) hR hAeq
         · rw [if_neg hl] at hvc
           exact absurd hvc (List.not_mem_nil)
   | «while» lbl c fuel inv b ihb =>

--- a/PLAN.md
+++ b/PLAN.md
@@ -2517,7 +2517,11 @@ of the ambient assertion for the block; the decomposition (window bytes,
 remainder) is a user annotation on the node, so sp stays fully
 determined and post-VCs compute. VCs: .ok, .focus (decomposition eq +
 remainder pcFree + window RwRegion.wf), .mem (window-routed blockVCs).
-Stage 4 landed: TreeSep.lean —
+Stage 4.5 landed: ghost + focus made RELATIONAL (annotations can name
+existentially-quantified ghosts — zipper contexts/subtrees — that
+functional annotations cannot) and both now record satisfiability of
+the pre-assertion in sp (the *harvest*: pure facts baked into
+predicates reach the pure VCs; harvestFn demo). Stage 4 landed: TreeSep.lean —
 Tree/keys/insert/Sorted/insert_sorted (pure model), 3-dword node layout
 (nodeBytes/nodeAt with baked p≠0 + RwRegion.wf), recursive treeAt,
 zipper Tree.Ctx/ctxAt with ctxAt_zip_fold (reseal) and


### PR DESCRIPTION
An interface fix caught while designing the tree demos — better now than after the how-to doc freezes the surface. (#9685 merged while this was in flight; main merged in.)

## Why

Designing `treeContains` exposed two gaps:

1. **Functional annotations can't name existential ghosts.** A tree-walk loop invariant is `∃ c t, A = ctxAt c root p ** treeAt p t ∧ …` — the zipper context and subtree are existentially quantified. The ghost node's `f : (rf, ws, A) → Assertion` and the focus node's `winF : (rf, ws, A) → (bytes × Assertion)` cannot mention `c`/`t`, so no descend step or node-open step could be written. Both annotations become **relations** (`R rf ws A A'`, `winR rf ws A win rest`): the VC *produces* a related witness (with entailment + pcFree), `sp` records the relation, and user relations quantify their ghosts freely.

2. **Pure facts trapped inside `A` were unreachable.** `treeAt` bakes `p ≠ 0` and node well-formedness into `⌜·⌝` conjuncts; loop-exhaustion and `.focus` obligations need them as *pure* facts. Both nodes now record **satisfiability of the pre-assertion** (`∃ hp, A hp`) in `sp`, and the ghost/`.focus` VCs receive it as a hypothesis — sound because the assertion demonstrably holds on a sub-state of the machine. The `blockAt` soundness extracts the satisfying sub-state before choosing focus witnesses (one manual triple unfold).

## Changes

`Ast`/`Vc`/`StmtSound`/`StmtSoundCall` reworked for both nodes; `swapCells`/`focusRead` demos updated to the relational interface; new `harvestFn` demo showing a `⌜n = 7⌝` conjunct inside `A` reaching a pure postcondition through a ghost step.

Kernel-clean; zero warnings; forbidden-tactics OK; no emitted-code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
