### PR TITLE
Batch-merge #10127 #10129 #10131 #10132 #10133 #10135 (pirapira)

### DIFF
--- a/EvmAsm/Codegen/Programs/DispatcherCaptureExecStateGasSAsm.lean
+++ b/EvmAsm/Codegen/Programs/DispatcherCaptureExecStateGasSAsm.lean
@@ -1,0 +1,163 @@
+/- Byte-identical linked-entry verification of `dispatcher_capture_exec_state_gas`. -/
+
+import EvmAsm.Codegen.Programs.DispatcherExecStateGas
+import EvmAsm.Rv64.LaResolve
+import EvmAsm.Rv64.SAsm.FramePort
+import EvmAsm.Evm64.CallingConvention
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+
+namespace DispatcherCaptureExecStateGasSAsm
+
+#guard GuestAddrs.dispatcher_capture_exec_state_gas = 0x80029fb8
+#guard GuestAddrs.evm_state_gas_used = 0xbb56a710
+#guard GuestAddrs.bvgr_tx_exec_state_gas = 0xaa25dbc8
+
+def captureBody : List Instr := dispatcherCaptureExecStateGas_prog.dropLast
+
+theorem capture_byte_tie :
+    captureBody ++ [.JALR .x0 .x1 (0 : BitVec 12)] =
+      dispatcherCaptureExecStateGas_prog := by
+  rfl
+
+def captureCr : CodeReq :=
+  CodeReq.ofProg (GuestAddrs.dispatcher_capture_exec_state_gas : Word)
+    dispatcherCaptureExecStateGas_prog
+
+private theorem add_zero_word (x : Word) : x + (0 : Word) = x := by
+  simp
+
+/-- Read the global executed-state-gas counter and store it in the caller's
+    transaction-indexed result cell. The source global is preserved. -/
+theorem dispatcherCaptureExecStateGas_spec
+    (index old5 old6 old7 gas oldDst retAddr : Word)
+    (halign : (retAddr &&& ~~~(1 : Word)) = retAddr) :
+    let ofs := index <<< 3
+    let dst := (GuestAddrs.bvgr_tx_exec_state_gas : Word) + ofs
+    cpsTripleWithin 9 (GuestAddrs.dispatcher_capture_exec_state_gas : Word)
+      retAddr captureCr
+      (((.x5 : Reg) ↦ᵣ old5) ** ((.x6 : Reg) ↦ᵣ old6) **
+        ((.x7 : Reg) ↦ᵣ old7) ** ((.x10 : Reg) ↦ᵣ index) **
+        ((.x1 : Reg) ↦ᵣ retAddr) **
+        ((GuestAddrs.evm_state_gas_used : Word) ↦ₘ gas) ** (dst ↦ₘ oldDst))
+      (((.x5 : Reg) ↦ᵣ gas) ** ((.x6 : Reg) ↦ᵣ dst) **
+        ((.x7 : Reg) ↦ᵣ ofs) ** ((.x10 : Reg) ↦ᵣ index) **
+        ((.x1 : Reg) ↦ᵣ retAddr) **
+        ((GuestAddrs.evm_state_gas_used : Word) ↦ₘ gas) ** (dst ↦ₘ gas)) := by
+  dsimp only
+  let ofs := index <<< 3
+  let dst := (GuestAddrs.bvgr_tx_exec_state_gas : Word) + ofs
+
+  have hla5 := la_materialize_within .x5 old5
+    (GuestAddrs.dispatcher_capture_exec_state_gas : Word)
+    (GuestAddrs.evm_state_gas_used : Word)
+    (cr := captureCr) (by decide) (by decide)
+    (by unfold captureCr; code_mem) (by unfold captureCr; code_mem)
+  rw [show (GuestAddrs.dispatcher_capture_exec_state_gas : Word) + 8 =
+      (GuestAddrs.dispatcher_capture_exec_state_gas + 8 : Word) from by decide] at hla5
+  have hla5F := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ old6) ** ((.x7 : Reg) ↦ᵣ old7) **
+      ((.x10 : Reg) ↦ᵣ index) ** ((.x1 : Reg) ↦ᵣ retAddr) **
+      ((GuestAddrs.evm_state_gas_used : Word) ↦ₘ gas) ** (dst ↦ₘ oldDst))
+    (by pcf) hla5
+
+  have hld0 := ld_spec_gen_same_within .x5
+    (GuestAddrs.evm_state_gas_used : Word)
+    gas 0
+    (GuestAddrs.dispatcher_capture_exec_state_gas + 8 : Word) (by decide)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show (GuestAddrs.dispatcher_capture_exec_state_gas + 8 : Word) + 4 =
+      (GuestAddrs.dispatcher_capture_exec_state_gas + 12 : Word) from by decide] at hld0
+  rw [add_zero_word] at hld0
+  have hld := liftCode (cr' := captureCr) hld0
+    (by unfold captureCr; code_mem)
+  have hldF := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ old6) ** ((.x7 : Reg) ↦ᵣ old7) **
+      ((.x10 : Reg) ↦ᵣ index) ** ((.x1 : Reg) ↦ᵣ retAddr) **
+      (dst ↦ₘ oldDst)) (by pcf) hld
+
+  have hla6 := la_materialize_within .x6 old6
+    (GuestAddrs.dispatcher_capture_exec_state_gas + 12 : Word)
+    (GuestAddrs.bvgr_tx_exec_state_gas : Word)
+    (cr := captureCr) (by decide) (by decide)
+    (by unfold captureCr; code_mem) (by unfold captureCr; code_mem)
+  rw [show (GuestAddrs.dispatcher_capture_exec_state_gas + 12 : Word) + 8 =
+      (GuestAddrs.dispatcher_capture_exec_state_gas + 20 : Word) from by decide] at hla6
+  have hla6F := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ gas) ** ((.x7 : Reg) ↦ᵣ old7) **
+      ((.x10 : Reg) ↦ᵣ index) ** ((.x1 : Reg) ↦ᵣ retAddr) **
+      ((GuestAddrs.evm_state_gas_used : Word) ↦ₘ gas) ** (dst ↦ₘ oldDst))
+    (by pcf) hla6
+
+  have hshift0 := slli_spec_gen_within .x7 .x10 old7 index (3 : BitVec 6)
+    (GuestAddrs.dispatcher_capture_exec_state_gas + 20 : Word) (by decide)
+  rw [show (3 : BitVec 6).toNat = 3 from by decide,
+    show (GuestAddrs.dispatcher_capture_exec_state_gas + 20 : Word) + 4 =
+      (GuestAddrs.dispatcher_capture_exec_state_gas + 24 : Word) from by decide] at hshift0
+  have hshift := liftCode (cr' := captureCr) hshift0
+    (by unfold captureCr; code_mem)
+  have hshiftF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ gas) **
+      ((.x6 : Reg) ↦ᵣ (GuestAddrs.bvgr_tx_exec_state_gas : Word)) **
+      ((.x1 : Reg) ↦ᵣ retAddr) **
+      ((GuestAddrs.evm_state_gas_used : Word) ↦ₘ gas) ** (dst ↦ₘ oldDst))
+    (by pcf) hshift
+
+  have hadd0 := add_spec_gen_rd_eq_rs1_within .x6 .x7
+    (GuestAddrs.bvgr_tx_exec_state_gas : Word) ofs
+    (GuestAddrs.dispatcher_capture_exec_state_gas + 24 : Word) (by decide)
+  rw [show (GuestAddrs.dispatcher_capture_exec_state_gas + 24 : Word) + 4 =
+      (GuestAddrs.dispatcher_capture_exec_state_gas + 28 : Word) from by decide] at hadd0
+  have hadd := liftCode (cr' := captureCr) hadd0
+    (by unfold captureCr; code_mem)
+  have haddF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ gas) ** ((.x10 : Reg) ↦ᵣ index) **
+      ((.x1 : Reg) ↦ᵣ retAddr) **
+      ((GuestAddrs.evm_state_gas_used : Word) ↦ₘ gas) ** (dst ↦ₘ oldDst))
+    (by pcf) hadd
+
+  have hsd0 := sd_spec_gen_within .x6 .x5 dst gas oldDst 0
+    (GuestAddrs.dispatcher_capture_exec_state_gas + 28 : Word)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show (GuestAddrs.dispatcher_capture_exec_state_gas + 28 : Word) + 4 =
+      (GuestAddrs.dispatcher_capture_exec_state_gas + 32 : Word) from by decide] at hsd0
+  rw [add_zero_word] at hsd0
+  have hsd := liftCode (cr' := captureCr) hsd0
+    (by unfold captureCr; code_mem)
+  have hsdF := cpsTripleWithin_frameR
+    (((.x7 : Reg) ↦ᵣ ofs) ** ((.x10 : Reg) ↦ᵣ index) **
+      ((.x1 : Reg) ↦ᵣ retAddr) **
+      ((GuestAddrs.evm_state_gas_used : Word) ↦ₘ gas)) (by pcf) hsd
+
+  have hret0 := EvmAsm.Evm64.ret_spec_within'
+    (GuestAddrs.dispatcher_capture_exec_state_gas + 32 : Word) retAddr
+  rw [halign] at hret0
+  have hret := liftCode (cr' := captureCr) hret0
+    (by unfold captureCr; code_mem)
+  have hretF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ gas) ** ((.x6 : Reg) ↦ᵣ dst) **
+      ((.x7 : Reg) ↦ᵣ ofs) ** ((.x10 : Reg) ↦ᵣ index) **
+      ((GuestAddrs.evm_state_gas_used : Word) ↦ₘ gas) ** (dst ↦ₘ gas))
+    (by pcf) hret
+
+  have h12 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hla5F hldF
+  have h123 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) h12 hla6F
+  have h1234 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) h123 hshiftF
+  have h12345 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) h1234 haddF
+  have h123456 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) h12345 hsdF
+  have hall := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) h123456 hretF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hall
+
+#print axioms dispatcherCaptureExecStateGas_spec
+
+end DispatcherCaptureExecStateGasSAsm
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/FrameDepthPopSAsm.lean
+++ b/EvmAsm/Codegen/Programs/FrameDepthPopSAsm.lean
@@ -1,0 +1,95 @@
+/- Byte-identical linked-PC verification of `frame_depth_pop`. -/
+
+import EvmAsm.Codegen.Programs.CallFrameSwitch
+import EvmAsm.Rv64.LaResolve
+import EvmAsm.Rv64.SAsm.FramePort
+import EvmAsm.Evm64.CallingConvention
+
+namespace EvmAsm.Codegen
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+namespace FrameDepthPopSAsm
+
+#guard GuestAddrs.frame_depth_pop = 0x80038304
+#guard GuestAddrs.evm_call_depth = 0xbc2bd580
+
+def frameDepthPopBody : List Instr :=
+  [ .AUIPC .x5 (laHi GuestAddrs.evm_call_depth GuestAddrs.frame_depth_pop),
+    .ADDI .x5 .x5 (laLo GuestAddrs.evm_call_depth GuestAddrs.frame_depth_pop),
+    .LD .x10 .x5 (0 : BitVec 12), .ADDI .x10 .x10 (-1 : BitVec 12),
+    .SD .x5 .x10 (0 : BitVec 12) ]
+
+theorem frameDepthPop_byte_tie :
+    frameDepthPopBody ++ [.JALR .x0 .x1 (0 : BitVec 12)] = frameDepthPop_prog := by rfl
+
+def frameDepthPopCr : CodeReq :=
+  CodeReq.ofProg (GuestAddrs.frame_depth_pop : Word) frameDepthPop_prog
+
+theorem frameDepthPop_spec (depth old5 old10 ret : Word)
+    (halign : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin 6 (GuestAddrs.frame_depth_pop : Word) ret frameDepthPopCr
+      (((.x5 : Reg) ↦ᵣ old5) ** ((.x10 : Reg) ↦ᵣ old10) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((GuestAddrs.evm_call_depth : Word) ↦ₘ depth))
+      (((.x5 : Reg) ↦ᵣ (GuestAddrs.evm_call_depth : Word)) **
+        ((.x10 : Reg) ↦ᵣ (depth - 1)) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((GuestAddrs.evm_call_depth : Word) ↦ₘ (depth - 1))) := by
+  have hla := la_materialize_within .x5 old5
+    (GuestAddrs.frame_depth_pop : Word) (GuestAddrs.evm_call_depth : Word)
+    (cr := frameDepthPopCr) (by decide) (by decide)
+    (by unfold frameDepthPopCr; code_mem) (by unfold frameDepthPopCr; code_mem)
+  rw [show (GuestAddrs.frame_depth_pop : Word) + 8 =
+      (GuestAddrs.frame_depth_pop + 8 : Word) from by decide] at hla
+  have hlaF := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ old10) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((GuestAddrs.evm_call_depth : Word) ↦ₘ depth)) (by pcf) hla
+  have hld0 := ld_spec_gen_within .x10 .x5
+    (GuestAddrs.evm_call_depth : Word) old10 depth 0
+    (GuestAddrs.frame_depth_pop + 8 : Word) (by decide)
+  rw [show (GuestAddrs.evm_call_depth : Word) + signExtend12 (0 : BitVec 12) =
+      (GuestAddrs.evm_call_depth : Word) from by decide,
+    show (GuestAddrs.frame_depth_pop + 8 : Word) + 4 =
+      (GuestAddrs.frame_depth_pop + 12 : Word) from by decide] at hld0
+  have hld := liftCode (cr' := frameDepthPopCr) hld0
+    (by unfold frameDepthPopCr; code_mem)
+  have hldF := cpsTripleWithin_frameR (((.x1 : Reg) ↦ᵣ ret)) (by pcf) hld
+  have hadd0 := addi_spec_gen_same_within .x10 depth (-1 : BitVec 12)
+    (GuestAddrs.frame_depth_pop + 12 : Word) (by decide)
+  rw [show depth + signExtend12 (-1 : BitVec 12) = depth - 1 from by
+      rw [show signExtend12 (-1 : BitVec 12) = (-1 : Word) from by decide]
+      bv_omega,
+    show (GuestAddrs.frame_depth_pop + 12 : Word) + 4 =
+      (GuestAddrs.frame_depth_pop + 16 : Word) from by decide] at hadd0
+  have hadd := liftCode (cr' := frameDepthPopCr) hadd0
+    (by unfold frameDepthPopCr; code_mem)
+  have haddF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (GuestAddrs.evm_call_depth : Word)) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((GuestAddrs.evm_call_depth : Word) ↦ₘ depth))
+    (by pcf) hadd
+  have hsd0 := sd_spec_gen_within .x5 .x10
+    (GuestAddrs.evm_call_depth : Word) (depth - 1) depth 0
+    (GuestAddrs.frame_depth_pop + 16 : Word)
+  rw [show (GuestAddrs.evm_call_depth : Word) + signExtend12 (0 : BitVec 12) =
+      (GuestAddrs.evm_call_depth : Word) from by decide,
+    show (GuestAddrs.frame_depth_pop + 16 : Word) + 4 =
+      (GuestAddrs.frame_depth_pop + 20 : Word) from by decide] at hsd0
+  have hsd := liftCode (cr' := frameDepthPopCr) hsd0
+    (by unfold frameDepthPopCr; code_mem)
+  have hsdF := cpsTripleWithin_frameR (((.x1 : Reg) ↦ᵣ ret)) (by pcf) hsd
+  have hret0 := EvmAsm.Evm64.ret_spec_within'
+    (GuestAddrs.frame_depth_pop + 20 : Word) ret
+  rw [halign] at hret0
+  have hret := liftCode (cr' := frameDepthPopCr) hret0
+    (by unfold frameDepthPopCr; code_mem)
+  have hretF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (GuestAddrs.evm_call_depth : Word)) **
+      ((.x10 : Reg) ↦ᵣ (depth - 1)) **
+      ((GuestAddrs.evm_call_depth : Word) ↦ₘ (depth - 1))) (by pcf) hret
+  have h12 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hlaF hldF
+  have h123 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h12 haddF
+  have h1234 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h123 hsdF
+  have h12345 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h1234 hretF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) h12345
+
+#print axioms frameDepthPop_spec
+end FrameDepthPopSAsm
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/FrameDepthPushSAsm.lean
+++ b/EvmAsm/Codegen/Programs/FrameDepthPushSAsm.lean
@@ -1,0 +1,93 @@
+/- Byte-identical linked-PC verification of `frame_depth_push`. -/
+
+import EvmAsm.Codegen.Programs.CallFrameSwitch
+import EvmAsm.Rv64.LaResolve
+import EvmAsm.Rv64.SAsm.FramePort
+import EvmAsm.Evm64.CallingConvention
+
+namespace EvmAsm.Codegen
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+namespace FrameDepthPushSAsm
+
+#guard GuestAddrs.frame_depth_push = 0x800382ec
+#guard GuestAddrs.evm_call_depth = 0xbc2bd580
+
+def frameDepthPushBody : List Instr :=
+  [ .AUIPC .x5 (laHi GuestAddrs.evm_call_depth GuestAddrs.frame_depth_push),
+    .ADDI .x5 .x5 (laLo GuestAddrs.evm_call_depth GuestAddrs.frame_depth_push),
+    .LD .x10 .x5 (0 : BitVec 12), .ADDI .x10 .x10 (1 : BitVec 12),
+    .SD .x5 .x10 (0 : BitVec 12) ]
+
+theorem frameDepthPush_byte_tie :
+    frameDepthPushBody ++ [.JALR .x0 .x1 (0 : BitVec 12)] = frameDepthPush_prog := by rfl
+
+def frameDepthPushCr : CodeReq :=
+  CodeReq.ofProg (GuestAddrs.frame_depth_push : Word) frameDepthPush_prog
+
+theorem frameDepthPush_spec (depth old5 old10 ret : Word)
+    (halign : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin 6 (GuestAddrs.frame_depth_push : Word) ret frameDepthPushCr
+      (((.x5 : Reg) ↦ᵣ old5) ** ((.x10 : Reg) ↦ᵣ old10) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((GuestAddrs.evm_call_depth : Word) ↦ₘ depth))
+      (((.x5 : Reg) ↦ᵣ (GuestAddrs.evm_call_depth : Word)) **
+        ((.x10 : Reg) ↦ᵣ (depth + 1)) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((GuestAddrs.evm_call_depth : Word) ↦ₘ (depth + 1))) := by
+  have hla := la_materialize_within .x5 old5
+    (GuestAddrs.frame_depth_push : Word) (GuestAddrs.evm_call_depth : Word)
+    (cr := frameDepthPushCr) (by decide) (by decide)
+    (by unfold frameDepthPushCr; code_mem) (by unfold frameDepthPushCr; code_mem)
+  rw [show (GuestAddrs.frame_depth_push : Word) + 8 =
+      (GuestAddrs.frame_depth_push + 8 : Word) from by decide] at hla
+  have hlaF := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ old10) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((GuestAddrs.evm_call_depth : Word) ↦ₘ depth)) (by pcf) hla
+  have hld0 := ld_spec_gen_within .x10 .x5
+    (GuestAddrs.evm_call_depth : Word) old10 depth 0
+    (GuestAddrs.frame_depth_push + 8 : Word) (by decide)
+  rw [show (GuestAddrs.evm_call_depth : Word) + signExtend12 (0 : BitVec 12) =
+      (GuestAddrs.evm_call_depth : Word) from by decide,
+    show (GuestAddrs.frame_depth_push + 8 : Word) + 4 =
+      (GuestAddrs.frame_depth_push + 12 : Word) from by decide] at hld0
+  have hld := liftCode (cr' := frameDepthPushCr) hld0
+    (by unfold frameDepthPushCr; code_mem)
+  have hldF := cpsTripleWithin_frameR (((.x1 : Reg) ↦ᵣ ret)) (by pcf) hld
+  have hadd0 := addi_spec_gen_same_within .x10 depth 1
+    (GuestAddrs.frame_depth_push + 12 : Word) (by decide)
+  rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide,
+    show (GuestAddrs.frame_depth_push + 12 : Word) + 4 =
+      (GuestAddrs.frame_depth_push + 16 : Word) from by decide] at hadd0
+  have hadd := liftCode (cr' := frameDepthPushCr) hadd0
+    (by unfold frameDepthPushCr; code_mem)
+  have haddF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (GuestAddrs.evm_call_depth : Word)) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((GuestAddrs.evm_call_depth : Word) ↦ₘ depth))
+    (by pcf) hadd
+  have hsd0 := sd_spec_gen_within .x5 .x10
+    (GuestAddrs.evm_call_depth : Word) (depth + 1) depth 0
+    (GuestAddrs.frame_depth_push + 16 : Word)
+  rw [show (GuestAddrs.evm_call_depth : Word) + signExtend12 (0 : BitVec 12) =
+      (GuestAddrs.evm_call_depth : Word) from by decide,
+    show (GuestAddrs.frame_depth_push + 16 : Word) + 4 =
+      (GuestAddrs.frame_depth_push + 20 : Word) from by decide] at hsd0
+  have hsd := liftCode (cr' := frameDepthPushCr) hsd0
+    (by unfold frameDepthPushCr; code_mem)
+  have hsdF := cpsTripleWithin_frameR (((.x1 : Reg) ↦ᵣ ret)) (by pcf) hsd
+  have hret0 := EvmAsm.Evm64.ret_spec_within'
+    (GuestAddrs.frame_depth_push + 20 : Word) ret
+  rw [halign] at hret0
+  have hret := liftCode (cr' := frameDepthPushCr) hret0
+    (by unfold frameDepthPushCr; code_mem)
+  have hretF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (GuestAddrs.evm_call_depth : Word)) **
+      ((.x10 : Reg) ↦ᵣ (depth + 1)) **
+      ((GuestAddrs.evm_call_depth : Word) ↦ₘ (depth + 1))) (by pcf) hret
+  have h12 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hlaF hldF
+  have h123 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h12 haddF
+  have h1234 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h123 hsdF
+  have h12345 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h1234 hretF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) h12345
+
+#print axioms frameDepthPush_spec
+end FrameDepthPushSAsm
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/FrameLoadRegsSAsm.lean
+++ b/EvmAsm/Codegen/Programs/FrameLoadRegsSAsm.lean
@@ -1,0 +1,112 @@
+/- Byte-identical linked-PC verification of `frame_load_regs`. -/
+
+import EvmAsm.Codegen.Programs.CallFrameSwitch
+import EvmAsm.Rv64.LaResolve
+import EvmAsm.Rv64.SAsm.FramePort
+import EvmAsm.Evm64.CallingConvention
+
+namespace EvmAsm.Codegen
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+namespace FrameLoadRegsSAsm
+
+#guard GuestAddrs.frame_load_regs = 0x80038338
+#guard GuestAddrs.frame_save_area = 0xbc2bd590
+
+def frameLoadRegsBody : List Instr := frameLoadRegs_prog.dropLast
+
+theorem frameLoadRegs_byte_tie :
+    frameLoadRegsBody ++ [.JALR .x0 .x1 (0 : BitVec 12)] = frameLoadRegs_prog := by rfl
+
+def frameLoadRegsCr : CodeReq :=
+  CodeReq.ofProg (GuestAddrs.frame_load_regs : Word) frameLoadRegs_prog
+
+/-- Load the saved PC and code-base from `frame_save_area + depth * 16` into
+    `a0` and `a1`, preserving both global dwords. -/
+theorem frameLoadRegs_spec (depth old5 old6 old11 pcVal codeBase ret : Word)
+    (halign : (ret &&& ~~~(1 : Word)) = ret) :
+    let ofs := depth <<< 4
+    let slot := (GuestAddrs.frame_save_area : Word) + ofs
+    cpsTripleWithin 7 (GuestAddrs.frame_load_regs : Word) ret frameLoadRegsCr
+      (((.x5 : Reg) ↦ᵣ old5) ** ((.x6 : Reg) ↦ᵣ old6) **
+        ((.x10 : Reg) ↦ᵣ depth) ** ((.x11 : Reg) ↦ᵣ old11) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((slot + 0) ↦ₘ pcVal) **
+        ((slot + 8) ↦ₘ codeBase))
+      (((.x5 : Reg) ↦ᵣ slot) ** ((.x6 : Reg) ↦ᵣ ofs) **
+        ((.x10 : Reg) ↦ᵣ pcVal) ** ((.x11 : Reg) ↦ᵣ codeBase) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((slot + 0) ↦ₘ pcVal) **
+        ((slot + 8) ↦ₘ codeBase)) := by
+  dsimp only
+  let ofs := depth <<< 4
+  let slot := (GuestAddrs.frame_save_area : Word) + ofs
+  have hla := la_materialize_within .x5 old5
+    (GuestAddrs.frame_load_regs : Word) (GuestAddrs.frame_save_area : Word)
+    (cr := frameLoadRegsCr) (by decide) (by decide)
+    (by unfold frameLoadRegsCr; code_mem) (by unfold frameLoadRegsCr; code_mem)
+  rw [show (GuestAddrs.frame_load_regs : Word) + 8 =
+      (GuestAddrs.frame_load_regs + 8 : Word) from by decide] at hla
+  have hlaF := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ old6) ** ((.x10 : Reg) ↦ᵣ depth) **
+      ((.x11 : Reg) ↦ᵣ old11) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((slot + 0) ↦ₘ pcVal) ** ((slot + 8) ↦ₘ codeBase)) (by pcf) hla
+  have hshift0 := slli_spec_gen_within .x6 .x10 old6 depth (4 : BitVec 6)
+    (GuestAddrs.frame_load_regs + 8 : Word) (by decide)
+  rw [show (4 : BitVec 6).toNat = 4 from by decide,
+    show (GuestAddrs.frame_load_regs + 8 : Word) + 4 =
+      (GuestAddrs.frame_load_regs + 12 : Word) from by decide] at hshift0
+  have hshift := liftCode (cr' := frameLoadRegsCr) hshift0
+    (by unfold frameLoadRegsCr; code_mem)
+  have hshiftF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (GuestAddrs.frame_save_area : Word)) **
+      ((.x11 : Reg) ↦ᵣ old11) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((slot + 0) ↦ₘ pcVal) ** ((slot + 8) ↦ₘ codeBase)) (by pcf) hshift
+  have hadd0 := add_spec_gen_rd_eq_rs1_within .x5 .x6
+    (GuestAddrs.frame_save_area : Word) ofs
+    (GuestAddrs.frame_load_regs + 12 : Word) (by decide)
+  rw [show (GuestAddrs.frame_load_regs + 12 : Word) + 4 =
+      (GuestAddrs.frame_load_regs + 16 : Word) from by decide] at hadd0
+  have hadd := liftCode (cr' := frameLoadRegsCr) hadd0
+    (by unfold frameLoadRegsCr; code_mem)
+  have haddF := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ depth) ** ((.x11 : Reg) ↦ᵣ old11) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((slot + 0) ↦ₘ pcVal) **
+      ((slot + 8) ↦ₘ codeBase)) (by pcf) hadd
+  have hld0 := ld_spec_gen_within .x10 .x5 slot depth pcVal 0
+    (GuestAddrs.frame_load_regs + 16 : Word) (by decide)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show (GuestAddrs.frame_load_regs + 16 : Word) + 4 =
+      (GuestAddrs.frame_load_regs + 20 : Word) from by decide] at hld0
+  have hld := liftCode (cr' := frameLoadRegsCr) hld0
+    (by unfold frameLoadRegsCr; code_mem)
+  have hldF := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ ofs) ** ((.x11 : Reg) ↦ᵣ old11) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((slot + 8) ↦ₘ codeBase)) (by pcf) hld
+  have hld8_0 := ld_spec_gen_within .x11 .x5 slot old11 codeBase 8
+    (GuestAddrs.frame_load_regs + 20 : Word) (by decide)
+  rw [show signExtend12 (8 : BitVec 12) = (8 : Word) from by decide,
+    show (GuestAddrs.frame_load_regs + 20 : Word) + 4 =
+      (GuestAddrs.frame_load_regs + 24 : Word) from by decide] at hld8_0
+  have hld8 := liftCode (cr' := frameLoadRegsCr) hld8_0
+    (by unfold frameLoadRegsCr; code_mem)
+  have hld8F := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ ofs) ** ((.x10 : Reg) ↦ᵣ pcVal) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((slot + 0) ↦ₘ pcVal)) (by pcf) hld8
+  have hret0 := EvmAsm.Evm64.ret_spec_within'
+    (GuestAddrs.frame_load_regs + 24 : Word) ret
+  rw [halign] at hret0
+  have hret := liftCode (cr' := frameLoadRegsCr) hret0
+    (by unfold frameLoadRegsCr; code_mem)
+  have hretF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ slot) ** ((.x6 : Reg) ↦ᵣ ofs) **
+      ((.x10 : Reg) ↦ᵣ pcVal) ** ((.x11 : Reg) ↦ᵣ codeBase) **
+      ((slot + 0) ↦ₘ pcVal) ** ((slot + 8) ↦ₘ codeBase)) (by pcf) hret
+  have h12 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hlaF hshiftF
+  have h123 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h12 haddF
+  have h1234 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h123 hldF
+  have h12345 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h1234 hld8F
+  have hall := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h12345 hretF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hall
+
+#print axioms frameLoadRegs_spec
+end FrameLoadRegsSAsm
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/FrameSaveRegsSAsm.lean
+++ b/EvmAsm/Codegen/Programs/FrameSaveRegsSAsm.lean
@@ -1,0 +1,117 @@
+/- Byte-identical linked-PC verification of `frame_save_regs`. -/
+
+import EvmAsm.Codegen.Programs.CallFrameSwitch
+import EvmAsm.Rv64.LaResolve
+import EvmAsm.Rv64.SAsm.FramePort
+import EvmAsm.Evm64.CallingConvention
+
+namespace EvmAsm.Codegen
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+namespace FrameSaveRegsSAsm
+
+#guard GuestAddrs.frame_save_regs = 0x8003831c
+#guard GuestAddrs.frame_save_area = 0xbc2bd590
+
+def frameSaveRegsBody : List Instr := frameSaveRegs_prog.dropLast
+
+theorem frameSaveRegs_byte_tie :
+    frameSaveRegsBody ++ [.JALR .x0 .x1 (0 : BitVec 12)] = frameSaveRegs_prog := by rfl
+
+def frameSaveRegsCr : CodeReq :=
+  CodeReq.ofProg (GuestAddrs.frame_save_regs : Word) frameSaveRegs_prog
+
+/-- Save `pcVal` and `codeBase` in the two dwords at
+    `frame_save_area + depth * 16`, preserving exact RV64 address arithmetic. -/
+theorem frameSaveRegs_spec (depth pcVal codeBase old5 old6 oldPc oldCode ret : Word)
+    (halign : (ret &&& ~~~(1 : Word)) = ret) :
+    let ofs := depth <<< 4
+    let slot := (GuestAddrs.frame_save_area : Word) + ofs
+    cpsTripleWithin 7 (GuestAddrs.frame_save_regs : Word) ret frameSaveRegsCr
+      (((.x5 : Reg) ↦ᵣ old5) ** ((.x6 : Reg) ↦ᵣ old6) **
+        ((.x10 : Reg) ↦ᵣ depth) ** ((.x11 : Reg) ↦ᵣ pcVal) **
+        ((.x12 : Reg) ↦ᵣ codeBase) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((slot + 0) ↦ₘ oldPc) ** ((slot + 8) ↦ₘ oldCode))
+      (((.x5 : Reg) ↦ᵣ slot) ** ((.x6 : Reg) ↦ᵣ ofs) **
+        ((.x10 : Reg) ↦ᵣ depth) ** ((.x11 : Reg) ↦ᵣ pcVal) **
+        ((.x12 : Reg) ↦ᵣ codeBase) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((slot + 0) ↦ₘ pcVal) ** ((slot + 8) ↦ₘ codeBase)) := by
+  dsimp only
+  let ofs := depth <<< 4
+  let slot := (GuestAddrs.frame_save_area : Word) + ofs
+  have hla := la_materialize_within .x5 old5
+    (GuestAddrs.frame_save_regs : Word) (GuestAddrs.frame_save_area : Word)
+    (cr := frameSaveRegsCr) (by decide) (by decide)
+    (by unfold frameSaveRegsCr; code_mem) (by unfold frameSaveRegsCr; code_mem)
+  rw [show (GuestAddrs.frame_save_regs : Word) + 8 =
+      (GuestAddrs.frame_save_regs + 8 : Word) from by decide] at hla
+  have hlaF := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ old6) ** ((.x10 : Reg) ↦ᵣ depth) **
+      ((.x11 : Reg) ↦ᵣ pcVal) ** ((.x12 : Reg) ↦ᵣ codeBase) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((slot + 0) ↦ₘ oldPc) ** ((slot + 8) ↦ₘ oldCode))
+    (by pcf) hla
+  have hshift0 := slli_spec_gen_within .x6 .x10 old6 depth (4 : BitVec 6)
+    (GuestAddrs.frame_save_regs + 8 : Word) (by decide)
+  rw [show (4 : BitVec 6).toNat = 4 from by decide,
+    show (GuestAddrs.frame_save_regs + 8 : Word) + 4 =
+      (GuestAddrs.frame_save_regs + 12 : Word) from by decide] at hshift0
+  have hshift := liftCode (cr' := frameSaveRegsCr) hshift0
+    (by unfold frameSaveRegsCr; code_mem)
+  have hshiftF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (GuestAddrs.frame_save_area : Word)) **
+      ((.x11 : Reg) ↦ᵣ pcVal) ** ((.x12 : Reg) ↦ᵣ codeBase) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((slot + 0) ↦ₘ oldPc) ** ((slot + 8) ↦ₘ oldCode))
+    (by pcf) hshift
+  have hadd0 := add_spec_gen_rd_eq_rs1_within .x5 .x6
+    (GuestAddrs.frame_save_area : Word) ofs
+    (GuestAddrs.frame_save_regs + 12 : Word) (by decide)
+  rw [show (GuestAddrs.frame_save_regs + 12 : Word) + 4 =
+      (GuestAddrs.frame_save_regs + 16 : Word) from by decide] at hadd0
+  have hadd := liftCode (cr' := frameSaveRegsCr) hadd0
+    (by unfold frameSaveRegsCr; code_mem)
+  have haddF := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ depth) ** ((.x11 : Reg) ↦ᵣ pcVal) **
+      ((.x12 : Reg) ↦ᵣ codeBase) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((slot + 0) ↦ₘ oldPc) ** ((slot + 8) ↦ₘ oldCode)) (by pcf) hadd
+  have hsd0 := sd_spec_gen_within .x5 .x11 slot pcVal oldPc 0
+    (GuestAddrs.frame_save_regs + 16 : Word)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show (GuestAddrs.frame_save_regs + 16 : Word) + 4 =
+      (GuestAddrs.frame_save_regs + 20 : Word) from by decide] at hsd0
+  have hsd := liftCode (cr' := frameSaveRegsCr) hsd0
+    (by unfold frameSaveRegsCr; code_mem)
+  have hsdF := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ ofs) ** ((.x10 : Reg) ↦ᵣ depth) **
+      ((.x12 : Reg) ↦ᵣ codeBase) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((slot + 8) ↦ₘ oldCode)) (by pcf) hsd
+  have hsd8_0 := sd_spec_gen_within .x5 .x12 slot codeBase oldCode 8
+    (GuestAddrs.frame_save_regs + 20 : Word)
+  rw [show signExtend12 (8 : BitVec 12) = (8 : Word) from by decide,
+    show (GuestAddrs.frame_save_regs + 20 : Word) + 4 =
+      (GuestAddrs.frame_save_regs + 24 : Word) from by decide] at hsd8_0
+  have hsd8 := liftCode (cr' := frameSaveRegsCr) hsd8_0
+    (by unfold frameSaveRegsCr; code_mem)
+  have hsd8F := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ ofs) ** ((.x10 : Reg) ↦ᵣ depth) **
+      ((.x11 : Reg) ↦ᵣ pcVal) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((slot + 0) ↦ₘ pcVal)) (by pcf) hsd8
+  have hret0 := EvmAsm.Evm64.ret_spec_within'
+    (GuestAddrs.frame_save_regs + 24 : Word) ret
+  rw [halign] at hret0
+  have hret := liftCode (cr' := frameSaveRegsCr) hret0
+    (by unfold frameSaveRegsCr; code_mem)
+  have hretF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ slot) ** ((.x6 : Reg) ↦ᵣ ofs) **
+      ((.x10 : Reg) ↦ᵣ depth) ** ((.x11 : Reg) ↦ᵣ pcVal) **
+      ((.x12 : Reg) ↦ᵣ codeBase) ** ((slot + 0) ↦ₘ pcVal) **
+      ((slot + 8) ↦ₘ codeBase)) (by pcf) hret
+  have h12 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hlaF hshiftF
+  have h123 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h12 haddF
+  have h1234 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h123 hsdF
+  have h12345 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h1234 hsd8F
+  have hall := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h12345 hretF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hall
+
+#print axioms frameSaveRegs_spec
+end FrameSaveRegsSAsm
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -411,3 +411,4 @@ import EvmAsm.Codegen.Programs.HpEncodeNibblesSAsm
 import EvmAsm.Codegen.Programs.NibblesCommonPrefixLenSAsm
 import EvmAsm.Codegen.Programs.Secp256k1FieldSubModPSAsm
 import EvmAsm.Codegen.Programs.Secp256k1FieldReduceOnceNSAsm
