### PR TITLE
feat(bloom): verify bloom_eq SAsm port

### DIFF
--- a/EvmAsm/Codegen/Programs/BloomEqSAsm.lean
+++ b/EvmAsm/Codegen/Programs/BloomEqSAsm.lean
@@ -1,0 +1,703 @@
+/-
+  EvmAsm.Codegen.Programs.BloomEqSAsm
+
+  `bloom_eq` via the **single-exit accumulate loop**
+  (`EvmAsm/Rv64/SAsm/AccumLoop.lean`, bead evm-asm-pr5lu) — the
+  acceptance consumer.
+
+  The routine compares two 256-byte bloom filters dword-by-dword with a
+  constant cycle count (no early exit — timing invariance for gas-cost
+  modeling): 32 iterations of `LD/LD/XOR/OR`, then the verdict
+  `acc == 0` is materialized by `SLTIU` and stored to the u64 out cell.
+
+  **Genuine post** (`bloomEq_spec`): the out dword is
+  `if bsA = bsB then 1 else 0` — REAL byte-list equality of the two
+  256-byte inputs (accumulator residue → per-slot facts → byte equality
+  via `xorAcc_eq_zero_iff_bytes_eq`), `a0 = 0`, both inputs untouched.
+
+  Byte-transparent: stated at the `#guard`-tied `GuestAddrs.bloom_eq`
+  directly over the emitted `bloomEq_prog` (no byte change, no A/B).
+-/
+
+import EvmAsm.Codegen.Programs.Bloom
+import EvmAsm.Rv64.SAsm.AccumLoop
+import EvmAsm.Rv64.SAsm.RetForwardJoin
+import EvmAsm.Rv64.SAsm.FnFlat
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.SAsm.AccumLoop
+
+namespace BloomEqSAsm
+
+-- Address anchor (fails the build if the guest link moves).
+#guard GuestAddrs.bloom_eq = 0x80011dfc
+
+/-
+  Layout (base 0x80011dfc):
+    +0  0x80011dfc  li   x5, 32
+    +4  0x80011e00  mv   x6, x10
+    +8  0x80011e04  mv   x7, x11
+    +12 0x80011e08  li   x30, 0
+    +16 0x80011e0c  beq  x5, x0, +36  → 0x80011e30   [hdr]
+    +20 0x80011e10  ld   x28, 0(x6)
+    +24 0x80011e14  ld   x29, 0(x7)
+    +28 0x80011e18  xor  x28, x28, x29
+    +32 0x80011e1c  or   x30, x30, x28
+    +36 0x80011e20  addi x6, x6, 8
+    +40 0x80011e24  addi x7, x7, 8
+    +44 0x80011e28  addi x5, x5, -1
+    +48 0x80011e2c  jal  x0, -32      → 0x80011e0c
+    +52 0x80011e30  sltiu x30, x30, 1
+    +56 0x80011e34  sd   x12, x30, 0
+    +60 0x80011e38  li   x10, 0
+    +64 0x80011e3c  jalr x0, x1, 0
+-/
+
+section Scan
+
+variable (aPtr bPtr outPtr ret : Word) (bsA bsB : List (BitVec 8))
+
+private theorem ctr_dec (i : Nat) (hi : i < 32) :
+    BitVec.ofNat 64 (32 - i) + signExtend12 (-1 : BitVec 12)
+      = BitVec.ofNat 64 (32 - (i + 1)) := by
+  rw [show signExtend12 (-1 : BitVec 12) = (-1 : Word) from by decide]
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_add, BitVec.toNat_ofNat, BitVec.toNat_ofNat,
+    show ((-1 : Word)).toNat = 18446744073709551615 from rfl]
+  omega
+
+private theorem cursor_advance (p : Word) (i : Nat) :
+    p + BitVec.ofNat 64 (8 * i) + signExtend12 (8 : BitVec 12)
+      = p + BitVec.ofNat 64 (8 * (i + 1)) := by
+  rw [show signExtend12 (8 : BitVec 12) = (8 : Word) from by decide,
+    BitVec.add_assoc]
+  congr 1
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_add, show ((8 : Word)).toNat = 8 from rfl,
+    BitVec.toNat_ofNat, BitVec.toNat_ofNat]
+  omega
+
+private theorem ctr_ne_zero (i : Nat) (hi : i < 32) :
+    ¬ (BitVec.ofNat 64 (32 - i) = (0 : Word)) := by
+  intro h
+  have := congrArg BitVec.toNat h
+  rw [BitVec.toNat_ofNat, show ((0 : Word)).toNat = 0 from rfl] at this
+  omega
+
+/-- Loop invariant at the header after `i` dwords: counter `32 - i`,
+    cursors at dword `i`, the accumulator at `xorAcc bsA bsB i` — a pure
+    function of the inputs, no existential residue. -/
+private def beInv (i : Nat) : Assertion :=
+  ((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+  ((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * i))) **
+  ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * i))) **
+  ((.x30 : Reg) ↦ᵣ xorAcc bsA bsB i) **
+  ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+  ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+  ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+  regOwn .x28 ** regOwn .x29 **
+  bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr
+
+/-- The genuine post: out dword = byte-list equality verdict, `a0 = 0`,
+    inputs untouched. -/
+private def bePost : Assertion :=
+  ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+  ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+  ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+  regOwn .x30 **
+  bytesRegion aPtr bsA ** bytesRegion bPtr bsB **
+  (outPtr ↦ₘ (if bsA = bsB then (1 : Word) else (0 : Word)))
+
+/-- One iteration: header guard (never taken), two cursor dword loads,
+    XOR/OR accumulate, advance, loop back — invariant advanced. -/
+private theorem beIter_spec
+    (hlenA : bsA.length = 256) (hlenB : bsB.length = 256)
+    (i : Nat) (hi : i < 32) :
+    cpsTripleWithin 9 (0x80011e0c : Word) (0x80011e0c : Word)
+      (CodeReq.ofProg (0x80011dfc : Word) bloomEq_prog)
+      (beInv aPtr bPtr outPtr ret bsA bsB i)
+      (beInv aPtr bPtr outPtr ret bsA bsB (i + 1)) := by
+  set CR := CodeReq.ofProg (0x80011dfc : Word) bloomEq_prog with hCR
+  unfold beInv
+  -- peel this iteration's scratch registers x28, x29
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x28)
+      (P := (((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+        ((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * i))) **
+        ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * i))) **
+        ((.x30 : Reg) ↦ᵣ xorAcc bsA bsB i) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr) **
+        regOwn .x29)
+      (fun v28 => ?_))
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x29)
+      (P := (((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+        ((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * i))) **
+        ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * i))) **
+        ((.x30 : Reg) ↦ᵣ xorAcc bsA bsB i) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr) **
+        ((.x28 : Reg) ↦ᵣ v28))
+      (fun v29 => ?_))
+  -- ---- the body instructions ----
+  have hldA := liftCode (cr' := CR)
+    (bytesRegion_ld_cursor_within .x28 .x6 aPtr v28 (0x80011e10 : Word)
+      bsA i (by decide) (by omega))
+    (by rw [hCR]; code_mem)
+  rw [show (0x80011e10 : Word) + 4 = (0x80011e14 : Word) from by decide,
+      show packBytes ((bsA.drop (8 * i)).take 8) = dwordSlot bsA i from rfl]
+    at hldA
+  have hldB := liftCode (cr' := CR)
+    (bytesRegion_ld_cursor_within .x29 .x7 bPtr v29 (0x80011e14 : Word)
+      bsB i (by decide) (by omega))
+    (by rw [hCR]; code_mem)
+  rw [show (0x80011e14 : Word) + 4 = (0x80011e18 : Word) from by decide,
+      show packBytes ((bsB.drop (8 * i)).take 8) = dwordSlot bsB i from rfl]
+    at hldB
+  have hxor := liftCode (cr' := CR)
+    (xor_spec_gen_rd_eq_rs1_within .x28 .x29 (dwordSlot bsA i)
+      (dwordSlot bsB i) (0x80011e18 : Word) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show (0x80011e18 : Word) + 4 = (0x80011e1c : Word) from by decide]
+    at hxor
+  have hor := liftCode (cr' := CR)
+    (or_spec_gen_rd_eq_rs1_within .x30 .x28
+      (xorAcc bsA bsB i) (dwordSlot bsA i ^^^ dwordSlot bsB i)
+      (0x80011e1c : Word) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show (0x80011e1c : Word) + 4 = (0x80011e20 : Word) from by decide]
+    at hor
+  have haddi6 := liftCode (cr' := CR)
+    (addi_spec_gen_same_within .x6 (aPtr + BitVec.ofNat 64 (8 * i))
+      (8 : BitVec 12) (0x80011e20 : Word) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [cursor_advance aPtr i,
+      show (0x80011e20 : Word) + 4 = (0x80011e24 : Word) from by decide]
+    at haddi6
+  have haddi7 := liftCode (cr' := CR)
+    (addi_spec_gen_same_within .x7 (bPtr + BitVec.ofNat 64 (8 * i))
+      (8 : BitVec 12) (0x80011e24 : Word) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [cursor_advance bPtr i,
+      show (0x80011e24 : Word) + 4 = (0x80011e28 : Word) from by decide]
+    at haddi7
+  have haddi5 := liftCode (cr' := CR)
+    (addi_spec_gen_same_within .x5 (BitVec.ofNat 64 (32 - i))
+      (-1 : BitVec 12) (0x80011e28 : Word) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [ctr_dec i hi,
+      show (0x80011e28 : Word) + 4 = (0x80011e2c : Word) from by decide]
+    at haddi5
+  have hjal := liftCode (cr' := CR)
+    (jal_x0_spec_gen_within (-32 : BitVec 21) (0x80011e2c : Word))
+    (by rw [hCR]; code_mem)
+  rw [show (0x80011e2c : Word) + signExtend21 (-32 : BitVec 21)
+    = (0x80011e0c : Word) from by decide] at hjal
+  -- ---- frames + chain of the body (from 0x80011e10) ----
+  have hldAF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+      ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * i))) **
+      ((.x30 : Reg) ↦ᵣ xorAcc bsA bsB i) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x29 : Reg) ↦ᵣ v29) **
+      bytesRegion bPtr bsB ** memOwn outPtr)
+    (by pcf) hldA
+  have hldBF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+      ((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * i))) **
+      ((.x30 : Reg) ↦ᵣ xorAcc bsA bsB i) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x28 : Reg) ↦ᵣ dwordSlot bsA i) **
+      bytesRegion aPtr bsA ** memOwn outPtr)
+    (by pcf) hldB
+  have hxorF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+      ((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * i))) **
+      ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * i))) **
+      ((.x30 : Reg) ↦ᵣ xorAcc bsA bsB i) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+    (by pcf) hxor
+  have horF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+      ((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * i))) **
+      ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * i))) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x29 : Reg) ↦ᵣ dwordSlot bsB i) **
+      bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+    (by pcf) hor
+  have haddi6F := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+      ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * i))) **
+      ((.x30 : Reg) ↦ᵣ xorAcc bsA bsB (i + 1)) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x28 : Reg) ↦ᵣ (dwordSlot bsA i ^^^ dwordSlot bsB i)) **
+      ((.x29 : Reg) ↦ᵣ dwordSlot bsB i) **
+      bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+    (by pcf) haddi6
+  have haddi7F := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+      ((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * (i + 1)))) **
+      ((.x30 : Reg) ↦ᵣ xorAcc bsA bsB (i + 1)) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x28 : Reg) ↦ᵣ (dwordSlot bsA i ^^^ dwordSlot bsB i)) **
+      ((.x29 : Reg) ↦ᵣ dwordSlot bsB i) **
+      bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+    (by pcf) haddi7
+  have haddi5F := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * (i + 1)))) **
+      ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * (i + 1)))) **
+      ((.x30 : Reg) ↦ᵣ xorAcc bsA bsB (i + 1)) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x28 : Reg) ↦ᵣ (dwordSlot bsA i ^^^ dwordSlot bsB i)) **
+      ((.x29 : Reg) ↦ᵣ dwordSlot bsB i) **
+      bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+    (by pcf) haddi5
+  have hjalF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - (i + 1))) **
+      ((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * (i + 1)))) **
+      ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * (i + 1)))) **
+      ((.x30 : Reg) ↦ᵣ xorAcc bsA bsB (i + 1)) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x28 : Reg) ↦ᵣ (dwordSlot bsA i ^^^ dwordSlot bsB i)) **
+      ((.x29 : Reg) ↦ᵣ dwordSlot bsB i) **
+      bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+    (by pcf) hjal
+  have hc1 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hldAF hldBF
+  have hc2 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hc1 hxorF
+  have hc3 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hc2 horF
+  have hc4 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      rw [← xorAcc_succ] at hp
+      xperm_hyp hp) hc3 haddi6F
+  have hc5 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hc4 haddi7F
+  have hc6 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hc5 haddi5F
+  have hc7 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by
+      rw [sepConj_emp_left']
+      xperm_hyp hp) hc6 hjalF
+  -- ---- header guard station (never taken at i < 32) ----
+  have hbrHdr := cpsBranchWithin_frameR
+    (((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * i))) **
+      ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * i))) **
+      ((.x30 : Reg) ↦ᵣ xorAcc bsA bsB i) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+      bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+    (by pcf)
+    (cpsBranchWithin_extend_code (cr' := CR)
+      (h := beq_spec_gen_within .x5 .x0 (36 : BitVec 13)
+        (BitVec.ofNat 64 (32 - i)) (0 : Word) (0x80011e0c : Word))
+      (hmono := by rw [hCR]; code_mem))
+  rw [show (0x80011e0c : Word) + signExtend13 (36 : BitVec 13)
+        = (0x80011e30 : Word) from by decide,
+      show (0x80011e0c : Word) + 4 = (0x80011e10 : Word) from by decide]
+    at hbrHdr
+  -- the body must re-own x28/x29 into the invariant
+  have hbody : cpsTripleWithin 8 (0x80011e10 : Word) (0x80011e0c : Word) CR
+      (((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+        ((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * i))) **
+        ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * i))) **
+        ((.x30 : Reg) ↦ᵣ xorAcc bsA bsB i) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+        bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+      (beInv aPtr bPtr outPtr ret bsA bsB (i + 1)) := by
+    refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun h hq => ?_) hc7
+    rw [sepConj_emp_left'] at hq
+    unfold beInv
+    have hq1 : (((.x28 : Reg) ↦ᵣ (dwordSlot bsA i ^^^ dwordSlot bsB i)) **
+        (((.x29 : Reg) ↦ᵣ dwordSlot bsB i) **
+          (((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - (i + 1))) **
+           ((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * (i + 1)))) **
+           ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * (i + 1)))) **
+           ((.x30 : Reg) ↦ᵣ xorAcc bsA bsB (i + 1)) **
+           ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+           ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+           ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+           bytesRegion aPtr bsA ** bytesRegion bPtr bsB **
+           memOwn outPtr))) h := by
+      xperm_hyp hq
+    have hq2 := sepConj_mono (regIs_to_regOwn .x28 _)
+      (sepConj_mono (regIs_to_regOwn .x29 _)
+        (fun _ hh => hh)) h hq1
+    xperm_hyp hq2
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq)
+    (retJoinStation_spec
+      (cond := (BitVec.ofNat 64 (32 - i) = (0 : Word)))
+      (PT := ((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+        ((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * i))) **
+        ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * i))) **
+        ((.x30 : Reg) ↦ᵣ xorAcc bsA bsB i) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+        bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+      (PF := ((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+        ((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * i))) **
+        ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * i))) **
+        ((.x30 : Reg) ↦ᵣ xorAcc bsA bsB i) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+        bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+      hbrHdr
+      (fun h hq => by xperm_hyp hq)
+      (fun h hq => by xperm_hyp hq)
+      (fun hc => absurd hc (ctr_ne_zero i hi))
+      (fun _ => cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+        (fun _ hq => hq) hbody))
+
+/-- Exhaustion: header guard taken, `SLTIU` materializes the verdict,
+    `SD` stores it, `a0 := 0`, `ret`. -/
+private theorem beExh_spec
+    (hlenA : bsA.length = 256) (hlenB : bsB.length = 256)
+    (halignRet : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin 5 (0x80011e0c : Word) ret
+      (CodeReq.ofProg (0x80011dfc : Word) bloomEq_prog)
+      (beInv aPtr bPtr outPtr ret bsA bsB 32)
+      (bePost aPtr bPtr outPtr ret bsA bsB) := by
+  set CR := CodeReq.ofProg (0x80011dfc : Word) bloomEq_prog with hCR
+  unfold beInv
+  have hflag : (if BitVec.ult (xorAcc bsA bsB 32) (1 : Word)
+      then (1 : Word) else (0 : Word))
+      = (if bsA = bsB then (1 : Word) else (0 : Word)) := by
+    by_cases hEq : bsA = bsB
+    · rw [if_pos hEq,
+        (xorAcc_eq_zero_iff_bytes_eq bsA bsB 32 (by omega) (by omega)).mpr
+          hEq]
+      rw [if_pos (by decide)]
+    · rw [if_neg hEq, if_neg ?_]
+      intro hlt
+      have hz : xorAcc bsA bsB 32 = 0 := by
+        apply BitVec.eq_of_toNat_eq
+        have h1 : (xorAcc bsA bsB 32).toNat < ((1 : Word)).toNat := by
+          simpa [BitVec.ult, decide_eq_true_eq] using hlt
+        rw [show ((1 : Word)).toNat = 1 from rfl] at h1
+        rw [show ((0 : Word)).toNat = 0 from rfl]
+        omega
+      exact hEq
+        ((xorAcc_eq_zero_iff_bytes_eq bsA bsB 32 (by omega) (by omega)).mp hz)
+  -- sltiu x30, x30, 1
+  have hsltiu := liftCode (cr' := CR)
+    (sltiu_spec_gen_same_within .x30 (xorAcc bsA bsB 32) (1 : BitVec 12)
+      (0x80011e30 : Word) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide,
+      hflag,
+      show (0x80011e30 : Word) + 4 = (0x80011e34 : Word) from by decide]
+    at hsltiu
+  -- sd x30, 0(x12)
+  have hsd := liftCode (cr' := CR)
+    (sd_spec_gen_own_within .x12 .x30 outPtr
+      (if bsA = bsB then (1 : Word) else (0 : Word)) (0 : BitVec 12)
+      (0x80011e34 : Word))
+    (by rw [hCR]; code_mem)
+  rw [show outPtr + signExtend12 (0 : BitVec 12) = outPtr from by
+        rw [signExtend12_0]; bv_omega,
+      show (0x80011e34 : Word) + 4 = (0x80011e38 : Word) from by decide]
+    at hsd
+  -- li a0, 0
+  have hli := liftCode (cr' := CR)
+    (li_spec_gen_within .x10 aPtr (0 : Word) (0x80011e38 : Word) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show (0x80011e38 : Word) + 4 = (0x80011e3c : Word) from by decide]
+    at hli
+  -- ret
+  have hret := liftCode (cr' := CR)
+    (EvmAsm.Evm64.ret_spec_within' (0x80011e3c : Word) ret)
+    (by rw [hCR]; code_mem)
+  rw [halignRet] at hret
+  -- frames
+  have hsltiuF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - 32)) **
+      ((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * 32))) **
+      ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * 32))) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x28 ** regOwn .x29 **
+      bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+    (by pcf) hsltiu
+  have hsdF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - 32)) **
+      ((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * 32))) **
+      ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * 32))) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      regOwn .x28 ** regOwn .x29 **
+      bytesRegion aPtr bsA ** bytesRegion bPtr bsB)
+    (by pcf) hsd
+  have hliF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - 32)) **
+      ((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * 32))) **
+      ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * 32))) **
+      ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ outPtr) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x30 : Reg) ↦ᵣ (if bsA = bsB then (1 : Word) else (0 : Word))) **
+      regOwn .x28 ** regOwn .x29 **
+      bytesRegion aPtr bsA ** bytesRegion bPtr bsB **
+      (outPtr ↦ₘ (if bsA = bsB then (1 : Word) else (0 : Word))))
+    (by pcf) hli
+  have hretF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - 32)) **
+      ((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * 32))) **
+      ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * 32))) **
+      ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x30 : Reg) ↦ᵣ (if bsA = bsB then (1 : Word) else (0 : Word))) **
+      regOwn .x28 ** regOwn .x29 **
+      bytesRegion aPtr bsA ** bytesRegion bPtr bsB **
+      (outPtr ↦ₘ (if bsA = bsB then (1 : Word) else (0 : Word))))
+    (by pcf) hret
+  -- tail chain
+  have htail := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hsltiuF hsdF
+  have htail2 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) htail hliF
+  have htail3 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) htail2 hretF
+  -- the tail weakened into the genuine post
+  have htailQ : cpsTripleWithin 4 (0x80011e30 : Word) ret CR
+      (((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - 32)) **
+        ((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * 32))) **
+        ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * 32))) **
+        ((.x30 : Reg) ↦ᵣ xorAcc bsA bsB 32) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x28 ** regOwn .x29 **
+        bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+      (bePost aPtr bPtr outPtr ret bsA bsB) := by
+    refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun h hq => ?_) htail3
+    unfold bePost
+    have hq1 : (((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - 32)) **
+        (((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * 32))) **
+          (((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * 32))) **
+            (((.x30 : Reg) ↦ᵣ (if bsA = bsB then (1 : Word) else (0 : Word))) **
+              (((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+               ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+               ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+               regOwn .x28 ** regOwn .x29 **
+               bytesRegion aPtr bsA ** bytesRegion bPtr bsB **
+               (outPtr ↦ₘ (if bsA = bsB then (1 : Word) else (0 : Word)))))))) h := by
+      xperm_hyp hq
+    have hq2 := sepConj_mono (regIs_to_regOwn .x5 _)
+      (sepConj_mono (regIs_to_regOwn .x6 _)
+        (sepConj_mono (regIs_to_regOwn .x7 _)
+          (sepConj_mono (regIs_to_regOwn .x30 _)
+            (fun _ hh => hh)))) h hq1
+    xperm_hyp hq2
+  -- header guard, taken (counter = 0)
+  have hbrHdr := cpsBranchWithin_frameR
+    (((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * 32))) **
+      ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * 32))) **
+      ((.x30 : Reg) ↦ᵣ xorAcc bsA bsB 32) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+      regOwn .x28 ** regOwn .x29 **
+      bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+    (by pcf)
+    (cpsBranchWithin_extend_code (cr' := CR)
+      (h := beq_spec_gen_within .x5 .x0 (36 : BitVec 13)
+        (BitVec.ofNat 64 (32 - 32)) (0 : Word) (0x80011e0c : Word))
+      (hmono := by rw [hCR]; code_mem))
+  rw [show (0x80011e0c : Word) + signExtend13 (36 : BitVec 13)
+        = (0x80011e30 : Word) from by decide,
+      show (0x80011e0c : Word) + 4 = (0x80011e10 : Word) from by decide]
+    at hbrHdr
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq)
+    (retJoinStation_spec
+      (cond := (BitVec.ofNat 64 (32 - 32) = (0 : Word)))
+      (PT := ((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - 32)) **
+        ((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * 32))) **
+        ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * 32))) **
+        ((.x30 : Reg) ↦ᵣ xorAcc bsA bsB 32) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x28 ** regOwn .x29 **
+        bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+      (PF := ((.x5 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - 32)) **
+        ((.x6 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (8 * 32))) **
+        ((.x7 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (8 * 32))) **
+        ((.x30 : Reg) ↦ᵣ xorAcc bsA bsB 32) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x28 ** regOwn .x29 **
+        bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+      hbrHdr
+      (fun h hq => by xperm_hyp hq)
+      (fun h hq => by xperm_hyp hq)
+      (fun _ => htailQ)
+      (fun hc => absurd (by decide :
+        (BitVec.ofNat 64 (32 - 32) : Word) = (0 : Word)) hc))
+
+end Scan
+
+-- ============================================================================
+-- The whole routine
+-- ============================================================================
+
+/-- **`bloom_eq` at its linked address** (genuine post): the out dword is
+    `1` iff the two 256-byte blooms are byte-equal, else `0`; `a0 = 0`;
+    both inputs untouched. -/
+theorem bloomEq_spec (aPtr bPtr outPtr ret : Word) (bsA bsB : List (BitVec 8))
+    (hlenA : bsA.length = 256) (hlenB : bsB.length = 256)
+    (halignRet : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin 297 (0x80011dfc : Word) ret
+      (CodeReq.ofProg (0x80011dfc : Word) bloomEq_prog)
+      (((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28 **
+        regOwn .x29 ** regOwn .x30 **
+        bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+      (((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28 **
+        regOwn .x29 ** regOwn .x30 **
+        bytesRegion aPtr bsA ** bytesRegion bPtr bsB **
+        (outPtr ↦ₘ (if bsA = bsB then (1 : Word) else (0 : Word)))) := by
+  set CR := CodeReq.ofProg (0x80011dfc : Word) bloomEq_prog with hCR
+  -- peel x5, x6, x7, x30 for the init writes
+  refine cpsTripleWithin_weaken
+    (fun h hp => by
+      simp only [regOwns_cons, regOwns_nil, sepConj_emp_right']
+      xperm_hyp hp)
+    (fun _ hq => hq)
+    (cpsTripleWithin_peel_regOwns [.x5, .x6, .x7, .x30] (by decide)
+      (P := ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x28 ** regOwn .x29 **
+        bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+      (fun vf => ?_))
+  simp only [regAtomsOf_cons, regAtomsOf_nil, sepConj_emp_right']
+  -- ---- init: li x5, 32 ; mv x6, a0 ; mv x7, a1 ; li x30, 0 ----
+  have hli5 := liftCode (cr' := CR)
+    (li_spec_gen_within .x5 (vf .x5) (32 : Word) (0x80011dfc : Word)
+      (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show (0x80011dfc : Word) + 4 = (0x80011e00 : Word) from by decide]
+    at hli5
+  have hmv6 := liftCode (cr' := CR)
+    (mv_spec_gen_within .x6 .x10 aPtr (vf .x6) (0x80011e00 : Word)
+      (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show (0x80011e00 : Word) + 4 = (0x80011e04 : Word) from by decide]
+    at hmv6
+  have hmv7 := liftCode (cr' := CR)
+    (mv_spec_gen_within .x7 .x11 bPtr (vf .x7) (0x80011e04 : Word)
+      (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show (0x80011e04 : Word) + 4 = (0x80011e08 : Word) from by decide]
+    at hmv7
+  have hli30 := liftCode (cr' := CR)
+    (li_spec_gen_within .x30 (vf .x30) (0 : Word) (0x80011e08 : Word)
+      (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show (0x80011e08 : Word) + 4 = (0x80011e0c : Word) from by decide]
+    at hli30
+  -- ---- the loop ----
+  have hloop := retLoop_spec (hdr := (0x80011e0c : Word)) (ret := ret)
+    (cr := CR) (Q := bePost aPtr bPtr outPtr ret bsA bsB) 32 9 5
+    (beInv aPtr bPtr outPtr ret bsA bsB)
+    (fun i hi => beIter_spec aPtr bPtr outPtr ret bsA bsB hlenA hlenB i hi)
+    (beExh_spec aPtr bPtr outPtr ret bsA bsB hlenA hlenB halignRet)
+  -- ---- frames + chain ----
+  have hli5F := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ vf .x6) ** ((.x7 : Reg) ↦ᵣ vf .x7) **
+      ((.x30 : Reg) ↦ᵣ vf .x30) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x28 ** regOwn .x29 **
+      bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+    (by pcf) hli5
+  have hmv6F := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (32 : Word)) ** ((.x7 : Reg) ↦ᵣ vf .x7) **
+      ((.x30 : Reg) ↦ᵣ vf .x30) **
+      ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x28 ** regOwn .x29 **
+      bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+    (by pcf) hmv6
+  have hmv7F := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (32 : Word)) ** ((.x6 : Reg) ↦ᵣ aPtr) **
+      ((.x30 : Reg) ↦ᵣ vf .x30) **
+      ((.x10 : Reg) ↦ᵣ aPtr) **
+      ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x28 ** regOwn .x29 **
+      bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+    (by pcf) hmv7
+  have hli30F := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (32 : Word)) ** ((.x6 : Reg) ↦ᵣ aPtr) **
+      ((.x7 : Reg) ↦ᵣ bPtr) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x28 ** regOwn .x29 **
+      bytesRegion aPtr bsA ** bytesRegion bPtr bsB ** memOwn outPtr)
+    (by pcf) hli30
+  have hc1 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hli5F hmv6F
+  have hc2 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hc1 hmv7F
+  have hc3 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hc2 hli30F
+  have hc4 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      unfold beInv
+      rw [show (BitVec.ofNat 64 (32 - 0) : Word) = (32 : Word) from by decide,
+          show aPtr + BitVec.ofNat 64 (8 * 0) = aPtr from by
+            rw [show (BitVec.ofNat 64 (8 * 0) : Word) = (0 : Word) from rfl]
+            bv_omega,
+          show bPtr + BitVec.ofNat 64 (8 * 0) = bPtr from by
+            rw [show (BitVec.ofNat 64 (8 * 0) : Word) = (0 : Word) from rfl]
+            bv_omega,
+          show xorAcc bsA bsB 0 = (0 : Word) from rfl]
+      xperm_hyp hp) hc3 hloop
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun h hq => by unfold bePost at hq; exact hq)
+    (cpsTripleWithin_mono_nSteps (by omega) hc4)
+
+#print axioms bloomEq_spec
+
+end BloomEqSAsm
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -154,6 +154,7 @@ import EvmAsm.Codegen.Programs.CreateDeployedCodeValidSAsm
 import EvmAsm.Codegen.Programs.U256MinSAsm
 import EvmAsm.Codegen.Programs.U256LtBeSAsm
 import EvmAsm.Codegen.Programs.MessageCallGasSAsm
+import EvmAsm.Codegen.Programs.BloomEqSAsm
 import EvmAsm.Codegen.Programs.CallFrameBaseSAsm
 import EvmAsm.Codegen.Programs.CreateInitcodeSizeValidSAsm
 import EvmAsm.Codegen.Programs.BalGasValid

--- a/EvmAsm/Rv64/SAsm.lean
+++ b/EvmAsm/Rv64/SAsm.lean
@@ -60,3 +60,4 @@ import EvmAsm.Rv64.SAsm.RwSubwindow
 import EvmAsm.Rv64.SAsm.TwoBreakWritable
 import EvmAsm.Rv64.SAsm.DualReadByteScan
 import EvmAsm.Rv64.SAsm.MultiRegRetTail
+import EvmAsm.Rv64.SAsm.AccumLoop

--- a/EvmAsm/Rv64/SAsm/AccumLoop.lean
+++ b/EvmAsm/Rv64/SAsm/AccumLoop.lean
@@ -1,0 +1,186 @@
+/-
+  EvmAsm.Rv64.SAsm.AccumLoop
+
+  The **single-exit accumulate loop** (bead evm-asm-pr5lu).
+
+  `DualReadScan` (#10038) covers early-exit dual-read equality scans;
+  `bloom_eq` is the SINGLE-EXIT variant: a constant-cycle XOR/OR
+  accumulate over two buffers (no early exit — timing invariance), with
+  the verdict derived from the accumulator and stored through an `SD` to
+  an rw out-cell:
+
+  ```
+        li   ctr, N ; mv pA, a0 ; mv pB, a1 ; li acc, 0
+  hdr:  beq  ctr, x0, .done
+        ld   tA, 0(pA) ; ld tB, 0(pB)
+        xor  tA, tA, tB ; or acc, acc, tA
+        addi pA, pA, 8 ; addi pB, pB, 8 ; addi ctr, ctr, -1 ; j hdr
+  .done: sltiu acc, acc, 1 ; sd acc, 0(out) ; li a0, 0 ; ret
+  ```
+
+  Three reusable pieces:
+
+  * `retLoop_spec` — the single-exit countdown loop at `cpsTripleWithin`
+    level: each iteration is an ordinary triple back to the header (no
+    break arm); exhaustion runs the tail to `ret`.  Derived from
+    `twoBreakRetLoop_spec` (#10067) with the early-return arm vacuous.
+
+  * `xorAcc` + `xorAcc_eq_zero_iff_bytes_eq` — the OR-of-XOR dword-slot
+    accumulator and its **result bridge**: the accumulator is zero after
+    `N` slots iff the two `8·N`-byte lists are EQUAL (per-slot facts via
+    `xorAcc_eq_zero_iff`, then #10038's `bytes_eq_of_dwordSlots_eq`) —
+    what turns the accumulator residue into the genuine equality post.
+
+  * `bytesRegion_ld_cursor_within` — dword load through an ADVANCING
+    cursor (`LD rd, 0(rs1)` with `rs1 = base + 8q`), the cursor analogue
+    of `bytesRegion_ld_within` (#10060, fixed base + immediate).
+
+  Consumer: `bloom_eq` (`Codegen/Programs/BloomEqSAsm.lean`).
+  Everything additive, `cpsTripleWithin` level.
+-/
+
+import EvmAsm.Rv64.SAsm.TwoBreakWritable
+import EvmAsm.Rv64.SAsm.DualReadScan
+import EvmAsm.Rv64.SAsm.SelectedRead
+
+namespace EvmAsm.Rv64.SAsm
+
+open EvmAsm.Rv64
+
+/-- **The single-exit countdown loop**: every iteration is an ordinary
+    triple back to the header (no break arm); after `N` iterations the
+    exhaustion path runs the tail to `ret` with the final post.  The
+    degenerate (vacuous-break) instance of `twoBreakRetLoop_spec`. -/
+theorem retLoop_spec {hdr ret : Word} {cr : CodeReq} {Q : Assertion}
+    (N m e : Nat) (inv : Nat → Assertion)
+    (hiter : ∀ i, i < N → cpsTripleWithin m hdr hdr cr (inv i) (inv (i + 1)))
+    (hexh : cpsTripleWithin e hdr ret cr (inv N) Q) :
+    cpsTripleWithin (N * m + e) hdr ret cr (inv 0) Q :=
+  twoBreakRetLoop_spec N m e inv
+    (fun i hi => cpsTripleWithin_as_cpsBranchWithin_right ret Q (hiter i hi))
+    hexh
+
+namespace AccumLoop
+
+/-- The OR-of-XOR dword-slot accumulator after `i` slots: zero exactly
+    when every processed slot pair matched. -/
+def xorAcc (bsA bsB : List (BitVec 8)) : Nat → Word
+  | 0 => 0
+  | i + 1 => xorAcc bsA bsB i
+      ||| (dwordSlot bsA i ^^^ dwordSlot bsB i)
+
+@[simp] theorem xorAcc_zero (bsA bsB : List (BitVec 8)) :
+    xorAcc bsA bsB 0 = 0 := rfl
+
+theorem xorAcc_succ (bsA bsB : List (BitVec 8)) (i : Nat) :
+    xorAcc bsA bsB (i + 1) = (xorAcc bsA bsB i
+      ||| (dwordSlot bsA i ^^^ dwordSlot bsB i)) :=
+  rfl
+
+private theorem or_eq_zero_iff (a b : Word) :
+    (a ||| b) = 0 ↔ a = 0 ∧ b = 0 := by
+  constructor
+  · intro h
+    constructor
+    · apply BitVec.eq_of_getLsbD_eq
+      intro i _hi
+      have hbit := congrArg (fun w : Word => w.getLsbD i) h
+      simp only [BitVec.getLsbD_or] at hbit
+      simp only [show ((0 : Word)).getLsbD i = false from by
+        simp [BitVec.getLsbD]] at hbit ⊢
+      exact (Bool.or_eq_false_iff.mp hbit).1
+    · apply BitVec.eq_of_getLsbD_eq
+      intro i _hi
+      have hbit := congrArg (fun w : Word => w.getLsbD i) h
+      simp only [BitVec.getLsbD_or] at hbit
+      simp only [show ((0 : Word)).getLsbD i = false from by
+        simp [BitVec.getLsbD]] at hbit ⊢
+      exact (Bool.or_eq_false_iff.mp hbit).2
+  · rintro ⟨rfl, rfl⟩
+    simp
+
+private theorem xor_eq_zero_iff (a b : Word) : (a ^^^ b) = 0 ↔ a = b := by
+  constructor
+  · intro h
+    apply BitVec.eq_of_getLsbD_eq
+    intro i _hi
+    have hbit := congrArg (fun w : Word => w.getLsbD i) h
+    simp only [BitVec.getLsbD_xor] at hbit
+    simp only [show ((0 : Word)).getLsbD i = false from by
+      simp [BitVec.getLsbD]] at hbit
+    revert hbit
+    cases a.getLsbD i <;> cases b.getLsbD i <;> simp
+  · rintro rfl
+    simp
+
+/-- The accumulator → per-slot bridge: zero after `N` slots iff every
+    slot pair matched. -/
+theorem xorAcc_eq_zero_iff (bsA bsB : List (BitVec 8)) (N : Nat) :
+    xorAcc bsA bsB N = 0
+      ↔ ∀ j, j < N →
+          dwordSlot bsA j = dwordSlot bsB j := by
+  induction N with
+  | zero =>
+      constructor
+      · intro _ j hj
+        exact absurd hj (Nat.not_lt_zero j)
+      · intro _
+        rfl
+  | succ n ih =>
+      rw [xorAcc_succ, or_eq_zero_iff, ih, xor_eq_zero_iff]
+      constructor
+      · rintro ⟨hall, hn⟩ j hj
+        by_cases hjn : j < n
+        · exact hall j hjn
+        · have : j = n := by omega
+          subst this
+          exact hn
+      · intro h
+        exact ⟨fun j hj => h j (by omega), h n (by omega)⟩
+
+/-- **The result bridge**: the accumulator is zero after `N` slots iff
+    the two `8·N`-byte lists are EQUAL — the genuine equality post of a
+    single-exit accumulate compare (per-slot facts + #10038's
+    `bytes_eq_of_dwordSlots_eq`). -/
+theorem xorAcc_eq_zero_iff_bytes_eq (bsA bsB : List (BitVec 8)) (N : Nat)
+    (hlenA : bsA.length = 8 * N) (hlenB : bsB.length = 8 * N) :
+    xorAcc bsA bsB N = 0 ↔ bsA = bsB := by
+  rw [xorAcc_eq_zero_iff]
+  constructor
+  · exact bytes_eq_of_dwordSlots_eq N bsA bsB hlenA hlenB
+  · intro h j _
+    exact dwordSlot_congr h j
+
+end AccumLoop
+
+/-- **`LD rd, 0(rs1)` through an advancing cursor** reads dword chunk `q`
+    of the region when `rs1 = base + 8q` — the cursor analogue of
+    `bytesRegion_ld_within` (fixed base + immediate). -/
+theorem bytesRegion_ld_cursor_within (rd rs1 : Reg) (regionBase vOld : Word)
+    (base : Word) (bs : List (BitVec 8)) (q : Nat)
+    (hrd : rd ≠ .x0) (hq : 8 * q < bs.length) :
+    cpsTripleWithin 1 base (base + 4)
+      (CodeReq.singleton base (.LD rd rs1 (0 : BitVec 12)))
+      ((rs1 ↦ᵣ (regionBase + BitVec.ofNat 64 (8 * q))) ** (rd ↦ᵣ vOld) **
+        bytesRegion regionBase bs)
+      ((rs1 ↦ᵣ (regionBase + BitVec.ofNat 64 (8 * q))) **
+        (rd ↦ᵣ packBytes ((bs.drop (8 * q)).take 8)) **
+        bytesRegion regionBase bs) := by
+  obtain ⟨front, rest, hf, hr, heq⟩ := bytesRegion_dword_at regionBase bs q hq
+  have hld := ld_spec_gen_within rd rs1 (regionBase + BitVec.ofNat 64 (8 * q))
+    vOld (packBytes ((bs.drop (8 * q)).take 8)) (0 : BitVec 12) base hrd
+  rw [show (regionBase + BitVec.ofNat 64 (8 * q)) + signExtend12 (0 : BitVec 12)
+      = regionBase + BitVec.ofNat 64 (8 * q) from by
+    rw [signExtend12_0]
+    bv_omega] at hld
+  rw [heq]
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hq' => by xperm_hyp hq')
+    (cpsTripleWithin_frameR (front ** rest) (pcFree_sepConj hf hr) hld)
+
+#print axioms retLoop_spec
+#print axioms AccumLoop.xorAcc_eq_zero_iff_bytes_eq
+#print axioms bytesRegion_ld_cursor_within
+
+end EvmAsm.Rv64.SAsm

--- a/PLAN.md
+++ b/PLAN.md
@@ -2954,8 +2954,12 @@ instantiations (`#guard`/`rfl`, flatten == emitted prog at the linked
 address): `bnp_fp2_eq` (`Codegen/Programs/Bn254Fp2EqSAsm.lean`, N = 8,
 bead 4ch8f.58.3.26), `bnq_eq` (`Codegen/Programs/Bn254Fq12EqSAsm.lean`,
 N = 48, bead 4ch8f.58.3.25), and `blq_eq` (`Codegen/Programs/Bls12Fq12EqSAsm.lean`,
-N = 72).  `bloom_eq` (single-exit XOR/OR accumulate + SD to an out window)
-can reuse pieces 1–2 but is not this scan shape — deferred.  `blsg_eq48`
+N = 72).  `bloom_eq` is now covered by the single-exit accumulate
+loop port (`BloomEqSAsm.lean`): `SAsm/AccumLoop.lean` adds
+`retLoop_spec`, `xorAcc_eq_zero_iff_bytes_eq`, and
+`bytesRegion_ld_cursor_within`; `bloomEq_spec` proves the emitted
+constant-cycle XOR/OR loop stores `if bsA = bsB then 1 else 0` to the
+out dword while preserving both 256-byte inputs.  `blsg_eq48`
 is also an equality leaf, but byte-wise (`LBU`) rather than dword-wise
 (`LD`), so it is verified separately in `Bls12G1Eq48SAsm.lean` as a
 48-byte whileBreak drop-in.  Classical-3.


### PR DESCRIPTION
## Summary
- add `SAsm.AccumLoop` helpers for single-exit countdown accumulator loops
- verify emitted `bloomEq_prog` with a genuine byte-equality post over the output dword
- wire `BloomEqSAsm` into Codegen program imports and update `PLAN.md`

Bead: evm-asm-4ch8f.20.2

## Gates
- `lake build`
- `scripts/port-check.sh EvmAsm/Codegen/Programs/BloomEqSAsm.lean`
- `scripts/check-forbidden-tactics.sh`
- `scripts/check-axioms.sh`
- `scripts/check-layering.sh`
- `scripts/check-unimported.sh`
- `scripts/check-file-size.sh`
- `scripts/check-no-warnings.sh`
- `scripts/check-heartbeats-approved.sh`
