### PR TITLE
chore(sasm): drop redundant GuestAddrs address value pins (finish 6agnq churn-kill)

### DIFF
--- a/EvmAsm/Codegen/Programs/BloomEqSAsm.lean
+++ b/EvmAsm/Codegen/Programs/BloomEqSAsm.lean
@@ -30,9 +30,6 @@ open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.SAsm.AccumLoop
 
 namespace BloomEqSAsm
 
--- Address anchor (fails the build if the guest link moves).
-#guard GuestAddrs.bloom_eq = 0x80011dfc
-
 /-
   Layout (base GuestAddrs.bloom_eq):
     +0  GuestAddrs.bloom_eq  li   x5, 32

--- a/EvmAsm/Codegen/Programs/Bls12Fq12EqSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12Fq12EqSAsm.lean
@@ -19,9 +19,6 @@ open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
 
 namespace Bls12Fq12EqSAsm
 
--- Address anchor (semantic constant: 72 dwords = 576 bytes of FQ12).
-#guard GuestAddrs.blq_eq = 0x80034864
-
 /-- The `blq_eq` body: the dual-read dword equality scan over 72 slots. -/
 def blqEqBody (ptr1 ptr2 : Word) (bs1 bs2 : List (BitVec 8)) : Stmt :=
   DualReadScan.scanBody .x5 .x6 .x7 .x10 .x11 ptr1 ptr2 bs1 bs2 72

--- a/EvmAsm/Codegen/Programs/Bls12Fq12SetOneSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12Fq12SetOneSAsm.lean
@@ -59,8 +59,6 @@ namespace Bls12Fq12SetOneSAsm
 
 -- The two routines are adjacent in the guest text: `blq_zero` (6 slots)
 -- immediately precedes `blq_set_one`.
-#guard GuestAddrs.blq_zero = 0x80034820
-#guard GuestAddrs.blq_set_one = 0x80034838
 #guard GuestAddrs.blq_zero + 4 * blqZero_prog.length = GuestAddrs.blq_set_one
 
 /-- The caller's 2-slot frame: `ra` at 0, `s0` at 8. -/

--- a/EvmAsm/Codegen/Programs/Bls12G2Copy192SAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12G2Copy192SAsm.lean
@@ -18,9 +18,6 @@ open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.Tactics
 
 namespace Bls12G2Copy192SAsm
 
-#guard GuestAddrs.blsf_copy_quads = 0x8002f65c
-#guard GuestAddrs.blsg2_copy192 = 0x80033d40
-
 /-- The caller's one-slot ABI frame: `ra` at 0(sp). -/
 def copy192Frame : FrameDesc := [(.x1, 0)]
 

--- a/EvmAsm/Codegen/Programs/Bls12G2EncodeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12G2EncodeSAsm.lean
@@ -53,9 +53,6 @@ namespace Bls12G2EncodeSAsm
 -- ============================================================================
 
 -- Semantic constants: 4 elements × 48 bytes.
--- Address anchors (`#guard`-tied to the live GuestAddrs):
-#guard GuestAddrs.blsg2_encode = 0x80034364
-#guard GuestAddrs.blsg_le_to_be = 0x8002f6cc
 
 /-- The caller's 4-slot frame: `ra`, `s0`, `s1`, `s2` (the loop counter is
     callee-saved — it must survive the callee's exposed-register clobber). -/

--- a/EvmAsm/Codegen/Programs/Bls12G2EqNSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12G2EqNSAsm.lean
@@ -550,9 +550,6 @@ theorem blsg2EqNFn_spec (ptr1 ptr2 : Word) (bs1 bs2 : List (BitVec 8)) (n : Nat)
     (`n` the entry value of `a2`), via `DualReadByteScan.scan_spec` and its
     per-byte → byte-list bridge `bytes_eq_of_prefix_eq`. -/
 
