### PR TITLE
fix(eest): overwrite transfer-log receipt gas

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictExactGas.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictExactGas.lean
@@ -301,7 +301,7 @@ def blockVerdictExactGasCheck : String :=
   "  la t0, eip7708_tl_typed_avail; ld t1, 0(t0); beqz t1, .Lbv_exact_wip_header_regular_receipt_store\n" ++
   "  li t4, 4800; bltu t2, t4, .Lbv_exact_wip_header_skip_receipt_store\n" ++
   "  sub t4, t2, t4\n" ++
-  "  la t0, bvgr_receipt_gas_increments; ld t1, 0(t0); bgeu t1, t4, .Lbv_exact_wip_header_skip_receipt_store\n" ++
+  "  la t0, bvgr_receipt_gas_increments\n" ++
   "  sd t4, 0(t0)\n" ++
   "  j .Lbv_exact_wip_header_skip_receipt_store\n" ++
   ".Lbv_exact_wip_header_regular_receipt_store:\n" ++


### PR DESCRIPTION
## Summary
- overwrite the WIP transfer-log receipt gas increment with header gas minus the 4800 transfer-log delta
- fixes the case where an already-recorded receipt increment is higher than the reconciled transfer-log receipt gas

## Verification
- lake build EvmAsm.Codegen.Programs.BlockVerdict
- earlier focused ziskemu run after this fix moved precomps_eip2929 yes100 receipt cumulative gas from 55763 to 51163; remaining failure is still receipt-root/log encoding (bv_fail=53)