### PR TITLE
feat(specref): v0.6.0 SSTORE reorder + generic_create conditional NEW_ACCOUNT — full-suite succ FAIL 0 (evm-asm-0w05f.7)

### DIFF
--- a/EvmAsm/Stateless/SpecRef/InstructionsCore.lean
+++ b/EvmAsm/Stateless/SpecRef/InstructionsCore.lean
@@ -456,13 +456,18 @@ def iSstore : EvmM Unit := do
   if (← EvmM.getEvm).message.isStatic then throw .writeInStaticContext
   let key := toBeBytes32 (← stackPop)
   let new_value ← stackPop
-  check_gas (GasCosts.CALL_STIPEND + 1)
   let target := (← EvmM.getEvm).message.currentTarget
+  -- v0.6.0: the access cost is computed and checked BEFORE the state
+  -- reads record the slot in the Block Access List — post-repricing the
+  -- cold access cost can exceed the EIP-2200 stipend, so the stipend
+  -- sentry alone is no longer sufficient.
+  let cold := !(← isWarmStorageKey (target, key))
+  let access_cost := if cold then GasCosts.COLD_STORAGE_ACCESS else GasCosts.WARM_ACCESS
+  check_gas (max access_cost (GasCosts.CALL_STIPEND + 1))
+  if cold then warmStorageKey (target, key)
   let original_value ← EvmM.liftTx (getStorageOriginal target key)
   let current_value ← EvmM.liftTx (getStorage target key)
-  let cold := !(← isWarmStorageKey (target, key))
-  if cold then warmStorageKey (target, key)
-  let gas_cost := (if cold then GasCosts.COLD_STORAGE_ACCESS else GasCosts.WARM_ACCESS)
+  let gas_cost := access_cost
     + (if original_value == current_value && current_value != new_value then
          GasCosts.STORAGE_WRITE else 0)
   if current_value != new_value then

--- a/EvmAsm/Stateless/SpecRef/Interpreter.lean
+++ b/EvmAsm/Stateless/SpecRef/Interpreter.lean
@@ -543,35 +543,40 @@ partial def generic_create (pre : PrecompileMap) (fuel : Nat)
     (endowment : U256) (contract_address : Address)
     (memory_start_position memory_size : U256) : EvmM Unit := do
   if memory_size > MAX_INIT_CODE_SIZE then throw .outOfGas
-  charge_state_gas StateGasCosts.NEW_ACCOUNT
   let e ← EvmM.getEvm
   let call_data := memory_read_bytes e.memory memory_start_position memory_size
-  let create_message_gas := max_message_call_gas e.gasLeft
-  EvmM.modifyEvm (fun e => { e with gasLeft := e.gasLeft - create_message_gas })
-  let reservoir := (← EvmM.getEvm).stateGasLeft
-  EvmM.modifyEvm (fun e => { e with stateGasLeft := 0, returnData := [] })
+  EvmM.modifyEvm (fun e => { e with returnData := [] })
   let sender_address := e.message.currentTarget
   let sender ← EvmM.liftTx (getAccount sender_address)
+  -- v0.6.0: the balance/nonce/depth early-out touches no gas pools (the
+  -- gas split and state-gas charge now happen after it).
   if sender.balance < endowment || sender.nonce == 2^64 - 1
       || e.message.depth + 1 > STACK_DEPTH_LIMIT then
-    EvmM.modifyEvm (fun e =>
-      { e with gasLeft := e.gasLeft + create_message_gas
-               stateGasLeft := e.stateGasLeft + reservoir })
-    credit_state_gas_refund StateGasCosts.NEW_ACCOUNT
     stackPush 0
     return
   EvmM.modifyEvm (fun e =>
     { e with accessedAddresses := setAdd e.accessedAddresses contract_address })
+  -- v0.6.0: NEW_ACCOUNT is charged iff the target does not exist —
+  -- decided by existence alone, independently of the collision outcome.
+  let new_account_charged := !(← EvmM.liftTx (isAccountAlive contract_address))
+  if new_account_charged then
+    charge_state_gas StateGasCosts.NEW_ACCOUNT
+  let create_message_gas := max_message_call_gas (← EvmM.getEvm).gasLeft
+  EvmM.modifyEvm (fun e => { e with gasLeft := e.gasLeft - create_message_gas })
   if !(← EvmM.liftTx (accountDeployable contract_address)) then
-    EvmM.liftTx (incrementNonce e.message.currentTarget)
+    EvmM.liftTx (incrementNonce sender_address)
     EvmM.modifyEvm (fun e =>
-      { e with regularGasUsed := e.regularGasUsed + create_message_gas
-               stateGasLeft := e.stateGasLeft + reservoir })
-    credit_state_gas_refund StateGasCosts.NEW_ACCOUNT
+      { e with regularGasUsed := e.regularGasUsed + create_message_gas })
+    -- A storage-only collision target is non-existent: charged above,
+    -- refilled here.
+    if new_account_charged then
+      credit_state_gas_refund StateGasCosts.NEW_ACCOUNT
     stackPush 0
     return
