### PR TITLE
feat(sasm): ambient-preserving flat-contract adapter (retSpecFlatAmbient)

### DIFF
--- a/EvmAsm/Rv64/SAsm.lean
+++ b/EvmAsm/Rv64/SAsm.lean
@@ -61,3 +61,4 @@ import EvmAsm.Rv64.SAsm.TwoBreakWritable
 import EvmAsm.Rv64.SAsm.DualReadByteScan
 import EvmAsm.Rv64.SAsm.MultiRegRetTail
 import EvmAsm.Rv64.SAsm.ContForwardJoin
+import EvmAsm.Rv64.SAsm.FnFlatAmbientDemo

--- a/EvmAsm/Rv64/SAsm/FnFlat.lean
+++ b/EvmAsm/Rv64/SAsm/FnFlat.lean
@@ -324,6 +324,92 @@ theorem Fn.retSpecFlat (f : Fn) (base : Word) (hspec : f.Spec base)
       (asrtOf_elim f.rw f.post hpostEmp hpost)) h hq1
 
 -- ============================================================================
+-- The ambient-preserving adapter (bead evm-asm-l0w4a).
+-- ============================================================================
+
+/-- Introduce `asrtOf` at an ARBITRARY (pc-free) ambient: a concrete
+    register file + rw-window pair with the reach's fact at ambient `A` is
+    one witness.  Generalizes `asrtOf_intro` (its `A = empAssertion`
+    instance). -/
+theorem asrtOf_intro_ambient (rw : RwRegion) (reach : Reach) (rf : RegFile)
+    (ws : List (BitVec 8)) (A : Assertion) (hlen : ws.length = rw.len)
+    (hApc : A.pcFree) (hreach : reach rf ws A) :
+    ∀ hp, (((regFileIs rf) ** bytesRegion rw.base ws) ** A) hp →
+      asrtOf rw reach hp :=
+  fun _hp hh => ⟨rf, ws, A, hlen, hApc, hreach, hh⟩
+
+/-- Eliminate `asrtOf` into a caller-chosen flat `Q` at an ARBITRARY fixed
+    ambient, FAITHFULLY: `Q` must follow from the reach itself (for every
+    witness), so nothing weaker than the leaf's own postcondition can be
+    produced.  Requires the reach to pin its ambient to the FIXED `A` —
+    the multi-read shape, where the read-only inputs ride in the ambient
+    unchanged.  Generalizes `asrtOf_elim` (`A = empAssertion`). -/
+theorem asrtOf_elim_ambient (rw : RwRegion) (reach : Reach) (A : Assertion)
+    {Q : Assertion}
+    (hAmb : ∀ rf ws A', reach rf ws A' → A' = A)
+    (h : ∀ (rf : RegFile) (ws : List (BitVec 8)), ws.length = rw.len →
+      reach rf ws A →
+      ∀ hp, (((regFileIs rf) ** bytesRegion rw.base ws) ** A) hp → Q hp) :
+    ∀ hp, asrtOf rw reach hp → Q hp := by
+  rintro hp ⟨rf, ws, A', hlen, hApc, hreach, hsts⟩
+  have hA := hAmb rf ws A' hreach
+  subst hA
+  exact h rf ws hlen hreach hp hsts
+
+/-- **The ambient-preserving flat-contract adapter** (bead evm-asm-l0w4a).
+
+    `Fn.retSpecFlat` forces the leaf's ambient to `empAssertion`
+    (side-condition 3), which rejects MULTI-READ leaves that keep their
+    read-only inputs in the ambient assertion (e.g. `u256_sub_be` /
+    `multiReadFn`: `A = bytesRegion a ** bytesRegion b`,
+    `region = Region.empty`).  This adapter preserves an arbitrary FIXED
+    pc-free ambient `A` across the call instead: the leaf's pre/post must
+    pin the ambient to the same `A` (`hpreAmb` is the leaf's own `f.pre`
+    instantiated; `hpostAmb` replaces `hpostEmp`), and the flat contract
+    carries `A` as an ordinary conjunct on both sides.  Faithfulness is
+    unchanged: the flat `Q` must follow from the leaf's own `f.post`
+    (hypothesis `hpost`), so the adapter cannot be instantiated to
+    anything the leaf's spec does not guarantee. -/
+theorem Fn.retSpecFlatAmbient (f : Fn) (base : Word) (hspec : f.Spec base)
+    (hsz : 4 * (f.body.size + 1) ≤ 2 ^ 64)
+    (ret : Word) (halign : (ret &&& ~~~(1 : Word)) = ret)
+    (rf : RegFile) (ws : List (BitVec 8)) (A : Assertion)
+    (hApc : A.pcFree)
+    (hlen : ws.length = f.rw.len)
+    (hpre : f.pre rf ws A)
+    {Q : Assertion}
+    (hpostAmb : ∀ rf' ws' A', f.post rf' ws' A' → A' = A)
+    (hpost : ∀ (rf' : RegFile) (ws' : List (BitVec 8)),
+      ws'.length = f.rw.len → f.post rf' ws' A →
+      ∀ hp, (((regFileIs rf') ** bytesRegion f.rw.base ws') ** A) hp → Q hp) :
+    cpsTripleWithin (f.body.steps + 1) base ret
+      (CodeReq.ofProg base (f.programRet base))
+      ((((.x1 : Reg) ↦ᵣ ret) ** ((regFileIs rf) ** bytesRegion f.rw.base ws)
+          ** A)
+        ** bytesRegion f.region.base f.region.bytes)
+      ((((.x1 : Reg) ↦ᵣ ret) ** Q)
+        ** bytesRegion f.region.base f.region.bytes) := by
+  have hr := Fn.retSpec f base hspec hsz ret halign
+  refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_) hr
+  · -- flat pre ⊢ (x1 ↦ ret) ** asrtM f.region f.rw f.pre
+    have hp1 : ((((.x1 : Reg) ↦ᵣ ret)
+        ** (((regFileIs rf) ** bytesRegion f.rw.base ws) ** A))
+        ** bytesRegion f.region.base f.region.bytes) h := by
+      xperm_hyp hp
+    have hp2 := sepConj_mono_left (sepConj_mono_right
+      (asrtOf_intro_ambient f.rw f.pre rf ws A hlen hApc hpre)) h hp1
+    show (((.x1 : Reg) ↦ᵣ ret) ** asrtM f.region f.rw f.pre) h
+    unfold asrtM
+    xperm_hyp hp2
+  · -- (x1 ↦ ret) ** asrtM f.region f.rw f.post ⊢ flat post
+    unfold asrtM at hq
+    have hq1 : ((((.x1 : Reg) ↦ᵣ ret) ** asrtOf f.rw f.post)
+        ** bytesRegion f.region.base f.region.bytes) h := by
+      xperm_hyp hq
+    exact sepConj_mono_left (sepConj_mono_right
+      (asrtOf_elim_ambient f.rw f.post A hpostAmb hpost)) h hq1
+
+-- ============================================================================
 -- Glue: atoms → ownership, `get` elimination, dword-region ↔ byte-region.
 -- ============================================================================
 
@@ -392,3 +478,4 @@ end EvmAsm.Rv64
 #print axioms EvmAsm.Rv64.SAsm.regFileIs_eq_regAtoms
 #print axioms EvmAsm.Rv64.SAsm.cpsTripleWithin_peel_regOwns
 #print axioms EvmAsm.Rv64.SAsm.Fn.retSpecFlat
+#print axioms EvmAsm.Rv64.SAsm.Fn.retSpecFlatAmbient

--- a/EvmAsm/Rv64/SAsm/FnFlatAmbientDemo.lean
+++ b/EvmAsm/Rv64/SAsm/FnFlatAmbientDemo.lean
@@ -1,0 +1,90 @@
+/-
+  EvmAsm.Rv64.SAsm.FnFlatAmbientDemo
+
+  Witness for the **ambient-preserving flat-contract adapter**
+  (`Fn.retSpecFlatAmbient`, bead evm-asm-l0w4a): flatten the multi-read
+  demo leaf `multiReadFn` — a leaf `Fn.retSpecFlat` CANNOT flatten,
+  because its pre/post pin the ambient to the two read-only input
+  buffers (`A = bytesRegion a0 bs0 ** bytesRegion a1 bs1`,
+  `region = Region.empty`) rather than `empAssertion`.
+
+  `multiReadFlat_spec` is the §5-shaped flat callee contract: entered at
+  `base` with any aligned return address in `ra`, it returns to `ra`
+  with the writable window pinned to the dword sum of the two ambient
+  inputs, BOTH inputs untouched, and the register file forgotten to
+  ownership — every conjunct derived from the leaf's own `Fn` post
+  through the adapter's faithfulness hypothesis (nothing weakened,
+  nothing invented).
+-/
+
+import EvmAsm.Rv64.SAsm.FnFlat
+import EvmAsm.Rv64.SAsm.MultiRead
+
+namespace EvmAsm.Rv64.SAsm
+
+namespace FnFlatAmbientDemo
+
+open MultiRead
+
+/-- The flat, ambient-preserving contract of the multi-read demo leaf:
+    `[a0..a0+8)` and `[a1..a1+8)` ride through UNCHANGED as ordinary
+    conjuncts, the window at `dst` ends as their dword sum. -/
+theorem multiReadFlat_spec (a0 a1 dst ret base : Word)
+    (bs0 bs1 : List (BitVec 8))
+    (hrw : RwRegion.wf ⟨dst, 8⟩)
+    (hro0 : Region.wf ⟨a0, bs0⟩) (hro1 : Region.wf ⟨a1, bs1⟩)
+    (hbs0 : bs0.length = 8) (hbs1 : bs1.length = 8)
+    (hne0 : a0 ≠ dst) (hne1 : a1 ≠ dst)
+    (halign : (ret &&& ~~~(1 : Word)) = ret)
+    (rf : RegFile) (ws : List (BitVec 8)) (hws : ws.length = 8)
+    (h10 : rf.get .x10 = a0) (h11 : rf.get .x11 = a1)
+    (h12 : rf.get .x12 = dst) :
+    cpsTripleWithin ((multiReadFn a0 a1 dst bs0 bs1).body.steps + 1) base ret
+      (CodeReq.ofProg base ((multiReadFn a0 a1 dst bs0 bs1).programRet base))
+      (((.x1 : Reg) ↦ᵣ ret) ** (regFileIs rf) ** bytesRegion dst ws **
+        (bytesRegion a0 bs0 ** bytesRegion a1 bs1))
+      (((.x1 : Reg) ↦ᵣ ret) **
+        bytesRegion dst (dwordBytes (packBytes bs0 + packBytes bs1)) **
+        (bytesRegion a0 bs0 ** bytesRegion a1 bs1) **
+        regOwns exposedRegs) := by
+  have had := Fn.retSpecFlatAmbient (multiReadFn a0 a1 dst bs0 bs1) base
+    (multiReadFn_spec a0 a1 dst bs0 bs1 base hrw hro0 hro1 hbs0 hbs1
+      hne0 hne1)
+    (by
+      rw [show (multiReadFn a0 a1 dst bs0 bs1).body.size = 4 from rfl]
+      decide)
+    ret halign rf ws (bytesRegion a0 bs0 ** bytesRegion a1 bs1)
+    (pcFree_sepConj (bytesRegion_pcFree _ _) (bytesRegion_pcFree _ _))
+    (show ws.length = 8 from hws)
+    ⟨h10, h11, h12, rfl⟩
+    (Q := bytesRegion dst (dwordBytes (packBytes bs0 + packBytes bs1)) **
+      (bytesRegion a0 bs0 ** bytesRegion a1 bs1) ** regOwns exposedRegs)
+    (fun _rf' _ws' _A' hpost => hpost.2.2)
+    (fun rf' ws' _hlen' hpost' hp hh => by
+      obtain ⟨_h12', hws', _hA⟩ := hpost'
+      rw [hws',
+        show ((multiReadFn a0 a1 dst bs0 bs1).rw.base : Word) = dst from rfl]
+        at hh
+      have hh1 := sepConj_mono_left (sepConj_mono_left (fun h hr => by
+        rw [regFileIs_eq_regAtoms,
+          regAtoms_eq_regAtomsOf rf' exposedRegs (by decide)] at hr
+        exact regAtomsOf_to_regOwns _ _ h hr)) hp hh
+      xperm_hyp hh1)
+  rw [show ((multiReadFn a0 a1 dst bs0 bs1).rw.base : Word) = dst from rfl,
+      show (multiReadFn a0 a1 dst bs0 bs1).region.bytes
+        = ([] : List (BitVec 8)) from rfl,
+      bytesRegion_nil] at had
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      rw [sepConj_emp_right']
+      xperm_hyp hp)
+    (fun h hq => by
+      rw [sepConj_emp_right'] at hq
+      xperm_hyp hq)
+    had
+
+#print axioms multiReadFlat_spec
+
+end FnFlatAmbientDemo
+
+end EvmAsm.Rv64.SAsm


### PR DESCRIPTION
Bead: `evm-asm-l0w4a` (child of 4ch8f.76 / `Fn.retSpecFlat` #9988; porting-agent feedback, `secf_reduce_once` caller/callee). **Overnight stack PR 2/N — stacked on #10075** (`feat/cont-forward-join`).

## The gap

`Fn.retSpecFlat` (#9988) forces the callee's post ambient to `empAssertion` (its side-condition 3, `hpostEmp`), so it cannot flatten **multi-read** callees that keep their read-only inputs in the ambient assertion — the `u256_sub_be`/`multiReadFn` shape: `A = bytesRegion a ** bytesRegion b`, `region = Region.empty`. The porting agent had a local consumer-side workaround; this promotes it as the reusable lemma.

## The adapter — appended to `EvmAsm/Rv64/SAsm/FnFlat.lean`

- **`asrtOf_intro_ambient` / `asrtOf_elim_ambient`** — the `asrtOf` intro/elim at an arbitrary FIXED pc-free ambient `A` (the existing `asrtOf_intro`/`asrtOf_elim` are their `A = empAssertion` instances).
- **`Fn.retSpecFlatAmbient`** — the adapter: the leaf's pre/post pin the ambient to the same `A` (`hpostAmb` replaces `hpostEmp`), and the flat contract carries `A` as an ordinary conjunct on both sides. **Faithfulness unchanged**: the flat `Q` must follow from the leaf's own `f.post` for every witness (hypothesis `hpost`), so nothing weaker than the leaf's spec is derivable.

## The witness — `EvmAsm/Rv64/SAsm/FnFlatAmbientDemo.lean`

`multiReadFlat_spec` flattens the multi-read demo leaf `multiReadFn` (#9883) — whose ambient-pinning post `retSpecFlat` rejects — into the §5-shaped flat callee contract: entered with any aligned `ra`, returns with the writable window pinned to `dwordBytes (packBytes bs0 + packBytes bs1)`, **both** read-only inputs untouched as ordinary conjuncts, register file forgotten to `regOwns exposedRegs`. Every conjunct derived from the leaf's own post through the faithfulness hypothesis.

## Checks

- Full `lake build` green; `check-forbidden-tactics` clean.
- `#print axioms`: `Fn.retSpecFlatAmbient`, `multiReadFlat_spec` — classical-3. In-file.
- Additive (append-only to FnFlat + new demo file); `cpsTripleWithin` level; disjoint from the `point_double` session's files. Unblocks derivations across the crypto/field caller layer (`u256_sub_be` et al.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)