### PR TITLE
proof(sasm): phase-ownership model for the call_frame_arena union (4ch8f.6)

### DIFF
--- a/EvmAsm/Codegen.lean
+++ b/EvmAsm/Codegen.lean
@@ -11,6 +11,7 @@ import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs
 import EvmAsm.Codegen.RegionMap
+import EvmAsm.Codegen.CallFramePhase
 import EvmAsm.Codegen.Driver
 import EvmAsm.Codegen.Cli
 import EvmAsm.Codegen.RoundTripTests

--- a/EvmAsm/Codegen/CallFramePhase.lean
+++ b/EvmAsm/Codegen/CallFramePhase.lean
@@ -1,0 +1,190 @@
+/-
+  EvmAsm.Codegen.CallFramePhase
+
+  The verified phase-ownership model for the `call_frame_arena` union —
+  bead `evm-asm-4ch8f.6`'s deferred hard half, instantiating the generic
+  machinery of `EvmAsm/Rv64/SAsm/PhaseSplit.lean` on the audited inventory
+  of `EvmAsm/Codegen/RegionMap.lean`.
+
+  ## What is being modeled
+
+  `call_frame_arena` (`frameArrayBytes` ≈ 164 MiB, the Phase-D EVM
+  call-frame overlay) physically coalesces seven execution-dead Phase-H
+  arenas into its front (`basr_values`, `basr_accounts`,
+  `bv_system_storage_log`, `baap_storage_{desc,paths,delete_paths,values}`;
+  `RegionMap.dataUnionChildren`).  Until now the no-corruption argument was
+  prose ("sequential, disjoint live windows",
+  `docs/call-frame-memory-layout.md` §5).  This module replaces the prose
+  with an ownership discipline:
+
+  * The arena is ONE separation-logic resource
+    (`phaseDView base = anyBytes base frameArrayBytes`), never two.
+  * The Phase-H view is a *tiling* of that same resource
+    (`phaseHView` = seven havoc'd children + havoc'd pad), and
+    `phaseD_eq_phaseH` proves the two views are THE SAME assertion.
+  * Phase transitions are rewrites across that equality.  Both directions
+    **forget contents by construction** (`anyBytes` carries ownership and
+    length, nothing else): Phase D provably cannot depend on what Phase H
+    left in the shared bytes, and a hypothetical post-dispatch Phase-H
+    reader cannot recover its old buffers — re-partition havocs them.
+    The unsoundness the prose worried about (a stale reader observing bytes
+    the other phase scribbled) is now structurally unexpressible in any
+    composed proof that frames the arena through these views.
+  * On the consuming side, `SAsm.cpsTripleWithin_anyBytes_pre` forces every
+    routine framed against a havoc'd range to be verified for all possible
+    contents of that range.
+
+  What routine beads must do: Phase-H routines (`.41`–`.48`) frame the
+  individual child ranges (obtained by rewriting `phaseD_eq_phaseH` /
+  `phaseD_children` left-to-right); Phase-D dispatch routines (`.49`,
+  `.56`) frame `phaseDView`; the `block_verdict` composition (`.61`)
+  performs each transition by a single rewrite, weakening any concrete
+  buffer contents through `SAsm.bytesRegion_anyBytes` first.
+
+  The absolute arena base stays a parameter (`base`) — the model is
+  link-layout-independent; `RegionMap.callFrameArenaBase` pins this build's
+  address, and `scripts/check-region-map.sh` guards it against the ELF.
+-/
+
+import EvmAsm.Codegen.RegionMap
+import EvmAsm.Rv64.SAsm.PhaseSplit
+
+namespace EvmAsm.Codegen
+namespace CallFramePhase
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+
+/-- Total bytes of the seven coalesced Phase-H arenas (the union front). -/
+def unionBytes : Nat := (RegionMap.dataUnionChildren.map (·.size)).sum
+
+/-- Trailing pad: arena bytes past the union front, owned by neither Phase-H
+    child (part of the Phase-D frame array only). -/
+def unionPadBytes : Nat := frameArrayBytes - unionBytes
+
+/-- The union front fits the arena (kernel recheck of
+    `RegionMap.dataUnionChildren_fit_arena` at the summed granularity). -/
+theorem unionBytes_le_arena : unionBytes ≤ frameArrayBytes := by decide
+
+/-- Phase-H tiling segment sizes: the seven children in layout order, then
+    the pad. -/
+def phaseHSegs : List Nat :=
+  RegionMap.dataUnionChildren.map (·.size) ++ [unionPadBytes]
+
+theorem phaseHSegs_sum : phaseHSegs.sum = frameArrayBytes := by decide
+
+theorem phaseHSegs_dvd8 : ∀ s ∈ phaseHSegs, 8 ∣ s := by decide
+
+-- ============================================================================
+-- The two phase views and their equality
+-- ============================================================================
+
+/-- **Phase-D view**: the whole `call_frame_arena` as one havoc'd resource
+    (the EVM call-frame overlay owns every byte, contents unspecified). -/
+def phaseDView (base : Word) : Assertion := anyBytes base frameArrayBytes
+
+/-- **Phase-H view**: the seven coalesced arenas plus the pad, each a
+    havoc'd tile of the same byte range. -/
+def phaseHView (base : Word) : Assertion := anyTilesAt base 0 phaseHSegs
+
+/-- **The phase-repartition theorem**: the two views are the SAME assertion.
+    Rewriting across this equality is the phase transition; contents are
+    forgotten in both directions by construction. -/
+theorem phaseD_eq_phaseH (base : Word) : phaseDView base = phaseHView base := by
+  rw [phaseDView, phaseHView, ← phaseHSegs_sum]
+  exact anyBytes_eq_anyTiles base phaseHSegs phaseHSegs_dvd8
+
+theorem pcFree_phaseDView (base : Word) : (phaseDView base).pcFree :=
+  pcFree_anyBytes _ _
+
+theorem pcFree_phaseHView (base : Word) : (phaseHView base).pcFree :=
+  pcFree_anyTilesAt _ _ _
+
+-- ============================================================================
+-- The named-children form (offsets as accumulated sums)
+-- ============================================================================
+
+/-- Abbreviations for the audited segment sizes (`RegionMap.dataUnionChildren`):
+    `S` = basr values/accounts stride, `L` = system-storage log,
+    `D` = baap descriptors, `P` = one baap path arena. -/
+private def S : Nat := RegionMap.basrArenaBytes
+private def L : Nat := bvSystemStorageLogBytes
+private def D : Nat := bsrMaxBalItems * baapStorageDescBytes
+private def P : Nat := bsrMaxBalItems * bsrPathBytes
+
+/-- The Phase-H view unfolded to the seven named children plus the pad, each
+    at its accumulated byte offset.  The offsets are stated as left-nested
+    sums exactly as the tiling produces them;
+    `children_offsets_match_regionMap` pins them to the audited
+    `RegionMap.dataUnionChildren` offsets. -/
+theorem phaseHView_children (base : Word) :
+    phaseHView base
+      = (anyBytes (base + BitVec.ofNat 64 0) S
+        ** (anyBytes (base + BitVec.ofNat 64 S) S
+        ** (anyBytes (base + BitVec.ofNat 64 (S + S)) L
+        ** (anyBytes (base + BitVec.ofNat 64 (S + S + L)) D
+        ** (anyBytes (base + BitVec.ofNat 64 (S + S + L + D)) P
+        ** (anyBytes (base + BitVec.ofNat 64 (S + S + L + D + P)) P
+        ** (anyBytes (base + BitVec.ofNat 64 (S + S + L + D + P + P)) P
+        ** anyBytes (base + BitVec.ofNat 64 (S + S + L + D + P + P + P))
+            unionPadBytes))))))) := by
+  show anyTilesAt base 0 phaseHSegs = _
+  rw [show phaseHSegs = [S, S, L, D, P, P, P, unionPadBytes] from rfl]
+  simp only [anyTilesAt, Nat.zero_add, sepConj_emp_right']
+
+/-- The accumulated offsets above are exactly the audited
+    `RegionMap.dataUnionChildren` offsets (and the pad starts at
+    `unionBytes`). -/
+theorem children_offsets_match_regionMap :
+    [0, S, S + S, S + S + L, S + S + L + D, S + S + L + D + P,
+        S + S + L + D + P + P]
+      = RegionMap.dataUnionChildren.map (·.off)
+    ∧ S + S + L + D + P + P + P = unionBytes := by
+  constructor <;> decide
+
+-- ============================================================================
+-- Phase transitions
+-- ============================================================================
+
+/-- **Phase-H → Phase-D handoff, from concrete buffers**: the seven child
+    buffers with WHATEVER contents Phase H left in them, plus the untouched
+    pad, assemble into the single arena resource Phase D owns.  Contents are
+    forgotten here — this hypothesis shape is all a `block_verdict`-level
+    composition needs at the dispatch boundary. -/
+theorem phaseH_to_phaseD (base : Word) (h : PartialState)
+    (bs₁ bs₂ bs₃ bs₄ bs₅ bs₆ bs₇ : List (BitVec 8))
+    (hl₁ : bs₁.length = S) (hl₂ : bs₂.length = S) (hl₃ : bs₃.length = L)
+    (hl₄ : bs₄.length = D) (hl₅ : bs₅.length = P) (hl₆ : bs₆.length = P)
+    (hl₇ : bs₇.length = P)
+    (hp : (bytesRegion (base + BitVec.ofNat 64 0) bs₁
+        ** (bytesRegion (base + BitVec.ofNat 64 S) bs₂
+        ** (bytesRegion (base + BitVec.ofNat 64 (S + S)) bs₃
+        ** (bytesRegion (base + BitVec.ofNat 64 (S + S + L)) bs₄
+        ** (bytesRegion (base + BitVec.ofNat 64 (S + S + L + D)) bs₅
+        ** (bytesRegion (base + BitVec.ofNat 64 (S + S + L + D + P)) bs₆
+        ** (bytesRegion (base + BitVec.ofNat 64 (S + S + L + D + P + P)) bs₇
+        ** anyBytes (base + BitVec.ofNat 64 (S + S + L + D + P + P + P))
+            unionPadBytes))))))) h) :
+    phaseDView base h := by
+  have w : ∀ (b : Word) (n : Nat) (bs : List (BitVec 8)), bs.length = n →
+      ∀ h', bytesRegion b bs h' → anyBytes b n h' :=
+    fun b n bs hl h' hx => hl ▸ bytesRegion_anyBytes b bs h' hx
+  rw [phaseD_eq_phaseH, phaseHView_children]
+  refine sepConj_mono_left (w _ _ _ hl₁) h (sepConj_mono_right (fun h₁ hx₁ => ?_) h hp)
+  refine sepConj_mono_left (w _ _ _ hl₂) h₁ (sepConj_mono_right (fun h₂ hx₂ => ?_) h₁ hx₁)
+  refine sepConj_mono_left (w _ _ _ hl₃) h₂ (sepConj_mono_right (fun h₃ hx₃ => ?_) h₂ hx₂)
+  refine sepConj_mono_left (w _ _ _ hl₄) h₃ (sepConj_mono_right (fun h₄ hx₄ => ?_) h₃ hx₃)
+  refine sepConj_mono_left (w _ _ _ hl₅) h₄ (sepConj_mono_right (fun h₅ hx₅ => ?_) h₄ hx₄)
+  refine sepConj_mono_left (w _ _ _ hl₆) h₅ (sepConj_mono_right (fun h₆ hx₆ => ?_) h₅ hx₅)
+  exact sepConj_mono_left (w _ _ _ hl₇) h₆ hx₆
+
+/-- **Phase-D → Phase-H re-entry** (stated for completeness; the guest's
+    phase order is H then D with no post-dispatch Phase-H reader — this
+    direction documents that even if one existed, it would receive its
+    buffers HAVOC'D, not with their old contents): the arena resource
+    re-partitions into the seven child tiles + pad, contents unspecified. -/
+theorem phaseD_to_phaseH (base : Word) (h : PartialState)
+    (hp : phaseDView base h) : phaseHView base h :=
+  (phaseD_eq_phaseH base) ▸ hp
+
+end CallFramePhase
+end EvmAsm.Codegen

--- a/EvmAsm/Rv64/SAsm/PhaseSplit.lean
+++ b/EvmAsm/Rv64/SAsm/PhaseSplit.lean
@@ -1,0 +1,201 @@
+/-
+  EvmAsm.Rv64.SAsm.PhaseSplit
+
+  Temporal (phase) re-partition of a shared byte arena — the generic half of
+  the `call_frame_arena` phase-ownership model (bead `evm-asm-4ch8f.6`, the
+  deferred hard half; the union inventory it instantiates is
+  `EvmAsm/Codegen/RegionMap.lean`, the instantiation itself
+  `EvmAsm/Codegen/CallFramePhase.lean`).
+
+  ## The model
+
+  A byte range that two execution phases use for different purposes is ONE
+  separation-logic resource, never two:
+
+  * `anyBytes base n` — ownership of the `n` bytes at `base` with
+    **unspecified contents** (the contents are existentially quantified).
+  * A *phase view* of the range is a tiling of that resource into
+    sub-ranges (`anyTilesAt`); `anyBytes_sum_eq_anyTilesAt` proves the whole
+    resource and any dword-tiling of it are THE SAME assertion.
+  * A phase transition is therefore just: weaken each concrete buffer to its
+    havoc form (`bytesRegion_anyBytes`), then re-associate through the tiling
+    equality.  Contents are FORGOTTEN at every transition **by
+    construction** — a later phase provably cannot depend on what an earlier
+    phase left in the shared bytes, because the only fact that crosses the
+    boundary is `anyBytes` (ownership + length, nothing else).
+  * On the consuming side, `cpsTripleWithin_anyBytes_pre` is the proof
+    obligation that discipline imposes: a routine framed against a havoc'd
+    range must be verified **for every possible contents** of that range.
+
+  Together these make the prose "phase-liveness" argument of
+  `docs/call-frame-memory-layout.md` §5 a checkable ownership discipline:
+  the seven Phase-H arenas and the Phase-D frame array can share bytes
+  soundly because at any point in the composed proof exactly one tiling of
+  the arena resource exists, and re-tiling havocs the contents.
+-/
+
+import EvmAsm.Rv64.SAsm.HandleWiden
+
+namespace EvmAsm.Rv64
+namespace SAsm
+
+-- ============================================================================
+-- Havoc'd byte-range ownership
+-- ============================================================================
+
+/-- Ownership of the `n` bytes at `base` with unspecified contents. -/
+def anyBytes (base : Word) (n : Nat) : Assertion :=
+  fun h => ∃ bs : List (BitVec 8), bs.length = n ∧ bytesRegion base bs h
+
+theorem pcFree_anyBytes (base : Word) (n : Nat) : (anyBytes base n).pcFree := by
+  rintro h ⟨bs, _, hb⟩
+  exact bytesRegion_pcFree base bs h hb
+
+/-- **The havoc weakening**: concrete contents are forgotten.  This is the
+    only way a buffer's ownership crosses a phase boundary. -/
+theorem bytesRegion_anyBytes (base : Word) (bs : List (BitVec 8))
+    (h : PartialState) (hb : bytesRegion base bs h) :
+    anyBytes base bs.length h :=
+  ⟨bs, rfl, hb⟩
+
+@[simp] theorem anyBytes_zero (base : Word) : anyBytes base 0 = empAssertion := by
+  funext h
+  apply propext
+  constructor
+  · rintro ⟨bs, hlen, hb⟩
+    rw [List.eq_nil_of_length_eq_zero hlen] at hb
+    simpa using hb
+  · intro h0
+    exact ⟨[], rfl, by simpa using h0⟩
+
+/-- Push a `+ ofNat` past a `+ ofNat` (addition modulo `2^64`, no side
+    conditions). -/
+theorem add_ofNat_ofNat (b : Word) (m k : Nat) :
+    (b + BitVec.ofNat 64 m) + BitVec.ofNat 64 k = b + BitVec.ofNat 64 (m + k) := by
+  rw [BitVec.add_assoc]
+  congr 1
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_add, BitVec.toNat_ofNat, BitVec.toNat_ofNat, BitVec.toNat_ofNat]
+  conv_rhs => rw [Nat.add_mod]
+
+/-- **Split/join a havoc'd range at a dword boundary**: the `m + k` bytes at
+    `base` are exactly the `m` bytes at `base` alongside the `k` bytes at
+    `base + m` (both havoc'd), provided the split point is dword-aligned. -/
+theorem anyBytes_add (base : Word) (m k : Nat) (h8 : 8 ∣ m) :
+    anyBytes base (m + k)
+      = (anyBytes base m ** anyBytes (base + BitVec.ofNat 64 m) k) := by
+  funext h
+  apply propext
+  constructor
+  · rintro ⟨bs, hlen, hb⟩
+    have htk : (bs.take m).length = m := by
+      rw [List.length_take]
+      omega
+    have hdr : (bs.drop m).length = k := by
+      rw [List.length_drop]
+      omega
+    rw [show bs = bs.take m ++ bs.drop m from (List.take_append_drop m bs).symm,
+      bytesRegion_append base _ _ (by rw [htk]; exact h8), htk] at hb
+    exact sepConj_mono_left (fun h' hx => ⟨bs.take m, htk, hx⟩) h
+      (sepConj_mono_right (fun h' hx => ⟨bs.drop m, hdr, hx⟩) h hb)
+  · rintro ⟨h1, h2, hd, hu, ⟨bs1, hl1, hb1⟩, ⟨bs2, hl2, hb2⟩⟩
+    refine ⟨bs1 ++ bs2, by rw [List.length_append]; omega, ?_⟩
+    rw [bytesRegion_append base bs1 bs2 (by rw [hl1]; exact h8), hl1]
+    exact ⟨h1, h2, hd, hu, hb1, hb2⟩
+
+-- ============================================================================
+-- Contiguous havoc'd tilings
+-- ============================================================================
+
+/-- Havoc'd tiles of the given sizes laid out contiguously from `base + off`,
+    with the running offset accumulated as a `Nat` sum — so the `j`-th tile's
+    assertion is literally `anyBytes (base + ofNat offⱼ) sizeⱼ` with `offⱼ`
+    a closed arithmetic term (matching e.g. the audited offsets of
+    `RegionMap.dataUnionChildren`). -/
+def anyTilesAt (base : Word) (off : Nat) : List Nat → Assertion
+  | [] => empAssertion
+  | n :: ns => anyBytes (base + BitVec.ofNat 64 off) n ** anyTilesAt base (off + n) ns
+
+theorem pcFree_anyTilesAt (base : Word) (off : Nat) (segs : List Nat) :
+    (anyTilesAt base off segs).pcFree := by
+  induction segs generalizing off with
+  | nil => exact pcFree_emp
+  | cons n ns ih => exact pcFree_sepConj (pcFree_anyBytes _ _) (ih _)
+
+/-- **The tiling equality**: a havoc'd range IS the separating conjunction of
+    any contiguous dword-aligned tiling of it.  Rewrite left-to-right to enter
+    a phase (hand each tile to its owner); right-to-left to leave it (collect
+    the tiles back into the arena resource).  Contents do not appear on either
+    side — crossing this equality havocs everything. -/
+theorem anyBytes_sum_eq_anyTilesAt (base : Word) (off : Nat) (segs : List Nat)
+    (h8 : ∀ s ∈ segs, 8 ∣ s) :
+    anyBytes (base + BitVec.ofNat 64 off) segs.sum = anyTilesAt base off segs := by
+  induction segs generalizing off with
+  | nil => exact anyBytes_zero _
+  | cons n ns ih =>
+      rw [List.sum_cons, anyBytes_add _ n ns.sum (h8 n (List.mem_cons_self ..)),
+        add_ofNat_ofNat,
+        ih (off + n) (fun s hs => h8 s (List.mem_cons_of_mem _ hs))]
+      rfl
+
+/-- The tiling equality at the range's own base (`off = 0`). -/
+theorem anyBytes_eq_anyTiles (base : Word) (segs : List Nat)
+    (h8 : ∀ s ∈ segs, 8 ∣ s) :
+    anyBytes base segs.sum = anyTilesAt base 0 segs := by
+  have h0 : base + BitVec.ofNat 64 0 = base := by
+    rw [show BitVec.ofNat 64 0 = (0 : Word) from rfl]
+    simp
+  rw [← anyBytes_sum_eq_anyTilesAt base 0 segs h8, h0]
+
+-- ============================================================================
+-- The proof obligation havoc imposes on consumers
+-- ============================================================================
+
+/-- **A routine framed against a havoc'd range must be verified for every
+    possible contents.**  This is the checkable form of "Phase D cannot
+    assume anything Phase H left in the shared bytes": to prove a triple
+    whose precondition owns `anyBytes b len`, exhibit the triple for every
+    concrete contents `bs` of that length. -/
+theorem cpsTripleWithin_anyBytes_pre {n : Nat} {entry exit_ : Word}
+    {cr : CodeReq} {P Q : Assertion} {b : Word} {len : Nat}
+    (h : ∀ bs : List (BitVec 8), bs.length = len →
+      cpsTripleWithin n entry exit_ cr (P ** bytesRegion b bs) Q) :
+    cpsTripleWithin n entry exit_ cr (P ** anyBytes b len) Q := by
+  intro R hR s hcr hPR hpc
+  obtain ⟨hp, hcompat, h1, h2, hd, hu,
+    ⟨h11, h12, hd', hu', hP, ⟨bs, hlen, hbs⟩⟩, hR2⟩ := hPR
+  exact h bs hlen R hR s hcr
+    ⟨hp, hcompat, h1, h2, hd, hu, ⟨h11, h12, hd', hu', hP, hbs⟩, hR2⟩ hpc
+
+/-- Demo of the obligation in action: an `LBU` from a havoc'd range admits
+    only an **existential** result — the strongest provable postcondition
+    says "some byte", never a particular value.  A hypothetical Phase-D
+    routine trying to read back what Phase H stored is exactly this triple,
+    and this is all it can ever prove. -/
+example (rd rs1 : Reg) (regionBase vOld base : Word) (n : Nat)
+    (hrd : rd ≠ .x0) (hn : 0 < n)
+    (halign : regionBase.toNat % 8 = 0)
+    (hover : regionBase.toNat + 0 < 2 ^ 64)
+    (hvalid : isValidByteAccess (regionBase + BitVec.ofNat 64 0) = true) :
+    cpsTripleWithin 1 base (base + 4) (CodeReq.singleton base (.LBU rd rs1 0))
+      (((rs1 ↦ᵣ (regionBase + BitVec.ofNat 64 0)) ** (rd ↦ᵣ vOld))
+        ** anyBytes regionBase n)
+      (fun h => ∃ b : BitVec 8,
+        ((((rs1 ↦ᵣ (regionBase + BitVec.ofNat 64 0))
+          ** (rd ↦ᵣ (b.zeroExtend 64))) ** anyBytes regionBase n) h)) := by
+  apply cpsTripleWithin_anyBytes_pre
+  intro bs hlen
+  have hi : 0 < bs.length := by omega
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) ?_
+    (bytesRegion_lbu_within rd rs1 regionBase vOld base bs 0 hrd halign hi
+      hover hvalid)
+  intro h' hp
+  refine ⟨bs[0]'hi, ?_⟩
+  have hp' : (((rs1 ↦ᵣ (regionBase + BitVec.ofNat 64 0))
+      ** (rd ↦ᵣ ((bs[0]'hi).zeroExtend 64))) ** bytesRegion regionBase bs) h' := by
+    xperm_hyp hp
+  exact sepConj_mono_right
+    (fun h'' hx => hlen ▸ bytesRegion_anyBytes regionBase bs h'' hx) h' hp'
+
+end SAsm
+end EvmAsm.Rv64

--- a/PLAN.md
+++ b/PLAN.md
@@ -2538,8 +2538,17 @@ kernel-reducible powMod inversion, BN254+BLS12-381 curve+Fp2) — all
 with independently-generated kernel decide KATs; execCsrs is
 definitionally ONE writeWords (csrsWrite computes target+payload), so
 projection lemmas are branch-count-independent; SAsm block exposure
-deferred to beads .17/.18 (design §3.3.1). Next for SAsm: more
-Stateless/SSZ ports. Assertion-state milestone started (approved plan
+deferred to beads .17/.18 (design §3.3.1). Phase-ownership model for the
+`call_frame_arena` union landed (bead evm-asm-4ch8f.6 hard half,
+`SAsm/PhaseSplit.lean` + `Codegen/CallFramePhase.lean`): the aliased
+arena is ONE havoc'd resource (`anyBytes`), the Phase-H
+seven-children+pad tiling is THE SAME assertion
+(`phaseD_eq_phaseH`/`phaseHView_children` at the audited RegionMap
+offsets), transitions forget contents by construction
+(`bytesRegion_anyBytes`, `phaseH_to_phaseD`), and consumers of a
+havoc'd range must verify for all contents
+(`cpsTripleWithin_anyBytes_pre`, LBU demo) — design §3.9. Next for
+SAsm: more Stateless/SSZ ports. Assertion-state milestone started (approved plan
 ~/.claude/plans/federated-wandering-pudding.md; epic evm-asm-6dt3v):
 Stages 1+2a landed — `Reach := RegFile → List Byte → Assertion → Prop`
 threads an ambient (pc-free) separation-logic assertion through the

--- a/docs/4ch8f-region-map.md
+++ b/docs/4ch8f-region-map.md
@@ -226,6 +226,22 @@ This overlap inventory (`aliasedPairs` + the `_overlap` theorems + the mutual
 disjointness of the children) is that proof's input: it fixes *which* bytes are
 shared and *over what ranges*, leaving only the temporal-exclusion argument.
 
+> **STATUS — DELIVERED.** The phase-ownership model landed as
+> `EvmAsm/Rv64/SAsm/PhaseSplit.lean` (generic havoc'd-ownership machinery:
+> `anyBytes`, tiling equalities, `cpsTripleWithin_anyBytes_pre`) +
+> `EvmAsm/Codegen/CallFramePhase.lean` (the union instantiation:
+> `phaseD_eq_phaseH`, `phaseHView_children`, `phaseH_to_phaseD`). Design
+> write-up: `docs/sasm-design.md` §3.9. Items 1–3 above are realized as an
+> *ownership* discipline rather than a control-flow analysis: the arena is
+> ONE resource; exactly one phase's tiling of it exists in the ambient at
+> any point of the composed proof; transitions forget contents by
+> construction, so a stale reader receives havoc'd buffers (item 3's "loud
+> break" = its triple becomes unprovable for want of the child view).
+> Item 2's temporal claim is discharged per-routine as the `.41`–`.48` /
+> `.49`/`.56` triples land and `.61` composes them — the model makes the
+> unsound interleavings unexpressible rather than proving the current
+> binary avoids them.
+
 ---
 
 ## 5. Drift handling

--- a/docs/sasm-design.md
+++ b/docs/sasm-design.md
@@ -600,6 +600,50 @@ Implementation constraints (robustness / recursion-safety):
   (label + statement, ✓/✗ after the default pass) without leaving goals,
   for the agentic explore loop.
 
+### 3.9 Phase ownership of aliased arenas (`SAsm/PhaseSplit.lean`, `Codegen/CallFramePhase.lean`)
+
+The guest has exactly one intentional physical aliasing:
+`call_frame_arena` (~164 MiB, the Phase-D EVM call-frame overlay) coalesces
+seven execution-dead Phase-H arenas into its front
+(`RegionMap.dataUnionChildren`; `docs/call-frame-memory-layout.md` §5).
+Framing the arena and a coalesced child as two separate regions in one
+ambient would be **unsound** (`**` would claim disjoint ownership of the
+same bytes), and until this section the no-corruption argument was prose.
+
+The model (bead `evm-asm-4ch8f.6`, hard half):
+
+- **One resource, many tilings.** `anyBytes base n` owns `n` bytes with
+  *unspecified contents*.  `anyBytes_add`/`anyBytes_eq_anyTiles` prove a
+  havoc'd range equal to any contiguous dword-aligned tiling of itself.
+  `CallFramePhase.phaseD_eq_phaseH` instantiates this on the audited union
+  inventory: the whole-arena view (`phaseDView`) and the
+  seven-children-plus-pad view (`phaseHView`) are the *same assertion*.
+- **Transitions forget contents.** A phase transition is one rewrite across
+  that equality, entered by weakening concrete buffers through
+  `bytesRegion_anyBytes` (`phaseH_to_phaseD` packages the seven-buffer
+  handoff).  `anyBytes` carries ownership and length, nothing else — so a
+  later phase provably cannot depend on what an earlier phase left in the
+  shared bytes, and a stale reader after re-partition receives havoc'd
+  buffers, not its old data.  The failure mode the prose worried about is
+  structurally unexpressible in a composed proof that frames the arena
+  through these views.
+- **Consumer obligation.** `cpsTripleWithin_anyBytes_pre`: a triple whose
+  precondition owns a havoc'd range must be proven *for every possible
+  contents* (demo in `PhaseSplit.lean`: an `LBU` from `anyBytes` admits
+  only an existential postcondition).
+- **Who uses what.** Phase-H routines (`.41`–`.48`) frame individual child
+  ranges (`phaseHView_children` names each child at its audited offset);
+  Phase-D dispatch (`.49`, `.56`) frames `phaseDView`; the `block_verdict`
+  composition (`.61`) performs the single H→D rewrite at the dispatch
+  boundary.  The arena base stays a parameter — the model is
+  link-layout-independent; `RegionMap.callFrameArenaBase` pins this build.
+
+What the model does **not** decide: *when* the guest transitions — that
+Phase H truly stops touching the children before dispatch is what the
+per-routine triples + the composition prove (a Phase-H routine cannot be
+composed after the rewrite, because the child views it frames against no
+longer exist in the ambient).
+
 ## 4. What this buys for `run_stateless_guest`
 
 - The existing SSZ decode/encode routines in `Stateless/SSZ/*/Program.lean`


### PR DESCRIPTION
The **hard half of bead `evm-asm-4ch8f.6`**: the `call_frame_arena` union's no-corruption argument, until now a prose phase-liveness claim (`docs/call-frame-memory-layout.md` §5, `CallFrameLayout.lean:99-120`), becomes a verified ownership discipline. Consumes the merged #9715 inventory (`RegionMap.dataUnionChildren`, the collision facts) as its input.

## The model

The aliased arena is **one separation-logic resource, never two**:

- **`SAsm/PhaseSplit.lean`** (generic machinery): `anyBytes base n` = ownership of `n` bytes with *unspecified contents* (existentially quantified). `anyBytes_add` / `anyBytes_eq_anyTiles`: a havoc'd range **equals** any contiguous dword-aligned tiling of itself. `bytesRegion_anyBytes`: the contents-forgetting weakening — the only way buffer ownership crosses a phase boundary. `cpsTripleWithin_anyBytes_pre`: a triple whose pre owns a havoc'd range must be proven **for every possible contents**; the in-file demo shows an `LBU` from `anyBytes` admits only an existential postcondition.
- **`Codegen/CallFramePhase.lean`** (union instantiation): `phaseDView base` (whole arena, havoc'd) and `phaseHView base` (seven children + pad, each havoc'd) are **the same assertion** — `phaseD_eq_phaseH`. `phaseHView_children` unfolds the view to the seven named children at their accumulated offsets, and `children_offsets_match_regionMap` pins those offsets to the audited `RegionMap.dataUnionChildren` values by kernel `decide`. `phaseH_to_phaseD` packages the dispatch-boundary handoff from concrete Phase-H buffers (any contents).

## Why this discharges the soundness worry

A phase transition is one rewrite across `phaseD_eq_phaseH`, entered by weakening concrete buffers to havoc form. Both sides carry ownership + length, nothing else, so:

- Phase D **provably cannot assume** anything Phase H wrote (its triples must hold for all contents — `cpsTripleWithin_anyBytes_pre`);
- a hypothetical post-dispatch Phase-H reader gets havoc'd buffers, not stale data — its old-content triple is **unprovable**, not merely untested;
- framing a child and the arena simultaneously is impossible (only one tiling of the resource exists in the ambient at any point of a composed proof).

The prose's feared interleavings become *unexpressible* rather than unobserved. The temporal claim itself ("Phase H stops before dispatch") is discharged per-routine as the `.41`–`.48` (Phase H) / `.49`,`.56` (Phase D) triples land and `.61` composes them with the single H→D rewrite.

The arena base stays a parameter — the model is link-layout-independent; `RegionMap.callFrameArenaBase` pins this build's address (drift-guarded by `check-region-map.sh`, unchanged here).

## Gates

- Full `lake build` green (3745 jobs); forbidden-tactics / file-size / unimported all pass.
- All new theorems classical-axioms-only (`propext`/`Classical.choice`/`Quot.sound`; several axiom-free) — verified with `#print axioms`.
- No `sorry`, no `native_decide`/`bv_decide`; the two big-Nat `decide`s (`unionBytes_le_arena`, `phaseHSegs_sum`) are concrete-arithmetic kernel computations.

Docs: `docs/sasm-design.md` §3.9 (design + who-uses-what per routine bead), status note in `docs/4ch8f-region-map.md` §4, PLAN.md.

With this, bead `.6` is complete: #9715 (mechanical half, merged) + this PR (phase-ownership half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)