### PR TITLE
feat(sasm): multi-dword focus-block ergonomics (agent-feedback round 1)

### DIFF
--- a/EvmAsm/Rv64/SAsm.lean
+++ b/EvmAsm/Rv64/SAsm.lean
@@ -22,6 +22,7 @@ import EvmAsm.Rv64.SAsm.AssertionSpec
 import EvmAsm.Rv64.SAsm.TreeSep
 import EvmAsm.Rv64.SAsm.TreeDemo
 import EvmAsm.Rv64.SAsm.TreeInsert
+import EvmAsm.Rv64.SAsm.MultiDword
 import EvmAsm.Rv64.SAsm.RaSpill
 import EvmAsm.Rv64.SAsm.Tactic
 import EvmAsm.Rv64.SAsm.Examples

--- a/EvmAsm/Rv64/SAsm/ExamplesVc.lean
+++ b/EvmAsm/Rv64/SAsm/ExamplesVc.lean
@@ -9,6 +9,7 @@
 import EvmAsm.Rv64.InstructionSpecs
 import EvmAsm.Rv64.SAsm.AssertionSpec
 import EvmAsm.Rv64.SAsm.RaSpill
+import EvmAsm.Rv64.SAsm.MultiDword
 import EvmAsm.Rv64.SAsm.Tactic
 
 namespace EvmAsm.Rv64
@@ -953,6 +954,254 @@ theorem harvestFn_spec (n base : Word) : (harvestFn n).Spec base := by
   case harvest.post =>
     rintro rf ws A' ⟨A, hA, hsat, rfl, h7⟩
     exact ⟨rfl, h7⟩
