### PR TITLE
feat(specref): v0.6.0 stateless wire format — schema id 0x1501 + ForkConfig shrink (evm-asm-0w05f.4)

### DIFF
--- a/EvmAsm/Stateless/SpecRef/Guest.lean
+++ b/EvmAsm/Stateless/SpecRef/Guest.lean
@@ -2,11 +2,11 @@
   EvmAsm.Stateless.SpecRef.Guest
 
   Port of `execution-specs/src/ethereum/forks/amsterdam/stateless_guest.py`
-  (`@tests-zkevm@v0.5.0`): the top-level guest shell.
+  (`@tests-zkevm@v0.6.0`, `40f956fab`): the top-level guest shell.
 
-  * `serialize_stateless_output`  (`stateless_guest.py:21`)
-  * `deserialize_stateless_input` (`stateless_guest.py:29`)
-  * `run_stateless_guest`         (`stateless_guest.py:47`)
+  * `serialize_stateless_output`  (`stateless_guest.py:27`)
+  * `deserialize_stateless_input` (`stateless_guest.py:35`)
+  * `run_stateless_guest`         (`stateless_guest.py:72`)
 
   `run_stateless_guest` threads the execution seam (`Seam.lean`); the
   default is the full seam `elExecute` (`PrecompilesTable.lean`),
@@ -35,7 +35,7 @@ def deserialize_stateless_input (data : Bytes) : Except SpecError StatelessInput
   let ssz_obj ← deserialize sszStatelessInputType (data.drop STATELESS_INPUT_SCHEMA_ID_SIZE)
   sszToStatelessInput ssz_obj
 
-/-! ## `_default_failed_stateless_output` (`stateless_guest.py:54`) -/
+/-! ## `_default_failed_stateless_output` (`stateless_guest.py:53`) -/
 
 /-- The sentinel output returned when the guest input cannot be decoded.
     This is deliberately distinct from validation failure after decoding: the
@@ -46,16 +46,14 @@ def _default_failed_stateless_output : StatelessValidationResult :=
     chainConfig :=
       { chainId := 0
         activeFork :=
-          { fork := .Frontier
-            activation := { blockNumber := none, timestamp := none }
-            blobSchedule := none } } }
+          { activation := { blockNumber := none, timestamp := none } } } }
 
 /-! ## `run_stateless_guest` (`stateless_guest.py:79`) -/
 
 /-- Run the stateless guest on serialized input, returning serialized output.
     The execution engine is the seam parameter (default: the full
     seam `elExecute`, `s1d19.5`).
-    Deserialization failures produce the Python v0.5.0 sentinel output. -/
+    Deserialization failures produce the Python sentinel output. -/
 def run_stateless_guest (input_bytes : Bytes)
     (execute : ExecutionSeam := elExecute) : Bytes :=
   match deserialize_stateless_input input_bytes with
@@ -76,14 +74,12 @@ def sanityPayload : ExecutionPayload :=
     transactions := [], withdrawals := [], blobGasUsed := 0, excessBlobGas := 0,
     blockAccessList := [], slotNumber := 0 }
 
-/-- A "happy path" chain config: Amsterdam, activation satisfied by a
-    zero-timestamp payload, and the expected blob schedule. -/
+/-- A "happy path" chain config: activation satisfied by a
+    zero-timestamp payload. -/
 def sanityHappyChainConfig : ChainConfig :=
   { chainId := 1
     activeFork :=
-      { fork := .Amsterdam
-        activation := { blockNumber := none, timestamp := some 0 }
-        blobSchedule := some _expected_amsterdam_blob_schedule } }
+      { activation := { blockNumber := none, timestamp := some 0 } } }
 
 /-- A single amsterdam witness header (23 RLP fields). A one-element chain is
     vacuously contiguous, so `validate_headers` succeeds and its `state_root`
@@ -151,7 +147,7 @@ def sanityInputBytes : Except SpecError Bytes := do
       | .error _ => false
   | .error _ => false
 
--- Invalid input takes the v0.5.0 failed-output path rather than exposing a
+-- Invalid input takes the failed-output path rather than exposing a
 -- deserialization exception to the caller.
 #guard
   match deserialize sszStatelessValidationResultType (run_stateless_guest [0x00]) with
@@ -160,7 +156,6 @@ def sanityInputBytes : Except SpecError Bytes := do
       | .ok r => !r.successfulValidation
                  && r.newPayloadRequestRoot == z 32
                  && r.chainConfig.chainId == 0
