### PR TITLE
Batch-merge #10122 #10123 #10124 #10125 (pirapira)

### DIFF
--- a/EvmAsm/Codegen/Programs/CopyWordGasSAsm.lean
+++ b/EvmAsm/Codegen/Programs/CopyWordGasSAsm.lean
@@ -1,0 +1,53 @@
+/-
+  Byte-identical SAsm specification of `copy_word_gas`.
+-/
+
+import EvmAsm.Codegen.Programs.DynamicOpcodeGas
+import EvmAsm.Rv64.SAsm.Tactic
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.SAsm.Stmt
+
+namespace CopyWordGasSAsm
+
+/-- RV64 semantics of the Amsterdam per-word copy-gas component.  Arithmetic
+    intentionally wraps at 64 bits, exactly like the emitted guest code. -/
+def copyWordGas (size : Word) : Word := ((size + 31) >>> 5) * 3
+
+def copyWordGasFn (size : Word) : Fn where
+  name := "copyWordGas"
+  region := Region.empty
+  rw := RwRegion.empty
+  pre := fun rf _ A => rf.get .x10 = size ∧ A = empAssertion
+  post := fun rf _ A => rf.get .x10 = copyWordGas size ∧ A = empAssertion
+  body := .block "copyWordGas"
+    [ .ADDI .x5 .x10 (31 : BitVec 12),
+      .SRLI .x5 .x5 (5 : BitVec 6),
+      .LI .x6 (3 : Word),
+      .MUL .x10 .x5 .x6 ]
+
+theorem copyWordGas_byte_tie :
+    (copyWordGasFn 0).body.flatten 0 ++
+      [Instr.JALR .x0 .x1 (0 : BitVec 12)] = copyWordGas_prog := by
+  rfl
+
+#guard (copyWordGasFn 0).body.flatten 0 =
+  (copyWordGasFn 0).body.flatten 0x80000000
+
+theorem copyWordGasFn_spec (size base : Word) :
+    (copyWordGasFn size).Spec base := by
+  vcgen
+  case copyWordGas.post =>
+    rintro rf ws A ⟨rf0, ws0, hlen, ⟨hx10, hA⟩, rfl, rfl⟩
+    simp only [copyWordGasFn, copyWordGas, execBlock_cons, execBlock_nil,
+      execInstrRF, aluSem, RegFile.get_set_self, RegFile.get_set_ne,
+      ne_eq, reduceCtorEq, not_false_eq_true, hx10]
+    constructor
+    · congr 1
+    · exact hA
+
+#print axioms copyWordGasFn_spec
+
+end CopyWordGasSAsm
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -407,3 +407,4 @@ import EvmAsm.Codegen.Programs.ReceiptList
 import EvmAsm.Codegen.Programs.StatelessGuestUnit
 import EvmAsm.Codegen.Programs.RegistryNames
 import EvmAsm.Codegen.Programs.HpEncodeNibblesSAsm
+import EvmAsm.Codegen.Programs.Keccak256WordGasSAsm

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -407,3 +407,4 @@ import EvmAsm.Codegen.Programs.ReceiptList
 import EvmAsm.Codegen.Programs.StatelessGuestUnit
 import EvmAsm.Codegen.Programs.RegistryNames
 import EvmAsm.Codegen.Programs.HpEncodeNibblesSAsm
+import EvmAsm.Codegen.Programs.CopyWordGasSAsm

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -407,3 +407,4 @@ import EvmAsm.Codegen.Programs.ReceiptList
 import EvmAsm.Codegen.Programs.StatelessGuestUnit
 import EvmAsm.Codegen.Programs.RegistryNames
 import EvmAsm.Codegen.Programs.HpEncodeNibblesSAsm
+import EvmAsm.Codegen.Programs.LogDataGasSAsm

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -407,3 +407,4 @@ import EvmAsm.Codegen.Programs.ReceiptList
 import EvmAsm.Codegen.Programs.StatelessGuestUnit
 import EvmAsm.Codegen.Programs.RegistryNames
 import EvmAsm.Codegen.Programs.HpEncodeNibblesSAsm
+import EvmAsm.Codegen.Programs.InitCodeCostSAsm

