### PR TITLE
feat(gas): verify copy_word_gas SAsm port

### DIFF
--- a/EvmAsm/Codegen/Programs/CopyWordGasSAsm.lean
+++ b/EvmAsm/Codegen/Programs/CopyWordGasSAsm.lean
@@ -1,0 +1,53 @@
+/-
+  Byte-identical SAsm specification of `copy_word_gas`.
+-/
+
+import EvmAsm.Codegen.Programs.DynamicOpcodeGas
+import EvmAsm.Rv64.SAsm.Tactic
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.SAsm.Stmt
+
+namespace CopyWordGasSAsm
+
+/-- RV64 semantics of the Amsterdam per-word copy-gas component.  Arithmetic
+    intentionally wraps at 64 bits, exactly like the emitted guest code. -/
+def copyWordGas (size : Word) : Word := ((size + 31) >>> 5) * 3
+
+def copyWordGasFn (size : Word) : Fn where
+  name := "copyWordGas"
+  region := Region.empty
+  rw := RwRegion.empty
+  pre := fun rf _ A => rf.get .x10 = size ∧ A = empAssertion
+  post := fun rf _ A => rf.get .x10 = copyWordGas size ∧ A = empAssertion
+  body := .block "copyWordGas"
+    [ .ADDI .x5 .x10 (31 : BitVec 12),
+      .SRLI .x5 .x5 (5 : BitVec 6),
+      .LI .x6 (3 : Word),
+      .MUL .x10 .x5 .x6 ]
+
+theorem copyWordGas_byte_tie :
+    (copyWordGasFn 0).body.flatten 0 ++
+      [Instr.JALR .x0 .x1 (0 : BitVec 12)] = copyWordGas_prog := by
+  rfl
+
+#guard (copyWordGasFn 0).body.flatten 0 =
+  (copyWordGasFn 0).body.flatten 0x80000000
+
+theorem copyWordGasFn_spec (size base : Word) :
+    (copyWordGasFn size).Spec base := by
+  vcgen
+  case copyWordGas.post =>
+    rintro rf ws A ⟨rf0, ws0, hlen, ⟨hx10, hA⟩, rfl, rfl⟩
+    simp only [copyWordGasFn, copyWordGas, execBlock_cons, execBlock_nil,
+      execInstrRF, aluSem, RegFile.get_set_self, RegFile.get_set_ne,
+      ne_eq, reduceCtorEq, not_false_eq_true, hx10]
+    constructor
+    · congr 1
+    · exact hA
+
+#print axioms copyWordGasFn_spec
+
+end CopyWordGasSAsm
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -407,3 +407,4 @@ import EvmAsm.Codegen.Programs.ReceiptList
 import EvmAsm.Codegen.Programs.StatelessGuestUnit
 import EvmAsm.Codegen.Programs.RegistryNames
 import EvmAsm.Codegen.Programs.HpEncodeNibblesSAsm
+import EvmAsm.Codegen.Programs.CopyWordGasSAsm

--- a/PLAN.md
+++ b/PLAN.md
@@ -367,6 +367,9 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   (isCold ? 2600 : 100) + (valueNonzero ? 9000 : 0)`) pinned to
   `callExtraGas_prog`, after converting the raw asm string to a `Program`
   rendered by `emitProgram`.
+  `CopyWordGasSAsm.lean` verifies `copy_word_gas` as a byte-identical
+  straight-line leaf (`copyWordGasFn_spec`, post `a0 = 3 * ((size + 31) >> 5)`
+  with exact RV64 wrapping semantics) pinned to `copyWordGas_prog`.
   Byte-reverse copies (`whileS`, runtime length, read-only src + writable dst):
   `SwrRevLeBeSAsm.lean` (`swrRevLeBeFn_spec`, `dst = (src[0..len)).reverse`,
   byte-identity fully pinned to `swrRevLeBe_prog`; pre REQUIRES src/dst


### PR DESCRIPTION
## Summary
- verify copy_word_gas as a byte-identical SAsm Fn
- give the genuine RV64 result formula: 3 times the wrapped ceil-word count computed as (size + 31) shifted right by 5
- wire the proof module into Codegen imports and record it in PLAN.md

## Verification
- lake build (4893 jobs)
- port-check PASS (4 declarations)
- forbidden-tactic, axiom, layering, orphan, symbolic-PC, file-size, and warning gates pass
- copyWordGasFn_spec uses only propext, Classical.choice, and Quot.sound

The emitted body is unchanged; copyWordGas_byte_tie closes by rfl, so EEST A/B is not required.

Bead: evm-asm-4ch8f.77