### PR TITLE
feat(rv64): concrete ZisK accelerator semantics via Instr.CSRS

### DIFF
--- a/EvmAsm/Codegen/Emit.lean
+++ b/EvmAsm/Codegen/Emit.lean
@@ -110,6 +110,17 @@ def emitInstr : Instr → String
   | .DIVU   rd rs1 rs2 => s!"divu {emitReg rd}, {emitReg rs1}, {emitReg rs2}"
   | .REM    rd rs1 rs2 => s!"rem {emitReg rd}, {emitReg rs1}, {emitReg rs2}"
   | .REMU   rd rs1 rs2 => s!"remu {emitReg rd}, {emitReg rs1}, {emitReg rs2}"
+  -- ZisK accelerator call: pre-encoded `csrrs x0, csr, rs1` so the plain
+  -- rv64imac toolchain assembles it without Zicsr (the `.4byte` pattern
+  -- used throughout Codegen/Programs)
+  | .CSRS   csr rs1    =>
+      s!".4byte {(csr.toNat <<< 20) ||| (rs1.toNat <<< 15) ||| 0x2073}"
+
+-- The pre-encoded accelerator words match the hand-written guest literals
+-- (`csrs 0x800, a0` / `csrs 0x802, t0` / `csrs 0x805, a0`).
+example : emitInstr (.CSRS 0x800 .x10) = s!".4byte {0x80052073}" := rfl
+example : emitInstr (.CSRS 0x802 .x5) = s!".4byte {0x8022a073}" := rfl
+example : emitInstr (.CSRS 0x805 .x10) = s!".4byte {0x80552073}" := rfl
 
 /-- Render a `Program` as one mnemonic per line, each indented two spaces. -/
 def emitProgram (p : Program) : String :=

--- a/EvmAsm/Codegen/RoundTripTests.lean
+++ b/EvmAsm/Codegen/RoundTripTests.lean
@@ -90,6 +90,11 @@ open EvmAsm.Rv64
 #guard emitInstr .FENCE  = "fence"
 #guard emitInstr .EBREAK = "ebreak"
 
+-- ZisK accelerator CSR calls (pre-encoded `.4byte` for the rv64imac toolchain)
+#guard emitInstr (.CSRS 0x800 .x10) = s!".4byte {0x80052073}"
+#guard emitInstr (.CSRS 0x802 .x5)  = s!".4byte {0x8022a073}"
+#guard emitInstr (.CSRS 0x805 .x10) = s!".4byte {0x80552073}"
+
 -- RV64M
 #guard emitInstr (.MUL    .x5 .x6 .x7) = "mul x5, x6, x7"
 #guard emitInstr (.MULH   .x5 .x6 .x7) = "mulh x5, x6, x7"

--- a/EvmAsm/Rv64/Basic.lean
+++ b/EvmAsm/Rv64/Basic.lean
@@ -234,6 +234,11 @@ inductive Instr where
   | REM  (rd rs1 rs2 : Reg)
   /-- REMU rd, rs1, rs2 : rd := rs1 %u rs2 (unsigned remainder) -/
   | REMU (rd rs1 rs2 : Reg)
+  -- ZisK accelerator invocation
+  /-- CSRS csr, rs1 (`csrrs x0, csr, rs1`): ZisK accelerator call with the
+      operand-block pointer in `rs1`.  Modeled with concrete semantics per
+      CSR id (`EvmAsm.Rv64.ZiskAccel`); unmodeled ids trap in `step`. -/
+  | CSRS (csr : BitVec 12) (rs1 : Reg)
   deriving Repr, DecidableEq
 
 -- ============================================================================

--- a/EvmAsm/Rv64/Execution.lean
+++ b/EvmAsm/Rv64/Execution.lean
@@ -171,6 +171,9 @@ def execInstrBr (s : MachineState) (i : Instr) : MachineState :=
   -- RV64I system
   | .ECALL =>
       s.setPC (s.pc + 4)
+  -- ZisK accelerator call (validity checked by `step`)
+  | .CSRS csr rs1 =>
+      (s.execCsrs csr rs1).setPC (s.pc + 4)
   | .FENCE =>
       s.setPC (s.pc + 4)
   | .EBREAK =>
@@ -389,6 +392,12 @@ def step (s : MachineState) : Option MachineState :=
     if isValidHalfwordAccess addr then
       some (execInstrBr s (.SH rs1 rs2 offset))
     else none
