### PR TITLE
feat(sasm): byte-granularity focus-block support (agent-feedback round 4)

### DIFF
--- a/EvmAsm/Rv64/SAsm/ExamplesVc.lean
+++ b/EvmAsm/Rv64/SAsm/ExamplesVc.lean
@@ -1203,6 +1203,184 @@ theorem revCellFn_spec (p l0 l1 l2 l3 base : Word) :
           ⌜RwRegion.wf ⟨p, 32⟩⌝) = _
       rw [hx12, sepConj_comm']
 
+-- ============================================================================
+-- Byte-granularity focus blocks: `rev4Fn`
+--
+-- The worked example for docs/sasm-howto.md ("Byte-granularity focus
+-- blocks"): reverse a 4-byte cell in place with two unrolled
+-- literal-offset swaps.  The recipe:
+--   1. `execInstrRF_lbu_byte` / `execInstrRF_sb_byte` (Sym.lean) — one
+--      rewrite per byte access, no routing `if`s;
+--   2. `setBytes_singleton` + `truncate_zeroExtend_byte` (MultiDword) —
+--      each store becomes a plain `List.set` of the original byte;
+--   3. for a FIXED-SIZE window, explode the byte list into cons cells
+--      (`w = [b0, b1, b2, b3]`) — `List.set`/`getD`/`reverse` then all
+--      reduce definitionally, so the engine result and `w.reverse` match
+--      by `rfl`-strength reasoning, with no take/drop invariants.
+-- ============================================================================
+
+/-- Swap the bytes at literal offsets `lo`/`hi` of the cell at `a2`. -/
+def byteSwapAt (lo hi : BitVec 12) : List Instr :=
+  [.LBU .x5 .x12 lo, .LBU .x6 .x12 hi, .SB .x12 .x6 lo, .SB .x12 .x5 hi]
+
+def rev4Block : List Instr := byteSwapAt 0 3 ++ byteSwapAt 1 2
+
+def rev4R (p : Word) (w : List (BitVec 8)) :
+    RegFile → List (BitVec 8) → Assertion →
+      List (BitVec 8) → Assertion → Prop :=
+  fun rf _ _ win rest =>
+    rf.get .x12 = p ∧ win = w ∧ rest = ⌜RwRegion.wf ⟨p, 4⟩⌝
+
+/-- Reverse the 4-byte cell at `a2` in place. -/
+def rev4Fn (p : Word) (w : List (BitVec 8)) : Fn where
+  name := "rev4"
+  pre := fun rf _ A => rf.get .x12 = p ∧ w.length = 4 ∧
+    A = (⌜RwRegion.wf ⟨p, 4⟩⌝ ** bytesRegion p w)
+  post := fun rf _ A => rf.get .x12 = p ∧
+    A = (⌜RwRegion.wf ⟨p, 4⟩⌝ ** bytesRegion p w.reverse)
+  body := .blockAt "rev" .x12 (rev4R p w) rev4Block
+
+private theorem rev4_off (b : Word) (ofs : BitVec 12) (k : Nat)
+    (hofs : signExtend12 ofs = BitVec.ofNat 64 k) (hk : k < 2 ^ 12) :
+    ((b + signExtend12 ofs) - b).toNat = k := by
+  rw [hofs]
+  bv_omega
+
+/-- The engine over the EXPLODED window: with the four bytes named, every
+    `getD`/`set` computes, and the final window is literally the reversal
+    (the closing `rfl` checks it by kernel reduction — no take/drop
+    invariant anywhere). -/
+private theorem rev4_engine (reg : Region) (rf : RegFile)
+    (b0 b1 b2 b3 : BitVec 8) :
+    execBlock reg (rf.get .x12) rf [b0, b1, b2, b3] rev4Block
+      = ((((rf.set .x5 (b0.zeroExtend 64)).set .x6 (b3.zeroExtend 64)).set
+            .x5 (b1.zeroExtend 64)).set .x6 (b2.zeroExtend 64),
+         [b3, b2, b1, b0]) := by
+  have h0 := rev4_off (rf.get .x12) 0 0 (by decide) (by decide)
+  have h1 := rev4_off (rf.get .x12) 1 1 (by decide) (by decide)
+  have h2 := rev4_off (rf.get .x12) 2 2 (by decide) (by decide)
+  have h3 := rev4_off (rf.get .x12) 3 3 (by decide) (by decide)
+  have hx12a : ∀ v : Word, (rf.set .x5 v).get .x12 = rf.get .x12 :=
+    fun v => RegFile.get_set_ne _ _ _ _ (by decide)
+  have hx12b : ∀ v w : Word, ((rf.set .x5 v).set .x6 w).get .x12
+      = rf.get .x12 := fun v w => by
+    rw [RegFile.get_set_ne _ _ _ _ (by decide), hx12a]
+  rw [show rev4Block = [.LBU .x5 .x12 0, .LBU .x6 .x12 3, .SB .x12 .x6 0,
+      .SB .x12 .x5 3, .LBU .x5 .x12 1, .LBU .x6 .x12 2, .SB .x12 .x6 1,
+      .SB .x12 .x5 2] from rfl]
+  rw [execBlock_cons, execInstrRF_lbu_byte _ _ _ _ _ _ _ 0 h0 (by simp)]
+  rw [execBlock_cons, execInstrRF_lbu_byte _ _ _ _ _ _ _ 3
+    (by rw [hx12a]; exact h3) (by simp)]
+  rw [execBlock_cons, execInstrRF_sb_byte _ _ _ _ _ _ _ 0
+    (by rw [hx12b]; exact h0)]
+  rw [RegFile.get_set_self _ _ _ (by decide), setBytes_singleton,
+    truncate_zeroExtend_byte]
+  rw [execBlock_cons, execInstrRF_sb_byte _ _ _ _ _ _ _ 3
+    (by rw [hx12b]; exact h3)]
+  rw [RegFile.get_set_ne _ _ _ _ (by decide),
+    RegFile.get_set_self _ _ _ (by decide), setBytes_singleton,
+    truncate_zeroExtend_byte]
+  rw [execBlock_cons, execInstrRF_lbu_byte _ _ _ _ _ _ _ 1
+    (by rw [hx12b]; exact h1) (by simp)]
+  rw [execBlock_cons, execInstrRF_lbu_byte _ _ _ _ _ _ _ 2
+    (by rw [RegFile.get_set_ne _ _ _ _ (by decide), hx12b]; exact h2)
+    (by simp)]
+  rw [execBlock_cons, execInstrRF_sb_byte _ _ _ _ _ _ _ 1
+    (by rw [RegFile.get_set_ne _ _ _ _ (by decide),
+      RegFile.get_set_ne _ _ _ _ (by decide), hx12b]; exact h1)]
+  rw [RegFile.get_set_self _ _ _ (by decide), setBytes_singleton,
+    truncate_zeroExtend_byte]
+  rw [execBlock_cons, execInstrRF_sb_byte _ _ _ _ _ _ _ 2
+    (by rw [RegFile.get_set_ne _ _ _ _ (by decide),
+      RegFile.get_set_ne _ _ _ _ (by decide), hx12b]; exact h2)]
+  rw [RegFile.get_set_ne _ _ _ _ (by decide),
+    RegFile.get_set_self _ _ _ (by decide), setBytes_singleton,
+    truncate_zeroExtend_byte]
+  rfl
+
+/-- The `.mem` VCs: byte accesses only need the in-window bound. -/
+private theorem rev4_blockVCs (reg : Region) (rf : RegFile)
+    (b0 b1 b2 b3 : BitVec 8) :
+    blockVCs reg (rf.get .x12) rf [b0, b1, b2, b3] rev4Block := by
+  have h0 := rev4_off (rf.get .x12) 0 0 (by decide) (by decide)
+  have h1 := rev4_off (rf.get .x12) 1 1 (by decide) (by decide)
+  have h2 := rev4_off (rf.get .x12) 2 2 (by decide) (by decide)
+  have h3 := rev4_off (rf.get .x12) 3 3 (by decide) (by decide)
+  have hx12a : ∀ v : Word, (rf.set .x5 v).get .x12 = rf.get .x12 :=
+    fun v => RegFile.get_set_ne _ _ _ _ (by decide)
+  have hx12b : ∀ v w : Word, ((rf.set .x5 v).set .x6 w).get .x12
+      = rf.get .x12 := fun v w => by
+    rw [RegFile.get_set_ne _ _ _ _ (by decide), hx12a]
+  rw [show rev4Block = [.LBU .x5 .x12 0, .LBU .x6 .x12 3, .SB .x12 .x6 0,
+      .SB .x12 .x5 3, .LBU .x5 .x12 1, .LBU .x6 .x12 2, .SB .x12 .x6 1,
+      .SB .x12 .x5 2] from rfl]
+  simp only [blockVCs, loadSem, storeSem]
+  rw [execInstrRF_lbu_byte _ _ _ _ _ _ _ 0 h0 (by simp)]
+  dsimp only
+  rw [execInstrRF_lbu_byte _ _ _ _ _ _ _ 3 (by rw [hx12a]; exact h3) (by simp)]
+  dsimp only
+  -- the SB steps never change the register file (`execInstrRF_sb_fst`,
+  -- a simp lemma), so the later loads' side conditions normalize through
+  -- them without resolving the stores
+  rw [execInstrRF_lbu_byte _ _ _ _ _ _ _ 1
+    (by simp only [execInstrRF_sb_fst]; rw [hx12b]; exact h1)
+    (by simp [execInstrRF_sb_snd])]
+  dsimp only
+  rw [execInstrRF_lbu_byte _ _ _ _ _ _ _ 2
+    (by simp only [execInstrRF_sb_fst]
+        rw [RegFile.get_set_ne _ _ _ _ (by decide), hx12b]; exact h2)
+    (by simp [execInstrRF_sb_snd])]
+  dsimp only
+  simp only [execInstrRF_sb_fst, execInstrRF_sb_snd, hx12a, hx12b,
+    RegFile.get_set_ne _ _ _ _ (by decide : Reg.x12 ≠ .x5),
+    RegFile.get_set_ne _ _ _ _ (by decide : Reg.x12 ≠ .x6),
+    h0, h1, h2, h3, setBytes_singleton, inRw, Region.loadOk,
+    List.length_set, List.length_cons, List.length_nil]
+  and_intros <;> trivial
+
+theorem rev4Fn_spec (p : Word) (w : List (BitVec 8)) (base : Word) :
+    (rev4Fn p w).Spec base := by
+  vcgen
+  case rev4.rev.focus =>
+    rintro rf ws A ⟨hx12, hw, hA⟩ hApc hp hhp
+    rw [hA] at hhp
+    refine ⟨w, ⌜RwRegion.wf ⟨p, 4⟩⌝, ⟨hx12, rfl, rfl⟩, ?_, pcFree_pure, ?_⟩
+    · rw [hx12]
+      xperm_hyp hhp
+    · rw [hx12, hw]
+      exact ((sepConj_pure_left hp).mp hhp).1
+  case rev4.rev.mem =>
+    rintro rf ws A win rest - ⟨-, hw, -⟩ ⟨hptr, rfl, rfl⟩ -
+    obtain ⟨b0, b1, b2, b3, rfl⟩ : ∃ b0 b1 b2 b3, win = [b0, b1, b2, b3] := by
+      rcases win with - | ⟨b0, - | ⟨b1, - | ⟨b2, - | ⟨b3, - | ⟨b4, win⟩⟩⟩⟩⟩ <;>
+        simp only [List.length_nil, List.length_cons] at hw <;>
+        first
+          | omega
+          | exact ⟨b0, b1, b2, b3, rfl⟩
+    exact rev4_blockVCs _ rf b0 b1 b2 b3
+  case rev4.post =>
+    rintro rf ws A ⟨rf₀, A₀, win, rest, -, ⟨hx12, hw, -⟩, -, ⟨hptr, rfl, rfl⟩,
+      hrf, hA⟩
+    obtain ⟨b0, b1, b2, b3, rfl⟩ : ∃ b0 b1 b2 b3, win = [b0, b1, b2, b3] := by
+      rcases win with - | ⟨b0, - | ⟨b1, - | ⟨b2, - | ⟨b3, - | ⟨b4, win⟩⟩⟩⟩⟩ <;>
+        simp only [List.length_nil, List.length_cons] at hw <;>
+        first
+          | omega
+          | exact ⟨b0, b1, b2, b3, rfl⟩
+    -- shrink the equations BEFORE substituting (howto §8)
+    rw [rev4_engine] at hrf hA
+    dsimp only at hrf hA
+    subst hrf
+    constructor
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide)]
+      exact hx12
+    · rw [hA, hx12, sepConj_comm',
+        show ([b0, b1, b2, b3] : List (BitVec 8)).reverse
+          = [b3, b2, b1, b0] from rfl]
+
 end ExamplesVc
 end SAsm
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/MultiDword.lean
+++ b/EvmAsm/Rv64/SAsm/MultiDword.lean
@@ -89,6 +89,28 @@ theorem setBytes_dword_at0 (v w : Word) (rest : List (BitVec 8)) :
   rw [setBytes_append_left _ _ _ _ (by rw [length_dwordBytes, length_dwordBytes]),
     setBytes_dword_full _ _ (length_dwordBytes v)]
 
