### PR TITLE
feat(call-frame): verify frame_depth_push SAsm port

### DIFF
--- a/EvmAsm/Codegen/Programs/FrameDepthPushSAsm.lean
+++ b/EvmAsm/Codegen/Programs/FrameDepthPushSAsm.lean
@@ -1,0 +1,93 @@
+/- Byte-identical linked-PC verification of `frame_depth_push`. -/
+
+import EvmAsm.Codegen.Programs.CallFrameSwitch
+import EvmAsm.Rv64.LaResolve
+import EvmAsm.Rv64.SAsm.FramePort
+import EvmAsm.Evm64.CallingConvention
+
+namespace EvmAsm.Codegen
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+namespace FrameDepthPushSAsm
+
+#guard GuestAddrs.frame_depth_push = 0x800382ec
+#guard GuestAddrs.evm_call_depth = 0xbc2bd580
+
+def frameDepthPushBody : List Instr :=
+  [ .AUIPC .x5 (laHi GuestAddrs.evm_call_depth GuestAddrs.frame_depth_push),
+    .ADDI .x5 .x5 (laLo GuestAddrs.evm_call_depth GuestAddrs.frame_depth_push),
+    .LD .x10 .x5 (0 : BitVec 12), .ADDI .x10 .x10 (1 : BitVec 12),
+    .SD .x5 .x10 (0 : BitVec 12) ]
+
+theorem frameDepthPush_byte_tie :
+    frameDepthPushBody ++ [.JALR .x0 .x1 (0 : BitVec 12)] = frameDepthPush_prog := by rfl
+
+def frameDepthPushCr : CodeReq :=
+  CodeReq.ofProg (GuestAddrs.frame_depth_push : Word) frameDepthPush_prog
+
+theorem frameDepthPush_spec (depth old5 old10 ret : Word)
+    (halign : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin 6 (GuestAddrs.frame_depth_push : Word) ret frameDepthPushCr
+      (((.x5 : Reg) ↦ᵣ old5) ** ((.x10 : Reg) ↦ᵣ old10) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((GuestAddrs.evm_call_depth : Word) ↦ₘ depth))
+      (((.x5 : Reg) ↦ᵣ (GuestAddrs.evm_call_depth : Word)) **
+        ((.x10 : Reg) ↦ᵣ (depth + 1)) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((GuestAddrs.evm_call_depth : Word) ↦ₘ (depth + 1))) := by
+  have hla := la_materialize_within .x5 old5
+    (GuestAddrs.frame_depth_push : Word) (GuestAddrs.evm_call_depth : Word)
+    (cr := frameDepthPushCr) (by decide) (by decide)
+    (by unfold frameDepthPushCr; code_mem) (by unfold frameDepthPushCr; code_mem)
+  rw [show (GuestAddrs.frame_depth_push : Word) + 8 =
+      (GuestAddrs.frame_depth_push + 8 : Word) from by decide] at hla
+  have hlaF := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ old10) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((GuestAddrs.evm_call_depth : Word) ↦ₘ depth)) (by pcf) hla
+  have hld0 := ld_spec_gen_within .x10 .x5
+    (GuestAddrs.evm_call_depth : Word) old10 depth 0
+    (GuestAddrs.frame_depth_push + 8 : Word) (by decide)
+  rw [show (GuestAddrs.evm_call_depth : Word) + signExtend12 (0 : BitVec 12) =
+      (GuestAddrs.evm_call_depth : Word) from by decide,
+    show (GuestAddrs.frame_depth_push + 8 : Word) + 4 =
+      (GuestAddrs.frame_depth_push + 12 : Word) from by decide] at hld0
+  have hld := liftCode (cr' := frameDepthPushCr) hld0
+    (by unfold frameDepthPushCr; code_mem)
+  have hldF := cpsTripleWithin_frameR (((.x1 : Reg) ↦ᵣ ret)) (by pcf) hld
+  have hadd0 := addi_spec_gen_same_within .x10 depth 1
+    (GuestAddrs.frame_depth_push + 12 : Word) (by decide)
+  rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide,
+    show (GuestAddrs.frame_depth_push + 12 : Word) + 4 =
+      (GuestAddrs.frame_depth_push + 16 : Word) from by decide] at hadd0
+  have hadd := liftCode (cr' := frameDepthPushCr) hadd0
+    (by unfold frameDepthPushCr; code_mem)
+  have haddF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (GuestAddrs.evm_call_depth : Word)) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((GuestAddrs.evm_call_depth : Word) ↦ₘ depth))
+    (by pcf) hadd
+  have hsd0 := sd_spec_gen_within .x5 .x10
+    (GuestAddrs.evm_call_depth : Word) (depth + 1) depth 0
+    (GuestAddrs.frame_depth_push + 16 : Word)
+  rw [show (GuestAddrs.evm_call_depth : Word) + signExtend12 (0 : BitVec 12) =
+      (GuestAddrs.evm_call_depth : Word) from by decide,
+    show (GuestAddrs.frame_depth_push + 16 : Word) + 4 =
+      (GuestAddrs.frame_depth_push + 20 : Word) from by decide] at hsd0
+  have hsd := liftCode (cr' := frameDepthPushCr) hsd0
+    (by unfold frameDepthPushCr; code_mem)
+  have hsdF := cpsTripleWithin_frameR (((.x1 : Reg) ↦ᵣ ret)) (by pcf) hsd
+  have hret0 := EvmAsm.Evm64.ret_spec_within'
+    (GuestAddrs.frame_depth_push + 20 : Word) ret
+  rw [halign] at hret0
+  have hret := liftCode (cr' := frameDepthPushCr) hret0
+    (by unfold frameDepthPushCr; code_mem)
+  have hretF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (GuestAddrs.evm_call_depth : Word)) **
+      ((.x10 : Reg) ↦ᵣ (depth + 1)) **
+      ((GuestAddrs.evm_call_depth : Word) ↦ₘ (depth + 1))) (by pcf) hret
+  have h12 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hlaF hldF
+  have h123 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h12 haddF
+  have h1234 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h123 hsdF
+  have h12345 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h1234 hretF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) h12345
+
+#print axioms frameDepthPush_spec
+end FrameDepthPushSAsm
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -407,3 +407,4 @@ import EvmAsm.Codegen.Programs.ReceiptList
 import EvmAsm.Codegen.Programs.StatelessGuestUnit
 import EvmAsm.Codegen.Programs.RegistryNames
 import EvmAsm.Codegen.Programs.HpEncodeNibblesSAsm
