### PR TITLE
feat(sasm): verified indirect calls via Stmt.callReg (jalr dispatch)

### DIFF
--- a/EvmAsm/Rv64/SAsm.lean
+++ b/EvmAsm/Rv64/SAsm.lean
@@ -27,5 +27,6 @@ import EvmAsm.Rv64.SAsm.RaSpill
 import EvmAsm.Rv64.SAsm.Tactic
 import EvmAsm.Rv64.SAsm.HandleWiden
 import EvmAsm.Rv64.SAsm.FrameConv
+import EvmAsm.Rv64.SAsm.CallRegDemo
 import EvmAsm.Rv64.SAsm.Examples
 import EvmAsm.Rv64.SAsm.ExamplesVc

--- a/EvmAsm/Rv64/SAsm/Ast.lean
+++ b/EvmAsm/Rv64/SAsm/Ast.lean
@@ -149,6 +149,14 @@ inductive Stmt where
       pre/post in the C-like ABI; the VC generator emits one `.pre`
       obligation per call site. -/
   | call   (label : String) (f : FnHandle)
+  /-- Indirect call (`jalr ra, rs, 0`) through an exposed register, against
+      a finite table of possible callees (docs/sasm-design.md §3.6.3).  The
+      `.pre` VC demands the register hold the entry address of one of the
+      handles whose precondition is met; the strongest postcondition is the
+      disjunction of the handles' postconditions.  Per-branch correlation
+      (which handler ran) is recovered by instantiating the handles' ghost
+      contracts per call site. -/
+  | callReg (label : String) (rs : Reg) (handles : List FnHandle)
 
 namespace Stmt
 
@@ -167,6 +175,7 @@ def size : Stmt → Nat
   | blockAt _ _ _ is  => is.length
   | «while» _ _ _ _ b   => b.size + 2
   | call _ _          => 1
+  | callReg _ _ _     => 1
 
 /-- All statement sizes are meaningful; `assert` is the only zero-size node. -/
 @[simp] theorem size_seq (a b : Stmt) : (seq a b).size = a.size + b.size := rfl
@@ -184,6 +193,7 @@ def callFree : Stmt → Bool
   | blockAt _ _ _ _   => true
   | «while» _ _ _ _ b => b.callFree
   | call _ _          => false
+  | callReg _ _ _     => false
 
 end Stmt
 

