### PR TITLE
docs(agents): 4ch8f roadmap + review playbook for lower-capability executors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,6 +365,15 @@ merged into a feature branch, not `main`). All three had to be reopened.
 Detailed material has been split out of this file to keep the agent guide compact. **Load each
 doc only when its trigger applies** — they are reference material, not required reading.
 
+- [`docs/agents/roadmap-4ch8f.md`](docs/agents/roadmap-4ch8f.md) — the epic's master map:
+  layer DAG + pick-next rules, recipe-by-routine-shape table, the gate matrix (what CI runs
+  vs what you must run per change type), non-negotiable conventions, the family-bead
+  decomposition pattern, and the session-knowledge index ("where the bodies are buried").
+  **Load when:** starting ANY 4ch8f bead, or unsure what to pick up next.
+- [`docs/agents/review-playbook.md`](docs/agents/review-playbook.md) — how to review a PR
+  here: per-PR-type gate checklists (the ones CI does NOT run), the adversarial
+  statement-reading checklist, and the known-hole catalog (every entry was a real defect
+  caught in review). **Load when:** reviewing any PR.
 - [`docs/agents/port-playbook.md`](docs/agents/port-playbook.md) — THE entry point for
   verifying one guest routine end-to-end: class decision table → exemplar → recipe →
   acceptance (`scripts/port-check.sh`, `scripts/gen-port-kit.py` scaffolds).

--- a/PLAN.md
+++ b/PLAN.md
@@ -2597,7 +2597,14 @@ OUTPUT[0..32)/OUTPUT[32] to the SpecRef SSZ encoder. REVISED post
 residue gives entry-owned resources a home at halt (original form was
 unprovable), while the pinned 40-byte window blocks the ∃-out
 decode-vacuity hole of the #9734 variant (record §3a). Next for
