### PR TITLE
feat(sasm): frame + cross-call composition — stackFree region + abiFrameCall_spec + two-call demo

### DIFF
--- a/EvmAsm/Rv64/SAsm.lean
+++ b/EvmAsm/Rv64/SAsm.lean
@@ -32,6 +32,8 @@ import EvmAsm.Rv64.SAsm.AbiFrame
 import EvmAsm.Rv64.SAsm.AbiFrameLoop
 import EvmAsm.Rv64.SAsm.AbiFrameDemo
 import EvmAsm.Rv64.SAsm.AbiFrameLoopDemo
+import EvmAsm.Rv64.SAsm.AbiFrameCall
+import EvmAsm.Rv64.SAsm.AbiFrameCallDemo
 import EvmAsm.Rv64.SAsm.ParentHeaderMemcmp
 import EvmAsm.Rv64.SAsm.ParentHeaderFrame
 import EvmAsm.Rv64.SAsm.CallRegDemo

--- a/EvmAsm/Rv64/SAsm/AbiFrameCall.lean
+++ b/EvmAsm/Rv64/SAsm/AbiFrameCall.lean
@@ -1,0 +1,209 @@
+/-
+  EvmAsm.Rv64.SAsm.AbiFrameCall
+
+  Frame + cross-call composition at the `cpsTripleWithin` level (bead
+  evm-asm-4ch8f.76 follow-up): the missing piece for the ~218 sp-frame guest
+  routines that CALL OUT (block-verdict / MPT / tx / crypto).
+
+  `abiFrame_spec` (AbiFrame.lean) lifts an arbitrary single-exit body into a
+  whole prologue·body·epilogue·ret routine.  Its `vals'` (the body-clobbered
+  register values) is COMPLETELY FREE — including `vals' .x1` — and the
+  epilogue restores every saved register (ra included) from its frame slot
+  (`loadSeq_spec` takes the slot value, ignoring the clobbered register).  So
+  the ra-clobber-across-call is ALREADY supported at the frame level; what a
+  cross-calling body needs is supplied here:
+
+  1. **A free-stack region below `sp`** (`stackFree sp k`): `k` genuinely
+     *owned* dword cells `sp - 8, sp - 16, …, sp - 8k` — the stack space a
+     callee may carve its own frame from.  Being ordinary `memOwn` atoms they
+     are disjoint (through `**`) from the caller's frame slots, saved-`ra`
+     slot, and every caller region — no arbitrary stack read/write hole.
+     `stackFree_split` splits off a callee-sized prefix, framing the rest.
+
+  2. **The call composition rule** (`callWithin_spec` / `abiFrameCall_spec`):
+     `jal ra, callee` links `ra := A + 4` (clobbering it — that is *why* the
+     caller saved `ra` in its frame) and transfers to the callee, whose own
+     whole-routine `cpsTripleWithin` contract (e.g. an `abiFrame_spec`
+     instance, entered with `sp = newSp` and its frame carved from
+     `stackFree newSp m`) runs back to `A + 4`.  Everything the callee does
+     not own — the caller's frame slots, the saved `ra`, the unused stack,
+     every caller region — is framed through the call, so its preservation is
+     *proven* by separation, never assumed.  A *sequence* of calls composes
+     by ordinary `cpsTripleWithin` sequencing: each `jal` re-clobbers `ra`
+     (the rule takes the incumbent value as a free `vOld`).
+
+  `AbiFrameCallDemo.lean` exercises the whole stack: a framed caller invokes
+  a framed callee TWICE via real `jal`s, the callee carving its frame from
+  the caller's free stack; `abiFrame_spec` then restores `sp`/`ra` to entry.
+
+  Strictly additive: `cpsTripleWithin` only; no `Ast`/`Vc`/`StmtSound*`/
+  `blockOk` changes.
+-/
+
+import EvmAsm.Rv64.SAsm.AbiFrame
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Rv64
+namespace SAsm
+
+open EvmAsm.Rv64.Tactics
+
+-- ============================================================================
+-- The free-stack region below `sp`.
+-- ============================================================================
+
+/-- `stackFree sp k`: `k` genuinely owned dword cells immediately below `sp`
+    (`sp - 8·(k)…sp - 8`, arbitrary contents).  The stack space a callee may
+    allocate its own frame from; ordinary owned-memory atoms, so disjoint
+    (through `**`) from the caller's frame slots and regions. -/
+def stackFree (sp : Word) : Nat → Assertion
+  | 0 => empAssertion
+  | k + 1 => memOwn (sp - BitVec.ofNat 64 (8 * (k + 1))) ** stackFree sp k
+
+@[simp] theorem stackFree_zero (sp : Word) : stackFree sp 0 = empAssertion := rfl
+
+theorem stackFree_succ (sp : Word) (k : Nat) :
+    stackFree sp (k + 1)
+      = (memOwn (sp - BitVec.ofNat 64 (8 * (k + 1))) ** stackFree sp k) := rfl
+
+theorem pcFree_stackFree (sp : Word) (k : Nat) : (stackFree sp k).pcFree := by
+  induction k with
+  | zero => exact pcFree_emp
+  | succ n ih => exact pcFree_sepConj pcFree_memOwn ih
+
+/-- Assertion-level (`=`) associativity, from the pointwise `sepConj_assoc`. -/
+private theorem sepConj_assoc_eq {P Q R : Assertion} :
+    ((P ** Q) ** R) = (P ** (Q ** R)) := by
+  funext h; exact propext (sepConj_assoc h)
+
+/-- Assertion-level (`=`) left identity. -/
+private theorem sepConj_emp_left_eq {P : Assertion} : (empAssertion ** P) = P := by
+  funext h; exact propext (sepConj_emp_left h)
+
+/-- Split a free-stack region: the shallow `m` cells a callee will use, with
+    the deeper remainder framed off. -/
+theorem stackFree_split (sp : Word) {m K : Nat} (h : m ≤ K) :
+    ∃ R : Assertion, R.pcFree ∧ stackFree sp K = (R ** stackFree sp m) := by
+  induction K with
+  | zero =>
+    have hm : m = 0 := Nat.le_zero.mp h
+    subst hm
+    exact ⟨empAssertion, pcFree_emp, sepConj_emp_left_eq.symm⟩
+  | succ K ih =>
+    rcases Nat.lt_or_ge m (K + 1) with hlt | hge
+    · obtain ⟨R, hRp, hReq⟩ := ih (Nat.lt_succ_iff.mp hlt)
+      refine ⟨memOwn (sp - BitVec.ofNat 64 (8 * (K + 1))) ** R,
+        pcFree_sepConj pcFree_memOwn hRp, ?_⟩
+      rw [stackFree_succ, hReq, sepConj_assoc_eq]
+    · have hm : m = K + 1 := Nat.le_antisymm h hge
+      subst hm
+      exact ⟨empAssertion, pcFree_emp, sepConj_emp_left_eq.symm⟩
+
+-- ============================================================================
+-- The linking jump: `jal ra, offset`.
+-- ============================================================================
+
+/-- One-step spec of the direct call jump `jal x1, offset`: the return
+    address `addr + 4` lands in the separately owned `ra` (clobbering the
+    incumbent `vOld`), and control transfers to `addr + offset`.  The direct
+    (`JAL`) analogue of `jalr_call_spec_within`. -/
+theorem jal_link_spec_within (offset : BitVec 21) (addr vOld : Word) :
+    cpsTripleWithin 1 addr (addr + signExtend21 offset)
+      (CodeReq.singleton addr (.JAL .x1 offset))
+      ((.x1 : Reg) ↦ᵣ vOld)
+      ((.x1 : Reg) ↦ᵣ (addr + 4)) := by
+  intro R hR s hcr hPR hpc; subst hpc
+  have hfetch : s.code s.pc = some (.JAL .x1 offset) :=
+    CodeReq.singleton_satisfiedBy.mp hcr
+  have hstep' : step s = some (execInstrBr s (.JAL .x1 offset)) :=
+    step_non_ecall_non_mem hfetch (by nofun) (by nofun) rfl
+  have hexec : execInstrBr s (.JAL .x1 offset)
+      = (s.setReg .x1 (s.pc + 4)).setPC (s.pc + signExtend21 offset) := rfl
+  refine ⟨1, Nat.le_refl 1,
+    (s.setReg .x1 (s.pc + 4)).setPC (s.pc + signExtend21 offset), ?_, rfl, ?_⟩
+  · show (step s).bind (stepN 0) = some _
+    rw [hstep', hexec]; rfl
+  · have h1 := holdsFor_sepConj_regIs_setReg (v' := s.pc + 4)
+      (show (.x1 : Reg) ≠ .x0 from by decide) hPR
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h1
+
+-- ============================================================================
+-- The call composition rule.
+-- ============================================================================
+
+/-- **Compose one `jal ra, callee` with the callee's whole-routine
+    contract.**  The callee is supplied as a `cpsTripleWithin` from its entry
+    back to the return address `A + 4` (the shape every `abiFrame_spec`
+    conclusion and every `FnHandle.sound` instance has, with `ret := A + 4`),
+    entered with `ra` holding that return address; the call site holds an
+    arbitrary incumbent `vOld` in `ra` (a second call in sequence passes the
+    previous call's link — each `jal` re-clobbers `ra`).  Everything not in
+    the callee's footprint `P`/`Q` is framed by the ordinary frame rule. -/
+theorem callWithin_spec {cr : CodeReq} {P Q : Assertion}
+    (A calleeEntry vOld : Word) (offset : BitVec 21) (n : Nat)
+    (htarget : A + signExtend21 offset = calleeEntry)
+    (hmem : ∀ a i, CodeReq.singleton A (.JAL .x1 offset) a = some i → cr a = some i)
+    (hP : P.pcFree)
+    (hcallee : cpsTripleWithin n calleeEntry (A + 4) cr
+        (((.x1 : Reg) ↦ᵣ (A + 4)) ** P)
+        (((.x1 : Reg) ↦ᵣ (A + 4)) ** Q)) :
+    cpsTripleWithin (1 + n) A (A + 4) cr
+      (((.x1 : Reg) ↦ᵣ vOld) ** P)
+      (((.x1 : Reg) ↦ᵣ (A + 4)) ** Q) := by
+  have hjal := jal_link_spec_within offset A vOld
+  rw [htarget] at hjal
+  have hjalF := cpsTripleWithin_frameR P hP hjal
+  have hjal' := cpsTripleWithin_extend_code hmem hjalF
+  exact cpsTripleWithin_seq_perm_same_cr (fun _ hp => hp) hjal' hcallee
+
+/-- **The frame + cross-call composition rule** (`abiFrameCall_spec`),
+    consumed inside an `abiFrame_spec` body hypothesis.
+
+    A framed caller (already inside its prologue, `sp = spVal = newSp`)
+    invokes a callee whose contract:
+
+    * enters at `calleeEntry` with `ra = A + 4`, `sp = spVal`, and `m` owned
+      free-stack dwords below `sp` (`stackFree spVal m` — the space the
+      callee carves its own frame from), plus its caller-visible footprint
+      `calleePre`;
+    * returns to `A + 4` with `ra`/`sp` intact, the free stack RELEASED
+      (owned again — the callee's epilogue deallocated its frame), and
+      `calleePost`.
+
+    `F` is everything the callee does not own — the **caller's frame slots
+    and saved `ra` slot**, the deeper unused stack (`stackFree_split`), and
+    any other caller region — and is preserved through the call by the frame
+    rule: preservation is *proven* by separation, never assumed.  Sequencing
+    N calls chains this rule N times (`vOld` absorbs the previous link). -/
+theorem abiFrameCall_spec {cr : CodeReq} {calleePre calleePost F : Assertion}
+    (A calleeEntry vOld spVal : Word) (offset : BitVec 21) (m n : Nat)
+    (htarget : A + signExtend21 offset = calleeEntry)
+    (hmem : ∀ a i, CodeReq.singleton A (.JAL .x1 offset) a = some i → cr a = some i)
+    (hpre : calleePre.pcFree) (hF : F.pcFree)
+    (hcallee : cpsTripleWithin n calleeEntry (A + 4) cr
+        (((.x1 : Reg) ↦ᵣ (A + 4)) ** (.x2 ↦ᵣ spVal) ** stackFree spVal m
+          ** calleePre)
+        (((.x1 : Reg) ↦ᵣ (A + 4)) ** (.x2 ↦ᵣ spVal) ** stackFree spVal m
+          ** calleePost)) :
+    cpsTripleWithin (1 + n) A (A + 4) cr
+      (((.x1 : Reg) ↦ᵣ vOld) ** (.x2 ↦ᵣ spVal) ** stackFree spVal m
+        ** calleePre ** F)
+      (((.x1 : Reg) ↦ᵣ (A + 4)) ** (.x2 ↦ᵣ spVal) ** stackFree spVal m
+        ** calleePost ** F) := by
+  have hcalleeF := cpsTripleWithin_frameR F hF hcallee
+  have hc : cpsTripleWithin n calleeEntry (A + 4) cr
+      (((.x1 : Reg) ↦ᵣ (A + 4)) ** ((.x2 ↦ᵣ spVal) ** stackFree spVal m
+        ** calleePre ** F))
+      (((.x1 : Reg) ↦ᵣ (A + 4)) ** ((.x2 ↦ᵣ spVal) ** stackFree spVal m
+        ** calleePost ** F)) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by xperm_hyp hq) hcalleeF
+  have hcall := callWithin_spec A calleeEntry vOld offset n htarget hmem
+    (pcFree_sepConj pcFree_regIs
+      (pcFree_sepConj (pcFree_stackFree _ _) (pcFree_sepConj hpre hF)))
+    hc
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hcall
+
+end SAsm
+end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/AbiFrameCallDemo.lean
+++ b/EvmAsm/Rv64/SAsm/AbiFrameCallDemo.lean
@@ -1,0 +1,440 @@
+/-
+  EvmAsm.Rv64.SAsm.AbiFrameCallDemo
+
+  End-to-end regression witness for the frame + cross-call composition
+  (`AbiFrameCall.lean`, bead evm-asm-4ch8f.76 follow-up): a framed caller
+  invokes a framed callee TWICE via real `jal ra` instructions.
+
+  The callee (`bump`, at `0x2000`) increments the dword at `[a0]`.  It uses
+  `s0` as a scratch pointer copy — a callee-saved register — so it has its
+  own 16-byte frame (saving `ra` + `s0`), carved from the CALLER's free
+  stack (`stackFree newSp 2`) and released on return; its whole-routine
+  contract is itself an `abiFrame_spec` instance:
+
+      bump:  addi sp, sp, -16
+             sd   ra, 0(sp)
+             sd   s0, 8(sp)
+             mv   s0, a0          -- clobbers callee-saved s0
+             ld   a1, 0(s0)
+             addi a1, a1, 1
+             sd   a1 -> 0(s0)     -- [a0] += 1
+             ld   ra, 0(sp)
+             ld   s0, 8(sp)
+             addi sp, sp, +16
+             ret
+
+  The caller (`twice`, at `0x1000`) saves only `ra` (each `jal` genuinely
+  clobbers it — the second call's link overwrites the first's) and calls
+  `bump` twice:
+
+      twice: addi sp, sp, -8
+             sd   ra, 0(sp)
+             jal  ra, bump        -- ra := 0x100C
+             jal  ra, bump        -- ra := 0x1010
+             ld   ra, 0(sp)
+             addi sp, sp, +8
+             ret
+
+  `twiceFrame_spec` proves the whole ABI contract: on return `sp` and `ra`
+  equal their ENTRY values (the body clobbered `ra` twice; restoration is
+  *derived* from the caller's saved-`ra` slot, which both callees provably
+  could not touch — it is framed out of their footprint), the dword at
+  `[a0]` holds `v + 1 + 1`, `s0` (used and restored by the callee, twice)
+  still holds the caller's value, and the free stack the callees borrowed is
+  owned again.  Byte-transparency: `#guard`/`rfl` tie both `abiFrameProg`
+  flattens to the spelled-out programs.
+-/
+
+import EvmAsm.Rv64.SAsm.AbiFrame
+import EvmAsm.Rv64.SAsm.AbiFrameCall
+import EvmAsm.Rv64.SAsm.Fn
+import EvmAsm.Rv64.Tactics.RunBlock
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Rv64
+namespace SAsm
+namespace AbiFrameCallDemo
+
+open EvmAsm.Rv64.Tactics
+
+-- ============================================================================
+-- The callee: `bump` (own frame, increments `[a0]`, clobbers s0).
+-- ============================================================================
+
+/-- The callee's 2-slot frame: `ra` at 0, `s0` at 8. -/
+def bumpFrame : FrameDesc := [(.x1, 0), (.x8, 8)]
+
+/-- Callee body: copy the pointer into (callee-saved) `s0`, load, increment,
+    store back. -/
+def bumpBody : List Instr :=
+  [ .MV .x8 .x10,
+    .LD .x11 .x8 (0 : BitVec 12),
+    .ADDI .x11 .x11 (1 : BitVec 12),
+    .SD .x8 .x11 (0 : BitVec 12) ]
+
+/-- The whole callee routine (11 instructions), as an `abiFrameProg`. -/
+def bumpProg : List Instr :=
+  abiFrameProg (-16 : BitVec 12) (16 : BitVec 12) bumpFrame bumpBody
+
+/-- The same 11 instructions spelled out. -/
+def bumpProgList : List Instr :=
+  [ .ADDI .x2 .x2 (-16 : BitVec 12),
+    .SD .x2 .x1 (0 : BitVec 12),
+    .SD .x2 .x8 (8 : BitVec 12),
+    .MV .x8 .x10,
+    .LD .x11 .x8 (0 : BitVec 12),
+    .ADDI .x11 .x11 (1 : BitVec 12),
+    .SD .x8 .x11 (0 : BitVec 12),
+    .LD .x1 .x2 (0 : BitVec 12),
+    .LD .x8 .x2 (8 : BitVec 12),
+    .ADDI .x2 .x2 (16 : BitVec 12),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
+
+#guard bumpProg = bumpProgList
+
+/-- Byte-transparency of the callee, kernel-checked. -/
+theorem bumpProg_eq : bumpProg = bumpProgList := rfl
+
+-- ============================================================================
+-- The caller: `twice` (saves only ra, two real `jal ra` calls).
+-- ============================================================================
+
+/-- The caller's 1-slot frame: just `ra` (the calls clobber nothing else it
+    must preserve). -/
+def twiceFrame : FrameDesc := [(.x1, 0)]
+
+/-- Caller body: two direct calls to `bump` (`0x1008 + 0xFF8 = 0x2000`,
+    `0x100C + 0xFF4 = 0x2000`). -/
+def twiceBody : List Instr :=
+  [ .JAL .x1 (0xFF8 : BitVec 21),
+    .JAL .x1 (0xFF4 : BitVec 21) ]
+
+/-- The whole caller routine (7 instructions), as an `abiFrameProg`. -/
+def twiceProg : List Instr :=
+  abiFrameProg (-8 : BitVec 12) (8 : BitVec 12) twiceFrame twiceBody
+
+/-- The same 7 instructions spelled out. -/
+def twiceProgList : List Instr :=
+  [ .ADDI .x2 .x2 (-8 : BitVec 12),
+    .SD .x2 .x1 (0 : BitVec 12),
+    .JAL .x1 (0xFF8 : BitVec 21),
+    .JAL .x1 (0xFF4 : BitVec 21),
+    .LD .x1 .x2 (0 : BitVec 12),
+    .ADDI .x2 .x2 (8 : BitVec 12),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
+
+#guard twiceProg = twiceProgList
+
+/-- Byte-transparency of the caller, kernel-checked. -/
+theorem twiceProg_eq : twiceProg = twiceProgList := rfl
+
+/-- The demo CodeReq: caller at `0x1000`, callee at `0x2000`. -/
+def callDemoCr : CodeReq :=
+  (CodeReq.ofProg 0x1000 twiceProgList).union (CodeReq.ofProg 0x2000 bumpProgList)
+
+/-- Caller code containment. -/
+private theorem twiceSub :
+    ∀ a i, CodeReq.ofProg 0x1000 twiceProgList a = some i → callDemoCr a = some i := by
+  intro a i h
+  simp only [callDemoCr, CodeReq.union, h]
+
+/-- Callee code containment (the caller's 7 slots never alias the callee's
+    11 slots). -/
+private theorem bumpSub :
+    ∀ a i, CodeReq.ofProg 0x2000 bumpProgList a = some i → callDemoCr a = some i := by
+  intro a i h
+  obtain ⟨k, hk, rfl⟩ := ofProg_some_range h
+  have hk11 : k < 11 := hk
+  have hnone : CodeReq.ofProg 0x1000 twiceProgList
+      ((0x2000 : Word) + BitVec.ofNat 64 (4 * k)) = none := by
+    apply CodeReq.ofProg_none_range
+    intro k' hk' heq
+    have : k' < 7 := hk'
+    bv_omega
+  simp only [callDemoCr, CodeReq.union, hnone, h]
+
+/-- Code-membership: instruction `idx` of the caller sits in `callDemoCr`. -/
+private theorem twiceAt (idx : Nat) (addr : Word) (instr : Instr)
+    (hk : idx < twiceProgList.length) (hbound : 4 * twiceProgList.length < 2 ^ 64)
+    (haddr : addr = (0x1000 : Word) + BitVec.ofNat 64 (4 * idx))
+    (hget : twiceProgList.get ⟨idx, hk⟩ = instr) :
+    ∀ a i, CodeReq.singleton addr instr a = some i → callDemoCr a = some i := by
+  have m := CodeReq.ofProg_lookup_addr (0x1000 : Word) twiceProgList idx addr hk hbound haddr
+  rw [hget] at m
+  exact fun a i h => twiceSub a i (CodeReq.singleton_mono m a i h)
+
+-- ============================================================================
+-- Address / word helpers.
+-- ============================================================================
+
+private theorem add_sext0 (x : Word) : x + signExtend12 (0 : BitVec 12) = x := by
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_add, show (signExtend12 (0 : BitVec 12)).toNat = 0 from by decide,
+      Nat.add_zero, Nat.mod_eq_of_lt x.isLt]
+
+/-- The callee's slot 0 is the deepest free-stack cell. -/
+private theorem slot0_addr (sp : Word) :
+    (sp + signExtend12 (-16 : BitVec 12)) + signExtend12 (0 : BitVec 12)
+      = sp - BitVec.ofNat 64 (8 * 2) := by
+  rw [show signExtend12 (-16 : BitVec 12) = (-16 : Word) from by decide,
+      show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+      show BitVec.ofNat 64 (8 * 2) = (16 : Word) from by decide]
+  bv_omega
+
+/-- The callee's slot 8 is the shallow free-stack cell. -/
+private theorem slot8_addr (sp : Word) :
+    (sp + signExtend12 (-16 : BitVec 12)) + signExtend12 (8 : BitVec 12)
+      = sp - BitVec.ofNat 64 (8 * 1) := by
+  rw [show signExtend12 (-16 : BitVec 12) = (-16 : Word) from by decide,
+      show signExtend12 (8 : BitVec 12) = (8 : Word) from by decide,
+      show BitVec.ofNat 64 (8 * 1) = (8 : Word) from by decide]
+  bv_omega
+
+private theorem frameRestore16 (sp : Word) :
+    (sp + signExtend12 (-16 : BitVec 12)) + signExtend12 (16 : BitVec 12) = sp := by
+  rw [show signExtend12 (-16 : BitVec 12) = (-16 : Word) from by decide,
+      show signExtend12 (16 : BitVec 12) = (16 : Word) from by decide]
+  bv_omega
+
+private theorem frameRestore8 (sp : Word) :
+    (sp + signExtend12 (-8 : BitVec 12)) + signExtend12 (8 : BitVec 12) = sp := by
+  rw [show signExtend12 (-8 : BitVec 12) = (-8 : Word) from by decide,
+      show signExtend12 (8 : BitVec 12) = (8 : Word) from by decide]
+  bv_omega
+
+-- ============================================================================
+-- The callee's whole-routine calling contract (an `abiFrame_spec` instance,
+-- reshaped onto the free-stack region).
+-- ============================================================================
+
+/-- Callee entry register values: `ra ↦ ret`, `s0 ↦ arb8` (the caller's
+    callee-saved value, arbitrary — the body clobbers it). -/
+def bumpVals (ret arb8 : Word) : Reg → Word :=
+  fun r => match r with | .x1 => ret | .x8 => arb8 | _ => 0
+
+/-- Post-body values: `ra` untouched, `s0 ↦ ptr` (the body's pointer copy). -/
+def bumpVals' (ret ptr : Word) : Reg → Word :=
+  fun r => match r with | .x1 => ret | .x8 => ptr | _ => 0
+
+/-- **The callee's calling contract**: entered at `0x2000` with any aligned
+    return address in `ra`, any `sp`, and TWO owned free-stack dwords below
+    `sp` (its frame space), it returns to `ra` with `sp`/`ra`/`s0` intact,
+    the free stack released (owned again), and `[a0]` incremented.  Derived
+    from `abiFrame_spec`; the exact `hcallee` shape `abiFrameCall_spec`
+    consumes. -/
+theorem bumpCall_spec (spVal ret ptr arb8 arb11 v : Word)
+    (halign : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin 11 (0x2000 : Word) ret callDemoCr
+      (((.x1 : Reg) ↦ᵣ ret) ** (.x2 ↦ᵣ spVal) ** stackFree spVal 2
+        ** ((.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ arb11) ** (ptr ↦ₘ v)))
+      (((.x1 : Reg) ↦ᵣ ret) ** (.x2 ↦ᵣ spVal) ** stackFree spVal 2
+        ** ((.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ (v + 1))
+          ** (ptr ↦ₘ (v + 1)))) := by
+  -- The body core: mv ; ld ; addi ; sd over the callee's slice.
+  have hcore : cpsTripleWithin 4 (0x200C : Word) (0x201C : Word) callDemoCr
+      ((.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ arb11) ** (ptr ↦ₘ v))
+      ((.x8 ↦ᵣ ptr) ** (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ (v + 1)) ** (ptr ↦ₘ (v + 1))) := by
+    refine cpsTripleWithin_extend_code
+      (fun a i h => bumpSub a i
+        (CodeReq.ofProg_mono_sub (0x2000 : Word) (0x200C : Word) bumpProgList
+          bumpBody 3 (by decide) (by rfl) (by decide) (by decide) a i h)) ?_
+    show cpsTripleWithin 4 (0x200C : Word) (0x201C : Word)
+      (CodeReq.ofProg (0x200C : Word) bumpBody) _ _
+    simp only [bumpBody]
+    simp only [CodeReq.ofProg_cons, CodeReq.ofProg_nil, CodeReq.union_empty_right]
+    have hmv := mv_spec_gen_within .x8 .x10 ptr arb8 (0x200C : Word) (by decide)
+    have hld := ld_spec_gen_within .x11 .x8 ptr arb11 v (0 : BitVec 12)
+      (0x2010 : Word) (by decide)
+    rw [add_sext0] at hld
+    have haddi := addi_spec_gen_same_within .x11 v (1 : BitVec 12) (0x2014 : Word)
+      (by decide)
+    rw [show v + signExtend12 (1 : BitVec 12) = v + 1 from by
+      rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide]] at haddi
+    have hsd := sd_spec_gen_within .x8 .x11 ptr (v + 1) v (0 : BitVec 12)
+      (0x2018 : Word)
+    rw [add_sext0] at hsd
+    runBlock hmv hld haddi hsd
+  -- The abiFrame instance.
+  have h := abiFrame_spec (base := 0x2000) (sp0 := spVal) (ret := ret)
+    (negImm := -16) (posImm := 16)
+    (frame := bumpFrame) (raOfs := 0) (sregs := [(.x8, 8)])
+    (vals := bumpVals ret arb8) (vals' := bumpVals' ret ptr)
+    (body := bumpBody) (bodySteps := 4)
+    (callerPre := (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ arb11) ** (ptr ↦ₘ v))
+    (callerPost := (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ (v + 1)) ** (ptr ↦ₘ (v + 1)))
+    (cr := callDemoCr)
+    (hframe := rfl)
+    (hne := by decide)
+    (hbound := by decide)
+    (hprogBound := by decide)
+    (hret := rfl)
+    (halign := halign)
+    (hframeRestore := frameRestore16 spVal)
+    (hcpF := by pcFree)
+    (hcpF' := by pcFree)
+    (hsub := fun a i h => bumpSub a i h)
+    (hbody := by
+      have hentry : (0x2000 : Word) + BitVec.ofNat 64 (4 * (1 + bumpFrame.length))
+          = (0x200C : Word) := by decide
+      have hexit : (0x2000 : Word)
+            + BitVec.ofNat 64 (4 * (1 + bumpFrame.length + bumpBody.length))
+          = (0x201C : Word) := by decide
+      rw [hentry, hexit]
+      simp only [bumpFrame, regsAt, frameSlotsSaved, bumpVals, bumpVals',
+        List.foldr_cons, List.foldr_nil, sepConj_emp_right']
+      have hframed := cpsTripleWithin_frameR
+        ((.x2 ↦ᵣ (spVal + signExtend12 (-16 : BitVec 12))) ** ((.x1 : Reg) ↦ᵣ ret)
+          ** (((spVal + signExtend12 (-16 : BitVec 12))
+                + signExtend12 (0 : BitVec 12)) ↦ₘ ret)
+          ** (((spVal + signExtend12 (-16 : BitVec 12))
+                + signExtend12 (8 : BitVec 12)) ↦ₘ arb8))
+        (by pcFree) hcore
+      exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+        (fun _ hq => by xperm_hyp hq) hframed)
+  -- Reshape: `frameSlotsOwn`/`frameSlotsSaved` ↔ the free-stack region.
+  rw [show (11 : Nat) = 1 + bumpFrame.length + 4 + bumpFrame.length + 1 + 1 from rfl]
+  refine cpsTripleWithin_weaken (fun h2 hp => ?_) (fun h2 hq => ?_) h
+  · -- pre: contract shape ⊢ abiFrame shape (stackFree → frameSlotsOwn).
+    simp only [bumpFrame, regsAt, frameSlotsOwn, bumpVals, List.foldr_cons,
+      List.foldr_nil, sepConj_emp_right', slot0_addr spVal, slot8_addr spVal]
+    simp only [stackFree_succ, stackFree_zero, sepConj_emp_right'] at hp
+    xperm_hyp hp
+  · -- post: abiFrame shape ⊢ contract shape (frameSlotsSaved → stackFree).
+    simp only [bumpFrame, regsAt, frameSlotsSaved, bumpVals, List.foldr_cons,
+      List.foldr_nil, sepConj_emp_right'] at hq
+    -- pull the two saved-value cells to the front, release them to ownership
+    have hq1 : ((((spVal + signExtend12 (-16 : BitVec 12))
+            + signExtend12 (0 : BitVec 12)) ↦ₘ ret)
+          ** (((spVal + signExtend12 (-16 : BitVec 12))
+            + signExtend12 (8 : BitVec 12)) ↦ₘ arb8)
+          ** (.x2 ↦ᵣ spVal) ** ((.x1 : Reg) ↦ᵣ ret) ** (.x8 ↦ᵣ arb8)
+          ** (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ (v + 1)) ** (ptr ↦ₘ (v + 1))) h2 := by
+      xperm_hyp hq
+    rw [slot0_addr spVal, slot8_addr spVal] at hq1
+    have hq2 := sepConj_mono memIs_implies_memOwn
+      (sepConj_mono memIs_implies_memOwn (fun _ hh => hh)) h2 hq1
+    simp only [stackFree_succ, stackFree_zero, sepConj_emp_right']
+    xperm_hyp hq2
+
+-- ============================================================================
+-- The caller: two composed calls inside its own frame.
+-- ============================================================================
+
+/-- Caller entry values: just `ra ↦ ret`. -/
+def twiceVals (ret : Word) : Reg → Word :=
+  fun r => match r with | .x1 => ret | _ => 0
+
+/-- Post-body values: `ra` holds the SECOND call's link address — the body
+    genuinely clobbered it twice; the epilogue restores from the slot. -/
+def twiceVals' : Reg → Word :=
+  fun r => match r with | .x1 => (0x1010 : Word) | _ => 0
+
+/-- **The whole-caller ABI contract.**  Running `twice` from `0x1000` with an
+    aligned return address, a stack pointer `sp0`, its own 1-slot frame
+    space, and TWO further free-stack dwords below its frame (the callee's
+    space), returns to `ret` with:
+
+    * `sp` and `ra` restored to ENTRY values — `ra` was genuinely clobbered
+      by both `jal`s (`vals' .x1 = 0x1010`, the second link); restoration is
+      derived from the caller's saved-`ra` slot, which both callee runs
+      provably could not touch (it is framed out of their footprint);
+    * the dword at `[a0]` incremented twice (`v + 1 + 1`) — the composed
+      callee effects;
+    * `s0` still `arb8` (the callee clobbered and restored it, twice), and
+      the borrowed free stack owned again. -/
+theorem twiceFrame_spec (sp0 ret ptr arb8 arb11 v : Word)
+    (halign : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin 29 (0x1000 : Word) ret callDemoCr
+      ((.x2 ↦ᵣ sp0) ** regsAt twiceFrame (twiceVals ret)
+        ** frameSlotsOwn twiceFrame (sp0 + signExtend12 (-8 : BitVec 12))
+        ** (stackFree (sp0 + signExtend12 (-8 : BitVec 12)) 2
+          ** (.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ arb11) ** (ptr ↦ₘ v)))
+      ((.x2 ↦ᵣ sp0) ** regsAt twiceFrame (twiceVals ret)
+        ** frameSlotsSaved twiceFrame (sp0 + signExtend12 (-8 : BitVec 12))
+            (twiceVals ret)
+        ** (stackFree (sp0 + signExtend12 (-8 : BitVec 12)) 2
+          ** (.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ (v + 1 + 1))
+          ** (ptr ↦ₘ (v + 1 + 1)))) := by
+  set newSp := sp0 + signExtend12 (-8 : BitVec 12) with hNS
+  -- ---- the two composed calls (the abiFrame body) ----
+  -- call 1: jal at 0x1008 → bump, back to 0x100C.
+  have hb1 := bumpCall_spec newSp ((0x1008 : Word) + 4) ptr arb8 arb11 v
+    (by decide)
+  have hcall1 := abiFrameCall_spec (cr := callDemoCr)
+    (A := 0x1008) (calleeEntry := 0x2000) (vOld := ret) (spVal := newSp)
+    (offset := (0xFF8 : BitVec 21)) (m := 2) (n := 11)
+    (calleePre := (.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ arb11) ** (ptr ↦ₘ v))
+    (calleePost := (.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ (v + 1))
+      ** (ptr ↦ₘ (v + 1)))
+    (F := ((newSp + signExtend12 (0 : BitVec 12)) ↦ₘ ret))
+    (by decide)
+    (twiceAt 2 (0x1008 : Word) (.JAL .x1 (0xFF8 : BitVec 21)) (by decide) (by decide)
+      (by decide) (by rfl))
+    (by pcFree) (by pcFree)
+    hb1
+  -- call 2: jal at 0x100C → bump, back to 0x1010.
+  have hb2 := bumpCall_spec newSp ((0x100C : Word) + 4) ptr arb8 (v + 1) (v + 1)
+    (by decide)
+  have hcall2 := abiFrameCall_spec (cr := callDemoCr)
+    (A := 0x100C) (calleeEntry := 0x2000) (vOld := (0x1008 : Word) + 4)
+    (spVal := newSp) (offset := (0xFF4 : BitVec 21)) (m := 2) (n := 11)
+    (calleePre := (.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ (v + 1))
+      ** (ptr ↦ₘ (v + 1)))
+    (calleePost := (.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ (v + 1 + 1))
+      ** (ptr ↦ₘ (v + 1 + 1)))
+    (F := ((newSp + signExtend12 (0 : BitVec 12)) ↦ₘ ret))
+    (by decide)
+    (twiceAt 3 (0x100C : Word) (.JAL .x1 (0xFF4 : BitVec 21)) (by decide) (by decide)
+      (by decide) (by rfl))
+    (by pcFree) (by pcFree)
+    hb2
+  -- chain the two calls
+  have hchain := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp)
+    hcall1 hcall2
+  rw [show (0x100C : Word) + 4 = (0x1010 : Word) from by decide] at hchain
+  -- ---- the abiFrame wrapper ----
+  have h := abiFrame_spec (base := 0x1000) (sp0 := sp0) (ret := ret)
+    (negImm := -8) (posImm := 8)
+    (frame := twiceFrame) (raOfs := 0) (sregs := [])
+    (vals := twiceVals ret) (vals' := twiceVals')
+    (body := twiceBody) (bodySteps := (1 + 11) + (1 + 11))
+    (callerPre := stackFree newSp 2 ** (.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr)
+      ** (.x11 ↦ᵣ arb11) ** (ptr ↦ₘ v))
+    (callerPost := stackFree newSp 2 ** (.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr)
+      ** (.x11 ↦ᵣ (v + 1 + 1)) ** (ptr ↦ₘ (v + 1 + 1)))
+    (cr := callDemoCr)
+    (hframe := rfl)
+    (hne := by decide)
+    (hbound := by decide)
+    (hprogBound := by decide)
+    (hret := rfl)
+    (halign := halign)
+    (hframeRestore := frameRestore8 sp0)
+    (hcpF := pcFree_sepConj (pcFree_stackFree _ _) (by pcFree))
+    (hcpF' := pcFree_sepConj (pcFree_stackFree _ _) (by pcFree))
+    (hsub := fun a i h => twiceSub a i h)
+    (hbody := by
+      have hentry : (0x1000 : Word) + BitVec.ofNat 64 (4 * (1 + twiceFrame.length))
+          = (0x1008 : Word) := by decide
+      have hexit : (0x1000 : Word)
+            + BitVec.ofNat 64 (4 * (1 + twiceFrame.length + twiceBody.length))
+          = (0x1010 : Word) := by decide
+      rw [hentry, hexit]
+      simp only [twiceFrame, regsAt, frameSlotsSaved, twiceVals, twiceVals',
+        List.foldr_cons, List.foldr_nil, sepConj_emp_right']
+      refine cpsTripleWithin_weaken (fun _ hp => ?_) (fun _ hq => ?_) hchain
+      · rw [← hNS] at hp
+        xperm_hyp hp
+      · rw [← hNS]
+        xperm_hyp hq)
+  rw [show (29 : Nat)
+      = 1 + twiceFrame.length + ((1 + 11) + (1 + 11)) + twiceFrame.length + 1 + 1
+    from rfl]
+  exact h
+
+#print axioms twiceFrame_spec
+#print axioms bumpCall_spec
+
+end AbiFrameCallDemo
+end SAsm
+end EvmAsm.Rv64

--- a/PLAN.md
+++ b/PLAN.md
@@ -2707,6 +2707,28 @@ the loop header (no base-generalization needed). Byte-tie:
 fixture + GuestAddrs + coverage doc regenerated. Axioms `[propext,
 Classical.choice, Quot.sound]`. Remaining candidates for the same treatment:
 `witnessCodesValidateLengths_prog`, `hpDecodeNibbles_prog`.
+**Frame + cross-call composition landed** (bead evm-asm-4ch8f.76.2, branch
+`feat/abi-frame-call`): `SAsm/AbiFrameCall.lean` adds `stackFree sp k` (the
+free-stack region below `sp`: `k` genuinely owned `memOwn` dwords a callee
+carves its own frame from — no arbitrary-stack hole; `stackFree_split` frames
+the unused depth), `jal_link_spec_within` (the linking `jal ra` step), and the
+call rules `callWithin_spec`/`abiFrameCall_spec` (compose a `jal ra` with a
+callee whole-routine `cpsTripleWithin` contract — the `abiFrame_spec` /
+`FnHandle.sound` shape at `ret := A + 4`; the caller's frame slots + saved-ra
+slot are framed out of the callee footprint, so their preservation across the
+call is PROVEN by separation; sequences of calls chain by ordinary
+sequencing, each `jal` re-clobbering `ra` via the free `vOld`).  Notably
+`abiFrame_spec` needed NO generalization: its `vals'` is already free
+(including `.x1`), so the epilogue restores a call-clobbered `ra` from the
+slot.  `SAsm/AbiFrameCallDemo.lean`: a framed caller (`twice`, saves only
+`ra`) calls a framed callee (`bump`, own 16-byte frame carved from the
+caller's `stackFree`, increments `[a0]`, clobbers `s0`) TWICE via real
+`jal`s; `twiceFrame_spec` restores `sp`/`ra` to entry with `[a0] = v + 2`.
+Byte-transparent (`#guard`/`rfl`), additive, classical-3 axioms.  This is the
+bridge the pre-existing blocker beads (4ch8f.58.3.17.1 "FnHandle call bridge
+with s-register locals", 4ch8f.58.3.22.1 "exact-ra call bridge") were waiting
+on; porting a real cross-calling routine additionally needs its callees'
+whole-routine contracts (each its own port).
 Indirect calls landed
 (`Stmt.callReg`, bead evm-asm-4ch8f.4): `jalr ra, rs, 0` against a
 finite handle table — `.pre` VC = register pins some handle's entry


### PR DESCRIPTION
Completes the ABI-frame story for **cross-calling** sp-frame routines (the ~218 load-bearing block-verdict / MPT / tx / crypto routines), following the loop-leaf unlock in #9975. Bead `evm-asm-4ch8f.76.2` (child of `4ch8f.76`); refs #9949 #9956 #9962 #9975.

## Finding first (per the task): does `abiFrame_spec` already allow the body to clobber `ra`?

**Yes.** `abiFrame_spec`'s `vals'` (the body-clobbered register values) is completely free — including `vals' .x1` — and `loadSeq_spec` restores every saved register from its frame slot regardless of the clobbered value. The ra-clobber-across-call is already supported at the frame level; **no generalization of `abiFrame_spec` was needed**. The genuinely new pieces are the stack region and the call rule.

## The construct (`EvmAsm/Rv64/SAsm/AbiFrameCall.lean`)

- **`stackFree sp k`** — the free-stack region below `sp`: `k` genuinely **owned** dword cells (`memOwn` at `sp - 8 … sp - 8k`) that a callee carves its own frame from and releases on return. Ordinary owned-memory atoms ⇒ disjoint through `**` from the caller's frame slots, saved-`ra` slot, and every caller region — **no arbitrary-stack read/write hole**. `stackFree_split` frames off the depth a callee doesn't use.
- **`jal_link_spec_within`** — the one-step linking jump `jal x1, offset` (`ra := A + 4`, control to `A + offset`); the direct analogue of `jalr_call_spec_within`.
- **`callWithin_spec`** — composes one `jal ra` with a callee **whole-routine `cpsTripleWithin` contract**: exactly the shape every `abiFrame_spec` conclusion and every `FnHandle.sound` instance already has, instantiated at `ret := A + 4`. The incumbent `ra` is a free `vOld`, so a **sequence of N calls** chains by ordinary sequencing — each `jal` re-clobbers `ra` with its own link.
- **`abiFrameCall_spec`** — the frame-aware rule consumed inside an `abiFrame_spec` body hypothesis: the callee enters with `sp = spVal` and `stackFree spVal m`, returns with `sp` back at `spVal` and the stack **released**; `F` (the caller's frame slots + saved-`ra` slot + unused stack + other regions) rides framed through the call — **preservation across the call is proven by separation, never assumed**.

## The demo (`EvmAsm/Rv64/SAsm/AbiFrameCallDemo.lean`)

- **`bump`** (callee, `0x2000`, 11 instrs): has its **own 16-byte frame** (saves `ra` + `s0` — its body genuinely clobbers callee-saved `s0`), increments the dword at `[a0]`. `bumpCall_spec` derives its calling contract from `abiFrame_spec`, reshaping `frameSlotsOwn`/`frameSlotsSaved` onto the caller's free-stack cells (`memIs → memOwn` release on return).
- **`twice`** (caller, `0x1000`, 7 instrs): saves only `ra`, then **two real `jal ra` calls** to `bump` — exercising the sequence case; the second link (`0x1010`) overwrites the first (`0x100C`), and `vals' .x1 = 0x1010` records the genuine clobber. `twiceFrame_spec` (via `abiFrame_spec` + 2× `abiFrameCall_spec`) concludes:
  - `sp` and `ra` restored to **entry** values (restoration derived from the caller's saved-`ra` slot, which both callee runs provably could not touch);
  - `[a0] = v + 1 + 1` — the composed callee effects;
  - `s0` still holds the caller's value (clobbered + restored by the callee's own frame, twice), and the borrowed free stack is owned again.
- `#guard`/`rfl` byte-transparency for both `abiFrameProg` flattens (each call site is exactly one `JAL`).

## Gates

- Full `lake build` green; **additive** (`cpsTripleWithin` only — `Ast`/`Vc`/`StmtSound*`/`blockOk` untouched; `callAt` not modified).
- `check-forbidden-tactics` OK; `check-layering` OK; `check-axioms` OK — `#print axioms bumpCall_spec / twiceFrame_spec` = `[propext, Classical.choice, Quot.sound]`; no `sorry`/`maxHeartbeats`/`maxRecDepth`.

## Stretch item (real cross-call routine) — deferred, with assessment

Every emitted cross-call candidate's callees must first have **whole-routine contracts** (`FnHandle.sound` instances or `abiFrame_spec` derivations) — each is its own port, a second blocker beyond this construct. The pre-existing blocker beads are exactly the consumers of this bridge: `4ch8f.58.3.17.1` ("ABI-frame caller body needs FnHandle call bridge with s-register locals") and `4ch8f.58.3.22.1` ("exact-ra call bridge") — `callWithin_spec` consumes `FnHandle.sound`'s shape directly at `ret := A + 4`. Recommend stacked follow-ups per candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)