### PR TITLE
feat(sasm): port-automation — FramePort tactics + bottom-test loop + dwordsIs + first tactic-driven cross-call port (bnq_set_one)

### DIFF
--- a/EvmAsm/Codegen/Programs/Bn254Fq12SetOneSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254Fq12SetOneSAsm.lean
@@ -1,0 +1,442 @@
+/-
+  EvmAsm.Codegen.Programs.Bn254Fq12SetOneSAsm
+
+  **The first tactic-driven cross-call sp-frame port** (bead
+  evm-asm-4ch8f.58.3.17, unblocked by the `abiFrameCall_spec` bridge and the
+  `FramePort` automation): `bnq_set_one`, byte-TRANSPARENT (the existing
+  emitted `bnqSetOne_prog` already IS an `abiFrameProg` flatten — no re-emit,
+  no guest-byte change):
+
+      bnq_set_one:  addi sp, sp, -16
+                    sd   ra, 0(sp)
+                    sd   s0, 8(sp)
+                    mv   s0, a0            -- clobbers callee-saved s0
+                    jal  ra, bnq_zero      -- zero all 48 dwords (clobbers ra!)
+                    li   t0, 1
+                    sd   t0 -> 0(s0)       -- coefficient 0 := 1
+                    ld   ra, 0(sp)
+                    ld   s0, 8(sp)
+                    addi sp, sp, +16
+                    ret
+
+  The callee `bnq_zero` gets a FLAT whole-routine contract
+  (`bnqZeroFlat_spec`) — the `cpsTripleWithin` shape `callWithin_spec`
+  consumes — with its bottom-test store loop discharged by the new
+  `countdownLoopBottom_spec` over the writable `dwordsIs` region and the
+  genuine invariant "the first `48 - n` dwords are already zero".  (This is
+  an independent flat derivation alongside the structured
+  `Bn254Fq12ZeroSAsm.bnqZeroFn_spec`; the flat form is what a frame-exposed
+  caller body can compose — exactly the gap bead 4ch8f.58.3.17.1 recorded.)
+
+  `bnqSetOneFrame_spec` is the whole-routine ABI contract, wrapped by
+  `abi_frame`: on return `sp`, `ra` (clobbered by the real `jal`!), and `s0`
+  (clobbered by the body) are restored to entry, and the FQ12 at the entry
+  `a0` holds ONE — dword 0 = 1, the other 47 dwords = 0 — the genuine,
+  unweakened semantics.  `a0` itself ends at `dst + 384` (advanced by
+  `bnq_zero`), exactly as the machine leaves it.
+
+  Byte-tie: `#guard`/`rfl` against the emitted `bnqSetOne_prog` (including
+  the concrete guest-linked `jalOff`) and the `GuestAddrs` anchors.
+-/
+
+import EvmAsm.Rv64.SAsm.FramePort
+import EvmAsm.Rv64.SAsm.Fn
+import EvmAsm.Rv64.Tactics.RunBlock
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Codegen.Programs.Bn254Fq12
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.Tactics
+
+namespace Bn254Fq12SetOneSAsm
+
+-- ============================================================================
+-- Anchors and byte-ties.
+-- ============================================================================
+
+-- The two routines are adjacent in the guest text: `bnq_zero` (6 slots)
+-- immediately precedes `bnq_set_one`.
+#guard GuestAddrs.bnq_zero = 0x800305E8
+#guard GuestAddrs.bnq_set_one = 0x80030600
+#guard GuestAddrs.bnq_zero + 4 * bnqZero_prog.length = GuestAddrs.bnq_set_one
+
+/-- The caller's 2-slot frame: `ra` at 0, `s0` at 8. -/
+def setOneFrame : FrameDesc := [(.x1, 0), (.x8, 8)]
+
+/-- The caller body: pointer copy, the cross-call, the coefficient-0 store. -/
+def setOneBody : List Instr :=
+  [ .MV .x8 .x10,
+    .JAL .x1 (jalOff GuestAddrs.bnq_zero (GuestAddrs.bnq_set_one + 16)),
+    .LI .x5 (1 : Word),
+    .SD .x8 .x5 (0 : BitVec 12) ]
+
+-- Byte-transparency: the emitted `bnqSetOne_prog` IS the abiFrameProg
+-- flatten of this frame + body — verified == emitted, bytes unchanged.
+#guard abiFrameProg (-16 : BitVec 12) (16 : BitVec 12) setOneFrame setOneBody
+  = bnqSetOne_prog
+
+/-- Byte-transparency, kernel-checked. -/
+theorem setOneProg_eq :
+    abiFrameProg (-16 : BitVec 12) (16 : BitVec 12) setOneFrame setOneBody
+      = bnqSetOne_prog := rfl
+
+/-- The verification `CodeReq`: both adjacent routines, at their guest
+    addresses. -/
+def bnqCr : CodeReq :=
+  CodeReq.ofProg (0x800305E8 : Word) (bnqZero_prog ++ bnqSetOne_prog)
+
+-- ============================================================================
+-- Word / list helpers.
+-- ============================================================================
+
+private theorem add_sext0 (x : Word) : x + signExtend12 (0 : BitVec 12) = x := by
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_add, show (signExtend12 (0 : BitVec 12)).toNat = 0 from by decide,
+      Nat.add_zero, Nat.mod_eq_of_lt x.isLt]
+
+private theorem add_ofNat_zero (x : Word) : x + BitVec.ofNat 64 0 = x := by
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_add, BitVec.toNat_ofNat, Nat.zero_mod, Nat.add_zero,
+      Nat.mod_eq_of_lt x.isLt]
+
+private theorem addr_step8 (dst : Word) (p : Nat) :
+    (dst + BitVec.ofNat 64 (8 * p)) + signExtend12 (8 : BitVec 12)
+      = dst + BitVec.ofNat 64 (8 * (p + 1)) := by
+  rw [show signExtend12 (8 : BitVec 12) = BitVec.ofNat 64 8 from by decide,
+      BitVec.add_assoc]
+  congr 1
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_add, BitVec.toNat_ofNat]
+  omega
+
+private theorem cnt_step_down (n : Nat) :
+    BitVec.ofNat 64 (n + 1) + signExtend12 (-1 : BitVec 12) = BitVec.ofNat 64 n := by
+  have e1 : BitVec.ofNat 64 (n + 1) = BitVec.ofNat 64 n + 1 := by
+    rw [show (1 : Word) = BitVec.ofNat 64 1 from rfl]
+    apply BitVec.eq_of_toNat_eq
+    simp only [BitVec.toNat_add, BitVec.toNat_ofNat]
+    omega
+  rw [e1, show signExtend12 (-1 : BitVec 12) = (-1 : Word) from by decide,
+      BitVec.add_assoc, show (1 : Word) + (-1 : Word) = 0 from by decide]
+  exact BitVec.add_zero _
+
+/-- Zeroing the next dword extends the zero prefix. -/
+private theorem zero_prefix_step (vs : List Word) (p : Nat) (hp : p < vs.length) :
+    (List.replicate p (0 : Word) ++ vs.drop p).set p 0
+      = List.replicate (p + 1) (0 : Word) ++ vs.drop (p + 1) := by
+  induction p generalizing vs with
+  | zero =>
+    cases vs with
+    | nil => exact absurd hp (by simp)
+    | cons v t => rfl
+  | succ k ih =>
+    cases vs with
+    | nil => exact absurd hp (by simp)
+    | cons v t =>
+      have hk : k < t.length := by simpa using hp
+      show ((0 : Word) :: (List.replicate k 0 ++ t.drop k)).set (k + 1) 0
+          = (0 : Word) :: (List.replicate (k + 1) 0 ++ t.drop (k + 1))
+      rw [List.set_cons_succ, ih t hk]
+
+-- ============================================================================
+-- The callee: a FLAT whole-routine contract for `bnq_zero`.
+-- ============================================================================
+
+/-- Loop invariant at remaining count `n`: the cursor has advanced past the
+    `48 - n` dwords already zeroed. -/
+def zeroInvF (dst : Word) (vs : List Word) (n : Nat) : Assertion :=
+  (.x10 ↦ᵣ (dst + BitVec.ofNat 64 (8 * (48 - n))))
+    ** dwordsIs dst (List.replicate (48 - n) (0 : Word) ++ vs.drop (48 - n))
+
+theorem pcFree_zeroInvF (dst : Word) (vs : List Word) (n : Nat) :
+    (zeroInvF dst vs n).pcFree := by
+  unfold zeroInvF
+  pcf
+
+/-- The per-iteration body (`sd ; addi a0 ; addi ctr`, `0x800305EC →
+    0x800305F8`): zero one dword, advance, decrement. -/
+private theorem zeroLoopBody_spec (dst : Word) (vs : List Word)
+    (hlen : vs.length = 48) (n : Nat) (hn : n < 48) :
+    cpsTripleWithin 3 (0x800305EC : Word) (0x800305F8 : Word) bnqCr
+      ((.x7 ↦ᵣ BitVec.ofNat 64 (n + 1)) ** (Reg.x0 ↦ᵣ (0 : Word))
+        ** zeroInvF dst vs (n + 1))
+      ((.x7 ↦ᵣ BitVec.ofNat 64 n) ** (Reg.x0 ↦ᵣ (0 : Word))
+        ** zeroInvF dst vs n) := by
+  have hpn : 48 - n = (48 - (n + 1)) + 1 := by omega
+  set p := 48 - (n + 1) with hp
+  set L := List.replicate p (0 : Word) ++ vs.drop p with hL
+  have hLlen : p < L.length := by
+    rw [hL]
+    simp only [List.length_append, List.length_replicate, List.length_drop, hlen]
+    omega
+  obtain ⟨front, rest, hf, hr, heq1, heq2⟩ := dwordsIs_at_set dst L p 0 hLlen
+  have hset : L.set p 0
+      = List.replicate (p + 1) (0 : Word) ++ vs.drop (p + 1) := by
+    rw [hL]
+    exact zero_prefix_step vs p (by omega)
+  simp only [zeroInvF, hpn, ← hp, ← hL]
+  rw [heq1, ← hset, heq2]
+  have hsd := sd_x0_spec_gen_within .x10 (dst + BitVec.ofNat 64 (8 * p))
+    (L.getD p 0) (0 : BitVec 12) (0x800305EC : Word)
+  rw [add_sext0] at hsd
+  rw [show (0x800305EC : Word) + 4 = (0x800305F0 : Word) from by decide] at hsd
+  have hsdC := liftCode (cr' := bnqCr) hsd (by code_mem)
+  have ha1 := addi_spec_gen_same_within .x10 (dst + BitVec.ofNat 64 (8 * p))
+    (8 : BitVec 12) (0x800305F0 : Word) (by decide)
+  rw [addr_step8] at ha1
+  rw [show (0x800305F0 : Word) + 4 = (0x800305F4 : Word) from by decide] at ha1
+  have ha1C := liftCode (cr' := bnqCr) ha1 (by code_mem)
+  have ha2 := addi_spec_gen_same_within .x7 (BitVec.ofNat 64 (n + 1))
+    (-1 : BitVec 12) (0x800305F4 : Word) (by decide)
+  rw [cnt_step_down] at ha2
+  rw [show (0x800305F4 : Word) + 4 = (0x800305F8 : Word) from by decide] at ha2
+  have ha2C := liftCode (cr' := bnqCr) ha2 (by code_mem)
+  have hFrontRest : (front ** rest).pcFree := pcFree_sepConj hf hr
+  have hsdF := cpsTripleWithin_frameR
+    ((.x7 ↦ᵣ BitVec.ofNat 64 (n + 1)) ** (Reg.x0 ↦ᵣ (0 : Word)) ** front ** rest)
+    (by repeat first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact hf
+        | exact hr) hsdC
+  have ha1F := cpsTripleWithin_frameR
+    ((.x7 ↦ᵣ BitVec.ofNat 64 (n + 1)) ** (Reg.x0 ↦ᵣ (0 : Word))
+      ** ((dst + BitVec.ofNat 64 (8 * p)) ↦ₘ (0 : Word)) ** front ** rest)
+    (by repeat first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact hf
+        | exact hr) ha1C
+  have ha2F := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ (dst + BitVec.ofNat 64 (8 * (p + 1))))
+      ** (Reg.x0 ↦ᵣ (0 : Word))
+      ** ((dst + BitVec.ofNat 64 (8 * p)) ↦ₘ (0 : Word)) ** front ** rest)
+    (by repeat first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact hf
+        | exact hr) ha2C
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hsdF ha1F
+  have s2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s1 ha2F
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) s2
+
+/-- **The flat whole-routine contract for `bnq_zero`** — the exact
+    `cpsTripleWithin` shape `callWithin_spec` consumes: entered at its guest
+    address with any aligned return address in `ra`, a buffer pointer in
+    `a0`, and 48 owned dwords, it returns with all 48 dwords zero, `a0`
+    advanced past the buffer, and `ra` intact. -/
+theorem bnqZeroFlat_spec (ret dst v7 : Word) (vs : List Word)
+    (hlen : vs.length = 48)
+    (halign : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin (1 + 48 * (3 + 1) + 1) (0x800305E8 : Word) ret bnqCr
+      (((.x1 : Reg) ↦ᵣ ret) ** (.x10 ↦ᵣ dst) ** (.x7 ↦ᵣ v7)
+        ** (Reg.x0 ↦ᵣ (0 : Word)) ** dwordsIs dst vs)
+      (((.x1 : Reg) ↦ᵣ ret) ** (.x10 ↦ᵣ (dst + BitVec.ofNat 64 384))
+        ** (.x7 ↦ᵣ BitVec.ofNat 64 0) ** (Reg.x0 ↦ᵣ (0 : Word))
+        ** dwordsIs dst (List.replicate 48 (0 : Word))) := by
+  -- init: li x7, 48
+  have hli := li_spec_gen_within .x7 v7 (48 : Word) (0x800305E8 : Word) (by decide)
+  rw [show (48 : Word) = BitVec.ofNat 64 48 from rfl] at hli
+  rw [show (0x800305E8 : Word) + 4 = (0x800305EC : Word) from by decide] at hli
+  have hliC := liftCode (cr' := bnqCr) hli (by code_mem)
+  have hliF := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ ret) ** (.x10 ↦ᵣ dst) ** (Reg.x0 ↦ᵣ (0 : Word)) ** dwordsIs dst vs)
+    (by pcf) hliC
+  -- the loop, endpoints presented at 48 / 0
+  have hloop : cpsTripleWithin (48 * (3 + 1)) (0x800305EC : Word) (0x800305FC : Word)
+      bnqCr
+      ((.x7 ↦ᵣ BitVec.ofNat 64 48) ** (Reg.x0 ↦ᵣ (0 : Word)) ** zeroInvF dst vs 48)
+      ((.x7 ↦ᵣ BitVec.ofNat 64 0) ** (Reg.x0 ↦ᵣ (0 : Word)) ** zeroInvF dst vs 0) := by
+    have h := countdownLoopBottom_spec bnqCr (0x800305EC : Word) (0x800305F8 : Word)
+      .x7 (-12 : BitVec 13) 3 48 (zeroInvF dst vs)
+      (by decide) (by omega) (by omega) (by decide)
+      (fun n => pcFree_zeroInvF dst vs n)
+      (by code_mem)
+      (fun n hn => zeroLoopBody_spec dst vs hlen n hn)
+    rw [show (0x800305F8 : Word) + 4 = (0x800305FC : Word) from by decide] at h
+    exact h
+  have hstart : zeroInvF dst vs 48
+      = ((.x10 ↦ᵣ dst) ** dwordsIs dst vs) := by
+    unfold zeroInvF
+    rw [show (48 - 48 : Nat) = 0 from rfl, show (8 * 0 : Nat) = 0 from rfl,
+        add_ofNat_zero, List.replicate_zero, List.drop_zero, List.nil_append]
+  have hend : zeroInvF dst vs 0
+      = ((.x10 ↦ᵣ (dst + BitVec.ofNat 64 384))
+          ** dwordsIs dst (List.replicate 48 (0 : Word))) := by
+    unfold zeroInvF
+    rw [show (48 - 0 : Nat) = 48 from rfl, show (8 * 48 : Nat) = 384 from rfl,
+        show vs.drop 48 = [] from by rw [← hlen]; exact List.drop_length,
+        List.append_nil]
+  rw [hstart, hend] at hloop
+  have hloopF := cpsTripleWithin_frameR ((.x1 : Reg) ↦ᵣ ret) (by pcf) hloop
+  -- ret
+  have hret := Fn.jalr_ret_spec (0x800305FC : Word) ret halign
+    (P := (.x10 ↦ᵣ (dst + BitVec.ofNat 64 384)) ** (.x7 ↦ᵣ BitVec.ofNat 64 0)
+      ** (Reg.x0 ↦ᵣ (0 : Word)) ** dwordsIs dst (List.replicate 48 (0 : Word)))
+    (by pcf)
+  have hretC := liftCode (cr' := bnqCr) hret (by code_mem)
+  -- chain
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hliF hloopF
+  have s2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s1 hretC
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) s2
+
+-- ============================================================================
+-- The caller: `bnq_set_one` via the frame + cross-call composition.
+-- ============================================================================
+
+/-- Entry values of the saved registers. -/
+def setOneVals (ret arb8 : Word) : Reg → Word :=
+  fun r => match r with | .x1 => ret | .x8 => arb8 | _ => 0
+
+/-- Post-body values: `ra` holds the call's link address (genuinely
+    clobbered by the `jal`; the epilogue restores it from the slot), `s0`
+    the buffer pointer. -/
+def setOneVals' (dst : Word) : Reg → Word :=
+  fun r => match r with | .x1 => (0x80030614 : Word) | .x8 => dst | _ => 0
+
+/-- **The whole-routine ABI contract for `bnq_set_one`.**  On return `sp`,
+    `ra`, and `s0` are restored to ENTRY values (`ra` was clobbered by the
+    real cross-call; `s0` by the body), and the FQ12 at the entry `a0` holds
+    ONE: dword 0 = 1, dwords 1–47 = 0 — the genuine, unweakened semantics.
+    `a0` ends at `dst + 384` exactly as `bnq_zero` leaves it. -/
+theorem bnqSetOneFrame_spec (sp0 ret dst arb8 v5 v7 : Word) (vs : List Word)
+    (hlen : vs.length = 48)
+    (halign : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin
+      (1 + setOneFrame.length + (1 + (1 + (1 + 48 * (3 + 1) + 1)) + 1 + 1)
+        + setOneFrame.length + 1 + 1)
+      (0x80030600 : Word) ret bnqCr
+      ((.x2 ↦ᵣ sp0) ** regsAt setOneFrame (setOneVals ret arb8)
+        ** frameSlotsOwn setOneFrame (sp0 + signExtend12 (-16 : BitVec 12))
+        ** ((.x10 ↦ᵣ dst) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7)
+          ** (Reg.x0 ↦ᵣ (0 : Word)) ** dwordsIs dst vs))
+      ((.x2 ↦ᵣ sp0) ** regsAt setOneFrame (setOneVals ret arb8)
+        ** frameSlotsSaved setOneFrame (sp0 + signExtend12 (-16 : BitVec 12))
+            (setOneVals ret arb8)
+        ** ((.x10 ↦ᵣ (dst + BitVec.ofNat 64 384)) ** regOwn .x5 ** regOwn .x7
+          ** (Reg.x0 ↦ᵣ (0 : Word))
+          ** dwordsIs dst ((1 : Word) :: List.replicate 47 (0 : Word)))) := by
+  -- ---- the single-exit body: mv ; call ; li ; sd ----
+  -- mv s0, a0 (0x8003060C)
+  have hmv := mv_spec_gen_within .x8 .x10 dst arb8 (0x8003060C : Word) (by decide)
+  rw [show (0x8003060C : Word) + 4 = (0x80030610 : Word) from by decide] at hmv
+  have hmvC := liftCode (cr' := bnqCr) hmv (by code_mem)
+  have hmvF := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ ret) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (Reg.x0 ↦ᵣ (0 : Word))
+      ** dwordsIs dst vs)
+    (by pcf) hmvC
+  -- jal ra, bnq_zero (0x80030610): the cross-call.
+  have hcallee := bnqZeroFlat_spec ((0x80030610 : Word) + 4) dst v7 vs hlen (by decide)
+  have hcall := callWithin_spec (0x80030610 : Word) (0x800305E8 : Word) ret
+    (jalOff GuestAddrs.bnq_zero (GuestAddrs.bnq_set_one + 16)) (1 + 48 * (3 + 1) + 1)
+    (by decide) (by code_mem) (by pcf) hcallee
+  rw [show (0x80030610 : Word) + 4 = (0x80030614 : Word) from by decide] at hcall
+  have hcallF := cpsTripleWithin_frameR
+    ((.x8 ↦ᵣ dst) ** (.x5 ↦ᵣ v5)) (by pcf) hcall
+  -- li t0, 1 (0x80030614)
+  have hli := li_spec_gen_within .x5 v5 (1 : Word) (0x80030614 : Word) (by decide)
+  rw [show (0x80030614 : Word) + 4 = (0x80030618 : Word) from by decide] at hli
+  have hliC := liftCode (cr' := bnqCr) hli (by code_mem)
+  have hliF := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ (0x80030614 : Word)) ** (.x8 ↦ᵣ dst)
+      ** (.x10 ↦ᵣ (dst + BitVec.ofNat 64 384)) ** (.x7 ↦ᵣ BitVec.ofNat 64 0)
+      ** (Reg.x0 ↦ᵣ (0 : Word)) ** dwordsIs dst (List.replicate 48 (0 : Word)))
+    (by pcf) hliC
+  -- sd t0 -> 0(s0) (0x80030618): coefficient 0 := 1.
+  obtain ⟨front, rest, hf, hr, heq1, heq2⟩ :=
+    dwordsIs_at_set dst (List.replicate 48 (0 : Word)) 0 1 (by decide)
+  have hcell0 : dst + BitVec.ofNat 64 (8 * 0) = dst := by
+    rw [show (8 * 0 : Nat) = 0 from rfl]
+    exact add_ofNat_zero dst
+  rw [hcell0] at heq1 heq2
+  have hone : (List.replicate 48 (0 : Word)).set 0 1
+      = ((1 : Word) :: List.replicate 47 (0 : Word)) := by decide
+  rw [hone] at heq2
+  have hsd := sd_spec_gen_within .x8 .x5 dst (1 : Word)
+    ((List.replicate 48 (0 : Word)).getD 0 0) (0 : BitVec 12) (0x80030618 : Word)
+  rw [add_sext0] at hsd
+  rw [show (0x80030618 : Word) + 4 = (0x8003061C : Word) from by decide] at hsd
+  have hsdC := liftCode (cr' := bnqCr) hsd (by code_mem)
+  have hsdF := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ (0x80030614 : Word))
+      ** (.x10 ↦ᵣ (dst + BitVec.ofNat 64 384)) ** (.x7 ↦ᵣ BitVec.ofNat 64 0)
+      ** (Reg.x0 ↦ᵣ (0 : Word)) ** front ** rest)
+    (by repeat first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact hf
+        | exact hr) hsdC
+  -- chain: mv ; call ; li ; sd
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hmvF hcallF
+  have s2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s1 hliF
+  have s3 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [heq1] at hp; xperm_hyp hp) s2 hsdF
+  -- the single-exit body triple, in `abiFrame_spec` shape
+  have hbody : cpsTripleWithin (1 + (1 + (1 + 48 * (3 + 1) + 1)) + 1 + 1)
+      ((0x80030600 : Word) + BitVec.ofNat 64 (4 * (1 + setOneFrame.length)))
+      ((0x80030600 : Word)
+        + BitVec.ofNat 64 (4 * (1 + setOneFrame.length + setOneBody.length)))
+      bnqCr
+      ((.x2 ↦ᵣ (sp0 + signExtend12 (-16 : BitVec 12)))
+        ** regsAt setOneFrame (setOneVals ret arb8)
+        ** frameSlotsSaved setOneFrame (sp0 + signExtend12 (-16 : BitVec 12))
+            (setOneVals ret arb8)
+        ** ((.x10 ↦ᵣ dst) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7)
+          ** (Reg.x0 ↦ᵣ (0 : Word)) ** dwordsIs dst vs))
+      ((.x2 ↦ᵣ (sp0 + signExtend12 (-16 : BitVec 12)))
+        ** regsAt setOneFrame (setOneVals' dst)
+        ** frameSlotsSaved setOneFrame (sp0 + signExtend12 (-16 : BitVec 12))
+            (setOneVals ret arb8)
+        ** ((.x10 ↦ᵣ (dst + BitVec.ofNat 64 384)) ** regOwn .x5 ** regOwn .x7
+          ** (Reg.x0 ↦ᵣ (0 : Word))
+          ** dwordsIs dst ((1 : Word) :: List.replicate 47 (0 : Word)))) := by
+    have hentry : (0x80030600 : Word) + BitVec.ofNat 64 (4 * (1 + setOneFrame.length))
+        = (0x8003060C : Word) := by decide
+    have hexit : (0x80030600 : Word)
+          + BitVec.ofNat 64 (4 * (1 + setOneFrame.length + setOneBody.length))
+        = (0x8003061C : Word) := by decide
+    rw [hentry, hexit]
+    simp only [setOneFrame, regsAt, frameSlotsSaved, setOneVals, setOneVals',
+      List.foldr_cons, List.foldr_nil, sepConj_emp_right']
+    have hchainF := cpsTripleWithin_frameR
+      ((.x2 ↦ᵣ (sp0 + signExtend12 (-16 : BitVec 12)))
+        ** (((sp0 + signExtend12 (-16 : BitVec 12))
+              + signExtend12 (0 : BitVec 12)) ↦ₘ ret)
+        ** (((sp0 + signExtend12 (-16 : BitVec 12))
+              + signExtend12 (8 : BitVec 12)) ↦ₘ arb8))
+      (by pcf) s3
+    refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun h hq => ?_)
+      hchainF
+    -- release t0 (`↦ 1`) and the drained counter (`↦ 0`) to ownership;
+    -- reassemble the ONE array from the extracted cell.
+    have hq1 : ((.x5 ↦ᵣ (1 : Word)) ** (.x7 ↦ᵣ BitVec.ofNat 64 0)
+        ** ((.x1 : Reg) ↦ᵣ (0x80030614 : Word)) ** (.x8 ↦ᵣ dst)
+        ** (.x10 ↦ᵣ (dst + BitVec.ofNat 64 384)) ** (Reg.x0 ↦ᵣ (0 : Word))
+        ** dwordsIs dst ((1 : Word) :: List.replicate 47 (0 : Word))
+        ** (.x2 ↦ᵣ (sp0 + signExtend12 (-16 : BitVec 12)))
+        ** (((sp0 + signExtend12 (-16 : BitVec 12))
+              + signExtend12 (0 : BitVec 12)) ↦ₘ ret)
+        ** (((sp0 + signExtend12 (-16 : BitVec 12))
+              + signExtend12 (8 : BitVec 12)) ↦ₘ arb8)) h := by
+      rw [heq2]
+      xperm_hyp hq
+    have hq2 := sepConj_mono (regIs_to_regOwn .x5 _)
+      (sepConj_mono (regIs_to_regOwn .x7 _) (fun _ hh => hh)) h hq1
+    xperm_hyp hq2
+  rw [show (1 + setOneFrame.length + (1 + (1 + (1 + 48 * (3 + 1) + 1)) + 1 + 1)
+        + setOneFrame.length + 1 + 1 : Nat)
+      = 1 + setOneFrame.length + (1 + (1 + (1 + 48 * (3 + 1) + 1)) + 1 + 1)
+        + setOneFrame.length + 1 + 1 from rfl]
+  abi_frame (16 : BitVec 12) halign hbody
+
+#print axioms bnqZeroFlat_spec
+#print axioms bnqSetOneFrame_spec
+
+end Bn254Fq12SetOneSAsm
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -98,6 +98,7 @@ import EvmAsm.Codegen.Programs.Secp256k1FieldLeToBeSAsm
 import EvmAsm.Codegen.Programs.Bn254FieldConvSAsm
 import EvmAsm.Codegen.Programs.Bn254FieldMulModSAsm
 import EvmAsm.Codegen.Programs.Bn254Fq12ZeroSAsm
+import EvmAsm.Codegen.Programs.Bn254Fq12SetOneSAsm
 import EvmAsm.Codegen.Programs.Bn254Fq12CopySAsm
 import EvmAsm.Codegen.Programs.Bls12Fq12ZeroSAsm
 import EvmAsm.Codegen.Programs.Bls12Fq12CopySAsm

--- a/EvmAsm/Rv64/SAsm.lean
+++ b/EvmAsm/Rv64/SAsm.lean
@@ -34,6 +34,8 @@ import EvmAsm.Rv64.SAsm.AbiFrameDemo
 import EvmAsm.Rv64.SAsm.AbiFrameLoopDemo
 import EvmAsm.Rv64.SAsm.AbiFrameCall
 import EvmAsm.Rv64.SAsm.AbiFrameCallDemo
+import EvmAsm.Rv64.SAsm.AbiFrameLoopBottom
+import EvmAsm.Rv64.SAsm.FramePort
 import EvmAsm.Rv64.SAsm.ParentHeaderMemcmp
 import EvmAsm.Rv64.SAsm.ParentHeaderFrame
 import EvmAsm.Rv64.SAsm.CallRegDemo

--- a/EvmAsm/Rv64/SAsm/AbiFrameCallDemo.lean
+++ b/EvmAsm/Rv64/SAsm/AbiFrameCallDemo.lean
@@ -48,6 +48,7 @@
 import EvmAsm.Rv64.SAsm.AbiFrame
 import EvmAsm.Rv64.SAsm.AbiFrameCall
 import EvmAsm.Rv64.SAsm.Fn
+import EvmAsm.Rv64.SAsm.FramePort
 import EvmAsm.Rv64.Tactics.RunBlock
 import EvmAsm.Rv64.Tactics.XSimp
 
@@ -235,9 +236,7 @@ theorem bumpCall_spec (spVal ret ptr arb8 arb11 v : Word)
       ((.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ arb11) ** (ptr ↦ₘ v))
       ((.x8 ↦ᵣ ptr) ** (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ (v + 1)) ** (ptr ↦ₘ (v + 1))) := by
     refine cpsTripleWithin_extend_code
-      (fun a i h => bumpSub a i
-        (CodeReq.ofProg_mono_sub (0x2000 : Word) (0x200C : Word) bumpProgList
-          bumpBody 3 (by decide) (by rfl) (by decide) (by decide) a i h)) ?_
+      (CodeReq.sub_ofProg_of_lookup (0x200C : Word) bumpBody (by decide) (by decide)) ?_
     show cpsTripleWithin 4 (0x200C : Word) (0x201C : Word)
       (CodeReq.ofProg (0x200C : Word) bumpBody) _ _
     simp only [bumpBody]
@@ -254,26 +253,31 @@ theorem bumpCall_spec (spVal ret ptr arb8 arb11 v : Word)
       (0x2018 : Word)
     rw [add_sext0] at hsd
     runBlock hmv hld haddi hsd
-  -- The abiFrame instance.
-  have h := abiFrame_spec (base := 0x2000) (sp0 := spVal) (ret := ret)
-    (negImm := -16) (posImm := 16)
-    (frame := bumpFrame) (raOfs := 0) (sregs := [(.x8, 8)])
-    (vals := bumpVals ret arb8) (vals' := bumpVals' ret ptr)
-    (body := bumpBody) (bodySteps := 4)
-    (callerPre := (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ arb11) ** (ptr ↦ₘ v))
-    (callerPost := (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ (v + 1)) ** (ptr ↦ₘ (v + 1)))
-    (cr := callDemoCr)
-    (hframe := rfl)
-    (hne := by decide)
-    (hbound := by decide)
-    (hprogBound := by decide)
-    (hret := rfl)
-    (halign := halign)
-    (hframeRestore := frameRestore16 spVal)
-    (hcpF := by pcFree)
-    (hcpF' := by pcFree)
-    (hsub := fun a i h => bumpSub a i h)
-    (hbody := by
+  -- The abiFrame instance (all routine side-conditions via `abi_frame`).
+  have h : cpsTripleWithin (1 + bumpFrame.length + 4 + bumpFrame.length + 1 + 1)
+      (0x2000 : Word) ret callDemoCr
+      ((.x2 ↦ᵣ spVal) ** regsAt bumpFrame (bumpVals ret arb8)
+        ** frameSlotsOwn bumpFrame (spVal + signExtend12 (-16 : BitVec 12))
+        ** ((.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ arb11) ** (ptr ↦ₘ v)))
+      ((.x2 ↦ᵣ spVal) ** regsAt bumpFrame (bumpVals ret arb8)
+        ** frameSlotsSaved bumpFrame (spVal + signExtend12 (-16 : BitVec 12))
+            (bumpVals ret arb8)
+        ** ((.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ (v + 1)) ** (ptr ↦ₘ (v + 1)))) := by
+    refine ?_
+    have hbody : cpsTripleWithin 4
+        ((0x2000 : Word) + BitVec.ofNat 64 (4 * (1 + bumpFrame.length)))
+        ((0x2000 : Word) + BitVec.ofNat 64 (4 * (1 + bumpFrame.length + bumpBody.length)))
+        callDemoCr
+        ((.x2 ↦ᵣ (spVal + signExtend12 (-16 : BitVec 12)))
+          ** regsAt bumpFrame (bumpVals ret arb8)
+          ** frameSlotsSaved bumpFrame (spVal + signExtend12 (-16 : BitVec 12))
+              (bumpVals ret arb8)
+          ** ((.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ arb11) ** (ptr ↦ₘ v)))
+        ((.x2 ↦ᵣ (spVal + signExtend12 (-16 : BitVec 12)))
+          ** regsAt bumpFrame (bumpVals' ret ptr)
+          ** frameSlotsSaved bumpFrame (spVal + signExtend12 (-16 : BitVec 12))
+              (bumpVals ret arb8)
+          ** ((.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ (v + 1)) ** (ptr ↦ₘ (v + 1)))) := by
       have hentry : (0x2000 : Word) + BitVec.ofNat 64 (4 * (1 + bumpFrame.length))
           = (0x200C : Word) := by decide
       have hexit : (0x2000 : Word)
@@ -290,7 +294,8 @@ theorem bumpCall_spec (spVal ret ptr arb8 arb11 v : Word)
                 + signExtend12 (8 : BitVec 12)) ↦ₘ arb8))
         (by pcFree) hcore
       exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
-        (fun _ hq => by xperm_hyp hq) hframed)
+        (fun _ hq => by xperm_hyp hq) hframed
+    abi_frame (16 : BitVec 12) halign hbody
   -- Reshape: `frameSlotsOwn`/`frameSlotsSaved` ↔ the free-stack region.
   rw [show (11 : Nat) = 1 + bumpFrame.length + 4 + bumpFrame.length + 1 + 1 from rfl]
   refine cpsTripleWithin_weaken (fun h2 hp => ?_) (fun h2 hq => ?_) h