-                 && r.chainConfig.activeFork.fork == .Frontier
       | .error _ => false
   | .error _ => false
 

--- a/EvmAsm/Stateless/SpecRef/Ssz.lean
+++ b/EvmAsm/Stateless/SpecRef/Ssz.lean
@@ -2,8 +2,8 @@
   EvmAsm.Stateless.SpecRef.Ssz
 
   Port of `execution-specs/src/ethereum/forks/amsterdam/stateless_ssz.py`
-  (`@tests-zkevm@v0.5.0`): the SSZ container schemas mirroring the domain
-  dataclasses, plus the 34 to/from-SSZ conversion functions.
+  (`@tests-zkevm@v0.6.0`, `40f956fab`): the SSZ container schemas mirroring
+  the domain dataclasses, plus the to/from-SSZ conversion functions.
 
   Each Python `class SszX(Container)` becomes an `SszType` descriptor
   (`sszXType`); each `_x_to_ssz` becomes `xToSsz : … → SszValue`; each
@@ -38,14 +38,26 @@ def MAX_BYTES_PER_WITNESS_NODE : Nat := 2 ^ 10
 def MAX_BYTES_PER_CODE : Nat := 2 ^ 16
 def MAX_BYTES_PER_HEADER : Nat := 2 ^ 10
 def MAX_OPTIONAL_FORK_ACTIVATION_VALUES : Nat := 1
-def MAX_BLOB_SCHEDULES_PER_FORK : Nat := 1
 def MAX_PUBLIC_KEYS : Nat := 2 ^ 15
 def PUBLIC_KEY_BYTES : Nat := 65
 
-/-- `STATELESS_INPUT_SCHEMA_ID` (`stateless_ssz.py:64`). -/
-def STATELESS_INPUT_SCHEMA_ID : Nat := 0x0001
-/-- `STATELESS_INPUT_SCHEMA_ID_SIZE` (`stateless_ssz.py:65`). -/
+/-! Stateless guest input bytes are schema-prefixed: `schema_id ||
+    encoded_payload`, where `schema_id = fork_index || schema_revision`
+    (`stateless_ssz.py:83`–`98`). Amsterdam is fork `0x15`, and revision
+    `0x01` uses SSZ `encode(SszStatelessInput)` for the payload. -/
+
+/-- `STATELESS_INPUT_SCHEMA_FORK_INDEX` (`stateless_ssz.py:89`). -/
+def STATELESS_INPUT_SCHEMA_FORK_INDEX : Nat := ProtocolFork.Amsterdam.value
+/-- `STATELESS_INPUT_SCHEMA_REVISION` (`stateless_ssz.py:90`). -/
+def STATELESS_INPUT_SCHEMA_REVISION : Nat := 0x01
+/-- `STATELESS_INPUT_SCHEMA_ID` (`stateless_ssz.py:91`). -/
+def STATELESS_INPUT_SCHEMA_ID : Nat :=
+  (STATELESS_INPUT_SCHEMA_FORK_INDEX <<< 8) ||| STATELESS_INPUT_SCHEMA_REVISION
+/-- `STATELESS_INPUT_SCHEMA_ID_SIZE` (`stateless_ssz.py:94`). -/
 def STATELESS_INPUT_SCHEMA_ID_SIZE : Nat := 2
+
+-- The two-byte big-endian prefix is `15 01`.
+#guard STATELESS_INPUT_SCHEMA_ID == 0x1501
 
 /-! ## SSZ type descriptors (mirror the `Container` classes) -/
 
@@ -103,27 +115,20 @@ def sszExecutionWitnessType : SszType :=
 def sszOptionalForkActivationValueType : SszType :=
   .list u64Type MAX_OPTIONAL_FORK_ACTIVATION_VALUES
 
-/-- `SszForkActivation` (`stateless_ssz.py:170`). -/
+/-- `SszForkActivation` (`stateless_ssz.py:199`). -/
 def sszForkActivationType : SszType :=
   .container [sszOptionalForkActivationValueType, sszOptionalForkActivationValueType]
 
-/-- `SszBlobSchedule` (`stateless_ssz.py:177`). -/
-def sszBlobScheduleType : SszType :=
-  .container [u64Type, u64Type, u64Type]
-
-/-- `SszOptionalBlobSchedule = List[SszBlobSchedule, 1]` (`stateless_ssz.py:185`). -/
-def sszOptionalBlobScheduleType : SszType :=
-  .list sszBlobScheduleType MAX_BLOB_SCHEDULES_PER_FORK
-
-/-- `SszForkConfig` (`stateless_ssz.py:190`). -/
+/-- `SszForkConfig` (`stateless_ssz.py:206`). v0.6.0 drops the `fork`
+    (uint64) and `blob_schedule` (zero-or-one list) fields. -/
 def sszForkConfigType : SszType :=