--- Address anchor (fails the build if the guest link moves).
-#guard GuestAddrs.blsg2_eq_n = 0x80033d74
-
 /-- Byte-tie: the emitted `blsg2_eq_n` IS the `mv;mv;mv` init followed by
     the dynamic-length byte dual-read scan at the emitted registers. -/
 theorem blsg2EqN_prog_eq_scan :

--- a/EvmAsm/Codegen/Programs/Bls12KzgG2WireSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12KzgG2WireSAsm.lean
@@ -62,9 +62,6 @@ namespace Bls12KzgG2WireSAsm
 -- ============================================================================
 
 -- Semantic constants: 4 elements × (16-byte pad + 48-byte body) records.
--- Address anchors (`#guard`-tied to the live GuestAddrs):
-#guard GuestAddrs.blsk_g2_wire = 0x80032e28
-#guard GuestAddrs.blsg_le_to_be = 0x8002f6cc
 
 /-- The caller's 4-slot frame: `ra`, `s0`, `s1`, `s2`. -/
 def wireFrame : FrameDesc := [(.x1, 0), (.x8, 8), (.x9, 16), (.x18, 24)]

--- a/EvmAsm/Codegen/Programs/Bn254FieldMulModPSAsmStage.lean
+++ b/EvmAsm/Codegen/Programs/Bn254FieldMulModPSAsmStage.lean
@@ -28,17 +28,6 @@ namespace Bn254FieldMulModPSAsm
 
 open Bn254FieldConvSAsm (bnfBeToLeFn bnfBeToLeFn_spec bnfLeToBeFn bnfLeToBeFn_spec)
 
--- Address anchors (routine, callees, and the LE staging arena).
-#guard GuestAddrs.bnf_mul_mod_p = 0x8003020c
-#guard GuestAddrs.bnf_be_to_le = 0x800300c0
-#guard GuestAddrs.bnf_le_to_be = 0x80030110
-#guard GuestAddrs.bnf_le_a = 0xbb55d9b0
-#guard GuestAddrs.bnf_le_b = 0xbb55d9d0
-#guard GuestAddrs.bnf_le_d = 0xbb55d9f0
-#guard GuestAddrs.bnf_le_zero = 0xbb55da10
-#guard GuestAddrs.bnf_le_p = 0xbb55da50
-#guard GuestAddrs.bnf_mul_params = 0xbb55da70
-
 /-- The arena base (`bnf_le_a`) and its 232-byte extent
     (`_a/_b/_d/_zero/_one/_p` 32-byte cells + the 40-byte `mul_params`). -/
 def arenaB : Word := 0xbb55d9b0

--- a/EvmAsm/Codegen/Programs/Bn254Fp2EqSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254Fp2EqSAsm.lean
@@ -17,9 +17,6 @@ open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
 
 namespace Bn254Fp2EqSAsm
 
--- Address anchor (semantic constant: 8 dwords = 64 bytes of Fp2).
-#guard GuestAddrs.bnp_fp2_eq = 0x800308d8
-
 /-- The `bnp_fp2_eq` body: the dual-read dword equality scan over 8 slots. -/
 def bnpFp2EqBody (ptr1 ptr2 : Word) (bs1 bs2 : List (BitVec 8)) : Stmt :=
   DualReadScan.scanBody .x5 .x6 .x7 .x10 .x11 ptr1 ptr2 bs1 bs2 8

--- a/EvmAsm/Codegen/Programs/Bn254Fq12EqSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254Fq12EqSAsm.lean
@@ -19,9 +19,6 @@ open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
 
 namespace Bn254Fq12EqSAsm
 
--- Address anchor (semantic constant: 48 dwords = 384 bytes of FQ12).
-#guard GuestAddrs.bnq_eq = 0x80030e4c
-
 /-- The `bnq_eq` body: the dual-read dword equality scan over 48 slots. -/
 def bnqEqBody (ptr1 ptr2 : Word) (bs1 bs2 : List (BitVec 8)) : Stmt :=
   DualReadScan.scanBody .x5 .x6 .x7 .x10 .x11 ptr1 ptr2 bs1 bs2 48

