### PR TITLE
feat(secp256k1): verify secf_reduce_once_n SAsm port

### DIFF
--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -406,3 +406,4 @@ import EvmAsm.Codegen.Programs.BlockVerdictGasResults
 import EvmAsm.Codegen.Programs.ReceiptList
 import EvmAsm.Codegen.Programs.StatelessGuestUnit
 import EvmAsm.Codegen.Programs.RegistryNames
+import EvmAsm.Codegen.Programs.Secp256k1FieldReduceOnceNSAsm

--- a/EvmAsm/Codegen/Programs/Secp256k1FieldReduceOnceNSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1FieldReduceOnceNSAsm.lean
@@ -1,0 +1,522 @@
+/-
+  EvmAsm.Codegen.Programs.Secp256k1FieldReduceOnceNSAsm
+
+  Final branch merge and whole-frame CPS proof for `secf_reduce_once`.
+-/
+
+import EvmAsm.Codegen.Programs.Secp256k1FieldReduceOnceNSAsmSupport
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Crypto
+
+namespace Secp256k1FieldReduceOnceNSAsm
+
+#guard secfReduceOnceN_prog.length = 32
+
+private theorem cmpFlag_ne_zero_reduce (xs orig : List (BitVec 8))
+    (hflag : cmpFlagWordN xs ≠ (0 : Word)) :
+    reduceOnceNFlag xs = (0 : Word) ∧ reduceOnceNBytes xs orig = xs := by
+  unfold cmpFlagWordN reduceOnceNFlag reduceOnceNBytes at *
+  by_cases hlt : beBytesToNat xs < beBytesToNat secfNBytes
+  · simp [hlt]
+  · simp [hlt] at hflag
+
+private theorem cmpFlag_eq_zero_reduce (xs orig : List (BitVec 8))
+    (hflag : cmpFlagWordN xs = (0 : Word)) :
+    reduceOnceNFlag xs = (1 : Word) ∧
+      reduceOnceNBytes xs orig = U256SubBeSAsm.u256SubBeBytes xs secfNBytes orig := by
+  unfold cmpFlagWordN reduceOnceNFlag reduceOnceNBytes at *
+  by_cases hlt : beBytesToNat xs < beBytesToNat secfNBytes
+  · simp [hlt] at hflag
+  · simp [hlt]
+
+
+private def copyBranchPostFrame (src dst flag : Word) (xs orig : List (BitVec 8)) : Assertion :=
+  (((.x6 : Reg) ↦ᵣ flag) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ⌜flag ≠ 0⌝ **
+    ((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+    ((.x10 : Reg) ↦ᵣ (0 : Word)) **
+    ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+    ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+    ((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 48 : Word)) **
+    ((.x5 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+    regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+    bytesRegion src xs ** globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+    ((GuestAddrs.secf_cmp : Word) ↦ₘ flag) **
+    (bytesRegion dst orig ** regOwns highScratch))
+
+private def copyArmPreFrame (src dst flag : Word) (xs orig : List (BitVec 8)) : Assertion :=
+  (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+    ((.x10 : Reg) ↦ᵣ (0 : Word)) **
+    ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+    ((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 48 : Word)) **
+    regOwns copyScratch ** bytesRegion src xs ** bytesRegion dst orig **
+    (⌜flag ≠ 0⌝ ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+      ((GuestAddrs.secf_cmp : Word) ↦ₘ flag)))
+
+private theorem copyBranch_to_copyPre (src dst flag : Word) (xs orig : List (BitVec 8)) :
+    ∀ h, copyBranchPostFrame src dst flag xs orig h → copyArmPreFrame src dst flag xs orig h := by
+  intro h hp
+  unfold copyBranchPostFrame at hp
+  unfold copyArmPreFrame
+  have hp1 : (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+        ((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 48 : Word)) **
+        ((((.x5 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) ** ((.x6 : Reg) ↦ᵣ flag) **
+          ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) ** regOwn .x7 ** regOwn .x28 **
+          regOwn .x29 ** regOwn .x30 ** regOwns highScratch)) **
+        bytesRegion src xs ** bytesRegion dst orig **
+        (⌜flag ≠ 0⌝ ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+          ((GuestAddrs.secf_cmp : Word) ↦ₘ flag))) h := by
+    xperm_hyp hp
+  exact sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono_right (sepConj_mono_left
+      (branchScratch_to_copyScratch (GuestAddrs.secf_cmp : Word) flag (GuestAddrs.secf_cmp : Word))))))) h hp1
+
+
+
+private def subBranchPostFrame (src dst flag : Word) (xs orig : List (BitVec 8)) : Assertion :=
+  (((.x6 : Reg) ↦ᵣ flag) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ⌜flag = 0⌝ **
+    ((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+    ((.x10 : Reg) ↦ᵣ (0 : Word)) **
+    ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+    ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+    ((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 48 : Word)) **
+    ((.x5 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+    regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+    bytesRegion src xs ** globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+    ((GuestAddrs.secf_cmp : Word) ↦ₘ flag) **
+    (bytesRegion dst orig ** regOwns highScratch))
+
+private def subArmPreFrame (src dst flag : Word) (xs orig : List (BitVec 8)) : Assertion :=
+  (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+    ((.x10 : Reg) ↦ᵣ (0 : Word)) **
+    ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+    ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+    ((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 48 : Word)) **
+    regOwns subScratch ** bytesRegion dst orig ** bytesRegion src xs **
+    globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+    (⌜flag = 0⌝ ** ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((GuestAddrs.secf_cmp : Word) ↦ₘ flag)))
+
+private theorem subBranch_to_subPre (src dst flag : Word) (xs orig : List (BitVec 8)) :
+    ∀ h, subBranchPostFrame src dst flag xs orig h → subArmPreFrame src dst flag xs orig h := by
+  intro h hp
+  unfold subBranchPostFrame at hp
+  unfold subArmPreFrame
+  have hp1 : (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+        ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        ((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 48 : Word)) **
+        ((((.x5 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) ** ((.x6 : Reg) ↦ᵣ flag) **
+          regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwns highScratch)) **
+        bytesRegion dst orig ** bytesRegion src xs **
+        globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+        (⌜flag = 0⌝ ** ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((GuestAddrs.secf_cmp : Word) ↦ₘ flag))) h := by
+    xperm_hyp hp
+  exact sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono_right (sepConj_mono_right (sepConj_mono_left
+      (branchScratch_to_subScratch (GuestAddrs.secf_cmp : Word) flag))))))) h hp1
+
+
+
+
+private def reduceCallerPre (src dst v12 : Word) (xs orig : List (BitVec 8)) : Assertion :=
+  (((.x10 : Reg) ↦ᵣ src) ** ((.x11 : Reg) ↦ᵣ dst) ** ((.x12 : Reg) ↦ᵣ v12) **
+    ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+    regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+    bytesRegion src xs ** globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+    memOwn (GuestAddrs.secf_cmp : Word) **
+    (bytesRegion dst orig ** regOwns highScratch))
+
+private theorem reduceCmpBranchFramed_spec (src dst ret v8 v9 v12 : Word)
+    (xs orig : List (BitVec 8))
+    (hlenX : xs.length = 32)
+    (halignX : src.toNat % 8 = 0)
+    (hovX : src.toNat + 32 < 2 ^ 64)
+    (hvalidX : ∀ k, k < 32 → isValidByteAccess (src + BitVec.ofNat 64 k) = true) :
+    cpsBranchWithin 307 (GuestAddrs.secf_reduce_once_n + 16 : Word) secfReduceOnceNCr
+      (((.x8 : Reg) ↦ᵣ v8) ** ((.x9 : Reg) ↦ᵣ v9) **
+        ((.x10 : Reg) ↦ᵣ src) ** ((.x11 : Reg) ↦ᵣ dst) **
+        ((.x12 : Reg) ↦ᵣ v12) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs **
+        globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+        memOwn (GuestAddrs.secf_cmp : Word) **
+        (bytesRegion dst orig ** regOwns highScratch))
+      (GuestAddrs.secf_reduce_once_n + 92 : Word)
+      (copyBranchPostFrame src dst (cmpFlagWordN xs) xs orig)
+      (GuestAddrs.secf_reduce_once_n + 64 : Word)
+      (subBranchPostFrame src dst (cmpFlagWordN xs) xs orig) := by
+  have hbr0 := ltSetupCallLoadBranch_spec src dst ret v8 v9 v12 xs hlenX halignX hovX hvalidX
+  have hbrF := cpsBranchWithin_frameR (bytesRegion dst orig ** regOwns highScratch) (by pcf) hbr0
+  exact cpsBranchWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by
+      unfold copyBranchPostFrame cmpFlagWordN
+      xperm_hyp hq)
+    (fun _ hq => by
+      unfold subBranchPostFrame cmpFlagWordN
+      xperm_hyp hq) hbrF
+
+private def reduceCallerPost (src dst : Word) (xs orig : List (BitVec 8)) : Assertion :=
+  (((.x10 : Reg) ↦ᵣ reduceOnceNFlag xs) ** regOwns retScratch **
+    bytesRegion dst (reduceOnceNBytes xs orig) ** bytesRegion src xs **
+    globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+    (((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((GuestAddrs.secf_cmp : Word) ↦ₘ cmpFlagWordN xs)))
+
+private def reduceJoinPost (src dst : Word) (xs orig : List (BitVec 8)) : Assertion :=
+  (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) ** regOwn .x1 **
+    reduceCallerPost src dst xs orig)
+
+private def copyArmPostFrame (src dst : Word) (xs : List (BitVec 8)) : Assertion :=
+  (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+    ((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 104 : Word)) **
+    ((.x10 : Reg) ↦ᵣ (0 : Word)) ** regOwns retScratch **
+    bytesRegion src xs ** bytesRegion dst xs **
+    (⌜cmpFlagWordN xs ≠ 0⌝ ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+      ((GuestAddrs.secf_cmp : Word) ↦ₘ cmpFlagWordN xs)))
+
+private def subArmPostFrame (src dst : Word) (xs orig : List (BitVec 8)) : Assertion :=
+  (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+    ((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 84 : Word)) **
+    ((.x10 : Reg) ↦ᵣ (1 : Word)) ** regOwns retScratch **
+    bytesRegion dst (U256SubBeSAsm.u256SubBeBytes xs secfNBytes orig) **
+    bytesRegion src xs ** globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+    (⌜cmpFlagWordN xs = 0⌝ ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((GuestAddrs.secf_cmp : Word) ↦ₘ cmpFlagWordN xs)))
+
+private theorem copyPost_to_reducePost (src dst : Word) (xs orig : List (BitVec 8)) :
+    ∀ h, copyArmPostFrame src dst xs h → reduceJoinPost src dst xs orig h := by
+  intro h hp
+  unfold copyArmPostFrame at hp
+  unfold reduceJoinPost
+  extract_pure_deep hp
+  obtain ⟨hflag, hp⟩ := hp
+  have hred := cmpFlag_ne_zero_reduce xs orig hflag
+  have hp1 : (((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 104 : Word)) **
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) ** regOwns retScratch **
+        bytesRegion src xs ** bytesRegion dst xs **
+        (((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+          ((GuestAddrs.secf_cmp : Word) ↦ₘ cmpFlagWordN xs)))) h := by
+    xperm_hyp hp
+  have hp2 : (regOwn .x1 **
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) ** regOwns retScratch **
+        bytesRegion src xs ** bytesRegion dst xs **
+        (((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+          ((GuestAddrs.secf_cmp : Word) ↦ₘ cmpFlagWordN xs)))) h := by
+    exact sepConj_mono_left
+      (regIs_to_regOwn .x1 (GuestAddrs.secf_reduce_once_n + 104 : Word)) h hp1
+  unfold reduceCallerPost
+  rw [hred.1, hred.2]
+  xperm_hyp hp2
+
+
+private theorem copyBranchToReduceJoin_spec (src dst : Word)
+    (xs orig : List (BitVec 8))
+    (hlenX : xs.length = 32) (hlenOrig : orig.length = 32) :
+    cpsTripleWithin ((2 + (1 + 9)) + 1)
+      (GuestAddrs.secf_reduce_once_n + 92 : Word)
+      (GuestAddrs.secf_reduce_once_n + 108 : Word) secfReduceOnceNCr
+      (copyBranchPostFrame src dst (cmpFlagWordN xs) xs orig)
+      (reduceJoinPost src dst xs orig) := by
+  have hcopy0 := copyArm_spec src dst (GuestAddrs.secf_reduce_once_n + 48 : Word)
+    (0 : Word) (GuestAddrs.secf_n_be : Word) xs orig hlenX hlenOrig
+  have hcopyF := cpsTripleWithin_frameR
+    (⌜cmpFlagWordN xs ≠ 0⌝ ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+      ((GuestAddrs.secf_cmp : Word) ↦ₘ cmpFlagWordN xs)) (by pcf) hcopy0
+  refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_) hcopyF
+  · have hp1 := copyBranch_to_copyPre src dst (cmpFlagWordN xs) xs orig h hp
+    unfold copyArmPreFrame at hp1
+    xperm_hyp hp1
+  · have hq1 : copyArmPostFrame src dst xs h := by
+      unfold copyArmPostFrame
+      xperm_hyp hq
+    exact copyPost_to_reducePost src dst xs orig h hq1
+
+private theorem subPost_to_reducePost (src dst : Word) (xs orig : List (BitVec 8)) :
+    ∀ h, subArmPostFrame src dst xs orig h → reduceJoinPost src dst xs orig h := by
+  intro h hp
+  unfold subArmPostFrame at hp
+  unfold reduceJoinPost
+  extract_pure_deep hp
+  obtain ⟨hflag, hp⟩ := hp
+  have hred := cmpFlag_eq_zero_reduce xs orig hflag
+  have hp1 : (((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 84 : Word)) **
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ (1 : Word)) ** regOwns retScratch **
+        bytesRegion dst (U256SubBeSAsm.u256SubBeBytes xs secfNBytes orig) **
+        bytesRegion src xs ** globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+        (((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          ((GuestAddrs.secf_cmp : Word) ↦ₘ cmpFlagWordN xs)))) h := by
+    xperm_hyp hp
+  have hp2 : (regOwn .x1 **
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ (1 : Word)) ** regOwns retScratch **
+        bytesRegion dst (U256SubBeSAsm.u256SubBeBytes xs secfNBytes orig) **
+        bytesRegion src xs ** globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+        (((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          ((GuestAddrs.secf_cmp : Word) ↦ₘ cmpFlagWordN xs)))) h := by
+    exact sepConj_mono_left
+      (regIs_to_regOwn .x1 (GuestAddrs.secf_reduce_once_n + 84 : Word)) h hp1
+  unfold reduceCallerPost
+  rw [hred.1, hred.2]
+  xperm_hyp hp2
+
+
+
+
+private theorem subBranchToReduceJoin_spec (src dst : Word)
+    (xs orig : List (BitVec 8))
+    (hroX : Region.wf ⟨src, xs⟩)
+    (hrwDst : RwRegion.wf ⟨dst, 32⟩)
+    (hlenX : xs.length = 32) (hlenOrig : orig.length = 32)
+    (hovX : src.toNat + 32 < 2 ^ 64)
+    (hovDst : dst.toNat + 32 < 2 ^ 64)
+    (hdisjX : src.toNat + 32 ≤ dst.toNat ∨ dst.toNat + 32 ≤ src.toNat)
+    (hdisjP : (GuestAddrs.secf_n_be : Word).toNat + 32 ≤ dst.toNat ∨
+      dst.toNat + 32 ≤ (GuestAddrs.secf_n_be : Word).toNat) :
+    cpsTripleWithin ((4 + (1 + ((U256SubBeSAsm.u256SubBeFn src
+        (GuestAddrs.secf_n_be : Word) dst xs secfNBytes orig).body.steps + 1))) + 2)
+      (GuestAddrs.secf_reduce_once_n + 64 : Word)
+      (GuestAddrs.secf_reduce_once_n + 108 : Word) secfReduceOnceNCr
+      (subBranchPostFrame src dst (cmpFlagWordN xs) xs orig)
+      (reduceJoinPost src dst xs orig) := by
+  have hsub0 := subArm_spec src dst (GuestAddrs.secf_reduce_once_n + 48 : Word)
+    (0 : Word) (GuestAddrs.secf_n_be : Word) (GuestAddrs.secf_cmp : Word)
+    xs orig hroX hrwDst hlenX hlenOrig hovX hovDst hdisjX hdisjP
+  have hsubF := cpsTripleWithin_frameR
+    (⌜cmpFlagWordN xs = 0⌝ ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((GuestAddrs.secf_cmp : Word) ↦ₘ cmpFlagWordN xs)) (by pcf) hsub0
+  refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_) hsubF
+  · have hp1 := subBranch_to_subPre src dst (cmpFlagWordN xs) xs orig h hp
+    unfold subArmPreFrame at hp1
+    xperm_hyp hp1
+  · have hq1 : subArmPostFrame src dst xs orig h := by
+      unfold subArmPostFrame
+      xperm_hyp hq
+    exact subPost_to_reducePost src dst xs orig h hq1
+
+
+private theorem reduceBodyBranch_spec (src dst ret v8 v9 v12 : Word)
+    (xs orig : List (BitVec 8))
+    (hroX : Region.wf ⟨src, xs⟩)
+    (hrwDst : RwRegion.wf ⟨dst, 32⟩)
+    (hlenX : xs.length = 32) (hlenOrig : orig.length = 32)
+    (halignX : src.toNat % 8 = 0)
+    (hovX : src.toNat + 32 < 2 ^ 64)
+    (hvalidX : ∀ k, k < 32 → isValidByteAccess (src + BitVec.ofNat 64 k) = true)
+    (hovDst : dst.toNat + 32 < 2 ^ 64)
+    (hdisjX : src.toNat + 32 ≤ dst.toNat ∨ dst.toNat + 32 ≤ src.toNat)
+    (hdisjP : (GuestAddrs.secf_n_be : Word).toNat + 32 ≤ dst.toNat ∨
+      dst.toNat + 32 ≤ (GuestAddrs.secf_n_be : Word).toNat) :
+    cpsTripleWithin (307 + (((2 + (1 + 9)) + 1) +
+        ((4 + (1 + ((U256SubBeSAsm.u256SubBeFn src
+        (GuestAddrs.secf_n_be : Word) dst xs secfNBytes orig).body.steps + 1))) + 2)))
+      (GuestAddrs.secf_reduce_once_n + 16 : Word)
+      (GuestAddrs.secf_reduce_once_n + 108 : Word) secfReduceOnceNCr
+      (((.x8 : Reg) ↦ᵣ v8) ** ((.x9 : Reg) ↦ᵣ v9) **
+        ((.x10 : Reg) ↦ᵣ src) ** ((.x11 : Reg) ↦ᵣ dst) **
+        ((.x12 : Reg) ↦ᵣ v12) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs **
+        globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+        memOwn (GuestAddrs.secf_cmp : Word) **
+        (bytesRegion dst orig ** regOwns highScratch))
+      (reduceJoinPost src dst xs orig) := by
+  have hbr := reduceCmpBranchFramed_spec src dst ret v8 v9 v12 xs orig
+    hlenX halignX hovX hvalidX
+  have hcopy0 := copyBranchToReduceJoin_spec src dst xs orig hlenX hlenOrig
+  have hcopy : cpsTripleWithin (((2 + (1 + 9)) + 1) +
+        ((4 + (1 + ((U256SubBeSAsm.u256SubBeFn src
+        (GuestAddrs.secf_n_be : Word) dst xs secfNBytes orig).body.steps + 1))) + 2))
+      (GuestAddrs.secf_reduce_once_n + 92 : Word)
+      (GuestAddrs.secf_reduce_once_n + 108 : Word) secfReduceOnceNCr
+      (copyBranchPostFrame src dst (cmpFlagWordN xs) xs orig)
+      (reduceJoinPost src dst xs orig) := by
+    exact cpsTripleWithin_mono_nSteps (by omega) hcopy0
+  have hsub0 := subBranchToReduceJoin_spec src dst xs orig hroX hrwDst hlenX hlenOrig
+    hovX hovDst hdisjX hdisjP
+  have hsub : cpsTripleWithin (((2 + (1 + 9)) + 1) +
+        ((4 + (1 + ((U256SubBeSAsm.u256SubBeFn src
+        (GuestAddrs.secf_n_be : Word) dst xs secfNBytes orig).body.steps + 1))) + 2))
+      (GuestAddrs.secf_reduce_once_n + 64 : Word)
+      (GuestAddrs.secf_reduce_once_n + 108 : Word) secfReduceOnceNCr
+      (subBranchPostFrame src dst (cmpFlagWordN xs) xs orig)
+      (reduceJoinPost src dst xs orig) := by
+    exact cpsTripleWithin_mono_nSteps (by omega) hsub0
+  exact cpsBranchWithin_merge_same_cr hbr hcopy hsub
+
+
+private theorem reduceRestoreTail_spec (sp0 ret src dst s0 s1 : Word)
+    (xs orig : List (BitVec 8))
+    (halign : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin (secfReduceOnceNFrame.length + 1 + 1)
+      (GuestAddrs.secf_reduce_once_n + 108 : Word) ret secfReduceOnceNCr
+      (((.x2 : Reg) ↦ᵣ (sp0 + signExtend12 (-32 : BitVec 12))) **
+        frameSlotsSaved secfReduceOnceNFrame (sp0 + signExtend12 (-32 : BitVec 12))
+          (secfReduceOnceNVals ret s0 s1) **
+        reduceJoinPost src dst xs orig)
+      (((.x2 : Reg) ↦ᵣ sp0) ** regsAt secfReduceOnceNFrame (secfReduceOnceNVals ret s0 s1) **
+        frameSlotsSaved secfReduceOnceNFrame (sp0 + signExtend12 (-32 : BitVec 12))
+          (secfReduceOnceNVals ret s0 s1) **
+        reduceCallerPost src dst xs orig) := by
+  set newSp := sp0 + signExtend12 (-32 : BitVec 12) with hnewSp
+  have hcore : cpsTripleWithin (secfReduceOnceNFrame.length + 1 + 1)
+      (GuestAddrs.secf_reduce_once_n + 108 : Word) ret secfReduceOnceNCr
+      (((((.x2 : Reg) ↦ᵣ newSp) **
+        frameSlotsSaved secfReduceOnceNFrame newSp (secfReduceOnceNVals ret s0 s1) **
+        ((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        reduceCallerPost src dst xs orig) ** regOwn .x1))
+      (((.x2 : Reg) ↦ᵣ sp0) ** regsAt secfReduceOnceNFrame (secfReduceOnceNVals ret s0 s1) **
+        frameSlotsSaved secfReduceOnceNFrame newSp (secfReduceOnceNVals ret s0 s1) **
+        reduceCallerPost src dst xs orig) := by
+    refine cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x1)
+      (P := (((.x2 : Reg) ↦ᵣ newSp) **
+        frameSlotsSaved secfReduceOnceNFrame newSp (secfReduceOnceNVals ret s0 s1) **
+        ((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        reduceCallerPost src dst xs orig))
+      (Q := (((.x2 : Reg) ↦ᵣ sp0) ** regsAt secfReduceOnceNFrame (secfReduceOnceNVals ret s0 s1) **
+        frameSlotsSaved secfReduceOnceNFrame newSp (secfReduceOnceNVals ret s0 s1) **
+        reduceCallerPost src dst xs orig)) ?_
+    intro v1
+    have hload0 := loadSeq_spec secfReduceOnceNFrame newSp
+      (secfReduceOnceNVals ret s0 s1) (secfReduceOnceNVals v1 src dst)
+      (GuestAddrs.secf_reduce_once_n + 108 : Word) (by decide) (by decide)
+    have hload := liftCode (cr' := secfReduceOnceNCr) hload0
+      (by unfold secfReduceOnceNCr; code_mem)
+    rw [show (GuestAddrs.secf_reduce_once_n + 108 : Word) + BitVec.ofNat 64 (4 * secfReduceOnceNFrame.length) =
+        (GuestAddrs.secf_reduce_once_n + 120 : Word) from by decide] at hload
+    have hloadF := cpsTripleWithin_frameR (reduceCallerPost src dst xs orig) (by pcf) hload
+    have hdealloc0 := addi_spec_gen_same_within .x2 newSp (32 : BitVec 12)
+      (GuestAddrs.secf_reduce_once_n + 120 : Word) (by decide)
+    rw [show newSp + signExtend12 (32 : BitVec 12) = sp0 from by
+        rw [hnewSp]
+        exact sext_frameRestore sp0 (-32 : BitVec 12) (32 : BitVec 12) (by decide)] at hdealloc0
+    have hdealloc := liftCode (cr' := secfReduceOnceNCr) hdealloc0
+      (by unfold secfReduceOnceNCr; code_mem)
+    rw [show (GuestAddrs.secf_reduce_once_n + 120 : Word) + 4 =
+        (GuestAddrs.secf_reduce_once_n + 124 : Word) from by decide] at hdealloc
+    have hdeallocF := cpsTripleWithin_frameR
+      (regsAt secfReduceOnceNFrame (secfReduceOnceNVals ret s0 s1) **
+        frameSlotsSaved secfReduceOnceNFrame newSp (secfReduceOnceNVals ret s0 s1) **
+        reduceCallerPost src dst xs orig) (by pcf) hdealloc
+    have hret0 := EvmAsm.Evm64.ret_spec_within' (GuestAddrs.secf_reduce_once_n + 124 : Word) ret
+    rw [halign] at hret0
+    have hret := liftCode (cr' := secfReduceOnceNCr) hret0
+      (by unfold secfReduceOnceNCr; code_mem)
+    have hretF := cpsTripleWithin_frameR
+      (((.x2 : Reg) ↦ᵣ sp0) ** regsAt [(.x8, (8 : BitVec 12)), (.x9, (16 : BitVec 12))]
+          (secfReduceOnceNVals ret s0 s1) **
+        frameSlotsSaved secfReduceOnceNFrame newSp (secfReduceOnceNVals ret s0 s1) **
+        reduceCallerPost src dst xs orig) (by pcf) hret
+    have h12 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by
+        xperm_hyp hp) hloadF hdeallocF
+    have hReg : regsAt secfReduceOnceNFrame (secfReduceOnceNVals ret s0 s1) =
+        (((.x1 : Reg) ↦ᵣ ret) ** regsAt [(.x8, (8 : BitVec 12)), (.x9, (16 : BitVec 12))]
+          (secfReduceOnceNVals ret s0 s1)) := by
+      simp only [secfReduceOnceNFrame, regsAt, secfReduceOnceNVals, List.foldr_cons,
+        List.foldr_nil, sepConj_emp_right']
+    rw [hReg] at h12
+    have h123 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h12 hretF
+    have hRegV : regsAt secfReduceOnceNFrame (secfReduceOnceNVals v1 src dst) =
+        (((.x1 : Reg) ↦ᵣ v1) ** ((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst)) := by
+      simp only [secfReduceOnceNFrame, regsAt, secfReduceOnceNVals, List.foldr_cons,
+        List.foldr_nil, sepConj_emp_right']
+    exact cpsTripleWithin_weaken (fun _ hp => by
+        rw [hRegV]
+        xperm_hyp hp)
+      (fun _ hq => by
+        rw [hReg]
+        xperm_hyp hq) h123
+  exact cpsTripleWithin_weaken (fun h hp => by
+      unfold reduceJoinPost at hp
+      rw [hnewSp]
+      xperm_hyp hp)
+    (fun h hq => by
+      rw [hnewSp] at hq
+      xperm_hyp hq) hcore
+
+
+theorem secfReduceOnceNFrame_spec (sp0 ret src dst s0 s1 v12 : Word)
+    (xs orig : List (BitVec 8))
+    (hroX : Region.wf ⟨src, xs⟩)
+    (hrwDst : RwRegion.wf ⟨dst, 32⟩)
+    (hlenX : xs.length = 32) (hlenOrig : orig.length = 32)
+    (halignX : src.toNat % 8 = 0)
+    (hovX : src.toNat + 32 < 2 ^ 64)
+    (hvalidX : ∀ k, k < 32 → isValidByteAccess (src + BitVec.ofNat 64 k) = true)
+    (hovDst : dst.toNat + 32 < 2 ^ 64)
+    (hdisjX : src.toNat + 32 ≤ dst.toNat ∨ dst.toNat + 32 ≤ src.toNat)
+    (hdisjP : (GuestAddrs.secf_n_be : Word).toNat + 32 ≤ dst.toNat ∨
+      dst.toNat + 32 ≤ (GuestAddrs.secf_n_be : Word).toNat)
+    (halignRet : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin (1 + secfReduceOnceNFrame.length +
+        (307 + (((2 + (1 + 9)) + 1) +
+          ((4 + (1 + ((U256SubBeSAsm.u256SubBeFn src
+            (GuestAddrs.secf_n_be : Word) dst xs secfNBytes orig).body.steps + 1))) + 2))) +
+        (secfReduceOnceNFrame.length + 1 + 1))
+      (GuestAddrs.secf_reduce_once_n : Word) ret secfReduceOnceNCr
+      (((.x2 : Reg) ↦ᵣ sp0) ** regsAt secfReduceOnceNFrame (secfReduceOnceNVals ret s0 s1) **
+        frameSlotsOwn secfReduceOnceNFrame (sp0 + signExtend12 (-32 : BitVec 12)) **
+        reduceCallerPre src dst v12 xs orig)
+      (((.x2 : Reg) ↦ᵣ sp0) ** regsAt secfReduceOnceNFrame (secfReduceOnceNVals ret s0 s1) **
+        frameSlotsSaved secfReduceOnceNFrame (sp0 + signExtend12 (-32 : BitVec 12))
+          (secfReduceOnceNVals ret s0 s1) **
+        reduceCallerPost src dst xs orig) := by
+  set newSp := sp0 + signExtend12 (-32 : BitVec 12) with hnewSp
+  have halloc0 := addi_spec_gen_same_within .x2 sp0 (-32 : BitVec 12)
+    (GuestAddrs.secf_reduce_once_n : Word) (by decide)
+  rw [← hnewSp] at halloc0
+  have halloc := liftCode (cr' := secfReduceOnceNCr) halloc0
+    (by unfold secfReduceOnceNCr; code_mem)
+  rw [show (GuestAddrs.secf_reduce_once_n : Word) + 4 =
+      (GuestAddrs.secf_reduce_once_n + 4 : Word) from by decide] at halloc
+  have hallocF := cpsTripleWithin_frameR
+    (regsAt secfReduceOnceNFrame (secfReduceOnceNVals ret s0 s1) **
+      frameSlotsOwn secfReduceOnceNFrame newSp ** reduceCallerPre src dst v12 xs orig) (by pcf) halloc
+  have hstore0 := storeSeq_spec secfReduceOnceNFrame newSp (secfReduceOnceNVals ret s0 s1)
+    (GuestAddrs.secf_reduce_once_n + 4 : Word) (by decide)
+  have hstore := liftCode (cr' := secfReduceOnceNCr) hstore0
+    (by unfold secfReduceOnceNCr; code_mem)
+  rw [show (GuestAddrs.secf_reduce_once_n + 4 : Word) + BitVec.ofNat 64 (4 * secfReduceOnceNFrame.length) =
+      (GuestAddrs.secf_reduce_once_n + 16 : Word) from by decide] at hstore
+  have hstoreF := cpsTripleWithin_frameR (reduceCallerPre src dst v12 xs orig) (by pcf) hstore
+  have hbody0 := reduceBodyBranch_spec src dst ret s0 s1 v12 xs orig hroX hrwDst hlenX hlenOrig
+    halignX hovX hvalidX hovDst hdisjX hdisjP
+  have hbodyF := cpsTripleWithin_frameR
+    (((.x2 : Reg) ↦ᵣ newSp) **
+      frameSlotsSaved secfReduceOnceNFrame newSp (secfReduceOnceNVals ret s0 s1)) (by pcf) hbody0
+  have htail := reduceRestoreTail_spec sp0 ret src dst s0 s1 xs orig halignRet
+  have h12 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hallocF hstoreF
+  have h123 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by
+      unfold reduceCallerPre at hp
+      simp only [secfReduceOnceNFrame, regsAt, secfReduceOnceNVals, List.foldr_cons,
+        List.foldr_nil, sepConj_emp_right'] at hp ⊢
+      xperm_hyp hp) h12 hbodyF
+  have h1234 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h123 htail
+  exact cpsTripleWithin_weaken (fun _ hp => by
+      rw [hnewSp]
+      xperm_hyp hp)
+    (fun _ hq => by
+      rw [hnewSp]
+      xperm_hyp hq) h1234
+
+#print axioms secfReduceOnceNFrame_spec
+
+end Secp256k1FieldReduceOnceNSAsm
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Secp256k1FieldReduceOnceNSAsmSupport.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1FieldReduceOnceNSAsmSupport.lean
@@ -1,0 +1,1234 @@
+/-
+  EvmAsm.Codegen.Programs.Secp256k1FieldReduceOnceNSAsmSupport
+
+  SAsm/CPS port scaffold for `secf_reduce_once_n`: reduce a 32-byte
+  big-endian secp256k1 scalar by subtracting the group order n at most once.
+
+  The emitted routine is an ABI-frame caller over three verified callees:
+  `u256_lt_be`, `u256_sub_be`, and `secf_copy32`, with `la` materialization
+  of the read-only modulus and the 8-byte comparison scratch cell.
+-/
+
+import EvmAsm.Codegen.Programs.Secp256k1Field
+import EvmAsm.Codegen.Programs.Secp256k1FieldLeavesSAsm
+import EvmAsm.Codegen.Programs.U256LtBeSAsm
+import EvmAsm.Codegen.Programs.U256SubBeSAsm
+import EvmAsm.Rv64.SAsm.BlockAtBridge
+import EvmAsm.Rv64.SAsm.FnFlat
+import EvmAsm.Rv64.SAsm.FramePort
+import EvmAsm.Rv64.SAsm.RetForwardJoin
+import EvmAsm.Rv64.Tactics.DropPure
+import EvmAsm.Rv64.Tactics.ExtractPure
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Crypto
+
+namespace Secp256k1FieldReduceOnceNSAsm
+
+#guard GuestAddrs.secf_reduce_once_n = 0x800202cc
+#guard GuestAddrs.secf_n_be = 0xa3c05360
+#guard GuestAddrs.secf_cmp = 0xa3c053e0
+#guard GuestAddrs.u256_lt_be = 0x800052c4
+#guard GuestAddrs.u256_sub_be = 0x80005248
+#guard GuestAddrs.secf_copy32 = 0x8001fca4
+
+/-- secp256k1 group order, as 32 big-endian bytes. -/
+def secfNBytes : List (BitVec 8) :=
+  [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+   0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe,
+   0xba, 0xae, 0xdc, 0xe6, 0xaf, 0x48, 0xa0, 0x3b,
+   0xbf, 0xd2, 0x5e, 0x8c, 0xd0, 0x36, 0x41, 0x41]
+
+#guard secfNBytes.length = 32
+#guard beBytesToNat secfNBytes =
+  0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
+
+/-- The routine's frame slots: `ra`, `s0`, `s1`. -/
+def secfReduceOnceNFrame : FrameDesc := [(.x1, 0), (.x8, 8), (.x9, 16)]
+
+/-- Body between ABI-frame prologue and epilogue. -/
+def secfReduceOnceNBody : List Instr :=
+  [ .MV .x8 .x10,
+    .MV .x9 .x11,
+    .MV .x10 .x8,
+    .AUIPC .x11 (laHi GuestAddrs.secf_n_be (GuestAddrs.secf_reduce_once_n + 28)),
+    .ADDI .x11 .x11 (laLo GuestAddrs.secf_n_be (GuestAddrs.secf_reduce_once_n + 28)),
+    .AUIPC .x12 (laHi GuestAddrs.secf_cmp (GuestAddrs.secf_reduce_once_n + 36)),
+    .ADDI .x12 .x12 (laLo GuestAddrs.secf_cmp (GuestAddrs.secf_reduce_once_n + 36)),
+    .JAL .x1 (jalOff GuestAddrs.u256_lt_be (GuestAddrs.secf_reduce_once_n + 44)),
+    .AUIPC .x5 (laHi GuestAddrs.secf_cmp (GuestAddrs.secf_reduce_once_n + 48)),
+    .ADDI .x5 .x5 (laLo GuestAddrs.secf_cmp (GuestAddrs.secf_reduce_once_n + 48)),
+    .LD .x6 .x5 (0 : BitVec 12),
+    .BNE .x6 .x0 (32 : BitVec 13),
+    .MV .x10 .x8,
+    .AUIPC .x11 (laHi GuestAddrs.secf_n_be (GuestAddrs.secf_reduce_once_n + 68)),
+    .ADDI .x11 .x11 (laLo GuestAddrs.secf_n_be (GuestAddrs.secf_reduce_once_n + 68)),
+    .MV .x12 .x9,
+    .JAL .x1 (jalOff GuestAddrs.u256_sub_be (GuestAddrs.secf_reduce_once_n + 80)),
+    .LI .x10 (1 : Word),
+    .JAL .x0 (20 : BitVec 21),
+    .MV .x10 .x8,
+    .MV .x11 .x9,
+    .JAL .x1 (jalOff GuestAddrs.secf_copy32 (GuestAddrs.secf_reduce_once_n + 100)),
+    .LI .x10 (0 : Word) ]
+
+#guard secfReduceOnceNBody.length = 23
+
+/-- Code surface for the caller plus all three callees it may jump to. -/
+def secfReduceOnceNCr : CodeReq :=
+  (((CodeReq.ofProg (GuestAddrs.secf_reduce_once_n : Word) secfReduceOnceN_prog).union
+    (CodeReq.ofProg (GuestAddrs.u256_lt_be : Word) u256LtBe_prog)).union
+    (CodeReq.ofProg (GuestAddrs.u256_sub_be : Word) u256SubBe_prog)).union
+    (CodeReq.ofProg (GuestAddrs.secf_copy32 : Word) secfCopy32_prog)
+
+/-- Byte-transparency: the emitted routine is exactly this ABI frame. -/
+theorem secfReduceOnceN_prog_eq :
+    abiFrameProg (-32 : BitVec 12) (32 : BitVec 12)
+      secfReduceOnceNFrame secfReduceOnceNBody = secfReduceOnceN_prog := rfl
+
+
+def secfReduceOnceNVals (ret s0 s1 : Word) : Reg → Word := fun r =>
+  match r with
+  | .x1 => ret
+  | .x8 => s0
+  | .x9 => s1
+  | _ => 0
+
+
+/-- Real reduce-once byte result.  The caller is expected to supply values
+    below `2n`; this pure post still states the exact branch semantics of
+    the emitted routine. -/
+def reduceOnceNBytes (x orig : List (BitVec 8)) : List (BitVec 8) :=
+  if beBytesToNat x < beBytesToNat secfNBytes then
+    x
+  else
+    U256SubBeSAsm.u256SubBeBytes x secfNBytes orig
+
+/-- Return flag: `1` iff the subtraction path was taken. -/
+def reduceOnceNFlag (x : List (BitVec 8)) : Word :=
+  if beBytesToNat x < beBytesToNat secfNBytes then (0 : Word) else (1 : Word)
+
+/-- The `secf_cmp` scratch dword after the `u256_lt_be` call. -/
+def cmpFlagWordN (x : List (BitVec 8)) : Word :=
+  if beBytesToNat x < beBytesToNat secfNBytes then (1 : Word) else (0 : Word)
+
+-- ============================================================================
+-- Local flat adapter for callees whose `Fn` post preserves ambient assertions.
+-- ============================================================================
+
+private theorem asrtOf_intro_ambient (rw : RwRegion) (reach : Reach)
+    (rf : RegFile) (ws : List (BitVec 8)) (A : Assertion)
+    (hlen : ws.length = rw.len) (hApc : A.pcFree) (hreach : reach rf ws A) :
+    ∀ hp, (((regFileIs rf) ** bytesRegion rw.base ws) ** A) hp →
+      asrtOf rw reach hp := by
+  intro hp hh
+  exact ⟨rf, ws, A, hlen, hApc, hreach, hh⟩
+
+private theorem asrtOf_elim_ambient (rw : RwRegion) (reach : Reach) {Q : Assertion}
+    (h : ∀ (rf : RegFile) (ws : List (BitVec 8)) (A : Assertion),
+      ws.length = rw.len → A.pcFree → reach rf ws A →
+      ∀ hp, (((regFileIs rf) ** bytesRegion rw.base ws) ** A) hp → Q hp) :
+    ∀ hp, asrtOf rw reach hp → Q hp := by
+  rintro hp ⟨rf, ws, A, hlen, hApc, hreach, hsts⟩
+  exact h rf ws A hlen hApc hreach hp hsts
+
+private theorem retSpecFlatAmbient (f : Fn) (base : Word) (hspec : f.Spec base)
+    (hsz : 4 * (f.body.size + 1) ≤ 2 ^ 64)
+    (ret : Word) (halign : (ret &&& ~~~(1 : Word)) = ret)
+    (rf : RegFile) (ws : List (BitVec 8)) (A : Assertion)
+    (hlen : ws.length = f.rw.len) (hApc : A.pcFree) (hpre : f.pre rf ws A)
+    {Q : Assertion}
+    (hpost : ∀ (rf' : RegFile) (ws' : List (BitVec 8)) (A' : Assertion),
+      ws'.length = f.rw.len → A'.pcFree → f.post rf' ws' A' →
+      ∀ hp, (((regFileIs rf') ** bytesRegion f.rw.base ws') ** A') hp → Q hp) :
+    cpsTripleWithin (f.body.steps + 1) base ret
+      (CodeReq.ofProg base (f.programRet base))
+      (((((.x1 : Reg) ↦ᵣ ret) ** (regFileIs rf) ** bytesRegion f.rw.base ws)
+        ** A) ** bytesRegion f.region.base f.region.bytes)
+      ((((.x1 : Reg) ↦ᵣ ret) ** Q) ** bytesRegion f.region.base f.region.bytes) := by
+  have hr := Fn.retSpec f base hspec hsz ret halign
+  refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_) hr
+  · have hp1 : ((((.x1 : Reg) ↦ᵣ ret)
+        ** ((regFileIs rf ** bytesRegion f.rw.base ws) ** A))
+        ** bytesRegion f.region.base f.region.bytes) h := by
+      xperm_hyp hp
+    have hp2 := sepConj_mono_left (sepConj_mono_right
+      (asrtOf_intro_ambient f.rw f.pre rf ws A hlen hApc hpre)) h hp1
+    show (((.x1 : Reg) ↦ᵣ ret) ** asrtM f.region f.rw f.pre) h
+    unfold asrtM
+    xperm_hyp hp2
+  · unfold asrtM at hq
+    have hq1 : ((((.x1 : Reg) ↦ᵣ ret) ** asrtOf f.rw f.post)
+        ** bytesRegion f.region.base f.region.bytes) h := by
+      xperm_hyp hq
+    exact sepConj_mono_left (sepConj_mono_right
+      (asrtOf_elim_ambient f.rw f.post hpost)) h hq1
+
+private theorem ltSetup_spec (src dst ret v8 v9 v12 : Word) :
+    cpsTripleWithin 7 (GuestAddrs.secf_reduce_once_n + 16 : Word)
+      (GuestAddrs.secf_reduce_once_n + 44 : Word) secfReduceOnceNCr
+      (((.x8 : Reg) ↦ᵣ v8) ** ((.x9 : Reg) ↦ᵣ v9) **
+        ((.x10 : Reg) ↦ᵣ src) ** ((.x11 : Reg) ↦ᵣ dst) **
+        ((.x12 : Reg) ↦ᵣ v12) ** ((.x1 : Reg) ↦ᵣ ret))
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ src) **
+        ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+        ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        ((.x1 : Reg) ↦ᵣ ret)) := by
+  have hmv8 := liftCode (cr' := secfReduceOnceNCr)
+    (mv_spec_gen_within .x8 .x10 src v8 (GuestAddrs.secf_reduce_once_n + 16 : Word)
+      (by decide))
+    (by unfold secfReduceOnceNCr; code_mem)
+  rw [show (GuestAddrs.secf_reduce_once_n + 16 : Word) + 4 =
+      (GuestAddrs.secf_reduce_once_n + 20 : Word) from by decide] at hmv8
+  have hmv9 := liftCode (cr' := secfReduceOnceNCr)
+    (mv_spec_gen_within .x9 .x11 dst v9 (GuestAddrs.secf_reduce_once_n + 20 : Word)
+      (by decide))
+    (by unfold secfReduceOnceNCr; code_mem)
+  rw [show (GuestAddrs.secf_reduce_once_n + 20 : Word) + 4 =
+      (GuestAddrs.secf_reduce_once_n + 24 : Word) from by decide] at hmv9
+  have hmv10 := liftCode (cr' := secfReduceOnceNCr)
+    (mv_spec_gen_within .x10 .x8 src src (GuestAddrs.secf_reduce_once_n + 24 : Word)
+      (by decide))
+    (by unfold secfReduceOnceNCr; code_mem)
+  rw [show (GuestAddrs.secf_reduce_once_n + 24 : Word) + 4 =
+      (GuestAddrs.secf_reduce_once_n + 28 : Word) from by decide] at hmv10
+  have hlaP := la_materialize_within .x11 dst
+    (GuestAddrs.secf_reduce_once_n + 28 : Word) (GuestAddrs.secf_n_be : Word)
+    (cr := secfReduceOnceNCr) (by decide) (by decide)
+    (by unfold secfReduceOnceNCr; code_mem) (by unfold secfReduceOnceNCr; code_mem)
+  rw [show (GuestAddrs.secf_reduce_once_n + 28 : Word) + 8 =
+      (GuestAddrs.secf_reduce_once_n + 36 : Word) from by decide] at hlaP
+  have hlaCmp := la_materialize_within .x12 v12
+    (GuestAddrs.secf_reduce_once_n + 36 : Word) (GuestAddrs.secf_cmp : Word)
+    (cr := secfReduceOnceNCr) (by decide) (by decide)
+    (by unfold secfReduceOnceNCr; code_mem) (by unfold secfReduceOnceNCr; code_mem)
+  rw [show (GuestAddrs.secf_reduce_once_n + 36 : Word) + 8 =
+      (GuestAddrs.secf_reduce_once_n + 44 : Word) from by decide] at hlaCmp
+  have hmv8F := cpsTripleWithin_frameR
+    (((.x9 : Reg) ↦ᵣ v9) ** ((.x11 : Reg) ↦ᵣ dst) **
+      ((.x12 : Reg) ↦ᵣ v12) ** ((.x1 : Reg) ↦ᵣ ret))
+    (by pcf) hmv8
+  have hmv9F := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ src) ** ((.x10 : Reg) ↦ᵣ src) **
+      ((.x12 : Reg) ↦ᵣ v12) ** ((.x1 : Reg) ↦ᵣ ret))
+    (by pcf) hmv9
+  have hmv10F := cpsTripleWithin_frameR
+    (((.x9 : Reg) ↦ᵣ dst) ** ((.x11 : Reg) ↦ᵣ dst) **
+      ((.x12 : Reg) ↦ᵣ v12) ** ((.x1 : Reg) ↦ᵣ ret))
+    (by pcf) hmv10
+  have hlaPF := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+      ((.x10 : Reg) ↦ᵣ src) ** ((.x12 : Reg) ↦ᵣ v12) **
+      ((.x1 : Reg) ↦ᵣ ret))
+    (by pcf) hlaP
+  have hlaCmpF := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+      ((.x10 : Reg) ↦ᵣ src) **
+      ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+      ((.x1 : Reg) ↦ᵣ ret))
+    (by pcf) hlaCmp
+  have c1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hmv8F hmv9F
+  have c2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c1 hmv10F
+  have c3 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c2 hlaPF
+  have c4 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c3 hlaCmpF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) c4
+
+private theorem u256LtBeInCr_spec (aPtr bPtr outPtr ret : Word)
+    (as bs : List (BitVec 8))
+    (hlenA : as.length = 32) (hlenB : bs.length = 32)
+    (halignA : aPtr.toNat % 8 = 0) (halignB : bPtr.toNat % 8 = 0)
+    (hovA : aPtr.toNat + 32 < 2 ^ 64) (hovB : bPtr.toNat + 32 < 2 ^ 64)
+    (hvalidA : ∀ k, k < 32 → isValidByteAccess (aPtr + BitVec.ofNat 64 k) = true)
+    (hvalidB : ∀ k, k < 32 → isValidByteAccess (bPtr + BitVec.ofNat 64 k) = true)
+    (halignRet : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin 295 (GuestAddrs.u256_lt_be : Word) ret secfReduceOnceNCr
+      (((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+       ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+       bytesRegion aPtr as ** bytesRegion bPtr bs ** memOwn outPtr)
+      (((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+       ((.x12 : Reg) ↦ᵣ outPtr) ** ((.x1 : Reg) ↦ᵣ ret) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+       bytesRegion aPtr as ** bytesRegion bPtr bs **
+       (outPtr ↦ₘ (if beBytesToNat as < beBytesToNat bs then (1 : Word) else (0 : Word)))) := by
+  have h := U256LtBeSAsm.u256LtBe_spec aPtr bPtr outPtr ret as bs hlenA hlenB
+    halignA halignB hovA hovB hvalidA hvalidB halignRet
+  exact liftCode (cr' := secfReduceOnceNCr) h (by unfold secfReduceOnceNCr; code_mem)
+
+private theorem secp256k1PByte_valid (k : Nat) (hk : k < 32) :
+    isValidByteAccess ((GuestAddrs.secf_n_be : Word) + BitVec.ofNat 64 k) = true := by
+  interval_cases k <;> decide
+
+private theorem ltSetupCall_spec (src dst ret v8 v9 v12 : Word)
+    (xs : List (BitVec 8))
+    (hlenX : xs.length = 32)
+    (halignX : src.toNat % 8 = 0)
+    (hovX : src.toNat + 32 < 2 ^ 64)
+    (hvalidX : ∀ k, k < 32 → isValidByteAccess (src + BitVec.ofNat 64 k) = true) :
+    cpsTripleWithin 303 (GuestAddrs.secf_reduce_once_n + 16 : Word)
+      (GuestAddrs.secf_reduce_once_n + 48 : Word) secfReduceOnceNCr
+      (((.x8 : Reg) ↦ᵣ v8) ** ((.x9 : Reg) ↦ᵣ v9) **
+        ((.x10 : Reg) ↦ᵣ src) ** ((.x11 : Reg) ↦ᵣ dst) **
+        ((.x12 : Reg) ↦ᵣ v12) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs **
+        globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+        memOwn (GuestAddrs.secf_cmp : Word))
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+        ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        ((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 48 : Word)) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs **
+        globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+        ((GuestAddrs.secf_cmp : Word) ↦ₘ
+          (if beBytesToNat xs < beBytesToNat secfNBytes then (1 : Word) else (0 : Word)))) := by
+  unfold globalConst
+  have hsetup := ltSetup_spec src dst ret v8 v9 v12
+  have hsetupF := cpsTripleWithin_frameR
+    (((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+      bytesRegion src xs ** bytesRegion (GuestAddrs.secf_n_be : Word) secfNBytes **
+      memOwn (GuestAddrs.secf_cmp : Word))
+    (by pcf) hsetup
+  have hcallee0 := u256LtBeInCr_spec src (GuestAddrs.secf_n_be : Word)
+    (GuestAddrs.secf_cmp : Word) (GuestAddrs.secf_reduce_once_n + 48 : Word)
+    xs secfNBytes hlenX (by decide) halignX (by decide) hovX (by decide)
+    hvalidX secp256k1PByte_valid (by decide)
+  have hcallee : cpsTripleWithin 295 (GuestAddrs.u256_lt_be : Word)
+      (GuestAddrs.secf_reduce_once_n + 48 : Word) secfReduceOnceNCr
+      (((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 48 : Word)) **
+        (((.x10 : Reg) ↦ᵣ src) **
+        ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+        ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs ** bytesRegion (GuestAddrs.secf_n_be : Word) secfNBytes **
+        memOwn (GuestAddrs.secf_cmp : Word)))
+      (((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 48 : Word)) **
+        (((.x10 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+        ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs ** bytesRegion (GuestAddrs.secf_n_be : Word) secfNBytes **
+        ((GuestAddrs.secf_cmp : Word) ↦ₘ
+          (if beBytesToNat xs < beBytesToNat secfNBytes then (1 : Word) else (0 : Word))))) := by
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by xperm_hyp hq) hcallee0
+  have hcall := callWithin_spec (cr := secfReduceOnceNCr)
+    (P := (((.x10 : Reg) ↦ᵣ src) **
+        ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+        ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs ** bytesRegion (GuestAddrs.secf_n_be : Word) secfNBytes **
+        memOwn (GuestAddrs.secf_cmp : Word)))
+    (Q := (((.x10 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+        ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs ** bytesRegion (GuestAddrs.secf_n_be : Word) secfNBytes **
+        ((GuestAddrs.secf_cmp : Word) ↦ₘ
+          (if beBytesToNat xs < beBytesToNat secfNBytes then (1 : Word) else (0 : Word)))) )
+    (GuestAddrs.secf_reduce_once_n + 44 : Word) (GuestAddrs.u256_lt_be : Word) ret
+    (jalOff GuestAddrs.u256_lt_be (GuestAddrs.secf_reduce_once_n + 44)) 295
+    (by decide) (by unfold secfReduceOnceNCr; code_mem) (by pcf) hcallee
+  rw [show (GuestAddrs.secf_reduce_once_n + 44 : Word) + 4 =
+      (GuestAddrs.secf_reduce_once_n + 48 : Word) from by decide] at hcall
+  have hcallF := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst)) (by pcf) hcall
+  have hc := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hsetupF hcallF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq)
+    (cpsTripleWithin_mono_nSteps (by omega) hc)
+
+private theorem cmpLoad_spec (flag src dst pPtr ret : Word)
+    (xs : List (BitVec 8)) :
+    cpsTripleWithin 3 (GuestAddrs.secf_reduce_once_n + 48 : Word)
+      (GuestAddrs.secf_reduce_once_n + 60 : Word) secfReduceOnceNCr
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ pPtr) **
+        ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs ** globalConst pPtr secfNBytes **
+        ((GuestAddrs.secf_cmp : Word) ↦ₘ flag))
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ pPtr) **
+        ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x5 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        ((.x6 : Reg) ↦ᵣ flag) ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs ** globalConst pPtr secfNBytes **
+        ((GuestAddrs.secf_cmp : Word) ↦ₘ flag)) := by
+  unfold globalConst
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => hq)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x5)
+      (P := (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ pPtr) **
+        ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs ** bytesRegion pPtr secfNBytes **
+        ((GuestAddrs.secf_cmp : Word) ↦ₘ flag)) )
+      (fun v5 => ?_))
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => hq)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x6)
+      (P := (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ pPtr) **
+        ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x5 : Reg) ↦ᵣ v5) ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs ** bytesRegion pPtr secfNBytes **
+        ((GuestAddrs.secf_cmp : Word) ↦ₘ flag)) )
+      (fun v6 => ?_))
+  have hla := la_materialize_within .x5 v5
+    (GuestAddrs.secf_reduce_once_n + 48 : Word) (GuestAddrs.secf_cmp : Word)
+    (cr := secfReduceOnceNCr) (by decide) (by decide)
+    (by unfold secfReduceOnceNCr; code_mem) (by unfold secfReduceOnceNCr; code_mem)
+  rw [show (GuestAddrs.secf_reduce_once_n + 48 : Word) + 8 =
+      (GuestAddrs.secf_reduce_once_n + 56 : Word) from by decide] at hla
+  have hld := liftCode (cr' := secfReduceOnceNCr)
+    (ld_spec_within .x6 .x5 (GuestAddrs.secf_cmp : Word) v6 flag (0 : BitVec 12)
+      (GuestAddrs.secf_reduce_once_n + 56 : Word) (by decide))
+    (by unfold secfReduceOnceNCr; code_mem)
+  rw [show (GuestAddrs.secf_cmp : Word) + signExtend12 (0 : BitVec 12) =
+      (GuestAddrs.secf_cmp : Word) from by decide,
+    show (GuestAddrs.secf_reduce_once_n + 56 : Word) + 4 =
+      (GuestAddrs.secf_reduce_once_n + 60 : Word) from by decide] at hld
+  have hlaF := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+      ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ pPtr) **
+      ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x6 : Reg) ↦ᵣ v6) ** regOwn .x7 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+      bytesRegion src xs ** bytesRegion pPtr secfNBytes **
+      ((GuestAddrs.secf_cmp : Word) ↦ₘ flag))
+    (by pcf) hla
+  have hldF := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+      ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ pPtr) **
+      ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+      bytesRegion src xs ** bytesRegion pPtr secfNBytes)
+    (by pcf) hld
+  have hc := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hlaF hldF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hc
+
+private theorem ltSetupCallLoad_spec (src dst ret v8 v9 v12 : Word)
+    (xs : List (BitVec 8))
+    (hlenX : xs.length = 32)
+    (halignX : src.toNat % 8 = 0)
+    (hovX : src.toNat + 32 < 2 ^ 64)
+    (hvalidX : ∀ k, k < 32 → isValidByteAccess (src + BitVec.ofNat 64 k) = true) :
+    cpsTripleWithin 306 (GuestAddrs.secf_reduce_once_n + 16 : Word)
+      (GuestAddrs.secf_reduce_once_n + 60 : Word) secfReduceOnceNCr
+      (((.x8 : Reg) ↦ᵣ v8) ** ((.x9 : Reg) ↦ᵣ v9) **
+        ((.x10 : Reg) ↦ᵣ src) ** ((.x11 : Reg) ↦ᵣ dst) **
+        ((.x12 : Reg) ↦ᵣ v12) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs **
+        globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+        memOwn (GuestAddrs.secf_cmp : Word))
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+        ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        ((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 48 : Word)) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x5 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        ((.x6 : Reg) ↦ᵣ
+          (if beBytesToNat xs < beBytesToNat secfNBytes then (1 : Word) else (0 : Word))) **
+        regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs **
+        globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+        ((GuestAddrs.secf_cmp : Word) ↦ₘ
+          (if beBytesToNat xs < beBytesToNat secfNBytes then (1 : Word) else (0 : Word)))) := by
+  have hpre := ltSetupCall_spec src dst ret v8 v9 v12 xs hlenX halignX hovX hvalidX
+  have hload := cmpLoad_spec
+    (if beBytesToNat xs < beBytesToNat secfNBytes then (1 : Word) else (0 : Word))
+    src dst (GuestAddrs.secf_n_be : Word)
+    (GuestAddrs.secf_reduce_once_n + 48 : Word) xs
+  have hc := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hpre hload
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq)
+    (cpsTripleWithin_mono_nSteps (by omega) hc)
+
+private theorem cmpBranch_spec (flag src dst pPtr ret : Word)
+    (xs : List (BitVec 8)) :
+    cpsBranchWithin 1 (GuestAddrs.secf_reduce_once_n + 60 : Word) secfReduceOnceNCr
+      (((.x6 : Reg) ↦ᵣ flag) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ pPtr) **
+        ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x5 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs ** globalConst pPtr secfNBytes **
+        ((GuestAddrs.secf_cmp : Word) ↦ₘ flag))
+      (GuestAddrs.secf_reduce_once_n + 92 : Word)
+      (((.x6 : Reg) ↦ᵣ flag) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ⌜flag ≠ 0⌝ **
+        ((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ pPtr) **
+        ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x5 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs ** globalConst pPtr secfNBytes **
+        ((GuestAddrs.secf_cmp : Word) ↦ₘ flag))
+      (GuestAddrs.secf_reduce_once_n + 64 : Word)
+      (((.x6 : Reg) ↦ᵣ flag) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ⌜flag = 0⌝ **
+        ((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ pPtr) **
+        ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x5 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs ** globalConst pPtr secfNBytes **
+        ((GuestAddrs.secf_cmp : Word) ↦ₘ flag)) := by
+  unfold globalConst
+  have hbr := cpsBranchWithin_frameR
+    (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+      ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ pPtr) **
+      ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+      ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x5 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+      regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+      bytesRegion src xs ** bytesRegion pPtr secfNBytes **
+      ((GuestAddrs.secf_cmp : Word) ↦ₘ flag))
+    (by pcf)
+    (cpsBranchWithin_extend_code (cr' := secfReduceOnceNCr)
+      (h := bne_spec_gen_within .x6 .x0 (32 : BitVec 13) flag (0 : Word)
+        (GuestAddrs.secf_reduce_once_n + 60 : Word))
+      (hmono := by unfold secfReduceOnceNCr; code_mem))
+  rw [show (GuestAddrs.secf_reduce_once_n + 60 : Word) + signExtend13 (32 : BitVec 13) =
+        (GuestAddrs.secf_reduce_once_n + 92 : Word) from by
+        rw [show signExtend13 (32 : BitVec 13) = (32 : Word) from by decide]
+        decide,
+      show (GuestAddrs.secf_reduce_once_n + 60 : Word) + 4 =
+        (GuestAddrs.secf_reduce_once_n + 64 : Word) from by decide] at hbr
+  exact cpsBranchWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq)
+    (fun _ hq => by xperm_hyp hq) hbr
+
+theorem ltSetupCallLoadBranch_spec (src dst ret v8 v9 v12 : Word)
+    (xs : List (BitVec 8))
+    (hlenX : xs.length = 32)
+    (halignX : src.toNat % 8 = 0)
+    (hovX : src.toNat + 32 < 2 ^ 64)
+    (hvalidX : ∀ k, k < 32 → isValidByteAccess (src + BitVec.ofNat 64 k) = true) :
+    cpsBranchWithin 307 (GuestAddrs.secf_reduce_once_n + 16 : Word) secfReduceOnceNCr
+      (((.x8 : Reg) ↦ᵣ v8) ** ((.x9 : Reg) ↦ᵣ v9) **
+        ((.x10 : Reg) ↦ᵣ src) ** ((.x11 : Reg) ↦ᵣ dst) **
+        ((.x12 : Reg) ↦ᵣ v12) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs **
+        globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+        memOwn (GuestAddrs.secf_cmp : Word))
+      (GuestAddrs.secf_reduce_once_n + 92 : Word)
+      (((.x6 : Reg) ↦ᵣ
+          (if beBytesToNat xs < beBytesToNat secfNBytes then (1 : Word) else (0 : Word))) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ⌜(if beBytesToNat xs < beBytesToNat secfNBytes then (1 : Word) else (0 : Word)) ≠ 0⌝ **
+        ((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+        ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        ((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 48 : Word)) **
+        ((.x5 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs **
+        globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+        ((GuestAddrs.secf_cmp : Word) ↦ₘ
+          (if beBytesToNat xs < beBytesToNat secfNBytes then (1 : Word) else (0 : Word))))
+      (GuestAddrs.secf_reduce_once_n + 64 : Word)
+      (((.x6 : Reg) ↦ᵣ
+          (if beBytesToNat xs < beBytesToNat secfNBytes then (1 : Word) else (0 : Word))) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ⌜(if beBytesToNat xs < beBytesToNat secfNBytes then (1 : Word) else (0 : Word)) = 0⌝ **
+        ((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+        ((.x12 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        ((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 48 : Word)) **
+        ((.x5 : Reg) ↦ᵣ (GuestAddrs.secf_cmp : Word)) **
+        regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        bytesRegion src xs **
+        globalConst (GuestAddrs.secf_n_be : Word) secfNBytes **
+        ((GuestAddrs.secf_cmp : Word) ↦ₘ
+          (if beBytesToNat xs < beBytesToNat secfNBytes then (1 : Word) else (0 : Word)))) := by
+  let flag : Word := if beBytesToNat xs < beBytesToNat secfNBytes then (1 : Word) else (0 : Word)
+  have hpre := ltSetupCallLoad_spec src dst ret v8 v9 v12 xs hlenX halignX hovX hvalidX
+  have hbr := cmpBranch_spec flag src dst (GuestAddrs.secf_n_be : Word)
+    (GuestAddrs.secf_reduce_once_n + 48 : Word) xs
+  exact cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr (fun _ hp => by xperm_hyp hp) hpre hbr
+
+/-- Registers owned across the `secf_copy32` call, excluding `a0`/`a1`. -/
+def copyScratch : List Reg :=
+  [.x5, .x6, .x7, .x28, .x29, .x30, .x31, .x12, .x13, .x14, .x15, .x16, .x17]
+
+/-- Copy scratch registers other than `t0`, which the copy leaf uses directly. -/
+def copyRest : List Reg :=
+  [.x6, .x7, .x28, .x29, .x30, .x31, .x12, .x13, .x14, .x15, .x16, .x17]
+
+/-- Registers owned across the `u256_sub_be` call, excluding `a0`/`a1`/`a2`. -/
+def subScratch : List Reg :=
+  [.x5, .x6, .x7, .x28, .x29, .x30, .x31, .x13, .x14, .x15, .x16, .x17]
+
+/-- Exposed registers preserved after the branch tail, excluding return register `a0`. -/
+def retScratch : List Reg :=
+  [.x5, .x6, .x7, .x28, .x29, .x30, .x31, .x11, .x12, .x13, .x14, .x15, .x16, .x17]
+
+private theorem x10_notin_retScratch : (.x10 : Reg) ∉ retScratch := by decide
+
+private theorem copyScratch_eq_x5_rest :
+    regOwns copyScratch = (regOwn .x5 ** regOwns copyRest) := by
+  simp only [copyScratch, copyRest, regOwns_cons, regOwns_nil]
+
+private theorem x11_copyScratch_to_retScratch (dst : Word) :
+    ∀ h, (((.x11 : Reg) ↦ᵣ dst) ** regOwns copyScratch) h → regOwns retScratch h := by
+  intro h hp
+  rw [copyScratch_eq_x5_rest] at hp
+  have hp1 : (regOwn .x11 ** (regOwn .x5 ** regOwns copyRest)) h := by
+    exact sepConj_mono_left (regIs_to_regOwn .x11 dst) h hp
+  simp only [retScratch, copyRest, regOwns_cons, regOwns_nil, sepConj_emp_right'] at hp1 ⊢
+  xperm_hyp hp1
+
+/-- High exposed scratch registers not materialized by the compare prefix. -/
+def highScratch : List Reg := [.x31, .x13, .x14, .x15, .x16, .x17]
+
+theorem branchScratch_to_subScratch (v5 v6 : Word) :
+    ∀ h, (((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) **
+      regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwns highScratch) h →
+      regOwns subScratch h := by
+  intro h hp
+  have hp1 : (regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28 **
+      regOwn .x29 ** regOwn .x30 ** regOwns highScratch) h := by
+    exact sepConj_mono
+      (regIs_to_regOwn .x5 v5)
+      (sepConj_mono (regIs_to_regOwn .x6 v6) (fun _ hh => hh)) h hp
+  simp only [subScratch, highScratch, regOwns_cons, regOwns_nil, sepConj_emp_right'] at hp1 ⊢
+  xperm_hyp hp1
+
+theorem branchScratch_to_copyScratch (v5 v6 v12 : Word) :
+    ∀ h, (((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) **
+      ((.x12 : Reg) ↦ᵣ v12) ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+      regOwn .x30 ** regOwns highScratch) h → regOwns copyScratch h := by
+  intro h hp
+  have hp1 : (regOwn .x5 ** regOwn .x6 ** regOwn .x12 ** regOwn .x7 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwns highScratch) h := by
+    exact sepConj_mono
+      (regIs_to_regOwn .x5 v5)
+      (sepConj_mono (regIs_to_regOwn .x6 v6)
+        (sepConj_mono (regIs_to_regOwn .x12 v12) (fun _ hh => hh))) h hp
+  simp only [copyScratch, highScratch, regOwns_cons, regOwns_nil, sepConj_emp_right'] at hp1 ⊢
+  xperm_hyp hp1
+
+private theorem x10_notin_copyScratch : (.x10 : Reg) ∉ copyScratch := by decide
+private theorem x11_notin_copyScratch : (.x11 : Reg) ∉ copyScratch := by decide
+private theorem x10_notin_subScratch : (.x10 : Reg) ∉ subScratch := by decide
+private theorem x11_notin_subScratch : (.x11 : Reg) ∉ subScratch := by decide
+private theorem x12_notin_subScratch : (.x12 : Reg) ∉ subScratch := by decide
+
+/-- Split the exposed register file around return register `a0`. -/
+private theorem exposedRegs_split_ret (vf : Reg → Word) :
+    regAtomsOf vf exposedRegs = ((.x10 ↦ᵣ vf .x10) ** regAtomsOf vf retScratch) := by
+  show regAtomsOf vf
+      [.x5, .x6, .x7, .x28, .x29, .x30, .x31,
+       .x10, .x11, .x12, .x13, .x14, .x15, .x16, .x17] = _
+  simp only [retScratch, regAtomsOf_cons, regAtomsOf_nil]
+  xperm
+
+/-- Split the exposed register file around `secf_copy32`'s argument registers. -/
+private theorem exposedRegs_split_copy (vf : Reg → Word) :
+    regAtomsOf vf exposedRegs
+      = ((.x10 ↦ᵣ vf .x10) ** (.x11 ↦ᵣ vf .x11) ** regAtomsOf vf copyScratch) := by
+  show regAtomsOf vf
+      [.x5, .x6, .x7, .x28, .x29, .x30, .x31,
+       .x10, .x11, .x12, .x13, .x14, .x15, .x16, .x17] = _
+  simp only [copyScratch, regAtomsOf_cons, regAtomsOf_nil]
+  xperm
+
+/-- Split the exposed register file around `u256_sub_be`'s argument registers. -/
+private theorem exposedRegs_split_sub (vf : Reg → Word) :
+    regAtomsOf vf exposedRegs
+      = ((.x10 ↦ᵣ vf .x10) ** (.x11 ↦ᵣ vf .x11) **
+          (.x12 ↦ᵣ vf .x12) ** regAtomsOf vf subScratch) := by
+  show regAtomsOf vf
+      [.x5, .x6, .x7, .x28, .x29, .x30, .x31,
+       .x10, .x11, .x12, .x13, .x14, .x15, .x16, .x17] = _
+  simp only [subScratch, regAtomsOf_cons, regAtomsOf_nil]
+  xperm
+
+private theorem secfCopy32Direct_spec (ret src dst : Word)
+    (srcBytes orig : List (BitVec 8))
+    (hlenSrc : srcBytes.length = 32) (hlenOrig : orig.length = 32)
+    (halign : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin 9 (GuestAddrs.secf_copy32 : Word) ret secfReduceOnceNCr
+      (((.x1 : Reg) ↦ᵣ ret) ** ((.x10 : Reg) ↦ᵣ src) ** ((.x11 : Reg) ↦ᵣ dst) **
+        regOwn .x5 ** bytesRegion src srcBytes ** bytesRegion dst orig)
+      (((.x1 : Reg) ↦ᵣ ret) ** ((.x10 : Reg) ↦ᵣ src) ** ((.x11 : Reg) ↦ᵣ dst) **
+        regOwn .x5 ** bytesRegion src srcBytes ** bytesRegion dst srcBytes) := by
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => hq)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x5)
+      (P := ((.x1 : Reg) ↦ᵣ ret) ** ((.x10 : Reg) ↦ᵣ src) ** ((.x11 : Reg) ↦ᵣ dst) **
+        bytesRegion src srcBytes ** bytesRegion dst orig)
+      (fun tv => ?_))
+  have hcopy0 := selectedDwordCopy_spec .x10 .x11 .x5 (by decide)
+    src dst tv srcBytes orig 0 4 (by omega) (by omega) (by decide)
+    (GuestAddrs.secf_copy32 : Word)
+  rw [show (GuestAddrs.secf_copy32 : Word) + BitVec.ofNat 64 (4 * (2 * 4)) =
+      (GuestAddrs.secf_copy32 + 32 : Word) from by decide,
+    copyDwords_covers srcBytes orig 4 (by omega) (by omega)] at hcopy0
+  have hcopy := liftCode (cr' := secfReduceOnceNCr) hcopy0
+    (by unfold secfReduceOnceNCr; code_mem)
+  have hcopyF := cpsTripleWithin_frameR (((.x1 : Reg) ↦ᵣ ret)) (by pcf) hcopy
+  have hret0 := EvmAsm.Evm64.ret_spec_within' (GuestAddrs.secf_copy32 + 32 : Word) ret
+  rw [halign] at hret0
+  have hret := liftCode (cr' := secfReduceOnceNCr) hret0
+    (by unfold secfReduceOnceNCr; code_mem)
+  have hretF := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ src) ** ((.x11 : Reg) ↦ᵣ dst) ** regOwn .x5 **
+      bytesRegion src srcBytes ** bytesRegion dst srcBytes)
+    (by pcf) hret
+  have hc := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hcopyF hretF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hc
+
+private theorem copySetup_spec (src dst ret old10 old11 : Word) :
+    cpsTripleWithin 2 (GuestAddrs.secf_reduce_once_n + 92 : Word)
+      (GuestAddrs.secf_reduce_once_n + 100 : Word) secfReduceOnceNCr
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ old10) ** ((.x11 : Reg) ↦ᵣ old11) **
+        ((.x1 : Reg) ↦ᵣ ret))
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ src) ** ((.x11 : Reg) ↦ᵣ dst) **
+        ((.x1 : Reg) ↦ᵣ ret)) := by
+  have hmv10 := liftCode (cr' := secfReduceOnceNCr)
+    (mv_spec_gen_within .x10 .x8 src old10 (GuestAddrs.secf_reduce_once_n + 92 : Word)
+      (by decide))
+    (by unfold secfReduceOnceNCr; code_mem)
+  rw [show (GuestAddrs.secf_reduce_once_n + 92 : Word) + 4 =
+      (GuestAddrs.secf_reduce_once_n + 96 : Word) from by decide] at hmv10
+  have hmv11 := liftCode (cr' := secfReduceOnceNCr)
+    (mv_spec_gen_within .x11 .x9 dst old11 (GuestAddrs.secf_reduce_once_n + 96 : Word)
+      (by decide))
+    (by unfold secfReduceOnceNCr; code_mem)
+  rw [show (GuestAddrs.secf_reduce_once_n + 96 : Word) + 4 =
+      (GuestAddrs.secf_reduce_once_n + 100 : Word) from by decide] at hmv11
+  have hmv10F := cpsTripleWithin_frameR
+    (((.x9 : Reg) ↦ᵣ dst) ** ((.x11 : Reg) ↦ᵣ old11) ** ((.x1 : Reg) ↦ᵣ ret))
+    (by pcf) hmv10
+  have hmv11F := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ src) ** ((.x10 : Reg) ↦ᵣ src) ** ((.x1 : Reg) ↦ᵣ ret))
+    (by pcf) hmv11
+  have hc := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hmv10F hmv11F
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hc
+
+private theorem copySetupCall_spec (src dst ret old10 old11 : Word)
+    (xs orig : List (BitVec 8))
+    (hlenX : xs.length = 32) (hlenOrig : orig.length = 32)
+    (halignRet : ((GuestAddrs.secf_reduce_once_n + 104 : Word) &&& ~~~(1 : Word)) =
+      (GuestAddrs.secf_reduce_once_n + 104 : Word)) :
+    cpsTripleWithin (2 + (1 + 9)) (GuestAddrs.secf_reduce_once_n + 92 : Word)
+      (GuestAddrs.secf_reduce_once_n + 104 : Word) secfReduceOnceNCr
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ old10) ** ((.x11 : Reg) ↦ᵣ old11) **
+        ((.x1 : Reg) ↦ᵣ ret) ** regOwn .x5 ** bytesRegion src xs ** bytesRegion dst orig)
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 104 : Word)) **
+        ((.x10 : Reg) ↦ᵣ src) ** ((.x11 : Reg) ↦ᵣ dst) **
+        regOwn .x5 ** bytesRegion src xs ** bytesRegion dst xs) := by
+  have hsetup := copySetup_spec src dst ret old10 old11
+  have hsetupF := cpsTripleWithin_frameR
+    (regOwn .x5 ** bytesRegion src xs ** bytesRegion dst orig) (by pcf) hsetup
+  have hcallee0 := secfCopy32Direct_spec (GuestAddrs.secf_reduce_once_n + 104 : Word)
+    src dst xs orig hlenX hlenOrig halignRet
+  have hcallee : cpsTripleWithin 9 (GuestAddrs.secf_copy32 : Word)
+      (GuestAddrs.secf_reduce_once_n + 104 : Word) secfReduceOnceNCr
+      (((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 104 : Word)) **
+        (((.x10 : Reg) ↦ᵣ src) ** ((.x11 : Reg) ↦ᵣ dst) **
+          regOwn .x5 ** bytesRegion src xs ** bytesRegion dst orig))
+      (((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 104 : Word)) **
+        (((.x10 : Reg) ↦ᵣ src) ** ((.x11 : Reg) ↦ᵣ dst) **
+          regOwn .x5 ** bytesRegion src xs ** bytesRegion dst xs)) := by
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by xperm_hyp hq) hcallee0
+  have hcall := callWithin_spec (cr := secfReduceOnceNCr)
+    (P := (((.x10 : Reg) ↦ᵣ src) ** ((.x11 : Reg) ↦ᵣ dst) **
+      regOwn .x5 ** bytesRegion src xs ** bytesRegion dst orig))
+    (Q := (((.x10 : Reg) ↦ᵣ src) ** ((.x11 : Reg) ↦ᵣ dst) **
+      regOwn .x5 ** bytesRegion src xs ** bytesRegion dst xs))
+    (GuestAddrs.secf_reduce_once_n + 100 : Word) (GuestAddrs.secf_copy32 : Word) ret
+    (jalOff GuestAddrs.secf_copy32 (GuestAddrs.secf_reduce_once_n + 100)) 9
+    (by decide) (by unfold secfReduceOnceNCr; code_mem) (by pcf) hcallee
+  rw [show (GuestAddrs.secf_reduce_once_n + 100 : Word) + 4 =
+      (GuestAddrs.secf_reduce_once_n + 104 : Word) from by decide] at hcall
+  have hcallF := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst)) (by pcf) hcall
+  have hc := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hsetupF hcallF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hc
+
+private theorem copySetupCallFull_spec (src dst ret old10 old11 : Word)
+    (xs orig : List (BitVec 8))
+    (hlenX : xs.length = 32) (hlenOrig : orig.length = 32) :
+    cpsTripleWithin (2 + (1 + 9)) (GuestAddrs.secf_reduce_once_n + 92 : Word)
+      (GuestAddrs.secf_reduce_once_n + 104 : Word) secfReduceOnceNCr
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ old10) ** ((.x11 : Reg) ↦ᵣ old11) **
+        ((.x1 : Reg) ↦ᵣ ret) ** regOwns copyScratch **
+        bytesRegion src xs ** bytesRegion dst orig)
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 104 : Word)) **
+        ((.x10 : Reg) ↦ᵣ src) ** ((.x11 : Reg) ↦ᵣ dst) **
+        regOwns copyScratch ** bytesRegion src xs ** bytesRegion dst xs) := by
+  have hbase := copySetupCall_spec src dst ret old10 old11 xs orig hlenX hlenOrig (by decide)
+  have hbaseF := cpsTripleWithin_frameR (regOwns copyRest) (by pcf) hbase
+  exact cpsTripleWithin_weaken (fun _ hp => by
+      rw [copyScratch_eq_x5_rest] at hp
+      xperm_hyp hp)
+    (fun _ hq => by
+      rw [copyScratch_eq_x5_rest]
+      xperm_hyp hq) hbaseF
+
+private theorem copyRetTail_spec (P : Assertion) (hP : P.pcFree) (src dst : Word) :
+    cpsTripleWithin 1 (GuestAddrs.secf_reduce_once_n + 104 : Word)
+      (GuestAddrs.secf_reduce_once_n + 108 : Word) secfReduceOnceNCr
+      ((((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 104 : Word)) **
+        ((.x10 : Reg) ↦ᵣ src) ** ((.x11 : Reg) ↦ᵣ dst) ** regOwns copyScratch) ** P)
+      ((((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 104 : Word)) **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) ** regOwns retScratch) ** P) := by
+  have hli := liftCode (cr' := secfReduceOnceNCr)
+    (li_spec_gen_within .x10 src (0 : Word) (GuestAddrs.secf_reduce_once_n + 104 : Word)
+      (by decide))
+    (by unfold secfReduceOnceNCr; code_mem)
+  rw [show (GuestAddrs.secf_reduce_once_n + 104 : Word) + 4 =
+      (GuestAddrs.secf_reduce_once_n + 108 : Word) from by decide] at hli
+  have hliF := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 104 : Word)) **
+      ((.x11 : Reg) ↦ᵣ dst) ** regOwns copyScratch ** P)
+    (by
+      apply pcFree_sepConj
+      · exact pcFree_regIs
+      · apply pcFree_sepConj
+        · exact pcFree_regIs
+        · exact pcFree_sepConj (by pcf) hP) hli
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun h hq => by
+      have hq1 : ((((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 104 : Word)) **
+          ((.x10 : Reg) ↦ᵣ (0 : Word)) **
+          (((.x11 : Reg) ↦ᵣ dst) ** regOwns copyScratch)) ** P) h := by
+        xperm_hyp hq
+      exact sepConj_mono_left
+        (sepConj_mono_right (sepConj_mono_right (x11_copyScratch_to_retScratch dst))) h hq1) hliF
+
+theorem copyArm_spec (src dst ret old10 old11 : Word)
+    (xs orig : List (BitVec 8))
+    (hlenX : xs.length = 32) (hlenOrig : orig.length = 32) :
+    cpsTripleWithin ((2 + (1 + 9)) + 1) (GuestAddrs.secf_reduce_once_n + 92 : Word)
+      (GuestAddrs.secf_reduce_once_n + 108 : Word) secfReduceOnceNCr
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ old10) ** ((.x11 : Reg) ↦ᵣ old11) **
+        ((.x1 : Reg) ↦ᵣ ret) ** regOwns copyScratch **
+        bytesRegion src xs ** bytesRegion dst orig)
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 104 : Word)) **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) ** regOwns retScratch **
+        bytesRegion src xs ** bytesRegion dst xs) := by
+  have hcall := copySetupCallFull_spec src dst ret old10 old11 xs orig hlenX hlenOrig
+  have htail := copyRetTail_spec
+    (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+      bytesRegion src xs ** bytesRegion dst xs) (by pcf) src dst
+  have hc := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hcall htail
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hc
+
+private theorem secfCopy32FlatAsrt_spec (ret src dst : Word)
+    (srcBytes orig : List (BitVec 8)) (rf : RegFile)
+    (hwf : (Region.mk src srcBytes).wf) (hrww : RwRegion.wf ⟨dst, 32⟩)
+    (hlenOrig : orig.length = 32)
+    (halign : (ret &&& ~~~(1 : Word)) = ret)
+    (hpre : Secp256k1FieldLeavesSAsm.secfCopy32Fn src dst srcBytes orig |>.pre rf orig empAssertion) :
+    cpsTripleWithin ((Secp256k1FieldLeavesSAsm.secfCopy32Fn src dst srcBytes orig).body.steps + 1)
+      (GuestAddrs.secf_copy32 : Word) ret secfReduceOnceNCr
+      (((((.x1 : Reg) ↦ᵣ ret) ** regFileIs rf ** bytesRegion dst orig)
+        ** empAssertion) ** bytesRegion src srcBytes)
+      ((((.x1 : Reg) ↦ᵣ ret) **
+        asrtOf ⟨dst, 32⟩
+          (Secp256k1FieldLeavesSAsm.secfCopy32Fn src dst srcBytes orig |>.post))
+        ** bytesRegion src srcBytes) := by
+  have had := retSpecFlatAmbient
+    (Secp256k1FieldLeavesSAsm.secfCopy32Fn src dst srcBytes orig)
+    (GuestAddrs.secf_copy32 : Word)
+    (Secp256k1FieldLeavesSAsm.secfCopy32Fn_spec src dst srcBytes orig hwf hrww
+      (GuestAddrs.secf_copy32 : Word))
+    (by show 4 * (8 + 1) ≤ 2 ^ 64; decide) ret halign rf orig empAssertion
+    (by exact hlenOrig) (by pcf) hpre
+    (Q := asrtOf ⟨dst, 32⟩
+      (Secp256k1FieldLeavesSAsm.secfCopy32Fn src dst srcBytes orig |>.post))
+    (fun rf' ws' A' hlen hApc hpost hp hh => ⟨rf', ws', A', hlen, hApc, hpost, hh⟩)
+  rw [show (Secp256k1FieldLeavesSAsm.secfCopy32Fn src dst srcBytes orig).programRet
+      (GuestAddrs.secf_copy32 : Word) = secfCopy32_prog from rfl] at had
+  exact liftCode (cr' := secfReduceOnceNCr) had (by unfold secfReduceOnceNCr; code_mem)
+
+private theorem u256SubBeFlat_spec (ret aPtr bPtr outPtr : Word)
+    (aBytes bBytes orig : List (BitVec 8))
+    (hrw : RwRegion.wf ⟨outPtr, 32⟩)
+    (hroA : Region.wf ⟨aPtr, aBytes⟩) (hroB : Region.wf ⟨bPtr, bBytes⟩)
+    (hlenA : aBytes.length = 32) (hlenB : bBytes.length = 32) (hlenOrig : orig.length = 32)
+    (hovA : aPtr.toNat + 32 < 2 ^ 64) (hovB : bPtr.toNat + 32 < 2 ^ 64)
+    (hovOut : outPtr.toNat + 32 < 2 ^ 64)
+    (hdisjA : aPtr.toNat + 32 ≤ outPtr.toNat ∨ outPtr.toNat + 32 ≤ aPtr.toNat)
+    (hdisjB : bPtr.toNat + 32 ≤ outPtr.toNat ∨ outPtr.toNat + 32 ≤ bPtr.toNat)
+    (halign : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin ((U256SubBeSAsm.u256SubBeFn aPtr bPtr outPtr aBytes bBytes orig).body.steps + 1)
+      (GuestAddrs.u256_sub_be : Word) ret secfReduceOnceNCr
+      (((.x1 : Reg) ↦ᵣ ret) ** ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x12 : Reg) ↦ᵣ outPtr) ** regOwns subScratch ** bytesRegion outPtr orig **
+        bytesRegion aPtr aBytes ** bytesRegion bPtr bBytes)
+      (((.x1 : Reg) ↦ᵣ ret) ** regOwns exposedRegs **
+        bytesRegion outPtr (U256SubBeSAsm.u256SubBeBytes aBytes bBytes orig) **
+        bytesRegion aPtr aBytes ** bytesRegion bPtr bBytes) := by
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => hq)
+    (cpsTripleWithin_peel_regOwns subScratch (by decide)
+      (P := ((.x1 : Reg) ↦ᵣ ret) ** ((.x10 : Reg) ↦ᵣ aPtr) **
+        ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ outPtr) **
+        bytesRegion outPtr orig ** bytesRegion aPtr aBytes ** bytesRegion bPtr bBytes)
+      (fun vf => ?_))
+  have hpre : U256SubBeSAsm.u256SubBePre aPtr bPtr outPtr aBytes bBytes orig
+      (fun r => if r = .x10 then aPtr else if r = .x11 then bPtr else if r = .x12 then outPtr else vf r)
+      orig (bytesRegion aPtr aBytes ** bytesRegion bPtr bBytes) := by
+    refine ⟨?_, ?_, ?_, rfl, hlenA, hlenB, hlenOrig, hovA, hovB, hovOut, hdisjA, hdisjB, rfl⟩
+    · show RegFile.get _ .x10 = aPtr
+      rw [RegFile.get, if_neg (by decide : (Reg.x10 : Reg) ≠ .x0)]
+      exact if_pos rfl
+    · show RegFile.get _ .x11 = bPtr
+      rw [RegFile.get, if_neg (by decide : (Reg.x11 : Reg) ≠ .x0)]
+      rw [if_neg (by decide : (Reg.x11 : Reg) ≠ .x10)]
+      exact if_pos rfl
+    · show RegFile.get _ .x12 = outPtr
+      rw [RegFile.get, if_neg (by decide : (Reg.x12 : Reg) ≠ .x0)]
+      rw [if_neg (by decide : (Reg.x12 : Reg) ≠ .x10),
+        if_neg (by decide : (Reg.x12 : Reg) ≠ .x11)]
+      exact if_pos rfl
+  have had := retSpecFlatAmbient
+    (U256SubBeSAsm.u256SubBeFn aPtr bPtr outPtr aBytes bBytes orig)
+    (GuestAddrs.u256_sub_be : Word)
+    (U256SubBeSAsm.u256SubBe_spec aPtr bPtr outPtr aBytes bBytes orig hrw hroA hroB
+      (GuestAddrs.u256_sub_be : Word))
+    (by show 4 * (16 + 1) ≤ 2 ^ 64; decide) ret halign
+    (fun r => if r = .x10 then aPtr else if r = .x11 then bPtr else if r = .x12 then outPtr else vf r)
+    orig (bytesRegion aPtr aBytes ** bytesRegion bPtr bBytes)
+    (by exact hlenOrig) (by pcf) hpre
+    (Q := (regOwns exposedRegs ** bytesRegion outPtr (U256SubBeSAsm.u256SubBeBytes aBytes bBytes orig)) **
+      (bytesRegion aPtr aBytes ** bytesRegion bPtr bBytes))
+    (fun rf' ws' A' hlen hApc hpost hp hh => by
+      obtain ⟨_, _, _, hws, hA⟩ := hpost
+      subst ws'
+      subst A'
+      rw [regFileIs_eq_regAtoms, regAtoms_eq_regAtomsOf _ _ (by decide)] at hh
+      exact sepConj_mono_left
+        (sepConj_mono_left (regAtomsOf_to_regOwns (fun r => rf' r) exposedRegs)) hp hh)
+  rw [show (U256SubBeSAsm.u256SubBeFn aPtr bPtr outPtr aBytes bBytes orig).programRet
+      (GuestAddrs.u256_sub_be : Word) = u256SubBe_prog from rfl] at had
+  have hadC := liftCode (cr' := secfReduceOnceNCr) had (by unfold secfReduceOnceNCr; code_mem)
+  rw [show (U256SubBeSAsm.u256SubBeFn aPtr bPtr outPtr aBytes bBytes orig).region = Region.empty from rfl,
+      show (U256SubBeSAsm.u256SubBeFn aPtr bPtr outPtr aBytes bBytes orig).rw.base = outPtr from rfl,
+      show Region.empty.base = (0 : Word) from rfl,
+      show Region.empty.bytes = ([] : List (BitVec 8)) from rfl,
+      bytesRegion_nil] at hadC
+  rw [regFileIs_eq_regAtoms, regAtoms_eq_regAtomsOf _ _ (by decide),
+    exposedRegs_split_sub,
+    show (if (Reg.x10 : Reg) = .x10 then aPtr else
+        if (Reg.x10 : Reg) = .x11 then bPtr else if (Reg.x10 : Reg) = .x12 then outPtr else vf .x10) = aPtr from if_pos rfl,
+    show (if (Reg.x11 : Reg) = .x10 then aPtr else
+        if (Reg.x11 : Reg) = .x11 then bPtr else if (Reg.x11 : Reg) = .x12 then outPtr else vf .x11) = bPtr from by
+      rw [if_neg (by decide : ¬ ((Reg.x11 : Reg) = .x10))]
+      exact if_pos rfl,
+    show (if (Reg.x12 : Reg) = .x10 then aPtr else
+        if (Reg.x12 : Reg) = .x11 then bPtr else if (Reg.x12 : Reg) = .x12 then outPtr else vf .x12) = outPtr from by
+      rw [if_neg (by decide : ¬ ((Reg.x12 : Reg) = .x10)),
+        if_neg (by decide : ¬ ((Reg.x12 : Reg) = .x11))]
+      exact if_pos rfl,
+    regAtomsOf_congr
+      (fun r => if r = .x10 then aPtr else if r = .x11 then bPtr else if r = .x12 then outPtr else vf r)
+      vf subScratch
+      (fun r hr => by
+        show (if r = .x10 then aPtr else if r = .x11 then bPtr else if r = .x12 then outPtr else vf r) = vf r
+        rw [if_neg (fun (hc : r = .x10) => x10_notin_subScratch (hc ▸ hr)),
+            if_neg (fun (hc : r = .x11) => x11_notin_subScratch (hc ▸ hr)),
+            if_neg (fun (hc : r = .x12) => x12_notin_subScratch (hc ▸ hr))])]
+    at hadC
+  exact cpsTripleWithin_weaken (fun h hp => by
+      have hp1 : ((((.x1 : Reg) ↦ᵣ ret) **
+            (((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+              ((.x12 : Reg) ↦ᵣ outPtr) ** regAtomsOf vf subScratch) **
+            bytesRegion outPtr orig) **
+          bytesRegion aPtr aBytes ** bytesRegion bPtr bBytes) h := by
+        xperm_hyp hp
+      have hp2 : (((((.x1 : Reg) ↦ᵣ ret) **
+              (((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+                ((.x12 : Reg) ↦ᵣ outPtr) ** regAtomsOf vf subScratch) **
+              bytesRegion outPtr orig) **
+            bytesRegion aPtr aBytes ** bytesRegion bPtr bBytes) ** empAssertion) h := by
+        rw [sepConj_emp_right']
+        exact hp1
+      exact hp2)
+    (fun h hq => by
+      rw [sepConj_emp_right'] at hq
+      xperm_hyp hq) hadC
+
+private theorem subSetup_spec (src dst ret old10 old11 old12 : Word) :
+    cpsTripleWithin 4 (GuestAddrs.secf_reduce_once_n + 64 : Word)
+      (GuestAddrs.secf_reduce_once_n + 80 : Word) secfReduceOnceNCr
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ old10) ** ((.x11 : Reg) ↦ᵣ old11) **
+        ((.x12 : Reg) ↦ᵣ old12) ** ((.x1 : Reg) ↦ᵣ ret))
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ src) **
+        ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+        ((.x12 : Reg) ↦ᵣ dst) ** ((.x1 : Reg) ↦ᵣ ret)) := by
+  have hmv10 := liftCode (cr' := secfReduceOnceNCr)
+    (mv_spec_gen_within .x10 .x8 src old10 (GuestAddrs.secf_reduce_once_n + 64 : Word)
+      (by decide))
+    (by unfold secfReduceOnceNCr; code_mem)
+  rw [show (GuestAddrs.secf_reduce_once_n + 64 : Word) + 4 =
+      (GuestAddrs.secf_reduce_once_n + 68 : Word) from by decide] at hmv10
+  have hlaP := la_materialize_within .x11 old11
+    (GuestAddrs.secf_reduce_once_n + 68 : Word) (GuestAddrs.secf_n_be : Word)
+    (cr := secfReduceOnceNCr) (by decide) (by decide)
+    (by unfold secfReduceOnceNCr; code_mem) (by unfold secfReduceOnceNCr; code_mem)
+  rw [show (GuestAddrs.secf_reduce_once_n + 68 : Word) + 8 =
+      (GuestAddrs.secf_reduce_once_n + 76 : Word) from by decide] at hlaP
+  have hmv12 := liftCode (cr' := secfReduceOnceNCr)
+    (mv_spec_gen_within .x12 .x9 dst old12 (GuestAddrs.secf_reduce_once_n + 76 : Word)
+      (by decide))
+    (by unfold secfReduceOnceNCr; code_mem)
+  rw [show (GuestAddrs.secf_reduce_once_n + 76 : Word) + 4 =
+      (GuestAddrs.secf_reduce_once_n + 80 : Word) from by decide] at hmv12
+  have hmv10F := cpsTripleWithin_frameR
+    (((.x9 : Reg) ↦ᵣ dst) ** ((.x11 : Reg) ↦ᵣ old11) **
+      ((.x12 : Reg) ↦ᵣ old12) ** ((.x1 : Reg) ↦ᵣ ret))
+    (by pcf) hmv10
+  have hlaPF := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+      ((.x10 : Reg) ↦ᵣ src) ** ((.x12 : Reg) ↦ᵣ old12) **
+      ((.x1 : Reg) ↦ᵣ ret))
+    (by pcf) hlaP
+  have hmv12F := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ src) ** ((.x10 : Reg) ↦ᵣ src) **
+      ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+      ((.x1 : Reg) ↦ᵣ ret))
+    (by pcf) hmv12
+  have c1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hmv10F hlaPF
+  have c2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c1 hmv12F
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) c2
+
+private theorem subSetupCall_spec (src dst ret old10 old11 old12 : Word)
+    (xs orig : List (BitVec 8))
+    (hroX : Region.wf ⟨src, xs⟩)
+    (hrwDst : RwRegion.wf ⟨dst, 32⟩)
+    (hlenX : xs.length = 32) (hlenOrig : orig.length = 32)
+    (hovX : src.toNat + 32 < 2 ^ 64)
+    (hovDst : dst.toNat + 32 < 2 ^ 64)
+    (hdisjX : src.toNat + 32 ≤ dst.toNat ∨ dst.toNat + 32 ≤ src.toNat)
+    (hdisjP : (GuestAddrs.secf_n_be : Word).toNat + 32 ≤ dst.toNat ∨
+      dst.toNat + 32 ≤ (GuestAddrs.secf_n_be : Word).toNat) :
+    cpsTripleWithin (4 + (1 + ((U256SubBeSAsm.u256SubBeFn src
+        (GuestAddrs.secf_n_be : Word) dst xs secfNBytes orig).body.steps + 1)))
+      (GuestAddrs.secf_reduce_once_n + 64 : Word)
+      (GuestAddrs.secf_reduce_once_n + 84 : Word) secfReduceOnceNCr
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ old10) ** ((.x11 : Reg) ↦ᵣ old11) **
+        ((.x12 : Reg) ↦ᵣ old12) ** ((.x1 : Reg) ↦ᵣ ret) **
+        regOwns subScratch ** bytesRegion dst orig ** bytesRegion src xs **
+        globalConst (GuestAddrs.secf_n_be : Word) secfNBytes)
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 84 : Word)) **
+        regOwns exposedRegs **
+        bytesRegion dst (U256SubBeSAsm.u256SubBeBytes xs secfNBytes orig) **
+        bytesRegion src xs **
+        globalConst (GuestAddrs.secf_n_be : Word) secfNBytes) := by
+  unfold globalConst
+  have hsetup := subSetup_spec src dst ret old10 old11 old12
+  have hsetupF := cpsTripleWithin_frameR
+    (regOwns subScratch ** bytesRegion dst orig ** bytesRegion src xs **
+      bytesRegion (GuestAddrs.secf_n_be : Word) secfNBytes)
+    (by pcf) hsetup
+  have hcallee0 := u256SubBeFlat_spec (GuestAddrs.secf_reduce_once_n + 84 : Word)
+    src (GuestAddrs.secf_n_be : Word) dst xs secfNBytes orig
+    hrwDst hroX (by decide) hlenX (by decide) hlenOrig hovX (by decide) hovDst
+    hdisjX hdisjP (by decide)
+  have hcallee : cpsTripleWithin
+      ((U256SubBeSAsm.u256SubBeFn src (GuestAddrs.secf_n_be : Word) dst xs secfNBytes orig).body.steps + 1)
+      (GuestAddrs.u256_sub_be : Word) (GuestAddrs.secf_reduce_once_n + 84 : Word)
+      secfReduceOnceNCr
+      (((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 84 : Word)) **
+        (((.x10 : Reg) ↦ᵣ src) **
+          ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+          ((.x12 : Reg) ↦ᵣ dst) ** regOwns subScratch **
+          bytesRegion dst orig ** bytesRegion src xs **
+          bytesRegion (GuestAddrs.secf_n_be : Word) secfNBytes))
+      (((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 84 : Word)) **
+        (regOwns exposedRegs **
+          bytesRegion dst (U256SubBeSAsm.u256SubBeBytes xs secfNBytes orig) **
+          bytesRegion src xs ** bytesRegion (GuestAddrs.secf_n_be : Word) secfNBytes)) := by
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by xperm_hyp hq) hcallee0
+  have hcall := callWithin_spec (cr := secfReduceOnceNCr)
+    (P := (((.x10 : Reg) ↦ᵣ src) **
+          ((.x11 : Reg) ↦ᵣ (GuestAddrs.secf_n_be : Word)) **
+          ((.x12 : Reg) ↦ᵣ dst) ** regOwns subScratch **
+          bytesRegion dst orig ** bytesRegion src xs **
+          bytesRegion (GuestAddrs.secf_n_be : Word) secfNBytes))
+    (Q := (regOwns exposedRegs **
+          bytesRegion dst (U256SubBeSAsm.u256SubBeBytes xs secfNBytes orig) **
+          bytesRegion src xs ** bytesRegion (GuestAddrs.secf_n_be : Word) secfNBytes))
+    (GuestAddrs.secf_reduce_once_n + 80 : Word) (GuestAddrs.u256_sub_be : Word) ret
+    (jalOff GuestAddrs.u256_sub_be (GuestAddrs.secf_reduce_once_n + 80))
+    ((U256SubBeSAsm.u256SubBeFn src (GuestAddrs.secf_n_be : Word) dst xs secfNBytes orig).body.steps + 1)
+    (by decide) (by unfold secfReduceOnceNCr; code_mem) (by pcf) hcallee
+  rw [show (GuestAddrs.secf_reduce_once_n + 80 : Word) + 4 =
+      (GuestAddrs.secf_reduce_once_n + 84 : Word) from by decide] at hcall
+  have hcallF := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst)) (by pcf) hcall
+  have hc := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hsetupF hcallF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hc
+
+private theorem subRetTail_spec (P : Assertion) (hP : P.pcFree) :
+    cpsTripleWithin 2 (GuestAddrs.secf_reduce_once_n + 84 : Word)
+      (GuestAddrs.secf_reduce_once_n + 108 : Word) secfReduceOnceNCr
+      ((((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 84 : Word)) **
+        regOwns exposedRegs) ** P)
+      ((((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 84 : Word)) **
+        ((.x10 : Reg) ↦ᵣ (1 : Word)) ** regOwns retScratch) ** P) := by
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => hq)
+    (cpsTripleWithin_peel_regOwns exposedRegs (by decide)
+      (P := ((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 84 : Word)) ** P)
+      (fun vf => ?_))
+  have hli := liftCode (cr' := secfReduceOnceNCr)
+    (li_spec_gen_within .x10 (vf .x10) (1 : Word)
+      (GuestAddrs.secf_reduce_once_n + 84 : Word) (by decide))
+    (by unfold secfReduceOnceNCr; code_mem)
+  rw [show (GuestAddrs.secf_reduce_once_n + 84 : Word) + 4 =
+      (GuestAddrs.secf_reduce_once_n + 88 : Word) from by decide] at hli
+  have hjal := cpsTripleWithin_extend_code (cr' := secfReduceOnceNCr)
+    (h := jal_x0_spec_gen_within (20 : BitVec 21)
+      (GuestAddrs.secf_reduce_once_n + 88 : Word))
+    (hmono := by unfold secfReduceOnceNCr; code_mem)
+  rw [show (GuestAddrs.secf_reduce_once_n + 88 : Word) + signExtend21 (20 : BitVec 21) =
+      (GuestAddrs.secf_reduce_once_n + 108 : Word) from by
+        rw [show signExtend21 (20 : BitVec 21) = (20 : Word) from by decide]
+        decide] at hjal
+  have hliF := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 84 : Word)) **
+      regAtomsOf vf retScratch ** P)
+    (by exact pcFree_sepConj (by pcf) (pcFree_sepConj (pcFree_regAtomsOf vf retScratch) hP)) hli
+  have hjalF0 := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 84 : Word)) **
+      ((.x10 : Reg) ↦ᵣ (1 : Word)) ** regAtomsOf vf retScratch ** P)
+    (by
+      apply pcFree_sepConj
+      · exact pcFree_regIs
+      · apply pcFree_sepConj
+        · exact pcFree_regIs
+        · exact pcFree_sepConj (pcFree_regAtomsOf vf retScratch) hP) hjal
+  have hjalF : cpsTripleWithin 1 (GuestAddrs.secf_reduce_once_n + 88 : Word)
+      (GuestAddrs.secf_reduce_once_n + 108 : Word) secfReduceOnceNCr
+      (((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 84 : Word)) **
+        ((.x10 : Reg) ↦ᵣ (1 : Word)) ** regAtomsOf vf retScratch ** P)
+      (((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 84 : Word)) **
+        ((.x10 : Reg) ↦ᵣ (1 : Word)) ** regAtomsOf vf retScratch ** P) := by
+    exact cpsTripleWithin_weaken (fun h hp => by
+        have hp1 : (empAssertion ** (((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 84 : Word)) **
+            ((.x10 : Reg) ↦ᵣ (1 : Word)) ** regAtomsOf vf retScratch ** P)) h := by
+          rw [sepConj_emp_left']
+          exact hp
+        exact hp1)
+      (fun h hq => by
+        rw [sepConj_emp_left'] at hq
+        exact hq) hjalF0
+  have hc := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hliF hjalF
+  exact cpsTripleWithin_weaken (fun _ hp => by
+      rw [exposedRegs_split_ret] at hp
+      xperm_hyp hp)
+    (fun h hq => by
+      have hq1 : ((((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 84 : Word)) **
+          ((.x10 : Reg) ↦ᵣ (1 : Word)) ** regAtomsOf vf retScratch) ** P) h := by
+        xperm_hyp hq
+      exact sepConj_mono_left
+        (sepConj_mono_right (sepConj_mono_right (regAtomsOf_to_regOwns vf retScratch))) h hq1) hc
+
+theorem subArm_spec (src dst ret old10 old11 old12 : Word)
+    (xs orig : List (BitVec 8))
+    (hroX : Region.wf ⟨src, xs⟩)
+    (hrwDst : RwRegion.wf ⟨dst, 32⟩)
+    (hlenX : xs.length = 32) (hlenOrig : orig.length = 32)
+    (hovX : src.toNat + 32 < 2 ^ 64)
+    (hovDst : dst.toNat + 32 < 2 ^ 64)
+    (hdisjX : src.toNat + 32 ≤ dst.toNat ∨ dst.toNat + 32 ≤ src.toNat)
+    (hdisjP : (GuestAddrs.secf_n_be : Word).toNat + 32 ≤ dst.toNat ∨
+      dst.toNat + 32 ≤ (GuestAddrs.secf_n_be : Word).toNat) :
+    cpsTripleWithin ((4 + (1 + ((U256SubBeSAsm.u256SubBeFn src
+        (GuestAddrs.secf_n_be : Word) dst xs secfNBytes orig).body.steps + 1))) + 2)
+      (GuestAddrs.secf_reduce_once_n + 64 : Word)
+      (GuestAddrs.secf_reduce_once_n + 108 : Word) secfReduceOnceNCr
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x10 : Reg) ↦ᵣ old10) ** ((.x11 : Reg) ↦ᵣ old11) **
+        ((.x12 : Reg) ↦ᵣ old12) ** ((.x1 : Reg) ↦ᵣ ret) **
+        regOwns subScratch ** bytesRegion dst orig ** bytesRegion src xs **
+        globalConst (GuestAddrs.secf_n_be : Word) secfNBytes)
+      (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+        ((.x1 : Reg) ↦ᵣ (GuestAddrs.secf_reduce_once_n + 84 : Word)) **
+        ((.x10 : Reg) ↦ᵣ (1 : Word)) ** regOwns retScratch **
+        bytesRegion dst (U256SubBeSAsm.u256SubBeBytes xs secfNBytes orig) **
+        bytesRegion src xs **
+        globalConst (GuestAddrs.secf_n_be : Word) secfNBytes) := by
+  have hcall := subSetupCall_spec src dst ret old10 old11 old12 xs orig
+    hroX hrwDst hlenX hlenOrig hovX hovDst hdisjX hdisjP
+  have htail := subRetTail_spec
+    (((.x8 : Reg) ↦ᵣ src) ** ((.x9 : Reg) ↦ᵣ dst) **
+      bytesRegion dst (U256SubBeSAsm.u256SubBeBytes xs secfNBytes orig) **
+      bytesRegion src xs ** globalConst (GuestAddrs.secf_n_be : Word) secfNBytes)
+    (by pcf)
+  have hc := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hcall htail
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hc
+
+end Secp256k1FieldReduceOnceNSAsm
+
+end EvmAsm.Codegen

