### PR TITLE
feat(system-writes): verify swd_write_be8 SAsm port

### DIFF
--- a/EvmAsm/Codegen/Programs/SwdWriteBe8SAsm.lean
+++ b/EvmAsm/Codegen/Programs/SwdWriteBe8SAsm.lean
@@ -16,9 +16,10 @@
   Post pins ALL eight destination bytes to the big-endian encoding of `a0`
   (`ws = beBytes a0`, independent of the incoming `orig` bytes).
 
-  Byte-identity to the emitted routine is kernel-pinned below
-  (`swdWriteBe8Body … .flatten 0 ++ [ret] = swdWriteBe8_prog`).  Spec-only
-  module (no emitted-code change) — no EEST A/B required.
+  The emitted routine is re-emitted from the verified structured loop.  Exact
+  identity is kernel-pinned below
+  (`swdWriteBe8Body … .flatten 0 ++ [ret] = swdWriteBe8_prog`).  This changes
+  the old back-edge displacement from `-40` to `-36`, so EEST A/B is required.
 -/
 
 import EvmAsm.Rv64.SAsm.MultiDword
@@ -117,24 +118,17 @@ def swdWriteBe8_verified : Program :=
 #guard (swdWriteBe8_verified : List Instr).length = 12
 #guard (swdWriteBe8Body 0 0 []).flatten 0 = (swdWriteBe8Body 0 0 []).flatten 0x80000000
 
--- Emitted instructions, pinned exactly.  This is `swdWriteBe8_prog` (sans its
--- trailing `ret`) EXCEPT the loop back-edge: the hand-written routine
--- redundantly re-loads `x6 := 8` on every iteration, so its `JAL` is `-40`
--- (target = the `LI x6 8` at index 1); the structured `while` back-edge is
--- `-36` (target = the `BEQ` guard), since the invariant already carries
--- `x6 = 8`.  Same 12 instructions, identical semantics; byte-identity to the
--- emitted `_prog` is therefore intentionally NOT claimed (single-field
--- divergence in the back-`JAL` offset, documented for review).
+-- Emitted instructions, pinned exactly.  The verified structured loop targets
+-- the guard directly on its back-edge; `swdWriteBe8_prog` is re-emitted with
+-- that `-36` displacement instead of the old hand-written `-40` displacement.
 #guard (swdWriteBe8Body 0 0 []).flatten 0 =
   [.LI .x5 0, .LI .x6 8,
    .BEQ .x5 .x6 (40 : BitVec 13),
    .LI .x7 56, .SLLI .x28 .x5 3, .SUB .x7 .x7 .x28, .SRL .x29 .x10 .x7,
    .ANDI .x29 .x29 255, .ADD .x30 .x11 .x5, .SB .x30 .x29 0, .ADDI .x5 .x5 1,
    .JAL .x0 (-36 : BitVec 21)]
--- For reference, the emitted routine (`swdWriteBe8_prog`, 13 instrs incl. ret)
--- is identical to the above except index 11 is `.JAL .x0 (-40)` and it has the
--- trailing `.JALR .x0 .x1 0`.
-#guard swdWriteBe8_prog.length = 13
+#guard (swdWriteBe8Body 0 0 []).flatten 0 ++ [Instr.JALR .x0 .x1 0] =
+  swdWriteBe8_prog
 
 /-- The register file after one loop body (the six ALU results plus the
     counter bump; the store leaves registers unchanged). -/
@@ -266,6 +260,8 @@ theorem swdWriteBe8Fn_spec (v dst : Word) (orig : List (BitVec 8))
       omega
     subst hi8
     exact writeBe8Win_8_eq v orig hlen
+
+#print axioms swdWriteBe8Fn_spec
 
 end SwdWriteBe8SAsm
 

--- a/EvmAsm/Codegen/Programs/SystemWrites.lean
+++ b/EvmAsm/Codegen/Programs/SystemWrites.lean
@@ -130,7 +130,7 @@ def swdWriteBe8_prog : Program :=
     .ADD .x30 .x11 .x5,
     .SB .x30 .x29 (0 : BitVec 12),
     .ADDI .x5 .x5 (1 : BitVec 12),
