### PR TITLE
sasm(4ch8f.huy8w): break/early-exit while combinator

### DIFF
--- a/EvmAsm/Rv64/SAsm.lean
+++ b/EvmAsm/Rv64/SAsm.lean
@@ -37,3 +37,4 @@ import EvmAsm.Rv64.SAsm.InterpLoopDemo
 import EvmAsm.Rv64.SAsm.AccelStep
 import EvmAsm.Rv64.SAsm.PowLadderDemo
 import EvmAsm.Rv64.SAsm.MultiRw
+import EvmAsm.Rv64.SAsm.WhileBreakDemo

--- a/EvmAsm/Rv64/SAsm/Ast.lean
+++ b/EvmAsm/Rv64/SAsm/Ast.lean
@@ -160,6 +160,21 @@ inductive Stmt where
            (inv : RegFile → List (BitVec 8) → Assertion →
              Nat → RegFile → List (BitVec 8) → Assertion → Prop)
            (body : Stmt)
+  /-- Bounded loop with a **mid-body early exit** (`break`).  The loop runs
+      while `guard` holds, at most `fuel` iterations; each iteration runs
+      `bodyBefore`, then — if `breakCond` holds — jumps out of the loop to
+      `post` (the break), otherwise runs `bodyAfter` and takes the back-edge.
+      Both the guard-fail exit and the break exit establish `post` directly.
+      `inv i` must hold at the i-th header evaluation.  This is the structured
+      form of the machine idiom "scan until a predicate holds" (a header
+      guard plus a mid-loop conditional branch to the loop exit, past the
+      back-edge — a shape the single-exit `«while»` cannot express).  The
+      generator emits initialization, continue-preservation, fuel-exhaustion,
+      guard-exit, and break VCs (docs/sasm-design.md §3.10). -/
+  | «whileBreak» (label : String) (guard : Cond) (fuel : Nat)
+           (inv : Nat → RegFile → List (BitVec 8) → Assertion → Prop)
+           (post : RegFile → List (BitVec 8) → Assertion → Prop)
+           (bodyBefore : Stmt) (breakCond : Cond) (bodyAfter : Stmt)
   /-- Direct call (`jal ra, f.entry`) to a routine with a verified caller
       interface (docs/sasm-design.md §3.6).  The handle carries the callee's
       pre/post in the C-like ABI; the VC generator emits one `.pre`
@@ -199,6 +214,7 @@ def size : Stmt → Nat
   | blockAt _ _ _ is  => is.length
   | «while» _ _ _ _ b   => b.size + 2
   | «whileS» _ _ _ _ b  => b.size + 2
+  | «whileBreak» _ _ _ _ _ bb _ ba => bb.size + ba.size + 3
   | call _ _          => 1
   | callReg _ _ _     => 1
   | callRegS _ _ _    => 1
@@ -219,6 +235,7 @@ def callFree : Stmt → Bool
   | blockAt _ _ _ _   => true
   | «while» _ _ _ _ b => b.callFree
   | «whileS» _ _ _ _ b => b.callFree
+  | «whileBreak» _ _ _ _ _ bb _ ba => bb.callFree && ba.callFree
   | call _ _          => false
   | callReg _ _ _     => false
   | callRegS _ _ _    => false

--- a/EvmAsm/Rv64/SAsm/Flatten.lean
+++ b/EvmAsm/Rv64/SAsm/Flatten.lean
@@ -64,6 +64,12 @@ def flatten (addr : Word) : Stmt → List Instr
   | «whileS» _ c _ _ b =>
       c.neg.toInstr (brOfs (b.size + 2))
         :: (b.flatten (addr + 4) ++ [.JAL .x0 (jBack (b.size + 1))])
+  | «whileBreak» _ guard _ _ _ bb breakCond ba =>
+      guard.neg.toInstr (brOfs (bb.size + ba.size + 3))
+        :: (bb.flatten (addr + 4)
+            ++ breakCond.toInstr (brOfs (ba.size + 2))
+            :: (ba.flatten (addr + BitVec.ofNat 64 (4 * (bb.size + 2)))
+                ++ [.JAL .x0 (jBack (bb.size + ba.size + 2))]))
   | call _ f =>
       [.JAL .x1 (BitVec.setWidth 21 (f.entry - addr))]
   | callReg _ rs _ =>
@@ -89,6 +95,8 @@ theorem flatten_length (s : Stmt) (addr : Word) :
       simp [flatten, size, ihb]
   | «whileS» _ c fuel inv b ihb =>
       simp [flatten, size, ihb]
+  | «whileBreak» _ guard fuel inv post bb breakCond ba ihbb ihba =>
+      simp [flatten, size, ihbb, ihba]; omega
   | call _ callee => rfl
   | callReg _ _ _ => rfl
   | callRegS _ _ _ => rfl
@@ -119,6 +127,12 @@ def offsetsOk : Stmt → Bool
       c.wf && decide (4 * (b.size + 2) < 2^12)
            && decide (4 * (b.size + 1) ≤ 2^20)
            && b.offsetsOk
+  | «whileBreak» _ guard _ _ _ bb breakCond ba =>
+      guard.wf && breakCond.wf
+           && decide (4 * (bb.size + ba.size + 3) < 2^12)
+           && decide (4 * (ba.size + 2) < 2^12)
+           && decide (4 * (bb.size + ba.size + 2) ≤ 2^20)
+           && bb.offsetsOk && ba.offsetsOk
   | call _ _ => true
   | callReg _ rs _ => Reg.isExposed rs
   | callRegS _ rs _ => Reg.isExposed rs
@@ -142,6 +156,9 @@ def callsOk : Stmt → Word → Prop
   | blockAt _ _ _ _, _ => True
   | «while» _ _ _ _ b, addr => b.callsOk (addr + 4)
   | «whileS» _ _ _ _ b, addr => b.callsOk (addr + 4)
+  | «whileBreak» _ _ _ _ _ bb _ ba, addr =>
+      bb.callsOk (addr + 4)
+        ∧ ba.callsOk (addr + BitVec.ofNat 64 (4 * (bb.size + 2)))
   | call _ f, addr =>
       addr + signExtend21 (BitVec.setWidth 21 (f.entry - addr)) = f.entry
       ∧ ((addr + 4) &&& ~~~(1 : Word)) = addr + 4

--- a/EvmAsm/Rv64/SAsm/StmtSound.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSound.lean
@@ -713,6 +713,249 @@ theorem Stmt.sound (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
           ⟨rf₀, ws₀, A₀, hlen, hApc, hInvInit rf₀ ws₀ A₀ hreach₀, hx⟩) hp hh2
       · -- the exit records the entry state alongside the invariant
         exact asrtM_mono (fun rf ws A hh => ⟨rf₀, ws₀, A₀, hreach₀, hh.1, hh.2⟩)