+import EvmAsm.Codegen.Programs.MptResolveCacheResetSAsm

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -407,3 +407,4 @@ import EvmAsm.Codegen.Programs.ReceiptList
 import EvmAsm.Codegen.Programs.StatelessGuestUnit
 import EvmAsm.Codegen.Programs.RegistryNames
 import EvmAsm.Codegen.Programs.HpEncodeNibblesSAsm
+import EvmAsm.Codegen.Programs.FrameDepthPushSAsm

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -410,4 +410,5 @@ import EvmAsm.Codegen.Programs.RegistryNames
 import EvmAsm.Codegen.Programs.HpEncodeNibblesSAsm
 import EvmAsm.Codegen.Programs.NibblesCommonPrefixLenSAsm
 import EvmAsm.Codegen.Programs.Secp256k1FieldSubModPSAsm
+import EvmAsm.Codegen.Programs.FrameLoadRegsSAsm
 import EvmAsm.Codegen.Programs.Secp256k1FieldReduceOnceNSAsm

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -411,3 +411,4 @@ import EvmAsm.Codegen.Programs.HpEncodeNibblesSAsm
 import EvmAsm.Codegen.Programs.NibblesCommonPrefixLenSAsm
 import EvmAsm.Codegen.Programs.Secp256k1FieldSubModPSAsm
 import EvmAsm.Codegen.Programs.Secp256k1FieldReduceOnceNSAsm
