### PR TITLE
docs(agents): verified-replacement strategy guide (drop-in principle, spec formulation, callee escalation ladder) + AGENTS.md pruning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,15 +48,6 @@ EvmAsm/
 EvmAsm.lean            -- Root module: imports Rv64, Evm64, EL
 ```
 
-## Key Lean 4 API Compatibility Notes
-
-When working with this codebase, be aware of these Lean 4 nightly API changes:
-
-1. **Logic lemmas**: Use lowercase names (`and_assoc`, `and_comm` instead of `And.assoc`, `And.comm`)
-2. **Doc comments**: Cannot place `/-- ... -/` doc comments immediately before `#eval` commands (use regular `--` comments)
-3. **Proof tactics**: `simp` may need explicit lemma lists or `rw` for manual rewriting
-4. **Namespace**: Most theorems are in `namespace MachineState`, so use full names like `MachineState.getReg_setPC`
-
 ## Verification Workflow
 
 When adding or modifying proofs:
@@ -113,29 +104,11 @@ silent `cpsTripleWithin N` inflation surfaces as a registry diff.
   1. Splitting the proof into smaller named lemmas.
   2. Marking expensive intermediate definitions `@[irreducible]` and proving a small set of lemmas about them, so later proofs unfold via those lemmas instead of re-reducing the body each time.
   3. Breaking up large `have`s into separate lemmas so the core composition step has fewer atoms to permute.