+  | «whileBreak» lbl guard fuel inv post bb breakCond ba ihbb ihba =>
+      simp only [Stmt.callFree, Bool.and_eq_true] at hleaf
+      obtain ⟨hleafBB, hleafBA⟩ := hleaf
+      simp only [Stmt.offsetsOk, Bool.and_eq_true, decide_eq_true_eq] at hofs
+      obtain ⟨⟨⟨⟨⟨⟨hwfG, hwfB⟩, hofsHdr⟩, hofsBreak⟩, hofsBack⟩, hOBB⟩, hOBA⟩ := hofs
+      simp only [Stmt.size] at hsz
+      -- VC pieces
+      have hInvInit : ∀ rf ws A, reach rf ws A → inv 0 rf ws A := hvcs.head
+      have hInvStep : ∀ i, i < fuel → ∀ rf' ws' A',
+          Stmt.sp reg rw ba (fun rf ws A =>
+            Stmt.sp reg rw bb (fun rf ws A => inv i rf ws A ∧ guard.holds rf) rf ws A
+              ∧ ¬ breakCond.holds rf) rf' ws' A' →
+          inv (i + 1) rf' ws' A' := hvcs.tail.head
+      have hExhausted : ∀ rf ws A, inv fuel rf ws A → ¬ guard.holds rf :=
+        hvcs.tail.tail.head
+      have hGuardExit : ∀ i, i ≤ fuel → ∀ rf ws A,
+          inv i rf ws A → ¬ guard.holds rf → post rf ws A := hvcs.tail.tail.tail.head
+      have hBreak : ∀ i, i < fuel → ∀ rf' ws' A',
+          Stmt.sp reg rw bb (fun rf ws A => inv i rf ws A ∧ guard.holds rf) rf' ws' A' →
+          breakCond.holds rf' → post rf' ws' A' := hvcs.tail.tail.tail.tail.head
+      have hBBVcs := hvcs.tail.tail.tail.tail.tail.left
+      have hBAVcs := hvcs.tail.tail.tail.tail.tail.right
+      -- Flattened layout
+      have hflat : Stmt.flatten base (.whileBreak lbl guard fuel inv post bb breakCond ba)
+          = guard.neg.toInstr (Stmt.brOfs (bb.size + ba.size + 3))
+            :: (bb.flatten (base + 4)
+                ++ breakCond.toInstr (Stmt.brOfs (ba.size + 2))
+                :: (ba.flatten (base + BitVec.ofNat 64 (4 * (bb.size + 2)))
+                    ++ [.JAL .x0 (Stmt.jBack (bb.size + ba.size + 2))])) := rfl
+      have hlenAll : 4 * ((bb.flatten (base + 4)
+          ++ breakCond.toInstr (Stmt.brOfs (ba.size + 2))
+          :: (ba.flatten (base + BitVec.ofNat 64 (4 * (bb.size + 2)))
+              ++ [.JAL .x0 (Stmt.jBack (bb.size + ba.size + 2))])).length + 1) ≤ 2 ^ 64 := by
+        simp only [List.length_append, List.length_cons, List.length_nil, Stmt.flatten_length]
+        omega
+      -- Code containment for the five regions
+      have hcode_header : ∀ a' i,
+          CodeReq.singleton base (guard.neg.toInstr (Stmt.brOfs (bb.size + ba.size + 3)))
+            a' = some i → cr a' = some i :=
+        fun a' i h => hcode a' i (hflat ▸ ofProg_head a' i h)
+      have hcode_bb : ∀ a' i,
+          CodeReq.ofProg (base + 4) (bb.flatten (base + 4)) a' = some i → cr a' = some i :=
+        fun a' i h => hcode a' i
+          (hflat ▸ ofProg_cons_tail hlenAll a' i (ofProg_mono_left a' i h))
+      have hcode_break : ∀ a' i,
+          CodeReq.singleton (base + BitVec.ofNat 64 (4 * (bb.size + 1)))
+            (breakCond.toInstr (Stmt.brOfs (ba.size + 2))) a' = some i → cr a' = some i := by
+        intro a' i h
+        apply hcode a' i
+        rw [hflat]
+        apply ofProg_cons_tail hlenAll
+        apply ofProg_mono_right (p1 := bb.flatten (base + 4))
+          (by simp only [List.length_append, List.length_cons, List.length_nil,
+            Stmt.flatten_length]; omega)
+        rw [Stmt.flatten_length,
+          show (base + 4) + BitVec.ofNat 64 (4 * bb.size)
+            = base + BitVec.ofNat 64 (4 * (bb.size + 1)) from by bv_omega]
+        exact ofProg_head a' i h
+      have hcode_ba : ∀ a' i,
+          CodeReq.ofProg (base + BitVec.ofNat 64 (4 * (bb.size + 2)))
+            (ba.flatten (base + BitVec.ofNat 64 (4 * (bb.size + 2)))) a' = some i →
+          cr a' = some i := by
+        intro a' i h
+        apply hcode a' i
+        rw [hflat]
+        apply ofProg_cons_tail hlenAll
+        apply ofProg_mono_right (p1 := bb.flatten (base + 4))
+          (by simp only [List.length_append, List.length_cons, List.length_nil,
+            Stmt.flatten_length]; omega)
+        rw [Stmt.flatten_length,
+          show (base + 4) + BitVec.ofNat 64 (4 * bb.size)
+            = base + BitVec.ofNat 64 (4 * (bb.size + 1)) from by bv_omega]
+        apply ofProg_cons_tail
+          (by simp only [List.length_append, List.length_cons, List.length_nil,
+            Stmt.flatten_length]; omega)
+        rw [show (base + BitVec.ofNat 64 (4 * (bb.size + 1))) + 4
+            = base + BitVec.ofNat 64 (4 * (bb.size + 2)) from by bv_omega]
+        exact ofProg_mono_left a' i h
+      have hcode_jal : ∀ a' i,
+          CodeReq.singleton (base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 2)))
+            (.JAL .x0 (Stmt.jBack (bb.size + ba.size + 2))) a' = some i → cr a' = some i := by
+        intro a' i h
+        apply hcode a' i
+        rw [hflat]
+        apply ofProg_cons_tail hlenAll
+        apply ofProg_mono_right (p1 := bb.flatten (base + 4))
+          (by simp only [List.length_append, List.length_cons, List.length_nil,
+            Stmt.flatten_length]; omega)
+        rw [Stmt.flatten_length,
+          show (base + 4) + BitVec.ofNat 64 (4 * bb.size)
+            = base + BitVec.ofNat 64 (4 * (bb.size + 1)) from by bv_omega]
+        apply ofProg_cons_tail
+          (by simp only [List.length_append, List.length_cons, List.length_nil,
+            Stmt.flatten_length]; omega)
+        rw [show (base + BitVec.ofNat 64 (4 * (bb.size + 1))) + 4
+            = base + BitVec.ofNat 64 (4 * (bb.size + 2)) from by bv_omega]
+        apply ofProg_mono_right (p1 := ba.flatten (base + BitVec.ofNat 64 (4 * (bb.size + 2))))
+          (by simp only [List.length_cons, List.length_nil, Stmt.flatten_length]; omega)
+        rw [Stmt.flatten_length,
+          show (base + BitVec.ofNat 64 (4 * (bb.size + 2))) + BitVec.ofNat 64 (4 * ba.size)
+            = base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 2)) from by bv_omega]
+        exact ofProg_head a' i h
+      -- Header branch at any invariant index: exit to `Lexit` when guard fails,
+      -- fall to `base + 4` (the body) when guard holds.
+      have hheader : ∀ (r : Reach),
+          cpsBranchWithin 1 base cr (asrtM reg rw r)
+            (base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 3)))
+              (asrtM reg rw fun rf ws A => r rf ws A ∧ ¬ guard.holds rf)
+            (base + 4) (asrtM reg rw fun rf ws A => r rf ws A ∧ guard.holds rf) := by
+        intro r
+        have hbr := branch_spec_asrt guard.neg (Stmt.brOfs (bb.size + ba.size + 3)) rw r base
+          (by rw [Cond.wf_neg]; exact hwfG)
+        rw [signExtend13_brOfs hofsHdr] at hbr
+        have hbr' := cpsBranchWithin_frameR (bytesRegion reg.base reg.bytes)
+          (bytesRegion_pcFree _ _) (cpsBranchWithin_extend_code hcode_header hbr)
+        refine cpsBranchWithin_weaken (fun _ hp => hp) ?_ ?_ hbr'
+        · exact asrtM_mono (fun rf ws A hh =>
+            ⟨hh.1, (Cond.holds_neg guard rf).mp hh.2⟩)
+        · exact asrtM_mono (fun rf ws A hh =>
+            ⟨hh.1, Decidable.of_not_not
+              (fun hcc => hh.2 ((Cond.holds_neg guard rf).mpr hcc))⟩)
+      -- Break branch at `breakPt`: exit to `Lexit` when `breakCond` holds,
+      -- fall to `afterEntry` otherwise.
+      have hbreak : ∀ (r : Reach),
+          cpsBranchWithin 1 (base + BitVec.ofNat 64 (4 * (bb.size + 1))) cr (asrtM reg rw r)
+            (base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 3)))
+              (asrtM reg rw fun rf ws A => r rf ws A ∧ breakCond.holds rf)
+            (base + BitVec.ofNat 64 (4 * (bb.size + 2)))
+              (asrtM reg rw fun rf ws A => r rf ws A ∧ ¬ breakCond.holds rf) := by
+        intro r
+        have hbr := branch_spec_asrt breakCond (Stmt.brOfs (ba.size + 2)) rw r
+          (base + BitVec.ofNat 64 (4 * (bb.size + 1))) hwfB
+        rw [signExtend13_brOfs hofsBreak,
+          show (base + BitVec.ofNat 64 (4 * (bb.size + 1)))
+              + BitVec.ofNat 64 (4 * (ba.size + 2))
+            = base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 3)) from by bv_omega,
+          show (base + BitVec.ofNat 64 (4 * (bb.size + 1))) + 4
+            = base + BitVec.ofNat 64 (4 * (bb.size + 2)) from by bv_omega] at hbr
+        exact cpsBranchWithin_frameR (bytesRegion reg.base reg.bytes)
+          (bytesRegion_pcFree _ _) (cpsBranchWithin_extend_code hcode_break hbr)
+      -- Body-before triple: `base + 4` → `breakPt`.
+      have hbeforeStep : ∀ i, i < fuel →
+          cpsTripleWithin bb.steps (base + 4)
+            (base + BitVec.ofNat 64 (4 * (bb.size + 1))) cr
+            (asrtM reg rw fun rf ws A => inv i rf ws A ∧ guard.holds rf)
+            (asrtM reg rw (Stmt.sp reg rw bb
+              (fun rf ws A => inv i rf ws A ∧ guard.holds rf))) := by
+        intro i hi
+        have hb := ihbb (base + 4) (pfx ++ lbl ++ ".before.")
+          (fun rf ws A => inv i rf ws A ∧ guard.holds rf) hleafBB hOBB (by omega) hcode_bb
+          (Stmt.vcs_antitone reg rw bb _ (fun rf ws A hr => ⟨i, hi, hr.1, hr.2⟩) hBBVcs)
+        rwa [show (base + 4) + BitVec.ofNat 64 (4 * bb.size)
+            = base + BitVec.ofNat 64 (4 * (bb.size + 1)) from by bv_omega] at hb
+      -- Body-after triple + back-jump: `afterEntry` → header, advancing the index.
+      have hafterStep : ∀ i, i < fuel →
+          cpsTripleWithin (ba.steps + 1)
+            (base + BitVec.ofNat 64 (4 * (bb.size + 2))) base cr
+            (asrtM reg rw fun rf ws A =>
+              Stmt.sp reg rw bb (fun rf ws A => inv i rf ws A ∧ guard.holds rf) rf ws A
+                ∧ ¬ breakCond.holds rf)
+            (asrtM reg rw fun rf ws A => inv (i + 1) rf ws A) := by
+        intro i hi
+        have hb := ihba (base + BitVec.ofNat 64 (4 * (bb.size + 2))) (pfx ++ lbl ++ ".after.")
+          (fun rf ws A =>
+            Stmt.sp reg rw bb (fun rf ws A => inv i rf ws A ∧ guard.holds rf) rf ws A
+              ∧ ¬ breakCond.holds rf) hleafBA hOBA (by omega) hcode_ba
+          (Stmt.vcs_antitone reg rw ba _ (fun rf ws A hr => ⟨i, hi, hr.1, hr.2⟩) hBAVcs)
+        have hjal := jal0_spec_pcFree (Stmt.jBack (bb.size + ba.size + 2))
+          (base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 2)))
+          (pcFree_asrtM reg rw (Stmt.sp reg rw ba fun rf ws A =>
+            Stmt.sp reg rw bb (fun rf ws A => inv i rf ws A ∧ guard.holds rf) rf ws A
+              ∧ ¬ breakCond.holds rf))
+        rw [show (base + BitVec.ofNat 64 (4 * (bb.size + 2)))
+              + BitVec.ofNat 64 (4 * ba.size)
+            = base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 2)) from by bv_omega] at hb
+        rw [add_jBack base (bb.size + ba.size + 2) (by omega) hofsBack] at hjal
+        have hjal' := cpsTripleWithin_extend_code hcode_jal hjal
+        have hseq := cpsTripleWithin_seq_same_cr hb hjal'
+        exact cpsTripleWithin_weaken (fun _ hp => hp)
+          (asrtM_mono (fun rf ws A hsp => hInvStep i hi rf ws A hsp)) hseq
+      -- The body as a branch: from `base + 4`, either back to header (continue)
+      -- or out to `Lexit` (break).
+      have hBodyBranch : ∀ i, i < fuel →
+          cpsBranchWithin (bb.steps + ba.steps + 2) (base + 4) cr
+            (asrtM reg rw fun rf ws A => inv i rf ws A ∧ guard.holds rf)
+            base (asrtM reg rw fun rf ws A => inv (i + 1) rf ws A)
+            (base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 3)))
+              (asrtM reg rw fun rf ws A =>
+                Stmt.sp reg rw bb (fun rf ws A => inv i rf ws A ∧ guard.holds rf) rf ws A
+                  ∧ breakCond.holds rf) := by
+        intro i hi
+        have hcomposed1 := cpsTripleWithin_seq_cpsBranchWithin_same_cr (hbeforeStep i hi)
+          (hbreak (Stmt.sp reg rw bb (fun rf ws A => inv i rf ws A ∧ guard.holds rf)))
+        have hcomposed2 := cpsBranchWithin_seq_cpsTripleWithin_same_cr hcomposed1
+          (hafterStep i hi) (fun _ hp => hp)
+        rw [show bb.steps + 1 + (ba.steps + 1) = bb.steps + ba.steps + 2 from by omega]
+          at hcomposed2
+        exact cpsBranchWithin_swap hcomposed2
+      -- The break-loop certificate, by downward recursion on the remaining fuel.
+      have hcert : ∀ fuel' start, start + fuel' = fuel →
+          WP.loopBreakNatCert 1 (bb.steps + ba.steps + 2) 1 base (base + 4)
+            (base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 3))) cr
+            (fun i => asrtM reg rw fun rf ws A => inv i rf ws A)
+            (fun i => asrtM reg rw fun rf ws A => inv i rf ws A ∧ guard.holds rf)
+            (fun i => asrtM reg rw fun rf ws A => inv i rf ws A ∧ ¬ guard.holds rf)
+            (fun i => asrtM reg rw fun rf ws A =>
+              Stmt.sp reg rw bb (fun rf ws A => inv i rf ws A ∧ guard.holds rf) rf ws A
+                ∧ breakCond.holds rf)
+            (asrtM reg rw post) start fuel' := by
+        intro fuel'
+        induction fuel' with
+        | zero =>
+            intro start hstart
+            simp only [WP.loopBreakNatCert]
+            have hsf : start = fuel := by omega
+            have hexit : cpsTripleWithin 0
+                (base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 3)))
+                (base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 3))) cr
+                (asrtM reg rw fun rf ws A => inv start rf ws A ∧ ¬ guard.holds rf)
+                (asrtM reg rw post) :=
+              cpsTripleWithin_entails (asrtM_mono (fun rf ws A hh =>
+                hGuardExit start (by omega) rf ws A hh.1 hh.2))
+            have hdead : cpsTripleWithin 0 (base + 4)
+                (base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 3))) cr
+                (asrtM reg rw fun rf ws A => inv start rf ws A ∧ guard.holds rf)
+                (asrtM reg rw post) :=
+              cpsTripleWithin_unreachable (asrtM_unsat (fun rf ws A hh =>
+                hExhausted rf ws A (hsf ▸ hh.1) hh.2))
+            exact cpsBranchWithin_merge_same_cr
+              (cpsBranchWithin_swap (hheader (fun rf ws A => inv start rf ws A))) hdead hexit
+        | succ fuel' ih =>
+            intro start hstart
+            refine ⟨cpsBranchWithin_swap (hheader (fun rf ws A => inv start rf ws A)),
+              hBodyBranch start (by omega), ?_, ?_, ih (start + 1) (by omega)⟩
+            · exact asrtM_mono (fun rf ws A hh =>
+                hGuardExit start (by omega) rf ws A hh.1 hh.2)
+            · exact asrtM_mono (fun rf ws A hh =>
+                hBreak start (by omega) rf ws A hh.1 hh.2)
+      have hsound := WP.loopBreakNatCert_sound (hcert fuel 0 (by omega))
+      exact cpsTripleWithin_weaken
+        (asrtM_mono (fun rf ws A hr => hInvInit rf ws A hr))
+        (fun _ hp => hp)
+        hsound
   | call lbl f =>
       exact absurd hleaf (by simp [Stmt.callFree])
   | callReg lbl rs handles =>

