### PR TITLE
fix(eest): apply EIP-7702 regular auth refunds

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -3182,6 +3182,8 @@ def emitRuntimeDispatcherDataSectionCore
   "  .zero 8\n" ++
   "runtime_tx_auth_state_refund:\n" ++
   "  .zero 8\n" ++
+  "runtime_tx_auth_regular_refund:\n" ++
+  "  .zero 8\n" ++
   runtimeSameBlockDelegationCodeData ++
   ".balign 8\n" ++
    -- t1iqb: 64-byte zero-pad staging window for the VERIFIED arena-free

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -451,8 +451,8 @@ def ziskStatelessVerdictV2DataSection : String :=
   -- with no state refund and leaves refund plumbing as explicit follow-up debt.
   "bvgr_tx_state_refund:\n  .zero " ++ toString bvMtxU64ArenaBytes ++ "\n" ++
   -- Per-tx count of EIP-7702 authorities whose pre-state code was already a
-  -- delegation marker. Those authorities are warm for the receipt regular
-  -- dimension, so the type-4 auth regular delta is discounted by 3000 each.
+  -- delegation marker. Debug/accounting context for auth-base state refunds;
+  -- regular gas refunds are threaded through tx_eip7702_existing_authority_refund.
   "bvgr_tx_predelegated_auth_count:\n  .zero " ++ toString bvMtxU64ArenaBytes ++ "\n" ++
   "bv_exact_header_gas_used:\n  .zero 8\n" ++
   "bv_exact_expected_gas_used:\n  .zero 8\n" ++
@@ -470,6 +470,7 @@ def ziskStatelessVerdictV2DataSection : String :=
   "teer_auth_off:\n  .zero 8\n" ++
   "teer_auth_len:\n  .zero 8\n" ++
   "teer_auth_count:\n  .zero 8\n" ++
+  "teer_regular_refund:\n  .zero 8\n" ++
   "teer_predelegated_count:\n  .zero 8\n" ++
   "teer_records_ptr:\n  .zero 8\n" ++
   "teer_tuple_off:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -718,13 +718,16 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  la t4, teer_auth_count; sd zero, 0(t4)\n" ++
   "  la t4, teer_predelegated_count; sd zero, 0(t4)\n" ++
   "  la t4, runtime_tx_auth_state_refund; sd zero, 0(t4)\n" ++
+  "  la t4, runtime_tx_auth_regular_refund; sd zero, 0(t4)\n" ++
   "  ld a0, 8(s2); ld a1, 16(s2)\n" ++
   "  la t4, bv_bal_start; ld a2, 0(t4); la t4, bv_bal_len; ld a3, 0(t4)\n" ++
   "  la t4, bv_chain_id; ld a4, 0(t4); la t4, current_block_access_index; ld a5, 0(t4)\n" ++
   "  jal ra, tx_eip7702_existing_authority_refund\n" ++
   "  la t4, runtime_tx_auth_state_refund; sd a0, 0(t4)\n" ++
+  "  la t4, runtime_tx_auth_regular_refund; sd a1, 0(t4)\n" ++
   "  la t4, current_block_access_index; ld t5, 0(t4); beqz t5, .Ldtrc_auth_predelegated_stored\n" ++
-  "  addi t5, t5, -1; slli t5, t5, 3; la t4, bvgr_tx_predelegated_auth_count; add t4, t4, t5\n" ++
+  "  addi t5, t5, -1; slli t5, t5, 3\n" ++
+  "  la t4, bvgr_tx_predelegated_auth_count; add t4, t4, t5\n" ++
   "  la t3, teer_predelegated_count; ld t3, 0(t3); sd t3, 0(t4)\n" ++
   ".Ldtrc_auth_predelegated_stored:\n" ++
   "  la t4, teer_auth_count; ld t5, 0(t4); la t4, runtime_tx_auth_count; sd t5, 0(t4)\n" ++
@@ -753,6 +756,7 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  jal ra, dispatcher_tx_gas_settle\n" ++
   "  mv s0, a0                    # effective gas_left\n" ++
   "  mv s1, a1                    # effective refund_counter\n" ++
+  "  la t4, runtime_tx_auth_regular_refund; ld t5, 0(t4); add s1, s1, t5\n" ++
   "  mv s2, a2                    # tx success bit (receipt status, .63.1.6.2.1)\n" ++
   "  la t4, runtime_tx_calldata_floor; ld s3, 0(t4)\n" ++
   -- .63.1.6.2.1: snapshot this tx's event-log window into the block log arena