--- a/EvmAsm/Rv64/SAsm/CallRegDemo.lean
+++ b/EvmAsm/Rv64/SAsm/CallRegDemo.lean
@@ -1,0 +1,154 @@
+/-
+  EvmAsm.Rv64.SAsm.CallRegDemo
+
+  Demo of the indirect-call construct `Stmt.callReg` (bead evm-asm-4ch8f.4):
+  a caller selects one of two handler entry addresses at runtime, then
+  dispatches through a register with `jalr ra, rs, 0`.  This is the SAsm
+  shape of the guest's dispatch tables (the 256-entry `opcode_handlers`
+  table, `tx_type_dispatch`, runtime-armed function-pointer backends): the
+  table *load* is ordinary ro-region block machinery; the only new
+  primitive is the register-indirect call, whose `.pre` VC demands the
+  register hold the entry of one of a finite set of handles.
+
+  The strongest postcondition of a `callReg` is the disjunction of the
+  handles' posts.  When a caller needs to know WHICH handler ran (opcode
+  dispatch), it instantiates the handles' ghost contracts per call site so
+  each disjunct carries its discriminating fact — same pattern as the
+  per-call-site region instantiation of `RoWidenDemo`.
+-/
+
+import EvmAsm.Rv64.SAsm.Fn
+import EvmAsm.Rv64.SAsm.Tactic
+
+namespace EvmAsm.Rv64
+namespace SAsm
+namespace CallRegDemo
+
+open Stmt
+
+/-- Handler A: set `x10 := 1`. -/
+def crLeafA : Fn where
+  name := "crleafA"
+  pre := fun _ _ _ => True
+  post := fun rf _ _ => rf.get .x10 = 1
+  body := .block "set" [.LI .x10 1]
+
+/-- Handler B: set `x10 := 2`. -/
+def crLeafB : Fn where
+  name := "crleafB"
+  pre := fun _ _ _ => True
+  post := fun rf _ _ => rf.get .x10 = 2
+  body := .block "set" [.LI .x10 2]
+
+theorem crLeafA_spec : crLeafA.Spec 0x2000 := by
+  vcgen
+  case crleafA.post =>
+    rintro rf' ws' A' ⟨rf₀, ws₀, hws₀, -, rfl, rfl⟩
+    simp only [crLeafA, execBlock_cons, execBlock_nil, execInstrRF, aluSem]
+    exact RegFile.get_set_self rf₀ .x10 1 (by decide)
+
+theorem crLeafB_spec : crLeafB.Spec 0x2100 := by
+  vcgen
+  case crleafB.post =>
+    rintro rf' ws' A' ⟨rf₀, ws₀, hws₀, -, rfl, rfl⟩
+    simp only [crLeafB, execBlock_cons, execBlock_nil, execInstrRF, aluSem]
+    exact RegFile.get_set_self rf₀ .x10 2 (by decide)
+
+def crLeafAHandle : FnHandle :=
+  crLeafA.toHandle 0x2000 crLeafA_spec
+    ((by decide : 4 * (crLeafA.body.size + 1) ≤ 2 ^ 64))
+
+def crLeafBHandle : FnHandle :=
+  crLeafB.toHandle 0x2100 crLeafB_spec
+    ((by decide : 4 * (crLeafB.body.size + 1) ≤ 2 ^ 64))
+
+/-- Dispatch: select a handler address on a runtime condition, call it
+    indirectly.  The `.pre` VC of the `callReg` sees the two `LI` branches
+    and picks the matching handle on each. -/
+def crCallerFn : Fn where
+  name := "crcaller"
+  pre := fun _ _ _ => True
+  post := fun rf _ _ => rf.get .x10 = 1 ∨ rf.get .x10 = 2
+  body :=
+    .ite "sel" (.beq .x11 .x0)
+      (.block "goA" [.LI .x28 0x2000])
+      (.block "goB" [.LI .x28 0x2100]) ;;;
+    .callReg "disp" .x28 [crLeafAHandle, crLeafBHandle]
+
+def crCallerCr : CodeReq :=
+  ((CodeReq.ofProg 0x1000 (crCallerFn.body.flatten 0x1000)).union
+    crLeafAHandle.code).union crLeafBHandle.code
+
+theorem crCallerFn_spec : crCallerFn.SpecR 0x1000 crCallerCr := by
+  have hcodeA : ∀ a i, crLeafAHandle.code a = some i →
+      crCallerCr a = some i := by
+    intro a i h
+    obtain ⟨kk, hk, rfl⟩ := ofProg_some_range h
+    have hk2 : kk < 2 := hk
+    have hP : CodeReq.ofProg 0x1000 (crCallerFn.body.flatten 0x1000)
+        ((0x2000 : Word) + BitVec.ofNat 64 (4 * kk)) = none := by
+      apply CodeReq.ofProg_none_range
+      intro k' hk' heq
+      have hk'5 : k' < 5 := hk'
+      bv_omega
+    simp only [crCallerCr, CodeReq.union, hP, h]
+  have hcodeB : ∀ a i, crLeafBHandle.code a = some i →
+      crCallerCr a = some i := by
+    intro a i h
+    obtain ⟨kk, hk, rfl⟩ := ofProg_some_range h
+    have hk2 : kk < 2 := hk
+    have hP : CodeReq.ofProg 0x1000 (crCallerFn.body.flatten 0x1000)
+        ((0x2100 : Word) + BitVec.ofNat 64 (4 * kk)) = none := by
+      apply CodeReq.ofProg_none_range
+      intro k' hk' heq
+      have hk'5 : k' < 5 := hk'
+      bv_omega
+    have hA : crLeafAHandle.code
+        ((0x2100 : Word) + BitVec.ofNat 64 (4 * kk)) = none := by
+      show CodeReq.ofProg 0x2000 (crLeafA.programRet 0x2000)
+        ((0x2100 : Word) + BitVec.ofNat 64 (4 * kk)) = none
+      apply CodeReq.ofProg_none_range
+      intro k' hk' heq
+      have hk'2 : k' < 2 := hk'
+      bv_omega
+    simp only [crCallerCr, CodeReq.union, hP, hA, h]
+  show Fn.SpecR _ _ _
+  vcgen
+  case code =>
+    intro a i h
+    simp only [crCallerCr, CodeReq.union, h]
+  case callees =>
+    refine ⟨⟨trivial, trivial⟩, ?_⟩
+    intro h hmem
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at hmem
+    rcases hmem with rfl | rfl
+    · exact ⟨hcodeA, rfl, rfl⟩
+    · exact ⟨hcodeB, rfl, rfl⟩
+  case calls =>
+    refine ⟨⟨trivial, trivial⟩, ?_, ?_⟩
+    · exact (by decide : (((0x1010 : Word) + 4) &&& ~~~(1 : Word)) = 0x1010 + 4)
+    · intro h hmem
+      simp only [List.mem_cons, List.not_mem_nil, or_false] at hmem
+      rcases hmem with rfl | rfl
+      · exact (by decide :
+          ((crLeafAHandle.entry &&& ~~~(1 : Word))) = crLeafAHandle.entry)
+      · exact (by decide :
+          ((crLeafBHandle.entry &&& ~~~(1 : Word))) = crLeafBHandle.entry)
+  case crcaller.disp.pre =>
+    rintro rf ws A (⟨rf₀, ws₀, hlen, -, rfl, rfl⟩ | ⟨rf₀, ws₀, hlen, -, rfl, rfl⟩)
+    · refine ⟨crLeafAHandle, by simp, ?_, trivial⟩
+      simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem]
+      exact RegFile.get_set_self rf₀ .x28 _ (by decide)
+    · refine ⟨crLeafBHandle, by simp, ?_, trivial⟩
+      simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem]
+      exact RegFile.get_set_self rf₀ .x28 _ (by decide)
+  case crcaller.post =>
+    rintro rf ws A ⟨h, hmem, hpost⟩
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at hmem
+    rcases hmem with rfl | rfl
+    · exact Or.inl hpost
+    · exact Or.inr hpost
+
+end CallRegDemo
+end SAsm
+end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/Flatten.lean
+++ b/EvmAsm/Rv64/SAsm/Flatten.lean
@@ -63,6 +63,8 @@ def flatten (addr : Word) : Stmt → List Instr
         :: (b.flatten (addr + 4) ++ [.JAL .x0 (jBack (b.size + 1))])
   | call _ f =>
       [.JAL .x1 (BitVec.setWidth 21 (f.entry - addr))]
