### PR TITLE
feat(codegen): asm→Program wave 1d — state/storage/bal/witness conversions + coverage (4ch8f.9.1)

### DIFF
--- a/EvmAsm/Codegen/Programs/BalGasValid.lean
+++ b/EvmAsm/Codegen/Programs/BalGasValid.lean
@@ -25,6 +25,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.RlpWalk
 
 namespace EvmAsm.Codegen
@@ -104,26 +105,60 @@ def balGasValidFunction : String :=
   "  ret"
 
 /-! ## bgv_u32le -- read a little-endian u32 byte-wise (a0=ptr -> a0). Leaf. -/
+def bgvU32le_prog : Program :=
+  [ .LBU .x5 .x10 (0 : BitVec 12),
+    .LBU .x6 .x10 (1 : BitVec 12),
+    .SLLI .x6 .x6 (8 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (2 : BitVec 12),
+    .SLLI .x6 .x6 (16 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (3 : BitVec 12),
+    .SLLI .x6 .x6 (24 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .MV .x10 .x5,
+    .JALR .x0 .x1 (0 : BitVec 12) ]
+
 def bgvU32leFunction : String :=
-  "bgv_u32le:\n" ++
-  "  lbu t0, 0(a0)\n" ++
-  "  lbu t1, 1(a0); slli t1, t1, 8;  or t0, t0, t1\n" ++
-  "  lbu t1, 2(a0); slli t1, t1, 16; or t0, t0, t1\n" ++
-  "  lbu t1, 3(a0); slli t1, t1, 24; or t0, t0, t1\n" ++
-  "  mv a0, t0\n" ++
-  "  ret"
+  "bgv_u32le:\n" ++ emitProgram bgvU32le_prog
 
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `bgvU32le_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem bgvU32leFunction_eq_prog :
+    bgvU32leFunction = "bgv_u32le:\n" ++ emitProgram bgvU32le_prog := rfl
+
+#guard bgvU32leFunction.startsWith "bgv_u32le:\n"
+#guard bgvU32le_prog.length = 12
 /-! ## bgv_u64le -- read a little-endian u64 byte-wise (a0=ptr -> a0). Leaf. -/
-def bgvU64leFunction : String :=
-  "bgv_u64le:\n" ++
-  "  li t0, 0; li t2, 0\n" ++
-  ".Lbgv64:\n" ++
-  "  li t3, 8; beq t2, t3, .Lbgv64d\n" ++
-  "  add t4, a0, t2; lbu t5, 0(t4); slli t6, t2, 3; sll t5, t5, t6; or t0, t0, t5\n" ++
-  "  addi t2, t2, 1; j .Lbgv64\n" ++
-  ".Lbgv64d:\n" ++
-  "  mv a0, t0; ret"
+def bgvU64le_prog : Program :=
+  [ .LI .x5 (0 : Word),
+    .LI .x7 (0 : Word),
+    .LI .x28 (8 : Word),
+    .BEQ .x7 .x28 (32 : BitVec 13),
+    .ADD .x29 .x10 .x7,
+    .LBU .x30 .x29 (0 : BitVec 12),
+    .SLLI .x31 .x7 (3 : BitVec 6),
+    .SLL .x30 .x30 .x31,
+    .OR .x5 .x5 .x30,
+    .ADDI .x7 .x7 (1 : BitVec 12),
+    .JAL .x0 (-32 : BitVec 21),
+    .MV .x10 .x5,
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def bgvU64leFunction : String :=
+  "bgv_u64le:\n" ++ emitProgram bgvU64le_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `bgvU64le_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem bgvU64leFunction_eq_prog :
+    bgvU64leFunction = "bgv_u64le:\n" ++ emitProgram bgvU64le_prog := rfl
+
+#guard bgvU64leFunction.startsWith "bgv_u64le:\n"
+#guard bgvU64le_prog.length = 13
 /-! ## bal_section_info -- locate BAL RLP inside an SszStatelessInput.
     a0 = SSZ_BASE   a1 = out BAL ptr   a2 = out BAL len   a3 = out account count
     a0 (output) = 0 ok / 1 parse error. -/

--- a/EvmAsm/Codegen/Programs/Blake2f.lean
+++ b/EvmAsm/Codegen/Programs/Blake2f.lean
@@ -34,6 +34,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 
 namespace EvmAsm.Codegen
 
@@ -58,37 +59,57 @@ def blake2fDataFragment : String :=
 
 /-- Load the little-endian u64 at byte pointer a0 (any alignment) into
     a0. Leaf; clobbers t0..t2. -/
-def blake2fLdLe64Function : String :=
-  "blk2_ld_le64:\n" ++
-  "  li t0, 0\n" ++
-  "  addi t1, a0, 7\n" ++
-  "  li t2, 8\n" ++
-  ".Lblk2_ld_byte:\n" ++
-  "  slli t0, t0, 8\n" ++
-  "  lbu a0, 0(t1)\n" ++
-  "  or t0, t0, a0\n" ++
-  "  addi t1, t1, -1\n" ++
-  "  addi t2, t2, -1\n" ++
-  "  bnez t2, .Lblk2_ld_byte\n" ++
-  "  mv a0, t0\n" ++
-  "  ret"
+def blk2LdLe64_prog : Program :=
+  [ .LI .x5 (0 : Word),
+    .ADDI .x6 .x10 (7 : BitVec 12),
+    .LI .x7 (8 : Word),
+    .SLLI .x5 .x5 (8 : BitVec 6),
+    .LBU .x10 .x6 (0 : BitVec 12),
+    .OR .x5 .x5 .x10,
+    .ADDI .x6 .x6 (-1 : BitVec 12),
+    .ADDI .x7 .x7 (-1 : BitVec 12),
+    .BNE .x7 .x0 (-20 : BitVec 13),
+    .MV .x10 .x5,
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def blake2fLdLe64Function : String :=
+  "blk2_ld_le64:\n" ++ emitProgram blk2LdLe64_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `blk2LdLe64_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem blake2fLdLe64Function_eq_prog :
+    blake2fLdLe64Function = "blk2_ld_le64:\n" ++ emitProgram blk2LdLe64_prog := rfl
+
+#guard blake2fLdLe64Function.startsWith "blk2_ld_le64:\n"
+#guard blk2LdLe64_prog.length = 11
 /-- Store a1 as a little-endian u64 at byte pointer a0 (any
     alignment). Leaf; clobbers t0..t2. -/
-def blake2fStLe64Function : String :=
-  "blk2_st_le64:\n" ++
-  "  mv t0, a1\n" ++
-  "  mv t1, a0\n" ++
-  "  li t2, 8\n" ++
-  ".Lblk2_st_byte:\n" ++
-  "  andi a1, t0, 0xff\n" ++
-  "  sb a1, 0(t1)\n" ++
-  "  srli t0, t0, 8\n" ++
-  "  addi t1, t1, 1\n" ++
-  "  addi t2, t2, -1\n" ++
-  "  bnez t2, .Lblk2_st_byte\n" ++
-  "  ret"
+def blk2StLe64_prog : Program :=
+  [ .MV .x5 .x11,
+    .MV .x6 .x10,
+    .LI .x7 (8 : Word),
+    .ANDI .x11 .x5 (255 : BitVec 12),
+    .SB .x6 .x11 (0 : BitVec 12),
+    .SRLI .x5 .x5 (8 : BitVec 6),
+    .ADDI .x6 .x6 (1 : BitVec 12),
+    .ADDI .x7 .x7 (-1 : BitVec 12),
+    .BNE .x7 .x0 (-20 : BitVec 13),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def blake2fStLe64Function : String :=
+  "blk2_st_le64:\n" ++ emitProgram blk2StLe64_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `blk2StLe64_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem blake2fStLe64Function_eq_prog :
+    blake2fStLe64Function = "blk2_st_le64:\n" ++ emitProgram blk2StLe64_prog := rfl
+
+#guard blake2fStLe64Function.startsWith "blk2_st_le64:\n"
+#guard blk2StLe64_prog.length = 10
 /-- Real BLAKE2F kernel (see the module docstring for the ABI). -/
 def zkvmBlake2fRealFunction : String :=
   ".globl zkvm_blake2f\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictSenderCounts.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictSenderCounts.lean
@@ -9,6 +9,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.BlockVerdictParams
 
 namespace EvmAsm.Codegen
@@ -154,38 +155,67 @@ def b1SenderCountTableFunction : String :=
     Returns:
       a0 = 0 and a1 = entry ptr when found
       a0 = 1 when absent/malformed. -/
-def b1SenderTableFindFunction : String :=
-  "b1_sender_table_find:\n" ++
-  "  addi sp, sp, -64\n" ++
-  "  sd ra, 0(sp); sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
-  "  sd s3, 32(sp); sd s4, 40(sp); sd s5, 48(sp)\n" ++
-  "  mv s0, a0; mv s1, a1; mv s2, a2\n" ++
-  "  li s3, 0; mv s4, s1\n" ++
-  ".Lb1stf_loop:\n" ++
-  "  bgeu s3, s4, .Lb1stf_absent\n" ++
-  "  add s5, s3, s4; srli s5, s5, 1\n" ++
-  "  li t0, 40; mul t0, s5, t0; add t1, s0, t0\n" ++
-  "  li t2, 0\n" ++
-  ".Lb1stf_cmp:\n" ++
-  "  li t3, 20; beq t2, t3, .Lb1stf_found\n" ++
-  "  add t3, t1, t2; lbu t4, 0(t3); add t3, s2, t2; lbu t5, 0(t3)\n" ++
-  "  bltu t4, t5, .Lb1stf_entry_less\n" ++
-  "  bltu t5, t4, .Lb1stf_entry_greater\n" ++
-  "  addi t2, t2, 1; j .Lb1stf_cmp\n" ++
-  ".Lb1stf_entry_less:\n" ++
-  "  addi s3, s5, 1; j .Lb1stf_loop\n" ++
-  ".Lb1stf_entry_greater:\n" ++
-  "  mv s4, s5; j .Lb1stf_loop\n" ++
-  ".Lb1stf_found:\n" ++
-  "  li a0, 0; mv a1, t1; j .Lb1stf_ret\n" ++
-  ".Lb1stf_absent:\n" ++
-  "  li a0, 1\n" ++
-  ".Lb1stf_ret:\n" ++
-  "  ld ra, 0(sp); ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
-  "  ld s3, 32(sp); ld s4, 40(sp); ld s5, 48(sp)\n" ++
-  "  addi sp, sp, 64\n" ++
-  "  ret"
+def b1SenderTableFind_prog : Program :=
+  [ .ADDI .x2 .x2 (-64 : BitVec 12),
+    .SD .x2 .x1 (0 : BitVec 12),
+    .SD .x2 .x8 (8 : BitVec 12),
+    .SD .x2 .x9 (16 : BitVec 12),
+    .SD .x2 .x18 (24 : BitVec 12),
+    .SD .x2 .x19 (32 : BitVec 12),
+    .SD .x2 .x20 (40 : BitVec 12),
+    .SD .x2 .x21 (48 : BitVec 12),
+    .MV .x8 .x10,
+    .MV .x9 .x11,
+    .MV .x18 .x12,
+    .LI .x19 (0 : Word),
+    .MV .x20 .x9,
+    .BGEU .x19 .x20 (96 : BitVec 13),
+    .ADD .x21 .x19 .x20,
+    .SRLI .x21 .x21 (1 : BitVec 6),
+    .LI .x5 (40 : Word),
+    .MUL .x5 .x21 .x5,
+    .ADD .x6 .x8 .x5,
+    .LI .x7 (0 : Word),
+    .LI .x28 (20 : Word),
+    .BEQ .x7 .x28 (52 : BitVec 13),
+    .ADD .x28 .x6 .x7,
+    .LBU .x29 .x28 (0 : BitVec 12),
+    .ADD .x28 .x18 .x7,
+    .LBU .x30 .x28 (0 : BitVec 12),
+    .BLTU .x29 .x30 (16 : BitVec 13),
+    .BLTU .x30 .x29 (20 : BitVec 13),
+    .ADDI .x7 .x7 (1 : BitVec 12),
+    .JAL .x0 (-36 : BitVec 21),
+    .ADDI .x19 .x21 (1 : BitVec 12),
+    .JAL .x0 (-72 : BitVec 21),
+    .MV .x20 .x21,
+    .JAL .x0 (-80 : BitVec 21),
+    .LI .x10 (0 : Word),
+    .MV .x11 .x6,
+    .JAL .x0 (8 : BitVec 21),
+    .LI .x10 (1 : Word),
+    .LD .x1 .x2 (0 : BitVec 12),
+    .LD .x8 .x2 (8 : BitVec 12),
+    .LD .x9 .x2 (16 : BitVec 12),
+    .LD .x18 .x2 (24 : BitVec 12),
+    .LD .x19 .x2 (32 : BitVec 12),
+    .LD .x20 .x2 (40 : BitVec 12),
+    .LD .x21 .x2 (48 : BitVec 12),
+    .ADDI .x2 .x2 (64 : BitVec 12),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def b1SenderTableFindFunction : String :=
+  "b1_sender_table_find:\n" ++ emitProgram b1SenderTableFind_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `b1SenderTableFind_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem b1SenderTableFindFunction_eq_prog :
+    b1SenderTableFindFunction = "b1_sender_table_find:\n" ++ emitProgram b1SenderTableFind_prog := rfl
+
+#guard b1SenderTableFindFunction.startsWith "b1_sender_table_find:\n"
+#guard b1SenderTableFind_prog.length = 47
 /-- Shared scratch arena for `b1_sender_count_table`. -/
 def b1SenderCountTableScratchDataSection : String :=
   ".balign 32\n" ++

--- a/EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean
+++ b/EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean
@@ -9,6 +9,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.BlockVerdictParams
 
 namespace EvmAsm.Codegen
@@ -31,32 +32,75 @@ open EvmAsm.Rv64
     then recipient[0..20] copied into bytes 0..20. Slot/original/current payload
     bytes are copied from the live entry. Overflow is checked before each append,
     so the first out-of-capacity entry leaves table memory untouched. -/
-def committedStorageSnapshotAppendFunction : String :=
-  "bv_mtx_committed_snapshot_append:\n" ++
-  "  li t0, 0                      # j = 0\n" ++
-  ".Lcssa_loop:\n" ++
-  "  beq t0, a2, .Lcssa_done\n" ++
-  "  bgeu a4, a5, .Lcssa_overflow\n" ++
-  "  slli t1, t0, 7; add t1, a1, t1   # src = live[j]\n" ++
-  "  slli t2, a4, 7; add t2, a3, t2   # dst = table[count]\n" ++
-  "  sd zero, 0(t2); sd zero, 8(t2); sd zero, 16(t2); sd zero, 24(t2)\n" ++
-  "  li t3, 0\n" ++
-  ".Lcssa_addr:\n" ++
-  "  li t4, 20; beq t3, t4, .Lcssa_addr_done\n" ++
-  "  add t5, a0, t3; lbu t6, 0(t5); add t5, t2, t3; sb t6, 0(t5); addi t3, t3, 1; j .Lcssa_addr\n" ++
-  ".Lcssa_addr_done:\n" ++
-  "  ld t3, 32(t1);  sd t3, 32(t2);  ld t3, 40(t1);  sd t3, 40(t2)\n" ++
-  "  ld t3, 48(t1);  sd t3, 48(t2);  ld t3, 56(t1);  sd t3, 56(t2)\n" ++
-  "  ld t3, 64(t1);  sd t3, 64(t2);  ld t3, 72(t1);  sd t3, 72(t2)\n" ++
-  "  ld t3, 80(t1);  sd t3, 80(t2);  ld t3, 88(t1);  sd t3, 88(t2)\n" ++
-  "  ld t3, 96(t1);  sd t3, 96(t2);  ld t3, 104(t1); sd t3, 104(t2)\n" ++
-  "  ld t3, 112(t1); sd t3, 112(t2); ld t3, 120(t1); sd t3, 120(t2)\n" ++
-  "  addi a4, a4, 1; addi t0, t0, 1; j .Lcssa_loop\n" ++
-  ".Lcssa_overflow:\n" ++
-  "  li t0, 1; sd t0, 0(a6); mv a0, a4; li a1, 1; ret\n" ++
-  ".Lcssa_done:\n" ++
-  "  mv a0, a4; li a1, 0; ret"
+def bvMtxCommittedSnapshotAppend_prog : Program :=
+  [ .LI .x5 (0 : Word),
+    .BEQ .x5 .x12 (204 : BitVec 13),
+    .BGEU .x14 .x15 (180 : BitVec 13),
+    .SLLI .x6 .x5 (7 : BitVec 6),
+    .ADD .x6 .x11 .x6,
+    .SLLI .x7 .x14 (7 : BitVec 6),
+    .ADD .x7 .x13 .x7,
+    .SD .x7 .x0 (0 : BitVec 12),
+    .SD .x7 .x0 (8 : BitVec 12),
+    .SD .x7 .x0 (16 : BitVec 12),
+    .SD .x7 .x0 (24 : BitVec 12),
+    .LI .x28 (0 : Word),
+    .LI .x29 (20 : Word),
+    .BEQ .x28 .x29 (28 : BitVec 13),
+    .ADD .x30 .x10 .x28,
+    .LBU .x31 .x30 (0 : BitVec 12),
+    .ADD .x30 .x7 .x28,
+    .SB .x30 .x31 (0 : BitVec 12),
+    .ADDI .x28 .x28 (1 : BitVec 12),
+    .JAL .x0 (-28 : BitVec 21),
+    .LD .x28 .x6 (32 : BitVec 12),
+    .SD .x7 .x28 (32 : BitVec 12),
+    .LD .x28 .x6 (40 : BitVec 12),
+    .SD .x7 .x28 (40 : BitVec 12),
+    .LD .x28 .x6 (48 : BitVec 12),
+    .SD .x7 .x28 (48 : BitVec 12),
+    .LD .x28 .x6 (56 : BitVec 12),
+    .SD .x7 .x28 (56 : BitVec 12),
+    .LD .x28 .x6 (64 : BitVec 12),
+    .SD .x7 .x28 (64 : BitVec 12),
+    .LD .x28 .x6 (72 : BitVec 12),
+    .SD .x7 .x28 (72 : BitVec 12),
+    .LD .x28 .x6 (80 : BitVec 12),
+    .SD .x7 .x28 (80 : BitVec 12),
+    .LD .x28 .x6 (88 : BitVec 12),
+    .SD .x7 .x28 (88 : BitVec 12),
+    .LD .x28 .x6 (96 : BitVec 12),
+    .SD .x7 .x28 (96 : BitVec 12),
+    .LD .x28 .x6 (104 : BitVec 12),
+    .SD .x7 .x28 (104 : BitVec 12),
+    .LD .x28 .x6 (112 : BitVec 12),
+    .SD .x7 .x28 (112 : BitVec 12),
+    .LD .x28 .x6 (120 : BitVec 12),
+    .SD .x7 .x28 (120 : BitVec 12),
+    .ADDI .x14 .x14 (1 : BitVec 12),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (-180 : BitVec 21),
+    .LI .x5 (1 : Word),
+    .SD .x16 .x5 (0 : BitVec 12),
+    .MV .x10 .x14,
+    .LI .x11 (1 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .MV .x10 .x14,
+    .LI .x11 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def committedStorageSnapshotAppendFunction : String :=
+  "bv_mtx_committed_snapshot_append:\n" ++ emitProgram bvMtxCommittedSnapshotAppend_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `bvMtxCommittedSnapshotAppend_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem committedStorageSnapshotAppendFunction_eq_prog :
+    committedStorageSnapshotAppendFunction = "bv_mtx_committed_snapshot_append:\n" ++ emitProgram bvMtxCommittedSnapshotAppend_prog := rfl
+
+#guard committedStorageSnapshotAppendFunction.startsWith "bv_mtx_committed_snapshot_append:\n"
+#guard bvMtxCommittedSnapshotAppend_prog.length = 55
 /-- `zisk_mtx_committed_snapshot_append`: focused probe.
     Input after ziskemu's length wrapper:
       +8  mode: 0 zero-live, 1 one-entry, 2 two-entry, 3 overflow
@@ -118,52 +162,104 @@ def ziskCommittedStorageSnapshotPrologue : String :=
     preserving latest-write-wins without growing the table. Non-matches append a
     new committed entry, and overflow is reported only when a new unique key
     cannot fit. -/
-def committedStorageSnapshotUpsertFunction : String :=
-  "bv_mtx_committed_snapshot_upsert:\n" ++
-  "  li t0, 0                      # j = 0\n" ++
-  ".Lcssu_loop:\n" ++
-  "  beq t0, a2, .Lcssu_done\n" ++
-  "  slli t1, t0, 7; add t1, a1, t1   # src = live[j]\n" ++
-  "  li t2, 0                      # i = 0\n" ++
-  ".Lcssu_scan:\n" ++
-  "  beq t2, a4, .Lcssu_no_match\n" ++
-  "  slli t3, t2, 7; add t3, a3, t3   # entry = table[i]\n" ++
-  "  li t4, 0\n" ++
-  ".Lcssu_addr_cmp:\n" ++
-  "  li t5, 20; beq t4, t5, .Lcssu_slot_cmp\n" ++
-  "  add t5, a0, t4; lbu t5, 0(t5); add t6, t3, t4; lbu t6, 0(t6); bne t5, t6, .Lcssu_next_entry\n" ++
-  "  addi t4, t4, 1; j .Lcssu_addr_cmp\n" ++
-  ".Lcssu_slot_cmp:\n" ++
-  "  ld t5, 32(t1);  ld t6, 32(t3);  bne t5, t6, .Lcssu_next_entry\n" ++
-  "  ld t5, 40(t1);  ld t6, 40(t3);  bne t5, t6, .Lcssu_next_entry\n" ++
-  "  ld t5, 48(t1);  ld t6, 48(t3);  bne t5, t6, .Lcssu_next_entry\n" ++
-  "  ld t5, 56(t1);  ld t6, 56(t3);  bne t5, t6, .Lcssu_next_entry\n" ++
-  "  j .Lcssu_store_payload\n" ++
-  ".Lcssu_next_entry:\n" ++
-  "  addi t2, t2, 1; j .Lcssu_scan\n" ++
-  ".Lcssu_no_match:\n" ++
-  "  bgeu a4, a5, .Lcssu_overflow\n" ++
-  "  slli t3, a4, 7; add t3, a3, t3   # dst = table[count]\n" ++
-  "  sd zero, 0(t3); sd zero, 8(t3); sd zero, 16(t3); sd zero, 24(t3)\n" ++
-  "  li t4, 0\n" ++
-  ".Lcssu_addr_copy:\n" ++
-  "  li t5, 20; beq t4, t5, .Lcssu_store_payload_append\n" ++
-  "  add t5, a0, t4; lbu t6, 0(t5); add t5, t3, t4; sb t6, 0(t5); addi t4, t4, 1; j .Lcssu_addr_copy\n" ++
-  ".Lcssu_store_payload_append:\n" ++
-  "  addi a4, a4, 1\n" ++
-  ".Lcssu_store_payload:\n" ++
-  "  ld t4, 32(t1);  sd t4, 32(t3);  ld t4, 40(t1);  sd t4, 40(t3)\n" ++
-  "  ld t4, 48(t1);  sd t4, 48(t3);  ld t4, 56(t1);  sd t4, 56(t3)\n" ++
-  "  ld t4, 64(t1);  sd t4, 64(t3);  ld t4, 72(t1);  sd t4, 72(t3)\n" ++
-  "  ld t4, 80(t1);  sd t4, 80(t3);  ld t4, 88(t1);  sd t4, 88(t3)\n" ++
-  "  ld t4, 96(t1);  sd t4, 96(t3);  ld t4, 104(t1); sd t4, 104(t3)\n" ++
-  "  ld t4, 112(t1); sd t4, 112(t3); ld t4, 120(t1); sd t4, 120(t3)\n" ++
-  "  addi t0, t0, 1; j .Lcssu_loop\n" ++
-  ".Lcssu_overflow:\n" ++
-  "  li t0, 1; sd t0, 0(a6); mv a0, a4; li a1, 1; ret\n" ++
-  ".Lcssu_done:\n" ++
-  "  mv a0, a4; li a1, 0; ret"
+def bvMtxCommittedSnapshotUpsert_prog : Program :=
+  [ .LI .x5 (0 : Word),
+    .BEQ .x5 .x12 (320 : BitVec 13),
+    .SLLI .x6 .x5 (7 : BitVec 6),
+    .ADD .x6 .x11 .x6,
+    .LI .x7 (0 : Word),
+    .BEQ .x7 .x14 (112 : BitVec 13),
+    .SLLI .x28 .x7 (7 : BitVec 6),
+    .ADD .x28 .x13 .x28,
+    .LI .x29 (0 : Word),
+    .LI .x30 (20 : Word),
+    .BEQ .x29 .x30 (32 : BitVec 13),
+    .ADD .x30 .x10 .x29,
+    .LBU .x30 .x30 (0 : BitVec 12),
+    .ADD .x31 .x28 .x29,
+    .LBU .x31 .x31 (0 : BitVec 12),
+    .BNE .x30 .x31 (64 : BitVec 13),
+    .ADDI .x29 .x29 (1 : BitVec 12),
+    .JAL .x0 (-32 : BitVec 21),
+    .LD .x30 .x6 (32 : BitVec 12),
+    .LD .x31 .x28 (32 : BitVec 12),
+    .BNE .x30 .x31 (44 : BitVec 13),
+    .LD .x30 .x6 (40 : BitVec 12),
+    .LD .x31 .x28 (40 : BitVec 12),
+    .BNE .x30 .x31 (32 : BitVec 13),
+    .LD .x30 .x6 (48 : BitVec 12),
+    .LD .x31 .x28 (48 : BitVec 12),
+    .BNE .x30 .x31 (20 : BitVec 13),
+    .LD .x30 .x6 (56 : BitVec 12),
+    .LD .x31 .x28 (56 : BitVec 12),
+    .BNE .x30 .x31 (8 : BitVec 13),
+    .JAL .x0 (80 : BitVec 21),
+    .ADDI .x7 .x7 (1 : BitVec 12),
+    .JAL .x0 (-108 : BitVec 21),
+    .BGEU .x14 .x15 (172 : BitVec 13),
+    .SLLI .x28 .x14 (7 : BitVec 6),
+    .ADD .x28 .x13 .x28,
+    .SD .x28 .x0 (0 : BitVec 12),
+    .SD .x28 .x0 (8 : BitVec 12),
+    .SD .x28 .x0 (16 : BitVec 12),
+    .SD .x28 .x0 (24 : BitVec 12),
+    .LI .x29 (0 : Word),
+    .LI .x30 (20 : Word),
+    .BEQ .x29 .x30 (28 : BitVec 13),
+    .ADD .x30 .x10 .x29,
+    .LBU .x31 .x30 (0 : BitVec 12),
+    .ADD .x30 .x28 .x29,
+    .SB .x30 .x31 (0 : BitVec 12),
+    .ADDI .x29 .x29 (1 : BitVec 12),
+    .JAL .x0 (-28 : BitVec 21),
+    .ADDI .x14 .x14 (1 : BitVec 12),
+    .LD .x29 .x6 (32 : BitVec 12),
+    .SD .x28 .x29 (32 : BitVec 12),
+    .LD .x29 .x6 (40 : BitVec 12),
+    .SD .x28 .x29 (40 : BitVec 12),
+    .LD .x29 .x6 (48 : BitVec 12),
+    .SD .x28 .x29 (48 : BitVec 12),
+    .LD .x29 .x6 (56 : BitVec 12),
+    .SD .x28 .x29 (56 : BitVec 12),
+    .LD .x29 .x6 (64 : BitVec 12),
+    .SD .x28 .x29 (64 : BitVec 12),
+    .LD .x29 .x6 (72 : BitVec 12),
+    .SD .x28 .x29 (72 : BitVec 12),
+    .LD .x29 .x6 (80 : BitVec 12),
+    .SD .x28 .x29 (80 : BitVec 12),
+    .LD .x29 .x6 (88 : BitVec 12),
+    .SD .x28 .x29 (88 : BitVec 12),
+    .LD .x29 .x6 (96 : BitVec 12),
+    .SD .x28 .x29 (96 : BitVec 12),
+    .LD .x29 .x6 (104 : BitVec 12),
+    .SD .x28 .x29 (104 : BitVec 12),
+    .LD .x29 .x6 (112 : BitVec 12),
+    .SD .x28 .x29 (112 : BitVec 12),
+    .LD .x29 .x6 (120 : BitVec 12),
+    .SD .x28 .x29 (120 : BitVec 12),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (-296 : BitVec 21),
+    .LI .x5 (1 : Word),
+    .SD .x16 .x5 (0 : BitVec 12),
+    .MV .x10 .x14,
+    .LI .x11 (1 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .MV .x10 .x14,
+    .LI .x11 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def committedStorageSnapshotUpsertFunction : String :=
+  "bv_mtx_committed_snapshot_upsert:\n" ++ emitProgram bvMtxCommittedSnapshotUpsert_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `bvMtxCommittedSnapshotUpsert_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem committedStorageSnapshotUpsertFunction_eq_prog :
+    committedStorageSnapshotUpsertFunction = "bv_mtx_committed_snapshot_upsert:\n" ++ emitProgram bvMtxCommittedSnapshotUpsert_prog := rfl
+
+#guard committedStorageSnapshotUpsertFunction.startsWith "bv_mtx_committed_snapshot_upsert:\n"
+#guard bvMtxCommittedSnapshotUpsert_prog.length = 84
 /-- `zisk_mtx_committed_snapshot_upsert`: focused probe.
     Input after ziskemu's length wrapper:
       +8  mode: 0 zero-live, 1 insert, 2 duplicate, 3 duplicate-plus-new,
@@ -252,52 +348,104 @@ def ziskCommittedStorageSnapshotUpsertProbeUnit : BuildUnit := {
     chunk pages. Existing keys update in place across page boundaries; new
     unique keys append at the global count and overflow only when total chunked
     capacity is exhausted. -/
-def committedStorageChunkedSnapshotUpsertFunction : String :=
-  "bv_mtx_committed_chunked_snapshot_upsert:\n" ++
-  "  li t0, 0                      # j = 0\n" ++
-  ".Lcscsu_loop:\n" ++
-  "  beq t0, a2, .Lcscsu_done\n" ++
-  "  slli t1, t0, 7; add t1, a1, t1   # src = live[j]\n" ++
-  "  li t2, 0                      # i = 0\n" ++
-  ".Lcscsu_scan:\n" ++
-  "  beq t2, a4, .Lcscsu_no_match\n" ++
-  "  slli t3, t2, 7; add t3, a3, t3   # entry = table[i]\n" ++
-  "  li t4, 0\n" ++
-  ".Lcscsu_addr_cmp:\n" ++
-  "  li t5, 20; beq t4, t5, .Lcscsu_slot_cmp\n" ++
-  "  add t5, a0, t4; lbu t5, 0(t5); add t6, t3, t4; lbu t6, 0(t6); bne t5, t6, .Lcscsu_next_entry\n" ++
-  "  addi t4, t4, 1; j .Lcscsu_addr_cmp\n" ++
-  ".Lcscsu_slot_cmp:\n" ++
-  "  ld t5, 32(t1);  ld t6, 32(t3);  bne t5, t6, .Lcscsu_next_entry\n" ++
-  "  ld t5, 40(t1);  ld t6, 40(t3);  bne t5, t6, .Lcscsu_next_entry\n" ++
-  "  ld t5, 48(t1);  ld t6, 48(t3);  bne t5, t6, .Lcscsu_next_entry\n" ++
-  "  ld t5, 56(t1);  ld t6, 56(t3);  bne t5, t6, .Lcscsu_next_entry\n" ++
-  "  j .Lcscsu_store_payload\n" ++
-  ".Lcscsu_next_entry:\n" ++
-  "  addi t2, t2, 1; j .Lcscsu_scan\n" ++
-  ".Lcscsu_no_match:\n" ++
-  "  bgeu a4, a5, .Lcscsu_overflow\n" ++
-  "  slli t3, a4, 7; add t3, a3, t3   # dst = table[count]\n" ++
-  "  sd zero, 0(t3); sd zero, 8(t3); sd zero, 16(t3); sd zero, 24(t3)\n" ++
-  "  li t4, 0\n" ++
-  ".Lcscsu_addr_copy:\n" ++
-  "  li t5, 20; beq t4, t5, .Lcscsu_store_payload_append\n" ++
-  "  add t5, a0, t4; lbu t6, 0(t5); add t5, t3, t4; sb t6, 0(t5); addi t4, t4, 1; j .Lcscsu_addr_copy\n" ++
-  ".Lcscsu_store_payload_append:\n" ++
-  "  addi a4, a4, 1\n" ++
-  ".Lcscsu_store_payload:\n" ++
-  "  ld t4, 32(t1);  sd t4, 32(t3);  ld t4, 40(t1);  sd t4, 40(t3)\n" ++
-  "  ld t4, 48(t1);  sd t4, 48(t3);  ld t4, 56(t1);  sd t4, 56(t3)\n" ++
-  "  ld t4, 64(t1);  sd t4, 64(t3);  ld t4, 72(t1);  sd t4, 72(t3)\n" ++
-  "  ld t4, 80(t1);  sd t4, 80(t3);  ld t4, 88(t1);  sd t4, 88(t3)\n" ++
-  "  ld t4, 96(t1);  sd t4, 96(t3);  ld t4, 104(t1); sd t4, 104(t3)\n" ++
-  "  ld t4, 112(t1); sd t4, 112(t3); ld t4, 120(t1); sd t4, 120(t3)\n" ++
-  "  addi t0, t0, 1; j .Lcscsu_loop\n" ++
-  ".Lcscsu_overflow:\n" ++
-  "  li t0, 1; sd t0, 0(a6); mv a0, a4; li a1, 1; ret\n" ++
-  ".Lcscsu_done:\n" ++
-  "  mv a0, a4; li a1, 0; ret"
+def bvMtxCommittedChunkedSnapshotUpsert_prog : Program :=
+  [ .LI .x5 (0 : Word),
+    .BEQ .x5 .x12 (320 : BitVec 13),
+    .SLLI .x6 .x5 (7 : BitVec 6),
+    .ADD .x6 .x11 .x6,
+    .LI .x7 (0 : Word),
+    .BEQ .x7 .x14 (112 : BitVec 13),
+    .SLLI .x28 .x7 (7 : BitVec 6),
+    .ADD .x28 .x13 .x28,
+    .LI .x29 (0 : Word),
+    .LI .x30 (20 : Word),
+    .BEQ .x29 .x30 (32 : BitVec 13),
+    .ADD .x30 .x10 .x29,
+    .LBU .x30 .x30 (0 : BitVec 12),
+    .ADD .x31 .x28 .x29,
+    .LBU .x31 .x31 (0 : BitVec 12),
+    .BNE .x30 .x31 (64 : BitVec 13),
+    .ADDI .x29 .x29 (1 : BitVec 12),
+    .JAL .x0 (-32 : BitVec 21),
+    .LD .x30 .x6 (32 : BitVec 12),
+    .LD .x31 .x28 (32 : BitVec 12),
+    .BNE .x30 .x31 (44 : BitVec 13),
+    .LD .x30 .x6 (40 : BitVec 12),
+    .LD .x31 .x28 (40 : BitVec 12),
+    .BNE .x30 .x31 (32 : BitVec 13),
+    .LD .x30 .x6 (48 : BitVec 12),
+    .LD .x31 .x28 (48 : BitVec 12),
+    .BNE .x30 .x31 (20 : BitVec 13),
+    .LD .x30 .x6 (56 : BitVec 12),
+    .LD .x31 .x28 (56 : BitVec 12),
+    .BNE .x30 .x31 (8 : BitVec 13),
+    .JAL .x0 (80 : BitVec 21),
+    .ADDI .x7 .x7 (1 : BitVec 12),
+    .JAL .x0 (-108 : BitVec 21),
+    .BGEU .x14 .x15 (172 : BitVec 13),
+    .SLLI .x28 .x14 (7 : BitVec 6),
+    .ADD .x28 .x13 .x28,
+    .SD .x28 .x0 (0 : BitVec 12),
+    .SD .x28 .x0 (8 : BitVec 12),
+    .SD .x28 .x0 (16 : BitVec 12),
+    .SD .x28 .x0 (24 : BitVec 12),
+    .LI .x29 (0 : Word),
+    .LI .x30 (20 : Word),
+    .BEQ .x29 .x30 (28 : BitVec 13),
+    .ADD .x30 .x10 .x29,
+    .LBU .x31 .x30 (0 : BitVec 12),
+    .ADD .x30 .x28 .x29,
+    .SB .x30 .x31 (0 : BitVec 12),
+    .ADDI .x29 .x29 (1 : BitVec 12),
+    .JAL .x0 (-28 : BitVec 21),
+    .ADDI .x14 .x14 (1 : BitVec 12),
+    .LD .x29 .x6 (32 : BitVec 12),
+    .SD .x28 .x29 (32 : BitVec 12),
+    .LD .x29 .x6 (40 : BitVec 12),
+    .SD .x28 .x29 (40 : BitVec 12),
+    .LD .x29 .x6 (48 : BitVec 12),
+    .SD .x28 .x29 (48 : BitVec 12),
+    .LD .x29 .x6 (56 : BitVec 12),
+    .SD .x28 .x29 (56 : BitVec 12),
+    .LD .x29 .x6 (64 : BitVec 12),
+    .SD .x28 .x29 (64 : BitVec 12),
+    .LD .x29 .x6 (72 : BitVec 12),
+    .SD .x28 .x29 (72 : BitVec 12),
+    .LD .x29 .x6 (80 : BitVec 12),
+    .SD .x28 .x29 (80 : BitVec 12),
+    .LD .x29 .x6 (88 : BitVec 12),
+    .SD .x28 .x29 (88 : BitVec 12),
+    .LD .x29 .x6 (96 : BitVec 12),
+    .SD .x28 .x29 (96 : BitVec 12),
+    .LD .x29 .x6 (104 : BitVec 12),
+    .SD .x28 .x29 (104 : BitVec 12),
+    .LD .x29 .x6 (112 : BitVec 12),
+    .SD .x28 .x29 (112 : BitVec 12),
+    .LD .x29 .x6 (120 : BitVec 12),
+    .SD .x28 .x29 (120 : BitVec 12),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (-296 : BitVec 21),
+    .LI .x5 (1 : Word),
+    .SD .x16 .x5 (0 : BitVec 12),
+    .MV .x10 .x14,
+    .LI .x11 (1 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .MV .x10 .x14,
+    .LI .x11 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def committedStorageChunkedSnapshotUpsertFunction : String :=
+  "bv_mtx_committed_chunked_snapshot_upsert:\n" ++ emitProgram bvMtxCommittedChunkedSnapshotUpsert_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `bvMtxCommittedChunkedSnapshotUpsert_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem committedStorageChunkedSnapshotUpsertFunction_eq_prog :
+    committedStorageChunkedSnapshotUpsertFunction = "bv_mtx_committed_chunked_snapshot_upsert:\n" ++ emitProgram bvMtxCommittedChunkedSnapshotUpsert_prog := rfl
+
+#guard committedStorageChunkedSnapshotUpsertFunction.startsWith "bv_mtx_committed_chunked_snapshot_upsert:\n"
+#guard bvMtxCommittedChunkedSnapshotUpsert_prog.length = 84
 /-- `zisk_mtx_committed_chunked_snapshot_upsert`: focused probe.
     Input after ziskemu's length wrapper:
       +8 mode: 0 zero-live, 1 129 unique inserts, 2 duplicate update across

--- a/EvmAsm/Codegen/Programs/ExecLogLatestValue.lean
+++ b/EvmAsm/Codegen/Programs/ExecLogLatestValue.lean
@@ -26,6 +26,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 
 namespace EvmAsm.Codegen
 
@@ -38,35 +39,62 @@ open EvmAsm.Rv64
     a0 (output) = 1 if a matching entry was found (out holds its committed value),
                   0 if the slot was never touched (out left unchanged).
     Leaf: uses only t-registers + the argument registers; no stack frame. -/
-def execLogLatestValueFunction : String :=
-  "exec_log_latest_value:\n" ++
-  "  li t6, 0                      # found flag\n" ++
-  "  li t0, 0                      # entry index i\n" ++
-  ".Lelv_loop:\n" ++
-  "  beq t0, a3, .Lelv_done\n" ++
-  "  slli t1, t0, 7; add t2, a2, t1   # entry ptr = base + i*128\n" ++
-  "  # match addrHash (entry@0 vs a0)\n" ++
-  "  ld t3, 0(t2);  ld t4, 0(a0);  bne t3, t4, .Lelv_next\n" ++
-  "  ld t3, 8(t2);  ld t4, 8(a0);  bne t3, t4, .Lelv_next\n" ++
-  "  ld t3, 16(t2); ld t4, 16(a0); bne t3, t4, .Lelv_next\n" ++
-  "  ld t3, 24(t2); ld t4, 24(a0); bne t3, t4, .Lelv_next\n" ++
-  "  # match slotKey (entry@32 vs a1)\n" ++
-  "  ld t3, 32(t2); ld t4, 0(a1);  bne t3, t4, .Lelv_next\n" ++
-  "  ld t3, 40(t2); ld t4, 8(a1);  bne t3, t4, .Lelv_next\n" ++
-  "  ld t3, 48(t2); ld t4, 16(a1); bne t3, t4, .Lelv_next\n" ++
-  "  ld t3, 56(t2); ld t4, 24(a1); bne t3, t4, .Lelv_next\n" ++
-  "  # matching entry: copy current (entry@96) -> out; set found. Overwrite keeps the LAST match.\n" ++
-  "  ld t3, 96(t2);  sd t3, 0(a4)\n" ++
-  "  ld t3, 104(t2); sd t3, 8(a4)\n" ++
-  "  ld t3, 112(t2); sd t3, 16(a4)\n" ++
-  "  ld t3, 120(t2); sd t3, 24(a4)\n" ++
-  "  li t6, 1\n" ++
-  ".Lelv_next:\n" ++
-  "  addi t0, t0, 1; j .Lelv_loop\n" ++
-  ".Lelv_done:\n" ++
-  "  mv a0, t6\n" ++
-  "  ret"
+def execLogLatestValue_prog : Program :=
+  [ .LI .x31 (0 : Word),
+    .LI .x5 (0 : Word),
+    .BEQ .x5 .x13 (152 : BitVec 13),
+    .SLLI .x6 .x5 (7 : BitVec 6),
+    .ADD .x7 .x12 .x6,
+    .LD .x28 .x7 (0 : BitVec 12),
+    .LD .x29 .x10 (0 : BitVec 12),
+    .BNE .x28 .x29 (124 : BitVec 13),
+    .LD .x28 .x7 (8 : BitVec 12),
+    .LD .x29 .x10 (8 : BitVec 12),
+    .BNE .x28 .x29 (112 : BitVec 13),
+    .LD .x28 .x7 (16 : BitVec 12),
+    .LD .x29 .x10 (16 : BitVec 12),
+    .BNE .x28 .x29 (100 : BitVec 13),
+    .LD .x28 .x7 (24 : BitVec 12),
+    .LD .x29 .x10 (24 : BitVec 12),
+    .BNE .x28 .x29 (88 : BitVec 13),
+    .LD .x28 .x7 (32 : BitVec 12),
+    .LD .x29 .x11 (0 : BitVec 12),
+    .BNE .x28 .x29 (76 : BitVec 13),
+    .LD .x28 .x7 (40 : BitVec 12),
+    .LD .x29 .x11 (8 : BitVec 12),
+    .BNE .x28 .x29 (64 : BitVec 13),
+    .LD .x28 .x7 (48 : BitVec 12),
+    .LD .x29 .x11 (16 : BitVec 12),
+    .BNE .x28 .x29 (52 : BitVec 13),
+    .LD .x28 .x7 (56 : BitVec 12),
+    .LD .x29 .x11 (24 : BitVec 12),
+    .BNE .x28 .x29 (40 : BitVec 13),
+    .LD .x28 .x7 (96 : BitVec 12),
+    .SD .x14 .x28 (0 : BitVec 12),
+    .LD .x28 .x7 (104 : BitVec 12),
+    .SD .x14 .x28 (8 : BitVec 12),
+    .LD .x28 .x7 (112 : BitVec 12),
+    .SD .x14 .x28 (16 : BitVec 12),
+    .LD .x28 .x7 (120 : BitVec 12),
+    .SD .x14 .x28 (24 : BitVec 12),
+    .LI .x31 (1 : Word),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (-148 : BitVec 21),
+    .MV .x10 .x31,
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def execLogLatestValueFunction : String :=
+  "exec_log_latest_value:\n" ++ emitProgram execLogLatestValue_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `execLogLatestValue_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem execLogLatestValueFunction_eq_prog :
+    execLogLatestValueFunction = "exec_log_latest_value:\n" ++ emitProgram execLogLatestValue_prog := rfl
+
+#guard execLogLatestValueFunction.startsWith "exec_log_latest_value:\n"
+#guard execLogLatestValue_prog.length = 42
 /-- `zisk_exec_log_latest_value`: focused probe.
     Input (after the ziskemu length wrapper at 0x40000000):
       bytes  8..16 : entry count

--- a/EvmAsm/Codegen/Programs/SenderPostNonceConsistent.lean
+++ b/EvmAsm/Codegen/Programs/SenderPostNonceConsistent.lean
@@ -28,6 +28,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 
 namespace EvmAsm.Codegen
 
@@ -37,24 +38,44 @@ open EvmAsm.Rv64
     a0 = tx_gas_sender_bal_lookup output record ptr
     a0 (output) = 0 consistent (post == pre+1) / 1 mismatch / 2 skip (absent or >u64).
     Leaf; clobbers t0-t5. -/
-def senderPostNonceConsistentFunction : String :=
-  "sender_post_nonce_consistent:\n" ++
-  "  ld t0, 128(a0)              # post nonce byte length\n" ++
-  "  li t1, -1; beq t0, t1, .Lspnc_skip       # absent -> skip\n" ++
-  "  li t1, 8;  bgtu t0, t1, .Lspnc_skip       # > u64 -> skip\n" ++
-  "  addi t2, a0, 136; li t3, 0; mv t4, t0     # decode big-endian post nonce\n" ++
-  ".Lspnc_be:\n" ++
-  "  beqz t4, .Lspnc_de\n" ++
-  "  slli t3, t3, 8; lbu t5, 0(t2); or t3, t3, t5; addi t2, t2, 1; addi t4, t4, -1; j .Lspnc_be\n" ++
-  ".Lspnc_de:\n" ++
-  "  ld t4, 80(a0); addi t4, t4, 1             # expected = pre nonce + 1\n" ++
-  "  beq t3, t4, .Lspnc_match\n" ++
-  "  li a0, 1; ret                             # mismatch\n" ++
-  ".Lspnc_match:\n" ++
-  "  li a0, 0; ret\n" ++
-  ".Lspnc_skip:\n" ++
-  "  li a0, 2; ret"
+def senderPostNonceConsistent_prog : Program :=
+  [ .LD .x5 .x10 (128 : BitVec 12),
+    .LI .x6 (-1 : Word),
+    .BEQ .x5 .x6 (80 : BitVec 13),
+    .LI .x6 (8 : Word),
+    .BLTU .x6 .x5 (72 : BitVec 13),
+    .ADDI .x7 .x10 (136 : BitVec 12),
+    .LI .x28 (0 : Word),
+    .MV .x29 .x5,
+    .BEQ .x29 .x0 (28 : BitVec 13),
+    .SLLI .x28 .x28 (8 : BitVec 6),
+    .LBU .x30 .x7 (0 : BitVec 12),
+    .OR .x28 .x28 .x30,
+    .ADDI .x7 .x7 (1 : BitVec 12),
+    .ADDI .x29 .x29 (-1 : BitVec 12),
+    .JAL .x0 (-24 : BitVec 21),
+    .LD .x29 .x10 (80 : BitVec 12),
+    .ADDI .x29 .x29 (1 : BitVec 12),
+    .BEQ .x28 .x29 (12 : BitVec 13),
+    .LI .x10 (1 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (2 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def senderPostNonceConsistentFunction : String :=
+  "sender_post_nonce_consistent:\n" ++ emitProgram senderPostNonceConsistent_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `senderPostNonceConsistent_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem senderPostNonceConsistentFunction_eq_prog :
+    senderPostNonceConsistentFunction = "sender_post_nonce_consistent:\n" ++ emitProgram senderPostNonceConsistent_prog := rfl
+
+#guard senderPostNonceConsistentFunction.startsWith "sender_post_nonce_consistent:\n"
+#guard senderPostNonceConsistent_prog.length = 24
 /-- `zisk_sender_post_nonce_consistent`: known-answer probe over a lookup-shaped
     buffer (pre nonce @+80, post-nonce len @+128, post-nonce bytes @+136). Cases
     surfaced to OUTPUT (0xa0010000):

--- a/EvmAsm/Codegen/Programs/SlotTupleSequencesMatch.lean
+++ b/EvmAsm/Codegen/Programs/SlotTupleSequencesMatch.lean
@@ -21,6 +21,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 
 namespace EvmAsm.Codegen
 
@@ -31,26 +32,49 @@ open EvmAsm.Rv64
     a2 = exec tuple-sequence ptr   a3 = exec tuple count
     a0 (output) = 0 sequences identical / 1 mismatch.
     Records are 40 bytes: block_access_index (u64) at +0, new_value (32B) at +8. -/
-def slotTupleSequencesMatchFunction : String :=
-  "slot_tuple_sequences_match:\n" ++
-  "  bne a1, a3, .Lstsm_bad        # length mismatch -> reject\n" ++
-  "  li t0, 0                      # i\n" ++
-  ".Lstsm_loop:\n" ++
-  "  beq t0, a1, .Lstsm_ok\n" ++
-  "  slli t1, t0, 5; slli t2, t0, 3; add t1, t1, t2   # i*40\n" ++
-  "  add t3, a0, t1                # BAL record i\n" ++
-  "  add t4, a2, t1                # exec record i\n" ++
-  "  ld t5, 0(t3);  ld t6, 0(t4);  bne t5, t6, .Lstsm_bad   # block_access_index\n" ++
-  "  ld t5, 8(t3);  ld t6, 8(t4);  bne t5, t6, .Lstsm_bad   # value[0:8]\n" ++
-  "  ld t5, 16(t3); ld t6, 16(t4); bne t5, t6, .Lstsm_bad   # value[8:16]\n" ++
-  "  ld t5, 24(t3); ld t6, 24(t4); bne t5, t6, .Lstsm_bad   # value[16:24]\n" ++
-  "  ld t5, 32(t3); ld t6, 32(t4); bne t5, t6, .Lstsm_bad   # value[24:32]\n" ++
-  "  addi t0, t0, 1; j .Lstsm_loop\n" ++
-  ".Lstsm_ok:\n" ++
-  "  li a0, 0; ret\n" ++
-  ".Lstsm_bad:\n" ++
-  "  li a0, 1; ret"
+def slotTupleSequencesMatch_prog : Program :=
+  [ .BNE .x11 .x13 (108 : BitVec 13),
+    .LI .x5 (0 : Word),
+    .BEQ .x5 .x11 (92 : BitVec 13),
+    .SLLI .x6 .x5 (5 : BitVec 6),
+    .SLLI .x7 .x5 (3 : BitVec 6),
+    .ADD .x6 .x6 .x7,
+    .ADD .x28 .x10 .x6,
+    .ADD .x29 .x12 .x6,
+    .LD .x30 .x28 (0 : BitVec 12),
+    .LD .x31 .x29 (0 : BitVec 12),
+    .BNE .x30 .x31 (68 : BitVec 13),
+    .LD .x30 .x28 (8 : BitVec 12),
+    .LD .x31 .x29 (8 : BitVec 12),
+    .BNE .x30 .x31 (56 : BitVec 13),
+    .LD .x30 .x28 (16 : BitVec 12),
+    .LD .x31 .x29 (16 : BitVec 12),
+    .BNE .x30 .x31 (44 : BitVec 13),
+    .LD .x30 .x28 (24 : BitVec 12),
+    .LD .x31 .x29 (24 : BitVec 12),
+    .BNE .x30 .x31 (32 : BitVec 13),
+    .LD .x30 .x28 (32 : BitVec 12),
+    .LD .x31 .x29 (32 : BitVec 12),
+    .BNE .x30 .x31 (20 : BitVec 13),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (-88 : BitVec 21),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (1 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def slotTupleSequencesMatchFunction : String :=
+  "slot_tuple_sequences_match:\n" ++ emitProgram slotTupleSequencesMatch_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `slotTupleSequencesMatch_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem slotTupleSequencesMatchFunction_eq_prog :
+    slotTupleSequencesMatchFunction = "slot_tuple_sequences_match:\n" ++ emitProgram slotTupleSequencesMatch_prog := rfl
+
+#guard slotTupleSequencesMatchFunction.startsWith "slot_tuple_sequences_match:\n"
+#guard slotTupleSequencesMatch_prog.length = 29
 /-- `zisk_slot_tuple_sequences_match`: focused probe.
     Input (after the ziskemu length wrapper at 0x40000000):
       bytes  8..16 : BAL tuple count

--- a/EvmAsm/Codegen/Programs/State.lean
+++ b/EvmAsm/Codegen/Programs/State.lean
@@ -23,6 +23,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.Mpt
 import EvmAsm.Codegen.Programs.HashBridge
@@ -441,46 +442,52 @@ def ziskAccountAtAddressProbeUnit : BuildUnit := {
 
     Internal: `mpt_lookup_by_key(slot_idx, ..., si_value_scratch)`
     then `slot_decode_u256` over the looked-up bytes. -/
-def slotDecodeU256Function : String :=
-  "slot_decode_u256:\n" ++
-  "  # a0 = val_bytes ptr, a1 = val_len, a2 = 32-byte BE out ptr.\n" ++
-  "  # Returns 0 (ok) / 1 (fail). Output is zeroed on every path.\n" ++
-  "  sd zero,  0(a2); sd zero,  8(a2); sd zero, 16(a2); sd zero, 24(a2)\n" ++
-  "  beqz a1, .Lsdu_fail        # empty input: malformed encoded value\n" ++
-  "  lbu t0, 0(a0)\n" ++
-  "  li t1, 0x80\n" ++
-  "  bltu t0, t1, .Lsdu_single  # b0 < 0x80: single byte\n" ++
-  "  beq t0, t1, .Lsdu_zero     # b0 == 0x80: empty string ⇒ 0\n" ++
-  "  li t1, 0xa1\n" ++
-  "  bgeu t0, t1, .Lsdu_fail    # b0 ≥ 0xa1: too long for a u256\n" ++
-  "  # Short string of n bytes (1 ≤ n ≤ 32).\n" ++
-  "  li t1, 0x80\n" ++
-  "  sub t2, t0, t1             # n\n" ++
-  "  addi t3, a1, -1\n" ++
-  "  bltu t3, t2, .Lsdu_fail    # not enough bytes for declared length\n" ++
-  "  li t4, 32\n" ++
-  "  sub t4, t4, t2             # 32 - n\n" ++
-  "  add t5, a2, t4             # dst (right-aligned)\n" ++
-  "  addi t6, a0, 1             # src\n" ++
-  "  mv t3, t2                  # remaining\n" ++
-  ".Lsdu_copy:\n" ++
-  "  beqz t3, .Lsdu_ok\n" ++
-  "  lbu t1, 0(t6)\n" ++
-  "  sb  t1, 0(t5)\n" ++
-  "  addi t5, t5, 1\n" ++
-  "  addi t6, t6, 1\n" ++
-  "  addi t3, t3, -1\n" ++
-  "  j .Lsdu_copy\n" ++
-  ".Lsdu_single:\n" ++
-  "  sb t0, 31(a2)              # write u256 = b0 at byte 31 (BE LSB)\n" ++
-  ".Lsdu_zero:\n" ++
-  ".Lsdu_ok:\n" ++
-  "  li a0, 0\n" ++
-  "  ret\n" ++
-  ".Lsdu_fail:\n" ++
-  "  li a0, 1\n" ++
-  "  ret"
+def slotDecodeU256_prog : Program :=
+  [ .SD .x12 .x0 (0 : BitVec 12),
+    .SD .x12 .x0 (8 : BitVec 12),
+    .SD .x12 .x0 (16 : BitVec 12),
+    .SD .x12 .x0 (24 : BitVec 12),
+    .BEQ .x11 .x0 (104 : BitVec 13),
+    .LBU .x5 .x10 (0 : BitVec 12),
+    .LI .x6 (128 : Word),
+    .BLTU .x5 .x6 (80 : BitVec 13),
+    .BEQ .x5 .x6 (80 : BitVec 13),
+    .LI .x6 (161 : Word),
+    .BGEU .x5 .x6 (80 : BitVec 13),
+    .LI .x6 (128 : Word),
+    .SUB .x7 .x5 .x6,
+    .ADDI .x28 .x11 (-1 : BitVec 12),
+    .BLTU .x28 .x7 (64 : BitVec 13),
+    .LI .x29 (32 : Word),
+    .SUB .x29 .x29 .x7,
+    .ADD .x30 .x12 .x29,
+    .ADDI .x31 .x10 (1 : BitVec 12),
+    .MV .x28 .x7,
+    .BEQ .x28 .x0 (32 : BitVec 13),
+    .LBU .x6 .x31 (0 : BitVec 12),
+    .SB .x30 .x6 (0 : BitVec 12),
+    .ADDI .x30 .x30 (1 : BitVec 12),
+    .ADDI .x31 .x31 (1 : BitVec 12),
+    .ADDI .x28 .x28 (-1 : BitVec 12),
+    .JAL .x0 (-24 : BitVec 21),
+    .SB .x12 .x5 (31 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12),
+    .LI .x10 (1 : Word),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def slotDecodeU256Function : String :=
+  "slot_decode_u256:\n" ++ emitProgram slotDecodeU256_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `slotDecodeU256_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem slotDecodeU256Function_eq_prog :
+    slotDecodeU256Function = "slot_decode_u256:\n" ++ emitProgram slotDecodeU256_prog := rfl
+
+#guard slotDecodeU256Function.startsWith "slot_decode_u256:\n"
+#guard slotDecodeU256_prog.length = 32
 def slotAtIndexFunction : String :=
   "slot_at_index:\n" ++
   "  addi sp, sp, -32\n" ++

--- a/EvmAsm/Codegen/Programs/SystemWrites.lean
+++ b/EvmAsm/Codegen/Programs/SystemWrites.lean
@@ -32,6 +32,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.AmsterdamSystemTx
 
 namespace EvmAsm.Codegen
@@ -39,72 +40,144 @@ namespace EvmAsm.Codegen
 open EvmAsm.Rv64
 
 /-! ## swd_read_u64le -- read a little-endian u64 byte-wise (a0=ptr -> a0). Leaf. -/
-def swdReadU64leFunction : String :=
-  "swd_read_u64le:\n" ++
-  "  lbu t0, 0(a0)\n" ++
-  "  lbu t1, 1(a0); slli t1, t1, 8;  or t0, t0, t1\n" ++
-  "  lbu t1, 2(a0); slli t1, t1, 16; or t0, t0, t1\n" ++
-  "  lbu t1, 3(a0); slli t1, t1, 24; or t0, t0, t1\n" ++
-  "  lbu t1, 4(a0); slli t1, t1, 32; or t0, t0, t1\n" ++
-  "  lbu t1, 5(a0); slli t1, t1, 40; or t0, t0, t1\n" ++
-  "  lbu t1, 6(a0); slli t1, t1, 48; or t0, t0, t1\n" ++
-  "  lbu t1, 7(a0); slli t1, t1, 56; or t0, t0, t1\n" ++
-  "  mv a0, t0\n" ++
-  "  ret"
+def swdReadU64le_prog : Program :=
+  [ .LBU .x5 .x10 (0 : BitVec 12),
+    .LBU .x6 .x10 (1 : BitVec 12),
+    .SLLI .x6 .x6 (8 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (2 : BitVec 12),
+    .SLLI .x6 .x6 (16 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (3 : BitVec 12),
+    .SLLI .x6 .x6 (24 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (4 : BitVec 12),
+    .SLLI .x6 .x6 (32 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (5 : BitVec 12),
+    .SLLI .x6 .x6 (40 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (6 : BitVec 12),
+    .SLLI .x6 .x6 (48 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .LBU .x6 .x10 (7 : BitVec 12),
+    .SLLI .x6 .x6 (56 : BitVec 6),
+    .OR .x5 .x5 .x6,
+    .MV .x10 .x5,
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def swdReadU64leFunction : String :=
+  "swd_read_u64le:\n" ++ emitProgram swdReadU64le_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `swdReadU64le_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem swdReadU64leFunction_eq_prog :
+    swdReadU64leFunction = "swd_read_u64le:\n" ++ emitProgram swdReadU64le_prog := rfl
+
+#guard swdReadU64leFunction.startsWith "swd_read_u64le:\n"
+#guard swdReadU64le_prog.length = 24
 /-! ## swd_write_be32_u64 -- write a0 (u64) big-endian into the LOW 8 bytes of a
     zeroed 32-byte buffer at a1 (the 32-byte storage slot key). Leaf. -/
+def swdWriteBe32U64_prog : Program :=
+  [ .LI .x5 (0 : Word),
+    .LI .x6 (32 : Word),
+    .BEQ .x5 .x6 (20 : BitVec 13),
+    .ADD .x7 .x11 .x5,
+    .SB .x7 .x0 (0 : BitVec 12),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (-20 : BitVec 21),
+    .LI .x5 (0 : Word),
+    .LI .x6 (8 : Word),
+    .BEQ .x5 .x6 (44 : BitVec 13),
+    .LI .x7 (56 : Word),
+    .SLLI .x28 .x5 (3 : BitVec 6),
+    .SUB .x7 .x7 .x28,
+    .SRL .x29 .x10 .x7,
+    .ANDI .x29 .x29 (255 : BitVec 12),
+    .ADDI .x30 .x11 (24 : BitVec 12),
+    .ADD .x30 .x30 .x5,
+    .SB .x30 .x29 (0 : BitVec 12),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (-44 : BitVec 21),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
+
 def swdWriteBe32U64Function : String :=
-  "swd_write_be32_u64:\n" ++
-  "  li t0, 0\n" ++
-  ".Lswd_z:\n" ++
-  "  li t1, 32; beq t0, t1, .Lswd_zd\n" ++
-  "  add t2, a1, t0; sb x0, 0(t2); addi t0, t0, 1; j .Lswd_z\n" ++
-  ".Lswd_zd:\n" ++
-  "  # write the 8 BE bytes into offsets 24..31\n" ++
-  "  li t0, 0\n" ++
-  ".Lswd_b:\n" ++
-  "  li t1, 8; beq t0, t1, .Lswd_bd\n" ++
-  "  li t2, 56; slli t3, t0, 3; sub t2, t2, t3   # shift = 56 - 8*t0\n" ++
-  "  srl t4, a0, t2; andi t4, t4, 0xff\n" ++
-  "  addi t5, a1, 24; add t5, t5, t0; sb t4, 0(t5)\n" ++
-  "  addi t0, t0, 1; j .Lswd_b\n" ++
-  ".Lswd_bd:\n" ++
-  "  ret"
+  "swd_write_be32_u64:\n" ++ emitProgram swdWriteBe32U64_prog
 
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `swdWriteBe32U64_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem swdWriteBe32U64Function_eq_prog :
+    swdWriteBe32U64Function = "swd_write_be32_u64:\n" ++ emitProgram swdWriteBe32U64_prog := rfl
+
+#guard swdWriteBe32U64Function.startsWith "swd_write_be32_u64:\n"
+#guard swdWriteBe32U64_prog.length = 21
 /-! ## swd_write_be8 -- write a0 (u64) big-endian into 8 bytes at a1. Leaf. -/
-def swdWriteBe8Function : String :=
-  "swd_write_be8:\n" ++
-  "  li t0, 0\n" ++
-  ".Lswd8:\n" ++
-  "  li t1, 8; beq t0, t1, .Lswd8d\n" ++
-  "  li t2, 56; slli t3, t0, 3; sub t2, t2, t3\n" ++
-  "  srl t4, a0, t2; andi t4, t4, 0xff\n" ++
-  "  add t5, a1, t0; sb t4, 0(t5)\n" ++
-  "  addi t0, t0, 1; j .Lswd8\n" ++
-  ".Lswd8d:\n" ++
-  "  ret"
+def swdWriteBe8_prog : Program :=
+  [ .LI .x5 (0 : Word),
+    .LI .x6 (8 : Word),
+    .BEQ .x5 .x6 (40 : BitVec 13),
+    .LI .x7 (56 : Word),
+    .SLLI .x28 .x5 (3 : BitVec 6),
+    .SUB .x7 .x7 .x28,
+    .SRL .x29 .x10 .x7,
+    .ANDI .x29 .x29 (255 : BitVec 12),
+    .ADD .x30 .x11 .x5,
+    .SB .x30 .x29 (0 : BitVec 12),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (-40 : BitVec 21),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def swdWriteBe8Function : String :=
+  "swd_write_be8:\n" ++ emitProgram swdWriteBe8_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `swdWriteBe8_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem swdWriteBe8Function_eq_prog :
+    swdWriteBe8Function = "swd_write_be8:\n" ++ emitProgram swdWriteBe8_prog := rfl
+
+#guard swdWriteBe8Function.startsWith "swd_write_be8:\n"
+#guard swdWriteBe8_prog.length = 13
 /-! ## swd_minimal_copy -- copy src[a0..a0+a1) stripping leading zero bytes into
     a2; write the resulting length to a3. Leaf. -/
-def swdMinimalCopyFunction : String :=
-  "swd_minimal_copy:\n" ++
-  "  mv t0, a0                   # src cursor\n" ++
-  "  mv t1, a1                   # remaining\n" ++
-  ".Lswd_skip:\n" ++
-  "  beqz t1, .Lswd_emit         # all zero -> length 0\n" ++
-  "  lbu t2, 0(t0); bnez t2, .Lswd_emit\n" ++
-  "  addi t0, t0, 1; addi t1, t1, -1; j .Lswd_skip\n" ++
-  ".Lswd_emit:\n" ++
-  "  sd t1, 0(a3)                # out length = remaining\n" ++
-  "  mv t3, a2; li t4, 0\n" ++
-  ".Lswd_cp:\n" ++
-  "  beq t4, t1, .Lswd_cpd\n" ++
-  "  add t5, t0, t4; lbu t6, 0(t5); add t2, t3, t4; sb t6, 0(t2)\n" ++
-  "  addi t4, t4, 1; j .Lswd_cp\n" ++
-  ".Lswd_cpd:\n" ++
-  "  ret"
+def swdMinimalCopy_prog : Program :=
+  [ .MV .x5 .x10,
+    .MV .x6 .x11,
+    .BEQ .x6 .x0 (24 : BitVec 13),
+    .LBU .x7 .x5 (0 : BitVec 12),
+    .BNE .x7 .x0 (16 : BitVec 13),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .ADDI .x6 .x6 (-1 : BitVec 12),
+    .JAL .x0 (-20 : BitVec 21),
+    .SD .x13 .x6 (0 : BitVec 12),
+    .MV .x28 .x12,
+    .LI .x29 (0 : Word),
+    .BEQ .x29 .x6 (28 : BitVec 13),
+    .ADD .x30 .x5 .x29,
+    .LBU .x31 .x30 (0 : BitVec 12),
+    .ADD .x7 .x28 .x29,
+    .SB .x7 .x31 (0 : BitVec 12),
+    .ADDI .x29 .x29 (1 : BitVec 12),
+    .JAL .x0 (-24 : BitVec 21),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def swdMinimalCopyFunction : String :=
+  "swd_minimal_copy:\n" ++ emitProgram swdMinimalCopy_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `swdMinimalCopy_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem swdMinimalCopyFunction_eq_prog :
+    swdMinimalCopyFunction = "swd_minimal_copy:\n" ++ emitProgram swdMinimalCopy_prog := rfl
+
+#guard swdMinimalCopyFunction.startsWith "swd_minimal_copy:\n"
+#guard swdMinimalCopy_prog.length = 19
 /-! ## system_write_descriptors
     a0 = SSZ_BASE.  Fills (slot_key 32 B, value, value_len) for EIP-2935 and
     EIP-4788 into swd_* buffers.  a0 (output) = 0. -/

--- a/EvmAsm/Codegen/Programs/WitnessValidation.lean
+++ b/EvmAsm/Codegen/Programs/WitnessValidation.lean
@@ -18,6 +18,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.Mpt
 import EvmAsm.Codegen.Programs.HashBridge
@@ -209,60 +210,74 @@ def ziskWitnessStateValidateNodeKindsProbeUnit : BuildUnit := {
         0 = all entries within cap (or empty section)
         1 = some entry exceeds `max_byte_length`
 -/
-def witnessCodesValidateLengthsFunction : String :=
-  "witness_codes_validate_lengths:\n" ++
-  "  addi sp, sp, -64\n" ++
-  "  sd ra,  0(sp)\n" ++
-  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
-  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
-  "  mv s0, a0                  # section ptr\n" ++
-  "  mv s1, a1                  # section_len\n" ++
-  "  mv s2, a2                  # max_byte_length\n" ++
-  "  mv s3, a3                  # n_processed out\n" ++
-  "  mv s4, a4                  # first_bad_index out\n" ++
-  "  sd zero, 0(s3)\n" ++
-  "  li t0, -1\n" ++
-  "  sd t0, 0(s4)\n" ++
-  "  beqz s1, .Lwcvl_ok           # empty section ⇒ vacuous-valid\n" ++
-  "  lwu t0, 0(s0)\n" ++
-  "  srli s5, t0, 2               # s5 = N\n" ++
-  "  li s6, 0                     # s6 = i\n" ++
-  ".Lwcvl_loop:\n" ++
-  "  beq s6, s5, .Lwcvl_ok\n" ++
-  "  # Element i bounds.\n" ++
-  "  slli t0, s6, 2\n" ++
-  "  add t1, s0, t0\n" ++
-  "  lwu t2, 0(t1)                # inner_off_i\n" ++
-  "  addi t3, s6, 1\n" ++
-  "  beq t3, s5, .Lwcvl_use_end\n" ++
-  "  slli t3, t3, 2\n" ++
-  "  add t3, s0, t3\n" ++
-  "  lwu t4, 0(t3)                # inner_off_{i+1}\n" ++
-  "  sub t5, t4, t2               # el_i_len\n" ++
-  "  j .Lwcvl_check\n" ++
-  ".Lwcvl_use_end:\n" ++
-  "  sub t5, s1, t2               # el_i_len = section_len - inner_off_i\n" ++
-  ".Lwcvl_check:\n" ++
-  "  bgtu t5, s2, .Lwcvl_too_long\n" ++
-  "  addi s6, s6, 1\n" ++
-  "  j .Lwcvl_loop\n" ++
-  ".Lwcvl_too_long:\n" ++
-  "  sd s6, 0(s3)                 # n_processed = i\n" ++
-  "  sd s6, 0(s4)                 # first_bad_index = i\n" ++
-  "  li a0, 1\n" ++
-  "  j .Lwcvl_ret\n" ++
-  ".Lwcvl_ok:\n" ++
-  "  sd s5, 0(s3)                 # n_processed = N\n" ++
-  "  li t0, -1\n" ++
-  "  sd t0, 0(s4)\n" ++
-  "  li a0, 0\n" ++
-  ".Lwcvl_ret:\n" ++
-  "  ld ra,  0(sp)\n" ++
-  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
-  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
-  "  addi sp, sp, 64\n" ++
-  "  ret"
+def witnessCodesValidateLengths_prog : Program :=
+  [ .ADDI .x2 .x2 (-64 : BitVec 12),
+    .SD .x2 .x1 (0 : BitVec 12),
+    .SD .x2 .x8 (8 : BitVec 12),
+    .SD .x2 .x9 (16 : BitVec 12),
+    .SD .x2 .x18 (24 : BitVec 12),
+    .SD .x2 .x19 (32 : BitVec 12),
+    .SD .x2 .x20 (40 : BitVec 12),
+    .SD .x2 .x21 (48 : BitVec 12),
+    .SD .x2 .x22 (56 : BitVec 12),
+    .MV .x8 .x10,
+    .MV .x9 .x11,
+    .MV .x18 .x12,
+    .MV .x19 .x13,
+    .MV .x20 .x14,
+    .SD .x19 .x0 (0 : BitVec 12),
+    .LI .x5 (-1 : Word),
+    .SD .x20 .x5 (0 : BitVec 12),
+    .BEQ .x9 .x0 (92 : BitVec 13),
+    .LWU .x5 .x8 (0 : BitVec 12),
+    .SRLI .x21 .x5 (2 : BitVec 6),
+    .LI .x22 (0 : Word),
+    .BEQ .x22 .x21 (76 : BitVec 13),
+    .SLLI .x5 .x22 (2 : BitVec 6),
+    .ADD .x6 .x8 .x5,
+    .LWU .x7 .x6 (0 : BitVec 12),
+    .ADDI .x28 .x22 (1 : BitVec 12),
+    .BEQ .x28 .x21 (24 : BitVec 13),
+    .SLLI .x28 .x28 (2 : BitVec 6),
+    .ADD .x28 .x8 .x28,
+    .LWU .x29 .x28 (0 : BitVec 12),
+    .SUB .x30 .x29 .x7,
+    .JAL .x0 (8 : BitVec 21),
+    .SUB .x30 .x9 .x7,
+    .BLTU .x18 .x30 (12 : BitVec 13),
+    .ADDI .x22 .x22 (1 : BitVec 12),
+    .JAL .x0 (-56 : BitVec 21),
+    .SD .x19 .x22 (0 : BitVec 12),
+    .SD .x20 .x22 (0 : BitVec 12),
+    .LI .x10 (1 : Word),
+    .JAL .x0 (20 : BitVec 21),
+    .SD .x19 .x21 (0 : BitVec 12),
+    .LI .x5 (-1 : Word),
+    .SD .x20 .x5 (0 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .LD .x1 .x2 (0 : BitVec 12),
+    .LD .x8 .x2 (8 : BitVec 12),
+    .LD .x9 .x2 (16 : BitVec 12),
+    .LD .x18 .x2 (24 : BitVec 12),
+    .LD .x19 .x2 (32 : BitVec 12),
+    .LD .x20 .x2 (40 : BitVec 12),
+    .LD .x21 .x2 (48 : BitVec 12),
+    .LD .x22 .x2 (56 : BitVec 12),
+    .ADDI .x2 .x2 (64 : BitVec 12),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
 
+def witnessCodesValidateLengthsFunction : String :=
+  "witness_codes_validate_lengths:\n" ++ emitProgram witnessCodesValidateLengths_prog
+
+/-- Kernel-checked drift guard: the Codegen helper string is exactly
+    `witnessCodesValidateLengths_prog` rendered under its label (bead evm-asm-4ch8f.9,
+    mechanical conversion by `scripts/asm_to_program.py`; guest binary
+    byte-identity verified offline by assemble+cmp of the `.text`). -/
+theorem witnessCodesValidateLengthsFunction_eq_prog :
+    witnessCodesValidateLengthsFunction = "witness_codes_validate_lengths:\n" ++ emitProgram witnessCodesValidateLengths_prog := rfl
+
+#guard witnessCodesValidateLengthsFunction.startsWith "witness_codes_validate_lengths:\n"
+#guard witnessCodesValidateLengths_prog.length = 54
 /-- `zisk_witness_codes_validate_lengths`: probe BuildUnit.
     Input layout (at INPUT_ADDR):
       bytes  0.. 8 : (ziskemu metadata)

--- a/docs/4ch8f-asm-to-program-coverage.md
+++ b/docs/4ch8f-asm-to-program-coverage.md
@@ -8,24 +8,131 @@ Every `*Function : String` def under `EvmAsm/Codegen/Programs/` and `EvmAsm/Code
 
 | Class | Count | Meaning |
 |---|---:|---|
-| BLOCKED_ON_.6 | 550 | Contains `la <symbol>` scratch/global addressing or a cross-function `jal <callee>` — needs the authoritative linker-pinned address table (bead evm-asm-4ch8f.6). |
+| BLOCKED_ON_.6 | 548 | Contains `la <symbol>` scratch/global addressing or a cross-function `jal <callee>` — needs the authoritative linker-pinned address table (bead evm-asm-4ch8f.6). |
 | COMPOSITE | 139 | RHS is not a pure string literal (concatenates other defs / probe prologues / data sections) — not a standalone routine body. **No wave bead needed:** these resolve automatically as their component functions convert. |
-| CONVERTED-CLEAN | 111 | Parses to a `Program`; the `emitProgram` render assembles `.text`-identically to the original hand-written text. Directly landable. |
-| ALREADY-STRUCTURED | 23 | RHS is already `"label:\n" ++ emitProgram <prog>` — a landed conversion (this PR: 16) or a prior template splice (RlpWalk, *SAsm). |
+| ALREADY-STRUCTURED | 132 | RHS is already `"label:\n" ++ emitProgram <prog>` — a landed conversion (this PR: 16) or a prior template splice (RlpWalk, *SAsm). |
 | NEEDS-LI-EXPANSION | 20 | Contains an `li rd, C` with C outside 12-bit signed range; a faithful 4-byte-per-`Instr` Program must emit the explicit `lui`/`addiw`/… expansion as separate `Instr`s (follow-up wave). |
 | CALLER-LOCAL-FRAGMENT | 8 | Branches/jumps to a `.L` label owned by the caller, or has no own entry label — no independent ABI; needs extraction into a status-returning callable first. |
+| MULTI-ENTRY-BUNDLE | 4 | Defines secondary non-`.L` labels (e.g. `*_clear`/`*_append`/`*_record_nth`) that other files `jal` into as cross-function entry points; `emitProgram` keeps only the entry label, so converting would silently break the guest link (caught only by the whole-guest byte-identity gate). Needs a multi-entry ABI / the .6 layout. |
 | **TOTAL** | **851** | |
 
-## Landed in this PR (16)
+## Landed in this PR (125)
 
 | Function | File | Instrs |
 |---|---|---:|
+| `b1SenderTableFindFunction` | `EvmAsm/Codegen/Programs/BlockVerdictSenderCounts.lean` | 0 |
+| `bahU32leFunction` | `EvmAsm/Codegen/Programs/BlockAccessListHash.lean` | 0 |
+| `bgvU32leFunction` | `EvmAsm/Codegen/Programs/BalGasValid.lean` | 0 |
+| `bgvU64leFunction` | `EvmAsm/Codegen/Programs/BalGasValid.lean` | 0 |
+| `bhrRevLeBeFunction` | `EvmAsm/Codegen/Programs/BlockHeaderSszToRlp.lean` | 0 |
+| `blake2fLdLe64Function` | `EvmAsm/Codegen/Programs/Blake2f.lean` | 0 |
+| `blake2fStLe64Function` | `EvmAsm/Codegen/Programs/Blake2f.lean` | 0 |
 | `bloomEqFunction` | `EvmAsm/Codegen/Programs/Bloom.lean` | 0 |
 | `bloomOrIntoFunction` | `EvmAsm/Codegen/Programs/Bloom.lean` | 0 |
+| `bls12CopyQuadsFunction` | `EvmAsm/Codegen/Programs/Bls12Field.lean` | 0 |
+| `bls12Fq12CopyFunction` | `EvmAsm/Codegen/Programs/Bls12Fq12.lean` | 0 |
+| `bls12Fq12EqFunction` | `EvmAsm/Codegen/Programs/Bls12Fq12.lean` | 0 |
+| `bls12Fq12IsZeroFunction` | `EvmAsm/Codegen/Programs/Bls12Fq12.lean` | 0 |
+| `bls12Fq12ZeroFunction` | `EvmAsm/Codegen/Programs/Bls12Fq12.lean` | 0 |
+| `bls12G1BeToLeFunction` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 0 |
+| `bls12G1Copy96Function` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 0 |
+| `bls12G1Eq48Function` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 0 |
+| `bls12G1IsZeroFunction` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 0 |
+| `bls12G1LeToBeFunction` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 0 |
+| `bls12G1Zero96Function` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 0 |
+| `bls12G2EqNFunction` | `EvmAsm/Codegen/Programs/Bls12G2.lean` | 0 |
+| `bls12G2Zero192Function` | `EvmAsm/Codegen/Programs/Bls12G2.lean` | 0 |
+| `bls12KzgG1WireFunction` | `EvmAsm/Codegen/Programs/Bls12Kzg.lean` | 0 |
+| `bls12KzgLtBeFunction` | `EvmAsm/Codegen/Programs/Bls12Kzg.lean` | 0 |
+| `bls12PtCopyFunction` | `EvmAsm/Codegen/Programs/Bls12Pairing.lean` | 0 |
+| `bn254CallAllotmentFunction` | `EvmAsm/Codegen/Programs/Bn254Curve.lean` | 0 |
+| `bn254FieldBeToLeFunction` | `EvmAsm/Codegen/Programs/Bn254Field.lean` | 0 |
+| `bn254FieldEq32Function` | `EvmAsm/Codegen/Programs/Bn254Field.lean` | 0 |
+| `bn254FieldIsZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Field.lean` | 0 |
+| `bn254FieldLeToBeFunction` | `EvmAsm/Codegen/Programs/Bn254Field.lean` | 0 |
+| `bn254Fp2CopyFunction` | `EvmAsm/Codegen/Programs/Bn254Fp2.lean` | 0 |
+| `bn254Fp2EqFunction` | `EvmAsm/Codegen/Programs/Bn254Fp2.lean` | 0 |
+| `bn254Fp2IsZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Fp2.lean` | 0 |
+| `bn254Fp2ZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Fp2.lean` | 0 |
+| `bn254Fq12CopyFunction` | `EvmAsm/Codegen/Programs/Bn254Fq12.lean` | 0 |
+| `bn254Fq12EqFunction` | `EvmAsm/Codegen/Programs/Bn254Fq12.lean` | 0 |
+| `bn254Fq12IsZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Fq12.lean` | 0 |
+| `bn254Fq12ZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Fq12.lean` | 0 |
+| `bn254PointCopy64Function` | `EvmAsm/Codegen/Programs/Bn254Curve.lean` | 0 |
+| `bn254PointIsInfFunction` | `EvmAsm/Codegen/Programs/Bn254Curve.lean` | 0 |
+| `bn254PointZero64Function` | `EvmAsm/Codegen/Programs/Bn254Curve.lean` | 0 |
+| `bn254PtCopyFunction` | `EvmAsm/Codegen/Programs/Bn254Pairing.lean` | 0 |
+| `bytesToNibblesFunction` | `EvmAsm/Codegen/Programs/Mpt.lean` | 0 |
+| `calcExcessBlobGasFunction` | `EvmAsm/Codegen/Programs/Header.lean` | 0 |
+| `callFrameSetCalldataFunction` | `EvmAsm/Codegen/Programs/CallFrameDescend.lean` | 0 |
+| `calldataByteCountsFunction` | `EvmAsm/Codegen/Programs/IntrinsicGas.lean` | 0 |
+| `codesBlockhashRequiredHeadersFunction` | `EvmAsm/Codegen/Programs/BlockhashRequiredHeaders.lean` | 0 |
+| `committedStorageChunkedSnapshotUpsertFunction` | `EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean` | 0 |
+| `committedStorageSnapshotAppendFunction` | `EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean` | 0 |
+| `committedStorageSnapshotUpsertFunction` | `EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean` | 0 |
+| `copyWordGasFunction` | `EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean` | 0 |
+| `deriveChainIdFromVFunction` | `EvmAsm/Codegen/Programs/Tx.lean` | 0 |
+| `eip8037BlockGasUsedFunction` | `EvmAsm/Codegen/Programs/IntrinsicGas.lean` | 0 |
+| `enrgU32leFunction` | `EvmAsm/Codegen/Programs/Eip7702NonceReuseGuard.lean` | 0 |
+| `ephU32leFunction` | `EvmAsm/Codegen/Programs/SszParentHeader.lean` | 0 |
+| `execLogLatestValueFunction` | `EvmAsm/Codegen/Programs/ExecLogLatestValue.lean` | 0 |
+| `expGasFunction` | `EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean` | 0 |
+| `findCodeEffectByAddressFunction` | `EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean` | 0 |
+| `headersParentHashFunction` | `EvmAsm/Codegen/Programs/HeadersKeccak.lean` | 0 |
+| `hpDecodeNibblesFunction` | `EvmAsm/Codegen/Programs/Mpt.lean` | 0 |
+| `hpEncodeNibblesFunction` | `EvmAsm/Codegen/Programs/Mpt.lean` | 0 |
+| `initCodeCostFunction` | `EvmAsm/Codegen/Programs/IntrinsicGas.lean` | 0 |
+| `intrinsicGasCalldataFloorEip7623Function` | `EvmAsm/Codegen/Programs/IntrinsicGas.lean` | 0 |
+| `keccak256WordGasFunction` | `EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean` | 0 |
+| `logDataGasFunction` | `EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean` | 0 |
+| `memoryExpansionGasFunction` | `EvmAsm/Codegen/Programs/MemoryExpansionGas.lean` | 0 |
+| `mptBranchPayloadTwoSlotsFunction` | `EvmAsm/Codegen/Programs/MptEncode.lean` | 0 |
+| `mptCompactToNibblesFunction` | `EvmAsm/Codegen/Programs/MptNibbles.lean` | 0 |
+| `mptNibblesToCompactFunction` | `EvmAsm/Codegen/Programs/MptNibbles.lean` | 0 |
 | `msetMemcpyFunction` | `EvmAsm/Codegen/Programs/MptSet.lean` | 0 |
 | `nibblesCommonPrefixLenFunction` | `EvmAsm/Codegen/Programs/MptEncode.lean` | 0 |
+| `p256BeToLeFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 0 |
+| `p256CopyNFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 0 |
+| `p256Eq32Function` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 0 |
+| `p256IsZeroNFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 0 |
+| `p256LeToBeFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 0 |
+| `p256LtBeFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 0 |
+| `parentHeaderMatchesWitnessFirstFunction` | `EvmAsm/Codegen/Programs/BlockHashPredicates.lean` | 0 |
+| `rlpBytesEncodedSizeFunction` | `EvmAsm/Codegen/Programs/BlockRlpSize.lean` | 0 |
+| `rlpEncodeBytesFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 0 |
+| `rlpEncodeListPrefixFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 0 |
+| `rlpEncodeU64Function` | `EvmAsm/Codegen/Programs/Receipt.lean` | 0 |
+| `rlpEncodeUintBeFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 0 |
+| `rlpListCountItemsFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 0 |
+| `rlpListEncodedSizeFunction` | `EvmAsm/Codegen/Programs/BlockRlpSize.lean` | 0 |
+| `rlpListNthItemFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 0 |
 | `runningBloomCopyFunction` | `EvmAsm/Codegen/Programs/Bloom.lean` | 0 |
 | `runningBloomZeroFunction` | `EvmAsm/Codegen/Programs/Bloom.lean` | 0 |
+| `secp256k1FieldBeToLeFunction` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 0 |
+| `secp256k1FieldCopy32Function` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 0 |
+| `secp256k1FieldEq32Function` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 0 |
+| `secp256k1FieldGetBitFunction` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 0 |
+| `secp256k1FieldIsZeroFunction` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 0 |
+| `secp256k1FieldLeToBeFunction` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 0 |
+| `secp256k1FieldZero32Function` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 0 |
+| `secp256k1PointCopy64Function` | `EvmAsm/Codegen/Programs/Secp256k1Curve.lean` | 0 |
+| `secp256k1PointZero64Function` | `EvmAsm/Codegen/Programs/Secp256k1Curve.lean` | 0 |
+| `senderPostNonceConsistentFunction` | `EvmAsm/Codegen/Programs/SenderPostNonceConsistent.lean` | 0 |
+| `slotDecodeU256Function` | `EvmAsm/Codegen/Programs/State.lean` | 0 |
+| `slotTupleSequencesMatchFunction` | `EvmAsm/Codegen/Programs/SlotTupleSequencesMatch.lean` | 0 |
+| `spwU32leFunction` | `EvmAsm/Codegen/Programs/SszPayloadWithdrawals.lean` | 0 |
+| `sszPackBytesFunction` | `EvmAsm/Codegen/Programs/Ssz.lean` | 0 |
+| `swdMinimalCopyFunction` | `EvmAsm/Codegen/Programs/SystemWrites.lean` | 0 |
+| `swdReadU64leFunction` | `EvmAsm/Codegen/Programs/SystemWrites.lean` | 0 |
+| `swdWriteBe32U64Function` | `EvmAsm/Codegen/Programs/SystemWrites.lean` | 0 |
+| `swdWriteBe8Function` | `EvmAsm/Codegen/Programs/SystemWrites.lean` | 0 |
+| `swrRevLeBeFunction` | `EvmAsm/Codegen/Programs/SszWithdrawal.lean` | 0 |
+| `swsU32leFunction` | `EvmAsm/Codegen/Programs/SszWitnessState.lean` | 0 |
+| `txGasResultIncrementsFunction` | `EvmAsm/Codegen/Programs/Account.lean` | 0 |
+| `txPubkeyEcrecoverStageMaterialFunction` | `EvmAsm/Codegen/Programs/TxPubkey.lean` | 0 |
+| `txRefundCapFunction` | `EvmAsm/Codegen/Programs/TxRefund.lean` | 0 |
+| `txTypeDispatchFunction` | `EvmAsm/Codegen/Programs/TxExtract.lean` | 0 |
+| `txValidateAgainstBlockFunction` | `EvmAsm/Codegen/Programs/Tx.lean` | 0 |
 | `u256AddBeFunction` | `EvmAsm/Codegen/Programs/U256.lean` | 0 |
 | `u256DivU64BeFunction` | `EvmAsm/Codegen/Programs/U256.lean` | 0 |
 | `u256EqFunction` | `EvmAsm/Codegen/Programs/U256.lean` | 0 |
@@ -36,122 +143,13 @@ Every `*Function : String` def under `EvmAsm/Codegen/Programs/` and `EvmAsm/Code
 | `u256MinFunction` | `EvmAsm/Codegen/Programs/U256.lean` | 0 |
 | `u256SubBeFunction` | `EvmAsm/Codegen/Programs/U256.lean` | 0 |
 | `u256ToU64BeFunction` | `EvmAsm/Codegen/Programs/U256.lean` | 0 |
+| `validateHeaderBasicFunction` | `EvmAsm/Codegen/Programs/Header.lean` | 0 |
+| `witnessCodesValidateLengthsFunction` | `EvmAsm/Codegen/Programs/WitnessValidation.lean` | 0 |
 
-## CONVERTED-CLEAN (111)
+## CONVERTED-CLEAN (0)
 
 | Function | File | Instrs | Note |
 |---|---|---:|---|
-| `txGasResultIncrementsFunction` | `EvmAsm/Codegen/Programs/Account.lean` | 26 |  |
-| `bgvU32leFunction` | `EvmAsm/Codegen/Programs/BalGasValid.lean` | 12 |  |
-| `bgvU64leFunction` | `EvmAsm/Codegen/Programs/BalGasValid.lean` | 13 |  |
-| `blake2fLdLe64Function` | `EvmAsm/Codegen/Programs/Blake2f.lean` | 11 |  |
-| `blake2fStLe64Function` | `EvmAsm/Codegen/Programs/Blake2f.lean` | 10 |  |
-| `bahU32leFunction` | `EvmAsm/Codegen/Programs/BlockAccessListHash.lean` | 12 |  |
-| `parentHeaderMatchesWitnessFirstFunction` | `EvmAsm/Codegen/Programs/BlockHashPredicates.lean` | 57 |  |
-| `bhrRevLeBeFunction` | `EvmAsm/Codegen/Programs/BlockHeaderSszToRlp.lean` | 11 |  |
-| `rlpBytesEncodedSizeFunction` | `EvmAsm/Codegen/Programs/BlockRlpSize.lean` | 20 |  |
-| `rlpListEncodedSizeFunction` | `EvmAsm/Codegen/Programs/BlockRlpSize.lean` | 13 |  |
-| `b1SenderTableFindFunction` | `EvmAsm/Codegen/Programs/BlockVerdictSenderCounts.lean` | 47 |  |
-| `codesBlockhashRequiredHeadersFunction` | `EvmAsm/Codegen/Programs/BlockhashRequiredHeaders.lean` | 88 |  |
-| `bls12CopyQuadsFunction` | `EvmAsm/Codegen/Programs/Bls12Field.lean` | 8 |  |
-| `bls12Fq12CopyFunction` | `EvmAsm/Codegen/Programs/Bls12Fq12.lean` | 8 |  |
-| `bls12Fq12EqFunction` | `EvmAsm/Codegen/Programs/Bls12Fq12.lean` | 13 |  |
-| `bls12Fq12IsZeroFunction` | `EvmAsm/Codegen/Programs/Bls12Fq12.lean` | 10 |  |
-| `bls12Fq12ZeroFunction` | `EvmAsm/Codegen/Programs/Bls12Fq12.lean` | 6 |  |
-| `bls12G1BeToLeFunction` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 20 |  |
-| `bls12G1Copy96Function` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 8 |  |
-| `bls12G1Eq48Function` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 15 |  |
-| `bls12G1IsZeroFunction` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 12 |  |
-| `bls12G1LeToBeFunction` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 19 |  |
-| `bls12G1Zero96Function` | `EvmAsm/Codegen/Programs/Bls12G1.lean` | 6 |  |
-| `bls12G2EqNFunction` | `EvmAsm/Codegen/Programs/Bls12G2.lean` | 15 |  |
-| `bls12G2Zero192Function` | `EvmAsm/Codegen/Programs/Bls12G2.lean` | 6 |  |
-| `bls12KzgG1WireFunction` | `EvmAsm/Codegen/Programs/Bls12Kzg.lean` | 23 |  |
-| `bls12KzgLtBeFunction` | `EvmAsm/Codegen/Programs/Bls12Kzg.lean` | 16 |  |
-| `bls12PtCopyFunction` | `EvmAsm/Codegen/Programs/Bls12Pairing.lean` | 8 |  |
-| `bn254CallAllotmentFunction` | `EvmAsm/Codegen/Programs/Bn254Curve.lean` | 13 |  |
-| `bn254PointCopy64Function` | `EvmAsm/Codegen/Programs/Bn254Curve.lean` | 9 |  |
-| `bn254PointIsInfFunction` | `EvmAsm/Codegen/Programs/Bn254Curve.lean` | 12 |  |
-| `bn254PointZero64Function` | `EvmAsm/Codegen/Programs/Bn254Curve.lean` | 7 |  |
-| `bn254FieldBeToLeFunction` | `EvmAsm/Codegen/Programs/Bn254Field.lean` | 20 |  |
-| `bn254FieldEq32Function` | `EvmAsm/Codegen/Programs/Bn254Field.lean` | 15 |  |
-| `bn254FieldIsZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Field.lean` | 12 |  |
-| `bn254FieldLeToBeFunction` | `EvmAsm/Codegen/Programs/Bn254Field.lean` | 19 |  |
-| `bn254Fp2CopyFunction` | `EvmAsm/Codegen/Programs/Bn254Fp2.lean` | 17 |  |
-| `bn254Fp2EqFunction` | `EvmAsm/Codegen/Programs/Bn254Fp2.lean` | 13 |  |
-| `bn254Fp2IsZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Fp2.lean` | 10 |  |
-| `bn254Fp2ZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Fp2.lean` | 9 |  |
-| `bn254Fq12CopyFunction` | `EvmAsm/Codegen/Programs/Bn254Fq12.lean` | 8 |  |
-| `bn254Fq12EqFunction` | `EvmAsm/Codegen/Programs/Bn254Fq12.lean` | 13 |  |
-| `bn254Fq12IsZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Fq12.lean` | 10 |  |
-| `bn254Fq12ZeroFunction` | `EvmAsm/Codegen/Programs/Bn254Fq12.lean` | 6 |  |
-| `bn254PtCopyFunction` | `EvmAsm/Codegen/Programs/Bn254Pairing.lean` | 8 |  |
-| `callFrameSetCalldataFunction` | `EvmAsm/Codegen/Programs/CallFrameDescend.lean` | 4 |  |
-| `committedStorageChunkedSnapshotUpsertFunction` | `EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean` | 84 |  |
-| `committedStorageSnapshotAppendFunction` | `EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean` | 55 |  |
-| `committedStorageSnapshotUpsertFunction` | `EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean` | 84 |  |
-| `findCodeEffectByAddressFunction` | `EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean` | 24 |  |
-| `copyWordGasFunction` | `EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean` | 5 |  |
-| `expGasFunction` | `EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean` | 16 |  |
-| `keccak256WordGasFunction` | `EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean` | 6 |  |
-| `logDataGasFunction` | `EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean` | 7 |  |
-| `enrgU32leFunction` | `EvmAsm/Codegen/Programs/Eip7702NonceReuseGuard.lean` | 11 |  |
-| `execLogLatestValueFunction` | `EvmAsm/Codegen/Programs/ExecLogLatestValue.lean` | 42 |  |
-| `calcExcessBlobGasFunction` | `EvmAsm/Codegen/Programs/Header.lean` | 6 |  |
-| `validateHeaderBasicFunction` | `EvmAsm/Codegen/Programs/Header.lean` | 19 |  |
-| `headersParentHashFunction` | `EvmAsm/Codegen/Programs/HeadersKeccak.lean` | 32 |  |
-| `calldataByteCountsFunction` | `EvmAsm/Codegen/Programs/IntrinsicGas.lean` | 17 |  |
-| `eip8037BlockGasUsedFunction` | `EvmAsm/Codegen/Programs/IntrinsicGas.lean` | 35 |  |
-| `initCodeCostFunction` | `EvmAsm/Codegen/Programs/IntrinsicGas.lean` | 6 |  |
-| `intrinsicGasCalldataFloorEip7623Function` | `EvmAsm/Codegen/Programs/IntrinsicGas.lean` | 20 |  |
-| `memoryExpansionGasFunction` | `EvmAsm/Codegen/Programs/MemoryExpansionGas.lean` | 18 |  |
-| `bytesToNibblesFunction` | `EvmAsm/Codegen/Programs/Mpt.lean` | 17 |  |
-| `hpDecodeNibblesFunction` | `EvmAsm/Codegen/Programs/Mpt.lean` | 54 |  |
-| `hpEncodeNibblesFunction` | `EvmAsm/Codegen/Programs/Mpt.lean` | 27 |  |
-| `mptBranchPayloadTwoSlotsFunction` | `EvmAsm/Codegen/Programs/MptEncode.lean` | 63 |  |
-| `mptCompactToNibblesFunction` | `EvmAsm/Codegen/Programs/MptNibbles.lean` | 34 |  |
-| `mptNibblesToCompactFunction` | `EvmAsm/Codegen/Programs/MptNibbles.lean` | 33 |  |
-| `p256BeToLeFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 20 |  |
-| `p256CopyNFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 8 |  |
-| `p256Eq32Function` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 15 |  |
-| `p256IsZeroNFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 12 |  |
-| `p256LeToBeFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 19 |  |
-| `p256LtBeFunction` | `EvmAsm/Codegen/Programs/P256Verify.lean` | 16 |  |
-| `rlpEncodeU64Function` | `EvmAsm/Codegen/Programs/Receipt.lean` | 51 |  |
-| `receiptRecordsFunction` | `EvmAsm/Codegen/Programs/ReceiptRecords.lean` | 61 |  |
-| `rlpEncodeBytesFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 76 |  |
-| `rlpEncodeListPrefixFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 46 |  |
-| `rlpEncodeUintBeFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 35 |  |
-| `rlpListCountItemsFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 76 |  |
-| `rlpListNthItemFunction` | `EvmAsm/Codegen/Programs/RlpRead.lean` | 160 |  |
-| `secp256k1PointCopy64Function` | `EvmAsm/Codegen/Programs/Secp256k1Curve.lean` | 9 |  |
-| `secp256k1PointZero64Function` | `EvmAsm/Codegen/Programs/Secp256k1Curve.lean` | 7 |  |
-| `secp256k1FieldBeToLeFunction` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 20 |  |
-| `secp256k1FieldCopy32Function` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 9 |  |
-| `secp256k1FieldEq32Function` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 15 |  |
-| `secp256k1FieldGetBitFunction` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 9 |  |
-| `secp256k1FieldIsZeroFunction` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 12 |  |
-| `secp256k1FieldLeToBeFunction` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 19 |  |
-| `secp256k1FieldZero32Function` | `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 5 |  |
-| `senderPostNonceConsistentFunction` | `EvmAsm/Codegen/Programs/SenderPostNonceConsistent.lean` | 24 |  |
-| `slotTupleSequencesMatchFunction` | `EvmAsm/Codegen/Programs/SlotTupleSequencesMatch.lean` | 29 |  |
-| `sszPackBytesFunction` | `EvmAsm/Codegen/Programs/Ssz.lean` | 22 |  |
-| `ephU32leFunction` | `EvmAsm/Codegen/Programs/SszParentHeader.lean` | 12 |  |
-| `spwU32leFunction` | `EvmAsm/Codegen/Programs/SszPayloadWithdrawals.lean` | 12 |  |
-| `swrRevLeBeFunction` | `EvmAsm/Codegen/Programs/SszWithdrawal.lean` | 11 |  |
-| `swsU32leFunction` | `EvmAsm/Codegen/Programs/SszWitnessState.lean` | 12 |  |
-| `slotDecodeU256Function` | `EvmAsm/Codegen/Programs/State.lean` | 32 |  |
-| `storageEffectRecordsFunction` | `EvmAsm/Codegen/Programs/StorageEffectRecords.lean` | 47 |  |
-| `swdMinimalCopyFunction` | `EvmAsm/Codegen/Programs/SystemWrites.lean` | 19 |  |
-| `swdReadU64leFunction` | `EvmAsm/Codegen/Programs/SystemWrites.lean` | 24 |  |
-| `swdWriteBe32U64Function` | `EvmAsm/Codegen/Programs/SystemWrites.lean` | 21 |  |
-| `swdWriteBe8Function` | `EvmAsm/Codegen/Programs/SystemWrites.lean` | 13 |  |
-| `deriveChainIdFromVFunction` | `EvmAsm/Codegen/Programs/Tx.lean` | 15 |  |
-| `txValidateAgainstBlockFunction` | `EvmAsm/Codegen/Programs/Tx.lean` | 11 |  |
-| `txTypeDispatchFunction` | `EvmAsm/Codegen/Programs/TxExtract.lean` | 45 |  |
-| `txPubkeyEcrecoverStageMaterialFunction` | `EvmAsm/Codegen/Programs/TxPubkey.lean` | 44 |  |
-| `txRefundCapFunction` | `EvmAsm/Codegen/Programs/TxRefund.lean` | 22 |  |
-| `witnessCodesValidateLengthsFunction` | `EvmAsm/Codegen/Programs/WitnessValidation.lean` | 54 |  |
 
 ## NEEDS-LI-EXPANSION (20)
 
@@ -191,7 +189,16 @@ Every `*Function : String` def under `EvmAsm/Codegen/Programs/` and `EvmAsm/Code
 | `zkvmBn254G1MulRealFunction` | `EvmAsm/Codegen/Programs/Bn254Curve.lean` |  | first line is not a label |
 | `runtimeAccessAccountSeedFunction` | `EvmAsm/Codegen/Programs/EvmAccessGas.lean` |  | unresolved branch/jump target '.exit_outofgas' |
 
-## BLOCKED_ON_.6 (550) — by file
+## MULTI-ENTRY-BUNDLE (4)
+
+| Function | File | Instrs | Note |
+|---|---|---:|---|
+| `blockValidateEmptyBlockFunction` | `EvmAsm/Codegen/Programs/BlockEmpty.lean` |  | secondary non-.L label 'beb_check_header_field_32B': multi-entry bundl |
+| `mptIndexedTrieRootOneLeafFunction` | `EvmAsm/Codegen/Programs/MptIndexedTrieRoot.lean` |  | secondary non-.L label 'rlp_prefix_to_buffer': multi-entry bundle, cro |
+| `receiptRecordsFunction` | `EvmAsm/Codegen/Programs/ReceiptRecords.lean` |  | secondary non-.L label 'receipt_records_clear': multi-entry bundle, cr |
+| `storageEffectRecordsFunction` | `EvmAsm/Codegen/Programs/StorageEffectRecords.lean` |  | secondary non-.L label 'storage_effect_records_clear': multi-entry bun |
+
+## BLOCKED_ON_.6 (548) — by file
 
 | File | Count |
 |---|---:|
@@ -243,7 +250,7 @@ Every `*Function : String` def under `EvmAsm/Codegen/Programs/` and `EvmAsm/Code
 | `EvmAsm/Codegen/Programs/Block.lean` | 6 |
 | `EvmAsm/Codegen/Programs/BlockAccessListHash.lean` | 1 |
 | `EvmAsm/Codegen/Programs/BlockBody.lean` | 6 |
-| `EvmAsm/Codegen/Programs/BlockEmpty.lean` | 4 |
+| `EvmAsm/Codegen/Programs/BlockEmpty.lean` | 3 |
 | `EvmAsm/Codegen/Programs/BlockGasRemaining.lean` | 1 |
 | `EvmAsm/Codegen/Programs/BlockHashAtBlockNumber.lean` | 1 |
 | `EvmAsm/Codegen/Programs/BlockHashAtStateRoot.lean` | 1 |
@@ -347,7 +354,7 @@ Every `*Function : String` def under `EvmAsm/Codegen/Programs/` and `EvmAsm/Code
 | `EvmAsm/Codegen/Programs/MptDeleteWalkDb.lean` | 1 |
 | `EvmAsm/Codegen/Programs/MptEncode.lean` | 2 |
 | `EvmAsm/Codegen/Programs/MptEncodeLeafBranch.lean` | 1 |
-| `EvmAsm/Codegen/Programs/MptIndexedTrieRoot.lean` | 3 |
+| `EvmAsm/Codegen/Programs/MptIndexedTrieRoot.lean` | 2 |
 | `EvmAsm/Codegen/Programs/MptInsert.lean` | 1 |
 | `EvmAsm/Codegen/Programs/MptInsertAcc.lean` | 1 |
 | `EvmAsm/Codegen/Programs/MptInsertWalk.lean` | 1 |
@@ -463,17 +470,68 @@ Every `*Function : String` def under `EvmAsm/Codegen/Programs/` and `EvmAsm/Code
 | `EvmAsm/Codegen/Programs/WitnessStorageNodeKindDistribution.lean` | 1 |
 | `EvmAsm/Codegen/Programs/WitnessValidation.lean` | 2 |
 
-## ALREADY-STRUCTURED (23) — by file
+## ALREADY-STRUCTURED (132) — by file
 
 | File | Count |
 |---|---:|
+| `EvmAsm/Codegen/Programs/Account.lean` | 1 |
+| `EvmAsm/Codegen/Programs/BalGasValid.lean` | 2 |
+| `EvmAsm/Codegen/Programs/Blake2f.lean` | 2 |
+| `EvmAsm/Codegen/Programs/BlockAccessListHash.lean` | 1 |
+| `EvmAsm/Codegen/Programs/BlockHashPredicates.lean` | 1 |
+| `EvmAsm/Codegen/Programs/BlockHeaderSszToRlp.lean` | 1 |
+| `EvmAsm/Codegen/Programs/BlockRlpSize.lean` | 2 |
+| `EvmAsm/Codegen/Programs/BlockVerdictSenderCounts.lean` | 1 |
+| `EvmAsm/Codegen/Programs/BlockhashRequiredHeaders.lean` | 1 |
 | `EvmAsm/Codegen/Programs/Bloom.lean` | 4 |
+| `EvmAsm/Codegen/Programs/Bls12Field.lean` | 1 |
+| `EvmAsm/Codegen/Programs/Bls12Fq12.lean` | 4 |
+| `EvmAsm/Codegen/Programs/Bls12G1.lean` | 6 |
+| `EvmAsm/Codegen/Programs/Bls12G2.lean` | 2 |
+| `EvmAsm/Codegen/Programs/Bls12Kzg.lean` | 2 |
+| `EvmAsm/Codegen/Programs/Bls12Pairing.lean` | 1 |
+| `EvmAsm/Codegen/Programs/Bn254Curve.lean` | 4 |
+| `EvmAsm/Codegen/Programs/Bn254Field.lean` | 4 |
+| `EvmAsm/Codegen/Programs/Bn254Fp2.lean` | 4 |
+| `EvmAsm/Codegen/Programs/Bn254Fq12.lean` | 4 |
+| `EvmAsm/Codegen/Programs/Bn254Pairing.lean` | 1 |
+| `EvmAsm/Codegen/Programs/CallFrameDescend.lean` | 1 |
+| `EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean` | 3 |
+| `EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean` | 1 |
 | `EvmAsm/Codegen/Programs/CreateDeployedCodeValid.lean` | 1 |
 | `EvmAsm/Codegen/Programs/CreateInitcodeSizeValid.lean` | 1 |
-| `EvmAsm/Codegen/Programs/MptEncode.lean` | 1 |
+| `EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean` | 4 |
+| `EvmAsm/Codegen/Programs/Eip7702NonceReuseGuard.lean` | 1 |
+| `EvmAsm/Codegen/Programs/ExecLogLatestValue.lean` | 1 |
+| `EvmAsm/Codegen/Programs/Header.lean` | 2 |
+| `EvmAsm/Codegen/Programs/HeadersKeccak.lean` | 1 |
+| `EvmAsm/Codegen/Programs/IntrinsicGas.lean` | 4 |
+| `EvmAsm/Codegen/Programs/MemoryExpansionGas.lean` | 1 |
+| `EvmAsm/Codegen/Programs/Mpt.lean` | 3 |
+| `EvmAsm/Codegen/Programs/MptEncode.lean` | 2 |
+| `EvmAsm/Codegen/Programs/MptNibbles.lean` | 2 |
 | `EvmAsm/Codegen/Programs/MptSet.lean` | 1 |
+| `EvmAsm/Codegen/Programs/P256Verify.lean` | 6 |
+| `EvmAsm/Codegen/Programs/Receipt.lean` | 1 |
+| `EvmAsm/Codegen/Programs/RlpRead.lean` | 5 |
 | `EvmAsm/Codegen/Programs/RlpWalk.lean` | 5 |
+| `EvmAsm/Codegen/Programs/Secp256k1Curve.lean` | 2 |
+| `EvmAsm/Codegen/Programs/Secp256k1Field.lean` | 7 |
+| `EvmAsm/Codegen/Programs/SenderPostNonceConsistent.lean` | 1 |
+| `EvmAsm/Codegen/Programs/SlotTupleSequencesMatch.lean` | 1 |
+| `EvmAsm/Codegen/Programs/Ssz.lean` | 1 |
+| `EvmAsm/Codegen/Programs/SszParentHeader.lean` | 1 |
+| `EvmAsm/Codegen/Programs/SszPayloadWithdrawals.lean` | 1 |
+| `EvmAsm/Codegen/Programs/SszWithdrawal.lean` | 1 |
+| `EvmAsm/Codegen/Programs/SszWitnessState.lean` | 1 |
+| `EvmAsm/Codegen/Programs/State.lean` | 1 |
+| `EvmAsm/Codegen/Programs/SystemWrites.lean` | 4 |
+| `EvmAsm/Codegen/Programs/Tx.lean` | 2 |
+| `EvmAsm/Codegen/Programs/TxExtract.lean` | 1 |
+| `EvmAsm/Codegen/Programs/TxPubkey.lean` | 1 |
+| `EvmAsm/Codegen/Programs/TxRefund.lean` | 1 |
 | `EvmAsm/Codegen/Programs/U256.lean` | 10 |
+| `EvmAsm/Codegen/Programs/WitnessValidation.lean` | 1 |
 
 ## COMPOSITE (139) — by file
 

--- a/scripts/asm-fixtures/MANIFEST.tsv
+++ b/scripts/asm-fixtures/MANIFEST.tsv
@@ -1,6 +1,11 @@
 # asm_to_program.py conversion manifest: <func>\t<lean file> (bead evm-asm-4ch8f.9)
+b1SenderTableFindFunction	EvmAsm/Codegen/Programs/BlockVerdictSenderCounts.lean
 bahU32leFunction	EvmAsm/Codegen/Programs/BlockAccessListHash.lean
+bgvU32leFunction	EvmAsm/Codegen/Programs/BalGasValid.lean
+bgvU64leFunction	EvmAsm/Codegen/Programs/BalGasValid.lean
 bhrRevLeBeFunction	EvmAsm/Codegen/Programs/BlockHeaderSszToRlp.lean
+blake2fLdLe64Function	EvmAsm/Codegen/Programs/Blake2f.lean
+blake2fStLe64Function	EvmAsm/Codegen/Programs/Blake2f.lean
 bloomEqFunction	EvmAsm/Codegen/Programs/Bloom.lean
 bloomOrIntoFunction	EvmAsm/Codegen/Programs/Bloom.lean
 bls12CopyQuadsFunction	EvmAsm/Codegen/Programs/Bls12Field.lean
@@ -41,11 +46,15 @@ calcExcessBlobGasFunction	EvmAsm/Codegen/Programs/Header.lean
 callFrameSetCalldataFunction	EvmAsm/Codegen/Programs/CallFrameDescend.lean
 calldataByteCountsFunction	EvmAsm/Codegen/Programs/IntrinsicGas.lean
 codesBlockhashRequiredHeadersFunction	EvmAsm/Codegen/Programs/BlockhashRequiredHeaders.lean
+committedStorageChunkedSnapshotUpsertFunction	EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean
+committedStorageSnapshotAppendFunction	EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean
+committedStorageSnapshotUpsertFunction	EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean
 copyWordGasFunction	EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean
 deriveChainIdFromVFunction	EvmAsm/Codegen/Programs/Tx.lean
 eip8037BlockGasUsedFunction	EvmAsm/Codegen/Programs/IntrinsicGas.lean
 enrgU32leFunction	EvmAsm/Codegen/Programs/Eip7702NonceReuseGuard.lean
 ephU32leFunction	EvmAsm/Codegen/Programs/SszParentHeader.lean
+execLogLatestValueFunction	EvmAsm/Codegen/Programs/ExecLogLatestValue.lean
 expGasFunction	EvmAsm/Codegen/Programs/DynamicOpcodeGas.lean
 findCodeEffectByAddressFunction	EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean
 headersParentHashFunction	EvmAsm/Codegen/Programs/HeadersKeccak.lean
@@ -87,8 +96,15 @@ secp256k1FieldLeToBeFunction	EvmAsm/Codegen/Programs/Secp256k1Field.lean
 secp256k1FieldZero32Function	EvmAsm/Codegen/Programs/Secp256k1Field.lean
 secp256k1PointCopy64Function	EvmAsm/Codegen/Programs/Secp256k1Curve.lean
 secp256k1PointZero64Function	EvmAsm/Codegen/Programs/Secp256k1Curve.lean
+senderPostNonceConsistentFunction	EvmAsm/Codegen/Programs/SenderPostNonceConsistent.lean
+slotDecodeU256Function	EvmAsm/Codegen/Programs/State.lean
+slotTupleSequencesMatchFunction	EvmAsm/Codegen/Programs/SlotTupleSequencesMatch.lean
 spwU32leFunction	EvmAsm/Codegen/Programs/SszPayloadWithdrawals.lean
 sszPackBytesFunction	EvmAsm/Codegen/Programs/Ssz.lean
+swdMinimalCopyFunction	EvmAsm/Codegen/Programs/SystemWrites.lean
+swdReadU64leFunction	EvmAsm/Codegen/Programs/SystemWrites.lean
+swdWriteBe32U64Function	EvmAsm/Codegen/Programs/SystemWrites.lean
+swdWriteBe8Function	EvmAsm/Codegen/Programs/SystemWrites.lean
 swrRevLeBeFunction	EvmAsm/Codegen/Programs/SszWithdrawal.lean
 swsU32leFunction	EvmAsm/Codegen/Programs/SszWitnessState.lean
 txGasResultIncrementsFunction	EvmAsm/Codegen/Programs/Account.lean
@@ -107,3 +123,4 @@ u256MinFunction	EvmAsm/Codegen/Programs/U256.lean
 u256SubBeFunction	EvmAsm/Codegen/Programs/U256.lean
 u256ToU64BeFunction	EvmAsm/Codegen/Programs/U256.lean
 validateHeaderBasicFunction	EvmAsm/Codegen/Programs/Header.lean
+witnessCodesValidateLengthsFunction	EvmAsm/Codegen/Programs/WitnessValidation.lean

--- a/scripts/asm-fixtures/b1SenderTableFindFunction.s
+++ b/scripts/asm-fixtures/b1SenderTableFindFunction.s
@@ -1,0 +1,30 @@
+b1_sender_table_find:
+  addi sp, sp, -64
+  sd ra, 0(sp); sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp)
+  sd s3, 32(sp); sd s4, 40(sp); sd s5, 48(sp)
+  mv s0, a0; mv s1, a1; mv s2, a2
+  li s3, 0; mv s4, s1
+.Lb1stf_loop:
+  bgeu s3, s4, .Lb1stf_absent
+  add s5, s3, s4; srli s5, s5, 1
+  li t0, 40; mul t0, s5, t0; add t1, s0, t0
+  li t2, 0
+.Lb1stf_cmp:
+  li t3, 20; beq t2, t3, .Lb1stf_found
+  add t3, t1, t2; lbu t4, 0(t3); add t3, s2, t2; lbu t5, 0(t3)
+  bltu t4, t5, .Lb1stf_entry_less
+  bltu t5, t4, .Lb1stf_entry_greater
+  addi t2, t2, 1; j .Lb1stf_cmp
+.Lb1stf_entry_less:
+  addi s3, s5, 1; j .Lb1stf_loop
+.Lb1stf_entry_greater:
+  mv s4, s5; j .Lb1stf_loop
+.Lb1stf_found:
+  li a0, 0; mv a1, t1; j .Lb1stf_ret
+.Lb1stf_absent:
+  li a0, 1
+.Lb1stf_ret:
+  ld ra, 0(sp); ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp)
+  ld s3, 32(sp); ld s4, 40(sp); ld s5, 48(sp)
+  addi sp, sp, 64
+  ret

--- a/scripts/asm-fixtures/bgvU32leFunction.s
+++ b/scripts/asm-fixtures/bgvU32leFunction.s
@@ -1,0 +1,7 @@
+bgv_u32le:
+  lbu t0, 0(a0)
+  lbu t1, 1(a0); slli t1, t1, 8;  or t0, t0, t1
+  lbu t1, 2(a0); slli t1, t1, 16; or t0, t0, t1
+  lbu t1, 3(a0); slli t1, t1, 24; or t0, t0, t1
+  mv a0, t0
+  ret

--- a/scripts/asm-fixtures/bgvU64leFunction.s
+++ b/scripts/asm-fixtures/bgvU64leFunction.s
@@ -1,0 +1,8 @@
+bgv_u64le:
+  li t0, 0; li t2, 0
+.Lbgv64:
+  li t3, 8; beq t2, t3, .Lbgv64d
+  add t4, a0, t2; lbu t5, 0(t4); slli t6, t2, 3; sll t5, t5, t6; or t0, t0, t5
+  addi t2, t2, 1; j .Lbgv64
+.Lbgv64d:
+  mv a0, t0; ret

--- a/scripts/asm-fixtures/blake2fLdLe64Function.s
+++ b/scripts/asm-fixtures/blake2fLdLe64Function.s
@@ -1,0 +1,13 @@
+blk2_ld_le64:
+  li t0, 0
+  addi t1, a0, 7
+  li t2, 8
+.Lblk2_ld_byte:
+  slli t0, t0, 8
+  lbu a0, 0(t1)
+  or t0, t0, a0
+  addi t1, t1, -1
+  addi t2, t2, -1
+  bnez t2, .Lblk2_ld_byte
+  mv a0, t0
+  ret

--- a/scripts/asm-fixtures/blake2fStLe64Function.s
+++ b/scripts/asm-fixtures/blake2fStLe64Function.s
@@ -1,0 +1,12 @@
+blk2_st_le64:
+  mv t0, a1
+  mv t1, a0
+  li t2, 8
+.Lblk2_st_byte:
+  andi a1, t0, 0xff
+  sb a1, 0(t1)
+  srli t0, t0, 8
+  addi t1, t1, 1
+  addi t2, t2, -1
+  bnez t2, .Lblk2_st_byte
+  ret

--- a/scripts/asm-fixtures/committedStorageChunkedSnapshotUpsertFunction.s
+++ b/scripts/asm-fixtures/committedStorageChunkedSnapshotUpsertFunction.s
@@ -1,0 +1,44 @@
+bv_mtx_committed_chunked_snapshot_upsert:
+  li t0, 0                      # j = 0
+.Lcscsu_loop:
+  beq t0, a2, .Lcscsu_done
+  slli t1, t0, 7; add t1, a1, t1   # src = live[j]
+  li t2, 0                      # i = 0
+.Lcscsu_scan:
+  beq t2, a4, .Lcscsu_no_match
+  slli t3, t2, 7; add t3, a3, t3   # entry = table[i]
+  li t4, 0
+.Lcscsu_addr_cmp:
+  li t5, 20; beq t4, t5, .Lcscsu_slot_cmp
+  add t5, a0, t4; lbu t5, 0(t5); add t6, t3, t4; lbu t6, 0(t6); bne t5, t6, .Lcscsu_next_entry
+  addi t4, t4, 1; j .Lcscsu_addr_cmp
+.Lcscsu_slot_cmp:
+  ld t5, 32(t1);  ld t6, 32(t3);  bne t5, t6, .Lcscsu_next_entry
+  ld t5, 40(t1);  ld t6, 40(t3);  bne t5, t6, .Lcscsu_next_entry
+  ld t5, 48(t1);  ld t6, 48(t3);  bne t5, t6, .Lcscsu_next_entry
+  ld t5, 56(t1);  ld t6, 56(t3);  bne t5, t6, .Lcscsu_next_entry
+  j .Lcscsu_store_payload
+.Lcscsu_next_entry:
+  addi t2, t2, 1; j .Lcscsu_scan
+.Lcscsu_no_match:
+  bgeu a4, a5, .Lcscsu_overflow
+  slli t3, a4, 7; add t3, a3, t3   # dst = table[count]
+  sd zero, 0(t3); sd zero, 8(t3); sd zero, 16(t3); sd zero, 24(t3)
+  li t4, 0
+.Lcscsu_addr_copy:
+  li t5, 20; beq t4, t5, .Lcscsu_store_payload_append
+  add t5, a0, t4; lbu t6, 0(t5); add t5, t3, t4; sb t6, 0(t5); addi t4, t4, 1; j .Lcscsu_addr_copy
+.Lcscsu_store_payload_append:
+  addi a4, a4, 1
+.Lcscsu_store_payload:
+  ld t4, 32(t1);  sd t4, 32(t3);  ld t4, 40(t1);  sd t4, 40(t3)
+  ld t4, 48(t1);  sd t4, 48(t3);  ld t4, 56(t1);  sd t4, 56(t3)
+  ld t4, 64(t1);  sd t4, 64(t3);  ld t4, 72(t1);  sd t4, 72(t3)
+  ld t4, 80(t1);  sd t4, 80(t3);  ld t4, 88(t1);  sd t4, 88(t3)
+  ld t4, 96(t1);  sd t4, 96(t3);  ld t4, 104(t1); sd t4, 104(t3)
+  ld t4, 112(t1); sd t4, 112(t3); ld t4, 120(t1); sd t4, 120(t3)
+  addi t0, t0, 1; j .Lcscsu_loop
+.Lcscsu_overflow:
+  li t0, 1; sd t0, 0(a6); mv a0, a4; li a1, 1; ret
+.Lcscsu_done:
+  mv a0, a4; li a1, 0; ret

--- a/scripts/asm-fixtures/committedStorageSnapshotAppendFunction.s
+++ b/scripts/asm-fixtures/committedStorageSnapshotAppendFunction.s
@@ -1,0 +1,24 @@
+bv_mtx_committed_snapshot_append:
+  li t0, 0                      # j = 0
+.Lcssa_loop:
+  beq t0, a2, .Lcssa_done
+  bgeu a4, a5, .Lcssa_overflow
+  slli t1, t0, 7; add t1, a1, t1   # src = live[j]
+  slli t2, a4, 7; add t2, a3, t2   # dst = table[count]
+  sd zero, 0(t2); sd zero, 8(t2); sd zero, 16(t2); sd zero, 24(t2)
+  li t3, 0
+.Lcssa_addr:
+  li t4, 20; beq t3, t4, .Lcssa_addr_done
+  add t5, a0, t3; lbu t6, 0(t5); add t5, t2, t3; sb t6, 0(t5); addi t3, t3, 1; j .Lcssa_addr
+.Lcssa_addr_done:
+  ld t3, 32(t1);  sd t3, 32(t2);  ld t3, 40(t1);  sd t3, 40(t2)
+  ld t3, 48(t1);  sd t3, 48(t2);  ld t3, 56(t1);  sd t3, 56(t2)
+  ld t3, 64(t1);  sd t3, 64(t2);  ld t3, 72(t1);  sd t3, 72(t2)
+  ld t3, 80(t1);  sd t3, 80(t2);  ld t3, 88(t1);  sd t3, 88(t2)
+  ld t3, 96(t1);  sd t3, 96(t2);  ld t3, 104(t1); sd t3, 104(t2)
+  ld t3, 112(t1); sd t3, 112(t2); ld t3, 120(t1); sd t3, 120(t2)
+  addi a4, a4, 1; addi t0, t0, 1; j .Lcssa_loop
+.Lcssa_overflow:
+  li t0, 1; sd t0, 0(a6); mv a0, a4; li a1, 1; ret
+.Lcssa_done:
+  mv a0, a4; li a1, 0; ret

--- a/scripts/asm-fixtures/committedStorageSnapshotUpsertFunction.s
+++ b/scripts/asm-fixtures/committedStorageSnapshotUpsertFunction.s
@@ -1,0 +1,44 @@
+bv_mtx_committed_snapshot_upsert:
+  li t0, 0                      # j = 0
+.Lcssu_loop:
+  beq t0, a2, .Lcssu_done
+  slli t1, t0, 7; add t1, a1, t1   # src = live[j]
+  li t2, 0                      # i = 0
+.Lcssu_scan:
+  beq t2, a4, .Lcssu_no_match
+  slli t3, t2, 7; add t3, a3, t3   # entry = table[i]
+  li t4, 0
+.Lcssu_addr_cmp:
+  li t5, 20; beq t4, t5, .Lcssu_slot_cmp
+  add t5, a0, t4; lbu t5, 0(t5); add t6, t3, t4; lbu t6, 0(t6); bne t5, t6, .Lcssu_next_entry
+  addi t4, t4, 1; j .Lcssu_addr_cmp
+.Lcssu_slot_cmp:
+  ld t5, 32(t1);  ld t6, 32(t3);  bne t5, t6, .Lcssu_next_entry
+  ld t5, 40(t1);  ld t6, 40(t3);  bne t5, t6, .Lcssu_next_entry
+  ld t5, 48(t1);  ld t6, 48(t3);  bne t5, t6, .Lcssu_next_entry
+  ld t5, 56(t1);  ld t6, 56(t3);  bne t5, t6, .Lcssu_next_entry
+  j .Lcssu_store_payload
+.Lcssu_next_entry:
+  addi t2, t2, 1; j .Lcssu_scan
+.Lcssu_no_match:
+  bgeu a4, a5, .Lcssu_overflow
+  slli t3, a4, 7; add t3, a3, t3   # dst = table[count]
+  sd zero, 0(t3); sd zero, 8(t3); sd zero, 16(t3); sd zero, 24(t3)
+  li t4, 0
+.Lcssu_addr_copy:
+  li t5, 20; beq t4, t5, .Lcssu_store_payload_append
+  add t5, a0, t4; lbu t6, 0(t5); add t5, t3, t4; sb t6, 0(t5); addi t4, t4, 1; j .Lcssu_addr_copy
+.Lcssu_store_payload_append:
+  addi a4, a4, 1
+.Lcssu_store_payload:
+  ld t4, 32(t1);  sd t4, 32(t3);  ld t4, 40(t1);  sd t4, 40(t3)
+  ld t4, 48(t1);  sd t4, 48(t3);  ld t4, 56(t1);  sd t4, 56(t3)
+  ld t4, 64(t1);  sd t4, 64(t3);  ld t4, 72(t1);  sd t4, 72(t3)
+  ld t4, 80(t1);  sd t4, 80(t3);  ld t4, 88(t1);  sd t4, 88(t3)
+  ld t4, 96(t1);  sd t4, 96(t3);  ld t4, 104(t1); sd t4, 104(t3)
+  ld t4, 112(t1); sd t4, 112(t3); ld t4, 120(t1); sd t4, 120(t3)
+  addi t0, t0, 1; j .Lcssu_loop
+.Lcssu_overflow:
+  li t0, 1; sd t0, 0(a6); mv a0, a4; li a1, 1; ret
+.Lcssu_done:
+  mv a0, a4; li a1, 0; ret

--- a/scripts/asm-fixtures/execLogLatestValueFunction.s
+++ b/scripts/asm-fixtures/execLogLatestValueFunction.s
@@ -1,0 +1,27 @@
+exec_log_latest_value:
+  li t6, 0                      # found flag
+  li t0, 0                      # entry index i
+.Lelv_loop:
+  beq t0, a3, .Lelv_done
+  slli t1, t0, 7; add t2, a2, t1   # entry ptr = base + i*128
+  # match addrHash (entry@0 vs a0)
+  ld t3, 0(t2);  ld t4, 0(a0);  bne t3, t4, .Lelv_next
+  ld t3, 8(t2);  ld t4, 8(a0);  bne t3, t4, .Lelv_next
+  ld t3, 16(t2); ld t4, 16(a0); bne t3, t4, .Lelv_next
+  ld t3, 24(t2); ld t4, 24(a0); bne t3, t4, .Lelv_next
+  # match slotKey (entry@32 vs a1)
+  ld t3, 32(t2); ld t4, 0(a1);  bne t3, t4, .Lelv_next
+  ld t3, 40(t2); ld t4, 8(a1);  bne t3, t4, .Lelv_next
+  ld t3, 48(t2); ld t4, 16(a1); bne t3, t4, .Lelv_next
+  ld t3, 56(t2); ld t4, 24(a1); bne t3, t4, .Lelv_next
+  # matching entry: copy current (entry@96) -> out; set found. Overwrite keeps the LAST match.
+  ld t3, 96(t2);  sd t3, 0(a4)
+  ld t3, 104(t2); sd t3, 8(a4)
+  ld t3, 112(t2); sd t3, 16(a4)
+  ld t3, 120(t2); sd t3, 24(a4)
+  li t6, 1
+.Lelv_next:
+  addi t0, t0, 1; j .Lelv_loop
+.Lelv_done:
+  mv a0, t6
+  ret

--- a/scripts/asm-fixtures/senderPostNonceConsistentFunction.s
+++ b/scripts/asm-fixtures/senderPostNonceConsistentFunction.s
@@ -1,0 +1,16 @@
+sender_post_nonce_consistent:
+  ld t0, 128(a0)              # post nonce byte length
+  li t1, -1; beq t0, t1, .Lspnc_skip       # absent -> skip
+  li t1, 8;  bgtu t0, t1, .Lspnc_skip       # > u64 -> skip
+  addi t2, a0, 136; li t3, 0; mv t4, t0     # decode big-endian post nonce
+.Lspnc_be:
+  beqz t4, .Lspnc_de
+  slli t3, t3, 8; lbu t5, 0(t2); or t3, t3, t5; addi t2, t2, 1; addi t4, t4, -1; j .Lspnc_be
+.Lspnc_de:
+  ld t4, 80(a0); addi t4, t4, 1             # expected = pre nonce + 1
+  beq t3, t4, .Lspnc_match
+  li a0, 1; ret                             # mismatch
+.Lspnc_match:
+  li a0, 0; ret
+.Lspnc_skip:
+  li a0, 2; ret

--- a/scripts/asm-fixtures/slotDecodeU256Function.s
+++ b/scripts/asm-fixtures/slotDecodeU256Function.s
@@ -1,0 +1,38 @@
+slot_decode_u256:
+  # a0 = val_bytes ptr, a1 = val_len, a2 = 32-byte BE out ptr.
+  # Returns 0 (ok) / 1 (fail). Output is zeroed on every path.
+  sd zero,  0(a2); sd zero,  8(a2); sd zero, 16(a2); sd zero, 24(a2)
+  beqz a1, .Lsdu_fail        # empty input: malformed encoded value
+  lbu t0, 0(a0)
+  li t1, 0x80
+  bltu t0, t1, .Lsdu_single  # b0 < 0x80: single byte
+  beq t0, t1, .Lsdu_zero     # b0 == 0x80: empty string ⇒ 0
+  li t1, 0xa1
+  bgeu t0, t1, .Lsdu_fail    # b0 ≥ 0xa1: too long for a u256
+  # Short string of n bytes (1 ≤ n ≤ 32).
+  li t1, 0x80
+  sub t2, t0, t1             # n
+  addi t3, a1, -1
+  bltu t3, t2, .Lsdu_fail    # not enough bytes for declared length
+  li t4, 32
+  sub t4, t4, t2             # 32 - n
+  add t5, a2, t4             # dst (right-aligned)
+  addi t6, a0, 1             # src
+  mv t3, t2                  # remaining
+.Lsdu_copy:
+  beqz t3, .Lsdu_ok
+  lbu t1, 0(t6)
+  sb  t1, 0(t5)
+  addi t5, t5, 1
+  addi t6, t6, 1
+  addi t3, t3, -1
+  j .Lsdu_copy
+.Lsdu_single:
+  sb t0, 31(a2)              # write u256 = b0 at byte 31 (BE LSB)
+.Lsdu_zero:
+.Lsdu_ok:
+  li a0, 0
+  ret
+.Lsdu_fail:
+  li a0, 1
+  ret

--- a/scripts/asm-fixtures/slotTupleSequencesMatchFunction.s
+++ b/scripts/asm-fixtures/slotTupleSequencesMatchFunction.s
@@ -1,0 +1,18 @@
+slot_tuple_sequences_match:
+  bne a1, a3, .Lstsm_bad        # length mismatch -> reject
+  li t0, 0                      # i
+.Lstsm_loop:
+  beq t0, a1, .Lstsm_ok
+  slli t1, t0, 5; slli t2, t0, 3; add t1, t1, t2   # i*40
+  add t3, a0, t1                # BAL record i
+  add t4, a2, t1                # exec record i
+  ld t5, 0(t3);  ld t6, 0(t4);  bne t5, t6, .Lstsm_bad   # block_access_index
+  ld t5, 8(t3);  ld t6, 8(t4);  bne t5, t6, .Lstsm_bad   # value[0:8]
+  ld t5, 16(t3); ld t6, 16(t4); bne t5, t6, .Lstsm_bad   # value[8:16]
+  ld t5, 24(t3); ld t6, 24(t4); bne t5, t6, .Lstsm_bad   # value[16:24]
+  ld t5, 32(t3); ld t6, 32(t4); bne t5, t6, .Lstsm_bad   # value[24:32]
+  addi t0, t0, 1; j .Lstsm_loop
+.Lstsm_ok:
+  li a0, 0; ret
+.Lstsm_bad:
+  li a0, 1; ret

--- a/scripts/asm-fixtures/swdMinimalCopyFunction.s
+++ b/scripts/asm-fixtures/swdMinimalCopyFunction.s
@@ -1,0 +1,16 @@
+swd_minimal_copy:
+  mv t0, a0                   # src cursor
+  mv t1, a1                   # remaining
+.Lswd_skip:
+  beqz t1, .Lswd_emit         # all zero -> length 0
+  lbu t2, 0(t0); bnez t2, .Lswd_emit
+  addi t0, t0, 1; addi t1, t1, -1; j .Lswd_skip
+.Lswd_emit:
+  sd t1, 0(a3)                # out length = remaining
+  mv t3, a2; li t4, 0
+.Lswd_cp:
+  beq t4, t1, .Lswd_cpd
+  add t5, t0, t4; lbu t6, 0(t5); add t2, t3, t4; sb t6, 0(t2)
+  addi t4, t4, 1; j .Lswd_cp
+.Lswd_cpd:
+  ret

--- a/scripts/asm-fixtures/swdReadU64leFunction.s
+++ b/scripts/asm-fixtures/swdReadU64leFunction.s
@@ -1,0 +1,11 @@
+swd_read_u64le:
+  lbu t0, 0(a0)
+  lbu t1, 1(a0); slli t1, t1, 8;  or t0, t0, t1
+  lbu t1, 2(a0); slli t1, t1, 16; or t0, t0, t1
+  lbu t1, 3(a0); slli t1, t1, 24; or t0, t0, t1
+  lbu t1, 4(a0); slli t1, t1, 32; or t0, t0, t1
+  lbu t1, 5(a0); slli t1, t1, 40; or t0, t0, t1
+  lbu t1, 6(a0); slli t1, t1, 48; or t0, t0, t1
+  lbu t1, 7(a0); slli t1, t1, 56; or t0, t0, t1
+  mv a0, t0
+  ret

--- a/scripts/asm-fixtures/swdWriteBe32U64Function.s
+++ b/scripts/asm-fixtures/swdWriteBe32U64Function.s
@@ -1,0 +1,16 @@
+swd_write_be32_u64:
+  li t0, 0
+.Lswd_z:
+  li t1, 32; beq t0, t1, .Lswd_zd
+  add t2, a1, t0; sb x0, 0(t2); addi t0, t0, 1; j .Lswd_z
+.Lswd_zd:
+  # write the 8 BE bytes into offsets 24..31
+  li t0, 0
+.Lswd_b:
+  li t1, 8; beq t0, t1, .Lswd_bd
+  li t2, 56; slli t3, t0, 3; sub t2, t2, t3   # shift = 56 - 8*t0
+  srl t4, a0, t2; andi t4, t4, 0xff
+  addi t5, a1, 24; add t5, t5, t0; sb t4, 0(t5)
+  addi t0, t0, 1; j .Lswd_b
+.Lswd_bd:
+  ret

--- a/scripts/asm-fixtures/swdWriteBe8Function.s
+++ b/scripts/asm-fixtures/swdWriteBe8Function.s
@@ -1,0 +1,10 @@
+swd_write_be8:
+  li t0, 0
+.Lswd8:
+  li t1, 8; beq t0, t1, .Lswd8d
+  li t2, 56; slli t3, t0, 3; sub t2, t2, t3
+  srl t4, a0, t2; andi t4, t4, 0xff
+  add t5, a1, t0; sb t4, 0(t5)
+  addi t0, t0, 1; j .Lswd8
+.Lswd8d:
+  ret

--- a/scripts/asm-fixtures/witnessCodesValidateLengthsFunction.s
+++ b/scripts/asm-fixtures/witnessCodesValidateLengthsFunction.s
@@ -1,0 +1,52 @@
+witness_codes_validate_lengths:
+  addi sp, sp, -64
+  sd ra,  0(sp)
+  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)
+  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)
+  mv s0, a0                  # section ptr
+  mv s1, a1                  # section_len
+  mv s2, a2                  # max_byte_length
+  mv s3, a3                  # n_processed out
+  mv s4, a4                  # first_bad_index out
+  sd zero, 0(s3)
+  li t0, -1
+  sd t0, 0(s4)
+  beqz s1, .Lwcvl_ok           # empty section ⇒ vacuous-valid
+  lwu t0, 0(s0)
+  srli s5, t0, 2               # s5 = N
+  li s6, 0                     # s6 = i
+.Lwcvl_loop:
+  beq s6, s5, .Lwcvl_ok
+  # Element i bounds.
+  slli t0, s6, 2
+  add t1, s0, t0
+  lwu t2, 0(t1)                # inner_off_i
+  addi t3, s6, 1
+  beq t3, s5, .Lwcvl_use_end
+  slli t3, t3, 2
+  add t3, s0, t3
+  lwu t4, 0(t3)                # inner_off_{i+1}
+  sub t5, t4, t2               # el_i_len
+  j .Lwcvl_check
+.Lwcvl_use_end:
+  sub t5, s1, t2               # el_i_len = section_len - inner_off_i
+.Lwcvl_check:
+  bgtu t5, s2, .Lwcvl_too_long
+  addi s6, s6, 1
+  j .Lwcvl_loop
+.Lwcvl_too_long:
+  sd s6, 0(s3)                 # n_processed = i
+  sd s6, 0(s4)                 # first_bad_index = i
+  li a0, 1
+  j .Lwcvl_ret
+.Lwcvl_ok:
+  sd s5, 0(s3)                 # n_processed = N
+  li t0, -1
+  sd t0, 0(s4)
+  li a0, 0
+.Lwcvl_ret:
+  ld ra,  0(sp)
+  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)
+  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)
+  addi sp, sp, 64
+  ret


### PR DESCRIPTION
Part of bead `evm-asm-4ch8f.9.1` (asm→Program wave 1). **PR 1d of 4** (tip) — stacked on #9718 (1c). Carries the coverage-doc regen for the whole wave.

## What
Converts **17 CONVERTED-CLEAN state/storage/bal/witness leaf functions**: `State`, `SystemWrites` (×4), `CommittedStorageSnapshot` (×3), `BalGasValid` (×2), `BlockVerdictSenderCounts`, `ExecLogLatestValue`, `SenderPostNonceConsistent`, `SlotTupleSequencesMatch`, `WitnessValidation`, `Blake2f` (×2).

`storageEffectRecordsFunction` (listed CONVERTED-CLEAN) is **refused by the `MULTI-ENTRY-BUNDLE` guard** added in 1b — same hazard as `receiptRecordsFunction` (secondary `*_clear`/`_append`/`_record_nth` labels that other files `jal` into, which `emitProgram` strips).

## Coverage doc regen (whole wave)
`docs/4ch8f-asm-to-program-coverage.md` regenerated:
- **CONVERTED-CLEAN 111 → 0**; 109 landed across waves 1a–1d.
- **ALREADY-STRUCTURED 23 → 132** (16 prior + 109 + 7 template splices already counted).
- **MULTI-ENTRY-BUNDLE = 4** (new class): `receiptRecordsFunction`, `storageEffectRecordsFunction` (reclassified from CONVERTED-CLEAN), plus `blockValidateEmptyBlockFunction`, `mptIndexedTrieRootOneLeafFunction` (previously masked as BLOCKED_ON_.6 — they carry both `la`/cross-call and secondary entry labels).
- BLOCKED_ON_.6 550 → 548; COMPOSITE 139, NEEDS-LI-EXPANSION 20, CALLER-LOCAL-FRAGMENT 8 unchanged. TOTAL 851.

## Wave-1 tally
**109 of 111 CONVERTED-CLEAN landed** (1a 48 + 1b 21 + 1c 23 + 1d 17); 2 reclassified MULTI-ENTRY-BUNDLE with a permanent generator guard so they can't be silently mis-converted.

## Gates (all pass)
- `check-asm-to-program.sh` → **CLEAN** (125 defs across 55 files).
- Full `lake build` → **green** (3742 jobs).
- **Whole-guest byte-identity** vs `main`: `stateless_guest` **IDENTICAL** (360792 B), `runtime_dispatcher` **IDENTICAL** (170160 B).
- forbidden-tactics / file-size / unimported → pass.

## Notes for reviewer (Fable)
- No `native_decide`/`bv_decide`/`sorry`.
- Instruction bytes preserved; only canonical `emitProgram` normalization applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)