### PR TITLE
fix(eest): charge Amsterdam CREATE access gas

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -474,8 +474,8 @@ def emitJumpTable (registry : List OpcodeHandlerSpec) : String :=
     (`execution-specs/src/ethereum/forks/prague/vm/gas.py`): ZERO=0,
     JUMPDEST=1, BASE=2, VERYLOW=3, LOW=5, MID=8, HIGH=10, BLOCKHASH=20,
     KECCAK256 base=30, LOG base=375, warm access=100. Amsterdam/EIP-8037
-    moves the account-growth portion of CREATE/CREATE2 into state gas, so the
-    regular static base is 9000 rather than the pre-Amsterdam 32000.
+    charges CREATE/CREATE2's account-access regular component as
+    CREATE_ACCESS = ACCOUNT_WRITE(8000) + COLD_STORAGE_ACCESS(3000).
 
     **Static base costs only** — all *dynamic* components are dropped:
     memory-expansion, copy (per-word), KECCAK/LOG per-word/per-topic, EXP
@@ -530,7 +530,7 @@ def staticGasCost (op : Nat) : Nat :=
     | 0x5e => 3                                              -- MCOPY (base)
     | 0x5f => 2                                              -- PUSH0 (BASE)
     -- child frames (base; dynamic call/create costs dropped)
-    | 0xf0 => 9000 | 0xf5 => 9000                              -- CREATE, CREATE2
+    | 0xf0 => 11000 | 0xf5 => 11000                            -- CREATE, CREATE2
     | 0xf1 | 0xf2 | 0xf4 | 0xfa => 100                       -- CALL,CALLCODE,DELEGATECALL,STATICCALL
     | 0xff => 5000                                           -- SELFDESTRUCT (base)
     -- STOP (0x00), RETURN (0xf3), REVERT (0xfd), INVALID (0xfe),

--- a/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
+++ b/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
@@ -254,7 +254,7 @@ def callMemoryExpansionGasAsm
   ".Lcallmem_" ++ tag ++ "_done:\n"
 
 /-- CREATE-family initcode dynamic gas. The dispatch loop already charges
-    `OPCODE_CREATE_BASE = 9000`; this charges the EIP-3860 initcode word
+    `CREATE_ACCESS = 11000`; this charges the EIP-3860 initcode word
     cost `2 * ceil32(size) / 32`, and for CREATE2 also the EIP-1014 hashcost
     `6 * ceil32(size) / 32`. Memory expansion is handled separately by
     `updateActiveMemorySizeAsm` over the same initcode range.

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -1203,33 +1203,33 @@ def opcodeTestCases : List OpcodeTestCase :=
       env              := "address=0x1234567890abcdef1234567890abcdef12345678"
       expectedOutHex   := "178d3687bd025a14373c429091ba42d0e82d853d000000000000000000000000"
       expectedHaltKind := "0000000000000000" }
-  , -- CREATE2 size=1 charges static CREATE base, EIP-3860 initcode word
+  , -- CREATE2 size=1 charges CREATE_ACCESS, EIP-3860 initcode word
     -- gas, EIP-1014 hashcost, and memory expansion: 4 PUSH1s (12) +
-    -- 9000 + 8 + 3.
+    -- 11000 + 8 + 3.
     { name             := "create2_initcode_len1_gas_exact"
       bytecode         := "0x60, 0x00, 0x60, 0x01, 0x60, 0x00, 0x60, 0x00, 0xf5, 0x00"
       expectedOutHex   := "38bf260bb3b098f0ff6ff250028ff8b42b2e1a4d000000000000000000000000"
       expectedHaltKind := "0000000000000000"
-      gasLimit         := "9023" }
+      gasLimit         := "11023" }
   , -- One less gas fails in CREATE2's dynamic initcode charge before
     -- address derivation or later unsupported deployment slices.
     { name             := "create2_initcode_len1_out_of_gas"
       bytecode         := "0x60, 0x00, 0x60, 0x01, 0x60, 0x00, 0x60, 0x00, 0xf5, 0x00"
       expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
       expectedHaltKind := "0600000000000000"
-      gasLimit         := "9022" }
+      gasLimit         := "11022" }
   , -- At 33 bytes CREATE2 rounds to two words for both EIP-3860 and
-    -- EIP-1014 hashcost: 4 PUSH1s (12) + 9000 + 16 + memory gas 6.
+    -- EIP-1014 hashcost: 4 PUSH1s (12) + 11000 + 16 + memory gas 6.
     { name             := "create2_initcode_len33_gas_exact"
       bytecode         := "0x60, 0x00, 0x60, 0x21, 0x60, 0x00, 0x60, 0x00, 0xf5, 0x00"
       expectedOutHex   := "05539a1fc4f022d6cdeb61c98ff5d21bf5d5d9b9000000000000000000000000"
       expectedHaltKind := "0000000000000000"
-      gasLimit         := "9034" }
+      gasLimit         := "11034" }
   , { name             := "create2_initcode_len33_out_of_gas"
       bytecode         := "0x60, 0x00, 0x60, 0x21, 0x60, 0x00, 0x60, 0x00, 0xf5, 0x00"
       expectedOutHex   := "0000000000000000000000000000000000000000000000000000000000000000"
       expectedHaltKind := "0600000000000000"
-      gasLimit         := "9033" }
+      gasLimit         := "11033" }
   , -- CREATE2 size is the third decoded word. High size limbs are rejected
     -- before later address/precheck/deployment slices consume initcode.
     { name             := "create2_high_size_limb_out_of_gas"


### PR DESCRIPTION
## Summary
- charge runtime CREATE/CREATE2 static gas as Amsterdam CREATE_ACCESS = ACCOUNT_WRITE + COLD_STORAGE_ACCESS = 11000
- update CREATE2 exact-gas runtime fixtures from the old 9000 base to 11000
- update the dynamic initcode helper comment to match the dispatch table

This removes the CREATE-family gas undercount at the emitted opcode table. It does not add any receipt-tail adjustment or post-fact normalization.

## Verification
- lake build
- scripts/check-file-size.sh
- scripts/check-asm-to-program.sh
- scripts/check-opcode-tables.sh
- scripts/check-region-map.sh --no-build
- Spike focused: create_opcode_emits_log: 4/4 full match
- Spike focused: failed_create_with_value_no_log: 2/2 full match
- Spike focused: create_collision_no_log: 2/2 full match
- Spike focused: initcode_calls_with_value: 2/2 full match
- Spike focused: create_out_of_gas_no_log: 3/3 full match
- Spike random: --limit 220 --random --seed 90709003: 198/210 full matches before stopping at 12 known separate failures; root/tail matched for all 210 ran
