### PR TITLE
feat(specref): port v0.5.0 failed-input guest sentinel

### DIFF
--- a/EvmAsm/Stateless/SpecRef/Guest.lean
+++ b/EvmAsm/Stateless/SpecRef/Guest.lean
@@ -2,7 +2,7 @@
   EvmAsm.Stateless.SpecRef.Guest
 
   Port of `execution-specs/src/ethereum/forks/amsterdam/stateless_guest.py`
-  (`@tests-zkevm@v0.4.0`): the top-level guest shell.
+  (`@tests-zkevm@v0.5.0`): the top-level guest shell.
 
   * `serialize_stateless_output`  (`stateless_guest.py:21`)
   * `deserialize_stateless_input` (`stateless_guest.py:29`)
@@ -34,16 +34,32 @@ def deserialize_stateless_input (data : Bytes) : Except SpecError StatelessInput
   let ssz_obj ← deserialize sszStatelessInputType (data.drop STATELESS_INPUT_SCHEMA_ID_SIZE)
   sszToStatelessInput ssz_obj
 
-/-! ## `run_stateless_guest` (`stateless_guest.py:47`) -/
+/-! ## `_default_failed_stateless_output` (`stateless_guest.py:54`) -/
+
+/-- The sentinel output returned when the guest input cannot be decoded.
+    This is deliberately distinct from validation failure after decoding: the
+    latter preserves the input's request root and chain config. -/
+def _default_failed_stateless_output : StatelessValidationResult :=
+  { newPayloadRequestRoot := List.replicate 32 0
+    successfulValidation := false
+    chainConfig :=
+      { chainId := 0
+        activeFork :=
+          { fork := .Frontier
+            activation := { blockNumber := none, timestamp := none }
+            blobSchedule := none } } }
+
+/-! ## `run_stateless_guest` (`stateless_guest.py:79`) -/
 
 /-- Run the stateless guest on serialized input, returning serialized output.
     The execution engine is the seam parameter (default: `executeAlwaysOk`).
-    Deserialization failures propagate (Python does not catch them). -/
+    Deserialization failures produce the Python v0.5.0 sentinel output. -/
 def run_stateless_guest (input_bytes : Bytes)
-    (execute : ExecutionSeam := executeAlwaysOk) : Except SpecError Bytes := do
-  let stateless_input ← deserialize_stateless_input input_bytes
-  let stateless_output := verify_stateless_new_payload stateless_input execute
-  pure (serialize_stateless_output stateless_output)
+    (execute : ExecutionSeam := executeAlwaysOk) : Bytes :=
+  match deserialize_stateless_input input_bytes with
+  | .error _ => serialize_stateless_output _default_failed_stateless_output
+  | .ok stateless_input =>
+      serialize_stateless_output (verify_stateless_new_payload stateless_input execute)
 
 /-! ## Sanity checks -/
 
@@ -106,16 +122,27 @@ def sanityInputBytes : Except SpecError Bytes := do
 -- Full pipeline: run the guest and get SSZ output bytes whose decoded
 -- successful_validation is true (placeholder seam) and whose NPR root matches.
 #guard
-  match (do
-      let bytes ← sanityInputBytes
-      run_stateless_guest bytes) with
+  match sanityInputBytes with
   | .ok out =>
-      match deserialize sszStatelessValidationResultType out with
+      match deserialize sszStatelessValidationResultType (run_stateless_guest out) with
       | .ok sv =>
           match sszToValidationResult sv with
           | .ok r => r.successfulValidation
                      && r.newPayloadRequestRoot == compute_new_payload_request_root sanityInput
           | .error _ => false
+      | .error _ => false
+  | .error _ => false
+
+-- Invalid input takes the v0.5.0 failed-output path rather than exposing a
+-- deserialization exception to the caller.
+#guard
+  match deserialize sszStatelessValidationResultType (run_stateless_guest [0x00]) with
+  | .ok sv =>
+      match sszToValidationResult sv with
+      | .ok r => !r.successfulValidation
+                 && r.newPayloadRequestRoot == z 32
+                 && r.chainConfig.chainId == 0
+                 && r.chainConfig.activeFork.fork == .Frontier
       | .error _ => false
   | .error _ => false
 

--- a/EvmAsm/Tests/SpecRefEestCheck.lean
+++ b/EvmAsm/Tests/SpecRefEestCheck.lean
@@ -76,7 +76,7 @@ def unpackZiskemuInput (packed : Bytes) : Except String Bytes := do
 -- ============================================================================
 -- `specref-eest-check <input_file> <output_file>`
 --   exit 0 + writes the 105-byte result to <output_file> on success.
---   exit 2 + stderr message on a malformed framing or a SpecError.
+--   exit 2 + stderr message on malformed framing.
 
 def usage : String :=
   "usage: specref-eest-check <input_file> <output_file>"
@@ -91,13 +91,9 @@ def main (args : List String) : IO UInt32 := do
       IO.eprintln s!"specref-eest-check: framing error ({inputFile}): {msg}"
       return 2
     | .ok blob =>
-      match run_stateless_guest blob with  -- default seam = executeAlwaysOk
-      | .error _ =>
-        IO.eprintln s!"specref-eest-check: SpecError ({inputFile})"
-        return 2
-      | .ok out =>
-        IO.FS.writeBinFile ⟨outputFile⟩ (byteArrayOfBytes out)
-        return 0
+      let out := run_stateless_guest blob  -- default seam = executeAlwaysOk
+      IO.FS.writeBinFile ⟨outputFile⟩ (byteArrayOfBytes out)
+      return 0
   | _ =>
     IO.eprintln usage
     return 1


### PR DESCRIPTION
## Summary
- port `stateless_guest.py` v0.5.0 failed-input sentinel output
- make `run_stateless_guest` return serialized output on malformed input
- update the SpecRef EEST driver and add a malformed-input guard

Refs `evm-asm-n9rtz.1`, parent `evm-asm-n9rtz`, #10151.

## Validation
- `lake build`
- `scripts/check-forbidden-tactics.sh`
- `scripts/check-axioms.sh`
- `scripts/check-spec-refs.sh`