### PR TITLE
feat(specref): EVM-core foundations — state tracker, BAL, full gas model, transactions (s1d19.5 stages 1–2)

### DIFF
--- a/EvmAsm/Stateless/SpecRef.lean
+++ b/EvmAsm/Stateless/SpecRef.lean
@@ -49,6 +49,9 @@ import EvmAsm.Stateless.SpecRef.Seam
 import EvmAsm.Stateless.SpecRef.Transactions
 import EvmAsm.Stateless.SpecRef.Gas
 import EvmAsm.Stateless.SpecRef.BlocksRlp
+import EvmAsm.Stateless.SpecRef.StateTracker
+import EvmAsm.Stateless.SpecRef.BlockAccessLists
+import EvmAsm.Stateless.SpecRef.Vm
 import EvmAsm.Stateless.SpecRef.SeamShell
 import EvmAsm.Stateless.SpecRef.Stateless
 import EvmAsm.Stateless.SpecRef.Guest

--- a/EvmAsm/Stateless/SpecRef/BlockAccessLists.lean
+++ b/EvmAsm/Stateless/SpecRef/BlockAccessLists.lean
@@ -1,0 +1,392 @@
+/-
+  EvmAsm.Stateless.SpecRef.BlockAccessLists
+
+  Port of
+  `execution-specs/src/ethereum/forks/amsterdam/block_access_lists.py`
+  (`@tests-zkevm@v0.5.0`, `bd8c673`) — the EIP-7928 Block Access List
+  builder (bead `evm-asm-s1d19.5`, Stack C):
+
+  * the BAL dataclasses (classes `StorageChange`, `BalanceChange`,
+    `NonceChange`, `CodeChange`, `SlotChanges`, `AccountChanges`,
+    `AccountData`, `BlockAccessListBuilder`)
+  * `ensure_account`, `add_storage_write`, `add_storage_read`,
+    `add_balance_change`, `add_nonce_change`, `add_code_change`,
+    `add_touched_account` (functions of the same names)
+  * `_build_from_builder`, `_get_pre_tx_account`, `_get_pre_tx_storage`,
+    `update_builder_from_tx`, `build_block_access_list`,
+    `hash_block_access_list`, `validate_block_access_list_gas_limit`
+    (functions of the same names)
+
+  plus `incorporate_tx_into_block` (`state_tracker.py`, function
+  `incorporate_tx_into_block`), which composes
+  `update_builder_from_tx` with the merge half in `StateTracker.lean`.
+
+  ## Modeling notes
+
+  * Builder dicts/sets are insertion-ordered assoc/dedup lists (see
+    `StateTracker.lean`); `_build_from_builder` sorts every output
+    axis (addresses, slots, reads, per-type change lists by
+    block-access index), so container order is unobservable in the
+    final BAL and its hash.  Python `sorted` is stable — mirrored by
+    `List.mergeSort`.
+  * `update_builder_from_tx`'s pre-tx lookups (`_get_pre_tx_account` /
+    `_get_pre_tx_storage`) read the witness DIRECTLY (no read
+    recording); the code-change path reads through the tracker
+    (`getCode`, recording `code_reads`) exactly as Python does.
+-/
+
+import EvmAsm.Stateless.SpecRef.StateTracker
+import EvmAsm.Stateless.SpecRef.WitnessStateRoot
+import EvmAsm.Stateless.SpecRef.Gas
+
+namespace EvmAsm.Stateless.SpecRef
+
+open EvmAsm.EL.RLP (RLPItem)
+
+/-! ## BAL dataclasses -/
+
+/-- `StorageChange` (class `StorageChange`). -/
+structure StorageChange where
+  blockAccessIndex : Nat
+  newValue : U256
+  deriving Repr, BEq
+
+/-- `BalanceChange` (class `BalanceChange`). -/
+structure BalanceChange where
+  blockAccessIndex : Nat
+  postBalance : U256
+  deriving Repr, BEq
+
+/-- `NonceChange` (class `NonceChange`). -/
+structure NonceChange where
+  blockAccessIndex : Nat
+  newNonce : U64
+  deriving Repr, BEq
+
+/-- `CodeChange` (class `CodeChange`). -/
+structure CodeChange where
+  blockAccessIndex : Nat
+  newCode : Bytes
+  deriving Repr, BEq
+
+/-- `SlotChanges` (class `SlotChanges`). -/
+structure SlotChanges where
+  slot : U256
+  changes : List StorageChange
+  deriving Repr, BEq
+
+/-- `AccountChanges` (class `AccountChanges`). -/
+structure AccountChanges where
+  address : Address
+  storageChanges : List SlotChanges
+  storageReads : List U256
+  balanceChanges : List BalanceChange
+  nonceChanges : List NonceChange
+  codeChanges : List CodeChange
+  deriving Repr, BEq
+
+/-- `BlockAccessList` — `List[AccountChanges]`. -/
+abbrev BlockAccessList := List AccountChanges
+
+/-- `AccountData` (class `AccountData`): per-account builder state. -/
+structure AccountData where
+  storageChanges : List (U256 × List StorageChange) := []
+  storageReads : List U256 := []
+  balanceChanges : List BalanceChange := []
+  nonceChanges : List NonceChange := []
+  codeChanges : List CodeChange := []
+  deriving Repr
+
+/-- `BlockAccessListBuilder` (class `BlockAccessListBuilder`). -/
+structure BlockAccessListBuilder where
+  blockAccessIndex : Nat := 0
+  accounts : List (Address × AccountData) := []
+  deriving Repr
+
+/-! ## Builder update functions -/
+
+/-- `ensure_account(builder, address)`. -/
+def ensure_account (b : BlockAccessListBuilder) (address : Address) :
+    BlockAccessListBuilder :=
+  if dictHas b.accounts address then b
+  else { b with accounts := b.accounts ++ [(address, {})] }
+
+private def modifyAccount (b : BlockAccessListBuilder) (address : Address)
+    (f : AccountData → AccountData) : BlockAccessListBuilder :=
+  let b := ensure_account b address
+  { b with accounts := b.accounts.map (fun p =>
+      if p.1 == address then (p.1, f p.2) else p) }
+
+/-- Replace the entry with the same block-access index, else append —
+    the shared update-or-append pattern of `add_storage_write` /
+    `add_balance_change` / `add_code_change`. -/
+private def upsertByIndex (changes : List α) (getIdx : α → Nat) (idx : Nat)
+    (mk : α) : List α :=
+  if changes.any (fun c => getIdx c == idx) then
+    changes.map (fun c => if getIdx c == idx then mk else c)
+  else changes ++ [mk]
+
+/-- `add_storage_write(builder, address, slot, block_access_index,
+    new_value)`. -/
+def add_storage_write (b : BlockAccessListBuilder) (address : Address)
+    (slot : U256) (idx : Nat) (new_value : U256) : BlockAccessListBuilder :=
+  modifyAccount b address (fun ad =>
+    let changes := (dictGet? ad.storageChanges slot).getD []
+    let changes := upsertByIndex changes (·.blockAccessIndex) idx
+      { blockAccessIndex := idx, newValue := new_value }
+    { ad with storageChanges := dictSet ad.storageChanges slot changes })
+
+/-- `add_storage_read(builder, address, slot)`. -/
+def add_storage_read (b : BlockAccessListBuilder) (address : Address)
+    (slot : U256) : BlockAccessListBuilder :=
+  modifyAccount b address (fun ad =>
+    { ad with storageReads := setAdd ad.storageReads slot })
+
+/-- `add_balance_change(builder, address, block_access_index,
+    post_balance)`. -/
+def add_balance_change (b : BlockAccessListBuilder) (address : Address)
+    (idx : Nat) (post_balance : U256) : BlockAccessListBuilder :=
+  modifyAccount b address (fun ad =>
+    let changes := upsertByIndex ad.balanceChanges (·.blockAccessIndex) idx
+      { blockAccessIndex := idx, postBalance := post_balance }
+    { ad with balanceChanges := changes })
+
+/-- `add_nonce_change(builder, address, block_access_index, new_nonce)`
+    — keeps the HIGHEST nonce per index. -/
+def add_nonce_change (b : BlockAccessListBuilder) (address : Address)
+    (idx : Nat) (new_nonce : U64) : BlockAccessListBuilder :=
+  modifyAccount b address (fun ad =>
+    if ad.nonceChanges.any (fun c => c.blockAccessIndex == idx) then
+      { ad with nonceChanges := ad.nonceChanges.map (fun c =>
+          if c.blockAccessIndex == idx && new_nonce > c.newNonce then
+            { blockAccessIndex := idx, newNonce := new_nonce }
+          else c) }
+    else
+      { ad with nonceChanges := ad.nonceChanges ++
+          [{ blockAccessIndex := idx, newNonce := new_nonce }] })
+
+/-- `add_code_change(builder, address, block_access_index, new_code)`. -/
+def add_code_change (b : BlockAccessListBuilder) (address : Address)
+    (idx : Nat) (new_code : Bytes) : BlockAccessListBuilder :=
+  modifyAccount b address (fun ad =>
+    let changes := upsertByIndex ad.codeChanges (·.blockAccessIndex) idx
+      { blockAccessIndex := idx, newCode := new_code }
+    { ad with codeChanges := changes })
+
+/-- `add_touched_account(builder, address)`. -/
+def add_touched_account (b : BlockAccessListBuilder) (address : Address) :
+    BlockAccessListBuilder :=
+  ensure_account b address
+
+/-! ## Build phase -/
+
+/-- Lexicographic byte-string order (Python `bytes` comparison). -/
+def bytesLt : Bytes → Bytes → Bool
+  | [], [] => false
+  | [], _ :: _ => true
+  | _ :: _, [] => false
+  | a :: as', b :: bs' =>
+      if a.toNat < b.toNat then true
+      else if a.toNat > b.toNat then false
+      else bytesLt as' bs'
+
+/-- `_build_from_builder(builder)`: sort every axis into the
+    deterministic BAL (stable sorts, like Python `sorted`). -/
+def _build_from_builder (b : BlockAccessListBuilder) : BlockAccessList :=
+  let per_account := b.accounts.map (fun (address, ad) =>
+    let storage_changes := (ad.storageChanges.map (fun (slot, slot_changes) =>
+        SlotChanges.mk slot
+          (slot_changes.mergeSort (fun x y => x.blockAccessIndex ≤ y.blockAccessIndex)))
+      ).mergeSort (fun x y => x.slot ≤ y.slot)
+    let storage_reads := (ad.storageReads.filter
+        (fun slot => !dictHas ad.storageChanges slot)).mergeSort (· ≤ ·)
+    { address := address
+      storageChanges := storage_changes
+      storageReads := storage_reads
+      balanceChanges := ad.balanceChanges.mergeSort
+        (fun x y => x.blockAccessIndex ≤ y.blockAccessIndex)
+      nonceChanges := ad.nonceChanges.mergeSort
+        (fun x y => x.blockAccessIndex ≤ y.blockAccessIndex)
+      codeChanges := ad.codeChanges.mergeSort
+        (fun x y => x.blockAccessIndex ≤ y.blockAccessIndex) })
+  per_account.mergeSort (fun x y => !(bytesLt y.address x.address))
+
+/-! ## Tx-diff extraction -/
+
+/-- `_get_pre_tx_account(pre_tx_accounts, pre_state, address)` — falls
+    back to the witness directly (no `reads` recording, but it DOES
+    populate the Python storage-root cache → `recordPreStateRead`). -/
+def _get_pre_tx_account (pre_tx_accounts : List (Address × Option Account))
+    (address : Address) : TxM (Option Account) := do
+  match dictGet? pre_tx_accounts address with
+  | some acct => pure acct
+  | none => do
+      recordPreStateRead address
+      let ts ← get
+      StateT.lift (get_account_optional ts.parent.preState address)
+
+/-- `_get_pre_tx_storage(pre_tx_storage, pre_state, address, key)`. -/
+def _get_pre_tx_storage (pre_tx_storage : List (Address × List (Bytes32 × U256)))
+    (address : Address) (key : Bytes32) : TxM U256 := do
+  match (dictGet? pre_tx_storage address).bind (fun slots => dictGet? slots key) with
+  | some v => pure v
+  | none => do
+      recordPreStateRead address
+      let ts ← get
+      StateT.lift (get_storage ts.parent.preState address key)
+
+/-- `update_builder_from_tx(builder, tx_state)`: diff the transaction's
+    writes against the block's cumulative state.  Must run BEFORE the
+    merge (`incorporateTxIntoBlock` composes them). -/
+def updateBuilderFromTx (builder : BlockAccessListBuilder) :
+    TxM BlockAccessListBuilder := do
+  let ts ← get
+  let block_state := ts.parent
+  let idx := builder.blockAccessIndex
+  -- Account writes: balance / nonce / code changes.
+  let mut b := builder
+  for (address, post_account) in ts.accountWrites do
+    let pre_account ← _get_pre_tx_account block_state.accountWrites address
+    let pre_balance := (pre_account.map (·.balance)).getD 0
+    let post_balance := (post_account.map (·.balance)).getD 0
+    if pre_balance ≠ post_balance then
+      b := add_balance_change b address idx post_balance
+    let pre_nonce := (pre_account.map (·.nonce)).getD 0
+    let post_nonce := (post_account.map (·.nonce)).getD 0
+    if pre_nonce ≠ post_nonce then
+      b := add_nonce_change b address idx post_nonce
+    let pre_code_hash := (pre_account.map (·.codeHash)).getD EMPTY_CODE_HASH
+    let post_code_hash := (post_account.map (·.codeHash)).getD EMPTY_CODE_HASH
+    if pre_code_hash ≠ post_code_hash then
+      let post_code ← getCode post_code_hash address
+      b := add_code_change b address idx post_code
+  -- Storage writes.
+  for (address, slots) in ts.storageWrites do
+    for (key, post_value) in slots do
+      let pre_value ← _get_pre_tx_storage block_state.storageWrites address key
+      if pre_value ≠ post_value then
+        b := add_storage_write b address (bytesBEtoNat key) idx post_value
+  pure b
+
+/-- `incorporate_tx_into_block(tx_state, builder)` (`state_tracker.py`,
+    function `incorporate_tx_into_block`): BAL update, then merge +
+    clear. -/
+def incorporateTxIntoBlock (builder : BlockAccessListBuilder) :
+    TxM BlockAccessListBuilder := do
+  let b ← updateBuilderFromTx builder
+  mergeTxIntoBlock
+  pure b
+
+/-- `build_block_access_list(builder, block_state)`. -/
+def build_block_access_list (builder : BlockAccessListBuilder)
+    (block_state : BlockState) : BlockAccessList :=
+  let b := block_state.storageReads.foldl (fun b (address, slot) =>
+    add_storage_read b address (bytesBEtoNat slot)) builder
+  let b := block_state.accountReads.foldl add_touched_account b
+  _build_from_builder b
+
+/-! ## Encoding / hashing -/
+
+private def scalarB (n : Nat) : RLPItem := .bytes (EvmAsm.EL.RLP.Nat.toBytesBE n)
+
+/-- `rlp.encode(block_access_list)`'s item (dataclasses as field
+    lists, scalars minimal BE). -/
+def balToRlpItem (bal : BlockAccessList) : RLPItem :=
+  .list (bal.map (fun ac => .list
+    [.bytes ac.address,
+     .list (ac.storageChanges.map (fun sc => .list
+       [scalarB sc.slot,
+        .list (sc.changes.map (fun c => .list
+          [scalarB c.blockAccessIndex, scalarB c.newValue]))])),
+     .list (ac.storageReads.map scalarB),
+     .list (ac.balanceChanges.map (fun c => .list
+       [scalarB c.blockAccessIndex, scalarB c.postBalance])),
+     .list (ac.nonceChanges.map (fun c => .list
+       [scalarB c.blockAccessIndex, scalarB c.newNonce])),
+     .list (ac.codeChanges.map (fun c => .list
+       [scalarB c.blockAccessIndex, .bytes c.newCode]))]))
+
+/-- `hash_block_access_list(block_access_list)`. -/
+def hash_block_access_list (bal : BlockAccessList) : Hash32 :=
+  keccak256 (EvmAsm.EL.RLP.encode (balToRlpItem bal))
+
+/-- `GasCosts.BLOCK_ACCESS_LIST_ITEM` (`vm/gas.py`, class `GasCosts`). -/
+def GasCosts.BLOCK_ACCESS_LIST_ITEM : Uint := 2000
+
+/-- `validate_block_access_list_gas_limit(block_access_list,
+    block_gas_limit)`. -/
+def validate_block_access_list_gas_limit (bal : BlockAccessList)
+    (block_gas_limit : Uint) : Except SpecError Unit := do
+  let bal_items := bal.foldl (fun n account =>
+    let unique_slots := (account.storageChanges.map (·.slot)).foldl setAdd []
+    let unique_slots := account.storageReads.foldl setAdd unique_slots
+    n + 1 + unique_slots.length) 0
+  if bal_items > block_gas_limit / GasCosts.BLOCK_ACCESS_LIST_ITEM then
+    throw (.invalidBlock "Block access list exceeds gas limit")
+
+/-! ## Sanity checks
+
+A full tracker→BAL→post-root scenario over the shared
+`MptWriteVectors` two-account witness, cross-checked against the Python
+spec at `bd8c673` (generator script in the PR description): read A,
+move 10 wei A→B, write A's slot k3, bump A's nonce, snapshot, make two
+writes that are then rolled back, read A's k1 through the rollback,
+deploy code on B, incorporate, build + hash the BAL, and recompute the
+post-state root from the extracted diff. -/
+
+section
+open MptWriteVectors
+
+private def trackerScenario :
+    Except SpecError (U256 × Nat × Nat × List Address) := do
+  let ws : WitnessPreState :=
+    { nodeDb := wNodeDb, stateRoot := wStateRoot, codeDb := [] }
+  let m : TxM (U256 × BlockAccessListBuilder) := do
+    let _ ← getAccount wAddrA
+    moveEther wAddrA wAddrB 10
+    setStorage wAddrA (k32 3) 9
+    incrementNonce wAddrA
+    let snap ← copyTxState
+    setAccountBalance wAddrB 999
+    setStorage wAddrA (k32 1) 0
+    restoreTxState snap
+    let v ← getStorage wAddrA (k32 1)
+    setCode wAddrB [0x60, 0x00]
+    let b ← incorporateTxIntoBlock { blockAccessIndex := 1 }
+    pure (v, b)
+  let ((v, b), ts) ← m.run { parent := { preState := ws } }
+  let bal := build_block_access_list b ts.parent
+  let diff := extract_block_diff ts.parent
+  let cache₀ ← cacheFromReads ws ts.parent.preStateReads
+  let root ← compute_state_root_and_trie_changes ws cache₀
+    diff.accountChanges diff.storageChanges
+  pure (v, bytesBEtoNat (hash_block_access_list bal), bytesBEtoNat root,
+        ts.parent.preStateReads)
+
+#guard
+  match trackerScenario with
+  | .ok (v, balHash, root, preReads) =>
+      v == 0x2A
+      && balHash == 0x4717683dc5dd0564e17998c463bf78dfbaf02a32c0a250abfda828a453786dc0
+      && root == 0x07a2451914beaffffbf6939093ebab39d395799886dee3b53f8bca8d0e1354b8
+      -- the witness-reaching reads are exactly A and B
+      && preReads.length == 2 && preReads.contains wAddrA && preReads.contains wAddrB
+  | .error _ => false
+
+-- Transient storage: set, read back, zero-pop, survives nothing.
+#guard
+  match (do
+    let m : TxM (U256 × U256) := do
+      setTransientStorage wAddrA (k32 1) 5
+      let a ← getTransientStorage wAddrA (k32 1)
+      setTransientStorage wAddrA (k32 1) 0
+      let b ← getTransientStorage wAddrA (k32 1)
+      pure (a, b)
+    m.run { parent := { preState :=
+      { nodeDb := wNodeDb, stateRoot := wStateRoot, codeDb := [] } } } :
+      Except SpecError ((U256 × U256) × TransactionState)) with
+  | .ok ((5, 0), _) => true | _ => false
+
+end
+
+end EvmAsm.Stateless.SpecRef

