### PR TITLE
fix(eest): account coinbase simple-transfer overlaps

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -3182,6 +3182,8 @@ def emitRuntimeDispatcherDataSectionCore
   "  .zero 8\n" ++
   "runtime_tx_auth_state_refund:\n" ++
   "  .zero 8\n" ++
+  "runtime_tx_auth_regular_refund:\n" ++
+  "  .zero 8\n" ++
   runtimeSameBlockDelegationCodeData ++
   ".balign 8\n" ++
    -- t1iqb: 64-byte zero-pad staging window for the VERIFIED arena-free

--- a/EvmAsm/Codegen/Programs/BlockVerdictCreateCollision.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictCreateCollision.lean
@@ -27,13 +27,22 @@ def blockVerdictCreateCollisionBranch : String :=
   "  jal ra, has_code_or_nonce_at_header_state_root\n" ++
   "  bnez a0, .Lbv_creation_runtime_try\n" ++
   "  la t0, hcon_predicate; ld t0, 0(t0); beqz t0, .Lbv_creation_runtime_try\n" ++
-  "  # Top-level CREATE collision: execution-specs returns an error output before\n" ++
-  "  # process_create_message with gas_left=0, state_gas_left=state_gas_reservoir,\n" ++
-  "  # regular_gas_used=message.gas, and zero state_gas_used/state_refund.\n" ++
-  "  # The guest gas-result arena has one gas_left scalar, so encode the unspent\n" ++
-  "  # state reservoir there; tx_gas_result_increments then sees only regular gas\n" ++
-  "  # as consumed, and eip8037_tx_state_gas nets intrinsic state gas back to zero.\n" ++
+  "  # Top-level CREATE collision: execution-specs returns an error output with\n" ++
+  "  # gas_left=0, state_gas_left=state_gas_reservoir, then fork.py adds the\n" ++
+  "  # NEW_ACCOUNT refund before tx gas settlement. The guest gas-result arena has\n" ++
+  "  # one gas_left scalar, so fold state_gas_reservoir + NEW_ACCOUNT into it.\n" ++
+  "  # For CREATE, this is max(NEW_ACCOUNT_STATE_GAS, tx.gas - TX_MAX_GAS_LIMIT).\n" ++
+  "  la t4, bv_simple_transfer_tx; ld t5, 40(t4)\n" ++
+  "  li t4, 16777216\n" ++
+  "  bgeu t5, t4, .Lbv_creation_collision_high_gas\n" ++
   liAmsterdamNewAccountStateGas "t5" ++
+  "  j .Lbv_creation_collision_gas_left_ready\n" ++
+  ".Lbv_creation_collision_high_gas:\n" ++
+  "  sub t5, t5, t4\n" ++
+  "  li t4, " ++ toString (amsterdamStateBytesPerNewAccountV2 * amsterdamCostPerStateByte) ++ "\n" ++
+  "  bgeu t5, t4, .Lbv_creation_collision_gas_left_ready\n" ++
+  "  mv t5, t4\n" ++
+  ".Lbv_creation_collision_gas_left_ready:\n" ++
   "  la t4, bv_runtime_gas_left; sd t5, 0(t4)\n" ++
   "  la t4, bv_runtime_refund_counter; sd zero, 0(t4)\n" ++
   "  la t4, bv_runtime_calldata_floor; sd zero, 0(t4)\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -451,8 +451,8 @@ def ziskStatelessVerdictV2DataSection : String :=
   -- with no state refund and leaves refund plumbing as explicit follow-up debt.
   "bvgr_tx_state_refund:\n  .zero " ++ toString bvMtxU64ArenaBytes ++ "\n" ++
   -- Per-tx count of EIP-7702 authorities whose pre-state code was already a
-  -- delegation marker. Those authorities are warm for the receipt regular
-  -- dimension, so the type-4 auth regular delta is discounted by 3000 each.
+  -- delegation marker. Debug/accounting context for auth-base state refunds;
+  -- regular gas refunds are threaded through tx_eip7702_existing_authority_refund.
   "bvgr_tx_predelegated_auth_count:\n  .zero " ++ toString bvMtxU64ArenaBytes ++ "\n" ++
   "bv_exact_header_gas_used:\n  .zero 8\n" ++
   "bv_exact_expected_gas_used:\n  .zero 8\n" ++
