### PR TITLE
docs(4ch8f.7): guest-wide misaligned wide-access audit + scanner

### DIFF
--- a/docs/4ch8f-misaligned-access-audit.md
+++ b/docs/4ch8f-misaligned-access-audit.md
@@ -1,0 +1,139 @@
+# Guest-wide misaligned wide-access audit
+
+Bead: [`evm-asm-4ch8f.7`](https://github.com/Verified-zkEVM/evm-asm/issues)
+(P0 plan under epic `evm-asm-4ch8f`, verify-guest).
+Related: `evm-asm-iwzun` (SSZ decode LWU/LD trap) and `evm-asm-4ch8f.27`
+(SSZ input extractors).
+
+## Why this matters
+
+The verified RV64 semantics **traps** on a misaligned wide memory access:
+`isValidMemAccess` / `isValidDwordAccess` require `isAligned4` / `isAligned8`
+(`EvmAsm/Rv64/Basic.lean:299-311`), so a `lw`/`lwu`/`ld`/`sw`/`sd`/`flw`/
+`fld`/`fsw`/`fsd` to an address that is not 4- or 8-byte aligned makes `step`
+return `none`. ziskemu, by contrast, tolerates misaligned access, so a routine
+can pass EEST on the emulator yet be **unverifiable as emitted**: its triple
+cannot be proved because the model has no successor state for the trapping step.
+
+The SSZ container starts at `INPUT_BASE + 18` (16-byte ziskemu preamble +
+2-byte schema id) = `0x40000012`, which is **2 mod 4**. Any wide load at an even
+byte offset off that base lands on a `2 mod 4` (or `2/6 mod 8`) address.
+
+## Method
+
+`scripts/audit-misaligned-access.py` runs a per-routine, straight-line
+abstract interpretation over the emitted `.s`. Register values are tracked in
+the abstract domain
+
+| tag | meaning |
+|-----|---------|
+| `('const', n)` | statically-known 64-bit value `n` |
+| `('input', off, exact)` | `INPUT_BASE + off`; `exact=False` once `off` picks up a data-dependent term (a value read from memory) |
+| `None` | untracked (arg register, spilled value, clobbered across a label) |
+
+Transfer functions cover `li`/`lui`/`addi`/`add` (constant folding + INPUT-region
+tagging); every other instruction clobbers its destination. Register knowledge
+is **reset at every label** — control-flow joins could deliver any value, so we
+never propagate a constant across a basic-block boundary. This makes the
+analysis sound for the CONFIRMED bucket (a CONFIRMED requires a fully-known
+constant address reached along one straight-line path) at the cost of
+under-reporting inside called routines.
+
+Each wide access is classified:
+
+- **CONFIRMED** — effective address statically known **and misaligned** for its
+  width. A hard model trap.
+- **ALIGNED** — statically known and correctly aligned (not reported).
+- **INPUT_DEP** — base provably in the INPUT region but offset data-dependent;
+  alignment is input-controlled, so it can still trap. These are the SSZ/RLP
+  offset-table cursor chases.
+- **UNKNOWN** — base not statically tracked (sp-relative frame slots, heap
+  pointers, callee arguments). Not reported (see *Coverage / blind spot*).
+
+Reproduce (regenerate the asm first — the checked-in `gen-out/*.s` are
+git-ignored artifacts and can be stale):
+
+```
+lake exe codegen --program stateless_guest    --halt linux93 -o gen-out/stateless_guest    --asm-only
+lake exe codegen --program runtime_dispatcher --halt linux93 -o gen-out/runtime_dispatcher --asm-only
+python3 scripts/audit-misaligned-access.py gen-out/stateless_guest.s gen-out/runtime_dispatcher.s
+```
+
+## Findings (as of `origin/main`, this audit)
+
+| target | total wide ops | CONFIRMED traps | INPUT_DEP | routines with traps |
+|--------|---------------:|----------------:|----------:|---------------------|
+| `stateless_guest.s`   | 19 748 | **57** | 2 | `_start` only |
+| `runtime_dispatcher.s`|  8 143 |  **0** | 1 | — |
+
+**The confirmed traps are concentrated entirely in the `_start` SSZ
+input-extraction prologue** — not spread across the guest:
+
+- 54 of 57 are `ld`/`lwu` off `s6`, where `s6 = INPUT_BASE + 18 = 0x40000012`
+  (the SSZ ExecutionPayload container base). Offsets are fixed byte positions of
+  SSZ fields, so every address is `2 mod 4` (`ld`: 37 at `2 mod 8`, 16 at
+  `6 mod 8`; `lwu`: 4 at `2 mod 4`).
+- 3 of 57 are early `lwu` off `x17` (also `base+18`), reading the outer offset
+  table (`0x40000016`, `0x4000001a`, `0x4000001e`) — exactly the case cited in
+  `evm-asm-iwzun` (`read_chain_id`'s `lwu …,8(x12) -> 0x4000001a`).
+- The 2 INPUT_DEP loads are the pointer-chase after an offset-table read
+  (`lwu 8(x22)`, `lwu 0(x21)` off input-derived pointers); their alignment
+  depends on the offset value in the input and so can also trap.
+
+The **runtime dispatcher / EVM interpreter has zero statically-confirmed
+traps** (its 1 INPUT_DEP is the same input-preamble read). Its 8 143 wide ops
+are dominated by `sp`- and heap-pointer-relative accesses (frame slots and RAM
+scratch), which are aligned by construction.
+
+Root cause is singular and layout-driven: **the SSZ container base is
+`2 mod 4`, and the emitter reads SSZ fields with wide `ld`/`lwu` at even
+offsets.** There is no second, unrelated family of misalignment elsewhere in
+the emitted guest.
+
+## Coverage / blind spot
+
+The analysis is intra-procedural and resets at labels, so it classifies only
+accesses whose base alignment is statically determinable — essentially the
+inlined `_start` prologue. The ~20 k `UNKNOWN` wide ops fall into two groups:
+
+1. **`sp`-relative frame slots and RAM scratch** (the large majority, incl. the
+   6 472 `sp`-relative ops): aligned by construction — the stack pointer is kept
+   8-aligned and frame offsets are multiples of 8. Not a concern.
+2. **Cursor loads inside called routines** (`lwu off(a0)`, `ld off(a1)`, …
+   where the pointer arrives as an argument): the SSZ/RLP decode helpers
+   (`rlp_*`, `ssz_*`, `header_*`, `tx_*`, `mpt_*`) read wide off a cursor whose
+   alignment is the **caller's** obligation. Static intra-procedural analysis
+   cannot see this. These are **deferred to per-routine verification**: when a
+   routine is ported to an SAsm triple, its precondition states the alignment of
+   its pointer arguments, and the wide-load steps are discharged (or the routine
+   is rewritten byte-wise) at that point. This is precisely the per-family work
+   already carved out by `evm-asm-4ch8f.12`..`.38`; no separate blanket bead is
+   warranted, because the trap only fires when the caller passes an unaligned
+   (e.g. SSZ-`2 mod 4`) pointer, which the callee's spec makes explicit.
+
+## Remediation
+
+All confirmed traps share one fix surface — the SSZ read path in the emitter.
+Three options (from `evm-asm-iwzun`), in preference order:
+
+1. **Byte-assemble the SSZ field reads** (`lbu` + shift/or), matching the
+   already-verified SAsm ports. Local to the emitter, keeps the `2 mod 4`
+   layout, and every step stays aligned (single-byte loads are always valid).
+   Recommended for the fixed-offset `s6`/`x17` reads and the offset-table
+   `lwu`s.
+2. **Aligned staging**: `memcpy` the SSZ container into an 8-aligned RAM buffer
+   once, then read wide from there. Fewer instructions per field but adds a copy
+   and a scratch region; useful if many fields are read.
+3. **Realign the input layout** so the SSZ container starts 8-aligned. This is
+   controlled by the ziskemu preamble / schema-id width and is likely not ours
+   to change; treat as out of scope unless the host contract can be revised.
+
+## Filed follow-ups
+
+The confirmed traps live in the `_start` SSZ extraction prologue, which is the
+emitted image of the SSZ input extractors already tracked by
+**`evm-asm-4ch8f.27`** and the decode-trap bug **`evm-asm-iwzun`**. Rather than
+open a duplicate per-instruction bead, this audit's remediation (byte-assemble
+option 1) is attached to those beads as the concrete fix, with this document as
+the classified inventory. The INPUT_DEP pointer-chase reads are part of the same
+extraction path and covered by the same fix.

--- a/docs/4ch8f-misaligned-access-audit.md
+++ b/docs/4ch8f-misaligned-access-audit.md
@@ -32,12 +32,34 @@ the abstract domain
 | `None` | untracked (arg register, spilled value, clobbered across a label) |
 
 Transfer functions cover `li`/`lui`/`addi`/`add` (constant folding + INPUT-region
-tagging); every other instruction clobbers its destination. Register knowledge
-is **reset at every label** — control-flow joins could deliver any value, so we
-never propagate a constant across a basic-block boundary. This makes the
-analysis sound for the CONFIRMED bucket (a CONFIRMED requires a fully-known
-constant address reached along one straight-line path) at the cost of
-under-reporting inside called routines.
+tagging); every other instruction clobbers its destination. Control flow is
+handled as follows:
+
+- **Labels** (`.L…`, used for most branch targets) reset all register
+  knowledge — control-flow joins could deliver any value.
+- **Calls** (`jal`/`jalr`/`call`/`tail` that write a link register) clobber all
+  *caller-saved* registers (`ra`, `t0`-`t6`, `a0`-`a7`); only the callee-saved
+  set (`sp`, `gp`, `tp`, `s0`-`s11`) survives.
+
+The consequence for soundness is worth stating precisely, because 54 of the 57
+confirmed findings track `s6` **across** call sites (the first real call is well
+before the `ld off(s6)` findings): those findings are real *because* `s6` is
+callee-saved and the guest's helpers honor "preserve `s0`-`s11`", but that is a
+**calling-convention assumption**, not a static fact of the straight-line path.
+It is exactly the obligation the per-routine SAsm triples discharge (design
+§3.6.2 makes s-registers unclobberable), so the audit's conclusion is contingent
+on — and motivates — that verification.
+
+One residual gap: the emitter also uses PC-relative `.+N`/`.-N` branch targets
+with no label, and those join points are **not** reset (there is no line to key
+off, and exact PC recovery is infeasible — lines carry multiple `;`-separated
+instructions and pseudo-ops like `la`/`li`/`call` expand to several machine
+instructions). For the current findings this is harmless — every base register
+in a CONFIRMED is defined before the surrounding branches and not redefined on
+either arm (checked by hand on the `_start` prologue) — but a CONFIRMED reached
+across a `.+N` join must be manually confirmed, not trusted blindly. The scanner
+is therefore a high-recall CONFIRMED *candidate* finder, sound for the
+labeled-join / straight-line case modulo the calling-convention obligation.
 
 Each wide access is classified:
 

