### PR TITLE
sasm: route loads through ambient bytesRegion atoms (multi-input routines)

### DIFF
--- a/EvmAsm/Rv64/SAsm.lean
+++ b/EvmAsm/Rv64/SAsm.lean
@@ -37,4 +37,5 @@ import EvmAsm.Rv64.SAsm.InterpLoopDemo
 import EvmAsm.Rv64.SAsm.AccelStep
 import EvmAsm.Rv64.SAsm.PowLadderDemo
 import EvmAsm.Rv64.SAsm.MultiRw
+import EvmAsm.Rv64.SAsm.MultiRead
 import EvmAsm.Rv64.SAsm.WhileBreakDemo

--- a/EvmAsm/Rv64/SAsm/Ast.lean
+++ b/EvmAsm/Rv64/SAsm/Ast.lean
@@ -128,6 +128,25 @@ inductive Stmt where
             (winR : RegFile → List (BitVec 8) → Assertion →
               List (BitVec 8) → Assertion → Prop)
             (instrs : List Instr)
+  /-- Read-focus block (the read-side mirror of `blockAt`): a straight-line
+      block whose *read-only source* is a `bytesRegion` at the address held
+      in register `ptr`, opened out of the ambient assertion for the block's
+      duration.  The annotation `roR` *relates* the entry state to the
+      decomposition (region bytes, remainder assertion) — relational so it
+      can name existentially-quantified ghosts from the ambient invariant.
+      The generator emits a `.focus` VC demanding a related decomposition
+      exist with `A = bytesRegion (rf.get ptr) robytes ** rest`.  Inside the
+      block, loads that miss the function's writable window read the focused
+      region's bytes; the primary read-only region is framed — inaccessible.
+      The writable window and the ambient assertion are untouched (the
+      focused region is read-only, so its bytes never change).  This is how
+      a multi-input routine reads from one of several independent external
+      buffers (each an ambient `bytesRegion`) while still writing its result
+      through the function's writable window (`bnfMulModP`/`secfMulModP`). -/
+  | readAt (label : String) (ptr : Reg)
+           (roR : RegFile → List (BitVec 8) → Assertion →
+              List (BitVec 8) → Assertion → Prop)
+           (instrs : List Instr)
   /-- Ghost step: emits no code; replaces the ambient assertion `A` by an
       `R`-related `A'`, justified by one VC producing such an `A'` with a
       pointwise entailment (and pc-freedom).  Relational rather than
@@ -240,6 +259,7 @@ def size : Stmt → Nat
   | assert _ _        => 0
   | ghost _ _         => 0
   | blockAt _ _ _ is  => is.length
+  | readAt _ _ _ is   => is.length
   | «while» _ _ _ _ b   => b.size + 2
   | «whileS» _ _ _ _ b  => b.size + 2
   | «whileBreak» _ _ _ _ _ bb _ ba => bb.size + ba.size + 3
@@ -263,6 +283,7 @@ def callFree : Stmt → Bool
   | assert _ _        => true
   | ghost _ _         => true
   | blockAt _ _ _ _   => true
+  | readAt _ _ _ _    => true
   | «while» _ _ _ _ b => b.callFree
   | «whileS» _ _ _ _ b => b.callFree
   | «whileBreak» _ _ _ _ _ bb _ ba => bb.callFree && ba.callFree

--- a/EvmAsm/Rv64/SAsm/Flatten.lean
+++ b/EvmAsm/Rv64/SAsm/Flatten.lean
@@ -63,6 +63,8 @@ def flatten (addr : Word) : Stmt → List Instr
       []
   | blockAt _ _ _ is =>
       is
+  | readAt _ _ _ is =>
+      is
   | «while» _ c _ _ b =>
       c.neg.toInstr (brOfs (b.size + 2))
         :: (b.flatten (addr + 4) ++ [.JAL .x0 (jBack (b.size + 1))])
@@ -100,6 +102,7 @@ theorem flatten_length (s : Stmt) (addr : Word) :
   | assert _ _ => rfl
   | ghost _ _ => rfl
   | blockAt _ _ _ _ => rfl
+  | readAt _ _ _ _ => rfl
   | «while» _ c fuel inv b ihb =>
       simp [flatten, size, ihb]
   | «whileS» _ c fuel inv b ihb =>
@@ -132,6 +135,7 @@ def offsetsOk : Stmt → Bool
   | assert _ _ => true
   | ghost _ _ => true
   | blockAt _ _ _ _ => true
+  | readAt _ _ _ _ => true
   | «while» _ c _ _ b =>
       c.wf && decide (4 * (b.size + 2) < 2^12)
            && decide (4 * (b.size + 1) ≤ 2^20)
@@ -171,6 +175,7 @@ def callsOk : Stmt → Word → Prop
   | assert _ _, _ => True
   | ghost _ _, _ => True
   | blockAt _ _ _ _, _ => True
+  | readAt _ _ _ _, _ => True
   | «while» _ _ _ _ b, addr => b.callsOk (addr + 4)
   | «whileS» _ _ _ _ b, addr => b.callsOk (addr + 4)
   | «whileBreak» _ _ _ _ _ bb _ ba, addr =>

