### PR TITLE
refactor(divmod): narrow loop body compose imports

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -14,6 +14,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1Loop
+import EvmAsm.Evm64.DivMod.Compose.FullPath
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3Loop
 import EvmAsm.Evm64.EvmWordArith.CLZLemmas

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Full.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Full.lean
@@ -6,6 +6,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Bridge
+import EvmAsm.Evm64.DivMod.Compose.FullPath
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
@@ -20,6 +20,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Loop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3Loop
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
@@ -15,6 +15,8 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3Loop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3
+import EvmAsm.Evm64.DivMod.Compose.FullPath
 import EvmAsm.Rv64.Tactics.XPermChunked
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
@@ -8,6 +8,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4Loop
+import EvmAsm.Evm64.DivMod.Compose.FullPath
 import EvmAsm.Evm64.DivMod.TrialPredicatesN4
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4BeqV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4BeqV4NoNop.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4Beq
+import EvmAsm.Evm64.DivMod.Compose.FullPathV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4AddbackV4NoNop
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4V4NoNop.lean
@@ -1097,41 +1097,4 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm_mod_v4_noNop (sp base : Word)
              u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw
   exact raw
 
-/-- Loop body n=4, call+addback (BEQ double-addback), j=0 over the full
-    `modCode_v4` bundle. -/
-theorem divK_loop_body_n4_call_addback_j0_beq_norm_mod_v4 (sp base : Word)
-    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
-    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (retMem dMem dloMem scratchUn0 scratchMem : Word)
-    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
-      base + div128CallRetOff)
-    (hbltu : BitVec.ult uTop v3)
-    (hborrow : loopBodyN4CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
-    (hcarry2_nz : loopBodyN4CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (modCode_v4 base)
-      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ u0) **
-       ((sp + 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ u2) **
-       ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + signExtend12 4024) ↦ₘ uTop) **
-       ((sp + signExtend12 4088) ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
-       regOwn .x1) **
-       (sp + signExtend12 3936 ↦ₘ scratchMem))
-      (loopBodyN4CallAddbackJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
-  exact cpsTripleWithin_modCode_noNop_v4_to_modCode_v4
-    (divK_loop_body_n4_call_addback_j0_beq_norm_mod_v4_noNop sp base
-      jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
-      retMem dMem dloMem scratchUn0 scratchMem
-      halign hbltu hborrow hcarry2_nz)
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4V4NoNop.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.V4Code
+import EvmAsm.Evm64.DivMod.Compose.FullPath
 import EvmAsm.Evm64.DivMod.Compose.ModPhaseABN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4Loop
 import EvmAsm.Evm64.DivMod.LoopIterN4MaxV4NoNop

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -9,7 +9,8 @@
 -/
 
 -- `DivN4Overestimate → LoopSemantic → LoopDefs`.
-import EvmAsm.Evm64.DivMod.Compose
+import EvmAsm.Evm64.DivMod.Compose.Base
+import EvmAsm.Evm64.DivMod.Compose.V4NoNop
 import EvmAsm.Evm64.DivMod.LimbSpec.AddBackFinalLoopControl
 import EvmAsm.Evm64.DivMod.LimbSpec.MulSub
 import EvmAsm.Evm64.DivMod.LimbSpec.MulSubLimb


### PR DESCRIPTION
## Summary

- replace the broad DivMod.Compose umbrella import in LoopBody with the two code-requirement modules it actually uses
- localize dependencies previously supplied accidentally by that umbrella at their real consumers
- preserve unified and bundle theorems used by the emitted v5/v6 composition paths

## Import DAG impact

- root depth: **98 -> 97**
- removes the legacy Compose umbrella edge from a module with roughly 1,040 reverse dependents
- modules remain 2,991, all reachable

## Validation

- lake build (4,956 jobs)
- scripts/check-layering.sh
- scripts/check-forbidden-tactics.sh
- scripts/check-unimported.sh
- scripts/check-file-size.sh
- git diff --check

Stacked on #10193.