+
+-- ============================================================================
+-- Multi-dword focus blocks: `revCellFn`
+--
+-- The worked example for docs/sasm-howto.md ("Multi-dword focus blocks"):
+-- one focus block that loads all four dwords of a 32-byte cell and stores
+-- them back reversed.  The recipe: per-step `execInstrRF_ld_dword` /
+-- `execInstrRF_sd_dword` rewrites (Sym.lean) — each resolves its routing
+-- `if` once and for all, so no nested `if` trees ever appear — plus the
+-- MultiDword slice/splice algebra for the window contents.
+-- ============================================================================
+
+/-- A 32-byte cell of four dwords (LSB dword first). -/
+def cell32 (l0 l1 l2 l3 : Word) : List (BitVec 8) :=
+  dwordBytes l0 ++ (dwordBytes l1 ++ (dwordBytes l2 ++ dwordBytes l3))
+
+@[simp] theorem length_cell32 (l0 l1 l2 l3 : Word) :
+    (cell32 l0 l1 l2 l3).length = 32 := by
+  simp [cell32]
+
+/-- The dword slices of a 32-byte cell, packed. -/
+theorem cell32_dword0 (l0 l1 l2 l3 : Word) :
+    packBytes (((cell32 l0 l1 l2 l3).drop 0).take 8) = l0 :=
+  packDword_at0 ..
+
+theorem cell32_drop8 (l0 l1 l2 l3 : Word) :
+    (cell32 l0 l1 l2 l3).drop 8
+      = dwordBytes l1 ++ (dwordBytes l2 ++ dwordBytes l3) := by
+  have h := drop8_dword_append l0
+    (dwordBytes l1 ++ (dwordBytes l2 ++ dwordBytes l3)) 0
+  simp only [Nat.add_zero, List.drop_zero] at h
+  rw [cell32, h]
+
+theorem cell32_dword1 (l0 l1 l2 l3 : Word) :
+    packBytes (((cell32 l0 l1 l2 l3).drop 8).take 8) = l1 := by
+  rw [cell32_drop8, take8_dword_append, packBytes_dwordBytes]
+
+theorem cell32_drop16 (l0 l1 l2 l3 : Word) :
+    (cell32 l0 l1 l2 l3).drop 16 = dwordBytes l2 ++ dwordBytes l3 := by
+  have h1 := drop8_dword_append l0
+    (dwordBytes l1 ++ (dwordBytes l2 ++ dwordBytes l3)) 8
+  have h2 := drop8_dword_append l1 (dwordBytes l2 ++ dwordBytes l3) 0
+  simp only [Nat.reduceAdd] at h1
+  simp only [Nat.add_zero, List.drop_zero] at h2
+  rw [cell32, h1, h2]
+
+theorem cell32_dword2 (l0 l1 l2 l3 : Word) :
+    packBytes (((cell32 l0 l1 l2 l3).drop 16).take 8) = l2 := by
+  rw [cell32_drop16, take8_dword_append, packBytes_dwordBytes]
+
+theorem cell32_drop24 (l0 l1 l2 l3 : Word) :
+    (cell32 l0 l1 l2 l3).drop 24 = dwordBytes l3 := by
+  have h1 := drop8_dword_append l0
+    (dwordBytes l1 ++ (dwordBytes l2 ++ dwordBytes l3)) 16
+  have h2 := drop8_dword_append l1 (dwordBytes l2 ++ dwordBytes l3) 8
+  have h3 := drop8_dword_append l2 (dwordBytes l3) 0
+  simp only [Nat.reduceAdd] at h1 h2
+  simp only [Nat.add_zero, List.drop_zero] at h3
+  rw [cell32, h1, h2, h3]
+
+theorem cell32_dword3 (l0 l1 l2 l3 : Word) :
+    packBytes (((cell32 l0 l1 l2 l3).drop 24).take 8) = l3 := by
+  rw [cell32_drop24, List.take_of_length_le (by rw [length_dwordBytes]),
+    packBytes_dwordBytes]
+
+/-- Splicing a dword at each cell offset. -/
+theorem cell32_set0 (l0 l1 l2 l3 v : Word) :
+    setBytes (cell32 l0 l1 l2 l3) 0 (dwordBytes v) = cell32 v l1 l2 l3 := by
+  rw [cell32, setBytes_dword_at0, cell32]
+
+theorem cell32_set8 (l0 l1 l2 l3 v : Word) :
+    setBytes (cell32 l0 l1 l2 l3) 8 (dwordBytes v) = cell32 l0 v l2 l3 := by
+  have h1 := setBytes_dword_past l0
+    (dwordBytes l1 ++ (dwordBytes l2 ++ dwordBytes l3)) (dwordBytes v) 0
+  simp only [Nat.add_zero] at h1
+  rw [cell32, h1, setBytes_dword_at0, cell32]
+
+theorem cell32_set16 (l0 l1 l2 l3 v : Word) :
+    setBytes (cell32 l0 l1 l2 l3) 16 (dwordBytes v) = cell32 l0 l1 v l3 := by
+  have h1 := setBytes_dword_past l0
+    (dwordBytes l1 ++ (dwordBytes l2 ++ dwordBytes l3)) (dwordBytes v) 8
+  have h2 := setBytes_dword_past l1
+    (dwordBytes l2 ++ dwordBytes l3) (dwordBytes v) 0
+  simp only [Nat.reduceAdd] at h1
+  simp only [Nat.add_zero] at h2
+  rw [cell32, h1, h2, setBytes_dword_at0, cell32]
+
+theorem cell32_set24 (l0 l1 l2 l3 v : Word) :
+    setBytes (cell32 l0 l1 l2 l3) 24 (dwordBytes v) = cell32 l0 l1 l2 v := by
+  have h1 := setBytes_dword_past l0
+    (dwordBytes l1 ++ (dwordBytes l2 ++ dwordBytes l3)) (dwordBytes v) 16
+  have h2 := setBytes_dword_past l1
+    (dwordBytes l2 ++ dwordBytes l3) (dwordBytes v) 8
+  have h3 := setBytes_dword_past l2 (dwordBytes l3) (dwordBytes v) 0
+  simp only [Nat.reduceAdd] at h1 h2
+  simp only [Nat.add_zero] at h3
+  rw [cell32, h1, h2, h3, setBytes_dword_full _ _ (length_dwordBytes l3),
+    cell32]
+
+/-- Load the four dwords of the cell at `a2`, store them back reversed. -/
+def revCellBlock : List Instr :=
+  [.LD .x5 .x12 0, .LD .x6 .x12 8, .LD .x7 .x12 16, .LD .x14 .x12 24,
+   .SD .x12 .x14 0, .SD .x12 .x7 8, .SD .x12 .x6 16, .SD .x12 .x5 24]
+
+/-- Focus annotation: window = the whole cell, remainder = its
+    well-formedness (all four limbs are `Fn`-level binders, so nothing
+    needs restating). -/
+def revCellR (p l0 l1 l2 l3 : Word) :
+    RegFile → List (BitVec 8) → Assertion →
+      List (BitVec 8) → Assertion → Prop :=
+  fun _ _ _ win rest =>
+    win = cell32 l0 l1 l2 l3 ∧ rest = ⌜RwRegion.wf ⟨p, 32⟩⌝
+
+/-- Reverse the four dwords of the 32-byte cell at `a2`. -/
+def revCellFn (p l0 l1 l2 l3 : Word) : Fn where
+  name := "revCell"
+  pre := fun rf _ A => rf.get .x12 = p ∧
+    A = (⌜RwRegion.wf ⟨p, 32⟩⌝ ** bytesRegion p (cell32 l0 l1 l2 l3))
+  post := fun rf _ A => rf.get .x12 = p ∧
+    A = (⌜RwRegion.wf ⟨p, 32⟩⌝ ** bytesRegion p (cell32 l3 l2 l1 l0))
+  body := .blockAt "rev" .x12 (revCellR p l0 l1 l2 l3) revCellBlock
+
+/-- The signExtend12 address arithmetic, once per offset. -/
+private theorem revCell_off (b : Word) (ofs : BitVec 12) (k : Nat)
+    (hofs : signExtend12 ofs = BitVec.ofNat 64 k) (hk : k < 2 ^ 12) :
+    ((b + signExtend12 ofs) - b).toNat = k := by
+  rw [hofs]
+  bv_omega
+
+/-- The engine: the block loads `l0..l3` and rewrites the window to the
+    reversed cell.  One `execInstrRF_ld_dword`/`execInstrRF_sd_dword`
+    rewrite per instruction — the routing `if`s never appear. -/
+private theorem revCell_engine (reg : Region) (rf : RegFile)
+    (l0 l1 l2 l3 : Word) :
+    execBlock reg (rf.get .x12) rf (cell32 l0 l1 l2 l3) revCellBlock
+      = ((((rf.set .x5 l0).set .x6 l1).set .x7 l2).set .x14 l3,
+         cell32 l3 l2 l1 l0) := by
+  have h0 := revCell_off (rf.get .x12) 0 0 (by decide) (by decide)
+  -- the base register is never a destination, so its value is stable
+  have hx12a : (rf.set .x5 l0).get .x12 = rf.get .x12 :=
+    RegFile.get_set_ne _ _ _ _ (by decide)
+  have hx12b : ((rf.set .x5 l0).set .x6 l1).get .x12 = rf.get .x12 := by
+    rw [RegFile.get_set_ne _ _ _ _ (by decide), hx12a]
+  have hx12c : (((rf.set .x5 l0).set .x6 l1).set .x7 l2).get .x12
+      = rf.get .x12 := by
+    rw [RegFile.get_set_ne _ _ _ _ (by decide), hx12b]
+  have hx12d : ((((rf.set .x5 l0).set .x6 l1).set .x7 l2).set .x14 l3).get .x12
+      = rf.get .x12 := by
+    rw [RegFile.get_set_ne _ _ _ _ (by decide), hx12c]
+  rw [show revCellBlock
+      = [.LD .x5 .x12 0, .LD .x6 .x12 8, .LD .x7 .x12 16, .LD .x14 .x12 24,
+         .SD .x12 .x14 0, .SD .x12 .x7 8, .SD .x12 .x6 16, .SD .x12 .x5 24]
+    from rfl]
+  rw [execBlock_cons, execInstrRF_ld_dword _ _ _ _ _ _ _ 0 l0
+    h0 (by simp) (cell32_dword0 ..)]
+  rw [execBlock_cons, execInstrRF_ld_dword _ _ _ _ _ _ _ 8 l1
+    (by rw [hx12a]; exact revCell_off _ 8 8 (by decide) (by decide))
+    (by simp) (cell32_dword1 ..)]
+  rw [execBlock_cons, execInstrRF_ld_dword _ _ _ _ _ _ _ 16 l2
+    (by rw [hx12b]; exact revCell_off _ 16 16 (by decide) (by decide))
+    (by simp) (cell32_dword2 ..)]
+  rw [execBlock_cons, execInstrRF_ld_dword _ _ _ _ _ _ _ 24 l3
+    (by rw [hx12c]; exact revCell_off _ 24 24 (by decide) (by decide))
+    (by simp) (cell32_dword3 ..)]
+  rw [execBlock_cons, execInstrRF_sd_dword _ _ _ _ _ _ _ 0
+    (by rw [hx12d]; exact h0)]
+  rw [RegFile.get_set_self _ _ _ (by decide), cell32_set0]
+  rw [execBlock_cons, execInstrRF_sd_dword _ _ _ _ _ _ _ 8
+    (by rw [hx12d]; exact revCell_off _ 8 8 (by decide) (by decide))]
+  rw [RegFile.get_set_ne _ _ _ _ (by decide),
+    RegFile.get_set_self _ _ _ (by decide), cell32_set8]
+  rw [execBlock_cons, execInstrRF_sd_dword _ _ _ _ _ _ _ 16
+    (by rw [hx12d]; exact revCell_off _ 16 16 (by decide) (by decide))]
+  rw [RegFile.get_set_ne _ _ _ _ (by decide),
+    RegFile.get_set_ne _ _ _ _ (by decide),
+    RegFile.get_set_self _ _ _ (by decide), cell32_set16]
+  rw [execBlock_cons, execInstrRF_sd_dword _ _ _ _ _ _ _ 24
+    (by rw [hx12d]; exact revCell_off _ 24 24 (by decide) (by decide))]
+  rw [RegFile.get_set_ne _ _ _ _ (by decide),
+    RegFile.get_set_ne _ _ _ _ (by decide),
+    RegFile.get_set_ne _ _ _ _ (by decide),
+    RegFile.get_set_self _ _ _ (by decide), cell32_set24]
+  rfl
+
+/-- The `.mem` VCs: rewrite each engine step with the same dword-step
+    lemmas, then every routing condition is about the ORIGINAL `rf`/window
+    and discharges by arithmetic. -/
+private theorem revCell_blockVCs (reg : Region) (rf : RegFile)
+    (l0 l1 l2 l3 : Word) :
+    blockVCs reg (rf.get .x12) rf (cell32 l0 l1 l2 l3) revCellBlock := by
+  have h0 := revCell_off (rf.get .x12) 0 0 (by decide) (by decide)
+  have hx12a : (rf.set .x5 l0).get .x12 = rf.get .x12 :=
+    RegFile.get_set_ne _ _ _ _ (by decide)
+  have hx12b : ((rf.set .x5 l0).set .x6 l1).get .x12 = rf.get .x12 := by
+    rw [RegFile.get_set_ne _ _ _ _ (by decide), hx12a]
+  have hx12c : (((rf.set .x5 l0).set .x6 l1).set .x7 l2).get .x12
+      = rf.get .x12 := by
+    rw [RegFile.get_set_ne _ _ _ _ (by decide), hx12b]
+  have hx12d : ((((rf.set .x5 l0).set .x6 l1).set .x7 l2).set .x14 l3).get .x12
+      = rf.get .x12 := by
+    rw [RegFile.get_set_ne _ _ _ _ (by decide), hx12c]
+  have h8 := revCell_off (rf.get .x12) 8 8 (by decide) (by decide)
+  have h16 := revCell_off (rf.get .x12) 16 16 (by decide) (by decide)
+  have h24 := revCell_off (rf.get .x12) 24 24 (by decide) (by decide)
+  simp only [revCellBlock, blockVCs, loadSem, storeSem,
+    execInstrRF_ld_dword _ _ _ _ _ _ _ 0 l0
+      h0 (by simp) (cell32_dword0 ..),
+    execInstrRF_ld_dword _ _ _ _ _ _ _ 8 l1
+      (by rw [hx12a]; exact h8) (by simp) (cell32_dword1 ..),
+    execInstrRF_ld_dword _ _ _ _ _ _ _ 16 l2
+      (by rw [hx12b]; exact h16) (by simp) (cell32_dword2 ..),
+    execInstrRF_ld_dword _ _ _ _ _ _ _ 24 l3
+      (by rw [hx12c]; exact h24) (by simp) (cell32_dword3 ..),
+    execInstrRF_sd_dword _ _ _ _ _ _ _ 0 (by rw [hx12d]; exact h0),
+    execInstrRF_sd_dword _ _ _ _ _ _ _ 8 (by rw [hx12d]; exact h8),
+    execInstrRF_sd_dword _ _ _ _ _ _ _ 16 (by rw [hx12d]; exact h16),
+    hx12a, hx12b, hx12c, hx12d, inRw, Region.loadOk,
+    length_cell32, length_setBytes, h0, h8, h16, h24]
+  and_intros <;> trivial
+
+theorem revCellFn_spec (p l0 l1 l2 l3 base : Word) :
+    (revCellFn p l0 l1 l2 l3).Spec base := by
+  vcgen
+  case revCell.rev.focus =>
+    rintro rf ws A ⟨hx12, hA⟩ hApc hp hhp
+    rw [hA] at hhp
+    refine ⟨cell32 l0 l1 l2 l3, _, ⟨rfl, rfl⟩, ?_, pcFree_pure, ?_⟩
+    · rw [hx12]
+      xperm_hyp hhp
+    · rw [hx12, length_cell32]
+      exact ((sepConj_pure_left hp).mp hhp).1
+  case revCell.rev.mem =>
+    rintro rf ws A win rest - - ⟨rfl, rfl⟩ -
+    exact revCell_blockVCs _ rf l0 l1 l2 l3
+  case revCell.post =>
+    rintro rf ws A ⟨rf₀, A₀, win, rest, -, ⟨hx12, hA⟩, -, ⟨rfl, rfl⟩, hrf, hA'⟩
+    rw [revCell_engine] at hrf hA'
+    rw [hrf, hA']
+    constructor
+    · show ((((rf₀.set .x5 l0).set .x6 l1).set .x7 l2).set .x14 l3).get .x12 = p
+      rw [RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide)]
+      exact hx12
+    · show (bytesRegion (rf₀.get .x12) (cell32 l3 l2 l1 l0) **
+          ⌜RwRegion.wf ⟨p, 32⟩⌝) = _
+      rw [hx12, sepConj_comm']
 
 end ExamplesVc
 end SAsm

--- a/EvmAsm/Rv64/SAsm/MultiDword.lean
+++ b/EvmAsm/Rv64/SAsm/MultiDword.lean
@@ -1,0 +1,100 @@
+/-
+  EvmAsm.Rv64.SAsm.MultiDword
+
+  Reusable algebra for multi-dword focus windows (docs/sasm-howto.md,
+  "Multi-dword focus blocks"): a window that is a concatenation of dword
+  cells (`dwordBytes a ++ (dwordBytes b ++ …)`), read and written at
+  literal offsets 0, 8, 16, ….
+
+  - The slice lemmas reduce `((win.drop k).take 8)` to the k/8-th cell,
+    feeding `execInstrRF_ld_dword`'s `hslice`.
+  - The splice lemmas push `setBytes` through `++`, so a dword store into
+    such a window rewrites to the same concatenation with one cell
+    replaced (`execInstrRF_sd_dword` + `setBytes_append_* ` +
+    `setBytes_dword_full`).
+
+  The worked example is `revCellFn` in ExamplesVc.lean.
+-/
+
+import EvmAsm.Rv64.SAsm.RaSpill
+
+namespace EvmAsm.Rv64
+namespace SAsm
+
+-- ============================================================================
+-- Slices of dword-concatenation windows (for loads)
+-- ============================================================================
+
+/-- The head cell of a dword-concatenation window. -/
+theorem take8_dword_append (v : Word) (rest : List (BitVec 8)) :
+    (dwordBytes v ++ rest).take 8 = dwordBytes v := by
+  rw [List.take_append_of_le_length (by rw [length_dwordBytes]),
+    List.take_of_length_le (by rw [length_dwordBytes])]
+
+/-- Step past the head cell of a dword-concatenation window. -/
+theorem drop8_dword_append (v : Word) (rest : List (BitVec 8)) (k : Nat) :
+    (dwordBytes v ++ rest).drop (8 + k) = rest.drop k := by
+  rw [show 8 + k = (dwordBytes v).length + k from by rw [length_dwordBytes],
+    List.drop_append, List.drop_eq_nil_of_le (by omega), List.nil_append,
+    Nat.add_sub_cancel_left]
+
+/-- A full-dword store replaces the window (the generic multi-dword
+    splice building block). -/
+theorem setBytes_dword_full (ws : List (BitVec 8)) (v : Word)
+    (h : ws.length = 8) : setBytes ws 0 (dwordBytes v) = dwordBytes v := by
+  have h1 := setBytes_slot ws (dwordBytes v) 0 (by rw [length_dwordBytes]; omega)
+  rwa [List.drop_zero, length_dwordBytes,
+    List.take_of_length_le (by rw [length_setBytes]; omega)] at h1
+
+/-- The head cell, packed (feeds `execInstrRF_ld_dword`'s `hslice`). -/
+theorem packDword_at0 (v : Word) (rest : List (BitVec 8)) :
+    packBytes (((dwordBytes v ++ rest).drop 0).take 8) = v := by
+  rw [List.drop_zero, take8_dword_append, packBytes_dwordBytes]
+
+-- ============================================================================
+-- Splices into dword-concatenation windows (for stores)
+-- ============================================================================
+
+/-- A splice entirely inside the left part of `a ++ b` stays left. -/
+theorem setBytes_append_left (a b ns : List (BitVec 8)) (i : Nat)
+    (h : i + ns.length ≤ a.length) :
+    setBytes (a ++ b) i ns = setBytes a i ns ++ b := by
+  induction ns generalizing a i with
+  | nil => rfl
+  | cons n rest ih =>
+      simp only [setBytes_cons]
+      rw [List.set_append_left _ _ (by
+        simp only [List.length_cons] at h
+        omega),
+        ih _ _ (by
+          simp only [List.length_cons] at h
+          simp only [List.length_set]
+          omega)]
+
+/-- A splice entirely inside the right part of `a ++ b` stays right. -/
+theorem setBytes_append_right (a b ns : List (BitVec 8)) (i : Nat)
+    (h : a.length ≤ i) :
+    setBytes (a ++ b) i ns = a ++ setBytes b (i - a.length) ns := by
+  induction ns generalizing b i with
+  | nil => rfl
+  | cons n rest ih =>
+      simp only [setBytes_cons]
+      rw [List.set_append_right _ _ (by omega),
+        ih _ _ (by omega),
+        show i + 1 - a.length = i - a.length + 1 from by omega]
+
+/-- Overwrite the head cell of a dword-concatenation window. -/
+theorem setBytes_dword_at0 (v w : Word) (rest : List (BitVec 8)) :
+    setBytes (dwordBytes v ++ rest) 0 (dwordBytes w) = dwordBytes w ++ rest := by
+  rw [setBytes_append_left _ _ _ _ (by rw [length_dwordBytes, length_dwordBytes]),
+    setBytes_dword_full _ _ (length_dwordBytes v)]
+
+/-- Step a splice past the head cell of a dword-concatenation window. -/
+theorem setBytes_dword_past (v : Word) (rest ns : List (BitVec 8)) (k : Nat) :
+    setBytes (dwordBytes v ++ rest) (8 + k) ns
+      = dwordBytes v ++ setBytes rest k ns := by
+  rw [setBytes_append_right _ _ _ _ (by rw [length_dwordBytes]; omega),
+    length_dwordBytes, show 8 + k - 8 = k from by omega]
+
+end SAsm
+end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/Sym.lean
+++ b/EvmAsm/Rv64/SAsm/Sym.lean
@@ -411,5 +411,107 @@ theorem not_inRw_nil {rwBase a : Word} {n : Nat} (hn : 0 < n) :
       = execBlock ro rwBase (execInstrRF ro rwBase rf ws i).1
           (execInstrRF ro rwBase rf ws i).2 is := rfl
 
+-- ============================================================================
+-- Engine-step projections (multi-access focus blocks)
+--
+-- `blockVCs`/`execBlock` thread the register file through each prior
+-- `execInstrRF`; for loads that term is an unreduced routing `if`, so a
+-- later access's address expression contains the whole previous load
+-- verbatim.  These projections let `simp only`/`rw` normalize
+-- "instruction doesn't write `r`" and "instruction doesn't touch the
+-- window" WITHOUT unfolding `execInstrRF` or resolving the routing `if`s.
+-- Recipe: docs/sasm-howto.md ("Multi-dword focus blocks").
+-- ============================================================================
+
+/-- One engine step leaves every register other than the classified
+    destination unchanged — including for loads, where the result is a
+    routing `if` (both branches set the same `rd`, so the read commutes
+    past the `if` without deciding it). -/
+theorem execInstrRF_get_ne (ro : Region) (rwBase : Word) (rf : RegFile)
+    (ws : List (BitVec 8)) (i : Instr) (r : Reg)
+    (halu : ∀ op, aluSem i = some op → r ≠ op.rd)
+    (hload : ∀ l, loadSem i = some l → r ≠ l.rd) :
+    (execInstrRF ro rwBase rf ws i).1.get r = rf.get r := by
+  unfold execInstrRF
+  cases ha : aluSem i with
+  | some op => exact RegFile.get_set_ne _ _ _ _ (halu op ha)
+  | none =>
+    cases hl : loadSem i with
+    | some l =>
+        dsimp only
+        split <;> exact RegFile.get_set_ne _ _ _ _ (hload l hl)
+    | none =>
+        cases hst : storeSem i with
+        | some st => rfl
+        | none => rfl
+
+/-- Load-step register projection, in directly-`rw`-able per-constructor
+    form: an `LD` into `rd` preserves every other register. -/
+theorem execInstrRF_ld_get_ne (ro : Region) (rwBase : Word) (rf : RegFile)
+    (ws : List (BitVec 8)) (rd rs1 : Reg) (ofs : BitVec 12) (r : Reg)
+    (h : r ≠ rd) :
+    (execInstrRF ro rwBase rf ws (.LD rd rs1 ofs)).1.get r = rf.get r :=
+  execInstrRF_get_ne ro rwBase rf ws _ r (fun op hop => nomatch hop)
+    (fun l hl => by injection hl with hl; subst hl; exact h)
+
+/-- A load step never changes the writable window. -/
+@[simp] theorem execInstrRF_ld_snd (ro : Region) (rwBase : Word)
+    (rf : RegFile) (ws : List (BitVec 8)) (rd rs1 : Reg) (ofs : BitVec 12) :
+    (execInstrRF ro rwBase rf ws (.LD rd rs1 ofs)).2 = ws := by
+  unfold execInstrRF
+  dsimp only [aluSem, loadSem]
+
+/-- A store step never changes the register file. -/
+@[simp] theorem execInstrRF_sd_fst (ro : Region) (rwBase : Word)
+    (rf : RegFile) (ws : List (BitVec 8)) (rs1 rs2 : Reg) (ofs : BitVec 12) :
+    (execInstrRF ro rwBase rf ws (.SD rs1 rs2 ofs)).1 = rf := rfl
+
+/-- A store step splices its payload into the window at the classified
+    index (stated so `.mem`/engine proofs can rewrite without unfolding
+    `execInstrRF`). -/
+theorem execInstrRF_sd_snd (ro : Region) (rwBase : Word) (rf : RegFile)
+    (ws : List (BitVec 8)) (rs1 rs2 : Reg) (ofs : BitVec 12) :
+    (execInstrRF ro rwBase rf ws (.SD rs1 rs2 ofs)).2
+      = setBytes ws ((rf.get rs1 + signExtend12 ofs) - rwBase).toNat
+          (dwordBytes (rf.get rs2)) := rfl
+
+/-- **The dword-load step, fully resolved**: an `LD` whose address lands
+    `k` bytes into the window, where the window's dword at `k` is `v`,
+    is exactly `rf.set rd v` with the window untouched.  Chain this once
+    per load (with `execBlock_cons`) to run a multi-load block through
+    the engine in one `rw` each — no routing `if`s survive.  The `haddr`
+    side condition is `bv_omega` after reducing the `signExtend12`
+    literal (`show signExtend12 (8 : BitVec 12) = (8 : Word) from by
+    decide`); `hslice` is `List.drop`/`take` algebra on the window. -/
+theorem execInstrRF_ld_dword (ro : Region) (rwBase : Word) (rf : RegFile)
+    (ws : List (BitVec 8)) (rd rs1 : Reg) (ofs : BitVec 12) (k : Nat)
+    (v : Word)
+    (haddr : ((rf.get rs1 + signExtend12 ofs) - rwBase).toNat = k)
+    (hfit : k + 8 ≤ ws.length)
+    (hslice : packBytes ((ws.drop k).take 8) = v) :
+    execInstrRF ro rwBase rf ws (.LD rd rs1 ofs) = (rf.set rd v, ws) := by
+  unfold execInstrRF
+  dsimp only [aluSem, loadSem]
+  rw [if_pos (show inRw rwBase ws (rf.get rs1 + signExtend12 ofs) 8 from by
+    unfold inRw
+    rw [haddr]
+    omega)]
+  unfold Region.dwordAt
+  rw [show ((rf.get rs1 + signExtend12 ofs)
+      - (⟨rwBase, ws⟩ : Region).base).toNat = k from haddr,
+    hslice]
+
+/-- **The dword-store step, fully resolved**: an `SD` whose address lands
+    `k` bytes into the window splices `dwordBytes (rf.get rs2)` at `k`
+    and leaves the registers alone. -/
+theorem execInstrRF_sd_dword (ro : Region) (rwBase : Word) (rf : RegFile)
+    (ws : List (BitVec 8)) (rs1 rs2 : Reg) (ofs : BitVec 12) (k : Nat)
+    (haddr : ((rf.get rs1 + signExtend12 ofs) - rwBase).toNat = k) :
+    execInstrRF ro rwBase rf ws (.SD rs1 rs2 ofs)
+      = (rf, setBytes ws k (dwordBytes (rf.get rs2))) := by
+  rw [show execInstrRF ro rwBase rf ws (.SD rs1 rs2 ofs)
+      = (rf, setBytes ws ((rf.get rs1 + signExtend12 ofs) - rwBase).toNat
+          (dwordBytes (rf.get rs2))) from rfl, haddr]
+
 end SAsm
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/TreeInsert.lean
+++ b/EvmAsm/Rv64/SAsm/TreeInsert.lean
@@ -17,6 +17,7 @@
 
 import EvmAsm.Rv64.SAsm.RaSpill
 import EvmAsm.Rv64.SAsm.TreeDemo
+import EvmAsm.Rv64.SAsm.MultiDword
 
 namespace EvmAsm.Rv64
 namespace SAsm
@@ -177,13 +178,6 @@ theorem bytesRegion_node_split (q k a b : Word) :
     bytesRegion_dword_eq q k, bytesRegion_dword_eq (q + 8) a]
   rw [sepConj_assoc', sepConj_emp_left']
   rw [sepConj_assoc', sepConj_emp_left']
-
-/-- A full-dword store replaces the window. -/
-theorem setBytes_dword_full (ws : List (BitVec 8)) (v : Word)
-    (h : ws.length = 8) : setBytes ws 0 (dwordBytes v) = dwordBytes v := by
-  have h1 := setBytes_slot ws (dwordBytes v) 0 (by rw [length_dwordBytes]; omega)
-  rwa [List.drop_zero, length_dwordBytes,
-    List.take_of_length_le (by rw [length_setBytes]; omega)] at h1
 
 /-- `getByteAt` through `drop`. -/
 theorem getByteAt_drop (l : List (BitVec 8)) (n m : Nat)

--- a/PLAN.md
+++ b/PLAN.md
@@ -2537,7 +2537,21 @@ term. Stage 6 landed: docs/sasm-howto.md — the agent-facing working manual
 (model, quickstart, VC recipes, spec surface/consequence/frame, loops +
 counter-register bridge, calls + hand-triple packaging, ghost/focus/
 harvest + tree-walk template, SSZ drop-in port recipe + EEST A/B,
-pitfalls, delivery checklist). Milestone stages 1-6 complete. Stage 5a landed: treeMinFn (TreeDemo.lean) — the tree-walk integration
+pitfalls, delivery checklist). Milestone stages 1-6 complete.
+Ergonomics round 1 (driven by delegated-agent feedback from the CLZ
+port attempt): resolved engine-step lemmas execInstrRF_ld_dword /
+execInstrRF_sd_dword + projections (execInstrRF_get_ne / _ld_snd /
+_sd_fst / _sd_snd) in Sym.lean so multi-access focus blocks never
+materialize nested routing-if trees; SAsm/MultiDword.lean (dword-window
+slice/splice algebra: take8/drop8_dword_append, setBytes_append_left/
+right, setBytes_dword_at0/past/full — setBytes_dword_full moved there
+from TreeInsert); revCellFn demo (ExamplesVc.lean, 4 LD + 4 SD in ONE
+focus block, kernel-clean); howto sections "Multi-dword focus blocks"
+and "Branchy straight-line code" (assert-as-join idiom: rintro ⟨-, hP⟩
+drops the 2^n when-disjunction; branchless SLTIU/SLL preference) + two
+new pitfalls (rintro-rfl whnf timeout on big execBlock equations — rw
+engine into the hypothesis first; numeral-rewrite motive failure vs
+BitVec 8). Stage 5a landed: treeMinFn (TreeDemo.lean) — the tree-walk integration
 proof: while-loop with existential zipper-ghost invariant, focus blocks
 opening nodes at a register-held pointer, ghost descend
 (ctxAt_push_left) with nil-shadow harvest, post-loop reseal

