### PR TITLE
sasm: callAt — direct calls with a focused ambient region (multi-input callees)

### DIFF
--- a/EvmAsm/Rv64/SAsm.lean
+++ b/EvmAsm/Rv64/SAsm.lean
@@ -38,4 +38,5 @@ import EvmAsm.Rv64.SAsm.AccelStep
 import EvmAsm.Rv64.SAsm.PowLadderDemo
 import EvmAsm.Rv64.SAsm.MultiRw
 import EvmAsm.Rv64.SAsm.MultiRead
+import EvmAsm.Rv64.SAsm.CallAt
 import EvmAsm.Rv64.SAsm.WhileBreakDemo

--- a/EvmAsm/Rv64/SAsm/Ast.lean
+++ b/EvmAsm/Rv64/SAsm/Ast.lean
@@ -243,6 +243,22 @@ inductive Stmt where
       construct for state-transforming callees invoked repeatedly at one
       call site (the interpreter's opcode handlers). -/
   | callRegS (label : String) (rs : Reg) (handles : List FnHandleS)
+  /-- Direct call with a **focused read-only region** (the callee analogue of
+      `readAt`): `jal ra, f.entry` to a routine whose read-only `region` is
+      NOT the enclosing function's `reg` but a `bytesRegion` atom carved out
+      of the ambient assertion `A` for that one call.  The relation `roR`
+      pins the decomposition `A = bytesRegion f.region.base f.region.bytes **
+      rest`; the `.focus` VC forces the caller to own that atom, and the
+      callee is run against it as its `region` while the enclosing `reg` and
+      the remainder `rest` are framed.  The callee's writable window is the
+      enclosing `rw` (as for a plain `call`); its ambient is empty (leaf
+      callee).  Flattens to the same single `JAL` as `call` — byte-identical,
+      no injected instructions.  This is how a multi-input routine calls one
+      converter per external buffer (`bnfMulModP`: be→le a0; be→le a1;
+      le→be dst, with a0/a1 arbitrary independent pointers). -/
+  | callAt (label : String)
+           (roR : RegFile → List (BitVec 8) → Assertion → Assertion → Prop)
+           (f : FnHandle)
 
 namespace Stmt
 
@@ -268,6 +284,7 @@ def size : Stmt → Nat
   | call _ _          => 1
   | callReg _ _ _     => 1
   | callRegS _ _ _    => 1
+  | callAt _ _ _      => 1
 
 /-- All statement sizes are meaningful; `assert` is the only zero-size node. -/
 @[simp] theorem size_seq (a b : Stmt) : (seq a b).size = a.size + b.size := rfl
@@ -292,6 +309,7 @@ def callFree : Stmt → Bool
   | call _ _          => false
   | callReg _ _ _     => false
   | callRegS _ _ _    => false
+  | callAt _ _ _      => false
 
 end Stmt
 

--- a/EvmAsm/Rv64/SAsm/CallAt.lean
+++ b/EvmAsm/Rv64/SAsm/CallAt.lean
@@ -1,0 +1,415 @@
+/-
+  EvmAsm.Rv64.SAsm.CallAt
+
+  Demo of `Stmt.callAt`: the callee analogue of `readAt`.  A caller with a
+  single primary `region`/`rw` calls a leaf routine TWICE, each call reading
+  from a different independent external buffer held as an ambient
+  `bytesRegion` atom — the exact shape `CalleesIn` rejects for a plain `call`
+  (which requires every callee's `region` to equal the caller's single
+  `reg`) and the wall `bnfMulModP`/`secfMulModP` hit (they call
+  `bnf_be_to_le(a0)` then `bnf_be_to_le(a1)` with `a0`, `a1` arbitrary
+  independent pointers).
+
+  `callAt lbl roR f` focuses one ambient `bytesRegion` atom as the region the
+  wrapped callee `f` sees, for the duration of that one call; the enclosing
+  `reg` and the remainder of the ambient are framed and restored after.  It
+  flattens to the same single `JAL` as `call` (byte-transparent), so a real
+  routine wrapping its converter calls this way stays byte-identical.
+
+  The demo callee `adderFn` is a genuine leaf (reads its focused buffer and
+  the writable window, writes their sum back; no sub-calls, empty ambient).
+  `callAtFn` calls it on `a0` then `a1` (allowed to coincide — a squaring —
+  or differ), and its post pins the window to `packBytes bs0 + packBytes bs1`
+  — a function of BOTH inputs.  GLM wraps the three converter calls of
+  `bnfMulModP` the same way to finish it byte-identically.
+-/
+
+import EvmAsm.Rv64.SAsm.MultiDword
+import EvmAsm.Rv64.SAsm.Tactic
+import EvmAsm.Rv64.SAsm.Fn
+
+namespace EvmAsm.Rv64
+
+namespace SAsm
+
+namespace CallAt
+
+open Stmt
+
+/-- The leaf accumulator callee body: read the dword at `x10` (its read-only
+    region), read the current window dword at `x11`, write their sum back. -/
+def adderBody : List Instr :=
+  [.LD .x5 .x10 0, .LD .x6 .x11 0, .ADD .x7 .x5 .x6, .SD .x11 .x7 0]
+
+/-- The leaf accumulator callee.  Read-only region `⟨src, bs⟩`, writable
+    window `⟨dst, 8⟩` holding `acc`; result window holds `acc + packBytes bs`.
+    Preserves `x11` (the window pointer) and `x13` (`other` — the *other*
+    buffer's pointer, which must survive for the caller's second call).
+    Empty ambient (a leaf touches no recursive-predicate memory). -/
+def adderFn (src dst other : Word) (bs : List (BitVec 8)) (acc : Word) : Fn where
+  name := "adder"
+  region := ⟨src, bs⟩
+  rw := ⟨dst, 8⟩
+  pre := fun rf ws A =>
+    rf.get .x10 = src ∧ rf.get .x11 = dst ∧ rf.get .x13 = other ∧
+    ws = dwordBytes acc ∧ A = empAssertion
+  post := fun rf ws A =>
+    rf.get .x11 = dst ∧ rf.get .x13 = other ∧
+    ws = dwordBytes (acc + packBytes bs) ∧ A = empAssertion
+  body := .block "acc" adderBody
+
+section Adder
+
+variable (src dst other : Word) (bs : List (BitVec 8)) (acc : Word)
+
+/-- The accumulator body's engine run, fully resolved. -/
+private theorem adder_engine (rf : RegFile) (ws : List (BitVec 8))
+    (hx10 : rf.get .x10 = src) (hx11 : rf.get .x11 = dst)
+    (hws : ws = dwordBytes acc) (hbs : bs.length = 8) (hne : src ≠ dst) :
+    execBlock ⟨src, bs⟩ dst rf ws adderBody
+      = (((rf.set .x5 (packBytes bs)).set .x6 acc).set .x7 (packBytes bs + acc),
+          dwordBytes (packBytes bs + acc)) := by
+  have hs0 : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
+  have hwslen : ws.length = 8 := by rw [hws, length_dwordBytes]
+  -- LD x5 x10 0 : misses the window, reads the region dword `packBytes bs`
+  have hmiss : ¬ inRw dst ws (rf.get .x10 + signExtend12 (0 : BitVec 12)) 8 := by
+    unfold inRw
+    rw [hx10, hs0, hwslen]
+    intro hin
+    exact hne (by bv_omega)
+  rw [show adderBody = [.LD .x5 .x10 0, .LD .x6 .x11 0, .ADD .x7 .x5 .x6, .SD .x11 .x7 0]
+      from rfl, execBlock_cons, execInstrRF]
+  dsimp only [aluSem, loadSem]
+  rw [if_neg hmiss]
+  rw [show Region.dwordAt ⟨src, bs⟩ (rf.get .x10 + signExtend12 (0 : BitVec 12))
+        = packBytes bs from by
+      unfold Region.dwordAt
+      rw [hx10, hs0, show ((src + (0 : Word)) - src).toNat = 0 from by bv_omega,
+        List.drop_zero, List.take_of_length_le (show bs.length ≤ 8 from by omega)]]
+  -- LD x6 x11 0 : hits the window, reads `acc`
+  rw [execBlock_cons, execInstrRF]
+  dsimp only [aluSem, loadSem]
+  rw [RegFile.get_set_ne _ _ _ _ (by decide : Reg.x11 ≠ .x5)]
+  rw [if_pos (show inRw dst ws (rf.get .x11 + signExtend12 (0 : BitVec 12)) 8 from by
+    unfold inRw; rw [hx11, hs0, hwslen]; bv_omega)]
+  rw [show Region.dwordAt ⟨dst, ws⟩ (rf.get .x11 + signExtend12 (0 : BitVec 12)) = acc from by
+    unfold Region.dwordAt
+    rw [hx11, hs0, show ((dst + (0 : Word)) - dst).toNat = 0 from by bv_omega,
+      List.drop_zero, List.take_of_length_le (show ws.length ≤ 8 from by omega), hws,
+      packBytes_dwordBytes]]
+  -- ADD x7 x5 x6
+  rw [execBlock_cons, execInstrRF]
+  dsimp only [aluSem]
+  rw [RegFile.get_set_self _ _ _ (by decide),
+    RegFile.get_set_ne _ _ _ _ (by decide : Reg.x5 ≠ .x6),
+    RegFile.get_set_self _ _ _ (by decide)]
+  -- SD x11 x7 0
+  rw [execBlock_cons, execInstrRF_sd_dword _ _ _ _ _ _ _ 0 (by
+    rw [RegFile.get_set_ne _ _ _ _ (by decide : Reg.x11 ≠ .x7),
+      RegFile.get_set_ne _ _ _ _ (by decide : Reg.x11 ≠ .x6),
+      RegFile.get_set_ne _ _ _ _ (by decide : Reg.x11 ≠ .x5), hx11, hs0]
+    bv_omega)]
+  rw [RegFile.get_set_self _ _ _ (by decide), execBlock_nil,
+    setBytes_dword_full _ _ hwslen]
+
+/-- Address side conditions of the accumulator block. -/
+private theorem adder_blockVCs (rf : RegFile) (ws : List (BitVec 8))
+    (hx10 : rf.get .x10 = src) (hx11 : rf.get .x11 = dst)
+    (hws : ws = dwordBytes acc) (hbs : bs.length = 8) (hne : src ≠ dst) :
+    blockVCs ⟨src, bs⟩ dst rf ws adderBody := by
+  have hs0 : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
+  have hwslen : ws.length = 8 := by rw [hws, length_dwordBytes]
+  have hmiss : ¬ inRw dst ws (rf.get .x10 + signExtend12 (0 : BitVec 12)) 8 := by
+    unfold inRw; rw [hx10, hs0, hwslen]; intro hin; exact hne (by bv_omega)
+  -- per-instruction step results (so the threaded register file reduces)
+  have hstep0 : execInstrRF ⟨src, bs⟩ dst rf ws (.LD .x5 .x10 0)
+      = (rf.set .x5 (packBytes bs), ws) := by
+    unfold execInstrRF; dsimp only [aluSem, loadSem]; rw [if_neg hmiss]
+    unfold Region.dwordAt
+    rw [hx10, hs0, show ((src + (0 : Word)) - src).toNat = 0 from by bv_omega,
+      List.drop_zero, List.take_of_length_le (show bs.length ≤ 8 from by omega)]
+  have hx11a : (rf.set .x5 (packBytes bs)).get .x11 = dst := by
+    rw [RegFile.get_set_ne _ _ _ _ (by decide : Reg.x11 ≠ .x5)]; exact hx11
+  have hstep1 : execInstrRF ⟨src, bs⟩ dst (rf.set .x5 (packBytes bs)) ws (.LD .x6 .x11 0)
+      = ((rf.set .x5 (packBytes bs)).set .x6 acc, ws) := by
+    unfold execInstrRF; dsimp only [aluSem, loadSem]
+    rw [if_pos (show inRw dst ws
+        ((rf.set .x5 (packBytes bs)).get .x11 + signExtend12 (0 : BitVec 12)) 8 from by
+      unfold inRw; rw [hx11a, hs0, hwslen]; bv_omega)]
+    unfold Region.dwordAt
+    rw [hx11a, hs0, show ((dst + (0 : Word)) - dst).toNat = 0 from by bv_omega,
+      List.drop_zero, List.take_of_length_le (show ws.length ≤ 8 from by omega), hws,
+      packBytes_dwordBytes]
+  have hstep2 : execInstrRF ⟨src, bs⟩ dst ((rf.set .x5 (packBytes bs)).set .x6 acc) ws
+        (.ADD .x7 .x5 .x6)
+      = (((rf.set .x5 (packBytes bs)).set .x6 acc).set .x7 (packBytes bs + acc), ws) := by
+    unfold execInstrRF; dsimp only [aluSem]
+    rw [RegFile.get_set_self _ _ _ (by decide),
+      RegFile.get_set_ne _ _ _ _ (by decide : Reg.x5 ≠ .x6),
+      RegFile.get_set_self _ _ _ (by decide)]
+  have hx11b : (((rf.set .x5 (packBytes bs)).set .x6 acc).set .x7 (packBytes bs + acc)).get .x11
+      = dst := by
+    rw [RegFile.get_set_ne _ _ _ _ (by decide : Reg.x11 ≠ .x7),
+      RegFile.get_set_ne _ _ _ _ (by decide : Reg.x11 ≠ .x6),
+      RegFile.get_set_ne _ _ _ _ (by decide : Reg.x11 ≠ .x5)]; exact hx11
+  rw [show adderBody = [.LD .x5 .x10 0, .LD .x6 .x11 0, .ADD .x7 .x5 .x6, .SD .x11 .x7 0]
+      from rfl]
+  simp only [blockVCs, hstep0, hstep1, hstep2, loadSem, storeSem]
+  refine ⟨?_, ?_, trivial, ?_, trivial⟩
+  · -- LD x5 x10 0 misses the window → reads region
+    rw [if_neg hmiss, hx10, hs0]
+    refine ⟨?_, ?_⟩
+    · show 8 ∣ ((src + (0 : Word)) - src).toNat
+      rw [show ((src + (0 : Word)) - src).toNat = 0 from by bv_omega]; exact ⟨0, rfl⟩
+    · show ((src + (0 : Word)) - src).toNat + 8 ≤ bs.length
+      rw [show ((src + (0 : Word)) - src).toNat = 0 from by bv_omega]; omega
+  · -- LD x6 x11 0 hits the window
+    rw [if_pos (show inRw dst ws
+        ((rf.set .x5 (packBytes bs)).get .x11 + signExtend12 (0 : BitVec 12)) 8 from by
+      unfold inRw; rw [hx11a, hs0, hwslen]; bv_omega), hx11a, hs0]
+    refine ⟨?_, ?_⟩
+    · show 8 ∣ ((dst + (0 : Word)) - dst).toNat
+      rw [show ((dst + (0 : Word)) - dst).toNat = 0 from by bv_omega]; exact ⟨0, rfl⟩
+    · show ((dst + (0 : Word)) - dst).toNat + 8 ≤ ws.length
+      rw [show ((dst + (0 : Word)) - dst).toNat = 0 from by bv_omega]; omega
+  · -- SD x11 x7 0 hits the window, aligned
+    rw [hx11b, hs0]
+    refine ⟨?_, ?_⟩
+    · unfold inRw
+      rw [show ((dst + (0 : Word)) - dst).toNat = 0 from by bv_omega]; omega
+    · show 8 ∣ ((dst + (0 : Word)) - dst).toNat
+      rw [show ((dst + (0 : Word)) - dst).toNat = 0 from by bv_omega]; exact ⟨0, rfl⟩
+
+/-- **The leaf callee is verified.**  `src ≠ dst` resolves the region/window
+    routing; `hbs` fixes the region width. -/
+theorem adderFn_spec (base : Word)
+    (hro : Region.wf ⟨src, bs⟩) (hrw : RwRegion.wf ⟨dst, 8⟩)
+    (hbs : bs.length = 8) (hne : src ≠ dst) :
+    (adderFn src dst other bs acc).Spec base := by
+  vcgen
+  case region => exact ⟨hro, hrw⟩
+  case adder.acc.mem =>
+    rintro rf ws A hws ⟨hx10, hx11, hx13, hwsd, hA⟩
+    exact adder_blockVCs src dst bs acc rf ws hx10 hx11 hwsd hbs hne
+  case adder.post =>
+    rintro rf' ws' A'' ⟨rf, ws, hlen, ⟨hx10, hx11, hx13, hwsd, hA⟩, hrf', hws'⟩
+    dsimp only [adderFn] at hrf' hws' ⊢
+    rw [adder_engine src dst bs acc rf ws hx10 hx11 hwsd hbs hne] at hrf' hws'
+    subst hrf' hws' hA
+    refine ⟨?_, ?_, ?_, rfl⟩
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide : Reg.x11 ≠ .x7),
+        RegFile.get_set_ne _ _ _ _ (by decide : Reg.x11 ≠ .x6),
+        RegFile.get_set_ne _ _ _ _ (by decide : Reg.x11 ≠ .x5)]
+      exact hx11
+    · rw [RegFile.get_set_ne _ _ _ _ (by decide : Reg.x13 ≠ .x7),
+        RegFile.get_set_ne _ _ _ _ (by decide : Reg.x13 ≠ .x6),
+        RegFile.get_set_ne _ _ _ _ (by decide : Reg.x13 ≠ .x5)]
+      exact hx13
+    · show dwordBytes (packBytes bs + acc) = dwordBytes (acc + packBytes bs)
+      rw [show (packBytes bs + acc : Word) = acc + packBytes bs from by bv_omega]
+
+end Adder
+
+-- ============================================================================
+-- The caller: two `callAt` calls to different focused regions
+-- ============================================================================
+
+section Caller
+
+/-- The adder body occupies 4 slots; `+ epilogue` fits the address space. -/
+private theorem adder_sz (src dst other : Word) (bs : List (BitVec 8)) (acc : Word) :
+    4 * ((adderFn src dst other bs acc).body.size + 1) ≤ 2 ^ 64 := by
+  show 4 * (4 + 1) ≤ 2 ^ 64; decide
+
+/-- Callee handle for the first buffer (`a0`), at `0x3000`. -/
+def adderHandle0 (a0 a1 dst : Word) (bs0 : List (BitVec 8))
+    (hro0 : Region.wf ⟨a0, bs0⟩) (hrw : RwRegion.wf ⟨dst, 8⟩)
+    (hbs0 : bs0.length = 8) (hne0 : a0 ≠ dst) : FnHandle :=
+  (adderFn a0 dst a1 bs0 0).toHandle 0x3000
+    (adderFn_spec a0 dst a1 bs0 0 0x3000 hro0 hrw hbs0 hne0) (adder_sz ..)
+
+/-- Callee handle for the second buffer (`a1`), at `0x3200`; its accumulator
+    seed is the first buffer's dword, so the result depends on BOTH inputs. -/
+def adderHandle1 (a1 dst : Word) (bs0 bs1 : List (BitVec 8))
+    (hro1 : Region.wf ⟨a1, bs1⟩) (hrw : RwRegion.wf ⟨dst, 8⟩)
+    (hbs1 : bs1.length = 8) (hne1 : a1 ≠ dst) : FnHandle :=
+  (adderFn a1 dst a1 bs1 (packBytes bs0)).toHandle 0x3200
+    (adderFn_spec a1 dst a1 bs1 (packBytes bs0) 0x3200 hro1 hrw hbs1 hne1) (adder_sz ..)
+
+/-- **The two-focused-call demo function.**  `a0`, `a1` are two independent
+    read-only buffers held as ambient `bytesRegion` atoms (allowed to
+    coincide); `dst` is the primary writable window.  It calls the adder on
+    `a0` (focusing `a0`), moves `a1`'s pointer into the argument register,
+    then calls the adder on `a1` (focusing `a1`).  The post pins the window
+    to `packBytes bs0 + packBytes bs1` — a function of BOTH inputs. -/
+def callAtFn (a0 a1 dst : Word) (bs0 bs1 : List (BitVec 8))
+    (hro0 : Region.wf ⟨a0, bs0⟩) (hro1 : Region.wf ⟨a1, bs1⟩)
+    (hrw : RwRegion.wf ⟨dst, 8⟩) (hbs0 : bs0.length = 8) (hbs1 : bs1.length = 8)
+    (hne0 : a0 ≠ dst) (hne1 : a1 ≠ dst) : Fn where
+  name := "callAt"
+  region := Region.empty
+  rw := ⟨dst, 8⟩
+  pre := fun rf ws A =>
+    rf.get .x10 = a0 ∧ rf.get .x11 = dst ∧ rf.get .x13 = a1 ∧
+    ws = dwordBytes 0 ∧ A = (bytesRegion a0 bs0 ** bytesRegion a1 bs1)
+  post := fun rf ws A =>
+    rf.get .x11 = dst ∧
+    ws = dwordBytes (packBytes bs0 + packBytes bs1) ∧
+    A = (bytesRegion a0 bs0 ** bytesRegion a1 bs1)
+  body :=
+    .callAt "cA0" (fun _ _ _ rest => rest = bytesRegion a1 bs1)
+        (adderHandle0 a0 a1 dst bs0 hro0 hrw hbs0 hne0) ;;;
+    .block "mv" [.MV .x10 .x13] ;;;
+    .callAt "cA1" (fun _ _ _ rest => rest = bytesRegion a0 bs0)
+        (adderHandle1 a1 dst bs0 bs1 hro1 hrw hbs1 hne1)
+
+/-- Byte-transparency: each `callAt` flattens to exactly one `JAL` — no
+    injected instructions, so a real routine wrapping converter calls this
+    way stays byte-identical. -/
+theorem callAt_byte_transparent (lbl : String)
+    (roR : RegFile → List (BitVec 8) → Assertion → Assertion → Prop)
+    (f : FnHandle) (addr : Word) :
+    (Stmt.callAt lbl roR f).flatten addr
+      = [.JAL .x1 (BitVec.setWidth 21 (f.entry - addr))] := rfl
+
+/-- The caller's code requirement: its own flattened body plus both callee
+    handles' code — one `union`, no manual disjointness. -/
+def callAtCr (a0 a1 dst : Word) (bs0 bs1 : List (BitVec 8))
+    (hro0 : Region.wf ⟨a0, bs0⟩) (hro1 : Region.wf ⟨a1, bs1⟩)
+    (hrw : RwRegion.wf ⟨dst, 8⟩) (hbs0 : bs0.length = 8) (hbs1 : bs1.length = 8)
+    (hne0 : a0 ≠ dst) (hne1 : a1 ≠ dst) : CodeReq :=
+  ((CodeReq.ofProg 0x1000
+      ((callAtFn a0 a1 dst bs0 bs1 hro0 hro1 hrw hbs0 hbs1 hne0 hne1).body.flatten 0x1000)).union
+    (adderHandle0 a0 a1 dst bs0 hro0 hrw hbs0 hne0).code).union
+    (adderHandle1 a1 dst bs0 bs1 hro1 hrw hbs1 hne1).code
+
+/-- **The two-focused-call demo is verified.**  Two `callAt` calls to
+    *different* focused regions `a0`, `a1` (the shape a plain `call` rejects),
+    with a post depending on BOTH — the `bnfMulModP`/`secfMulModP` template. -/
+theorem callAtFn_spec (a0 a1 dst : Word) (bs0 bs1 : List (BitVec 8))
+    (hro0 : Region.wf ⟨a0, bs0⟩) (hro1 : Region.wf ⟨a1, bs1⟩)
+    (hrw : RwRegion.wf ⟨dst, 8⟩) (hbs0 : bs0.length = 8) (hbs1 : bs1.length = 8)
+    (hne0 : a0 ≠ dst) (hne1 : a1 ≠ dst) :
+    (callAtFn a0 a1 dst bs0 bs1 hro0 hro1 hrw hbs0 hbs1 hne0 hne1).SpecR 0x1000
+      (callAtCr a0 a1 dst bs0 bs1 hro0 hro1 hrw hbs0 hbs1 hne0 hne1) := by
+  -- handle entries / regions / pre / post, exposed by unfolding
+  have hH0e : (adderHandle0 a0 a1 dst bs0 hro0 hrw hbs0 hne0).entry = 0x3000 := rfl
+  have hH1e : (adderHandle1 a1 dst bs0 bs1 hro1 hrw hbs1 hne1).entry = 0x3200 := rfl
+  -- code containment of the two callees into `cr`
+  have hcode0 : ∀ a i, (adderHandle0 a0 a1 dst bs0 hro0 hrw hbs0 hne0).code a = some i →
+      callAtCr a0 a1 dst bs0 bs1 hro0 hro1 hrw hbs0 hbs1 hne0 hne1 a = some i := by
+    intro a i h
+    obtain ⟨kk, hk, rfl⟩ := ofProg_some_range h
+    have hk5 : kk < 5 := hk
+    have hP : CodeReq.ofProg 0x1000
+        ((callAtFn a0 a1 dst bs0 bs1 hro0 hro1 hrw hbs0 hbs1 hne0 hne1).body.flatten 0x1000)
+        ((0x3000 : Word) + BitVec.ofNat 64 (4 * kk)) = none := by
+      apply CodeReq.ofProg_none_range
+      intro k' hk' heq
+      have : k' < 3 := hk'
+      bv_omega
+    simp only [callAtCr, CodeReq.union, hP, h]
+  have hcode1 : ∀ a i, (adderHandle1 a1 dst bs0 bs1 hro1 hrw hbs1 hne1).code a = some i →
+      callAtCr a0 a1 dst bs0 bs1 hro0 hro1 hrw hbs0 hbs1 hne0 hne1 a = some i := by
+    intro a i h
+    obtain ⟨kk, hk, rfl⟩ := ofProg_some_range h
+    have hk5 : kk < 5 := hk
+    have hP : CodeReq.ofProg 0x1000
+        ((callAtFn a0 a1 dst bs0 bs1 hro0 hro1 hrw hbs0 hbs1 hne0 hne1).body.flatten 0x1000)
+        ((0x3200 : Word) + BitVec.ofNat 64 (4 * kk)) = none := by
+      apply CodeReq.ofProg_none_range
+      intro k' hk' heq
+      have : k' < 3 := hk'
+      bv_omega
+    have hA0 : (adderHandle0 a0 a1 dst bs0 hro0 hrw hbs0 hne0).code
+        ((0x3200 : Word) + BitVec.ofNat 64 (4 * kk)) = none := by
+      show CodeReq.ofProg 0x3000 (_) ((0x3200 : Word) + BitVec.ofNat 64 (4 * kk)) = none
+      apply CodeReq.ofProg_none_range
+      intro k' hk' heq
+      have : k' < 5 := hk'
+      bv_omega
+    simp only [callAtCr, CodeReq.union, hP, hA0, h]
+  show Fn.SpecR _ _ _
+  vcgen
+  case region => exact ⟨Region.empty_wf, hrw⟩
+  case code =>
+    intro a i h
+    simp only [callAtCr, CodeReq.union, h]
+  case callees =>
+    refine ⟨⟨hcode0, rfl⟩, trivial, hcode1, rfl⟩
+  case calls =>
+    refine ⟨⟨?_, ?_, ?_⟩, trivial, ?_, ?_, ?_⟩
+    · rw [hH0e]; decide
+    · decide
+    · apply CodeReq.ofProg_none_range
+      intro k' hk' heq
+      have : k' < 5 := hk'
+      bv_omega
+    · simp only [Stmt.size, List.length_cons, List.length_nil]; rw [hH1e]; decide
+    · simp only [Stmt.size, List.length_cons, List.length_nil]; decide
+    · simp only [Stmt.size, List.length_cons, List.length_nil]
+      apply CodeReq.ofProg_none_range
+      intro k' hk' heq
+      have : k' < 5 := hk'
+      bv_omega
+  case callAt.cA0.focus =>
+    rintro rf ws A ⟨hx10, hx11, hx13, hwsd, hA⟩ hApc hp hhp
+    refine ⟨bytesRegion a1 bs1, rfl, ?_, bytesRegion_pcFree _ _⟩
+    show (bytesRegion a0 bs0 ** bytesRegion a1 bs1) hp
+    rw [hA] at hhp; exact hhp
+  case callAt.cA0.pre =>
+    rintro rf ws A rest hws ⟨hx10, hx11, hx13, hwsd, hA⟩ hrest
+    exact ⟨hx10, hx11, hx13, hwsd, rfl⟩
+  case callAt.cA0.post_emp =>
+    rintro rf ws A ⟨hx11, hx13, hwsd, hA⟩
+    exact hA
+  case callAt.cA1.focus =>
+    rintro rf ws A hreach hApc hp hhp
+    -- reach = sp mv (sp cA0 pre); recover A = a0-region ** a1-region
+    obtain ⟨rf1, ws1, hlen1, hcA0, hrfmv, hwsmv⟩ := hreach
+    obtain ⟨rf0, ws0, A0, rest0, hlen0, ⟨hx10, hx11, hx13, hwsd, hA0⟩,
+      -, hrest0, hpost0, hAeq⟩ := hcA0
+    subst hrest0
+    refine ⟨bytesRegion a0 bs0, rfl, ?_, bytesRegion_pcFree _ _⟩
+    show (bytesRegion a1 bs1 ** bytesRegion a0 bs0) hp
+    have hAeq' : A = (bytesRegion a0 bs0 ** bytesRegion a1 bs1) := by
+      rw [hAeq]; rfl
+    rw [hAeq'] at hhp
+    xperm_hyp hhp
+  case callAt.cA1.pre =>
+    rintro rf ws A rest hws hreach hrest
+    obtain ⟨rf1, ws1, hlen1, hcA0, hrfmv, hwsmv⟩ := hreach
+    obtain ⟨rf0, ws0, A0, rest0, hlen0, ⟨hx10, hx11, hx13, hwsd, hA0⟩,
+      -, hrest0, hpost0, hAeq⟩ := hcA0
+    obtain ⟨hx11', hx13', hws1', hemp⟩ := hpost0
+    -- after cA0: rf1.get x11 = dst, x13 = a1, ws1 = dwordBytes (packBytes bs0);
+    -- mv sets x10 := rf1.get x13 = a1, ws unchanged
+    have hmv : rf = rf1.set .x10 (rf1.get .x13) := by rw [hrfmv]; rfl
+    refine ⟨?_, ?_, ?_, ?_, rfl⟩
+    · rw [hmv, RegFile.get_set_self _ _ _ (by decide)]; exact hx13'
+    · rw [hmv, RegFile.get_set_ne _ _ _ _ (by decide : Reg.x11 ≠ .x10)]; exact hx11'
+    · rw [hmv, RegFile.get_set_ne _ _ _ _ (by decide : Reg.x13 ≠ .x10)]; exact hx13'
+    · rw [hwsmv]
+      show ws1 = dwordBytes (packBytes bs0)
+      rw [hws1']; congr 1; bv_omega
+  case callAt.cA1.post_emp =>
+    rintro rf ws A ⟨hx11, hx13, hwsd, hA⟩
+    exact hA
+  case callAt.post =>
+    rintro rf' ws' A''
+      ⟨rf1, ws1, A1, rest1, hlen1, hmvReach, -, hrest1, hpost1, hAeq1⟩
+    obtain ⟨hx11p, hx13p, hws1eq, -⟩ := hpost1
+    subst hrest1
+    refine ⟨hx11p, ?_, ?_⟩
+    · exact hws1eq
+    · show A'' = (bytesRegion a0 bs0 ** bytesRegion a1 bs1)
+      rw [hAeq1]
+      show (bytesRegion a1 bs1 ** bytesRegion a0 bs0) = _
+      xperm
+
+end Caller
+
+end CallAt
+
+end SAsm
+end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/Flatten.lean
+++ b/EvmAsm/Rv64/SAsm/Flatten.lean
@@ -87,6 +87,8 @@ def flatten (addr : Word) : Stmt → List Instr
       [.JALR .x1 rs 0]
   | callRegS _ rs _ =>
       [.JALR .x1 rs 0]
+  | callAt _ _ f =>
+      [.JAL .x1 (BitVec.setWidth 21 (f.entry - addr))]
 
 /-- The flattened code of a statement occupies exactly `size` slots. -/
 theorem flatten_length (s : Stmt) (addr : Word) :
@@ -116,6 +118,7 @@ theorem flatten_length (s : Stmt) (addr : Word) :
   | call _ callee => rfl
   | callReg _ _ _ => rfl
   | callRegS _ _ _ => rfl
+  | callAt _ _ f => rfl
 
 /-- Decidable well-formedness: every synthesized offset fits its immediate
     field, and every branch condition reads only exposed registers (or x0).
@@ -157,6 +160,7 @@ def offsetsOk : Stmt → Bool
   | call _ _ => true
   | callReg _ rs _ => Reg.isExposed rs
   | callRegS _ rs _ => Reg.isExposed rs
+  | callAt _ _ _ => true
 
 /-- Address-aware side conditions of the call sites of a statement placed at
     `addr`: each `jal` offset round-trips through its 21-bit immediate, the
@@ -193,6 +197,10 @@ def callsOk : Stmt → Word → Prop
   | callRegS _ _ handles, addr =>
       ((addr + 4) &&& ~~~(1 : Word)) = addr + 4
       ∧ ∀ h ∈ handles, (h.entry &&& ~~~(1 : Word)) = h.entry
+  | callAt _ _ f, addr =>
+      addr + signExtend21 (BitVec.setWidth 21 (f.entry - addr)) = f.entry
+      ∧ ((addr + 4) &&& ~~~(1 : Word)) = addr + 4
+      ∧ f.code addr = none
 
 end Stmt
 end SAsm

--- a/EvmAsm/Rv64/SAsm/StmtSound.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSound.lean
@@ -1249,6 +1249,8 @@ theorem Stmt.sound (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
       exact absurd hleaf (by simp [Stmt.callFree])
   | callReg lbl rs handles =>
       exact absurd hleaf (by simp [Stmt.callFree])
+  | callAt lbl roR f =>
+      exact absurd hleaf (by simp [Stmt.callFree])
   | callRegS lbl rs handles =>
       exact absurd hleaf (by simp [Stmt.callFree])
 

--- a/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
+++ b/EvmAsm/Rv64/SAsm/StmtSoundCall.lean
@@ -136,6 +136,25 @@ theorem FnHandleS.nSteps_le_foldr_max {h : FnHandleS} :
       · exact Nat.le_trans (FnHandleS.nSteps_le_foldr_max hmem')
           (Nat.le_max_right _ _)
 
+/-- Eliminate an existentially-quantified precondition. -/
+theorem cpsTripleWithin_exists_pre_gen {n : Nat} {entry exit_ : Word}
+    {cr : CodeReq} {Q : Assertion} {α : Sort u} {P : α → Assertion}
+    (h : ∀ x, cpsTripleWithin n entry exit_ cr (P x) Q) :
+    cpsTripleWithin n entry exit_ cr (fun hp => ∃ x, P x hp) Q := by
+  intro R hR s hcr hPR hpc
+  obtain ⟨h0, hcompat, h1, h2, hd, hu, ⟨x, hPx⟩, hR2⟩ := hPR
+  exact h x R hR s hcr ⟨h0, hcompat, h1, h2, hd, hu, hPx, hR2⟩ hpc
+
+/-- Discharge a pure-proposition conjunct in the precondition. -/
+theorem cpsTripleWithin_pure_pre {n : Nat} {entry exit_ : Word}
+    {cr : CodeReq} {P : Prop} {H Q : Assertion}
+    (h : P → cpsTripleWithin n entry exit_ cr H Q) :
+    cpsTripleWithin n entry exit_ cr (⌜P⌝ ** H) Q := by
+  intro R hR s hcr hPR hpc
+  obtain ⟨h0, hcompat, hh⟩ := hPR
+  rw [sepConj_assoc', sepConj_pure_left] at hh
+  exact h hh.1 R hR s hcr ⟨h0, hcompat, hh.2⟩ hpc
+
 /-- Caller-shaped soundness (Milestone M4): the flattened code of `s`
     satisfies a bounded CPS triple at `asrtR` granularity, provided the
     ambient `cr` also contains every callee's code (`hcallees`) and the call
@@ -1146,6 +1165,146 @@ theorem Stmt.soundR (reg : Region) (rw : RwRegion) (s : Stmt) (base : Word)
       have h4 : base + BitVec.ofNat 64 4 = base + 4 := rfl
       rw [h4]
       exact hfinal
+  | callAt lbl roR f =>
+      obtain ⟨hoffset, halign, hnotself⟩ := hcalls
+      obtain ⟨hcalleeCode, hrweq⟩ := hcallees
+      have hfocus : ∀ rf ws A, reach rf ws A → A.pcFree → ∀ hp, A hp →
+          ∃ rest, roR rf ws A rest
+            ∧ (bytesRegion f.region.base f.region.bytes ** rest) hp
+            ∧ rest.pcFree := hvcs.head
+      have hpreVC : ∀ rf ws A rest, ws.length = rw.len → reach rf ws A →
+          roR rf ws A rest → f.pre rf ws empAssertion := hvcs.tail.head
+      have hpostEmp : ∀ rf ws A, f.post rf ws A → A = empAssertion :=
+        hvcs.tail.tail.head
+      -- callee triple retargeted at the aligned return address (region NOT rewritten)
+      have hret' : cpsTripleWithin f.nSteps f.entry ((base + 4) &&& ~~~(1 : Word)) f.code
+          ((.x1 ↦ᵣ (base + 4)) ** asrtM f.region rw f.pre)
+          ((.x1 ↦ᵣ (base + 4)) ** asrtM f.region rw f.post) := by
+        rw [halign, ← hrweq]; exact f.sound (base + 4) halign
+      have hdisj : (CodeReq.singleton base
+          (.JAL .x1 (BitVec.setWidth 21 (f.entry - base)))).Disjoint f.code := by
+        intro a
+        by_cases ha : a = base
+        · subst ha; exact Or.inr hnotself
+        · left; simp [CodeReq.singleton, ha]
+      have hmono : ∀ a i,
+          ((CodeReq.singleton base
+            (.JAL .x1 (BitVec.setWidth 21 (f.entry - base)))).union f.code) a = some i →
+          cr a = some i := by
+        intro a i hh
+        simp only [CodeReq.union] at hh
+        cases hs : CodeReq.singleton base
+            (.JAL .x1 (BitVec.setWidth 21 (f.entry - base))) a with
+        | none => rw [hs] at hh; exact hcalleeCode a i hh
+        | some j =>
+            rw [hs] at hh
+            apply hcode a i
+            rw [show Stmt.flatten base (.callAt lbl roR f)
+              = [.JAL .x1 (BitVec.setWidth 21 (f.entry - base))] from rfl,
+              CodeReq.ofProg_singleton]
+            rw [hs]; exact hh
+      -- the fixed call triple (callee run against its own focused region)
+      have hcall : ∀ vOld : Word, cpsTripleWithin (1 + f.nSteps) base (base + 4) cr
+          (((.x1 : Reg) ↦ᵣ vOld) ** asrtM f.region rw f.pre)
+          (((.x1 : Reg) ↦ᵣ (base + 4)) ** asrtM f.region rw f.post) := fun vOld =>
+        cpsTripleWithin_extend_code hmono
+          (WP.cpsCallWithin (vOld := vOld) (BitVec.setWidth 21 (f.entry - base))
+            hoffset halign (pcFree_asrtM f.region rw f.pre) hdisj hret')
+      simp only [Stmt.steps, Stmt.size, Nat.mul_one]
+      rw [show base + BitVec.ofNat 64 4 = base + 4 from rfl]
+      apply cpsTripleWithin_regOwn_right_pre
+      intro vOld
+      -- The flat middle assertions: the callee's owned resources (regfile, the
+      -- primary rw window, and the FOCUSED region) plus the framed enclosing
+      -- read-only region and the remainder `rest`, guarded by the pure facts
+      -- that ride from pre to post so the exit `sp` can be reconstructed.
+      refine cpsTripleWithin_weaken (P := fun hp => ∃ rf ws A rest,
+          (⌜ws.length = rw.len ∧ reach rf ws A ∧ roR rf ws A rest ∧ rest.pcFree⌝ **
+            ((((.x1 : Reg) ↦ᵣ vOld) **
+                ((regFileIs rf ** bytesRegion rw.base ws) **
+                  bytesRegion f.region.base f.region.bytes)) **
+              (bytesRegion reg.base reg.bytes ** rest))) hp)
+        (Q := fun hp => ∃ rf ws A rest rf'' ws'',
+          (⌜reach rf ws A ∧ roR rf ws A rest ∧ f.post rf'' ws'' empAssertion
+              ∧ ws.length = rw.len ∧ ws''.length = rw.len ∧ rest.pcFree⌝ **
+            ((((.x1 : Reg) ↦ᵣ (base + 4)) **
+                ((regFileIs rf'' ** bytesRegion rw.base ws'') **
+                  bytesRegion f.region.base f.region.bytes)) **
+              (bytesRegion reg.base reg.bytes ** rest))) hp)
+        ?_ ?_ ?_
+      · -- PRE entailment: asrtM reg rw reach ** (.x1↦vOld)  ⊢  Pmid.
+        --   Decompose the region assertion, focus the ambient onto the
+        --   callee's region atom + remainder, then permute into flat form.
+        intro hp hh
+        obtain ⟨hL, hx1, hdx, hux, hLv, hx1v⟩ := hh
+        obtain ⟨hAo, hRg, hdo, huo, hAov, hRgv⟩ := hLv
+        obtain ⟨rf, ws, A, hlen, hApc, hreach, hcore⟩ := hAov
+        obtain ⟨hRW, hAh, hdc, huc, hRWv, hAv⟩ := hcore
+        obtain ⟨rest, hroR, hpairA, hrestpc⟩ := hfocus rf ws A hreach hApc hAh hAv
+        refine ⟨rf, ws, A, rest, ?_⟩
+        rw [sepConj_pure_left]
+        refine ⟨⟨hlen, hreach, hroR, hrestpc⟩, ?_⟩
+        have hh' : ((((regFileIs rf ** bytesRegion rw.base ws) **
+            (bytesRegion f.region.base f.region.bytes ** rest)) **
+            bytesRegion reg.base reg.bytes) ** ((.x1 : Reg) ↦ᵣ vOld)) hp :=
+          ⟨hL, hx1, hdx, hux,
+            ⟨hAo, hRg, hdo, huo, ⟨hRW, hAh, hdc, huc, hRWv, hpairA⟩, hRgv⟩, hx1v⟩
+        xperm_hyp hh'
+      · -- POST entailment: Qmid  ⊢  asrtR reg rw (sp callAt reach).
+        intro hp hh
+        obtain ⟨rf, ws, A, rest, rf'', ws'', hh2⟩ := hh
+        rw [sepConj_pure_left] at hh2
+        obtain ⟨⟨hreach, hroR, hpost, hlen, hlen'', hrestpc⟩, hheap⟩ := hh2
+        have hheap' : ((((regFileIs rf'' ** bytesRegion rw.base ws'') **
+            (bytesRegion f.region.base f.region.bytes ** rest)) **
+            bytesRegion reg.base reg.bytes) ** ((.x1 : Reg) ↦ᵣ (base + 4))) hp := by
+          xperm_hyp hheap
+        obtain ⟨hY, hx1, hd0, hu0, hYv, hx1v⟩ := hheap'
+        obtain ⟨hAoC, hRgh, hd1, hu1, hAoCv, hRgv⟩ := hYv
+        obtain ⟨hRW, hFRrest, hd2, hu2, hRWv, hFRrestv⟩ := hAoCv
+        refine ⟨hY, hx1, hd0, hu0, ⟨hAoC, hRgh, hd1, hu1, ?_, hRgv⟩, ⟨base + 4, hx1v⟩⟩
+        refine ⟨rf'', ws'',
+          bytesRegion f.region.base f.region.bytes ** rest, hlen'',
+          pcFree_sepConj (bytesRegion_pcFree _ _) hrestpc, ?_,
+          ⟨hRW, hFRrest, hd2, hu2, hRWv, hFRrestv⟩⟩
+        exact ⟨rf, ws, A, rest, hlen, hreach, ⟨hFRrest, hFRrestv⟩, hroR, hpost, rfl⟩
+      · -- MIDDLE triple: the framed call, bridged flat ↔ asrtM at the callee.
+        apply cpsTripleWithin_exists_pre_gen; intro rf
+        apply cpsTripleWithin_exists_pre_gen; intro ws
+        apply cpsTripleWithin_exists_pre_gen; intro A
+        apply cpsTripleWithin_exists_pre_gen; intro rest
+        apply cpsTripleWithin_pure_pre; rintro ⟨hlen, hreach, hroR, hrestpc⟩
+        have hpre := hpreVC rf ws A rest hlen hreach hroR
+        refine cpsTripleWithin_weaken ?_ ?_
+          (cpsTripleWithin_frameR (bytesRegion reg.base reg.bytes ** rest)
+            (pcFree_sepConj (bytesRegion_pcFree _ _) hrestpc) (hcall vOld))
+        · -- pre bridge: flat callee resources ⊢ asrtM f.region rw f.pre (emp ambient)
+          intro hp hh
+          obtain ⟨hLeft, hFrame, hd, hu, hLv, hFv⟩ := hh
+          obtain ⟨hx1, hX, hd2, hu2, hx1v, hXv⟩ := hLv
+          obtain ⟨hRW, hFR, hd3, hu3, hRWv, hFRv⟩ := hXv
+          exact ⟨hLeft, hFrame, hd, hu,
+            ⟨hx1, hX, hd2, hu2, hx1v,
+              ⟨hRW, hFR, hd3, hu3,
+                ⟨rf, ws, empAssertion, hlen, pcFree_emp, hpre,
+                  by rw [sepConj_emp_right']; exact hRWv⟩,
+                hFRv⟩⟩,
+            hFv⟩
+        · -- post bridge: asrtM f.region rw f.post (emp ambient) ⊢ Qmid
+          intro hp hh
+          obtain ⟨hLeft, hFrame, hd, hu, hLv, hFv⟩ := hh
+          obtain ⟨hx1, hM, hd2, hu2, hx1v, hMv⟩ := hLv
+          obtain ⟨hAo, hFR, hd3, hu3, hAov, hFRv⟩ := hMv
+          obtain ⟨rf'', ws'', A_c'', hlen'', hApc'', hpost'', hcore''⟩ := hAov
+          have hAce : A_c'' = empAssertion := hpostEmp rf'' ws'' A_c'' hpost''
+          subst hAce
+          rw [sepConj_emp_right'] at hcore''
+          exact ⟨rf, ws, A, rest, rf'', ws'', by
+            rw [sepConj_pure_left]
+            exact ⟨⟨hreach, hroR, hpost'', hlen, hlen'', hrestpc⟩,
+              ⟨hLeft, hFrame, hd, hu,
+                ⟨hx1, hM, hd2, hu2, hx1v, ⟨hAo, hFR, hd3, hu3, hcore'', hFRv⟩⟩,
+                hFv⟩⟩⟩
   | callReg lbl rs handles =>
       obtain ⟨halignRet, hentries⟩ := hcalls
       have hrs : Reg.isExposed rs = true := hofs

--- a/EvmAsm/Rv64/SAsm/Vc.lean
+++ b/EvmAsm/Rv64/SAsm/Vc.lean
@@ -129,6 +129,12 @@ def sp (reg : Region) (rw : RwRegion) : Stmt → Reach → Reach
   | callRegS _ rs handles, reach => fun rf ws A => ∃ rf₀ ws₀ A₀,
       reach rf₀ ws₀ A₀ ∧ ∃ h ∈ handles, rf₀.get rs = h.entry
         ∧ h.pre rf₀ ws₀ A₀ ∧ h.post rf₀ ws₀ A₀ rf ws A
+  | callAt _ roR f, reach => fun rf' ws' A'' => ∃ rf ws A rest,
+      ws.length = rw.len ∧ reach rf ws A
+      ∧ (∃ hp, (bytesRegion f.region.base f.region.bytes ** rest) hp)
+      ∧ roR rf ws A rest
+      ∧ f.post rf' ws' empAssertion
+      ∧ A'' = (bytesRegion f.region.base f.region.bytes ** rest)
 
 /-- Labeled verification conditions of a statement, given the reachable set
     at its entry.  `pfx` is the path prefix for labels. -/
@@ -247,6 +253,15 @@ def vcs (reg : Region) (rw : RwRegion) : Stmt → String → Reach → List VC
   | callRegS lbl rs handles, pfx, reach =>
       [⟨pfx ++ lbl ++ ".pre", ∀ rf ws A, reach rf ws A →
           ∃ h ∈ handles, rf.get rs = h.entry ∧ h.pre rf ws A⟩]
+  | callAt lbl roR f, pfx, reach =>
+      ⟨pfx ++ lbl ++ ".focus", ∀ rf ws A, reach rf ws A → A.pcFree →
+          ∀ hp, A hp →
+          ∃ rest, roR rf ws A rest
+            ∧ (bytesRegion f.region.base f.region.bytes ** rest) hp
+            ∧ rest.pcFree⟩ ::
+      ⟨pfx ++ lbl ++ ".pre", ∀ rf ws A rest, ws.length = rw.len →
+          reach rf ws A → roR rf ws A rest → f.pre rf ws empAssertion⟩ ::
+      [⟨pfx ++ lbl ++ ".post_emp", ∀ rf ws A, f.post rf ws A → A = empAssertion⟩]
 
 /-- Exact step bound of a statement (docs/sasm-design.md §3.5; the loop bound
     is `WP.loopBound`). -/
@@ -268,6 +283,7 @@ def steps : Stmt → Nat
   | call _ f => 1 + f.nSteps
   | callReg _ _ handles => 1 + handles.foldr (fun h m => max h.nSteps m) 0
   | callRegS _ _ handles => 1 + handles.foldr (fun h m => max h.nSteps m) 0
+  | callAt _ _ f => 1 + f.nSteps
 
 /-- `sp` is monotone in the reachable set. -/
 theorem sp_mono (reg : Region) (rw : RwRegion) (s : Stmt) {r₁ r₂ : Reach}
@@ -317,6 +333,9 @@ theorem sp_mono (reg : Region) (rw : RwRegion) (s : Stmt) {r₁ r₂ : Reach}
   | callRegS lbl rs handles =>
       rintro rf ws A ⟨rf₀, ws₀, A₀, hr, hrest⟩
       exact ⟨rf₀, ws₀, A₀, h rf₀ ws₀ A₀ hr, hrest⟩
+  | callAt lbl roR f =>
+      rintro rf' ws' A'' ⟨rf, ws, A, rest, hlen, hr, hsat, hR, hpost, hA⟩
+      exact ⟨rf, ws, A, rest, hlen, h rf ws A hr, hsat, hR, hpost, hA⟩
 
 -- ============================================================================
 -- Structural `sp` eliminators (docs/sasm-howto.md, "Branchy straight-line
@@ -474,6 +493,7 @@ theorem sp_of_endsWith (reg : Region) (rw : RwRegion) {P : Reach}
   | call lbl f => exact nomatch h
   | callReg lbl rs handles => exact nomatch h
   | callRegS lbl rs handles => exact nomatch h
+  | callAt lbl roR f => exact nomatch h
 
 /-- `vcs` is antitone in the reachable set: obligations proven for a larger
     reachable set cover any smaller one.  Used to specialize loop-body VCs
@@ -648,6 +668,16 @@ theorem vcs_antitone (reg : Region) (rw : RwRegion) (s : Stmt) (pfx : String)
       simp only [vcs, List.mem_singleton] at hvc
       subst hvc
       exact fun rf ws A hr => hvcs.head rf ws A (h rf ws A hr)
+  | callAt lbl roR f =>
+      intro vc hvc
+      rcases List.mem_cons.mp hvc with rfl | hvc
+      · exact fun rf ws A hr hApc hp hA =>
+          hvcs.head rf ws A (h rf ws A hr) hApc hp hA
+      · rcases List.mem_cons.mp hvc with rfl | hvc
+        · exact fun rf ws A rest hlen hr =>
+            hvcs.tail.head rf ws A rest hlen (h rf ws A hr)
+        · rcases List.mem_singleton.mp hvc with rfl
+          exact hvcs.tail.tail.head
 
 /-- Per call site: the callee's code is contained in `cr` and the callee
     shares the caller's regions.  Stated structurally (rather than as a union
@@ -677,6 +707,7 @@ def CalleesIn (s : Stmt) (reg : Region) (rw : RwRegion) (cr : CodeReq) : Prop :=
   | callRegS _ _ handles => ∀ h ∈ handles,
       (∀ a i, h.code a = some i → cr a = some i)
       ∧ h.region = reg ∧ h.rw = rw
+  | callAt _ _ f => (∀ a i, f.code a = some i → cr a = some i) ∧ f.rw = rw
 
 end Stmt
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2753,7 +2753,32 @@ reads a dword from EACH of two independent ambient buffers `a0`, `a1`
 (NO `a0 ≠ a1` hypothesis — squaring `a0=a1` and product `a0≠a1` both
 work), sums them, writes through the writable window `dst`; the exact
 `be→le(a0); be→le(a1); arithMod; le→be(dst)` shape GLM + the crypto
-session clone for their `MulModP` proofs. Stage 5b LANDED: TreeInsert.lean — the slot-based predicate layer
+session clone for their `MulModP` proofs.  Focused-region CALLS landed
+(`SAsm/CallAt.lean`): `readAt` covers inline focused reads but NOT the
+converter CALLS of `bnfMulModP`/`secfMulModP` (`CalleesIn` statically
+requires every callee's `region = reg`, so one `Fn` can't call
+`bnf_be_to_le(a0)` then `(a1)`).  NEW `Stmt.callAt lbl roR f` (callee
+analogue of `readAt`): the wrapped callee's read-only `region` is a
+`bytesRegion` atom carved from the ambient `A` for that one call (NOT the
+enclosing `reg`); the `.focus` VC forces caller ownership, the enclosing
+`reg` and remainder `rest` are framed, and the callee's writable window
+stays the enclosing `rw` (`.pre` VC = callee pre at emp ambient, `.post_emp`
+VC = callee post ambient is emp so the enclosing `A = fregion ** rest`
+reconstructs).  Byte-transparent: flattens to the SAME single `JAL` as
+`call` (`callAt_byte_transparent`), so wrapping converter calls keeps
+`bnfMulModP` byte-identical (spec-only, no re-emit/EEST).  Soundness
+`Stmt.soundR`'s `callAt` case: `cpsCallWithin` on the callee triple
+(`f.sound` at `asrtM f.region rw`, region NOT rewritten to `reg`), framed
+by `reg ** rest` with pre-facts riding through a `⌜⌝` conjunct so the exit
+`sp` reconstructs; two helper lemmas (`cpsTripleWithin_exists_pre_gen`,
+`_pure_pre`).  Additive: engine/`blockVCs`/existing calls unchanged, corpus
+green; `Stmt.soundR`, `adderFn_spec`, `callAtFn_spec` all classical-3.
+Demo `callAtFn`/`callAtFn_spec`: leaf accumulator callee (`adderFn`, reads
+its focused buffer + window, writes the sum) called TWICE under `callAt` on
+`a0` then `a1` (allowed to coincide), post pins the window to
+`packBytes bs0 + packBytes bs1` — a function of BOTH inputs; the exact
+`bnfMulModP` shape `CalleesIn` rejects today, GLM clones it to finish.
+Stage 5b LANDED: TreeInsert.lean — the slot-based predicate layer
 (slotCell/keyCell, mutual treeAtS/treeFrom, ctxS slot-zipper with
 ctxS_zip_fold + ctxS_push_left/right, the 3-dword bytesRegion split,
 setBytes_junk_node) plus treeInsertFn + treeInsertFn_spec: the full BST


### PR DESCRIPTION
## What & why

`readAt` (#9883) let an **inline** block read from an ambient `bytesRegion` atom, unblocking the inline multi-input field leaves. But it does **not** unblock `bnfMulModP`/`secfMulModP`, which **call** their be↔le converters (`JAL bnf_be_to_le(a0)`, `JAL bnf_be_to_le(a1)`, `JAL bnf_le_to_be(res)`). Those are *callees*, and `CalleesIn` statically requires every callee's `region` to equal the `Fn`'s single `reg` — so one `Fn` can't call two converters reading `a0` then `a1` (arbitrary, non-contiguous pointers).

This PR adds the **callee analogue of `readAt`**.

## The mechanism — `Stmt.callAt`

`callAt lbl roR f` is a direct call whose wrapped callee `f` sees, as its read-only `region`, a `bytesRegion` atom carved out of the ambient assertion `A` for the duration of that one call — NOT the enclosing `reg`:

- `readAt` swaps the read-only **source** of an inline block; `callAt` swaps the read-only **region a callee sees**.
- The `.focus` VC forces the caller to own `bytesRegion f.region.base f.region.bytes ** rest` in `A` (no arbitrary-heap-read hole). The enclosing `reg` and remainder `rest` are framed and restored; the focused region is read-only so the ambient reconstructs as `A = fregion ** rest`.
- The callee's writable window stays the enclosing `rw` (as for a plain `call`).
- VCs: `.focus`, `.pre` (callee precondition at empty ambient), `.post_emp` (callee post ambient is empty — the leaf-callee scope).

**Byte-transparent**: `callAt` flattens to the same single `JAL` as `call` (`callAt_byte_transparent : flatten (callAt _ _ f) addr = [.JAL .x1 (setWidth 21 (f.entry - addr))]`), so wrapping converter calls keeps `bnfMulModP` byte-identical — spec-only, no re-emit, no EEST.

## Soundness

`Stmt.soundR`'s new `callAt` case: `WP.cpsCallWithin` on the callee triple (`f.sound` at `asrtM f.region rw f.pre`, region **not** rewritten to `reg`), framed by `reg ** rest`, with the pre-facts (`reach`, `roR`) riding through a `⌜⌝` pure conjunct so the exit `sp` can reconstruct. Two small reusable helpers: `cpsTripleWithin_exists_pre_gen`, `cpsTripleWithin_pure_pre`. Additive: the engine, `blockVCs`, and existing `call`/`callReg`/`callRegS` are unchanged — the whole corpus rebuilds green.

## Files
- `Ast`/`Flatten`/`Vc`: the `callAt` constructor threaded through size/callFree/flatten/offsetsOk/callsOk/sp/vcs/steps/sp_mono/vcs_antitone/sp_of_endsWith/CalleesIn
- `StmtSound`: vacuous non-callFree case; `StmtSoundCall`: the `soundR` case + helpers
- `CallAt.lean`: the demo

## Demo / acceptance test
`adderFn` (a genuine leaf: reads its focused buffer **and** the writable window, writes their sum back) is called **twice under `callAt`** on `a0` then `a1` (allowed to coincide — a squaring — or differ). `callAtFn`'s post pins the window to `packBytes bs0 + packBytes bs1` — a function of **both** inputs. This is exactly the two-different-region call shape `CalleesIn` rejects today; GLM wraps the three converter calls of `bnfMulModP` the same way to finish it.

## Gates
- ✅ Full corpus `lake build` green (backward-compat; existing calls unchanged)
- ✅ `#print axioms` on `Stmt.soundR`, `adderFn_spec`, `callAtFn_spec` → `[propext, Classical.choice, Quot.sound]`
- ✅ `check-forbidden-tactics.sh`, `check-axioms.sh` (65 witnesses, classical only), `port-check.sh` (48 theorems) all clean
- ✅ No `sorry`/`native_decide`/`bv_decide`/`maxHeartbeats`/`maxRecDepth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)