+-- ============================================================================
+-- Byte-granularity windows (docs/sasm-howto.md, "Byte-granularity focus
+-- blocks"): with `execInstrRF_lbu_byte`/`execInstrRF_sb_byte` (Sym.lean),
+-- a byte store is a plain `List.set` and a byte load round-trips through
+-- the zero-extension.  For FIXED-SIZE windows, explode the byte list into
+-- cons cells (`w = [b0, …, bN]`) and `List.set`/`getD`/`reverse` all
+-- reduce definitionally — no take/drop invariants needed for unrolled
+-- code.  Worked example: `rev4Fn` in ExamplesVc.lean.
+-- ============================================================================
+
+/-- A one-byte splice is a plain `List.set`. -/
+theorem setBytes_singleton (ws : List (BitVec 8)) (k : Nat) (b : BitVec 8) :
+    setBytes ws k [b] = ws.set k b := rfl
+
+/-- A byte loaded zero-extended (`LBU`) and stored truncated (`SB`)
+    round-trips. -/
+theorem truncate_zeroExtend_byte (b : BitVec 8) :
+    ((b.zeroExtend 64).truncate 8) = b := by
+  apply BitVec.eq_of_getLsbD_eq
+  intro i
+  simp
+
 /-- Step a splice past the head cell of a dword-concatenation window. -/
 theorem setBytes_dword_past (v : Word) (rest ns : List (BitVec 8)) (k : Nat) :
     setBytes (dwordBytes v ++ rest) (8 + k) ns

--- a/EvmAsm/Rv64/SAsm/Sym.lean
+++ b/EvmAsm/Rv64/SAsm/Sym.lean
@@ -501,6 +501,52 @@ theorem execInstrRF_ld_dword (ro : Region) (rwBase : Word) (rf : RegFile)
       - (⟨rwBase, ws⟩ : Region).base).toNat = k from haddr,
     hslice]
 
