### PR TITLE
fix(gas): preserve settled prefix across create check

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -454,6 +454,9 @@ def ziskStatelessVerdictV2DataSection : String :=
   -- delegation marker. Debug/accounting context for auth-base state refunds;
   -- regular gas refunds are threaded through tx_eip7702_existing_authority_refund.
   "bvgr_tx_predelegated_auth_count:\n  .zero " ++ toString bvMtxU64ArenaBytes ++ "\n" ++
+  -- Preserve the settled-prefix block gas across `bgv_u64le` while checking
+  -- whether a following CREATE transaction fits the remaining 2D budget.
+  "bv_mtx_creation_prefix_used:\n  .zero 8\n" ++
   "bv_exact_header_gas_used:\n  .zero 8\n" ++
   "bv_exact_expected_gas_used:\n  .zero 8\n" ++
   "bv_exact_net_status:\n  .zero 8\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictMtxRuntime.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictMtxRuntime.lean
@@ -302,7 +302,9 @@ def blockVerdictMtxRuntimeLoop : String :=
   "  la t0, bv_mtx_i; ld a5, 0(t0); la a6, bvgr_block_gas_increments; li a7, 0\n" ++
   "  jal ra, eip7778_remaining_block_gas_from_results\n" ++
   "  bnez a0, .Lbv_mtx_creation_prefix_done\n" ++
-  "  mv t0, a2; la t1, bv_exec_p; ld t1, 0(t1); addi a0, t1, 412; jal ra, bgv_u64le\n" ++
+  "  la t0, bv_mtx_creation_prefix_used; sd a2, 0(t0)\n" ++
+  "  la t1, bv_exec_p; ld t1, 0(t1); addi a0, t1, 412; jal ra, bgv_u64le\n" ++
+  "  la t0, bv_mtx_creation_prefix_used; ld t0, 0(t0)\n" ++
   "  bltu a0, t0, .Lbv_eip8037_gas_fail\n" ++
   "  sub t1, a0, t0; la t0, bv_mtx_ctx; ld t2, 40(t0); li t3, 16777216; bleu t2, t3, .Lbv_mtx_creation_cap_done; mv t2, t3\n" ++
   ".Lbv_mtx_creation_cap_done:\n" ++


### PR DESCRIPTION
## Summary
- preserve exact settled-prefix block gas across the payload gas-limit decode
- apply the CREATE transaction regular/state availability checks to the preserved value
- remove a false rejection caused by using a clobbered caller-saved register

## Execution-specs alignment
The multi-transaction path now checks the following CREATE transaction against the remaining 2D block budget after the preceding transaction settles, matching execution-specs reservation/release ordering.

## Verification
- fixture 2236: 1/1 exact
- EIP-8025 witness bytecode contract-creation group: 10/10 exact
- randomized fixtures 2000-2999, seed 20260777: 1000/1000 exact
- lake build
- check-file-size.sh
- check-layering.sh
- check-forbidden-tactics.sh
- check-no-hardcoded-guest-pc.sh