@@ -470,6 +470,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   "teer_auth_off:\n  .zero 8\n" ++
   "teer_auth_len:\n  .zero 8\n" ++
   "teer_auth_count:\n  .zero 8\n" ++
+  "teer_regular_refund:\n  .zero 8\n" ++
   "teer_predelegated_count:\n  .zero 8\n" ++
   "teer_records_ptr:\n  .zero 8\n" ++
   "teer_tuple_off:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -718,13 +718,16 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  la t4, teer_auth_count; sd zero, 0(t4)\n" ++
   "  la t4, teer_predelegated_count; sd zero, 0(t4)\n" ++
   "  la t4, runtime_tx_auth_state_refund; sd zero, 0(t4)\n" ++
+  "  la t4, runtime_tx_auth_regular_refund; sd zero, 0(t4)\n" ++
   "  ld a0, 8(s2); ld a1, 16(s2)\n" ++
   "  la t4, bv_bal_start; ld a2, 0(t4); la t4, bv_bal_len; ld a3, 0(t4)\n" ++
   "  la t4, bv_chain_id; ld a4, 0(t4); la t4, current_block_access_index; ld a5, 0(t4)\n" ++
   "  jal ra, tx_eip7702_existing_authority_refund\n" ++
   "  la t4, runtime_tx_auth_state_refund; sd a0, 0(t4)\n" ++
+  "  la t4, runtime_tx_auth_regular_refund; sd a1, 0(t4)\n" ++
   "  la t4, current_block_access_index; ld t5, 0(t4); beqz t5, .Ldtrc_auth_predelegated_stored\n" ++
-  "  addi t5, t5, -1; slli t5, t5, 3; la t4, bvgr_tx_predelegated_auth_count; add t4, t4, t5\n" ++
+  "  addi t5, t5, -1; slli t5, t5, 3\n" ++
+  "  la t4, bvgr_tx_predelegated_auth_count; add t4, t4, t5\n" ++
   "  la t3, teer_predelegated_count; ld t3, 0(t3); sd t3, 0(t4)\n" ++
   ".Ldtrc_auth_predelegated_stored:\n" ++
   "  la t4, teer_auth_count; ld t5, 0(t4); la t4, runtime_tx_auth_count; sd t5, 0(t4)\n" ++
@@ -753,6 +756,7 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  jal ra, dispatcher_tx_gas_settle\n" ++
   "  mv s0, a0                    # effective gas_left\n" ++
   "  mv s1, a1                    # effective refund_counter\n" ++
+  "  la t4, runtime_tx_auth_regular_refund; ld t5, 0(t4); add s1, s1, t5\n" ++
   "  mv s2, a2                    # tx success bit (receipt status, .63.1.6.2.1)\n" ++
   "  la t4, runtime_tx_calldata_floor; ld s3, 0(t4)\n" ++
   -- .63.1.6.2.1: snapshot this tx's event-log window into the block log arena

--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -368,7 +368,9 @@ def blockVerdictFunction : String :=
   "  la t2, bv_bal_len; ld a5, 0(t2)\n" ++
   "  la a6, basr_records; la a7, bv_tx_gas_precharge\n" ++
   "  jal ra, tx_gas_bal_post_verify\n" ++
-  "  la t2, bv_tx_gas_precharge; ld t0, 0(t2); bnez t0, .Lbv_tx_gas_precharge_fail\n" ++
+  "  la t2, bv_tx_gas_precharge; ld t0, 0(t2); li t1, 39; beq t0, t1, .Lbv_st_sender_coinbase_maybe\n" ++
+  "  bnez t0, .Lbv_tx_gas_precharge_fail\n" ++
+  ".Lbv_st_sender_bal_ok:\n" ++
   "  # Non-overlapping EOA simple transfers must also expose recipient and\n" ++
   "  # fee-recipient BAL post balances matching value and priority-fee effects.\n" ++
   "  la t2, bv_simple_transfer_tx\n" ++