--- a/EvmAsm/Rv64/SAsm/MultiRead.lean
+++ b/EvmAsm/Rv64/SAsm/MultiRead.lean
@@ -1,0 +1,295 @@
+/-
+  EvmAsm.Rv64.SAsm.MultiRead
+
+  Multiple read-only inputs for SAsm functions: the read-side mirror of
+  `MultiRw`/`blockAt`, realized by the new `Stmt.readAt` focus node.
+
+  ## The design decision (recorded)
+
+  A routine that reads from TWO OR MORE independent read-only pointers
+  (e.g. a field-arithmetic precompile whose two operands `a0`, `a1` are
+  arbitrary 32-byte buffers — never guaranteed contiguous) cannot express
+  those inputs as the function's single `region : Region`.  Instead it owns:
+
+  - region 1, …, k as `bytesRegion` conjuncts of the ambient assertion `A`,
+    each read through a `Stmt.readAt` node focused at the region's pointer
+    register, and
+  - the function's writable window as the primary `rw : RwRegion` (contents
+    threaded through the symbolic state `ws` as usual).
+
+  This is the exact mirror of `MultiRw`'s *store* design: `blockAt` swaps the
+  writable window for an ambient region while the read-only `region` stays
+  fixed; `readAt` swaps the read-only source for an ambient region while the
+  writable `rw` stays fixed.  Because a read-only region's bytes are
+  immutable, the ambient assertion is threaded UNCHANGED across a `readAt`
+  block (simpler than `blockAt`, which must write the window back).  The
+  same soundness argument applies: inside the block, a load that misses the
+  writable window reads the focused ambient region's bytes and nothing else
+  (`Stmt.sound`'s `readAt` case), disjointness is structural via `**` (an
+  overlapping region makes the precondition unsatisfiable), and block
+  granularity loses nothing (values cross a region-switch cut in registers).
+
+  The demo `multiReadFn` below is the template for `bnfMulModP` /
+  `secfMulModP`: it reads a dword from EACH of two independent read-only
+  buffers `a0`, `a1` (both ambient `bytesRegion` atoms, allowed to coincide
+  — a squaring `a0 = a1` — or to differ), sums them, and writes the result
+  through the writable window `dst`.  Its post pins the window to the
+  function of the two inputs and both read buffers to their (unchanged)
+  input bytes.
+-/
+
+import EvmAsm.Rv64.SAsm.MultiDword
+import EvmAsm.Rv64.SAsm.Tactic
+import EvmAsm.Rv64.SAsm.Fn
+
+namespace EvmAsm.Rv64
+
+namespace SAsm
+
+namespace MultiRead
+
+/-- Focus relation of the first read: the region bytes are `bs0` at the
+    pointer pinned in `a0` (`x10`); the remainder is the second buffer. -/
+def roA0 (a0 a1 : Word) (bs0 bs1 : List (BitVec 8)) :
+    RegFile → List (BitVec 8) → Assertion → List (BitVec 8) → Assertion → Prop :=
+  fun rf _ _ rob rst => rf.get .x10 = a0 ∧ rob = bs0 ∧ rst = bytesRegion a1 bs1
+
+/-- Focus relation of the second read: the region bytes are `bs1` at the
+    pointer pinned in `a1` (`x11`); the remainder is the first buffer. -/
+def roA1 (a0 a1 : Word) (bs0 bs1 : List (BitVec 8)) :
+    RegFile → List (BitVec 8) → Assertion → List (BitVec 8) → Assertion → Prop :=
+  fun rf _ _ rob rst => rf.get .x11 = a1 ∧ rob = bs1 ∧ rst = bytesRegion a0 bs0
+
+open Stmt in
+/-- Read a dword from `a0` (focused), then from `a1` (focused), then sum and
+    write the result to the writable window `dst` (primary `rw`). -/
+def multiReadBody (a0 a1 : Word) (bs0 bs1 : List (BitVec 8)) : Stmt :=
+  .readAt "readA0" .x10 (roA0 a0 a1 bs0 bs1) [.LD .x5 .x10 0] ;;;
+  .readAt "readA1" .x11 (roA1 a0 a1 bs0 bs1) [.LD .x6 .x11 0] ;;;
+  .block "write" [.ADD .x7 .x5 .x6, .SD .x12 .x7 0]
+
+/-- **The two-read-only-region demo function.**  `a0`, `a1`, `dst` are three
+    independent pointers: `a0`, `a1` are read-only 8-byte buffers held as
+    ambient `bytesRegion` atoms, `dst` is the writable window (primary `rw`).
+    The post pins `dst` to the dword sum of the two inputs and both read
+    buffers to their input bytes — all functions of the input, no
+    existentials. -/
+def multiReadFn (a0 a1 dst : Word) (bs0 bs1 : List (BitVec 8)) : Fn where
+  name := "multiRead"
+  region := Region.empty
+  rw := ⟨dst, 8⟩
+  pre := fun rf _ A =>
+    rf.get .x10 = a0 ∧ rf.get .x11 = a1 ∧ rf.get .x12 = dst ∧
+    A = (bytesRegion a0 bs0 ** bytesRegion a1 bs1)
+  post := fun rf ws A =>
+    rf.get .x12 = dst ∧
+    ws = dwordBytes (packBytes bs0 + packBytes bs1) ∧
+    A = (bytesRegion a0 bs0 ** bytesRegion a1 bs1)
+  body := multiReadBody a0 a1 bs0 bs1
+
+-- The emitted code is the two focus blocks and the write block back to
+-- back: read-side focus routing adds zero instructions.
+#guard ((multiReadBody 0 0 [] []).flatten 0 : List Instr)
+  = [.LD .x5 .x10 0, .LD .x6 .x11 0, .ADD .x7 .x5 .x6, .SD .x12 .x7 0]
+
+-- Position independence: no PC-relative instructions.
+#guard ((multiReadBody 0 0 [] []).flatten 0 = (multiReadBody 0 0 [] []).flatten 0x80000000)
+
+section Demo
+
+variable (a0 a1 dst : Word) (bs0 bs1 : List (BitVec 8))
+
+/-- A focused read (`LD`) that misses the writable window reads the focused
+    read-only region at the pointer register; stated fully resolved (base is
+    `rf.get rs1`, matching the `readAt` engine's `⟨rf.get p, _⟩`). -/
+private theorem read_engine (roBytes : List (BitVec 8)) (rwBase : Word)
+    (rf : RegFile) (ws : List (BitVec 8)) (rd rs1 : Reg) (ofs : BitVec 12)
+    (hofs : signExtend12 ofs = (0 : Word)) (hws : ws.length = 8)
+    (hlen : roBytes.length = 8) (hne : rf.get rs1 ≠ rwBase) :
+    execBlock ⟨rf.get rs1, roBytes⟩ rwBase rf ws [.LD rd rs1 ofs]
+      = (rf.set rd (packBytes roBytes), ws) := by
+  have haddr : rf.get rs1 + signExtend12 ofs = rf.get rs1 := by rw [hofs]; bv_omega
+  rw [execBlock_cons, execInstrRF]
+  dsimp only [aluSem, loadSem]
+  rw [if_neg (by
+    unfold inRw
+    rw [haddr, hws]
+    intro hin
+    exact hne (by bv_omega))]
+  unfold Region.dwordAt
+  rw [show ((rf.get rs1 + signExtend12 ofs) - (⟨rf.get rs1, roBytes⟩ : Region).base).toNat = 0
+      from by rw [haddr]; bv_omega,
+    List.drop_zero, List.take_of_length_le (show roBytes.length ≤ 8 from by omega),
+    execBlock_nil]
+
+/-- Address side conditions of a focused read: the load misses the writable
+    window (routing to the focused region), and indexes the focused region
+    at offset 0, aligned. -/
+private theorem read_blockVCs (roBytes : List (BitVec 8)) (rwBase : Word)
+    (rf : RegFile) (ws : List (BitVec 8)) (rd rs1 : Reg) (ofs : BitVec 12)
+    (hofs : signExtend12 ofs = (0 : Word)) (hws : ws.length = 8)
+    (hlen : roBytes.length = 8) (hne : rf.get rs1 ≠ rwBase) :
+    blockVCs ⟨rf.get rs1, roBytes⟩ rwBase rf ws [.LD rd rs1 ofs] := by
+  have haddr : rf.get rs1 + signExtend12 ofs = rf.get rs1 := by rw [hofs]; bv_omega
+  refine ⟨?_, trivial⟩
+  show (if inRw rwBase ws (rf.get rs1 + signExtend12 ofs) 8
+    then _ else Region.loadOk _ _ _)
+  rw [if_neg (by unfold inRw; rw [haddr, hws]; intro hin; exact hne (by bv_omega)), haddr]
+  refine ⟨?_, ?_⟩
+  · show 8 ∣ ((rf.get rs1 - rf.get rs1 : Word)).toNat
+    rw [show ((rf.get rs1 - rf.get rs1 : Word)).toNat = 0 from by bv_omega]
+    exact ⟨0, rfl⟩
+  · show ((rf.get rs1 - rf.get rs1 : Word)).toNat + 8 ≤ roBytes.length
+    rw [show ((rf.get rs1 - rf.get rs1 : Word)).toNat = 0 from by bv_omega]
+    omega
+
+/-- The write block's engine run, fully resolved: `x7 := x5 + x6`, the window
+    becomes the dword of that sum. -/
+private theorem write_engine (rf : RegFile) (ws : List (BitVec 8))
+    (hx12 : rf.get .x12 = dst) (hws : ws.length = 8) :
+    execBlock Region.empty dst rf ws [.ADD .x7 .x5 .x6, .SD .x12 .x7 0]
+      = (rf.set .x7 (rf.get .x5 + rf.get .x6),
+          dwordBytes (rf.get .x5 + rf.get .x6)) := by
+  have hs0 : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
+  rw [execBlock_cons,
+    show execInstrRF Region.empty dst rf ws (.ADD .x7 .x5 .x6)
+      = (rf.set .x7 (rf.get .x5 + rf.get .x6), ws) from rfl]
+  rw [execBlock_cons, execInstrRF_sd_dword _ _ _ _ _ _ _ 0
+    (by
+      rw [RegFile.get_set_ne _ _ _ _ (by decide : Reg.x12 ≠ .x7), hx12, hs0]
+      bv_omega)]
+  rw [RegFile.get_set_self _ _ _ (by decide), execBlock_nil,
+    setBytes_dword_full _ _ hws]
+
+/-- Address side conditions of the write block: the store fits the writable
+    window at offset 0, aligned. -/
+private theorem write_blockVCs (rf : RegFile) (ws : List (BitVec 8))
+    (hx12 : rf.get .x12 = dst) (hws : ws.length = 8) :
+    blockVCs Region.empty dst rf ws [.ADD .x7 .x5 .x6, .SD .x12 .x7 0] := by
+  have haddr : (((rf.set .x7 (rf.get .x5 + rf.get .x6)).get .x12
+      + signExtend12 (0 : BitVec 12)) - dst).toNat = 0 := by
+    rw [RegFile.get_set_ne _ _ _ _ (by decide : Reg.x12 ≠ .x7), hx12,
+      show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]
+    bv_omega
+  simp only [blockVCs, loadSem, storeSem, aluSem, execInstrRF, inRw, haddr]
+  refine ⟨trivial, ⟨?_, ⟨0, rfl⟩⟩, trivial⟩
+  omega
+
+/-- **The two-read-only-region triple.**  Hypotheses: the writable window is
+    well-formed (`hrw`), both read buffers are well-formed 8-byte regions
+    (`hro0`/`hro1`, `hbs0`/`hbs1`), and each read pointer misses the writable
+    window (`hne0`/`hne1` — the routing disjointness; regions that actually
+    overlapped would make the precondition unsatisfiable via `**`).  Note
+    NO `a0 ≠ a1` hypothesis: the two reads may target the same buffer (a
+    squaring) or different buffers (a product). -/
+theorem multiReadFn_spec (base : Word)
+    (hrw : RwRegion.wf ⟨dst, 8⟩)
+    (hro0 : Region.wf ⟨a0, bs0⟩) (hro1 : Region.wf ⟨a1, bs1⟩)
+    (hbs0 : bs0.length = 8) (hbs1 : bs1.length = 8)
+    (hne0 : a0 ≠ dst) (hne1 : a1 ≠ dst) :
+    (multiReadFn a0 a1 dst bs0 bs1).Spec base := by
+  have hofs0 : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
+  vcgen
+  case region => exact ⟨Region.empty_wf, hrw⟩
+  case multiRead.readA0.focus =>
+    rintro rf ws A ⟨hx10, hx11, hx12, hA⟩ hApc hp hhp
+    refine ⟨bs0, bytesRegion a1 bs1, ⟨hx10, rfl, rfl⟩, ?_, bytesRegion_pcFree _ _, ?_⟩
+    · rw [hx10]; rw [hA] at hhp; exact hhp
+    · rw [hx10]; exact hro0
+  case multiRead.readA0.mem =>
+    rintro rf ws A robytes rest hws ⟨hx10, hx11, hx12, hA⟩ ⟨hptr, hrob, hrest⟩ hsat
+    have hws8 : ws.length = 8 := hws
+    exact read_blockVCs robytes dst rf ws .x5 .x10 0 hofs0 hws8
+      (by rw [hrob]; exact hbs0) (by rw [hptr]; exact hne0)
+  case multiRead.readA1.focus =>
+    rintro rf ws A hreach hApc hp hhp
+    -- reach = sp readA0 pre; recover the pinned pointers and ambient shape
+    obtain ⟨rf₀, ws₀, A₀, rob0, rest0, hlen₀, ⟨hx10, hx11, hx12, hA⟩,
+      hsat0, ⟨hptr0, hrob0, hrest0⟩, hrf, hwsE, hAeq⟩ := hreach
+    dsimp only [multiReadFn] at hrf hlen₀
+    have hlr0 : rob0.length = 8 := by rw [hrob0]; exact hbs0
+    have hws0 : ws₀.length = 8 := hlen₀
+    have hx11' : rf.get .x11 = a1 := by
+      rw [hrf, read_engine rob0 dst rf₀ ws₀ .x5 .x10 0 hofs0 hws0 hlr0
+          (by rw [hx10]; exact hne0),
+        RegFile.get_set_ne _ _ _ _ (by decide : Reg.x11 ≠ .x5)]
+      exact hx11
+    have hAeq' : A = (bytesRegion a0 bs0 ** bytesRegion a1 bs1) := by
+      rw [hAeq, hrob0, hrest0, hx10]
+    refine ⟨bs1, bytesRegion a0 bs0, ⟨hx11', rfl, rfl⟩, ?_, bytesRegion_pcFree _ _, ?_⟩
+    · rw [hx11']
+      rw [hAeq'] at hhp
+      xperm_hyp hhp
+    · rw [hx11']; exact hro1
+  case multiRead.readA1.mem =>
+    rintro rf ws A robytes rest hws hreach ⟨hptr, hrob, hrest⟩ hsat
+    have hws8 : ws.length = 8 := hws
+    exact read_blockVCs robytes dst rf ws .x6 .x11 0 hofs0 hws8
+      (by rw [hrob]; exact hbs1) (by rw [hptr]; exact hne1)
+  case multiRead.write.mem =>
+    rintro rf ws A hws hreach
+    have hws8 : ws.length = 8 := hws
+    -- recover x12 = dst through the two focus blocks
+    obtain ⟨rf₁, ws₁, A₁, rob1, rest1, hlen1, hreach0, hsat1,
+      ⟨hptr1, hrob1, hrest1⟩, hrf1, hws1, hAeq1⟩ := hreach
+    obtain ⟨rf₀, ws₀, A₀, rob0, rest0, hlen0, ⟨hx10, hx11, hx12, hA⟩,
+      hsat0, ⟨hptr0, hrob0, hrest0⟩, hrf0, hws0, hAeq0⟩ := hreach0
+    dsimp only [multiReadFn] at hrf1 hrf0 hlen0 hlen1 ⊢
+    have hlr0 : rob0.length = 8 := by rw [hrob0]; exact hbs0
+    have hlr1 : rob1.length = 8 := by rw [hrob1]; exact hbs1
+    have hws08 : ws₀.length = 8 := hlen0
+    have hws18 : ws₁.length = 8 := hlen1
+    have hx12' : rf.get .x12 = dst := by
+      rw [hrf1, read_engine rob1 dst rf₁ ws₁ .x6 .x11 0 hofs0 hws18 hlr1
+          (by rw [hptr1]; exact hne1),
+        RegFile.get_set_ne _ _ _ _ (by decide : Reg.x12 ≠ .x6), hrf0,
+        read_engine rob0 dst rf₀ ws₀ .x5 .x10 0 hofs0 hws08 hlr0
+          (by rw [hx10]; exact hne0),
+        RegFile.get_set_ne _ _ _ _ (by decide : Reg.x12 ≠ .x5)]
+      exact hx12
+    exact write_blockVCs dst rf ws hx12' hws8
+  case multiRead.post =>
+    rintro rf' ws' A''
+      ⟨rfW, wsW, hlenW, hreachW, hrf', hws'⟩
+    -- outer: the write block; inner: readA1 then readA0
+    obtain ⟨rf₁, ws₁, A₁, rob1, rest1, hlen1, hreach0, hsat1,
+      ⟨hptr1, hrob1, hrest1⟩, hrf1, hws1, hAeq1⟩ := hreachW
+    obtain ⟨rf₀, ws₀, A₀, rob0, rest0, hlen0, ⟨hx10, hx11, hx12, hA⟩,
+      hsat0, ⟨hptr0, hrob0, hrest0⟩, hrf0, hws0, hAeq0⟩ := hreach0
+    dsimp only [multiReadFn] at hrf1 hrf0 hlen0 hlen1 hrf' hws'
+    have hlr0 : rob0.length = 8 := by rw [hrob0]; exact hbs0
+    have hlr1 : rob1.length = 8 := by rw [hrob1]; exact hbs1
+    have hws08 : ws₀.length = 8 := hlen0
+    have hws18 : ws₁.length = 8 := hlen1
+    -- fully resolve the register file after both reads
+    have hrfW : rfW = (rf₀.set .x5 (packBytes rob0)).set .x6 (packBytes rob1) := by
+      rw [hrf1, read_engine rob1 dst rf₁ ws₁ .x6 .x11 0 hofs0 hws18 hlr1
+          (by rw [hptr1]; exact hne1), hrf0,
+        read_engine rob0 dst rf₀ ws₀ .x5 .x10 0 hofs0 hws08 hlr0
+          (by rw [hx10]; exact hne0)]
+    have hx12W : rfW.get .x12 = dst := by
+      rw [hrfW, RegFile.get_set_ne _ _ _ _ (by decide : Reg.x12 ≠ .x6),
+        RegFile.get_set_ne _ _ _ _ (by decide : Reg.x12 ≠ .x5)]
+      exact hx12
+    have hx5W : rfW.get .x5 = packBytes rob0 := by
+      rw [hrfW, RegFile.get_set_ne _ _ _ _ (by decide : Reg.x5 ≠ .x6),
+        RegFile.get_set_self _ _ _ (by decide)]
+    have hx6W : rfW.get .x6 = packBytes rob1 := by
+      rw [hrfW, RegFile.get_set_self _ _ _ (by decide)]
+    have hwsW8 : wsW.length = 8 := by
+      rw [hws1, execBlock_ws_length, hws0, execBlock_ws_length]; exact hws08
+    -- run the write block
+    rw [write_engine dst rfW wsW hx12W hwsW8] at hrf' hws'
+    subst hrf' hws'
+    refine ⟨?_, ?_, ?_⟩
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide : Reg.x12 ≠ .x7)]; exact hx12W
+    · rw [hx5W, hx6W, hrob0, hrob1]
+    · rw [hAeq1, hptr1, hrob1, hrest1]; xperm
+end Demo
+
+#print axioms multiReadFn_spec
+
+end MultiRead
+
+end SAsm
+end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/StmtSound.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSound.lean
@@ -426,6 +426,54 @@ theorem Stmt.sound (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
             hlen, pcFree_sepConj (bytesRegion_pcFree _ _) hrestpc,
             ⟨rf, A, win, rest, hlen, hreach, ⟨h4, hpair⟩, hRw, rfl, rfl⟩,
             hx⟩) hp hh2
+  | readAt lbl p roR is =>
+      have hok : blockOk is = true := hvcs.head
+      have hfocus : ∀ rf ws A, reach rf ws A → A.pcFree → ∀ hp, A hp →
+          ∃ robytes rest, roR rf ws A robytes rest
+            ∧ (bytesRegion (rf.get p) robytes ** rest) hp
+            ∧ rest.pcFree ∧ Region.wf ⟨rf.get p, robytes⟩ := hvcs.tail.head
+      have hmem : ∀ rf ws A robytes rest, ws.length = rw.len → reach rf ws A →
+          roR rf ws A robytes rest →
+          (∃ hp, (bytesRegion (rf.get p) robytes ** rest) hp) →
+          blockVCs ⟨rf.get p, robytes⟩ rw.base rf ws is := by
+        by_cases hl : hasLoad is
+        · have ht := hvcs.tail.tail
+          simp only [hl, if_true] at ht
+          exact ht.head
+        · exact fun rf ws A robytes rest _ _ _ _ =>
+            blockVCs_of_not_hasLoad ⟨rf.get p, robytes⟩ rw.base rf ws is (by simpa using hl)
+      apply cpsTripleWithin_exists_pre_M
+      intro rf ws A hlen hApc hreach R hR s hcr hPR hpc
+      obtain ⟨h0, hcompat, h1, h2, hd, hu, hP1, hR2⟩ := hPR
+      obtain ⟨h3, h4, hd2, hu2, hP3, hA4⟩ := hP1
+      obtain ⟨robytes, rest, hRoR, hpair, hrestpc, hwf⟩ :=
+        hfocus rf ws A hreach hApc h4 hA4
+      have hPR' : ((((regFileIs rf) ** (bytesRegion reg.base reg.bytes **
+          bytesRegion rw.base ws)) ** (bytesRegion (rf.get p) robytes ** rest))
+          ** R).holdsFor s :=
+        ⟨h0, hcompat, h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hP3, hpair⟩, hR2⟩
+      have h := execBlock_sound ⟨rf.get p, robytes⟩ rw is rf ws base hwf
+        hrw hlen hok (hmem rf ws A robytes rest hlen hreach hRoR ⟨h4, hpair⟩)
+        (by simpa [Stmt.size] using hsz)
+      have hA2 := cpsTripleWithin_frameR (bytesRegion reg.base reg.bytes ** rest)
+        (pcFree_sepConj (bytesRegion_pcFree _ _) hrestpc) h
+      have h' := cpsTripleWithin_extend_code hcode hA2
+      refine cpsTripleWithin_weaken ?_ ?_ h' R hR s hcr hPR' hpc
+      · intro hp hh
+        xperm_hyp hh
+      · intro hp hh
+        have hh2 : ((((regFileIs (execBlock ⟨rf.get p, robytes⟩ rw.base rf ws is).1) **
+            bytesRegion rw.base (execBlock ⟨rf.get p, robytes⟩ rw.base rf ws is).2) **
+            (bytesRegion (rf.get p) robytes ** rest)) **
+            bytesRegion reg.base reg.bytes) hp := by xperm_hyp hh
+        exact sepConj_mono_left (fun hq hx =>
+          ⟨(execBlock ⟨rf.get p, robytes⟩ rw.base rf ws is).1,
+            (execBlock ⟨rf.get p, robytes⟩ rw.base rf ws is).2,
+            (bytesRegion (rf.get p) robytes ** rest),
+            by rw [execBlock_ws_length]; exact hlen,
+            pcFree_sepConj (bytesRegion_pcFree _ _) hrestpc,
+            ⟨rf, ws, A, robytes, rest, hlen, hreach, ⟨h4, hpair⟩, hRoR, rfl, rfl, rfl⟩,
+            hx⟩) hp hh2
   | ghost lbl R =>
       have hvc := hvcs _ (List.mem_singleton_self _)
       have h : cpsTripleWithin 0 base base cr (asrtM reg rw reach)

