### PR TITLE
feat: verify copy_word_gas SAsm port

### DIFF
--- a/EvmAsm/Codegen/Programs/GasRoutinesSAsm.lean
+++ b/EvmAsm/Codegen/Programs/GasRoutinesSAsm.lean
@@ -1,0 +1,70 @@
+/-
+  EvmAsm.Codegen.Programs.GasRoutinesSAsm
+
+  Verified SAsm ports of the straight-line dynamic-gas leaves (bead
+  evm-asm-4ch8f): pure `a0 → a0` register arithmetic, no memory, no
+  loops, no calls.  Each routine pins `x10_out` to the exact closed form
+  the 4–7 body instructions compute (a genuine functional spec, not a
+  tautology), and the body's flat instruction list is byte-identical to
+  the emitted guest program — so these are spec-only drop-ins (no EEST
+  A/B, no re-emit).
+-/
+
+import EvmAsm.Codegen.Programs.DynamicOpcodeGas
+import EvmAsm.Rv64.SAsm.Tactic
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.SAsm.Stmt
+
+namespace GasRoutinesSAsm
+
+/-! ## copy_word_gas
+
+    `a0 = size_bytes → a0 = OPCODE_COPY_PER_WORD(3) * ceil32(size) // 32`,
+    with `ceil32(size) // 32 = (size + 31) >>> 5`.  Pure register
+    arithmetic: `ADDI; SRLI; LI; MUL`, ret. -/
+
+/-- Verified port of `copy_word_gas`: `a0 := 3 * ((a0 + 31) >>> 5)`. -/
+def copyWordGasFn (len : Word) : Fn where
+  name := "copyWordGas"
+  region := Region.empty
+  rw := RwRegion.empty
+  pre  := fun rf _ A => rf.get .x10 = len ∧ A = empAssertion
+  post := fun rf _ A =>
+    rf.get .x10 = ((len + 31) >>> 5) * 3 ∧ A = empAssertion
+  body := .block "body"
+    [ .ADDI .x5 .x10 (31 : BitVec 12),
+      .SRLI .x5 .x5 (5 : BitVec 6),
+      .LI .x6 (3 : Word),
+      .MUL .x10 .x5 .x6 ]
+
+/-- The four body instructions match the emitted routine (excluding the
+    shared `ret` epilogue). -/
+theorem copyWordGas_byte_tie :
+    (copyWordGasFn 0).body.flatten 0
+      ++ [Instr.JALR .x0 .x1 (0 : BitVec 12)] = copyWordGas_prog := rfl
+
+#guard ((copyWordGasFn 0).body.flatten 0).length = 4
+
+private theorem se12_31 : signExtend12 (31 : BitVec 12) = (31 : Word) := by decide
+
+/-- Specification: at every entry state with `a0 = len` and an empty
+    ambient assertion, the body leaves `a0 = 3 * ((len + 31) >>> 5)` and
+    the ambient assertion empty. -/
+theorem copyWordGasFn_spec (len : Word) (base : Word) :
+    (copyWordGasFn len).Spec base := by
+  vcgen
+  case copyWordGas.post =>
+    rintro rf' ws' A' ⟨rf₀, ws₀, hws₀, hpre, rfl, rfl⟩
+    obtain ⟨hx10, hA⟩ := hpre
+    obtain rfl : ws' = [] := List.eq_nil_of_length_eq_zero hws₀
+    refine ⟨?_, hA⟩
+    simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem,
+      RegFile.get_set_self, RegFile.get_set_ne, ne_eq, reduceCtorEq,
+      not_false_eq_true, hx10, se12_31,
+      show (5 : BitVec 6).toNat = 5 from by decide]
+
+end GasRoutinesSAsm
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -147,6 +147,7 @@ import EvmAsm.Codegen.Programs.WitnessCodeLookup
 import EvmAsm.Codegen.Programs.Ssz
 import EvmAsm.Codegen.Programs.U256
 import EvmAsm.Codegen.Programs.U256IsZeroSAsm
+import EvmAsm.Codegen.Programs.GasRoutinesSAsm
 import EvmAsm.Codegen.Programs.Tx
 import EvmAsm.Codegen.Programs.TxDecode
 import EvmAsm.Codegen.Programs.TxExtract


### PR DESCRIPTION
Verified SAsm port of `copy_word_gas` (bead evm-asm-4ch8f), the first of three straight-line dynamic-gas leaves.

## What
- New `EvmAsm/Codegen/Programs/GasRoutinesSAsm.lean` with `copyWordGasFn` and `copyWordGasFn_spec`.
- Pure `a0 → a0` register arithmetic (`ADDI; SRLI; LI; MUL`), no memory, no loops, no calls.
- Post pins `x10_out = 3 * ((len+31) >>> 5)` — the exact closed form the 4 instructions compute (genuine functional spec, not `True`).
- Byte-tie `copyWordGas_byte_tie` proves the body flatten + `ret` equals `copyWordGas_prog` by `rfl`.
- Wired into `Programs/Imports.lean`.

## Spec design
Static preconditions only (`rf.get .x10 = len`, `A = empAssertion`); outcome in the post. Single `vcgen` obligation (`copyWordGas.post`) discharged by symbolic execution of the 4 ALU ops + BitVec simp.

## Gates
- `scripts/port-check.sh EvmAsm/Codegen/Programs/GasRoutinesSAsm.lean` PASS
- `lake build EvmAsm` green
- `check-forbidden-tactics.sh`, `check-layering.sh`, `check-unimported.sh`, `check-no-warnings.sh` clean
- `#print axioms copyWordGasFn_spec` → `[propext, Classical.choice, Quot.sound]` only
- No `sorry`/`native_decide`/`bv_decide`/`maxHeartbeats`/`maxRecDepth`
- Not registered in `Progress.lean` (Codegen-layer spec; `check-layering.sh` L1)

## EEST
Spec-only drop-in: byte-identical to the emitted guest (`rfl`), so no EEST A/B and no re-emit required.

Confidence ladder: `logDataGas` and `initCodeCost` follow as separate PRs in the same shape.

Generated by GLM-5.2.
Co-Authored-By: GLM-5.2 <noreply@anthropic.com>