### PR TITLE
refactor(sdiv): narrow code handle imports

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BaseFinalBlockSpecs.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseFinalBlockSpecs.lean
@@ -6,6 +6,7 @@
 -/
 
 import EvmAsm.Evm64.SDiv.Compose.BaseCode
+import EvmAsm.Evm64.SDiv.LimbSpec
 
 namespace EvmAsm.Evm64.SDiv.Compose
 

--- a/EvmAsm/Evm64/SDiv/Compose/BaseResultSignFixBlockSpec.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseResultSignFixBlockSpec.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.SDiv.Compose.BaseCode
+import EvmAsm.Evm64.SDiv.LimbSpec
 import EvmAsm.Evm64.SDiv.Compose.BaseResultSignFix
 
 namespace EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/CodeHandles.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/CodeHandles.lean
@@ -4,8 +4,8 @@
   CodeReq handles for the SDIV wrapper and its sub-blocks.
 -/
 
-import EvmAsm.Evm64.SDiv.LimbSpec
-import EvmAsm.Evm64.SDiv.AddrNorm
+import EvmAsm.Evm64.SDiv.Program
+import EvmAsm.Rv64.SepLogic
 import EvmAsm.Evm64.SDiv.Compose.BaseOffsets
 
 namespace EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/SaveRaSignBlockSpecs.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SaveRaSignBlockSpecs.lean
@@ -6,6 +6,7 @@
 -/
 
 import EvmAsm.Evm64.SDiv.Compose.BaseCode
+import EvmAsm.Evm64.SDiv.LimbSpec
 
 namespace EvmAsm.Evm64.SDiv.Compose
 


### PR DESCRIPTION
## Summary

- make SDiv CodeHandles depend only on Program, SepLogic, and BaseOffsets
- remove proof-heavy LimbSpec and AddrNorm imports from the definitions-only handle module
- import LimbSpec directly in the three block-spec consumers that use its declarations

## Impact

- stacked root import depth drops from 101 to 100
- cumulative depth drops from 114 on main to 100
- localizes SDIV proof/tactic rebuild fan-out instead of routing it through every BaseCode consumer

## Validation

- lake build
- scripts/check-unimported.sh
- scripts/check-layering.sh
- scripts/check-forbidden-tactics.sh
- scripts/check-file-size.sh
- git diff --check