@@ -360,77 +365,52 @@ theorem twiceFrame_spec (sp0 ret ptr arb8 arb11 v : Word)
   -- call 1: jal at 0x1008 → bump, back to 0x100C.
   have hb1 := bumpCall_spec newSp ((0x1008 : Word) + 4) ptr arb8 arb11 v
     (by decide)
-  have hcall1 := abiFrameCall_spec (cr := callDemoCr)
-    (A := 0x1008) (calleeEntry := 0x2000) (vOld := ret) (spVal := newSp)
-    (offset := (0xFF8 : BitVec 21)) (m := 2) (n := 11)
-    (calleePre := (.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ arb11) ** (ptr ↦ₘ v))
-    (calleePost := (.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ (v + 1))
-      ** (ptr ↦ₘ (v + 1)))
+  have hcall1 := abiFrameCall_spec (A := 0x1008) (vOld := ret)
+    (offset := (0xFF8 : BitVec 21))
     (F := ((newSp + signExtend12 (0 : BitVec 12)) ↦ₘ ret))
-    (by decide)
-    (twiceAt 2 (0x1008 : Word) (.JAL .x1 (0xFF8 : BitVec 21)) (by decide) (by decide)
-      (by decide) (by rfl))
-    (by pcFree) (by pcFree)
-    hb1
+    (htarget := by decide) (hmem := by code_mem) (hpre := by pcf) (hF := by pcf)
+    (hcallee := hb1)
   -- call 2: jal at 0x100C → bump, back to 0x1010.
   have hb2 := bumpCall_spec newSp ((0x100C : Word) + 4) ptr arb8 (v + 1) (v + 1)
     (by decide)