--- a/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
@@ -165,6 +165,10 @@ theorem Stmt.soundR (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
       exact cpsTripleWithin_frameR (regOwn .x1) pcFree_regOwn
         (Stmt.sound reg rw (.blockAt lbl p winR is) base pfx reach hreg hrw rfl hofs hsz
           hcode hvcs)
+  | readAt lbl p roR is =>
+      exact cpsTripleWithin_frameR (regOwn .x1) pcFree_regOwn
+        (Stmt.sound reg rw (.readAt lbl p roR is) base pfx reach hreg hrw rfl hofs hsz
+          hcode hvcs)
   | seq a b iha ihb =>
       simp only [Stmt.offsetsOk, Bool.and_eq_true] at hofs
       simp only [Stmt.size] at hsz

--- a/EvmAsm/Rv64/SAsm/Vc.lean
+++ b/EvmAsm/Rv64/SAsm/Vc.lean
@@ -106,6 +106,13 @@ def sp (reg : Region) (rw : RwRegion) : Stmt → Reach → Reach
       ∧ rf' = (execBlock reg (rf.get p) rf win is).1
       ∧ A'' = (bytesRegion (rf.get p) (execBlock reg (rf.get p) rf win is).2
           ** rest)
+  | readAt _ p roR is, reach => fun rf' ws' A'' => ∃ rf ws A robytes rest,
+      ws.length = rw.len ∧ reach rf ws A
+      ∧ (∃ hp, (bytesRegion (rf.get p) robytes ** rest) hp)
+      ∧ roR rf ws A robytes rest
+      ∧ rf' = (execBlock ⟨rf.get p, robytes⟩ rw.base rf ws is).1
+      ∧ ws' = (execBlock ⟨rf.get p, robytes⟩ rw.base rf ws is).2
+      ∧ A'' = (bytesRegion (rf.get p) robytes ** rest)
   | «while» _ c fuel inv _, _ =>
       fun rf ws A => (∃ i, i ≤ fuel ∧ inv i rf ws A) ∧ ¬ c.holds rf
   | «whileS» _ c fuel inv _, reach =>
@@ -156,6 +163,19 @@ def vcs (reg : Region) (rw : RwRegion) : Stmt → String → Reach → List VC
             reach rf ws A → winR rf ws A win rest →
             (∃ hp, (bytesRegion (rf.get p) win ** rest) hp) →
             blockVCs reg (rf.get p) rf win is⟩]
