### PR TITLE
fix(eest): account CREATE collision state gas left

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictCreateCollision.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictCreateCollision.lean
@@ -27,13 +27,22 @@ def blockVerdictCreateCollisionBranch : String :=
   "  jal ra, has_code_or_nonce_at_header_state_root\n" ++
   "  bnez a0, .Lbv_creation_runtime_try\n" ++
   "  la t0, hcon_predicate; ld t0, 0(t0); beqz t0, .Lbv_creation_runtime_try\n" ++
-  "  # Top-level CREATE collision: execution-specs returns an error output before\n" ++
-  "  # process_create_message with gas_left=0, state_gas_left=state_gas_reservoir,\n" ++
-  "  # regular_gas_used=message.gas, and zero state_gas_used/state_refund.\n" ++
-  "  # The guest gas-result arena has one gas_left scalar, so encode the unspent\n" ++
-  "  # state reservoir there; tx_gas_result_increments then sees only regular gas\n" ++
-  "  # as consumed, and eip8037_tx_state_gas nets intrinsic state gas back to zero.\n" ++
+  "  # Top-level CREATE collision: execution-specs returns an error output with\n" ++
+  "  # gas_left=0, state_gas_left=state_gas_reservoir, then fork.py adds the\n" ++
+  "  # NEW_ACCOUNT refund before tx gas settlement. The guest gas-result arena has\n" ++
+  "  # one gas_left scalar, so fold state_gas_reservoir + NEW_ACCOUNT into it.\n" ++
+  "  # For CREATE, this is max(NEW_ACCOUNT_STATE_GAS, tx.gas - TX_MAX_GAS_LIMIT).\n" ++
+  "  la t4, bv_simple_transfer_tx; ld t5, 40(t4)\n" ++
+  "  li t4, 16777216\n" ++
+  "  bgeu t5, t4, .Lbv_creation_collision_high_gas\n" ++
   liAmsterdamNewAccountStateGas "t5" ++
+  "  j .Lbv_creation_collision_gas_left_ready\n" ++
+  ".Lbv_creation_collision_high_gas:\n" ++
+  "  sub t5, t5, t4\n" ++
+  "  li t4, " ++ toString (amsterdamStateBytesPerNewAccountV2 * amsterdamCostPerStateByte) ++ "\n" ++
+  "  bgeu t5, t4, .Lbv_creation_collision_gas_left_ready\n" ++
+  "  mv t5, t4\n" ++
+  ".Lbv_creation_collision_gas_left_ready:\n" ++
   "  la t4, bv_runtime_gas_left; sd t5, 0(t4)\n" ++
   "  la t4, bv_runtime_refund_counter; sd zero, 0(t4)\n" ++
   "  la t4, bv_runtime_calldata_floor; sd zero, 0(t4)\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
@@ -246,10 +246,10 @@ def bvBlockLogFullDataBytes : Nat :=
     (`block_receipt_logs_materialize`, `materialize_log_records`,
     `parse_deposit_requests`) must walk the packed stride. The runtime
     dispatcher's `evm_event_logs` 256 B source format is unchanged. Closing this
-    makes `bv_block_log_overflow -> .Lbv_receipts_accept` (BlockVerdictReceiptsTail
-    line ~95) and the receipt-logs status-3 capacity skip UNREACHABLE under 200M,
-    removing the shared class-D (receipts-enforce) and class-E (deposit-derivation)
-    capacity skip. -/
+    keeps `bv_block_log_overflow` unreachable under 200M. If it is reached anyway,
+    BlockVerdictReceiptsTail now fails visibly instead of accepting through a
+    capacity skip, so class-D receipt enforcement and class-E deposit derivation do
+    not normalize incomplete log materialization into success. -/
 def bvBlockLogPackedUnitBytes : Nat := 32
 def bvBlockLogPackedDescBytes : Nat :=
   bvBlockLogPackedUnitBytes * bvBlockLogFullDescTarget

