### PR TITLE
refactor(divmod): extract phase2b quotient definition

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
@@ -8,6 +8,7 @@
 import EvmAsm.Evm64.DivMod.Compose.Base
 import EvmAsm.Evm64.DivMod.Compose.V4NoNop
 import EvmAsm.Evm64.DivMod.LimbSpec.CLZ
+import EvmAsm.Evm64.DivMod.LoopDefs.CLZResult
 
 open EvmAsm.Rv64.Tactics
 
@@ -163,7 +164,7 @@ private theorem clz_init_sub_noNop_v4 {base : Word} :
 -- Stage 5 (last): K=63, M_a=1,   index 21
 
 /-- CLZ result function: compute (count, shifted_val) from a 6-stage binary search. -/
-def clzResult (val : Word) : Word × Word :=
+private def clzResult_legacy (val : Word) : Word × Word :=
   -- Stage 0: check top 32 bits
   let v0 := if val >>> (32 : BitVec 6).toNat ≠ 0 then val else val <<< (32 : BitVec 6).toNat
   let c0 := if val >>> (32 : BitVec 6).toNat ≠ 0 then signExtend12 (0 : BitVec 12)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
@@ -17,6 +17,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Program
+import EvmAsm.Evm64.DivMod.LoopDefs.Div128Phase2b
 import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
@@ -30,7 +31,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
-/-- Phase 2b refined quotient digit in `div128Quot`.
+/- Phase 2b refined quotient digit in `div128Quot`.
 
     Guards the multiplication-check decrement with `rhat2c < 2^32` per
     Knuth TAOCP §4.3.1 Step D3 ("repeat this test if r̂ < b"). When
@@ -44,17 +45,8 @@ open EvmAsm.Rv64
     that precedes the Phase 2b mul-check. See counterexample at
     `/home/zksecurity/.claude/plans/dynamic-strolling-riddle.md`.
 