-  .container [u64Type, sszForkActivationType, sszOptionalBlobScheduleType]
+  .container [sszForkActivationType]
 
-/-- `SszChainConfig` (`stateless_ssz.py:198`). -/
+/-- `SszChainConfig` (`stateless_ssz.py:212`). -/
 def sszChainConfigType : SszType :=
   .container [u64Type, sszForkConfigType]
 
-/-- `SszStatelessInput` (`stateless_ssz.py:205`). -/
+/-- `SszStatelessInput` (`stateless_ssz.py:219`). -/
 def sszStatelessInputType : SszType :=
   .container [sszNewPayloadRequestType, sszExecutionWitnessType, sszChainConfigType,
     .list (.byteVector PUBLIC_KEY_BYTES) MAX_PUBLIC_KEYS]
@@ -160,18 +165,7 @@ def getField (fs : List SszValue) (i : Nat) : Except SpecError SszValue :=
   | some v => .ok v
   | none => .error (.sszError s!"missing field {i}")
 
-/-! ## `_protocol_fork_to_ssz` / `_ssz_to_protocol_fork`
-    (`stateless_ssz.py:228`, `:234`) -/
-
-def protocolForkToSsz (fork : ProtocolFork) : SszValue :=
-  .uint 8 (protocolForks.findIdx (· == fork))
-
-def sszToProtocolFork (ssz : Nat) : Except SpecError ProtocolFork :=
-  match protocolForks[ssz]? with
-  | some f => .ok f
-  | none => .error (.unknownProtocolFork ssz)
-
-/-! ## `_withdrawal_to_ssz` / `_ssz_to_withdrawal` (`:242`, `:252`) -/
+/-! ## `_withdrawal_to_ssz` / `_ssz_to_withdrawal` (`:239`, `:249`) -/
 
 def withdrawalToSsz (w : Withdrawal) : SszValue :=
   .container [.uint 8 w.index, .uint 8 w.validatorIndex,
@@ -334,46 +328,17 @@ def sszToForkActivation (sv : SszValue) : Except SpecError ForkActivation := do
   let timestamp ← sszToOptionalU64 (← getField fs 1)
   pure { blockNumber, timestamp }
 
-/-! ## `_blob_schedule_to_ssz` / `_ssz_to_blob_schedule` (`:518`, `:531`) -/
-
-def blobScheduleToSsz (b : BlobSchedule) : SszValue :=
-  .container [.uint 8 b.target, .uint 8 b.max, .uint 8 b.baseFeeUpdateFraction]
-
-def sszToBlobSchedule (sv : SszValue) : Except SpecError BlobSchedule := do
-  let fs ← asContainerV sv
-  let target ← asUintV (← getField fs 0)
-  let max ← asUintV (← getField fs 1)
-  let baseFeeUpdateFraction ← asUintV (← getField fs 2)
-  pure { target, max, baseFeeUpdateFraction }
-
-/-! ## `_optional_blob_schedule_to_ssz` / `_ssz_to_optional_blob_schedule`
-    (`:544`, `:553`) -/
-
-def optionalBlobScheduleToSsz (b : Option BlobSchedule) : SszValue :=
-  match b with
-  | none => .list MAX_BLOB_SCHEDULES_PER_FORK none []
-  | some bs => .list MAX_BLOB_SCHEDULES_PER_FORK none [blobScheduleToSsz bs]
-
-def sszToOptionalBlobSchedule (sv : SszValue) : Except SpecError (Option BlobSchedule) := do
-  let es ← asListV sv
-  match es with
-  | [] => pure none
-  | v :: _ => pure (some (← sszToBlobSchedule v))
-
-/-! ## `_fork_config_to_ssz` / `_ssz_to_fork_config` (`:562`, `:575`) -/
+/-! ## `_fork_config_to_ssz` / `_ssz_to_fork_config` (`:515`, `:524`) -/
 
 def forkConfigToSsz (fc : ForkConfig) : SszValue :=
-  .container [protocolForkToSsz fc.fork, forkActivationToSsz fc.activation,
-    optionalBlobScheduleToSsz fc.blobSchedule]
+  .container [forkActivationToSsz fc.activation]
 
 def sszToForkConfig (sv : SszValue) : Except SpecError ForkConfig := do
   let fs ← asContainerV sv
-  let fork ← sszToProtocolFork (← asUintV (← getField fs 0))
-  let activation ← sszToForkActivation (← getField fs 1)
-  let blobSchedule ← sszToOptionalBlobSchedule (← getField fs 2)
-  pure { fork, activation, blobSchedule }
+  let activation ← sszToForkActivation (← getField fs 0)
+  pure { activation }
 
-/-! ## `_chain_config_to_ssz` / `_ssz_to_chain_config` (`:588`, `:598`) -/
+/-! ## `_chain_config_to_ssz` / `_ssz_to_chain_config` (`:533`, `:543`) -/
 
 def chainConfigToSsz (cc : ChainConfig) : SszValue :=
   .container [.uint 8 cc.chainId, forkConfigToSsz cc.activeFork]
@@ -418,13 +383,11 @@ def sszToValidationResult (sv : SszValue) : Except SpecError StatelessValidation
 /-! ## Sanity: SSZ container round-trips (serialize → deserialize → domain) -/
 
 /-- A `ChainConfig` exercising an empty and a present optional (`none`
-    block_number, `some` timestamp) and a present blob schedule. -/
+    block_number, `some` timestamp). -/
 def sanityChainConfig : ChainConfig :=
   { chainId := 1
     activeFork :=
-      { fork := .Amsterdam
-        activation := { blockNumber := none, timestamp := some 100 }
-        blobSchedule := some { target := 14, max := 21, baseFeeUpdateFraction := 11684671 } } }
+      { activation := { blockNumber := none, timestamp := some 100 } } }
 
 -- Round-trip a `ChainConfig` through SSZ bytes and back.
 #guard
