### PR TITLE
feat(sasm): structural sp eliminators, the assert cut, and branch-tail summaries (agent-feedback round 3)

### DIFF
--- a/EvmAsm/Codegen/Programs/ClzSAsm.lean
+++ b/EvmAsm/Codegen/Programs/ClzSAsm.lean
@@ -221,27 +221,16 @@ def clzNarrowBlock : List Instr :=
 def clzNarrowBody : Stmt :=
   .block "narrow" clzNarrowBlock
 
-def clzSelectBody : Stmt :=
-  .ite "limb3" (.bne .x14 .x0)
-    (.block "off0" [.LI .x15 0])
-    (.block "limb2" [.MV .x14 .x7, .LI .x15 64] ;;;
-      .ite "limb2nz" (.bne .x14 .x0)
-        (.block "keep2" [])
-        (.block "limb1" [.MV .x14 .x6, .LI .x15 128] ;;;
-          .ite "limb1nz" (.bne .x14 .x0)
-            (.block "keep1" [])
-            (.block "limb0" [.MV .x14 .x5, .LI .x15 192] ;;;
-              .ite "limb0nz" (.bne .x14 .x0)
-                (.block "keep0" [])
-                (.block "zero" [.LI .x15 193]))))
-
-def clzComputed (p pc aux1 aux3 l0 l1 l2 l3 : Word) :
+/-- Register summary after the load block. -/
+def clzLoaded (p pc aux1 aux3 l0 l1 l2 l3 : Word) :
     RegFile → List (BitVec 8) → Assertion → Prop :=
   fun rf _ A =>
     rf.get .x10 = pc ∧ rf.get .x11 = aux1 ∧ rf.get .x12 = p ∧
-    rf.get .x13 = aux3 ∧ rf.get .x15 = clz256 l0 l1 l2 l3 ∧
+    rf.get .x13 = aux3 ∧ rf.get .x5 = l0 ∧ rf.get .x6 = l1 ∧
+    rf.get .x7 = l2 ∧ rf.get .x14 = l3 ∧
     A = (⌜RwRegion.wf ⟨p, 32⟩⌝ ** bytesRegion p (clzCellBytes l0 l1 l2 l3))
 
+/-- Register summary after the limb-select cascade. -/
 def clzSelected (p pc aux1 aux3 l0 l1 l2 l3 : Word) :
     RegFile → List (BitVec 8) → Assertion → Prop :=
   fun rf _ A =>
@@ -251,10 +240,38 @@ def clzSelected (p pc aux1 aux3 l0 l1 l2 l3 : Word) :
     rf.get .x15 = clzSelectedAcc l0 l1 l2 l3 ∧
     A = (⌜RwRegion.wf ⟨p, 32⟩⌝ ** bytesRegion p (clzCellBytes l0 l1 l2 l3))
 
+/-- Register summary after the branchless narrowing. -/
+def clzComputed (p pc aux1 aux3 l0 l1 l2 l3 : Word) :
+    RegFile → List (BitVec 8) → Assertion → Prop :=
+  fun rf _ A =>
+    rf.get .x10 = pc ∧ rf.get .x11 = aux1 ∧ rf.get .x12 = p ∧
+    rf.get .x13 = aux3 ∧ rf.get .x15 = clz256 l0 l1 l2 l3 ∧
+    A = (⌜RwRegion.wf ⟨p, 32⟩⌝ ** bytesRegion p (clzCellBytes l0 l1 l2 l3))
+
+/-- The limb-select cascade, with the SAME `.assert` summary at the tail
+    of every branch (the branch-tail summary idiom, docs/sasm-howto.md):
+    each assert VC sees only its own linear path, and the downstream
+    narrowing recovers `clzSelected` via `Stmt.sp_of_endsWith` with zero
+    case analysis.  Asserts emit no code — `clz_verified` is unchanged. -/
+def clzSelectBody (p pc aux1 aux3 l0 l1 l2 l3 : Word) : Stmt :=
+  have sel : Stmt := .assert "sel" (clzSelected p pc aux1 aux3 l0 l1 l2 l3)
+  .ite "limb3" (.bne .x14 .x0)
+    (.block "off0" [.LI .x15 0] ;;; sel)
+    (.block "limb2" [.MV .x14 .x7, .LI .x15 64] ;;;
+      .ite "limb2nz" (.bne .x14 .x0)
+        sel
+        (.block "limb1" [.MV .x14 .x6, .LI .x15 128] ;;;
+          .ite "limb1nz" (.bne .x14 .x0)
+            sel
+            (.block "limb0" [.MV .x14 .x5, .LI .x15 192] ;;;
+              .ite "limb0nz" (.bne .x14 .x0)
+                sel
+                (.block "zero" [.LI .x15 193] ;;; sel))))
+
 def clzBody (p pc aux1 aux3 l0 l1 l2 l3 : Word) : Stmt :=
   .blockAt "load" .x12 (clzLoadR p l0 l1 l2 l3) clzLoadBlock ;;;
