### PR TITLE
feat: verify keccak256_word_gas SAsm port

### DIFF
--- a/EvmAsm/Codegen/Programs/GasRoutinesSAsm.lean
+++ b/EvmAsm/Codegen/Programs/GasRoutinesSAsm.lean
@@ -67,13 +67,59 @@ theorem copyWordGasFn_spec (len : Word) (base : Word) :
       not_false_eq_true, hx10, se12_31,
       show (5 : BitVec 6).toNat = 5 from by decide]
 
+/-! ## keccak256_word_gas
+
+    `a0 = size_bytes → a0 = OPCODE_KECCAK256_BASE(30)
+    + OPCODE_KECCAK256_PER_WORD(6) * ceil32(size) // 32`.
+    Pure register arithmetic: `ADDI;SRLI;LI;MUL;ADDI`, ret. -/
+
+/-- Verified port of `keccak256_word_gas`:
+    `a0 := ((len + 31) >>> 5) * 6 + 30`. -/
+def keccak256WordGasFn (len : Word) : Fn where
+  name := "keccak256WordGas"
+  region := Region.empty
+  rw := RwRegion.empty
+  pre  := fun rf _ A => rf.get .x10 = len ∧ A = empAssertion
+  post := fun rf _ A =>
+    rf.get .x10 = ((len + 31) >>> 5) * 6 + 30 ∧ A = empAssertion
+  body := .block "body"
+    [ .ADDI .x5 .x10 (31 : BitVec 12),
+      .SRLI .x5 .x5 (5 : BitVec 6),
+      .LI .x6 (6 : Word),
+      .MUL .x5 .x5 .x6,
+      .ADDI .x10 .x5 (30 : BitVec 12) ]
+
+/-- The five body instructions match the emitted routine (excluding the
+    shared `ret` epilogue). -/
+theorem keccak256WordGas_byte_tie :
+    (keccak256WordGasFn 0).body.flatten 0
+      ++ [Instr.JALR .x0 .x1 (0 : BitVec 12)] = keccak256WordGas_prog := rfl
+
+#guard ((keccak256WordGasFn 0).body.flatten 0).length = 5
+
+private theorem se12_30 : signExtend12 (30 : BitVec 12) = (30 : Word) := by decide
+
+/-- Specification: at every entry state with `a0 = len` and an empty
+    ambient assertion, the body leaves `a0 = ((len + 31) >>> 5) * 6 + 30`
+    and the ambient assertion empty. -/
+theorem keccak256WordGasFn_spec (len : Word) (base : Word) :
+    (keccak256WordGasFn len).Spec base := by
+  vcgen
+  case keccak256WordGas.post =>
+    rintro rf' ws' A' ⟨rf₀, ws₀, hws₀, hpre, rfl, rfl⟩
+    obtain ⟨hx10, hA⟩ := hpre
+    obtain rfl : ws' = [] := List.eq_nil_of_length_eq_zero hws₀
+    refine ⟨?_, hA⟩
+    simp only [execBlock_cons, execBlock_nil, execInstrRF, aluSem,
+      RegFile.get_set_self, RegFile.get_set_ne, ne_eq, reduceCtorEq,
+      not_false_eq_true, hx10, se12_31, se12_30,
+      show (5 : BitVec 6).toNat = 5 from by decide]
+
 /-! ## log_data_gas
 
     `a0 = num_topics, a1 = data_bytes → a0 = OPCODE_LOG_BASE(375)
     + OPCODE_LOG_TOPIC(375)*num_topics + OPCODE_LOG_DATA_PER_BYTE(8)*data_bytes`.
-    Pure register arithmetic: `LI;MUL;ADD;LI;MUL;ADD`, ret. -/
-
-/-- Verified port of `log_data_gas`:
+    Pure register arithmetic: `LI;MUL;ADD;LI;MUL;ADD`, ret. -//-- Verified port of `log_data_gas`:
     `a0 := (topics * 375 + 375) + (dataBytes * 8)`. -/
 def logDataGasFn (topics dataBytes : Word) : Fn where
   name := "logDataGas"


### PR DESCRIPTION
Verified SAsm port of `keccak256_word_gas` (bead evm-asm-4ch8f), the fourth straight-line dynamic-gas leaf — same shape as `copy_word_gas` (#9886) but with an extra `ADDI` for the KECCAK256 base cost.

## What
Adds `keccak256WordGasFn` and `keccak256WordGasFn_spec` to `GasRoutinesSAsm.lean`.
- Pure `a0 → a0` register arithmetic (`ADDI;SRLI;LI;MUL;ADDI`), no memory, no loops, no calls.
- Post pins `x10_out = ((len+31) >>> 5) * 6 + 30` — exact closed form matching the body's evaluation order (genuine functional spec, not `True`).
- Byte-tie `keccak256WordGas_byte_tie` proves body flatten + `ret` equals `keccak256WordGas_prog` by `rfl`.

## Spec design
Static preconditions only (`rf.get .x10 = len`, `A = empAssertion`); outcome in the post. Single `vcgen` obligation (`keccak256WordGas.post`) discharged by symbolic execution of the 5 ALU ops + BitVec simp on the two immediates (signExtend12 31, signExtend12 30, SRLI shamt 5).

## Gates
- `scripts/port-check.sh EvmAsm/Codegen/Programs/GasRoutinesSAsm.lean` PASS (25 theorems, 4 #guards)
- `lake build EvmAsm` green
- `check-forbidden-tactics.sh`, `check-layering.sh`, `check-unimported.sh`, `check-no-warnings.sh` clean
- `#print axioms keccak256WordGasFn_spec` → `[propext, Classical.choice, Quot.sound]` only
- No `sorry`/`native_decide`/`bv_decide`/`maxHeartbeats`/`maxRecDepth`
- Not registered in `Progress.lean` (Codegen-layer spec; `check-layering.sh` L1)

## EEST
Spec-only drop-in: byte-identical to the emitted guest (`rfl`), so no EEST A/B and no re-emit required.

Generated by GLM-5.2.
Co-Authored-By: GLM-5.2 <noreply@anthropic.com>