--- a/EvmAsm/Stateless/SpecRef/Gas.lean
+++ b/EvmAsm/Stateless/SpecRef/Gas.lean
@@ -6,14 +6,23 @@
   (`@tests-zkevm@v0.5.0`, `bd8c673`) needed by the seam shell's
   `validate_header` (bead `evm-asm-s1d19.3`):
 
-  * the `GasCosts` constants it reads (class `GasCosts`)
+  * the `GasCosts` / `StateGasCosts` constants (classes `GasCosts` and
+    `StateGasCosts`) — the seam-shell subset plus the transaction-level
+    EIP-8037 constants (Stack C stage 2); the per-opcode `OPCODE_*`
+    table lands with the interpreter stage
   * `calculate_blob_gas_price` (function `calculate_blob_gas_price`)
   * `calculate_excess_blob_gas` (function `calculate_excess_blob_gas`)
+  * `calculate_total_blob_gas` / `calculate_data_fee` (functions of the
+    same names)
+  * `calculate_memory_gas_cost`, `calculate_gas_extend_memory`,
+    `calculate_message_call_gas`, `max_message_call_gas`,
+    `init_code_cost` (functions of the same names)
 
-  plus `taylor_exponential` from `ethereum/utils/numeric.py`
+  plus `taylor_exponential` and `ceil32` from `ethereum/utils/numeric.py`
   (`execution-specs/src/ethereum/utils/numeric.py`, function
-  `taylor_exponential`).  The full EIP-8037 gas model (two-dimensional
-  regular/state gas, memory expansion) is Stack C (`s1d19.5`).
+  `taylor_exponential` and function `ceil32`).  `check_gas` /
+  `charge_gas` / `charge_state_gas` mutate the `Evm` object and land
+  with the interpreter stage.
 
   ## Modeling note: `taylor_exponential` fuel
 
@@ -32,10 +41,45 @@ import EvmAsm.Stateless.SpecRef.Types
 
 namespace EvmAsm.Stateless.SpecRef
 
+/-! ## `StateGasCosts` (`vm/gas.py`, class `StateGasCosts`) — EIP-8037
+state-byte counts converted to gas via `COST_PER_STATE_BYTE`. -/
+
+namespace StateGasCosts
+
+def COST_PER_STATE_BYTE : Uint := 1530
+def STATE_BYTES_PER_NEW_ACCOUNT : Uint := 120
+def STATE_BYTES_PER_STORAGE_SET : Uint := 64
+def STATE_BYTES_PER_AUTH_BASE : Uint := 23
+def STORAGE_SET : Uint := STATE_BYTES_PER_STORAGE_SET * COST_PER_STATE_BYTE
+def NEW_ACCOUNT : Uint := STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE
+def AUTH_BASE : Uint := STATE_BYTES_PER_AUTH_BASE * COST_PER_STATE_BYTE
+
+end StateGasCosts
+
 /-! ## `GasCosts` constants (`vm/gas.py`, class `GasCosts`) -/
 
 namespace GasCosts
 
+def BASE : Uint := 2
+def VERY_LOW : Uint := 3
+def LOW : Uint := 5
+def MID : Uint := 8
+def HIGH : Uint := 10
+def WARM_ACCESS : Uint := 100
+def COLD_ACCOUNT_ACCESS : Uint := 3000
+def COLD_STORAGE_ACCESS : Uint := 3000
+def STORAGE_WRITE : Uint := 10000
+def CALL_VALUE : Uint := 10300  -- ACCOUNT_WRITE + CALL_STIPEND
+def CALL_STIPEND : Uint := 2300
+def ACCOUNT_WRITE : Uint := 8000
+def CODE_DEPOSIT_PER_BYTE : Uint := 200
+def CODE_INIT_PER_WORD : Uint := 2
+def CREATE_ACCESS : Uint := ACCOUNT_WRITE + COLD_STORAGE_ACCESS
+def ZERO : Uint := 0
+def MEMORY_PER_WORD : Uint := 3
+def FAST_STEP : Uint := 5
+def REFUND_STORAGE_CLEAR : Nat :=
+  (STORAGE_WRITE + COLD_STORAGE_ACCESS) * 4800 / 5000
 def PER_BLOB : U64 := 2^17
 def BLOB_SCHEDULE_TARGET : U64 := 14
 def BLOB_TARGET_GAS_PER_BLOCK : U64 := PER_BLOB * BLOB_SCHEDULE_TARGET
@@ -43,10 +87,29 @@ def BLOB_BASE_COST : Uint := 2^13
 def BLOB_SCHEDULE_MAX : U64 := 21
 def BLOB_MIN_GASPRICE : Uint := 1
 def BLOB_BASE_FEE_UPDATE_FRACTION : Uint := 11684671
+def TX_BASE : Uint := 12000
+def TX_CREATE : Uint := 32000
+def TX_VALUE_COST : Uint := 4244
+def TRANSFER_LOG_COST : Uint := 1756
+def TX_DATA_TOKEN_STANDARD : Uint := 4
+def TX_DATA_TOKEN_FLOOR : Uint := 16
+def TX_ACCESS_LIST_ADDRESS : Uint := COLD_ACCOUNT_ACCESS
+def TX_ACCESS_LIST_STORAGE_KEY : Uint := COLD_STORAGE_ACCESS
+def PRECOMPILE_ECRECOVER : Uint := 3000
+def AUTH_TUPLE_BYTES : Uint := 101
+def REGULAR_PER_AUTH_BASE_COST : Uint :=
+  AUTH_TUPLE_BYTES * TX_DATA_TOKEN_FLOOR + PRECOMPILE_ECRECOVER
+    + COLD_ACCOUNT_ACCESS + 2 * WARM_ACCESS
 def LIMIT_ADJUSTMENT_FACTOR : Uint := 1024
 def LIMIT_MINIMUM : Uint := 5000
 
 end GasCosts
+
+/-! ## `ceil32` (`ethereum/utils/numeric.py`, function `ceil32`) -/
+
+/-- The smallest multiple of 32 that is ≥ `value`. -/
+def ceil32 (value : Uint) : Uint :=
+  if value % 32 == 0 then value else value + 32 - value % 32
 
 /-! ## `taylor_exponential` (`ethereum/utils/numeric.py`, function `taylor_exponential`) -/
 
@@ -99,7 +162,84 @@ def calculate_excess_blob_gas (parent_header : Header) :
     else
       pure (parent_blob_gas - GasCosts.BLOB_TARGET_GAS_PER_BLOCK)
 