-  have hcall2 := abiFrameCall_spec (cr := callDemoCr)
-    (A := 0x100C) (calleeEntry := 0x2000) (vOld := (0x1008 : Word) + 4)
-    (spVal := newSp) (offset := (0xFF4 : BitVec 21)) (m := 2) (n := 11)
-    (calleePre := (.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ (v + 1))
-      ** (ptr ↦ₘ (v + 1)))
-    (calleePost := (.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr) ** (.x11 ↦ᵣ (v + 1 + 1))
-      ** (ptr ↦ₘ (v + 1 + 1)))
+  have hcall2 := abiFrameCall_spec (A := 0x100C) (vOld := (0x1008 : Word) + 4)
+    (offset := (0xFF4 : BitVec 21))
     (F := ((newSp + signExtend12 (0 : BitVec 12)) ↦ₘ ret))
-    (by decide)
-    (twiceAt 3 (0x100C : Word) (.JAL .x1 (0xFF4 : BitVec 21)) (by decide) (by decide)
-      (by decide) (by rfl))
-    (by pcFree) (by pcFree)
-    hb2
+    (htarget := by decide) (hmem := by code_mem) (hpre := by pcf) (hF := by pcf)
+    (hcallee := hb2)
   -- chain the two calls
   have hchain := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp)
     hcall1 hcall2
   rw [show (0x100C : Word) + 4 = (0x1010 : Word) from by decide] at hchain
   -- ---- the abiFrame wrapper ----