--- a/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
@@ -611,6 +611,249 @@ theorem Stmt.soundR (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
           ⟨rf₀, ws₀, A₀, hlen, hApc, hInvInit rf₀ ws₀ A₀ hreach₀, hx⟩)) hp hh2
       · -- the exit records the entry state alongside the invariant
         exact asrtR_mono (fun rf ws A hh => ⟨rf₀, ws₀, A₀, hreach₀, hh.1, hh.2⟩)
+  | «whileBreak» lbl guard fuel inv post bb breakCond ba ihbb ihba =>
+      simp only [Stmt.offsetsOk, Bool.and_eq_true, decide_eq_true_eq] at hofs
+      obtain ⟨⟨⟨⟨⟨⟨hwfG, hwfB⟩, hofsHdr⟩, hofsBreak⟩, hofsBack⟩, hOBB⟩, hOBA⟩ := hofs
+      simp only [Stmt.size] at hsz
+      obtain ⟨hcalleesBB, hcalleesBA⟩ := hcallees
+      obtain ⟨hcallsBB, hcallsBA⟩ := hcalls
+      -- VC pieces
+      have hInvInit : ∀ rf ws A, reach rf ws A → inv 0 rf ws A := hvcs.head
+      have hInvStep : ∀ i, i < fuel → ∀ rf' ws' A',
+          Stmt.sp reg rw ba (fun rf ws A =>
+            Stmt.sp reg rw bb (fun rf ws A => inv i rf ws A ∧ guard.holds rf) rf ws A
+              ∧ ¬ breakCond.holds rf) rf' ws' A' →
+          inv (i + 1) rf' ws' A' := hvcs.tail.head
+      have hExhausted : ∀ rf ws A, inv fuel rf ws A → ¬ guard.holds rf :=
+        hvcs.tail.tail.head
+      have hGuardExit : ∀ i, i ≤ fuel → ∀ rf ws A,
+          inv i rf ws A → ¬ guard.holds rf → post rf ws A := hvcs.tail.tail.tail.head
+      have hBreak : ∀ i, i < fuel → ∀ rf' ws' A',
+          Stmt.sp reg rw bb (fun rf ws A => inv i rf ws A ∧ guard.holds rf) rf' ws' A' →
+          breakCond.holds rf' → post rf' ws' A' := hvcs.tail.tail.tail.tail.head
+      have hBBVcs := hvcs.tail.tail.tail.tail.tail.left
+      have hBAVcs := hvcs.tail.tail.tail.tail.tail.right
+      -- Flattened layout
+      have hflat : Stmt.flatten base (.whileBreak lbl guard fuel inv post bb breakCond ba)
+          = guard.neg.toInstr (Stmt.brOfs (bb.size + ba.size + 3))
+            :: (bb.flatten (base + 4)
+                ++ breakCond.toInstr (Stmt.brOfs (ba.size + 2))
+                :: (ba.flatten (base + BitVec.ofNat 64 (4 * (bb.size + 2)))
+                    ++ [.JAL .x0 (Stmt.jBack (bb.size + ba.size + 2))])) := rfl
+      have hlenAll : 4 * ((bb.flatten (base + 4)
+          ++ breakCond.toInstr (Stmt.brOfs (ba.size + 2))
+          :: (ba.flatten (base + BitVec.ofNat 64 (4 * (bb.size + 2)))
+              ++ [.JAL .x0 (Stmt.jBack (bb.size + ba.size + 2))])).length + 1) ≤ 2 ^ 64 := by
+        simp only [List.length_append, List.length_cons, List.length_nil, Stmt.flatten_length]
+        omega
+      -- Code containment for the five regions
+      have hcode_header : ∀ a' i,
+          CodeReq.singleton base (guard.neg.toInstr (Stmt.brOfs (bb.size + ba.size + 3)))
+            a' = some i → cr a' = some i :=
+        fun a' i h => hcode a' i (hflat ▸ ofProg_head a' i h)
+      have hcode_bb : ∀ a' i,
+          CodeReq.ofProg (base + 4) (bb.flatten (base + 4)) a' = some i → cr a' = some i :=
+        fun a' i h => hcode a' i
+          (hflat ▸ ofProg_cons_tail hlenAll a' i (ofProg_mono_left a' i h))
+      have hcode_break : ∀ a' i,
+          CodeReq.singleton (base + BitVec.ofNat 64 (4 * (bb.size + 1)))
+            (breakCond.toInstr (Stmt.brOfs (ba.size + 2))) a' = some i → cr a' = some i := by
+        intro a' i h
+        apply hcode a' i
+        rw [hflat]
+        apply ofProg_cons_tail hlenAll
+        apply ofProg_mono_right (p1 := bb.flatten (base + 4))
+          (by simp only [List.length_append, List.length_cons, List.length_nil,
+            Stmt.flatten_length]; omega)
+        rw [Stmt.flatten_length,
+          show (base + 4) + BitVec.ofNat 64 (4 * bb.size)
+            = base + BitVec.ofNat 64 (4 * (bb.size + 1)) from by bv_omega]
+        exact ofProg_head a' i h
+      have hcode_ba : ∀ a' i,
+          CodeReq.ofProg (base + BitVec.ofNat 64 (4 * (bb.size + 2)))
+            (ba.flatten (base + BitVec.ofNat 64 (4 * (bb.size + 2)))) a' = some i →
+          cr a' = some i := by
+        intro a' i h
+        apply hcode a' i
+        rw [hflat]
+        apply ofProg_cons_tail hlenAll
+        apply ofProg_mono_right (p1 := bb.flatten (base + 4))
+          (by simp only [List.length_append, List.length_cons, List.length_nil,
+            Stmt.flatten_length]; omega)
+        rw [Stmt.flatten_length,
+          show (base + 4) + BitVec.ofNat 64 (4 * bb.size)
+            = base + BitVec.ofNat 64 (4 * (bb.size + 1)) from by bv_omega]
+        apply ofProg_cons_tail
+          (by simp only [List.length_append, List.length_cons, List.length_nil,
+            Stmt.flatten_length]; omega)
+        rw [show (base + BitVec.ofNat 64 (4 * (bb.size + 1))) + 4
+            = base + BitVec.ofNat 64 (4 * (bb.size + 2)) from by bv_omega]
+        exact ofProg_mono_left a' i h
+      have hcode_jal : ∀ a' i,
+          CodeReq.singleton (base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 2)))
+            (.JAL .x0 (Stmt.jBack (bb.size + ba.size + 2))) a' = some i → cr a' = some i := by
+        intro a' i h
+        apply hcode a' i
+        rw [hflat]
+        apply ofProg_cons_tail hlenAll
+        apply ofProg_mono_right (p1 := bb.flatten (base + 4))
+          (by simp only [List.length_append, List.length_cons, List.length_nil,
+            Stmt.flatten_length]; omega)
+        rw [Stmt.flatten_length,
+          show (base + 4) + BitVec.ofNat 64 (4 * bb.size)
+            = base + BitVec.ofNat 64 (4 * (bb.size + 1)) from by bv_omega]
+        apply ofProg_cons_tail
+          (by simp only [List.length_append, List.length_cons, List.length_nil,
+            Stmt.flatten_length]; omega)
+        rw [show (base + BitVec.ofNat 64 (4 * (bb.size + 1))) + 4
+            = base + BitVec.ofNat 64 (4 * (bb.size + 2)) from by bv_omega]
+        apply ofProg_mono_right (p1 := ba.flatten (base + BitVec.ofNat 64 (4 * (bb.size + 2))))
+          (by simp only [List.length_cons, List.length_nil, Stmt.flatten_length]; omega)
+        rw [Stmt.flatten_length,
+          show (base + BitVec.ofNat 64 (4 * (bb.size + 2))) + BitVec.ofNat 64 (4 * ba.size)
+            = base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 2)) from by bv_omega]
+        exact ofProg_head a' i h
+      -- Header branch at any invariant index.
+      have hheader : ∀ (r : Reach),
+          cpsBranchWithin 1 base cr (asrtR reg rw r)
+            (base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 3)))
+              (asrtR reg rw fun rf ws A => r rf ws A ∧ ¬ guard.holds rf)
+            (base + 4) (asrtR reg rw fun rf ws A => r rf ws A ∧ guard.holds rf) := by
+        intro r
+        have hbr := branch_spec_asrt guard.neg (Stmt.brOfs (bb.size + ba.size + 3)) rw r base
+          (by rw [Cond.wf_neg]; exact hwfG)
+        rw [signExtend13_brOfs hofsHdr] at hbr
+        have hbr' := cpsBranchWithin_frameR (regOwn .x1) pcFree_regOwn
+          (cpsBranchWithin_frameR (bytesRegion reg.base reg.bytes)
+            (bytesRegion_pcFree _ _) (cpsBranchWithin_extend_code hcode_header hbr))
+        refine cpsBranchWithin_weaken (fun _ hp => hp) ?_ ?_ hbr'
+        · exact asrtR_mono (fun rf ws A hh =>
+            ⟨hh.1, (Cond.holds_neg guard rf).mp hh.2⟩)
+        · exact asrtR_mono (fun rf ws A hh =>
+            ⟨hh.1, Decidable.of_not_not
+              (fun hcc => hh.2 ((Cond.holds_neg guard rf).mpr hcc))⟩)
+      -- Break branch at `breakPt`.
+      have hbreak : ∀ (r : Reach),
+          cpsBranchWithin 1 (base + BitVec.ofNat 64 (4 * (bb.size + 1))) cr (asrtR reg rw r)
+            (base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 3)))
+              (asrtR reg rw fun rf ws A => r rf ws A ∧ breakCond.holds rf)
+            (base + BitVec.ofNat 64 (4 * (bb.size + 2)))
+              (asrtR reg rw fun rf ws A => r rf ws A ∧ ¬ breakCond.holds rf) := by
+        intro r
+        have hbr := branch_spec_asrt breakCond (Stmt.brOfs (ba.size + 2)) rw r
+          (base + BitVec.ofNat 64 (4 * (bb.size + 1))) hwfB
+        rw [signExtend13_brOfs hofsBreak,
+          show (base + BitVec.ofNat 64 (4 * (bb.size + 1)))
+              + BitVec.ofNat 64 (4 * (ba.size + 2))
+            = base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 3)) from by bv_omega,
+          show (base + BitVec.ofNat 64 (4 * (bb.size + 1))) + 4
+            = base + BitVec.ofNat 64 (4 * (bb.size + 2)) from by bv_omega] at hbr
+        exact cpsBranchWithin_frameR (regOwn .x1) pcFree_regOwn
+          (cpsBranchWithin_frameR (bytesRegion reg.base reg.bytes)
+            (bytesRegion_pcFree _ _) (cpsBranchWithin_extend_code hcode_break hbr))
+      -- Body-before triple: `base + 4` → `breakPt`.
+      have hbeforeStep : ∀ i, i < fuel →
+          cpsTripleWithin bb.steps (base + 4)
+            (base + BitVec.ofNat 64 (4 * (bb.size + 1))) cr
+            (asrtR reg rw fun rf ws A => inv i rf ws A ∧ guard.holds rf)
+            (asrtR reg rw (Stmt.sp reg rw bb
+              (fun rf ws A => inv i rf ws A ∧ guard.holds rf))) := by
+        intro i hi
+        have hb := ihbb (base + 4) (pfx ++ lbl ++ ".before.")
+          (fun rf ws A => inv i rf ws A ∧ guard.holds rf) hOBB (by omega) hcode_bb
+          hcalleesBB hcallsBB
+          (Stmt.vcs_antitone reg rw bb _ (fun rf ws A hr => ⟨i, hi, hr.1, hr.2⟩) hBBVcs)
+        rwa [show (base + 4) + BitVec.ofNat 64 (4 * bb.size)
+            = base + BitVec.ofNat 64 (4 * (bb.size + 1)) from by bv_omega] at hb
+      -- Body-after triple + back-jump: `afterEntry` → header.
+      have hafterStep : ∀ i, i < fuel →
+          cpsTripleWithin (ba.steps + 1)
+            (base + BitVec.ofNat 64 (4 * (bb.size + 2))) base cr
+            (asrtR reg rw fun rf ws A =>
+              Stmt.sp reg rw bb (fun rf ws A => inv i rf ws A ∧ guard.holds rf) rf ws A
+                ∧ ¬ breakCond.holds rf)
+            (asrtR reg rw fun rf ws A => inv (i + 1) rf ws A) := by
+        intro i hi
+        have hb := ihba (base + BitVec.ofNat 64 (4 * (bb.size + 2))) (pfx ++ lbl ++ ".after.")
+          (fun rf ws A =>
+            Stmt.sp reg rw bb (fun rf ws A => inv i rf ws A ∧ guard.holds rf) rf ws A
+              ∧ ¬ breakCond.holds rf) hOBA (by omega) hcode_ba hcalleesBA hcallsBA
+          (Stmt.vcs_antitone reg rw ba _ (fun rf ws A hr => ⟨i, hi, hr.1, hr.2⟩) hBAVcs)
+        have hjal := jal0_spec_pcFree (Stmt.jBack (bb.size + ba.size + 2))
+          (base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 2)))
+          (pcFree_asrtR reg rw (Stmt.sp reg rw ba fun rf ws A =>
+            Stmt.sp reg rw bb (fun rf ws A => inv i rf ws A ∧ guard.holds rf) rf ws A
+              ∧ ¬ breakCond.holds rf))
+        rw [show (base + BitVec.ofNat 64 (4 * (bb.size + 2)))
+              + BitVec.ofNat 64 (4 * ba.size)
+            = base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 2)) from by bv_omega] at hb
+        rw [add_jBack base (bb.size + ba.size + 2) (by omega) hofsBack] at hjal
+        have hjal' := cpsTripleWithin_extend_code hcode_jal hjal
+        have hseq := cpsTripleWithin_seq_same_cr hb hjal'
+        exact cpsTripleWithin_weaken (fun _ hp => hp)
+          (asrtR_mono (fun rf ws A hsp => hInvStep i hi rf ws A hsp)) hseq
+      -- The body as a branch: continue back to header, or break out to `Lexit`.
+      have hBodyBranch : ∀ i, i < fuel →
+          cpsBranchWithin (bb.steps + ba.steps + 2) (base + 4) cr
+            (asrtR reg rw fun rf ws A => inv i rf ws A ∧ guard.holds rf)
+            base (asrtR reg rw fun rf ws A => inv (i + 1) rf ws A)
+            (base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 3)))
+              (asrtR reg rw fun rf ws A =>
+                Stmt.sp reg rw bb (fun rf ws A => inv i rf ws A ∧ guard.holds rf) rf ws A
+                  ∧ breakCond.holds rf) := by
+        intro i hi
+        have hcomposed1 := cpsTripleWithin_seq_cpsBranchWithin_same_cr (hbeforeStep i hi)
+          (hbreak (Stmt.sp reg rw bb (fun rf ws A => inv i rf ws A ∧ guard.holds rf)))
+        have hcomposed2 := cpsBranchWithin_seq_cpsTripleWithin_same_cr hcomposed1
+          (hafterStep i hi) (fun _ hp => hp)
+        rw [show bb.steps + 1 + (ba.steps + 1) = bb.steps + ba.steps + 2 from by omega]
+          at hcomposed2
+        exact cpsBranchWithin_swap hcomposed2
+      -- The break-loop certificate, by downward recursion on the remaining fuel.
+      have hcert : ∀ fuel' start, start + fuel' = fuel →
+          WP.loopBreakNatCert 1 (bb.steps + ba.steps + 2) 1 base (base + 4)
+            (base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 3))) cr
+            (fun i => asrtR reg rw fun rf ws A => inv i rf ws A)
+            (fun i => asrtR reg rw fun rf ws A => inv i rf ws A ∧ guard.holds rf)
+            (fun i => asrtR reg rw fun rf ws A => inv i rf ws A ∧ ¬ guard.holds rf)
+            (fun i => asrtR reg rw fun rf ws A =>
+              Stmt.sp reg rw bb (fun rf ws A => inv i rf ws A ∧ guard.holds rf) rf ws A
+                ∧ breakCond.holds rf)
+            (asrtR reg rw post) start fuel' := by
+        intro fuel'
+        induction fuel' with
+        | zero =>
+            intro start hstart
+            simp only [WP.loopBreakNatCert]
+            have hsf : start = fuel := by omega
+            have hexit : cpsTripleWithin 0
+                (base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 3)))
+                (base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 3))) cr
+                (asrtR reg rw fun rf ws A => inv start rf ws A ∧ ¬ guard.holds rf)
+                (asrtR reg rw post) :=
+              cpsTripleWithin_entails (asrtR_mono (fun rf ws A hh =>
+                hGuardExit start (by omega) rf ws A hh.1 hh.2))
+            have hdead : cpsTripleWithin 0 (base + 4)
+                (base + BitVec.ofNat 64 (4 * (bb.size + ba.size + 3))) cr
+                (asrtR reg rw fun rf ws A => inv start rf ws A ∧ guard.holds rf)
+                (asrtR reg rw post) :=
+              cpsTripleWithin_unreachable (asrtR_unsat (fun rf ws A hh =>
+                hExhausted rf ws A (hsf ▸ hh.1) hh.2))
+            exact cpsBranchWithin_merge_same_cr
+              (cpsBranchWithin_swap (hheader (fun rf ws A => inv start rf ws A))) hdead hexit
+        | succ fuel' ih =>
+            intro start hstart
+            refine ⟨cpsBranchWithin_swap (hheader (fun rf ws A => inv start rf ws A)),
+              hBodyBranch start (by omega), ?_, ?_, ih (start + 1) (by omega)⟩
+            · exact asrtR_mono (fun rf ws A hh =>
+                hGuardExit start (by omega) rf ws A hh.1 hh.2)
+            · exact asrtR_mono (fun rf ws A hh =>
+                hBreak start (by omega) rf ws A hh.1 hh.2)
+      have hsound := WP.loopBreakNatCert_sound (hcert fuel 0 (by omega))
+      exact cpsTripleWithin_weaken
+        (asrtR_mono (fun rf ws A hr => hInvInit rf ws A hr))
+        (fun _ hp => hp)
+        hsound
   | call lbl f =>
       obtain ⟨hoffset, halign, hnotself⟩ := hcalls
       obtain ⟨hcalleeCode, hregeq, hrweq⟩ := hcallees

