### PR TITLE
feat(codegen): asm→Program wave 1c — gas/tx/header/account leaf conversions (4ch8f.9.1)

### DIFF
--- a/EvmAsm/Codegen/Programs/Account.lean
+++ b/EvmAsm/Codegen/Programs/Account.lean
@@ -17,6 +17,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.RlpWalk
 import EvmAsm.Codegen.Programs.Tx
@@ -1048,39 +1049,46 @@ def ziskTxPostExecGasSettlementProbeUnit : BuildUnit := {
       a3 (output) : tx_gas_used_before_refund
       a4 (output) : applied refund
 -/
-def txGasResultIncrementsFunction : String :=
-  "tx_gas_result_increments:\n" ++
-  "  bgtu a1, a0, .Ltgri_bad_remaining\n" ++
-  "  sub t0, a0, a1              # before_refund\n" ++
-  "  li t1, 5\n" ++
-  "  divu t2, t0, t1             # refund cap = before_refund / 5\n" ++
-  "  mv t3, a2                   # refund_counter\n" ++
-  "  bleu t3, t2, .Ltgri_refund_min_done\n" ++
-  "  mv t3, t2\n" ++
-  ".Ltgri_refund_min_done:\n" ++
-  "  sub t4, t0, t3              # after_refund\n" ++
-  "  mv t5, t0                   # block_inc = max(before_refund, floor)\n" ++
-  "  bleu a3, t5, .Ltgri_block_max_done\n" ++
-  "  mv t5, a3\n" ++
-  ".Ltgri_block_max_done:\n" ++
-  "  mv t6, t4                   # receipt_inc = max(after_refund, floor)\n" ++
-  "  bleu a3, t6, .Ltgri_receipt_max_done\n" ++
-  "  mv t6, a3\n" ++
-  ".Ltgri_receipt_max_done:\n" ++
-  "  li a0, 0\n" ++
-  "  mv a1, t5\n" ++
-  "  mv a2, t6\n" ++
-  "  mv a3, t0\n" ++
-  "  mv a4, t3\n" ++
-  "  ret\n" ++
-  ".Ltgri_bad_remaining:\n" ++
-  "  li a0, 1\n" ++
-  "  li a1, 0\n" ++
-  "  li a2, 0\n" ++
-  "  li a3, 0\n" ++
-  "  li a4, 0\n" ++
-  "  ret"
+def txGasResultIncrements_prog : Program :=
+  [ .BLTU .x10 .x11 (80 : BitVec 13),
+    .SUB .x5 .x10 .x11,
+    .LI .x6 (5 : Word),
+    .DIVU .x7 .x5 .x6,
+    .MV .x28 .x12,
+    .BGEU .x7 .x28 (8 : BitVec 13),
+    .MV .x28 .x7,
+    .SUB .x29 .x5 .x28,
+    .MV .x30 .x5,
+    .BGEU .x30 .x13 (8 : BitVec 13),
+    .MV .x30 .x13,
+    .MV .x31 .x29,
+    .BGEU .x31 .x13 (8 : BitVec 13),
+    .MV .x31 .x13,
+    .LI .x10 (0 : Word),
+    .MV .x11 .x30,
+    .MV .x12 .x31,
+    .MV .x13 .x5,
+    .MV .x14 .x28,
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (1 : Word),
+    .LI .x11 (0 : Word),
+    .LI .x12 (0 : Word),
+    .LI .x13 (0 : Word),
+    .LI .x14 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def txGasResultIncrementsFunction : String :=
+  "tx_gas_result_increments:\n" ++ emitProgram txGasResultIncrements_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `txGasResultIncrements_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem txGasResultIncrementsFunction_eq_prog :
+    txGasResultIncrementsFunction = "tx_gas_result_increments:\n" ++ emitProgram txGasResultIncrements_prog := rfl
+
+#guard txGasResultIncrementsFunction.startsWith "tx_gas_result_increments:\n"
+#guard txGasResultIncrements_prog.length = 26
 /-- `zisk_tx_gas_result_increments`: focused probe for the scalar
     post-execution gas increment formula. Input payload after zisk's length
     prefix is four u64s: tx_gas_limit, gas_left, refund_counter,

--- a/EvmAsm/Codegen/Programs/BalGasValid.lean
+++ b/EvmAsm/Codegen/Programs/BalGasValid.lean
@@ -25,6 +25,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.RlpWalk
 
 namespace EvmAsm.Codegen
@@ -104,26 +105,60 @@ def balGasValidFunction : String :=
   "  ret"
 
 /-! ## bgv_u32le -- read a little-endian u32 byte-wise (a0=ptr -> a0). Leaf. -/
+def bgvU32le_prog : Program :=
+  [ .LBU .x5 .x10 (0 : BitVec 12),
+    .LBU .x6 .x10 (1 : BitVec 12),
+    .SLLI .x6 .x6 (8 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (2 : BitVec 12),
+    .SLLI .x6 .x6 (16 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (3 : BitVec 12),
+    .SLLI .x6 .x6 (24 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .MV .x10 .x5,
+    .JALR .x0 .x1 (0 : BitVec 12) ]
+
 def bgvU32leFunction : String :=
-  "bgv_u32le:\n" ++
-  "  lbu t0, 0(a0)\n" ++
-  "  lbu t1, 1(a0); slli t1, t1, 8;  or t0, t0, t1\n" ++
-  "  lbu t1, 2(a0); slli t1, t1, 16; or t0, t0, t1\n" ++
-  "  lbu t1, 3(a0); slli t1, t1, 24; or t0, t0, t1\n" ++
-  "  mv a0, t0\n" ++
-  "  ret"
+  "bgv_u32le:\n" ++ emitProgram bgvU32le_prog
 
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `bgvU32le_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem bgvU32leFunction_eq_prog :
+    bgvU32leFunction = "bgv_u32le:\n" ++ emitProgram bgvU32le_prog := rfl
+
+#guard bgvU32leFunction.startsWith "bgv_u32le:\n"
+#guard bgvU32le_prog.length = 12
 /-! ## bgv_u64le -- read a little-endian u64 byte-wise (a0=ptr -> a0). Leaf. -/
-def bgvU64leFunction : String :=
-  "bgv_u64le:\n" ++
-  "  li t0, 0; li t2, 0\n" ++
-  ".Lbgv64:\n" ++
-  "  li t3, 8; beq t2, t3, .Lbgv64d\n" ++
-  "  add t4, a0, t2; lbu t5, 0(t4); slli t6, t2, 3; sll t5, t5, t6; or t0, t0, t5\n" ++
-  "  addi t2, t2, 1; j .Lbgv64\n" ++
-  ".Lbgv64d:\n" ++
-  "  mv a0, t0; ret"
+def bgvU64le_prog : Program :=
+  [ .LI .x5 (0 : Word),
+    .LI .x7 (0 : Word),
+    .LI .x28 (8 : Word),
+    .BEQ .x7 .x28 (32 : BitVec 13),
+    .ADD .x29 .x10 .x7,
+    .LBU .x30 .x29 (0 : BitVec 12),
+    .SLLI .x31 .x7 (3 : BitVec 6),
+    .SLL .x30 .x30 .x31,
+    .OR .x5 .x5 .x30,
+    .ADDI .x7 .x7 (1 : BitVec 12),
+    .JAL .x0 (-32 : BitVec 21),
+    .MV .x10 .x5,
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def bgvU64leFunction : String :=
+  "bgv_u64le:\n" ++ emitProgram bgvU64le_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `bgvU64le_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem bgvU64leFunction_eq_prog :
+    bgvU64leFunction = "bgv_u64le:\n" ++ emitProgram bgvU64le_prog := rfl
+
+#guard bgvU64leFunction.startsWith "bgv_u64le:\n"
+#guard bgvU64le_prog.length = 13
 /-! ## bal_section_info -- locate BAL RLP inside an SszStatelessInput.
     a0 = SSZ_BASE   a1 = out BAL ptr   a2 = out BAL len   a3 = out account count
     a0 (output) = 0 ok / 1 parse error. -/

--- a/EvmAsm/Codegen/Programs/Blake2f.lean
+++ b/EvmAsm/Codegen/Programs/Blake2f.lean
@@ -34,6 +34,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 
 namespace EvmAsm.Codegen
 
@@ -58,37 +59,57 @@ def blake2fDataFragment : String :=
 
 /-- Load the little-endian u64 at byte pointer a0 (any alignment) into
     a0. Leaf; clobbers t0..t2. -/
-def blake2fLdLe64Function : String :=
-  "blk2_ld_le64:\n" ++
-  "  li t0, 0\n" ++
-  "  addi t1, a0, 7\n" ++
-  "  li t2, 8\n" ++
-  ".Lblk2_ld_byte:\n" ++
-  "  slli t0, t0, 8\n" ++
-  "  lbu a0, 0(t1)\n" ++
-  "  or t0, t0, a0\n" ++
-  "  addi t1, t1, -1\n" ++
-  "  addi t2, t2, -1\n" ++
-  "  bnez t2, .Lblk2_ld_byte\n" ++
-  "  mv a0, t0\n" ++
-  "  ret"
+def blk2LdLe64_prog : Program :=
+  [ .LI .x5 (0 : Word),
+    .ADDI .x6 .x10 (7 : BitVec 12),
+    .LI .x7 (8 : Word),
+    .SLLI .x5 .x5 (8 : BitVec 6),
+    .LBU .x10 .x6 (0 : BitVec 12),
+    .OR .x5 .x5 .x10,
+    .ADDI .x6 .x6 (-1 : BitVec 12),
+    .ADDI .x7 .x7 (-1 : BitVec 12),
+    .BNE .x7 .x0 (-20 : BitVec 13),
+    .MV .x10 .x5,
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def blake2fLdLe64Function : String :=
+  "blk2_ld_le64:\n" ++ emitProgram blk2LdLe64_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `blk2LdLe64_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem blake2fLdLe64Function_eq_prog :
+    blake2fLdLe64Function = "blk2_ld_le64:\n" ++ emitProgram blk2LdLe64_prog := rfl
+
+#guard blake2fLdLe64Function.startsWith "blk2_ld_le64:\n"
+#guard blk2LdLe64_prog.length = 11
 /-- Store a1 as a little-endian u64 at byte pointer a0 (any
     alignment). Leaf; clobbers t0..t2. -/
-def blake2fStLe64Function : String :=
-  "blk2_st_le64:\n" ++
-  "  mv t0, a1\n" ++
-  "  mv t1, a0\n" ++
-  "  li t2, 8\n" ++
-  ".Lblk2_st_byte:\n" ++
-  "  andi a1, t0, 0xff\n" ++
-  "  sb a1, 0(t1)\n" ++
-  "  srli t0, t0, 8\n" ++
-  "  addi t1, t1, 1\n" ++
-  "  addi t2, t2, -1\n" ++
-  "  bnez t2, .Lblk2_st_byte\n" ++
-  "  ret"
+def blk2StLe64_prog : Program :=
+  [ .MV .x5 .x11,
+    .MV .x6 .x10,
+    .LI .x7 (8 : Word),
+    .ANDI .x11 .x5 (255 : BitVec 12),
+    .SB .x6 .x11 (0 : BitVec 12),
+    .SRLI .x5 .x5 (8 : BitVec 6),
+    .ADDI .x6 .x6 (1 : BitVec 12),
+    .ADDI .x7 .x7 (-1 : BitVec 12),
+    .BNE .x7 .x0 (-20 : BitVec 13),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def blake2fStLe64Function : String :=
+  "blk2_st_le64:\n" ++ emitProgram blk2StLe64_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `blk2StLe64_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem blake2fStLe64Function_eq_prog :
+    blake2fStLe64Function = "blk2_st_le64:\n" ++ emitProgram blk2StLe64_prog := rfl
+
+#guard blake2fStLe64Function.startsWith "blk2_st_le64:\n"
+#guard blk2StLe64_prog.length = 10
 /-- Real BLAKE2F kernel (see the module docstring for the ABI). -/
 def zkvmBlake2fRealFunction : String :=
   ".globl zkvm_blake2f\n" ++

--- a/EvmAsm/Codegen/Programs/BlockAccessListHash.lean
+++ b/EvmAsm/Codegen/Programs/BlockAccessListHash.lean
@@ -23,6 +23,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.HashBridge
 
 namespace EvmAsm.Codegen
@@ -30,15 +31,32 @@ namespace EvmAsm.Codegen
 open EvmAsm.Rv64
 
 /-! ## bah_u32le -- read a little-endian u32 byte-wise (a0=ptr -> a0). Leaf. -/
-def bahU32leFunction : String :=
-  "bah_u32le:\n" ++
-  "  lbu t0, 0(a0)\n" ++
-  "  lbu t1, 1(a0); slli t1, t1, 8;  or t0, t0, t1\n" ++
-  "  lbu t1, 2(a0); slli t1, t1, 16; or t0, t0, t1\n" ++
-  "  lbu t1, 3(a0); slli t1, t1, 24; or t0, t0, t1\n" ++
-  "  mv a0, t0\n" ++
-  "  ret"
+def bahU32le_prog : Program :=
+  [ .LBU .x5 .x10 (0 : BitVec 12),
+    .LBU .x6 .x10 (1 : BitVec 12),
+    .SLLI .x6 .x6 (8 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (2 : BitVec 12),
+    .SLLI .x6 .x6 (16 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (3 : BitVec 12),
+    .SLLI .x6 .x6 (24 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .MV .x10 .x5,
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def bahU32leFunction : String :=
+  "bah_u32le:\n" ++ emitProgram bahU32le_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `bahU32le_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem bahU32leFunction_eq_prog :
+    bahU32leFunction = "bah_u32le:\n" ++ emitProgram bahU32le_prog := rfl
+
+#guard bahU32leFunction.startsWith "bah_u32le:\n"
+#guard bahU32le_prog.length = 12
 /-! ## block_access_list_hash
     a0 = SSZ_BASE ptr   a1 = 32-byte out hash ptr.   a0 (output) = 0. -/
 def blockAccessListHashFunction : String :=

--- a/EvmAsm/Codegen/Programs/BlockHashPredicates.lean
+++ b/EvmAsm/Codegen/Programs/BlockHashPredicates.lean
@@ -19,6 +19,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.HashBridge
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.Tx
@@ -676,67 +677,77 @@ def ziskWitnessHeadersChainValidateProbeUnit : BuildUnit := {
         0 = success (is_match holds 0 or 1)
         1 = witness.headers section is empty (is_match = 0)
 -/
-def parentHeaderMatchesWitnessFirstFunction : String :=
-  "parent_header_matches_witness_first:\n" ++
-  "  addi sp, sp, -64\n" ++
-  "  sd ra,  0(sp)\n" ++
-  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
-  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
-  "  mv s0, a0                  # parent_header_rlp ptr\n" ++
-  "  mv s1, a1                  # parent_header_rlp_len\n" ++
-  "  mv s2, a2                  # section ptr\n" ++
-  "  mv s3, a3                  # section_len\n" ++
-  "  mv s4, a4                  # is_match out ptr\n" ++
-  "  sd zero, 0(s4)\n" ++
-  "  beqz s3, .Lphmw_empty       # empty section -> status 1\n" ++
-  "  # Compute element 0 bounds (SSZ list).\n" ++
-  "  lwu t0, 0(s2)\n" ++
-  "  srli t0, t0, 2              # N = first_offset / 4\n" ++
-  "  beqz t0, .Lphmw_empty      # zero entries\n" ++
-  "  lwu t1, 0(s2)               # el_0 inner offset (= 4 * N)\n" ++
-  "  add s5, s2, t1              # el_0 start\n" ++
-  "  # el_0 end: if N > 1, read offset[1] (4 bytes at offset 4); else use section_end.\n" ++
-  "  li t2, 1\n" ++
-  "  bgtu t0, t2, .Lphmw_have_next\n" ++
-  "  add s6, s2, s3              # el_0_end = section_end\n" ++
-  "  j .Lphmw_compare\n" ++
-  ".Lphmw_have_next:\n" ++
-  "  lwu t2, 4(s2)\n" ++
-  "  add s6, s2, t2              # el_0_end = section + inner_off[1]\n" ++
-  ".Lphmw_compare:\n" ++
-  "  sub t0, s6, s5              # el_0 length\n" ++
-  "  # Length must match parent_header_rlp_len.\n" ++
-  "  bne t0, s1, .Lphmw_no_match_success\n" ++
-  "  # Byte-compare s0..s0+s1 against s5..s6.\n" ++
-  "  mv t1, s0\n" ++
-  "  mv t2, s5\n" ++
-  "  mv t3, s1\n" ++
-  ".Lphmw_loop:\n" ++
-  "  beqz t3, .Lphmw_match\n" ++
-  "  lbu t4, 0(t1)\n" ++
-  "  lbu t5, 0(t2)\n" ++
-  "  bne t4, t5, .Lphmw_no_match_success\n" ++
-  "  addi t1, t1, 1\n" ++
-  "  addi t2, t2, 1\n" ++
-  "  addi t3, t3, -1\n" ++
-  "  j .Lphmw_loop\n" ++
-  ".Lphmw_match:\n" ++
-  "  li t1, 1\n" ++
-  "  sd t1, 0(s4)\n" ++
-  "  li a0, 0\n" ++
-  "  j .Lphmw_ret\n" ++
-  ".Lphmw_no_match_success:\n" ++
-  "  li a0, 0\n" ++
-  "  j .Lphmw_ret\n" ++
-  ".Lphmw_empty:\n" ++
-  "  li a0, 1\n" ++
-  ".Lphmw_ret:\n" ++
-  "  ld ra,  0(sp)\n" ++
-  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
-  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
-  "  addi sp, sp, 64\n" ++
-  "  ret"
+def parentHeaderMatchesWitnessFirst_prog : Program :=
+  [ .ADDI .x2 .x2 (-64 : BitVec 12),
+    .SD .x2 .x1 (0 : BitVec 12),
+    .SD .x2 .x8 (8 : BitVec 12),
+    .SD .x2 .x9 (16 : BitVec 12),
+    .SD .x2 .x18 (24 : BitVec 12),
+    .SD .x2 .x19 (32 : BitVec 12),
+    .SD .x2 .x20 (40 : BitVec 12),
+    .SD .x2 .x21 (48 : BitVec 12),
+    .SD .x2 .x22 (56 : BitVec 12),
+    .MV .x8 .x10,
+    .MV .x9 .x11,
+    .MV .x18 .x12,
+    .MV .x19 .x13,
+    .MV .x20 .x14,
+    .SD .x20 .x0 (0 : BitVec 12),
+    .BEQ .x19 .x0 (124 : BitVec 13),
+    .LWU .x5 .x18 (0 : BitVec 12),
+    .SRLI .x5 .x5 (2 : BitVec 6),
+    .BEQ .x5 .x0 (112 : BitVec 13),
+    .LWU .x6 .x18 (0 : BitVec 12),
+    .ADD .x21 .x18 .x6,
+    .LI .x7 (1 : Word),
+    .BLTU .x7 .x5 (12 : BitVec 13),
+    .ADD .x22 .x18 .x19,
+    .JAL .x0 (12 : BitVec 21),
+    .LWU .x7 .x18 (4 : BitVec 12),
+    .ADD .x22 .x18 .x7,
+    .SUB .x5 .x22 .x21,
+    .BNE .x5 .x9 (64 : BitVec 13),
+    .MV .x6 .x8,
+    .MV .x7 .x21,
+    .MV .x28 .x9,
+    .BEQ .x28 .x0 (32 : BitVec 13),
+    .LBU .x29 .x6 (0 : BitVec 12),
+    .LBU .x30 .x7 (0 : BitVec 12),
+    .BNE .x29 .x30 (36 : BitVec 13),
+    .ADDI .x6 .x6 (1 : BitVec 12),
+    .ADDI .x7 .x7 (1 : BitVec 12),
+    .ADDI .x28 .x28 (-1 : BitVec 12),
+    .JAL .x0 (-28 : BitVec 21),
+    .LI .x6 (1 : Word),
+    .SD .x20 .x6 (0 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JAL .x0 (16 : BitVec 21),
+    .LI .x10 (0 : Word),
+    .JAL .x0 (8 : BitVec 21),
+    .LI .x10 (1 : Word),
+    .LD .x1 .x2 (0 : BitVec 12),
+    .LD .x8 .x2 (8 : BitVec 12),
+    .LD .x9 .x2 (16 : BitVec 12),
+    .LD .x18 .x2 (24 : BitVec 12),
+    .LD .x19 .x2 (32 : BitVec 12),
+    .LD .x20 .x2 (40 : BitVec 12),
+    .LD .x21 .x2 (48 : BitVec 12),
+    .LD .x22 .x2 (56 : BitVec 12),
+    .ADDI .x2 .x2 (64 : BitVec 12),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def parentHeaderMatchesWitnessFirstFunction : String :=
+  "parent_header_matches_witness_first:\n" ++ emitProgram parentHeaderMatchesWitnessFirst_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `parentHeaderMatchesWitnessFirst_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem parentHeaderMatchesWitnessFirstFunction_eq_prog :
+    parentHeaderMatchesWitnessFirstFunction = "parent_header_matches_witness_first:\n" ++ emitProgram parentHeaderMatchesWitnessFirst_prog := rfl
+
+#guard parentHeaderMatchesWitnessFirstFunction.startsWith "parent_header_matches_witness_first:\n"
+#guard parentHeaderMatchesWitnessFirst_prog.length = 57
 /-- `zisk_parent_header_matches_witness_first`: probe BuildUnit.
     Input layout (at INPUT_ADDR):
       bytes  0.. 8 : (ziskemu metadata)

--- a/EvmAsm/Codegen/Programs/BlockVerdictSenderCounts.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictSenderCounts.lean
@@ -9,6 +9,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.BlockVerdictParams
 
 namespace EvmAsm.Codegen
@@ -154,38 +155,67 @@ def b1SenderCountTableFunction : String :=
     Returns:
       a0 = 0 and a1 = entry ptr when found
       a0 = 1 when absent/malformed. -/
-def b1SenderTableFindFunction : String :=
-  "b1_sender_table_find:\n" ++
-  "  addi sp, sp, -64\n" ++
-  "  sd ra, 0(sp); sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
-  "  sd s3, 32(sp); sd s4, 40(sp); sd s5, 48(sp)\n" ++
-  "  mv s0, a0; mv s1, a1; mv s2, a2\n" ++
-  "  li s3, 0; mv s4, s1\n" ++
-  ".Lb1stf_loop:\n" ++
-  "  bgeu s3, s4, .Lb1stf_absent\n" ++
-  "  add s5, s3, s4; srli s5, s5, 1\n" ++
-  "  li t0, 40; mul t0, s5, t0; add t1, s0, t0\n" ++
-  "  li t2, 0\n" ++
-  ".Lb1stf_cmp:\n" ++
-  "  li t3, 20; beq t2, t3, .Lb1stf_found\n" ++
-  "  add t3, t1, t2; lbu t4, 0(t3); add t3, s2, t2; lbu t5, 0(t3)\n" ++
-  "  bltu t4, t5, .Lb1stf_entry_less\n" ++
-  "  bltu t5, t4, .Lb1stf_entry_greater\n" ++
-  "  addi t2, t2, 1; j .Lb1stf_cmp\n" ++
-  ".Lb1stf_entry_less:\n" ++
-  "  addi s3, s5, 1; j .Lb1stf_loop\n" ++
-  ".Lb1stf_entry_greater:\n" ++
-  "  mv s4, s5; j .Lb1stf_loop\n" ++
-  ".Lb1stf_found:\n" ++
-  "  li a0, 0; mv a1, t1; j .Lb1stf_ret\n" ++
-  ".Lb1stf_absent:\n" ++
-  "  li a0, 1\n" ++
-  ".Lb1stf_ret:\n" ++
-  "  ld ra, 0(sp); ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
-  "  ld s3, 32(sp); ld s4, 40(sp); ld s5, 48(sp)\n" ++
-  "  addi sp, sp, 64\n" ++
-  "  ret"
+def b1SenderTableFind_prog : Program :=
+  [ .ADDI .x2 .x2 (-64 : BitVec 12),
+    .SD .x2 .x1 (0 : BitVec 12),
+    .SD .x2 .x8 (8 : BitVec 12),
+    .SD .x2 .x9 (16 : BitVec 12),
+    .SD .x2 .x18 (24 : BitVec 12),
+    .SD .x2 .x19 (32 : BitVec 12),
+    .SD .x2 .x20 (40 : BitVec 12),
+    .SD .x2 .x21 (48 : BitVec 12),
+    .MV .x8 .x10,
+    .MV .x9 .x11,
+    .MV .x18 .x12,
+    .LI .x19 (0 : Word),
+    .MV .x20 .x9,
+    .BGEU .x19 .x20 (96 : BitVec 13),
+    .ADD .x21 .x19 .x20,
+    .SRLI .x21 .x21 (1 : BitVec 6),
+    .LI .x5 (40 : Word),
+    .MUL .x5 .x21 .x5,
+    .ADD .x6 .x8 .x5,
+    .LI .x7 (0 : Word),
+    .LI .x28 (20 : Word),
+    .BEQ .x7 .x28 (52 : BitVec 13),
+    .ADD .x28 .x6 .x7,
+    .LBU .x29 .x28 (0 : BitVec 12),
+    .ADD .x28 .x18 .x7,
+    .LBU .x30 .x28 (0 : BitVec 12),
+    .BLTU .x29 .x30 (16 : BitVec 13),
+    .BLTU .x30 .x29 (20 : BitVec 13),
+    .ADDI .x7 .x7 (1 : BitVec 12),
+    .JAL .x0 (-36 : BitVec 21),
+    .ADDI .x19 .x21 (1 : BitVec 12),
+    .JAL .x0 (-72 : BitVec 21),
+    .MV .x20 .x21,
+    .JAL .x0 (-80 : BitVec 21),
+    .LI .x10 (0 : Word),
+    .MV .x11 .x6,
+    .JAL .x0 (8 : BitVec 21),
+    .LI .x10 (1 : Word),
+    .LD .x1 .x2 (0 : BitVec 12),
+    .LD .x8 .x2 (8 : BitVec 12),
+    .LD .x9 .x2 (16 : BitVec 12),
+    .LD .x18 .x2 (24 : BitVec 12),
+    .LD .x19 .x2 (32 : BitVec 12),
+    .LD .x20 .x2 (40 : BitVec 12),
+    .LD .x21 .x2 (48 : BitVec 12),
+    .ADDI .x2 .x2 (64 : BitVec 12),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def b1SenderTableFindFunction : String :=
+  "b1_sender_table_find:\n" ++ emitProgram b1SenderTableFind_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `b1SenderTableFind_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem b1SenderTableFindFunction_eq_prog :
+    b1SenderTableFindFunction = "b1_sender_table_find:\n" ++ emitProgram b1SenderTableFind_prog := rfl
+
+#guard b1SenderTableFindFunction.startsWith "b1_sender_table_find:\n"
+#guard b1SenderTableFind_prog.length = 47
 /-- Shared scratch arena for `b1_sender_count_table`. -/
 def b1SenderCountTableScratchDataSection : String :=
   ".balign 32\n" ++

--- a/EvmAsm/Codegen/Programs/CallFrameDescend.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameDescend.lean
@@ -25,6 +25,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.CallFrameBase
 import EvmAsm.Codegen.Programs.CallFrameSwitch
 import EvmAsm.Codegen.Programs.StaticContext
@@ -148,13 +149,24 @@ def callFrameSetCallEnvFunction : String :=
     `callDataLen@424 = argsLen`. No copy: the parent frame slot persists
     (strictly shallower index) while the child runs, so CALLDATALOAD/COPY read
     directly from it. Clobbers t0. -/
-def callFrameSetCalldataFunction : String :=
-  "call_frame_set_calldata:\n" ++
-  "  add t0, a1, a2\n" ++
-  "  sd t0, 416(a0)\n" ++
-  "  sd a3, 424(a0)\n" ++
-  "  ret"
+def callFrameSetCalldata_prog : Program :=
+  [ .ADD .x5 .x11 .x12,
+    .SD .x10 .x5 (416 : BitVec 12),
+    .SD .x10 .x13 (424 : BitVec 12),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def callFrameSetCalldataFunction : String :=
+  "call_frame_set_calldata:\n" ++ emitProgram callFrameSetCalldata_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `callFrameSetCalldata_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem callFrameSetCalldataFunction_eq_prog :
+    callFrameSetCalldataFunction = "call_frame_set_calldata:\n" ++ emitProgram callFrameSetCalldata_prog := rfl
+
+#guard callFrameSetCalldataFunction.startsWith "call_frame_set_calldata:\n"
+#guard callFrameSetCalldata_prog.length = 4
 /-- `call_frame_forward_gas(a0 = gas_left, a1 = requested, a2 = value_nonzero)`:
     EIP-150 message-call gas forwarding (`vm/gas.py:419,424,64,415`). Returns
     `a0 = min(requested, gas_left - gas_left/64) + (value_nonzero ? 2300 : 0)`.

--- a/EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean
+++ b/EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean
@@ -9,6 +9,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.BlockVerdictParams
 
 namespace EvmAsm.Codegen
@@ -31,32 +32,75 @@ open EvmAsm.Rv64
     then recipient[0..20] copied into bytes 0..20. Slot/original/current payload
     bytes are copied from the live entry. Overflow is checked before each append,
     so the first out-of-capacity entry leaves table memory untouched. -/
-def committedStorageSnapshotAppendFunction : String :=
-  "bv_mtx_committed_snapshot_append:\n" ++
-  "  li t0, 0                      # j = 0\n" ++
-  ".Lcssa_loop:\n" ++
-  "  beq t0, a2, .Lcssa_done\n" ++
-  "  bgeu a4, a5, .Lcssa_overflow\n" ++
-  "  slli t1, t0, 7; add t1, a1, t1   # src = live[j]\n" ++
-  "  slli t2, a4, 7; add t2, a3, t2   # dst = table[count]\n" ++
-  "  sd zero, 0(t2); sd zero, 8(t2); sd zero, 16(t2); sd zero, 24(t2)\n" ++
-  "  li t3, 0\n" ++
-  ".Lcssa_addr:\n" ++
-  "  li t4, 20; beq t3, t4, .Lcssa_addr_done\n" ++
-  "  add t5, a0, t3; lbu t6, 0(t5); add t5, t2, t3; sb t6, 0(t5); addi t3, t3, 1; j .Lcssa_addr\n" ++
-  ".Lcssa_addr_done:\n" ++
-  "  ld t3, 32(t1);  sd t3, 32(t2);  ld t3, 40(t1);  sd t3, 40(t2)\n" ++
-  "  ld t3, 48(t1);  sd t3, 48(t2);  ld t3, 56(t1);  sd t3, 56(t2)\n" ++
-  "  ld t3, 64(t1);  sd t3, 64(t2);  ld t3, 72(t1);  sd t3, 72(t2)\n" ++
-  "  ld t3, 80(t1);  sd t3, 80(t2);  ld t3, 88(t1);  sd t3, 88(t2)\n" ++
-  "  ld t3, 96(t1);  sd t3, 96(t2);  ld t3, 104(t1); sd t3, 104(t2)\n" ++
-  "  ld t3, 112(t1); sd t3, 112(t2); ld t3, 120(t1); sd t3, 120(t2)\n" ++
-  "  addi a4, a4, 1; addi t0, t0, 1; j .Lcssa_loop\n" ++
-  ".Lcssa_overflow:\n" ++
-  "  li t0, 1; sd t0, 0(a6); mv a0, a4; li a1, 1; ret\n" ++
-  ".Lcssa_done:\n" ++
-  "  mv a0, a4; li a1, 0; ret"
+def bvMtxCommittedSnapshotAppend_prog : Program :=
+  [ .LI .x5 (0 : Word),
+    .BEQ .x5 .x12 (204 : BitVec 13),
+    .BGEU .x14 .x15 (180 : BitVec 13),
+    .SLLI .x6 .x5 (7 : BitVec 6),
+    .ADD .x6 .x11 .x6,
+    .SLLI .x7 .x14 (7 : BitVec 6),
+    .ADD .x7 .x13 .x7,
+    .SD .x7 .x0 (0 : BitVec 12),
+    .SD .x7 .x0 (8 : BitVec 12),
+    .SD .x7 .x0 (16 : BitVec 12),
+    .SD .x7 .x0 (24 : BitVec 12),
+    .LI .x28 (0 : Word),
+    .LI .x29 (20 : Word),
+    .BEQ .x28 .x29 (28 : BitVec 13),
+    .ADD .x30 .x10 .x28,
+    .LBU .x31 .x30 (0 : BitVec 12),
+    .ADD .x30 .x7 .x28,
+    .SB .x30 .x31 (0 : BitVec 12),
+    .ADDI .x28 .x28 (1 : BitVec 12),
+    .JAL .x0 (-28 : BitVec 21),
+    .LD .x28 .x6 (32 : BitVec 12),
+    .SD .x7 .x28 (32 : BitVec 12),
+    .LD .x28 .x6 (40 : BitVec 12),
+    .SD .x7 .x28 (40 : BitVec 12),
+    .LD .x28 .x6 (48 : BitVec 12),
+    .SD .x7 .x28 (48 : BitVec 12),
+    .LD .x28 .x6 (56 : BitVec 12),
+    .SD .x7 .x28 (56 : BitVec 12),
+    .LD .x28 .x6 (64 : BitVec 12),
+    .SD .x7 .x28 (64 : BitVec 12),
+    .LD .x28 .x6 (72 : BitVec 12),
+    .SD .x7 .x28 (72 : BitVec 12),
+    .LD .x28 .x6 (80 : BitVec 12),
+    .SD .x7 .x28 (80 : BitVec 12),
+    .LD .x28 .x6 (88 : BitVec 12),
+    .SD .x7 .x28 (88 : BitVec 12),
+    .LD .x28 .x6 (96 : BitVec 12),
+    .SD .x7 .x28 (96 : BitVec 12),
+    .LD .x28 .x6 (104 : BitVec 12),
+    .SD .x7 .x28 (104 : BitVec 12),
+    .LD .x28 .x6 (112 : BitVec 12),
+    .SD .x7 .x28 (112 : BitVec 12),
+    .LD .x28 .x6 (120 : BitVec 12),
+    .SD .x7 .x28 (120 : BitVec 12),
+    .ADDI .x14 .x14 (1 : BitVec 12),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (-180 : BitVec 21),
+    .LI .x5 (1 : Word),
+    .SD .x16 .x5 (0 : BitVec 12),
+    .MV .x10 .x14,
+    .LI .x11 (1 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .MV .x10 .x14,
+    .LI .x11 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def committedStorageSnapshotAppendFunction : String :=
+  "bv_mtx_committed_snapshot_append:\n" ++ emitProgram bvMtxCommittedSnapshotAppend_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `bvMtxCommittedSnapshotAppend_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem committedStorageSnapshotAppendFunction_eq_prog :
+    committedStorageSnapshotAppendFunction = "bv_mtx_committed_snapshot_append:\n" ++ emitProgram bvMtxCommittedSnapshotAppend_prog := rfl
+
+#guard committedStorageSnapshotAppendFunction.startsWith "bv_mtx_committed_snapshot_append:\n"
+#guard bvMtxCommittedSnapshotAppend_prog.length = 55
 /-- `zisk_mtx_committed_snapshot_append`: focused probe.
     Input after ziskemu's length wrapper:
       +8  mode: 0 zero-live, 1 one-entry, 2 two-entry, 3 overflow
@@ -118,52 +162,104 @@ def ziskCommittedStorageSnapshotPrologue : String :=
     preserving latest-write-wins without growing the table. Non-matches append a
     new committed entry, and overflow is reported only when a new unique key
     cannot fit. -/
-def committedStorageSnapshotUpsertFunction : String :=
-  "bv_mtx_committed_snapshot_upsert:\n" ++
-  "  li t0, 0                      # j = 0\n" ++
-  ".Lcssu_loop:\n" ++
-  "  beq t0, a2, .Lcssu_done\n" ++
-  "  slli t1, t0, 7; add t1, a1, t1   # src = live[j]\n" ++
-  "  li t2, 0                      # i = 0\n" ++
-  ".Lcssu_scan:\n" ++
-  "  beq t2, a4, .Lcssu_no_match\n" ++
-  "  slli t3, t2, 7; add t3, a3, t3   # entry = table[i]\n" ++
-  "  li t4, 0\n" ++
-  ".Lcssu_addr_cmp:\n" ++
-  "  li t5, 20; beq t4, t5, .Lcssu_slot_cmp\n" ++
-  "  add t5, a0, t4; lbu t5, 0(t5); add t6, t3, t4; lbu t6, 0(t6); bne t5, t6, .Lcssu_next_entry\n" ++
-  "  addi t4, t4, 1; j .Lcssu_addr_cmp\n" ++
-  ".Lcssu_slot_cmp:\n" ++
-  "  ld t5, 32(t1);  ld t6, 32(t3);  bne t5, t6, .Lcssu_next_entry\n" ++
-  "  ld t5, 40(t1);  ld t6, 40(t3);  bne t5, t6, .Lcssu_next_entry\n" ++
-  "  ld t5, 48(t1);  ld t6, 48(t3);  bne t5, t6, .Lcssu_next_entry\n" ++
-  "  ld t5, 56(t1);  ld t6, 56(t3);  bne t5, t6, .Lcssu_next_entry\n" ++
-  "  j .Lcssu_store_payload\n" ++
-  ".Lcssu_next_entry:\n" ++
-  "  addi t2, t2, 1; j .Lcssu_scan\n" ++
-  ".Lcssu_no_match:\n" ++
-  "  bgeu a4, a5, .Lcssu_overflow\n" ++
-  "  slli t3, a4, 7; add t3, a3, t3   # dst = table[count]\n" ++
-  "  sd zero, 0(t3); sd zero, 8(t3); sd zero, 16(t3); sd zero, 24(t3)\n" ++
-  "  li t4, 0\n" ++
-  ".Lcssu_addr_copy:\n" ++
-  "  li t5, 20; beq t4, t5, .Lcssu_store_payload_append\n" ++
-  "  add t5, a0, t4; lbu t6, 0(t5); add t5, t3, t4; sb t6, 0(t5); addi t4, t4, 1; j .Lcssu_addr_copy\n" ++
-  ".Lcssu_store_payload_append:\n" ++
-  "  addi a4, a4, 1\n" ++
-  ".Lcssu_store_payload:\n" ++
-  "  ld t4, 32(t1);  sd t4, 32(t3);  ld t4, 40(t1);  sd t4, 40(t3)\n" ++
-  "  ld t4, 48(t1);  sd t4, 48(t3);  ld t4, 56(t1);  sd t4, 56(t3)\n" ++
-  "  ld t4, 64(t1);  sd t4, 64(t3);  ld t4, 72(t1);  sd t4, 72(t3)\n" ++
-  "  ld t4, 80(t1);  sd t4, 80(t3);  ld t4, 88(t1);  sd t4, 88(t3)\n" ++
-  "  ld t4, 96(t1);  sd t4, 96(t3);  ld t4, 104(t1); sd t4, 104(t3)\n" ++
-  "  ld t4, 112(t1); sd t4, 112(t3); ld t4, 120(t1); sd t4, 120(t3)\n" ++
-  "  addi t0, t0, 1; j .Lcssu_loop\n" ++
-  ".Lcssu_overflow:\n" ++
-  "  li t0, 1; sd t0, 0(a6); mv a0, a4; li a1, 1; ret\n" ++
-  ".Lcssu_done:\n" ++
-  "  mv a0, a4; li a1, 0; ret"
+def bvMtxCommittedSnapshotUpsert_prog : Program :=
+  [ .LI .x5 (0 : Word),
+    .BEQ .x5 .x12 (320 : BitVec 13),
+    .SLLI .x6 .x5 (7 : BitVec 6),
+    .ADD .x6 .x11 .x6,
+    .LI .x7 (0 : Word),
+    .BEQ .x7 .x14 (112 : BitVec 13),
+    .SLLI .x28 .x7 (7 : BitVec 6),
+    .ADD .x28 .x13 .x28,
+    .LI .x29 (0 : Word),
+    .LI .x30 (20 : Word),
+    .BEQ .x29 .x30 (32 : BitVec 13),
+    .ADD .x30 .x10 .x29,
+    .LBU .x30 .x30 (0 : BitVec 12),
+    .ADD .x31 .x28 .x29,
+    .LBU .x31 .x31 (0 : BitVec 12),
+    .BNE .x30 .x31 (64 : BitVec 13),
+    .ADDI .x29 .x29 (1 : BitVec 12),
+    .JAL .x0 (-32 : BitVec 21),
+    .LD .x30 .x6 (32 : BitVec 12),
+    .LD .x31 .x28 (32 : BitVec 12),
+    .BNE .x30 .x31 (44 : BitVec 13),
+    .LD .x30 .x6 (40 : BitVec 12),
+    .LD .x31 .x28 (40 : BitVec 12),
+    .BNE .x30 .x31 (32 : BitVec 13),
+    .LD .x30 .x6 (48 : BitVec 12),
+    .LD .x31 .x28 (48 : BitVec 12),
+    .BNE .x30 .x31 (20 : BitVec 13),
+    .LD .x30 .x6 (56 : BitVec 12),
+    .LD .x31 .x28 (56 : BitVec 12),
+    .BNE .x30 .x31 (8 : BitVec 13),
+    .JAL .x0 (80 : BitVec 21),
+    .ADDI .x7 .x7 (1 : BitVec 12),
+    .JAL .x0 (-108 : BitVec 21),
+    .BGEU .x14 .x15 (172 : BitVec 13),
+    .SLLI .x28 .x14 (7 : BitVec 6),
+    .ADD .x28 .x13 .x28,
+    .SD .x28 .x0 (0 : BitVec 12),
+    .SD .x28 .x0 (8 : BitVec 12),
+    .SD .x28 .x0 (16 : BitVec 12),
+    .SD .x28 .x0 (24 : BitVec 12),
+    .LI .x29 (0 : Word),
+    .LI .x30 (20 : Word),
+    .BEQ .x29 .x30 (28 : BitVec 13),
+    .ADD .x30 .x10 .x29,
+    .LBU .x31 .x30 (0 : BitVec 12),
+    .ADD .x30 .x28 .x29,
+    .SB .x30 .x31 (0 : BitVec 12),
+    .ADDI .x29 .x29 (1 : BitVec 12),
+    .JAL .x0 (-28 : BitVec 21),
+    .ADDI .x14 .x14 (1 : BitVec 12),
+    .LD .x29 .x6 (32 : BitVec 12),
+    .SD .x28 .x29 (32 : BitVec 12),
+    .LD .x29 .x6 (40 : BitVec 12),
+    .SD .x28 .x29 (40 : BitVec 12),
+    .LD .x29 .x6 (48 : BitVec 12),
+    .SD .x28 .x29 (48 : BitVec 12),
+    .LD .x29 .x6 (56 : BitVec 12),
+    .SD .x28 .x29 (56 : BitVec 12),
+    .LD .x29 .x6 (64 : BitVec 12),
+    .SD .x28 .x29 (64 : BitVec 12),
+    .LD .x29 .x6 (72 : BitVec 12),
+    .SD .x28 .x29 (72 : BitVec 12),
+    .LD .x29 .x6 (80 : BitVec 12),
+    .SD .x28 .x29 (80 : BitVec 12),
+    .LD .x29 .x6 (88 : BitVec 12),
+    .SD .x28 .x29 (88 : BitVec 12),
+    .LD .x29 .x6 (96 : BitVec 12),
+    .SD .x28 .x29 (96 : BitVec 12),
+    .LD .x29 .x6 (104 : BitVec 12),
+    .SD .x28 .x29 (104 : BitVec 12),
+    .LD .x29 .x6 (112 : BitVec 12),
+    .SD .x28 .x29 (112 : BitVec 12),
+    .LD .x29 .x6 (120 : BitVec 12),
+    .SD .x28 .x29 (120 : BitVec 12),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (-296 : BitVec 21),
+    .LI .x5 (1 : Word),
+    .SD .x16 .x5 (0 : BitVec 12),
+    .MV .x10 .x14,
+    .LI .x11 (1 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .MV .x10 .x14,
+    .LI .x11 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def committedStorageSnapshotUpsertFunction : String :=
+  "bv_mtx_committed_snapshot_upsert:\n" ++ emitProgram bvMtxCommittedSnapshotUpsert_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `bvMtxCommittedSnapshotUpsert_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem committedStorageSnapshotUpsertFunction_eq_prog :
+    committedStorageSnapshotUpsertFunction = "bv_mtx_committed_snapshot_upsert:\n" ++ emitProgram bvMtxCommittedSnapshotUpsert_prog := rfl
+
+#guard committedStorageSnapshotUpsertFunction.startsWith "bv_mtx_committed_snapshot_upsert:\n"
+#guard bvMtxCommittedSnapshotUpsert_prog.length = 84
 /-- `zisk_mtx_committed_snapshot_upsert`: focused probe.
     Input after ziskemu's length wrapper:
       +8  mode: 0 zero-live, 1 insert, 2 duplicate, 3 duplicate-plus-new,
@@ -252,52 +348,104 @@ def ziskCommittedStorageSnapshotUpsertProbeUnit : BuildUnit := {
     chunk pages. Existing keys update in place across page boundaries; new
     unique keys append at the global count and overflow only when total chunked
     capacity is exhausted. -/
-def committedStorageChunkedSnapshotUpsertFunction : String :=
-  "bv_mtx_committed_chunked_snapshot_upsert:\n" ++
-  "  li t0, 0                      # j = 0\n" ++
-  ".Lcscsu_loop:\n" ++
-  "  beq t0, a2, .Lcscsu_done\n" ++
-  "  slli t1, t0, 7; add t1, a1, t1   # src = live[j]\n" ++
-  "  li t2, 0                      # i = 0\n" ++
-  ".Lcscsu_scan:\n" ++
-  "  beq t2, a4, .Lcscsu_no_match\n" ++
-  "  slli t3, t2, 7; add t3, a3, t3   # entry = table[i]\n" ++
-  "  li t4, 0\n" ++
-  ".Lcscsu_addr_cmp:\n" ++
-  "  li t5, 20; beq t4, t5, .Lcscsu_slot_cmp\n" ++
-  "  add t5, a0, t4; lbu t5, 0(t5); add t6, t3, t4; lbu t6, 0(t6); bne t5, t6, .Lcscsu_next_entry\n" ++
-  "  addi t4, t4, 1; j .Lcscsu_addr_cmp\n" ++
-  ".Lcscsu_slot_cmp:\n" ++
-  "  ld t5, 32(t1);  ld t6, 32(t3);  bne t5, t6, .Lcscsu_next_entry\n" ++
-  "  ld t5, 40(t1);  ld t6, 40(t3);  bne t5, t6, .Lcscsu_next_entry\n" ++
-  "  ld t5, 48(t1);  ld t6, 48(t3);  bne t5, t6, .Lcscsu_next_entry\n" ++
-  "  ld t5, 56(t1);  ld t6, 56(t3);  bne t5, t6, .Lcscsu_next_entry\n" ++
-  "  j .Lcscsu_store_payload\n" ++
-  ".Lcscsu_next_entry:\n" ++
-  "  addi t2, t2, 1; j .Lcscsu_scan\n" ++
-  ".Lcscsu_no_match:\n" ++
-  "  bgeu a4, a5, .Lcscsu_overflow\n" ++
-  "  slli t3, a4, 7; add t3, a3, t3   # dst = table[count]\n" ++
-  "  sd zero, 0(t3); sd zero, 8(t3); sd zero, 16(t3); sd zero, 24(t3)\n" ++
-  "  li t4, 0\n" ++
-  ".Lcscsu_addr_copy:\n" ++
-  "  li t5, 20; beq t4, t5, .Lcscsu_store_payload_append\n" ++
-  "  add t5, a0, t4; lbu t6, 0(t5); add t5, t3, t4; sb t6, 0(t5); addi t4, t4, 1; j .Lcscsu_addr_copy\n" ++
-  ".Lcscsu_store_payload_append:\n" ++
-  "  addi a4, a4, 1\n" ++
-  ".Lcscsu_store_payload:\n" ++
-  "  ld t4, 32(t1);  sd t4, 32(t3);  ld t4, 40(t1);  sd t4, 40(t3)\n" ++
-  "  ld t4, 48(t1);  sd t4, 48(t3);  ld t4, 56(t1);  sd t4, 56(t3)\n" ++
-  "  ld t4, 64(t1);  sd t4, 64(t3);  ld t4, 72(t1);  sd t4, 72(t3)\n" ++
-  "  ld t4, 80(t1);  sd t4, 80(t3);  ld t4, 88(t1);  sd t4, 88(t3)\n" ++
-  "  ld t4, 96(t1);  sd t4, 96(t3);  ld t4, 104(t1); sd t4, 104(t3)\n" ++
-  "  ld t4, 112(t1); sd t4, 112(t3); ld t4, 120(t1); sd t4, 120(t3)\n" ++
-  "  addi t0, t0, 1; j .Lcscsu_loop\n" ++
-  ".Lcscsu_overflow:\n" ++
-  "  li t0, 1; sd t0, 0(a6); mv a0, a4; li a1, 1; ret\n" ++
-  ".Lcscsu_done:\n" ++
-  "  mv a0, a4; li a1, 0; ret"
+def bvMtxCommittedChunkedSnapshotUpsert_prog : Program :=
+  [ .LI .x5 (0 : Word),
+    .BEQ .x5 .x12 (320 : BitVec 13),
+    .SLLI .x6 .x5 (7 : BitVec 6),
+    .ADD .x6 .x11 .x6,
+    .LI .x7 (0 : Word),
+    .BEQ .x7 .x14 (112 : BitVec 13),
+    .SLLI .x28 .x7 (7 : BitVec 6),
+    .ADD .x28 .x13 .x28,
+    .LI .x29 (0 : Word),
+    .LI .x30 (20 : Word),
+    .BEQ .x29 .x30 (32 : BitVec 13),
+    .ADD .x30 .x10 .x29,
+    .LBU .x30 .x30 (0 : BitVec 12),
+    .ADD .x31 .x28 .x29,
+    .LBU .x31 .x31 (0 : BitVec 12),
+    .BNE .x30 .x31 (64 : BitVec 13),
+    .ADDI .x29 .x29 (1 : BitVec 12),
+    .JAL .x0 (-32 : BitVec 21),
+    .LD .x30 .x6 (32 : BitVec 12),
+    .LD .x31 .x28 (32 : BitVec 12),
+    .BNE .x30 .x31 (44 : BitVec 13),
+    .LD .x30 .x6 (40 : BitVec 12),
+    .LD .x31 .x28 (40 : BitVec 12),
+    .BNE .x30 .x31 (32 : BitVec 13),
+    .LD .x30 .x6 (48 : BitVec 12),
+    .LD .x31 .x28 (48 : BitVec 12),
+    .BNE .x30 .x31 (20 : BitVec 13),
+    .LD .x30 .x6 (56 : BitVec 12),
+    .LD .x31 .x28 (56 : BitVec 12),
+    .BNE .x30 .x31 (8 : BitVec 13),
+    .JAL .x0 (80 : BitVec 21),
+    .ADDI .x7 .x7 (1 : BitVec 12),
+    .JAL .x0 (-108 : BitVec 21),
+    .BGEU .x14 .x15 (172 : BitVec 13),
+    .SLLI .x28 .x14 (7 : BitVec 6),
+    .ADD .x28 .x13 .x28,
+    .SD .x28 .x0 (0 : BitVec 12),
+    .SD .x28 .x0 (8 : BitVec 12),
+    .SD .x28 .x0 (16 : BitVec 12),
+    .SD .x28 .x0 (24 : BitVec 12),
+    .LI .x29 (0 : Word),
+    .LI .x30 (20 : Word),
+    .BEQ .x29 .x30 (28 : BitVec 13),
+    .ADD .x30 .x10 .x29,
+    .LBU .x31 .x30 (0 : BitVec 12),
+    .ADD .x30 .x28 .x29,
+    .SB .x30 .x31 (0 : BitVec 12),
+    .ADDI .x29 .x29 (1 : BitVec 12),
+    .JAL .x0 (-28 : BitVec 21),
+    .ADDI .x14 .x14 (1 : BitVec 12),
+    .LD .x29 .x6 (32 : BitVec 12),
+    .SD .x28 .x29 (32 : BitVec 12),
+    .LD .x29 .x6 (40 : BitVec 12),
+    .SD .x28 .x29 (40 : BitVec 12),
+    .LD .x29 .x6 (48 : BitVec 12),
+    .SD .x28 .x29 (48 : BitVec 12),
+    .LD .x29 .x6 (56 : BitVec 12),
+    .SD .x28 .x29 (56 : BitVec 12),
+    .LD .x29 .x6 (64 : BitVec 12),
+    .SD .x28 .x29 (64 : BitVec 12),
+    .LD .x29 .x6 (72 : BitVec 12),
+    .SD .x28 .x29 (72 : BitVec 12),
+    .LD .x29 .x6 (80 : BitVec 12),
+    .SD .x28 .x29 (80 : BitVec 12),
+    .LD .x29 .x6 (88 : BitVec 12),
+    .SD .x28 .x29 (88 : BitVec 12),
+    .LD .x29 .x6 (96 : BitVec 12),
+    .SD .x28 .x29 (96 : BitVec 12),
+    .LD .x29 .x6 (104 : BitVec 12),
+    .SD .x28 .x29 (104 : BitVec 12),
+    .LD .x29 .x6 (112 : BitVec 12),
+    .SD .x28 .x29 (112 : BitVec 12),
+    .LD .x29 .x6 (120 : BitVec 12),
+    .SD .x28 .x29 (120 : BitVec 12),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (-296 : BitVec 21),
+    .LI .x5 (1 : Word),
+    .SD .x16 .x5 (0 : BitVec 12),
+    .MV .x10 .x14,
+    .LI .x11 (1 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .MV .x10 .x14,
+    .LI .x11 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def committedStorageChunkedSnapshotUpsertFunction : String :=
+  "bv_mtx_committed_chunked_snapshot_upsert:\n" ++ emitProgram bvMtxCommittedChunkedSnapshotUpsert_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `bvMtxCommittedChunkedSnapshotUpsert_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem committedStorageChunkedSnapshotUpsertFunction_eq_prog :
+    committedStorageChunkedSnapshotUpsertFunction = "bv_mtx_committed_chunked_snapshot_upsert:\n" ++ emitProgram bvMtxCommittedChunkedSnapshotUpsert_prog := rfl
+
+#guard committedStorageChunkedSnapshotUpsertFunction.startsWith "bv_mtx_committed_chunked_snapshot_upsert:\n"
+#guard bvMtxCommittedChunkedSnapshotUpsert_prog.length = 84
 /-- `zisk_mtx_committed_chunked_snapshot_upsert`: focused probe.
     Input after ziskemu's length wrapper:
       +8 mode: 0 zero-live, 1 129 unique inserts, 2 duplicate update across

--- a/EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean
+++ b/EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean
@@ -28,6 +28,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 
 namespace EvmAsm.Codegen
 
@@ -105,25 +106,44 @@ def createRecordCodeEffectFunction : String :=
       a0 = record ptr (at the +0 addr field; pass record+32 to
            bal_account_code_consistent) or 0 if not found.
     Walks variable-stride entries (round8(48 + code_len)). Clobbers t0-t6, a0. -/
-def findCodeEffectByAddressFunction : String :=
-  "find_code_effect_by_address:\n" ++
-  "  mv t0, a0                   # cursor (entry base)\n" ++
-  "  mv t1, a1                   # remaining count\n" ++
-  ".Lfce_loop:\n" ++
-  "  beqz t1, .Lfce_none\n" ++
-  "  mv t2, t0; mv t3, a2; li t4, 20\n" ++
-  ".Lfce_cmp:\n" ++
-  "  beqz t4, .Lfce_found\n" ++
-  "  lbu t5, 0(t2); lbu t6, 0(t3); bne t5, t6, .Lfce_next\n" ++
-  "  addi t2, t2, 1; addi t3, t3, 1; addi t4, t4, -1; j .Lfce_cmp\n" ++
-  ".Lfce_next:\n" ++
-  "  ld t5, 40(t0); addi t5, t5, 55; andi t5, t5, -8   # stride = round8(48 + code_len)\n" ++
-  "  add t0, t0, t5; addi t1, t1, -1; j .Lfce_loop\n" ++
-  ".Lfce_found:\n" ++
-  "  mv a0, t0; ret\n" ++
-  ".Lfce_none:\n" ++
-  "  li a0, 0; ret"
+def findCodeEffectByAddress_prog : Program :=
+  [ .MV .x5 .x10,
+    .MV .x6 .x11,
+    .BEQ .x6 .x0 (80 : BitVec 13),
+    .MV .x7 .x5,
+    .MV .x28 .x12,
+    .LI .x29 (20 : Word),
+    .BEQ .x29 .x0 (56 : BitVec 13),
+    .LBU .x30 .x7 (0 : BitVec 12),
+    .LBU .x31 .x28 (0 : BitVec 12),
+    .BNE .x30 .x31 (20 : BitVec 13),
+    .ADDI .x7 .x7 (1 : BitVec 12),
+    .ADDI .x28 .x28 (1 : BitVec 12),
+    .ADDI .x29 .x29 (-1 : BitVec 12),
+    .JAL .x0 (-28 : BitVec 21),
+    .LD .x30 .x5 (40 : BitVec 12),
+    .ADDI .x30 .x30 (55 : BitVec 12),
+    .ANDI .x30 .x30 (-8 : BitVec 12),
+    .ADD .x5 .x5 .x30,
+    .ADDI .x6 .x6 (-1 : BitVec 12),
+    .JAL .x0 (-68 : BitVec 21),
+    .MV .x10 .x5,
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def findCodeEffectByAddressFunction : String :=
+  "find_code_effect_by_address:\n" ++ emitProgram findCodeEffectByAddress_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `findCodeEffectByAddress_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem findCodeEffectByAddressFunction_eq_prog :
+    findCodeEffectByAddressFunction = "find_code_effect_by_address:\n" ++ emitProgram findCodeEffectByAddress_prog := rfl
+
+#guard findCodeEffectByAddressFunction.startsWith "find_code_effect_by_address:\n"
+#guard findCodeEffectByAddress_prog.length = 24
 /-- Data region for the code-effect log (linked wherever CREATE deposit runs;
     included in this probe and, in step .8b-2, the runtime dispatcher data). -/
 def createCodeEffectLogData : String :=

--- a/EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean
+++ b/EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean
@@ -21,6 +21,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 
 namespace EvmAsm.Codegen
 
@@ -28,56 +29,108 @@ open EvmAsm.Rv64
 
 /-! ## keccak256_word_gas
     a0 = size in bytes → a0 = OPCODE_KECCAK256_BASE(30) + 6 * ceil32(size)//32. -/
-def keccak256WordGasFunction : String :=
-  "keccak256_word_gas:\n" ++
-  "  addi t0, a0, 31; srli t0, t0, 5   # words\n" ++
-  "  li t1, 6; mul t0, t0, t1\n" ++
-  "  addi a0, t0, 30                   # + KECCAK256 base\n" ++
-  "  ret"
+def keccak256WordGas_prog : Program :=
+  [ .ADDI .x5 .x10 (31 : BitVec 12),
+    .SRLI .x5 .x5 (5 : BitVec 6),
+    .LI .x6 (6 : Word),
+    .MUL .x5 .x5 .x6,
+    .ADDI .x10 .x5 (30 : BitVec 12),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def keccak256WordGasFunction : String :=
+  "keccak256_word_gas:\n" ++ emitProgram keccak256WordGas_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `keccak256WordGas_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem keccak256WordGasFunction_eq_prog :
+    keccak256WordGasFunction = "keccak256_word_gas:\n" ++ emitProgram keccak256WordGas_prog := rfl
+
+#guard keccak256WordGasFunction.startsWith "keccak256_word_gas:\n"
+#guard keccak256WordGas_prog.length = 6
 /-! ## copy_word_gas
     a0 = size in bytes → a0 = OPCODE_COPY_PER_WORD(3) * ceil32(size)//32.
     (The *COPY base cost is the static opcode base; this is the per-word part.) -/
-def copyWordGasFunction : String :=
-  "copy_word_gas:\n" ++
-  "  addi t0, a0, 31; srli t0, t0, 5   # words\n" ++
-  "  li t1, 3; mul a0, t0, t1\n" ++
-  "  ret"
+def copyWordGas_prog : Program :=
+  [ .ADDI .x5 .x10 (31 : BitVec 12),
+    .SRLI .x5 .x5 (5 : BitVec 6),
+    .LI .x6 (3 : Word),
+    .MUL .x10 .x5 .x6,
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def copyWordGasFunction : String :=
+  "copy_word_gas:\n" ++ emitProgram copyWordGas_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `copyWordGas_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem copyWordGasFunction_eq_prog :
+    copyWordGasFunction = "copy_word_gas:\n" ++ emitProgram copyWordGas_prog := rfl
+
+#guard copyWordGasFunction.startsWith "copy_word_gas:\n"
+#guard copyWordGas_prog.length = 5
 /-! ## log_data_gas
     a0 = num_topics   a1 = data size in bytes
     a0 = OPCODE_LOG_BASE(375) + OPCODE_LOG_TOPIC(375)*num_topics
          + OPCODE_LOG_DATA_PER_BYTE(8)*data_bytes. -/
-def logDataGasFunction : String :=
-  "log_data_gas:\n" ++
-  "  li t0, 375; mul t1, a0, t0        # 375 * num_topics\n" ++
-  "  add t1, t1, t0                    # + LOG base (375)\n" ++
-  "  li t2, 8; mul t2, a1, t2          # 8 * data_bytes\n" ++
-  "  add a0, t1, t2\n" ++
-  "  ret"
+def logDataGas_prog : Program :=
+  [ .LI .x5 (375 : Word),
+    .MUL .x6 .x10 .x5,
+    .ADD .x6 .x6 .x5,
+    .LI .x7 (8 : Word),
+    .MUL .x7 .x11 .x7,
+    .ADD .x10 .x6 .x7,
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def logDataGasFunction : String :=
+  "log_data_gas:\n" ++ emitProgram logDataGas_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `logDataGas_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem logDataGasFunction_eq_prog :
+    logDataGasFunction = "log_data_gas:\n" ++ emitProgram logDataGas_prog := rfl
+
+#guard logDataGasFunction.startsWith "log_data_gas:\n"
+#guard logDataGas_prog.length = 7
 /-! ## exp_gas
     a0 = exponent value ptr (32-byte BE)
     a0 = OPCODE_EXP_BASE(10) + OPCODE_EXP_PER_BYTE(50) * exponent_bytes, where
     exponent_bytes = (bit_length(exponent) + 7)//8 = 32 - leading_zero_bytes of the
     32-byte big-endian exponent (0 when the exponent is 0). Leaf, no calls. -/
-def expGasFunction : String :=
-  "exp_gas:\n" ++
-  "  li t0, 0                          # i = leading-zero byte count (scan from MSB)\n" ++
-  ".Lexp_lead:\n" ++
-  "  li t1, 32; beq t0, t1, .Lexp_zero # all 32 bytes zero -> exponent_bytes = 0\n" ++
-  "  add t2, a0, t0; lbu t2, 0(t2)\n" ++
-  "  bnez t2, .Lexp_found\n" ++
-  "  addi t0, t0, 1; j .Lexp_lead\n" ++
-  ".Lexp_found:\n" ++
-  "  li t1, 32; sub t1, t1, t0         # exponent_bytes = 32 - i\n" ++
-  "  li t2, 50; mul t1, t1, t2         # 50 * exponent_bytes\n" ++
-  "  addi a0, t1, 10                   # + EXP base\n" ++
-  "  ret\n" ++
-  ".Lexp_zero:\n" ++
-  "  li a0, 10\n" ++
-  "  ret"
+def expGas_prog : Program :=
+  [ .LI .x5 (0 : Word),
+    .LI .x6 (32 : Word),
+    .BEQ .x5 .x6 (48 : BitVec 13),
+    .ADD .x7 .x10 .x5,
+    .LBU .x7 .x7 (0 : BitVec 12),
+    .BNE .x7 .x0 (12 : BitVec 13),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (-24 : BitVec 21),
+    .LI .x6 (32 : Word),
+    .SUB .x6 .x6 .x5,
+    .LI .x7 (50 : Word),
+    .MUL .x6 .x6 .x7,
+    .ADDI .x10 .x6 (10 : BitVec 12),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (10 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def expGasFunction : String :=
+  "exp_gas:\n" ++ emitProgram expGas_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `expGas_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem expGasFunction_eq_prog :
+    expGasFunction = "exp_gas:\n" ++ emitProgram expGas_prog := rfl
+
+#guard expGasFunction.startsWith "exp_gas:\n"
+#guard expGas_prog.length = 16
 /-- `zisk_dynamic_opcode_gas`: probe over the leaves.
     Input (after the ziskemu length wrapper at 0x40000000):
       bytes  8..16 : keccak size in bytes

--- a/EvmAsm/Codegen/Programs/Eip7702NonceReuseGuard.lean
+++ b/EvmAsm/Codegen/Programs/Eip7702NonceReuseGuard.lean
@@ -6,6 +6,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.TxExtract
 import EvmAsm.Codegen.Programs.Address
@@ -15,14 +16,31 @@ namespace EvmAsm.Codegen
 open EvmAsm.Rv64
 
 /-! ## enrg_u32le -- local unaligned u32 little-endian reader. -/
-def enrgU32leFunction : String :=
-  "enrg_u32le:\n" ++
-  "  lbu t0, 0(a0)\n" ++
-  "  lbu t1, 1(a0); slli t1, t1, 8; or t0, t0, t1\n" ++
-  "  lbu t1, 2(a0); slli t1, t1, 16; or t0, t0, t1\n" ++
-  "  lbu t1, 3(a0); slli t1, t1, 24; or a0, t0, t1\n" ++
-  "  ret"
+def enrgU32le_prog : Program :=
+  [ .LBU .x5 .x10 (0 : BitVec 12),
+    .LBU .x6 .x10 (1 : BitVec 12),
+    .SLLI .x6 .x6 (8 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (2 : BitVec 12),
+    .SLLI .x6 .x6 (16 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (3 : BitVec 12),
+    .SLLI .x6 .x6 (24 : BitVec 6),
+    .OR .x10 .x5 .x6,
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def enrgU32leFunction : String :=
+  "enrg_u32le:\n" ++ emitProgram enrgU32le_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `enrgU32le_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem enrgU32leFunction_eq_prog :
+    enrgU32leFunction = "enrg_u32le:\n" ++ emitProgram enrgU32le_prog := rfl
+
+#guard enrgU32leFunction.startsWith "enrg_u32le:\n"
+#guard enrgU32le_prog.length = 11
 /-! ## eip7702_nonce_reuse_guard -- reject tx nonce below prior BAL nonce.
     a0 = exec_payload ptr   a1 = SSZ_BASE   a2 = BAL ptr   a3 = BAL len
     a0 (output) = 0 ok/unsupported, 1 invalid nonce reuse.

--- a/EvmAsm/Codegen/Programs/ExecLogLatestValue.lean
+++ b/EvmAsm/Codegen/Programs/ExecLogLatestValue.lean
@@ -26,6 +26,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 
 namespace EvmAsm.Codegen
 
@@ -38,35 +39,62 @@ open EvmAsm.Rv64
     a0 (output) = 1 if a matching entry was found (out holds its committed value),
                   0 if the slot was never touched (out left unchanged).
     Leaf: uses only t-registers + the argument registers; no stack frame. -/
-def execLogLatestValueFunction : String :=
-  "exec_log_latest_value:\n" ++
-  "  li t6, 0                      # found flag\n" ++
-  "  li t0, 0                      # entry index i\n" ++
-  ".Lelv_loop:\n" ++
-  "  beq t0, a3, .Lelv_done\n" ++
-  "  slli t1, t0, 7; add t2, a2, t1   # entry ptr = base + i*128\n" ++
-  "  # match addrHash (entry@0 vs a0)\n" ++
-  "  ld t3, 0(t2);  ld t4, 0(a0);  bne t3, t4, .Lelv_next\n" ++
-  "  ld t3, 8(t2);  ld t4, 8(a0);  bne t3, t4, .Lelv_next\n" ++
-  "  ld t3, 16(t2); ld t4, 16(a0); bne t3, t4, .Lelv_next\n" ++
-  "  ld t3, 24(t2); ld t4, 24(a0); bne t3, t4, .Lelv_next\n" ++
-  "  # match slotKey (entry@32 vs a1)\n" ++
-  "  ld t3, 32(t2); ld t4, 0(a1);  bne t3, t4, .Lelv_next\n" ++
-  "  ld t3, 40(t2); ld t4, 8(a1);  bne t3, t4, .Lelv_next\n" ++
-  "  ld t3, 48(t2); ld t4, 16(a1); bne t3, t4, .Lelv_next\n" ++
-  "  ld t3, 56(t2); ld t4, 24(a1); bne t3, t4, .Lelv_next\n" ++
-  "  # matching entry: copy current (entry@96) -> out; set found. Overwrite keeps the LAST match.\n" ++
-  "  ld t3, 96(t2);  sd t3, 0(a4)\n" ++
-  "  ld t3, 104(t2); sd t3, 8(a4)\n" ++
-  "  ld t3, 112(t2); sd t3, 16(a4)\n" ++
-  "  ld t3, 120(t2); sd t3, 24(a4)\n" ++
-  "  li t6, 1\n" ++
-  ".Lelv_next:\n" ++
-  "  addi t0, t0, 1; j .Lelv_loop\n" ++
-  ".Lelv_done:\n" ++
-  "  mv a0, t6\n" ++
-  "  ret"
+def execLogLatestValue_prog : Program :=
+  [ .LI .x31 (0 : Word),
+    .LI .x5 (0 : Word),
+    .BEQ .x5 .x13 (152 : BitVec 13),
+    .SLLI .x6 .x5 (7 : BitVec 6),
+    .ADD .x7 .x12 .x6,
+    .LD .x28 .x7 (0 : BitVec 12),
+    .LD .x29 .x10 (0 : BitVec 12),
+    .BNE .x28 .x29 (124 : BitVec 13),
+    .LD .x28 .x7 (8 : BitVec 12),
+    .LD .x29 .x10 (8 : BitVec 12),
+    .BNE .x28 .x29 (112 : BitVec 13),
+    .LD .x28 .x7 (16 : BitVec 12),
+    .LD .x29 .x10 (16 : BitVec 12),
+    .BNE .x28 .x29 (100 : BitVec 13),
+    .LD .x28 .x7 (24 : BitVec 12),
+    .LD .x29 .x10 (24 : BitVec 12),
+    .BNE .x28 .x29 (88 : BitVec 13),
+    .LD .x28 .x7 (32 : BitVec 12),
+    .LD .x29 .x11 (0 : BitVec 12),
+    .BNE .x28 .x29 (76 : BitVec 13),
+    .LD .x28 .x7 (40 : BitVec 12),
+    .LD .x29 .x11 (8 : BitVec 12),
+    .BNE .x28 .x29 (64 : BitVec 13),
+    .LD .x28 .x7 (48 : BitVec 12),
+    .LD .x29 .x11 (16 : BitVec 12),
+    .BNE .x28 .x29 (52 : BitVec 13),
+    .LD .x28 .x7 (56 : BitVec 12),
+    .LD .x29 .x11 (24 : BitVec 12),
+    .BNE .x28 .x29 (40 : BitVec 13),
+    .LD .x28 .x7 (96 : BitVec 12),
+    .SD .x14 .x28 (0 : BitVec 12),
+    .LD .x28 .x7 (104 : BitVec 12),
+    .SD .x14 .x28 (8 : BitVec 12),
+    .LD .x28 .x7 (112 : BitVec 12),
+    .SD .x14 .x28 (16 : BitVec 12),
+    .LD .x28 .x7 (120 : BitVec 12),
+    .SD .x14 .x28 (24 : BitVec 12),
+    .LI .x31 (1 : Word),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (-148 : BitVec 21),
+    .MV .x10 .x31,
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def execLogLatestValueFunction : String :=
+  "exec_log_latest_value:\n" ++ emitProgram execLogLatestValue_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `execLogLatestValue_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem execLogLatestValueFunction_eq_prog :
+    execLogLatestValueFunction = "exec_log_latest_value:\n" ++ emitProgram execLogLatestValue_prog := rfl
+
+#guard execLogLatestValueFunction.startsWith "exec_log_latest_value:\n"
+#guard execLogLatestValue_prog.length = 42
 /-- `zisk_exec_log_latest_value`: focused probe.
     Input (after the ziskemu length wrapper at 0x40000000):
       bytes  8..16 : entry count

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -36,6 +36,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.HashBridge
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.Tx
@@ -433,31 +434,39 @@ def ziskHeaderExtractBlockRootsProbeUnit : BuildUnit := {
                     3 timestamp <= parent.timestamp
 
     Pure register arithmetic, no scratch memory, leaf-callable. -/
-def validateHeaderBasicFunction : String :=
-  "validate_header_basic:\n" ++
-  "  ld t0, 88(a0)              # this.gas_used\n" ++
-  "  ld t1, 80(a0)              # this.gas_limit\n" ++
-  "  bgtu t0, t1, .Lvhb_fail_gas\n" ++
-  "  ld t0, 64(a0)              # this.number\n" ++
-  "  beqz t0, .Lvhb_fail_number\n" ++
-  "  ld t1, 64(a1)              # parent.number\n" ++
-  "  addi t1, t1, 1\n" ++
-  "  bne t0, t1, .Lvhb_fail_number\n" ++
-  "  ld t0, 72(a0)              # this.timestamp\n" ++
-  "  ld t1, 72(a1)              # parent.timestamp\n" ++
-  "  bgeu t1, t0, .Lvhb_fail_timestamp  # parent_ts >= this_ts → fail\n" ++
-  "  li a0, 0\n" ++
-  "  ret\n" ++
-  ".Lvhb_fail_gas:\n" ++
-  "  li a0, 1\n" ++
-  "  ret\n" ++
-  ".Lvhb_fail_number:\n" ++
-  "  li a0, 2\n" ++
-  "  ret\n" ++
-  ".Lvhb_fail_timestamp:\n" ++
-  "  li a0, 3\n" ++
-  "  ret"
+def validateHeaderBasic_prog : Program :=
+  [ .LD .x5 .x10 (88 : BitVec 12),
+    .LD .x6 .x10 (80 : BitVec 12),
+    .BLTU .x6 .x5 (44 : BitVec 13),
+    .LD .x5 .x10 (64 : BitVec 12),
+    .BEQ .x5 .x0 (44 : BitVec 13),
+    .LD .x6 .x11 (64 : BitVec 12),
+    .ADDI .x6 .x6 (1 : BitVec 12),
+    .BNE .x5 .x6 (32 : BitVec 13),
+    .LD .x5 .x10 (72 : BitVec 12),
+    .LD .x6 .x11 (72 : BitVec 12),
+    .BGEU .x6 .x5 (28 : BitVec 13),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (1 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (2 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (3 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def validateHeaderBasicFunction : String :=
+  "validate_header_basic:\n" ++ emitProgram validateHeaderBasic_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `validateHeaderBasic_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem validateHeaderBasicFunction_eq_prog :
+    validateHeaderBasicFunction = "validate_header_basic:\n" ++ emitProgram validateHeaderBasic_prog := rfl
+
+#guard validateHeaderBasicFunction.startsWith "validate_header_basic:\n"
+#guard validateHeaderBasic_prog.length = 19
 /-- `zisk_validate_header_basic`: probe BuildUnit. Reads two
     128-byte extended-header structs from host input (after an
     8-byte tag) and writes the 8-byte status to OUTPUT. -/
@@ -601,16 +610,26 @@ def ziskCheckGasLimitProbeUnit : BuildUnit := {
       a0 (output) : excess_blob_gas for this header (u64).
 
     Pure register arithmetic, no scratch memory, leaf-callable. -/
-def calcExcessBlobGasFunction : String :=
-  "calc_excess_blob_gas:\n" ++
-  "  add t0, a0, a1              # parent_excess + parent_used\n" ++
-  "  bgeu t0, a2, .Lcebg_pos     # >= target → return diff\n" ++
-  "  li a0, 0\n" ++
-  "  ret\n" ++
-  ".Lcebg_pos:\n" ++
-  "  sub a0, t0, a2\n" ++
-  "  ret"
+def calcExcessBlobGas_prog : Program :=
+  [ .ADD .x5 .x10 .x11,
+    .BGEU .x5 .x12 (12 : BitVec 13),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .SUB .x10 .x5 .x12,
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def calcExcessBlobGasFunction : String :=
+  "calc_excess_blob_gas:\n" ++ emitProgram calcExcessBlobGas_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `calcExcessBlobGas_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem calcExcessBlobGasFunction_eq_prog :
+    calcExcessBlobGasFunction = "calc_excess_blob_gas:\n" ++ emitProgram calcExcessBlobGas_prog := rfl
+
+#guard calcExcessBlobGasFunction.startsWith "calc_excess_blob_gas:\n"
+#guard calcExcessBlobGas_prog.length = 6
 /-- `zisk_calc_excess_blob_gas`: probe BuildUnit. Reads
     (parent_excess, parent_used, target) from host input, writes
     the u64 result to OUTPUT. -/

--- a/EvmAsm/Codegen/Programs/HeadersKeccak.lean
+++ b/EvmAsm/Codegen/Programs/HeadersKeccak.lean
@@ -21,6 +21,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.HashBridge
 
 namespace EvmAsm.Codegen
@@ -245,45 +246,52 @@ def ziskHeadersKeccakArrayProbeUnit : BuildUnit := {
 
     Pure register arithmetic; no scratch memory, no callee-saved
     registers used. Leaf-callable. -/
-def headersParentHashFunction : String :=
-  "headers_parent_hash:\n" ++
-  "  # a0 = header ptr, a1 = header_len, a2 = out ptr\n" ++
-  "  lbu t0, 0(a0)                # first byte\n" ++
-  "  li t1, 0xc0\n" ++
-  "  bltu t0, t1, .Lhph_fail      # not an RLP list (< 0xc0)\n" ++
-  "  li t1, 0xf8\n" ++
-  "  bltu t0, t1, .Lhph_short     # 0xc0..0xf7 → short list, 1-byte prefix\n" ++
-  "  # long list: t0 in [0xf8..0xff].\n" ++
-  "  # length_of_length = t0 - 0xf7. Outer prefix = 1 + length_of_length bytes.\n" ++
-  "  li t1, 0xf7\n" ++
-  "  sub t2, t0, t1               # length_of_length\n" ++
-  "  li t3, 2                     # cap: support 0xf8 (LoL=1), 0xf9 (LoL=2)\n" ++
-  "  bltu t3, t2, .Lhph_fail      # LoL > 2 → unsupported\n" ++
-  "  addi t2, t2, 1               # prefix bytes = LoL + 1\n" ++
-  "  add a0, a0, t2               # skip prefix\n" ++
-  "  sub a1, a1, t2\n" ++
-  "  j .Lhph_after_prefix\n" ++
-  ".Lhph_short:\n" ++
-  "  addi a0, a0, 1               # skip 1-byte prefix\n" ++
-  "  addi a1, a1, -1\n" ++
-  ".Lhph_after_prefix:\n" ++
-  "  # Expect 0xa0 Bytes32 prefix.\n" ++
-  "  li t0, 33\n" ++
-  "  bltu a1, t0, .Lhph_fail      # not enough bytes for 0xa0 + 32\n" ++
-  "  lbu t1, 0(a0)\n" ++
-  "  li t2, 0xa0\n" ++
-  "  bne t1, t2, .Lhph_fail       # not a Bytes32 string\n" ++
-  "  # Copy 32 bytes from a0+1 to a2.\n" ++
-  "  ld t0,  1(a0); sd t0,  0(a2)\n" ++
-  "  ld t0,  9(a0); sd t0,  8(a2)\n" ++
-  "  ld t0, 17(a0); sd t0, 16(a2)\n" ++
-  "  ld t0, 25(a0); sd t0, 24(a2)\n" ++
-  "  li a0, 0\n" ++
-  "  ret\n" ++
-  ".Lhph_fail:\n" ++
-  "  li a0, 1\n" ++
-  "  ret"
+def headersParentHash_prog : Program :=
+  [ .LBU .x5 .x10 (0 : BitVec 12),
+    .LI .x6 (192 : Word),
+    .BLTU .x5 .x6 (112 : BitVec 13),
+    .LI .x6 (248 : Word),
+    .BLTU .x5 .x6 (36 : BitVec 13),
+    .LI .x6 (247 : Word),
+    .SUB .x7 .x5 .x6,
+    .LI .x28 (2 : Word),
+    .BLTU .x28 .x7 (88 : BitVec 13),
+    .ADDI .x7 .x7 (1 : BitVec 12),
+    .ADD .x10 .x10 .x7,
+    .SUB .x11 .x11 .x7,
+    .JAL .x0 (12 : BitVec 21),
+    .ADDI .x10 .x10 (1 : BitVec 12),
+    .ADDI .x11 .x11 (-1 : BitVec 12),
+    .LI .x5 (33 : Word),
+    .BLTU .x11 .x5 (56 : BitVec 13),
+    .LBU .x6 .x10 (0 : BitVec 12),
+    .LI .x7 (160 : Word),
+    .BNE .x6 .x7 (44 : BitVec 13),
+    .LD .x5 .x10 (1 : BitVec 12),
+    .SD .x12 .x5 (0 : BitVec 12),
+    .LD .x5 .x10 (9 : BitVec 12),
+    .SD .x12 .x5 (8 : BitVec 12),
+    .LD .x5 .x10 (17 : BitVec 12),
+    .SD .x12 .x5 (16 : BitVec 12),
+    .LD .x5 .x10 (25 : BitVec 12),
+    .SD .x12 .x5 (24 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (1 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def headersParentHashFunction : String :=
+  "headers_parent_hash:\n" ++ emitProgram headersParentHash_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `headersParentHash_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem headersParentHashFunction_eq_prog :
+    headersParentHashFunction = "headers_parent_hash:\n" ++ emitProgram headersParentHash_prog := rfl
+
+#guard headersParentHashFunction.startsWith "headers_parent_hash:\n"
+#guard headersParentHash_prog.length = 32
 /-- `zisk_headers_parent_hash`: probe BuildUnit that reads an
     RLP-encoded header from host input and writes
     `(status, parent_hash)` to OUTPUT.

--- a/EvmAsm/Codegen/Programs/IntrinsicGas.lean
+++ b/EvmAsm/Codegen/Programs/IntrinsicGas.lean
@@ -16,6 +16,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.AmsterdamSystemTx
 
 namespace EvmAsm.Codegen
@@ -46,32 +47,37 @@ open EvmAsm.Rv64.Program
       a0 (output) : 0 (always succeeds — total over the buffer).
 
     `zero_count + non_zero_count == byte_length` exactly. -/
-def calldataByteCountsFunction : String :=
-  "calldata_byte_counts:\n" ++
-  "  # Pure-leaf, but we read into t-regs and update in-place; no\n" ++
-  "  # callee-saved usage needed.\n" ++
-  "  li t0, 0                    # zero_count\n" ++
-  "  li t1, 0                    # non_zero_count\n" ++
-  "  mv t2, a0                   # cursor\n" ++
-  "  mv t3, a1                   # remaining bytes\n" ++
-  ".Lcbc_loop:\n" ++
-  "  beqz t3, .Lcbc_done\n" ++
-  "  lbu t4, 0(t2)\n" ++
-  "  bnez t4, .Lcbc_nz\n" ++
-  "  addi t0, t0, 1\n" ++
-  "  j .Lcbc_step\n" ++
-  ".Lcbc_nz:\n" ++
-  "  addi t1, t1, 1\n" ++
-  ".Lcbc_step:\n" ++
-  "  addi t2, t2, 1\n" ++
-  "  addi t3, t3, -1\n" ++
-  "  j .Lcbc_loop\n" ++
-  ".Lcbc_done:\n" ++
-  "  sd t0, 0(a2)\n" ++
-  "  sd t1, 0(a3)\n" ++
-  "  li a0, 0\n" ++
-  "  ret"
+def calldataByteCounts_prog : Program :=
+  [ .LI .x5 (0 : Word),
+    .LI .x6 (0 : Word),
+    .MV .x7 .x10,
+    .MV .x28 .x11,
+    .BEQ .x28 .x0 (36 : BitVec 13),
+    .LBU .x29 .x7 (0 : BitVec 12),
+    .BNE .x29 .x0 (12 : BitVec 13),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (8 : BitVec 21),
+    .ADDI .x6 .x6 (1 : BitVec 12),
+    .ADDI .x7 .x7 (1 : BitVec 12),
+    .ADDI .x28 .x28 (-1 : BitVec 12),
+    .JAL .x0 (-32 : BitVec 21),
+    .SD .x12 .x5 (0 : BitVec 12),
+    .SD .x13 .x6 (0 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def calldataByteCountsFunction : String :=
+  "calldata_byte_counts:\n" ++ emitProgram calldataByteCounts_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `calldataByteCounts_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem calldataByteCountsFunction_eq_prog :
+    calldataByteCountsFunction = "calldata_byte_counts:\n" ++ emitProgram calldataByteCounts_prog := rfl
+
+#guard calldataByteCountsFunction.startsWith "calldata_byte_counts:\n"
+#guard calldataByteCounts_prog.length = 17
 /-- `zisk_calldata_byte_counts`: probe BuildUnit. Reads
     (length, bytes) from host input, writes (status,
     zero_count, non_zero_count) to OUTPUT (24 bytes total). -/
@@ -129,36 +135,40 @@ def ziskCalldataByteCountsProbeUnit : BuildUnit := {
       a0 (output) : 0 (always succeeds — total function).
 
     Pure-leaf semantics: no scratch memory, no transitive calls. -/
-def intrinsicGasCalldataFloorEip7623Function : String :=
-  "intrinsic_gas_calldata_floor_eip7623:\n" ++
-  "  # Count zeros and non-zeros in one pass.\n" ++
-  "  li t0, 0                    # zero_count\n" ++
-  "  li t1, 0                    # non_zero_count\n" ++
-  "  mv t2, a0                   # cursor\n" ++
-  "  mv t3, a1                   # remaining\n" ++
-  ".Ligcf_loop:\n" ++
-  "  beqz t3, .Ligcf_done\n" ++
-  "  lbu t4, 0(t2)\n" ++
-  "  bnez t4, .Ligcf_nz\n" ++
-  "  addi t0, t0, 1\n" ++
-  "  j .Ligcf_step\n" ++
-  ".Ligcf_nz:\n" ++
-  "  addi t1, t1, 1\n" ++
-  ".Ligcf_step:\n" ++
-  "  addi t2, t2, 1\n" ++
-  "  addi t3, t3, -1\n" ++
-  "  j .Ligcf_loop\n" ++
-  ".Ligcf_done:\n" ++
-  "  # tokens = zero + non_zero × token_per_nonzero\n" ++
-  "  mul t5, t1, a3              # non_zero × token_per_nz\n" ++
-  "  add t5, t5, t0              # tokens\n" ++
-  "  # floor = tokens × floor_gas_per_token + base_gas\n" ++
-  "  mul t6, t5, a2\n" ++
-  "  add t6, t6, a4\n" ++
-  "  sd t6, 0(a5)\n" ++
-  "  li a0, 0\n" ++
-  "  ret"
+def intrinsicGasCalldataFloorEip7623_prog : Program :=
+  [ .LI .x5 (0 : Word),
+    .LI .x6 (0 : Word),
+    .MV .x7 .x10,
+    .MV .x28 .x11,
+    .BEQ .x28 .x0 (36 : BitVec 13),
+    .LBU .x29 .x7 (0 : BitVec 12),
+    .BNE .x29 .x0 (12 : BitVec 13),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (8 : BitVec 21),
+    .ADDI .x6 .x6 (1 : BitVec 12),
+    .ADDI .x7 .x7 (1 : BitVec 12),
+    .ADDI .x28 .x28 (-1 : BitVec 12),
+    .JAL .x0 (-32 : BitVec 21),
+    .MUL .x30 .x6 .x13,
+    .ADD .x30 .x30 .x5,
+    .MUL .x31 .x30 .x12,
+    .ADD .x31 .x31 .x14,
+    .SD .x15 .x31 (0 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def intrinsicGasCalldataFloorEip7623Function : String :=
+  "intrinsic_gas_calldata_floor_eip7623:\n" ++ emitProgram intrinsicGasCalldataFloorEip7623_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `intrinsicGasCalldataFloorEip7623_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem intrinsicGasCalldataFloorEip7623Function_eq_prog :
+    intrinsicGasCalldataFloorEip7623Function = "intrinsic_gas_calldata_floor_eip7623:\n" ++ emitProgram intrinsicGasCalldataFloorEip7623_prog := rfl
+
+#guard intrinsicGasCalldataFloorEip7623Function.startsWith "intrinsic_gas_calldata_floor_eip7623:\n"
+#guard intrinsicGasCalldataFloorEip7623_prog.length = 20
 /-- `zisk_intrinsic_gas_calldata_floor_eip7623`: probe BuildUnit.
     Input layout:
       bytes  0.. 8 : data length
@@ -222,15 +232,26 @@ def ziskIntrinsicGasCalldataFloorEip7623ProbeUnit : BuildUnit := {
     The arithmetic stays in u64; for any `init_code_length` within
     the EIP-3860 cap (`MAX_INIT_CODE_SIZE = 49_152`) and any
     `gas_per_word ≤ 2^48`, the cost fits in u64. -/
-def initCodeCostFunction : String :=
-  "init_code_cost:\n" ++
-  "  addi t0, a0, 31             # len + 31\n" ++
-  "  srli t0, t0, 5              # / 32 → ceil(len/32)\n" ++
-  "  mul t0, t0, a1              # × gas_per_word\n" ++
-  "  sd t0, 0(a2)\n" ++
-  "  li a0, 0\n" ++
-  "  ret"
+def initCodeCost_prog : Program :=
+  [ .ADDI .x5 .x10 (31 : BitVec 12),
+    .SRLI .x5 .x5 (5 : BitVec 6),
+    .MUL .x5 .x5 .x11,
+    .SD .x12 .x5 (0 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def initCodeCostFunction : String :=
+  "init_code_cost:\n" ++ emitProgram initCodeCost_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `initCodeCost_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem initCodeCostFunction_eq_prog :
+    initCodeCostFunction = "init_code_cost:\n" ++ emitProgram initCodeCost_prog := rfl
+
+#guard initCodeCostFunction.startsWith "init_code_cost:\n"
+#guard initCodeCost_prog.length = 6
 /-- `zisk_init_code_cost`: probe BuildUnit. Reads
     (init_code_length, gas_per_word) from host input, writes
     (status, init_code_cost) to OUTPUT (16 bytes total).
@@ -735,51 +756,55 @@ def ziskEip8037TxStateGasNetArrayProbeUnit : BuildUnit := {
     accumulating either total is reported as a distinct nonzero status rather
     than wrapping. The wiring into `block_verdict` lands in a separate child
     once a real metered regular-gas accumulator exists. -/
-def eip8037BlockGasUsedFunction : String :=
-  "eip8037_block_gas_used:\n" ++
-  "  # a0=regular_inc ptr, a1=tx_state_gas ptr, a2=count,\n" ++
-  "  # a3=header_gas_used, a4=block_gas_used_out\n" ++
-  "  mv t0, a0                   # regular_inc ptr\n" ++
-  "  mv t1, a1                   # tx_state_gas ptr\n" ++
-  "  mv t2, a2                   # count\n" ++
-  "  li t3, 0                    # i\n" ++
-  "  li t4, 0                    # block_regular\n" ++
-  "  li t5, 0                    # block_state\n" ++
-  ".Le8037bg_loop:\n" ++
-  "  beq t3, t2, .Le8037bg_done\n" ++
-  "  slli t6, t3, 3\n" ++
-  "  add a5, t0, t6\n" ++
-  "  ld a5, 0(a5)               # regular increment\n" ++
-  "  add a6, t4, a5\n" ++
-  "  bltu a6, t4, .Le8037bg_overflow\n" ++
-  "  mv t4, a6                  # block_regular += regular increment\n" ++
-  "  add a5, t1, t6\n" ++
-  "  ld a5, 0(a5)               # tx_state_gas\n" ++
-  "  add a6, t5, a5\n" ++
-  "  bltu a6, t5, .Le8037bg_overflow\n" ++
-  "  mv t5, a6                  # block_state += tx_state_gas\n" ++
-  "  addi t3, t3, 1\n" ++
-  "  j .Le8037bg_loop\n" ++
-  ".Le8037bg_done:\n" ++
-  "  mv a5, t4                  # block_gas_used = block_regular\n" ++
-  "  bgeu t4, t5, .Le8037bg_have_max\n" ++
-  "  mv a5, t5                  # block_gas_used = block_state\n" ++
-  ".Le8037bg_have_max:\n" ++
-  "  sd a5, 0(a4)\n" ++
-  "  bne a5, a3, .Le8037bg_mismatch\n" ++
-  "  li a0, 0\n" ++
-  "  mv a1, a5\n" ++
-  "  ret\n" ++
-  ".Le8037bg_mismatch:\n" ++
-  "  li a0, 1\n" ++
-  "  mv a1, a5\n" ++
-  "  ret\n" ++
-  ".Le8037bg_overflow:\n" ++
-  "  sd zero, 0(a4)\n" ++
-  "  li a0, 2\n" ++
-  "  li a1, 0\n" ++
-  "  ret"
+def eip8037BlockGasUsed_prog : Program :=
+  [ .MV .x5 .x10,
+    .MV .x6 .x11,
+    .MV .x7 .x12,
+    .LI .x28 (0 : Word),
+    .LI .x29 (0 : Word),
+    .LI .x30 (0 : Word),
+    .BEQ .x28 .x7 (56 : BitVec 13),
+    .SLLI .x31 .x28 (3 : BitVec 6),
+    .ADD .x15 .x5 .x31,
+    .LD .x15 .x15 (0 : BitVec 12),
+    .ADD .x16 .x29 .x15,
+    .BLTU .x16 .x29 (80 : BitVec 13),
+    .MV .x29 .x16,
+    .ADD .x15 .x6 .x31,
+    .LD .x15 .x15 (0 : BitVec 12),
+    .ADD .x16 .x30 .x15,
+    .BLTU .x16 .x30 (60 : BitVec 13),
+    .MV .x30 .x16,
+    .ADDI .x28 .x28 (1 : BitVec 12),
+    .JAL .x0 (-52 : BitVec 21),
+    .MV .x15 .x29,
+    .BGEU .x29 .x30 (8 : BitVec 13),
+    .MV .x15 .x30,
+    .SD .x14 .x15 (0 : BitVec 12),
+    .BNE .x15 .x13 (16 : BitVec 13),
+    .LI .x10 (0 : Word),
+    .MV .x11 .x15,
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (1 : Word),
+    .MV .x11 .x15,
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .SD .x14 .x0 (0 : BitVec 12),
+    .LI .x10 (2 : Word),
+    .LI .x11 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def eip8037BlockGasUsedFunction : String :=
+  "eip8037_block_gas_used:\n" ++ emitProgram eip8037BlockGasUsed_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `eip8037BlockGasUsed_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem eip8037BlockGasUsedFunction_eq_prog :
+    eip8037BlockGasUsedFunction = "eip8037_block_gas_used:\n" ++ emitProgram eip8037BlockGasUsed_prog := rfl
+
+#guard eip8037BlockGasUsedFunction.startsWith "eip8037_block_gas_used:\n"
+#guard eip8037BlockGasUsed_prog.length = 35
 /-- `zisk_eip8037_block_gas_used`: focused probe.
     Input layout (after the ziskemu length wrapper at 0x40000000+8):
       bytes  8..16 : count            (number of transactions, <= 4)

--- a/EvmAsm/Codegen/Programs/MemoryExpansionGas.lean
+++ b/EvmAsm/Codegen/Programs/MemoryExpansionGas.lean
@@ -22,6 +22,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 
 namespace EvmAsm.Codegen
 
@@ -31,24 +32,38 @@ open EvmAsm.Rv64
     a0 = old size in bytes   a1 = new size in bytes
     a0 (output) = the memory-expansion gas charge = cost(new) - cost(old), or 0 if
     new <= old. cost(b) = w*3 + w*w/512 with w = (b + 31) >> 5. Leaf (no calls). -/
-def memoryExpansionGasFunction : String :=
-  "memory_expansion_gas:\n" ++
-  "  bgeu a0, a1, .Lmeg_zero        # new <= old -> no expansion\n" ++
-  "  addi t0, a0, 31; srli t0, t0, 5   # t0 = words_old = (old+31)/32\n" ++
-  "  addi t1, a1, 31; srli t1, t1, 5   # t1 = words_new = (new+31)/32\n" ++
-  "  li t2, 3\n" ++
-  "  mul t3, t0, t2                 # words_old * 3\n" ++
-  "  mul t4, t0, t0; srli t4, t4, 9 # words_old^2 / 512\n" ++
-  "  add t3, t3, t4                 # cost_old\n" ++
-  "  mul t5, t1, t2                 # words_new * 3\n" ++
-  "  mul t6, t1, t1; srli t6, t6, 9 # words_new^2 / 512\n" ++
-  "  add t5, t5, t6                 # cost_new\n" ++
-  "  sub a0, t5, t3                 # expansion = cost_new - cost_old\n" ++
-  "  ret\n" ++
-  ".Lmeg_zero:\n" ++
-  "  li a0, 0\n" ++
-  "  ret"
+def memoryExpansionGas_prog : Program :=
+  [ .BGEU .x10 .x11 (64 : BitVec 13),
+    .ADDI .x5 .x10 (31 : BitVec 12),
+    .SRLI .x5 .x5 (5 : BitVec 6),
+    .ADDI .x6 .x11 (31 : BitVec 12),
+    .SRLI .x6 .x6 (5 : BitVec 6),
+    .LI .x7 (3 : Word),
+    .MUL .x28 .x5 .x7,
+    .MUL .x29 .x5 .x5,
+    .SRLI .x29 .x29 (9 : BitVec 6),
+    .ADD .x28 .x28 .x29,
+    .MUL .x30 .x6 .x7,
+    .MUL .x31 .x6 .x6,
+    .SRLI .x31 .x31 (9 : BitVec 6),
+    .ADD .x30 .x30 .x31,
+    .SUB .x10 .x30 .x28,
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def memoryExpansionGasFunction : String :=
+  "memory_expansion_gas:\n" ++ emitProgram memoryExpansionGas_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `memoryExpansionGas_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem memoryExpansionGasFunction_eq_prog :
+    memoryExpansionGasFunction = "memory_expansion_gas:\n" ++ emitProgram memoryExpansionGas_prog := rfl
+
+#guard memoryExpansionGasFunction.startsWith "memory_expansion_gas:\n"
+#guard memoryExpansionGas_prog.length = 18
 /-- `zisk_memory_expansion_gas`: focused probe.
     Input (after the ziskemu length wrapper at 0x40000000):
       bytes  8..16 : old size in bytes (u64)

--- a/EvmAsm/Codegen/Programs/SenderPostNonceConsistent.lean
+++ b/EvmAsm/Codegen/Programs/SenderPostNonceConsistent.lean
@@ -28,6 +28,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 
 namespace EvmAsm.Codegen
 
@@ -37,24 +38,44 @@ open EvmAsm.Rv64
     a0 = tx_gas_sender_bal_lookup output record ptr
     a0 (output) = 0 consistent (post == pre+1) / 1 mismatch / 2 skip (absent or >u64).
     Leaf; clobbers t0-t5. -/
-def senderPostNonceConsistentFunction : String :=
-  "sender_post_nonce_consistent:\n" ++
-  "  ld t0, 128(a0)              # post nonce byte length\n" ++
-  "  li t1, -1; beq t0, t1, .Lspnc_skip       # absent -> skip\n" ++
-  "  li t1, 8;  bgtu t0, t1, .Lspnc_skip       # > u64 -> skip\n" ++
-  "  addi t2, a0, 136; li t3, 0; mv t4, t0     # decode big-endian post nonce\n" ++
-  ".Lspnc_be:\n" ++
-  "  beqz t4, .Lspnc_de\n" ++
-  "  slli t3, t3, 8; lbu t5, 0(t2); or t3, t3, t5; addi t2, t2, 1; addi t4, t4, -1; j .Lspnc_be\n" ++
-  ".Lspnc_de:\n" ++
-  "  ld t4, 80(a0); addi t4, t4, 1             # expected = pre nonce + 1\n" ++
-  "  beq t3, t4, .Lspnc_match\n" ++
-  "  li a0, 1; ret                             # mismatch\n" ++
-  ".Lspnc_match:\n" ++
-  "  li a0, 0; ret\n" ++
-  ".Lspnc_skip:\n" ++
-  "  li a0, 2; ret"
+def senderPostNonceConsistent_prog : Program :=
+  [ .LD .x5 .x10 (128 : BitVec 12),
+    .LI .x6 (-1 : Word),
+    .BEQ .x5 .x6 (80 : BitVec 13),
+    .LI .x6 (8 : Word),
+    .BLTU .x6 .x5 (72 : BitVec 13),
+    .ADDI .x7 .x10 (136 : BitVec 12),
+    .LI .x28 (0 : Word),
+    .MV .x29 .x5,
+    .BEQ .x29 .x0 (28 : BitVec 13),
+    .SLLI .x28 .x28 (8 : BitVec 6),
+    .LBU .x30 .x7 (0 : BitVec 12),
+    .OR .x28 .x28 .x30,
+    .ADDI .x7 .x7 (1 : BitVec 12),
+    .ADDI .x29 .x29 (-1 : BitVec 12),
+    .JAL .x0 (-24 : BitVec 21),
+    .LD .x29 .x10 (80 : BitVec 12),
+    .ADDI .x29 .x29 (1 : BitVec 12),
+    .BEQ .x28 .x29 (12 : BitVec 13),
+    .LI .x10 (1 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (2 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def senderPostNonceConsistentFunction : String :=
+  "sender_post_nonce_consistent:\n" ++ emitProgram senderPostNonceConsistent_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `senderPostNonceConsistent_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem senderPostNonceConsistentFunction_eq_prog :
+    senderPostNonceConsistentFunction = "sender_post_nonce_consistent:\n" ++ emitProgram senderPostNonceConsistent_prog := rfl
+
+#guard senderPostNonceConsistentFunction.startsWith "sender_post_nonce_consistent:\n"
+#guard senderPostNonceConsistent_prog.length = 24
 /-- `zisk_sender_post_nonce_consistent`: known-answer probe over a lookup-shaped
     buffer (pre nonce @+80, post-nonce len @+128, post-nonce bytes @+136). Cases
     surfaced to OUTPUT (0xa0010000):

--- a/EvmAsm/Codegen/Programs/SlotTupleSequencesMatch.lean
+++ b/EvmAsm/Codegen/Programs/SlotTupleSequencesMatch.lean
@@ -21,6 +21,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 
 namespace EvmAsm.Codegen
 
@@ -31,26 +32,49 @@ open EvmAsm.Rv64
     a2 = exec tuple-sequence ptr   a3 = exec tuple count
     a0 (output) = 0 sequences identical / 1 mismatch.
     Records are 40 bytes: block_access_index (u64) at +0, new_value (32B) at +8. -/
-def slotTupleSequencesMatchFunction : String :=
-  "slot_tuple_sequences_match:\n" ++
-  "  bne a1, a3, .Lstsm_bad        # length mismatch -> reject\n" ++
-  "  li t0, 0                      # i\n" ++
-  ".Lstsm_loop:\n" ++
-  "  beq t0, a1, .Lstsm_ok\n" ++
-  "  slli t1, t0, 5; slli t2, t0, 3; add t1, t1, t2   # i*40\n" ++
-  "  add t3, a0, t1                # BAL record i\n" ++
-  "  add t4, a2, t1                # exec record i\n" ++
-  "  ld t5, 0(t3);  ld t6, 0(t4);  bne t5, t6, .Lstsm_bad   # block_access_index\n" ++
-  "  ld t5, 8(t3);  ld t6, 8(t4);  bne t5, t6, .Lstsm_bad   # value[0:8]\n" ++
-  "  ld t5, 16(t3); ld t6, 16(t4); bne t5, t6, .Lstsm_bad   # value[8:16]\n" ++
-  "  ld t5, 24(t3); ld t6, 24(t4); bne t5, t6, .Lstsm_bad   # value[16:24]\n" ++
-  "  ld t5, 32(t3); ld t6, 32(t4); bne t5, t6, .Lstsm_bad   # value[24:32]\n" ++
-  "  addi t0, t0, 1; j .Lstsm_loop\n" ++
-  ".Lstsm_ok:\n" ++
-  "  li a0, 0; ret\n" ++
-  ".Lstsm_bad:\n" ++
-  "  li a0, 1; ret"
+def slotTupleSequencesMatch_prog : Program :=
+  [ .BNE .x11 .x13 (108 : BitVec 13),
+    .LI .x5 (0 : Word),
+    .BEQ .x5 .x11 (92 : BitVec 13),
+    .SLLI .x6 .x5 (5 : BitVec 6),
+    .SLLI .x7 .x5 (3 : BitVec 6),
+    .ADD .x6 .x6 .x7,
+    .ADD .x28 .x10 .x6,
+    .ADD .x29 .x12 .x6,
+    .LD .x30 .x28 (0 : BitVec 12),
+    .LD .x31 .x29 (0 : BitVec 12),
+    .BNE .x30 .x31 (68 : BitVec 13),
+    .LD .x30 .x28 (8 : BitVec 12),
+    .LD .x31 .x29 (8 : BitVec 12),
+    .BNE .x30 .x31 (56 : BitVec 13),
+    .LD .x30 .x28 (16 : BitVec 12),
+    .LD .x31 .x29 (16 : BitVec 12),
+    .BNE .x30 .x31 (44 : BitVec 13),
+    .LD .x30 .x28 (24 : BitVec 12),
+    .LD .x31 .x29 (24 : BitVec 12),
+    .BNE .x30 .x31 (32 : BitVec 13),
+    .LD .x30 .x28 (32 : BitVec 12),
+    .LD .x31 .x29 (32 : BitVec 12),
+    .BNE .x30 .x31 (20 : BitVec 13),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (-88 : BitVec 21),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (1 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def slotTupleSequencesMatchFunction : String :=
+  "slot_tuple_sequences_match:\n" ++ emitProgram slotTupleSequencesMatch_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `slotTupleSequencesMatch_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem slotTupleSequencesMatchFunction_eq_prog :
+    slotTupleSequencesMatchFunction = "slot_tuple_sequences_match:\n" ++ emitProgram slotTupleSequencesMatch_prog := rfl
+
+#guard slotTupleSequencesMatchFunction.startsWith "slot_tuple_sequences_match:\n"
+#guard slotTupleSequencesMatch_prog.length = 29
 /-- `zisk_slot_tuple_sequences_match`: focused probe.
     Input (after the ziskemu length wrapper at 0x40000000):
       bytes  8..16 : BAL tuple count

--- a/EvmAsm/Codegen/Programs/State.lean
+++ b/EvmAsm/Codegen/Programs/State.lean
@@ -23,6 +23,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.Mpt
 import EvmAsm.Codegen.Programs.HashBridge
@@ -441,46 +442,52 @@ def ziskAccountAtAddressProbeUnit : BuildUnit := {
 
     Internal: `mpt_lookup_by_key(slot_idx, ..., si_value_scratch)`
     then `slot_decode_u256` over the looked-up bytes. -/
-def slotDecodeU256Function : String :=
-  "slot_decode_u256:\n" ++
-  "  # a0 = val_bytes ptr, a1 = val_len, a2 = 32-byte BE out ptr.\n" ++
-  "  # Returns 0 (ok) / 1 (fail). Output is zeroed on every path.\n" ++
-  "  sd zero,  0(a2); sd zero,  8(a2); sd zero, 16(a2); sd zero, 24(a2)\n" ++
-  "  beqz a1, .Lsdu_fail        # empty input: malformed encoded value\n" ++
-  "  lbu t0, 0(a0)\n" ++
-  "  li t1, 0x80\n" ++
-  "  bltu t0, t1, .Lsdu_single  # b0 < 0x80: single byte\n" ++
-  "  beq t0, t1, .Lsdu_zero     # b0 == 0x80: empty string ⇒ 0\n" ++
-  "  li t1, 0xa1\n" ++
-  "  bgeu t0, t1, .Lsdu_fail    # b0 ≥ 0xa1: too long for a u256\n" ++
-  "  # Short string of n bytes (1 ≤ n ≤ 32).\n" ++
-  "  li t1, 0x80\n" ++
-  "  sub t2, t0, t1             # n\n" ++
-  "  addi t3, a1, -1\n" ++
-  "  bltu t3, t2, .Lsdu_fail    # not enough bytes for declared length\n" ++
-  "  li t4, 32\n" ++
-  "  sub t4, t4, t2             # 32 - n\n" ++
-  "  add t5, a2, t4             # dst (right-aligned)\n" ++
-  "  addi t6, a0, 1             # src\n" ++
-  "  mv t3, t2                  # remaining\n" ++
-  ".Lsdu_copy:\n" ++
-  "  beqz t3, .Lsdu_ok\n" ++
-  "  lbu t1, 0(t6)\n" ++
-  "  sb  t1, 0(t5)\n" ++
-  "  addi t5, t5, 1\n" ++
-  "  addi t6, t6, 1\n" ++
-  "  addi t3, t3, -1\n" ++
-  "  j .Lsdu_copy\n" ++
-  ".Lsdu_single:\n" ++
-  "  sb t0, 31(a2)              # write u256 = b0 at byte 31 (BE LSB)\n" ++
-  ".Lsdu_zero:\n" ++
-  ".Lsdu_ok:\n" ++
-  "  li a0, 0\n" ++
-  "  ret\n" ++
-  ".Lsdu_fail:\n" ++
-  "  li a0, 1\n" ++
-  "  ret"
+def slotDecodeU256_prog : Program :=
+  [ .SD .x12 .x0 (0 : BitVec 12),
+    .SD .x12 .x0 (8 : BitVec 12),
+    .SD .x12 .x0 (16 : BitVec 12),
+    .SD .x12 .x0 (24 : BitVec 12),
+    .BEQ .x11 .x0 (104 : BitVec 13),
+    .LBU .x5 .x10 (0 : BitVec 12),
+    .LI .x6 (128 : Word),
+    .BLTU .x5 .x6 (80 : BitVec 13),
+    .BEQ .x5 .x6 (80 : BitVec 13),
+    .LI .x6 (161 : Word),
+    .BGEU .x5 .x6 (80 : BitVec 13),
+    .LI .x6 (128 : Word),
+    .SUB .x7 .x5 .x6,
+    .ADDI .x28 .x11 (-1 : BitVec 12),
+    .BLTU .x28 .x7 (64 : BitVec 13),
+    .LI .x29 (32 : Word),
+    .SUB .x29 .x29 .x7,
+    .ADD .x30 .x12 .x29,
+    .ADDI .x31 .x10 (1 : BitVec 12),
+    .MV .x28 .x7,
+    .BEQ .x28 .x0 (32 : BitVec 13),
+    .LBU .x6 .x31 (0 : BitVec 12),
+    .SB .x30 .x6 (0 : BitVec 12),
+    .ADDI .x30 .x30 (1 : BitVec 12),
+    .ADDI .x31 .x31 (1 : BitVec 12),
+    .ADDI .x28 .x28 (-1 : BitVec 12),
+    .JAL .x0 (-24 : BitVec 21),
+    .SB .x12 .x5 (31 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (1 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def slotDecodeU256Function : String :=
+  "slot_decode_u256:\n" ++ emitProgram slotDecodeU256_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `slotDecodeU256_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem slotDecodeU256Function_eq_prog :
+    slotDecodeU256Function = "slot_decode_u256:\n" ++ emitProgram slotDecodeU256_prog := rfl
+
+#guard slotDecodeU256Function.startsWith "slot_decode_u256:\n"
+#guard slotDecodeU256_prog.length = 32
 def slotAtIndexFunction : String :=
   "slot_at_index:\n" ++
   "  addi sp, sp, -32\n" ++

--- a/EvmAsm/Codegen/Programs/SystemWrites.lean
+++ b/EvmAsm/Codegen/Programs/SystemWrites.lean
@@ -32,6 +32,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.AmsterdamSystemTx
 
 namespace EvmAsm.Codegen
@@ -39,72 +40,144 @@ namespace EvmAsm.Codegen
 open EvmAsm.Rv64
 
 /-! ## swd_read_u64le -- read a little-endian u64 byte-wise (a0=ptr -> a0). Leaf. -/
-def swdReadU64leFunction : String :=
-  "swd_read_u64le:\n" ++
-  "  lbu t0, 0(a0)\n" ++
-  "  lbu t1, 1(a0); slli t1, t1, 8;  or t0, t0, t1\n" ++
-  "  lbu t1, 2(a0); slli t1, t1, 16; or t0, t0, t1\n" ++
-  "  lbu t1, 3(a0); slli t1, t1, 24; or t0, t0, t1\n" ++
-  "  lbu t1, 4(a0); slli t1, t1, 32; or t0, t0, t1\n" ++
-  "  lbu t1, 5(a0); slli t1, t1, 40; or t0, t0, t1\n" ++
-  "  lbu t1, 6(a0); slli t1, t1, 48; or t0, t0, t1\n" ++
-  "  lbu t1, 7(a0); slli t1, t1, 56; or t0, t0, t1\n" ++
-  "  mv a0, t0\n" ++
-  "  ret"
+def swdReadU64le_prog : Program :=
+  [ .LBU .x5 .x10 (0 : BitVec 12),
+    .LBU .x6 .x10 (1 : BitVec 12),
+    .SLLI .x6 .x6 (8 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (2 : BitVec 12),
+    .SLLI .x6 .x6 (16 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (3 : BitVec 12),
+    .SLLI .x6 .x6 (24 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (4 : BitVec 12),
+    .SLLI .x6 .x6 (32 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (5 : BitVec 12),
+    .SLLI .x6 .x6 (40 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (6 : BitVec 12),
+    .SLLI .x6 .x6 (48 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (7 : BitVec 12),
+    .SLLI .x6 .x6 (56 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .MV .x10 .x5,
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def swdReadU64leFunction : String :=
+  "swd_read_u64le:\n" ++ emitProgram swdReadU64le_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `swdReadU64le_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem swdReadU64leFunction_eq_prog :
+    swdReadU64leFunction = "swd_read_u64le:\n" ++ emitProgram swdReadU64le_prog := rfl
+
+#guard swdReadU64leFunction.startsWith "swd_read_u64le:\n"
+#guard swdReadU64le_prog.length = 24
 /-! ## swd_write_be32_u64 -- write a0 (u64) big-endian into the LOW 8 bytes of a
     zeroed 32-byte buffer at a1 (the 32-byte storage slot key). Leaf. -/
+def swdWriteBe32U64_prog : Program :=
+  [ .LI .x5 (0 : Word),
+    .LI .x6 (32 : Word),
+    .BEQ .x5 .x6 (20 : BitVec 13),
+    .ADD .x7 .x11 .x5,
+    .SB .x7 .x0 (0 : BitVec 12),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (-20 : BitVec 21),
+    .LI .x5 (0 : Word),
+    .LI .x6 (8 : Word),
+    .BEQ .x5 .x6 (44 : BitVec 13),
+    .LI .x7 (56 : Word),
+    .SLLI .x28 .x5 (3 : BitVec 6),
+    .SUB .x7 .x7 .x28,
+    .SRL .x29 .x10 .x7,
+    .ANDI .x29 .x29 (255 : BitVec 12),
+    .ADDI .x30 .x11 (24 : BitVec 12),
+    .ADD .x30 .x30 .x5,
+    .SB .x30 .x29 (0 : BitVec 12),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (-44 : BitVec 21),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
+
 def swdWriteBe32U64Function : String :=
-  "swd_write_be32_u64:\n" ++
-  "  li t0, 0\n" ++
-  ".Lswd_z:\n" ++
-  "  li t1, 32; beq t0, t1, .Lswd_zd\n" ++
-  "  add t2, a1, t0; sb x0, 0(t2); addi t0, t0, 1; j .Lswd_z\n" ++
-  ".Lswd_zd:\n" ++
-  "  # write the 8 BE bytes into offsets 24..31\n" ++
-  "  li t0, 0\n" ++
-  ".Lswd_b:\n" ++
-  "  li t1, 8; beq t0, t1, .Lswd_bd\n" ++
-  "  li t2, 56; slli t3, t0, 3; sub t2, t2, t3   # shift = 56 - 8*t0\n" ++
-  "  srl t4, a0, t2; andi t4, t4, 0xff\n" ++
-  "  addi t5, a1, 24; add t5, t5, t0; sb t4, 0(t5)\n" ++
-  "  addi t0, t0, 1; j .Lswd_b\n" ++
-  ".Lswd_bd:\n" ++
-  "  ret"
+  "swd_write_be32_u64:\n" ++ emitProgram swdWriteBe32U64_prog
 
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `swdWriteBe32U64_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem swdWriteBe32U64Function_eq_prog :
+    swdWriteBe32U64Function = "swd_write_be32_u64:\n" ++ emitProgram swdWriteBe32U64_prog := rfl
+
+#guard swdWriteBe32U64Function.startsWith "swd_write_be32_u64:\n"
+#guard swdWriteBe32U64_prog.length = 21
 /-! ## swd_write_be8 -- write a0 (u64) big-endian into 8 bytes at a1. Leaf. -/
-def swdWriteBe8Function : String :=
-  "swd_write_be8:\n" ++
-  "  li t0, 0\n" ++
-  ".Lswd8:\n" ++
-  "  li t1, 8; beq t0, t1, .Lswd8d\n" ++
-  "  li t2, 56; slli t3, t0, 3; sub t2, t2, t3\n" ++
-  "  srl t4, a0, t2; andi t4, t4, 0xff\n" ++
-  "  add t5, a1, t0; sb t4, 0(t5)\n" ++
-  "  addi t0, t0, 1; j .Lswd8\n" ++
-  ".Lswd8d:\n" ++
-  "  ret"
+def swdWriteBe8_prog : Program :=
+  [ .LI .x5 (0 : Word),
+    .LI .x6 (8 : Word),
+    .BEQ .x5 .x6 (40 : BitVec 13),
+    .LI .x7 (56 : Word),
+    .SLLI .x28 .x5 (3 : BitVec 6),
+    .SUB .x7 .x7 .x28,
+    .SRL .x29 .x10 .x7,
+    .ANDI .x29 .x29 (255 : BitVec 12),
+    .ADD .x30 .x11 .x5,
+    .SB .x30 .x29 (0 : BitVec 12),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (-40 : BitVec 21),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def swdWriteBe8Function : String :=
+  "swd_write_be8:\n" ++ emitProgram swdWriteBe8_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `swdWriteBe8_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem swdWriteBe8Function_eq_prog :
+    swdWriteBe8Function = "swd_write_be8:\n" ++ emitProgram swdWriteBe8_prog := rfl
+
+#guard swdWriteBe8Function.startsWith "swd_write_be8:\n"
+#guard swdWriteBe8_prog.length = 13
 /-! ## swd_minimal_copy -- copy src[a0..a0+a1) stripping leading zero bytes into
     a2; write the resulting length to a3. Leaf. -/
-def swdMinimalCopyFunction : String :=
-  "swd_minimal_copy:\n" ++
-  "  mv t0, a0                   # src cursor\n" ++
-  "  mv t1, a1                   # remaining\n" ++
-  ".Lswd_skip:\n" ++
-  "  beqz t1, .Lswd_emit         # all zero -> length 0\n" ++
-  "  lbu t2, 0(t0); bnez t2, .Lswd_emit\n" ++
-  "  addi t0, t0, 1; addi t1, t1, -1; j .Lswd_skip\n" ++
-  ".Lswd_emit:\n" ++
-  "  sd t1, 0(a3)                # out length = remaining\n" ++
-  "  mv t3, a2; li t4, 0\n" ++
-  ".Lswd_cp:\n" ++
-  "  beq t4, t1, .Lswd_cpd\n" ++
-  "  add t5, t0, t4; lbu t6, 0(t5); add t2, t3, t4; sb t6, 0(t2)\n" ++
-  "  addi t4, t4, 1; j .Lswd_cp\n" ++
-  ".Lswd_cpd:\n" ++
-  "  ret"
+def swdMinimalCopy_prog : Program :=
+  [ .MV .x5 .x10,
+    .MV .x6 .x11,
+    .BEQ .x6 .x0 (24 : BitVec 13),
+    .LBU .x7 .x5 (0 : BitVec 12),
+    .BNE .x7 .x0 (16 : BitVec 13),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .ADDI .x6 .x6 (-1 : BitVec 12),
+    .JAL .x0 (-20 : BitVec 21),
+    .SD .x13 .x6 (0 : BitVec 12),
+    .MV .x28 .x12,
+    .LI .x29 (0 : Word),
+    .BEQ .x29 .x6 (28 : BitVec 13),
+    .ADD .x30 .x5 .x29,
+    .LBU .x31 .x30 (0 : BitVec 12),
+    .ADD .x7 .x28 .x29,
+    .SB .x7 .x31 (0 : BitVec 12),
+    .ADDI .x29 .x29 (1 : BitVec 12),
+    .JAL .x0 (-24 : BitVec 21),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def swdMinimalCopyFunction : String :=
+  "swd_minimal_copy:\n" ++ emitProgram swdMinimalCopy_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `swdMinimalCopy_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem swdMinimalCopyFunction_eq_prog :
+    swdMinimalCopyFunction = "swd_minimal_copy:\n" ++ emitProgram swdMinimalCopy_prog := rfl
+
+#guard swdMinimalCopyFunction.startsWith "swd_minimal_copy:\n"
+#guard swdMinimalCopy_prog.length = 19
 /-! ## system_write_descriptors
     a0 = SSZ_BASE.  Fills (slot_key 32 B, value, value_len) for EIP-2935 and
     EIP-4788 into swd_* buffers.  a0 (output) = 0. -/

--- a/EvmAsm/Codegen/Programs/Tx.lean
+++ b/EvmAsm/Codegen/Programs/Tx.lean
@@ -36,6 +36,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.HashBridge
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.RlpWalk
@@ -436,26 +437,35 @@ def ziskTxLegacyDecodeProbeUnit : BuildUnit := {
                     invalid v values just produce wrong
                     chain_id; the signing-hash check catches
                     them later) -/
-def deriveChainIdFromVFunction : String :=
-  "derive_chain_id_from_v:\n" ++
-  "  li t0, 27\n" ++
-  "  beq a0, t0, .Ldcid_pre155\n" ++
-  "  li t0, 28\n" ++
-  "  beq a0, t0, .Ldcid_pre155\n" ++
-  "  # EIP-155: chain_id = (v - 35) / 2\n" ++
-  "  addi t1, a0, -35\n" ++
-  "  srli t1, t1, 1\n" ++
-  "  sd t1, 0(a1)\n" ++
-  "  li t2, 1\n" ++
-  "  sd t2, 0(a2)\n" ++
-  "  li a0, 0\n" ++
-  "  ret\n" ++
-  ".Ldcid_pre155:\n" ++
-  "  sd zero, 0(a1)\n" ++
-  "  sd zero, 0(a2)\n" ++
-  "  li a0, 0\n" ++
-  "  ret"
+def deriveChainIdFromV_prog : Program :=
+  [ .LI .x5 (27 : Word),
+    .BEQ .x10 .x5 (40 : BitVec 13),
+    .LI .x5 (28 : Word),
+    .BEQ .x10 .x5 (32 : BitVec 13),
+    .ADDI .x6 .x10 (-35 : BitVec 12),
+    .SRLI .x6 .x6 (1 : BitVec 6),
+    .SD .x11 .x6 (0 : BitVec 12),
+    .LI .x7 (1 : Word),
+    .SD .x12 .x7 (0 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .SD .x11 .x0 (0 : BitVec 12),
+    .SD .x12 .x0 (0 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def deriveChainIdFromVFunction : String :=
+  "derive_chain_id_from_v:\n" ++ emitProgram deriveChainIdFromV_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `deriveChainIdFromV_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem deriveChainIdFromVFunction_eq_prog :
+    deriveChainIdFromVFunction = "derive_chain_id_from_v:\n" ++ emitProgram deriveChainIdFromV_prog := rfl
+
+#guard deriveChainIdFromVFunction.startsWith "derive_chain_id_from_v:\n"
+#guard deriveChainIdFromV_prog.length = 15
 /-- `zisk_derive_chain_id_from_v`: probe BuildUnit. Reads
     (v, padding) from host input, writes (chain_id, is_eip155)
     to OUTPUT. -/
@@ -604,23 +614,31 @@ def ziskBlobGasUsedFromVersionedHashesProbeUnit : BuildUnit := {
 
     Distinct codes let callers pinpoint which check fired
     without re-running individual asserts. -/
-def txValidateAgainstBlockFunction : String :=
-  "tx_validate_against_block:\n" ++
-  "  bne a0, a1, .Ltvab_fail_chain\n" ++
-  "  bgtu a2, a3, .Ltvab_fail_gas\n" ++
-  "  bne a4, a5, .Ltvab_fail_nonce\n" ++
-  "  li a0, 0\n" ++
-  "  ret\n" ++
-  ".Ltvab_fail_chain:\n" ++
-  "  li a0, 1\n" ++
-  "  ret\n" ++
-  ".Ltvab_fail_gas:\n" ++
-  "  li a0, 2\n" ++
-  "  ret\n" ++
-  ".Ltvab_fail_nonce:\n" ++
-  "  li a0, 3\n" ++
-  "  ret"
+def txValidateAgainstBlock_prog : Program :=
+  [ .BNE .x10 .x11 (20 : BitVec 13),
+    .BLTU .x13 .x12 (24 : BitVec 13),
+    .BNE .x14 .x15 (28 : BitVec 13),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (1 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (2 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (3 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def txValidateAgainstBlockFunction : String :=
+  "tx_validate_against_block:\n" ++ emitProgram txValidateAgainstBlock_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `txValidateAgainstBlock_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem txValidateAgainstBlockFunction_eq_prog :
+    txValidateAgainstBlockFunction = "tx_validate_against_block:\n" ++ emitProgram txValidateAgainstBlock_prog := rfl
+
+#guard txValidateAgainstBlockFunction.startsWith "tx_validate_against_block:\n"
+#guard txValidateAgainstBlock_prog.length = 11
 /-- `zisk_tx_validate_against_block`: probe BuildUnit. Reads
     (tx_chain, block_chain, tx_gas, block_gas, tx_nonce,
     account_nonce) as 6 u64 LE words from host input, writes

--- a/EvmAsm/Codegen/Programs/TxExtract.lean
+++ b/EvmAsm/Codegen/Programs/TxExtract.lean
@@ -23,6 +23,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.RlpWalk
 import EvmAsm.Codegen.Programs.Tx
@@ -72,60 +73,65 @@ private def txExtractWalkFieldAsm (failLabel : String) (n : Nat) : String :=
       a0 (output) : 0 success / 1 unknown / empty input
 
     Leaf-callable, no scratch. -/
-def txTypeDispatchFunction : String :=
-  "tx_type_dispatch:\n" ++
-  "  beqz a1, .Ltd_fail\n" ++
-  "  lbu t0, 0(a0)\n" ++
-  "  li t1, 0xc0\n" ++
-  "  bgeu t0, t1, .Ltd_legacy\n" ++
-  "  li t1, 1\n" ++
-  "  beq t0, t1, .Ltd_t1\n" ++
-  "  li t1, 2\n" ++
-  "  beq t0, t1, .Ltd_t2\n" ++
-  "  li t1, 3\n" ++
-  "  beq t0, t1, .Ltd_t3\n" ++
-  "  li t1, 4\n" ++
-  "  beq t0, t1, .Ltd_t4\n" ++
-  "  j .Ltd_fail\n" ++
-  ".Ltd_legacy:\n" ++
-  "  sd zero, 0(a2)\n" ++
-  "  sd zero, 0(a3)\n" ++
-  "  li a0, 0\n" ++
-  "  ret\n" ++
-  ".Ltd_t1:\n" ++
-  "  li t0, 1\n" ++
-  "  sd t0, 0(a2)\n" ++
-  "  li t1, 1\n" ++
-  "  sd t1, 0(a3)\n" ++
-  "  li a0, 0\n" ++
-  "  ret\n" ++
-  ".Ltd_t2:\n" ++
-  "  li t0, 2\n" ++
-  "  sd t0, 0(a2)\n" ++
-  "  li t1, 1\n" ++
-  "  sd t1, 0(a3)\n" ++
-  "  li a0, 0\n" ++
-  "  ret\n" ++
-  ".Ltd_t3:\n" ++
-  "  li t0, 3\n" ++
-  "  sd t0, 0(a2)\n" ++
-  "  li t1, 1\n" ++
-  "  sd t1, 0(a3)\n" ++
-  "  li a0, 0\n" ++
-  "  ret\n" ++
-  ".Ltd_t4:\n" ++
-  "  li t0, 4\n" ++
-  "  sd t0, 0(a2)\n" ++
-  "  li t1, 1\n" ++
-  "  sd t1, 0(a3)\n" ++
-  "  li a0, 0\n" ++
-  "  ret\n" ++
-  ".Ltd_fail:\n" ++
-  "  sd zero, 0(a2)\n" ++
-  "  sd zero, 0(a3)\n" ++
-  "  li a0, 1\n" ++
-  "  ret"
+def txTypeDispatch_prog : Program :=
+  [ .BEQ .x11 .x0 (164 : BitVec 13),
+    .LBU .x5 .x10 (0 : BitVec 12),
+    .LI .x6 (192 : Word),
+    .BGEU .x5 .x6 (40 : BitVec 13),
+    .LI .x6 (1 : Word),
+    .BEQ .x5 .x6 (48 : BitVec 13),
+    .LI .x6 (2 : Word),
+    .BEQ .x5 .x6 (64 : BitVec 13),
+    .LI .x6 (3 : Word),
+    .BEQ .x5 .x6 (80 : BitVec 13),
+    .LI .x6 (4 : Word),
+    .BEQ .x5 .x6 (96 : BitVec 13),
+    .JAL .x0 (116 : BitVec 21),
+    .SD .x12 .x0 (0 : BitVec 12),
+    .SD .x13 .x0 (0 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x5 (1 : Word),
+    .SD .x12 .x5 (0 : BitVec 12),
+    .LI .x6 (1 : Word),
+    .SD .x13 .x6 (0 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x5 (2 : Word),
+    .SD .x12 .x5 (0 : BitVec 12),
+    .LI .x6 (1 : Word),
+    .SD .x13 .x6 (0 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x5 (3 : Word),
+    .SD .x12 .x5 (0 : BitVec 12),
+    .LI .x6 (1 : Word),
+    .SD .x13 .x6 (0 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x5 (4 : Word),
+    .SD .x12 .x5 (0 : BitVec 12),
+    .LI .x6 (1 : Word),
+    .SD .x13 .x6 (0 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .SD .x12 .x0 (0 : BitVec 12),
+    .SD .x13 .x0 (0 : BitVec 12),
+    .LI .x10 (1 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def txTypeDispatchFunction : String :=
+  "tx_type_dispatch:\n" ++ emitProgram txTypeDispatch_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `txTypeDispatch_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem txTypeDispatchFunction_eq_prog :
+    txTypeDispatchFunction = "tx_type_dispatch:\n" ++ emitProgram txTypeDispatch_prog := rfl
+
+#guard txTypeDispatchFunction.startsWith "tx_type_dispatch:\n"
+#guard txTypeDispatch_prog.length = 45
 /-- `zisk_tx_type_dispatch`: probe BuildUnit. -/
 def ziskTxTypeDispatchPrologue : String :=
   "  li sp, 0xa0050000\n" ++

--- a/EvmAsm/Codegen/Programs/TxPubkey.lean
+++ b/EvmAsm/Codegen/Programs/TxPubkey.lean
@@ -8,6 +8,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.Tx
 import EvmAsm.Codegen.Programs.TxExtract
 import EvmAsm.Codegen.Programs.TxSignature
@@ -230,47 +231,64 @@ def txPubkeySignatureMaterialFunction : String :=
     Scalar and signing-hash validity are owned by `tx_pubkey_signature_material`;
     this helper is deliberately just the ABI staging layer for the later recovery
     and compare slices. -/
-def txPubkeyEcrecoverStageMaterialFunction : String :=
-  "tx_pubkey_ecrecover_stage_material:\n" ++
-  "  addi sp, sp, -32\n" ++
-  "  sd s0,  0(sp); sd s1,  8(sp); sd s2, 16(sp); sd s3, 24(sp)\n" ++
-  "  mv s0, a0                   # material ptr\n" ++
-  "  mv s1, a1                   # staging ptr\n" ++
-  "  ld s2, 8(s0)                # recid\n" ++
-  "  li t0, 1\n" ++
-  "  bgtu s2, t0, .Ltpes_bad_recid\n" ++
-  "  # message hash = material.signing_hash\n" ++
-  "  addi t0, s0, 80\n" ++
-  "  mv t1, s1\n" ++
-  "  li t2, 4\n" ++
-  ".Ltpes_copy_hash:\n" ++
-  "  ld t3, 0(t0); sd t3, 0(t1)\n" ++
-  "  addi t0, t0, 8; addi t1, t1, 8; addi t2, t2, -1\n" ++
-  "  bnez t2, .Ltpes_copy_hash\n" ++
-  "  # signature = r || s\n" ++
-  "  addi t0, s0, 16\n" ++
-  "  addi t1, s1, 32\n" ++
-  "  li t2, 8\n" ++
-  ".Ltpes_copy_sig:\n" ++
-  "  ld t3, 0(t0); sd t3, 0(t1)\n" ++
-  "  addi t0, t0, 8; addi t1, t1, 8; addi t2, t2, -1\n" ++
-  "  bnez t2, .Ltpes_copy_sig\n" ++
-  "  sd s2, 96(s1)\n" ++
-  "  addi t1, s1, 104\n" ++
-  "  li t2, 8\n" ++
-  ".Ltpes_zero_pubkey:\n" ++
-  "  sd zero, 0(t1)\n" ++
-  "  addi t1, t1, 8; addi t2, t2, -1\n" ++
-  "  bnez t2, .Ltpes_zero_pubkey\n" ++
-  "  li a0, 0\n" ++
-  "  j .Ltpes_ret\n" ++
-  ".Ltpes_bad_recid:\n" ++
-  "  li a0, 1\n" ++
-  ".Ltpes_ret:\n" ++
-  "  ld s0,  0(sp); ld s1,  8(sp); ld s2, 16(sp); ld s3, 24(sp)\n" ++
-  "  addi sp, sp, 32\n" ++
-  "  ret"
+def txPubkeyEcrecoverStageMaterial_prog : Program :=
+  [ .ADDI .x2 .x2 (-32 : BitVec 12),
+    .SD .x2 .x8 (0 : BitVec 12),
+    .SD .x2 .x9 (8 : BitVec 12),
+    .SD .x2 .x18 (16 : BitVec 12),
+    .SD .x2 .x19 (24 : BitVec 12),
+    .MV .x8 .x10,
+    .MV .x9 .x11,
+    .LD .x18 .x8 (8 : BitVec 12),
+    .LI .x5 (1 : Word),
+    .BLTU .x5 .x18 (112 : BitVec 13),
+    .ADDI .x5 .x8 (80 : BitVec 12),
+    .MV .x6 .x9,
+    .LI .x7 (4 : Word),
+    .LD .x28 .x5 (0 : BitVec 12),
+    .SD .x6 .x28 (0 : BitVec 12),
+    .ADDI .x5 .x5 (8 : BitVec 12),
+    .ADDI .x6 .x6 (8 : BitVec 12),
+    .ADDI .x7 .x7 (-1 : BitVec 12),
+    .BNE .x7 .x0 (-20 : BitVec 13),
+    .ADDI .x5 .x8 (16 : BitVec 12),
+    .ADDI .x6 .x9 (32 : BitVec 12),
+    .LI .x7 (8 : Word),
+    .LD .x28 .x5 (0 : BitVec 12),
+    .SD .x6 .x28 (0 : BitVec 12),
+    .ADDI .x5 .x5 (8 : BitVec 12),
+    .ADDI .x6 .x6 (8 : BitVec 12),
+    .ADDI .x7 .x7 (-1 : BitVec 12),
+    .BNE .x7 .x0 (-20 : BitVec 13),
+    .SD .x9 .x18 (96 : BitVec 12),
+    .ADDI .x6 .x9 (104 : BitVec 12),
+    .LI .x7 (8 : Word),
+    .SD .x6 .x0 (0 : BitVec 12),
+    .ADDI .x6 .x6 (8 : BitVec 12),
+    .ADDI .x7 .x7 (-1 : BitVec 12),
+    .BNE .x7 .x0 (-12 : BitVec 13),
+    .LI .x10 (0 : Word),
+    .JAL .x0 (8 : BitVec 21),
+    .LI .x10 (1 : Word),
+    .LD .x8 .x2 (0 : BitVec 12),
+    .LD .x9 .x2 (8 : BitVec 12),
+    .LD .x18 .x2 (16 : BitVec 12),
+    .LD .x19 .x2 (24 : BitVec 12),
+    .ADDI .x2 .x2 (32 : BitVec 12),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def txPubkeyEcrecoverStageMaterialFunction : String :=
+  "tx_pubkey_ecrecover_stage_material:\n" ++ emitProgram txPubkeyEcrecoverStageMaterial_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `txPubkeyEcrecoverStageMaterial_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem txPubkeyEcrecoverStageMaterialFunction_eq_prog :
+    txPubkeyEcrecoverStageMaterialFunction = "tx_pubkey_ecrecover_stage_material:\n" ++ emitProgram txPubkeyEcrecoverStageMaterial_prog := rfl
+
+#guard txPubkeyEcrecoverStageMaterialFunction.startsWith "tx_pubkey_ecrecover_stage_material:\n"
+#guard txPubkeyEcrecoverStageMaterial_prog.length = 44
 /-! ## tx_pubkey_recover_raw
 
     Callable recovered-key helper surface. Mirrors execution-specs Amsterdam

--- a/EvmAsm/Codegen/Programs/TxRefund.lean
+++ b/EvmAsm/Codegen/Programs/TxRefund.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Rv64.Program
 
 namespace EvmAsm.Codegen
@@ -30,34 +31,42 @@ open EvmAsm.Rv64
                     +24 gas_used_after_refund
       a0 output : 0 success, 1 invalid gas_left > tx_gas_limit
 -/
-def txRefundCapFunction : String :=
-  "tx_refund_cap:\n" ++
-  "  bltu a0, a1, .Ltrc_invalid\n" ++
-  "  sub t0, a0, a1              # gas_used_before_refund\n" ++
-  "  sd t0, 0(a3)\n" ++
-  "  li t1, 5\n" ++
-  "  divu t2, t0, t1             # one-fifth cap\n" ++
-  "  sd t2, 8(a3)\n" ++
-  "  mv t3, a2\n" ++
-  "  bltu t2, t3, .Ltrc_use_cap\n" ++
-  "  mv t4, t3\n" ++
-  "  j .Ltrc_apply\n" ++
-  ".Ltrc_use_cap:\n" ++
-  "  mv t4, t2\n" ++
-  ".Ltrc_apply:\n" ++
-  "  sd t4, 16(a3)\n" ++
-  "  sub t5, t0, t4\n" ++
-  "  sd t5, 24(a3)\n" ++
-  "  li a0, 0\n" ++
-  "  ret\n" ++
-  ".Ltrc_invalid:\n" ++
-  "  sd zero, 0(a3)\n" ++
-  "  sd zero, 8(a3)\n" ++
-  "  sd zero, 16(a3)\n" ++
-  "  sd zero, 24(a3)\n" ++
-  "  li a0, 1\n" ++
-  "  ret"
+def txRefundCap_prog : Program :=
+  [ .BLTU .x10 .x11 (64 : BitVec 13),
+    .SUB .x5 .x10 .x11,
+    .SD .x13 .x5 (0 : BitVec 12),
+    .LI .x6 (5 : Word),
+    .DIVU .x7 .x5 .x6,
+    .SD .x13 .x7 (8 : BitVec 12),
+    .MV .x28 .x12,
+    .BLTU .x7 .x28 (12 : BitVec 13),
+    .MV .x29 .x28,
+    .JAL .x0 (8 : BitVec 21),
+    .MV .x29 .x7,
+    .SD .x13 .x29 (16 : BitVec 12),
+    .SUB .x30 .x5 .x29,
+    .SD .x13 .x30 (24 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .SD .x13 .x0 (0 : BitVec 12),
+    .SD .x13 .x0 (8 : BitVec 12),
+    .SD .x13 .x0 (16 : BitVec 12),
+    .SD .x13 .x0 (24 : BitVec 12),
+    .LI .x10 (1 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def txRefundCapFunction : String :=
+  "tx_refund_cap:\n" ++ emitProgram txRefundCap_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `txRefundCap_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem txRefundCapFunction_eq_prog :
+    txRefundCapFunction = "tx_refund_cap:\n" ++ emitProgram txRefundCap_prog := rfl
+
+#guard txRefundCapFunction.startsWith "tx_refund_cap:\n"
+#guard txRefundCap_prog.length = 22
 /-- `zisk_tx_refund_cap`: probe BuildUnit.
 
     Input: 24 bytes `(tx_gas_limit, gas_left, refund_counter)`.

--- a/EvmAsm/Codegen/Programs/WitnessValidation.lean
+++ b/EvmAsm/Codegen/Programs/WitnessValidation.lean
@@ -18,6 +18,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.Mpt
 import EvmAsm.Codegen.Programs.HashBridge
@@ -209,60 +210,74 @@ def ziskWitnessStateValidateNodeKindsProbeUnit : BuildUnit := {
         0 = all entries within cap (or empty section)
         1 = some entry exceeds `max_byte_length`
 -/
-def witnessCodesValidateLengthsFunction : String :=
-  "witness_codes_validate_lengths:\n" ++
-  "  addi sp, sp, -64\n" ++
-  "  sd ra,  0(sp)\n" ++
-  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
-  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
-  "  mv s0, a0                  # section ptr\n" ++
-  "  mv s1, a1                  # section_len\n" ++
-  "  mv s2, a2                  # max_byte_length\n" ++
-  "  mv s3, a3                  # n_processed out\n" ++
-  "  mv s4, a4                  # first_bad_index out\n" ++
-  "  sd zero, 0(s3)\n" ++
-  "  li t0, -1\n" ++
-  "  sd t0, 0(s4)\n" ++
-  "  beqz s1, .Lwcvl_ok           # empty section ⇒ vacuous-valid\n" ++
-  "  lwu t0, 0(s0)\n" ++
-  "  srli s5, t0, 2               # s5 = N\n" ++
-  "  li s6, 0                     # s6 = i\n" ++
-  ".Lwcvl_loop:\n" ++
-  "  beq s6, s5, .Lwcvl_ok\n" ++
-  "  # Element i bounds.\n" ++
-  "  slli t0, s6, 2\n" ++
-  "  add t1, s0, t0\n" ++
-  "  lwu t2, 0(t1)                # inner_off_i\n" ++
-  "  addi t3, s6, 1\n" ++
-  "  beq t3, s5, .Lwcvl_use_end\n" ++
-  "  slli t3, t3, 2\n" ++
-  "  add t3, s0, t3\n" ++
-  "  lwu t4, 0(t3)                # inner_off_{i+1}\n" ++
-  "  sub t5, t4, t2               # el_i_len\n" ++
-  "  j .Lwcvl_check\n" ++
-  ".Lwcvl_use_end:\n" ++
-  "  sub t5, s1, t2               # el_i_len = section_len - inner_off_i\n" ++
-  ".Lwcvl_check:\n" ++
-  "  bgtu t5, s2, .Lwcvl_too_long\n" ++
-  "  addi s6, s6, 1\n" ++
-  "  j .Lwcvl_loop\n" ++
-  ".Lwcvl_too_long:\n" ++
-  "  sd s6, 0(s3)                 # n_processed = i\n" ++
-  "  sd s6, 0(s4)                 # first_bad_index = i\n" ++
-  "  li a0, 1\n" ++
-  "  j .Lwcvl_ret\n" ++
-  ".Lwcvl_ok:\n" ++
-  "  sd s5, 0(s3)                 # n_processed = N\n" ++
-  "  li t0, -1\n" ++
-  "  sd t0, 0(s4)\n" ++
-  "  li a0, 0\n" ++
-  ".Lwcvl_ret:\n" ++
-  "  ld ra,  0(sp)\n" ++
-  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
-  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
-  "  addi sp, sp, 64\n" ++
-  "  ret"
+def witnessCodesValidateLengths_prog : Program :=
+  [ .ADDI .x2 .x2 (-64 : BitVec 12),
+    .SD .x2 .x1 (0 : BitVec 12),
+    .SD .x2 .x8 (8 : BitVec 12),
+    .SD .x2 .x9 (16 : BitVec 12),
+    .SD .x2 .x18 (24 : BitVec 12),
+    .SD .x2 .x19 (32 : BitVec 12),
+    .SD .x2 .x20 (40 : BitVec 12),
+    .SD .x2 .x21 (48 : BitVec 12),
+    .SD .x2 .x22 (56 : BitVec 12),
+    .MV .x8 .x10,
+    .MV .x9 .x11,
+    .MV .x18 .x12,
+    .MV .x19 .x13,
+    .MV .x20 .x14,
+    .SD .x19 .x0 (0 : BitVec 12),
+    .LI .x5 (-1 : Word),
+    .SD .x20 .x5 (0 : BitVec 12),
+    .BEQ .x9 .x0 (92 : BitVec 13),
+    .LWU .x5 .x8 (0 : BitVec 12),
+    .SRLI .x21 .x5 (2 : BitVec 6),
+    .LI .x22 (0 : Word),
+    .BEQ .x22 .x21 (76 : BitVec 13),
+    .SLLI .x5 .x22 (2 : BitVec 6),
+    .ADD .x6 .x8 .x5,
+    .LWU .x7 .x6 (0 : BitVec 12),
+    .ADDI .x28 .x22 (1 : BitVec 12),
+    .BEQ .x28 .x21 (24 : BitVec 13),
+    .SLLI .x28 .x28 (2 : BitVec 6),
+    .ADD .x28 .x8 .x28,
+    .LWU .x29 .x28 (0 : BitVec 12),
+    .SUB .x30 .x29 .x7,
+    .JAL .x0 (8 : BitVec 21),
+    .SUB .x30 .x9 .x7,
+    .BLTU .x18 .x30 (12 : BitVec 13),
+    .ADDI .x22 .x22 (1 : BitVec 12),
+    .JAL .x0 (-56 : BitVec 21),
+    .SD .x19 .x22 (0 : BitVec 12),
+    .SD .x20 .x22 (0 : BitVec 12),
+    .LI .x10 (1 : Word),
+    .JAL .x0 (20 : BitVec 21),
+    .SD .x19 .x21 (0 : BitVec 12),
+    .LI .x5 (-1 : Word),
+    .SD .x20 .x5 (0 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .LD .x1 .x2 (0 : BitVec 12),
+    .LD .x8 .x2 (8 : BitVec 12),
+    .LD .x9 .x2 (16 : BitVec 12),
+    .LD .x18 .x2 (24 : BitVec 12),
+    .LD .x19 .x2 (32 : BitVec 12),
+    .LD .x20 .x2 (40 : BitVec 12),
+    .LD .x21 .x2 (48 : BitVec 12),
+    .LD .x22 .x2 (56 : BitVec 12),
+    .ADDI .x2 .x2 (64 : BitVec 12),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def witnessCodesValidateLengthsFunction : String :=
+  "witness_codes_validate_lengths:\n" ++ emitProgram witnessCodesValidateLengths_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `witnessCodesValidateLengths_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem witnessCodesValidateLengthsFunction_eq_prog :
+    witnessCodesValidateLengthsFunction = "witness_codes_validate_lengths:\n" ++ emitProgram witnessCodesValidateLengths_prog := rfl
+
+#guard witnessCodesValidateLengthsFunction.startsWith "witness_codes_validate_lengths:\n"
+#guard witnessCodesValidateLengths_prog.length = 54
 /-- `zisk_witness_codes_validate_lengths`: probe BuildUnit.
     Input layout (at INPUT_ADDR):
       bytes  0.. 8 : (ziskemu metadata)

--- a/docs/4ch8f-asm-to-program-coverage.md
+++ b/docs/4ch8f-asm-to-program-coverage.md
@@ -8,24 +8,131 @@ Every `*Function : String` def under `EvmAsm/Codegen/Programs/` and `EvmAsm/Code
 
 | Class | Count | Meaning |
 |---|---:|---|
-| BLOCKED_ON_.6 | 550 | Contains `la <symbol>` scratch/global addressing or a cross-function `jal <callee>` — needs the authoritative linker-pinned address table (bead evm-asm-4ch8f.6). |
+| BLOCKED_ON_.6 | 548 | Contains `la <symbol>` scratch/global addressing or a cross-function `jal <callee>` — needs the authoritative linker-pinned address table (bead evm-asm-4ch8f.6). |
 | COMPOSITE | 139 | RHS is not a pure string literal (concatenates other defs / probe prologues / data sections) — not a standalone routine body. **No wave bead needed:** these resolve automatically as their component functions convert. |
-| CONVERTED-CLEAN | 111 | Parses to a `Program`; the `emitProgram` render assembles `.text`-identically to the original hand-written text. Directly landable. |
-| ALREADY-STRUCTURED | 23 | RHS is already `"label:\n" ++ emitProgram <prog>` — a landed conversion (this PR: 16) or a prior template splice (RlpWalk, *SAsm). |
+| ALREADY-STRUCTURED | 132 | RHS is already `"label:\n" ++ emitProgram <prog>` — a landed conversion (this PR: 16) or a prior template splice (RlpWalk, *SAsm). |
 | NEEDS-LI-EXPANSION | 20 | Contains an `li rd, C` with C outside 12-bit signed range; a faithful 4-byte-per-`Instr` Program must emit the explicit `lui`/`addiw`/… expansion as separate `Instr`s (follow-up wave). |
 | CALLER-LOCAL-FRAGMENT | 8 | Branches/jumps to a `.L` label owned by the caller, or has no own entry label — no independent ABI; needs extraction into a status-returning callable first. |
+| MULTI-ENTRY-BUNDLE | 4 | Defines secondary non-`.L` labels (e.g. `*_clear`/`*_append`/`*_record_nth`) that other files `jal` into as cross-function entry points; `emitProgram` keeps only the entry label, so converting would silently break the guest link (caught only by the whole-guest byte-identity gate). Needs a multi-entry ABI / the .6 layout. |
 | **TOTAL** | **851** | |
 
-## Landed in this PR (16)
+## Landed in this PR (125)
 
 | Function | File | Instrs |
 |---|---|---:|
+| `b1SenderTableFindFunction` | `EvmAsm/Codegen/Programs/BlockVerdictSenderCounts.lean` | 0 |
+| `bahU32leFunction` | `EvmAsm/Codegen/Programs/BlockAccessListHash.lean` | 0 |
+| `bgvU32leFunction` | `EvmAsm/Codegen/Programs/BalGasValid.lean` | 0 |
+| `bgvU64leFunction` | `EvmAsm/Codegen/Programs/BalGasValid.lean` | 0 |
+| `bhrRevLeBeFunction` | `EvmAsm/Codegen/Programs/BlockHeaderSszToRlp.lean` | 0 |
+| `blake2fLdLe64Function` | `EvmAsm/Codegen/Programs/Blake2f.lean` | 0 |
+| `blake2fStLe64Function` | `EvmAsm/Codegen/Programs/Blake2f.lean` | 0 |
 | `bloomEqFunction` | `EvmAsm/Codegen/Programs/Bloom.lean` | 0 |
 | `bloomOrIntoFunction` | `EvmAsm/Codegen/Programs/Bloom.lean` | 0 |
+| `bls12CopyQuadsFunction` | `EvmAsm/Codegen/Programs/Bls12Field.lean` | 0 |
+| `bls12Fq12CopyFunction` | `EvmAsm/Codegen/Programs/Bls12Fq12.lean` | 0 |
+| `bls12Fq12EqFunction` | `EvmAsm/Codegen/Programs/Bls12Fq12.lean` | 0 |
+| `bls12Fq12IsZeroFunction` | `EvmAsm/Codegen/Programs/Bls12Fq12.lean` | 0 |
+| `bls12Fq12ZeroFunction` | `EvmAsm/Codegen/Programs/Bls12Fq12.lean` | 0 |
+| `bls12G1BeToLeFunction` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 0 |
+| `bls12G1Copy96Function` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 0 |
+| `bls12G1Eq48Function` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 0 |
+| `bls12G1IsZeroFunction` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 0 |
+| `bls12G1LeToBeFunction` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 0 |
+| `bls12G1Zero96Function` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 0 |
+| `bls12G2EqNFunction` | `EvmAsm/Codegen/Programs/Bls12G2.lean` | 0 |
+| `bls12G2Zero192Function` | `EvmAsm/Codegen/Programs/Bls12G2.lean` | 0 |
+| `bls12KzgG1WireFunction` | `EvmAsm/Codegen/Programs/Bls12Kzg.lean` | 0 |
+| `bls12KzgLtBeFunction` | `EvmAsm/Codegen/Programs/Bls12Kzg.lean` | 0 |
+| `bls12PtCopyFunction` | `EvmAsm/Codegen/Programs/Bls12Pairing.lean` | 0 |
+| `bn254CallAllotmentFunction` | `EvmAsm/Codegen/Programs/Bn254Curve.lean` | 0 |
+| `bn254FieldBeToLeFunction` | `EvmAsm/Codegen/Programs/Bn254Field.lean` | 0 |
+| `bn254FieldEq32Function` | `EvmAsm/Codegen/Programs/Bn254Field.lean` | 0 |
+| `bn254FieldIsZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Field.lean` | 0 |
+| `bn254FieldLeToBeFunction` | `EvmAsm/Codegen/Programs/Bn254Field.lean` | 0 |
+| `bn254Fp2CopyFunction` | `EvmAsm/Codegen/Programs/Bn254Fp2.lean` | 0 |
+| `bn254Fp2EqFunction` | `EvmAsm/Codegen/Programs/Bn254Fp2.lean` | 0 |
+| `bn254Fp2IsZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Fp2.lean` | 0 |
+| `bn254Fp2ZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Fp2.lean` | 0 |
+| `bn254Fq12CopyFunction` | `EvmAsm/Codegen/Programs/Bn254Fq12.lean` | 0 |
+| `bn254Fq12EqFunction` | `EvmAsm/Codegen/Programs/Bn254Fq12.lean` | 0 |
+| `bn254Fq12IsZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Fq12.lean` | 0 |
+| `bn254Fq12ZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Fq12.lean` | 0 |
+| `bn254PointCopy64Function` | `EvmAsm/Codegen/Programs/Bn254Curve.lean` | 0 |
+| `bn254PointIsInfFunction` | `EvmAsm/Codegen/Programs/Bn254Curve.lean` | 0 |
+| `bn254PointZero64Function` | `EvmAsm/Codegen/Programs/Bn254Curve.lean` | 0 |
+| `bn254PtCopyFunction` | `EvmAsm/Codegen/Programs/Bn254Pairing.lean` | 0 |
+| `bytesToNibblesFunction` | `EvmAsm/Codegen/Programs/Mpt.lean` | 0 |
+| `calcExcessBlobGasFunction` | `EvmAsm/Codegen/Programs/Header.lean` | 0 |
+| `callFrameSetCalldataFunction` | `EvmAsm/Codegen/Programs/CallFrameDescend.lean` | 0 |
+| `calldataByteCountsFunction` | `EvmAsm/Codegen/Programs/IntrinsicGas.lean` | 0 |
+| `codesBlockhashRequiredHeadersFunction` | `EvmAsm/Codegen/Programs/BlockhashRequiredHeaders.lean` | 0 |
+| `committedStorageChunkedSnapshotUpsertFunction` | `EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean` | 0 |
+| `committedStorageSnapshotAppendFunction` | `EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean` | 0 |
+| `committedStorageSnapshotUpsertFunction` | `EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean` | 0 |
+| `copyWordGasFunction` | `EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean` | 0 |
+| `deriveChainIdFromVFunction` | `EvmAsm/Codegen/Programs/Tx.lean` | 0 |
+| `eip8037BlockGasUsedFunction` | `EvmAsm/Codegen/Programs/IntrinsicGas.lean` | 0 |
+| `enrgU32leFunction` | `EvmAsm/Codegen/Programs/Eip7702NonceReuseGuard.lean` | 0 |
+| `ephU32leFunction` | `EvmAsm/Codegen/Programs/SszParentHeader.lean` | 0 |
+| `execLogLatestValueFunction` | `EvmAsm/Codegen/Programs/ExecLogLatestValue.lean` | 0 |
+| `expGasFunction` | `EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean` | 0 |
+| `findCodeEffectByAddressFunction` | `EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean` | 0 |
+| `headersParentHashFunction` | `EvmAsm/Codegen/Programs/HeadersKeccak.lean` | 0 |
+| `hpDecodeNibblesFunction` | `EvmAsm/Codegen/Programs/Mpt.lean` | 0 |
+| `hpEncodeNibblesFunction` | `EvmAsm/Codegen/Programs/Mpt.lean` | 0 |
+| `initCodeCostFunction` | `EvmAsm/Codegen/Programs/IntrinsicGas.lean` | 0 |
+| `intrinsicGasCalldataFloorEip7623Function` | `EvmAsm/Codegen/Programs/IntrinsicGas.lean` | 0 |
+| `keccak256WordGasFunction` | `EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean` | 0 |
+| `logDataGasFunction` | `EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean` | 0 |
+| `memoryExpansionGasFunction` | `EvmAsm/Codegen/Programs/MemoryExpansionGas.lean` | 0 |
+| `mptBranchPayloadTwoSlotsFunction` | `EvmAsm/Codegen/Programs/MptEncode.lean` | 0 |
+| `mptCompactToNibblesFunction` | `EvmAsm/Codegen/Programs/MptNibbles.lean` | 0 |
+| `mptNibblesToCompactFunction` | `EvmAsm/Codegen/Programs/MptNibbles.lean` | 0 |
 | `msetMemcpyFunction` | `EvmAsm/Codegen/Programs/MptSet.lean` | 0 |
 | `nibblesCommonPrefixLenFunction` | `EvmAsm/Codegen/Programs/MptEncode.lean` | 0 |
+| `p256BeToLeFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 0 |
+| `p256CopyNFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 0 |
+| `p256Eq32Function` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 0 |
+| `p256IsZeroNFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 0 |
+| `p256LeToBeFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 0 |
+| `p256LtBeFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 0 |
+| `parentHeaderMatchesWitnessFirstFunction` | `EvmAsm/Codegen/Programs/BlockHashPredicates.lean` | 0 |
+| `rlpBytesEncodedSizeFunction` | `EvmAsm/Codegen/Programs/BlockRlpSize.lean` | 0 |
+| `rlpEncodeBytesFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 0 |
+| `rlpEncodeListPrefixFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 0 |
+| `rlpEncodeU64Function` | `EvmAsm/Codegen/Programs/Receipt.lean` | 0 |
+| `rlpEncodeUintBeFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 0 |
+| `rlpListCountItemsFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 0 |
+| `rlpListEncodedSizeFunction` | `EvmAsm/Codegen/Programs/BlockRlpSize.lean` | 0 |
+| `rlpListNthItemFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 0 |
 | `runningBloomCopyFunction` | `EvmAsm/Codegen/Programs/Bloom.lean` | 0 |
 | `runningBloomZeroFunction` | `EvmAsm/Codegen/Programs/Bloom.lean` | 0 |
+| `secp256k1FieldBeToLeFunction` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 0 |
+| `secp256k1FieldCopy32Function` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 0 |
+| `secp256k1FieldEq32Function` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 0 |
+| `secp256k1FieldGetBitFunction` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 0 |
+| `secp256k1FieldIsZeroFunction` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 0 |
+| `secp256k1FieldLeToBeFunction` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 0 |
+| `secp256k1FieldZero32Function` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 0 |
+| `secp256k1PointCopy64Function` | `EvmAsm/Codegen/Programs/Secp256k1Curve.lean` | 0 |
+| `secp256k1PointZero64Function` | `EvmAsm/Codegen/Programs/Secp256k1Curve.lean` | 0 |
+| `senderPostNonceConsistentFunction` | `EvmAsm/Codegen/Programs/SenderPostNonceConsistent.lean` | 0 |
+| `slotDecodeU256Function` | `EvmAsm/Codegen/Programs/State.lean` | 0 |
+| `slotTupleSequencesMatchFunction` | `EvmAsm/Codegen/Programs/SlotTupleSequencesMatch.lean` | 0 |
+| `spwU32leFunction` | `EvmAsm/Codegen/Programs/SszPayloadWithdrawals.lean` | 0 |
+| `sszPackBytesFunction` | `EvmAsm/Codegen/Programs/Ssz.lean` | 0 |
+| `swdMinimalCopyFunction` | `EvmAsm/Codegen/Programs/SystemWrites.lean` | 0 |
+| `swdReadU64leFunction` | `EvmAsm/Codegen/Programs/SystemWrites.lean` | 0 |
+| `swdWriteBe32U64Function` | `EvmAsm/Codegen/Programs/SystemWrites.lean` | 0 |
+| `swdWriteBe8Function` | `EvmAsm/Codegen/Programs/SystemWrites.lean` | 0 |
+| `swrRevLeBeFunction` | `EvmAsm/Codegen/Programs/SszWithdrawal.lean` | 0 |
+| `swsU32leFunction` | `EvmAsm/Codegen/Programs/SszWitnessState.lean` | 0 |
+| `txGasResultIncrementsFunction` | `EvmAsm/Codegen/Programs/Account.lean` | 0 |
+| `txPubkeyEcrecoverStageMaterialFunction` | `EvmAsm/Codegen/Programs/TxPubkey.lean` | 0 |
+| `txRefundCapFunction` | `EvmAsm/Codegen/Programs/TxRefund.lean` | 0 |
+| `txTypeDispatchFunction` | `EvmAsm/Codegen/Programs/TxExtract.lean` | 0 |
+| `txValidateAgainstBlockFunction` | `EvmAsm/Codegen/Programs/Tx.lean` | 0 |
 | `u256AddBeFunction` | `EvmAsm/Codegen/Programs/U256.lean` | 0 |
 | `u256DivU64BeFunction` | `EvmAsm/Codegen/Programs/U256.lean` | 0 |
 | `u256EqFunction` | `EvmAsm/Codegen/Programs/U256.lean` | 0 |
@@ -36,122 +143,13 @@ Every `*Function : String` def under `EvmAsm/Codegen/Programs/` and `EvmAsm/Code
 | `u256MinFunction` | `EvmAsm/Codegen/Programs/U256.lean` | 0 |
 | `u256SubBeFunction` | `EvmAsm/Codegen/Programs/U256.lean` | 0 |
 | `u256ToU64BeFunction` | `EvmAsm/Codegen/Programs/U256.lean` | 0 |
+| `validateHeaderBasicFunction` | `EvmAsm/Codegen/Programs/Header.lean` | 0 |
+| `witnessCodesValidateLengthsFunction` | `EvmAsm/Codegen/Programs/WitnessValidation.lean` | 0 |
 
-## CONVERTED-CLEAN (111)
+## CONVERTED-CLEAN (0)
 
 | Function | File | Instrs | Note |
 |---|---|---:|---|
-| `txGasResultIncrementsFunction` | `EvmAsm/Codegen/Programs/Account.lean` | 26 |  |
-| `bgvU32leFunction` | `EvmAsm/Codegen/Programs/BalGasValid.lean` | 12 |  |
-| `bgvU64leFunction` | `EvmAsm/Codegen/Programs/BalGasValid.lean` | 13 |  |
-| `blake2fLdLe64Function` | `EvmAsm/Codegen/Programs/Blake2f.lean` | 11 |  |
-| `blake2fStLe64Function` | `EvmAsm/Codegen/Programs/Blake2f.lean` | 10 |  |
-| `bahU32leFunction` | `EvmAsm/Codegen/Programs/BlockAccessListHash.lean` | 12 |  |
-| `parentHeaderMatchesWitnessFirstFunction` | `EvmAsm/Codegen/Programs/BlockHashPredicates.lean` | 57 |  |
-| `bhrRevLeBeFunction` | `EvmAsm/Codegen/Programs/BlockHeaderSszToRlp.lean` | 11 |  |
-| `rlpBytesEncodedSizeFunction` | `EvmAsm/Codegen/Programs/BlockRlpSize.lean` | 20 |  |
-| `rlpListEncodedSizeFunction` | `EvmAsm/Codegen/Programs/BlockRlpSize.lean` | 13 |  |
-| `b1SenderTableFindFunction` | `EvmAsm/Codegen/Programs/BlockVerdictSenderCounts.lean` | 47 |  |
-| `codesBlockhashRequiredHeadersFunction` | `EvmAsm/Codegen/Programs/BlockhashRequiredHeaders.lean` | 88 |  |
-| `bls12CopyQuadsFunction` | `EvmAsm/Codegen/Programs/Bls12Field.lean` | 8 |  |
-| `bls12Fq12CopyFunction` | `EvmAsm/Codegen/Programs/Bls12Fq12.lean` | 8 |  |
-| `bls12Fq12EqFunction` | `EvmAsm/Codegen/Programs/Bls12Fq12.lean` | 13 |  |
-| `bls12Fq12IsZeroFunction` | `EvmAsm/Codegen/Programs/Bls12Fq12.lean` | 10 |  |
-| `bls12Fq12ZeroFunction` | `EvmAsm/Codegen/Programs/Bls12Fq12.lean` | 6 |  |
-| `bls12G1BeToLeFunction` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 20 |  |
-| `bls12G1Copy96Function` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 8 |  |
-| `bls12G1Eq48Function` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 15 |  |
-| `bls12G1IsZeroFunction` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 12 |  |
-| `bls12G1LeToBeFunction` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 19 |  |
-| `bls12G1Zero96Function` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 6 |  |
-| `bls12G2EqNFunction` | `EvmAsm/Codegen/Programs/Bls12G2.lean` | 15 |  |
-| `bls12G2Zero192Function` | `EvmAsm/Codegen/Programs/Bls12G2.lean` | 6 |  |
-| `bls12KzgG1WireFunction` | `EvmAsm/Codegen/Programs/Bls12Kzg.lean` | 23 |  |
-| `bls12KzgLtBeFunction` | `EvmAsm/Codegen/Programs/Bls12Kzg.lean` | 16 |  |
-| `bls12PtCopyFunction` | `EvmAsm/Codegen/Programs/Bls12Pairing.lean` | 8 |  |
-| `bn254CallAllotmentFunction` | `EvmAsm/Codegen/Programs/Bn254Curve.lean` | 13 |  |
-| `bn254PointCopy64Function` | `EvmAsm/Codegen/Programs/Bn254Curve.lean` | 9 |  |
-| `bn254PointIsInfFunction` | `EvmAsm/Codegen/Programs/Bn254Curve.lean` | 12 |  |
-| `bn254PointZero64Function` | `EvmAsm/Codegen/Programs/Bn254Curve.lean` | 7 |  |
-| `bn254FieldBeToLeFunction` | `EvmAsm/Codegen/Programs/Bn254Field.lean` | 20 |  |
-| `bn254FieldEq32Function` | `EvmAsm/Codegen/Programs/Bn254Field.lean` | 15 |  |
-| `bn254FieldIsZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Field.lean` | 12 |  |
-| `bn254FieldLeToBeFunction` | `EvmAsm/Codegen/Programs/Bn254Field.lean` | 19 |  |
-| `bn254Fp2CopyFunction` | `EvmAsm/Codegen/Programs/Bn254Fp2.lean` | 17 |  |
-| `bn254Fp2EqFunction` | `EvmAsm/Codegen/Programs/Bn254Fp2.lean` | 13 |  |
-| `bn254Fp2IsZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Fp2.lean` | 10 |  |
-| `bn254Fp2ZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Fp2.lean` | 9 |  |
-| `bn254Fq12CopyFunction` | `EvmAsm/Codegen/Programs/Bn254Fq12.lean` | 8 |  |
-| `bn254Fq12EqFunction` | `EvmAsm/Codegen/Programs/Bn254Fq12.lean` | 13 |  |
-| `bn254Fq12IsZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Fq12.lean` | 10 |  |
-| `bn254Fq12ZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Fq12.lean` | 6 |  |
-| `bn254PtCopyFunction` | `EvmAsm/Codegen/Programs/Bn254Pairing.lean` | 8 |  |
-| `callFrameSetCalldataFunction` | `EvmAsm/Codegen/Programs/CallFrameDescend.lean` | 4 |  |
-| `committedStorageChunkedSnapshotUpsertFunction` | `EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean` | 84 |  |
-| `committedStorageSnapshotAppendFunction` | `EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean` | 55 |  |
-| `committedStorageSnapshotUpsertFunction` | `EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean` | 84 |  |
-| `findCodeEffectByAddressFunction` | `EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean` | 24 |  |
-| `copyWordGasFunction` | `EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean` | 5 |  |
-| `expGasFunction` | `EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean` | 16 |  |
-| `keccak256WordGasFunction` | `EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean` | 6 |  |
-| `logDataGasFunction` | `EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean` | 7 |  |
-| `enrgU32leFunction` | `EvmAsm/Codegen/Programs/Eip7702NonceReuseGuard.lean` | 11 |  |
-| `execLogLatestValueFunction` | `EvmAsm/Codegen/Programs/ExecLogLatestValue.lean` | 42 |  |
-| `calcExcessBlobGasFunction` | `EvmAsm/Codegen/Programs/Header.lean` | 6 |  |
-| `validateHeaderBasicFunction` | `EvmAsm/Codegen/Programs/Header.lean` | 19 |  |
-| `headersParentHashFunction` | `EvmAsm/Codegen/Programs/HeadersKeccak.lean` | 32 |  |
-| `calldataByteCountsFunction` | `EvmAsm/Codegen/Programs/IntrinsicGas.lean` | 17 |  |
-| `eip8037BlockGasUsedFunction` | `EvmAsm/Codegen/Programs/IntrinsicGas.lean` | 35 |  |
-| `initCodeCostFunction` | `EvmAsm/Codegen/Programs/IntrinsicGas.lean` | 6 |  |
-| `intrinsicGasCalldataFloorEip7623Function` | `EvmAsm/Codegen/Programs/IntrinsicGas.lean` | 20 |  |
-| `memoryExpansionGasFunction` | `EvmAsm/Codegen/Programs/MemoryExpansionGas.lean` | 18 |  |
-| `bytesToNibblesFunction` | `EvmAsm/Codegen/Programs/Mpt.lean` | 17 |  |
-| `hpDecodeNibblesFunction` | `EvmAsm/Codegen/Programs/Mpt.lean` | 54 |  |
-| `hpEncodeNibblesFunction` | `EvmAsm/Codegen/Programs/Mpt.lean` | 27 |  |
-| `mptBranchPayloadTwoSlotsFunction` | `EvmAsm/Codegen/Programs/MptEncode.lean` | 63 |  |
-| `mptCompactToNibblesFunction` | `EvmAsm/Codegen/Programs/MptNibbles.lean` | 34 |  |
-| `mptNibblesToCompactFunction` | `EvmAsm/Codegen/Programs/MptNibbles.lean` | 33 |  |
-| `p256BeToLeFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 20 |  |
-| `p256CopyNFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 8 |  |
-| `p256Eq32Function` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 15 |  |
-| `p256IsZeroNFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 12 |  |
-| `p256LeToBeFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 19 |  |
-| `p256LtBeFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 16 |  |
-| `rlpEncodeU64Function` | `EvmAsm/Codegen/Programs/Receipt.lean` | 51 |  |
-| `receiptRecordsFunction` | `EvmAsm/Codegen/Programs/ReceiptRecords.lean` | 61 |  |
-| `rlpEncodeBytesFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 76 |  |
-| `rlpEncodeListPrefixFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 46 |  |
-| `rlpEncodeUintBeFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 35 |  |
-| `rlpListCountItemsFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 76 |  |
-| `rlpListNthItemFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 160 |  |
-| `secp256k1PointCopy64Function` | `EvmAsm/Codegen/Programs/Secp256k1Curve.lean` | 9 |  |
-| `secp256k1PointZero64Function` | `EvmAsm/Codegen/Programs/Secp256k1Curve.lean` | 7 |  |
-| `secp256k1FieldBeToLeFunction` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 20 |  |
-| `secp256k1FieldCopy32Function` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 9 |  |
-| `secp256k1FieldEq32Function` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 15 |  |
-| `secp256k1FieldGetBitFunction` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 9 |  |
-| `secp256k1FieldIsZeroFunction` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 12 |  |
-| `secp256k1FieldLeToBeFunction` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 19 |  |
-| `secp256k1FieldZero32Function` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 5 |  |
-| `senderPostNonceConsistentFunction` | `EvmAsm/Codegen/Programs/SenderPostNonceConsistent.lean` | 24 |  |
-| `slotTupleSequencesMatchFunction` | `EvmAsm/Codegen/Programs/SlotTupleSequencesMatch.lean` | 29 |  |
-| `sszPackBytesFunction` | `EvmAsm/Codegen/Programs/Ssz.lean` | 22 |  |
-| `ephU32leFunction` | `EvmAsm/Codegen/Programs/SszParentHeader.lean` | 12 |  |
-| `spwU32leFunction` | `EvmAsm/Codegen/Programs/SszPayloadWithdrawals.lean` | 12 |  |
-| `swrRevLeBeFunction` | `EvmAsm/Codegen/Programs/SszWithdrawal.lean` | 11 |  |
-| `swsU32leFunction` | `EvmAsm/Codegen/Programs/SszWitnessState.lean` | 12 |  |
-| `slotDecodeU256Function` | `EvmAsm/Codegen/Programs/State.lean` | 32 |  |
-| `storageEffectRecordsFunction` | `EvmAsm/Codegen/Programs/StorageEffectRecords.lean` | 47 |  |
-| `swdMinimalCopyFunction` | `EvmAsm/Codegen/Programs/SystemWrites.lean` | 19 |  |
-| `swdReadU64leFunction` | `EvmAsm/Codegen/Programs/SystemWrites.lean` | 24 |  |
-| `swdWriteBe32U64Function` | `EvmAsm/Codegen/Programs/SystemWrites.lean` | 21 |  |
-| `swdWriteBe8Function` | `EvmAsm/Codegen/Programs/SystemWrites.lean` | 13 |  |
-| `deriveChainIdFromVFunction` | `EvmAsm/Codegen/Programs/Tx.lean` | 15 |  |
-| `txValidateAgainstBlockFunction` | `EvmAsm/Codegen/Programs/Tx.lean` | 11 |  |
-| `txTypeDispatchFunction` | `EvmAsm/Codegen/Programs/TxExtract.lean` | 45 |  |
-| `txPubkeyEcrecoverStageMaterialFunction` | `EvmAsm/Codegen/Programs/TxPubkey.lean` | 44 |  |
-| `txRefundCapFunction` | `EvmAsm/Codegen/Programs/TxRefund.lean` | 22 |  |
-| `witnessCodesValidateLengthsFunction` | `EvmAsm/Codegen/Programs/WitnessValidation.lean` | 54 |  |
 
 ## NEEDS-LI-EXPANSION (20)
 
@@ -191,7 +189,16 @@ Every `*Function : String` def under `EvmAsm/Codegen/Programs/` and `EvmAsm/Code
 | `zkvmBn254G1MulRealFunction` | `EvmAsm/Codegen/Programs/Bn254Curve.lean` |  | first line is not a label |
 | `runtimeAccessAccountSeedFunction` | `EvmAsm/Codegen/Programs/EvmAccessGas.lean` |  | unresolved branch/jump target '.exit_outofgas' |
 
-## BLOCKED_ON_.6 (550) — by file
+## MULTI-ENTRY-BUNDLE (4)
+
+| Function | File | Instrs | Note |
+|---|---|---:|---|
+| `blockValidateEmptyBlockFunction` | `EvmAsm/Codegen/Programs/BlockEmpty.lean` |  | secondary non-.L label 'beb_check_header_field_32B': multi-entry bundl |
+| `mptIndexedTrieRootOneLeafFunction` | `EvmAsm/Codegen/Programs/MptIndexedTrieRoot.lean` |  | secondary non-.L label 'rlp_prefix_to_buffer': multi-entry bundle, cro |
+| `receiptRecordsFunction` | `EvmAsm/Codegen/Programs/ReceiptRecords.lean` |  | secondary non-.L label 'receipt_records_clear': multi-entry bundle, cr |
+| `storageEffectRecordsFunction` | `EvmAsm/Codegen/Programs/StorageEffectRecords.lean` |  | secondary non-.L label 'storage_effect_records_clear': multi-entry bun |
+
+## BLOCKED_ON_.6 (548) — by file
 
 | File | Count |
 |---|---:|
@@ -243,7 +250,7 @@ Every `*Function : String` def under `EvmAsm/Codegen/Programs/` and `EvmAsm/Code
 | `EvmAsm/Codegen/Programs/Block.lean` | 6 |
 | `EvmAsm/Codegen/Programs/BlockAccessListHash.lean` | 1 |
 | `EvmAsm/Codegen/Programs/BlockBody.lean` | 6 |
-| `EvmAsm/Codegen/Programs/BlockEmpty.lean` | 4 |
+| `EvmAsm/Codegen/Programs/BlockEmpty.lean` | 3 |
 | `EvmAsm/Codegen/Programs/BlockGasRemaining.lean` | 1 |
 | `EvmAsm/Codegen/Programs/BlockHashAtBlockNumber.lean` | 1 |
 | `EvmAsm/Codegen/Programs/BlockHashAtStateRoot.lean` | 1 |
@@ -347,7 +354,7 @@ Every `*Function : String` def under `EvmAsm/Codegen/Programs/` and `EvmAsm/Code
 | `EvmAsm/Codegen/Programs/MptDeleteWalkDb.lean` | 1 |
 | `EvmAsm/Codegen/Programs/MptEncode.lean` | 2 |
 | `EvmAsm/Codegen/Programs/MptEncodeLeafBranch.lean` | 1 |
-| `EvmAsm/Codegen/Programs/MptIndexedTrieRoot.lean` | 3 |
+| `EvmAsm/Codegen/Programs/MptIndexedTrieRoot.lean` | 2 |
 | `EvmAsm/Codegen/Programs/MptInsert.lean` | 1 |
 | `EvmAsm/Codegen/Programs/MptInsertAcc.lean` | 1 |
 | `EvmAsm/Codegen/Programs/MptInsertWalk.lean` | 1 |
@@ -463,17 +470,68 @@ Every `*Function : String` def under `EvmAsm/Codegen/Programs/` and `EvmAsm/Code
 | `EvmAsm/Codegen/Programs/WitnessStorageNodeKindDistribution.lean` | 1 |
 | `EvmAsm/Codegen/Programs/WitnessValidation.lean` | 2 |
 
-## ALREADY-STRUCTURED (23) — by file
+## ALREADY-STRUCTURED (132) — by file
 
 | File | Count |
 |---|---:|
+| `EvmAsm/Codegen/Programs/Account.lean` | 1 |
+| `EvmAsm/Codegen/Programs/BalGasValid.lean` | 2 |
+| `EvmAsm/Codegen/Programs/Blake2f.lean` | 2 |
+| `EvmAsm/Codegen/Programs/BlockAccessListHash.lean` | 1 |
+| `EvmAsm/Codegen/Programs/BlockHashPredicates.lean` | 1 |
+| `EvmAsm/Codegen/Programs/BlockHeaderSszToRlp.lean` | 1 |
+| `EvmAsm/Codegen/Programs/BlockRlpSize.lean` | 2 |
+| `EvmAsm/Codegen/Programs/BlockVerdictSenderCounts.lean` | 1 |
+| `EvmAsm/Codegen/Programs/BlockhashRequiredHeaders.lean` | 1 |
 | `EvmAsm/Codegen/Programs/Bloom.lean` | 4 |
+| `EvmAsm/Codegen/Programs/Bls12Field.lean` | 1 |
+| `EvmAsm/Codegen/Programs/Bls12Fq12.lean` | 4 |
+| `EvmAsm/Codegen/Programs/Bls12G1.lean` | 6 |
+| `EvmAsm/Codegen/Programs/Bls12G2.lean` | 2 |
+| `EvmAsm/Codegen/Programs/Bls12Kzg.lean` | 2 |
+| `EvmAsm/Codegen/Programs/Bls12Pairing.lean` | 1 |
+| `EvmAsm/Codegen/Programs/Bn254Curve.lean` | 4 |
+| `EvmAsm/Codegen/Programs/Bn254Field.lean` | 4 |
+| `EvmAsm/Codegen/Programs/Bn254Fp2.lean` | 4 |
+| `EvmAsm/Codegen/Programs/Bn254Fq12.lean` | 4 |
+| `EvmAsm/Codegen/Programs/Bn254Pairing.lean` | 1 |
+| `EvmAsm/Codegen/Programs/CallFrameDescend.lean` | 1 |
+| `EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean` | 3 |
+| `EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean` | 1 |
 | `EvmAsm/Codegen/Programs/CreateDeployedCodeValid.lean` | 1 |
 | `EvmAsm/Codegen/Programs/CreateInitcodeSizeValid.lean` | 1 |
-| `EvmAsm/Codegen/Programs/MptEncode.lean` | 1 |
+| `EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean` | 4 |
+| `EvmAsm/Codegen/Programs/Eip7702NonceReuseGuard.lean` | 1 |
+| `EvmAsm/Codegen/Programs/ExecLogLatestValue.lean` | 1 |
+| `EvmAsm/Codegen/Programs/Header.lean` | 2 |
+| `EvmAsm/Codegen/Programs/HeadersKeccak.lean` | 1 |
+| `EvmAsm/Codegen/Programs/IntrinsicGas.lean` | 4 |
+| `EvmAsm/Codegen/Programs/MemoryExpansionGas.lean` | 1 |
+| `EvmAsm/Codegen/Programs/Mpt.lean` | 3 |
+| `EvmAsm/Codegen/Programs/MptEncode.lean` | 2 |
+| `EvmAsm/Codegen/Programs/MptNibbles.lean` | 2 |
 | `EvmAsm/Codegen/Programs/MptSet.lean` | 1 |
+| `EvmAsm/Codegen/Programs/P256Verify.lean` | 6 |
+| `EvmAsm/Codegen/Programs/Receipt.lean` | 1 |
+| `EvmAsm/Codegen/Programs/RlpRead.lean` | 5 |
 | `EvmAsm/Codegen/Programs/RlpWalk.lean` | 5 |
+| `EvmAsm/Codegen/Programs/Secp256k1Curve.lean` | 2 |
+| `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 7 |
+| `EvmAsm/Codegen/Programs/SenderPostNonceConsistent.lean` | 1 |
+| `EvmAsm/Codegen/Programs/SlotTupleSequencesMatch.lean` | 1 |
+| `EvmAsm/Codegen/Programs/Ssz.lean` | 1 |
+| `EvmAsm/Codegen/Programs/SszParentHeader.lean` | 1 |
+| `EvmAsm/Codegen/Programs/SszPayloadWithdrawals.lean` | 1 |
+| `EvmAsm/Codegen/Programs/SszWithdrawal.lean` | 1 |
+| `EvmAsm/Codegen/Programs/SszWitnessState.lean` | 1 |
+| `EvmAsm/Codegen/Programs/State.lean` | 1 |
+| `EvmAsm/Codegen/Programs/SystemWrites.lean` | 4 |
+| `EvmAsm/Codegen/Programs/Tx.lean` | 2 |
+| `EvmAsm/Codegen/Programs/TxExtract.lean` | 1 |
+| `EvmAsm/Codegen/Programs/TxPubkey.lean` | 1 |
+| `EvmAsm/Codegen/Programs/TxRefund.lean` | 1 |
 | `EvmAsm/Codegen/Programs/U256.lean` | 10 |
+| `EvmAsm/Codegen/Programs/WitnessValidation.lean` | 1 |
 
 ## COMPOSITE (139) — by file
 

--- a/scripts/asm-fixtures/MANIFEST.tsv
+++ b/scripts/asm-fixtures/MANIFEST.tsv
@@ -1,6 +1,11 @@
 # asm_to_program.py conversion manifest: <func>\t<lean file> (bead evm-asm-4ch8f.9)
+b1SenderTableFindFunction	EvmAsm/Codegen/Programs/BlockVerdictSenderCounts.lean
 bahU32leFunction	EvmAsm/Codegen/Programs/BlockAccessListHash.lean
+bgvU32leFunction	EvmAsm/Codegen/Programs/BalGasValid.lean
+bgvU64leFunction	EvmAsm/Codegen/Programs/BalGasValid.lean
 bhrRevLeBeFunction	EvmAsm/Codegen/Programs/BlockHeaderSszToRlp.lean
+blake2fLdLe64Function	EvmAsm/Codegen/Programs/Blake2f.lean
+blake2fStLe64Function	EvmAsm/Codegen/Programs/Blake2f.lean
 bloomEqFunction	EvmAsm/Codegen/Programs/Bloom.lean
 bloomOrIntoFunction	EvmAsm/Codegen/Programs/Bloom.lean
 bls12CopyQuadsFunction	EvmAsm/Codegen/Programs/Bls12Field.lean
@@ -41,11 +46,15 @@ calcExcessBlobGasFunction	EvmAsm/Codegen/Programs/Header.lean
 callFrameSetCalldataFunction	EvmAsm/Codegen/Programs/CallFrameDescend.lean
 calldataByteCountsFunction	EvmAsm/Codegen/Programs/IntrinsicGas.lean
 codesBlockhashRequiredHeadersFunction	EvmAsm/Codegen/Programs/BlockhashRequiredHeaders.lean
+committedStorageChunkedSnapshotUpsertFunction	EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean
+committedStorageSnapshotAppendFunction	EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean
+committedStorageSnapshotUpsertFunction	EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean
 copyWordGasFunction	EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean
 deriveChainIdFromVFunction	EvmAsm/Codegen/Programs/Tx.lean
 eip8037BlockGasUsedFunction	EvmAsm/Codegen/Programs/IntrinsicGas.lean
 enrgU32leFunction	EvmAsm/Codegen/Programs/Eip7702NonceReuseGuard.lean
 ephU32leFunction	EvmAsm/Codegen/Programs/SszParentHeader.lean
+execLogLatestValueFunction	EvmAsm/Codegen/Programs/ExecLogLatestValue.lean
 expGasFunction	EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean
 findCodeEffectByAddressFunction	EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean
 headersParentHashFunction	EvmAsm/Codegen/Programs/HeadersKeccak.lean
@@ -87,8 +96,15 @@ secp256k1FieldLeToBeFunction	EvmAsm/Codegen/Programs/Secp256k1Field.lean
 secp256k1FieldZero32Function	EvmAsm/Codegen/Programs/Secp256k1Field.lean
 secp256k1PointCopy64Function	EvmAsm/Codegen/Programs/Secp256k1Curve.lean
 secp256k1PointZero64Function	EvmAsm/Codegen/Programs/Secp256k1Curve.lean
+senderPostNonceConsistentFunction	EvmAsm/Codegen/Programs/SenderPostNonceConsistent.lean
+slotDecodeU256Function	EvmAsm/Codegen/Programs/State.lean
+slotTupleSequencesMatchFunction	EvmAsm/Codegen/Programs/SlotTupleSequencesMatch.lean
 spwU32leFunction	EvmAsm/Codegen/Programs/SszPayloadWithdrawals.lean
 sszPackBytesFunction	EvmAsm/Codegen/Programs/Ssz.lean
+swdMinimalCopyFunction	EvmAsm/Codegen/Programs/SystemWrites.lean
+swdReadU64leFunction	EvmAsm/Codegen/Programs/SystemWrites.lean
+swdWriteBe32U64Function	EvmAsm/Codegen/Programs/SystemWrites.lean
+swdWriteBe8Function	EvmAsm/Codegen/Programs/SystemWrites.lean
 swrRevLeBeFunction	EvmAsm/Codegen/Programs/SszWithdrawal.lean
 swsU32leFunction	EvmAsm/Codegen/Programs/SszWitnessState.lean
 txGasResultIncrementsFunction	EvmAsm/Codegen/Programs/Account.lean
@@ -107,3 +123,4 @@ u256MinFunction	EvmAsm/Codegen/Programs/U256.lean
 u256SubBeFunction	EvmAsm/Codegen/Programs/U256.lean
 u256ToU64BeFunction	EvmAsm/Codegen/Programs/U256.lean
 validateHeaderBasicFunction	EvmAsm/Codegen/Programs/Header.lean
+witnessCodesValidateLengthsFunction	EvmAsm/Codegen/Programs/WitnessValidation.lean

--- a/scripts/asm-fixtures/MANIFEST.tsv
+++ b/scripts/asm-fixtures/MANIFEST.tsv
@@ -1,4 +1,5 @@
 # asm_to_program.py conversion manifest: <func>\t<lean file> (bead evm-asm-4ch8f.9)
+bahU32leFunction	EvmAsm/Codegen/Programs/BlockAccessListHash.lean
 bhrRevLeBeFunction	EvmAsm/Codegen/Programs/BlockHeaderSszToRlp.lean
 bloomEqFunction	EvmAsm/Codegen/Programs/Bloom.lean
 bloomOrIntoFunction	EvmAsm/Codegen/Programs/Bloom.lean
@@ -36,10 +37,25 @@ bn254PointIsInfFunction	EvmAsm/Codegen/Programs/Bn254Curve.lean
 bn254PointZero64Function	EvmAsm/Codegen/Programs/Bn254Curve.lean
 bn254PtCopyFunction	EvmAsm/Codegen/Programs/Bn254Pairing.lean
 bytesToNibblesFunction	EvmAsm/Codegen/Programs/Mpt.lean
+calcExcessBlobGasFunction	EvmAsm/Codegen/Programs/Header.lean
+callFrameSetCalldataFunction	EvmAsm/Codegen/Programs/CallFrameDescend.lean
+calldataByteCountsFunction	EvmAsm/Codegen/Programs/IntrinsicGas.lean
 codesBlockhashRequiredHeadersFunction	EvmAsm/Codegen/Programs/BlockhashRequiredHeaders.lean
+copyWordGasFunction	EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean
+deriveChainIdFromVFunction	EvmAsm/Codegen/Programs/Tx.lean
+eip8037BlockGasUsedFunction	EvmAsm/Codegen/Programs/IntrinsicGas.lean
+enrgU32leFunction	EvmAsm/Codegen/Programs/Eip7702NonceReuseGuard.lean
 ephU32leFunction	EvmAsm/Codegen/Programs/SszParentHeader.lean
+expGasFunction	EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean
+findCodeEffectByAddressFunction	EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean
+headersParentHashFunction	EvmAsm/Codegen/Programs/HeadersKeccak.lean
 hpDecodeNibblesFunction	EvmAsm/Codegen/Programs/Mpt.lean
 hpEncodeNibblesFunction	EvmAsm/Codegen/Programs/Mpt.lean
+initCodeCostFunction	EvmAsm/Codegen/Programs/IntrinsicGas.lean
+intrinsicGasCalldataFloorEip7623Function	EvmAsm/Codegen/Programs/IntrinsicGas.lean
+keccak256WordGasFunction	EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean
+logDataGasFunction	EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean
+memoryExpansionGasFunction	EvmAsm/Codegen/Programs/MemoryExpansionGas.lean
 mptBranchPayloadTwoSlotsFunction	EvmAsm/Codegen/Programs/MptEncode.lean
 mptCompactToNibblesFunction	EvmAsm/Codegen/Programs/MptNibbles.lean
 mptNibblesToCompactFunction	EvmAsm/Codegen/Programs/MptNibbles.lean
@@ -51,6 +67,7 @@ p256Eq32Function	EvmAsm/Codegen/Programs/P256Verify.lean
 p256IsZeroNFunction	EvmAsm/Codegen/Programs/P256Verify.lean
 p256LeToBeFunction	EvmAsm/Codegen/Programs/P256Verify.lean
 p256LtBeFunction	EvmAsm/Codegen/Programs/P256Verify.lean
+parentHeaderMatchesWitnessFirstFunction	EvmAsm/Codegen/Programs/BlockHashPredicates.lean
 rlpBytesEncodedSizeFunction	EvmAsm/Codegen/Programs/BlockRlpSize.lean
 rlpEncodeBytesFunction	EvmAsm/Codegen/Programs/RlpRead.lean
 rlpEncodeListPrefixFunction	EvmAsm/Codegen/Programs/RlpRead.lean
@@ -74,6 +91,11 @@ spwU32leFunction	EvmAsm/Codegen/Programs/SszPayloadWithdrawals.lean
 sszPackBytesFunction	EvmAsm/Codegen/Programs/Ssz.lean
 swrRevLeBeFunction	EvmAsm/Codegen/Programs/SszWithdrawal.lean
 swsU32leFunction	EvmAsm/Codegen/Programs/SszWitnessState.lean
+txGasResultIncrementsFunction	EvmAsm/Codegen/Programs/Account.lean
+txPubkeyEcrecoverStageMaterialFunction	EvmAsm/Codegen/Programs/TxPubkey.lean
+txRefundCapFunction	EvmAsm/Codegen/Programs/TxRefund.lean
+txTypeDispatchFunction	EvmAsm/Codegen/Programs/TxExtract.lean
+txValidateAgainstBlockFunction	EvmAsm/Codegen/Programs/Tx.lean
 u256AddBeFunction	EvmAsm/Codegen/Programs/U256.lean
 u256DivU64BeFunction	EvmAsm/Codegen/Programs/U256.lean
 u256EqFunction	EvmAsm/Codegen/Programs/U256.lean
@@ -84,3 +106,4 @@ u256MaxFunction	EvmAsm/Codegen/Programs/U256.lean
 u256MinFunction	EvmAsm/Codegen/Programs/U256.lean
 u256SubBeFunction	EvmAsm/Codegen/Programs/U256.lean
 u256ToU64BeFunction	EvmAsm/Codegen/Programs/U256.lean
+validateHeaderBasicFunction	EvmAsm/Codegen/Programs/Header.lean

--- a/scripts/asm-fixtures/b1SenderTableFindFunction.s
+++ b/scripts/asm-fixtures/b1SenderTableFindFunction.s
@@ -1,0 +1,30 @@
+b1_sender_table_find:
+  addi sp, sp, -64
+  sd ra, 0(sp); sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp)
+  sd s3, 32(sp); sd s4, 40(sp); sd s5, 48(sp)
+  mv s0, a0; mv s1, a1; mv s2, a2
+  li s3, 0; mv s4, s1
+.Lb1stf_loop:
+  bgeu s3, s4, .Lb1stf_absent
+  add s5, s3, s4; srli s5, s5, 1
+  li t0, 40; mul t0, s5, t0; add t1, s0, t0
+  li t2, 0
+.Lb1stf_cmp:
+  li t3, 20; beq t2, t3, .Lb1stf_found
+  add t3, t1, t2; lbu t4, 0(t3); add t3, s2, t2; lbu t5, 0(t3)
+  bltu t4, t5, .Lb1stf_entry_less
+  bltu t5, t4, .Lb1stf_entry_greater
+  addi t2, t2, 1; j .Lb1stf_cmp
+.Lb1stf_entry_less:
+  addi s3, s5, 1; j .Lb1stf_loop
+.Lb1stf_entry_greater:
+  mv s4, s5; j .Lb1stf_loop
+.Lb1stf_found:
+  li a0, 0; mv a1, t1; j .Lb1stf_ret
+.Lb1stf_absent:
+  li a0, 1
+.Lb1stf_ret:
+  ld ra, 0(sp); ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp)
+  ld s3, 32(sp); ld s4, 40(sp); ld s5, 48(sp)
+  addi sp, sp, 64
+  ret

--- a/scripts/asm-fixtures/bahU32leFunction.s
+++ b/scripts/asm-fixtures/bahU32leFunction.s
@@ -1,0 +1,7 @@
+bah_u32le:
+  lbu t0, 0(a0)
+  lbu t1, 1(a0); slli t1, t1, 8;  or t0, t0, t1
+  lbu t1, 2(a0); slli t1, t1, 16; or t0, t0, t1
+  lbu t1, 3(a0); slli t1, t1, 24; or t0, t0, t1
+  mv a0, t0
+  ret

--- a/scripts/asm-fixtures/bgvU32leFunction.s
+++ b/scripts/asm-fixtures/bgvU32leFunction.s
@@ -1,0 +1,7 @@
+bgv_u32le:
+  lbu t0, 0(a0)
+  lbu t1, 1(a0); slli t1, t1, 8;  or t0, t0, t1
+  lbu t1, 2(a0); slli t1, t1, 16; or t0, t0, t1
+  lbu t1, 3(a0); slli t1, t1, 24; or t0, t0, t1
+  mv a0, t0
+  ret

--- a/scripts/asm-fixtures/bgvU64leFunction.s
+++ b/scripts/asm-fixtures/bgvU64leFunction.s
@@ -1,0 +1,8 @@
+bgv_u64le:
+  li t0, 0; li t2, 0
+.Lbgv64:
+  li t3, 8; beq t2, t3, .Lbgv64d
+  add t4, a0, t2; lbu t5, 0(t4); slli t6, t2, 3; sll t5, t5, t6; or t0, t0, t5
+  addi t2, t2, 1; j .Lbgv64
+.Lbgv64d:
+  mv a0, t0; ret

--- a/scripts/asm-fixtures/blake2fLdLe64Function.s
+++ b/scripts/asm-fixtures/blake2fLdLe64Function.s
@@ -1,0 +1,13 @@
+blk2_ld_le64:
+  li t0, 0
+  addi t1, a0, 7
+  li t2, 8
+.Lblk2_ld_byte:
+  slli t0, t0, 8
+  lbu a0, 0(t1)
+  or t0, t0, a0
+  addi t1, t1, -1
+  addi t2, t2, -1
+  bnez t2, .Lblk2_ld_byte
+  mv a0, t0
+  ret

--- a/scripts/asm-fixtures/blake2fStLe64Function.s
+++ b/scripts/asm-fixtures/blake2fStLe64Function.s
@@ -1,0 +1,12 @@
+blk2_st_le64:
+  mv t0, a1
+  mv t1, a0
+  li t2, 8
+.Lblk2_st_byte:
+  andi a1, t0, 0xff
+  sb a1, 0(t1)
+  srli t0, t0, 8
+  addi t1, t1, 1
+  addi t2, t2, -1
+  bnez t2, .Lblk2_st_byte
+  ret

--- a/scripts/asm-fixtures/calcExcessBlobGasFunction.s
+++ b/scripts/asm-fixtures/calcExcessBlobGasFunction.s
@@ -1,0 +1,8 @@
+calc_excess_blob_gas:
+  add t0, a0, a1              # parent_excess + parent_used
+  bgeu t0, a2, .Lcebg_pos     # >= target → return diff
+  li a0, 0
+  ret
+.Lcebg_pos:
+  sub a0, t0, a2
+  ret

--- a/scripts/asm-fixtures/callFrameSetCalldataFunction.s
+++ b/scripts/asm-fixtures/callFrameSetCalldataFunction.s
@@ -1,0 +1,5 @@
+call_frame_set_calldata:
+  add t0, a1, a2
+  sd t0, 416(a0)
+  sd a3, 424(a0)
+  ret

--- a/scripts/asm-fixtures/calldataByteCountsFunction.s
+++ b/scripts/asm-fixtures/calldataByteCountsFunction.s
@@ -1,0 +1,24 @@
+calldata_byte_counts:
+  # Pure-leaf, but we read into t-regs and update in-place; no
+  # callee-saved usage needed.
+  li t0, 0                    # zero_count
+  li t1, 0                    # non_zero_count
+  mv t2, a0                   # cursor
+  mv t3, a1                   # remaining bytes
+.Lcbc_loop:
+  beqz t3, .Lcbc_done
+  lbu t4, 0(t2)
+  bnez t4, .Lcbc_nz
+  addi t0, t0, 1
+  j .Lcbc_step
+.Lcbc_nz:
+  addi t1, t1, 1
+.Lcbc_step:
+  addi t2, t2, 1
+  addi t3, t3, -1
+  j .Lcbc_loop
+.Lcbc_done:
+  sd t0, 0(a2)
+  sd t1, 0(a3)
+  li a0, 0
+  ret

--- a/scripts/asm-fixtures/committedStorageChunkedSnapshotUpsertFunction.s
+++ b/scripts/asm-fixtures/committedStorageChunkedSnapshotUpsertFunction.s
@@ -1,0 +1,44 @@
+bv_mtx_committed_chunked_snapshot_upsert:
+  li t0, 0                      # j = 0
+.Lcscsu_loop:
+  beq t0, a2, .Lcscsu_done
+  slli t1, t0, 7; add t1, a1, t1   # src = live[j]
+  li t2, 0                      # i = 0
+.Lcscsu_scan:
+  beq t2, a4, .Lcscsu_no_match
+  slli t3, t2, 7; add t3, a3, t3   # entry = table[i]
+  li t4, 0
+.Lcscsu_addr_cmp:
+  li t5, 20; beq t4, t5, .Lcscsu_slot_cmp
+  add t5, a0, t4; lbu t5, 0(t5); add t6, t3, t4; lbu t6, 0(t6); bne t5, t6, .Lcscsu_next_entry
+  addi t4, t4, 1; j .Lcscsu_addr_cmp
+.Lcscsu_slot_cmp:
+  ld t5, 32(t1);  ld t6, 32(t3);  bne t5, t6, .Lcscsu_next_entry
+  ld t5, 40(t1);  ld t6, 40(t3);  bne t5, t6, .Lcscsu_next_entry
+  ld t5, 48(t1);  ld t6, 48(t3);  bne t5, t6, .Lcscsu_next_entry
+  ld t5, 56(t1);  ld t6, 56(t3);  bne t5, t6, .Lcscsu_next_entry
+  j .Lcscsu_store_payload
+.Lcscsu_next_entry:
+  addi t2, t2, 1; j .Lcscsu_scan
+.Lcscsu_no_match:
+  bgeu a4, a5, .Lcscsu_overflow
+  slli t3, a4, 7; add t3, a3, t3   # dst = table[count]
+  sd zero, 0(t3); sd zero, 8(t3); sd zero, 16(t3); sd zero, 24(t3)
+  li t4, 0
+.Lcscsu_addr_copy:
+  li t5, 20; beq t4, t5, .Lcscsu_store_payload_append
+  add t5, a0, t4; lbu t6, 0(t5); add t5, t3, t4; sb t6, 0(t5); addi t4, t4, 1; j .Lcscsu_addr_copy
+.Lcscsu_store_payload_append:
+  addi a4, a4, 1
+.Lcscsu_store_payload:
+  ld t4, 32(t1);  sd t4, 32(t3);  ld t4, 40(t1);  sd t4, 40(t3)
+  ld t4, 48(t1);  sd t4, 48(t3);  ld t4, 56(t1);  sd t4, 56(t3)
+  ld t4, 64(t1);  sd t4, 64(t3);  ld t4, 72(t1);  sd t4, 72(t3)
+  ld t4, 80(t1);  sd t4, 80(t3);  ld t4, 88(t1);  sd t4, 88(t3)
+  ld t4, 96(t1);  sd t4, 96(t3);  ld t4, 104(t1); sd t4, 104(t3)
+  ld t4, 112(t1); sd t4, 112(t3); ld t4, 120(t1); sd t4, 120(t3)
+  addi t0, t0, 1; j .Lcscsu_loop
+.Lcscsu_overflow:
+  li t0, 1; sd t0, 0(a6); mv a0, a4; li a1, 1; ret
+.Lcscsu_done:
+  mv a0, a4; li a1, 0; ret

--- a/scripts/asm-fixtures/committedStorageSnapshotAppendFunction.s
+++ b/scripts/asm-fixtures/committedStorageSnapshotAppendFunction.s
@@ -1,0 +1,24 @@
+bv_mtx_committed_snapshot_append:
+  li t0, 0                      # j = 0
+.Lcssa_loop:
+  beq t0, a2, .Lcssa_done
+  bgeu a4, a5, .Lcssa_overflow
+  slli t1, t0, 7; add t1, a1, t1   # src = live[j]
+  slli t2, a4, 7; add t2, a3, t2   # dst = table[count]
+  sd zero, 0(t2); sd zero, 8(t2); sd zero, 16(t2); sd zero, 24(t2)
+  li t3, 0
+.Lcssa_addr:
+  li t4, 20; beq t3, t4, .Lcssa_addr_done
+  add t5, a0, t3; lbu t6, 0(t5); add t5, t2, t3; sb t6, 0(t5); addi t3, t3, 1; j .Lcssa_addr
+.Lcssa_addr_done:
+  ld t3, 32(t1);  sd t3, 32(t2);  ld t3, 40(t1);  sd t3, 40(t2)
+  ld t3, 48(t1);  sd t3, 48(t2);  ld t3, 56(t1);  sd t3, 56(t2)
+  ld t3, 64(t1);  sd t3, 64(t2);  ld t3, 72(t1);  sd t3, 72(t2)
+  ld t3, 80(t1);  sd t3, 80(t2);  ld t3, 88(t1);  sd t3, 88(t2)
+  ld t3, 96(t1);  sd t3, 96(t2);  ld t3, 104(t1); sd t3, 104(t2)
+  ld t3, 112(t1); sd t3, 112(t2); ld t3, 120(t1); sd t3, 120(t2)
+  addi a4, a4, 1; addi t0, t0, 1; j .Lcssa_loop
+.Lcssa_overflow:
+  li t0, 1; sd t0, 0(a6); mv a0, a4; li a1, 1; ret
+.Lcssa_done:
+  mv a0, a4; li a1, 0; ret

--- a/scripts/asm-fixtures/committedStorageSnapshotUpsertFunction.s
+++ b/scripts/asm-fixtures/committedStorageSnapshotUpsertFunction.s
@@ -1,0 +1,44 @@
+bv_mtx_committed_snapshot_upsert:
+  li t0, 0                      # j = 0
+.Lcssu_loop:
+  beq t0, a2, .Lcssu_done
+  slli t1, t0, 7; add t1, a1, t1   # src = live[j]
+  li t2, 0                      # i = 0
+.Lcssu_scan:
+  beq t2, a4, .Lcssu_no_match
+  slli t3, t2, 7; add t3, a3, t3   # entry = table[i]
+  li t4, 0
+.Lcssu_addr_cmp:
+  li t5, 20; beq t4, t5, .Lcssu_slot_cmp
+  add t5, a0, t4; lbu t5, 0(t5); add t6, t3, t4; lbu t6, 0(t6); bne t5, t6, .Lcssu_next_entry
+  addi t4, t4, 1; j .Lcssu_addr_cmp
+.Lcssu_slot_cmp:
+  ld t5, 32(t1);  ld t6, 32(t3);  bne t5, t6, .Lcssu_next_entry
+  ld t5, 40(t1);  ld t6, 40(t3);  bne t5, t6, .Lcssu_next_entry
+  ld t5, 48(t1);  ld t6, 48(t3);  bne t5, t6, .Lcssu_next_entry
+  ld t5, 56(t1);  ld t6, 56(t3);  bne t5, t6, .Lcssu_next_entry
+  j .Lcssu_store_payload
+.Lcssu_next_entry:
+  addi t2, t2, 1; j .Lcssu_scan
+.Lcssu_no_match:
+  bgeu a4, a5, .Lcssu_overflow
+  slli t3, a4, 7; add t3, a3, t3   # dst = table[count]
+  sd zero, 0(t3); sd zero, 8(t3); sd zero, 16(t3); sd zero, 24(t3)
+  li t4, 0
+.Lcssu_addr_copy:
+  li t5, 20; beq t4, t5, .Lcssu_store_payload_append
+  add t5, a0, t4; lbu t6, 0(t5); add t5, t3, t4; sb t6, 0(t5); addi t4, t4, 1; j .Lcssu_addr_copy
+.Lcssu_store_payload_append:
+  addi a4, a4, 1
+.Lcssu_store_payload:
+  ld t4, 32(t1);  sd t4, 32(t3);  ld t4, 40(t1);  sd t4, 40(t3)
+  ld t4, 48(t1);  sd t4, 48(t3);  ld t4, 56(t1);  sd t4, 56(t3)
+  ld t4, 64(t1);  sd t4, 64(t3);  ld t4, 72(t1);  sd t4, 72(t3)
+  ld t4, 80(t1);  sd t4, 80(t3);  ld t4, 88(t1);  sd t4, 88(t3)
+  ld t4, 96(t1);  sd t4, 96(t3);  ld t4, 104(t1); sd t4, 104(t3)
+  ld t4, 112(t1); sd t4, 112(t3); ld t4, 120(t1); sd t4, 120(t3)
+  addi t0, t0, 1; j .Lcssu_loop
+.Lcssu_overflow:
+  li t0, 1; sd t0, 0(a6); mv a0, a4; li a1, 1; ret
+.Lcssu_done:
+  mv a0, a4; li a1, 0; ret

--- a/scripts/asm-fixtures/copyWordGasFunction.s
+++ b/scripts/asm-fixtures/copyWordGasFunction.s
@@ -1,0 +1,4 @@
+copy_word_gas:
+  addi t0, a0, 31; srli t0, t0, 5   # words
+  li t1, 3; mul a0, t0, t1
+  ret

--- a/scripts/asm-fixtures/deriveChainIdFromVFunction.s
+++ b/scripts/asm-fixtures/deriveChainIdFromVFunction.s
@@ -1,0 +1,18 @@
+derive_chain_id_from_v:
+  li t0, 27
+  beq a0, t0, .Ldcid_pre155
+  li t0, 28
+  beq a0, t0, .Ldcid_pre155
+  # EIP-155: chain_id = (v - 35) / 2
+  addi t1, a0, -35
+  srli t1, t1, 1
+  sd t1, 0(a1)
+  li t2, 1
+  sd t2, 0(a2)
+  li a0, 0
+  ret
+.Ldcid_pre155:
+  sd zero, 0(a1)
+  sd zero, 0(a2)
+  li a0, 0
+  ret

--- a/scripts/asm-fixtures/eip8037BlockGasUsedFunction.s
+++ b/scripts/asm-fixtures/eip8037BlockGasUsedFunction.s
@@ -1,0 +1,43 @@
+eip8037_block_gas_used:
+  # a0=regular_inc ptr, a1=tx_state_gas ptr, a2=count,
+  # a3=header_gas_used, a4=block_gas_used_out
+  mv t0, a0                   # regular_inc ptr
+  mv t1, a1                   # tx_state_gas ptr
+  mv t2, a2                   # count
+  li t3, 0                    # i
+  li t4, 0                    # block_regular
+  li t5, 0                    # block_state
+.Le8037bg_loop:
+  beq t3, t2, .Le8037bg_done
+  slli t6, t3, 3
+  add a5, t0, t6
+  ld a5, 0(a5)               # regular increment
+  add a6, t4, a5
+  bltu a6, t4, .Le8037bg_overflow
+  mv t4, a6                  # block_regular += regular increment
+  add a5, t1, t6
+  ld a5, 0(a5)               # tx_state_gas
+  add a6, t5, a5
+  bltu a6, t5, .Le8037bg_overflow
+  mv t5, a6                  # block_state += tx_state_gas
+  addi t3, t3, 1
+  j .Le8037bg_loop
+.Le8037bg_done:
+  mv a5, t4                  # block_gas_used = block_regular
+  bgeu t4, t5, .Le8037bg_have_max
+  mv a5, t5                  # block_gas_used = block_state
+.Le8037bg_have_max:
+  sd a5, 0(a4)
+  bne a5, a3, .Le8037bg_mismatch
+  li a0, 0
+  mv a1, a5
+  ret
+.Le8037bg_mismatch:
+  li a0, 1
+  mv a1, a5
+  ret
+.Le8037bg_overflow:
+  sd zero, 0(a4)
+  li a0, 2
+  li a1, 0
+  ret

--- a/scripts/asm-fixtures/enrgU32leFunction.s
+++ b/scripts/asm-fixtures/enrgU32leFunction.s
@@ -1,0 +1,6 @@
+enrg_u32le:
+  lbu t0, 0(a0)
+  lbu t1, 1(a0); slli t1, t1, 8; or t0, t0, t1
+  lbu t1, 2(a0); slli t1, t1, 16; or t0, t0, t1
+  lbu t1, 3(a0); slli t1, t1, 24; or a0, t0, t1
+  ret

--- a/scripts/asm-fixtures/execLogLatestValueFunction.s
+++ b/scripts/asm-fixtures/execLogLatestValueFunction.s
@@ -1,0 +1,27 @@
+exec_log_latest_value:
+  li t6, 0                      # found flag
+  li t0, 0                      # entry index i
+.Lelv_loop:
+  beq t0, a3, .Lelv_done
+  slli t1, t0, 7; add t2, a2, t1   # entry ptr = base + i*128
+  # match addrHash (entry@0 vs a0)
+  ld t3, 0(t2);  ld t4, 0(a0);  bne t3, t4, .Lelv_next
+  ld t3, 8(t2);  ld t4, 8(a0);  bne t3, t4, .Lelv_next
+  ld t3, 16(t2); ld t4, 16(a0); bne t3, t4, .Lelv_next
+  ld t3, 24(t2); ld t4, 24(a0); bne t3, t4, .Lelv_next
+  # match slotKey (entry@32 vs a1)
+  ld t3, 32(t2); ld t4, 0(a1);  bne t3, t4, .Lelv_next
+  ld t3, 40(t2); ld t4, 8(a1);  bne t3, t4, .Lelv_next
+  ld t3, 48(t2); ld t4, 16(a1); bne t3, t4, .Lelv_next
+  ld t3, 56(t2); ld t4, 24(a1); bne t3, t4, .Lelv_next
+  # matching entry: copy current (entry@96) -> out; set found. Overwrite keeps the LAST match.
+  ld t3, 96(t2);  sd t3, 0(a4)
+  ld t3, 104(t2); sd t3, 8(a4)
+  ld t3, 112(t2); sd t3, 16(a4)
+  ld t3, 120(t2); sd t3, 24(a4)
+  li t6, 1
+.Lelv_next:
+  addi t0, t0, 1; j .Lelv_loop
+.Lelv_done:
+  mv a0, t6
+  ret

--- a/scripts/asm-fixtures/expGasFunction.s
+++ b/scripts/asm-fixtures/expGasFunction.s
@@ -1,0 +1,15 @@
+exp_gas:
+  li t0, 0                          # i = leading-zero byte count (scan from MSB)
+.Lexp_lead:
+  li t1, 32; beq t0, t1, .Lexp_zero # all 32 bytes zero -> exponent_bytes = 0
+  add t2, a0, t0; lbu t2, 0(t2)
+  bnez t2, .Lexp_found
+  addi t0, t0, 1; j .Lexp_lead
+.Lexp_found:
+  li t1, 32; sub t1, t1, t0         # exponent_bytes = 32 - i
+  li t2, 50; mul t1, t1, t2         # 50 * exponent_bytes
+  addi a0, t1, 10                   # + EXP base
+  ret
+.Lexp_zero:
+  li a0, 10
+  ret

--- a/scripts/asm-fixtures/findCodeEffectByAddressFunction.s
+++ b/scripts/asm-fixtures/findCodeEffectByAddressFunction.s
@@ -1,0 +1,17 @@
+find_code_effect_by_address:
+  mv t0, a0                   # cursor (entry base)
+  mv t1, a1                   # remaining count
+.Lfce_loop:
+  beqz t1, .Lfce_none
+  mv t2, t0; mv t3, a2; li t4, 20
+.Lfce_cmp:
+  beqz t4, .Lfce_found
+  lbu t5, 0(t2); lbu t6, 0(t3); bne t5, t6, .Lfce_next
+  addi t2, t2, 1; addi t3, t3, 1; addi t4, t4, -1; j .Lfce_cmp
+.Lfce_next:
+  ld t5, 40(t0); addi t5, t5, 55; andi t5, t5, -8   # stride = round8(48 + code_len)
+  add t0, t0, t5; addi t1, t1, -1; j .Lfce_loop
+.Lfce_found:
+  mv a0, t0; ret
+.Lfce_none:
+  li a0, 0; ret

--- a/scripts/asm-fixtures/headersParentHashFunction.s
+++ b/scripts/asm-fixtures/headersParentHashFunction.s
@@ -1,0 +1,37 @@
+headers_parent_hash:
+  # a0 = header ptr, a1 = header_len, a2 = out ptr
+  lbu t0, 0(a0)                # first byte
+  li t1, 0xc0
+  bltu t0, t1, .Lhph_fail      # not an RLP list (< 0xc0)
+  li t1, 0xf8
+  bltu t0, t1, .Lhph_short     # 0xc0..0xf7 → short list, 1-byte prefix
+  # long list: t0 in [0xf8..0xff].
+  # length_of_length = t0 - 0xf7. Outer prefix = 1 + length_of_length bytes.
+  li t1, 0xf7
+  sub t2, t0, t1               # length_of_length
+  li t3, 2                     # cap: support 0xf8 (LoL=1), 0xf9 (LoL=2)
+  bltu t3, t2, .Lhph_fail      # LoL > 2 → unsupported
+  addi t2, t2, 1               # prefix bytes = LoL + 1
+  add a0, a0, t2               # skip prefix
+  sub a1, a1, t2
+  j .Lhph_after_prefix
+.Lhph_short:
+  addi a0, a0, 1               # skip 1-byte prefix
+  addi a1, a1, -1
+.Lhph_after_prefix:
+  # Expect 0xa0 Bytes32 prefix.
+  li t0, 33
+  bltu a1, t0, .Lhph_fail      # not enough bytes for 0xa0 + 32
+  lbu t1, 0(a0)
+  li t2, 0xa0
+  bne t1, t2, .Lhph_fail       # not a Bytes32 string
+  # Copy 32 bytes from a0+1 to a2.
+  ld t0,  1(a0); sd t0,  0(a2)
+  ld t0,  9(a0); sd t0,  8(a2)
+  ld t0, 17(a0); sd t0, 16(a2)
+  ld t0, 25(a0); sd t0, 24(a2)
+  li a0, 0
+  ret
+.Lhph_fail:
+  li a0, 1
+  ret

--- a/scripts/asm-fixtures/initCodeCostFunction.s
+++ b/scripts/asm-fixtures/initCodeCostFunction.s
@@ -1,0 +1,7 @@
+init_code_cost:
+  addi t0, a0, 31             # len + 31
+  srli t0, t0, 5              # / 32 → ceil(len/32)
+  mul t0, t0, a1              # × gas_per_word
+  sd t0, 0(a2)
+  li a0, 0
+  ret

--- a/scripts/asm-fixtures/intrinsicGasCalldataFloorEip7623Function.s
+++ b/scripts/asm-fixtures/intrinsicGasCalldataFloorEip7623Function.s
@@ -1,0 +1,28 @@
+intrinsic_gas_calldata_floor_eip7623:
+  # Count zeros and non-zeros in one pass.
+  li t0, 0                    # zero_count
+  li t1, 0                    # non_zero_count
+  mv t2, a0                   # cursor
+  mv t3, a1                   # remaining
+.Ligcf_loop:
+  beqz t3, .Ligcf_done
+  lbu t4, 0(t2)
+  bnez t4, .Ligcf_nz
+  addi t0, t0, 1
+  j .Ligcf_step
+.Ligcf_nz:
+  addi t1, t1, 1
+.Ligcf_step:
+  addi t2, t2, 1
+  addi t3, t3, -1
+  j .Ligcf_loop
+.Ligcf_done:
+  # tokens = zero + non_zero × token_per_nonzero
+  mul t5, t1, a3              # non_zero × token_per_nz
+  add t5, t5, t0              # tokens
+  # floor = tokens × floor_gas_per_token + base_gas
+  mul t6, t5, a2
+  add t6, t6, a4
+  sd t6, 0(a5)
+  li a0, 0
+  ret

--- a/scripts/asm-fixtures/keccak256WordGasFunction.s
+++ b/scripts/asm-fixtures/keccak256WordGasFunction.s
@@ -1,0 +1,5 @@
+keccak256_word_gas:
+  addi t0, a0, 31; srli t0, t0, 5   # words
+  li t1, 6; mul t0, t0, t1
+  addi a0, t0, 30                   # + KECCAK256 base
+  ret

--- a/scripts/asm-fixtures/logDataGasFunction.s
+++ b/scripts/asm-fixtures/logDataGasFunction.s
@@ -1,0 +1,6 @@
+log_data_gas:
+  li t0, 375; mul t1, a0, t0        # 375 * num_topics
+  add t1, t1, t0                    # + LOG base (375)
+  li t2, 8; mul t2, a1, t2          # 8 * data_bytes
+  add a0, t1, t2
+  ret

--- a/scripts/asm-fixtures/memoryExpansionGasFunction.s
+++ b/scripts/asm-fixtures/memoryExpansionGasFunction.s
@@ -1,0 +1,16 @@
+memory_expansion_gas:
+  bgeu a0, a1, .Lmeg_zero        # new <= old -> no expansion
+  addi t0, a0, 31; srli t0, t0, 5   # t0 = words_old = (old+31)/32
+  addi t1, a1, 31; srli t1, t1, 5   # t1 = words_new = (new+31)/32
+  li t2, 3
+  mul t3, t0, t2                 # words_old * 3
+  mul t4, t0, t0; srli t4, t4, 9 # words_old^2 / 512
+  add t3, t3, t4                 # cost_old
+  mul t5, t1, t2                 # words_new * 3
+  mul t6, t1, t1; srli t6, t6, 9 # words_new^2 / 512
+  add t5, t5, t6                 # cost_new
+  sub a0, t5, t3                 # expansion = cost_new - cost_old
+  ret
+.Lmeg_zero:
+  li a0, 0
+  ret

--- a/scripts/asm-fixtures/parentHeaderMatchesWitnessFirstFunction.s
+++ b/scripts/asm-fixtures/parentHeaderMatchesWitnessFirstFunction.s
@@ -1,0 +1,59 @@
+parent_header_matches_witness_first:
+  addi sp, sp, -64
+  sd ra,  0(sp)
+  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)
+  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)
+  mv s0, a0                  # parent_header_rlp ptr
+  mv s1, a1                  # parent_header_rlp_len
+  mv s2, a2                  # section ptr
+  mv s3, a3                  # section_len
+  mv s4, a4                  # is_match out ptr
+  sd zero, 0(s4)
+  beqz s3, .Lphmw_empty       # empty section -> status 1
+  # Compute element 0 bounds (SSZ list).
+  lwu t0, 0(s2)
+  srli t0, t0, 2              # N = first_offset / 4
+  beqz t0, .Lphmw_empty      # zero entries
+  lwu t1, 0(s2)               # el_0 inner offset (= 4 * N)
+  add s5, s2, t1              # el_0 start
+  # el_0 end: if N > 1, read offset[1] (4 bytes at offset 4); else use section_end.
+  li t2, 1
+  bgtu t0, t2, .Lphmw_have_next
+  add s6, s2, s3              # el_0_end = section_end
+  j .Lphmw_compare
+.Lphmw_have_next:
+  lwu t2, 4(s2)
+  add s6, s2, t2              # el_0_end = section + inner_off[1]
+.Lphmw_compare:
+  sub t0, s6, s5              # el_0 length
+  # Length must match parent_header_rlp_len.
+  bne t0, s1, .Lphmw_no_match_success
+  # Byte-compare s0..s0+s1 against s5..s6.
+  mv t1, s0
+  mv t2, s5
+  mv t3, s1
+.Lphmw_loop:
+  beqz t3, .Lphmw_match
+  lbu t4, 0(t1)
+  lbu t5, 0(t2)
+  bne t4, t5, .Lphmw_no_match_success
+  addi t1, t1, 1
+  addi t2, t2, 1
+  addi t3, t3, -1
+  j .Lphmw_loop
+.Lphmw_match:
+  li t1, 1
+  sd t1, 0(s4)
+  li a0, 0
+  j .Lphmw_ret
+.Lphmw_no_match_success:
+  li a0, 0
+  j .Lphmw_ret
+.Lphmw_empty:
+  li a0, 1
+.Lphmw_ret:
+  ld ra,  0(sp)
+  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)
+  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)
+  addi sp, sp, 64
+  ret

--- a/scripts/asm-fixtures/senderPostNonceConsistentFunction.s
+++ b/scripts/asm-fixtures/senderPostNonceConsistentFunction.s
@@ -1,0 +1,16 @@
+sender_post_nonce_consistent:
+  ld t0, 128(a0)              # post nonce byte length
+  li t1, -1; beq t0, t1, .Lspnc_skip       # absent -> skip
+  li t1, 8;  bgtu t0, t1, .Lspnc_skip       # > u64 -> skip
+  addi t2, a0, 136; li t3, 0; mv t4, t0     # decode big-endian post nonce
+.Lspnc_be:
+  beqz t4, .Lspnc_de
+  slli t3, t3, 8; lbu t5, 0(t2); or t3, t3, t5; addi t2, t2, 1; addi t4, t4, -1; j .Lspnc_be
+.Lspnc_de:
+  ld t4, 80(a0); addi t4, t4, 1             # expected = pre nonce + 1
+  beq t3, t4, .Lspnc_match
+  li a0, 1; ret                             # mismatch
+.Lspnc_match:
+  li a0, 0; ret
+.Lspnc_skip:
+  li a0, 2; ret

--- a/scripts/asm-fixtures/slotDecodeU256Function.s
+++ b/scripts/asm-fixtures/slotDecodeU256Function.s
@@ -1,0 +1,38 @@
+slot_decode_u256:
+  # a0 = val_bytes ptr, a1 = val_len, a2 = 32-byte BE out ptr.
+  # Returns 0 (ok) / 1 (fail). Output is zeroed on every path.
+  sd zero,  0(a2); sd zero,  8(a2); sd zero, 16(a2); sd zero, 24(a2)
+  beqz a1, .Lsdu_fail        # empty input: malformed encoded value
+  lbu t0, 0(a0)
+  li t1, 0x80
+  bltu t0, t1, .Lsdu_single  # b0 < 0x80: single byte
+  beq t0, t1, .Lsdu_zero     # b0 == 0x80: empty string ⇒ 0
+  li t1, 0xa1
+  bgeu t0, t1, .Lsdu_fail    # b0 ≥ 0xa1: too long for a u256
+  # Short string of n bytes (1 ≤ n ≤ 32).
+  li t1, 0x80
+  sub t2, t0, t1             # n
+  addi t3, a1, -1
+  bltu t3, t2, .Lsdu_fail    # not enough bytes for declared length
+  li t4, 32
+  sub t4, t4, t2             # 32 - n
+  add t5, a2, t4             # dst (right-aligned)
+  addi t6, a0, 1             # src
+  mv t3, t2                  # remaining
+.Lsdu_copy:
+  beqz t3, .Lsdu_ok
+  lbu t1, 0(t6)
+  sb  t1, 0(t5)
+  addi t5, t5, 1
+  addi t6, t6, 1
+  addi t3, t3, -1
+  j .Lsdu_copy
+.Lsdu_single:
+  sb t0, 31(a2)              # write u256 = b0 at byte 31 (BE LSB)
+.Lsdu_zero:
+.Lsdu_ok:
+  li a0, 0
+  ret
+.Lsdu_fail:
+  li a0, 1
+  ret

--- a/scripts/asm-fixtures/slotTupleSequencesMatchFunction.s
+++ b/scripts/asm-fixtures/slotTupleSequencesMatchFunction.s
@@ -1,0 +1,18 @@
+slot_tuple_sequences_match:
+  bne a1, a3, .Lstsm_bad        # length mismatch -> reject
+  li t0, 0                      # i
+.Lstsm_loop:
+  beq t0, a1, .Lstsm_ok
+  slli t1, t0, 5; slli t2, t0, 3; add t1, t1, t2   # i*40
+  add t3, a0, t1                # BAL record i
+  add t4, a2, t1                # exec record i
+  ld t5, 0(t3);  ld t6, 0(t4);  bne t5, t6, .Lstsm_bad   # block_access_index
+  ld t5, 8(t3);  ld t6, 8(t4);  bne t5, t6, .Lstsm_bad   # value[0:8]
+  ld t5, 16(t3); ld t6, 16(t4); bne t5, t6, .Lstsm_bad   # value[8:16]
+  ld t5, 24(t3); ld t6, 24(t4); bne t5, t6, .Lstsm_bad   # value[16:24]
+  ld t5, 32(t3); ld t6, 32(t4); bne t5, t6, .Lstsm_bad   # value[24:32]
+  addi t0, t0, 1; j .Lstsm_loop
+.Lstsm_ok:
+  li a0, 0; ret
+.Lstsm_bad:
+  li a0, 1; ret

--- a/scripts/asm-fixtures/swdMinimalCopyFunction.s
+++ b/scripts/asm-fixtures/swdMinimalCopyFunction.s
@@ -1,0 +1,16 @@
+swd_minimal_copy:
+  mv t0, a0                   # src cursor
+  mv t1, a1                   # remaining
+.Lswd_skip:
+  beqz t1, .Lswd_emit         # all zero -> length 0
+  lbu t2, 0(t0); bnez t2, .Lswd_emit
+  addi t0, t0, 1; addi t1, t1, -1; j .Lswd_skip
+.Lswd_emit:
+  sd t1, 0(a3)                # out length = remaining
+  mv t3, a2; li t4, 0
+.Lswd_cp:
+  beq t4, t1, .Lswd_cpd
+  add t5, t0, t4; lbu t6, 0(t5); add t2, t3, t4; sb t6, 0(t2)
+  addi t4, t4, 1; j .Lswd_cp
+.Lswd_cpd:
+  ret

--- a/scripts/asm-fixtures/swdReadU64leFunction.s
+++ b/scripts/asm-fixtures/swdReadU64leFunction.s
@@ -1,0 +1,11 @@
+swd_read_u64le:
+  lbu t0, 0(a0)
+  lbu t1, 1(a0); slli t1, t1, 8;  or t0, t0, t1
+  lbu t1, 2(a0); slli t1, t1, 16; or t0, t0, t1
+  lbu t1, 3(a0); slli t1, t1, 24; or t0, t0, t1
+  lbu t1, 4(a0); slli t1, t1, 32; or t0, t0, t1
+  lbu t1, 5(a0); slli t1, t1, 40; or t0, t0, t1
+  lbu t1, 6(a0); slli t1, t1, 48; or t0, t0, t1
+  lbu t1, 7(a0); slli t1, t1, 56; or t0, t0, t1
+  mv a0, t0
+  ret

--- a/scripts/asm-fixtures/swdWriteBe32U64Function.s
+++ b/scripts/asm-fixtures/swdWriteBe32U64Function.s
@@ -1,0 +1,16 @@
+swd_write_be32_u64:
+  li t0, 0
+.Lswd_z:
+  li t1, 32; beq t0, t1, .Lswd_zd
+  add t2, a1, t0; sb x0, 0(t2); addi t0, t0, 1; j .Lswd_z
+.Lswd_zd:
+  # write the 8 BE bytes into offsets 24..31
+  li t0, 0
+.Lswd_b:
+  li t1, 8; beq t0, t1, .Lswd_bd
+  li t2, 56; slli t3, t0, 3; sub t2, t2, t3   # shift = 56 - 8*t0
+  srl t4, a0, t2; andi t4, t4, 0xff
+  addi t5, a1, 24; add t5, t5, t0; sb t4, 0(t5)
+  addi t0, t0, 1; j .Lswd_b
+.Lswd_bd:
+  ret

--- a/scripts/asm-fixtures/swdWriteBe8Function.s
+++ b/scripts/asm-fixtures/swdWriteBe8Function.s
@@ -1,0 +1,10 @@
+swd_write_be8:
+  li t0, 0
+.Lswd8:
+  li t1, 8; beq t0, t1, .Lswd8d
+  li t2, 56; slli t3, t0, 3; sub t2, t2, t3
+  srl t4, a0, t2; andi t4, t4, 0xff
+  add t5, a1, t0; sb t4, 0(t5)
+  addi t0, t0, 1; j .Lswd8
+.Lswd8d:
+  ret

--- a/scripts/asm-fixtures/txGasResultIncrementsFunction.s
+++ b/scripts/asm-fixtures/txGasResultIncrementsFunction.s
@@ -1,0 +1,31 @@
+tx_gas_result_increments:
+  bgtu a1, a0, .Ltgri_bad_remaining
+  sub t0, a0, a1              # before_refund
+  li t1, 5
+  divu t2, t0, t1             # refund cap = before_refund / 5
+  mv t3, a2                   # refund_counter
+  bleu t3, t2, .Ltgri_refund_min_done
+  mv t3, t2
+.Ltgri_refund_min_done:
+  sub t4, t0, t3              # after_refund
+  mv t5, t0                   # block_inc = max(before_refund, floor)
+  bleu a3, t5, .Ltgri_block_max_done
+  mv t5, a3
+.Ltgri_block_max_done:
+  mv t6, t4                   # receipt_inc = max(after_refund, floor)
+  bleu a3, t6, .Ltgri_receipt_max_done
+  mv t6, a3
+.Ltgri_receipt_max_done:
+  li a0, 0
+  mv a1, t5
+  mv a2, t6
+  mv a3, t0
+  mv a4, t3
+  ret
+.Ltgri_bad_remaining:
+  li a0, 1
+  li a1, 0
+  li a2, 0
+  li a3, 0
+  li a4, 0
+  ret

--- a/scripts/asm-fixtures/txPubkeyEcrecoverStageMaterialFunction.s
+++ b/scripts/asm-fixtures/txPubkeyEcrecoverStageMaterialFunction.s
@@ -1,0 +1,39 @@
+tx_pubkey_ecrecover_stage_material:
+  addi sp, sp, -32
+  sd s0,  0(sp); sd s1,  8(sp); sd s2, 16(sp); sd s3, 24(sp)
+  mv s0, a0                   # material ptr
+  mv s1, a1                   # staging ptr
+  ld s2, 8(s0)                # recid
+  li t0, 1
+  bgtu s2, t0, .Ltpes_bad_recid
+  # message hash = material.signing_hash
+  addi t0, s0, 80
+  mv t1, s1
+  li t2, 4
+.Ltpes_copy_hash:
+  ld t3, 0(t0); sd t3, 0(t1)
+  addi t0, t0, 8; addi t1, t1, 8; addi t2, t2, -1
+  bnez t2, .Ltpes_copy_hash
+  # signature = r || s
+  addi t0, s0, 16
+  addi t1, s1, 32
+  li t2, 8
+.Ltpes_copy_sig:
+  ld t3, 0(t0); sd t3, 0(t1)
+  addi t0, t0, 8; addi t1, t1, 8; addi t2, t2, -1
+  bnez t2, .Ltpes_copy_sig
+  sd s2, 96(s1)
+  addi t1, s1, 104
+  li t2, 8
+.Ltpes_zero_pubkey:
+  sd zero, 0(t1)
+  addi t1, t1, 8; addi t2, t2, -1
+  bnez t2, .Ltpes_zero_pubkey
+  li a0, 0
+  j .Ltpes_ret
+.Ltpes_bad_recid:
+  li a0, 1
+.Ltpes_ret:
+  ld s0,  0(sp); ld s1,  8(sp); ld s2, 16(sp); ld s3, 24(sp)
+  addi sp, sp, 32
+  ret

--- a/scripts/asm-fixtures/txRefundCapFunction.s
+++ b/scripts/asm-fixtures/txRefundCapFunction.s
@@ -1,0 +1,26 @@
+tx_refund_cap:
+  bltu a0, a1, .Ltrc_invalid
+  sub t0, a0, a1              # gas_used_before_refund
+  sd t0, 0(a3)
+  li t1, 5
+  divu t2, t0, t1             # one-fifth cap
+  sd t2, 8(a3)
+  mv t3, a2
+  bltu t2, t3, .Ltrc_use_cap
+  mv t4, t3
+  j .Ltrc_apply
+.Ltrc_use_cap:
+  mv t4, t2
+.Ltrc_apply:
+  sd t4, 16(a3)
+  sub t5, t0, t4
+  sd t5, 24(a3)
+  li a0, 0
+  ret
+.Ltrc_invalid:
+  sd zero, 0(a3)
+  sd zero, 8(a3)
+  sd zero, 16(a3)
+  sd zero, 24(a3)
+  li a0, 1
+  ret

--- a/scripts/asm-fixtures/txTypeDispatchFunction.s
+++ b/scripts/asm-fixtures/txTypeDispatchFunction.s
@@ -1,0 +1,52 @@
+tx_type_dispatch:
+  beqz a1, .Ltd_fail
+  lbu t0, 0(a0)
+  li t1, 0xc0
+  bgeu t0, t1, .Ltd_legacy
+  li t1, 1
+  beq t0, t1, .Ltd_t1
+  li t1, 2
+  beq t0, t1, .Ltd_t2
+  li t1, 3
+  beq t0, t1, .Ltd_t3
+  li t1, 4
+  beq t0, t1, .Ltd_t4
+  j .Ltd_fail
+.Ltd_legacy:
+  sd zero, 0(a2)
+  sd zero, 0(a3)
+  li a0, 0
+  ret
+.Ltd_t1:
+  li t0, 1
+  sd t0, 0(a2)
+  li t1, 1
+  sd t1, 0(a3)
+  li a0, 0
+  ret
+.Ltd_t2:
+  li t0, 2
+  sd t0, 0(a2)
+  li t1, 1
+  sd t1, 0(a3)
+  li a0, 0
+  ret
+.Ltd_t3:
+  li t0, 3
+  sd t0, 0(a2)
+  li t1, 1
+  sd t1, 0(a3)
+  li a0, 0
+  ret
+.Ltd_t4:
+  li t0, 4
+  sd t0, 0(a2)
+  li t1, 1
+  sd t1, 0(a3)
+  li a0, 0
+  ret
+.Ltd_fail:
+  sd zero, 0(a2)
+  sd zero, 0(a3)
+  li a0, 1
+  ret

--- a/scripts/asm-fixtures/txValidateAgainstBlockFunction.s
+++ b/scripts/asm-fixtures/txValidateAgainstBlockFunction.s
@@ -1,0 +1,15 @@
+tx_validate_against_block:
+  bne a0, a1, .Ltvab_fail_chain
+  bgtu a2, a3, .Ltvab_fail_gas
+  bne a4, a5, .Ltvab_fail_nonce
+  li a0, 0
+  ret
+.Ltvab_fail_chain:
+  li a0, 1
+  ret
+.Ltvab_fail_gas:
+  li a0, 2
+  ret
+.Ltvab_fail_nonce:
+  li a0, 3
+  ret

--- a/scripts/asm-fixtures/validateHeaderBasicFunction.s
+++ b/scripts/asm-fixtures/validateHeaderBasicFunction.s
@@ -1,0 +1,23 @@
+validate_header_basic:
+  ld t0, 88(a0)              # this.gas_used
+  ld t1, 80(a0)              # this.gas_limit
+  bgtu t0, t1, .Lvhb_fail_gas
+  ld t0, 64(a0)              # this.number
+  beqz t0, .Lvhb_fail_number
+  ld t1, 64(a1)              # parent.number
+  addi t1, t1, 1
+  bne t0, t1, .Lvhb_fail_number
+  ld t0, 72(a0)              # this.timestamp
+  ld t1, 72(a1)              # parent.timestamp
+  bgeu t1, t0, .Lvhb_fail_timestamp  # parent_ts >= this_ts → fail
+  li a0, 0
+  ret
+.Lvhb_fail_gas:
+  li a0, 1
+  ret
+.Lvhb_fail_number:
+  li a0, 2
+  ret
+.Lvhb_fail_timestamp:
+  li a0, 3
+  ret

--- a/scripts/asm-fixtures/witnessCodesValidateLengthsFunction.s
+++ b/scripts/asm-fixtures/witnessCodesValidateLengthsFunction.s
@@ -1,0 +1,52 @@
+witness_codes_validate_lengths:
+  addi sp, sp, -64
+  sd ra,  0(sp)
+  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)
+  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)
+  mv s0, a0                  # section ptr
+  mv s1, a1                  # section_len
+  mv s2, a2                  # max_byte_length
+  mv s3, a3                  # n_processed out
+  mv s4, a4                  # first_bad_index out
+  sd zero, 0(s3)
+  li t0, -1
+  sd t0, 0(s4)
+  beqz s1, .Lwcvl_ok           # empty section ⇒ vacuous-valid
+  lwu t0, 0(s0)
+  srli s5, t0, 2               # s5 = N
+  li s6, 0                     # s6 = i
+.Lwcvl_loop:
+  beq s6, s5, .Lwcvl_ok
+  # Element i bounds.
+  slli t0, s6, 2
+  add t1, s0, t0
+  lwu t2, 0(t1)                # inner_off_i
+  addi t3, s6, 1
+  beq t3, s5, .Lwcvl_use_end
+  slli t3, t3, 2
+  add t3, s0, t3
+  lwu t4, 0(t3)                # inner_off_{i+1}
+  sub t5, t4, t2               # el_i_len
+  j .Lwcvl_check
+.Lwcvl_use_end:
+  sub t5, s1, t2               # el_i_len = section_len - inner_off_i
+.Lwcvl_check:
+  bgtu t5, s2, .Lwcvl_too_long
+  addi s6, s6, 1
+  j .Lwcvl_loop
+.Lwcvl_too_long:
+  sd s6, 0(s3)                 # n_processed = i
+  sd s6, 0(s4)                 # first_bad_index = i
+  li a0, 1
+  j .Lwcvl_ret
+.Lwcvl_ok:
+  sd s5, 0(s3)                 # n_processed = N
+  li t0, -1
+  sd t0, 0(s4)
+  li a0, 0
+.Lwcvl_ret:
+  ld ra,  0(sp)
+  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)
+  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)
+  addi sp, sp, 64
+  ret


### PR DESCRIPTION
Part of bead `evm-asm-4ch8f.9.1` (asm→Program wave 1). **PR 1c of 4** — stacked on #9717 (1b).

## What
Converts **23 CONVERTED-CLEAN gas/tx/header/account/block leaf functions**: `Account`, `DynamicOpcodeGas` (×4), `IntrinsicGas` (×4), `MemoryExpansionGas`, `Header` (×2), `Tx` (×2), `TxExtract`, `TxPubkey`, `TxRefund`, `HeadersKeccak`, `BlockAccessListHash`, `CallFrameDescend`, `CreateCodeEffectLog`, `Eip7702NonceReuseGuard`, `BlockHashPredicates`.

Each def rewritten in place to `"label:\n" ++ emitProgram foo_prog` with the `rfl` drift-guard theorem and `#guard` length pins; fixtures + MANIFEST rows added.

## Gates (all pass)
- `check-asm-to-program.sh` → **CLEAN** (108 defs across 45 files).
- Full `lake build` → **green** (3742 jobs).
- **Whole-guest byte-identity** vs `main`: `stateless_guest` **IDENTICAL** (360792 B), `runtime_dispatcher` **IDENTICAL** (170160 B).
- forbidden-tactics / file-size / unimported → pass.

## Notes for reviewer (Fable)
- No `native_decide`/`bv_decide`/`sorry`; conversions need only `rfl`/`#guard`.
- Instruction bytes preserved; only canonical `emitProgram` normalization applied. No function hit the `MULTI-ENTRY-BUNDLE` guard added in 1b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)