### PR TITLE
feat(sasm): machine-tie sg_memcpy emission

### DIFF
--- a/EvmAsm/Codegen/Programs/SgMemcpySAsm.lean
+++ b/EvmAsm/Codegen/Programs/SgMemcpySAsm.lean
@@ -124,6 +124,18 @@ def sgMemcpy_verified : Program :=
 #guard (sgMemcpy_verified : List Instr).length = 7
 #guard (sgMemcpyBody 0 0 0 [] []).flatten 0 = (sgMemcpyBody 0 0 0 [] []).flatten 0x80000000
 
+/-- The complete verified forward-copy routine, including its leaf `ret`. -/
+def sgMemcpy_prog : Program :=
+  (sgMemcpyBody 0 0 0 [] []).flatten 0 ++ [Instr.JALR .x0 .x1 (0 : BitVec 12)]
+
+/-- Kernel correspondence between the structured loop and emitted routine. -/
+theorem sgMemcpy_body_eq_prog :
+    (sgMemcpyBody 0 0 0 [] []).flatten 0 ++ [Instr.JALR .x0 .x1 (0 : BitVec 12)]
+      = sgMemcpy_prog := by
+  rfl
+
+#guard sgMemcpy_prog.length = 8
+
 /-- An `LBU` that misses the writable window reads the read-only region. -/
 theorem execInstrRF_lbu_ro (ro : Region) (rwBase : Word) (rf : RegFile)
     (ws : List (BitVec 8)) (rd rs1 : Reg) (ofs : BitVec 12)
@@ -326,6 +338,8 @@ theorem sgMemcpyFn_spec (src dst : Word) (len : Nat) (bs orig : List (BitVec 8))
     subst hi_len
     show ws = bs.take i
     rw [hwin, copyWin_len_eq bs orig i hol hlb]
+
+#print axioms sgMemcpyFn_spec
 
 end SgMemcpySAsm
 

--- a/EvmAsm/Codegen/Programs/StatelessGuestEpilogue.lean
+++ b/EvmAsm/Codegen/Programs/StatelessGuestEpilogue.lean
@@ -11,6 +11,7 @@ import EvmAsm.Codegen.Programs.ChainValidate
 import EvmAsm.Codegen.Programs.ChainValidateBlob
 import EvmAsm.Codegen.Programs.ChainValidatePostMerge
 import EvmAsm.Codegen.Programs.HashBridge
+import EvmAsm.Codegen.Programs.SgMemcpySAsm
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.Ssz
 import EvmAsm.Codegen.Programs.Tx
@@ -911,16 +912,7 @@ def statelessGuestEpilogue : String :=
   -- (LBU/SB) so src/dst may be unaligned. Leaf; clobbers t0,a0,a1,a2;
   -- preserves all s-registers and ra.
   "sg_memcpy:\n" ++
-  ".Lsgmc_loop:\n" ++
-  "  beqz a2, .Lsgmc_done\n" ++
-  "  lbu t0, 0(a1)\n" ++
-  "  sb  t0, 0(a0)\n" ++
-  "  addi a0, a0, 1\n" ++
-  "  addi a1, a1, 1\n" ++
-  "  addi a2, a2, -1\n" ++
-  "  j .Lsgmc_loop\n" ++
-  ".Lsgmc_done:\n" ++
-  "  ret\n" ++
+  emitProgram SgMemcpySAsm.sgMemcpy_prog ++ "\n" ++
   -- hash_tree_root(List[SszWithdrawal, 16]):  a0=section ptr (may be
   -- unaligned), a1=section_len, a2=32-byte out. Each withdrawal is a
   -- fixed 44-byte container; its root = merkleize([index|pad,

--- a/PLAN.md
+++ b/PLAN.md
@@ -262,7 +262,9 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   `Eip7702NonceReuseGuardSAsm.lean` (`enrgU32leFn_spec`, byte-identity pinned
   to `enrgU32le_prog`) are verified straight-line byte-wise readers over the
   SAsm `Region` model (own-budget engine lemma per the heavy `execBlock`
-  reduction).
+  reduction). `SgMemcpySAsm.lean` verifies the length-generic forward byte-copy
+  loop (`sgMemcpyFn_spec`, post `dst = src.take len`), and `sg_memcpy` is now
+  emitted directly from the kernel-tied `sgMemcpy_prog`.
   `BalGasValidU64SAsm.lean` verifies `bgv_u64le` (`bgvU64leFn_spec`,
   `a0 := leU64 (bytes@a0)`) as a byte-identical `whileHeader` loop pinned to
   `bgvU64le_prog`.  `Blake2fLoadLe64SAsm.lean` verifies `blk2_ld_le64`


### PR DESCRIPTION
## Summary
- define complete `sgMemcpy_prog` from the proven SAsm loop plus `ret`
- emit `sg_memcpy` directly from that kernel-tied program instead of hand-written labeled asm
- update PLAN.md with the verified-to-emitted correspondence

Bead: evm-asm-4ch8f.12.10.2

## Verification
- `scripts/port-check.sh EvmAsm/Codegen/Programs/SgMemcpySAsm.lean`
- `scripts/check-asm-to-program.sh`
- `lake build`
- forbidden-tactics, axioms, layering, unimported, file-size, no-warnings, heartbeat, and hardcoded-PC gates
- whole-guest linked `.text` compared with `origin/main`: both 353316 bytes, SHA-256 `930987d4832cc570246d3040b7db690d3d5fc74fe47c416dd6a1b3f16aec6be5`; `cmp` passed

No EEST A/B is needed because the linked guest bytes are identical.

Directed by @pirapira; implemented by Codex