### PR TITLE
refactor(divmod): extract trial call helpers

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialCall.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialCall.lean
@@ -19,6 +19,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.LoopBody.TrialCallPath
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCallHelpers
 import EvmAsm.Evm64.DivMod.LoopBody.TrialMax
 
 open EvmAsm.Rv64.Tactics
@@ -197,7 +198,7 @@ def divKTrialCallV4QHat (uHi uLo vTop : Word) : Word :=
   (divKTrialCallV4Q1dd uHi uLo vTop <<< (32 : BitVec 6).toNat) |||
     divKTrialCallV4Q0dd uHi uLo vTop
 
-theorem div128Quot_phase2b_q0'_and_form (q rhat dLo un : Word) :
+private theorem div128Quot_phase2b_q0'_and_form_legacy (q rhat dLo un : Word) :
     (if rhat >>> (32 : BitVec 6).toNat = 0 ∧
         BitVec.ult ((rhat <<< (32 : BitVec 6).toNat) ||| un) (q * dLo) then
       q + signExtend12 4095
@@ -222,7 +223,7 @@ theorem div128Quot_phase2b_q0'_and_form (q rhat dLo un : Word) :
     rw [if_neg h_and]
     rw [if_neg h_hi]
 
-theorem div128Quot_phase2b_rhat_and_form (q rhat dHi dLo un : Word) :
+private theorem div128Quot_phase2b_rhat_and_form_legacy (q rhat dHi dLo un : Word) :
     (if rhat >>> (32 : BitVec 6).toNat = 0 ∧
         BitVec.ult ((rhat <<< (32 : BitVec 6).toNat) ||| un) (q * dLo) then
       rhat + dHi

--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialCallHelpers.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialCallHelpers.lean
@@ -1,0 +1,33 @@
+import EvmAsm.Evm64.DivMod.LoopDefs.IterV5
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem div128Quot_phase2b_q0'_and_form (q rhat dLo un : Word) :
+    (if rhat >>> (32 : BitVec 6).toNat = 0 ∧
+        BitVec.ult ((rhat <<< (32 : BitVec 6).toNat) ||| un) (q * dLo) then
+      q + signExtend12 4095 else q) = div128Quot_phase2b_q0' q rhat dLo un := by
+  unfold div128Quot_phase2b_q0'
+  by_cases h_hi : rhat >>> (32 : BitVec 6).toNat = (0 : Word)
+  · by_cases h_ult : BitVec.ult ((rhat <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+    · rw [if_pos ⟨h_hi, h_ult⟩, if_pos h_hi, if_pos h_ult]
+    · rw [if_neg (fun h => h_ult h.2), if_pos h_hi, if_neg h_ult]
+  · rw [if_neg (fun h => h_hi h.1), if_neg h_hi]
+
+theorem div128Quot_phase2b_rhat_and_form (q rhat dHi dLo un : Word) :
+    (if rhat >>> (32 : BitVec 6).toNat = 0 ∧
+        BitVec.ult ((rhat <<< (32 : BitVec 6).toNat) ||| un) (q * dLo) then
+      rhat + dHi else rhat) =
+      (if rhat >>> (32 : BitVec 6).toNat = 0 then
+        let qDlo := q * dLo
+        let rhatUn := (rhat <<< (32 : BitVec 6).toNat) ||| un
+        if BitVec.ult rhatUn qDlo then rhat + dHi else rhat
+      else rhat) := by
+  by_cases h_hi : rhat >>> (32 : BitVec 6).toNat = (0 : Word)
+  · by_cases h_ult : BitVec.ult ((rhat <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
+    · rw [if_pos ⟨h_hi, h_ult⟩, if_pos h_hi, if_pos h_ult]
+    · rw [if_neg (fun h => h_ult h.2), if_pos h_hi, if_neg h_ult]
+  · rw [if_neg (fun h => h_hi h.1), if_neg h_hi]
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialCallV5.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialCallV5.lean
@@ -24,7 +24,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.LoopDefs.IterV5
-import EvmAsm.Evm64.DivMod.LoopBody.TrialCall
+import EvmAsm.Evm64.DivMod.LoopBody.TrialCallHelpers
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
## Summary
- extract the generic phase-2 conditional-form lemmas into a small `TrialCallHelpers` leaf
- let the V5 arithmetic aliases depend directly on that leaf instead of the 1,286-line executable `TrialCall` proof
- retain private legacy copies temporarily in `TrialCall` to keep this DAG-only change minimal

## DAG impact
- root import depth decreases from **95 to 94**
- removes `TrialCallV5 -> TrialCall -> TrialCallPath -> Div128V5` from the V5 arithmetic chain
- the critical path now reaches the RV64 proof infrastructure through a shorter dependency

## Validation
- `lake build`
- `scripts/check-layering.sh`
- `scripts/check-forbidden-tactics.sh`
- `scripts/check-unimported.sh`
- `scripts/check-file-size.sh`
- `git diff --check`

Stacked on #10200.