### PR TITLE
feat(gas): verify log_data_gas SAsm port

### DIFF
--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -407,3 +407,4 @@ import EvmAsm.Codegen.Programs.ReceiptList
 import EvmAsm.Codegen.Programs.StatelessGuestUnit
 import EvmAsm.Codegen.Programs.RegistryNames
 import EvmAsm.Codegen.Programs.HpEncodeNibblesSAsm
+import EvmAsm.Codegen.Programs.LogDataGasSAsm

--- a/EvmAsm/Codegen/Programs/LogDataGasSAsm.lean
+++ b/EvmAsm/Codegen/Programs/LogDataGasSAsm.lean
@@ -1,0 +1,53 @@
+/- Byte-identical SAsm specification of `log_data_gas`. -/
+
+import EvmAsm.Codegen.Programs.DynamicOpcodeGas
+import EvmAsm.Rv64.SAsm.Tactic
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.SAsm.Stmt
+
+namespace LogDataGasSAsm
+
+/-- Exact RV64 Amsterdam LOG base, topic, and data-byte gas arithmetic. -/
+def logDataGas (numTopics dataBytes : Word) : Word :=
+  numTopics * 375 + 375 + dataBytes * 8
+
+def logDataGasFn (numTopics dataBytes : Word) : Fn where
+  name := "logDataGas"
+  region := Region.empty
+  rw := RwRegion.empty
+  pre := fun rf _ A =>
+    rf.get .x10 = numTopics ∧ rf.get .x11 = dataBytes ∧ A = empAssertion
+  post := fun rf _ A =>
+    rf.get .x10 = logDataGas numTopics dataBytes ∧ A = empAssertion
+  body := .block "logDataGas"
+    [ .LI .x5 (375 : Word),
+      .MUL .x6 .x10 .x5,
+      .ADD .x6 .x6 .x5,
+      .LI .x7 (8 : Word),
+      .MUL .x7 .x11 .x7,
+      .ADD .x10 .x6 .x7 ]
+
+theorem logDataGas_byte_tie :
+    (logDataGasFn 0 0).body.flatten 0 ++
+      [Instr.JALR .x0 .x1 (0 : BitVec 12)] = logDataGas_prog := by
+  rfl
+
+#guard (logDataGasFn 0 0).body.flatten 0 =
+  (logDataGasFn 0 0).body.flatten 0x80000000
+
+theorem logDataGasFn_spec (numTopics dataBytes base : Word) :
+    (logDataGasFn numTopics dataBytes).Spec base := by
+  vcgen
+  case logDataGas.post =>
+    rintro rf ws A ⟨rf0, ws0, hlen, ⟨hx10, hx11, hA⟩, rfl, rfl⟩
+    simp only [logDataGasFn, logDataGas, execBlock_cons, execBlock_nil,
+      execInstrRF, aluSem, RegFile.get_set_self, RegFile.get_set_ne,
+      ne_eq, reduceCtorEq, not_false_eq_true, hx10, hx11]
+    constructor <;> trivial
+
+#print axioms logDataGasFn_spec
+
+end LogDataGasSAsm
+end EvmAsm.Codegen

--- a/PLAN.md
+++ b/PLAN.md
@@ -367,6 +367,9 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   (isCold ? 2600 : 100) + (valueNonzero ? 9000 : 0)`) pinned to
   `callExtraGas_prog`, after converting the raw asm string to a `Program`
   rendered by `emitProgram`.
+  `LogDataGasSAsm.lean` verifies `log_data_gas` as a byte-identical
+  straight-line leaf (`logDataGasFn_spec`, post `a0 = topics * 375 + 375 +
+  dataBytes * 8` with exact RV64 wrapping semantics).
   Byte-reverse copies (`whileS`, runtime length, read-only src + writable dst):
   `SwrRevLeBeSAsm.lean` (`swrRevLeBeFn_spec`, `dst = (src[0..len)).reverse`,
   byte-identity fully pinned to `swrRevLeBe_prog`; pre REQUIRES src/dst


### PR DESCRIPTION
## Summary
- verify log_data_gas as a byte-identical SAsm Fn
- specify the genuine two-input RV64 Amsterdam formula: topics times 375, plus base 375, plus data bytes times 8
- wire the proof into Codegen imports and PLAN.md

## Verification
- lake build (4893 jobs)
- port-check PASS (4 declarations)
- forbidden-tactic, axiom, layering, orphan, symbolic-PC, file-size, and warning gates pass
- logDataGasFn_spec uses only propext, Classical.choice, and Quot.sound

The emitted body is unchanged and the byte tie closes by rfl, so EEST A/B is not required.

Bead: evm-asm-4ch8f.79