+/-- **The byte-load step, fully resolved**: an `LBU` whose address lands
+    `k` bytes into the window is exactly `rf.set rd` of the (zero-extended)
+    `k`-th window byte, window untouched.  Byte accesses have no alignment
+    side condition — only `hfit`. -/
+theorem execInstrRF_lbu_byte (ro : Region) (rwBase : Word) (rf : RegFile)
+    (ws : List (BitVec 8)) (rd rs1 : Reg) (ofs : BitVec 12) (k : Nat)
+    (haddr : ((rf.get rs1 + signExtend12 ofs) - rwBase).toNat = k)
+    (hfit : k + 1 ≤ ws.length) :
+    execInstrRF ro rwBase rf ws (.LBU rd rs1 ofs)
+      = (rf.set rd ((ws.getD k 0).zeroExtend 64), ws) := by
+  unfold execInstrRF
+  dsimp only [aluSem, loadSem]
+  rw [if_pos (show inRw rwBase ws (rf.get rs1 + signExtend12 ofs) 1 from by
+    unfold inRw
+    rw [haddr]
+    omega)]
+  unfold Region.byteAt
+  rw [show ((rf.get rs1 + signExtend12 ofs)
+      - (⟨rwBase, ws⟩ : Region).base).toNat = k from haddr]
+
+/-- **The byte-store step, fully resolved**: an `SB` whose address lands
+    `k` bytes into the window splices the (truncated) source byte at `k`
+    and leaves the registers alone.  With `setBytes_singleton`
+    (MultiDword.lean) the window becomes a plain `List.set`. -/
+theorem execInstrRF_sb_byte (ro : Region) (rwBase : Word) (rf : RegFile)
+    (ws : List (BitVec 8)) (rs1 rs2 : Reg) (ofs : BitVec 12) (k : Nat)
+    (haddr : ((rf.get rs1 + signExtend12 ofs) - rwBase).toNat = k) :
+    execInstrRF ro rwBase rf ws (.SB rs1 rs2 ofs)
+      = (rf, setBytes ws k [(rf.get rs2).truncate 8]) := by
+  rw [show execInstrRF ro rwBase rf ws (.SB rs1 rs2 ofs)
+      = (rf, setBytes ws ((rf.get rs1 + signExtend12 ofs) - rwBase).toNat
+          [(rf.get rs2).truncate 8]) from rfl, haddr]
+
+/-- A byte-store step never changes the register file. -/
+@[simp] theorem execInstrRF_sb_fst (ro : Region) (rwBase : Word)
+    (rf : RegFile) (ws : List (BitVec 8)) (rs1 rs2 : Reg) (ofs : BitVec 12) :
+    (execInstrRF ro rwBase rf ws (.SB rs1 rs2 ofs)).1 = rf := rfl
+
+/-- A byte-store step splices its (truncated) byte at the classified
+    index. -/
+theorem execInstrRF_sb_snd (ro : Region) (rwBase : Word) (rf : RegFile)
+    (ws : List (BitVec 8)) (rs1 rs2 : Reg) (ofs : BitVec 12) :
+    (execInstrRF ro rwBase rf ws (.SB rs1 rs2 ofs)).2
+      = setBytes ws ((rf.get rs1 + signExtend12 ofs) - rwBase).toNat
+          [(rf.get rs2).truncate 8] := rfl
+
 /-- **The dword-store step, fully resolved**: an `SD` whose address lands
     `k` bytes into the window splices `dwordBytes (rf.get rs2)` at `k`
     and leaves the registers alone. -/

