### PR TITLE
Batch-merge #10083 #10099 #10100 #10105 #10107 #10150 #10152 (pirapira)

### DIFF
--- a/EvmAsm/Codegen/Programs/Bls12KzgLtBeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12KzgLtBeSAsm.lean
@@ -1,0 +1,819 @@
+/-
+  EvmAsm.Codegen.Programs.Bls12KzgLtBeSAsm
+
+  `blsk_lt_be` — the KZG point-eval helper's general big-endian
+  lexicographic comparator (`a0 = 1` iff the `len`-byte BE integer at
+  `a0` is strictly less than the one at `a1`, `len` in `a2`) — via the
+  three-outcome compare join (`EvmAsm/Rv64/SAsm/TriCmpStoreJoin.lean`)
+  over SHARED `li a0, c ; ret` return tails
+  (`sharedRetTail_spec`, `EvmAsm/Rv64/SAsm/RetForwardJoin.lean`).
+
+  The routine byte-walks the two `len`-byte big-endian operands (both
+  caller-provided buffers — no global constant, no `la`, the program is
+  position-independent) with a countdown counter seeded from `a2` (the
+  first DATA-DEPENDENT trip count in this family — `twoBreakRetLoop_spec`
+  is trip-count-generic, so the loop instance is `N := len` with the
+  count a spec parameter) and advancing cursors, and routes its THREE
+  exits onto TWO `li`/`ret` tails:
+
+  ```
+        mv   t0, a0 ; mv t1, a1 ; mv t2, a2
+  hdr:  beq  t2, x0, .tailZero          -- exhaustion (equal)  → a0 = 0
+        lbu  x28, 0(t0) ; lbu x29, 0(t1)
+        bltu x28, x29, .tailOne         -- a[i] < b[i]         → a0 = 1
+        bltu x29, x28, .tailZero        -- b[i] < a[i]         → a0 = 0
+        addi t0, t0, 1 ; addi t1, t1, 1 ; addi t2, t2, -1 ; j hdr
+  .tailOne:  li a0, 1 ; ret
+  .tailZero: li a0, 0 ; ret
+  ```
+
+  Each tail is one `sharedRetTail_spec` instance (proven once per tail
+  address); the ordered `bltu` pair is one `triCmpStoreJoin_spec`
+  station; the loop is one `twoBreakRetLoop_spec` at `N := len`.  The
+  `=` and `>` outcomes SHARE the zero tail — big-endian lexicographic
+  order IS numeric order (`U256MinSAsm.beBytesToNat_lt_of_prefix_lt` in
+  both directions, all-equal bridge `bytes_eq_of_prefix_all`; both are
+  length-generic).
+
+  **Genuine post**: `a0 = if beBytesToNat as < beBytesToNat bs
+  then 1 else 0` — the REAL numeric strict less-than of the two
+  operands; both input regions untouched, `a1`/`a2` preserved.
+
+  Byte-transparent: the spec is stated at the `#guard`-tied symbolic
+  `GuestAddrs.blsk_lt_be` base (bead evm-asm-6agnq) over the emitted
+  `blskLtBe_prog` directly — no guest-byte change, no A/B run needed.
+
+  Bead: evm-asm-4ch8f.58.4.5.
+-/
+
+import EvmAsm.Codegen.Programs.Bls12Kzg
+import EvmAsm.Codegen.Programs.U256MinSAsm
+import EvmAsm.Rv64.SAsm.TriCmpStoreJoin
+import EvmAsm.Rv64.SAsm.RetForwardJoin
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Crypto
+
+namespace Bls12KzgLtBeSAsm
+
+open U256MinSAsm (beBytesToNat_lt_of_prefix_lt bytes_eq_of_prefix_all)
+
+/-- The routine base, symbolic (bead evm-asm-6agnq). -/
+def ltPBase : Word := (GuestAddrs.blsk_lt_be : Word)
+
+-- Address anchor (fails the build if the guest link moves).
+#guard GuestAddrs.blsk_lt_be = 0x80032b14
+#guard blskLtBe_prog.length = 16
+-- The comparator is position-independent (no PC-relative instruction).
+
+/-
+  Emitted layout relative to `GuestAddrs.blsk_lt_be`:
+    +0   mv    x5, x10
+    +4   mv    x6, x11
+    +8   mv    x7, x12
+    +12  beq   x7, x0, +44  → +56 (zero tail)                   [hdr]
+    +16  lbu   x28, 0(x5)
+    +20  lbu   x29, 0(x6)
+    +24  bltu  x28, x29, +24 → +48 (one tail)
+    +28  bltu  x29, x28, +28 → +56 (zero tail)
+    +32  addi  x5, x5, 1
+    +36  addi  x6, x6, 1
+    +40  addi  x7, x7, -1
+    +44  jal   x0, -32      → +12
+    +48  li    x10, 1                                           [one tail]
+    +52  jalr  x0, x1, 0
+    +56  li    x10, 0                                           [zero tail]
+    +60  jalr  x0, x1, 0
+-/
+
+-- ============================================================================
+-- §1  Word-arithmetic helpers (countdown counter / advancing cursors)
+-- ============================================================================
+
+private theorem counter_dec (len i : Nat) (hi : i < len) :
+    BitVec.ofNat 64 (len - i) + signExtend12 (-1 : BitVec 12)
+      = BitVec.ofNat 64 (len - (i + 1)) := by
+  rw [show signExtend12 (-1 : BitVec 12) = (-1 : Word) from by decide]
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_add, BitVec.toNat_ofNat, BitVec.toNat_ofNat,
+    show ((-1 : Word)).toNat = 18446744073709551615 from rfl]
+  omega
+
+private theorem cursor_advance (p : Word) (i : Nat) :
+    p + BitVec.ofNat 64 i + signExtend12 (1 : BitVec 12)
+      = p + BitVec.ofNat 64 (i + 1) := by
+  rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide,
+    BitVec.add_assoc]
+  congr 1
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_add, show ((1 : Word)).toNat = 1 from rfl,
+    BitVec.toNat_ofNat, BitVec.toNat_ofNat]
+  omega
+
+private theorem ctr_ne_zero (len i : Nat) (hi : i < len) (hlb : len < 2 ^ 64) :
+    ¬ (BitVec.ofNat 64 (len - i) = (0 : Word)) := by
+  intro h
+  have := congrArg BitVec.toNat h
+  rw [BitVec.toNat_ofNat, show ((0 : Word)).toNat = 0 from rfl] at this
+  omega
+
+-- ============================================================================
+-- §2  Invariant and genuine post
+-- ============================================================================
+
+section Scan
+
+variable (aPtr bPtr ret : Word) (len : Nat) (xs bs : List (BitVec 8))
+
+/-- Loop invariant at the header after `i` matched bytes: the counter holds
+    `len - i`, both cursors sit at byte `i`, the first `i` bytes of the two
+    operands agree (pure conjunct), the fixed registers and both input
+    regions are untouched. -/
+private def ltInv (i : Nat) : Assertion :=
+  ⌜∀ j, j < i → xs.getD j 0 = bs.getD j 0⌝ **
+  ((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - i)) **
+  ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+  ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+  ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+  ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+  regOwn .x28 ** regOwn .x29 **
+  bytesRegion aPtr xs ** bytesRegion bPtr bs
+
+/-- The genuine post: `a0` is the REAL numeric strict less-than of the
+    two `len`-byte big-endian operands; both input regions untouched,
+    `a1`/`a2` preserved. -/
+private def ltPost : Assertion :=
+  ((.x10 : Reg) ↦ᵣ (if beBytesToNat xs < beBytesToNat bs
+    then (1 : Word) else (0 : Word))) **
+  ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+  ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+  regOwn .x6 ** regOwn .x7 ** regOwn .x5 **
+  regOwn .x28 ** regOwn .x29 **
+  bytesRegion aPtr xs ** bytesRegion bPtr bs
+
+-- ============================================================================
+-- §3  One loop iteration (the three-outcome join station)
+-- ============================================================================
+
+/-- One iteration at the header with `i < len` bytes known equal: either a
+    `bltu` break fires and the corresponding shared `li`/`ret` tail
+    RETURNS with the genuine post, or the iteration loops back to the
+    header with the invariant advanced.  Exactly the
+    `twoBreakRetLoop_spec` iteration shape, built from one
+    `triCmpStoreJoin_spec` station wrapped by the header `beq`
+    `breakStation_spec`. -/
+private theorem ltIter_spec
+    (hlenX : xs.length = len) (hlenB : bs.length = len)
+    (halignA : aPtr.toNat % 8 = 0) (halignB : bPtr.toNat % 8 = 0)
+    (hovA : aPtr.toNat + len < 2 ^ 64) (hovB : bPtr.toNat + len < 2 ^ 64)
+    (hvalidA : ∀ k, k < len → isValidByteAccess (aPtr + BitVec.ofNat 64 k) = true)
+    (hvalidB : ∀ k, k < len → isValidByteAccess (bPtr + BitVec.ofNat 64 k) = true)
+    (halignRet : (ret &&& ~~~(1 : Word)) = ret)
+    (i : Nat) (hi : i < len) :
+    cpsBranchWithin 9 (ltPBase + 12)
+      (CodeReq.ofProg ltPBase blskLtBe_prog)
+      (ltInv aPtr bPtr ret len xs bs i)
+      ret (ltPost aPtr bPtr ret len xs bs)
+      (ltPBase + 12) (ltInv aPtr bPtr ret len xs bs (i + 1)) := by
+  set CR := CodeReq.ofProg ltPBase blskLtBe_prog with hCR
+  have hplen : bs.length = len := hlenB
+  have hlb : len < 2 ^ 64 := by omega
+  have hix : i < xs.length := by omega
+  have hip : i < bs.length := by omega
+  set xByte := (xs[i]'hix).zeroExtend 64 with hxByte
+  set pByte := (bs[i]'hip).zeroExtend 64 with hpByte
+  have hxBN : xByte.toNat = (xs[i]'hix).toNat := by
+    rw [hxByte]
+    show (BitVec.setWidth 64 _).toNat = _
+    rw [BitVec.toNat_setWidth]
+    have := (xs[i]'hix).isLt
+    omega
+  have hpBN : pByte.toNat = (bs[i]'hip).toNat := by
+    rw [hpByte]
+    show (BitVec.setWidth 64 _).toNat = _
+    rw [BitVec.toNat_setWidth]
+    have := (bs[i]'hip).isLt
+    omega
+  have hgdX : xs.getD i 0 = xs[i]'hix := by
+    rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem hix]
+    rfl
+  have hgdP : bs.getD i 0 = bs[i]'hip := by
+    rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem hip]
+    rfl
+  -- strip the pure prefix fact
+  unfold ltInv
+  refine cpsBranchWithin_pure_pre (fun hpref => ?_)
+  -- peel this iteration's scratch registers x28, x29
+  refine cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq) (fun _ hq => hq)
+    (cpsBranchWithin_of_forall_regIs_to_regOwn (r := .x28)
+      (P := (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - i)) **
+        ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs) **
+        regOwn .x29)
+      (fun v28 => ?_))
+  refine cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq) (fun _ hq => hq)
+    (cpsBranchWithin_of_forall_regIs_to_regOwn (r := .x29)
+      (P := (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - i)) **
+        ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs) **
+        ((.x28 : Reg) ↦ᵣ v28))
+      (fun v29 => ?_))
+  -- canonical working set, x28/x29 concrete
+  suffices hmain :
+      cpsBranchWithin 9 (ltPBase + 12) CR
+        (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - i)) **
+         ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+         ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+         ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+         ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+         bytesRegion aPtr xs ** bytesRegion bPtr bs)
+        ret (ltPost aPtr bPtr ret len xs bs)
+        (ltPBase + 12) (ltInv aPtr bPtr ret len xs bs (i + 1)) by
+    exact cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
+      (fun _ hq => hq) (fun _ hq => hq) hmain
+  -- ---- the two LBU loads (+20 input, +24 const) ----
+  have hlbuX := liftCode (cr' := CR)
+    (bytesRegion_lbu_within .x28 .x5 aPtr v28 (ltPBase + 16) xs i
+      (by decide) halignA hix (by omega) (hvalidA i hi))
+    (by rw [hCR]; code_mem)
+  rw [show (ltPBase + 16 : Word) + 4 = (ltPBase + 20 : Word) from by decide]
+    at hlbuX
+  have hlbuP := liftCode (cr' := CR)
+    (bytesRegion_lbu_within .x29 .x6 bPtr v29 (ltPBase + 20)
+      bs i (by decide) halignB hip (by omega) (hvalidB i hi))
+    (by rw [hCR]; code_mem)
+  rw [show (ltPBase + 20 : Word) + 4 = (ltPBase + 24 : Word) from by decide]
+    at hlbuP
+  have hlbuXF := cpsTripleWithin_frameR
+    (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - i)) **
+      ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x29 : Reg) ↦ᵣ v29) **
+      bytesRegion bPtr bs)
+    (by pcf) hlbuX
+  have hlbuPF := cpsTripleWithin_frameR
+    (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - i)) **
+      ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x28 : Reg) ↦ᵣ xByte) **
+      bytesRegion aPtr xs)
+    (by pcf) hlbuP
+  have hpre1 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hlbuXF hlbuPF
+  -- ---- the header BEQ station (+16; never taken at i < len) ----
+  have hbrHdr := cpsBranchWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+      ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+      ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+      bytesRegion aPtr xs ** bytesRegion bPtr bs)
+    (by pcf)
+    (cpsBranchWithin_extend_code (cr' := CR)
+      (h := beq_spec_gen_within .x7 .x0 (44 : BitVec 13)
+        (BitVec.ofNat 64 (len - i)) (0 : Word) (ltPBase + 12))
+      (hmono := by rw [hCR]; code_mem))
+  rw [show (ltPBase + 12 : Word) + signExtend13 (44 : BitVec 13)
+        = (ltPBase + 56 : Word) from by decide,
+      show (ltPBase + 12 : Word) + 4 = (ltPBase + 16 : Word) from by decide]
+    at hbrHdr
+  -- ---- the ordered bltu pair, framed ----
+  have hbrA := cpsBranchWithin_frameR
+    (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - i)) **
+      ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+      ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      bytesRegion aPtr xs ** bytesRegion bPtr bs)
+    (by pcf)
+    (cpsBranchWithin_extend_code (cr' := CR)
+      (h := bltu_spec_gen_within .x28 .x29 (24 : BitVec 13) xByte pByte
+        (ltPBase + 24))
+      (hmono := by rw [hCR]; code_mem))
+  rw [show (ltPBase + 24 : Word) + signExtend13 (24 : BitVec 13)
+        = (ltPBase + 48 : Word) from by decide,
+      show (ltPBase + 24 : Word) + 4 = (ltPBase + 28 : Word) from by decide]
+    at hbrA
+  have hbrB := cpsBranchWithin_frameR
+    (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - i)) **
+      ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+      ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      bytesRegion aPtr xs ** bytesRegion bPtr bs)
+    (by pcf)
+    (cpsBranchWithin_extend_code (cr' := CR)
+      (h := bltu_spec_gen_within .x29 .x28 (28 : BitVec 13) pByte xByte
+        (ltPBase + 28))
+      (hmono := by rw [hCR]; code_mem))
+  rw [show (ltPBase + 28 : Word) + signExtend13 (28 : BitVec 13)
+        = (ltPBase + 56 : Word) from by decide,
+      show (ltPBase + 28 : Word) + 4 = (ltPBase + 32 : Word) from by decide]
+    at hbrB
+  -- the canonical post-load working set (all three arms' currency)
+  set WSL : Assertion :=
+    ((.x28 : Reg) ↦ᵣ xByte) ** ((.x29 : Reg) ↦ᵣ pByte) **
+    ((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - i)) **
+    ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+    ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+    ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+    ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+    bytesRegion aPtr xs ** bytesRegion bPtr bs with hWSL
+  -- ---- break arm A: one tail returns 1 (in < p decided) ----
+  have htailOne : BitVec.ult xByte pByte →
+      cpsTripleWithin 4 (ltPBase + 48) ret CR WSL
+        (ltPost aPtr bPtr ret len xs bs) := by
+    intro hc
+    have hltN : (xs[i]'hix).toNat < (bs[i]'hip).toNat := by
+      have hc' : xByte.toNat < pByte.toNat := by
+        simpa [BitVec.ult, decide_eq_true_eq] using hc
+      omega
+    have hlt : beBytesToNat xs < beBytesToNat bs :=
+      beBytesToNat_lt_of_prefix_lt xs bs (by omega) i hix hpref
+        (by rw [hgdX, hgdP]; omega)
+    have h := cpsTripleWithin_frameR
+      (((.x28 : Reg) ↦ᵣ xByte) ** ((.x29 : Reg) ↦ᵣ pByte) **
+        ((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - i)) **
+        ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+        ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)))
+      (by pcf)
+      (sharedRetTail_spec CR (ltPBase + 48) ret .x10 (1 : Word) aPtr
+        (bytesRegion aPtr xs ** bytesRegion bPtr bs)
+        (by pcf) (by decide) halignRet
+        (by rw [hCR]; code_mem) (by rw [hCR]; code_mem))
+    refine cpsTripleWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_) h)
+    · rw [hWSL] at hp
+      xperm_hyp hp
+    · unfold ltPost
+      rw [if_pos hlt]
+      have hq1 : (((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+          (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - i)) **
+            (((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+              (((.x28 : Reg) ↦ᵣ xByte) ** (((.x29 : Reg) ↦ᵣ pByte) **
+                (((.x10 : Reg) ↦ᵣ (1 : Word)) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+                 ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+                 bytesRegion aPtr xs **
+                 bytesRegion bPtr bs)))))) h := by
+        xperm_hyp hq
+      have hq2 := sepConj_mono (regIs_to_regOwn .x6 _)
+        (sepConj_mono (regIs_to_regOwn .x7 _)
+          (sepConj_mono (regIs_to_regOwn .x5 _)
+            (sepConj_mono (regIs_to_regOwn .x28 _)
+              (sepConj_mono (regIs_to_regOwn .x29 _)
+                (fun _ hh => hh))))) h hq1
+      xperm_hyp hq2
+  -- ---- break arm B: zero tail returns 0 (p < in decided) ----
+  have htailZeroGt : ¬ BitVec.ult xByte pByte → BitVec.ult pByte xByte →
+      cpsTripleWithin 4 (ltPBase + 56) ret CR WSL
+        (ltPost aPtr bPtr ret len xs bs) := by
+    intro _ hc
+    have hgtN : (bs[i]'hip).toNat < (xs[i]'hix).toNat := by
+      have hc' : pByte.toNat < xByte.toNat := by
+        simpa [BitVec.ult, decide_eq_true_eq] using hc
+      omega
+    have hgt : beBytesToNat bs < beBytesToNat xs :=
+      beBytesToNat_lt_of_prefix_lt bs xs (by omega) i hip
+        (fun j hj => (hpref j hj).symm)
+        (by rw [hgdX, hgdP]; omega)
+    have hnlt : ¬ (beBytesToNat xs < beBytesToNat bs) := by
+      omega
+    have h := cpsTripleWithin_frameR
+      (((.x28 : Reg) ↦ᵣ xByte) ** ((.x29 : Reg) ↦ᵣ pByte) **
+        ((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - i)) **
+        ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+        ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)))
+      (by pcf)
+      (sharedRetTail_spec CR (ltPBase + 56) ret .x10 (0 : Word) aPtr
+        (bytesRegion aPtr xs ** bytesRegion bPtr bs)
+        (by pcf) (by decide) halignRet
+        (by rw [hCR]; code_mem) (by rw [hCR]; code_mem))
+    refine cpsTripleWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_) h)
+    · rw [hWSL] at hp
+      xperm_hyp hp
+    · unfold ltPost
+      rw [if_neg hnlt]
+      have hq1 : (((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+          (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - i)) **
+            (((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+              (((.x28 : Reg) ↦ᵣ xByte) ** (((.x29 : Reg) ↦ᵣ pByte) **
+                (((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+                 ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+                 bytesRegion aPtr xs **
+                 bytesRegion bPtr bs)))))) h := by
+        xperm_hyp hq
+      have hq2 := sepConj_mono (regIs_to_regOwn .x6 _)
+        (sepConj_mono (regIs_to_regOwn .x7 _)
+          (sepConj_mono (regIs_to_regOwn .x5 _)
+            (sepConj_mono (regIs_to_regOwn .x28 _)
+              (sepConj_mono (regIs_to_regOwn .x29 _)
+                (fun _ hh => hh))))) h hq1
+      xperm_hyp hq2
+  -- ---- continue segment: 3 × addi ; jal → header with inv (i+1) ----
+  have hcont : ¬ BitVec.ult xByte pByte → ¬ BitVec.ult pByte xByte →
+      cpsTripleWithin 4 (ltPBase + 32) (ltPBase + 12) CR WSL
+        (ltInv aPtr bPtr ret len xs bs (i + 1)) := by
+    intro hnXP hnPX
+    have hEqByte : xs[i]'hix = bs[i]'hip := by
+      apply BitVec.eq_of_toNat_eq
+      have h1 : ¬ xByte.toNat < pByte.toNat := by
+        intro hlt
+        exact hnXP (by simp [BitVec.ult, decide_eq_true_eq]; omega)
+      have h2 : ¬ pByte.toNat < xByte.toNat := by
+        intro hlt
+        exact hnPX (by simp [BitVec.ult, decide_eq_true_eq]; omega)
+      omega
+    have hpref' : ∀ j, j < i + 1 → xs.getD j 0 = bs.getD j 0 := by
+      intro j hj
+      by_cases hji : j < i
+      · exact hpref j hji
+      · have : j = i := by omega
+        subst this
+        rw [hgdX, hgdP, hEqByte]
+    have haddi7 := liftCode (cr' := CR)
+      (addi_spec_gen_same_within .x5 (aPtr + BitVec.ofNat 64 i) (1 : BitVec 12)
+        (ltPBase + 32) (by decide))
+      (by rw [hCR]; code_mem)
+    rw [cursor_advance aPtr i,
+        show (ltPBase + 32 : Word) + 4 = (ltPBase + 36 : Word) from by decide]
+      at haddi7
+    have haddi5 := liftCode (cr' := CR)
+      (addi_spec_gen_same_within .x6 (bPtr + BitVec.ofNat 64 i)
+        (1 : BitVec 12) (ltPBase + 36) (by decide))
+      (by rw [hCR]; code_mem)
+    rw [cursor_advance bPtr i,
+        show (ltPBase + 36 : Word) + 4 = (ltPBase + 40 : Word) from by decide]
+      at haddi5
+    have haddi6 := liftCode (cr' := CR)
+      (addi_spec_gen_same_within .x7 (BitVec.ofNat 64 (len - i)) (-1 : BitVec 12)
+        (ltPBase + 40) (by decide))
+      (by rw [hCR]; code_mem)
+    rw [counter_dec len i hi,
+        show (ltPBase + 40 : Word) + 4 = (ltPBase + 44 : Word) from by decide]
+      at haddi6
+    have hjal := liftCode (cr' := CR)
+      (jal_x0_spec_gen_within (-32 : BitVec 21) (ltPBase + 44))
+      (by rw [hCR]; code_mem)
+    rw [show (ltPBase + 44 : Word) + signExtend21 (-32 : BitVec 21)
+          = (ltPBase + 12 : Word) from by decide] at hjal
+    have haddi7F := cpsTripleWithin_frameR
+      (((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+        ((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - i)) **
+        ((.x28 : Reg) ↦ᵣ xByte) ** ((.x29 : Reg) ↦ᵣ pByte) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs)
+      (by pcf) haddi7
+    have haddi5F := cpsTripleWithin_frameR
+      (((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (i + 1))) **
+        ((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - i)) **
+        ((.x28 : Reg) ↦ᵣ xByte) ** ((.x29 : Reg) ↦ᵣ pByte) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs)
+      (by pcf) haddi5
+    have haddi6F := cpsTripleWithin_frameR
+      (((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (i + 1))) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (i + 1))) **
+        ((.x28 : Reg) ↦ᵣ xByte) ** ((.x29 : Reg) ↦ᵣ pByte) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs)
+      (by pcf) haddi6
+    have hjalF := cpsTripleWithin_frameR
+      (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - (i + 1))) **
+        ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (i + 1))) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (i + 1))) **
+        ((.x28 : Reg) ↦ᵣ xByte) ** ((.x29 : Reg) ↦ᵣ pByte) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs)
+      (by pcf) hjal
+    have hc1 := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by xperm_hyp hp) haddi7F haddi5F
+    have hc2 := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by xperm_hyp hp) hc1 haddi6F
+    have hc3 := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by
+        rw [sepConj_emp_left']
+        xperm_hyp hp) hc2 hjalF
+    refine cpsTripleWithin_weaken
+      (fun h hp => by rw [hWSL] at hp; xperm_hyp hp)
+      (fun h hq => ?_) hc3
+    rw [sepConj_emp_left'] at hq
+    unfold ltInv
+    refine (sepConj_pure_left h).2 ⟨hpref', ?_⟩
+    have hq1 : (((.x28 : Reg) ↦ᵣ xByte) ** (((.x29 : Reg) ↦ᵣ pByte) **
+        (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - (i + 1))) **
+         ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (i + 1))) **
+         ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (i + 1))) **
+         ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+         ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         bytesRegion aPtr xs ** bytesRegion bPtr bs))) h := by
+      xperm_hyp hq
+    have hq2 := sepConj_mono (regIs_to_regOwn .x28 _)
+      (sepConj_mono (regIs_to_regOwn .x29 _)
+        (fun _ hh => hh)) h hq1
+    xperm_hyp hq2
+  -- ---- the ordered bltu pair as ONE three-outcome join station ----
+  have hjoin : cpsBranchWithin (1 + (1 + 4)) (ltPBase + 24) CR WSL
+      ret (ltPost aPtr bPtr ret len xs bs)
+      (ltPBase + 12) (ltInv aPtr bPtr ret len xs bs (i + 1)) :=
+    triCmpStoreJoin_spec
+      (condLt := BitVec.ult xByte pByte) (condGt := BitVec.ult pByte xByte)
+      (PLt := WSL) (PMid := WSL) (PGt := WSL) (PEq := WSL)
+      (cpsBranchWithin_weaken
+        (fun h hp => by rw [hWSL] at hp; xperm_hyp hp)
+        (fun _ hq => hq) (fun _ hq => hq) hbrA)
+      (fun h hq => by rw [hWSL]; xperm_hyp hq)
+      (fun h hq => by rw [hWSL]; xperm_hyp hq)
+      (fun hc => cpsTripleWithin_mono_nSteps (by omega) (htailOne hc))
+      (fun _ => cpsBranchWithin_weaken
+        (fun h hp => by rw [hWSL] at hp; xperm_hyp hp)
+        (fun _ hq => hq) (fun _ hq => hq) hbrB)
+      (fun h hq => by rw [hWSL]; xperm_hyp hq)
+      (fun h hq => by rw [hWSL]; xperm_hyp hq)
+      (fun hnXP hc => htailZeroGt hnXP hc)
+      (fun hnXP hnPX => cpsTripleWithin_as_cpsBranchWithin_right ret
+        (ltPost aPtr bPtr ret len xs bs) (hcont hnXP hnPX))
+  -- ---- loads ; join station ----
+  have hfallIter := cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr
+    (fun h hp => by rw [hWSL]; xperm_hyp hp) hpre1 hjoin
+  -- ---- the header BEQ station wraps it all ----
+  refine cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq) (fun _ hq => hq)
+    (breakStation_spec (cond := (BitVec.ofNat 64 (len - i) = (0 : Word)))
+      (PT := ((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - i)) **
+        ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs)
+      (PF := ((((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+        ((.x28 : Reg) ↦ᵣ v28) ** bytesRegion aPtr xs) **
+        (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - i)) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x29 : Reg) ↦ᵣ v29) **
+        bytesRegion bPtr bs)))
+      hbrHdr
+      (fun h hq => by xperm_hyp hq)
+      (fun h hq => by xperm_hyp hq)
+      (fun hc => absurd hc (ctr_ne_zero len i hi hlb))
+      (fun _ => hfallIter))
+
+-- ============================================================================
+-- §4  Loop exhaustion: all len bytes equal → zero tail returns 0
+-- ============================================================================
+
+private theorem ltExh_spec
+    (hlenX : xs.length = len) (hlenB : bs.length = len)
+    (halignRet : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin 5 (ltPBase + 12) ret
+      (CodeReq.ofProg ltPBase blskLtBe_prog)
+      (ltInv aPtr bPtr ret len xs bs len)
+      (ltPost aPtr bPtr ret len xs bs) := by
+  set CR := CodeReq.ofProg ltPBase blskLtBe_prog with hCR
+  have hplen : bs.length = len := hlenB
+  unfold ltInv
+  refine cpsTripleWithin_pure_pre (fun hpref => ?_)
+  have hEq : xs = bs := bytes_eq_of_prefix_all xs bs
+    (by omega) (fun j hj => hpref j (by omega))
+  have heqN : beBytesToNat xs = beBytesToNat bs := by rw [hEq]
+  have hnlt : ¬ (beBytesToNat xs < beBytesToNat bs) := by omega
+  -- header BEQ, taken (counter = 0)
+  have hbrHdr := cpsBranchWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 len)) **
+      ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 len)) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+      ((.x1 : Reg) ↦ᵣ ret) **
+      regOwn .x28 ** regOwn .x29 **
+      bytesRegion aPtr xs ** bytesRegion bPtr bs)
+    (by pcf)
+    (cpsBranchWithin_extend_code (cr' := CR)
+      (h := beq_spec_gen_within .x7 .x0 (44 : BitVec 13)
+        (BitVec.ofNat 64 (len - len)) (0 : Word) (ltPBase + 12))
+      (hmono := by rw [hCR]; code_mem))
+  rw [show (ltPBase + 12 : Word) + signExtend13 (44 : BitVec 13)
+        = (ltPBase + 56 : Word) from by decide,
+      show (ltPBase + 12 : Word) + 4 = (ltPBase + 16 : Word) from by decide]
+    at hbrHdr
+  -- taken arm: zero tail returns 0 (framed, converted, if-resolved)
+  have htail : cpsTripleWithin 4 (ltPBase + 56) ret CR
+      (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - len)) **
+       ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 len)) **
+       ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 len)) **
+       ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+       ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       regOwn .x28 ** regOwn .x29 **
+       bytesRegion aPtr xs ** bytesRegion bPtr bs)
+      (ltPost aPtr bPtr ret len xs bs) := by
+    have h := cpsTripleWithin_frameR
+      (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - len)) **
+        ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 len)) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 len)) **
+        ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x28 ** regOwn .x29)
+      (by pcf)
+      (sharedRetTail_spec CR (ltPBase + 56) ret .x10 (0 : Word) aPtr
+        (bytesRegion aPtr xs ** bytesRegion bPtr bs)
+        (by pcf) (by decide) halignRet
+        (by rw [hCR]; code_mem) (by rw [hCR]; code_mem))
+    refine cpsTripleWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_) h)
+    · xperm_hyp hp
+    · unfold ltPost
+      rw [if_neg hnlt]
+      have hq1 : (((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 len)) **
+          (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - len)) **
+            (((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 len)) **
+              (((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+               ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+               regOwn .x28 ** regOwn .x29 **
+               bytesRegion aPtr xs **
+               bytesRegion bPtr bs)))) h := by
+        xperm_hyp hq
+      have hq2 := sepConj_mono (regIs_to_regOwn .x6 _)
+        (sepConj_mono (regIs_to_regOwn .x7 _)
+          (sepConj_mono (regIs_to_regOwn .x5 _)
+            (fun _ hh => hh))) h hq1
+      xperm_hyp hq2
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq)
+    (retJoinStation_spec
+      (cond := (BitVec.ofNat 64 (len - len) = (0 : Word)))
+      (PT := (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - len)) **
+        ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 len)) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 len)) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x28 ** regOwn .x29 **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs))
+      (PF := (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (len - len)) **
+        ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 len)) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 len)) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x28 ** regOwn .x29 **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs))
+      hbrHdr
+      (fun h hq => by xperm_hyp hq)
+      (fun h hq => by xperm_hyp hq)
+      (fun _ => htail)
+      (fun hc => absurd (by rw [Nat.sub_self]; rfl :
+        (BitVec.ofNat 64 (len - len) : Word) = (0 : Word)) hc))
+
+end Scan
+
+-- ============================================================================
+-- §5  The whole routine
+-- ============================================================================
+
+/-- **`blsk_lt_be` at its linked address** (genuine post): `a0` is the
+    REAL numeric strict less-than of the two `len`-byte big-endian
+    operands — `1` for `as < bs`, `0` otherwise (big-endian
+    lexicographic order IS numeric order); the trip count is the
+    DATA-DEPENDENT byte length in `a2` (`x12 = len`, preserved); both
+    input regions untouched, `a1` preserved. -/
+theorem blskLtBe_spec (aPtr bPtr ret : Word) (len : Nat) (xs bs : List (BitVec 8))
+    (hlenX : xs.length = len) (hlenB : bs.length = len)
+    (halignA : aPtr.toNat % 8 = 0) (halignB : bPtr.toNat % 8 = 0)
+    (hovA : aPtr.toNat + len < 2 ^ 64) (hovB : bPtr.toNat + len < 2 ^ 64)
+    (hvalidA : ∀ k, k < len → isValidByteAccess (aPtr + BitVec.ofNat 64 k) = true)
+    (hvalidB : ∀ k, k < len → isValidByteAccess (bPtr + BitVec.ofNat 64 k) = true)
+    (halignRet : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin (len * 9 + 8) ltPBase ret
+      (CodeReq.ofProg ltPBase blskLtBe_prog)
+      (((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+       ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       regOwn .x6 ** regOwn .x7 ** regOwn .x5 **
+       regOwn .x28 ** regOwn .x29 **
+       bytesRegion aPtr xs **
+       bytesRegion bPtr bs)
+      (((.x10 : Reg) ↦ᵣ (if beBytesToNat xs < beBytesToNat bs
+         then (1 : Word) else (0 : Word))) **
+       ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+       ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       regOwn .x6 ** regOwn .x7 ** regOwn .x5 **
+       regOwn .x28 ** regOwn .x29 **
+       bytesRegion aPtr xs **
+       bytesRegion bPtr bs) := by
+  set CR := CodeReq.ofProg ltPBase blskLtBe_prog with hCR
+  -- peel the three MV destinations x5, x6, x7
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x6)
+      (P := (((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs) **
+        regOwn .x5)
+      (fun v6 => ?_))
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x5)
+      (P := (((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs) **
+        ((.x6 : Reg) ↦ᵣ v6))
+      (fun v5 => ?_))
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x7)
+      (P := (((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x28 ** regOwn .x29 **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs) **
+        ((.x6 : Reg) ↦ᵣ v6) ** ((.x5 : Reg) ↦ᵣ v5))
+      (fun v7 => ?_))
+  -- ---- init: mv x5, a0 ; mv x6, a1 ; mv x7, a2 ----
+  have hmv5 := liftCode (cr' := CR)
+    (mv_spec_gen_within .x5 .x10 aPtr v5 ltPBase (by decide))
+    (by rw [hCR]; code_mem)
+  have hmv6 := liftCode (cr' := CR)
+    (mv_spec_gen_within .x6 .x11 bPtr v6 (ltPBase + 4) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show (ltPBase + 4 : Word) + 4 = (ltPBase + 8 : Word) from by decide]
+    at hmv6
+  have hmv7 := liftCode (cr' := CR)
+    (mv_spec_gen_within .x7 .x12 (BitVec.ofNat 64 len) v7 (ltPBase + 8) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show (ltPBase + 8 : Word) + 4 = (ltPBase + 12 : Word) from by decide]
+    at hmv7
+  -- ---- the three-outcome two-tail loop ----
+  have hloop := twoBreakRetLoop_spec (hdr := (ltPBase + 12 : Word)) (ret := ret)
+    (cr := CR) (Q := ltPost aPtr bPtr ret len xs bs) len 9 5
+    (ltInv aPtr bPtr ret len xs bs)
+    (fun i hi => ltIter_spec aPtr bPtr ret len xs bs hlenX hlenB
+      halignA halignB hovA hovB hvalidA hvalidB halignRet i hi)
+    (ltExh_spec aPtr bPtr ret len xs bs hlenX hlenB halignRet)
+  -- ---- frames + chain ----
+  have hmv5F := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+      ((.x11 : Reg) ↦ᵣ bPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      regOwn .x28 ** regOwn .x29 **
+      bytesRegion aPtr xs ** bytesRegion bPtr bs)
+    (by pcf) hmv5
+  have hmv6F := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ aPtr) ** ((.x7 : Reg) ↦ᵣ v7) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x12 : Reg) ↦ᵣ BitVec.ofNat 64 len) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      regOwn .x28 ** regOwn .x29 **
+      bytesRegion aPtr xs ** bytesRegion bPtr bs)
+    (by pcf) hmv6
+  have hmv7F := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ aPtr) ** ((.x6 : Reg) ↦ᵣ bPtr) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      regOwn .x28 ** regOwn .x29 **
+      bytesRegion aPtr xs ** bytesRegion bPtr bs)
+    (by pcf) hmv7
+  have hc1 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hmv5F hmv6F
+  have hc2 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hc1 hmv7F
+  have hc3 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      unfold ltInv
+      refine (sepConj_pure_left h).2
+        ⟨fun j hj => absurd hj (Nat.not_lt_zero j), ?_⟩
+      rw [show (BitVec.ofNat 64 (len - 0) : Word) = BitVec.ofNat 64 len from by
+            rw [Nat.sub_zero],
+          show aPtr + BitVec.ofNat 64 0 = aPtr from by
+            rw [show (BitVec.ofNat 64 0 : Word) = (0 : Word) from rfl]
+            bv_omega,
+          show bPtr + BitVec.ofNat 64 0 = bPtr from by
+            rw [show (BitVec.ofNat 64 0 : Word) = (0 : Word) from rfl]
+            bv_omega]
+      xperm_hyp hp) hc2 hloop
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun h hq => by unfold ltPost at hq; exact hq)
+    (cpsTripleWithin_mono_nSteps (by omega) hc3)
+
+#print axioms blskLtBe_spec
+
+end Bls12KzgLtBeSAsm
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Bls12KzgLtBeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12KzgLtBeSAsm.lean
@@ -62,8 +62,6 @@ open U256MinSAsm (beBytesToNat_lt_of_prefix_lt bytes_eq_of_prefix_all)
 /-- The routine base, symbolic (bead evm-asm-6agnq). -/
 def ltPBase : Word := (GuestAddrs.blsk_lt_be : Word)
 
--- Address anchor (fails the build if the guest link moves).
-#guard GuestAddrs.blsk_lt_be = 0x80032b14
 #guard blskLtBe_prog.length = 16
 -- The comparator is position-independent (no PC-relative instruction).
 

--- a/EvmAsm/Codegen/Programs/Bn254CallAllotmentSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254CallAllotmentSAsm.lean
@@ -52,8 +52,6 @@ namespace Bn254CallAllotmentSAsm
 /-- The routine base, symbolic (bead evm-asm-6agnq). -/
 def allotBase : Word := (GuestAddrs.bn254_call_allotment : Word)
 