@@ -446,7 +409,7 @@ def sanityResult : StatelessValidationResult :=
     let sv ← deserialize sszStatelessValidationResultType bytes
     sszToValidationResult sv).toOption == some sanityResult
 
--- v0.5.0 witness resource bounds from `stateless_ssz.py`.
+-- v0.6.0 witness resource bounds from `stateless_ssz.py`.
 #guard MAX_WITNESS_NODES == 2 ^ 22
 #guard MAX_WITNESS_CODES == 2 ^ 18
 #guard MAX_BYTES_PER_WITNESS_NODE == 2 ^ 10

--- a/EvmAsm/Stateless/SpecRef/Stateless.lean
+++ b/EvmAsm/Stateless/SpecRef/Stateless.lean
@@ -2,21 +2,20 @@
   EvmAsm.Stateless.SpecRef.Stateless
 
   Port of `execution-specs/src/ethereum/forks/amsterdam/stateless.py`
-  (`@tests-zkevm@v0.4.0`): the seven functions of the stateless validation
-  shell.
+  (`@tests-zkevm@v0.6.0`, `40f956fab`): the six functions of the stateless
+  validation shell.
 
-  * `compute_new_payload_request_root` (`stateless.py:231`)
-  * `_decode_header`                   (`stateless.py:246`)
-  * `validate_headers`                 (`stateless.py:257`)
-  * `_is_activation_active`            (`stateless.py:280`)
-  * `_expected_amsterdam_blob_schedule`(`stateless.py:305`)
-  * `validate_chain_config`            (`stateless.py:316`)
-  * `verify_stateless_new_payload`     (`stateless.py:344`)
+  * `compute_new_payload_request_root` (`stateless.py:229`)
+  * `_decode_header`                   (`stateless.py:244`)
+  * `validate_headers`                 (`stateless.py:255`)
+  * `_is_activation_active`            (`stateless.py:278`)
+  * `validate_chain_config`            (`stateless.py:303`)
+  * `verify_stateless_new_payload`     (`stateless.py:321`)
 
   ## The execution seam
 
   `verify_stateless_new_payload` calls `execute_new_payload_request`
-  (`stateless.py:378`) — full statefull block re-execution
+  (`stateless.py:355`) — full statefull block re-execution
   (`execution_engine.new_payload`). That is NOT ported here (it is the
   whole EVM). We cut at exactly that call: everything on the
   validation/deserialization/hashing side is real; the execution engine is
@@ -36,13 +35,13 @@ namespace EvmAsm.Stateless.SpecRef
 
 open EvmAsm.EL.RLP (RLPItem decodeFully)
 
-/-! ## `compute_new_payload_request_root` (`stateless.py:231`) -/
+/-! ## `compute_new_payload_request_root` (`stateless.py:229`) -/
 
 /-- Compute the request root for a stateless input via SSZ hash tree root. -/
 def compute_new_payload_request_root (si : StatelessInput) : Hash32 :=
   (newPayloadRequestToSsz si.newPayloadRequest).hashTreeRoot
 