--- a/EvmAsm/Codegen/Programs/InitCodeCostSAsm.lean
+++ b/EvmAsm/Codegen/Programs/InitCodeCostSAsm.lean
@@ -1,0 +1,86 @@
+/- Byte-identical SAsm specification of `init_code_cost`. -/
+
+import EvmAsm.Codegen.Programs.IntrinsicGas
+import EvmAsm.Rv64.SAsm.Tactic
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.SAsm.Stmt
+
+namespace InitCodeCostSAsm
+
+def initCodeCost (initCodeLength gasPerWord : Word) : Word :=
+  ((initCodeLength + 31) >>> 5) * gasPerWord
+
+def initCodeCostFn (initCodeLength gasPerWord outPtr : Word)
+    (orig : List (BitVec 8)) : Fn where
+  name := "initCodeCost"
+  region := Region.empty
+  rw := ⟨outPtr, 8⟩
+  pre := fun rf ws A =>
+    rf.get .x10 = initCodeLength ∧ rf.get .x11 = gasPerWord ∧
+    rf.get .x12 = outPtr ∧ ws = orig ∧ orig.length = 8 ∧ A = empAssertion
+  post := fun rf ws A =>
+    rf.get .x10 = 0 ∧ ws = dwordBytes (initCodeCost initCodeLength gasPerWord) ∧
+    A = empAssertion
+  body := .block "initCodeCost"
+    [ .ADDI .x5 .x10 (31 : BitVec 12),
+      .SRLI .x5 .x5 (5 : BitVec 6),
+      .MUL .x5 .x5 .x11,
+      .SD .x12 .x5 (0 : BitVec 12),
+      .LI .x10 (0 : Word) ]
+
+theorem initCodeCost_byte_tie :
+    (initCodeCostFn 0 0 0 []).body.flatten 0 ++
+      [Instr.JALR .x0 .x1 (0 : BitVec 12)] = initCodeCost_prog := by
+  rfl
+
+#guard (initCodeCostFn 0 0 0 []).body.flatten 0 =
+  (initCodeCostFn 0 0 0 []).body.flatten 0x80000000
+
+private theorem setBytes_zero_dword_eq (orig : List (BitVec 8))
+    (v : Word) (h : orig.length = 8) :
+    setBytes orig 0 (dwordBytes v) = dwordBytes v := by
+  apply List.ext_getElem
+  · simp only [length_setBytes, h, length_dwordBytes]
+  · intro i hi hj
+    rw [length_setBytes, h] at hi
+    interval_cases i <;> simp [setBytes, dwordBytes]
+
+theorem initCodeCostFn_spec (initCodeLength gasPerWord outPtr base : Word)
+    (orig : List (BitVec 8)) (hrw : RwRegion.wf ⟨outPtr, 8⟩) :
+    (initCodeCostFn initCodeLength gasPerWord outPtr orig).Spec base := by
+  vcgen
+  case region => exact ⟨Region.empty_wf, hrw⟩
+  case initCodeCost.mem =>
+    rintro rf ws A hlen ⟨hx10, hx11, hx12, hws, horig, hA⟩
+    subst ws
+    simp only [initCodeCostFn, blockVCs, execInstrRF, aluSem, loadSem,
+      storeSem, RegFile.get_set_self, RegFile.get_set_ne, ne_eq,
+      reduceCtorEq, not_false_eq_true, hx10, hx11, hx12, horig,
+      signExtend12_0, true_and]
+    have hzero : (outPtr + (0 : Word) - outPtr).toNat = 0 := by
+      rw [show outPtr + (0 : Word) - outPtr = (0 : Word) by bv_omega]
+      decide
+    refine ⟨⟨?_, ?_⟩, trivial⟩
+    · unfold inRw
+      rw [horig, hzero]
+    · rw [hzero]
+      norm_num
+  case initCodeCost.post =>
+    rintro rf ws A ⟨rf0, ws0, hlen, ⟨hx10, hx11, hx12, hws, horig, hA⟩,
+      rfl, rfl⟩
+    subst ws0
+    simp only [initCodeCostFn, initCodeCost, execBlock_cons, execBlock_nil,
+      execInstrRF, aluSem, loadSem, storeSem, RegFile.get_set_self,
+      RegFile.get_set_ne, ne_eq, reduceCtorEq, not_false_eq_true,
+      hx10, hx11, hx12, signExtend12_0]
+    rw [show (outPtr + (0 : Word) - outPtr).toNat = 0 by bv_omega,
+      show (5 : BitVec 6).toNat = 5 by decide,
+      setBytes_zero_dword_eq orig _ horig, hA]
+    norm_num
+
+#print axioms initCodeCostFn_spec
+
+end InitCodeCostSAsm
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Keccak256WordGasSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Keccak256WordGasSAsm.lean
@@ -1,0 +1,52 @@
+/- Byte-identical SAsm specification of `keccak256_word_gas`. -/
+
+import EvmAsm.Codegen.Programs.DynamicOpcodeGas
+import EvmAsm.Rv64.SAsm.Tactic
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.SAsm.Stmt
+
+namespace Keccak256WordGasSAsm
+
+/-- Exact RV64 arithmetic performed by the Amsterdam KECCAK256 dynamic-gas
+    leaf, including machine-word wrapping. -/
+def keccak256WordGas (size : Word) : Word := ((size + 31) >>> 5) * 6 + 30
+
+def keccak256WordGasFn (size : Word) : Fn where
+  name := "keccak256WordGas"
+  region := Region.empty
+  rw := RwRegion.empty
+  pre := fun rf _ A => rf.get .x10 = size ∧ A = empAssertion
+  post := fun rf _ A => rf.get .x10 = keccak256WordGas size ∧ A = empAssertion
+  body := .block "keccak256WordGas"
+    [ .ADDI .x5 .x10 (31 : BitVec 12),
+      .SRLI .x5 .x5 (5 : BitVec 6),
+      .LI .x6 (6 : Word),
+      .MUL .x5 .x5 .x6,
+      .ADDI .x10 .x5 (30 : BitVec 12) ]
+
+theorem keccak256WordGas_byte_tie :
+    (keccak256WordGasFn 0).body.flatten 0 ++
+      [Instr.JALR .x0 .x1 (0 : BitVec 12)] = keccak256WordGas_prog := by
+  rfl
+
+#guard (keccak256WordGasFn 0).body.flatten 0 =
+  (keccak256WordGasFn 0).body.flatten 0x80000000
+
+theorem keccak256WordGasFn_spec (size base : Word) :
+    (keccak256WordGasFn size).Spec base := by
+  vcgen
+  case keccak256WordGas.post =>
+    rintro rf ws A ⟨rf0, ws0, hlen, ⟨hx10, hA⟩, rfl, rfl⟩
+    simp only [keccak256WordGasFn, keccak256WordGas, execBlock_cons,
+      execBlock_nil, execInstrRF, aluSem, RegFile.get_set_self,
+      RegFile.get_set_ne, ne_eq, reduceCtorEq, not_false_eq_true, hx10]
+    constructor
+    · congr 1
+    · exact hA
+
+#print axioms keccak256WordGasFn_spec
+
+end Keccak256WordGasSAsm
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/LogDataGasSAsm.lean
+++ b/EvmAsm/Codegen/Programs/LogDataGasSAsm.lean
@@ -1,0 +1,53 @@
+/- Byte-identical SAsm specification of `log_data_gas`. -/
+
+import EvmAsm.Codegen.Programs.DynamicOpcodeGas
+import EvmAsm.Rv64.SAsm.Tactic
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.SAsm.Stmt
+
+namespace LogDataGasSAsm
+
+/-- Exact RV64 Amsterdam LOG base, topic, and data-byte gas arithmetic. -/
+def logDataGas (numTopics dataBytes : Word) : Word :=
+  numTopics * 375 + 375 + dataBytes * 8
+
+def logDataGasFn (numTopics dataBytes : Word) : Fn where
+  name := "logDataGas"
+  region := Region.empty
+  rw := RwRegion.empty
+  pre := fun rf _ A =>
+    rf.get .x10 = numTopics ∧ rf.get .x11 = dataBytes ∧ A = empAssertion
+  post := fun rf _ A =>
+    rf.get .x10 = logDataGas numTopics dataBytes ∧ A = empAssertion
+  body := .block "logDataGas"
+    [ .LI .x5 (375 : Word),
+      .MUL .x6 .x10 .x5,
+      .ADD .x6 .x6 .x5,
+      .LI .x7 (8 : Word),
+      .MUL .x7 .x11 .x7,
+      .ADD .x10 .x6 .x7 ]
+
+theorem logDataGas_byte_tie :
+    (logDataGasFn 0 0).body.flatten 0 ++
+      [Instr.JALR .x0 .x1 (0 : BitVec 12)] = logDataGas_prog := by
+  rfl
+
+#guard (logDataGasFn 0 0).body.flatten 0 =
+  (logDataGasFn 0 0).body.flatten 0x80000000
+
+theorem logDataGasFn_spec (numTopics dataBytes base : Word) :
+    (logDataGasFn numTopics dataBytes).Spec base := by
+  vcgen
+  case logDataGas.post =>
+    rintro rf ws A ⟨rf0, ws0, hlen, ⟨hx10, hx11, hA⟩, rfl, rfl⟩
+    simp only [logDataGasFn, logDataGas, execBlock_cons, execBlock_nil,
+      execInstrRF, aluSem, RegFile.get_set_self, RegFile.get_set_ne,
+      ne_eq, reduceCtorEq, not_false_eq_true, hx10, hx11]
+    constructor <;> trivial
+
+#print axioms logDataGasFn_spec
+
+end LogDataGasSAsm
+end EvmAsm.Codegen