+import EvmAsm.Codegen.Programs.DispatcherCaptureExecStateGasSAsm

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -410,4 +410,5 @@ import EvmAsm.Codegen.Programs.RegistryNames
 import EvmAsm.Codegen.Programs.HpEncodeNibblesSAsm
 import EvmAsm.Codegen.Programs.NibblesCommonPrefixLenSAsm
 import EvmAsm.Codegen.Programs.Secp256k1FieldSubModPSAsm
+import EvmAsm.Codegen.Programs.FrameSaveRegsSAsm
 import EvmAsm.Codegen.Programs.Secp256k1FieldReduceOnceNSAsm

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -407,3 +407,4 @@ import EvmAsm.Codegen.Programs.ReceiptList
 import EvmAsm.Codegen.Programs.StatelessGuestUnit
 import EvmAsm.Codegen.Programs.RegistryNames
 import EvmAsm.Codegen.Programs.HpEncodeNibblesSAsm
+import EvmAsm.Codegen.Programs.FrameDepthPopSAsm

--- a/EvmAsm/Codegen/Programs/MptResolveCacheResetSAsm.lean
+++ b/EvmAsm/Codegen/Programs/MptResolveCacheResetSAsm.lean
@@ -1,0 +1,340 @@
+/- Byte-identical SAsm verification of `mpt_resolve_cache_reset`. -/
+
+import EvmAsm.Rv64.SAsm.MultiDword
+import EvmAsm.Rv64.SAsm.Tactic
+import EvmAsm.Rv64.SAsm.FnFlat
+import EvmAsm.Rv64.SAsm.FramePort
+import EvmAsm.Rv64.LaResolve
+import EvmAsm.Codegen.Programs.MptSetAcc
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.SAsm.Stmt
+
+namespace MptResolveCacheResetSAsm
+
+#guard GuestAddrs.mpt_resolve_cache_reset = 0x800063d4
+#guard GuestAddrs.mset_res_cache_valid = 0xa3c672e0
+
+def zeroWindow (orig : List (BitVec 8)) (i : Nat) : List (BitVec 8) :=
+  List.replicate (8 * i) (0 : BitVec 8) ++ orig.drop (8 * i)
+
+theorem zeroWindow_zero (orig : List (BitVec 8)) : zeroWindow orig 0 = orig := by
+  simp [zeroWindow]
+
+theorem zeroWindow_done (orig : List (BitVec 8)) (h : orig.length = 32768) :
+    zeroWindow orig 4096 = List.replicate 32768 (0 : BitVec 8) := by
+  simp only [zeroWindow, Nat.reduceMul,
+    List.drop_eq_nil_of_le (by omega : orig.length ≤ 32768), List.append_nil]
+
+theorem length_zeroWindow (orig : List (BitVec 8)) (i : Nat)
+    (h : orig.length = 32768) (hi : i ≤ 4096) : (zeroWindow orig i).length = 32768 := by
+  simp only [zeroWindow, List.length_append, List.length_replicate, List.length_drop, h]
+  omega
+
+theorem zeroWindow_step (orig : List (BitVec 8)) (i : Nat)
+    (h : orig.length = 32768) (hi : i < 4096) :
+    setBytes (zeroWindow orig i) (8 * i) (dwordBytes (0 : Word)) =
+      zeroWindow orig (i + 1) := by
+  rw [zeroWindow]
+  rw [setBytes_append_right _ _ _ _ (by simp)]
+  simp only [List.length_replicate, Nat.sub_self]
+  have hsuf : (orig.drop (8 * i)).length = 32768 - 8 * i := by simp [h]
+  have hfit : 0 + (dwordBytes (0 : Word)).length ≤ (orig.drop (8 * i)).length := by
+    rw [length_dwordBytes, hsuf]
+    omega
+  have hslot := setBytes_slot (orig.drop (8 * i)) (dwordBytes (0 : Word)) 0 hfit
+  rw [List.drop_zero, length_dwordBytes] at hslot
+  have hdrop : (setBytes (orig.drop (8 * i)) 0 (dwordBytes (0 : Word))).drop 8 =
+      (orig.drop (8 * i)).drop 8 := by
+    simpa [length_dwordBytes] using
+      (setBytes_drop_of_le (dwordBytes (0 : Word)) (orig.drop (8 * i)) 0 8 (by
+        rw [length_dwordBytes]))
+  have hset : setBytes (List.drop (8 * i) orig) 0 (dwordBytes (0 : Word)) =
+      dwordBytes (0 : Word) ++ (List.drop (8 * i) orig).drop 8 := by
+    conv_lhs =>
+      rw [← List.take_append_drop 8
+        (setBytes (List.drop (8 * i) orig) 0 (dwordBytes 0))]
+    rw [hslot, hdrop]
+  rw [hset]
+  rw [show (List.drop (8 * i) orig).drop 8 = orig.drop (8 * (i + 1)) from by
+    rw [List.drop_drop]
+    congr 1]
+  rw [show dwordBytes (0 : Word) = List.replicate 8 (0 : BitVec 8) from by decide]
+  simp only [zeroWindow]
+  rw [← List.append_assoc]
+  congr 1
+  rw [List.replicate_append_replicate]
+  congr
+
+def zeroStepBlock : List Instr :=
+  [.SD .x5 .x0 (0 : BitVec 12),
+   .ADDI .x5 .x5 (8 : BitVec 12),
+   .ADDI .x6 .x6 (-1 : BitVec 12)]
+
+def zeroStepRf (rf : RegFile) : RegFile :=
+  let r1 := rf.set .x5 (rf.get .x5 + signExtend12 (8 : BitVec 12))
+  r1.set .x6 (r1.get .x6 + signExtend12 (-1 : BitVec 12))
+
+theorem zeroStepRf_get_x5 (rf : RegFile) :
+    (zeroStepRf rf).get .x5 = rf.get .x5 + signExtend12 (8 : BitVec 12) := by
+  unfold zeroStepRf
+  simp only [RegFile.get_set_self, RegFile.get_set_ne, ne_eq, reduceCtorEq,
+    not_false_eq_true]
+
+theorem zeroStepRf_get_x6 (rf : RegFile) :
+    (zeroStepRf rf).get .x6 = rf.get .x6 + signExtend12 (-1 : BitVec 12) := by
+  unfold zeroStepRf
+  simp only [RegFile.get_set_self, RegFile.get_set_ne, ne_eq, reduceCtorEq,
+    not_false_eq_true]
+
+theorem zero_engine (reg : Region) (dst : Word) (rf : RegFile)
+    (ws : List (BitVec 8)) (i : Nat) (hi : i < 4096)
+    (hx5 : rf.get .x5 = dst + BitVec.ofNat 64 (8 * i)) :
+    execBlock reg dst rf ws zeroStepBlock =
+      (zeroStepRf rf, setBytes ws (8 * i) (dwordBytes (0 : Word))) := by
+  have haddr : (rf.get .x5 + signExtend12 (0 : BitVec 12) - dst).toNat = 8 * i := by
+    rw [hx5, show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]
+    bv_omega
+  apply Prod.ext
+  · rfl
+  · show setBytes ws ((rf.get .x5 + signExtend12 (0 : BitVec 12) - dst).toNat)
+        (dwordBytes (rf.get .x0)) = setBytes ws (8 * i) (dwordBytes (0 : Word))
+    rw [haddr, RegFile.get_x0]
+
+def zeroInv (dst : Word) (orig : List (BitVec 8)) :
+    Nat → RegFile → List (BitVec 8) → Assertion → Prop :=
+  fun i rf ws A =>
+    rf.get .x5 = dst + BitVec.ofNat 64 (8 * i) ∧
+    rf.get .x6 = BitVec.ofNat 64 (4096 - i) ∧
+    i ≤ 4096 ∧ orig.length = 32768 ∧ ws = zeroWindow orig i ∧ A = empAssertion
+
+def cacheResetBody (orig : List (BitVec 8)) : Stmt :=
+  .block "init" [.LUI .x6 (1 : BitVec 20)] ;;;
+  .while "loop" (.bne .x6 .x0) 4096
+    (zeroInv (GuestAddrs.mset_res_cache_valid : Word) orig)
+    (.block "zero" zeroStepBlock) ;;;
+  .block "done" []
+
+def cacheResetFn (orig : List (BitVec 8)) : Fn where
+  name := "mptResolveCacheReset"
+  rw := ⟨GuestAddrs.mset_res_cache_valid, 32768⟩
+  pre := fun rf ws A =>
+    rf.get .x5 = GuestAddrs.mset_res_cache_valid ∧ ws = orig ∧
+      orig.length = 32768 ∧ A = empAssertion
+  post := fun _ ws A =>
+    ws = List.replicate 32768 (0 : BitVec 8) ∧ A = empAssertion
+  body := cacheResetBody orig
+
+theorem cacheReset_byte_tie :
+    [.AUIPC .x5 (laHi GuestAddrs.mset_res_cache_valid
+        (GuestAddrs.mpt_resolve_cache_reset + 0)),
+     .ADDI .x5 .x5 (laLo GuestAddrs.mset_res_cache_valid
+        (GuestAddrs.mpt_resolve_cache_reset + 0))] ++
+    (cacheResetBody []).flatten (GuestAddrs.mpt_resolve_cache_reset + 8) ++
+      [.JALR .x0 .x1 (0 : BitVec 12)] = mptResolveCacheReset_prog := by
+  rfl
+
+theorem cacheResetFn_spec (orig : List (BitVec 8))
+    (hwf : RwRegion.wf ⟨GuestAddrs.mset_res_cache_valid, 32768⟩) :
+    (cacheResetFn orig).Spec (GuestAddrs.mpt_resolve_cache_reset + 8) := by
+  have hbase : (cacheResetFn orig).rw.base = GuestAddrs.mset_res_cache_valid := rfl
+  vcgen
+  case region => exact ⟨Region.empty_wf, hwf⟩
+  case mptResolveCacheReset.loop.inv_init =>
+    rintro rf' ws' A' h
+    rcases h with ⟨rf0, ws0, -, hpre, rfl, rfl⟩
+    rcases hpre with ⟨hx5, hws0, hlen, hA⟩
+    simp only [hbase]
+    refine ⟨?_, ?_, by omega, hlen, ?_, hA⟩
+    · simp only [cacheResetFn, cacheResetBody, execBlock_cons, execBlock_nil,
+        execInstrRF, aluSem, RegFile.get_set_ne, ne_eq, reduceCtorEq,
+        not_false_eq_true, hx5]
+      simp
+    · simp only [cacheResetFn, cacheResetBody, execBlock_cons, execBlock_nil,
+        execInstrRF, aluSem, RegFile.get_set_self, ne_eq,
+        reduceCtorEq, not_false_eq_true]
+      rfl
+    · exact hws0.trans (zeroWindow_zero orig).symm
+  case mptResolveCacheReset.loop.inv_step =>
+    rintro i hi rf' ws' A' ⟨rf0, ws0, -, ⟨⟨hx5, hx6, hle, hlen, hws0, hA⟩, hcond⟩,
+      rfl, rfl⟩
+    simp only [hbase]
+    have hlt : i < 4096 := by
+      by_contra hnot
+      have hi4096 : i = 4096 := by omega
+      subst hi4096
+      exact hcond (by simp [hx6])
+    rw [zero_engine _ GuestAddrs.mset_res_cache_valid rf0 ws0 i hlt hx5]
+    refine ⟨?_, ?_, by omega, hlen, ?_, hA⟩
+    · rw [zeroStepRf_get_x5, hx5,
+        show signExtend12 (8 : BitVec 12) = (8 : Word) from by decide]
+      apply BitVec.eq_of_toNat_eq
+      simp only [BitVec.toNat_add, BitVec.toNat_ofNat,
+        show (8 : Word).toNat = 8 from by decide]
+      omega
+    · rw [zeroStepRf_get_x6, hx6,
+        show signExtend12 (-1 : BitVec 12) = (-1 : Word) from by decide]
+      bv_omega
+    · rw [hws0, zeroWindow_step orig i hlen hlt]
+  case mptResolveCacheReset.loop.exhausted =>
+    rintro rf ws A ⟨-, hx6, -, -, -, -⟩
+    simp [Cond.holds, hx6]
+  case mptResolveCacheReset.loop.body.zero.mem =>
+    rintro rf ws A hlen ⟨i, hi, ⟨hx5, hx6, hle, horiglen, hws, hA⟩, hcond⟩
+    have hlt : i < 4096 := by
+      by_contra hnot
+      have hi4096 : i = 4096 := by omega
+      subst hi4096
+      exact hcond (by simp [hx6])
+    have haddr : (rf.get .x5 + signExtend12 (0 : BitVec 12) -
+        GuestAddrs.mset_res_cache_valid).toNat = 8 * i := by
+      rw [hx5, show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]
+      bv_omega
+    have hlen32768 : ws.length = 32768 := by
+      change ws.length = 32768 at hlen
+      exact hlen
+    simp only [zeroStepBlock, blockVCs, loadSem, storeSem, inRw, hbase, haddr,
+      hlen32768, and_true]
+    constructor
+    · omega
+    · exact Nat.dvd_mul_right 8 i
+  case mptResolveCacheReset.post =>
+    rintro rf ws A ⟨rf0, ws0, -, ⟨⟨i, hi, hx5, hx6, hle, hlen, hws, hA⟩, hncond⟩,
+      rfl, rfl⟩
+    have hi4096 : i = 4096 := by
+      simp only [Cond.holds, hx6, RegFile.get_x0, not_not] at hncond
+      change BitVec.ofNat 64 (4096 - i) = (0 : Word) at hncond
+      have hzero := congrArg BitVec.toNat hncond
+      change (4096 - i) % 2 ^ 64 = 0 at hzero
+      rw [Nat.mod_eq_of_lt (by omega : 4096 - i < 2 ^ 64)] at hzero
+      omega
+    subst hi4096
+    constructor
+    · rw [hws, zeroWindow_done orig hlen]
+    · exact hA
+
+def cacheResetCr : CodeReq :=
+  CodeReq.ofProg (GuestAddrs.mpt_resolve_cache_reset : Word) mptResolveCacheReset_prog
+
+def cacheScratch : List Reg :=
+  [.x6, .x7, .x28, .x29, .x30, .x31,
+   .x10, .x11, .x12, .x13, .x14, .x15, .x16, .x17]
+
+private theorem exposedRegs_split (vf : Reg → Word) :
+    regAtomsOf vf exposedRegs = ((.x5 ↦ᵣ vf .x5) ** regAtomsOf vf cacheScratch) := by
+  show regAtomsOf vf
+      [.x5, .x6, .x7, .x28, .x29, .x30, .x31,
+       .x10, .x11, .x12, .x13, .x14, .x15, .x16, .x17] = _
+  simp only [cacheScratch, regAtomsOf_cons, regAtomsOf_nil]
+
+private theorem x5_notin_scratch : (.x5 : Reg) ∉ cacheScratch := by decide
+
+set_option linter.constructorNameAsVariable false in
+private theorem cacheResetTail_spec (retAddr : Word) (orig : List (BitVec 8))
+    (hlen : orig.length = 32768)
+    (hwf : RwRegion.wf ⟨GuestAddrs.mset_res_cache_valid, 32768⟩)
+    (halign : (retAddr &&& ~~~(1 : Word)) = retAddr) :
+    cpsTripleWithin ((cacheResetFn orig).body.steps + 1)
+      (GuestAddrs.mpt_resolve_cache_reset + 8 : Word) retAddr cacheResetCr
+      (((.x1 : Reg) ↦ᵣ retAddr) **
+        ((.x5 : Reg) ↦ᵣ (GuestAddrs.mset_res_cache_valid : Word)) **
+        regOwns cacheScratch ** bytesRegion GuestAddrs.mset_res_cache_valid orig)
+      (((.x1 : Reg) ↦ᵣ retAddr) ** regOwn .x5 ** regOwns cacheScratch **
+        bytesRegion GuestAddrs.mset_res_cache_valid
+          (List.replicate 32768 (0 : BitVec 8))) := by
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => hq)
+    (cpsTripleWithin_peel_regOwns cacheScratch (by decide)
+      (P := ((.x1 : Reg) ↦ᵣ retAddr) **
+        ((.x5 : Reg) ↦ᵣ (GuestAddrs.mset_res_cache_valid : Word)) **
+        bytesRegion GuestAddrs.mset_res_cache_valid orig)
+      (fun vf => ?_))
+  have had := Fn.retSpecFlat (cacheResetFn orig)
+    (GuestAddrs.mpt_resolve_cache_reset + 8 : Word)
+    (cacheResetFn_spec orig hwf)
+    (by change 4 * (6 + 1) ≤ 2 ^ 64; decide)
+    retAddr halign
+    (fun r => if r = .x5 then (GuestAddrs.mset_res_cache_valid : Word) else vf r)
+    orig hlen
+    (by
+      refine ⟨?_, rfl, hlen, rfl⟩
+      show RegFile.get
+          (fun r => if r = .x5 then (GuestAddrs.mset_res_cache_valid : Word) else vf r)
+          .x5 = GuestAddrs.mset_res_cache_valid
+      rw [RegFile.get, if_neg (by decide : (Reg.x5 : Reg) ≠ .x0)]
+      exact if_pos rfl)
+    (fun _ _ _ h => h.2)
+    (Q := regOwn .x5 ** regOwns cacheScratch **
+      bytesRegion GuestAddrs.mset_res_cache_valid
+        (List.replicate 32768 (0 : BitVec 8)))
+    (fun rf' ws' _ hpost hp hh => by
+      obtain ⟨rfl, -⟩ := hpost
+      rw [regFileIs_eq_regAtoms, regAtoms_eq_regAtomsOf _ _ (by decide),
+        exposedRegs_split] at hh
+      rw [show (cacheResetFn orig).rw.base = GuestAddrs.mset_res_cache_valid from rfl] at hh
+      have hh2 : (((regOwn .x5 ** regOwns cacheScratch) **
+          bytesRegion GuestAddrs.mset_res_cache_valid
+            (List.replicate 32768 (0 : BitVec 8))) hp) :=
+        sepConj_mono
+          (sepConj_mono (regIs_to_regOwn .x5 (rf' .x5))
+            (regAtomsOf_to_regOwns (fun r => rf' r) cacheScratch))
+          (fun _ h => h) hp hh
+      xperm_hyp hh2)
+  rw [show (cacheResetFn orig).programRet
+      (GuestAddrs.mpt_resolve_cache_reset + 8 : Word) =
+      mptResolveCacheReset_prog.drop 2 from rfl] at had
+  have hadC := liftCode (cr' := cacheResetCr) had
+    (by unfold cacheResetCr; code_mem)
+  rw [show (cacheResetFn orig).region = Region.empty from rfl,
+    show bytesRegion Region.empty.base Region.empty.bytes = empAssertion from
+      bytesRegion_nil _, sepConj_emp_right', sepConj_emp_right'] at hadC
+  rw [regFileIs_eq_regAtoms, regAtoms_eq_regAtomsOf _ _ (by decide),
+    exposedRegs_split,
+    show (if (Reg.x5 : Reg) = .x5 then (GuestAddrs.mset_res_cache_valid : Word)
+      else vf .x5) = GuestAddrs.mset_res_cache_valid from if_pos rfl,
+    regAtomsOf_congr
+      (fun r => if r = .x5 then (GuestAddrs.mset_res_cache_valid : Word) else vf r)
+      vf cacheScratch
+      (fun r hr => by
+        show (if r = .x5 then (GuestAddrs.mset_res_cache_valid : Word) else vf r) = vf r
+        exact if_neg (by
+          intro hc
+          subst r
+          exact x5_notin_scratch hr)),
+    show (cacheResetFn orig).rw.base = GuestAddrs.mset_res_cache_valid from rfl] at hadC
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hadC
+
+/-- Whole linked routine: materialize the cache-valid base, zero all 4096
+    dwords, and return with the save-area bytes exactly zero. -/
+theorem mptResolveCacheReset_spec (old5 retAddr : Word) (orig : List (BitVec 8))
+    (hlen : orig.length = 32768)
+    (hwf : RwRegion.wf ⟨GuestAddrs.mset_res_cache_valid, 32768⟩)
+    (halign : (retAddr &&& ~~~(1 : Word)) = retAddr) :
+    cpsTripleWithin (2 + ((cacheResetFn orig).body.steps + 1))
+      (GuestAddrs.mpt_resolve_cache_reset : Word) retAddr cacheResetCr
+      (((.x5 : Reg) ↦ᵣ old5) ** ((.x1 : Reg) ↦ᵣ retAddr) **
+        regOwns cacheScratch ** bytesRegion GuestAddrs.mset_res_cache_valid orig)
+      (((.x1 : Reg) ↦ᵣ retAddr) ** regOwn .x5 ** regOwns cacheScratch **
+        bytesRegion GuestAddrs.mset_res_cache_valid
+          (List.replicate 32768 (0 : BitVec 8))) := by
+  have hla := la_materialize_within .x5 old5
+    (GuestAddrs.mpt_resolve_cache_reset : Word)
+    (GuestAddrs.mset_res_cache_valid : Word)
+    (cr := cacheResetCr) (by decide) (by decide)
+    (by unfold cacheResetCr; code_mem) (by unfold cacheResetCr; code_mem)
+  rw [show (GuestAddrs.mpt_resolve_cache_reset : Word) + 8 =
+      (GuestAddrs.mpt_resolve_cache_reset + 8 : Word) from by decide] at hla
+  have hlaF := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ retAddr) ** regOwns cacheScratch **
+      bytesRegion GuestAddrs.mset_res_cache_valid orig) (by pcf) hla
+  have htail := cacheResetTail_spec retAddr orig hlen hwf halign
+  have hall := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hlaF htail
+  exact hall
+
+#print axioms cacheResetFn_spec
+#print axioms mptResolveCacheReset_spec
+
+end MptResolveCacheResetSAsm
+end EvmAsm.Codegen

--- a/PLAN.md
+++ b/PLAN.md
@@ -3755,6 +3755,10 @@ saved-register restore.
 shared-join architecture to the scalar-field mirror `secf_reduce_once_n`, with
 the group-order bytes at `secf_n_be`, exact conditional-subtraction bytes and
 return flag, and an `rfl` byte-identity guard against `secfReduceOnceN_prog`.
+`MptResolveCacheResetSAsm.lean` verifies `mpt_resolve_cache_reset`
+byte-identically: a 4096-iteration dword loop zeros the complete 32768-byte
+resolver-validity table, with the global-address `la` prefix composed into the
+whole linked-entry theorem and an exact `List.replicate` zero postcondition.
 `Secp256k1FieldEq32SAsm.lean` verifies `secf_eq32` as a `whileBreak` drop-in
 (`secfEq32Fn_spec`, `a0 = 1` iff the two 32-byte inputs are equal); the
 emitted `secfEq32_prog` is rewired to the verified body and the asm fixture is

--- a/PLAN.md
+++ b/PLAN.md
@@ -3755,6 +3755,9 @@ saved-register restore.
 shared-join architecture to the scalar-field mirror `secf_reduce_once_n`, with
 the group-order bytes at `secf_n_be`, exact conditional-subtraction bytes and
 return flag, and an `rfl` byte-identity guard against `secfReduceOnceN_prog`.
+`FrameLoadRegsSAsm.lean` verifies linked-PC `frame_load_regs` byte-identically:
+it computes `frame_save_area + (depth << 4)`, loads the saved PC and code-base
+into `a0`/`a1`, and preserves both global save-area cells.
 `Secp256k1FieldEq32SAsm.lean` verifies `secf_eq32` as a `whileBreak` drop-in
 (`secfEq32Fn_spec`, `a0 = 1` iff the two 32-byte inputs are equal); the
 emitted `secfEq32_prog` is rewired to the verified body and the asm fixture is

--- a/PLAN.md
+++ b/PLAN.md
@@ -349,6 +349,9 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   (`callFrameSetCalldataFn_spec`, post stores `parentMem + argsOff` at offset
   416 and `argsLen` at offset 424) with byte-identity pinned to
   `callFrameSetCalldata_prog`.
+  `FrameSaveRegsSAsm.lean` verifies linked-PC `frame_save_regs`: it computes
+  `frame_save_area + (depth << 4)` and updates the two owned PC/code-base
+  dwords, with exact RV64 address arithmetic and byte identity.
   `CalcExcessBlobGasSAsm.lean` verifies `calc_excess_blob_gas` as a
   byte-identical return-terminating `retIf` body (`calcExcessBlobGas_spec`,
   post `a0 = if (a0 + a1) < a2 then 0 else (a0 + a1) - a2`

--- a/PLAN.md
+++ b/PLAN.md
@@ -349,6 +349,10 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   (`callFrameSetCalldataFn_spec`, post stores `parentMem + argsOff` at offset
   416 and `argsLen` at offset 424) with byte-identity pinned to
   `callFrameSetCalldata_prog`.
+  `FrameDepthPushSAsm.lean` verifies the linked-PC `frame_depth_push` global
+  state leaf: it materializes `evm_call_depth`, increments the owned dword with
+  RV64 wrapping semantics, writes it back, and returns the new depth in `a0`,
+  with byte identity pinned to `frameDepthPush_prog`.
   `CalcExcessBlobGasSAsm.lean` verifies `calc_excess_blob_gas` as a
   byte-identical return-terminating `retIf` body (`calcExcessBlobGas_spec`,
   post `a0 = if (a0 + a1) < a2 then 0 else (a0 + a1) - a2`

--- a/PLAN.md
+++ b/PLAN.md
@@ -349,6 +349,9 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   (`callFrameSetCalldataFn_spec`, post stores `parentMem + argsOff` at offset
   416 and `argsLen` at offset 424) with byte-identity pinned to
   `callFrameSetCalldata_prog`.
+  `FrameDepthPopSAsm.lean` verifies the linked-PC `frame_depth_pop` global
+  state leaf: materialize `evm_call_depth`, decrement its owned dword with
+  exact RV64 wrapping, write it back, and return the new depth in `a0`.
   `CalcExcessBlobGasSAsm.lean` verifies `calc_excess_blob_gas` as a
   byte-identical return-terminating `retIf` body (`calcExcessBlobGas_spec`,
   post `a0 = if (a0 + a1) < a2 then 0 else (a0 + a1) - a2`

--- a/PLAN.md
+++ b/PLAN.md
@@ -3755,6 +3755,11 @@ saved-register restore.
 shared-join architecture to the scalar-field mirror `secf_reduce_once_n`, with
 the group-order bytes at `secf_n_be`, exact conditional-subtraction bytes and
 return flag, and an `rfl` byte-identity guard against `secfReduceOnceN_prog`.
+`DispatcherCaptureExecStateGasSAsm.lean` verifies
+`dispatcher_capture_exec_state_gas` byte-identically: two symbolic global
+address materializations feed a load and an index-scaled dword store, with a
+whole-entry post that preserves `evm_state_gas_used` and updates exactly the
+selected `bvgr_tx_exec_state_gas` cell.
 `Secp256k1FieldEq32SAsm.lean` verifies `secf_eq32` as a `whileBreak` drop-in
 (`secfEq32Fn_spec`, `a0 = 1` iff the two 32-byte inputs are equal); the
 emitted `secfEq32_prog` is rewired to the verified body and the asm fixture is


### PR DESCRIPTION
Batch-merge of #10127 #10129 #10131 #10132 #10133 #10135 (all author pirapira: frame_depth_push/pop, frame_save/load_regs, mpt_resolve_cache_reset, dispatcher_capture_exec_state_gas).

Verified locally: `lake build` (full, after every merge step) + all `scripts/check-*.sh` green, including `check-region-map.sh` (ELF-measured layout check).

All conflicts were straightforward import-line-append in `EvmAsm/Codegen/Programs/Imports.lean` plus independent PLAN.md journal paragraphs — kept both sides / merged the paragraphs.

Not included: #10098 (dependent on #10097's earlier state) is stale relative to current main and fails its own `#guard` check — needs its own rebase.