### PR TITLE
feat(stateless): SpecRef — Lean functional port of the stateless-guest spec (4ch8f.8 feeder)

### DIFF
--- a/EvmAsm/Stateless.lean
+++ b/EvmAsm/Stateless.lean
@@ -35,3 +35,4 @@ import EvmAsm.Stateless.Headers
 import EvmAsm.Stateless.State
 import EvmAsm.Stateless.Entry
 import EvmAsm.Stateless.EntrySpec
+import EvmAsm.Stateless.SpecRef

--- a/EvmAsm/Stateless/SpecRef.lean
+++ b/EvmAsm/Stateless/SpecRef.lean
@@ -1,0 +1,26 @@
+/-
+  EvmAsm.Stateless.SpecRef
+
+  Umbrella for the Lean functional *reference port* of the Amsterdam
+  stateless-guest spec (`execution-specs @ tests-zkevm@v0.4.0`), feeder for
+  bead `evm-asm-4ch8f.8`. This is a reference model only — no theorems about
+  the RV64 guest live here. See `docs/4ch8f-specref-port.md` for the
+  Python↔Lean mapping, the execution seam, and reuse notes.
+
+  Module map (mirrors the Python modules):
+  * `Crypto`       — full keccak256/sha256 on the ZisK accel permutations
+  * `Types`        — the `@dataclass`/`StrEnum` mirrors + `SpecError`
+  * `SszCodec`     — generic SSZ serialize / deserialize / hash_tree_root
+  * `Ssz`          — `stateless_ssz.py` containers + 34 conversions
+  * `WitnessState` — `witness_state.py` (4 module-level defs)
+  * `Stateless`    — `stateless.py` (7 defs) + the execution seam
+  * `Guest`        — `stateless_guest.py` (3 defs), the top-level shell
+-/
+
+import EvmAsm.Stateless.SpecRef.Crypto
+import EvmAsm.Stateless.SpecRef.Types
+import EvmAsm.Stateless.SpecRef.SszCodec
+import EvmAsm.Stateless.SpecRef.Ssz
+import EvmAsm.Stateless.SpecRef.WitnessState
+import EvmAsm.Stateless.SpecRef.Stateless
+import EvmAsm.Stateless.SpecRef.Guest

