### PR TITLE
feat(sasm): verify hp_decode_nibbles byte-transparently — upLoop_spec + abiFrame contract (4ch8f.16.3)

### DIFF
--- a/EvmAsm/Codegen/Programs/HpDecodeNibblesSAsm.lean
+++ b/EvmAsm/Codegen/Programs/HpDecodeNibblesSAsm.lean
@@ -1,0 +1,1127 @@
+/-
+  Verified byte-transparent port of `hp_decode_nibbles` (bead
+  evm-asm-4ch8f.16.3, unblocking .16.3.1's two capability gaps with the
+  landed `AbiFrame` (PR #9982) and `UpLoop` (this PR) machinery).
+
+  The routine (`EvmAsm/Codegen/Programs/Mpt.lean`, PR-K23) decodes the
+  hex-prefix compact path of a leaf/extension MPT node into one-nibble
+  bytes, writing the nibble count and the is-leaf flag to caller cells:
+
+    a0 src ptr, a1 len, a2 nibble buf, a3 count cell, a4 is_leaf cell
+    → a0 = 0 success / 1 parse failure.
+
+  Shape: a C-ABI saved-register frame (`abiFrameProg`, byte-transparent —
+  no re-emit), a validation prefix whose failure branches jump straight to
+  a shared `li a0,1` fail tail, an odd/even parity split, and an
+  up-counting nibble loop (`bgeu i, len` top guard — `upLoop_spec`).
+
+  The genuine post is stated against `hdnRes`, the guest-exact decode
+  mirror, tied to the spec-side `EvmAsm.Evm64.hpDecode`
+  (`MptAssertions.lean`) by `hdnRes_eq_hpDecode` / `hdnRes_hpEncode`:
+  the guest is STRICTER than `hpDecode` exactly on even paths whose head
+  byte has a non-zero low nibble (it rejects; `hpDecode` ignores the
+  padding nibble) — on every hex-prefix ENCODING the two agree, so the
+  `.29` walk can consume either.
+-/
+
+import EvmAsm.Codegen.Programs.BytesToNibblesSAsm
+import EvmAsm.Evm64.MptAssertions
+import EvmAsm.Rv64.SAsm.AbiFrame
+import EvmAsm.Rv64.SAsm.UpLoop
+import EvmAsm.Rv64.MemRegionStore
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+
+namespace HpDecodeNibblesSAsm
+
+open BytesToNibblesSAsm (highNibble lowNibble nibblePair nibblePrefix
+  length_nibblePrefix)
+
+/-! ## The byte-transparent frame split -/
+
+/-- The saved-register frame `hp_decode_nibbles` allocates:
+    `ra` at 0, then `s0/s1/s2/s3/s4` = `x8/x9/x18/x19/x20`. -/
+def hdnFrame : FrameDesc :=
+  [(.x1, 0), (.x8, 8), (.x9, 16), (.x18, 24), (.x19, 32), (.x20, 40)]
+
+/-- The body slice of the emitted routine (between the frame prologue and
+    the shared epilogue): argument moves, validation with branches into
+    the shared `li a0,1` fail tail, the parity split, the up-counting
+    nibble loop, and the success tail. -/
+def hdnBody : List Instr :=
+  [ .MV .x8 .x10,
+    .MV .x9 .x11,
+    .MV .x18 .x12,
+    .MV .x19 .x13,
+    .MV .x20 .x14,
+    .BEQ .x9 .x0 (132 : BitVec 13),
+    .LBU .x5 .x8 (0 : BitVec 12),
+    .SRLI .x6 .x5 (4 : BitVec 6),
+    .ANDI .x7 .x5 (15 : BitVec 12),
+    .LI .x28 (4 : Word),
+    .BGEU .x6 .x28 (112 : BitVec 13),
+    .ANDI .x28 .x6 (2 : BitVec 12),
+    .SRLI .x28 .x28 (1 : BitVec 6),
+    .SD .x20 .x28 (0 : BitVec 12),
+    .ANDI .x6 .x6 (1 : BitVec 12),
+    .BEQ .x6 .x0 (20 : BitVec 13),
+    .SB .x18 .x7 (0 : BitVec 12),
+    .LI .x30 (1 : Word),
+    .ADDI .x31 .x18 (1 : BitVec 12),
+    .JAL .x0 (16 : BitVec 21),
+    .BNE .x7 .x0 (72 : BitVec 13),
+    .LI .x30 (0 : Word),
+    .MV .x31 .x18,
+    .LI .x5 (1 : Word),
+    .BGEU .x5 .x9 (44 : BitVec 13),
+    .ADD .x6 .x8 .x5,
+    .LBU .x7 .x6 (0 : BitVec 12),
+    .SRLI .x28 .x7 (4 : BitVec 6),
+    .ANDI .x29 .x7 (15 : BitVec 12),
+    .SB .x31 .x28 (0 : BitVec 12),
+    .SB .x31 .x29 (1 : BitVec 12),
+    .ADDI .x31 .x31 (2 : BitVec 12),
+    .ADDI .x30 .x30 (2 : BitVec 12),
+    .ADDI .x5 .x5 (1 : BitVec 12),
+    .JAL .x0 (-40 : BitVec 21),
+    .SD .x19 .x30 (0 : BitVec 12),
+    .LI .x10 (0 : Word),
+    .JAL .x0 (8 : BitVec 21),
+    .LI .x10 (1 : Word) ]
+
+/-- **Byte transparency**: the emitted routine is EXACTLY the ABI-frame
+    flatten of `hdnFrame` around `hdnBody` — no re-emission, the verified
+    triple is over the guest's own bytes. -/
+theorem hdnProg_eq :
+    abiFrameProg (-48 : BitVec 12) (48 : BitVec 12) hdnFrame hdnBody
+      = hpDecodeNibbles_prog := rfl
+
+#guard abiFrameProg (-48 : BitVec 12) (48 : BitVec 12) hdnFrame hdnBody
+  = hpDecodeNibbles_prog
+
+#guard hdnBody.length = 39
+#guard hpDecodeNibbles_prog.length = 54
+
+/-! ## The guest-exact decode model -/
+
+/-- The guest-exact hex-prefix decode: like `EvmAsm.Evm64.hpDecode`, but
+    STRICT on even paths — a head byte with flag parity 0 and a non-zero
+    low nibble is a parse failure (the routine's `bne x7, x0` check),
+    where `hpDecode` ignores the padding nibble. -/
+def hdnRes (bs : List (BitVec 8)) : Option (Bool × List (BitVec 8)) :=
+  match bs with
+  | [] => none
+  | b0 :: _ =>
+    if b0.toNat / 16 % 2 = 0 ∧ b0.toNat % 16 ≠ 0 then none
+    else EvmAsm.Evm64.hpDecode bs
+
+/-- Wherever the guest succeeds, it agrees with the spec-side
+    `hpDecode` (`MptAssertions.lean`). -/
+theorem hdnRes_eq_hpDecode {bs : List (BitVec 8)} {r : Bool × List (BitVec 8)}
+    (h : hdnRes bs = some r) : EvmAsm.Evm64.hpDecode bs = some r := by
+  match bs with
+  | [] => exact absurd h (by simp [hdnRes])
+  | b0 :: rest =>
+    simp only [hdnRes] at h
+    split at h
+    · exact absurd h (by simp)
+    · exact h
+
+/-- **Round-trip against the spec encoder**: on every hex-prefix encoding
+    of a well-formed nibble path the guest decode succeeds with exactly
+    the flag and path (the even-case head byte `flag * 16` has a zero low
+    nibble, so the guest's strict check passes). -/
+theorem hdnRes_hpEncode (isLeaf : Bool) (nibs : List (BitVec 8))
+    (hn : ∀ n ∈ nibs, n.toNat < 16) :
+    hdnRes (EvmAsm.Evm64.hpEncode isLeaf nibs) = some (isLeaf, nibs) := by
+  have hdec := EvmAsm.Evm64.hpDecode_hpEncode isLeaf nibs hn
+  have hflag : (if isLeaf then 2 else 0) ≤ 2 := by cases isLeaf <;> simp
+  obtain ⟨b0, tl, heq, hdiv⟩ :=
+    EvmAsm.Evm64.hpEncodeAux_head_div (if isLeaf then 2 else 0) hflag nibs hn
+  have henc : EvmAsm.Evm64.hpEncode isLeaf nibs = b0 :: tl := heq
+  rw [henc] at hdec ⊢
+  simp only [hdnRes]
+  split
+  · next hc =>
+    exfalso
+    by_cases hodd : nibs.length % 2 = 1
+    · -- Odd path: head high nibble = flag + 1, which is odd for flag ∈ {0,2}.
+      rw [hdiv, hodd] at hc
+      rcases hc with ⟨hc1, -⟩
+      cases isLeaf <;> simp at hc1
+    · -- Even path: the head byte is `flag * 16`, so the low nibble is 0.
+      have hshape : EvmAsm.Evm64.hpEncodeAux (if isLeaf then 2 else 0) nibs
+          = BitVec.ofNat 8 ((if isLeaf then 2 else 0) * 16)
+              :: EvmAsm.Evm64.hpPackPairs nibs := by
+        unfold EvmAsm.Evm64.hpEncodeAux
+        rw [if_neg hodd]
+      have h2 : b0 :: tl = BitVec.ofNat 8 ((if isLeaf then 2 else 0) * 16)
+          :: EvmAsm.Evm64.hpPackPairs nibs := heq.symm.trans hshape
+      have hb0 : b0 = BitVec.ofNat 8 ((if isLeaf then 2 else 0) * 16) := by
+        injection h2
+      rcases hc with ⟨-, hc2⟩
+      apply hc2
+      rw [hb0, BitVec.toNat_ofNat]
+      cases isLeaf <;> simp
+  · exact hdec
+
+/-! ## Machine-value bridges -/
+
+/-- `highNibble`/`lowNibble` (the machine's `srli 4` / `andi 15` on the
+    zero-extended byte, truncated back by `sb`) are the spec's nibble
+    arithmetic. -/
+theorem highNibble_eq (b : BitVec 8) :
+    highNibble b = BitVec.ofNat 8 (b.toNat / 16) := by
+  revert b; decide
+
+theorem lowNibble_eq (b : BitVec 8) :
+    lowNibble b = BitVec.ofNat 8 (b.toNat % 16) := by
+  revert b; decide
+
+/-- The machine loop's pair sequence is `hpUnpackPairs` over the consumed
+    bytes. -/
+theorem nibblePrefix_eq_hpUnpackPairs (bs : List (BitVec 8)) :
+    ∀ i, i ≤ bs.length →
+      nibblePrefix bs i = EvmAsm.Evm64.hpUnpackPairs (bs.take i) := by
+  intro i
+  induction i with
+  | zero => intro _; rfl
+  | succ k ih =>
+    intro hle
+    have hk : k < bs.length := by omega
+    rw [show nibblePrefix bs (k + 1)
+          = nibblePrefix bs k ++ nibblePair (bs.getD k 0) from rfl,
+        ih (by omega),
+        show bs.take (k + 1) = bs.take k ++ [bs[k]'hk] from by
+          rw [List.take_add_one, List.getElem?_eq_getElem hk]; rfl]
+    unfold EvmAsm.Evm64.hpUnpackPairs
+    rw [List.flatMap_append]
+    congr 1
+    show nibblePair (bs.getD k 0) = [_, _] ++ []
+    rw [List.append_nil,
+      show bs.getD k 0 = bs[k]'hk from by
+        rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem hk]; rfl]
+    show [highNibble _, lowNibble _] = _
+    rw [highNibble_eq, lowNibble_eq]
+
+/-! ## The result pieces the post is stated with -/
+
+/-- Head byte (meaningful only when `bs ≠ []`). -/
+def hdnB0 (bs : List (BitVec 8)) : BitVec 8 := bs.getD 0 0
+
+/-- Parity of the compact path (1 = odd, carries a nibble in byte 0). -/
+def hdnOdd (bs : List (BitVec 8)) : Bool := (hdnB0 bs).toNat / 16 % 2 = 1
+
+/-- The is-leaf machine word `(hi & 2) >> 1` the routine stores. -/
+def hdnIsLeafW (bs : List (BitVec 8)) : Word :=
+  BitVec.ofNat 64 ((hdnB0 bs).toNat / 16 / 2 % 2)
+
+/-- Whether the is-leaf cell is written at all: the store sits after the
+    `len = 0` and `hi ≥ 4` rejects but BEFORE the even-parity strict
+    check, so it executes iff the head byte exists and has a valid flag. -/
+def hdnIslWritten (bs : List (BitVec 8)) : Bool :=
+  !bs.isEmpty && decide ((hdnB0 bs).toNat / 16 < 4)
+
+/-- The decoded nibble list (empty on failure). -/
+def hdnNibs (bs : List (BitVec 8)) : List (BitVec 8) :=
+  ((hdnRes bs).map Prod.snd).getD []
+
+/-- Success flag as the returned status word (0 success / 1 failure). -/
+def hdnStatusW (bs : List (BitVec 8)) : Word :=
+  if (hdnRes bs).isSome then 0 else 1
+
+/-- Final nibble-buffer contents: the decoded nibbles spliced over the
+    original buffer (nothing is written on failure — `hdnNibs = []`). -/
+def hdnBufFinal (bs orig : List (BitVec 8)) : List (BitVec 8) :=
+  setBytes orig 0 (hdnNibs bs)
+
+/-- Final count cell: the nibble count on success, untouched otherwise. -/
+def hdnCntFinal (bs : List (BitVec 8)) (old : Word) : Word :=
+  if (hdnRes bs).isSome then BitVec.ofNat 64 (hdnNibs bs).length else old
+
+/-- Final is-leaf cell. -/
+def hdnIslFinal (bs : List (BitVec 8)) (old : Word) : Word :=
+  if hdnIslWritten bs then hdnIsLeafW bs else old
+
+-- Executable cross-checks of the model against the spec round-trip.
+#guard hdnRes (EvmAsm.Evm64.hpEncode true [1, 2, 3]) = some (true, [1, 2, 3])
+#guard hdnRes (EvmAsm.Evm64.hpEncode false [0xa, 0xb]) = some (false, [0xa, 0xb])
+#guard hdnRes [] = none
+#guard hdnRes [0x4a] = none            -- hi ≥ 4
+#guard hdnRes [0x01, 0xab] = none      -- even flag, non-zero low nibble
+#guard hdnRes [0x2a] = none            -- hi = 2 (even leaf), lo = 0xa ≠ 0 → strict reject
+#guard EvmAsm.Evm64.hpDecode [0x2a] = some (true, [])  -- where the spec is lenient
+
+/-- `bytesRegion` is pc-free (instance form, for `runBlock`'s automatic
+    framing). -/
+instance (b : Word) (bs : List (BitVec 8)) :
+    EvmAsm.Rv64.Assertion.PCFree (bytesRegion b bs) :=
+  ⟨bytesRegion_pcFree b bs⟩
+
+/-! ## Machine addressing and code membership (symbolic base) -/
+
+/-- The routine `CodeReq` at a symbolic guest base. -/
+def hdnCr (base : Word) : CodeReq := CodeReq.ofProg base hpDecodeNibbles_prog
+
+/-- Address of body instruction `k` (the prologue is 7 instructions). -/
+def bAt (base : Word) (k : Nat) : Word := base + BitVec.ofNat 64 (4 * (7 + k))
+
+private theorem memAt (base : Word) (k : Nat) (instr : Instr)
+    (hk : 7 + k < hpDecodeNibbles_prog.length)
+    (hget : hpDecodeNibbles_prog.get ⟨7 + k, hk⟩ = instr) :
+    ∀ a i, CodeReq.singleton (bAt base k) instr a = some i → hdnCr base a = some i := by
+  have m := CodeReq.ofProg_lookup_addr base hpDecodeNibbles_prog (7 + k) (bAt base k)
+    hk (by decide) rfl
+  rw [hget] at m
+  exact CodeReq.singleton_mono m
+
+/-- Lift a segment triple over its own contiguous `ofProg` slice into the
+    routine `CodeReq` (body index `k`). -/
+private theorem liftSeg (base : Word) {n : Nat} {B : Word} {seg : List Instr}
+    {P Q : Assertion} (k : Nat)
+    (hslice : (hpDecodeNibbles_prog.drop (7 + k)).take seg.length = seg)
+    (hrange : 7 + k + seg.length ≤ hpDecodeNibbles_prog.length)
+    (h : cpsTripleWithin n (bAt base k) B (CodeReq.ofProg (bAt base k) seg) P Q) :
+    cpsTripleWithin n (bAt base k) B (hdnCr base) P Q :=
+  cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mono_sub base (bAt base k) hpDecodeNibbles_prog seg (7 + k)
+      rfl hslice hrange (by decide)) h
+
+private theorem ofNat_add' (a b : Nat) :
+    BitVec.ofNat 64 a + BitVec.ofNat 64 b = BitVec.ofNat 64 (a + b) := by
+  apply BitVec.eq_of_toNat_eq
+  simp [BitVec.toNat_add, Nat.add_mod]
+
+private theorem bAt_add (base : Word) (k j : Nat) :
+    bAt base k + BitVec.ofNat 64 (4 * j) = bAt base (k + j) := by
+  unfold bAt
+  rw [BitVec.add_assoc, ofNat_add']
+  congr 2
+  omega
+
+private theorem bAt_succ (base : Word) (k : Nat) : bAt base k + 4 = bAt base (k + 1) := by
+  have := bAt_add base k 1
+  rwa [show BitVec.ofNat 64 (4 * 1) = (4 : Word) from rfl] at this
+
+/-- Forward branch/jump landing: `bAt k + ofs = bAt (k + ofs/4)` for the
+    emitted positive immediates. -/
+private theorem bAt_br (base : Word) (k j : Nat) (ofs : BitVec 13)
+    (h : signExtend13 ofs = BitVec.ofNat 64 (4 * j)) :
+    bAt base k + signExtend13 ofs = bAt base (k + j) := by
+  rw [h]; exact bAt_add base k j
+
+private theorem bAt_jal (base : Word) (k j : Nat) (ofs : BitVec 21)
+    (h : signExtend21 ofs = BitVec.ofNat 64 (4 * j)) :
+    bAt base k + signExtend21 ofs = bAt base (k + j) := by
+  rw [h]; exact bAt_add base k j
+
+/-- Backward jump: the loop back-edge `jal x0, -40` from body 34 to body 24. -/
+private theorem bAt_jal_back40 (base : Word) :
+    bAt base 34 + signExtend21 (-40 : BitVec 21) = bAt base 24 := by
+  unfold bAt
+  rw [BitVec.add_assoc]
+  congr 1
+
+/-! ## Value bridges (machine words ↔ nibble arithmetic) -/
+
+private theorem hi_word_eq (b : BitVec 8) :
+    (b.zeroExtend 64 : Word) >>> (4 : BitVec 6).toNat
+      = BitVec.ofNat 64 (b.toNat / 16) := by
+  revert b; decide
+
+private theorem lo_word_eq (b : BitVec 8) :
+    (b.zeroExtend 64 : Word) &&& signExtend12 (15 : BitVec 12)
+      = BitVec.ofNat 64 (b.toNat % 16) := by
+  revert b; decide
+
+private theorem isleaf_word_eq (b : BitVec 8) :
+    (BitVec.ofNat 64 (b.toNat / 16) &&& signExtend12 (2 : BitVec 12))
+        >>> (1 : BitVec 6).toNat
+      = BitVec.ofNat 64 (b.toNat / 16 / 2 % 2) := by
+  revert b; decide
+
+private theorem parity_word_eq (b : BitVec 8) :
+    BitVec.ofNat 64 (b.toNat / 16) &&& signExtend12 (1 : BitVec 12)
+      = BitVec.ofNat 64 (b.toNat / 16 % 2) := by
+  revert b; decide
+
+private theorem hi_truncate_eq (b : BitVec 8) :
+    ((b.zeroExtend 64 : Word) >>> (4 : BitVec 6).toNat).truncate 8 = highNibble b := rfl
+
+private theorem lo_truncate_eq (b : BitVec 8) :
+    ((b.zeroExtend 64 : Word) &&& signExtend12 (15 : BitVec 12)).truncate 8
+      = lowNibble b := rfl
+
+private theorem hi_lt4_iff (b : BitVec 8) :
+    BitVec.ult (BitVec.ofNat 64 (b.toNat / 16)) (4 : Word) ↔ b.toNat / 16 < 4 := by
+  revert b; decide
+
+private theorem nib_word_eq_zero {n : Nat} (h : BitVec.ofNat 64 n = 0)
+    (hlt : n < 2 ^ 64) : n = 0 := by
+  have h2 := congrArg BitVec.toNat h
+  rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt hlt] at h2
+  simpa using h2
+
+private theorem nib_word_ne_zero_iff (n : Nat) (h : n < 16) :
+    BitVec.ofNat 64 n ≠ (0 : Word) ↔ n ≠ 0 := by
+  constructor
+  · intro hne h0; exact hne (by rw [h0]; rfl)
+  · intro hne heq
+    have := congrArg BitVec.toNat heq
+    rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt (by omega)] at this
+    exact hne (by simpa using this)
+
+/-! ## SB at instruction offset 1 (the loop's second nibble store) -/
+
+/-- `bytesRegion_sb_within` sibling for `.SB rs1 rs2 1`: with `rs1` at
+    region index `i`, the store writes index `i + 1`. -/
+theorem bytesRegion_sb1_within (rs1 rs2 : Reg) (regionBase v_data : Word) (base : Word)
+    (bs : List (BitVec 8)) (i : Nat)
+    (halign : regionBase.toNat % 8 = 0) (hi : i + 1 < bs.length)
+    (hover : regionBase.toNat + (i + 1) < 2 ^ 64)
+    (hvalid : isValidByteAccess (regionBase + BitVec.ofNat 64 (i + 1)) = true) :
+    cpsTripleWithin 1 base (base + 4)
+      (CodeReq.singleton base (.SB rs1 rs2 1))
+      ((rs1 ↦ᵣ (regionBase + BitVec.ofNat 64 i)) ** (rs2 ↦ᵣ v_data)
+        ** bytesRegion regionBase bs)
+      ((rs1 ↦ᵣ (regionBase + BitVec.ofNat 64 i)) ** (rs2 ↦ᵣ v_data) **
+       bytesRegion regionBase (bs.set (i + 1) (v_data.truncate 8))) := by
+  have hsb := bytesRegion_sb_within rs1 rs2 regionBase v_data base bs (i + 1)
+    halign hi hover hvalid
+  -- Transport the offset-0 lemma along `rs1 = (regionBase + i+1) - 1`:
+  -- redo it directly instead, since the instruction differs.  We inline the
+  -- same skeleton via the generic store spec.
+  clear hsb
+  have hr : (i + 1) % 8 < 8 := Nat.mod_lt _ (by norm_num)
+  obtain ⟨front, rest, hf, hrst, heq, heqset⟩ :=
+    bytesRegion_dword_at_set regionBase bs ((i + 1) / 8) ((i + 1) % 8)
+      (v_data.truncate 8) hr (by omega)
+  rw [Nat.div_add_mod (i + 1) 8] at heqset
+  set dwordAddr := regionBase + BitVec.ofNat 64 (8 * ((i + 1) / 8)) with hdwa
+  set wordVal := packBytes ((bs.drop (8 * ((i + 1) / 8))).take 8) with hwv
+  have hptr_eq : (regionBase + BitVec.ofNat 64 i) + signExtend12 (1 : BitVec 12)
+      = regionBase + BitVec.ofNat 64 (i + 1) := by
+    rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide,
+      BitVec.add_assoc]
+    congr 1
+    apply BitVec.eq_of_toNat_eq
+    simp [BitVec.toNat_add, Nat.add_mod]
+  have halign' :
+      alignToDword ((regionBase + BitVec.ofNat 64 i) + signExtend12 (1 : BitVec 12))
+        = dwordAddr := by
+    rw [hptr_eq]; exact alignToDword_add_ofNat_of_aligned halign hover
+  have hvalid' :
+      isValidByteAccess ((regionBase + BitVec.ofNat 64 i) + signExtend12 (1 : BitVec 12))
+        = true := by
+    rw [hptr_eq]; exact hvalid
+  have sb := generic_sb_spec_within rs1 rs2 (regionBase + BitVec.ofNat 64 i) v_data 1 base
+    dwordAddr wordVal halign' hvalid'
+  have hbo : byteOffset (regionBase + BitVec.ofNat 64 (i + 1)) = (i + 1) % 8 :=
+    byteOffset_add_ofNat_of_aligned halign hover
+  rw [hptr_eq, hbo, hwv,
+    packBytes_set _ ((i + 1) % 8) (v_data.truncate 8) hr
+      (by rw [List.length_take, List.length_drop]; omega)] at sb
+  rw [heq, heqset]
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hp => by xperm_hyp hp)
+    (cpsTripleWithin_frameR (front ** rest) (pcFree_sepConj hf hrst) sb)
+
+/-! ## The buffer window -/
+
+/-- Initial-count nibbles (the odd path's first nibble). -/
+def hdnC0 (bs : List (BitVec 8)) : Nat := if hdnOdd bs then 1 else 0
+
+def hdnInitNibs (bs : List (BitVec 8)) : List (BitVec 8) :=
+  if hdnOdd bs then [lowNibble (hdnB0 bs)] else []
+
+@[simp] theorem hdnInitNibs_length (bs : List (BitVec 8)) :
+    (hdnInitNibs bs).length = hdnC0 bs := by
+  unfold hdnInitNibs hdnC0
+  split <;> rfl
+
+/-- The nibble buffer after the loop has consumed `j` tail bytes. -/
+def hdnWin (bs orig : List (BitVec 8)) (j : Nat) : List (BitVec 8) :=
+  setBytes orig 0 (hdnInitNibs bs ++ nibblePrefix (bs.drop 1) j)
+
+private theorem setBytes_append (bs : List (BitVec 8)) (i : Nat)
+    (xs ys : List (BitVec 8)) :
+    setBytes bs i (xs ++ ys) = setBytes (setBytes bs i xs) (i + xs.length) ys := by
+  induction xs generalizing bs i with
+  | nil => simp
+  | cons x xt ih =>
+    rw [List.cons_append, setBytes_cons, setBytes_cons, ih]
+    congr 1
+    simp; omega
+
+/-- One loop iteration extends the window by the byte's nibble pair. -/
+theorem hdnWin_step (bs orig : List (BitVec 8)) (j : Nat) :
+    ((hdnWin bs orig j).set (hdnC0 bs + 2 * j)
+        (highNibble ((bs.drop 1).getD j 0))).set (hdnC0 bs + 2 * j + 1)
+        (lowNibble ((bs.drop 1).getD j 0))
+      = hdnWin bs orig (j + 1) := by
+  unfold hdnWin
+  rw [show nibblePrefix (bs.drop 1) (j + 1)
+        = nibblePrefix (bs.drop 1) j ++ nibblePair ((bs.drop 1).getD j 0) from rfl,
+    ← List.append_assoc]
+  have hlen : (hdnInitNibs bs ++ nibblePrefix (bs.drop 1) j).length
+      = hdnC0 bs + 2 * j := by
+    rw [List.length_append, hdnInitNibs_length, length_nibblePrefix]
+  conv_rhs => rw [setBytes_append, hlen]
+  rw [Nat.zero_add]
+  simp only [BytesToNibblesSAsm.nibblePair, setBytes_cons, setBytes_nil]
+
+@[simp] theorem hdnWin_zero_length (bs orig : List (BitVec 8)) (j : Nat) :
+    (hdnWin bs orig j).length = orig.length := by
+  unfold hdnWin
+  exact length_setBytes _ _ _
+
+/-! ## Segment triples -/
+
+private def seg0Prog : List Instr :=
+  [ .MV .x8 .x10, .MV .x9 .x11, .MV .x18 .x12, .MV .x19 .x13, .MV .x20 .x14 ]
+
+/-- Body 0–4: move the five arguments into the saved `s`-registers. -/
+theorem seg0_spec (base src lenW dst cnt isl s8 s9 s18 s19 s20 : Word) :
+    cpsTripleWithin 5 (bAt base 0) (bAt base 5) (hdnCr base)
+      ((.x10 ↦ᵣ src) ** (.x8 ↦ᵣ s8) ** (.x11 ↦ᵣ lenW) ** (.x9 ↦ᵣ s9)
+        ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ s18) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ s19)
+        ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ s20))
+      ((.x10 ↦ᵣ src) ** (.x8 ↦ᵣ src) ** (.x11 ↦ᵣ lenW) ** (.x9 ↦ᵣ lenW)
+        ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+        ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)) := by
+  have hexit : base + BitVec.ofNat 64 28 + 4 + 4 + 4 + 4 + 4 = bAt base 5 := by
+    simp only [bAt, BitVec.add_assoc]
+    congr 1
+  refine liftSeg base 0 (seg := seg0Prog) (by rfl) (by decide) ?_
+  show cpsTripleWithin 5 (base + BitVec.ofNat 64 28) (bAt base 5)
+    (CodeReq.ofProg (base + BitVec.ofNat 64 28) seg0Prog) _ _
+  rw [← hexit]
+  simp only [seg0Prog, CodeReq.ofProg_cons, CodeReq.ofProg_nil,
+    CodeReq.union_empty_right]
+  have h0 := mv_spec_gen_within .x8 .x10 src s8
+    (base + BitVec.ofNat 64 28) (by decide)
+  have h1 := mv_spec_gen_within .x9 .x11 lenW s9
+    (base + BitVec.ofNat 64 28 + 4) (by decide)
+  have h2 := mv_spec_gen_within .x18 .x12 dst s18
+    (base + BitVec.ofNat 64 28 + 4 + 4) (by decide)
+  have h3 := mv_spec_gen_within .x19 .x13 cnt s19
+    (base + BitVec.ofNat 64 28 + 4 + 4 + 4) (by decide)
+  have h4 := mv_spec_gen_within .x20 .x14 isl s20
+    (base + BitVec.ofNat 64 28 + 4 + 4 + 4 + 4) (by decide)
+  runBlock h0 h1 h2 h3 h4
+
+private theorem add_sext0 (x : Word) : x + signExtend12 (0 : BitVec 12) = x := by
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]
+  exact BitVec.add_zero x
+
+theorem add_ofNat_zero (x : Word) : x + BitVec.ofNat 64 0 = x := by
+  rw [show BitVec.ofNat 64 0 = (0 : Word) from rfl]
+  exact BitVec.add_zero x
+
+/-- Numeral truncate bridge for the odd path's first-nibble store. -/
+private theorem lo64_truncate_eq (b : BitVec 8) :
+    (BitVec.ofNat 64 (b.toNat % 16)).truncate 8 = lowNibble b := by
+  revert b; decide
+
+
+private def seg1Prog : List Instr :=
+  [ .LBU .x5 .x8 (0 : BitVec 12), .SRLI .x6 .x5 (4 : BitVec 6),
+    .ANDI .x7 .x5 (15 : BitVec 12), .LI .x28 (4 : Word) ]
+
+private def seg2Prog : List Instr :=
+  [ .ANDI .x28 .x6 (2 : BitVec 12), .SRLI .x28 .x28 (1 : BitVec 6),
+    .SD .x20 .x28 (0 : BitVec 12), .ANDI .x6 .x6 (1 : BitVec 12) ]
+
+private def seg3oddProg : List Instr :=
+  [ .SB .x18 .x7 (0 : BitVec 12), .LI .x30 (1 : Word),
+    .ADDI .x31 .x18 (1 : BitVec 12) ]
+
+private def seg4evenProg : List Instr :=
+  [ .LI .x30 (0 : Word), .MV .x31 .x18 ]
+
+/-- Body 5 (`beq s1, x0, +132`), taken: `len = 0` → fail tail. -/
+theorem br1_taken (base : Word) (v : Word) (hv : v = 0) :
+    cpsTripleWithin 1 (bAt base 5) (bAt base 38) (hdnCr base)
+      ((.x9 ↦ᵣ v) ** (Reg.x0 ↦ᵣ (0 : Word)))
+      ((.x9 ↦ᵣ v) ** (Reg.x0 ↦ᵣ (0 : Word))) := by
+  have hbeq := beq_spec_gen_within .x9 .x0 (132 : BitVec 13) v 0 (bAt base 5)
+  rw [show bAt base 5 + signExtend13 (132 : BitVec 13) = bAt base 38 from by
+    simp only [bAt, BitVec.add_assoc]; congr 1] at hbeq
+  exact cpsBranchWithin_takenStripPure2
+    (cpsBranchWithin_extend_code
+      (memAt base 5 (.BEQ .x9 .x0 (132 : BitVec 13)) (by decide) (by rfl)) hbeq)
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, hBP⟩ := hQf
+      exact ((sepConj_pure_right _).1 hBP).2 hv)
+
+/-- Body 5, not taken: `len ≠ 0`. -/
+theorem br1_ntaken (base : Word) (v : Word) (hv : v ≠ 0) :
+    cpsTripleWithin 1 (bAt base 5) (bAt base 6) (hdnCr base)
+      ((.x9 ↦ᵣ v) ** (Reg.x0 ↦ᵣ (0 : Word)))
+      ((.x9 ↦ᵣ v) ** (Reg.x0 ↦ᵣ (0 : Word))) := by
+  have hbeq := beq_spec_gen_within .x9 .x0 (132 : BitVec 13) v 0 (bAt base 5)
+  rw [bAt_succ base 5] at hbeq
+  exact cpsBranchWithin_ntakenStripPure2
+    (cpsBranchWithin_extend_code
+      (memAt base 5 (.BEQ .x9 .x0 (132 : BitVec 13)) (by decide) (by rfl)) hbeq)
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, hBP⟩ := hQt
+      exact hv ((sepConj_pure_right _).1 hBP).2)
+
+/-- `seg1Prog` core at a free entry address. -/
+private theorem seg1_core (A src : Word) (srcBytes : List (BitVec 8))
+    (v5 v6 v7 v28 : Word)
+    (hne : 0 < srcBytes.length) (halign : src.toNat % 8 = 0)
+    (_hover : src.toNat + srcBytes.length < 2 ^ 64)
+    (hvalid : isValidByteAccess (src + BitVec.ofNat 64 0) = true) :
+    cpsTripleWithin 4 A (A + 4 + 4 + 4 + 4) (CodeReq.ofProg A seg1Prog)
+      ((.x8 ↦ᵣ src) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7)
+        ** (.x28 ↦ᵣ v28) ** bytesRegion src srcBytes)
+      ((.x8 ↦ᵣ src) ** (.x5 ↦ᵣ ((srcBytes.getD 0 0).zeroExtend 64))
+        ** (.x6 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16))
+        ** (.x7 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16))
+        ** (.x28 ↦ᵣ (4 : Word)) ** bytesRegion src srcBytes) := by
+  have hb0 : srcBytes.getD 0 0 = srcBytes[0]'hne := by
+    rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem hne]; rfl
+  simp only [seg1Prog, CodeReq.ofProg_cons, CodeReq.ofProg_nil,
+    CodeReq.union_empty_right]
+  have h0 := bytesRegion_lbu_within .x5 .x8 src v5 A srcBytes 0
+    (by decide) halign hne (by omega) hvalid
+  rw [add_ofNat_zero src] at h0
+  have h1 := srli_spec_gen_within .x6 .x5 v6 ((srcBytes[0]'hne).zeroExtend 64)
+    (4 : BitVec 6) (A + 4) (by decide)
+  have h2 := andi_spec_gen_within .x7 .x5 v7 ((srcBytes[0]'hne).zeroExtend 64)
+    (15 : BitVec 12) (A + 4 + 4) (by decide)
+  have h3 := li_spec_gen_within .x28 v28 (4 : Word) (A + 4 + 4 + 4) (by decide)
+  rw [hi_word_eq] at h1
+  rw [lo_word_eq] at h2
+  rw [hb0]
+  runBlock h0 h1 h2 h3
+
+/-- Body 6–9: load byte 0 and split it into the high/low nibbles; stage the
+    flag bound. -/
+theorem seg1_spec (base src : Word) (srcBytes : List (BitVec 8))
+    (v5 v6 v7 v28 : Word)
+    (hne : 0 < srcBytes.length) (halign : src.toNat % 8 = 0)
+    (hover : src.toNat + srcBytes.length < 2 ^ 64)
+    (hvalid : isValidByteAccess (src + BitVec.ofNat 64 0) = true) :
+    cpsTripleWithin 4 (bAt base 6) (bAt base 10) (hdnCr base)
+      ((.x8 ↦ᵣ src) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7)
+        ** (.x28 ↦ᵣ v28) ** bytesRegion src srcBytes)
+      ((.x8 ↦ᵣ src) ** (.x5 ↦ᵣ ((srcBytes.getD 0 0).zeroExtend 64))
+        ** (.x6 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16))
+        ** (.x7 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16))
+        ** (.x28 ↦ᵣ (4 : Word)) ** bytesRegion src srcBytes) := by
+  have hexit : bAt base 6 + 4 + 4 + 4 + 4 = bAt base 10 := by
+    simp only [bAt, BitVec.add_assoc]
+    congr 1
+  have hc := seg1_core (bAt base 6) src srcBytes v5 v6 v7 v28 hne halign hover hvalid
+  rw [hexit] at hc
+  exact liftSeg base 6 (seg := seg1Prog) (by rfl) (by decide) hc
+
+/-- Body 10 (`bgeu hi, 4, +112`), taken: invalid flag nibble → fail tail. -/
+theorem br2_taken (base : Word) (b0 : BitVec 8) (hv : 4 ≤ b0.toNat / 16) :
+    cpsTripleWithin 1 (bAt base 10) (bAt base 38) (hdnCr base)
+      ((.x6 ↦ᵣ BitVec.ofNat 64 (b0.toNat / 16)) ** (.x28 ↦ᵣ (4 : Word)))
+      ((.x6 ↦ᵣ BitVec.ofNat 64 (b0.toNat / 16)) ** (.x28 ↦ᵣ (4 : Word))) := by
+  have hb := bgeu_spec_gen_within .x6 .x28 (112 : BitVec 13)
+    (BitVec.ofNat 64 (b0.toNat / 16)) (4 : Word) (bAt base 10)
+  rw [show bAt base 10 + signExtend13 (112 : BitVec 13) = bAt base 38 from by
+    simp only [bAt, BitVec.add_assoc]; congr 1] at hb
+  exact cpsBranchWithin_takenStripPure2
+    (cpsBranchWithin_extend_code
+      (memAt base 10 (.BGEU .x6 .x28 (112 : BitVec 13)) (by decide) (by rfl)) hb)
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, hBP⟩ := hQf
+      exact absurd ((hi_lt4_iff b0).1 ((sepConj_pure_right _).1 hBP).2) (by omega))
+
+/-- Body 10, not taken: valid flag nibble. -/
+theorem br2_ntaken (base : Word) (b0 : BitVec 8) (hv : b0.toNat / 16 < 4) :
+    cpsTripleWithin 1 (bAt base 10) (bAt base 11) (hdnCr base)
+      ((.x6 ↦ᵣ BitVec.ofNat 64 (b0.toNat / 16)) ** (.x28 ↦ᵣ (4 : Word)))
+      ((.x6 ↦ᵣ BitVec.ofNat 64 (b0.toNat / 16)) ** (.x28 ↦ᵣ (4 : Word))) := by
+  have hb := bgeu_spec_gen_within .x6 .x28 (112 : BitVec 13)
+    (BitVec.ofNat 64 (b0.toNat / 16)) (4 : Word) (bAt base 10)
+  rw [bAt_succ base 10] at hb
+  exact cpsBranchWithin_ntakenStripPure2
+    (cpsBranchWithin_extend_code
+      (memAt base 10 (.BGEU .x6 .x28 (112 : BitVec 13)) (by decide) (by rfl)) hb)
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, hBP⟩ := hQt
+      exact absurd ((sepConj_pure_right _).1 hBP).2
+        (by simp only [not_not]; exact (hi_lt4_iff b0).2 hv))
+
+/-- `seg2Prog` core at a free entry address. -/
+private theorem seg2_core (A isl oldIsl : Word) (b0 : BitVec 8) (v28 : Word) :
+    cpsTripleWithin 4 A (A + 4 + 4 + 4 + 4) (CodeReq.ofProg A seg2Prog)
+      ((.x6 ↦ᵣ BitVec.ofNat 64 (b0.toNat / 16)) ** (.x28 ↦ᵣ v28)
+        ** (.x20 ↦ᵣ isl) ** (isl ↦ₘ oldIsl))
+      ((.x6 ↦ᵣ BitVec.ofNat 64 (b0.toNat / 16 % 2))
+        ** (.x28 ↦ᵣ BitVec.ofNat 64 (b0.toNat / 16 / 2 % 2))
+        ** (.x20 ↦ᵣ isl) ** (isl ↦ₘ BitVec.ofNat 64 (b0.toNat / 16 / 2 % 2))) := by
+  simp only [seg2Prog, CodeReq.ofProg_cons, CodeReq.ofProg_nil,
+    CodeReq.union_empty_right]
+  have h0 := andi_spec_gen_within .x28 .x6 v28 (BitVec.ofNat 64 (b0.toNat / 16))
+    (2 : BitVec 12) A (by decide)
+  have h1 := srli_spec_gen_same_within .x28
+    (BitVec.ofNat 64 (b0.toNat / 16) &&& signExtend12 (2 : BitVec 12))
+    (1 : BitVec 6) (A + 4) (by decide)
+  rw [isleaf_word_eq] at h1
+  have h2 := sd_spec_gen_within .x20 .x28 isl
+    (BitVec.ofNat 64 (b0.toNat / 16 / 2 % 2)) oldIsl (0 : BitVec 12) (A + 4 + 4)
+  rw [add_sext0 isl] at h2
+  have h3 := andi_spec_gen_same_within .x6 (BitVec.ofNat 64 (b0.toNat / 16))
+    (1 : BitVec 12) (A + 4 + 4 + 4) (by decide)
+  rw [parity_word_eq] at h3
+  runBlock h0 h1 h2 h3
+
+/-- Body 11–14: compute + store the is-leaf flag, reduce `x6` to the
+    parity bit. -/
+theorem seg2_spec (base isl oldIsl : Word) (b0 : BitVec 8) (v28 : Word) :
+    cpsTripleWithin 4 (bAt base 11) (bAt base 15) (hdnCr base)
+      ((.x6 ↦ᵣ BitVec.ofNat 64 (b0.toNat / 16)) ** (.x28 ↦ᵣ v28)
+        ** (.x20 ↦ᵣ isl) ** (isl ↦ₘ oldIsl))
+      ((.x6 ↦ᵣ BitVec.ofNat 64 (b0.toNat / 16 % 2))
+        ** (.x28 ↦ᵣ BitVec.ofNat 64 (b0.toNat / 16 / 2 % 2))
+        ** (.x20 ↦ᵣ isl) ** (isl ↦ₘ BitVec.ofNat 64 (b0.toNat / 16 / 2 % 2))) := by
+  have hexit : bAt base 11 + 4 + 4 + 4 + 4 = bAt base 15 := by
+    simp only [bAt, BitVec.add_assoc]
+    congr 1
+  have hc := seg2_core (bAt base 11) isl oldIsl b0 v28
+  rw [hexit] at hc
+  exact liftSeg base 11 (seg := seg2Prog) (by rfl) (by decide) hc
+
+/-- Body 15 (`beq parity, x0, +20`), taken: even path. -/
+theorem br3_taken (base : Word) (b0 : BitVec 8)
+    (hv : b0.toNat / 16 % 2 = 0) :
+    cpsTripleWithin 1 (bAt base 15) (bAt base 20) (hdnCr base)
+      ((.x6 ↦ᵣ BitVec.ofNat 64 (b0.toNat / 16 % 2)) ** (Reg.x0 ↦ᵣ (0 : Word)))
+      ((.x6 ↦ᵣ BitVec.ofNat 64 (b0.toNat / 16 % 2)) ** (Reg.x0 ↦ᵣ (0 : Word))) := by
+  have hbeq := beq_spec_gen_within .x6 .x0 (20 : BitVec 13)
+    (BitVec.ofNat 64 (b0.toNat / 16 % 2)) 0 (bAt base 15)
+  rw [show bAt base 15 + signExtend13 (20 : BitVec 13) = bAt base 20 from by
+    simp only [bAt, BitVec.add_assoc]; congr 1] at hbeq
+  exact cpsBranchWithin_takenStripPure2
+    (cpsBranchWithin_extend_code
+      (memAt base 15 (.BEQ .x6 .x0 (20 : BitVec 13)) (by decide) (by rfl)) hbeq)
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, hBP⟩ := hQf
+      exact ((sepConj_pure_right _).1 hBP).2 (by rw [hv]; rfl))
+
+/-- Body 15, not taken: odd path. -/
+theorem br3_ntaken (base : Word) (b0 : BitVec 8)
+    (hv : b0.toNat / 16 % 2 ≠ 0) :
+    cpsTripleWithin 1 (bAt base 15) (bAt base 16) (hdnCr base)
+      ((.x6 ↦ᵣ BitVec.ofNat 64 (b0.toNat / 16 % 2)) ** (Reg.x0 ↦ᵣ (0 : Word)))
+      ((.x6 ↦ᵣ BitVec.ofNat 64 (b0.toNat / 16 % 2)) ** (Reg.x0 ↦ᵣ (0 : Word))) := by
+  have hbeq := beq_spec_gen_within .x6 .x0 (20 : BitVec 13)
+    (BitVec.ofNat 64 (b0.toNat / 16 % 2)) 0 (bAt base 15)
+  rw [bAt_succ base 15] at hbeq
+  exact cpsBranchWithin_ntakenStripPure2
+    (cpsBranchWithin_extend_code
+      (memAt base 15 (.BEQ .x6 .x0 (20 : BitVec 13)) (by decide) (by rfl)) hbeq)
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, hBP⟩ := hQt
+      exact hv (nib_word_eq_zero ((sepConj_pure_right _).1 hBP).2 (by omega)))
+
+/-- `seg3oddProg` core at a free entry address. -/
+private theorem seg3odd_core (A dst : Word) (b0 : BitVec 8)
+    (bufOrig : List (BitVec 8)) (v30 v31 : Word)
+    (hlen : 0 < bufOrig.length) (halign : dst.toNat % 8 = 0)
+    (_hover : dst.toNat + bufOrig.length < 2 ^ 64)
+    (hvalid : isValidByteAccess (dst + BitVec.ofNat 64 0) = true) :
+    cpsTripleWithin 3 A (A + 4 + 4 + 4) (CodeReq.ofProg A seg3oddProg)
+      ((.x18 ↦ᵣ dst) ** (.x7 ↦ᵣ BitVec.ofNat 64 (b0.toNat % 16))
+        ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) ** bytesRegion dst bufOrig)
+      ((.x18 ↦ᵣ dst) ** (.x7 ↦ᵣ BitVec.ofNat 64 (b0.toNat % 16))
+        ** (.x30 ↦ᵣ (1 : Word)) ** (.x31 ↦ᵣ (dst + BitVec.ofNat 64 1))
+        ** bytesRegion dst (bufOrig.set 0 (lowNibble b0))) := by
+  simp only [seg3oddProg, CodeReq.ofProg_cons, CodeReq.ofProg_nil,
+    CodeReq.union_empty_right]
+  have h0 := bytesRegion_sb_within .x18 .x7 dst
+    (BitVec.ofNat 64 (b0.toNat % 16)) A bufOrig 0 halign hlen (by omega) hvalid
+  rw [add_ofNat_zero dst, lo64_truncate_eq] at h0
+  have h1 := li_spec_gen_within .x30 v30 (1 : Word) (A + 4) (by decide)
+  have h2 := addi_spec_gen_within .x31 .x18 v31 dst (1 : BitVec 12)
+    (A + 4 + 4) (by decide)
+  rw [show dst + signExtend12 (1 : BitVec 12) = dst + BitVec.ofNat 64 1 from by
+    congr 1] at h2
+  runBlock h0 h1 h2
+
+/-- Body 16–18 (odd path): store the head nibble at `dst[0]`, count 1,
+    cursor `dst + 1`. -/
+theorem seg3odd_spec (base dst : Word) (b0 : BitVec 8)
+    (bufOrig : List (BitVec 8)) (v30 v31 : Word)
+    (hlen : 0 < bufOrig.length) (halign : dst.toNat % 8 = 0)
+    (hover : dst.toNat + bufOrig.length < 2 ^ 64)
+    (hvalid : isValidByteAccess (dst + BitVec.ofNat 64 0) = true) :
+    cpsTripleWithin 3 (bAt base 16) (bAt base 19) (hdnCr base)
+      ((.x18 ↦ᵣ dst) ** (.x7 ↦ᵣ BitVec.ofNat 64 (b0.toNat % 16))
+        ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) ** bytesRegion dst bufOrig)
+      ((.x18 ↦ᵣ dst) ** (.x7 ↦ᵣ BitVec.ofNat 64 (b0.toNat % 16))
+        ** (.x30 ↦ᵣ (1 : Word)) ** (.x31 ↦ᵣ (dst + BitVec.ofNat 64 1))
+        ** bytesRegion dst (bufOrig.set 0 (lowNibble b0))) := by
+  have hexit : bAt base 16 + 4 + 4 + 4 = bAt base 19 := by
+    simp only [bAt, BitVec.add_assoc]
+    congr 1
+  have hc := seg3odd_core (bAt base 16) dst b0 bufOrig v30 v31 hlen halign hover hvalid
+  rw [hexit] at hc
+  exact liftSeg base 16 (seg := seg3oddProg) (by rfl) (by decide) hc
+
+/-- Body 19: the odd path's `jal x0, +16` over the even block into the
+    loop init. -/
+theorem jal19_spec (base : Word) {P : Assertion} (hP : P.pcFree) :
+    cpsTripleWithin 1 (bAt base 19) (bAt base 23) (hdnCr base) P P := by
+  have h := jal0_spec_pcFree (16 : BitVec 21) (bAt base 19) hP
+  rw [show bAt base 19 + signExtend21 (16 : BitVec 21) = bAt base 23 from by
+    simp only [bAt, BitVec.add_assoc]; congr 1] at h
+  exact cpsTripleWithin_extend_code
+    (memAt base 19 (.JAL .x0 (16 : BitVec 21)) (by decide) (by rfl)) h
+
+/-- Body 20 (`bne lo, x0, +72`), taken: even path with non-zero padding
+    nibble → fail tail (the guest's strict check). -/
+theorem br4_taken (base : Word) (b0 : BitVec 8) (hv : b0.toNat % 16 ≠ 0) :
+    cpsTripleWithin 1 (bAt base 20) (bAt base 38) (hdnCr base)
+      ((.x7 ↦ᵣ BitVec.ofNat 64 (b0.toNat % 16)) ** (Reg.x0 ↦ᵣ (0 : Word)))
+      ((.x7 ↦ᵣ BitVec.ofNat 64 (b0.toNat % 16)) ** (Reg.x0 ↦ᵣ (0 : Word))) := by
+  have hbne := bne_spec_gen_within .x7 .x0 (72 : BitVec 13)
+    (BitVec.ofNat 64 (b0.toNat % 16)) 0 (bAt base 20)
+  rw [show bAt base 20 + signExtend13 (72 : BitVec 13) = bAt base 38 from by
+    simp only [bAt, BitVec.add_assoc]; congr 1] at hbne
+  exact cpsBranchWithin_takenStripPure2
+    (cpsBranchWithin_extend_code
+      (memAt base 20 (.BNE .x7 .x0 (72 : BitVec 13)) (by decide) (by rfl)) hbne)
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, hBP⟩ := hQf
+      exact hv (nib_word_eq_zero ((sepConj_pure_right _).1 hBP).2 (by omega)))
+
+/-- Body 20, not taken: zero padding nibble — the even path proceeds. -/
+theorem br4_ntaken (base : Word) (b0 : BitVec 8) (hv : b0.toNat % 16 = 0) :
+    cpsTripleWithin 1 (bAt base 20) (bAt base 21) (hdnCr base)
+      ((.x7 ↦ᵣ BitVec.ofNat 64 (b0.toNat % 16)) ** (Reg.x0 ↦ᵣ (0 : Word)))
+      ((.x7 ↦ᵣ BitVec.ofNat 64 (b0.toNat % 16)) ** (Reg.x0 ↦ᵣ (0 : Word))) := by
+  have hbne := bne_spec_gen_within .x7 .x0 (72 : BitVec 13)
+    (BitVec.ofNat 64 (b0.toNat % 16)) 0 (bAt base 20)
+  rw [bAt_succ base 20] at hbne
+  exact cpsBranchWithin_ntakenStripPure2
+    (cpsBranchWithin_extend_code
+      (memAt base 20 (.BNE .x7 .x0 (72 : BitVec 13)) (by decide) (by rfl)) hbne)
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, hBP⟩ := hQt
+      exact ((sepConj_pure_right _).1 hBP).2 (by rw [hv]; rfl))
+
+/-- `seg4evenProg` core at a free entry address. -/
+private theorem seg4even_core (A dst : Word) (v30 v31 : Word) :
+    cpsTripleWithin 2 A (A + 4 + 4) (CodeReq.ofProg A seg4evenProg)
+      ((.x18 ↦ᵣ dst) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))
+      ((.x18 ↦ᵣ dst) ** (.x30 ↦ᵣ (0 : Word)) ** (.x31 ↦ᵣ dst)) := by
+  simp only [seg4evenProg, CodeReq.ofProg_cons, CodeReq.ofProg_nil,
+    CodeReq.union_empty_right]
+  have h0 := li_spec_gen_within .x30 v30 (0 : Word) A (by decide)
+  have h1 := mv_spec_gen_within .x31 .x18 dst v31 (A + 4) (by decide)
+  runBlock h0 h1
+
+/-- Body 21–22 (even path): count 0, cursor `dst`. -/
+theorem seg4even_spec (base dst : Word) (v30 v31 : Word) :
+    cpsTripleWithin 2 (bAt base 21) (bAt base 23) (hdnCr base)
+      ((.x18 ↦ᵣ dst) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))
+      ((.x18 ↦ᵣ dst) ** (.x30 ↦ᵣ (0 : Word)) ** (.x31 ↦ᵣ dst)) := by
+  have hexit : bAt base 21 + 4 + 4 = bAt base 23 := by
+    simp only [bAt, BitVec.add_assoc]
+    congr 1
+  have hc := seg4even_core (bAt base 21) dst v30 v31
+  rw [hexit] at hc
+  exact liftSeg base 21 (seg := seg4evenProg) (by rfl) (by decide) hc
+
+/-- Body 23: loop-cursor init `li t0, 1`. -/
+theorem seg5_spec (base : Word) (v5 : Word) :
+    cpsTripleWithin 1 (bAt base 23) (bAt base 24) (hdnCr base)
+      (.x5 ↦ᵣ v5) (.x5 ↦ᵣ (1 : Word)) := by
+  have h := li_spec_gen_within .x5 v5 (1 : Word) (bAt base 23) (by decide)
+  rw [bAt_succ base 23] at h
+  exact cpsTripleWithin_extend_code
+    (memAt base 23 (.LI .x5 (1 : Word)) (by decide) (by rfl)) h
+
+/-- Body 35–37: store the nibble count, status 0, jump to the body exit. -/
+theorem seg6_spec (base cnt oldCnt : Word) (v30 v10 : Word) :
+    cpsTripleWithin 3 (bAt base 35) (bAt base 39) (hdnCr base)
+      ((.x19 ↦ᵣ cnt) ** (.x30 ↦ᵣ v30) ** (.x10 ↦ᵣ v10) ** (cnt ↦ₘ oldCnt))
+      ((.x19 ↦ᵣ cnt) ** (.x30 ↦ᵣ v30) ** (.x10 ↦ᵣ (0 : Word)) ** (cnt ↦ₘ v30)) := by
+  -- SD, then LI, then the jump — the jump is handled separately since
+  -- `runBlock` chains fall-through exits only.
+  have h0 := sd_spec_gen_within .x19 .x30 cnt v30 oldCnt (0 : BitVec 12) (bAt base 35)
+  rw [add_sext0 cnt, bAt_succ base 35] at h0
+  have h1 := li_spec_gen_within .x10 v10 (0 : Word) (bAt base 36) (by decide)
+  rw [bAt_succ base 36] at h1
+  have h2 := jal0_spec_pcFree (8 : BitVec 21) (bAt base 37)
+    (P := (.x19 ↦ᵣ cnt) ** (.x30 ↦ᵣ v30) ** (.x10 ↦ᵣ (0 : Word)) ** (cnt ↦ₘ v30))
+    (pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs
+      (pcFree_sepConj pcFree_regIs pcFree_memIs)))
+  rw [show bAt base 37 + signExtend21 (8 : BitVec 21) = bAt base 39 from by
+    simp only [bAt, BitVec.add_assoc]; congr 1] at h2
+  have m0 := cpsTripleWithin_extend_code
+    (memAt base 35 (.SD .x19 .x30 (0 : BitVec 12)) (by decide) (by rfl)) h0
+  have m1 := cpsTripleWithin_extend_code
+    (memAt base 36 (.LI .x10 (0 : Word)) (by decide) (by rfl)) h1
+  have m2 := cpsTripleWithin_extend_code
+    (memAt base 37 (.JAL .x0 (8 : BitVec 21)) (by decide) (by rfl)) h2
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp)
+    (cpsTripleWithin_frameR (.x10 ↦ᵣ v10) pcFree_regIs m0)
+    (cpsTripleWithin_frameR ((.x19 ↦ᵣ cnt) ** (cnt ↦ₘ v30)) (pcFree_sepConj
+      pcFree_regIs pcFree_memIs) (cpsTripleWithin_frameR (.x30 ↦ᵣ v30)
+        pcFree_regIs m1))
+  have s2 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) s1 m2
+  exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq) s2
+
+/-- Body 38: the shared fail tail `li a0, 1`, falling into the epilogue. -/
+theorem fail38_spec (base : Word) (v10 : Word) :
+    cpsTripleWithin 1 (bAt base 38) (bAt base 39) (hdnCr base)
+      (.x10 ↦ᵣ v10) (.x10 ↦ᵣ (1 : Word)) := by
+  have h := li_spec_gen_within .x10 v10 (1 : Word) (bAt base 38) (by decide)
+  rw [bAt_succ base 38] at h
+  exact cpsTripleWithin_extend_code
+    (memAt base 38 (.LI .x10 (1 : Word)) (by decide) (by rfl)) h
+
+
+/-! ## The nibble loop -/
+
+private def loopProg : List Instr :=
+  [ .ADD .x6 .x8 .x5,
+    .LBU .x7 .x6 (0 : BitVec 12),
+    .SRLI .x28 .x7 (4 : BitVec 6),
+    .ANDI .x29 .x7 (15 : BitVec 12),
+    .SB .x31 .x28 (0 : BitVec 12),
+    .SB .x31 .x29 (1 : BitVec 12),
+    .ADDI .x31 .x31 (2 : BitVec 12),
+    .ADDI .x30 .x30 (2 : BitVec 12),
+    .ADDI .x5 .x5 (1 : BitVec 12) ]
+
+private theorem hi64_truncate_eq (b : BitVec 8) :
+    (BitVec.ofNat 64 (b.toNat / 16)).truncate 8 = highNibble b := by
+  revert b; decide
+
+private theorem getD_drop1 (bs : List (BitVec 8)) (i : Nat) (hi : 1 ≤ i) :
+    (bs.drop 1).getD (i - 1) 0 = bs.getD i 0 := by
+  simp only [List.getD_eq_getElem?_getD, List.getElem?_drop]
+  congr 2
+  omega
+
+private theorem add_ofNat_sext2 (x : Word) (a : Nat) :
+    x + BitVec.ofNat 64 a + signExtend12 (2 : BitVec 12) = x + BitVec.ofNat 64 (a + 2) := by
+  rw [show signExtend12 (2 : BitVec 12) = BitVec.ofNat 64 2 from by decide,
+    BitVec.add_assoc, ofNat_add']
+
+private theorem ofNat_sext2 (a : Nat) :
+    BitVec.ofNat 64 a + signExtend12 (2 : BitVec 12) = BitVec.ofNat 64 (a + 2) := by
+  rw [show signExtend12 (2 : BitVec 12) = BitVec.ofNat 64 2 from by decide, ofNat_add']
+
+private theorem ofNat_sext1 (a : Nat) :
+    BitVec.ofNat 64 a + signExtend12 (1 : BitVec 12) = BitVec.ofNat 64 (a + 1) := by
+  rw [show signExtend12 (1 : BitVec 12) = BitVec.ofNat 64 1 from by decide, ofNat_add']
+
+/-- One loop iteration's straight-line core (body 25–33) at a free entry
+    address: read byte `i`, write its nibble pair at the cursor, bump
+    cursor/count/index.  `W` is the current buffer window. -/
+private theorem loopCore (A src dst : Word) (bs W : List (BitVec 8)) (i p : Nat)
+    (w6 w7 w28 w29 : Word)
+    (hi : i < bs.length) (hsalign : src.toNat % 8 = 0)
+    (hsover : src.toNat + bs.length < 2 ^ 64)
+    (hsvalid : isValidByteAccess (src + BitVec.ofNat 64 i) = true)
+    (hp : p + 1 < W.length) (hdalign : dst.toNat % 8 = 0)
+    (hdover : dst.toNat + W.length < 2 ^ 64)
+    (hdvalid0 : isValidByteAccess (dst + BitVec.ofNat 64 p) = true)
+    (hdvalid1 : isValidByteAccess (dst + BitVec.ofNat 64 (p + 1)) = true) :
+    cpsTripleWithin 9 A (A + 4 + 4 + 4 + 4 + 4 + 4 + 4 + 4 + 4)
+      (CodeReq.ofProg A loopProg)
+      ((.x5 ↦ᵣ BitVec.ofNat 64 i) ** (.x8 ↦ᵣ src) ** (.x6 ↦ᵣ w6)
+        ** (.x7 ↦ᵣ w7) ** (.x28 ↦ᵣ w28) ** (.x29 ↦ᵣ w29)
+        ** (.x30 ↦ᵣ BitVec.ofNat 64 p) ** (.x31 ↦ᵣ (dst + BitVec.ofNat 64 p))
+        ** bytesRegion src bs ** bytesRegion dst W)
+      ((.x5 ↦ᵣ BitVec.ofNat 64 (i + 1)) ** (.x8 ↦ᵣ src)
+        ** (.x6 ↦ᵣ (src + BitVec.ofNat 64 i))
+        ** (.x7 ↦ᵣ ((bs.getD i 0).zeroExtend 64))
+        ** (.x28 ↦ᵣ BitVec.ofNat 64 ((bs.getD i 0).toNat / 16))
+        ** (.x29 ↦ᵣ BitVec.ofNat 64 ((bs.getD i 0).toNat % 16))
+        ** (.x30 ↦ᵣ BitVec.ofNat 64 (p + 2))
+        ** (.x31 ↦ᵣ (dst + BitVec.ofNat 64 (p + 2)))
+        ** bytesRegion src bs
+        ** bytesRegion dst
+            ((W.set p (highNibble (bs.getD i 0))).set (p + 1)
+              (lowNibble (bs.getD i 0)))) := by
+  have hbi : bs.getD i 0 = bs[i]'hi := by
+    rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem hi]; rfl
+  simp only [loopProg, CodeReq.ofProg_cons, CodeReq.ofProg_nil,
+    CodeReq.union_empty_right]
+  have h0 := add_spec_gen_within .x6 .x8 .x5 src (BitVec.ofNat 64 i) w6 A (by decide)
+  have h1 := bytesRegion_lbu_within .x7 .x6 src w7 (A + 4) bs i
+    (by decide) hsalign hi (by omega) hsvalid
+  have h2 := srli_spec_gen_within .x28 .x7 w28 ((bs[i]'hi).zeroExtend 64)
+    (4 : BitVec 6) (A + 4 + 4) (by decide)
+  rw [hi_word_eq] at h2
+  have h3 := andi_spec_gen_within .x29 .x7 w29 ((bs[i]'hi).zeroExtend 64)
+    (15 : BitVec 12) (A + 4 + 4 + 4) (by decide)
+  rw [lo_word_eq] at h3
+  have h4 := bytesRegion_sb_within .x31 .x28 dst
+    (BitVec.ofNat 64 ((bs[i]'hi).toNat / 16)) (A + 4 + 4 + 4 + 4) W p
+    hdalign (by omega) (by omega) hdvalid0
+  rw [hi64_truncate_eq] at h4
+  have h5 := bytesRegion_sb1_within .x31 .x29 dst
+    (BitVec.ofNat 64 ((bs[i]'hi).toNat % 16)) (A + 4 + 4 + 4 + 4 + 4)
+    (W.set p (highNibble (bs[i]'hi))) p
+    hdalign (by rw [List.length_set]; omega) (by omega) hdvalid1
+  rw [lo64_truncate_eq] at h5
+  have h6 := addi_spec_gen_same_within .x31 (dst + BitVec.ofNat 64 p)
+    (2 : BitVec 12) (A + 4 + 4 + 4 + 4 + 4 + 4) (by decide)
+  rw [add_ofNat_sext2] at h6
+  have h7 := addi_spec_gen_same_within .x30 (BitVec.ofNat 64 p)
+    (2 : BitVec 12) (A + 4 + 4 + 4 + 4 + 4 + 4 + 4) (by decide)
+  rw [ofNat_sext2] at h7
+  have h8 := addi_spec_gen_same_within .x5 (BitVec.ofNat 64 i)
+    (1 : BitVec 12) (A + 4 + 4 + 4 + 4 + 4 + 4 + 4 + 4) (by decide)
+  rw [ofNat_sext1] at h8
+  rw [hbi]
+  runBlock h0 h1 h2 h3 h4 h5 h6 h7 h8
+
+/-- The loop invariant at cursor `i` (`1 ≤ i`): the first `i - 1` tail
+    bytes have been unpacked into the window, count and cursor are at
+    `c0 + 2 * (i - 1)`, and the scratch registers hold the entry values
+    (`i = 1`) or the previous iteration's values. -/
+def hdnInv (src dst : Word) (bs orig : List (BitVec 8))
+    (e6 e7 e28 e29 : Word) (i : Nat) : Assertion :=
+  (.x8 ↦ᵣ src) **
+  (.x6 ↦ᵣ (if i ≤ 1 then e6 else src + BitVec.ofNat 64 (i - 1))) **
+  (.x7 ↦ᵣ (if i ≤ 1 then e7 else (bs.getD (i - 1) 0).zeroExtend 64)) **
+  (.x28 ↦ᵣ (if i ≤ 1 then e28
+    else BitVec.ofNat 64 ((bs.getD (i - 1) 0).toNat / 16))) **
+  (.x29 ↦ᵣ (if i ≤ 1 then e29
+    else BitVec.ofNat 64 ((bs.getD (i - 1) 0).toNat % 16))) **
+  (.x30 ↦ᵣ BitVec.ofNat 64 (hdnC0 bs + 2 * (i - 1))) **
+  (.x31 ↦ᵣ (dst + BitVec.ofNat 64 (hdnC0 bs + 2 * (i - 1)))) **
+  bytesRegion src bs ** bytesRegion dst (hdnWin bs orig (i - 1))
+
+private theorem pcFree_hdnInv (src dst : Word) (bs orig : List (BitVec 8))
+    (e6 e7 e28 e29 : Word) (i : Nat) :
+    (hdnInv src dst bs orig e6 e7 e28 e29 i).pcFree := by
+  unfold hdnInv
+  exact pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs
+    (pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs
+      (pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs
+        (pcFree_sepConj pcFree_regIs (pcFree_sepConj
+          (bytesRegion_pcFree _ _) (bytesRegion_pcFree _ _))))))))
+
+/-- The per-iteration body triple `upLoop_spec` consumes: fall-through
+    (body 25) back to the header (body 24). -/
+private theorem loopBody_spec (base src dst : Word) (bs orig : List (BitVec 8))
+    (e6 e7 e28 e29 : Word) (i : Nat)
+    (h1i : 1 ≤ i) (hi : i < bs.length)
+    (hsalign : src.toNat % 8 = 0) (hsover : src.toNat + bs.length < 2 ^ 64)
+    (hsvalid : ∀ j, j < bs.length → isValidByteAccess (src + BitVec.ofNat 64 j) = true)
+    (hbuf : hdnC0 bs + 2 * (bs.length - 1) ≤ orig.length)
+    (hdalign : dst.toNat % 8 = 0) (hdover : dst.toNat + orig.length < 2 ^ 64)
+    (hdvalid : ∀ j, j < orig.length → isValidByteAccess (dst + BitVec.ofNat 64 j) = true) :
+    cpsTripleWithin 10 (bAt base 25) (bAt base 24) (hdnCr base)
+      ((.x5 ↦ᵣ BitVec.ofNat 64 i) ** (.x9 ↦ᵣ BitVec.ofNat 64 bs.length)
+        ** hdnInv src dst bs orig e6 e7 e28 e29 i)
+      ((.x5 ↦ᵣ BitVec.ofNat 64 (i + 1)) ** (.x9 ↦ᵣ BitVec.ofNat 64 bs.length)
+        ** hdnInv src dst bs orig e6 e7 e28 e29 (i + 1)) := by
+  have hc0 : hdnC0 bs ≤ 1 := by unfold hdnC0; split <;> omega
+  have hplen : hdnC0 bs + 2 * (i - 1) + 1 < orig.length := by omega
+  have hwinlen : (hdnWin bs orig (i - 1)).length = orig.length :=
+    hdnWin_zero_length bs orig (i - 1)
+  -- The straight-line core over the real bytes.
+  have hcore := loopCore (bAt base 25) src dst bs (hdnWin bs orig (i - 1)) i
+    (hdnC0 bs + 2 * (i - 1))
+    (if i ≤ 1 then e6 else src + BitVec.ofNat 64 (i - 1))
+    (if i ≤ 1 then e7 else (bs.getD (i - 1) 0).zeroExtend 64)
+    (if i ≤ 1 then e28 else BitVec.ofNat 64 ((bs.getD (i - 1) 0).toNat / 16))
+    (if i ≤ 1 then e29 else BitVec.ofNat 64 ((bs.getD (i - 1) 0).toNat % 16))
+    hi hsalign hsover (hsvalid i hi)
+    (by rw [hwinlen]; omega) hdalign (by rw [hwinlen]; omega)
+    (hdvalid _ (by omega)) (hdvalid _ (by omega))
+  -- Rewrite the window step and the tail-byte bridge.
+  have hstep := hdnWin_step bs orig (i - 1)
+  rw [getD_drop1 bs i h1i] at hstep
+  rw [show i - 1 + 1 = i from by omega] at hstep
+  rw [hstep] at hcore
+  -- Lift into the routine CodeReq.
+  have hexit : bAt base 25 + 4 + 4 + 4 + 4 + 4 + 4 + 4 + 4 + 4 = bAt base 34 := by
+    simp only [bAt, BitVec.add_assoc]
+    congr 1
+  rw [hexit] at hcore
+  have hlift := liftSeg base 25 (seg := loopProg) (by rfl) (by decide) hcore
+  -- The back-edge.
+  have hjal := jal0_spec_pcFree (-40 : BitVec 21) (bAt base 34)
+    (P := (.x5 ↦ᵣ BitVec.ofNat 64 (i + 1)) ** (.x8 ↦ᵣ src)
+      ** (.x6 ↦ᵣ (src + BitVec.ofNat 64 i))
+      ** (.x7 ↦ᵣ ((bs.getD i 0).zeroExtend 64))
+      ** (.x28 ↦ᵣ BitVec.ofNat 64 ((bs.getD i 0).toNat / 16))
+      ** (.x29 ↦ᵣ BitVec.ofNat 64 ((bs.getD i 0).toNat % 16))
+      ** (.x30 ↦ᵣ BitVec.ofNat 64 (hdnC0 bs + 2 * (i - 1) + 2))
+      ** (.x31 ↦ᵣ (dst + BitVec.ofNat 64 (hdnC0 bs + 2 * (i - 1) + 2)))
+      ** bytesRegion src bs ** bytesRegion dst (hdnWin bs orig i))
+    (hP := pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs
+      (pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs
+        (pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs
+          (pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs
+            (pcFree_sepConj (bytesRegion_pcFree _ _)
+              (bytesRegion_pcFree _ _))))))))))
+  rw [bAt_jal_back40 base] at hjal
+  have hjal' := cpsTripleWithin_extend_code
+    (memAt base 34 (.JAL .x0 (-40 : BitVec 21)) (by decide) (by rfl)) hjal
+  -- core ; jal, then frame x9 and reshape into the invariant.
+  have hseq := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp)
+    hlift hjal'
+  have hframed := cpsTripleWithin_frameR (.x9 ↦ᵣ BitVec.ofNat 64 bs.length)
+    pcFree_regIs hseq
+  refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_) hframed
+  · unfold hdnInv at hp
+    xperm_hyp hp
+  · unfold hdnInv
+    rw [if_neg (by omega : ¬ i + 1 ≤ 1), if_neg (by omega : ¬ i + 1 ≤ 1),
+      if_neg (by omega : ¬ i + 1 ≤ 1), if_neg (by omega : ¬ i + 1 ≤ 1),
+      show i + 1 - 1 = i from by omega,
+      show hdnC0 bs + 2 * i = hdnC0 bs + 2 * (i - 1) + 2 from by omega]
+    xperm_hyp hq
+
+/-- The whole nibble loop, from the header at cursor 1 to the exit at
+    cursor `len` (`upLoop_spec` instance on the emitted `bgeu`/back-edge). -/
+theorem loop_spec (base src dst : Word) (bs orig : List (BitVec 8))
+    (e6 e7 e28 e29 : Word)
+    (hlen1 : 1 ≤ bs.length)
+    (hsalign : src.toNat % 8 = 0) (hsover : src.toNat + bs.length < 2 ^ 64)
+    (hsvalid : ∀ j, j < bs.length → isValidByteAccess (src + BitVec.ofNat 64 j) = true)
+    (hbuf : hdnC0 bs + 2 * (bs.length - 1) ≤ orig.length)
+    (hdalign : dst.toNat % 8 = 0) (hdover : dst.toNat + orig.length < 2 ^ 64)
+    (hdvalid : ∀ j, j < orig.length → isValidByteAccess (dst + BitVec.ofNat 64 j) = true) :
+    cpsTripleWithin ((bs.length - 1) * 11 + 1) (bAt base 24) (bAt base 35)
+      (hdnCr base)
+      ((.x5 ↦ᵣ BitVec.ofNat 64 1) ** (.x9 ↦ᵣ BitVec.ofNat 64 bs.length)
+        ** hdnInv src dst bs orig e6 e7 e28 e29 1)
+      ((.x5 ↦ᵣ BitVec.ofNat 64 bs.length) ** (.x9 ↦ᵣ BitVec.ofNat 64 bs.length)
+        ** hdnInv src dst bs orig e6 e7 e28 e29 bs.length) := by
+  have h := upLoop_spec (hdnCr base) (bAt base 24) (bAt base 35) .x5 .x9
+    (44 : BitVec 13) 10 bs.length
+    (hdnInv src dst bs orig e6 e7 e28 e29)
+    (by omega)
+    (by
+      show bAt base 24 + signExtend13 (44 : BitVec 13) = bAt base 35
+      simp only [bAt, BitVec.add_assoc]
+      congr 1)
+    (fun n => pcFree_hdnInv src dst bs orig e6 e7 e28 e29 n)
+    (memAt base 24 (.BGEU .x5 .x9 (44 : BitVec 13)) (by decide) (by rfl))
+    1 hlen1
+    (fun i h1i hi => by
+      have h := loopBody_spec base src dst bs orig e6 e7 e28 e29 i h1i hi
+        hsalign hsover hsvalid hbuf hdalign hdover hdvalid
+      rw [← bAt_succ base 24] at h
+      exact h)
+  exact cpsTripleWithin_mono_nSteps (by omega) h
+
+
+end HpDecodeNibblesSAsm
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/HpDecodeNibblesSAsmPaths.lean
+++ b/EvmAsm/Codegen/Programs/HpDecodeNibblesSAsmPaths.lean
@@ -1,0 +1,1459 @@
+/-
+  EvmAsm.Codegen.Programs.HpDecodeNibblesSAsmPaths
+
+  Path assembly + whole-routine contract for the verified byte-transparent
+  `hp_decode_nibbles` port (bead evm-asm-4ch8f.16.3) — the five control
+  paths over the segment/loop triples of `HpDecodeNibblesSAsm.lean`, the
+  unified single-exit body, and the `abiFrame_spec` wrap
+  (`hp_decode_nibbles_spec`).  Split from the base module for the file-size
+  gate; see that file's header for the routine and model documentation.
+-/
+
+import EvmAsm.Codegen.Programs.HpDecodeNibblesSAsm
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+
+namespace HpDecodeNibblesSAsm
+
+open BytesToNibblesSAsm (highNibble lowNibble nibblePair nibblePrefix
+  length_nibblePrefix)
+
+/-! ## Path assembly -/
+
+/-- The full body footprint at one program point (fixed atom order). -/
+private def hdnFoot (src dst cnt isl : Word) (srcBytes : List (BitVec 8))
+    (x10v x8v x11v x9v x12v x18v x13v x19v x14v x20v : Word)
+    (w5 w6 w7 w28 w29 w30 w31 : Word)
+    (bufW : List (BitVec 8)) (cntW islW : Word) : Assertion :=
+  (.x10 ↦ᵣ x10v) ** (.x8 ↦ᵣ x8v) ** (.x11 ↦ᵣ x11v) ** (.x9 ↦ᵣ x9v)
+  ** (.x12 ↦ᵣ x12v) ** (.x18 ↦ᵣ x18v) ** (.x13 ↦ᵣ x13v) ** (.x19 ↦ᵣ x19v)
+  ** (.x14 ↦ᵣ x14v) ** (.x20 ↦ᵣ x20v)
+  ** (.x5 ↦ᵣ w5) ** (.x6 ↦ᵣ w6) ** (.x7 ↦ᵣ w7) ** (.x28 ↦ᵣ w28)
+  ** (.x29 ↦ᵣ w29) ** (.x30 ↦ᵣ w30) ** (.x31 ↦ᵣ w31) ** (Reg.x0 ↦ᵣ (0 : Word))
+  ** bytesRegion src srcBytes ** bytesRegion dst bufW
+  ** (cnt ↦ₘ cntW) ** (isl ↦ₘ islW)
+
+private theorem pcFree_hdnFoot (src dst cnt isl : Word) (srcBytes : List (BitVec 8))
+    (x10v x8v x11v x9v x12v x18v x13v x19v x14v x20v : Word)
+    (w5 w6 w7 w28 w29 w30 w31 : Word)
+    (bufW : List (BitVec 8)) (cntW islW : Word) :
+    (hdnFoot src dst cnt isl srcBytes x10v x8v x11v x9v x12v x18v x13v x19v
+      x14v x20v w5 w6 w7 w28 w29 w30 w31 bufW cntW islW).pcFree := by
+  unfold hdnFoot
+  repeat' first
+    | exact pcFree_regIs
+    | exact pcFree_memIs
+    | exact bytesRegion_pcFree _ _
+    | apply pcFree_sepConj
+
+/-- Path A: `len = 0` — the first guard branches straight to the fail
+    tail; nothing is written. -/
+private theorem pathA_spec (base src dst cnt isl : Word)
+    (srcBytes bufOrig : List (BitVec 8))
+    (v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl : Word)
+    (s8 s9 s18 s19 s20 : Word)
+    (hlen0 : srcBytes.length = 0) :
+    cpsTripleWithin 7 (bAt base 0) (bAt base 39) (hdnCr base)
+      (hdnFoot src dst cnt isl srcBytes src s8 (BitVec.ofNat 64 srcBytes.length)
+        s9 dst s18 cnt s19 isl s20 v5 v6 v7 v28 v29 v30 v31 bufOrig oldCnt oldIsl)
+      (hdnFoot src dst cnt isl srcBytes (1 : Word) src
+        (BitVec.ofNat 64 srcBytes.length) (BitVec.ofNat 64 srcBytes.length)
+        dst dst cnt cnt isl isl v5 v6 v7 v28 v29 v30 v31 bufOrig oldCnt oldIsl) := by
+  have h0 := seg0_spec base src (BitVec.ofNat 64 srcBytes.length) dst cnt isl
+    s8 s9 s18 s19 s20
+  have h1 := br1_taken base (BitVec.ofNat 64 srcBytes.length)
+    (by rw [hlen0]; rfl)
+  have h2 := fail38_spec base src
+  -- Widen each link to the full footprint and chain.
+  have F0 := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x28 ↦ᵣ v28)
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+      ** (Reg.x0 ↦ᵣ (0 : Word)) ** bytesRegion src srcBytes
+      ** bytesRegion dst bufOrig ** (cnt ↦ₘ oldCnt) ** (isl ↦ₘ oldIsl))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h0
+  have F1 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ src) ** (.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x28 ↦ᵣ v28)
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+      ** bytesRegion src srcBytes ** bytesRegion dst bufOrig
+      ** (cnt ↦ₘ oldCnt) ** (isl ↦ₘ oldIsl))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h1
+  have F2 := cpsTripleWithin_frameR
+    ((.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x28 ↦ᵣ v28)
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+      ** (Reg.x0 ↦ᵣ (0 : Word)) ** bytesRegion src srcBytes
+      ** bytesRegion dst bufOrig ** (cnt ↦ₘ oldCnt) ** (isl ↦ₘ oldIsl))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h2
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) F0 F1
+  have s2 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) s1 F2
+  refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_)
+    (cpsTripleWithin_mono_nSteps (by omega) s2)
+  · unfold hdnFoot at hp
+    xperm_hyp hp
+  · unfold hdnFoot
+    xperm_hyp hq
+
+
+/-- Path B: `len ≠ 0`, invalid flag nibble (`hi ≥ 4`) — reject before the
+    is-leaf store. -/
+private theorem pathB_spec (base src dst cnt isl : Word)
+    (srcBytes bufOrig : List (BitVec 8))
+    (v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl : Word)
+    (s8 s9 s18 s19 s20 : Word)
+    (hlen : 0 < srcBytes.length)
+    (hhi : 4 ≤ (srcBytes.getD 0 0).toNat / 16)
+    (hsalign : src.toNat % 8 = 0) (hsover : src.toNat + srcBytes.length < 2 ^ 64)
+    (hsvalid : ∀ j, j < srcBytes.length →
+      isValidByteAccess (src + BitVec.ofNat 64 j) = true) :
+    cpsTripleWithin 12 (bAt base 0) (bAt base 39) (hdnCr base)
+      (hdnFoot src dst cnt isl srcBytes src s8 (BitVec.ofNat 64 srcBytes.length)
+        s9 dst s18 cnt s19 isl s20 v5 v6 v7 v28 v29 v30 v31 bufOrig oldCnt oldIsl)
+      (hdnFoot src dst cnt isl srcBytes (1 : Word) src
+        (BitVec.ofNat 64 srcBytes.length) (BitVec.ofNat 64 srcBytes.length)
+        dst dst cnt cnt isl isl
+        ((srcBytes.getD 0 0).zeroExtend 64)
+        (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16))
+        (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16))
+        (4 : Word) v29 v30 v31 bufOrig oldCnt oldIsl) := by
+  have hlen64 : srcBytes.length < 2 ^ 64 := by omega
+  have h0 := seg0_spec base src (BitVec.ofNat 64 srcBytes.length) dst cnt isl
+    s8 s9 s18 s19 s20
+  have h1 := br1_ntaken base (BitVec.ofNat 64 srcBytes.length)
+    (by
+      intro heq
+      have h2 := congrArg BitVec.toNat heq
+      rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt hlen64] at h2
+      rw [show (0 : Word).toNat = 0 from rfl] at h2
+      omega)
+  have h2 := seg1_spec base src srcBytes v5 v6 v7 v28 hlen hsalign hsover
+    (hsvalid 0 hlen)
+  have h3 := br2_taken base (srcBytes.getD 0 0) hhi
+  have h4 := fail38_spec base src
+  -- Chain with full-footprint framing.
+  have pcF : ∀ (P : Assertion), P.pcFree → P.pcFree := fun _ h => h
+  have F0 := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x28 ↦ᵣ v28)
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+      ** (Reg.x0 ↦ᵣ (0 : Word)) ** bytesRegion src srcBytes
+      ** bytesRegion dst bufOrig ** (cnt ↦ₘ oldCnt) ** (isl ↦ₘ oldIsl))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h0
+  have F1 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ src) ** (.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x28 ↦ᵣ v28)
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+      ** bytesRegion src srcBytes ** bytesRegion dst bufOrig
+      ** (cnt ↦ₘ oldCnt) ** (isl ↦ₘ oldIsl))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h1
+  have F2 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+      ** (Reg.x0 ↦ᵣ (0 : Word))
+      ** bytesRegion dst bufOrig ** (cnt ↦ₘ oldCnt) ** (isl ↦ₘ oldIsl))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h2
+  have F3 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ src) ** (.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x5 ↦ᵣ ((srcBytes.getD 0 0).zeroExtend 64))
+      ** (.x7 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16))
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+      ** (Reg.x0 ↦ᵣ (0 : Word))
+      ** bytesRegion src srcBytes ** bytesRegion dst bufOrig
+      ** (cnt ↦ₘ oldCnt) ** (isl ↦ₘ oldIsl))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h3
+  have F4 := cpsTripleWithin_frameR
+    ((.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x5 ↦ᵣ ((srcBytes.getD 0 0).zeroExtend 64))
+      ** (.x6 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16))
+      ** (.x7 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16))
+      ** (.x28 ↦ᵣ (4 : Word))
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+      ** (Reg.x0 ↦ᵣ (0 : Word))
+      ** bytesRegion src srcBytes ** bytesRegion dst bufOrig
+      ** (cnt ↦ₘ oldCnt) ** (isl ↦ₘ oldIsl))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h4
+  clear pcF
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) F0 F1
+  have s2 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) s1 F2
+  have s3 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) s2 F3
+  have s4 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) s3 F4
+  refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_)
+    (cpsTripleWithin_mono_nSteps (by omega) s4)
+  · unfold hdnFoot at hp
+    xperm_hyp hp
+  · unfold hdnFoot
+    xperm_hyp hq
+
+
+/-- Shared prefix of paths C/D/E: body 0–14 (`len ≠ 0`, valid flag, is-leaf
+    flag stored, `x6` reduced to the parity bit). -/
+private theorem prefix2_spec (base src dst cnt isl : Word)
+    (srcBytes bufOrig : List (BitVec 8))
+    (v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl : Word)
+    (s8 s9 s18 s19 s20 : Word)
+    (hlen : 0 < srcBytes.length)
+    (hhi : (srcBytes.getD 0 0).toNat / 16 < 4)
+    (hsalign : src.toNat % 8 = 0) (hsover : src.toNat + srcBytes.length < 2 ^ 64)
+    (hsvalid : ∀ j, j < srcBytes.length →
+      isValidByteAccess (src + BitVec.ofNat 64 j) = true) :
+    cpsTripleWithin 15 (bAt base 0) (bAt base 15) (hdnCr base)
+      (hdnFoot src dst cnt isl srcBytes src s8 (BitVec.ofNat 64 srcBytes.length)
+        s9 dst s18 cnt s19 isl s20 v5 v6 v7 v28 v29 v30 v31 bufOrig oldCnt oldIsl)
+      (hdnFoot src dst cnt isl srcBytes src src
+        (BitVec.ofNat 64 srcBytes.length) (BitVec.ofNat 64 srcBytes.length)
+        dst dst cnt cnt isl isl
+        ((srcBytes.getD 0 0).zeroExtend 64)
+        (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 % 2))
+        (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16))
+        (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))
+        v29 v30 v31 bufOrig oldCnt
+        (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))) := by
+  have hlen64 : srcBytes.length < 2 ^ 64 := by omega
+  have h0 := seg0_spec base src (BitVec.ofNat 64 srcBytes.length) dst cnt isl
+    s8 s9 s18 s19 s20
+  have h1 := br1_ntaken base (BitVec.ofNat 64 srcBytes.length)
+    (by
+      intro heq
+      have h2 := congrArg BitVec.toNat heq
+      rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt hlen64] at h2
+      rw [show (0 : Word).toNat = 0 from rfl] at h2
+      omega)
+  have h2 := seg1_spec base src srcBytes v5 v6 v7 v28 hlen hsalign hsover
+    (hsvalid 0 hlen)
+  have h3 := br2_ntaken base (srcBytes.getD 0 0) hhi
+  have h4 := seg2_spec base isl oldIsl (srcBytes.getD 0 0) (4 : Word)
+  have F0 := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x28 ↦ᵣ v28)
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+      ** (Reg.x0 ↦ᵣ (0 : Word)) ** bytesRegion src srcBytes
+      ** bytesRegion dst bufOrig ** (cnt ↦ₘ oldCnt) ** (isl ↦ₘ oldIsl))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h0
+  have F1 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ src) ** (.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x28 ↦ᵣ v28)
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+      ** bytesRegion src srcBytes ** bytesRegion dst bufOrig
+      ** (cnt ↦ₘ oldCnt) ** (isl ↦ₘ oldIsl))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h1
+  have F2 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+      ** (Reg.x0 ↦ᵣ (0 : Word))
+      ** bytesRegion dst bufOrig ** (cnt ↦ₘ oldCnt) ** (isl ↦ₘ oldIsl))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h2
+  have F3 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ src) ** (.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x5 ↦ᵣ ((srcBytes.getD 0 0).zeroExtend 64))
+      ** (.x7 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16))
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+      ** (Reg.x0 ↦ᵣ (0 : Word))
+      ** bytesRegion src srcBytes ** bytesRegion dst bufOrig
+      ** (cnt ↦ₘ oldCnt) ** (isl ↦ₘ oldIsl))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h3
+  have F4 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ src) ** (.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl)
+      ** (.x5 ↦ᵣ ((srcBytes.getD 0 0).zeroExtend 64))
+      ** (.x7 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16))
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+      ** (Reg.x0 ↦ᵣ (0 : Word))
+      ** bytesRegion src srcBytes ** bytesRegion dst bufOrig
+      ** (cnt ↦ₘ oldCnt))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h4
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) F0 F1
+  have s2 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) s1 F2
+  have s3 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) s2 F3
+  have s4 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) s3 F4
+  refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_)
+    (cpsTripleWithin_mono_nSteps (by omega) s4)
+  · unfold hdnFoot at hp
+    xperm_hyp hp
+  · unfold hdnFoot
+    xperm_hyp hq
+
+/-- Path C: even parity with a non-zero padding nibble — the strict check
+    rejects AFTER the is-leaf store. -/
+private theorem pathC_spec (base src dst cnt isl : Word)
+    (srcBytes bufOrig : List (BitVec 8))
+    (v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl : Word)
+    (s8 s9 s18 s19 s20 : Word)
+    (hlen : 0 < srcBytes.length)
+    (hhi : (srcBytes.getD 0 0).toNat / 16 < 4)
+    (heven : (srcBytes.getD 0 0).toNat / 16 % 2 = 0)
+    (hlo : (srcBytes.getD 0 0).toNat % 16 ≠ 0)
+    (hsalign : src.toNat % 8 = 0) (hsover : src.toNat + srcBytes.length < 2 ^ 64)
+    (hsvalid : ∀ j, j < srcBytes.length →
+      isValidByteAccess (src + BitVec.ofNat 64 j) = true) :
+    cpsTripleWithin 18 (bAt base 0) (bAt base 39) (hdnCr base)
+      (hdnFoot src dst cnt isl srcBytes src s8 (BitVec.ofNat 64 srcBytes.length)
+        s9 dst s18 cnt s19 isl s20 v5 v6 v7 v28 v29 v30 v31 bufOrig oldCnt oldIsl)
+      (hdnFoot src dst cnt isl srcBytes (1 : Word) src
+        (BitVec.ofNat 64 srcBytes.length) (BitVec.ofNat 64 srcBytes.length)
+        dst dst cnt cnt isl isl
+        ((srcBytes.getD 0 0).zeroExtend 64)
+        (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 % 2))
+        (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16))
+        (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))
+        v29 v30 v31 bufOrig oldCnt
+        (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))) := by
+  have hpre := prefix2_spec base src dst cnt isl srcBytes bufOrig
+    v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl s8 s9 s18 s19 s20
+    hlen hhi hsalign hsover hsvalid
+  have h5 := br3_taken base (srcBytes.getD 0 0) heven
+  have h6 := br4_taken base (srcBytes.getD 0 0) hlo
+  have h7 := fail38_spec base src
+  have Fb3 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ src) ** (.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x5 ↦ᵣ ((srcBytes.getD 0 0).zeroExtend 64))
+      ** (.x7 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16))
+      ** (.x28 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+      ** bytesRegion src srcBytes ** bytesRegion dst bufOrig
+      ** (cnt ↦ₘ oldCnt)
+      ** (isl ↦ₘ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2)))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h5
+  have Fb4 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ src) ** (.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x5 ↦ᵣ ((srcBytes.getD 0 0).zeroExtend 64))
+      ** (.x6 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 % 2))
+      ** (.x28 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+      ** bytesRegion src srcBytes ** bytesRegion dst bufOrig
+      ** (cnt ↦ₘ oldCnt)
+      ** (isl ↦ₘ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2)))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h6
+  have Fb5 := cpsTripleWithin_frameR
+    ((.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x5 ↦ᵣ ((srcBytes.getD 0 0).zeroExtend 64))
+      ** (.x6 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 % 2))
+      ** (.x7 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16))
+      ** (.x28 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+      ** (Reg.x0 ↦ᵣ (0 : Word))
+      ** bytesRegion src srcBytes ** bytesRegion dst bufOrig
+      ** (cnt ↦ₘ oldCnt)
+      ** (isl ↦ₘ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2)))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h7
+  have s5 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by unfold hdnFoot at hp; xperm_hyp hp) hpre Fb3
+  have s6 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) s5 Fb4
+  have s7 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) s6 Fb5
+  refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_)
+    (cpsTripleWithin_mono_nSteps (by omega) s7)
+  · exact hp
+  · unfold hdnFoot
+    xperm_hyp hq
+
+
+/-! ## Success-path window bridges -/
+
+private theorem hdnOdd_true_of (bs : List (BitVec 8))
+    (h : (hdnB0 bs).toNat / 16 % 2 = 1) : hdnOdd bs = true := by
+  unfold hdnOdd
+  exact decide_eq_true h
+
+private theorem hdnOdd_false_of (bs : List (BitVec 8))
+    (h : (hdnB0 bs).toNat / 16 % 2 = 0) : hdnOdd bs = false := by
+  unfold hdnOdd
+  exact decide_eq_false (by omega)
+
+private theorem hdnC0_odd (bs : List (BitVec 8))
+    (h : (hdnB0 bs).toNat / 16 % 2 = 1) : hdnC0 bs = 1 := by
+  unfold hdnC0
+  rw [hdnOdd_true_of bs h]
+  rfl
+
+private theorem hdnC0_even (bs : List (BitVec 8))
+    (h : (hdnB0 bs).toNat / 16 % 2 = 0) : hdnC0 bs = 0 := by
+  unfold hdnC0
+  rw [hdnOdd_false_of bs h]
+  rfl
+
+private theorem hdnWin_zero_odd (bs orig : List (BitVec 8))
+    (h : (hdnB0 bs).toNat / 16 % 2 = 1) :
+    hdnWin bs orig 0 = orig.set 0 (lowNibble (hdnB0 bs)) := by
+  unfold hdnWin hdnInitNibs
+  rw [hdnOdd_true_of bs h]
+  show setBytes orig 0 ([lowNibble (hdnB0 bs)] ++ nibblePrefix (bs.drop 1) 0) = _
+  rw [show nibblePrefix (bs.drop 1) 0 = [] from rfl, List.append_nil]
+  rfl
+
+private theorem hdnWin_zero_even (bs orig : List (BitVec 8))
+    (h : (hdnB0 bs).toNat / 16 % 2 = 0) :
+    hdnWin bs orig 0 = orig := by
+  unfold hdnWin hdnInitNibs
+  rw [hdnOdd_false_of bs h]
+  show setBytes orig 0 ([] ++ nibblePrefix (bs.drop 1) 0) = _
+  rw [show nibblePrefix (bs.drop 1) 0 = [] from rfl]
+  rfl
+
+/-- Path E: even parity, zero padding nibble — the full success run
+    through the loop. -/
+private theorem pathE_spec (base src dst cnt isl : Word)
+    (srcBytes bufOrig : List (BitVec 8))
+    (v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl : Word)
+    (s8 s9 s18 s19 s20 : Word)
+    (hlen : 0 < srcBytes.length)
+    (hhi : (srcBytes.getD 0 0).toNat / 16 < 4)
+    (heven : (srcBytes.getD 0 0).toNat / 16 % 2 = 0)
+    (hlo : (srcBytes.getD 0 0).toNat % 16 = 0)
+    (hsalign : src.toNat % 8 = 0) (hsover : src.toNat + srcBytes.length < 2 ^ 64)
+    (hsvalid : ∀ j, j < srcBytes.length →
+      isValidByteAccess (src + BitVec.ofNat 64 j) = true)
+    (hbuf : hdnC0 srcBytes + 2 * (srcBytes.length - 1) ≤ bufOrig.length)
+    (hdalign : dst.toNat % 8 = 0) (hdover : dst.toNat + bufOrig.length < 2 ^ 64)
+    (hdvalid : ∀ j, j < bufOrig.length →
+      isValidByteAccess (dst + BitVec.ofNat 64 j) = true) :
+    cpsTripleWithin (15 + 5 + ((srcBytes.length - 1) * 11 + 1) + 3 + 5)
+      (bAt base 0) (bAt base 39) (hdnCr base)
+      (hdnFoot src dst cnt isl srcBytes src s8 (BitVec.ofNat 64 srcBytes.length)
+        s9 dst s18 cnt s19 isl s20 v5 v6 v7 v28 v29 v30 v31 bufOrig oldCnt oldIsl)
+      (hdnFoot src dst cnt isl srcBytes (0 : Word) src
+        (BitVec.ofNat 64 srcBytes.length) (BitVec.ofNat 64 srcBytes.length)
+        dst dst cnt cnt isl isl
+        (BitVec.ofNat 64 srcBytes.length)
+        (if srcBytes.length ≤ 1 then BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 % 2)
+          else src + BitVec.ofNat 64 (srcBytes.length - 1))
+        (if srcBytes.length ≤ 1 then BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16)
+          else (srcBytes.getD (srcBytes.length - 1) 0).zeroExtend 64)
+        (if srcBytes.length ≤ 1 then BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2)
+          else BitVec.ofNat 64 ((srcBytes.getD (srcBytes.length - 1) 0).toNat / 16))
+        (if srcBytes.length ≤ 1 then v29
+          else BitVec.ofNat 64 ((srcBytes.getD (srcBytes.length - 1) 0).toNat % 16))
+        (BitVec.ofNat 64 (hdnC0 srcBytes + 2 * (srcBytes.length - 1)))
+        (dst + BitVec.ofNat 64 (hdnC0 srcBytes + 2 * (srcBytes.length - 1)))
+        (hdnWin srcBytes bufOrig (srcBytes.length - 1))
+        (BitVec.ofNat 64 (hdnC0 srcBytes + 2 * (srcBytes.length - 1)))
+        (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))) := by
+  have hc0 : hdnC0 srcBytes = 0 := hdnC0_even srcBytes heven
+  have hpre := prefix2_spec base src dst cnt isl srcBytes bufOrig
+    v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl s8 s9 s18 s19 s20
+    hlen hhi hsalign hsover hsvalid
+  have h5 := br3_taken base (srcBytes.getD 0 0) heven
+  have h6 := br4_ntaken base (srcBytes.getD 0 0) hlo
+  have h7 := seg4even_spec base dst v30 v31
+  have h8 := seg5_spec base ((srcBytes.getD 0 0).zeroExtend 64)
+  have hLoop := loop_spec base src dst srcBytes bufOrig
+    (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 % 2))
+    (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16))
+    (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))
+    v29 hlen hsalign hsover hsvalid hbuf hdalign hdover hdvalid
+  -- Normalize the loop-entry invariant (`i = 1`).
+  unfold hdnInv at hLoop
+  rw [if_pos (Nat.le_refl 1), if_pos (Nat.le_refl 1), if_pos (Nat.le_refl 1),
+    if_pos (Nat.le_refl 1), show (1 : Nat) - 1 = 0 from rfl,
+    show hdnC0 srcBytes + 2 * 0 = 0 from by rw [hc0],
+    add_ofNat_zero dst,
+    show (BitVec.ofNat 64 0 : Word) = (0 : Word) from rfl,
+    hdnWin_zero_even srcBytes bufOrig heven,
+    show (BitVec.ofNat 64 1 : Word) = (1 : Word) from rfl] at hLoop
+  have h9 := seg6_spec base cnt oldCnt
+    (BitVec.ofNat 64 (hdnC0 srcBytes + 2 * (srcBytes.length - 1))) src
+  -- Frames.
+  have Fb3 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ src) ** (.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x5 ↦ᵣ ((srcBytes.getD 0 0).zeroExtend 64))
+      ** (.x7 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16))
+      ** (.x28 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+      ** bytesRegion src srcBytes ** bytesRegion dst bufOrig
+      ** (cnt ↦ₘ oldCnt)
+      ** (isl ↦ₘ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2)))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h5
+  have Fb4 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ src) ** (.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x5 ↦ᵣ ((srcBytes.getD 0 0).zeroExtend 64))
+      ** (.x6 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 % 2))
+      ** (.x28 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+      ** bytesRegion src srcBytes ** bytesRegion dst bufOrig
+      ** (cnt ↦ₘ oldCnt)
+      ** (isl ↦ₘ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2)))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h6
+  have Fb5 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ src) ** (.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x5 ↦ᵣ ((srcBytes.getD 0 0).zeroExtend 64))
+      ** (.x6 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 % 2))
+      ** (.x7 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16))
+      ** (.x28 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))
+      ** (.x29 ↦ᵣ v29) ** (Reg.x0 ↦ᵣ (0 : Word))
+      ** bytesRegion src srcBytes ** bytesRegion dst bufOrig
+      ** (cnt ↦ₘ oldCnt)
+      ** (isl ↦ₘ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2)))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h7
+  have Fb6 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ src) ** (.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x6 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 % 2))
+      ** (.x7 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16))
+      ** (.x28 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ (0 : Word)) ** (.x31 ↦ᵣ dst)
+      ** (Reg.x0 ↦ᵣ (0 : Word))
+      ** bytesRegion src srcBytes ** bytesRegion dst bufOrig
+      ** (cnt ↦ₘ oldCnt)
+      ** (isl ↦ₘ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2)))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h8
+  have FLoop := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl) ** (Reg.x0 ↦ᵣ (0 : Word))
+      ** (cnt ↦ₘ oldCnt)
+      ** (isl ↦ₘ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2)))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) hLoop
+  have Fb7 := cpsTripleWithin_frameR
+    ((.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x5 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x6 ↦ᵣ (if srcBytes.length ≤ 1
+          then BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 % 2)
+          else src + BitVec.ofNat 64 (srcBytes.length - 1)))
+      ** (.x7 ↦ᵣ (if srcBytes.length ≤ 1
+          then BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16)
+          else (srcBytes.getD (srcBytes.length - 1) 0).zeroExtend 64))
+      ** (.x28 ↦ᵣ (if srcBytes.length ≤ 1
+          then BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2)
+          else BitVec.ofNat 64 ((srcBytes.getD (srcBytes.length - 1) 0).toNat / 16)))
+      ** (.x29 ↦ᵣ (if srcBytes.length ≤ 1 then v29
+          else BitVec.ofNat 64 ((srcBytes.getD (srcBytes.length - 1) 0).toNat % 16)))
+      ** (.x31 ↦ᵣ (dst + BitVec.ofNat 64 (hdnC0 srcBytes + 2 * (srcBytes.length - 1))))
+      ** (Reg.x0 ↦ᵣ (0 : Word))
+      ** bytesRegion src srcBytes
+      ** bytesRegion dst (hdnWin srcBytes bufOrig (srcBytes.length - 1))
+      ** (isl ↦ₘ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2)))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h9
+  have s5 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by unfold hdnFoot at hp; xperm_hyp hp) hpre Fb3
+  have s6 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) s5 Fb4
+  have s7 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) s6 Fb5
+  have s8x := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) s7 Fb6
+  have s9x := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) s8x FLoop
+  have s10 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) s9x Fb7
+  refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_)
+    (cpsTripleWithin_mono_nSteps (by omega) s10)
+  · exact hp
+  · unfold hdnFoot
+    xperm_hyp hq
+
+
+/-- Path D: odd parity — head nibble stored, then the full success run. -/
+private theorem pathD_spec (base src dst cnt isl : Word)
+    (srcBytes bufOrig : List (BitVec 8))
+    (v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl : Word)
+    (s8 s9 s18 s19 s20 : Word)
+    (hlen : 0 < srcBytes.length)
+    (hhi : (srcBytes.getD 0 0).toNat / 16 < 4)
+    (hodd : (srcBytes.getD 0 0).toNat / 16 % 2 = 1)
+    (hsalign : src.toNat % 8 = 0) (hsover : src.toNat + srcBytes.length < 2 ^ 64)
+    (hsvalid : ∀ j, j < srcBytes.length →
+      isValidByteAccess (src + BitVec.ofNat 64 j) = true)
+    (hbuf : hdnC0 srcBytes + 2 * (srcBytes.length - 1) ≤ bufOrig.length)
+    (hbuf0 : 0 < bufOrig.length)
+    (hdalign : dst.toNat % 8 = 0) (hdover : dst.toNat + bufOrig.length < 2 ^ 64)
+    (hdvalid : ∀ j, j < bufOrig.length →
+      isValidByteAccess (dst + BitVec.ofNat 64 j) = true) :
+    cpsTripleWithin (15 + 6 + ((srcBytes.length - 1) * 11 + 1) + 3 + 5)
+      (bAt base 0) (bAt base 39) (hdnCr base)
+      (hdnFoot src dst cnt isl srcBytes src s8 (BitVec.ofNat 64 srcBytes.length)
+        s9 dst s18 cnt s19 isl s20 v5 v6 v7 v28 v29 v30 v31 bufOrig oldCnt oldIsl)
+      (hdnFoot src dst cnt isl srcBytes (0 : Word) src
+        (BitVec.ofNat 64 srcBytes.length) (BitVec.ofNat 64 srcBytes.length)
+        dst dst cnt cnt isl isl
+        (BitVec.ofNat 64 srcBytes.length)
+        (if srcBytes.length ≤ 1 then BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 % 2)
+          else src + BitVec.ofNat 64 (srcBytes.length - 1))
+        (if srcBytes.length ≤ 1 then BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16)
+          else (srcBytes.getD (srcBytes.length - 1) 0).zeroExtend 64)
+        (if srcBytes.length ≤ 1 then BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2)
+          else BitVec.ofNat 64 ((srcBytes.getD (srcBytes.length - 1) 0).toNat / 16))
+        (if srcBytes.length ≤ 1 then v29
+          else BitVec.ofNat 64 ((srcBytes.getD (srcBytes.length - 1) 0).toNat % 16))
+        (BitVec.ofNat 64 (hdnC0 srcBytes + 2 * (srcBytes.length - 1)))
+        (dst + BitVec.ofNat 64 (hdnC0 srcBytes + 2 * (srcBytes.length - 1)))
+        (hdnWin srcBytes bufOrig (srcBytes.length - 1))
+        (BitVec.ofNat 64 (hdnC0 srcBytes + 2 * (srcBytes.length - 1)))
+        (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))) := by
+  have hc1 : hdnC0 srcBytes = 1 := hdnC0_odd srcBytes hodd
+  have hpre := prefix2_spec base src dst cnt isl srcBytes bufOrig
+    v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl s8 s9 s18 s19 s20
+    hlen hhi hsalign hsover hsvalid
+  have h5 := br3_ntaken base (srcBytes.getD 0 0) (by omega)
+  have h6 := seg3odd_spec base dst (srcBytes.getD 0 0) bufOrig v30 v31
+    hbuf0 hdalign hdover (hdvalid 0 hbuf0)
+  rw [show (1 : Word) = BitVec.ofNat 64 1 from rfl] at h6
+  have h8 := seg5_spec base ((srcBytes.getD 0 0).zeroExtend 64)
+  rw [show (1 : Word) = BitVec.ofNat 64 1 from rfl] at h8
+  have hLoop := loop_spec base src dst srcBytes bufOrig
+    (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 % 2))
+    (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16))
+    (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))
+    v29 hlen hsalign hsover hsvalid hbuf hdalign hdover hdvalid
+  unfold hdnInv at hLoop
+  rw [if_pos (Nat.le_refl 1), if_pos (Nat.le_refl 1), if_pos (Nat.le_refl 1),
+    if_pos (Nat.le_refl 1), show (1 : Nat) - 1 = 0 from rfl,
+    show hdnC0 srcBytes + 2 * 0 = 1 from by rw [hc1],
+    hdnWin_zero_odd srcBytes bufOrig hodd,
+    show hdnB0 srcBytes = srcBytes.getD 0 0 from rfl] at hLoop
+  have h9 := seg6_spec base cnt oldCnt
+    (BitVec.ofNat 64 (hdnC0 srcBytes + 2 * (srcBytes.length - 1))) src
+  have Fb3 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ src) ** (.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x5 ↦ᵣ ((srcBytes.getD 0 0).zeroExtend 64))
+      ** (.x7 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16))
+      ** (.x28 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+      ** bytesRegion src srcBytes ** bytesRegion dst bufOrig
+      ** (cnt ↦ₘ oldCnt)
+      ** (isl ↦ₘ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2)))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h5
+  have Fb4 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ src) ** (.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x5 ↦ᵣ ((srcBytes.getD 0 0).zeroExtend 64))
+      ** (.x6 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 % 2))
+      ** (.x28 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))
+      ** (.x29 ↦ᵣ v29) ** (Reg.x0 ↦ᵣ (0 : Word))
+      ** bytesRegion src srcBytes
+      ** (cnt ↦ₘ oldCnt)
+      ** (isl ↦ₘ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2)))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h6
+  have hjal := jal19_spec base
+    (P := (.x10 ↦ᵣ src) ** (.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x5 ↦ᵣ ((srcBytes.getD 0 0).zeroExtend 64))
+      ** (.x6 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 % 2))
+      ** (.x7 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16))
+      ** (.x28 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ BitVec.ofNat 64 1)
+      ** (.x31 ↦ᵣ (dst + BitVec.ofNat 64 1)) ** (Reg.x0 ↦ᵣ (0 : Word))
+      ** bytesRegion src srcBytes
+      ** bytesRegion dst (bufOrig.set 0 (lowNibble (srcBytes.getD 0 0)))
+      ** (cnt ↦ₘ oldCnt)
+      ** (isl ↦ₘ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2)))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj)
+  have Fb6 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ src) ** (.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x6 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 % 2))
+      ** (.x7 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16))
+      ** (.x28 ↦ᵣ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))
+      ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ BitVec.ofNat 64 1)
+      ** (.x31 ↦ᵣ (dst + BitVec.ofNat 64 1)) ** (Reg.x0 ↦ᵣ (0 : Word))
+      ** bytesRegion src srcBytes
+      ** bytesRegion dst (bufOrig.set 0 (lowNibble (srcBytes.getD 0 0)))
+      ** (cnt ↦ₘ oldCnt)
+      ** (isl ↦ₘ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2)))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h8
+  have FLoop := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x19 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl) ** (Reg.x0 ↦ᵣ (0 : Word))
+      ** (cnt ↦ₘ oldCnt)
+      ** (isl ↦ₘ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2)))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) hLoop
+  have Fb7 := cpsTripleWithin_frameR
+    ((.x8 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x12 ↦ᵣ dst) ** (.x18 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt)
+      ** (.x14 ↦ᵣ isl) ** (.x20 ↦ᵣ isl)
+      ** (.x5 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+      ** (.x6 ↦ᵣ (if srcBytes.length ≤ 1
+          then BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 % 2)
+          else src + BitVec.ofNat 64 (srcBytes.length - 1)))
+      ** (.x7 ↦ᵣ (if srcBytes.length ≤ 1
+          then BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat % 16)
+          else (srcBytes.getD (srcBytes.length - 1) 0).zeroExtend 64))
+      ** (.x28 ↦ᵣ (if srcBytes.length ≤ 1
+          then BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2)
+          else BitVec.ofNat 64 ((srcBytes.getD (srcBytes.length - 1) 0).toNat / 16)))
+      ** (.x29 ↦ᵣ (if srcBytes.length ≤ 1 then v29
+          else BitVec.ofNat 64 ((srcBytes.getD (srcBytes.length - 1) 0).toNat % 16)))
+      ** (.x31 ↦ᵣ (dst + BitVec.ofNat 64 (hdnC0 srcBytes + 2 * (srcBytes.length - 1))))
+      ** (Reg.x0 ↦ᵣ (0 : Word))
+      ** bytesRegion src srcBytes
+      ** bytesRegion dst (hdnWin srcBytes bufOrig (srcBytes.length - 1))
+      ** (isl ↦ₘ BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2)))
+    (by
+      repeat' first
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) h9
+  have s5 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by unfold hdnFoot at hp; xperm_hyp hp) hpre Fb3
+  have s6 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) s5 Fb4
+  have s7 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) s6 hjal
+  have s8x := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) s7 Fb6
+  have s9x := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) s8x FLoop
+  have s10 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) s9x Fb7
+  refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_)
+    (cpsTripleWithin_mono_nSteps (by omega) s10)
+  · exact hp
+  · unfold hdnFoot
+    xperm_hyp hq
+
+
+/-! ## Classification ties (guest model ↔ path outcomes) -/
+
+private theorem hdnRes_len0 (bs : List (BitVec 8)) (h : bs.length = 0) :
+    hdnRes bs = none := by
+  rw [List.length_eq_zero_iff.mp h]
+  rfl
+
+private theorem hdnRes_none_hi4 (bs : List (BitVec 8)) (hlen : 0 < bs.length)
+    (h : 4 ≤ (bs.getD 0 0).toNat / 16) : hdnRes bs = none := by
+  match bs, hlen with
+  | b0 :: rest, _ =>
+    have hd : ((b0 :: rest : List (BitVec 8)).getD 0 0) = b0 := rfl
+    rw [hd] at h
+    simp only [hdnRes]
+    split
+    · rfl
+    · obtain ⟨k, hk⟩ : ∃ k, b0.toNat / 16 = k + 4 := ⟨b0.toNat / 16 - 4, by omega⟩
+      simp only [EvmAsm.Evm64.hpDecode]
+      rw [hk]
+      rfl
+
+private theorem hdnRes_none_strict (bs : List (BitVec 8)) (hlen : 0 < bs.length)
+    (heven : (bs.getD 0 0).toNat / 16 % 2 = 0)
+    (hlo : (bs.getD 0 0).toNat % 16 ≠ 0) : hdnRes bs = none := by
+  match bs, hlen with
+  | b0 :: rest, _ =>
+    have hd : ((b0 :: rest : List (BitVec 8)).getD 0 0) = b0 := rfl
+    rw [hd] at heven hlo
+    simp only [hdnRes]
+    rw [if_pos ⟨heven, hlo⟩]
+
+private theorem hdnRes_some_odd (bs : List (BitVec 8)) (hlen : 0 < bs.length)
+    (hhi : (bs.getD 0 0).toNat / 16 < 4)
+    (hodd : (bs.getD 0 0).toNat / 16 % 2 = 1) :
+    hdnRes bs = some (decide (2 ≤ (bs.getD 0 0).toNat / 16),
+      lowNibble (bs.getD 0 0)
+        :: EvmAsm.Evm64.hpUnpackPairs (bs.drop 1)) := by
+  match bs, hlen with
+  | b0 :: rest, _ =>
+    have hd : ((b0 :: rest : List (BitVec 8)).getD 0 0) = b0 := rfl
+    rw [hd] at hhi hodd ⊢
+    simp only [hdnRes]
+    rw [if_neg (by omega), lowNibble_eq,
+      show (b0 :: rest : List (BitVec 8)).drop 1 = rest from rfl]
+    rcases (by omega : b0.toNat / 16 = 1 ∨ b0.toNat / 16 = 3) with h1 | h3
+    · rw [EvmAsm.Evm64.hpDecode_cons_div1 b0 rest h1, h1]
+      rfl
+    · rw [EvmAsm.Evm64.hpDecode_cons_div3 b0 rest h3, h3]
+      rfl
+
+private theorem hdnRes_some_even (bs : List (BitVec 8)) (hlen : 0 < bs.length)
+    (hhi : (bs.getD 0 0).toNat / 16 < 4)
+    (heven : (bs.getD 0 0).toNat / 16 % 2 = 0)
+    (hlo : (bs.getD 0 0).toNat % 16 = 0) :
+    hdnRes bs = some (decide (2 ≤ (bs.getD 0 0).toNat / 16),
+      EvmAsm.Evm64.hpUnpackPairs (bs.drop 1)) := by
+  match bs, hlen with
+  | b0 :: rest, _ =>
+    have hd : ((b0 :: rest : List (BitVec 8)).getD 0 0) = b0 := rfl
+    rw [hd] at hhi heven hlo ⊢
+    simp only [hdnRes]
+    rw [if_neg (by omega),
+      show (b0 :: rest : List (BitVec 8)).drop 1 = rest from rfl]
+    rcases (by omega : b0.toNat / 16 = 0 ∨ b0.toNat / 16 = 2) with h0 | h2
+    · rw [EvmAsm.Evm64.hpDecode_cons_div0 b0 rest h0, h0]
+      rfl
+    · rw [EvmAsm.Evm64.hpDecode_cons_div2 b0 rest h2, h2]
+      rfl
+
+private theorem hpUnpackPairs_length (l : List (BitVec 8)) :
+    (EvmAsm.Evm64.hpUnpackPairs l).length = 2 * l.length := by
+  unfold EvmAsm.Evm64.hpUnpackPairs
+  rw [List.length_flatMap]
+  induction l with
+  | nil => rfl
+  | cons a t ih => simp_all; omega
+
+/-- On success the loop-exit window IS the spliced decode result. -/
+private theorem hdnWin_final (bs orig : List (BitVec 8)) (_hlen : 0 < bs.length)
+    (hnibs : hdnNibs bs
+      = hdnInitNibs bs ++ EvmAsm.Evm64.hpUnpackPairs (bs.drop 1)) :
+    hdnWin bs orig (bs.length - 1) = hdnBufFinal bs orig := by
+  unfold hdnWin hdnBufFinal
+  rw [hnibs, nibblePrefix_eq_hpUnpackPairs (bs.drop 1) (bs.length - 1)
+    (by rw [List.length_drop]),
+    show (bs.drop 1).take (bs.length - 1) = bs.drop 1 from by
+      rw [List.take_of_length_le (by rw [List.length_drop])]]
+
+/-- Nibble-count tie: on success, `|hdnNibs| = c0 + 2 * (len - 1)`. -/
+private theorem hdnNibs_length (bs : List (BitVec 8)) (_hlen : 0 < bs.length)
+    (hnibs : hdnNibs bs
+      = hdnInitNibs bs ++ EvmAsm.Evm64.hpUnpackPairs (bs.drop 1)) :
+    (hdnNibs bs).length = hdnC0 bs + 2 * (bs.length - 1) := by
+  rw [hnibs, List.length_append, hdnInitNibs_length, hpUnpackPairs_length,
+    List.length_drop]
+
+
+/-! ## The unified caller contract -/
+
+/-- Caller-visible precondition: arguments in `a0..a4`, scratch registers
+    arbitrary, the input path bytes, the caller's nibble buffer, and the
+    two output cells. -/
+def hdnCallerPre (src dst cnt isl : Word) (srcBytes bufOrig : List (BitVec 8))
+    (v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl : Word) : Assertion :=
+  (.x10 ↦ᵣ src) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length) ** (.x12 ↦ᵣ dst)
+  ** (.x13 ↦ᵣ cnt) ** (.x14 ↦ᵣ isl)
+  ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x28 ↦ᵣ v28)
+  ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)
+  ** (Reg.x0 ↦ᵣ (0 : Word))
+  ** bytesRegion src srcBytes ** bytesRegion dst bufOrig
+  ** (cnt ↦ₘ oldCnt) ** (isl ↦ₘ oldIsl)
+
+/-- Caller-visible postcondition — **the genuine `hp_decode_nibbles`
+    semantics**: `a0` holds the status (`hdnStatusW`, 0 iff the guest-exact
+    decode `hdnRes` succeeds), the nibble buffer holds the decoded nibbles
+    spliced over its old contents (`hdnBufFinal`), and the count/is-leaf
+    cells are updated exactly as the routine does (`hdnCntFinal` /
+    `hdnIslFinal`).  Scratch registers are clobbered (`regOwn`);
+    arguments `a1..a4` are preserved. -/
+def hdnCallerPost (src dst cnt isl : Word) (srcBytes bufOrig : List (BitVec 8))
+    (oldCnt oldIsl : Word) : Assertion :=
+  (.x10 ↦ᵣ hdnStatusW srcBytes) ** (.x11 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+  ** (.x12 ↦ᵣ dst) ** (.x13 ↦ᵣ cnt) ** (.x14 ↦ᵣ isl)
+  ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28
+  ** regOwn .x29 ** regOwn .x30 ** regOwn .x31
+  ** (Reg.x0 ↦ᵣ (0 : Word))
+  ** bytesRegion src srcBytes ** bytesRegion dst (hdnBufFinal srcBytes bufOrig)
+  ** (cnt ↦ₘ hdnCntFinal srcBytes oldCnt) ** (isl ↦ₘ hdnIslFinal srcBytes oldIsl)
+
+/-- Final saved-register values: the argument copies. -/
+def hdnVals' (vals : Reg → Word) (src lenW dst cnt isl : Word) : Reg → Word :=
+  fun r => match r with
+  | .x8 => src
+  | .x9 => lenW
+  | .x18 => dst
+  | .x19 => cnt
+  | .x20 => isl
+  | r => vals r
+
+/-- Per-case post reconciliation: each path's concrete `hdnFoot` exit
+    implies the unified caller post (given the four value ties). -/
+private theorem hdnFoot_to_callerPost (src dst cnt isl : Word)
+    (srcBytes bufOrig : List (BitVec 8)) (oldCnt oldIsl : Word)
+    (st : Word) (w5 w6 w7 w28 w29 w30 w31 : Word)
+    (bufW : List (BitVec 8)) (cntW islW : Word)
+    (hst : hdnStatusW srcBytes = st)
+    (hbe : hdnBufFinal srcBytes bufOrig = bufW)
+    (hce : hdnCntFinal srcBytes oldCnt = cntW)
+    (hie : hdnIslFinal srcBytes oldIsl = islW) :
+    ∀ h, (hdnFoot src dst cnt isl srcBytes st src
+        (BitVec.ofNat 64 srcBytes.length) (BitVec.ofNat 64 srcBytes.length)
+        dst dst cnt cnt isl isl w5 w6 w7 w28 w29 w30 w31 bufW cntW islW) h →
+      ((.x8 ↦ᵣ src) ** (.x9 ↦ᵣ BitVec.ofNat 64 srcBytes.length)
+        ** (.x18 ↦ᵣ dst) ** (.x19 ↦ᵣ cnt) ** (.x20 ↦ᵣ isl)
+        ** hdnCallerPost src dst cnt isl srcBytes bufOrig oldCnt oldIsl) h := by
+  intro h hp
+  unfold hdnFoot at hp
+  unfold hdnCallerPost
+  rw [hst, hbe, hce, hie]
+  have hp2 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+      (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+        (sepConj_mono_right
+          (sepConj_mono (regIs_to_regOwn .x5 _)
+            (sepConj_mono (regIs_to_regOwn .x6 _)
+              (sepConj_mono (regIs_to_regOwn .x7 _)
+                (sepConj_mono (regIs_to_regOwn .x28 _)
+                  (sepConj_mono (regIs_to_regOwn .x29 _)
+                    (sepConj_mono (regIs_to_regOwn .x30 _)
+                      (sepConj_mono (regIs_to_regOwn .x31 _)
+                        (fun _ hx => hx))))))))))))))))) h hp
+  xperm_hyp hp2
+
+
+private theorem pcFree_frame_bundle (sp0new : Word) (vals : Reg → Word) :
+    ((.x2 ↦ᵣ sp0new) ** (((.x1 : Reg) ↦ᵣ vals .x1)
+      ** frameSlotsSaved hdnFrame sp0new vals)).pcFree :=
+  pcFree_sepConj pcFree_regIs (pcFree_sepConj pcFree_regIs
+    (pcFree_frameSlotsSaved _ _ _))
+
+/-- The unified single-exit body triple `abiFrame_spec` consumes: the
+    five control paths, dispatched on the guest-exact classification. -/
+private theorem hdnBody_unified (base sp0new : Word) (vals : Reg → Word)
+    (src dst cnt isl : Word) (srcBytes bufOrig : List (BitVec 8))
+    (v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl : Word)
+    (hsalign : src.toNat % 8 = 0) (hsover : src.toNat + srcBytes.length < 2 ^ 64)
+    (hsvalid : ∀ j, j < srcBytes.length →
+      isValidByteAccess (src + BitVec.ofNat 64 j) = true)
+    (hbuf : hdnC0 srcBytes + 2 * (srcBytes.length - 1) ≤ bufOrig.length)
+    (hdalign : dst.toNat % 8 = 0) (hdover : dst.toNat + bufOrig.length < 2 ^ 64)
+    (hdvalid : ∀ j, j < bufOrig.length →
+      isValidByteAccess (dst + BitVec.ofNat 64 j) = true) :
+    cpsTripleWithin (30 + 11 * srcBytes.length)
+      (base + BitVec.ofNat 64 (4 * (1 + hdnFrame.length)))
+      (base + BitVec.ofNat 64 (4 * (1 + hdnFrame.length + hdnBody.length)))
+      (hdnCr base)
+      ((.x2 ↦ᵣ sp0new) ** regsAt hdnFrame vals
+        ** frameSlotsSaved hdnFrame sp0new vals
+        ** hdnCallerPre src dst cnt isl srcBytes bufOrig
+            v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl)
+      ((.x2 ↦ᵣ sp0new)
+        ** regsAt hdnFrame
+            (hdnVals' vals src (BitVec.ofNat 64 srcBytes.length) dst cnt isl)
+        ** frameSlotsSaved hdnFrame sp0new vals
+        ** hdnCallerPost src dst cnt isl srcBytes bufOrig oldCnt oldIsl) := by
+  show cpsTripleWithin (30 + 11 * srcBytes.length) (bAt base 0) (bAt base 39)
+    (hdnCr base) _ _
+  -- The five-way classification.
+  by_cases hlen0 : srcBytes.length = 0
+  · -- Path A: empty input.
+    have hst : hdnStatusW srcBytes = 1 := by
+      unfold hdnStatusW
+      rw [hdnRes_len0 _ hlen0]
+      rfl
+    have hbe : hdnBufFinal srcBytes bufOrig = bufOrig := by
+      unfold hdnBufFinal hdnNibs
+      rw [hdnRes_len0 _ hlen0]
+      rfl
+    have hce : hdnCntFinal srcBytes oldCnt = oldCnt := by
+      unfold hdnCntFinal
+      rw [hdnRes_len0 _ hlen0]
+      rfl
+    have hie : hdnIslFinal srcBytes oldIsl = oldIsl := by
+      unfold hdnIslFinal hdnIslWritten
+      rw [List.length_eq_zero_iff.mp hlen0]
+      rfl
+    have hpath := pathA_spec base src dst cnt isl srcBytes bufOrig
+      v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl
+      (vals .x8) (vals .x9) (vals .x18) (vals .x19) (vals .x20) hlen0
+    have hframed := cpsTripleWithin_frameR
+      ((.x2 ↦ᵣ sp0new) ** (((.x1 : Reg) ↦ᵣ vals .x1)
+        ** frameSlotsSaved hdnFrame sp0new vals))
+      (pcFree_frame_bundle sp0new vals) hpath
+    refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_)
+      (cpsTripleWithin_mono_nSteps (by omega) hframed)
+    · unfold hdnCallerPre at hp
+      simp only [hdnFrame, regsAt_cons, regsAt_nil, frameSlotsSaved_cons,
+        frameSlotsSaved_nil, sepConj_emp_right'] at hp ⊢
+      unfold hdnFoot
+      xperm_hyp hp
+    · have hq2 := sepConj_mono_left
+        (hdnFoot_to_callerPost src dst cnt isl srcBytes bufOrig oldCnt oldIsl
+          (1 : Word) v5 v6 v7 v28 v29 v30 v31 bufOrig oldCnt oldIsl
+          hst hbe hce hie) h hq
+      unfold hdnCallerPost at hq2 ⊢
+      simp only [hdnFrame, regsAt_cons, regsAt_nil, frameSlotsSaved_cons,
+        frameSlotsSaved_nil, sepConj_emp_right', hdnVals'] at hq2 ⊢
+      xperm_hyp hq2
+  · have hlen : 0 < srcBytes.length := by omega
+    rcases Nat.lt_or_ge ((srcBytes.getD 0 0).toNat / 16) 4 with hhi | hhi
+    · by_cases hpar : (srcBytes.getD 0 0).toNat / 16 % 2 = 1
+      · -- Path D: odd success.
+        have hsome := hdnRes_some_odd srcBytes hlen hhi hpar
+        have hnibs : hdnNibs srcBytes
+            = hdnInitNibs srcBytes
+              ++ EvmAsm.Evm64.hpUnpackPairs (srcBytes.drop 1) := by
+          unfold hdnNibs hdnInitNibs
+          rw [hsome, hdnOdd_true_of srcBytes hpar]
+          rfl
+        have hst : hdnStatusW srcBytes = 0 := by
+          unfold hdnStatusW
+          rw [hsome]
+          rfl
+        have hbe : hdnBufFinal srcBytes bufOrig
+            = hdnWin srcBytes bufOrig (srcBytes.length - 1) :=
+          (hdnWin_final srcBytes bufOrig hlen hnibs).symm
+        have hce : hdnCntFinal srcBytes oldCnt
+            = BitVec.ofNat 64 (hdnC0 srcBytes + 2 * (srcBytes.length - 1)) := by
+          unfold hdnCntFinal
+          rw [hsome]
+          show BitVec.ofNat 64 (hdnNibs srcBytes).length = _
+          rw [hdnNibs_length srcBytes hlen hnibs]
+        have hie : hdnIslFinal srcBytes oldIsl
+            = BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2) := by
+          have hemp : srcBytes.isEmpty = false := by
+            cases srcBytes
+            · simp at hlen
+            · rfl
+          unfold hdnIslFinal hdnIslWritten
+          rw [hemp]
+          simp only [Bool.not_false, Bool.true_and]
+          rw [if_pos (show decide ((hdnB0 srcBytes).toNat / 16 < 4) = true from
+            decide_eq_true hhi)]
+          rfl
+        have hbuf0 : 0 < bufOrig.length := by
+          have := hdnC0_odd srcBytes hpar
+          omega
+        have hpath := pathD_spec base src dst cnt isl srcBytes bufOrig
+          v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl
+          (vals .x8) (vals .x9) (vals .x18) (vals .x19) (vals .x20)
+          hlen hhi hpar hsalign hsover hsvalid hbuf hbuf0 hdalign hdover hdvalid
+        have hframed := cpsTripleWithin_frameR
+          ((.x2 ↦ᵣ sp0new) ** (((.x1 : Reg) ↦ᵣ vals .x1)
+            ** frameSlotsSaved hdnFrame sp0new vals))
+          (pcFree_frame_bundle sp0new vals) hpath
+        refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_)
+          (cpsTripleWithin_mono_nSteps (by omega) hframed)
+        · unfold hdnCallerPre at hp
+          simp only [hdnFrame, regsAt_cons, regsAt_nil, frameSlotsSaved_cons,
+            frameSlotsSaved_nil, sepConj_emp_right'] at hp ⊢
+          unfold hdnFoot
+          xperm_hyp hp
+        · have hq2 := sepConj_mono_left
+            (hdnFoot_to_callerPost src dst cnt isl srcBytes bufOrig oldCnt oldIsl
+              (0 : Word) _ _ _ _ _ _ _
+              (hdnWin srcBytes bufOrig (srcBytes.length - 1))
+              (BitVec.ofNat 64 (hdnC0 srcBytes + 2 * (srcBytes.length - 1)))
+              (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))
+              hst hbe hce hie) h hq
+          unfold hdnCallerPost at hq2 ⊢
+          simp only [hdnFrame, regsAt_cons, regsAt_nil, frameSlotsSaved_cons,
+            frameSlotsSaved_nil, sepConj_emp_right', hdnVals'] at hq2 ⊢
+          xperm_hyp hq2
+      · have heven : (srcBytes.getD 0 0).toNat / 16 % 2 = 0 := by omega
+        by_cases hlo : (srcBytes.getD 0 0).toNat % 16 = 0
+        · -- Path E: even success.
+          have hsome := hdnRes_some_even srcBytes hlen hhi heven hlo
+          have hnibs : hdnNibs srcBytes
+              = hdnInitNibs srcBytes
+                ++ EvmAsm.Evm64.hpUnpackPairs (srcBytes.drop 1) := by
+            unfold hdnNibs hdnInitNibs
+            rw [hsome, hdnOdd_false_of srcBytes heven]
+            rfl
+          have hst : hdnStatusW srcBytes = 0 := by
+            unfold hdnStatusW
+            rw [hsome]
+            rfl
+          have hbe : hdnBufFinal srcBytes bufOrig
+              = hdnWin srcBytes bufOrig (srcBytes.length - 1) :=
+            (hdnWin_final srcBytes bufOrig hlen hnibs).symm
+          have hce : hdnCntFinal srcBytes oldCnt
+              = BitVec.ofNat 64 (hdnC0 srcBytes + 2 * (srcBytes.length - 1)) := by
+            unfold hdnCntFinal
+            rw [hsome]
+            show BitVec.ofNat 64 (hdnNibs srcBytes).length = _
+            rw [hdnNibs_length srcBytes hlen hnibs]
+          have hie : hdnIslFinal srcBytes oldIsl
+              = BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2) := by
+            have hemp : srcBytes.isEmpty = false := by
+              cases srcBytes
+              · simp at hlen
+              · rfl
+            unfold hdnIslFinal hdnIslWritten
+            rw [hemp]
+            simp only [Bool.not_false, Bool.true_and]
+            rw [if_pos (show decide ((hdnB0 srcBytes).toNat / 16 < 4) = true from
+              decide_eq_true hhi)]
+            rfl
+          have hpath := pathE_spec base src dst cnt isl srcBytes bufOrig
+            v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl
+            (vals .x8) (vals .x9) (vals .x18) (vals .x19) (vals .x20)
+            hlen hhi heven hlo hsalign hsover hsvalid hbuf hdalign hdover hdvalid
+          have hframed := cpsTripleWithin_frameR
+            ((.x2 ↦ᵣ sp0new) ** (((.x1 : Reg) ↦ᵣ vals .x1)
+              ** frameSlotsSaved hdnFrame sp0new vals))
+            (pcFree_frame_bundle sp0new vals) hpath
+          refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_)
+            (cpsTripleWithin_mono_nSteps (by omega) hframed)
+          · unfold hdnCallerPre at hp
+            simp only [hdnFrame, regsAt_cons, regsAt_nil, frameSlotsSaved_cons,
+              frameSlotsSaved_nil, sepConj_emp_right'] at hp ⊢
+            unfold hdnFoot
+            xperm_hyp hp
+          · have hq2 := sepConj_mono_left
+              (hdnFoot_to_callerPost src dst cnt isl srcBytes bufOrig oldCnt oldIsl
+                (0 : Word) _ _ _ _ _ _ _
+                (hdnWin srcBytes bufOrig (srcBytes.length - 1))
+                (BitVec.ofNat 64 (hdnC0 srcBytes + 2 * (srcBytes.length - 1)))
+                (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))
+                hst hbe hce hie) h hq
+            unfold hdnCallerPost at hq2 ⊢
+            simp only [hdnFrame, regsAt_cons, regsAt_nil, frameSlotsSaved_cons,
+              frameSlotsSaved_nil, sepConj_emp_right', hdnVals'] at hq2 ⊢
+            xperm_hyp hq2
+        · -- Path C: even strict reject.
+          have hnone := hdnRes_none_strict srcBytes hlen heven hlo
+          have hst : hdnStatusW srcBytes = 1 := by
+            unfold hdnStatusW
+            rw [hnone]
+            rfl
+          have hbe : hdnBufFinal srcBytes bufOrig = bufOrig := by
+            unfold hdnBufFinal hdnNibs
+            rw [hnone]
+            rfl
+          have hce : hdnCntFinal srcBytes oldCnt = oldCnt := by
+            unfold hdnCntFinal
+            rw [hnone]
+            rfl
+          have hie : hdnIslFinal srcBytes oldIsl
+              = BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2) := by
+            have hemp : srcBytes.isEmpty = false := by
+              cases srcBytes
+              · simp at hlen
+              · rfl
+            unfold hdnIslFinal hdnIslWritten
+            rw [hemp]
+            simp only [Bool.not_false, Bool.true_and]
+            rw [if_pos (show decide ((hdnB0 srcBytes).toNat / 16 < 4) = true from
+              decide_eq_true hhi)]
+            rfl
+          have hpath := pathC_spec base src dst cnt isl srcBytes bufOrig
+            v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl
+            (vals .x8) (vals .x9) (vals .x18) (vals .x19) (vals .x20)
+            hlen hhi heven hlo hsalign hsover hsvalid
+          have hframed := cpsTripleWithin_frameR
+            ((.x2 ↦ᵣ sp0new) ** (((.x1 : Reg) ↦ᵣ vals .x1)
+              ** frameSlotsSaved hdnFrame sp0new vals))
+            (pcFree_frame_bundle sp0new vals) hpath
+          refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_)
+            (cpsTripleWithin_mono_nSteps (by omega) hframed)
+          · unfold hdnCallerPre at hp
+            simp only [hdnFrame, regsAt_cons, regsAt_nil, frameSlotsSaved_cons,
+              frameSlotsSaved_nil, sepConj_emp_right'] at hp ⊢
+            unfold hdnFoot
+            xperm_hyp hp
+          · have hq2 := sepConj_mono_left
+              (hdnFoot_to_callerPost src dst cnt isl srcBytes bufOrig oldCnt oldIsl
+                (1 : Word) _ _ _ _ _ _ _ bufOrig oldCnt
+                (BitVec.ofNat 64 ((srcBytes.getD 0 0).toNat / 16 / 2 % 2))
+                hst hbe hce hie) h hq
+            unfold hdnCallerPost at hq2 ⊢
+            simp only [hdnFrame, regsAt_cons, regsAt_nil, frameSlotsSaved_cons,
+              frameSlotsSaved_nil, sepConj_emp_right', hdnVals'] at hq2 ⊢
+            xperm_hyp hq2
+    · -- Path B: invalid flag nibble.
+      have hnone := hdnRes_none_hi4 srcBytes hlen hhi
+      have hst : hdnStatusW srcBytes = 1 := by
+        unfold hdnStatusW
+        rw [hnone]
+        rfl
+      have hbe : hdnBufFinal srcBytes bufOrig = bufOrig := by
+        unfold hdnBufFinal hdnNibs
+        rw [hnone]
+        rfl
+      have hce : hdnCntFinal srcBytes oldCnt = oldCnt := by
+        unfold hdnCntFinal
+        rw [hnone]
+        rfl
+      have hie : hdnIslFinal srcBytes oldIsl = oldIsl := by
+        have hemp : srcBytes.isEmpty = false := by
+          cases srcBytes
+          · simp at hlen
+          · rfl
+        unfold hdnIslFinal hdnIslWritten
+        rw [hemp]
+        simp only [Bool.not_false, Bool.true_and]
+        rw [if_neg (show ¬ decide ((hdnB0 srcBytes).toNat / 16 < 4) = true from by
+          intro hdec
+          have h4 := of_decide_eq_true hdec
+          unfold hdnB0 at h4
+          omega)]
+      have hpath := pathB_spec base src dst cnt isl srcBytes bufOrig
+        v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl
+        (vals .x8) (vals .x9) (vals .x18) (vals .x19) (vals .x20)
+        hlen hhi hsalign hsover hsvalid
+      have hframed := cpsTripleWithin_frameR
+        ((.x2 ↦ᵣ sp0new) ** (((.x1 : Reg) ↦ᵣ vals .x1)
+          ** frameSlotsSaved hdnFrame sp0new vals))
+        (pcFree_frame_bundle sp0new vals) hpath
+      refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_)
+        (cpsTripleWithin_mono_nSteps (by omega) hframed)
+      · unfold hdnCallerPre at hp
+        simp only [hdnFrame, regsAt_cons, regsAt_nil, frameSlotsSaved_cons,
+          frameSlotsSaved_nil, sepConj_emp_right'] at hp ⊢
+        unfold hdnFoot
+        xperm_hyp hp
+      · have hq2 := sepConj_mono_left
+          (hdnFoot_to_callerPost src dst cnt isl srcBytes bufOrig oldCnt oldIsl
+            (1 : Word) _ _ _ _ _ _ _ bufOrig oldCnt oldIsl
+            hst hbe hce hie) h hq
+        unfold hdnCallerPost at hq2 ⊢
+        simp only [hdnFrame, regsAt_cons, regsAt_nil, frameSlotsSaved_cons,
+          frameSlotsSaved_nil, sepConj_emp_right', hdnVals'] at hq2 ⊢
+        xperm_hyp hq2
+
+
+/-! ## The whole-routine contract -/
+
+private theorem pcFree_hdnCallerPre (src dst cnt isl : Word)
+    (srcBytes bufOrig : List (BitVec 8))
+    (v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl : Word) :
+    (hdnCallerPre src dst cnt isl srcBytes bufOrig
+      v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl).pcFree := by
+  unfold hdnCallerPre
+  repeat' first
+    | exact pcFree_regIs
+    | exact pcFree_memIs
+    | exact bytesRegion_pcFree _ _
+    | apply pcFree_sepConj
+
+private theorem pcFree_hdnCallerPost (src dst cnt isl : Word)
+    (srcBytes bufOrig : List (BitVec 8)) (oldCnt oldIsl : Word) :
+    (hdnCallerPost src dst cnt isl srcBytes bufOrig oldCnt oldIsl).pcFree := by
+  unfold hdnCallerPost
+  repeat' first
+    | exact pcFree_regIs
+    | exact pcFree_regOwn
+    | exact pcFree_memIs
+    | exact bytesRegion_pcFree _ _
+    | apply pcFree_sepConj
+
+/-- **The verified `hp_decode_nibbles` routine contract** (bead
+    evm-asm-4ch8f.16.3): over the guest's own bytes (`hdnCr` at a symbolic
+    base), from a standard C-ABI entry state, the routine returns to `ret`
+    with `sp`/`ra`/all callee-saved registers restored, `a0` holding the
+    parse status, the caller's nibble buffer holding the decoded hex-prefix
+    path (`hdnBufFinal`), and the count / is-leaf cells written exactly per
+    the guest-exact decode `hdnRes` — which agrees with the spec-side
+    `EvmAsm.Evm64.hpDecode` on every well-formed encoding
+    (`hdnRes_eq_hpDecode` / `hdnRes_hpEncode`). -/
+theorem hp_decode_nibbles_spec (base sp0 ret : Word) (vals : Reg → Word)
+    (src dst cnt isl : Word) (srcBytes bufOrig : List (BitVec 8))
+    (v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl : Word)
+    (hret : vals .x1 = ret)
+    (halignRet : (ret &&& ~~~(1 : Word)) = ret)
+    (hsalign : src.toNat % 8 = 0) (hsover : src.toNat + srcBytes.length < 2 ^ 64)
+    (hsvalid : ∀ j, j < srcBytes.length →
+      isValidByteAccess (src + BitVec.ofNat 64 j) = true)
+    (hbuf : hdnC0 srcBytes + 2 * (srcBytes.length - 1) ≤ bufOrig.length)
+    (hdalign : dst.toNat % 8 = 0) (hdover : dst.toNat + bufOrig.length < 2 ^ 64)
+    (hdvalid : ∀ j, j < bufOrig.length →
+      isValidByteAccess (dst + BitVec.ofNat 64 j) = true) :
+    cpsTripleWithin (1 + hdnFrame.length + (30 + 11 * srcBytes.length)
+        + hdnFrame.length + 1 + 1) base ret (hdnCr base)
+      ((.x2 ↦ᵣ sp0) ** regsAt hdnFrame vals
+        ** frameSlotsOwn hdnFrame (sp0 + signExtend12 (-48 : BitVec 12))
+        ** hdnCallerPre src dst cnt isl srcBytes bufOrig
+            v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl)
+      ((.x2 ↦ᵣ sp0) ** regsAt hdnFrame vals
+        ** frameSlotsSaved hdnFrame (sp0 + signExtend12 (-48 : BitVec 12)) vals
+        ** hdnCallerPost src dst cnt isl srcBytes bufOrig oldCnt oldIsl) := by
+  exact abiFrame_spec base sp0 ret (-48 : BitVec 12) (48 : BitVec 12)
+    hdnFrame (0 : BitVec 12)
+    [(.x8, 8), (.x9, 16), (.x18, 24), (.x19, 32), (.x20, 40)]
+    vals (hdnVals' vals src (BitVec.ofNat 64 srcBytes.length) dst cnt isl)
+    hdnBody (30 + 11 * srcBytes.length)
+    (hdnCallerPre src dst cnt isl srcBytes bufOrig
+      v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl)
+    (hdnCallerPost src dst cnt isl srcBytes bufOrig oldCnt oldIsl)
+    (hdnCr base)
+    rfl
+    (by decide)
+    (by decide)
+    (by
+      rw [show abiFrameProg (-48 : BitVec 12) (48 : BitVec 12) hdnFrame hdnBody
+        = hpDecodeNibbles_prog from hdnProg_eq]
+      decide)
+    hret halignRet
+    (by
+      rw [show signExtend12 (-48 : BitVec 12) = (-48 : Word) from by decide,
+        show signExtend12 (48 : BitVec 12) = (48 : Word) from by decide]
+      bv_omega)
+    (pcFree_hdnCallerPre src dst cnt isl srcBytes bufOrig
+      v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl)
+    (pcFree_hdnCallerPost src dst cnt isl srcBytes bufOrig oldCnt oldIsl)
+    (by
+      intro a i h
+      rw [show abiFrameProg (-48 : BitVec 12) (48 : BitVec 12) hdnFrame hdnBody
+        = hpDecodeNibbles_prog from hdnProg_eq] at h
+      exact h)
+    (hdnBody_unified base (sp0 + signExtend12 (-48 : BitVec 12)) vals
+      src dst cnt isl srcBytes bufOrig v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl
+      hsalign hsover hsvalid hbuf hdalign hdover hdvalid)
+
+#print axioms hp_decode_nibbles_spec
+#print axioms hdnRes_hpEncode
+
+end HpDecodeNibblesSAsm
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -419,6 +419,8 @@ import EvmAsm.Codegen.Programs.BlockVerdictGasResults
 import EvmAsm.Codegen.Programs.ReceiptList
 import EvmAsm.Codegen.Programs.StatelessGuestUnit
 import EvmAsm.Codegen.Programs.RegistryNames
+import EvmAsm.Codegen.Programs.HpDecodeNibblesSAsm
+import EvmAsm.Codegen.Programs.HpDecodeNibblesSAsmPaths
 import EvmAsm.Codegen.Programs.HpEncodeNibblesSAsm
 import EvmAsm.Codegen.Programs.NibblesCommonPrefixLenSAsm
 import EvmAsm.Codegen.Programs.Secp256k1FieldSubModPSAsm

--- a/EvmAsm/Rv64/SAsm.lean
+++ b/EvmAsm/Rv64/SAsm.lean
@@ -61,6 +61,7 @@ import EvmAsm.Rv64.SAsm.TwoBreakWritable
 import EvmAsm.Rv64.SAsm.DualReadByteScan
 import EvmAsm.Rv64.SAsm.MultiRegRetTail
 import EvmAsm.Rv64.SAsm.RetFromLoop
+import EvmAsm.Rv64.SAsm.UpLoop
 import EvmAsm.Rv64.SAsm.ContForwardJoin
 import EvmAsm.Rv64.SAsm.TriCmpStoreJoin
 import EvmAsm.Rv64.SAsm.FnFlatAmbientDemo

--- a/EvmAsm/Rv64/SAsm/UpLoop.lean
+++ b/EvmAsm/Rv64/SAsm/UpLoop.lean
@@ -1,0 +1,138 @@
+/-
+  EvmAsm.Rv64.SAsm.UpLoop
+
+  **General s-register-exposed up-counting loop lemma** (bead
+  evm-asm-4ch8f.16.3.1, sibling of `countdownLoop_spec` in
+  `AbiFrameLoop.lean`).
+
+  `countdownLoop_spec` recognizes the bottom-decrement countdown
+  (`beq ctr, x0, exit` header).  Several emitted guest loops instead count a
+  cursor UP against a limit register with an unsigned-compare top guard — the
+  `hp_decode_nibbles` nibble loop is the canonical instance:
+
+  ```
+    hdr:  bgeu idx, lim, exitOff     -- exit when idx ≥ lim (unsigned)
+          <body>                     -- runs with inv exposed; increments idx
+          jal  x0, hdr               -- back-edge (part of `<body>`)
+    exit:                            -- `hdr + signExtend13 exitOff`
+  ```
+
+  `upLoop_spec` is the direct analogue: parameterized over an arbitrary index
+  register `idx`, limit register `lim` (both may be callee-saved
+  `s`-registers — a register is just a `↦ᵣ` atom at this level), and an
+  invariant family `inv : Nat → Assertion`.  Given a per-iteration body triple
+  from the fall-through address back to the header taking `idx` from `i` to
+  `i+1` (`start ≤ i < len`), the whole loop runs from the header to the exit
+  with the index climbing from `start` to `len`.
+
+  Strictly additive: `cpsTripleWithin` level only — no `Ast`/`Vc`/
+  `StmtSound*`/`blockOk` changes.
+-/
+
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.ControlFlow
+import EvmAsm.Rv64.Tactics.RunBlock
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Rv64
+namespace SAsm
+
+open EvmAsm.Rv64.Tactics
+
+/-- Unsigned word comparison of in-range `ofNat`s is the `Nat` comparison. -/
+private theorem word_ofNat_ult_iff {i j : Nat} (hi : i < 2 ^ 64) (hj : j < 2 ^ 64) :
+    BitVec.ult (BitVec.ofNat 64 i) (BitVec.ofNat 64 j) ↔ i < j := by
+  simp only [BitVec.ult, decide_eq_true_eq, BitVec.toNat_ofNat,
+    Nat.mod_eq_of_lt hi, Nat.mod_eq_of_lt hj]
+
+/-- **General s-register-exposed up-counting loop lemma** — the
+    `bgeu idx, lim, exit` top-guard analogue of `countdownLoop_spec`.
+
+    Given a per-iteration body triple `hbody` that, for every index
+    `i` with `start ≤ i < len`, runs from the fall-through address `hdr + 4`
+    back to the header `hdr` taking `idx` from `i` to `i+1` and stepping the
+    invariant from `inv i` to `inv (i+1)`, the whole loop runs from the header
+    `hdr` to `exit` with the index climbing from `start` to `len`. -/
+theorem upLoop_spec
+    (cr : CodeReq) (hdr exitAddr : Word) (idx lim : Reg) (exitOff : BitVec 13)
+    (bodyStep len : Nat) (inv : Nat → Assertion)
+    (hlen : len < 2 ^ 64)
+    (hexit : hdr + signExtend13 exitOff = exitAddr)
+    (hpcFree : ∀ n, (inv n).pcFree)
+    (hguardMem : ∀ a i,
+      CodeReq.singleton hdr (.BGEU idx lim exitOff) a = some i → cr a = some i)
+    (start : Nat) (hstart : start ≤ len)
+    (hbody : ∀ i, start ≤ i → i < len →
+      cpsTripleWithin bodyStep (hdr + 4) hdr cr
+        ((idx ↦ᵣ BitVec.ofNat 64 i) ** (lim ↦ᵣ BitVec.ofNat 64 len) ** inv i)
+        ((idx ↦ᵣ BitVec.ofNat 64 (i + 1)) ** (lim ↦ᵣ BitVec.ofNat 64 len)
+          ** inv (i + 1))) :
+    cpsTripleWithin ((len - start) * (bodyStep + 1) + 1) hdr exitAddr cr
+      ((idx ↦ᵣ BitVec.ofNat 64 start) ** (lim ↦ᵣ BitVec.ofNat 64 len) ** inv start)
+      ((idx ↦ᵣ BitVec.ofNat 64 len) ** (lim ↦ᵣ BitVec.ofNat 64 len) ** inv len) := by
+  -- Induction on the remaining distance `len - s` for cursors `s ≥ start`.
+  suffices h : ∀ d s, start ≤ s → s ≤ len → len - s = d →
+      cpsTripleWithin (d * (bodyStep + 1) + 1) hdr exitAddr cr
+        ((idx ↦ᵣ BitVec.ofNat 64 s) ** (lim ↦ᵣ BitVec.ofNat 64 len) ** inv s)
+        ((idx ↦ᵣ BitVec.ofNat 64 len) ** (lim ↦ᵣ BitVec.ofNat 64 len) ** inv len) by
+    exact h (len - start) start (Nat.le_refl start) hstart rfl
+  intro d
+  induction d with
+  | zero =>
+    intro start' hge hle hd
+    have hsl : start' = len := by omega
+    subst hsl
+    -- idx = lim: the guard is taken (¬ ult) and jumps to `exit`.
+    have hbgeu := bgeu_spec_gen_within idx lim exitOff (BitVec.ofNat 64 start')
+      (BitVec.ofNat 64 start') hdr
+    rw [hexit] at hbgeu
+    have hbr := cpsBranchWithin_extend_code hguardMem
+      (cpsBranchWithin_frameR (inv start') (hpcFree start') hbgeu)
+    have htaken := cpsBranchWithin_takenPath hbr
+      (fun hp hQf => by
+        obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_pure⟩, _⟩ := hQf
+        have hult := ((sepConj_pure_right _).1 h_pure).2
+        exact absurd ((word_ofNat_ult_iff (by omega) (by omega)).1 hult)
+          (Nat.lt_irrefl start'))
+    simp only [Nat.zero_mul, Nat.zero_add]
+    exact cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp)
+      (fun h hq => by
+        have hq1 := sepConj_mono_left
+          (sepConj_mono_right (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hq
+        xperm_hyp hq1) htaken
+  | succ k ih =>
+    intro start' hge hle hd
+    have hsl : start' < len := by omega
+    -- Header guard: start' < len so `ult` holds and the branch is NOT taken.
+    have hbgeu := bgeu_spec_gen_within idx lim exitOff (BitVec.ofNat 64 start')
+      (BitVec.ofNat 64 len) hdr
+    rw [hexit] at hbgeu
+    have hbr := cpsBranchWithin_extend_code hguardMem
+      (cpsBranchWithin_frameR (inv start') (hpcFree start') hbgeu)
+    have hguard := cpsBranchWithin_ntakenPath hbr
+      (fun hp hQt => by
+        obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_pure⟩, _⟩ := hQt
+        have hnult := ((sepConj_pure_right _).1 h_pure).2
+        exact hnult ((word_ofNat_ult_iff (by omega) hlen).2 hsl))
+    -- Body (fall-through → header), and inductive tail (header → exit).
+    have hbodyk := hbody start' hge hsl
+    have ihk := ih (start' + 1) (by omega) (by omega) (by omega)
+    -- guard ; body
+    have s1 := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        have hp2 := sepConj_mono_left
+          (sepConj_mono_right (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+        xperm_hyp hp2) hguard hbodyk
+    -- (guard ; body) ; tail
+    have s2 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) s1 ihk
+    -- Step count: 1 + bodyStep + (k*(bodyStep+1)+1) = (k+1)*(bodyStep+1)+1.
+    have hstep : (k + 1) * (bodyStep + 1) + 1
+        = 1 + bodyStep + (k * (bodyStep + 1) + 1) := by
+      rw [Nat.add_mul, Nat.one_mul]; omega
+    rw [hstep]
+    exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+      (fun h hp => by xperm_hyp hp) s2
+
+end SAsm
+end EvmAsm.Rv64

--- a/PLAN.md
+++ b/PLAN.md
@@ -146,7 +146,14 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   done (`.75.3`, `Evm64/MptCorrespondence.lean`): `rlpToMutableNode` +
   `alpha_node` + the `rlpToMutableNode_rlp` round-trip (WF `MptNode.rlp`
   decodes to its SpecRef `MutableNode`; inlined `<32`-byte children are
-  `.75.4`).
+  `.75.4`). `hp_decode_nibbles` is verified byte-transparently (`.16.3`,
+  `Codegen/Programs/HpDecodeNibblesSAsm{,Paths}.lean` +
+  `Rv64/SAsm/UpLoop.lean`'s `upLoop_spec` — the `bgeu`-guard up-counting
+  sibling of `countdownLoop_spec`): `hp_decode_nibbles_spec` is the
+  whole-routine `abiFrame_spec` contract against the guest-exact decode
+  `hdnRes`, tied to `hpDecode` by `hdnRes_eq_hpDecode`/`hdnRes_hpEncode`
+  (the guest is strictly stricter only on even paths with non-zero
+  padding nibble).
 - **Transient store recipe** (`EvmAsm/Evm64/Transient/`, TSTORE done; TLOAD next):
   Body-as-Program `evm_tstore` (`StoreProgram.lean`) is the la-FREE append core
   (`li 0xa0830000` concrete base, `slli`+`add` for `base+128*n`); the handler


### PR DESCRIPTION
Bead: **evm-asm-4ch8f.16.3** (unblocks the `.16.3.1` shape blocker and one of `.29` mpt_walk's three missing callees). **Stacked on #10184** (shares a PLAN.md hunk — merge that first).

`.16.3.1` recorded two capability gaps: a branch-to-tail/shared-epilogue combinator (landed as `RetFromLoop`, #10115) and saved-register frame support (landed as `AbiFrame`, #9982). This PR adds the one still-missing piece and completes the port **byte-transparently — no re-emit**:

- **`EvmAsm/Rv64/SAsm/UpLoop.lean`**: `upLoop_spec` — the `bgeu idx, lim` top-guard **up-counting** loop lemma at `cpsTripleWithin` level, register-agnostic (s-register-capable), sibling of `countdownLoop_spec`. Reusable for every emitted cursor-vs-limit loop.
- **`HpDecodeNibblesSAsm.lean`**: byte transparency `abiFrameProg (-48) 48 hdnFrame hdnBody = hpDecodeNibbles_prog` (`rfl` + `#guard`); the guest-exact decode model `hdnRes` with its SpecRef ties — `hdnRes_eq_hpDecode` (agreement wherever the guest succeeds) and `hdnRes_hpEncode` (round-trip on every hex-prefix encoding; the guest is stricter than `EvmAsm.Evm64.hpDecode` exactly on even paths with a non-zero padding nibble, which it rejects — documented divergence); segment/branch/loop triples at a **symbolic base** (no `GuestAddrs` value pins); `bytesRegion_sb1_within` (offset-1 byte store); a `bytesRegion` `PCFree` instance (unblocks `runBlock` framing over byte regions generally).
- **`HpDecodeNibblesSAsmPaths.lean`** (file-size-gate split): the five control paths (empty input, invalid flag, even-strict reject, odd success, even success), the unified single-exit body (ParentHeaderFrame disjunctive-post technique, scratch registers weakened to `regOwn`), and **`hp_decode_nibbles_spec`** — the whole-routine `abiFrame_spec` contract: `sp`/`ra`/all callee-saved registers restored, `a0` = parse status, nibble buffer = `hdnBufFinal` (decoded nibbles spliced over the caller buffer), count/is-leaf cells written exactly as the routine does (including the fail-path subtlety that the is-leaf cell IS written on the even-strict reject but NOT on the earlier rejects).

Genuine, unweakened post: the full decode semantics vs `hdnRes`/`hpDecode`, not a shape claim. Anti-vacuity: `hdnRes` `#guard`s incl. both round-trip vectors and all three reject classes.

Gates: `lake build` green (4961 jobs); in-file `#print axioms` = classical-3 on `hp_decode_nibbles_spec` + `hdnRes_hpEncode`; check-{forbidden-tactics,axioms,layering,unimported,file-size,no-warnings,naming,statement-tamper,drift,asm-to-program} all PASS. Additive: `cpsTripleWithin` level only, no `Ast`/`Vc`/`StmtSound*`/`blockOk` changes; guest bytes untouched (spec-only, no EEST).

🤖 Generated with [Claude Code](https://claude.com/claude-code)