### PR TITLE
feat(sasm): register-preservation + static-frame conventions via Reach.pin

### DIFF
--- a/EvmAsm/Rv64/SAsm.lean
+++ b/EvmAsm/Rv64/SAsm.lean
@@ -26,5 +26,6 @@ import EvmAsm.Rv64.SAsm.MultiDword
 import EvmAsm.Rv64.SAsm.RaSpill
 import EvmAsm.Rv64.SAsm.Tactic
 import EvmAsm.Rv64.SAsm.HandleWiden
+import EvmAsm.Rv64.SAsm.FrameConv
 import EvmAsm.Rv64.SAsm.Examples
 import EvmAsm.Rv64.SAsm.ExamplesVc

--- a/EvmAsm/Rv64/SAsm/FrameConv.lean
+++ b/EvmAsm/Rv64/SAsm/FrameConv.lean
@@ -1,0 +1,324 @@
+/-
+  EvmAsm.Rv64.SAsm.FrameConv
+
+  Register-preservation and frame-layout conventions for deep call trees
+  (bead evm-asm-4ch8f.3, docs/sasm-design.md §3.6.2).
+
+  `Stmt.sp` for a `.call` replaces the reachable set by the callee's
+  postcondition: the callee owns the whole exposed register file, so any
+  register the post does not mention is forgotten.  Exposed registers
+  (t0–t6, a0–a7) are therefore *caller-saved*, with two conventions for
+  keeping a value live across a call:
+
+  * contract pinning (`Reach.pin`): when the callee provably does not
+    touch the register, its contract family carries the entry value as a
+    ghost and re-asserts it in the post — zero runtime cost (`PinDemo`);
+
+  * spill/reload: the caller stores the value into a private dword of its
+    own frame window — outside the callee's `FnHandle.widenRw` window, so
+    the widened postcondition preserves the slot by construction — and
+    reloads it after the call (`SpillDemo`).  Pointers are never spilled:
+    they are re-materialized by `LI` from the static layout (§3.6.1).
+
+  s-registers (and `sp`/`gp`/`tp`) are outside the exposed set: `blockOk`
+  rejects any access, so verified SAsm code cannot clobber them and no
+  preservation machinery is needed.  Frames are *static* windows of the
+  stack arena — assigned by the global memory layout (bead evm-asm-4ch8f.6)
+  and carved per call edge by `widenRw`; verified code contains no dynamic
+  `addi sp` prologue.
+-/
+
+import EvmAsm.Rv64.SAsm.HandleWiden
+
+namespace EvmAsm.Rv64
+namespace SAsm
+
+/-- Pin an exposed register through a reachable set: the contract family's
+    ghost `v` records the entry value, and using `pin` in both pre and post
+    states preservation.  Nest applications to pin several registers. -/
+def Reach.pin (r : Reg) (v : Word) (reach : Reach) : Reach :=
+  fun rf ws A => rf.get r = v ∧ reach rf ws A
+
+-- ============================================================================
+-- Demo: contract pinning — a value survives a call in a register
+-- ============================================================================
+
+namespace PinDemo
+
+open Stmt
+
+/-- Leaf callee: clobber `x10` but leave `x15` alone.  The contract family
+    pins `x15` to ghost `g` through pre AND post; the leaf's own `.post` VC
+    proves the preservation (the block never writes `x15`). -/
+def pinLeafFn (g : Word) : Fn where
+  name := "pinleaf"
+  pre := Reach.pin .x15 g (fun _ _ _ => True)
+  post := Reach.pin .x15 g (fun rf _ _ => rf.get .x10 = 99)
+  body := .block "clob" [.LI .x10 99]
+
+theorem pinLeafFn_spec (g : Word) : (pinLeafFn g).Spec 0x2000 := by
+  vcgen
+  case pinleaf.post =>
+    rintro rf' ws' A' ⟨rf₀, ws₀, hws₀, ⟨hx15, -⟩, rfl, rfl⟩
+    simp only [pinLeafFn, Reach.pin, execBlock_cons, execBlock_nil,
+      execInstrRF, aluSem]
+    exact ⟨by rw [RegFile.get_set_ne rf₀ .x10 .x15 99 (by decide)]; exact hx15,
+      RegFile.get_set_self rf₀ .x10 99 (by decide)⟩
+
+/-- The leaf as a callee, contract instantiated per ghost `g`. -/
+def pinLeafHandle (g : Word) : FnHandle :=
+  (pinLeafFn g).toHandle 0x2000 (pinLeafFn_spec g)
+    ((by decide : 4 * ((pinLeafFn 0).body.size + 1) ≤ 2 ^ 64))
+
+/-- Caller: keep `w` live in `x15` across the call, then USE it after —
+    the pinned contract carries it through. -/
+def pinCallerFn (w : Word) : Fn where
+  name := "pincaller"
+  pre := fun rf _ _ => rf.get .x15 = w
+  post := fun rf _ _ => rf.get .x11 = w ∧ rf.get .x10 = 99
+  body := .call "leaf" (pinLeafHandle w) ;;;
+    .block "use" [.ADDI .x11 .x15 0]
+
+def pinCallerCr (w : Word) : CodeReq :=
+  (CodeReq.ofProg 0x1000 ((pinCallerFn w).body.flatten 0x1000)).union
+    (pinLeafHandle w).code
+
+theorem pinCallerFn_spec (w : Word) :
+    (pinCallerFn w).SpecR 0x1000 (pinCallerCr w) := by
+  have hcode : ∀ a i, (pinLeafHandle w).code a = some i →
+      pinCallerCr w a = some i := by
+    intro a i h
+    obtain ⟨kk, hk, rfl⟩ := ofProg_some_range h
+    have hk2 : kk < 2 := hk
+    simp only [pinCallerCr, CodeReq.union]
+    rw [CodeReq.ofProg_none_range 0x1000 ((pinCallerFn w).body.flatten 0x1000)
+      (fun k' hk' heq => ?_)]
+    · exact h
+    · have hk'2 : k' < 2 := hk'
+      bv_omega
+  show Fn.SpecR _ _ _
+  vcgen
+  case code =>
+    intro a i h
+    simp only [pinCallerCr, CodeReq.union, h]
+  case callees =>
+    exact ⟨⟨hcode, rfl, rfl⟩, trivial⟩
+  case calls =>
+    exact ⟨⟨(by decide : (0x1000 : Word) + signExtend21 (BitVec.setWidth 21
+          ((0x2000 : Word) - 0x1000)) = 0x2000),
+       (by decide : (((0x1000 : Word) + 4) &&& ~~~(1 : Word)) = 0x1000 + 4),
+       (by decide : CodeReq.ofProg 0x2000 ((pinLeafFn 0).programRet 0x2000)
+          (0x1000 : Word) = none)⟩,
+      trivial⟩
+  case pincaller.leaf.pre =>
+    rintro rf ws A hx15
+    exact ⟨hx15, trivial⟩
+  case pincaller.post =>
+    rintro rf' ws' A' ⟨rf₀, ws₀, hws₀, ⟨hx15, hx10⟩, rfl, rfl⟩
+    simp only [pinCallerFn, execBlock_cons, execBlock_nil, execInstrRF, aluSem]
+    refine ⟨?_, ?_⟩
+    · rw [RegFile.get_set_self rf₀ .x11 _ (by decide), hx15,
+        show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]
+      bv_omega
+    · rw [RegFile.get_set_ne rf₀ .x11 .x10 _ (by decide)]
+      exact hx10
+
+end PinDemo
+
+-- ============================================================================
+-- Demo: spill/reload — a value survives a clobbering call through memory
+-- ============================================================================
+
+namespace SpillDemo
+
+open Stmt
+
+/-- The caller's frame window: its private save slot in the first dword,
+    the callee's window in the second. -/
+def spRw : RwRegion := ⟨0x30000, 16⟩
+
+/-- The leaf's own writable window: the second dword of `spRw`. -/
+def spLeafRw : RwRegion := ⟨0x30008, 8⟩
+
+/-- Leaf callee: CLOBBERS `x15` (and writes its own window via `x14`).
+    Its contract says nothing about the caller's value. -/
+def spLeafFn : Fn where
+  name := "spleaf"
+  rw := spLeafRw
+  pre := fun rf _ _ => rf.get .x14 = 0x30008
+  post := fun rf ws _ => rf.get .x15 = 7 ∧ ws = dwordBytes 7
+  body := .block "clob" [.LI .x15 7, .SD .x14 .x15 0]
+
+private theorem spleaf_hidx : ∀ rf : RegFile, rf.get .x14 = 0x30008 →
+    ((rf.get .x14 + signExtend12 (0 : BitVec 12)) - (0x30008 : Word)).toNat
+      = 0 := by
+  intro rf h
+  rw [h, show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]
+  bv_omega
+
+theorem spLeafFn_spec : spLeafFn.Spec 0x2000 := by
+  have hx14' : ∀ rf : RegFile, rf.get .x14 = 0x30008 →
+      (rf.set .x15 7).get .x14 = 0x30008 := by
+    intro rf h
+    rw [RegFile.get_set_ne rf .x15 .x14 7 (by decide)]
+    exact h
+  vcgen
+  case spleaf.clob.mem =>
+    rintro rf ws A hws hx14
+    have hws8 : ws.length = 8 := hws
+    simp only [blockVCs, loadSem, storeSem, aluSem, execInstrRF, spLeafFn,
+      spLeafRw, inRw, spleaf_hidx _ (hx14' rf hx14)]
+    exact ⟨trivial, ⟨by omega, by decide⟩, trivial⟩
+  case spleaf.post =>
+    rintro rf' ws' A' ⟨rf₀, ws₀, hws₀, hx14, rfl, rfl⟩
+    have hws8 : ws₀.length = 8 := hws₀
+    simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem, loadSem,
+      storeSem, spLeafFn, spLeafRw, spleaf_hidx _ (hx14' rf₀ hx14)]
+    refine ⟨?_, ?_⟩
+    · rw [RegFile.get_set_self _ _ _ (by decide)]
+    · rw [RegFile.get_set_self _ _ _ (by decide)]
+      have hs := setBytes_slot ws₀ (dwordBytes 7) 0
+        (by rw [length_dwordBytes]; omega)
+      rw [List.drop_zero, length_dwordBytes] at hs
+      conv_lhs => rw [← List.take_of_length_le
+        (l := setBytes ws₀ 0 (dwordBytes 7)) (i := 8)
+        (by rw [length_setBytes]; omega)]
+      exact hs
+
+/-- The leaf as a callee at `0x2000`, against its OWN window only. -/
+def spLeafHandle : FnHandle :=
+  spLeafFn.toHandle 0x2000 spLeafFn_spec
+    ((by decide : 4 * (spLeafFn.body.size + 1) ≤ 2 ^ 64))
+
+/-- The leaf widened to the caller's frame: the caller's saved dword
+    (`dwordBytes w`) is framed across the call by construction. -/
+def spLeafWide (w : Word) : FnHandle :=
+  spLeafHandle.widenRw spRw (dwordBytes w) []
+    (by rw [length_dwordBytes]; decide)
+    (by rw [length_dwordBytes]; decide)
+    (by rw [length_dwordBytes])
+    (by decide)
+
+private theorem spcaller_hidx : ∀ rf : RegFile, rf.get .x13 = 0x30000 →
+    ((rf.get .x13 + signExtend12 (0 : BitVec 12)) - (0x30000 : Word)).toNat
+      = 0 := by
+  intro rf h
+  rw [h, show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]
+  bv_omega
+
+private theorem sp_hidx0 :
+    (((0x30000 : Word) + signExtend12 (0 : BitVec 12)) - (0x30000 : Word)).toNat
+      = 0 := by decide
+
+/-- Caller: save `w` (live in `x15`) to its own slot, call the clobbering
+    leaf, re-materialize the pointer with `LI`, reload.  The callee's
+    contract never mentions `w`; the widened window preserves the slot. -/
+def spCallerFn (w : Word) : Fn where
+  name := "spcaller"
+  rw := spRw
+  pre := fun rf _ _ => rf.get .x13 = 0x30000 ∧ rf.get .x15 = w
+  post := fun rf _ _ => rf.get .x15 = w
+  body :=
+    .block "save" [.SD .x13 .x15 0, .LI .x14 0x30008] ;;;
+    .call "spleaf" (spLeafWide w) ;;;
+    .block "restore" [.LI .x13 0x30000, .LD .x15 .x13 0]
+
+def spCallerCr (w : Word) : CodeReq :=
+  (CodeReq.ofProg 0x1000 ((spCallerFn w).body.flatten 0x1000)).union
+    spLeafHandle.code
+
+theorem spCallerFn_spec (w : Word) :
+    (spCallerFn w).SpecR 0x1000 (spCallerCr w) := by
+  have hcode : ∀ a i, spLeafHandle.code a = some i →
+      spCallerCr w a = some i := by
+    intro a i h
+    obtain ⟨kk, hk, rfl⟩ := ofProg_some_range h
+    have hk3 : kk < 3 := hk
+    simp only [spCallerCr, CodeReq.union]
+    rw [CodeReq.ofProg_none_range 0x1000 ((spCallerFn w).body.flatten 0x1000)
+      (fun k' hk' heq => ?_)]
+    · exact h
+    · have hk'5 : k' < 5 := hk'
+      bv_omega
+  show Fn.SpecR _ _ _
+  vcgen
+  case region =>
+    exact ⟨Region.empty_wf, (by decide : spRw.wf)⟩
+  case code =>
+    intro a i h
+    simp only [spCallerCr, CodeReq.union, h]
+  case callees =>
+    exact ⟨trivial, ⟨hcode, rfl, rfl⟩, trivial⟩
+  case calls =>
+    exact ⟨trivial,
+      ⟨(by decide : (0x1008 : Word) + signExtend21 (BitVec.setWidth 21
+          ((0x2000 : Word) - 0x1008)) = 0x2000),
+       (by decide : (((0x1008 : Word) + 4) &&& ~~~(1 : Word)) = 0x1008 + 4),
+       (by decide : CodeReq.ofProg 0x2000 (spLeafFn.programRet 0x2000)
+          (0x1008 : Word) = none)⟩,
+      trivial⟩
+  case spcaller.save.mem =>
+    rintro rf ws A hws ⟨hx13, hx15⟩
+    have hws16 : ws.length = 16 := hws
+    simp only [blockVCs, loadSem, storeSem, spCallerFn,
+      spRw, inRw, spcaller_hidx rf hx13]
+    exact ⟨⟨by omega, by decide⟩, trivial, trivial⟩
+  case spcaller.spleaf.pre =>
+    rintro rf ws A ⟨rf₀, ws₀, hws₀, ⟨hx13, hx15⟩, rfl, rfl⟩
+    have hws16 : ws₀.length = 16 := hws₀
+    simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem, loadSem,
+      storeSem, spCallerFn, spRw, spcaller_hidx rf₀ hx13, hx15]
+    refine ⟨(setBytes ws₀ 0 (dwordBytes w)).drop 8, ?_, ?_, ?_⟩
+    · show ((setBytes ws₀ 0 (dwordBytes w)).drop 8).length = 8
+      rw [List.length_drop, length_setBytes]
+      omega
+    · rw [List.append_nil]
+      conv_lhs => rw [← List.take_append_drop 8 (setBytes ws₀ 0 (dwordBytes w))]
+      congr 1
+      have hs := setBytes_slot ws₀ (dwordBytes w) 0
+        (by rw [length_dwordBytes]; omega)
+      rw [List.drop_zero, length_dwordBytes] at hs
+      exact hs
+    · exact RegFile.get_set_self rf₀ .x14 _ (by decide)
+  case spcaller.restore.mem =>
+    rintro rf ws A hws ⟨win, hwl, rfl, hpost⟩
+    have hws16 : (dwordBytes w ++ win ++ []).length = 16 := hws
+    simp only [blockVCs, loadSem, storeSem, aluSem, execInstrRF, spCallerFn,
+      spRw, inRw, Region.loadOk,
+      RegFile.get_set_self rf .x13 (0x30000 : Word) (by decide), sp_hidx0]
+    have hcond : (0 : Nat) + 8 ≤ (dwordBytes w ++ win ++ []).length := by
+      rw [hws16]
+      omega
+    rw [if_pos hcond]
+    exact ⟨trivial, ⟨by decide, hcond⟩, trivial⟩
+  case spcaller.post =>
+    rintro rf' ws' A' ⟨rf₀, ws₀, hws₀, hreach, rfl, rfl⟩
+    obtain ⟨win, hwl, rfl, hx15leaf, hwsleaf⟩ := hreach
+    show RegFile.get _ .x15 = w
+    simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem, loadSem,
+      spCallerFn, spRw,
+      RegFile.get_set_self rf₀ .x13 (0x30000 : Word) (by decide)]
+    rw [if_pos (show inRw (0x30000 : Word) (dwordBytes w ++ win ++ [])
+        ((0x30000 : Word) + signExtend12 (0 : BitVec 12)) 8 from by
+      unfold inRw
+      rw [sp_hidx0]
+      simp only [List.append_nil, List.length_append, length_dwordBytes]
+      omega)]
+    rw [RegFile.get_set_self _ .x15 _ (by decide)]
+    show Region.dwordAt _ _ = w
+    unfold Region.dwordAt
+    rw [show ((⟨0x30000, dwordBytes w ++ win ++ []⟩ : Region).bytes.drop
+        (((0x30000 : Word) + signExtend12 (0 : BitVec 12)
+          - (⟨0x30000, dwordBytes w ++ win ++ []⟩ : Region).base).toNat))
+        = dwordBytes w ++ win ++ [] from by
+      show (dwordBytes w ++ win ++ []).drop _ = _
+      rw [sp_hidx0, List.drop_zero]]
+    rw [List.append_nil,
+      List.take_append_of_le_length (by rw [length_dwordBytes]),
+      List.take_of_length_le (by rw [length_dwordBytes]),
+      packBytes_dwordBytes]
+
+end SpillDemo
+
+end SAsm
+end EvmAsm.Rv64

--- a/PLAN.md
+++ b/PLAN.md
@@ -2509,8 +2509,16 @@ materializing its slice pointer with `LI` (the SAsm rendering of
 `la`-per-arena). Named-region/`la` design decisions recorded in
 docs/sasm-design.md §3.6.1 (contiguous slices → wideners; disjoint
 arenas → ambient `A` + blockAt + frameA; the named symbol-address table
-is the memory-layout bead's deliverable). Remaining for deep call
-trees: exposed s-register preservation conventions, then more
+is the memory-layout bead's deliverable). Register-preservation + frame
+conventions landed (`SAsm/FrameConv.lean`, completes bead
+evm-asm-4ch8f.3): exposed regs are caller-saved (call sp replaces the
+register file by the callee's post) — preserve via `Reach.pin`
+ghost-pinned contract families (PinDemo) or spill to a caller-private
+dword outside the callee's `widenRw` window and reload after `LI`
+re-materializing the pointer (SpillDemo); s-regs/`sp` are outside the
+exposed set (blockOk rejects them) so verified code can't clobber them;
+frames are STATIC windows of the stack arena (no dynamic `addi sp`),
+design in docs/sasm-design.md §3.6.2. Next for SAsm: more
 Stateless/SSZ ports. Assertion-state milestone started (approved plan
 ~/.claude/plans/federated-wandering-pudding.md; epic evm-asm-6dt3v):
 Stages 1+2a landed — `Reach := RegFile → List Byte → Assertion → Prop`

--- a/docs/sasm-design.md
+++ b/docs/sasm-design.md
@@ -377,9 +377,8 @@ structure FnHandle where
   (e.g. `dwordBytes v` for the spilled `ra`).  The underlying frame seam
   is `bytesRegion_append` (split a byte region at a dword boundary).
   `WidenDemo` replays the ra-spill two-level tree with the leaf owning
-  only its 8-byte window; the remaining deep-tree follow-up is exposed
-  s-register preservation conventions (today a callee's post must state
-  which exposed registers it preserves).
+  only its 8-byte window; register-preservation conventions across calls
+  are §3.6.2 (`SAsm/FrameConv.lean`).
 - **Read-only sub-slices** (`FnHandle.widenRo`, same file): the `.ro`
   analogue — a callee verified against its own slice of a larger
   read-only buffer is repackaged over the caller's full region, pre/post
@@ -414,6 +413,43 @@ the first widening adapters (bead evm-asm-4ch8f.2):
    table plus pairwise-disjointness facts is the memory-layout
    formalization's deliverable (bead evm-asm-4ch8f.6); SAsm consumes
    those names, it does not define them.
+
+### 3.6.2 Register preservation and frame layout (design decisions)
+
+How values survive calls and where frames live (bead evm-asm-4ch8f.3,
+`SAsm/FrameConv.lean`):
+
+1. **Exposed registers (t0–t6, a0–a7) are caller-saved.**  `Stmt.sp` for
+   a `.call` replaces the reachable set by the callee's postcondition —
+   the callee owns the whole exposed file, so any register its post does
+   not mention is forgotten.  Two conventions keep a value live:
+   - *contract pinning* (`Reach.pin r v`): when the callee provably does
+     not touch `r`, its contract family carries the entry value `v` as a
+     ghost through pre AND post; the callee's own `.post` VC proves the
+     preservation and the caller gets it for free — zero runtime cost
+     (`PinDemo`: `w` survives in `x15` across a call and is used after);
+   - *spill/reload*: the caller stores the value into a private dword of
+     its own frame window — outside the callee's `widenRw` window, so
+     the widened post preserves the slot by construction — and reloads
+     after the call (`SpillDemo`: `w` survives a callee that clobbers
+     `x15`).  Pointers are never spilled: they are re-materialized with
+     `LI` from the static layout (§3.6.1), which keeps reload blocks
+     self-contained.
+2. **s-registers (and `sp`/`gp`/`tp`) need no machinery.**  They are
+   outside the exposed set: `blockOk` rejects any read or write, so a
+   verified SAsm routine can never clobber them.  They only matter at
+   boundaries with unverified raw asm, where the boundary spec owns them.
+3. **Frames are static windows; no dynamic `addi sp`.**  Each verified
+   routine gets a fixed dword-aligned window of the stack arena, assigned
+   by the global memory layout (bead evm-asm-4ch8f.6) and carved per call
+   edge by `FnHandle.widenRw`; `ra` spill slots live in the routine's own
+   window (`Fn.toHandleR`, slot dword `k` of `.rw`, first dword by
+   convention).  The guest's existing `addi sp`-style frames are
+   *replaced* by this convention, not modeled — sound because the
+   verified call graph is a finite static tree, so total stack need is
+   known at layout time.  Dynamically-deep recursion (the EVM
+   interpreter's call depth) does not stack-allocate: it goes through the
+   data-indexed EVM frame arena (beads evm-asm-4ch8f.5/.56).
 
 ### 3.7 Flattening (`SAsm/Flatten.lean`)
 

--- a/docs/sasm-howto.md
+++ b/docs/sasm-howto.md
@@ -190,6 +190,24 @@ contract; the call machinery consumes it unchanged.
   unreduced projections mention free variables — and if `vcgen` reports
   a `Fn.Spec`/`SpecR` mismatch, insert `show Fn.SpecR _ _ _` before it.
   Design rationale for named arenas: docs/sasm-design.md §3.6.1.
+- **Preserving a value across a call** (`SAsm/FrameConv.lean`; design
+  §3.6.2).  The call's sp replaces the reachable set by the callee's
+  post, so exposed registers are caller-saved.  Two recipes:
+  1. *Contract pinning* — callee doesn't touch the register: wrap both
+     its pre and post in `Reach.pin r v` with ghost `v`; the callee's
+     `.post` VC discharges the preservation (`RegFile.get_set_ne`), and
+     the caller instantiates the handle at its live value
+     (`PinDemo.pinCallerFn`).
+  2. *Spill/reload* — callee clobbers the register: `SD` the value into
+     a caller-private dword before the call (its bytes become the
+     `preB`/`sufB` ghost of the callee's `widenRw` widening, so the
+     widened post returns them intact), then re-materialize the frame
+     pointer with `LI` and `LD` the value back
+     (`SpillDemo.spCallerFn`).  Don't spill pointers — reload them with
+     `LI` from the static layout.
+  s-registers and `sp` never need either recipe: they are outside the
+  exposed set, so verified code cannot touch them (frames are static
+  windows of the stack arena; there is no `addi sp` in verified code).
 
 ### Calling an existing hand-verified `cpsTripleWithin`
 


### PR DESCRIPTION
## Summary

Completes bead **evm-asm-4ch8f.3** (deep call trees): the last open items were register-preservation conventions and the frame-layout decision for the guest's `addi sp` frames.

`Stmt.sp` for a `.call` replaces the reachable set by the callee's postcondition — the callee owns the whole exposed register file, so anything the post doesn't mention is forgotten. Exposed registers (t0–t6/a0–a7) are therefore **caller-saved**, and this PR establishes (and proves end-to-end) the two conventions for keeping a value live across a call.

## New: `EvmAsm/Rv64/SAsm/FrameConv.lean`

- **`Reach.pin r v`** — pin an exposed register through a reachable set; using it in both pre and post of a ghost-indexed contract family states preservation, discharged by the callee's own `.post` VC.
- **`PinDemo`** — contract pinning end-to-end: a leaf clobbers `x10` but pins `x15` to ghost `g`; the caller keeps `w` live in `x15` across the call and *uses it after* (`pinCallerFn_spec`). Zero runtime cost.
- **`SpillDemo`** — spill/reload end-to-end: the callee *clobbers* `x15`; the caller SDs `w` into its private dword (framed as the `preB` ghost of the callee's `widenRw` widening, so the widened post returns it intact), re-materializes the frame pointer with `LI`, and LDs `w` back (`spCallerFn_spec`). Pointers are never spilled — they reload via `LI` from the static layout.

## Design decisions (docs/sasm-design.md §3.6.2)

1. Exposed registers are caller-saved; preserve via contract pinning or spill/reload as above.
2. s-registers (and `sp`/`gp`/`tp`) need **no machinery**: they are outside the exposed set and `blockOk` rejects any access, so verified SAsm code can never clobber them.
3. **Frames are static windows** of the stack arena — assigned by the global memory layout (bead .6), carved per call edge by `FnHandle.widenRw`; no dynamic `addi sp` in verified code. The guest's addi-sp frames are *replaced*, not modeled (sound: the verified call graph is a finite static tree; interpreter recursion goes through the data-indexed EVM frame arena, beads .5/.56).

Recipes added to docs/sasm-howto.md §5; PLAN.md updated.

## Verification

- `lake build EvmAsm.Rv64.SAsm` green, zero warnings
- `#print axioms` on `PinDemo.pinCallerFn_spec` and `SpillDemo.spCallerFn_spec`: `[propext, Classical.choice, Quot.sound]` only
- check-forbidden-tactics / check-file-size / check-unimported all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)