-  clzSelectBody ;;;
-  .assert "selected" (clzSelected p pc aux1 aux3 l0 l1 l2 l3) ;;;
+  .assert "loaded" (clzLoaded p pc aux1 aux3 l0 l1 l2 l3) ;;;
+  clzSelectBody p pc aux1 aux3 l0 l1 l2 l3 ;;;
   clzNarrowBody ;;;
   .assert "computed" (clzComputed p pc aux1 aux3 l0 l1 l2 l3) ;;;
   .blockAt "store" .x12
@@ -412,6 +429,32 @@ private theorem clz_narrow_engine_preserve_x13 (reg : Region) (b : Word)
 private theorem clz64From_zero_193 : clz64From 0 193 = (256 : Word) := by
   decide
 
+-- The tiny ALU engines of the select cascade.
+private theorem clz_li_engine (reg : Region) (b : Word) (rf : RegFile)
+    (ws : List (BitVec 8)) (imm : Word) :
+    (execBlock reg b rf ws [.LI .x15 imm]).1 = rf.set .x15 imm := by
+  simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem]
+
+private theorem clz_mvli_engine (reg : Region) (b : Word) (rf : RegFile)
+    (ws : List (BitVec 8)) (src : Reg) (imm : Word) :
+    (execBlock reg b rf ws [.MV .x14 src, .LI .x15 imm]).1
+      = (rf.set .x14 (rf.get src)).set .x15 imm := by
+  simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem]
+
+private theorem clz_mvli_get_pres (rf : RegFile) (src : Reg) (imm : Word)
+    (r : Reg) (h14 : r ≠ .x14) (h15 : r ≠ .x15) :
+    ((rf.set .x14 (rf.get src)).set .x15 imm).get r = rf.get r := by
+  rw [RegFile.get_set_ne _ _ _ _ h15, RegFile.get_set_ne _ _ _ _ h14]
+
+private theorem clz_mvli_get_x14 (rf : RegFile) (src : Reg) (imm : Word) :
+    ((rf.set .x14 (rf.get src)).set .x15 imm).get .x14 = rf.get src := by
+  rw [RegFile.get_set_ne _ _ _ _ (by decide),
+    RegFile.get_set_self _ _ _ (by decide)]
+
+private theorem clz_mvli_get_x15 (rf : RegFile) (src : Reg) (imm : Word) :
+    ((rf.set .x14 (rf.get src)).set .x15 imm).get .x15 = imm :=
+  RegFile.get_set_self _ _ _ (by decide)
+
 theorem clzFn_spec (p pc aux1 aux3 l0 l1 l2 l3 base : Word) :
     (clzFn p pc aux1 aux3 l0 l1 l2 l3).Spec base := by
   vcgen
@@ -427,6 +470,253 @@ theorem clzFn_spec (p pc aux1 aux3 l0 l1 l2 l3 base : Word) :
   case clz.load.mem =>
     rintro rf ws A win rest - - ⟨hptr, rfl, rfl⟩ -
     exact clz_load_blockVCs _ rf l0 l1 l2 l3
