### PR TITLE
perf(rlp): migrate tx signature extractors to RlpWalk (22pwv.1)

### DIFF
--- a/EvmAsm/Codegen/Programs/TxPubkey.lean
+++ b/EvmAsm/Codegen/Programs/TxPubkey.lean
@@ -865,6 +865,7 @@ def ziskTxPubkeyEcrecoverStageMaterialPrologue : String :=
   "  j .Ltpes_probe_done\n" ++
   txTypeDispatchFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
+  rlpWalkHelpersClosure ++ "\n" ++
   rlpEncodeUintBeFunction ++ "\n" ++
   rlpEncodeListPrefixFunction ++ "\n" ++
   rlpListTruncateToNFieldsFunction ++ "\n" ++
@@ -905,6 +906,7 @@ def ziskTxPubkeySignatureMaterialPrologue : String :=
   "  j .Ltps_pdone\n" ++
   txTypeDispatchFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
+  rlpWalkHelpersClosure ++ "\n" ++
   rlpEncodeUintBeFunction ++ "\n" ++
   rlpEncodeListPrefixFunction ++ "\n" ++
   rlpListTruncateToNFieldsFunction ++ "\n" ++
@@ -1020,6 +1022,7 @@ def ziskTxPubkeyRecoverRawStatusPrologue : String :=
   "  j .Ltprrs_pdone\n" ++
   txTypeDispatchFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
+  rlpWalkHelpersClosure ++ "\n" ++
   rlpEncodeUintBeFunction ++ "\n" ++
   rlpEncodeListPrefixFunction ++ "\n" ++
   rlpListTruncateToNFieldsFunction ++ "\n" ++
@@ -1101,6 +1104,7 @@ def ziskTxPubkeyPublicKeyMatchesStatusPrologue : String :=
   "  j .Ltpms_pdone\n" ++
   txTypeDispatchFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
+  rlpWalkHelpersClosure ++ "\n" ++
   rlpEncodeUintBeFunction ++ "\n" ++
   rlpEncodeListPrefixFunction ++ "\n" ++
   rlpListTruncateToNFieldsFunction ++ "\n" ++


### PR DESCRIPTION
References evm-asm-22pwv.1 / epic evm-asm-22pwv.

The RlpWalk migration itself is already present on current main (5734707ac). This follow-up repairs the four TxPubkey standalone probe closures so the migrated extractors' rlp_walk_* and rlp_content_to_* calls are linked.

Validation:
- lake build EvmAsm.Codegen.Programs.TxPubkey EvmAsm.Codegen.Programs.TxSignature
- all six tx/auth signature zisk probe checks
- scripts/codegen-zisk-tx-pubkey-signature-material-check.sh
- check-forbidden-tactics, check-axioms, check-no-hardcoded-guest-pc, check-layering, check-unimported, check-no-warnings, check-asm-to-program, check-region-map

No stateless guest bytes changed in this follow-up, so the prior migration's recorded 200-case EEST A/B parity remains applicable: selected=200, ran=200, full=177, root=200, succ=177, tail=200, fail=23, errored=0, budget=0; 223 .output and 200 .result.tsv artifacts matched byte-for-byte.