+      else [])
+  | readAt lbl p roR is, pfx, reach =>
+      ⟨pfx ++ lbl ++ ".ok", blockOk is = true⟩ ::
+      ⟨pfx ++ lbl ++ ".focus", ∀ rf ws A, reach rf ws A → A.pcFree →
+          ∀ hp, A hp →
+          ∃ robytes rest, roR rf ws A robytes rest
+            ∧ (bytesRegion (rf.get p) robytes ** rest) hp
+            ∧ rest.pcFree ∧ Region.wf ⟨rf.get p, robytes⟩⟩ ::
+      (if hasLoad is then
+        [⟨pfx ++ lbl ++ ".mem", ∀ rf ws A robytes rest, ws.length = rw.len →
+            reach rf ws A → roR rf ws A robytes rest →
+            (∃ hp, (bytesRegion (rf.get p) robytes ** rest) hp) →
+            blockVCs ⟨rf.get p, robytes⟩ rw.base rf ws is⟩]
       else [])
   | «while» lbl c fuel inv b, pfx, reach =>
       ⟨pfx ++ lbl ++ ".inv_init", ∀ rf ws A, reach rf ws A → inv 0 rf ws A⟩ ::
@@ -238,6 +258,7 @@ def steps : Stmt → Nat
   | assert _ _ => 0
   | ghost _ _ => 0
   | blockAt _ _ _ is => is.length
