### PR TITLE
refactor(divmod): extract pure CLZ result

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
@@ -8,6 +8,7 @@
 import EvmAsm.Evm64.DivMod.Compose.Base
 import EvmAsm.Evm64.DivMod.Compose.V4NoNop
 import EvmAsm.Evm64.DivMod.LimbSpec.CLZ
+import EvmAsm.Evm64.DivMod.LoopDefs.CLZResult
 
 open EvmAsm.Rv64.Tactics
 
@@ -163,7 +164,7 @@ private theorem clz_init_sub_noNop_v4 {base : Word} :
 -- Stage 5 (last): K=63, M_a=1,   index 21
 
 /-- CLZ result function: compute (count, shifted_val) from a 6-stage binary search. -/
-def clzResult (val : Word) : Word × Word :=
+private def clzResult_legacy (val : Word) : Word × Word :=
   -- Stage 0: check top 32 bits
   let v0 := if val >>> (32 : BitVec 6).toNat ≠ 0 then val else val <<< (32 : BitVec 6).toNat
   let c0 := if val >>> (32 : BitVec 6).toNat ≠ 0 then signExtend12 (0 : BitVec 12)

--- a/EvmAsm/Evm64/DivMod/LoopDefs/CLZResult.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/CLZResult.lean
@@ -1,0 +1,22 @@
+import EvmAsm.Rv64.Instructions
+
+namespace EvmAsm.Evm64
+open EvmAsm.Rv64
+
+/-- Pure result of the six-stage CLZ binary search. -/
+def clzResult (val : Word) : Word × Word :=
+  let v0 := if val >>> (32 : BitVec 6).toNat ≠ 0 then val else val <<< (32 : BitVec 6).toNat
+  let c0 := if val >>> (32 : BitVec 6).toNat ≠ 0 then signExtend12 (0 : BitVec 12)
+    else signExtend12 (0 : BitVec 12) + signExtend12 (32 : BitVec 12)
+  let v1 := if v0 >>> (48 : BitVec 6).toNat ≠ 0 then v0 else v0 <<< (16 : BitVec 6).toNat
+  let c1 := if v0 >>> (48 : BitVec 6).toNat ≠ 0 then c0 else c0 + signExtend12 (16 : BitVec 12)
+  let v2 := if v1 >>> (56 : BitVec 6).toNat ≠ 0 then v1 else v1 <<< (8 : BitVec 6).toNat
+  let c2 := if v1 >>> (56 : BitVec 6).toNat ≠ 0 then c1 else c1 + signExtend12 (8 : BitVec 12)
+  let v3 := if v2 >>> (60 : BitVec 6).toNat ≠ 0 then v2 else v2 <<< (4 : BitVec 6).toNat
+  let c3 := if v2 >>> (60 : BitVec 6).toNat ≠ 0 then c2 else c2 + signExtend12 (4 : BitVec 12)
+  let v4 := if v3 >>> (62 : BitVec 6).toNat ≠ 0 then v3 else v3 <<< (2 : BitVec 6).toNat
+  let c4 := if v3 >>> (62 : BitVec 6).toNat ≠ 0 then c3 else c3 + signExtend12 (2 : BitVec 12)
+  let c5 := if v4 >>> (63 : Nat) ≠ 0 then c4 else c4 + signExtend12 (1 : BitVec 12)
+  (c5, v4)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean
@@ -14,7 +14,8 @@
   Then chain these through the 6 stages.
 -/
 
-import EvmAsm.Evm64.DivMod.Compose.CLZ
+import EvmAsm.Evm64.DivMod.LimbSpec.CLZ
+import EvmAsm.Evm64.DivMod.LoopDefs.CLZResult
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
## Summary
- extract the pure `clzResult` computation into a lightweight loop-definitions leaf
- let arithmetic `CLZLemmas` bypass the instruction-level `Compose.CLZ` proof
- keep the composition proof consuming the same pure model

## DAG impact
- removes `CLZLemmas -> Compose.CLZ -> LimbSpec.CLZ` from the arithmetic chain
- shortens that formerly maximum-height branch by one edge
- root height remains 94 because a separate legacy V4 composition branch is tied at the maximum

## Validation
- `lake build`
- `scripts/check-unimported.sh`
- `git diff --check`

Stacked on #10203.