### PR TITLE
feat(bn254): add arithHandle instance + winRw_wf for bnfMulModP

### DIFF
--- a/EvmAsm/Codegen/Programs/Bn254FieldMulModSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254FieldMulModSAsm.lean
@@ -5,31 +5,42 @@
   base-field modular multiply `(a · b) mod p_bn254`.
 
   The routine composes the two verified converters (`bnfBeToLe` / `bnfLeToBe`,
-  #9858/#9875) around the `Arith256Mod` accelerator handle (`.11.6 arithModHandle`):
+  #9858/#9875) around the `Arith256Mod` accelerator handle:
     bnfBeToLe(a0 → bnf_le_a) → bnfBeToLe(a1 → bnf_le_b) →
     arithModHandle → bnfLeToBe(bnf_le_d → output).
 
-  This file provides the arithmetic bridge (the accelerator's result, read
-  through the bn254 modulus, equals the genuine modular product in the
-  `Accel`/`.38.1` Nat vocabulary).  The full VC proof (composing the
-  converter retSpecs + the accelerator handle via framed FnHandleS over
-  the 272-byte data window) is WIP.
+  ## Proven
 
-  Handle instantiation check (no mismatch): the arithModHandle's
-  decode-valued post writes `Accel.arith256Mod(wsNat aOff, wsNat bOff,
-  wsNat cOff, wsNat mOff)` to `dOff`.  With bn254 mul params:
-    aOff=0(bnf_le_a), bOff=32(bnf_le_b), cOff=96(bnf_le_zero=0),
-    mOff=160(bnf_le_p=p), dOff=64(bnf_le_d).
-  This gives `(A·B + 0) mod p` — exactly the intended modular product.
+  - `arith256Mod_bn254_mul_eq`: the accelerator's result equals the genuine
+    `(A·B) mod p_bn254`.
+  - `winRw_wf`: well-formedness of the 272-byte data-section window.
+  - `arithHandle`: the `arithModHandle .w256` instance, instantiated at the
+    bn254 layout offsets (aOff=0, bOff=32, cOff=96=zero, mOff=160=p, dOff=64).
+    No mismatch — the handle's decode-valued post gives exactly `(A·B + 0) mod p`.
+
+  ## WIP (documented for follow-up)
+
+  The full VC proof (`bnfMulModPFn_spec`) needs:
+  1. **Framed converter handles** — FnHandleS for bnfBeToLe/bnfLeToBe with
+     region/rw = the caller's full 272-byte window, deriving soundness from
+     the converter specs via the separation-logic frame rule (the converters'
+     own rw is a 32-byte sub-window of the caller's 272-byte window; the frame
+     preserves everything else).
+  2. **SAsm body** — `.callRegS` at each call site (entry register `.x5`),
+     with `.block` prologue/inter/epilogue (all straight-line: stack save,
+     arg setup, pointer loads).
+  3. **`Fn.SpecR` via `vcgen`** — compose the three call sites (two converter
+     calls + one accelerator), close the post with `arith256Mod_bn254_mul_eq`.
 -/
 
 import EvmAsm.Rv64.SAsm.AccelStep
 import EvmAsm.Rv64.SAsm.Tactic
+import EvmAsm.Rv64.SAsm.MultiRw
 import EvmAsm.Codegen.Programs.Bn254Field
 import EvmAsm.Codegen.Programs.Bn254FieldConvSAsm
 
 namespace EvmAsm.Codegen
-open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Crypto
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.SAsm.Stmt EvmAsm.Crypto
 
 -- ============================================================================
 -- Constants
@@ -39,50 +50,76 @@ open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Crypto
 def p_bn254 : Nat :=
   21888242871839275222246405745257275088696311157297823662689037894645226208583
 
-/-- Window offsets (from `bnf_le_a`). -/
-def offA : Nat := 0      -- bnf_le_a
-def offB : Nat := 32     -- bnf_le_b
-def offD : Nat := 64     -- bnf_le_d
-def offZero : Nat := 96  -- bnf_le_zero (c-slot = 0 for mul)
-def offOne : Nat := 128  -- bnf_le_one  (b-slot = 1 for add)
-def offP : Nat := 160    -- bnf_le_p
-def offMulParams : Nat := 192  -- bnf_mul_params (5 × 8-byte pointers)
-def winLen : Nat := 272       -- total window size
+/-- Window offsets (from `bnf_le_a` = window base). -/
+def offA : Nat := 0       -- bnf_le_a
+def offB : Nat := 32      -- bnf_le_b
+def offD : Nat := 64      -- bnf_le_d
+def offZero : Nat := 96   -- bnf_le_zero (c-slot = 0 for mul)
+def offOne : Nat := 128   -- bnf_le_one  (b-slot = 1 for add)
+def offP : Nat := 160     -- bnf_le_p
+def offMulParams : Nat := 192 -- bnf_mul_params (5 × 8-byte pointers)
+def winLen : Nat := 272
+
+/-- Window base address. -/
+def winBase : Word := BitVec.ofNat 64 GuestAddrs.bnf_le_a
 
 -- ============================================================================
--- Arithmetic bridge
+-- Proven: arithmetic bridge
 -- ============================================================================
 
-/-- The accelerator's result, read through the bn254 modulus, equals the
-    genuine modular product in the Nat vocabulary.  This is the key
-    arithmetic identity that connects `Accel.arith256Mod` (the accelerator's
-    decode-valued post) to the spec's `(A·B) mod p_bn254`. -/
+/-- `Accel.arith256Mod A B 0 p = (A * B) % p` — by definition. -/
 theorem arith256Mod_bn254_mul_eq (bytesA bytesB : List (BitVec 8)) :
     Accel.arith256Mod (beBytesToNat bytesA) (beBytesToNat bytesB) 0 p_bn254
-    = (beBytesToNat bytesA * beBytesToNat bytesB) % p_bn254 := by
-  -- Accel.arith256Mod a b c m = (a * b + c) % m by definition
-  rfl
+    = (beBytesToNat bytesA * beBytesToNat bytesB) % p_bn254 := rfl
 
 -- ============================================================================
--- WIP: the full VC proof
+-- Proven: window well-formedness + accelerator handle
 -- ============================================================================
---
--- The remaining work to complete `bnfMulModPFn_spec`:
---
--- 1. Framed converter handles: FnHandleS for bnfBeToLe/bnfLeToBe with
---    region/rw = the caller's full window, derived from the converter
---    specs via the frame rule.
---
--- 2. arithModHandle instance: arithModHandle .w256 accelEntry .x5 with
---    pOff=offMulParams, aOff=offA, bOff=offB, cOff=offZero, mOff=offP,
---    dOff=offD.
---
--- 3. SAsm body: prologue + .callRegS(be2le_a) + inter + .callRegS(be2le_b)
---    + accel_setup + .callRegS(accel) + post-accel + .callRegS(le2be) +
---    epilogue.
---
--- 4. Fn.SpecR via vcgen, closing the post with:
---    beBytesToNat(output) = (beBytesToNat(A) · beBytesToNat(B)) mod p_bn254
---    via the converter specs + arith256Mod_bn254_mul_eq.
+
+/-- The writable window for the data section. -/
+def winRw : RwRegion := ⟨winBase, 272⟩
+
+/-- Well-formedness of the data-section window. -/
+private theorem winRw_wf : winRw.wf := by
+  show winBase.toNat % 8 = 0 ∧ winBase.toNat + 272 < 2 ^ 64 ∧
+    ∀ k, k < 272 → isValidMemAddr (winBase + BitVec.ofNat 64 k) = true
+  refine ⟨rfl, by decide, ?_⟩
+  intro k hk
+  rw [winBase]
+  show isValidMemAddr (BitVec.ofNat 64 GuestAddrs.bnf_le_a + BitVec.ofNat 64 k) = true
+  rw [show GuestAddrs.bnf_le_a = 3142584624 from rfl]
+  have : (BitVec.ofNat 64 3142584624 + BitVec.ofNat 64 k).toNat = 3142584624 + k := by
+    rw [BitVec.toNat_add, BitVec.toNat_ofNat, BitVec.toNat_ofNat]
+    have h1 : (3142584624 : Nat) < 2 ^ 64 := by decide
+    have h2 : k < 2 ^ 64 := by omega
+    have h3 : (3142584624 + k : Nat) < 2 ^ 64 := by omega
+    rw [Nat.mod_eq_of_lt h2, Nat.mod_eq_of_lt h1, Nat.mod_eq_of_lt h3]
+  show isValidMemAddr (BitVec.ofNat 64 3142584624 + BitVec.ofNat 64 k) = true
+  unfold isValidMemAddr
+  have : (BitVec.ofNat 64 3142584624 + BitVec.ofNat 64 k).toNat = 3142584624 + k := this
+  rw [this]
+  have h1 : decide (Rv64.RAM_MEM_START ≤ 3142584624 + k) = true := by
+    show decide (2684354560 ≤ 3142584624 + k) = true
+    exact decide_eq_true_iff.mpr (by omega)
+  have h2 : decide (3142584624 + k ≤ Rv64.RAM_MEM_END) = true := by
+    show decide (3142584624 + k ≤ 3221225472) = true
+    exact decide_eq_true_iff.mpr (by omega)
+  simp only [h1, h2, Bool.true_and, Bool.or_true]
+
+/-- The accelerator handle for bn254 modular multiply.
+    Parameter block at offset offMulParams:
+      [0]:  ptr to bnf_le_a (offset offA)
+      [8]:  ptr to bnf_le_b (offset offB)
+      [16]: ptr to bnf_le_zero (offset offZero)
+      [24]: ptr to bnf_le_p (offset offP)
+      [32]: ptr to bnf_le_d (offset offD)
+    The accelerator computes `(A·B + 0) mod p` — exactly the intended
+    modular product (no mismatch). -/
+def arithHandle : FnHandleS :=
+  arithModHandle .w256 (winBase + BitVec.ofNat 64 offMulParams) .x5
+    (by decide) Region.empty winBase winLen winRw_wf
+    offMulParams offA offB offZero offP offD
+    (by decide) (by decide) (by decide) (by decide) (by decide) (by decide)
+    (by decide) (by decide) (by decide) (by decide) (by decide) (by decide)
 
 end EvmAsm.Codegen


### PR DESCRIPTION
Follow-up to the merged #9877. Adds the `arithModHandle .w256` instance for bn254 modular multiply and proves `winRw_wf` (the 272-byte data window is well-formed).

## What's new

- **`winRw_wf`**: proves `RwRegion.wf ⟨winBase, 272⟩` — the data-section window (bnf_le_a through bnf_add_params) is in valid RAM range, 8-aligned, no wrap.
- **`arithHandle`**: the `arithModHandle .w256` instance at bn254 layout offsets (aOff=0, bOff=32, cOff=96=zero, mOff=160=p, dOff=64). Validates the handle instantiation — no mismatch.
- **Import fix**: `Bn254FieldMulModSAsm` wired into `Imports.lean` (was the #9877 CI blocker).

## What's proven (carried from #9877)

- `arith256Mod_bn254_mul_eq`: accelerator result = genuine `(A·B) % p_bn254`.

## What's WIP (documented in file)

The full `bnfMulModPFn_spec` VC proof: framed converter handles + SAsm body + vcgen.

Co-Authored-By: GLM-5.2 <noreply@anthropic.com>