-/-! ## `_decode_header` (`stateless.py:246`)
+/-! ## `_decode_header` (`stateless.py:244`)
 
 `rlp.decode_to(Header, …)` is type-directed; we decode to a generic RLP
 list and discriminate the current fork (amsterdam, 23 fields) from the
@@ -84,7 +83,7 @@ def _decode_header (header_bytes : Bytes) : Except SpecError Header :=
           else .error .headerDecodeError
   | _ => .error .headerDecodeError
 
-/-! ## `validate_headers` (`stateless.py:257`) -/
+/-! ## `validate_headers` (`stateless.py:255`) -/
 
 /-- Validate that a sequence of encoded headers forms a contiguous chain.
     Each header's `parent_hash` must match the hash of the preceding header.
@@ -101,7 +100,7 @@ def validate_headers (encoded_headers : List Bytes) :
   if contiguous then pure (headers, block_hashes)
   else throw .headersNotContiguous
 
-/-! ## `_is_activation_active` (`stateless.py:280`) -/
+/-! ## `_is_activation_active` (`stateless.py:278`) -/
 
 /-- Whether an activation point is active for the payload. -/
 def _is_activation_active (activation : ForkActivation) (ep : ExecutionPayload) :
@@ -114,15 +113,12 @@ def _is_activation_active (activation : ForkActivation) (ep : ExecutionPayload) 
     if ep.timestamp < ts then return false
   return true
 
-/-! ## `_expected_amsterdam_blob_schedule` (`stateless.py:305`) -/
+/-! ## `validate_chain_config` (`stateless.py:303`)
 
-/-- The blob schedule compiled into the Amsterdam guest. -/
-def _expected_amsterdam_blob_schedule : BlobSchedule :=
-  { target := blobScheduleTarget
-    max := blobScheduleMax
-    baseFeeUpdateFraction := blobBaseFeeUpdateFraction }
-
-/-! ## `validate_chain_config` (`stateless.py:316`) -/
+v0.6.0 deletes the Amsterdam-fork and blob-schedule checks
+(`UnsupportedForkConfigError`, `_expected_amsterdam_blob_schedule`):
+fork identity is carried by the input's schema id, and the blob
+schedule is compiled into the guest. Only activation checking remains. -/
 
 /-- Validate and return the target payload's active fork config. -/
 def validate_chain_config (chain_config : ChainConfig) (npr : NewPayloadRequest) :
@@ -131,10 +127,6 @@ def validate_chain_config (chain_config : ChainConfig) (npr : NewPayloadRequest)
   let execution_payload := npr.executionPayload
   if !(← _is_activation_active active_fork.activation execution_payload) then
     throw .inactiveForkConfig
-  if active_fork.fork ≠ ProtocolFork.Amsterdam then
-    throw (.unsupportedForkConfig "Amsterdam guest cannot execute configured fork")
-  if active_fork.blobSchedule ≠ some _expected_amsterdam_blob_schedule then
-    throw (.unsupportedForkConfig "blob_schedule does not match Amsterdam")
   pure active_fork
 
 /-! ## The execution seam
@@ -146,7 +138,7 @@ below is `elExecute` (`PrecompilesTable.lean`): the FULL ported
 `apply_body` + post-state root, `ElExecute.lean`) over the complete
 18-entry precompile table — no fallback. -/
 
-/-! ## `verify_stateless_new_payload` (`stateless.py:344`) -/
+/-! ## `verify_stateless_new_payload` (`stateless.py:321`) -/
 
 /-- Statelessly validate the execution payload. Every exception the Python
     `try` would catch is folded into `successful_validation = false`. -/
@@ -178,11 +170,8 @@ def verify_stateless_new_payload (si : StatelessInput)
 
 /-! ## Sanity checks -/
 
--- A blob schedule matching the expected Amsterdam schedule is accepted.
 def sanityForkConfig : ForkConfig :=
-  { fork := .Amsterdam
-    activation := { blockNumber := none, timestamp := some 100 }
-    blobSchedule := some _expected_amsterdam_blob_schedule }
+  { activation := { blockNumber := none, timestamp := some 100 } }
 
 -- Build a minimal RLP header with `n` fields, field 0 = parent_hash,
 -- field 3 = state_root, all others empty.