-  let target_alive ← EvmM.liftTx (isAccountAlive contract_address)
-  EvmM.liftTx (incrementNonce e.message.currentTarget)
+  -- Move full reservoir to child (no 63/64 rule for state gas).
+  let reservoir := (← EvmM.getEvm).stateGasLeft
+  EvmM.modifyEvm (fun e => { e with stateGasLeft := 0 })
+  EvmM.liftTx (incrementNonce sender_address)
   let parentEvm ← EvmM.getEvm
   let child_message : Message :=
     { blockEnv := e.message.blockEnv
@@ -594,13 +599,12 @@ partial def generic_create (pre : PrecompileMap) (fuel : Nat)
   let child ← process_create_message pre fuel child_message
   if child.error.isSome then
     incorporate_child_on_error child
-    credit_state_gas_refund StateGasCosts.NEW_ACCOUNT
+    if new_account_charged then
+      credit_state_gas_refund StateGasCosts.NEW_ACCOUNT
     EvmM.modifyEvm (fun e => { e with returnData := child.output })
     stackPush 0
   else
     incorporate_child_on_success child
-    if target_alive then
-      credit_state_gas_refund StateGasCosts.NEW_ACCOUNT
     EvmM.modifyEvm (fun e => { e with returnData := [] })
     stackPush (bytesBEtoNat child.message.currentTarget)
 

--- a/scripts/eest-succ-allow.txt
+++ b/scripts/eest-succ-allow.txt
@@ -1,21 +1,26 @@
 # eest-succ-allow.txt — fixtures whose recorded `statelessOutputBytes`
-# succ byte disagrees with execution-specs @ bd8c673 (tests-zkevm@v0.5.0)
-# ITSELF, so a SpecRef "divergence" on them is fixture-side, not a port
-# bug.  Allowlist discipline mirrors spec-refs-allow.txt: every entry
-# needs recorded evidence, and the goal is an empty file (entries leave
-# when the fixtures are regenerated or the spec pin moves).
+# succ byte disagrees with execution-specs @ 40f956fab
+# (tests-zkevm@v0.6.0) ITSELF, so a SpecRef "divergence" on them is
+# fixture-side, not a port bug.  Allowlist discipline mirrors
+# spec-refs-allow.txt: every entry needs recorded evidence, and the
+# goal is an empty file (entries leave when the fixtures are
+# regenerated or the spec pin moves).
 #
 # Format: one substring per line, matched against the case label
 # (manifest column 1).  Lines starting with # are comments.
 #
 # Tracking: issue #10182.
-# Evidence for the two entries below (bead evm-asm-s1d19.5,
-# 2026-07-11): running the PINNED Python spec's run_stateless_guest on
-# the exact converted inputs returns successful_validation = 0
-# ("requests hash mismatch": the engine-API typed ExecutionRequests
-# container cannot represent builder-type (0x03/0x04) request blobs,
-# so execute_block's computed requests_hash cannot match the header's
-# for blocks emitting builder requests), while the fixtures record
-# succ = 1.  SpecRef output == pinned-spec output on both.
+# Evidence for the two entries below, first recorded against bd8c673
+# (bead evm-asm-s1d19.5) and RE-VERIFIED against 40f956fab /
+# tests-zkevm@v0.6.0 fixtures (bead evm-asm-0w05f.7, 2026-07-11, via
+# `eest-stateless-to-input.py --verify-run-stateless-guest`): running
+# the PINNED Python spec's run_stateless_guest on the exact converted
+# inputs returns successful_validation = 0 ("requests hash mismatch":
+# the engine-API typed ExecutionRequests container cannot represent
+# builder-type (0x03/0x04) request blobs, so execute_block's computed
+# requests_hash cannot match the header's for blocks emitting builder
+# requests), while the fixtures record succ = 1.  SpecRef output ==
+# pinned-spec output on both (execution_engine/ is byte-identical
+# between the two pins).
 test_invalid_multi_type_requests_fork_Amsterdam-single_builderdeposit_empty_requests_list
 test_invalid_multi_type_requests_fork_Amsterdam-single_builderexit_empty_requests_list


### PR DESCRIPTION
Phase 4d of the **tests-zkevm@v0.6.0 migration** — bead `evm-asm-0w05f.7`, references #10207. Final SpecRef phase; based on main (the 4a–4c stack #10216–#10218 merged).

## What (C10+C11 in `docs/agents/v06-migration-scope.md`)
- **SSTORE (C10)**: access cost computed and checked via `max(access_cost, CALL_STIPEND+1)` **before** `get_storage_original`/`get_storage` record the slot in the Block Access List; post-repricing cold access (3000) exceeds the EIP-2200 stipend (2300), and failing early keeps the slot out of the BAL and the accessed set.
- **`generic_create` (C11)**: `NEW_ACCOUNT` charged iff the target is not alive (decided by existence alone), after the balance/nonce/depth early-out (which no longer touches gas pools); refill only-if-charged on collision and child error; no more target-alive success refund; reservoir hand-off moved after the collision check (a state-gas spill now reduces the 63/64 child allowance).
- **Allowlist re-triage**: both `eest-succ-allow.txt` entries re-verified against `40f956fab` + v0.6.0 fixtures via `eest-stateless-to-input.py --verify-run-stateless-guest` — the pinned Python spec itself returns `succ=0` on those two inputs (builder-type request blobs can't be represented in the typed `ExecutionRequests` container → requests-hash mismatch), while the fixtures record `succ=1`. Fixture-side, evidence refreshed in the header.

## Full-suite conformance (the phase-4 exit gate)
`scripts/eest-specref-check.sh --all` vs **tests-zkevm@v0.6.0**, 25,693 stateless cases:

| metric | result |
|---|---|
| full match | **25,691** |
| succ FAIL | **0** |
| ERROR/FAIL | **0** |
| succ divergences | 2 (fixture-side, allowlisted with re-verified evidence) |
| malformed-length cases | 8 (byte-exact matches) |

SpecRef is fully conformant at v0.6.0 — same milestone as v0.5.0's 25,477-fixture run. `lake build` green (4,966 jobs), `check-spec-refs`/forbidden-tactics clean.

Next: phase 5 (guest code) — beads `evm-asm-0w05f.8`–`.10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)