+/-! ## Memory / call gas (`vm/gas.py`) -/
+
+/-- `ExtendMemory` (class `ExtendMemory`). -/
+structure ExtendMemory where
+  cost : Uint
+  expandBy : Uint
+  deriving Repr, BEq
+
+/-- `MessageCallGas` (class `MessageCallGas`). -/
+structure MessageCallGas where
+  cost : Uint
+  subCall : Uint
+  deriving Repr, BEq
+
+/-- `calculate_memory_gas_cost(size_in_bytes)`. -/
+def calculate_memory_gas_cost (size_in_bytes : Uint) : Uint :=
+  let size_in_words := ceil32 size_in_bytes / 32
+  size_in_words * GasCosts.MEMORY_PER_WORD + size_in_words ^ 2 / 512
+
+/-- `calculate_gas_extend_memory(memory, extensions)` — over the current
+    memory SIZE (the Python takes the bytearray; only its length is
+    read). -/
+def calculate_gas_extend_memory (memory_size : Uint)
+    (extensions : List (U256 × U256)) : ExtendMemory := Id.run do
+  let mut size_to_extend : Uint := 0
+  let mut to_be_paid : Uint := 0
+  let mut current_size := memory_size
+  for (start_position, size) in extensions do
+    if size == 0 then continue
+    let before_size := ceil32 current_size
+    let after_size := ceil32 (start_position + size)
+    if after_size ≤ before_size then continue
+    size_to_extend := size_to_extend + (after_size - before_size)
+    to_be_paid := to_be_paid +
+      (calculate_memory_gas_cost after_size - calculate_memory_gas_cost before_size)
+    current_size := after_size
+  pure { cost := to_be_paid, expandBy := size_to_extend }
+
+/-- `max_message_call_gas(gas)`: the 63/64 rule. -/
+def max_message_call_gas (gas : Uint) : Uint := gas - gas / 64
+
+/-- `calculate_message_call_gas(value, gas, gas_left, memory_cost,
+    extra_gas, call_stipend)`. -/
+def calculate_message_call_gas (value : U256) (gas gas_left memory_cost
+    extra_gas : Uint) (call_stipend : Uint := GasCosts.CALL_STIPEND) :
+    MessageCallGas :=
+  let call_stipend := if value == 0 then 0 else call_stipend
+  if gas_left < extra_gas + memory_cost then
+    { cost := gas + extra_gas, subCall := gas + call_stipend }
+  else
+    let gas := min gas (max_message_call_gas (gas_left - memory_cost - extra_gas))
+    { cost := gas + extra_gas, subCall := gas + call_stipend }
+
+/-- `init_code_cost(init_code_length)`. -/
+def init_code_cost (init_code_length : Uint) : Uint :=
+  GasCosts.CODE_INIT_PER_WORD * ceil32 init_code_length / 32
+
 /-! ## Sanity checks (cross-checked against the Python spec at `bd8c673`) -/
+
+#guard ceil32 0 == 0
+#guard ceil32 1 == 32
+#guard ceil32 32 == 32
+#guard ceil32 33 == 64
+#guard GasCosts.REGULAR_PER_AUTH_BASE_COST == 7816
+#guard GasCosts.REFUND_STORAGE_CLEAR == 12480
+#guard StateGasCosts.STORAGE_SET == 97920
+#guard StateGasCosts.NEW_ACCOUNT == 183600
+#guard StateGasCosts.AUTH_BASE == 35190
+
+-- memory gas: one word = 3; 32 KiB = 3072 + 1048576/512·… (Python:
+-- calculate_memory_gas_cost(32768) = 5120).
+#guard calculate_memory_gas_cost 32 == 3
+#guard calculate_memory_gas_cost 32768 == 5120
+#guard (calculate_gas_extend_memory 0 [(0, 64)])
+  == { cost := 6, expandBy := 64 }
+#guard (calculate_gas_extend_memory 64 [(0, 32), (32, 64), (0, 0)])
+  == { cost := 3, expandBy := 32 }
+#guard max_message_call_gas 6400 == 6300
 
 -- calculate_blob_gas_price: zero excess → min price; two Python-checked
 -- points on the exponential.

--- a/EvmAsm/Stateless/SpecRef/SeamShell.lean
+++ b/EvmAsm/Stateless/SpecRef/SeamShell.lean
@@ -243,6 +243,144 @@ def validate_header (parent_header header : Header) :
   if header.parentHash ≠ headerHash parent_header then
     throw (.invalidBlock "parent hash mismatch")
 
