### PR TITLE
feat(evm64): evmMemoryIs separation-logic assertion for the EVM memory region

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -165,6 +165,7 @@ import EvmAsm.Evm64.PrecompileDispatch
 
 -- EVM memory model (issue #99)
 import EvmAsm.Evm64.Memory
+import EvmAsm.Evm64.StateAssertions
 import EvmAsm.Evm64.MemoryGas
 import EvmAsm.Evm64.KeccakArgs
 import EvmAsm.Evm64.KeccakArgsStackDecode

--- a/EvmAsm/Evm64/MLoad.lean
+++ b/EvmAsm/Evm64/MLoad.lean
@@ -8,4 +8,5 @@ import EvmAsm.Evm64.MLoad.ByteWindow
 import EvmAsm.Evm64.MLoad.StackSpec
 import EvmAsm.Evm64.MLoad.UnalignedStackSpec
 import EvmAsm.Evm64.MLoad.UnalignedFramedStackSpec
+import EvmAsm.Evm64.MLoad.MemoryRegionStackSpec
 import EvmAsm.Evm64.MLoad.Expansion

--- a/EvmAsm/Evm64/MLoad/MemoryRegionStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/MemoryRegionStackSpec.lean
@@ -1,0 +1,420 @@
+/-
+  EvmAsm.Evm64.MLoad.MemoryRegionStackSpec
+
+  The public MLOAD stack spec restated against `evmMemoryIs` — the
+  load-bearing check that `evmMemoryIs` (EvmAsm/Evm64/StateAssertions.lean)
+  describes the guest's *actual* EVM memory region.
+
+  `evm_mload_stack_spec_within` frames against eight raw dword cells (four
+  lo/hi window pairs governed by `mloadLimbWindowOk`). Here we consume the
+  proven spec and repackage that footprint: the pre/post own a single
+  `evmMemoryIs memBase capacity contents` resource, the touched 64-byte
+  dword window is peeled out via `evmMemoryIs_peel_window64`, the window
+  side conditions are discharged from the region-placement facts, and the
+  value pushed on the EVM stack is shown to be
+  `evmMemoryReadWord contents offset.toNat` — the 32 bytes at the
+  requested offset, big-endian, exactly the EVM-spec MLOAD result.
+
+  Scope: the dword-aligned case (`start = 0`, i.e. `offset ≡ 0 (mod 8)`
+  with a dword-aligned `memBase`). For `start ≠ 0` adjacent limb windows
+  of the public spec share a dword cell, so its separated eight-cell
+  precondition is only instantiable in the aligned case; the aligned spec
+  is the one the proven pipeline exercises.
+-/
+
+import EvmAsm.Evm64.StateAssertions
+import EvmAsm.Evm64.MLoad.UnalignedFramedStackSpec
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-! ## The MLOAD result as a function of the region contents -/
+
+/-- The 256-bit value MLOAD reads from region bytes `[k, k+32)`:
+    big-endian (byte `k` is most significant), zero-padded past the end of
+    the list — the EVM's zero-extended-tail read semantics. -/
+def evmMemoryReadWord (bs : List (BitVec 8)) (k : Nat) : EvmWord :=
+  mloadLoadedWordFromBytes
+    (getByteAt bs k) (getByteAt bs (k + 1)) (getByteAt bs (k + 2))
+    (getByteAt bs (k + 3)) (getByteAt bs (k + 4)) (getByteAt bs (k + 5))
+    (getByteAt bs (k + 6)) (getByteAt bs (k + 7))
+    (getByteAt bs (k + 8)) (getByteAt bs (k + 9)) (getByteAt bs (k + 10))
+    (getByteAt bs (k + 11)) (getByteAt bs (k + 12)) (getByteAt bs (k + 13))
+    (getByteAt bs (k + 14)) (getByteAt bs (k + 15))
+    (getByteAt bs (k + 16)) (getByteAt bs (k + 17)) (getByteAt bs (k + 18))
+    (getByteAt bs (k + 19)) (getByteAt bs (k + 20)) (getByteAt bs (k + 21))
+    (getByteAt bs (k + 22)) (getByteAt bs (k + 23))
+    (getByteAt bs (k + 24)) (getByteAt bs (k + 25)) (getByteAt bs (k + 26))
+    (getByteAt bs (k + 27)) (getByteAt bs (k + 28)) (getByteAt bs (k + 29))
+    (getByteAt bs (k + 30)) (getByteAt bs (k + 31))
+
+/-! ## Bridges: window-pair byte algebra → region bytes -/
+
+/-- With `start = 0` a window byte comes from the lo dword only, and the
+    lo dword of the region at dword-aligned `c` holds bytes `[c, c+8)`. -/
+theorem mloadByteFromDwordPair_dwordAt (bs : List (BitVec 8)) (c i : Nat)
+    (hiVal : Word) (hi : i < 8) (hin : c + 8 ≤ bs.length) :
+    mloadByteFromDwordPair (dwordAt bs c) hiVal 0 i = getByteAt bs (c + i) := by
+  rw [mloadByteFromDwordPair_start_zero _ _ hi]
+  unfold dwordAt
+  rw [extractByte_packBytes _ i hi
+    (by rw [List.length_take, List.length_drop]; omega)]
+  rw [List.getElem_take, List.getElem_drop]
+  unfold getByteAt
+  rw [dif_pos (by omega : c + i < bs.length)]
+
+/-- The word the proven MLOAD spec pushes, instantiated with the region's
+    window dwords at aligned offset `k`, is the region read
+    `evmMemoryReadWord bs k`. The hi dwords are scratch (unread at
+    `start = 0`), so they are arbitrary. -/
+theorem mloadStackOutputWordFromDwordPairs_dwordAt
+    (bs : List (BitVec 8)) (k : Nat) (h0 h1 h2 h3 : Word)
+    (hin : k + 32 ≤ bs.length) :
+    mloadStackOutputWordFromDwordPairs
+      (dwordAt bs (k + 24)) h0 0 (dwordAt bs (k + 16)) h1 0
+      (dwordAt bs (k + 8)) h2 0 (dwordAt bs k) h3 0 =
+      evmMemoryReadWord bs k := by
+  unfold mloadStackOutputWordFromDwordPairs evmMemoryReadWord
+  rw [mloadByteFromDwordPair_dwordAt bs k 0 h3 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs k 1 h3 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs k 2 h3 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs k 3 h3 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs k 4 h3 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs k 5 h3 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs k 6 h3 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs k 7 h3 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 8) 0 h2 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 8) 1 h2 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 8) 2 h2 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 8) 3 h2 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 8) 4 h2 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 8) 5 h2 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 8) 6 h2 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 8) 7 h2 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 16) 0 h1 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 16) 1 h1 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 16) 2 h1 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 16) 3 h1 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 16) 4 h1 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 16) 5 h1 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 16) 6 h1 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 16) 7 h1 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 24) 0 h0 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 24) 1 h0 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 24) 2 h0 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 24) 3 h0 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 24) 4 h0 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 24) 5 h0 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 24) 6 h0 (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs (k + 24) 7 h0 (by omega) (by omega)]
+  rw [show k + 0 = k from rfl,
+      show k + 8 + 0 = k + 8 from rfl,
+      show k + 8 + 1 = k + 9 from by omega,
+      show k + 8 + 2 = k + 10 from by omega,
+      show k + 8 + 3 = k + 11 from by omega,
+      show k + 8 + 4 = k + 12 from by omega,
+      show k + 8 + 5 = k + 13 from by omega,
+      show k + 8 + 6 = k + 14 from by omega,
+      show k + 8 + 7 = k + 15 from by omega,
+      show k + 16 + 0 = k + 16 from rfl,
+      show k + 16 + 1 = k + 17 from by omega,
+      show k + 16 + 2 = k + 18 from by omega,
+      show k + 16 + 3 = k + 19 from by omega,
+      show k + 16 + 4 = k + 20 from by omega,
+      show k + 16 + 5 = k + 21 from by omega,
+      show k + 16 + 6 = k + 22 from by omega,
+      show k + 16 + 7 = k + 23 from by omega,
+      show k + 24 + 0 = k + 24 from rfl,
+      show k + 24 + 1 = k + 25 from by omega,
+      show k + 24 + 2 = k + 26 from by omega,
+      show k + 24 + 3 = k + 27 from by omega,
+      show k + 24 + 4 = k + 28 from by omega,
+      show k + 24 + 5 = k + 29 from by omega,
+      show k + 24 + 6 = k + 30 from by omega,
+      show k + 24 + 7 = k + 31 from by omega]
+
+/-- Scratch-register bridge: the packed limb the guest leaves in the
+    accumulator is the MSB limb of the region read. -/
+theorem mloadPackedLimbFromDwordPair_dwordAt
+    (bs : List (BitVec 8)) (k : Nat) (hiVal : Word) (hin : k + 32 ≤ bs.length) :
+    mloadPackedLimbFromDwordPair (dwordAt bs k) hiVal 0 =
+      (evmMemoryReadWord bs k).getLimbN 3 := by
+  unfold mloadPackedLimbFromDwordPair evmMemoryReadWord
+  rw [getLimbN_mloadLoadedWordFromBytes_3]
+  rw [mloadByteFromDwordPair_dwordAt bs k 0 hiVal (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs k 1 hiVal (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs k 2 hiVal (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs k 3 hiVal (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs k 4 hiVal (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs k 5 hiVal (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs k 6 hiVal (by omega) (by omega),
+      mloadByteFromDwordPair_dwordAt bs k 7 hiVal (by omega) (by omega)]
+  rw [show k + 0 = k from rfl]
+
+/-! ## Window side conditions from region facts -/
+
+/-- Discharge one aligned (`start = 0`) MLOAD limb window from
+    region-placement facts: base and offset dword-aligned, the access
+    inside the addressable region, and every region byte a valid guest
+    address. `c ∈ {0, 8, 16, 24}` selects the limb; the lo dword is the
+    region dword at `k + c` and the hi dword is the (unread) scratch
+    dword at `k + (c + 32)`. -/
+theorem mloadLimbWindowOk_aligned_region
+    (memBase offset : Word) (k c len : Nat)
+    (hk : offset.toNat = k)
+    (halignB : memBase.toNat % 8 = 0)
+    (hk8 : k % 8 = 0) (hc8 : c % 8 = 0) (hc : c ≤ 24)
+    (hbound : memBase.toNat + len ≤ 2 ^ 64)
+    (hin : k + 64 ≤ len)
+    (hvalid : ∀ i : Nat, i < len →
+      isValidMemAddr (memBase + BitVec.ofNat 64 i) = true) :
+    mloadLimbWindowOk (memBase + offset)
+      (memBase + BitVec.ofNat 64 (k + c))
+      (memBase + BitVec.ofNat 64 (k + (c + 32))) 0
+      (BitVec.ofNat 12 c) (BitVec.ofNat 12 (c + 1)) (BitVec.ofNat 12 (c + 2))
+      (BitVec.ofNat 12 (c + 3)) (BitVec.ofNat 12 (c + 4)) (BitVec.ofNat 12 (c + 5))
+      (BitVec.ofNat 12 (c + 6)) (BitVec.ofNat 12 (c + 7)) := by
+  have hmb := memBase.isLt
+  have hoffl := offset.isLt
+  have hptr : memBase + offset = memBase + BitVec.ofNat 64 k := by
+    congr 1
+    apply BitVec.eq_of_toNat_eq
+    rw [BitVec.toNat_ofNat]
+    omega
+  have halignFact : ∀ m i : Nat, c + i = m → i < 8 →
+      alignToDword ((memBase + offset) + BitVec.ofNat 64 m) =
+        memBase + BitVec.ofNat 64 (k + c) := by
+    intro m i hm hi
+    rw [hptr, add_ofNat_add_ofNat,
+        alignToDword_add_ofNat_of_aligned halignB (by omega)]
+    have hdiv : 8 * ((k + m) / 8) = k + c := by omega
+    rw [hdiv]
+  have hboFact : ∀ m i : Nat, c + i = m → i < 8 →
+      byteOffset ((memBase + offset) + BitVec.ofNat 64 m) = (0 + i) % 8 := by
+    intro m i hm hi
+    rw [hptr, add_ofNat_add_ofNat,
+        byteOffset_add_ofNat_of_aligned halignB (by omega)]
+    omega
+  have hvalFact : ∀ m i : Nat, c + i = m → i < 8 →
+      isValidByteAccess ((memBase + offset) + BitVec.ofNat 64 m) = true := by
+    intro m i hm hi
+    rw [hptr, add_ofNat_add_ofNat, isValidByteAccess_eq]
+    exact hvalid (k + m) (by omega)
+  unfold mloadLimbWindowOk
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_,
+          ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · rw [signExtend12_ofNat_small (by omega), mloadDwordPairAddr_low _ _ (by omega)]
+    exact halignFact c 0 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega)]
+    exact hvalFact c 0 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega)]
+    exact hboFact c 0 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega), mloadDwordPairAddr_low _ _ (by omega)]
+    exact halignFact (c + 1) 1 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega)]
+    exact hvalFact (c + 1) 1 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega)]
+    exact hboFact (c + 1) 1 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega), mloadDwordPairAddr_low _ _ (by omega)]
+    exact halignFact (c + 2) 2 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega)]
+    exact hvalFact (c + 2) 2 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega)]
+    exact hboFact (c + 2) 2 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega), mloadDwordPairAddr_low _ _ (by omega)]
+    exact halignFact (c + 3) 3 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega)]
+    exact hvalFact (c + 3) 3 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega)]
+    exact hboFact (c + 3) 3 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega), mloadDwordPairAddr_low _ _ (by omega)]
+    exact halignFact (c + 4) 4 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega)]
+    exact hvalFact (c + 4) 4 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega)]
+    exact hboFact (c + 4) 4 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega), mloadDwordPairAddr_low _ _ (by omega)]
+    exact halignFact (c + 5) 5 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega)]
+    exact hvalFact (c + 5) 5 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega)]
+    exact hboFact (c + 5) 5 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega), mloadDwordPairAddr_low _ _ (by omega)]
+    exact halignFact (c + 6) 6 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega)]
+    exact hvalFact (c + 6) 6 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega)]
+    exact hboFact (c + 6) 6 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega), mloadDwordPairAddr_low _ _ (by omega)]
+    exact halignFact (c + 7) 7 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega)]
+    exact hvalFact (c + 7) 7 rfl (by omega)
+  · rw [signExtend12_ofNat_small (by omega)]
+    exact hboFact (c + 7) 7 rfl (by omega)
+
+/-! ## The reframed public MLOAD stack spec -/
+
+/-- **MLOAD against `evmMemoryIs`** (aligned case). The proven public
+    MLOAD stack spec `evm_mload_stack_spec_within`, with its raw
+    eight-dword window footprint repackaged as the single region resource
+    `evmMemoryIs memBase capacity contents`: the region is unchanged, and
+    the word pushed on the EVM stack is `evmMemoryReadWord contents
+    offset.toNat` — the 32 region bytes at the requested offset. This is
+    the honesty gate for `evmMemoryIs`: it is derived from (not assumed
+    of) the guest's proven MLOAD routine.
+
+    Region side conditions: `contents` covers the full static allocation
+    (`hlen`), the region is addressable without wrap (`hbound`) and valid
+    (`hvalid` — discharged by `isValidMemAddr_evmMemoryArea` for the real
+    `EVM_MEMORY_AREA` slab, see `evm_mload_stack_spec_within_evmMemoryArea`),
+    and the access window `[offset, offset+64)` is in bounds (`hin` — the
+    extra 32 bytes past the loaded word are the four scratch hi-dwords of
+    the guest's limb windows). -/
+theorem evm_mload_stack_spec_within_evmMemoryIs
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase byteOld accOld : Word)
+    (offsetWord : EvmWord) (rest : List EvmWord)
+    (dstOld1 dstOld2 dstOld3 : Word)
+    (capacity : Nat) (contents : List (BitVec 8)) (base : Word)
+    (h_offset0 : offsetWord.getLimbN 0 = offset)
+    (h_offset1 : offsetWord.getLimbN 1 = dstOld1)
+    (h_offset2 : offsetWord.getLimbN 2 = dstOld2)
+    (h_offset3 : offsetWord.getLimbN 3 = dstOld3)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (hlen : contents.length = capacity)
+    (halignB : memBase.toNat % 8 = 0)
+    (hoff8 : offset.toNat % 8 = 0)
+    (hin : offset.toNat + 64 ≤ contents.length)
+    (hbound : memBase.toNat + contents.length ≤ 2 ^ 64)
+    (hvalid : ∀ i : Nat, i < contents.length →
+      isValidMemAddr (memBase + BitVec.ofNat 64 i) = true) :
+    cpsTripleWithin (2 + (23 + 23 + 23 + 23)) base (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+       evmStackIs sp (offsetWord :: rest) **
+       (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+       evmMemoryIs memBase capacity contents)
+      (evmStackIs sp (evmMemoryReadWord contents offset.toNat :: rest) **
+       ((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+       (byteReg ↦ᵣ (getByteAt contents (offset.toNat + 7)).zeroExtend 64) **
+       (accReg ↦ᵣ (evmMemoryReadWord contents offset.toNat).getLimbN 3) **
+       evmMemoryIs memBase capacity contents) := by
+  set k := offset.toNat with hkdef
+  -- The four aligned limb windows, coerced to the numeral-offset shapes
+  -- the public spec expects (definitional equalities only).
+  have hw0 : mloadLimbWindowOk (memBase + offset)
+      (memBase + BitVec.ofNat 64 (k + 24)) (memBase + BitVec.ofNat 64 (k + 56)) 0
+      24 25 26 27 28 29 30 31 :=
+    mloadLimbWindowOk_aligned_region memBase offset k 24 contents.length rfl
+      halignB hoff8 (by omega) (by omega) hbound hin hvalid
+  have hw1 : mloadLimbWindowOk (memBase + offset)
+      (memBase + BitVec.ofNat 64 (k + 16)) (memBase + BitVec.ofNat 64 (k + 48)) 0
+      16 17 18 19 20 21 22 23 :=
+    mloadLimbWindowOk_aligned_region memBase offset k 16 contents.length rfl
+      halignB hoff8 (by omega) (by omega) hbound hin hvalid
+  have hw2 : mloadLimbWindowOk (memBase + offset)
+      (memBase + BitVec.ofNat 64 (k + 8)) (memBase + BitVec.ofNat 64 (k + 40)) 0
+      8 9 10 11 12 13 14 15 :=
+    mloadLimbWindowOk_aligned_region memBase offset k 8 contents.length rfl
+      halignB hoff8 (by omega) (by omega) hbound hin hvalid
+  have hw3 : mloadLimbWindowOk (memBase + offset)
+      (memBase + BitVec.ofNat 64 k) (memBase + BitVec.ofNat 64 (k + 32)) 0
+      0 1 2 3 4 5 6 7 :=
+    mloadLimbWindowOk_aligned_region memBase offset k 0 contents.length rfl
+      halignB hoff8 (by omega) (by omega) hbound hin hvalid
+  -- The proven public spec, instantiated with the region's window dwords.
+  have hCore := evm_mload_stack_spec_within
+    offReg byteReg accReg addrReg memBaseReg
+    sp offset offOld addrOld memBase byteOld accOld offsetWord rest
+    dstOld1 dstOld2 dstOld3
+    (memBase + BitVec.ofNat 64 (k + 24)) (memBase + BitVec.ofNat 64 (k + 56))
+    (dwordAt contents (k + 24)) (dwordAt contents (k + 56))
+    (memBase + BitVec.ofNat 64 (k + 16)) (memBase + BitVec.ofNat 64 (k + 48))
+    (dwordAt contents (k + 16)) (dwordAt contents (k + 48))
+    (memBase + BitVec.ofNat 64 (k + 8)) (memBase + BitVec.ofNat 64 (k + 40))
+    (dwordAt contents (k + 8)) (dwordAt contents (k + 40))
+    (memBase + BitVec.ofNat 64 k) (memBase + BitVec.ofNat 64 (k + 32))
+    (dwordAt contents k) (dwordAt contents (k + 32))
+    0 base
+    h_offset0 h_offset1 h_offset2 h_offset3
+    h_off_ne_x0 h_addr_ne_x0 h_byte_ne_x0 h_acc_ne_x0
+    hw0 hw1 hw2 hw3
+  dsimp only at hCore
+  -- Frame the untouched front/tail of the region around the core spec.
+  have hFramed := cpsTripleWithin_frameR
+    (bytesRegion memBase (contents.take k) **
+     bytesRegion (memBase + BitVec.ofNat 64 (k + 64)) (contents.drop (k + 64)))
+    (pcFree_sepConj (bytesRegion_pcFree _ _) (bytesRegion_pcFree _ _))
+    hCore
+  -- Peel/fold equality for the region and value bridges.
+  have hpeel := evmMemoryIs_peel_window64 memBase capacity k contents hlen hoff8 hin
+  have hword := mloadStackOutputWordFromDwordPairs_dwordAt contents k
+    (dwordAt contents (k + 56)) (dwordAt contents (k + 48))
+    (dwordAt contents (k + 40)) (dwordAt contents (k + 32)) (by omega)
+  have hbyte := mloadByteFromDwordPair_dwordAt contents k 7
+    (dwordAt contents (k + 32)) (by omega) (by omega)
+  have hlimb := mloadPackedLimbFromDwordPair_dwordAt contents k
+    (dwordAt contents (k + 32)) (by omega)
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      rw [hpeel] at hp
+      sep_perm hp)
+    (fun _ hq => by
+      rw [hword, hbyte, hlimb] at hq
+      rw [hpeel]
+      sep_perm hq)
+    hFramed
+
+/-- The reframed MLOAD spec at the guest's actual EVM memory slab:
+    `memBase = EVM_MEMORY_AREA`, `capacity = EVM_MEMORY_CAPACITY`. The
+    alignment/validity/no-wrap side conditions of the generic theorem are
+    discharged from the region-placement facts in `StateAssertions`. -/
+theorem evm_mload_stack_spec_within_evmMemoryArea
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld byteOld accOld : Word)
+    (offsetWord : EvmWord) (rest : List EvmWord)
+    (dstOld1 dstOld2 dstOld3 : Word)
+    (contents : List (BitVec 8)) (base : Word)
+    (h_offset0 : offsetWord.getLimbN 0 = offset)
+    (h_offset1 : offsetWord.getLimbN 1 = dstOld1)
+    (h_offset2 : offsetWord.getLimbN 2 = dstOld2)
+    (h_offset3 : offsetWord.getLimbN 3 = dstOld3)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (hlen : contents.length = EVM_MEMORY_CAPACITY)
+    (hoff8 : offset.toNat % 8 = 0)
+    (hin : offset.toNat + 64 ≤ contents.length) :
+    cpsTripleWithin (2 + (23 + 23 + 23 + 23)) base (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+       (memBaseReg ↦ᵣ Stateless.EVM_MEMORY_AREA) ** (addrReg ↦ᵣ addrOld) **
+       evmStackIs sp (offsetWord :: rest) **
+       (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+       evmMemoryIs Stateless.EVM_MEMORY_AREA EVM_MEMORY_CAPACITY contents)
+      (evmStackIs sp (evmMemoryReadWord contents offset.toNat :: rest) **
+       ((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+       (memBaseReg ↦ᵣ Stateless.EVM_MEMORY_AREA) **
+       (addrReg ↦ᵣ (Stateless.EVM_MEMORY_AREA + offset)) **
+       (byteReg ↦ᵣ (getByteAt contents (offset.toNat + 7)).zeroExtend 64) **
+       (accReg ↦ᵣ (evmMemoryReadWord contents offset.toNat).getLimbN 3) **
+       evmMemoryIs Stateless.EVM_MEMORY_AREA EVM_MEMORY_CAPACITY contents) := by
+  exact evm_mload_stack_spec_within_evmMemoryIs
+    offReg byteReg accReg addrReg memBaseReg
+    sp offset offOld addrOld Stateless.EVM_MEMORY_AREA byteOld accOld
+    offsetWord rest dstOld1 dstOld2 dstOld3
+    EVM_MEMORY_CAPACITY contents base
+    h_offset0 h_offset1 h_offset2 h_offset3
+    h_off_ne_x0 h_addr_ne_x0 h_byte_ne_x0 h_acc_ne_x0
+    hlen EVM_MEMORY_AREA_aligned hoff8 hin
+    (by rw [hlen, EVM_MEMORY_AREA_toNat]; decide)
+    (fun i hi => isValidMemAddr_evmMemoryArea (hlen ▸ hi))
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/StateAssertions.lean
+++ b/EvmAsm/Evm64/StateAssertions.lean
@@ -1,0 +1,405 @@
+/-
+  EvmAsm.Evm64.StateAssertions
+
+  Separation-logic assertion for the EVM interpreter memory region.
+
+  ## Layout faithfulness (what this describes)
+
+  The RISC-V guest keeps the current frame's EVM memory as a flat byte
+  buffer at `EVM_MEMORY_AREA = 0xa0b70000` inside ziskemu's writable RAM
+  zone (`EvmAsm/Stateless/MemoryLayout.lean`, working-RAM anchor table).
+  The region is **statically allocated at 16 MiB per frame**: the block
+  gas limit (~200 Mgas) bounds how far EVM memory can ever expand
+  (quadratic memory-expansion gas makes even a single frame's memory far
+  smaller than 16 MiB), so the guest never grows or relocates the buffer.
+  `EVM_MEMORY_CAPACITY` below is that static allocation, and
+  `evmMemoryIs` is parametrized by it.
+
+  The MLOAD/MSTORE/MSTORE8 guest routines (`EvmAsm/Evm64/MLoad/*`,
+  `MStore/*`, `MStore8/*`) access this buffer with byte loads/stores
+  (`LBU`/`SB`) at `memBase + offset + c`; at the separation-logic level
+  each 8-byte-aligned group of bytes is one RV64 dword cell (`↦ₘ`,
+  little-endian `packBytes`), exactly the `bytesRegion` representation
+  from `EvmAsm/Rv64/MemRegion.lean`. `evmMemoryIs` is `bytesRegion`
+  over the whole allocation, so the proven opcode specs (which frame
+  against raw dword cells) can be restated against it by *peeling* the
+  touched dword window — see `evmMemoryIs_peel_word` /
+  `evmMemoryIs_peel_window64` and
+  `EvmAsm/Evm64/MLoad/MemoryRegionStackSpec.lean` (the reframed MLOAD
+  stack spec, which proves this assertion is the guest's real memory).
+
+  ## Zero-extended tail
+
+  EVM memory reads beyond the current high-water mark return zero. The
+  guest gets this for free: ziskemu's RAM is zero-initialized and the
+  region is written only by the memory opcodes, so the not-yet-written
+  tail of the 16 MiB allocation holds zero bytes. `evmMemoryIs` models
+  the *full* allocation (`contents.length = capacity` is part of the
+  assertion); the freshly-initialized state is `evmMemoryInit`, whose
+  contents are all zeros, and a partially-written state is
+  `live ++ List.replicate (capacity - live.length) 0`.
+-/
+
+import EvmAsm.Rv64.MemRegion
+import EvmAsm.Stateless.MemoryLayout
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-! ## Static capacity of the EVM memory region
+
+The per-frame EVM memory allocation. 16 MiB, per the working-RAM anchor
+table in `EvmAsm/Stateless/MemoryLayout.lean` (`EVM_MEMORY_AREA` row):
+the ~200 Mgas block gas limit and the quadratic memory-expansion cost
+bound any frame's EVM memory well below this, so the guest allocates a
+fixed 16 MiB slab and never grows it. -/
+def EVM_MEMORY_CAPACITY : Nat := 0x1000000
+
+/-! ## The assertion -/
+
+/-- `evmMemoryIs base capacity contents` — ownership of the guest's EVM
+    memory buffer: the byte list `contents` stored little-endian-per-dword
+    from `base` (`bytesRegion`), together with the pure fact that the
+    buffer covers the full static allocation (`contents.length =
+    capacity`). Instantiate `base := Stateless.EVM_MEMORY_AREA` and
+    `capacity := EVM_MEMORY_CAPACITY` for the real guest region; the
+    parameters keep the peel/framing lemmas usable for any statically
+    allocated byte buffer. -/
+def evmMemoryIs (base : Word) (capacity : Nat) (contents : List (BitVec 8)) : Assertion :=
+  fun ps => contents.length = capacity ∧ bytesRegion base contents ps
+
+/-- The freshly-initialized EVM memory region: all `capacity` bytes zero
+    (ziskemu zero-initializes RAM, so this is the state at frame entry). -/
+def evmMemoryInit (base : Word) (capacity : Nat) : Assertion :=
+  evmMemoryIs base capacity (List.replicate capacity 0)
+
+/-- The RV64 dword cell value holding bytes `[k, k+8)` of a byte list
+    (zero-padded past the end, matching `packBytes`). -/
+def dwordAt (bs : List (BitVec 8)) (k : Nat) : Word :=
+  packBytes ((bs.drop k).take 8)
+
+theorem evmMemoryIs_unfold {base : Word} {capacity : Nat} {contents : List (BitVec 8)} :
+    evmMemoryIs base capacity contents =
+      fun ps => contents.length = capacity ∧ bytesRegion base contents ps := rfl
+
+/-- With the length side condition in hand, `evmMemoryIs` *is* the raw
+    `bytesRegion` — the bridge to all `MemRegion` machinery. -/
+theorem evmMemoryIs_eq_bytesRegion {base : Word} {capacity : Nat}
+    {contents : List (BitVec 8)} (hlen : contents.length = capacity) :
+    evmMemoryIs base capacity contents = bytesRegion base contents := by
+  funext ps
+  exact propext ⟨fun h => h.2, fun h => ⟨hlen, h⟩⟩
+
+/-- `evmMemoryIs` pins the buffer length to the declared capacity: a
+    satisfying state certifies `contents.length = capacity`. -/
+theorem evmMemoryIs_length {base : Word} {capacity : Nat}
+    {contents : List (BitVec 8)} {ps : PartialState}
+    (h : evmMemoryIs base capacity contents ps) :
+    contents.length = capacity := h.1
+
+theorem evmMemoryInit_eq {base : Word} {capacity : Nat} :
+    evmMemoryInit base capacity =
+      evmMemoryIs base capacity (List.replicate capacity 0) := rfl
+
+theorem pcFree_evmMemoryIs {base : Word} {capacity : Nat}
+    {contents : List (BitVec 8)} :
+    (evmMemoryIs base capacity contents).pcFree :=
+  fun ps h => bytesRegion_pcFree base contents ps h.2
+
+theorem pcFree_evmMemoryInit {base : Word} {capacity : Nat} :
+    (evmMemoryInit base capacity).pcFree := pcFree_evmMemoryIs
+
+instance (base : Word) (capacity : Nat) (contents : List (BitVec 8)) :
+    Assertion.PCFree (evmMemoryIs base capacity contents) :=
+  ⟨pcFree_evmMemoryIs⟩
+
+instance (base : Word) (capacity : Nat) : Assertion.PCFree (evmMemoryInit base capacity) :=
+  ⟨pcFree_evmMemoryInit⟩
+
+/-- Contents-side congruence. -/
+theorem evmMemoryIs_congr {base : Word} {capacity : Nat}
+    {bs bs' : List (BitVec 8)} (h : bs = bs') :
+    evmMemoryIs base capacity bs = evmMemoryIs base capacity bs' :=
+  congrArg (evmMemoryIs base capacity) h
+
+/-! ## Address arithmetic helpers -/
+
+/-- Fold two `ofNat` offsets from the same base into one. Pure wrap-around
+    BitVec arithmetic — no overflow side conditions. -/
+theorem add_ofNat_add_ofNat (b : Word) (i j : Nat) :
+    (b + BitVec.ofNat 64 i) + BitVec.ofNat 64 j = b + BitVec.ofNat 64 (i + j) := by
+  rw [BitVec.add_assoc]
+  congr 1
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_add, BitVec.toNat_ofNat]
+  omega
+
+/-- Specialization: stepping a based offset by one dword. -/
+theorem add_ofNat_add_eight (b : Word) (i : Nat) :
+    (b + BitVec.ofNat 64 i) + 8 = b + BitVec.ofNat 64 (i + 8) := by
+  rw [show (8 : Word) = BitVec.ofNat 64 8 from rfl]
+  exact add_ofNat_add_ofNat b i 8
+
+/-! ## Region split and dword-window peel
+
+The lemmas the memory opcodes need: split `bytesRegion` at a dword
+boundary, and peel the dword cells covering one 32-byte EVM word (or the
+64-byte window the proven MLOAD/MSTORE stack specs frame against). All
+are *equalities* of assertions, so they rewrite in both pre and post
+(peel to consume, `rw [←]` to fold back). -/
+
+/-- Chunk-count split of `bytesRegionAux`: the first `m1` dwords cover
+    `bs.take (8 * m1)`, the remainder continues at `base + 8 * m1`. -/
+theorem bytesRegionAux_append (m1 m2 : Nat) (base : Word) (bs : List (BitVec 8)) :
+    bytesRegionAux base (m1 + m2) bs =
+      (bytesRegionAux base m1 (bs.take (8 * m1)) **
+       bytesRegionAux (base + BitVec.ofNat 64 (8 * m1)) m2 (bs.drop (8 * m1))) := by
+  induction m1 generalizing base bs with
+  | zero =>
+    simp only [Nat.zero_add, Nat.mul_zero, List.take_zero, List.drop_zero]
+    rw [show bytesRegionAux base 0 ([] : List (BitVec 8)) = empAssertion from rfl,
+        sepConj_emp_left']
+    rw [show (BitVec.ofNat 64 0 : Word) = 0 from rfl,
+        show base + (0 : Word) = base from by bv_omega]
+  | succ k ih =>
+    rw [show k + 1 + m2 = (k + m2) + 1 from by omega]
+    rw [show bytesRegionAux base ((k + m2) + 1) bs =
+        ((base ↦ₘ packBytes (bs.take 8)) **
+         bytesRegionAux (base + 8) (k + m2) (bs.drop 8)) from rfl]
+    rw [ih (base + 8) (bs.drop 8)]
+    rw [show bytesRegionAux base (k + 1) (bs.take (8 * (k + 1))) =
+        ((base ↦ₘ packBytes ((bs.take (8 * (k + 1))).take 8)) **
+         bytesRegionAux (base + 8) k ((bs.take (8 * (k + 1))).drop 8)) from rfl]
+    have htt : (bs.take (8 * (k + 1))).take 8 = bs.take 8 := by
+      rw [List.take_take]
+      congr 1
+    have hdt : (bs.take (8 * (k + 1))).drop 8 = (bs.drop 8).take (8 * k) := by
+      rw [List.drop_take]
+      congr 1
+    have hdd : (bs.drop 8).drop (8 * k) = bs.drop (8 * (k + 1)) := by
+      rw [List.drop_drop]
+      congr 1
+      omega
+    have haddr : (base + 8) + BitVec.ofNat 64 (8 * k) = base + BitVec.ofNat 64 (8 * (k + 1)) := by
+      rw [BitVec.add_assoc]
+      congr 1
+      apply BitVec.eq_of_toNat_eq
+      have h8 : (8 : Word).toNat = 8 := by decide
+      rw [BitVec.toNat_add, BitVec.toNat_ofNat, BitVec.toNat_ofNat, h8]
+      omega
+    rw [htt, hdt, hdd, haddr, sepConj_assoc']
+
+/-- Split a byte region at a dword-aligned byte position `n`. -/
+theorem bytesRegion_split (base : Word) (bs : List (BitVec 8)) (n : Nat)
+    (h8 : n % 8 = 0) (hn : n ≤ bs.length) :
+    bytesRegion base bs =
+      (bytesRegion base (bs.take n) **
+       bytesRegion (base + BitVec.ofNat 64 n) (bs.drop n)) := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = 8 * m := ⟨n / 8, by omega⟩
+  show bytesRegionAux base ((bs.length + 7) / 8) bs = _
+  have hchunks : (bs.length + 7) / 8 = m + ((bs.drop (8 * m)).length + 7) / 8 := by
+    rw [List.length_drop]
+    omega
+  rw [hchunks, bytesRegionAux_append m _ base bs]
+  congr 1
+  show bytesRegionAux base m (bs.take (8 * m)) =
+    bytesRegionAux base (((bs.take (8 * m)).length + 7) / 8) (bs.take (8 * m))
+  congr 1
+  rw [List.length_take]
+  omega
+
+/-- Peel the leading dword cell off a `take`-windowed region and step the
+    window forward one dword. Building block for the word/window peels. -/
+theorem bytesRegion_take_chunk (b : Word) (bs : List (BitVec 8)) (k n : Nat)
+    (hk : k < bs.length) (hn : 8 ≤ n) :
+    bytesRegion b ((bs.drop k).take n) =
+      ((b ↦ₘ dwordAt bs k) **
+       bytesRegion (b + 8) ((bs.drop (k + 8)).take (n - 8))) := by
+  have hne : (bs.drop k).take n ≠ [] := by
+    intro h
+    have := congrArg List.length h
+    simp only [List.length_take, List.length_drop, List.length_nil] at this
+    omega
+  rw [bytesRegion_eq_cons _ _ hne]
+  have htt : ((bs.drop k).take n).take 8 = (bs.drop k).take 8 := by
+    rw [List.take_take]
+    congr 1
+    omega
+  have hdt : ((bs.drop k).take n).drop 8 = (bs.drop (k + 8)).take (n - 8) := by
+    rw [List.drop_take, List.drop_drop]
+  rw [htt, hdt]
+  rfl
+
+/-- **Peel a 32-byte EVM word at dword-aligned offset `k`.** The four
+    dword cells covering bytes `[k, k+32)` come out of `evmMemoryIs` as
+    raw `↦ₘ` atoms (the shape the MLOAD/MSTORE limb specs consume), with
+    the untouched front and tail staying `bytesRegion`s. Being an
+    equality, `rw [←]` folds an unchanged (or value-updated) window back. -/
+theorem evmMemoryIs_peel_word (base : Word) (capacity k : Nat) (bs : List (BitVec 8))
+    (hlen : bs.length = capacity) (hk8 : k % 8 = 0) (hin : k + 32 ≤ bs.length) :
+    evmMemoryIs base capacity bs =
+      (bytesRegion base (bs.take k) **
+       ((base + BitVec.ofNat 64 k) ↦ₘ dwordAt bs k) **
+       ((base + BitVec.ofNat 64 (k + 8)) ↦ₘ dwordAt bs (k + 8)) **
+       ((base + BitVec.ofNat 64 (k + 16)) ↦ₘ dwordAt bs (k + 16)) **
+       ((base + BitVec.ofNat 64 (k + 24)) ↦ₘ dwordAt bs (k + 24)) **
+       bytesRegion (base + BitVec.ofNat 64 (k + 32)) (bs.drop (k + 32))) := by
+  rw [evmMemoryIs_eq_bytesRegion hlen,
+      bytesRegion_split base bs k hk8 (by omega)]
+  have hsplit2 : bytesRegion (base + BitVec.ofNat 64 k) (bs.drop k) =
+      (bytesRegion (base + BitVec.ofNat 64 k) ((bs.drop k).take 32) **
+       bytesRegion (base + BitVec.ofNat 64 (k + 32)) (bs.drop (k + 32))) := by
+    rw [bytesRegion_split (base + BitVec.ofNat 64 k) (bs.drop k) 32 (by omega)
+        (by rw [List.length_drop]; omega)]
+    rw [add_ofNat_add_ofNat, List.drop_drop]
+  rw [hsplit2]
+  rw [bytesRegion_take_chunk _ bs k 32 (by omega) (by omega),
+      add_ofNat_add_eight,
+      show (32 : Nat) - 8 = 24 from rfl,
+      bytesRegion_take_chunk _ bs (k + 8) 24 (by omega) (by omega),
+      add_ofNat_add_eight,
+      show (24 : Nat) - 8 = 16 from rfl,
+      bytesRegion_take_chunk _ bs (k + 8 + 8) 16 (by omega) (by omega),
+      add_ofNat_add_eight,
+      show (16 : Nat) - 8 = 8 from rfl,
+      bytesRegion_take_chunk _ bs (k + 8 + 8 + 8) 8 (by omega) (by omega)]
+  rw [show k + 8 + 8 = k + 16 from by omega, show k + 8 + 8 + 8 = k + 24 from by omega]
+  simp only [Nat.sub_self, List.take_zero, bytesRegion_nil, sepConj_emp_right']
+  rw [sepConj_assoc', sepConj_assoc', sepConj_assoc']
+
+/-- **Peel the 64-byte dword window at dword-aligned offset `k`** — eight
+    consecutive dword cells. This is the exact memory footprint of the
+    proven aligned MLOAD/MSTORE stack specs
+    (`evm_mload_stack_spec_within` / `evm_mstore_stack_spec_within`):
+    four lo/hi dword pairs, of which the four lo cells cover the accessed
+    32-byte word `[k, k+32)` and the four hi cells `[k+32, k+64)` are the
+    windows' scratch dwords (owned but unread when the access is
+    dword-aligned). -/
+theorem evmMemoryIs_peel_window64 (base : Word) (capacity k : Nat) (bs : List (BitVec 8))
+    (hlen : bs.length = capacity) (hk8 : k % 8 = 0) (hin : k + 64 ≤ bs.length) :
+    evmMemoryIs base capacity bs =
+      (bytesRegion base (bs.take k) **
+       ((base + BitVec.ofNat 64 k) ↦ₘ dwordAt bs k) **
+       ((base + BitVec.ofNat 64 (k + 8)) ↦ₘ dwordAt bs (k + 8)) **
+       ((base + BitVec.ofNat 64 (k + 16)) ↦ₘ dwordAt bs (k + 16)) **
+       ((base + BitVec.ofNat 64 (k + 24)) ↦ₘ dwordAt bs (k + 24)) **
+       ((base + BitVec.ofNat 64 (k + 32)) ↦ₘ dwordAt bs (k + 32)) **
+       ((base + BitVec.ofNat 64 (k + 40)) ↦ₘ dwordAt bs (k + 40)) **
+       ((base + BitVec.ofNat 64 (k + 48)) ↦ₘ dwordAt bs (k + 48)) **
+       ((base + BitVec.ofNat 64 (k + 56)) ↦ₘ dwordAt bs (k + 56)) **
+       bytesRegion (base + BitVec.ofNat 64 (k + 64)) (bs.drop (k + 64))) := by
+  rw [evmMemoryIs_eq_bytesRegion hlen,
+      bytesRegion_split base bs k hk8 (by omega)]
+  have hsplit2 : bytesRegion (base + BitVec.ofNat 64 k) (bs.drop k) =
+      (bytesRegion (base + BitVec.ofNat 64 k) ((bs.drop k).take 64) **
+       bytesRegion (base + BitVec.ofNat 64 (k + 64)) (bs.drop (k + 64))) := by
+    rw [bytesRegion_split (base + BitVec.ofNat 64 k) (bs.drop k) 64 (by omega)
+        (by rw [List.length_drop]; omega)]
+    rw [add_ofNat_add_ofNat, List.drop_drop]
+  rw [hsplit2]
+  rw [bytesRegion_take_chunk _ bs k 64 (by omega) (by omega),
+      add_ofNat_add_eight,
+      show (64 : Nat) - 8 = 56 from rfl,
+      bytesRegion_take_chunk _ bs (k + 8) 56 (by omega) (by omega),
+      add_ofNat_add_eight,
+      show (56 : Nat) - 8 = 48 from rfl,
+      bytesRegion_take_chunk _ bs (k + 8 + 8) 48 (by omega) (by omega),
+      add_ofNat_add_eight,
+      show (48 : Nat) - 8 = 40 from rfl,
+      bytesRegion_take_chunk _ bs (k + 8 + 8 + 8) 40 (by omega) (by omega),
+      add_ofNat_add_eight,
+      show (40 : Nat) - 8 = 32 from rfl,
+      bytesRegion_take_chunk _ bs (k + 8 + 8 + 8 + 8) 32 (by omega) (by omega),
+      add_ofNat_add_eight,
+      show (32 : Nat) - 8 = 24 from rfl,
+      bytesRegion_take_chunk _ bs (k + 8 + 8 + 8 + 8 + 8) 24 (by omega) (by omega),
+      add_ofNat_add_eight,
+      show (24 : Nat) - 8 = 16 from rfl,
+      bytesRegion_take_chunk _ bs (k + 8 + 8 + 8 + 8 + 8 + 8) 16 (by omega) (by omega),
+      add_ofNat_add_eight,
+      show (16 : Nat) - 8 = 8 from rfl,
+      bytesRegion_take_chunk _ bs (k + 8 + 8 + 8 + 8 + 8 + 8 + 8) 8 (by omega) (by omega)]
+  rw [show k + 8 + 8 = k + 16 from by omega,
+      show k + 8 + 8 + 8 = k + 24 from by omega,
+      show k + 8 + 8 + 8 + 8 = k + 32 from by omega,
+      show k + 8 + 8 + 8 + 8 + 8 = k + 40 from by omega,
+      show k + 8 + 8 + 8 + 8 + 8 + 8 = k + 48 from by omega,
+      show k + 8 + 8 + 8 + 8 + 8 + 8 + 8 = k + 56 from by omega]
+  simp only [Nat.sub_self, List.take_zero, bytesRegion_nil, sepConj_emp_right']
+  rw [sepConj_assoc', sepConj_assoc', sepConj_assoc', sepConj_assoc',
+      sepConj_assoc', sepConj_assoc', sepConj_assoc']
+
+/-! ## Region placement facts
+
+Validity and disjointness of the concrete `EVM_MEMORY_AREA` allocation
+against the rest of the working-RAM anchor map
+(`EvmAsm/Stateless/MemoryLayout.lean`). These discharge the
+`isValidByteAccess` side conditions of the byte-level opcode specs and
+document that the 16 MiB slab does not alias its neighbours
+(`EVM_VALUE_STACK` below, `KECCAK_SCRATCH` above). -/
+
+theorem EVM_MEMORY_AREA_toNat : Stateless.EVM_MEMORY_AREA.toNat = 0xa0b70000 := rfl
+
+theorem EVM_MEMORY_AREA_aligned : Stateless.EVM_MEMORY_AREA.toNat % 8 = 0 := by decide
+
+/-- Every byte of the 16 MiB EVM memory slab is a valid guest address:
+    `0xa0b70000 + k` with `k < 0x1000000` sits inside ziskemu's writable
+    RAM zone `RAM_MEM_START .. RAM_MEM_END` (`0xa0000000 .. 0xc0000000`). -/
+theorem isValidMemAddr_evmMemoryArea {k : Nat} (hk : k < EVM_MEMORY_CAPACITY) :
+    isValidMemAddr (Stateless.EVM_MEMORY_AREA + BitVec.ofNat 64 k) = true := by
+  have hcap : EVM_MEMORY_CAPACITY = 0x1000000 := rfl
+  have htoNat : (Stateless.EVM_MEMORY_AREA + BitVec.ofNat 64 k).toNat = 0xa0b70000 + k := by
+    rw [BitVec.toNat_add, BitVec.toNat_ofNat, EVM_MEMORY_AREA_toNat]
+    omega
+  simp only [isValidMemAddr_eq, htoNat, Bool.or_eq_true, Bool.and_eq_true,
+    decide_eq_true_eq]
+  right
+  constructor
+  · show RAM_MEM_START ≤ 0xa0b70000 + k
+    have : RAM_MEM_START = 0xa0000000 := rfl
+    omega
+  · show 0xa0b70000 + k ≤ RAM_MEM_END
+    have : RAM_MEM_END = 0xc0000000 := rfl
+    omega
+
+/-- The EVM memory slab is disjoint from the EVM value stack below it
+    (`EVM_VALUE_STACK = 0xa0a70000`, 1 MiB): no address aliases. -/
+theorem evmMemoryArea_disjoint_valueStack {i j : Nat}
+    (hi : i < EVM_MEMORY_CAPACITY) (hj : j < 0x100000) :
+    Stateless.EVM_MEMORY_AREA + BitVec.ofNat 64 i ≠
+      Stateless.EVM_VALUE_STACK + BitVec.ofNat 64 j := by
+  intro h
+  have hcap : EVM_MEMORY_CAPACITY = 0x1000000 := rfl
+  have hmem : (Stateless.EVM_MEMORY_AREA + BitVec.ofNat 64 i).toNat = 0xa0b70000 + i := by
+    rw [BitVec.toNat_add, BitVec.toNat_ofNat, EVM_MEMORY_AREA_toNat]
+    omega
+  have hstk : (Stateless.EVM_VALUE_STACK + BitVec.ofNat 64 j).toNat = 0xa0a70000 + j := by
+    rw [BitVec.toNat_add, BitVec.toNat_ofNat,
+        show Stateless.EVM_VALUE_STACK.toNat = 0xa0a70000 from rfl]
+    omega
+  have := congrArg BitVec.toNat h
+  rw [hmem, hstk] at this
+  omega
+
+/-- The EVM memory slab is disjoint from the Keccak scratch buffer above
+    it (`KECCAK_SCRATCH = 0xa1b70000`, 64 KiB): the slab ends exactly at
+    the scratch base. -/
+theorem evmMemoryArea_disjoint_keccakScratch {i j : Nat}
+    (hi : i < EVM_MEMORY_CAPACITY) (hj : j < 0x10000) :
+    Stateless.EVM_MEMORY_AREA + BitVec.ofNat 64 i ≠
+      Stateless.KECCAK_SCRATCH + BitVec.ofNat 64 j := by
+  intro h
+  have hcap : EVM_MEMORY_CAPACITY = 0x1000000 := rfl
+  have hmem : (Stateless.EVM_MEMORY_AREA + BitVec.ofNat 64 i).toNat = 0xa0b70000 + i := by
+    rw [BitVec.toNat_add, BitVec.toNat_ofNat, EVM_MEMORY_AREA_toNat]
+    omega
+  have hscr : (Stateless.KECCAK_SCRATCH + BitVec.ofNat 64 j).toNat = 0xa1b70000 + j := by
+    rw [BitVec.toNat_add, BitVec.toNat_ofNat,
+        show Stateless.KECCAK_SCRATCH.toNat = 0xa1b70000 from rfl]
+    omega
+  have := congrArg BitVec.toNat h
+  rw [hmem, hscr] at this
+  omega
+
+end EvmAsm.Evm64

--- a/PLAN.md
+++ b/PLAN.md
@@ -119,6 +119,21 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
 
 ### Infrastructure — RV64 only, no sorry
 
+- **Separation-logic state assertions** (`EvmAsm/Evm64/StateAssertions.lean`):
+  `evmMemoryIs base capacity contents` — the EVM interpreter memory region
+  (`EVM_MEMORY_AREA = 0xa0b70000`, statically 16 MiB =
+  `EVM_MEMORY_CAPACITY` per the gas-limit sizing) as `bytesRegion` +
+  pinned length. Split/peel lemmas (`bytesRegion_split`,
+  `evmMemoryIs_peel_word`, `evmMemoryIs_peel_window64`), pcFree,
+  placement facts (`isValidMemAddr_evmMemoryArea`,
+  disjointness vs `EVM_VALUE_STACK`/`KECCAK_SCRATCH`). Honesty gate:
+  `evm_mload_stack_spec_within_evmMemoryIs` /
+  `..._evmMemoryArea` (`EvmAsm/Evm64/MLoad/MemoryRegionStackSpec.lean`)
+  restate the proven public MLOAD stack spec against `evmMemoryIs`, with
+  the pushed word shown to be `evmMemoryReadWord contents offset.toNat`.
+  Remaining: MSTORE reframing (needs contents-update fold), account
+  (`accountIs`) and storage (`storageSlotIs`) assertions — see the
+  "State-assertion vocabulary" notes in the session PRs.
 - RV64: Basic, Instructions, Program, Execution, CPSSpec,
   ControlFlow, SepLogic, GenericSpecs, InstructionSpecs, SyscallSpecs,
   HalfwordOps, WordOps


### PR DESCRIPTION
## What

The first of the state-assertion vocabulary PRs: a structured separation-logic `Assertion` for the **EVM interpreter memory region**, plus the load-bearing check that it describes the guest's *actual* memory (a reframing of the already-proven public MLOAD stack spec).

### `EvmAsm/Evm64/StateAssertions.lean`

- **`evmMemoryIs base capacity contents`** — `bytesRegion base contents` (the `MemRegion` little-endian-dword byte-region primitive) *plus* the pure fact `contents.length = capacity`. Layout-derived, not idealized:
  - base = `Stateless.EVM_MEMORY_AREA = 0xa0b70000` (working-RAM anchor table, `Stateless/MemoryLayout.lean`);
  - `capacity` parametrizes the **static 16 MiB per-frame allocation** (`EVM_MEMORY_CAPACITY`) — the ~200 Mgas block gas limit + quadratic memory expansion bound frame memory far below 16 MiB, so the guest never grows/relocates the slab;
  - the EVM "reads beyond MSIZE return zero" semantics is the zero tail of the full-capacity contents (ziskemu zero-initializes RAM); `evmMemoryInit` is the all-zero frame-entry state.
- **Split/peel lemmas** (all assertion *equalities*, so `rw [←]` folds the window back): `bytesRegionAux_append`, `bytesRegion_split`, `bytesRegion_take_chunk`, **`evmMemoryIs_peel_word`** (the 4 dword cells of a 32-byte EVM word at dword-aligned offset k), **`evmMemoryIs_peel_window64`** (the exact 8-cell footprint of the proven MLOAD/MSTORE stack specs: 4 lo cells covering the word + 4 scratch hi cells).
- `pcFree` + `PCFree` instances; region placement facts: `isValidMemAddr_evmMemoryArea` (every slab byte is in ziskemu's RAM zone) and disjointness vs `EVM_VALUE_STACK` / `KECCAK_SCRATCH`.

### `EvmAsm/Evm64/MLoad/MemoryRegionStackSpec.lean` — the honesty gate

**`evm_mload_stack_spec_within_evmMemoryIs`** restates the proven `evm_mload_stack_spec_within` with pre/post owning a single `evmMemoryIs memBase capacity contents` resource:

- derived by *consuming* the proven spec (peel window → instantiate the 8 raw dword cells → discharge all four `mloadLimbWindowOk` bundles from region facts → fold back);
- the pushed stack word is proven to be **`evmMemoryReadWord contents offset.toNat`** — the 32 region bytes at the requested offset, big-endian, with `getByteAt` zero-padding (the EVM read semantics);
- `evm_mload_stack_spec_within_evmMemoryArea` instantiates it at the real `EVM_MEMORY_AREA`/`EVM_MEMORY_CAPACITY` slab, all side conditions discharged from the placement facts.

Scope note: the reframing covers the dword-aligned case (`start = 0`). For `start ≠ 0` the public spec's adjacent limb windows share a dword cell, so its separated 8-cell precondition is only instantiable when aligned — the aligned spec is the one the proven pipeline exercises. The in-bounds condition is `offset + 64 ≤ contents.length`: the 32 bytes past the loaded word are the guest windows' scratch hi-dwords.

## Gates

- `lake build` green (full library, 4749 jobs), zero warnings in new files.
- `#print axioms` on `evmMemoryIs_peel_word` / `evmMemoryIs_peel_window64` / `evm_mload_stack_spec_within_evmMemoryIs` / `..._evmMemoryArea`: `[propext, Classical.choice, Quot.sound]`.
- No `sorry` / `native_decide` / `bv_decide` / `maxHeartbeats` / `maxRecDepth`; `scripts/check-forbidden-tactics.sh` OK.
- `MemRegion` / `Stack` / `Assertion` / `MemoryLayout` untouched.

Follow-ups (separate PRs): MSTORE reframing (needs the contents-update fold), `accountIs`, `storageSlotIs`/log assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)