### PR TITLE
chore: import AccountFieldExtractSpec into Evm64 umbrella

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -170,6 +170,7 @@ import EvmAsm.Evm64.Memory
 import EvmAsm.Evm64.StateAssertions
 import EvmAsm.Evm64.MptAssertions
 import EvmAsm.Evm64.AccountRlp
+import EvmAsm.Evm64.AccountFieldExtractSpec
 import EvmAsm.Evm64.WitnessAssertions
 import EvmAsm.Evm64.MemoryGas
 import EvmAsm.Evm64.KeccakArgs


### PR DESCRIPTION
Fixes \`check-unimported.sh\` (currently failing on main and thus every PR based on it): #10144 added \`EvmAsm/Evm64/AccountFieldExtractSpec.lean\` without wiring it into the \`EvmAsm/Evm64.lean\` umbrella import, leaving it an orphan module.

One-line mechanical fix — no statement/definition changed. Verified locally: \`lake build\` + all \`scripts/check-*.sh\` green (including \`check-unimported.sh\`, which now reports 0 orphans).