+  | readAt _ _ _ is => is.length
   | «while» _ _ fuel _ b => WP.loopBound 1 (b.steps + 1) 1 fuel
   | «whileS» _ _ fuel _ b => WP.loopBound 1 (b.steps + 1) 1 fuel
   | «whileBreak» _ _ fuel _ _ bb _ ba =>
@@ -274,6 +295,9 @@ theorem sp_mono (reg : Region) (rw : RwRegion) (s : Stmt) {r₁ r₂ : Reach}
   | blockAt lbl p winR is =>
       rintro rf' ws' A'' ⟨rf, A, win, rest, hlen, hr, hsat, hR, hrf, hA⟩
       exact ⟨rf, A, win, rest, hlen, h rf ws' A hr, hsat, hR, hrf, hA⟩
+  | readAt lbl p roR is =>
+      rintro rf' ws' A'' ⟨rf, ws, A, robytes, rest, hlen, hr, hsat, hR, hrf, hws, hA⟩
+      exact ⟨rf, ws, A, robytes, rest, hlen, h rf ws A hr, hsat, hR, hrf, hws, hA⟩
   | «while» lbl c fuel inv b ihb =>
       exact fun rf ws A hr => hr
   | «whileS» lbl c fuel inv b ihb =>
@@ -377,6 +401,26 @@ theorem sp_blockAt_split (reg : Region) (rw : RwRegion) {lbl : String}
   rintro rf' ws' A'' ⟨rf, A, win, rest, hlen, hr, hsat, hwinR, rfl, rfl⟩
   exact h rf ws' A win rest hlen hr hsat hwinR
 
