### PR TITLE
refactor(divmod): remove unused v4 mod composition theorem

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4V4NoNop.lean
@@ -1097,41 +1097,4 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm_mod_v4_noNop (sp base : Word)
              u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw
   exact raw
 
-/-- Loop body n=4, call+addback (BEQ double-addback), j=0 over the full
-    `modCode_v4` bundle. -/
-theorem divK_loop_body_n4_call_addback_j0_beq_norm_mod_v4 (sp base : Word)
-    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
-    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (retMem dMem dloMem scratchUn0 scratchMem : Word)
-    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
-      base + div128CallRetOff)
-    (hbltu : BitVec.ult uTop v3)
-    (hborrow : loopBodyN4CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
-    (hcarry2_nz : loopBodyN4CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (modCode_v4 base)
-      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ u0) **
-       ((sp + 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ u2) **
-       ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + signExtend12 4024) ↦ₘ uTop) **
-       ((sp + signExtend12 4088) ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
-       regOwn .x1) **
-       (sp + signExtend12 3936 ↦ₘ scratchMem))
-      (loopBodyN4CallAddbackJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
-  exact cpsTripleWithin_modCode_noNop_v4_to_modCode_v4
-    (divK_loop_body_n4_call_addback_j0_beq_norm_mod_v4_noNop sp base
-      jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
-      retMem dMem dloMem scratchUn0 scratchMem
-      halign hbltu hborrow hcarry2_nz)
-
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

- remove the unused full-code v4 MOD call-addback composition wrapper
- retain the no-NOP theorem consumed by the current preloop composition
- avoid touching v5/v6 emitted-code theorems

The deleted theorem only lifted the live no-NOP result to the legacy modCode_v4 bundle and had no consumers anywhere in the Lean tree.

## Validation

- lake build (4,956 jobs)
- scripts/check-unimported.sh
- git diff --check

Stacked on #10196.