--- a/docs/sasm-howto.md
+++ b/docs/sasm-howto.md
@@ -269,6 +269,69 @@ make the `get`-chains rewrite regardless of the (opaque) loaded values.
 - exit: depth bound + shadow give the nil pointer; a post-loop ghost
   reseals via `ctxAt_zip_fold`.
 
+### Multi-dword focus blocks (N loads/stores at one base)
+
+The worked example is `revCellFn` (ExamplesVc.lean): one focus block that
+loads all four dwords of a 32-byte cell and stores them back reversed.
+**Do not** unfold `execInstrRF` with a broad `simp` — each load leaves a
+routing `if` in the register file, and the next access's address then
+contains the whole previous load verbatim (term blowup, then `whnf`
+heartbeat timeouts).  Instead:
+
+1. **One rewrite per instruction** with the resolved step lemmas
+   (Sym.lean): `execInstrRF_ld_dword` (an `LD` landing `k` bytes into the
+   window with dword `v` there *is* `(rf.set rd v, ws)`) and
+   `execInstrRF_sd_dword` (an `SD` *is* `(rf, setBytes ws k …)`).  Each
+   application discharges its own routing `if`; none survive.  Side
+   conditions: `haddr` via a `signExtend12`-literal `decide` show +
+   `bv_omega`; `hslice` via the MultiDword slice lemmas.
+2. **Window algebra** from `SAsm/MultiDword.lean`: slices
+   (`take8_dword_append`, `drop8_dword_append`, `packDword_at0`) feed the
+   load steps; splices (`setBytes_append_left/right`,
+   `setBytes_dword_at0/past/full`) normalize each store's `setBytes` back
+   into a `dwordBytes … ++ …` concatenation.  Beware rewriting bare
+   numerals (`show (8 : Nat) = 8 + 0`): it abstracts the `8` in
+   `BitVec 8` and fails with "motive is not type correct" — instantiate
+   the lemma at the right `k` and `simp only [Nat.reduceAdd]` the
+   hypothesis instead.
+3. **Base-register stability** as `have`-chains
+   (`(rf.set .x5 l0).get .x12 = rf.get .x12`, …) so every step's `haddr`
+   is about the *original* `rf`.
+4. `.mem` VCs: `simp only [<block>, blockVCs, loadSem, storeSem,
+   <the same step-lemma instances>, <the get-chains>, inRw,
+   Region.loadOk, length_*, <the offset toNat facts>]` reduces every
+   condition to literal arithmetic; finish `and_intros <;> trivial`.
+   The generic projections `execInstrRF_get_ne` / `execInstrRF_ld_snd` /
+   `execInstrRF_sd_fst` cover mixed blocks where a full step resolution
+   is unnecessary.
+5. **After the block**: do NOT `rintro rfl`/`subst` the
+   `rf' = (execBlock …).1` equation of a large block — the unifier
+   whnf-grinds through the load `if`s and times out.  Name the equations
+   (`hrf`, `hA'`), `rw [<engine lemma>] at hrf hA'` **first** (shrinking
+   them to `rf' = rf.set …`-form), and only then rewrite them into the
+   goal.
+
+### Branchy straight-line code: joins and disjunction blowup
+
+`sp` of `.when`/`.ite` is a **disjunction** — `n` sequential `when`s make
+`2^n` reachable-set disjuncts, and every downstream VC must destructure
+all of them.  Two ways out:
+
+- **Prefer branchless data flow** where RV64 allows it: `SLTIU`/`SLTU`
+  materialize conditions as 0/1, `SLL`/`SRL` take *register* shift
+  amounts — a conditional "shift and bump the counter" step becomes
+  `SRLI probe; SLTIU cond; SLLI amt; SLL x; ADD acc` with no branch at
+  all, and `sp` stays a single symbolic path.
+- **`.assert` as a join point**: `sp(assert P) = reach ∧ P`, so a
+  downstream VC can `rintro ⟨-, hP⟩` — the branch disjunction is
+  *dropped* and only the summary `P` flows on.  Put an `.assert` pinning
+  the registers you care about immediately after each `when`/`ite` (the
+  assert's own VC does the 2-way case analysis; done per-branch it stays
+  linear, not exponential).  A shared relational ghost at the join does
+  the same for the ambient assertion (both `ite` arms ending in the SAME
+  `R` — the context existential hides the direction; see
+  `treeInsDescendR` in TreeInsert.lean).
+
 ## 7. Porting an unverified routine (the SSZ drop-in recipe)
 
 The pattern of `ChainIdSAsm.lean` / `ActiveForkSAsm.lean`:
