### PR TITLE
feat: verify log_data_gas SAsm port

### DIFF
--- a/EvmAsm/Codegen/Programs/GasRoutinesSAsm.lean
+++ b/EvmAsm/Codegen/Programs/GasRoutinesSAsm.lean
@@ -65,6 +65,54 @@ theorem copyWordGasFn_spec (len : Word) (base : Word) :
       not_false_eq_true, hx10, se12_31,
       show (5 : BitVec 6).toNat = 5 from by decide]
 
+/-! ## log_data_gas
+
+    `a0 = num_topics, a1 = data_bytes → a0 = OPCODE_LOG_BASE(375)
+    + OPCODE_LOG_TOPIC(375)*num_topics + OPCODE_LOG_DATA_PER_BYTE(8)*data_bytes`.
+    Pure register arithmetic: `LI;MUL;ADD;LI;MUL;ADD`, ret. -/
+
+/-- Verified port of `log_data_gas`:
+    `a0 := (topics * 375 + 375) + (dataBytes * 8)`. -/
+def logDataGasFn (topics dataBytes : Word) : Fn where
+  name := "logDataGas"
+  region := Region.empty
+  rw := RwRegion.empty
+  pre  := fun rf _ A =>
+    rf.get .x10 = topics ∧ rf.get .x11 = dataBytes ∧ A = empAssertion
+  post := fun rf _ A =>
+    rf.get .x10 = topics * 375 + 375 + dataBytes * 8 ∧ A = empAssertion
+  body := .block "body"
+    [ .LI .x5 (375 : Word),
+      .MUL .x6 .x10 .x5,
+      .ADD .x6 .x6 .x5,
+      .LI .x7 (8 : Word),
+      .MUL .x7 .x11 .x7,
+      .ADD .x10 .x6 .x7 ]
+
+/-- The six body instructions match the emitted routine (excluding the
+    shared `ret` epilogue). -/
+theorem logDataGas_byte_tie :
+    (logDataGasFn 0 0).body.flatten 0
+      ++ [Instr.JALR .x0 .x1 (0 : BitVec 12)] = logDataGas_prog := rfl
+
+#guard ((logDataGasFn 0 0).body.flatten 0).length = 6
+
+/-- Specification: at every entry state with `a0 = topics`, `a1 = dataBytes`,
+    and an empty ambient assertion, the body leaves
+    `a0 = (topics * 375 + 375) + (dataBytes * 8)` and the ambient
+    assertion empty. -/
+theorem logDataGasFn_spec (topics dataBytes : Word) (base : Word) :
+    (logDataGasFn topics dataBytes).Spec base := by
+  vcgen
+  case logDataGas.post =>
+    rintro rf' ws' A' ⟨rf₀, ws₀, hws₀, hpre, rfl, rfl⟩
+    obtain ⟨hx10, hx11, hA⟩ := hpre
+    obtain rfl : ws' = [] := List.eq_nil_of_length_eq_zero hws₀
+    refine ⟨?_, hA⟩
+    simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem,
+      RegFile.get_set_self, RegFile.get_set_ne, ne_eq, reduceCtorEq,
+      not_false_eq_true, hx10, hx11]
+
 end GasRoutinesSAsm
 
 end EvmAsm.Codegen


### PR DESCRIPTION
Verified SAsm port of `log_data_gas` (bead evm-asm-4ch8f), the second of three straight-line dynamic-gas leaves. **Stacks on #9886** — merge that first.

## What
Adds `logDataGasFn` and `logDataGasFn_spec` to `GasRoutinesSAsm.lean`.
- Two-input pure `a0/a1 → a0` register arithmetic (`LI;MUL;ADD;LI;MUL;ADD`), no memory, no loops, no calls.
- Post pins `x10_out = (topics * 375 + 375) + (dataBytes * 8)` — exact closed form matching the body's evaluation order (genuine functional spec, not `True`).
- Byte-tie `logDataGas_byte_tie` proves body flatten + `ret` equals `logDataGas_prog` by `rfl`.

## Spec design
Static preconditions only (`rf.get .x10 = topics`, `rf.get .x11 = dataBytes`, `A = empAssertion`); outcome in the post. Single `vcgen` obligation (`logDataGas.post`) discharged by symbolic execution of the 6 ALU ops + BitVec simp on the immediate hypotheses.

## Gates
- `scripts/port-check.sh EvmAsm/Codegen/Programs/GasRoutinesSAsm.lean` PASS (5 theorems, 2 #guards)
- `lake build EvmAsm` green
- `check-forbidden-tactics.sh`, `check-layering.sh`, `check-unimported.sh`, `check-no-warnings.sh` clean
- `#print axioms logDataGasFn_spec` → `[propext, Classical.choice, Quot.sound]` only
- No `sorry`/`native_decide`/`bv_decide`/`maxHeartbeats`/`maxRecDepth`
- Not registered in `Progress.lean` (Codegen-layer spec; `check-layering.sh` L1)

## EEST
Spec-only drop-in: byte-identical to the emitted guest (`rfl`), so no EEST A/B and no re-emit required.

Confidence ladder: `initCodeCost` (with its writable window) follows as a separate PR.

Generated by GLM-5.2.
Co-Authored-By: GLM-5.2 <noreply@anthropic.com>