### PR TITLE
feat(sasm): bal_account_nonstorage_finals top-theorem groundwork (4ch8f.43.5)

### DIFF
--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainB.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainB.lean
@@ -213,12 +213,374 @@ def outerRej (aB : Word) (acctBytes : List (BitVec 8)) (F : Assertion) :
   ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
   bytesRegion aB acctBytes ** F
 
-/- The outer `rlp_walk_init` dispatch (slot 22 call + slot 23 status check
-   ⇒ `outerRej` / `outerInitPost`) is the next slice: the nine callee arms
-   need explicit per-arm branch lemmas (seven `outerFail` instantiations +
-   the two success arms unified into `OuterInitOk` via the short/long
-   `listHeaderSize` bridges), recombined with `cpsBranchWithin_pre_or` as in
-   `fl_round`.  The interfaces above are final. -/
+/-- Outer `rlp_walk_init` (slot 22) + status check (slot 23): reject on any
+    non-zero status; on success, land at `B + 96` with the unified
+    `listHeaderSize`-anchored content cursor.  The nine callee arms collapse
+    pointwise into success (`OuterInitOk`) vs failure (some non-zero status)
+    BEFORE the branch dispatch, so only two branch lemmas are needed. -/
+theorem bansf_outerInit_spec (aB : Word) (aLen : Nat)
+    (acctBytes : List (BitVec 8))
+    (v5 v6 v7 v12 v28 v29 v30 v31 vRa : Word) (F : Assertion)
+    (hF : F.pcFree)
+    (hsalign : aB.toNat % 8 = 0)
+    (hslack : aLen + 9 ≤ acctBytes.length)
+    (hover : aB.toNat + acctBytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < acctBytes.length →
+      isValidByteAccess (aB + BitVec.ofNat 64 k) = true) :
+    cpsBranchWithin 84 (B + 88) bansfCR
+      (((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ BitVec.ofNat 64 aLen) **
+       ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+       bytesRegion aB acctBytes ** F)
+      (B + 736) (outerRej aB acctBytes F)
+      (B + 96) (outerInitPost aB aLen acctBytes F) := by
+  have hoffb : 0 < acctBytes.length := by omega
+  have hlenlt : aLen < 2 ^ 64 := by omega
+  -- the callee triple at its entry with ra = B + 88 + 4
+  have hwi := rlp_walk_init_spec_within WI aB (B + 88 + 4) (BitVec.ofNat 64 aLen)
+    v12 v5 v6 v7 v28 v29 v30 v31 acctBytes 0 hsalign hoffb (by omega)
+    (by have := hvalid 0 hoffb; exact this)
+    (fun hf8 => by
+      have hlo : ((acctBytes[0]'hoffb).zeroExtend 64 - (0xf7 : Word)).toNat ≤ 8 := by
+        have h2 := not_ult_le hf8
+        have h3 := (acctBytes[0]'hoffb).isLt
+        bv_omega
+      omega)
+    (fun hf8 => by
+      have hlo : ((acctBytes[0]'hoffb).zeroExtend 64 - (0xf7 : Word)).toNat ≤ 8 := by
+        have h2 := not_ult_le hf8
+        have h3 := (acctBytes[0]'hoffb).isLt
+        bv_omega
+      omega)
+    (fun hf8 => by
+      intro k hk
+      have hlo : ((acctBytes[0]'hoffb).zeroExtend 64 - (0xf7 : Word)).toNat ≤ 8 := by
+        have h2 := not_ult_le hf8
+        have h3 := (acctBytes[0]'hoffb).isLt
+        bv_omega
+      exact hvalid _ (by omega))
+  rw [show aB + BitVec.ofNat 64 0 = aB from by bv_omega] at hwi
+  have hwi' := cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp) (fun _ hq => hq) hwi
+    (P' := ((.x1 : Reg) ↦ᵣ (B + 88 + 4)) **
+      (((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ BitVec.ofNat 64 aLen) **
+       ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion aB acctBytes))
+  have hcall := bansf_callSite22_walk_init (n := 81) vRa (by pcf) hwi'
+  rw [show (B + 88) + 4 = B + 92 from by bv_omega] at hcall
+  have hcallF := cpsTripleWithin_frameR F hF hcall
+  -- the value-representation bridge for the long success arm
+  set bb : BitVec 8 := acctBytes[0]'hoffb with hbb
+  -- ===== the success continuation (status pinned 0) =====
+  have hsucc : cpsBranchWithin 2 (B + 92) bansfCR
+      (fun h => ∃ cOff : Nat,
+        ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+          ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+          ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 88 + 4)) **
+          bytesRegion aB acctBytes ** F) **
+         ⌜OuterInitOk acctBytes aLen cOff⌝) h)
+      (B + 736) (outerRej aB acctBytes F)
+      (B + 96) (outerInitPost aB aLen acctBytes F) := by
+    refine cpsBranchWithin_exists_pre (fun cOff => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hok => ?_)
+    have hbne := bne_spec_gen_within .x12 .x0 (640 : BitVec 13) (0 : Word) (0 : Word) (B + 92)
+    rw [show (B + 92) + 4 = B + 96 from by bv_omega] at hbne
+    have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 92) bansfProg 23 (.BNE .x12 .x0 (640 : BitVec 13))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+      hbne
+    have hfall := cpsBranchWithin_ntakenPath hbneL
+      (fun hp hQt => by
+        obtain ⟨_, _, _, _, _, h_pure⟩ := hQt
+        exact absurd rfl (((sepConj_pure_right _).1 h_pure).2))
+    have hfallF := cpsTripleWithin_frameR
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+       ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 88 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hfall
+    have hout : cpsTripleWithin 1 (B + 92) (B + 96) bansfCR
+        (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+         ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+         ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 88 + 4)) **
+         bytesRegion aB acctBytes ** F)
+        (outerInitPost aB aLen acctBytes F) := by
+      refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hfallF
+      unfold outerInitPost
+      refine ⟨cOff, ?_⟩
+      have hq2 : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+          ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+          ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+          bytesRegion aB acctBytes ** F)) h := by
+        have hq3 := sepConj_mono_left (sepConj_mono_right
+          (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hq
+        have hq4 : ((((.x1 : Reg) ↦ᵣ (B + 88 + 4)) **
+            (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+             ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+             ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+             regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+             regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+             ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+             bytesRegion aB acctBytes ** F))) h := by
+          xperm_hyp hq3
+        have hq5 := sepConj_mono (regIs_implies_regOwn .x1) (fun _ x => x) h hq4
+        xperm_hyp hq5
+      exact (sepConj_pure_right h).2 ⟨hq2, hok⟩
+    exact cpsBranchWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_as_cpsBranchWithin_right _ _ hout)
+  -- ===== the failure continuation (status pinned non-zero) =====
+  have hfailc : cpsBranchWithin 2 (B + 92) bansfCR
+      (fun h => ∃ cur endW k : Word,
+        ((((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ endW) **
+          ((.x12 : Reg) ↦ᵣ k) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 88 + 4)) **
+          bytesRegion aB acctBytes ** F) **
+         ⌜k ≠ (0 : Word)⌝) h)
+      (B + 736) (outerRej aB acctBytes F)
+      (B + 96) (outerInitPost aB aLen acctBytes F) := by
+    refine cpsBranchWithin_exists_pre (fun cur => ?_)
+    refine cpsBranchWithin_exists_pre (fun endW => ?_)
+    refine cpsBranchWithin_exists_pre (fun k => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hk => ?_)
+    refine cpsTripleWithin_as_cpsBranchWithin_left _ _
+      (cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
+        (outerFail aB cur endW k acctBytes F hF hk))
+  -- ===== chain: call ; (success ∨ failure) =====
+  refine cpsBranchWithin_weaken
+    (fun h hp => by xperm_hyp hp) (fun _ x => x) (fun _ x => x)
+    (cpsTripleWithin_seq_branch_same_cr hcallF
+      (cpsBranchWithin_weaken (fun h hp => ?_) (fun _ x => x) (fun _ x => x)
+        (cpsBranchWithin_pre_or hsucc hfailc)))
+  -- pointwise: collapse the nine callee arms into success ∨ failure
+  obtain ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, hor⟩, hEx⟩ := hp
+  have rebuild : ∀ (arm : Assertion), arm h4 →
+      ((((regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+          regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x1 : Reg) ↦ᵣ (B + 88 + 4)) ** bytesRegion aB acctBytes) ** arm) ** F)) h :=
+    fun arm ha => ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, ha⟩, hEx⟩
+  rcases hor with a1 | a2 | a3 | a4 | a5 | a6 | a7 | a8 | a9
+  · -- fail arm: status 2
+    refine Or.inr ⟨aB, (0 : Word), (2 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a1
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (2 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (2 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 88 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 1
+    refine Or.inr ⟨aB, (aB + BitVec.ofNat 64 aLen), (1 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a2
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x12 : Reg) ↦ᵣ (1 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x12 : Reg) ↦ᵣ (1 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 88 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- short-list success (status 0)
+    refine Or.inl ⟨1, ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a3
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, hfacts⟩ := (sepConj_pure_right g4).1 grest2
+    obtain ⟨hne0, _, hf8, _⟩ := hfacts
+    have hx10' : ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 1)) g1 := by
+      rwa [show aB + signExtend12 (1 : BitVec 12) = aB + BitVec.ofNat 64 1 from by
+        rw [show signExtend12 (1 : BitVec 12) = BitVec.ofNat 64 1 from by decide]] at hx10
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 1)) **
+        ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10', g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 1)) **
+        ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 88 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    refine (sepConj_pure_right h).2 ⟨hflat, ⟨bb, List.getElem?_eq_getElem hoffb, ?_, le_refl 1, ?_⟩⟩
+    · -- listHeaderSize bb = 1: short-form prefix
+      have hlt := ult_lt hf8
+      have hzb : (bb.zeroExtend 64).toNat = bb.toNat := by bv_omega
+      unfold listHeaderSize
+      rw [if_pos (by
+        rw [show ((0xf8 : Word)).toNat = 0xf8 from rfl] at hlt
+        omega)]
+    · -- 1 ≤ aLen: the passed window length is non-zero
+      have : aLen ≠ 0 := by
+        intro hc
+        subst hc
+        exact hne0 rfl
+      omega
+  · -- fail arm: status 3
+    refine Or.inr ⟨aB, (aB + BitVec.ofNat 64 aLen), (3 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a4
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x12 : Reg) ↦ᵣ (3 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x12 : Reg) ↦ᵣ (3 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 88 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 4
+    refine Or.inr ⟨aB, (aB + BitVec.ofNat 64 aLen), (4 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a5
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x12 : Reg) ↦ᵣ (4 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x12 : Reg) ↦ᵣ (4 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 88 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 5
+    refine Or.inr ⟨aB, (aB + BitVec.ofNat 64 aLen), (5 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a6
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x12 : Reg) ↦ᵣ (5 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x12 : Reg) ↦ᵣ (5 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 88 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 6
+    refine Or.inr ⟨aB, (aB + BitVec.ofNat 64 aLen), (6 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a7
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x12 : Reg) ↦ᵣ (6 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x12 : Reg) ↦ᵣ (6 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 88 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 7
+    refine Or.inr ⟨aB, (aB + BitVec.ofNat 64 aLen), (7 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a8
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x12 : Reg) ↦ᵣ (7 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x12 : Reg) ↦ᵣ (7 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 88 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- long-list success (status 0)
+    refine Or.inl ⟨((bb.zeroExtend 64 - (0xf7 : Word)) + signExtend12 (1 : BitVec 12)).toNat, ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a9
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, hfacts⟩ := (sepConj_pure_right g4).1 grest2
+    obtain ⟨hne0, _, hnf8, hfit, _, _⟩ := hfacts
+    have hgef8 := not_ult_le hnf8
+    rw [show ((0xf8 : Word)).toNat = 0xf8 from rfl] at hgef8
+    have hzb : (bb.zeroExtend 64).toNat = bb.toNat := by bv_omega
+    have hhdrN : ((bb.zeroExtend 64 - (0xf7 : Word)) + signExtend12 (1 : BitVec 12)).toNat
+        = 1 + (bb.toNat - 0xf7) := by
+      rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide]
+      have hb := bb.isLt
+      bv_omega
+    have hx10' : ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64
+        (((bb.zeroExtend 64 - (0xf7 : Word)) + signExtend12 (1 : BitVec 12)).toNat))) g1 := by
+      rwa [show aB + ((bb.zeroExtend 64 - (0xf7 : Word)) + signExtend12 (1 : BitVec 12))
+          = aB + BitVec.ofNat 64
+            (((bb.zeroExtend 64 - (0xf7 : Word)) + signExtend12 (1 : BitVec 12)).toNat) from by
+        rw [BitVec.ofNat_toNat, BitVec.setWidth_eq]] at hx10
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64
+        (((bb.zeroExtend 64 - (0xf7 : Word)) + signExtend12 (1 : BitVec 12)).toNat))) **
+        ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10', g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64
+        (((bb.zeroExtend 64 - (0xf7 : Word)) + signExtend12 (1 : BitVec 12)).toNat))) **
+        ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 88 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    refine (sepConj_pure_right h).2 ⟨hflat, ⟨bb, List.getElem?_eq_getElem hoffb, ?_, ?_, ?_⟩⟩
+    · -- listHeaderSize bb = 1 + (bb - 0xf7): long-form prefix
+      unfold listHeaderSize
+      rw [if_neg (by omega), hhdrN]
+    · omega
+    · -- header fits inside the window
+      rw [hhdrN]
+      have hfit' := not_ult_le hfit
+      have hb := bb.isLt
+      have hRn : (aB + BitVec.ofNat 64 aLen).toNat = aB.toNat + aLen := by
+        rw [BitVec.toNat_add, BitVec.toNat_ofNat]
+        omega
+      have hLn : (aB + ((bb.zeroExtend 64 - (0xf7 : Word)) +
+          signExtend12 (1 : BitVec 12))).toNat
+          = aB.toNat + (1 + (bb.toNat - 0xf7)) := by
+        rw [BitVec.toNat_add, hhdrN]
+        omega
+      rw [hLn, hRn] at hfit'
+      omega
+
+#print axioms bansf_outerInit_spec
 
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainB.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainB.lean
@@ -1,0 +1,224 @@
+/-
+  EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB
+
+  The OUTER chain of `bal_account_nonstorage_finals` (bead evm-asm-4ch8f.43.5,
+  slice 3a): body entry (`B + 28`, slot 7) through the balance-station
+  boundary (`B + 184`, slot 46) —
+
+    7–9    mv s0,a0 ; mv s1,a1 ; mv s2,a2
+    10–19  sd x0 → 0/40/56/64/72/8/16/24/32/48(s2)   (zero the out block)
+    20–21  mv a0,s0 ; mv a1,s1
+    22     jal rlp_walk_init            (AccountChanges outer list; 9 outcomes)
+    23     bnez a2 → reject
+    24–25  sd a0→48(sp) ; sd a1→56(sp)
+    26–27  ld a0←48(sp) ; ld a1←56(sp)
+    28     jal rlp_walk_next            (item 0 = address)      29 bnez → reject
+    30     sd a0→48(sp)
+    31–33  ld ; ld ; jal rlp_walk_next  (item 1)                34 bnez ; 35 sd
+    36–38  ld ; ld ; jal rlp_walk_next  (item 2)                39 bnez ; 40 sd
+    41–43  ld ; ld ; jal rlp_walk_next  (item 3 = balance_changes)  44 bnez
+    45     sd a0→48(sp)
+
+  Success carries the unified `ListWindowOk` header fact for the outer list
+  plus the four-item `rlpItemDecode` chain; every failure status routes to
+  the shared reject epilogue entry (`B + 736`) with `a0 = 1`.
+-/
+
+import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsLoop3
+
+set_option maxRecDepth 8000
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.RLP
+
+namespace BalAccountNonstorageFinalsSpec
+
+private theorem se48 : signExtend12 (48 : BitVec 12) = (48 : Word) := by decide
+private theorem se56 : signExtend12 (56 : BitVec 12) = (56 : Word) := by decide
+
+/-- The routine's own bytes as an abbrev (`runBlock`'s CodeReq delta-unfolder
+    needs a named head; a bare `ofProg` head gets wrongly unfolded). -/
+abbrev bansfCode : CodeReq := CodeReq.ofProg B bansfProg
+
+/-! ## §1  The unified list-header fact
+
+    `rlp_walk_init`'s two success arms (short / long list) normalize to one
+    header-decode fact tied to the §2 `listHeaderSize` semantics of the spec
+    file: the content cursor sits `listHeaderSize b` past the window start,
+    and the header + declared content exactly fill the window. -/
+
+/-- The window `[off, off + spanN)` of `bytes` is an RLP LIST whose content
+    starts at `off + listHeaderSize b` — the pure residue of a successful
+    `rlp_walk_init` on the window. -/
+def ListWindowOk (bytes : List (BitVec 8)) (off spanN : Nat) : Prop :=
+  ∃ b, bytes[off]? = some b ∧ 0xc0 ≤ b.toNat ∧
+    listHeaderSize b ≤ spanN
+
+/-- Content-start offset of a `ListWindowOk` window. -/
+noncomputable def listContentOff (bytes : List (BitVec 8)) (off : Nat) : Nat :=
+  off + listHeaderSize (bytes.getD off 0)
+
+/-! ## §2  The prologue: argument moves + out-block zeroing (slots 7–21) -/
+
+theorem bansf_prologue_spec (aB aLenW oB v8 v9 v18 : Word) :
+    cpsTripleWithin 15 (B + 28) (B + 88) bansfCode
+      (((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ aLenW) ** ((.x12 : Reg) ↦ᵣ oB) **
+       ((.x8 : Reg) ↦ᵣ v8) ** ((.x9 : Reg) ↦ᵣ v9) ** ((.x18 : Reg) ↦ᵣ v18) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       memOwn oB ** memOwn (oB + 40) ** memOwn (oB + 56) **
+       memOwn (oB + 64) ** memOwn (oB + 72) ** memOwn (oB + 8) **
+       memOwn (oB + 16) ** memOwn (oB + 24) ** memOwn (oB + 32) **
+       memOwn (oB + 48))
+      (((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ aLenW) ** ((.x12 : Reg) ↦ᵣ oB) **
+       ((.x8 : Reg) ↦ᵣ aB) ** ((.x9 : Reg) ↦ᵣ aLenW) ** ((.x18 : Reg) ↦ᵣ oB) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       (oB ↦ₘ (0 : Word)) ** ((oB + 40) ↦ₘ (0 : Word)) **
+       ((oB + 56) ↦ₘ (0 : Word)) ** ((oB + 64) ↦ₘ (0 : Word)) **
+       ((oB + 72) ↦ₘ (0 : Word)) ** ((oB + 8) ↦ₘ (0 : Word)) **
+       ((oB + 16) ↦ₘ (0 : Word)) ** ((oB + 24) ↦ₘ (0 : Word)) **
+       ((oB + 32) ↦ₘ (0 : Word)) ** ((oB + 48) ↦ₘ (0 : Word))) := by
+  have s1 := mv_spec_gen_within .x8 .x10 aB v8 (B + 28) (by decide)
+  have s2 := mv_spec_gen_within .x9 .x11 aLenW v9 (B + 32) (by decide)
+  have s3 := mv_spec_gen_within .x18 .x12 oB v18 (B + 36) (by decide)
+  have s4 := sd_spec_gen_own_within .x18 .x0 oB (0 : Word) (0 : BitVec 12) (B + 40)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+      show oB + (0 : Word) = oB from by bv_omega] at s4
+  have s5 := sd_spec_gen_own_within .x18 .x0 oB (0 : Word) (40 : BitVec 12) (B + 44)
+  rw [show signExtend12 (40 : BitVec 12) = (40 : Word) from by decide] at s5
+  have s6 := sd_spec_gen_own_within .x18 .x0 oB (0 : Word) (56 : BitVec 12) (B + 48)
+  rw [show signExtend12 (56 : BitVec 12) = (56 : Word) from by decide] at s6
+  have s7 := sd_spec_gen_own_within .x18 .x0 oB (0 : Word) (64 : BitVec 12) (B + 52)
+  rw [show signExtend12 (64 : BitVec 12) = (64 : Word) from by decide] at s7
+  have s8 := sd_spec_gen_own_within .x18 .x0 oB (0 : Word) (72 : BitVec 12) (B + 56)
+  rw [show signExtend12 (72 : BitVec 12) = (72 : Word) from by decide] at s8
+  have s9 := sd_spec_gen_own_within .x18 .x0 oB (0 : Word) (8 : BitVec 12) (B + 60)
+  rw [show signExtend12 (8 : BitVec 12) = (8 : Word) from by decide] at s9
+  have s10 := sd_spec_gen_own_within .x18 .x0 oB (0 : Word) (16 : BitVec 12) (B + 64)
+  rw [show signExtend12 (16 : BitVec 12) = (16 : Word) from by decide] at s10
+  have s11 := sd_spec_gen_own_within .x18 .x0 oB (0 : Word) (24 : BitVec 12) (B + 68)
+  rw [show signExtend12 (24 : BitVec 12) = (24 : Word) from by decide] at s11
+  have s12 := sd_spec_gen_own_within .x18 .x0 oB (0 : Word) (32 : BitVec 12) (B + 72)
+  rw [show signExtend12 (32 : BitVec 12) = (32 : Word) from by decide] at s12
+  have s13 := sd_spec_gen_own_within .x18 .x0 oB (0 : Word) (48 : BitVec 12) (B + 76)
+  rw [show signExtend12 (48 : BitVec 12) = (48 : Word) from by decide] at s13
+  have s14 := mv_spec_gen_within .x10 .x8 aB aB (B + 80) (by decide)
+  have s15 := mv_spec_gen_within .x11 .x9 aLenW aLenW (B + 84) (by decide)
+  runBlock s1 s2 s3 s4 s5 s6 s7 s8 s9 s10 s11 s12 s13 s14 s15
+
+#print axioms bansf_prologue_spec
+
+/-! ## §3  The outer `rlp_walk_init` call and status dispatch (slots 22–23)
+
+    Nine callee outcomes: seven failure statuses route through the `bne` to
+    the shared reject epilogue entry; the two success arms (short / long
+    list header) unify into the `listHeaderSize`-anchored content cursor. -/
+
+/-- The reject-routing helper at the outer status check (`B + 92`,
+    `bne a2, x0, +640 → B+732`). -/
+private theorem outerFail (aB cur endW k : Word)
+    (acctBytes : List (BitVec 8)) (F : Assertion)
+    (hF : F.pcFree) (hk : k ≠ (0 : Word)) :
+    cpsTripleWithin 2 (B + 92) (B + 736) bansfCR
+      (((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ endW) **
+       ((.x12 : Reg) ↦ᵣ k) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 88 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (((.x10 : Reg) ↦ᵣ (1 : Word)) **
+       regOwn .x11 ** regOwn .x12 **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+       bytesRegion aB acctBytes ** F) := by
+  have hbne := bne_spec_gen_within .x12 .x0 (640 : BitVec 13) k (0 : Word) (B + 92)
+  rw [show (B + 92) + signExtend13 (640 : BitVec 13) = B + 732 from by
+        rw [show signExtend13 (640 : BitVec 13) = (640 : Word) from by decide]
+        bv_omega,
+      show (B + 92) + 4 = B + 96 from by bv_omega] at hbne
+  have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 92) bansfProg 23 (.BNE .x12 .x0 (640 : BitVec 13))
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+    hbne
+  have hbneF := cpsBranchWithin_frameR
+    (((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ endW) **
+     regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+     regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+     ((.x1 : Reg) ↦ᵣ (B + 88 + 4)) ** bytesRegion aB acctBytes ** F)
+    (by pcf; exact hF) hbneL
+  have htaken := cpsBranchWithin_takenPath hbneF
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_pure⟩, _⟩ := hQf
+      exact hk (((sepConj_pure_right _).1 h_pure).2))
+  have hrej := liftCode (cr' := bansfCR)
+    (bansf_rejectTail_spec B cur (by decide))
+    (fun a i h => CodeReq.union_mono_left a i h)
+  have hrejF := cpsTripleWithin_frameR
+    (((.x12 : Reg) ↦ᵣ k) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     ((.x11 : Reg) ↦ᵣ endW) **
+     regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+     regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+     ((.x1 : Reg) ↦ᵣ (B + 88 + 4)) ** bytesRegion aB acctBytes ** F)
+    (by pcf; exact hF) hrej
+  have hchain := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      have hp2 := sepConj_mono_left (sepConj_mono_right
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+      xperm_hyp hp2)
+    htaken hrejF
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hchain
+  have hq2 := sepConj_mono (fun _ x => x)
+    (sepConj_mono (regIs_implies_regOwn .x12)
+      (sepConj_mono (fun _ x => x)
+        (sepConj_mono (regIs_implies_regOwn .x11)
+          (sepConj_mono (fun _ x => x) (sepConj_mono (fun _ x => x)
+            (sepConj_mono (fun _ x => x) (sepConj_mono (fun _ x => x)
+              (sepConj_mono (fun _ x => x) (sepConj_mono (fun _ x => x)
+                (sepConj_mono (fun _ x => x)
+                  (sepConj_mono (regIs_implies_regOwn .x1)
+                    (fun _ x => x))))))))))))
+    h hq
+  xperm_hyp hq2
+
+#print axioms outerFail
+
+/-- The pure residue of a successful outer `rlp_walk_init`: the content
+    cursor offset is `listHeaderSize` of the window's first byte. -/
+def OuterInitOk (bytes : List (BitVec 8)) (aLen cOff : Nat) : Prop :=
+  ∃ b0, bytes[0]? = some b0 ∧ cOff = listHeaderSize b0 ∧ 1 ≤ cOff ∧ cOff ≤ aLen
+
+/-- The unified continue-state after the outer init status check
+    (`B + 96`). -/
+def outerInitPost (aB : Word) (aLen : Nat) (acctBytes : List (BitVec 8))
+    (F : Assertion) : Assertion :=
+  fun h => ∃ cOff : Nat,
+    ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+      ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+      ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+      bytesRegion aB acctBytes ** F) **
+     ⌜OuterInitOk acctBytes aLen cOff⌝) h
+
+/-- The reject-side post shared by every outer-chain failure. -/
+def outerRej (aB : Word) (acctBytes : List (BitVec 8)) (F : Assertion) :
+    Assertion :=
+  ((.x10 : Reg) ↦ᵣ (1 : Word)) **
+  regOwn .x11 ** regOwn .x12 **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+  ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+  bytesRegion aB acctBytes ** F
+
+/- The outer `rlp_walk_init` dispatch (slot 22 call + slot 23 status check
+   ⇒ `outerRej` / `outerInitPost`) is the next slice: the nine callee arms
+   need explicit per-arm branch lemmas (seven `outerFail` instantiations +
+   the two success arms unified into `OuterInitOk` via the short/long
+   `listHeaderSize` bridges), recombined with `cpsBranchWithin_pre_or` as in
+   `fl_round`.  The interfaces above are final. -/
+
+end BalAccountNonstorageFinalsSpec
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainB.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainB.lean
@@ -582,5 +582,474 @@ theorem bansf_outerInit_spec (aB : Word) (aLen : Nat)
 
 #print axioms bansf_outerInit_spec
 
+/-! ## §4  The four outer item units (slots 24–45)
+
+    Each unit reloads the outer cursor/end spills, calls `rlp_walk_next`,
+    checks the status, and spills the advanced cursor.  Six callee arms
+    collapse into ok-vs-failure as in §3. -/
+
+/-- The unit reject shape (everything the unit touches, weakened). -/
+def itemRej (aB newSp : Word) (acctBytes : List (BitVec 8)) (F : Assertion) :
+    Assertion :=
+  ((.x10 : Reg) ↦ᵣ (1 : Word)) ** ((.x2 : Reg) ↦ᵣ newSp) **
+  memOwn (newSp + 48) ** memOwn (newSp + 56) **
+  regOwn .x11 ** regOwn .x12 **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+  ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+  bytesRegion aB acctBytes ** F
+
+/-- The unit success shape at its exit: the advanced cursor is spilled and
+    pinned in `a0`, `a2` reports the decoded length, and the pure decode
+    fact is recorded. -/
+def itemOk (aB newSp : Word) (aLen off : Nat) (acctBytes : List (BitVec 8))
+    (F : Assertion) : Assertion :=
+  fun h => ∃ next len : Word,
+    ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x12 : Reg) ↦ᵣ len) **
+      ((.x2 : Reg) ↦ᵣ newSp) **
+      ((newSp + 48) ↦ₘ next) **
+      ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+      bytesRegion aB acctBytes ** F) **
+     ⌜rlpItemDecode acctBytes off (aB + BitVec.ofNat 64 off)
+       (aB + BitVec.ofNat 64 aLen) next len⌝) h
+
+/-- Outer item unit 0 (slots 26–30, `B + 104 → B + 124`). -/
+theorem bansf_item0_spec (aB newSp : Word) (aLen off : Nat)
+    (acctBytes : List (BitVec 8))
+    (v5 v6 v7 v10 v11 v12 v28 v29 v30 v31 vRa : Word) (F : Assertion)
+    (hF : F.pcFree)
+    (hsalign : aB.toNat % 8 = 0)
+    (hslack : aLen + 9 ≤ acctBytes.length)
+    (hover : aB.toNat + acctBytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < acctBytes.length →
+      isValidByteAccess (aB + BitVec.ofNat 64 k) = true)
+    (hoffle : off ≤ aLen) :
+    cpsBranchWithin 93 (B + 104) bansfCR
+      (((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((.x10 : Reg) ↦ᵣ v10) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+       bytesRegion aB acctBytes ** F)
+      (B + 736) (itemRej aB newSp acctBytes F)
+      (B + 124) (itemOk aB newSp aLen off acctBytes F) := by
+  have hoffb : off < acctBytes.length := by omega
+  -- LD a0, 48(sp) ; LD a1, 56(sp)  (B+104, B+108)
+  have hld1 := ld_spec_gen_within .x10 .x2 newSp v10 (aB + BitVec.ofNat 64 off)
+    (48 : BitVec 12) (B + 104) (by decide)
+  rw [se48, show (B + 104) + 4 = B + 108 from by bv_omega] at hld1
+  have hld1L := liftCode (cr' := bansfCR) hld1
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 104) bansfProg 26 (.LD .x10 .x2 (48 : BitVec 12))
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+  have hld2 := ld_spec_gen_within .x11 .x2 newSp v11 (aB + BitVec.ofNat 64 aLen)
+    (56 : BitVec 12) (B + 108) (by decide)
+  rw [se56, show (B + 108) + 4 = B + 112 from by bv_omega] at hld2
+  have hld2L := liftCode (cr' := bansfCR) hld2
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 108) bansfProg 27 (.LD .x11 .x2 (56 : BitVec 12))
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+  have hld1F := cpsTripleWithin_frameR
+    (((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) ** ((.x11 : Reg) ↦ᵣ v11))
+    (by pcf) hld1L
+  have hld2F := cpsTripleWithin_frameR
+    (((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+     ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)))
+    (by pcf) hld2L
+  have hlds := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hld1F hld2F
+  have hldsF := cpsTripleWithin_frameR
+    (((.x12 : Reg) ↦ᵣ v12) **
+     ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+     ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+     bytesRegion aB acctBytes ** F)
+    (by pcf; exact hF) hlds
+  -- the callee triple with ra = B + 112 + 4
+  have hwn := rlp_walk_next_spec_within WN aB (aB + BitVec.ofNat 64 aLen)
+    (B + 112 + 4) v12 v5 v6 v7 v28 v29 v30 v31 acctBytes off hsalign hoffb (by omega)
+    (hvalid off hoffb)
+    (fun h80 hb8 => ⟨by omega, by omega, hvalid _ (by omega)⟩)
+    (fun hb8 hc0 => by
+      have hlo : ((acctBytes[off]'hoffb).zeroExtend 64 - (0xb7 : Word)).toNat ≤ 8 := by
+        have h1 := ult_lt hc0
+        have h2 := not_ult_le hb8
+        bv_omega
+      exact ⟨by omega, by omega, fun k hk => hvalid _ (by omega)⟩)
+    (fun hf8 => by
+      have hlo : ((acctBytes[off]'hoffb).zeroExtend 64 - (0xf7 : Word)).toNat ≤ 8 := by
+        have h2 := not_ult_le hf8
+        have h3 := (acctBytes[off]'hoffb).isLt
+        bv_omega
+      exact ⟨by omega, by omega, fun k hk => hvalid _ (by omega)⟩)
+  have hwn' := cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp) (fun _ hq => hq) hwn
+    (P' := ((.x1 : Reg) ↦ᵣ (B + 112 + 4)) **
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+       ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion aB acctBytes))
+  have hcall := bansf_callSite28_walk_next (n := 87) vRa (by pcf) hwn'
+  rw [show (B + 112) + 4 = B + 116 from by bv_omega] at hcall
+  have hcallF := cpsTripleWithin_frameR
+    (((.x2 : Reg) ↦ᵣ newSp) **
+     ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+     ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) ** F)
+    (by pcf; exact hF) hcall
+  have hpre := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp)
+    hldsF hcallF
+  -- ===== ok continuation: BNE falls through, SD spills the cursor =====
+  have hokc : cpsBranchWithin 2 (B + 116) bansfCR
+      (fun h => ∃ next len : Word,
+        ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 112 + 4)) **
+          bytesRegion aB acctBytes ** F) **
+         ⌜rlpItemDecode acctBytes off (aB + BitVec.ofNat 64 off)
+           (aB + BitVec.ofNat 64 aLen) next len⌝) h)
+      (B + 736) (itemRej aB newSp acctBytes F)
+      (B + 124) (itemOk aB newSp aLen off acctBytes F) := by
+    refine cpsBranchWithin_exists_pre (fun next => ?_)
+    refine cpsBranchWithin_exists_pre (fun len => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hdec => ?_)
+    have hbne := bne_spec_gen_within .x11 .x0 (616 : BitVec 13) (0 : Word) (0 : Word) (B + 116)
+    rw [show (B + 116) + 4 = B + 120 from by bv_omega] at hbne
+    have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 116) bansfProg 29 (.BNE .x11 .x0 (616 : BitVec 13))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+      hbne
+    have hfall := cpsBranchWithin_ntakenPath hbneL
+      (fun hp hQt => by
+        obtain ⟨_, _, _, _, _, h_pure⟩ := hQt
+        exact absurd rfl (((sepConj_pure_right _).1 h_pure).2))
+    -- SD a0, 48(sp) at B+120
+    have hsd := sd_spec_gen_within .x2 .x10 newSp next (aB + BitVec.ofNat 64 off)
+      (48 : BitVec 12) (B + 120)
+    rw [se48, show (B + 120) + 4 = B + 124 from by bv_omega] at hsd
+    have hsdL := liftCode (cr' := bansfCR) hsd
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 120) bansfProg 30 (.SD .x2 .x10 (48 : BitVec 12))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+    have hfallF := cpsTripleWithin_frameR
+      (((.x10 : Reg) ↦ᵣ next) ** ((.x12 : Reg) ↦ᵣ len) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 112 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hfall
+    have hsdF := cpsTripleWithin_frameR
+      (((.x11 : Reg) ↦ᵣ (0 : Word)) ** ((.x12 : Reg) ↦ᵣ len) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 112 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hsdL
+    have hout : cpsTripleWithin 2 (B + 116) (B + 124) bansfCR
+        (((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x12 : Reg) ↦ᵣ len) **
+         ((.x2 : Reg) ↦ᵣ newSp) **
+         ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+         ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 112 + 4)) **
+         bytesRegion aB acctBytes ** F)
+        (itemOk aB newSp aLen off acctBytes F) := by
+      have hchain := cpsTripleWithin_seq_perm_same_cr
+        (fun h hp => by
+          have hp2 := sepConj_mono_left (sepConj_mono_right
+            (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+          xperm_hyp hp2)
+        hfallF hsdF
+      refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hchain
+      unfold itemOk
+      refine ⟨next, len, ?_⟩
+      have hq2 : ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 48) ↦ₘ next) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 112 + 4)) **
+          bytesRegion aB acctBytes ** F)) h := by
+        xperm_hyp hq
+      have hq3 : ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 48) ↦ₘ next) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+          bytesRegion aB acctBytes ** F)) h := by
+        have hq4 : ((((.x1 : Reg) ↦ᵣ (B + 112 + 4)) **
+            (((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+             ((.x12 : Reg) ↦ᵣ len) **
+             ((.x2 : Reg) ↦ᵣ newSp) **
+             ((newSp + 48) ↦ₘ next) **
+             ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+             regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+             regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+             ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+             bytesRegion aB acctBytes ** F))) h := by
+          xperm_hyp hq2
+        have hq5 := sepConj_mono (regIs_implies_regOwn .x1) (fun _ x => x) h hq4
+        xperm_hyp hq5
+      exact (sepConj_pure_right h).2 ⟨hq3, hdec⟩
+    exact cpsBranchWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_as_cpsBranchWithin_right _ _ hout)
+  -- ===== fail continuation =====
+  have hfailc : cpsBranchWithin 2 (B + 116) bansfCR
+      (fun h => ∃ cur k : Word,
+        ((((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ k) **
+          ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 112 + 4)) **
+          bytesRegion aB acctBytes ** F) **
+         ⌜k ≠ (0 : Word)⌝) h)
+      (B + 736) (itemRej aB newSp acctBytes F)
+      (B + 124) (itemOk aB newSp aLen off acctBytes F) := by
+    refine cpsBranchWithin_exists_pre (fun cur => ?_)
+    refine cpsBranchWithin_exists_pre (fun k => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hk => ?_)
+    have hbne := bne_spec_gen_within .x11 .x0 (616 : BitVec 13) k (0 : Word) (B + 116)
+    rw [show (B + 116) + signExtend13 (616 : BitVec 13) = B + 732 from by
+          rw [show signExtend13 (616 : BitVec 13) = (616 : Word) from by decide]
+          bv_omega,
+        show (B + 116) + 4 = B + 120 from by bv_omega] at hbne
+    have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 116) bansfProg 29 (.BNE .x11 .x0 (616 : BitVec 13))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+      hbne
+    have hbneF := cpsBranchWithin_frameR
+      (((.x10 : Reg) ↦ᵣ cur) ** ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 112 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hbneL
+    have htaken := cpsBranchWithin_takenPath hbneF
+      (fun hp hQf => by
+        obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_pure⟩, _⟩ := hQf
+        exact hk (((sepConj_pure_right _).1 h_pure).2))
+    have hrej := liftCode (cr' := bansfCR)
+      (bansf_rejectTail_spec B cur (by decide))
+      (fun a i h => CodeReq.union_mono_left a i h)
+    have hrejF := cpsTripleWithin_frameR
+      (((.x11 : Reg) ↦ᵣ k) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 112 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hrej
+    have hchain := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        have hp2 := sepConj_mono_left (sepConj_mono_right
+          (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+        xperm_hyp hp2)
+      htaken hrejF
+    have hout : cpsTripleWithin 2 (B + 116) (B + 736) bansfCR
+        (((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ k) **
+         ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x2 : Reg) ↦ᵣ newSp) **
+         ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+         ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 112 + 4)) **
+         bytesRegion aB acctBytes ** F)
+        (itemRej aB newSp acctBytes F) := by
+      refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hchain
+      unfold itemRej
+      have hq4 : ((((.x11 : Reg) ↦ᵣ k) ** ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x1 : Reg) ↦ᵣ (B + 112 + 4)) **
+          ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          (((.x10 : Reg) ↦ᵣ (1 : Word)) ** ((.x2 : Reg) ↦ᵣ newSp) **
+           regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+           regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+           ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+           bytesRegion aB acctBytes ** F))) h := by
+        xperm_hyp hq
+      have hq5 := sepConj_mono (regIs_implies_regOwn .x11)
+        (sepConj_mono (regIs_implies_regOwn .x12)
+          (sepConj_mono (regIs_implies_regOwn .x1)
+            (sepConj_mono memIs_implies_memOwn
+              (sepConj_mono memIs_implies_memOwn (fun _ x => x))))) h hq4
+      xperm_hyp hq5
+    exact cpsTripleWithin_as_cpsBranchWithin_left _ _ hout
+  -- ===== chain: loads ; call ; (ok ∨ fail) =====
+  refine cpsBranchWithin_weaken
+    (fun h hp => by xperm_hyp hp) (fun _ x => x) (fun _ x => x)
+    (cpsBranchWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_seq_branch_same_cr hpre
+        (cpsBranchWithin_weaken (fun h hp => ?_) (fun _ x => x) (fun _ x => x)
+          (cpsBranchWithin_pre_or hokc hfailc))))
+  -- pointwise: collapse the six callee arms into ok ∨ fail
+  obtain ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, hor⟩, hEx⟩ := hp
+  have rebuild : ∀ (arm : Assertion), arm h4 →
+      ((((regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+          regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x1 : Reg) ↦ᵣ (B + 112 + 4)) ** bytesRegion aB acctBytes) ** arm) **
+        (((.x2 : Reg) ↦ᵣ newSp) **
+         ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+         ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) ** F))) h :=
+    fun arm ha => ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, ha⟩, hEx⟩
+  rcases hor with a1 | a2 | a3 | a4 | a5 | a6
+  · -- ok arm: rlpWalkNextOk
+    obtain ⟨next, len, hpins⟩ := a1
+    refine Or.inl ⟨next, len, ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := hpins
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, hdec⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ len))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ len) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 112 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, hdec⟩
+  · -- fail arm: status 2
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (2 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a2
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (2 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (2 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 112 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 3
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (3 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a3
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (3 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (3 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 112 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 4
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (4 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a4
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (4 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (4 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 112 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 5
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (5 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a5
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (5 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (5 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 112 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 6
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (6 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a6
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (6 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (6 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 112 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+
+#print axioms bansf_item0_spec
+
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainB2.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainB2.lean
@@ -1,0 +1,1326 @@
+/-
+  EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB2
+
+  Outer item units 1–3 of `bal_account_nonstorage_finals` (slots 31–45),
+  instantiated from the verified unit-0 stack in
+  `BalAccountNonstorageFinalsChainB.lean` via the concrete address table
+  (bead evm-asm-4ch8f.43.5, slice 3c).
+-/
+
+import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB
+
+set_option maxRecDepth 8000
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.RLP
+
+namespace BalAccountNonstorageFinalsSpec
+
+private theorem se48 : signExtend12 (48 : BitVec 12) = (48 : Word) := by decide
+private theorem se56 : signExtend12 (56 : BitVec 12) = (56 : Word) := by decide
+
+/-- Outer item unit 1 (slots 31–35, `B + 124 → B + 144`). -/
+theorem bansf_item1_spec (aB newSp : Word) (aLen off : Nat)
+    (acctBytes : List (BitVec 8))
+    (v5 v6 v7 v10 v11 v12 v28 v29 v30 v31 vRa : Word) (F : Assertion)
+    (hF : F.pcFree)
+    (hsalign : aB.toNat % 8 = 0)
+    (hslack : aLen + 9 ≤ acctBytes.length)
+    (hover : aB.toNat + acctBytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < acctBytes.length →
+      isValidByteAccess (aB + BitVec.ofNat 64 k) = true)
+    (hoffle : off ≤ aLen) :
+    cpsBranchWithin 93 (B + 124) bansfCR
+      (((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((.x10 : Reg) ↦ᵣ v10) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+       bytesRegion aB acctBytes ** F)
+      (B + 736) (itemRej aB newSp acctBytes F)
+      (B + 144) (itemOk aB newSp aLen off acctBytes F) := by
+  have hoffb : off < acctBytes.length := by omega
+  -- LD a0, 48(sp) ; LD a1, 56(sp)  (B+104, B+108)
+  have hld1 := ld_spec_gen_within .x10 .x2 newSp v10 (aB + BitVec.ofNat 64 off)
+    (48 : BitVec 12) (B + 124) (by decide)
+  rw [se48, show (B + 124) + 4 = B + 128 from by bv_omega] at hld1
+  have hld1L := liftCode (cr' := bansfCR) hld1
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 124) bansfProg 31 (.LD .x10 .x2 (48 : BitVec 12))
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+  have hld2 := ld_spec_gen_within .x11 .x2 newSp v11 (aB + BitVec.ofNat 64 aLen)
+    (56 : BitVec 12) (B + 128) (by decide)
+  rw [se56, show (B + 128) + 4 = B + 132 from by bv_omega] at hld2
+  have hld2L := liftCode (cr' := bansfCR) hld2
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 128) bansfProg 32 (.LD .x11 .x2 (56 : BitVec 12))
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+  have hld1F := cpsTripleWithin_frameR
+    (((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) ** ((.x11 : Reg) ↦ᵣ v11))
+    (by pcf) hld1L
+  have hld2F := cpsTripleWithin_frameR
+    (((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+     ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)))
+    (by pcf) hld2L
+  have hlds := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hld1F hld2F
+  have hldsF := cpsTripleWithin_frameR
+    (((.x12 : Reg) ↦ᵣ v12) **
+     ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+     ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+     bytesRegion aB acctBytes ** F)
+    (by pcf; exact hF) hlds
+  -- the callee triple with ra = B + 132 + 4
+  have hwn := rlp_walk_next_spec_within WN aB (aB + BitVec.ofNat 64 aLen)
+    (B + 132 + 4) v12 v5 v6 v7 v28 v29 v30 v31 acctBytes off hsalign hoffb (by omega)
+    (hvalid off hoffb)
+    (fun h80 hb8 => ⟨by omega, by omega, hvalid _ (by omega)⟩)
+    (fun hb8 hc0 => by
+      have hlo : ((acctBytes[off]'hoffb).zeroExtend 64 - (0xb7 : Word)).toNat ≤ 8 := by
+        have h1 := ult_lt hc0
+        have h2 := not_ult_le hb8
+        bv_omega
+      exact ⟨by omega, by omega, fun k hk => hvalid _ (by omega)⟩)
+    (fun hf8 => by
+      have hlo : ((acctBytes[off]'hoffb).zeroExtend 64 - (0xf7 : Word)).toNat ≤ 8 := by
+        have h2 := not_ult_le hf8
+        have h3 := (acctBytes[off]'hoffb).isLt
+        bv_omega
+      exact ⟨by omega, by omega, fun k hk => hvalid _ (by omega)⟩)
+  have hwn' := cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp) (fun _ hq => hq) hwn
+    (P' := ((.x1 : Reg) ↦ᵣ (B + 132 + 4)) **
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+       ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion aB acctBytes))
+  have hcall := bansf_callSite33_walk_next (n := 87) vRa (by pcf) hwn'
+  rw [show (B + 132) + 4 = B + 136 from by bv_omega] at hcall
+  have hcallF := cpsTripleWithin_frameR
+    (((.x2 : Reg) ↦ᵣ newSp) **
+     ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+     ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) ** F)
+    (by pcf; exact hF) hcall
+  have hpre := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp)
+    hldsF hcallF
+  -- ===== ok continuation: BNE falls through, SD spills the cursor =====
+  have hokc : cpsBranchWithin 2 (B + 136) bansfCR
+      (fun h => ∃ next len : Word,
+        ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 132 + 4)) **
+          bytesRegion aB acctBytes ** F) **
+         ⌜rlpItemDecode acctBytes off (aB + BitVec.ofNat 64 off)
+           (aB + BitVec.ofNat 64 aLen) next len⌝) h)
+      (B + 736) (itemRej aB newSp acctBytes F)
+      (B + 144) (itemOk aB newSp aLen off acctBytes F) := by
+    refine cpsBranchWithin_exists_pre (fun next => ?_)
+    refine cpsBranchWithin_exists_pre (fun len => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hdec => ?_)
+    have hbne := bne_spec_gen_within .x11 .x0 (596 : BitVec 13) (0 : Word) (0 : Word) (B + 136)
+    rw [show (B + 136) + 4 = B + 140 from by bv_omega] at hbne
+    have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 136) bansfProg 34 (.BNE .x11 .x0 (596 : BitVec 13))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+      hbne
+    have hfall := cpsBranchWithin_ntakenPath hbneL
+      (fun hp hQt => by
+        obtain ⟨_, _, _, _, _, h_pure⟩ := hQt
+        exact absurd rfl (((sepConj_pure_right _).1 h_pure).2))
+    -- SD a0, 48(sp) at B+120
+    have hsd := sd_spec_gen_within .x2 .x10 newSp next (aB + BitVec.ofNat 64 off)
+      (48 : BitVec 12) (B + 140)
+    rw [se48, show (B + 140) + 4 = B + 144 from by bv_omega] at hsd
+    have hsdL := liftCode (cr' := bansfCR) hsd
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 140) bansfProg 35 (.SD .x2 .x10 (48 : BitVec 12))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+    have hfallF := cpsTripleWithin_frameR
+      (((.x10 : Reg) ↦ᵣ next) ** ((.x12 : Reg) ↦ᵣ len) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 132 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hfall
+    have hsdF := cpsTripleWithin_frameR
+      (((.x11 : Reg) ↦ᵣ (0 : Word)) ** ((.x12 : Reg) ↦ᵣ len) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 132 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hsdL
+    have hout : cpsTripleWithin 2 (B + 136) (B + 144) bansfCR
+        (((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x12 : Reg) ↦ᵣ len) **
+         ((.x2 : Reg) ↦ᵣ newSp) **
+         ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+         ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 132 + 4)) **
+         bytesRegion aB acctBytes ** F)
+        (itemOk aB newSp aLen off acctBytes F) := by
+      have hchain := cpsTripleWithin_seq_perm_same_cr
+        (fun h hp => by
+          have hp2 := sepConj_mono_left (sepConj_mono_right
+            (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+          xperm_hyp hp2)
+        hfallF hsdF
+      refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hchain
+      unfold itemOk
+      refine ⟨next, len, ?_⟩
+      have hq2 : ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 48) ↦ₘ next) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 132 + 4)) **
+          bytesRegion aB acctBytes ** F)) h := by
+        xperm_hyp hq
+      have hq3 : ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 48) ↦ₘ next) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+          bytesRegion aB acctBytes ** F)) h := by
+        have hq4 : ((((.x1 : Reg) ↦ᵣ (B + 132 + 4)) **
+            (((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+             ((.x12 : Reg) ↦ᵣ len) **
+             ((.x2 : Reg) ↦ᵣ newSp) **
+             ((newSp + 48) ↦ₘ next) **
+             ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+             regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+             regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+             ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+             bytesRegion aB acctBytes ** F))) h := by
+          xperm_hyp hq2
+        have hq5 := sepConj_mono (regIs_implies_regOwn .x1) (fun _ x => x) h hq4
+        xperm_hyp hq5
+      exact (sepConj_pure_right h).2 ⟨hq3, hdec⟩
+    exact cpsBranchWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_as_cpsBranchWithin_right _ _ hout)
+  -- ===== fail continuation =====
+  have hfailc : cpsBranchWithin 2 (B + 136) bansfCR
+      (fun h => ∃ cur k : Word,
+        ((((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ k) **
+          ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 132 + 4)) **
+          bytesRegion aB acctBytes ** F) **
+         ⌜k ≠ (0 : Word)⌝) h)
+      (B + 736) (itemRej aB newSp acctBytes F)
+      (B + 144) (itemOk aB newSp aLen off acctBytes F) := by
+    refine cpsBranchWithin_exists_pre (fun cur => ?_)
+    refine cpsBranchWithin_exists_pre (fun k => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hk => ?_)
+    have hbne := bne_spec_gen_within .x11 .x0 (596 : BitVec 13) k (0 : Word) (B + 136)
+    rw [show (B + 136) + signExtend13 (596 : BitVec 13) = B + 732 from by
+          rw [show signExtend13 (596 : BitVec 13) = (596 : Word) from by decide]
+          bv_omega,
+        show (B + 136) + 4 = B + 140 from by bv_omega] at hbne
+    have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 136) bansfProg 34 (.BNE .x11 .x0 (596 : BitVec 13))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+      hbne
+    have hbneF := cpsBranchWithin_frameR
+      (((.x10 : Reg) ↦ᵣ cur) ** ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 132 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hbneL
+    have htaken := cpsBranchWithin_takenPath hbneF
+      (fun hp hQf => by
+        obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_pure⟩, _⟩ := hQf
+        exact hk (((sepConj_pure_right _).1 h_pure).2))
+    have hrej := liftCode (cr' := bansfCR)
+      (bansf_rejectTail_spec B cur (by decide))
+      (fun a i h => CodeReq.union_mono_left a i h)
+    have hrejF := cpsTripleWithin_frameR
+      (((.x11 : Reg) ↦ᵣ k) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 132 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hrej
+    have hchain := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        have hp2 := sepConj_mono_left (sepConj_mono_right
+          (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+        xperm_hyp hp2)
+      htaken hrejF
+    have hout : cpsTripleWithin 2 (B + 136) (B + 736) bansfCR
+        (((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ k) **
+         ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x2 : Reg) ↦ᵣ newSp) **
+         ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+         ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 132 + 4)) **
+         bytesRegion aB acctBytes ** F)
+        (itemRej aB newSp acctBytes F) := by
+      refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hchain
+      unfold itemRej
+      have hq4 : ((((.x11 : Reg) ↦ᵣ k) ** ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x1 : Reg) ↦ᵣ (B + 132 + 4)) **
+          ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          (((.x10 : Reg) ↦ᵣ (1 : Word)) ** ((.x2 : Reg) ↦ᵣ newSp) **
+           regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+           regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+           ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+           bytesRegion aB acctBytes ** F))) h := by
+        xperm_hyp hq
+      have hq5 := sepConj_mono (regIs_implies_regOwn .x11)
+        (sepConj_mono (regIs_implies_regOwn .x12)
+          (sepConj_mono (regIs_implies_regOwn .x1)
+            (sepConj_mono memIs_implies_memOwn
+              (sepConj_mono memIs_implies_memOwn (fun _ x => x))))) h hq4
+      xperm_hyp hq5
+    exact cpsTripleWithin_as_cpsBranchWithin_left _ _ hout
+  -- ===== chain: loads ; call ; (ok ∨ fail) =====
+  refine cpsBranchWithin_weaken
+    (fun h hp => by xperm_hyp hp) (fun _ x => x) (fun _ x => x)
+    (cpsBranchWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_seq_branch_same_cr hpre
+        (cpsBranchWithin_weaken (fun h hp => ?_) (fun _ x => x) (fun _ x => x)
+          (cpsBranchWithin_pre_or hokc hfailc))))
+  -- pointwise: collapse the six callee arms into ok ∨ fail
+  obtain ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, hor⟩, hEx⟩ := hp
+  have rebuild : ∀ (arm : Assertion), arm h4 →
+      ((((regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+          regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x1 : Reg) ↦ᵣ (B + 132 + 4)) ** bytesRegion aB acctBytes) ** arm) **
+        (((.x2 : Reg) ↦ᵣ newSp) **
+         ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+         ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) ** F))) h :=
+    fun arm ha => ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, ha⟩, hEx⟩
+  rcases hor with a1 | a2 | a3 | a4 | a5 | a6
+  · -- ok arm: rlpWalkNextOk
+    obtain ⟨next, len, hpins⟩ := a1
+    refine Or.inl ⟨next, len, ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := hpins
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, hdec⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ len))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ len) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 132 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, hdec⟩
+  · -- fail arm: status 2
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (2 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a2
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (2 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (2 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 132 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 3
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (3 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a3
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (3 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (3 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 132 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 4
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (4 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a4
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (4 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (4 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 132 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 5
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (5 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a5
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (5 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (5 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 132 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 6
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (6 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a6
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (6 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (6 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 132 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+
+#print axioms bansf_item1_spec
+
+/-- Outer item unit 2 (slots 36–40, `B + 144 → B + 164`). -/
+theorem bansf_item2_spec (aB newSp : Word) (aLen off : Nat)
+    (acctBytes : List (BitVec 8))
+    (v5 v6 v7 v10 v11 v12 v28 v29 v30 v31 vRa : Word) (F : Assertion)
+    (hF : F.pcFree)
+    (hsalign : aB.toNat % 8 = 0)
+    (hslack : aLen + 9 ≤ acctBytes.length)
+    (hover : aB.toNat + acctBytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < acctBytes.length →
+      isValidByteAccess (aB + BitVec.ofNat 64 k) = true)
+    (hoffle : off ≤ aLen) :
+    cpsBranchWithin 93 (B + 144) bansfCR
+      (((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((.x10 : Reg) ↦ᵣ v10) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+       bytesRegion aB acctBytes ** F)
+      (B + 736) (itemRej aB newSp acctBytes F)
+      (B + 164) (itemOk aB newSp aLen off acctBytes F) := by
+  have hoffb : off < acctBytes.length := by omega
+  -- LD a0, 48(sp) ; LD a1, 56(sp)  (B+104, B+108)
+  have hld1 := ld_spec_gen_within .x10 .x2 newSp v10 (aB + BitVec.ofNat 64 off)
+    (48 : BitVec 12) (B + 144) (by decide)
+  rw [se48, show (B + 144) + 4 = B + 148 from by bv_omega] at hld1
+  have hld1L := liftCode (cr' := bansfCR) hld1
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 144) bansfProg 36 (.LD .x10 .x2 (48 : BitVec 12))
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+  have hld2 := ld_spec_gen_within .x11 .x2 newSp v11 (aB + BitVec.ofNat 64 aLen)
+    (56 : BitVec 12) (B + 148) (by decide)
+  rw [se56, show (B + 148) + 4 = B + 152 from by bv_omega] at hld2
+  have hld2L := liftCode (cr' := bansfCR) hld2
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 148) bansfProg 37 (.LD .x11 .x2 (56 : BitVec 12))
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+  have hld1F := cpsTripleWithin_frameR
+    (((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) ** ((.x11 : Reg) ↦ᵣ v11))
+    (by pcf) hld1L
+  have hld2F := cpsTripleWithin_frameR
+    (((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+     ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)))
+    (by pcf) hld2L
+  have hlds := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hld1F hld2F
+  have hldsF := cpsTripleWithin_frameR
+    (((.x12 : Reg) ↦ᵣ v12) **
+     ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+     ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+     bytesRegion aB acctBytes ** F)
+    (by pcf; exact hF) hlds
+  -- the callee triple with ra = B + 152 + 4
+  have hwn := rlp_walk_next_spec_within WN aB (aB + BitVec.ofNat 64 aLen)
+    (B + 152 + 4) v12 v5 v6 v7 v28 v29 v30 v31 acctBytes off hsalign hoffb (by omega)
+    (hvalid off hoffb)
+    (fun h80 hb8 => ⟨by omega, by omega, hvalid _ (by omega)⟩)
+    (fun hb8 hc0 => by
+      have hlo : ((acctBytes[off]'hoffb).zeroExtend 64 - (0xb7 : Word)).toNat ≤ 8 := by
+        have h1 := ult_lt hc0
+        have h2 := not_ult_le hb8
+        bv_omega
+      exact ⟨by omega, by omega, fun k hk => hvalid _ (by omega)⟩)
+    (fun hf8 => by
+      have hlo : ((acctBytes[off]'hoffb).zeroExtend 64 - (0xf7 : Word)).toNat ≤ 8 := by
+        have h2 := not_ult_le hf8
+        have h3 := (acctBytes[off]'hoffb).isLt
+        bv_omega
+      exact ⟨by omega, by omega, fun k hk => hvalid _ (by omega)⟩)
+  have hwn' := cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp) (fun _ hq => hq) hwn
+    (P' := ((.x1 : Reg) ↦ᵣ (B + 152 + 4)) **
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+       ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion aB acctBytes))
+  have hcall := bansf_callSite38_walk_next (n := 87) vRa (by pcf) hwn'
+  rw [show (B + 152) + 4 = B + 156 from by bv_omega] at hcall
+  have hcallF := cpsTripleWithin_frameR
+    (((.x2 : Reg) ↦ᵣ newSp) **
+     ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+     ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) ** F)
+    (by pcf; exact hF) hcall
+  have hpre := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp)
+    hldsF hcallF
+  -- ===== ok continuation: BNE falls through, SD spills the cursor =====
+  have hokc : cpsBranchWithin 2 (B + 156) bansfCR
+      (fun h => ∃ next len : Word,
+        ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 152 + 4)) **
+          bytesRegion aB acctBytes ** F) **
+         ⌜rlpItemDecode acctBytes off (aB + BitVec.ofNat 64 off)
+           (aB + BitVec.ofNat 64 aLen) next len⌝) h)
+      (B + 736) (itemRej aB newSp acctBytes F)
+      (B + 164) (itemOk aB newSp aLen off acctBytes F) := by
+    refine cpsBranchWithin_exists_pre (fun next => ?_)
+    refine cpsBranchWithin_exists_pre (fun len => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hdec => ?_)
+    have hbne := bne_spec_gen_within .x11 .x0 (576 : BitVec 13) (0 : Word) (0 : Word) (B + 156)
+    rw [show (B + 156) + 4 = B + 160 from by bv_omega] at hbne
+    have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 156) bansfProg 39 (.BNE .x11 .x0 (576 : BitVec 13))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+      hbne
+    have hfall := cpsBranchWithin_ntakenPath hbneL
+      (fun hp hQt => by
+        obtain ⟨_, _, _, _, _, h_pure⟩ := hQt
+        exact absurd rfl (((sepConj_pure_right _).1 h_pure).2))
+    -- SD a0, 48(sp) at B+120
+    have hsd := sd_spec_gen_within .x2 .x10 newSp next (aB + BitVec.ofNat 64 off)
+      (48 : BitVec 12) (B + 160)
+    rw [se48, show (B + 160) + 4 = B + 164 from by bv_omega] at hsd
+    have hsdL := liftCode (cr' := bansfCR) hsd
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 160) bansfProg 40 (.SD .x2 .x10 (48 : BitVec 12))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+    have hfallF := cpsTripleWithin_frameR
+      (((.x10 : Reg) ↦ᵣ next) ** ((.x12 : Reg) ↦ᵣ len) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 152 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hfall
+    have hsdF := cpsTripleWithin_frameR
+      (((.x11 : Reg) ↦ᵣ (0 : Word)) ** ((.x12 : Reg) ↦ᵣ len) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 152 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hsdL
+    have hout : cpsTripleWithin 2 (B + 156) (B + 164) bansfCR
+        (((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x12 : Reg) ↦ᵣ len) **
+         ((.x2 : Reg) ↦ᵣ newSp) **
+         ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+         ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 152 + 4)) **
+         bytesRegion aB acctBytes ** F)
+        (itemOk aB newSp aLen off acctBytes F) := by
+      have hchain := cpsTripleWithin_seq_perm_same_cr
+        (fun h hp => by
+          have hp2 := sepConj_mono_left (sepConj_mono_right
+            (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+          xperm_hyp hp2)
+        hfallF hsdF
+      refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hchain
+      unfold itemOk
+      refine ⟨next, len, ?_⟩
+      have hq2 : ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 48) ↦ₘ next) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 152 + 4)) **
+          bytesRegion aB acctBytes ** F)) h := by
+        xperm_hyp hq
+      have hq3 : ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 48) ↦ₘ next) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+          bytesRegion aB acctBytes ** F)) h := by
+        have hq4 : ((((.x1 : Reg) ↦ᵣ (B + 152 + 4)) **
+            (((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+             ((.x12 : Reg) ↦ᵣ len) **
+             ((.x2 : Reg) ↦ᵣ newSp) **
+             ((newSp + 48) ↦ₘ next) **
+             ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+             regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+             regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+             ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+             bytesRegion aB acctBytes ** F))) h := by
+          xperm_hyp hq2
+        have hq5 := sepConj_mono (regIs_implies_regOwn .x1) (fun _ x => x) h hq4
+        xperm_hyp hq5
+      exact (sepConj_pure_right h).2 ⟨hq3, hdec⟩
+    exact cpsBranchWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_as_cpsBranchWithin_right _ _ hout)
+  -- ===== fail continuation =====
+  have hfailc : cpsBranchWithin 2 (B + 156) bansfCR
+      (fun h => ∃ cur k : Word,
+        ((((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ k) **
+          ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 152 + 4)) **
+          bytesRegion aB acctBytes ** F) **
+         ⌜k ≠ (0 : Word)⌝) h)
+      (B + 736) (itemRej aB newSp acctBytes F)
+      (B + 164) (itemOk aB newSp aLen off acctBytes F) := by
+    refine cpsBranchWithin_exists_pre (fun cur => ?_)
+    refine cpsBranchWithin_exists_pre (fun k => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hk => ?_)
+    have hbne := bne_spec_gen_within .x11 .x0 (576 : BitVec 13) k (0 : Word) (B + 156)
+    rw [show (B + 156) + signExtend13 (576 : BitVec 13) = B + 732 from by
+          rw [show signExtend13 (576 : BitVec 13) = (576 : Word) from by decide]
+          bv_omega,
+        show (B + 156) + 4 = B + 160 from by bv_omega] at hbne
+    have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 156) bansfProg 39 (.BNE .x11 .x0 (576 : BitVec 13))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+      hbne
+    have hbneF := cpsBranchWithin_frameR
+      (((.x10 : Reg) ↦ᵣ cur) ** ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 152 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hbneL
+    have htaken := cpsBranchWithin_takenPath hbneF
+      (fun hp hQf => by
+        obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_pure⟩, _⟩ := hQf
+        exact hk (((sepConj_pure_right _).1 h_pure).2))
+    have hrej := liftCode (cr' := bansfCR)
+      (bansf_rejectTail_spec B cur (by decide))
+      (fun a i h => CodeReq.union_mono_left a i h)
+    have hrejF := cpsTripleWithin_frameR
+      (((.x11 : Reg) ↦ᵣ k) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 152 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hrej
+    have hchain := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        have hp2 := sepConj_mono_left (sepConj_mono_right
+          (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+        xperm_hyp hp2)
+      htaken hrejF
+    have hout : cpsTripleWithin 2 (B + 156) (B + 736) bansfCR
+        (((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ k) **
+         ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x2 : Reg) ↦ᵣ newSp) **
+         ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+         ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 152 + 4)) **
+         bytesRegion aB acctBytes ** F)
+        (itemRej aB newSp acctBytes F) := by
+      refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hchain
+      unfold itemRej
+      have hq4 : ((((.x11 : Reg) ↦ᵣ k) ** ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x1 : Reg) ↦ᵣ (B + 152 + 4)) **
+          ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          (((.x10 : Reg) ↦ᵣ (1 : Word)) ** ((.x2 : Reg) ↦ᵣ newSp) **
+           regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+           regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+           ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+           bytesRegion aB acctBytes ** F))) h := by
+        xperm_hyp hq
+      have hq5 := sepConj_mono (regIs_implies_regOwn .x11)
+        (sepConj_mono (regIs_implies_regOwn .x12)
+          (sepConj_mono (regIs_implies_regOwn .x1)
+            (sepConj_mono memIs_implies_memOwn
+              (sepConj_mono memIs_implies_memOwn (fun _ x => x))))) h hq4
+      xperm_hyp hq5
+    exact cpsTripleWithin_as_cpsBranchWithin_left _ _ hout
+  -- ===== chain: loads ; call ; (ok ∨ fail) =====
+  refine cpsBranchWithin_weaken
+    (fun h hp => by xperm_hyp hp) (fun _ x => x) (fun _ x => x)
+    (cpsBranchWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_seq_branch_same_cr hpre
+        (cpsBranchWithin_weaken (fun h hp => ?_) (fun _ x => x) (fun _ x => x)
+          (cpsBranchWithin_pre_or hokc hfailc))))
+  -- pointwise: collapse the six callee arms into ok ∨ fail
+  obtain ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, hor⟩, hEx⟩ := hp
+  have rebuild : ∀ (arm : Assertion), arm h4 →
+      ((((regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+          regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x1 : Reg) ↦ᵣ (B + 152 + 4)) ** bytesRegion aB acctBytes) ** arm) **
+        (((.x2 : Reg) ↦ᵣ newSp) **
+         ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+         ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) ** F))) h :=
+    fun arm ha => ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, ha⟩, hEx⟩
+  rcases hor with a1 | a2 | a3 | a4 | a5 | a6
+  · -- ok arm: rlpWalkNextOk
+    obtain ⟨next, len, hpins⟩ := a1
+    refine Or.inl ⟨next, len, ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := hpins
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, hdec⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ len))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ len) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 152 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, hdec⟩
+  · -- fail arm: status 2
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (2 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a2
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (2 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (2 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 152 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 3
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (3 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a3
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (3 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (3 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 152 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 4
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (4 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a4
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (4 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (4 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 152 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 5
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (5 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a5
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (5 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (5 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 152 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 6
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (6 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a6
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (6 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (6 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 152 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+
+#print axioms bansf_item2_spec
+
+/-- Outer item unit 3 (slots 41–45, `B + 164 → B + 184`). -/
+theorem bansf_item3_spec (aB newSp : Word) (aLen off : Nat)
+    (acctBytes : List (BitVec 8))
+    (v5 v6 v7 v10 v11 v12 v28 v29 v30 v31 vRa : Word) (F : Assertion)
+    (hF : F.pcFree)
+    (hsalign : aB.toNat % 8 = 0)
+    (hslack : aLen + 9 ≤ acctBytes.length)
+    (hover : aB.toNat + acctBytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < acctBytes.length →
+      isValidByteAccess (aB + BitVec.ofNat 64 k) = true)
+    (hoffle : off ≤ aLen) :
+    cpsBranchWithin 93 (B + 164) bansfCR
+      (((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((.x10 : Reg) ↦ᵣ v10) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+       bytesRegion aB acctBytes ** F)
+      (B + 736) (itemRej aB newSp acctBytes F)
+      (B + 184) (itemOk aB newSp aLen off acctBytes F) := by
+  have hoffb : off < acctBytes.length := by omega
+  -- LD a0, 48(sp) ; LD a1, 56(sp)  (B+104, B+108)
+  have hld1 := ld_spec_gen_within .x10 .x2 newSp v10 (aB + BitVec.ofNat 64 off)
+    (48 : BitVec 12) (B + 164) (by decide)
+  rw [se48, show (B + 164) + 4 = B + 168 from by bv_omega] at hld1
+  have hld1L := liftCode (cr' := bansfCR) hld1
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 164) bansfProg 41 (.LD .x10 .x2 (48 : BitVec 12))
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+  have hld2 := ld_spec_gen_within .x11 .x2 newSp v11 (aB + BitVec.ofNat 64 aLen)
+    (56 : BitVec 12) (B + 168) (by decide)
+  rw [se56, show (B + 168) + 4 = B + 172 from by bv_omega] at hld2
+  have hld2L := liftCode (cr' := bansfCR) hld2
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 168) bansfProg 42 (.LD .x11 .x2 (56 : BitVec 12))
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+  have hld1F := cpsTripleWithin_frameR
+    (((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) ** ((.x11 : Reg) ↦ᵣ v11))
+    (by pcf) hld1L
+  have hld2F := cpsTripleWithin_frameR
+    (((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+     ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)))
+    (by pcf) hld2L
+  have hlds := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hld1F hld2F
+  have hldsF := cpsTripleWithin_frameR
+    (((.x12 : Reg) ↦ᵣ v12) **
+     ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+     ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+     bytesRegion aB acctBytes ** F)
+    (by pcf; exact hF) hlds
+  -- the callee triple with ra = B + 172 + 4
+  have hwn := rlp_walk_next_spec_within WN aB (aB + BitVec.ofNat 64 aLen)
+    (B + 172 + 4) v12 v5 v6 v7 v28 v29 v30 v31 acctBytes off hsalign hoffb (by omega)
+    (hvalid off hoffb)
+    (fun h80 hb8 => ⟨by omega, by omega, hvalid _ (by omega)⟩)
+    (fun hb8 hc0 => by
+      have hlo : ((acctBytes[off]'hoffb).zeroExtend 64 - (0xb7 : Word)).toNat ≤ 8 := by
+        have h1 := ult_lt hc0
+        have h2 := not_ult_le hb8
+        bv_omega
+      exact ⟨by omega, by omega, fun k hk => hvalid _ (by omega)⟩)
+    (fun hf8 => by
+      have hlo : ((acctBytes[off]'hoffb).zeroExtend 64 - (0xf7 : Word)).toNat ≤ 8 := by
+        have h2 := not_ult_le hf8
+        have h3 := (acctBytes[off]'hoffb).isLt
+        bv_omega
+      exact ⟨by omega, by omega, fun k hk => hvalid _ (by omega)⟩)
+  have hwn' := cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp) (fun _ hq => hq) hwn
+    (P' := ((.x1 : Reg) ↦ᵣ (B + 172 + 4)) **
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+       ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion aB acctBytes))
+  have hcall := bansf_callSite43_walk_next (n := 87) vRa (by pcf) hwn'
+  rw [show (B + 172) + 4 = B + 176 from by bv_omega] at hcall
+  have hcallF := cpsTripleWithin_frameR
+    (((.x2 : Reg) ↦ᵣ newSp) **
+     ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+     ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) ** F)
+    (by pcf; exact hF) hcall
+  have hpre := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp)
+    hldsF hcallF
+  -- ===== ok continuation: BNE falls through, SD spills the cursor =====
+  have hokc : cpsBranchWithin 2 (B + 176) bansfCR
+      (fun h => ∃ next len : Word,
+        ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 172 + 4)) **
+          bytesRegion aB acctBytes ** F) **
+         ⌜rlpItemDecode acctBytes off (aB + BitVec.ofNat 64 off)
+           (aB + BitVec.ofNat 64 aLen) next len⌝) h)
+      (B + 736) (itemRej aB newSp acctBytes F)
+      (B + 184) (itemOk aB newSp aLen off acctBytes F) := by
+    refine cpsBranchWithin_exists_pre (fun next => ?_)
+    refine cpsBranchWithin_exists_pre (fun len => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hdec => ?_)
+    have hbne := bne_spec_gen_within .x11 .x0 (556 : BitVec 13) (0 : Word) (0 : Word) (B + 176)
+    rw [show (B + 176) + 4 = B + 180 from by bv_omega] at hbne
+    have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 176) bansfProg 44 (.BNE .x11 .x0 (556 : BitVec 13))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+      hbne
+    have hfall := cpsBranchWithin_ntakenPath hbneL
+      (fun hp hQt => by
+        obtain ⟨_, _, _, _, _, h_pure⟩ := hQt
+        exact absurd rfl (((sepConj_pure_right _).1 h_pure).2))
+    -- SD a0, 48(sp) at B+120
+    have hsd := sd_spec_gen_within .x2 .x10 newSp next (aB + BitVec.ofNat 64 off)
+      (48 : BitVec 12) (B + 180)
+    rw [se48, show (B + 180) + 4 = B + 184 from by bv_omega] at hsd
+    have hsdL := liftCode (cr' := bansfCR) hsd
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 180) bansfProg 45 (.SD .x2 .x10 (48 : BitVec 12))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+    have hfallF := cpsTripleWithin_frameR
+      (((.x10 : Reg) ↦ᵣ next) ** ((.x12 : Reg) ↦ᵣ len) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 172 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hfall
+    have hsdF := cpsTripleWithin_frameR
+      (((.x11 : Reg) ↦ᵣ (0 : Word)) ** ((.x12 : Reg) ↦ᵣ len) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 172 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hsdL
+    have hout : cpsTripleWithin 2 (B + 176) (B + 184) bansfCR
+        (((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x12 : Reg) ↦ᵣ len) **
+         ((.x2 : Reg) ↦ᵣ newSp) **
+         ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+         ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 172 + 4)) **
+         bytesRegion aB acctBytes ** F)
+        (itemOk aB newSp aLen off acctBytes F) := by
+      have hchain := cpsTripleWithin_seq_perm_same_cr
+        (fun h hp => by
+          have hp2 := sepConj_mono_left (sepConj_mono_right
+            (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+          xperm_hyp hp2)
+        hfallF hsdF
+      refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hchain
+      unfold itemOk
+      refine ⟨next, len, ?_⟩
+      have hq2 : ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 48) ↦ₘ next) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 172 + 4)) **
+          bytesRegion aB acctBytes ** F)) h := by
+        xperm_hyp hq
+      have hq3 : ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 48) ↦ₘ next) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+          bytesRegion aB acctBytes ** F)) h := by
+        have hq4 : ((((.x1 : Reg) ↦ᵣ (B + 172 + 4)) **
+            (((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+             ((.x12 : Reg) ↦ᵣ len) **
+             ((.x2 : Reg) ↦ᵣ newSp) **
+             ((newSp + 48) ↦ₘ next) **
+             ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+             regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+             regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+             ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+             bytesRegion aB acctBytes ** F))) h := by
+          xperm_hyp hq2
+        have hq5 := sepConj_mono (regIs_implies_regOwn .x1) (fun _ x => x) h hq4
+        xperm_hyp hq5
+      exact (sepConj_pure_right h).2 ⟨hq3, hdec⟩
+    exact cpsBranchWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_as_cpsBranchWithin_right _ _ hout)
+  -- ===== fail continuation =====
+  have hfailc : cpsBranchWithin 2 (B + 176) bansfCR
+      (fun h => ∃ cur k : Word,
+        ((((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ k) **
+          ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 172 + 4)) **
+          bytesRegion aB acctBytes ** F) **
+         ⌜k ≠ (0 : Word)⌝) h)
+      (B + 736) (itemRej aB newSp acctBytes F)
+      (B + 184) (itemOk aB newSp aLen off acctBytes F) := by
+    refine cpsBranchWithin_exists_pre (fun cur => ?_)
+    refine cpsBranchWithin_exists_pre (fun k => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hk => ?_)
+    have hbne := bne_spec_gen_within .x11 .x0 (556 : BitVec 13) k (0 : Word) (B + 176)
+    rw [show (B + 176) + signExtend13 (556 : BitVec 13) = B + 732 from by
+          rw [show signExtend13 (556 : BitVec 13) = (556 : Word) from by decide]
+          bv_omega,
+        show (B + 176) + 4 = B + 180 from by bv_omega] at hbne
+    have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 176) bansfProg 44 (.BNE .x11 .x0 (556 : BitVec 13))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+      hbne
+    have hbneF := cpsBranchWithin_frameR
+      (((.x10 : Reg) ↦ᵣ cur) ** ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 172 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hbneL
+    have htaken := cpsBranchWithin_takenPath hbneF
+      (fun hp hQf => by
+        obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_pure⟩, _⟩ := hQf
+        exact hk (((sepConj_pure_right _).1 h_pure).2))
+    have hrej := liftCode (cr' := bansfCR)
+      (bansf_rejectTail_spec B cur (by decide))
+      (fun a i h => CodeReq.union_mono_left a i h)
+    have hrejF := cpsTripleWithin_frameR
+      (((.x11 : Reg) ↦ᵣ k) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 172 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hrej
+    have hchain := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        have hp2 := sepConj_mono_left (sepConj_mono_right
+          (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+        xperm_hyp hp2)
+      htaken hrejF
+    have hout : cpsTripleWithin 2 (B + 176) (B + 736) bansfCR
+        (((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ k) **
+         ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x2 : Reg) ↦ᵣ newSp) **
+         ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+         ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 172 + 4)) **
+         bytesRegion aB acctBytes ** F)
+        (itemRej aB newSp acctBytes F) := by
+      refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hchain
+      unfold itemRej
+      have hq4 : ((((.x11 : Reg) ↦ᵣ k) ** ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x1 : Reg) ↦ᵣ (B + 172 + 4)) **
+          ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          (((.x10 : Reg) ↦ᵣ (1 : Word)) ** ((.x2 : Reg) ↦ᵣ newSp) **
+           regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+           regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+           ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+           bytesRegion aB acctBytes ** F))) h := by
+        xperm_hyp hq
+      have hq5 := sepConj_mono (regIs_implies_regOwn .x11)
+        (sepConj_mono (regIs_implies_regOwn .x12)
+          (sepConj_mono (regIs_implies_regOwn .x1)
+            (sepConj_mono memIs_implies_memOwn
+              (sepConj_mono memIs_implies_memOwn (fun _ x => x))))) h hq4
+      xperm_hyp hq5
+    exact cpsTripleWithin_as_cpsBranchWithin_left _ _ hout
+  -- ===== chain: loads ; call ; (ok ∨ fail) =====
+  refine cpsBranchWithin_weaken
+    (fun h hp => by xperm_hyp hp) (fun _ x => x) (fun _ x => x)
+    (cpsBranchWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_seq_branch_same_cr hpre
+        (cpsBranchWithin_weaken (fun h hp => ?_) (fun _ x => x) (fun _ x => x)
+          (cpsBranchWithin_pre_or hokc hfailc))))
+  -- pointwise: collapse the six callee arms into ok ∨ fail
+  obtain ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, hor⟩, hEx⟩ := hp
+  have rebuild : ∀ (arm : Assertion), arm h4 →
+      ((((regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+          regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x1 : Reg) ↦ᵣ (B + 172 + 4)) ** bytesRegion aB acctBytes) ** arm) **
+        (((.x2 : Reg) ↦ᵣ newSp) **
+         ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+         ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) ** F))) h :=
+    fun arm ha => ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, ha⟩, hEx⟩
+  rcases hor with a1 | a2 | a3 | a4 | a5 | a6
+  · -- ok arm: rlpWalkNextOk
+    obtain ⟨next, len, hpins⟩ := a1
+    refine Or.inl ⟨next, len, ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := hpins
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, hdec⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ len))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ len) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 172 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, hdec⟩
+  · -- fail arm: status 2
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (2 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a2
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (2 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (2 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 172 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 3
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (3 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a3
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (3 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (3 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 172 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 4
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (4 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a4
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (4 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (4 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 172 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 5
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (5 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a5
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (5 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (5 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 172 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 6
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (6 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a6
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (6 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (6 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 172 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+
+#print axioms bansf_item3_spec
+
+end BalAccountNonstorageFinalsSpec
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainB3.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainB3.lean
@@ -1,0 +1,605 @@
+/-
+  EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB3
+
+  SEG-B assembly for `bal_account_nonstorage_finals` (bead
+  evm-asm-4ch8f.43.5, slice 3d): body entry (`B + 28`) through the
+  balance-station boundary (`B + 184`) as ONE two-exit branch — the
+  prologue, the outer `rlp_walk_init` dispatch, the cursor/end spills, and
+  the four outer item units, with the reject exits threaded to the shared
+  epilogue entry and the success exit carrying the accumulated
+  `rlpItemDecode` chain for items 0–3.
+-/
+
+import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB2
+
+set_option maxRecDepth 8000
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.RLP
+
+namespace BalAccountNonstorageFinalsSpec
+
+private theorem se48' : signExtend12 (48 : BitVec 12) = (48 : Word) := by decide
+private theorem se56' : signExtend12 (56 : BitVec 12) = (56 : Word) := by decide
+
+/-- The SEG-B grand reject: everything the outer chain touches, with the
+    prologue's stable state (`s0/s1/s2`, the zeroed out block) still pinned. -/
+def chainRejB (aB newSp oB : Word) (aLen : Nat) (acctBytes : List (BitVec 8))
+    (F : Assertion) : Assertion :=
+  ((.x10 : Reg) ↦ᵣ (1 : Word)) ** ((.x2 : Reg) ↦ᵣ newSp) **
+  memOwn (newSp + 48) ** memOwn (newSp + 56) **
+  ((.x8 : Reg) ↦ᵣ aB) ** ((.x9 : Reg) ↦ᵣ BitVec.ofNat 64 aLen) **
+  ((.x18 : Reg) ↦ᵣ oB) **
+  (oB ↦ₘ (0 : Word)) ** ((oB + 40) ↦ₘ (0 : Word)) **
+  ((oB + 56) ↦ₘ (0 : Word)) ** ((oB + 64) ↦ₘ (0 : Word)) **
+  ((oB + 72) ↦ₘ (0 : Word)) ** ((oB + 8) ↦ₘ (0 : Word)) **
+  ((oB + 16) ↦ₘ (0 : Word)) ** ((oB + 24) ↦ₘ (0 : Word)) **
+  ((oB + 32) ↦ₘ (0 : Word)) ** ((oB + 48) ↦ₘ (0 : Word)) **
+  regOwn .x11 ** regOwn .x12 **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+  ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+  bytesRegion aB acctBytes ** F
+
+/-- The item-0-ready state (`B + 104`): outer header consumed, cursor and
+    window end spilled. -/
+def chainMidB (aB newSp oB : Word) (aLen : Nat) (acctBytes : List (BitVec 8))
+    (F : Assertion) : Assertion :=
+  fun h => ∃ c : Nat,
+    ((((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 c)) **
+      ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+      ((.x2 : Reg) ↦ᵣ newSp) **
+      ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 c)) **
+      ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+      ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x8 : Reg) ↦ᵣ aB) ** ((.x9 : Reg) ↦ᵣ BitVec.ofNat 64 aLen) **
+      ((.x18 : Reg) ↦ᵣ oB) **
+      (oB ↦ₘ (0 : Word)) ** ((oB + 40) ↦ₘ (0 : Word)) **
+      ((oB + 56) ↦ₘ (0 : Word)) ** ((oB + 64) ↦ₘ (0 : Word)) **
+      ((oB + 72) ↦ₘ (0 : Word)) ** ((oB + 8) ↦ₘ (0 : Word)) **
+      ((oB + 16) ↦ₘ (0 : Word)) ** ((oB + 24) ↦ₘ (0 : Word)) **
+      ((oB + 32) ↦ₘ (0 : Word)) ** ((oB + 48) ↦ₘ (0 : Word)) **
+      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+      bytesRegion aB acctBytes ** F) **
+     ⌜OuterInitOk acctBytes aLen c⌝) h
+
+/-- Part A of SEG-B: body entry (`B + 28`) through the spilled outer
+    cursor (`B + 104`): prologue, outer `rlp_walk_init` dispatch, and the
+    two spill stores. -/
+theorem bansf_chainA_spec (aB newSp oB : Word) (aLen : Nat)
+    (acctBytes : List (BitVec 8)) (v8 v9 v18 : Word) (F : Assertion)
+    (hF : F.pcFree)
+    (hsalign : aB.toNat % 8 = 0)
+    (hslack : aLen + 9 ≤ acctBytes.length)
+    (hover : aB.toNat + acctBytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < acctBytes.length →
+      isValidByteAccess (aB + BitVec.ofNat 64 k) = true) :
+    cpsBranchWithin 101 (B + 28) bansfCR
+      (((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ BitVec.ofNat 64 aLen) **
+       ((.x12 : Reg) ↦ᵣ oB) **
+       ((.x8 : Reg) ↦ᵣ v8) ** ((.x9 : Reg) ↦ᵣ v9) ** ((.x18 : Reg) ↦ᵣ v18) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       memOwn (newSp + 48) ** memOwn (newSp + 56) **
+       memOwn oB ** memOwn (oB + 40) ** memOwn (oB + 56) **
+       memOwn (oB + 64) ** memOwn (oB + 72) ** memOwn (oB + 8) **
+       memOwn (oB + 16) ** memOwn (oB + 24) ** memOwn (oB + 32) **
+       memOwn (oB + 48) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+       bytesRegion aB acctBytes ** F)
+      (B + 736) (chainRejB aB newSp oB aLen acctBytes F)
+      (B + 104) (chainMidB aB newSp oB aLen acctBytes F) := by
+  -- expose the eight owned scratch registers for the init call
+  refine cpsBranchWithin_weaken
+    (P := ((((.x10 : Reg) ↦ᵣ aB) ** ((.x11 : Reg) ↦ᵣ BitVec.ofNat 64 aLen) **
+       ((.x12 : Reg) ↦ᵣ oB) **
+       ((.x8 : Reg) ↦ᵣ v8) ** ((.x9 : Reg) ↦ᵣ v9) ** ((.x18 : Reg) ↦ᵣ v18) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       memOwn (newSp + 48) ** memOwn (newSp + 56) **
+       memOwn oB ** memOwn (oB + 40) ** memOwn (oB + 56) **
+       memOwn (oB + 64) ** memOwn (oB + 72) ** memOwn (oB + 8) **
+       memOwn (oB + 16) ** memOwn (oB + 24) ** memOwn (oB + 32) **
+       memOwn (oB + 48) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion aB acctBytes ** F) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** regOwn .x1))
+    (fun h hp => by xperm_hyp hp) (fun _ x => x) (fun _ x => x) ?_
+  refine cpsBranchWithin_of_forall_regIs_to_regOwn8
+    (fun v5 v6 v7 v28 v29 v30 v31 vRa => ?_)
+  -- prologue triple (B+28 → B+88), framed
+  have hpro := liftCode (cr' := bansfCR)
+    (bansf_prologue_spec aB (BitVec.ofNat 64 aLen) oB v8 v9 v18)
+    (fun a i h => CodeReq.union_mono_left a i h)
+  have hproF := cpsTripleWithin_frameR
+    (((.x2 : Reg) ↦ᵣ newSp) **
+     memOwn (newSp + 48) ** memOwn (newSp + 56) **
+     ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+     ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x1 : Reg) ↦ᵣ vRa) **
+     bytesRegion aB acctBytes ** F)
+    (by pcf; exact hF) hpro
+  -- outer init dispatch (B+88), with the prologue's stable state framed
+  have hinit := bansf_outerInit_spec aB aLen acctBytes v5 v6 v7 oB v28 v29 v30 v31
+    vRa
+    (((.x8 : Reg) ↦ᵣ aB) ** ((.x9 : Reg) ↦ᵣ BitVec.ofNat 64 aLen) **
+     ((.x18 : Reg) ↦ᵣ oB) **
+     ((.x2 : Reg) ↦ᵣ newSp) **
+     memOwn (newSp + 48) ** memOwn (newSp + 56) **
+     (oB ↦ₘ (0 : Word)) ** ((oB + 40) ↦ₘ (0 : Word)) **
+     ((oB + 56) ↦ₘ (0 : Word)) ** ((oB + 64) ↦ₘ (0 : Word)) **
+     ((oB + 72) ↦ₘ (0 : Word)) ** ((oB + 8) ↦ₘ (0 : Word)) **
+     ((oB + 16) ↦ₘ (0 : Word)) ** ((oB + 24) ↦ₘ (0 : Word)) **
+     ((oB + 32) ↦ₘ (0 : Word)) ** ((oB + 48) ↦ₘ (0 : Word)) ** F)
+    (by pcf; exact hF) hsalign hslack hover hvalid
+  -- glue: SD a0, 48(sp) ; SD a1, 56(sp)  (slots 24–25, B+96 → B+104)
+  have hglue : ∀ c : Nat, cpsTripleWithin 2 (B + 96) (B + 104) bansfCR
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 c)) **
+       ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       memOwn (newSp + 48) ** memOwn (newSp + 56))
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 c)) **
+       ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 c)) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen))) := by
+    intro c
+    have hsd1 := sd_spec_gen_own_within .x2 .x10 newSp (aB + BitVec.ofNat 64 c)
+      (48 : BitVec 12) (B + 96)
+    rw [se48', show (B + 96) + 4 = B + 100 from by bv_omega] at hsd1
+    have hsd1L := liftCode (cr' := bansfCR) hsd1
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 96) bansfProg 24 (.SD .x2 .x10 (48 : BitVec 12))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+    have hsd2 := sd_spec_gen_own_within .x2 .x11 newSp (aB + BitVec.ofNat 64 aLen)
+      (56 : BitVec 12) (B + 100)
+    rw [se56', show (B + 100) + 4 = B + 104 from by bv_omega] at hsd2
+    have hsd2L := liftCode (cr' := bansfCR) hsd2
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 100) bansfProg 25 (.SD .x2 .x11 (56 : BitVec 12))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+    have hsd1F := cpsTripleWithin_frameR
+      (((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) ** memOwn (newSp + 56))
+      (by pcf) hsd1L
+    have hsd2F := cpsTripleWithin_frameR
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 c)) **
+       ((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 c)))
+      (by pcf) hsd2L
+    have hchain := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp)
+      hsd1F hsd2F
+    exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+      (fun h hq => by xperm_hyp hq) hchain
+  -- the post-init continuation: eliminate the ∃c, run the glue, restate
+  have hcont : cpsBranchWithin 2 (B + 96) bansfCR
+      (outerInitPost aB aLen acctBytes
+        (((.x8 : Reg) ↦ᵣ aB) ** ((.x9 : Reg) ↦ᵣ BitVec.ofNat 64 aLen) **
+         ((.x18 : Reg) ↦ᵣ oB) **
+         ((.x2 : Reg) ↦ᵣ newSp) **
+         memOwn (newSp + 48) ** memOwn (newSp + 56) **
+         (oB ↦ₘ (0 : Word)) ** ((oB + 40) ↦ₘ (0 : Word)) **
+         ((oB + 56) ↦ₘ (0 : Word)) ** ((oB + 64) ↦ₘ (0 : Word)) **
+         ((oB + 72) ↦ₘ (0 : Word)) ** ((oB + 8) ↦ₘ (0 : Word)) **
+         ((oB + 16) ↦ₘ (0 : Word)) ** ((oB + 24) ↦ₘ (0 : Word)) **
+         ((oB + 32) ↦ₘ (0 : Word)) ** ((oB + 48) ↦ₘ (0 : Word)) ** F))
+      (B + 736) (chainRejB aB newSp oB aLen acctBytes F)
+      (B + 104) (chainMidB aB newSp oB aLen acctBytes F) := by
+    unfold outerInitPost
+    refine cpsBranchWithin_exists_pre (fun c => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hok => ?_)
+    have hg := hglue c
+    have hgF := cpsTripleWithin_frameR
+      (((.x12 : Reg) ↦ᵣ (0 : Word)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+       bytesRegion aB acctBytes **
+       ((.x8 : Reg) ↦ᵣ aB) ** ((.x9 : Reg) ↦ᵣ BitVec.ofNat 64 aLen) **
+       ((.x18 : Reg) ↦ᵣ oB) **
+       (oB ↦ₘ (0 : Word)) ** ((oB + 40) ↦ₘ (0 : Word)) **
+       ((oB + 56) ↦ₘ (0 : Word)) ** ((oB + 64) ↦ₘ (0 : Word)) **
+       ((oB + 72) ↦ₘ (0 : Word)) ** ((oB + 8) ↦ₘ (0 : Word)) **
+       ((oB + 16) ↦ₘ (0 : Word)) ** ((oB + 24) ↦ₘ (0 : Word)) **
+       ((oB + 32) ↦ₘ (0 : Word)) ** ((oB + 48) ↦ₘ (0 : Word)) ** F)
+      (by pcf; exact hF) hg
+    have hout : cpsTripleWithin 2 (B + 96) (B + 104) bansfCR
+        (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 c)) **
+         ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+         ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+         bytesRegion aB acctBytes **
+         (((.x8 : Reg) ↦ᵣ aB) ** ((.x9 : Reg) ↦ᵣ BitVec.ofNat 64 aLen) **
+          ((.x18 : Reg) ↦ᵣ oB) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          memOwn (newSp + 48) ** memOwn (newSp + 56) **
+          (oB ↦ₘ (0 : Word)) ** ((oB + 40) ↦ₘ (0 : Word)) **
+          ((oB + 56) ↦ₘ (0 : Word)) ** ((oB + 64) ↦ₘ (0 : Word)) **
+          ((oB + 72) ↦ₘ (0 : Word)) ** ((oB + 8) ↦ₘ (0 : Word)) **
+          ((oB + 16) ↦ₘ (0 : Word)) ** ((oB + 24) ↦ₘ (0 : Word)) **
+          ((oB + 32) ↦ₘ (0 : Word)) ** ((oB + 48) ↦ₘ (0 : Word)) ** F))
+        (chainMidB aB newSp oB aLen acctBytes F) := by
+      refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hgF
+      unfold chainMidB
+      refine ⟨c, ?_⟩
+      have hq2 : ((((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 c)) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 c)) **
+          ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+          ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x8 : Reg) ↦ᵣ aB) ** ((.x9 : Reg) ↦ᵣ BitVec.ofNat 64 aLen) **
+          ((.x18 : Reg) ↦ᵣ oB) **
+          (oB ↦ₘ (0 : Word)) ** ((oB + 40) ↦ₘ (0 : Word)) **
+          ((oB + 56) ↦ₘ (0 : Word)) ** ((oB + 64) ↦ₘ (0 : Word)) **
+          ((oB + 72) ↦ₘ (0 : Word)) ** ((oB + 8) ↦ₘ (0 : Word)) **
+          ((oB + 16) ↦ₘ (0 : Word)) ** ((oB + 24) ↦ₘ (0 : Word)) **
+          ((oB + 32) ↦ₘ (0 : Word)) ** ((oB + 48) ↦ₘ (0 : Word)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+          bytesRegion aB acctBytes ** F)) h := by
+        xperm_hyp hq
+      exact (sepConj_pure_right h).2 ⟨hq2, hok⟩
+    exact cpsTripleWithin_as_cpsBranchWithin_right _ _ hout
+  -- assemble: prologue ; init-dispatch(+reject weaken) ; glue
+  refine cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun _ x => x) (fun _ x => x)
+    (cpsBranchWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_seq_branch_same_cr hproF
+        (cpsBranchWithin_chain_snd
+          (cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
+            (fun h hq => ?_) (fun _ x => x) hinit)
+          hcont)))
+  -- the init reject, weakened into the grand SEG-B reject
+  unfold outerRej at hq
+  unfold chainRejB
+  have hq2 : ((((.x8 : Reg) ↦ᵣ aB) ** ((.x9 : Reg) ↦ᵣ BitVec.ofNat 64 aLen) **
+      ((.x18 : Reg) ↦ᵣ oB) **
+      (((.x10 : Reg) ↦ᵣ (1 : Word)) ** ((.x2 : Reg) ↦ᵣ newSp) **
+       memOwn (newSp + 48) ** memOwn (newSp + 56) **
+       (oB ↦ₘ (0 : Word)) ** ((oB + 40) ↦ₘ (0 : Word)) **
+       ((oB + 56) ↦ₘ (0 : Word)) ** ((oB + 64) ↦ₘ (0 : Word)) **
+       ((oB + 72) ↦ₘ (0 : Word)) ** ((oB + 8) ↦ₘ (0 : Word)) **
+       ((oB + 16) ↦ₘ (0 : Word)) ** ((oB + 24) ↦ₘ (0 : Word)) **
+       ((oB + 32) ↦ₘ (0 : Word)) ** ((oB + 48) ↦ₘ (0 : Word)) **
+       regOwn .x11 ** regOwn .x12 **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+       bytesRegion aB acctBytes ** F))) h := by
+    xperm_hyp hq
+  xperm_hyp hq2
+
+#print axioms bansf_chainA_spec
+
+/-! ## §2  The four-item chain (B + 104 → B + 184) -/
+
+def acc0 (aB newSp : Word) (aLen off0 : Nat) (acctBytes : List (BitVec 8))
+    (F : Assertion) : Assertion :=
+  fun h => ∃ n0 l0 : Word,
+    ((((newSp + 48) ↦ₘ n0) **
+      ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+      ((.x2 : Reg) ↦ᵣ newSp) **
+      ((.x10 : Reg) ↦ᵣ n0) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x12 : Reg) ↦ᵣ l0) **
+      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+      bytesRegion aB acctBytes ** F) **
+     ⌜((rlpItemDecode acctBytes off0 (aB + BitVec.ofNat 64 off0)
+        (aB + BitVec.ofNat 64 aLen) n0 l0)) ∧
+      (n0 - aB).toNat ≤ aLen⌝) h
+
+def acc1 (aB newSp : Word) (aLen off0 : Nat) (acctBytes : List (BitVec 8))
+    (F : Assertion) : Assertion :=
+  fun h => ∃ n0 l0 n1 l1 : Word,
+    ((((newSp + 48) ↦ₘ n1) **
+      ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+      ((.x2 : Reg) ↦ᵣ newSp) **
+      ((.x10 : Reg) ↦ᵣ n1) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x12 : Reg) ↦ᵣ l1) **
+      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+      bytesRegion aB acctBytes ** F) **
+     ⌜((rlpItemDecode acctBytes off0 (aB + BitVec.ofNat 64 off0)
+        (aB + BitVec.ofNat 64 aLen) n0 l0) ∧
+      (rlpItemDecode acctBytes ((n0 - aB).toNat) (aB + BitVec.ofNat 64 ((n0 - aB).toNat))
+        (aB + BitVec.ofNat 64 aLen) n1 l1)) ∧
+      (n1 - aB).toNat ≤ aLen⌝) h
+
+def acc2 (aB newSp : Word) (aLen off0 : Nat) (acctBytes : List (BitVec 8))
+    (F : Assertion) : Assertion :=
+  fun h => ∃ n0 l0 n1 l1 n2 l2 : Word,
+    ((((newSp + 48) ↦ₘ n2) **
+      ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+      ((.x2 : Reg) ↦ᵣ newSp) **
+      ((.x10 : Reg) ↦ᵣ n2) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x12 : Reg) ↦ᵣ l2) **
+      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+      bytesRegion aB acctBytes ** F) **
+     ⌜(((rlpItemDecode acctBytes off0 (aB + BitVec.ofNat 64 off0)
+        (aB + BitVec.ofNat 64 aLen) n0 l0) ∧
+      (rlpItemDecode acctBytes ((n0 - aB).toNat) (aB + BitVec.ofNat 64 ((n0 - aB).toNat))
+        (aB + BitVec.ofNat 64 aLen) n1 l1)) ∧
+      (rlpItemDecode acctBytes ((n1 - aB).toNat) (aB + BitVec.ofNat 64 ((n1 - aB).toNat))
+        (aB + BitVec.ofNat 64 aLen) n2 l2)) ∧
+      (n2 - aB).toNat ≤ aLen⌝) h
+
+def acc3 (aB newSp : Word) (aLen off0 : Nat) (acctBytes : List (BitVec 8))
+    (F : Assertion) : Assertion :=
+  fun h => ∃ n0 l0 n1 l1 n2 l2 n3 l3 : Word,
+    ((((newSp + 48) ↦ₘ n3) **
+      ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+      ((.x2 : Reg) ↦ᵣ newSp) **
+      ((.x10 : Reg) ↦ᵣ n3) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x12 : Reg) ↦ᵣ l3) **
+      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+      bytesRegion aB acctBytes ** F) **
+     ⌜((((rlpItemDecode acctBytes off0 (aB + BitVec.ofNat 64 off0)
+        (aB + BitVec.ofNat 64 aLen) n0 l0) ∧
+      (rlpItemDecode acctBytes ((n0 - aB).toNat) (aB + BitVec.ofNat 64 ((n0 - aB).toNat))
+        (aB + BitVec.ofNat 64 aLen) n1 l1)) ∧
+      (rlpItemDecode acctBytes ((n1 - aB).toNat) (aB + BitVec.ofNat 64 ((n1 - aB).toNat))
+        (aB + BitVec.ofNat 64 aLen) n2 l2)) ∧
+      (rlpItemDecode acctBytes ((n2 - aB).toNat) (aB + BitVec.ofNat 64 ((n2 - aB).toNat))
+        (aB + BitVec.ofNat 64 aLen) n3 l3)) ∧
+      (n3 - aB).toNat ≤ aLen⌝) h
+
+/-- Items 0–3 chained (`B + 104 → B + 184`), from the item-0-ready state at
+    offset `off0`, accumulating the outer `rlpItemDecode` chain. -/
+theorem bansf_chainItems_spec (aB newSp : Word) (aLen off0 : Nat)
+    (acctBytes : List (BitVec 8)) (F : Assertion)
+    (hF : F.pcFree)
+    (hsalign : aB.toNat % 8 = 0)
+    (hslack : aLen + 9 ≤ acctBytes.length)
+    (hover : aB.toNat + acctBytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < acctBytes.length →
+      isValidByteAccess (aB + BitVec.ofNat 64 k) = true)
+    (hoff0le : off0 ≤ aLen) :
+    cpsBranchWithin 372 (B + 104) bansfCR
+      (((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off0)) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off0)) **
+       ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+       ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+       bytesRegion aB acctBytes ** F)
+      (B + 736) (itemRej aB newSp acctBytes F)
+      (B + 184) (acc3 aB newSp aLen off0 acctBytes F) := by
+  have hover9 : aB.toNat + aLen + 9 < 2 ^ 64 := by omega
+  -- ===== item 0 =====
+  have hstep0 : cpsBranchWithin 93 (B + 104) bansfCR
+      (((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off0)) **
+       ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off0)) **
+       ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+       ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+       bytesRegion aB acctBytes ** F)
+      (B + 736) (itemRej aB newSp acctBytes F)
+      (B + 124) (acc0 aB newSp aLen off0 acctBytes F) := by
+    refine cpsBranchWithin_weaken
+      (Q_f := itemOk aB newSp aLen off0 acctBytes F)
+      (P := ((((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 off0)) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off0)) **
+        ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion aB acctBytes ** F) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** regOwn .x1))
+      (fun h hp => by xperm_hyp hp) (fun _ x => x) (fun h hq => ?_) ?_
+    · unfold itemOk at hq
+      obtain ⟨next, len, hqq⟩ := hq
+      obtain ⟨hA, hdec⟩ := (sepConj_pure_right h).1 hqq
+      have hadv := rlpItemDecode_advance (bytes := acctBytes) (base := aB)
+        (off := off0) (endOff := aLen) hdec hoff0le hover9
+      refine ⟨next, len, ?_⟩
+      have hA' : ((((newSp + 48) ↦ₘ next) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+          bytesRegion aB acctBytes ** F)) h := by
+        xperm_hyp hA
+      exact (sepConj_pure_right h).2 ⟨hA', hdec, hadv.2.2⟩
+    · refine cpsBranchWithin_of_forall_regIs_to_regOwn8
+        (fun v5 v6 v7 v28 v29 v30 v31 vRa => ?_)
+      exact cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
+        (fun _ x => x) (fun _ x => x)
+        (bansf_item0_spec aB newSp aLen off0 acctBytes
+          v5 v6 v7 (aB + BitVec.ofNat 64 off0) (aB + BitVec.ofNat 64 aLen) (0 : Word)
+          v28 v29 v30 v31 vRa F hF hsalign hslack hover hvalid hoff0le)
+  -- ===== item 1 at the advanced cursor =====
+  have hstep1 : cpsBranchWithin 93 (B + 124) bansfCR
+      (acc0 aB newSp aLen off0 acctBytes F)
+      (B + 736) (itemRej aB newSp acctBytes F)
+      (B + 144) (acc1 aB newSp aLen off0 acctBytes F) := by
+    unfold acc0
+    refine cpsBranchWithin_exists_pre (fun n0 => ?_)
+    refine cpsBranchWithin_exists_pre (fun l0 => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hdecs => ?_)
+    obtain ⟨hchain, hbound⟩ := hdecs
+    have hrep : n0 = aB + BitVec.ofNat 64 ((n0 - aB).toNat) := by
+      rw [BitVec.ofNat_toNat, BitVec.setWidth_eq]
+      bv_omega
+    refine cpsBranchWithin_weaken
+      (Q_f := itemOk aB newSp aLen ((n0 - aB).toNat) acctBytes F)
+      (P := ((((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 ((n0 - aB).toNat))) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 ((n0 - aB).toNat))) **
+        ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ l0) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion aB acctBytes ** F) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** regOwn .x1))
+      (fun h hp => by rw [← hrep]; xperm_hyp hp)
+      (fun _ x => x) (fun h hq => ?_) ?_
+    · -- accumulate the new decode and its bound
+      unfold itemOk at hq
+      obtain ⟨next, len, hqq⟩ := hq
+      obtain ⟨hA, hdnew⟩ := (sepConj_pure_right h).1 hqq
+      have hadv := rlpItemDecode_advance (bytes := acctBytes) (base := aB)
+        (off := ((n0 - aB).toNat)) (endOff := aLen) hdnew hbound hover9
+      refine ⟨n0, l0, next, len, ?_⟩
+      have hA' : ((((newSp + 48) ↦ₘ next) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+          bytesRegion aB acctBytes ** F)) h := by
+        xperm_hyp hA
+      exact (sepConj_pure_right h).2 ⟨hA', ⟨hchain, hdnew⟩, hadv.2.2⟩
+    · refine cpsBranchWithin_of_forall_regIs_to_regOwn8
+        (fun v5 v6 v7 v28 v29 v30 v31 vRa => ?_)
+      exact cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
+        (fun _ x => x) (fun _ x => x)
+        (bansf_item1_spec aB newSp aLen ((n0 - aB).toNat) acctBytes
+          v5 v6 v7 (aB + BitVec.ofNat 64 ((n0 - aB).toNat)) (0 : Word) l0
+          v28 v29 v30 v31 vRa F hF hsalign hslack hover hvalid hbound)
+  -- ===== item 2 at the advanced cursor =====
+  have hstep2 : cpsBranchWithin 93 (B + 144) bansfCR
+      (acc1 aB newSp aLen off0 acctBytes F)
+      (B + 736) (itemRej aB newSp acctBytes F)
+      (B + 164) (acc2 aB newSp aLen off0 acctBytes F) := by
+    unfold acc1
+    refine cpsBranchWithin_exists_pre (fun n0 => ?_)
+    refine cpsBranchWithin_exists_pre (fun l0 => ?_)
+    refine cpsBranchWithin_exists_pre (fun n1 => ?_)
+    refine cpsBranchWithin_exists_pre (fun l1 => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hdecs => ?_)
+    obtain ⟨hchain, hbound⟩ := hdecs
+    have hrep : n1 = aB + BitVec.ofNat 64 ((n1 - aB).toNat) := by
+      rw [BitVec.ofNat_toNat, BitVec.setWidth_eq]
+      bv_omega
+    refine cpsBranchWithin_weaken
+      (Q_f := itemOk aB newSp aLen ((n1 - aB).toNat) acctBytes F)
+      (P := ((((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 ((n1 - aB).toNat))) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 ((n1 - aB).toNat))) **
+        ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ l1) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion aB acctBytes ** F) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** regOwn .x1))
+      (fun h hp => by rw [← hrep]; xperm_hyp hp)
+      (fun _ x => x) (fun h hq => ?_) ?_
+    · -- accumulate the new decode and its bound
+      unfold itemOk at hq
+      obtain ⟨next, len, hqq⟩ := hq
+      obtain ⟨hA, hdnew⟩ := (sepConj_pure_right h).1 hqq
+      have hadv := rlpItemDecode_advance (bytes := acctBytes) (base := aB)
+        (off := ((n1 - aB).toNat)) (endOff := aLen) hdnew hbound hover9
+      refine ⟨n0, l0, n1, l1, next, len, ?_⟩
+      have hA' : ((((newSp + 48) ↦ₘ next) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+          bytesRegion aB acctBytes ** F)) h := by
+        xperm_hyp hA
+      exact (sepConj_pure_right h).2 ⟨hA', ⟨hchain, hdnew⟩, hadv.2.2⟩
+    · refine cpsBranchWithin_of_forall_regIs_to_regOwn8
+        (fun v5 v6 v7 v28 v29 v30 v31 vRa => ?_)
+      exact cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
+        (fun _ x => x) (fun _ x => x)
+        (bansf_item2_spec aB newSp aLen ((n1 - aB).toNat) acctBytes
+          v5 v6 v7 (aB + BitVec.ofNat 64 ((n1 - aB).toNat)) (0 : Word) l1
+          v28 v29 v30 v31 vRa F hF hsalign hslack hover hvalid hbound)
+  -- ===== item 3 at the advanced cursor =====
+  have hstep3 : cpsBranchWithin 93 (B + 164) bansfCR
+      (acc2 aB newSp aLen off0 acctBytes F)
+      (B + 736) (itemRej aB newSp acctBytes F)
+      (B + 184) (acc3 aB newSp aLen off0 acctBytes F) := by
+    unfold acc2
+    refine cpsBranchWithin_exists_pre (fun n0 => ?_)
+    refine cpsBranchWithin_exists_pre (fun l0 => ?_)
+    refine cpsBranchWithin_exists_pre (fun n1 => ?_)
+    refine cpsBranchWithin_exists_pre (fun l1 => ?_)
+    refine cpsBranchWithin_exists_pre (fun n2 => ?_)
+    refine cpsBranchWithin_exists_pre (fun l2 => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hdecs => ?_)
+    obtain ⟨hchain, hbound⟩ := hdecs
+    have hrep : n2 = aB + BitVec.ofNat 64 ((n2 - aB).toNat) := by
+      rw [BitVec.ofNat_toNat, BitVec.setWidth_eq]
+      bv_omega
+    refine cpsBranchWithin_weaken
+      (Q_f := itemOk aB newSp aLen ((n2 - aB).toNat) acctBytes F)
+      (P := ((((newSp + 48) ↦ₘ (aB + BitVec.ofNat 64 ((n2 - aB).toNat))) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 ((n2 - aB).toNat))) **
+        ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ l2) **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion aB acctBytes ** F) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** regOwn .x1))
+      (fun h hp => by rw [← hrep]; xperm_hyp hp)
+      (fun _ x => x) (fun h hq => ?_) ?_
+    · -- accumulate the new decode and its bound
+      unfold itemOk at hq
+      obtain ⟨next, len, hqq⟩ := hq
+      obtain ⟨hA, hdnew⟩ := (sepConj_pure_right h).1 hqq
+      have hadv := rlpItemDecode_advance (bytes := acctBytes) (base := aB)
+        (off := ((n2 - aB).toNat)) (endOff := aLen) hdnew hbound hover9
+      refine ⟨n0, l0, n1, l1, n2, l2, next, len, ?_⟩
+      have hA' : ((((newSp + 48) ↦ₘ next) **
+          ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+          bytesRegion aB acctBytes ** F)) h := by
+        xperm_hyp hA
+      exact (sepConj_pure_right h).2 ⟨hA', ⟨hchain, hdnew⟩, hadv.2.2⟩
+    · refine cpsBranchWithin_of_forall_regIs_to_regOwn8
+        (fun v5 v6 v7 v28 v29 v30 v31 vRa => ?_)
+      exact cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
+        (fun _ x => x) (fun _ x => x)
+        (bansf_item3_spec aB newSp aLen ((n2 - aB).toNat) acctBytes
+          v5 v6 v7 (aB + BitVec.ofNat 64 ((n2 - aB).toNat)) (0 : Word) l2
+          v28 v29 v30 v31 vRa F hF hsalign hslack hover hvalid hbound)
+  exact cpsBranchWithin_mono_nSteps (by omega)
+    (cpsBranchWithin_chain_snd hstep0
+      (cpsBranchWithin_chain_snd hstep1
+        (cpsBranchWithin_chain_snd hstep2 hstep3)))
+
+#print axioms bansf_chainItems_spec
+
+end BalAccountNonstorageFinalsSpec
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsSpec.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsSpec.lean
@@ -319,9 +319,11 @@ def fieldResolves (bytes : List (BitVec 8)) (base : Word) (fOff fSpan : Nat)
   (has = true ∧ ∃ vNext vLen,
     FieldFinal bytes base fOff fSpan (some (vNext, vLen)) ∧ imageOf vNext vLen)
 