-    Lives in `Div128ProdCheck2.lean` (the lowest-level file that
-    naturally talks about Phase 2b's mul-check). Visible from
-    `LimbSpec.Div128Step2`, `Compose/Base` (transitively via `LimbSpec`),
-    and `LoopDefs.Iter` (where `div128Quot` calls it). -/
-def div128Quot_phase2b_q0' (q0c rhat2c dLo div_un0 : Word) : Word :=
-  if rhat2c >>> (32 : BitVec 6).toNat = 0 then
-    let q0Dlo := q0c * dLo
-    let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  else q0c
-
+    The pure definition lives in `LoopDefs.Div128Phase2b`; this file proves
+    the corresponding instruction-level behavior. -/
 /-- Phase 2b guard: 2-instruction cpsBranchWithin that skips the Phase 2b mul-check
     when `rhat2c ≥ 2^32`. Per Knuth TAOCP §4.3.1 Step D3 ("repeat this test
     if r̂ < b") — when `rhat2c ≥ 2^32`, the 64-bit `<< 32` in `rhat2Un0`

--- a/EvmAsm/Evm64/DivMod/LoopDefs/CLZResult.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/CLZResult.lean
@@ -1,0 +1,22 @@
+import EvmAsm.Rv64.Instructions
+
+namespace EvmAsm.Evm64
+open EvmAsm.Rv64
+
+/-- Pure result of the six-stage CLZ binary search. -/
+def clzResult (val : Word) : Word × Word :=
+  let v0 := if val >>> (32 : BitVec 6).toNat ≠ 0 then val else val <<< (32 : BitVec 6).toNat
+  let c0 := if val >>> (32 : BitVec 6).toNat ≠ 0 then signExtend12 (0 : BitVec 12)
+    else signExtend12 (0 : BitVec 12) + signExtend12 (32 : BitVec 12)
+  let v1 := if v0 >>> (48 : BitVec 6).toNat ≠ 0 then v0 else v0 <<< (16 : BitVec 6).toNat
+  let c1 := if v0 >>> (48 : BitVec 6).toNat ≠ 0 then c0 else c0 + signExtend12 (16 : BitVec 12)
+  let v2 := if v1 >>> (56 : BitVec 6).toNat ≠ 0 then v1 else v1 <<< (8 : BitVec 6).toNat
+  let c2 := if v1 >>> (56 : BitVec 6).toNat ≠ 0 then c1 else c1 + signExtend12 (8 : BitVec 12)
+  let v3 := if v2 >>> (60 : BitVec 6).toNat ≠ 0 then v2 else v2 <<< (4 : BitVec 6).toNat
+  let c3 := if v2 >>> (60 : BitVec 6).toNat ≠ 0 then c2 else c2 + signExtend12 (4 : BitVec 12)
+  let v4 := if v3 >>> (62 : BitVec 6).toNat ≠ 0 then v3 else v3 <<< (2 : BitVec 6).toNat
+  let c4 := if v3 >>> (62 : BitVec 6).toNat ≠ 0 then c3 else c3 + signExtend12 (2 : BitVec 12)
+  let c5 := if v4 >>> (63 : Nat) ≠ 0 then c4 else c4 + signExtend12 (1 : BitVec 12)
+  (c5, v4)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Div128Phase2b.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Div128Phase2b.lean
@@ -1,0 +1,19 @@
+import EvmAsm.Rv64.Instructions
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Phase 2b refined quotient digit used by the V4 and V5 div128 models.
+
+The high-half guard implements Knuth's requirement to repeat the D3 test only
+while `rhat2c < 2^32`; otherwise the truncated 64-bit comparison can fire
+spuriously. -/
+def div128Quot_phase2b_q0' (q0c rhat2c dLo div_un0 : Word) : Word :=
+  if rhat2c >>> (32 : BitVec 6).toNat = 0 then
+    let q0Dlo := q0c * dLo
+    let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+    if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  else q0c
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
@@ -14,7 +14,7 @@
 
 import EvmAsm.Evm64.DivMod.Program
 import EvmAsm.Evm64.DivMod.Compose.Offsets
-import EvmAsm.Evm64.DivMod.LimbSpec.Div128ProdCheck2
+import EvmAsm.Evm64.DivMod.LoopDefs.Div128Phase2b
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
@@ -14,6 +14,8 @@
 
 import EvmAsm.Evm64.DivMod.LoopDefs.Iter
 import EvmAsm.Evm64.DivMod.LoopDefs.IterV4
+import EvmAsm.Rv64.Tactics.RunBlock
+import EvmAsm.Rv64.Tactics.XSimp
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean
@@ -14,7 +14,8 @@
   Then chain these through the 6 stages.
 -/
 
-import EvmAsm.Evm64.DivMod.Compose.CLZ
+import EvmAsm.Evm64.DivMod.LimbSpec.CLZ
+import EvmAsm.Evm64.DivMod.LoopDefs.CLZResult
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase2bNoFireBound.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase2bNoFireBound.lean
@@ -20,6 +20,7 @@
 import EvmAsm.Evm64.EvmWordArith.Div128Lemmas
 import EvmAsm.Evm64.EvmWordArith.Common
 import EvmAsm.Evm64.DivMod.LoopDefs.Iter
+import EvmAsm.Rv64.AddrNorm
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/CapBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/CapBounds.lean
@@ -11,6 +11,7 @@
 -/
 
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV5.Algorithm
+import EvmAsm.Rv64.AddrNorm
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
@@ -14,6 +14,7 @@ import EvmAsm.Evm64.EvmWordArith.DivAccumulate
 import EvmAsm.Evm64.EvmWordArith.Div128Lemmas
 import EvmAsm.Evm64.EvmWordArith.SignExtendLemmas
 import EvmAsm.Evm64.DivMod.LoopSemantic
+import Mathlib.Tactic.FinCases
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
## Summary
- move the pure `div128Quot_phase2b_q0\x27` definition out of the instruction-level `Div128ProdCheck2` proof
- let `LoopDefs.Iter` import the lightweight definition leaf directly
- make tactic and address-normalization dependencies explicit in consumers that previously received them transitively

## DAG impact
- removes `LoopDefs.Iter -> LimbSpec.Div128ProdCheck2 -> Rv64.Tactics.RunBlock` from the pure loop-definition chain
- localizes instruction-proof rebuilds away from all V4/V5 quotient models and their V6 consumers
- the global maximum remains 94 because the independent CLZ arithmetic chain is tied for the current maximum

## Validation
- `lake build`
- architecture gates (`check-layering`, forbidden tactics, unimported files, file size)
- `git diff --check`

Stacked on #10199.