+/-! ## Static per-transaction checks (sound-for-accepts extension)
+
+The accepting path runs `process_transaction` on every transaction,
+whose unconditional prefix (`fork.py`, functions `process_transaction`
+and `check_transaction`) performs checks that do NOT depend on
+execution state:
+
+* sender recovery from the supplied public key
+  (`recover_sender_from_public_key` — pure signature verification);
+* `validate_transaction` (intrinsic gas / EIP-7623 floor / EIP-2681
+  nonce cap / init-code size — pure);
+* the gas-dimension caps against the *initial* availability
+  (`regular/state_gas_available ≤ block_gas_limit` always, so
+  `min(TX_MAX_GAS_LIMIT, tx.gas) > block_gas_limit` or
+  `tx.gas > block_gas_limit` can never pass later);
+* cumulative blob gas vs `MAX_BLOB_GAS_PER_BLOCK` (fully determined by
+  the payload);
+* fee sanity vs the header base fee, blob static checks (count,
+  version byte, `max_fee_per_blob_gas` vs the header-derived blob gas
+  price), and the EIP-7702 non-empty-authorization check;
+* for the FIRST transaction only, against the (witness-backed,
+  pre-execution) state: the nonce-too-LOW check — nonces never
+  decrease, so `pre_state.nonce > tx.nonce` implies the at-check nonce
+  is also too high — and the EOA/delegation sender check — an existing
+  account's code cannot change during the pre-tx system calls
+  (`set_code` happens only on CREATE at a fresh address or in-tx
+  EIP-7702, and hitting an existing account's address with CREATE2
+  needs a keccak preimage, the model's standing assumption).  The
+  balance and nonce-too-HIGH checks are NOT sound against pre-state
+  (adversarial system-contract code could credit/debit the sender or
+  drive a delegated sender's CREATE before the first transaction) and
+  wait for `apply_body`, as do all later transactions' state checks.
+
+`MAX_BLOB_GAS_PER_BLOCK` / `BLOB_COUNT_LIMIT` /
+`VERSIONED_HASH_VERSION_KZG` are `fork.py` constants;
+`is_valid_delegation` is `vm/eoa_delegation.py` (function
+`is_valid_delegation`). -/
+
+/-- `MAX_BLOB_GAS_PER_BLOCK = BLOB_SCHEDULE_MAX * PER_BLOB` (`fork.py`). -/
+def MAX_BLOB_GAS_PER_BLOCK : U64 := GasCosts.BLOB_SCHEDULE_MAX * GasCosts.PER_BLOB
+/-- `BLOB_COUNT_LIMIT` (`fork.py`). -/
+def BLOB_COUNT_LIMIT : Nat := 6
+/-- `VERSIONED_HASH_VERSION_KZG` (`fork.py`). -/
+def VERSIONED_HASH_VERSION_KZG : BitVec 8 := 0x01
+
+/-- `is_valid_delegation(code)` (`vm/eoa_delegation.py`, function
+    `is_valid_delegation`): 23 bytes prefixed `0xEF0100`. -/
+def is_valid_delegation (code : Bytes) : Bool :=
+  code.length == 23 && code.take 3 == [0xEF, 0x01, 0x00]
+
+/-- `calculate_total_blob_gas(tx)` (`vm/gas.py`, function
+    `calculate_total_blob_gas`). -/
+def calculate_total_blob_gas (tx : Transaction) : U64 :=
+  match tx with
+  | .blob t => GasCosts.PER_BLOB * t.blobVersionedHashes.length
+  | _ => 0
+
+/-- The execution-independent prefix of `check_transaction` (`fork.py`,
+    function `check_transaction`) for one transaction; returns
+    `max_gas_fee` (for the first-tx balance check). -/
+def staticCheckTransaction (base_fee_per_gas : Uint)
+    (block_gas_limit : Uint) (excess_blob_gas : U64) (tx : Transaction) :
+    Except SpecError Uint := do
+  if min TX_MAX_GAS_LIMIT tx.gas > block_gas_limit then
+    throw (.invalidBlock "regular gas used exceeds limit")
+  if tx.gas > block_gas_limit then
+    throw (.invalidBlock "state gas used exceeds limit")
+  let max_gas_fee ←
+    match tx with
+    | .feeMarket t => feeCap t.maxFeePerGas t.maxPriorityFeePerGas t.gas
+    | .blob t => feeCap t.maxFeePerGas t.maxPriorityFeePerGas t.gas
+    | .setCode t => feeCap t.maxFeePerGas t.maxPriorityFeePerGas t.gas
+    | .legacy t => legacyCap t.gasPrice t.gas
+    | .accessList t => legacyCap t.gasPrice t.gas
+  let max_gas_fee ←
+    match tx with
+    | .blob t => do
+        if t.blobVersionedHashes.isEmpty then
+          throw (.invalidBlock "no blob data in transaction")
+        if t.blobVersionedHashes.length > BLOB_COUNT_LIMIT then
+          throw (.invalidBlock "blob count exceeded")
+        if t.blobVersionedHashes.any (fun h => h.take 1 != [VERSIONED_HASH_VERSION_KZG]) then
+          throw (.invalidBlock "invalid blob versioned hash")
+        let blob_gas_price ← calculate_blob_gas_price excess_blob_gas
+        if t.maxFeePerBlobGas < blob_gas_price then
+          throw (.invalidBlock "insufficient max fee per blob gas")
+        pure (max_gas_fee + calculate_total_blob_gas tx * t.maxFeePerBlobGas)
+    | _ => pure max_gas_fee
+  if let .setCode t := tx then
+    if t.authorizations.isEmpty then
+      throw (.invalidBlock "empty authorization list")
+  pure max_gas_fee
+where
+  feeCap (maxFee maxPriority gas : Uint) : Except SpecError Uint := do
+    if maxFee < maxPriority then
+      throw (.invalidBlock "priority fee greater than max fee")
+    if maxFee < base_fee_per_gas then
+      throw (.invalidBlock "insufficient max fee per gas")
+    pure (gas * maxFee)
+  legacyCap (gasPrice gas : Uint) : Except SpecError Uint := do
+    if gasPrice < base_fee_per_gas then
+      throw (.invalidBlock "gas price below base fee")
+    pure (gas * gasPrice)
+
+/-- Static per-transaction checks over the whole payload (see the
+    section header): sender/pubkey verification + `validate_transaction`
+    + the execution-independent `check_transaction` prefix for every
+    transaction, cumulative blob gas, and the pre-state nonce / balance
+    / EOA checks for the first transaction. -/
+def staticTransactionChecks (chain_id : U64) (header : Header)
+    (ws : WitnessPreState) (transactions : List Bytes)
+    (public_keys : List Bytes) : Except SpecError Unit := do
+  let mut total_blob_gas : U64 := 0
+  let mut is_first := true
+  for (encoded_tx, public_key) in transactions.zip public_keys do
+    let tx ← decode_transaction encoded_tx
+    let sender ← recover_sender_from_public_key chain_id tx public_key
+    let _ ← validate_transaction tx sender
+    let _ ← staticCheckTransaction header.baseFeePerGas
+      header.gasLimit header.excessBlobGas tx
+    total_blob_gas := total_blob_gas + calculate_total_blob_gas tx
+    if is_first then
+      is_first := false
+      -- check_transaction's pre-state reads for the first transaction
+      -- (only the checks sound against pre-state; see the header):
+      -- get_account(tx_state, sender) on the untouched tracker reads
+      -- the witness directly.
+      let sender_account := ((← get_account_optional ws sender).getD
+        { nonce := 0, balance := 0, codeHash := EMPTY_CODE_HASH })
+      if sender_account.nonce > tx.nonce then
+        throw (.invalidBlock "nonce too low")
+      if sender_account.codeHash != EMPTY_CODE_HASH then
+        let sender_code ← get_code ws sender_account.codeHash
+        if !is_valid_delegation sender_code then
+          throw (.invalidBlock "not EOA")
+  if total_blob_gas > MAX_BLOB_GAS_PER_BLOCK then
+    throw (.invalidBlock "blob gas limit exceeded")
+
 /-! ## The partial seam -/
 
 /-- The pre-check prefix of `execute_new_payload_request`
@@ -271,6 +409,10 @@ def executeSeamShell : ExecutionSeam := fun input => do
   -- Root-anchored witness authentication (obligation #7): the accepting
   -- path always decodes the state trie from the witness.
   let _ ← decode_witness_to_mpt input.preState.nodeDb input.preState.stateRoot
+  -- Static per-transaction checks (the execution-independent prefix of
+  -- process_transaction/check_transaction; see the section above).
+  staticTransactionChecks input.chainContext.chainId block.header
+    input.preState block.transactions input.transactionPublicKeys
   -- apply_body + post-execution root checks: Stack C (s1d19.5).
   pure ()
 

--- a/EvmAsm/Stateless/SpecRef/StateTracker.lean
+++ b/EvmAsm/Stateless/SpecRef/StateTracker.lean
@@ -1,0 +1,386 @@
+/-
+  EvmAsm.Stateless.SpecRef.StateTracker
+
+  Port of `execution-specs/src/ethereum/forks/amsterdam/state_tracker.py`
+  (`@tests-zkevm@v0.5.0`, `bd8c673`) — the diff-tracking state layer of
+  the EVM core (bead `evm-asm-s1d19.5`, Stack C):
+
+  * `BlockState` / `TransactionState` (classes of the same names)
+  * reads: `get_pre_state_account_optional`, `get_pre_state_account`,
+    `get_account_optional`, `get_account`, `get_code`, `get_storage`,
+    `get_storage_original`, `get_transient_storage`
+  * predicates: `account_exists`, `account_deployable`,
+    `account_has_storage`, `account_exists_and_is_empty`,
+    `is_account_alive`
+  * writes: `set_account`, `set_storage`, `destroy_account`,
+    `clear_account_preserving_balance`, `destroy_storage`,
+    `mark_account_created`, `set_transient_storage`, `modify_state`,
+    `move_ether`, `create_ether`, `set_account_balance`,
+    `increment_nonce`, `set_code`
+  * snapshot/rollback: `copy_tx_state`, `restore_tx_state`
+  * lifecycle: `incorporate_tx_into_block` (the BAL half lives in
+    `BlockAccessLists.lean`), `extract_block_diff`,
+    `get_witness_ancestors`, `track_ancestor_access`
+  * `EMPTY_ACCOUNT` (`ethereum/state.py`,
+    `execution-specs/src/ethereum/state.py` constant `EMPTY_ACCOUNT`)
+    and `BlockDiff` (class `BlockDiff`)
+
+  ## Modeling notes
+
+  * The Python trackers are mutable dataclasses threaded through every
+    VM function; here the whole tracker is the state of the monad
+    `TxM α := StateT TransactionState (Except SpecError) α` (the
+    `BlockState` parent lives inside the `TransactionState`).
+    `pre_state` reads go through the authenticated witness layer
+    (`WitnessReads.lean`), whose rejections propagate in the `Except`.
+  * Python `dict`s become insertion-ordered assoc lists (update keeps
+    position, new keys append) and `set`s append-ordered dedup lists —
+    every consumer either checks membership or sorts before use
+    (`BlockAccessLists.lean`), so set order is unobservable.
+  * **Rollback sharing**: `copy_tx_state` deep-copies the write maps
+    and transient storage but SHARES `account_reads`/`storage_reads`/
+    `code_reads`/`created_accounts` (reads survive rollback, for BAL).
+    Immutably: `restore_tx_state` takes the write fields from the
+    snapshot and keeps the current read fields — same observable
+    result.
+  * `move_ether`'s insufficient-balance `AssertionError` is a
+    rejection (`SpecError.stateError`); the accepting path never hits
+    it (callers check balances first).
+-/
+
+import EvmAsm.Stateless.SpecRef.WitnessReads
+
+namespace EvmAsm.Stateless.SpecRef
+
+/-- `EMPTY_ACCOUNT` (`ethereum/state.py`). -/
+def EMPTY_ACCOUNT : Account := { nonce := 0, balance := 0, codeHash := EMPTY_CODE_HASH }
+
+/-! ## Assoc-list dict/set helpers (Python `dict`/`set` semantics) -/
+
+/-- Dict write: update keeps position, new key appends. -/
+def dictSet [BEq κ] (d : List (κ × α)) (k : κ) (v : α) : List (κ × α) :=
+  if d.any (·.1 == k) then d.map (fun p => if p.1 == k then (k, v) else p)
+  else d ++ [(k, v)]
+
+def dictGet? [BEq κ] (d : List (κ × α)) (k : κ) : Option α :=
+  (d.find? (·.1 == k)).map (·.2)
+
+def dictHas [BEq κ] (d : List (κ × α)) (k : κ) : Bool := d.any (·.1 == k)
+
+def dictDel [BEq κ] (d : List (κ × α)) (k : κ) : List (κ × α) :=
+  d.filter (·.1 != k)
+
+/-- Set add: dedup, append order. -/
+def setAdd [BEq α] (s : List α) (x : α) : List α :=
+  if s.contains x then s else s ++ [x]
+
+/-- Set union (`update`): add each in order. -/
+def setUnion [BEq α] (s t : List α) : List α := t.foldl setAdd s
+
+/-! ## `BlockState` / `TransactionState` -/
+
+abbrev StorageKey := Address × Bytes32
+abbrev CodeRead := Address × Hash32
+
+/-- `BlockState` (class `BlockState`): committed transaction-level
+    changes accumulated across a block. -/
+structure BlockState where
+  preState : WitnessPreState
+  accountReads : List Address := []
+  accountWrites : List (Address × Option Account) := []
+  storageReads : List StorageKey := []
+  storageWrites : List (Address × List (Bytes32 × U256)) := []
+  codeReads : List CodeRead := []
+  codeWrites : List (Hash32 × Bytes) := []
+  oldestAncestorOffset : Option Uint := none
+  /-- Modeling-only (not a Python field): the addresses whose reads
+      reached the witness (`ws.get_account_optional` / `ws.get_storage`
+      / `ws.account_has_storage` fall-throughs) — exactly the keys the
+      Python `WitnessState._storage_root_cache` holds at block end,
+      which `compute_state_root_and_trie_changes` observes (its
+      `cache₀`; values are the deterministic `_storage_root_of`).
+      See `WitnessStateRoot.lean` `cacheFromReads`. -/
+  preStateReads : List Address := []
+
+/-- `TransactionState` (class `TransactionState`): in-flight changes
+    within a single transaction. -/
+structure TransactionState where
+  parent : BlockState
+  accountReads : List Address := []
+  accountWrites : List (Address × Option Account) := []
+  storageReads : List StorageKey := []
+  storageWrites : List (Address × List (Bytes32 × U256)) := []
+  codeReads : List CodeRead := []
+  codeWrites : List (Hash32 × Bytes) := []
+  createdAccounts : List Address := []
+  transientStorage : List (StorageKey × U256) := []
+
+/-- The transaction-state monad: every `state_tracker.py` function
+    threads the mutable trackers; rejections propagate in `Except`. -/
+abbrev TxM (α : Type) := StateT TransactionState (Except SpecError) α
+
+/-- `BlockDiff` (`ethereum/state.py`, class `BlockDiff`). -/
+structure BlockDiff where
+  accountChanges : List (Address × Option Account)
+  storageChanges : List (Address × List (Bytes32 × U256))
+  codeChanges : List (Hash32 × Bytes)
+
+/-! ## Reads -/
+
+/-- Record a witness-reaching read (see `BlockState.preStateReads`). -/
+def recordPreStateRead (address : Address) : TxM Unit :=
+  modify (fun ts => { ts with parent :=
+    { ts.parent with preStateReads := setAdd ts.parent.preStateReads address } })
+
+/-- `get_pre_state_account_optional(tx_state, address)`. -/
+def get_pre_state_account_optional (address : Address) : TxM (Option Account) := do
+  modify (fun ts => { ts with accountReads := setAdd ts.accountReads address })
+  let ts ← get
+  match dictGet? ts.parent.accountWrites address with
+  | some acct => pure acct
+  | none => do
+      recordPreStateRead address
+      StateT.lift (get_account_optional ts.parent.preState address)
+
+/-- `get_pre_state_account(tx_state, address)`. -/
+def get_pre_state_account (address : Address) : TxM Account := do
+  pure ((← get_pre_state_account_optional address).getD EMPTY_ACCOUNT)
+
+/-- `get_account_optional(tx_state, address)` — NB shadows the
+    `WitnessReads` name inside `TxM`; the tx-write layer first. -/
+def getAccountOptional (address : Address) : TxM (Option Account) := do
+  modify (fun ts => { ts with accountReads := setAdd ts.accountReads address })
+  let ts ← get
+  match dictGet? ts.accountWrites address with
+  | some acct => pure acct
+  | none => get_pre_state_account_optional address
+
+/-- `get_account(tx_state, address)`. -/
+def getAccount (address : Address) : TxM Account := do
+  pure ((← getAccountOptional address).getD EMPTY_ACCOUNT)
+
+/-- `get_code(tx_state, code_hash, address)`: tx code writes → block
+    code writes → witness code DB (recording `code_reads` only on the
+    pre-state fetch). -/
+def getCode (code_hash : Hash32) (address : Address) : TxM Bytes := do
+  if code_hash == EMPTY_CODE_HASH then pure [] else
+  let ts ← get
+  match dictGet? ts.codeWrites code_hash with
+  | some code => pure code
+  | none =>
+  match dictGet? ts.parent.codeWrites code_hash with
+  | some code => pure code
+  | none => do
+      modify (fun ts => { ts with codeReads := setAdd ts.codeReads (address, code_hash) })
+      let ts ← get
+      StateT.lift (get_code ts.parent.preState code_hash)
+
+/-- `get_storage(tx_state, address, key)`. -/
+def getStorage (address : Address) (key : Bytes32) : TxM U256 := do
+  modify (fun ts => { ts with storageReads := setAdd ts.storageReads (address, key) })
+  let ts ← get
+  match (dictGet? ts.storageWrites address).bind (fun slots => dictGet? slots key) with
+  | some v => pure v
+  | none =>
+  match (dictGet? ts.parent.storageWrites address).bind (fun slots => dictGet? slots key) with
+  | some v => pure v
+  | none => do
+      recordPreStateRead address
+      StateT.lift (get_storage ts.parent.preState address key)
+
+/-- `get_storage_original(tx_state, address, key)`: the value before
+    the current transaction (0 for accounts created in it). -/
+def getStorageOriginal (address : Address) (key : Bytes32) : TxM U256 := do
+  let ts ← get
+  if ts.createdAccounts.contains address then pure 0 else
+  match (dictGet? ts.parent.storageWrites address).bind (fun slots => dictGet? slots key) with
+  | some v => pure v
+  | none => do
+      recordPreStateRead address
+      StateT.lift (get_storage ts.parent.preState address key)
+
+/-- `get_transient_storage(tx_state, address, key)`. -/
+def getTransientStorage (address : Address) (key : Bytes32) : TxM U256 := do
+  pure (((← get).transientStorage.find? (·.1 == (address, key))).map (·.2) |>.getD 0)
+
+/-! ## Predicates -/
+
+/-- `account_exists(tx_state, address)`. -/
+def accountExists (address : Address) : TxM Bool := do
+  pure (← getAccountOptional address).isSome
+
+/-- `account_has_storage(tx_state, address)` — note the Python
+    `storage_writes.get(address)` truthiness: an address mapped to an
+    EMPTY slot dict does not count. -/
+def accountHasStorage (address : Address) : TxM Bool := do
+  let ts ← get
+  if ((dictGet? ts.storageWrites address).getD []).length > 0 then pure true
+  else if ((dictGet? ts.parent.storageWrites address).getD []).length > 0 then pure true
+  else do
+    recordPreStateRead address
+    StateT.lift (account_has_storage ts.parent.preState address)
+
+/-- `account_deployable(tx_state, address)`. -/
+def accountDeployable (address : Address) : TxM Bool := do
+  let account ← getAccount address
+  if account.nonce ≠ 0 || account.codeHash ≠ EMPTY_CODE_HASH then pure false
+  else pure !(← accountHasStorage address)
+
+/-- `account_exists_and_is_empty(tx_state, address)`. -/
+def accountExistsAndIsEmpty (address : Address) : TxM Bool := do
+  match ← getAccountOptional address with
+  | some a => pure (a.nonce == 0 && a.codeHash == EMPTY_CODE_HASH && a.balance == 0)
+  | none => pure false
+
+/-- `is_account_alive(tx_state, address)`. -/
+def isAccountAlive (address : Address) : TxM Bool := do
+  match ← getAccountOptional address with
+  | some a => pure (a != EMPTY_ACCOUNT)
+  | none => pure false
+
+/-! ## Writes -/
+
+/-- `set_account(tx_state, address, account)`. -/
+def setAccount (address : Address) (account : Option Account) : TxM Unit :=
+  modify (fun ts => { ts with accountWrites := dictSet ts.accountWrites address account })
+
+/-- `set_storage(tx_state, address, key, value)`; the Python `assert`
+    (account must exist) is a rejection. -/
+def setStorage (address : Address) (key : Bytes32) (value : U256) : TxM Unit := do
+  if (← getAccountOptional address).isNone then
+    throw (.stateError "set_storage on non-existent account")
+  modify (fun ts =>
+    let slots := dictSet ((dictGet? ts.storageWrites address).getD []) key value
+    { ts with storageWrites := dictSet ts.storageWrites address slots })
+
+/-- `destroy_storage(tx_state, address)`: writes convert to reads
+    before deletion (created-then-destroyed accesses stay in the BAL). -/
+def destroyStorage (address : Address) : TxM Unit :=
+  modify (fun ts =>
+    match dictGet? ts.storageWrites address with
+    | none => ts
+    | some slots =>
+        { ts with
+          storageReads := slots.foldl (fun rs (k, _) => setAdd rs (address, k)) ts.storageReads
+          storageWrites := dictDel ts.storageWrites address })
+
+/-- `destroy_account(tx_state, address)`. -/
+def destroyAccount (address : Address) : TxM Unit := do
+  destroyStorage address
+  setAccount address none
+
+/-- `account_exists_and_is_empty` post-check + destroy — the tail of
+    `modify_state`. -/
+def modifyState (address : Address) (f : Account → Account) : TxM Unit := do
+  setAccount address (some (f (← getAccount address)))
+  if ← accountExistsAndIsEmpty address then
+    destroyAccount address
+
+/-- `clear_account_preserving_balance(tx_state, address)`. -/
+def clearAccountPreservingBalance (address : Address) : TxM Unit := do
+  destroyStorage address
+  modifyState address (fun a => { a with nonce := 0, codeHash := EMPTY_CODE_HASH })
+
+/-- `mark_account_created(tx_state, address)`. -/
+def markAccountCreated (address : Address) : TxM Unit :=
+  modify (fun ts => { ts with createdAccounts := setAdd ts.createdAccounts address })
+
+/-- `set_transient_storage(tx_state, address, key, value)` (zero pops). -/
+def setTransientStorage (address : Address) (key : Bytes32) (value : U256) : TxM Unit :=
+  modify (fun ts =>
+    if value == 0 then
+      { ts with transientStorage := ts.transientStorage.filter (·.1 != (address, key)) }
+    else
+      { ts with transientStorage := dictSet ts.transientStorage (address, key) value })
+
+/-- `move_ether(tx_state, sender, recipient, amount)`; the
+    insufficient-balance `AssertionError` rejects. -/
+def moveEther (sender_address recipient_address : Address) (amount : U256) : TxM Unit := do
+  let sender ← getAccount sender_address
+  if sender.balance < amount then
+    throw (.stateError "move_ether: insufficient balance")
+  modifyState sender_address (fun a => { a with balance := a.balance - amount })
+  modifyState recipient_address (fun a => { a with balance := a.balance + amount })
+
+/-- `create_ether(tx_state, address, amount)`. -/
+def createEther (address : Address) (amount : U256) : TxM Unit :=
+  modifyState address (fun a => { a with balance := a.balance + amount })
+
+/-- `set_account_balance(tx_state, address, amount)`. -/
+def setAccountBalance (address : Address) (amount : U256) : TxM Unit :=
+  modifyState address (fun a => { a with balance := amount })
+
+/-- `increment_nonce(tx_state, address)`. -/
+def incrementNonce (address : Address) : TxM Unit :=
+  modifyState address (fun a => { a with nonce := a.nonce + 1 })
+
+/-- `set_code(tx_state, address, code)`. -/
+def setCode (address : Address) (code : Bytes) : TxM Unit := do
+  let code_hash := keccak256 code
+  if code_hash != EMPTY_CODE_HASH then
+    modify (fun ts => { ts with codeWrites := dictSet ts.codeWrites code_hash code })
+  modifyState address (fun a => { a with codeHash := code_hash })
+
+/-! ## Snapshot / rollback -/
+
+/-- `copy_tx_state(tx_state)`: the whole record IS the snapshot (the
+    shared-reference read sets are handled by `restoreTxState`). -/
+def copyTxState : TxM TransactionState := get
+
+/-- `restore_tx_state(tx_state, snapshot)`: restore the write maps and
+    transient storage; reads and `created_accounts` keep accumulating. -/
+def restoreTxState (snapshot : TransactionState) : TxM Unit :=
+  modify (fun ts =>
+    { ts with accountWrites := snapshot.accountWrites
+              storageWrites := snapshot.storageWrites
+              codeWrites := snapshot.codeWrites
+              transientStorage := snapshot.transientStorage })
+
+/-! ## Lifecycle -/
+
+/-- The read/write-merging half of `incorporate_tx_into_block` (the
+    `update_builder_from_tx` call happens first — see
+    `BlockAccessLists.lean`, which wraps both). -/
+def mergeTxIntoBlock : TxM Unit :=
+  modify (fun ts =>
+    let block := ts.parent
+    let block :=
+      { block with
+        storageReads := setUnion block.storageReads ts.storageReads
+        accountReads := setUnion block.accountReads ts.accountReads
+        codeReads := setUnion block.codeReads ts.codeReads
+        accountWrites := ts.accountWrites.foldl (fun d (a, acct) => dictSet d a acct)
+          block.accountWrites
+        storageWrites := ts.storageWrites.foldl (fun d (a, slots) =>
+          dictSet d a (slots.foldl (fun s (k, v) => dictSet s k v)
+            ((dictGet? d a).getD []))) block.storageWrites
+        codeWrites := ts.codeWrites.foldl (fun d (h, c) => dictSet d h c)
+          block.codeWrites }
+    { parent := block })
+
+/-- `extract_block_diff(block_state)`. -/
+def extract_block_diff (block_state : BlockState) : BlockDiff :=
+  { accountChanges := block_state.accountWrites
+    storageChanges := block_state.storageWrites
+    codeChanges := block_state.codeWrites }
+
+/-- `get_witness_ancestors(block_headers, oldest_ancestor_offset)`. -/
+def get_witness_ancestors (block_headers : List Bytes)
+    (oldest_ancestor_offset : Option Uint) : List Bytes :=
+  match oldest_ancestor_offset with
+  | none => []
+  | some off =>
+      -- Python `block_headers[-off:]`: `-0` slices the whole list.
+      if off == 0 then block_headers
+      else block_headers.drop (block_headers.length - off)
+
+/-- `track_ancestor_access(block_state, offset)`. -/
+def trackAncestorAccess (offset : Uint) : TxM Unit :=
+  modify (fun ts =>
+    { ts with parent :=
+      { ts.parent with oldestAncestorOffset :=
+          match ts.parent.oldestAncestorOffset with
+          | none => some offset
+          | some cur => some (max cur offset) } })
+
+end EvmAsm.Stateless.SpecRef

--- a/EvmAsm/Stateless/SpecRef/Transactions.lean
+++ b/EvmAsm/Stateless/SpecRef/Transactions.lean
@@ -11,10 +11,21 @@
     `fork_types.py` `Authorization` (class `Authorization`)
   * `decode_transaction` (function `decode_transaction`)
 
-  This is the decode subset the seam shell needs
-  (`is_valid_versioned_hashes`, bead `evm-asm-s1d19.3`); the rest of
-  `transactions.py` (intrinsic costs, sender recovery, signing hashes)
-  is Stack C (`s1d19.5`).
+  This began as the decode subset the seam shell needs
+  (`is_valid_versioned_hashes`, bead `evm-asm-s1d19.3`); Stack C stage 2
+  (`s1d19.5`) adds the rest of `transactions.py`:
+
+  * `IntrinsicGasCost` (class `IntrinsicGasCost`), `TX_MAX_GAS_LIMIT`
+  * `encode_transaction`, `get_transaction_hash` (functions of the
+    same names)
+  * `validate_transaction`, `calculate_intrinsic_cost`,
+    `count_tokens_in_data` (functions of the same names)
+  * `recover_sender`, `recover_transaction_public_key`,
+    `recover_sender_from_public_key`, `_sender_address_from_public_key`,
+    `_signature_recovery_parameters`, and the five `signing_hash_*`
+    (functions of the same names) — secp256k1 recovery delegates to
+    `Secp256k1Recover.lean` (the project-side reference for the
+    coincurve dependency).
 
   ## Modeling notes
 
@@ -33,6 +44,8 @@
 -/
 
 import EvmAsm.Stateless.SpecRef.Types
+import EvmAsm.Stateless.SpecRef.Gas
+import EvmAsm.Stateless.SpecRef.Secp256k1Recover
 import EvmAsm.EL.RLP.FullDecode
 
 namespace EvmAsm.Stateless.SpecRef
@@ -307,6 +320,304 @@ def decode_transaction (tx : Bytes) : Except SpecError Transaction := do
         | none => txErr "transaction RLP decode failed"
       else txErr s!"unknown transaction type {b0.toNat}"
 
+/-! ## Uniform accessors over the `Transaction` union -/
+
+namespace Transaction
+
+def gas : Transaction → Uint
+  | .legacy tx => tx.gas | .accessList tx => tx.gas | .feeMarket tx => tx.gas
+  | .blob tx => tx.gas | .setCode tx => tx.gas
+
+def nonce : Transaction → Nat
+  | .legacy tx => tx.nonce | .accessList tx => tx.nonce | .feeMarket tx => tx.nonce
+  | .blob tx => tx.nonce | .setCode tx => tx.nonce
+
+/-- `tx.to` — `none` is the `Bytes0` creation form (only legacy /
+    access-list / fee-market allow it). -/
+def to : Transaction → Option Address
+  | .legacy tx => tx.to | .accessList tx => tx.to | .feeMarket tx => tx.to
+  | .blob tx => some tx.to | .setCode tx => some tx.to
+
+def value : Transaction → U256
+  | .legacy tx => tx.value | .accessList tx => tx.value | .feeMarket tx => tx.value
+  | .blob tx => tx.value | .setCode tx => tx.value
+
+def data : Transaction → Bytes
+  | .legacy tx => tx.data | .accessList tx => tx.data | .feeMarket tx => tx.data
+  | .blob tx => tx.data | .setCode tx => tx.data
+
+def r : Transaction → U256
+  | .legacy tx => tx.r | .accessList tx => tx.r | .feeMarket tx => tx.r
+  | .blob tx => tx.r | .setCode tx => tx.r
+
+def s : Transaction → U256
+  | .legacy tx => tx.s | .accessList tx => tx.s | .feeMarket tx => tx.s
+  | .blob tx => tx.s | .setCode tx => tx.s
+
+/-- `has_access_list(tx)` (function `has_access_list`) — the access
+    list itself (`[]` for legacy). -/
+def accessList? : Transaction → Option (List Access)
+  | .legacy _ => none
+  | .accessList tx => some tx.accessList
+  | .feeMarket tx => some tx.accessList
+  | .blob tx => some tx.accessList
+  | .setCode tx => some tx.accessList
+
+end Transaction
+
+/-! ## Envelope encoding (`encode_transaction`, `get_transaction_hash`) -/
+
+private def scalarT (n : Nat) : RLPItem := .bytes (EvmAsm.EL.RLP.Nat.toBytesBE n)
+private def toItem : Option Address → RLPItem
+  | none => .bytes []
+  | some a => .bytes a
+private def accessItem (a : Access) : RLPItem :=
+  .list [.bytes a.account, .list (a.slots.map .bytes)]
+private def authItem (a : Authorization) : RLPItem :=
+  .list [scalarT a.chainId, .bytes a.address, scalarT a.nonce,
+         scalarT a.yParity, scalarT a.r, scalarT a.s]
+
+/-- The RLP item of each dataclass (`rlp.encode(tx)`'s argument). -/
+def txToRlpItem : Transaction → RLPItem
+  | .legacy tx => .list
+      [scalarT tx.nonce, scalarT tx.gasPrice, scalarT tx.gas, toItem tx.to,
+       scalarT tx.value, .bytes tx.data, scalarT tx.v, scalarT tx.r, scalarT tx.s]
+  | .accessList tx => .list
+      [scalarT tx.chainId, scalarT tx.nonce, scalarT tx.gasPrice, scalarT tx.gas,
+       toItem tx.to, scalarT tx.value, .bytes tx.data,
+       .list (tx.accessList.map accessItem), scalarT tx.yParity, scalarT tx.r,
+       scalarT tx.s]
+  | .feeMarket tx => .list
+      [scalarT tx.chainId, scalarT tx.nonce, scalarT tx.maxPriorityFeePerGas,
+       scalarT tx.maxFeePerGas, scalarT tx.gas, toItem tx.to, scalarT tx.value,
+       .bytes tx.data, .list (tx.accessList.map accessItem), scalarT tx.yParity,
+       scalarT tx.r, scalarT tx.s]
+  | .blob tx => .list
+      [scalarT tx.chainId, scalarT tx.nonce, scalarT tx.maxPriorityFeePerGas,
+       scalarT tx.maxFeePerGas, scalarT tx.gas, .bytes tx.to, scalarT tx.value,
+       .bytes tx.data, .list (tx.accessList.map accessItem),
+       scalarT tx.maxFeePerBlobGas, .list (tx.blobVersionedHashes.map .bytes),
+       scalarT tx.yParity, scalarT tx.r, scalarT tx.s]
+  | .setCode tx => .list
+      [scalarT tx.chainId, scalarT tx.nonce, scalarT tx.maxPriorityFeePerGas,
+       scalarT tx.maxFeePerGas, scalarT tx.gas, .bytes tx.to, scalarT tx.value,
+       .bytes tx.data, .list (tx.accessList.map accessItem),
+       .list (tx.authorizations.map authItem), scalarT tx.yParity, scalarT tx.r,
+       scalarT tx.s]
+
+/-- `encode_transaction(tx)` (function `encode_transaction`): the raw
+    envelope — legacy is its RLP, typed forms get their type byte. -/
+def encode_transaction (tx : Transaction) : Bytes :=
+  match tx with
+  | .legacy _ => EvmAsm.EL.RLP.encode (txToRlpItem tx)
+  | .accessList _ => 0x01 :: EvmAsm.EL.RLP.encode (txToRlpItem tx)
+  | .feeMarket _ => 0x02 :: EvmAsm.EL.RLP.encode (txToRlpItem tx)
+  | .blob _ => 0x03 :: EvmAsm.EL.RLP.encode (txToRlpItem tx)
+  | .setCode _ => 0x04 :: EvmAsm.EL.RLP.encode (txToRlpItem tx)
+
+/-- `get_transaction_hash(tx)` (function `get_transaction_hash`) on the
+    raw envelope bytes (payload transactions are always `Bytes`; a
+    legacy envelope IS its RLP, so one keccak covers both arms). -/
+def get_transaction_hash (encoded_tx : Bytes) : Hash32 :=
+  keccak256 encoded_tx
+
+/-! ## Intrinsic gas (`IntrinsicGasCost`, `validate_transaction`,
+`calculate_intrinsic_cost`, `count_tokens_in_data`) -/
+
+/-- `IntrinsicGasCost` (class `IntrinsicGasCost`). -/
+structure IntrinsicGasCost where
+  regular : Uint
+  state : Uint
+  calldataFloor : Uint
+  deriving Repr, BEq
+
+/-- `TX_MAX_GAS_LIMIT` (EIP-8037). -/
+def TX_MAX_GAS_LIMIT : Uint := 16777216
+
+/-- `ACCESS_LIST_ADDRESS_FLOOR_TOKENS` (EIP-7981). -/
+def ACCESS_LIST_ADDRESS_FLOOR_TOKENS : Uint := 80
+/-- `ACCESS_LIST_STORAGE_KEY_FLOOR_TOKENS` (EIP-7981). -/
+def ACCESS_LIST_STORAGE_KEY_FLOOR_TOKENS : Uint := 128
+
+/-- `MAX_CODE_SIZE` / `MAX_INIT_CODE_SIZE` (`vm/interpreter.py`). -/
+def MAX_CODE_SIZE : Nat := 0x10000
+def MAX_INIT_CODE_SIZE : Nat := 2 * MAX_CODE_SIZE
+
+/-- `count_tokens_in_data(data)`: zero bytes 1 token, non-zero 4. -/
+def count_tokens_in_data (data : Bytes) : Uint :=
+  let num_zeros := data.countP (· == 0)
+  num_zeros + (data.length - num_zeros) * 4
+
+/-- `calculate_intrinsic_cost(tx, sender)`. -/
+def calculate_intrinsic_cost (tx : Transaction) (sender : Address) :
+    IntrinsicGasCost :=
+  let tokens_in_calldata := count_tokens_in_data tx.data
+  let data_cost := tokens_in_calldata * GasCosts.TX_DATA_TOKEN_STANDARD
+  let is_create := tx.to == none
+  let is_self_transfer := tx.to == some sender
+  let (recipient_regular_gas, recipient_state_gas) :=
+    if is_create then
+      (GasCosts.CREATE_ACCESS + init_code_cost tx.data.length
+        + (if tx.value > 0 then GasCosts.TRANSFER_LOG_COST else 0),
+       StateGasCosts.NEW_ACCOUNT)
+    else if !is_self_transfer then
+      (GasCosts.COLD_ACCOUNT_ACCESS
+        + (if tx.value > 0 then GasCosts.TRANSFER_LOG_COST + GasCosts.TX_VALUE_COST else 0),
+       0)
+    else (0, 0)
+  let (access_list_cost, tokens_in_access_list) :=
+    match tx.accessList? with
+    | none => (0, 0)
+    | some al => al.foldl (fun (cost, tokens) access =>
+        (cost + GasCosts.TX_ACCESS_LIST_ADDRESS
+           + access.slots.length * GasCosts.TX_ACCESS_LIST_STORAGE_KEY,
+         tokens + ACCESS_LIST_ADDRESS_FLOOR_TOKENS
+           + access.slots.length * ACCESS_LIST_STORAGE_KEY_FLOOR_TOKENS)) (0, 0)
+  let access_list_cost := access_list_cost
+    + tokens_in_access_list * GasCosts.TX_DATA_TOKEN_FLOOR
+  let (auth_regular_gas, auth_state_gas) :=
+    match tx with
+    | .setCode t =>
+        ((GasCosts.ACCOUNT_WRITE + GasCosts.REGULAR_PER_AUTH_BASE_COST)
+           * t.authorizations.length,
+         (StateGasCosts.NEW_ACCOUNT + StateGasCosts.AUTH_BASE)
+           * t.authorizations.length)
+    | _ => (0, 0)
+  let floor_tokens_in_calldata := tx.data.length * GasCosts.TX_DATA_TOKEN_STANDARD
+  let total_floor_tokens := floor_tokens_in_calldata + tokens_in_access_list
+  { regular := GasCosts.TX_BASE + data_cost + recipient_regular_gas
+      + access_list_cost + auth_regular_gas
+    state := recipient_state_gas + auth_state_gas
+    calldataFloor := total_floor_tokens * GasCosts.TX_DATA_TOKEN_FLOOR
+      + GasCosts.TX_BASE }
+
+/-- `validate_transaction(tx, sender)`: each raise is a distinct
+    rejection reason. -/
+def validate_transaction (tx : Transaction) (sender : Address) :
+    Except SpecError IntrinsicGasCost := do
+  let intrinsic := calculate_intrinsic_cost tx sender
+  if intrinsic.regular + intrinsic.state > tx.gas then
+    throw (.invalidTransaction "Insufficient intrinsic gas")
+  if intrinsic.calldataFloor > tx.gas then
+    throw (.invalidTransaction "Insufficient calldata floor")
+  if intrinsic.regular > TX_MAX_GAS_LIMIT then
+    throw (.invalidTransaction "Intrinsic regular gas exceeds TX_MAX_GAS_LIMIT")
+  if intrinsic.calldataFloor > TX_MAX_GAS_LIMIT then
+    throw (.invalidTransaction "Intrinsic calldata floor exceeds TX_MAX_GAS_LIMIT")
+  if tx.nonce ≥ 2^64 - 1 then
+    throw (.invalidTransaction "Nonce too high")
+  if tx.to == none && tx.data.length > MAX_INIT_CODE_SIZE then
+    throw (.invalidTransaction "Code size too large")
+  pure intrinsic
+
+/-! ## Sender recovery (`_signature_recovery_parameters`,
+`recover_transaction_public_key`, `recover_sender_from_public_key`,
+`_sender_address_from_public_key`, `signing_hash_*`) -/
+
+/-- `SECP256K1N` (`ethereum/crypto/elliptic_curve.py`). -/
+def SECP256K1N : Nat := Secp256k1.n
+
+private def signPrefix (typeByte : Option (BitVec 8)) (item : RLPItem) : Hash32 :=
+  keccak256 ((typeByte.map ([·])).getD [] ++ EvmAsm.EL.RLP.encode item)
+
+/-- `signing_hash_pre155(tx)` (function `signing_hash_pre155`). -/
+def signing_hash_pre155 (tx : LegacyTransaction) : Hash32 :=
+  signPrefix none (.list [scalarT tx.nonce, scalarT tx.gasPrice, scalarT tx.gas,
+    toItem tx.to, scalarT tx.value, .bytes tx.data])
+
+/-- `signing_hash_155(tx, chain_id)` (function `signing_hash_155`). -/
+def signing_hash_155 (tx : LegacyTransaction) (chain_id : U64) : Hash32 :=
+  signPrefix none (.list [scalarT tx.nonce, scalarT tx.gasPrice, scalarT tx.gas,
+    toItem tx.to, scalarT tx.value, .bytes tx.data, scalarT chain_id,
+    scalarT 0, scalarT 0])
+
+/-- `signing_hash_2930(tx)` (function `signing_hash_2930`). -/
+def signing_hash_2930 (tx : AccessListTransaction) : Hash32 :=
+  signPrefix (some 0x01) (.list [scalarT tx.chainId, scalarT tx.nonce,
+    scalarT tx.gasPrice, scalarT tx.gas, toItem tx.to, scalarT tx.value,
+    .bytes tx.data, .list (tx.accessList.map accessItem)])
+
+/-- `signing_hash_1559(tx)` (function `signing_hash_1559`). -/
+def signing_hash_1559 (tx : FeeMarketTransaction) : Hash32 :=
+  signPrefix (some 0x02) (.list [scalarT tx.chainId, scalarT tx.nonce,
+    scalarT tx.maxPriorityFeePerGas, scalarT tx.maxFeePerGas, scalarT tx.gas,
+    toItem tx.to, scalarT tx.value, .bytes tx.data,
+    .list (tx.accessList.map accessItem)])
+
+/-- `signing_hash_4844(tx)` (function `signing_hash_4844`). -/
+def signing_hash_4844 (tx : BlobTransaction) : Hash32 :=
+  signPrefix (some 0x03) (.list [scalarT tx.chainId, scalarT tx.nonce,
+    scalarT tx.maxPriorityFeePerGas, scalarT tx.maxFeePerGas, scalarT tx.gas,
+    .bytes tx.to, scalarT tx.value, .bytes tx.data,
+    .list (tx.accessList.map accessItem), scalarT tx.maxFeePerBlobGas,
+    .list (tx.blobVersionedHashes.map .bytes)])
+
+/-- `signing_hash_7702(tx)` (function `signing_hash_7702`). -/
+def signing_hash_7702 (tx : SetCodeTransaction) : Hash32 :=
+  signPrefix (some 0x04) (.list [scalarT tx.chainId, scalarT tx.nonce,
+    scalarT tx.maxPriorityFeePerGas, scalarT tx.maxFeePerGas, scalarT tx.gas,
+    .bytes tx.to, scalarT tx.value, .bytes tx.data,
+    .list (tx.accessList.map accessItem),
+    .list (tx.authorizations.map authItem)])
+
+/-- `_signature_recovery_parameters(chain_id, tx)`: `(r, s, recovery_id,
+    signing_hash)`; every `InvalidSignatureError` is a rejection. -/
+def _signature_recovery_parameters (chain_id : U64) (tx : Transaction) :
+    Except SpecError (U256 × U256 × U256 × Hash32) := do
+  let r := tx.r
+  let s := tx.s
+  if 0 ≥ r || r ≥ SECP256K1N then throw (.invalidSignature "bad r")
+  if 0 ≥ s || s > SECP256K1N / 2 then throw (.invalidSignature "bad s")
+  match tx with
+  | .legacy t =>
+      if t.v == 27 || t.v == 28 then
+        pure (r, s, t.v - 27, signing_hash_pre155 t)
+      else
+        let chain_id_x2 := chain_id * 2
+        if t.v ≠ 35 + chain_id_x2 && t.v ≠ 36 + chain_id_x2 then
+          throw (.invalidSignature "bad v")
+        pure (r, s, t.v - 35 - chain_id_x2, signing_hash_155 t chain_id)
+  | .accessList t =>
+      if t.yParity ≠ 0 && t.yParity ≠ 1 then throw (.invalidSignature "bad y_parity")
+      pure (r, s, t.yParity, signing_hash_2930 t)
+  | .feeMarket t =>
+      if t.yParity ≠ 0 && t.yParity ≠ 1 then throw (.invalidSignature "bad y_parity")
+      pure (r, s, t.yParity, signing_hash_1559 t)
+  | .blob t =>
+      if t.yParity ≠ 0 && t.yParity ≠ 1 then throw (.invalidSignature "bad y_parity")
+      pure (r, s, t.yParity, signing_hash_4844 t)
+  | .setCode t =>
+      if t.yParity ≠ 0 && t.yParity ≠ 1 then throw (.invalidSignature "bad y_parity")
+      pure (r, s, t.yParity, signing_hash_7702 t)
+
+/-- `recover_transaction_public_key(chain_id, tx)`: the canonical
+    uncompressed SEC1 key `0x04 ‖ x ‖ y`; any recovery failure is the
+    Python exception → rejection. -/
+def recover_transaction_public_key (chain_id : U64) (tx : Transaction) :
+    Except SpecError Bytes := do
+  let (r, s, recovery_id, signing_hash) ← _signature_recovery_parameters chain_id tx
+  match Secp256k1.recover (bytesBEtoNat signing_hash) r s recovery_id with
+  | .ok (x, y) => pure (0x04 :: (natToBytesBE 32 x ++ natToBytesBE 32 y))
+  | .error _ => throw (.invalidSignature "recovery failed")
+
+/-- `_sender_address_from_public_key(public_key)`. -/
+def _sender_address_from_public_key (public_key : Bytes) : Address :=
+  (keccak256 (public_key.drop 1)).drop 12
+
+/-- `recover_sender(chain_id, tx)` (function `recover_sender`). -/
+def recover_sender (chain_id : U64) (tx : Transaction) :
+    Except SpecError Address := do
+  pure (_sender_address_from_public_key (← recover_transaction_public_key chain_id tx))
+
+/-- `recover_sender_from_public_key(chain_id, tx, public_key)`: verify
+    the supplied key by full recovery + comparison (the stateless-guest
+    path, fed from `StatelessInput.publicKeys`). -/
+def recover_sender_from_public_key (chain_id : U64) (tx : Transaction)
+    (public_key : Bytes) : Except SpecError Address := do
+  if public_key != (← recover_transaction_public_key chain_id tx) then
+    throw (.invalidSignature "public key mismatch")
+  pure (_sender_address_from_public_key public_key)
+
 /-! ## Sanity checks -/
 
 private def encT (i : RLPItem) : Bytes := EvmAsm.EL.RLP.encode i
@@ -362,5 +673,83 @@ private def blobTxBytes : Bytes := 0x03 :: encT (.list
                               .list [.bytes [0x01]]]],
      scalar 0, scalar 1, scalar 1])) with
   | .error (.txDecodeError _) => true | _ => false