--- a/EvmAsm/Stateless/SpecRef/Types.lean
+++ b/EvmAsm/Stateless/SpecRef/Types.lean
@@ -50,8 +50,6 @@ inductive SpecError where
   | sszError (why : String)
   /-- `stateless_input_to_ssz`: a transaction public key ≠ 65 bytes. -/
   | publicKeyWrongLength (len : Nat)
-  /-- `_ssz_to_protocol_fork`: enum value out of range. -/
-  | unknownProtocolFork (value : Nat)
   /-- `validate_headers`: more than 256 witness headers. -/
   | tooManyHeaders (count : Nat)
   /-- `_decode_header`: RLP decode failed for both current and previous fork. -/
@@ -64,9 +62,6 @@ inductive SpecError where
   /-- `validate_chain_config`: active fork not active for the payload
       (`InactiveForkConfigError`). -/
   | inactiveForkConfig
-  /-- `validate_chain_config`: fork ≠ Amsterdam or blob schedule mismatch
-      (`UnsupportedForkConfigError`). -/
-  | unsupportedForkConfig (why : String)
   /-- `_decode_account_from_leaf`: leaf RLP is not a 4-item list. -/
   | accountLeafMalformed
   /-- `_trie_lookup`: hit an unresolved `HashedNode`. -/
@@ -115,11 +110,13 @@ inductive SpecError where
   | executionRejected (why : String)
   deriving Repr, BEq, DecidableEq
 
-/-! ## Protocol forks (`stateless.py:83` `ProtocolFork`) -/
+/-! ## Protocol forks (`stateless.py:81` `ProtocolFork`) -/
 
-/-- Semantic execution-layer fork names understood by stateless inputs.
-    Constructor order MUST match Python declaration order, because
-    `_protocol_fork_to_ssz` uses `tuple(ProtocolFork).index(fork)`. -/
+/-- Stable execution-layer fork identifiers used by stateless schemas.
+    v0.6.0 turns this into an `IntEnum` (`Frontier = 0x01` …
+    `Amsterdam = 0x15`); the value no longer travels in the SSZ payload —
+    its only wire use is the schema-id prefix
+    (`STATELESS_INPUT_SCHEMA_FORK_INDEX`, `stateless_ssz.py:89`). -/
 inductive ProtocolFork where
   | Frontier | Homestead | DAOFork | TangerineWhistle | SpuriousDragon
   | Byzantium | StPetersburg | Istanbul | MuirGlacier | Berlin | London
@@ -127,36 +124,33 @@ inductive ProtocolFork where
   | BPO1 | BPO2 | Amsterdam
   deriving Repr, BEq, DecidableEq
 
-/-- `tuple(ProtocolFork)` — the SSZ enum ordering (`stateless_ssz.py:249`). -/
-def protocolForks : List ProtocolFork :=
-  [.Frontier, .Homestead, .DAOFork, .TangerineWhistle, .SpuriousDragon,
-   .Byzantium, .StPetersburg, .Istanbul, .MuirGlacier, .Berlin, .London,
-   .ArrowGlacier, .GrayGlacier, .Paris, .Shanghai, .Cancun, .Prague, .Osaka,
-   .BPO1, .BPO2, .Amsterdam]
+/-- The `IntEnum` value of a fork (`stateless.py:86`–`106`): declaration
+    index + 1, spelled out to keep each value visibly tied to the spec. -/
+def ProtocolFork.value : ProtocolFork → Nat
+  | .Frontier => 0x01 | .Homestead => 0x02 | .DAOFork => 0x03
+  | .TangerineWhistle => 0x04 | .SpuriousDragon => 0x05 | .Byzantium => 0x06
+  | .StPetersburg => 0x07 | .Istanbul => 0x08 | .MuirGlacier => 0x09
+  | .Berlin => 0x0A | .London => 0x0B | .ArrowGlacier => 0x0C
+  | .GrayGlacier => 0x0D | .Paris => 0x0E | .Shanghai => 0x0F
+  | .Cancun => 0x10 | .Prague => 0x11 | .Osaka => 0x12
+  | .BPO1 => 0x13 | .BPO2 => 0x14 | .Amsterdam => 0x15
 
-/-! ## Chain-config dataclasses (`stateless.py:139`–`183`) -/
+/-! ## Chain-config dataclasses (`stateless.py:126`–`160`) -/
 
-/-- `ForkActivation` (`stateless.py:141`). -/
+/-- `ForkActivation` (`stateless.py:130`). -/
 structure ForkActivation where
   blockNumber : Option U64
   timestamp : Option U64
   deriving Repr, BEq, DecidableEq
 
