### PR TITLE
refactor(divmod): narrow loop body arithmetic import

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -8,7 +8,6 @@
   Issue #87: DIV/MOD loop body composition.
 -/
 
--- `DivN4Overestimate → LoopSemantic → LoopDefs`.
 import EvmAsm.Evm64.DivMod.Compose.Base
 import EvmAsm.Evm64.DivMod.Compose.V4NoNop
 import EvmAsm.Evm64.DivMod.LimbSpec.AddBackFinalLoopControl
@@ -18,7 +17,7 @@ import EvmAsm.Evm64.DivMod.LimbSpec.MulSubSetup
 import EvmAsm.Evm64.DivMod.LimbSpec.SubCarryStoreQj
 import EvmAsm.Evm64.DivMod.LimbSpec.TrialQuotient
 import EvmAsm.Evm64.DivMod.LimbSpec.TrialStoreComposed
-import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
+import EvmAsm.Evm64.DivMod.LoopDefs.Post
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialCall.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialCall.lean
@@ -19,6 +19,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.LoopBody.TrialCallPath
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCallHelpers
 import EvmAsm.Evm64.DivMod.LoopBody.TrialMax
 
 open EvmAsm.Rv64.Tactics
@@ -197,7 +198,7 @@ def divKTrialCallV4QHat (uHi uLo vTop : Word) : Word :=
   (divKTrialCallV4Q1dd uHi uLo vTop <<< (32 : BitVec 6).toNat) |||
     divKTrialCallV4Q0dd uHi uLo vTop
 