+
+/-! Intrinsic-cost and recovery vectors, cross-checked against the
+Python spec at `bd8c673` (generator in the PR description). -/
+
+private def vSender : Address := List.replicate 20 0xAA
+
+-- Legacy call with mixed calldata.
+private def vTx1 : LegacyTransaction :=
+  { nonce := 1, gasPrice := 10, gas := 100000, to := some (List.replicate 20 0xBB),
+    value := 5, data := [0x00, 0x01, 0x02, 0x00], v := 27, r := 1, s := 1 }
+
+#guard calculate_intrinsic_cost (.legacy vTx1) vSender
+  == { regular := 21040, state := 0, calldataFloor := 12256 }
+
+-- Creation with value: CREATE_ACCESS + init-code words + transfer log +
+-- NEW_ACCOUNT state gas.
+#guard calculate_intrinsic_cost (.legacy
+    { nonce := 1, gasPrice := 10, gas := 500000, to := none, value := 1,
+      data := List.replicate 40 0x60, v := 27, r := 1, s := 1 }) vSender
+  == { regular := 25400, state := 183600, calldataFloor := 14560 }
+
+-- Self-transfer with an access list: recipient/value charges skipped.
+#guard calculate_intrinsic_cost (.feeMarket
+    { chainId := 1, nonce := 0, maxPriorityFeePerGas := 1, maxFeePerGas := 10,
+      gas := 100000, to := some vSender, value := 0, data := [],
+      accessList := [{ account := List.replicate 20 0xCC,
+                       slots := [List.replicate 32 0x01, List.replicate 32 0x02] }],
+      yParity := 0, r := 1, s := 1 }) vSender
+  == { regular := 26376, state := 0, calldataFloor := 17376 }
+
+-- Set-code with one authorization.
+#guard calculate_intrinsic_cost (.setCode
+    { chainId := 1, nonce := 0, maxPriorityFeePerGas := 1, maxFeePerGas := 10,
+      gas := 200000, to := some (List.replicate 20 0xBB) |>.getD [], value := 0,
+      data := [], accessList := [],
+      authorizations := [{ chainId := 1, address := List.replicate 20 0xDD,
+                           nonce := 0, yParity := 0, r := 1, s := 1 }],
+      yParity := 0, r := 1, s := 1 }) vSender
+  == { regular := 30816, state := 218790, calldataFloor := 12000 }
+
+-- validate_transaction: vTx1 passes; a 21k-gas creation is short.
+#guard (validate_transaction (.legacy vTx1) vSender).toOption
+  == some { regular := 21040, state := 0, calldataFloor := 12256 }
+#guard match validate_transaction (.legacy { vTx1 with to := none, gas := 21000 })
+    vSender with
+  | .error (.invalidTransaction _) => true | _ => false
+
+-- EIP-155 signing hash + full sender recovery on a coincurve-signed
+-- transaction (privkey 0x0101…01, chain id 1).
+#guard bytesBEtoNat (signing_hash_155 vTx1 1)
+  == 0x65c3ae64d466f2a8ffeab9ea674e0275cd4428e6df077c3d786b5d7a5d8984db
+
+private def vTx1Signed : LegacyTransaction :=
+  { vTx1 with
+    v := 38
+    r := 0x1518619670d02fb8bf8f6f78b6b0885aae6820737cfdd8080a6d829e2f9cb327
+    s := 0x6cb5e9483bb48d9ddc77f9ae18296e8df37e00a99d5ea4b927e2b54c41492eec }
+
+private def vPubKey : Bytes :=
+  0x04 :: (natToBytesBE 32 0x1b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f
+    ++ natToBytesBE 32 0x70beaf8f588b541507fed6a642c5ab42dfdf8120a7f639de5122d47a69a8e8d1)
+
+#guard (recover_transaction_public_key 1 (.legacy vTx1Signed)).toOption == some vPubKey
+#guard (recover_sender 1 (.legacy vTx1Signed)).toOption.map bytesBEtoNat
+  == some 0x1a642f0e3c3af545e7acbd38b07251b3990914f1
+#guard (recover_sender_from_public_key 1 (.legacy vTx1Signed) vPubKey).toOption.map bytesBEtoNat
+  == some 0x1a642f0e3c3af545e7acbd38b07251b3990914f1
+-- A wrong supplied key is InvalidSignatureError.
+#guard match recover_sender_from_public_key 1 (.legacy vTx1Signed)
+    (0x04 :: List.replicate 64 0x01) with
+  | .error (.invalidSignature _) => true | _ => false
+-- High-s rejects (EIP-2).
+#guard match recover_sender 1 (.legacy { vTx1Signed with s := SECP256K1N - 1 }) with
+  | .error (.invalidSignature _) => true | _ => false
+
+-- encode_transaction round-trips through decode_transaction.
+#guard match decode_transaction (encode_transaction (.legacy vTx1Signed)) with
+  | .ok (.legacy tx) => tx == vTx1Signed | _ => false
 
 end EvmAsm.Stateless.SpecRef