--- a/PLAN.md
+++ b/PLAN.md
@@ -2561,7 +2561,15 @@ VCs + zero-case-analysis downstream summary). ClzSAsm.lean reworked as
 the demonstration: both bounded-aesop VCs replaced by the structural
 lemmas (clzSelectBody now carries per-branch asserts; emitted code
 unchanged). Howto: new subsections for the eliminators and branch-tail
-summaries. CLZ handler port landed on this substrate: ClzSAsm.lean
+summaries. Ergonomics round 4 (from the keccak byte-reverse delegated
+attempt): resolved byte step lemmas execInstrRF_lbu_byte/_sb_byte +
+projections _sb_fst/_sb_snd (Sym.lean); setBytes_singleton (byte store
+= List.set) + truncate_zeroExtend_byte (MultiDword); rev4Fn demo
+(ExamplesVc: 4-byte in-place reverse, unrolled — the explode-the-window
+recipe: destructure the byte list into cons cells and set/getD/reverse
+reduce definitionally, no take/drop invariants for unrolled code);
+howto "Byte-granularity focus blocks" incl. the metavariable-pinning
+pitfall for step-lemma side proofs. CLZ handler port landed on this substrate: ClzSAsm.lean
 now provides clzFn_spec and clz_verified, and h_CLZ uses the verified
 SAsm body plus advanceAndRet instead of the legacy raw custom tail.
 Stage 5a landed: treeMinFn (TreeDemo.lean) — the tree-walk integration