-- **When DivMod postconditions explode under `xperm` or kernel `whnf`:** fold the postcondition before trying harder tactics. Put the final register/memory assertion spine behind a small `@[irreducible]` helper such as `...PostCore`, parameterized by the final values that the branch proof should expose. If the public post has a deep body let-chain, add a second folded helper such as `...PostFromBody` that takes already-computed intermediates; the public `...Post` should compute the lets and delegate to the helper. In branch bridge proofs, use `change` to refold the expanded target to the helper with local names, simplify only the relevant `if_pos`/`if_neg`, then unfold only the small core immediately before `xperm_hyp`. Split repeated bridge obligations into named lemmas for fresh heartbeat budgets. Use `lean_goal` at the failing line to confirm the target is folded; if it prints a huge `BitVec.toNat 32` or nested-let/nested-if term, fold first instead of running `xperm` on the expanded goal.
-- **When extracting framed pure facts in bridge posts:** inspect the shape with `lean_goal` before repeatedly applying `drop_pure` or `extract_pure`. Framed pures may remain behind an extra `sepConj` layer, so remove one layer at a time with small local rewrites (`rw [sepConj_assoc']`, `simp only [sepConj_pure_mid_left]`) and `obtain` the pure fact you need. Broad `simp` or blind repeated extraction can expand the folded post again or destruct useful `sepConj` structure.
-- **When `extract_pure`, `drop_pure`, or `xperm_pure` struggle on a folded framed post:** avoid broad pure-extraction tactics on the whole post if they expand the folded helper, trigger kernel `whnf`, leave `xperm` atom-count mismatches, or report an expected-type/free-variable error. First extract only the outer pure fact you need, then rewrite the specific remaining pure assertion to `empAssertion` with a local extensional proof and simplify the emp frame before calling `xperm_hyp`. Shape:
-
-  ```lean
-  extract_pure hp
-  obtain ⟨hp, h_pure⟩ := hp
-  rw [show (⌜P⌝ : Assertion) = empAssertion by
-    funext h
-    unfold EvmAsm.Rv64.pure EvmAsm.Rv64.empAssertion
-    apply propext
-    constructor
-    · intro h_p
-      exact h_p.1
-    · intro h_empty
-      exact ⟨h_empty, h_pure⟩] at hp
-  simp only [the relevant sepConj_emp lemma] at hp
-  xperm_hyp hp
-  ```
-
-  Keep `EvmAsm.Rv64.pure` qualified in the unfold so Lean does not choose an unrelated `pure`, and keep the target folded until the final local rewrite. Tracking issue: https://github.com/Verified-zkEVM/evm-asm/issues/7174.
-- **Exception for Shift composition files**: `set_option maxHeartbeats` up to 6400000 is acceptable for body/path composition proofs (Section 4+) which are bottlenecked by `xperm_hyp` permutation on large atom chains. Subsumption lemmas (Section 2) should NOT need heartbeat overrides — they use structural `unionAll` reasoning.
-
+- **Large-post `xperm`/`whnf` blowups and framed-pure extraction** (DivMod-scale
+  posts, `extract_pure`/`drop_pure` struggles): fold posts behind
+  `@[irreducible]` helpers and extract pures one layer at a time — full
+  recipes moved to `docs/agents/proof-patterns.md`
+  §"Folded framed posts" (tracking issue #7174).
 - **All memory accesses must be aligned.** The verified RV64 operational semantics in `EvmAsm/Rv64/Basic.lean` defines `isValidDwordAccess = isValidMemAddr && isAligned8` and `isValidMemAccess = isValidMemAddr && isAligned4` — i.e. an `LD`/`SD` has no semantics unless its address is a multiple of 8, and `LW`/`LWU`/`SW` likewise need a multiple of 4. Per-width requirements:
 
   | Op            | Width | Required alignment |
@@ -172,13 +145,6 @@ All concrete examples should pass with no sorries:
 ```bash
 lake build  # Should succeed with 0 errors and 0 sorries
 ```
-
-The project includes concrete test cases using `decide` (kernel-checkable):
-- Multiply by constants: 0, 1, 3, 6, 10, 255
-- Swap macro correctness
-- Zero and triple macros
-- ECALL/halt termination examples
-- COMMIT-then-halt examples
 
 ### Codegen & ziskemu round-trips
 
@@ -378,6 +344,15 @@ doc only when its trigger applies** — they are reference material, not require
   verifying one guest routine end-to-end: class decision table → exemplar → recipe →
   acceptance (`scripts/port-check.sh`, `scripts/gen-port-kit.py` scaffolds).
   **Load when:** working any `port: verify …` bead or any 4ch8f routine-family bead.
+- [`docs/agents/verified-replacement-strategy.md`](docs/agents/verified-replacement-strategy.md) —
+  the strategy layer above the port playbook: the drop-in principle (functional
+  drop-in, NOT byte equality — and the two byte-tie strategies with their gates),
+  how to formulate a routine's specification (vocabulary altitude, value-carrying
+  assertions, honest domains, outcome disjunctions), and the escalation ladder for
+  when a verified callee doesn't expose enough (bridging lemma → variant theorem →
+  reframe → strengthen → re-emit → STOP-and-file-bug).
+  **Load when:** replacing an unverified routine with a verified one, deciding what
+  a routine's spec should say, or blocked on a callee's spec shape.
 - [`docs/agents/top-theorem-ledger.md`](docs/agents/top-theorem-ledger.md) — the obligation
   ledger decomposing `run_stateless_guest_spec` (statement: `EvmAsm/Stateless/EntrySpec.lean`)
   into leaf work, with per-row status and exemplars.

--- a/docs/agents/proof-patterns.md
+++ b/docs/agents/proof-patterns.md
@@ -9,6 +9,7 @@ writing hits one of these symptoms; do **not** read end-to-end:
 - **End-to-end composition needs existential intermediates** → §End-to-End Composition with Existential Intermediates.
 - **`xperm` hits scaling limits / atom-count cliffs** → §XPerm Scaling Limits and Sub-Assertion Bundling.
 - **Double-addback (`_da`) postcondition shape needed** → §Double-Addback (_da) Postcondition Pattern.
+- **Folded framed post fights `xperm`/`whnf`, or `extract_pure`/`drop_pure` misbehave** → §Folded Framed Posts.
 
 Each section is self-contained — jump to the matching heading instead of reading top-to-bottom.
 
@@ -585,3 +586,38 @@ Be careful with the projection depth — off-by-one here causes type mismatches
 that are hard to diagnose (the error appears at the `hbltu` application site,
 far from the definition).
 
