### PR TITLE
fix(eest): reject create at running max nonce

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
@@ -199,6 +199,7 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     "  la x18, create_nonce\n" ++
     "  sd a0, 0(x18)\n" ++
     "  mv x10, s10\n" ++
+    "  la x18, create_nonce; ld x19, 0(x18); li x18, -1; beq x19, x18, 7f\n" ++
     (if hasSalt then
       -- Convert the CREATE2 salt stack word to canonical 32-byte big-endian.
       "  la x18, create_salt_be\n" ++

--- a/EvmAsm/Codegen/Programs/CreateCreatorNonce.lean
+++ b/EvmAsm/Codegen/Programs/CreateCreatorNonce.lean
@@ -64,6 +64,7 @@ def createCreatorNonceUseFunction : String :=
   "  addi t2, t2, 1; j .Lccnu_loop\n" ++
   ".Lccnu_found:\n" ++
   "  ld a0, 32(t3)               # ret = entry.nonce\n" ++
+  "  li t4, -1; beq a0, t4, .Lccnu_ret  # max nonce: CREATE must fail; do not wrap table\n" ++
   "  addi t4, a0, 1; sd t4, 32(t3)   # entry.nonce += 1\n" ++
   "  j .Lccnu_ret\n" ++
   ".Lccnu_new:\n" ++


### PR DESCRIPTION
## Summary
- prevent the per-creator CREATE nonce table from wrapping after it reaches uint64 max
- reject CREATE/CREATE2 when the running nonce returned by the table is max, matching execution-specs generic_create

## Verification
- lake build EvmAsm.Codegen.Programs.BlockVerdict
- EEST_BACKEND=spike scripts/codegen-eest-stateless-check.sh --backend spike --filter stCreate2 --all --skip 26 --limit 1 --jobs 1 --max-jobs 1 --steps 1000000000 --max-failures 1 --quiet-passes --run-dir gen-out/eest-run/codex-bv34-highnonce-running-nonce-target2
  - advanced through 49 full matches after the previous failing high-nonce row
  - next remaining independent failure: create2_smart_init_code bv_fail=53 at rerun_skip=75