--- Address anchor (fails the build if the guest link moves).
-#guard GuestAddrs.bn254_call_allotment = 0x800307f4
 #guard bn254CallAllotment_prog.length = 13
 -- The routine is position-independent (no PC-relative instruction).
 

--- a/EvmAsm/Codegen/Programs/Bn254CallAllotmentSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254CallAllotmentSAsm.lean
@@ -1,0 +1,542 @@
+/-
+  EvmAsm.Codegen.Programs.Bn254CallAllotmentSAsm
+
+  `bn254_call_allotment` — the EIP-150 child gas allotment for a
+  precompile call — via TWO `retJoinStation_spec` forward joins to the
+  routine's single shared `ret` (`EvmAsm/Rv64/SAsm/RetForwardJoin.lean`).
+
+  The routine (see `Bn254Curve.lean`):
+
+  ```
+        ld   a7, 568(s4)              -- remaining = dispatcher gas cell
+        srli s6, a7, 6
+        sub  s6, a7, s6               -- cap = remaining - remaining/64
+        ld   s7, 8(a2) ; ld s8, 16(a2) ; or s7, s7, s8
+        ld   s8, 24(a2) ; or s7, s7, s8   -- high-limb OR of the gas word
+        bne  s7, x0, .ret             -- any high limb set → keep cap
+        ld   s7, 0(a2)                -- low limb
+        bgeu s7, s6, .ret             -- low ≥ cap → keep cap
+        mv   s6, s7                   -- else allot the requested gas
+  .ret: ret
+  ```
+
+  Both guards jump FORWARD to the one shared `ret` — each is one
+  `retJoinStation_spec`; the straight-line prefix is per-instruction
+  `spec_gen` lemmas over the five owned dword cells (the 32-byte
+  LE-limb stack word at `a2` and the dispatcher gas cell at `568(s4)`).
+
+  **Genuine post**: `x22 = bn254Allotment w0 w1 w2 w3 rem` — the REAL
+  EIP-150 rule `min(gas word, remaining - remaining/64)` where any
+  nonzero high limb caps at the 63/64 send limit; `a2`/`s4` and all
+  five memory cells untouched (`x17`/`x23`/`x24` are the documented
+  clobbers).
+
+  Byte-transparent: stated at the `#guard`-tied symbolic
+  `GuestAddrs.bn254_call_allotment` base (bead evm-asm-6agnq) over the
+  emitted `bn254CallAllotment_prog` directly — no guest-byte change,
+  no A/B run needed.
+
+  Bead: evm-asm-4ch8f.57.3.
+-/
+
+import EvmAsm.Codegen.Programs.Bn254Curve
+import EvmAsm.Rv64.SAsm.RetForwardJoin
+import EvmAsm.Rv64.SAsm.FnFlat
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+
+namespace Bn254CallAllotmentSAsm
+
+/-- The routine base, symbolic (bead evm-asm-6agnq). -/
+def allotBase : Word := (GuestAddrs.bn254_call_allotment : Word)
+
+-- Address anchor (fails the build if the guest link moves).
+#guard GuestAddrs.bn254_call_allotment = 0x800307f4
+#guard bn254CallAllotment_prog.length = 13
+-- The routine is position-independent (no PC-relative instruction).
+
+/-
+  Emitted layout relative to `GuestAddrs.bn254_call_allotment`:
+    +0   ld    x17, 568(x20)
+    +4   srli  x22, x17, 6
+    +8   sub   x22, x17, x22
+    +12  ld    x23, 8(x12)
+    +16  ld    x24, 16(x12)
+    +20  or    x23, x23, x24
+    +24  ld    x24, 24(x12)
+    +28  or    x23, x23, x24
+    +32  bne   x23, x0, +16 → +48 (ret)
+    +36  ld    x23, 0(x12)
+    +40  bgeu  x23, x22, +8 → +48 (ret)
+    +44  mv    x22, x23
+    +48  jalr  x0, x1, 0
+-/
+
+/-! ## The routine's semantics -/
+
+/-- The EIP-150 63/64 send limit: `remaining - remaining/64`. -/
+def allotCap (rem : Word) : Word := rem - (rem >>> 6)
+
+/-- The child allotment: the requested gas word (LE u64 limbs
+    `w0 … w3`) capped at the 63/64 limit — any nonzero high limb, or a
+    low limb at/above the cap, allots the cap; otherwise the request. -/
+def bn254Allotment (w0 w1 w2 w3 rem : Word) : Word :=
+  if (w1 ||| w2) ||| w3 = 0 then
+    (if BitVec.ult w0 (allotCap rem) then w0 else allotCap rem)
+  else allotCap rem
+
+/-! ## The whole routine -/
+
+/-- **`bn254_call_allotment` at its linked address** (genuine post):
+    `x22 = bn254Allotment w0 w1 w2 w3 rem`; the gas-word pointer `a2`,
+    the dispatcher base `s4` and all five memory cells untouched;
+    `x17`/`x23`/`x24` are the documented clobbers (returned as owned). -/
+theorem bn254CallAllotment_spec (gp sp ret : Word) (w0 w1 w2 w3 rem : Word)
+    (halignRet : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin 13 allotBase ret
+      (CodeReq.ofProg allotBase bn254CallAllotment_prog)
+      (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+       ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       regOwn .x17 ** regOwn .x22 ** regOwn .x23 ** regOwn .x24 **
+       ((gp + 568) ↦ₘ rem) **
+       (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+       ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3))
+      (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+       ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       regOwn .x17 ** ((.x22 : Reg) ↦ᵣ bn254Allotment w0 w1 w2 w3 rem) **
+       regOwn .x23 ** regOwn .x24 **
+       ((gp + 568) ↦ₘ rem) **
+       (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+       ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3)) := by
+  set CR := CodeReq.ofProg allotBase bn254CallAllotment_prog with hCR
+  set cap := allotCap rem with hcap
+  set hi := (w1 ||| w2) ||| w3 with hhi
+  -- peel the scratch registers
+  refine cpsTripleWithin_weaken
+    (fun h hp => by
+      simp only [regOwns_cons, regOwns_nil, sepConj_emp_right']
+      xperm_hyp hp)
+    (fun _ hq => hq)
+    (cpsTripleWithin_peel_regOwns [.x17, .x22, .x23, .x24] (by decide)
+      (P := ((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((gp + 568) ↦ₘ rem) **
+        (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+        ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3))
+      (fun vf => ?_))
+  simp only [regAtomsOf_cons, regAtomsOf_nil, sepConj_emp_right']
+  -- the shared post, reached by every arm
+  set POST : Assertion :=
+    ((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+    ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+    regOwn .x17 ** ((.x22 : Reg) ↦ᵣ bn254Allotment w0 w1 w2 w3 rem) **
+    regOwn .x23 ** regOwn .x24 **
+    ((gp + 568) ↦ₘ rem) **
+    (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+    ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3) with hPOST
+  -- ---- straight-line prefix (+0 … +28) ----
+  have hld17 := liftCode (cr' := CR)
+    (ld_spec_gen_within .x17 .x20 gp (vf .x17) rem (568 : BitVec 12)
+      allotBase (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show signExtend12 (568 : BitVec 12) = (568 : Word) from by decide,
+      show (allotBase : Word) + 4 = (allotBase + 4 : Word) from by decide]
+    at hld17
+  have hsrli := liftCode (cr' := CR)
+    (srli_spec_gen_within .x22 .x17 (vf .x22) rem (6 : BitVec 6)
+      (allotBase + 4) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show ((6 : BitVec 6)).toNat = 6 from rfl,
+      show (allotBase + 4 : Word) + 4 = (allotBase + 8 : Word) from by decide]
+    at hsrli
+  have hsub := liftCode (cr' := CR)
+    (sub_spec_gen_rd_eq_rs2_within .x22 .x17 rem (rem >>> 6)
+      (allotBase + 8) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show (allotBase + 8 : Word) + 4 = (allotBase + 12 : Word) from by decide]
+    at hsub
+  have hld23 := liftCode (cr' := CR)
+    (ld_spec_gen_within .x23 .x12 sp (vf .x23) w1 (8 : BitVec 12)
+      (allotBase + 12) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show signExtend12 (8 : BitVec 12) = (8 : Word) from by decide,
+      show (allotBase + 12 : Word) + 4 = (allotBase + 16 : Word) from by decide]
+    at hld23
+  have hld24 := liftCode (cr' := CR)
+    (ld_spec_gen_within .x24 .x12 sp (vf .x24) w2 (16 : BitVec 12)
+      (allotBase + 16) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show signExtend12 (16 : BitVec 12) = (16 : Word) from by decide,
+      show (allotBase + 16 : Word) + 4 = (allotBase + 20 : Word) from by decide]
+    at hld24
+  have hor1 := liftCode (cr' := CR)
+    (or_spec_gen_rd_eq_rs1_within .x23 .x24 w1 w2
+      (allotBase + 20) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show (allotBase + 20 : Word) + 4 = (allotBase + 24 : Word) from by decide]
+    at hor1
+  have hld24b := liftCode (cr' := CR)
+    (ld_spec_gen_within .x24 .x12 sp w2 w3 (24 : BitVec 12)
+      (allotBase + 24) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show signExtend12 (24 : BitVec 12) = (24 : Word) from by decide,
+      show (allotBase + 24 : Word) + 4 = (allotBase + 28 : Word) from by decide]
+    at hld24b
+  have hor2 := liftCode (cr' := CR)
+    (or_spec_gen_rd_eq_rs1_within .x23 .x24 (w1 ||| w2) w3
+      (allotBase + 28) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show (allotBase + 28 : Word) + 4 = (allotBase + 32 : Word) from by decide]
+    at hor2
+  -- frames for the prefix
+  have hld17F := cpsTripleWithin_frameR
+    (((.x12 : Reg) ↦ᵣ sp) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x22 : Reg) ↦ᵣ vf .x22) ** ((.x23 : Reg) ↦ᵣ vf .x23) **
+      ((.x24 : Reg) ↦ᵣ vf .x24) **
+      (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+      ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3))
+    (by pcf) hld17
+  have hsrliF := cpsTripleWithin_frameR
+    (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x23 : Reg) ↦ᵣ vf .x23) ** ((.x24 : Reg) ↦ᵣ vf .x24) **
+      ((gp + 568) ↦ₘ rem) **
+      (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+      ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3))
+    (by pcf) hsrli
+  have hsubF := cpsTripleWithin_frameR
+    (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x23 : Reg) ↦ᵣ vf .x23) ** ((.x24 : Reg) ↦ᵣ vf .x24) **
+      ((gp + 568) ↦ₘ rem) **
+      (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+      ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3))
+    (by pcf) hsub
+  have hld23F := cpsTripleWithin_frameR
+    (((.x20 : Reg) ↦ᵣ gp) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x17 : Reg) ↦ᵣ rem) ** ((.x22 : Reg) ↦ᵣ (rem - rem >>> 6)) **
+      ((.x24 : Reg) ↦ᵣ vf .x24) **
+      ((gp + 568) ↦ₘ rem) **
+      (sp ↦ₘ w0) ** ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3))
+    (by pcf) hld23
+  have hld24F := cpsTripleWithin_frameR
+    (((.x20 : Reg) ↦ᵣ gp) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x17 : Reg) ↦ᵣ rem) ** ((.x22 : Reg) ↦ᵣ (rem - rem >>> 6)) **
+      ((.x23 : Reg) ↦ᵣ w1) **
+      ((gp + 568) ↦ₘ rem) **
+      (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) ** ((sp + 24) ↦ₘ w3))
+    (by pcf) hld24
+  have hor1F := cpsTripleWithin_frameR
+    (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x17 : Reg) ↦ᵣ rem) ** ((.x22 : Reg) ↦ᵣ (rem - rem >>> 6)) **
+      ((gp + 568) ↦ₘ rem) **
+      (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+      ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3))
+    (by pcf) hor1
+  have hld24bF := cpsTripleWithin_frameR
+    (((.x20 : Reg) ↦ᵣ gp) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x17 : Reg) ↦ᵣ rem) ** ((.x22 : Reg) ↦ᵣ (rem - rem >>> 6)) **
+      ((.x23 : Reg) ↦ᵣ (w1 ||| w2)) **
+      ((gp + 568) ↦ₘ rem) **
+      (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) ** ((sp + 16) ↦ₘ w2))
+    (by pcf) hld24b
+  have hor2F := cpsTripleWithin_frameR
+    (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x17 : Reg) ↦ᵣ rem) ** ((.x22 : Reg) ↦ᵣ (rem - rem >>> 6)) **
+      ((gp + 568) ↦ₘ rem) **
+      (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+      ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3))
+    (by pcf) hor2
+  -- ---- the shared ret (+48), one arm per x22 value ----
+  have hret : ∀ x22v x23v x24v : Word,
+      x22v = bn254Allotment w0 w1 w2 w3 rem →
+      cpsTripleWithin 1 (allotBase + 48) ret CR
+        (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+          ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x17 : Reg) ↦ᵣ rem) ** ((.x22 : Reg) ↦ᵣ x22v) **
+          ((.x23 : Reg) ↦ᵣ x23v) ** ((.x24 : Reg) ↦ᵣ x24v) **
+          ((gp + 568) ↦ₘ rem) **
+          (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+          ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3))
+        POST := by
+    intro x22v x23v x24v hx22
+    have h := cpsTripleWithin_extend_code (cr' := CR)
+      (hmono := by rw [hCR]; code_mem)
+      (h := EvmAsm.Evm64.ret_spec_within' (allotBase + 48) ret)
+    rw [halignRet] at h
+    have hF := cpsTripleWithin_frameR
+      (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x17 : Reg) ↦ᵣ rem) ** ((.x22 : Reg) ↦ᵣ x22v) **
+        ((.x23 : Reg) ↦ᵣ x23v) ** ((.x24 : Reg) ↦ᵣ x24v) **
+        ((gp + 568) ↦ₘ rem) **
+        (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+        ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3))
+      (by pcf) h
+    refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+      (fun h hq => ?_) hF
+    rw [hPOST, ← hx22]
+    have hq1 : (((.x17 : Reg) ↦ᵣ rem) ** (((.x23 : Reg) ↦ᵣ x23v) **
+        (((.x24 : Reg) ↦ᵣ x24v) **
+          (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+           ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+           ((.x22 : Reg) ↦ᵣ x22v) **
+           ((gp + 568) ↦ₘ rem) **
+           (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+           ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3))))) h := by
+      xperm_hyp hq
+    have hq2 := sepConj_mono (regIs_to_regOwn .x17 _)
+      (sepConj_mono (regIs_to_regOwn .x23 _)
+        (sepConj_mono (regIs_to_regOwn .x24 _)
+          (fun _ hh => hh))) h hq1
+    xperm_hyp hq2
+  -- ---- the low-limb guard (+36 … +44) into the shared ret ----
+  have hlow : hi = 0 →
+      cpsTripleWithin 4 (allotBase + 36) ret CR
+        (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+          ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x17 : Reg) ↦ᵣ rem) ** ((.x22 : Reg) ↦ᵣ (rem - rem >>> 6)) **
+          ((.x23 : Reg) ↦ᵣ hi) ** ((.x24 : Reg) ↦ᵣ w3) **
+          ((gp + 568) ↦ₘ rem) **
+          (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+          ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3))
+        POST := by
+    intro hhiz
+    -- ld x23, 0(x12)
+    have hld := liftCode (cr' := CR)
+      (ld_spec_gen_within .x23 .x12 sp hi w0 (0 : BitVec 12)
+        (allotBase + 36) (by decide))
+      (by rw [hCR]; code_mem)
+    rw [show sp + signExtend12 (0 : BitVec 12) = sp from by
+          rw [signExtend12_0]; bv_omega,
+        show (allotBase + 36 : Word) + 4 = (allotBase + 40 : Word) from by decide]
+      at hld
+    have hldF := cpsTripleWithin_frameR
+      (((.x20 : Reg) ↦ᵣ gp) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x17 : Reg) ↦ᵣ rem) ** ((.x22 : Reg) ↦ᵣ (rem - rem >>> 6)) **
+        ((.x24 : Reg) ↦ᵣ w3) **
+        ((gp + 568) ↦ₘ rem) **
+        ((sp + 8) ↦ₘ w1) ** ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3))
+      (by pcf) hld
+    -- bgeu x23, x22 (+40)
+    have hbrGe := cpsBranchWithin_frameR
+      (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x17 : Reg) ↦ᵣ rem) ** ((.x24 : Reg) ↦ᵣ w3) **
+        ((gp + 568) ↦ₘ rem) **
+        (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+        ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3))
+      (by pcf)
+      (cpsBranchWithin_extend_code (cr' := CR)
+        (h := bgeu_spec_gen_within .x23 .x22 (8 : BitVec 13) w0
+          (rem - rem >>> 6) (allotBase + 40))
+        (hmono := by rw [hCR]; code_mem))
+    rw [show (allotBase + 40 : Word) + signExtend13 (8 : BitVec 13)
+          = (allotBase + 48 : Word) from by decide,
+        show (allotBase + 40 : Word) + 4 = (allotBase + 44 : Word) from by decide]
+      at hbrGe
+    -- ge arm: keep the cap
+    have hge : ¬ BitVec.ult w0 (rem - rem >>> 6) →
+        cpsTripleWithin 2 (allotBase + 48) ret CR
+          (((.x23 : Reg) ↦ᵣ w0) ** ((.x22 : Reg) ↦ᵣ (rem - rem >>> 6)) **
+            (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+             ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+             ((.x17 : Reg) ↦ᵣ rem) ** ((.x24 : Reg) ↦ᵣ w3) **
+             ((gp + 568) ↦ₘ rem) **
+             (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+             ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3)))
+          POST := by
+      intro hnlt
+      have hx22 : (rem - rem >>> 6) = bn254Allotment w0 w1 w2 w3 rem := by
+        unfold bn254Allotment allotCap
+        rw [← hhi, if_pos hhiz, if_neg hnlt]
+      refine cpsTripleWithin_mono_nSteps (by omega)
+        (cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+          (fun _ hq => hq)
+          (hret (rem - rem >>> 6) w0 w3 hx22))
+    -- lt arm: mv x22, x23 then ret
+    have hlt : BitVec.ult w0 (rem - rem >>> 6) →
+        cpsTripleWithin 2 (allotBase + 44) ret CR
+          (((.x23 : Reg) ↦ᵣ w0) ** ((.x22 : Reg) ↦ᵣ (rem - rem >>> 6)) **
+            (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+             ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+             ((.x17 : Reg) ↦ᵣ rem) ** ((.x24 : Reg) ↦ᵣ w3) **
+             ((gp + 568) ↦ₘ rem) **
+             (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+             ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3)))
+          POST := by
+      intro hltc
+      have hmv := liftCode (cr' := CR)
+        (mv_spec_gen_within .x22 .x23 w0 (rem - rem >>> 6)
+          (allotBase + 44) (by decide))
+        (by rw [hCR]; code_mem)
+      rw [show (allotBase + 44 : Word) + 4 = (allotBase + 48 : Word) from by decide]
+        at hmv
+      have hmvF := cpsTripleWithin_frameR
+        (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+          ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x17 : Reg) ↦ᵣ rem) ** ((.x24 : Reg) ↦ᵣ w3) **
+          ((gp + 568) ↦ₘ rem) **
+          (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+          ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3))
+        (by pcf) hmv
+      have hx22 : w0 = bn254Allotment w0 w1 w2 w3 rem := by
+        unfold bn254Allotment allotCap
+        rw [← hhi, if_pos hhiz, if_pos hltc]
+      have hc := cpsTripleWithin_seq_perm_same_cr
+        (fun _ hp => by xperm_hyp hp) hmvF
+        (hret w0 w0 w3 hx22)
+      exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+        (fun _ hq => hq) hc
+    -- the low-limb station
+    have hstGe := retJoinStation_spec
+      (cond := ¬ BitVec.ult w0 (rem - rem >>> 6))
+      (PT := ((.x23 : Reg) ↦ᵣ w0) ** ((.x22 : Reg) ↦ᵣ (rem - rem >>> 6)) **
+        (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+         ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x17 : Reg) ↦ᵣ rem) ** ((.x24 : Reg) ↦ᵣ w3) **
+         ((gp + 568) ↦ₘ rem) **
+         (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+         ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3)))
+      (PF := ((.x23 : Reg) ↦ᵣ w0) ** ((.x22 : Reg) ↦ᵣ (rem - rem >>> 6)) **
+        (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+         ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x17 : Reg) ↦ᵣ rem) ** ((.x24 : Reg) ↦ᵣ w3) **
+         ((gp + 568) ↦ₘ rem) **
+         (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+         ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3)))
+      hbrGe
+      (fun h hq => by xperm_hyp hq)
+      (fun h hq => by
+        have hq1 : (⌜BitVec.ult w0 (rem - rem >>> 6)⌝ **
+            (((.x23 : Reg) ↦ᵣ w0) **
+             ((.x22 : Reg) ↦ᵣ (rem - rem >>> 6)) **
+             ((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+             ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+             ((.x17 : Reg) ↦ᵣ rem) ** ((.x24 : Reg) ↦ᵣ w3) **
+             ((gp + 568) ↦ₘ rem) **
+             (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+             ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3))) h := by
+          xperm_hyp hq
+        obtain ⟨hltc, hrest⟩ := (sepConj_pure_left h).1 hq1
+        exact (sepConj_pure_left h).2 ⟨fun hn => hn hltc, hrest⟩)
+      (fun hnlt => hge hnlt)
+      (fun hnn => hlt (not_not.mp hnn))
+    -- ld ; station
+    have hc := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by xperm_hyp hp) hldF hstGe
+    exact cpsTripleWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+        (fun _ hq => hq) hc)
+  -- ---- the high-limb guard (BNE at +32) ----
+  have hbrHi := cpsBranchWithin_frameR
+    (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+      ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x17 : Reg) ↦ᵣ rem) ** ((.x22 : Reg) ↦ᵣ (rem - rem >>> 6)) **
+      ((.x24 : Reg) ↦ᵣ w3) **
+      ((gp + 568) ↦ₘ rem) **
+      (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+      ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3))
+    (by pcf)
+    (cpsBranchWithin_extend_code (cr' := CR)
+      (h := bne_spec_gen_within .x23 .x0 (16 : BitVec 13) hi (0 : Word)
+        (allotBase + 32))
+      (hmono := by rw [hCR]; code_mem))
+  rw [show (allotBase + 32 : Word) + signExtend13 (16 : BitVec 13)
+        = (allotBase + 48 : Word) from by decide,
+      show (allotBase + 32 : Word) + 4 = (allotBase + 36 : Word) from by decide]
+    at hbrHi
+  -- taken arm: keep the cap
+  have hhiTail : hi ≠ 0 →
+      cpsTripleWithin 4 (allotBase + 48) ret CR
+        (((.x23 : Reg) ↦ᵣ hi) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+           ((.x1 : Reg) ↦ᵣ ret) **
+           ((.x17 : Reg) ↦ᵣ rem) ** ((.x22 : Reg) ↦ᵣ (rem - rem >>> 6)) **
+           ((.x24 : Reg) ↦ᵣ w3) **
+           ((gp + 568) ↦ₘ rem) **
+           (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+           ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3)))
+        POST := by
+    intro hne
+    have hx22 : (rem - rem >>> 6) = bn254Allotment w0 w1 w2 w3 rem := by
+      unfold bn254Allotment allotCap
+      rw [← hhi, if_neg hne]
+    exact cpsTripleWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+        (fun _ hq => hq)
+        (hret (rem - rem >>> 6) hi w3 hx22))
+  -- the high-limb station
+  have hstHi := retJoinStation_spec
+    (cond := hi ≠ (0 : Word))
+    (PT := ((.x23 : Reg) ↦ᵣ hi) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+       ((.x1 : Reg) ↦ᵣ ret) **
+       ((.x17 : Reg) ↦ᵣ rem) ** ((.x22 : Reg) ↦ᵣ (rem - rem >>> 6)) **
+       ((.x24 : Reg) ↦ᵣ w3) **
+       ((gp + 568) ↦ₘ rem) **
+       (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+       ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3)))
+    (PF := ((.x23 : Reg) ↦ᵣ hi) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      (((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+       ((.x1 : Reg) ↦ᵣ ret) **
+       ((.x17 : Reg) ↦ᵣ rem) ** ((.x22 : Reg) ↦ᵣ (rem - rem >>> 6)) **
+       ((.x24 : Reg) ↦ᵣ w3) **
+       ((gp + 568) ↦ₘ rem) **
+       (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+       ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3)))
+    hbrHi
+    (fun h hq => by xperm_hyp hq)
+    (fun h hq => by
+      have hq1 : (⌜hi = (0 : Word)⌝ **
+          (((.x23 : Reg) ↦ᵣ hi) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+           ((.x20 : Reg) ↦ᵣ gp) ** ((.x12 : Reg) ↦ᵣ sp) **
+           ((.x1 : Reg) ↦ᵣ ret) **
+           ((.x17 : Reg) ↦ᵣ rem) ** ((.x22 : Reg) ↦ᵣ (rem - rem >>> 6)) **
+           ((.x24 : Reg) ↦ᵣ w3) **
+           ((gp + 568) ↦ₘ rem) **
+           (sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+           ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3))) h := by
+        xperm_hyp hq
+      obtain ⟨hz, hrest⟩ := (sepConj_pure_left h).1 hq1
+      exact (sepConj_pure_left h).2 ⟨fun hn => hn hz, hrest⟩)
+    (fun hne => hhiTail hne)
+    (fun hnn => by
+      have hz : hi = 0 := not_not.mp hnn
+      refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+        (fun _ hq => hq) (hlow hz))
+  -- ---- assemble the straight-line prefix into the station ----
+  have hc1 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hld17F hsrliF
+  have hc2 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hc1 hsubF
+  have hc3 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hc2 hld23F
+  have hc4 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hc3 hld24F
+  have hc5 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hc4 hor1F
+  have hc6 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hc5 hld24bF
+  have hc7 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hc6 hor2F
+  have hc8 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by rw [hhi]; xperm_hyp hp) hc7 hstHi
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun h hq => by rw [hPOST] at hq; xperm_hyp hq)
+    (cpsTripleWithin_mono_nSteps (by omega) hc8)
+
+#print axioms bn254CallAllotment_spec
+
+end Bn254CallAllotmentSAsm
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Bn254FieldAddModPSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254FieldAddModPSAsm.lean
@@ -1,0 +1,744 @@
+/-
+  EvmAsm.Codegen.Programs.Bn254FieldAddModPSAsm
+
+  `bnf_add_mod_p` via the **multi-RW-subwindow callee adapter**
+  (`EvmAsm/Rv64/SAsm/RwSubwindow.lean`, bead evm-asm-4ch8f.38.5) — the
+  acceptance consumer for the converter+arithMod crypto caller layer.
+
+  The routine is an sp-frame (`ra`/`s0`/`s1`) around a SEQUENCE of callees
+  that each write a different subwindow of the global LE staging arena
+  (`bnf_le_a` … `bnf_add_params`, one contiguous `.data` block):
+
+  ```
+    s0 := a1 ; s1 := a2
+    la a1, bnf_le_a      ; call bnf_be_to_le   -- writes arena[0x00..0x20)
+    a0 := s0
+    la a1, bnf_le_b      ; call bnf_be_to_le   -- writes arena[0x20..0x40)
+    la t0, bnf_add_params; csrs 2050, t0       -- writes arena[0x40..0x60)
+    la a0, bnf_le_d ; a1 := s1
+    call bnf_le_to_be                          -- reads _d, writes out
+    a0 := 0
+  ```
+
+  Each call's write window is carved from the arena atom
+  (`bytesRegion_window_focus`), handed to the callee as its whole `rw`
+  (the converter contracts are `Fn.retSpecFlat`-derived, #9988), and
+  merged back (`bytesRegion_window_update`) — the other subwindows
+  (the one factor, the addend, the modulus, the parameter block) PROVABLY ride
+  through untouched (`wsNat256_setBytes_high` etc.), which is exactly what
+  lets the inline `arithMod` accelerator step
+  (`csrs_arith256Mod_spec_within`, CSR 0x802 = 2050) decode its operands
+  from the accumulated arena image.  The `la`-materialized subwindow
+  addresses are `la_resolve`-proven (#10059/#10064).
+
+  **Genuine post** (`bnfAddModP_spec`): with `one₀ = wsNat256 ws 0x80` and `m₀ = wsNat256 ws 0xA0` (the
+  modulus staged in the arena — the guest data pins it to the BN254 prime)
+  and the one-factor cell at offset 0x80, the external output holds
+  `beBytesToNat out' = Accel.arith256Mod (beBytesToNat aBE) one₀ (beBytesToNat bBE) m₀`
+  (`Accel.arith256Mod`), `sp`/`ra`/`s0`/`s1` restored to entry, inputs and
+  non-written arena cells untouched.  Byte-transparent: the emitted
+  `bnfAddModP_prog` IS `abiFrameProg (-32)/(+32)` over the body
+  (kernel-checked `rfl`), at the `#guard`-tied `GuestAddrs`.
+-/
+
+import EvmAsm.Codegen.Programs.Bn254Field
+import EvmAsm.Codegen.Programs.Bn254FieldConvSAsm
+import EvmAsm.Codegen.Programs.Bn254FieldConvSAsmLeToBe
+import EvmAsm.Rv64.SAsm.RwSubwindow
+import EvmAsm.Rv64.SAsm.AbiFrameCall
+import EvmAsm.Rv64.SAsm.FnFlat
+import EvmAsm.Rv64.LaResolve
+import EvmAsm.Crypto.PowLadder
+import EvmAsm.Codegen.Programs.Bn254FieldAddModPSAsmStage
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Crypto
+
+namespace Bn254FieldAddModPSAsm
+
+open Bn254FieldConvSAsm (bnfBeToLeFn bnfBeToLeFn_spec bnfLeToBeFn bnfLeToBeFn_spec)
+
+#guard abiFrameProg (-32 : BitVec 12) (32 : BitVec 12) addFrame addBody = bnfAddModP_prog
+
+/-- Entry values of the saved registers. -/
+def addVals (ret v8 v9 : Word) : Reg → Word :=
+  fun r => match r with
+  | .x1 => ret | .x8 => v8 | .x9 => v9 | _ => 0
+
+/-- Post-body values: `ra` holds the last call's link address, `s0`/`s1`
+    the operand/output pointer copies. -/
+def addVals' (bPtr outPtr : Word) : Reg → Word :=
+  fun r => match r with
+  | .x1 => (0x80030240 : Word) | .x8 => bPtr | .x9 => outPtr | _ => 0
+
+/-- Exposed registers beyond the three pinned argument pointers. -/
+def addRest : List Reg :=
+  [.x5, .x6, .x7, .x28, .x29, .x30, .x31, .x13, .x14, .x15, .x16, .x17]
+
+/-- The modular addition result the routine computes via the add parameter block. -/
+def addResult (aBE bBE ws : List (BitVec 8)) : Nat :=
+  Accel.arith256Mod (beBytesToNat aBE) (wsNat256 ws 0x80)
+    (beBytesToNat bBE) (wsNat256 ws 0xA0)
+
+private theorem ownsExposedSplit :
+    regOwns exposedRegs = (regOwns [.x10, .x11] ** regOwns convScratch) := by
+  show regOwns
+      [.x5, .x6, .x7, .x28, .x29, .x30, .x31,
+       .x10, .x11, .x12, .x13, .x14, .x15, .x16, .x17] = _
+  simp only [convScratch, regOwns_cons, regOwns_nil, sepConj_emp_right']
+  funext h
+  exact propext ⟨fun hp => by xperm_hyp hp, fun hp => by xperm_hyp hp⟩
+
+private theorem ownsConvSplit12 :
+    regOwns convScratch = (regOwn .x12 ** regOwns addRest) := by
+  show regOwns
+      [.x5, .x6, .x7, .x28, .x29, .x30, .x31,
+       .x12, .x13, .x14, .x15, .x16, .x17] = _
+  simp only [addRest, regOwns_cons, regOwns_nil]
+  funext h
+  exact propext ⟨fun hp => by xperm_hyp hp, fun hp => by xperm_hyp hp⟩
+
+private theorem ownsSplit1112 :
+    regOwns outRest = (regOwn .x11 ** regOwn .x12 ** regOwns addRest) := by
+  show regOwns
+      [.x5, .x6, .x7, .x28, .x29, .x30, .x31,
+       .x11, .x12, .x13, .x14, .x15, .x16, .x17] = _
+  simp only [addRest, regOwns_cons, regOwns_nil]
+  funext h
+  exact propext ⟨fun hp => by xperm_hyp hp, fun hp => by xperm_hyp hp⟩
+
+/-- Pull three data out of an ∃-post. -/
+private theorem exists_pull3 {α β γ : Sort _} {F : α → β → γ → Assertion}
+    {G : Assertion} (h : PartialState) (hin : ∃ a b c, (G ** F a b c) h) :
+    (G ** (fun hp => ∃ a b c, F a b c hp) : Assertion) h := by
+  obtain ⟨a, b, c, h1, h2, hd, hu, hG, hF⟩ := hin
+  exact ⟨h1, h2, hd, hu, hG, ⟨a, b, c, hF⟩⟩
+
+/-- `pcFree` for a triply-existential post. -/
+private theorem pcFree_exists3 {α β γ : Sort _} {F : α → β → γ → Assertion}
+    (h : ∀ a b c, (F a b c).pcFree) :
+    Assertion.pcFree (fun hp => ∃ a b c, F a b c hp) := by
+  rintro hp ⟨a, b, c, hF⟩
+  exact h a b c hp hF
+
+/-- **`bnf_add_mod_p` at its linked address** (genuine post): the external
+    output window holds the big-endian encoding of
+    `(beBytesToNat aBE * beBytesToNat bBE + c₀) mod m₀`, where `c₀`/`m₀`
+    are the arena's staged addend/modulus cells (the guest data pins them
+    to `0` / the BN254 prime); `sp`/`ra`/`s0`/`s1` restored to entry; the
+    inputs and every non-written arena subwindow framed through. -/
+theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
+    (aBE bBE outOld ws : List (BitVec 8))
+    (halen : aBE.length = 32) (hblen : bBE.length = 32)
+    (holen : outOld.length = 32) (hwslen : ws.length = 272)
+    (hwfA : Region.wf ⟨aPtr, aBE⟩) (hwfB : Region.wf ⟨bPtr, bBE⟩)
+    (hoal : outPtr.toNat % 8 = 0) (hoov : outPtr.toNat + 32 < 2 ^ 64)
+    (hovalid : ∀ k, k < 32 → isValidMemAddr (outPtr + BitVec.ofNat 64 k) = true)
+    (harval : ∀ j, j < 272 → isValidMemAddr (arenaB + BitVec.ofNat 64 j) = true)
+    (hdA : aPtr.toNat + 32 ≤ (0xbb55d9b0 : Nat) ∨ (0xbb55d9d0 : Nat) ≤ aPtr.toNat)
+    (hdB : bPtr.toNat + 32 ≤ (0xbb55d9d0 : Nat) ∨ (0xbb55d9f0 : Nat) ≤ bPtr.toNat)
+    (hdO : (0xbb55da10 : Nat) ≤ outPtr.toNat ∨ outPtr.toNat + 32 ≤ (0xbb55d9f0 : Nat))
+    (hpa : wsDword ws 0xE8 = arenaB + BitVec.ofNat 64 0)
+    (hpb : wsDword ws 0xF0 = arenaB + BitVec.ofNat 64 0x80)
+    (hpc : wsDword ws 0xF8 = arenaB + BitVec.ofNat 64 0x20)
+    (hpm : wsDword ws 0x100 = arenaB + BitVec.ofNat 64 0xA0)
+    (hpd : wsDword ws 0x108 = arenaB + BitVec.ofNat 64 0x40)
+    (hmne : wsNat256 ws 0xA0 ≠ 0)
+    (halign : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin
+      (1 + addFrame.length
+        + (17 + ((bnfBeToLeFn 0 0 [] []).body.steps + 1) * 2
+            + ((bnfLeToBeFn 0 0 [] []).body.steps + 1))
+        + addFrame.length + 1 + 1)
+      (0x800301f0 : Word) ret addCr
+      ((.x2 ↦ᵣ sp0) ** regsAt addFrame (addVals ret v8 v9)
+        ** frameSlotsOwn addFrame (sp0 + signExtend12 (-32 : BitVec 12))
+        ** (((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr)
+          ** ((.x12 : Reg) ↦ᵣ outPtr) ** regOwns addRest
+          ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+          ** bytesRegion outPtr outOld ** bytesRegion arenaB ws))
+      ((.x2 ↦ᵣ sp0) ** regsAt addFrame (addVals ret v8 v9)
+        ** frameSlotsSaved addFrame (sp0 + signExtend12 (-32 : BitVec 12))
+            (addVals ret v8 v9)
+        ** (fun hp => ∃ ws₁ ws₂ out',
+            ((⌜wsNat256 ws₁ 0 = beBytesToNat aBE ∧ ws₁.length = 32
+              ∧ wsNat256 ws₂ 0 = beBytesToNat bBE ∧ ws₂.length = 32
+              ∧ beBytesToNat out' = addResult aBE bBE ws ∧ out'.length = 32⌝
+              ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x11 ** regOwn .x12
+              ** regOwns addRest
+              ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+              ** bytesRegion outPtr out'
+              ** bytesRegion arenaB
+                (setBytes (setBytes (setBytes ws 0 ws₁) 0x20 ws₂) 0x40
+                  (leBytes32 (addResult aBE bBE ws))))) hp)) := by
+  -- ---- the single-exit body triple, in `abiFrame_spec` shape ----
+  have hbody : cpsTripleWithin
+      (17 + ((bnfBeToLeFn 0 0 [] []).body.steps + 1) * 2
+        + ((bnfLeToBeFn 0 0 [] []).body.steps + 1))
+      ((0x800301f0 : Word) + BitVec.ofNat 64 (4 * (1 + addFrame.length)))
+      ((0x800301f0 : Word)
+        + BitVec.ofNat 64 (4 * (1 + addFrame.length + addBody.length)))
+      addCr
+      ((.x2 ↦ᵣ (sp0 + signExtend12 (-32 : BitVec 12)))
+        ** regsAt addFrame (addVals ret v8 v9)
+        ** frameSlotsSaved addFrame (sp0 + signExtend12 (-32 : BitVec 12))
+            (addVals ret v8 v9)
+        ** (((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr)
+          ** ((.x12 : Reg) ↦ᵣ outPtr) ** regOwns addRest
+          ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+          ** bytesRegion outPtr outOld ** bytesRegion arenaB ws))
+      ((.x2 ↦ᵣ (sp0 + signExtend12 (-32 : BitVec 12)))
+        ** regsAt addFrame (addVals' bPtr outPtr)
+        ** frameSlotsSaved addFrame (sp0 + signExtend12 (-32 : BitVec 12))
+            (addVals ret v8 v9)
+        ** (fun hp => ∃ ws₁ ws₂ out',
+            ((⌜wsNat256 ws₁ 0 = beBytesToNat aBE ∧ ws₁.length = 32
+              ∧ wsNat256 ws₂ 0 = beBytesToNat bBE ∧ ws₂.length = 32
+              ∧ beBytesToNat out' = addResult aBE bBE ws ∧ out'.length = 32⌝
+              ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x11 ** regOwn .x12
+              ** regOwns addRest
+              ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+              ** bytesRegion outPtr out'
+              ** bytesRegion arenaB
+                (setBytes (setBytes (setBytes ws 0 ws₁) 0x20 ws₂) 0x40
+                  (leBytes32 (addResult aBE bBE ws))))) hp)) := by
+    have hentry : (0x800301f0 : Word)
+          + BitVec.ofNat 64 (4 * (1 + addFrame.length))
+        = (0x80030200 : Word) := by decide
+    have hexit : (0x800301f0 : Word)
+          + BitVec.ofNat 64 (4 * (1 + addFrame.length + addBody.length))
+        = (0x80030244 : Word) := by decide
+    rw [hentry, hexit]
+    -- ---- the continuation past the first call (per written `_a` window) ----
+    have hB : ∀ ws₁ : List (BitVec 8),
+        cpsTripleWithin
+          ((4 + ((bnfBeToLeFn 0 0 [] []).body.steps + 1))
+            + (7 + ((bnfLeToBeFn 0 0 [] []).body.steps + 1) + 1))
+          (0x80030214 : Word) (0x80030244 : Word) addCr
+          (⌜wsNat256 ws₁ 0 = beBytesToNat aBE ∧ ws₁.length = 32⌝
+            ** ((.x1 : Reg) ↦ᵣ (0x80030214 : Word)) ** regOwns exposedRegs
+            ** bytesRegion (0xbb55d9b0 : Word) ws₁ ** bytesRegion aPtr aBE
+            ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr) ** bytesRegion bPtr bBE
+            ** bytesRegion outPtr outOld ** windowRest arenaB ws 0 32)
+          (((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+            ** (.x9 ↦ᵣ outPtr)
+            ** (fun hp => ∃ ws₁' ws₂' out',
+              ((⌜wsNat256 ws₁' 0 = beBytesToNat aBE ∧ ws₁'.length = 32
+                ∧ wsNat256 ws₂' 0 = beBytesToNat bBE ∧ ws₂'.length = 32
+                ∧ beBytesToNat out' = addResult aBE bBE ws ∧ out'.length = 32⌝
+                ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x11 ** regOwn .x12
+                ** regOwns addRest
+                ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+                ** bytesRegion outPtr out'
+                ** bytesRegion arenaB
+                  (setBytes (setBytes (setBytes ws 0 ws₁') 0x20 ws₂') 0x40
+                    (leBytes32 (addResult aBE bBE ws))))) hp)) := by
+      intro ws₁
+      refine cpsTripleWithin_pure_pre (fun hfacts₁ => ?_)
+      obtain ⟨hf1a, hf1b⟩ := hfacts₁
+      -- ---- the stage-C continuation (per written `_b` window) ----
+      have hC : ∀ ws₂ : List (BitVec 8),
+          cpsTripleWithin (7 + ((bnfLeToBeFn 0 0 [] []).body.steps + 1) + 1)
+            (0x80030224 : Word) (0x80030244 : Word) addCr
+            (⌜wsNat256 ws₂ 0 = beBytesToNat bBE ∧ ws₂.length = 32⌝
+              ** ((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** regOwns exposedRegs
+              ** bytesRegion (0xbb55d9d0 : Word) ws₂ ** bytesRegion bPtr bBE
+              ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr) ** bytesRegion aPtr aBE
+              ** bytesRegion outPtr outOld
+              ** windowRest arenaB (setBytes ws 0 ws₁) 0x20 32)
+            (((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+              ** (.x9 ↦ᵣ outPtr)
+              ** (fun hp => ∃ ws₁' ws₂' out',
+                ((⌜wsNat256 ws₁' 0 = beBytesToNat aBE ∧ ws₁'.length = 32
+                  ∧ wsNat256 ws₂' 0 = beBytesToNat bBE ∧ ws₂'.length = 32
+                  ∧ beBytesToNat out' = addResult aBE bBE ws
+                  ∧ out'.length = 32⌝
+                  ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x11 ** regOwn .x12
+                  ** regOwns addRest
+                  ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+                  ** bytesRegion outPtr out'
+                  ** bytesRegion arenaB
+                    (setBytes (setBytes (setBytes ws 0 ws₁') 0x20 ws₂') 0x40
+                      (leBytes32 (addResult aBE bBE ws))))) hp)) := by
+        intro ws₂
+        refine cpsTripleWithin_pure_pre (fun hfacts₂ => ?_)
+        obtain ⟨hf2a, hf2b⟩ := hfacts₂
+        -- decode the accumulated arena image at the accelerator operands
+        have e0 : wsNat256 (setBytes (setBytes ws 0 ws₁) 0x20 ws₂) 0
+            = beBytesToNat aBE := by
+          rw [wsNat256_setBytes_low (by omega),
+            wsNat256_setBytes_inside hf1b (by omega), hf1a]
+        have e1 : wsNat256 (setBytes (setBytes ws 0 ws₁) 0x20 ws₂) 0x80
+            = wsNat256 ws 0x80 := by
+          rw [wsNat256_setBytes_high (by omega),
+            wsNat256_setBytes_high (by omega)]
+        have e2 : wsNat256 (setBytes (setBytes ws 0 ws₁) 0x20 ws₂) 0x20
+            = beBytesToNat bBE := by
+          rw [wsNat256_setBytes_inside hf2b (by rw [length_setBytes]; omega),
+            hf2a]
+        have e3 : wsNat256 (setBytes (setBytes ws 0 ws₁) 0x20 ws₂) 0xA0
+            = wsNat256 ws 0xA0 := by
+          rw [wsNat256_setBytes_high (by omega),
+            wsNat256_setBytes_high (by omega)]
+        have hstage := stageC_spec aPtr bPtr outPtr aBE bBE outOld
+          (setBytes (setBytes ws 0 ws₁) 0x20 ws₂)
+          (by rw [length_setBytes, length_setBytes]; exact hwslen)
+          holen hoal hoov hovalid harval hdO
+          (by
+            rw [wsDword_setBytes_high (by omega),
+              wsDword_setBytes_high (by omega)]
+            exact hpa)
+          (by
+            rw [wsDword_setBytes_high (by omega),
+              wsDword_setBytes_high (by omega)]
+            exact hpb)
+          (by
+            rw [wsDword_setBytes_high (by omega),
+              wsDword_setBytes_high (by omega)]
+            exact hpc)
+          (by
+            rw [wsDword_setBytes_high (by omega),
+              wsDword_setBytes_high (by omega)]
+            exact hpm)
+          (by
+            rw [wsDword_setBytes_high (by omega),
+              wsDword_setBytes_high (by omega)]
+            exact hpd)
+          (by
+            rw [wsNat256_setBytes_high (by omega),
+              wsNat256_setBytes_high (by omega)]
+            exact hmne)
+        have hcompute : Accel.arith256Mod
+            (wsNat256 (setBytes (setBytes ws 0 ws₁) 0x20 ws₂) 0)
+            (wsNat256 (setBytes (setBytes ws 0 ws₁) 0x20 ws₂) 0x80)
+            (wsNat256 (setBytes (setBytes ws 0 ws₁) 0x20 ws₂) 0x20)
+            (wsNat256 (setBytes (setBytes ws 0 ws₁) 0x20 ws₂) 0xA0)
+            = addResult aBE bBE ws := by
+          rw [e0, e1, e2, e3]
+          rfl
+        rw [hcompute] at hstage
+        refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_) hstage
+        · -- reassemble the arena around the written `_b` window
+          have hp1 : ((((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr)
+              ** (.x9 ↦ᵣ outPtr) ** regOwns exposedRegs
+              ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+              ** bytesRegion outPtr outOld
+              ** (bytesRegion (arenaB + BitVec.ofNat 64 0x20) ws₂
+                ** windowRest arenaB (setBytes ws 0 ws₁) 0x20 32))
+              : Assertion) h := by
+            rw [show arenaB + BitVec.ofNat 64 0x20 = (0xbb55d9d0 : Word)
+              from by decide]
+            xperm_hyp hp
+          rw [← bytesRegion_window_update arenaB (setBytes ws 0 ws₁) ws₂ 0x20 32
+            (by rw [length_setBytes]; omega) (by norm_num) (by norm_num)
+            hf2b] at hp1
+          xperm_hyp hp1
+        · -- rebuild the whole-routine ∃-post from the stage-C witness
+          obtain ⟨out', hin⟩ := hq
+          obtain ⟨hf3, hrest⟩ := (sepConj_pure_left h).mp hin
+          rw [ownsSplit1112] at hrest
+          have hfin : ((⌜wsNat256 ws₁ 0 = beBytesToNat aBE ∧ ws₁.length = 32
+              ∧ wsNat256 ws₂ 0 = beBytesToNat bBE ∧ ws₂.length = 32
+              ∧ beBytesToNat out' = addResult aBE bBE ws ∧ out'.length = 32⌝
+              : Assertion)
+              ** (((.x10 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x11 ** regOwn .x12
+                ** regOwns addRest
+                ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+                ** bytesRegion outPtr out'
+                ** bytesRegion arenaB
+                  (setBytes (setBytes (setBytes ws 0 ws₁) 0x20 ws₂) 0x40
+                    (leBytes32 (addResult aBE bBE ws)))
+                ** ((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+                ** (.x9 ↦ᵣ outPtr))) h :=
+            (sepConj_pure_left h).mpr
+              ⟨⟨hf1a, hf1b, hf2a, hf2b, hf3.1, hf3.2⟩, by xperm_hyp hrest⟩
+          have hout : ((((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+              ** (.x9 ↦ᵣ outPtr))
+              ** (fun hp => ∃ ws₁' ws₂' out'',
+                ((⌜wsNat256 ws₁' 0 = beBytesToNat aBE ∧ ws₁'.length = 32
+                  ∧ wsNat256 ws₂' 0 = beBytesToNat bBE ∧ ws₂'.length = 32
+                  ∧ beBytesToNat out'' = addResult aBE bBE ws
+                  ∧ out''.length = 32⌝
+                  ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x11 ** regOwn .x12
+                  ** regOwns addRest
+                  ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+                  ** bytesRegion outPtr out''
+                  ** bytesRegion arenaB
+                    (setBytes (setBytes (setBytes ws 0 ws₁') 0x20 ws₂') 0x40
+                      (leBytes32 (addResult aBE bBE ws))))) hp)
+              : Assertion) h :=
+            exists_pull3 h ⟨ws₁, ws₂, out', by xperm_hyp hfin⟩
+          xperm_hyp hout
+      -- ---- reassemble the `_a` splice, peel `a0`/`a1`, run mv/la/call ----
+      refine cpsTripleWithin_weaken (fun h hp => ?_) (fun _ hq => hq)
+        (cpsTripleWithin_peel_regOwns [.x10, .x11] (by decide)
+          (P := ((.x1 : Reg) ↦ᵣ (0x80030214 : Word)) ** regOwns convScratch
+            ** bytesRegion aPtr aBE ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+            ** bytesRegion bPtr bBE ** bytesRegion outPtr outOld
+            ** bytesRegion arenaB (setBytes ws 0 ws₁))
+          (fun vf => ?_))
+      · rw [ownsExposedSplit] at hp
+        have hp1 : ((((.x1 : Reg) ↦ᵣ (0x80030214 : Word)) ** regOwns [.x10, .x11]
+            ** regOwns convScratch ** bytesRegion aPtr aBE ** (.x8 ↦ᵣ bPtr)
+            ** (.x9 ↦ᵣ outPtr) ** bytesRegion bPtr bBE
+            ** bytesRegion outPtr outOld
+            ** (bytesRegion (arenaB + BitVec.ofNat 64 0) ws₁
+              ** windowRest arenaB ws 0 32)) : Assertion) h := by
+          rw [show arenaB + BitVec.ofNat 64 0 = (0xbb55d9b0 : Word)
+            from by decide]
+          xperm_hyp hp
+        rw [← bytesRegion_window_update arenaB ws ws₁ 0 32 (by omega)
+          (by norm_num) (by norm_num) hf1b] at hp1
+        xperm_hyp hp1
+      · -- a0 := s0
+        have hmv10 := liftCode (cr' := addCr)
+          (mv_spec_gen_within .x10 .x8 bPtr (vf .x10) (0x80030214 : Word)
+            (by decide))
+          (by code_mem)
+        rw [show (0x80030214 : Word) + 4 = (0x80030218 : Word) from by decide]
+          at hmv10
+        -- la a1, bnf_le_b
+        have hla11 := la_materialize_within .x11 (vf .x11) (0x80030218 : Word)
+          (0xbb55d9d0 : Word) (cr := addCr) (by decide) (by decide)
+          (by code_mem) (by code_mem)
+        rw [show (0x80030218 : Word) + 8 = (0x80030220 : Word) from by decide]
+          at hla11
+        -- the second conversion call over the FOCUSED `_b` window
+        have hflat2 := bnfBeToLeFlat_spec (0x80030224 : Word) bPtr
+          (0xbb55d9d0 : Word) bBE (((setBytes ws 0 ws₁).drop 0x20).take 32)
+          hblen
+          (by
+            rw [List.length_take, List.length_drop, length_setBytes, hwslen]
+            omega)
+          hwfB
+          (by
+            refine ⟨?_, ?_, ?_⟩
+            · show ((0xbb55d9d0 : Word)).toNat % 8 = 0
+              decide
+            · show ((0xbb55d9d0 : Word)).toNat + 32 < 2 ^ 64
+              decide
+            · intro k hk
+              have hk' : k < 32 := hk
+              rw [show (0xbb55d9d0 : Word) + BitVec.ofNat 64 k
+                  = arenaB + BitVec.ofNat 64 (0x20 + k) from by
+                apply BitVec.eq_of_toNat_eq
+                rw [BitVec.toNat_add, BitVec.toNat_add, BitVec.toNat_ofNat,
+                  BitVec.toNat_ofNat,
+                  show ((0xbb55d9d0 : Word)).toNat = 0xbb55d9d0 from by decide,
+                  show (arenaB).toNat = 0xbb55d9b0 from by decide]
+                omega]
+              exact harval (0x20 + k) (by omega))
+          (by
+            have h := hwfB.2.1
+            rwa [hblen] at h)
+          (by decide)
+          (by
+            have hdst : ((0xbb55d9d0 : Word)).toNat = 0xbb55d9d0 := by decide
+            rcases hdB with h | h
+            · left
+              rw [hdst]
+              exact h
+            · right
+              rw [hdst]
+              omega)
+          (by decide)
+        have hcallee2 : cpsTripleWithin
+            ((bnfBeToLeFn bPtr (0xbb55d9d0 : Word) bBE
+              (((setBytes ws 0 ws₁).drop 0x20).take 32)).body.steps + 1)
+            (0x8003003c : Word) (0x80030224 : Word) addCr
+            (((.x1 : Reg) ↦ᵣ (0x80030224 : Word))
+              ** ((.x10 ↦ᵣ bPtr) ** (.x11 ↦ᵣ (0xbb55d9d0 : Word))
+                ** regOwns convScratch
+                ** bytesRegion (0xbb55d9d0 : Word)
+                    (((setBytes ws 0 ws₁).drop 0x20).take 32)
+                ** bytesRegion bPtr bBE))
+            (((.x1 : Reg) ↦ᵣ (0x80030224 : Word))
+              ** (fun hp => ∃ ws',
+                ((⌜wsNat256 ws' 0 = beBytesToNat bBE ∧ ws'.length = 32⌝
+                  ** regOwns exposedRegs ** bytesRegion (0xbb55d9d0 : Word) ws'
+                  ** bytesRegion bPtr bBE)) hp)) := by
+          refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+            (fun h hq => ?_) hflat2
+          obtain ⟨ws', hin⟩ := hq
+          refine exists_pull h ⟨ws', ?_⟩
+          xperm_hyp hin
+        have hcall2 := callWithin_spec (0x80030220 : Word) (0x8003003c : Word)
+          (0x80030214 : Word)
+          (jalOff GuestAddrs.bnf_be_to_le (GuestAddrs.bnf_add_mod_p + 48))
+          ((bnfBeToLeFn bPtr (0xbb55d9d0 : Word) bBE
+            (((setBytes ws 0 ws₁).drop 0x20).take 32)).body.steps + 1)
+          (by decide) (by code_mem) (by pcf) hcallee2
+        rw [show (0x80030220 : Word) + 4 = (0x80030224 : Word) from by decide]
+          at hcall2
+        rw [show (bnfBeToLeFn bPtr (0xbb55d9d0 : Word) bBE
+            (((setBytes ws 0 ws₁).drop 0x20).take 32)).body.steps
+          = (bnfBeToLeFn 0 0 [] []).body.steps from rfl] at hcall2
+        -- ---- frames + chain ----
+        have hmv10F := cpsTripleWithin_frameR
+          (((.x1 : Reg) ↦ᵣ (0x80030214 : Word)) ** (.x11 ↦ᵣ vf .x11)
+            ** regOwns convScratch ** bytesRegion aPtr aBE ** (.x9 ↦ᵣ outPtr)
+            ** bytesRegion bPtr bBE ** bytesRegion outPtr outOld
+            ** bytesRegion arenaB (setBytes ws 0 ws₁))
+          (by pcf) hmv10
+        have hla11F := cpsTripleWithin_frameR
+          (((.x1 : Reg) ↦ᵣ (0x80030214 : Word)) ** (.x8 ↦ᵣ bPtr)
+            ** (.x9 ↦ᵣ outPtr) ** (.x10 ↦ᵣ bPtr) ** regOwns convScratch
+            ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+            ** bytesRegion outPtr outOld
+            ** bytesRegion arenaB (setBytes ws 0 ws₁))
+          (by pcf) hla11
+        have hcall2F := cpsTripleWithin_frameR
+          ((.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr) ** bytesRegion aPtr aBE
+            ** bytesRegion outPtr outOld
+            ** windowRest arenaB (setBytes ws 0 ws₁) 0x20 32)
+          (by
+            exact pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs
+              (pcFree_sepConj (bytesRegion_pcFree _ _)
+                (pcFree_sepConj (bytesRegion_pcFree _ _)
+                  (pcFree_windowRest _ _ _ _))))) hcall2
+        have hd1 := cpsTripleWithin_seq_perm_same_cr
+          (fun _ hp => by xperm_hyp hp) hmv10F hla11F
+        have hd2 := cpsTripleWithin_seq_perm_same_cr
+          (fun h hp => by
+            rw [bytesRegion_window_focus arenaB (setBytes ws 0 ws₁) 0x20 32
+                  (by rw [length_setBytes]; omega) (by norm_num) (by norm_num),
+                show arenaB + BitVec.ofNat 64 0x20 = (0xbb55d9d0 : Word)
+                  from by decide] at hp
+            xperm_hyp hp) hd1 hcall2F
+        have hd2' : cpsTripleWithin
+            (4 + ((bnfBeToLeFn 0 0 [] []).body.steps + 1))
+            (0x80030214 : Word) (0x80030224 : Word) addCr
+            ((((.x8 : Reg) ↦ᵣ bPtr) ** (.x10 ↦ᵣ vf .x10))
+              ** (((.x1 : Reg) ↦ᵣ (0x80030214 : Word)) ** (.x11 ↦ᵣ vf .x11)
+                ** regOwns convScratch ** bytesRegion aPtr aBE
+                ** (.x9 ↦ᵣ outPtr) ** bytesRegion bPtr bBE
+                ** bytesRegion outPtr outOld
+                ** bytesRegion arenaB (setBytes ws 0 ws₁)))
+            (fun hp => ∃ ws₂,
+              ((⌜wsNat256 ws₂ 0 = beBytesToNat bBE ∧ ws₂.length = 32⌝
+                ** ((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** regOwns exposedRegs
+                ** bytesRegion (0xbb55d9d0 : Word) ws₂ ** bytesRegion bPtr bBE
+                ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr) ** bytesRegion aPtr aBE
+                ** bytesRegion outPtr outOld
+                ** windowRest arenaB (setBytes ws 0 ws₁) 0x20 32)) hp) := by
+          refine cpsTripleWithin_mono_nSteps (by omega)
+            (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+              (fun h hq => ?_) hd2)
+          have hq1 : ((fun hp => ∃ ws',
+              ((⌜wsNat256 ws' 0 = beBytesToNat bBE ∧ ws'.length = 32⌝
+                ** regOwns exposedRegs ** bytesRegion (0xbb55d9d0 : Word) ws'
+                ** bytesRegion bPtr bBE)) hp)
+              ** (((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr)
+                ** (.x9 ↦ᵣ outPtr) ** bytesRegion aPtr aBE
+                ** bytesRegion outPtr outOld
+                ** windowRest arenaB (setBytes ws 0 ws₁) 0x20 32)
+              : Assertion) h := by
+            xperm_hyp hq
+          obtain ⟨ws₂, hin⟩ := (sepConj_exists_left h).mp hq1
+          exact ⟨ws₂, by xperm_hyp hin⟩
+        refine cpsTripleWithin_weaken (fun _ hp => by
+            simp only [regAtomsOf_cons, regAtomsOf_nil, sepConj_emp_right']
+              at hp
+            xperm_hyp hp)
+          (fun _ hq => hq)
+          (cpsTripleWithin_seq_exists_same_cr hd2' hC)
+    -- ---- stage A: mv s0,a1 ; mv s1,a2 ; la a1,_a ; call bnf_be_to_le ----
+    have hm1 := liftCode (cr' := addCr)
+      (mv_spec_gen_within .x8 .x11 bPtr v8 (0x80030200 : Word) (by decide))
+      (by code_mem)
+    rw [show (0x80030200 : Word) + 4 = (0x80030204 : Word) from by decide] at hm1
+    have hm2 := liftCode (cr' := addCr)
+      (mv_spec_gen_within .x9 .x12 outPtr v9 (0x80030204 : Word) (by decide))
+      (by code_mem)
+    rw [show (0x80030204 : Word) + 4 = (0x80030208 : Word) from by decide] at hm2
+    have hla := la_materialize_within .x11 bPtr (0x80030208 : Word)
+      (0xbb55d9b0 : Word) (cr := addCr) (by decide) (by decide)
+      (by code_mem) (by code_mem)
+    rw [show (0x80030208 : Word) + 8 = (0x80030210 : Word) from by decide] at hla
+    have hflat1 := bnfBeToLeFlat_spec (0x80030214 : Word) aPtr
+      (0xbb55d9b0 : Word) aBE ((ws.drop 0).take 32)
+      halen
+      (by
+        rw [List.length_take, List.length_drop, hwslen]
+        omega)
+      hwfA
+      (by
+        refine ⟨?_, ?_, ?_⟩
+        · show ((0xbb55d9b0 : Word)).toNat % 8 = 0
+          decide
+        · show ((0xbb55d9b0 : Word)).toNat + 32 < 2 ^ 64
+          decide
+        · intro k hk
+          have hk' : k < 32 := hk
+          rw [show (0xbb55d9b0 : Word) = arenaB from by decide]
+          exact harval k (by omega))
+      (by
+        have h := hwfA.2.1
+        rwa [halen] at h)
+      (by decide)
+      (by
+        have hdst : ((0xbb55d9b0 : Word)).toNat = 0xbb55d9b0 := by decide
+        rcases hdA with h | h
+        · left
+          rw [hdst]
+          exact h
+        · right
+          rw [hdst]
+          omega)
+      (by decide)
+    have hcallee1 : cpsTripleWithin
+        ((bnfBeToLeFn aPtr (0xbb55d9b0 : Word) aBE
+          ((ws.drop 0).take 32)).body.steps + 1)
+        (0x8003003c : Word) (0x80030214 : Word) addCr
+        (((.x1 : Reg) ↦ᵣ (0x80030214 : Word))
+          ** ((.x10 ↦ᵣ aPtr) ** (.x11 ↦ᵣ (0xbb55d9b0 : Word))
+            ** regOwns convScratch
+            ** bytesRegion (0xbb55d9b0 : Word) ((ws.drop 0).take 32)
+            ** bytesRegion aPtr aBE))
+        (((.x1 : Reg) ↦ᵣ (0x80030214 : Word))
+          ** (fun hp => ∃ ws',
+            ((⌜wsNat256 ws' 0 = beBytesToNat aBE ∧ ws'.length = 32⌝
+              ** regOwns exposedRegs ** bytesRegion (0xbb55d9b0 : Word) ws'
+              ** bytesRegion aPtr aBE)) hp)) := by
+      refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+        (fun h hq => ?_) hflat1
+      obtain ⟨ws', hin⟩ := hq
+      refine exists_pull h ⟨ws', ?_⟩
+      xperm_hyp hin
+    have hcall1 := callWithin_spec (0x80030210 : Word) (0x8003003c : Word) ret
+      (jalOff GuestAddrs.bnf_be_to_le (GuestAddrs.bnf_add_mod_p + 32))
+      ((bnfBeToLeFn aPtr (0xbb55d9b0 : Word) aBE
+        ((ws.drop 0).take 32)).body.steps + 1)
+      (by decide) (by code_mem) (by pcf) hcallee1
+    rw [show (0x80030210 : Word) + 4 = (0x80030214 : Word) from by decide]
+      at hcall1
+    rw [show (bnfBeToLeFn aPtr (0xbb55d9b0 : Word) aBE
+        ((ws.drop 0).take 32)).body.steps
+      = (bnfBeToLeFn 0 0 [] []).body.steps from rfl] at hcall1
+    -- ---- frames + chain ----
+    have hm1F := cpsTripleWithin_frameR
+      (((.x1 : Reg) ↦ᵣ ret) ** (.x9 ↦ᵣ v9) ** (.x10 ↦ᵣ aPtr)
+        ** (.x12 ↦ᵣ outPtr) ** regOwns addRest
+        ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+        ** bytesRegion outPtr outOld ** bytesRegion arenaB ws)
+      (by pcf) hm1
+    have hm2F := cpsTripleWithin_frameR
+      (((.x1 : Reg) ↦ᵣ ret) ** (.x8 ↦ᵣ bPtr) ** (.x10 ↦ᵣ aPtr)
+        ** (.x11 ↦ᵣ bPtr) ** regOwns addRest
+        ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+        ** bytesRegion outPtr outOld ** bytesRegion arenaB ws)
+      (by pcf) hm2
+    have hlaF := cpsTripleWithin_frameR
+      (((.x1 : Reg) ↦ᵣ ret) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+        ** (.x10 ↦ᵣ aPtr) ** (.x12 ↦ᵣ outPtr) ** regOwns addRest
+        ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+        ** bytesRegion outPtr outOld ** bytesRegion arenaB ws)
+      (by pcf) hla
+    have hcall1F := cpsTripleWithin_frameR
+      ((.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr) ** bytesRegion bPtr bBE
+        ** bytesRegion outPtr outOld ** windowRest arenaB ws 0 32)
+      (by
+        exact pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs
+          (pcFree_sepConj (bytesRegion_pcFree _ _)
+            (pcFree_sepConj (bytesRegion_pcFree _ _)
+              (pcFree_windowRest _ _ _ _))))) hcall1
+    have ha1 := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by xperm_hyp hp) hm1F hm2F
+    have ha2 := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by xperm_hyp hp) ha1 hlaF
+    have ha3 := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        rw [bytesRegion_window_focus arenaB ws 0 32 (by omega) (by norm_num)
+              (by norm_num),
+            show arenaB + BitVec.ofNat 64 0 = (0xbb55d9b0 : Word)
+              from by decide] at hp
+        have hp1 : ((.x12 ↦ᵣ outPtr)
+            ** (((.x1 : Reg) ↦ᵣ ret) ** (.x10 ↦ᵣ aPtr)
+              ** (.x11 ↦ᵣ (0xbb55d9b0 : Word)) ** regOwns addRest
+              ** bytesRegion (0xbb55d9b0 : Word) ((ws.drop 0).take 32)
+              ** bytesRegion aPtr aBE ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+              ** bytesRegion bPtr bBE ** bytesRegion outPtr outOld
+              ** windowRest arenaB ws 0 32)) h := by
+          xperm_hyp hp
+        have hp2 := sepConj_mono (regIs_to_regOwn .x12 outPtr)
+          (fun _ hh => hh) h hp1
+        have hp3 : (regOwns convScratch
+            ** (((.x1 : Reg) ↦ᵣ ret) ** (.x10 ↦ᵣ aPtr)
+              ** (.x11 ↦ᵣ (0xbb55d9b0 : Word))
+              ** bytesRegion (0xbb55d9b0 : Word) ((ws.drop 0).take 32)
+              ** bytesRegion aPtr aBE ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+              ** bytesRegion bPtr bBE ** bytesRegion outPtr outOld
+              ** windowRest arenaB ws 0 32)) h := by
+          rw [ownsConvSplit12]
+          xperm_hyp hp2
+        xperm_hyp hp3) ha2 hcall1F
+    have ha3' : cpsTripleWithin (5 + ((bnfBeToLeFn 0 0 [] []).body.steps + 1))
+        (0x80030200 : Word) (0x80030214 : Word) addCr
+        ((((.x11 : Reg) ↦ᵣ bPtr) ** (.x8 ↦ᵣ v8))
+          ** (((.x1 : Reg) ↦ᵣ ret) ** (.x9 ↦ᵣ v9) ** (.x10 ↦ᵣ aPtr)
+            ** (.x12 ↦ᵣ outPtr) ** regOwns addRest
+            ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+            ** bytesRegion outPtr outOld ** bytesRegion arenaB ws))
+        (fun hp => ∃ ws₁,
+          ((⌜wsNat256 ws₁ 0 = beBytesToNat aBE ∧ ws₁.length = 32⌝
+            ** ((.x1 : Reg) ↦ᵣ (0x80030214 : Word)) ** regOwns exposedRegs
+            ** bytesRegion (0xbb55d9b0 : Word) ws₁ ** bytesRegion aPtr aBE
+            ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr) ** bytesRegion bPtr bBE
+            ** bytesRegion outPtr outOld ** windowRest arenaB ws 0 32)) hp)
+        := by
+      refine cpsTripleWithin_mono_nSteps (by omega)
+        (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+          (fun h hq => ?_) ha3)
+      have hq1 : ((fun hp => ∃ ws',
+          ((⌜wsNat256 ws' 0 = beBytesToNat aBE ∧ ws'.length = 32⌝
+            ** regOwns exposedRegs ** bytesRegion (0xbb55d9b0 : Word) ws'
+            ** bytesRegion aPtr aBE)) hp)
+          ** (((.x1 : Reg) ↦ᵣ (0x80030214 : Word)) ** (.x8 ↦ᵣ bPtr)
+            ** (.x9 ↦ᵣ outPtr) ** bytesRegion bPtr bBE
+            ** bytesRegion outPtr outOld
+            ** windowRest arenaB ws 0 32) : Assertion) h := by
+        xperm_hyp hq
+      obtain ⟨ws₁, hin⟩ := (sepConj_exists_left h).mp hq1
+      exact ⟨ws₁, by xperm_hyp hin⟩
+    have hcore := cpsTripleWithin_seq_exists_same_cr ha3' hB
+    have hcoreF := cpsTripleWithin_frameR
+      ((.x2 ↦ᵣ (sp0 + signExtend12 (-32 : BitVec 12)))
+        ** ((sp0 + signExtend12 (-32 : BitVec 12)
+              + signExtend12 (0 : BitVec 12)) ↦ₘ ret)
+        ** ((sp0 + signExtend12 (-32 : BitVec 12)
+              + signExtend12 (8 : BitVec 12)) ↦ₘ v8)
+        ** ((sp0 + signExtend12 (-32 : BitVec 12)
+              + signExtend12 (16 : BitVec 12)) ↦ₘ v9))
+      (by pcf) hcore
+    refine cpsTripleWithin_weaken (fun _ hp => ?_) (fun h hq => ?_)
+      (cpsTripleWithin_mono_nSteps (by omega) hcoreF)
+    · simp only [addFrame, regsAt, frameSlotsSaved, addVals,
+        List.foldr_cons, List.foldr_nil, sepConj_emp_right'] at hp
+      xperm_hyp hp
+    · simp only [addFrame, regsAt, frameSlotsSaved, addVals, addVals',
+        List.foldr_cons, List.foldr_nil, sepConj_emp_right']
+      xperm_hyp hq
+  -- ---- wrap the body with the ABI frame ----
+  exact abiFrame_spec
+    (posImm := (32 : BitVec 12))
+    (hframe := rfl)
+    (hne := by decide)
+    (hbound := by decide)
+    (hprogBound := by decide)
+    (hret := rfl)
+    (halign := halign)
+    (hframeRestore := sext_frameRestore _ _ _ (by decide))
+    (hcpF := by pcf)
+    (hcpF' := pcFree_exists3 (fun ws₁ ws₂ out' => by pcf))
+    (hsub := by code_mem)
+    (hbody := hbody)
+
+#print axioms bnfBeToLeFlat_spec
+#print axioms bnfLeToBeFlat_spec
+#print axioms csrsStep_spec
+#print axioms bnfAddModP_spec
+
+end Bn254FieldAddModPSAsm
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Bn254FieldAddModPSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254FieldAddModPSAsm.lean
@@ -70,7 +70,7 @@ def addVals (ret v8 v9 : Word) : Reg → Word :=
     the operand/output pointer copies. -/
 def addVals' (bPtr outPtr : Word) : Reg → Word :=
   fun r => match r with
-  | .x1 => (0x80030240 : Word) | .x8 => bPtr | .x9 => outPtr | _ => 0
+  | .x1 => ((GuestAddrs.bnf_add_mod_p + 80) : Word) | .x8 => bPtr | .x9 => outPtr | _ => 0
 
 /-- Exposed registers beyond the three pinned argument pointers. -/
 def addRest : List Reg :=
@@ -151,7 +151,7 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
         + (17 + ((bnfBeToLeFn 0 0 [] []).body.steps + 1) * 2
             + ((bnfLeToBeFn 0 0 [] []).body.steps + 1))
         + addFrame.length + 1 + 1)
-      (0x800301f0 : Word) ret addCr
+      (GuestAddrs.bnf_add_mod_p : Word) ret addCr
       ((.x2 ↦ᵣ sp0) ** regsAt addFrame (addVals ret v8 v9)
         ** frameSlotsOwn addFrame (sp0 + signExtend12 (-32 : BitVec 12))
         ** (((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr)
@@ -176,8 +176,8 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
   have hbody : cpsTripleWithin
       (17 + ((bnfBeToLeFn 0 0 [] []).body.steps + 1) * 2
         + ((bnfLeToBeFn 0 0 [] []).body.steps + 1))
-      ((0x800301f0 : Word) + BitVec.ofNat 64 (4 * (1 + addFrame.length)))
-      ((0x800301f0 : Word)
+      ((GuestAddrs.bnf_add_mod_p : Word) + BitVec.ofNat 64 (4 * (1 + addFrame.length)))
+      ((GuestAddrs.bnf_add_mod_p : Word)
         + BitVec.ofNat 64 (4 * (1 + addFrame.length + addBody.length)))
       addCr
       ((.x2 ↦ᵣ (sp0 + signExtend12 (-32 : BitVec 12)))
@@ -203,25 +203,25 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
               ** bytesRegion arenaB
                 (setBytes (setBytes (setBytes ws 0 ws₁) 0x20 ws₂) 0x40
                   (leBytes32 (addResult aBE bBE ws))))) hp)) := by
-    have hentry : (0x800301f0 : Word)
+    have hentry : (GuestAddrs.bnf_add_mod_p : Word)
           + BitVec.ofNat 64 (4 * (1 + addFrame.length))
-        = (0x80030200 : Word) := by decide
-    have hexit : (0x800301f0 : Word)
+        = ((GuestAddrs.bnf_add_mod_p + 16) : Word) := by decide
+    have hexit : (GuestAddrs.bnf_add_mod_p : Word)
           + BitVec.ofNat 64 (4 * (1 + addFrame.length + addBody.length))
-        = (0x80030244 : Word) := by decide
+        = ((GuestAddrs.bnf_add_mod_p + 84) : Word) := by decide
     rw [hentry, hexit]
     -- ---- the continuation past the first call (per written `_a` window) ----
     have hB : ∀ ws₁ : List (BitVec 8),
         cpsTripleWithin
           ((4 + ((bnfBeToLeFn 0 0 [] []).body.steps + 1))
             + (7 + ((bnfLeToBeFn 0 0 [] []).body.steps + 1) + 1))
-          (0x80030214 : Word) (0x80030244 : Word) addCr
+          ((GuestAddrs.bnf_add_mod_p + 36) : Word) ((GuestAddrs.bnf_add_mod_p + 84) : Word) addCr
           (⌜wsNat256 ws₁ 0 = beBytesToNat aBE ∧ ws₁.length = 32⌝
-            ** ((.x1 : Reg) ↦ᵣ (0x80030214 : Word)) ** regOwns exposedRegs
+            ** ((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 36) : Word)) ** regOwns exposedRegs
             ** bytesRegion (0xbb55d9b0 : Word) ws₁ ** bytesRegion aPtr aBE
             ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr) ** bytesRegion bPtr bBE
             ** bytesRegion outPtr outOld ** windowRest arenaB ws 0 32)
-          (((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+          (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 80) : Word)) ** (.x8 ↦ᵣ bPtr)
             ** (.x9 ↦ᵣ outPtr)
             ** (fun hp => ∃ ws₁' ws₂' out',
               ((⌜wsNat256 ws₁' 0 = beBytesToNat aBE ∧ ws₁'.length = 32
@@ -240,14 +240,14 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
       -- ---- the stage-C continuation (per written `_b` window) ----
       have hC : ∀ ws₂ : List (BitVec 8),
           cpsTripleWithin (7 + ((bnfLeToBeFn 0 0 [] []).body.steps + 1) + 1)
-            (0x80030224 : Word) (0x80030244 : Word) addCr
+            ((GuestAddrs.bnf_add_mod_p + 52) : Word) ((GuestAddrs.bnf_add_mod_p + 84) : Word) addCr
             (⌜wsNat256 ws₂ 0 = beBytesToNat bBE ∧ ws₂.length = 32⌝
-              ** ((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** regOwns exposedRegs
+              ** ((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 52) : Word)) ** regOwns exposedRegs
               ** bytesRegion (0xbb55d9d0 : Word) ws₂ ** bytesRegion bPtr bBE
               ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr) ** bytesRegion aPtr aBE
               ** bytesRegion outPtr outOld
               ** windowRest arenaB (setBytes ws 0 ws₁) 0x20 32)
-            (((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+            (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 80) : Word)) ** (.x8 ↦ᵣ bPtr)
               ** (.x9 ↦ᵣ outPtr)
               ** (fun hp => ∃ ws₁' ws₂' out',
                 ((⌜wsNat256 ws₁' 0 = beBytesToNat aBE ∧ ws₁'.length = 32
@@ -320,7 +320,7 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
         rw [hcompute] at hstage
         refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_) hstage
         · -- reassemble the arena around the written `_b` window
-          have hp1 : ((((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr)
+          have hp1 : ((((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 52) : Word)) ** (.x8 ↦ᵣ bPtr)
               ** (.x9 ↦ᵣ outPtr) ** regOwns exposedRegs
               ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
               ** bytesRegion outPtr outOld
@@ -349,11 +349,11 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
                 ** bytesRegion arenaB
                   (setBytes (setBytes (setBytes ws 0 ws₁) 0x20 ws₂) 0x40
                     (leBytes32 (addResult aBE bBE ws)))
-                ** ((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+                ** ((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 80) : Word)) ** (.x8 ↦ᵣ bPtr)
                 ** (.x9 ↦ᵣ outPtr))) h :=
             (sepConj_pure_left h).mpr
               ⟨⟨hf1a, hf1b, hf2a, hf2b, hf3.1, hf3.2⟩, by xperm_hyp hrest⟩
-          have hout : ((((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+          have hout : ((((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 80) : Word)) ** (.x8 ↦ᵣ bPtr)
               ** (.x9 ↦ᵣ outPtr))
               ** (fun hp => ∃ ws₁' ws₂' out'',
                 ((⌜wsNat256 ws₁' 0 = beBytesToNat aBE ∧ ws₁'.length = 32
@@ -373,13 +373,13 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
       -- ---- reassemble the `_a` splice, peel `a0`/`a1`, run mv/la/call ----
       refine cpsTripleWithin_weaken (fun h hp => ?_) (fun _ hq => hq)
         (cpsTripleWithin_peel_regOwns [.x10, .x11] (by decide)
-          (P := ((.x1 : Reg) ↦ᵣ (0x80030214 : Word)) ** regOwns convScratch
+          (P := ((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 36) : Word)) ** regOwns convScratch
             ** bytesRegion aPtr aBE ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
             ** bytesRegion bPtr bBE ** bytesRegion outPtr outOld
             ** bytesRegion arenaB (setBytes ws 0 ws₁))
           (fun vf => ?_))
       · rw [ownsExposedSplit] at hp
-        have hp1 : ((((.x1 : Reg) ↦ᵣ (0x80030214 : Word)) ** regOwns [.x10, .x11]
+        have hp1 : ((((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 36) : Word)) ** regOwns [.x10, .x11]
             ** regOwns convScratch ** bytesRegion aPtr aBE ** (.x8 ↦ᵣ bPtr)
             ** (.x9 ↦ᵣ outPtr) ** bytesRegion bPtr bBE
             ** bytesRegion outPtr outOld
@@ -393,19 +393,19 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
         xperm_hyp hp1
       · -- a0 := s0
         have hmv10 := liftCode (cr' := addCr)
-          (mv_spec_gen_within .x10 .x8 bPtr (vf .x10) (0x80030214 : Word)
+          (mv_spec_gen_within .x10 .x8 bPtr (vf .x10) ((GuestAddrs.bnf_add_mod_p + 36) : Word)
             (by decide))
           (by code_mem)
-        rw [show (0x80030214 : Word) + 4 = (0x80030218 : Word) from by decide]
+        rw [show ((GuestAddrs.bnf_add_mod_p + 36) : Word) + 4 = ((GuestAddrs.bnf_add_mod_p + 40) : Word) from by decide]
           at hmv10
         -- la a1, bnf_le_b
-        have hla11 := la_materialize_within .x11 (vf .x11) (0x80030218 : Word)
+        have hla11 := la_materialize_within .x11 (vf .x11) ((GuestAddrs.bnf_add_mod_p + 40) : Word)
           (0xbb55d9d0 : Word) (cr := addCr) (by decide) (by decide)
           (by code_mem) (by code_mem)
-        rw [show (0x80030218 : Word) + 8 = (0x80030220 : Word) from by decide]
+        rw [show ((GuestAddrs.bnf_add_mod_p + 40) : Word) + 8 = ((GuestAddrs.bnf_add_mod_p + 48) : Word) from by decide]
           at hla11
         -- the second conversion call over the FOCUSED `_b` window
-        have hflat2 := bnfBeToLeFlat_spec (0x80030224 : Word) bPtr
+        have hflat2 := bnfBeToLeFlat_spec ((GuestAddrs.bnf_add_mod_p + 52) : Word) bPtr
           (0xbb55d9d0 : Word) bBE (((setBytes ws 0 ws₁).drop 0x20).take 32)
           hblen
           (by
@@ -446,14 +446,14 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
         have hcallee2 : cpsTripleWithin
             ((bnfBeToLeFn bPtr (0xbb55d9d0 : Word) bBE
               (((setBytes ws 0 ws₁).drop 0x20).take 32)).body.steps + 1)
-            (0x8003003c : Word) (0x80030224 : Word) addCr
-            (((.x1 : Reg) ↦ᵣ (0x80030224 : Word))
+            (GuestAddrs.bnf_be_to_le : Word) ((GuestAddrs.bnf_add_mod_p + 52) : Word) addCr
+            (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 52) : Word))
               ** ((.x10 ↦ᵣ bPtr) ** (.x11 ↦ᵣ (0xbb55d9d0 : Word))
                 ** regOwns convScratch
                 ** bytesRegion (0xbb55d9d0 : Word)
                     (((setBytes ws 0 ws₁).drop 0x20).take 32)
                 ** bytesRegion bPtr bBE))
-            (((.x1 : Reg) ↦ᵣ (0x80030224 : Word))
+            (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 52) : Word))
               ** (fun hp => ∃ ws',
                 ((⌜wsNat256 ws' 0 = beBytesToNat bBE ∧ ws'.length = 32⌝
                   ** regOwns exposedRegs ** bytesRegion (0xbb55d9d0 : Word) ws'
@@ -463,26 +463,26 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
           obtain ⟨ws', hin⟩ := hq
           refine exists_pull h ⟨ws', ?_⟩
           xperm_hyp hin
-        have hcall2 := callWithin_spec (0x80030220 : Word) (0x8003003c : Word)
-          (0x80030214 : Word)
+        have hcall2 := callWithin_spec ((GuestAddrs.bnf_add_mod_p + 48) : Word) (GuestAddrs.bnf_be_to_le : Word)
+          ((GuestAddrs.bnf_add_mod_p + 36) : Word)
           (jalOff GuestAddrs.bnf_be_to_le (GuestAddrs.bnf_add_mod_p + 48))
           ((bnfBeToLeFn bPtr (0xbb55d9d0 : Word) bBE
             (((setBytes ws 0 ws₁).drop 0x20).take 32)).body.steps + 1)
           (by decide) (by code_mem) (by pcf) hcallee2
-        rw [show (0x80030220 : Word) + 4 = (0x80030224 : Word) from by decide]
+        rw [show ((GuestAddrs.bnf_add_mod_p + 48) : Word) + 4 = ((GuestAddrs.bnf_add_mod_p + 52) : Word) from by decide]
           at hcall2
         rw [show (bnfBeToLeFn bPtr (0xbb55d9d0 : Word) bBE
             (((setBytes ws 0 ws₁).drop 0x20).take 32)).body.steps
           = (bnfBeToLeFn 0 0 [] []).body.steps from rfl] at hcall2
         -- ---- frames + chain ----
         have hmv10F := cpsTripleWithin_frameR
-          (((.x1 : Reg) ↦ᵣ (0x80030214 : Word)) ** (.x11 ↦ᵣ vf .x11)
+          (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 36) : Word)) ** (.x11 ↦ᵣ vf .x11)
             ** regOwns convScratch ** bytesRegion aPtr aBE ** (.x9 ↦ᵣ outPtr)
             ** bytesRegion bPtr bBE ** bytesRegion outPtr outOld
             ** bytesRegion arenaB (setBytes ws 0 ws₁))
           (by pcf) hmv10
         have hla11F := cpsTripleWithin_frameR
-          (((.x1 : Reg) ↦ᵣ (0x80030214 : Word)) ** (.x8 ↦ᵣ bPtr)
+          (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 36) : Word)) ** (.x8 ↦ᵣ bPtr)
             ** (.x9 ↦ᵣ outPtr) ** (.x10 ↦ᵣ bPtr) ** regOwns convScratch
             ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
             ** bytesRegion outPtr outOld
@@ -508,16 +508,16 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
             xperm_hyp hp) hd1 hcall2F
         have hd2' : cpsTripleWithin
             (4 + ((bnfBeToLeFn 0 0 [] []).body.steps + 1))
-            (0x80030214 : Word) (0x80030224 : Word) addCr
+            ((GuestAddrs.bnf_add_mod_p + 36) : Word) ((GuestAddrs.bnf_add_mod_p + 52) : Word) addCr
             ((((.x8 : Reg) ↦ᵣ bPtr) ** (.x10 ↦ᵣ vf .x10))
-              ** (((.x1 : Reg) ↦ᵣ (0x80030214 : Word)) ** (.x11 ↦ᵣ vf .x11)
+              ** (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 36) : Word)) ** (.x11 ↦ᵣ vf .x11)
                 ** regOwns convScratch ** bytesRegion aPtr aBE
                 ** (.x9 ↦ᵣ outPtr) ** bytesRegion bPtr bBE
                 ** bytesRegion outPtr outOld
                 ** bytesRegion arenaB (setBytes ws 0 ws₁)))
             (fun hp => ∃ ws₂,
               ((⌜wsNat256 ws₂ 0 = beBytesToNat bBE ∧ ws₂.length = 32⌝
-                ** ((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** regOwns exposedRegs
+                ** ((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 52) : Word)) ** regOwns exposedRegs
                 ** bytesRegion (0xbb55d9d0 : Word) ws₂ ** bytesRegion bPtr bBE
                 ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr) ** bytesRegion aPtr aBE
                 ** bytesRegion outPtr outOld
@@ -529,7 +529,7 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
               ((⌜wsNat256 ws' 0 = beBytesToNat bBE ∧ ws'.length = 32⌝
                 ** regOwns exposedRegs ** bytesRegion (0xbb55d9d0 : Word) ws'
                 ** bytesRegion bPtr bBE)) hp)
-              ** (((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr)
+              ** (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 52) : Word)) ** (.x8 ↦ᵣ bPtr)
                 ** (.x9 ↦ᵣ outPtr) ** bytesRegion aPtr aBE
                 ** bytesRegion outPtr outOld
                 ** windowRest arenaB (setBytes ws 0 ws₁) 0x20 32)
@@ -545,18 +545,18 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
           (cpsTripleWithin_seq_exists_same_cr hd2' hC)
     -- ---- stage A: mv s0,a1 ; mv s1,a2 ; la a1,_a ; call bnf_be_to_le ----
     have hm1 := liftCode (cr' := addCr)
-      (mv_spec_gen_within .x8 .x11 bPtr v8 (0x80030200 : Word) (by decide))
+      (mv_spec_gen_within .x8 .x11 bPtr v8 ((GuestAddrs.bnf_add_mod_p + 16) : Word) (by decide))
       (by code_mem)
-    rw [show (0x80030200 : Word) + 4 = (0x80030204 : Word) from by decide] at hm1
+    rw [show ((GuestAddrs.bnf_add_mod_p + 16) : Word) + 4 = ((GuestAddrs.bnf_add_mod_p + 20) : Word) from by decide] at hm1
     have hm2 := liftCode (cr' := addCr)
-      (mv_spec_gen_within .x9 .x12 outPtr v9 (0x80030204 : Word) (by decide))
+      (mv_spec_gen_within .x9 .x12 outPtr v9 ((GuestAddrs.bnf_add_mod_p + 20) : Word) (by decide))
       (by code_mem)
-    rw [show (0x80030204 : Word) + 4 = (0x80030208 : Word) from by decide] at hm2
-    have hla := la_materialize_within .x11 bPtr (0x80030208 : Word)
+    rw [show ((GuestAddrs.bnf_add_mod_p + 20) : Word) + 4 = ((GuestAddrs.bnf_add_mod_p + 24) : Word) from by decide] at hm2
+    have hla := la_materialize_within .x11 bPtr ((GuestAddrs.bnf_add_mod_p + 24) : Word)
       (0xbb55d9b0 : Word) (cr := addCr) (by decide) (by decide)
       (by code_mem) (by code_mem)
-    rw [show (0x80030208 : Word) + 8 = (0x80030210 : Word) from by decide] at hla
-    have hflat1 := bnfBeToLeFlat_spec (0x80030214 : Word) aPtr
+    rw [show ((GuestAddrs.bnf_add_mod_p + 24) : Word) + 8 = ((GuestAddrs.bnf_add_mod_p + 32) : Word) from by decide] at hla
+    have hflat1 := bnfBeToLeFlat_spec ((GuestAddrs.bnf_add_mod_p + 36) : Word) aPtr
       (0xbb55d9b0 : Word) aBE ((ws.drop 0).take 32)
       halen
       (by
@@ -590,13 +590,13 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
     have hcallee1 : cpsTripleWithin
         ((bnfBeToLeFn aPtr (0xbb55d9b0 : Word) aBE
           ((ws.drop 0).take 32)).body.steps + 1)
-        (0x8003003c : Word) (0x80030214 : Word) addCr
-        (((.x1 : Reg) ↦ᵣ (0x80030214 : Word))
+        (GuestAddrs.bnf_be_to_le : Word) ((GuestAddrs.bnf_add_mod_p + 36) : Word) addCr
+        (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 36) : Word))
           ** ((.x10 ↦ᵣ aPtr) ** (.x11 ↦ᵣ (0xbb55d9b0 : Word))
             ** regOwns convScratch
             ** bytesRegion (0xbb55d9b0 : Word) ((ws.drop 0).take 32)
             ** bytesRegion aPtr aBE))
-        (((.x1 : Reg) ↦ᵣ (0x80030214 : Word))
+        (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 36) : Word))
           ** (fun hp => ∃ ws',
             ((⌜wsNat256 ws' 0 = beBytesToNat aBE ∧ ws'.length = 32⌝
               ** regOwns exposedRegs ** bytesRegion (0xbb55d9b0 : Word) ws'
@@ -606,12 +606,12 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
       obtain ⟨ws', hin⟩ := hq
       refine exists_pull h ⟨ws', ?_⟩
       xperm_hyp hin
-    have hcall1 := callWithin_spec (0x80030210 : Word) (0x8003003c : Word) ret
+    have hcall1 := callWithin_spec ((GuestAddrs.bnf_add_mod_p + 32) : Word) (GuestAddrs.bnf_be_to_le : Word) ret
       (jalOff GuestAddrs.bnf_be_to_le (GuestAddrs.bnf_add_mod_p + 32))
       ((bnfBeToLeFn aPtr (0xbb55d9b0 : Word) aBE
         ((ws.drop 0).take 32)).body.steps + 1)
       (by decide) (by code_mem) (by pcf) hcallee1
-    rw [show (0x80030210 : Word) + 4 = (0x80030214 : Word) from by decide]
+    rw [show ((GuestAddrs.bnf_add_mod_p + 32) : Word) + 4 = ((GuestAddrs.bnf_add_mod_p + 36) : Word) from by decide]
       at hcall1
     rw [show (bnfBeToLeFn aPtr (0xbb55d9b0 : Word) aBE
         ((ws.drop 0).take 32)).body.steps
@@ -674,7 +674,7 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
           xperm_hyp hp2
         xperm_hyp hp3) ha2 hcall1F
     have ha3' : cpsTripleWithin (5 + ((bnfBeToLeFn 0 0 [] []).body.steps + 1))
-        (0x80030200 : Word) (0x80030214 : Word) addCr
+        ((GuestAddrs.bnf_add_mod_p + 16) : Word) ((GuestAddrs.bnf_add_mod_p + 36) : Word) addCr
         ((((.x11 : Reg) ↦ᵣ bPtr) ** (.x8 ↦ᵣ v8))
           ** (((.x1 : Reg) ↦ᵣ ret) ** (.x9 ↦ᵣ v9) ** (.x10 ↦ᵣ aPtr)
             ** (.x12 ↦ᵣ outPtr) ** regOwns addRest
@@ -682,7 +682,7 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
             ** bytesRegion outPtr outOld ** bytesRegion arenaB ws))
         (fun hp => ∃ ws₁,
           ((⌜wsNat256 ws₁ 0 = beBytesToNat aBE ∧ ws₁.length = 32⌝
-            ** ((.x1 : Reg) ↦ᵣ (0x80030214 : Word)) ** regOwns exposedRegs
+            ** ((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 36) : Word)) ** regOwns exposedRegs
             ** bytesRegion (0xbb55d9b0 : Word) ws₁ ** bytesRegion aPtr aBE
             ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr) ** bytesRegion bPtr bBE
             ** bytesRegion outPtr outOld ** windowRest arenaB ws 0 32)) hp)
@@ -694,7 +694,7 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
           ((⌜wsNat256 ws' 0 = beBytesToNat aBE ∧ ws'.length = 32⌝
             ** regOwns exposedRegs ** bytesRegion (0xbb55d9b0 : Word) ws'
             ** bytesRegion aPtr aBE)) hp)
-          ** (((.x1 : Reg) ↦ᵣ (0x80030214 : Word)) ** (.x8 ↦ᵣ bPtr)
+          ** (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 36) : Word)) ** (.x8 ↦ᵣ bPtr)
             ** (.x9 ↦ᵣ outPtr) ** bytesRegion bPtr bBE
             ** bytesRegion outPtr outOld
             ** windowRest arenaB ws 0 32) : Assertion) h := by

--- a/EvmAsm/Codegen/Programs/Bn254FieldAddModPSAsmStage.lean
+++ b/EvmAsm/Codegen/Programs/Bn254FieldAddModPSAsmStage.lean
@@ -29,9 +29,9 @@ namespace Bn254FieldAddModPSAsm
 open Bn254FieldConvSAsm (bnfBeToLeFn bnfBeToLeFn_spec bnfLeToBeFn bnfLeToBeFn_spec)
 
 -- Address anchors (routine, callees, and the LE staging arena).
-#guard GuestAddrs.bnf_add_mod_p = 0x800301f0
-#guard GuestAddrs.bnf_be_to_le = 0x8003003c
-#guard GuestAddrs.bnf_le_to_be = 0x8003008c
+#guard GuestAddrs.bnf_add_mod_p = 0x80030258
+#guard GuestAddrs.bnf_be_to_le = 0x800300a4
+#guard GuestAddrs.bnf_le_to_be = 0x800300f4
 #guard GuestAddrs.bnf_le_a = 0xbb55d9b0
 #guard GuestAddrs.bnf_le_b = 0xbb55d9d0
 #guard GuestAddrs.bnf_le_d = 0xbb55d9f0
@@ -74,9 +74,9 @@ theorem addProg_tie :
 /-- The routine's single code map: its own program plus the two converter
     callees'. -/
 def addCr : CodeReq :=
-  (CodeReq.ofProg (0x800301f0 : Word) bnfAddModP_prog).union
-    ((CodeReq.ofProg (0x8003003c : Word) bnfBeToLe_prog).union
-      (CodeReq.ofProg (0x8003008c : Word) bnfLeToBe_prog))
+  (CodeReq.ofProg (GuestAddrs.bnf_add_mod_p : Word) bnfAddModP_prog).union
+    ((CodeReq.ofProg (GuestAddrs.bnf_be_to_le : Word) bnfBeToLe_prog).union
+      (CodeReq.ofProg (GuestAddrs.bnf_le_to_be : Word) bnfLeToBe_prog))
 
 /-- The exposed registers the converter contracts clobber beyond `a0`/`a1`. -/
 def convScratch : List Reg :=
@@ -104,7 +104,7 @@ theorem bnfBeToLeFlat_spec (ret srci dsti : Word) (inb ob : List (BitVec 8))
     (hdisj : srci.toNat + 32 ≤ dsti.toNat ∨ dsti.toNat + 32 ≤ srci.toNat)
     (halign : (ret &&& ~~~(1 : Word)) = ret) :
     cpsTripleWithin ((bnfBeToLeFn srci dsti inb ob).body.steps + 1)
-      (0x8003003c : Word) ret addCr
+      (GuestAddrs.bnf_be_to_le : Word) ret addCr
       (((.x1 : Reg) ↦ᵣ ret) ** (.x10 ↦ᵣ srci) ** (.x11 ↦ᵣ dsti)
         ** regOwns convScratch ** bytesRegion dsti ob ** bytesRegion srci inb)
       (fun hp => ∃ ws',
@@ -117,8 +117,8 @@ theorem bnfBeToLeFlat_spec (ret srci dsti : Word) (inb ob : List (BitVec 8))
         ** bytesRegion dsti ob ** bytesRegion srci inb)
       (fun vf => ?_))
   have had := Fn.retSpecFlat (bnfBeToLeFn srci dsti inb ob)
-    (0x8003003c : Word)
-    (bnfBeToLeFn_spec srci dsti inb ob hwfR hrww hilen (0x8003003c : Word))
+    (GuestAddrs.bnf_be_to_le : Word)
+    (bnfBeToLeFn_spec srci dsti inb ob hwfR hrww hilen (GuestAddrs.bnf_be_to_le : Word))
     (by show 4 * (19 + 1) ≤ 2 ^ 64; decide) ret halign
     (fun r => if r = .x10 then srci else if r = .x11 then dsti else vf r)
     ob
@@ -145,7 +145,7 @@ theorem bnfBeToLeFlat_spec (ret srci dsti : Word) (inb ob : List (BitVec 8))
           ** (regOwns exposedRegs ** bytesRegion dsti ws')) hp :=
         (sepConj_pure_left hp).mpr ⟨⟨hpost'.1, hlen'⟩, hh2⟩
       xperm_hyp hpure)
-  rw [show (bnfBeToLeFn srci dsti inb ob).programRet (0x8003003c : Word)
+  rw [show (bnfBeToLeFn srci dsti inb ob).programRet (GuestAddrs.bnf_be_to_le : Word)
       = bnfBeToLe_prog from rfl] at had
   have hadC := liftCode (cr' := addCr) had (by code_mem)
   rw [show (bnfBeToLeFn srci dsti inb ob).region = (⟨srci, inb⟩ : Region) from rfl,
@@ -186,7 +186,7 @@ theorem bnfLeToBeFlat_spec (ret srci dsti : Word) (inb ob : List (BitVec 8))
     (hdisj : srci.toNat + 32 ≤ dsti.toNat ∨ dsti.toNat + 32 ≤ srci.toNat)
     (halign : (ret &&& ~~~(1 : Word)) = ret) :
     cpsTripleWithin ((bnfLeToBeFn srci dsti inb ob).body.steps + 1)
-      (0x8003008c : Word) ret addCr
+      (GuestAddrs.bnf_le_to_be : Word) ret addCr
       (((.x1 : Reg) ↦ᵣ ret) ** (.x10 ↦ᵣ srci) ** (.x11 ↦ᵣ dsti)
         ** regOwns convScratch ** bytesRegion dsti ob ** bytesRegion srci inb)
       (fun hp => ∃ ws',
@@ -199,8 +199,8 @@ theorem bnfLeToBeFlat_spec (ret srci dsti : Word) (inb ob : List (BitVec 8))
         ** bytesRegion dsti ob ** bytesRegion srci inb)
       (fun vf => ?_))
   have had := Fn.retSpecFlat (bnfLeToBeFn srci dsti inb ob)
-    (0x8003008c : Word)
-    (bnfLeToBeFn_spec srci dsti inb ob hwfR hrww hilen (0x8003008c : Word))
+    (GuestAddrs.bnf_le_to_be : Word)
+    (bnfLeToBeFn_spec srci dsti inb ob hwfR hrww hilen (GuestAddrs.bnf_le_to_be : Word))
     (by show 4 * (18 + 1) ≤ 2 ^ 64; decide) ret halign
     (fun r => if r = .x10 then srci else if r = .x11 then dsti else vf r)
     ob
@@ -227,7 +227,7 @@ theorem bnfLeToBeFlat_spec (ret srci dsti : Word) (inb ob : List (BitVec 8))
           ** (regOwns exposedRegs ** bytesRegion dsti ws')) hp :=
         (sepConj_pure_left hp).mpr ⟨⟨hpost'.1, hlen'⟩, hh2⟩
       xperm_hyp hpure)
-  rw [show (bnfLeToBeFn srci dsti inb ob).programRet (0x8003008c : Word)
+  rw [show (bnfLeToBeFn srci dsti inb ob).programRet (GuestAddrs.bnf_le_to_be : Word)
       = bnfLeToBe_prog from rfl] at had
   have hadC := liftCode (cr' := addCr) had (by code_mem)
   rw [show (bnfLeToBeFn srci dsti inb ob).region = (⟨srci, inb⟩ : Region) from rfl,
@@ -290,7 +290,7 @@ theorem csrsStep_spec (img : List (BitVec 8))
     (hpm : wsDword img 0x100 = arenaB + BitVec.ofNat 64 0xA0)
     (hpd : wsDword img 0x108 = arenaB + BitVec.ofNat 64 0x40)
     (hmne : wsNat256 img 0xA0 ≠ 0) :
-    cpsTripleWithin 1 (0x8003022c : Word) (0x80030230 : Word) addCr
+    cpsTripleWithin 1 ((GuestAddrs.bnf_add_mod_p + 60) : Word) ((GuestAddrs.bnf_add_mod_p + 64) : Word) addCr
       (((.x5 : Reg) ↦ᵣ (0xbb55da98 : Word)) ** regOwns csrsRest
         ** bytesRegion arenaB img)
       (((.x5 : Reg) ↦ᵣ (0xbb55da98 : Word)) ** regOwns csrsRest
@@ -302,7 +302,7 @@ theorem csrsStep_spec (img : List (BitVec 8))
     (cpsTripleWithin_peel_regOwns csrsRest (by decide)
       (P := ((.x5 : Reg) ↦ᵣ (0xbb55da98 : Word)) ** bytesRegion arenaB img)
       (fun vf => ?_))
-  have hcs := csrs_arith256Mod_spec_within (0x8003022c : Word) .x5 (by decide)
+  have hcs := csrs_arith256Mod_spec_within ((GuestAddrs.bnf_add_mod_p + 60) : Word) .x5 (by decide)
     arenaB 272 img
     (fun r => if r = .x5 then (0xbb55da98 : Word) else vf r)
     hlen (by decide) hvalid
@@ -317,7 +317,7 @@ theorem csrsStep_spec (img : List (BitVec 8))
     (by decide) (by decide) (by decide) (by decide) (by decide) (by decide)
     hpa hpb hpc hpm hpd hmne
   have hcsC := liftCode (cr' := addCr) hcs (by code_mem)
-  rw [show (0x8003022c : Word) + 4 = (0x80030230 : Word) from by decide] at hcsC
+  rw [show ((GuestAddrs.bnf_add_mod_p + 60) : Word) + 4 = ((GuestAddrs.bnf_add_mod_p + 64) : Word) from by decide] at hcsC
   -- unpack the register file on both sides (same file — the step moves nothing)
   rw [regFileIs_eq_regAtoms, regAtoms_eq_regAtomsOf _ _ (by decide),
     exposedRegs_split5,
@@ -426,8 +426,8 @@ theorem stageC_spec (aPtr bPtr outPtr : Word)
     (hpd₂ : wsDword img₂ 0x108 = arenaB + BitVec.ofNat 64 0x40)
     (hmne₂ : wsNat256 img₂ 0xA0 ≠ 0) :
     cpsTripleWithin (7 + ((bnfLeToBeFn 0 0 [] []).body.steps + 1) + 1)
-      (0x80030224 : Word) (0x80030244 : Word) addCr
-      (((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+      ((GuestAddrs.bnf_add_mod_p + 52) : Word) ((GuestAddrs.bnf_add_mod_p + 84) : Word) addCr
+      (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 52) : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
         ** regOwns exposedRegs
         ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
         ** bytesRegion outPtr outOld ** bytesRegion arenaB img₂)
@@ -436,7 +436,7 @@ theorem stageC_spec (aPtr bPtr outPtr : Word)
             = Accel.arith256Mod (wsNat256 img₂ 0) (wsNat256 img₂ 0x80)
                 (wsNat256 img₂ 0x20) (wsNat256 img₂ 0xA0)
           ∧ out'.length = 32⌝
-          ** ((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+          ** ((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 80) : Word)) ** (.x8 ↦ᵣ bPtr)
           ** (.x9 ↦ᵣ outPtr) ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** regOwns outRest
           ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
           ** bytesRegion outPtr out'
@@ -463,28 +463,28 @@ theorem stageC_spec (aPtr bPtr outPtr : Word)
   -- ---- la t0, bnf_add_params ----
   refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => hq)
     (cpsTripleWithin_peel_regOwns exposedRegs (by decide)
-      (P := ((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+      (P := ((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 52) : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
         ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
         ** bytesRegion outPtr outOld ** bytesRegion arenaB img₂)
       (fun vf => ?_))
-  have hla5 := la_materialize_within .x5 (vf .x5) (0x80030224 : Word)
+  have hla5 := la_materialize_within .x5 (vf .x5) ((GuestAddrs.bnf_add_mod_p + 52) : Word)
     (0xbb55da98 : Word) (cr := addCr) (by decide) (by decide)
     (by code_mem) (by code_mem)
-  rw [show (0x80030224 : Word) + 8 = (0x8003022c : Word) from by decide] at hla5
+  rw [show ((GuestAddrs.bnf_add_mod_p + 52) : Word) + 8 = ((GuestAddrs.bnf_add_mod_p + 60) : Word) from by decide] at hla5
   -- CSRS over the whole arena atom
   have hcsrs := csrsStep_spec img₂ hilen harval hpa₂ hpb₂ hpc₂ hpm₂ hpd₂ hmne₂
   rw [← hr, ← himg₃] at hcsrs
   -- the rest of the stage, from the CSRS exit, with the register file owned
   have hrest : cpsTripleWithin
       (4 + ((bnfLeToBeFn 0 0 [] []).body.steps + 1) + 1)
-      (0x80030230 : Word) (0x80030244 : Word) addCr
+      ((GuestAddrs.bnf_add_mod_p + 64) : Word) ((GuestAddrs.bnf_add_mod_p + 84) : Word) addCr
       (((.x5 : Reg) ↦ᵣ (0xbb55da98 : Word)) ** regOwns csrsRest
-        ** ((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+        ** ((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 52) : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
         ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
         ** bytesRegion outPtr outOld ** bytesRegion arenaB img₃)
       (fun hp => ∃ out',
         ((⌜beBytesToNat out' = r ∧ out'.length = 32⌝
-          ** ((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+          ** ((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 80) : Word)) ** (.x8 ↦ᵣ bPtr)
           ** (.x9 ↦ᵣ outPtr) ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** regOwns outRest
           ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
           ** bytesRegion outPtr out'
@@ -492,22 +492,22 @@ theorem stageC_spec (aPtr bPtr outPtr : Word)
     refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => hq)
       (cpsTripleWithin_peel_regOwns csrsRest (by decide)
         (P := ((.x5 : Reg) ↦ᵣ (0xbb55da98 : Word))
-          ** ((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+          ** ((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 52) : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
           ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
           ** bytesRegion outPtr outOld ** bytesRegion arenaB img₃)
         (fun vg => ?_))
     -- la a0, bnf_le_d
-    have hla10 := la_materialize_within .x10 (vg .x10) (0x80030230 : Word)
+    have hla10 := la_materialize_within .x10 (vg .x10) ((GuestAddrs.bnf_add_mod_p + 64) : Word)
       (0xbb55d9f0 : Word) (cr := addCr) (by decide) (by decide)
       (by code_mem) (by code_mem)
-    rw [show (0x80030230 : Word) + 8 = (0x80030238 : Word) from by decide] at hla10
+    rw [show ((GuestAddrs.bnf_add_mod_p + 64) : Word) + 8 = ((GuestAddrs.bnf_add_mod_p + 72) : Word) from by decide] at hla10
     -- a1 := s1
     have hmv := liftCode (cr' := addCr)
-      (mv_spec_gen_within .x11 .x9 outPtr (vg .x11) (0x80030238 : Word) (by decide))
+      (mv_spec_gen_within .x11 .x9 outPtr (vg .x11) ((GuestAddrs.bnf_add_mod_p + 72) : Word) (by decide))
       (by code_mem)
-    rw [show (0x80030238 : Word) + 4 = (0x8003023c : Word) from by decide] at hmv
+    rw [show ((GuestAddrs.bnf_add_mod_p + 72) : Word) + 4 = ((GuestAddrs.bnf_add_mod_p + 76) : Word) from by decide] at hmv
     -- the final conversion call over the FOCUSED d-window
-    have hflat := bnfLeToBeFlat_spec (0x80030240 : Word) (0xbb55d9f0 : Word)
+    have hflat := bnfLeToBeFlat_spec ((GuestAddrs.bnf_add_mod_p + 80) : Word) (0xbb55d9f0 : Word)
       outPtr (leBytes32 r) outOld (by rw [length_leBytes32]) holen
       (by
         refine ⟨?_, ?_, ?_⟩
@@ -543,12 +543,12 @@ theorem stageC_spec (aPtr bPtr outPtr : Word)
     -- massage into callWithin shape: pull `ra` out of the ∃-post
     have hcallee : cpsTripleWithin ((bnfLeToBeFn (0xbb55d9f0 : Word) outPtr
         (leBytes32 r) outOld).body.steps + 1)
-        (0x8003008c : Word) (0x80030240 : Word) addCr
-        (((.x1 : Reg) ↦ᵣ (0x80030240 : Word))
+        (GuestAddrs.bnf_le_to_be : Word) ((GuestAddrs.bnf_add_mod_p + 80) : Word) addCr
+        (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 80) : Word))
           ** ((.x10 ↦ᵣ (0xbb55d9f0 : Word)) ** (.x11 ↦ᵣ outPtr)
             ** regOwns convScratch ** bytesRegion outPtr outOld
             ** bytesRegion (0xbb55d9f0 : Word) (leBytes32 r)))
-        (((.x1 : Reg) ↦ᵣ (0x80030240 : Word))
+        (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 80) : Word))
           ** (fun hp => ∃ ws',
             ((⌜beBytesToNat ws' = wsNat256 (leBytes32 r) 0 ∧ ws'.length = 32⌝
               ** regOwns exposedRegs ** bytesRegion outPtr ws'
@@ -558,23 +558,23 @@ theorem stageC_spec (aPtr bPtr outPtr : Word)
       obtain ⟨ws', hin⟩ := hq
       refine exists_pull h ⟨ws', ?_⟩
       xperm_hyp hin
-    have hcall := callWithin_spec (0x8003023c : Word) (0x8003008c : Word)
-      (0x80030224 : Word)
+    have hcall := callWithin_spec ((GuestAddrs.bnf_add_mod_p + 76) : Word) (GuestAddrs.bnf_le_to_be : Word)
+      ((GuestAddrs.bnf_add_mod_p + 52) : Word)
       (jalOff GuestAddrs.bnf_le_to_be (GuestAddrs.bnf_add_mod_p + 76))
       ((bnfLeToBeFn (0xbb55d9f0 : Word) outPtr (leBytes32 r) outOld).body.steps + 1)
       (by decide) (by code_mem) (by pcf) hcallee
-    rw [show (0x8003023c : Word) + 4 = (0x80030240 : Word) from by decide] at hcall
+    rw [show ((GuestAddrs.bnf_add_mod_p + 76) : Word) + 4 = ((GuestAddrs.bnf_add_mod_p + 80) : Word) from by decide] at hcall
     rw [show (bnfLeToBeFn (0xbb55d9f0 : Word) outPtr
         (leBytes32 r) outOld).body.steps
       = (bnfLeToBeFn 0 0 [] []).body.steps from rfl] at hcall
     -- a0 := 0
     have hli := liftCode (cr' := addCr)
-      (li_spec_gen_own_within .x10 (0 : Word) (0x80030240 : Word) (by decide))
+      (li_spec_gen_own_within .x10 (0 : Word) ((GuestAddrs.bnf_add_mod_p + 80) : Word) (by decide))
       (by code_mem)
-    rw [show (0x80030240 : Word) + 4 = (0x80030244 : Word) from by decide] at hli
+    rw [show ((GuestAddrs.bnf_add_mod_p + 80) : Word) + 4 = ((GuestAddrs.bnf_add_mod_p + 84) : Word) from by decide] at hli
     -- ---- frames + chain ----
     have hla10F := cpsTripleWithin_frameR
-      (((.x5 : Reg) ↦ᵣ (0xbb55da98 : Word)) ** ((.x1 : Reg) ↦ᵣ (0x80030224 : Word))
+      (((.x5 : Reg) ↦ᵣ (0xbb55da98 : Word)) ** ((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 52) : Word))
         ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr) ** (.x11 ↦ᵣ vg .x11)
         ** (.x6 ↦ᵣ vg .x6) ** (.x7 ↦ᵣ vg .x7) ** (.x28 ↦ᵣ vg .x28)
         ** (.x29 ↦ᵣ vg .x29) ** (.x30 ↦ᵣ vg .x30) ** (.x31 ↦ᵣ vg .x31)
@@ -584,7 +584,7 @@ theorem stageC_spec (aPtr bPtr outPtr : Word)
         ** bytesRegion outPtr outOld ** bytesRegion arenaB img₃)
       (by pcf) hla10
     have hmvF := cpsTripleWithin_frameR
-      (((.x5 : Reg) ↦ᵣ (0xbb55da98 : Word)) ** ((.x1 : Reg) ↦ᵣ (0x80030224 : Word))
+      (((.x5 : Reg) ↦ᵣ (0xbb55da98 : Word)) ** ((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 52) : Word))
         ** (.x8 ↦ᵣ bPtr) ** (.x10 ↦ᵣ (0xbb55d9f0 : Word))
         ** (.x6 ↦ᵣ vg .x6) ** (.x7 ↦ᵣ vg .x7) ** (.x28 ↦ᵣ vg .x28)
         ** (.x29 ↦ᵣ vg .x29) ** (.x30 ↦ᵣ vg .x30) ** (.x31 ↦ᵣ vg .x31)
@@ -617,7 +617,7 @@ theorem stageC_spec (aPtr bPtr outPtr : Word)
             ** (.x12 ↦ᵣ vg .x12) ** (.x13 ↦ᵣ vg .x13) ** (.x14 ↦ᵣ vg .x14)
             ** (.x15 ↦ᵣ vg .x15) ** (.x16 ↦ᵣ vg .x16) ** (.x17 ↦ᵣ vg .x17)
             ** (((.x5 : Reg)) ↦ᵣ (0xbb55da98 : Word))
-            ** (((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x10 ↦ᵣ (0xbb55d9f0 : Word))
+            ** (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 52) : Word)) ** (.x10 ↦ᵣ (0xbb55d9f0 : Word))
               ** (.x11 ↦ᵣ outPtr) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
               ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
               ** bytesRegion outPtr outOld
@@ -639,7 +639,7 @@ theorem stageC_spec (aPtr bPtr outPtr : Word)
                                 (sepConj_mono (regIs_to_regOwn .x5 _)
                                   (fun _ hh => hh))))))))))))) h hp1
         have hp3 : (regOwns convScratch **
-            (((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x10 ↦ᵣ (0xbb55d9f0 : Word))
+            (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 52) : Word)) ** (.x10 ↦ᵣ (0xbb55d9f0 : Word))
               ** (.x11 ↦ᵣ outPtr) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
               ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
               ** bytesRegion outPtr outOld
@@ -655,22 +655,22 @@ theorem stageC_spec (aPtr bPtr outPtr : Word)
             ((⌜beBytesToNat ws' = wsNat256 (leBytes32 r) 0 ∧ ws'.length = 32⌝
               ** regOwns exposedRegs ** bytesRegion outPtr ws'
               ** bytesRegion (0xbb55d9f0 : Word) (leBytes32 r))) hp) : Assertion)
-            ** (((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+            ** (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 80) : Word)) ** (.x8 ↦ᵣ bPtr)
               ** (.x9 ↦ᵣ outPtr) ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
               ** windowRest arenaB img₃ 0x40 32)) h := by
           xperm_hyp hq
         exact (sepConj_exists_left h).mp hq1) hchain2
     have hcont : ∀ ws' : List (BitVec 8),
-        cpsTripleWithin 1 (0x80030240 : Word) (0x80030244 : Word) addCr
+        cpsTripleWithin 1 ((GuestAddrs.bnf_add_mod_p + 80) : Word) ((GuestAddrs.bnf_add_mod_p + 84) : Word) addCr
           ((⌜beBytesToNat ws' = wsNat256 (leBytes32 r) 0 ∧ ws'.length = 32⌝
             ** regOwns exposedRegs ** bytesRegion outPtr ws'
             ** bytesRegion (0xbb55d9f0 : Word) (leBytes32 r))
-            ** (((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+            ** (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 80) : Word)) ** (.x8 ↦ᵣ bPtr)
               ** (.x9 ↦ᵣ outPtr) ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
               ** windowRest arenaB img₃ 0x40 32))
           (fun hp => ∃ out',
             ((⌜beBytesToNat out' = r ∧ out'.length = 32⌝
-              ** ((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+              ** ((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 80) : Word)) ** (.x8 ↦ᵣ bPtr)
               ** (.x9 ↦ᵣ outPtr) ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** regOwns outRest
               ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
               ** bytesRegion outPtr out'
@@ -682,12 +682,12 @@ theorem stageC_spec (aPtr bPtr outPtr : Word)
           (P := beBytesToNat ws' = wsNat256 (leBytes32 r) 0 ∧ ws'.length = 32)
           (H := regOwns exposedRegs ** bytesRegion outPtr ws'
             ** bytesRegion (0xbb55d9f0 : Word) (leBytes32 r)
-            ** (((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+            ** (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 80) : Word)) ** (.x8 ↦ᵣ bPtr)
               ** (.x9 ↦ᵣ outPtr) ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
               ** windowRest arenaB img₃ 0x40 32))
           (fun hfacts => ?_))
       have hliF := cpsTripleWithin_frameR
-        (((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+        (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 80) : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
           ** regOwns outRest ** bytesRegion outPtr ws'
           ** bytesRegion (0xbb55d9f0 : Word) (leBytes32 r)
           ** windowRest arenaB img₃ 0x40 32
@@ -708,7 +708,7 @@ theorem stageC_spec (aPtr bPtr outPtr : Word)
         have hval : beBytesToNat ws' = r := by
           rw [hfacts.1, wsNat256_leBytes32 r hrlt]
         have hq1 : ((⌜beBytesToNat ws' = r ∧ ws'.length = 32⌝ : Assertion)
-            ** (((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+            ** (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 80) : Word)) ** (.x8 ↦ᵣ bPtr)
               ** (.x9 ↦ᵣ outPtr) ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** regOwns outRest
               ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
               ** bytesRegion outPtr ws'
@@ -731,7 +731,7 @@ theorem stageC_spec (aPtr bPtr outPtr : Word)
         (cpsTripleWithin_seq_exists_same_cr hchain2' hcont))
   -- ---- assemble stage C: la ; csrs ; rest ----
   have hla5F := cpsTripleWithin_frameR
-    (((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+    (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 52) : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
       ** (.x6 ↦ᵣ vf .x6) ** (.x7 ↦ᵣ vf .x7) ** (.x28 ↦ᵣ vf .x28)
       ** (.x29 ↦ᵣ vf .x29) ** (.x30 ↦ᵣ vf .x30) ** (.x31 ↦ᵣ vf .x31)
       ** (.x10 ↦ᵣ vf .x10) ** (.x11 ↦ᵣ vf .x11) ** (.x12 ↦ᵣ vf .x12)
@@ -741,7 +741,7 @@ theorem stageC_spec (aPtr bPtr outPtr : Word)
       ** bytesRegion outPtr outOld ** bytesRegion arenaB img₂)
     (by pcf) hla5
   have hcsrsF := cpsTripleWithin_frameR
-    (((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+    (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 52) : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
       ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE ** bytesRegion outPtr outOld)
     (by pcf) hcsrs
   have hc1 := cpsTripleWithin_seq_perm_same_cr
@@ -753,7 +753,7 @@ theorem stageC_spec (aPtr bPtr outPtr : Word)
           ** (.x13 ↦ᵣ vf .x13) ** (.x14 ↦ᵣ vf .x14) ** (.x15 ↦ᵣ vf .x15)
           ** (.x16 ↦ᵣ vf .x16) ** (.x17 ↦ᵣ vf .x17)
           ** ((((.x5 : Reg)) ↦ᵣ (0xbb55da98 : Word))
-            ** ((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr)
+            ** ((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 52) : Word)) ** (.x8 ↦ᵣ bPtr)
             ** (.x9 ↦ᵣ outPtr)
             ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
             ** bytesRegion outPtr outOld
@@ -776,7 +776,7 @@ theorem stageC_spec (aPtr bPtr outPtr : Word)
                                   (fun _ hh => hh)))))))))))))) h hp1
       have hp3 : ((((.x5 : Reg)) ↦ᵣ (0xbb55da98 : Word)) ** regOwns csrsRest
           ** bytesRegion arenaB img₂
-          ** (((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr)
+          ** (((.x1 : Reg) ↦ᵣ ((GuestAddrs.bnf_add_mod_p + 52) : Word)) ** (.x8 ↦ᵣ bPtr)
             ** (.x9 ↦ᵣ outPtr)
             ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
             ** bytesRegion outPtr outOld)) h := by

--- a/EvmAsm/Codegen/Programs/Bn254FieldAddModPSAsmStage.lean
+++ b/EvmAsm/Codegen/Programs/Bn254FieldAddModPSAsmStage.lean
@@ -1,0 +1,799 @@
+/-
+  EvmAsm.Codegen.Programs.Bn254FieldAddModPSAsmStage
+
+  Split out of `Bn254FieldAddModPSAsm.lean` (file-size guardrail): the
+  staging infrastructure for `bnf_add_mod_p` — the emitted routine
+  (`addBody`/`addFrame`/`addProg_tie`), its code map (`addCr`), the two
+  converter-callee focused adapters (`bnfBeToLeFlat_spec` /
+  `bnfLeToBeFlat_spec`), the inline CSR-2050 arithMod step
+  (`csrsStep_spec`), and the accumulated-splice `stageC_spec`.  The
+  capstone `bnfAddModP_spec` lives in `Bn254FieldAddModPSAsm`, which
+  imports this file.  See that file's header for the full design notes.
+-/
+
+import EvmAsm.Codegen.Programs.Bn254Field
+import EvmAsm.Codegen.Programs.Bn254FieldConvSAsm
+import EvmAsm.Codegen.Programs.Bn254FieldConvSAsmLeToBe
+import EvmAsm.Rv64.SAsm.RwSubwindow
+import EvmAsm.Rv64.SAsm.AbiFrameCall
+import EvmAsm.Rv64.SAsm.FnFlat
+import EvmAsm.Rv64.LaResolve
+import EvmAsm.Crypto.PowLadder
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Crypto
+
+namespace Bn254FieldAddModPSAsm
+
+open Bn254FieldConvSAsm (bnfBeToLeFn bnfBeToLeFn_spec bnfLeToBeFn bnfLeToBeFn_spec)
+
+-- Address anchors (routine, callees, and the LE staging arena).
+#guard GuestAddrs.bnf_add_mod_p = 0x800301f0
+#guard GuestAddrs.bnf_be_to_le = 0x8003003c
+#guard GuestAddrs.bnf_le_to_be = 0x8003008c
+#guard GuestAddrs.bnf_le_a = 0xbb55d9b0
+#guard GuestAddrs.bnf_le_b = 0xbb55d9d0
+#guard GuestAddrs.bnf_le_d = 0xbb55d9f0
+#guard GuestAddrs.bnf_le_zero = 0xbb55da10
+#guard GuestAddrs.bnf_le_p = 0xbb55da50
+#guard GuestAddrs.bnf_add_params = 0xbb55da98
+
+/-- The arena base (`bnf_le_a`) and its 272-byte extent
+    (`_a/_b/_d/_zero/_one/_p` 32-byte cells + the 40-byte `add_params`). -/
+def arenaB : Word := 0xbb55d9b0
+
+/-- The frame and body of the emitted routine. -/
+def addFrame : FrameDesc := [(.x1, 0), (.x8, 8), (.x9, 16)]
+
+def addBody : List Instr :=
+  [ .MV .x8 .x11,
+    .MV .x9 .x12,
+    .AUIPC .x11 (laHi GuestAddrs.bnf_le_a (GuestAddrs.bnf_add_mod_p + 24)),
+    .ADDI .x11 .x11 (laLo GuestAddrs.bnf_le_a (GuestAddrs.bnf_add_mod_p + 24)),
+    .JAL .x1 (jalOff GuestAddrs.bnf_be_to_le (GuestAddrs.bnf_add_mod_p + 32)),
+    .MV .x10 .x8,
+    .AUIPC .x11 (laHi GuestAddrs.bnf_le_b (GuestAddrs.bnf_add_mod_p + 40)),
+    .ADDI .x11 .x11 (laLo GuestAddrs.bnf_le_b (GuestAddrs.bnf_add_mod_p + 40)),
+    .JAL .x1 (jalOff GuestAddrs.bnf_be_to_le (GuestAddrs.bnf_add_mod_p + 48)),
+    .AUIPC .x5 (laHi GuestAddrs.bnf_add_params (GuestAddrs.bnf_add_mod_p + 52)),
+    .ADDI .x5 .x5 (laLo GuestAddrs.bnf_add_params (GuestAddrs.bnf_add_mod_p + 52)),
+    .CSRS (2050 : BitVec 12) .x5,
+    .AUIPC .x10 (laHi GuestAddrs.bnf_le_d (GuestAddrs.bnf_add_mod_p + 64)),
+    .ADDI .x10 .x10 (laLo GuestAddrs.bnf_le_d (GuestAddrs.bnf_add_mod_p + 64)),
+    .MV .x11 .x9,
+    .JAL .x1 (jalOff GuestAddrs.bnf_le_to_be (GuestAddrs.bnf_add_mod_p + 76)),
+    .LI .x10 (0 : Word) ]
+
+/-- Byte tie (kernel-checked): the emitted routine IS the ABI frame over
+    the body — byte-transparent, no A/B. -/
+theorem addProg_tie :
+    abiFrameProg (-32 : BitVec 12) (32 : BitVec 12) addFrame addBody
+      = bnfAddModP_prog := rfl
+
+/-- The routine's single code map: its own program plus the two converter
+    callees'. -/
+def addCr : CodeReq :=
+  (CodeReq.ofProg (0x800301f0 : Word) bnfAddModP_prog).union
+    ((CodeReq.ofProg (0x8003003c : Word) bnfBeToLe_prog).union
+      (CodeReq.ofProg (0x8003008c : Word) bnfLeToBe_prog))
+
+/-- The exposed registers the converter contracts clobber beyond `a0`/`a1`. -/
+def convScratch : List Reg :=
+  [.x5, .x6, .x7, .x28, .x29, .x30, .x31, .x12, .x13, .x14, .x15, .x16, .x17]
+
+private theorem exposedRegs_split2 (vf : Reg → Word) :
+    regAtomsOf vf exposedRegs
+      = ((.x10 ↦ᵣ vf .x10) ** (.x11 ↦ᵣ vf .x11) ** regAtomsOf vf convScratch) := by
+  show regAtomsOf vf
+      [.x5, .x6, .x7, .x28, .x29, .x30, .x31,
+       .x10, .x11, .x12, .x13, .x14, .x15, .x16, .x17] = _
+  simp only [convScratch, regAtomsOf_cons, regAtomsOf_nil]
+  xperm
+
+private theorem x10_notin_convScratch : (.x10 : Reg) ∉ convScratch := by decide
+private theorem x11_notin_convScratch : (.x11 : Reg) ∉ convScratch := by decide
+
+/-- **Flat contract for `bnf_be_to_le`** (adapter-derived, ∃-post: the
+    written window's exact bytes are existential, its 256-bit LE decode is
+    pinned to the input's BE value). -/
+theorem bnfBeToLeFlat_spec (ret srci dsti : Word) (inb ob : List (BitVec 8))
+    (hilen : inb.length = 32) (holen : ob.length = 32)
+    (hwfR : Region.wf ⟨srci, inb⟩) (hrww : RwRegion.wf ⟨dsti, 32⟩)
+    (hso : srci.toNat + 32 < 2 ^ 64) (hdo : dsti.toNat + 32 < 2 ^ 64)
+    (hdisj : srci.toNat + 32 ≤ dsti.toNat ∨ dsti.toNat + 32 ≤ srci.toNat)
+    (halign : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin ((bnfBeToLeFn srci dsti inb ob).body.steps + 1)
+      (0x8003003c : Word) ret addCr
+      (((.x1 : Reg) ↦ᵣ ret) ** (.x10 ↦ᵣ srci) ** (.x11 ↦ᵣ dsti)
+        ** regOwns convScratch ** bytesRegion dsti ob ** bytesRegion srci inb)
+      (fun hp => ∃ ws',
+        ((⌜wsNat256 ws' 0 = beBytesToNat inb ∧ ws'.length = 32⌝
+          ** ((.x1 : Reg) ↦ᵣ ret) ** regOwns exposedRegs
+          ** bytesRegion dsti ws' ** bytesRegion srci inb)) hp) := by
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => hq)
+    (cpsTripleWithin_peel_regOwns convScratch (by decide)
+      (P := ((.x1 : Reg) ↦ᵣ ret) ** (.x10 ↦ᵣ srci) ** (.x11 ↦ᵣ dsti)
+        ** bytesRegion dsti ob ** bytesRegion srci inb)
+      (fun vf => ?_))
+  have had := Fn.retSpecFlat (bnfBeToLeFn srci dsti inb ob)
+    (0x8003003c : Word)
+    (bnfBeToLeFn_spec srci dsti inb ob hwfR hrww hilen (0x8003003c : Word))
+    (by show 4 * (19 + 1) ≤ 2 ^ 64; decide) ret halign
+    (fun r => if r = .x10 then srci else if r = .x11 then dsti else vf r)
+    ob
+    (by show ob.length = 32; exact holen)
+    (by
+      refine ⟨?_, ?_, rfl, holen, hilen, hso, hdo, hdisj, rfl⟩
+      · show RegFile.get _ .x10 = srci
+        rw [RegFile.get, if_neg (by decide : (Reg.x10 : Reg) ≠ .x0)]
+        exact if_pos rfl
+      · show RegFile.get _ .x11 = dsti
+        rw [RegFile.get, if_neg (by decide : (Reg.x11 : Reg) ≠ .x0)]
+        rw [if_neg (by decide : (Reg.x11 : Reg) ≠ .x10)]
+        exact if_pos rfl)
+    (fun _ _ _ h => h.2.2)
+    (Q := fun hp => ∃ ws',
+      ((⌜wsNat256 ws' 0 = beBytesToNat inb ∧ ws'.length = 32⌝
+        ** regOwns exposedRegs ** bytesRegion dsti ws')) hp)
+    (fun rf' ws' hlen' hpost' hp hh => by
+      refine ⟨ws', ?_⟩
+      rw [regFileIs_eq_regAtoms, regAtoms_eq_regAtomsOf _ _ (by decide)] at hh
+      have hh2 := sepConj_mono_left
+        (regAtomsOf_to_regOwns (fun r => rf' r) exposedRegs) hp hh
+      have hpure : (⌜wsNat256 ws' 0 = beBytesToNat inb ∧ ws'.length = 32⌝
+          ** (regOwns exposedRegs ** bytesRegion dsti ws')) hp :=
+        (sepConj_pure_left hp).mpr ⟨⟨hpost'.1, hlen'⟩, hh2⟩
+      xperm_hyp hpure)
+  rw [show (bnfBeToLeFn srci dsti inb ob).programRet (0x8003003c : Word)
+      = bnfBeToLe_prog from rfl] at had
+  have hadC := liftCode (cr' := addCr) had (by code_mem)
+  rw [show (bnfBeToLeFn srci dsti inb ob).region = (⟨srci, inb⟩ : Region) from rfl,
+      show (bnfBeToLeFn srci dsti inb ob).rw.base = dsti from rfl] at hadC
+  rw [regFileIs_eq_regAtoms, regAtoms_eq_regAtomsOf _ _ (by decide),
+    exposedRegs_split2,
+    show (if (Reg.x10 : Reg) = .x10 then srci else
+        if (Reg.x10 : Reg) = .x11 then dsti else vf .x10) = srci from if_pos rfl,
+    show (if (Reg.x11 : Reg) = .x10 then srci else
+        if (Reg.x11 : Reg) = .x11 then dsti else vf .x11) = dsti from by
+      rw [if_neg (by decide : ¬ ((Reg.x11 : Reg) = .x10))]
+      exact if_pos rfl,
+    regAtomsOf_congr
+      (fun r => if r = .x10 then srci else if r = .x11 then dsti else vf r)
+      vf convScratch
+      (fun r hr => by
+        show (if r = .x10 then srci else if r = .x11 then dsti else vf r) = vf r
+        rw [if_neg (fun (hc : r = .x10) => x10_notin_convScratch (hc ▸ hr)),
+            if_neg (fun (hc : r = .x11) => x11_notin_convScratch (hc ▸ hr))])]
+    at hadC
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun h hq => ?_) hadC
+  -- push the frame atoms inside the existential
+  have hq1 : ((fun hp => ∃ ws',
+      ((⌜wsNat256 ws' 0 = beBytesToNat inb ∧ ws'.length = 32⌝
+        ** regOwns exposedRegs ** bytesRegion dsti ws')) hp)
+      ** (((.x1 : Reg) ↦ᵣ ret) ** bytesRegion srci inb) : Assertion) h := by
+    xperm_hyp hq
+  obtain ⟨ws', hin⟩ := (sepConj_exists_left h).mp hq1
+  exact ⟨ws', by xperm_hyp hin⟩
+
+/-- **Flat contract for `bnf_le_to_be`** (adapter-derived, ∃-post: the
+    output's BE decode is pinned to the LE staging window's value). -/
+theorem bnfLeToBeFlat_spec (ret srci dsti : Word) (inb ob : List (BitVec 8))
+    (hilen : inb.length = 32) (holen : ob.length = 32)
+    (hwfR : Region.wf ⟨srci, inb⟩) (hrww : RwRegion.wf ⟨dsti, 32⟩)
+    (hso : srci.toNat + 32 < 2 ^ 64) (hdo : dsti.toNat + 32 < 2 ^ 64)
+    (hdisj : srci.toNat + 32 ≤ dsti.toNat ∨ dsti.toNat + 32 ≤ srci.toNat)
+    (halign : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin ((bnfLeToBeFn srci dsti inb ob).body.steps + 1)
+      (0x8003008c : Word) ret addCr
+      (((.x1 : Reg) ↦ᵣ ret) ** (.x10 ↦ᵣ srci) ** (.x11 ↦ᵣ dsti)
+        ** regOwns convScratch ** bytesRegion dsti ob ** bytesRegion srci inb)
+      (fun hp => ∃ ws',
+        ((⌜beBytesToNat ws' = wsNat256 inb 0 ∧ ws'.length = 32⌝
+          ** ((.x1 : Reg) ↦ᵣ ret) ** regOwns exposedRegs
+          ** bytesRegion dsti ws' ** bytesRegion srci inb)) hp) := by
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => hq)
+    (cpsTripleWithin_peel_regOwns convScratch (by decide)
+      (P := ((.x1 : Reg) ↦ᵣ ret) ** (.x10 ↦ᵣ srci) ** (.x11 ↦ᵣ dsti)
+        ** bytesRegion dsti ob ** bytesRegion srci inb)
+      (fun vf => ?_))
+  have had := Fn.retSpecFlat (bnfLeToBeFn srci dsti inb ob)
+    (0x8003008c : Word)
+    (bnfLeToBeFn_spec srci dsti inb ob hwfR hrww hilen (0x8003008c : Word))
+    (by show 4 * (18 + 1) ≤ 2 ^ 64; decide) ret halign
+    (fun r => if r = .x10 then srci else if r = .x11 then dsti else vf r)
+    ob
+    (by show ob.length = 32; exact holen)
+    (by
+      refine ⟨?_, ?_, rfl, holen, hilen, hso, hdo, hdisj, rfl⟩
+      · show RegFile.get _ .x10 = srci
+        rw [RegFile.get, if_neg (by decide : (Reg.x10 : Reg) ≠ .x0)]
+        exact if_pos rfl
+      · show RegFile.get _ .x11 = dsti
+        rw [RegFile.get, if_neg (by decide : (Reg.x11 : Reg) ≠ .x0)]
+        rw [if_neg (by decide : (Reg.x11 : Reg) ≠ .x10)]
+        exact if_pos rfl)
+    (fun _ _ _ h => h.2.2)
+    (Q := fun hp => ∃ ws',
+      ((⌜beBytesToNat ws' = wsNat256 inb 0 ∧ ws'.length = 32⌝
+        ** regOwns exposedRegs ** bytesRegion dsti ws')) hp)
+    (fun rf' ws' hlen' hpost' hp hh => by
+      refine ⟨ws', ?_⟩
+      rw [regFileIs_eq_regAtoms, regAtoms_eq_regAtomsOf _ _ (by decide)] at hh
+      have hh2 := sepConj_mono_left
+        (regAtomsOf_to_regOwns (fun r => rf' r) exposedRegs) hp hh
+      have hpure : (⌜beBytesToNat ws' = wsNat256 inb 0 ∧ ws'.length = 32⌝
+          ** (regOwns exposedRegs ** bytesRegion dsti ws')) hp :=
+        (sepConj_pure_left hp).mpr ⟨⟨hpost'.1, hlen'⟩, hh2⟩
+      xperm_hyp hpure)
+  rw [show (bnfLeToBeFn srci dsti inb ob).programRet (0x8003008c : Word)
+      = bnfLeToBe_prog from rfl] at had
+  have hadC := liftCode (cr' := addCr) had (by code_mem)
+  rw [show (bnfLeToBeFn srci dsti inb ob).region = (⟨srci, inb⟩ : Region) from rfl,
+      show (bnfLeToBeFn srci dsti inb ob).rw.base = dsti from rfl] at hadC
+  rw [regFileIs_eq_regAtoms, regAtoms_eq_regAtomsOf _ _ (by decide),
+    exposedRegs_split2,
+    show (if (Reg.x10 : Reg) = .x10 then srci else
+        if (Reg.x10 : Reg) = .x11 then dsti else vf .x10) = srci from if_pos rfl,
+    show (if (Reg.x11 : Reg) = .x10 then srci else
+        if (Reg.x11 : Reg) = .x11 then dsti else vf .x11) = dsti from by
+      rw [if_neg (by decide : ¬ ((Reg.x11 : Reg) = .x10))]
+      exact if_pos rfl,
+    regAtomsOf_congr
+      (fun r => if r = .x10 then srci else if r = .x11 then dsti else vf r)
+      vf convScratch
+      (fun r hr => by
+        show (if r = .x10 then srci else if r = .x11 then dsti else vf r) = vf r
+        rw [if_neg (fun (hc : r = .x10) => x10_notin_convScratch (hc ▸ hr)),
+            if_neg (fun (hc : r = .x11) => x11_notin_convScratch (hc ▸ hr))])]
+    at hadC
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun h hq => ?_) hadC
+  have hq1 : ((fun hp => ∃ ws',
+      ((⌜beBytesToNat ws' = wsNat256 inb 0 ∧ ws'.length = 32⌝
+        ** regOwns exposedRegs ** bytesRegion dsti ws')) hp)
+      ** (((.x1 : Reg) ↦ᵣ ret) ** bytesRegion srci inb) : Assertion) h := by
+    xperm_hyp hq
+  obtain ⟨ws', hin⟩ := (sepConj_exists_left h).mp hq1
+  exact ⟨ws', by xperm_hyp hin⟩
+
+-- ============================================================================
+-- The inline arithMod accelerator step (CSR 0x802 = 2050)
+-- ============================================================================
+
+/-- Exposed registers other than `t0` (the parameter-block pointer). -/
+def csrsRest : List Reg :=
+  [.x6, .x7, .x28, .x29, .x30, .x31,
+   .x10, .x11, .x12, .x13, .x14, .x15, .x16, .x17]
+
+private theorem exposedRegs_split5 (vf : Reg → Word) :
+    regAtomsOf vf exposedRegs
+      = ((.x5 ↦ᵣ vf .x5) ** regAtomsOf vf csrsRest) := by
+  show regAtomsOf vf
+      [.x5, .x6, .x7, .x28, .x29, .x30, .x31,
+       .x10, .x11, .x12, .x13, .x14, .x15, .x16, .x17] = _
+  simp only [csrsRest, regAtomsOf_cons, regAtomsOf_nil]
+
+private theorem x5_notin_csrsRest : (.x5 : Reg) ∉ csrsRest := by decide
+
+/-- The one-step accelerator triple at atom granularity: `t0` points at the
+    staged parameter block, the whole arena rides as ONE atom, and the `_d`
+    subwindow becomes the `arith256Mod` result — nothing else (registers or
+    other subwindows) moves. -/
+theorem csrsStep_spec (img : List (BitVec 8))
+    (hlen : img.length = 272)
+    (hvalid : ∀ j, j < 272 → isValidMemAddr (arenaB + BitVec.ofNat 64 j) = true)
+    (hpa : wsDword img 0xE8 = arenaB + BitVec.ofNat 64 0)
+    (hpb : wsDword img 0xF0 = arenaB + BitVec.ofNat 64 0x80)
+    (hpc : wsDword img 0xF8 = arenaB + BitVec.ofNat 64 0x20)
+    (hpm : wsDword img 0x100 = arenaB + BitVec.ofNat 64 0xA0)
+    (hpd : wsDword img 0x108 = arenaB + BitVec.ofNat 64 0x40)
+    (hmne : wsNat256 img 0xA0 ≠ 0) :
+    cpsTripleWithin 1 (0x8003022c : Word) (0x80030230 : Word) addCr
+      (((.x5 : Reg) ↦ᵣ (0xbb55da98 : Word)) ** regOwns csrsRest
+        ** bytesRegion arenaB img)
+      (((.x5 : Reg) ↦ᵣ (0xbb55da98 : Word)) ** regOwns csrsRest
+        ** bytesRegion arenaB
+          (setBytes img 0x40 (leBytes32 (Accel.arith256Mod
+            (wsNat256 img 0) (wsNat256 img 0x80)
+            (wsNat256 img 0x20) (wsNat256 img 0xA0))))) := by
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => hq)
+    (cpsTripleWithin_peel_regOwns csrsRest (by decide)
+      (P := ((.x5 : Reg) ↦ᵣ (0xbb55da98 : Word)) ** bytesRegion arenaB img)
+      (fun vf => ?_))
+  have hcs := csrs_arith256Mod_spec_within (0x8003022c : Word) .x5 (by decide)
+    arenaB 272 img
+    (fun r => if r = .x5 then (0xbb55da98 : Word) else vf r)
+    hlen (by decide) hvalid
+    0xE8 0 0x80 0x20 0xA0 0x40
+    (by
+      show RegFile.get _ .x5 = arenaB + BitVec.ofNat 64 0xE8
+      rw [RegFile.get, if_neg (by decide : (Reg.x5 : Reg) ≠ .x0)]
+      show (if (Reg.x5 : Reg) = .x5 then (0xbb55da98 : Word) else vf .x5) = _
+      rw [if_pos rfl]
+      decide)
+    (by decide) (by decide) (by decide) (by decide) (by decide) (by decide)
+    (by decide) (by decide) (by decide) (by decide) (by decide) (by decide)
+    hpa hpb hpc hpm hpd hmne
+  have hcsC := liftCode (cr' := addCr) hcs (by code_mem)
+  rw [show (0x8003022c : Word) + 4 = (0x80030230 : Word) from by decide] at hcsC
+  -- unpack the register file on both sides (same file — the step moves nothing)
+  rw [regFileIs_eq_regAtoms, regAtoms_eq_regAtomsOf _ _ (by decide),
+    exposedRegs_split5,
+    show (if (Reg.x5 : Reg) = .x5 then (0xbb55da98 : Word) else vf .x5)
+      = (0xbb55da98 : Word) from if_pos rfl,
+    regAtomsOf_congr
+      (fun r => if r = .x5 then (0xbb55da98 : Word) else vf r) vf csrsRest
+      (fun r hr => by
+        show (if r = .x5 then (0xbb55da98 : Word) else vf r) = vf r
+        rw [if_neg (fun (hc : r = .x5) => x5_notin_csrsRest (hc ▸ hr))])]
+    at hcsC
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun h hq => ?_) hcsC
+  have hq2 := sepConj_mono_left (sepConj_mono_right
+    (regAtomsOf_to_regOwns vf csrsRest)) h hq
+  xperm_hyp hq2
+
+
+-- ============================================================================
+-- The whole routine
+-- ============================================================================
+
+/-- Pull an atom out of an ∃-post (the written window stays inside). -/
+theorem exists_pull {α : Sort _} {F : α → Assertion} {G : Assertion}
+    (h : PartialState) (hin : ∃ a, (G ** F a) h) :
+    (G ** (fun hp => ∃ a, F a hp) : Assertion) h := by
+  obtain ⟨a, h1, h2, hd, hu, hG, hFa⟩ := hin
+  exact ⟨h1, h2, hd, hu, hG, ⟨a, hFa⟩⟩
+
+/-- A 256-bit window decode is bounded. -/
+private theorem wsNat256_lt (ws : List (BitVec 8)) (k : Nat) :
+    wsNat256 ws k < 2 ^ 256 := by
+  unfold wsNat256 Accel.leLimbsToNat
+  simp only [List.foldr_cons, List.foldr_nil]
+  have h0 := (wsDword ws k).isLt
+  have h1 := (wsDword ws (k + 8)).isLt
+  have h2 := (wsDword ws (k + 16)).isLt
+  have h3 := (wsDword ws (k + 24)).isLt
+  set M : Nat := 2 ^ 64 with hM
+  have e2 : (2 : Nat) ^ 256 = M * M * M * M := by rw [hM]; norm_num
+  rw [e2]
+  set d3 := (wsDword ws (k + 24)).toNat
+  set d2 := (wsDword ws (k + 16)).toNat
+  set d1 := (wsDword ws (k + 8)).toNat
+  set d0 := (wsDword ws k).toNat
+  clear_value M d3 d2 d1 d0
+  have A1 : 0 * M + d3 < M := by omega
+  have A2 : (0 * M + d3) * M + d2 < M * M := by
+    calc (0 * M + d3) * M + d2 < (0 * M + d3) * M + M := by omega
+      _ = ((0 * M + d3) + 1) * M := (Nat.succ_mul _ _).symm
+      _ ≤ M * M := Nat.mul_le_mul_right M A1
+  have A3 : ((0 * M + d3) * M + d2) * M + d1 < M * M * M := by
+    calc ((0 * M + d3) * M + d2) * M + d1
+        < ((0 * M + d3) * M + d2) * M + M := by omega
+      _ = (((0 * M + d3) * M + d2) + 1) * M := (Nat.succ_mul _ _).symm
+      _ ≤ (M * M) * M := Nat.mul_le_mul_right M A2
+  calc (((0 * M + d3) * M + d2) * M + d1) * M + d0
+      < (((0 * M + d3) * M + d2) * M + d1) * M + M := by omega
+    _ = ((((0 * M + d3) * M + d2) * M + d1) + 1) * M := (Nat.succ_mul _ _).symm
+    _ ≤ (M * M * M) * M := Nat.mul_le_mul_right M A3
+
+/-- Exposed registers other than `a0` (the stage-C result register). -/
+def outRest : List Reg :=
+  [.x5, .x6, .x7, .x28, .x29, .x30, .x31,
+   .x11, .x12, .x13, .x14, .x15, .x16, .x17]
+
+private theorem exposedRegs_split10 (vf : Reg → Word) :
+    regAtomsOf vf exposedRegs
+      = ((.x10 ↦ᵣ vf .x10) ** regAtomsOf vf outRest) := by
+  show regAtomsOf vf
+      [.x5, .x6, .x7, .x28, .x29, .x30, .x31,
+       .x10, .x11, .x12, .x13, .x14, .x15, .x16, .x17] = _
+  simp only [outRest, regAtomsOf_cons, regAtomsOf_nil]
+  xperm
+
+private theorem exists_push {α : Sort _} {F : α → Assertion} {G : Assertion}
+    (h : PartialState) (hin : (G ** (fun hp => ∃ a, F a hp) : Assertion) h) :
+    ∃ a, (G ** F a) h := by
+  obtain ⟨h1, h2, hd, hu, hG, ⟨a, hFa⟩⟩ := hin
+  exact ⟨a, h1, h2, hd, hu, hG, hFa⟩
+
+private theorem ownsSplit10 :
+    regOwns exposedRegs = (regOwn .x10 ** regOwns outRest) := by
+  show regOwns
+      [.x5, .x6, .x7, .x28, .x29, .x30, .x31,
+       .x10, .x11, .x12, .x13, .x14, .x15, .x16, .x17] = _
+  simp only [outRest, regOwns_cons, regOwns_nil]
+  funext h
+  exact propext ⟨fun hp => by xperm_hyp hp, fun hp => by xperm_hyp hp⟩
+
+/-- **Stage C** (`la t0, params ; csrs ; la a0, _d ; a1 := s1 ;
+    call bnf_le_to_be ; a0 := 0`): from the post-conversion arena image,
+    run the accelerator over the staged operands and convert the `_d`
+    subwindow (read-only focused) out to the caller's window. -/
+theorem stageC_spec (aPtr bPtr outPtr : Word)
+    (aBE bBE outOld img₂ : List (BitVec 8))
+    (hilen : img₂.length = 272) (holen : outOld.length = 32)
+    (hoal : outPtr.toNat % 8 = 0) (hoov : outPtr.toNat + 32 < 2 ^ 64)
+    (hovalid : ∀ k, k < 32 → isValidMemAddr (outPtr + BitVec.ofNat 64 k) = true)
+    (harval : ∀ j, j < 272 → isValidMemAddr (arenaB + BitVec.ofNat 64 j) = true)
+    (hdO : (0xbb55da10 : Nat) ≤ outPtr.toNat ∨ outPtr.toNat + 32 ≤ (0xbb55d9f0 : Nat))
+    (hpa₂ : wsDword img₂ 0xE8 = arenaB + BitVec.ofNat 64 0)
+    (hpb₂ : wsDword img₂ 0xF0 = arenaB + BitVec.ofNat 64 0x80)
+    (hpc₂ : wsDword img₂ 0xF8 = arenaB + BitVec.ofNat 64 0x20)
+    (hpm₂ : wsDword img₂ 0x100 = arenaB + BitVec.ofNat 64 0xA0)
+    (hpd₂ : wsDword img₂ 0x108 = arenaB + BitVec.ofNat 64 0x40)
+    (hmne₂ : wsNat256 img₂ 0xA0 ≠ 0) :
+    cpsTripleWithin (7 + ((bnfLeToBeFn 0 0 [] []).body.steps + 1) + 1)
+      (0x80030224 : Word) (0x80030244 : Word) addCr
+      (((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+        ** regOwns exposedRegs
+        ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+        ** bytesRegion outPtr outOld ** bytesRegion arenaB img₂)
+      (fun hp => ∃ out',
+        ((⌜beBytesToNat out'
+            = Accel.arith256Mod (wsNat256 img₂ 0) (wsNat256 img₂ 0x80)
+                (wsNat256 img₂ 0x20) (wsNat256 img₂ 0xA0)
+          ∧ out'.length = 32⌝
+          ** ((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+          ** (.x9 ↦ᵣ outPtr) ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** regOwns outRest
+          ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+          ** bytesRegion outPtr out'
+          ** bytesRegion arenaB
+            (setBytes img₂ 0x40 (leBytes32 (Accel.arith256Mod
+              (wsNat256 img₂ 0) (wsNat256 img₂ 0x80)
+              (wsNat256 img₂ 0x20) (wsNat256 img₂ 0xA0)))))) hp) := by
+  set r := Accel.arith256Mod (wsNat256 img₂ 0) (wsNat256 img₂ 0x80)
+    (wsNat256 img₂ 0x20) (wsNat256 img₂ 0xA0) with hr
+  set img₃ := setBytes img₂ 0x40 (leBytes32 r) with himg₃
+  have hrlt : r < 2 ^ 256 := by
+    rw [hr]
+    unfold Accel.arith256Mod
+    exact lt_trans (Nat.mod_lt _ (Nat.pos_of_ne_zero hmne₂)) (wsNat256_lt img₂ 0xA0)
+  have himg₃len : img₃.length = 272 := by
+    rw [himg₃, length_setBytes]
+    exact hilen
+  -- the d-window of the accelerator image is the fresh LE result
+  have hdwin : ((img₃.drop 0x40).take 32) = leBytes32 r := by
+    rw [himg₃]
+    have := window_readback img₂ (leBytes32 r) 0x40
+      (by rw [length_leBytes32]; omega)
+    rwa [length_leBytes32] at this
+  -- ---- la t0, bnf_add_params ----
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => hq)
+    (cpsTripleWithin_peel_regOwns exposedRegs (by decide)
+      (P := ((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+        ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+        ** bytesRegion outPtr outOld ** bytesRegion arenaB img₂)
+      (fun vf => ?_))
+  have hla5 := la_materialize_within .x5 (vf .x5) (0x80030224 : Word)
+    (0xbb55da98 : Word) (cr := addCr) (by decide) (by decide)
+    (by code_mem) (by code_mem)
+  rw [show (0x80030224 : Word) + 8 = (0x8003022c : Word) from by decide] at hla5
+  -- CSRS over the whole arena atom
+  have hcsrs := csrsStep_spec img₂ hilen harval hpa₂ hpb₂ hpc₂ hpm₂ hpd₂ hmne₂
+  rw [← hr, ← himg₃] at hcsrs
+  -- the rest of the stage, from the CSRS exit, with the register file owned
+  have hrest : cpsTripleWithin
+      (4 + ((bnfLeToBeFn 0 0 [] []).body.steps + 1) + 1)
+      (0x80030230 : Word) (0x80030244 : Word) addCr
+      (((.x5 : Reg) ↦ᵣ (0xbb55da98 : Word)) ** regOwns csrsRest
+        ** ((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+        ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+        ** bytesRegion outPtr outOld ** bytesRegion arenaB img₃)
+      (fun hp => ∃ out',
+        ((⌜beBytesToNat out' = r ∧ out'.length = 32⌝
+          ** ((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+          ** (.x9 ↦ᵣ outPtr) ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** regOwns outRest
+          ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+          ** bytesRegion outPtr out'
+          ** bytesRegion arenaB img₃)) hp) := by
+    refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => hq)
+      (cpsTripleWithin_peel_regOwns csrsRest (by decide)
+        (P := ((.x5 : Reg) ↦ᵣ (0xbb55da98 : Word))
+          ** ((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+          ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+          ** bytesRegion outPtr outOld ** bytesRegion arenaB img₃)
+        (fun vg => ?_))
+    -- la a0, bnf_le_d
+    have hla10 := la_materialize_within .x10 (vg .x10) (0x80030230 : Word)
+      (0xbb55d9f0 : Word) (cr := addCr) (by decide) (by decide)
+      (by code_mem) (by code_mem)
+    rw [show (0x80030230 : Word) + 8 = (0x80030238 : Word) from by decide] at hla10
+    -- a1 := s1
+    have hmv := liftCode (cr' := addCr)
+      (mv_spec_gen_within .x11 .x9 outPtr (vg .x11) (0x80030238 : Word) (by decide))
+      (by code_mem)
+    rw [show (0x80030238 : Word) + 4 = (0x8003023c : Word) from by decide] at hmv
+    -- the final conversion call over the FOCUSED d-window
+    have hflat := bnfLeToBeFlat_spec (0x80030240 : Word) (0xbb55d9f0 : Word)
+      outPtr (leBytes32 r) outOld (by rw [length_leBytes32]) holen
+      (by
+        refine ⟨?_, ?_, ?_⟩
+        · show ((0xbb55d9f0 : Word)).toNat % 8 = 0
+          decide
+        · show ((0xbb55d9f0 : Word)).toNat + (leBytes32 r).length < 2 ^ 64
+          rw [length_leBytes32]
+          decide
+        · intro k hk
+          rw [length_leBytes32] at hk
+          rw [show (0xbb55d9f0 : Word) + BitVec.ofNat 64 k
+              = arenaB + BitVec.ofNat 64 (0x40 + k) from by
+            show _ = arenaB + BitVec.ofNat 64 (0x40 + k)
+            apply BitVec.eq_of_toNat_eq
+            rw [BitVec.toNat_add, BitVec.toNat_add, BitVec.toNat_ofNat,
+              BitVec.toNat_ofNat,
+              show ((0xbb55d9f0 : Word)).toNat = 0xbb55d9f0 from by decide,
+              show (arenaB).toNat = 0xbb55d9b0 from by decide]
+            omega]
+          exact harval (0x40 + k) (by omega))
+      ⟨hoal, by omega, hovalid⟩
+      (by decide) (by omega)
+      (by
+        have hsrc : ((0xbb55d9f0 : Word)).toNat = 0xbb55d9f0 := by decide
+        rcases hdO with h | h
+        · left
+          rw [hsrc]
+          omega
+        · right
+          rw [hsrc]
+          omega)
+      (by decide)
+    -- massage into callWithin shape: pull `ra` out of the ∃-post
+    have hcallee : cpsTripleWithin ((bnfLeToBeFn (0xbb55d9f0 : Word) outPtr
+        (leBytes32 r) outOld).body.steps + 1)
+        (0x8003008c : Word) (0x80030240 : Word) addCr
+        (((.x1 : Reg) ↦ᵣ (0x80030240 : Word))
+          ** ((.x10 ↦ᵣ (0xbb55d9f0 : Word)) ** (.x11 ↦ᵣ outPtr)
+            ** regOwns convScratch ** bytesRegion outPtr outOld
+            ** bytesRegion (0xbb55d9f0 : Word) (leBytes32 r)))
+        (((.x1 : Reg) ↦ᵣ (0x80030240 : Word))
+          ** (fun hp => ∃ ws',
+            ((⌜beBytesToNat ws' = wsNat256 (leBytes32 r) 0 ∧ ws'.length = 32⌝
+              ** regOwns exposedRegs ** bytesRegion outPtr ws'
+              ** bytesRegion (0xbb55d9f0 : Word) (leBytes32 r))) hp)) := by
+      refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+        (fun h hq => ?_) hflat
+      obtain ⟨ws', hin⟩ := hq
+      refine exists_pull h ⟨ws', ?_⟩
+      xperm_hyp hin
+    have hcall := callWithin_spec (0x8003023c : Word) (0x8003008c : Word)
+      (0x80030224 : Word)
+      (jalOff GuestAddrs.bnf_le_to_be (GuestAddrs.bnf_add_mod_p + 76))
+      ((bnfLeToBeFn (0xbb55d9f0 : Word) outPtr (leBytes32 r) outOld).body.steps + 1)
+      (by decide) (by code_mem) (by pcf) hcallee
+    rw [show (0x8003023c : Word) + 4 = (0x80030240 : Word) from by decide] at hcall
+    rw [show (bnfLeToBeFn (0xbb55d9f0 : Word) outPtr
+        (leBytes32 r) outOld).body.steps
+      = (bnfLeToBeFn 0 0 [] []).body.steps from rfl] at hcall
+    -- a0 := 0
+    have hli := liftCode (cr' := addCr)
+      (li_spec_gen_own_within .x10 (0 : Word) (0x80030240 : Word) (by decide))
+      (by code_mem)
+    rw [show (0x80030240 : Word) + 4 = (0x80030244 : Word) from by decide] at hli
+    -- ---- frames + chain ----
+    have hla10F := cpsTripleWithin_frameR
+      (((.x5 : Reg) ↦ᵣ (0xbb55da98 : Word)) ** ((.x1 : Reg) ↦ᵣ (0x80030224 : Word))
+        ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr) ** (.x11 ↦ᵣ vg .x11)
+        ** (.x6 ↦ᵣ vg .x6) ** (.x7 ↦ᵣ vg .x7) ** (.x28 ↦ᵣ vg .x28)
+        ** (.x29 ↦ᵣ vg .x29) ** (.x30 ↦ᵣ vg .x30) ** (.x31 ↦ᵣ vg .x31)
+        ** (.x12 ↦ᵣ vg .x12) ** (.x13 ↦ᵣ vg .x13) ** (.x14 ↦ᵣ vg .x14)
+        ** (.x15 ↦ᵣ vg .x15) ** (.x16 ↦ᵣ vg .x16) ** (.x17 ↦ᵣ vg .x17)
+        ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+        ** bytesRegion outPtr outOld ** bytesRegion arenaB img₃)
+      (by pcf) hla10
+    have hmvF := cpsTripleWithin_frameR
+      (((.x5 : Reg) ↦ᵣ (0xbb55da98 : Word)) ** ((.x1 : Reg) ↦ᵣ (0x80030224 : Word))
+        ** (.x8 ↦ᵣ bPtr) ** (.x10 ↦ᵣ (0xbb55d9f0 : Word))
+        ** (.x6 ↦ᵣ vg .x6) ** (.x7 ↦ᵣ vg .x7) ** (.x28 ↦ᵣ vg .x28)
+        ** (.x29 ↦ᵣ vg .x29) ** (.x30 ↦ᵣ vg .x30) ** (.x31 ↦ᵣ vg .x31)
+        ** (.x12 ↦ᵣ vg .x12) ** (.x13 ↦ᵣ vg .x13) ** (.x14 ↦ᵣ vg .x14)
+        ** (.x15 ↦ᵣ vg .x15) ** (.x16 ↦ᵣ vg .x16) ** (.x17 ↦ᵣ vg .x17)
+        ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+        ** bytesRegion outPtr outOld ** bytesRegion arenaB img₃)
+      (by pcf) hmv
+    have hcallF := cpsTripleWithin_frameR
+      ((.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+        ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+        ** windowRest arenaB img₃ 0x40 32)
+      (by
+        exact pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs
+          (pcFree_sepConj (bytesRegion_pcFree _ _)
+            (pcFree_sepConj (bytesRegion_pcFree _ _)
+              (pcFree_windowRest _ _ _ _))))) hcall
+    have hchain1 := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by xperm_hyp hp) hla10F hmvF
+    have hchain2 := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        -- split the accelerator image: focus the d-window (read-only src)
+        rw [bytesRegion_window_focus arenaB img₃ 0x40 32 (by omega)
+              (by norm_num) (by norm_num), hdwin,
+            show arenaB + BitVec.ofNat 64 0x40 = (0xbb55d9f0 : Word) from by decide]
+          at hp
+        -- release the scratch file to ownership for the callee
+        have hp1 : ((.x6 ↦ᵣ vg .x6) ** (.x7 ↦ᵣ vg .x7) ** (.x28 ↦ᵣ vg .x28)
+            ** (.x29 ↦ᵣ vg .x29) ** (.x30 ↦ᵣ vg .x30) ** (.x31 ↦ᵣ vg .x31)
+            ** (.x12 ↦ᵣ vg .x12) ** (.x13 ↦ᵣ vg .x13) ** (.x14 ↦ᵣ vg .x14)
+            ** (.x15 ↦ᵣ vg .x15) ** (.x16 ↦ᵣ vg .x16) ** (.x17 ↦ᵣ vg .x17)
+            ** (((.x5 : Reg)) ↦ᵣ (0xbb55da98 : Word))
+            ** (((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x10 ↦ᵣ (0xbb55d9f0 : Word))
+              ** (.x11 ↦ᵣ outPtr) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+              ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+              ** bytesRegion outPtr outOld
+              ** bytesRegion (0xbb55d9f0 : Word) (leBytes32 r)
+              ** windowRest arenaB img₃ 0x40 32)) h := by
+          xperm_hyp hp
+        have hp2 := sepConj_mono (regIs_to_regOwn .x6 _)
+          (sepConj_mono (regIs_to_regOwn .x7 _)
+            (sepConj_mono (regIs_to_regOwn .x28 _)
+              (sepConj_mono (regIs_to_regOwn .x29 _)
+                (sepConj_mono (regIs_to_regOwn .x30 _)
+                  (sepConj_mono (regIs_to_regOwn .x31 _)
+                    (sepConj_mono (regIs_to_regOwn .x12 _)
+                      (sepConj_mono (regIs_to_regOwn .x13 _)
+                        (sepConj_mono (regIs_to_regOwn .x14 _)
+                          (sepConj_mono (regIs_to_regOwn .x15 _)
+                            (sepConj_mono (regIs_to_regOwn .x16 _)
+                              (sepConj_mono (regIs_to_regOwn .x17 _)
+                                (sepConj_mono (regIs_to_regOwn .x5 _)
+                                  (fun _ hh => hh))))))))))))) h hp1
+        have hp3 : (regOwns convScratch **
+            (((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x10 ↦ᵣ (0xbb55d9f0 : Word))
+              ** (.x11 ↦ᵣ outPtr) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+              ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+              ** bytesRegion outPtr outOld
+              ** bytesRegion (0xbb55d9f0 : Word) (leBytes32 r)
+              ** windowRest arenaB img₃ 0x40 32)) h := by
+          simp only [convScratch, regOwns_cons, regOwns_nil, sepConj_emp_right']
+          xperm_hyp hp2
+        xperm_hyp hp3) hchain1 hcallF
+    -- run the epilogue `li a0, 0` under the existential
+    have hchain2' := cpsTripleWithin_weaken (fun _ hp => hp)
+      (fun h hq => by
+        have hq1 : (((fun hp => ∃ ws',
+            ((⌜beBytesToNat ws' = wsNat256 (leBytes32 r) 0 ∧ ws'.length = 32⌝
+              ** regOwns exposedRegs ** bytesRegion outPtr ws'
+              ** bytesRegion (0xbb55d9f0 : Word) (leBytes32 r))) hp) : Assertion)
+            ** (((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+              ** (.x9 ↦ᵣ outPtr) ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+              ** windowRest arenaB img₃ 0x40 32)) h := by
+          xperm_hyp hq
+        exact (sepConj_exists_left h).mp hq1) hchain2
+    have hcont : ∀ ws' : List (BitVec 8),
+        cpsTripleWithin 1 (0x80030240 : Word) (0x80030244 : Word) addCr
+          ((⌜beBytesToNat ws' = wsNat256 (leBytes32 r) 0 ∧ ws'.length = 32⌝
+            ** regOwns exposedRegs ** bytesRegion outPtr ws'
+            ** bytesRegion (0xbb55d9f0 : Word) (leBytes32 r))
+            ** (((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+              ** (.x9 ↦ᵣ outPtr) ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+              ** windowRest arenaB img₃ 0x40 32))
+          (fun hp => ∃ out',
+            ((⌜beBytesToNat out' = r ∧ out'.length = 32⌝
+              ** ((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+              ** (.x9 ↦ᵣ outPtr) ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** regOwns outRest
+              ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+              ** bytesRegion outPtr out'
+              ** bytesRegion arenaB img₃)) hp) := by
+      intro ws'
+      refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+        (fun _ hq => hq)
+        (cpsTripleWithin_pure_pre
+          (P := beBytesToNat ws' = wsNat256 (leBytes32 r) 0 ∧ ws'.length = 32)
+          (H := regOwns exposedRegs ** bytesRegion outPtr ws'
+            ** bytesRegion (0xbb55d9f0 : Word) (leBytes32 r)
+            ** (((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+              ** (.x9 ↦ᵣ outPtr) ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+              ** windowRest arenaB img₃ 0x40 32))
+          (fun hfacts => ?_))
+      have hliF := cpsTripleWithin_frameR
+        (((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+          ** regOwns outRest ** bytesRegion outPtr ws'
+          ** bytesRegion (0xbb55d9f0 : Word) (leBytes32 r)
+          ** windowRest arenaB img₃ 0x40 32
+          ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE)
+        (by
+          refine pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs
+            (pcFree_sepConj pcFree_regIs (pcFree_sepConj (pcFree_regOwns _)
+              (pcFree_sepConj (bytesRegion_pcFree _ _)
+                (pcFree_sepConj (bytesRegion_pcFree _ _)
+                  (pcFree_sepConj (pcFree_windowRest _ _ _ _)
+                    (pcFree_sepConj (bytesRegion_pcFree _ _)
+                      (bytesRegion_pcFree _ _)))))))))
+        hli
+      refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_) hliF
+      · rw [ownsSplit10] at hp
+        xperm_hyp hp
+      · refine ⟨ws', ?_⟩
+        have hval : beBytesToNat ws' = r := by
+          rw [hfacts.1, wsNat256_leBytes32 r hrlt]
+        have hq1 : ((⌜beBytesToNat ws' = r ∧ ws'.length = 32⌝ : Assertion)
+            ** (((.x1 : Reg) ↦ᵣ (0x80030240 : Word)) ** (.x8 ↦ᵣ bPtr)
+              ** (.x9 ↦ᵣ outPtr) ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** regOwns outRest
+              ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+              ** bytesRegion outPtr ws'
+              ** (bytesRegion (arenaB + BitVec.ofNat 64 0x40)
+                    ((img₃.drop 0x40).take 32)
+                ** windowRest arenaB img₃ 0x40 32))) h := by
+          refine (sepConj_pure_left h).mpr ⟨⟨hval, hfacts.2⟩, ?_⟩
+          rw [hdwin, show arenaB + BitVec.ofNat 64 0x40 = (0xbb55d9f0 : Word)
+            from by decide]
+          xperm_hyp hq
+        rw [← bytesRegion_window_focus arenaB img₃ 0x40 32 (by omega)
+              (by norm_num) (by norm_num)] at hq1
+        xperm_hyp hq1
+    refine cpsTripleWithin_weaken (fun _ hp => by
+        simp only [csrsRest, regAtomsOf_cons, regAtomsOf_nil,
+          sepConj_emp_right'] at hp
+        xperm_hyp hp)
+      (fun _ hq => hq)
+      (cpsTripleWithin_mono_nSteps (by omega)
+        (cpsTripleWithin_seq_exists_same_cr hchain2' hcont))
+  -- ---- assemble stage C: la ; csrs ; rest ----
+  have hla5F := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+      ** (.x6 ↦ᵣ vf .x6) ** (.x7 ↦ᵣ vf .x7) ** (.x28 ↦ᵣ vf .x28)
+      ** (.x29 ↦ᵣ vf .x29) ** (.x30 ↦ᵣ vf .x30) ** (.x31 ↦ᵣ vf .x31)
+      ** (.x10 ↦ᵣ vf .x10) ** (.x11 ↦ᵣ vf .x11) ** (.x12 ↦ᵣ vf .x12)
+      ** (.x13 ↦ᵣ vf .x13) ** (.x14 ↦ᵣ vf .x14) ** (.x15 ↦ᵣ vf .x15)
+      ** (.x16 ↦ᵣ vf .x16) ** (.x17 ↦ᵣ vf .x17)
+      ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+      ** bytesRegion outPtr outOld ** bytesRegion arenaB img₂)
+    (by pcf) hla5
+  have hcsrsF := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr) ** (.x9 ↦ᵣ outPtr)
+      ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE ** bytesRegion outPtr outOld)
+    (by pcf) hcsrs
+  have hc1 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      -- release the scratch file into `regOwns csrsRest` for the CSRS step
+      have hp1 : ((.x6 ↦ᵣ vf .x6) ** (.x7 ↦ᵣ vf .x7) ** (.x28 ↦ᵣ vf .x28)
+          ** (.x29 ↦ᵣ vf .x29) ** (.x30 ↦ᵣ vf .x30) ** (.x31 ↦ᵣ vf .x31)
+          ** (.x10 ↦ᵣ vf .x10) ** (.x11 ↦ᵣ vf .x11) ** (.x12 ↦ᵣ vf .x12)
+          ** (.x13 ↦ᵣ vf .x13) ** (.x14 ↦ᵣ vf .x14) ** (.x15 ↦ᵣ vf .x15)
+          ** (.x16 ↦ᵣ vf .x16) ** (.x17 ↦ᵣ vf .x17)
+          ** ((((.x5 : Reg)) ↦ᵣ (0xbb55da98 : Word))
+            ** ((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr)
+            ** (.x9 ↦ᵣ outPtr)
+            ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+            ** bytesRegion outPtr outOld
+            ** bytesRegion arenaB img₂)) h := by
+        xperm_hyp hp
+      have hp2 := sepConj_mono (regIs_to_regOwn .x6 _)
+        (sepConj_mono (regIs_to_regOwn .x7 _)
+          (sepConj_mono (regIs_to_regOwn .x28 _)
+            (sepConj_mono (regIs_to_regOwn .x29 _)
+              (sepConj_mono (regIs_to_regOwn .x30 _)
+                (sepConj_mono (regIs_to_regOwn .x31 _)
+                  (sepConj_mono (regIs_to_regOwn .x10 _)
+                    (sepConj_mono (regIs_to_regOwn .x11 _)
+                      (sepConj_mono (regIs_to_regOwn .x12 _)
+                        (sepConj_mono (regIs_to_regOwn .x13 _)
+                          (sepConj_mono (regIs_to_regOwn .x14 _)
+                            (sepConj_mono (regIs_to_regOwn .x15 _)
+                              (sepConj_mono (regIs_to_regOwn .x16 _)
+                                (sepConj_mono (regIs_to_regOwn .x17 _)
+                                  (fun _ hh => hh)))))))))))))) h hp1
+      have hp3 : ((((.x5 : Reg)) ↦ᵣ (0xbb55da98 : Word)) ** regOwns csrsRest
+          ** bytesRegion arenaB img₂
+          ** (((.x1 : Reg) ↦ᵣ (0x80030224 : Word)) ** (.x8 ↦ᵣ bPtr)
+            ** (.x9 ↦ᵣ outPtr)
+            ** bytesRegion aPtr aBE ** bytesRegion bPtr bBE
+            ** bytesRegion outPtr outOld)) h := by
+        simp only [csrsRest, regOwns_cons, regOwns_nil, sepConj_emp_right']
+        xperm_hyp hp2
+      xperm_hyp hp3) hla5F hcsrsF
+  have hc2 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hc1 hrest
+  exact cpsTripleWithin_weaken (fun _ hp => by
+      simp only [exposedRegs, regAtomsOf_cons, regAtomsOf_nil,
+        sepConj_emp_right'] at hp
+      xperm_hyp hp)
+    (fun _ hq => hq)
+    (cpsTripleWithin_mono_nSteps (by omega) hc2)
+
+
+
+end Bn254FieldAddModPSAsm
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -168,6 +168,7 @@ import EvmAsm.Codegen.Programs.CheckGasLimitSAsm
 import EvmAsm.Codegen.Programs.BloomEqSAsm
 import EvmAsm.Codegen.Programs.Bls12KzgG2WireSAsm
 import EvmAsm.Codegen.Programs.RlpListEncodedSizeSAsm
+import EvmAsm.Codegen.Programs.RlpBytesEncodedSizeSAsm
 import EvmAsm.Codegen.Programs.CallFrameBaseSAsm
 import EvmAsm.Codegen.Programs.CreateInitcodeSizeValidSAsm
 import EvmAsm.Codegen.Programs.BalGasValid

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -116,6 +116,8 @@ import EvmAsm.Codegen.Programs.Bn254FieldConvSAsmLeToBe
 import EvmAsm.Codegen.Programs.Bn254FieldMulModSAsm
 import EvmAsm.Codegen.Programs.Bn254FieldMulModPSAsmStage
 import EvmAsm.Codegen.Programs.Bn254FieldMulModPSAsm
+import EvmAsm.Codegen.Programs.Bn254FieldAddModPSAsmStage
+import EvmAsm.Codegen.Programs.Bn254FieldAddModPSAsm
 import EvmAsm.Codegen.Programs.Bn254CurveZeroSAsm
 import EvmAsm.Codegen.Programs.Bn254CurveCopySAsm
 import EvmAsm.Codegen.Programs.Bn254CurveIsInfSAsm

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -122,6 +122,7 @@ import EvmAsm.Codegen.Programs.Bn254FieldMulModSAsm
 import EvmAsm.Codegen.Programs.Bn254FieldMulModPSAsmStage
 import EvmAsm.Codegen.Programs.Bn254FieldMulModPSAsm
 import EvmAsm.Codegen.Programs.Bn254FieldLtPSAsm
+import EvmAsm.Codegen.Programs.P256LtBeSAsm
 import EvmAsm.Codegen.Programs.Bn254CurveZeroSAsm
 import EvmAsm.Codegen.Programs.Bn254CurveCopySAsm
 import EvmAsm.Codegen.Programs.Bn254CurveIsInfSAsm

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -148,6 +148,7 @@ import EvmAsm.Codegen.Programs.Bls12G1Zero96SAsm
 import EvmAsm.Codegen.Programs.Bls12G1Copy96SAsm
 import EvmAsm.Codegen.Programs.Bls12G1IsZeroNSAsm
 import EvmAsm.Codegen.Programs.Bls12G1LtPSAsm
+import EvmAsm.Codegen.Programs.Bls12KzgLtBeSAsm
 import EvmAsm.Codegen.Programs.Bls12FieldCopyQuadsSAsm
 import EvmAsm.Codegen.Programs.Bls12G1Eq48SAsm
 import EvmAsm.Codegen.Programs.Bls12G2EqNSAsm

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -122,6 +122,7 @@ import EvmAsm.Codegen.Programs.Bn254FieldMulModSAsm
 import EvmAsm.Codegen.Programs.Bn254FieldMulModPSAsmStage
 import EvmAsm.Codegen.Programs.Bn254FieldMulModPSAsm
 import EvmAsm.Codegen.Programs.Bn254FieldLtPSAsm
+import EvmAsm.Codegen.Programs.Bn254CallAllotmentSAsm
 import EvmAsm.Codegen.Programs.P256LtBeSAsm
 import EvmAsm.Codegen.Programs.Bn254CurveZeroSAsm
 import EvmAsm.Codegen.Programs.Bn254CurveCopySAsm

--- a/EvmAsm/Codegen/Programs/P256LtBeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/P256LtBeSAsm.lean
@@ -58,8 +58,6 @@ open U256MinSAsm (beBytesToNat_lt_of_prefix_lt bytes_eq_of_prefix_all)
 /-- The routine base, symbolic (bead evm-asm-6agnq). -/
 def ltPBase : Word := (GuestAddrs.p256_lt_be : Word)
 
--- Address anchor (fails the build if the guest link moves).
-#guard GuestAddrs.p256_lt_be = 0x800330f8
 #guard p256LtBe_prog.length = 16
 -- The comparator is position-independent (no PC-relative instruction).
 

--- a/EvmAsm/Codegen/Programs/P256LtBeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/P256LtBeSAsm.lean
@@ -1,0 +1,804 @@
+/-
+  EvmAsm.Codegen.Programs.P256LtBeSAsm
+
+  `p256_lt_be` — the 32-byte big-endian lexicographic comparator of the
+  P256VERIFY range checks — via the three-outcome compare join
+  (`EvmAsm/Rv64/SAsm/TriCmpStoreJoin.lean`) over SHARED `li a0, c ; ret`
+  return tails (`sharedRetTail_spec`, `EvmAsm/Rv64/SAsm/RetForwardJoin.lean`).
+
+  The routine byte-walks the two 32-byte big-endian operands (both
+  caller-provided buffers — no global constant, no `la`, the program is
+  position-independent) with a countdown counter and advancing cursors,
+  and routes its THREE exits onto TWO `li`/`ret` tails:
+
+  ```
+        li   t2, 32 ; mv t0, a0 ; mv t1, a1
+  hdr:  beq  t2, x0, .tailZero          -- exhaustion (equal)  → a0 = 0
+        lbu  x28, 0(t0) ; lbu x29, 0(t1)
+        bltu x28, x29, .tailOne         -- a[i] < b[i]         → a0 = 1
+        bltu x29, x28, .tailZero        -- b[i] < a[i]         → a0 = 0
+        addi t0, t0, 1 ; addi t1, t1, 1 ; addi t2, t2, -1 ; j hdr
+  .tailOne:  li a0, 1 ; ret
+  .tailZero: li a0, 0 ; ret
+  ```
+
+  Each tail is one `sharedRetTail_spec` instance (proven once per tail
+  address); the ordered `bltu` pair is one `triCmpStoreJoin_spec`
+  station; the loop is one `twoBreakRetLoop_spec`.  The `=` and `>`
+  outcomes SHARE the zero tail — big-endian lexicographic order IS
+  numeric order (`U256MinSAsm.beBytesToNat_lt_of_prefix_lt` in both
+  directions, all-equal bridge `bytes_eq_of_prefix_all`).
+
+  **Genuine post**: `a0 = if beBytesToNat as < beBytesToNat bs
+  then 1 else 0` — the REAL numeric strict less-than of the two
+  operands; both input regions untouched, `a1` preserved.
+
+  Byte-transparent: the spec is stated at the `#guard`-tied symbolic
+  `GuestAddrs.p256_lt_be` base (bead evm-asm-6agnq) over the emitted
+  `p256LtBe_prog` directly — no guest-byte change, no A/B run needed.
+
+  Resolves blocker bead evm-asm-4ch8f.58.2.7.1 (the "return-tail
+  two-break loop" shape is exactly this composition — no new `Stmt`
+  combinator was needed).  Bead: evm-asm-4ch8f.58.2.7.
+-/
+
+import EvmAsm.Codegen.Programs.P256Verify
+import EvmAsm.Codegen.Programs.U256MinSAsm
+import EvmAsm.Rv64.SAsm.TriCmpStoreJoin
+import EvmAsm.Rv64.SAsm.RetForwardJoin
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Crypto
+
+namespace P256LtBeSAsm
+
+open U256MinSAsm (beBytesToNat_lt_of_prefix_lt bytes_eq_of_prefix_all)
+
+/-- The routine base, symbolic (bead evm-asm-6agnq). -/
+def ltPBase : Word := (GuestAddrs.p256_lt_be : Word)
+
+-- Address anchor (fails the build if the guest link moves).
+#guard GuestAddrs.p256_lt_be = 0x800330f8
+#guard p256LtBe_prog.length = 16
+-- The comparator is position-independent (no PC-relative instruction).
+
+/-
+  Emitted layout relative to `GuestAddrs.p256_lt_be`:
+    +0   li    x7, 32
+    +4   mv    x5, x10
+    +8   mv    x6, x11
+    +12  beq   x7, x0, +44  → +56 (zero tail)                   [hdr]
+    +16  lbu   x28, 0(x5)
+    +20  lbu   x29, 0(x6)
+    +24  bltu  x28, x29, +24 → +48 (one tail)
+    +28  bltu  x29, x28, +28 → +56 (zero tail)
+    +32  addi  x5, x5, 1
+    +36  addi  x6, x6, 1
+    +40  addi  x7, x7, -1
+    +44  jal   x0, -32      → +12
+    +48  li    x10, 1                                           [one tail]
+    +52  jalr  x0, x1, 0
+    +56  li    x10, 0                                           [zero tail]
+    +60  jalr  x0, x1, 0
+-/
+
+-- ============================================================================
+-- §1  Word-arithmetic helpers (countdown counter / advancing cursors)
+-- ============================================================================
+
+private theorem counter_dec (i : Nat) (hi : i < 32) :
+    BitVec.ofNat 64 (32 - i) + signExtend12 (-1 : BitVec 12)
+      = BitVec.ofNat 64 (32 - (i + 1)) := by
+  rw [show signExtend12 (-1 : BitVec 12) = (-1 : Word) from by decide]
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_add, BitVec.toNat_ofNat, BitVec.toNat_ofNat,
+    show ((-1 : Word)).toNat = 18446744073709551615 from rfl]
+  omega
+
+private theorem cursor_advance (p : Word) (i : Nat) :
+    p + BitVec.ofNat 64 i + signExtend12 (1 : BitVec 12)
+      = p + BitVec.ofNat 64 (i + 1) := by
+  rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide,
+    BitVec.add_assoc]
+  congr 1
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_add, show ((1 : Word)).toNat = 1 from rfl,
+    BitVec.toNat_ofNat, BitVec.toNat_ofNat]
+  omega
+
+private theorem ctr_ne_zero (i : Nat) (hi : i < 32) :
+    ¬ (BitVec.ofNat 64 (32 - i) = (0 : Word)) := by
+  intro h
+  have := congrArg BitVec.toNat h
+  rw [BitVec.toNat_ofNat, show ((0 : Word)).toNat = 0 from rfl] at this
+  omega
+
+-- ============================================================================
+-- §2  Invariant and genuine post
+-- ============================================================================
+
+section Scan
+
+variable (aPtr bPtr ret : Word) (xs bs : List (BitVec 8))
+
+/-- Loop invariant at the header after `i` matched bytes: the counter holds
+    `32 - i`, both cursors sit at byte `i`, the first `i` bytes of the two
+    operands agree (pure conjunct), the fixed registers and both input
+    regions are untouched. -/
+private def ltInv (i : Nat) : Assertion :=
+  ⌜∀ j, j < i → xs.getD j 0 = bs.getD j 0⌝ **
+  ((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+  ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+  ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+  ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+  ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+  regOwn .x28 ** regOwn .x29 **
+  bytesRegion aPtr xs ** bytesRegion bPtr bs
+
+/-- The genuine post: `a0` is the REAL numeric strict less-than of the
+    two 32-byte big-endian operands; both input regions untouched, `a1`
+    preserved. -/
+private def ltPost : Assertion :=
+  ((.x10 : Reg) ↦ᵣ (if beBytesToNat xs < beBytesToNat bs
+    then (1 : Word) else (0 : Word))) **
+  ((.x11 : Reg) ↦ᵣ bPtr) **
+  ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+  regOwn .x6 ** regOwn .x7 ** regOwn .x5 **
+  regOwn .x28 ** regOwn .x29 **
+  bytesRegion aPtr xs ** bytesRegion bPtr bs
+
+-- ============================================================================
+-- §3  One loop iteration (the three-outcome join station)
+-- ============================================================================
+
+/-- One iteration at the header with `i < 32` bytes known equal: either a
+    `bltu` break fires and the corresponding shared `li`/`ret` tail
+    RETURNS with the genuine post, or the iteration loops back to the
+    header with the invariant advanced.  Exactly the
+    `twoBreakRetLoop_spec` iteration shape, built from one
+    `triCmpStoreJoin_spec` station wrapped by the header `beq`
+    `breakStation_spec`. -/
+private theorem ltIter_spec
+    (hlenX : xs.length = 32) (hlenB : bs.length = 32)
+    (halignA : aPtr.toNat % 8 = 0) (halignB : bPtr.toNat % 8 = 0)
+    (hovA : aPtr.toNat + 32 < 2 ^ 64) (hovB : bPtr.toNat + 32 < 2 ^ 64)
+    (hvalidA : ∀ k, k < 32 → isValidByteAccess (aPtr + BitVec.ofNat 64 k) = true)
+    (hvalidB : ∀ k, k < 32 → isValidByteAccess (bPtr + BitVec.ofNat 64 k) = true)
+    (halignRet : (ret &&& ~~~(1 : Word)) = ret)
+    (i : Nat) (hi : i < 32) :
+    cpsBranchWithin 9 (ltPBase + 12)
+      (CodeReq.ofProg ltPBase p256LtBe_prog)
+      (ltInv aPtr bPtr ret xs bs i)
+      ret (ltPost aPtr bPtr ret xs bs)
+      (ltPBase + 12) (ltInv aPtr bPtr ret xs bs (i + 1)) := by
+  set CR := CodeReq.ofProg ltPBase p256LtBe_prog with hCR
+  have hplen : bs.length = 32 := hlenB
+  have hix : i < xs.length := by omega
+  have hip : i < bs.length := by omega
+  set xByte := (xs[i]'hix).zeroExtend 64 with hxByte
+  set pByte := (bs[i]'hip).zeroExtend 64 with hpByte
+  have hxBN : xByte.toNat = (xs[i]'hix).toNat := by
+    rw [hxByte]
+    show (BitVec.setWidth 64 _).toNat = _
+    rw [BitVec.toNat_setWidth]
+    have := (xs[i]'hix).isLt
+    omega
+  have hpBN : pByte.toNat = (bs[i]'hip).toNat := by
+    rw [hpByte]
+    show (BitVec.setWidth 64 _).toNat = _
+    rw [BitVec.toNat_setWidth]
+    have := (bs[i]'hip).isLt
+    omega
+  have hgdX : xs.getD i 0 = xs[i]'hix := by
+    rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem hix]
+    rfl
+  have hgdP : bs.getD i 0 = bs[i]'hip := by
+    rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem hip]
+    rfl
+  -- strip the pure prefix fact
+  unfold ltInv
+  refine cpsBranchWithin_pure_pre (fun hpref => ?_)
+  -- peel this iteration's scratch registers x28, x29
+  refine cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq) (fun _ hq => hq)
+    (cpsBranchWithin_of_forall_regIs_to_regOwn (r := .x28)
+      (P := (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+        ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs) **
+        regOwn .x29)
+      (fun v28 => ?_))
+  refine cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq) (fun _ hq => hq)
+    (cpsBranchWithin_of_forall_regIs_to_regOwn (r := .x29)
+      (P := (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+        ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs) **
+        ((.x28 : Reg) ↦ᵣ v28))
+      (fun v29 => ?_))
+  -- canonical working set, x28/x29 concrete
+  suffices hmain :
+      cpsBranchWithin 9 (ltPBase + 12) CR
+        (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+         ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+         ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+         ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+         ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+         bytesRegion aPtr xs ** bytesRegion bPtr bs)
+        ret (ltPost aPtr bPtr ret xs bs)
+        (ltPBase + 12) (ltInv aPtr bPtr ret xs bs (i + 1)) by
+    exact cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
+      (fun _ hq => hq) (fun _ hq => hq) hmain
+  -- ---- the two LBU loads (+20 input, +24 const) ----
+  have hlbuX := liftCode (cr' := CR)
+    (bytesRegion_lbu_within .x28 .x5 aPtr v28 (ltPBase + 16) xs i
+      (by decide) halignA hix (by omega) (hvalidA i hi))
+    (by rw [hCR]; code_mem)
+  rw [show (ltPBase + 16 : Word) + 4 = (ltPBase + 20 : Word) from by decide]
+    at hlbuX
+  have hlbuP := liftCode (cr' := CR)
+    (bytesRegion_lbu_within .x29 .x6 bPtr v29 (ltPBase + 20)
+      bs i (by decide) halignB hip (by omega) (hvalidB i hi))
+    (by rw [hCR]; code_mem)
+  rw [show (ltPBase + 20 : Word) + 4 = (ltPBase + 24 : Word) from by decide]
+    at hlbuP
+  have hlbuXF := cpsTripleWithin_frameR
+    (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+      ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x29 : Reg) ↦ᵣ v29) **
+      bytesRegion bPtr bs)
+    (by pcf) hlbuX
+  have hlbuPF := cpsTripleWithin_frameR
+    (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+      ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x28 : Reg) ↦ᵣ xByte) **
+      bytesRegion aPtr xs)
+    (by pcf) hlbuP
+  have hpre1 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hlbuXF hlbuPF
+  -- ---- the header BEQ station (+16; never taken at i < 32) ----
+  have hbrHdr := cpsBranchWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+      ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+      bytesRegion aPtr xs ** bytesRegion bPtr bs)
+    (by pcf)
+    (cpsBranchWithin_extend_code (cr' := CR)
+      (h := beq_spec_gen_within .x7 .x0 (44 : BitVec 13)
+        (BitVec.ofNat 64 (32 - i)) (0 : Word) (ltPBase + 12))
+      (hmono := by rw [hCR]; code_mem))
+  rw [show (ltPBase + 12 : Word) + signExtend13 (44 : BitVec 13)
+        = (ltPBase + 56 : Word) from by decide,
+      show (ltPBase + 12 : Word) + 4 = (ltPBase + 16 : Word) from by decide]
+    at hbrHdr
+  -- ---- the ordered bltu pair, framed ----
+  have hbrA := cpsBranchWithin_frameR
+    (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+      ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+      ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      bytesRegion aPtr xs ** bytesRegion bPtr bs)
+    (by pcf)
+    (cpsBranchWithin_extend_code (cr' := CR)
+      (h := bltu_spec_gen_within .x28 .x29 (24 : BitVec 13) xByte pByte
+        (ltPBase + 24))
+      (hmono := by rw [hCR]; code_mem))
+  rw [show (ltPBase + 24 : Word) + signExtend13 (24 : BitVec 13)
+        = (ltPBase + 48 : Word) from by decide,
+      show (ltPBase + 24 : Word) + 4 = (ltPBase + 28 : Word) from by decide]
+    at hbrA
+  have hbrB := cpsBranchWithin_frameR
+    (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+      ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+      ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      bytesRegion aPtr xs ** bytesRegion bPtr bs)
+    (by pcf)
+    (cpsBranchWithin_extend_code (cr' := CR)
+      (h := bltu_spec_gen_within .x29 .x28 (28 : BitVec 13) pByte xByte
+        (ltPBase + 28))
+      (hmono := by rw [hCR]; code_mem))
+  rw [show (ltPBase + 28 : Word) + signExtend13 (28 : BitVec 13)
+        = (ltPBase + 56 : Word) from by decide,
+      show (ltPBase + 28 : Word) + 4 = (ltPBase + 32 : Word) from by decide]
+    at hbrB
+  -- the canonical post-load working set (all three arms' currency)
+  set WSL : Assertion :=
+    ((.x28 : Reg) ↦ᵣ xByte) ** ((.x29 : Reg) ↦ᵣ pByte) **
+    ((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+    ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+    ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+    ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+    ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+    bytesRegion aPtr xs ** bytesRegion bPtr bs with hWSL
+  -- ---- break arm A: one tail returns 1 (in < p decided) ----
+  have htailOne : BitVec.ult xByte pByte →
+      cpsTripleWithin 4 (ltPBase + 48) ret CR WSL
+        (ltPost aPtr bPtr ret xs bs) := by
+    intro hc
+    have hltN : (xs[i]'hix).toNat < (bs[i]'hip).toNat := by
+      have hc' : xByte.toNat < pByte.toNat := by
+        simpa [BitVec.ult, decide_eq_true_eq] using hc
+      omega
+    have hlt : beBytesToNat xs < beBytesToNat bs :=
+      beBytesToNat_lt_of_prefix_lt xs bs (by omega) i hix hpref
+        (by rw [hgdX, hgdP]; omega)
+    have h := cpsTripleWithin_frameR
+      (((.x28 : Reg) ↦ᵣ xByte) ** ((.x29 : Reg) ↦ᵣ pByte) **
+        ((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+        ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+        ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)))
+      (by pcf)
+      (sharedRetTail_spec CR (ltPBase + 48) ret .x10 (1 : Word) aPtr
+        (bytesRegion aPtr xs ** bytesRegion bPtr bs)
+        (by pcf) (by decide) halignRet
+        (by rw [hCR]; code_mem) (by rw [hCR]; code_mem))
+    refine cpsTripleWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_) h)
+    · rw [hWSL] at hp
+      xperm_hyp hp
+    · unfold ltPost
+      rw [if_pos hlt]
+      have hq1 : (((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+          (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+            (((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+              (((.x28 : Reg) ↦ᵣ xByte) ** (((.x29 : Reg) ↦ᵣ pByte) **
+                (((.x10 : Reg) ↦ᵣ (1 : Word)) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+                 ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+                 bytesRegion aPtr xs **
+                 bytesRegion bPtr bs)))))) h := by
+        xperm_hyp hq
+      have hq2 := sepConj_mono (regIs_to_regOwn .x6 _)
+        (sepConj_mono (regIs_to_regOwn .x7 _)
+          (sepConj_mono (regIs_to_regOwn .x5 _)
+            (sepConj_mono (regIs_to_regOwn .x28 _)
+              (sepConj_mono (regIs_to_regOwn .x29 _)
+                (fun _ hh => hh))))) h hq1
+      xperm_hyp hq2
+  -- ---- break arm B: zero tail returns 0 (p < in decided) ----
+  have htailZeroGt : ¬ BitVec.ult xByte pByte → BitVec.ult pByte xByte →
+      cpsTripleWithin 4 (ltPBase + 56) ret CR WSL
+        (ltPost aPtr bPtr ret xs bs) := by
+    intro _ hc
+    have hgtN : (bs[i]'hip).toNat < (xs[i]'hix).toNat := by
+      have hc' : pByte.toNat < xByte.toNat := by
+        simpa [BitVec.ult, decide_eq_true_eq] using hc
+      omega
+    have hgt : beBytesToNat bs < beBytesToNat xs :=
+      beBytesToNat_lt_of_prefix_lt bs xs (by omega) i hip
+        (fun j hj => (hpref j hj).symm)
+        (by rw [hgdX, hgdP]; omega)
+    have hnlt : ¬ (beBytesToNat xs < beBytesToNat bs) := by
+      omega
+    have h := cpsTripleWithin_frameR
+      (((.x28 : Reg) ↦ᵣ xByte) ** ((.x29 : Reg) ↦ᵣ pByte) **
+        ((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+        ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+        ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)))
+      (by pcf)
+      (sharedRetTail_spec CR (ltPBase + 56) ret .x10 (0 : Word) aPtr
+        (bytesRegion aPtr xs ** bytesRegion bPtr bs)
+        (by pcf) (by decide) halignRet
+        (by rw [hCR]; code_mem) (by rw [hCR]; code_mem))
+    refine cpsTripleWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_) h)
+    · rw [hWSL] at hp
+      xperm_hyp hp
+    · unfold ltPost
+      rw [if_neg hnlt]
+      have hq1 : (((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+          (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+            (((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+              (((.x28 : Reg) ↦ᵣ xByte) ** (((.x29 : Reg) ↦ᵣ pByte) **
+                (((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+                 ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+                 bytesRegion aPtr xs **
+                 bytesRegion bPtr bs)))))) h := by
+        xperm_hyp hq
+      have hq2 := sepConj_mono (regIs_to_regOwn .x6 _)
+        (sepConj_mono (regIs_to_regOwn .x7 _)
+          (sepConj_mono (regIs_to_regOwn .x5 _)
+            (sepConj_mono (regIs_to_regOwn .x28 _)
+              (sepConj_mono (regIs_to_regOwn .x29 _)
+                (fun _ hh => hh))))) h hq1
+      xperm_hyp hq2
+  -- ---- continue segment: 3 × addi ; jal → header with inv (i+1) ----
+  have hcont : ¬ BitVec.ult xByte pByte → ¬ BitVec.ult pByte xByte →
+      cpsTripleWithin 4 (ltPBase + 32) (ltPBase + 12) CR WSL
+        (ltInv aPtr bPtr ret xs bs (i + 1)) := by
+    intro hnXP hnPX
+    have hEqByte : xs[i]'hix = bs[i]'hip := by
+      apply BitVec.eq_of_toNat_eq
+      have h1 : ¬ xByte.toNat < pByte.toNat := by
+        intro hlt
+        exact hnXP (by simp [BitVec.ult, decide_eq_true_eq]; omega)
+      have h2 : ¬ pByte.toNat < xByte.toNat := by
+        intro hlt
+        exact hnPX (by simp [BitVec.ult, decide_eq_true_eq]; omega)
+      omega
+    have hpref' : ∀ j, j < i + 1 → xs.getD j 0 = bs.getD j 0 := by
+      intro j hj
+      by_cases hji : j < i
+      · exact hpref j hji
+      · have : j = i := by omega
+        subst this
+        rw [hgdX, hgdP, hEqByte]
+    have haddi7 := liftCode (cr' := CR)
+      (addi_spec_gen_same_within .x5 (aPtr + BitVec.ofNat 64 i) (1 : BitVec 12)
+        (ltPBase + 32) (by decide))
+      (by rw [hCR]; code_mem)
+    rw [cursor_advance aPtr i,
+        show (ltPBase + 32 : Word) + 4 = (ltPBase + 36 : Word) from by decide]
+      at haddi7
+    have haddi5 := liftCode (cr' := CR)
+      (addi_spec_gen_same_within .x6 (bPtr + BitVec.ofNat 64 i)
+        (1 : BitVec 12) (ltPBase + 36) (by decide))
+      (by rw [hCR]; code_mem)
+    rw [cursor_advance bPtr i,
+        show (ltPBase + 36 : Word) + 4 = (ltPBase + 40 : Word) from by decide]
+      at haddi5
+    have haddi6 := liftCode (cr' := CR)
+      (addi_spec_gen_same_within .x7 (BitVec.ofNat 64 (32 - i)) (-1 : BitVec 12)
+        (ltPBase + 40) (by decide))
+      (by rw [hCR]; code_mem)
+    rw [counter_dec i hi,
+        show (ltPBase + 40 : Word) + 4 = (ltPBase + 44 : Word) from by decide]
+      at haddi6
+    have hjal := liftCode (cr' := CR)
+      (jal_x0_spec_gen_within (-32 : BitVec 21) (ltPBase + 44))
+      (by rw [hCR]; code_mem)
+    rw [show (ltPBase + 44 : Word) + signExtend21 (-32 : BitVec 21)
+          = (ltPBase + 12 : Word) from by decide] at hjal
+    have haddi7F := cpsTripleWithin_frameR
+      (((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+        ((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+        ((.x28 : Reg) ↦ᵣ xByte) ** ((.x29 : Reg) ↦ᵣ pByte) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs)
+      (by pcf) haddi7
+    have haddi5F := cpsTripleWithin_frameR
+      (((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (i + 1))) **
+        ((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+        ((.x28 : Reg) ↦ᵣ xByte) ** ((.x29 : Reg) ↦ᵣ pByte) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs)
+      (by pcf) haddi5
+    have haddi6F := cpsTripleWithin_frameR
+      (((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (i + 1))) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (i + 1))) **
+        ((.x28 : Reg) ↦ᵣ xByte) ** ((.x29 : Reg) ↦ᵣ pByte) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs)
+      (by pcf) haddi6
+    have hjalF := cpsTripleWithin_frameR
+      (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - (i + 1))) **
+        ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (i + 1))) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (i + 1))) **
+        ((.x28 : Reg) ↦ᵣ xByte) ** ((.x29 : Reg) ↦ᵣ pByte) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs)
+      (by pcf) hjal
+    have hc1 := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by xperm_hyp hp) haddi7F haddi5F
+    have hc2 := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by xperm_hyp hp) hc1 haddi6F
+    have hc3 := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by
+        rw [sepConj_emp_left']
+        xperm_hyp hp) hc2 hjalF
+    refine cpsTripleWithin_weaken
+      (fun h hp => by rw [hWSL] at hp; xperm_hyp hp)
+      (fun h hq => ?_) hc3
+    rw [sepConj_emp_left'] at hq
+    unfold ltInv
+    refine (sepConj_pure_left h).2 ⟨hpref', ?_⟩
+    have hq1 : (((.x28 : Reg) ↦ᵣ xByte) ** (((.x29 : Reg) ↦ᵣ pByte) **
+        (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - (i + 1))) **
+         ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 (i + 1))) **
+         ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 (i + 1))) **
+         ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+         ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         bytesRegion aPtr xs ** bytesRegion bPtr bs))) h := by
+      xperm_hyp hq
+    have hq2 := sepConj_mono (regIs_to_regOwn .x28 _)
+      (sepConj_mono (regIs_to_regOwn .x29 _)
+        (fun _ hh => hh)) h hq1
+    xperm_hyp hq2
+  -- ---- the ordered bltu pair as ONE three-outcome join station ----
+  have hjoin : cpsBranchWithin (1 + (1 + 4)) (ltPBase + 24) CR WSL
+      ret (ltPost aPtr bPtr ret xs bs)
+      (ltPBase + 12) (ltInv aPtr bPtr ret xs bs (i + 1)) :=
+    triCmpStoreJoin_spec
+      (condLt := BitVec.ult xByte pByte) (condGt := BitVec.ult pByte xByte)
+      (PLt := WSL) (PMid := WSL) (PGt := WSL) (PEq := WSL)
+      (cpsBranchWithin_weaken
+        (fun h hp => by rw [hWSL] at hp; xperm_hyp hp)
+        (fun _ hq => hq) (fun _ hq => hq) hbrA)
+      (fun h hq => by rw [hWSL]; xperm_hyp hq)
+      (fun h hq => by rw [hWSL]; xperm_hyp hq)
+      (fun hc => cpsTripleWithin_mono_nSteps (by omega) (htailOne hc))
+      (fun _ => cpsBranchWithin_weaken
+        (fun h hp => by rw [hWSL] at hp; xperm_hyp hp)
+        (fun _ hq => hq) (fun _ hq => hq) hbrB)
+      (fun h hq => by rw [hWSL]; xperm_hyp hq)
+      (fun h hq => by rw [hWSL]; xperm_hyp hq)
+      (fun hnXP hc => htailZeroGt hnXP hc)
+      (fun hnXP hnPX => cpsTripleWithin_as_cpsBranchWithin_right ret
+        (ltPost aPtr bPtr ret xs bs) (hcont hnXP hnPX))
+  -- ---- loads ; join station ----
+  have hfallIter := cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr
+    (fun h hp => by rw [hWSL]; xperm_hyp hp) hpre1 hjoin
+  -- ---- the header BEQ station wraps it all ----
+  refine cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq) (fun _ hq => hq)
+    (breakStation_spec (cond := (BitVec.ofNat 64 (32 - i) = (0 : Word)))
+      (PT := ((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+        ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs)
+      (PF := ((((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 i)) **
+        ((.x28 : Reg) ↦ᵣ v28) ** bytesRegion aPtr xs) **
+        (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - i)) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 i)) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x29 : Reg) ↦ᵣ v29) **
+        bytesRegion bPtr bs)))
+      hbrHdr
+      (fun h hq => by xperm_hyp hq)
+      (fun h hq => by xperm_hyp hq)
+      (fun hc => absurd hc (ctr_ne_zero i hi))
+      (fun _ => hfallIter))
+
+-- ============================================================================
+-- §4  Loop exhaustion: all 32 bytes equal → zero tail returns 0
+-- ============================================================================
+
+private theorem ltExh_spec
+    (hlenX : xs.length = 32) (hlenB : bs.length = 32)
+    (halignRet : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin 5 (ltPBase + 12) ret
+      (CodeReq.ofProg ltPBase p256LtBe_prog)
+      (ltInv aPtr bPtr ret xs bs 32)
+      (ltPost aPtr bPtr ret xs bs) := by
+  set CR := CodeReq.ofProg ltPBase p256LtBe_prog with hCR
+  have hplen : bs.length = 32 := hlenB
+  unfold ltInv
+  refine cpsTripleWithin_pure_pre (fun hpref => ?_)
+  have hEq : xs = bs := bytes_eq_of_prefix_all xs bs
+    (by omega) (fun j hj => hpref j (by omega))
+  have heqN : beBytesToNat xs = beBytesToNat bs := by rw [hEq]
+  have hnlt : ¬ (beBytesToNat xs < beBytesToNat bs) := by omega
+  -- header BEQ, taken (counter = 0)
+  have hbrHdr := cpsBranchWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 32)) **
+      ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 32)) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x1 : Reg) ↦ᵣ ret) **
+      regOwn .x28 ** regOwn .x29 **
+      bytesRegion aPtr xs ** bytesRegion bPtr bs)
+    (by pcf)
+    (cpsBranchWithin_extend_code (cr' := CR)
+      (h := beq_spec_gen_within .x7 .x0 (44 : BitVec 13)
+        (BitVec.ofNat 64 (32 - 32)) (0 : Word) (ltPBase + 12))
+      (hmono := by rw [hCR]; code_mem))
+  rw [show (ltPBase + 12 : Word) + signExtend13 (44 : BitVec 13)
+        = (ltPBase + 56 : Word) from by decide,
+      show (ltPBase + 12 : Word) + 4 = (ltPBase + 16 : Word) from by decide]
+    at hbrHdr
+  -- taken arm: zero tail returns 0 (framed, converted, if-resolved)
+  have htail : cpsTripleWithin 4 (ltPBase + 56) ret CR
+      (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - 32)) **
+       ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 32)) **
+       ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 32)) **
+       ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+       ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       regOwn .x28 ** regOwn .x29 **
+       bytesRegion aPtr xs ** bytesRegion bPtr bs)
+      (ltPost aPtr bPtr ret xs bs) := by
+    have h := cpsTripleWithin_frameR
+      (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - 32)) **
+        ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 32)) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 32)) **
+        ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x28 ** regOwn .x29)
+      (by pcf)
+      (sharedRetTail_spec CR (ltPBase + 56) ret .x10 (0 : Word) aPtr
+        (bytesRegion aPtr xs ** bytesRegion bPtr bs)
+        (by pcf) (by decide) halignRet
+        (by rw [hCR]; code_mem) (by rw [hCR]; code_mem))
+    refine cpsTripleWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_) h)
+    · xperm_hyp hp
+    · unfold ltPost
+      rw [if_neg hnlt]
+      have hq1 : (((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 32)) **
+          (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - 32)) **
+            (((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 32)) **
+              (((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+               ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+               regOwn .x28 ** regOwn .x29 **
+               bytesRegion aPtr xs **
+               bytesRegion bPtr bs)))) h := by
+        xperm_hyp hq
+      have hq2 := sepConj_mono (regIs_to_regOwn .x6 _)
+        (sepConj_mono (regIs_to_regOwn .x7 _)
+          (sepConj_mono (regIs_to_regOwn .x5 _)
+            (fun _ hh => hh))) h hq1
+      xperm_hyp hq2
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq)
+    (retJoinStation_spec
+      (cond := (BitVec.ofNat 64 (32 - 32) = (0 : Word)))
+      (PT := (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - 32)) **
+        ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 32)) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 32)) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x28 ** regOwn .x29 **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs))
+      (PF := (((.x7 : Reg) ↦ᵣ BitVec.ofNat 64 (32 - 32)) **
+        ((.x5 : Reg) ↦ᵣ (aPtr + BitVec.ofNat 64 32)) **
+        ((.x6 : Reg) ↦ᵣ (bPtr + BitVec.ofNat 64 32)) **
+        ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x28 ** regOwn .x29 **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs))
+      hbrHdr
+      (fun h hq => by xperm_hyp hq)
+      (fun h hq => by xperm_hyp hq)
+      (fun _ => htail)
+      (fun hc => absurd (by decide :
+        (BitVec.ofNat 64 (32 - 32) : Word) = (0 : Word)) hc))
+
+end Scan
+
+-- ============================================================================
+-- §5  The whole routine
+-- ============================================================================
+
+/-- **`p256_lt_be` at its linked address** (genuine post): `a0` is the
+    REAL numeric strict less-than of the two 32-byte big-endian
+    operands — `1` for `as < bs`, `0` otherwise (big-endian
+    lexicographic order IS numeric order); both input regions
+    untouched, `a1` preserved. -/
+theorem p256LtBe_spec (aPtr bPtr ret : Word) (xs bs : List (BitVec 8))
+    (hlenX : xs.length = 32) (hlenB : bs.length = 32)
+    (halignA : aPtr.toNat % 8 = 0) (halignB : bPtr.toNat % 8 = 0)
+    (hovA : aPtr.toNat + 32 < 2 ^ 64) (hovB : bPtr.toNat + 32 < 2 ^ 64)
+    (hvalidA : ∀ k, k < 32 → isValidByteAccess (aPtr + BitVec.ofNat 64 k) = true)
+    (hvalidB : ∀ k, k < 32 → isValidByteAccess (bPtr + BitVec.ofNat 64 k) = true)
+    (halignRet : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin 296 ltPBase ret
+      (CodeReq.ofProg ltPBase p256LtBe_prog)
+      (((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+       ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       regOwn .x6 ** regOwn .x7 ** regOwn .x5 **
+       regOwn .x28 ** regOwn .x29 **
+       bytesRegion aPtr xs **
+       bytesRegion bPtr bs)
+      (((.x10 : Reg) ↦ᵣ (if beBytesToNat xs < beBytesToNat bs
+         then (1 : Word) else (0 : Word))) **
+       ((.x11 : Reg) ↦ᵣ bPtr) **
+       ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       regOwn .x6 ** regOwn .x7 ** regOwn .x5 **
+       regOwn .x28 ** regOwn .x29 **
+       bytesRegion aPtr xs **
+       bytesRegion bPtr bs) := by
+  set CR := CodeReq.ofProg ltPBase p256LtBe_prog with hCR
+  -- peel the two MV destinations x5, x6 (the LI destination x7 is
+  -- consumed as ownership by `li_spec_gen_own_within` directly)
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x6)
+      (P := (((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs) **
+        regOwn .x5)
+      (fun v6 => ?_))
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x5)
+      (P := (((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+        bytesRegion aPtr xs ** bytesRegion bPtr bs) **
+        ((.x6 : Reg) ↦ᵣ v6))
+      (fun v5 => ?_))
+  -- ---- init: li x7, 32 ; mv x5, a0 ; mv x6, a1 ----
+  have hli7 := liftCode (cr' := CR)
+    (li_spec_gen_own_within .x7 (32 : Word) ltPBase (by decide))
+    (by rw [hCR]; code_mem)
+  have hmv5 := liftCode (cr' := CR)
+    (mv_spec_gen_within .x5 .x10 aPtr v5 (ltPBase + 4) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show (ltPBase + 4 : Word) + 4 = (ltPBase + 8 : Word) from by decide]
+    at hmv5
+  have hmv6 := liftCode (cr' := CR)
+    (mv_spec_gen_within .x6 .x11 bPtr v6 (ltPBase + 8) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show (ltPBase + 8 : Word) + 4 = (ltPBase + 12 : Word) from by decide]
+    at hmv6
+  -- ---- the three-outcome two-tail loop ----
+  have hloop := twoBreakRetLoop_spec (hdr := (ltPBase + 12 : Word)) (ret := ret)
+    (cr := CR) (Q := ltPost aPtr bPtr ret xs bs) 32 9 5
+    (ltInv aPtr bPtr ret xs bs)
+    (fun i hi => ltIter_spec aPtr bPtr ret xs bs hlenX hlenB
+      halignA halignB hovA hovB hvalidA hvalidB halignRet i hi)
+    (ltExh_spec aPtr bPtr ret xs bs hlenX hlenB halignRet)
+  -- ---- frames + chain ----
+  have hli7F := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) **
+      ((.x10 : Reg) ↦ᵣ aPtr) ** ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      regOwn .x28 ** regOwn .x29 **
+      bytesRegion aPtr xs ** bytesRegion bPtr bs)
+    (by pcf) hli7
+  have hmv5F := cpsTripleWithin_frameR
+    (((.x7 : Reg) ↦ᵣ (32 : Word)) ** ((.x6 : Reg) ↦ᵣ v6) **
+      ((.x11 : Reg) ↦ᵣ bPtr) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      regOwn .x28 ** regOwn .x29 **
+      bytesRegion aPtr xs ** bytesRegion bPtr bs)
+    (by pcf) hmv5
+  have hmv6F := cpsTripleWithin_frameR
+    (((.x7 : Reg) ↦ᵣ (32 : Word)) ** ((.x5 : Reg) ↦ᵣ aPtr) **
+      ((.x10 : Reg) ↦ᵣ aPtr) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      regOwn .x28 ** regOwn .x29 **
+      bytesRegion aPtr xs ** bytesRegion bPtr bs)
+    (by pcf) hmv6
+  have hc1 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hli7F hmv5F
+  have hc2 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hc1 hmv6F
+  have hc3 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      unfold ltInv
+      refine (sepConj_pure_left h).2
+        ⟨fun j hj => absurd hj (Nat.not_lt_zero j), ?_⟩
+      rw [show (BitVec.ofNat 64 (32 - 0) : Word) = (32 : Word) from by decide,
+          show aPtr + BitVec.ofNat 64 0 = aPtr from by
+            rw [show (BitVec.ofNat 64 0 : Word) = (0 : Word) from rfl]
+            bv_omega,
+          show bPtr + BitVec.ofNat 64 0 = bPtr from by
+            rw [show (BitVec.ofNat 64 0 : Word) = (0 : Word) from rfl]
+            bv_omega]
+      xperm_hyp hp) hc2 hloop
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun h hq => by unfold ltPost at hq; exact hq)
+    (cpsTripleWithin_mono_nSteps (by omega) hc3)
+
+#print axioms p256LtBe_spec
+
+end P256LtBeSAsm
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/RlpBytesEncodedSizeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpBytesEncodedSizeSAsm.lean
@@ -1,0 +1,823 @@
+/-
+  EvmAsm.Codegen.Programs.RlpBytesEncodedSizeSAsm
+
+  `rlp_bytes_encoded_size` — the RLP byte-string encoded size — the
+  `rlp_list_encoded_size` shape (`RlpListEncodedSizeSAsm.lean`, #10082)
+  prefixed by the single-byte prelude, all forward joins expressed with
+  `retJoinStation_spec` (this resolves blocker bead
+  evm-asm-4ch8f.15.5.1: the "return-if-with-fallthrough" it asked for
+  IS a `retJoinStation` whose taken arm runs a `li`/`ret` tail and
+  whose fall arm is the shared length-header continuation, proven once
+  and consumed by BOTH the `len ≠ 1` branch and the `b0 ≥ 0x80`
+  fall-through — no new `Stmt` node needed at `cpsTripleWithin` level).
+
+      rlp_bytes_encoded_size:            -- a0 = ptr, a1 = len
+        li   t0, 1
+        bne  a1, t0, .hdr                -- len ≠ 1 → header path
+        lbu  t1, 0(a0) ; li t2, 128
+        bltu t1, t2, .one                -- single byte < 0x80 → size 1
+      .hdr:
+        li   t0, 56
+        bgeu a1, t0, .long
+        addi a0, a1, 1 ; ret             -- short form: 1-byte header
+      .one:
+        li   a0, 1 ; ret
+      .long:
+        mv   t0, a1 ; li t1, 0
+      .len: beq t0, x0, .done            -- while (len >>> 8·i) ≠ 0
+        srli t0, t0, 8 ; addi t1, t1, 1 ; j .len
+      .done:
+        add  a0, a1, t1 ; addi a0, a0, 1 ; ret
+
+  **Genuine post** (`rlpBytesEncodedSize_spec`):
+  `a0 = rbesSize xs len` — `1` when the string is a single byte below
+  `0x80` (RLP encodes it as itself), else `len + 1` below 56, else
+  `len + u64ByteLen len + 1`; the input region and `a1` untouched.
+  The loop-exit index is tied to `u64ByteLen` by the #10082 shift
+  bridges (`u64ByteLen_shift_zero` / `_ne`), reused as-is.
+
+  Byte-transparent: stated at the `#guard`-tied symbolic
+  `GuestAddrs.rlp_bytes_encoded_size` base (bead evm-asm-6agnq) over
+  the emitted `rlpBytesEncodedSize_prog` — no guest-byte change, no
+  A/B run needed.  Bead: evm-asm-4ch8f.15.5.
+-/
+
+import EvmAsm.Codegen.Programs.RlpListEncodedSizeSAsm
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+
+namespace RlpBytesEncodedSizeSAsm
+
+open RlpListEncodedSizeSAsm (u64ByteLen u64ByteLen_le u64ByteLen_shift_zero
+  u64ByteLen_shift_ne)
+
+/-- The routine base, symbolic (bead evm-asm-6agnq). -/
+def rbesBase : Word := (GuestAddrs.rlp_bytes_encoded_size : Word)
+
+-- Address anchor (fails the build if the guest link moves).
+#guard GuestAddrs.rlp_bytes_encoded_size = 0x8000add0
+#guard rlpBytesEncodedSize_prog.length = 20
+-- The routine is position-independent (no PC-relative instruction).
+
+/-
+  Layout relative to `GuestAddrs.rlp_bytes_encoded_size`:
+    +0   li   x5, 1
+    +4   bne  x11, x5, +16 → +20
+    +8   lbu  x6, 0(x10)
+    +12  li   x7, 128
+    +16  bltu x6, x7, +20 → +36 (size-1 tail)
+    +20  li   x5, 56
+    +24  bgeu x11, x5, +20 → +44 (long)
+    +28  addi x10, x11, 1
+    +32  jalr (short ret)
+    +36  li   x10, 1
+    +40  jalr (size-1 ret)
+    +44  mv   x5, x11
+    +48  li   x6, 0
+    +52  beq  x5, x0, +16 → +68   [hdr]
+    +56  srli x5, x5, 8
+    +60  addi x6, x6, 1
+    +64  jal  x0, -12     → +52
+    +68  add  x10, x11, x6
+    +72  addi x10, x10, 1
+    +76  jalr (long ret)
+-/
+
+/-- The RLP byte-string encoded size: a single byte below `0x80`
+    encodes as itself (size 1); otherwise a 1-byte header below 56,
+    else a `1 + length-of-length` header. -/
+def rbesSize (xs : List (BitVec 8)) (len : Word) : Word :=
+  if len = (1 : Word) ∧ (xs.getD 0 0).toNat < 128 then 1
+  else if BitVec.ult len (56 : Word) then len + 1
+  else (len + BitVec.ofNat 64 (u64ByteLen len)) + 1
+
+
+/-- One `SRLI 8` advances the shift count by one byte (local copy of the
+    #10082 private helper). -/
+private theorem shift_step (v : Word) (i : Nat) :
+    (v >>> (8 * i)) >>> ((8 : BitVec 6)).toNat = v >>> (8 * (i + 1)) := by
+  rw [show ((8 : BitVec 6)).toNat = 8 from rfl]
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_ushiftRight, BitVec.toNat_ushiftRight,
+    BitVec.toNat_ushiftRight, ← Nat.shiftRight_add,
+    show 8 * i + 8 = 8 * (i + 1) from by omega]
+
+private theorem shift_zero_self (v : Word) : v >>> (8 * 0) = v := by
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_ushiftRight]
+  rfl
+
+private theorem cnt_step_up (n : Nat) (_h : n + 1 < 2 ^ 64) :
+    BitVec.ofNat 64 n + signExtend12 (1 : BitVec 12) = BitVec.ofNat 64 (n + 1) := by
+  rw [show signExtend12 (1 : BitVec 12) = BitVec.ofNat 64 1 from by decide]
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_add, BitVec.toNat_ofNat]
+  omega
+
+section Routine
+
+variable (ptr len ret : Word) (xs : List (BitVec 8))
+
+/-- Loop invariant at iteration `i` (the `.len` byte-length loop):
+    shift register, counter, and the riding inputs. -/
+private def rbsInv (i : Nat) : Assertion :=
+  ((.x5 : Reg) ↦ᵣ (len >>> (8 * i))) **
+  ((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 i) **
+  ((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+  ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+  regOwn .x7 ** bytesRegion ptr xs
+
+/-- The genuine routine post. -/
+private def rbsPost : Assertion :=
+  ((.x10 : Reg) ↦ᵣ rbesSize xs len) ** ((.x11 : Reg) ↦ᵣ len) **
+  ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  bytesRegion ptr xs
+
+/-- One `.len` iteration (`i < u64ByteLen len`). -/
+private theorem rbsIter_spec (i : Nat) (hi : i < u64ByteLen len) :
+    cpsBranchWithin 4 (rbesBase + 52)
+      (CodeReq.ofProg rbesBase rlpBytesEncodedSize_prog)
+      (rbsInv ptr len ret xs i)
+      ret (rbsPost ptr len ret xs)
+      (rbesBase + 52) (rbsInv ptr len ret xs (i + 1)) := by
+  set CR := CodeReq.ofProg rbesBase rlpBytesEncodedSize_prog with hCR
+  have hN8 := u64ByteLen_le len
+  unfold rbsInv
+  have hbr := cpsBranchWithin_frameR
+    (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 i) **
+      ((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+      ((.x1 : Reg) ↦ᵣ ret) ** regOwn .x7 ** bytesRegion ptr xs)
+    (by pcf)
+    (cpsBranchWithin_extend_code (cr' := CR)
+      (h := beq_spec_gen_within .x5 .x0 (16 : BitVec 13) (len >>> (8 * i))
+        (0 : Word) (rbesBase + 52))
+      (hmono := by rw [hCR]; code_mem))
+  rw [show (rbesBase + 52 : Word) + signExtend13 (16 : BitVec 13)
+        = (rbesBase + 68 : Word) from by decide,
+      show (rbesBase + 52 : Word) + 4 = (rbesBase + 56 : Word) from by decide]
+    at hbr
+  have hsrli := liftCode (cr' := CR)
+    (srli_spec_gen_same_within .x5 (len >>> (8 * i)) (8 : BitVec 6)
+      (rbesBase + 56) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [shift_step len i,
+      show (rbesBase + 56 : Word) + 4 = (rbesBase + 60 : Word) from by decide]
+    at hsrli
+  have haddi := liftCode (cr' := CR)
+    (addi_spec_gen_same_within .x6 (BitVec.ofNat 64 i) (1 : BitVec 12)
+      (rbesBase + 60) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [cnt_step_up i (by omega),
+      show (rbesBase + 60 : Word) + 4 = (rbesBase + 64 : Word) from by decide]
+    at haddi
+  have hjal := liftCode (cr' := CR)
+    (jal_x0_spec_gen_within (-12 : BitVec 21) (rbesBase + 64))
+    (by rw [hCR]; code_mem)
+  rw [show (rbesBase + 64 : Word) + signExtend21 (-12 : BitVec 21)
+    = (rbesBase + 52 : Word) from by decide] at hjal
+  have hsrliF := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 i) **
+      ((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      regOwn .x7 ** bytesRegion ptr xs)
+    (by pcf) hsrli
+  have haddiF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (len >>> (8 * (i + 1)))) **
+      ((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      regOwn .x7 ** bytesRegion ptr xs)
+    (by pcf) haddi
+  have hjalF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (len >>> (8 * (i + 1)))) **
+      ((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (i + 1)) **
+      ((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      regOwn .x7 ** bytesRegion ptr xs)
+    (by pcf) hjal
+  have hc1 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hsrliF haddiF
+  have hc2 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by
+      rw [sepConj_emp_left']
+      xperm_hyp hp) hc1 hjalF
+  have hcont : cpsTripleWithin 3 (rbesBase + 56) (rbesBase + 52) CR
+      (((.x5 : Reg) ↦ᵣ (len >>> (8 * i))) **
+        ((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 i) **
+        ((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x7 ** bytesRegion ptr xs)
+      (rbsInv ptr len ret xs (i + 1)) := by
+    refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun h hq => ?_) hc2
+    rw [sepConj_emp_left'] at hq
+    unfold rbsInv
+    xperm_hyp hq
+  refine cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq) (fun _ hq => hq)
+    (breakStation_spec (cond := (len >>> (8 * i) = (0 : Word)))
+    (PT := ((.x5 : Reg) ↦ᵣ (len >>> (8 * i))) **
+      ((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 i) **
+      ((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      regOwn .x7 ** bytesRegion ptr xs)
+    (PF := ((.x5 : Reg) ↦ᵣ (len >>> (8 * i))) **
+      ((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 i) **
+      ((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      regOwn .x7 ** bytesRegion ptr xs)
+    hbr
+    (fun h hq => by xperm_hyp hq)
+    (fun h hq => by xperm_hyp hq)
+    (fun hc => absurd hc (u64ByteLen_shift_ne len i hi))
+    (fun _ => cpsTripleWithin_as_cpsBranchWithin_right ret
+      (rbsPost ptr len ret xs) hcont))
+
+/-- Exhaustion (`i = u64ByteLen len`): guard fires; under the two
+    excluded cases the materialized `len + byteLen + 1` IS `rbesSize`. -/
+private theorem rbsExh_spec
+    (hnot1 : ¬ (len = (1 : Word) ∧ (xs.getD 0 0).toNat < 128))
+    (hge : ¬ BitVec.ult len (56 : Word))
+    (halignRet : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin 4 (rbesBase + 52) ret
+      (CodeReq.ofProg rbesBase rlpBytesEncodedSize_prog)
+      (rbsInv ptr len ret xs (u64ByteLen len))
+      (rbsPost ptr len ret xs) := by
+  set CR := CodeReq.ofProg rbesBase rlpBytesEncodedSize_prog with hCR
+  unfold rbsInv
+  have hbr := cpsBranchWithin_frameR
+    (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (u64ByteLen len)) **
+      ((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+      ((.x1 : Reg) ↦ᵣ ret) ** regOwn .x7 ** bytesRegion ptr xs)
+    (by pcf)
+    (cpsBranchWithin_extend_code (cr' := CR)
+      (h := beq_spec_gen_within .x5 .x0 (16 : BitVec 13)
+        (len >>> (8 * u64ByteLen len)) (0 : Word) (rbesBase + 52))
+      (hmono := by rw [hCR]; code_mem))
+  rw [show (rbesBase + 52 : Word) + signExtend13 (16 : BitVec 13)
+        = (rbesBase + 68 : Word) from by decide,
+      show (rbesBase + 52 : Word) + 4 = (rbesBase + 56 : Word) from by decide]
+    at hbr
+  -- add a0, a1, t1 ; addi a0, a0, 1 ; ret
+  have hadd := liftCode (cr' := CR)
+    (add_spec_gen_within .x10 .x11 .x6 len
+      (BitVec.ofNat 64 (u64ByteLen len)) ptr (rbesBase + 68) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show (rbesBase + 68 : Word) + 4 = (rbesBase + 72 : Word) from by decide]
+    at hadd
+  have haddi := liftCode (cr' := CR)
+    (addi_spec_gen_same_within .x10 (len + BitVec.ofNat 64 (u64ByteLen len))
+      (1 : BitVec 12) (rbesBase + 72) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide,
+      show (rbesBase + 72 : Word) + 4 = (rbesBase + 76 : Word) from by decide]
+    at haddi
+  have hret := liftCode (cr' := CR)
+    (EvmAsm.Evm64.ret_spec_within' (rbesBase + 76) ret)
+    (by rw [hCR]; code_mem)
+  rw [halignRet] at hret
+  have haddF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (len >>> (8 * u64ByteLen len))) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      regOwn .x7 ** bytesRegion ptr xs)
+    (by pcf) hadd
+  have haddiF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (len >>> (8 * u64ByteLen len))) **
+      ((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (u64ByteLen len)) **
+      ((.x11 : Reg) ↦ᵣ len) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      regOwn .x7 ** bytesRegion ptr xs)
+    (by pcf) haddi
+  have hretF := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ (len >>> (8 * u64ByteLen len))) **
+      ((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (u64ByteLen len)) **
+      ((.x10 : Reg) ↦ᵣ ((len + BitVec.ofNat 64 (u64ByteLen len)) + (1 : Word))) **
+      ((.x11 : Reg) ↦ᵣ len) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      regOwn .x7 ** bytesRegion ptr xs)
+    (by pcf) hret
+  have htail1 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) haddF haddiF
+  have htail2 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) htail1 hretF
+  have htailQ : cpsTripleWithin 3 (rbesBase + 68) ret CR
+      (((.x5 : Reg) ↦ᵣ (len >>> (8 * u64ByteLen len))) **
+        ((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (u64ByteLen len)) **
+        ((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x7 ** bytesRegion ptr xs)
+      (rbsPost ptr len ret xs) := by
+    refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun h hq => ?_) htail2
+    unfold rbsPost rbesSize
+    rw [if_neg hnot1, if_neg hge]
+    have hq1 : (((.x5 : Reg) ↦ᵣ (len >>> (8 * u64ByteLen len))) **
+        ((((.x6 : Reg)) ↦ᵣ BitVec.ofNat 64 (u64ByteLen len)) **
+          (((.x10 : Reg) ↦ᵣ ((len + BitVec.ofNat 64 (u64ByteLen len)) + (1 : Word))) **
+           ((.x11 : Reg) ↦ᵣ len) **
+           ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+           regOwn .x7 ** bytesRegion ptr xs))) h := by
+      xperm_hyp hq
+    have hq2 := sepConj_mono (regIs_to_regOwn .x5 _)
+      (sepConj_mono (regIs_to_regOwn .x6 _) (fun _ hh => hh)) h hq1
+    xperm_hyp hq2
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq)
+    (retJoinStation_spec
+      (cond := (len >>> (8 * u64ByteLen len) = (0 : Word)))
+      (PT := ((.x5 : Reg) ↦ᵣ (len >>> (8 * u64ByteLen len))) **
+        ((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (u64ByteLen len)) **
+        ((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x7 ** bytesRegion ptr xs)
+      (PF := ((.x5 : Reg) ↦ᵣ (len >>> (8 * u64ByteLen len))) **
+        ((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (u64ByteLen len)) **
+        ((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x7 ** bytesRegion ptr xs)
+      hbr
+      (fun h hq => by xperm_hyp hq)
+      (fun h hq => by xperm_hyp hq)
+      (fun _ => htailQ)
+      (fun hc => absurd (u64ByteLen_shift_zero len) hc))
+
+/-- The shared length-header continuation (from `.hdr`, at `+20`),
+    proven ONCE and consumed by both the `len ≠ 1` branch and the
+    `b0 ≥ 0x80` fall-through.  `v6`/`v7` are whatever the two entry
+    paths left in the scratch registers. -/
+private theorem rbsHdr_spec (v6 v7 : Word)
+    (hnot1 : ¬ (len = (1 : Word) ∧ (xs.getD 0 0).toNat < 128))
+    (halignRet : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin 42 (rbesBase + 20) ret
+      (CodeReq.ofProg rbesBase rlpBytesEncodedSize_prog)
+      (((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+        bytesRegion ptr xs)
+      (rbsPost ptr len ret xs) := by
+  set CR := CodeReq.ofProg rbesBase rlpBytesEncodedSize_prog with hCR
+  have hN8 := u64ByteLen_le len
+  -- peel x5 (the li destination)
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x5)
+      (P := (((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+        bytesRegion ptr xs))
+      (fun v5 => ?_))
+  -- li x5, 56
+  have hli := liftCode (cr' := CR)
+    (li_spec_gen_within .x5 v5 (56 : Word) (rbesBase + 20) (by decide))
+    (by rw [hCR]; code_mem)
+  rw [show (rbesBase + 20 : Word) + 4 = (rbesBase + 24 : Word) from by decide]
+    at hli
+  -- bgeu a1, t0 (the short/long dispatch)
+  have hbr := cpsBranchWithin_frameR
+    (((.x10 : Reg) ↦ᵣ ptr) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+      bytesRegion ptr xs)
+    (by pcf)
+    (cpsBranchWithin_extend_code (cr' := CR)
+      (h := bgeu_spec_gen_within .x11 .x5 (20 : BitVec 13) len (56 : Word)
+        (rbesBase + 24))
+      (hmono := by rw [hCR]; code_mem))
+  rw [show (rbesBase + 24 : Word) + signExtend13 (20 : BitVec 13)
+        = (rbesBase + 44 : Word) from by decide,
+      show (rbesBase + 24 : Word) + 4 = (rbesBase + 28 : Word) from by decide]
+    at hbr
+  -- short arm: addi a0, a1, 1 ; ret
+  have hshort : BitVec.ult len (56 : Word) →
+      cpsTripleWithin 40 (rbesBase + 28) ret CR
+        (((.x11 : Reg) ↦ᵣ len) ** ((.x5 : Reg) ↦ᵣ (56 : Word)) **
+          (((.x10 : Reg) ↦ᵣ ptr) ** ((.x1 : Reg) ↦ᵣ ret) **
+            ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+            ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+            bytesRegion ptr xs))
+        (rbsPost ptr len ret xs) := by
+    intro hlt
+    have haddi := liftCode (cr' := CR)
+      (addi_spec_gen_within .x10 .x11 ptr len (1 : BitVec 12)
+        (rbesBase + 28) (by decide))
+      (by rw [hCR]; code_mem)
+    rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide,
+        show (rbesBase + 28 : Word) + 4 = (rbesBase + 32 : Word) from by decide]
+      at haddi
+    have hret := liftCode (cr' := CR)
+      (EvmAsm.Evm64.ret_spec_within' (rbesBase + 32) ret)
+      (by rw [hCR]; code_mem)
+    rw [halignRet] at hret
+    have haddiF := cpsTripleWithin_frameR
+      (((.x5 : Reg) ↦ᵣ (56 : Word)) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+        bytesRegion ptr xs)
+      (by pcf) haddi
+    have hretF := cpsTripleWithin_frameR
+      (((.x10 : Reg) ↦ᵣ (len + (1 : Word))) ** ((.x11 : Reg) ↦ᵣ len) **
+        ((.x5 : Reg) ↦ᵣ (56 : Word)) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+        bytesRegion ptr xs)
+      (by pcf) hret
+    have hc := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by xperm_hyp hp) haddiF hretF
+    refine cpsTripleWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+        (fun h hq => ?_) hc)
+    unfold rbsPost rbesSize
+    rw [if_neg hnot1, if_pos hlt]
+    have hq1 : (((.x5 : Reg) ↦ᵣ (56 : Word)) ** (((.x6 : Reg) ↦ᵣ v6) **
+        (((.x7 : Reg) ↦ᵣ v7) **
+          (((.x10 : Reg) ↦ᵣ (len + (1 : Word))) ** ((.x11 : Reg) ↦ᵣ len) **
+           ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+           bytesRegion ptr xs)))) h := by
+      xperm_hyp hq
+    have hq2 := sepConj_mono (regIs_to_regOwn .x5 _)
+      (sepConj_mono (regIs_to_regOwn .x6 _)
+        (sepConj_mono (regIs_to_regOwn .x7 _) (fun _ hh => hh))) h hq1
+    xperm_hyp hq2
+  -- long arm: mv t0, a1 ; li t1, 0 ; the payload-dependent while
+  have hlong : ¬ BitVec.ult len (56 : Word) →
+      cpsTripleWithin 40 (rbesBase + 44) ret CR
+        (((.x11 : Reg) ↦ᵣ len) ** ((.x5 : Reg) ↦ᵣ (56 : Word)) **
+          (((.x10 : Reg) ↦ᵣ ptr) ** ((.x1 : Reg) ↦ᵣ ret) **
+            ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+            ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+            bytesRegion ptr xs))
+        (rbsPost ptr len ret xs) := by
+    intro hge
+    have hmv := liftCode (cr' := CR)
+      (mv_spec_gen_within .x5 .x11 len (56 : Word) (rbesBase + 44)
+        (by decide))
+      (by rw [hCR]; code_mem)
+    rw [show (rbesBase + 44 : Word) + 4 = (rbesBase + 48 : Word) from by decide]
+      at hmv
+    have hli6 := liftCode (cr' := CR)
+      (li_spec_gen_within .x6 v6 (0 : Word) (rbesBase + 48) (by decide))
+      (by rw [hCR]; code_mem)
+    rw [show (rbesBase + 48 : Word) + 4 = (rbesBase + 52 : Word) from by decide,
+        show (0 : Word) = BitVec.ofNat 64 0 from rfl] at hli6
+    have hloop := twoBreakRetLoop_spec (hdr := (rbesBase + 52 : Word))
+      (ret := ret) (cr := CR) (Q := rbsPost ptr len ret xs) (u64ByteLen len) 4 4
+      (rbsInv ptr len ret xs)
+      (fun i hi => rbsIter_spec ptr len ret xs i hi)
+      (rbsExh_spec ptr len ret xs hnot1 hge halignRet)
+    have hmvF := cpsTripleWithin_frameR
+      (((.x10 : Reg) ↦ᵣ ptr) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+        bytesRegion ptr xs)
+      (by pcf) hmv
+    have hli6F := cpsTripleWithin_frameR
+      (((.x5 : Reg) ↦ᵣ len) ** ((.x10 : Reg) ↦ᵣ ptr) **
+        ((.x11 : Reg) ↦ᵣ len) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x7 : Reg) ↦ᵣ v7) **
+        bytesRegion ptr xs)
+      (by pcf) hli6
+    have hc1 := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by xperm_hyp hp) hmvF hli6F
+    have hc2 := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        unfold rbsInv
+        rw [shift_zero_self len]
+        have hp1 : ((((.x7 : Reg) ↦ᵣ v7) **
+            (((.x5 : Reg) ↦ᵣ len) **
+             ((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 0) **
+             ((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+             ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+             bytesRegion ptr xs))) h := by
+          xperm_hyp hp
+        have hp2 := sepConj_mono (regIs_to_regOwn .x7 _)
+          (fun _ hh => hh) h hp1
+        xperm_hyp hp2) hc1 hloop
+    refine cpsTripleWithin_mono_nSteps ?hle
+      (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+        (fun _ hq => hq) hc2)
+    case hle => omega
+  -- the dispatch station
+  have hliF := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+      bytesRegion ptr xs)
+    (by pcf) hli
+  have hstation := retJoinStation_spec
+    (cond := ¬ BitVec.ult len (56 : Word))
+    (PT := ((.x11 : Reg) ↦ᵣ len) ** ((.x5 : Reg) ↦ᵣ (56 : Word)) **
+      (((.x10 : Reg) ↦ᵣ ptr) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+        bytesRegion ptr xs))
+    (PF := ((.x11 : Reg) ↦ᵣ len) ** ((.x5 : Reg) ↦ᵣ (56 : Word)) **
+      (((.x10 : Reg) ↦ᵣ ptr) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+        bytesRegion ptr xs))
+    hbr
+    (fun h hq => by xperm_hyp hq)
+    (fun h hq => by
+      have hq1 : (⌜BitVec.ult len (56 : Word)⌝ **
+          (((.x11 : Reg) ↦ᵣ len) ** ((.x5 : Reg) ↦ᵣ (56 : Word)) **
+           ((.x10 : Reg) ↦ᵣ ptr) ** ((.x1 : Reg) ↦ᵣ ret) **
+           ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+           ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+           bytesRegion ptr xs)) h := by
+        xperm_hyp hq
+      obtain ⟨hlt, hrest⟩ := (sepConj_pure_left h).1 hq1
+      exact (sepConj_pure_left h).2 ⟨fun hn => hn hlt, hrest⟩)
+    (fun hge => hlong hge)
+    (fun hnge => hshort (not_not.mp hnge))
+  have hall := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hliF hstation
+  exact cpsTripleWithin_mono_nSteps (by omega)
+    (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => hq) hall)
+
+/-- **`rlp_bytes_encoded_size` at its linked address** (genuine post):
+    `a0 = rbesSize xs len` — the real RLP byte-string size formula;
+    the input region and `a1` untouched. -/
+theorem rlpBytesEncodedSize_spec
+    (hlenXs : xs.length = len.toNat)
+    (halignPtr : ptr.toNat % 8 = 0)
+    (hvalidPtr : ∀ k, k < len.toNat →
+      isValidByteAccess (ptr + BitVec.ofNat 64 k) = true)
+    (halignRet : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin 48 rbesBase ret
+      (CodeReq.ofProg rbesBase rlpBytesEncodedSize_prog)
+      (((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        bytesRegion ptr xs)
+      (((.x10 : Reg) ↦ᵣ rbesSize xs len) ** ((.x11 : Reg) ↦ᵣ len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        bytesRegion ptr xs) := by
+  set CR := CodeReq.ofProg rbesBase rlpBytesEncodedSize_prog with hCR
+  -- peel x5, x6, x7
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x5)
+      (P := (((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x6 ** regOwn .x7 ** bytesRegion ptr xs))
+      (fun v5 => ?_))
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x6)
+      (P := (((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x7 ** bytesRegion ptr xs) **
+        ((.x5 : Reg) ↦ᵣ v5))
+      (fun v6 => ?_))
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ hq => hq)
+    (cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x7)
+      (P := (((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion ptr xs) **
+        ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6))
+      (fun v7 => ?_))
+  -- li x5, 1
+  have hli := liftCode (cr' := CR)
+    (li_spec_gen_within .x5 v5 (1 : Word) rbesBase (by decide))
+    (by rw [hCR]; code_mem)
+  -- bne a1, t0 (the single-byte prelude dispatch)
+  have hbr := cpsBranchWithin_frameR
+    (((.x10 : Reg) ↦ᵣ ptr) ** ((.x1 : Reg) ↦ᵣ ret) **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+      bytesRegion ptr xs)
+    (by pcf)
+    (cpsBranchWithin_extend_code (cr' := CR)
+      (h := bne_spec_gen_within .x11 .x5 (16 : BitVec 13) len (1 : Word)
+        (rbesBase + 4))
+      (hmono := by rw [hCR]; code_mem))
+  rw [show (rbesBase + 4 : Word) + signExtend13 (16 : BitVec 13)
+        = (rbesBase + 20 : Word) from by decide,
+      show (rbesBase + 4 : Word) + 4 = (rbesBase + 8 : Word) from by decide]
+    at hbr
+  -- taken arm (len ≠ 1): straight to the shared header continuation
+  have hne1 : len ≠ (1 : Word) →
+      cpsTripleWithin 46 (rbesBase + 20) ret CR
+        (((.x11 : Reg) ↦ᵣ len) ** ((.x5 : Reg) ↦ᵣ (1 : Word)) **
+          (((.x10 : Reg) ↦ᵣ ptr) ** ((.x1 : Reg) ↦ᵣ ret) **
+            ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+            ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+            bytesRegion ptr xs))
+        (rbsPost ptr len ret xs) := by
+    intro hne
+    have hnot1 : ¬ (len = (1 : Word) ∧ (xs.getD 0 0).toNat < 128) :=
+      fun hand => hne hand.1
+    refine cpsTripleWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_weaken (fun h hp => ?_) (fun _ hq => hq)
+        (rbsHdr_spec ptr len ret xs v6 v7 hnot1 halignRet))
+    have hp1 : (((.x5 : Reg) ↦ᵣ (1 : Word)) **
+        (((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+         ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+         bytesRegion ptr xs)) h := by
+      xperm_hyp hp
+    have hp2 := sepConj_mono (regIs_to_regOwn .x5 _)
+      (fun _ hh => hh) h hp1
+    xperm_hyp hp2
+  -- fall arm (len = 1): lbu ; li 128 ; the byte guard
+  have heq1 : len = (1 : Word) →
+      cpsTripleWithin 46 (rbesBase + 8) ret CR
+        (((.x11 : Reg) ↦ᵣ len) ** ((.x5 : Reg) ↦ᵣ (1 : Word)) **
+          (((.x10 : Reg) ↦ᵣ ptr) ** ((.x1 : Reg) ↦ᵣ ret) **
+            ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+            ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+            bytesRegion ptr xs))
+        (rbsPost ptr len ret xs) := by
+    intro he1
+    have hxlen : xs.length = 1 := by
+      rw [hlenXs, he1]; rfl
+    have h0lt : 0 < xs.length := by omega
+    -- lbu t1, 0(a0): reads xs[0]
+    have hlbu := liftCode (cr' := CR)
+      (bytesRegion_lbu_within .x6 .x10 ptr v6 (rbesBase + 8) xs 0
+        (by decide) halignPtr h0lt (by omega)
+        (hvalidPtr 0 (by omega)))
+      (by rw [hCR]; code_mem)
+    rw [show ptr + BitVec.ofNat 64 0 = ptr from by
+          rw [show (BitVec.ofNat 64 0 : Word) = (0 : Word) from rfl]
+          bv_omega,
+        show (rbesBase + 8 : Word) + 4 = (rbesBase + 12 : Word) from by decide]
+      at hlbu
+    set b0 := (xs[0]'h0lt).zeroExtend 64 with hb0
+    have hgd0 : xs.getD 0 0 = xs[0]'h0lt := by
+      rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem h0lt]
+      rfl
+    have hb0N : b0.toNat = (xs[0]'h0lt).toNat := by
+      rw [hb0]
+      show (BitVec.setWidth 64 _).toNat = _
+      rw [BitVec.toNat_setWidth]
+      have := (xs[0]'h0lt).isLt
+      omega
+    -- li t2, 128
+    have hli7 := liftCode (cr' := CR)
+      (li_spec_gen_within .x7 v7 (128 : Word) (rbesBase + 12) (by decide))
+      (by rw [hCR]; code_mem)
+    rw [show (rbesBase + 12 : Word) + 4 = (rbesBase + 16 : Word) from by decide]
+      at hli7
+    -- bltu t1, t2 (the byte guard)
+    have hbrB := cpsBranchWithin_frameR
+      (((.x11 : Reg) ↦ᵣ len) ** ((.x5 : Reg) ↦ᵣ (1 : Word)) **
+        ((.x10 : Reg) ↦ᵣ ptr) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion ptr xs)
+      (by pcf)
+      (cpsBranchWithin_extend_code (cr' := CR)
+        (h := bltu_spec_gen_within .x6 .x7 (20 : BitVec 13) b0 (128 : Word)
+          (rbesBase + 16))
+        (hmono := by rw [hCR]; code_mem))
+    rw [show (rbesBase + 16 : Word) + signExtend13 (20 : BitVec 13)
+          = (rbesBase + 36 : Word) from by decide,
+        show (rbesBase + 16 : Word) + 4 = (rbesBase + 20 : Word) from by decide]
+      at hbrB
+    -- taken: li a0, 1 ; ret — the size-1 tail
+    have hone : BitVec.ult b0 (128 : Word) →
+        cpsTripleWithin 43 (rbesBase + 36) ret CR
+          (((.x6 : Reg) ↦ᵣ b0) ** ((.x7 : Reg) ↦ᵣ (128 : Word)) **
+            (((.x11 : Reg) ↦ᵣ len) ** ((.x5 : Reg) ↦ᵣ (1 : Word)) **
+             ((.x10 : Reg) ↦ᵣ ptr) ** ((.x1 : Reg) ↦ᵣ ret) **
+             ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion ptr xs))
+          (rbsPost ptr len ret xs) := by
+      intro hblt
+      have hb0small : (xs.getD 0 0).toNat < 128 := by
+        have : b0.toNat < 128 := by
+          simpa [BitVec.ult, decide_eq_true_eq] using hblt
+        rw [hgd0]
+        omega
+      have h := sharedRetTail_spec CR (rbesBase + 36) ret .x10 (1 : Word)
+        ptr
+        (((.x11 : Reg) ↦ᵣ len) ** ((.x5 : Reg) ↦ᵣ (1 : Word)) **
+          ((.x6 : Reg) ↦ᵣ b0) ** ((.x7 : Reg) ↦ᵣ (128 : Word)) **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion ptr xs)
+        (by pcf) (by decide) halignRet
+        (by rw [hCR]; code_mem) (by rw [hCR]; code_mem)
+      refine cpsTripleWithin_mono_nSteps (by omega)
+        (cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+          (fun h hq => ?_) h)
+      unfold rbsPost rbesSize
+      rw [if_pos ⟨he1, hb0small⟩]
+      have hq1 : (((.x5 : Reg) ↦ᵣ (1 : Word)) ** (((.x6 : Reg) ↦ᵣ b0) **
+          (((.x7 : Reg) ↦ᵣ (128 : Word)) **
+            (((.x10 : Reg) ↦ᵣ (1 : Word)) ** ((.x11 : Reg) ↦ᵣ len) **
+             ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+             bytesRegion ptr xs)))) h := by
+        xperm_hyp hq
+      have hq2 := sepConj_mono (regIs_to_regOwn .x5 _)
+        (sepConj_mono (regIs_to_regOwn .x6 _)
+          (sepConj_mono (regIs_to_regOwn .x7 _) (fun _ hh => hh))) h hq1
+      xperm_hyp hq2
+    -- fall: the shared header continuation (b0 ≥ 0x80)
+    have hbig : ¬ BitVec.ult b0 (128 : Word) →
+        cpsTripleWithin 43 (rbesBase + 20) ret CR
+          (((.x6 : Reg) ↦ᵣ b0) ** ((.x7 : Reg) ↦ᵣ (128 : Word)) **
+            (((.x11 : Reg) ↦ᵣ len) ** ((.x5 : Reg) ↦ᵣ (1 : Word)) **
+             ((.x10 : Reg) ↦ᵣ ptr) ** ((.x1 : Reg) ↦ᵣ ret) **
+             ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion ptr xs))
+          (rbsPost ptr len ret xs) := by
+      intro hnblt
+      have hnot1 : ¬ (len = (1 : Word) ∧ (xs.getD 0 0).toNat < 128) := by
+        rintro ⟨-, hsmall⟩
+        apply hnblt
+        have : b0.toNat < 128 := by rw [hb0N, ← hgd0]; omega
+        simpa [BitVec.ult, decide_eq_true_eq] using this
+      refine cpsTripleWithin_mono_nSteps (by omega)
+        (cpsTripleWithin_weaken (fun h hp => ?_) (fun _ hq => hq)
+          (rbsHdr_spec ptr len ret xs b0 (128 : Word) hnot1 halignRet))
+      have hp1 : (((.x5 : Reg) ↦ᵣ (1 : Word)) **
+          (((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+           ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+           ((.x6 : Reg) ↦ᵣ b0) ** ((.x7 : Reg) ↦ᵣ (128 : Word)) **
+           bytesRegion ptr xs)) h := by
+        xperm_hyp hp
+      have hp2 := sepConj_mono (regIs_to_regOwn .x5 _)
+        (fun _ hh => hh) h hp1
+      xperm_hyp hp2
+    -- the byte-guard station
+    have hstB := retJoinStation_spec
+      (cond := BitVec.ult b0 (128 : Word))
+      (PT := ((.x6 : Reg) ↦ᵣ b0) ** ((.x7 : Reg) ↦ᵣ (128 : Word)) **
+        (((.x11 : Reg) ↦ᵣ len) ** ((.x5 : Reg) ↦ᵣ (1 : Word)) **
+         ((.x10 : Reg) ↦ᵣ ptr) ** ((.x1 : Reg) ↦ᵣ ret) **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion ptr xs))
+      (PF := ((.x6 : Reg) ↦ᵣ b0) ** ((.x7 : Reg) ↦ᵣ (128 : Word)) **
+        (((.x11 : Reg) ↦ᵣ len) ** ((.x5 : Reg) ↦ᵣ (1 : Word)) **
+         ((.x10 : Reg) ↦ᵣ ptr) ** ((.x1 : Reg) ↦ᵣ ret) **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion ptr xs))
+      hbrB
+      (fun h hq => by xperm_hyp hq)
+      (fun h hq => by xperm_hyp hq)
+      (fun hblt => hone hblt)
+      (fun hnblt => hbig hnblt)
+    -- lbu ; li ; station
+    have hlbuF := cpsTripleWithin_frameR
+      (((.x11 : Reg) ↦ᵣ len) ** ((.x5 : Reg) ↦ᵣ (1 : Word)) **
+        ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x7 : Reg) ↦ᵣ v7))
+      (by pcf) hlbu
+    have hli7F := cpsTripleWithin_frameR
+      (((.x11 : Reg) ↦ᵣ len) ** ((.x5 : Reg) ↦ᵣ (1 : Word)) **
+        ((.x10 : Reg) ↦ᵣ ptr) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x6 : Reg) ↦ᵣ b0) **
+        bytesRegion ptr xs)
+      (by pcf) hli7
+    have hc1 := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by xperm_hyp hp) hlbuF hli7F
+    have hc2 := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by xperm_hyp hp) hc1 hstB
+    exact cpsTripleWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+        (fun _ hq => hq) hc2)
+  -- the prelude station
+  have hliF := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ ptr) ** ((.x11 : Reg) ↦ᵣ len) **
+      ((.x1 : Reg) ↦ᵣ ret) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+      bytesRegion ptr xs)
+    (by pcf) hli
+  have hstation := retJoinStation_spec
+    (cond := len ≠ (1 : Word))
+    (PT := ((.x11 : Reg) ↦ᵣ len) ** ((.x5 : Reg) ↦ᵣ (1 : Word)) **
+      (((.x10 : Reg) ↦ᵣ ptr) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+        bytesRegion ptr xs))
+    (PF := ((.x11 : Reg) ↦ᵣ len) ** ((.x5 : Reg) ↦ᵣ (1 : Word)) **
+      (((.x10 : Reg) ↦ᵣ ptr) ** ((.x1 : Reg) ↦ᵣ ret) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+        bytesRegion ptr xs))
+    hbr
+    (fun h hq => by xperm_hyp hq)
+    (fun h hq => by
+      have hq1 : (⌜len = (1 : Word)⌝ **
+          (((.x11 : Reg) ↦ᵣ len) ** ((.x5 : Reg) ↦ᵣ (1 : Word)) **
+           ((.x10 : Reg) ↦ᵣ ptr) ** ((.x1 : Reg) ↦ᵣ ret) **
+           ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+           ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+           bytesRegion ptr xs)) h := by
+        xperm_hyp hq
+      obtain ⟨he, hrest⟩ := (sepConj_pure_left h).1 hq1
+      exact (sepConj_pure_left h).2 ⟨fun hn => hn he, hrest⟩)
+    (fun hne => hne1 hne)
+    (fun hnn => heq1 (not_not.mp hnn))
+  have hall := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hliF hstation
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun h hq => by
+      unfold rbsPost at hq
+      xperm_hyp hq)
+    (cpsTripleWithin_mono_nSteps (by omega) hall)
+
+end Routine
+
+#print axioms rlpBytesEncodedSize_spec
+
+end RlpBytesEncodedSizeSAsm
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/TxPubkey.lean
+++ b/EvmAsm/Codegen/Programs/TxPubkey.lean
@@ -865,6 +865,7 @@ def ziskTxPubkeyEcrecoverStageMaterialPrologue : String :=
   "  j .Ltpes_probe_done\n" ++
   txTypeDispatchFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
+  rlpWalkHelpersClosure ++ "\n" ++
   rlpEncodeUintBeFunction ++ "\n" ++
   rlpEncodeListPrefixFunction ++ "\n" ++
   rlpListTruncateToNFieldsFunction ++ "\n" ++
@@ -905,6 +906,7 @@ def ziskTxPubkeySignatureMaterialPrologue : String :=
   "  j .Ltps_pdone\n" ++
   txTypeDispatchFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
+  rlpWalkHelpersClosure ++ "\n" ++
   rlpEncodeUintBeFunction ++ "\n" ++
   rlpEncodeListPrefixFunction ++ "\n" ++
   rlpListTruncateToNFieldsFunction ++ "\n" ++
@@ -1020,6 +1022,7 @@ def ziskTxPubkeyRecoverRawStatusPrologue : String :=
   "  j .Ltprrs_pdone\n" ++
   txTypeDispatchFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
+  rlpWalkHelpersClosure ++ "\n" ++
   rlpEncodeUintBeFunction ++ "\n" ++
   rlpEncodeListPrefixFunction ++ "\n" ++
   rlpListTruncateToNFieldsFunction ++ "\n" ++
@@ -1101,6 +1104,7 @@ def ziskTxPubkeyPublicKeyMatchesStatusPrologue : String :=
   "  j .Ltpms_pdone\n" ++
   txTypeDispatchFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
+  rlpWalkHelpersClosure ++ "\n" ++
   rlpEncodeUintBeFunction ++ "\n" ++
   rlpEncodeListPrefixFunction ++ "\n" ++
   rlpListTruncateToNFieldsFunction ++ "\n" ++

--- a/EvmAsm/Stateless/SSZ/HashTreeRoot/ZeroHashes.lean
+++ b/EvmAsm/Stateless/SSZ/HashTreeRoot/ZeroHashes.lean
@@ -22,8 +22,9 @@
 
   See the SSZ spec at
   https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#merkleization
-  and `compute_zero_hashes` in
-  `execution-specs/src/ethereum/forks/amsterdam/_serialize.py`.
+  The pinned execution-specs tree does not expose a fork-local helper for this
+  table; the construction above is the SSZ merkleization rule.  See the
+  consensus-specs reference linked above.
 
   ## Layout
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -3296,7 +3296,14 @@ prime regions (`beBytesToNat` `#guard`-pinned to the true primes),
 SYMBOLIC `GuestAddrs` bases per 6agnq, spec directly over the emitted
 `bnfLtP_prog`/`blsgLtP_prog` — byte-transparent, no A/B.  GENUINE post
 `a0 = if beBytesToNat in < p then 1 else 0`; input and const regions
-untouched.  Classical-3.
+untouched.  Classical-3.  Same-session siblings **`p256_lt_be`** (bead
+`.58.2.7`, `P256LtBeSAsm.lean` — two caller buffers, no `la`; resolves
+the `.58.2.7.1` "return-tail two-break loop" blocker: the kit already
+composes it) and **`blsk_lt_be`** (bead `.58.4.5`,
+`Bls12KzgLtBeSAsm.lean` — the family's first DATA-DEPENDENT trip count:
+`a2 = len` is a spec parameter, `twoBreakRetLoop_spec` at `N := len`,
+bound `len * 9 + 8`); both genuine `a0 = if as < bs then 1 else 0`
+posts, byte-transparent, classical-3.
 Indirect calls landed
 (`Stmt.callReg`, bead evm-asm-4ch8f.4): `jalr ra, rs, 0` against a
 finite handle table — `.pre` VC = register pins some handle's entry

--- a/PLAN.md
+++ b/PLAN.md
@@ -3086,6 +3086,15 @@ bBE) c₀ m₀` (`(a·b+c₀) mod m₀`, `c₀`/`m₀` the staged addend/modulus
 framed.  Both converters (`Bn254FieldConvSAsm`) retrofitted with ambient-`A`
 pinning (`A = empAssertion`) to satisfy `Fn.retSpecFlat`'s side condition.
 Classical-3.
+Acceptance consumer `bnf_add_mod_p`
+(`Codegen/Programs/Bn254FieldAddModPSAsm.lean`, byte-transparent
+`abiFrameProg` rfl tie, no A/B): mirrors the BN254 mul caller over the
+wider 272-byte LE arena and `bnf_add_params` block `{a, one, b, p, d}`.
+The two converter calls stage external BE inputs into `_a` and `_b`, CSR-2050
+computes `_d = Accel.arith256Mod a one b p`, and `bnf_le_to_be` writes the
+external BE output.  Genuine post pins the output decode to that semantic
+result while restoring `sp`/`ra`/`s0`/`s1` and preserving all non-written
+arena subwindows.  Classical-3.
 **Two-break writable-output combinator + `u256_lt_be` landed** (branch
 `feat/two-break-writable-lt`, bead evm-asm-i177q; porting-agent feedback —
 `retWhileBreak` has one mid-loop return break, `while2BreakJoin`

--- a/docs/agents/specref-v050-audit.md
+++ b/docs/agents/specref-v050-audit.md
@@ -1,0 +1,83 @@
+# SpecRef v0.5.0 audit
+
+Scope audit for `evm-asm-n9rtz`, against execution-specs `bd8c673`
+(`tests-zkevm@v0.5.0`).  The baseline is `tests-zkevm@v0.4.0`
+(`a0c182656`).  This is a classification document, not a porting claim.
+
+## Result
+
+The diff changes 27 Amsterdam Python files (+1157/-834).  The current Lean
+SpecRef deliberately models the stateless input/output shell, SSZ, witness
+decoding helpers, and a small runtime helper module; it cuts at
+`execute_new_payload_request`.  The agreed direction is to replace that cut
+only along the concrete call graph needed by `run_stateless_guest`: this is a
+vertical-slice reference model, not a general-purpose Lean EVM or a port of
+every Amsterdam VM API.  EIP-8037 and VM deltas reachable from that call graph
+are real reference-model gaps; unrelated generic API reshaping is not work.
+
+Two direct v0.5.0 changes were already present on `main` before this audit:
+
+| Source delta | Current status | Evidence |
+|---|---|---|
+| `ProtocolFork`: remove Constantinople/ConstantinopleFix/BPO3–BPO5; add StPetersburg | unchanged — already v0.5.0-correct | `9d5ee19a8` updated `Types.lean` and the enum ordering |
+| payload `block_access_list` cap becomes `MAX_BYTES_PER_TRANSACTION` | unchanged — already v0.5.0-correct | `9d4f3f995` updated `Ssz.lean` |
+
+## Per-Module Delta Table
+
+| Lean module | v0.5.0 sources examined | Classification | Required follow-up |
+|---|---|---|---|
+| `Guest.lean` | `stateless_guest.py` | needs-update | Add `_default_failed_stateless_output`; make `run_stateless_guest` catch decoding errors and serialize the sentinel result rather than return `SpecError`. |
+| `Stateless.lean` | `stateless.py` | unchanged | The diff is `@final` and documentation only; its only semantic enum delta is already correct in `Types.lean`. |
+| `Types.lean` | `stateless.py`, `stateless_ssz.py` | unchanged | Current enum and the payload list cap match v0.5.0.  No new stateless shell fields were added. |
+| `Ssz.lean` | `stateless_ssz.py` | needs-update | Update `MAX_WITNESS_NODES` to `2^22`, `MAX_WITNESS_CODES` to `2^18`, `MAX_BYTES_PER_CODE` to `2^16`, `MAX_BYTES_PER_WITNESS_NODE` to `2^10`, and `MAX_PUBLIC_KEYS` to `2^15`. |
+| `SszCodec.lean` | `stateless_ssz.py` / remerkleable use | unchanged | No generic codec algorithm changed; only schemas/constants changed. |
+| `WitnessState.lean` | `witness_state.py`, `incremental_mpt.py` | new-function-to-add | v0.5.0 adds `storage_clears` to `compute_state_root_and_trie_changes`; that method is currently behind the execution seam and has no Lean port. |
+| `Runtime.lean` | `vm/runtime.py` | unchanged | `vm/runtime.py` is absent from the v0.4.0→v0.5.0 diff. |
+| `Crypto.lean` | crypto helpers | unchanged | No mapped crypto helper changed. |
+
+`Secp256k1Recover.lean` is additionally present under `SpecRef/`, but is not in
+the assigned eight-module source map and none of its mapped source files changed
+in this diff.
+
+## Execution-Seam Deltas (New Surface Required)
+
+The following changed source is not currently represented by a SpecRef function.
+It cannot be called “unchanged”; faithful v0.5.0 coverage needs a new execution
+reference-model layer or a replacement of the current seam.
+
+| Source families | v0.5.0 delta | Classification |
+|---|---|---|
+| `vm/gas.py`, `fork.py`, `transactions.py`, `blocks.py` | EIP-8037 two-dimensional regular/state gas, `StateGasCosts`, `TX_MAX_GAS_LIMIT`, settlement/check-transaction changes, receipt gas and header `gas_used = max(regular, state)` | new-function-to-add when reached by the guest slice |
+| `state_tracker.py`, `witness_state.py`, `incremental_mpt.py`, `block_access_lists.py` | pre-state reads, account deployability, preserving-balance clear, storage clear propagation, BAL state changes | new-function-to-add when reached by the guest slice |
+| `vm/__init__.py`, `vm/interpreter.py`, `vm/instructions/{system,storage,stack,environment,keccak,log}.py` | state-gas accounting/refill, full-U256 copy guards and RETURNDATACOPY OOB behavior, create/collision handling, PREVRANDAO/beacon-root behavior, SELFDESTRUCT transfer-only behavior | new-function-to-add when reached by the guest slice |
+| `vm/eoa_delegation.py` | EIP-7702 authorization/delegation changes, including one-hop execution | new-function-to-add when reached by the guest slice |
+| `requests.py`, `execution_engine/{requests,types}.py`, BLS files, package/doc-only changes | request typing/cleanup and BLS call-site signature adjustments | removed/not currently ported unless shown reachable |
+
+## EIP-8037 Gap
+
+SpecRef currently has only payload/header scalar gas fields and the three blob
+schedule constants.  It has no `Evm`, transaction, receipt, gas-accounting, or
+state-transition model.  Therefore it models none of EIP-8037: separate regular
+and state gas, `block_state_gas_used`, `TX_MAX_GAS_LIMIT`,
+`StateGasCosts.NEW_ACCOUNT`, transaction inclusion and settlement, or the
+Amsterdam `GasCosts` table.
+
+The modeling decision is now resolved: implement the smallest concrete
+execution slice that `run_stateless_guest` calls, including reachable EIP-8037
+and VM behavior, and leave unrelated generic VM APIs out of SpecRef.  The
+children must demonstrate reachability from the guest call graph before adding a
+source function.
+
+## Citation Audit
+
+`scripts/check-spec-refs.sh` initially reported one allowlisted stale path:
+`EvmAsm/Stateless/SSZ/HashTreeRoot/ZeroHashes.lean` cited the removed
+`amsterdam/_serialize.py`.  The citation was removed in favor of the canonical
+consensus SSZ-merkleization reference; the allowlist is now empty.
+
+## Child Work
+
+The child beads created under `evm-asm-n9rtz` correspond to the direct Guest and
+SSZ ports, witness-state storage-clear support, the EIP-8037 guest slice, and
+the remaining reachable VM/state-transition surface.  Their descriptions name
+the exact v0.5.0 source families and acceptance criteria.

--- a/scripts/spec-refs-allow.txt
+++ b/scripts/spec-refs-allow.txt
@@ -4,9 +4,3 @@
 # with a named owner-fix (update the docstring to the pinned rev's real
 # location, or bump the submodule), and the goal is an empty file.
 # Entries are cited paths relative to the execution-specs submodule root.
-
-# EvmAsm/Stateless/SSZ/HashTreeRoot/ZeroHashes.lean cites `compute_zero_hashes`
-# in amsterdam/_serialize.py; neither the file nor the symbol exists at pinned
-# rev bd8c673 (the function appears to come from a different execution-specs
-# revision). Fix = repoint the docstring or bump the pin.
-src/ethereum/forks/amsterdam/_serialize.py


### PR DESCRIPTION
Batch-merge of #10083 #10099 #10100 #10105 #10107 #10150 #10152 (all author pirapira).

Verified locally: `lake build` (full, after every merge step) + all `scripts/check-*.sh` green, including `check-region-map.sh`.

#10083 built clean as-is (its own branch had been rebased with symbolic `GuestAddrs` references since the last check). #10099, #10100, #10105 each hit the same stale-`#guard`-sanity-check pattern as #10098 (redundant literal address pin, symbol used everywhere else in the proof) — dropped the guard following #10103's established pattern, verified each individually before continuing. #10107, #10150, #10152 merged clean.

Not included: #10148 (rlpwalk account field helpers) — combining it here shifts the guest layout enough to break #10083's proof body (which still bakes some addresses as raw literals rather than symbols), so it's held back for its own pass.