### PR TITLE
feat(specref): incremental-MPT write side + post-state root (s1d19.4)

### DIFF
--- a/EvmAsm/Stateless/SpecRef.lean
+++ b/EvmAsm/Stateless/SpecRef.lean
@@ -20,6 +20,10 @@
                      + helpers): MPT witness authentication (obligation #7)
   * `WitnessReads`  — `witness_state.py` `WitnessState` read methods
                      (`get_account_optional`/`get_storage`/`get_code`/…)
+  * `IncrementalMptWrite` — `incremental_mpt.py` write side (`mpt_set`/
+                     `mpt_root`/`build_mpt` + node encoding)
+  * `WitnessStateRoot` — `witness_state.py`
+                     `compute_state_root_and_trie_changes` (obligation #8)
   * `Stateless`    — `stateless.py` (7 defs) + the execution seam
   * `Guest`        — `stateless_guest.py` (3 defs), the top-level shell
 -/
@@ -33,5 +37,7 @@ import EvmAsm.Stateless.SpecRef.Ssz
 import EvmAsm.Stateless.SpecRef.WitnessState
 import EvmAsm.Stateless.SpecRef.IncrementalMpt
 import EvmAsm.Stateless.SpecRef.WitnessReads
+import EvmAsm.Stateless.SpecRef.IncrementalMptWrite
+import EvmAsm.Stateless.SpecRef.WitnessStateRoot
 import EvmAsm.Stateless.SpecRef.Stateless
 import EvmAsm.Stateless.SpecRef.Guest

--- a/EvmAsm/Stateless/SpecRef/IncrementalMptWrite.lean
+++ b/EvmAsm/Stateless/SpecRef/IncrementalMptWrite.lean
@@ -1,0 +1,678 @@
+/-
+  EvmAsm.Stateless.SpecRef.IncrementalMptWrite
+
+  Port of the write side of
+  `execution-specs/src/ethereum/forks/amsterdam/incremental_mpt.py`
+  (`@tests-zkevm@v0.5.0`, `bd8c673`) — bead `evm-asm-s1d19.4`,
+  obligation #8 (post-state root):
+
+  * `IncrementalMPT` (class `IncrementalMPT`) — here `IncrementalMpt`
+  * `_build_mutable_tree`, `build_mpt` (functions of the same names)
+  * `_encode_mutable_node`, `_encode_mutable_node_to_extended`,
+    `_compute_node_hash_and_rlp` (functions of the same names)
+  * `mpt_get` (function `mpt_get`) + `_mpt_traverse_for_witness`
+  * `mpt_set` (function `mpt_set`) + `_mpt_insert_node`,
+    `_insert_into_leaf`, `_create_branch_from_two_leaves`,
+    `_insert_into_extension`, `_split_extension`, `_insert_into_branch`
+  * `_mpt_delete_node`, `_delete_from_extension`, `_delete_from_branch`,
+    `_collapse_branch` (functions of the same names)
+  * `mpt_root` (function `mpt_root`)
+
+  plus the `ethereum/merkle_patricia_trie.py` helpers they consume:
+  `common_prefix_length`, `nibble_list_to_compact`, `encode_account`,
+  `encode_node`, `_prepare_data`
+  (all cited from `execution-specs/src/ethereum/merkle_patricia_trie.py`).
+
+  ## Modeling notes
+
+  * **Immutable tree, pure functions.**  The Python nodes are mutated in
+    place and carry `_hash`/`_rlp` memo caches plus a `_dirty` flag; the
+    caches only memoize the deterministic keccak/RLP encoding of the
+    current node content (`_invalidate_hash` clears them on every write
+    path), so recomputation is observationally equal and this port drops
+    all three fields, returning fresh nodes instead of mutating.
+  * **`_dirty` / identity checks.**  `_delete_from_extension` /
+    `_delete_from_branch` skip the update (and the branch collapse) when
+    the recursive delete returns the same, un-dirtied child object.  A
+    content-unchanged subtree makes the parent update a no-op, and
+    `_collapse_branch` on an unchanged branch is a no-op too (a
+    well-formed branch keeps ≥ 2 occupied entries — enforced by the
+    witness decoder and preserved by every operation), so the port
+    always applies the update + collapse.  The flag's only other
+    consumer is witness *generation* bookkeeping (`_record_witness`
+    dedup), which is not modeled — except its `HashedNode` assert, see
+    next note.
+  * **Every Python `assert`/`raise` on the write path is a rejection**
+    (`SpecError.mptWriteError`), never a wrong value: touching a
+    `HashedNode` on an insert/delete path (`_invalidate_hash`),
+    inline-encoding a `HashedNode` (`_encode_mutable_node`), collapsing
+    a branch onto a `HashedNode` child (`_record_witness` inside
+    `_collapse_branch`), `_split_extension`'s collision assert,
+    `mpt_set`/`_prepare_data` on an unencodable value.
+  * **Fuel.**  Tree-walking recursion (insert/delete/traverse/build) is
+    fueled by the nibble-key length: every recursive call strictly
+    increases `level` (extension segments are non-empty in well-formed
+    tries), so `key.length + 1` never exhausts on them; exhaustion —
+    reachable only through a malformed (empty-segment) decoded node —
+    is a rejection.  Encoding recursion is fueled by `sizeOf node`,
+    a strict upper bound on tree depth, so its exhaustion branch is
+    unreachable.
+  * **Values.**  The Python `V` is dynamically dispatched by
+    `encode_node` (`Account` / raw `Bytes` / RLP-encodable `U256`);
+    here it is the explicit sum `MptValue`, with `Option` for the
+    Python `None` (the state trie's `default`).  `_data` stores only
+    non-default values (Python deletes the key when the default is
+    stored), so it is `List (Bytes × MptValue)` with dict semantics
+    (update-in-place keeps position, new keys append).
+  * `witness.accessed_nodes` (witness *generation*) is not modeled; on
+    the verification path nothing reads it.  Its `HashedNode` asserts
+    are kept where reachable (see above).
+-/
+
+import EvmAsm.Stateless.SpecRef.IncrementalMpt
+
+namespace EvmAsm.Stateless.SpecRef
+
+open EvmAsm.EL.RLP (RLPItem)
+
+private def encR (i : RLPItem) : Bytes := EvmAsm.EL.RLP.encode i
+
+/-! ## `merkle_patricia_trie.py` helpers
+
+`execution-specs/src/ethereum/merkle_patricia_trie.py`,
+functions `common_prefix_length`, `nibble_list_to_compact`,
+`encode_account`, `encode_node`, `_prepare_data`.
+(`bytes_to_nibble_list` is `keyToNibbles` in `WitnessState.lean`.) -/
+
+/-- Length of the longest common prefix of two nibble sequences. -/
+def common_prefix_length (a b : Bytes) : Nat :=
+  ((a.zip b).takeWhile (fun p => p.1 == p.2)).length
+
+/-- Hex-prefix (compact) encoding of a nibble list; inverse of
+    `compact_to_nibbles`. -/
+def nibble_list_to_compact (x : Bytes) (is_leaf : Bool) : Bytes :=
+  let flag : Nat := if is_leaf then 2 else 0
+  let packPairs : List (BitVec 8) → Bytes := fun nibs =>
+    (List.range (nibs.length / 2)).map (fun i =>
+      BitVec.ofNat 8 (16 * (nibs.getD (2*i) 0).toNat + (nibs.getD (2*i+1) 0).toNat))
+  if x.length % 2 == 0 then
+    BitVec.ofNat 8 (16 * flag) :: packPairs x
+  else
+    BitVec.ofNat 8 (16 * (flag + 1) + (x.getD 0 0).toNat) :: packPairs (x.drop 1)
+
+/-- RLP of a `Uint`/`U256` scalar: minimal big-endian bytes. -/
+private def rlpScalar (n : Nat) : Bytes := EvmAsm.EL.RLP.Nat.toBytesBE n
+
+/-- `encode_account(raw_account_data, storage_root)`:
+    `rlp.encode((nonce, balance, storage_root, code_hash))`. -/
+def encode_account (a : Account) (storage_root : Bytes) : Bytes :=
+  encR (.list [.bytes (rlpScalar a.nonce), .bytes (rlpScalar a.balance),
+               .bytes storage_root, .bytes a.codeHash])
+
+/-! ## Trie values
+
+The Python `V` type parameter, made explicit: `encode_node` dispatches on
+`Account` (needs `storage_root`) / raw `Bytes` (unchanged) / anything else
+(RLP-encoded — here `U256` scalars, the only other instantiation on the
+stateless-guest path). -/
+
+/-- A trie value: storage `U256`, state-trie `Account`, or raw bytes
+    (transaction/receipt/withdrawal tries). -/
+inductive MptValue where
+  | u256 (v : U256)
+  | account (a : Account)
+  | bytes (b : Bytes)
+  deriving Repr, BEq
+
+/-- `encode_node(node, storage_root)` on an `MptValue`; the Python
+    `None` (`Option.none`) is unencodable (`AssertionError`). -/
+def encode_mpt_value (key : Bytes) (value : Option MptValue)
+    (get_storage_root : Option (Bytes → Root)) : Except SpecError Bytes :=
+  match value with
+  | some (.account a) =>
+      match get_storage_root with
+      | some gsr => pure (encode_account a (gsr key))
+      | none => throw (.mptWriteError "encode_node: Account requires storage_root")
+  | some (.bytes b) => pure b
+  | some (.u256 v) => pure (encR (.bytes (rlpScalar v)))
+  | none => throw (.mptWriteError "cannot encode `None`")
+
+/-! ## `IncrementalMPT` (class `IncrementalMPT`) -/
+
+/-- The incremental MPT: `secured`/`default`/`root_node`/`_data`.  The
+    `witness` field (witness generation) is not modeled. -/
+structure IncrementalMpt where
+  secured : Bool
+  default : Option MptValue
+  rootNode : Option MutableNode
+  data : List (Bytes × MptValue) := []
+
+/-- Dict write on the `_data` assoc list: update keeps position, new key
+    appends (Python dict semantics). -/
+private def dataSet (data : List (Bytes × MptValue)) (key : Bytes) (v : MptValue) :
+    List (Bytes × MptValue) :=
+  if data.any (·.1 == key) then
+    data.map (fun p => if p.1 == key then (key, v) else p)
+  else data ++ [(key, v)]
+
+/-- `decode_witness_to_mpt` (function `decode_witness_to_mpt`) returning
+    the full `IncrementalMPT` record (the `s1d19.1` port returns just the
+    root node; the write side needs `secured`/`default`/`_data = {}`). -/
+def decode_witness_mpt (nodeDb : List (Hash32 × Bytes)) (root_hash : Root)
+    (secured : Bool) (default : Option MptValue) :
+    Except SpecError IncrementalMpt := do
+  pure { secured, default, rootNode := ← decode_witness_to_mpt nodeDb root_hash }
+
+/-! ## `_build_mutable_tree` / `build_mpt` -/
+
+/-- `_build_mutable_tree(obj, level)`: patricialize a nibble-keyed mapping
+    into mutable nodes.  Fueled by the maximal key length (each recursion
+    strictly increases `level`; see header). -/
+def _build_mutable_tree : Nat → List (Bytes × Bytes) → Nat →
+    Except SpecError (Option MutableNode)
+  | _, [], _ => pure none
+  | fuel, obj@((arbitrary_key, arbitrary_value) :: _), level => do
+    if obj.length == 1 then
+      pure (some (.leaf (arbitrary_key.drop level) arbitrary_value))
+    else match fuel with
+    | 0 => throw (.mptWriteError "_build_mutable_tree: fuel exhausted")
+    | fuel + 1 =>
+      let substring := arbitrary_key.drop level
+      let prefix_length := obj.foldl (init := substring.length) (fun pl (key, _) =>
+        min pl (common_prefix_length substring (key.drop level)))
+      if prefix_length > 0 then
+        let pfx := (arbitrary_key.drop level).take prefix_length
+        let child ← _build_mutable_tree fuel obj (level + prefix_length)
+        match child with
+        | some c => pure (some (.extension pfx c))
+        | none => throw (.mptWriteError "_build_mutable_tree: empty extension child")
+      else do
+        let value := (obj.find? (fun p => p.1.length == level)).map (·.2) |>.getD []
+        let children ← (List.range 16).mapM (fun k =>
+          _build_mutable_tree fuel
+            (obj.filter (fun p => p.1.length != level && (p.1.getD level 0).toNat == k))
+            (level + 1))
+        pure (some (.branch children value))
+
+/-- `_prepare_data(data, secured, get_storage_root)`: encode values and
+    nibblize (secured → keccak) keys. -/
+def _prepare_data (data : List (Bytes × MptValue)) (secured : Bool)
+    (get_storage_root : Option (Bytes → Root)) :
+    Except SpecError (List (Bytes × Bytes)) :=
+  data.mapM (fun (preimage, value) => do
+    let encoded ← encode_mpt_value preimage (some value) get_storage_root
+    if encoded.isEmpty then
+      throw (.mptWriteError "_prepare_data: empty encoded value")
+    let key := if secured then keccak256 preimage else preimage
+    pure (keyToNibbles key, encoded))
+
+/-- `build_mpt(data, secured, default, get_storage_root)`. -/
+def build_mpt (data : List (Bytes × MptValue)) (secured : Bool)
+    (default : Option MptValue)
+    (get_storage_root : Option (Bytes → Root) := none) :
+    Except SpecError IncrementalMpt := do
+  let prepared ← _prepare_data data secured get_storage_root
+  let maxKeyLen := prepared.foldl (fun m p => max m p.1.length) 0
+  let root ← _build_mutable_tree (maxKeyLen + 1) prepared 0
+  pure { secured, default, rootNode := root, data }
+
+/-! ## Node encoding (`_encode_mutable_node`,
+`_encode_mutable_node_to_extended`, `_compute_node_hash_and_rlp`)
+
+Structural (well-founded) recursion over the tree; memo-cache fast paths
+are dropped as recompute-equal; a `HashedNode` embeds as its hash. -/
+
+mutual
+
+/-- `_encode_mutable_node(node)`: the RLP `Extended` form. -/
+def _encode_mutable_node : Option MutableNode → Except SpecError RLPItem
+  | none => pure (.bytes [])
+  | some (.hashed _) => throw (.mptWriteError "HashedNode cannot be inline-encoded")
+  | some (.leaf restOfKey value) =>
+      pure (.list [.bytes (nibble_list_to_compact restOfKey true), .bytes value])
+  | some (.extension keySegment child) => do
+      let childEncoded ← _encode_mutable_node_to_extended (some child)
+      pure (.list [.bytes (nibble_list_to_compact keySegment false), childEncoded])
+  | some (.branch children value) => do
+      let childrenEncoded ← encodeChildren children
+      pure (.list (childrenEncoded ++ [.bytes value]))
+termination_by n => (sizeOf n, 0)
+
+/-- The 16 branch children, each via `_encode_mutable_node_to_extended`. -/
+def encodeChildren : List (Option MutableNode) → Except SpecError (List RLPItem)
+  | [] => pure []
+  | child :: rest => do
+      pure ((← _encode_mutable_node_to_extended child) :: (← encodeChildren rest))
+termination_by cs => (sizeOf cs, 0)
+
+/-- `_encode_mutable_node_to_extended(node)`: hash if RLP ≥ 32 bytes,
+    else the unencoded form; a `HashedNode` is its hash. -/
+def _encode_mutable_node_to_extended : Option MutableNode →
+    Except SpecError RLPItem
+  | none => pure (.bytes [])
+  | some (.hashed h) => pure (.bytes h)
+  | some node => do
+      let unencoded ← _encode_mutable_node (some node)
+      let encoded := encR unencoded
+      if encoded.length < 32 then pure unencoded
+      else pure (.bytes (keccak256 encoded))
+termination_by n => (sizeOf n, 1)
+
+end
+
+/-- `_compute_node_hash_and_rlp(node)`: `(hash?, rlp)`, hash `none` for
+    < 32-byte encodings.  (`HashedNode` is an assert.) -/
+def _compute_node_hash_and_rlp (node : Option MutableNode) :
+    Except SpecError (Option Bytes × Bytes) := do
+  match node with
+  | none => pure (none, [])
+  | some (.hashed _) =>
+      throw (.mptWriteError "HashedNode cannot appear in _compute_node_hash_and_rlp")
+  | some _ =>
+      let encoded := encR (← _encode_mutable_node node)
+      if encoded.length ≥ 32 then pure (some (keccak256 encoded), encoded)
+      else pure (none, encoded)
+
+/-! ## `mpt_get` (function `mpt_get`) -/
+
+/-- `_mpt_traverse_for_witness(mpt, node, key, level)`: witness-recording
+    walk; the recording itself is unmodeled, but visiting a `HashedNode`
+    is `_record_witness`'s assert → rejection. -/
+def _mpt_traverse_for_witness : Nat → Option MutableNode → Bytes → Nat →
+    Except SpecError Unit
+  | _, none, _, _ => pure ()
+  | 0, some _, _, _ => throw (.mptWriteError "_mpt_traverse_for_witness: fuel exhausted")
+  | _, some (.hashed _), _, _ =>
+      throw (.mptWriteError "HashedNode cannot be witnessed")
+  | _ + 1, some (.leaf ..), _, _ => pure ()
+  | fuel + 1, some (.extension keySegment child), key, level =>
+      if (key.drop level).take keySegment.length == keySegment then
+        _mpt_traverse_for_witness fuel (some child) key (level + keySegment.length)
+      else pure ()
+  | fuel + 1, some (.branch children _), key, level =>
+      if level < key.length then
+        _mpt_traverse_for_witness fuel
+          (children.getD (key.getD level 0).toNat none) key (level + 1)
+      else pure ()
+
+/-- `mpt_get(mpt, key)`: the value from `_data` (default when absent);
+    the witness traversal can reject on `HashedNode` contact. -/
+def mpt_get (mpt : IncrementalMpt) (key : Bytes) :
+    Except SpecError (Option MptValue) := do
+  let value := ((mpt.data.find? (·.1 == key)).map (fun p => some p.2)).getD mpt.default
+  let nibble_key := keyToNibbles (if mpt.secured then keccak256 key else key)
+  _mpt_traverse_for_witness (nibble_key.length + 1) mpt.rootNode nibble_key 0
+  pure value
+
+/-! ## Insertion (`_mpt_insert_node` and helpers) -/
+
+/-- `_create_branch_from_two_leaves(key1, value1, key2, value2)`. -/
+def _create_branch_from_two_leaves (key1 : Bytes) (value1 : Bytes)
+    (key2 : Bytes) (value2 : Bytes) : MutableNode :=
+  let place := fun (children : List (Option MutableNode)) (value : Bytes)
+      (k : Bytes) (v : Bytes) =>
+    match k with
+    | [] => (children, v)
+    | idx :: rest =>
+        (children.set idx.toNat (some (.leaf rest v)), value)
+  let (children, value) := place (List.replicate 16 none) [] key1 value1
+  let (children, value) := place children value key2 value2
+  .branch children value
+
+/-- `_split_extension(node, remaining_key, value, prefix_len)`. -/
+def _split_extension (segment : Bytes) (child : MutableNode)
+    (remaining_key : Bytes) (value : Bytes) (prefix_len : Nat) :
+    Except SpecError MutableNode := do
+  let segment_after_prefix := segment.drop prefix_len
+  let children : List (Option MutableNode) :=
+    match segment_after_prefix with
+    | [] => List.replicate 16 none
+    | idx :: [] => (List.replicate 16 none).set idx.toNat (some child)
+    | idx :: rest => (List.replicate 16 none).set idx.toNat (some (.extension rest child))
+  let key_after_prefix := remaining_key.drop prefix_len
+  match key_after_prefix with
+  | [] => pure (.branch children value)
+  | idx :: rest =>
+      match children.getD idx.toNat none with
+      | none => pure (.branch (children.set idx.toNat (some (.leaf rest value))) [])
+      | some _ => throw (.mptWriteError "Unexpected collision during split")
+
+mutual
+
+/-- `_mpt_insert_node(mpt, node, key, value, level)`.  `_invalidate_hash`
+    on a `HashedNode` is the assert → rejection; on other nodes it only
+    clears the unmodeled memo caches. -/
+def _mpt_insert_node (fuel : Nat) (node : Option MutableNode) (key : Bytes)
+    (value : Bytes) (level : Nat) : Except SpecError MutableNode := do
+  match node with
+  | none => pure (.leaf (key.drop level) value)
+  | some (.hashed _) => throw (.mptWriteError "HashedNode cannot be invalidated")
+  | some node =>
+    match fuel with
+    | 0 => throw (.mptWriteError "_mpt_insert_node: fuel exhausted")
+    | fuel + 1 =>
+      match node with
+      | .leaf restOfKey leafValue =>
+          _insert_into_leaf restOfKey leafValue key value level
+      | .extension keySegment child =>
+          _insert_into_extension fuel keySegment child key value level
+      | .branch children branchValue =>
+          _insert_into_branch fuel children branchValue key value level
+      | .hashed _ => throw (.mptWriteError "HashedNode cannot be invalidated")
+
+/-- `_insert_into_leaf(mpt, node, key, value, level)`. -/
+def _insert_into_leaf (existing_key : Bytes) (existing_value : Bytes)
+    (key : Bytes) (value : Bytes) (level : Nat) : Except SpecError MutableNode := do
+  let remaining_key := key.drop level
+  if existing_key == remaining_key then
+    pure (.leaf existing_key value)
+  else
+    let prefix_len := common_prefix_length existing_key remaining_key
+    if prefix_len > 0 then
+      let branch := _create_branch_from_two_leaves
+        (existing_key.drop prefix_len) existing_value
+        (remaining_key.drop prefix_len) value
+      pure (.extension (existing_key.take prefix_len) branch)
+    else
+      pure (_create_branch_from_two_leaves existing_key existing_value
+        remaining_key value)
+
+/-- `_insert_into_extension(mpt, node, key, value, level)`. -/
+def _insert_into_extension (fuel : Nat) (segment : Bytes) (child : MutableNode)
+    (key : Bytes) (value : Bytes) (level : Nat) : Except SpecError MutableNode := do
+  let remaining_key := key.drop level
+  let prefix_len := common_prefix_length segment remaining_key
+  if prefix_len == segment.length then do
+    let child' ← _mpt_insert_node fuel (some child) key value (level + prefix_len)
+    pure (.extension segment child')
+  else if prefix_len > 0 then do
+    let new_child ← _split_extension segment child remaining_key value prefix_len
+    pure (.extension (segment.take prefix_len) new_child)
+  else
+    _split_extension segment child remaining_key value 0
+
+/-- `_insert_into_branch(mpt, node, key, value, level)`. -/
+def _insert_into_branch (fuel : Nat) (children : List (Option MutableNode))
+    (branchValue : Bytes) (key : Bytes) (value : Bytes) (level : Nat) :
+    Except SpecError MutableNode := do
+  match key.drop level with
+  | [] => pure (.branch children value)
+  | idx :: _ =>
+      let child' ← _mpt_insert_node fuel (children.getD idx.toNat none)
+        key value (level + 1)
+      pure (.branch (children.set idx.toNat (some child')) branchValue)
+
+end
+
+/-! ## Deletion (`_mpt_delete_node` and helpers) -/
+
+/-- `_collapse_branch(mpt, node)`: collapse a single-child branch.  The
+    `_record_witness` call on the surviving child asserts it is not a
+    `HashedNode` → rejection. -/
+def _collapse_branch (children : List (Option MutableNode)) (value : Bytes) :
+    Except SpecError MutableNode := do
+  let non_empty := (children.zipIdx.filterMap (fun (c, i) => c.map ((i, ·))))
+  if non_empty.isEmpty && value.isEmpty then
+    throw (.mptWriteError "_collapse_branch: empty branch")
+  if non_empty.length == 1 && value.isEmpty then
+    match non_empty with
+    | [(idx, child)] =>
+        let nibble : BitVec 8 := BitVec.ofNat 8 idx
+        match child with
+        | .leaf restOfKey v => pure (.leaf (nibble :: restOfKey) v)
+        | .extension keySegment c => pure (.extension (nibble :: keySegment) c)
+        | .branch .. => pure (.extension [nibble] child)
+        | .hashed _ => throw (.mptWriteError "HashedNode cannot be witnessed")
+    | _ => throw (.mptWriteError "_collapse_branch: unreachable")
+  else if non_empty.isEmpty then
+    pure (.leaf [] value)
+  else
+    pure (.branch children value)
+
+mutual
+
+/-- `_mpt_delete_node(mpt, node, key, level)`. -/
+def _mpt_delete_node (fuel : Nat) (node : Option MutableNode) (key : Bytes)
+    (level : Nat) : Except SpecError (Option MutableNode) := do
+  match node with
+  | none => pure none
+  | some (.hashed _) => throw (.mptWriteError "HashedNode cannot be invalidated")
+  | some node =>
+    match fuel with
+    | 0 => throw (.mptWriteError "_mpt_delete_node: fuel exhausted")
+    | fuel + 1 =>
+      match node with
+      | .leaf restOfKey value =>
+          if restOfKey == key.drop level then pure none
+          else pure (some (.leaf restOfKey value))
+      | .extension keySegment child =>
+          _delete_from_extension fuel keySegment child key level
+      | .branch children value =>
+          _delete_from_branch fuel children value key level
+      | .hashed _ => throw (.mptWriteError "HashedNode cannot be invalidated")
+
+/-- `_delete_from_extension(mpt, node, key, level)`. -/
+def _delete_from_extension (fuel : Nat) (segment : Bytes) (child : MutableNode)
+    (key : Bytes) (level : Nat) : Except SpecError (Option MutableNode) := do
+  let remaining_key := key.drop level
+  let prefix_len := common_prefix_length segment remaining_key
+  if prefix_len < segment.length then
+    pure (some (.extension segment child))
+  else do
+    match ← _mpt_delete_node fuel (some child) key (level + segment.length) with
+    | none => pure none
+    | some (.extension childSegment grandchild) =>
+        pure (some (.extension (segment ++ childSegment) grandchild))
+    | some (.leaf restOfKey value) =>
+        pure (some (.leaf (segment ++ restOfKey) value))
+    | some new_child@(.branch ..) => pure (some (.extension segment new_child))
+    | some (.hashed _) => throw (.mptWriteError "HashedNode delete child")
+
+/-- `_delete_from_branch(mpt, node, key, level)`.  The `child_changed`
+    identity check is dropped (see the header note): the update and
+    collapse are no-ops on content-unchanged subtrees. -/
+def _delete_from_branch (fuel : Nat) (children : List (Option MutableNode))
+    (value : Bytes) (key : Bytes) (level : Nat) :
+    Except SpecError (Option MutableNode) := do
+  match key.drop level with
+  | [] =>
+      if value.isEmpty then pure (some (.branch children value))
+      else pure (some (← _collapse_branch children []))
+  | idx :: _ =>
+      let new_child ← _mpt_delete_node fuel (children.getD idx.toNat none)
+        key (level + 1)
+      pure (some (← _collapse_branch (children.set idx.toNat new_child) value))
+
+end
+
+/-! ## `mpt_set` (function `mpt_set`) -/
+
+/-- `mpt_set(mpt, key, value, get_storage_root)`: update `_data`, encode
+    the value (default → `b""` → delete), and insert/delete in the tree. -/
+def mpt_set (mpt : IncrementalMpt) (key : Bytes) (value : Option MptValue)
+    (get_storage_root : Option (Bytes → Root) := none) :
+    Except SpecError IncrementalMpt := do
+  let data :=
+    if value == mpt.default then mpt.data.filter (·.1 != key)
+    else match value with
+      | some v => dataSet mpt.data key v
+      | none => mpt.data  -- non-default `None`: unencodable, rejected below
+  let nibble_key := keyToNibbles (if mpt.secured then keccak256 key else key)
+  let encoded_value ←
+    if value == mpt.default then pure ([] : Bytes)
+    else encode_mpt_value key value get_storage_root
+  if encoded_value.isEmpty then
+    let root ← _mpt_delete_node (nibble_key.length + 1) mpt.rootNode nibble_key 0
+    pure { mpt with data, rootNode := root }
+  else
+    let root ← _mpt_insert_node (nibble_key.length + 1) mpt.rootNode nibble_key
+      encoded_value 0
+    pure { mpt with data, rootNode := some root }
+
+/-! ## `mpt_root` (function `mpt_root`) -/
+
+/-- `mpt_root(mpt)`: the root hash — `EMPTY_TRIE_ROOT` for the empty
+    trie; a bytes result of `_encode_mutable_node_to_extended` IS the
+    32-byte root (hashed or `HashedNode`); a small unencoded root is
+    hashed from its RLP. -/
+def mpt_root (mpt : IncrementalMpt) : Except SpecError Root := do
+  match mpt.rootNode with
+  | none => pure EMPTY_TRIE_ROOT
+  | some root =>
+      match ← _encode_mutable_node_to_extended (some root) with
+      | .bytes b => pure b
+      | item => pure (keccak256 (encR item))
+
+/-! ## Sanity checks
+
+Every expected root below is cross-checked against the Python spec at
+`bd8c673` (`build_mpt`/`mpt_set`/`mpt_root` executed on the submodule;
+generator script in the s1d19.4 PR description).  The `MptWriteVectors`
+namespace is shared with `WitnessStateRoot.lean`'s sanity block. -/
+
+-- nibble_list_to_compact: even/odd extension, even/odd leaf, empty leaf;
+-- round trip with compact_to_nibbles.
+#guard nibble_list_to_compact [0x0A, 0x0B] false == [0x00, 0xAB]
+#guard nibble_list_to_compact [0x0A, 0x0B, 0x0C] false == [0x1A, 0xBC]
+#guard nibble_list_to_compact [0x0A, 0x0B] true == [0x20, 0xAB]
+#guard nibble_list_to_compact [0x0B] true == [0x3B]
+#guard nibble_list_to_compact [] true == [0x20]
+#guard (compact_to_nibbles (nibble_list_to_compact [0x0A, 0x0B, 0x0C] true)).toOption
+  == some ([0x0A, 0x0B, 0x0C], true)
+
+namespace MptWriteVectors
+
+def k32 (b : BitVec 8) : Bytes := List.replicate 32 b
+
+/-- Secured `U256` storage trie: insert ×3, update, delete ×3 — the root
+    after each step, vs the Python spec. -/
+def storageRoots : Except SpecError (List Nat) := do
+  let mut m : IncrementalMpt :=
+    { secured := true, default := some (.u256 0), rootNode := none }
+  let mut rs : List Nat := []
+  for (k, v) in [(k32 1, 0x2A), (k32 2, 7), (k32 3, 9), (k32 2, 8),
+                 (k32 3, 0), (k32 2, 0), (k32 1, 0)] do
+    m ← mpt_set m k (some (.u256 v))
+    rs := rs ++ [bytesBEtoNat (← mpt_root m)]
+  pure rs
+
+#guard storageRoots.toOption == some
+  [0x28e1a0e686a820dd23a1e58573a163f3d69f22a614f89a29022cd5aa2993109e,
+   0x42a9aa2b9aba3c215c27f0013174de2fd38c930c119aebaca4ef1ddd2095cf76,
+   0xa12bcb7aadad162343e1d0dde93193bddf51c246ed0c0ff440826f0df1611029,
+   0xff9df1abc787b0e61dec88be35b8cdbedb6829ab5d1559163a3536acc2dc58f2,
+   0x5322886238e47cc6aabf650e889eef69ef568556a6edca297de466b09a43dc5e,
+   0x28e1a0e686a820dd23a1e58573a163f3d69f22a614f89a29022cd5aa2993109e,
+   0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421]
+
+-- Unsecured bytes trie (transaction-trie shape): rlp-scalar keys, fat
+-- values; incremental mpt_set and build_mpt agree with the Python root.
+def txKey (i : Nat) : Bytes := encR (.bytes (EvmAsm.EL.RLP.Nat.toBytesBE i))
+def txVal (i : BitVec 8) : Bytes := 0xF8 :: 0x6B :: List.replicate 40 i
+def txRootExpected : Nat :=
+  0x1783cc7612107c3315a3c8efb682a80e83a9aaeeb69c85d143f20a62ebb96a06
+
+#guard
+  (do
+    let mut m : IncrementalMpt :=
+      { secured := false, default := some (.bytes []), rootNode := none }
+    for i in [0, 1, 2] do
+      m ← mpt_set m (txKey i) (some (.bytes (txVal (BitVec.ofNat 8 i))))
+    mpt_root m : Except SpecError Root).toOption.map bytesBEtoNat
+  == some txRootExpected
+
+#guard
+  (do
+    let m ← build_mpt ((List.range 3).map (fun i =>
+      (txKey i, .bytes (txVal (BitVec.ofNat 8 i))))) false (some (.bytes []))
+    mpt_root m).toOption.map bytesBEtoNat == some txRootExpected
+
+/-! The two-account state (accounts `0xA1…`/`0x00…`, `0xA1…` holding a
+two-slot storage trie), its witness node DB, and the Python-computed
+roots — shared with `WitnessStateRoot.lean`. -/
+
+def wAddrA : Address := List.replicate 20 0xA1
+def wAddrB : Address := List.replicate 20 0x00
+def wAddrD : Address := List.replicate 20 0xD4
+def acctA : Account := { nonce := 1, balance := 100, codeHash := EMPTY_CODE_HASH }
+def acctB : Account := { nonce := 0, balance := 5, codeHash := EMPTY_CODE_HASH }
+def acctD : Account := { nonce := 0, balance := 3, codeHash := EMPTY_CODE_HASH }
+
+/-- `0xA1…`'s storage root: `{k1 ↦ 0x2A, k2 ↦ 7}`. -/
+def srootA : Root :=
+  (do
+    let m : IncrementalMpt :=
+      { secured := true, default := some (.u256 0), rootNode := none }
+    let m ← mpt_set m (k32 1) (some (.u256 0x2A))
+    let m ← mpt_set m (k32 2) (some (.u256 7))
+    mpt_root m).toOption.getD []
+
+#guard bytesBEtoNat srootA
+  == 0x42a9aa2b9aba3c215c27f0013174de2fd38c930c119aebaca4ef1ddd2095cf76
+
+def gsrA : Bytes → Root := fun a => if a == wAddrA then srootA else EMPTY_TRIE_ROOT
+
+/-- The two-account state root, built incrementally. -/
+def wStateRoot : Root :=
+  (do
+    let m : IncrementalMpt := { secured := true, default := none, rootNode := none }
+    let m ← mpt_set m wAddrA (some (.account acctA)) (get_storage_root := some gsrA)
+    let m ← mpt_set m wAddrB (some (.account acctB)) (get_storage_root := some gsrA)
+    mpt_root m).toOption.getD []
+
+#guard bytesBEtoNat wStateRoot
+  == 0x0f33d0ee44133b51a53c207779c89e3c1a847923161b238f6091f527e2ea8a3b
+
+/-- The witness node DB for the state above: the six hash-referenced
+    node preimages (state branch, two account leaves, storage branch,
+    two storage leaves), as collected from the Python spec. -/
+def wnode0 : Bytes := [0xF8, 0x51, 0x80, 0x80, 0x80, 0x80, 0x80, 0xA0, 0xDF, 0xBF, 0x39, 0xFA, 0x78, 0xBE, 0x34, 0x8F, 0xBD, 0x2A, 0xCE, 0xA6, 0x06, 0xAD, 0x4B, 0xEE, 0x38, 0xE1, 0xD0, 0xAD, 0x50, 0x3D, 0x56, 0x62, 0xAE, 0x39, 0xF5, 0x0C, 0x52, 0x47, 0xB8, 0xCD, 0x80, 0x80, 0xA0, 0x51, 0x17, 0xC9, 0x35, 0xD6, 0xE7, 0x79, 0x09, 0xD9, 0x24, 0xED, 0xB1, 0x0E, 0x0E, 0x95, 0x7B, 0xFB, 0x74, 0xA1, 0x33, 0x18, 0xC7, 0xDA, 0x07, 0x72, 0xE1, 0x0A, 0xA7, 0xE3, 0xFB, 0xB4, 0x98, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80]
+def wnode1 : Bytes := [0xF8, 0x69, 0xA0, 0x33, 0x80, 0xC7, 0xB7, 0xAE, 0x81, 0xA5, 0x8E, 0xB9, 0x8D, 0x9C, 0x78, 0xDE, 0x4A, 0x1F, 0xD7, 0xFD, 0x95, 0x35, 0xFC, 0x95, 0x3E, 0xD2, 0xBE, 0x60, 0x2D, 0xAA, 0xA4, 0x17, 0x67, 0x31, 0x2A, 0xB8, 0x46, 0xF8, 0x44, 0x80, 0x05, 0xA0, 0x56, 0xE8, 0x1F, 0x17, 0x1B, 0xCC, 0x55, 0xA6, 0xFF, 0x83, 0x45, 0xE6, 0x92, 0xC0, 0xF8, 0x6E, 0x5B, 0x48, 0xE0, 0x1B, 0x99, 0x6C, 0xAD, 0xC0, 0x01, 0x62, 0x2F, 0xB5, 0xE3, 0x63, 0xB4, 0x21, 0xA0, 0xC5, 0xD2, 0x46, 0x01, 0x86, 0xF7, 0x23, 0x3C, 0x92, 0x7E, 0x7D, 0xB2, 0xDC, 0xC7, 0x03, 0xC0, 0xE5, 0x00, 0xB6, 0x53, 0xCA, 0x82, 0x27, 0x3B, 0x7B, 0xFA, 0xD8, 0x04, 0x5D, 0x85, 0xA4, 0x70]
+def wnode2 : Bytes := [0xF8, 0x69, 0xA0, 0x36, 0x0E, 0x2F, 0x2A, 0x05, 0x9D, 0xEF, 0xB5, 0x08, 0x24, 0xAF, 0x2B, 0x02, 0x4B, 0x4E, 0x7A, 0x37, 0x75, 0x4D, 0x03, 0x67, 0x6B, 0x00, 0xDE, 0x68, 0x4D, 0x95, 0xD1, 0x12, 0xAE, 0xFD, 0x87, 0xB8, 0x46, 0xF8, 0x44, 0x01, 0x64, 0xA0, 0x42, 0xA9, 0xAA, 0x2B, 0x9A, 0xBA, 0x3C, 0x21, 0x5C, 0x27, 0xF0, 0x01, 0x31, 0x74, 0xDE, 0x2F, 0xD3, 0x8C, 0x93, 0x0C, 0x11, 0x9A, 0xEB, 0xAC, 0xA4, 0xEF, 0x1D, 0xDD, 0x20, 0x95, 0xCF, 0x76, 0xA0, 0xC5, 0xD2, 0x46, 0x01, 0x86, 0xF7, 0x23, 0x3C, 0x92, 0x7E, 0x7D, 0xB2, 0xDC, 0xC7, 0x03, 0xC0, 0xE5, 0x00, 0xB6, 0x53, 0xCA, 0x82, 0x27, 0x3B, 0x7B, 0xFA, 0xD8, 0x04, 0x5D, 0x85, 0xA4, 0x70]
+def wnode3 : Bytes := [0xF8, 0x51, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0xA0, 0x4E, 0x54, 0x53, 0x2C, 0x70, 0x13, 0x3E, 0xA2, 0x97, 0x06, 0x7C, 0x48, 0x55, 0xA1, 0x59, 0x61, 0x03, 0x8A, 0x08, 0x21, 0x6F, 0xD1, 0x7F, 0x12, 0x9A, 0x16, 0xFE, 0x84, 0xB6, 0x65, 0xE7, 0xD9, 0x80, 0xA0, 0x10, 0xE5, 0xE5, 0xD2, 0x66, 0xB0, 0x29, 0x1C, 0x23, 0x13, 0x79, 0x5C, 0x70, 0x19, 0x77, 0x2E, 0x73, 0xAA, 0x27, 0xB0, 0x34, 0xA7, 0x26, 0x35, 0x3B, 0xE7, 0x34, 0x42, 0xA1, 0x17, 0xC4, 0xBE, 0x80, 0x80]
+def wnode4 : Bytes := [0xE2, 0xA0, 0x3E, 0xBC, 0x88, 0x82, 0xFE, 0xCB, 0xEC, 0x7F, 0xB8, 0x0D, 0x2C, 0xF4, 0xB3, 0x12, 0xBE, 0xC0, 0x18, 0x88, 0x4C, 0x2D, 0x66, 0x66, 0x7C, 0x67, 0xA9, 0x05, 0x08, 0x21, 0x4B, 0xD8, 0xBA, 0xFC, 0x2A]
+def wnode5 : Bytes := [0xE2, 0xA0, 0x3E, 0x4A, 0x07, 0x9F, 0x5B, 0x14, 0xA2, 0x44, 0x65, 0x18, 0x1D, 0x45, 0xAF, 0x32, 0xA8, 0x05, 0x3C, 0x2D, 0x44, 0x64, 0x46, 0xD7, 0x01, 0x93, 0x59, 0xE2, 0x10, 0xB8, 0x2E, 0x53, 0xB8, 0xBA, 0x07]
+
+def wNodeDb : List (Hash32 × Bytes) :=
+  build_node_db [wnode0, wnode1, wnode2, wnode3, wnode4, wnode5]
+
+-- Decode-then-mutate round trip: decode the witness, insert a fresh
+-- account, then delete one — roots match the Python spec at each step.
+#guard
+  (do
+    let m ← decode_witness_mpt wNodeDb wStateRoot true none
+    let m ← mpt_set m wAddrD (some (.account acctD))
+      (get_storage_root := some (fun _ => EMPTY_TRIE_ROOT))
+    let r1 := bytesBEtoNat (← mpt_root m)
+    let m ← mpt_set m wAddrB none
+    let r2 := bytesBEtoNat (← mpt_root m)
+    pure (r1, r2) : Except SpecError (Nat × Nat)).toOption
+  == some (0xbb679da078ce8197f2b6b177425b0b9119d6fde290bd120a0c7e060ab6d21ee9,
+           0x20ecc67460eb17737f3bc764a73e1da36f78128cef05ae9ac2d56317a35de254)
+
+-- Withheld-node rejection: with the 0xA1… account leaf (wnode2) missing
+-- from the DB, deleting 0x00… forces the branch collapse onto its
+-- HashedNode sibling — a rejection, never a wrong root.
+#guard
+  (match (do
+      let m ← decode_witness_mpt
+        (build_node_db [wnode0, wnode1, wnode3, wnode4, wnode5]) wStateRoot true none
+      let m ← mpt_set m wAddrB none
+      mpt_root m : Except SpecError Root) with
+   | .error (.mptWriteError _) => true
+   | _ => false)
+
+-- mpt_get: _data round trip + HashedNode-contact rejection on traversal.
+#guard
+  (do
+    let m : IncrementalMpt :=
+      { secured := true, default := some (.u256 0), rootNode := none }
+    let m ← mpt_set m (k32 1) (some (.u256 0x2A))
+    let v1 ← mpt_get m (k32 1)
+    let v2 ← mpt_get m (k32 9)
+    pure (v1, v2) : Except SpecError (Option MptValue × Option MptValue)).toOption
+  == some (some (.u256 0x2A), some (.u256 0))
+
+end MptWriteVectors
+
+end EvmAsm.Stateless.SpecRef

--- a/EvmAsm/Stateless/SpecRef/Types.lean
+++ b/EvmAsm/Stateless/SpecRef/Types.lean
@@ -74,6 +74,11 @@ inductive SpecError where
   /-- `decode_witness_to_mpt`: `node_db[root_hash]` raised `KeyError` — the
       witness does not contain the trie's root node. -/
   | witnessRootMissing
+  /-- `incremental_mpt.py` write side (`mpt_set`/`mpt_get`/`mpt_root`/
+      `build_mpt` and helpers): any `AssertionError` raised on the
+      insert/delete/encode/traverse path — e.g. touching an unresolved
+      `HashedNode`, `_split_extension` collision, unencodable value. -/
+  | mptWriteError (why : String)
   /-- `WitnessState.get_code`: `self._code_db[code_hash]` raised `KeyError` —
       the witness does not contain the bytecode for a non-empty code hash. -/
   | codeHashMissing

--- a/EvmAsm/Stateless/SpecRef/WitnessStateRoot.lean
+++ b/EvmAsm/Stateless/SpecRef/WitnessStateRoot.lean
@@ -1,0 +1,174 @@
+/-
+  EvmAsm.Stateless.SpecRef.WitnessStateRoot
+
+  Port of `WitnessState.compute_state_root_and_trie_changes` in
+  `execution-specs/src/ethereum/forks/amsterdam/witness_state.py`
+  (`@tests-zkevm@v0.5.0`, `bd8c673`, method
+  `compute_state_root_and_trie_changes`) — the post-state-root
+  computation, obligation #8 (bead `evm-asm-s1d19.4`), including the
+  v0.5.0 `storage_clears` parameter.
+
+  ## Modeling notes
+
+  * **The `_storage_root_cache` is observable here** (unlike on the read
+    surface, see `WitnessReads.lean`): the `get_storage_root` closure for
+    the `account_changes` pass reads
+    `self._storage_root_cache.get(addr, EMPTY_TRIE_ROOT)` *without*
+    populating it, so its result depends on which addresses were read —
+    by block execution before this call, and by this method's own
+    `get_account_optional` calls.  The port therefore threads the cache
+    explicitly: `cache₀` is the cache content at entry (every address
+    `get_account_optional` was called on during execution, mapped to its
+    storage root), and the two internal passes extend it exactly where
+    Python does.
+  * **Iteration order**: Python iterates `storage_changes` /
+    `account_changes` dicts in insertion order — mirrored by the assoc
+    lists — and `storage_touched = set(storage_changes) |
+    set(storage_clears)` in *unspecified* set order; every operation in
+    that pass is an insert/update of a distinct state-trie key (never a
+    delete), and distinct-key MPT inserts commute (same resulting tree,
+    and `HashedNode` contact depends only on each key's own path), so
+    the choice `storage_changes ++ (storage_clears \ storage_changes)`
+    is observationally equal.
+  * Python returns `(root, [])` — the `List[InternalNode]` component is
+    always empty at `bd8c673` — so the port returns only the root.
+-/
+
+import EvmAsm.Stateless.SpecRef.IncrementalMptWrite
+import EvmAsm.Stateless.SpecRef.WitnessReads
+
+namespace EvmAsm.Stateless.SpecRef
+
+/-- The `_storage_root_cache` content, threaded explicitly (see header). -/
+abbrev StorageRootCache := List (Address × Root)
+
+/-- `self._storage_root_cache.get(address, EMPTY_TRIE_ROOT)`. -/
+def cacheGet (cache : StorageRootCache) (address : Address) : Root :=
+  ((cache.find? (·.1 == address)).map (·.2)).getD EMPTY_TRIE_ROOT
+
+/-- `address in self._storage_root_cache`. -/
+def cacheHas (cache : StorageRootCache) (address : Address) : Bool :=
+  cache.any (·.1 == address)
+
+/-- `get_account_optional`'s cache write (`WitnessReads.lean` models the
+    read surface cache-free; here the fill is observable):
+    `self._storage_root_cache[address] = storage_root-or-EMPTY_TRIE_ROOT`. -/
+def cacheFill (ws : WitnessPreState) (cache : StorageRootCache)
+    (address : Address) : Except SpecError StorageRootCache := do
+  let sr ← _storage_root_of ws address
+  if cacheHas cache address then
+    pure (cache.map (fun p => if p.1 == address then (address, sr) else p))
+  else
+    pure (cache ++ [(address, sr)])
+
+/-- `compute_state_root_and_trie_changes(account_changes, storage_changes,
+    storage_clears)`.  `cache₀`: the `_storage_root_cache` at entry (see
+    header).  Values: `account_changes` uses `none` for deleted accounts
+    (`Optional[Account]`), `storage_changes` slots use `0` for cleared
+    slots. -/
+def compute_state_root_and_trie_changes (ws : WitnessPreState)
+    (cache₀ : StorageRootCache)
+    (account_changes : List (Address × Option Account))
+    (storage_changes : List (Address × List (Bytes32 × U256)))
+    (storage_clears : List Address := []) : Except SpecError Root := do
+  -- Pass 1: per-address storage tries → new storage roots.
+  let mut cache := cache₀
+  let mut new_storage_roots : List (Address × Root) := []
+  for (address, slots) in storage_changes do
+    if !(storage_clears.any (· == address)) && !(cacheHas cache address) then
+      cache ← cacheFill ws cache address
+    let old_root :=
+      if storage_clears.any (· == address) then EMPTY_TRIE_ROOT
+      else cacheGet cache address
+    let mut storage_mpt ← decode_witness_mpt ws.nodeDb old_root true (some (.u256 0))
+    -- Insertions + updates before deletions, to minimize branch compressions.
+    for (key, value) in slots do
+      if value != 0 then
+        storage_mpt ← mpt_set storage_mpt key (some (.u256 value))
+    for (key, value) in slots do
+      if value == 0 then
+        storage_mpt ← mpt_set storage_mpt key (some (.u256 0))
+    new_storage_roots := new_storage_roots ++ [(address, ← mpt_root storage_mpt)]
+
+  -- The state trie from the witness.
+  let mut state_mpt ← decode_witness_mpt ws.nodeDb ws.stateRoot true none
+
+  -- Pass 2: storage-touched addresses absent from account_changes keep
+  -- their account but pick up the new storage root.
+  let storage_touched :=
+    storage_changes.map (·.1)
+      ++ storage_clears.filter (fun a => !(storage_changes.any (·.1 == a)))
+  for address in storage_touched do
+    if !(account_changes.any (·.1 == address)) then
+      let account ← get_account_optional ws address
+      cache ← cacheFill ws cache address
+      if let some a := account then
+        let sr := ((new_storage_roots.find? (·.1 == address)).map (·.2)).getD
+          EMPTY_TRIE_ROOT
+        state_mpt ← mpt_set state_mpt address (some (.account a))
+          (get_storage_root := some (fun _ => sr))
+
+  -- Pass 3: account changes, with the storage-root closure over the
+  -- final cache.
+  let cacheFinal := cache
+  let get_storage_root : Address → Root := fun addr =>
+    match new_storage_roots.find? (·.1 == addr) with
+    | some p => p.2
+    | none =>
+        if storage_clears.any (· == addr) then EMPTY_TRIE_ROOT
+        else cacheGet cacheFinal addr
+  for (address, account) in account_changes do
+    state_mpt ← mpt_set state_mpt address (account.map .account)
+      (get_storage_root := some get_storage_root)
+
+  mpt_root state_mpt
+
+/-! ## Sanity checks
+
+End-to-end over the shared `MptWriteVectors` witness (two accounts,
+`0xA1…` with a two-slot storage trie); every expected root is
+cross-checked against the Python `WitnessState` at `bd8c673`. -/
+
+section
+open MptWriteVectors
+
+private def testWs' : WitnessPreState :=
+  { nodeDb := wNodeDb, stateRoot := wStateRoot, codeDb := [] }
+
+-- Execution read A and B (cache filled for both); B's balance changes,
+-- D is created, A clears one slot and writes another.
+#guard
+  (compute_state_root_and_trie_changes testWs'
+    (cache₀ := [(wAddrA, srootA), (wAddrB, EMPTY_TRIE_ROOT)])
+    (account_changes := [(wAddrB, some { acctB with balance := 6 }),
+                         (wAddrD, some acctD)])
+    (storage_changes := [(wAddrA, [(k32 1, 0), (k32 3, 9)])])).toOption.map bytesBEtoNat
+  == some 0x062aba06a58d8c131a312254525a767a623e65635b65014353a122b4a02c475a
+
+-- storage_clears: A's storage is rebuilt from the empty trie (old slots
+-- gone), then k3 written.
+#guard
+  (compute_state_root_and_trie_changes testWs'
+    (cache₀ := [(wAddrA, srootA)])
+    (account_changes := [])
+    (storage_changes := [(wAddrA, [(k32 3, 9)])])
+    (storage_clears := [wAddrA])).toOption.map bytesBEtoNat
+  == some 0xea7cba513b3ff34d17534862573077aa3427b41df241d1f081fce6d14ece5f56
+
+-- Account deletion (branch collapse onto the remaining account leaf),
+-- with an empty entry cache (no reads during execution).
+#guard
+  (compute_state_root_and_trie_changes testWs' (cache₀ := [])
+    (account_changes := [(wAddrB, none)])
+    (storage_changes := [])).toOption.map bytesBEtoNat
+  == some 0x45fa6823f441f19afb852972d0c225cacbcee853c7e9ea979cde53cae8bfb38c
+
+-- No changes at all: the root is unchanged.
+#guard
+  (compute_state_root_and_trie_changes testWs' (cache₀ := [])
+    (account_changes := []) (storage_changes := [])).toOption
+  == some wStateRoot
+
+end
+
+end EvmAsm.Stateless.SpecRef

--- a/PLAN.md
+++ b/PLAN.md
@@ -4233,10 +4233,17 @@ through ECALL bridges (extending `EvmAsm/EL/Keccak*EcallBridge.lean`).
   `get_storage`, `get_code`, `account_has_storage`) cache-free over the
   `.1` decoder (`WitnessPreState` moved there from `Stateless.lean`;
   memo caches modeled as recomputation — observationally equal on the
-  read surface, documented in the module header). Next: `.3` seam shell,
-  `.4` post-state root (#8), `.5` EVM core (maintainer green-light
-  given: full pure port), `.6` `eest-specref-check` succ gate (baseline
-  974/25,474 divergences).
+  read surface, documented in the module header). Third increment
+  (`s1d19.4`, obligation #8): `IncrementalMptWrite.lean` ports the full
+  `incremental_mpt.py` write side (`build_mpt`, `mpt_get`, `mpt_set`
+  insert/delete/collapse, node encoding, `mpt_root`; immutable tree,
+  asserts → rejections, `#guard` roots cross-checked against the Python
+  spec run on the submodule) and `WitnessStateRoot.lean` ports
+  `compute_state_root_and_trie_changes` with the v0.5.0
+  `storage_clears` parameter (`_storage_root_cache` threaded explicitly
+  — it is observable there). Next: `.3` seam shell, `.5` EVM core
+  (maintainer green-light given: full pure port), `.6`
+  `eest-specref-check` succ gate (baseline 974/25,474 divergences).
 
 ### Cross-references
 

--- a/docs/agents/specref-execution-seam-scope.md
+++ b/docs/agents/specref-execution-seam-scope.md
@@ -178,9 +178,12 @@ wrong-hash node yields a rejection, never a wrong value.
 
 Status (2026-07-10): `.1` landed (`IncrementalMpt.lean`, PR #10166);
 `.2` landed (`WitnessReads.lean` — `WitnessState` read methods,
-cache-free over the `.1` decoder). The `.5` maintainer decision is
-**resolved**: proceed with the full pure port (see the bead comment on
-`s1d19.5`).
+cache-free over the `.1` decoder); `.4` landed
+(`IncrementalMptWrite.lean` — the full `incremental_mpt.py` write side —
+and `WitnessStateRoot.lean` — `compute_state_root_and_trie_changes`
+with `storage_clears`, obligation #8; roots cross-checked against the
+Python spec). The `.5` maintainer decision is **resolved**: proceed
+with the full pure port (see the bead comment on `s1d19.5`).
 
 ### Maintainer checkpoint (STOP-and-report, per the bead — since resolved)
 


### PR DESCRIPTION
Stacked on #10168. Third increment of the SpecRef execution seam (bead `evm-asm-s1d19`, issue #10141) — **obligation #8** (post-state root).

## `IncrementalMptWrite.lean` — `incremental_mpt.py` write side @ `bd8c673`

- `merkle_patricia_trie.py` helpers (`common_prefix_length`, `nibble_list_to_compact`, `encode_account`, `encode_node` as the explicit `MptValue` sum, `_prepare_data`).
- `IncrementalMpt`, `decode_witness_mpt`, `_build_mutable_tree`/`build_mpt`, `mpt_get` (+ witness traversal, rejecting on `HashedNode` contact), `mpt_set` (insert: `_mpt_insert_node`/`_insert_into_*`/`_split_extension`; delete: `_mpt_delete_node`/`_delete_from_*`/`_collapse_branch`), node encoding, `mpt_root`.
- **Modeling** (header notes): immutable tree — `_hash`/`_rlp`/`_dirty` are recompute-equal and dropped (incl. why skipping the `child_changed` identity check is observationally equal); every Python `assert` on the write path is a `SpecError.mptWriteError` rejection; tree-walk recursion fueled by nibble-key length, encode recursion is well-founded structural.

## `WitnessStateRoot.lean` — `compute_state_root_and_trie_changes` (v0.5.0, incl. `storage_clears`)

The one place the `_storage_root_cache` is genuinely observable (the `get_storage_root` closure reads without populating), so the port threads the cache explicitly: `cache₀` = cache at entry (addresses read during execution), plus the method's own fills. `storage_touched` set-iteration order is commutative (insert-only pass) — documented.

## Validation

`#guard`s cross-check **every root against the Python spec executed on the pinned submodule** (generator script below): storage-trie insert/update/delete chains (7 roots), unsecured tx-style tries (incremental `mpt_set` ≡ `build_mpt`), a two-account state with hash-referenced witness nodes — decode-then-mutate round trip and the withheld-node rejection — and four end-to-end `compute_state_root_and_trie_changes` scenarios (slot clear+write, `storage_clears`, account-deletion collapse, no-op ≡ identity).

<details><summary>Python vector generator (run in `execution-specs/` @ bd8c673)</summary>

```python
import sys
sys.path.insert(0, 'src')
from ethereum.forks.amsterdam.incremental_mpt import (
    build_mpt, mpt_set, mpt_root, decode_witness_to_mpt,
    MutableLeafNode, MutableExtensionNode, MutableBranchNode, HashedNode,
    _compute_node_hash_and_rlp,
)
from ethereum.forks.amsterdam.witness_state import WitnessState, build_node_db, build_code_db
from ethereum_types.numeric import U256, Uint
from ethereum_rlp import rlp
from ethereum.crypto.hash import keccak256
from ethereum.state import Account


def collect_nodes(node, acc):
    """Collect RLP preimages of all hash-referenced nodes reachable from node."""
    if node is None or isinstance(node, HashedNode):
        return
    h, r = _compute_node_hash_and_rlp(node)
    if h is not None:
        acc.append(bytes(r))
    if isinstance(node, MutableExtensionNode):
        collect_nodes(node.child, acc)
    elif isinstance(node, MutableBranchNode):
        for c in node.children:
            collect_nodes(c, acc)


def hexlist(bs):
    return '[' + ', '.join(f'0x{b:02X}' for b in bs) + ']'


print('=== 1. storage trie set/update/delete roots (secured, U256) ===')
m = build_mpt({}, True, U256(0))
mpt_set(m, b'\x01'*32, U256(0x2A)); print('r1', mpt_root(m).hex())
mpt_set(m, b'\x02'*32, U256(7));    print('r2', mpt_root(m).hex())
mpt_set(m, b'\x03'*32, U256(9));    print('r3', mpt_root(m).hex())
mpt_set(m, b'\x02'*32, U256(8));    print('r4 upd', mpt_root(m).hex())
mpt_set(m, b'\x03'*32, U256(0));    print('r5 del', mpt_root(m).hex())
mpt_set(m, b'\x02'*32, U256(0));    print('r6 del->single', mpt_root(m).hex())
mpt_set(m, b'\x01'*32, U256(0));    print('r7 empty', mpt_root(m).hex())

print('=== 2. unsecured bytes trie (tx-style) ===')
t = build_mpt({}, False, b'')
for i in range(3):
    mpt_set(t, rlp.encode(Uint(i)), b'\xF8\x6B' + bytes([i])*40)
print('txroot', mpt_root(t).hex())
t2 = build_mpt({rlp.encode(Uint(i)): b'\xF8\x6B' + bytes([i])*40 for i in range(3)}, False, b'')
print('txroot_build', mpt_root(t2).hex())

print('=== 3. account trie (secured, Account + storage roots) ===')
addrA = bytes([0xA1]*20)
addrB = bytes([0x00]*20)
addrD = bytes([0xD4]*20)
k1 = bytes([0x01]*32); k2 = bytes([0x02]*32); k3 = bytes([0x03]*32)
EMPTY_CODE = keccak256(b'')
# A's storage trie
sm = build_mpt({}, True, U256(0))
mpt_set(sm, k1, U256(0x2A)); mpt_set(sm, k2, U256(7))
srootA = mpt_root(sm)
print('srootA', srootA.hex())
acctA = Account(nonce=Uint(1), balance=U256(100), code_hash=EMPTY_CODE)
acctB = Account(nonce=Uint(0), balance=U256(5), code_hash=EMPTY_CODE)
def gsr(addr):
    return srootA if addr == addrA else keccak256(rlp.encode(b''))
am = build_mpt({}, True, None)
mpt_set(am, addrA, acctA, get_storage_root=gsr)
mpt_set(am, addrB, acctB, get_storage_root=gsr)
state_root = mpt_root(am)
print('stateroot', state_root.hex())

print('=== 4. witness node DB for the state above ===')
state_nodes = []
collect_nodes(am.root_node, state_nodes)
storage_nodes = []
collect_nodes(sm.root_node, storage_nodes)
all_nodes = state_nodes + storage_nodes
print('node count', len(all_nodes))
for n in all_nodes:
    print('NODE', n.hex())

print('=== 5. decode-then-mutate round trip ===')
node_db = build_node_db(tuple(all_nodes))
dm = decode_witness_to_mpt(node_db, state_root, secured=True, default=None)
mpt_set(dm, addrD, Account(nonce=Uint(0), balance=U256(3), code_hash=EMPTY_CODE),
        get_storage_root=lambda a: keccak256(rlp.encode(b'')))
print('after insert D', mpt_root(dm).hex())
mpt_set(dm, addrB, None, get_storage_root=gsr)
print('after delete B', mpt_root(dm).hex())

print('=== 6. compute_state_root_and_trie_changes end-to-end ===')
ws = WitnessState(
    _node_db=build_node_db(tuple(all_nodes)),
    _state_root=state_root,
    _code_db=build_code_db(()),
)
# execution reads A and B (fills cache)
ws.get_account_optional(addrA)
ws.get_account_optional(addrB)
acctB2 = Account(nonce=Uint(0), balance=U256(6), code_hash=EMPTY_CODE)
acctD = Account(nonce=Uint(0), balance=U256(3), code_hash=EMPTY_CODE)
root6, _ = ws.compute_state_root_and_trie_changes(
    account_changes={addrB: acctB2, addrD: acctD},
    storage_changes={addrA: {k1: U256(0), k3: U256(9)}},
)
print('root6', root6.hex())

print('=== 7. with storage_clears ===')
ws2 = WitnessState(
    _node_db=build_node_db(tuple(all_nodes)),
    _state_root=state_root,
    _code_db=build_code_db(()),
)
ws2.get_account_optional(addrA)
root7, _ = ws2.compute_state_root_and_trie_changes(
    account_changes={},
    storage_changes={addrA: {k3: U256(9)}},
    storage_clears={addrA},
)
print('root7', root7.hex())

print('=== 8. account deletion via account_changes (collapse) ===')
ws3 = WitnessState(
    _node_db=build_node_db(tuple(all_nodes)),
    _state_root=state_root,
    _code_db=build_code_db(()),
)
root8, _ = ws3.compute_state_root_and_trie_changes(
    account_changes={addrB: None},
    storage_changes={},
)
print('root8', root8.hex())

print('=== 9. nibble_list_to_compact vectors ===')
from ethereum.merkle_patricia_trie import nibble_list_to_compact
print('evenext', nibble_list_to_compact(bytes([0xA, 0xB]), False).hex())
print('oddext ', nibble_list_to_compact(bytes([0xA, 0xB, 0xC]), False).hex())
print('evenleaf', nibble_list_to_compact(bytes([0xA, 0xB]), True).hex())
print('oddleaf', nibble_list_to_compact(bytes([0xB]), True).hex())
print('emptyleaf', nibble_list_to_compact(b'', True).hex())
```
</details>

Gates: `lake build` green (all `#guard`s), `check-forbidden-tactics`, `check-spec-refs` (30 resolved citations), `check-axioms` pass.

Refs: evm-asm-s1d19.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)