### PR TITLE
ci: parallelize build verification gates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  source-checks:
     runs-on: ubuntu-latest
 
     steps:
@@ -41,6 +41,12 @@ jobs:
       - name: Naming convention scan (advisory)
         if: ${{ github.event_name == 'pull_request' }}
         run: scripts/check-naming.sh --base "origin/${{ github.base_ref }}"
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
       # Restore the lake build cache. The key matches lean-action@v1's scheme
       # so we keep compatibility with caches it has already saved on main.
       - name: Restore lake cache
@@ -73,57 +79,20 @@ jobs:
       - name: No-warnings guard (EvmAsm/ source paths)
         run: scripts/check-no-warnings.sh build.log
 
-      # The `codegen` exe (root `Main`) is NOT part of defaultTargets, so the
-      # plain `lake build` above does not build it. Build it explicitly as its
-      # own gate: this is the closure the Docker image build compiles, so a
-      # codegen-only break (e.g. a registry/program edit that the EvmAsm lib
-      # never imports) is caught on the PR path instead of at image-build time.
-      # The downstream link-check reuses this build via the lake cache.
-      - name: Build codegen executable
-        run: lake build codegen
+      # These executables are not defaultTargets. Build them before launching
+      # their independent checks concurrently, avoiding concurrent Lake writes.
+      - name: Build CI executables
+        run: lake build codegen progress-report arith-diff-check
 
       - name: Install RISC-V binutils for codegen link checks
         run: |
           sudo apt-get update
           sudo apt-get install -y binutils-riscv64-unknown-elf
 
-      - name: Build codegen and link stateless_guest.elf
-        run: scripts/codegen-stateless-link-check.sh
-
-      - name: Region-map / link-layout drift (RegionMap sizes + symbol-addresses.tsv match ELF)
-        run: scripts/check-region-map.sh
-
-      - name: Asm-to-Program drift (fixtures + concrete verification immediates)
-        run: scripts/check-asm-to-program.sh
-
-      # Byte-tie (bead evm-asm-vgyg9 = .49.a): the verified guarded ADD handler
-      # Program (GuardedHandlerSpecs.lean) must be byte-identical to the emitted
-      # h_ADD subroutine at the dispatch-table address. Keeps the verified handle
-      # bytes honest against the EMITTED guest image.
-      - name: Guarded-handler byte-tie (verified Program == emitted h_ADD)
-        run: scripts/check-guarded-handler-bytes.sh
-
-      - name: Progress-report drift check
-        run: scripts/check-progress.sh
-
-      - name: DRIFT.md ledger drift check
-        run: scripts/check-drift.sh
-
-      # Kernel-truth trust-base audit: any bv_decide OR native_decide trust
-      # axiom (or sorry) reaching a witnessed proof fails. Both were fully
-      # eliminated (bv_decide 290->0, native_decide 206->0) and tightened to
-      # FORBIDDEN (2026-06-02; see scripts/check-axioms.sh); scripts/axiom-allow.txt
-      # is an empty burndown — any NEW such owner fails. Needs oleans → runs after build.
-      - name: Axiom audit (no bv_decide / native_decide trust axioms; classical-only TCB)
-        run: scripts/check-axioms.sh
-
-      # DIV-class defense PR fast-path: fuzz the six arithmetic opcodes
-      # against an independent Nat/Int reference + re-verify the permanent
-      # corpus still matches its frozen execution-specs verdict. Pure Lean,
-      # deterministic, no submodule/Python (the heavy execution-specs
-      # differential runs nightly in fuzz-arith.yml). Needs the built exe.
-      - name: Arithmetic differential fuzz (PR fast-path)
-        run: scripts/fuzz-arith-diff.sh
+      # Run independent post-build gates concurrently. The codegen/link group
+      # stays ordered because the byte-tie consumes the region-map ELF.
+      - name: Post-build verification gates
+        run: scripts/check-build-parallel.sh
 
       # Advisory only (no --strict, PR-only, best-effort on shallow clones):
       # surfaces theorem-statement and verifier-config edits for reviewers.

--- a/scripts/check-build-parallel.sh
+++ b/scripts/check-build-parallel.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Run independent build-dependent CI gates concurrently on one prepared runner.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+names=()
+pids=()
+
+start() {
+  local name="$1"
+  shift
+  names+=("$name")
+  ( "$@" ) >"$work/$name.log" 2>&1 &
+  pids+=("$!")
+}
+
+codegen_checks() {
+  scripts/codegen-stateless-link-check.sh --no-build
+  scripts/check-region-map.sh
+  scripts/check-guarded-handler-bytes.sh
+}
+
+report_checks() {
+  scripts/check-progress.sh
+  scripts/check-drift.sh
+}
+
+start codegen codegen_checks
+start asm-to-program scripts/check-asm-to-program.sh
+start reports report_checks
+start axioms scripts/check-axioms.sh
+start arithmetic-fuzz scripts/fuzz-arith-diff.sh
+
+status=0
+for i in "${!pids[@]}"; do
+  name="${names[$i]}"
+  if wait "${pids[$i]}"; then
+    echo "==> $name: PASS"
+  else
+    echo "==> $name: FAIL" >&2
+    status=1
+  fi
+  sed "s/^/[$name] /" "$work/$name.log"
+done
+
+exit "$status"


### PR DESCRIPTION
## Summary

- move source-only fitness checks into a dedicated job that runs alongside the Lean build
- prebuild all non-default CI executables before launching dependent checks
- run independent post-build verification groups concurrently on the prepared build runner
- preserve ordering for link-layout and guarded-handler checks that share the generated ELF
- preserve the existing `build` job name for branch-protection compatibility

## Why

A recent cache-hit PR build spent about 50 seconds on source scans before beginning cache/toolchain setup, followed by about 52 seconds of serial post-build checks. This overlaps the source scans with the build and reduces the post-build checks to their longest independent group without duplicating the roughly 74-second Lean/cache setup across hosted runners.

## Validation

- `bash -n scripts/check-build-parallel.sh`
- `git diff --check`
- `lake build codegen progress-report arith-diff-check`
- `scripts/check-build-parallel.sh`
  - codegen/link/layout/guarded-handler byte checks
  - 384 asm-to-Program conversions
  - progress and DRIFT report checks
  - 87-witness axiom audit
  - 25,000-case arithmetic differential fuzz plus permanent corpus
- all source-only workflow gates