--- a/EvmAsm/Rv64/SAsm/Vc.lean
+++ b/EvmAsm/Rv64/SAsm/Vc.lean
@@ -111,6 +111,7 @@ def sp (reg : Region) (rw : RwRegion) : Stmt → Reach → Reach
   | «whileS» _ c fuel inv _, reach =>
       fun rf ws A => ∃ rf₀ ws₀ A₀, reach rf₀ ws₀ A₀
         ∧ (∃ i, i ≤ fuel ∧ inv rf₀ ws₀ A₀ i rf ws A) ∧ ¬ c.holds rf
+  | «whileBreak» _ _ _ _ post _ _ _, _ => post
   | call _ f, _ => fun rf ws A => f.post rf ws A
   | callReg _ _ handles, _ => fun rf ws A => ∃ h ∈ handles, h.post rf ws A
   | callRegS _ rs handles, reach => fun rf ws A => ∃ rf₀ ws₀ A₀,
@@ -170,6 +171,26 @@ def vcs (reg : Region) (rw : RwRegion) : Stmt → String → Reach → List VC
       vcs reg rw b (pfx ++ lbl ++ ".body.")
         (fun rf ws A => ∃ rf₀ ws₀ A₀, reach rf₀ ws₀ A₀
           ∧ ∃ i, i < fuel ∧ inv rf₀ ws₀ A₀ i rf ws A ∧ c.holds rf)
