### PR TITLE
fix(eest): fail receipt helper status paths

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
@@ -246,10 +246,10 @@ def bvBlockLogFullDataBytes : Nat :=
     (`block_receipt_logs_materialize`, `materialize_log_records`,
     `parse_deposit_requests`) must walk the packed stride. The runtime
     dispatcher's `evm_event_logs` 256 B source format is unchanged. Closing this
-    makes `bv_block_log_overflow -> .Lbv_receipts_accept` (BlockVerdictReceiptsTail
-    line ~95) and the receipt-logs status-3 capacity skip UNREACHABLE under 200M,
-    removing the shared class-D (receipts-enforce) and class-E (deposit-derivation)
-    capacity skip. -/
+    keeps `bv_block_log_overflow` unreachable under 200M. If it is reached anyway,
+    BlockVerdictReceiptsTail now fails visibly instead of accepting through a
+    capacity skip, so class-D receipt enforcement and class-E deposit derivation do
+    not normalize incomplete log materialization into success. -/
 def bvBlockLogPackedUnitBytes : Nat := 32
 def bvBlockLogPackedDescBytes : Nat :=
   bvBlockLogPackedUnitBytes * bvBlockLogFullDescTarget

--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -43,9 +43,9 @@ def blockVerdictReceiptsTail : String :=
   -- rejects on a header mismatch (fork.py 368-371). Encode the materialized per-tx receipt
   -- records (status||cumulative_gas||bloom||logs, with the .2.1 log descriptors @56) into one
   -- RLP list, then validate header.receipts_root == MPT(indexed(receipts)) AND header.bloom ==
-  -- OR(receipt blooms) via the shared consensus validator. Unsupported capacity still
-  -- conservatively accepts, but malformed helper statuses on an enforced receipt shape reject
-  -- instead of silently accepting. Confirmed root/bloom mismatches reject as before.
+  -- OR(receipt blooms) via the shared consensus validator. Helper failures are not
+  -- normalized into acceptance; wrong or incomplete upstream values fail visibly here.
+  -- Confirmed root/bloom mismatches reject as before.
   "  bnez a0, .Lbv_receipt_logs_helper_status\n" ++
   -- `bv_block_log_overflow` is recorded separately from the helper return status because
   -- block_log_window_snapshot can set it before this tail runs. Do not accept on overflow:
@@ -100,10 +100,10 @@ def blockVerdictReceiptsTail : String :=
   "  jal ra, receipt_records_encode_no_logs\n" ++
   -- Persist the exact encoder status before branching: 0 success,
   -- 1 malformed arena, 2 missing logs descriptor, 3 output/scratch overflow,
-  -- 4 unsupported tx type, 5 record-count capacity overflow. Statuses 3/5 remain
-  -- capacity debt; statuses 1/2/4 are malformed enforced-shape data and reject.
+  -- 4 unsupported tx type, 5 record-count capacity overflow. Any nonzero status
+  -- means the enforced receipt list was not checked precisely, so fail.
   "  la t2, bv_receipts_encoder_status; sd a0, 0(t2)\n" ++
-  "  bnez a0, .Lbv_receipts_encoder_helper_status\n" ++
+  "  bnez a0, .Lbv_receipts_helper_fail\n" ++
   "  la a0, sv_this_rlp; la t0, sv_this_rlp_len; ld a1, 0(t0)\n" ++
   "  la a2, bv_receipts_rlp; la t0, bv_receipts_rlp_len; ld a3, 0(t0)\n" ++
   "  jal ra, block_validate_receipts_consensus_list\n" ++
@@ -118,12 +118,6 @@ def blockVerdictReceiptsTail : String :=
   "  li t0, 3; beq a0, t0, .Lbv_receipts_helper_fail\n" ++
   "  j .Lbv_receipts_accept\n" ++
   ".Lbv_receipt_logs_helper_status:\n" ++
-  "  li t0, 3; beq a0, t0, .Lbv_receipts_accept\n" ++
-  "  la t0, bv_receipts_enforce_enabled; ld t0, 0(t0); beqz t0, .Lbv_receipts_accept\n" ++
-  "  j .Lbv_receipts_helper_fail\n" ++
-  ".Lbv_receipts_encoder_helper_status:\n" ++
-  "  li t0, 3; beq a0, t0, .Lbv_receipts_accept\n" ++
-  "  li t0, 1; beq a0, t0, .Lbv_receipts_accept\n" ++
   "  j .Lbv_receipts_helper_fail\n" ++
   ".Lbv_receipts_accept:\n" ++
   "  li a0, 1; j .Lbv_ret\n" ++


### PR DESCRIPTION
## Summary
- remove receipt-tail helper-status accept paths for log materializer and receipt encoder failures
- keep wrong/incomplete receipt/log materialization visible as verdict failure instead of normalizing it into success
- update the block-log capacity comment to reflect the no-skip behavior

## Verification
- lake build
- scripts/check-file-size.sh
- scripts/check-asm-to-program.sh
- Spike focused: selfdestruct_mainnet (expected remaining bv_fail=53 receipts-root mismatch)
- Spike random: seed 456181708, limit 120, 118/120 full match; remaining failures are the existing value_moving_transactions bv_fail=10 cases