--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -43,9 +43,9 @@ def blockVerdictReceiptsTail : String :=
   -- rejects on a header mismatch (fork.py 368-371). Encode the materialized per-tx receipt
   -- records (status||cumulative_gas||bloom||logs, with the .2.1 log descriptors @56) into one
   -- RLP list, then validate header.receipts_root == MPT(indexed(receipts)) AND header.bloom ==
-  -- OR(receipt blooms) via the shared consensus validator. Unsupported capacity still
-  -- conservatively accepts, but malformed helper statuses on an enforced receipt shape reject
-  -- instead of silently accepting. Confirmed root/bloom mismatches reject as before.
+  -- OR(receipt blooms) via the shared consensus validator. Helper failures are not
+  -- normalized into acceptance; wrong or incomplete upstream values fail visibly here.
+  -- Confirmed root/bloom mismatches reject as before.
   "  bnez a0, .Lbv_receipt_logs_helper_status\n" ++
   -- `bv_block_log_overflow` is recorded separately from the helper return status because
   -- block_log_window_snapshot can set it before this tail runs. Do not accept on overflow:
@@ -100,10 +100,10 @@ def blockVerdictReceiptsTail : String :=
   "  jal ra, receipt_records_encode_no_logs\n" ++
   -- Persist the exact encoder status before branching: 0 success,
   -- 1 malformed arena, 2 missing logs descriptor, 3 output/scratch overflow,
-  -- 4 unsupported tx type, 5 record-count capacity overflow. Statuses 3/5 remain
-  -- capacity debt; statuses 1/2/4 are malformed enforced-shape data and reject.
+  -- 4 unsupported tx type, 5 record-count capacity overflow. Any nonzero status
+  -- means the enforced receipt list was not checked precisely, so fail.
   "  la t2, bv_receipts_encoder_status; sd a0, 0(t2)\n" ++
-  "  bnez a0, .Lbv_receipts_encoder_helper_status\n" ++
+  "  bnez a0, .Lbv_receipts_helper_fail\n" ++
   "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++
   "  la a2, bv_receipts_rlp; la t0, bv_receipts_rlp_len; ld a3, 0(t0)\n" ++
   "  jal ra, block_validate_receipts_consensus_list\n" ++
@@ -118,12 +118,6 @@ def blockVerdictReceiptsTail : String :=
   "  li t0, 3; beq a0, t0, .Lbv_receipts_helper_fail\n" ++
   "  j .Lbv_receipts_accept\n" ++
   ".Lbv_receipt_logs_helper_status:\n" ++
-  "  li t0, 3; beq a0, t0, .Lbv_receipts_accept\n" ++
-  "  la t0, bv_receipts_enforce_enabled; ld t0, 0(t0); beqz t0, .Lbv_receipts_accept\n" ++
-  "  j .Lbv_receipts_helper_fail\n" ++
-  ".Lbv_receipts_encoder_helper_status:\n" ++
-  "  li t0, 3; beq a0, t0, .Lbv_receipts_accept\n" ++
-  "  li t0, 1; beq a0, t0, .Lbv_receipts_accept\n" ++
   "  j .Lbv_receipts_helper_fail\n" ++
   ".Lbv_receipts_accept:\n" ++
   "  li a0, 1; j .Lbv_ret\n" ++


### PR DESCRIPTION
## Summary
- fold execution-specs CREATE-collision state_gas_reservoir plus NEW_ACCOUNT refund into the guest's synthetic gas_left scalar
- keep top-level CREATE collision receipt gas derived through the normal gas-result arena instead of a receipt-tail correction

## Verification
- lake build
- scripts/check-file-size.sh
- scripts/check-asm-to-program.sh
- focused Spike: contract_creation_tx_collision selected 2, full match 2, fail 0
- random Spike seed 90709006 limit 160: full match 157/160, fail 3

Remaining random failures in that sample are unrelated to this fix:
- selfdestruct_mainnet.json: bv_fail=53 receipt root/gas path
- value_moving_transactions.json rows 00099 and 00104: bv_fail=10 with runtime_count=0