-SAsm: more Stateless/SSZ ports. Assertion-state milestone started (approved plan
+SAsm: more Stateless/SSZ ports. AGENT-HANDOFF layer landed (bead epic
+4ch8f): docs/agents/roadmap-4ch8f.md (layer DAG, pick-next rules,
+recipe-by-shape table, gate matrix per change type, decomposition
+pattern) + docs/agents/review-playbook.md (per-PR-type gates CI doesn't
+run, adversarial statement checklist, known-hole catalog) are the entry
+points for ALL future 4ch8f sessions at any capability tier; one-session
+port children exist under .12-.16/.20/.22-.24/.26, composition beads
+carry plan notes, remaining families carry DECOMPOSE FIRST notes. Assertion-state milestone started (approved plan
 ~/.claude/plans/federated-wandering-pudding.md; epic evm-asm-6dt3v):
 Stages 1+2a landed — `Reach := RegFile → List Byte → Assertion → Prop`
 threads an ambient (pc-free) separation-logic assertion through the

--- a/docs/agents/review-playbook.md
+++ b/docs/agents/review-playbook.md
@@ -1,0 +1,133 @@
+# Review playbook — how to review a 4ch8f PR
+
+**Audience**: the agent reviewing any PR in this repo. The review's job is NOT
+to re-run CI (it runs build, tactic/TCB scans, axiom audit of registered
+witnesses, layering, region-map, etc. — full list in
+`docs/agents/roadmap-4ch8f.md` §3). The review's job is (a) the gates CI does
+not run, and (b) **adversarial reading of statements** — every hole listed in
+§3 below was found in review, in this repo, after the author believed the work
+was done.
+
+## 1. Per-PR-type checklist (gates CI does not run)
+
+**Lean-proof PR** (new specs/theorems):
+1. `#print axioms <FULLY.QUALIFIED.name>` yourself on the headline theorems —
+   expect exactly `[propext, Classical.choice, Quot.sound]` (or fewer). Do not
+   trust the PR body; namespaces have tripped this before.
+2. Read every `def …Pre`/`…Post`/spec statement with §2's checklist.
+3. `scripts/port-check.sh <module>` where the module is a port.
+
+**Conversion PR** (emitted strings / `_prog`s):
+1. `bash scripts/check-asm-to-program.sh` → CLEAN over the full manifest.
+2. Whole-guest LINKED `.text` byte-identity vs merge-base — build both sides
+   (`lake exe codegen --program stateless_guest --halt linux93 -o …`;
+   `objcopy -O binary -j .text`; `cmp`). Comparing unlinked `.s` is INVALID
+   (symbolic `la` assembles to zeroed relocations).
+3. Run ≥1 probe the author did NOT run, from a family the PR touches.
+4. `GuestAddrs.lean` diff purely additive (0 deletions) or absent — unless the
+   PR is itself a regen.
+5. Grep added def strings for baked immediates (`auipc`, `%pcrel`,
+   `la x, 0x…`) — link-dependent operands must stay symbolic in emission
+   views (the #9720 multi-image lesson).
+
+**Guest-byte-changing PR** (fixes/restructures):
+1. The PR must carry its own layout regen (region-map GREEN in CI now, but
+   verify `check-asm-to-program` CLEAN too — GuestAddrs/TSV can desync, §3.6).
+2. EEST parity: `scripts/codegen-eest-stateless-check.sh` A/B vs base —
+   identical pass/fail sets, or strictly-better with flipped cases named.
+3. The `.s` diff vs base contains ONLY the advertised change.
+4. Probes covering the changed paths — including one that FAILS on base if the
+   PR fixes a behavior bug (a fix without a base-failing test is unverified).
+
+**Layout-metadata regen PR**:
+1. `check-region-map.sh` GREEN, `check-asm-to-program.sh` CLEAN, guest bytes
+   UNCHANGED (byte-identity vs base must hold — metadata never moves bytes).
+2. Merge-order awareness: such PRs race every byte-changing merge. Merge
+   promptly; conflicts are resolved by RE-RUNNING the regen on the merged tree
+   (take either side textually first), never by textual merge.
+
+**Docs/bead-only PR**: spot-check citations (file:line drift is common —
+measurements taken pre-merge of a rewriting wave go stale); reproduce at least
+one load-bearing measurement independently.
+
+## 2. Adversarial statement-reading checklist
+
+For every spec/postcondition/Prop in the PR, ask:
+
+1. **∃-escape**: does the post existentially quantify something the routine
+   determines (a state, an output buffer, a length)? If the prover picks the
+   witness, can it pick a degenerate one (`[]`, over-long, wrong-but-undecodable)?
+   Fixed lengths and function-of-snapshot posts are the antidotes.
+2. **Vacuity, pre side**: can the precondition be unsatisfiable (a wrong
+   framing, contradictory pins)? For framing bundles demand a satisfiability
+   witness (`scratch_sat` pattern).
+3. **Vacuity, provability side**: can the triple be discharged without the
+   intended work (does the exhausted/cap VC actually depend on the loop
+   body's charge? would the proof fail if the body's key instruction were
+   deleted)?
+4. **Resource accounting**: does the postcondition give every entry-owned
+   resource a home (residue slot)? A post owning less than the pre is
+   unprovable; a post letting residue absorb the OBSERVED region is vacuous.
+5. **Spec-shaped restatement**: is the post the actual mathematical claim
+   (`Nat.pow`, `List.reverse`, the SpecRef function) or a ladder/loop-shaped
+   restatement a wrong implementation could satisfy? Guard bridges with
+   kernel KATs where cheap.
+6. **Weakening under pressure**: `take`-truncations, `getD` defaults, dropped
+   bound checks — each is a place a wrong input pins WRONG values instead of
+   being unsatisfiable. Demand the length/bounds invariant.
+7. **Convention over-constraint**: does a precondition assert something the
+   real host/machine does not guarantee (meta bytes zero, unaliased operands
+   the hardware allows aliased)? Over-constrained pres silently narrow the
+   theorem's applicability.
+
+## 3. The known-hole catalog (all real, all caught in review here)
+
+1. **∃-out decode vacuity** — post `∃ out, bytesRegion … out ∧ (decode out
+   claims valid → …)` with no length pin: prover picks `out = []` (resource
+   slides into residue) or an over-long undecodable `out`; claim vacuous even
+   on accept runs. Fix: pin `out.length`, state claims on fixed offsets.
+2. **Missing residue slot** — halt-triple post owning only the observation
+   window while the pre owned all scratch: unprovable. Fix: `GuestFraming`
+   with a residue conjunct.
+3. **Multi-image baked immediates** — a def emitted into N linked images had
+   guest-layout `la`/`jal` immediates baked in; every other image broke.
+   Emission views keep link-dependent operands symbolic; only `_prog`
+   verification views pin.
+4. **Verbatim-block split** — a generated conversion block split across two
+   files defeated the source-drift gate. A block moves as a unit; the
+   MANIFEST points at the file that holds ALL of it.
+5. **Differential-testing gap** — the MODEXP `exp==0 ∧ modulus==1 → 1` bug
+   survived months of probes: differential testing is not a terminal
+   verification tier for math kernels.
+6. **GuestAddrs/TSV desync** — the two regen outputs committed from different
+   builds (mid-work main merge between them): `check-region-map` green while
+   `check-asm-to-program` red. Always regen BOTH after the LAST merge.
+7. **Layout-snapshot race** — a regen measured on a stale base fails CI once
+   main moves (CI tests the MERGE). Re-regen after merging main; merge such
+   PRs promptly.
+8. **Stale citations** — inventory measured pre-wave; line refs and status
+   columns drifted after the wave rewrote the cited files. Pin a provenance
+   commit in measurement docs.
+9. **`take`-truncating encodings** — a stack serialization that truncates
+   over-deep stacks pins wrong bytes instead of being unsatisfiable (a
+   soundness trap if it graduates from placeholder to real relation). Carry
+   the capacity invariant.
+10. **Over-constrained host pre** — asserting the ZisK meta dwords are zero
+    would make the top theorem inapplicable to real hosts. Leave unread host
+    bytes in the frame.
+
+## 4. Review output conventions
+
+- Verify claims INDEPENDENTLY (re-derive the spec corner from
+  `tests-zkevm@v0.4.0`, re-run the probe, re-compute the constant) — author
+  assertions are hypotheses. Refuting a claimed bug is a successful review.
+- Post one comment: what you verified (with the exact commands/theorem names),
+  defects found (severity-ordered), non-blocking notes routed to the consumer
+  bead (`bd update <bead> --append-notes …`) so the knowledge lands where the
+  next session will look.
+- Small mechanical defects in an idle author's PR (a missed regen, a stale
+  sync): fix and push to the PR branch yourself, and say so in the comment —
+  unless the PR is near-merge (then a fresh stacked branch; automerge can
+  orphan late pushes).
+- If two open PRs rewrite the same generated files, post the merge-order plan
+  explicitly on both.

--- a/docs/agents/roadmap-4ch8f.md
+++ b/docs/agents/roadmap-4ch8f.md
@@ -1,0 +1,191 @@
+# The 4ch8f roadmap — how to take `run_stateless_guest` verification to conclusion
+
+**Audience**: the agent (any capability tier) picking up the next bead of epic
+`evm-asm-4ch8f`. This page is the map; it tells you which bead to pick, which
+recipe applies, which gates you must run, and where every load-bearing
+definition lives. Read it top-to-bottom once; afterwards jump via §7.
+
+**The goal, in one sentence**: prove
+`runStatelessGuestSound cr fuel fr execute` (`EvmAsm/Stateless/EntrySpec.lean`)
+for the real guest image — every routine of the RISC-V `stateless_guest`
+replaced by a verified triple — while the empirical harness
+`scripts/codegen-eest-stateless-check.sh` (EEST conformance,
+`tests-zkevm@v0.4.0` fixtures) keeps passing at every step.
+
+Companion pages (do not duplicate their content; link into them):
+- `docs/agents/port-playbook.md` — the per-routine port workflow (kit → spec →
+  proof → `port-check.sh`). **This is the recipe for ~80 % of remaining beads.**
+- `docs/agents/review-playbook.md` — how to review a 4ch8f PR (the gates CI
+  does NOT run, the adversarial checklists, the known-hole catalog).
+- `docs/agents/top-theorem-ledger.md` — obligation rows from the statement
+  down; update rows as beads close.
+- `docs/4ch8f-top-spec.md` (the statement + trust boundary),
+  `docs/4ch8f-interp-strategy.md` (interpreter/dispatch/frames),
+  `docs/4ch8f-crypto-strategy.md` (crypto kernels + field-arith library),
+  `docs/sasm-design.md` (the SAsm framework itself),
+  `docs/agents/proof-patterns.md` + `docs/agents/tactics-deep.md` (tactic craft).
+
+## 1. The layer DAG (verify callee-first, bottom-up)
+
+```
+L0  DONE  machine model + accelerators (.1), SAsm core (.2-.5, .10 machinery),
+          layout + phase model (.6), asm→Program conversions (.9, 384 defs),
+          statement (.8), all strategy decisions (.7, .10, .11)
+L1  leaf ports          .12 .13 .14 .15 .16 .20 .23 .24 (+.17 .18 hash bridges)
+L2  mid composites      .19 .21 .22 .25 .26 .27 .35 .36 .37 (decode/extract/gas)
+L3  state + MPT         .28 .29 .30 .31 .32 (walk -> mutation -> roots)
+L4  headers + chain     .33 .34
+L5  crypto track        .38 -> .39 .40 -> .57 -> .58   (order: 4ch8f-crypto-strategy §5)
+L6  interpreter         .49 (loop) .50-.55 (handler families) .56 (frames)
+L7  tx + verdict        .41-.48 .59 .60 .61 .62
+L8  shell + top         .63 -> .64
+```
+
+Rules:
+- **A bead is READY when every routine it calls is verified** (or it calls
+  none). `bd show <bead>` lists the family's functions; the call tree is in the
+  routine's header comment in `EvmAsm/Codegen/Programs/*.lean` ("Composes:" /
+  "Calling convention:" blocks).
+- **Pick the lowest READY layer.** Within a layer, prefer beads that unblock
+  the most (the MPT chain .28→.32 and the hash bridges .17/.18 have the widest
+  fan-out).
+- L1/L2 beads have one-session children (`port: verify <fn>`). If a family
+  bead you reach has no children yet, **decompose it first** (§5) — that
+  decomposition is itself a valid session outcome.
+
+## 2. Which recipe applies (by routine shape)
+
+| shape | recipe | exemplar (proved, on main) |
+|---|---|---|
+| straight-line loads/stores | port-playbook, block lemma over `execInstrRF` | `SSZ/Decode/ChainIdSAsm.lean` |
+| fixed-trip loop (byte reverse, copy N) | SAsm `while` + `vcgen` | `Codegen/Programs/KeccakReverseSAsm.lean`, `BalValueReverseSAsm.lean` |
+| data-dependent loop (len/count from input) | `Stmt.whileS` + static cap; cap as spec hypothesis | `SAsm/LoopFuelDemo.lean` (`capScanFn_spec`) |
+| calls a verified routine | `Fn`/`FnHandle`, `Stmt.call`/`callReg` | `SAsm/CallRegDemo.lean` |
+| state-transforming callee at one call site (handlers) | `FnHandleS` + `Stmt.callRegS` | `SAsm/InterpLoopDemo.lean`, `Codegen/Proofs/HandlerHandles*.lean` |
+| accelerator invocation (`csrs 0x8xx`) | machine-level CSRS triple + `FnHandleS` wrapper; NEVER extend the SAsm block engine | `SAsm/AccelStep.lean` (`csrs_arith256Mod_spec_within`) |
+| exponent/scalar ladder | `Crypto/PowLadder.lean` fold + `whileS`; post in `Nat.pow`/scalar-mult | `SAsm/PowLadderDemo.lean` (`powFn_spec`) |
+| aliased arena phases (call-frame windows) | `anyBytes`/`phaseDView` focus/unfocus | `SAsm/PhaseSplit.lean`, `Codegen/CallFrameWindows.lean` |
+| ro table indexed load | `tableAt` + `exec_table_load` | `Codegen/Proofs/OpcodeTables.lean` |
+
+Spec-side reference: `EvmAsm/Stateless/SpecRef/*` is the Lean port of the
+Python spec (`tests-zkevm@v0.4.0` — read the Python via
+`git -C ~/execution-specs show 'tests-zkevm@v0.4.0:src/ethereum/forks/amsterdam/<file>'`;
+those files exist ONLY on that tag). When a routine has a SpecRef counterpart,
+the port's functional post must be stated against it (or against a leaf-level
+byte equation the SpecRef bridge later consumes).
+
+## 3. Gates: what CI runs vs what YOU must run
+
+CI (`.github/workflows/build.yml`) runs: `lake build` (+no-warnings),
+forbidden-tactics, file-size, unimported, roundtrip-coverage,
+heartbeats-approved, layering, opcode-structure, naming, codegen build,
+stateless-link-check, progress, DRIFT.md, axioms (registered witnesses),
+conformance-floor, fuzz-arith, statement-tamper, region-map/link-layout.
+
+**You must run, by change type** (paste outputs in the PR body):
+
+| change type | required beyond CI |
+|---|---|
+| Lean-proof-only (new specs/theorems) | `#print axioms <full.name>` per headline theorem (classical-3 only: `[propext, Classical.choice, Quot.sound]`); `scripts/port-check.sh <module>` where applicable |
+| emitted-string / `_prog` conversion | `scripts/check-asm-to-program.sh` CLEAN; whole-guest LINKED `.text` byte-identity vs merge-base (`lake exe codegen --program stateless_guest --halt linux93 -o …`, `objcopy -O binary -j .text`, `cmp`; state size+sha256); ≥2 `codegen-zisk-*-check.sh` probes embedding changed functions; dispatcher render 0-added-`auipc` |
+| guest-BYTE-changing (fix/restructure) | all of the above EXCEPT byte-identity, replaced by: the SAME-PR layout regen (`gen-symbol-addresses.py --build` + `asm_to_program.py guest-addrs` + repin `RegionMap.textSizeBytes`), a scoped dispatcher/guest `.s` diff (only the intended change), AND **EEST parity**: `scripts/codegen-eest-stateless-check.sh` pass/fail sets identical vs base (or strictly better, with the flipped cases named) |
+| layout metadata regen | `check-region-map.sh` GREEN, `check-asm-to-program.sh` CLEAN, byte-identity UNCHANGED (metadata must never move guest bytes) |
+
+**EEST harness**: `scripts/codegen-eest-stateless-check.sh` is the ground-truth
+conformance sweep. It is slow; run the full sweep only for byte-changing PRs
+(A/B vs base) — probes cover everything else. `--jobs 8` is the calibrated cap
+(see the check-script perf notes in PLAN.md history).
+
+## 4. Non-negotiable conventions (each has bitten before)
+
+1. **No `sorry`, `native_decide`, `bv_decide`** anywhere; never raise
+   `maxHeartbeats`/`maxRecDepth` (find the real cause — usually a `let`-bundle
+   needing `@[irreducible]`, or an over-unfolded window; see
+   `docs/agents/tactics-deep.md`).
+2. **Compose, don't enumerate**: anything sized 256/1025/4096 is proved by a
+   generic lemma over `n`/`List.replicate`, never case enumeration.
+3. **Base-parameterized everything**: no numeric guest addresses in specs;
+   reference `GuestAddrs.*` constants BY NAME only inside `_prog` defs (they
+   are regenerated wholesale on layout drift).
+4. **No ∃-state escapes in posts**: a postcondition pins exit
+   registers/windows as FUNCTIONS of inputs/snapshot. If you find yourself
+   writing `∃ ws', …` for something the routine determines, stop — that is a
+   spec-weakening (review-playbook §3 has the catalog of past instances).
+5. **The STOP rule**: a routine that surprises you (overlap semantics,
+   misaligned access, unreachable-looking guard, spec mismatch) ⇒ STOP that
+   bead, write the finding into it, file a P1 for any guest↔spec divergence
+   (standing policy), move on. A documented blocker always beats a weakened
+   spec or a "conservative" workaround. **Never bail-to-reject to make
+   something pass** — fix the exact model (no-conservative-skips policy).
+6. **Aligned accesses only**: the verified semantics traps on misaligned
+   LD/SD/LW; ziskemu tolerating it does not make it legal. Byte access =
+   LBU+shift/OR.
+7. **Regen is authoritative**: merge conflicts on
+   `GuestAddrs.lean`/`symbol-addresses.tsv`/`RegionMap` sizes are NEVER
+   resolved textually — take either side, then re-run the regen on the merged
+   tree. Merge layout-racing PRs promptly.
+8. Git: merge (never rebase); stack PRs with `--base`; never push to a branch
+   whose PR is near merge; conventional-commit titles; commit trailer
+   `Co-Authored-By:` line per repo convention; zero-sorry PRs only.
+
+## 5. Decomposing a family bead (when you reach one without children)
+
+Pattern (already applied to .12/.13 — copy it):
+1. `bd show <family>` — the description lists the routine names.
+2. For each routine: `bd create --parent <family> -p 1 -t task
+   "port: verify \`<fn>\` (SAsm, one-session)"` with a description holding:
+   the file (grep the label in `EvmAsm/Codegen/Programs/`), its MANIFEST/
+   fixture row, its callees ("Composes:" comment), the SpecRef counterpart if
+   any, and the recipe row from §2 that applies.
+3. Order the children callee-first in the family bead's notes.
+4. A routine that is COMPOSITE/unconverted or calls unverified helpers gets a
+   `blocked-by` note naming the prerequisite bead instead of being guessed at.
+
+The composition beads (.48, .61, .62, .63, .64) are NOT decomposable this way
+— each carries a bead note written by the strategy sessions describing its
+specific plan; read the note before starting, and extend the note (not the
+description) with what you learn.
+
+## 6. Where the bodies are buried (session knowledge you would otherwise lack)
+
+- **The statement has been through one repair cycle**: `GuestFraming`
+  (scratch/residue + `scratch_sat`) exists because the bare form was
+  unprovable, and the 40-byte pinned observation window exists because a
+  decode-based `∃ out` post is vacuously dischargeable. Details + both defects:
+  `docs/4ch8f-top-spec.md` §3a. Do not "simplify" either away.
+- **`1 < m` gates every pow-ladder consumer** (`Crypto/PowLadder.lean`): at
+  `m = 1` the staged `acc = 1` is unreduced — exactly the `.11.5` MODEXP bug
+  class. Ladder consumers must gate or special-case `m ≤ 1`.
+- **Handlers move the stack pointer by convention**: binary ops `x12 → sp+32`,
+  unary in place, POP `+32` with no bytes; dead bytes below the new top are
+  PINNED to old contents in the posts (`Codegen/Proofs/HandlerHandles*.lean`).
+- **The frame arena is havoc-first**: dispatch owns `phaseDView` (contents
+  forgotten); anything reading a frame must go through
+  `cpsTripleWithin_anyBytes_pre` (all-contents quantification) or a focused
+  window. Never assume Phase-H contents in Phase-D.
+- **`bytesRegion` pads trailing dwords with zeros** — a non-multiple-of-8 byte
+  list pins its final-dword tail to 0. Choose window sizes ≡ 0 (mod 8) or
+  account for the pad explicitly.
+- **The `.data` tables are drift-guarded, not assumed**:
+  `scripts/check-opcode-tables.sh`, `scripts/check-region-map.sh` — if your
+  work adds a Lean mirror of any emitted data, add the same style of
+  ELF-comparison guard in the same PR.
+- **EEST receipt-gas / bv_fail lore**: the verdict-side false-reject debugging
+  history (bv_fail codes, receipt-gas reconstruction, EIP-8037 state gas) is
+  indexed in the memory files referenced from PLAN.md history; for verdict
+  beads (.44/.45/.61/.62) grep PLAN.md and the bead notes before re-deriving.
+
+## 7. Quick index
+
+| I need… | go to |
+|---|---|
+| next bead | §1 rules + `bd list --parent evm-asm-4ch8f` |
+| the port workflow | `docs/agents/port-playbook.md` |
+| review a PR | `docs/agents/review-playbook.md` |
+| the top statement + trust boundary | `docs/4ch8f-top-spec.md`, `EvmAsm/Stateless/EntrySpec.lean` |
+| dispatch/frames/interpreter plan | `docs/4ch8f-interp-strategy.md` |
+| crypto tiers + field-arith library | `docs/4ch8f-crypto-strategy.md` |
+| SAsm reference | `docs/sasm-design.md`, `docs/agents/wp-framework.md` |
+| memory layout / regions | `EvmAsm/Codegen/RegionMap.lean`, `docs/4ch8f-region-map.md` |
+| spec ground truth | `EvmAsm/Stateless/SpecRef/`, `tests-zkevm@v0.4.0` tag |
+| conformance harness | `scripts/codegen-eest-stateless-check.sh` (§3) |