+
+## Folded Framed Posts: DivMod-Scale xperm/whnf Blowups and Framed-Pure Extraction
+
+(Moved from AGENTS.md "Critical Rules" to keep the agent guide compact;
+tracking issue for the pure-extraction tactic gaps:
+https://github.com/Verified-zkEVM/evm-asm/issues/7174.)
+
+### When DivMod postconditions explode under `xperm` or kernel `whnf`
+
+Fold the postcondition before trying harder tactics. Put the final register/memory assertion spine behind a small `@[irreducible]` helper such as `...PostCore`, parameterized by the final values that the branch proof should expose. If the public post has a deep body let-chain, add a second folded helper such as `...PostFromBody` that takes already-computed intermediates; the public `...Post` should compute the lets and delegate to the helper. In branch bridge proofs, use `change` to refold the expanded target to the helper with local names, simplify only the relevant `if_pos`/`if_neg`, then unfold only the small core immediately before `xperm_hyp`. Split repeated bridge obligations into named lemmas for fresh heartbeat budgets. Use `lean_goal` at the failing line to confirm the target is folded; if it prints a huge `BitVec.toNat 32` or nested-let/nested-if term, fold first instead of running `xperm` on the expanded goal.
+
+### When extracting framed pure facts in bridge posts
+
+Inspect the shape with `lean_goal` before repeatedly applying `drop_pure` or `extract_pure`. Framed pures may remain behind an extra `sepConj` layer, so remove one layer at a time with small local rewrites (`rw [sepConj_assoc']`, `simp only [sepConj_pure_mid_left]`) and `obtain` the pure fact you need. Broad `simp` or blind repeated extraction can expand the folded post again or destruct useful `sepConj` structure.
+### When `extract_pure`, `drop_pure`, or `xperm_pure` struggle on a folded framed post
+
+Avoid broad pure-extraction tactics on the whole post if they expand the folded helper, trigger kernel `whnf`, leave `xperm` atom-count mismatches, or report an expected-type/free-variable error. First extract only the outer pure fact you need, then rewrite the specific remaining pure assertion to `empAssertion` with a local extensional proof and simplify the emp frame before calling `xperm_hyp`. Shape:
+
+  ```lean
+  extract_pure hp
+  obtain ⟨hp, h_pure⟩ := hp
+  rw [show (⌜P⌝ : Assertion) = empAssertion by
+    funext h
+    unfold EvmAsm.Rv64.pure EvmAsm.Rv64.empAssertion
+    apply propext
+    constructor
+    · intro h_p
+      exact h_p.1
+    · intro h_empty
+      exact ⟨h_empty, h_pure⟩] at hp
+  simp only [the relevant sepConj_emp lemma] at hp
+  xperm_hyp hp
+  ```
+
+  Keep `EvmAsm.Rv64.pure` qualified in the unfold so Lean does not choose an unrelated `pure`, and keep the target folded until the final local rewrite. Tracking issue: https://github.com/Verified-zkEVM/evm-asm/issues/7174.

--- a/docs/agents/verified-replacement-strategy.md
+++ b/docs/agents/verified-replacement-strategy.md
@@ -1,0 +1,156 @@
+# Replacing an unverified program with a verified one — strategy
+
+The high-level decision guide for any bead of the shape "verify `<routine>`"
+or "swap `<routine>` for a verified implementation". The *mechanics* (class
+table, scaffold, VC closers, deploy gates) live in
+[`port-playbook.md`](port-playbook.md) — read that when you start typing.
+Read THIS page when you are deciding **what to prove, against what interface,
+and what to do when the pieces don't fit**.
+
+## 1. The drop-in principle
+
+**Byte-sequence equality with the old unverified routine is NOT required.**
+What must be preserved is the routine's *observable contract at its call
+boundary* — the replacement must be a **functional drop-in**:
+
+| Must be preserved | Why |
+|---|---|
+| ABI: argument/return registers, status-code conventions | callers are unverified asm that reads exactly these |
+| Clobber set ⊆ the documented convention for its class (leaf vs non-leaf; caller-saved x5–x7/x28–x31, dispatcher x14–x19 conventions, callee-saved discipline) | a wider clobber silently corrupts an unverified caller |
+| Memory footprint: which regions/cells it reads and writes — including its **static `.data` scratch cells** | anything it touches that the old one didn't can break a phase/aliasing assumption |
+| Termination/halt behavior and any exit ECALLs | the guest's control structure is straight-line composition |
+| Link-layout constraints *only where callers bake them in*: entry symbol name; nothing else. Function length and internal layout are free to change — `GuestAddrs.lean` and `symbol-addresses.tsv` are **regenerated**, not preserved (the `.9.5` regen pattern) | |
+
+What is explicitly FREE to change: instruction sequence, register allocation
+inside the clobber budget, loop shape (a `whileBreak` scan may become a
+canonical `while`, cf. bead `.70.2`), internal scratch layout, code length.
+Exemplars of landed drop-ins: the bn254 compare-leaves replacement
+(PR #9843, `port/bn254-cmp-leaves-dropin`) and the `.12.10` re-emit leaves.
+
+**The two byte-tie strategies** (pick one per PR, consciously):
+
+1. **Byte-identity** (`<name>Function_eq_prog` `rfl` drift guards): you did NOT
+   change the emitted routine; you verified a `Program` conversion of the
+   exact existing bytes. Cheap gate, no A/B needed. This is the default for
+   pure verification beads.
+2. **Re-emit** (true drop-in): the emitted bytes change. Then the gate is the
+   full emit pipeline: guest re-emit, `scripts/check-region-map.sh`,
+   link-layout regen (`gen-symbol-addresses.py`, `GuestAddrs`), and an
+   **EEST A/B** (sasm-howto §7.6) — failures acceptable only if identical on
+   both legs. #9852 (the frame-arena resize) is the maximal example of this
+   path. Never mix strategies silently: a "verification" PR that quietly
+   re-emits has skipped the A/B gate.
+
+## 2. How to formulate the specification
+
+The binding rule is already in AGENTS.md ("Spec design — keep preconditions
+static; put outcomes in the postcondition"). Strategy on top of it:
+
+- **State the footprint in the assertion vocabulary, not raw cells.** Frame
+  against `evmStackIs`, `evmMemoryIs`, `storageLogIs`, `accountRlpIs`,
+  `mptNodeIs`/`nodeDbIs`, `witnessSectionIs`/`codeDbIs`, `bytesRegion` — not
+  ad-hoc `↦ₘ` chains. A spec stated in raw dwords is *consumable only by the
+  session that wrote it*; a spec stated in the vocabulary is consumable by
+  every later composition (and by the refinement map,
+  `docs/4ch8f-slstate-specref-correspondence.md`). If the vocabulary lacks
+  your structure, adding the assertion (with a faithfulness tie) is part of
+  the job — copy the pattern of `EvmAsm/Evm64/StateAssertions.lean`.
+  Historical warning: the MLOAD/MSTORE stack specs were first stated against
+  raw dword windows and had to be *reframed afterwards*
+  (`Evm64/MLoad/MemoryRegionStackSpec.lean`) — state new specs at the right
+  altitude the first time.
+- **Value-carrying assertions + pure WF.** Assertions carry their contents as
+  parameters (`SepLogic.assertPure` shape: `fun ps => WF ∧ region ps`), so
+  the postcondition is a *pure function of the input parameters* — e.g.
+  "pushes `evmMemoryReadWord contents offset`", not "pushes whatever was in
+  memory". That pure function should be an **executable spec-level mirror**
+  (decode/lookup/replay), ideally tied to `SpecRef` (`decode_account_from_leaf`,
+  `build_node_db`, …) — then the routine spec and the refinement compose for
+  free. `#guard` the mirror on concrete vectors.
+- **All outcomes, one theorem.** Parse-fail / miss / conservative-failure
+  paths are part of the contract: model them as postcondition disjuncts with
+  static guards (the `ContentToU256Be` shape), never as preconditions that
+  assume success. A routine's *conservative-failure path is load-bearing*
+  (e.g. the witness-index builder failing over capacity is what makes the
+  uncapped linear fallback reachable).
+- **Own what you clobber.** Scratch registers and static `.data` scratch
+  cells (`mnk_dummy_offset`-style) appear in the pre as owned resources and
+  in the post either restored or existentially havoc'd (`memOwn`/`aExists`) —
+  fabricating concrete final values for scratch makes the spec unprovable or,
+  worse, over-specified so that a future re-emit breaks it.
+- **State the honest domain.** If the routine is only *instantiable* on a
+  sub-domain, gate the theorem on it and say so — do not force a general
+  statement whose extra cases have unsatisfiable preconditions. (Lesson: the
+  unaligned MLOAD/MSTORE window specs force adjacent limbs to share a dword,
+  so the separated precondition is satisfiable only for the aligned case;
+  the honest spec is the aligned one, recorded as such.) The `conditional`
+  tier of `Progress.lean` exists for exactly this — with a
+  `…_precondition_reachable` cover lemma to prove the gate is non-vacuous.
+- **Non-vacuity is a deliverable.** Provide the satisfiability witness for
+  your pre (the vacuity-guard section of `top-theorem-ledger.md`). Reviewers
+  reject triples whose pre can't be inhabited.
+
+## 3. When the callee doesn't expose enough
+
+You are composing routine B, and verified callee A's spec doesn't give you
+what B's proof needs. The escalation ladder, cheapest first — **do not skip
+to the bottom**:
+
+1. **A bridging lemma next to A.** Often A's spec is fine and you need a pure
+   consequence of its postcondition (a fold of its output bytes, an algebraic
+   restatement). Add the lemma in A's module; don't touch the triple.
+2. **A variant theorem for A** (additive). A's proof usually supports a
+   differently-shaped conclusion — a folded post, a mid-chain `_right`
+   rewrite form, an instantiated corollary. Add `A_spec_within_<shape>`
+   alongside; never *weaken or reshape the existing theorem* (other callers
+   and the witness registry depend on it).
+3. **Reframe A against the assertion vocabulary.** If A predates the
+   vocabulary and frames raw cells, write the reframed theorem by *consuming*
+   the proven one (peel the assertion into A's raw footprint, run A's spec,
+   fold back). This is the `evm_mload_stack_spec_within_evmMemoryIs` pattern
+   — the reframe is itself the assertion's honesty gate.
+4. **Strengthen A's spec** (re-prove with a stronger post). Needed when A's
+   post genuinely forgets information B needs (e.g. A returns a pointer but
+   its spec doesn't relate it to the region — the `(offset,len)`-view shape
+   should use a `matchesSection`-style relation, not a bare word). This costs
+   re-proving A; budget it as its own bead if nontrivial.
+5. **Change A's code** (true drop-in replacement, §1 path 2). Justified when
+   A's *interface* is the problem: it doesn't return a fact it inescapably
+   computed (a length, a status), or its contract is unspecifiable as-is
+   (multi-exit tails — cf. the `.10.3` set-flag+ret restructure that made all
+   256 handlers satisfy one return contract). Full emit gates apply.
+6. **STOP and file a bug.** If B's correctness *requires* something A cannot
+   provide because the guest is wrong — A reads garbage, relies on
+   zero-init that aliasing violates, its output is clobbered before B reads
+   it — that is not a proof obstacle. Do not prove around it, do not weaken
+   B's statement to avoid it. File the bead with the concrete failure
+   scenario (the `.72`/`.73` audit findings are the template) and wire it as
+   a blocker of the affected beads.
+
+Two special cases that look like "not enough" but aren't:
+
+- **Global aliasing/phase facts** (call-frame arena unions): never assert
+  disjointness that the physical layout doesn't provide. Consume the phase
+  views (`Codegen/CallFramePhase.lean`, `CallFrameWindows.lean`); the havoc
+  on view switches is the guarantee. If your proof wants to carry a value
+  across a phase switch, that is finding a bug, not missing a lemma.
+- **Link-layout facts** (absolute addresses, section extents): these come
+  from `RegionMap.lean` + the ELF drift guard, never from hardcoding. If A's
+  spec pins an address B needs symbolic, parametrize (the assertions are
+  base-parametrized for exactly this reason).
+
+## 4. Review expectations for a replacement PR
+
+What a reviewer will check (be ahead of it):
+
+- Which byte-tie strategy (§1) the PR uses, stated explicitly; A/B evidence
+  present iff re-emit.
+- The spec's pre is static + satisfiable; outcomes are disjunctive; the
+  domain restriction (if any) is honest and registered at the right
+  `Progress.lean` tier with witnesses.
+- The footprint is complete (including static scratch) and stated in the
+  vocabulary; nothing in the pre pre-decides a branch.
+- No existing theorem was weakened or reshaped (statement-tamper check);
+  strengthenings are additive.
+- Blockers honored: if the routine sits behind an open bug bead (`.72`,
+  `.73` class), the PR either fixes it first or is re-scoped.


### PR DESCRIPTION
## What

**New `docs/agents/verified-replacement-strategy.md`** — the high-level strategy guide for replacing an unverified guest program with a verified one, positioned as the decision layer above `port-playbook.md` (which stays the mechanics entry point). Contents:

- **The drop-in principle**: byte-sequence equality is *not* required — the replacement must be a *functional* drop-in. A table of what must be preserved (ABI, clobber budget, complete memory footprint including static `.data` scratch, halt behavior, entry symbol) vs what is free (instruction sequence, register allocation, loop shape, length — `GuestAddrs`/TSV are regenerated, not preserved). The **two byte-tie strategies** made explicit — byte-identity (`_eq_prog` drift guards, no A/B needed) vs re-emit (full gates: EEST A/B, `check-region-map`, link-layout regen) — with the rule that a PR picks one consciously and never mixes them silently. Grounded in landed exemplars (#9843 bn254 drop-in, #9852 as the maximal re-emit).
- **How to formulate the specification**: state footprints in the assertion vocabulary rather than raw cells (with the MLOAD reframe as the cautionary tale), value-carrying assertions whose posts are pure functions of the parameters via executable spec-level mirrors tied to SpecRef, all outcomes as postcondition disjuncts (conservative-failure paths are load-bearing), own-what-you-clobber for scratch, honest domain restrictions (the unaligned-window lesson + the `conditional` tier and cover lemmas), and non-vacuity witnesses as a deliverable.
- **When the callee doesn't expose enough** — an explicit escalation ladder, cheapest first: bridging lemma → additive variant theorem → reframe against the vocabulary (the `evm_mload_stack_spec_within_evmMemoryIs` pattern) → strengthen the callee's spec → change the emit (full drop-in path) → **STOP and file a bug** (the `.72`/`.73` audit findings as the template, with the never-prove-around rule). Plus the two lookalikes that aren't missing lemmas: phase/aliasing facts (consume the phase views) and link-layout facts (RegionMap, parametrized bases).
- **Reviewer expectations** for replacement PRs.

Linked from AGENTS.md's "Deep references" with a load-when trigger.

## AGENTS.md pruning (requested cleanup)

Following AGENTS.md's own keep-the-guide-compact policy:
- Removed **"Key Lean 4 API Compatibility Notes"** — dated Lean-nightly trivia (`And.assoc` naming, `#eval` doc-comments, "most theorems are in `namespace MachineState`"-era framing).
- Removed the **infancy-era concrete test list** from Testing (multiply-by-0/1/3/6/10/255, swap/zero/triple macros).
- **Moved the three long deep recipes** (DivMod-scale `xperm`/`whnf` blowups; framed-pure extraction; the `extract_pure`/`drop_pure` workaround with its code block) from Critical Rules into `docs/agents/proof-patterns.md` as a new indexed **"Folded Framed Posts"** section — preserved verbatim, replaced in AGENTS.md by a five-line pointer.
- Removed the **redundant standalone Shift-composition `maxHeartbeats` exception** bullet (already stated inside the main `maxHeartbeats` rule).

## Gates

Docs-only; no Lean changes, no guest bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)