### PR TITLE
feat(sasm): machine-tie sg_load_u32le emission

### DIFF
--- a/EvmAsm/Codegen/Programs/SgLoadU32leSAsm.lean
+++ b/EvmAsm/Codegen/Programs/SgLoadU32leSAsm.lean
@@ -69,6 +69,20 @@ def sgLoadU32le_verified : Program :=
 #guard (sgLoadU32le_verified : List Instr).length = 11
 #guard sgLoadU32leBody.flatten 0 = sgLoadU32leBody.flatten 0x80000000
 
+/-- The complete verified routine, including its leaf `ret`.  This is the
+    program consumed by `StatelessGuestEpilogue` so the emitted guest and the
+    proved body cannot drift independently. -/
+def sgLoadU32le_prog : Program :=
+  sgLoadU32leBody.flatten 0 ++ [Instr.JALR .x0 .x1 (0 : BitVec 12)]
+
+/-- Kernel correspondence between the structured body and emitted routine. -/
+theorem sgLoadU32le_body_eq_prog :
+    sgLoadU32leBody.flatten 0 ++ [Instr.JALR .x0 .x1 (0 : BitVec 12)]
+      = sgLoadU32le_prog := by
+  rfl
+
+#guard sgLoadU32le_prog.length = 12
+
 /-- Engine lemma (own heartbeat budget): stepping the four byte loads leaves
     `a0` holding the little-endian u32 assembled from `reg`'s first 4 bytes. -/
 private theorem sgLoadU32le_engine (reg : Region) (rwb : Word) (rf : RegFile)
@@ -118,6 +132,8 @@ theorem sgLoadU32leFn_spec (p : Word) (bs : List (BitVec 8))
     show RegFile.get _ .x10 = leU32 bs 0
     exact sgLoadU32le_engine (sgLoadU32leFn p bs).region
       (sgLoadU32leFn p bs).rw.base rf₀ hx10
+
+#print axioms sgLoadU32leFn_spec
 
 end SgLoadU32leSAsm
 

--- a/EvmAsm/Codegen/Programs/StatelessGuestEpilogue.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuestEpilogue.lean
@@ -11,6 +11,7 @@ import EvmAsm.Codegen.Programs.ChainValidate
 import EvmAsm.Codegen.Programs.ChainValidateBlob
 import EvmAsm.Codegen.Programs.ChainValidatePostMerge
 import EvmAsm.Codegen.Programs.HashBridge
+import EvmAsm.Codegen.Programs.SgLoadU32leSAsm
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.Ssz
 import EvmAsm.Codegen.Programs.Tx
@@ -901,12 +902,7 @@ def statelessGuestEpilogue : String :=
   -- Reads byte-wise (LBU) so the source may be unaligned (SSZ base is
   -- 0x40000012). Leaf; clobbers t0,t1,a0; preserves all s-registers and ra.
   "sg_load_u32le:\n" ++
-  "  lbu t0, 0(a0)\n" ++
-  "  lbu t1, 1(a0); slli t1, t1, 8;  or t0, t0, t1\n" ++
-  "  lbu t1, 2(a0); slli t1, t1, 16; or t0, t0, t1\n" ++
-  "  lbu t1, 3(a0); slli t1, t1, 24; or t0, t0, t1\n" ++
-  "  mv a0, t0\n" ++
-  "  ret\n" ++
+  emitProgram SgLoadU32leSAsm.sgLoadU32le_prog ++ "\n" ++
   -- Alignment-safe byte copy: a0 = dst, a1 = src, a2 = len. Byte-wise
   -- (LBU/SB) so src/dst may be unaligned. Leaf; clobbers t0,a0,a1,a2;
   -- preserves all s-registers and ra.

--- a/PLAN.md
+++ b/PLAN.md
@@ -251,7 +251,8 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   Byte/copy leaf ports (bead 4ch8f.12): `SwdReadU64leSAsm.lean`
   (`swdReadU64leFn_spec`, `a0 := leU64 (bytes@a0) 0`, byte-identity pinned to
   `swdReadU64le_prog`) and `SgLoadU32leSAsm.lean` (`sgLoadU32leFn_spec`,
-  `a0 := leU32 (bytes@a0) 0`), `BlockAccessListHashSAsm.lean` verifies the
+  `a0 := leU32 (bytes@a0) 0`, with `sg_load_u32le` now emitted directly from
+  the kernel-tied `sgLoadU32le_prog`), `BlockAccessListHashSAsm.lean` verifies the
   identical `bah_u32le` leaf (`bahU32leFn_spec`, byte-identity pinned to
   `bahU32le_prog`), `SszPayloadWithdrawalsSAsm.lean` (`spwU32leFn_spec`,
   byte-identity pinned to `spwU32le_prog`), `SszParentHeaderSAsm.lean`


### PR DESCRIPTION
## Summary
- define the complete verified `sgLoadU32le_prog` as the proven SAsm body plus `ret`
- emit `sg_load_u32le` directly from that program instead of a hand-written asm string
- update PLAN.md to record the closed verified-to-emitted correspondence gap

Bead: evm-asm-4ch8f.12.10.1

## Verification
- `scripts/port-check.sh EvmAsm/Codegen/Programs/SgLoadU32leSAsm.lean`
- `scripts/check-asm-to-program.sh`
- `lake build`
- forbidden-tactics, axioms, layering, unimported, file-size, no-warnings, heartbeat, and hardcoded-PC gates
- whole-guest linked `.text` compared with `origin/main`: both 353316 bytes, SHA-256 `930987d4832cc570246d3040b7db690d3d5fc74fe47c416dd6a1b3f16aec6be5`; `cmp` passed

No EEST A/B is needed because the linked guest bytes are identical.

Directed by @pirapira; implemented by Codex