-/-- `BlobSchedule` (`stateless.py:152`). -/
-structure BlobSchedule where
-  target : U64
-  max : U64
-  baseFeeUpdateFraction : U64
-  deriving Repr, BEq, DecidableEq
-
-/-- `ForkConfig` (`stateless.py:164`). -/
+/-- `ForkConfig` (`stateless.py:142`). v0.6.0 drops the `fork` and
+    `blob_schedule` fields: fork identity is carried by the schema id
+    and the blob schedule is compiled into the guest. -/
 structure ForkConfig where
-  fork : ProtocolFork
   activation : ForkActivation
-  blobSchedule : Option BlobSchedule
   deriving Repr, BEq, DecidableEq
 
-/-- `ChainConfig` (`stateless.py:176`). -/
+/-- `ChainConfig` (`stateless.py:153`). -/
 structure ChainConfig where
   chainId : U64
   activeFork : ForkConfig
@@ -304,14 +298,5 @@ structure Header where
   /-- amsterdam-only (`0` when `isCurrentFork = false`). -/
   slotNumber : U64
   deriving Repr, BEq, DecidableEq
-
-/-! ## Amsterdam-compiled constants (`vm/gas.py`) -/
-
-/-- `BLOB_SCHEDULE_TARGET` (`vm/gas.py:106`). -/
-def blobScheduleTarget : U64 := 14
-/-- `BLOB_SCHEDULE_MAX` (`vm/gas.py:109`). -/
-def blobScheduleMax : U64 := 21
-/-- `BLOB_BASE_FEE_UPDATE_FRACTION` (`vm/gas.py:111`). -/
-def blobBaseFeeUpdateFraction : Uint := 11684671
 
 end EvmAsm.Stateless.SpecRef

--- a/EvmAsm/Tests/SpecRefEestCheck.lean
+++ b/EvmAsm/Tests/SpecRefEestCheck.lean
@@ -6,7 +6,7 @@
   *same* ziskemu-framed fixture inputs produced by
   `scripts/eest-stateless-to-input.py` (the fixture set
   `scripts/codegen-eest-stateless-check.sh` exercises) and writes the
-  105-byte `StatelessValidationResult` for the harness
+  69-byte `StatelessValidationResult` for the harness
   (`scripts/eest-specref-check.sh`) to compare against the fixture's
   `statelessOutputBytes`.
 
@@ -77,7 +77,7 @@ def unpackZiskemuInput (packed : Bytes) : Except String Bytes := do
 -- CLI
 -- ============================================================================
 -- `specref-eest-check <input_file> <output_file>`
---   exit 0 + writes the 105-byte result to <output_file> on success.
+--   exit 0 + writes the 69-byte result to <output_file> on success.
 --   exit 2 + stderr message on malformed framing.
 
 def usage : String :=

--- a/scripts/eest-specref-check.sh
+++ b/scripts/eest-specref-check.sh
@@ -22,14 +22,14 @@
 #
 #     * root  (bytes 0:32,  new_payload_request_root)  -- pre-execution hashing;
 #              SpecRef MUST match on every fixture.            [gateable]
-#     * tail  (bytes 33:105, chain_config echo)        -- pure echo;
+#     * tail  (bytes 33:69, chain_config echo)         -- pure echo;
 #              SpecRef MUST match on every fixture.            [gateable]
 #     * succ  (byte 32,     successful_validation)     -- SpecRef always reports
 #              true here; it DIVERGES on every fixture whose real EVM execution
 #              failed (succ=0). This is the expected execution-seam gap, NOT a
 #              SpecRef defect, and is reported separately rather than folded
 #              into fail / the --min-* gates.
-#     * full  (all 105 bytes match)                    -- informational only.
+#     * full  (all 69 bytes match)                     -- informational only.
 #
 #   A per-case line shows which regions matched, e.g. "[root/----/tail]" means
 #   root + tail matched but the succ bit diverged. "[----/----/----]" means the
@@ -271,12 +271,14 @@ case_identity() {
 }
 
 # --- run + classify ---------------------------------------------------------
-# A normal 105-byte SszStatelessValidationResult decomposes into three regions:
+# A normal 69-byte SszStatelessValidationResult (tests-zkevm@v0.6.0: the
+# ChainConfig lost its fork and blob-schedule fields) decomposes into three
+# regions:
 #   root  [0:32]   (hex chars 0..64)   = new_payload_request_root
 #   succ  [32]     (hex chars 64..66)  = successful_validation