--- a/EvmAsm/Codegen/Programs/Bn254Fq12SetOneSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254Fq12SetOneSAsm.lean
@@ -59,8 +59,6 @@ namespace Bn254Fq12SetOneSAsm
 
 -- The two routines are adjacent in the guest text: `bnq_zero` (6 slots)
 -- immediately precedes `bnq_set_one`.
-#guard GuestAddrs.bnq_zero = 0x80030e08
-#guard GuestAddrs.bnq_set_one = 0x80030e20
 #guard GuestAddrs.bnq_zero + 4 * bnqZero_prog.length = GuestAddrs.bnq_set_one
 
 /-- The caller's 2-slot frame: `ra` at 0, `s0` at 8. -/

--- a/EvmAsm/Codegen/Programs/CallFrameBaseSAsm.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameBaseSAsm.lean
@@ -33,10 +33,6 @@ open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
 
 namespace CallFrameBaseSAsm
 
--- Address anchors.
-#guard GuestAddrs.frame_base = 0x800382ec
-#guard GuestAddrs.call_frame_arena = 0xac4639a0
-
 /-- The 6-instruction body (everything but the `ret`). -/
 def fbBlock : List Instr :=
   [ .ADDI .x5 .x10 (-1 : BitVec 12),

--- a/EvmAsm/Codegen/Programs/CheckGasLimitSAsm.lean
+++ b/EvmAsm/Codegen/Programs/CheckGasLimitSAsm.lean
@@ -42,9 +42,6 @@ open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
 
 namespace CheckGasLimitSAsm
 
--- Address anchor (fails the build if the guest link moves).
-#guard GuestAddrs.check_gas_limit = 0x80009c14
-
 /-! ## The routine's semantics -/
 
 /-- `|new − parent|` — the gas-limit adjustment magnitude (the if-value

--- a/EvmAsm/Codegen/Programs/RlpListEncodedSizeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpListEncodedSizeSAsm.lean
@@ -44,9 +44,6 @@ open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
 
 namespace RlpListEncodedSizeSAsm
 
--- Address anchor (fails the build if the guest link moves).
-#guard GuestAddrs.rlp_list_encoded_size = 0x8000ae20
-
 /-
   Layout relative to `GuestAddrs.rlp_list_encoded_size`:
     +0   li   x5, 56

--- a/EvmAsm/Codegen/Programs/Secp256k1FieldCmpPSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1FieldCmpPSAsm.lean
@@ -64,9 +64,6 @@ def cmpPBase : Word := (GuestAddrs.secf_cmp_p : Word)
 /-- The read-only prime constant's link address, symbolic. -/
 def pConstAddr : Word := (GuestAddrs.secp256k1_p_be : Word)
 
--- Address anchors (fail the build if the guest link moves).
-#guard GuestAddrs.secf_cmp_p = 0x8001fe08
-#guard GuestAddrs.secp256k1_p_be = 0xa3c052c0
 #guard secfCmpP_prog.length = 24
 
 -- The constant bytes ARE the secp256k1 field prime p = 2^256 - 0x1000003d1.

--- a/EvmAsm/Codegen/Programs/Secp256k1FieldReduceOnceSAsmSupport.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1FieldReduceOnceSAsmSupport.lean
@@ -26,14 +26,6 @@ open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Crypto
 
 namespace Secp256k1FieldReduceOnceSAsm
 
--- Address anchors for byte-transparent proof.
-#guard GuestAddrs.secf_reduce_once = 0x8001fe68
-#guard GuestAddrs.u256_lt_be = 0x800052c4
-#guard GuestAddrs.u256_sub_be = 0x80005248
-#guard GuestAddrs.secf_copy32 = 0x8001fca4
-#guard GuestAddrs.secp256k1_p_be = 0xa3c052c0
-#guard GuestAddrs.secf_cmp = 0xa3c053e0
-
 /-- secp256k1 field prime, as 32 big-endian bytes. -/
 def secp256k1PBytes : List (BitVec 8) :=
   [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,

--- a/EvmAsm/Codegen/Programs/Secp256k1PointDoubleSAsmStage.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1PointDoubleSAsmStage.lean
@@ -34,14 +34,6 @@ open Secp256k1FieldIsZeroSAsm (secfIsZero32Fn secfIsZero32Fn_spec)
 open Secp256k1FieldLeavesSAsm (secfZero32Fn secfZero32Fn_spec)
 open EvmAsm.Rv64.SAsm.WhileBreakDemo (nlz nlz_le nlz_spec nlz_boundary)
 
--- Address anchors (routine, callees, and the LE staging point).
-#guard GuestAddrs.secp256k1_point_double = 0x80020578
-#guard GuestAddrs.secf_is_zero32 = 0x8001fd9c
-#guard GuestAddrs.secf_zero32 = 0x8001fcc8
-#guard GuestAddrs.secf_be_to_le = 0x8001fcdc
-#guard GuestAddrs.secf_le_to_be = 0x8001fd2c
-#guard GuestAddrs.secc_le_p1 = 0xa3c05618
-
 /-- The staging-point base (`secc_le_p1`): a 64-byte LE point image
     `x || y`, four u64 limbs per coordinate. -/
 def arenaB : Word := GuestAddrs.secc_le_p1

--- a/EvmAsm/Codegen/Programs/U256LtBeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/U256LtBeSAsm.lean
@@ -50,9 +50,6 @@ namespace U256LtBeSAsm
 
 open U256MinSAsm (beBytesToNat_lt_of_prefix_lt bytes_eq_of_prefix_all)
 
--- Address anchor (fails the build if the guest link moves).
-#guard GuestAddrs.u256_lt_be = 0x800052c4
-
 /-
   Emitted layout (base GuestAddrs.u256_lt_be):
     +0  GuestAddrs.u256_lt_be  li   x5, 32

--- a/EvmAsm/Codegen/Programs/U256MinSAsm.lean
+++ b/EvmAsm/Codegen/Programs/U256MinSAsm.lean
@@ -50,9 +50,6 @@ open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Crypto
 
 namespace U256MinSAsm
 
--- Address anchor.
-#guard GuestAddrs.u256_min = 0x80024da4
-
 -- The shared copy tail of the emitted program IS the combinator's
 -- generator (kernel-checked byte tie).
 theorem u256Min_copyTail_tie :


### PR DESCRIPTION
## Summary
- remove all 44 standalone `#guard GuestAddrs.<sym> = 0x...` address value pins from 19 SAsm wrapper/support files
- retain symbolic GuestAddrs bases, semantic/length guards, position-independence checks, adjacency checks, and emitted-program byte ties
- leave GuestAddrs.lean, symbol-addresses.tsv, RegionMap.lean, and guest bytes unchanged

Refs: evm-asm-af3rp, evm-asm-6agnq, #10088

## Verification
- address-pin grep: empty
- `lake build`: green (4891 jobs)
- `scripts/check-region-map.sh`: green; symbol-addresses.tsv matches ELF; no regeneration
- `scripts/check-asm-to-program.sh`: green (384 converted defs across 145 files)
- `scripts/check-forbidden-tactics.sh`: green
- full `scripts/check-*.sh` suite: all 20 scripts pass
- touched-spec axiom output remains `[propext, Classical.choice, Quot.sound]` (or fewer), including secfCmpP_spec, bloomEq_spec, checkGasLimit_spec, rlpListEncodedSize_spec, blqEq_spec, bnqEq_spec, and bnpFp2Eq_spec

## Scope
Commit diff is deletion-only in `EvmAsm/Codegen/Programs/*SAsm*.lean`; no generated address/map files changed.