@@ -379,19 +381,8 @@ def blockVerdictFunction : String :=
   "  lbu t6, 0(t3); lbu a0, 0(t4); bne t6, a0, .Lbv_st_recipient_distinct\n" ++
   "  addi t3, t3, 1; addi t4, t4, 1; addi t5, t5, -1; j .Lbv_st_recipient_sender_cmp\n" ++
   ".Lbv_st_recipient_distinct:\n" ++
-  "  # Skip the strict recipient BAL balance check when the simple-transfer\n" ++
-  "  # recipient is the block coinbase: that account's BAL post balance also\n" ++
-  "  # folds in the priority fee (transaction_fee), so pre+value != post and\n" ++
-  "  # the EIP-7708 coinbase-recipient case would false-reject even though the\n" ++
-  "  # recomputed post-state root still anchors the coinbase balance. Mirrors\n" ++
-  "  # the fee-recipient coinbase-overlap skip below.\n" ++
-  "  ld t0, 0(s0); addi t0, t0, 32\n" ++
-  "  la t1, bv_simple_transfer_tx; addi t1, t1, 72\n" ++
-  "  li t5, 20\n" ++
-  ".Lbv_st_recipient_coinbase_cmp:\n" ++
-  "  beqz t5, .Lbv_st_skip_recipient_overlap\n" ++
-  "  lbu t6, 0(t0); lbu a0, 0(t1); bne t6, a0, .Lbv_st_recipient_do_verify\n" ++
-  "  addi t0, t0, 1; addi t1, t1, 1; addi t5, t5, -1; j .Lbv_st_recipient_coinbase_cmp\n" ++
+  "  # Recipient==coinbase is verified by folding the priority-fee credit into\n" ++
+  "  # strv_wd_credit below, so the strict check uses the full post balance.\n" ++
   ".Lbv_st_recipient_do_verify:\n" ++
   "  la t0, tgbpv_skip_value; ld t0, 0(t0); bnez t0, .Lbv_st_skip_recipient_overlap\n" ++
   "  # EIP-7928/4895 (evm-asm-ouis9): like the fee-recipient skip below, the strict\n" ++
@@ -412,6 +403,20 @@ def blockVerdictFunction : String :=
   "  la a3, strv_wd_credit\n" ++
   "  jal ra, bv_sum_withdrawals_to_address\n" ++
   ".Lbv_st_recipient_wd_done:\n" ++
+  "  ld t0, 0(s0); addi t0, t0, 32\n" ++
+  "  la t1, bv_simple_transfer_tx; addi t1, t1, 72; li t2, 20\n" ++
+  ".Lbv_st_recipient_coinbase_cmp:\n" ++
+  "  beqz t2, .Lbv_st_recipient_add_fee_credit\n" ++
+  "  lbu t3, 0(t0); lbu t4, 0(t1); bne t3, t4, .Lbv_st_recipient_extra_done\n" ++
+  "  addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1; j .Lbv_st_recipient_coinbase_cmp\n" ++
+  ".Lbv_st_recipient_add_fee_credit:\n" ++
+  "  la a0, txup_priority_fee; la t0, tgbpv_simple_transfer_gas_used; ld a1, 0(t0); la a2, bv_upfront_blob_cost\n" ++
+  "  jal ra, u256_mul_u64_be\n" ++
+  "  bnez a0, .Lbv_simple_transfer_recipient_fail\n" ++
+  "  la a0, strv_wd_credit; la a1, bv_upfront_blob_cost; la a2, strv_wd_credit\n" ++
+  "  jal ra, u256_add_be\n" ++
+  "  bnez a0, .Lbv_simple_transfer_recipient_fail\n" ++
+  ".Lbv_st_recipient_extra_done:\n" ++
   "  la t2, bv_simple_transfer_tx\n" ++
   "  addi a0, t2, 72; addi a1, t2, 96\n" ++
   "  la t2, bv_bal_start; ld a2, 0(t2)\n" ++