+  | «whileBreak» lbl guard fuel inv post bb breakCond ba, pfx, reach =>
+      ⟨pfx ++ lbl ++ ".inv_init", ∀ rf ws A, reach rf ws A → inv 0 rf ws A⟩ ::
+      ⟨pfx ++ lbl ++ ".inv_step", ∀ i, i < fuel →
+          ∀ rf' ws' A', sp reg rw ba
+              (fun rf ws A =>
+                sp reg rw bb (fun rf ws A => inv i rf ws A ∧ guard.holds rf) rf ws A
+                  ∧ ¬ breakCond.holds rf) rf' ws' A' →
+            inv (i + 1) rf' ws' A'⟩ ::
+      ⟨pfx ++ lbl ++ ".exhausted", ∀ rf ws A, inv fuel rf ws A → ¬ guard.holds rf⟩ ::
+      ⟨pfx ++ lbl ++ ".guard_exit", ∀ i, i ≤ fuel → ∀ rf ws A,
+          inv i rf ws A → ¬ guard.holds rf → post rf ws A⟩ ::
+      ⟨pfx ++ lbl ++ ".break", ∀ i, i < fuel → ∀ rf' ws' A',
+          sp reg rw bb (fun rf ws A => inv i rf ws A ∧ guard.holds rf) rf' ws' A' →
+          breakCond.holds rf' → post rf' ws' A'⟩ ::
+      (vcs reg rw bb (pfx ++ lbl ++ ".before.")
+        (fun rf ws A => ∃ i, i < fuel ∧ inv i rf ws A ∧ guard.holds rf)
+       ++ vcs reg rw ba (pfx ++ lbl ++ ".after.")
+        (fun rf ws A => ∃ i, i < fuel ∧
+          sp reg rw bb (fun rf ws A => inv i rf ws A ∧ guard.holds rf) rf ws A
+            ∧ ¬ breakCond.holds rf))
   | call lbl f, pfx, reach =>
       [⟨pfx ++ lbl ++ ".pre", ∀ rf ws A, reach rf ws A → f.pre rf ws A⟩]
   | callReg lbl rs handles, pfx, reach =>
@@ -191,6 +212,8 @@ def steps : Stmt → Nat
   | blockAt _ _ _ is => is.length
   | «while» _ _ fuel _ b => WP.loopBound 1 (b.steps + 1) 1 fuel
   | «whileS» _ _ fuel _ b => WP.loopBound 1 (b.steps + 1) 1 fuel
+  | «whileBreak» _ _ fuel _ _ bb _ ba =>
+      WP.loopBound 1 (bb.steps + ba.steps + 2) 1 fuel
   | call _ f => 1 + f.nSteps
   | callReg _ _ handles => 1 + handles.foldr (fun h m => max h.nSteps m) 0
   | callRegS _ _ handles => 1 + handles.foldr (fun h m => max h.nSteps m) 0
@@ -226,6 +249,8 @@ theorem sp_mono (reg : Region) (rw : RwRegion) (s : Stmt) {r₁ r₂ : Reach}
   | «whileS» lbl c fuel inv b ihb =>
       rintro rf ws A ⟨rf₀, ws₀, A₀, hr, hrest⟩
       exact ⟨rf₀, ws₀, A₀, h rf₀ ws₀ A₀ hr, hrest⟩
+  | «whileBreak» lbl guard fuel inv post bb breakCond ba ihbb ihba =>
+      exact fun rf ws A hr => hr
   | call lbl f =>
       exact fun rf ws A hr => hr
   | callReg lbl rs handles =>