+  case clz.loaded =>
+    refine Stmt.sp_blockAt_split _ _ ?_
+    rintro rf ws A win rest - ⟨hx10, hx11, hx12, hx13, -⟩ - ⟨hptr, rfl, rfl⟩
+    rw [clz_load_engine]
+    unfold clzLoaded
+    refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide)]
+      exact hx10
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide)]
+      exact hx11
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide)]
+      exact hx12
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide)]
+      exact hx13
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_self _ _ _ (by decide)]
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_self _ _ _ (by decide)]
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_self _ _ _ (by decide)]
+    · rw [RegFile.get_set_self _ _ _ (by decide)]
+    · rw [hx12, sepConj_comm']
+  case clz.limb3.t.sel =>
+    refine Stmt.sp_block_split _ _ ?_
+    rintro rf ws A - ⟨⟨-, hL⟩, hc⟩
+    obtain ⟨hx10, hx11, hx12, hx13, hx5, hx6, hx7, hx14, hA⟩ := hL
+    simp only [Cond.holds, RegFile.get_x0, ne_eq] at hc
+    rw [hx14] at hc
+    have hsel : clzSelectedLimb l0 l1 l2 l3 = l3 := by
+      unfold clzSelectedLimb
+      rw [if_pos hc]
+    have hacc : clzSelectedAcc l0 l1 l2 l3 = 0 := by
+      unfold clzSelectedAcc
+      rw [if_pos hc]
+    rw [clz_li_engine]
+    unfold clzSelected
+    refine ⟨?_, ?_, ?_, ?_, ?_, ?_, hA⟩
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide)]
+      exact hx10
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide)]
+      exact hx11
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide)]
+      exact hx12
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide)]
+      exact hx13
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide), hx14, hsel]
+    · rw [RegFile.get_set_self _ _ _ (by decide), hacc]
+  case clz.limb3.e.limb2nz.t.sel =>
+    rintro rf ws A ⟨hblk, hc2⟩
+    obtain ⟨rf₀, ws₀, -, ⟨⟨-, hL⟩, hn3⟩, hrf, -⟩ := hblk
+    obtain ⟨hx10, hx11, hx12, hx13, hx5, hx6, hx7, hx14, hA⟩ := hL
+    rw [clz_mvli_engine] at hrf
+    simp only [Cond.holds, RegFile.get_x0, ne_eq, not_not] at hn3
+    rw [hx14] at hn3
+    simp only [Cond.holds, RegFile.get_x0, ne_eq] at hc2
+    rw [hrf, clz_mvli_get_x14, hx7] at hc2
+    have hsel : clzSelectedLimb l0 l1 l2 l3 = l2 := by
+      unfold clzSelectedLimb
+      rw [if_neg (by simp [hn3]), if_pos hc2]
+    have hacc : clzSelectedAcc l0 l1 l2 l3 = 64 := by
+      unfold clzSelectedAcc
+      rw [if_neg (by simp [hn3]), if_pos hc2]
+    subst hrf
+    unfold clzSelected
+    refine ⟨?_, ?_, ?_, ?_, ?_, ?_, hA⟩
+    · rw [clz_mvli_get_pres _ _ _ _ (by decide) (by decide)]
+      exact hx10
+    · rw [clz_mvli_get_pres _ _ _ _ (by decide) (by decide)]
+      exact hx11
+    · rw [clz_mvli_get_pres _ _ _ _ (by decide) (by decide)]
+      exact hx12
+    · rw [clz_mvli_get_pres _ _ _ _ (by decide) (by decide)]
+      exact hx13
+    · rw [clz_mvli_get_x14, hx7, hsel]
+    · rw [clz_mvli_get_x15, hacc]
+  case clz.limb3.e.limb2nz.e.limb1nz.t.sel =>
+    rintro rf ws A ⟨hb1, hc1⟩
+    obtain ⟨rf₁, ws₁, -, ⟨hb2, hn2⟩, hrf, -⟩ := hb1
+    obtain ⟨rf₀, ws₀, -, ⟨⟨-, hL⟩, hn3⟩, hrf₁, -⟩ := hb2
+    obtain ⟨hx10, hx11, hx12, hx13, hx5, hx6, hx7, hx14, hA⟩ := hL
+    rw [clz_mvli_engine] at hrf₁
+    rw [clz_mvli_engine] at hrf
+    simp only [Cond.holds, RegFile.get_x0, ne_eq, not_not] at hn3 hn2
+    rw [hx14] at hn3
+    rw [hrf₁, clz_mvli_get_x14, hx7] at hn2
+    simp only [Cond.holds, RegFile.get_x0, ne_eq] at hc1
+    have hx6₁ : rf₁.get .x6 = l1 := by
+      rw [hrf₁, clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hx6]
+    rw [hrf, clz_mvli_get_x14, hx6₁] at hc1
+    have hsel : clzSelectedLimb l0 l1 l2 l3 = l1 := by
+      unfold clzSelectedLimb
+      rw [if_neg (by simp [hn3]), if_neg (by simp [hn2]), if_pos hc1]
+    have hacc : clzSelectedAcc l0 l1 l2 l3 = 128 := by
+      unfold clzSelectedAcc
+      rw [if_neg (by simp [hn3]), if_neg (by simp [hn2]), if_pos hc1]
+    subst hrf
+    unfold clzSelected
+    refine ⟨?_, ?_, ?_, ?_, ?_, ?_, hA⟩
+    · rw [clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₁,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide)]
+      exact hx10
+    · rw [clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₁,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide)]
+      exact hx11
+    · rw [clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₁,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide)]
+      exact hx12
+    · rw [clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₁,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide)]
+      exact hx13
+    · rw [clz_mvli_get_x14, hx6₁, hsel]
+    · rw [clz_mvli_get_x15, hacc]
+  case clz.limb3.e.limb2nz.e.limb1nz.e.limb0nz.t.sel =>
+    rintro rf ws A ⟨hb1, hc0⟩
+    obtain ⟨rf₂, ws₂, -, ⟨hb2, hn1⟩, hrf, -⟩ := hb1
+    obtain ⟨rf₁, ws₁, -, ⟨hb3, hn2⟩, hrf₂, -⟩ := hb2
+    obtain ⟨rf₀, ws₀, -, ⟨⟨-, hL⟩, hn3⟩, hrf₁, -⟩ := hb3
+    obtain ⟨hx10, hx11, hx12, hx13, hx5, hx6, hx7, hx14, hA⟩ := hL
+    rw [clz_mvli_engine] at hrf₁
+    rw [clz_mvli_engine] at hrf₂
+    rw [clz_mvli_engine] at hrf
+    simp only [Cond.holds, RegFile.get_x0, ne_eq, not_not] at hn3 hn2 hn1
+    rw [hx14] at hn3
+    rw [hrf₁, clz_mvli_get_x14, hx7] at hn2
+    have hx6₁ : rf₁.get .x6 = l1 := by
+      rw [hrf₁, clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hx6]
+    rw [hrf₂, clz_mvli_get_x14, hx6₁] at hn1
+    have hx5₂ : rf₂.get .x5 = l0 := by
+      rw [hrf₂, clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₁,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hx5]
+    simp only [Cond.holds, RegFile.get_x0, ne_eq] at hc0
+    rw [hrf, clz_mvli_get_x14, hx5₂] at hc0
+    have hsel : clzSelectedLimb l0 l1 l2 l3 = l0 := by
+      unfold clzSelectedLimb
+      rw [if_neg (by simp [hn3]), if_neg (by simp [hn2]),
+        if_neg (by simp [hn1]), if_pos hc0]
+    have hacc : clzSelectedAcc l0 l1 l2 l3 = 192 := by
+      unfold clzSelectedAcc
+      rw [if_neg (by simp [hn3]), if_neg (by simp [hn2]),
+        if_neg (by simp [hn1]), if_pos hc0]
+    subst hrf
+    unfold clzSelected
+    refine ⟨?_, ?_, ?_, ?_, ?_, ?_, hA⟩
+    · rw [clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₂,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₁,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide)]
+      exact hx10
+    · rw [clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₂,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₁,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide)]
+      exact hx11
+    · rw [clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₂,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₁,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide)]
+      exact hx12
+    · rw [clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₂,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₁,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide)]
+      exact hx13
+    · rw [clz_mvli_get_x14, hx5₂, hsel]
+    · rw [clz_mvli_get_x15, hacc]
+  case clz.limb3.e.limb2nz.e.limb1nz.e.limb0nz.e.sel =>
+    refine Stmt.sp_block_split _ _ ?_
+    rintro rf ws A - ⟨hb1, hn0⟩
+    obtain ⟨rf₂, ws₂, -, ⟨hb2, hn1⟩, hrf, -⟩ := hb1
+    obtain ⟨rf₁, ws₁, -, ⟨hb3, hn2⟩, hrf₂, -⟩ := hb2
+    obtain ⟨rf₀, ws₀, -, ⟨⟨-, hL⟩, hn3⟩, hrf₁, -⟩ := hb3
+    obtain ⟨hx10, hx11, hx12, hx13, hx5, hx6, hx7, hx14, hA⟩ := hL
+    rw [clz_mvli_engine] at hrf₁
+    rw [clz_mvli_engine] at hrf₂
+    rw [clz_mvli_engine] at hrf
+    simp only [Cond.holds, RegFile.get_x0, ne_eq, not_not] at hn3 hn2 hn1 hn0
+    rw [hx14] at hn3
+    rw [hrf₁, clz_mvli_get_x14, hx7] at hn2
+    have hx6₁ : rf₁.get .x6 = l1 := by
+      rw [hrf₁, clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hx6]
+    rw [hrf₂, clz_mvli_get_x14, hx6₁] at hn1
+    have hx5₂ : rf₂.get .x5 = l0 := by
+      rw [hrf₂, clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₁,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hx5]
+    rw [hrf, clz_mvli_get_x14, hx5₂] at hn0
+    have hsel : clzSelectedLimb l0 l1 l2 l3 = 0 := by
+      unfold clzSelectedLimb
+      rw [if_neg (by simp [hn3]), if_neg (by simp [hn2]),
+        if_neg (by simp [hn1]), if_neg (by simp [hn0])]
+    have hacc : clzSelectedAcc l0 l1 l2 l3 = 193 := by
+      unfold clzSelectedAcc
+      rw [if_neg (by simp [hn3]), if_neg (by simp [hn2]),
+        if_neg (by simp [hn1]), if_neg (by simp [hn0])]
+    subst hrf
+    rw [clz_li_engine]
+    unfold clzSelected
+    refine ⟨?_, ?_, ?_, ?_, ?_, ?_, hA⟩
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide),
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₂,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₁,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide)]
+      exact hx10
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide),
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₂,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₁,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide)]
+      exact hx11
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide),
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₂,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₁,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide)]
+      exact hx12
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide),
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₂,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide), hrf₁,
+        clz_mvli_get_pres _ _ _ _ (by decide) (by decide)]
+      exact hx13
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide), clz_mvli_get_x14, hx5₂,
+        hsel]
+      exact hn0
+    · rw [RegFile.get_set_self _ _ _ (by decide), hacc]
+  case clz.computed =>
+    refine Stmt.sp_block_split _ _ ?_
+    rintro rf ws A - hsel
+    have hP := Stmt.sp_of_endsWith _ _
+      (P := clzSelected p pc aux1 aux3 l0 l1 l2 l3)
+      (by simp [clzSelectBody, Stmt.EndsWith]) rf ws A hsel
+    obtain ⟨hx10, hx11, hx12, hx13, hx14, hx15, hA⟩ := hP
+    unfold clzComputed
+    refine ⟨?_, ?_, ?_, ?_, ?_, hA⟩
+    · rw [clz_narrow_engine_preserve_x10, hx10]
+    · rw [clz_narrow_engine_preserve_x11, hx11]
+    · rw [clz_narrow_engine_preserve_x12, hx12]
+    · rw [clz_narrow_engine_preserve_x13, hx13]
+    · rw [clz_narrow_engine_x15, hx14, hx15]
+      rfl
   case clz.store.focus =>
     rintro rf ws A ⟨hsp, hcomp⟩ hApc hp hhp
     obtain ⟨hx10, hx11, hx12, hx13, hx15, hA⟩ := hcomp