+/-- Eliminate a `.readAt`: prove `P` of the engine result over the focused
+    read-only region at every reachable entry state.  The primary writable
+    window is threaded (stores land there); the ambient assertion becomes
+    the region decomposition (the focused region is read-only, so unchanged). -/
+theorem sp_readAt_split (reg : Region) (rw : RwRegion) {lbl : String}
+    {p : Reg}
+    {roR : RegFile → List (BitVec 8) → Assertion →
+      List (BitVec 8) → Assertion → Prop}
+    {is : List Instr} {reach : Reach} {P : Reach}
+    (h : ∀ rf ws A robytes rest, ws.length = rw.len → reach rf ws A →
+      (∃ hp, (bytesRegion (rf.get p) robytes ** rest) hp) →
+      roR rf ws A robytes rest →
+      P (execBlock ⟨rf.get p, robytes⟩ rw.base rf ws is).1
+        (execBlock ⟨rf.get p, robytes⟩ rw.base rf ws is).2
+        (bytesRegion (rf.get p) robytes ** rest)) :
+    ∀ rf' ws' A'', sp reg rw (.readAt lbl p roR is) reach rf' ws' A'' →
+      P rf' ws' A'' := by
+  rintro rf' ws' A'' ⟨rf, ws, A, robytes, rest, hlen, hr, hsat, hroR, rfl, rfl, rfl⟩
+  exact h rf ws A robytes rest hlen hr hsat hroR
+
 /-- Eliminate a `.ghost`. -/
 theorem sp_ghost_split (reg : Region) (rw : RwRegion) {lbl : String}
     {R : RegFile → List (BitVec 8) → Assertion → Assertion → Prop}