-  have h := abiFrame_spec (base := 0x1000) (sp0 := sp0) (ret := ret)
-    (negImm := -8) (posImm := 8)
-    (frame := twiceFrame) (raOfs := 0) (sregs := [])
-    (vals := twiceVals ret) (vals' := twiceVals')
-    (body := twiceBody) (bodySteps := (1 + 11) + (1 + 11))
-    (callerPre := stackFree newSp 2 ** (.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr)
-      ** (.x11 ↦ᵣ arb11) ** (ptr ↦ₘ v))
-    (callerPost := stackFree newSp 2 ** (.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr)
-      ** (.x11 ↦ᵣ (v + 1 + 1)) ** (ptr ↦ₘ (v + 1 + 1)))
-    (cr := callDemoCr)
-    (hframe := rfl)
-    (hne := by decide)
-    (hbound := by decide)
-    (hprogBound := by decide)
-    (hret := rfl)
-    (halign := halign)
-    (hframeRestore := frameRestore8 sp0)
-    (hcpF := pcFree_sepConj (pcFree_stackFree _ _) (by pcFree))
-    (hcpF' := pcFree_sepConj (pcFree_stackFree _ _) (by pcFree))
-    (hsub := fun a i h => twiceSub a i h)
-    (hbody := by
-      have hentry : (0x1000 : Word) + BitVec.ofNat 64 (4 * (1 + twiceFrame.length))
-          = (0x1008 : Word) := by decide
-      have hexit : (0x1000 : Word)
-            + BitVec.ofNat 64 (4 * (1 + twiceFrame.length + twiceBody.length))
-          = (0x1010 : Word) := by decide
-      rw [hentry, hexit]
-      simp only [twiceFrame, regsAt, frameSlotsSaved, twiceVals, twiceVals',
-        List.foldr_cons, List.foldr_nil, sepConj_emp_right']
-      refine cpsTripleWithin_weaken (fun _ hp => ?_) (fun _ hq => ?_) hchain
-      · rw [← hNS] at hp
-        xperm_hyp hp
-      · rw [← hNS]
-        xperm_hyp hq)
+  have hbody : cpsTripleWithin ((1 + 11) + (1 + 11))
+      ((0x1000 : Word) + BitVec.ofNat 64 (4 * (1 + twiceFrame.length)))
+      ((0x1000 : Word) + BitVec.ofNat 64 (4 * (1 + twiceFrame.length + twiceBody.length)))
+      callDemoCr
+      ((.x2 ↦ᵣ newSp) ** regsAt twiceFrame (twiceVals ret)
+        ** frameSlotsSaved twiceFrame newSp (twiceVals ret)
+        ** (stackFree newSp 2 ** (.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr)
+          ** (.x11 ↦ᵣ arb11) ** (ptr ↦ₘ v)))
+      ((.x2 ↦ᵣ newSp) ** regsAt twiceFrame twiceVals'
+        ** frameSlotsSaved twiceFrame newSp (twiceVals ret)
+        ** (stackFree newSp 2 ** (.x8 ↦ᵣ arb8) ** (.x10 ↦ᵣ ptr)
+          ** (.x11 ↦ᵣ (v + 1 + 1)) ** (ptr ↦ₘ (v + 1 + 1)))) := by
+    have hentry : (0x1000 : Word) + BitVec.ofNat 64 (4 * (1 + twiceFrame.length))
+        = (0x1008 : Word) := by decide
+    have hexit : (0x1000 : Word)
+          + BitVec.ofNat 64 (4 * (1 + twiceFrame.length + twiceBody.length))
+        = (0x1010 : Word) := by decide
+    rw [hentry, hexit]
+    simp only [twiceFrame, regsAt, frameSlotsSaved, twiceVals, twiceVals',
+      List.foldr_cons, List.foldr_nil, sepConj_emp_right']
+    refine cpsTripleWithin_weaken (fun _ hp => ?_) (fun _ hq => ?_) hchain
+    · xperm_hyp hp
+    · xperm_hyp hq
   rw [show (29 : Nat)
       = 1 + twiceFrame.length + ((1 + 11) + (1 + 11)) + twiceFrame.length + 1 + 1
     from rfl]
-  exact h
+  rw [hNS] at hbody ⊢
+  abi_frame (8 : BitVec 12) halign hbody
 
 #print axioms twiceFrame_spec
 #print axioms bumpCall_spec

--- a/EvmAsm/Rv64/SAsm/AbiFrameLoopBottom.lean
+++ b/EvmAsm/Rv64/SAsm/AbiFrameLoopBottom.lean
@@ -1,0 +1,214 @@
+/-
+  EvmAsm.Rv64.SAsm.AbiFrameLoopBottom
+
+  Two reusable pieces for the bottom-test (`do-while`) converter loops the
+  guest emits everywhere (`bnq_zero`/`bnq_copy`/`blq_*` and the other
+  4ch8f.58 helpers), companions to `countdownLoop_spec` (top-guard shape):
+
+  * `dwordsIs base vs` — a writable dword-array region: `|vs|` consecutive
+    owned dword cells holding `vs`.  `dwordsIs_at_set` extracts the `p`-th
+    cell with a SHARED frame for both the old and the updated list, so a
+    plain `sd` lands exactly on `vs.set p w` — the store-side analogue of
+    `bytesRegion_dword_at_set` at dword granularity.
+
+  * `countdownLoopBottom_spec` — the register-agnostic bottom-decrement
+    do-while loop:
+
+    ```
+      hdr:  <body>                  -- decrements ctr (n+1 → n)
+      tst:  bne  ctr, x0, backOff   -- back-edge to hdr while ctr ≠ 0
+      exit:                         -- tst + 4
+    ```
+
+    Given a per-iteration body triple, the whole loop runs `ctr` from
+    `N ≥ 1` down to `0` (a do-while executes its body at least once).  As
+    with `countdownLoop_spec`, `ctr` and the invariant family are FREE, so
+    they may reference callee-saved `s`-registers.
+
+  Strictly additive: `cpsTripleWithin` only.
+-/
+
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.RunBlock
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Rv64
+namespace SAsm
+
+open EvmAsm.Rv64.Tactics
+
+-- ============================================================================
+-- The writable dword-array region.
+-- ============================================================================
+
+/-- `|vs|` consecutive owned dword cells from `base`, holding `vs`. -/
+def dwordsIs (base : Word) : List Word → Assertion
+  | [] => empAssertion
+  | v :: vs => (base ↦ₘ v) ** dwordsIs (base + 8) vs
+
+@[simp] theorem dwordsIs_nil (base : Word) : dwordsIs base [] = empAssertion := rfl
+
+@[simp] theorem dwordsIs_cons (base : Word) (v : Word) (vs : List Word) :
+    dwordsIs base (v :: vs) = ((base ↦ₘ v) ** dwordsIs (base + 8) vs) := rfl
+
+theorem pcFree_dwordsIs (base : Word) (vs : List Word) : (dwordsIs base vs).pcFree := by
+  induction vs generalizing base with
+  | nil => exact pcFree_emp
+  | cons v vs ih => exact pcFree_sepConj pcFree_memIs (ih _)
+
+private theorem sepConj_assoc_eq {P Q R : Assertion} :
+    ((P ** Q) ** R) = (P ** (Q ** R)) := by
+  funext h; exact propext (sepConj_assoc h)
+
+private theorem sepConj_emp_left_eq {P : Assertion} : (empAssertion ** P) = P := by
+  funext h; exact propext (sepConj_emp_left h)
+
+private theorem addr_shift (base : Word) (k : Nat) :
+    (base + 8) + BitVec.ofNat 64 (8 * k) = base + BitVec.ofNat 64 (8 * (k + 1)) := by
+  rw [BitVec.add_assoc]
+  congr 1
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_add, BitVec.toNat_ofNat, BitVec.toNat_ofNat,
+      show ((8 : Word)).toNat = 8 from by decide]
+  omega
+
+/-- Extract the `p`-th dword cell with a frame SHARED between `vs` and
+    `vs.set p w`: a store on that cell lands exactly on the updated array. -/
+theorem dwordsIs_at_set (base : Word) (vs : List Word) (p : Nat) (w : Word)
+    (hp : p < vs.length) :
+    ∃ front rest : Assertion, front.pcFree ∧ rest.pcFree ∧
+      dwordsIs base vs
+        = (front ** (((base + BitVec.ofNat 64 (8 * p)) ↦ₘ vs.getD p 0) ** rest)) ∧
+      dwordsIs base (vs.set p w)
+        = (front ** (((base + BitVec.ofNat 64 (8 * p)) ↦ₘ w) ** rest)) := by
+  induction p generalizing base vs with
+  | zero =>
+    obtain ⟨v, vs', rfl⟩ : ∃ v vs', vs = v :: vs' := by
+      cases vs with
+      | nil => exact absurd hp (by simp)
+      | cons v vs' => exact ⟨v, vs', rfl⟩
+    have haddr : base + BitVec.ofNat 64 (8 * 0) = base := by
+      apply BitVec.eq_of_toNat_eq
+      rw [BitVec.toNat_add, show (8 * 0 : Nat) = 0 from rfl, BitVec.toNat_ofNat]
+      have := base.isLt
+      omega
+    refine ⟨empAssertion, dwordsIs (base + 8) vs', pcFree_emp, pcFree_dwordsIs _ _, ?_, ?_⟩
+    · rw [dwordsIs_cons, haddr, sepConj_emp_left_eq]; rfl
+    · rw [show (v :: vs').set 0 w = w :: vs' from rfl, dwordsIs_cons, haddr,
+        sepConj_emp_left_eq]
+  | succ k ih =>
+    obtain ⟨v, vs', rfl⟩ : ∃ v vs', vs = v :: vs' := by
+      cases vs with
+      | nil => exact absurd hp (by simp)
+      | cons v vs' => exact ⟨v, vs', rfl⟩
+    have hk : k < vs'.length := by simpa using hp
+    obtain ⟨front', rest', hf', hr', heq1, heq2⟩ := ih (base + 8) vs' hk
+    refine ⟨(base ↦ₘ v) ** front', rest', pcFree_sepConj pcFree_memIs hf', hr', ?_, ?_⟩
+    · rw [dwordsIs_cons, heq1, addr_shift, ← sepConj_assoc_eq]; rfl
+    · rw [show (v :: vs').set (k + 1) w = v :: vs'.set k w from rfl, dwordsIs_cons,
+        heq2, addr_shift, ← sepConj_assoc_eq]
+
+-- ============================================================================
+-- The bottom-test countdown loop.
+-- ============================================================================
+
+private theorem word_ofNat_succ_ne_zero (n : Nat) (h : n + 1 < 2 ^ 64) :
+    BitVec.ofNat 64 (n + 1) ≠ (0 : Word) := by
+  intro heq
+  have h2 := congrArg BitVec.toNat heq
+  rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt h] at h2
+  have hz : ((0 : Word).toNat) = 0 := by decide
+  omega
+
+/-- **General s-register-exposed bottom-test countdown-loop lemma** (the
+    `do-while` companion to `countdownLoop_spec`).
+
+    ```
+      hdr:  <body>                  -- decrements ctr (n+1 → n)
+      tst:  bne  ctr, x0, backOff   -- back-edge while ctr ≠ 0
+      exit:                         -- tst + 4
+    ```
+
+    Given a per-iteration body triple from `hdr` to `tst` taking `ctr` from
+    `n + 1` to `n` and the invariant from `inv (n + 1)` to `inv n`, the whole
+    loop runs from `hdr` to `tst + 4` with `ctr` draining from `N` to `0`,
+    for any `N ≥ 1` (a do-while runs its body at least once). -/
+theorem countdownLoopBottom_spec
+    (cr : CodeReq) (hdr tst : Word) (ctr : Reg) (backOff : BitVec 13)
+    (bodyStep N : Nat) (inv : Nat → Assertion)
+    (_hctr_ne : ctr ≠ .x0)
+    (hN1 : 1 ≤ N)
+    (hNbound : N < 18446744073709551616)
+    (hback : tst + signExtend13 backOff = hdr)
+    (hpcFree : ∀ n, (inv n).pcFree)
+    (hguardMem : ∀ a i,
+      CodeReq.singleton tst (.BNE ctr .x0 backOff) a = some i → cr a = some i)
+    (hbody : ∀ n, n < N →
+      cpsTripleWithin bodyStep hdr tst cr
+        ((ctr ↦ᵣ BitVec.ofNat 64 (n + 1)) ** (Reg.x0 ↦ᵣ (0 : Word)) ** inv (n + 1))
+        ((ctr ↦ᵣ BitVec.ofNat 64 n) ** (Reg.x0 ↦ᵣ (0 : Word)) ** inv n)) :
+    cpsTripleWithin (N * (bodyStep + 1)) hdr (tst + 4) cr
+      ((ctr ↦ᵣ BitVec.ofNat 64 N) ** (Reg.x0 ↦ᵣ (0 : Word)) ** inv N)
+      ((ctr ↦ᵣ BitVec.ofNat 64 0) ** (Reg.x0 ↦ᵣ (0 : Word)) ** inv 0) := by
+  -- Strengthened statement over every `1 ≤ n ≤ N`, by induction on `n`.
+  suffices h : ∀ n, 1 ≤ n → n ≤ N →
+      cpsTripleWithin (n * (bodyStep + 1)) hdr (tst + 4) cr
+        ((ctr ↦ᵣ BitVec.ofNat 64 n) ** (Reg.x0 ↦ᵣ (0 : Word)) ** inv n)
+        ((ctr ↦ᵣ BitVec.ofNat 64 0) ** (Reg.x0 ↦ᵣ (0 : Word)) ** inv 0) from
+    h N hN1 (Nat.le_refl N)
+  intro n
+  induction n with
+  | zero => intro h1 _; exact absurd h1 (by omega)
+  | succ k ih =>
+    intro _ hk
+    have hkN : k < N := Nat.lt_of_succ_le hk
+    -- One body pass: k+1 → k.
+    have hbodyk := hbody k hkN
+    -- The bottom test with ctr = ofNat k.
+    have hbne := bne_spec_gen_within ctr .x0 backOff (BitVec.ofNat 64 k) (0 : Word) tst
+    rw [hback] at hbne
+    have hbr := cpsBranchWithin_extend_code hguardMem
+      (cpsBranchWithin_frameR (inv k) (hpcFree k) hbne)
+    rcases Nat.eq_zero_or_pos k with hk0 | hkpos
+    · -- k = 0: the test falls through to the exit.
+      subst hk0
+      have hexit := cpsBranchWithin_ntakenPath hbr
+        (fun hp hQt => by
+          obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_pure⟩, _⟩ := hQt
+          exact ((sepConj_pure_right _).1 h_pure).2 rfl)
+      have hstep := cpsTripleWithin_seq_perm_same_cr
+        (fun _ hp => by xperm_hyp hp) hbodyk hexit
+      rw [show (0 + 1) * (bodyStep + 1) = bodyStep + 1 from by omega]
+      -- Strip the not-taken pure `≠` fact and reassociate.
+      refine cpsTripleWithin_weaken (fun _ hp => hp)
+        (fun h hq => ?_) hstep
+      have hq1 := sepConj_mono_left
+        (sepConj_mono_right (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hq
+      xperm_hyp hq1
+    · -- k ≥ 1: the test takes the back edge; recurse.
+      have hne : BitVec.ofNat 64 k ≠ (0 : Word) := by
+        have : k - 1 + 1 = k := by omega
+        rw [← this]
+        exact word_ofNat_succ_ne_zero (k - 1) (by omega)
+      have htaken := cpsBranchWithin_takenPath hbr
+        (fun hp hQf => by
+          obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_pure⟩, _⟩ := hQf
+          exact hne ((sepConj_pure_right _).1 h_pure).2)
+      have ihk := ih hkpos (Nat.le_of_lt hkN)
+      -- body ; test(back-edge) — plain perm glue.
+      have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp)
+        hbodyk htaken
+      -- (body ; test) ; tail — strip the taken pure `=` in the glue.
+      have s2 := cpsTripleWithin_seq_perm_same_cr
+        (fun h hp => by
+          have hp2 := sepConj_mono_left
+            (sepConj_mono_right (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+          xperm_hyp hp2) s1 ihk
+      have hstep : (k + 1) * (bodyStep + 1)
+          = bodyStep + 1 + k * (bodyStep + 1) := by
+        rw [Nat.add_mul, Nat.one_mul]; omega
+      rw [hstep]
+      exact s2
+
+end SAsm
+end EvmAsm.Rv64

--- a/EvmAsm/Rv64/SAsm/AbiFrameLoopDemo.lean
+++ b/EvmAsm/Rv64/SAsm/AbiFrameLoopDemo.lean
@@ -45,6 +45,7 @@
 
 import EvmAsm.Rv64.SAsm.AbiFrame
 import EvmAsm.Rv64.SAsm.AbiFrameLoop
+import EvmAsm.Rv64.SAsm.FramePort
 import EvmAsm.Rv64.Tactics.XSimp
 import Mathlib.Data.BitVec
 
@@ -143,16 +144,6 @@ def mulInv (inc outPtr : Word) (K : Nat) (n : Nat) : Assertion :=
 theorem pcFree_mulInv (inc outPtr : Word) (K n : Nat) : (mulInv inc outPtr K n).pcFree :=
   pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs pcFree_regIs)
 
-/-- Code-membership: instruction `idx` of the routine sits in `mulCr`. -/
-private theorem memAt (idx : Nat) (addr : Word) (instr : Instr)
-    (hk : idx < mulProgList.length) (hbound : 4 * mulProgList.length < 2 ^ 64)
-    (haddr : addr = (0x1000 : Word) + BitVec.ofNat 64 (4 * idx))
-    (hget : mulProgList.get ⟨idx, hk⟩ = instr) :
-    ∀ a i, CodeReq.singleton addr instr a = some i → mulCr a = some i := by
-  have m := CodeReq.ofProg_lookup_addr (0x1000 : Word) mulProgList idx addr hk hbound haddr
-  rw [hget] at m
-  exact CodeReq.singleton_mono m
-
 /-- **The per-iteration loop body** (`add ; addi ; jal-back`, `0x101C → 0x1018`):
     `acc += inc`, `cnt -= 1`, back-edge to the header.  Discharges the loop's
     `hbody` obligation. -/
@@ -182,15 +173,8 @@ theorem mulLoopBody_spec (inc outPtr : Word) (K n : Nat) (hn : n < K) :
 theorem mulLoop_spec (inc outPtr kw : Word) :
     cpsTripleWithin (kw.toNat * (3 + 1) + 1) (0x1018 : Word) (0x1028 : Word) mulCr
       ((.x9 ↦ᵣ BitVec.ofNat 64 kw.toNat) ** (Reg.x0 ↦ᵣ (0 : Word)) ** mulInv inc outPtr kw.toNat kw.toNat)
-      ((.x9 ↦ᵣ BitVec.ofNat 64 0) ** (Reg.x0 ↦ᵣ (0 : Word)) ** mulInv inc outPtr kw.toNat 0) :=
-  countdownLoop_spec mulCr (0x1018 : Word) (0x1028 : Word) .x9 (16 : BitVec 13)
-    3 kw.toNat (mulInv inc outPtr kw.toNat)
-    (by decide)
-    (kw.isLt)
-    (by decide)
-    (fun n => pcFree_mulInv inc outPtr kw.toNat n)
-    (memAt 6 0x1018 (.BEQ .x9 .x0 (16 : BitVec 13)) (by decide) (by decide) (by decide) (by rfl))
-    (fun n hn => mulLoopBody_spec inc outPtr kw.toNat n hn)
+      ((.x9 ↦ᵣ BitVec.ofNat 64 0) ** (Reg.x0 ↦ᵣ (0 : Word)) ** mulInv inc outPtr kw.toNat 0) := by
+  countdown_loop (16 : BitVec 13) (fun n hn => mulLoopBody_spec inc outPtr kw.toNat n hn)
 
 /-- **The prefix** (`li s0,0 ; mv s1,a2`, `0x1010 → 0x1018`): initialize the
     accumulator and load the counter. -/
@@ -326,31 +310,7 @@ theorem mulFrame_spec (ret inc kw outPtr arb8 arb9 oldD : Word)
         ** ((0x2FFE0 : Word) ↦ₘ ret) ** ((0x2FFE8 : Word) ↦ₘ arb8) ** ((0x2FFF0 : Word) ↦ₘ arb9))
       (by pcFree) (mulCore_spec inc kw outPtr arb8 arb9 oldD)
     exact cpsTripleWithin_weaken (by xsimp) (by xsimp) hframed
-  have h := abiFrame_spec (base := 0x1000) (sp0 := 0x30000) (ret := ret)
-    (negImm := -32) (posImm := 32)
-    (frame := mulFrame) (raOfs := 0) (sregs := [(.x8, 8), (.x9, 16)])
-    (vals := mulVals ret arb8 arb9) (vals' := mulVals' ret inc kw)
-    (body := mulBody) (bodySteps := 2 + (kw.toNat * (3 + 1) + 1) + 1)
-    (callerPre := mulCallerPre inc kw outPtr oldD) (callerPost := mulCallerPost inc kw outPtr)
-    (cr := mulCr)
-    (hframe := rfl)
-    (hne := by decide)
-    (hbound := by decide)
-    (hprogBound := by decide)
-    (hret := rfl)
-    (halign := halign)
-    (hframeRestore := by decide)
-    (hcpF := by
-      simp only [mulCallerPre]
-      exact pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs
-        (pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs pcFree_memIs))))
-    (hcpF' := by
-      simp only [mulCallerPost]
-      exact pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs
-        (pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs pcFree_memIs))))
-    (hsub := fun a i h => h)
-    (hbody := hbody)
-  exact h
+  abi_frame (32 : BitVec 12) halign hbody
 
 #print axioms countdownLoop_spec
 #print axioms mulFrame_spec