--- a/PLAN.md
+++ b/PLAN.md
@@ -367,6 +367,9 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   (isCold ? 2600 : 100) + (valueNonzero ? 9000 : 0)`) pinned to
   `callExtraGas_prog`, after converting the raw asm string to a `Program`
   rendered by `emitProgram`.
+  `CopyWordGasSAsm.lean` verifies `copy_word_gas` as a byte-identical
+  straight-line leaf (`copyWordGasFn_spec`, post `a0 = 3 * ((size + 31) >> 5)`
+  with exact RV64 wrapping semantics) pinned to `copyWordGas_prog`.
   Byte-reverse copies (`whileS`, runtime length, read-only src + writable dst):
   `SwrRevLeBeSAsm.lean` (`swrRevLeBeFn_spec`, `dst = (src[0..len)).reverse`,
   byte-identity fully pinned to `swrRevLeBe_prog`; pre REQUIRES src/dst

--- a/PLAN.md
+++ b/PLAN.md
@@ -367,6 +367,9 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   (isCold ? 2600 : 100) + (valueNonzero ? 9000 : 0)`) pinned to
   `callExtraGas_prog`, after converting the raw asm string to a `Program`
   rendered by `emitProgram`.
+  `InitCodeCostSAsm.lean` verifies `init_code_cost` byte-identically with a
+  writable dword post (`a0 = 0`, output `= gasPerWord * ((len + 31) >> 5)`
+  under exact RV64 wrapping semantics).
   Byte-reverse copies (`whileS`, runtime length, read-only src + writable dst):
   `SwrRevLeBeSAsm.lean` (`swrRevLeBeFn_spec`, `dst = (src[0..len)).reverse`,
   byte-identity fully pinned to `swrRevLeBe_prog`; pre REQUIRES src/dst

--- a/PLAN.md
+++ b/PLAN.md
@@ -367,6 +367,9 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   (isCold ? 2600 : 100) + (valueNonzero ? 9000 : 0)`) pinned to
   `callExtraGas_prog`, after converting the raw asm string to a `Program`
   rendered by `emitProgram`.
+  `LogDataGasSAsm.lean` verifies `log_data_gas` as a byte-identical
+  straight-line leaf (`logDataGasFn_spec`, post `a0 = topics * 375 + 375 +
+  dataBytes * 8` with exact RV64 wrapping semantics).
   Byte-reverse copies (`whileS`, runtime length, read-only src + writable dst):
   `SwrRevLeBeSAsm.lean` (`swrRevLeBeFn_spec`, `dst = (src[0..len)).reverse`,
   byte-identity fully pinned to `swrRevLeBe_prog`; pre REQUIRES src/dst

--- a/PLAN.md
+++ b/PLAN.md
@@ -367,6 +367,9 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   (isCold ? 2600 : 100) + (valueNonzero ? 9000 : 0)`) pinned to
   `callExtraGas_prog`, after converting the raw asm string to a `Program`
   rendered by `emitProgram`.
+  `Keccak256WordGasSAsm.lean` verifies `keccak256_word_gas` as a byte-identical
+  straight-line leaf (`keccak256WordGasFn_spec`, post `a0 =
+  (((size + 31) >> 5) * 6) + 30` with exact RV64 wrapping semantics).
   Byte-reverse copies (`whileS`, runtime length, read-only src + writable dst):
   `SwrRevLeBeSAsm.lean` (`swrRevLeBeFn_spec`, `dst = (src[0..len)).reverse`,
   byte-identity fully pinned to `swrRevLeBe_prog`; pre REQUIRES src/dst


### PR DESCRIPTION
Batch-merge of #10122 #10123 #10124 #10125 (all author pirapira, the copy_word_gas / keccak256_word_gas / log_data_gas / init_code_cost SAsm gas-cost leaf ports).

Verified locally: `lake build` (full, after every merge step) + all `scripts/check-*.sh` green, including `check-region-map.sh` (ELF-measured layout check).

All four merges were straightforward import-line-append conflicts in `EvmAsm/Codegen/Programs/Imports.lean` plus independent PLAN.md journal paragraphs — kept both sides / merged the paragraphs.