### PR DESCRIPTION
The project is migrating to Opus-high and smaller models for the remainder of the `run_stateless_guest` verification (epic `evm-asm-4ch8f`), including reviews. This PR moves the knowledge that previously lived in session context into the repo, and the bead DB has been enriched alongside (DB-side).

## New docs

**`docs/agents/roadmap-4ch8f.md`** — the master map any session loads first:
- the layer DAG (L1 leaf ports → … → L8 shell+top) with pick-next rules (callee-first, lowest ready layer, widest fan-out);
- the recipe-by-routine-shape table — every row points at a PROVED exemplar on main (ChainIdSAsm, KeccakReverseSAsm, LoopFuelDemo, InterpLoopDemo, HandlerHandles, AccelStep, PowLadderDemo, PhaseSplit/CallFrameWindows, OpcodeTables);
- the gate matrix: what CI runs vs what the author must run per change type (Lean-only / conversion / guest-byte-changing / metadata regen), including when the EEST sweep (`scripts/codegen-eest-stateless-check.sh`) is required and in what form (A/B parity);
- the non-negotiable conventions, each annotated with the incident that made it a rule;
- the family-bead decomposition pattern (§5) so families without children can be fanned out mechanically;
- "where the bodies are buried" — the load-bearing facts a fresh session would otherwise re-derive or violate (GuestFraming's two repaired defects, the `1 < m` ladder gate, handler stack-pointer conventions, havoc-first frame arena, bytesRegion tail padding, drift-guard discipline).

**`docs/agents/review-playbook.md`** — reviews are also migrating, so the review methodology is written down: per-PR-type checklists for the gates CI does NOT run (linked-`.text` byte-identity, independent probe picks, baked-immediate greps, EEST parity, regen-is-authoritative conflict resolution), the adversarial statement-reading checklist (∃-escapes, both vacuity directions, resource accounting, spec-shaped restatements, truncating encodings, over-constrained pres), and a ten-entry known-hole catalog — every entry a real defect caught in review in this repo.

AGENTS.md deep-references both (load-when triggers); PLAN.md notes the handoff layer.

## Bead-DB enrichment (already applied, not in this diff)

- **Plan notes** on the composition/hard beads: `.49` (the dispatch-loop assembly plan from the three merged interface pieces + the per-iteration widenRw gotcha), `.64` (instantiation quadruple + halt composition + post-stamp trap-freedom), `.61`/`.62` (monolith decomposition guidance + bv_fail lore pointers), `.48` (the EIP-2935/4788 storage-trie blocker), `.38`/`.57`/`.58` (crypto wave order, AccelStep/PowLadder recipes, the ECDSA reference-spec dependency, a0-aliases-x10 + EIP-150 landmines), `.17`/`.18`/`.21` (hash-bridge patterns, zk3_state hazard, endianness landmines), `.28` (MPT chain order), `.50`–`.55` (the #9771 handle recipe per family).
- **41 new one-session `port: verify` children** under `.14`/`.15`/`.16`/`.20`/`.22`/`.23`/`.24`/`.26`, each with file-lookup instructions, spec targets, blocked-by markers, and the port-check acceptance criterion (4 accidental duplicates under .14 closed as such).
- **DECOMPOSE FIRST notes** on every remaining family bead, pointing at roadmap §5.

Docs-only diff; `lake build` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)