@@ -334,6 +397,14 @@ The pattern of `ChainIdSAsm.lean` / `ActiveForkSAsm.lean`:
 - The routing `if` inside `execInstrRF` lives in the *RegFile component*
   of the result pair, so `.2` (the window) is definitionally inert —
   rely on it (`from rfl` shows) rather than simp.
+- `rintro rfl`/`subst` on `rf' = (execBlock …).1` of a **multi-load
+  block** whnf-times-out (the unifier grinds through the routing `if`s).
+  Name the equation, `rw [<engine>] at` it first (§6, "Multi-dword focus
+  blocks").
+- `rw [show (8 : Nat) = 8 + 0 from rfl]` in byte-list goals fails with
+  "motive is not type correct" — the numeral also occurs as the width in
+  `BitVec 8`.  Instantiate lemmas at the composite index and
+  `simp only [Nat.reduceAdd] at h` instead.
 - Zero-warning policy: heed `unusedSimpArgs` hints; `lake build EvmAsm`
   must be warning-free under `EvmAsm/`.
 


### PR DESCRIPTION
First ergonomics iteration on the SAsm framework, driven by feedback from a delegated agent attempting the CLZ-handler port. The agent got blocked on the `.mem` VC of a 4-load focus block: `blockVCs` threads each later access's address through the previous loads' **unreduced routing `if`s**, so the terms explode and a broad `simp` hits whnf heartbeat timeouts.

## What this adds

- **Resolved step lemmas** (`Sym.lean`): `execInstrRF_ld_dword` — an `LD` whose address lands `k` bytes into the window, where the window's dword at `k` is `v`, *is* `(rf.set rd v, ws)`; and `execInstrRF_sd_dword` for `SD`. One rewrite per instruction, each discharging its own routing `if` — none survive. Plus projections (`execInstrRF_get_ne`, `_ld_snd`, `_sd_fst`, `_sd_snd`) for mixed blocks.
- **`SAsm/MultiDword.lean`** (new): dword-concatenation window algebra — slice lemmas for loads (`take8_dword_append`, `drop8_dword_append`, `packDword_at0`), splice lemmas for stores (`setBytes_append_left/right`, `setBytes_dword_at0/past`); `setBytes_dword_full` moved here from TreeInsert.
- **`revCellFn`** (ExamplesVc.lean): the worked example — 4 `LD` + 4 `SD` in ONE focus block reversing a 32-byte cell, with engine, `blockVCs`, and full `Fn.Spec`. Kernel-clean (`#print axioms` = 3 classical only).
- **Howto**: new subsections *Multi-dword focus blocks* (the 5-step recipe) and *Branchy straight-line code* (the `2^n` `when`-disjunction problem, the `.assert`-as-join idiom — `rintro ⟨-, hP⟩` drops the disjunction — and the branchless `SLTIU`/`SLL` preference); two new pitfalls (`rintro rfl`/`subst` on a large `execBlock` equation whnf-times-out — `rw` the engine lemma into the hypothesis first; bare-numeral rewrites clash with the width in `BitVec 8`).

Gates: `lake build EvmAsm.Rv64.SAsm` zero errors/warnings, `check-forbidden-tactics` OK, `revCellFn_spec` axioms = `[propext, Classical.choice, Quot.sound]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)