--- a/EvmAsm/Stateless/SpecRef/Crypto.lean
+++ b/EvmAsm/Stateless/SpecRef/Crypto.lean
@@ -1,0 +1,156 @@
+/-
+  EvmAsm.Stateless.SpecRef.Crypto
+
+  Full-message hash functions for the stateless-guest reference port,
+  built on the *concrete* ZisK accelerator permutations
+  (`EvmAsm.Rv64.Accel.keccakF`, `EvmAsm.Rv64.Accel.sha256Compress`).
+
+  The Python reference (`ethereum.crypto.hash.keccak256`,
+  `hashlib.sha256`) is the ground truth; here we wrap the permutations
+  with the standard sponge / Merkle–Damgård padding so the SpecRef port
+  has an executable, kernel-reducible `keccak256`/`sha256` over arbitrary
+  byte strings. No new cryptographic primitive is introduced — the round
+  functions are reused verbatim, so the pinned KATs in
+  `EvmAsm/Rv64/ZiskAccel.lean` (`keccakF_kat_empty`, `sha256Compress_kat_empty`)
+  transitively pin these wrappers, and the `#guard`s at the bottom check the
+  empty-string digests end-to-end.
+
+  Bytes are `List (BitVec 8)`, matching `EvmAsm.EL.RLP.Byte`.
+-/
+
+import EvmAsm.Rv64.ZiskAccel
+import EvmAsm.EL.RLP.Basic
+
+namespace EvmAsm.Stateless.SpecRef
+
+open EvmAsm.Rv64
+
+/-- A byte, matching the repo-wide `EvmAsm.EL.RLP.Byte = BitVec 8`. -/
+abbrev Byte := EvmAsm.EL.RLP.Byte
+
+/-- A byte string. -/
+abbrev Bytes := List Byte
+
+/-! ## Little/big-endian byte helpers -/
+
+/-- Interpret bytes as a little-endian natural number (first byte least
+    significant). -/
+def bytesLEtoNat : Bytes → Nat
+  | [] => 0
+  | b :: bs => b.toNat + 256 * bytesLEtoNat bs
+
+/-- The low `width` bytes of `x`, little-endian (first byte least
+    significant). -/
+def natToBytesLE (width x : Nat) : Bytes :=
+  (List.range width).map (fun i => BitVec.ofNat 8 (x >>> (8 * i)))
+
+/-- The low `width` bytes of `x`, big-endian (first byte most
+    significant). Fixed-width companion to the minimal
+    `EvmAsm.EL.RLP.Nat.toBytesBE`. -/
+def natToBytesBE (width x : Nat) : Bytes :=
+  (List.range width).reverse.map (fun i => BitVec.ofNat 8 (x >>> (8 * i)))
+
+/-- Big-endian bytes → natural number (reuses the RLP model's converter). -/
+abbrev bytesBEtoNat : Bytes → Nat := EvmAsm.EL.RLP.Nat.fromBytesBE
+
+/-- Split a byte list into chunks of `n` bytes (last chunk full only when
+    the length is a multiple of `n`, which is always the case for padded
+    hash inputs). Fuel = input length guarantees termination. -/
+def chunkBytesAux : Nat → Nat → Bytes → List Bytes
+  | 0, _, _ => []
+  | _, _, [] => []
+  | fuel + 1, n, bs => bs.take n :: chunkBytesAux fuel n (bs.drop n)
+
+/-- Split `bs` into `n`-byte chunks. -/
+def chunkBytes (n : Nat) (bs : Bytes) : List Bytes :=
+  chunkBytesAux (bs.length + 1) n bs
+
+/-! ## Keccak-256 (sponge over `Accel.keccakF`) -/
+
+/-- Keccak-256 rate in bytes (1088-bit rate, 512-bit capacity). -/
+def keccakRateBytes : Nat := 136
+
+/-- `pad10*1` with the Keccak domain byte `0x01`: append `0x01`, then
+    zeros, then set the top bit of the final rate byte (`0x80`). When only
+    one pad byte fits, the two collapse to `0x81`. -/
+def keccakPad (msg : Bytes) : Bytes :=
+  let padLen := keccakRateBytes - (msg.length % keccakRateBytes)
+  let pad :=
+    if padLen = 1 then [(0x81 : Byte)]
+    else (0x01 : Byte) :: List.replicate (padLen - 2) (0 : Byte) ++ [(0x80 : Byte)]
+  msg ++ pad
+
+/-- XOR a 136-byte rate block (as 17 little-endian u64 lanes) into the
+    25-lane state. -/
+def keccakAbsorbBlock (st : List (BitVec 64)) (block : Bytes) : List (BitVec 64) :=
+  let lanes : List (BitVec 64) :=
+    (List.range 17).map (fun i =>
+      BitVec.ofNat 64 (bytesLEtoNat ((block.drop (8 * i)).take 8)))
+  let laneVec := lanes ++ List.replicate (25 - lanes.length) (0 : BitVec 64)
+  List.zipWith (· ^^^ ·) st laneVec
+
+/-- Absorb all rate blocks, permuting after each. -/
+def keccakAbsorb : List (BitVec 64) → List Bytes → List (BitVec 64)
+  | st, [] => st
+  | st, block :: rest => keccakAbsorb (Accel.keccakF (keccakAbsorbBlock st block)) rest
+
+/-- `keccak256(msg)` — the 32-byte digest (first four state lanes, each
+    little-endian). Mirrors `ethereum.crypto.hash.keccak256`. -/
+def keccak256 (msg : Bytes) : Bytes :=
+  let st0 : List (BitVec 64) := List.replicate 25 (0 : BitVec 64)
+  let st := keccakAbsorb st0 (chunkBytes keccakRateBytes (keccakPad msg))
+  (st.take 4).flatMap (fun lane => natToBytesLE 8 lane.toNat)
+
+/-! ## SHA-256 (Merkle–Damgård over `Accel.sha256Compress`) -/
+
+/-- The SHA-256 initial hash value (eight 32-bit words). -/
+def sha256IV : List (BitVec 32) :=
+  [0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+   0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19]
+
+/-- SHA-256 padding: append `0x80`, zero-pad, then the 64-bit big-endian
+    bit length, filling to a multiple of 64 bytes. -/
+def sha256Pad (msg : Bytes) : Bytes :=
+  let l := msg.length
+  let zeros := (64 - ((l + 9) % 64)) % 64
+  msg ++ [(0x80 : Byte)] ++ List.replicate zeros (0 : Byte)
+      ++ natToBytesBE 8 (l * 8)
+
+/-- Interpret a 64-byte block as sixteen 32-bit big-endian words. -/
+def sha256BlockWords (block : Bytes) : List (BitVec 32) :=
+  (List.range 16).map (fun i =>
+    BitVec.ofNat 32 (bytesBEtoNat ((block.drop (4 * i)).take 4)))
+
+/-- Fold the compression function over all 64-byte blocks. -/
+def sha256Compress' : List (BitVec 32) → List Bytes → List (BitVec 32)
+  | hs, [] => hs
+  | hs, block :: rest =>
+      sha256Compress' (Accel.sha256Compress hs (sha256BlockWords block)) rest
+
+/-- `sha256(msg)` — the 32-byte digest. Mirrors `hashlib.sha256`. -/
+def sha256 (msg : Bytes) : Bytes :=
+  let hs := sha256Compress' sha256IV (chunkBytes 64 (sha256Pad msg))
+  hs.flatMap (fun w => natToBytesBE 4 w.toNat)
+
+/-- `sha256(a ‖ b)` — the SSZ pair hash used in merkleization. -/
+def sha256Pair (a b : Bytes) : Bytes := sha256 (a ++ b)
+
+/-! ## End-to-end known-answer checks -/
+
+-- keccak256("") = c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
+#guard bytesBEtoNat (keccak256 [])
+  = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
+
+-- sha256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+#guard bytesBEtoNat (sha256 [])
+  = 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+
+-- sha256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+#guard bytesBEtoNat (sha256 [0x61, 0x62, 0x63])
+  = 0xba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+
+-- keccak256("abc") = 4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45
+#guard bytesBEtoNat (keccak256 [0x61, 0x62, 0x63])
+  = 0x4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45
+
+end EvmAsm.Stateless.SpecRef

--- a/EvmAsm/Stateless/SpecRef/Guest.lean
+++ b/EvmAsm/Stateless/SpecRef/Guest.lean
@@ -1,0 +1,122 @@
+/-
+  EvmAsm.Stateless.SpecRef.Guest
+
+  Port of `execution-specs/src/ethereum/forks/amsterdam/stateless_guest.py`
+  (`@tests-zkevm@v0.4.0`): the top-level guest shell.
+
+  * `serialize_stateless_output`  (`stateless_guest.py:21`)
+  * `deserialize_stateless_input` (`stateless_guest.py:29`)
+  * `run_stateless_guest`         (`stateless_guest.py:47`)
+
+  `run_stateless_guest` threads the execution seam (`Stateless.lean`) so the
+  whole pipeline is `#eval`-runnable with the `executeAlwaysOk` placeholder.
+-/
+
+import EvmAsm.Stateless.SpecRef.Stateless
+
+namespace EvmAsm.Stateless.SpecRef
+
+/-! ## `serialize_stateless_output` (`stateless_guest.py:21`) -/
+
+/-- Serialize a `StatelessValidationResult` to SSZ bytes. -/
+def serialize_stateless_output (output : StatelessValidationResult) : Bytes :=
+  (validationResultToSsz output).serialize
+
+/-! ## `deserialize_stateless_input` (`stateless_guest.py:29`) -/
+
+/-- Deserialize a `StatelessInput` from schema-prefixed SSZ bytes. -/
+def deserialize_stateless_input (data : Bytes) : Except SpecError StatelessInput := do
+  if data.length < STATELESS_INPUT_SCHEMA_ID_SIZE then
+    throw .missingSchemaId
+  let schema_id := bytesBEtoNat (data.take STATELESS_INPUT_SCHEMA_ID_SIZE)
+  if schema_id ≠ STATELESS_INPUT_SCHEMA_ID then
+    throw (.unsupportedSchemaId schema_id)
+  let ssz_obj ← deserialize sszStatelessInputType (data.drop STATELESS_INPUT_SCHEMA_ID_SIZE)
+  sszToStatelessInput ssz_obj
+
+/-! ## `run_stateless_guest` (`stateless_guest.py:47`) -/
+
+/-- Run the stateless guest on serialized input, returning serialized output.
+    The execution engine is the seam parameter (default: `executeAlwaysOk`).
+    Deserialization failures propagate (Python does not catch them). -/
+def run_stateless_guest (input_bytes : Bytes)
+    (execute : ExecutionSeam := executeAlwaysOk) : Except SpecError Bytes := do
+  let stateless_input ← deserialize_stateless_input input_bytes
+  let stateless_output := verify_stateless_new_payload stateless_input execute
+  pure (serialize_stateless_output stateless_output)
+
+/-! ## Sanity checks -/
+
+private def z (n : Nat) : Bytes := List.replicate n (0 : Byte)
+
+/-- A minimal, correctly-sized `ExecutionPayload` (all fixed byte fields at
+    their declared widths so SSZ decode round-trips). -/
+def sanityPayload : ExecutionPayload :=
+  { parentHash := z 32, feeRecipient := z 20, stateRoot := z 32, receiptsRoot := z 32,
+    logsBloom := z 256, prevRandao := z 32, blockNumber := 0, gasLimit := 0, gasUsed := 0,
+    timestamp := 0, extraData := [], baseFeePerGas := 0, blockHash := z 32,
+    transactions := [], withdrawals := [], blobGasUsed := 0, excessBlobGas := 0,
+    blockAccessList := [], slotNumber := 0 }
+
+/-- A "happy path" chain config: Amsterdam, activation satisfied by a
+    zero-timestamp payload, and the expected blob schedule. -/
+def sanityHappyChainConfig : ChainConfig :=
+  { chainId := 1
+    activeFork :=
+      { fork := .Amsterdam
+        activation := { blockNumber := none, timestamp := some 0 }
+        blobSchedule := some _expected_amsterdam_blob_schedule } }
+
+/-- A single amsterdam witness header (23 RLP fields). A one-element chain is
+    vacuously contiguous, so `validate_headers` succeeds and its `state_root`
+    seeds the pre-state. -/
+def sanityHeader : Bytes := mkTestHeaderBytes 23 (z 32) (z 32)
+
+def sanityInput : StatelessInput :=
+  { newPayloadRequest :=
+      { executionPayload := sanityPayload
+        versionedHashes := []
+        parentBeaconBlockRoot := z 32
+        executionRequests := { deposits := [], withdrawals := [], consolidations := [] } }
+    witness := { state := [], codes := [], headers := [sanityHeader] }
+    chainConfig := sanityHappyChainConfig
+    publicKeys := [] }
+
+/-- Schema-prefixed SSZ encoding of `sanityInput`. -/
+def sanityInputBytes : Except SpecError Bytes := do
+  let ssz ← statelessInputToSsz sanityInput
+  pure (natToBytesBE STATELESS_INPUT_SCHEMA_ID_SIZE STATELESS_INPUT_SCHEMA_ID ++ ssz.serialize)
+
+-- End-to-end: schema-prefixed bytes deserialize back to `sanityInput`.
+#guard
+  (do
+    let bytes ← sanityInputBytes
+    deserialize_stateless_input bytes).toOption == some sanityInput
+
+-- Wrong schema id is rejected.
+#guard
+  match deserialize_stateless_input (natToBytesBE 2 0x0002 ++ z 8) with
+  | .error (.unsupportedSchemaId 2) => true | _ => false
+
+-- Input shorter than the schema id is rejected.
+#guard
+  match deserialize_stateless_input [0x00] with
+  | .error .missingSchemaId => true | _ => false
+
+-- Full pipeline: run the guest and get SSZ output bytes whose decoded
+-- successful_validation is true (placeholder seam) and whose NPR root matches.
+#guard
+  match (do
+      let bytes ← sanityInputBytes
+      run_stateless_guest bytes) with
+  | .ok out =>
+      match deserialize sszStatelessValidationResultType out with
+      | .ok sv =>
+          match sszToValidationResult sv with
+          | .ok r => r.successfulValidation
+                     && r.newPayloadRequestRoot == compute_new_payload_request_root sanityInput
+          | .error _ => false
+      | .error _ => false
+  | .error _ => false
+
+end EvmAsm.Stateless.SpecRef

--- a/EvmAsm/Stateless/SpecRef/Ssz.lean
+++ b/EvmAsm/Stateless/SpecRef/Ssz.lean
@@ -1,0 +1,449 @@
+/-
+  EvmAsm.Stateless.SpecRef.Ssz
+
+  Port of `execution-specs/src/ethereum/forks/amsterdam/stateless_ssz.py`
+  (`@tests-zkevm@v0.4.0`): the SSZ container schemas mirroring the domain
+  dataclasses, plus the 34 to/from-SSZ conversion functions.
+
+  Each Python `class SszX(Container)` becomes an `SszType` descriptor
+  (`sszXType`); each `_x_to_ssz` becomes `xToSsz : … → SszValue`; each
+  `_ssz_to_x` becomes `sszToX : SszValue → Except SpecError …`. The generic
+  `encode_bytes` / `decode_bytes` / `hash_tree_root` live in `SszCodec.lean`.
+
+  Field ORDER in every `SszType.container`/`SszValue.container` matches the
+  Python class field order exactly (SSZ is order-sensitive), so the
+  positional `getField` accessors in the `sszToX` direction line up with
+  the class attributes.
+-/
+
+import EvmAsm.Stateless.SpecRef.SszCodec
+
+namespace EvmAsm.Stateless.SpecRef
+
+/-! ## SSZ max-length constants (`stateless_ssz.py:41`–`61`) -/
+
+def MAX_EXTRA_DATA_BYTES : Nat := 32
+def MAX_BYTES_PER_TRANSACTION : Nat := 2 ^ 30
+def MAX_TRANSACTIONS_PER_PAYLOAD : Nat := 2 ^ 20
+def MAX_WITHDRAWALS_PER_PAYLOAD : Nat := 2 ^ 4
+def MAX_BLOB_COMMITMENTS_PER_BLOCK : Nat := 4096
+def MAX_DEPOSIT_REQUESTS_PER_PAYLOAD : Nat := 2 ^ 13
+def MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD : Nat := 2 ^ 4
+def MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD : Nat := 2 ^ 1
+def MAX_BLOCK_ACCESS_LIST_BYTES : Nat := 2 ^ 24
+def MAX_WITNESS_NODES : Nat := 2 ^ 20
+def MAX_WITNESS_CODES : Nat := 2 ^ 16
+def MAX_WITNESS_HEADERS : Nat := 256
+def MAX_BYTES_PER_WITNESS_NODE : Nat := 2 ^ 20
+def MAX_BYTES_PER_CODE : Nat := 2 ^ 24
+def MAX_BYTES_PER_HEADER : Nat := 2 ^ 10
+def MAX_OPTIONAL_FORK_ACTIVATION_VALUES : Nat := 1
+def MAX_BLOB_SCHEDULES_PER_FORK : Nat := 1
+def MAX_PUBLIC_KEYS : Nat := 2 ^ 20
+def PUBLIC_KEY_BYTES : Nat := 65
+
+/-- `STATELESS_INPUT_SCHEMA_ID` (`stateless_ssz.py:64`). -/
+def STATELESS_INPUT_SCHEMA_ID : Nat := 0x0001
+/-- `STATELESS_INPUT_SCHEMA_ID_SIZE` (`stateless_ssz.py:65`). -/
+def STATELESS_INPUT_SCHEMA_ID_SIZE : Nat := 2
+
+/-! ## SSZ type descriptors (mirror the `Container` classes) -/
+
+/-- `Bytes32` / `ByteVector[32]`. -/
+def bytes32Type : SszType := .byteVector 32
+/-- `uint64`. -/
+def u64Type : SszType := .uint 8
+/-- `uint256`. -/
+def u256Type : SszType := .uint 32
+
+/-- `SszWithdrawal` (`stateless_ssz.py:80`). -/
+def sszWithdrawalType : SszType :=
+  .container [u64Type, u64Type, .byteVector 20, u64Type]
+
+/-- `SszExecutionPayload` (`stateless_ssz.py:89`). -/
+def sszExecutionPayloadType : SszType :=
+  .container [bytes32Type, .byteVector 20, bytes32Type, bytes32Type,
+    .byteVector 256, bytes32Type, u64Type, u64Type, u64Type, u64Type,
+    .byteList MAX_EXTRA_DATA_BYTES, u256Type, bytes32Type,
+    .list (.byteList MAX_BYTES_PER_TRANSACTION) MAX_TRANSACTIONS_PER_PAYLOAD,
+    .list sszWithdrawalType MAX_WITHDRAWALS_PER_PAYLOAD,
+    u64Type, u64Type, .byteList MAX_BLOCK_ACCESS_LIST_BYTES, u64Type]
+
+/-- `SszDepositRequest` (`stateless_ssz.py:115`). -/
+def sszDepositRequestType : SszType :=
+  .container [.byteVector 48, bytes32Type, u64Type, .byteVector 96, u64Type]
+
+/-- `SszWithdrawalRequest` (`stateless_ssz.py:125`). -/
+def sszWithdrawalRequestType : SszType :=
+  .container [.byteVector 20, .byteVector 48, u64Type]
+
+/-- `SszConsolidationRequest` (`stateless_ssz.py:133`). -/
+def sszConsolidationRequestType : SszType :=
+  .container [.byteVector 20, .byteVector 48, .byteVector 48]
+
+/-- `SszExecutionRequests` (`stateless_ssz.py:141`). -/
+def sszExecutionRequestsType : SszType :=
+  .container [.list sszDepositRequestType MAX_DEPOSIT_REQUESTS_PER_PAYLOAD,
+    .list sszWithdrawalRequestType MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD,
+    .list sszConsolidationRequestType MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD]
+
+/-- `SszNewPayloadRequest` (`stateless_ssz.py:153`). -/
+def sszNewPayloadRequestType : SszType :=
+  .container [sszExecutionPayloadType,
+    .list bytes32Type MAX_BLOB_COMMITMENTS_PER_BLOCK,
+    bytes32Type, sszExecutionRequestsType]
+
+/-- `SszExecutionWitness` (`stateless_ssz.py:162`). -/
+def sszExecutionWitnessType : SszType :=
+  .container [.list (.byteList MAX_BYTES_PER_WITNESS_NODE) MAX_WITNESS_NODES,
+    .list (.byteList MAX_BYTES_PER_CODE) MAX_WITNESS_CODES,
+    .list (.byteList MAX_BYTES_PER_HEADER) MAX_WITNESS_HEADERS]
+
+/-- `SszOptionalForkActivationValue = List[uint64, 1]` (`stateless_ssz.py:75`). -/
+def sszOptionalForkActivationValueType : SszType :=
+  .list u64Type MAX_OPTIONAL_FORK_ACTIVATION_VALUES
+
+/-- `SszForkActivation` (`stateless_ssz.py:170`). -/
+def sszForkActivationType : SszType :=
+  .container [sszOptionalForkActivationValueType, sszOptionalForkActivationValueType]
+
+/-- `SszBlobSchedule` (`stateless_ssz.py:177`). -/
+def sszBlobScheduleType : SszType :=
+  .container [u64Type, u64Type, u64Type]
+
+/-- `SszOptionalBlobSchedule = List[SszBlobSchedule, 1]` (`stateless_ssz.py:185`). -/
+def sszOptionalBlobScheduleType : SszType :=
+  .list sszBlobScheduleType MAX_BLOB_SCHEDULES_PER_FORK
+
+/-- `SszForkConfig` (`stateless_ssz.py:190`). -/
+def sszForkConfigType : SszType :=
+  .container [u64Type, sszForkActivationType, sszOptionalBlobScheduleType]
+
+/-- `SszChainConfig` (`stateless_ssz.py:198`). -/
+def sszChainConfigType : SszType :=
+  .container [u64Type, sszForkConfigType]
+
+/-- `SszStatelessInput` (`stateless_ssz.py:205`). -/
+def sszStatelessInputType : SszType :=
+  .container [sszNewPayloadRequestType, sszExecutionWitnessType, sszChainConfigType,
+    .list (.byteVector PUBLIC_KEY_BYTES) MAX_PUBLIC_KEYS]
+
+/-- `SszStatelessValidationResult` (`stateless_ssz.py:214`). -/
+def sszStatelessValidationResultType : SszType :=
+  .container [bytes32Type, .bool, sszChainConfigType]
+
+/-! ## Accessors for the `ssz_to_*` direction -/
+
+def asContainerV : SszValue → Except SpecError (List SszValue)
+  | .container fs => .ok fs
+  | _ => .error (.sszError "expected container")
+
+def asUintV : SszValue → Except SpecError Nat
+  | .uint _ v => .ok v
+  | _ => .error (.sszError "expected uint")
+
+def asBoolV : SszValue → Except SpecError Bool
+  | .bool b => .ok b
+  | _ => .error (.sszError "expected bool")
+
+def asBytesV : SszValue → Except SpecError Bytes
+  | .byteVector d => .ok d
+  | .byteList _ d => .ok d
+  | _ => .error (.sszError "expected bytes")
+
+def asListV : SszValue → Except SpecError (List SszValue)
+  | .list _ _ es => .ok es
+  | _ => .error (.sszError "expected list")
+
+def getField (fs : List SszValue) (i : Nat) : Except SpecError SszValue :=
+  match fs[i]? with
+  | some v => .ok v
+  | none => .error (.sszError s!"missing field {i}")
+
+/-! ## `_protocol_fork_to_ssz` / `_ssz_to_protocol_fork`
+    (`stateless_ssz.py:228`, `:234`) -/
+
+def protocolForkToSsz (fork : ProtocolFork) : SszValue :=
+  .uint 8 (protocolForks.findIdx (· == fork))
+
+def sszToProtocolFork (ssz : Nat) : Except SpecError ProtocolFork :=
+  match protocolForks[ssz]? with
+  | some f => .ok f
+  | none => .error (.unknownProtocolFork ssz)
+
+/-! ## `_withdrawal_to_ssz` / `_ssz_to_withdrawal` (`:242`, `:252`) -/
+
+def withdrawalToSsz (w : Withdrawal) : SszValue :=
+  .container [.uint 8 w.index, .uint 8 w.validatorIndex,
+    .byteVector w.address, .uint 8 w.amount]
+
+def sszToWithdrawal (sv : SszValue) : Except SpecError Withdrawal := do
+  let fs ← asContainerV sv
+  let index ← asUintV (← getField fs 0)
+  let validatorIndex ← asUintV (← getField fs 1)
+  let address ← asBytesV (← getField fs 2)
+  let amount ← asUintV (← getField fs 3)
+  pure { index, validatorIndex, address, amount }
+
+/-! ## `_payload_to_ssz` / `_ssz_to_payload` (`:262`, `:299`) -/
+
+def payloadToSsz (p : ExecutionPayload) : SszValue :=
+  .container [.byteVector p.parentHash, .byteVector p.feeRecipient,
+    .byteVector p.stateRoot, .byteVector p.receiptsRoot, .byteVector p.logsBloom,
+    .byteVector p.prevRandao, .uint 8 p.blockNumber, .uint 8 p.gasLimit,
+    .uint 8 p.gasUsed, .uint 8 p.timestamp,
+    .byteList MAX_EXTRA_DATA_BYTES p.extraData, .uint 32 p.baseFeePerGas,
+    .byteVector p.blockHash,
+    .list MAX_TRANSACTIONS_PER_PAYLOAD none
+      (p.transactions.map (fun t => .byteList MAX_BYTES_PER_TRANSACTION t)),
+    .list MAX_WITHDRAWALS_PER_PAYLOAD none (p.withdrawals.map withdrawalToSsz),
+    .uint 8 p.blobGasUsed, .uint 8 p.excessBlobGas,
+    .byteList MAX_BLOCK_ACCESS_LIST_BYTES p.blockAccessList, .uint 8 p.slotNumber]
+
+def sszToPayload (sv : SszValue) : Except SpecError ExecutionPayload := do
+  let fs ← asContainerV sv
+  let parentHash ← asBytesV (← getField fs 0)
+  let feeRecipient ← asBytesV (← getField fs 1)
+  let stateRoot ← asBytesV (← getField fs 2)
+  let receiptsRoot ← asBytesV (← getField fs 3)
+  let logsBloom ← asBytesV (← getField fs 4)
+  let prevRandao ← asBytesV (← getField fs 5)
+  let blockNumber ← asUintV (← getField fs 6)
+  let gasLimit ← asUintV (← getField fs 7)
+  let gasUsed ← asUintV (← getField fs 8)
+  let timestamp ← asUintV (← getField fs 9)
+  let extraData ← asBytesV (← getField fs 10)
+  let baseFeePerGas ← asUintV (← getField fs 11)
+  let blockHash ← asBytesV (← getField fs 12)
+  let transactions ← (← asListV (← getField fs 13)).mapM asBytesV
+  let withdrawals ← (← asListV (← getField fs 14)).mapM sszToWithdrawal
+  let blobGasUsed ← asUintV (← getField fs 15)
+  let excessBlobGas ← asUintV (← getField fs 16)
+  let blockAccessList ← asBytesV (← getField fs 17)
+  let slotNumber ← asUintV (← getField fs 18)
+  let payload : ExecutionPayload :=
+    { parentHash, feeRecipient, stateRoot, receiptsRoot, logsBloom, prevRandao,
+      blockNumber, gasLimit, gasUsed, timestamp, extraData, baseFeePerGas, blockHash,
+      transactions, withdrawals, blobGasUsed, excessBlobGas, blockAccessList, slotNumber }
+  pure payload
+
+/-! ## Request conversions (`:326`, `:337`, `:348`, `:359`, `:370`, `:381`) -/
+
+def depositRequestToSsz (d : DepositRequest) : SszValue :=
+  .container [.byteVector d.pubkey, .byteVector d.withdrawalCredentials,
+    .uint 8 d.amount, .byteVector d.signature, .uint 8 d.index]
+
+def sszToDepositRequest (sv : SszValue) : Except SpecError DepositRequest := do
+  let fs ← asContainerV sv
+  let pubkey ← asBytesV (← getField fs 0)
+  let withdrawalCredentials ← asBytesV (← getField fs 1)
+  let amount ← asUintV (← getField fs 2)
+  let signature ← asBytesV (← getField fs 3)
+  let index ← asUintV (← getField fs 4)
+  pure { pubkey, withdrawalCredentials, amount, signature, index }
+
+def withdrawalRequestToSsz (w : WithdrawalRequest) : SszValue :=
+  .container [.byteVector w.sourceAddress, .byteVector w.validatorPubkey, .uint 8 w.amount]
+
+def sszToWithdrawalRequest (sv : SszValue) : Except SpecError WithdrawalRequest := do
+  let fs ← asContainerV sv
+  let sourceAddress ← asBytesV (← getField fs 0)
+  let validatorPubkey ← asBytesV (← getField fs 1)
+  let amount ← asUintV (← getField fs 2)
+  pure { sourceAddress, validatorPubkey, amount }
+
+def consolidationRequestToSsz (c : ConsolidationRequest) : SszValue :=
+  .container [.byteVector c.sourceAddress, .byteVector c.sourcePubkey, .byteVector c.targetPubkey]
+
+def sszToConsolidationRequest (sv : SszValue) : Except SpecError ConsolidationRequest := do
+  let fs ← asContainerV sv
+  let sourceAddress ← asBytesV (← getField fs 0)
+  let sourcePubkey ← asBytesV (← getField fs 1)
+  let targetPubkey ← asBytesV (← getField fs 2)
+  pure { sourceAddress, sourcePubkey, targetPubkey }
+
+/-! ## `_execution_requests_to_ssz` / `_ssz_to_execution_requests` (`:392`, `:409`) -/
+
+def executionRequestsToSsz (er : ExecutionRequests) : SszValue :=
+  .container [
+    .list MAX_DEPOSIT_REQUESTS_PER_PAYLOAD none (er.deposits.map depositRequestToSsz),
+    .list MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD none (er.withdrawals.map withdrawalRequestToSsz),
+    .list MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD none
+      (er.consolidations.map consolidationRequestToSsz)]
+
+def sszToExecutionRequests (sv : SszValue) : Except SpecError ExecutionRequests := do
+  let fs ← asContainerV sv
+  let deposits ← (← asListV (← getField fs 0)).mapM sszToDepositRequest
+  let withdrawals ← (← asListV (← getField fs 1)).mapM sszToWithdrawalRequest
+  let consolidations ← (← asListV (← getField fs 2)).mapM sszToConsolidationRequest
+  pure { deposits, withdrawals, consolidations }
+
+/-! ## `_new_payload_request_to_ssz` / `_ssz_to_new_payload_request` (`:424`, `:438`) -/
+
+def newPayloadRequestToSsz (npr : NewPayloadRequest) : SszValue :=
+  .container [payloadToSsz npr.executionPayload,
+    .list MAX_BLOB_COMMITMENTS_PER_BLOCK none
+      (npr.versionedHashes.map (fun vh => .byteVector vh)),
+    .byteVector npr.parentBeaconBlockRoot,
+    executionRequestsToSsz npr.executionRequests]
+
+def sszToNewPayloadRequest (sv : SszValue) : Except SpecError NewPayloadRequest := do
+  let fs ← asContainerV sv
+  let executionPayload ← sszToPayload (← getField fs 0)
+  let versionedHashes ← (← asListV (← getField fs 1)).mapM asBytesV
+  let parentBeaconBlockRoot ← asBytesV (← getField fs 2)
+  let executionRequests ← sszToExecutionRequests (← getField fs 3)
+  pure { executionPayload, versionedHashes, parentBeaconBlockRoot, executionRequests }
+
+/-! ## `_witness_to_ssz` / `_ssz_to_witness` (`:452`, `:469`) -/
+
+def witnessToSsz (w : ExecutionWitness) : SszValue :=
+  .container [
+    .list MAX_WITNESS_NODES none (w.state.map (fun s => .byteList MAX_BYTES_PER_WITNESS_NODE s)),
+    .list MAX_WITNESS_CODES none (w.codes.map (fun c => .byteList MAX_BYTES_PER_CODE c)),
+    .list MAX_WITNESS_HEADERS none (w.headers.map (fun h => .byteList MAX_BYTES_PER_HEADER h))]
+
+def sszToWitness (sv : SszValue) : Except SpecError ExecutionWitness := do
+  let fs ← asContainerV sv
+  let state ← (← asListV (← getField fs 0)).mapM asBytesV
+  let codes ← (← asListV (← getField fs 1)).mapM asBytesV
+  let headers ← (← asListV (← getField fs 2)).mapM asBytesV
+  pure { state, codes, headers }
+
+/-! ## `_optional_u64_to_ssz` / `_ssz_to_optional_u64` (`:480`, `:489`) -/
+
+def optionalU64ToSsz (value : Option U64) : SszValue :=
+  match value with
+  | none => .list MAX_OPTIONAL_FORK_ACTIVATION_VALUES (some 8) []
+  | some v => .list MAX_OPTIONAL_FORK_ACTIVATION_VALUES (some 8) [.uint 8 v]
+
+def sszToOptionalU64 (sv : SszValue) : Except SpecError (Option U64) := do
+  let es ← asListV sv
+  match es with
+  | [] => pure none
+  | v :: _ => pure (some (← asUintV v))
+
+/-! ## `_fork_activation_to_ssz` / `_ssz_to_fork_activation` (`:498`, `:508`) -/
+
+def forkActivationToSsz (a : ForkActivation) : SszValue :=
+  .container [optionalU64ToSsz a.blockNumber, optionalU64ToSsz a.timestamp]
+
+def sszToForkActivation (sv : SszValue) : Except SpecError ForkActivation := do
+  let fs ← asContainerV sv
+  let blockNumber ← sszToOptionalU64 (← getField fs 0)
+  let timestamp ← sszToOptionalU64 (← getField fs 1)
+  pure { blockNumber, timestamp }
+
+/-! ## `_blob_schedule_to_ssz` / `_ssz_to_blob_schedule` (`:518`, `:531`) -/
+
+def blobScheduleToSsz (b : BlobSchedule) : SszValue :=
+  .container [.uint 8 b.target, .uint 8 b.max, .uint 8 b.baseFeeUpdateFraction]
+
+def sszToBlobSchedule (sv : SszValue) : Except SpecError BlobSchedule := do
+  let fs ← asContainerV sv
+  let target ← asUintV (← getField fs 0)
+  let max ← asUintV (← getField fs 1)
+  let baseFeeUpdateFraction ← asUintV (← getField fs 2)
+  pure { target, max, baseFeeUpdateFraction }
+
+/-! ## `_optional_blob_schedule_to_ssz` / `_ssz_to_optional_blob_schedule`
+    (`:544`, `:553`) -/
+
+def optionalBlobScheduleToSsz (b : Option BlobSchedule) : SszValue :=
+  match b with
+  | none => .list MAX_BLOB_SCHEDULES_PER_FORK none []
+  | some bs => .list MAX_BLOB_SCHEDULES_PER_FORK none [blobScheduleToSsz bs]
+
+def sszToOptionalBlobSchedule (sv : SszValue) : Except SpecError (Option BlobSchedule) := do
+  let es ← asListV sv
+  match es with
+  | [] => pure none
+  | v :: _ => pure (some (← sszToBlobSchedule v))
+
+/-! ## `_fork_config_to_ssz` / `_ssz_to_fork_config` (`:562`, `:575`) -/
+
+def forkConfigToSsz (fc : ForkConfig) : SszValue :=
+  .container [protocolForkToSsz fc.fork, forkActivationToSsz fc.activation,
+    optionalBlobScheduleToSsz fc.blobSchedule]
+
+def sszToForkConfig (sv : SszValue) : Except SpecError ForkConfig := do
+  let fs ← asContainerV sv
+  let fork ← sszToProtocolFork (← asUintV (← getField fs 0))
+  let activation ← sszToForkActivation (← getField fs 1)
+  let blobSchedule ← sszToOptionalBlobSchedule (← getField fs 2)
+  pure { fork, activation, blobSchedule }
+
+/-! ## `_chain_config_to_ssz` / `_ssz_to_chain_config` (`:588`, `:598`) -/
+
+def chainConfigToSsz (cc : ChainConfig) : SszValue :=
+  .container [.uint 8 cc.chainId, forkConfigToSsz cc.activeFork]
+
+def sszToChainConfig (sv : SszValue) : Except SpecError ChainConfig := do
+  let fs ← asContainerV sv
+  let chainId ← asUintV (← getField fs 0)
+  let activeFork ← sszToForkConfig (← getField fs 1)
+  pure { chainId, activeFork }
+
+/-! ## `stateless_input_to_ssz` / `ssz_to_stateless_input` (`:608`, `:630`) -/
+
+def statelessInputToSsz (si : StatelessInput) : Except SpecError SszValue := do
+  for pk in si.publicKeys do
+    if pk.length ≠ PUBLIC_KEY_BYTES then
+      throw (.publicKeyWrongLength pk.length)
+  pure (.container [newPayloadRequestToSsz si.newPayloadRequest,
+    witnessToSsz si.witness, chainConfigToSsz si.chainConfig,
+    .list MAX_PUBLIC_KEYS none (si.publicKeys.map (fun pk => .byteVector pk))])
+
+def sszToStatelessInput (sv : SszValue) : Except SpecError StatelessInput := do
+  let fs ← asContainerV sv
+  let newPayloadRequest ← sszToNewPayloadRequest (← getField fs 0)
+  let witness ← sszToWitness (← getField fs 1)
+  let chainConfig ← sszToChainConfig (← getField fs 2)
+  let publicKeys ← (← asListV (← getField fs 3)).mapM asBytesV
+  pure { newPayloadRequest, witness, chainConfig, publicKeys }
+
+/-! ## `validation_result_to_ssz` / `ssz_to_validation_result` (`:644`, `:655`) -/
+
+def validationResultToSsz (vr : StatelessValidationResult) : SszValue :=
+  .container [.byteVector vr.newPayloadRequestRoot, .bool vr.successfulValidation,
+    chainConfigToSsz vr.chainConfig]
+
+def sszToValidationResult (sv : SszValue) : Except SpecError StatelessValidationResult := do
+  let fs ← asContainerV sv
+  let newPayloadRequestRoot ← asBytesV (← getField fs 0)
+  let successfulValidation ← asBoolV (← getField fs 1)
+  let chainConfig ← sszToChainConfig (← getField fs 2)
+  pure { newPayloadRequestRoot, successfulValidation, chainConfig }
+
+/-! ## Sanity: SSZ container round-trips (serialize → deserialize → domain) -/
+
+/-- A `ChainConfig` exercising an empty and a present optional (`none`
+    block_number, `some` timestamp) and a present blob schedule. -/
+def sanityChainConfig : ChainConfig :=
+  { chainId := 1
+    activeFork :=
+      { fork := .Amsterdam
+        activation := { blockNumber := none, timestamp := some 100 }
+        blobSchedule := some { target := 14, max := 21, baseFeeUpdateFraction := 11684671 } } }
+
+-- Round-trip a `ChainConfig` through SSZ bytes and back.
+#guard
+  (do
+    let bytes := (chainConfigToSsz sanityChainConfig).serialize
+    let sv ← deserialize sszChainConfigType bytes
+    sszToChainConfig sv).toOption == some sanityChainConfig
+
+/-- A `StatelessValidationResult` (fixed + bool + nested container). -/
+def sanityResult : StatelessValidationResult :=
+  { newPayloadRequestRoot := List.replicate 32 (0x11 : Byte)
+    successfulValidation := true
+    chainConfig := sanityChainConfig }
+
+-- Round-trip a `StatelessValidationResult`.
+#guard
+  (do
+    let bytes := (validationResultToSsz sanityResult).serialize
+    let sv ← deserialize sszStatelessValidationResultType bytes
+    sszToValidationResult sv).toOption == some sanityResult
+
+end EvmAsm.Stateless.SpecRef

--- a/EvmAsm/Stateless/SpecRef/SszCodec.lean
+++ b/EvmAsm/Stateless/SpecRef/SszCodec.lean
@@ -1,0 +1,320 @@
+/-
+  EvmAsm.Stateless.SpecRef.SszCodec
+
+  A generic, executable SSZ engine for the stateless-guest reference port:
+  a value model (`SszValue`), a type descriptor for type-directed decoding
+  (`SszType`), and the three operations the Python shell depends on:
+
+  * `serialize`      — `remerkleable`'s `.encode_bytes()`
+  * `deserialize`    — `remerkleable`'s `.decode_bytes(ty, …)`
+  * `hashTreeRoot`   — `remerkleable`'s `.hash_tree_root()`
+
+  Nothing pure-Lean for this existed in the repo (only SAsm emitters and
+  doc-only contracts under `EvmAsm/Stateless/SSZ/`), so this is a fresh
+  port of the SSZ spec
+  (https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md),
+  built on the sha256 in `Crypto.lean`.
+
+  Recursion over the (finite, shallow) SSZ schema uses the repo's explicit
+  fuel convention (cf. `powModAux` in `EvmAsm/Rv64/ZiskAccel.lean`): the
+  fuel bounds *type-nesting depth* (not element count), so a small constant
+  budget is always sufficient and the definitions stay kernel-reducible.
+-/
+
+import EvmAsm.Stateless.SpecRef.Types
+
+namespace EvmAsm.Stateless.SpecRef
+
+/-- Depth budget for SSZ recursion. The deepest schema
+    (`SszStatelessInput`) nests ~7 levels; 64 is comfortably safe. -/
+def sszFuel : Nat := 64
+
+/-- SSZ length-offset width (`BYTES_PER_LENGTH_OFFSET`). -/
+def sszOffsetSize : Nat := 4
+
+/-! ## Value and type models -/
+
+/-- An SSZ value. `byteVector` carries its bytes (its length is implicit);
+    `list` carries `elemBasicSize = some sz` when its elements are a basic
+    type (packed during merkleization) or `none` for composite elements
+    (one Merkle root per element). -/
+inductive SszValue where
+  | uint (width : Nat) (val : Nat)
+  | bool (b : Bool)
+  | byteVector (data : Bytes)
+  | byteList (limit : Nat) (data : Bytes)
+  | container (fields : List SszValue)
+  | list (limit : Nat) (elemBasicSize : Option Nat) (elems : List SszValue)
+  deriving Repr, Inhabited
+
+/-- An SSZ type descriptor, used to drive `deserialize`. -/
+inductive SszType where
+  | uint (width : Nat)
+  | bool
+  | byteVector (len : Nat)
+  | byteList (limit : Nat)
+  | container (fields : List SszType)
+  | list (elem : SszType) (limit : Nat)
+  deriving Repr, Inhabited
+
+/-! ## Structural predicates on types -/
+
+/-- Whether an SSZ type is variable-size. Fuel bounds type-nesting depth. -/
+def SszType.isVariableAux : Nat → SszType → Bool
+  | 0, _ => false
+  | _ + 1, .uint _ => false
+  | _ + 1, .bool => false
+  | _ + 1, .byteVector _ => false
+  | _ + 1, .byteList _ => true
+  | _ + 1, .list _ _ => true
+  | f + 1, .container fields => fields.any (fun t => SszType.isVariableAux f t)
+
+def SszType.isVariable (t : SszType) : Bool := SszType.isVariableAux sszFuel t
+
+/-- Fixed byte size of a fixed-size SSZ type (meaningless for variable
+    types, where the offset slot size `sszOffsetSize` is used instead). -/
+def SszType.fixedSizeAux : Nat → SszType → Nat
+  | 0, _ => 0
+  | _ + 1, .uint w => w
+  | _ + 1, .bool => 1
+  | _ + 1, .byteVector n => n
+  | _ + 1, .byteList _ => 0
+  | _ + 1, .list _ _ => 0
+  | f + 1, .container fields =>
+      (fields.map (fun t =>
+        if SszType.isVariableAux f t then sszOffsetSize
+        else SszType.fixedSizeAux f t)).foldl (· + ·) 0
+
+def SszType.fixedSize (t : SszType) : Nat := SszType.fixedSizeAux sszFuel t
+
+/-- The basic-type element size, if `t` is a basic type (`uint`/`bool`). -/
+def SszType.basicSize? : SszType → Option Nat
+  | .uint w => some w
+  | .bool => some 1
+  | _ => none
+
+/-! ## Serialization (`encode_bytes`) -/
+
+/-- Whether a value is variable-size (for offset layout). -/
+def SszValue.isVariableAux : Nat → SszValue → Bool
+  | 0, _ => false
+  | _ + 1, .uint _ _ => false
+  | _ + 1, .bool _ => false
+  | _ + 1, .byteVector _ => false
+  | _ + 1, .byteList _ _ => true
+  | _ + 1, .list _ _ _ => true
+  | f + 1, .container fields => fields.any (fun v => SszValue.isVariableAux f v)
+
+def SszValue.isVariable (v : SszValue) : Bool := SszValue.isVariableAux sszFuel v
+
+/-- Serialize a value. Fuel bounds nesting depth. -/
+def SszValue.serializeAux : Nat → SszValue → Bytes
+  | 0, _ => []
+  | _ + 1, .uint width val => natToBytesLE width val
+  | _ + 1, .bool b => [if b then (1 : Byte) else 0]
+  | _ + 1, .byteVector data => data
+  | _ + 1, .byteList _ data => data
+  | f + 1, .container fields => serializeSeq f fields
+  | f + 1, .list _ _ elems => serializeSeq f elems
+where
+  /-- Serialize a heterogeneous element sequence with the SSZ fixed part
+      (values + 4-byte offsets) followed by the concatenated variable
+      parts. -/
+  serializeSeq (f : Nat) (elems : List SszValue) : Bytes :=
+    let parts : List (Bool × Bytes) :=
+      elems.map (fun e => (SszValue.isVariable e, SszValue.serializeAux f e))
+    let fixedLen :=
+      (parts.map (fun p => if p.1 then sszOffsetSize else p.2.length)).foldl (· + ·) 0
+    let fixedRegion : Bytes :=
+      (parts.foldl (fun (acc : Bytes × Nat) p =>
+        if p.1 then (acc.1 ++ natToBytesLE sszOffsetSize acc.2, acc.2 + p.2.length)
+        else (acc.1 ++ p.2, acc.2)) ([], fixedLen)).1
+    let varRegion : Bytes :=
+      (parts.filterMap (fun p => if p.1 then some p.2 else none)).flatten
+    fixedRegion ++ varRegion
+
+def SszValue.serialize (v : SszValue) : Bytes := SszValue.serializeAux sszFuel v
+
+/-! ## Deserialization (`decode_bytes`) -/
+
+/-- `data[start .. stop)` (clamped). -/
+def sliceBytes (data : Bytes) (start stop : Nat) : Bytes :=
+  (data.drop start).take (stop - start)
+
+/-- Read a little-endian offset (`sszOffsetSize` bytes) at `pos`. -/
+def readOffset (data : Bytes) (pos : Nat) : Nat :=
+  bytesLEtoNat ((data.drop pos).take sszOffsetSize)
+
+/-- Ceil-div by 32 (chunk count for `len` bytes). -/
+def chunkCount (len : Nat) : Nat := (len + 31) / 32
+
+/-- One field parsed from a container's fixed region: either its raw
+    fixed bytes (`Sum.inl`) or its variable-part offset (`Sum.inr`). -/
+abbrev Head := SszType × (Bytes ⊕ Nat)
+
+/-- Walk the fixed region collecting per-field fixed bytes or offsets. -/
+def collectHeads (data : Bytes) : List SszType → Nat → List Head
+  | [], _ => []
+  | t :: rest, cur =>
+    if t.isVariable then
+      (t, Sum.inr (readOffset data cur)) :: collectHeads data rest (cur + sszOffsetSize)
+    else
+      let sz := t.fixedSize
+      (t, Sum.inl (sliceBytes data cur (cur + sz))) :: collectHeads data rest (cur + sz)
+
+/-- Assign each head its byte slice; variable heads span from their offset
+    to the next variable offset (or end of `data`). -/
+def headsToSegments (data : Bytes) : List Head → List Nat → List (SszType × Bytes)
+  | [], _ => []
+  | (t, Sum.inl b) :: rest, stops => (t, b) :: headsToSegments data rest stops
+  | (t, Sum.inr off) :: rest, stop :: stops =>
+      (t, sliceBytes data off stop) :: headsToSegments data rest stops
+  | (t, Sum.inr off) :: rest, [] =>
+      (t, sliceBytes data off data.length) :: headsToSegments data rest []
+
+/-- Deserialize a value of type `t` from exactly `data`. Fuel bounds
+    type-nesting depth. -/
+def deserializeAux : Nat → SszType → Bytes → Except SpecError SszValue
+  | 0, _, _ => .error (.sszError "ssz decode fuel exhausted")
+  | f + 1, t, data =>
+    match t with
+    | .uint w =>
+        if data.length = w then .ok (.uint w (bytesLEtoNat data))
+        else .error (.sszError s!"uint{w} wrong length {data.length}")
+    | .bool =>
+        match data with
+        | [b] =>
+            if b.toNat ≤ 1 then .ok (.bool (b.toNat = 1))
+            else .error (.sszError "boolean out of range")
+        | _ => .error (.sszError "boolean wrong length")
+    | .byteVector n =>
+        if data.length = n then .ok (.byteVector data)
+        else .error (.sszError s!"byte vector wrong length {data.length} ≠ {n}")
+    | .byteList lim =>
+        if data.length ≤ lim then .ok (.byteList lim data)
+        else .error (.sszError "byte list over limit")
+    | .container fields =>
+        let heads := collectHeads data fields 0
+        let varOffsets := heads.filterMap (fun h =>
+          match h.2 with | Sum.inr o => some o | _ => none)
+        let stops := varOffsets.drop 1 ++ [data.length]
+        let segs := headsToSegments data heads stops
+        (segs.mapM (fun s => deserializeAux f s.1 s.2)).map SszValue.container
+    | .list elem lim =>
+        if elem.isVariable then
+          match data with
+          | [] => .ok (.list lim elem.basicSize? [])
+          | _ =>
+              let firstOff := readOffset data 0
+              let count := firstOff / sszOffsetSize
+              let offsets := (List.range count).map (fun i => readOffset data (i * sszOffsetSize))
+              let stops := offsets.drop 1 ++ [data.length]
+              let segs := (offsets.zip stops).map (fun p => sliceBytes data p.1 p.2)
+              (segs.mapM (fun b => deserializeAux f elem b)).map
+                (fun vs => .list lim elem.basicSize? vs)
+        else
+          let sz := elem.fixedSize
+          if sz = 0 then .error (.sszError "zero-size list element")
+          else
+            let count := data.length / sz
+            let segs := (List.range count).map (fun i => sliceBytes data (i * sz) (i * sz + sz))
+            (segs.mapM (fun b => deserializeAux f elem b)).map
+              (fun vs => .list lim elem.basicSize? vs)
+
+def deserialize (t : SszType) (data : Bytes) : Except SpecError SszValue :=
+  deserializeAux sszFuel t data
+
+/-! ## Merkleization (`hash_tree_root`) -/
+
+/-- The all-zero 32-byte chunk (`Z_0`). -/
+def zeroChunk : Bytes := List.replicate 32 (0 : Byte)
+
+/-- Pack bytes into right-zero-padded 32-byte chunks. -/
+def packBytesAux : Nat → Bytes → List Bytes
+  | 0, _ => []
+  | _, [] => []
+  | fuel + 1, data =>
+      let chunk := data.take 32
+      (chunk ++ List.replicate (32 - chunk.length) (0 : Byte)) :: packBytesAux fuel (data.drop 32)
+
+def packBytes (data : Bytes) : List Bytes := packBytesAux (data.length + 1) data
+
+/-- SSZ zero hash at depth `d`: `Z_0 = 0…0`, `Z_{i+1} = sha256(Z_i ‖ Z_i)`.
+    Lets merkleization skip all-zero padding subtrees in `O(depth)` instead
+    of materializing `2^depth` leaves (essential — real SSZ capacities reach
+    `2^24`). -/
+def zeroHash : Nat → Bytes
+  | 0 => zeroChunk
+  | d + 1 => let z := zeroHash d; sha256Pair z z
+
+/-- Ceil log2: smallest `d` with `2^d ≥ n` (with `ceilLog2 0 = 0`). -/
+def ceilLog2Aux : Nat → Nat → Nat → Nat
+  | 0, _, d => d
+  | f + 1, n, d => if 2 ^ d ≥ n then d else ceilLog2Aux f n (d + 1)
+
+def ceilLog2 (n : Nat) : Nat := ceilLog2Aux 64 (max n 1) 0
+
+/-- Pair-hash adjacent chunks once (halving a power-of-two-length list). -/
+def pairReduce : List Bytes → List Bytes
+  | [] => []
+  | [a] => [a]
+  | a :: b :: rest => sha256Pair a b :: pairReduce rest
+
+/-- Reduce a power-of-two leaf list to its Merkle root. -/
+def merkleizeReduce : Nat → List Bytes → Bytes
+  | 0, leaves => leaves.headD zeroChunk
+  | _, [] => zeroChunk
+  | _, [x] => x
+  | f + 1, leaves => merkleizeReduce f (pairReduce leaves)
+
+/-- Lift `partial` (root of a populated subtree at `cur` depth) up to
+    `target` depth by pair-hashing with the zero-subtree root at each level
+    (the right sibling above the populated region is all zeros = `Z_d`). -/
+def liftToDepth : Nat → Bytes → Nat → Nat → Bytes
+  | 0, part, _, _ => part
+  | f + 1, part, cur, target =>
+      if cur ≥ target then part
+      else liftToDepth f (sha256Pair part (zeroHash cur)) (cur + 1) target
+
+/-- SSZ `merkleize(chunks, limit)`: the root of a depth-`ceil(log2 limit)`
+    perfect tree whose first `chunks.length` leaves are `chunks` and the rest
+    are zero. Only the populated part is materialized; the zero upper region
+    is folded in via `zeroHash` (`O(n + log limit)`). -/
+def merkleize (chunks : List Bytes) (limitChunks : Nat) : Bytes :=
+  let target := max (ceilLog2 limitChunks) (ceilLog2 chunks.length)
+  match chunks with
+  | [] => zeroHash target
+  | _ =>
+      let pd := ceilLog2 chunks.length
+      let padded := chunks ++ List.replicate (2 ^ pd - chunks.length) zeroChunk
+      let part := merkleizeReduce (2 ^ pd + 1) padded
+      liftToDepth (target + 1) part pd target
+
+/-- SSZ `mix_in_length(root, length)`. -/
+def mixInLength (root : Bytes) (length : Nat) : Bytes :=
+  sha256Pair root (natToBytesLE 32 length)
+
+/-- `hash_tree_root(value)`. Fuel bounds nesting depth. -/
+def SszValue.hashTreeRootAux : Nat → SszValue → Bytes
+  | 0, _ => zeroChunk
+  | _ + 1, .uint _ val => natToBytesLE 32 val
+  | _ + 1, .bool b => (if b then (1 : Byte) else 0) :: List.replicate 31 (0 : Byte)
+  | _ + 1, .byteVector data => merkleize (packBytes data) (chunkCount data.length)
+  | _ + 1, .byteList lim data =>
+      mixInLength (merkleize (packBytes data) (chunkCount lim)) data.length
+  | f + 1, .container fields =>
+      merkleize (fields.map (fun v => SszValue.hashTreeRootAux f v)) fields.length
+  | f + 1, .list lim elemBasicSize elems =>
+      match elemBasicSize with
+      | some sz =>
+          -- basic-element list: pack serialized elements, mix in the count
+          let packed := packBytes (elems.flatMap SszValue.serialize)
+          mixInLength (merkleize packed (chunkCount (lim * sz))) elems.length
+      | none =>
+          -- composite-element list: one root per element, mix in the count
+          mixInLength (merkleize (elems.map (fun v => SszValue.hashTreeRootAux f v)) lim)
+            elems.length
+
+def SszValue.hashTreeRoot (v : SszValue) : Bytes := SszValue.hashTreeRootAux sszFuel v
+
+end EvmAsm.Stateless.SpecRef

--- a/EvmAsm/Stateless/SpecRef/Stateless.lean
+++ b/EvmAsm/Stateless/SpecRef/Stateless.lean
@@ -1,0 +1,263 @@
+/-
+  EvmAsm.Stateless.SpecRef.Stateless
+
+  Port of `execution-specs/src/ethereum/forks/amsterdam/stateless.py`
+  (`@tests-zkevm@v0.4.0`): the seven functions of the stateless validation
+  shell.
+
+  * `compute_new_payload_request_root` (`stateless.py:231`)
+  * `_decode_header`                   (`stateless.py:246`)
+  * `validate_headers`                 (`stateless.py:257`)
+  * `_is_activation_active`            (`stateless.py:280`)
+  * `_expected_amsterdam_blob_schedule`(`stateless.py:305`)
+  * `validate_chain_config`            (`stateless.py:316`)
+  * `verify_stateless_new_payload`     (`stateless.py:344`)
+
+  ## The execution seam
+
+  `verify_stateless_new_payload` calls `execute_new_payload_request`
+  (`stateless.py:378`) — full statefull block re-execution
+  (`execution_engine.new_payload`). That is NOT ported here (it is the
+  whole EVM). We cut at exactly that call: everything on the
+  validation/deserialization/hashing side is real; the execution engine is
+  an explicit parameter `execute : ExecutionSeam` taking the precise inputs
+  the Python call passes (`NewPayloadRequest`, the witness-backed pre-state,
+  the `ChainContext`, and the transaction public keys) and returning
+  `Except SpecError Unit` (`ok` ≙ Python returning normally, `error` ≙ any
+  raised exception). Bead `evm-asm-4ch8f.8` decides how this seam is
+  instantiated against the RV64 guest. `executeAlwaysOk` is a placeholder
+  so the shell is `#eval`-runnable end-to-end.
+-/
+
+import EvmAsm.Stateless.SpecRef.Ssz
+import EvmAsm.Stateless.SpecRef.WitnessState
+
+namespace EvmAsm.Stateless.SpecRef
+
+open EvmAsm.EL.RLP (RLPItem decodeFully)
+
+/-! ## `compute_new_payload_request_root` (`stateless.py:231`) -/
+
+/-- Compute the request root for a stateless input via SSZ hash tree root. -/
+def compute_new_payload_request_root (si : StatelessInput) : Hash32 :=
+  (newPayloadRequestToSsz si.newPayloadRequest).hashTreeRoot
+
+/-! ## `_decode_header` (`stateless.py:246`)
+
+`rlp.decode_to(Header, …)` is type-directed; we decode to a generic RLP
+list and discriminate the current fork (amsterdam, 23 fields) from the
+previous fork (bpo5, 21 fields) by RLP list length. See
+docs/4ch8f-specref-port.md for the one modeling simplification here (we do
+not re-impose `rlp.decode_to`'s per-field byte-length checks; the field
+count is the fork discriminant). -/
+
+private def rlpBytes? : RLPItem → Option Bytes
+  | .bytes b => some b
+  | _ => none
+
+/-- Build a `Header` from its decoded RLP field bytes. Fields 21–22
+    (`block_access_list_hash`, `slot_number`) are amsterdam-only and default
+    to `[]`/`0` for the previous fork. -/
+private def mkHeader (isCurrent : Bool) (bs : List Bytes) : Header :=
+  let getB := fun i => bs.getD i []
+  let getN := fun i => bytesBEtoNat (bs.getD i [])
+  { isCurrentFork := isCurrent
+    parentHash := getB 0, ommersHash := getB 1, coinbase := getB 2,
+    stateRoot := getB 3, transactionsRoot := getB 4, receiptRoot := getB 5,
+    bloom := getB 6, difficulty := getN 7, number := getN 8, gasLimit := getN 9,
+    gasUsed := getN 10, timestamp := getN 11, extraData := getB 12,
+    prevRandao := getB 13, nonce := getB 14, baseFeePerGas := getN 15,
+    withdrawalsRoot := getB 16, blobGasUsed := getN 17, excessBlobGas := getN 18,
+    parentBeaconBlockRoot := getB 19, requestsHash := getB 20,
+    blockAccessListHash := getB 21, slotNumber := getN 22 }
+
+/-- Decode an RLP-encoded header, current fork (23 fields) first, else the
+    previous fork (21 fields). -/
+def _decode_header (header_bytes : Bytes) : Except SpecError Header :=
+  match decodeFully header_bytes with
+  | some (.list items) =>
+      match items.mapM rlpBytes? with
+      | none => .error .headerDecodeError
+      | some bs =>
+          if bs.length = 23 then .ok (mkHeader true bs)
+          else if bs.length = 21 then .ok (mkHeader false bs)
+          else .error .headerDecodeError
+  | _ => .error .headerDecodeError
+
+/-! ## `validate_headers` (`stateless.py:257`) -/
+
+/-- Validate that a sequence of encoded headers forms a contiguous chain.
+    Each header's `parent_hash` must match the hash of the preceding header.
+    Returns the decoded headers and their block hashes. -/
+def validate_headers (encoded_headers : List Bytes) :
+    Except SpecError (List Header × List Hash32) := do
+  if encoded_headers.length > 256 then
+    throw (.tooManyHeaders encoded_headers.length)
+  let headers ← encoded_headers.mapM _decode_header
+  let block_hashes : List Hash32 := encoded_headers.map keccak256
+  -- headers[i].parent_hash == block_hashes[i-1] for i in 1..len
+  let contiguous := (headers.drop 1).zip block_hashes
+    |>.all (fun p => p.1.parentHash == p.2)
+  if contiguous then pure (headers, block_hashes)
+  else throw .headersNotContiguous
+
+/-! ## `_is_activation_active` (`stateless.py:280`) -/
+
+/-- Whether an activation point is active for the payload. -/
+def _is_activation_active (activation : ForkActivation) (ep : ExecutionPayload) :
+    Except SpecError Bool := do
+  if activation.blockNumber.isNone ∧ activation.timestamp.isNone then
+    throw .forkActivationMissing
+  if let some bn := activation.blockNumber then
+    if ep.blockNumber < bn then return false
+  if let some ts := activation.timestamp then
+    if ep.timestamp < ts then return false
+  return true
+
+/-! ## `_expected_amsterdam_blob_schedule` (`stateless.py:305`) -/
+
+/-- The blob schedule compiled into the Amsterdam guest. -/
+def _expected_amsterdam_blob_schedule : BlobSchedule :=
+  { target := blobScheduleTarget
+    max := blobScheduleMax
+    baseFeeUpdateFraction := blobBaseFeeUpdateFraction }
+
+/-! ## `validate_chain_config` (`stateless.py:316`) -/
+
+/-- Validate and return the target payload's active fork config. -/
+def validate_chain_config (chain_config : ChainConfig) (npr : NewPayloadRequest) :
+    Except SpecError ForkConfig := do
+  let active_fork := chain_config.activeFork
+  let execution_payload := npr.executionPayload
+  if !(← _is_activation_active active_fork.activation execution_payload) then
+    throw .inactiveForkConfig
+  if active_fork.fork ≠ ProtocolFork.Amsterdam then
+    throw (.unsupportedForkConfig "Amsterdam guest cannot execute configured fork")
+  if active_fork.blobSchedule ≠ some _expected_amsterdam_blob_schedule then
+    throw (.unsupportedForkConfig "blob_schedule does not match Amsterdam")
+  pure active_fork
+
+/-! ## The execution seam -/
+
+/-- Witness-backed pre-state passed to execution (`WitnessState.__init__`). -/
+structure WitnessPreState where
+  nodeDb : List (Hash32 × Bytes)
+  stateRoot : Root
+  codeDb : List (Hash32 × Bytes)
+  deriving Repr
+
+/-- `ChainContext(chain_id, block_hashes, parent_header)` (`fork.py`). -/
+structure ChainContext where
+  chainId : U64
+  blockHashes : List Hash32
+  parentHeader : Header
+  deriving Repr
+
+/-- The exact argument bundle passed to `execute_new_payload_request`
+    (`stateless.py:378`). -/
+structure ExecutionSeamInput where
+  newPayloadRequest : NewPayloadRequest
+  preState : WitnessPreState
+  chainContext : ChainContext
+  transactionPublicKeys : List Bytes
+
+/-- The execution engine, abstracted at the seam. `ok ()` mirrors Python
+    returning normally; `error _` mirrors any raised exception. -/
+abbrev ExecutionSeam := ExecutionSeamInput → Except SpecError Unit
+
+/-- Placeholder seam that accepts every payload, so the shell runs under
+    `#eval`. NOT a validation claim — the real engine is supplied by the
+    `.8` design session. -/
+def executeAlwaysOk : ExecutionSeam := fun _ => .ok ()
+
+/-! ## `verify_stateless_new_payload` (`stateless.py:344`) -/
+
+/-- Statelessly validate the execution payload. Every exception the Python
+    `try` would catch is folded into `successful_validation = false`. -/
+def verify_stateless_new_payload (si : StatelessInput)
+    (execute : ExecutionSeam := executeAlwaysOk) : StatelessValidationResult :=
+  let new_payload_request_root := compute_new_payload_request_root si
+  let witness := si.witness
+  let attempt : Except SpecError Unit := do
+    let _ ← validate_chain_config si.chainConfig si.newPayloadRequest
+    let (decoded_headers, block_hashes) ← validate_headers witness.headers
+    let parent_header ← match decoded_headers.getLast? with
+      | some h => pure h
+      | none => throw (.executionRejected "no witness headers")  -- decoded_headers[-1]
+    let chain_context : ChainContext :=
+      { chainId := si.chainConfig.chainId
+        blockHashes := block_hashes
+        parentHeader := parent_header }
+    let pre_state : WitnessPreState :=
+      { nodeDb := build_node_db witness.state
+        stateRoot := parent_header.stateRoot
+        codeDb := build_code_db witness.codes }
+    execute { newPayloadRequest := si.newPayloadRequest
+              preState := pre_state
+              chainContext := chain_context
+              transactionPublicKeys := si.publicKeys }
+  { newPayloadRequestRoot := new_payload_request_root
+    successfulValidation := (match attempt with | .ok _ => true | .error _ => false)
+    chainConfig := si.chainConfig }
+
+/-! ## Sanity checks -/
+
+-- A blob schedule matching the expected Amsterdam schedule is accepted.
+def sanityForkConfig : ForkConfig :=
+  { fork := .Amsterdam
+    activation := { blockNumber := none, timestamp := some 100 }
+    blobSchedule := some _expected_amsterdam_blob_schedule }
+
+-- Build a minimal RLP header with `n` fields, field 0 = parent_hash,
+-- field 3 = state_root, all others empty.
+def mkTestHeaderBytes (n : Nat) (parentHash stateRoot : Bytes) : Bytes :=
+  let fields : List RLPItem := (List.range n).map (fun i =>
+    if i = 0 then .bytes parentHash
+    else if i = 3 then .bytes stateRoot
+    else .bytes [])
+  EvmAsm.EL.RLP.encode (.list fields)
+
+-- Amsterdam header (23 fields) decodes with isCurrentFork = true.
+#guard
+  match _decode_header (mkTestHeaderBytes 23 (List.replicate 32 0x01) (List.replicate 32 0x02)) with
+  | .ok h => h.isCurrentFork && h.parentHash == List.replicate 32 0x01
+             && h.stateRoot == List.replicate 32 0x02
+  | .error _ => false
+
+-- Previous-fork header (21 fields) decodes with isCurrentFork = false.
+#guard
+  match _decode_header (mkTestHeaderBytes 21 (List.replicate 32 0x03) (List.replicate 32 0x04)) with
+  | .ok h => (!h.isCurrentFork) && h.parentHash == List.replicate 32 0x03
+  | .error _ => false
+
+-- A header with a bad field count is rejected.
+#guard match _decode_header (mkTestHeaderBytes 20 [] []) with
+  | .error .headerDecodeError => true | _ => false
+
+-- Two contiguous headers validate; a non-contiguous pair does not.
+#guard
+  let h0 := mkTestHeaderBytes 23 (List.replicate 32 0x00) (List.replicate 32 0x00)
+  let h0hash := keccak256 h0
+  let h1 := mkTestHeaderBytes 23 h0hash (List.replicate 32 0x05)
+  match validate_headers [h0, h1] with
+  | .ok (hs, hashes) => hs.length == 2 && hashes.length == 2
+  | .error _ => false
+
+#guard
+  let h0 := mkTestHeaderBytes 23 (List.replicate 32 0x00) (List.replicate 32 0x00)
+  let h1 := mkTestHeaderBytes 23 (List.replicate 32 0xEE) (List.replicate 32 0x05)  -- wrong parent
+  match validate_headers [h0, h1] with
+  | .error .headersNotContiguous => true | _ => false
+
+-- Activation: active when payload meets the timestamp; missing both fails.
+#guard
+  let ep : ExecutionPayload := (Inhabited.default : ExecutionPayload)
+  match _is_activation_active { blockNumber := none, timestamp := some 0 } ep with
+  | .ok b => b | _ => false
+
+#guard
+  match _is_activation_active { blockNumber := none, timestamp := none }
+      (Inhabited.default : ExecutionPayload) with
+  | .error .forkActivationMissing => true | _ => false
+
+end EvmAsm.Stateless.SpecRef

--- a/EvmAsm/Stateless/SpecRef/Types.lean
+++ b/EvmAsm/Stateless/SpecRef/Types.lean
@@ -1,0 +1,276 @@
+/-
+  EvmAsm.Stateless.SpecRef.Types
+
+  Domain types for the stateless-guest reference port. These mirror the
+  Python `@dataclass`/`StrEnum` types in
+  `execution-specs/src/ethereum/forks/amsterdam/stateless.py` (and the
+  `execution_engine.types` / `blocks` / `state` types it references),
+  at tag `tests-zkevm@v0.4.0`.
+
+  Modeling choices (see docs/4ch8f-specref-port.md):
+  * `Bytes = List (BitVec 8)` (see `Crypto.lean`), `#eval`/`decide`-friendly.
+  * Ethereum numeric widths (`U64`, `U256`, `Uint`) are unbounded `Nat`;
+    width enforcement lives in the SSZ codec (`Ssz.lean`), matching how the
+    Python `remerkleable` types apply width only at (de)serialization.
+  * Fixed-width byte fields (`Hash32`, `Root`, `Address`, `Bloom`,
+    `VersionedHash`) are raw `Bytes`; their length is a codec invariant, not
+    a type-level one (mirrors `bytes(x)` in the Python conversions).
+-/
+
+import EvmAsm.Stateless.SpecRef.Crypto
+
+namespace EvmAsm.Stateless.SpecRef
+
+/-! ## Numeric and byte-field aliases (all mirror Ethereum types) -/
+
+abbrev U64 := Nat
+abbrev U256 := Nat
+abbrev Uint := Nat
+abbrev Hash32 := Bytes
+abbrev Root := Bytes
+abbrev Address := Bytes
+abbrev Bloom := Bytes
+abbrev VersionedHash := Bytes
+
+/-! ## Distinct failure reasons
+
+`verify_stateless_new_payload` catches every exception and folds it into
+`successful_validation=False`, but the porting rules require the interior
+functions to surface the *distinct* reasons rather than collapse them. -/
+
+/-- Every distinct spec-level failure the port can raise, tagged by the
+    Python exception/`raise` site it corresponds to. -/
+inductive SpecError where
+  /-- `deserialize_stateless_input`: input shorter than the schema id. -/
+  | missingSchemaId
+  /-- `deserialize_stateless_input`: schema id ≠ `STATELESS_INPUT_SCHEMA_ID`. -/
+  | unsupportedSchemaId (found : Nat)
+  /-- `SszStatelessInput.decode_bytes` / `encode_bytes` failure. -/
+  | sszError (why : String)
+  /-- `stateless_input_to_ssz`: a transaction public key ≠ 65 bytes. -/
+  | publicKeyWrongLength (len : Nat)
+  /-- `_ssz_to_protocol_fork`: enum value out of range. -/
+  | unknownProtocolFork (value : Nat)
+  /-- `validate_headers`: more than 256 witness headers. -/
+  | tooManyHeaders (count : Nat)
+  /-- `_decode_header`: RLP decode failed for both current and previous fork. -/
+  | headerDecodeError
+  /-- `validate_headers`: `parent_hash` chain is not contiguous. -/
+  | headersNotContiguous
+  /-- `_is_activation_active`: activation sets neither block_number nor timestamp
+      (`InvalidForkActivationError`). -/
+  | forkActivationMissing
+  /-- `validate_chain_config`: active fork not active for the payload
+      (`InactiveForkConfigError`). -/
+  | inactiveForkConfig
+  /-- `validate_chain_config`: fork ≠ Amsterdam or blob schedule mismatch
+      (`UnsupportedForkConfigError`). -/
+  | unsupportedForkConfig (why : String)
+  /-- `_decode_account_from_leaf`: leaf RLP is not a 4-item list. -/
+  | accountLeafMalformed
+  /-- `_trie_lookup`: hit an unresolved `HashedNode`. -/
+  | unresolvedHashedNode
+  /-- Execution seam (`execute_new_payload_request`) rejected the payload. -/
+  | executionRejected (why : String)
+  deriving Repr, BEq, DecidableEq
+
+/-! ## Protocol forks (`stateless.py:83` `ProtocolFork`) -/
+
+/-- Semantic execution-layer fork names understood by stateless inputs.
+    Constructor order MUST match Python declaration order, because
+    `_protocol_fork_to_ssz` uses `tuple(ProtocolFork).index(fork)`. -/
+inductive ProtocolFork where
+  | Frontier | Homestead | DAOFork | TangerineWhistle | SpuriousDragon
+  | Byzantium | Constantinople | ConstantinopleFix | Istanbul | MuirGlacier
+  | Berlin | London | ArrowGlacier | GrayGlacier | Paris | Shanghai | Cancun
+  | Prague | Osaka | BPO1 | BPO2 | BPO3 | BPO4 | BPO5 | Amsterdam
+  deriving Repr, BEq, DecidableEq
+
+/-- `tuple(ProtocolFork)` — the SSZ enum ordering (`stateless_ssz.py:225`). -/
+def protocolForks : List ProtocolFork :=
+  [.Frontier, .Homestead, .DAOFork, .TangerineWhistle, .SpuriousDragon,
+   .Byzantium, .Constantinople, .ConstantinopleFix, .Istanbul, .MuirGlacier,
+   .Berlin, .London, .ArrowGlacier, .GrayGlacier, .Paris, .Shanghai, .Cancun,
+   .Prague, .Osaka, .BPO1, .BPO2, .BPO3, .BPO4, .BPO5, .Amsterdam]
+
+/-! ## Chain-config dataclasses (`stateless.py:139`–`183`) -/
+
+/-- `ForkActivation` (`stateless.py:141`). -/
+structure ForkActivation where
+  blockNumber : Option U64
+  timestamp : Option U64
+  deriving Repr, BEq, DecidableEq
+
+/-- `BlobSchedule` (`stateless.py:152`). -/
+structure BlobSchedule where
+  target : U64
+  max : U64
+  baseFeeUpdateFraction : U64
+  deriving Repr, BEq, DecidableEq
+
+/-- `ForkConfig` (`stateless.py:164`). -/
+structure ForkConfig where
+  fork : ProtocolFork
+  activation : ForkActivation
+  blobSchedule : Option BlobSchedule
+  deriving Repr, BEq, DecidableEq
+
+/-- `ChainConfig` (`stateless.py:176`). -/
+structure ChainConfig where
+  chainId : U64
+  activeFork : ForkConfig
+  deriving Repr, BEq, DecidableEq
+
+/-! ## Payload / request dataclasses
+    (`blocks.py`, `execution_engine/types.py`, `execution_engine/requests.py`) -/
+
+/-- `Withdrawal` (`blocks.py:36`). -/
+structure Withdrawal where
+  index : U64
+  validatorIndex : U64
+  address : Address
+  amount : U256
+  deriving Repr, BEq, DecidableEq
+
+/-- `ExecutionPayload` (`execution_engine/types.py:29`). -/
+structure ExecutionPayload where
+  parentHash : Hash32
+  feeRecipient : Address
+  stateRoot : Root
+  receiptsRoot : Root
+  logsBloom : Bloom
+  prevRandao : Bytes
+  blockNumber : Uint
+  gasLimit : Uint
+  gasUsed : Uint
+  timestamp : U256
+  extraData : Bytes
+  baseFeePerGas : Uint
+  blockHash : Hash32
+  transactions : List Bytes
+  withdrawals : List Withdrawal
+  blobGasUsed : U64
+  excessBlobGas : U64
+  blockAccessList : Bytes
+  slotNumber : U64
+  deriving Repr, BEq, DecidableEq, Inhabited
+
+/-- `DepositRequest` (`execution_engine/requests.py:35`). -/
+structure DepositRequest where
+  pubkey : Bytes
+  withdrawalCredentials : Bytes
+  amount : U64
+  signature : Bytes
+  index : U64
+  deriving Repr, BEq, DecidableEq
+
+/-- `WithdrawalRequest` (`execution_engine/requests.py:47`). -/
+structure WithdrawalRequest where
+  sourceAddress : Address
+  validatorPubkey : Bytes
+  amount : U64
+  deriving Repr, BEq, DecidableEq
+
+/-- `ConsolidationRequest` (`execution_engine/requests.py:57`). -/
+structure ConsolidationRequest where
+  sourceAddress : Address
+  sourcePubkey : Bytes
+  targetPubkey : Bytes
+  deriving Repr, BEq, DecidableEq
+
+/-- `ExecutionRequests` (`execution_engine/requests.py:67`). -/
+structure ExecutionRequests where
+  deposits : List DepositRequest
+  withdrawals : List WithdrawalRequest
+  consolidations : List ConsolidationRequest
+  deriving Repr, BEq, DecidableEq
+
+/-- `NewPayloadRequest` (`execution_engine/types.py:63`). -/
+structure NewPayloadRequest where
+  executionPayload : ExecutionPayload
+  versionedHashes : List VersionedHash
+  parentBeaconBlockRoot : Root
+  executionRequests : ExecutionRequests
+  deriving Repr, BEq, DecidableEq
+
+/-- `ExecutionWitness` (`stateless.py:32`). -/
+structure ExecutionWitness where
+  state : List Bytes
+  codes : List Bytes
+  headers : List Bytes
+  deriving Repr, BEq, DecidableEq
+
+/-- `StatelessInput` (`stateless.py:185`). -/
+structure StatelessInput where
+  newPayloadRequest : NewPayloadRequest
+  witness : ExecutionWitness
+  chainConfig : ChainConfig
+  publicKeys : List Bytes
+  deriving Repr, BEq, DecidableEq
+
+/-- `StatelessValidationResult` (`stateless.py:216`). -/
+structure StatelessValidationResult where
+  newPayloadRequestRoot : Hash32
+  successfulValidation : Bool
+  chainConfig : ChainConfig
+  deriving Repr, BEq, DecidableEq
+
+/-! ## State-side types (`ethereum.state`, `witness_state.py`) -/
+
+/-- `ethereum.state.Account` — the three fields stored on the account
+    object (`storage_root` is returned separately by
+    `_decode_account_from_leaf`). -/
+structure Account where
+  nonce : Uint
+  balance : U256
+  codeHash : Hash32
+  deriving Repr, BEq, DecidableEq
+
+/-- A decoded block header. The Python `_decode_header` returns
+    `Header | PreviousForkHeader`; both share the leading fields, and
+    `validate_headers`/`verify_stateless_new_payload` only read
+    `parent_hash` and `state_root`. We collapse the union into one record
+    carrying every decoded field plus a `fork` tag recording which decoder
+    succeeded (amsterdam = 23 RLP fields, bpo5 = 21). Scalar fields are
+    kept as `Nat`, byte/hash fields as `Bytes`. -/
+structure Header where
+  /-- `true` if decoded as the amsterdam `Header` (23 fields), `false` for
+      the previous-fork (bpo5) `Header` (21 fields). -/
+  isCurrentFork : Bool
+  parentHash : Hash32
+  ommersHash : Hash32
+  coinbase : Address
+  stateRoot : Root
+  transactionsRoot : Root
+  receiptRoot : Root
+  bloom : Bloom
+  difficulty : Uint
+  number : Uint
+  gasLimit : Uint
+  gasUsed : Uint
+  timestamp : U256
+  extraData : Bytes
+  prevRandao : Bytes
+  nonce : Bytes
+  baseFeePerGas : Uint
+  withdrawalsRoot : Root
+  blobGasUsed : U64
+  excessBlobGas : U64
+  parentBeaconBlockRoot : Root
+  requestsHash : Hash32
+  /-- amsterdam-only (`Bytes.empty` when `isCurrentFork = false`). -/
+  blockAccessListHash : Hash32
+  /-- amsterdam-only (`0` when `isCurrentFork = false`). -/
+  slotNumber : U64
+  deriving Repr, BEq, DecidableEq
+
+/-! ## Amsterdam-compiled constants (`vm/gas.py`) -/
+
+/-- `BLOB_SCHEDULE_TARGET` (`vm/gas.py:106`). -/
+def blobScheduleTarget : U64 := 14
+/-- `BLOB_SCHEDULE_MAX` (`vm/gas.py:109`). -/
+def blobScheduleMax : U64 := 21
+/-- `BLOB_BASE_FEE_UPDATE_FRACTION` (`vm/gas.py:111`). -/
+def blobBaseFeeUpdateFraction : Uint := 11684671
+
+end EvmAsm.Stateless.SpecRef

--- a/EvmAsm/Stateless/SpecRef/WitnessState.lean
+++ b/EvmAsm/Stateless/SpecRef/WitnessState.lean
@@ -1,0 +1,178 @@
+/-
+  EvmAsm.Stateless.SpecRef.WitnessState
+
+  Port of the four module-level functions in
+  `execution-specs/src/ethereum/forks/amsterdam/witness_state.py`
+  (`@tests-zkevm@v0.4.0`):
+
+  * `build_node_db`            (`witness_state.py:36`)
+  * `build_code_db`            (`witness_state.py:44`)
+  * `_trie_lookup`             (`witness_state.py:52`)
+  * `_decode_account_from_leaf`(`witness_state.py:102`)
+
+  The `WitnessState` *methods* (`get_account_optional`, `get_storage`,
+  `get_code`, `compute_state_root_and_trie_changes`, …) are the read/write
+  side of the `PreState` protocol consumed by block execution; they sit
+  BEHIND the execution seam (see `Stateless.lean`) and are out of scope
+  here. Likewise `decode_witness_to_mpt` (which turns a node DB into the
+  `MutableNode` tree `_trie_lookup` walks) lives in `incremental_mpt.py`,
+  not among the four target functions — so `_trie_lookup` is ported as a
+  pure walk over an already-decoded `MutableNode`, and the `#guard`s below
+  exercise it on hand-built trees.
+-/
+
+import EvmAsm.Stateless.SpecRef.Types
+import EvmAsm.EL.RLP.FullDecode
+
+namespace EvmAsm.Stateless.SpecRef
+
+open EvmAsm.EL.RLP (RLPItem decodeFully)
+
+/-! ## Empty-trie / empty-code sentinels (`ethereum.state`, `merkle_patricia_trie`) -/
+
+/-- `EMPTY_CODE_HASH = keccak256(b"")`. -/
+def EMPTY_CODE_HASH : Hash32 := keccak256 []
+
+/-- `EMPTY_TRIE_ROOT = keccak256(rlp.encode(b"")) = keccak256(0x80)`. -/
+def EMPTY_TRIE_ROOT : Root := keccak256 [0x80]
+
+-- keccak256("") = c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
+#guard bytesBEtoNat EMPTY_CODE_HASH
+  = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
+-- EMPTY_TRIE_ROOT = keccak256(0x80), matching merkle_patricia_trie.py:63
+#guard bytesBEtoNat EMPTY_TRIE_ROOT
+  = 0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
+
+/-! ## `build_node_db` / `build_code_db` (`witness_state.py:36`, `:44`)
+
+Python builds a `Dict[keccak256(entry), entry]`; we model the DB as an
+association list `List (Hash32 × Bytes)` in witness order. -/
+
+/-- Build the `hash → RLP` mapping from witness state preimages. -/
+def build_node_db (state_entries : List Bytes) : List (Hash32 × Bytes) :=
+  state_entries.map (fun entry => (keccak256 entry, entry))
+
+/-- Build the `code_hash → bytecode` mapping from witness codes. -/
+def build_code_db (code_entries : List Bytes) : List (Hash32 × Bytes) :=
+  code_entries.map (fun code => (keccak256 code, code))
+
+/-! ## MPT node model (`incremental_mpt.MutableNode`)
+
+The `MutableNode` union `_trie_lookup` walks. Nibble sequences
+(`rest_of_key`, `key_segment`, and the key path) are `Bytes` with each byte
+holding a single nibble value `0..15`, matching the Python
+`bytearray` of nibbles. A branch has 16 children (`none` for absent) and a
+value (`empty` = absent). `hashed` is an unresolved node. -/
+inductive MutableNode where
+  | hashed (hash : Bytes)
+  | leaf (restOfKey : Bytes) (value : Bytes)
+  | extension (keySegment : Bytes) (child : MutableNode)
+  | branch (children : List (Option MutableNode)) (value : Bytes)
+  deriving Inhabited
+
+/-! ## `_trie_lookup` (`witness_state.py:52`) -/
+
+/-- Expand a byte string into its nibble sequence (`byte >> 4`, `byte & 0x0F`). -/
+def keyToNibbles (key : Bytes) : Bytes :=
+  key.flatMap (fun b =>
+    [BitVec.ofNat 8 (b.toNat >>> 4), BitVec.ofNat 8 (b.toNat &&& 0x0F)])
+
+/-- Walk a decoded MPT from `node`, following `nibbles` from position `pos`.
+    Returns the leaf value or `none` if not found; errors on an unresolved
+    `HashedNode`. Fuel bounds the nibble path length. -/
+def trieLookupAux : Nat → Option MutableNode → Bytes → Nat → Except SpecError (Option Bytes)
+  | _, none, _, _ => .ok none
+  | 0, _, _, _ => .ok none
+  | f + 1, some node, nibbles, pos =>
+    match node with
+    | .hashed _ => .error .unresolvedHashedNode
+    | .leaf restOfKey value =>
+        if nibbles.drop pos == restOfKey then .ok (some value) else .ok none
+    | .extension keySegment child =>
+        if (nibbles.drop pos).take keySegment.length == keySegment then
+          trieLookupAux f (some child) nibbles (pos + keySegment.length)
+        else .ok none
+    | .branch children value =>
+        if nibbles.length ≤ pos then
+          .ok (if value.isEmpty then none else some value)
+        else
+          let idx := (nibbles.getD pos 0).toNat
+          trieLookupAux f (children.getD idx none) nibbles (pos + 1)
+
+/-- `_trie_lookup(root_node, key_hash)`. `root` is `Option` to capture the
+    empty-trie (`None` root) case the Python `while node is not None` guard
+    handles. -/
+def trieLookup (root : Option MutableNode) (keyHash : Hash32) :
+    Except SpecError (Option Bytes) :=
+  let nibbles := keyToNibbles keyHash
+  trieLookupAux (nibbles.length + 2) root nibbles 0
+
+/-! ## `_decode_account_from_leaf` (`witness_state.py:102`) -/
+
+/-- Decode `(nonce, balance, storage_root, code_hash)` from a trie leaf.
+    Returns the `Account` and the `storage_root` separately (mirrors the
+    Python tuple return). -/
+def decode_account_from_leaf (leaf_value : Bytes) :
+    Except SpecError (Account × Root) := do
+  match decodeFully leaf_value with
+  | some (.list [.bytes n, .bytes b, .bytes sr, .bytes ch]) =>
+      let nonce : Uint := if n.isEmpty then 0 else bytesBEtoNat n
+      let balance : U256 := if b.isEmpty then 0 else bytesBEtoNat b
+      let storageRoot : Root := if sr.isEmpty then EMPTY_TRIE_ROOT else sr
+      let codeHash : Hash32 := if ch.isEmpty then EMPTY_CODE_HASH else ch
+      pure ({ nonce, balance, codeHash }, storageRoot)
+  | _ => .error .accountLeafMalformed
+
+/-! ## Sanity checks -/
+
+-- build_node_db keys are the keccak256 of the entries.
+#guard (build_node_db [[0x80]]).map (fun p => bytesBEtoNat p.1)
+  == [0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421]
+
+-- A single-leaf trie whose leaf key is all the nibbles of key `0xAB` returns
+-- its value; a mismatching key returns none.
+#guard
+  let key : Bytes := [0xAB]
+  let nibbles := keyToNibbles key   -- [0x0A, 0x0B]
+  match trieLookup (some (.leaf nibbles [0x99])) key with
+  | .ok (some [0x99]) => true | _ => false
+
+#guard
+  match trieLookup (some (.leaf [0x0C, 0x0D] [0x99])) [0xAB] with
+  | .ok none => true | _ => false
+
+-- Empty (None) root → not found.
+#guard match trieLookup none [0xAB] with | .ok none => true | _ => false
+
+-- Unresolved HashedNode → error.
+#guard
+  match trieLookup (some (.hashed [])) [0xAB] with
+  | .error .unresolvedHashedNode => true | _ => false
+
+-- A branch dispatching on the first nibble (0x0A) of key 0xAB to a leaf.
+#guard
+  let leaf : MutableNode := .leaf [0x0B] [0x77]
+  let children : List (Option MutableNode) :=
+    (List.range 16).map (fun i => if i == 0x0A then some leaf else none)
+  match trieLookup (some (.branch children [])) [0xAB] with
+  | .ok (some [0x77]) => true | _ => false
+
+-- Decode a minimal account leaf: rlp([nonce=1, balance=0x0de0b6b3a7640000,
+-- storage_root=EMPTY_TRIE_ROOT, code_hash=EMPTY_CODE_HASH]).
+#guard
+  let leaf : RLPItem := .list
+    [.bytes [0x01],
+     .bytes (natToBytesBE 8 1000000000000000000),
+     .bytes EMPTY_TRIE_ROOT,
+     .bytes EMPTY_CODE_HASH]
+  (decode_account_from_leaf (EvmAsm.EL.RLP.encode leaf)).toOption
+    == some ({ nonce := 1, balance := 1000000000000000000, codeHash := EMPTY_CODE_HASH },
+             EMPTY_TRIE_ROOT)
+
+-- Empty scalar fields default to 0 / empty sentinels.
+#guard
+  let leaf : RLPItem := .list [.bytes [], .bytes [], .bytes [], .bytes []]
+  (decode_account_from_leaf (EvmAsm.EL.RLP.encode leaf)).toOption
+    == some ({ nonce := 0, balance := 0, codeHash := EMPTY_CODE_HASH }, EMPTY_TRIE_ROOT)
+
+end EvmAsm.Stateless.SpecRef

--- a/docs/4ch8f-specref-port.md
+++ b/docs/4ch8f-specref-port.md
@@ -1,0 +1,179 @@
+# SpecRef — Lean functional port of the stateless-guest spec (`4ch8f.8` feeder)
+
+A faithful, executable Lean reference model of the Amsterdam stateless-guest
+Python spec, ported line-for-line against
+`execution-specs @ tests-zkevm@v0.4.0` (the project's canonical conformance
+target). This is a **reference model only** — no proofs, no theorems about the
+RV64 guest. It is the scaffolding bead `evm-asm-4ch8f.8` (the top-level spec
+*statement*) can consume regardless of the trust-boundary / one-sided-vs-two-sided
+decisions that bead makes.
+
+Code lives under `EvmAsm/Stateless/SpecRef/`, imported via
+`EvmAsm/Stateless/SpecRef.lean` (wired into the `EvmAsm.Stateless` umbrella).
+
+## Reading the source on the right ref
+
+The spec does **not** live on execution-specs master or `origin/forks/amsterdam`.
+It is on the `tests-zkevm@v0.4.0` tag (checked out as the in-repo `execution-specs`
+submodule). Read files with:
+
+```
+git -C execution-specs show 'tests-zkevm@v0.4.0:src/ethereum/forks/amsterdam/<file>'
+```
+
+## Modeling choices
+
+| Concept | Model | Rationale |
+|---|---|---|
+| `Bytes` | `List (BitVec 8)` (= `EvmAsm.EL.RLP.Byte`) | `#eval`/`decide`-friendly; lets us reuse the repo's RLP model verbatim |
+| `U64`/`U256`/`Uint` | `Nat` | width is an SSZ-codec property, not a Lean type; matches how `remerkleable` applies width only at (de)serialization |
+| `Hash32`/`Root`/`Address`/`Bloom`/`VersionedHash` | raw `Bytes` | mirrors `bytes(x)` in the Python conversions; length is a codec invariant, checked on decode |
+| Python `raise` | `Except SpecError α` / `Option α` | distinct reasons kept in the `SpecError` enum, not collapsed |
+| structural recursion the kernel can't see | explicit fuel arg | repo convention (`powModAux`); fuel bounds *type-nesting depth*, so a small constant suffices and terms stay kernel-reducible |
+
+## Reused vs ported
+
+**Reused** (no re-implementation):
+
+- `EvmAsm.Rv64.Accel.keccakF`, `Accel.sha256Compress` — the concrete ZisK
+  permutations (KAT-checked in-repo). `SpecRef.Crypto` wraps them with the
+  sponge / Merkle–Damgård padding to get full `keccak256`/`sha256`.
+- `EvmAsm.EL.RLP` — the full functional RLP model: `RLPItem`, `decode`,
+  `decodeFully`, `encode`, `Nat.toBytesBE`, `Nat.fromBytesBE`. Used by
+  `_decode_header` and `_decode_account_from_leaf`.
+
+**Ported fresh** (nothing functional existed in-repo — only SAsm emitters and
+doc-only contracts under `EvmAsm/Stateless/SSZ/`):
+
+- The generic SSZ engine (`SszCodec`): `serialize` (`encode_bytes`),
+  `deserialize` (`decode_bytes`), `hashTreeRoot` (merkleization with
+  `mix_in_length`, packed basic-type lists, `Z_0` padding).
+- The domain types, the SSZ containers + 34 conversions, the 4 witness-state
+  defs, the 7 stateless defs, and the 3 guest-shell defs.
+
+## The execution seam
+
+`verify_stateless_new_payload` (`stateless.py:344`) calls
+`execute_new_payload_request` (`stateless.py:378`) — full stateful block
+re-execution (`execution_engine.new_payload`, the whole EVM). We cut **exactly**
+at that call:
+
+- Everything on the validation / deserialization / hashing side is **real**:
+  NPR-root hashing, chain-config validation, header decode + contiguity, node/code
+  DB construction, the witness pre-state assembly.
+- The engine is an explicit parameter `execute : ExecutionSeam`, i.e.
+  `ExecutionSeamInput → Except SpecError Unit`, where `ExecutionSeamInput`
+  carries the exact bundle the Python call passes: the `NewPayloadRequest`, the
+  witness-backed `WitnessPreState` (`_node_db` / `_state_root` / `_code_db`), the
+  `ChainContext` (`chain_id` / `block_hashes` / `parent_header`), and the
+  transaction public keys.
+- `ok ()` ≙ Python returning normally; `error _` ≙ any raised exception (folded
+  into `successful_validation = false`, as the Python `try/except Exception`
+  does).
+- `executeAlwaysOk` is a placeholder instantiation so the shell is
+  `#eval`-runnable end-to-end. Bead `4ch8f.8` decides the real instantiation
+  against the RV64 guest.
+
+`WitnessState`'s read/write methods (`get_account_optional`, `get_storage`,
+`get_code`, `compute_state_root_and_trie_changes`) and `decode_witness_to_mpt`
+are behind this seam and are **not** ported (they are the `PreState` protocol
+consumed by execution, plus `incremental_mpt.py`).
+
+## Python ↔ Lean mapping
+
+All line numbers are `@tests-zkevm@v0.4.0`. Lean names are in
+`namespace EvmAsm.Stateless.SpecRef`.
+
+### `stateless_guest.py` → `Guest.lean`
+
+| Python (line) | Lean |
+|---|---|
+| `serialize_stateless_output` (21) | `serialize_stateless_output` |
+| `deserialize_stateless_input` (29) | `deserialize_stateless_input` |
+| `run_stateless_guest` (47) | `run_stateless_guest` |
+
+### `stateless.py` → `Stateless.lean` (+ types in `Types.lean`)
+
+| Python (line) | Lean |
+|---|---|
+| `ExecutionWitness` (34) | `ExecutionWitness` (Types) |
+| `ProtocolFork` (83) | `ProtocolFork` + `protocolForks` (Types) |
+| `ForkActivation`/`BlobSchedule`/`ForkConfig`/`ChainConfig` (139–183) | same names (Types) |
+| `StatelessInput` (185) / `StatelessValidationResult` (216) | same names (Types) |
+| `compute_new_payload_request_root` (231) | `compute_new_payload_request_root` |
+| `_decode_header` (246) | `_decode_header` (+ `mkHeader`, `rlpBytes?`) |
+| `validate_headers` (257) | `validate_headers` |
+| `_is_activation_active` (280) | `_is_activation_active` |
+| `_expected_amsterdam_blob_schedule` (305) | `_expected_amsterdam_blob_schedule` |
+| `validate_chain_config` (316) | `validate_chain_config` |
+| `verify_stateless_new_payload` (344) | `verify_stateless_new_payload` |
+
+The `Header`/`PreviousForkHeader` union is collapsed into one `Header` record
+with an `isCurrentFork` tag (see simplifications below).
+
+### `stateless_ssz.py` → `Ssz.lean` (engine in `SszCodec.lean`)
+
+Constants `MAX_*` (41–61), `STATELESS_INPUT_SCHEMA_ID{,_SIZE}` (64–65) ported
+verbatim. Each `class SszX(Container)` → `sszXType : SszType`. Each `_x_to_ssz` →
+`xToSsz`, each `_ssz_to_x` → `sszToX` (34 conversions total):
+`_protocol_fork_to_ssz`/`_ssz_to_protocol_fork`, `_withdrawal_*`, `_payload_*`,
+`_deposit_request_*`, `_withdrawal_request_*`, `_consolidation_request_*`,
+`_execution_requests_*`, `_new_payload_request_*`, `_witness_*`,
+`_optional_u64_*`, `_fork_activation_*`, `_blob_schedule_*`,
+`_optional_blob_schedule_*`, `_fork_config_*`, `_chain_config_*`,
+`stateless_input_to_ssz`/`ssz_to_stateless_input`,
+`validation_result_to_ssz`/`ssz_to_validation_result`. The generic
+`.encode_bytes()`/`.decode_bytes()`/`.hash_tree_root()` (from `remerkleable`) are
+`SszValue.serialize` / `deserialize` / `SszValue.hashTreeRoot`.
+
+### `witness_state.py` → `WitnessState.lean`
+
+| Python (line) | Lean |
+|---|---|
+| `build_node_db` (36) | `build_node_db` |
+| `build_code_db` (44) | `build_code_db` |
+| `_trie_lookup` (52) | `trieLookup` (+ `trieLookupAux`, `keyToNibbles`) |
+| `_decode_account_from_leaf` (102) | `decode_account_from_leaf` |
+
+`MutableNode` (from `incremental_mpt`) is modeled as an inductive with
+`hashed`/`leaf`/`extension`/`branch`.
+
+## Sanity evidence (`#guard`, kernel-evaluated)
+
+- **Crypto** (`Crypto.lean`): `keccak256`/`sha256` KATs for `""`, `"abc"`.
+- **SSZ** (`Ssz.lean`): `ChainConfig` (optionals + nested container) and
+  `StatelessValidationResult` (bool + nested) round-trip serialize→deserialize→domain.
+- **Witness** (`WitnessState.lean`): `EMPTY_CODE_HASH`/`EMPTY_TRIE_ROOT` match the
+  spec's constants; `build_node_db` keys; `trieLookup` on leaf/extension/branch,
+  empty-root, and the `HashedNode` error; `decode_account_from_leaf` on a full and
+  an all-empty leaf.
+- **Stateless** (`Stateless.lean`): `_decode_header` for amsterdam (23) vs previous
+  (21) fork and a bad field count; `validate_headers` contiguity accept/reject;
+  `_is_activation_active` active + missing-both.
+- **Guest** (`Guest.lean`): end-to-end schema-prefixed
+  `StatelessInput` round-trip, wrong-schema and too-short rejection, and a full
+  `run_stateless_guest` run whose decoded output carries `successful_validation =
+  true` and the matching NPR root (under the placeholder seam).
+
+## Known simplifications / spec ambiguities
+
+1. **Header decode discriminant.** `rlp.decode_to(Header, …)` is type-directed and
+   validates each field's byte length; we discriminate current fork (amsterdam, 23
+   RLP fields) from previous fork (bpo5, 21 fields) by RLP list length only, and do
+   not re-impose per-field length checks. The two forks have distinct field counts,
+   so this reproduces the fork-selection behavior; it is slightly more permissive on
+   malformed field widths. Not observed to matter for the spec's downstream use
+   (`parent_hash`, `state_root`).
+2. **`Header | PreviousForkHeader` union** collapsed into one `Header` record with an
+   `isCurrentFork` tag; the two amsterdam-only fields default to `[]`/`0` for the
+   previous fork. Downstream only reads `parent_hash`/`state_root`.
+3. **Node DB as association list.** `Dict[bytes, bytes]` is modeled as
+   `List (Hash32 × Bytes)` in witness order (last-write-wins dict semantics are moot
+   — colliding keys carry identical values). Lookups are behind the seam, so this is
+   inert here.
+
+## Divergence policy
+
+No disagreement between the Python spec and the emitted guest / existing Lean was
+found while porting (the port is a fresh functional model, disjoint from the SAsm
+side). If a future audit surfaces one, file a P1 bead per standing project policy.