--- a/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
+++ b/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
@@ -193,8 +193,9 @@ def ziskTxIntrinsicStateGasProbeUnit : BuildUnit := {
       a2 = BAL ptr gate (0 disables), a3 = BAL length
       a4 = block chain id
       a5 = current tx block_access_index (tx index + 1)
-      a0 output = refund amount (u64). Parse failures for an individual
-                  authorization conservatively contribute zero. -/
+      a0 output = state refund amount (u64). Parse failures for an individual
+                  authorization conservatively contribute zero.
+      a1 output = regular refund amount (u64) to add to refund_counter. -/
 def txEip7702ExistingAuthorityRefundFunction : String :=
   "tx_eip7702_existing_authority_refund:\n" ++
   "  addi sp, sp, -160\n" ++
@@ -208,7 +209,8 @@ def txEip7702ExistingAuthorityRefundFunction : String :=
   "  mv s2, a2                   # BAL ptr\n" ++
   "  mv s3, a3                   # reserved\n" ++
   "  mv s4, a4                   # chain id\n" ++
-  "  li s10, 0                   # accumulated refund\n" ++
+  "  li s10, 0                   # accumulated state refund\n" ++
+  "  la t0, teer_regular_refund; sd zero, 0(t0)\n" ++
   "  beqz s2, .Lteer_done\n" ++
   "  mv a0, s0; mv a1, s1; la a2, teer_type; la a3, teer_inner_off\n" ++
   "  jal ra, tx_type_dispatch\n" ++
@@ -272,6 +274,7 @@ def txEip7702ExistingAuthorityRefundFunction : String :=
   "  ld t3, 16(t2); bnez t3, .Lteer_existing_code_check\n" ++
   liAmsterdamNewAccountStateGas "t3" ++
   "  add s10, s10, t3\n" ++
+  "  la t0, teer_regular_refund; ld t4, 0(t0); li t3, 8000; add t4, t4, t3; sd t4, 0(t0)\n" ++
   ".Lteer_existing_code_check:\n" ++
   "  la t0, teer_finals; ld t1, 56(t0); beqz t1, .Lteer_next\n" ++
   "  ld t2, 72(t0); beqz t2, .Lteer_marker_match\n" ++
@@ -436,9 +439,12 @@ def txEip7702ExistingAuthorityRefundFunction : String :=
   "  ld t3, 16(t2)\n" ++
   liAmsterdamNewAccountStateGas "t4" ++
   "  mul s10, s7, t4\n" ++
+  "  li t6, 8000; mul t6, s7, t6\n" ++
   "  beqz t3, .Lteer_same_have_new_refund\n" ++
   "  sub s10, s10, t4\n" ++
+  "  li t5, 8000; sub t6, t6, t5\n" ++
   ".Lteer_same_have_new_refund:\n" ++
+  "  la t5, teer_regular_refund; sd t6, 0(t5)\n" ++
   "  la t5, teer_auth_nonce; ld t5, 0(t5)\n" ++
   "  li t4, " ++ toString (amsterdamStateBytesPerAuthBase * amsterdamCostPerStateByte) ++ "\n" ++
   "  mul t5, t5, t4\n" ++
@@ -446,6 +452,7 @@ def txEip7702ExistingAuthorityRefundFunction : String :=
   "  j .Lteer_done\n" ++
   ".Lteer_done:\n" ++
   "  mv a0, s10\n" ++
+  "  la t0, teer_regular_refund; ld a1, 0(t0)\n" ++
   "  ld ra, 0(sp)\n" ++
   "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
   "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
@@ -869,6 +876,7 @@ def ziskBlockVerdictTxStateGasArrayDataSection : String :=
   "teer_type:\n  .zero 8\n" ++
   "teer_inner_off:\n  .zero 8\n" ++
   "teer_auth_count:\n  .zero 8\n" ++
+  "teer_regular_refund:\n  .zero 8\n" ++
   "teer_predelegated_count:\n  .zero 8\n" ++
   "teer_records_ptr:\n  .zero 8\n" ++
   "teer_tuple_off:\n  .zero 8\n" ++


### PR DESCRIPTION
## Summary
- return EIP-7702 set_delegation regular ACCOUNT_WRITE refunds from tx_eip7702_existing_authority_refund alongside the existing state refund
- stage the regular refund through block-verdict dispatch and add it to the tx refund counter before receipt gas materialization
- remove the stale count-derived receipt-normalization direction from this path; receipts now use the normal refund-counter mechanism

## Verification
- lake build
- scripts/check-file-size.sh
- scripts/check-asm-to-program.sh
- SPIKE_RUN=/home/yoichi-bkp/evm-asm2/scripts/spike/spike_run EEST_FIXTURES_DIR=/home/yoichi-bkp/evm-asm2/gen-out/eest-fixtures/tests-zkevm@v0.5.0/fixtures/fixtures scripts/codegen-eest-stateless-check.sh --backend spike --filter tx_installs_delegation --jobs 10 --max-jobs 10 --max-failures 8 --quiet-passes --progress  # 8/8 full match
- SPIKE_RUN=/home/yoichi-bkp/evm-asm2/scripts/spike/spike_run EEST_FIXTURES_DIR=/home/yoichi-bkp/evm-asm2/gen-out/eest-fixtures/tests-zkevm@v0.5.0/fixtures/fixtures scripts/codegen-eest-stateless-check.sh --backend spike --random --seed 90709006 --limit 160 --jobs 10 --max-jobs 10 --max-failures 8 --quiet-passes --progress  # 155/160 full match; remaining failures are known unrelated non-delegation areas