--- a/PLAN.md
+++ b/PLAN.md
@@ -3711,6 +3711,10 @@ an ABI-frame caller over `u256_lt_be`, `u256_sub_be`, and `secf_copy32`, with
 `blockAt`/global-data materialization for `secp256k1_p_be` and `secf_cmp`, a
 genuine post `a0 = reduceOnceFlag xs` and `dst = reduceOnceBytes xs orig`, and
 byte identity pinned by `secfReduceOnce_prog_eq`.
+`Secp256k1FieldReduceOnceNSAsm.lean` applies the same verified ABI-frame and
+shared-join architecture to the scalar-field mirror `secf_reduce_once_n`, with
+the group-order bytes at `secf_n_be`, exact conditional-subtraction bytes and
+return flag, and an `rfl` byte-identity guard against `secfReduceOnceN_prog`.
 `Secp256k1FieldEq32SAsm.lean` verifies `secf_eq32` as a `whileBreak` drop-in
 (`secfEq32Fn_spec`, `a0 = 1` iff the two 32-byte inputs are equal); the
 emitted `secfEq32_prog` is rewired to the verified body and the asm fixture is


### PR DESCRIPTION
## Summary
- verify secf_reduce_once_n as a byte-identical ABI-frame SAsm/CPS routine
- compose u256_lt_be, u256_sub_be, and secf_copy32 using symbolic GuestAddrs and global secf_n_be/secf_cmp regions
- state exact scalar conditional-reduction bytes and the subtraction flag while preserving the input
- discharge the former ABI-frame, global-symbol, and shared-epilogue blocker

## Verification
- lake build (4893 jobs)
- port-check for Secp256k1FieldReduceOnceNSAsm.lean (35 declarations, PASS)
- forbidden-tactics, axioms, layering, unimported, symbolic-PC, file-size, heartbeat, and no-warning gates all pass
- group-order byte decoding is pinned to fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141

The secfReduceOnceNFrame_spec axiom audit reports only propext, Classical.choice, and Quot.sound.

This is a spec-only byte-identical port: secfReduceOnceN_prog_eq closes by rfl, so emitted guest bytes are unchanged and EEST A/B is not required.

Bead: evm-asm-4ch8f.38.2.8.1