--- a/EvmAsm/Stateless/SpecRef/Types.lean
+++ b/EvmAsm/Stateless/SpecRef/Types.lean
@@ -80,6 +80,13 @@ inductive SpecError where
   /-- `state_tracker.py`: an `AssertionError` on the state layer
       (`set_storage` on a missing account, `move_ether` underflow). -/
   | stateError (why : String)
+  /-- `transactions.py` `validate_transaction`:
+      `InsufficientTransactionGasError` / `NonceOverflowError` /
+      `InitCodeTooLargeError`. -/
+  | invalidTransaction (why : String)
+  /-- `transactions.py` signature validation / recovery:
+      `InvalidSignatureError`. -/
+  | invalidSignature (why : String)
   /-- `transactions.py` `decode_transaction` / `rlp.decode_to`: any
       `DecodingError`, `TransactionTypeError`, or `IndexError` while
       decoding a transaction envelope. -/

--- a/EvmAsm/Stateless/SpecRef/Types.lean
+++ b/EvmAsm/Stateless/SpecRef/Types.lean
@@ -77,6 +77,9 @@ inductive SpecError where
   /-- `fork.py` / `execution_engine/new_payload.py`: any `InvalidBlock`
       raised by the pre-checks or the `execute_block` frame. -/
   | invalidBlock (why : String)