--- a/docs/sasm-howto.md
+++ b/docs/sasm-howto.md
@@ -311,6 +311,40 @@ heartbeat timeouts).  Instead:
    them to `rf' = rf.set …`-form), and only then rewrite them into the
    goal.
 
+### Byte-granularity focus blocks
+
+The worked example is `rev4Fn` (ExamplesVc.lean): reverse a 4-byte cell
+in place with unrolled literal-offset swaps.  Byte accesses differ from
+the dword recipe in three ways:
+
+1. **Resolved byte steps** (`Sym.lean`): `execInstrRF_lbu_byte` (an
+   `LBU` landing `k` bytes into the window *is*
+   `rf.set rd ((ws.getD k 0).zeroExtend 64)`) and `execInstrRF_sb_byte`;
+   projections `execInstrRF_sb_fst` (simp) / `execInstrRF_sb_snd`.
+   With `setBytes_singleton` a byte store is a plain `List.set`, and
+   `truncate_zeroExtend_byte` collapses the LBU→SB round trip
+   (MultiDword.lean).  No alignment side conditions — only the
+   in-window bound.
+2. **Explode fixed-size windows into cons cells.**  For an unrolled
+   block over a window of known length, obtain
+   `w = [b0, …, bN]` once (an `rcases`-per-cons chain closed by the
+   length hypothesis) — then `List.set`/`getD`/`reverse` all reduce
+   definitionally and the engine's final window matches the model by
+   the closing `rfl`.  No take/drop invariants for unrolled code;
+   loops over a window still use invariants (§4).
+3. **Pin metavariables through side proofs.**  A step-lemma instance's
+   `haddr` side proof runs against a goal that may still contain
+   *metavariables* (the instance's `rf`): rewriting with a ∀-quantified
+   helper assigns the meta to a pattern-with-metas and the proof leaves
+   them unsolved.  Two safe forms: sequential tactic `rw`s on the goal
+   (each occurrence pins the metas before the side proof runs — the
+   `rev4_engine`/`rev4_blockVCs` style), or *specific* helper equations
+   (the `revCell_blockVCs` style).  If a later access's side condition
+   mentions an earlier store's `(execInstrRF …).1`, normalize it with
+   `simp only [execInstrRF_sb_fst]` first — store steps do not
+   `dsimp`-reduce (the def hides the match), but their projections are
+   one simp lemma away.
+
 ### Branchy straight-line code: joins and disjunction blowup
 
 `sp` of `.when`/`.ite` is a **disjunction** — `n` sequential `when`s make


### PR DESCRIPTION
Fourth ergonomics iteration, driven by the delegated keccak digest byte-reverse attempt (branch `feat/sasm-keccak-reverse`): the agent produced a sound unrolled design and the handler splice, but stalled on the proof for lack of byte-level framework support — exactly the gap called out in `/tmp/sasm-feedback-bytereverse.md`.

## Framework

- **Resolved byte steps** (`Sym.lean`): `execInstrRF_lbu_byte` — an `LBU` whose address lands `k` bytes into the window **is** `(rf.set rd ((ws.getD k 0).zeroExtend 64), ws)` — and `execInstrRF_sb_byte`; plus store projections `execInstrRF_sb_fst` (`@[simp]`) / `execInstrRF_sb_snd`. Byte accesses have no alignment side conditions.
- **`MultiDword.lean`**: `setBytes_singleton` (a one-byte splice is a plain `List.set`) and `truncate_zeroExtend_byte` (the LBU→SB round trip).
- **`rev4Fn`** (ExamplesVc.lean): the worked example — a 4-byte cell reversed in place by two unrolled literal-offset swaps, with engine, `blockVCs`, and full `Fn.Spec`, kernel-clean. It demonstrates the **explode-the-window recipe**: for fixed-size windows destructure the byte list into cons cells once, and `List.set`/`getD`/`reverse` all reduce definitionally — the engine's final window matches `w.reverse` by the closing `rfl`, no take/drop invariants anywhere.
- **Howto**: new *Byte-granularity focus blocks* subsection, including a subtle pitfall found while building the demo: step-lemma **side proofs elaborated as simp-arg instances can leave metavariables unpinned** (a ∀-quantified helper rewrite assigns the meta to a pattern-with-metas); the safe forms are sequential tactic `rw`s or specific helper equations, and store projections normalize via `simp only [execInstrRF_sb_fst]` since store steps don't `dsimp`-reduce.

This directly unblocks finishing `feat/sasm-keccak-reverse`: its 16-swap `byteReverse32Block` is `rev4Fn` at 8× scale.

Gates: `lake build EvmAsm.Rv64.SAsm` zero errors/warnings; `check-forbidden-tactics` OK; `rev4Fn_spec` axioms = `[propext, Classical.choice, Quot.sound]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)