@@ -440,27 +730,17 @@ theorem clzFn_spec (p pc aux1 aux3 l0 l1 l2 l3 base : Word) :
   case clz.store.mem =>
     rintro rf ws A win rest - hreach ⟨hptr, rfl, rfl⟩ -
     exact clz_store_blockVCs _ rf l0 l1 l2 l3
-  case clz.selected =>
-    rintro rf ws A h
-    aesop (add simp [clzFn, clzSelected, Stmt.sp, clzSelectBody, clzLoadR,
-      clzSelectedLimb, clzSelectedAcc, clz_load_engine, Cond.holds, execInstrRF,
-      aluSem, RegFile.get_set_self, RegFile.get_set_ne, sepConj_comm'])
-  case clz.computed =>
-    rintro rf ws A ⟨rf₀, ws₀, hws₀, ⟨hprev, hsel⟩, hrf, hws⟩
-    obtain ⟨hx10, hx11, hx12, hx13, hx14, hx15, hA⟩ := hsel
-    unfold clzComputed
-    refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
-    · rw [hrf, clz_narrow_engine_preserve_x10, hx10]
-    · rw [hrf, clz_narrow_engine_preserve_x11, hx11]
-    · rw [hrf, clz_narrow_engine_preserve_x12, hx12]
-    · rw [hrf, clz_narrow_engine_preserve_x13, hx13]
-    · rw [hrf, clz_narrow_engine_x15, hx14, hx15]
-      rfl
-    · exact hA
   case clz.post =>
-    rintro rf ws A h
-    aesop (add simp [clzFn, clzBody, clzComputed, clzStoreR, Stmt.sp,
-      clz_store_engine, sepConj_comm'])
+    intro rf ws A h
+    have h' := Stmt.sp_cut _ _
+      (.blockAt "store" .x12 (clzStoreR p l0 l1 l2 l3) clzStoreBlock)
+      "computed" rf ws A h
+    refine Stmt.sp_blockAt_split _ _ ?_ rf ws A h'
+    rintro rf₀ ws₀ A₀ win rest - hcomp - ⟨hptr, rfl, rfl⟩
+    obtain ⟨hx10, hx11, hx12, hx13, hx15, -⟩ := hcomp
+    rw [clz_store_engine]
+    refine ⟨hx10, hx11, hx12, hx13, ?_⟩
+    rw [hx12, hx15, sepConj_comm']
 
 
 end ClzSAsm

--- a/EvmAsm/Rv64/SAsm/Vc.lean
+++ b/EvmAsm/Rv64/SAsm/Vc.lean
@@ -199,6 +199,136 @@ theorem sp_mono (reg : Region) (rw : RwRegion) (s : Stmt) {r₁ r₂ : Reach}
   | call lbl f =>
       exact fun rf ws A hr => hr
 
+-- ============================================================================
+-- Structural `sp` eliminators (docs/sasm-howto.md, "Branchy straight-line
+-- code"): prove `∀ rf ws A, sp s reach rf ws A → P rf ws A` by the shape
+-- of `s`, without hand-destructuring the raw existentials/disjunctions.
+-- ============================================================================
+
+/-- `sp` through `;;;`, as a rewrite. -/
+theorem sp_seq_eq (reg : Region) (rw : RwRegion) (a b : Stmt) (reach : Reach) :
+    sp reg rw (.seq a b) reach = sp reg rw b (sp reg rw a reach) := rfl
+
+/-- `sp` through `.assert`, as a rewrite. -/
+theorem sp_assert_eq (reg : Region) (rw : RwRegion) (lbl : String)
+    (P reach : Reach) :
+    sp reg rw (.assert lbl P) reach
+      = fun rf ws A => reach rf ws A ∧ P rf ws A := rfl
+
+/-- **The cut**: downstream of an `.assert`, the pre-assert reachable set
+    may be forgotten — any `sp` continuation from `sp (assert P) reach`
+    is also an `sp` continuation from `P` alone.  Apply this first in a
+    VC whose reach passes through an assert; the rest of the proof only
+    ever sees the summary `P`. -/
+theorem sp_cut (reg : Region) (rw : RwRegion) (s : Stmt) (lbl : String)
+    {reach P : Reach} :
+    ∀ rf ws A, sp reg rw s (sp reg rw (.assert lbl P) reach) rf ws A →
+      sp reg rw s P rf ws A :=
+  sp_mono reg rw s (fun _ _ _ h => h.2)
+
+/-- Split an `.ite` elimination into its two branches. -/
+theorem sp_ite_split (reg : Region) (rw : RwRegion) {lbl : String}
+    {c : Cond} {t e : Stmt} {reach : Reach} {P : Reach}
+    (ht : ∀ rf ws A,
+      sp reg rw t (fun rf ws A => reach rf ws A ∧ c.holds rf) rf ws A →
+      P rf ws A)
+    (he : ∀ rf ws A,
+      sp reg rw e (fun rf ws A => reach rf ws A ∧ ¬ c.holds rf) rf ws A →
+      P rf ws A) :
+    ∀ rf ws A, sp reg rw (.ite lbl c t e) reach rf ws A → P rf ws A := by
+  rintro rf ws A (h | h)
+  · exact ht rf ws A h
+  · exact he rf ws A h
+
+/-- Split a `.when` elimination into its body and skip paths. -/
+theorem sp_when_split (reg : Region) (rw : RwRegion) {lbl : String}
+    {c : Cond} {b : Stmt} {reach : Reach} {P : Reach}
+    (hb : ∀ rf ws A,
+      sp reg rw b (fun rf ws A => reach rf ws A ∧ c.holds rf) rf ws A →
+      P rf ws A)
+    (hskip : ∀ rf ws A, reach rf ws A → ¬ c.holds rf → P rf ws A) :
+    ∀ rf ws A, sp reg rw (.when lbl c b) reach rf ws A → P rf ws A := by
+  rintro rf ws A (h | ⟨hr, hn⟩)
+  · exact hb rf ws A h
+  · exact hskip rf ws A hr hn
+
+/-- Eliminate a `.block`: prove `P` of the engine result at every
+    reachable entry state. -/
+theorem sp_block_split (reg : Region) (rw : RwRegion) {lbl : String}
+    {is : List Instr} {reach : Reach} {P : Reach}
+    (h : ∀ rf ws A, ws.length = rw.len → reach rf ws A →
+      P (execBlock reg rw.base rf ws is).1
+        (execBlock reg rw.base rf ws is).2 A) :
+    ∀ rf ws A, sp reg rw (.block lbl is) reach rf ws A → P rf ws A := by
+  rintro rf' ws' A ⟨rf, ws, hlen, hr, rfl, rfl⟩
+  exact h rf ws A hlen hr
+
+/-- Eliminate a `.blockAt`: prove `P` of the engine result over the
+    focused window at every reachable entry state — the post-VC shape
+    after a focus block, without hand-destructuring the six-tuple. -/
+theorem sp_blockAt_split (reg : Region) (rw : RwRegion) {lbl : String}
+    {p : Reg}
+    {winR : RegFile → List (BitVec 8) → Assertion →
+      List (BitVec 8) → Assertion → Prop}
+    {is : List Instr} {reach : Reach} {P : Reach}
+    (h : ∀ rf ws A win rest, ws.length = rw.len → reach rf ws A →
+      (∃ hp, (bytesRegion (rf.get p) win ** rest) hp) →
+      winR rf ws A win rest →
+      P (execBlock reg (rf.get p) rf win is).1 ws
+        ((bytesRegion (rf.get p) (execBlock reg (rf.get p) rf win is).2)
+          ** rest)) :
+    ∀ rf' ws' A'', sp reg rw (.blockAt lbl p winR is) reach rf' ws' A'' →
+      P rf' ws' A'' := by
+  rintro rf' ws' A'' ⟨rf, A, win, rest, hlen, hr, hsat, hwinR, rfl, rfl⟩
+  exact h rf ws' A win rest hlen hr hsat hwinR
+
+/-- Eliminate a `.ghost`. -/
+theorem sp_ghost_split (reg : Region) (rw : RwRegion) {lbl : String}
+    {R : RegFile → List (BitVec 8) → Assertion → Assertion → Prop}
+    {reach : Reach} {P : Reach}
+    (h : ∀ rf ws A A', reach rf ws A → (∃ hp, A hp) → R rf ws A A' →
+      P rf ws A') :
+    ∀ rf ws A', sp reg rw (.ghost lbl R) reach rf ws A' → P rf ws A' := by
+  rintro rf ws A' ⟨A, hr, hsat, hR⟩
+  exact h rf ws A A' hr hsat hR
+
+/-- Every control path through the statement ends in `.assert P`
+    (syntactically).  This is the *branch-tail summary* shape: instead of
+    one `.assert` after an `ite` cascade (whose VC must destructure the
+    whole disjunction), place the SAME assert at the tail of every
+    branch — each assert VC then sees only its own linear path, and
+    `sp_of_endsWith` hands the downstream the summary with no case
+    analysis at all. -/
+def EndsWith (P : Reach) : Stmt → Prop
+  | .assert _ Q => Q = P
+  | .seq _ b => b.EndsWith P
+  | .ite _ _ t e => t.EndsWith P ∧ e.EndsWith P
+  | _ => False
+
+/-- The branch-tail summary: if every path ends in `.assert P`, the
+    strongest postcondition entails `P` — for any entry reachable set. -/
+theorem sp_of_endsWith (reg : Region) (rw : RwRegion) {P : Reach}
+    {s : Stmt} (h : s.EndsWith P) :
+    ∀ {reach : Reach} (rf : RegFile) (ws : List (BitVec 8)) (A : Assertion),
+      sp reg rw s reach rf ws A → P rf ws A := by
+  induction s with
+  | assert lbl Q =>
+      intro reach rf ws A hsp
+      exact h ▸ hsp.2
+  | seq a b iha ihb =>
+      intro reach rf ws A hsp
+      exact ihb h rf ws A hsp
+  | ite lbl c t e iht ihe =>
+      rintro reach rf ws A (hsp | hsp)
+      · exact iht h.1 rf ws A hsp
+      · exact ihe h.2 rf ws A hsp
+  | block lbl is => exact nomatch h
+  | «when» lbl c b ih => exact nomatch h
+  | blockAt lbl p winR is => exact nomatch h
+  | ghost lbl R => exact nomatch h
+  | «while» lbl c fuel inv b ih => exact nomatch h
+  | call lbl f => exact nomatch h
+
 /-- `vcs` is antitone in the reachable set: obligations proven for a larger
     reachable set cover any smaller one.  Used to specialize loop-body VCs
     (generated at the union over iterations) to a specific iteration. -/

--- a/PLAN.md
+++ b/PLAN.md
@@ -2551,7 +2551,17 @@ and "Branchy straight-line code" (assert-as-join idiom: rintro ⟨-, hP⟩
 drops the 2^n when-disjunction; branchless SLTIU/SLL preference) + two
 new pitfalls (rintro-rfl whnf timeout on big execBlock equations — rw
 engine into the hypothesis first; numeral-rewrite motive failure vs
-BitVec 8). CLZ handler port landed on this substrate: ClzSAsm.lean
+BitVec 8). Ergonomics round 3 (from the round-2 CLZ feedback):
+structural sp eliminators in Vc.lean (sp_ite_split/sp_when_split/
+sp_block_split/sp_blockAt_split/sp_ghost_split + sp_seq_eq/sp_assert_eq),
+Stmt.sp_cut (the assert cut: downstream of an .assert, forget the
+pre-assert reach), and Stmt.EndsWith + sp_of_endsWith (branch-tail
+summaries: the SAME .assert at every ite-branch tail → per-leaf linear
+VCs + zero-case-analysis downstream summary). ClzSAsm.lean reworked as
+the demonstration: both bounded-aesop VCs replaced by the structural
+lemmas (clzSelectBody now carries per-branch asserts; emitted code
+unchanged). Howto: new subsections for the eliminators and branch-tail
+summaries. CLZ handler port landed on this substrate: ClzSAsm.lean
 now provides clzFn_spec and clz_verified, and h_CLZ uses the verified
 SAsm body plus advanceAndRet instead of the legacy raw custom tail.
 Stage 5a landed: treeMinFn (TreeDemo.lean) — the tree-walk integration

--- a/docs/sasm-howto.md
+++ b/docs/sasm-howto.md
@@ -332,6 +332,46 @@ all of them.  Two ways out:
   `R` — the context existential hides the direction; see
   `treeInsDescendR` in TreeInsert.lean).
 
+### The structural `sp` eliminators (Vc.lean)
+
+For any VC of the form `∀ rf ws A, sp s reach rf ws A → P rf ws A`,
+prove it by the shape of `s` instead of hand-destructuring the raw
+existentials/disjunctions:
+
+- `Stmt.sp_ite_split` / `sp_when_split` — one subgoal per branch;
+- `Stmt.sp_block_split` / `sp_blockAt_split` — prove `P` of the engine
+  result at every reachable entry (the post-VC shape after a block,
+  without the six-tuple `rintro`);
+- `Stmt.sp_ghost_split`; `sp_seq_eq` / `sp_assert_eq` rfl-rewrites.
+- **`Stmt.sp_cut`** — the assert cut:
+  `sp s (sp (assert P) reach) → sp s P`.  Apply it first in any VC whose
+  reach passes through an `.assert`; everything before the assert is
+  forgotten and the rest of the proof only sees the summary `P`
+  (`ClzSAsm.lean`'s `clz.post`: one `sp_cut`, one `sp_blockAt_split`,
+  then five rewrites).
+
+### Branch-tail summaries: `Stmt.EndsWith` + `sp_of_endsWith`
+
+For an `ite` *cascade* (n-way limb select, dispatch trees), a single
+`.assert` after the join still faces the full n-way disjunction in its
+own VC.  Instead, place the SAME `.assert P` at the **tail of every
+branch**:
+
+- each assert VC sees only its own linear path (one branch's blocks and
+  conditions — small, engine-lemma-sized);
+- the downstream recovers `P` with **zero case analysis** via
+  `Stmt.sp_of_endsWith (P := …) (by simp [<cascade def>, Stmt.EndsWith])`
+  — `EndsWith` checks syntactically that every path ends in `.assert P`.
+- asserts emit no code, so the flattened `Program` (and its `#guard`s)
+  are unchanged.
+
+The worked instance is `clzSelectBody`/`clzFn_spec` in
+`EvmAsm/Codegen/Programs/ClzSAsm.lean`: a 5-leaf select cascade, five
+~25-line leaf VCs, and a `computed` VC that gets the joined summary in
+one line.  (A bounded `aesop (add simp [Stmt.sp, …])` can close such
+VCs too, but is slower and brittle under definition changes — prefer
+the structural lemmas.)
+
 ## 7. Porting an unverified routine (the SSZ drop-in recipe)
 
 The pattern of `ChainIdSAsm.lean` / `ActiveForkSAsm.lean`:


### PR DESCRIPTION
Third ergonomics iteration, driven by the round-2 feedback from the delegated CLZ port (#9694, merged): the two VC shapes the agent could only close with bounded `aesop` — the n-way ite-cascade summary and the `assert`+`blockAt` post plumbing — get principled tools, and the CLZ proof itself is reworked as the demonstration (now **aesop-free**).

## Framework (`Vc.lean`)

- **Structural `sp` eliminators** — prove `∀ rf ws A, sp s reach → P` by the shape of `s`: `sp_ite_split` / `sp_when_split` (one subgoal per branch), `sp_block_split` / `sp_blockAt_split` (prove `P` of the engine result at every reachable entry, no six-tuple `rintro`), `sp_ghost_split`, and `sp_seq_eq` / `sp_assert_eq` rfl-rewrites.
- **`Stmt.sp_cut`** — the assert cut: `sp s (sp (assert P) reach) → sp s P`. Downstream of an `.assert`, everything before it is forgotten in one lemma application.
- **`Stmt.EndsWith` + `sp_of_endsWith`** — branch-tail summaries: place the SAME `.assert P` at the tail of every branch of an ite cascade; each assert VC sees only its own linear path, and the downstream recovers `P` with zero case analysis (`sp_of_endsWith (P := …) (by simp [<cascade>, Stmt.EndsWith])`). Asserts emit no code, so the flattened `Program` is unchanged.

## Demonstration (`ClzSAsm.lean`)

`clzSelectBody` now carries per-branch asserts plus an `.assert "loaded"` after the load focus block. The two `aesop (add simp [Stmt.sp, execInstrRF, …])` calls are gone:
- five ~25-line leaf VCs (one per select path);
- `computed` gets the joined `clzSelected` summary in one `sp_of_endsWith` line;
- `post` is one `sp_cut` + one `sp_blockAt_split` + five rewrites.

`clz_verified` and all its `#guard`s (length 52, position independence, the exhaustive model checks) are unchanged — this is proof-layer only.

## Docs

`docs/sasm-howto.md`: new subsections *The structural sp eliminators* and *Branch-tail summaries* under "Branchy straight-line code", with the CLZ file as the worked instance and a note that bounded `aesop` remains a legitimate-but-brittle fallback.

Gates: `lake build` (SAsm umbrella + Codegen registry + ClzSAsm) zero errors/warnings; `check-forbidden-tactics` OK; `#print axioms clzFn_spec` = `[propext, Classical.choice, Quot.sound]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)