+  /-- `state_tracker.py`: an `AssertionError` on the state layer
+      (`set_storage` on a missing account, `move_ether` underflow). -/
+  | stateError (why : String)
   /-- `transactions.py` `decode_transaction` / `rlp.decode_to`: any
       `DecodingError`, `TransactionTypeError`, or `IndexError` while
       decoding a transaction envelope. -/

--- a/EvmAsm/Stateless/SpecRef/Vm.lean
+++ b/EvmAsm/Stateless/SpecRef/Vm.lean
@@ -1,0 +1,410 @@
+/-
+  EvmAsm.Stateless.SpecRef.Vm
+
+  Port of the EVM machine layer of
+  `execution-specs/src/ethereum/forks/amsterdam/` (`@tests-zkevm@v0.5.0`,
+  `bd8c673`) — bead `evm-asm-s1d19.5`, Stack C stage 3:
+
+  * `vm/__init__.py`: `BlockEnvironment`, `BlockOutput`,
+    `TransactionEnvironment`, `Message`, `Evm` (classes of the same
+    names), `credit_state_gas_refund` (function
+    `credit_state_gas_refund`), `TRANSFER_TOPIC` / `SYSTEM_ADDRESS` /
+    `CALL_SUCCESS` and the `blocks.py` `Log` (class `Log`)
+  * `vm/exceptions.py`: the `ExceptionalHalt` / `Revert` hierarchy
+    (class `ExceptionalHalt` and friends) as `EvmError`
+  * `vm/stack.py`: `pop`, `push`, `decode_single`, `decode_pair`
+    (functions of the same names)
+  * `vm/memory.py`: `memory_write`, `memory_read_bytes`, `buffer_read`
+    (functions of the same names)
+  * `vm/gas.py`: `check_gas`, `charge_gas`, `charge_state_gas`
+    (functions of the same names) — the `Evm`-mutating half deferred
+    from the stage-2 `Gas.lean`
+
+  ## The machine monad
+
+  Python instruction implementations mutate an `Evm` object (which
+  aliases the `TransactionState`/`BlockState` trackers through
+  `message.tx_env.state`) and raise two kinds of exceptions:
+
+  * `ExceptionalHalt` / `Revert` — caught at frame boundaries
+    (`execute_code`); the `Evm`'s mutations up to the raise are KEPT
+    (state-tracker rollback is a separate, explicit
+    `restore_tx_state`).
+  * everything else (witness-authentication failures, spec asserts) —
+    propagates uncaught to `verify_stateless_new_payload` → rejection.
+
+  The monad mirrors exactly that:
+  `EvmM α := ExceptT EvmError (StateT Machine (Except SpecError)) α`
+  — a thrown `EvmError` carries the mutated `Machine` with it, while a
+  `SpecError` aborts the whole computation.  `Machine` is the current
+  frame's `Evm` plus the shared world (the transaction tracker; the
+  Python aliasing `evm.message.tx_env.state.parent == block_env.state`
+  becomes a single copy living in `Machine.txState`).  Frame nesting
+  (`parent_evm`) is realized by RUNNING the child's `EvmM` on a child
+  `Machine` and merging (the interpreter stage); `parent_evm` itself is
+  only read by tracing hooks, which are not modeled.
+
+  Python `bytearray` memory is `Bytes` here; `Set`s are dedup lists
+  (`StateTracker.lean` conventions).
+-/
+
+import EvmAsm.Stateless.SpecRef.BlockAccessLists
+import EvmAsm.Stateless.SpecRef.Transactions
+
+namespace EvmAsm.Stateless.SpecRef
+
+/-! ## `vm/exceptions.py` — `EvmError` -/
+
+/-- The `ExceptionalHalt`/`Revert` hierarchy (`vm/exceptions.py`).
+    `revert` is the only non-halt: it preserves unspent gas. -/
+inductive EvmError where
+  | revert
+  | stackUnderflow
+  | stackOverflow
+  | outOfGas
+  | invalidOpcode (op : Nat)
+  | invalidJumpDest
+  | stackDepthLimit
+  | writeInStaticContext
+  | outOfBoundsRead
+  | invalidParameter (why : String)
+  | invalidContractPrefix
+  | addressCollision
+  | kzgProofError
+  deriving Repr, BEq
+
+/-- Is this an `ExceptionalHalt` (consumes all frame gas)? -/
+def EvmError.isHalt : EvmError → Bool
+  | .revert => false
+  | _ => true
+
+/-! ## `blocks.py` `Log` (class `Log`) -/
+
+/-- `Log` (`blocks.py`, class `Log`). -/
+structure Log where
+  address : Address
+  topics : List Hash32
+  data : Bytes
+  deriving Repr, BEq
+
+/-! ## `vm/__init__.py` dataclasses -/
+
+/-- `TRANSFER_TOPIC = keccak256(b"Transfer(address,address,uint256)")`. -/
+def TRANSFER_TOPIC : Hash32 :=
+  keccak256 ("Transfer(address,address,uint256)".toUTF8.toList.map
+    (fun b => BitVec.ofNat 8 b.toNat))
+
+/-- `SYSTEM_ADDRESS` (`vm/__init__.py`). -/
+def VM_SYSTEM_ADDRESS : Address :=
+  natToBytesBE 20 0xfffffffffffffffffffffffffffffffffffffffe
+
+/-- `CALL_SUCCESS` (`vm/__init__.py`). -/
+def CALL_SUCCESS : U256 := 1
+
+/-- `BlockEnvironment` (class `BlockEnvironment`), minus the mutable
+    `state`/`block_access_list_builder` — those live in `Machine`
+    (see the header note on aliasing). -/
+structure BlockEnvironment where
+  chainId : U64
+  blockGasLimit : Uint
+  blockHashes : List Hash32
+  coinbase : Address
+  number : Uint
+  baseFeePerGas : Uint
+  time : U256
+  prevRandao : Bytes32
+  excessBlobGas : U64
+  parentBeaconBlockRoot : Hash32
+  slotNumber : U64
+  transactionPublicKeys : Option (List Bytes) := none
+  deriving Repr
+
+/-- `BlockOutput` (class `BlockOutput`); the three `Trie`s are their
+    key→value assoc data (roots are computed at the end via
+    `build_mpt`/`mpt_root`, exactly the Python `root(trie)`). -/
+structure BlockOutput where
+  blockGasUsed : Uint := 0
+  blockStateGasUsed : Uint := 0
+  cumulativeGasUsed : Uint := 0
+  transactionsTrie : List (Bytes × Bytes) := []
+  receiptsTrie : List (Bytes × Bytes) := []
+  receiptKeys : List Bytes := []
+  blockLogs : List Log := []
+  withdrawalsTrie : List (Bytes × Bytes) := []
+  blobGasUsed : U64 := 0
+  requests : List Bytes := []
+  blockAccessList : BlockAccessList := []
+  deriving Repr
+
+/-- `TransactionEnvironment` (class `TransactionEnvironment`), minus
+    the mutable `state` tracker (lives in `Machine`). -/
+structure TransactionEnvironment where
+  origin : Address
+  /-- `Bytes0 | Address`: `none` = creation. -/
+  recipient : Option Address
+  value : U256
+  gasPrice : Uint
+  gas : Uint
+  stateGasReservoir : Uint
+  accessListAddresses : List Address
+  accessListStorageKeys : List (Address × Bytes32)
+  blobVersionedHashes : List VersionedHash
+  authorizations : List Authorization
+  indexInBlock : Option Uint
+  txHash : Option Hash32
+  intrinsicRegularGas : Uint
+  intrinsicStateGas : Uint
+  deriving Repr
+
+/-- `Message` (class `Message`), minus `parent_evm` (tracing only). -/
+structure Message where
+  blockEnv : BlockEnvironment
+  txEnv : TransactionEnvironment
+  caller : Address
+  /-- `Bytes0 | Address`: `none` = creation. -/
+  target : Option Address
+  currentTarget : Address
+  gas : Uint
+  stateGasReservoir : Uint
+  value : U256
+  data : Bytes
+  codeAddress : Option Address
+  code : Bytes
+  depth : Uint
+  shouldTransferValue : Bool
+  isStatic : Bool
+  accessedAddresses : List Address
+  accessedStorageKeys : List (Address × Bytes32)
+  disablePrecompiles : Bool
+  deriving Repr
+
+/-- `Evm` (class `Evm`) — the per-frame machine registers. -/
+structure Evm where
+  pc : Uint := 0
+  stack : List U256 := []
+  memory : Bytes := []
+  code : Bytes
+  gasLeft : Uint
+  stateGasLeft : Uint
+  validJumpDestinations : List Uint
+  logs : List Log := []
+  refundCounter : Int := 0
+  running : Bool := true
+  message : Message
+  output : Bytes := []
+  accountsToDelete : List Address := []
+  returnData : Bytes := []
+  error : Option EvmError := none
+  accessedAddresses : List Address
+  accessedStorageKeys : List (Address × Bytes32)
+  regularGasUsed : Uint := 0
+  stateGasUsed : Int := 0
+  stateGasSpilled : Uint := 0
+  deriving Repr
+
+/-- The machine: the current frame plus the shared mutable world (the
+    transaction tracker — whose `parent` is the block tracker — and
+    the BAL builder). -/
+structure Machine where
+  evm : Evm
+  txState : TransactionState
+
+/-- The machine monad (see the header): `EvmError` throws carry the
+    mutated state; `SpecError`s abort everything. -/
+abbrev EvmM (α : Type) := ExceptT EvmError (StateT Machine (Except SpecError)) α
+
+namespace EvmM
+
+/-- Run a `TxM` (state-tracker) action against the machine's tracker. -/
+def liftTx (m : TxM α) : EvmM α := fun s =>
+  match m.run s.txState with
+  | .error e => .error e
+  | .ok (a, ts) => .ok (.ok a, { s with txState := ts })
+
+/-- Abort with a spec-level rejection (never caught by frames). -/
+def liftSpec (m : Except SpecError α) : EvmM α := fun s =>
+  match m with
+  | .error e => .error e
+  | .ok a => .ok (.ok a, s)
+
+def getEvm : EvmM Evm := fun s => .ok (.ok s.evm, s)
+
+def modifyEvm (f : Evm → Evm) : EvmM Unit := fun s =>
+  .ok (.ok (), { s with evm := f s.evm })
+
+end EvmM
+
+/-! ## `vm/stack.py` -/
+
+/-- `pop(stack)` (`vm/stack.py`, function `pop`). -/
+def stackPop : EvmM U256 := do
+  match (← EvmM.getEvm).stack with
+  | [] => throw .stackUnderflow
+  | top :: rest =>
+      EvmM.modifyEvm (fun e => { e with stack := rest })
+      pure top
+
+/-- Pop `n` items (top first). -/
+def stackPopN (n : Nat) : EvmM (List U256) :=
+  (List.range n).mapM (fun _ => stackPop)
+
+/-- `push(stack, value)` (`vm/stack.py`, function `push`). -/
+def stackPush (value : U256) : EvmM Unit := do
+  if (← EvmM.getEvm).stack.length == 1024 then throw .stackOverflow
+  EvmM.modifyEvm (fun e => { e with stack := value :: e.stack })
+
+/-- `decode_single(x)` (`vm/stack.py`, function `decode_single`):
+    DUPN/SWAPN immediate → stack index `17 ≤ n ≤ 235`. -/
+def decode_single (x : Nat) : Except EvmError Nat :=
+  if x ≤ 90 || (128 ≤ x && x ≤ 255) then pure ((x + 145) % 256)
+  else throw (.invalidParameter "DUPN/SWAPN immediate out of range")
+
+/-- `decode_pair(x)` (`vm/stack.py`, function `decode_pair`):
+    EXCHANGE immediate → `(n, m)`, `1 ≤ n ≤ 14`, `n < m ≤ 30 − n`. -/
+def decode_pair (x : Nat) : Except EvmError (Nat × Nat) :=
+  if x ≤ 81 || (128 ≤ x && x ≤ 255) then
+    let k := x ^^^ 143
+    let q := k / 16
+    let r := k % 16
+    if q < r then pure (q + 1, r + 1)
+    else pure (r + 1, 30 - q - r + 1)
+  else throw (.invalidParameter "EXCHANGE immediate in forbidden range")
+
+/-! ## `vm/memory.py`
+
+Memory is `Bytes`; expansion happens explicitly (`extend_memory` at the
+instruction sites appends zeros), matching the Python bytearray whose
+size only grows via the gas-metered extension. -/
+
+/-- `memory_write(memory, start_position, value)`. -/
+def memory_write (memory : Bytes) (start_position : U256) (value : Bytes) : Bytes :=
+  memory.take start_position ++ value ++ memory.drop (start_position + value.length)
+
+/-- `memory_read_bytes(memory, start_position, size)`. -/
+def memory_read_bytes (memory : Bytes) (start_position size : U256) : Bytes :=
+  (memory.drop start_position).take size
+
+/-- `buffer_read(buffer, start_position, size)`: zero-padded read. -/
+def buffer_read (buffer : Bytes) (start_position size : U256) : Bytes :=
+  let s := (buffer.drop start_position).take size
+  s ++ List.replicate (size - s.length) 0x00
+
+/-- Grow the frame memory by `expand_by` zero bytes (the instruction
+    sites' `evm.memory += b"\x00" * extend_memory.expand_by`). -/
+def extendMemory (expand_by : Uint) : EvmM Unit :=
+  EvmM.modifyEvm (fun e => { e with memory := e.memory ++ List.replicate expand_by 0x00 })
+
+/-! ## `vm/gas.py` — the `Evm`-mutating half
+(`check_gas` / `charge_gas` / `charge_state_gas`, and
+`vm/__init__.py` `credit_state_gas_refund`) -/
+
+/-- `check_gas(evm, amount)`. -/
+def check_gas (amount : Uint) : EvmM Unit := do
+  if (← EvmM.getEvm).gasLeft < amount then throw .outOfGas
+
+/-- `charge_gas(evm, amount)`. -/
+def charge_gas (amount : Uint) : EvmM Unit := do
+  if (← EvmM.getEvm).gasLeft < amount then throw .outOfGas
+  EvmM.modifyEvm (fun e =>
+    { e with gasLeft := e.gasLeft - amount
+             regularGasUsed := e.regularGasUsed + amount })
+
+/-- `charge_state_gas(evm, amount)`: reservoir first, spill into
+    `gas_left`. -/
+def charge_state_gas (amount : Uint) : EvmM Unit := do
+  let e ← EvmM.getEvm
+  if e.stateGasLeft ≥ amount then
+    EvmM.modifyEvm (fun e => { e with stateGasLeft := e.stateGasLeft - amount })
+  else if e.stateGasLeft + e.gasLeft ≥ amount then
+    let remainder := amount - e.stateGasLeft
+    EvmM.modifyEvm (fun e =>
+      { e with stateGasLeft := 0
+               gasLeft := e.gasLeft - remainder
+               stateGasSpilled := e.stateGasSpilled + remainder })
+  else
+    throw .outOfGas
+  EvmM.modifyEvm (fun e => { e with stateGasUsed := e.stateGasUsed + amount })
+
+/-- `credit_state_gas_refund(evm, amount)` (`vm/__init__.py`): LIFO —
+    `gas_left` up to `state_gas_spilled`, then the reservoir. -/
+def credit_state_gas_refund (amount : Uint) : EvmM Unit := do
+  let e ← EvmM.getEvm
+  let from_gas_left := min amount e.stateGasSpilled
+  EvmM.modifyEvm (fun e =>
+    { e with gasLeft := e.gasLeft + from_gas_left
+             stateGasSpilled := e.stateGasSpilled - from_gas_left
+             stateGasLeft := e.stateGasLeft + (amount - from_gas_left)
+             stateGasUsed := e.stateGasUsed - amount })
+
+/-! ## Sanity checks -/
+
+private def testMachine : Machine :=
+  let blockEnv : BlockEnvironment :=
+    { chainId := 1, blockGasLimit := 30000000, blockHashes := [],
+      coinbase := List.replicate 20 0, number := 1, baseFeePerGas := 7,
+      time := 0, prevRandao := List.replicate 32 0, excessBlobGas := 0,
+      parentBeaconBlockRoot := List.replicate 32 0, slotNumber := 1 }
+  let txEnv : TransactionEnvironment :=
+    { origin := List.replicate 20 0xAA, recipient := none, value := 0,
+      gasPrice := 10, gas := 100000, stateGasReservoir := 0,
+      accessListAddresses := [], accessListStorageKeys := [],
+      blobVersionedHashes := [], authorizations := [], indexInBlock := none,
+      txHash := none, intrinsicRegularGas := 21000, intrinsicStateGas := 0 }
+  let msg : Message :=
+    { blockEnv, txEnv, caller := List.replicate 20 0xAA, target := none,
+      currentTarget := List.replicate 20 0xBB, gas := 79000,
+      stateGasReservoir := 0, value := 0, data := [], codeAddress := none,
+      code := [], depth := 0, shouldTransferValue := true, isStatic := false,
+      accessedAddresses := [], accessedStorageKeys := [],
+      disablePrecompiles := false }
+  { evm := { code := [], gasLeft := 1000, stateGasLeft := 50,
+             validJumpDestinations := [], message := msg,
+             accessedAddresses := [], accessedStorageKeys := [] }
+    txState := { parent := { preState := { nodeDb := [], stateRoot := EMPTY_TRIE_ROOT,
+                                           codeDb := [] } } } }
+
+private def runVm (m : EvmM α) : Except SpecError (Except EvmError α × Machine) :=
+  (m.run.run testMachine)
+
+-- push/pop round trip; underflow and overflow throw.
+#guard match runVm (do stackPush 5; stackPush 7; stackPop) with
+  | .ok (.ok 7, s) => s.evm.stack == [5] | _ => false
+#guard match runVm stackPop with
+  | .ok (.error .stackUnderflow, _) => true | _ => false
+#guard match runVm (do
+    for _ in [0:1024] do stackPush 1
+    stackPush 1) with
+  | .ok (.error .stackOverflow, s) => s.evm.stack.length == 1024 | _ => false
+
+-- decode_single/decode_pair vectors (Python: decode_single(0)=145,
+-- decode_single(90)=235, decode_single(128)=17, decode_single(255)=144;
+-- decode_pair(0)=(1,16)… k=143→q=8,r=15,q<r→(9,16); forbidden ranges).
+#guard (decode_single 0).toOption == some 145
+#guard (decode_single 90).toOption == some 235
+#guard (decode_single 128).toOption == some 17
+#guard (decode_single 255).toOption == some 144
+#guard match decode_single 100 with | .error (.invalidParameter _) => true | _ => false
+#guard (decode_pair 0).toOption == some (9, 16)
+#guard match decode_pair 100 with | .error (.invalidParameter _) => true | _ => false
+
+-- memory: write/read round trip, zero-padded buffer read.
+#guard memory_write [0, 0, 0, 0] 1 [0xAA, 0xBB] == [0, 0xAA, 0xBB, 0]
+#guard memory_read_bytes [1, 2, 3, 4] 1 2 == [2, 3]
+#guard buffer_read [1, 2, 3] 2 4 == [3, 0, 0, 0]
+
+-- charge_gas debits and records; OOG preserves the machine state.
+#guard match runVm (do charge_gas 300; charge_gas 800) with
+  | .ok (.error .outOfGas, s) => s.evm.gasLeft == 700 && s.evm.regularGasUsed == 300
+  | _ => false
+
+-- charge_state_gas: reservoir first, then spill; refund restores LIFO.
+#guard match runVm (do
+    charge_state_gas 30   -- reservoir 50 → 20
+    charge_state_gas 120  -- reservoir → 0, spill 100 from gas_left
+    credit_state_gas_refund 110) with
+  | .ok (.ok _, s) =>
+      s.evm.stateGasLeft == 10 && s.evm.gasLeft == 1000
+      && s.evm.stateGasSpilled == 0 && s.evm.stateGasUsed == 40
+  | _ => false
+
+end EvmAsm.Stateless.SpecRef