@@ -363,6 +388,7 @@ theorem sp_of_endsWith (reg : Region) (rw : RwRegion) {P : Reach}
   | ghost lbl R => exact nomatch h
   | «while» lbl c fuel inv b ih => exact nomatch h
   | «whileS» lbl c fuel inv b ih => exact nomatch h
+  | «whileBreak» lbl guard fuel inv post bb breakCond ba ihbb ihba => exact nomatch h
   | call lbl f => exact nomatch h
   | callReg lbl rs handles => exact nomatch h
   | callRegS lbl rs handles => exact nomatch h
@@ -463,6 +489,18 @@ theorem vcs_antitone (reg : Region) (rw : RwRegion) (s : Stmt) (pfx : String)
           hr.elim fun rf₀ hr => hr.elim fun ws₀ hr => hr.elim fun A₀ hr =>
             ⟨rf₀, ws₀, A₀, h rf₀ ws₀ A₀ hr.1, hr.2⟩)
           (hvcs.tail.tail.tail) vc hvc
+  | «whileBreak» lbl guard fuel inv post bb breakCond ba ihbb ihba =>
+      intro vc hvc
+      simp only [vcs, List.mem_cons] at hvc
+      rcases hvc with rfl | rfl | rfl | rfl | rfl | hvc
+      · exact fun rf ws A hr => hvcs.head rf ws A (h rf ws A hr)
+      · exact hvcs.tail.head
+      · exact hvcs.tail.tail.head
+      · exact hvcs.tail.tail.tail.head
+      · exact hvcs.tail.tail.tail.tail.head
+      · -- body VCs (before ++ after): their reaches do not mention the outer
+        -- reachable set, so the same obligations serve `r₁` and `r₂`.
+        exact hvcs.tail.tail.tail.tail.tail vc hvc
   | call lbl f =>
       intro vc hvc
       simp only [vcs, List.mem_singleton] at hvc
@@ -494,6 +532,8 @@ def CalleesIn (s : Stmt) (reg : Region) (rw : RwRegion) (cr : CodeReq) : Prop :=
   | blockAt _ _ _ _ => True
   | «while» _ _ _ _ b => b.CalleesIn reg rw cr
   | «whileS» _ _ _ _ b => b.CalleesIn reg rw cr
+  | «whileBreak» _ _ _ _ _ bb _ ba =>
+      bb.CalleesIn reg rw cr ∧ ba.CalleesIn reg rw cr
   | call _ f => (∀ a i, f.code a = some i → cr a = some i)
       ∧ f.region = reg ∧ f.rw = rw
   | callReg _ _ handles => ∀ h ∈ handles,