### PR DESCRIPTION
Feeder for bead **evm-asm-4ch8f.8** (child **evm-asm-4ch8f.8.1**). A faithful, executable Lean **reference model** of the Amsterdam stateless-guest Python spec, ported def-by-def against `execution-specs @ tests-zkevm@v0.4.0` (the project's canonical conformance target — *not* master / `forks/amsterdam`). **Reference model only**: no proofs, no theorems about the RV64 guest. This is the scaffolding `.8` (the top-level spec *statement*) can consume under any trust-boundary / one-sided-vs-two-sided decision.

Does **not** stack on the wave PRs; file-disjoint from the `.9.x` work (new dir `EvmAsm/Stateless/SpecRef/`).

## Module-by-module port status

| File | Python module (`@tests-zkevm@v0.4.0`) | Status |
|---|---|---|
| `Crypto.lean` | — (support) | full `keccak256`/`sha256` on the KAT-checked `Accel.keccakF`/`sha256Compress` |
| `Types.lean` | `stateless.py` dataclasses/`ProtocolFork` + `Account`/`Header` | ✅ all mirrors + `SpecError` |
| `SszCodec.lean` | `remerkleable` generic SSZ | ✅ `serialize`/`deserialize`/`hashTreeRoot` (zero-hash-aware merkleization) |
| `Ssz.lean` | `stateless_ssz.py` | ✅ container `SszType`s + all 34 conversions + constants |
| `WitnessState.lean` | `witness_state.py` | ✅ 4 module-level defs (`build_node_db`, `build_code_db`, `_trie_lookup`, `_decode_account_from_leaf`) + `MutableNode` |
| `Stateless.lean` | `stateless.py` | ✅ all 7 defs + execution seam |
| `Guest.lean` | `stateless_guest.py` | ✅ all 3 shell defs |

Umbrella `EvmAsm/Stateless/SpecRef.lean`, imported by `EvmAsm.Stateless`. Full def-by-def mapping (with line refs) in **`docs/4ch8f-specref-port.md`**.

## The execution seam

Cut **exactly** at `execute_new_payload_request` (`stateless.py:378`) — the whole EVM. Everything on the validation/deserialization/hashing side is **real** (NPR-root hashing, chain-config validation, header decode + contiguity, node/code DB build, witness pre-state assembly). The engine is an explicit parameter `execute : ExecutionSeam = ExecutionSeamInput → Except SpecError Unit`, where `ExecutionSeamInput` carries the exact bundle the Python call passes (`NewPayloadRequest`, `WitnessPreState`, `ChainContext`, transaction public keys). `ok ()` ≙ Python returning normally; `error _` ≙ any raised exception (folded into `successful_validation = false`). `executeAlwaysOk` is a placeholder so the shell is `#eval`-runnable end-to-end; `.8` decides the real instantiation. `WitnessState`'s read/write methods and `decode_witness_to_mpt` are behind the seam and not ported.

## Reused vs ported

- **Reused verbatim**: `EvmAsm.EL.RLP` (`RLPItem`/`decode`/`decodeFully`/`Nat.toBytesBE`/`Nat.fromBytesBE`) for header + account-leaf decode; `EvmAsm.Rv64.Accel.keccakF`/`sha256Compress` (wrapped, not re-implemented).
- **Ported fresh**: the generic SSZ engine (nothing functional existed in-repo — only SAsm emitters + doc-only contracts under `EvmAsm/Stateless/SSZ/`), the domain types, all conversions, and the shell.

## Sanity-check inventory (all `#guard`, kernel-evaluated green)

- **Crypto**: `keccak256`/`sha256` KATs for `""` and `"abc"`.
- **SSZ**: `ChainConfig` (optionals + nested container) and `StatelessValidationResult` (bool + nested) round-trip serialize→deserialize→domain.
- **Witness**: `EMPTY_CODE_HASH`/`EMPTY_TRIE_ROOT` match the spec's `merkle_patricia_trie.py:63` constant; `build_node_db` keys; `trieLookup` on leaf/extension/branch + empty-root + `HashedNode` error; `decode_account_from_leaf` full + all-empty leaf.
- **Stateless**: `_decode_header` amsterdam(23) vs previous(21) fork + bad count; `validate_headers` contiguity accept/reject; `_is_activation_active` active + missing-both.
- **Guest**: end-to-end schema-prefixed `StatelessInput` round-trip; wrong-schema + too-short rejection; full `run_stateless_guest` producing SSZ output with `successful_validation = true` and matching NPR root.

## Gates

- Full `lake build` green (`EvmAsm.Stateless`, 1029 jobs).
- `check-forbidden-tactics.sh` / `check-file-size.sh` (all ≤ 449 lines) / `check-unimported.sh` pass.
- No `native_decide` / `bv_decide` / `sorry` / `panic!`; no `maxHeartbeats` raising.

## Open questions / known simplifications

1. `_decode_header` discriminates current(23)/previous(21) fork by **RLP list length**, not by re-imposing `rlp.decode_to`'s per-field byte-length checks (slightly more permissive on malformed field widths; the field count is the fork discriminant and downstream only reads `parent_hash`/`state_root`).
2. `Header | PreviousForkHeader` collapsed into one `Header` record with an `isCurrentFork` tag.
3. Node DB modeled as an association list (lookups are behind the seam).

No spec/guest divergence found while porting. Reviewer (Fable) can audit the port against the Python line-by-line via the mapping doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