--- a/EvmAsm/Stateless/SpecRef/WitnessStateRoot.lean
+++ b/EvmAsm/Stateless/SpecRef/WitnessStateRoot.lean
@@ -61,6 +61,13 @@ def cacheFill (ws : WitnessPreState) (cache : StorageRootCache)
   else
     pure (cache ++ [(address, sr)])
 
+/-- Reconstruct the `_storage_root_cache` content at block end from the
+    set of witness-reaching read addresses (`BlockState.preStateReads`):
+    the values are the deterministic `_storage_root_of` results. -/
+def cacheFromReads (ws : WitnessPreState) (reads : List Address) :
+    Except SpecError StorageRootCache :=
+  reads.foldlM (cacheFill ws) []
+
 /-- `compute_state_root_and_trie_changes(account_changes, storage_changes,
     storage_clears)`.  `cache₀`: the `_storage_root_cache` at entry (see
     header).  Values: `account_changes` uses `none` for deleted accounts


### PR DESCRIPTION
Stacked on #10174. First two increments of the EVM-core epic (bead `evm-asm-s1d19.5`, issue #10141), as **two commits reviewable separately**:

## Commit 1 — state tracker + block access lists (`state_tracker.py`, `block_access_lists.py`)

- `StateTracker.lean` — `BlockState`/`TransactionState` as the state of `TxM := StateT TransactionState (Except SpecError)`; full read chain (tx writes → block writes → authenticated witness), predicates, writes (`modify_state` empty-account destruction, `move_ether`, `set_code`, transient storage), snapshot/rollback with Python's sharing semantics (reads + `created_accounts` survive rollback), merge-into-block, `extract_block_diff`, ancestor tracking.
- **Modeling addition** (documented): `BlockState.preStateReads` tracks which addresses reached the witness — exactly the `_storage_root_cache` keys `compute_state_root_and_trie_changes` observes; `cacheFromReads` reconstructs its `cache₀` deterministically.
- `BlockAccessLists.lean` — EIP-7928 builder (final-write-per-index, highest-nonce), `_build_from_builder` (stable sorts, all axes), `update_builder_from_tx`, RLP + `hash_block_access_list`, gas-limit validation.
- `#guard`: full tracker→BAL→post-root scenario pinned to the Python spec (BAL hash + recomputed root exact).

## Commit 2 — full gas model + transactions intrinsic/recovery (`vm/gas.py`, `transactions.py`)

- `Gas.lean` — `StateGasCosts` (EIP-8037) + full non-opcode `GasCosts`; `ceil32`, memory-expansion gas, `calculate_message_call_gas` (63/64), `init_code_cost`. Python-checked vectors incl. derived constants.
- `Transactions.lean` — uniform union accessors, `encode_transaction`/`get_transaction_hash`, `IntrinsicGasCost`/`calculate_intrinsic_cost`/`validate_transaction` (EIP-7623/7981/8037), the five `signing_hash_*`, `_signature_recovery_parameters` (EIP-2/155 gates), `recover_transaction_public_key` via the SpecRef secp256k1 reference, `recover_sender_from_public_key` (the supplied-pubkey stateless path).
- `#guard`: 4 intrinsic shapes, EIP-155 signing hash, **full sender recovery on a coincurve-signed tx** (pubkey + address exact), wrong-pubkey/high-s rejections, encode/decode round trip.

Gates: `lake build`, `check-forbidden-tactics`, `check-axioms`, `check-spec-refs` (38 citations) all green.

Refs: evm-asm-s1d19.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)