--- a/EvmAsm/Rv64/SAsm/WhileBreakDemo.lean
+++ b/EvmAsm/Rv64/SAsm/WhileBreakDemo.lean
@@ -1,0 +1,327 @@
+/-
+  EvmAsm.Rv64.SAsm.WhileBreakDemo
+
+  End-to-end demo for the early-exit / break loop combinator `Stmt.whileBreak`
+  (bead evm-asm-huy8w).
+
+  `scanNzFn` is a *scan-until-predicate* loop: starting from a pointer `a0`
+  over a read-only byte region, count the leading zero bytes of `a0[0..a1)`,
+  stopping at the first non-zero byte (the mid-loop **break**) or when the
+  window is exhausted (the header guard).  Both exits establish the SAME
+  functional postcondition — `a0`-cursor and remaining count as functions of
+  the input — which is exactly the payoff of the break arm (`breakPost ⇒
+  post`).
+
+  This is the control-flow shape the single-exit `«while»` cannot express: a
+  header guard `beq x6,x0` PLUS a mid-loop `bne x7,x0` that jumps out *past*
+  the back-edge `JAL`.  The `#guard` below pins the flattened code
+  byte-for-byte against the hand-written break-past-`JAL` instruction stream.
+-/
+
+import EvmAsm.Rv64.SAsm.LoopFuel
+import EvmAsm.Rv64.SAsm.Tactic
+
+namespace EvmAsm.Rv64
+namespace SAsm
+namespace WhileBreakDemo
+
+open Stmt
+
+-- ============================================================================
+-- Ghost spec: number of leading zero bytes (self-contained, no `takeWhile`)
+-- ============================================================================
+
+/-- Number of leading zero bytes of the first `len` bytes of `bs`. -/
+def nlz : List (BitVec 8) → Nat → Nat
+  | _, 0 => 0
+  | [], _ + 1 => 0
+  | b :: bs, n + 1 => if b = 0 then nlz bs n + 1 else 0
+
+@[simp] theorem nlz_zero (bs : List (BitVec 8)) : nlz bs 0 = 0 := by
+  cases bs <;> rfl
+
+theorem nlz_le (bs : List (BitVec 8)) (len : Nat) : nlz bs len ≤ len := by
+  induction bs generalizing len with
+  | nil => cases len <;> simp [nlz]
+  | cons b bs ih =>
+      cases len with
+      | zero => simp
+      | succ n =>
+          unfold nlz
+          split
+          · have := ih n; omega
+          · omega
+
+/-- Every index below `nlz` names a zero byte. -/
+theorem nlz_spec (bs : List (BitVec 8)) (len i : Nat)
+    (hi : i < nlz bs len) : bs.getD i 0 = 0 := by
+  induction bs generalizing len i with
+  | nil => cases len <;> simp [nlz] at hi
+  | cons b bs ih =>
+      cases len with
+      | zero => simp [nlz] at hi
+      | succ n =>
+          unfold nlz at hi
+          by_cases hb : b = 0
+          · simp only [hb, if_true] at hi
+            cases i with
+            | zero => simpa using hb
+            | succ k =>
+                rw [List.getD_cons_succ]
+                exact ih n k (by omega)
+          · simp only [hb, if_false] at hi; omega
+
+/-- If `nlz` stops before `len` (with the window in range), the boundary byte
+    is non-zero — that is why the scan stopped. -/
+theorem nlz_boundary (bs : List (BitVec 8)) (len : Nat)
+    (hlt : nlz bs len < len) (hlen : len ≤ bs.length) : bs.getD (nlz bs len) 0 ≠ 0 := by
+  induction bs generalizing len with
+  | nil => cases len <;> simp_all [nlz]
+  | cons b bs ih =>
+      cases len with
+      | zero => simp [nlz] at hlt
+      | succ n =>
+          simp only [nlz] at hlt ⊢
+          by_cases hb : b = 0
+          · simp only [hb, if_true] at hlt ⊢
+            rw [List.getD_cons_succ]
+            exact ih n (by omega) (by simpa using hlen)
+          · simp only [hb, if_false]; simpa using hb
+
+/-- Continue step: still inside a zero run. -/
+theorem nlz_continue (bs : List (BitVec 8)) (len i : Nat)
+    (hi : i < len) (hlen : len ≤ bs.length) (hz : bs.getD i 0 = 0)
+    (hle : i ≤ nlz bs len) : i + 1 ≤ nlz bs len := by
+  rcases Nat.lt_or_ge i (nlz bs len) with h | h
+  · omega
+  · have hieq : i = nlz bs len := by omega
+    have hb := nlz_boundary bs len (by omega) hlen
+    rw [← hieq] at hb
+    exact absurd hz hb
+
+/-- Break step: the first non-zero byte is exactly at index `nlz`. -/
+theorem nlz_break (bs : List (BitVec 8)) (len i : Nat)
+    (hle : i ≤ nlz bs len) (hnz : bs.getD i 0 ≠ 0) : i = nlz bs len := by
+  rcases Nat.lt_or_ge i (nlz bs len) with h | h
+  · exact absurd (nlz_spec bs len i h) hnz
+  · omega
+
+-- ============================================================================
+-- The function
+-- ============================================================================
+
+/-- Loop invariant at header evaluation `i`: `i` leading zeros consumed. -/
+def scanInv (ptr : Word) (bs : List (BitVec 8)) (len : Nat) :
+    Nat → RegFile → List (BitVec 8) → Assertion → Prop :=
+  fun i rf _ _ =>
+    rf.get .x5 = ptr + BitVec.ofNat 64 i
+    ∧ rf.get .x6 = BitVec.ofNat 64 (len - i)
+    ∧ i ≤ nlz bs len
+    ∧ len ≤ bs.length
+    ∧ ptr.toNat + len < 2 ^ 64
+
+/-- Unified postcondition: cursor and remaining count as functions of input. -/
+def scanPost (ptr : Word) (bs : List (BitVec 8)) (len : Nat) :
+    RegFile → List (BitVec 8) → Assertion → Prop :=
+  fun rf _ _ =>
+    rf.get .x5 = ptr + BitVec.ofNat 64 (nlz bs len)
+    ∧ rf.get .x6 = BitVec.ofNat 64 (len - nlz bs len)
+
+/-- Scan `a0[0..a1)` for the first non-zero byte, counting leading zeros.
+    `x5` = cursor, `x6` = remaining; the loop breaks out at the first non-zero
+    byte (`bne x7,x0`) and exits at the top when the window empties
+    (`beq x6,x0`). -/
+def scanNzFn (ptr : Word) (bs : List (BitVec 8)) (len : Nat) : Fn where
+  name := "scanNz"
+  region := ⟨ptr, bs⟩
+  pre := fun rf _ _ =>
+    rf.get .x10 = ptr ∧ rf.get .x11 = BitVec.ofNat 64 len
+    ∧ len ≤ bs.length ∧ ptr.toNat + len < 2 ^ 64
+  post := scanPost ptr bs len
+  body :=
+    .block "init" [.MV .x5 .x10, .MV .x6 .x11] ;;;
+    .«whileBreak» "scan" (.bne .x6 .x0) len (scanInv ptr bs len) (scanPost ptr bs len)
+      (.block "load" [.LBU .x7 .x5 0]) (.bne .x7 .x0)
+      (.block "next" [.ADDI .x5 .x5 1, .ADDI .x6 .x6 (-1 : BitVec 12)])
+
+-- The flattened code, byte-for-byte, is the hand-written break-past-`JAL`
+-- pattern: init, header guard, load, break branch (jumps PAST the back-edge),
+-- decrements, back-edge.
+def scanNz_verified : Program := (scanNzFn 0 [] 0).body.flatten 0
+
+-- **Byte-identity pin**: the structured body flattens to exactly the
+-- hand-written scan-until-non-zero instruction stream, with the break branch
+-- at `+16` (past the `JAL -20` back-edge).
+#guard (scanNzFn 0 [] 0).body.flatten 0 =
+  [ .MV .x5 .x10,
+    .MV .x6 .x11,
+    .BEQ .x6 .x0 (24 : BitVec 13),
+    .LBU .x7 .x5 (0 : BitVec 12),
+    .BNE .x7 .x0 (16 : BitVec 13),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .ADDI .x6 .x6 (-1 : BitVec 12),
+    .JAL .x0 (-20 : BitVec 21) ]
+
+-- Position independence: no PC-relative instruction in the loop body.
+#guard (scanNzFn 0 [] 0).body.flatten 0 = (scanNzFn 0 [] 0).body.flatten 0x80000000
+
+theorem scanNzFn_spec (ptr : Word) (bs : List (BitVec 8)) (len : Nat)
+    (hwf : (Region.mk ptr bs).wf) (base : Word) :
+    (scanNzFn ptr bs len).Spec base := by
+  have hse0 : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
+  have hse1 : signExtend12 (1 : BitVec 12) = (1 : Word) := by decide
+  have hsem1 : signExtend12 (-1 : BitVec 12) = (-1 : Word) := by decide
+  vcgen
+  case region => exact ⟨hwf, RwRegion.empty_wf⟩
+  case scanNz.scan.inv_init =>
+    rintro rf ws A ⟨rf₀, ws₀, hws₀, ⟨hx10, hx11, hlen, hptr⟩, rfl, rfl⟩
+    obtain rfl := List.eq_nil_of_length_eq_zero hws₀
+    simp only [execBlock_cons, execBlock_nil, execInstrRF_nil, aluSem]
+    refine ⟨?_, ?_, Nat.zero_le _, hlen, hptr⟩
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide : Reg.x5 ≠ .x6),
+        RegFile.get_set_self _ _ _ (by decide), hx10]
+      simp
+    · rw [RegFile.get_set_self _ _ _ (by decide),
+        RegFile.get_set_ne _ _ _ _ (by decide : Reg.x11 ≠ .x5), hx11]
+      simp
+  case scanNz.scan.inv_step =>
+    rintro i hi rf' ws' A' hsp
+    -- unfold the after-block sp, then the before-block sp (named, not `rfl`)
+    obtain ⟨rfa, wsa, hwsa, ⟨hspbb, hnbreak⟩, hrf', -⟩ := hsp
+    obtain ⟨rfb, wsb, hwsb, ⟨hinv, hg⟩, hrfa, -⟩ := hspbb
+    obtain ⟨hx5, hx6, hle, hlen, hptr⟩ := hinv
+    obtain rfl := List.eq_nil_of_length_eq_zero hwsb
+    have hilt : i < len := by
+      rcases Nat.lt_or_ge i len with h | h
+      · exact h
+      · exfalso; apply hg
+        show rfb.get .x6 = rfb.get .x0
+        rw [hx6, show len - i = 0 from by omega]; rfl
+    have hbyte : (scanNzFn ptr bs len).region.byteAt (rfb.get .x5 + signExtend12 0)
+        = bs.getD i 0 := by
+      unfold Region.byteAt
+      rw [show (scanNzFn ptr bs len).region.bytes = bs from rfl,
+          show (scanNzFn ptr bs len).region.base = ptr from rfl, hx5, hse0]
+      congr 1
+      have hti : (BitVec.ofNat 64 i).toNat = i := by rw [BitVec.toNat_ofNat]; omega
+      bv_omega
+    -- load block: `x7 := byte`, `x5`/`x6` unchanged
+    have hrfa5 : rfa.get .x5 = rfb.get .x5 := by
+      rw [hrfa]
+      simp only [execBlock_cons, execBlock_nil, execInstrRF_nil, aluSem, loadSem,
+        RegFile.get_set_ne _ _ _ _ (by decide : Reg.x5 ≠ .x7)]
+    have hrfa6 : rfa.get .x6 = rfb.get .x6 := by
+      rw [hrfa]
+      simp only [execBlock_cons, execBlock_nil, execInstrRF_nil, aluSem, loadSem,
+        RegFile.get_set_ne _ _ _ _ (by decide : Reg.x6 ≠ .x7)]
+    have hrfa7 : rfa.get .x7 = BitVec.zeroExtend 64 (bs.getD i 0) := by
+      rw [hrfa]
+      simp only [execBlock_cons, execBlock_nil, execInstrRF_nil, aluSem, loadSem,
+        RegFile.get_set_self _ _ _ (by decide : (Reg.x7 : Reg) ≠ .x0)]
+      rw [hbyte]
+    -- ¬ breakCond ⇒ byte is zero
+    have hz : bs.getD i 0 = 0 := by
+      have hne : rfa.get .x7 = rfa.get .x0 := by
+        by_contra h; exact hnbreak h
+      rw [hrfa7, show rfa.get .x0 = 0 from rfl] at hne
+      bv_omega
+    refine ⟨?_, ?_, nlz_continue bs len i hilt hlen hz hle, hlen, hptr⟩
+    · rw [hrf']
+      simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem,
+        RegFile.get_set_ne _ _ _ _ (by decide : Reg.x5 ≠ .x6),
+        RegFile.get_set_self _ _ _ (by decide : (Reg.x5 : Reg) ≠ .x0)]
+      rw [hrfa5, hx5, hse1]
+      have h1 : (BitVec.ofNat 64 i).toNat = i := by rw [BitVec.toNat_ofNat]; omega
+      have h2 : (BitVec.ofNat 64 (i + 1)).toNat = i + 1 := by rw [BitVec.toNat_ofNat]; omega
+      bv_omega
+    · rw [hrf']
+      simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem,
+        RegFile.get_set_self _ _ _ (by decide : (Reg.x6 : Reg) ≠ .x0),
+        RegFile.get_set_ne _ _ _ _ (by decide : Reg.x6 ≠ .x5)]
+      rw [hrfa6, hx6, hsem1]
+      have h1 : (BitVec.ofNat 64 (len - i)).toNat = len - i := by rw [BitVec.toNat_ofNat]; omega
+      have h2 : (BitVec.ofNat 64 (len - (i + 1))).toNat = len - (i + 1) := by
+        rw [BitVec.toNat_ofNat]; omega
+      bv_omega
+  case scanNz.scan.exhausted =>
+    rintro rf ws A ⟨-, hx6, -, -, -⟩
+    intro hc
+    apply hc
+    rw [hx6, show len - len = 0 from by omega]; rfl
+  case scanNz.scan.guard_exit =>
+    rintro i hile rf ws A ⟨hx5, hx6, hle, hlen, hptr⟩ hng
+    -- ¬guard: x6 = 0 ⇒ i = len ⇒ nlz = len
+    have hil : i = len := by
+      by_contra hne
+      apply hng
+      show rf.get .x6 ≠ rf.get .x0
+      rw [hx6, show rf.get .x0 = 0 from rfl]
+      intro h
+      have := congrArg (fun w : Word => w.toNat) h
+      simp only [BitVec.toNat_ofNat, show (0 : Word).toNat = 0 from rfl] at this
+      omega
+    have hnlz : nlz bs len = len := by
+      have := nlz_le bs len; omega
+    refine ⟨?_, ?_⟩
+    · rw [hx5, hnlz, hil]
+    · rw [hx6, hnlz, hil]
+  case scanNz.scan.break =>
+    rintro i hi rf' ws' A' hsp hbreak
+    obtain ⟨rfb, wsb, hwsb, ⟨hinv, hg⟩, hrf', -⟩ := hsp
+    obtain ⟨hx5, hx6, hle, hlen, hptr⟩ := hinv
+    obtain rfl := List.eq_nil_of_length_eq_zero hwsb
+    have hbyte : (scanNzFn ptr bs len).region.byteAt (rfb.get .x5 + signExtend12 0)
+        = bs.getD i 0 := by
+      unfold Region.byteAt
+      rw [show (scanNzFn ptr bs len).region.bytes = bs from rfl,
+          show (scanNzFn ptr bs len).region.base = ptr from rfl, hx5, hse0]
+      congr 1
+      have hti : (BitVec.ofNat 64 i).toNat = i := by rw [BitVec.toNat_ofNat]; omega
+      bv_omega
+    have hrf7 : rf'.get .x7 = BitVec.zeroExtend 64 (bs.getD i 0) := by
+      rw [hrf']
+      simp only [execBlock_cons, execBlock_nil, execInstrRF_nil, aluSem, loadSem,
+        RegFile.get_set_self _ _ _ (by decide : (Reg.x7 : Reg) ≠ .x0)]
+      rw [hbyte]
+    have hrf5 : rf'.get .x5 = rfb.get .x5 := by
+      rw [hrf']
+      simp only [execBlock_cons, execBlock_nil, execInstrRF_nil, aluSem, loadSem,
+        RegFile.get_set_ne _ _ _ _ (by decide : Reg.x5 ≠ .x7)]
+    have hrf6 : rf'.get .x6 = rfb.get .x6 := by
+      rw [hrf']
+      simp only [execBlock_cons, execBlock_nil, execInstrRF_nil, aluSem, loadSem,
+        RegFile.get_set_ne _ _ _ _ (by decide : Reg.x6 ≠ .x7)]
+    -- breakCond ⇒ byte ≠ 0
+    have hnz : bs.getD i 0 ≠ 0 := by
+      have hne : rf'.get .x7 ≠ rf'.get .x0 := hbreak
+      rw [hrf7, show rf'.get .x0 = 0 from rfl] at hne
+      intro hz
+      exact hne (by rw [hz]; rfl)
+    have hieq : i = nlz bs len := nlz_break bs len i hle hnz
+    refine ⟨?_, ?_⟩
+    · rw [hrf5, hx5, hieq]
+    · rw [hrf6, hx6, hieq]
+  case scanNz.scan.before.load.mem =>
+    rintro rf ws A hws ⟨i, hi, ⟨hx5, hx6, hle, hlen, hptr⟩, hg⟩
+    obtain rfl := List.eq_nil_of_length_eq_zero hws
+    have hilt : i < len := by
+      rcases Nat.lt_or_ge i len with h | h
+      · exact h
+      · exfalso; apply hg
+        rw [hx6, show len - i = 0 from by omega]; rfl
+    simp only [blockVCs, loadSem]
+    refine ⟨⟨one_dvd _, ?_⟩, trivial⟩
+    show ((rf.get .x5 + signExtend12 (0 : BitVec 12)) - ptr).toNat + 1 ≤ bs.length
+    rw [hse0, hx5]
+    have : (BitVec.ofNat 64 i).toNat = i := by rw [BitVec.toNat_ofNat]; omega
+    have haddr : ((ptr + BitVec.ofNat 64 i + 0) - ptr).toNat = i := by bv_omega
+    rw [haddr]; omega
+  case scanNz.post =>
+    rintro rf ws A h
+    exact h
+
+#print axioms scanNzFn_spec
+
+end WhileBreakDemo
+end SAsm
+end EvmAsm.Rv64

--- a/EvmAsm/Rv64/WP/Loop.lean
+++ b/EvmAsm/Rv64/WP/Loop.lean
@@ -68,6 +68,71 @@ theorem loopNatCert_sound {nHeader nBody nExit : Nat}
       simpa [loopBound] using
         (cpsBranchWithin_merge_same_cr hHeader hBodyTail hExit)
 
+/-- Input obligations for a bounded natural-number loop **with a mid-body
+    early exit** (`break`).
+
+    Same skeleton as `loopNatCert`, but the body is a *branch* rather than a
+    straight triple: from `bodyEntry` it either falls back to `header` with
+    `inv (start + 1)` (continue) or jumps to `exit_` with `breakPost start`
+    (break).  The break arm short-cuts straight to the loop's postcondition
+    — that is the whole content of the construct: `breakPost` need only
+    entail `post`.  Both the header exit (guard fails) and the break exit
+    entail `post`. -/
+def loopBreakNatCert (nHeader nBody nExit : Nat)
+    (header bodyEntry exit_ : Word) (cr : CodeReq)
+    (inv bodyPre exitPost breakPost : Nat → Assertion) (post : Assertion)
+    (start : Nat) : Nat → Prop
+  | 0 =>
+      cpsTripleWithin nExit header exit_ cr (inv start) post
+  | fuel + 1 =>
+      cpsBranchWithin nHeader header cr (inv start)
+        bodyEntry (bodyPre start) exit_ (exitPost start) ∧
+      cpsBranchWithin nBody bodyEntry cr (bodyPre start)
+        header (inv (start + 1)) exit_ (breakPost start) ∧
+      Entails (exitPost start) post ∧
+      Entails (breakPost start) post ∧
+      loopBreakNatCert nHeader nBody nExit header bodyEntry exit_ cr
+        inv bodyPre exitPost breakPost post (start + 1) fuel
+
+/-- Soundness of `loopBreakNatCert`: the generated precondition is `inv start`,
+    and the step budget is the same `loopBound` as an ordinary bounded loop
+    (the break can only reach the exit *sooner*). -/
+theorem loopBreakNatCert_sound {nHeader nBody nExit : Nat}
+    {header bodyEntry exit_ : Word} {cr : CodeReq}
+    {inv bodyPre exitPost breakPost : Nat → Assertion} {post : Assertion}
+    {start fuel : Nat}
+    (hcert : loopBreakNatCert nHeader nBody nExit header bodyEntry exit_ cr
+      inv bodyPre exitPost breakPost post start fuel) :
+    cpsTripleWithin (loopBound nHeader nBody nExit fuel)
+      header exit_ cr (inv start) post := by
+  induction fuel generalizing start with
+  | zero =>
+      simpa [loopBreakNatCert, loopBound] using hcert
+  | succ fuel ih =>
+      obtain ⟨hHeader, hBody, hExitPost, hBreakPost, hTailCert⟩ := hcert
+      have hTail :
+          cpsTripleWithin (loopBound nHeader nBody nExit fuel)
+            header exit_ cr (inv (start + 1)) post :=
+        ih hTailCert
+      have hBreakExit :
+          cpsTripleWithin (loopBound nHeader nBody nExit fuel)
+            exit_ exit_ cr (breakPost start) post :=
+        cpsTripleWithin_mono_nSteps (Nat.zero_le _)
+          (Triple.refl exit_ cr hBreakPost).sound
+      -- The body branch, closed on both arms: continue folds into the tail
+      -- certificate, break short-cuts to `post`.
+      have hBodyMerged :
+          cpsTripleWithin (nBody + loopBound nHeader nBody nExit fuel)
+            bodyEntry exit_ cr (bodyPre start) post :=
+        cpsBranchWithin_merge_same_cr hBody hTail hBreakExit
+      have hHeaderExit :
+          cpsTripleWithin (nBody + loopBound nHeader nBody nExit fuel)
+            exit_ exit_ cr (exitPost start) post :=
+        cpsTripleWithin_mono_nSteps (Nat.zero_le _)
+          (Triple.refl exit_ cr hExitPost).sound
+      simpa [loopBound] using
+        (cpsBranchWithin_merge_same_cr hHeader hBodyMerged hHeaderExit)
+
 /-- Package a bounded loop certificate as a WP triple. -/
 def Triple.ofLoopNatCert {nHeader nBody nExit : Nat}
     {header bodyEntry exit_ : Word} {cr : CodeReq}


### PR DESCRIPTION
## What

Adds `Stmt.whileBreak`, a bounded loop with a **mid-body early exit** (break) to the SAsm structured-assembly DSL — the control-flow shape the single-exit `«while»` cannot express: a header guard **plus** a mid-loop conditional branch that jumps out of the loop *past the synthesized back-edge* (the machine idiom "scan until a predicate holds").

Surfaced by `swd_minimal_copy` (`.12.9`), whose leading-zero strip loop (`BNE x7,x0 → .Lstore` at `+16`, past `JAL -20`) is byte-identical to a structured body at every instruction **except** that early-exit branch. Bead `evm-asm-huy8w`.

**Purely additive** — every existing `«while»`/`«whileS»` user is untouched.

## Design (a break just short-cuts the loop's post)

The break arm is one extra VC: when the break condition holds at the break point, the loop's exit `post` already holds. Everything else mirrors `«while»`.

- **WP** (`WP/Loop.lean`): `loopBreakNatCert` + `loopBreakNatCert_sound`. Same `loopBound` budget; the per-iteration body is a *branch* — continue → header (`inv (i+1)`), or break → `exit_` (`breakPost`); both `exitPost`/`breakPost ⇒ post`.
- **AST/Flatten**: constructor + `size`/`callFree`; layout `[B¬guard→Lexit] · bodyBefore · [B breakCond→Lexit] · bodyAfter · [JAL→hdr]`; `offsetsOk`, `callsOk`.
- **Vc**: `sp` (= the stated `post`); five VCs — `inv_init`, `inv_step`, `exhausted`, `guard_exit`, `break` — + per-body VCs; `steps`; `sp_mono`/`vcs_antitone`/`CalleesIn`/`EndsWith` arms.
- **Soundness**: the `whileBreak` case in both `Stmt.sound` and `Stmt.soundR`.

## Demo

`WhileBreakDemo.scanNzFn` — a leading-zero scan; both exits (guard-fail and break-at-first-nonzero) establish the SAME functional post. Flatten pinned byte-for-byte:

```
#guard (scanNzFn 0 [] 0).body.flatten 0 =
  [ .MV .x5 .x10, .MV .x6 .x11, .BEQ .x6 .x0 24, .LBU .x7 .x5 0,
    .BNE .x7 .x0 16,          -- break: +16, PAST the JAL -20 back-edge
    .ADDI .x5 .x5 1, .ADDI .x6 .x6 (-1), .JAL .x0 (-20) ]
```

## Gates

- Corpus `lake build` green (3800 jobs); `check-forbidden-tactics.sh` clean; no `sorry`/`native_decide`/`bv_decide`, no heartbeat/recDepth bumps.
- `#print axioms`: `Stmt.sound`, `Stmt.soundR`, `WhileBreakDemo.scanNzFn_spec` → `[propext, Classical.choice, Quot.sound]`; `WP.loopBreakNatCert_sound` → `[propext, Quot.sound]`.

`.67` has landed on main; this rebases onto it. `swd_minimal_copy` (`.12.9`) stacks on this next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)