--- a/EvmAsm/Rv64/SAsm/FramePort.lean
+++ b/EvmAsm/Rv64/SAsm/FramePort.lean
@@ -1,0 +1,238 @@
+/-
+  EvmAsm.Rv64.SAsm.FramePort
+
+  **Port-automation for sp-frame routines** (bead evm-asm-4ch8f.76 follow-up):
+  collapses the mechanical boilerplate of an ABI-frame port — the
+  `abiFrame_spec`/`abiFrameCall_spec`/`countdownLoop_spec` side-conditions,
+  `pcFree` obligations, code-membership plumbing, and address bridges — into
+  tactics, so each port reduces to its genuine core (body semantics + loop
+  invariant + the disjunctive post).
+
+  ## The recipe: how to port an sp-frame routine
+
+  1. **Define the routine** as an `abiFrameProg` flatten and byte-tie it:
+     ```
+     def fooProg : List Instr := abiFrameProg negImm posImm fooFrame fooBody
+     def fooProgList : List Instr := [ …spelled out… ]
+     #guard fooProg = fooProgList          -- byte-transparency
+     theorem fooProg_eq : fooProg = fooProgList := rfl
+     def fooCr : CodeReq := CodeReq.ofProg BASE fooProgList
+     ```
+     (For a re-emitted drop-in, `fooProgList` must also equal the emitted
+     `Program` by `rfl`, and ziskemu/EEST A/B parity vs the old bytes is
+     mandatory — see `ParentHeaderFrame.lean` / PR #9975.)
+
+  2. **State the genuine post** (unweakened: the routine's full semantics) and
+     prove the **body triple** — the only bespoke work.  Straight-line pieces
+     go through `runBlock` over an `ofProg` slice lifted with `lift_code`;
+     an internal countdown loop through `countdown_loop`; a cross-call
+     through `frame_call` (callee contract = any whole-routine
+     `cpsTripleWithin` at `ret := A + 4`, e.g. another `abi_frame` port).
+
+  3. **Wrap with `abi_frame posImm halign hbody`**: applies `abiFrame_spec` and discharges
+     all twelve routine side-conditions (`hframe`/`hne`/`hbound`/
+     `hprogBound`/`hret`/`halign`/`hframeRestore`/`hcpF`/`hcpF'`/`hsub`)
+     automatically, leaving nothing.  The goal must be the standard
+     `abiFrame_spec` conclusion shape (see `AbiFrameLoopDemo.mulFrame_spec`).
+
+  4. `#print axioms` the result — it must be `[propext, Classical.choice,
+     Quot.sound]`.  The tactics build genuine proof terms only (`decide`/
+     `rfl`/`omega`/lemma application); nothing is admitted.
+
+  ## What the tactics close vs what you supply
+
+  | goal | tactic | closes |
+  |---|---|---|
+  | `P.pcFree` over `**`/`↦ᵣ`/`↦ₘ`/`memOwn`/`regOwn`/`⌜⌝`/`bytesRegion`/`stackFree`/`regsAt`/`frameSlots*` | `pcf` | always |
+  | `∀ a i, singleton/ofProg … = some i → cr a = some i` (concrete) | `code_mem` | always |
+  | lift a slice/loop triple into the routine `CodeReq` | `lift_code h` | always |
+  | whole-routine wrap + its 12 side-conditions | `abi_frame posImm halign hbody` | all but `hbody` |
+  | countdown loop + its 5 side-conditions | `countdown_loop exitOff hbody` | all but the per-iteration `hbody` |
+  | one `jal ra` call + its 4 side-conditions | `frame_call offset hcallee` | all but the callee contract |
+  | the body triple, loop invariant, genuine post | — | **you** (this IS the proof) |
+
+  Zero soundness surface: every tactic assembles existing kernel-checked
+  lemmas; no axioms, no `sorry`, no `native_decide`/`bv_decide`.
+
+  ## Worked examples (read in this order)
+
+  * `AbiFrameLoopDemo.mulFrame_spec` — leaf + internal loop
+    (`countdown_loop` + `abi_frame`).
+  * `AbiFrameCallDemo.twiceFrame_spec` — cross-calls (`abiFrameCall_spec` +
+    `abi_frame`), callee with its own frame carved from `stackFree`.
+  * `Codegen/Programs/Bn254Fq12SetOneSAsm.lean` — a REAL guest routine,
+    byte-transparent: flat callee contract (`bnqZeroFlat_spec`, bottom-test
+    loop via `countdownLoopBottom_spec` over the writable `dwordsIs` region)
+    consumed by `callWithin_spec` inside an `abi_frame` wrap.
+
+  Known limits: `abi_frame` at very large scale (the 84-instruction
+  `ParentHeaderFrame` routine) hits elaboration limits in the automated
+  side-condition search — such routines keep the explicit `abiFrame_spec`
+  application (same statement, spelled side-conditions).  `runBlock` chains
+  single-instruction specs; multi-instruction sub-triples (a lifted loop, a
+  call) compose with `cpsTripleWithin_frameR` + `…_seq_perm_same_cr` as in
+  the worked examples.
+-/
+
+import EvmAsm.Rv64.SAsm.AbiFrame
+import EvmAsm.Rv64.SAsm.AbiFrameLoop
+import EvmAsm.Rv64.SAsm.AbiFrameCall
+import EvmAsm.Rv64.SAsm.AbiFrameLoopBottom
+import EvmAsm.Rv64.MemRegion
+
+namespace EvmAsm.Rv64
+namespace SAsm
+
+-- ============================================================================
+-- Code-membership by evaluation.
+-- ============================================================================
+
+/-- Slice containment by pointwise lookup: if every slot of the (concrete)
+    slice `seg` at `A` is already mapped by `cr`, then `ofProg A seg ⊆ cr`.
+    The hypothesis is decidable for concrete data, so `code_mem` discharges
+    it with `decide` — replacing the manual `ofProg_mono_sub` index/range
+    plumbing. -/
+theorem CodeReq.sub_ofProg_of_lookup {cr : CodeReq} (A : Word) (seg : List Instr)
+    (hbound : 4 * seg.length < 2 ^ 64)
+    (h : ∀ k, (hk : k < seg.length) →
+      cr (A + BitVec.ofNat 64 (4 * k)) = some (seg.get ⟨k, hk⟩)) :
+    ∀ a i, CodeReq.ofProg A seg a = some i → cr a = some i := by
+  intro a i hai
+  obtain ⟨k, hk, rfl⟩ := ofProg_some_range hai
+  have hl := CodeReq.ofProg_lookup_addr A seg k (A + BitVec.ofNat 64 (4 * k)) hk hbound rfl
+  have hi : i = seg.get ⟨k, hk⟩ := Option.some.inj (hai.symm.trans hl)
+  rw [hi]
+  exact h k hk
+
+/-- `code_mem` closes concrete code-membership goals
+    `∀ a i, (singleton addr instr / ofProg A seg) a = some i → cr a = some i`
+    by evaluation: identity, a `singleton_mono` point lookup, or the
+    pointwise slice lookup — all via `decide` on the concrete `CodeReq`. -/
+macro "code_mem" : tactic =>
+  `(tactic| first
+    | (with_reducible exact fun a i h => h)
+    | (with_reducible exact CodeReq.singleton_mono (by decide))
+    | (with_reducible exact CodeReq.sub_ofProg_of_lookup _ _ (by decide) (by decide)))
+
+-- ============================================================================
+-- pcFree automation.
+-- ============================================================================
+
+/-- `pcf` closes `P.pcFree` for any assertion built from the standard atoms
+    and the frame/region/stack combinators. -/
+macro "pcf" : tactic =>
+  `(tactic| repeat
+      first
+      | apply pcFree_sepConj
+      | exact pcFree_regIs
+      | exact pcFree_regOwn
+      | exact pcFree_memIs
+      | exact pcFree_memOwn
+      | exact pcFree_emp
+      | exact pcFree_pure
+      | exact pcFree_instrAt
+      | exact bytesRegion_pcFree _ _
+      | exact pcFree_stackFree _ _
+      | exact pcFree_dwordsIs _ _
+      | exact pcFree_regsAt _ _
+      | exact pcFree_frameSlotsOwn _ _
+      | exact pcFree_frameSlotsSaved _ _ _
+      | exact pcFree_regFileIs _)
+
+-- ============================================================================
+-- Address-bridge helpers.
+-- ============================================================================
+
+/-- The frame-restore side-condition, reduced to a `decide`-able immediate
+    fact (`sext negImm + sext posImm = 0`), for a FREE `sp0`. -/
+theorem sext_frameRestore (sp0 : Word) (negImm posImm : BitVec 12)
+    (h : signExtend12 negImm + signExtend12 posImm = 0) :
+    (sp0 + signExtend12 negImm) + signExtend12 posImm = sp0 := by
+  rw [BitVec.add_assoc, h]
+  exact BitVec.add_zero sp0
+
+-- ============================================================================
+-- The wrappers.
+-- ============================================================================
+
+/-- Term-form lift with the triple FIRST (so the containment side-goal
+    elaborates with the sub-`CodeReq` already pinned): use
+    `liftCode (cr' := routineCr) h (by code_mem)`.  The `lift_code h` tactic
+    below is the goal-directed form. -/
+theorem liftCode {nSteps : Nat} {entry exit_ : Word} {cr cr' : CodeReq}
+    {P Q : Assertion}
+    (h : cpsTripleWithin nSteps entry exit_ cr P Q)
+    (hmono : ∀ a i, cr a = some i → cr' a = some i) :
+    cpsTripleWithin nSteps entry exit_ cr' P Q :=
+  cpsTripleWithin_extend_code hmono h
+
+/-- `lift_code h` lifts a triple proven over a sub-`CodeReq` (an `ofProg`
+    slice, a loop core at its anchor, …) into the goal's routine `CodeReq`,
+    discharging the containment by evaluation. -/
+macro "lift_code" h:term : tactic =>
+  `(tactic| (refine cpsTripleWithin_extend_code ?_ $h; code_mem))
+
+/-- `abi_frame posImm halign hbody` closes a whole-routine goal in the
+    standard `abiFrame_spec` conclusion shape, given the frame-release
+    immediate, the return-address alignment fact, and the single-exit body
+    triple `hbody` (which pins `body`/`bodySteps`/`vals'`): all other
+    side-conditions are discharged automatically. -/
+macro "abi_frame" posImm:term:max halign:term:max hbody:term:max : tactic =>
+  `(tactic| exact abiFrame_spec
+      (posImm := $posImm)
+      (hframe := rfl)
+      (hne := by decide)
+      (hbound := by decide)
+      (hprogBound := by decide)
+      (hret := rfl)
+      (halign := $halign)
+      (hframeRestore := sext_frameRestore _ _ _ (by decide))
+      (hcpF := by pcf)
+      (hcpF' := by pcf)
+      (hsub := by code_mem)
+      (hbody := $hbody))
+
+/-- `countdown_loop hbody` closes a whole-loop goal in the
+    `countdownLoop_spec` conclusion shape, given the per-iteration body
+    triple family `hbody : ∀ n, n < N → …`: guard membership, exit address,
+    counter bound, and the invariant's `pcFree` are discharged
+    automatically. -/
+macro "countdown_loop" exitOff:term:max hbody:term:max : tactic =>
+  `(tactic| exact countdownLoop_spec (exitOff := $exitOff) (cr := _) (hdr := _)
+      (exitAddr := _) (ctr := _) (bodyStep := _) (N := _) (inv := _)
+      (_hctr_ne := by decide)
+      (hNbound := by first | assumption | exact BitVec.isLt _ | omega)
+      (hexit := by decide)
+      (hpcFree := fun n => by pcf)
+      (hguardMem := by code_mem)
+      (hbody := $hbody))
+
+/-- `countdown_loop_bottom backOff hbody` — the do-while analogue of
+    `countdown_loop`, closing a `countdownLoopBottom_spec`-shaped goal given
+    the per-iteration body triple family. -/
+macro "countdown_loop_bottom" backOff:term:max hbody:term:max : tactic =>
+  `(tactic| exact countdownLoopBottom_spec (backOff := $backOff) (cr := _)
+      (hdr := _) (tst := _) (ctr := _) (bodyStep := _) (N := _) (inv := _)
+      (_hctr_ne := by decide)
+      (hN1 := by first | assumption | omega)
+      (hNbound := by first | assumption | exact BitVec.isLt _ | omega)
+      (hback := by decide)
+      (hpcFree := fun n => by pcf)
+      (hguardMem := by code_mem)
+      (hbody := $hbody))
+
+/-- `frame_call hcallee` closes a single-call goal in the
+    `abiFrameCall_spec` conclusion shape, given the callee's whole-routine
+    contract `hcallee` (at `ret := A + 4`): the `jal` target arithmetic,
+    call-site code membership, and `pcFree` side-conditions are discharged
+    automatically. -/
+macro "frame_call" offset:term:max hcallee:term:max : tactic =>
+  `(tactic| exact abiFrameCall_spec (offset := $offset)
+      (htarget := by decide)
+      (hmem := by code_mem)
+      (hpre := by pcf)
+      (hF := by pcf)
+      (hcallee := $hcallee))
+
+end SAsm
+end EvmAsm.Rv64

--- a/PLAN.md
+++ b/PLAN.md
@@ -2729,6 +2729,30 @@ bridge the pre-existing blocker beads (4ch8f.58.3.17.1 "FnHandle call bridge
 with s-register locals", 4ch8f.58.3.22.1 "exact-ra call bridge") were waiting
 on; porting a real cross-calling routine additionally needs its callees'
 whole-routine contracts (each its own port).
+**Port-automation + first real cross-call port landed** (branch
+`feat/frame-port-tactic`): `SAsm/FramePort.lean` collapses the sp-frame port
+boilerplate into tactics — `pcf` (pcFree over all atoms + region/stack/frame
+combinators), `code_mem` (code membership by kernel evaluation:
+`CodeReq.sub_ofProg_of_lookup` + `singleton_mono (by decide)` — replaces the
+manual `ofProg_mono_sub`/`ofProg_lookup_addr`/`memAt` plumbing),
+`lift_code`/`liftCode`, and the apply-and-discharge wrappers `abi_frame` /
+`countdown_loop` / `countdown_loop_bottom` / `frame_call` (all
+`abiFrame_spec`/loop/call side-conditions auto-closed; only the genuine body
+triple/invariant remains).  `SAsm/AbiFrameLoopBottom.lean` adds the
+`do-while` loop lemma `countdownLoopBottom_spec` + the writable dword-array
+region `dwordsIs`/`dwordsIs_at_set` (the store-loop analogue of
+`bytesRegion`).  Re-derived via the tactics with identical statements:
+`mulFrame_spec`/`mulLoop_spec`, `bumpCall_spec`/`twiceFrame_spec`.  First
+REAL cross-call sp-frame port: `bnq_set_one`
+(`Codegen/Programs/Bn254Fq12SetOneSAsm.lean`, bead 4ch8f.58.3.17,
+byte-TRANSPARENT — the emitted `bnqSetOne_prog` IS the `abiFrameProg`
+flatten, `#guard`/`rfl`, no guest-byte change, no A/B needed): the callee
+`bnq_zero` gets a flat whole-routine contract (`bnqZeroFlat_spec`,
+bottom-test store loop over `dwordsIs`, genuine zero-prefix invariant)
+consumed by `callWithin_spec`; `bnqSetOneFrame_spec` concludes sp/ra/s0
+restored + the FQ12 at entry `a0` = ONE (dword 0 = 1, rest 0) — resolving
+blocker bead 4ch8f.58.3.17.1 (the "FnHandle call bridge" gap) via the flat
+contract route.  All classical-3; recipe in `FramePort.lean`'s module doc.
 Indirect calls landed
 (`Stmt.callReg`, bead evm-asm-4ch8f.4): `jalr ra, rs, 0` against a
 finite handle table — `.pre` VC = register pins some handle's entry


### PR DESCRIPTION
Turns the sp-frame port boilerplate into automation (bead `evm-asm-4ch8f.76.3`, child of `4ch8f.76`), following the merged #9978. Refs #9949 #9956 #9962 #9975 #9978.

## The tactic layer (`EvmAsm/Rv64/SAsm/FramePort.lean`)

| goal | tactic | closes |
|---|---|---|
| `P.pcFree` (atoms + `bytesRegion`/`stackFree`/`dwordsIs`/`regsAt`/`frameSlots*`) | `pcf` | always |
| code membership (`singleton`/`ofProg … ⊆ cr`, concrete) | `code_mem` | always (kernel evaluation via the new `CodeReq.sub_ofProg_of_lookup`; replaces the manual `ofProg_mono_sub`/`ofProg_lookup_addr`/`memAt` plumbing) |
| lift a slice/loop/call triple into the routine CodeReq | `lift_code` / `liftCode` | always |
| `abiFrame_spec` wrap + its ~12 side-conditions | `abi_frame posImm halign hbody` | all but the body triple |
| `countdownLoop_spec` / `countdownLoopBottom_spec` + side-conditions | `countdown_loop` / `countdown_loop_bottom` | all but the per-iteration body |
| `abiFrameCall_spec` + side-conditions | `frame_call offset hcallee` | all but the callee contract |

**Zero soundness surface**: every tactic assembles existing kernel-checked lemmas (`decide`/`rfl`/`omega`/lemma application); nothing admitted, no forbidden tactics, no `maxHeartbeats`/`maxRecDepth`. The module doc is the **recipe**: the 4-step "how to port an sp-frame routine", the closes/you-supply table, worked-example pointers, and known limits — concrete enough for other sessions to port from.

New reusable core (`EvmAsm/Rv64/SAsm/AbiFrameLoopBottom.lean`): `countdownLoopBottom_spec` (the **do-while** loop shape the converter helpers emit — body ; `bne ctr,x0,back`; register-agnostic, free invariant family) and `dwordsIs` (writable dword-array region) with `dwordsIs_at_set` (shared-frame cell extraction, the SD-store analogue of `bytesRegion_dword_at_set`).

## Acceptance 1 — re-derivations (identical statements, boilerplate gone)

- `AbiFrameLoopDemo`: `mulLoop_spec` = **one line** (`countdown_loop`); `mulFrame_spec`'s ~25-line `abiFrame_spec` application = `abi_frame`; `memAt` plumbing deleted. Net **−46 lines**.
- `AbiFrameCallDemo`: `bumpCall_spec`/`twiceFrame_spec` via `abi_frame` + auto side-conditions. Net **−80 lines**.
- Statements byte-for-byte unchanged (same genuine posts, `#guard`/`rfl` byte-ties intact); `#print axioms` = classical-3 on all.
- `ParentHeaderFrame` (84 instrs) keeps its explicit application — the wrapper's automated search hits elaboration limits at that scale; recorded as a known limit in the recipe (its boilerplate savings for FUTURE ports come from `code_mem`/`pcf`/the loop/call wrappers regardless).

## Acceptance 2 — a genuinely NEW routine ported with the tactics

**`bnq_set_one`** (`EvmAsm/Codegen/Programs/Bn254Fq12SetOneSAsm.lean`) — the first real **cross-call** sp-frame guest routine, resolving bead `4ch8f.58.3.17` and its blocker `4ch8f.58.3.17.1` ("ABI-frame caller body needs FnHandle call bridge with s-register locals") via the flat-contract route:

- **Byte-TRANSPARENT**: `#guard`/`rfl` that the emitted `bnqSetOne_prog` (including the concrete guest-linked `jalOff`) **is** the `abiFrameProg` flatten — verified == emitted, zero guest-byte change (⇒ no ziskemu/EEST A/B applicable), `GuestAddrs` anchors `#guard`-tied.
- `bnqZeroFlat_spec`: flat whole-routine contract for the callee `bnq_zero` — bottom-test store loop over `dwordsIs` with the genuine zero-prefix invariant; all 48 dwords zero, `a0` advanced, `ra` intact.
- `bnqSetOneFrame_spec` (via `abi_frame` + `callWithin_spec`): `sp`, `ra` (clobbered by the real `jal`), and `s0` (clobbered by the body) **restored to entry**; the FQ12 at the entry `a0` holds **ONE** (dword 0 = 1, dwords 1–47 = 0) — the genuine, unweakened semantics.

## Gates

Full `lake build` green; `check-forbidden-tactics` OK; `check-axioms` OK (`bnqZeroFlat_spec`/`bnqSetOneFrame_spec` and all re-derived specs = `[propext, Classical.choice, Quot.sound]`); `check-layering` OK (the port file lives in Codegen, which may import core; core imports nothing back). Additive — structured layer untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)