-/-- **The success derivation** (the genuine post of the eventual end-to-end
-    triple, against EIP-7928 semantics): the AccountChanges bytes decode as an
-    RLP list whose items 0..5 chain by `rlpItemDecode`; items 3/4/5
+/-- **The success derivation** (the genuine post of the end-to-end triple,
+    against EIP-7928 semantics): the AccountChanges WINDOW `[base, base+aLen)`
+    (the routine's `(a0, a1)` arguments; `bytes` is the owned region, which
+    may extend past the window — the walkers need header-read slack) decodes
+    as an RLP list whose items 0..5 chain by `rlpItemDecode`; items 3/4/5
     (balance/nonce/code changes) each resolve per `fieldResolves` with the
     field-specific value image —
 
@@ -331,24 +333,24 @@ def fieldResolves (bytes : List (BitVec 8)) (base : Word) (fOff fSpan : Nat)
       (`rlp_content_to_u64`'s success post);
     * code: the recorded `(code_off, code_len)` window equals the value
       content window, `code_off` stated relative to the AccountChanges base. -/
-def FinalsDerivation (bytes : List (BitVec 8)) (base : Word)
+def FinalsDerivation (bytes : List (BitVec 8)) (base : Word) (aLen : Nat)
     (out : FinalsOut) : Prop :=
   ∃ b0 : BitVec 8, bytes[0]? = some b0 ∧
   ∃ n0 l0 n1 l1 n2 l2 n3 l3 n4 l4 n5 l5 : Word,
     -- the six outer items, chained from the outer list's content start
     rlpItemDecode bytes (listHeaderSize b0)
       (base + BitVec.ofNat 64 (listHeaderSize b0))
-      (base + BitVec.ofNat 64 bytes.length) n0 l0 ∧
+      (base + BitVec.ofNat 64 aLen) n0 l0 ∧
     rlpItemDecode bytes (n0 - base).toNat n0
-      (base + BitVec.ofNat 64 bytes.length) n1 l1 ∧
+      (base + BitVec.ofNat 64 aLen) n1 l1 ∧
     rlpItemDecode bytes (n1 - base).toNat n1
-      (base + BitVec.ofNat 64 bytes.length) n2 l2 ∧
+      (base + BitVec.ofNat 64 aLen) n2 l2 ∧
     rlpItemDecode bytes (n2 - base).toNat n2
-      (base + BitVec.ofNat 64 bytes.length) n3 l3 ∧
+      (base + BitVec.ofNat 64 aLen) n3 l3 ∧
     rlpItemDecode bytes (n3 - base).toNat n3
-      (base + BitVec.ofNat 64 bytes.length) n4 l4 ∧
+      (base + BitVec.ofNat 64 aLen) n4 l4 ∧
     rlpItemDecode bytes (n4 - base).toNat n4
-      (base + BitVec.ofNat 64 bytes.length) n5 l5 ∧
+      (base + BitVec.ofNat 64 aLen) n5 l5 ∧
     -- item 3 = balance_changes: 32-byte right-aligned BE image
     fieldResolves bytes base (n3 - l3 - base).toNat l3.toNat out.hasBalance
       (fun vNext vLen =>
@@ -384,7 +386,7 @@ def witnessBytes : List (BitVec 8) := [0xc6, 0x80, 0xc0, 0xc0, 0xc0, 0xc0, 0xc0]
 /-- The derivation accepts the minimal witness with the all-absent result —
     the pre is satisfiable and the post is not vacuous. -/
 theorem finalsDerivation_witness :
-    FinalsDerivation witnessBytes 0 FinalsOut.absent := by
+    FinalsDerivation witnessBytes 0 7 FinalsOut.absent := by
   refine ⟨0xc6, rfl, 2, 0, 3, 1, 4, 1, 5, 1, 6, 1, 7, 1,
     ⟨0x80, rfl, by decide⟩, ⟨0xc0, rfl, by decide⟩, ⟨0xc0, rfl, by decide⟩,
     ⟨0xc0, rfl, by decide⟩, ⟨0xc0, rfl, by decide⟩, ⟨0xc0, rfl, by decide⟩,

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -440,3 +440,4 @@ import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsWalk
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsLoop
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsLoop2
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsLoop3
+import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -441,3 +441,4 @@ import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsLoop
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsLoop2
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsLoop3
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB
+import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB2

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -442,3 +442,4 @@ import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsLoop2
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsLoop3
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB2
+import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB3

--- a/EvmAsm/Rv64/SAsm/MeasureLoop.lean
+++ b/EvmAsm/Rv64/SAsm/MeasureLoop.lean
@@ -319,4 +319,48 @@ theorem cpsNBranchWithin_of_forall_regIs_to_regOwn9
        g12, g13, d7, u7, hv6, g14, g15, d8, u8, hv7, g16, g17, d9, u9,
        hv8, hv9⟩, hRb⟩ hpc
 
+/-- Introduce EIGHT owned registers' values at once for a branch (the
+    callee-scratch + link-register intro at chain-segment boundaries). -/
+theorem cpsBranchWithin_of_forall_regIs_to_regOwn8
+    {n : Nat} {entry : Word} {r1 r2 r3 r4 r5 r6 r7 r8 : Reg}
+    {P : Assertion} {e1 : Word} {Q1 : Assertion} {e2 : Word} {Q2 : Assertion}
+    {cr : CodeReq}
+    (h : ∀ v1 v2 v3 v4 v5 v6 v7 v8, cpsBranchWithin n entry cr
+      (P ** (r1 ↦ᵣ v1) ** (r2 ↦ᵣ v2) ** (r3 ↦ᵣ v3) ** (r4 ↦ᵣ v4) **
+       (r5 ↦ᵣ v5) ** (r6 ↦ᵣ v6) ** (r7 ↦ᵣ v7) ** (r8 ↦ᵣ v8)) e1 Q1 e2 Q2) :
+    cpsBranchWithin n entry cr
+      (P ** regOwn r1 ** regOwn r2 ** regOwn r3 ** regOwn r4 **
+       regOwn r5 ** regOwn r6 ** regOwn r7 ** regOwn r8) e1 Q1 e2 Q2 := by
+  intro R hR s hcr hPR hpc
+  obtain ⟨hp, hcompat, h1, h2, hd, hu, hPP, hRb⟩ := hPR
+  obtain ⟨g0, g1, d1, u1, hP0, hO1⟩ := hPP
+  obtain ⟨g2, g3, d2, u2, ⟨v1, hv1⟩, hO2⟩ := hO1
+  obtain ⟨g4, g5, d3, u3, ⟨v2, hv2⟩, hO3⟩ := hO2
+  obtain ⟨g6, g7, d4, u4, ⟨v3, hv3⟩, hO4⟩ := hO3
+  obtain ⟨g8, g9, d5, u5, ⟨v4, hv4⟩, hO5⟩ := hO4
+  obtain ⟨g10, g11, d6, u6, ⟨v5, hv5⟩, hO6⟩ := hO5
+  obtain ⟨g12, g13, d7, u7, ⟨v6, hv6⟩, hO7⟩ := hO6
+  obtain ⟨g14, g15, d8, u8, ⟨v7, hv7⟩, ⟨v8, hv8⟩⟩ := hO7
+  exact h v1 v2 v3 v4 v5 v6 v7 v8 R hR s hcr
+    ⟨hp, hcompat, h1, h2, hd, hu,
+      ⟨g0, g1, d1, u1, hP0, g2, g3, d2, u2, hv1, g4, g5, d3, u3, hv2,
+       g6, g7, d4, u4, hv3, g8, g9, d5, u5, hv4, g10, g11, d6, u6, hv5,
+       g12, g13, d7, u7, hv6, g14, g15, d8, u8, hv7, hv8⟩, hRb⟩ hpc
+
+/-- Chain a two-exit branch into a follow-on branch at its SECOND exit,
+    staying put at the shared first exit (the reject-threading step for
+    fail-normalized chains). -/
+theorem cpsBranchWithin_chain_snd {n m : Nat} {entry mid eRej : Word}
+    {cr : CodeReq} {P QRej Qmid : Assertion} {e2 : Word} {Q2 : Assertion}
+    (h1 : cpsBranchWithin n entry cr P eRej QRej mid Qmid)
+    (h2 : cpsBranchWithin m mid cr Qmid eRej QRej e2 Q2) :
+    cpsBranchWithin (n + m) entry cr P eRej QRej e2 Q2 := by
+  intro R hR s hcr hPR hpc
+  obtain ⟨k1, hk1, s1, hstep1, hcase⟩ := h1 R hR s hcr hPR hpc
+  have hcr1 := CodeReq.SatisfiedBy_preserved hstep1 hcr
+  rcases hcase with ⟨hpc1, hQ⟩ | ⟨hpc1, hQ⟩
+  · exact ⟨k1, Nat.le_trans hk1 (Nat.le_add_right n m), s1, hstep1, Or.inl ⟨hpc1, hQ⟩⟩
+  · obtain ⟨k2, hk2, s2, hstep2, hcase2⟩ := h2 R hR s1 hcr1 hQ hpc1
+    exact ⟨k1 + k2, Nat.add_le_add hk1 hk2, s2, stepN_add_eq hstep1 hstep2, hcase2⟩
+
 end EvmAsm.Rv64.SAsm


### PR DESCRIPTION
## Summary

Slice 3a toward the `bansf_spec_within` top theorem (bead `evm-asm-4ch8f.43.5`), continuing merged #10181 + #10183. Two corrections to the #10183 body first: (a) the two kit files (`MeasureLoop`/`AbiFrameOwn`) are `#print axioms`-witnessed **transitively** via the Loop theorems (they have no in-file prints); (b) #10183 already delivered stations 2/3 (`bansf_findLastLoop2/3_spec`) — the real remainder was and is the station chains + assembly.

## What's here

- **`FinalsDerivation` is now window-anchored** (takes the walk window `aLen`; `endPtr = base + aLen`). Genuine composition finding: the routine walks the passed `(a0, a1)` window while the owned region must extend ≥ 9 bytes past it (the walkers' header-read slack, per the `rlpItemDecode_advance` wrap analysis in #10183) — so anchoring the outer walk at `bytes.length` made the derivation uncomposable with the run. No weakening; the witness is updated (`aLen = 7`).
- **`BalAccountNonstorageFinalsChainB.lean`**: `bansf_prologue_spec` — the body prologue (slots 7–21: argument saves, the ten-dword out-block zeroing, argument reloads) verified via `runBlock`. Tooling note for the next porter: **the goal CodeReq must sit behind a named abbrev** (`bansfCode`); with a bare `ofProg` head, `runBlock`'s delta-unfolder unfolds `ofProg` itself and the composition fails with an opaque placeholder error.
- `outerFail` — the outer status-check reject route (`B+92 → B+732 → B+736`), classical-3.
- The final interfaces for the outer `rlp_walk_init` dispatch: `ListWindowOk` / `OuterInitOk` / `outerInitPost` / `outerRej` (the `listHeaderSize`-anchored unified success state).

## Remaining for `bansf_spec_within` (scoped, mechanical from here)

1. The outer init dispatch (nine callee arms: 7 × `outerFail` + the short/long success arms bridged to `OuterInitOk` — the per-arm branch lemmas + `pre_or` recombination exactly as in `fl_round`).
2. The four outer item units (spill-reload + `rlp_walk_next` + status check ×4, generated like Loop2/3).
3. The three field stations (init dispatch + empty-skip BEQ → `FieldFinal.empty`, loop entry ⇒ `bansf_findLastLoop{1,2,3}_spec`, tuple parse, `rlp_content_to_u256_be`/`u64` capture into the out block).
4. Body assembly via `abiFrame_spec_own` + the `FinalsDerivation` reconstruction + a non-absent success witness.

The loop side conditions (`hslack`/`hover`/`hvalid`/`hsalign`) ARE dischargeable from the account-region bounds — the field windows nest inside the outer window by the decode fit conjuncts, so `endOff_field + 9 ≤ aLen + 9 ≤ |region|`; no slack gap (the HARD obligation from the review is safe).

All new lemmas classical-3; `lake build` green; all `scripts/check-*.sh` clean; byte-transparent, symbolic `GuestAddrs`, additive.

Refs `evm-asm-4ch8f.43.5`; builds on merged #10181/#10183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)