### PR TITLE
fix(stateless): GuestFraming synthesis for the top-level spec (4ch8f.8 follow-up)

### DIFF
--- a/EvmAsm/Stateless/EntrySpec.lean
+++ b/EvmAsm/Stateless/EntrySpec.lean
@@ -4,7 +4,7 @@
   The top-level specification SHAPE for the verified stateless guest
   (bead evm-asm-4ch8f.8). Decision record: docs/4ch8f-top-spec.md.
 
-  The headline Prop is `runStatelessGuestSound cr fuel work execute`:
+  The headline Prop is `runStatelessGuestSound cr fuel fr execute`:
 
     for every host-supplied input (≤ `MAX_INPUT_BYTES`), starting at the
     guest ELF entry with the input framed at `INPUT_ADDR` and owning the
@@ -21,8 +21,11 @@
       composes it from the wave-.9 `Program` conversions).
     * `fuel : Nat`     — the step budget (a gas-derived static cap in the
       `.5` `whileS` style; wrong cap ⇒ unprovable, never unsound).
-    * `work : Assertion` — ownership of the guest's scratch/work regions
-      (bead .6 phase views over `RegionMap`; bead .63 fixes the bundle).
+    * `fr : GuestFraming` — ownership of the guest's scratch/work regions
+      at entry (`fr.scratch`, bead .6 phase views over `RegionMap`; bead
+      .63 fixes the bundle) and the residue left at halt (`fr.residue`).
+      `fr.scratch_sat` is the non-vacuity witness: an unsatisfiable
+      scratch would make the halt triple hold trivially.
     * `execute : SpecRef.ExecutionSeam` — the Lean model of
       `execute_new_payload_request` (bead .10's interpreter model closes
       this seam; until then the Prop is stated against the seam
@@ -127,23 +130,53 @@ def guestOutputSound (execute : ExecutionSeam) (input : Bytes) : Assertion :=
     bytesRegion OUTPUT_ADDR out h ∧
     (out.getD 32 0 = 1 → SpecAccepts execute input (out.take 32))
 
+/-! ## The framing bundle -/
+
+/-- The guest's working-state framing (decision record §3, revised after
+    the #9733/#9734 cross-review):
+
+    * `scratch` — the resources the guest owns at entry beyond the input
+      record (working RAM, the OUTPUT window, the stack, …; bead .63
+      instantiates it from the RegionMap phase views).
+    * `residue` — whatever those resources have become at halt. Without
+      this slot the halt triple is UNPROVABLE: the postcondition heap
+      must account for every resource owned at entry, and the soundness
+      claim alone owns only the 40-byte observation window.
+    * `scratch_sat` — the non-vacuity witness (from #9734): a
+      `cpsHaltTripleWithin` with an unsatisfiable precondition holds
+      trivially, so a framing must come with evidence that the
+      precondition is inhabited for every admissible input.
+
+    Note the OUTPUT observation window is deliberately NOT allowed to
+    hide in `residue`: `guestOutputSound` pins `out.length` to the fixed
+    window size, so its `bytesRegion OUTPUT_ADDR out` conjunct must own
+    the window dwords in the postcondition split, and `out` is therefore
+    uniquely the memory content the verifier reads (this closes the
+    ∃-out vacuity hole found in #9734's decode-based variant). -/
+structure GuestFraming where
+  scratch : Assertion
+  residue : Assertion
+  scratch_sat : ∀ input : Bytes, input.length ≤ MAX_INPUT_BYTES →
+    ∃ h, (guestInputAssertion input ** scratch) h
+
 /-! ## The top-level Props -/
 
 /-- **The headline statement shape** (soundness + termination): for every
     host input within the size bound, the guest — running from the ELF
-    entry with the input framed and the work regions owned — halts within
-    `fuel` steps in a state whose output window is a sound claim.
+    entry with the input framed and `fr.scratch` owned — halts within
+    `fuel` steps in a state that splits into the sound 40-byte
+    observation window and `fr.residue`.
 
-    Bead `.64` proves this for the concrete `(cr, fuel, work, execute)`
+    Bead `.64` proves this for the concrete `(cr, fuel, fr, execute)`
     quadruple: the guest-image `CodeReq` (bead .63), the gas-derived step
-    cap, the `.6`-style work-region bundle, and the `.10` interpreter
-    model closing the execution seam. -/
-def runStatelessGuestSound (cr : CodeReq) (fuel : Nat) (work : Assertion)
+    cap, the `.6`-style framing bundle (with its satisfiability witness),
+    and the `.10` interpreter model closing the execution seam. -/
+def runStatelessGuestSound (cr : CodeReq) (fuel : Nat) (fr : GuestFraming)
     (execute : ExecutionSeam) : Prop :=
   ∀ input : Bytes, input.length ≤ MAX_INPUT_BYTES →
     cpsHaltTripleWithin fuel GUEST_ENTRY cr
-      (guestInputAssertion input ** work)
-      (guestOutputSound execute input)
+      (guestInputAssertion input ** fr.scratch)
+      (guestOutputSound execute input ** fr.residue)
 
 /-- The two-sided fidelity Prop (stated, NOT a `.64` v1 goal): on every
     deserializable input the guest's full output equals the spec's
@@ -152,14 +185,24 @@ def runStatelessGuestSound (cr : CodeReq) (fuel : Nat) (work : Assertion)
     requires the exact chain-config echo produced by
     `SSZ.Encode.serialize_stateless_output` to match the SpecRef
     serializer — tracked as a `.64` follow-up. -/
-def runStatelessGuestFaithful (cr : CodeReq) (fuel : Nat) (work : Assertion)
+def runStatelessGuestFaithful (cr : CodeReq) (fuel : Nat) (fr : GuestFraming)
     (execute : ExecutionSeam) : Prop :=
   ∀ input si, input.length ≤ MAX_INPUT_BYTES →
     deserialize_stateless_input input = .ok si →
     cpsHaltTripleWithin fuel GUEST_ENTRY cr
-      (guestInputAssertion input ** work)
+      (guestInputAssertion input ** fr.scratch)
       (bytesRegion OUTPUT_ADDR
-        (serialize_stateless_output (verify_stateless_new_payload si execute)))
+        (serialize_stateless_output (verify_stateless_new_payload si execute))
+        ** fr.residue)
+
+/- Fidelity refines soundness pointwise on the halt heap: a byte-exact
+   output window satisfies the sound-claim window (the serialized
+   result's first 40 bytes are the observation, and its claim clause
+   holds because the spec result IS the source of the bytes) — recorded
+   here as the reason `.64` v1 can target `runStatelessGuestSound`
+   without losing the upgrade path. Proving the implication between the
+   two Props needs `serialize` length facts and belongs to the `.64`
+   follow-up, not the statement layer. -/
 
 /-! ## Kernel-checked layout pins
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2578,7 +2578,12 @@ window is a sound claim (`OUTPUT[32]=1 → SpecAccepts`: deserializes +
 soundness-only for .64 v1, `runStatelessGuestFaithful` (byte-exact
 output) stated as the deferred two-sided form; execution seam stays a
 parameter until .10's `elExecute`; kernel-checked `#guard` pins tie
-OUTPUT[0..32)/OUTPUT[32] to the SpecRef SSZ encoder. Next for
+OUTPUT[0..32)/OUTPUT[32] to the SpecRef SSZ encoder. REVISED post
+#9733/#9734 cross-review: `GuestFraming` (scratch/residue +
+`scratch_sat` non-vacuity witness) replaces the bare `work` parameter —
+residue gives entry-owned resources a home at halt (original form was
+unprovable), while the pinned 40-byte window blocks the ∃-out
+decode-vacuity hole of the #9734 variant (record §3a). Next for
 SAsm: more Stateless/SSZ ports. Assertion-state milestone started (approved plan
 ~/.claude/plans/federated-wandering-pudding.md; epic evm-asm-6dt3v):
 Stages 1+2a landed — `Reach := RegFile → List Byte → Assertion → Prop`

--- a/docs/4ch8f-top-spec.md
+++ b/docs/4ch8f-top-spec.md
@@ -66,7 +66,8 @@ the verdict — the entire guest body.
 ## 3. Statement shape (decision)
 
 `cpsHaltTripleWithin fuel GUEST_ENTRY cr (input ** work) (sound-output)`,
-wrapped as a plain `Prop` parameterized over `(cr, fuel, work, execute)`.
+wrapped as a plain `Prop` parameterized over `(cr, fuel, fr, execute)`
+(`fr : GuestFraming` — the scratch/residue bundle, see §3a).
 
 - **Why `cpsHaltTripleWithin`** (not `cpsTripleWithin` to an exit pc):
   the guest ends in a halt ecall, not a return; the halt triple
@@ -103,6 +104,33 @@ Rejected alternatives:
   put the EVM inside the trusted base; instead the seam stays a
   parameter until `.10` supplies the model (§4).
 
+## 3a. The framing bundle (post-review revision, PRs #9733/#9734)
+
+Bead `.8` was executed twice in parallel (#9733 and #9734); the
+cross-review found one defect in each statement, and the landed form is
+the synthesis:
+
+- **#9733 defect (this record's original form): no residue slot.** The
+  postcondition owned only the 40-byte observation window, but the
+  precondition owned all scratch — a `cpsHaltTripleWithin` must account
+  for every entry-owned resource in its post, so the triple was
+  *unprovable*. Fix: `GuestFraming.residue` joins the post
+  (`guestOutputSound … ** fr.residue`).
+- **#9734 defect: ∃-out vacuity.** Its post was `∃ out,
+  outputBytesAt out ** ⌜sound⌝ ** residue` with the claim judged by a
+  self-delimiting SSZ decode and no length pin. The prover chooses
+  `out`: `out = []` lets the residue absorb the OUTPUT window, and any
+  over-long `out` fails the exact-length decode — both make the claim
+  vacuous even on accept runs. Fix kept from #9733: `out.length =
+  OUTPUT_CLAIM_BYTES` is pinned *inside* the post, so the
+  `bytesRegion OUTPUT_ADDR out` conjunct must own the window dwords and
+  `out` is uniquely the memory the verifier reads.
+- **Kept from #9734**: `GuestFraming.scratch_sat` — the satisfiability
+  witness that rules out discharging the triple with an unsatisfiable
+  scratch assertion; and the framing of the input meta dwords stays
+  *unconstrained* (asserting them zero, as #9734 did, would make the
+  theorem inapplicable to hosts that write nonzero ZisK meta).
+
 ## 4. Closing the execution seam (interface to `.10`)
 
 `SpecRef.verify_stateless_new_payload` takes
@@ -136,8 +164,8 @@ txs, EVM) — call it `elExecute`. Then:
 
 ## 6. Obligations this creates downstream
 
-- **`.63` (shell)**: compose the image `CodeReq`; fix the `work` bundle
-  (RegionMap-derived, `.6` phase views); prove the verdict stamp writes
+- **`.63` (shell)**: compose the image `CodeReq`; fix the `GuestFraming`
+  bundle (RegionMap-derived, `.6` phase views + the `scratch_sat` witness); prove the verdict stamp writes
   `OUTPUT[32] = 1` only on the all-pass path and that no bail marker or
   reason code writes 1 there (reason codes land at `OUTPUT[32..40)` —
   audit the encoding); reconcile/retire the legacy `Stateless.Entry`

--- a/docs/agents/top-theorem-ledger.md
+++ b/docs/agents/top-theorem-ledger.md
@@ -12,11 +12,11 @@ alternatives, review synthesis of PRs #9733/#9734 — is
 **docs/4ch8f-top-spec.md**.
 
 ```
-runStatelessGuestSound cr fuel work execute :
+runStatelessGuestSound cr fuel fr execute :
   ∀ input, input.length ≤ MAX_INPUT_BYTES →
     cpsHaltTripleWithin fuel GUEST_ENTRY cr
-      (guestInputAssertion input ** work)
-      (guestOutputSound execute input)
+      (guestInputAssertion input ** fr.scratch)
+      (guestOutputSound execute input ** fr.residue)
 ```
 
 - **One-sided, pinned observation window**: `guestOutputSound` = "the 40-byte
@@ -31,12 +31,15 @@ runStatelessGuestSound cr fuel work execute :
   serialized result, byte-for-byte) is stated but a declared NON-goal for
   `.64` v1 (decision record §1).
 - **Non-vacuity**: kernel `#guard`s pin the flag/root offsets to the SpecRef
-  encoder and witness `SpecAccepts` end-to-end on the sanity pipeline.
+  encoder and witness `SpecAccepts` end-to-end on the sanity pipeline; the
+  `GuestFraming.scratch_sat` witness rules out an unsatisfiable-precondition
+  discharge, and `fr.residue` gives the entry-owned resources a home at halt
+  (without it the triple is unprovable — #9733 review defect, fixed).
 - **Seam**: parameter `execute : ExecutionSeam` — the `.10` interpreter model
   closes it.
 
 The final theorem (bead `evm-asm-4ch8f.64`) instantiates the
-`(cr, fuel, work, execute)` quadruple: the COMPOSED guest image `CodeReq`
+`(cr, fuel, fr, execute)` quadruple: the COMPOSED guest image `CodeReq`
 (bead .63, from the wave-.9 conversions — today's `Entry.run_stateless_guest`
 is still the PR6 stub), the gas-derived step cap, the `.6` work-region
 bundle, and the real seam.


### PR DESCRIPTION
The promised #9733/#9734 cross-review synthesis, applied to the landed statement (main kept #9733's `EntrySpec.lean`; #9734 contributed the toolchain).

## What changes

**`GuestFraming` replaces the bare `work : Assertion` parameter** in `runStatelessGuestSound`/`runStatelessGuestFaithful`:

- `residue` joins the postcondition (`guestOutputSound … ** fr.residue`). **This fixes a real defect in the merged statement (#9733's):** the post owned only the 40-byte observation window while the pre owned all scratch — a `cpsHaltTripleWithin` must account for every entry-owned resource at halt, so the `.64` triple was *unprovable as stated*.
- `scratch_sat` (adopted from #9734) — the non-vacuity witness: an unsatisfiable scratch assertion would make the halt triple hold trivially; `.63` must ship the witness along with the bundle.
- **Kept from #9733, deliberately:** the pinned 40-byte observation window (`out.length = OUTPUT_CLAIM_BYTES` inside the post). With the length pinned, the `bytesRegion OUTPUT_ADDR out` conjunct must own the window dwords in the post split — `out` is uniquely the memory the verifier reads, and `fr.residue` cannot absorb the window. This is what blocks the ∃-out decode-vacuity hole found in #9734's variant (prover picks `out = []` or an over-long undecodable `out` ⇒ claim vacuous even on accept runs).
- Input meta dwords stay **unconstrained** (asserting them zero would make the theorem inapplicable to hosts writing nonzero ZisK meta).

## Records updated

- `docs/4ch8f-top-spec.md` **new §3a** — both defects + fixes, so the reasoning survives the PR threads.
- `docs/agents/top-theorem-ledger.md` statement block + non-vacuity bullet updated to the `(cr, fuel, fr, execute)` signature.
- PLAN.md `.8` entry notes the revision.

## Gates

Full `lake build` green (3775 jobs); all `#guard` pins unchanged; statement-layer only (defs/Props, no theorems, no `sorry`). CI covers the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)