### PR TITLE
feat(sasm): per-state focus witnesses + tree satisfiability shadows (stage 4.75)

### DIFF
--- a/EvmAsm/Rv64/SAsm/ExamplesVc.lean
+++ b/EvmAsm/Rv64/SAsm/ExamplesVc.lean
@@ -887,21 +887,22 @@ theorem focusReadFn_spec (q v base : Word) (hwf : RwRegion.wf ⟨q, 8⟩) :
     bv_omega
   vcgen
   case focusRead.win.focus =>
-    rintro rf ws A ⟨hx11, hA⟩ hApc hsat
+    rintro rf ws A ⟨hx11, hA⟩ hApc hp hhp
     refine ⟨dwordBytes v, empAssertion, ⟨rfl, rfl⟩, ?_, pcFree_emp, ?_⟩
     · rw [sepConj_emp_right', hx11]
-      exact hA
+      rw [hA] at hhp
+      exact hhp
     · rw [hx11, length_dwordBytes]
       exact hwf
   case focusRead.win.mem =>
-    rintro rf ws A win rest hws ⟨hx11, hA⟩ ⟨rfl, rfl⟩ hAeq
+    rintro rf ws A win rest hws ⟨hx11, hA⟩ ⟨rfl, rfl⟩ hsat
     simp only [blockVCs, loadSem, inRw, Region.loadOk,
       hidx rf hx11, length_dwordBytes]
     rw [if_pos (by omega)]
     exact ⟨⟨by omega, by omega⟩, trivial⟩
   case focusRead.seal =>
     rintro rf ws A ⟨rf₀, A₀, win, rest, hlen, ⟨hx11, hA₀⟩, hsat, ⟨rfl, rfl⟩,
-      hAeq, rfl, rfl⟩ hApc hsat'
+      rfl, rfl⟩ hApc hsat'
     refine ⟨_, rfl, ?_, bytesRegion_pcFree _ _⟩
     intro hp hh
     rw [sepConj_emp_right'] at hh
@@ -910,7 +911,7 @@ theorem focusReadFn_spec (q v base : Word) (hwf : RwRegion.wf ⟨q, 8⟩) :
     exact hh
   case focusRead.post =>
     rintro rf' ws' A' ⟨A1, ⟨rf₀, A₀, win, rest, hlen, ⟨hx11, hA₀⟩, hsat,
-      ⟨rfl, rfl⟩, hAeq, rfl, rfl⟩, hsat1, rfl⟩
+      ⟨rfl, rfl⟩, rfl, rfl⟩, hsat1, rfl⟩
     refine ⟨?_, rfl⟩
     simp only [execBlock_cons, execBlock_nil, execInstrRF, loadSem, aluSem]
     rw [if_pos (show inRw (rf₀.get .x11) (dwordBytes v)

--- a/EvmAsm/Rv64/SAsm/StmtSound.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSound.lean
@@ -380,12 +380,13 @@ theorem Stmt.sound (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
       exact h
   | blockAt lbl p winR is =>
       have hok : blockOk is = true := hvcs.head
-      have hfocus : ∀ rf ws A, reach rf ws A → A.pcFree → (∃ hp, A hp) →
+      have hfocus : ∀ rf ws A, reach rf ws A → A.pcFree → ∀ hp, A hp →
           ∃ win rest, winR rf ws A win rest
-            ∧ A = (bytesRegion (rf.get p) win ** rest)
+            ∧ (bytesRegion (rf.get p) win ** rest) hp
             ∧ rest.pcFree ∧ RwRegion.wf ⟨rf.get p, win.length⟩ := hvcs.tail.head
       have hmem : ∀ rf ws A win rest, ws.length = rw.len → reach rf ws A →
-          winR rf ws A win rest → A = (bytesRegion (rf.get p) win ** rest) →
+          winR rf ws A win rest →
+          (∃ hp, (bytesRegion (rf.get p) win ** rest) hp) →
           blockVCs reg (rf.get p) rf win is := by
         by_cases hl : hasLoad is
         · have ht := hvcs.tail.tail
@@ -395,21 +396,22 @@ theorem Stmt.sound (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
             blockVCs_of_not_hasLoad reg (rf.get p) rf win is (by simpa using hl)
       apply cpsTripleWithin_exists_pre_M
       intro rf ws A hlen hApc hreach R hR s hcr hPR hpc
-      have hsat : ∃ hp, A hp := by
-        obtain ⟨h0, hcompat, h1, h2, hd, hu, hP1, hR2⟩ := hPR
-        obtain ⟨h3, h4, hd2, hu2, hP3, hA4⟩ := hP1
-        exact ⟨h4, hA4⟩
-      obtain ⟨win, rest, hRw, hAeq, hrestpc, hwf⟩ :=
-        hfocus rf ws A hreach hApc hsat
+      obtain ⟨h0, hcompat, h1, h2, hd, hu, hP1, hR2⟩ := hPR
+      obtain ⟨h3, h4, hd2, hu2, hP3, hA4⟩ := hP1
+      obtain ⟨win, rest, hRw, hpair, hrestpc, hwf⟩ :=
+        hfocus rf ws A hreach hApc h4 hA4
+      have hPR' : ((((regFileIs rf) ** (bytesRegion reg.base reg.bytes **
+          bytesRegion rw.base ws)) ** (bytesRegion (rf.get p) win ** rest))
+          ** R).holdsFor s :=
+        ⟨h0, hcompat, h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hP3, hpair⟩, hR2⟩
       have h := execBlock_sound reg ⟨rf.get p, win.length⟩ is rf win base hreg
-        hwf rfl hok (hmem rf ws A win rest hlen hreach hRw hAeq)
+        hwf rfl hok (hmem rf ws A win rest hlen hreach hRw ⟨h4, hpair⟩)
         (by simpa [Stmt.size] using hsz)
       have hA2 := cpsTripleWithin_frameR (bytesRegion rw.base ws ** rest)
         (pcFree_sepConj (bytesRegion_pcFree _ _) hrestpc) h
       have h' := cpsTripleWithin_extend_code hcode hA2
-      refine cpsTripleWithin_weaken ?_ ?_ h' R hR s hcr hPR hpc
+      refine cpsTripleWithin_weaken ?_ ?_ h' R hR s hcr hPR' hpc
       · intro hp hh
-        rw [hAeq] at hh
         xperm_hyp hh
       · intro hp hh
         have hh2 : ((((regFileIs (execBlock reg (rf.get p) rf win is).1) **
@@ -422,7 +424,7 @@ theorem Stmt.sound (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
             (bytesRegion (rf.get p) (execBlock reg (rf.get p) rf win is).2
               ** rest),
             hlen, pcFree_sepConj (bytesRegion_pcFree _ _) hrestpc,
-            ⟨rf, A, win, rest, hlen, hreach, hsat, hRw, hAeq, rfl, rfl⟩,
+            ⟨rf, A, win, rest, hlen, hreach, ⟨h4, hpair⟩, hRw, rfl, rfl⟩,
             hx⟩) hp hh2
   | ghost lbl R =>
       have hvc := hvcs _ (List.mem_singleton_self _)

--- a/EvmAsm/Rv64/SAsm/TreeSep.lean
+++ b/EvmAsm/Rv64/SAsm/TreeSep.lean
@@ -269,5 +269,41 @@ theorem ctxAt_push_right (c : Tree.Ctx) (root p k pl pr : Word) (l r : Tree) :
   rw [sepConj_comm'] at hh
   exact sepConj_mono_left (fun hq hx => ⟨p, pl, hx⟩) hp hh
 
+-- ============================================================================
+-- Satisfiability shadows (what harvest steps extract)
+-- ============================================================================
+
+/-- Satisfiability of a conjunct, from satisfiability of the whole. -/
+theorem sepConj_sat_left {A B : Assertion} {hp : PartialState}
+    (h : (A ** B) hp) : ∃ hq, A hq := by
+  obtain ⟨h1, h2, -, -, ha, -⟩ := h
+  exact ⟨h1, ha⟩
+
+/-- Satisfiability of a conjunct, from satisfiability of the whole. -/
+theorem sepConj_sat_right {A B : Assertion} {hp : PartialState}
+    (h : (A ** B) hp) : ∃ hq, B hq := by
+  obtain ⟨h1, h2, -, -, -, hb⟩ := h
+  exact ⟨h2, hb⟩
+
+/-- On a satisfying state, a node's address is nonzero and well-formed —
+    what a `.focus` VC extracts before opening the node. -/
+theorem treeAt_sat_node {p k : Word} {l r : Tree} {hp : PartialState}
+    (h : treeAt p (.node k l r) hp) :
+    p ≠ 0 ∧ RwRegion.wf ⟨p, 24⟩ := by
+  obtain ⟨pl, pr, hh⟩ := h
+  obtain ⟨h1, h2, hd, hu, hnode, hch⟩ := hh
+  exact ((sepConj_pure_left h1).mp hnode).1
+
+/-- The nil-pointer shadow: on any satisfying state, the pointer is nil
+    exactly when the tree is a leaf.  This is the pure fact tree walks
+    harvest at ghost steps for their loop-exit reasoning. -/
+theorem treeAt_sat_shadow {p : Word} {t : Tree} {hp : PartialState}
+    (h : treeAt p t hp) : p = 0 ↔ t = .leaf := by
+  cases t with
+  | leaf => exact ⟨fun _ => rfl, fun _ => h.2⟩
+  | node k l r =>
+      have hne := (treeAt_sat_node h).1
+      exact ⟨fun h0 => absurd h0 hne, fun hleaf => nomatch hleaf⟩
+
 end SAsm
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/Vc.lean
+++ b/EvmAsm/Rv64/SAsm/Vc.lean
@@ -100,9 +100,9 @@ def sp (reg : Region) (rw : RwRegion) : Stmt → Reach → Reach
   | ghost _ R, reach => fun rf ws A' => ∃ A, reach rf ws A
       ∧ (∃ hp, A hp) ∧ R rf ws A A'
   | blockAt _ p winR is, reach => fun rf' ws' A'' => ∃ rf A win rest,
-      ws'.length = rw.len ∧ reach rf ws' A ∧ (∃ hp, A hp)
+      ws'.length = rw.len ∧ reach rf ws' A
+      ∧ (∃ hp, (bytesRegion (rf.get p) win ** rest) hp)
       ∧ winR rf ws' A win rest
-      ∧ A = (bytesRegion (rf.get p) win ** rest)
       ∧ rf' = (execBlock reg (rf.get p) rf win is).1
       ∧ A'' = (bytesRegion (rf.get p) (execBlock reg (rf.get p) rf win is).2
           ** rest)
@@ -134,14 +134,14 @@ def vcs (reg : Region) (rw : RwRegion) : Stmt → String → Reach → List VC
   | blockAt lbl p winR is, pfx, reach =>
       ⟨pfx ++ lbl ++ ".ok", blockOk is = true⟩ ::
       ⟨pfx ++ lbl ++ ".focus", ∀ rf ws A, reach rf ws A → A.pcFree →
-          (∃ hp, A hp) →
+          ∀ hp, A hp →
           ∃ win rest, winR rf ws A win rest
-            ∧ A = (bytesRegion (rf.get p) win ** rest)
+            ∧ (bytesRegion (rf.get p) win ** rest) hp
             ∧ rest.pcFree ∧ RwRegion.wf ⟨rf.get p, win.length⟩⟩ ::
       (if hasLoad is then
         [⟨pfx ++ lbl ++ ".mem", ∀ rf ws A win rest, ws.length = rw.len →
             reach rf ws A → winR rf ws A win rest →
-            A = (bytesRegion (rf.get p) win ** rest) →
+            (∃ hp, (bytesRegion (rf.get p) win ** rest) hp) →
             blockVCs reg (rf.get p) rf win is⟩]
       else [])
   | «while» lbl c fuel inv b, pfx, reach =>
@@ -192,8 +192,8 @@ theorem sp_mono (reg : Region) (rw : RwRegion) (s : Stmt) {r₁ r₂ : Reach}
       rintro rf ws A' ⟨A, hr, hsat, hR⟩
       exact ⟨A, h rf ws A hr, hsat, hR⟩
   | blockAt lbl p winR is =>
-      rintro rf' ws' A'' ⟨rf, A, win, rest, hlen, hr, hsat, hR, hAeq, hrf, hA⟩
-      exact ⟨rf, A, win, rest, hlen, h rf ws' A hr, hsat, hR, hAeq, hrf, hA⟩
+      rintro rf' ws' A'' ⟨rf, A, win, rest, hlen, hr, hsat, hR, hrf, hA⟩
+      exact ⟨rf, A, win, rest, hlen, h rf ws' A hr, hsat, hR, hrf, hA⟩
   | «while» lbl c fuel inv b ihb =>
       exact fun rf ws A hr => hr
   | call lbl f =>
@@ -261,19 +261,19 @@ theorem vcs_antitone (reg : Region) (rw : RwRegion) (s : Stmt) (pfx : String)
           rw [show vcs reg rw (.blockAt lbl p winR is) pfx r₂
               = ⟨pfx ++ lbl ++ ".ok", blockOk is = true⟩ ::
                 ⟨pfx ++ lbl ++ ".focus", ∀ rf ws A, r₂ rf ws A → A.pcFree →
-                    (∃ hp, A hp) →
+                    ∀ hp, A hp →
                     ∃ win rest, winR rf ws A win rest
-                      ∧ A = (bytesRegion (rf.get p) win ** rest)
+                      ∧ (bytesRegion (rf.get p) win ** rest) hp
                       ∧ rest.pcFree ∧ RwRegion.wf ⟨rf.get p, win.length⟩⟩ ::
                 [⟨pfx ++ lbl ++ ".mem", ∀ rf ws A win rest, ws.length = rw.len →
                     r₂ rf ws A → winR rf ws A win rest →
-                    A = (bytesRegion (rf.get p) win ** rest) →
+                    (∃ hp, (bytesRegion (rf.get p) win ** rest) hp) →
                     blockVCs reg (rf.get p) rf win is⟩]
             from by simp [vcs, hl]] at hvcs
           simp only [List.mem_singleton] at hvc
           subst hvc
-          exact fun rf ws A win rest hlen hr hR hAeq =>
-            hvcs.tail.tail.head rf ws A win rest hlen (h rf ws A hr) hR hAeq
+          exact fun rf ws A win rest hlen hr hR hsat =>
+            hvcs.tail.tail.head rf ws A win rest hlen (h rf ws A hr) hR hsat
         · rw [if_neg hl] at hvc
           exact absurd hvc (List.not_mem_nil)
   | «while» lbl c fuel inv b ihb =>

--- a/PLAN.md
+++ b/PLAN.md
@@ -2517,7 +2517,13 @@ of the ambient assertion for the block; the decomposition (window bytes,
 remainder) is a user annotation on the node, so sp stays fully
 determined and post-VCs compute. VCs: .ok, .focus (decomposition eq +
 remainder pcFree + window RwRegion.wf), .mem (window-routed blockVCs).
-Stage 4.5 landed: ghost + focus made RELATIONAL (annotations can name
+Stage 4.75 landed: focus `.focus` VC witnesses are PER-SATISFYING-STATE
+(recursive predicates carry existential child pointers *inside* the
+assertion; a single decomposition equality is unsatisfiable — the VC now
+skolemizes at the machine sub-state, sp records satisfiability of the
+chosen decomposition); TreeSep gains the satisfiability shadows
+(sepConj_sat_left/right, treeAt_sat_node, treeAt_sat_shadow: p = 0 ↔
+leaf on satisfying states). Stage 4.5 landed: ghost + focus made RELATIONAL (annotations can name
 existentially-quantified ghosts — zipper contexts/subtrees — that
 functional annotations cannot) and both now record satisfiability of
 the pre-assertion in sp (the *harvest*: pure facts baked into


### PR DESCRIPTION
Found while building the tree-walk demos against the merged library — the last soundness-level refinement the focus mechanism needed.

## The problem

Recursive predicates carry existential child pointers *inside* the assertion: `treeAt p (node k l r) = fun h => ∃ pl pr, (nodeAt p k pl pr ** …) h`. A focus block on such a node cannot satisfy the previous `.focus` VC, which demanded a single decomposition **equality** `A = bytesRegion (rf.get ptr) win ** rest` — no specific `win` works, because different satisfying states realize different child-pointer values.

## The fix

The `.focus` VC skolemizes **per satisfying state**:

```
∀ hp, A hp → ∃ win rest, winR rf ws A win rest ∧ (bytesRegion (rf.get ptr) win ** rest) hp ∧ rest.pcFree ∧ wf
```

Soundness picks the witnesses at the actual machine sub-state (the ambient-assertion component of the precondition) and swaps the atom for the chosen decomposition at the tuple level — the rest of the proof is unchanged. `sp` records satisfiability of the decomposition (the equality no longer exists); the `.mem` VC receives the same satisfiability.

## TreeSep: satisfiability shadows

The pure facts walk demos harvest: `sepConj_sat_left/right`, `treeAt_sat_node` (`p ≠ 0 ∧ RwRegion.wf ⟨p,24⟩` from any satisfying state — exactly what a `.focus` VC needs to open a node), and `treeAt_sat_shadow` (`p = 0 ↔ t = leaf` — the loop-exit fact).

`focusRead` demo updated to the per-state interface. Kernel-clean; zero warnings; no emitted-code change. The `treeMin`/`treeContains` walk demos follow in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