+  | callReg _ rs _ =>
+      [.JALR .x1 rs 0]
 
 /-- The flattened code of a statement occupies exactly `size` slots. -/
 theorem flatten_length (s : Stmt) (addr : Word) :
@@ -81,6 +83,7 @@ theorem flatten_length (s : Stmt) (addr : Word) :
   | «while» _ c fuel inv b ihb =>
       simp [flatten, size, ihb]
   | call _ callee => rfl
+  | callReg _ _ _ => rfl
 
 /-- Decidable well-formedness: every synthesized offset fits its immediate
     field, and every branch condition reads only exposed registers (or x0).
@@ -105,12 +108,15 @@ def offsetsOk : Stmt → Bool
            && decide (4 * (b.size + 1) ≤ 2^20)
            && b.offsetsOk
   | call _ _ => true
+  | callReg _ rs _ => Reg.isExposed rs
 
 /-- Address-aware side conditions of the call sites of a statement placed at
     `addr`: each `jal` offset round-trips through its 21-bit immediate, the
     return address is aligned, and the callee's code does not sit on the
-    call instruction itself.  Decidable for concrete layouts (`decide`),
-    `bv_omega` for relative ones. -/
+    call instruction itself.  For an indirect call, the return address must
+    be aligned and every table entry must be a `jalr`-fixed-point address.
+    Decidable for concrete layouts (`decide`), `bv_omega` for relative
+    ones. -/
 def callsOk : Stmt → Word → Prop
   | block _ _, _ => True
   | seq a b, addr =>
@@ -126,6 +132,9 @@ def callsOk : Stmt → Word → Prop
       addr + signExtend21 (BitVec.setWidth 21 (f.entry - addr)) = f.entry
       ∧ ((addr + 4) &&& ~~~(1 : Word)) = addr + 4
       ∧ f.code addr = none
+  | callReg _ _ handles, addr =>
+      ((addr + 4) &&& ~~~(1 : Word)) = addr + 4
+      ∧ ∀ h ∈ handles, (h.entry &&& ~~~(1 : Word)) = h.entry
 
 end Stmt
 end SAsm

--- a/EvmAsm/Rv64/SAsm/RaSpill.lean
+++ b/EvmAsm/Rv64/SAsm/RaSpill.lean
@@ -243,29 +243,6 @@ theorem ld_ra_spec_within (rs : Reg) (sofs : BitVec 12) (rwBase : Word)
 -- Existential-precondition splitters with the `ra` atom alongside
 -- ============================================================================
 
