### PR TITLE
refactor(divmod): extract sign extension lemma

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
@@ -25,6 +25,8 @@
 -- (→ `DivMod.LoopSemantic`). The n=4 path predicates are imported directly.
 import EvmAsm.Evm64.EvmWordArith.Div128FinalAssembly
 import EvmAsm.Evm64.EvmWordArith.Div128KB6Composition
+import EvmAsm.Evm64.EvmWordArith.DivLimbBridge
+import EvmAsm.Evm64.DivMod.LoopSemantic
 import EvmAsm.Evm64.DivMod.TrialPredicatesN4
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
@@ -31,6 +31,7 @@
 -/
 
 import EvmAsm.Evm64.EvmWordArith.KnuthTheoremB
+import EvmAsm.Evm64.EvmWordArith.Div128Lemmas
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
@@ -12,6 +12,7 @@
 
 import EvmAsm.Evm64.EvmWordArith.DivAccumulate
 import EvmAsm.Evm64.EvmWordArith.Div128Lemmas
+import EvmAsm.Evm64.EvmWordArith.SignExtendLemmas
 import EvmAsm.Evm64.DivMod.LoopSemantic
 
 namespace EvmAsm.Evm64
@@ -36,10 +37,6 @@ theorem val256_div_lt_pow64 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (hb3nz : b3 ≠ 0) 
       ≤ (2^256 - 1) / val256 b0 b1 b2 b3 := Nat.div_le_div_right (by omega)
     _ ≤ (2^256 - 1) / 2^192 := Nat.div_le_div_left hb_ge (by omega)
     _ = 2^64 - 1 := by norm_num
-
-/-- signExtend12 4095 as Word has toNat = 2^64 - 1. -/
-theorem signExtend12_4095_toNat : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by
-  decide
 
 theorem add_signExtend12_4095_toNat (q : Word) (hq : 1 ≤ q.toNat) :
     (q + signExtend12 (4095 : BitVec 12)).toNat = q.toNat - 1 := by

--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -71,9 +71,9 @@
     Phase 1b, regardless of branch (input bound for Round 2).
 -/
 
-import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
 import EvmAsm.Evm64.EvmWordArith.MaxTrialVacuity
 import EvmAsm.Evm64.EvmWordArith.DenormLemmas
+import EvmAsm.Evm64.EvmWordArith.SignExtendLemmas
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/EvmWordArith/SignExtendLemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/SignExtendLemmas.lean
@@ -1,0 +1,13 @@
+import EvmAsm.Evm64.Basic
+import EvmAsm.Rv64.Instructions
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Sign-extending the 12-bit immediate `4095` produces the all-ones word. -/
+theorem signExtend12_4095_toNat :
+    (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by
+  decide
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- extract `signExtend12_4095_toNat` into a small shared arithmetic leaf
- remove the broad `KnuthTheoremB -> DivN4Overestimate` dependency
- make two previously transitive supporting dependencies explicit at their actual consumers

## DAG impact
- root import depth decreases from **97 to 95**
- `KnuthTheoremB` no longer pulls the 1,337-line n=4 overestimate proof and its loop-semantic chain merely for one concrete immediate lemma
- the newly exposed critical path now runs through the V5 loop-body implementation chain

## Validation
- `lake build`
- `scripts/check-layering.sh`
- `scripts/check-forbidden-tactics.sh`
- `scripts/check-unimported.sh`
- `scripts/check-file-size.sh`
- `git diff --check`

Stacked on #10199.