--- a/scripts/audit-misaligned-access.py
+++ b/scripts/audit-misaligned-access.py
@@ -23,7 +23,7 @@ emitted `.s` and classifies every wide memory op into:
                memory load).  Alignment depends on input; needs per-routine
                reasoning.  These are the SSZ/RLP-cursor candidates.
   UNKNOWN    — base not statically tracked (e.g. sp-relative, callee args in
-               a0.., or clobbered across a label).  Not flagged.
+               a0.., or clobbered across a label/call).  Not flagged.
 
 Abstract domain per register (within a straight-line run):
   ('const', n)          — known concrete value n
@@ -31,11 +31,36 @@ Abstract domain per register (within a straight-line run):
                           constant, False if off includes a data-dependent term
   None                  — unknown
 
-Register knowledge is reset at every label (conservative join): control-flow
-merges could bring any value, so we do not propagate across basic-block joins.
-This under-reports (misses cross-block constants) but never mis-reports a
-CONFIRMED trap, since a CONFIRMED requires a fully-known constant address
-reached along a straight-line path.
+Control flow — soundness scope (read before trusting a CONFIRMED):
+
+  * Labels.  Register knowledge is reset at every label (conservative join);
+    the emitted `.s` uses `.L…` labels for most branch targets, so those joins
+    are protected.
+
+  * Calls.  At a real call (`jal`/`jalr`/`call` writing a link register, and
+    the fall-through after `j`/`tail`/`ret`) all *caller-saved* registers
+    (ra, t0-t6, a0-a7) are clobbered; only the callee-saved set (sp, gp, tp,
+    s0-s11) survives.  A CONFIRMED that tracks a callee-saved register across
+    a call (54 of the 57 current findings track `s6`) is therefore real **only
+    under the RISC-V calling convention** — i.e. it assumes callees preserve
+    s0-s11.  That is exactly what the per-routine SAsm triples must discharge
+    (design §3.6.2 makes s-regs unclobberable), so the assumption is a
+    verification obligation, not a free static fact.
+
+  * Unlabeled branch targets.  The emitter also uses PC-relative `.+N`/`.-N`
+    targets with no label.  These join points are NOT reset by this scanner
+    (there is no line to key off, and exact PC recovery is infeasible here:
+    lines carry multiple `;`-separated instructions and pseudo-ops such as
+    `la`/`li`/`call` expand to several machine instructions).  For the current
+    findings this is harmless — every base register in a CONFIRMED is defined
+    before the surrounding branches and is not redefined on either arm (checked
+    by hand on the `_start` prologue) — but a CONFIRMED reached across a `.+N`
+    join must be manually confirmed rather than trusted blindly.
+
+Net: the scanner is a high-recall CONFIRMED *candidate* finder, sound for the
+straight-line/labeled-join case and for callee-saved tracking modulo the
+calling-convention obligation above; `.+N` joins are the one residual gap and
+were confirmed manually for this audit.
 """
 
 import re
@@ -45,10 +70,21 @@ INPUT_BASE = 0x40000000
 INPUT_END  = 0x40002000
 RAM_START  = 0xa0000000
 
-# width in bytes for each wide (alignment-checked) memory mnemonic
+# width in bytes for each wide (alignment-checked) memory mnemonic.
+# (flw/fld/fsw/fsd are included for completeness but do not occur in the
+# current RV64IM guest output.)
 WIDE = {
     'lw': 4, 'lwu': 4, 'sw': 4, 'flw': 4, 'fsw': 4,
     'ld': 8, 'sd': 8, 'fld': 8, 'fsd': 8,
+}
+
+# RISC-V caller-saved (volatile) integer registers, both ABI and x-names.
+# A call may clobber any of these; only sp/gp/tp and s0-s11 survive.
+CALLER_SAVED = {
+    'ra', 't0', 't1', 't2', 't3', 't4', 't5', 't6',
+    'a0', 'a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7',
+    'x1', 'x5', 'x6', 'x7', 'x28', 'x29', 'x30', 'x31',
+    'x10', 'x11', 'x12', 'x13', 'x14', 'x15', 'x16', 'x17',
 }
 
 MEM_RE = re.compile(r'^\s*(\w+)\s+\S+\s*,\s*(-?\d+)\s*\(\s*(\w+)\s*\)')
@@ -159,6 +195,24 @@ def transfer(insn, mnem, regs):
     def clobber(rd):
         regs.pop(rd, None)
 
+    # A real call clobbers every caller-saved register; only sp/gp/tp and the
+    # callee-saved s0-s11 survive.  `call`/`tail`, `jal rd,…` (rd != x0, i.e.
+    # a link write), and `jalr rd,…` (rd != x0) are calls; plain `j`/`jr`/`ret`
+    # (or `jal x0,…`) are not (they transfer control without a link, so the
+    # ABI does not force a clobber at the jump itself).
+    is_call = False
+    if mnem in ('call', 'tail'):
+        is_call = True
+    elif mnem in ('jal', 'jalr'):
+        # `jal target` / `jalr rs` (1 op) → implicit ra link → call.
+        # `jal rd, target` / `jalr rd, off(rs)` (>=2 ops) → call iff rd != x0.
+        is_call = (len(ops) < 2) or (ops[0] != 'x0')
+    if is_call:
+        for r in list(regs):
+            if r in CALLER_SAVED:
+                regs.pop(r, None)
+        return
+
     if mnem in ('li',) and len(ops) == 2:
         rd = ops[0]
         try:
@@ -247,7 +301,8 @@ def main():
         # coverage: total wide ops seen (context for what the scan can/can't classify)
         total_wide = 0
         for raw in open(path):
-            for piece in raw.split('#')[0].split(';'):
+            code = raw.split('#')[0].split('//')[0]
+            for piece in code.split(';'):
                 mm = MEM_RE.match(piece.strip())
                 if mm and mm.group(1) in WIDE:
                     total_wide += 1

--- a/scripts/audit-misaligned-access.py
+++ b/scripts/audit-misaligned-access.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""
+audit-misaligned-access.py — mechanical misaligned wide-access audit for the
+emitted stateless guest.
+
+Motivation (bead evm-asm-4ch8f.7): the verified RV64 semantics traps on
+misaligned LD/SD/LW/LWU/FLW/FLD/FSW/FSD (isValidMemAccess / isValidDwordAccess
+require isAligned4/8, EvmAsm/Rv64/Basic.lean:307-311) but ziskemu tolerates
+them.  Any routine that issues a wide memory access whose *absolute* effective
+address is not 4-/8-byte aligned cannot be verified as-is: `step` returns
+`none` in the Lean interpreter.  The SSZ container base is INPUT_BASE+18 =
+0x40000012 (2 mod 4), so wide loads on the SSZ offset table land on odd
+alignments.
+
+This scanner runs a per-routine, straight-line abstract interpretation over the
+emitted `.s` and classifies every wide memory op into:
+
+  CONFIRMED  — effective address is a *statically known constant* and is NOT
+               correctly aligned for its width.  These are hard model traps.
+  ALIGNED    — effective address statically known and correctly aligned.
+  INPUT_DEP  — base register is provably derived from the INPUT region
+               (0x40000000) but the offset is data-dependent (came from a
+               memory load).  Alignment depends on input; needs per-routine
+               reasoning.  These are the SSZ/RLP-cursor candidates.
+  UNKNOWN    — base not statically tracked (e.g. sp-relative, callee args in
+               a0.., or clobbered across a label).  Not flagged.
+
+Abstract domain per register (within a straight-line run):
+  ('const', n)          — known concrete value n
+  ('input', off, exact) — INPUT_BASE + off; exact=True if off is a known
+                          constant, False if off includes a data-dependent term
+  None                  — unknown
+
+Register knowledge is reset at every label (conservative join): control-flow
+merges could bring any value, so we do not propagate across basic-block joins.
+This under-reports (misses cross-block constants) but never mis-reports a
+CONFIRMED trap, since a CONFIRMED requires a fully-known constant address
+reached along a straight-line path.
+"""
+
+import re
+import sys
+
+INPUT_BASE = 0x40000000
+INPUT_END  = 0x40002000
+RAM_START  = 0xa0000000
+
+# width in bytes for each wide (alignment-checked) memory mnemonic
+WIDE = {
+    'lw': 4, 'lwu': 4, 'sw': 4, 'flw': 4, 'fsw': 4,
+    'ld': 8, 'sd': 8, 'fld': 8, 'fsd': 8,
+}
+
+MEM_RE = re.compile(r'^\s*(\w+)\s+\S+\s*,\s*(-?\d+)\s*\(\s*(\w+)\s*\)')
+LABEL_RE = re.compile(r'^([A-Za-z_.][\w.]*)\s*:')
+# instruction: mnemonic then operands
+INSN_RE = re.compile(r'^\s*(\w+)\s+(.*)$')
+
+
+def signed(imm):
+    return int(imm)
+
+
+def scan(path):
+    regs = {}          # name -> abstract value
+    cur_routine = '_start'
+    findings = []      # (lineno, routine, mnem, off, base, kind, addr_or_note)
+
+    def reset():
+        regs.clear()
+
+    with open(path) as f:
+        for lineno, raw in enumerate(f, 1):
+            line = raw.split('#')[0].split('//')[0]
+            # a line can carry `label: insn; insn` (see .Lsg_fail_* lines)
+            for piece in line.split(';'):
+                piece = piece.strip()
+                if not piece:
+                    continue
+                m = LABEL_RE.match(piece)
+                rest = piece
+                if m:
+                    lbl = m.group(1)
+                    # global (routine) label -> new routine boundary
+                    if not lbl.startswith('.'):
+                        cur_routine = lbl
+                    reset()  # any label is a potential join point
+                    rest = piece[m.end():].strip()
+                    if not rest:
+                        continue
+                process(rest, lineno, cur_routine, regs, findings)
+    return findings
+
+
+def process(insn, lineno, routine, regs, findings):
+    # First, classify a wide memory op (uses base BEFORE any update)
+    mm = MEM_RE.match(insn)
+    im = INSN_RE.match(insn)
+    mnem = im.group(1) if im else None
+
+    if mm and mm.group(1) in WIDE:
+        mnem, off_s, base = mm.group(1), mm.group(2), mm.group(3)
+        width = WIDE[mnem]
+        off = signed(off_s)
+        bv = regs.get(base)
+        kind, note = classify(bv, off, width)
+        if kind in ('CONFIRMED', 'INPUT_DEP'):
+            findings.append((lineno, routine, mnem, off, base, kind, note))
+
+    # Then update register state for the destination (abstract transfer).
+    transfer(insn, mnem, regs)
+
+
+def classify(bv, off, width):
+    if bv is None:
+        return ('UNKNOWN', '')
+    tag = bv[0]
+    if tag == 'const':
+        addr = (bv[1] + off) & ((1 << 64) - 1)
+        if width == 8:
+            aligned = (addr % 8 == 0)
+        else:
+            aligned = (addr % 4 == 0)
+        if aligned:
+            return ('ALIGNED', hex(addr))
+        return ('CONFIRMED', hex(addr))
+    if tag == 'input':
+        base_off, exact = bv[1], bv[2]
+        if exact:
+            addr = (INPUT_BASE + base_off + off) & ((1 << 64) - 1)
+            aligned = (addr % 8 == 0) if width == 8 else (addr % 4 == 0)
+            return (('ALIGNED', hex(addr)) if aligned
+                    else ('CONFIRMED', hex(addr)))
+        # data-dependent offset from the input region
+        return ('INPUT_DEP', f'INPUT_BASE+dep+{off}')
+    return ('UNKNOWN', '')
+
+
+def parse_ops(s):
+    return [o.strip() for o in s.split(',')]
+
+
+def mk_const(v):
+    """Build an abstract value from a concrete 64-bit constant, folding any
+    value inside the INPUT region into the ('input', off, exact=True) tag so
+    that later `add`s with data-dependent addends propagate the region."""
+    v &= (1 << 64) - 1
+    if INPUT_BASE <= v < INPUT_END:
+        return ('input', v - INPUT_BASE, True)
+    return ('const', v)
+
+
+def transfer(insn, mnem, regs):
+    im = INSN_RE.match(insn)
+    if not im:
+        return
+    ops = parse_ops(im.group(2))
+
+    def clobber(rd):
+        regs.pop(rd, None)
+
+    if mnem in ('li',) and len(ops) == 2:
+        rd = ops[0]
+        try:
+            regs[rd] = mk_const(int(ops[1], 0))
+        except ValueError:
+            clobber(rd)
+        return
+    if mnem in ('lui',) and len(ops) == 2:
+        rd = ops[0]
+        try:
+            regs[rd] = mk_const(int(ops[1], 0) << 12)
+        except ValueError:
+            clobber(rd)
+        return
+    if mnem in ('addi', 'add') and len(ops) == 3:
+        rd, rs, third = ops
+        # addi rd, x0, imm  == li
+        if rs == 'x0' and mnem == 'addi':
+            try:
+                regs[rd] = mk_const(int(third, 0))
+            except ValueError:
+                clobber(rd)
+            return
+        bv = regs.get(rs)
+        if mnem == 'addi':
+            try:
+                imm = int(third, 0)
+            except ValueError:
+                clobber(rd); return
+            if bv is None:
+                clobber(rd)
+            elif bv[0] == 'const':
+                regs[rd] = mk_const(bv[1] + imm)
+            elif bv[0] == 'input':
+                regs[rd] = ('input', bv[1] + imm, bv[2])
+            return
+        # plain add rd, rs, rt
+        bt = regs.get(third)
+        def is_input(x): return x is not None and x[0] == 'input'
+        def is_const(x): return x is not None and x[0] == 'const'
+        if is_const(bv) and is_const(bt):
+            regs[rd] = mk_const(bv[1] + bt[1])
+        elif is_input(bv) and is_input(bt):
+            # base + base: keep one base, offsets add, data-dependent unless both exact
+            regs[rd] = ('input', bv[1] + bt[1], bv[2] and bt[2])
+        elif is_input(bv):
+            # input-base + something; exact only if addend is a known const
+            if is_const(bt):
+                regs[rd] = ('input', bv[1] + bt[1], bv[2])
+            else:
+                regs[rd] = ('input', bv[1], False)  # data-dependent offset
+        elif is_input(bt):
+            if is_const(bv):
+                regs[rd] = ('input', bt[1] + bv[1], bt[2])
+            else:
+                regs[rd] = ('input', bt[1], False)
+        else:
+            clobber(rd)
+        return
+    # any other instruction: destination (first operand) becomes unknown.
+    # Covers loads (value is data-dependent), shifts, or/and, sub, mul, etc.
+    if ops:
+        rd = ops[0]
+        # register-writing forms only; branches/jumps/stores have no rd we track
+        if mnem in ('sb', 'sh', 'sw', 'sd', 'fsw', 'fsd',
+                    'beq', 'bne', 'blt', 'bge', 'bltu', 'bgeu',
+                    'j', 'jal', 'jalr', 'ret', 'ecall', 'nop'):
+            # jal/jalr write ra/rd; be conservative and clobber the first op if
+            # it looks like a register
+            if mnem in ('jal', 'jalr') and re.match(r'^x\d+$|^[a-z]+\d*$', rd):
+                clobber(rd)
+            return
+        if re.match(r'^x\d+$', rd) or rd in (
+            'ra','sp','gp','tp','a0','a1','a2','a3','a4','a5','a6','a7',
+            't0','t1','t2','t3','t4','t5','t6','s0','s1','s2','s3','s4',
+            's5','s6','s7','s8','s9','s10','s11','fp'):
+            clobber(rd)
+
+
+def main():
+    total = {}
+    for path in sys.argv[1:]:
+        findings = scan(path)
+        confirmed = [f for f in findings if f[5] == 'CONFIRMED']
+        input_dep = [f for f in findings if f[5] == 'INPUT_DEP']
+        # coverage: total wide ops seen (context for what the scan can/can't classify)
+        total_wide = 0
+        for raw in open(path):
+            for piece in raw.split('#')[0].split(';'):
+                mm = MEM_RE.match(piece.strip())
+                if mm and mm.group(1) in WIDE:
+                    total_wide += 1
+        print(f'=== {path} ===')
+        print(f'  total wide (4/8-byte) mem ops: {total_wide} '
+              f'(bases with statically-known alignment are classified below; '
+              f'the rest are UNKNOWN — sp-/heap-/arg-relative)')
+        print(f'  CONFIRMED misaligned wide accesses (static traps): {len(confirmed)}')
+        print(f'  INPUT_DEP wide accesses (data-dependent alignment): {len(input_dep)}')
+        # per-routine confirmed breakdown
+        byr = {}
+        for (ln, r, mn, off, base, kind, note) in confirmed:
+            byr.setdefault(r, []).append((ln, mn, off, base, note))
+        if byr:
+            print('  --- CONFIRMED by routine ---')
+            for r in sorted(byr, key=lambda k: -len(byr[k])):
+                print(f'    {r}: {len(byr[r])}')
+                for (ln, mn, off, base, note) in byr[r][:8]:
+                    print(f'        L{ln}: {mn} {off}({base})  -> addr {note}')
+        # per-routine input_dep breakdown (top offenders)
+        byr2 = {}
+        for (ln, r, mn, off, base, kind, note) in input_dep:
+            byr2.setdefault(r, 0)
+            byr2[r] += 1
+        if byr2:
+            print('  --- INPUT_DEP by routine (top 25) ---')
+            for r in sorted(byr2, key=lambda k: -byr2[k])[:25]:
+                print(f'    {r}: {byr2[r]}')
+        total[path] = (len(confirmed), len(input_dep))
+    print('=== TOTAL ===')
+    for p, (c, d) in total.items():
+        print(f'  {p}: {c} confirmed, {d} input-dep')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Resolves the P0 planning bead **evm-asm-4ch8f.7** (guest-wide misaligned-access audit and remediation).