-theorem div128Quot_phase2b_q0'_and_form (q rhat dLo un : Word) :
+private theorem div128Quot_phase2b_q0'_and_form_legacy (q rhat dLo un : Word) :
     (if rhat >>> (32 : BitVec 6).toNat = 0 ∧
         BitVec.ult ((rhat <<< (32 : BitVec 6).toNat) ||| un) (q * dLo) then
       q + signExtend12 4095
@@ -222,7 +223,7 @@ theorem div128Quot_phase2b_q0'_and_form (q rhat dLo un : Word) :
     rw [if_neg h_and]
     rw [if_neg h_hi]
 
-theorem div128Quot_phase2b_rhat_and_form (q rhat dHi dLo un : Word) :
+private theorem div128Quot_phase2b_rhat_and_form_legacy (q rhat dHi dLo un : Word) :
     (if rhat >>> (32 : BitVec 6).toNat = 0 ∧
         BitVec.ult ((rhat <<< (32 : BitVec 6).toNat) ||| un) (q * dLo) then
       rhat + dHi

--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialCallHelpers.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialCallHelpers.lean
@@ -1,0 +1,33 @@
+import EvmAsm.Evm64.DivMod.LoopDefs.IterV5
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem div128Quot_phase2b_q0'_and_form (q rhat dLo un : Word) :
+    (if rhat >>> (32 : BitVec 6).toNat = 0 ∧
+        BitVec.ult ((rhat <<< (32 : BitVec 6).toNat) ||| un) (q * dLo) then
+      q + signExtend12 4095 else q) = div128Quot_phase2b_q0' q rhat dLo un := by
+  unfold div128Quot_phase2b_q0'
+  by_cases h_hi : rhat >>> (32 : BitVec 6).toNat = (0 : Word)
+  · by_cases h_ult : BitVec.ult ((rhat <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+    · rw [if_pos ⟨h_hi, h_ult⟩, if_pos h_hi, if_pos h_ult]
+    · rw [if_neg (fun h => h_ult h.2), if_pos h_hi, if_neg h_ult]
+  · rw [if_neg (fun h => h_hi h.1), if_neg h_hi]
+
+theorem div128Quot_phase2b_rhat_and_form (q rhat dHi dLo un : Word) :
+    (if rhat >>> (32 : BitVec 6).toNat = 0 ∧
+        BitVec.ult ((rhat <<< (32 : BitVec 6).toNat) ||| un) (q * dLo) then
+      rhat + dHi else rhat) =
+      (if rhat >>> (32 : BitVec 6).toNat = 0 then
+        let qDlo := q * dLo
+        let rhatUn := (rhat <<< (32 : BitVec 6).toNat) ||| un
+        if BitVec.ult rhatUn qDlo then rhat + dHi else rhat
+      else rhat) := by
+  by_cases h_hi : rhat >>> (32 : BitVec 6).toNat = (0 : Word)
+  · by_cases h_ult : BitVec.ult ((rhat <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+    · rw [if_pos ⟨h_hi, h_ult⟩, if_pos h_hi, if_pos h_ult]
+    · rw [if_neg (fun h => h_ult h.2), if_pos h_hi, if_neg h_ult]
+  · rw [if_neg (fun h => h_hi h.1), if_neg h_hi]
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialCallV5.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialCallV5.lean
@@ -24,7 +24,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.LoopDefs.IterV5
-import EvmAsm.Evm64.DivMod.LoopBody.TrialCall
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCallHelpers
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
@@ -14,6 +14,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.LoopIterN3NoNop
+import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
 import EvmAsm.Rv64.Tactics.XPermChunked
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN1.lean
@@ -19,6 +19,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.LoopComposeN1
+import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
@@ -25,6 +25,8 @@
 -- (→ `DivMod.LoopSemantic`). The n=4 path predicates are imported directly.
 import EvmAsm.Evm64.EvmWordArith.Div128FinalAssembly
 import EvmAsm.Evm64.EvmWordArith.Div128KB6Composition
+import EvmAsm.Evm64.EvmWordArith.DivLimbBridge
+import EvmAsm.Evm64.DivMod.LoopSemantic
 import EvmAsm.Evm64.DivMod.TrialPredicatesN4
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
@@ -31,6 +31,7 @@
 -/
 
 import EvmAsm.Evm64.EvmWordArith.KnuthTheoremB
+import EvmAsm.Evm64.EvmWordArith.Div128Lemmas
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
@@ -12,6 +12,7 @@
 
 import EvmAsm.Evm64.EvmWordArith.DivAccumulate
 import EvmAsm.Evm64.EvmWordArith.Div128Lemmas
+import EvmAsm.Evm64.EvmWordArith.SignExtendLemmas
 import EvmAsm.Evm64.DivMod.LoopSemantic
 
 namespace EvmAsm.Evm64
@@ -36,10 +37,6 @@ theorem val256_div_lt_pow64 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (hb3nz : b3 ≠ 0) 
       ≤ (2^256 - 1) / val256 b0 b1 b2 b3 := Nat.div_le_div_right (by omega)
     _ ≤ (2^256 - 1) / 2^192 := Nat.div_le_div_left hb_ge (by omega)
     _ = 2^64 - 1 := by norm_num
-
-/-- signExtend12 4095 as Word has toNat = 2^64 - 1. -/
-theorem signExtend12_4095_toNat : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by
-  decide
 
 theorem add_signExtend12_4095_toNat (q : Word) (hq : 1 ≤ q.toNat) :
     (q + signExtend12 (4095 : BitVec 12)).toNat = q.toNat - 1 := by

--- a/EvmAsm/Evm64/EvmWordArith/DivV4TrialOverestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivV4TrialOverestimate.lean
@@ -25,6 +25,7 @@
 -/
 
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Algorithm
+import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -71,9 +71,9 @@
     Phase 1b, regardless of branch (input bound for Round 2).
 -/
 
-import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
 import EvmAsm.Evm64.EvmWordArith.MaxTrialVacuity
 import EvmAsm.Evm64.EvmWordArith.DenormLemmas
+import EvmAsm.Evm64.EvmWordArith.SignExtendLemmas
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/EvmWordArith/SignExtendLemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/SignExtendLemmas.lean
@@ -1,0 +1,13 @@
+import EvmAsm.Evm64.Basic
+import EvmAsm.Rv64.Instructions
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Sign-extending the 12-bit immediate `4095` produces the all-ones word. -/
+theorem signExtend12_4095_toNat :
+    (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by
+  decide
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- replace the broad `DivN4Overestimate` import in `LoopBody` with the definitions-only `LoopDefs.Post` dependency it actually uses
- make the three downstream arithmetic consumers that relied on transitive visibility import `DivN4Overestimate` explicitly
- localize arithmetic rebuild impact away from the central loop-body composition module

## DAG impact
- removes `LoopBody -> DivN4Overestimate -> LoopSemantic -> LoopDefs` from the loop-body composition chain
- keeps arithmetic theorem dependencies at their actual consumers
- the global maximum remains 97 because an independent V5 arithmetic path is now critical

## Validation
- `lake build`
- `scripts/check-layering.sh`
- `scripts/check-forbidden-tactics.sh`
- `scripts/check-unimported.sh`
- `scripts/check-file-size.sh`
- `git diff --check`

Stacked on #10196.