+  | some (.CSRS csr rs1) =>
+    -- ZisK accelerator: all operand dwords valid (and, for Arith256Mod,
+    -- modulus ≠ 0), else trap.  Unmodeled CSR ids always trap.
+    if s.csrsValid csr rs1 then
+      some (execInstrBr s (.CSRS csr rs1))
+    else none
   | some .EBREAK => none  -- trap: breakpoint
   | some .ECALL =>
     let t0 := s.getReg .x5
@@ -517,6 +526,21 @@ theorem stepResult_ok_iff {s s' : MachineState} :
     (hnm : i.isMemAccess = false) :
     step s = some (execInstrBr s i) := by
   unfold step; rw [hfetch]; cases i <;> simp_all [Instr.isMemAccess]
+
+/-- step for a ZisK accelerator call with valid operand blocks. -/
+theorem step_csrs {s : MachineState} {csr : BitVec 12} {rs1 : Reg}
+    (hfetch : s.code s.pc = some (.CSRS csr rs1))
+    (hvalid : s.csrsValid csr rs1 = true) :
+    step s = some (execInstrBr s (.CSRS csr rs1)) := by
+  unfold step; rw [hfetch]; simp [hvalid]
+
+/-- step for a ZisK accelerator call with an invalid operand block (or an
+    unmodeled CSR id): trap. -/
+theorem step_csrs_trap {s : MachineState} {csr : BitVec 12} {rs1 : Reg}
+    (hfetch : s.code s.pc = some (.CSRS csr rs1))
+    (hinvalid : s.csrsValid csr rs1 = false) :
+    step s = none := by
+  unfold step; rw [hfetch]; simp [hinvalid]
 
 /-- step for LD with valid dword memory access. -/
 theorem step_ld {s : MachineState} {rd rs1 : Reg} {offset : BitVec 12}

--- a/EvmAsm/Rv64/Instructions.lean
+++ b/EvmAsm/Rv64/Instructions.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Rv64.Basic
+import EvmAsm.Rv64.ZiskAccel
 
 namespace EvmAsm.Rv64
 
@@ -35,6 +36,7 @@ def Instr.isMemAccess : Instr → Bool
   | .LHU _ _ _  => true
   | .SB _ _ _   => true
   | .SH _ _ _   => true
+  | .CSRS _ _   => true  -- accelerator call: reads/writes operand blocks
   | _           => false
 
 -- ============================================================================
@@ -272,6 +274,7 @@ def execInstr (s : MachineState) (i : Instr) : MachineState :=
         s.setReg rd (rv64_rem (s.getReg rs1) (s.getReg rs2))
     | .REMU rd rs1 rs2 =>
         s.setReg rd (rv64_remu (s.getReg rs1) (s.getReg rs2))
+    | .CSRS csr rs1 => s.execCsrs csr rs1
     | .BEQ _ _ _ | .BNE _ _ _ | .BLT _ _ _ | .BGE _ _ _
     | .BLTU _ _ _ | .BGEU _ _ _ | .JAL _ _ | .JALR _ _ _ | .ECALL => s
   s'.setPC (s'.pc + 4#64)

--- a/EvmAsm/Rv64/ZiskAccel.lean
+++ b/EvmAsm/Rv64/ZiskAccel.lean
@@ -1,0 +1,371 @@
+/-
+  EvmAsm.Rv64.ZiskAccel
+
+  Concrete semantics of the ZisK accelerator instructions
+  (bead evm-asm-4ch8f.1).
+
+  The guest invokes ZisK precompiles via raw `csrs <id>, <reg>` encodings
+  (`.4byte` words, e.g. `0x80052073 = csrs 0x800, a0`); the register holds
+  a pointer to the operand block.  This module gives those instructions
+  *concrete* mathematical semantics — the actual Keccak-f[1600]
+  permutation, the actual SHA-256 compression function, exact
+  512-bit-intermediate modular arithmetic — rather than an axiomatized
+  accelerator contract:
+
+  * evm-asm carries SOFTWARE implementations of several hashes (RIPEMD-160,
+    the SHA-256 Merkle–Damgård wrapper, P-256 over Arith256Mod); proofs
+    must relate the software and accelerator paths to the SAME function,
+    so the function has to exist concretely;
+  * the project's trusted base is the three classical axioms — an
+    axiomatized accelerator contract would widen it;
+  * concrete permutations are testable in-repo: the known-answer theorems
+    below are kernel-checked with `decide` against pinned vectors
+    (`keccak256("")`, `sha256("")`).
+
+  Modeled accelerators (CSR ids per `ziskos` and the pinned probes in
+  `Codegen/Programs/HashProbes.lean` / `Secp256k1Field.lean`):
+
+    0x800  Keccakf      rs1 → 200-byte state, 25 LE u64 lanes, in place
+    0x802  Arith256Mod  rs1 → [a*, b*, c*, module*, d*], 4 LE u64 limbs
+                        each; d := (a*b + c) mod module (exact 512-bit
+                        intermediate; module = 0 traps)
+    0x805  Sha256f      rs1 → [state*, input*]; state = 8 u32 (LE-u32
+                        packed in u64), input = 16 u32; one compression,
+                        in place
+
+  Any other CSR id traps (`step` returns `none`): unmodeled accelerators
+  halt the model rather than silently no-op.  Follow-up accelerators
+  (Secp256k1Add/Dbl 0x803/0x804, Blake2bRound 0x819, BN254, BLS12-381)
+  slot into the same `execCsrs`/`csrsValid` dispatch.
+-/
+
+import EvmAsm.Rv64.Basic
+
+namespace EvmAsm.Rv64
+
+namespace Accel
+
+-- ============================================================================
+-- Keccak-f[1600]
+-- ============================================================================
+
+/-- The 24 Keccak round constants. -/
+def keccakRC : List (BitVec 64) :=
+  [0x0000000000000001, 0x0000000000008082, 0x800000000000808A,
+   0x8000000080008000, 0x000000000000808B, 0x0000000080000001,
+   0x8000000080008081, 0x8000000000008009, 0x000000000000008A,
+   0x0000000000000088, 0x0000000080008009, 0x000000008000000A,
+   0x000000008000808B, 0x800000000000008B, 0x8000000000008089,
+   0x8000000000008003, 0x8000000000008002, 0x8000000000000080,
+   0x000000000000800A, 0x800000008000000A, 0x8000000080008081,
+   0x8000000000008080, 0x0000000080000001, 0x8000000080008008]
+
+/-- Rho rotation offsets, indexed `rhoOff x y` for lane (x, y). -/
+def rhoOff (x y : Nat) : Nat :=
+  ([[0, 36, 3, 41, 18],
+    [1, 44, 10, 45, 2],
+    [62, 6, 43, 15, 61],
+    [28, 55, 25, 21, 56],
+    [27, 20, 39, 8, 14]].getD (x % 5) []).getD (y % 5) 0
+
+/-- One Keccak-f round on the 5×5 lane state (lane (x, y) at index
+    `x + 5*y`).  The result is MATERIALIZED as a list: composing rounds
+    over a functional state would re-evaluate shared lanes exponentially. -/
+def keccakRound (rc : BitVec 64) (st : List (BitVec 64)) : List (BitVec 64) :=
+  let A : Nat → Nat → BitVec 64 := fun x y => st.getD (x % 5 + 5 * (y % 5)) 0
+  let C : Nat → BitVec 64 := fun x => A x 0 ^^^ A x 1 ^^^ A x 2 ^^^ A x 3 ^^^ A x 4
+  let D : Nat → BitVec 64 := fun x => C (x + 4) ^^^ (C (x + 1)).rotateLeft 1
+  -- theta, then rho+pi: B[X + 5Y] sources lane (X + 3Y, X)
+  let B : Nat → Nat → BitVec 64 := fun X Y =>
+    let xs := (X + 3 * Y) % 5
+    let ys := X % 5
+    (A xs ys ^^^ D xs).rotateLeft (rhoOff xs ys)
+  let chi : Nat → BitVec 64 := fun j =>
+    let X := j % 5
+    let Y := j / 5
+    B X Y ^^^ ((~~~(B (X + 1) Y)) &&& B (X + 2) Y)
+  List.ofFn (n := 25) (fun j => if j.val = 0 then chi 0 ^^^ rc else chi j.val)
+
+/-- Keccak-f[1600]: 24 rounds over the 25-lane state. -/
+def keccakF (st : List (BitVec 64)) : List (BitVec 64) :=
+  keccakRC.foldl (fun s rc => keccakRound rc s) st
+
+set_option maxRecDepth 40000 in
+/-- Known-answer test, kernel-checked: absorbing the padded empty message
+    into a zero state (rate 1088: `st[0] ^= 0x01`, `st[16] ^= 0x80 << 56`)
+    and permuting yields `keccak256("") =
+    c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`
+    in the first four LE lanes.
+
+    The `maxRecDepth` bump is NOT proof-search scaling: `decide` here is
+    concrete evaluation, and the recursion depth is the intrinsic
+    evaluation depth of 24 chained rounds (each round's lanes read the
+    previous round's materialized list), not a symptom of a mis-stated
+    goal. -/
+theorem keccakF_kat_empty :
+    (keccakF (List.ofFn (n := 25) (fun j =>
+      if j.val = 0 then 0x0000000000000001
+      else if j.val = 16 then 0x8000000000000000
+      else 0))).take 4
+    = [0x3C23F7860146D2C5, 0xC003C7DCB27D7E92,
+       0x3B2782CA53B600E5, 0x70A4855D04D8FA7B] := by decide
+
+-- ============================================================================
+-- SHA-256 compression
+-- ============================================================================
+
+/-- The 64 SHA-256 round constants. -/
+def sha256K : List (BitVec 32) :=
+  [0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+   0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+   0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+   0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+   0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+   0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+   0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+   0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+   0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+   0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+   0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+   0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+   0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+   0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+   0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+   0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2]
+
+/-- Message schedule: extend the 16 block words to 64. -/
+def sha256W (w : List (BitVec 32)) : List (BitVec 32) :=
+  (List.range 64).foldl (fun acc t =>
+    if t < 16 then acc ++ [w.getD t 0]
+    else
+      let s0 := (acc.getD (t - 15) 0).rotateRight 7
+        ^^^ (acc.getD (t - 15) 0).rotateRight 18 ^^^ (acc.getD (t - 15) 0 >>> 3)
+      let s1 := (acc.getD (t - 2) 0).rotateRight 17
+        ^^^ (acc.getD (t - 2) 0).rotateRight 19 ^^^ (acc.getD (t - 2) 0 >>> 10)
+      acc ++ [acc.getD (t - 16) 0 + s0 + acc.getD (t - 7) 0 + s1]) []
+
+/-- One SHA-256 compression: 8-word state, 16-word block, new 8-word
+    state (Davies–Meyer feed-forward included). -/
+def sha256Compress (hs w : List (BitVec 32)) : List (BitVec 32) :=
+  let W := sha256W w
+  let fin := (List.range 64).foldl (fun st t =>
+    let a := st.getD 0 0
+    let b := st.getD 1 0
+    let c := st.getD 2 0
+    let d := st.getD 3 0
+    let e := st.getD 4 0
+    let f := st.getD 5 0
+    let g := st.getD 6 0
+    let h := st.getD 7 0
+    let S1 := e.rotateRight 6 ^^^ e.rotateRight 11 ^^^ e.rotateRight 25
+    let ch := (e &&& f) ^^^ ((~~~e) &&& g)
+    let T1 := h + S1 + ch + sha256K.getD t 0 + W.getD t 0
+    let S0 := a.rotateRight 2 ^^^ a.rotateRight 13 ^^^ a.rotateRight 22
+    let maj := (a &&& b) ^^^ (a &&& c) ^^^ (b &&& c)
+    let T2 := S0 + maj
+    [T1 + T2, a, b, c, d + T1, e, f, g]) (hs.take 8)
+  List.zipWith (· + ·) (hs.take 8) fin
+
+set_option maxRecDepth 40000 in
+/-- Known-answer test, kernel-checked: compressing the padded empty
+    message over the initial state yields `sha256("") =
+    e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`.
+    (Same intrinsic-evaluation-depth note as `keccakF_kat_empty`.) -/
+theorem sha256Compress_kat_empty :
+    sha256Compress
+      [0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+       0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19]
+      [0x80000000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    = [0xe3b0c442, 0x98fc1c14, 0x9afbf4c8, 0x996fb924,
+       0x27ae41e4, 0x649b934c, 0xa495991b, 0x7852b855] := by decide
+
+-- ============================================================================
+-- Arith256Mod
+-- ============================================================================
+
+/-- Interpret a little-endian u64 limb list as a natural number. -/
+def leLimbsToNat (ws : List Word) : Nat :=
+  ws.foldr (fun w acc => acc * 2 ^ 64 + w.toNat) 0
+
+/-- The low `n` little-endian u64 limbs of a natural number. -/
+def natToLeLimbs (n : Nat) (x : Nat) : List Word :=
+  (List.range n).map (fun i => BitVec.ofNat 64 (x >>> (64 * i)))
+
+/-- `d = (a*b + c) mod m` with exact intermediate arithmetic (the ZisK
+    `Arith256Mod` contract).  Callers guard `m ≠ 0` (`csrsValid`). -/
+def arith256Mod (a b c m : Nat) : Nat :=
+  (a * b + c) % m
+
+-- ============================================================================
+-- u32-in-dword packing (the pinned ziskemu 0.18 Sha256f layout)
+-- ============================================================================
+
+/-- Unpack dwords into u32s, low half first (LE-u32-within-u64). -/
+def dwordsToU32s (ws : List Word) : List (BitVec 32) :=
+  ws.flatMap (fun (w : Word) => [w.setWidth 32, (w >>> 32).setWidth 32])
+
+/-- Pack u32 pairs back into dwords, low half first. -/
+def u32sToDwords : List (BitVec 32) → List Word
+  | lo :: hi :: rest =>
+      ((hi.setWidth 64 <<< 32) ||| lo.setWidth 64) :: u32sToDwords rest
+  | _ => []
+
+/-- The SHA-256 state words are big-endian u32s stored as LE u32s in
+    memory; as u32 VALUES read from the dwords they are already the
+    spec-side words, so the pinned layout round-trips through
+    `dwordsToU32s`/`u32sToDwords` with no byte swap. -/
+theorem u32sToDwords_dwordsToU32s_pair (w : Word) :
+    u32sToDwords (dwordsToU32s [w]) = [w] := by
+  show [(((w >>> 32).setWidth 32).setWidth 64 <<< 32)
+    ||| (w.setWidth 32).setWidth 64] = [w]
+  congr 1
+  apply BitVec.eq_of_getLsbD_eq
+  intro i hi
+  rw [BitVec.getLsbD_or, BitVec.getLsbD_shiftLeft]
+  by_cases h32 : i < 32
+  · simp [BitVec.getLsbD_setWidth, h32, hi]
+  · simp [BitVec.getLsbD_setWidth, BitVec.getLsbD_ushiftRight, h32, hi,
+      show i - 32 < 32 from by omega, show 32 + (i - 32) = i from by omega]
+    intro _
+    omega
+
+end Accel
+
+-- ============================================================================
+-- Machine-level accelerator dispatch
+-- ============================================================================
+
+namespace MachineState
+
+/-- Every dword of an `n`-dword operand block is a valid access. -/
+def validDwordRange (p : Word) (n : Nat) : Bool :=
+  (List.range n).all (fun i => isValidDwordAccess (p + BitVec.ofNat 64 (8 * i)))
+
+/-- Effect of `csrs csr, rs1` on the machine state (validity is checked
+    separately by `csrsValid`; `step` traps when it fails).  Unknown CSR
+    ids leave the state unchanged here and trap in `step`. -/
+def execCsrs (s : MachineState) (csr : BitVec 12) (rs1 : Reg) : MachineState :=
+  let p := s.getReg rs1
+  if csr = 0x800 then
+    -- Keccakf: 25-lane state at p, in place
+    s.writeWords p (Accel.keccakF (s.readWords p 25))
+  else if csr = 0x802 then
+    -- Arith256Mod: parameter block [a*, b*, c*, module*, d*] at p
+    let a := Accel.leLimbsToNat (s.readWords (s.getMem p) 4)
+    let b := Accel.leLimbsToNat (s.readWords (s.getMem (p + 8)) 4)
+    let c := Accel.leLimbsToNat (s.readWords (s.getMem (p + 16)) 4)
+    let m := Accel.leLimbsToNat (s.readWords (s.getMem (p + 24)) 4)
+    s.writeWords (s.getMem (p + 32)) (Accel.natToLeLimbs 4 (Accel.arith256Mod a b c m))
+  else if csr = 0x805 then
+    -- Sha256f: parameter block [state*, input*] at p
+    let stP := s.getMem p
+    let st := Accel.dwordsToU32s (s.readWords stP 4)
+    let blk := Accel.dwordsToU32s (s.readWords (s.getMem (p + 8)) 8)
+    s.writeWords stP (Accel.u32sToDwords (Accel.sha256Compress st blk))
+  else
+    s
+
+/-- Validity of a `csrs csr, rs1` accelerator call: every operand dword
+    (parameter blocks and the blocks they point to) is a valid dword
+    access, and `Arith256Mod`'s modulus is nonzero.  `false` for CSR ids
+    the model does not cover — `step` TRAPS on those rather than
+    no-opping, so unmodeled accelerators cannot be silently skipped. -/
+def csrsValid (s : MachineState) (csr : BitVec 12) (rs1 : Reg) : Bool :=
+  let p := s.getReg rs1
+  if csr = 0x800 then
+    validDwordRange p 25
+  else if csr = 0x802 then
+    validDwordRange p 5 &&
+    validDwordRange (s.getMem p) 4 &&
+    validDwordRange (s.getMem (p + 8)) 4 &&
+    validDwordRange (s.getMem (p + 16)) 4 &&
+    validDwordRange (s.getMem (p + 24)) 4 &&
+    validDwordRange (s.getMem (p + 32)) 4 &&
+    !(Accel.leLimbsToNat (s.readWords (s.getMem (p + 24)) 4) == 0)
+  else if csr = 0x805 then
+    validDwordRange p 2 &&
+    validDwordRange (s.getMem p) 4 &&
+    validDwordRange (s.getMem (p + 8)) 8
+  else
+    false
+
+@[simp] theorem pc_execCsrs (s : MachineState) (csr : BitVec 12) (rs1 : Reg) :
+    (s.execCsrs csr rs1).pc = s.pc := by
+  unfold execCsrs
+  split
+  · simp
+  · split
+    · simp
+    · split
+      · simp
+      · rfl
+
+@[simp] theorem committed_execCsrs (s : MachineState) (csr : BitVec 12)
+    (rs1 : Reg) : (s.execCsrs csr rs1).committed = s.committed := by
+  unfold execCsrs
+  split
+  · simp
+  · split
+    · simp
+    · split
+      · simp
+      · rfl
+
+@[simp] theorem publicValues_execCsrs (s : MachineState) (csr : BitVec 12)
+    (rs1 : Reg) : (s.execCsrs csr rs1).publicValues = s.publicValues := by
+  unfold execCsrs
+  split
+  · simp
+  · split
+    · simp
+    · split
+      · simp
+      · rfl
+
+@[simp] theorem privateInput_execCsrs (s : MachineState) (csr : BitVec 12)
+    (rs1 : Reg) : (s.execCsrs csr rs1).privateInput = s.privateInput := by
+  unfold execCsrs
+  split
+  · simp
+  · split
+    · simp
+    · split
+      · simp
+      · rfl
+
+@[simp] theorem inputBufBase_execCsrs (s : MachineState) (csr : BitVec 12)
+    (rs1 : Reg) : (s.execCsrs csr rs1).inputBufBase = s.inputBufBase := by
+  unfold execCsrs
+  split
+  · simp
+  · split
+    · simp
+    · split
+      · simp
+      · rfl
+
+@[simp] theorem code_execCsrs (s : MachineState) (csr : BitVec 12)
+    (rs1 : Reg) : (s.execCsrs csr rs1).code = s.code := by
+  unfold execCsrs
+  split
+  · simp
+  · split
+    · simp
+    · split
+      · simp
+      · rfl
+
+@[simp] theorem getReg_execCsrs (s : MachineState) (csr : BitVec 12)
+    (rs1 : Reg) (r : Reg) : (s.execCsrs csr rs1).getReg r = s.getReg r := by
+  unfold execCsrs
+  split
+  · simp
+  · split
+    · simp
+    · split
+      · simp
+      · rfl
+
+end MachineState
+
+end EvmAsm.Rv64

--- a/PLAN.md
+++ b/PLAN.md
@@ -2525,8 +2525,17 @@ with its pre met, sp = disjunction of posts, soundness via
 `jalr_call_spec_within` reading the target out of `regFileIs`; table
 loads are ordinary ro-region blocks, correlation via per-call-site
 ghost instantiation, tail calls (`jalr x0`) future work
-(docs/sasm-design.md §3.6.3, CallRegDemo). Next for SAsm: more
-Stateless/SSZ ports. Assertion-state milestone started (approved plan
+(docs/sasm-design.md §3.6.3, CallRegDemo). ZisK accelerator semantics
+landed (`Rv64/ZiskAccel.lean` + `Instr.CSRS`, bead evm-asm-4ch8f.1):
+CONCRETE per-CSR semantics — Keccak-f[1600], SHA-256 compression,
+Arith256Mod exact (a*b+c) mod m — with kernel-checked KATs pinned to
+keccak256("")/sha256(""); step traps on invalid operand blocks AND on
+unmodeled CSR ids (no silent skips); emitInstr pre-encodes `.4byte`
+words matching the guest literals (0x80052073/0x8022a073/0x80552073);
+follow-up accelerators (secp add/dbl 0x803/4, blake2b 0x819, bn254,
+bls12) slot into the same execCsrs/csrsValid dispatch; SAsm block
+exposure deferred to beads .17/.18 (design §3.3.1). Next for SAsm:
+more Stateless/SSZ ports. Assertion-state milestone started (approved plan
 ~/.claude/plans/federated-wandering-pudding.md; epic evm-asm-6dt3v):
 Stages 1+2a landed — `Reach := RegFile → List Byte → Assertion → Prop`
 threads an ambient (pc-free) separation-logic assertion through the

--- a/docs/sasm-design.md
+++ b/docs/sasm-design.md
@@ -201,9 +201,48 @@ def regionsAssert : List Region → Assertion   -- ⋆ of bytesRegion-style atom
   Overlapping regions need no side condition — the separation conjunction
   makes them unsatisfiable.  Stores (to the writable region only) update
   the symbolic bytes via `setBytes`.
-- Other effects (syscalls/hints, publicValues, …) are future extensions at
+- Other effects (hints, publicValues, …) are future extensions at
   the same seam: enlarge `SymState` and the per-leaf soundness lemmas;
   the structural rules (§3.5) do not change.
+
+### 3.3.1 ZisK accelerator semantics (`Rv64/ZiskAccel.lean`, design decisions)
+
+The guest's hashing and crypto kernels call ZisK precompiles through raw
+`csrs <id>, <reg>` words (`.4byte 0x80052073` etc.); bead evm-asm-4ch8f.1
+models them (machine level, below SAsm):
+
+- **Concrete, not parametrized.**  `Instr.CSRS csr rs1` executes the
+  actual mathematical function per CSR id — Keccak-f[1600], the SHA-256
+  compression, exact-intermediate `(a*b + c) mod m` — rather than an
+  axiomatized accelerator contract.  Rationale: (1) evm-asm carries
+  *software* implementations of several hashes (RIPEMD-160, SHA-256
+  wrapper, P-256 over Arith256Mod), and their proofs must meet the
+  accelerator path at the same concrete function; (2) an axiomatized
+  contract widens the trusted base beyond the three classical axioms;
+  (3) concrete permutations admit in-repo kernel-checked known-answer
+  tests (`keccakF_kat_empty`, `sha256Compress_kat_empty`, pinned to
+  `keccak256("")`/`sha256("")`).  What a parametrized model would buy —
+  insulation from ziskemu version drift in operand packing — is instead
+  handled by pinning the layouts to the probe results
+  (`Codegen/Programs/HashProbes.lean`) and re-validating via EEST runs.
+- **Modeled ids** (v1): `0x800` Keccakf (25-lane LE state, in place),
+  `0x802` Arith256Mod (`[a*, b*, c*, module*, d*]`, 4 LE u64 limbs each),
+  `0x805` Sha256f (`[state*, input*]`, LE-u32-in-u64 packing).  Follow-ups
+  slot into the same `execCsrs`/`csrsValid` dispatch: Secp256k1Add/Dbl
+  (0x803/0x804), Blake2bRound (0x819), BN254, BLS12-381.
+- **Traps, not no-ops.**  `step` requires `csrsValid`: every operand dword
+  a valid access and (Arith256Mod) a nonzero modulus; an UNMODELED CSR id
+  always traps.  A verified triple over code containing a `csrs` therefore
+  cannot silently skip the accelerator — the proof obligation is exactly
+  the operand-block validity.
+- **The ECALL surfaces stay as they are**: SP1-convention HALT/WRITE/
+  read_input remain on `ECALL` in `step`; ZisK accelerators are csrs-only.
+- **SAsm exposure is deliberately deferred** to the consuming beads
+  (.17 keccak bridge, .18 sha256): `blockOk` rejects `CSRS` inside blocks
+  today; the bridge beads decide between a new block-leaf classification
+  (`accelSem`, mirroring `storeSem` with a multi-dword footprint) or a
+  `Stmt`-level node.  The machine-level `step_csrs`/`step_csrs_trap`
+  lemmas are the composition points either way.
 
 ### 3.4 Block symbolic execution (`SAsm/Sym.lean`)
 


### PR DESCRIPTION
## Summary

Implements bead **evm-asm-4ch8f.1** (ZisK syscall/accelerator semantics). Originally stacked on #9707/#9706 — both merged meanwhile, so this targets main.

The guest invokes ZisK precompiles through raw `csrs <id>, <reg>` encodings (`.4byte 0x80052073` = `csrs 0x800, a0`, etc.). Until now these instructions were **unrepresentable** in the verified model — `Instr` had no CSR constructor, so no guest routine touching an accelerator could be verified at all. This PR adds the instruction and gives it **concrete** mathematical semantics.

## Audit result (what the model covered before)

- `step` models ECALL surfaces only (SP1 HALT/WRITE/read_input; other ecalls no-op). ZisK accelerators are **csrs**, not ecall — they had no representation.
- No pure Lean keccak-f / sha256 existed anywhere in the repo (the EL bridges treat digests abstractly).

## What's new

**`Instr.CSRS csr rs1`** + concrete semantics (`EvmAsm/Rv64/ZiskAccel.lean`):

| CSR | Accelerator | Semantics |
|---|---|---|
| `0x800` | Keccakf | actual Keccak-f[1600] on the 25-lane LE state at `rs1`, in place |
| `0x802` | Arith256Mod | exact-intermediate `(a*b + c) mod m`; param block `[a*, b*, c*, module*, d*]`, 4 LE u64 limbs each |
| `0x805` | Sha256f | actual SHA-256 compression; param block `[state*, input*]`, pinned LE-u32-in-u64 packing |

- **Kernel-checked KATs**: `keccakF_kat_empty` (padded-empty absorb + permute = `keccak256("")`) and `sha256Compress_kat_empty` (= `sha256("")`), both by `decide` — the `maxRecDepth` bump is the intrinsic evaluation depth of 24 chained rounds, not proof-search scaling.
- **Traps, not no-ops**: `step` requires `csrsValid` (every operand dword a valid access; nonzero modulus) and **traps on unmodeled CSR ids** — verified code can never silently skip an accelerator; the proof obligation is exactly operand-block validity. `step_csrs`/`step_csrs_trap` are the composition points for the consuming beads.
- **Emitter**: `emitInstr` pre-encodes `csrrs x0, csr, rs1` as `.4byte` words; pinned by `example`s to the guest's hand-written literals (`0x80052073`/`0x8022a073`/`0x80552073`).
- Permutation state is **materialized per round** (list-based) — a `Fin 25 →` functional state would re-evaluate shared lanes exponentially under kernel reduction.

## Concrete vs. parametrized (requested evaluation)

Concrete wins on all three axes that matter here:
1. **evm-asm has software hash implementations** (RIPEMD-160, the SHA-256 Merkle–Damgård wrapper, P-256 built over Arith256Mod). Their correctness proofs and the accelerator path must meet at the *same* function — impossible against an opaque parameter.
2. **TCB**: an axiomatized accelerator contract widens the trusted base beyond the three classical axioms (the KATs above depend on `[propext, Quot.sound]` only).
3. **Testability**: concrete functions admit in-repo kernel-checked known-answer tests.

What parametrization would buy — insulation from ziskemu packing drift across versions — is real but better handled the way the repo already does: layouts pinned by the emulator probes (`HashProbes.lean`, which caught the 0.15→0.18 Sha256f packing change) and re-validated by EEST conformance runs. A wrong concrete model fails loudly in both; a parametrized model would just relocate the mismatch into an unverifiable axiom.

## Follow-ups (same seam, noted in bead)

Secp256k1Add/Dbl (0x803/0x804), Blake2bRound (0x819), BN254, BLS12-381 slot into the same `execCsrs`/`csrsValid` dispatch. SAsm block exposure (`accelSem` block-leaf vs. `Stmt`-level node) is deliberately deferred to the keccak/sha256 bridge beads .17/.18 (design §3.3.1).

## Verification

- Full `lake build` green (adding the constructor rippled only into `Emit.lean`; all other matches absorbed it)
- `#print axioms`: KATs, `step_csrs`, `execCsrs` → `[propext, Quot.sound]`
- check-forbidden-tactics / check-file-size / check-unimported all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)