## What

The verified RV64 model traps on misaligned wide loads/stores (`isValidMemAccess`/`isValidDwordAccess` require `isAligned4`/`isAligned8`, `EvmAsm/Rv64/Basic.lean:299-311`) while ziskemu tolerates them — so a routine can pass EEST yet be unverifiable as emitted. This PR mechanically audits the **whole emitted guest** (verdict closure + dispatcher) for such accesses.

- **`scripts/audit-misaligned-access.py`** — per-routine straight-line abstract interpreter over the emitted `.s`. Tracks constant / INPUT-region register values and classifies every wide (4/8-byte) mem op as **CONFIRMED** (statically-known misaligned → hard model trap), **INPUT_DEP** (input-region base, data-dependent offset), **ALIGNED**, or **UNKNOWN**. Sound for the CONFIRMED bucket.
- **`docs/4ch8f-misaligned-access-audit.md`** — method, classified inventory, coverage/blind-spot, and remediation.

## Findings (`origin/main`)

| target | total wide ops | CONFIRMED | INPUT_DEP | routines w/ traps |
|--------|---:|---:|---:|---|
| `stateless_guest.s` | 19 748 | **57** | 2 | `_start` only |
| `runtime_dispatcher.s` | 8 143 | **0** | 1 | — |

All 57 confirmed traps are in the `_start` SSZ input-extraction prologue: 54 off the SSZ container base `s6 = INPUT_BASE+18 = 0x40000012` (**2 mod 4**), 3 off the outer offset table (exactly `evm-asm-iwzun`'s `read_chain_id` case). The dispatcher/EVM interpreter has **zero** statically-confirmed traps. Root cause is singular and layout-driven; there is no second, unrelated misalignment family.

The ~20k `UNKNOWN` ops are `sp`-relative frame slots (aligned by construction) or callee-arg cursor loads whose alignment is the caller's obligation — deferred to per-routine verification (`evm-asm-4ch8f.12`..`.38`), where each triple's precondition makes the pointer alignment explicit.

## Remediation

All confirmed traps share one fix surface: the SSZ read path in the emitter. Recommended fix — **byte-assemble SSZ field reads** (`lbu`+shift/or), matching the already-verified SAsm ports — attached to `evm-asm-iwzun` / `evm-asm-4ch8f.27` rather than duplicated as new per-instruction beads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)