### PR TITLE
fix(proofs): GuestImage data-region extent — unbreak feat/v06-guest-input-parsing build

### DIFF
--- a/EvmAsm/Codegen/Proofs/GuestImage.lean
+++ b/EvmAsm/Codegen/Proofs/GuestImage.lean
@@ -186,8 +186,8 @@ theorem guestScratch_sat : ∀ input : SpecRef.Bytes,
     satWithin_ramRegion 0xa0630000 0x200000 (by omega) (by omega)
       (by omega) (by omega)
   have t5 : (regionScratch RegionMap.dataRegion).SatWithin
-      0xa3000000 0xbeab21a0 :=
-    satWithin_ramRegion 0xa3000000 0x1bab21a0 (by omega) (by omega)
+      0xa3000000 0xbf33e300 :=
+    satWithin_ramRegion 0xa3000000 0x1c33e300 (by omega) (by omega)
       (by omega) (by omega)
   have t6 : (regionScratch RegionMap.sszScratchRegion).SatWithin
       0xbf500000 0xbfb80000 :=


### PR DESCRIPTION
One-line build fix for the base branch: the merge of main into `feat/v06-guest-input-parsing` (2d8b9080a) kept `RegionMap.dataSizeBytes = 0x1c33e300` (bumped in #10225) but left `GuestImage.lean`'s `t5` data-region scratch step at the pre-merge `0x1bab21a0`, so `lake build` fails on the branch (`guestImageEntries` extents proof). This aligns the `t5` literals with RegionMap.

Found while scoping `evm-asm-0w05f.13` (frame-memory lift) — the scoping outcome is a STOP-report (the 9 fixtures turn out not to be frame-memory-capped; details in the bead + /tmp/fable2-frame-mem-report.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)