+import EvmAsm.Codegen.Programs.FrameDepthPushSAsm

--- a/PLAN.md
+++ b/PLAN.md
@@ -349,6 +349,10 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   (`callFrameSetCalldataFn_spec`, post stores `parentMem + argsOff` at offset
   416 and `argsLen` at offset 424) with byte-identity pinned to
   `callFrameSetCalldata_prog`.
+  `FrameDepthPushSAsm.lean` verifies the linked-PC `frame_depth_push` global
+  state leaf: it materializes `evm_call_depth`, increments the owned dword with
+  RV64 wrapping semantics, writes it back, and returns the new depth in `a0`,
+  with byte identity pinned to `frameDepthPush_prog`.
   `CalcExcessBlobGasSAsm.lean` verifies `calc_excess_blob_gas` as a
   byte-identical return-terminating `retIf` body (`calcExcessBlobGas_spec`,
   post `a0 = if (a0 + a1) < a2 then 0 else (a0 + a1) - a2`


### PR DESCRIPTION
## Summary
- verify frame_depth_push byte-identically at its linked guest address
- prove the AUIPC/ADDI pair materializes evm_call_depth through la_materialize_within
- compose load, wrapped increment, store, and return triples
- genuine post owns the incremented global dword and returns the same value in a0

## Verification
- lake build (4893 jobs)
- port-check PASS
- forbidden-tactic, axiom, layering, orphan, symbolic-PC, file-size, and warning gates pass
- frameDepthPush_spec uses only propext, Classical.choice, and Quot.sound

The emitted program is unchanged and the byte tie closes by rfl, so EEST A/B is not required.

Bead: evm-asm-4ch8f.56.8