-    .JAL .x0 (-40 : BitVec 21),
+    .JAL .x0 (-36 : BitVec 21),
     .JALR .x0 .x1 (0 : BitVec 12) ]
 
 def swdWriteBe8Function : String :=

--- a/PLAN.md
+++ b/PLAN.md
@@ -271,10 +271,12 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   `blk2LdLe64_prog`.  Big-endian writers (`whileS` loops over a writable
   region): `SwdWriteBe8SAsm.lean` (`swdWriteBe8Fn_spec`, `ws = beBytes a0`) and
   `SwdWriteBe32U64SAsm.lean` (`swdWriteBe32U64Fn_spec`, `ws = replicate 24 0 ++
-  beBytes a0`, two sequential loops).  Byte-identity caveat: the emitted loops
-  re-init the limit register inside the loop (back-`JAL` targets the `LI`), so a
-  structured `while` (back-edge → guard) differs by exactly that one offset
-  field; explicit structured flattens are pinned and the divergence documented.
+  beBytes a0`, two sequential loops). `swd_write_be8` is re-emitted from its
+  verified structured loop (back-edge → guard), with exact identity pinned to
+  `swdWriteBe8_prog`; the guest-byte change requires EEST A/B. Byte-identity
+  caveat remains for `swd_write_be32_u64`: its emitted loops re-init the limit
+  register inside the loop (back-`JAL` targets the `LI`), so structured `while`
+  differs by one offset field per loop; the divergence is documented.
   `RunningBloomZeroSAsm.lean` verifies `running_bloom_zero`, a fixed 32-dword zero loop over a 256-byte bloom/checkpoint buffer, with byte-identity pinned to `runningBloomZero_prog`.
   `U256FromU64BeSAsm.lean` verifies the straight-line `u256_from_u64_be` leaf
   (`u256FromU64BeFn_spec`, post `ws = u256FromU64Bytes a0`) with byte-identity

--- a/scripts/asm-fixtures/swdWriteBe8Function.s
+++ b/scripts/asm-fixtures/swdWriteBe8Function.s
@@ -1,7 +1,8 @@
 swd_write_be8:
   li t0, 0
+  li t1, 8
 .Lswd8:
-  li t1, 8; beq t0, t1, .Lswd8d
+  beq t0, t1, .Lswd8d
   li t2, 56; slli t3, t0, 3; sub t2, t2, t3
   srl t4, a0, t2; andi t4, t4, 0xff
   add t5, a1, t0; sb t4, 0(t5)


### PR DESCRIPTION
## Summary
- re-emit `swd_write_be8` from its already-proved structured SAsm loop
- kernel-pin the verified flatten plus return to `swdWriteBe8_prog`
- move the loop back-edge from the redundant limit initialization (`-40`) to the verified guard (`-36`)
- update the authoritative assembly fixture and PLAN entry

## Verification
- `lake build`
- `scripts/port-check.sh EvmAsm/Codegen/Programs/SwdWriteBe8SAsm.lean`
- `scripts/check-asm-to-program.sh`
- `scripts/check-region-map.sh`
- `scripts/codegen-zisk-system-writes-check.sh` (12/12 fixture-derived cases pass)
- forbidden-tactic, axiom, layering, orphan, file-size, warning, heartbeat, and hardcoded-PC gates pass
- `#print axioms swdWriteBe8Fn_spec` = `[propext, Classical.choice, Quot.sound]`

## Guest-byte change / EEST
This is an intentional re-emit and requires maintainer EEST A/B before merge. Relative to `main` commit `d58c6a3c6`, linked `.text` stays 353,316 bytes and differs at exactly one byte (1-based offset 49,987), the JAL immediate field. All linked addresses and RegionMap values remain unchanged. Current `.text` SHA-256: `8901edfd174388b5d7e04bc9de1633a0d9655458bdcc1491a56829dc3db33ad9`; baseline: `930987d4832cc570246d3040b7db690d3d5fc74fe47c416dd6a1b3f16aec6be5`.

Bead: `evm-asm-4ch8f.12.10.3`

Directed by @pirapira; implemented by Codex.