@@ -420,6 +464,7 @@ theorem sp_of_endsWith (reg : Region) (rw : RwRegion) {P : Reach}
   | block lbl is => exact nomatch h
   | «when» lbl c b ih => exact nomatch h
   | blockAt lbl p winR is => exact nomatch h
+  | readAt lbl p roR is => exact nomatch h
   | ghost lbl R => exact nomatch h
   | «while» lbl c fuel inv b ih => exact nomatch h
   | «whileS» lbl c fuel inv b ih => exact nomatch h
@@ -507,6 +552,32 @@ theorem vcs_antitone (reg : Region) (rw : RwRegion) (s : Stmt) (pfx : String)
             hvcs.tail.tail.head rf ws A win rest hlen (h rf ws A hr) hR hsat
         · rw [if_neg hl] at hvc
           exact absurd hvc (List.not_mem_nil)
+  | readAt lbl p roR is =>
+      intro vc hvc
+      simp only [vcs, List.mem_cons] at hvc
+      rcases hvc with rfl | rfl | hvc
+      · exact hvcs.head
+      · exact fun rf ws A hr => hvcs.tail.head rf ws A (h rf ws A hr)
+      · by_cases hl : hasLoad is
+        · rw [if_pos hl] at hvc
+          rw [show vcs reg rw (.readAt lbl p roR is) pfx r₂
+              = ⟨pfx ++ lbl ++ ".ok", blockOk is = true⟩ ::
+                ⟨pfx ++ lbl ++ ".focus", ∀ rf ws A, r₂ rf ws A → A.pcFree →
+                    ∀ hp, A hp →
+                    ∃ robytes rest, roR rf ws A robytes rest
+                      ∧ (bytesRegion (rf.get p) robytes ** rest) hp
+                      ∧ rest.pcFree ∧ Region.wf ⟨rf.get p, robytes⟩⟩ ::
+                [⟨pfx ++ lbl ++ ".mem", ∀ rf ws A robytes rest, ws.length = rw.len →
+                    r₂ rf ws A → roR rf ws A robytes rest →
+                    (∃ hp, (bytesRegion (rf.get p) robytes ** rest) hp) →
+                    blockVCs ⟨rf.get p, robytes⟩ rw.base rf ws is⟩]
+            from by simp [vcs, hl]] at hvcs
+          simp only [List.mem_singleton] at hvc
+          subst hvc
+          exact fun rf ws A robytes rest hlen hr hR hsat =>
+            hvcs.tail.tail.head rf ws A robytes rest hlen (h rf ws A hr) hR hsat
+        · rw [if_neg hl] at hvc
+          exact absurd hvc (List.not_mem_nil)
   | «while» lbl c fuel inv b ihb =>
       intro vc hvc
       simp only [vcs, List.mem_cons] at hvc
@@ -591,6 +662,7 @@ def CalleesIn (s : Stmt) (reg : Region) (rw : RwRegion) (cr : CodeReq) : Prop :=
   | assert _ _ => True
   | ghost _ _ => True
   | blockAt _ _ _ _ => True
+  | readAt _ _ _ _ => True
   | «while» _ _ _ _ b => b.CalleesIn reg rw cr
   | «whileS» _ _ _ _ b => b.CalleesIn reg rw cr
   | «whileBreak» _ _ _ _ _ bb _ ba =>

--- a/PLAN.md
+++ b/PLAN.md
@@ -2731,7 +2731,29 @@ block/blockAt leaves flattens contiguously). Artifacts: focus_rwAtom
 pointer demo (copy ro→primary-rw dst + count dword at cnt via blockAt),
 post pins BOTH regions as functions of the input, kernel-clean
 (classical-3). Recipe: howto §6 "Multiple writable regions"; design
