### PR TITLE
fix(eest): isolate parallel worker result files

### DIFF
--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -1101,7 +1101,11 @@ run_case() {
   local out="$RUN_DIR/$label.output"
   local log="$RUN_DIR/$label.emu.log"
   local result="$RUN_DIR/$label.result.tsv"
-  local tmp_result="$result.tmp.$$"
+  # `run_case` runs in background workers.  `$$` remains the parent shell's
+  # PID in those workers, so it races when several cases finish together.
+  # `BASHPID` is unique to each worker subshell and keeps the final rename
+  # atomic without letting one case publish another case's result.
+  local tmp_result="$result.tmp.$BASHPID"
   local actual_hex run_steps
 
   run_steps="$STEPS"


### PR DESCRIPTION
Fixes the EEST runner's per-case temporary result path. Background bash workers share `1373619`; using `BASHPID` prevents concurrent workers from racing the atomic result-file publish.\n\nValidation: `bash -n scripts/codegen-eest-stateless-check.sh`; randomized EIP-8037 Spike run.