### PR TITLE
fix(eest): reemit staged transfer logs

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -2626,6 +2626,7 @@ def emitRuntimeDispatcherCallablePrologue (depthAwareStop : Bool := false) : Str
   "  la x5, runtime_dispatcher_caller_sp\n" ++
   "  sd sp, 0(x5)\n" ++
   emitRuntimeDispatcherCallableSetup ++ "\n" ++
+  "  jal ra, dispatcher_reemit_pending_tl\n" ++
   emitTxAccessListSeedLoop ++ "\n" ++
   emitTxAuthListWarmLoop ++ "\n" ++
   emitCalleeStorageSeedLoop ++ "\n" ++


### PR DESCRIPTION
## Summary
- replay staged EIP-7708 top-level transfer logs after dispatcher setup resets the runtime log arena
- keep access-list and callee-storage seeding after the replay so normal dispatcher initialization still runs

## Validation
- lake build EvmAsm.Codegen.Programs.BlockVerdict

## Notes
- GitHub currently reports #9760 as open, so this is stacked on fix/eest-memory-oog-receipts rather than origin/main.
- This is a partial EEST receipt fix; stMemoryTest/buffer still has a receipt-root mismatch that needs follow-up investigation.