-/-- Split `asrtM ** X` into a per-symbolic-state family (both regions and the
-    extra atom `X` alongside). -/
-theorem cpsTripleWithin_exists_pre_M_frame {n : Nat} {entry exit_ : Word}
-    {cr : CodeReq} {X : Assertion} {reg : Region} {rw : RwRegion}
-    {reach : Reach} {Q : Assertion}
-    (h : ∀ rf ws (A : Assertion), ws.length = rw.len → A.pcFree → reach rf ws A →
-      cpsTripleWithin n entry exit_ cr
-        ((((regFileIs rf) ** bytesRegion rw.base ws) ** A) **
-          (bytesRegion reg.base reg.bytes ** X)) Q) :
-    cpsTripleWithin n entry exit_ cr (asrtM reg rw reach ** X) Q := by
-  intro R hR s hcr hPR hpc
-  rw [show asrtM reg rw reach
-      = (asrtOf rw reach ** bytesRegion reg.base reg.bytes) from rfl,
-    sepConj_assoc', sepConj_assoc'] at hPR
-  -- hPR : (asrtOf ** (bytesRegion reg ** (X ** R)))
-  obtain ⟨hp, hcompat, h1, h2, hd, hu, ⟨rf, ws, A, hlen, hApc, hreach, hsts⟩, hR2⟩ := hPR
-  have hPR' : (((((regFileIs rf) ** bytesRegion rw.base ws) ** A) **
-      (bytesRegion reg.base reg.bytes ** (X ** R)))).holdsFor s :=
-    ⟨hp, hcompat, h1, h2, hd, hu, hsts, hR2⟩
-  rw [← sepConj_assoc' (bytesRegion reg.base reg.bytes) X R,
-    ← sepConj_assoc'] at hPR'
-  exact h rf ws A hlen hApc hreach R hR s hcr hPR' hpc
-
 /-- Split an `asrtR` precondition into a per-symbolic-state family, including
     a concrete value for the owned `ra`. -/
 theorem cpsTripleWithin_exists_pre_R {n : Nat} {entry exit_ : Word}

--- a/EvmAsm/Rv64/SAsm/StmtSound.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSound.lean
@@ -568,6 +568,8 @@ theorem Stmt.sound (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
         hsound
   | call lbl f =>
       exact absurd hleaf (by simp [Stmt.callFree])
+  | callReg lbl rs handles =>
+      exact absurd hleaf (by simp [Stmt.callFree])
 
 end SAsm
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
@@ -53,6 +53,78 @@ theorem cpsTripleWithin_regOwn_right_pre {n : Nat} {entry exit_ : Word}
   exact h v R hR s hcr
     ⟨hp, hcompat, h1, h2, hd, hu, ⟨h1a, h1b, hd1, hu1, hPa, hv⟩, hR2⟩ hpc
 
+/-- Split `asrtM ** X` into a per-symbolic-state family (both regions and the
+    extra atom `X` alongside). -/
+theorem cpsTripleWithin_exists_pre_M_frame {n : Nat} {entry exit_ : Word}
+    {cr : CodeReq} {X : Assertion} {reg : Region} {rw : RwRegion}
+    {reach : Reach} {Q : Assertion}
+    (h : ∀ rf ws (A : Assertion), ws.length = rw.len → A.pcFree → reach rf ws A →
+      cpsTripleWithin n entry exit_ cr
+        ((((regFileIs rf) ** bytesRegion rw.base ws) ** A) **
+          (bytesRegion reg.base reg.bytes ** X)) Q) :
+    cpsTripleWithin n entry exit_ cr (asrtM reg rw reach ** X) Q := by
+  intro R hR s hcr hPR hpc
+  rw [show asrtM reg rw reach
+      = (asrtOf rw reach ** bytesRegion reg.base reg.bytes) from rfl,
+    sepConj_assoc', sepConj_assoc'] at hPR
+  -- hPR : (asrtOf ** (bytesRegion reg ** (X ** R)))
+  obtain ⟨hp, hcompat, h1, h2, hd, hu, ⟨rf, ws, A, hlen, hApc, hreach, hsts⟩, hR2⟩ := hPR
+  have hPR' : (((((regFileIs rf) ** bytesRegion rw.base ws) ** A) **
+      (bytesRegion reg.base reg.bytes ** (X ** R)))).holdsFor s :=
+    ⟨hp, hcompat, h1, h2, hd, hu, hsts, hR2⟩
+  rw [← sepConj_assoc' (bytesRegion reg.base reg.bytes) X R,
+    ← sepConj_assoc'] at hPR'
+  exact h rf ws A hlen hApc hreach R hR s hcr hPR' hpc
+
+/-- One-step spec of the indirect-call jump `jalr x1, rs, 0`: the (exposed)
+    target register is read out of `regFileIs`, the return address lands in
+    the separately owned `ra`, and control transfers to the masked target.
+    The `regFileIs`-based analogue of `generic_jalr_spec_within`. -/
+theorem jalr_call_spec_within (rs : Reg) (rf : RegFile) (vOld base : Word)
+    (hrs : Reg.isExposed rs = true) :
+    cpsTripleWithin 1 base
+      ((rf.get rs + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word))
+      (CodeReq.singleton base (.JALR .x1 rs 0))
+      (((.x1 : Reg) ↦ᵣ vOld) ** regFileIs rf)
+      (((.x1 : Reg) ↦ᵣ (base + 4)) ** regFileIs rf) := by
+  intro R hR s hcr hPR hpc; subst hpc
+  have hfetch : s.code s.pc = some (.JALR .x1 rs 0) :=
+    CodeReq.singleton_satisfiedBy.mp hcr
+  have hPR1 := hPR
+  rw [sepConj_assoc', sepConj_left_comm] at hPR1
+  -- hPR1 : (regFileIs rf ** ((.x1 ↦ᵣ vOld) ** R))
+  have hrsv : s.getReg rs = rf.get rs :=
+    holdsFor_regFileIs_agree hPR1 (by rw [hrs]; rfl)
+  have hstep' : step s = some (execInstrBr s (.JALR .x1 rs 0)) :=
+    step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl)
+  have hexec : execInstrBr s (.JALR .x1 rs 0)
+      = (s.setReg .x1 (s.pc + 4)).setPC
+          ((rf.get rs + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)) := by
+    simp only [execInstrBr, hrsv]
+    rfl
+  refine ⟨1, Nat.le_refl 1, (s.setReg .x1 (s.pc + 4)).setPC
+    ((rf.get rs + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)), ?_, rfl, ?_⟩
+  · show (step s).bind (stepN 0) = some _
+    rw [hstep', hexec]; rfl
+  · have hPR2 := hPR
+    rw [sepConj_assoc'] at hPR2
+    -- hPR2 : ((.x1 ↦ᵣ vOld) ** (regFileIs rf ** R))
+    have h1 := holdsFor_sepConj_regIs_setReg (v' := s.pc + 4)
+      (show (.x1 : Reg) ≠ .x0 from by decide) hPR2
+    rw [← sepConj_assoc'] at h1
+    exact holdsFor_pcFree_setPC
+      (pcFree_sepConj (pcFree_sepConj (by pcFree) (pcFree_regFileIs _)) hR) h1
+
+/-- A table member's step bound is below the table's folded maximum. -/
+theorem FnHandle.nSteps_le_foldr_max {h : FnHandle} :
+    ∀ {hs : List FnHandle}, h ∈ hs →
+      h.nSteps ≤ hs.foldr (fun f m => max f.nSteps m) 0
+  | a :: as, hmem => by
+      rcases List.mem_cons.mp hmem with rfl | hmem'
+      · exact Nat.le_max_left _ _
+      · exact Nat.le_trans (FnHandle.nSteps_le_foldr_max hmem')
+          (Nat.le_max_right _ _)
+
 /-- Caller-shaped soundness (Milestone M4): the flattened code of `s`
     satisfies a bounded CPS triple at `asrtR` granularity, provided the
     ambient `cr` also contains every callee's code (`hcallees`) and the call
@@ -449,6 +521,99 @@ theorem Stmt.soundR (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
           (sepConj_mono_left (asrtM_mono (fun rf ws A hr => hpreVC rf ws A hr)))
           (fun _ hp => hp)
           (cpsTripleWithin_regOwn_right_pre hcall)
+      simp only [Stmt.steps, Stmt.size, Nat.mul_one]
+      have h4 : base + BitVec.ofNat 64 4 = base + 4 := rfl
+      rw [h4]
+      exact hfinal
+  | callReg lbl rs handles =>
+      obtain ⟨halignRet, hentries⟩ := hcalls
+      have hrs : Reg.isExposed rs = true := hofs
+      have hpreVC : ∀ rf ws A, reach rf ws A →
+          ∃ h ∈ handles, rf.get rs = h.entry ∧ h.pre rf ws A :=
+        hvcs _ (List.mem_singleton_self _)
+      have hcodeJalr : ∀ a' i,
+          CodeReq.singleton base (.JALR .x1 rs 0) a' = some i →
+          cr a' = some i := by
+        intro a' i h
+        apply hcode a' i
+        rw [show Stmt.flatten base (.callReg lbl rs handles)
+          = [.JALR .x1 rs 0] from rfl, CodeReq.ofProg_singleton]
+        exact h
+      have hfinal : cpsTripleWithin
+          (1 + handles.foldr (fun f m => max f.nSteps m) 0)
+          base (base + 4) cr
+          (asrtR reg rw reach)
+          (asrtR reg rw (Stmt.sp reg rw (.callReg lbl rs handles) reach)) := by
+        show cpsTripleWithin _ _ _ _ (asrtM reg rw reach ** regOwn .x1) _
+        apply cpsTripleWithin_regOwn_right_pre
+        intro vOld
+        apply cpsTripleWithin_exists_pre_M_frame
+        intro rf ws A hlen hApc hreach
+        obtain ⟨h, hmem, hrsentry, hpre⟩ := hpreVC rf ws A hreach
+        obtain ⟨hcalleeCode, hregeq, hrweq⟩ := hcallees h hmem
+        have htarget : ((rf.get rs + signExtend12 (0 : BitVec 12))
+            &&& ~~~(1 : Word)) = h.entry := by
+          rw [hrsentry,
+            show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+            show h.entry + (0 : Word) = h.entry from by bv_omega]
+          exact hentries h hmem
+        -- the jump
+        have hjal := jalr_call_spec_within rs rf vOld base hrs
+        rw [htarget] at hjal
+        have hjalC := cpsTripleWithin_extend_code hcodeJalr hjal
+        have hjalF := cpsTripleWithin_frameR
+          ((bytesRegion rw.base ws ** A) ** bytesRegion reg.base reg.bytes)
+          (pcFree_sepConj (pcFree_sepConj (bytesRegion_pcFree _ _) hApc)
+            (bytesRegion_pcFree _ _))
+          hjalC
+        -- the callee, retargeted at the return address
+        have hsound := h.sound (base + 4) halignRet
+        rw [hregeq, hrweq] at hsound
+        have hsoundC := cpsTripleWithin_extend_code hcalleeCode hsound
+        -- glue the shapes
+        have hjalW := cpsTripleWithin_weaken
+          (P := (((.x1 : Reg) ↦ᵣ vOld) ** regFileIs rf) **
+            ((bytesRegion rw.base ws ** A) ** bytesRegion reg.base reg.bytes))
+          (P' := (((regFileIs rf) ** bytesRegion rw.base ws) ** A) **
+            (bytesRegion reg.base reg.bytes ** ((.x1 : Reg) ↦ᵣ vOld)))
+          (Q' := (((.x1 : Reg) ↦ᵣ (base + 4)) ** regFileIs rf) **
+            ((bytesRegion rw.base ws ** A) ** bytesRegion reg.base reg.bytes))
+          (fun hp hh => by
+            rw [show ((((regFileIs rf) ** bytesRegion rw.base ws) ** A) **
+                (bytesRegion reg.base reg.bytes ** ((.x1 : Reg) ↦ᵣ vOld)))
+              = ((((.x1 : Reg) ↦ᵣ vOld) ** regFileIs rf) **
+                ((bytesRegion rw.base ws ** A) ** bytesRegion reg.base reg.bytes))
+              from by ac_rfl] at hh
+            exact hh)
+          (fun hp hh => hh)
+          hjalF
+        have hsoundW := cpsTripleWithin_weaken
+          (P := ((.x1 : Reg) ↦ᵣ (base + 4)) ** asrtM reg rw h.pre)
+          (P' := (((.x1 : Reg) ↦ᵣ (base + 4)) ** regFileIs rf) **
+            ((bytesRegion rw.base ws ** A) ** bytesRegion reg.base reg.bytes))
+          (Q' := asrtR reg rw (Stmt.sp reg rw (.callReg lbl rs handles) reach))
+          (fun hp hh => by
+            rw [show ((((.x1 : Reg) ↦ᵣ (base + 4)) ** regFileIs rf) **
+                ((bytesRegion rw.base ws ** A) ** bytesRegion reg.base reg.bytes))
+              = (((.x1 : Reg) ↦ᵣ (base + 4)) **
+                ((((regFileIs rf) ** bytesRegion rw.base ws) ** A) **
+                  bytesRegion reg.base reg.bytes))
+              from by ac_rfl] at hh
+            refine sepConj_mono_right (fun hq hx => ?_) hp hh
+            show asrtM reg rw h.pre hq
+            exact sepConj_mono_left
+              (fun hv hy => ⟨rf, ws, A, hlen, hApc, hpre, hy⟩) hq hx)
+          (fun hp hh => by
+            rw [sepConj_comm'] at hh
+            -- hh : (asrtM reg rw h.post ** ((.x1) ↦ᵣ (base + 4))) hp
+            refine sepConj_mono_right
+              (fun hq hx => (⟨base + 4, hx⟩ : regOwn .x1 hq)) hp ?_
+            exact sepConj_mono_left
+              (asrtM_mono (fun rf' ws' A' hp' => ⟨h, hmem, hp'⟩)) hp hh)
+          hsoundC
+        exact cpsTripleWithin_mono_nSteps
+          (Nat.add_le_add_left (FnHandle.nSteps_le_foldr_max hmem) 1)
+          (cpsTripleWithin_seq_same_cr hjalW hsoundW)
       simp only [Stmt.steps, Stmt.size, Nat.mul_one]
       have h4 : base + BitVec.ofNat 64 4 = base + 4 := rfl
       rw [h4]

--- a/EvmAsm/Rv64/SAsm/Vc.lean
+++ b/EvmAsm/Rv64/SAsm/Vc.lean
@@ -109,6 +109,7 @@ def sp (reg : Region) (rw : RwRegion) : Stmt → Reach → Reach
   | «while» _ c fuel inv _, _ =>
       fun rf ws A => (∃ i, i ≤ fuel ∧ inv i rf ws A) ∧ ¬ c.holds rf
   | call _ f, _ => fun rf ws A => f.post rf ws A
+  | callReg _ _ handles, _ => fun rf ws A => ∃ h ∈ handles, h.post rf ws A
 
 /-- Labeled verification conditions of a statement, given the reachable set
     at its entry.  `pfx` is the path prefix for labels. -/
@@ -154,6 +155,9 @@ def vcs (reg : Region) (rw : RwRegion) : Stmt → String → Reach → List VC
         (fun rf ws A => ∃ i, i < fuel ∧ inv i rf ws A ∧ c.holds rf)
   | call lbl f, pfx, reach =>
       [⟨pfx ++ lbl ++ ".pre", ∀ rf ws A, reach rf ws A → f.pre rf ws A⟩]
+  | callReg lbl rs handles, pfx, reach =>
+      [⟨pfx ++ lbl ++ ".pre", ∀ rf ws A, reach rf ws A →
+          ∃ h ∈ handles, rf.get rs = h.entry ∧ h.pre rf ws A⟩]
 
 /-- Exact step bound of a statement (docs/sasm-design.md §3.5; the loop bound
     is `WP.loopBound`). -/
@@ -167,6 +171,7 @@ def steps : Stmt → Nat
   | blockAt _ _ _ is => is.length
   | «while» _ _ fuel _ b => WP.loopBound 1 (b.steps + 1) 1 fuel
   | call _ f => 1 + f.nSteps
+  | callReg _ _ handles => 1 + handles.foldr (fun h m => max h.nSteps m) 0
 
 /-- `sp` is monotone in the reachable set. -/
 theorem sp_mono (reg : Region) (rw : RwRegion) (s : Stmt) {r₁ r₂ : Reach}
@@ -197,6 +202,8 @@ theorem sp_mono (reg : Region) (rw : RwRegion) (s : Stmt) {r₁ r₂ : Reach}
   | «while» lbl c fuel inv b ihb =>
       exact fun rf ws A hr => hr
   | call lbl f =>
+      exact fun rf ws A hr => hr
+  | callReg lbl rs handles =>
       exact fun rf ws A hr => hr
 
 -- ============================================================================
@@ -328,6 +335,7 @@ theorem sp_of_endsWith (reg : Region) (rw : RwRegion) {P : Reach}
   | ghost lbl R => exact nomatch h
   | «while» lbl c fuel inv b ih => exact nomatch h
   | call lbl f => exact nomatch h
+  | callReg lbl rs handles => exact nomatch h
 
 /-- `vcs` is antitone in the reachable set: obligations proven for a larger
     reachable set cover any smaller one.  Used to specialize loop-body VCs
@@ -419,6 +427,11 @@ theorem vcs_antitone (reg : Region) (rw : RwRegion) (s : Stmt) (pfx : String)
       simp only [vcs, List.mem_singleton] at hvc
       subst hvc
       exact fun rf ws A hr => hvcs.head rf ws A (h rf ws A hr)
+  | callReg lbl rs handles =>
+      intro vc hvc
+      simp only [vcs, List.mem_singleton] at hvc
+      subst hvc
+      exact fun rf ws A hr => hvcs.head rf ws A (h rf ws A hr)
 
 /-- Per call site: the callee's code is contained in `cr` and the callee
     shares the caller's regions.  Stated structurally (rather than as a union
@@ -436,6 +449,9 @@ def CalleesIn (s : Stmt) (reg : Region) (rw : RwRegion) (cr : CodeReq) : Prop :=
   | «while» _ _ _ _ b => b.CalleesIn reg rw cr
   | call _ f => (∀ a i, f.code a = some i → cr a = some i)
       ∧ f.region = reg ∧ f.rw = rw
+  | callReg _ _ handles => ∀ h ∈ handles,
+      (∀ a i, h.code a = some i → cr a = some i)
+      ∧ h.region = reg ∧ h.rw = rw
 
 end Stmt
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2518,7 +2518,14 @@ dword outside the callee's `widenRw` window and reload after `LI`
 re-materializing the pointer (SpillDemo); s-regs/`sp` are outside the
 exposed set (blockOk rejects them) so verified code can't clobber them;
 frames are STATIC windows of the stack arena (no dynamic `addi sp`),
-design in docs/sasm-design.md §3.6.2. Next for SAsm: more
+design in docs/sasm-design.md §3.6.2. Indirect calls landed
+(`Stmt.callReg`, bead evm-asm-4ch8f.4): `jalr ra, rs, 0` against a
+finite handle table — `.pre` VC = register pins some handle's entry
+with its pre met, sp = disjunction of posts, soundness via
+`jalr_call_spec_within` reading the target out of `regFileIs`; table
+loads are ordinary ro-region blocks, correlation via per-call-site
+ghost instantiation, tail calls (`jalr x0`) future work
+(docs/sasm-design.md §3.6.3, CallRegDemo). Next for SAsm: more
 Stateless/SSZ ports. Assertion-state milestone started (approved plan
 ~/.claude/plans/federated-wandering-pudding.md; epic evm-asm-6dt3v):
 Stages 1+2a landed — `Reach := RegFile → List Byte → Assertion → Prop`

--- a/docs/sasm-design.md
+++ b/docs/sasm-design.md
@@ -451,6 +451,51 @@ How values survive calls and where frames live (bead evm-asm-4ch8f.3,
    interpreter's call depth) does not stack-allocate: it goes through the
    data-indexed EVM frame arena (beads evm-asm-4ch8f.5/.56).
 
+### 3.6.3 Indirect calls (`Stmt.callReg`, design decisions)
+
+The guest dispatches through function pointers in three places: the
+256-entry `opcode_handlers` jump table, `tx_type_dispatch`, and
+runtime-armed backends (`ecrecover_backend_ptr`).  All of them reduce to
+one primitive (bead evm-asm-4ch8f.4):
+
+- **`Stmt.callReg lbl rs handles`** emits a single `jalr ra, rs, 0` and
+  carries a *finite table* of candidate callees.  Its one `.pre` VC
+  demands that every reachable state pin the (exposed) register to the
+  entry address of some handle whose precondition holds:
+  `∃ h ∈ handles, rf.get rs = h.entry ∧ h.pre rf ws A`.  The strongest
+  postcondition is the disjunction `∃ h ∈ handles, h.post rf ws A`; the
+  step bound is `1 +` the folded maximum of the handles' bounds.
+  Soundness (the `callReg` case of `Stmt.soundR`) splits the symbolic
+  state, picks the handle the `.pre` VC names, steps the `jalr`
+  (`jalr_call_spec_within`, which reads the target out of `regFileIs`
+  and drops the return address into the owned `ra`), and runs that
+  handle's contract — no disjointness side conditions, since both the
+  jump and the callee code live in the ambient `cr`.
+- **Table loads are not a new primitive.**  A dispatch table in `.data`
+  is a read-only region of little-endian dword entries; the load
+  `ld rs, 8*i(table)` is ordinary block machinery, and its `.post`
+  relates `rf.get rs` to `Region.dwordAt` — exactly what the `.pre` VC
+  of the following `callReg` consumes.  Runtime-armed pointers live in a
+  `rw` dword instead; same shape.
+- **Correlation** (knowing WHICH handler ran): the bare disjunction
+  loses it, deliberately.  Callers that need it instantiate the handles'
+  ghost contracts per call site — e.g. handler `i`'s instantiated post
+  can pin the dispatch index or its distinguishing effect — the same
+  per-call-site instantiation used for regions (`RoWidenDemo`) and
+  saved registers (§3.6.2).  For the 256-entry opcode table this is one
+  handle family indexed by the opcode byte.
+- **Address side conditions** (`callsOk`): the return address `pc + 4`
+  is aligned and every table entry is a `jalr` fixed point
+  (`entry &&& ~1 = entry`) — decidable per concrete layout.  `offsetsOk`
+  additionally requires `rs` exposed.  Tail calls (`jalr x0`) remain
+  future work; they need a different contract shape (the callee returns
+  to the CALLER's caller), not just a new emitter.
+
+`CallRegDemo` exercises the construct end-to-end: two verified handlers,
+a caller that selects an entry address on a runtime condition and
+dispatches through `x28`, and a proof that the merged postcondition
+holds.
+
 ### 3.7 Flattening (`SAsm/Flatten.lean`)
 
 ```lean
@@ -468,6 +513,7 @@ Layouts (sizes in instructions):
 | `when c b`   | `B¬c → Lend` · `b` | `b.size + 1` |
 | `while c n _ b` | `Lhdr: B¬c → Lend` · `b` · `J → Lhdr` | `b.size + 2` |
 | `call _ f`   | `JAL x1, (f.entry − pc)` | `1` |
+| `callReg _ rs hs` | `JALR x1, rs, 0` | `1` |
 | `assert`     | (nothing) | `0` |
 
 `#eval`-able: flattened programs plug directly into the existing codegen

--- a/docs/sasm-howto.md
+++ b/docs/sasm-howto.md
@@ -208,6 +208,19 @@ contract; the call machinery consumes it unchanged.
   s-registers and `sp` never need either recipe: they are outside the
   exposed set, so verified code cannot touch them (frames are static
   windows of the stack arena; there is no `addi sp` in verified code).
+- **Indirect calls** (`Stmt.callReg lbl rs handles`; design §3.6.3).
+  Emits `jalr ra, rs, 0` against a finite table of candidate handles.
+  One `.pre` VC: produce `⟨h, membership, rf.get rs = h.entry, h.pre⟩`
+  for every reachable state — after a table `ld` or a branch of `LI`s,
+  this is `RegFile.get_set_self` plus picking the branch's handle.  The
+  call's sp is the disjunction `∃ h ∈ handles, h.post`; destructure the
+  membership with `simp only [List.mem_cons, ...] ; rcases ... with rfl | rfl`.
+  `callees` asks the per-handle triple (code ⊆ cr, regions equal —
+  widen each handle first if it owns a sub-window); `calls` asks
+  `pc + 4` aligned plus every entry a `jalr` fixed point (`decide`).
+  `offsetsOk` requires `rs` exposed.  To know WHICH handler ran,
+  instantiate the handles' ghost contracts per call site (see
+  `CallRegDemo` and §3.6.3).
 
 ### Calling an existing hand-verified `cpsTripleWithin`
 


### PR DESCRIPTION
## Summary

Implements bead **evm-asm-4ch8f.4** (indirect jumps / dispatch tables). Stacked on #9706 (`feat/sasm-frame-conv`).

The guest dispatches through function pointers in three places — the 256-entry `opcode_handlers` jump table, `tx_type_dispatch`, and runtime-armed backends. All reduce to one new primitive: a register-indirect call whose VC is a case split over a finite table of verified callees.

## The construct

**`Stmt.callReg lbl rs handles`** flattens to a single `jalr ra, rs, 0` and carries a `List FnHandle` of candidate callees:

- **`.pre` VC** (the case split): every reachable state must pin the exposed register to some handle's entry with that handle's precondition met — `∃ h ∈ handles, rf.get rs = h.entry ∧ h.pre rf ws A`.
- **Strongest post**: the disjunction `∃ h ∈ handles, h.post rf ws A`. Step bound: `1 +` the folded maximum of the handles' bounds.
- **Soundness** (new `callReg` case of `Stmt.soundR`): split the symbolic state per `(rf, ws, A)`, pick the handle the `.pre` VC names, step the jump via the new `jalr_call_spec_within` (reads the target out of `regFileIs`, drops the return address into the owned `ra`), and run that handle's contract. Composition is through the ambient `cr`, so — unlike the direct-call case — no disjointness side conditions at all.
- **Side conditions**: `callsOk` = return address aligned + every entry a `jalr` fixed point (`decide` per layout); `offsetsOk` additionally requires `rs` exposed.

## Design decisions (docs/sasm-design.md §3.6.3)

- **Table loads are not a new primitive** — a `.data` dispatch table is a read-only region of dword entries; `ld rs, 8*i(table)` is existing block machinery whose post feeds the `callReg` `.pre` VC. Runtime-armed pointers live in a rw dword; same shape.
- **Correlation** (which handler ran) is recovered by instantiating the handles' ghost contracts per call site — the same pattern as per-slice regions (`RoWidenDemo`) and pinned registers (§3.6.2). For the opcode table: one handle family indexed by the opcode byte.
- **Tail calls** (`jalr x0`) are explicitly future work — they need a different contract shape, not just an emitter.

## Demo

`CallRegDemo`: two verified handlers (`x10 := 1` / `x10 := 2`), a caller that selects an entry address on a runtime condition (`ite` + `LI`) and dispatches through `x28`, proven end-to-end (`crCallerFn_spec`).

Also: `cpsTripleWithin_exists_pre_M_frame` moves from RaSpill.lean to StmtSoundCall.lean (the induction needs it; RaSpill sees it via its existing imports).

## Verification

- Full `lake build` green (only the pre-existing LeanRV64D deprecation warning)
- `#print axioms` on `Stmt.soundR` and `CallRegDemo.crCallerFn_spec`: `[propext, Classical.choice, Quot.sound]` only
- check-forbidden-tactics / check-file-size / check-unimported all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)