-#   tail  [33:105] (hex chars 66..210) = u32 offset + 68-byte chain_config
-# Failed-input sentinel results may be shorter because the nested ChainConfig
-# has an empty optional blob schedule. Compare those encodings byte-for-byte.
+#   tail  [33:69]  (hex chars 66..138) = u32 offset + 32-byte chain_config
+# Results whose ForkActivation optionals differ from the common
+# timestamp-only shape encode to other lengths. Compare those byte-for-byte.
 # See the file header for why `succ` diverges (placeholder execution seam).
 total=0 err=0 full=0 succ=0 root=0 tail=0 succdiv=0 succfail=0 malformed=0
 
@@ -340,7 +342,7 @@ classify_case() {
     return 0
   fi
 
-  if [[ "${#expected_hex}" -ne 210 || "${#actual_hex}" -ne 210 ]]; then
+  if [[ "${#expected_hex}" -ne 138 || "${#actual_hex}" -ne 138 ]]; then
     if [[ "$expected_hex" == "$actual_hex" ]]; then
       full=$((full + 1))
       malformed=$((malformed + 1))
@@ -360,8 +362,8 @@ classify_case() {
   local act_root="${actual_hex:0:64}"
   local exp_succ="${expected_hex:64:2}"
   local act_succ="${actual_hex:64:2}"
-  local exp_tail="${expected_hex:66:144}"
-  local act_tail="${actual_hex:66:144}"
+  local exp_tail="${expected_hex:66:72}"
+  local act_tail="${actual_hex:66:72}"
 
   local r="root" s="succ" t="tail"
   [[ "$exp_root" == "$act_root" ]] || r="----"

--- a/scripts/eest-stateless-to-input.py
+++ b/scripts/eest-stateless-to-input.py
@@ -5,7 +5,7 @@ The EEST zkevm fixtures (release line ``zkevm@vX.Y.Z``, targeting the
 Amsterdam / Glamsterdam fork) are ``blockchain_tests`` whose blocks each
 carry two extra hex fields:
 
-  * ``statelessInputBytes``  -- the schema-prefixed (``0x0001...``) SSZ
+  * ``statelessInputBytes``  -- the schema-prefixed (``0x1501...``) SSZ
     ``StatelessInput`` that ``run_stateless_guest`` consumes.
   * ``statelessOutputBytes`` -- the canonical SSZ
     ``StatelessValidationResult`` the guest is expected to produce.


### PR DESCRIPTION
Phase 4a of the **tests-zkevm@v0.6.0 migration** — bead `evm-asm-0w05f.4`, references #10207. Based on #10215 (fixture tag) so the diff shows only the increment.

## What (C1+C2 in `docs/agents/v06-migration-scope.md`)
- **Schema id `0x0001` → `0x1501`**: `fork_index << 8 | revision` with new `ProtocolFork.value` IntEnum mapping (`Frontier = 0x01` … `Amsterdam = 0x15`); `#guard STATELESS_INPUT_SCHEMA_ID == 0x1501` pins the big-endian `15 01` prefix.
- **`ForkConfig` = `{activation}`**: `fork` and `blob_schedule` fields deleted along with `BlobSchedule`, its SSZ types/converters, `protocolForkToSsz`/`sszToProtocolFork`, and the now-dead `protocolForks` list and Types.lean blob constants.
- **`validate_chain_config`**: Amsterdam-fork and blob-schedule checks deleted (`SpecError.unsupportedForkConfig`/`.unknownProtocolFork` constructors removed); only activation checking remains, matching `stateless.py:303`.
- Sentinel output, sanity fixtures, and citation line numbers refreshed to `40f956fab`.
- Harness: `eest-specref-check.sh` region decomposition updated for the 69-byte (was 105) `SszStatelessValidationResult`; stale schema prose in `SpecRefEestCheck.lean` / `eest-stateless-to-input.py`.

## Verification
- `lake build` green; all SSZ round-trip `#guard`s (input, chain config, validation result, end-to-end guest pipeline) pass at the new format.
- `check-spec-refs` / `check-forbidden-tactics` clean.
- Smoke conformance vs real `tests-zkevm@v0.6.0` fixtures: **root 40/40, tail 40/40, ERROR/FAIL 0** — the port decodes v0.6.0 inputs and byte-exactly reproduces the new output layout including the chain-config echo.
- `succ` diverges on 38/40 (all EIP-2780 gas fixtures) — expected and scoped: execution-semantics deltas land in phases 4b–4d; the succ gate returns to FAIL 0 at the 4d exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)