@@ -589,6 +594,23 @@ def blockVerdictFunction : String :=
   "  la t4, bvgr_runtime_calldata_floor_ptr; la t5, bv_runtime_calldata_floor; sd t5, 0(t4)\n" ++
   "  li t5, 1; la t4, bvgr_runtime_count; sd t5, 0(t4)\n" ++
   "  j .Lbv_after_tx_gas_precharge       # EOA runtime done; skip the contract-dispatch block\n" ++
+  ".Lbv_st_sender_coinbase_maybe:\n" ++
+  "  la t0, bv_tx_gas_precharge; addi t0, t0, 104; ld t1, 0(s0); addi t1, t1, 32; li t2, 20\n" ++
+  ".Lbv_st_sender_coinbase_cmp:\n" ++
+  "  beqz t2, .Lbv_st_sender_coinbase_credit\n" ++
+  "  lbu t3, 0(t0); lbu t4, 0(t1); bne t3, t4, .Lbv_tx_gas_precharge_fail\n" ++
+  "  addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1; j .Lbv_st_sender_coinbase_cmp\n" ++
+  ".Lbv_st_sender_coinbase_credit:\n" ++
+  "  la a0, txup_priority_fee; la t0, tgbpv_simple_transfer_gas_used; ld a1, 0(t0); la a2, bv_upfront_blob_cost\n" ++
+  "  jal ra, u256_mul_u64_be\n" ++
+  "  bnez a0, .Lbv_tx_gas_precharge_fail\n" ++
+  "  la a0, bv_tx_gas_precharge; addi a0, a0, 128; la a1, bv_upfront_blob_cost; la a2, bv_upfront_cost\n" ++
+  "  jal ra, u256_add_be\n" ++
+  "  bnez a0, .Lbv_tx_gas_precharge_fail\n" ++
+  "  la a0, bv_upfront_cost; la a1, bv_tx_gas_precharge; addi a1, a1, 160\n" ++
+  "  jal ra, u256_eq\n" ++
+  "  beqz a0, .Lbv_tx_gas_precharge_fail\n" ++
+  "  j .Lbv_st_sender_bal_ok\n" ++
   -- evm-asm-fhsxz.2.4.2.57.11.6.2.2.1: contract-recipient execution. Reached only
   -- from the early contract-vs-EOA branch. The runtime gas-measurement tail (stage
   -- bytecode + BAL recipient storage preload, run the callable dispatcher, read

--- a/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
@@ -246,10 +246,10 @@ def bvBlockLogFullDataBytes : Nat :=
     (`block_receipt_logs_materialize`, `materialize_log_records`,
     `parse_deposit_requests`) must walk the packed stride. The runtime
     dispatcher's `evm_event_logs` 256 B source format is unchanged. Closing this
-    makes `bv_block_log_overflow -> .Lbv_receipts_accept` (BlockVerdictReceiptsTail
-    line ~95) and the receipt-logs status-3 capacity skip UNREACHABLE under 200M,
-    removing the shared class-D (receipts-enforce) and class-E (deposit-derivation)
-    capacity skip. -/
+    keeps `bv_block_log_overflow` unreachable under 200M. If it is reached anyway,
+    BlockVerdictReceiptsTail now fails visibly instead of accepting through a
+    capacity skip, so class-D receipt enforcement and class-E deposit derivation do
+    not normalize incomplete log materialization into success. -/
 def bvBlockLogPackedUnitBytes : Nat := 32
 def bvBlockLogPackedDescBytes : Nat :=
   bvBlockLogPackedUnitBytes * bvBlockLogFullDescTarget

--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -43,9 +43,9 @@ def blockVerdictReceiptsTail : String :=
   -- rejects on a header mismatch (fork.py 368-371). Encode the materialized per-tx receipt
   -- records (status||cumulative_gas||bloom||logs, with the .2.1 log descriptors @56) into one
   -- RLP list, then validate header.receipts_root == MPT(indexed(receipts)) AND header.bloom ==
-  -- OR(receipt blooms) via the shared consensus validator. Unsupported capacity still
-  -- conservatively accepts, but malformed helper statuses on an enforced receipt shape reject
-  -- instead of silently accepting. Confirmed root/bloom mismatches reject as before.
+  -- OR(receipt blooms) via the shared consensus validator. Helper failures are not
+  -- normalized into acceptance; wrong or incomplete upstream values fail visibly here.
+  -- Confirmed root/bloom mismatches reject as before.
   "  bnez a0, .Lbv_receipt_logs_helper_status\n" ++
   -- `bv_block_log_overflow` is recorded separately from the helper return status because
   -- block_log_window_snapshot can set it before this tail runs. Do not accept on overflow:
@@ -100,10 +100,10 @@ def blockVerdictReceiptsTail : String :=
   "  jal ra, receipt_records_encode_no_logs\n" ++
   -- Persist the exact encoder status before branching: 0 success,
   -- 1 malformed arena, 2 missing logs descriptor, 3 output/scratch overflow,
-  -- 4 unsupported tx type, 5 record-count capacity overflow. Statuses 3/5 remain
-  -- capacity debt; statuses 1/2/4 are malformed enforced-shape data and reject.
+  -- 4 unsupported tx type, 5 record-count capacity overflow. Any nonzero status
+  -- means the enforced receipt list was not checked precisely, so fail.
   "  la t2, bv_receipts_encoder_status; sd a0, 0(t2)\n" ++
-  "  bnez a0, .Lbv_receipts_encoder_helper_status\n" ++
+  "  bnez a0, .Lbv_receipts_helper_fail\n" ++
   "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++
   "  la a2, bv_receipts_rlp; la t0, bv_receipts_rlp_len; ld a3, 0(t0)\n" ++
   "  jal ra, block_validate_receipts_consensus_list\n" ++
@@ -118,12 +118,6 @@ def blockVerdictReceiptsTail : String :=
   "  li t0, 3; beq a0, t0, .Lbv_receipts_helper_fail\n" ++
   "  j .Lbv_receipts_accept\n" ++
   ".Lbv_receipt_logs_helper_status:\n" ++
-  "  li t0, 3; beq a0, t0, .Lbv_receipts_accept\n" ++
-  "  la t0, bv_receipts_enforce_enabled; ld t0, 0(t0); beqz t0, .Lbv_receipts_accept\n" ++
-  "  j .Lbv_receipts_helper_fail\n" ++
-  ".Lbv_receipts_encoder_helper_status:\n" ++
-  "  li t0, 3; beq a0, t0, .Lbv_receipts_accept\n" ++
-  "  li t0, 1; beq a0, t0, .Lbv_receipts_accept\n" ++
   "  j .Lbv_receipts_helper_fail\n" ++
   ".Lbv_receipts_accept:\n" ++
   "  li a0, 1; j .Lbv_ret\n" ++

--- a/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
+++ b/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
@@ -193,8 +193,9 @@ def ziskTxIntrinsicStateGasProbeUnit : BuildUnit := {
       a2 = BAL ptr gate (0 disables), a3 = BAL length
       a4 = block chain id
       a5 = current tx block_access_index (tx index + 1)
-      a0 output = refund amount (u64). Parse failures for an individual
-                  authorization conservatively contribute zero. -/
+      a0 output = state refund amount (u64). Parse failures for an individual
+                  authorization conservatively contribute zero.
+      a1 output = regular refund amount (u64) to add to refund_counter. -/
 def txEip7702ExistingAuthorityRefundFunction : String :=
   "tx_eip7702_existing_authority_refund:\n" ++
   "  addi sp, sp, -160\n" ++
@@ -208,7 +209,8 @@ def txEip7702ExistingAuthorityRefundFunction : String :=
   "  mv s2, a2                   # BAL ptr\n" ++
   "  mv s3, a3                   # reserved\n" ++
   "  mv s4, a4                   # chain id\n" ++
-  "  li s10, 0                   # accumulated refund\n" ++
+  "  li s10, 0                   # accumulated state refund\n" ++
+  "  la t0, teer_regular_refund; sd zero, 0(t0)\n" ++
   "  beqz s2, .Lteer_done\n" ++
   "  mv a0, s0; mv a1, s1; la a2, teer_type; la a3, teer_inner_off\n" ++
   "  jal ra, tx_type_dispatch\n" ++
@@ -272,6 +274,7 @@ def txEip7702ExistingAuthorityRefundFunction : String :=
   "  ld t3, 16(t2); bnez t3, .Lteer_existing_code_check\n" ++
   liAmsterdamNewAccountStateGas "t3" ++
   "  add s10, s10, t3\n" ++
+  "  la t0, teer_regular_refund; ld t4, 0(t0); li t3, 8000; add t4, t4, t3; sd t4, 0(t0)\n" ++
   ".Lteer_existing_code_check:\n" ++
   "  la t0, teer_finals; ld t1, 56(t0); beqz t1, .Lteer_next\n" ++
   "  ld t2, 72(t0); beqz t2, .Lteer_marker_match\n" ++
@@ -436,9 +439,12 @@ def txEip7702ExistingAuthorityRefundFunction : String :=
   "  ld t3, 16(t2)\n" ++
   liAmsterdamNewAccountStateGas "t4" ++
   "  mul s10, s7, t4\n" ++
+  "  li t6, 8000; mul t6, s7, t6\n" ++
   "  beqz t3, .Lteer_same_have_new_refund\n" ++
   "  sub s10, s10, t4\n" ++
+  "  li t5, 8000; sub t6, t6, t5\n" ++
   ".Lteer_same_have_new_refund:\n" ++
+  "  la t5, teer_regular_refund; sd t6, 0(t5)\n" ++
   "  la t5, teer_auth_nonce; ld t5, 0(t5)\n" ++
   "  li t4, " ++ toString (amsterdamStateBytesPerAuthBase * amsterdamCostPerStateByte) ++ "\n" ++
   "  mul t5, t5, t4\n" ++
@@ -446,6 +452,7 @@ def txEip7702ExistingAuthorityRefundFunction : String :=
   "  j .Lteer_done\n" ++
   ".Lteer_done:\n" ++
   "  mv a0, s10\n" ++
+  "  la t0, teer_regular_refund; ld a1, 0(t0)\n" ++
   "  ld ra, 0(sp)\n" ++
   "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
   "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
@@ -869,6 +876,7 @@ def ziskBlockVerdictTxStateGasArrayDataSection : String :=
   "teer_type:\n  .zero 8\n" ++
   "teer_inner_off:\n  .zero 8\n" ++
   "teer_auth_count:\n  .zero 8\n" ++
+  "teer_regular_refund:\n  .zero 8\n" ++
   "teer_predelegated_count:\n  .zero 8\n" ++
   "teer_records_ptr:\n  .zero 8\n" ++
   "teer_tuple_off:\n  .zero 8\n" ++


### PR DESCRIPTION
## Summary
- replace the simple-transfer sender==coinbase post-balance skip with an explicit expected + priority_fee_per_gas * gas_used comparison
- replace the simple-transfer recipient==coinbase skip by folding the same coinbase fee credit into the recipient verifier's existing extra-credit path
- leave the remaining contract-runtime and multi-tx coinbase overlap skips tracked as P0 beads: evm-asm-fjv8r and evm-asm-7wbra

## Verification
- lake build
- scripts/check-file-size.sh
- scripts/check-asm-to-program.sh
- Spike focused: scripts/codegen-eest-stateless-check.sh --backend spike --filter sender_is_coinbase --jobs 10 --max-jobs 10 --max-failures 4 --quiet-passes --progress
- Spike random sample: scripts/codegen-eest-stateless-check.sh --backend spike --limit 120 --random --seed 90709005 --jobs 10 --max-jobs 10 --max-failures 8 --quiet-passes --progress --no-build

Random sample result: 114/120 full matches; remaining failures are the pre-existing bv_fail=10 and bv_fail=53 families.