-§3.6.1 item 2 updated. Stage 5b LANDED: TreeInsert.lean — the slot-based predicate layer
+§3.6.1 item 2 updated. Multiple READ-ONLY regions landed
+(`SAsm/MultiRead.lean`, unblocks `bnfMulModP`/`secfMulModP` — the
+multi-external-input class): the read-side mirror of `blockAt`, a NEW
+`Stmt.readAt ptr roR is` focus node whose read-only SOURCE is a
+bytesRegion at the register-held `ptr`, opened out of the ambient `A`
+for the block while the primary `rw` stays fixed (blockAt swaps the
+writable window keeping `region`; readAt swaps `region` keeping `rw`).
+Because a read-only region's bytes are immutable, the ambient assertion
+is threaded UNCHANGED (simpler than blockAt's write-back); soundness is
+the exact mirror — `Stmt.sound`'s `readAt` case runs
+`execBlock_sound ⟨rf.get p, robytes⟩ rw …`, framing the primary
+`region` atom, so an in-focus load that misses `rw` reads the ambient
+region's bytes and nothing else (no path reads arbitrary heap as the
+region). VCs: .ok, .focus (decomposition eq + remainder pcFree + focused
+`Region.wf`), .mem (region-routed blockVCs). Additive to the sound core
+(all existing `execInstrRF`/`blockVCs`/`Stmt.sound`/`blockAt` consumers
+unchanged, corpus green = backward-compat); `Stmt.sound`, `Stmt.soundR`,
+`multiReadFn_spec` all classical-3. Demo `multiReadFn`/`multiReadFn_spec`:
+reads a dword from EACH of two independent ambient buffers `a0`, `a1`
+(NO `a0 ≠ a1` hypothesis — squaring `a0=a1` and product `a0≠a1` both
+work), sums them, writes through the writable window `dst`; the exact
+`be→le(a0); be→le(a1); arithMod; le→be(dst)` shape GLM + the crypto
+session clone for their `MulModP` proofs. Stage 5b LANDED: TreeInsert.lean — the slot-based predicate layer
 (slotCell/keyCell, mutual treeAtS/treeFrom, ctxS slot-zipper with
 ctxS_zip_fold + ctxS_push_left/right, the 3-dword bytesRegion split,
 setBytes_junk_node) plus treeInsertFn + treeInsertFn_spec: the full BST


### PR DESCRIPTION
## What & why

Multi-input routines (`bnfMulModP`, `secfMulModP`, future pairings, MPT multi-node reads) read from **two or more independent external buffers**, but the SAsm `Fn` model has ONE read-only `Region` and `CalleesIn` requires each callee's `region`/`rw` to structurally equal the caller's — so a converter reading from two arbitrary pointers `a0`, `a1` (squarings `a0=a1`, products `a0≠a1`, never guaranteed contiguous) can't be expressed.

The store side already solved the analogue: `Stmt.blockAt` routes **stores** through ambient `bytesRegion` atoms and is proven in `Stmt.sound`. This PR adds the **read-side mirror**.

## The mechanism — `Stmt.readAt` (Option A)

`readAt ptr roR is` opens a read-only `bytesRegion` at the register-held `ptr` out of the ambient assertion `A` for the block's duration, while the primary writable `rw` stays fixed:

- `blockAt` swaps the **writable window** for an ambient region, keeping `region` fixed → `execBlock_sound reg ⟨rf.get p, win⟩ …`
- `readAt` swaps the **read-only source** for an ambient region, keeping `rw` fixed → `execBlock_sound ⟨rf.get p, robytes⟩ rw …`

Because a read-only region's bytes are immutable, the ambient assertion threads through **unchanged** (simpler than `blockAt`'s write-back). A focused load that misses `rw` reads exactly the ambient region's bytes and nothing else — no path reads arbitrary heap as the region (`Stmt.sound`'s `readAt` case frames the primary `region` atom and reuses the identical machine-level block soundness).

Additive to the sound core: engine (`execInstrRF`), `blockVCs`, existing loads/stores, and the `blockAt` store case are **unchanged**. The whole corpus rebuilds green (= backward-compat proof).

## Files
- `Ast`: `readAt` constructor + `size`/`callFree`
- `Flatten`: `flatten`/`flatten_length`/`offsetsOk`/`callsOk`
- `Vc`: `sp`/`vcs`/`steps`/`sp_mono`/`sp_readAt_split`/`sp_of_endsWith`/`vcs_antitone`/`CalleesIn`
- `StmtSound`: the `readAt` soundness case (mirror of `blockAt`)
- `StmtSoundCall`: `soundR` delegation
- `MultiRead.lean`: the demo (acceptance test)

## Demo / acceptance test
`multiReadFn` / `multiReadFn_spec`: reads a dword from **each of two independent ambient buffers** `a0`, `a1` (**no `a0 ≠ a1` hypothesis** — squaring `a0=a1` and product `a0≠a1` both verify), sums them, and writes the result through the writable window `dst` — verified end-to-end via `Fn.Spec`. This is exactly the `bnfMulModP`/`secfMulModP` shape (two external read buffers + a write window); GLM + the crypto session clone this pattern for their `MulModP` proofs.

## Gates
- ✅ Full corpus `lake build` green (all existing consumers unchanged)
- ✅ `#print axioms` on `Stmt.sound`, `Stmt.soundR`, `multiReadFn_spec` → `[propext, Classical.choice, Quot.sound]`
- ✅ `check-forbidden-tactics.sh` OK; `check-axioms.sh` OK (65 witnesses, only classical)
- ✅ No `sorry`/`native_decide`/`bv_decide`/`maxHeartbeats`/`maxRecDepth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)